### PR TITLE
Remove default Bugsnag key

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -82,6 +82,14 @@ func GetEnv(key string, defaultVal string) string {
 	return defaultVal
 }
 
+// GetRequiredEnv returns the environment value stored in key variable, no default
+func GetRequiredEnv(key string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	panic(fmt.Errorf("Fatal error, no required environment variable: %s", key))
+}
+
 // Override Config by application or command line
 
 // SetBool override existing config

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func init() {
 
 func main() {
 	bugsnag.Configure(bugsnag.Configuration{
-		APIKey:       config.GetEnv("BUGSNAG_KEY", "a82c3193aa5914abe2cfb66557f1cc2b"),
+		APIKey:       config.GetRequiredEnv("BUGSNAG_KEY"),
 		ReleaseStage: config.GetEnv("GO_ENV", "development"),
 		// The import paths for the Go packages containing your source files
 		ProjectPackages: []string{"main", "github.com/rudderlabs/rudder-server"},

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func init() {
 
 func main() {
 	bugsnag.Configure(bugsnag.Configuration{
-		APIKey:       config.GetRequiredEnv("BUGSNAG_KEY"),
+		APIKey:       config.GetEnv("BUGSNAG_KEY", ""),
 		ReleaseStage: config.GetEnv("GO_ENV", "development"),
 		// The import paths for the Go packages containing your source files
 		ProjectPackages: []string{"main", "github.com/rudderlabs/rudder-server"},


### PR DESCRIPTION
This change removes the default Bugsnag key and requires the developer to obtain their own.

To support this, `config.GetRequiredEnv()` is added, to retrieve a environment variable but fail if not present.