### PR TITLE
Get backend config from file

### DIFF
--- a/config/backend-config/backend-config.go
+++ b/config/backend-config/backend-config.go
@@ -76,7 +76,7 @@ type TransformationT struct {
 
 type BackendConfig interface {
 	SetUp()
-	GetBackendConfig() (SourcesT, bool)
+	Get() (SourcesT, bool)
 	GetWorkspaceIDForWriteKey(string) string
 }
 
@@ -140,11 +140,12 @@ func init() {
 func pollConfigUpdate() {
 	statConfigBackendError := stats.NewStat("config_backend.errors", stats.CountType)
 	for {
-		sourceJSON, ok := backendConfig.GetBackendConfig()
+		sourceJSON, ok := backendConfig.Get()
 		if !ok {
 			statConfigBackendError.Increment()
 		}
 		if ok && !reflect.DeepEqual(curSourceJSON, sourceJSON) {
+			logger.Info("Config changed from ", curSourceJSON, " to : ", sourceJSON)
 			curSourceJSONLock.Lock()
 			curSourceJSON = sourceJSON
 			curSourceJSONLock.Unlock()

--- a/config/backend-config/backend-config.go
+++ b/config/backend-config/backend-config.go
@@ -24,6 +24,8 @@ var (
 	multiWorkspaceSecret                 string
 	configBackendURL, configBackendToken string
 	pollInterval                         time.Duration
+	configFromFile                       bool
+	configJSONPath                       string
 	curSourceJSON                        SourcesT
 	curSourceJSONLock                    sync.RWMutex
 	initialized                          bool
@@ -87,6 +89,8 @@ func loadConfig() {
 	configBackendURL = config.GetEnv("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
 	configBackendToken = config.GetEnv("CONFIG_BACKEND_TOKEN", "1P2tfQQKarhlsG6S3JGLdXptyZY")
 	pollInterval = config.GetDuration("BackendConfig.pollIntervalInS", 5) * time.Second
+	configJSONPath = config.GetString("BackendConfig.configJSONPath", "./workspaceConfig.json")
+	configFromFile = config.GetBool("BackendConfig.configFromFile", false)
 }
 
 func GetConfigBackendToken() string {

--- a/config/backend-config/multi-workspace-config.go
+++ b/config/backend-config/multi-workspace-config.go
@@ -38,8 +38,8 @@ func (multiWorkspaceConfig *MultiWorkspaceConfig) GetWorkspaceIDForWriteKey(give
 	return ""
 }
 
-//GetBackendConfig returns sources from all hosted workspaces
-func (multiWorkspaceConfig *MultiWorkspaceConfig) GetBackendConfig() (SourcesT, bool) {
+//Get returns sources from all hosted workspaces
+func (multiWorkspaceConfig *MultiWorkspaceConfig) Get() (SourcesT, bool) {
 	url := fmt.Sprintf("%s/hostedWorkspaceConfig", configBackendURL)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/config/backend-config/workspace-config.go
+++ b/config/backend-config/workspace-config.go
@@ -21,6 +21,13 @@ func (workspaceConfig *WorkspaceConfig) GetWorkspaceIDForWriteKey(writeKey strin
 
 //GetBackendConfig returns sources from the workspace
 func (workspaceConfig *WorkspaceConfig) GetBackendConfig() (SourcesT, bool) {
+	if configFromFile {
+		return workspaceConfig.getBackendConfigFromFile()
+	}
+	return workspaceConfig.getBackendConfigFromAPI()
+}
+
+func (workspaceConfig *WorkspaceConfig) getBackendConfigFromAPI() (SourcesT, bool) {
 	url := fmt.Sprintf("%s/workspaceConfig", configBackendURL)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -51,4 +58,20 @@ func (workspaceConfig *WorkspaceConfig) GetBackendConfig() (SourcesT, bool) {
 		return SourcesT{}, false
 	}
 	return sourcesJSON, true
+}
+
+func (workspaceConfig *WorkspaceConfig) getBackendConfigFromFile() (SourcesT, bool) {
+	logger.Info("Reading workspace config from JSON file")
+	data, err := ioutil.ReadFile(configJSONPath)
+	if err != nil {
+		logger.Error("Unable to read backend config from file.")
+		return SourcesT{}, false
+	}
+	var configJSON SourcesT
+	error := json.Unmarshal(data, &configJSON)
+	if error != nil {
+		logger.Error("Unable to parse backend config from file.")
+		return SourcesT{}, false
+	}
+	return configJSON, true
 }

--- a/config/backend-config/workspace-config.go
+++ b/config/backend-config/workspace-config.go
@@ -19,15 +19,16 @@ func (workspaceConfig *WorkspaceConfig) GetWorkspaceIDForWriteKey(writeKey strin
 	return ""
 }
 
-//GetBackendConfig returns sources from the workspace
-func (workspaceConfig *WorkspaceConfig) GetBackendConfig() (SourcesT, bool) {
+//Get returns sources from the workspace
+func (workspaceConfig *WorkspaceConfig) Get() (SourcesT, bool) {
 	if configFromFile {
-		return workspaceConfig.getBackendConfigFromFile()
+		return workspaceConfig.getFromFile()
 	}
-	return workspaceConfig.getBackendConfigFromAPI()
+	return workspaceConfig.getFromAPI()
 }
 
-func (workspaceConfig *WorkspaceConfig) getBackendConfigFromAPI() (SourcesT, bool) {
+// getFromApi gets the workspace config from api
+func (workspaceConfig *WorkspaceConfig) getFromAPI() (SourcesT, bool) {
 	url := fmt.Sprintf("%s/workspaceConfig", configBackendURL)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -60,7 +61,8 @@ func (workspaceConfig *WorkspaceConfig) getBackendConfigFromAPI() (SourcesT, boo
 	return sourcesJSON, true
 }
 
-func (workspaceConfig *WorkspaceConfig) getBackendConfigFromFile() (SourcesT, bool) {
+// getFromApi reads the workspace config from JSON file
+func (workspaceConfig *WorkspaceConfig) getFromFile() (SourcesT, bool) {
 	logger.Info("Reading workspace config from JSON file")
 	data, err := ioutil.ReadFile(configJSONPath)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,8 @@ func Initialize() {
 	viper.SetConfigFile(configPath)
 	viper.AddConfigPath(".")
 	err := viper.ReadInConfig() // Find and read the config file
-	if err != nil {             // Using the default config values when config.toml is not found
+	// Don't panic if config.toml is not found. Use the default config values instead
+	if err != nil {
 		fmt.Println("Config toml file not found. Using the default values")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/bugsnag/bugsnag-go"
 	"github.com/joho/godotenv"
 	"github.com/spf13/viper"
 )
@@ -21,9 +20,8 @@ func Initialize() {
 	viper.SetConfigFile(configPath)
 	viper.AddConfigPath(".")
 	err := viper.ReadInConfig() // Find and read the config file
-	if err != nil {             // Handle errors reading the config file
-		defer bugsnag.AutoNotify()
-		panic(fmt.Errorf("Fatal error config file: %s", err))
+	if err != nil {             // Using the default config values when config.toml is not found
+		fmt.Println("Config toml file not found. Using the default values")
 	}
 }
 

--- a/config/config.toml
+++ b/config/config.toml
@@ -61,8 +61,6 @@ keepOrderOnFailure = true
 [BatchRouter]
 mainLoopSleepInS = 2
 noOfWorkers = 8
-jobQueryBatchSize = 100000
-uploadFreqInS = 30
 
 [Warehouse]
 stagingFilesTable = "wh_staging_files"
@@ -90,6 +88,7 @@ maxRetry = 30
 retrySleepInMS = 100
 
 [BackendConfig]
+configFromFile = false
 pollIntervalInS = 5
 
 

--- a/config/config.toml
+++ b/config/config.toml
@@ -91,6 +91,7 @@ retrySleepInMS = 100
 
 [BackendConfig]
 configFromFile = false
+configJSONPath = "./workspaceConfig.json"
 pollIntervalInS = 5
 
 

--- a/config/config.toml
+++ b/config/config.toml
@@ -61,6 +61,8 @@ keepOrderOnFailure = true
 [BatchRouter]
 mainLoopSleepInS = 2
 noOfWorkers = 8
+jobQueryBatchSize = 100000
+uploadFreqInS = 30
 
 [Warehouse]
 stagingFilesTable = "wh_staging_files"

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -86,7 +86,7 @@ func loadConfig() {
 	// Maximum request size to gateway
 	maxReqSize = config.GetInt("Gateway.maxReqSizeInKB", 100000) * 1000
 	// Enable dedup of incoming events by default
-	enableDedup = config.GetBool("Gateway.enableDedup", true)
+	enableDedup = config.GetBool("Gateway.enableDedup", false)
 	// Dedup time window in hours
 	dedupWindow = config.GetDuration("Gateway.dedupWindowInS", time.Duration(86400))
 	// Enable rate limit on incoming events. false by default


### PR DESCRIPTION
Gets workspace config from a local json. Make rudder-server work without config.toml file.