### PR TITLE
Fallback for RUDDER_TMPDIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ psql "jobsdb" -c "grant all privileges on database jobsdb to rudder";
 4. Go to the [dashboard](https://app.rudderlabs.com/signup) and set up your account. Copy your workspace token from top of the home page
 5. Clone this repository. Run `git submodule init` and `git submodule update` to fetch the rudder-transformer repo.
  and navigate to the transformer directory `cd rudder-transformer`
-6. Start the destination transformer `node destTransformer.js`
+6. Install dependencies `npm i` and start the destination transformer `node destTransformer.js`
 7. Navigate back to main directory `cd rudder-server`. Copy the sample.env to the main directory `cp config/sample.env .env`
 8. Update the `CONFIG_BACKEND_TOKEN` environment variable with the token fetched in step 4
 9. Run the backend server `go run -mod=vendor main.go`

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -306,6 +306,15 @@ func ReadLines(path string) ([]string, error) {
 // CreateTMPDIR creates tmp dir at path configured via RUDDER_TMPDIR env var
 func CreateTMPDIR() string {
 	tmpdirPath := strings.TrimSuffix(config.GetEnv("RUDDER_TMPDIR", ""), "/")
+	// second chance: fallback to /tmp if this folder exists
+	if tmpdirPath == "" {
+		fallbackPath := "/tmp"
+		_, err := os.Stat(fallbackPath)
+		if err == nil {
+			tmpdirPath = fallbackPath
+			logger.Infof("RUDDER_TMPDIR not found, falling back to %v\n", fallbackPath)
+		}
+	}
 	if tmpdirPath == "" {
 		var err error
 		tmpdirPath, err = os.UserHomeDir()


### PR DESCRIPTION
There's an issue related to `RUDDER_TMPDIR` when I run rudder-server in Centos 7 with suppervisord. This causes the server crash and falling back to `degraded` mode.

Solution for `*unix` system: fallback to `/tmp` if this folder exists
