### PR TITLE
Separate replay implementation from processor

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/replay"
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 
 	"github.com/bugsnag/bugsnag-go"
@@ -188,6 +189,11 @@ func startRudderCore(clearDB *bool, normalMode bool, degradedMode bool, maintena
 	if enableProcessor {
 		var processor processor.HandleT
 		processor.Setup(&gatewayDB, &routerDB, &batchRouterDB)
+
+		if !isReplayServer {
+			var replay replay.ReplayProcessorT
+			replay.Setup(&gatewayDB)
+		}
 	}
 
 	var gateway gateway.HandleT


### PR DESCRIPTION
Replay Processor is move to its own package, separated from processor implementation.
Replay has now its own main loop, and backend config subscriber.
Current implementation is using the Processor's configuration controlling main loop's time.
It also does not include any stats.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-server/239)
<!-- Reviewable:end -->
