### PR TITLE
Send process sessions as a query parameter to transformer

### DIFF
--- a/processor/integrations/integrations.go
+++ b/processor/integrations/integrations.go
@@ -210,6 +210,9 @@ func GetDestinationURL(destID string) string {
 }
 
 //GetUserTransformURL returns the port of running user transform
-func GetUserTransformURL() string {
+func GetUserTransformURL(processSessions bool) string {
+	if processSessions {
+		return destTransformURL + "/customTransform?processSessions=true"
+	}
 	return destTransformURL + "/customTransform"
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -699,12 +699,12 @@ func (proc *HandleT) processJobsForDest(jobList []*jobsdb.JobT, parsedEventList 
 				// This way all the events of a user session are never broken into separate batches
 				// Note: Assumption is events from a user's session are together in destEventList, which is guaranteed by the way destEventList is created
 				destStat.sessionTransform.Start()
-				response = proc.transformer.Transform(destEventList, integrations.GetUserTransformURL(), userTransformBatchSize, true)
+				response = proc.transformer.Transform(destEventList, integrations.GetUserTransformURL(processSessions), userTransformBatchSize, true)
 				destStat.sessionTransform.End()
 			} else {
 				// We need not worry about breaking up a single user sessions in this case
 				destStat.userTransform.Start()
-				response = proc.transformer.Transform(destEventList, integrations.GetUserTransformURL(), userTransformBatchSize, false)
+				response = proc.transformer.Transform(destEventList, integrations.GetUserTransformURL(processSessions), userTransformBatchSize, false)
 				destStat.userTransform.End()
 			}
 			for _, userTransformedEvent := range response.Events {


### PR DESCRIPTION
This is to decide if we should group events based on userId in custom transformer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-server/262)
<!-- Reviewable:end -->
