### PR TITLE
Fixes bug in dedupe logic

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -419,6 +420,7 @@ func (gateway *HandleT) dedup(body *[]byte, messageIDs []string, allMessageIDsSe
 		toRemoveMessageIndexes = append(toRemoveMessageIndexes, k)
 	}
 
+	sort.Ints(toRemoveMessageIndexes)
 	count := 0
 	for _, idx := range toRemoveMessageIndexes {
 		logger.Debugf("Dropping event with duplicate messageId: %s", messageIDs[idx])


### PR DESCRIPTION
Dedupe can remove the wrong messages from a batch due to a logic error.

Steps to reproduce:
```go
body := []byte(`{"batch":["a","b","c","c"]}`)
messageIDs := []string{"a", "b", "c", "c"}
allMessageIDsSet := map[string]struct{}{"a": struct{}{}}
writeKey := "writeKey"
writeKeyDupStats := map[string]int{}
c := &HandleT{}
c.dedup(&body, messageIDs, allMessageIDsSet, writeKey, writeKeyDupStats)
```
Expected result:
```
{"batch":["b","c"]}
```
Actual result:
```
{"batch":["a","b"]}
```

The fix is pretty simple.  
The logic functions correctly when `toRemoveMessageIndexes` is sorted.

Normally I would write a failing test, but this method has no tests and is not easily testable because the badger client is referenced directly within the function rather than through an interface so it can't be mocked.

---

The dedupe system contains other false negative errors likely to produce duplicate output under high load (like race conditions due to non-atomic compare-and-set in Badger), but given that the dedupe database is being stored in the `/tmp` directory and I don't see any cross-node communication to handle dedupe in HA environments, I don't have a lot of motivation to restructure the code if it's not likely to fix what is also an operational problem in multi-node environments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-server/337)
<!-- Reviewable:end -->
