### PR TITLE
BigQuery Warehouse - Fix DataSet Location

### DIFF
--- a/warehouse/bigquery/bigquery.go
+++ b/warehouse/bigquery/bigquery.go
@@ -40,6 +40,7 @@ type HandleT struct {
 const (
 	GCPProjectID   = "project"
 	GCPCredentials = "credentials"
+	GCPLocation = "location"
 )
 
 // maps datatype stored in rudder to datatype in bigquery
@@ -142,8 +143,18 @@ func (bq *HandleT) addColumn(tableName string, columnName string, columnType str
 
 func (bq *HandleT) createSchema() (err error) {
 	logger.Infof("BQ: Creating bigquery dataset: %s in project: %s", bq.Namespace, bq.ProjectID)
+
+	location := strings.TrimSpace(warehouseutils.GetConfigValue(GCPLocation, bq.Warehouse))
+	if location == "" {
+		location = "US"
+	}
+
 	ds := bq.Db.Dataset(bq.Namespace)
-	err = ds.Create(bq.BQContext, nil)
+	meta := &bigquery.DatasetMetadata{
+		Location: location,
+	}
+
+	err = ds.Create(bq.BQContext, meta)
 	return
 }
 


### PR DESCRIPTION
Fixes #357 

When setting the location in the connection credentials, I expected the Dataset to be created in this location, but it was created in the US.
![image](https://user-images.githubusercontent.com/5872952/84385089-474d4080-abef-11ea-9999-179cc7ab2cf2.png)



This commit fix this behaviour by using the "location" configuration (and defaulting it to `US`).

---

To test this, create a BigQuery destination with a location different than US (such as EU). The dataset when created will be in the given location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-server/358)
<!-- Reviewable:end -->
