### PR TITLE
Api Version for backend compatibility <-> transformer

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -120,19 +120,6 @@ func (trans *HandleT) transformWorker() {
 			transformRequestTimerStat.Start()
 			resp, err = client.Post(job.url, "application/json; charset=utf-8",
 				bytes.NewBuffer(rawJSON))
-			var transformerAPIVersion int
-			var convErr error
-			if err == nil {
-				transformerAPIVersion, convErr = strconv.Atoi(resp.Header.Get("apiVersion"))
-
-				if convErr != nil {
-					transformerAPIVersion = 0
-				}
-			}
-			if supportedTransformerAPIVersion != transformerAPIVersion {
-				logger.Errorf("Incompatible transformer version: Expected: %d Received: %d", supportedTransformerAPIVersion, transformerAPIVersion)
-				panic(fmt.Errorf("Incompatible transformer version: Expected: %d Received: %d", supportedTransformerAPIVersion, transformerAPIVersion))
-			}
 			if err != nil {
 				transformRequestTimerStat.End()
 				reqFailed = true
@@ -147,6 +134,15 @@ func (trans *HandleT) transformWorker() {
 			}
 			if reqFailed {
 				logger.Errorf("Failed request succeeded after %v retries, URL: %v", retryCount, job.url)
+			}
+
+			transformerAPIVersion, convErr := strconv.Atoi(resp.Header.Get("apiVersion"))
+			if convErr != nil {
+				transformerAPIVersion = 0
+			}
+			if supportedTransformerAPIVersion != transformerAPIVersion {
+				logger.Errorf("Incompatible transformer version: Expected: %d Received: %d", supportedTransformerAPIVersion, transformerAPIVersion)
+				panic(fmt.Errorf("Incompatible transformer version: Expected: %d Received: %d", supportedTransformerAPIVersion, transformerAPIVersion))
 			}
 			transformRequestTimerStat.End()
 			break

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -23,7 +23,7 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
-var supportedTransformerAPIVersion = 1
+const supportedTransformerAPIVersion = 1
 
 type MetadataT struct {
 	SourceID        string `json:"sourceId"`
@@ -129,11 +129,14 @@ func (trans *HandleT) transformWorker() {
 					transformerAPIVersion = 0
 				}
 			}
-			if err != nil || supportedTransformerAPIVersion != transformerAPIVersion{
+			if supportedTransformerAPIVersion != transformerAPIVersion {
+				logger.Errorf("Incompatible transformer version: Expected: %d Received: %d", supportedTransformerAPIVersion, transformerAPIVersion)
+				panic(fmt.Errorf("Incompatible transformer version: Expected: %d Received: %d", supportedTransformerAPIVersion, transformerAPIVersion))
+			}
+			if err != nil {
 				transformRequestTimerStat.End()
 				reqFailed = true
 				logger.Errorf("JS HTTP connection error: URL: %v Error: %+v", job.url, err)
-				logger.Errorf("JS HTTP version mismatch: URL: %v SupportedVersion: %d, ReceivedVersion: %d", job.url, supportedTransformerAPIVersion, transformerAPIVersion)
 				if retryCount > maxRetry {
 					panic(fmt.Errorf("JS HTTP connection error: URL: %v Error: %+v", job.url, err))
 				}


### PR DESCRIPTION
Receiving an apiVersion as a response header for destination transformations to check against a supported version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-server/380)
<!-- Reviewable:end -->
