### PR TITLE
Crash reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ enterprise
 *.coverprofile
 junit*.xml
 **/profile.out
+crash-report-*

--- a/app/app.go
+++ b/app/app.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"runtime/pprof"
 
+	"github.com/rudderlabs/rudder-server/app/crash"
+	"github.com/rudderlabs/rudder-server/services/stats"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 )
 
@@ -28,6 +30,9 @@ type Interface interface {
 
 // Setup initializes application
 func (a *App) Setup() {
+	// start default crash manager
+	go crash.Default.HandlePanics()
+
 	// If cpuprofile flag is present, setup cpu profiling
 	if a.options.Cpuprofile != "" {
 		a.initCPUProfiling()
@@ -97,6 +102,11 @@ func (a *App) Stop() {
 
 // New creates a new application instance
 func New(options *Options) Interface {
+	logger.Setup()
+
+	//Creating Stats Client should be done right after setting up logger and before setting up other modules.
+	stats.Setup()
+
 	return &App{
 		options: options,
 	}

--- a/app/crash/bugsnag.go
+++ b/app/crash/bugsnag.go
@@ -1,0 +1,40 @@
+package crash
+
+import (
+	"context"
+	"runtime"
+
+	"github.com/bugsnag/bugsnag-go"
+	"github.com/rudderlabs/rudder-server/app/version"
+	"github.com/rudderlabs/rudder-server/config"
+)
+
+var ctx context.Context
+
+// SetupBugsnag will initialize bugsnag integration
+func SetupBugsnag() {
+	bugsnag.Configure(bugsnag.Configuration{
+		APIKey:       config.GetEnv("BUGSNAG_KEY", ""),
+		ReleaseStage: config.GetEnv("GO_ENV", "development"),
+		// The import paths for the Go packages containing your source files
+		ProjectPackages: []string{"main", "github.com/rudderlabs/rudder-server"},
+		// more configuration options
+		AppType:      "rudder-server",
+		AppVersion:   version.Current().Version,
+		PanicHandler: func() {},
+	})
+}
+
+// StartBugsnagSession will return a Context for a new Bugsnag session
+func StartBugsnagSession() context.Context {
+	return bugsnag.StartSession(context.Background())
+}
+
+// BugsnagHandler is crash Handler that forwards PanicInformation to Bugsnag
+func BugsnagHandler(pi PanicInformation) {
+	bugsnag.AutoNotify(pi.Context, bugsnag.SeverityError, bugsnag.MetaData{
+		"GoRoutines": {
+			"Number": runtime.NumGoroutine(),
+		},
+	})
+}

--- a/app/crash/compress.go
+++ b/app/crash/compress.go
@@ -1,0 +1,93 @@
+package crash
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func (r *Report) packageTempDir() error {
+	tempDir := r.TempDir()
+	packageName := fmt.Sprintf("%s.tar.gz", tempDir)
+
+	// package and compress tempDir to buffer
+	var buffer bytes.Buffer
+	if err := compress(tempDir, &buffer); err != nil {
+		return err
+	}
+
+	// create package file and copy buffer
+	packageFile, err := os.OpenFile(packageName, os.O_CREATE|os.O_RDWR, os.FileMode(0700))
+	if err != nil {
+		return err
+	}
+	defer packageFile.Close()
+
+	if _, err = io.Copy(packageFile, &buffer); err != nil {
+		return err
+	}
+
+	// remove tempDir
+	if err = os.RemoveAll(tempDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// from https://gist.githubusercontent.com/mimoo/25fc9716e0f1353791f5908f94d6e726/raw/4383bf695f4ba8bbb0687d83b0882bb7e71fd521/compress_tar_gzip.go
+func compress(src string, buf io.Writer) error {
+	// tar > gzip > buf
+	zr := gzip.NewWriter(buf)
+	tw := tar.NewWriter(zr)
+
+	// walk through every file in the folder
+	err := filepath.Walk(src, func(file string, fi os.FileInfo, err error) error {
+		// generate tar header
+		header, err := tar.FileInfoHeader(fi, file)
+		if err != nil {
+			return err
+		}
+
+		// must provide real name
+		// (see https://golang.org/src/archive/tar/common.go?#L626)
+		header.Name = filepath.ToSlash(file)
+
+		// write header
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+
+		// if not a dir, write file content
+		if !fi.IsDir() {
+			data, err := os.Open(file)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(tw, data); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// produce tar
+	if err = tw.Close(); err != nil {
+		return err
+	}
+
+	// produce gzip
+	if err := zr.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/app/crash/crash.go
+++ b/app/crash/crash.go
@@ -1,0 +1,107 @@
+// Package crash handles unexpected panics by running registered crash handlers.
+package crash
+
+import (
+	"context"
+	"os"
+	"runtime"
+
+	"github.com/rudderlabs/rudder-server/utils/logger"
+)
+
+// PanicInformation describes a panic.
+type PanicInformation struct {
+	Error   interface{}
+	Stack   string
+	Context context.Context
+}
+
+// Handler functions handle errors received by errorSignal.
+// They can be used for a number of purposes, such as logging the error, send it to external monitoring services,
+// or generate crash reports
+type Handler func(info PanicInformation)
+
+// Manager will provide Defer functions that capture panics, and handles them using registered handlers.
+type Manager struct {
+	// array of registered handlers
+	handlers []Handler
+
+	// errorSignal is a channel that lets goroutines catch their own panics and safely forward them to one central listener.
+	errorSignal chan PanicInformation
+}
+
+// Default manager provides the default crash behavior, with Log and Bugsnag handlers.
+var Default *Manager
+
+// New creates a new Crash manager,
+func New() *Manager {
+	return &Manager{
+		errorSignal: make(chan PanicInformation),
+	}
+}
+
+func init() {
+	// Setup integration with https://www.bugsnag.com error monitoring service
+	SetupBugsnag()
+
+	Default = New()
+	Default.RegisterHandler(BugsnagHandler)
+	Default.RegisterHandler(LogHandler)
+}
+
+// RegisterHandler registers a function that will run by crash module after an unhandled panic is encountered.
+// Handler function will receive the PanicInformation of the panic.
+func (m *Manager) RegisterHandler(handler Handler) {
+	m.handlers = append(m.handlers, handler)
+}
+
+func stackTrace() string {
+	stack := make([]byte, 1024*8)
+	stack = stack[:runtime.Stack(stack, false)]
+	return string(stack)
+}
+
+// sendError sends panic information up the Signal channel.
+func (m *Manager) sendError(ctx context.Context, err interface{}) {
+	m.errorSignal <- PanicInformation{
+		Error:   err,
+		Stack:   stackTrace(),
+		Context: ctx,
+	}
+}
+
+// DeferWithContext is a deferred function that recovers from a panic and sends it
+// through the Signal channel, along with provided context.
+func (m *Manager) DeferWithContext(ctx context.Context) {
+	if err := recover(); err != nil {
+		m.sendError(ctx, err)
+	}
+}
+
+// Defer is a deferred function that recovers from a panic and sends it
+// through the Signal channel, using context.Background() context.
+func (m *Manager) Defer() {
+	if err := recover(); err != nil {
+		m.sendError(context.Background(), err)
+	}
+}
+
+// HandlePanics watches the Signal channel for any panics caught by crash.Defer functions,
+// and passes them to any registered crash.Handler functions.
+// It will exit the application after all handlers have run.
+func (m *Manager) HandlePanics() {
+	var pi PanicInformation
+	for {
+		pi = <-m.errorSignal
+		for _, handler := range m.handlers {
+			handler(pi)
+		}
+		os.Exit(2)
+	}
+}
+
+// LogHandler will log PanicInformations Error and Stack to stderr
+func LogHandler(pi PanicInformation) {
+	logger.Error(pi.Error)
+	logger.Error(pi.Stack)
+}

--- a/app/crash/crash_suite_test.go
+++ b/app/crash/crash_suite_test.go
@@ -1,0 +1,13 @@
+package crash_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCrash(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Crash Suite")
+}

--- a/app/crash/report.go
+++ b/app/crash/report.go
@@ -1,0 +1,205 @@
+package crash
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/utils/logger"
+)
+
+// ReportFileHandler is a function responsible for producing contents of a report file.
+type ReportFileHandler func(file *os.File) error
+
+// Report contains information about a crash report
+type Report struct {
+	// base directory in which report files, and temporary directory, will be created.
+	BaseDir string
+
+	// generic metadata about the application state during a crash.
+	Metadata map[string]interface{}
+
+	// PanicInformation related to this report
+	PanicInformation PanicInformation
+
+	// registered ReportFileHandlers that will produce report files on Save()
+	// the map's key corresponds to the filename
+	handlers map[string]ReportFileHandler
+
+	startedAt time.Time // holds when Save() was called
+	tempDir   string    // on Save(), will be initialized to path of temporary directory, used to hold report contents
+}
+
+// RegisterFileHandler registers a new ReportFileHandler on this Report,
+// that will run during report's Save(), and is responsible for create contents of file with provided name.
+func (r *Report) RegisterFileHandler(name string, handler ReportFileHandler) {
+	if r.handlers == nil {
+		r.handlers = make(map[string]ReportFileHandler)
+	}
+	r.handlers[name] = handler
+}
+
+func (r *Report) ensureDir(dir string) error {
+	fileInfo, err := os.Stat(dir)
+
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(dir, os.FileMode(0700))
+		if err != nil {
+			return fmt.Errorf("Could not create crash report dir '%v': '%w'", dir, err)
+		}
+	} else if err != nil {
+		return err
+	} else if !fileInfo.IsDir() {
+		return fmt.Errorf("Crash report base dir '%v' already exists and is not a directory", r.BaseDir)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Could not open crash report's base dir: '%v': %w", r.BaseDir, err)
+	}
+
+	return nil
+}
+
+// EnsureTempDir creates a temporary directory in BaseDir, if it does not exist.
+// Any report files will be stored there, and the directory will be compressed to .tar.gz on Save()
+func (r *Report) EnsureTempDir() {
+	tempDir := r.TempDir()
+	err := r.ensureDir(tempDir)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// TempDir returns the path of the directory that will be used to store all report files.
+// It should be removed after it is compressed to .tar.gz successfully on Save().
+func (r *Report) TempDir() string {
+	if r.startedAt.IsZero() {
+		r.startedAt = time.Now()
+	}
+
+	return path.Join(r.BaseDir, fmt.Sprintf("crash-report-%d", r.startedAt.UnixNano()))
+}
+
+func (r *Report) filePath(file string) string {
+	return path.Join(r.TempDir(), file)
+}
+
+// Save stores the report file.
+// TODO: Explain
+func (r *Report) Save() (err error) {
+	r.startedAt = time.Now()
+
+	r.EnsureTempDir()
+
+	// store report's metadata
+	_, err = r.SaveMetadata()
+	if err != nil {
+		logger.Errorf("Could not store crash report metadata")
+	}
+
+	// run any registered report handlers, for custom report files
+	for name, handler := range r.handlers {
+		filePath := r.filePath(name)
+		logger.Infof("Crash Report for: %s", path.Dir(filePath))
+		err := r.ensureDir(path.Dir(filePath))
+		if err != nil {
+			logger.Errorf("Could not read or create base directory for file '%v': '%v'", name, err)
+		}
+
+		file, err := os.Create(filePath)
+		if err != nil {
+			logger.Errorf("Could not create report file '%v': '%v'", name, err)
+		}
+
+		defer file.Close()
+
+		err = handler(file)
+		if err != nil {
+			logger.Errorf("Could not generate contents of file '%v': '%v'", name, err)
+		}
+	}
+
+	return
+}
+
+func (r *Report) SaveMetadata() (metadataPath string, err error) {
+	metadataPath = r.filePath("report.json")
+	file, err := os.Create(metadataPath)
+	if err != nil {
+		err = fmt.Errorf("Could not create report metadata file '%v': %w", metadataPath, err)
+		return
+	}
+
+	defer file.Close()
+
+	metadata := r.metadata()
+	err = WriteMapToFile(metadata, file)
+	if err != nil {
+		err = fmt.Errorf("Could not write report metadata file '%v': %w", metadataPath, err)
+		return
+	}
+
+	return
+}
+
+// Compress will compress the report's BaseDir and contents, and remove the original BaseDir
+// The compressed file's path will be returned, if no error occurred.
+// If an error occurred, the compress file is not generated, and the report directory is not removed.
+func (r *Report) Compress() {
+
+}
+
+func (r *Report) metadata() map[string]interface{} {
+	metadata := r.Metadata
+
+	metadata["report"] = r.reportMetadata()
+	metadata["panic"] = r.panicMetadata()
+
+	return metadata
+}
+
+func (r *Report) reportMetadata() map[string]interface{} {
+	metadata := make(map[string]interface{})
+
+	metadata["started_at"] = r.startedAt
+
+	return metadata
+}
+
+func (r *Report) panicMetadata() map[string]interface{} {
+	metadata := make(map[string]interface{})
+
+	if r.PanicInformation.Error != nil {
+		metadata["error"] = r.PanicInformation.Error.Error()
+	}
+
+	metadata["received_at"] = r.PanicInformation.ReceivedAt
+	metadata["trace"] = r.PanicInformation.Trace
+	metadata["context"] = r.PanicInformation.Context
+
+	return metadata
+}
+
+// ReportHandler is the Crash handler responsible for creating the report file.
+func (r *Report) ReportHandler(pi PanicInformation) {
+	r.PanicInformation = pi
+	r.Save()
+}
+
+// WriteMapToFile is a utility function that dumps contents of a map to a file.
+func WriteMapToFile(data map[string]interface{}, file *os.File) (err error) {
+	marshalled, err := json.MarshalIndent(data, "", "\t")
+	if err != nil {
+		err = fmt.Errorf("Could not marshal report metadata: %w", err)
+		return
+	}
+
+	reader := bytes.NewReader(marshalled)
+	_, err = io.Copy(file, reader)
+
+	return
+}

--- a/app/crash/report.go
+++ b/app/crash/report.go
@@ -1,15 +1,13 @@
 package crash
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"time"
 
 	"github.com/rudderlabs/rudder-server/utils/logger"
+	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
 // ReportFileHandler is a function responsible for producing contents of a report file.
@@ -148,7 +146,7 @@ func (r *Report) SaveMetadata() (metadataPath string, err error) {
 	defer file.Close()
 
 	metadata := r.metadata()
-	err = WriteMapToFile(metadata, file)
+	err = misc.WriteMapToWriter(metadata, file)
 	if err != nil {
 		err = fmt.Errorf("Could not write report metadata file '%v': %w", metadataPath, err)
 		return
@@ -201,18 +199,4 @@ func (r *Report) ReportHandler(pi PanicInformation) {
 	if err := r.Save(); err != nil {
 		logger.Errorf("Could not generate crash report: %v", err)
 	}
-}
-
-// WriteMapToFile is a utility function that dumps contents of a map to a file.
-func WriteMapToFile(data map[string]interface{}, file *os.File) (err error) {
-	marshalled, err := json.MarshalIndent(data, "", "\t")
-	if err != nil {
-		err = fmt.Errorf("Could not marshal report metadata: %w", err)
-		return
-	}
-
-	reader := bytes.NewReader(marshalled)
-	_, err = io.Copy(file, reader)
-
-	return
 }

--- a/app/crash/report_test.go
+++ b/app/crash/report_test.go
@@ -1,0 +1,55 @@
+package crash_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/rudderlabs/rudder-server/app/crash"
+)
+
+var _ = Describe("Crash Report", func() {
+	var c *crash.Manager
+
+	BeforeEach(func() {
+		c = crash.New()
+		baseDir, err := ioutil.TempDir("", "")
+		if err != nil {
+			panic(err)
+		}
+
+		c.Report.BaseDir = baseDir
+		c.Report.EnsureTempDir()
+	})
+
+	It("should create report metadata file", func() {
+		c.Report.Metadata = map[string]interface{}{
+			"key": "value",
+		}
+
+		// save metadata
+		metadataPath, err := c.Report.SaveMetadata()
+		if err != nil {
+			panic(err)
+		}
+
+		// file should be created in c.Report.BaseDir
+		Expect(metadataPath).To(HavePrefix(c.Report.BaseDir))
+
+		// read stored metadata file
+		data, err := ioutil.ReadFile(metadataPath)
+		if err != nil {
+			panic(err)
+		}
+
+		// convert to map and compare
+		var metadata = make(map[string]interface{})
+		err = json.Unmarshal(data, &metadata)
+		if err != nil {
+			panic(err)
+		}
+
+		Expect(metadata["key"]).To(Equal(c.Report.Metadata["key"]))
+	})
+})

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -1,0 +1,43 @@
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+var version = "Not an official release. Get the latest release from the github repo."
+var major, minor, commit, buildDate, builtBy, gitURL, patch string
+
+// Version contains aggregated versioning information
+type Version struct {
+	Version   string
+	Major     string
+	Minor     string
+	Patch     string
+	Commit    string
+	BuildDate string
+	BuiltBy   string
+	GitURL    string
+}
+
+// Current returns the application's version, as set by build time flags
+// TODO: fill in details about ldflags
+func Current() Version {
+	return Version{
+		Version:   version,
+		Major:     major,
+		Minor:     minor,
+		Patch:     patch,
+		Commit:    commit,
+		BuildDate: buildDate,
+		BuiltBy:   builtBy,
+		GitURL:    gitURL,
+	} // return map[string]interface{}{"Version": version, "Major": major, "Minor": minor, "Patch": patch, "Commit": commit, "BuildDate": buildDate, "BuiltBy": builtBy, "GitUrl": gitURL}
+}
+
+// PrintVersion prints the application's version on stdout.
+func PrintVersion() {
+	version := Current()
+	versionFormatted, _ := json.MarshalIndent(&version, "", " ")
+	fmt.Printf("Version Info %s\n", versionFormatted)
+}

--- a/build/buildspec.docker.dev.yml
+++ b/build/buildspec.docker.dev.yml
@@ -28,14 +28,14 @@ phases:
       - ginkgo -mod vendor --randomizeAllSpecs --randomizeSuites --failOnPending --cover -coverprofile=profile.out -covermode=atomic --trace --progress --skipPackage=tests ./...
       - find . -name "profile.out" | while read file;do cat $file >> coverage.txt; echo "" >> coverage.txt;done
       - bash build/codecov.sh
-      - GOOS=linux CGO_ENABLED=1 RACE_ENABLED=TRUE LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
-      - GOOS=linux LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
+      - GOOS=linux CGO_ENABLED=1 RACE_ENABLED=TRUE LDFLAGS="-s -w -X github.com/rudderlabs/rudder-server/app/version.version=$VERSION -X github.com/rudderlabs/rudder-server/app/version.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X github.com/rudderlabs/rudder-server/app/version.buildDate=$DATE -X github.com/rudderlabs/rudder-server/app/version.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
+      - GOOS=linux LDFLAGS="-s -w -X github.com/rudderlabs/rudder-server/app/version.version=$VERSION -X github.com/rudderlabs/rudder-server/app/version.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X github.com/rudderlabs/rudder-server/app/version.buildDate=$DATE -X github.com/rudderlabs/rudder-server/app/version.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - docker build -t rudderlabs/develop-rudder-server:$VERSION -f build/Dockerfile-aws-dev .
       # Build Enterprise version
       - make enterprise-init
       - ginkgo -mod vendor --randomizeAllSpecs --randomizeSuites --failOnPending --cover -coverprofile=profile.out -covermode=atomic --trace --progress --skipPackage=tests ./...
-      - GOOS=linux CGO_ENABLED=1 RACE_ENABLED=TRUE LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
-      - GOOS=linux LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
+      - GOOS=linux CGO_ENABLED=1 RACE_ENABLED=TRUE LDFLAGS="-s -w -X github.com/rudderlabs/rudder-server/app/version.version=$VERSION -X github.com/rudderlabs/rudder-server/app/version.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X github.com/rudderlabs/rudder-server/app/version.buildDate=$DATE -X github.com/rudderlabs/rudder-server/app/version.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
+      - GOOS=linux LDFLAGS="-s -w -X github.com/rudderlabs/rudder-server/app/version.version=$VERSION -X github.com/rudderlabs/rudder-server/app/version.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X github.com/rudderlabs/rudder-server/app/version.buildDate=$DATE -X github.com/rudderlabs/rudder-server/app/version.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - docker build -t rudderstack/rudder-server-enterprise:$VERSION -f build/Dockerfile-aws-dev .
   post_build:
     commands:

--- a/build/buildspec.docker.master.yml
+++ b/build/buildspec.docker.master.yml
@@ -51,7 +51,7 @@ phases:
       - ginkgo -mod vendor --randomizeAllSpecs --randomizeSuites --failOnPending --cover -coverprofile=profile.out -covermode=atomic --trace --progress --skipPackage=tests ./...
       - find . -name "profile.out" | while read file;do cat $file >> coverage.txt; echo "" >> coverage.txt;done
       - bash build/codecov.sh
-      - GOOS=linux LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
+      - GOOS=linux LDFLAGS="-s -w -X github.com/rudderlabs/rudder-server/app/version.version=$VERSION -X github.com/rudderlabs/rudder-server/app/version.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X github.com/rudderlabs/rudder-server/app/version.buildDate=$DATE -X github.com/rudderlabs/rudder-server/app/version.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - docker build -t rudderlabs/rudder-server:$VERSION -f build/Dockerfile-aws .
       # Build Enterprise version
       - make enterprise-init
@@ -66,7 +66,7 @@ phases:
       #- docker-compose down
 
       - ginkgo -mod vendor --randomizeAllSpecs --randomizeSuites --failOnPending --cover -coverprofile=profile.out -covermode=atomic --trace --progress -p --skipPackage=tests ./...
-      - GOOS=linux LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
+      - GOOS=linux LDFLAGS="-s -w -X github.com/rudderlabs/rudder-server/app/version.version=$VERSION -X github.com/rudderlabs/rudder-server/app/version.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X github.com/rudderlabs/rudder-server/app/version.buildDate=$DATE -X github.com/rudderlabs/rudder-server/app/version.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - docker build -t rudderstack/rudder-server-enterprise:$VERSION -f build/Dockerfile-aws . 
   post_build:
     commands:

--- a/build/buildspec.docker.saas.yml
+++ b/build/buildspec.docker.saas.yml
@@ -24,12 +24,12 @@ phases:
       - DATE=$(date "+%F,%T")
 
       # Build Open source version
-      - GOOS=linux LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
+      - GOOS=linux LDFLAGS="-s -w -X github.com/rudderlabs/rudder-server/app/version.version=$VERSION -X github.com/rudderlabs/rudder-server/app/version.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X github.com/rudderlabs/rudder-server/app/version.buildDate=$DATE -X github.com/rudderlabs/rudder-server/app/version.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - docker build -t rudderlabs/rudder-server:$VERSION -f build/Dockerfile-aws .
       - docker tag rudderlabs/rudder-server:$VERSION rudderlabs/rudder-server:latest
       # Build Enterprise version
       - make enterprise-init
-      - GOOS=linux LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
+      - GOOS=linux LDFLAGS="-s -w -X github.com/rudderlabs/rudder-server/app/version.version=$VERSION -X github.com/rudderlabs/rudder-server/app/version.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X github.com/rudderlabs/rudder-server/app/version.buildDate=$DATE -X github.com/rudderlabs/rudder-server/app/version.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - docker build -t rudderstack/rudder-server-enterprise:$VERSION -f build/Dockerfile-aws . 
   post_build:
     commands:

--- a/build/buildspec.docker.yml
+++ b/build/buildspec.docker.yml
@@ -24,11 +24,11 @@ phases:
       - DATE=$(date "+%F,%T")
 
       # Build Open source version
-      - GOOS=linux LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
+      - GOOS=linux LDFLAGS="-s -w -X github.com/rudderlabs/rudder-server/app/version.version=$VERSION -X github.com/rudderlabs/rudder-server/app/version.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X github.com/rudderlabs/rudder-server/app/version.buildDate=$DATE -X github.com/rudderlabs/rudder-server/app/version.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - docker build -t rudderlabs/rudder-server:$VERSION -f build/Dockerfile-aws .
       # Build Enterprise version
       - make enterprise-init
-      - GOOS=linux LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
+      - GOOS=linux LDFLAGS="-s -w -X github.com/rudderlabs/rudder-server/app/version.version=$VERSION -X github.com/rudderlabs/rudder-server/app/version.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X github.com/rudderlabs/rudder-server/app/version.buildDate=$DATE -X github.com/rudderlabs/rudder-server/app/version.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - docker build -t rudderstack/rudder-server-enterprise:$VERSION -f build/Dockerfile-aws . 
   post_build:
     commands:

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -373,17 +373,18 @@ dsRetentionPeriod = A DS is not deleted if it has some activity
 in the retention time
 */
 func (jd *HandleT) Setup(clearAll bool, tablePrefix string, retentionPeriod time.Duration, migrationMode string) {
-
 	var err error
 	jd.migrationState.migrationMode = migrationMode
-	psqlInfo := GetConnectionString()
 	jd.assert(tablePrefix != "", "tablePrefix received is empty")
 	jd.tablePrefix = tablePrefix
 	jd.dsRetentionPeriod = retentionPeriod
 	jd.dsEmptyResultCache = map[dataSetT]map[string]map[string]map[string]bool{}
 
+	jd.registerCrashReportHandlers()
+
 	jd.BackupSettings = jd.getBackUpSettings()
 
+	psqlInfo := GetConnectionString()
 	jd.dbHandle, err = sql.Open("postgres", psqlInfo)
 	jd.assertError(err)
 
@@ -1898,6 +1899,11 @@ func (jd *HandleT) isEmpty(ds dataSetT) bool {
 //GetTablePrefix returns the table prefix of the jobsdb
 func (jd *HandleT) GetTablePrefix() string {
 	return jd.tablePrefix
+}
+
+// GetTableName returns a full table name by prefixing with this JobsDB tablePrefix
+func (jd *HandleT) GetTableName(name string) string {
+	return fmt.Sprintf("%s_%s", jd.tablePrefix, name)
 }
 
 func (jd *HandleT) backupTable(backupDSRange dataSetRangeT, isJobStatusTable bool) (success bool, err error) {

--- a/jobsdb/report.go
+++ b/jobsdb/report.go
@@ -1,0 +1,110 @@
+package jobsdb
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/rudderlabs/rudder-server/app/crash"
+	"github.com/rudderlabs/rudder-server/utils/logger"
+)
+
+// Crash report handling - On a crash, a JobsDB will dump basic metadata and table contents
+
+func handleReportError() {
+	if err := recover(); err != nil {
+		logger.Error(err)
+	}
+}
+
+func (jd *HandleT) registerCrashReportHandlers() {
+	reportDir := fmt.Sprintf("jobsdb/%s/report.json", jd.tablePrefix)
+	crash.Default.Report.RegisterFileHandler(reportDir, jd.reportFileHandler)
+}
+
+func datasetsMetadata(datasets []dataSetT) map[string]interface{} {
+	metadata := make(map[string]interface{})
+
+	metadata["count"] = len(datasets)
+
+	return metadata
+}
+
+func (jd *HandleT) reportFileHandler(file *os.File) error {
+	defer handleReportError()
+	datasets := jd.getDSList(true)
+
+	dir := path.Dir(file.Name())
+
+	jd.createTableDataReports(datasets, dir)
+	jd.createReportMetadata(datasets, file)
+
+	return nil
+}
+
+func (jd *HandleT) createTableDataReports(datasets []dataSetT, dir string) error {
+	jd.createTableFile(dir, jd.GetTableName("journal"))
+	jd.createTableFile(dir, jd.GetTableName("schema_migrations"))
+
+	for _, ds := range datasets {
+		jd.createTableFile(dir, ds.JobTable)
+		jd.createTableFile(dir, ds.JobStatusTable)
+	}
+
+	return nil
+}
+
+func (jd *HandleT) createReportMetadata(datasets []dataSetT, file *os.File) error {
+	metadata := make(map[string]interface{})
+	metadata["datasets"] = datasetsMetadata(datasets)
+
+	return crash.WriteMapToFile(metadata, file)
+}
+
+func (jd *HandleT) createTableFile(dir string, table string) error {
+	logger.Infof("JobsDB: %[1]s: Dumping data for table %[2]s", jd.tablePrefix, table)
+
+	// create file
+	file, err := os.Create(path.Join(dir, fmt.Sprintf("%s.jsonl", table)))
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	// query all data
+	query := fmt.Sprintf("SELECT * FROM %s", table)
+	rows, err := jd.dbHandle.Query(query)
+	if err != nil {
+		panic(err)
+	}
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		panic(err)
+	}
+
+	// scan all rows, for each write a map to file, with columns as keys and query results as values.
+	values := make([][]byte, len(columns))
+	valuePointers := make([]interface{}, len(columns))
+
+	for i := range values {
+		valuePointers[i] = &values[i]
+	}
+
+	for rows.Next() {
+		row := make(map[string]interface{})
+		err := rows.Scan(valuePointers...)
+		if err != nil {
+			panic(err)
+		}
+
+		for i, raw := range values {
+			row[columns[i]] = string(raw)
+		}
+
+		crash.WriteMapToFile(row, file)
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -163,7 +163,6 @@ func startRudderCore(clearDB *bool, normalMode bool, degradedMode bool, maintena
 	runtime.GOMAXPROCS(maxProcess)
 	logger.Info("Clearing DB ", *clearDB)
 
-	backendconfig.Setup()
 	destinationdebugger.Setup()
 	sourcedebugger.Setup()
 

--- a/processor/integrations/integrations.go
+++ b/processor/integrations/integrations.go
@@ -3,29 +3,18 @@ package integrations
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 
-	"github.com/rudderlabs/rudder-server/config"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/types"
 	"github.com/tidwall/gjson"
 )
 
 var (
-	destTransformURL, userTransformURL string
-	customDestination                  []string
-	whSchemaVersion                    string
+	customDestination []string
+	whSchemaVersion   string
 )
-
-func init() {
-	loadConfig()
-}
-
-func loadConfig() {
-	destTransformURL = config.GetEnv("DEST_TRANSFORM_URL", "http://localhost:9090")
-}
 
 const (
 	//PostDataKV means post data is sent as KV
@@ -179,17 +168,4 @@ func FilterClientIntegrations(clientEvent types.SingularEventT, destNameIDMap ma
 	}
 	retVal = outVal
 	return
-}
-
-//GetDestinationURL returns node URL
-func GetDestinationURL(destID string) string {
-	return fmt.Sprintf("%s/v0/%s?whSchemaVersion=%s", destTransformURL, strings.ToLower(destID), config.GetWHSchemaVersion())
-}
-
-//GetUserTransformURL returns the port of running user transform
-func GetUserTransformURL(processSessions bool) string {
-	if processSessions {
-		return destTransformURL + "/customTransform?processSessions=true"
-	}
-	return destTransformURL + "/customTransform"
 }

--- a/processor/transformer/client.go
+++ b/processor/transformer/client.go
@@ -1,0 +1,34 @@
+package transformer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rudderlabs/rudder-server/config"
+)
+
+// DestTransformURL is the transformer service base URL, configured by DEST_TRANSFORM_URL environmental variable.
+var DestTransformURL string
+
+func init() {
+	DestTransformURL = strings.TrimSuffix(config.GetEnv("DEST_TRANSFORM_URL", "http://localhost:9090"), "/")
+}
+
+// GetURL returns a full URL for the configured transformer and provided endpoint.
+// Endpoint should start with '/'.
+func GetURL(endpoint string) string {
+	return fmt.Sprintf("%s%s", DestTransformURL, endpoint)
+}
+
+//GetDestinationURL returns node URL
+func GetDestinationURL(destID string) string {
+	return GetURL(fmt.Sprintf("/v0/%s?whSchemaVersion=%s", strings.ToLower(destID), config.GetWHSchemaVersion()))
+}
+
+//GetUserTransformURL returns the port of running user transform
+func GetUserTransformURL(processSessions bool) string {
+	if processSessions {
+		return GetURL("/customTransform?processSessions=true")
+	}
+	return GetURL("/customTransform")
+}

--- a/processor/transformer/version.go
+++ b/processor/transformer/version.go
@@ -1,0 +1,49 @@
+package transformer
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+var cachedVersion string = ""
+
+// Version returns the version returned by the configured transformer's /version endpoint.
+// The version is requested once, and cached for any future calls to Version() function.
+func Version() (version string, err error) {
+	if cachedVersion == "" {
+		v, err := getVersion()
+
+		if err != nil {
+			return "", err
+		}
+
+		cachedVersion = v
+	}
+
+	return cachedVersion, nil
+}
+
+func getVersion() (version string, err error) {
+	tr := &http.Transport{}
+	client := &http.Client{Transport: tr}
+
+	response, err := client.Get(GetURL("/version"))
+	if err != nil {
+		panic(fmt.Errorf("Could not read transformer version: %w", err))
+	}
+
+	defer response.Body.Close()
+
+	if response.StatusCode == http.StatusOK {
+		bodyBytes, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			panic(fmt.Errorf("Could not parse transformer version: %w", err))
+		}
+
+		bodyString := string(bodyBytes)
+		return bodyString, nil
+	}
+
+	panic(fmt.Errorf("Could not read transformer version: Transformer status code was %v", response.StatusCode))
+}

--- a/rruntime/goroutine-factory.go
+++ b/rruntime/goroutine-factory.go
@@ -1,16 +1,12 @@
 package rruntime
 
 import (
-	"context"
-	"fmt"
-	"runtime"
-
-	"github.com/bugsnag/bugsnag-go"
-	"github.com/rudderlabs/rudder-server/utils/logger"
-	"github.com/rudderlabs/rudder-server/utils/misc"
+	"github.com/rudderlabs/rudder-server/app/crash"
 )
 
-//Go Starts the excution of the function passed as argument in a new Goroutine
+//Go Starts the excution of the function passed as argument in a new Goroutine.
+//The created goroutine will handle panics using the default crash handler and a new Bugsnag session.
+//
 //THING TO NOTE: If the function you are intending to run inside a goroutine takes any parameters,
 //before calling this function, create local variable for every argument (so that evaluation of the argument happens immediately)
 //and then pass those local variables as arguments
@@ -24,19 +20,8 @@ import (
 //    })
 func Go(function func()) {
 	go func() {
-		ctx := bugsnag.StartSession(context.Background())
-		defer func() {
-			if r := recover(); r != nil {
-				defer bugsnag.AutoNotify(ctx, bugsnag.SeverityError, bugsnag.MetaData{
-					"GoRoutines": {
-						"Number": runtime.NumGoroutine(),
-					}})
-
-				misc.RecordAppError(fmt.Errorf("%v", r))
-				logger.Fatal(r)
-				panic(r)
-			}
-		}()
+		ctx := crash.StartBugsnagSession()
+		defer crash.Default.DeferWithContext(ctx)
 		function()
 	}()
 }

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -736,3 +736,17 @@ func MakeRetryablePostRequest(url string, endpoint string, data interface{}) (re
 	logger.Debugf("Post request: Successful %s", string(body))
 	return body, resp.StatusCode, nil
 }
+
+// WriteMapToWriter is a utility function that dumps contents of a map to an io.Writer.
+func WriteMapToWriter(data map[string]interface{}, writer io.Writer) (err error) {
+	marshalled, err := json.Marshal(data)
+	if err != nil {
+		err = fmt.Errorf("Could not marshal report metadata: %w", err)
+		return
+	}
+
+	reader := bytes.NewReader(marshalled)
+	_, err = io.Copy(writer, reader)
+
+	return
+}


### PR DESCRIPTION
All application's panics are now handled by crash manager defined in app/crash package. Crash manager provides a defer function that recovers any panics and sends them to an internal channel. Registered crash handlers will act on a panic read from the channel. Current crash handlers include:
- Logging: logs error and trace
- Bugsnag: forwards panic to Bugsnag
- Report: creates a crash report .tar.gz file with various metadata for debugging purposes.

Crash Report provides file handlers that can be registered by various modules to add contents to a crash report.
Current implementation includes a JobsDB report file handler, that dump all JobsDB tables to .jsonl files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-server/387)
<!-- Reviewable:end -->
