### PR TITLE
Adds admin interface using rpc over a unix socket

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -44,6 +44,8 @@ import (
 	"github.com/rudderlabs/rudder-server/services/db"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/misc"
+
+	"github.com/spf13/viper"
 )
 
 // PackageStatusHandler to be implemented by other package admin objects
@@ -107,6 +109,17 @@ func (a Admin) HeapDump(path *string, reply *string) error {
 	pprof.Lookup("heap").WriteTo(f, 1)
 	*reply = "Heap profile written to " + *path
 	return nil
+}
+
+// ServerConfig fetches current configuration as set in viper
+func (a Admin) ServerConfig(arg *string, reply *string) error {
+	config := make(map[string]interface{})
+	for _, key := range viper.AllKeys() {
+		config[key] = viper.Get(key)
+	}
+	formattedOutput, err := json.MarshalIndent(config, "", "  ")
+	*reply = string(formattedOutput)
+	return err
 }
 
 // StartServer starts an http server listening on unix socket and serving rpc communication

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -1,0 +1,120 @@
+package admin
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/rpc"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"strings"
+)
+
+const sockAddr = "/tmp/rudder-server.sock"
+
+/*
+Example for registering admin handler from another package
+
+// Add this while initializing the package in setup or init etc.
+admin.RegisterAdminHandler("PackageName", &PackageAdmin{})
+
+// Convention is to keep the following code in admin.go in the respective package
+type PackageAdmin struct {
+}
+
+// Status function is used for debug purposes by the admin interface
+func (p *PackageAdmin) Status() string {
+	return fmt.Sprintf(
+		`Package:
+---------
+Parameter 1  : value
+Parameter 2  : value
+`)
+}
+
+// The following function can be called from rudder-cli using getUDSClient().Call("PackageName.SomeAdminFunction", &arg, &reply)
+func (p *PackageAdmin) SomeAdminFunction(arg *string, reply *string) error {
+	*reply = "admin function output"
+	return nil
+}
+*/
+
+// PackageAdminHandler to be implemented by other package admin objects
+type PackageAdminHandler interface {
+	Status() string
+}
+
+// RegisterAdminHandler is used by other packages to
+// expose admin functions over the unix socket based rpc interface
+func RegisterAdminHandler(name string, handler PackageAdminHandler) {
+	instance.handlers[strings.ToLower(name)] = handler
+	instance.rpcServer.RegisterName(name, handler)
+}
+
+type Admin struct {
+	handlers  map[string]PackageAdminHandler
+	rpcServer *rpc.Server
+}
+
+var instance Admin
+
+func init() {
+	instance = Admin{
+		handlers:  make(map[string]PackageAdminHandler),
+		rpcServer: rpc.NewServer(),
+	}
+	instance.rpcServer.Register(instance)
+}
+
+func (a Admin) Status(module *string, reply *string) error {
+
+	if *module == "" {
+		for _, handler := range a.handlers {
+			*reply += handler.Status() + "\n"
+		}
+	} else if _, ok := a.handlers[*module]; ok {
+		*reply = a.handlers[*module].Status()
+	} else {
+		statusEnabledModules := make([]string, 0, len(a.handlers))
+		for k := range a.handlers {
+			statusEnabledModules = append(statusEnabledModules, "\""+k+"\"")
+		}
+		return fmt.Errorf("valid module arguments are " + strings.Join(statusEnabledModules, ","))
+	}
+
+	return nil
+}
+
+func (s Admin) PrintStack(arg *string, reply *string) error {
+	byteArr := make([]byte, 2048*1024)
+	n := runtime.Stack(byteArr, true)
+	*reply = string(byteArr[:n])
+	return nil
+}
+
+func (s Admin) HeapDump(path *string, reply *string) error {
+	f, err := os.OpenFile(*path, os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	pprof.Lookup("heap").WriteTo(f, 1)
+	*reply = "Heap profile written to " + *path
+	return nil
+}
+
+func StartServer() {
+	if err := os.RemoveAll(sockAddr); err != nil {
+		log.Fatal(err)
+	}
+	l, e := net.Listen("unix", sockAddr)
+	if e != nil {
+		log.Fatal("listen error:", e)
+	}
+	fmt.Println("Serving on admin interface...")
+	srvMux := http.NewServeMux()
+	srvMux.Handle(rpc.DefaultRPCPath, instance.rpcServer)
+	http.Serve(l, srvMux)
+}

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -79,7 +79,7 @@ func init() {
 }
 
 // Status reports overall server status by fetching status of all registered admin handlers
-func (a Admin) Status(arg *string, reply *string) error {
+func (a Admin) Status(noArgs struct{}, reply *string) error {
 	statusObj := make(map[string]interface{})
 	statusObj["server-mode"] = db.CurrentMode
 
@@ -92,7 +92,7 @@ func (a Admin) Status(arg *string, reply *string) error {
 }
 
 // PrintStack fetches stack traces of all running goroutines
-func (a Admin) PrintStack(arg *string, reply *string) error {
+func (a Admin) PrintStack(noArgs struct{}, reply *string) error {
 	byteArr := make([]byte, 2048*1024)
 	n := runtime.Stack(byteArr, true)
 	*reply = string(byteArr[:n])
@@ -112,7 +112,7 @@ func (a Admin) HeapDump(path *string, reply *string) error {
 }
 
 // ServerConfig fetches current configuration as set in viper
-func (a Admin) ServerConfig(arg *string, reply *string) error {
+func (a Admin) ServerConfig(noArgs struct{}, reply *string) error {
 	config := make(map[string]interface{})
 	for _, key := range viper.AllKeys() {
 		config[key] = viper.Get(key)

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -48,9 +48,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-// PackageStatusHandler to be implemented by other package admin objects
+// PackageStatusHandler to be implemented by the package objects that are registered as status handlers
+// output of Status() is expected to be json encodeable by default
 type PackageStatusHandler interface {
-	Status() map[string]interface{}
+	Status() interface{}
 }
 
 // RegisterAdminHandler is used by other packages to
@@ -59,6 +60,7 @@ func RegisterAdminHandler(name string, handler interface{}) {
 	instance.rpcServer.RegisterName(name, handler)
 }
 
+// RegisterStatusHandler expects object implementing PackageStatusHandler interface
 func RegisterStatusHandler(name string, handler PackageStatusHandler) {
 	instance.statushandlers[strings.ToLower(name)] = handler
 }

--- a/build/Dockerfile-aws
+++ b/build/Dockerfile-aws
@@ -5,5 +5,6 @@ RUN mkdir /app
 ADD . /app
 ADD build/wait-for /
 ADD build/docker-entrypoint.sh /
+RUN ln -s /app/rudder-cli/rudder-cli.linux.x86_64 /usr/bin/rudder-cli
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/rudder-server"]

--- a/build/Dockerfile-aws-dev
+++ b/build/Dockerfile-aws-dev
@@ -6,5 +6,6 @@ RUN mkdir /app
 ADD . /app
 ADD build/wait-for /
 ADD build/docker-entrypoint.sh /
+RUN ln -s /app/rudder-cli/rudder-cli.linux.x86_64 /usr/bin/rudder-cli
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/rudder-server-with-race"]

--- a/config/backend-config/admin.go
+++ b/config/backend-config/admin.go
@@ -1,0 +1,74 @@
+package backendconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// BackendConfigAdmin is container object to expose admin functions
+type BackendConfigAdmin struct{}
+
+// RoutingConfig reports current backend config and process config after masking secret fields
+func (bca *BackendConfigAdmin) RoutingConfig(filterProcessor bool, reply *string) error {
+	curSourceJSONLock.RLock()
+	defer curSourceJSONLock.RUnlock()
+	outputJSON := curSourceJSON
+	if filterProcessor {
+		outputJSON = filterProcessorEnabledDestinations(outputJSON)
+	}
+
+	outputObj := make([]interface{}, 0)
+
+	for _, source := range outputJSON.Sources {
+		destinations := make([]interface{}, 0)
+		for _, destination := range source.Destinations {
+			destinationConfigCopy := make(map[string]interface{})
+			for k, v := range destination.Config {
+				destinationConfigCopy[k] = v
+			}
+
+			//Mask secret config fields by replacing latter 2/3rd of the field with 'x's
+			destinationSecretKeys, ok := destination.DestinationDefinition.Config["secretKeys"]
+			if !ok {
+				destinationSecretKeys = []string{}
+			}
+			for _, k := range destinationSecretKeys.([]interface{}) {
+				secretKey := k.(string)
+				secret, ok := destinationConfigCopy[secretKey]
+				if ok {
+					switch v := secret.(type) {
+					case string:
+						s := secret.(string)
+						mask := strings.Repeat("x", (len(s)*2)/3)
+						destinationConfigCopy[secretKey] = s[0:len(s)-len(mask)] + mask
+					default:
+						return fmt.Errorf("I don't know how to handle secret config field of type %T", v)
+					}
+				}
+			}
+
+			destinations = append(destinations, map[string]interface{}{
+				"name":              destination.Name,
+				"enabled":           destination.Enabled,
+				"processor-enabled": destination.IsProcessorEnabled,
+				"id":                destination.ID,
+				"config":            destinationConfigCopy,
+				"type":              destination.DestinationDefinition.DisplayName,
+			})
+		}
+		outputObj = append(outputObj, map[string]interface{}{
+			"name":         source.Name,
+			"config":       source.Config,
+			"writekey":     source.WriteKey,
+			"id":           source.ID,
+			"enabled":      source.Enabled,
+			"destinations": destinations,
+			"type":         source.SourceDefinition.Name,
+		})
+	}
+
+	formattedOutput, err := json.MarshalIndent(outputObj, "", "  ")
+	*reply = string(formattedOutput)
+	return err
+}

--- a/config/backend-config/backend-config.go
+++ b/config/backend-config/backend-config.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/admin"
+
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 	"github.com/rudderlabs/rudder-server/services/stats"
 
@@ -62,7 +64,7 @@ type DestinationDefinitionT struct {
 	ID          string
 	Name        string
 	DisplayName string
-	Config      interface{}
+	Config      map[string]interface{}
 }
 
 type SourceDefinitionT struct {
@@ -317,4 +319,6 @@ func Setup() {
 	rruntime.Go(func() {
 		pollConfigUpdate()
 	})
+
+	admin.RegisterAdminHandler("BackendConfig", &BackendConfigAdmin{})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,13 @@ func init() {
 }
 
 //GetBool is a wrapper for viper's GetBool
-func GetBool(key string, defaultValue bool) bool {
+func GetBool(key string, defaultValue bool) (value bool) {
+	defer func() {
+		if value != defaultValue {
+			viper.Set(key, value)
+		}
+	}()
+
 	envVal := GetEnv(transformKey(key), "")
 	if envVal != "" {
 		return cast.ToBool(envVal)
@@ -68,7 +74,13 @@ func GetBool(key string, defaultValue bool) bool {
 }
 
 // GetInt is wrapper for viper's GetInt
-func GetInt(key string, defaultValue int) int {
+func GetInt(key string, defaultValue int) (value int) {
+	defer func() {
+		if value != defaultValue {
+			viper.Set(key, value)
+		}
+	}()
+
 	envVal := GetEnv(transformKey(key), "")
 	if envVal != "" {
 		return cast.ToInt(envVal)
@@ -81,7 +93,13 @@ func GetInt(key string, defaultValue int) int {
 }
 
 // GetInt64 is wrapper for viper's GetInt
-func GetInt64(key string, defaultValue int64) int64 {
+func GetInt64(key string, defaultValue int64) (value int64) {
+	defer func() {
+		if value != defaultValue {
+			viper.Set(key, value)
+		}
+	}()
+
 	envVal := GetEnv(transformKey(key), "")
 	if envVal != "" {
 		return cast.ToInt64(envVal)
@@ -94,7 +112,13 @@ func GetInt64(key string, defaultValue int64) int64 {
 }
 
 // GetFloat64 is wrapper for viper's GetFloat64
-func GetFloat64(key string, defaultValue float64) float64 {
+func GetFloat64(key string, defaultValue float64) (value float64) {
+	defer func() {
+		if value != defaultValue {
+			viper.Set(key, value)
+		}
+	}()
+
 	envVal := GetEnv(transformKey(key), "")
 	if envVal != "" {
 		return cast.ToFloat64(envVal)
@@ -107,7 +131,13 @@ func GetFloat64(key string, defaultValue float64) float64 {
 }
 
 // GetString is wrapper for viper's GetString
-func GetString(key string, defaultValue string) string {
+func GetString(key string, defaultValue string) (value string) {
+	defer func() {
+		if value != defaultValue {
+			viper.Set(key, value)
+		}
+	}()
+
 	envVal := GetEnv(transformKey(key), "")
 	if envVal != "" {
 		return envVal
@@ -120,7 +150,13 @@ func GetString(key string, defaultValue string) string {
 }
 
 // GetDuration is wrapper for viper's GetDuration
-func GetDuration(key string, defaultValue time.Duration) time.Duration {
+func GetDuration(key string, defaultValue time.Duration) (value time.Duration) {
+	defer func() {
+		if value != defaultValue {
+			viper.Set(key, value)
+		}
+	}()
+
 	envVal := GetEnv(transformKey(key), "")
 	if envVal != "" {
 		return cast.ToDuration(envVal)

--- a/gateway/admin.go
+++ b/gateway/admin.go
@@ -1,0 +1,30 @@
+package gateway
+
+import (
+	"fmt"
+	"strings"
+)
+
+type GatewayAdmin struct {
+	handle *HandleT
+}
+
+// Status function is used for debug purposes by the admin interface
+func (g *GatewayAdmin) Status() string {
+	configSubscriberLock.RLock()
+	defer configSubscriberLock.RUnlock()
+	writeKeys := make([]string, 0, len(enabledWriteKeysSourceMap))
+	for k := range enabledWriteKeysSourceMap {
+		writeKeys = append(writeKeys, k)
+	}
+	return fmt.Sprintf(
+		`Gateway:
+---------
+Ack Count  : %d
+Recv Count : %d
+Enabled write keys:
+ %s`,
+		g.handle.ackCount,
+		g.handle.recvCount,
+		strings.Join(writeKeys, "\n "))
+}

--- a/gateway/admin.go
+++ b/gateway/admin.go
@@ -1,30 +1,23 @@
 package gateway
 
-import (
-	"fmt"
-	"strings"
-)
-
 type GatewayAdmin struct {
 	handle *HandleT
 }
 
 // Status function is used for debug purposes by the admin interface
-func (g *GatewayAdmin) Status() string {
+func (g *GatewayAdmin) Status() map[string]interface{} {
 	configSubscriberLock.RLock()
 	defer configSubscriberLock.RUnlock()
 	writeKeys := make([]string, 0, len(enabledWriteKeysSourceMap))
 	for k := range enabledWriteKeysSourceMap {
 		writeKeys = append(writeKeys, k)
 	}
-	return fmt.Sprintf(
-		`Gateway:
----------
-Ack Count  : %d
-Recv Count : %d
-Enabled write keys:
- %s`,
-		g.handle.ackCount,
-		g.handle.recvCount,
-		strings.Join(writeKeys, "\n "))
+
+	return map[string]interface{}{
+		"ack-count":          g.handle.ackCount,
+		"recv-count":         g.handle.recvCount,
+		"enabled-write-keys": writeKeys,
+		"jobsdb":             g.handle.jobsDB.Status(),
+	}
+
 }

--- a/gateway/admin.go
+++ b/gateway/admin.go
@@ -5,7 +5,7 @@ type GatewayAdmin struct {
 }
 
 // Status function is used for debug purposes by the admin interface
-func (g *GatewayAdmin) Status() map[string]interface{} {
+func (g *GatewayAdmin) Status() interface{} {
 	configSubscriberLock.RLock()
 	defer configSubscriberLock.RUnlock()
 	writeKeys := make([]string, 0, len(enabledWriteKeysSourceMap))

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -924,6 +924,7 @@ func (gateway *HandleT) Setup(application app.Interface, backendConfig backendco
 	gateway.versionHandler = versionHandler
 
 	admin.RegisterAdminHandler("Gateway", &GatewayAdmin{handle: gateway})
+	admin.RegisterStatusHandler("Gateway", &GatewayAdmin{handle: gateway})
 
 	//gateway.webhookHandler should be initialised before workspace config fetch.
 	if gateway.application.Features().Webhook != nil {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -923,7 +923,6 @@ func (gateway *HandleT) Setup(application app.Interface, backendConfig backendco
 
 	gateway.versionHandler = versionHandler
 
-	admin.RegisterAdminHandler("Gateway", &GatewayAdmin{handle: gateway})
 	admin.RegisterStatusHandler("Gateway", &GatewayAdmin{handle: gateway})
 
 	//gateway.webhookHandler should be initialised before workspace config fetch.

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/app"
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 
@@ -556,7 +557,7 @@ func (gateway *HandleT) printStats() {
 		time.Sleep(10 * time.Second)
 		recvCount := atomic.LoadUint64(&gateway.recvCount)
 		ackCount := atomic.LoadUint64(&gateway.ackCount)
-		logger.Info("Gateway Recv/Ack ", recvCount, ackCount)
+		logger.Debug("Gateway Recv/Ack ", recvCount, ackCount)
 	}
 }
 
@@ -746,14 +747,6 @@ func (gateway *HandleT) healthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(healthVal))
 }
 
-func (gateway *HandleT) printStackHandler(w http.ResponseWriter, r *http.Request) {
-	byteArr := make([]byte, 2048*1024)
-	n := runtime.Stack(byteArr, true)
-	stackTrace := string(byteArr[:n])
-	instanceID := misc.GetNodeID()
-	w.Write([]byte(fmt.Sprintf(`{"instance": "%s", "stack": "%s"}`, instanceID, stackTrace)))
-}
-
 func reflectOrigin(origin string) bool {
 	return true
 }
@@ -775,19 +768,9 @@ func (gateway *HandleT) StartWebHandler() {
 	srvMux.HandleFunc("/v1/alias", gateway.stat(gateway.webAliasHandler))
 	srvMux.HandleFunc("/v1/group", gateway.stat(gateway.webGroupHandler))
 	srvMux.HandleFunc("/health", gateway.healthHandler)
-	srvMux.HandleFunc("/debugStack", gateway.printStackHandler)
 	srvMux.HandleFunc("/pixel/v1/track", gateway.stat(gateway.pixelTrackHandler))
 	srvMux.HandleFunc("/pixel/v1/page", gateway.stat(gateway.pixelPageHandler))
 	srvMux.HandleFunc("/version", gateway.versionHandler)
-	srvMux.HandleFunc("/writeKeys", func(w http.ResponseWriter, r *http.Request) {
-		configSubscriberLock.RLock()
-		defer configSubscriberLock.RUnlock()
-		writeKeys := make([]string, 0, len(enabledWriteKeysSourceMap))
-		for k := range enabledWriteKeysSourceMap {
-			writeKeys = append(writeKeys, k)
-		}
-		w.Write([]byte(fmt.Sprintf(`["%s"]`, strings.Join(writeKeys, `","`))))
-	})
 
 	if gateway.application.Features().Webhook != nil {
 		srvMux.HandleFunc("/v1/webhook", gateway.stat(gateway.webhookHandler.RequestHandler))
@@ -885,12 +868,12 @@ func (gateway *HandleT) AddToWebRequestQ(req *http.Request, writer *http.Respons
 
 // IncrementRecvCount increments the received count for gateway requests
 func (gateway *HandleT) IncrementRecvCount(count uint64) {
-	atomic.AddUint64(&gateway.ackCount, count)
+	atomic.AddUint64(&gateway.recvCount, count)
 }
 
 // IncrementAckCount increments the acknowledged count for gateway requests
 func (gateway *HandleT) IncrementAckCount(count uint64) {
-	atomic.AddUint64(&gateway.recvCount, count)
+	atomic.AddUint64(&gateway.ackCount, count)
 }
 
 // UpdateWriteKeyStats creates a new stat for every writekey and updates it with the corresponding count
@@ -939,6 +922,8 @@ func (gateway *HandleT) Setup(application app.Interface, backendConfig backendco
 	gateway.jobsDB = jobsDB
 
 	gateway.versionHandler = versionHandler
+
+	admin.RegisterAdminHandler("Gateway", &GatewayAdmin{handle: gateway})
 
 	//gateway.webhookHandler should be initialised before workspace config fetch.
 	if gateway.application.Features().Webhook != nil {

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -71,7 +71,7 @@ type JobsDB interface {
 	GetUnprocessed(customValFilters []string, count int, parameterFilters []ParameterFilterT) []*JobT
 	GetExecuting(customValFilters []string, count int, parameterFilters []ParameterFilterT) []*JobT
 
-	Status() map[string]interface{}
+	Status() interface{}
 }
 
 /*
@@ -227,7 +227,7 @@ func (jd *HandleT) assert(cond bool, errorString string) {
 	}
 }
 
-func (jd *HandleT) Status() map[string]interface{} {
+func (jd *HandleT) Status() interface{} {
 	statusObj := map[string]interface{}{
 		"dataset-list":    jd.getDSList(false),
 		"dataset-ranges":  jd.getDSRangeList(false),

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -30,6 +30,7 @@ import (
 	"sort"
 	"unicode/utf8"
 
+	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 
 	"strconv"
@@ -69,6 +70,8 @@ type JobsDB interface {
 	GetToRetry(customValFilters []string, count int, parameterFilters []ParameterFilterT) []*JobT
 	GetUnprocessed(customValFilters []string, count int, parameterFilters []ParameterFilterT) []*JobT
 	GetExecuting(customValFilters []string, count int, parameterFilters []ParameterFilterT) []*JobT
+
+	Status() map[string]interface{}
 }
 
 /*
@@ -224,6 +227,24 @@ func (jd *HandleT) assert(cond bool, errorString string) {
 	}
 }
 
+func (jd *HandleT) Status() map[string]interface{} {
+	statusObj := map[string]interface{}{
+		"dataset-list":    jd.getDSList(false),
+		"dataset-ranges":  jd.getDSRangeList(false),
+		"backups-enabled": jd.BackupSettings.BackupEnabled,
+	}
+	emptyResults := make(map[string]interface{})
+	for ds, entry := range jd.dsEmptyResultCache {
+		emptyResults[ds.JobTable] = entry
+	}
+	statusObj["empty-results-cache"] = emptyResults
+
+	if db.IsValidMigrationMode(jd.migrationState.migrationMode) {
+		statusObj["migration-state"] = jd.migrationState
+	}
+	return statusObj
+}
+
 type jobStateT struct {
 	isValid    bool
 	isTerminal bool
@@ -372,7 +393,7 @@ multiple users of JobsDB
 dsRetentionPeriod = A DS is not deleted if it has some activity
 in the retention time
 */
-func (jd *HandleT) Setup(clearAll bool, tablePrefix string, retentionPeriod time.Duration, migrationMode string) {
+func (jd *HandleT) Setup(clearAll bool, tablePrefix string, retentionPeriod time.Duration, migrationMode string, registerStatusHandler bool) {
 
 	var err error
 	jd.migrationState.migrationMode = migrationMode
@@ -381,6 +402,9 @@ func (jd *HandleT) Setup(clearAll bool, tablePrefix string, retentionPeriod time
 	jd.tablePrefix = tablePrefix
 	jd.dsRetentionPeriod = retentionPeriod
 	jd.dsEmptyResultCache = map[dataSetT]map[string]map[string]map[string]bool{}
+	if registerStatusHandler {
+		admin.RegisterStatusHandler(tablePrefix+"-jobsdb", jd)
+	}
 
 	jd.BackupSettings = jd.getBackUpSettings()
 

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rudderlabs/rudder-server/replay"
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 
+	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/app"
 	"github.com/rudderlabs/rudder-server/config"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
@@ -338,6 +339,8 @@ func main() {
 			startWarehouseService()
 		})
 	}
+
+	rruntime.Go(admin.StartServer)
 
 	misc.KeepProcessAlive()
 }

--- a/main.go
+++ b/main.go
@@ -185,10 +185,10 @@ func startRudderCore(clearDB *bool, normalMode bool, degradedMode bool, maintena
 	}
 
 	migrationMode := application.Options().MigrationMode
-	gatewayDB.Setup(*clearDB, "gw", gwDBRetention, migrationMode)
-	routerDB.Setup(*clearDB, "rt", routerDBRetention, migrationMode)
-	batchRouterDB.Setup(*clearDB, "batch_rt", routerDBRetention, migrationMode)
-	procErrorDB.Setup(*clearDB, "proc_error", routerDBRetention, migrationMode)
+	gatewayDB.Setup(*clearDB, "gw", gwDBRetention, migrationMode, false)
+	routerDB.Setup(*clearDB, "rt", routerDBRetention, migrationMode, true)
+	batchRouterDB.Setup(*clearDB, "batch_rt", routerDBRetention, migrationMode, true)
+	procErrorDB.Setup(*clearDB, "proc_error", routerDBRetention, migrationMode, false)
 
 	enableGateway := true
 

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -90,6 +90,20 @@ func (mr *MockJobsDBMockRecorder) GetUnprocessed(arg0, arg1, arg2 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnprocessed", reflect.TypeOf((*MockJobsDB)(nil).GetUnprocessed), arg0, arg1, arg2)
 }
 
+// Status mocks base method
+func (m *MockJobsDB) Status() map[string]interface{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Status")
+	ret0, _ := ret[0].(map[string]interface{})
+	return ret0
+}
+
+// Status indicates an expected call of Status
+func (mr *MockJobsDBMockRecorder) Status() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockJobsDB)(nil).Status))
+}
+
 // Store mocks base method
 func (m *MockJobsDB) Store(arg0 []*jobsdb.JobT) {
 	m.ctrl.T.Helper()

--- a/router/admin.go
+++ b/router/admin.go
@@ -1,0 +1,11 @@
+package router
+
+type RouterAdmin struct {
+	handle *HandleT
+}
+
+// Status function is used for debug purposes by the admin interface
+func (r *RouterAdmin) Status() map[string]interface{} {
+	return map[string]interface{}{}
+
+}

--- a/router/admin.go
+++ b/router/admin.go
@@ -1,11 +1,33 @@
 package router
 
+import "github.com/rudderlabs/rudder-server/admin"
+
 type RouterAdmin struct {
-	handle *HandleT
+	handles map[string]*HandleT
+}
+
+var adminInstance *RouterAdmin
+
+func init() {
+	adminInstance = &RouterAdmin{
+		handles: make(map[string]*HandleT),
+	}
+	admin.RegisterStatusHandler("routers", adminInstance)
+}
+
+func (ra *RouterAdmin) registerRouter(name string, handle *HandleT) {
+	ra.handles[name] = handle
 }
 
 // Status function is used for debug purposes by the admin interface
-func (r *RouterAdmin) Status() map[string]interface{} {
-	return map[string]interface{}{}
-
+func (ra *RouterAdmin) Status() interface{} {
+	statusList := make([]map[string]interface{}, 0)
+	for name, router := range ra.handles {
+		routerStatus := router.perfStats.Status()
+		routerStatus["name"] = name
+		routerStatus["success-count"] = router.successCount
+		routerStatus["failure-count"] = router.failCount
+		statusList = append(statusList, routerStatus)
+	}
+	return statusList
 }

--- a/router/batchrouter/admin.go
+++ b/router/batchrouter/admin.go
@@ -1,11 +1,31 @@
 package batchrouter
 
+import "github.com/rudderlabs/rudder-server/admin"
+
 type BatchRouterAdmin struct {
-	handle *HandleT
+	handles map[string]*HandleT
+}
+
+var adminInstance *BatchRouterAdmin
+
+func init() {
+	adminInstance = &BatchRouterAdmin{
+		handles: make(map[string]*HandleT),
+	}
+	admin.RegisterStatusHandler("batchrouters", adminInstance)
+}
+
+func (ba *BatchRouterAdmin) registerBatchRouter(name string, handle *HandleT) {
+	ba.handles[name] = handle
 }
 
 // Status function is used for debug purposes by the admin interface
-func (b *BatchRouterAdmin) Status() map[string]interface{} {
-	return map[string]interface{}{}
-
+func (ba *BatchRouterAdmin) Status() interface{} {
+	statusList := make([]map[string]interface{}, 0)
+	for name := range ba.handles {
+		batchrouterStatus := make(map[string]interface{})
+		batchrouterStatus["name"] = name
+		statusList = append(statusList, batchrouterStatus)
+	}
+	return statusList
 }

--- a/router/batchrouter/admin.go
+++ b/router/batchrouter/admin.go
@@ -1,0 +1,11 @@
+package batchrouter
+
+type BatchRouterAdmin struct {
+	handle *HandleT
+}
+
+// Status function is used for debug purposes by the admin interface
+func (b *BatchRouterAdmin) Status() map[string]interface{} {
+	return map[string]interface{}{}
+
+}

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 
 	"github.com/rudderlabs/rudder-server/config"
@@ -797,4 +798,5 @@ func (brt *HandleT) Setup(jobsDB *jobsdb.HandleT, destType string) {
 	rruntime.Go(func() {
 		brt.mainLoop()
 	})
+	admin.RegisterStatusHandler(fmt.Sprintf("batch-router-%v", destType), &BatchRouterAdmin{brt})
 }

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 
 	"github.com/rudderlabs/rudder-server/config"
@@ -798,5 +797,5 @@ func (brt *HandleT) Setup(jobsDB *jobsdb.HandleT, destType string) {
 	rruntime.Go(func() {
 		brt.mainLoop()
 	})
-	admin.RegisterStatusHandler(fmt.Sprintf("batch-router-%v", destType), &BatchRouterAdmin{brt})
+	adminInstance.registerBatchRouter(destType, brt)
 }

--- a/router/router.go
+++ b/router/router.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 	uuid "github.com/satori/go.uuid"
 
@@ -749,4 +750,5 @@ func (rt *HandleT) Setup(jobsDB *jobsdb.HandleT, destID string) {
 	rruntime.Go(func() {
 		rt.generatorLoop()
 	})
+	admin.RegisterStatusHandler(fmt.Sprintf("router-%v", destID), &RouterAdmin{rt})
 }

--- a/router/router.go
+++ b/router/router.go
@@ -12,7 +12,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 	uuid "github.com/satori/go.uuid"
 
@@ -454,7 +453,6 @@ func (rt *HandleT) statusInsertLoop() {
 		}
 
 		if len(responseList) >= updateStatusBatchSize || time.Since(lastUpdate) > maxStatusUpdateWait {
-			rt.perfStats.Print()
 			statusStat.Start()
 			var statusList []*jobsdb.JobStatusT
 			for _, resp := range responseList {
@@ -750,5 +748,5 @@ func (rt *HandleT) Setup(jobsDB *jobsdb.HandleT, destID string) {
 	rruntime.Go(func() {
 		rt.generatorLoop()
 	})
-	admin.RegisterStatusHandler(fmt.Sprintf("router-%v", destID), &RouterAdmin{rt})
+	adminInstance.registerRouter(destID, rt)
 }

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -355,6 +355,13 @@ func (stats *PerfStats) Print() {
 	}
 }
 
+func (stats *PerfStats) Status() map[string]interface{} {
+	return map[string]interface{}{
+		"total-events": stats.eventCount,
+		"overall-rate": float64(stats.eventCount) * float64(time.Second) / float64(stats.elapsedTime),
+	}
+}
+
 //Copy copies the exported fields from src to dest
 //Used for copying the default transport
 func Copy(dst, src interface{}) {

--- a/warehouse/admin.go
+++ b/warehouse/admin.go
@@ -1,0 +1,13 @@
+package warehouse
+
+type WarehouseAdmin struct{}
+
+func (wh *WarehouseAdmin) TriggerUpload(off bool, reply *string) error {
+	startUploadAlways = !off
+	if off {
+		*reply = "Turned off explicit warehouse upload triggers.\nWarehouse uploads will continue to be done as per schedule in control plane."
+	} else {
+		*reply = "Successfully set uploads to start always without delay.\nRun same command with -o flag to turn off explicit triggers."
+	}
+	return nil
+}

--- a/warehouse/scheduling.go
+++ b/warehouse/scheduling.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 	"github.com/thoas/go-funk"
@@ -13,10 +14,12 @@ import (
 
 var (
 	scheduledTimesCache map[string][]int
+	startUploadAlways   bool
 )
 
 func init() {
 	scheduledTimesCache = map[string][]int{}
+	admin.RegisterAdminHandler("Warehouse", &WarehouseAdmin{})
 }
 
 // ScheduledTimes returns all possible start times as per schedule
@@ -102,6 +105,10 @@ func (wh *HandleT) getLastUploadStartTime(warehouse warehouseutils.WarehouseT) (
 
 // canStartUpload indicates if a upload can be started now for the warehouse based on its configured schedule
 func (wh *HandleT) canStartUpload(warehouse warehouseutils.WarehouseT) bool {
+	// can be set from rudder-cli to force uploads always
+	if startUploadAlways {
+		return true
+	}
 	if warehouseSyncFreqIgnore {
 		return !uploadFrequencyExceeded(warehouse, "")
 	}


### PR DESCRIPTION
* Removed debugStack and writeKeys endpoints in gateway and moved to this admin interface
* Added support for getting pprof heap profile for a running server
* Refer https://github.com/rudderlabs/rudder-cli/pull/2/files for rudder-cli changes

![image](https://user-images.githubusercontent.com/52436067/86217844-a6262a00-bb9d-11ea-8727-3bca47734da4.png)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-server/389)
<!-- Reviewable:end -->
