### PR TITLE
Discard master/slave language

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,9 +21,9 @@ var (
 
 const (
 	EmbeddedMode    = "embedded"
-	MasterMode      = "master"
-	MasterSlaveMode = "master_and_slave"
-	SlaveMode       = "slave"
+	MainMode      = "main"
+	MainSubordinateMode = "main_and_subordinate"
+	SubordinateMode       = "subordinate"
 	OffMode         = "off"
 )
 

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -190,12 +190,12 @@ var dbErrorMap = map[string]string{
 // pathPrefix = by default is the jobsdb table prefix, is the path appended before instanceID in s3 folder structure
 func (jd *HandleT) getBackUpSettings() *BackupSettingsT {
 	// for replay server, we are changing the gateway backup to false in main.go
-	masterBackupEnabled := config.GetBool("JobsDB.backup.enabled", false)
+	mainBackupEnabled := config.GetBool("JobsDB.backup.enabled", false)
 	instanceBackupEnabled := config.GetBool(fmt.Sprintf("JobsDB.backup.%v.enabled", jd.tablePrefix), false)
 	instanceBackupFailedAndAborted := config.GetBool(fmt.Sprintf("JobsDB.backup.%v.failedOnly", jd.tablePrefix), false)
 	pathPrefix := config.GetString(fmt.Sprintf("JobsDB.backup.%v.pathPrefix", jd.tablePrefix), jd.tablePrefix)
 
-	backupSettings := BackupSettingsT{BackupEnabled: masterBackupEnabled && instanceBackupEnabled,
+	backupSettings := BackupSettingsT{BackupEnabled: mainBackupEnabled && instanceBackupEnabled,
 		FailedOnly: instanceBackupFailedAndAborted, PathPrefix: strings.TrimSpace(pathPrefix)}
 
 	return &backupSettings

--- a/vendor/github.com/aws/aws-sdk-go/service/firehose/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/firehose/api.go
@@ -2117,7 +2117,7 @@ func (s *DeliveryStreamDescription) SetVersionId(v string) *DeliveryStreamDescri
 }
 
 // Contains information about the server-side encryption (SSE) status for the
-// delivery stream, the type customer master key (CMK) in use, if any, and the
+// delivery stream, the type customer main key (CMK) in use, if any, and the
 // ARN of the CMK. You can get DeliveryStreamEncryptionConfiguration by invoking
 // the DescribeDeliveryStream operation.
 type DeliveryStreamEncryptionConfiguration struct {
@@ -2133,9 +2133,9 @@ type DeliveryStreamEncryptionConfiguration struct {
 	// doesn't contain a value for KeyARN.
 	KeyARN *string `min:"1" type:"string"`
 
-	// Indicates the type of customer master key (CMK) that is used for encryption.
+	// Indicates the type of customer main key (CMK) that is used for encryption.
 	// The default setting is AWS_OWNED_CMK. For more information about CMKs, see
-	// Customer Master Keys (CMKs) (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys).
+	// Customer Main Keys (CMKs) (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys).
 	KeyType *string `type:"string" enum:"KeyType"`
 
 	// This is the server-side encryption (SSE) status for the delivery stream.
@@ -2189,9 +2189,9 @@ type DeliveryStreamEncryptionConfigurationInput struct {
 	// Firehose uses a service-account CMK.
 	KeyARN *string `min:"1" type:"string"`
 
-	// Indicates the type of customer master key (CMK) to use for encryption. The
+	// Indicates the type of customer main key (CMK) to use for encryption. The
 	// default setting is AWS_OWNED_CMK. For more information about CMKs, see Customer
-	// Master Keys (CMKs) (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys).
+	// Main Keys (CMKs) (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys).
 	// When you invoke CreateDeliveryStream or StartDeliveryStreamEncryption with
 	// KeyType set to CUSTOMER_MANAGED_CMK, Kinesis Data Firehose invokes the Amazon
 	// KMS operation CreateGrant (https://docs.aws.amazon.com/kms/latest/APIReference/API_CreateGrant.html)

--- a/vendor/github.com/aws/aws-sdk-go/service/kinesis/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kinesis/api.go
@@ -1297,13 +1297,13 @@ func (c *Kinesis) GetRecordsRequest(input *GetRecordsInput) (req *request.Reques
 //   The provided iterator exceeds the maximum age allowed.
 //
 //   * KMSDisabledException
-//   The request was rejected because the specified customer master key (CMK)
+//   The request was rejected because the specified customer main key (CMK)
 //   isn't enabled.
 //
 //   * KMSInvalidStateException
 //   The request was rejected because the state of the specified resource isn't
 //   valid for this request. For more information, see How Key State Affects Use
-//   of a Customer Master Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   of a Customer Main Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 //   in the AWS Key Management Service Developer Guide.
 //
 //   * KMSAccessDeniedException
@@ -2314,13 +2314,13 @@ func (c *Kinesis) PutRecordRequest(input *PutRecordInput) (req *request.Request,
 //   in the AWS General Reference.
 //
 //   * KMSDisabledException
-//   The request was rejected because the specified customer master key (CMK)
+//   The request was rejected because the specified customer main key (CMK)
 //   isn't enabled.
 //
 //   * KMSInvalidStateException
 //   The request was rejected because the state of the specified resource isn't
 //   valid for this request. For more information, see How Key State Affects Use
-//   of a Customer Master Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   of a Customer Main Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 //   in the AWS Key Management Service Developer Guide.
 //
 //   * KMSAccessDeniedException
@@ -2490,13 +2490,13 @@ func (c *Kinesis) PutRecordsRequest(input *PutRecordsInput) (req *request.Reques
 //   in the AWS General Reference.
 //
 //   * KMSDisabledException
-//   The request was rejected because the specified customer master key (CMK)
+//   The request was rejected because the specified customer main key (CMK)
 //   isn't enabled.
 //
 //   * KMSInvalidStateException
 //   The request was rejected because the state of the specified resource isn't
 //   valid for this request. For more information, see How Key State Affects Use
-//   of a Customer Master Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   of a Customer Main Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 //   in the AWS Key Management Service Developer Guide.
 //
 //   * KMSAccessDeniedException
@@ -2963,13 +2963,13 @@ func (c *Kinesis) StartStreamEncryptionRequest(input *StartStreamEncryptionInput
 //   correctly.
 //
 //   * KMSDisabledException
-//   The request was rejected because the specified customer master key (CMK)
+//   The request was rejected because the specified customer main key (CMK)
 //   isn't enabled.
 //
 //   * KMSInvalidStateException
 //   The request was rejected because the state of the specified resource isn't
 //   valid for this request. For more information, see How Key State Affects Use
-//   of a Customer Master Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   of a Customer Main Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 //   in the AWS Key Management Service Developer Guide.
 //
 //   * KMSAccessDeniedException
@@ -5299,7 +5299,7 @@ func (s KMSAccessDeniedException) RequestID() string {
 	return s.respMetadata.RequestID
 }
 
-// The request was rejected because the specified customer master key (CMK)
+// The request was rejected because the specified customer main key (CMK)
 // isn't enabled.
 type KMSDisabledException struct {
 	_            struct{} `type:"structure"`
@@ -5386,7 +5386,7 @@ func (s KMSDisabledException) RequestID() string {
 
 // The request was rejected because the state of the specified resource isn't
 // valid for this request. For more information, see How Key State Affects Use
-// of a Customer Master Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// of a Customer Main Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 type KMSInvalidStateException struct {
 	_            struct{} `type:"structure"`
@@ -7481,7 +7481,7 @@ type StartStreamEncryptionInput struct {
 	// The GUID for the customer-managed AWS KMS key to use for encryption. This
 	// value can be a globally unique identifier, a fully specified Amazon Resource
 	// Name (ARN) to either an alias or a key, or an alias name prefixed by "alias/".You
-	// can also use a master key owned by Kinesis Data Streams by specifying the
+	// can also use a main key owned by Kinesis Data Streams by specifying the
 	// alias aws/kinesis.
 	//
 	//    * Key ARN example: arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
@@ -7492,7 +7492,7 @@ type StartStreamEncryptionInput struct {
 	//
 	//    * Alias name example: alias/MyAliasName
 	//
-	//    * Master key owned by Kinesis Data Streams: alias/aws/kinesis
+	//    * Main key owned by Kinesis Data Streams: alias/aws/kinesis
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -7633,7 +7633,7 @@ type StopStreamEncryptionInput struct {
 	// The GUID for the customer-managed AWS KMS key to use for encryption. This
 	// value can be a globally unique identifier, a fully specified Amazon Resource
 	// Name (ARN) to either an alias or a key, or an alias name prefixed by "alias/".You
-	// can also use a master key owned by Kinesis Data Streams by specifying the
+	// can also use a main key owned by Kinesis Data Streams by specifying the
 	// alias aws/kinesis.
 	//
 	//    * Key ARN example: arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
@@ -7644,7 +7644,7 @@ type StopStreamEncryptionInput struct {
 	//
 	//    * Alias name example: alias/MyAliasName
 	//
-	//    * Master key owned by Kinesis Data Streams: alias/aws/kinesis
+	//    * Main key owned by Kinesis Data Streams: alias/aws/kinesis
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -7748,7 +7748,7 @@ type StreamDescription struct {
 	// The GUID for the customer-managed AWS KMS key to use for encryption. This
 	// value can be a globally unique identifier, a fully specified ARN to either
 	// an alias or a key, or an alias name prefixed by "alias/".You can also use
-	// a master key owned by Kinesis Data Streams by specifying the alias aws/kinesis.
+	// a main key owned by Kinesis Data Streams by specifying the alias aws/kinesis.
 	//
 	//    * Key ARN example: arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
 	//
@@ -7758,7 +7758,7 @@ type StreamDescription struct {
 	//
 	//    * Alias name example: alias/MyAliasName
 	//
-	//    * Master key owned by Kinesis Data Streams: alias/aws/kinesis
+	//    * Main key owned by Kinesis Data Streams: alias/aws/kinesis
 	KeyId *string `min:"1" type:"string"`
 
 	// The current retention period, in hours.
@@ -7899,7 +7899,7 @@ type StreamDescriptionSummary struct {
 	// The GUID for the customer-managed AWS KMS key to use for encryption. This
 	// value can be a globally unique identifier, a fully specified ARN to either
 	// an alias or a key, or an alias name prefixed by "alias/".You can also use
-	// a master key owned by Kinesis Data Streams by specifying the alias aws/kinesis.
+	// a main key owned by Kinesis Data Streams by specifying the alias aws/kinesis.
 	//
 	//    * Key ARN example: arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
 	//
@@ -7909,7 +7909,7 @@ type StreamDescriptionSummary struct {
 	//
 	//    * Alias name example: alias/MyAliasName
 	//
-	//    * Master key owned by Kinesis Data Streams: alias/aws/kinesis
+	//    * Main key owned by Kinesis Data Streams: alias/aws/kinesis
 	KeyId *string `min:"1" type:"string"`
 
 	// The number of open shards in the stream.

--- a/vendor/github.com/aws/aws-sdk-go/service/kinesis/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kinesis/errors.go
@@ -41,7 +41,7 @@ const (
 	// ErrCodeKMSDisabledException for service response error code
 	// "KMSDisabledException".
 	//
-	// The request was rejected because the specified customer master key (CMK)
+	// The request was rejected because the specified customer main key (CMK)
 	// isn't enabled.
 	ErrCodeKMSDisabledException = "KMSDisabledException"
 
@@ -50,7 +50,7 @@ const (
 	//
 	// The request was rejected because the state of the specified resource isn't
 	// valid for this request. For more information, see How Key State Affects Use
-	// of a Customer Master Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+	// of a Customer Main Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 	// in the AWS Key Management Service Developer Guide.
 	ErrCodeKMSInvalidStateException = "KMSInvalidStateException"
 

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
@@ -744,7 +744,7 @@ func (c *S3) CreateMultipartUploadRequest(input *CreateMultipartUploadInput) (re
 // You can optionally request server-side encryption. For server-side encryption,
 // Amazon S3 encrypts your data as it writes it to disks in its data centers
 // and decrypts it when you access it. You can provide your own encryption key,
-// or use AWS Key Management Service (AWS KMS) customer master keys (CMKs) or
+// or use AWS Key Management Service (AWS KMS) customer main keys (CMKs) or
 // Amazon S3-managed encryption keys. If you choose to provide your own encryption
 // key, the request headers you provide in UploadPart) and UploadPartCopy) requests
 // must match the headers you used in the request to initiate the upload by
@@ -789,7 +789,7 @@ func (c *S3) CreateMultipartUploadRequest(input *CreateMultipartUploadInput) (re
 // it when you access it. The option you use depends on whether you want to
 // use AWS managed encryption keys or provide your own encryption key.
 //
-//    * Use encryption keys managed by Amazon S3 or customer master keys (CMKs)
+//    * Use encryption keys managed by Amazon S3 or customer main keys (CMKs)
 //    stored in AWS Key Management Service (AWS KMS) – If you want AWS to
 //    manage the keys used to encrypt data, specify the following headers in
 //    the request. x-amz-server-side​-encryption x-amz-server-side-encryption-aws-kms-key-id
@@ -6824,7 +6824,7 @@ func (c *S3) PutBucketEncryptionRequest(input *PutBucketEncryptionInput) (req *r
 //
 // This implementation of the PUT operation sets default encryption for a bucket
 // using server-side encryption with Amazon S3-managed keys SSE-S3 or AWS KMS
-// customer master keys (CMKs) (SSE-KMS).
+// customer main keys (CMKs) (SSE-KMS).
 //
 // This operation requires AWS Signature Version 4. For more information, see
 // Authenticating Requests (AWS Signature Version 4) (sig-v4-authenticating-requests.html).
@@ -8453,7 +8453,7 @@ func (c *S3) PutObjectRequest(input *PutObjectInput) (req *request.Request, outp
 // it when you access it. The option you use depends on whether you want to
 // use AWS managed encryption keys or provide your own encryption key.
 //
-//    * Use encryption keys managed by Amazon S3 or customer master keys (CMKs)
+//    * Use encryption keys managed by Amazon S3 or customer main keys (CMKs)
 //    stored in AWS Key Management Service (AWS KMS) – If you want AWS to
 //    manage the keys used to encrypt data, specify the following headers in
 //    the request. x-amz-server-side​-encryption x-amz-server-side-encryption-aws-kms-key-id
@@ -8521,7 +8521,7 @@ func (c *S3) PutObjectRequest(input *PutObjectInput) (req *request.Request, outp
 // it when you access it. The option you use depends on whether you want to
 // use AWS-managed encryption keys or provide your own encryption key.
 //
-//    * Use encryption keys managed by Amazon S3 or customer master keys (CMKs)
+//    * Use encryption keys managed by Amazon S3 or customer main keys (CMKs)
 //    stored in AWS Key Management Service (AWS KMS) – If you want AWS to
 //    manage the keys used to encrypt data, specify the following headers in
 //    the request. x-amz-server-side​-encryption x-amz-server-side-encryption-aws-kms-key-id
@@ -9555,7 +9555,7 @@ func (c *S3) SelectObjectContentRequest(input *SelectObjectContentInput) (req *r
 //    Encryption Keys) (https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)
 //    in the Amazon Simple Storage Service Developer Guide. For objects that
 //    are encrypted with Amazon S3 managed encryption keys (SSE-S3) and customer
-//    master keys (CMKs) stored in AWS Key Management Service (SSE-KMS), server-side
+//    main keys (CMKs) stored in AWS Key Management Service (SSE-KMS), server-side
 //    encryption is handled transparently, so you don't need to specify anything.
 //    For more information about server-side encryption, including SSE-S3 and
 //    SSE-KMS, see Protecting Data Using Server-Side Encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html)
@@ -11362,12 +11362,12 @@ type CompleteMultipartUploadOutput struct {
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
 
 	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
+	// symmetric customer managed customer main key (CMK) that was used for the
 	// object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
 	// If you specified server-side encryption either with an Amazon S3-managed
-	// encryption key or an AWS KMS customer master key (CMK) in your initiate multipart
+	// encryption key or an AWS KMS customer main key (CMK) in your initiate multipart
 	// upload request, the response includes this header. It confirms the encryption
 	// algorithm that Amazon S3 used to encrypt the object.
 	ServerSideEncryption *string `location:"header" locationName:"x-amz-server-side-encryption" type:"string" enum:"ServerSideEncryption"`
@@ -12062,7 +12062,7 @@ type CopyObjectOutput struct {
 	SSEKMSEncryptionContext *string `location:"header" locationName:"x-amz-server-side-encryption-context" type:"string" sensitive:"true"`
 
 	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
+	// symmetric customer managed customer main key (CMK) that was used for the
 	// object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
@@ -12769,7 +12769,7 @@ type CreateMultipartUploadOutput struct {
 	SSEKMSEncryptionContext *string `location:"header" locationName:"x-amz-server-side-encryption-context" type:"string" sensitive:"true"`
 
 	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
+	// symmetric customer managed customer main key (CMK) that was used for the
 	// object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
@@ -14741,7 +14741,7 @@ type EncryptionConfiguration struct {
 	_ struct{} `type:"structure"`
 
 	// Specifies the ID (Key ARN or Alias ARN) of the customer managed customer
-	// master key (CMK) stored in AWS Key Management Service (KMS) for the destination
+	// main key (CMK) stored in AWS Key Management Service (KMS) for the destination
 	// bucket. Amazon S3 uses this key to encrypt replica objects. Amazon S3 only
 	// supports symmetric customer managed CMKs. For more information, see Using
 	// Symmetric and Asymmetric Keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
@@ -17747,7 +17747,7 @@ type GetObjectOutput struct {
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
 	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
+	// symmetric customer managed customer main key (CMK) that was used for the
 	// object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
@@ -19018,12 +19018,12 @@ type HeadObjectOutput struct {
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
 	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
+	// symmetric customer managed customer main key (CMK) that was used for the
 	// object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
 	// If the object is stored using server-side encryption either with an AWS KMS
-	// customer master key (CMK) or an Amazon S3-managed encryption key, the response
+	// customer main key (CMK) or an Amazon S3-managed encryption key, the response
 	// includes this header with the value of the server-side encryption algorithm
 	// used when storing this object in Amazon S3 (for example, AES256, aws:kms).
 	ServerSideEncryption *string `location:"header" locationName:"x-amz-server-side-encryption" type:"string" enum:"ServerSideEncryption"`
@@ -24068,7 +24068,7 @@ type PutBucketEncryptionInput struct {
 	_ struct{} `locationName:"PutBucketEncryptionRequest" type:"structure" payload:"ServerSideEncryptionConfiguration"`
 
 	// Specifies default encryption for a bucket using server-side encryption with
-	// Amazon S3-managed keys (SSE-S3) or customer master keys stored in AWS KMS
+	// Amazon S3-managed keys (SSE-S3) or customer main keys stored in AWS KMS
 	// (SSE-KMS). For information about the Amazon S3 default encryption feature,
 	// see Amazon S3 Default Bucket Encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html)
 	// in the Amazon Simple Storage Service Developer Guide.
@@ -25753,7 +25753,7 @@ type PutObjectInput struct {
 
 	// If x-amz-server-side-encryption is present and has the value of aws:kms,
 	// this header specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetrical customer managed customer master key (CMK) that was used for
+	// symmetrical customer managed customer main key (CMK) that was used for
 	// the object.
 	//
 	// If the value of x-amz-server-side-encryption is aws:kms, this header specifies
@@ -26329,11 +26329,11 @@ type PutObjectOutput struct {
 
 	// If x-amz-server-side-encryption is present and has the value of aws:kms,
 	// this header specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
+	// symmetric customer managed customer main key (CMK) that was used for the
 	// object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
-	// If you specified server-side encryption either with an AWS KMS customer master
+	// If you specified server-side encryption either with an AWS KMS customer main
 	// key (CMK) or Amazon S3-managed encryption key in your PUT request, the response
 	// includes this header. It confirms the encryption algorithm that Amazon S3
 	// used to encrypt the object.
@@ -27222,7 +27222,7 @@ type ReplicationRule struct {
 	// objects that you want to replicate. You can choose to enable or disable the
 	// replication of these objects. Currently, Amazon S3 supports only the filter
 	// that you can specify for objects created with server-side encryption using
-	// a customer master key (CMK) stored in AWS Key Management Service (SSE-KMS).
+	// a customer main key (CMK) stored in AWS Key Management Service (SSE-KMS).
 	SourceSelectionCriteria *SourceSelectionCriteria `type:"structure"`
 
 	// Specifies whether the rule is enabled.
@@ -28061,7 +28061,7 @@ type SSEKMS struct {
 	_ struct{} `locationName:"SSE-KMS" type:"structure"`
 
 	// Specifies the ID of the AWS Key Management Service (AWS KMS) symmetric customer
-	// managed customer master key (CMK) to use for encrypting inventory reports.
+	// managed customer main key (CMK) to use for encrypting inventory reports.
 	//
 	// KeyId is a required field
 	KeyId *string `type:"string" required:"true" sensitive:"true"`
@@ -28623,9 +28623,9 @@ func (s *SelectParameters) SetOutputSerialization(v *OutputSerialization) *Selec
 type ServerSideEncryptionByDefault struct {
 	_ struct{} `type:"structure"`
 
-	// KMS master key ID to use for the default encryption. This parameter is allowed
+	// KMS main key ID to use for the default encryption. This parameter is allowed
 	// if and only if SSEAlgorithm is set to aws:kms.
-	KMSMasterKeyID *string `type:"string" sensitive:"true"`
+	KMSMainKeyID *string `type:"string" sensitive:"true"`
 
 	// Server-side encryption algorithm to use for the default encryption.
 	//
@@ -28656,9 +28656,9 @@ func (s *ServerSideEncryptionByDefault) Validate() error {
 	return nil
 }
 
-// SetKMSMasterKeyID sets the KMSMasterKeyID field's value.
-func (s *ServerSideEncryptionByDefault) SetKMSMasterKeyID(v string) *ServerSideEncryptionByDefault {
-	s.KMSMasterKeyID = &v
+// SetKMSMainKeyID sets the KMSMainKeyID field's value.
+func (s *ServerSideEncryptionByDefault) SetKMSMainKeyID(v string) *ServerSideEncryptionByDefault {
+	s.KMSMainKeyID = &v
 	return s
 }
 
@@ -28763,7 +28763,7 @@ func (s *ServerSideEncryptionRule) SetApplyServerSideEncryptionByDefault(v *Serv
 // objects that you want to replicate. You can choose to enable or disable the
 // replication of these objects. Currently, Amazon S3 supports only the filter
 // that you can specify for objects created with server-side encryption using
-// a customer master key (CMK) stored in AWS Key Management Service (SSE-KMS).
+// a customer main key (CMK) stored in AWS Key Management Service (SSE-KMS).
 type SourceSelectionCriteria struct {
 	_ struct{} `type:"structure"`
 
@@ -28810,7 +28810,7 @@ type SseKmsEncryptedObjects struct {
 	_ struct{} `type:"structure"`
 
 	// Specifies whether Amazon S3 replicates objects created with server-side encryption
-	// using a customer master key (CMK) stored in AWS Key Management Service.
+	// using a customer main key (CMK) stored in AWS Key Management Service.
 	//
 	// Status is a required field
 	Status *string `type:"string" required:"true" enum:"SseKmsEncryptedObjectsStatus"`
@@ -29665,7 +29665,7 @@ type UploadPartCopyOutput struct {
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
 	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
+	// symmetric customer managed customer main key (CMK) that was used for the
 	// object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
@@ -29940,7 +29940,7 @@ type UploadPartOutput struct {
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
 	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) was used for the object.
+	// symmetric customer managed customer main key (CMK) was used for the object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
 	// The server-side encryption algorithm used when storing this object in Amazon

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/upload_input.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/upload_input.go
@@ -127,7 +127,7 @@ type UploadInput struct {
 
 	// If x-amz-server-side-encryption is present and has the value of aws:kms,
 	// this header specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetrical customer managed customer master key (CMK) that was used for
+	// symmetrical customer managed customer main key (CMK) that was used for
 	// the object.
 	//
 	// If the value of x-amz-server-side-encryption is aws:kms, this header specifies

--- a/vendor/github.com/eapache/go-xerial-snappy/snappy.go
+++ b/vendor/github.com/eapache/go-xerial-snappy/snappy.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	master "github.com/golang/snappy"
+	main "github.com/golang/snappy"
 )
 
 const (
@@ -33,7 +33,7 @@ func min(x, y int) int {
 
 // Encode encodes data as snappy with no framing header.
 func Encode(src []byte) []byte {
-	return master.Encode(nil, src)
+	return main.Encode(nil, src)
 }
 
 // EncodeStream *appends* to the specified 'dst' the compressed
@@ -56,7 +56,7 @@ func EncodeStream(dst, src []byte) []byte {
 
 	for pos < max {
 		newPos := min(pos + blockSize, max)
-		chunk = master.Encode(chunk[:cap(chunk)], src[pos:newPos])
+		chunk = main.Encode(chunk[:cap(chunk)], src[pos:newPos])
 
 		// First encode the compressed size (big-endian)
 		// Put* panics if the buffer is too small, so pad 4 bytes first
@@ -89,7 +89,7 @@ func DecodeInto(dst, src []byte) ([]byte, error) {
 	}
 
 	if !bytes.Equal(src[:8], xerialHeader) {
-		return master.Decode(dst[:cap(dst)], src)
+		return main.Decode(dst[:cap(dst)], src)
 	}
 
 	if max < sizeOffset+sizeBytes {
@@ -119,7 +119,7 @@ func DecodeInto(dst, src []byte) ([]byte, error) {
 			return nil, ErrMalformed
 		}
 
-		chunk, err = master.Decode(chunk[:cap(chunk)], src[pos:nextPos])
+		chunk, err = main.Decode(chunk[:cap(chunk)], src[pos:nextPos])
 
 		if err != nil {
 			return nil, err

--- a/vendor/github.com/go-redis/redis/cluster_commands.go
+++ b/vendor/github.com/go-redis/redis/cluster_commands.go
@@ -5,8 +5,8 @@ import "sync/atomic"
 func (c *ClusterClient) DBSize() *IntCmd {
 	cmd := NewIntCmd("dbsize")
 	var size int64
-	err := c.ForEachMaster(func(master *Client) error {
-		n, err := master.DBSize().Result()
+	err := c.ForEachMain(func(main *Client) error {
+		n, err := main.DBSize().Result()
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/go-redis/redis/commands.go
+++ b/vendor/github.com/go-redis/redis/commands.go
@@ -248,7 +248,7 @@ type Cmdable interface {
 	Shutdown() *StatusCmd
 	ShutdownSave() *StatusCmd
 	ShutdownNoSave() *StatusCmd
-	SlaveOf(host, port string) *StatusCmd
+	SubordinateOf(host, port string) *StatusCmd
 	Time() *TimeCmd
 	Eval(script string, keys []string, args ...interface{}) *Cmd
 	EvalSha(sha1 string, keys []string, args ...interface{}) *Cmd
@@ -276,7 +276,7 @@ type Cmdable interface {
 	ClusterDelSlots(slots ...int) *StatusCmd
 	ClusterDelSlotsRange(min, max int) *StatusCmd
 	ClusterSaveConfig() *StatusCmd
-	ClusterSlaves(nodeID string) *StringSliceCmd
+	ClusterSubordinates(nodeID string) *StringSliceCmd
 	ClusterFailover() *StatusCmd
 	ClusterAddSlots(slots ...int) *StatusCmd
 	ClusterAddSlotsRange(min, max int) *StatusCmd
@@ -344,8 +344,8 @@ func (c *cmdable) Ping() *StatusCmd {
 	return cmd
 }
 
-func (c *cmdable) Wait(numSlaves int, timeout time.Duration) *IntCmd {
-	cmd := NewIntCmd("wait", numSlaves, int(timeout/time.Millisecond))
+func (c *cmdable) Wait(numSubordinates int, timeout time.Duration) *IntCmd {
+	cmd := NewIntCmd("wait", numSubordinates, int(timeout/time.Millisecond))
 	c.process(cmd)
 	return cmd
 }
@@ -2223,8 +2223,8 @@ func (c *cmdable) ShutdownNoSave() *StatusCmd {
 	return c.shutdown("nosave")
 }
 
-func (c *cmdable) SlaveOf(host, port string) *StatusCmd {
-	cmd := NewStatusCmd("slaveof", host, port)
+func (c *cmdable) SubordinateOf(host, port string) *StatusCmd {
+	cmd := NewStatusCmd("subordinateof", host, port)
 	c.process(cmd)
 	return cmd
 }
@@ -2449,8 +2449,8 @@ func (c *cmdable) ClusterSaveConfig() *StatusCmd {
 	return cmd
 }
 
-func (c *cmdable) ClusterSlaves(nodeID string) *StringSliceCmd {
-	cmd := NewStringSliceCmd("cluster", "slaves", nodeID)
+func (c *cmdable) ClusterSubordinates(nodeID string) *StringSliceCmd {
+	cmd := NewStringSliceCmd("cluster", "subordinates", nodeID)
 	c.process(cmd)
 	return cmd
 }

--- a/vendor/github.com/go-redis/redis/options.go
+++ b/vendor/github.com/go-redis/redis/options.go
@@ -90,7 +90,7 @@ type Options struct {
 	// if IdleTimeout is set.
 	IdleCheckFrequency time.Duration
 
-	// Enables read only queries on slave nodes.
+	// Enables read only queries on subordinate nodes.
 	readOnly bool
 
 	// TLS Config to use. When set TLS will be negotiated.

--- a/vendor/github.com/go-redis/redis/universal.go
+++ b/vendor/github.com/go-redis/redis/universal.go
@@ -41,9 +41,9 @@ type UniversalOptions struct {
 	RouteByLatency bool
 	RouteRandomly  bool
 
-	// The sentinel master name.
+	// The sentinel main name.
 	// Only failover clients.
-	MasterName string
+	MainName string
 }
 
 func (o *UniversalOptions) cluster() *ClusterOptions {
@@ -87,7 +87,7 @@ func (o *UniversalOptions) failover() *FailoverOptions {
 
 	return &FailoverOptions{
 		SentinelAddrs: o.Addrs,
-		MasterName:    o.MasterName,
+		MainName:    o.MainName,
 		OnConnect:     o.OnConnect,
 
 		DB:       o.DB,
@@ -167,11 +167,11 @@ var _ UniversalClient = (*ClusterClient)(nil)
 // NewUniversalClient returns a new multi client. The type of client returned depends
 // on the following three conditions:
 //
-// 1. if a MasterName is passed a sentinel-backed FailoverClient will be returned
+// 1. if a MainName is passed a sentinel-backed FailoverClient will be returned
 // 2. if the number of Addrs is two or more, a ClusterClient will be returned
 // 3. otherwise, a single-node redis Client will be returned.
 func NewUniversalClient(opts *UniversalOptions) UniversalClient {
-	if opts.MasterName != "" {
+	if opts.MainName != "" {
 		return NewFailoverClient(opts.failover())
 	} else if len(opts.Addrs) > 1 {
 		return NewClusterClient(opts.cluster())

--- a/vendor/github.com/gogo/protobuf/proto/discard.go
+++ b/vendor/github.com/gogo/protobuf/proto/discard.go
@@ -60,7 +60,7 @@ func DiscardUnknown(m Message) {
 		return
 	}
 	// TODO: Dynamically populate a InternalMessageInfo for legacy messages,
-	// but the master branch has no implementation for InternalMessageInfo,
+	// but the main branch has no implementation for InternalMessageInfo,
 	// so it would be more work to replicate that approach.
 	discardLegacy(m)
 }

--- a/vendor/github.com/golang/protobuf/proto/discard.go
+++ b/vendor/github.com/golang/protobuf/proto/discard.go
@@ -60,7 +60,7 @@ func DiscardUnknown(m Message) {
 		return
 	}
 	// TODO: Dynamically populate a InternalMessageInfo for legacy messages,
-	// but the master branch has no implementation for InternalMessageInfo,
+	// but the main branch has no implementation for InternalMessageInfo,
 	// so it would be more work to replicate that approach.
 	discardLegacy(m)
 }

--- a/vendor/github.com/snowflakedb/gosnowflake/auth.go
+++ b/vendor/github.com/snowflakedb/gosnowflake/auth.go
@@ -164,8 +164,8 @@ type authResponseSessionInfo struct {
 type authResponseMain struct {
 	Token               string                  `json:"token,omitempty"`
 	Validity            time.Duration           `json:"validityInSeconds,omitempty"`
-	MasterToken         string                  `json:"masterToken,omitempty"`
-	MasterValidity      time.Duration           `json:"masterValidityInSeconds"`
+	MainToken         string                  `json:"mainToken,omitempty"`
+	MainValidity      time.Duration           `json:"mainValidityInSeconds"`
 	DisplayUserName     string                  `json:"displayUserName"`
 	ServerVersion       string                  `json:"serverVersion"`
 	FirstLogin          bool                    `json:"firstLogin"`
@@ -356,7 +356,7 @@ func authenticate(
 		glog.V(1).Infoln("Authentication FAILED")
 		glog.Flush()
 		sc.rest.Token = ""
-		sc.rest.MasterToken = ""
+		sc.rest.MainToken = ""
 		sc.rest.SessionID = -1
 		code, err := strconv.Atoi(respd.Code)
 		if err != nil {
@@ -371,7 +371,7 @@ func authenticate(
 	}
 	glog.V(2).Info("Authentication SUCCESS")
 	sc.rest.Token = respd.Data.Token
-	sc.rest.MasterToken = respd.Data.MasterToken
+	sc.rest.MainToken = respd.Data.MainToken
 	sc.rest.SessionID = respd.Data.SessionID
 	return &respd.Data, nil
 }

--- a/vendor/github.com/snowflakedb/gosnowflake/heartbeat.go
+++ b/vendor/github.com/snowflakedb/gosnowflake/heartbeat.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	// One hour interval should be good enough to renew tokens for four hours master token validity
+	// One hour interval should be good enough to renew tokens for four hours main token validity
 	heartBeatInterval = 3600 * time.Second
 )
 

--- a/vendor/github.com/snowflakedb/gosnowflake/restful.go
+++ b/vendor/github.com/snowflakedb/gosnowflake/restful.go
@@ -51,7 +51,7 @@ type snowflakeRestful struct {
 
 	Client      *http.Client
 	Token       string
-	MasterToken string
+	MainToken string
 	SessionID   int
 	HeartBeat   *heartbeat
 
@@ -99,7 +99,7 @@ type renewSessionResponse struct {
 type renewSessionResponseMain struct {
 	SessionToken        string        `json:"sessionToken"`
 	ValidityInSecondsST time.Duration `json:"validityInSecondsST"`
-	MasterToken         string        `json:"masterToken"`
+	MainToken         string        `json:"mainToken"`
 	ValidityInSecondsMT time.Duration `json:"validityInSecondsMT"`
 	SessionID           int           `json:"sessionId"`
 }
@@ -322,7 +322,7 @@ func renewRestfulSession(ctx context.Context, sr *snowflakeRestful) error {
 	headers["Content-Type"] = headerContentTypeApplicationJSON
 	headers["accept"] = headerAcceptTypeApplicationSnowflake
 	headers["User-Agent"] = userAgent
-	headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, sr.MasterToken)
+	headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, sr.MainToken)
 
 	body := make(map[string]string)
 	body["oldSessionToken"] = sr.Token
@@ -358,7 +358,7 @@ func renewRestfulSession(ctx context.Context, sr *snowflakeRestful) error {
 			}
 		}
 		sr.Token = respd.Data.SessionToken
-		sr.MasterToken = respd.Data.MasterToken
+		sr.MainToken = respd.Data.MainToken
 		return nil
 	}
 	b, err := ioutil.ReadAll(resp.Body)

--- a/vendor/golang.org/x/net/publicsuffix/table.go
+++ b/vendor/golang.org/x/net/publicsuffix/table.go
@@ -72,7 +72,7 @@ const text = "9guacuiababia-goracleaningroks-theatree12hpalermomahachijoinvill" 
 	"ingmodellingmxn--11b4c3dynathomebuiltwithdarkashiharabzzcolumbus" +
 	"heycommunecommunity-prochowicecomoarekecomparemarkerryhotelsanta" +
 	"mariakecompute-1computerhistoryofscience-fictioncomsecuritytacti" +
-	"csantoandreamhostersanukis-a-cubicle-slavellinodearthachiojiyaho" +
+	"csantoandreamhostersanukis-a-cubicle-subordinatellinodearthachiojiyaho" +
 	"oguycondoshichinohealth-carereforminamidaitomanchesterconference" +
 	"constructionconsuladonnagatorodoyconsultanthropologyconsultingro" +
 	"ngausdalukowhalingrossetouchihayaakasakawaharacontactraniandriab" +

--- a/vendor/gopkg.in/jcmturner/gokrb5.v7/config/krb5conf.go
+++ b/vendor/gopkg.in/jcmturner/gokrb5.v7/config/krb5conf.go
@@ -321,7 +321,7 @@ type Realm struct {
 	DefaultDomain string
 	KDC           []string
 	KPasswdServer []string //default admin_server:464
-	MasterKDC     []string
+	MainKDC     []string
 }
 
 // Parse the lines of a [realms] entry into the Realm struct.
@@ -330,7 +330,7 @@ func (r *Realm) parseLines(name string, lines []string) (err error) {
 	var adminServerFinal bool
 	var KDCFinal bool
 	var kpasswdServerFinal bool
-	var masterKDCFinal bool
+	var mainKDCFinal bool
 	var ignore bool
 	var c int // counts the depth of blocks within brackets { }
 	for _, line := range lines {
@@ -392,8 +392,8 @@ func (r *Realm) parseLines(name string, lines []string) (err error) {
 			appendUntilFinal(&r.KDC, v, &KDCFinal)
 		case "kpasswd_server":
 			appendUntilFinal(&r.KPasswdServer, v, &kpasswdServerFinal)
-		case "master_kdc":
-			appendUntilFinal(&r.MasterKDC, v, &masterKDCFinal)
+		case "main_kdc":
+			appendUntilFinal(&r.MainKDC, v, &mainKDCFinal)
 		default:
 			//Ignore the line
 			continue

--- a/vendor/gopkg.in/jcmturner/gokrb5.v7/iana/errorcode/constants.go
+++ b/vendor/gopkg.in/jcmturner/gokrb5.v7/iana/errorcode/constants.go
@@ -9,8 +9,8 @@ const (
 	KDC_ERR_NAME_EXP                      int32 = 1  //Client's entry in database has expired
 	KDC_ERR_SERVICE_EXP                   int32 = 2  //Server's entry in database has expired
 	KDC_ERR_BAD_PVNO                      int32 = 3  //Requested protocol version number not supported
-	KDC_ERR_C_OLD_MAST_KVNO               int32 = 4  //Client's key encrypted in old master key
-	KDC_ERR_S_OLD_MAST_KVNO               int32 = 5  //Server's key encrypted in old master key
+	KDC_ERR_C_OLD_MAST_KVNO               int32 = 4  //Client's key encrypted in old main key
+	KDC_ERR_S_OLD_MAST_KVNO               int32 = 5  //Server's key encrypted in old main key
 	KDC_ERR_C_PRINCIPAL_UNKNOWN           int32 = 6  //Client not found in Kerberos database
 	KDC_ERR_S_PRINCIPAL_UNKNOWN           int32 = 7  //Server not found in Kerberos database
 	KDC_ERR_PRINCIPAL_NOT_UNIQUE          int32 = 8  //Multiple principal entries in database
@@ -88,8 +88,8 @@ var errorcodeLookup = map[int32]string{
 	KDC_ERR_NAME_EXP:                      "KDC_ERR_NAME_EXP Client's entry in database has expired",
 	KDC_ERR_SERVICE_EXP:                   "KDC_ERR_SERVICE_EXP Server's entry in database has expired",
 	KDC_ERR_BAD_PVNO:                      "KDC_ERR_BAD_PVNO Requested protocol version number not supported",
-	KDC_ERR_C_OLD_MAST_KVNO:               "KDC_ERR_C_OLD_MAST_KVNO Client's key encrypted in old master key",
-	KDC_ERR_S_OLD_MAST_KVNO:               "KDC_ERR_S_OLD_MAST_KVNO Server's key encrypted in old master key",
+	KDC_ERR_C_OLD_MAST_KVNO:               "KDC_ERR_C_OLD_MAST_KVNO Client's key encrypted in old main key",
+	KDC_ERR_S_OLD_MAST_KVNO:               "KDC_ERR_S_OLD_MAST_KVNO Server's key encrypted in old main key",
 	KDC_ERR_C_PRINCIPAL_UNKNOWN:           "KDC_ERR_C_PRINCIPAL_UNKNOWN Client not found in Kerberos database",
 	KDC_ERR_S_PRINCIPAL_UNKNOWN:           "KDC_ERR_S_PRINCIPAL_UNKNOWN Server not found in Kerberos database",
 	KDC_ERR_PRINCIPAL_NOT_UNIQUE:          "KDC_ERR_PRINCIPAL_NOT_UNIQUE Multiple principal entries in database",

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -730,8 +730,8 @@ func GetIP() string {
 	return serverIP
 }
 
-func GetSlaveWorkerId(workerIdx int, slaveID string) string {
-	return fmt.Sprintf("%v-%v-%v", GetIP(), workerIdx, slaveID)
+func GetSubordinateWorkerId(workerIdx int, subordinateID string) string {
+	return fmt.Sprintf("%v-%v-%v", GetIP(), workerIdx, subordinateID)
 }
 
 func SnowflakeCloudProvider(config interface{}) string {


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.