### PR TITLE
warehouse destination debugger bug

### DIFF
--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -187,7 +187,7 @@ func (wh *HandleT) backendConfigSubscriber() {
 }
 
 func (wh *HandleT) syncLiveWarehouseStatus(sourceID string, destinationID string) {
-	rows, err := wh.dbHandle.Query(fmt.Sprintf(`select id from %s where source_id='%s' and destination_id='%s' order by updated_at asc limit %d`, warehouseutils.WarehouseUploadsTable, sourceID, destinationID, warehouseSyncPreFetchCount))
+	rows, err := wh.dbHandle.Query(fmt.Sprintf(`select id from (select id from %s where source_id='%s' and destination_id='%s' order by updated_at desc limit %d) as _ order by updated_at asc`, warehouseutils.WarehouseUploadsTable, sourceID, destinationID, warehouseSyncPreFetchCount))
 	if err != nil && err != sql.ErrNoRows {
 		panic(err)
 	}


### PR DESCRIPTION
this is a bug that fetches first 10 records and sends it to the destination debugger. but the actual use case is to fetch last 10 records order by updated_at asc

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-server/455)
<!-- Reviewable:end -->
