### PR TITLE
Improve performance of batch request worker

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -364,7 +364,6 @@ func (gateway *HandleT) userWebRequestWorkerProcess(userWebRequestWorker *userWe
 			}
 
 			// set anonymousId if not set in payload
-			var index int
 			result := gjson.GetBytes(body, "batch")
 			out := []map[string]interface{}{}
 
@@ -392,8 +391,6 @@ func (gateway *HandleT) userWebRequestWorkerProcess(userWebRequestWorker *userWe
 					toSet["messageId"] = uuid.NewV4().String()
 				}
 				out = append(out, toSet)
-
-				index++
 				return true // keep iterating
 			})
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -366,11 +366,13 @@ func (gateway *HandleT) userWebRequestWorkerProcess(userWebRequestWorker *userWe
 			// set anonymousId if not set in payload
 			var index int
 			result := gjson.GetBytes(body, "batch")
+			out := []map[string]interface{}{}
 
 			var notIdentifiable bool
-			result.ForEach(func(_, _ gjson.Result) bool {
-				anonIDFromReq := strings.TrimSpace(gjson.GetBytes(body, fmt.Sprintf(`batch.%v.anonymousId`, index)).String())
-				userIDFromReq := strings.TrimSpace(gjson.GetBytes(body, fmt.Sprintf(`batch.%v.userId`, index)).String())
+			result.ForEach(func(_, vjson gjson.Result) bool {
+				anonIDFromReq := strings.TrimSpace(vjson.Get("anonymousId").String())
+				userIDFromReq := strings.TrimSpace(vjson.Get("userId").String())
+
 				if anonIDFromReq == "" {
 					if userIDFromReq == "" && !allowReqsWithoutUserIDAndAnonymousID {
 						notIdentifiable = true
@@ -383,13 +385,19 @@ func (gateway *HandleT) userWebRequestWorkerProcess(userWebRequestWorker *userWe
 					notIdentifiable = true
 					return false
 				}
-				body, _ = sjson.SetBytes(body, fmt.Sprintf(`batch.%v.rudderId`, index), rudderId)
-				if strings.TrimSpace(gjson.GetBytes(body, fmt.Sprintf(`batch.%v.messageId`, index)).String()) == "" {
-					body, _ = sjson.SetBytes(body, fmt.Sprintf(`batch.%v.messageId`, index), uuid.NewV4().String())
+
+				toSet := vjson.Value().(map[string]interface{})
+				toSet["rudderId"] = rudderId
+				if messageId := strings.TrimSpace(vjson.Get("messageId").String()); messageId == "" {
+					toSet["messageId"] = uuid.NewV4().String()
 				}
+				out = append(out, toSet)
+
 				index++
 				return true // keep iterating
 			})
+
+			body, _ = sjson.SetBytes(body, "batch", out)
 
 			if notIdentifiable {
 				req.done <- response.GetStatus(response.NonIdentifiableRequest)


### PR DESCRIPTION
**Fixes** # (*issue*)

I'm not sure exactly which time complexity the original code falls under (e.g. O(n^2) ), but the problem only becomes apparent with larger batch sizes. Batches larger than ~ 400 events were causing severe performance issues.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

[K6](https://k6.io/) results locally with batch size of 400

```
  before 

  scenarios: (100.00%) 1 scenario, 200 max VUs, 1m30s max duration (incl. graceful stop):
           * constant_request_rate: 2.83 iterations/s for 1m0s (maxVUs: 100-200, gracefulStop: 30s)


    iteration_duration.........: avg=616.1ms  min=575.44ms med=607.48ms max=907.34ms p(90)=643.99ms p(95)=663.54ms


  after


  scenarios: (100.00%) 1 scenario, 200 max VUs, 1m30s max duration (incl. graceful stop):
           * constant_request_rate: 2.83 iterations/s for 1m0s (maxVUs: 100-200, gracefulStop: 30s)


    iteration_duration.........: avg=77.19ms  min=43.47ms  med=78.15ms  max=130.14ms p(90)=95.7ms   p(95)=100.47ms
```

Batch sizes much larger than that cause request build up and eventual failed requests.


My K6 test script:

```
import http from 'k6/http';


let file400 = open('./400'); // request body produced by using  `go run genload.go -n 400`

export let options = {
  scenarios: {
    constant_request_rate: {
      executor: 'constant-arrival-rate',
      rate: 170,
      timeUnit: '1m',
      duration: '5m',
      preAllocatedVUs: 25, // how large the initial pool of VUs would be
      maxVUs: 200, // if the preAllocatedVUs are not enough, we can initialize more
    },
  },
};

export default function () {

  var url = 'http://MY_WRITE_KEY:@localhost:8080/v1/batch';

  var payload = file400;

  var params = {
    headers: {
      'Content-Type': 'application/json',
      'Accept-Encoding': 'gzip',
    },
  };

  http.post(url, payload, params);
}
```