### PR TITLE
Use getTagsFormat for normal stats

### DIFF
--- a/services/stats/stats.go
+++ b/services/stats/stats.go
@@ -101,7 +101,7 @@ func Setup() {
 	var err error
 	conn = statsd.Address(statsdServerURL)
 	//TODO: Add tags by calling a function...
-	client, err = statsd.New(conn, statsd.TagsFormat(statsd.InfluxDB), defaultTags())
+	client, err = statsd.New(conn, statsd.TagsFormat(getTagsFormat()), defaultTags())
 	if err != nil {
 		// If nothing is listening on the target port, an error is returned and
 		// the returned client does nothing but is still usable. So we can


### PR DESCRIPTION
Stats tags format was only made configurable on the taggedClient when it should have been applied to both clients

**Fixes** # (*issue*)

Original work missed configuring this client:
https://github.com/rudderlabs/rudder-server/pull/832

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
