### PR TITLE
Verify `go generate`d files are committed and gomock@1.6 is used

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           go-version: '^1.16.1'
       - run: go version
-      - run: go get github.com/golang/mock/mockgen@v1.5.0
+      - run: go get github.com/golang/mock/mockgen@v1.6.0
       - run: go generate ./... -mod vendor
       - run: git diff --exit-code

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,7 +18,7 @@ jobs:
           go-version: '^1.16.1'
       - run: go version
       - run: make mocks
-      - run: git diff --exit-code
+      - run: git diff --exit-code && exit 1
       - name: Error message
         if: ${{ failure() }}
         run: echo "::error file=Makefile,line=11,col=1::Incorrectly generated files. Ensure you have run `make mocks` and committed the files locally."

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,7 +18,7 @@ jobs:
           go-version: '^1.16.1'
       - run: go version
       - run: make mocks
-      - run: git diff --exit-code
+      - run: git diff --exit-code; exit 1
       - name: Error message
         if: ${{ failure() }}
         run: echo '::error file=Makefile,line=11,col=1::Incorrectly generated files. Ensure you have run `make mocks` and committed the files locally.'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,4 +19,4 @@ jobs:
       - run: go version
       - run: go install github.com/golang/mock/mockgen@v1.6.0
       - run: go generate ./... -mod vendor
-      - run: git diff --exit-code
+      - run: git diff --exit-code || echo "Incorrect generated files, ensure you have run mockgen@v1.6.0 locally"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,11 +17,8 @@ jobs:
         with:
           go-version: '^1.16.1'
       - run: go version
-      - run: go install github.com/golang/mock/mockgen@v1.6.0
-      - run: go generate ./... -mod vendor
+      - run: make mocks
       - run: git diff --exit-code
-      - run: exit 1
-
       - name: Error message
         if: ${{ failure() }}
-        run: echo "::error file=Makefile,line=11,col=1::Incorrectly generated files.\n Ensure you have run `make mocks` with mockgen@v1.6.0 installed."
+        run: echo "::error file=Makefile,line=11,col=1::Incorrectly generated files. Ensure you have run `make mocks` and committed the files locally."

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,7 +18,7 @@ jobs:
           go-version: '^1.16.1'
       - run: go version
       - run: make mocks
-      - run: git diff --exit-code && exit 1
+      - run: git diff --exit-code
       - name: Error message
         if: ${{ failure() }}
         run: echo "::error file=Makefile,line=11,col=1::Incorrectly generated files. Ensure you have run `make mocks` and committed the files locally."

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -21,4 +21,4 @@ jobs:
       - run: git diff --exit-code
       - name: Error message
         if: ${{ failure() }}
-        run: echo "::error file=Makefile,line=11,col=1::Incorrectly generated files. Ensure you have run `make mocks` and committed the files locally."
+        run: echo '::error file=Makefile,line=11,col=1::Incorrectly generated files. Ensure you have run `make mocks` and committed the files locally.'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,7 +18,7 @@ jobs:
           go-version: '^1.16.1'
       - run: go version
       - run: make mocks
-      - run: git diff --exit-code; exit 1
+      - run: git diff --exit-code
       - name: Error message
         if: ${{ failure() }}
         run: echo '::error file=Makefile,line=11,col=1::Incorrectly generated files. Ensure you have run `make mocks` and committed the files locally.'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           go-version: '^1.16.1'
       - run: go version
-      - run: go get github.com/golang/mock/mockgen@v1.6.0
+      - run: go install github.com/golang/mock/mockgen@v1.6.0
       - run: go generate ./... -mod vendor
       - run: git diff --exit-code

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,22 @@
+name: verify
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+jobs:
+  generate:
+    name: Correct generated files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16.1'
+      - run: go version
+      - run: go get github.com/golang/mock/mockgen@v1.5.0
+      - run: go generate ./... -mod vendor
+      - run: git diff --exit-code

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,4 +19,9 @@ jobs:
       - run: go version
       - run: go install github.com/golang/mock/mockgen@v1.6.0
       - run: go generate ./... -mod vendor
-      - run: git diff --exit-code || echo "Incorrect generated files, ensure you have run mockgen@v1.6.0 locally"
+      - run: git diff --exit-code
+      - run: exit 1
+
+      - name: Error message
+        if: ${{ failure() }}
+        run: echo "::error file=Makefile,line=11,col=1::Incorrectly generated files.\n Ensure you have run `make mocks` with mockgen@v1.6.0 installed."

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ include .enterprise/env
 
 default: build
 
-mocks: ## Generate all mocks
-	$(GO) generate ./...
+mocks: install-tools ## Generate all mocks
+	$(GO) generate -mod vendor ./...
 
 test: enterprise-prepare-build mocks ## Run all unit tests
 ifdef package
@@ -62,3 +62,6 @@ enterprise-prepare-build: ## Create ./imports/enterprise.go, to link enterprise 
 	else \
 		rm -f ./imports/enterprise.go; \
 	fi
+
+install-tools:
+	go install github.com/golang/mock/mockgen@v1.6.0

--- a/Makefile
+++ b/Makefile
@@ -64,4 +64,7 @@ enterprise-prepare-build: ## Create ./imports/enterprise.go, to link enterprise 
 	fi
 
 install-tools:
-	go install github.com/golang/mock/mockgen@v1.6.0
+	# Try install for go 1.16+, fallback to get
+	go install github.com/golang/mock/mockgen@v1.6.0 || \
+	GO111MODULE=on go get github.com/golang/mock/mockgen@v1.6.0 
+ 

--- a/mocks/app/mock_app.go
+++ b/mocks/app/mock_app.go
@@ -5,35 +5,36 @@
 package mock_app
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	app "github.com/rudderlabs/rudder-server/app"
-	reflect "reflect"
 )
 
-// MockInterface is a mock of Interface interface
+// MockInterface is a mock of Interface interface.
 type MockInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockInterfaceMockRecorder
 }
 
-// MockInterfaceMockRecorder is the mock recorder for MockInterface
+// MockInterfaceMockRecorder is the mock recorder for MockInterface.
 type MockInterfaceMockRecorder struct {
 	mock *MockInterface
 }
 
-// NewMockInterface creates a new mock instance
+// NewMockInterface creates a new mock instance.
 func NewMockInterface(ctrl *gomock.Controller) *MockInterface {
 	mock := &MockInterface{ctrl: ctrl}
 	mock.recorder = &MockInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Features mocks base method
+// Features mocks base method.
 func (m *MockInterface) Features() *app.Features {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Features")
@@ -41,13 +42,13 @@ func (m *MockInterface) Features() *app.Features {
 	return ret0
 }
 
-// Features indicates an expected call of Features
+// Features indicates an expected call of Features.
 func (mr *MockInterfaceMockRecorder) Features() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Features", reflect.TypeOf((*MockInterface)(nil).Features))
 }
 
-// Options mocks base method
+// Options mocks base method.
 func (m *MockInterface) Options() *app.Options {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Options")
@@ -55,31 +56,31 @@ func (m *MockInterface) Options() *app.Options {
 	return ret0
 }
 
-// Options indicates an expected call of Options
+// Options indicates an expected call of Options.
 func (mr *MockInterfaceMockRecorder) Options() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Options", reflect.TypeOf((*MockInterface)(nil).Options))
 }
 
-// Setup mocks base method
+// Setup mocks base method.
 func (m *MockInterface) Setup() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Setup")
 }
 
-// Setup indicates an expected call of Setup
+// Setup indicates an expected call of Setup.
 func (mr *MockInterfaceMockRecorder) Setup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setup", reflect.TypeOf((*MockInterface)(nil).Setup))
 }
 
-// Stop mocks base method
+// Stop mocks base method.
 func (m *MockInterface) Stop() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Stop")
 }
 
-// Stop indicates an expected call of Stop
+// Stop indicates an expected call of Stop.
 func (mr *MockInterfaceMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockInterface)(nil).Stop))

--- a/mocks/app/mock_features.go
+++ b/mocks/app/mock_features.go
@@ -5,84 +5,85 @@
 package mock_app
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	jobsdb "github.com/rudderlabs/rudder-server/jobsdb"
 	types "github.com/rudderlabs/rudder-server/utils/types"
-	reflect "reflect"
 )
 
-// MockMigratorFeature is a mock of MigratorFeature interface
+// MockMigratorFeature is a mock of MigratorFeature interface.
 type MockMigratorFeature struct {
 	ctrl     *gomock.Controller
 	recorder *MockMigratorFeatureMockRecorder
 }
 
-// MockMigratorFeatureMockRecorder is the mock recorder for MockMigratorFeature
+// MockMigratorFeatureMockRecorder is the mock recorder for MockMigratorFeature.
 type MockMigratorFeatureMockRecorder struct {
 	mock *MockMigratorFeature
 }
 
-// NewMockMigratorFeature creates a new mock instance
+// NewMockMigratorFeature creates a new mock instance.
 func NewMockMigratorFeature(ctrl *gomock.Controller) *MockMigratorFeature {
 	mock := &MockMigratorFeature{ctrl: ctrl}
 	mock.recorder = &MockMigratorFeatureMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMigratorFeature) EXPECT() *MockMigratorFeatureMockRecorder {
 	return m.recorder
 }
 
-// PrepareJobsdbsForImport mocks base method
+// PrepareJobsdbsForImport mocks base method.
 func (m *MockMigratorFeature) PrepareJobsdbsForImport(arg0, arg1, arg2 *jobsdb.HandleT) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "PrepareJobsdbsForImport", arg0, arg1, arg2)
 }
 
-// PrepareJobsdbsForImport indicates an expected call of PrepareJobsdbsForImport
+// PrepareJobsdbsForImport indicates an expected call of PrepareJobsdbsForImport.
 func (mr *MockMigratorFeatureMockRecorder) PrepareJobsdbsForImport(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareJobsdbsForImport", reflect.TypeOf((*MockMigratorFeature)(nil).PrepareJobsdbsForImport), arg0, arg1, arg2)
 }
 
-// Setup mocks base method
+// Setup mocks base method.
 func (m *MockMigratorFeature) Setup(arg0, arg1, arg2 *jobsdb.HandleT, arg3, arg4 func()) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Setup", arg0, arg1, arg2, arg3, arg4)
 }
 
-// Setup indicates an expected call of Setup
+// Setup indicates an expected call of Setup.
 func (mr *MockMigratorFeatureMockRecorder) Setup(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setup", reflect.TypeOf((*MockMigratorFeature)(nil).Setup), arg0, arg1, arg2, arg3, arg4)
 }
 
-// MockSuppressUserFeature is a mock of SuppressUserFeature interface
+// MockSuppressUserFeature is a mock of SuppressUserFeature interface.
 type MockSuppressUserFeature struct {
 	ctrl     *gomock.Controller
 	recorder *MockSuppressUserFeatureMockRecorder
 }
 
-// MockSuppressUserFeatureMockRecorder is the mock recorder for MockSuppressUserFeature
+// MockSuppressUserFeatureMockRecorder is the mock recorder for MockSuppressUserFeature.
 type MockSuppressUserFeatureMockRecorder struct {
 	mock *MockSuppressUserFeature
 }
 
-// NewMockSuppressUserFeature creates a new mock instance
+// NewMockSuppressUserFeature creates a new mock instance.
 func NewMockSuppressUserFeature(ctrl *gomock.Controller) *MockSuppressUserFeature {
 	mock := &MockSuppressUserFeature{ctrl: ctrl}
 	mock.recorder = &MockSuppressUserFeatureMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSuppressUserFeature) EXPECT() *MockSuppressUserFeatureMockRecorder {
 	return m.recorder
 }
 
-// Setup mocks base method
+// Setup mocks base method.
 func (m *MockSuppressUserFeature) Setup(arg0 backendconfig.BackendConfig) types.SuppressUserI {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Setup", arg0)
@@ -90,7 +91,7 @@ func (m *MockSuppressUserFeature) Setup(arg0 backendconfig.BackendConfig) types.
 	return ret0
 }
 
-// Setup indicates an expected call of Setup
+// Setup indicates an expected call of Setup.
 func (mr *MockSuppressUserFeatureMockRecorder) Setup(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setup", reflect.TypeOf((*MockSuppressUserFeature)(nil).Setup), arg0)

--- a/mocks/config/backend-config/mock_backendconfig.go
+++ b/mocks/config/backend-config/mock_backendconfig.go
@@ -5,36 +5,37 @@
 package mock_backendconfig
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	utils "github.com/rudderlabs/rudder-server/utils"
-	reflect "reflect"
 )
 
-// MockBackendConfig is a mock of BackendConfig interface
+// MockBackendConfig is a mock of BackendConfig interface.
 type MockBackendConfig struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackendConfigMockRecorder
 }
 
-// MockBackendConfigMockRecorder is the mock recorder for MockBackendConfig
+// MockBackendConfigMockRecorder is the mock recorder for MockBackendConfig.
 type MockBackendConfigMockRecorder struct {
 	mock *MockBackendConfig
 }
 
-// NewMockBackendConfig creates a new mock instance
+// NewMockBackendConfig creates a new mock instance.
 func NewMockBackendConfig(ctrl *gomock.Controller) *MockBackendConfig {
 	mock := &MockBackendConfig{ctrl: ctrl}
 	mock.recorder = &MockBackendConfigMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBackendConfig) EXPECT() *MockBackendConfigMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockBackendConfig) Get() (backendconfig.ConfigT, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get")
@@ -43,13 +44,13 @@ func (m *MockBackendConfig) Get() (backendconfig.ConfigT, bool) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockBackendConfigMockRecorder) Get() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBackendConfig)(nil).Get))
 }
 
-// GetRegulations mocks base method
+// GetRegulations mocks base method.
 func (m *MockBackendConfig) GetRegulations() (backendconfig.RegulationsT, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRegulations")
@@ -58,13 +59,13 @@ func (m *MockBackendConfig) GetRegulations() (backendconfig.RegulationsT, bool) 
 	return ret0, ret1
 }
 
-// GetRegulations indicates an expected call of GetRegulations
+// GetRegulations indicates an expected call of GetRegulations.
 func (mr *MockBackendConfigMockRecorder) GetRegulations() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegulations", reflect.TypeOf((*MockBackendConfig)(nil).GetRegulations))
 }
 
-// GetWorkspaceIDForWriteKey mocks base method
+// GetWorkspaceIDForWriteKey mocks base method.
 func (m *MockBackendConfig) GetWorkspaceIDForWriteKey(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkspaceIDForWriteKey", arg0)
@@ -72,13 +73,13 @@ func (m *MockBackendConfig) GetWorkspaceIDForWriteKey(arg0 string) string {
 	return ret0
 }
 
-// GetWorkspaceIDForWriteKey indicates an expected call of GetWorkspaceIDForWriteKey
+// GetWorkspaceIDForWriteKey indicates an expected call of GetWorkspaceIDForWriteKey.
 func (mr *MockBackendConfigMockRecorder) GetWorkspaceIDForWriteKey(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceIDForWriteKey", reflect.TypeOf((*MockBackendConfig)(nil).GetWorkspaceIDForWriteKey), arg0)
 }
 
-// GetWorkspaceLibrariesForWorkspaceID mocks base method
+// GetWorkspaceLibrariesForWorkspaceID mocks base method.
 func (m *MockBackendConfig) GetWorkspaceLibrariesForWorkspaceID(arg0 string) backendconfig.LibrariesT {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkspaceLibrariesForWorkspaceID", arg0)
@@ -86,43 +87,43 @@ func (m *MockBackendConfig) GetWorkspaceLibrariesForWorkspaceID(arg0 string) bac
 	return ret0
 }
 
-// GetWorkspaceLibrariesForWorkspaceID indicates an expected call of GetWorkspaceLibrariesForWorkspaceID
+// GetWorkspaceLibrariesForWorkspaceID indicates an expected call of GetWorkspaceLibrariesForWorkspaceID.
 func (mr *MockBackendConfigMockRecorder) GetWorkspaceLibrariesForWorkspaceID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspaceLibrariesForWorkspaceID", reflect.TypeOf((*MockBackendConfig)(nil).GetWorkspaceLibrariesForWorkspaceID), arg0)
 }
 
-// SetUp mocks base method
+// SetUp mocks base method.
 func (m *MockBackendConfig) SetUp() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetUp")
 }
 
-// SetUp indicates an expected call of SetUp
+// SetUp indicates an expected call of SetUp.
 func (mr *MockBackendConfigMockRecorder) SetUp() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUp", reflect.TypeOf((*MockBackendConfig)(nil).SetUp))
 }
 
-// Subscribe mocks base method
+// Subscribe mocks base method.
 func (m *MockBackendConfig) Subscribe(arg0 chan utils.DataEvent, arg1 backendconfig.Topic) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Subscribe", arg0, arg1)
 }
 
-// Subscribe indicates an expected call of Subscribe
+// Subscribe indicates an expected call of Subscribe.
 func (mr *MockBackendConfigMockRecorder) Subscribe(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockBackendConfig)(nil).Subscribe), arg0, arg1)
 }
 
-// WaitForConfig mocks base method
+// WaitForConfig mocks base method.
 func (m *MockBackendConfig) WaitForConfig() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "WaitForConfig")
 }
 
-// WaitForConfig indicates an expected call of WaitForConfig
+// WaitForConfig indicates an expected call of WaitForConfig.
 func (mr *MockBackendConfigMockRecorder) WaitForConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForConfig", reflect.TypeOf((*MockBackendConfig)(nil).WaitForConfig))

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -7,60 +7,61 @@ package mocks_jobsdb
 import (
 	sql "database/sql"
 	json "encoding/json"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	jobsdb "github.com/rudderlabs/rudder-server/jobsdb"
 	uuid "github.com/satori/go.uuid"
-	reflect "reflect"
 )
 
-// MockJobsDB is a mock of JobsDB interface
+// MockJobsDB is a mock of JobsDB interface.
 type MockJobsDB struct {
 	ctrl     *gomock.Controller
 	recorder *MockJobsDBMockRecorder
 }
 
-// MockJobsDBMockRecorder is the mock recorder for MockJobsDB
+// MockJobsDBMockRecorder is the mock recorder for MockJobsDB.
 type MockJobsDBMockRecorder struct {
 	mock *MockJobsDB
 }
 
-// NewMockJobsDB creates a new mock instance
+// NewMockJobsDB creates a new mock instance.
 func NewMockJobsDB(ctrl *gomock.Controller) *MockJobsDB {
 	mock := &MockJobsDB{ctrl: ctrl}
 	mock.recorder = &MockJobsDBMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockJobsDB) EXPECT() *MockJobsDBMockRecorder {
 	return m.recorder
 }
 
-// AcquireStoreLock mocks base method
+// AcquireStoreLock mocks base method.
 func (m *MockJobsDB) AcquireStoreLock() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AcquireStoreLock")
 }
 
-// AcquireStoreLock indicates an expected call of AcquireStoreLock
+// AcquireStoreLock indicates an expected call of AcquireStoreLock.
 func (mr *MockJobsDBMockRecorder) AcquireStoreLock() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcquireStoreLock", reflect.TypeOf((*MockJobsDB)(nil).AcquireStoreLock))
 }
 
-// AcquireUpdateJobStatusLocks mocks base method
+// AcquireUpdateJobStatusLocks mocks base method.
 func (m *MockJobsDB) AcquireUpdateJobStatusLocks() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AcquireUpdateJobStatusLocks")
 }
 
-// AcquireUpdateJobStatusLocks indicates an expected call of AcquireUpdateJobStatusLocks
+// AcquireUpdateJobStatusLocks indicates an expected call of AcquireUpdateJobStatusLocks.
 func (mr *MockJobsDBMockRecorder) AcquireUpdateJobStatusLocks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcquireUpdateJobStatusLocks", reflect.TypeOf((*MockJobsDB)(nil).AcquireUpdateJobStatusLocks))
 }
 
-// BeginGlobalTransaction mocks base method
+// BeginGlobalTransaction mocks base method.
 func (m *MockJobsDB) BeginGlobalTransaction() *sql.Tx {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BeginGlobalTransaction")
@@ -68,13 +69,13 @@ func (m *MockJobsDB) BeginGlobalTransaction() *sql.Tx {
 	return ret0
 }
 
-// BeginGlobalTransaction indicates an expected call of BeginGlobalTransaction
+// BeginGlobalTransaction indicates an expected call of BeginGlobalTransaction.
 func (mr *MockJobsDBMockRecorder) BeginGlobalTransaction() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginGlobalTransaction", reflect.TypeOf((*MockJobsDB)(nil).BeginGlobalTransaction))
 }
 
-// CheckPGHealth mocks base method
+// CheckPGHealth mocks base method.
 func (m *MockJobsDB) CheckPGHealth() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckPGHealth")
@@ -82,37 +83,37 @@ func (m *MockJobsDB) CheckPGHealth() bool {
 	return ret0
 }
 
-// CheckPGHealth indicates an expected call of CheckPGHealth
+// CheckPGHealth indicates an expected call of CheckPGHealth.
 func (mr *MockJobsDBMockRecorder) CheckPGHealth() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckPGHealth", reflect.TypeOf((*MockJobsDB)(nil).CheckPGHealth))
 }
 
-// CommitTransaction mocks base method
+// CommitTransaction mocks base method.
 func (m *MockJobsDB) CommitTransaction(arg0 *sql.Tx) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CommitTransaction", arg0)
 }
 
-// CommitTransaction indicates an expected call of CommitTransaction
+// CommitTransaction indicates an expected call of CommitTransaction.
 func (mr *MockJobsDBMockRecorder) CommitTransaction(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitTransaction", reflect.TypeOf((*MockJobsDB)(nil).CommitTransaction), arg0)
 }
 
-// DeleteExecuting mocks base method
+// DeleteExecuting mocks base method.
 func (m *MockJobsDB) DeleteExecuting(arg0 jobsdb.GetQueryParamsT) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "DeleteExecuting", arg0)
 }
 
-// DeleteExecuting indicates an expected call of DeleteExecuting
+// DeleteExecuting indicates an expected call of DeleteExecuting.
 func (mr *MockJobsDBMockRecorder) DeleteExecuting(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExecuting", reflect.TypeOf((*MockJobsDB)(nil).DeleteExecuting), arg0)
 }
 
-// GetExecuting mocks base method
+// GetExecuting mocks base method.
 func (m *MockJobsDB) GetExecuting(arg0 jobsdb.GetQueryParamsT) []*jobsdb.JobT {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetExecuting", arg0)
@@ -120,13 +121,13 @@ func (m *MockJobsDB) GetExecuting(arg0 jobsdb.GetQueryParamsT) []*jobsdb.JobT {
 	return ret0
 }
 
-// GetExecuting indicates an expected call of GetExecuting
+// GetExecuting indicates an expected call of GetExecuting.
 func (mr *MockJobsDBMockRecorder) GetExecuting(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExecuting", reflect.TypeOf((*MockJobsDB)(nil).GetExecuting), arg0)
 }
 
-// GetIdentifier mocks base method
+// GetIdentifier mocks base method.
 func (m *MockJobsDB) GetIdentifier() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIdentifier")
@@ -134,13 +135,13 @@ func (m *MockJobsDB) GetIdentifier() string {
 	return ret0
 }
 
-// GetIdentifier indicates an expected call of GetIdentifier
+// GetIdentifier indicates an expected call of GetIdentifier.
 func (mr *MockJobsDBMockRecorder) GetIdentifier() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIdentifier", reflect.TypeOf((*MockJobsDB)(nil).GetIdentifier))
 }
 
-// GetImportingList mocks base method
+// GetImportingList mocks base method.
 func (m *MockJobsDB) GetImportingList(arg0 jobsdb.GetQueryParamsT) []*jobsdb.JobT {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetImportingList", arg0)
@@ -148,13 +149,13 @@ func (m *MockJobsDB) GetImportingList(arg0 jobsdb.GetQueryParamsT) []*jobsdb.Job
 	return ret0
 }
 
-// GetImportingList indicates an expected call of GetImportingList
+// GetImportingList indicates an expected call of GetImportingList.
 func (mr *MockJobsDBMockRecorder) GetImportingList(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImportingList", reflect.TypeOf((*MockJobsDB)(nil).GetImportingList), arg0)
 }
 
-// GetJournalEntries mocks base method
+// GetJournalEntries mocks base method.
 func (m *MockJobsDB) GetJournalEntries(arg0 string) []jobsdb.JournalEntryT {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetJournalEntries", arg0)
@@ -162,13 +163,13 @@ func (m *MockJobsDB) GetJournalEntries(arg0 string) []jobsdb.JournalEntryT {
 	return ret0
 }
 
-// GetJournalEntries indicates an expected call of GetJournalEntries
+// GetJournalEntries indicates an expected call of GetJournalEntries.
 func (mr *MockJobsDBMockRecorder) GetJournalEntries(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJournalEntries", reflect.TypeOf((*MockJobsDB)(nil).GetJournalEntries), arg0)
 }
 
-// GetProcessed mocks base method
+// GetProcessed mocks base method.
 func (m *MockJobsDB) GetProcessed(arg0 jobsdb.GetQueryParamsT) []*jobsdb.JobT {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProcessed", arg0)
@@ -176,13 +177,13 @@ func (m *MockJobsDB) GetProcessed(arg0 jobsdb.GetQueryParamsT) []*jobsdb.JobT {
 	return ret0
 }
 
-// GetProcessed indicates an expected call of GetProcessed
+// GetProcessed indicates an expected call of GetProcessed.
 func (mr *MockJobsDBMockRecorder) GetProcessed(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProcessed", reflect.TypeOf((*MockJobsDB)(nil).GetProcessed), arg0)
 }
 
-// GetThrottled mocks base method
+// GetThrottled mocks base method.
 func (m *MockJobsDB) GetThrottled(arg0 jobsdb.GetQueryParamsT) []*jobsdb.JobT {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetThrottled", arg0)
@@ -190,13 +191,13 @@ func (m *MockJobsDB) GetThrottled(arg0 jobsdb.GetQueryParamsT) []*jobsdb.JobT {
 	return ret0
 }
 
-// GetThrottled indicates an expected call of GetThrottled
+// GetThrottled indicates an expected call of GetThrottled.
 func (mr *MockJobsDBMockRecorder) GetThrottled(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThrottled", reflect.TypeOf((*MockJobsDB)(nil).GetThrottled), arg0)
 }
 
-// GetToRetry mocks base method
+// GetToRetry mocks base method.
 func (m *MockJobsDB) GetToRetry(arg0 jobsdb.GetQueryParamsT) []*jobsdb.JobT {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetToRetry", arg0)
@@ -204,13 +205,13 @@ func (m *MockJobsDB) GetToRetry(arg0 jobsdb.GetQueryParamsT) []*jobsdb.JobT {
 	return ret0
 }
 
-// GetToRetry indicates an expected call of GetToRetry
+// GetToRetry indicates an expected call of GetToRetry.
 func (mr *MockJobsDBMockRecorder) GetToRetry(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToRetry", reflect.TypeOf((*MockJobsDB)(nil).GetToRetry), arg0)
 }
 
-// GetUnprocessed mocks base method
+// GetUnprocessed mocks base method.
 func (m *MockJobsDB) GetUnprocessed(arg0 jobsdb.GetQueryParamsT) []*jobsdb.JobT {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnprocessed", arg0)
@@ -218,13 +219,13 @@ func (m *MockJobsDB) GetUnprocessed(arg0 jobsdb.GetQueryParamsT) []*jobsdb.JobT 
 	return ret0
 }
 
-// GetUnprocessed indicates an expected call of GetUnprocessed
+// GetUnprocessed indicates an expected call of GetUnprocessed.
 func (mr *MockJobsDBMockRecorder) GetUnprocessed(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnprocessed", reflect.TypeOf((*MockJobsDB)(nil).GetUnprocessed), arg0)
 }
 
-// GetWaiting mocks base method
+// GetWaiting mocks base method.
 func (m *MockJobsDB) GetWaiting(arg0 jobsdb.GetQueryParamsT) []*jobsdb.JobT {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWaiting", arg0)
@@ -232,25 +233,25 @@ func (m *MockJobsDB) GetWaiting(arg0 jobsdb.GetQueryParamsT) []*jobsdb.JobT {
 	return ret0
 }
 
-// GetWaiting indicates an expected call of GetWaiting
+// GetWaiting indicates an expected call of GetWaiting.
 func (mr *MockJobsDBMockRecorder) GetWaiting(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWaiting", reflect.TypeOf((*MockJobsDB)(nil).GetWaiting), arg0)
 }
 
-// JournalDeleteEntry mocks base method
+// JournalDeleteEntry mocks base method.
 func (m *MockJobsDB) JournalDeleteEntry(arg0 int64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "JournalDeleteEntry", arg0)
 }
 
-// JournalDeleteEntry indicates an expected call of JournalDeleteEntry
+// JournalDeleteEntry indicates an expected call of JournalDeleteEntry.
 func (mr *MockJobsDBMockRecorder) JournalDeleteEntry(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JournalDeleteEntry", reflect.TypeOf((*MockJobsDB)(nil).JournalDeleteEntry), arg0)
 }
 
-// JournalMarkStart mocks base method
+// JournalMarkStart mocks base method.
 func (m *MockJobsDB) JournalMarkStart(arg0 string, arg1 json.RawMessage) int64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JournalMarkStart", arg0, arg1)
@@ -258,37 +259,37 @@ func (m *MockJobsDB) JournalMarkStart(arg0 string, arg1 json.RawMessage) int64 {
 	return ret0
 }
 
-// JournalMarkStart indicates an expected call of JournalMarkStart
+// JournalMarkStart indicates an expected call of JournalMarkStart.
 func (mr *MockJobsDBMockRecorder) JournalMarkStart(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JournalMarkStart", reflect.TypeOf((*MockJobsDB)(nil).JournalMarkStart), arg0, arg1)
 }
 
-// ReleaseStoreLock mocks base method
+// ReleaseStoreLock mocks base method.
 func (m *MockJobsDB) ReleaseStoreLock() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReleaseStoreLock")
 }
 
-// ReleaseStoreLock indicates an expected call of ReleaseStoreLock
+// ReleaseStoreLock indicates an expected call of ReleaseStoreLock.
 func (mr *MockJobsDBMockRecorder) ReleaseStoreLock() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseStoreLock", reflect.TypeOf((*MockJobsDB)(nil).ReleaseStoreLock))
 }
 
-// ReleaseUpdateJobStatusLocks mocks base method
+// ReleaseUpdateJobStatusLocks mocks base method.
 func (m *MockJobsDB) ReleaseUpdateJobStatusLocks() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReleaseUpdateJobStatusLocks")
 }
 
-// ReleaseUpdateJobStatusLocks indicates an expected call of ReleaseUpdateJobStatusLocks
+// ReleaseUpdateJobStatusLocks indicates an expected call of ReleaseUpdateJobStatusLocks.
 func (mr *MockJobsDBMockRecorder) ReleaseUpdateJobStatusLocks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseUpdateJobStatusLocks", reflect.TypeOf((*MockJobsDB)(nil).ReleaseUpdateJobStatusLocks))
 }
 
-// Status mocks base method
+// Status mocks base method.
 func (m *MockJobsDB) Status() interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
@@ -296,13 +297,13 @@ func (m *MockJobsDB) Status() interface{} {
 	return ret0
 }
 
-// Status indicates an expected call of Status
+// Status indicates an expected call of Status.
 func (mr *MockJobsDBMockRecorder) Status() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockJobsDB)(nil).Status))
 }
 
-// Store mocks base method
+// Store mocks base method.
 func (m *MockJobsDB) Store(arg0 []*jobsdb.JobT) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Store", arg0)
@@ -310,13 +311,13 @@ func (m *MockJobsDB) Store(arg0 []*jobsdb.JobT) error {
 	return ret0
 }
 
-// Store indicates an expected call of Store
+// Store indicates an expected call of Store.
 func (mr *MockJobsDBMockRecorder) Store(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockJobsDB)(nil).Store), arg0)
 }
 
-// StoreWithRetryEach mocks base method
+// StoreWithRetryEach mocks base method.
 func (m *MockJobsDB) StoreWithRetryEach(arg0 []*jobsdb.JobT) map[uuid.UUID]string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreWithRetryEach", arg0)
@@ -324,13 +325,13 @@ func (m *MockJobsDB) StoreWithRetryEach(arg0 []*jobsdb.JobT) map[uuid.UUID]strin
 	return ret0
 }
 
-// StoreWithRetryEach indicates an expected call of StoreWithRetryEach
+// StoreWithRetryEach indicates an expected call of StoreWithRetryEach.
 func (mr *MockJobsDBMockRecorder) StoreWithRetryEach(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreWithRetryEach", reflect.TypeOf((*MockJobsDB)(nil).StoreWithRetryEach), arg0)
 }
 
-// UpdateJobStatus mocks base method
+// UpdateJobStatus mocks base method.
 func (m *MockJobsDB) UpdateJobStatus(arg0 []*jobsdb.JobStatusT, arg1 []string, arg2 []jobsdb.ParameterFilterT) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateJobStatus", arg0, arg1, arg2)
@@ -338,13 +339,13 @@ func (m *MockJobsDB) UpdateJobStatus(arg0 []*jobsdb.JobStatusT, arg1 []string, a
 	return ret0
 }
 
-// UpdateJobStatus indicates an expected call of UpdateJobStatus
+// UpdateJobStatus indicates an expected call of UpdateJobStatus.
 func (mr *MockJobsDBMockRecorder) UpdateJobStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateJobStatus", reflect.TypeOf((*MockJobsDB)(nil).UpdateJobStatus), arg0, arg1, arg2)
 }
 
-// UpdateJobStatusInTxn mocks base method
+// UpdateJobStatusInTxn mocks base method.
 func (m *MockJobsDB) UpdateJobStatusInTxn(arg0 *sql.Tx, arg1 []*jobsdb.JobStatusT, arg2 []string, arg3 []jobsdb.ParameterFilterT) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateJobStatusInTxn", arg0, arg1, arg2, arg3)
@@ -352,7 +353,7 @@ func (m *MockJobsDB) UpdateJobStatusInTxn(arg0 *sql.Tx, arg1 []*jobsdb.JobStatus
 	return ret0
 }
 
-// UpdateJobStatusInTxn indicates an expected call of UpdateJobStatusInTxn
+// UpdateJobStatusInTxn indicates an expected call of UpdateJobStatusInTxn.
 func (mr *MockJobsDBMockRecorder) UpdateJobStatusInTxn(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateJobStatusInTxn", reflect.TypeOf((*MockJobsDB)(nil).UpdateJobStatusInTxn), arg0, arg1, arg2, arg3)

--- a/mocks/rate-limiter/mock_ratelimiter.go
+++ b/mocks/rate-limiter/mock_ratelimiter.go
@@ -5,34 +5,35 @@
 package mocks_ratelimiter
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockRateLimiter is a mock of RateLimiter interface
+// MockRateLimiter is a mock of RateLimiter interface.
 type MockRateLimiter struct {
 	ctrl     *gomock.Controller
 	recorder *MockRateLimiterMockRecorder
 }
 
-// MockRateLimiterMockRecorder is the mock recorder for MockRateLimiter
+// MockRateLimiterMockRecorder is the mock recorder for MockRateLimiter.
 type MockRateLimiterMockRecorder struct {
 	mock *MockRateLimiter
 }
 
-// NewMockRateLimiter creates a new mock instance
+// NewMockRateLimiter creates a new mock instance.
 func NewMockRateLimiter(ctrl *gomock.Controller) *MockRateLimiter {
 	mock := &MockRateLimiter{ctrl: ctrl}
 	mock.recorder = &MockRateLimiterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRateLimiter) EXPECT() *MockRateLimiterMockRecorder {
 	return m.recorder
 }
 
-// LimitReached mocks base method
+// LimitReached mocks base method.
 func (m *MockRateLimiter) LimitReached(arg0 string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LimitReached", arg0)
@@ -40,7 +41,7 @@ func (m *MockRateLimiter) LimitReached(arg0 string) bool {
 	return ret0
 }
 
-// LimitReached indicates an expected call of LimitReached
+// LimitReached indicates an expected call of LimitReached.
 func (mr *MockRateLimiterMockRecorder) LimitReached(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LimitReached", reflect.TypeOf((*MockRateLimiter)(nil).LimitReached), arg0)

--- a/mocks/router/mock_network.go
+++ b/mocks/router/mock_network.go
@@ -5,35 +5,36 @@
 package mock_network
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	integrations "github.com/rudderlabs/rudder-server/processor/integrations"
-	reflect "reflect"
 )
 
-// MockNetHandleI is a mock of NetHandleI interface
+// MockNetHandleI is a mock of NetHandleI interface.
 type MockNetHandleI struct {
 	ctrl     *gomock.Controller
 	recorder *MockNetHandleIMockRecorder
 }
 
-// MockNetHandleIMockRecorder is the mock recorder for MockNetHandleI
+// MockNetHandleIMockRecorder is the mock recorder for MockNetHandleI.
 type MockNetHandleIMockRecorder struct {
 	mock *MockNetHandleI
 }
 
-// NewMockNetHandleI creates a new mock instance
+// NewMockNetHandleI creates a new mock instance.
 func NewMockNetHandleI(ctrl *gomock.Controller) *MockNetHandleI {
 	mock := &MockNetHandleI{ctrl: ctrl}
 	mock.recorder = &MockNetHandleIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNetHandleI) EXPECT() *MockNetHandleIMockRecorder {
 	return m.recorder
 }
 
-// SendPost mocks base method
+// SendPost mocks base method.
 func (m *MockNetHandleI) SendPost(arg0 integrations.PostParametersT) (int, string) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendPost", arg0)
@@ -42,7 +43,7 @@ func (m *MockNetHandleI) SendPost(arg0 integrations.PostParametersT) (int, strin
 	return ret0, ret1
 }
 
-// SendPost indicates an expected call of SendPost
+// SendPost indicates an expected call of SendPost.
 func (mr *MockNetHandleIMockRecorder) SendPost(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendPost", reflect.TypeOf((*MockNetHandleI)(nil).SendPost), arg0)

--- a/mocks/router/transformer/mock_transformer.go
+++ b/mocks/router/transformer/mock_transformer.go
@@ -5,47 +5,48 @@
 package mocks_transformer
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/rudderlabs/rudder-server/router/types"
-	reflect "reflect"
 )
 
-// MockTransformer is a mock of Transformer interface
+// MockTransformer is a mock of Transformer interface.
 type MockTransformer struct {
 	ctrl     *gomock.Controller
 	recorder *MockTransformerMockRecorder
 }
 
-// MockTransformerMockRecorder is the mock recorder for MockTransformer
+// MockTransformerMockRecorder is the mock recorder for MockTransformer.
 type MockTransformerMockRecorder struct {
 	mock *MockTransformer
 }
 
-// NewMockTransformer creates a new mock instance
+// NewMockTransformer creates a new mock instance.
 func NewMockTransformer(ctrl *gomock.Controller) *MockTransformer {
 	mock := &MockTransformer{ctrl: ctrl}
 	mock.recorder = &MockTransformerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTransformer) EXPECT() *MockTransformerMockRecorder {
 	return m.recorder
 }
 
-// Setup mocks base method
+// Setup mocks base method.
 func (m *MockTransformer) Setup() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Setup")
 }
 
-// Setup indicates an expected call of Setup
+// Setup indicates an expected call of Setup.
 func (mr *MockTransformerMockRecorder) Setup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setup", reflect.TypeOf((*MockTransformer)(nil).Setup))
 }
 
-// Transform mocks base method
+// Transform mocks base method.
 func (m *MockTransformer) Transform(arg0 string, arg1 *types.TransformMessageT) []types.DestinationJobT {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Transform", arg0, arg1)
@@ -53,7 +54,7 @@ func (m *MockTransformer) Transform(arg0 string, arg1 *types.TransformMessageT) 
 	return ret0
 }
 
-// Transform indicates an expected call of Transform
+// Transform indicates an expected call of Transform.
 func (mr *MockTransformerMockRecorder) Transform(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transform", reflect.TypeOf((*MockTransformer)(nil).Transform), arg0, arg1)

--- a/mocks/services/debugger/uploader.go
+++ b/mocks/services/debugger/uploader.go
@@ -5,34 +5,35 @@
 package mock_debugger
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockTransformer is a mock of Transformer interface
+// MockTransformer is a mock of Transformer interface.
 type MockTransformer struct {
 	ctrl     *gomock.Controller
 	recorder *MockTransformerMockRecorder
 }
 
-// MockTransformerMockRecorder is the mock recorder for MockTransformer
+// MockTransformerMockRecorder is the mock recorder for MockTransformer.
 type MockTransformerMockRecorder struct {
 	mock *MockTransformer
 }
 
-// NewMockTransformer creates a new mock instance
+// NewMockTransformer creates a new mock instance.
 func NewMockTransformer(ctrl *gomock.Controller) *MockTransformer {
 	mock := &MockTransformer{ctrl: ctrl}
 	mock.recorder = &MockTransformerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTransformer) EXPECT() *MockTransformerMockRecorder {
 	return m.recorder
 }
 
-// Transform mocks base method
+// Transform mocks base method.
 func (m *MockTransformer) Transform(arg0 interface{}) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Transform", arg0)
@@ -41,36 +42,36 @@ func (m *MockTransformer) Transform(arg0 interface{}) ([]byte, error) {
 	return ret0, ret1
 }
 
-// Transform indicates an expected call of Transform
+// Transform indicates an expected call of Transform.
 func (mr *MockTransformerMockRecorder) Transform(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transform", reflect.TypeOf((*MockTransformer)(nil).Transform), arg0)
 }
 
-// MockUploaderI is a mock of UploaderI interface
+// MockUploaderI is a mock of UploaderI interface.
 type MockUploaderI struct {
 	ctrl     *gomock.Controller
 	recorder *MockUploaderIMockRecorder
 }
 
-// MockUploaderIMockRecorder is the mock recorder for MockUploaderI
+// MockUploaderIMockRecorder is the mock recorder for MockUploaderI.
 type MockUploaderIMockRecorder struct {
 	mock *MockUploaderI
 }
 
-// NewMockUploaderI creates a new mock instance
+// NewMockUploaderI creates a new mock instance.
 func NewMockUploaderI(ctrl *gomock.Controller) *MockUploaderI {
 	mock := &MockUploaderI{ctrl: ctrl}
 	mock.recorder = &MockUploaderIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUploaderI) EXPECT() *MockUploaderIMockRecorder {
 	return m.recorder
 }
 
-// RecordEvent mocks base method
+// RecordEvent mocks base method.
 func (m *MockUploaderI) RecordEvent(arg0 interface{}) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecordEvent", arg0)
@@ -78,19 +79,19 @@ func (m *MockUploaderI) RecordEvent(arg0 interface{}) bool {
 	return ret0
 }
 
-// RecordEvent indicates an expected call of RecordEvent
+// RecordEvent indicates an expected call of RecordEvent.
 func (mr *MockUploaderIMockRecorder) RecordEvent(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordEvent", reflect.TypeOf((*MockUploaderI)(nil).RecordEvent), arg0)
 }
 
-// Start mocks base method
+// Start mocks base method.
 func (m *MockUploaderI) Start() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Start")
 }
 
-// Start indicates an expected call of Start
+// Start indicates an expected call of Start.
 func (mr *MockUploaderIMockRecorder) Start() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockUploaderI)(nil).Start))

--- a/mocks/services/dedup/mock_dedup.go
+++ b/mocks/services/dedup/mock_dedup.go
@@ -5,34 +5,35 @@
 package mock_dedup
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockDedupI is a mock of DedupI interface
+// MockDedupI is a mock of DedupI interface.
 type MockDedupI struct {
 	ctrl     *gomock.Controller
 	recorder *MockDedupIMockRecorder
 }
 
-// MockDedupIMockRecorder is the mock recorder for MockDedupI
+// MockDedupIMockRecorder is the mock recorder for MockDedupI.
 type MockDedupIMockRecorder struct {
 	mock *MockDedupI
 }
 
-// NewMockDedupI creates a new mock instance
+// NewMockDedupI creates a new mock instance.
 func NewMockDedupI(ctrl *gomock.Controller) *MockDedupI {
 	mock := &MockDedupI{ctrl: ctrl}
 	mock.recorder = &MockDedupIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDedupI) EXPECT() *MockDedupIMockRecorder {
 	return m.recorder
 }
 
-// FindDuplicates mocks base method
+// FindDuplicates mocks base method.
 func (m *MockDedupI) FindDuplicates(arg0 []string, arg1 map[string]struct{}) []int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindDuplicates", arg0, arg1)
@@ -40,31 +41,31 @@ func (m *MockDedupI) FindDuplicates(arg0 []string, arg1 map[string]struct{}) []i
 	return ret0
 }
 
-// FindDuplicates indicates an expected call of FindDuplicates
+// FindDuplicates indicates an expected call of FindDuplicates.
 func (mr *MockDedupIMockRecorder) FindDuplicates(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDuplicates", reflect.TypeOf((*MockDedupI)(nil).FindDuplicates), arg0, arg1)
 }
 
-// MarkProcessed mocks base method
+// MarkProcessed mocks base method.
 func (m *MockDedupI) MarkProcessed(arg0 []string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "MarkProcessed", arg0)
 }
 
-// MarkProcessed indicates an expected call of MarkProcessed
+// MarkProcessed indicates an expected call of MarkProcessed.
 func (mr *MockDedupIMockRecorder) MarkProcessed(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkProcessed", reflect.TypeOf((*MockDedupI)(nil).MarkProcessed), arg0)
 }
 
-// PrintHistogram mocks base method
+// PrintHistogram mocks base method.
 func (m *MockDedupI) PrintHistogram() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "PrintHistogram")
 }
 
-// PrintHistogram indicates an expected call of PrintHistogram
+// PrintHistogram indicates an expected call of PrintHistogram.
 func (mr *MockDedupIMockRecorder) PrintHistogram() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrintHistogram", reflect.TypeOf((*MockDedupI)(nil).PrintHistogram))

--- a/mocks/services/filemanager/mock_filemanager.go
+++ b/mocks/services/filemanager/mock_filemanager.go
@@ -5,36 +5,37 @@
 package mock_filemanager
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	filemanager "github.com/rudderlabs/rudder-server/services/filemanager"
 	os "os"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	filemanager "github.com/rudderlabs/rudder-server/services/filemanager"
 )
 
-// MockFileManagerFactory is a mock of FileManagerFactory interface
+// MockFileManagerFactory is a mock of FileManagerFactory interface.
 type MockFileManagerFactory struct {
 	ctrl     *gomock.Controller
 	recorder *MockFileManagerFactoryMockRecorder
 }
 
-// MockFileManagerFactoryMockRecorder is the mock recorder for MockFileManagerFactory
+// MockFileManagerFactoryMockRecorder is the mock recorder for MockFileManagerFactory.
 type MockFileManagerFactoryMockRecorder struct {
 	mock *MockFileManagerFactory
 }
 
-// NewMockFileManagerFactory creates a new mock instance
+// NewMockFileManagerFactory creates a new mock instance.
 func NewMockFileManagerFactory(ctrl *gomock.Controller) *MockFileManagerFactory {
 	mock := &MockFileManagerFactory{ctrl: ctrl}
 	mock.recorder = &MockFileManagerFactoryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFileManagerFactory) EXPECT() *MockFileManagerFactoryMockRecorder {
 	return m.recorder
 }
 
-// New mocks base method
+// New mocks base method.
 func (m *MockFileManagerFactory) New(arg0 *filemanager.SettingsT) (filemanager.FileManager, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "New", arg0)
@@ -43,36 +44,36 @@ func (m *MockFileManagerFactory) New(arg0 *filemanager.SettingsT) (filemanager.F
 	return ret0, ret1
 }
 
-// New indicates an expected call of New
+// New indicates an expected call of New.
 func (mr *MockFileManagerFactoryMockRecorder) New(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "New", reflect.TypeOf((*MockFileManagerFactory)(nil).New), arg0)
 }
 
-// MockFileManager is a mock of FileManager interface
+// MockFileManager is a mock of FileManager interface.
 type MockFileManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockFileManagerMockRecorder
 }
 
-// MockFileManagerMockRecorder is the mock recorder for MockFileManager
+// MockFileManagerMockRecorder is the mock recorder for MockFileManager.
 type MockFileManagerMockRecorder struct {
 	mock *MockFileManager
 }
 
-// NewMockFileManager creates a new mock instance
+// NewMockFileManager creates a new mock instance.
 func NewMockFileManager(ctrl *gomock.Controller) *MockFileManager {
 	mock := &MockFileManager{ctrl: ctrl}
 	mock.recorder = &MockFileManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFileManager) EXPECT() *MockFileManagerMockRecorder {
 	return m.recorder
 }
 
-// DeleteObjects mocks base method
+// DeleteObjects mocks base method.
 func (m *MockFileManager) DeleteObjects(arg0 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteObjects", arg0)
@@ -80,13 +81,13 @@ func (m *MockFileManager) DeleteObjects(arg0 []string) error {
 	return ret0
 }
 
-// DeleteObjects indicates an expected call of DeleteObjects
+// DeleteObjects indicates an expected call of DeleteObjects.
 func (mr *MockFileManagerMockRecorder) DeleteObjects(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObjects", reflect.TypeOf((*MockFileManager)(nil).DeleteObjects), arg0)
 }
 
-// Download mocks base method
+// Download mocks base method.
 func (m *MockFileManager) Download(arg0 *os.File, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Download", arg0, arg1)
@@ -94,13 +95,13 @@ func (m *MockFileManager) Download(arg0 *os.File, arg1 string) error {
 	return ret0
 }
 
-// Download indicates an expected call of Download
+// Download indicates an expected call of Download.
 func (mr *MockFileManagerMockRecorder) Download(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*MockFileManager)(nil).Download), arg0, arg1)
 }
 
-// GetConfiguredPrefix mocks base method
+// GetConfiguredPrefix mocks base method.
 func (m *MockFileManager) GetConfiguredPrefix() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConfiguredPrefix")
@@ -108,13 +109,13 @@ func (m *MockFileManager) GetConfiguredPrefix() string {
 	return ret0
 }
 
-// GetConfiguredPrefix indicates an expected call of GetConfiguredPrefix
+// GetConfiguredPrefix indicates an expected call of GetConfiguredPrefix.
 func (mr *MockFileManagerMockRecorder) GetConfiguredPrefix() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfiguredPrefix", reflect.TypeOf((*MockFileManager)(nil).GetConfiguredPrefix))
 }
 
-// GetDownloadKeyFromFileLocation mocks base method
+// GetDownloadKeyFromFileLocation mocks base method.
 func (m *MockFileManager) GetDownloadKeyFromFileLocation(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownloadKeyFromFileLocation", arg0)
@@ -122,13 +123,13 @@ func (m *MockFileManager) GetDownloadKeyFromFileLocation(arg0 string) string {
 	return ret0
 }
 
-// GetDownloadKeyFromFileLocation indicates an expected call of GetDownloadKeyFromFileLocation
+// GetDownloadKeyFromFileLocation indicates an expected call of GetDownloadKeyFromFileLocation.
 func (mr *MockFileManagerMockRecorder) GetDownloadKeyFromFileLocation(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadKeyFromFileLocation", reflect.TypeOf((*MockFileManager)(nil).GetDownloadKeyFromFileLocation), arg0)
 }
 
-// GetObjectNameFromLocation mocks base method
+// GetObjectNameFromLocation mocks base method.
 func (m *MockFileManager) GetObjectNameFromLocation(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetObjectNameFromLocation", arg0)
@@ -137,13 +138,13 @@ func (m *MockFileManager) GetObjectNameFromLocation(arg0 string) (string, error)
 	return ret0, ret1
 }
 
-// GetObjectNameFromLocation indicates an expected call of GetObjectNameFromLocation
+// GetObjectNameFromLocation indicates an expected call of GetObjectNameFromLocation.
 func (mr *MockFileManagerMockRecorder) GetObjectNameFromLocation(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectNameFromLocation", reflect.TypeOf((*MockFileManager)(nil).GetObjectNameFromLocation), arg0)
 }
 
-// ListFilesWithPrefix mocks base method
+// ListFilesWithPrefix mocks base method.
 func (m *MockFileManager) ListFilesWithPrefix(arg0 string, arg1 int64) ([]*filemanager.FileObject, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListFilesWithPrefix", arg0, arg1)
@@ -152,13 +153,13 @@ func (m *MockFileManager) ListFilesWithPrefix(arg0 string, arg1 int64) ([]*filem
 	return ret0, ret1
 }
 
-// ListFilesWithPrefix indicates an expected call of ListFilesWithPrefix
+// ListFilesWithPrefix indicates an expected call of ListFilesWithPrefix.
 func (mr *MockFileManagerMockRecorder) ListFilesWithPrefix(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFilesWithPrefix", reflect.TypeOf((*MockFileManager)(nil).ListFilesWithPrefix), arg0, arg1)
 }
 
-// Upload mocks base method
+// Upload mocks base method.
 func (m *MockFileManager) Upload(arg0 *os.File, arg1 ...string) (filemanager.UploadOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -171,7 +172,7 @@ func (m *MockFileManager) Upload(arg0 *os.File, arg1 ...string) (filemanager.Upl
 	return ret0, ret1
 }
 
-// Upload indicates an expected call of Upload
+// Upload indicates an expected call of Upload.
 func (mr *MockFileManagerMockRecorder) Upload(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)

--- a/mocks/utils/logger/mock_logger.go
+++ b/mocks/utils/logger/mock_logger.go
@@ -5,36 +5,37 @@
 package mock_logger
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	logger "github.com/rudderlabs/rudder-server/utils/logger"
 	http "net/http"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	logger "github.com/rudderlabs/rudder-server/utils/logger"
 )
 
-// MockLoggerI is a mock of LoggerI interface
+// MockLoggerI is a mock of LoggerI interface.
 type MockLoggerI struct {
 	ctrl     *gomock.Controller
 	recorder *MockLoggerIMockRecorder
 }
 
-// MockLoggerIMockRecorder is the mock recorder for MockLoggerI
+// MockLoggerIMockRecorder is the mock recorder for MockLoggerI.
 type MockLoggerIMockRecorder struct {
 	mock *MockLoggerI
 }
 
-// NewMockLoggerI creates a new mock instance
+// NewMockLoggerI creates a new mock instance.
 func NewMockLoggerI(ctrl *gomock.Controller) *MockLoggerI {
 	mock := &MockLoggerI{ctrl: ctrl}
 	mock.recorder = &MockLoggerIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLoggerI) EXPECT() *MockLoggerIMockRecorder {
 	return m.recorder
 }
 
-// Child mocks base method
+// Child mocks base method.
 func (m *MockLoggerI) Child(arg0 string) logger.LoggerI {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Child", arg0)
@@ -42,13 +43,13 @@ func (m *MockLoggerI) Child(arg0 string) logger.LoggerI {
 	return ret0
 }
 
-// Child indicates an expected call of Child
+// Child indicates an expected call of Child.
 func (mr *MockLoggerIMockRecorder) Child(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Child", reflect.TypeOf((*MockLoggerI)(nil).Child), arg0)
 }
 
-// Debug mocks base method
+// Debug mocks base method.
 func (m *MockLoggerI) Debug(arg0 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -58,13 +59,13 @@ func (m *MockLoggerI) Debug(arg0 ...interface{}) {
 	m.ctrl.Call(m, "Debug", varargs...)
 }
 
-// Debug indicates an expected call of Debug
+// Debug indicates an expected call of Debug.
 func (mr *MockLoggerIMockRecorder) Debug(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debug", reflect.TypeOf((*MockLoggerI)(nil).Debug), arg0...)
 }
 
-// Debugf mocks base method
+// Debugf mocks base method.
 func (m *MockLoggerI) Debugf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -74,14 +75,14 @@ func (m *MockLoggerI) Debugf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Debugf", varargs...)
 }
 
-// Debugf indicates an expected call of Debugf
+// Debugf indicates an expected call of Debugf.
 func (mr *MockLoggerIMockRecorder) Debugf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debugf", reflect.TypeOf((*MockLoggerI)(nil).Debugf), varargs...)
 }
 
-// Error mocks base method
+// Error mocks base method.
 func (m *MockLoggerI) Error(arg0 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -91,13 +92,13 @@ func (m *MockLoggerI) Error(arg0 ...interface{}) {
 	m.ctrl.Call(m, "Error", varargs...)
 }
 
-// Error indicates an expected call of Error
+// Error indicates an expected call of Error.
 func (mr *MockLoggerIMockRecorder) Error(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockLoggerI)(nil).Error), arg0...)
 }
 
-// Errorf mocks base method
+// Errorf mocks base method.
 func (m *MockLoggerI) Errorf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -107,14 +108,14 @@ func (m *MockLoggerI) Errorf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Errorf", varargs...)
 }
 
-// Errorf indicates an expected call of Errorf
+// Errorf indicates an expected call of Errorf.
 func (mr *MockLoggerIMockRecorder) Errorf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Errorf", reflect.TypeOf((*MockLoggerI)(nil).Errorf), varargs...)
 }
 
-// Fatal mocks base method
+// Fatal mocks base method.
 func (m *MockLoggerI) Fatal(arg0 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -124,13 +125,13 @@ func (m *MockLoggerI) Fatal(arg0 ...interface{}) {
 	m.ctrl.Call(m, "Fatal", varargs...)
 }
 
-// Fatal indicates an expected call of Fatal
+// Fatal indicates an expected call of Fatal.
 func (mr *MockLoggerIMockRecorder) Fatal(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fatal", reflect.TypeOf((*MockLoggerI)(nil).Fatal), arg0...)
 }
 
-// Fatalf mocks base method
+// Fatalf mocks base method.
 func (m *MockLoggerI) Fatalf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -140,14 +141,14 @@ func (m *MockLoggerI) Fatalf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Fatalf", varargs...)
 }
 
-// Fatalf indicates an expected call of Fatalf
+// Fatalf indicates an expected call of Fatalf.
 func (mr *MockLoggerIMockRecorder) Fatalf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fatalf", reflect.TypeOf((*MockLoggerI)(nil).Fatalf), varargs...)
 }
 
-// Info mocks base method
+// Info mocks base method.
 func (m *MockLoggerI) Info(arg0 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -157,13 +158,13 @@ func (m *MockLoggerI) Info(arg0 ...interface{}) {
 	m.ctrl.Call(m, "Info", varargs...)
 }
 
-// Info indicates an expected call of Info
+// Info indicates an expected call of Info.
 func (mr *MockLoggerIMockRecorder) Info(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockLoggerI)(nil).Info), arg0...)
 }
 
-// Infof mocks base method
+// Infof mocks base method.
 func (m *MockLoggerI) Infof(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -173,14 +174,14 @@ func (m *MockLoggerI) Infof(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Infof", varargs...)
 }
 
-// Infof indicates an expected call of Infof
+// Infof indicates an expected call of Infof.
 func (mr *MockLoggerIMockRecorder) Infof(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Infof", reflect.TypeOf((*MockLoggerI)(nil).Infof), varargs...)
 }
 
-// IsDebugLevel mocks base method
+// IsDebugLevel mocks base method.
 func (m *MockLoggerI) IsDebugLevel() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsDebugLevel")
@@ -188,25 +189,25 @@ func (m *MockLoggerI) IsDebugLevel() bool {
 	return ret0
 }
 
-// IsDebugLevel indicates an expected call of IsDebugLevel
+// IsDebugLevel indicates an expected call of IsDebugLevel.
 func (mr *MockLoggerIMockRecorder) IsDebugLevel() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDebugLevel", reflect.TypeOf((*MockLoggerI)(nil).IsDebugLevel))
 }
 
-// LogRequest mocks base method
+// LogRequest mocks base method.
 func (m *MockLoggerI) LogRequest(arg0 *http.Request) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "LogRequest", arg0)
 }
 
-// LogRequest indicates an expected call of LogRequest
+// LogRequest indicates an expected call of LogRequest.
 func (mr *MockLoggerIMockRecorder) LogRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogRequest", reflect.TypeOf((*MockLoggerI)(nil).LogRequest), arg0)
 }
 
-// Warn mocks base method
+// Warn mocks base method.
 func (m *MockLoggerI) Warn(arg0 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -216,13 +217,13 @@ func (m *MockLoggerI) Warn(arg0 ...interface{}) {
 	m.ctrl.Call(m, "Warn", varargs...)
 }
 
-// Warn indicates an expected call of Warn
+// Warn indicates an expected call of Warn.
 func (mr *MockLoggerIMockRecorder) Warn(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Warn", reflect.TypeOf((*MockLoggerI)(nil).Warn), arg0...)
 }
 
-// Warnf mocks base method
+// Warnf mocks base method.
 func (m *MockLoggerI) Warnf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -232,7 +233,7 @@ func (m *MockLoggerI) Warnf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Warnf", varargs...)
 }
 
-// Warnf indicates an expected call of Warnf
+// Warnf indicates an expected call of Warnf.
 func (mr *MockLoggerIMockRecorder) Warnf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)

--- a/mocks/utils/mock_pubsub.go
+++ b/mocks/utils/mock_pubsub.go
@@ -5,65 +5,66 @@
 package utils
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	utils "github.com/rudderlabs/rudder-server/utils"
-	reflect "reflect"
 )
 
-// MockPublishSubscriber is a mock of PublishSubscriber interface
+// MockPublishSubscriber is a mock of PublishSubscriber interface.
 type MockPublishSubscriber struct {
 	ctrl     *gomock.Controller
 	recorder *MockPublishSubscriberMockRecorder
 }
 
-// MockPublishSubscriberMockRecorder is the mock recorder for MockPublishSubscriber
+// MockPublishSubscriberMockRecorder is the mock recorder for MockPublishSubscriber.
 type MockPublishSubscriberMockRecorder struct {
 	mock *MockPublishSubscriber
 }
 
-// NewMockPublishSubscriber creates a new mock instance
+// NewMockPublishSubscriber creates a new mock instance.
 func NewMockPublishSubscriber(ctrl *gomock.Controller) *MockPublishSubscriber {
 	mock := &MockPublishSubscriber{ctrl: ctrl}
 	mock.recorder = &MockPublishSubscriberMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPublishSubscriber) EXPECT() *MockPublishSubscriberMockRecorder {
 	return m.recorder
 }
 
-// Publish mocks base method
+// Publish mocks base method.
 func (m *MockPublishSubscriber) Publish(arg0 string, arg1 interface{}) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Publish", arg0, arg1)
 }
 
-// Publish indicates an expected call of Publish
+// Publish indicates an expected call of Publish.
 func (mr *MockPublishSubscriberMockRecorder) Publish(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Publish", reflect.TypeOf((*MockPublishSubscriber)(nil).Publish), arg0, arg1)
 }
 
-// PublishToChannel mocks base method
+// PublishToChannel mocks base method.
 func (m *MockPublishSubscriber) PublishToChannel(arg0 utils.DataChannel, arg1 string, arg2 interface{}) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "PublishToChannel", arg0, arg1, arg2)
 }
 
-// PublishToChannel indicates an expected call of PublishToChannel
+// PublishToChannel indicates an expected call of PublishToChannel.
 func (mr *MockPublishSubscriberMockRecorder) PublishToChannel(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishToChannel", reflect.TypeOf((*MockPublishSubscriber)(nil).PublishToChannel), arg0, arg1, arg2)
 }
 
-// Subscribe mocks base method
+// Subscribe mocks base method.
 func (m *MockPublishSubscriber) Subscribe(arg0 string, arg1 utils.DataChannel) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Subscribe", arg0, arg1)
 }
 
-// Subscribe indicates an expected call of Subscribe
+// Subscribe indicates an expected call of Subscribe.
 func (mr *MockPublishSubscriberMockRecorder) Subscribe(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockPublishSubscriber)(nil).Subscribe), arg0, arg1)

--- a/mocks/utils/sysUtils/mock_archive.go
+++ b/mocks/utils/sysUtils/mock_archive.go
@@ -6,37 +6,38 @@ package mock_sysUtils
 
 import (
 	zip "archive/zip"
-	gomock "github.com/golang/mock/gomock"
 	io "io"
-	os "os"
+	fs "io/fs"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockZipI is a mock of ZipI interface
+// MockZipI is a mock of ZipI interface.
 type MockZipI struct {
 	ctrl     *gomock.Controller
 	recorder *MockZipIMockRecorder
 }
 
-// MockZipIMockRecorder is the mock recorder for MockZipI
+// MockZipIMockRecorder is the mock recorder for MockZipI.
 type MockZipIMockRecorder struct {
 	mock *MockZipI
 }
 
-// NewMockZipI creates a new mock instance
+// NewMockZipI creates a new mock instance.
 func NewMockZipI(ctrl *gomock.Controller) *MockZipI {
 	mock := &MockZipI{ctrl: ctrl}
 	mock.recorder = &MockZipIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockZipI) EXPECT() *MockZipIMockRecorder {
 	return m.recorder
 }
 
-// FileInfoHeader mocks base method
-func (m *MockZipI) FileInfoHeader(arg0 os.FileInfo) (*zip.FileHeader, error) {
+// FileInfoHeader mocks base method.
+func (m *MockZipI) FileInfoHeader(arg0 fs.FileInfo) (*zip.FileHeader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FileInfoHeader", arg0)
 	ret0, _ := ret[0].(*zip.FileHeader)
@@ -44,13 +45,13 @@ func (m *MockZipI) FileInfoHeader(arg0 os.FileInfo) (*zip.FileHeader, error) {
 	return ret0, ret1
 }
 
-// FileInfoHeader indicates an expected call of FileInfoHeader
+// FileInfoHeader indicates an expected call of FileInfoHeader.
 func (mr *MockZipIMockRecorder) FileInfoHeader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileInfoHeader", reflect.TypeOf((*MockZipI)(nil).FileInfoHeader), arg0)
 }
 
-// NewWriter mocks base method
+// NewWriter mocks base method.
 func (m *MockZipI) NewWriter(arg0 io.Writer) *zip.Writer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewWriter", arg0)
@@ -58,13 +59,13 @@ func (m *MockZipI) NewWriter(arg0 io.Writer) *zip.Writer {
 	return ret0
 }
 
-// NewWriter indicates an expected call of NewWriter
+// NewWriter indicates an expected call of NewWriter.
 func (mr *MockZipIMockRecorder) NewWriter(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewWriter", reflect.TypeOf((*MockZipI)(nil).NewWriter), arg0)
 }
 
-// OpenReader mocks base method
+// OpenReader mocks base method.
 func (m *MockZipI) OpenReader(arg0 string) (*zip.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenReader", arg0)
@@ -73,7 +74,7 @@ func (m *MockZipI) OpenReader(arg0 string) (*zip.ReadCloser, error) {
 	return ret0, ret1
 }
 
-// OpenReader indicates an expected call of OpenReader
+// OpenReader indicates an expected call of OpenReader.
 func (mr *MockZipIMockRecorder) OpenReader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenReader", reflect.TypeOf((*MockZipI)(nil).OpenReader), arg0)

--- a/mocks/utils/sysUtils/mock_compress.go
+++ b/mocks/utils/sysUtils/mock_compress.go
@@ -6,35 +6,36 @@ package mock_sysUtils
 
 import (
 	gzip "compress/gzip"
-	gomock "github.com/golang/mock/gomock"
 	io "io"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockGZipI is a mock of GZipI interface
+// MockGZipI is a mock of GZipI interface.
 type MockGZipI struct {
 	ctrl     *gomock.Controller
 	recorder *MockGZipIMockRecorder
 }
 
-// MockGZipIMockRecorder is the mock recorder for MockGZipI
+// MockGZipIMockRecorder is the mock recorder for MockGZipI.
 type MockGZipIMockRecorder struct {
 	mock *MockGZipI
 }
 
-// NewMockGZipI creates a new mock instance
+// NewMockGZipI creates a new mock instance.
 func NewMockGZipI(ctrl *gomock.Controller) *MockGZipI {
 	mock := &MockGZipI{ctrl: ctrl}
 	mock.recorder = &MockGZipIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGZipI) EXPECT() *MockGZipIMockRecorder {
 	return m.recorder
 }
 
-// NewReader mocks base method
+// NewReader mocks base method.
 func (m *MockGZipI) NewReader(arg0 io.Reader) (*gzip.Reader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewReader", arg0)
@@ -43,13 +44,13 @@ func (m *MockGZipI) NewReader(arg0 io.Reader) (*gzip.Reader, error) {
 	return ret0, ret1
 }
 
-// NewReader indicates an expected call of NewReader
+// NewReader indicates an expected call of NewReader.
 func (mr *MockGZipIMockRecorder) NewReader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReader", reflect.TypeOf((*MockGZipI)(nil).NewReader), arg0)
 }
 
-// NewWriter mocks base method
+// NewWriter mocks base method.
 func (m *MockGZipI) NewWriter(arg0 io.Writer) *gzip.Writer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewWriter", arg0)
@@ -57,7 +58,7 @@ func (m *MockGZipI) NewWriter(arg0 io.Writer) *gzip.Writer {
 	return ret0
 }
 
-// NewWriter indicates an expected call of NewWriter
+// NewWriter indicates an expected call of NewWriter.
 func (mr *MockGZipIMockRecorder) NewWriter(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewWriter", reflect.TypeOf((*MockGZipI)(nil).NewWriter), arg0)

--- a/mocks/utils/sysUtils/mock_http.go
+++ b/mocks/utils/sysUtils/mock_http.go
@@ -5,36 +5,37 @@
 package mock_sysUtils
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	io "io"
 	http "net/http"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockHttpI is a mock of HttpI interface
+// MockHttpI is a mock of HttpI interface.
 type MockHttpI struct {
 	ctrl     *gomock.Controller
 	recorder *MockHttpIMockRecorder
 }
 
-// MockHttpIMockRecorder is the mock recorder for MockHttpI
+// MockHttpIMockRecorder is the mock recorder for MockHttpI.
 type MockHttpIMockRecorder struct {
 	mock *MockHttpI
 }
 
-// NewMockHttpI creates a new mock instance
+// NewMockHttpI creates a new mock instance.
 func NewMockHttpI(ctrl *gomock.Controller) *MockHttpI {
 	mock := &MockHttpI{ctrl: ctrl}
 	mock.recorder = &MockHttpIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHttpI) EXPECT() *MockHttpIMockRecorder {
 	return m.recorder
 }
 
-// NewRequest mocks base method
+// NewRequest mocks base method.
 func (m *MockHttpI) NewRequest(arg0, arg1 string, arg2 io.Reader) (*http.Request, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewRequest", arg0, arg1, arg2)
@@ -43,7 +44,7 @@ func (m *MockHttpI) NewRequest(arg0, arg1 string, arg2 io.Reader) (*http.Request
 	return ret0, ret1
 }
 
-// NewRequest indicates an expected call of NewRequest
+// NewRequest indicates an expected call of NewRequest.
 func (mr *MockHttpIMockRecorder) NewRequest(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRequest", reflect.TypeOf((*MockHttpI)(nil).NewRequest), arg0, arg1, arg2)

--- a/mocks/utils/sysUtils/mock_httpclient.go
+++ b/mocks/utils/sysUtils/mock_httpclient.go
@@ -5,35 +5,36 @@
 package mock_sysUtils
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	http "net/http"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockHTTPClientI is a mock of HTTPClientI interface
+// MockHTTPClientI is a mock of HTTPClientI interface.
 type MockHTTPClientI struct {
 	ctrl     *gomock.Controller
 	recorder *MockHTTPClientIMockRecorder
 }
 
-// MockHTTPClientIMockRecorder is the mock recorder for MockHTTPClientI
+// MockHTTPClientIMockRecorder is the mock recorder for MockHTTPClientI.
 type MockHTTPClientIMockRecorder struct {
 	mock *MockHTTPClientI
 }
 
-// NewMockHTTPClientI creates a new mock instance
+// NewMockHTTPClientI creates a new mock instance.
 func NewMockHTTPClientI(ctrl *gomock.Controller) *MockHTTPClientI {
 	mock := &MockHTTPClientI{ctrl: ctrl}
 	mock.recorder = &MockHTTPClientIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHTTPClientI) EXPECT() *MockHTTPClientIMockRecorder {
 	return m.recorder
 }
 
-// Do mocks base method
+// Do mocks base method.
 func (m *MockHTTPClientI) Do(arg0 *http.Request) (*http.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Do", arg0)
@@ -42,7 +43,7 @@ func (m *MockHTTPClientI) Do(arg0 *http.Request) (*http.Response, error) {
 	return ret0, ret1
 }
 
-// Do indicates an expected call of Do
+// Do indicates an expected call of Do.
 func (mr *MockHTTPClientIMockRecorder) Do(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Do", reflect.TypeOf((*MockHTTPClientI)(nil).Do), arg0)

--- a/mocks/utils/sysUtils/mock_io.go
+++ b/mocks/utils/sysUtils/mock_io.go
@@ -5,36 +5,37 @@
 package mock_sysUtils
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	io "io"
-	os "os"
+	fs "io/fs"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockIoI is a mock of IoI interface
+// MockIoI is a mock of IoI interface.
 type MockIoI struct {
 	ctrl     *gomock.Controller
 	recorder *MockIoIMockRecorder
 }
 
-// MockIoIMockRecorder is the mock recorder for MockIoI
+// MockIoIMockRecorder is the mock recorder for MockIoI.
 type MockIoIMockRecorder struct {
 	mock *MockIoI
 }
 
-// NewMockIoI creates a new mock instance
+// NewMockIoI creates a new mock instance.
 func NewMockIoI(ctrl *gomock.Controller) *MockIoI {
 	mock := &MockIoI{ctrl: ctrl}
 	mock.recorder = &MockIoIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockIoI) EXPECT() *MockIoIMockRecorder {
 	return m.recorder
 }
 
-// Copy mocks base method
+// Copy mocks base method.
 func (m *MockIoI) Copy(arg0 io.Writer, arg1 io.Reader) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Copy", arg0, arg1)
@@ -43,36 +44,36 @@ func (m *MockIoI) Copy(arg0 io.Writer, arg1 io.Reader) (int64, error) {
 	return ret0, ret1
 }
 
-// Copy indicates an expected call of Copy
+// Copy indicates an expected call of Copy.
 func (mr *MockIoIMockRecorder) Copy(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Copy", reflect.TypeOf((*MockIoI)(nil).Copy), arg0, arg1)
 }
 
-// MockIoUtilI is a mock of IoUtilI interface
+// MockIoUtilI is a mock of IoUtilI interface.
 type MockIoUtilI struct {
 	ctrl     *gomock.Controller
 	recorder *MockIoUtilIMockRecorder
 }
 
-// MockIoUtilIMockRecorder is the mock recorder for MockIoUtilI
+// MockIoUtilIMockRecorder is the mock recorder for MockIoUtilI.
 type MockIoUtilIMockRecorder struct {
 	mock *MockIoUtilI
 }
 
-// NewMockIoUtilI creates a new mock instance
+// NewMockIoUtilI creates a new mock instance.
 func NewMockIoUtilI(ctrl *gomock.Controller) *MockIoUtilI {
 	mock := &MockIoUtilI{ctrl: ctrl}
 	mock.recorder = &MockIoUtilIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockIoUtilI) EXPECT() *MockIoUtilIMockRecorder {
 	return m.recorder
 }
 
-// NopCloser mocks base method
+// NopCloser mocks base method.
 func (m *MockIoUtilI) NopCloser(arg0 io.Reader) io.ReadCloser {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NopCloser", arg0)
@@ -80,13 +81,13 @@ func (m *MockIoUtilI) NopCloser(arg0 io.Reader) io.ReadCloser {
 	return ret0
 }
 
-// NopCloser indicates an expected call of NopCloser
+// NopCloser indicates an expected call of NopCloser.
 func (mr *MockIoUtilIMockRecorder) NopCloser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NopCloser", reflect.TypeOf((*MockIoUtilI)(nil).NopCloser), arg0)
 }
 
-// ReadAll mocks base method
+// ReadAll mocks base method.
 func (m *MockIoUtilI) ReadAll(arg0 io.Reader) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadAll", arg0)
@@ -95,13 +96,13 @@ func (m *MockIoUtilI) ReadAll(arg0 io.Reader) ([]byte, error) {
 	return ret0, ret1
 }
 
-// ReadAll indicates an expected call of ReadAll
+// ReadAll indicates an expected call of ReadAll.
 func (mr *MockIoUtilIMockRecorder) ReadAll(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAll", reflect.TypeOf((*MockIoUtilI)(nil).ReadAll), arg0)
 }
 
-// ReadFile mocks base method
+// ReadFile mocks base method.
 func (m *MockIoUtilI) ReadFile(arg0 string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadFile", arg0)
@@ -110,21 +111,21 @@ func (m *MockIoUtilI) ReadFile(arg0 string) ([]byte, error) {
 	return ret0, ret1
 }
 
-// ReadFile indicates an expected call of ReadFile
+// ReadFile indicates an expected call of ReadFile.
 func (mr *MockIoUtilIMockRecorder) ReadFile(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockIoUtilI)(nil).ReadFile), arg0)
 }
 
-// WriteFile mocks base method
-func (m *MockIoUtilI) WriteFile(arg0 string, arg1 []byte, arg2 os.FileMode) error {
+// WriteFile mocks base method.
+func (m *MockIoUtilI) WriteFile(arg0 string, arg1 []byte, arg2 fs.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteFile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// WriteFile indicates an expected call of WriteFile
+// WriteFile indicates an expected call of WriteFile.
 func (mr *MockIoUtilIMockRecorder) WriteFile(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockIoUtilI)(nil).WriteFile), arg0, arg1, arg2)

--- a/mocks/utils/sysUtils/mock_os.go
+++ b/mocks/utils/sysUtils/mock_os.go
@@ -5,35 +5,37 @@
 package mock_sysUtils
 
 import (
-	gomock "github.com/golang/mock/gomock"
+	fs "io/fs"
 	os "os"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockOsI is a mock of OsI interface
+// MockOsI is a mock of OsI interface.
 type MockOsI struct {
 	ctrl     *gomock.Controller
 	recorder *MockOsIMockRecorder
 }
 
-// MockOsIMockRecorder is the mock recorder for MockOsI
+// MockOsIMockRecorder is the mock recorder for MockOsI.
 type MockOsIMockRecorder struct {
 	mock *MockOsI
 }
 
-// NewMockOsI creates a new mock instance
+// NewMockOsI creates a new mock instance.
 func NewMockOsI(ctrl *gomock.Controller) *MockOsI {
 	mock := &MockOsI{ctrl: ctrl}
 	mock.recorder = &MockOsIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockOsI) EXPECT() *MockOsIMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method
+// Create mocks base method.
 func (m *MockOsI) Create(arg0 string) (*os.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0)
@@ -42,13 +44,13 @@ func (m *MockOsI) Create(arg0 string) (*os.File, error) {
 	return ret0, ret1
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockOsIMockRecorder) Create(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockOsI)(nil).Create), arg0)
 }
 
-// Getenv mocks base method
+// Getenv mocks base method.
 func (m *MockOsI) Getenv(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Getenv", arg0)
@@ -56,13 +58,13 @@ func (m *MockOsI) Getenv(arg0 string) string {
 	return ret0
 }
 
-// Getenv indicates an expected call of Getenv
+// Getenv indicates an expected call of Getenv.
 func (mr *MockOsIMockRecorder) Getenv(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Getenv", reflect.TypeOf((*MockOsI)(nil).Getenv), arg0)
 }
 
-// IsNotExist mocks base method
+// IsNotExist mocks base method.
 func (m *MockOsI) IsNotExist(arg0 error) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsNotExist", arg0)
@@ -70,13 +72,13 @@ func (m *MockOsI) IsNotExist(arg0 error) bool {
 	return ret0
 }
 
-// IsNotExist indicates an expected call of IsNotExist
+// IsNotExist indicates an expected call of IsNotExist.
 func (mr *MockOsIMockRecorder) IsNotExist(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNotExist", reflect.TypeOf((*MockOsI)(nil).IsNotExist), arg0)
 }
 
-// LookupEnv mocks base method
+// LookupEnv mocks base method.
 func (m *MockOsI) LookupEnv(arg0 string) (string, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LookupEnv", arg0)
@@ -85,27 +87,27 @@ func (m *MockOsI) LookupEnv(arg0 string) (string, bool) {
 	return ret0, ret1
 }
 
-// LookupEnv indicates an expected call of LookupEnv
+// LookupEnv indicates an expected call of LookupEnv.
 func (mr *MockOsIMockRecorder) LookupEnv(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupEnv", reflect.TypeOf((*MockOsI)(nil).LookupEnv), arg0)
 }
 
-// MkdirAll mocks base method
-func (m *MockOsI) MkdirAll(arg0 string, arg1 os.FileMode) error {
+// MkdirAll mocks base method.
+func (m *MockOsI) MkdirAll(arg0 string, arg1 fs.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MkdirAll", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// MkdirAll indicates an expected call of MkdirAll
+// MkdirAll indicates an expected call of MkdirAll.
 func (mr *MockOsIMockRecorder) MkdirAll(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockOsI)(nil).MkdirAll), arg0, arg1)
 }
 
-// Open mocks base method
+// Open mocks base method.
 func (m *MockOsI) Open(arg0 string) (*os.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Open", arg0)
@@ -114,14 +116,14 @@ func (m *MockOsI) Open(arg0 string) (*os.File, error) {
 	return ret0, ret1
 }
 
-// Open indicates an expected call of Open
+// Open indicates an expected call of Open.
 func (mr *MockOsIMockRecorder) Open(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockOsI)(nil).Open), arg0)
 }
 
-// OpenFile mocks base method
-func (m *MockOsI) OpenFile(arg0 string, arg1 int, arg2 os.FileMode) (*os.File, error) {
+// OpenFile mocks base method.
+func (m *MockOsI) OpenFile(arg0 string, arg1 int, arg2 fs.FileMode) (*os.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenFile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*os.File)
@@ -129,13 +131,13 @@ func (m *MockOsI) OpenFile(arg0 string, arg1 int, arg2 os.FileMode) (*os.File, e
 	return ret0, ret1
 }
 
-// OpenFile indicates an expected call of OpenFile
+// OpenFile indicates an expected call of OpenFile.
 func (mr *MockOsIMockRecorder) OpenFile(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenFile", reflect.TypeOf((*MockOsI)(nil).OpenFile), arg0, arg1, arg2)
 }
 
-// Remove mocks base method
+// Remove mocks base method.
 func (m *MockOsI) Remove(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove", arg0)
@@ -143,28 +145,28 @@ func (m *MockOsI) Remove(arg0 string) error {
 	return ret0
 }
 
-// Remove indicates an expected call of Remove
+// Remove indicates an expected call of Remove.
 func (mr *MockOsIMockRecorder) Remove(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockOsI)(nil).Remove), arg0)
 }
 
-// Stat mocks base method
-func (m *MockOsI) Stat(arg0 string) (os.FileInfo, error) {
+// Stat mocks base method.
+func (m *MockOsI) Stat(arg0 string) (fs.FileInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat", arg0)
-	ret0, _ := ret[0].(os.FileInfo)
+	ret0, _ := ret[0].(fs.FileInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Stat indicates an expected call of Stat
+// Stat indicates an expected call of Stat.
 func (mr *MockOsIMockRecorder) Stat(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockOsI)(nil).Stat), arg0)
 }
 
-// UserHomeDir mocks base method
+// UserHomeDir mocks base method.
 func (m *MockOsI) UserHomeDir() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UserHomeDir")
@@ -173,7 +175,7 @@ func (m *MockOsI) UserHomeDir() (string, error) {
 	return ret0, ret1
 }
 
-// UserHomeDir indicates an expected call of UserHomeDir
+// UserHomeDir indicates an expected call of UserHomeDir.
 func (mr *MockOsIMockRecorder) UserHomeDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserHomeDir", reflect.TypeOf((*MockOsI)(nil).UserHomeDir))

--- a/mocks/utils/types/mock_types.go
+++ b/mocks/utils/types/mock_types.go
@@ -6,35 +6,36 @@ package mock_types
 
 import (
 	sql "database/sql"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/rudderlabs/rudder-server/utils/types"
-	reflect "reflect"
 )
 
-// MockSuppressUserI is a mock of SuppressUserI interface
+// MockSuppressUserI is a mock of SuppressUserI interface.
 type MockSuppressUserI struct {
 	ctrl     *gomock.Controller
 	recorder *MockSuppressUserIMockRecorder
 }
 
-// MockSuppressUserIMockRecorder is the mock recorder for MockSuppressUserI
+// MockSuppressUserIMockRecorder is the mock recorder for MockSuppressUserI.
 type MockSuppressUserIMockRecorder struct {
 	mock *MockSuppressUserI
 }
 
-// NewMockSuppressUserI creates a new mock instance
+// NewMockSuppressUserI creates a new mock instance.
 func NewMockSuppressUserI(ctrl *gomock.Controller) *MockSuppressUserI {
 	mock := &MockSuppressUserI{ctrl: ctrl}
 	mock.recorder = &MockSuppressUserIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSuppressUserI) EXPECT() *MockSuppressUserIMockRecorder {
 	return m.recorder
 }
 
-// IsSuppressedUser mocks base method
+// IsSuppressedUser mocks base method.
 func (m *MockSuppressUserI) IsSuppressedUser(arg0, arg1, arg2 string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsSuppressedUser", arg0, arg1, arg2)
@@ -42,66 +43,66 @@ func (m *MockSuppressUserI) IsSuppressedUser(arg0, arg1, arg2 string) bool {
 	return ret0
 }
 
-// IsSuppressedUser indicates an expected call of IsSuppressedUser
+// IsSuppressedUser indicates an expected call of IsSuppressedUser.
 func (mr *MockSuppressUserIMockRecorder) IsSuppressedUser(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSuppressedUser", reflect.TypeOf((*MockSuppressUserI)(nil).IsSuppressedUser), arg0, arg1, arg2)
 }
 
-// MockReportingI is a mock of ReportingI interface
+// MockReportingI is a mock of ReportingI interface.
 type MockReportingI struct {
 	ctrl     *gomock.Controller
 	recorder *MockReportingIMockRecorder
 }
 
-// MockReportingIMockRecorder is the mock recorder for MockReportingI
+// MockReportingIMockRecorder is the mock recorder for MockReportingI.
 type MockReportingIMockRecorder struct {
 	mock *MockReportingI
 }
 
-// NewMockReportingI creates a new mock instance
+// NewMockReportingI creates a new mock instance.
 func NewMockReportingI(ctrl *gomock.Controller) *MockReportingI {
 	mock := &MockReportingI{ctrl: ctrl}
 	mock.recorder = &MockReportingIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockReportingI) EXPECT() *MockReportingIMockRecorder {
 	return m.recorder
 }
 
-// AddClient mocks base method
+// AddClient mocks base method.
 func (m *MockReportingI) AddClient(arg0 types.Config) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddClient", arg0)
 }
 
-// AddClient indicates an expected call of AddClient
+// AddClient indicates an expected call of AddClient.
 func (mr *MockReportingIMockRecorder) AddClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddClient", reflect.TypeOf((*MockReportingI)(nil).AddClient), arg0)
 }
 
-// Report mocks base method
+// Report mocks base method.
 func (m *MockReportingI) Report(arg0 []*types.PUReportedMetric, arg1 *sql.Tx) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Report", arg0, arg1)
 }
 
-// Report indicates an expected call of Report
+// Report indicates an expected call of Report.
 func (mr *MockReportingIMockRecorder) Report(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockReportingI)(nil).Report), arg0, arg1)
 }
 
-// WaitForSetup mocks base method
+// WaitForSetup mocks base method.
 func (m *MockReportingI) WaitForSetup(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "WaitForSetup", arg0)
 }
 
-// WaitForSetup indicates an expected call of WaitForSetup
+// WaitForSetup indicates an expected call of WaitForSetup.
 func (mr *MockReportingIMockRecorder) WaitForSetup(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForSetup", reflect.TypeOf((*MockReportingI)(nil).WaitForSetup), arg0)


### PR DESCRIPTION
## Issue

This PR addresses two issues:
1. People forgetting running `go generate` after making changes to a particular interface, or more commonly people forgetting to commit those files.

2. People with different tools version `gomock` in our case, generating mock files with small differences everytime they prepare a PR. For instance, the following changes are only related to gomock version differences.

```diff
diff --git a/mocks/app/mock_app.go b/mocks/app/mock_app.go
index 58bc44b..aaf1a94 100644
--- a/mocks/app/mock_app.go
+++ b/mocks/app/mock_app.go
@@ -5,35 +5,36 @@
 package mock_app
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	app "github.com/rudderlabs/rudder-server/app"
-	reflect "reflect"
 )
 
-// MockInterface is a mock of Interface interface
+// MockInterface is a mock of Interface interface.
 type MockInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockInterfaceMockRecorder
 }
 
```

Both of the issues are not critical but create a lot of noise when working on code or review PRs.

## Solution

In this PR a github action is introduced that enforces files that are generated with a particular version. It does that by install and then running `gomock` at a specific version and ensuring that no file has changed `git diff --exit-code`.

This will force people to either update the versions or commit the missing files.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests for the code
- [x] I have made corresponding changes to the documentation
