### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -610,7 +610,7 @@ func (gateway *HandleT) eventSchemaWebHandler(wrappedFunc func(http.ResponseWrit
 
 func (gateway *HandleT) getPayloadFromRequest(r *http.Request) ([]byte, error) {
 	if r.Body != nil {
-		payload, err := ioutil.ReadAll(r.Body)
+		payload, err := io.ReadAll(r.Body)
 		r.Body.Close()
 		return payload, err
 	}
@@ -868,7 +868,7 @@ func (gateway *HandleT) getWarehousePending(payload []byte) bool {
 	defer resp.Body.Close()
 
 	var whPendingResponse warehouseutils.PendingEventsResponseT
-	respData, err := ioutil.ReadAll(resp.Body)
+	respData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false
 	}
@@ -1108,7 +1108,7 @@ func (gateway *HandleT) setWebPayload(r *http.Request, qp url.Values, reqType st
 		}
 	}
 	// add body to request
-	r.Body = ioutil.NopCloser(bytes.NewReader(body))
+	r.Body = io.NopCloser(bytes.NewReader(body))
 	return nil
 }
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -569,7 +568,7 @@ func expectHandlerResponse(handler http.HandlerFunc, req *http.Request, response
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
 
-		bodyBytes, _ := ioutil.ReadAll(rr.Body)
+		bodyBytes, _ := io.ReadAll(rr.Body)
 		body := string(bodyBytes)
 
 		Expect(rr.Result().StatusCode).To(Equal(responseStatus))

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -3,7 +3,7 @@ package webhook
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -168,7 +168,7 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(jsonByte) != 0 {
-		r.Body = ioutil.NopCloser(bytes.NewReader(jsonByte))
+		r.Body = io.NopCloser(bytes.NewReader(jsonByte))
 		r.Header.Set("Content-Type", "application/json")
 	}
 
@@ -226,7 +226,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 		payloadArr := [][]byte{}
 		webRequests := []*webhookT{}
 		for _, req := range breq.batchRequest {
-			body, err := ioutil.ReadAll(req.request.Body)
+			body, err := io.ReadAll(req.request.Body)
 			req.request.Body.Close()
 
 			if err != nil {
@@ -293,11 +293,11 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 
 func (webhook *HandleT) enqueueInGateway(req *webhookT, payload []byte) {
 	// replace body with transformed event (it comes in a batch format)
-	req.request.Body = ioutil.NopCloser(bytes.NewReader(payload))
+	req.request.Body = io.NopCloser(bytes.NewReader(payload))
 	// set write key in basic auth header
 	req.request.SetBasicAuth(req.writeKey, "")
 	var errorMessage = ""
-	payload, err := ioutil.ReadAll(req.request.Body)
+	payload, err := io.ReadAll(req.request.Body)
 	req.request.Body.Close()
 	if err == nil {
 		errorMessage = webhook.gwHandle.ProcessWebRequest(req.writer, req.request, "batch", payload, req.writeKey)

--- a/gateway/webhook/webhookTransformer.go
+++ b/gateway/webhook/webhookTransformer.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -48,7 +48,7 @@ func (bt *batchWebhookTransformerT) transform(events [][]byte, sourceType string
 		panic(err)
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 
 	if err != nil {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"reflect"
@@ -392,7 +392,7 @@ func (proc *HandleT) getTransformerFeatureJson() {
 				continue
 			}
 			if res.StatusCode == 200 {
-				body, err := ioutil.ReadAll(res.Body)
+				body, err := io.ReadAll(res.Body)
 				if err == nil {
 					proc.transformerFeatures = json.RawMessage(body)
 					res.Body.Close()

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strconv"
@@ -163,7 +163,7 @@ func (trans *HandleT) transformWorker() {
 			if err == nil {
 				//If no err returned by client.Post, reading body.
 				//If reading body fails, retrying.
-				respData, err = ioutil.ReadAll(resp.Body)
+				respData, err = io.ReadAll(resp.Body)
 			}
 
 			if err != nil {
@@ -274,7 +274,7 @@ func GetVersion() (transformerBuildVersion string) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			pkgLogger.Errorf("Unable to read response into bytes with error : %s", err.Error())
 			transformerBuildVersion = "Unable to read response from transformer."

--- a/router/network.go
+++ b/router/network.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -140,7 +139,7 @@ func (network *NetHandleT) SendPost(structData integrations.PostParametersT) (st
 		var respBody []byte
 
 		if resp != nil && resp.Body != nil {
-			respBody, _ = ioutil.ReadAll(resp.Body)
+			respBody, _ = io.ReadAll(resp.Body)
 			network.logger.Debug(postInfo.URL, " : ", req.Proto, " : ", resp.Proto, resp.ProtoMajor, resp.ProtoMinor, resp.ProtoAtLeast)
 			defer resp.Body.Close()
 		}

--- a/router/network_test.go
+++ b/router/network_test.go
@@ -2,7 +2,7 @@ package router
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/golang/mock/gomock"
@@ -78,7 +78,7 @@ var _ = Describe("Network", func() {
 				"full_name": "mock-repo"
    			}]`
 			//New reader with that JSON
-			r := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+			r := io.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 
 			c.mockHTTPClient.EXPECT().Do(gomock.Any()).Times(1).Do(func(req *http.Request) {
 				//asserting http request

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -93,7 +93,7 @@ func (trans *HandleT) Transform(transformType string, transformMessage *types.Tr
 		if err == nil {
 			//If no err returned by client.Post, reading body.
 			//If reading body fails, retrying.
-			respData, err = ioutil.ReadAll(resp.Body)
+			respData, err = io.ReadAll(resp.Body)
 		}
 
 		if err != nil {

--- a/services/alert/pagerduty.go
+++ b/services/alert/pagerduty.go
@@ -3,7 +3,7 @@ package alert
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/rudderlabs/rudder-server/utils/logger"
@@ -39,7 +39,7 @@ func (ops *PagerDuty) Alert(message string) {
 		pkgLogger.Errorf("Alert: Got error response %d", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		pkgLogger.Errorf("Alert: Failed to read response body: %s", err.Error())

--- a/services/alert/victorops.go
+++ b/services/alert/victorops.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -29,7 +29,7 @@ func (ops *VictorOps) Alert(message string) {
 		pkgLogger.Errorf("Alert: Got error response %d", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		pkgLogger.Errorf("Alert: Failed to read response body: %s", err.Error())

--- a/services/db/recovery.go
+++ b/services/db/recovery.go
@@ -3,7 +3,6 @@ package db
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"time"
@@ -52,7 +51,7 @@ func Init() {
 }
 
 func getRecoveryData() RecoveryDataT {
-	data, err := ioutil.ReadFile(storagePath)
+	data, err := os.ReadFile(storagePath)
 	if os.IsNotExist(err) {
 		defaultRecoveryJSON := "{\"mode\":\"" + normalMode + "\"}"
 		data = []byte(defaultRecoveryJSON)
@@ -78,7 +77,7 @@ func saveRecoveryData(recoveryData RecoveryDataT) {
 	if err != nil {
 		panic(err)
 	}
-	err = ioutil.WriteFile(storagePath, recoveryDataJSON, 0644)
+	err = os.WriteFile(storagePath, recoveryDataJSON, 0644)
 	if err != nil {
 		panic(err)
 	}

--- a/services/debugger/uploader_test.go
+++ b/services/debugger/uploader_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -84,7 +84,7 @@ var _ = Describe("Uploader", func() {
 			//Response JSON
 			jsonResponse := `OK`
 			//New reader with that JSON
-			r := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+			r := io.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 
 			mockHTTPClient.EXPECT().Do(gomock.Any()).Do(func(req *http.Request) {
 				//asserting http request
@@ -121,7 +121,7 @@ var _ = Describe("Uploader", func() {
 			//Response JSON
 			jsonResponse := `OK`
 			//New reader with that JSON
-			r := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+			r := io.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 
 			mockHTTPClient.EXPECT().Do(gomock.Any()).Do(func(req *http.Request) {
 				//asserting http request
@@ -204,7 +204,7 @@ var _ = Describe("Uploader", func() {
 			//Response JSON
 			jsonResponse := `OK`
 			//New reader with that JSON
-			r := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+			r := io.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 
 			uploader.(*Uploader).retrySleep = time.Second
 
@@ -245,7 +245,7 @@ var _ = Describe("Uploader", func() {
 			//Response JSON
 			jsonResponse := `OK`
 			//New reader with that JSON
-			r := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+			r := io.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 
 			mockHTTPClient.EXPECT().Do(gomock.Any()).Do(func(req *http.Request) {
 				//asserting http request
@@ -295,7 +295,7 @@ var _ = Describe("Uploader", func() {
 			//Response JSON
 			jsonResponse := `OK`
 			//New reader with that JSON
-			r := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+			r := io.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 
 			mockHTTPClient.EXPECT().Do(gomock.Any()).Do(func(req *http.Request) {
 				//asserting http request

--- a/services/filemanager/filemanager.go
+++ b/services/filemanager/filemanager.go
@@ -4,7 +4,6 @@ package filemanager
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -27,8 +26,8 @@ type FileManagerFactory interface {
 }
 
 type FileObject struct {
-	Key              string
-	LastModified 	 time.Time
+	Key          string
+	LastModified time.Time
 }
 
 // FileManager implements all upload methods
@@ -39,7 +38,7 @@ type FileManager interface {
 	GetDownloadKeyFromFileLocation(location string) string
 	DeleteObjects(locations []string) error
 	ListFilesWithPrefix(prefix string, maxItems int64) (fileObjects []*FileObject, err error)
-	GetConfiguredPrefix() (string)
+	GetConfiguredPrefix() string
 }
 
 // SettingsT sets configuration for FileManager
@@ -98,7 +97,7 @@ func GetProviderConfigFromEnv() map[string]interface{} {
 	case "GCS":
 		providerConfig["bucketName"] = config.GetEnv("JOBS_BACKUP_BUCKET", "")
 		providerConfig["prefix"] = config.GetEnv("JOBS_BACKUP_PREFIX", "")
-		credentials, err := ioutil.ReadFile(config.GetEnv("GOOGLE_APPLICATION_CREDENTIALS", ""))
+		credentials, err := os.ReadFile(config.GetEnv("GOOGLE_APPLICATION_CREDENTIALS", ""))
 		if err == nil {
 			providerConfig["credentials"] = string(credentials)
 		}

--- a/services/sql-migrator/migrator.go
+++ b/services/sql-migrator/migrator.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -112,7 +112,7 @@ func (m *Migrator) MigrateFromTemplates(templatesDir string, context interface{}
 				return nil, fmt.Errorf("Could not open migration template '%v': '%w'", path, err)
 			}
 
-			templateData, err := ioutil.ReadAll(file)
+			templateData, err := io.ReadAll(file)
 			if err != nil {
 				return nil, fmt.Errorf("Could not read migration template '%v': %w", name, err)
 			}

--- a/tests/helpers/helpers.go
+++ b/tests/helpers/helpers.go
@@ -5,17 +5,18 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
 
+	"reflect"
+
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	uuid "github.com/satori/go.uuid"
 	"github.com/segmentio/ksuid"
 	"github.com/tidwall/sjson"
-	"reflect"
 )
 
 const (
@@ -302,7 +303,7 @@ func SendHealthRequest() []byte {
 		panic(err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(err)
 	}
@@ -316,7 +317,7 @@ func SendVersionRequest() []byte {
 		panic(err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/tests/load/correctness.go
+++ b/tests/load/correctness.go
@@ -14,7 +14,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"math/rand"
 	"net/http"
@@ -237,7 +237,7 @@ func generateRandomData(payload *[]byte, path string, value interface{}) ([]byte
 }
 
 func generateEvents(userID string, eventDelay int) {
-	var fileData, err = ioutil.ReadFile("batchEvent.json")
+	var fileData, err = os.ReadFile("batchEvent.json")
 	if err != nil {
 		panic(err)
 	}
@@ -283,7 +283,7 @@ func sendToRudderGateway(jsonPayload []byte) bool {
 	}
 	defer resp.Body.Close()
 
-	ioutil.ReadAll(resp.Body)
+	io.ReadAll(resp.Body)
 	if resp.StatusCode == 200 {
 		atomic.AddUint64(&successCount, 1)
 		return true
@@ -403,7 +403,7 @@ func main() {
 				fmt.Println("Invalid Sink URL")
 			}
 			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if string(body) == "no" {
 				break
 			}

--- a/tests/load/genload.go
+++ b/tests/load/genload.go
@@ -7,10 +7,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"math/rand"
 	"net/http"
+	"os"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -120,7 +121,7 @@ func generateJobsForSameEvent(uid string, eventName string, count int, rudder bo
 	var data []byte
 	var rudderEvents []map[string]interface{}
 	var unmarshalleRudderdData map[string]interface{}
-	data, err = ioutil.ReadFile("mapping.json")
+	data, err = os.ReadFile("mapping.json")
 	if err != nil {
 		panic(err)
 	}
@@ -237,7 +238,7 @@ func generateJobsForMulitpleEvent(uid string, count int, rudder bool) {
 	var data []byte
 	var rudderEvents []map[string]interface{}
 	var unmarshalleRudderdData map[string]interface{}
-	data, err = ioutil.ReadFile("mapping.json")
+	data, err = os.ReadFile("mapping.json")
 	if err != nil {
 		panic(err)
 	}
@@ -393,8 +394,8 @@ func sendToRudder(jsonPayload string) {
 	}
 	// fmt.Println("response Status:", resp.Status)
 	// fmt.Println("response Headers:", resp.Header)
-	ioutil.ReadAll(resp.Body)
-	// body, _ := ioutil.ReadAll(resp.Body)
+	io.ReadAll(resp.Body)
+	// body, _ := io.ReadAll(resp.Body)
 	// fmt.Println("response Body:", string(body))
 	atomic.AddUint64(&successCount, 1)
 }

--- a/utils/logger/logger.go
+++ b/utils/logger/logger.go
@@ -22,7 +22,7 @@ package logger
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"runtime"
 	"strings"
@@ -324,9 +324,9 @@ func (l *LoggerT) Fatalf(format string, args ...interface{}) {
 func (l *LoggerT) LogRequest(req *http.Request) {
 	if levelEvent >= l.getLoggingLevel() {
 		defer req.Body.Close()
-		bodyBytes, _ := ioutil.ReadAll(req.Body)
+		bodyBytes, _ := io.ReadAll(req.Body)
 		bodyString := string(bodyBytes)
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		//print raw request body for debugging purposes
 		Log.Debug("Request Body: ", bodyString)
 	}

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -73,7 +72,7 @@ func Init() {
 
 func getErrorStore() (ErrorStoreT, error) {
 	var errorStore ErrorStoreT
-	data, err := ioutil.ReadFile(errorStorePath)
+	data, err := os.ReadFile(errorStorePath)
 	if os.IsNotExist(err) {
 		defaultErrorStoreJSON := "{\"Errors\":[]}"
 		data = []byte(defaultErrorStoreJSON)
@@ -99,7 +98,7 @@ func saveErrorStore(errorStore ErrorStoreT) {
 		pkgLogger.Fatal("failed to marshal errorStore", errorStore)
 		return
 	}
-	err = ioutil.WriteFile(errorStorePath, errorStoreJSON, 0644)
+	err = os.WriteFile(errorStorePath, errorStoreJSON, 0644)
 	if err != nil {
 		pkgLogger.Fatal("failed to write to errorStore")
 	}
@@ -605,7 +604,7 @@ func MakeHTTPRequestWithTimeout(url string, payload io.Reader, timeout time.Dura
 
 	var respBody []byte
 	if resp != nil && resp.Body != nil {
-		respBody, _ = ioutil.ReadAll(resp.Body)
+		respBody, _ = io.ReadAll(resp.Body)
 		defer resp.Body.Close()
 	}
 
@@ -977,7 +976,7 @@ func MakeRetryablePostRequest(url string, endpoint string, data interface{}) (re
 		return nil, -1, err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 
 	pkgLogger.Debugf("Post request: Successful %s", string(body))

--- a/utils/sysUtils/io.go
+++ b/utils/sysUtils/io.go
@@ -22,7 +22,6 @@ package sysUtils
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -72,14 +71,14 @@ func NewIoUtil() IoUtilI {
 // reads the whole file, it does not treat an EOF from Read as an error
 // to be reported.
 func (iu *IoUtil) ReadFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 // WriteFile writes data to a file named by filename.
 // If the file does not exist, WriteFile creates it with permissions perm
 // (before umask); otherwise WriteFile truncates it before writing.
 func (iu *IoUtil) WriteFile(filename string, data []byte, perm os.FileMode) error {
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 
 }
 
@@ -88,13 +87,13 @@ func (iu *IoUtil) WriteFile(filename string, data []byte, perm os.FileMode) erro
 // defined to read from src until EOF, it does not treat an EOF from Read
 // as an error to be reported.
 func (iu *IoUtil) ReadAll(r io.Reader) ([]byte, error) {
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 
 }
 
 // NopCloser returns a ReadCloser with a no-op Close method wrapping
 // the provided Reader r.
 func (iu *IoUtil) NopCloser(r io.Reader) io.ReadCloser {
-	return ioutil.NopCloser(r)
+	return io.NopCloser(r)
 
 }

--- a/utils/tests/GA/GAcheck.go
+++ b/utils/tests/GA/GAcheck.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math"
 	"math/rand"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -82,7 +83,7 @@ func main() {
 
 	fmt.Println(*sendToRuderPtr)
 
-	gaReferenceMap, _ = ioutil.ReadFile("GAReference.json")
+	gaReferenceMap, _ = os.ReadFile("GAReference.json")
 
 	for i := 1; i <= *numberOfUsers; i++ {
 		id := uuid.NewV4()
@@ -103,7 +104,7 @@ func generateJobsForSameEvent(uid string, eventName string, count int, rudder bo
 	var data, gaJSONData []byte
 	var rudderEvents []map[string]interface{}
 	var unmarshalleRudderdData, unmarshalleGAData map[string]interface{}
-	data, err = ioutil.ReadFile("mapping.json")
+	data, err = os.ReadFile("mapping.json")
 	check(err)
 	//fmt.Println(string(data))
 
@@ -229,7 +230,7 @@ func generateJobsForMulitpleEvent(uid string, count int, rudder bool) {
 	var data, gaJSONData []byte
 	var rudderEvents []map[string]interface{}
 	var unmarshalleRudderdData, unmarshalleGAData map[string]interface{}
-	data, err = ioutil.ReadFile("mapping.json")
+	data, err = os.ReadFile("mapping.json")
 	check(err)
 	//fmt.Println(string(data))
 
@@ -388,7 +389,7 @@ func sendToRudder(jsonPayload string) {
 
 	fmt.Println("response Status:", resp.Status)
 	fmt.Println("response Headers:", resp.Header)
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	fmt.Println("response Body:", string(body))
 }
 
@@ -463,7 +464,7 @@ func sendToGA(payload *map[string]interface{}, url string) {
 	check(err)
 
 	defer resp.Body.Close()
-	respBody, _ := ioutil.ReadAll(resp.Body)
+	respBody, _ := io.ReadAll(resp.Body)
 
 	fmt.Println(string(respBody))
 

--- a/warehouse/redshift/redshift.go
+++ b/warehouse/redshift/redshift.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -222,7 +221,7 @@ func (rs *HandleT) generateManifest(tableName string, columnMap map[string]strin
 		panic(err)
 	}
 	defer os.Remove(localManifestPath)
-	_ = ioutil.WriteFile(localManifestPath, manifestJSON, 0644)
+	_ = os.WriteFile(localManifestPath, manifestJSON, 0644)
 
 	file, err := os.Open(localManifestPath)
 	if err != nil {

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"runtime"
@@ -1093,7 +1093,7 @@ func CheckPGHealth(dbHandle *sql.DB) bool {
 func processHandler(w http.ResponseWriter, r *http.Request) {
 	pkgLogger.LogRequest(r)
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		pkgLogger.Errorf("[WH]: Error reading body: %v", err)
 		http.Error(w, "can't read body", http.StatusBadRequest)
@@ -1150,7 +1150,7 @@ func pendingEventsHandler(w http.ResponseWriter, r *http.Request) {
 	pkgLogger.LogRequest(r)
 
 	// read body
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		pkgLogger.Errorf("[WH]: Error reading body: %v", err)
 		http.Error(w, "can't read body", http.StatusBadRequest)
@@ -1316,7 +1316,7 @@ func triggerUploadHandler(w http.ResponseWriter, r *http.Request) {
 	pkgLogger.LogRequest(r)
 
 	// read body
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		pkgLogger.Errorf("[WH]: Error reading body: %v", err)
 		http.Error(w, "can't read body", http.StatusBadRequest)


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

#### Special notes for reviewers
No breaking changes.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

A small refactoring.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
