### PR TITLE
Remove unnecessary cache invalidation

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1792,7 +1792,6 @@ func (jd *HandleT) storeJobsDSInTxn(txHandler transactionHandler, ds dataSetT, c
 
 	defer stmt.Close()
 
-	customValParamMap := make(map[string]map[string]struct{})
 	for _, job := range jobList {
 		if copyID {
 			_, err = stmt.Exec(job.JobID, job.UUID, job.UserID, job.CustomVal, string(job.Parameters),
@@ -1803,13 +1802,6 @@ func (jd *HandleT) storeJobsDSInTxn(txHandler transactionHandler, ds dataSetT, c
 		if err != nil {
 			return err
 		}
-
-		jd.populateCustomValParamMap(customValParamMap, job.CustomVal, job.Parameters)
-	}
-	if useNewCacheBurst {
-		jd.clearCache(ds, customValParamMap)
-	} else {
-		jd.markClearEmptyResult(ds, []string{}, []string{}, nil, hasJobs, nil)
 	}
 	_, err = stmt.Exec()
 


### PR DESCRIPTION
Since this PR the cache invalidation takes place after database commit:
https://github.com/rudderlabs/rudder-server/pull/1280/files#diff-6b1d4978447cbee0288087476d81c9cf578adc1b0cdedfe2fa11327d26499e16R1676

Thus the invalidation inside is redundant.

Thanks @Sidddddarth for pointing this out.