### PR TITLE
Replace .Start/.End with concurrent safe .SendTiming

### DIFF
--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -86,7 +86,7 @@ func (trans *HandleT) Transform(transformType string, transformMessage *types.Tr
 	}
 
 	for {
-		trans.transformRequestTimerStat.Start()
+		s := time.Now()
 		resp, err = trans.client.Post(url, "application/json; charset=utf-8",
 			bytes.NewBuffer(rawJSON))
 
@@ -97,7 +97,7 @@ func (trans *HandleT) Transform(transformType string, transformMessage *types.Tr
 		}
 
 		if err != nil {
-			trans.transformRequestTimerStat.End()
+			trans.transformRequestTimerStat.SendTiming(time.Since(s))
 			reqFailed = true
 			trans.logger.Errorf("JS HTTP connection error: URL: %v Error: %+v", url, err)
 			if retryCount > maxRetry {
@@ -112,7 +112,7 @@ func (trans *HandleT) Transform(transformType string, transformMessage *types.Tr
 			trans.logger.Errorf("Failed request succeeded after %v retries, URL: %v", retryCount, url)
 		}
 
-		trans.transformRequestTimerStat.End()
+		trans.transformRequestTimerStat.SendTiming(time.Since(s))
 		break
 	}
 

--- a/services/stats/stats.go
+++ b/services/stats/stats.go
@@ -222,6 +222,7 @@ func (rStats *RudderStatsT) Gauge(value interface{}) {
 }
 
 // Start starts a new timing for this stat. Only applies to TimerType stats
+
 func (rStats *RudderStatsT) Start() {
 	if !statsEnabled || rStats.dontProcess {
 		return
@@ -233,6 +234,7 @@ func (rStats *RudderStatsT) Start() {
 }
 
 // End send the time elapsed since the Start()  call of this stat. Only applies to TimerType stats
+// Deprecated: Use concurrent safe SendTiming() instead
 func (rStats *RudderStatsT) End() {
 	if !statsEnabled || rStats.dontProcess {
 		return


### PR DESCRIPTION

The following pattern can lead to incorrect measurements  if the timer is shared among code that runs from multiple go routines. That was the cause for router transformer code.
```
timer.Start()
...
timer.End()
```

It is replaced with 

```
s := time.Now()
...
timer.SendTiming(time.Since(s))
```