### PR TITLE
Make codecov reports informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,8 @@
 coverage:
   status:
-    patch: false
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
We want to reduce the ❌  noise in our PRs. A lot of times, ❌  are miss leading / not actionable.

One of those tools is `codecov`, although increasing coverage is good given the testability in some parts of the code is not always possible.

Until some refactoring is done to make the code more testable and we configure code coverage in order to be more accurate, `codecov` would better serve as informational.

https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks