### PR TITLE
Remove FK from status table

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1373,7 +1373,7 @@ func (jd *HandleT) createDS(appendLast bool, newDSIdx string) dataSetT {
 
 	sqlStatement = fmt.Sprintf(`CREATE TABLE %s (
                                      id BIGSERIAL,
-                                     job_id BIGINT REFERENCES %s(job_id),
+                                     job_id BIGINT,
                                      job_state VARCHAR(64),
                                      attempt SMALLINT,
                                      exec_time TIMESTAMP,
@@ -1381,7 +1381,7 @@ func (jd *HandleT) createDS(appendLast bool, newDSIdx string) dataSetT {
                                      error_code VARCHAR(32),
                                      error_response JSONB DEFAULT '{}'::JSONB,
 									 parameters JSONB DEFAULT '{}'::JSONB,
-									 PRIMARY KEY (job_id, job_state, id));`, newDS.JobStatusTable, newDS.JobTable)
+									 PRIMARY KEY (job_id, job_state, id));`, newDS.JobStatusTable)
 	_, err = jd.dbHandle.Exec(sqlStatement)
 	jd.assertError(err)
 


### PR DESCRIPTION
# Dropping FK for performance


## Context

This change is part of the effort to make db_write in the processor faster.  

The status table contained a FK `job_id BIGINT REFERENCES %s(job_id),`, which means for every insert to the table a lookup to jobs table needs to happen. Which has some performance impact. 

## Impact
**With FK (320ms):**
<img width="320" alt="Screenshot 2021-11-04 at 10 15 50 PM" src="https://user-images.githubusercontent.com/733195/140468011-47665489-1f4f-4fae-9810-e3d050b455df.png">
**Without FK (128ms):**
<img width="318" alt="Screenshot 2021-11-04 at 10 15 41 PM" src="https://user-images.githubusercontent.com/733195/140468006-bc137098-a74f-4ada-a1c8-94f1f3f819ff.png">

