### PR TITLE
Response transform, fix for empty payload on response transform retry

### DIFF
--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -180,10 +180,10 @@ func (trans *HandleT) ResponseTransform(ctx context.Context, responseData integr
 	var respData []byte
 	var respCode int
 	var tempRespData []byte
-	var payload io.Reader
 	url := getResponseTransformURL(destName)
-	payload = strings.NewReader(string(rawJSON))
+	payload := strings.NewReader(string(rawJSON))
 	for {
+		payload.Seek(0, io.SeekStart)
 		req, err := http.NewRequestWithContext(ctx, "POST", url, payload)
 		if err != nil {
 			trans.logger.Error(fmt.Sprintf(`400 Unable to construct POST request for URL : "%s"`, url))


### PR DESCRIPTION
**Fixes** # (*issue*)

Fix for payload value being set to nil upon retry of response transform, as the length of the reader (*strings.reader) type was not set to 0 during retry. Hence used Seek from `i.o.Seeker` interface to set the offset of the payload on retry

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

