### PR TITLE
Add build-base to fix missing gcc

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.16.8-alpine
-RUN apk add --no-cache build-base  
+RUN apk add --no-cache build-base
 RUN mkdir /app
 WORKDIR /app
 COPY go.mod .

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:1.16.8-alpine
+RUN apk add --no-cache build-base  
 RUN mkdir /app
 WORKDIR /app
 COPY go.mod .


### PR DESCRIPTION
## To fix:
```
 > [8/8] RUN go install:
#12 43.97 # github.com/DataDog/zstd
#12 43.97 cgo: exec gcc: exec: "gcc": executable file not found in $PATH
```