### PR TITLE
Disable cursor  reading, event_count flag, checks for out of order/sequence

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -78,6 +78,8 @@ JobsDB:
     batch_rt:
       enabled: false
       failedOnly: false
+  gw:
+    enableWriterQueue: false
 Router:
   jobQueryBatchSize: 10000
   updateStatusBatchSize: 1000
@@ -174,6 +176,7 @@ Processor:
   errDBReadBatchSize: 1000
   noOfErrStashWorkers: 2
   maxFailedCountForErrJob: 3
+  enableEventCount: true
   Stats:
     captureEventName: false
 Dedup:

--- a/main.go
+++ b/main.go
@@ -214,6 +214,13 @@ func main() {
 		cancel()
 	}()
 
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGUSR1)
+		<-c
+		panic("triggered panic")
+	}()
+
 	Run(ctx)
 }
 

--- a/main.go
+++ b/main.go
@@ -214,13 +214,6 @@ func main() {
 		cancel()
 	}()
 
-	go func() {
-		c := make(chan os.Signal, 1)
-		signal.Notify(c, syscall.SIGUSR1)
-		<-c
-		panic("triggered panic")
-	}()
-
 	Run(ctx)
 }
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1780,11 +1780,12 @@ func (proc *HandleT) handlePendingGatewayJobs(nextJobID int64) (bool, int64) {
 	})
 	totalEvents := 0
 	totalPayloadBytes := 0
-	for _, job := range unprocessedList {
+	for i, job := range unprocessedList {
 		totalEvents += job.EventCount
 		totalPayloadBytes += len(job.EventPayload)
 
 		if !enableEventCount && totalEvents > maxEventsToProcess {
+			unprocessedList = unprocessedList[:i]
 			break
 		}
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1790,10 +1790,10 @@ func (proc *HandleT) handlePendingGatewayJobs(nextJobID int64) (bool, int64) {
 		}
 
 		if job.JobID <= proc.lastJobID {
-			proc.logger.Warnf("Out of order job_id: prev: %d cur: %d", proc.lastJobID, job.JobID)
+			proc.logger.Debugf("Out of order job_id: prev: %d cur: %d", proc.lastJobID, job.JobID)
 			proc.statDBReadOutOfOrder.Count(1)
 		} else if proc.lastJobID != 0 && job.JobID != proc.lastJobID+1 {
-			proc.logger.Warnf("Out of sequence job_id: prev: %d cur: %d", proc.lastJobID, job.JobID)
+			proc.logger.Debugf("Out of sequence job_id: prev: %d cur: %d", proc.lastJobID, job.JobID)
 			proc.statDBReadOutOfSequence.Count(1)
 		}
 		proc.lastJobID = job.JobID

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1784,7 +1784,7 @@ func (proc *HandleT) handlePendingGatewayJobs(nextJobID int64) (bool, int64) {
 		totalEvents += job.EventCount
 		totalPayloadBytes += len(job.EventPayload)
 
-		if !enableEventCount && totalPayloadBytes > maxEventsToProcess {
+		if !enableEventCount && totalEvents > maxEventsToProcess {
 			break
 		}
 


### PR DESCRIPTION
**Fixes** # [(*issue*)](https://www.notion.so/rudderstacks/Event-Delivery-disruption-d0ac4fa62da54e91838eaa96fd10ac5d)

Patch to remove unsafe db_read cursor technique, this is a patch, not a proper cleanup. The cleanup of code related to this feature will happen in another PR.

Also set:
```
JobsDB:
  gw:
    enableWriterQueue: false
```
as is the default every customer is using but not used for dev cluster or local testing.

Also added metrics and logs for detecting job_id gaps and out of order.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
