### PR TITLE
Uses the latest updated_at time; instead of id to load the latest schema

### DIFF
--- a/warehouse/schema.go
+++ b/warehouse/schema.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 	"github.com/rudderlabs/rudder-server/warehouse/manager"
@@ -48,7 +49,7 @@ func (sHandle *SchemaHandleT) getLocalSchema() (currentSchema warehouseutils.Sch
 	namespace := sHandle.warehouse.Namespace
 
 	var rawSchema json.RawMessage
-	sqlStatement := fmt.Sprintf(`SELECT schema FROM %[1]s WHERE (%[1]s.destination_id='%[2]s' AND %[1]s.namespace='%[3]s') ORDER BY %[1]s.id DESC`, warehouseutils.WarehouseSchemasTable, destID, namespace)
+	sqlStatement := fmt.Sprintf(`SELECT schema FROM %[1]s WHERE (%[1]s.destination_id='%[2]s' AND %[1]s.namespace='%[3]s') ORDER BY %[1]s.updated_at DESC`, warehouseutils.WarehouseSchemasTable, destID, namespace)
 	pkgLogger.Infof("[WH]: Fetching current schema from wh postgresql: %s", sqlStatement)
 
 	err := dbHandle.QueryRow(sqlStatement).Scan(&rawSchema)


### PR DESCRIPTION


**Fixes** # (*issue*)
Uses the latest updated_at time; instead of id to load the latest schema

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation


What is the issue?
The code fetches the schema changed on the warehouse destination and stores it locally, but it queries to fetch by the latest-id which need not be the latest, as we're [upsert-ing the schema here](https://github.com/rudderlabs/rudder-server/blob/ebd99531d6f9f6f2d6a21d59408c0baf7142d195/warehouse/schema.go#L91-L96)

What is the fix?
The change proposed will get the latest schema known which is by the latest time updated_at and uses it to write to destination.