### PR TITLE
correct the order of node migrations

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -41,8 +41,8 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 	pkgLogger.Info("Main starting")
 
 	rudderCoreDBValidator()
-	rudderCoreNodeSetup()
 	rudderCoreWorkSpaceTableSetup()
+	rudderCoreNodeSetup()
 	rudderCoreBaseSetup()
 
 	g, ctx := errgroup.WithContext(ctx)

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -67,8 +67,8 @@ func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app
 	pkgLogger.Info("Processor starting")
 
 	rudderCoreDBValidator()
-	rudderCoreNodeSetup()
 	rudderCoreWorkSpaceTableSetup()
+	rudderCoreNodeSetup()
 	rudderCoreBaseSetup()
 	g, ctx := errgroup.WithContext(ctx)
 


### PR DESCRIPTION
**Fixes** # 
When workspace token is changed, rudder-server renames the existing jobsdb and starts with a fresh one. In such scenario, node migrations are not getting applied on the new jobsdb. This pr fixes the order in which new db is created & migrations are applied.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
