### PR TITLE
gw-time-stats-fix

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -664,7 +664,7 @@ func (gateway *HandleT) getPayloadFromRequest(r *http.Request) ([]byte, error) {
 	}
 
 	start := time.Now()
-	defer gateway.bodyReadTimeStat.SendTiming(time.Since(start))
+	defer gateway.bodyReadTimeStat.Since(start)
 
 	payload, err := io.ReadAll(r.Body)
 	r.Body.Close()
@@ -1033,7 +1033,7 @@ func (rrh *RegularRequestHandler) ProcessRequest(gateway *HandleT, w *http.Respo
 	start := time.Now()
 	gateway.addToWebRequestQ(w, r, done, reqType, payload, writeKey)
 	gateway.addToWebRequestQWaitTime.SendTiming(time.Since(start))
-	defer gateway.ProcessRequestTime.SendTiming(time.Since(start))
+	defer gateway.ProcessRequestTime.Since(start)
 	errorMessage := <-done
 	return errorMessage
 }


### PR DESCRIPTION
**Fixes** # 
Times are reported incorrectly because the execution of the parameters passed to the function happens immediately. This pr fixes it.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
