### PR TITLE
Check ptr not nil before dereference 

### DIFF
--- a/services/filemanager/s3manager.go
+++ b/services/filemanager/s3manager.go
@@ -248,6 +248,9 @@ func (manager *S3Manager) ListFilesWithPrefix(prefix string, maxItems int64) (fi
 	if err != nil {
 		return
 	}
+	if resp.IsTruncated != nil {
+		manager.Config.IsTruncated = *resp.IsTruncated
+	}
 	manager.Config.IsTruncated = *resp.IsTruncated
 	manager.Config.ContinuationToken = resp.NextContinuationToken
 	for _, item := range resp.Contents {


### PR DESCRIPTION
Temporary fix to address panic when `resp.IsTruncated` is nil

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
