### PR TITLE
Remove spammy logs

### DIFF
--- a/event-schema/event_schema.go
+++ b/event-schema/event_schema.go
@@ -775,7 +775,6 @@ func (manager *EventSchemaManagerT) offloadEventSchemas() {
 		for _, modelsByWriteKey := range manager.schemaVersionMap {
 			for _, version := range modelsByWriteKey {
 				if timeutil.Now().Sub(version.LastSeen) > offloadThreshold {
-					pkgLogger.Infof("offloading schema version: %s", version.UUID)
 					if _, ok := offloadedSchemaVersions[version.EventModelID]; !ok {
 						offloadedSchemaVersions[version.EventModelID] = make(map[string]*OffloadedSchemaVersionT)
 					}

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -2491,6 +2491,8 @@ func (jd *HandleT) migrateDSLoop(ctx context.Context) {
 func (jd *HandleT) backupDSLoop(ctx context.Context) {
 	sleepMultiplier := time.Duration(1)
 
+	jd.logger.Info("BackupDS loop is running")
+
 	for {
 		select {
 		case <-time.After(sleepMultiplier * backupCheckSleepDuration):
@@ -2498,7 +2500,6 @@ func (jd *HandleT) backupDSLoop(ctx context.Context) {
 			return
 		}
 
-		jd.logger.Info("BackupDS check:Start")
 		backupDSRange := jd.getBackupDSRange()
 		// check if non empty dataset is present to backup
 		// else continue

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1480,7 +1480,7 @@ func (proc *HandleT) Store(in storeMessage) {
 		in.procErrorJobs = append(in.procErrorJobs, jobs...)
 	}
 	if len(in.procErrorJobs) > 0 {
-		proc.logger.Info("[Processor] Total jobs written to proc_error: ", len(in.procErrorJobs))
+		proc.logger.Debug("[Processor] Total jobs written to proc_error: ", len(in.procErrorJobs))
 		err := proc.errorDB.Store(in.procErrorJobs)
 		if err != nil {
 			proc.logger.Errorf("Store into proc error table failed with error: %v", err)
@@ -1528,9 +1528,6 @@ func (proc *HandleT) Store(in storeMessage) {
 	proc.statRouterDBW.Count(len(destJobs))
 	proc.statBatchRouterDBW.Count(len(batchDestJobs))
 	proc.statProcErrDBW.Count(len(in.procErrorJobs))
-
-	proc.pStatsJobs.Print()
-	proc.pStatsDBW.Print()
 }
 
 type transformSrcDestOutput struct {
@@ -2004,8 +2001,6 @@ func (proc *HandleT) getJobs() []*jobsdb.JobT {
 	proc.statDBReadRequests.Observe(float64(len(unprocessedList)))
 	proc.statDBReadEvents.Observe(float64(totalEvents))
 	proc.statDBReadPayloadBytes.Observe(float64(totalPayloadBytes))
-
-	proc.pStatsDBR.Print()
 
 	return unprocessedList
 }

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -258,7 +258,6 @@ func (trans *HandleT) Transform(clientEvents []TransformerEventT,
 	trans.receivedStat.Count(len(outClientEvents))
 	trans.failedStat.Count(len(failedEvents))
 	trans.perfStats.Rate(len(clientEvents), time.Since(s))
-	trans.perfStats.Print()
 
 	return ResponseT{
 		Events:       outClientEvents,

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -416,20 +416,14 @@ func CreateTMPDIR() (string, error) {
 type PerfStats struct {
 	eventCount           int64
 	elapsedTime          time.Duration
-	lastPrintEventCount  int64
-	lastPrintElapsedTime time.Duration
-	lastPrintTime        time.Time
 	compStr              string
 	tmpStart             time.Time
 	instantRateCall      float64
-	printThres           int
 }
 
 //Setup initializes the stat collector
 func (stats *PerfStats) Setup(comp string) {
 	stats.compStr = comp
-	stats.lastPrintTime = time.Now()
-	stats.printThres = 5 //seconds
 }
 
 //Start marks the start of event collection
@@ -449,19 +443,6 @@ func (stats *PerfStats) Rate(events int, elapsed time.Duration) {
 	stats.elapsedTime += elapsed
 	stats.eventCount += int64(events)
 	stats.instantRateCall = float64(events) * float64(time.Second) / float64(elapsed)
-}
-
-//Print displays the stats
-func (stats *PerfStats) Print() {
-	if time.Since(stats.lastPrintTime) > time.Duration(stats.printThres)*time.Second {
-		overallRate := float64(stats.eventCount) * float64(time.Second) / float64(stats.elapsedTime)
-		instantRate := float64(stats.eventCount-stats.lastPrintEventCount) * float64(time.Second) / float64(stats.elapsedTime-stats.lastPrintElapsedTime)
-		pkgLogger.Infof("%s: Total: %d Overall:%f, Instant(print):%f, Instant(call):%f",
-			stats.compStr, stats.eventCount, overallRate, instantRate, stats.instantRateCall)
-		stats.lastPrintEventCount = stats.eventCount
-		stats.lastPrintElapsedTime = stats.elapsedTime
-		stats.lastPrintTime = time.Now()
-	}
 }
 
 func (stats *PerfStats) Status() map[string]interface{} {

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -628,10 +628,6 @@ func SortedStructSliceValues(input interface{}, filedName string) []string {
 	return keys
 }
 
-func bToMb(b uint64) uint64 {
-	return b / 1024 / 1024
-}
-
 func ReplaceMultiRegex(str string, expList map[string]string) (string, error) {
 	replacedStr := str
 	for regex, substitute := range expList {

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -745,20 +745,6 @@ func SingleQuoteLiteralJoin(slice []string) string {
 	return str
 }
 
-// PrintMemUsage outputs the current, total and OS memory being used. As well as the number
-// of garage collection cycles completed.
-func PrintMemUsage() {
-	var m runtime.MemStats
-	runtime.ReadMemStats(&m)
-	// For info on each, see: https://golang.org/pkg/runtime/#MemStats
-	pkgLogger.Debug("#########")
-	pkgLogger.Debugf("Alloc = %v MiB\n", bToMb(m.Alloc))
-	pkgLogger.Debugf("\tTotalAlloc = %v MiB\n", bToMb(m.TotalAlloc))
-	pkgLogger.Debugf("\tSys = %v MiB\n", bToMb(m.Sys))
-	pkgLogger.Debugf("\tNumGC = %v\n", m.NumGC)
-	pkgLogger.Debug("#########")
-}
-
 type BufferedWriter struct {
 	File   *os.File
 	Writer *bufio.Writer

--- a/warehouse/slave.go
+++ b/warehouse/slave.go
@@ -381,7 +381,6 @@ func processStagingFile(job PayloadT, workerIndex int) (loadFileUploadOutputs []
 	jobRun.outputFileWritersMap = make(map[string]warehouseutils.LoadFileWriterI)
 	jobRun.tableEventCountMap = make(map[string]int)
 	jobRun.uuidTS = timeutil.Now()
-	misc.PrintMemUsage()
 
 	// Initilize Discards Table
 	discardsTable := job.getDiscardsTable()
@@ -496,7 +495,6 @@ func processStagingFile(job PayloadT, workerIndex int) (loadFileUploadOutputs []
 		jobRun.tableEventCountMap[tableName]++
 	}
 	timer.End()
-	misc.PrintMemUsage()
 
 	pkgLogger.Debugf("[WH]: Process %v bytes from downloaded staging file: %s", lineBytesCounter, job.StagingFileLocation)
 	jobRun.counterStat("bytes_processed_in_staging_file").Count(lineBytesCounter)


### PR DESCRIPTION
## Why

Certain logs are frequently repeated and are no longer useful. Metrics and pprof endpoint, can be used for debugging this situations.

Those logs create noise when debugging an issue locally, prod, even tests!  
Also they increase the cost of storage and the time to query the logs in general.


[notion
](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=b53cf35b1d724079aff2790c3255e721)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
