### PR TITLE
Remove costly reflection compare

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -599,7 +599,9 @@ func (gateway *HandleT) userWebRequestWorkerProcess(userWebRequestWorker *userWe
 func (gateway *HandleT) isWriteKeyEnabled(writeKey string) bool {
 	configSubscriberLock.RLock()
 	defer configSubscriberLock.RUnlock()
-	return misc.Contains(enabledWriteKeysSourceMap, writeKey)
+
+	_, ok := enabledWriteKeysSourceMap[writeKey]
+	return ok
 }
 
 func (gateway *HandleT) getSourceIDForWriteKey(writeKey string) string {

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -446,7 +446,7 @@ var _ = Describe("Gateway", func() {
 			gateway.Setup(c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockRateLimiter, c.mockVersionHandler)
 		})
 
-		It("should store messages successfuly if rate limit is not reached for workspace", func() {
+		It("should store messages successfully if rate limit is not reached for workspace", func() {
 			workspaceID := "some-workspace-id"
 
 			c.mockBackendConfig.EXPECT().GetWorkspaceIDForWriteKey(WriteKeyEnabled).Return(workspaceID).AnyTimes().Do(c.asyncHelper.ExpectAndNotifyCallbackWithName(""))


### PR DESCRIPTION
**Fixes** # (*issue*)


## Issue

`misc.Contains` is a computationally expensive function since it is using reflect.

1m CPU sample of hosted:
<img width="1325" alt="Screenshot 2022-01-13 at 9 17 27 AM" src="https://user-images.githubusercontent.com/733195/149262480-6ad6dadc-ac3b-4377-a5e6-d4bbfe53d556.png">


## Solution 
`misc.Contains` is replaced with a simple map lookup.

What misc.Contains was doing:

```go
func Contains(in interface{}, elem interface{}) bool {
	inValue := reflect.ValueOf(in)
	elemValue := reflect.ValueOf(elem)
	inType := inValue.Type()

	switch inType.Kind() {

	case reflect.Map:
		for _, key := range inValue.MapKeys() {
			if equal(key.Interface(), elem) {
```

First, it reflect both on in and elem values.
If ti was a map, it was iterating all the map keys and comparing their interfaces - this comparison was doing:

```go
func equal(expected, actual interface{}) bool {
	if expected == nil || actual == nil {
		return expected == actual
	}
	return reflect.DeepEqual(expected, actual)
}
``` 

So we have a combination of costly reflect that increased linearly by the number of `enabledWriteKeysSourceMap` keys. 
Thus it explains why on hosted this method was consuming so much memory.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
