### PR TITLE
Router jobid crashfix

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -801,17 +801,17 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 			worker.sendRouterResponseCountStat(destinationJobMetadata, &status, &destinationJob.Destination)
 		}
 
-		//not needed because from same source in a destinationJob(see asserts above)
-		// if !misc.Contains(sourceIDs, destinationJobMetadata.SourceID) {
-		// 	sourceIDs = append(sourceIDs, destinationJobMetadata.SourceID)
-		// }
 		//Sending only one destination live event for every destinationJob.
 		if _, ok := destLiveEventSentMap[destinationJob]; !ok {
 			payload := destinationJob.Message
 			if destinationJob.Message == nil {
 				payload = destinationJobMetadata.JobT.EventPayload
 			}
-			worker.sendDestinationResponseToConfigBackend(payload, destinationJobMetadata, &status, []string{destinationJobMetadata.SourceID})
+			sourcesIDs := make([]string, 0)
+			for _, metadata := range destinationJob.JobMetadataArray {
+				sourcesIDs = append(sourcesIDs, metadata.SourceID)
+			}
+			worker.sendDestinationResponseToConfigBackend(payload, destinationJobMetadata, &status, sourcesIDs)
 			destLiveEventSentMap[destinationJob] = struct{}{}
 		}
 	}

--- a/router/router.go
+++ b/router/router.go
@@ -761,7 +761,7 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 				//Only one job is marked failed and the rest are marked waiting
 				//Job order logic requires that at any point of time, we should have only one failed job per user
 				//This is introduced to ensure the above statement
-				resp := fmt.Sprintf(`{"blocking_id":"%v", "user_id":"%s", "moreinfo": "attempted to send in a batch"}`, prevFailedJobID, destinationJobMetadata.UserID)
+				resp := fmt.Sprintf(`{"blocking_id":"%d", "user_id":"%s", "moreinfo": "attempted to send in a batch"}`, prevFailedJobID, destinationJobMetadata.UserID)
 				status := jobsdb.JobStatusT{
 					JobID:         destinationJobMetadata.JobID,
 					AttemptNum:    destinationJobMetadata.AttemptNum,

--- a/router/router.go
+++ b/router/router.go
@@ -749,7 +749,6 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 		return routerJobResponses[i].jobID < routerJobResponses[j].jobID
 	})
 
-	destLiveEventSentMap := make(map[*types.DestinationJobT]struct{})
 	//Struct to hold unique users in the batch (worker.destinationJobs)
 	userToJobIDMap := make(map[string]int64)
 
@@ -803,6 +802,7 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 		}
 	}
 
+	destLiveEventSentMap := make(map[*types.DestinationJobT]struct{})
 	for _, routerJobResponse := range routerJobResponses {
 		//Sending only one destination live event for every destinationJob, if it was attemptedToSendTheJob
 		if _, ok := destLiveEventSentMap[routerJobResponse.destinationJob]; !ok && routerJobResponse.attemptedToSendTheJob {

--- a/router/router.go
+++ b/router/router.go
@@ -736,12 +736,14 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 			_destinationJob := destinationJob
 			_destinationJobMetadata := destinationJobMetadata
 
-			routerJobResponses = append(routerJobResponses, &RouterJobResponse{jobID: destinationJobMetadata.JobID,
+			routerJobResponses = append(routerJobResponses, &RouterJobResponse{
+			    jobID: destinationJobMetadata.JobID,
 				destinationJob:         &_destinationJob,
 				destinationJobMetadata: &_destinationJobMetadata,
 				respStatusCode:         respStatusCode,
 				respBody:               respBody,
-				attemptedToSendTheJob:  attemptedToSendTheJob})
+				attemptedToSendTheJob:  attemptedToSendTheJob,
+			})
 		}
 	}
 

--- a/router/router.go
+++ b/router/router.go
@@ -722,9 +722,6 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 			respBody = destinationJob.Error
 		}
 
-		//TODO remove
-		respStatusCode = 504
-
 		prevRespStatusCode = respStatusCode
 
 		if !isJobTerminated(respStatusCode) {
@@ -804,7 +801,7 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 			worker.sendRouterResponseCountStat(destinationJobMetadata, &status, &destinationJob.Destination)
 		}
 
-		//not needed because from same source in a destinationJob(look at asserts above)
+		//not needed because from same source in a destinationJob(see asserts above)
 		// if !misc.Contains(sourceIDs, destinationJobMetadata.SourceID) {
 		// 	sourceIDs = append(sourceIDs, destinationJobMetadata.SourceID)
 		// }

--- a/router/router.go
+++ b/router/router.go
@@ -803,8 +803,8 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 			worker.sendRouterResponseCountStat(destinationJobMetadata, &status, &destinationJob.Destination)
 		}
 
-		//Sending only one destination live event for every destinationJob.
-		if _, ok := destLiveEventSentMap[destinationJob]; !ok {
+		//Sending only one destination live event for every destinationJob, if it was attemptedToSendTheJob
+		if _, ok := destLiveEventSentMap[destinationJob]; !ok && attemptedToSendTheJob {
 			payload := destinationJob.Message
 			if destinationJob.Message == nil {
 				payload = destinationJobMetadata.JobT.EventPayload

--- a/router/router.go
+++ b/router/router.go
@@ -600,8 +600,6 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 
 	failedUserIDsMap := make(map[string]struct{})
 	apiCallsCount := make(map[string]*destJobCountsT)
-	//Struct to hold unique users in the batch (worker.destinationJobs)
-	userToJobIDMap := make(map[string]int64)
 	routerJobResponses := make([]*RouterJobResponse, 0)
 	for _, destinationJob := range worker.destinationJobs {
 		var attemptedToSendTheJob bool
@@ -737,7 +735,7 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 			_destinationJobMetadata := destinationJobMetadata
 
 			routerJobResponses = append(routerJobResponses, &RouterJobResponse{
-			    jobID: destinationJobMetadata.JobID,
+				jobID:                  destinationJobMetadata.JobID,
 				destinationJob:         &_destinationJob,
 				destinationJobMetadata: &_destinationJobMetadata,
 				respStatusCode:         respStatusCode,
@@ -752,6 +750,8 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 	})
 
 	destLiveEventSentMap := make(map[*types.DestinationJobT]struct{})
+	//Struct to hold unique users in the batch (worker.destinationJobs)
+	userToJobIDMap := make(map[string]int64)
 
 	for _, routerJobResponse := range routerJobResponses {
 		destinationJobMetadata := routerJobResponse.destinationJobMetadata

--- a/router/router.go
+++ b/router/router.go
@@ -811,7 +811,9 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 			}
 			sourcesIDs := make([]string, 0)
 			for _, metadata := range destinationJob.JobMetadataArray {
-				sourcesIDs = append(sourcesIDs, metadata.SourceID)
+				if !misc.Contains(sourcesIDs, metadata.SourceID) {
+					sourcesIDs = append(sourcesIDs, metadata.SourceID)
+				}
 			}
 			worker.sendDestinationResponseToConfigBackend(payload, destinationJobMetadata, &status, sourcesIDs)
 			destLiveEventSentMap[destinationJob] = struct{}{}


### PR DESCRIPTION
Attempts to avoid `FailedJobID2` < `FailedJobID1` crashes in routers where batching is enabled.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
