### PR TITLE
moved deleteexecuting out from router. Doing it once for all routers.

### DIFF
--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -154,6 +154,14 @@ func monitorDestRouters(ctx context.Context, routerDB, batchRouterDB, procErrorD
 
 	cleanup := make([]func(), 0)
 
+	//Crash recover routerDB, batchRouterDB
+	//Note: The following cleanups can take time if there are too many
+	//rt / batch_rt tables and there would be a delay readin from channel `ch`
+	//However, this shouldn't be the problem since backend config pushes config
+	//to its subscribers in separate goroutines to prevent blocking.
+	routerDB.DeleteExecuting(jobsdb.GetQueryParamsT{JobCount: -1})
+	batchRouterDB.DeleteExecuting(jobsdb.GetQueryParamsT{JobCount: -1})
+
 loop:
 	for {
 		select {

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1900,8 +1900,6 @@ func IsAsyncDestination(destType string) bool {
 }
 
 func (brt *HandleT) crashRecover() {
-	brt.jobsDB.DeleteExecuting(jobsdb.GetQueryParamsT{CustomValFilters: []string{brt.destType}, JobCount: -1})
-
 	if misc.Contains(objectStorageDestinations, brt.destType) {
 		brt.dedupRawDataDestJobsOnCrash()
 	}

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -147,7 +147,6 @@ var _ = Describe("BatchRouter", func() {
 		It("should initialize and recover after crash", func() {
 			batchrouter := &HandleT{}
 
-			c.mockBatchRouterJobsDB.EXPECT().DeleteExecuting(jobsdb.GetQueryParamsT{CustomValFilters: []string{s3DestinationDefinition.Name}, JobCount: -1}).Times(1)
 			c.mockBatchRouterJobsDB.EXPECT().GetJournalEntries(gomock.Any()).Times(1).Return(emptyJournalEntries)
 
 			batchrouter.Setup(c.mockBackendConfig, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, s3DestinationDefinition.Name, nil)
@@ -157,7 +156,6 @@ var _ = Describe("BatchRouter", func() {
 	Context("normal operation - s3 - do not readPerDestination", func() {
 		BeforeEach(func() {
 			// crash recovery check
-			c.mockBatchRouterJobsDB.EXPECT().DeleteExecuting(jobsdb.GetQueryParamsT{CustomValFilters: []string{s3DestinationDefinition.Name}, JobCount: -1}).Times(1)
 			c.mockBatchRouterJobsDB.EXPECT().GetJournalEntries(gomock.Any()).Times(1).Return(emptyJournalEntries)
 		})
 

--- a/router/router.go
+++ b/router/router.go
@@ -1874,7 +1874,8 @@ func destinationID(job *jobsdb.JobT) string {
 }
 
 func (rt *HandleT) crashRecover() {
-	rt.jobsDB.DeleteExecuting(jobsdb.GetQueryParamsT{CustomValFilters: []string{rt.destName}, JobCount: -1})
+	//Perform any crash recover items here.
+	//None as of now
 }
 
 func Init() {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -127,8 +127,6 @@ var _ = Describe("Router", func() {
 		It("should initialize and recover after crash", func() {
 			router := &HandleT{}
 
-			c.mockRouterJobsDB.EXPECT().DeleteExecuting(jobsdb.GetQueryParamsT{CustomValFilters: []string{gaDestinationDefinition.Name}, JobCount: -1}).Times(1)
-
 			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition, nil)
 		})
 	})
@@ -136,9 +134,6 @@ var _ = Describe("Router", func() {
 	Context("normal operation - ga", func() {
 		BeforeEach(func() {
 			maxStatusUpdateWait = 2 * time.Second
-
-			// crash recovery check
-			c.mockRouterJobsDB.EXPECT().DeleteExecuting(jobsdb.GetQueryParamsT{CustomValFilters: []string{gaDestinationDefinition.Name}, JobCount: -1}).Times(1)
 		})
 
 		It("should send failed, unprocessed jobs to ga destination", func() {
@@ -344,9 +339,6 @@ var _ = Describe("Router", func() {
 	Context("Router Batching", func() {
 		BeforeEach(func() {
 			maxStatusUpdateWait = 2 * time.Second
-
-			// crash recovery check
-			c.mockRouterJobsDB.EXPECT().DeleteExecuting(jobsdb.GetQueryParamsT{CustomValFilters: []string{gaDestinationDefinition.Name}, JobCount: -1}).Times(1)
 		})
 
 		It("can batch jobs together", func() {
@@ -623,8 +615,6 @@ var _ = Describe("Router", func() {
 		BeforeEach(func() {
 			maxStatusUpdateWait = 2 * time.Second
 			jobsBatchTimeout = 10 * time.Second
-			// crash recovery check
-			c.mockRouterJobsDB.EXPECT().DeleteExecuting(jobsdb.GetQueryParamsT{CustomValFilters: []string{gaDestinationDefinition.Name}, JobCount: -1}).Times(1)
 		})
 		/*
 			Router transform


### PR DESCRIPTION
**Fixes** # (*issue*)
Cleaning up router tables during startup per router takes huge time when there are too may router tables. Pulled cleanup out of router and doing it once for all the routers.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
