### PR TITLE
correct-marshalling-cacheEntry

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1883,8 +1883,8 @@ const (
 )
 
 type cacheEntry struct {
-	value cacheValue
-	t     time.Time
+	Value cacheValue `json:"value"`
+	T     time.Time  `json:"set_at"`
 }
 
 /*
@@ -1935,10 +1935,10 @@ func (jd *HandleT) markClearEmptyResult(ds dataSetT, stateFilters []string, cust
 
 		for _, st := range stateFilters {
 			previous := jd.dsEmptyResultCache[ds][cVal][pVal][st]
-			if checkAndSet == nil || *checkAndSet == previous.value {
+			if checkAndSet == nil || *checkAndSet == previous.Value {
 				jd.dsEmptyResultCache[ds][cVal][pVal][st] = cacheEntry{
-					value: value,
-					t:     time.Now(),
+					Value: value,
+					T:     time.Now(),
 				}
 			}
 		}
@@ -1989,7 +1989,7 @@ func (jd *HandleT) isEmptyResult(ds dataSetT, stateFilters []string, customValFi
 
 		for _, st := range stateFilters {
 			mark, ok := jd.dsEmptyResultCache[ds][cVal][pVal][st]
-			if !ok || mark.value != noJobs || time.Now().After(mark.t.Add(cacheExpiration)) {
+			if !ok || mark.Value != noJobs || time.Now().After(mark.T.Add(cacheExpiration)) {
 				return false
 			}
 		}


### PR DESCRIPTION
**Fixes** # (*issue*)
Because the variables inside cacheEntry struct start with lowercase, they aren't json marshalled properly. The response we see when investigating jobsdb cachemap using rudder-cli is incorrect. This fixes it.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
