### PR TITLE
Fix expiration value for entries TTL

### DIFF
--- a/services/dedup/dedup.go
+++ b/services/dedup/dedup.go
@@ -110,7 +110,7 @@ func (d *DedupHandleT) gcBadgerDB() {
 func (d *DedupHandleT) writeToBadger(messageIDs []string) {
 	err := d.badgerDB.Update(func(txn *badger.Txn) error {
 		for _, messageID := range messageIDs {
-			e := badger.NewEntry([]byte(messageID), nil).WithTTL(dedupWindow * time.Second)
+			e := badger.NewEntry([]byte(messageID), nil).WithTTL(dedupWindow)
 			if err := txn.SetEntry(e); err == badger.ErrTxnTooBig {
 				_ = txn.Commit()
 				txn = d.badgerDB.NewTransaction(true)


### PR DESCRIPTION
https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=6b928ca0c96642019a931d889f6d1039

This is a quick fix for a critical dedup issue. A PR with other improvements and testing is being prepared as well.

## Problem 
We were configuring `dedupWindow` in seconds https://github.com/rudderlabs/rudder-server/blob/39c312d6a18cd8e8a8e1e6807309c500078a71a3/services/dedup/dedup.go#L41

And then [multiply with time.Seconds](https://github.com/rudderlabs/rudder-server/pull/1657/files#diff-0fec60879512f77a2e223aa0353389b5efb1f9cdfdf9b723b59681a41c581346L113) again, going from `1h0m0s` to `801362h40m26.63743488s` - essentially for ever.
Entries never expired and thus disk usage kept growing.

## Solution

Stop multiplying with `time.Seconds`. Unfortunately, we can not pick a configuration value low enough to fix the issue without deploying code. 
