### PR TITLE
Run docker test only once

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,6 @@ jobs:
           ${{ runner.os }}-go-
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
-    - run: go test -v ./docker_test.go -integration -count 1
     - run: ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration -count 1
   integration-multitenant:
     name: Service Integration Multitenant


### PR DESCRIPTION
integration test was running twice in the default integration test, no need for that:
```yaml
    - run: go test -v ./docker_test.go -integration -count 1
    - run: ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration -count 1
```

fixed since it was taking more time