### PR TITLE
Dedup bigquery tables

### DIFF
--- a/warehouse/bigquery/bigquery.go
+++ b/warehouse/bigquery/bigquery.go
@@ -484,7 +484,7 @@ func (bq *HandleT) LoadUserTables() (errorMap map[string]error) {
 
 	loadUserTableByMerge := func() {
 		stagingTableName := misc.TruncateStr(fmt.Sprintf(`%s%s_%s`, stagingTablePrefix, strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", ""), warehouseutils.UsersTable), 127)
-		pkgLogger.Infof(`BQ: Creating staging table for users: %v :: %v`, sqlStatement)
+		pkgLogger.Infof(`BQ: Creating staging table for users: %v`, sqlStatement)
 		query := bq.Db.Query(sqlStatement)
 		query.QueryConfig.Dst = bq.Db.Dataset(bq.Namespace).Table(stagingTableName)
 		query.WriteDisposition = bigquery.WriteAppend
@@ -533,7 +533,7 @@ func (bq *HandleT) LoadUserTables() (errorMap map[string]error) {
 										INSERT (%[3]s) VALUES (%[6]s)`, bqTable(warehouseutils.UsersTable), bqTable(stagingTableName), columnNamesStr, primaryKey, columnsWithValues, stagingColumnValues)
 		pkgLogger.Infof("BQ: Dedup records for table:%s using staging table: %s\n", warehouseutils.UsersTable, sqlStatement)
 
-		pkgLogger.Infof(`BQ: Loading data into users table: %v :: %v`, sqlStatement)
+		pkgLogger.Infof(`BQ: Loading data into users table: %v`, sqlStatement)
 		// partitionedUsersTable := partitionedTable(warehouseutils.UsersTable, partitionDate)
 		q := bq.Db.Query(sqlStatement)
 		job, err = q.Run(bq.BQContext)

--- a/warehouse/bigquery/bigquery.go
+++ b/warehouse/bigquery/bigquery.go
@@ -289,7 +289,7 @@ func (bq *HandleT) loadTable(tableName string, forceLoad bool, getLoadFileLocFro
 			Schema:           sampleSchema,
 			TimePartitioning: &bigquery.TimePartitioning{},
 		}
-		tableRef := bq.Db.Dataset(bq.Namespace).Table(tableName)
+		tableRef := bq.Db.Dataset(bq.Namespace).Table(stagingTableName)
 		err = tableRef.Create(bq.BQContext, metaData)
 		if err != nil {
 			pkgLogger.Infof("BQ: Error creating temporary staging table %s", stagingTableName)


### PR DESCRIPTION
## Description of the change

> Dedup big query tables on flag isDedupEnabled

## Notion Link

> [Notion Link](https://www.notion.so/rudderstacks/Dedup-on-bigquery-5384cb414b544e2ab6e1f2d37e57e274)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
