### PR TITLE
New jobsdb Lifecycle control

### DIFF
--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -288,7 +288,7 @@ func TestJobsDB(t *testing.T) {
 	t.Run("DSoverflow", func(t *testing.T) {
 		customVal := "MOCKDS"
 
-		triggerAddNewDS := make(chan time.Time, 0)
+		triggerAddNewDS := make(chan time.Time)
 
 		maxDSSize := 9
 		jobDB := jobsdb.HandleT{
@@ -407,8 +407,8 @@ func BenchmarkJobsdb(b *testing.B) {
 
 		g, _ := errgroup.WithContext(context.Background())
 		g.Go(func() error {
-			for _, j := range expectedJobs {
-				err := jobDB.Store([]*jobsdb.JobT{&j})
+			for i := range expectedJobs {
+				err := jobDB.Store([]*jobsdb.JobT{&expectedJobs[i]})
 				if err != nil {
 					return err
 				}
@@ -460,13 +460,13 @@ func BenchmarkJobsdb(b *testing.B) {
 		err := g.Wait()
 		require.NoError(b, err)
 		require.Len(b, consumedJobs, len(expectedJobs))
-		for i, actualJob := range consumedJobs {
+		for i := range consumedJobs {
 			expectedJob := expectedJobs[i]
-			require.Equal(b, expectedJob.UUID, actualJob.UUID)
-			require.Equal(b, expectedJob.UserID, actualJob.UserID)
-			require.Equal(b, expectedJob.CustomVal, actualJob.CustomVal)
-			require.JSONEq(b, string(expectedJob.Parameters), string(actualJob.Parameters))
-			require.JSONEq(b, string(expectedJob.EventPayload), string(actualJob.EventPayload))
+			require.Equal(b, expectedJob.UUID, consumedJobs[i].UUID)
+			require.Equal(b, expectedJob.UserID, consumedJobs[i].UserID)
+			require.Equal(b, expectedJob.CustomVal, consumedJobs[i].CustomVal)
+			require.JSONEq(b, string(expectedJob.Parameters), string(consumedJobs[i].Parameters))
+			require.JSONEq(b, string(expectedJob.EventPayload), string(consumedJobs[i].EventPayload))
 		}
 	})
 }
@@ -482,7 +482,7 @@ func BenchmarkLifecycle(b *testing.B) {
 	const newJobs = 100
 
 	dsSize := writeConcurrency * newJobs
-	triggerAddNewDS := make(chan time.Time, 0)
+	triggerAddNewDS := make(chan time.Time)
 
 	jobDB.MaxDSSize = &dsSize
 	jobDB.TriggerAddNewDS = func() <-chan time.Time {

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -766,6 +766,8 @@ func (jd *HandleT) workersAndAuxSetup() {
 	config.RegisterIntConfigVariable(3, &jd.maxReaders, false, 1, maxReadersKeys...)
 }
 
+// Start starts the jobsdb worker and housekeeping (migration, archive) threads.
+// Start should be called before any other jobsdb methods are called.
 func (jd *HandleT) Start() {
 	jd.writeChannel = make(chan writeJob)
 	jd.readChannel = make(chan readJob)
@@ -968,6 +970,9 @@ func (jd *HandleT) dbReader(ctx context.Context) {
 	}
 }
 
+// Stop stops the background goroutines and waits until they finish.
+// Stop should be called once only after Start.
+// Only Start and Close can be called after Stop.
 func (jd *HandleT) Stop() {
 	jd.backgroundCancel()
 	close(jd.readChannel)
@@ -975,14 +980,15 @@ func (jd *HandleT) Stop() {
 	jd.backgroundGroup.Wait()
 }
 
-/*
-TearDown releases all the resources
-*/
+// TearDown stops the background goroutines,
+//	waits until they finish and closes the database.
 func (jd *HandleT) TearDown() {
 	jd.Stop()
 	jd.Close()
 }
 
+// Close closes the database connection.
+// 	Stop should be called before Close.
 func (jd *HandleT) Close() {
 	jd.dbHandle.Close()
 }

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -644,15 +644,15 @@ func WithStatusHandler() OptsFunc {
 	}
 }
 
-func NewForRead(clearAll bool, tablePrefix string, opts ...OptsFunc) *HandleT {
+func NewForRead(tablePrefix string, opts ...OptsFunc) *HandleT {
 	return newOwnerType(Read, tablePrefix)
 }
 
-func NewForWrite(clearAll bool, tablePrefix string, opts ...OptsFunc) *HandleT {
+func NewForWrite(tablePrefix string, opts ...OptsFunc) *HandleT {
 	return newOwnerType(Write, tablePrefix)
 }
 
-func NewForReadWrite(clearAll bool, tablePrefix string, opts ...OptsFunc) *HandleT {
+func NewForReadWrite(tablePrefix string, opts ...OptsFunc) *HandleT {
 	return newOwnerType(ReadWrite, tablePrefix)
 }
 

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -645,15 +645,15 @@ func WithStatusHandler() OptsFunc {
 }
 
 func NewForRead(tablePrefix string, opts ...OptsFunc) *HandleT {
-	return newOwnerType(Read, tablePrefix)
+	return newOwnerType(Read, tablePrefix, opts...)
 }
 
 func NewForWrite(tablePrefix string, opts ...OptsFunc) *HandleT {
-	return newOwnerType(Write, tablePrefix)
+	return newOwnerType(Write, tablePrefix, opts...)
 }
 
 func NewForReadWrite(tablePrefix string, opts ...OptsFunc) *HandleT {
-	return newOwnerType(ReadWrite, tablePrefix)
+	return newOwnerType(ReadWrite, tablePrefix, opts...)
 }
 
 func newOwnerType(ownerType OwnerType, tablePrefix string, opts ...OptsFunc) *HandleT {


### PR DESCRIPTION
# JobsDB new Lifecycle

## Motivation

We wanted to be able to Start and Stop jobsdb, in order to get to degraded mode without process restart. 

Moreover, we would like to maintain the database connection, so start/stop should have the minimum amount of performance impact while remaining safe.

Our goal with this change is to maintain backward compatibility and minimise the number of changes.

## Change 1: Lifecycle

For this, we came up with a new interface, while keeping the existing one intact.

The new methods (& function) are:
* New()
* .Start()
* .Stop()
* .Close()

They meant to be symmetric:

```go
   gw := New()
   defer gw.Close()
   gw.Start()
   defer gw.Stop()
   
   // jobsdb can be used now
   // and will safely close
``` 

![Jobsdb-lifecycle drawio](https://user-images.githubusercontent.com/733195/157869601-4f46d804-ea0f-47e9-abc9-fb14b867604f.png)

## Change 2: replace `.Setup` with `NewFor*`


### Usage example
```go
gatewayDB.Setup(jobsdb.ReadWrite, options.ClearDB, "gw", gwDBRetention, migrationMode, true, jobsdb.QueryFiltersT{})
defer gatewayDB.TearDown()
```

```go
	gatewayDB := jobsdb.NewForReadWrite(
		"gw",
		jobsdb.WithClearDB(options.ClearDB),
		jobsdb.WithMigrationMode(migrationMode),
		jobsdb.WithRetention(gwDBRetention),
		jobsdb.WithStatusHandler(),
	)
	defer gatewayDB.Close()

	gatewayDB.Start()
	defer gatewayDB.Stop()
```
## Testing

We used `BenchmarkLifecycle` to test the start/stop the behavior. We used a benchmark because we wanted to ensure that after repeating many start/stop cycles, there was no memory, go routines, or other kinds of leaks.

## Migrations Issue

We stumble upon a known issue with migrations. The existing migration library was leaving some connections occupied, every time we run it, leading to connection exhaustion.

For this, a new connection is created for running the migrations and the destroyed. This increases the time it takes to start/stop. 


## Notion Link

> [Refactor jobsdb to support new life cycle managers](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
