### PR TITLE
CFD: Kill past connections from rudder-server

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -533,8 +533,8 @@ func getValidNonTerminalStates() (validNonTerminalStates []string) {
 }
 
 var (
-	host, user, password, dbname, sslmode string
-	port                                  int
+	host, user, password, dbname, sslmode, appName string
+	port                                           int
 )
 
 var (
@@ -567,6 +567,9 @@ func loadConfig() {
 	port, _ = strconv.Atoi(config.GetEnv("JOBS_DB_PORT", "5432"))
 	password = config.GetEnv("JOBS_DB_PASSWORD", "ubuntu") // Reading secrets from
 	sslmode = config.GetEnv("JOBS_DB_SSL_MODE", "disable")
+	// Application Name can be any string of less than NAMEDATALEN characters (64 characters in a standard PostgreSQL build).
+	// There is no need to truncate the string on our own though since PostgreSQL auto-truncates this identifier and issues a relevant notice if necessary.
+	appName = config.GetEnv("JOBS_DB_APP_NAME", misc.DefaultString("rudder-server").OnError(os.Hostname()))
 
 	/*Migration related parameters
 	jobDoneMigrateThres: A DS is migrated when this fraction of the jobs have been processed
@@ -604,8 +607,8 @@ func Init2() {
 // GetConnectionString Returns Jobs DB connection configuration
 func GetConnectionString() string {
 	return fmt.Sprintf("host=%s port=%d user=%s "+
-		"password=%s dbname=%s sslmode=%s",
-		host, port, user, password, dbname, sslmode)
+		"password=%s dbname=%s sslmode=%s application_name=%s",
+		host, port, user, password, dbname, sslmode, appName)
 
 }
 

--- a/utils/misc/default_string.go
+++ b/utils/misc/default_string.go
@@ -1,0 +1,22 @@
+package misc
+
+// DefaultString is a utility type for providing default values using one-liners
+// in otherwise multi-line scenarios.
+//
+// E.g. this
+//   v := misc.DefaultString("unknown").OnError(os.Hostname())
+//
+// is the equivalent of
+//   v, err := os.Hostname()
+//   if err != nil {
+//     v = 	"unknown"
+//   }
+type DefaultString string
+
+// OnError returns the default value if the err argument is not nil, otherwise the value
+func (r DefaultString) OnError(value string, err error) string {
+	if err != nil {
+		return string(r)
+	}
+	return value
+}

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -1070,7 +1070,7 @@ func GetObjectStorageConfig(opts ObjectStorageOptsT) map[string]interface{} {
 }
 
 func GetSpacesLocation(location string) (region string) {
-	r, _ := regexp.Compile("\\.*.*\\.digitaloceanspaces\\.com")
+	r, _ := regexp.Compile(`\.*.*\.digitaloceanspaces\.com`)
 	subLocation := r.FindString(location)
 	regionTokens := strings.Split(subLocation, ".")
 	if len(regionTokens) == 3 {


### PR DESCRIPTION
## Description of the change

SQL statements in rudder-server are not executed with a timeout context,
instead we are letting them take as much time as they need.

Due to the above, when a server shutdown is initiated in a cloud environment
while long-running statements are being executed, the server process will not
manage to shutdown gracefully, since it will be blocked by the SQL statements.
The container orchestrator will eventually kill the server process, leaving
one or more dangling connections in the database.

This change ensures that before a new rudder-server instance starts working,
all previous dangling connections belonging to this server are being killed.

To support killing only connections opened by a specific rudder-server,
the `application_name` parameter is being populated with the server's hostname.
This behaviour can be overrided though through the `JOBS_DB_APP_NAME` environment
variable.

## Notion Link

https://www.notion.so/rudderstacks/Kill-past-connections-from-rudder-server-c9fb7a9d3c55492eb29cb621ad2afc9b

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
