### PR TITLE
patch for handling marshal panic in router transformer

### DIFF
--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -73,6 +73,14 @@ func Init() {
 
 //Transform transforms router jobs to destination jobs
 func (trans *HandleT) Transform(transformType string, transformMessage *types.TransformMessageT) []types.DestinationJobT {
+
+	// Patch fix for handling panic when marshal fails, by assigning empty secret in router job transform as json.RawMessage(nil)
+	for _, routerJobT := range transformMessage.Data {
+		if len(routerJobT.JobMetadata.Secret) == 0 {
+			routerJobT.JobMetadata.Secret = json.RawMessage(nil)
+		}
+	}
+
 	//Call remote transformation
 	rawJSON, err := json.Marshal(transformMessage)
 	if err != nil {


### PR DESCRIPTION
## Patch for handling marshal panic in router transformer

## Description of the change
Router transformer fails to marshal payload if `Secret` contains `json.rawMessage{}`. Using `jsoniter` instead of `encoding/json` to resolve the issue.

## Minimal reproduction steps
Run the following code on https://go.dev/play/
```
package main

import (
	"encoding/json"
	"fmt"

	jsoniter "github.com/json-iterator/go"
)

type someStruct struct {
	Secret  json.RawMessage
	Somekey int
}

var jsonfast = jsoniter.ConfigCompatibleWithStandardLibrary

func main() {
	var s1 someStruct
	s1.Secret = json.RawMessage{}
	s1.Somekey = 2
	_, err1 := json.Marshal(s1)
	_, err2 := jsonfast.Marshal(s1)
	fmt.Printf("err1 : %v\n", err1)
	fmt.Printf("err2 : %v\n", err2)
}


```

## Notion Link
`server-eng` to fill this

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests for the code
- [x] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
