### PR TITLE
Use bash to run entrypoint script

### DIFF
--- a/build/Dockerfile-aws
+++ b/build/Dockerfile-aws
@@ -1,5 +1,5 @@
 FROM frolvlad/alpine-glibc:alpine-3.15_glibc-2.34
-RUN apk add --no-cache ca-certificates postgresql-client curl 
+RUN apk add --no-cache ca-certificates postgresql-client curl bash
 RUN apk upgrade
 ADD rudder-server /
 ADD ./rudder-cli/rudder-cli.linux.x86_64 /usr/bin/rudder-cli

--- a/build/Dockerfile-aws-dev
+++ b/build/Dockerfile-aws-dev
@@ -1,5 +1,5 @@
 FROM frolvlad/alpine-glibc:alpine-3.15_glibc-2.34
-RUN apk add --no-cache ca-certificates postgresql-client curl
+RUN apk add --no-cache ca-certificates postgresql-client curl bash
 RUN apk upgrade
 ADD rudder-server /
 ADD rudder-server-with-race /

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Used mysql docker entrypoint script as reference to create this script
 # https://github.com/docker-library/mysql/blob/master/5.6/docker-entrypoint.sh


### PR DESCRIPTION
## Description of the change

Add and use bash to run our entrypoint.sh script. Latest alpine versions have introduce a `sh` shell that didn't support our syntax.

## Notion Link

 [Notion Link](https://www.notion.so/rudderstacks/Fix-entrypoint-sh-script-issue-f185b8c0e23a4339baba2d8f783cb3e5)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
