### PR TITLE
Remove batch id from stats as it has high cardinality

### DIFF
--- a/services/pgnotifier/pgnotifier.go
+++ b/services/pgnotifier/pgnotifier.go
@@ -359,7 +359,6 @@ func (notifier *PgNotifierT) Publish(jobs []JobPayload, priority int) (ch chan [
 	pkgLogger.Infof("PgNotifier: Inserted %d records into %s as batch: %s", len(jobs), queueName, batchID)
 	stats.NewTaggedStat("pg_notifier_insert_records", stats.CountType, map[string]string{
 		"queueName": queueName,
-		"batchID":   batchID,
 		"module":    "pg_notifier",
 	}).Count(len(jobs))
 	notifier.trackBatch(batchID, &ch)


### PR DESCRIPTION
## Description of the change

> Remove batch id from stats as it has high cardinality

## Notion Link

> [Notion Link](https://www.notion.so/rudderstacks/Remove-batchId-from-stats-high-cardinality-0f25e8dfcddd4c76a8fe1194dd5d9cbf)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
