### PR TITLE
Mitigation for stuck processor: Panic on processor store timeout

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -173,6 +173,7 @@ Processor:
   loopSleep: 10ms
   maxLoopSleep: 5000ms
   fixedLoopSleep: 0ms
+  storeTimeout: 5m
   maxLoopProcessEvents: 10000
   transformBatchSize: 100
   userTransformBatchSize: 200

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -476,7 +476,7 @@ func loadConfig() {
 	config.RegisterIntConfigVariable(0, &pipelineBufferedItems, false, 1, "Processor.pipelineBufferedItems")
 	config.RegisterIntConfigVariable(2000, &subJobSize, false, 1, "Processor.subJobSize")
 	config.RegisterDurationConfigVariable(time.Duration(5000), &maxLoopSleep, true, time.Millisecond, []string{"Processor.maxLoopSleep", "Processor.maxLoopSleepInMS"}...)
-	config.RegisterDurationConfigVariable(5*time.Minute, &storeTimeout, true, time.Millisecond, "Processor.storeTimeout")
+	config.RegisterDurationConfigVariable(time.Duration(5*time.Minute/time.Minute), &storeTimeout, true, time.Minute, "Processor.storeTimeout")
 
 	config.RegisterDurationConfigVariable(time.Duration(200), &readLoopSleep, true, time.Millisecond, "Processor.readLoopSleep")
 	//DEPRECATED: used only on the old mainLoop:
@@ -1478,9 +1478,11 @@ type storeMessage struct {
 }
 
 func (proc *HandleT) Store(in storeMessage) {
+	// FIXME: This is a hack to get around the fact that,
+	// 	processor will stuck in case write query takes for ever.
+	// SHOULD BE REMOVED AFTER PROPER TIMEOUTS ARE IMPLEMENTED.
 	ctx, cancel := context.WithTimeout(context.TODO(), proc.storeTimeout)
 	defer cancel()
-
 	go func() {
 		<-ctx.Done()
 		if ctx.Err() == context.DeadlineExceeded {
@@ -1494,29 +1496,6 @@ func (proc *HandleT) Store(in storeMessage) {
 	processorLoopStats["batch_router"] = make(map[string]map[string]int)
 	beforeStoreStatus := time.Now()
 	//XX: Need to do this in a transaction
-	if len(destJobs) > 0 {
-		proc.logger.Debug("[Processor] Total jobs written to router : ", len(destJobs))
-
-		err := proc.routerDB.Store(destJobs)
-		if err != nil {
-			proc.logger.Errorf("Store into router table failed with error: %v", err)
-			proc.logger.Errorf("destJobs: %v", destJobs)
-			panic(err)
-		}
-		totalPayloadRouterBytes := 0
-		for i := range destJobs {
-			_, ok := processorLoopStats["router"][destJobs[i].WorkspaceId]
-			if !ok {
-				processorLoopStats["router"][destJobs[i].WorkspaceId] = make(map[string]int)
-			}
-			processorLoopStats["router"][destJobs[i].WorkspaceId][destJobs[i].CustomVal] += 1
-			totalPayloadRouterBytes += len(destJobs[i].EventPayload)
-		}
-
-		proc.statDestNumOutputEvents.Count(len(destJobs))
-		proc.statDBWriteRouterEvents.Observe(float64(len(destJobs)))
-		proc.statDBWriteRouterPayloadBytes.Observe(float64(totalPayloadRouterBytes))
-	}
 	if len(batchDestJobs) > 0 {
 		proc.logger.Debug("[Processor] Total jobs written to batch router : ", len(batchDestJobs))
 		err := proc.batchRouterDB.Store(batchDestJobs)
@@ -1539,6 +1518,30 @@ func (proc *HandleT) Store(in storeMessage) {
 		proc.statBatchDestNumOutputEvents.Count(len(batchDestJobs))
 		proc.statDBWriteBatchEvents.Observe(float64(len(batchDestJobs)))
 		proc.statDBWriteBatchPayloadBytes.Observe(float64(totalPayloadBatchBytes))
+	}
+
+	if len(destJobs) > 0 {
+		proc.logger.Debug("[Processor] Total jobs written to router : ", len(destJobs))
+
+		err := proc.routerDB.Store(destJobs)
+		if err != nil {
+			proc.logger.Errorf("Store into router table failed with error: %v", err)
+			proc.logger.Errorf("destJobs: %v", destJobs)
+			panic(err)
+		}
+		totalPayloadRouterBytes := 0
+		for i := range destJobs {
+			_, ok := processorLoopStats["router"][destJobs[i].WorkspaceId]
+			if !ok {
+				processorLoopStats["router"][destJobs[i].WorkspaceId] = make(map[string]int)
+			}
+			processorLoopStats["router"][destJobs[i].WorkspaceId][destJobs[i].CustomVal] += 1
+			totalPayloadRouterBytes += len(destJobs[i].EventPayload)
+		}
+
+		proc.statDestNumOutputEvents.Count(len(destJobs))
+		proc.statDBWriteRouterEvents.Observe(float64(len(destJobs)))
+		proc.statDBWriteRouterPayloadBytes.Observe(float64(totalPayloadRouterBytes))
 	}
 
 	for _, jobs := range in.procErrorJobsByDestID {


### PR DESCRIPTION
## Issue: stuck processor

The processor can get stuck under some conditions. We know that in this case writes to batchrouter (or router) at wait for a very long time or forever.

We still have found the root cause of this issue, but given the urgency and impact of this problem, we would like to provide quick mitigation.

**Note**: we could have also used metrics, to automatically restart the server and avoid this hack. However, automatic actions based on metrics are only available for Prometheus alerts, not Kapacitor.

## Mitigation

When the store method is called, we create a context with a timeout. We check in a goroutine if the context is Done due to Deadline, if yes then we panic.

It might seem crude way but is better to panic than block forever. Unfortunately, there wasn't any easy way to exit gracefully.

## Timeout

I've set the timeout to 5 minutes, I wanted to make sure that we want `panic` in case of a slow insert, but we will detect a stuck processor fast enough.

## How to test
apply the following change

```diff
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -173,7 +173,7 @@ Processor:
   loopSleep: 10ms
   maxLoopSleep: 5000ms
   fixedLoopSleep: 0ms
-  storeTimeout: 5m
+  storeTimeout: 1ms
   maxLoopProcessEvents: 10000
   transformBatchSize: 100
   userTransformBatchSize: 200
```

Run the server and generate an event. You should see:

```
panic: processor .Store() timed out after 1ms

goroutine 1525 [running]:
github.com/rudderlabs/rudder-server/processor.(*HandleT).Store.func1({0x102f03c38, 0x14001c6aa20}, 0x14000466c00)
        /Users/leonidas/src/rudder/rudder-server/processor/processor.go:1487 +0x118
created by github.com/rudderlabs/rudder-server/processor.(*HandleT).Store
        /Users/leonidas/src/rudder/rudder-server/processor/processor.go:1484 +0x98
exit status 2
```

## Notion Link

[Notion Link
](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=c6a8cbadea854c60bb705e757bc7ee94)
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
