### PR TITLE
compute index fixes

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1431,8 +1431,8 @@ func computeInsertIdx(beforeIndex, afterIndex string) (string, error) {
 		return "", fmt.Errorf("Not a valid insert request between %s and %s", beforeIndex, afterIndex)
 	}
 
-	//No dataset should have 0 as the index.
-	//0_1, 0_2 are allowed.
+	// No dataset should have 0 as the index.
+	// 0_1, 0_2 are allowed.
 	if beforeIndex == "0" {
 		return "", fmt.Errorf("Unsupported beforeIndex: %s", beforeIndex)
 	}

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1371,6 +1371,12 @@ func computeIdxForClusterMigration(tablePrefix string, dList []dataSetT, insertB
 //Tries to give a slice between before and after by incrementing last value in before. If the order doesn't maintain, it adds a level and recurses.
 func computeInsertVals(before, after []string) ([]string, error) {
 	for {
+		//Safe check: In the current jobsdb implementation, indices don't go more
+		//than 3 levels deep. Breaking out of the loop if the before is of size more than 4.
+		if len(before) > 4 {
+			return before, fmt.Errorf("can't compute insert index due to bad inputs. before: %v, after: %v", before, after)
+		}
+
 		calculatedVals := make([]string, len(before))
 		copy(calculatedVals, before)
 		lastVal, err := strconv.Atoi(calculatedVals[len(calculatedVals)-1])
@@ -1391,25 +1397,27 @@ func computeInsertVals(before, after []string) ([]string, error) {
 			}
 		}
 
-		var comparison bool
 		if !equals {
-			comparison, err = dsComparitor(calculatedVals, after)
+			comparison, err := dsComparitor(calculatedVals, after)
 			if err != nil {
 				return calculatedVals, err
 			}
-		} else {
-			comparison = false
+			if !comparison {
+				return calculatedVals, fmt.Errorf("computed index is invalid. before: %v, after: %v, calculatedVals: %v", before, after, calculatedVals)
+			}
 		}
 
-		//The basic requirement is that the possible candidate should be smaller compared to the insertBeforeDS.
-		if comparison {
-			//Only when the index starts with 0, we allow three levels. This would be when we have to insert an internal migration DS between two import DSs
-			//In all other cases, we allow only two levels
-			if (before[0] == "0" && len(calculatedVals) == 3) ||
-				(before[0] != "0" && len(calculatedVals) == 2) {
+		//Only when the index starts with 0, we allow three levels. This would be when we have to insert an internal migration DS between two import DSs
+		//In all other cases, we allow only two levels
+		if (before[0] == "0" && len(calculatedVals) == 3) ||
+			(before[0] != "0" && len(calculatedVals) == 2) {
+			if equals {
+				return calculatedVals, fmt.Errorf("calculatedVals and after are same. computed index is invalid. before: %v, after: %v, calculatedVals: %v", before, after, calculatedVals)
+			} else {
 				return calculatedVals, nil
 			}
 		}
+
 		before = append(before, "0")
 	}
 }
@@ -1421,6 +1429,12 @@ func computeInsertIdx(beforeIndex, afterIndex string) (string, error) {
 	}
 	if !comparison {
 		return "", fmt.Errorf("Not a valid insert request between %s and %s", beforeIndex, afterIndex)
+	}
+
+	//No dataset should have 0 as the index.
+	//0_1, 0_2 are allowed.
+	if beforeIndex == "0" {
+		return "", fmt.Errorf("Unsupported beforeIndex: %s", beforeIndex)
 	}
 
 	beforeVals := strings.Split(beforeIndex, "_")

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -59,7 +59,70 @@ var _ = Describe("Calculate newDSIdx for internal migrations", func() {
 		Entry("Internal Migration for import tables Case 5 Test 1 : ", "0_1", "0_2_1", "0_1_1"),
 
 		Entry("OrderTest Case 1 Test 1 : ", "9", "10", "9_1"),
+
+		Entry("Internal Migration for tables : ", "10_1", "11_3", "10_2"),
+		Entry("Internal Migration for tables : ", "0_1", "1", "0_1_1"),
+		Entry("Internal Migration for tables : ", "0_1", "20", "0_1_1"),
+		Entry("Internal Migration for tables : ", "0_1", "0_2", "0_1_1"),
 	)
+
+	Context("computeInsertIdx - bad input tests", func() {
+		It("Should throw error for input 1, 1_1", func() {
+			_, err := computeInsertIdx("1", "1_1")
+			Expect(err).To(HaveOccurred())
+		})
+		It("Should throw error for input 10_1, 10_2", func() {
+			_, err := computeInsertIdx("10_1", "10_2")
+			Expect(err).To(HaveOccurred())
+		})
+		It("Should throw error for input 10_1, 10_1", func() {
+			_, err := computeInsertIdx("10_1", "10_1")
+			Expect(err).To(HaveOccurred())
+		})
+		It("Should throw error for input 10, 9", func() {
+			_, err := computeInsertIdx("10", "9")
+			Expect(err).To(HaveOccurred())
+		})
+		It("Should throw error for input 10_1_2, 11_3", func() {
+			_, err := computeInsertIdx("10_1_2", "11_3")
+			Expect(err).To(HaveOccurred())
+		})
+		It("Should throw error for input 0, 1", func() {
+			_, err := computeInsertIdx("0", "1")
+			Expect(err).To(HaveOccurred())
+		})
+		It("Should throw error for input 0_1, 0", func() {
+			_, err := computeInsertIdx("0_1", "0")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("computeInsertVals - good input tests", func() {
+		It("Should not throw error for input 0_1, 0_2", func() {
+			calculatedIdx, err := computeInsertVals([]string{"0", "1"}, []string{"0", "2"})
+			Expect(err).To(BeNil())
+			Expect(calculatedIdx).To(Equal([]string{"0", "1", "1"}))
+		})
+	})
+
+	Context("computeInsertVals - bad input tests", func() {
+		It("Should throw error for input 1, 1_1", func() {
+			_, err := computeInsertVals([]string{"1"}, []string{"1", "1"})
+			Expect(err).To(HaveOccurred())
+		})
+		It("Should throw error for input 10_1, 10_2", func() {
+			_, err := computeInsertVals([]string{"10", "1"}, []string{"10", "2"})
+			Expect(err).To(HaveOccurred())
+		})
+		It("Should throw error for input 10_1, 10_1", func() {
+			_, err := computeInsertVals([]string{"10", "1"}, []string{"10", "1"})
+			Expect(err).To(HaveOccurred())
+		})
+		It("Should throw error for input 10, 9", func() {
+			_, err := computeInsertVals([]string{"10"}, []string{"9"})
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })
 
 var _ = Describe("Calculate newDSIdx for cluster migrations", func() {


### PR DESCRIPTION
## Description of the change

computeInsertVals function goes into infinite loop, when before and after are given as follows:
before: 10_1
after: 10_2.

This pr fixes the bug and adds some safe checks.

## Notion Link

https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=98a1ca1d4c5f429b9116fa0eb1652714

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
