### PR TITLE
fix order of checkifmigrate function

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -2642,9 +2642,6 @@ func (jd *HandleT) migrateDSLoop(ctx context.Context) {
 
 		for idx, ds := range dsList {
 
-			ifMigrate, remCount := jd.checkIfMigrateDS(ds)
-			jd.logger.Debugf("[[ %s : migrateDSLoop ]]: Migrate check %v, ds: %v", jd.tablePrefix, ifMigrate, ds)
-
 			var idxCheck bool
 			if jd.ownerType == Read {
 				//if jobsdb owner is read, expempting the last two datasets from migration.
@@ -2657,6 +2654,9 @@ func (jd *HandleT) migrateDSLoop(ctx context.Context) {
 			if liveDSCount >= maxMigrateOnce || liveJobCount >= maxDSSize || idxCheck {
 				break
 			}
+
+			ifMigrate, remCount := jd.checkIfMigrateDS(ds)
+			jd.logger.Debugf("[[ %s : migrateDSLoop ]]: Migrate check %v, ds: %v", jd.tablePrefix, ifMigrate, ds)
 
 			if ifMigrate {
 				migrateFrom = append(migrateFrom, ds)


### PR DESCRIPTION
## Description of the change

When we evaluate the datasets eligible for internal migration, we don't have to check the right most dataset. This pr makes sure that we dont call checkIfMigrateDS on the right most dataset by breaking out of the loop.

## Notion Link

https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=cbaf61884eef45fbbb49da47a6d0b60f

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
