### PR TITLE
Fix: Jobsdb migration bug

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -554,13 +554,6 @@ var (
 	useNewCacheBurst                             bool
 )
 
-//Different scenarios for addNewDS
-const (
-	appendToDsList     = "appendToDsList"
-	insertForMigration = "insertForMigration"
-	insertForImport    = "insertForImport"
-)
-
 // Loads db config and migration related config from config file
 func loadConfig() {
 	host = config.GetEnv("JOBS_DB_HOST", "localhost")
@@ -873,7 +866,7 @@ func (jd *HandleT) writerSetup(ctx context.Context) {
 
 	//If no DS present, add one
 	if len(jd.datasetList) == 0 {
-		jd.addNewDS(appendToDsList, dataSetT{})
+		jd.addDS(jd.newDataSetStruct(jd.computeNewIdxForAppend()), true)
 	}
 
 	jd.backgroundGroup.Go(misc.WithBugsnag(func() error {
@@ -1240,37 +1233,26 @@ func mapDSToLevel(ds dataSetT) (levelInt int, levelVals []int, err error) {
 	return len(levelVals), levelVals, nil
 }
 
-func (jd *HandleT) createTableNames(dsIdx string) (string, string) {
+func (jd *HandleT) newDataSetStruct(dsIdx string) dataSetT {
 	jobTable := fmt.Sprintf("%s_jobs_%s", jd.tablePrefix, dsIdx)
 	jobStatusTable := fmt.Sprintf("%s_job_status_%s", jd.tablePrefix, dsIdx)
-	return jobTable, jobStatusTable
+	return dataSetT{
+		JobTable:       jobTable,
+		JobStatusTable: jobStatusTable,
+		Index:          dsIdx,
+	}
 }
 
-func (jd *HandleT) addNewDS(newDSType string, insertBeforeDS dataSetT) dataSetT {
-	jd.logger.Infof("Creating new DS of type %s before ds %s for %s jobsdb", newDSType, insertBeforeDS.Index, jd.tablePrefix)
-	var newDSIdx string
-	appendLast := newDSType == appendToDsList
+func (jd *HandleT) addDS(ds dataSetT, isNew bool) {
+	jd.logger.Infof("Creating new DS %+v", ds)
 
 	queryStat := stats.NewTaggedStat("add_new_ds", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix})
 
 	queryStat.Start()
 	defer queryStat.End()
 
-	switch newDSType {
-	case appendToDsList:
-		newDSIdx = jd.computeNewIdxForAppend()
-	case insertForMigration:
-		newDSIdx = jd.computeNewIdxForIntraNodeMigration(insertBeforeDS)
-	case insertForImport:
-		newDSIdx = jd.computeNewIdxForInterNodeMigration(insertBeforeDS)
-	default:
-		panic("Unknown usage for newDSType : " + newDSType)
-
-	}
-	jd.assert(newDSIdx != "", "newDSIdx is empty")
-
 	defer func() {
-		if appendLast {
+		if isNew {
 			// Tracking time interval between new ds creations. Hence calling end before start
 			if jd.isStatNewDSPeriodInitialized {
 				jd.statNewDSPeriod.End()
@@ -1280,7 +1262,7 @@ func (jd *HandleT) addNewDS(newDSType string, insertBeforeDS dataSetT) dataSetT 
 		}
 	}()
 
-	return jd.createDS(appendLast, newDSIdx)
+	jd.createDS(ds, isNew)
 }
 
 func (jd *HandleT) computeNewIdxForAppend() string {
@@ -1477,10 +1459,7 @@ type transactionHandler interface {
 	//Only the function that passes *sql.Tx should do the commit or rollback based on the error it receives
 }
 
-func (jd *HandleT) createDS(appendLast bool, newDSIdx string) dataSetT {
-	var newDS dataSetT
-	newDS.JobTable, newDS.JobStatusTable = jd.createTableNames(newDSIdx)
-	newDS.Index = newDSIdx
+func (jd *HandleT) createDS(newDS dataSetT, refreshList bool) {
 
 	//Mark the start of operation. If we crash somewhere here, we delete the
 	//DS being added
@@ -1506,7 +1485,7 @@ func (jd *HandleT) createDS(appendLast bool, newDSIdx string) dataSetT {
 
 	//TODO : Evaluate a way to handle indexes only for particular tables
 	if jd.tablePrefix == "rt" {
-		sqlStatement = fmt.Sprintf(`CREATE INDEX IF NOT EXISTS customval_workspace_%s ON "%s" (custom_val,workspace_id)`, newDSIdx, newDS.JobTable)
+		sqlStatement = fmt.Sprintf(`CREATE INDEX IF NOT EXISTS customval_workspace_%s ON "%s" (custom_val,workspace_id)`, newDS.Index, newDS.JobTable)
 		_, err = jd.dbHandle.Exec(sqlStatement)
 		jd.assertError(err)
 	}
@@ -1525,16 +1504,12 @@ func (jd *HandleT) createDS(appendLast bool, newDSIdx string) dataSetT {
 	_, err = jd.dbHandle.Exec(sqlStatement)
 	jd.assertError(err)
 
-	if appendLast {
-		newDSWithSeqNumber := jd.setSequenceNumber(newDSIdx)
-		jd.JournalMarkDone(opID)
-		return newDSWithSeqNumber
-	}
-
-	//This is the migration case. We don't yet update the in-memory list till
+	//In case of a migration, we don't yet update the in-memory list till
 	//we finish the migration
+	if refreshList {
+		jd.setSequenceNumber(newDS.Index)
+	}
 	jd.JournalMarkDone(opID)
-	return newDS
 }
 
 func (jd *HandleT) setSequenceNumber(newDSIdx string) dataSetT {
@@ -2589,7 +2564,7 @@ func (jd *HandleT) addNewDSLoop(ctx context.Context) {
 			//take the list lock
 			jd.dsListLock.Lock()
 			jd.logger.Infof("[[ %s : addNewDSLoop ]]: NewDS", jd.tablePrefix)
-			jd.addNewDS(appendToDsList, dataSetT{})
+			jd.addDS(jd.newDataSetStruct(jd.computeNewIdxForAppend()), true)
 			jd.dsListLock.Unlock()
 		}
 	}
@@ -2680,9 +2655,8 @@ func (jd *HandleT) migrateDSLoop(ctx context.Context) {
 		if len(migrateFrom) > 0 {
 			if liveJobCount > 0 {
 				jd.dsListLock.Lock()
-				migrateTo := jd.addNewDS(insertForMigration, insertBeforeDS)
-				jd.inProgressMigrationTargetDS = &migrateTo
-				jd.dsListLock.Unlock()
+
+				migrateTo := jd.newDataSetStruct(jd.computeNewIdxForIntraNodeMigration(insertBeforeDS))
 
 				jd.logger.Infof("[[ %s : migrateDSLoop ]]: Migrate from: %v", jd.tablePrefix, migrateFrom)
 				jd.logger.Infof("[[ %s : migrateDSLoop ]]: Next: %v", jd.tablePrefix, insertBeforeDS)
@@ -2690,10 +2664,13 @@ func (jd *HandleT) migrateDSLoop(ctx context.Context) {
 				//Mark the start of copy operation. If we fail here
 				//we just delete the new DS being copied into. The
 				//sources are still around
-
 				opPayload, err := json.Marshal(&journalOpPayloadT{From: migrateFrom, To: migrateTo})
 				jd.assertError(err)
 				opID := jd.JournalMarkStart(migrateCopyOperation, opPayload)
+
+				jd.addDS(migrateTo, false)
+				jd.inProgressMigrationTargetDS = &migrateTo
+				jd.dsListLock.Unlock()
 
 				totalJobsMigrated := 0
 				for _, ds := range migrateFrom {

--- a/jobsdb/jobsdb_import.go
+++ b/jobsdb/jobsdb_import.go
@@ -15,7 +15,8 @@ func (jd *HandleT) SetupForImport() {
 }
 
 func (jd *HandleT) getDsForImport(dsList []dataSetT) dataSetT {
-	ds := jd.addNewDS(insertForImport, jd.migrationState.dsForNewEvents)
+	ds := jd.newDataSetStruct(jd.computeNewIdxForInterNodeMigration(jd.migrationState.dsForNewEvents))
+	jd.addDS(ds, false)
 	jd.logger.Infof("[[ %s-JobsDB Import ]] Should Checkpoint Import Setup event for the new ds : %v", jd.GetTablePrefix(), ds)
 	return ds
 }
@@ -70,7 +71,8 @@ func (jd *HandleT) StoreJobsAndCheckpoint(jobList []*JobT, migrationCheckpoint M
 		opID = jd.JournalMarkStart(migrateImportOperation, opPayload)
 	} else if jd.checkIfFullDS(jd.migrationState.dsForImport) {
 		jd.dsListLock.Lock()
-		jd.migrationState.dsForImport = jd.addNewDS(insertForImport, jd.migrationState.dsForNewEvents)
+		jd.migrationState.dsForImport = jd.newDataSetStruct(jd.computeNewIdxForInterNodeMigration(jd.migrationState.dsForNewEvents))
+		jd.addDS(jd.migrationState.dsForImport, false)
 		setupCheckpoint, found := jd.GetSetupCheckpoint(ImportOp)
 		jd.assert(found, "There should be a setup checkpoint at this point. If not something went wrong. Go debug")
 		setupCheckpoint.Payload, _ = json.Marshal(jd.migrationState.dsForImport)
@@ -154,7 +156,8 @@ func (jd *HandleT) UpdateSequenceNumberOfLatestDS(seqNoForNewDS int64) {
 	if jd.isEmpty(dsList[dsListLen-1]) {
 		ds = dsList[dsListLen-1]
 	} else {
-		ds = jd.addNewDS(appendToDsList, dataSetT{})
+		ds = jd.newDataSetStruct(jd.computeNewIdxForAppend())
+		jd.addDS(ds, true)
 	}
 
 	var serialInt sql.NullInt64

--- a/jobsdb/jobsdb_import.go
+++ b/jobsdb/jobsdb_import.go
@@ -15,8 +15,8 @@ func (jd *HandleT) SetupForImport() {
 }
 
 func (jd *HandleT) getDsForImport(dsList []dataSetT) dataSetT {
-	ds := jd.newDataSetStruct(jd.computeNewIdxForInterNodeMigration(jd.migrationState.dsForNewEvents))
-	jd.addDS(ds, false)
+	ds := newDataSet(jd.tablePrefix, jd.computeNewIdxForInterNodeMigration(jd.migrationState.dsForNewEvents))
+	jd.addDS(ds)
 	jd.logger.Infof("[[ %s-JobsDB Import ]] Should Checkpoint Import Setup event for the new ds : %v", jd.GetTablePrefix(), ds)
 	return ds
 }
@@ -71,8 +71,8 @@ func (jd *HandleT) StoreJobsAndCheckpoint(jobList []*JobT, migrationCheckpoint M
 		opID = jd.JournalMarkStart(migrateImportOperation, opPayload)
 	} else if jd.checkIfFullDS(jd.migrationState.dsForImport) {
 		jd.dsListLock.Lock()
-		jd.migrationState.dsForImport = jd.newDataSetStruct(jd.computeNewIdxForInterNodeMigration(jd.migrationState.dsForNewEvents))
-		jd.addDS(jd.migrationState.dsForImport, false)
+		jd.migrationState.dsForImport = newDataSet(jd.tablePrefix, jd.computeNewIdxForInterNodeMigration(jd.migrationState.dsForNewEvents))
+		jd.addDS(jd.migrationState.dsForImport)
 		setupCheckpoint, found := jd.GetSetupCheckpoint(ImportOp)
 		jd.assert(found, "There should be a setup checkpoint at this point. If not something went wrong. Go debug")
 		setupCheckpoint.Payload, _ = json.Marshal(jd.migrationState.dsForImport)
@@ -156,8 +156,8 @@ func (jd *HandleT) UpdateSequenceNumberOfLatestDS(seqNoForNewDS int64) {
 	if jd.isEmpty(dsList[dsListLen-1]) {
 		ds = dsList[dsListLen-1]
 	} else {
-		ds = jd.newDataSetStruct(jd.computeNewIdxForAppend())
-		jd.addDS(ds, true)
+		ds = newDataSet(jd.tablePrefix, jd.computeNewIdxForAppend())
+		jd.addNewDS(ds)
 	}
 
 	var serialInt sql.NullInt64


### PR DESCRIPTION
## Description of the change

If server crashes (panics)  while the `migrateDSLoop` is running and has managed to create a new `dataSet` but has not managed to mark the start of copy operation in the journal yet, then the dataSet's tables are not cleaned up during recovery.

This fix reverses the order of actions so that the copy operation is recorded in the journal before any new dataSet gets created. To achieve this, `HandleT#addNewDS` method had to be refactored to accept the `dataSetT` to be created as a parameter instead of calculating it within the method's body  based on the previous method parameters. Due to this change, all invocations of this method had to be adapted as well.

_**Hint:**_
The jobDB's journal table appears to be a poor man's method for performing transaction demarcation. To understand this a bit better, please consider first that long-running transactions are not preferred by `rudder-server` due to the involved lock contention. But, there are occasions where we need to perform multiple database operations as atomic operations (either succeed completely or fail completely). An operation entry in the journal table marks the start of such a transaction. If the operation fails to complete successfully, the server will crash (panic). Upon restart, the recovery process will kick in, it will scan the journal for incomplete operations and perform all necessary compensation actions, a.k.a. rollback. After recovery finishes, the server's services are safe to start again against a consistent state.

## Notion Link

https://www.notion.so/rudderstacks/Jobsdb-migration-bug-f71cff7202734ce0814b9f807777d008

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
