### PR TITLE
Feat[github]: stale PR handling

### DIFF
--- a/.github/workflows/handle-stale-pr.yaml
+++ b/.github/workflows/handle-stale-pr.yaml
@@ -1,0 +1,22 @@
+name: Handle stale PRs
+
+on:
+  schedule:
+    - cron: '42 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: 'This PR is considered to be stale. It has been open 20 days with no further activity thus it is going to be closed in 5 days. To avoid such a case please consider removing the stale label manually or add a comment to the PR.'
+          days-before-pr-stale: 20
+          days-before-pr-close: 7
+          stale-pr-label: 'Stale'
+


### PR DESCRIPTION
## Description of the change

We need to reduce the overal repo noise. One of the action items we came up with is to automatically annotate PR to be `Stale` after 20 days of inactivity.
Every `Stale` annotated PR is going to be closed and the related branch to be deleted after 7 days of inactivity. 

## Notion Link

https://www.notion.so/rudderstacks/GHA-Mark-and-close-stale-PRs-fa4dd98cef2846b3bf82f18e2f3ec909

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
