### PR TITLE
fix: `pre_drop` table pileup issue

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -2772,6 +2772,10 @@ func (jd *HandleT) backupDSLoop(ctx context.Context) {
 
 		// drop dataset after successfully uploading both jobs and jobs_status to s3
 		opID = jd.JournalMarkStart(backupDropDSOperation, opPayload)
+		//Currently, we retry uploading a table for sometime & if it fails. We only drop that table & not all `pre_drop` tables.
+		// So, in situation when new table creation rate is more than drop. We will still have pipe up issue.
+		// An easy way to fix this is, if at any point of time exponential retry fails then instead of just dropping that particular
+		// table drop all subsequent `pre_drop` table. As, most likely the upload of rest of the table will also fail with the same error.
 		jd.dropDS(backupDS, false)
 		jd.JournalMarkDone(opID)
 	}


### PR DESCRIPTION
## Description of the issue

> Currently, when `BackupEnabled` is `true`, we try backing-up `pre_drop` tables to the configured bucket. And, drop the table only after the upload is successful. But, there is no upper limit on how many times (or for how long) we are going to retry in case of failure. Because of this, we end up retrying infinitely & never really drop the table if config is incorrect or if access key is has expired.

## Description of the change

>We have introduced an `exponentialBackoff` retry mechanism with maximum retry time of 10 minute, i.e. if upload didn't succeed in 10 min, retry will be stopped & `pre_drop` tables will be dropped.

## NOTE
>Currently, we retry uploading a table for sometime & if it fails. We only drop that table & not all `pre_drop` tables. So, in situation when new table creation rate is more than drop. We will still have pipe up issue. An easy way to fix this is, if at any point of time exponential retry fails then instead of just dropping that particular table drop all subsequent `pre_drop` table. As, most likely the upload of rest of the table will also fail with the same error.

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Notion Link
https://www.notion.so/rudderstacks/Handle-pre_drop-table-upload-errors-d7c049e11ad84a779bee843e0d4c4c94
