### PR TITLE
Use legacy pickup algorithm on non multi-tenant environments. 

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -63,7 +63,7 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 	var batchRouterDB jobsdb.HandleT
 	var procErrorDB jobsdb.HandleT
 
-	var tenantRouterDB jobsdb.MultiTenantJobsDB = &jobsdb.MultiTenantLegacy{HandleT: &routerDB}
+	var tenantRouterDB jobsdb.MultiTenantJobsDB
 	var multitenantStats multitenant.MultiTenantI = multitenant.NOOP
 
 	pkgLogger.Info("Clearing DB ", options.ClearDB)
@@ -90,11 +90,17 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 
 		if config.GetBool("EnableMultitenancy", false) {
 			tenantRouterDB = &jobsdb.MultiTenantHandleT{HandleT: &routerDB}
+			multitenantStats = multitenant.NewStats(map[string]jobsdb.MultiTenantJobsDB{
+				"rt":       tenantRouterDB,
+				"batch_rt": &jobsdb.MultiTenantLegacy{HandleT: &batchRouterDB},
+			})
+		} else {
+			tenantRouterDB = &jobsdb.MultiTenantLegacy{HandleT: &routerDB}
+			multitenantStats = multitenant.WithLegacyPickupJobs(multitenant.NewStats(map[string]jobsdb.MultiTenantJobsDB{
+				"rt":       tenantRouterDB,
+				"batch_rt": &jobsdb.MultiTenantLegacy{HandleT: &batchRouterDB},
+			}))
 		}
-		multitenantStats = multitenant.NewStats(map[string]jobsdb.MultiTenantJobsDB{
-			"rt":       tenantRouterDB,
-			"batch_rt": &jobsdb.MultiTenantLegacy{HandleT: &batchRouterDB},
-		})
 	}
 
 	enableGateway := true

--- a/services/multitenant/legacy.go
+++ b/services/multitenant/legacy.go
@@ -4,15 +4,15 @@ import (
 	"time"
 )
 
-type legacy struct {
+type Legacy struct {
 	*MultitenantStatsT
 }
 
-func WithLegacyPickupJobs(stats *MultitenantStatsT) *legacy {
-	return &legacy{stats}
+func WithLegacyPickupJobs(stats *MultitenantStatsT) *Legacy {
+	return &Legacy{stats}
 }
 
-func (*legacy) GetRouterPickupJobs(destType string, noOfWorkers int, routerTimeOut time.Duration, jobQueryBatchSize int, timeGained float64) (map[string]int, map[string]float64) {
+func (*Legacy) GetRouterPickupJobs(destType string, noOfWorkers int, routerTimeOut time.Duration, jobQueryBatchSize int, timeGained float64) (map[string]int, map[string]float64) {
 	return map[string]int{
 		"0": jobQueryBatchSize,
 	}, map[string]float64{}

--- a/services/multitenant/legacy.go
+++ b/services/multitenant/legacy.go
@@ -12,7 +12,7 @@ func WithLegacyPickupJobs(stats *MultitenantStatsT) *Legacy {
 	return &Legacy{stats}
 }
 
-func (*Legacy) GetRouterPickupJobs(destType string, noOfWorkers int, routerTimeOut time.Duration, jobQueryBatchSize int, timeGained float64) (map[string]int, map[string]float64) {
+func (*Legacy) GetRouterPickupJobs(_ string, _ int, _ time.Duration, jobQueryBatchSize int, _ float64) (map[string]int, map[string]float64) {
 	return map[string]int{
 		"0": jobQueryBatchSize,
 	}, map[string]float64{}

--- a/services/multitenant/legacy.go
+++ b/services/multitenant/legacy.go
@@ -1,0 +1,19 @@
+package multitenant
+
+import (
+	"time"
+)
+
+type legacy struct {
+	*MultitenantStatsT
+}
+
+func WithLegacyPickupJobs(stats *MultitenantStatsT) *legacy {
+	return &legacy{stats}
+}
+
+func (*legacy) GetRouterPickupJobs(destType string, noOfWorkers int, routerTimeOut time.Duration, jobQueryBatchSize int, timeGained float64) (map[string]int, map[string]float64) {
+	return map[string]int{
+		"0": jobQueryBatchSize,
+	}, map[string]float64{}
+}


### PR DESCRIPTION
## Context

`multitenantStats` are responsible for two things:
1. Collect input/output jobs from processor/router
2. Determine the number of pickup jobs based on collected stats


Until [pending-event metrics PR](https://github.com/rudderlabs/rudder-server/pull/1736), there was a flag to enable/disable `multitenantStats` via `EnableMultitenancy`.

After pending-event metrics, the `multitenantStats` are always enabled.


## Refactor

This PR enables/disables only the `pickup jobs` functionality depending on the `EnableMultitenancy` flag.

## Notion Link

> [Notion Link
](https://www.notion.so/rudderstacks/Use-legacy-pickup-algorithm-on-non-multi-tenant-environments-7474d1ff5dac489a902ec64e7d8ad75b)


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
