### PR TITLE
Remove entries from journal with download error

### DIFF
--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1954,6 +1954,7 @@ func (brt *HandleT) dedupRawDataDestJobsOnCrash() {
 		err = downloader.Download(context.TODO(), jsonFile, objKey)
 		if err != nil {
 			brt.logger.Errorf("BRT: Failed to download data for incomplete journal entry to recover from %s at key: %s with error: %v\n", object.Provider, object.Key, err)
+			brt.jobsDB.JournalDeleteEntry(entry.OpID)
 			continue
 		}
 


### PR DESCRIPTION
## Description of the change

Whenever the server crashes , on restart it performs a crashRecover on all the components to ensure that all the dangling/incomplete operations are cleaned up. The crashRecover in `batch_router` component performs a function called `dedupRawDataDestJobsOnCrash` where the idea essentially is to ensure we do not upload duplicate files/events to the destination(i.e crash between uploading to the destination and storing the job status).We have all such entries in journalTable  and such entries are deleted post successful updation of `job_status` table.

The current `batch_rt_journal` table has very old unsuccessful entries because we fail to download those files from the objectStorage but do not remove them from journal table causing the `crashRecover` to retry these jobs every time a restart happens.

This fix aims to remove the journal entry if we encounter an error while downloading the file

[Logs Supporting the Same](https://logs.rudderlabs.com/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Loki%22,%7B%22expr%22:%22%7Bcluster%3D%5C%22multi-tenant-rudder%5C%22,namespace%3D%5C%22hostedsted%5C%22,pod%3D~%5C%22hostedsted-v0-rs-0%7Chostedsted-v0-rs-1%5C%22%7D%20%7C%3D%20%5C%22BRT:%20Failed%20to%20download%20data%20for%20incomplete%20journal%20entry%20to%20recover%5C%22%22%7D%5D)

## Notion Link

> [Notion Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=69190475e2174757a9722ffd887a9880)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
