### PR TITLE
Config[gha]: increase the limit for stale pr managment

### DIFF
--- a/.github/workflows/handle-stale-pr.yaml
+++ b/.github/workflows/handle-stale-pr.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/stale@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          operations-per-run: 200
           stale-pr-message: 'This PR is considered to be stale. It has been open 20 days with no further activity thus it is going to be closed in 5 days. To avoid such a case please consider removing the stale label manually or add a comment to the PR.'
           days-before-pr-stale: 20
           days-before-pr-close: 7


### PR DESCRIPTION
## Description of the change

Since we use the repo GITHUB_TOKEN we can increase the operations limit to 200 so as all PRs are included on every execution round.

## Notion Link

> Notion Link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
