### PR TITLE
use azure-sql-edge db for docker test

### DIFF
--- a/build/buildspec.docker.dev.yml
+++ b/build/buildspec.docker.dev.yml
@@ -28,7 +28,7 @@ phases:
       - docker pull postgres:11-alpine
       - docker pull rudderlabs/rudder-transformer:latest
       - docker pull yandex/clickhouse-server:21-alpine
-      - docker pull mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
+      - docker pull mcr.microsoft.com/azure-sql-edge:1.0.5
       - docker pull zookeeper:3.5
       - docker pull minio/minio:latest
       - docker pull mcr.microsoft.com/azure-storage/azurite:latest

--- a/testhelper/warehouse/mssql.go
+++ b/testhelper/warehouse/mssql.go
@@ -45,7 +45,7 @@ func SetWHMssqlDestination(pool *dockertest.Pool) (cleanup func()) {
 	cleanup = func() {}
 
 	var err error
-	if mssqlTest.Resource, err = pool.Run("mcr.microsoft.com/mssql/server", "2019-CU10-ubuntu-20.04", []string{
+	if mssqlTest.Resource, err = pool.Run("mcr.microsoft.com/azure-sql-edge", "1.0.5", []string{
 		fmt.Sprintf("ACCEPT_EULA=%s", "Y"),
 		fmt.Sprintf("SA_PASSWORD=%s", credentials.Password),
 		fmt.Sprintf("SA_DB=%s", credentials.DBName),


### PR DESCRIPTION
## Description of the change

> Docker tests are failing in Apple Macbooks having M1 processors due to the unavailability of `mcr.microsoft.com/mssql/server` docker image for amd64 platforms. Changed this to `mcr.microsoft.com/azure-sql-edge` for tests. 

Container logs:
```SQL Server 2019 will run as non-root by default.

This container is running as user mssql.

To learn more visit https://go.microsoft.com/fwlink/?linkid=2099216.

/opt/mssql/bin/sqlservr: Invalid mapping of address 0x40037d0000 in reserved address space below 0x400000000000. Possible causes:

1) the process (itself, or via a wrapper) starts-up its own running environment sets the stack size limit to unlimited via syscall setrlimit(2);

2) the process (itself, or via a wrapper) adjusts its own execution domain and flag the system its legacy personality via syscall personality(2);

3) sysadmin deliberately sets the system to run on legacy VA layout mode by adjusting a sysctl knob vm.legacy_va_layout.
```


Test error logs because container is not coming up: 
```--- Teardown done (unexpected)
panic: could not connect to warehouse mssql with error: unable to open tcp connection with host 'localhost:55879': dial tcp [::1]:55879: connect: connection refused

goroutine 1 [running]:
github.com/rudderlabs/rudder-server/testhelper/warehouse.SetWHMssqlDestination(0x140007df580)
        /Users/kumar/workspace/rudder-server/testhelper/warehouse/mssql.go:78 +0x94c
command-line-arguments_test.run(0x14000189180)
        /Users/kumar/workspace/rudder-server/docker_test.go:372 +0x860
command-line-arguments_test.TestMain(0x14000189180)
        /Users/kumar/workspace/rudder-server/docker_test.go:299 +0x144
main.main()
        _testmain.go:75 +0x180
FAIL    command-line-arguments  186.572s
FAIL
```

## Notion Link

> Notion Link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
