### PR TITLE
Processor manager cleanup

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -3,31 +3,31 @@ package apphandlers
 import (
 	"context"
 	"fmt"
-	"github.com/rudderlabs/rudder-server/app/cluster"
-	"github.com/rudderlabs/rudder-server/app/cluster/state"
-	operationmanager "github.com/rudderlabs/rudder-server/operation-manager"
-	"github.com/rudderlabs/rudder-server/processor"
-	routerManager "github.com/rudderlabs/rudder-server/router/manager"
-	destinationdebugger "github.com/rudderlabs/rudder-server/services/debugger/destination"
-	sourcedebugger "github.com/rudderlabs/rudder-server/services/debugger/source"
-	transformationdebugger "github.com/rudderlabs/rudder-server/services/debugger/transformation"
-	"github.com/rudderlabs/rudder-server/utils/types/servermode"
 	"net/http"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/rudderlabs/rudder-server/app"
+	"github.com/rudderlabs/rudder-server/app/cluster"
+	"github.com/rudderlabs/rudder-server/app/cluster/state"
 	"github.com/rudderlabs/rudder-server/config"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/gateway"
 	"github.com/rudderlabs/rudder-server/jobsdb"
+	operationmanager "github.com/rudderlabs/rudder-server/operation-manager"
+	"github.com/rudderlabs/rudder-server/processor"
 	ratelimiter "github.com/rudderlabs/rudder-server/rate-limiter"
 	"github.com/rudderlabs/rudder-server/router"
 	"github.com/rudderlabs/rudder-server/router/batchrouter"
+	routerManager "github.com/rudderlabs/rudder-server/router/manager"
 	"github.com/rudderlabs/rudder-server/services/db"
+	destinationdebugger "github.com/rudderlabs/rudder-server/services/debugger/destination"
+	sourcedebugger "github.com/rudderlabs/rudder-server/services/debugger/source"
+	transformationdebugger "github.com/rudderlabs/rudder-server/services/debugger/transformation"
 	"github.com/rudderlabs/rudder-server/services/multitenant"
 	"github.com/rudderlabs/rudder-server/utils/misc"
-	"golang.org/x/sync/errgroup"
-
 	"github.com/rudderlabs/rudder-server/utils/types"
+	"github.com/rudderlabs/rudder-server/utils/types/servermode"
 
 	// This is necessary for compatibility with enterprise features
 	_ "github.com/rudderlabs/rudder-server/imports"
@@ -132,21 +132,27 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 		if migrationMode == db.IMPORT || migrationMode == db.EXPORT || migrationMode == db.IMPORT_EXPORT {
 			startProcessorFunc := func() {
 				clearDB := false
-				g.Go(misc.WithBugsnag(func() error {
-					StartProcessor(ctx, &clearDB, enableProcessor, gwDBForProcessor, routerDB, batchRouterDB, errDB,
-						reportingI, multitenant.NOOP)
-					return nil
-				}))
+				if enableProcessor {
+					g.Go(misc.WithBugsnag(func() error {
+						StartProcessor(
+							ctx, &clearDB, gwDBForProcessor, routerDB, batchRouterDB, errDB,
+							reportingI, multitenant.NOOP,
+						)
+						return nil
+					}))
+				}
 			}
 			startRouterFunc := func() {
-				g.Go(misc.WithBugsnag(func() error {
-					StartRouter(ctx, enableRouter, tenantRouterDB, batchRouterDB, errDB, reportingI, multitenant.NOOP)
-					return nil
-				}))
+				if enableRouter {
+					g.Go(misc.WithBugsnag(func() error {
+						StartRouter(ctx, tenantRouterDB, batchRouterDB, errDB, reportingI, multitenant.NOOP)
+						return nil
+					}))
+				}
 			}
 			enableRouter = false
 			enableProcessor = false
-			enableGateway = (migrationMode != db.EXPORT)
+			enableGateway = migrationMode != db.EXPORT
 
 			embedded.App.Features().Migrator.PrepareJobsdbsForImport(gwDBForProcessor, routerDB, batchRouterDB)
 
@@ -188,13 +194,13 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 	rt := routerManager.New(rtFactory, brtFactory, backendconfig.DefaultBackendConfig)
 
 	dm := cluster.Dynamic{
-		Provider:      &modeProvider,
-		GatewayDB:     gwDBForProcessor,
-		RouterDB:      routerDB,
-		BatchRouterDB: batchRouterDB,
-		ErrorDB:       errDB,
-		Processor:     proc,
-		Router:        rt,
+		Provider:        &modeProvider,
+		GatewayDB:       gwDBForProcessor,
+		RouterDB:        routerDB,
+		BatchRouterDB:   batchRouterDB,
+		ErrorDB:         errDB,
+		Processor:       proc,
+		Router:          rt,
 		MultiTenantStat: multitenantStats,
 	}
 

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -3,10 +3,11 @@ package apphandlers
 import (
 	"context"
 	"fmt"
-	operationmanager "github.com/rudderlabs/rudder-server/operation-manager"
 	"net/http"
 	"strconv"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/bugsnag/bugsnag-go/v2"
 	"github.com/gorilla/mux"
@@ -16,6 +17,7 @@ import (
 	"github.com/rudderlabs/rudder-server/config"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
+	operationmanager "github.com/rudderlabs/rudder-server/operation-manager"
 	proc "github.com/rudderlabs/rudder-server/processor"
 	"github.com/rudderlabs/rudder-server/router"
 	"github.com/rudderlabs/rudder-server/router/batchrouter"
@@ -27,7 +29,6 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/types"
 	"github.com/rudderlabs/rudder-server/utils/types/servermode"
-	"golang.org/x/sync/errgroup"
 
 	// This is necessary for compatibility with enterprise features
 	_ "github.com/rudderlabs/rudder-server/imports"
@@ -151,17 +152,22 @@ func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app
 			startProcessorFunc := func() {
 				g.Go(func() error {
 					clearDB := false
-					StartProcessor(ctx, &clearDB, enableProcessor, gwDBForProcessor, routerDB, batchRouterDB, errDB,
-						reportingI, multitenant.NOOP)
-
+					if enableProcessor {
+						StartProcessor(
+							ctx, &clearDB, gwDBForProcessor, routerDB, batchRouterDB, errDB,
+							reportingI, multitenant.NOOP,
+						)
+					}
 					return nil
 				})
 			}
 			startRouterFunc := func() {
-				g.Go(func() error {
-					StartRouter(ctx, enableRouter, tenantRouterDB, batchRouterDB, errDB, reportingI, multitenant.NOOP)
-					return nil
-				})
+				if enableRouter {
+					g.Go(func() error {
+						StartRouter(ctx, tenantRouterDB, batchRouterDB, errDB, reportingI, multitenant.NOOP)
+						return nil
+					})
+				}
 			}
 			enableRouter = false
 			enableProcessor = false
@@ -205,13 +211,13 @@ func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app
 	rt := routerManager.New(rtFactory, brtFactory, backendconfig.DefaultBackendConfig)
 
 	dm := cluster.Dynamic{
-		Provider:      &modeProvider,
-		GatewayDB:     gwDBForProcessor,
-		RouterDB:      routerDB,
-		BatchRouterDB: batchRouterDB,
-		ErrorDB:       errDB,
-		Processor:     p,
-		Router:        rt,
+		Provider:        &modeProvider,
+		GatewayDB:       gwDBForProcessor,
+		RouterDB:        routerDB,
+		BatchRouterDB:   batchRouterDB,
+		ErrorDB:         errDB,
+		Processor:       p,
+		Router:          rt,
 		MultiTenantStat: multitenantStats,
 	}
 
@@ -395,6 +401,5 @@ func (processor *ProcessorApp) LegacyStart(ctx context.Context, options *app.Opt
 	g.Go(func() error {
 		return startHealthWebHandler(ctx)
 	})
-	err := g.Wait()
-	return err
+	return g.Wait()
 }

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -113,13 +113,9 @@ func rudderCoreBaseSetup() {
 
 //StartProcessor atomically starts processor process if not already started
 func StartProcessor(
-	ctx context.Context, clearDB *bool, enableProcessor bool, gatewayDB, routerDB, batchRouterDB,
+	ctx context.Context, clearDB *bool, gatewayDB, routerDB, batchRouterDB,
 	procErrorDB *jobsdb.HandleT, reporting types.ReportingI, multitenantStat multitenant.MultiTenantI,
 ) {
-	if !enableProcessor {
-		return
-	}
-
 	if !processorLoaded.First() {
 		pkgLogger.Debug("processor started by an other go routine")
 		return
@@ -134,13 +130,9 @@ func StartProcessor(
 
 //StartRouter atomically starts router process if not already started
 func StartRouter(
-	ctx context.Context, enableRouter bool, routerDB jobsdb.MultiTenantJobsDB, batchRouterDB *jobsdb.HandleT,
+	ctx context.Context, routerDB jobsdb.MultiTenantJobsDB, batchRouterDB *jobsdb.HandleT,
 	procErrorDB *jobsdb.HandleT, reporting types.ReportingI, multitenantStat multitenant.MultiTenantI,
 ) {
-	if !enableRouter {
-		return
-	}
-
 	if !routerLoaded.First() {
 		pkgLogger.Debug("processor started by an other go routine")
 		return

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-server/app"
 	"github.com/rudderlabs/rudder-server/config"
@@ -23,9 +23,8 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 	utilsync "github.com/rudderlabs/rudder-server/utils/sync"
-	"golang.org/x/sync/errgroup"
-
 	"github.com/rudderlabs/rudder-server/utils/types"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
 var (
@@ -125,7 +124,7 @@ func StartProcessor(ctx context.Context, clearDB *bool, enableProcessor bool, ga
 	}
 
 	var processorInstance = processor.NewProcessor()
-	processor.ProcessorManagerSetup(processorInstance)
+	processor.ManagerSetup(processorInstance)
 	processorInstance.Setup(backendconfig.DefaultBackendConfig, gatewayDB, routerDB, batchRouterDB, procErrorDB, clearDB, reporting, multitenantStat)
 	defer processorInstance.Shutdown()
 	processorInstance.Start(ctx)

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -230,7 +230,10 @@ loop:
 	for _, f := range cleanup {
 		f := f
 		wg.Add(1)
-		go f()
+		go func() {
+			defer wg.Done()
+			f()
+		}()
 	}
 	wg.Wait()
 }

--- a/operation-manager/clear-queue-manager.go
+++ b/operation-manager/clear-queue-manager.go
@@ -80,7 +80,7 @@ func (handler *ClearOperationHandlerT) Exec(payload []byte) error {
 		)
 	}
 
-	var pm processor.ProcessorManagerI
+	var pm processor.Manager
 	for {
 		pm, err = processor.GetProcessorManager()
 		if err == nil {

--- a/operation-manager/clear-queue-manager.go
+++ b/operation-manager/clear-queue-manager.go
@@ -11,6 +11,11 @@ import (
 	"github.com/rudderlabs/rudder-server/router/batchrouter"
 )
 
+type processorManager interface {
+	Pause()
+	Resume()
+}
+
 type ClearOperationHandlerT struct {
 	gatewayDB     jobsdb.JobsDB
 	routerDB      jobsdb.JobsDB
@@ -80,7 +85,7 @@ func (handler *ClearOperationHandlerT) Exec(payload []byte) error {
 		)
 	}
 
-	var pm processor.Manager
+	var pm processorManager
 	for {
 		pm, err = processor.GetProcessorManager()
 		if err == nil {

--- a/processor/processor-manager.go
+++ b/processor/processor-manager.go
@@ -18,7 +18,7 @@ func ManagerSetup(processor *HandleT) {
 	pm.Processor = processor
 }
 
-func GetProcessorManager() (*managerImpl, error) {
+func GetProcessorManager() (*managerImpl, error) { // skipcq: RVV-B0011
 	if globalManager == nil {
 		return nil, fmt.Errorf("processorManager is not initialized. Retry after sometime")
 	}

--- a/processor/processor-manager.go
+++ b/processor/processor-manager.go
@@ -3,13 +3,8 @@ package processor
 import "fmt"
 
 var (
-	globalManager Manager
+	globalManager *managerImpl
 )
-
-type Manager interface {
-	Pause()
-	Resume()
-}
 
 type managerImpl struct {
 	Processor *HandleT
@@ -23,7 +18,7 @@ func ManagerSetup(processor *HandleT) {
 	pm.Processor = processor
 }
 
-func GetProcessorManager() (Manager, error) {
+func GetProcessorManager() (*managerImpl, error) {
 	if globalManager == nil {
 		return nil, fmt.Errorf("processorManager is not initialized. Retry after sometime")
 	}

--- a/processor/processor-manager.go
+++ b/processor/processor-manager.go
@@ -3,38 +3,37 @@ package processor
 import "fmt"
 
 var (
-	ProcessorManager ProcessorManagerI
+	globalManager Manager
 )
 
-type ProcessorManagerI interface {
+type Manager interface {
 	Pause()
 	Resume()
 }
 
-type ProcessorManagerT struct {
+type managerImpl struct {
 	Processor *HandleT
 }
 
-func ProcessorManagerSetup(processor *HandleT) {
+func ManagerSetup(processor *HandleT) {
 	pkgLogger.Info("setting up ProcessorManager.")
-	pm := new(ProcessorManagerT)
+	pm := new(managerImpl)
 
-	ProcessorManager = pm
+	globalManager = pm
 	pm.Processor = processor
 }
 
-func GetProcessorManager() (ProcessorManagerI, error) {
-	if ProcessorManager == nil {
+func GetProcessorManager() (Manager, error) {
+	if globalManager == nil {
 		return nil, fmt.Errorf("processorManager is not initialized. Retry after sometime")
 	}
-
-	return ProcessorManager, nil
+	return globalManager, nil
 }
 
-func (pm *ProcessorManagerT) Pause() {
+func (pm *managerImpl) Pause() {
 	pm.Processor.Pause()
 }
 
-func (pm *ProcessorManagerT) Resume() {
+func (pm *managerImpl) Resume() {
 	pm.Processor.Resume()
 }


### PR DESCRIPTION
## Description of the change

* removed unnecessary types and abstraction in the processor manager
* made some types unexported for better encapsulation
* removed `Processor` as a prefix to types given that the package name already has the word `processor` it is not needed (it is also an issue highlighted by linters)
* using private `processorManager` interface to decouple `operation-manager` package from `processor`
* removed `enableProcessor` and `enableRouter` from `StartProcessor` and `StartRouter` functions due to `Control-coupled functions detected: RVV-A0005`
* replaced errgroup with WaitGroup because usage of contexts and ignoring error made it unnecessary

## Notion Link

[> Notion Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=d3806f442555412fb7c5c86a51ab2c11&p=c7e5e52686f04fd58b2b0ca96fa72845)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
