### PR TITLE
closingNilChannelStatsFix

### DIFF
--- a/services/stats/stats.go
+++ b/services/stats/stats.go
@@ -160,6 +160,9 @@ func Setup() {
 				taggedClientsMapLock.Unlock()
 			}
 		}
+		taggedClientsMapLock.Lock()
+		connEstablished = true
+		taggedClientsMapLock.Unlock()
 
 		collectPeriodicStats(client)
 	})
@@ -361,7 +364,9 @@ func collectPeriodicStats(client *statsd.Client) {
 
 // StopPeriodicStats stops periodic collection of stats.
 func StopPeriodicStats() {
-	if !statsEnabled {
+	taggedClientsMapLock.RLock()
+	defer taggedClientsMapLock.RUnlock()
+	if !statsEnabled || !connEstablished {
 		return
 	}
 


### PR DESCRIPTION
## Description of the change

> Observed that on graceful shutdown if stats client is not created, shutting the server down led to a panic(closing a nil map) during graceful shutdown. Addressing that issue.

## Notion Link

> N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
