### PR TITLE
tenantStat empty map bg fixed

### DIFF
--- a/services/multitenant/tenantstats.go
+++ b/services/multitenant/tenantstats.go
@@ -87,6 +87,7 @@ func NewStats(routerDBs map[string]jobsdb.MultiTenantJobsDB) *MultitenantStatsT 
 	multitenantStat.routerInputRates = make(map[string]map[string]map[string]metric.MovingAverage)
 	multitenantStat.lastDrainedTimestamps = make(map[string]map[string]time.Time)
 	multitenantStat.failureRate = make(map[string]map[string]metric.MovingAverage)
+	multitenantStat.RouterDBs = routerDBs
 	for dbPrefix := range routerDBs {
 		multitenantStat.routerInputRates[dbPrefix] = make(map[string]map[string]metric.MovingAverage)
 		pileUpStatMap := make(map[string]map[string]int)


### PR DESCRIPTION
## Description of the change

> There was a bug in mutitenanat stat, when creating NewStat we were not storing the routerDBs which was creating issues for lifecycle Manager.

## Notion Link

> [Notion Link](https://www.notion.so/rudderstacks/Integration-of-Cluster-Manager-451b5da33c2944919996532b8d8d1a0e)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
