### PR TITLE
feat(jobsdb): made backup related config hot-reloadable

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -60,7 +60,6 @@ type BackupSettingsT struct {
 	instanceBackupEnabled bool
 	FailedOnly            bool
 	PathPrefix            string
-	once                  sync.Once
 }
 
 func (b *BackupSettingsT) IsBackupEnabled() bool {
@@ -398,14 +397,12 @@ var dbErrorMap = map[string]string{
 // instanceBackupFailedAndAborted = true => the individual jobdb backsup failed and aborted jobs only
 // pathPrefix = by default is the jobsdb table prefix, is the path appended before instanceID in s3 folder structure
 func (jd *HandleT) registerBackUpSettings() {
-	jd.BackupSettings.once.Do(func() {
-		config.RegisterBoolConfigVariable(true, &masterBackupEnabled, true, "JobsDB.backup.enabled")
-		config.RegisterBoolConfigVariable(false, &jd.BackupSettings.instanceBackupEnabled, true, fmt.Sprintf("JobsDB.backup.%v.enabled", jd.tablePrefix))
-		config.RegisterBoolConfigVariable(false, &jd.BackupSettings.FailedOnly, false, fmt.Sprintf("JobsDB.backup.%v.failedOnly", jd.tablePrefix))
-		config.RegisterStringConfigVariable(jd.tablePrefix, &pathPrefix, false, fmt.Sprintf("JobsDB.backup.%v.pathPrefix", jd.tablePrefix))
-		config.RegisterDurationConfigVariable(10, &jd.maxBackupRetryTime, false, time.Minute, "JobsDB.backup.maxRetry")
-		jd.BackupSettings.PathPrefix = strings.TrimSpace(pathPrefix)
-	})
+	config.RegisterBoolConfigVariable(true, &masterBackupEnabled, true, "JobsDB.backup.enabled")
+	config.RegisterBoolConfigVariable(false, &jd.BackupSettings.instanceBackupEnabled, true, fmt.Sprintf("JobsDB.backup.%v.enabled", jd.tablePrefix))
+	config.RegisterBoolConfigVariable(false, &jd.BackupSettings.FailedOnly, false, fmt.Sprintf("JobsDB.backup.%v.failedOnly", jd.tablePrefix))
+	config.RegisterStringConfigVariable(jd.tablePrefix, &pathPrefix, false, fmt.Sprintf("JobsDB.backup.%v.pathPrefix", jd.tablePrefix))
+	config.RegisterDurationConfigVariable(10, &jd.maxBackupRetryTime, false, time.Minute, "JobsDB.backup.maxRetry")
+	jd.BackupSettings.PathPrefix = strings.TrimSpace(pathPrefix)
 }
 
 //Some helper functions

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -391,13 +391,18 @@ var dbErrorMap = map[string]string{
 	"Invalid Escape Character": "22019",
 }
 
-// return backup settings depending on jobdb type
-// the gateway, the router and the processor
-// BackupEnabled = true => all the jobsdb are eligible for backup
-// instanceBackupEnabled[table_prefix] = true => the individual jobsdb too is eligible for backup
+// registers the backup settings depending on jobdb type the gateway, the router and the processor
+// masterBackupEnabled = true => all the jobsdb are eligible for backup
+// instanceBackupEnabled = true => the individual jobsdb too is eligible for backup
 // instanceBackupFailedAndAborted = true => the individual jobdb backsup failed and aborted jobs only
 // pathPrefix = by default is the jobsdb table prefix, is the path appended before instanceID in s3 folder structure
-func (jd *HandleT) getBackUpSettings() {
+func (jd *HandleT) registerBackUpSettings() {
+	jd.BackupSettings = &BackupSettingsT{
+		masterBackupEnabled: true,
+		instanceBackupEnabled: true,
+		FailedOnly: false,
+		PathPrefix: "",
+	}
 	config.RegisterBoolConfigVariable(true, &jd.BackupSettings.masterBackupEnabled, true, "JobsDB.backup.enabled")
 	config.RegisterBoolConfigVariable(false, &jd.BackupSettings.instanceBackupEnabled, true, fmt.Sprintf("JobsDB.backup.%v.enabled", jd.tablePrefix))
 	config.RegisterBoolConfigVariable(false, &jd.BackupSettings.FailedOnly, false, fmt.Sprintf("JobsDB.backup.%v.failedOnly", jd.tablePrefix))
@@ -748,7 +753,7 @@ func (jd *HandleT) workersAndAuxSetup() {
 		admin.RegisterStatusHandler(jd.tablePrefix+"-jobsdb", jd)
 	}
 
-	jd.getBackUpSettings()
+	jd.registerBackUpSettings()
 
 	jd.logger.Infof("Connected to %s DB", jd.tablePrefix)
 

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -826,6 +826,7 @@ func (jd *HandleT) startBackupDSLoop(ctx context.Context) {
 	jd.jobsFileUploader, err = jd.getFileUploader()
 	if err != nil {
 		jd.logger.Errorf("failed to get a file uploader for %s", jd.tablePrefix)
+		return
 	}
 	jd.backgroundGroup.Go(misc.WithBugsnag(func() error {
 		jd.backupDSLoop(ctx)


### PR DESCRIPTION
## Description of the change

> `JobsDB.backup.enabled` config was not hot-reloadable till now, which means if we want to stop the tables backup while server is already running, that was not possible. Now this is hot-reloadable. Now if we switch this feature in config then the effect will take effect at-max in time which is defined by`JobsDB.backupCheckSleepDuration` config. 

## Notion Link

> [Notion Link](https://www.notion.so/rudderstacks/Make-backup-config-masterBackupEnabled-hot-reloadable-4bf69e32c37a40f194749cb7e4633f1a)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
