### PR TITLE
fix(router): panic sources grouped together

### DIFF
--- a/router/customdestinationmanager/customdestinationmanager.go
+++ b/router/customdestinationmanager/customdestinationmanager.go
@@ -34,7 +34,7 @@ var (
 
 // DestinationManager implements the method to send the events to custom destinations
 type DestinationManager interface {
-	SendData(jsonData json.RawMessage, sourceID string, destID string) (int, string)
+	SendData(jsonData json.RawMessage, destID string) (int, string)
 }
 
 // CustomManagerT handles this module
@@ -123,7 +123,7 @@ func (customManager *CustomManagerT) send(jsonData json.RawMessage, destType str
 }
 
 // SendData gets the producer from streamDestinationsMap and sends data
-func (customManager *CustomManagerT) SendData(jsonData json.RawMessage, sourceID string, destID string) (int, string) {
+func (customManager *CustomManagerT) SendData(jsonData json.RawMessage, destID string) (int, string) {
 	if disableEgress {
 		return 200, `200: outgoing disabled`
 	}

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -81,7 +81,7 @@ func (trans *HandleT) Transform(transformType string, transformMessage *types.Tr
 		trans.logger.Errorf("problematic input for marshalling: %#v", transformMessage)
 		panic(err)
 	}
-	trans.logger.Debugf("[Router Transfomrer] :: input payload : %s", string(rawJSON))
+	trans.logger.Debugf("[Router Transformer] :: input payload : %s", string(rawJSON))
 
 	retryCount := 0
 	var resp *http.Response


### PR DESCRIPTION
## Description of the change

I was able to replicate the `panic` mentioned in the Notion ticket and noticed that the comparison with the source ID in each destination was done considering only the first `sourceID` encountered (i.e. `sourceID := destinationJob.JobMetadataArray[0].SourceID`) which made the following code fail.

Then I also realized that the `sourceID` is not really used by `SendData` so there shouldn't be a bug there. To make it more clear I dropped `sourceID` altogether.

## Notion Link

> [Notion Link](https://www.notion.so/rudderstacks/Fix-panic-different-sources-are-grouped-together-in-router-a484a53a9b4448dabc5714d4f8e6c67e)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
