### PR TITLE
WIP: feat: Gateway back pressure mechanism implementation

### DIFF
--- a/gateway/configuration.go
+++ b/gateway/configuration.go
@@ -43,6 +43,10 @@ func loadConfig() {
 	config.RegisterDurationConfigVariable(time.Duration(10), &WriteTimeout, false, time.Second, []string{"WriteTimeout", "WriteTimeOutInSec"}...)
 	config.RegisterDurationConfigVariable(time.Duration(720), &IdleTimeout, false, time.Second, []string{"IdleTimeout", "IdleTimeoutInSec"}...)
 	config.RegisterIntConfigVariable(524288, &MaxHeaderBytes, false, 1, "MaxHeaderBytes")
+	//default is set with assumption that 4GB of RAM is present, with avg. event size=5KB & avg. batch size=10.
+	config.RegisterIntConfigVariable(80000, &maxClients, false, 1, "Gateway.maxClients")
+	config.RegisterBoolConfigVariable(true, &enableClientLimit, false, "Gateway.enableClientLimit")
+
 }
 
 // MaxReqSize is the maximum request body size, in bytes, accepted by gateway web handlers


### PR DESCRIPTION
## Description of the change

>To avoid OOM kill of gateway in scenarios where we have a lot of sudden spike in gateway traffic or when DB is under pressure. We have introduced a back pressure mechanism that restrict on maximum number of active request in memory, by using counting Semaphore.

## Notion Link

> [Notion Link](https://www.notion.so/rudderstacks/Rate-limiting-in-Gateway-5a00130da4a545f58d147c81867afd4f)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
