### PR TITLE
chore(ci): run all tests only in github actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,7 @@ jobs:
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration -count 1
   integration-enterprise:
-    name: Service Integration Enterprise
+    name: Service Integration [Enterprise]
     runs-on: 'ubuntu-18.04'
 
     steps:
@@ -56,7 +56,7 @@ jobs:
     - run: make enterprise-init
     - run: RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration -count 1
   integration-enterprise-multitenant:
-    name: Service Integration Enterprise Multitenant
+    name: Service Integration [Enterprise Multitenant]
     runs-on: 'ubuntu-18.04'
 
     steps:
@@ -83,27 +83,6 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: make enterprise-init
-    - run: RSERVER_ENABLE_MULTITENANCY=true go test -v ./docker_test.go -integration -count 1
-
-  integration-multitenant:
-    name: Service Integration Multitenant
-    runs-on: 'ubuntu-18.04'
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '~1.17.8'
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - run: go version
-    - run: go mod download # Not required, used to segregate module download vs test times
     - run: RSERVER_ENABLE_MULTITENANCY=true go test -v ./docker_test.go -integration -count 1
   unit:
     name: Unit & Component Integration

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -137,3 +137,4 @@ jobs:
     # - run: make enterprise-cleanup
     - run: make enterprise-init
     - run: make test
+    - uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,49 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration -count 1
+  integration-enterprise:
+    name: Service Integration Enterprise
+    runs-on: 'ubuntu-18.04'
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '~1.17.8'
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - run: go version
+    - run: go mod download # Not required, used to segregate module download vs test times
+    - run: make enterprise-init
+    - run: RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration -count 1
+  integration-enterprise-multitenant:
+    name: Service Integration Enterprise Multitenant
+    runs-on: 'ubuntu-18.04'
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '~1.17.8'
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - run: go version
+    - run: go mod download # Not required, used to segregate module download vs test times
+    - run: make enterprise-init
+    - run: RSERVER_ENABLE_MULTITENANCY=true go test -v ./docker_test.go -integration -count 1
+
   integration-multitenant:
     name: Service Integration Multitenant
     runs-on: 'ubuntu-18.04'
@@ -66,4 +109,27 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: (cd /tmp && go get -u github.com/onsi/ginkgo/ginkgo@v1.16.5)
+    - run: make test
+
+  unit-enterprise:
+    name: Unit & Component Integration Enterprise
+    runs-on: 'ubuntu-18.04'
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '~1.17.8'
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - run: go version
+    - run: go mod download # Not required, used to segregate module download vs test times
+    - run: (cd /tmp && go get -u github.com/onsi/ginkgo/ginkgo@v1.16.5)
+    - run: make enterprise-init
     - run: make test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -131,5 +131,6 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: (cd /tmp && go get -u github.com/onsi/ginkgo/ginkgo@v1.16.5)
+    - run: make enterprise-cleanup
     - run: make enterprise-init
     - run: make test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,12 @@ jobs:
           ${{ runner.os }}-go-
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
-    - run: RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration -bigqueryintegration -count 1
+    - name: Integration test
+      run: go test -v ./docker_test.go -integration -bigqueryintegration -count 1
+      env:
+        RSERVER_ENABLE_MULTITENANCY: false
+        BIGQUERY_INTEGRATION_TEST_USER_CRED: ${{ secrets.BIGQUERY_INTEGRATION_TEST_USER_CRED }}
+
   integration-enterprise:
     name: Service Integration [Enterprise]
     runs-on: 'ubuntu-18.04'
@@ -56,7 +61,12 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: make enterprise-init
-    - run: RSERVER_ENABLE_MULTITENANCY=${{ matrix.MULTITENANCY }} go test -v ./docker_test.go -integration -bigqueryintegration -count 1
+    - name: Integration test
+      run: go test -v ./docker_test.go -integration -bigqueryintegration -count 1
+      env:
+        RSERVER_ENABLE_MULTITENANCY: ${{ matrix.MULTITENANCY }}
+        BIGQUERY_INTEGRATION_TEST_USER_CRED: ${{ secrets.BIGQUERY_INTEGRATION_TEST_USER_CRED }}
+
   unit:
     name: Unit & Component Integration
     runs-on: 'ubuntu-18.04'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
           ${{ runner.os }}-go-
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
-    - run: RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration -count 1
+    - run: RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration integration -bigqueryintegration -count 1
   integration-enterprise:
     name: Service Integration [Enterprise]
     runs-on: 'ubuntu-18.04'
@@ -54,7 +54,7 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: make enterprise-init
-    - run: RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration -count 1
+    - run: RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration integration -bigqueryintegration -count 1
   integration-enterprise-multitenant:
     name: Service Integration [Enterprise Multitenant]
     runs-on: 'ubuntu-18.04'
@@ -83,7 +83,7 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: make enterprise-init
-    - run: RSERVER_ENABLE_MULTITENANCY=true go test -v ./docker_test.go -integration -count 1
+    - run: RSERVER_ENABLE_MULTITENANCY=true go test -v ./docker_test.go -integration integration -bigqueryintegration -count 1
   unit:
     name: Unit & Component Integration
     runs-on: 'ubuntu-18.04'
@@ -107,7 +107,7 @@ jobs:
     - run: make test
 
   unit-enterprise:
-    name: Unit & Component Integration Enterprise
+    name: Unit & Component Integration [Enterprise]
     runs-on: 'ubuntu-18.04'
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -116,7 +116,14 @@ jobs:
     runs-on: 'ubuntu-18.04'
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Checkout enterprise 
+      uses: actions/checkout@v3
+      with:
+        repository: rudderlabs/rudder-server-enterprise
+        path: enterprise
     - uses: actions/setup-go@v2
       with:
         go-version: '~1.17.8'
@@ -131,6 +138,6 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: (cd /tmp && go get -u github.com/onsi/ginkgo/ginkgo@v1.16.5)
-    - run: make enterprise-cleanup
+    # - run: make enterprise-cleanup
     - run: make enterprise-init
     - run: make test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,9 @@ jobs:
   integration-enterprise:
     name: Service Integration [Enterprise]
     runs-on: 'ubuntu-18.04'
-
+    strategy:
+      matrix:
+        MULTITENANCY: [true, false]
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -54,36 +56,7 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: make enterprise-init
-    - run: RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration integration -bigqueryintegration -count 1
-  integration-enterprise-multitenant:
-    name: Service Integration [Enterprise Multitenant]
-    runs-on: 'ubuntu-18.04'
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Checkout enterprise 
-      uses: actions/checkout@v3
-      with:
-        repository: rudderlabs/rudder-server-enterprise
-        path: enterprise
-        ref: master
-        token: ${{ secrets.GH_PAT }}
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '~1.17.8'
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - run: go version
-    - run: go mod download # Not required, used to segregate module download vs test times
-    - run: make enterprise-init
-    - run: RSERVER_ENABLE_MULTITENANCY=true go test -v ./docker_test.go -integration integration -bigqueryintegration -count 1
+    - run: RSERVER_ENABLE_MULTITENANCY=${{ matrix.MULTITENANCY }} go test -v ./docker_test.go -integration integration -bigqueryintegration -count 1
   unit:
     name: Unit & Component Integration
     runs-on: 'ubuntu-18.04'
@@ -134,7 +107,6 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: (cd /tmp && go get -u github.com/onsi/ginkgo/ginkgo@v1.16.5)
-    # - run: make enterprise-cleanup
     - run: make enterprise-init
     - run: make test
     - uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -124,6 +124,7 @@ jobs:
       with:
         repository: rudderlabs/rudder-server-enterprise
         path: enterprise
+        ref: master
     - uses: actions/setup-go@v2
       with:
         go-version: '~1.17.8'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,15 @@ jobs:
     runs-on: 'ubuntu-18.04'
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Checkout enterprise 
+      uses: actions/checkout@v3
+      with:
+        repository: rudderlabs/rudder-server-enterprise
+        path: enterprise
+        ref: master
+        token: ${{ secrets.GH_PAT }}
     - uses: actions/setup-go@v2
       with:
         go-version: '~1.17.8'
@@ -52,7 +60,15 @@ jobs:
     runs-on: 'ubuntu-18.04'
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Checkout enterprise 
+      uses: actions/checkout@v3
+      with:
+        repository: rudderlabs/rudder-server-enterprise
+        path: enterprise
+        ref: master
+        token: ${{ secrets.GH_PAT }}
     - uses: actions/setup-go@v2
       with:
         go-version: '~1.17.8'
@@ -118,7 +134,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-
     - name: Checkout enterprise 
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
           ${{ runner.os }}-go-
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
-    - run: RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration integration -bigqueryintegration -count 1
+    - run: RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration -bigqueryintegration -count 1
   integration-enterprise:
     name: Service Integration [Enterprise]
     runs-on: 'ubuntu-18.04'
@@ -56,7 +56,7 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: make enterprise-init
-    - run: RSERVER_ENABLE_MULTITENANCY=${{ matrix.MULTITENANCY }} go test -v ./docker_test.go -integration integration -bigqueryintegration -count 1
+    - run: RSERVER_ENABLE_MULTITENANCY=${{ matrix.MULTITENANCY }} go test -v ./docker_test.go -integration -bigqueryintegration -count 1
   unit:
     name: Unit & Component Integration
     runs-on: 'ubuntu-18.04'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -125,6 +125,7 @@ jobs:
         repository: rudderlabs/rudder-server-enterprise
         path: enterprise
         ref: master
+        token: ${{ secrets.GH_PAT }}
     - uses: actions/setup-go@v2
       with:
         go-version: '~1.17.8'

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ junit*.xml
 build/regulation-worker
 *.out.*
 *.out
+coverage.txt
+coverage.html

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ ifdef package
 else
 	$(GINKGO) -p --randomizeAllSpecs --randomizeSuites --failOnPending --cover -coverprofile=profile.out -covermode=atomic --trace ./...
 endif
+	echo "mode: atomic" > coverage.txt
+	find . -name "profile.out" | while read file;do grep -v 'mode: atomic' $${file} >> coverage.txt; rm $${file};done
+
+coverage:
+	go tool cover -html=coverage.txt -o coverage.html
 
 build-sql-migrations: ./services/sql-migrator/migrations_vfsdata.go ## Prepare sql migrations embedded scripts
 

--- a/build/buildspec.docker.dev-ent.yml
+++ b/build/buildspec.docker.dev-ent.yml
@@ -4,7 +4,6 @@ env:
     # The SSH deploy key with enterprise rudder server repo
     ssh_key: "/codebuild/github/ssh-key"
     dockerhub_passwd: "/dev/codebuild/dockerhub-password"
-    BIGQUERY_INTEGRATION_TEST_USER_CRED: "/codebuild/integration/tests/bigquery"
 
 phases:
   install:

--- a/build/buildspec.docker.dev-ent.yml
+++ b/build/buildspec.docker.dev-ent.yml
@@ -25,18 +25,6 @@ phases:
       - ssh-add ~/.ssh/ssh_key
       - (cd && go get github.com/onsi/ginkgo/ginkgo)
       - (cd && go get github.com/golang/mock/mockgen)
-      - docker pull confluentinc/cp-zookeeper:latest
-      - docker pull confluentinc/cp-kafka:7.0.0
-      - docker pull minio/minio:latest
-      - docker pull redis:alpine3.14
-      - docker pull postgres:11-alpine
-      - docker pull rudderlabs/rudder-transformer:latest
-      - docker pull yandex/clickhouse-server:21-alpine
-      - docker pull mcr.microsoft.com/azure-sql-edge:1.0.5
-      - docker pull zookeeper:3.5
-      - docker pull minio/minio:latest
-      - docker pull mcr.microsoft.com/azure-storage/azurite:latest
-      - docker pull fsouza/fake-gcs-server:latest
       - go mod download
 
   build:
@@ -46,9 +34,6 @@ phases:
       - VERSION=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed 's/refs\/heads\///g' | tr "/" .)
       # Build Enterprise version
       - make enterprise-init
-      - make test
-      - RSERVER_ENABLE_MULTITENANCY=true  go test -v ./docker_test.go -integration -bigqueryintegration -count 1
-      - RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration -bigqueryintegration -count 1
       - GOOS=linux GOARCH=amd64 CGO_ENABLED=1 RACE_ENABLED=TRUE LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - docker build -t rudderstack/develop-rudder-server-enterprise:$VERSION -f build/Dockerfile-aws-dev .

--- a/build/buildspec.docker.dev-ent.yml
+++ b/build/buildspec.docker.dev-ent.yml
@@ -4,7 +4,6 @@ env:
     # The SSH deploy key with enterprise rudder server repo
     ssh_key: "/codebuild/github/ssh-key"
     dockerhub_passwd: "/dev/codebuild/dockerhub-password"
-    CODECOV_TOKEN: "/codebuild/codecov-token"
     BIGQUERY_INTEGRATION_TEST_USER_CRED: "/codebuild/integration/tests/bigquery"
 
 phases:
@@ -23,8 +22,6 @@ phases:
       - chmod 600 ~/.ssh/ssh_key
       - eval "$(ssh-agent -s)"
       - ssh-add ~/.ssh/ssh_key
-      - (cd && go get github.com/onsi/ginkgo/ginkgo)
-      - (cd && go get github.com/golang/mock/mockgen)
       - go mod download
 
   build:
@@ -40,10 +37,6 @@ phases:
   post_build:
     commands:
       - docker push rudderstack/develop-rudder-server-enterprise:$VERSION
-reports:
-  GinkgoUnitTestReports:
-    files:
-      - "**/junit_*.xml"
 artifacts:
   files:
     - "**/*"

--- a/build/buildspec.docker.dev.yml
+++ b/build/buildspec.docker.dev.yml
@@ -25,18 +25,6 @@ phases:
       - ssh-add ~/.ssh/ssh_key
       - (cd && go get github.com/onsi/ginkgo/ginkgo)
       - (cd && go get github.com/golang/mock/mockgen)
-      - docker pull confluentinc/cp-zookeeper:latest
-      - docker pull confluentinc/cp-kafka:7.0.0
-      - docker pull minio/minio:latest
-      - docker pull redis:alpine3.14
-      - docker pull postgres:11-alpine
-      - docker pull rudderlabs/rudder-transformer:latest
-      - docker pull yandex/clickhouse-server:21-alpine
-      - docker pull mcr.microsoft.com/azure-sql-edge:1.0.5
-      - docker pull zookeeper:3.5
-      - docker pull minio/minio:latest
-      - docker pull mcr.microsoft.com/azure-storage/azurite:latest
-      - docker pull fsouza/fake-gcs-server:latest
       - go mod download
 
   build:
@@ -45,11 +33,6 @@ phases:
       - DATE=$(date "+%F,%T")
       - VERSION=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed 's/refs\/heads\///g' | tr "/" .)
       # Build Open source version
-      - make test
-      - RSERVER_ENABLE_MULTITENANCY=true  go test -v ./docker_test.go -integration -bigqueryintegration -count 1
-      - RSERVER_ENABLE_MULTITENANCY=false go test -v ./docker_test.go -integration -bigqueryintegration -count 1
-      - find . -name "profile.out" | while read file;do cat $file >> coverage.txt; echo "" >> coverage.txt;done
-      - bash build/codecov.sh
       - GOOS=linux GOARCH=amd64 CGO_ENABLED=1 RACE_ENABLED=TRUE LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - docker build -t rudderlabs/develop-rudder-server:$VERSION -f build/Dockerfile-aws-dev .

--- a/build/buildspec.docker.dev.yml
+++ b/build/buildspec.docker.dev.yml
@@ -4,7 +4,6 @@ env:
     # The SSH deploy key with enterprise rudder server repo
     ssh_key: "/codebuild/github/ssh-key"
     dockerhub_passwd: "/dev/codebuild/dockerhub-password"
-    CODECOV_TOKEN: "/codebuild/codecov-token"
     BIGQUERY_INTEGRATION_TEST_USER_CRED: "/codebuild/integration/tests/bigquery"
 
 phases:
@@ -23,8 +22,6 @@ phases:
       - chmod 600 ~/.ssh/ssh_key
       - eval "$(ssh-agent -s)"
       - ssh-add ~/.ssh/ssh_key
-      - (cd && go get github.com/onsi/ginkgo/ginkgo)
-      - (cd && go get github.com/golang/mock/mockgen)
       - go mod download
 
   build:
@@ -39,10 +36,6 @@ phases:
   post_build:
     commands:
       - docker push rudderlabs/develop-rudder-server:$VERSION
-reports:
-  GinkgoUnitTestReports:
-    files:
-      - "**/junit_*.xml"
 artifacts:
   files:
     - "**/*"

--- a/build/buildspec.docker.dev.yml
+++ b/build/buildspec.docker.dev.yml
@@ -4,7 +4,6 @@ env:
     # The SSH deploy key with enterprise rudder server repo
     ssh_key: "/codebuild/github/ssh-key"
     dockerhub_passwd: "/dev/codebuild/dockerhub-password"
-    BIGQUERY_INTEGRATION_TEST_USER_CRED: "/codebuild/integration/tests/bigquery"
 
 phases:
   install:


### PR DESCRIPTION
## Motivation
* CI tests taking a lot of time 
* Slow to get a docker image for testing, since all tests had to run before
* Hard to debug failed tests in code build (require AWS access /w two-factor auth)
* Need to run tests under multiple configurations (matrix strategy & scalable GitHub action resources are perfect for that) 
* Ability to re-run tests


## Changes

1. Run enterprise tests in GitHub actions, for this required a bot to be created for a PAT to be used.
2. Include `-bigqueryintegration` flag in integration tests and adding `BIGQUERY_INTEGRATION_TEST_USER_CRED` as a secret.
3. Improve code coverage [consolidation script](https://github.com/rudderlabs/rudder-server/pull/1852/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R20) 
4. Add codecov report  as GitHub action
5. Remove tests running from AWS codebuild 

## Results 

* AWS build times from more than 20 minutes to less than 4 minutes
* Docker image build not dependent on test success 
* Time for all checks 10 minutes
* Ability to do matrix tests
* Easier to create parallel workflows 

## Notion Link

[Notion Link
](https://www.notion.so/rudderstacks/Run-CI-tests-only-in-GitHub-actions-c485bf15d0234e7a8c82a122c89334fc)
## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
