### PR TITLE
chore(ci): simplify pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,11 @@
-## Description of the change
+# Description
 
-> Description here
+< Replace with adequate description for this PR as per [Pull Request document](https://www.notion.so/rudderstacks/Pull-Requests-40a4c6bd7a5e4387ba9029bab297c9e3) >
 
-## Notion Link
+## Notion Ticket
 
-> Notion Link
-
-## Type of change
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-
-## Checklist:
-
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have added unit tests for the code
-- [ ] I have made corresponding changes to the documentation
+< Replace with Notion Link >
 
 ## Security
 
-- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
+- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


### PR DESCRIPTION
# Description

## Motivation

The existing template had a few issues and was missing a reference to Pull Request description document.
I wanted to simplify the template and use other conventions and automation instead of the checklists.

**Problem with the checklists**:

Most of our PRs look like this:
<img width="116" alt="Screenshot 2022-04-18 at 12 58 49 PM" src="https://user-images.githubusercontent.com/733195/163792263-a1aaaabf-3da5-4e01-988e-6f3c96326ace.png">

That not a problem per se, but we can use the checklist to indicate work to be done in order to merge rather than optional checks.


**Type of change** -> checklist doesn't make sense, a radio button would, but we have the pattern of the PR name to convey the type. Automated labels can be used instead. Also, most people forget to check this button.

**Checklist** -> Most people tend to ignore this, let's use Github actions for:
* I have added unit tests for the code -> add a label if `_test.go` is detected in the changes.
* My code follows the style guidelines of this project -> golintci



## Notion Link

[Notion Link](https://www.notion.so/rudderstacks/Simplify-PR-template-53f1a9720c414bc1a18a168913f78e7e)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
