### PR TITLE
feat: calculate aggregated pending_events_count metrics for all workspaces

### DIFF
--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1210,7 +1210,7 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 
 	for workspace := range batchRouterWorkspaceJobStatusCount {
 		for destID := range batchRouterWorkspaceJobStatusCount[workspace] {
-			metric.GetPendingEventsMeasurement("batch_rt", workspace, brt.destType).Sub(float64(batchRouterWorkspaceJobStatusCount[workspace][destID]))
+			metric.SubFromPendingEventsMeasurement("batch_rt", workspace, brt.destType, float64(batchRouterWorkspaceJobStatusCount[workspace][destID]))
 		}
 	}
 	//tracking batch router errors
@@ -1644,7 +1644,7 @@ func (worker *workerT) workerProcess() {
 						"workspace": destDrainStat.Workspace,
 					})
 					brt.drainedJobsStat.Count(destDrainStat.Count)
-					metric.GetPendingEventsMeasurement("batch_rt", destDrainStat.Workspace, brt.destType).Sub(float64(drainStatsbyDest[destID].Count))
+					metric.SubFromPendingEventsMeasurement("batch_rt", destDrainStat.Workspace, brt.destType, float64(drainStatsbyDest[destID].Count))
 				}
 			}
 			//Mark the jobs as executing

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1210,7 +1210,7 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 
 	for workspace := range batchRouterWorkspaceJobStatusCount {
 		for destID := range batchRouterWorkspaceJobStatusCount[workspace] {
-			metric.SubFromPendingEventsMeasurement("batch_rt", workspace, brt.destType, float64(batchRouterWorkspaceJobStatusCount[workspace][destID]))
+			metric.DecreasePendingEvents("batch_rt", workspace, brt.destType, float64(batchRouterWorkspaceJobStatusCount[workspace][destID]))
 		}
 	}
 	//tracking batch router errors
@@ -1644,7 +1644,7 @@ func (worker *workerT) workerProcess() {
 						"workspace": destDrainStat.Workspace,
 					})
 					brt.drainedJobsStat.Count(destDrainStat.Count)
-					metric.SubFromPendingEventsMeasurement("batch_rt", destDrainStat.Workspace, brt.destType, float64(drainStatsbyDest[destID].Count))
+					metric.DecreasePendingEvents("batch_rt", destDrainStat.Workspace, brt.destType, float64(drainStatsbyDest[destID].Count))
 				}
 			}
 			//Mark the jobs as executing

--- a/router/router.go
+++ b/router/router.go
@@ -1607,8 +1607,7 @@ func (rt *HandleT) commitStatusList(responseList *[]jobResponseT) {
 
 	defer func() {
 		for workspace := range routerWorkspaceJobStatusCount {
-			metric.GetPendingEventsMeasurement("rt", workspace, rt.destName).
-				Sub(float64(routerWorkspaceJobStatusCount[workspace]))
+			metric.SubFromPendingEventsMeasurement("rt", workspace, rt.destName, float64(routerWorkspaceJobStatusCount[workspace]))
 		}
 	}()
 
@@ -2023,7 +2022,7 @@ func (rt *HandleT) readAndProcess() int {
 				"reasons":  strings.Join(destDrainStat.Reasons, ", "),
 			})
 			rt.drainedJobsStat.Count(destDrainStat.Count)
-			metric.GetPendingEventsMeasurement("rt", destDrainStat.Workspace, rt.destName).Sub(float64(drainStatsbyDest[destID].Count))
+			metric.SubFromPendingEventsMeasurement("rt", destDrainStat.Workspace, rt.destName, float64(drainStatsbyDest[destID].Count))
 		}
 	}
 	rt.logger.Debugf("[DRAIN DEBUG] counts  %v final jobs length being processed %v", rt.destName, len(toProcess))

--- a/router/router.go
+++ b/router/router.go
@@ -1607,7 +1607,7 @@ func (rt *HandleT) commitStatusList(responseList *[]jobResponseT) {
 
 	defer func() {
 		for workspace := range routerWorkspaceJobStatusCount {
-			metric.SubFromPendingEventsMeasurement("rt", workspace, rt.destName, float64(routerWorkspaceJobStatusCount[workspace]))
+			metric.DecreasePendingEvents("rt", workspace, rt.destName, float64(routerWorkspaceJobStatusCount[workspace]))
 		}
 	}()
 
@@ -2022,7 +2022,7 @@ func (rt *HandleT) readAndProcess() int {
 				"reasons":  strings.Join(destDrainStat.Reasons, ", "),
 			})
 			rt.drainedJobsStat.Count(destDrainStat.Count)
-			metric.SubFromPendingEventsMeasurement("rt", destDrainStat.Workspace, rt.destName, float64(drainStatsbyDest[destID].Count))
+			metric.DecreasePendingEvents("rt", destDrainStat.Workspace, rt.destName, float64(drainStatsbyDest[destID].Count))
 		}
 	}
 	rt.logger.Debugf("[DRAIN DEBUG] counts  %v final jobs length being processed %v", rt.destName, len(toProcess))

--- a/services/metric/measurement.go
+++ b/services/metric/measurement.go
@@ -1,6 +1,8 @@
 package metric
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Measurement acts as a key in a Registry.
 type Measurement interface {
@@ -11,6 +13,19 @@ type Measurement interface {
 }
 
 const JOBSDB_PENDING_EVENTS_COUNT = "jobsdb_%s_pending_events_count"
+const ALL_WORKSPACES = "ALL"
+
+// AddToPendingEventsMeasurement increments two gauges, both the workspace-specific and the global
+func AddToPendingEventsMeasurement(tablePrefix string, workspace string, destType string, value float64) {
+	GetPendingEventsMeasurement(tablePrefix, workspace, destType).Add(value)
+	GetPendingEventsMeasurement(tablePrefix, ALL_WORKSPACES, destType).Add(value)
+}
+
+// SubFromPendingEventsMeasurement increments two gauges, both the workspace-specific and the global
+func SubFromPendingEventsMeasurement(tablePrefix string, workspace string, destType string, value float64) {
+	GetPendingEventsMeasurement(tablePrefix, workspace, destType).Sub(value)
+	GetPendingEventsMeasurement(tablePrefix, ALL_WORKSPACES, destType).Sub(value)
+}
 
 // GetPendingEventsMeasurement gets the measurement for pending events metric
 func GetPendingEventsMeasurement(tablePrefix string, workspace string, destType string) Gauge {

--- a/services/metric/measurement.go
+++ b/services/metric/measurement.go
@@ -13,22 +13,24 @@ type Measurement interface {
 }
 
 const JOBSDB_PENDING_EVENTS_COUNT = "jobsdb_%s_pending_events_count"
-const ALL_WORKSPACES = "ALL"
+const ALL = "ALL"
 
-// AddToPendingEventsMeasurement increments two gauges, both the workspace-specific and the global
-func AddToPendingEventsMeasurement(tablePrefix string, workspace string, destType string, value float64) {
-	GetPendingEventsMeasurement(tablePrefix, workspace, destType).Add(value)
-	GetPendingEventsMeasurement(tablePrefix, ALL_WORKSPACES, destType).Add(value)
+// IncreasePendingEvents increments two gauges, both the workspace-specific and the global
+func IncreasePendingEvents(tablePrefix string, workspace string, destType string, value float64) {
+	PendingEvents(tablePrefix, workspace, destType).Add(value)
+	PendingEvents(tablePrefix, ALL, destType).Add(value)
+	PendingEvents(ALL, ALL, destType).Add(value)
 }
 
-// SubFromPendingEventsMeasurement increments two gauges, both the workspace-specific and the global
-func SubFromPendingEventsMeasurement(tablePrefix string, workspace string, destType string, value float64) {
-	GetPendingEventsMeasurement(tablePrefix, workspace, destType).Sub(value)
-	GetPendingEventsMeasurement(tablePrefix, ALL_WORKSPACES, destType).Sub(value)
+// DecreasePendingEvents increments two gauges, both the workspace-specific and the global
+func DecreasePendingEvents(tablePrefix string, workspace string, destType string, value float64) {
+	PendingEvents(tablePrefix, workspace, destType).Sub(value)
+	PendingEvents(tablePrefix, ALL, destType).Sub(value)
+	PendingEvents(ALL, ALL, destType).Sub(value)
 }
 
-// GetPendingEventsMeasurement gets the measurement for pending events metric
-func GetPendingEventsMeasurement(tablePrefix string, workspace string, destType string) Gauge {
+// PendingEvents gets the measurement for pending events metric
+func PendingEvents(tablePrefix string, workspace string, destType string) Gauge {
 	return GetManager().GetRegistry(PUBLISHED_METRICS).MustGetGauge(pendingEventsMeasurement{tablePrefix, workspace, destType})
 }
 

--- a/services/metric/measurement.go
+++ b/services/metric/measurement.go
@@ -15,14 +15,14 @@ type Measurement interface {
 const JOBSDB_PENDING_EVENTS_COUNT = "jobsdb_%s_pending_events_count"
 const ALL = "ALL"
 
-// IncreasePendingEvents increments two gauges, both the workspace-specific and the global
+// IncreasePendingEvents increments three gauges, the dest & workspace-specific gauge, plus two aggregate (global) gauges
 func IncreasePendingEvents(tablePrefix string, workspace string, destType string, value float64) {
 	PendingEvents(tablePrefix, workspace, destType).Add(value)
 	PendingEvents(tablePrefix, ALL, destType).Add(value)
 	PendingEvents(ALL, ALL, destType).Add(value)
 }
 
-// DecreasePendingEvents increments two gauges, both the workspace-specific and the global
+// DecreasePendingEvents increments three gauges, the dest & workspace-specific gauge, plus two aggregate (global) gauges
 func DecreasePendingEvents(tablePrefix string, workspace string, destType string, value float64) {
 	PendingEvents(tablePrefix, workspace, destType).Sub(value)
 	PendingEvents(tablePrefix, ALL, destType).Sub(value)

--- a/services/multitenant/tenantstats.go
+++ b/services/multitenant/tenantstats.go
@@ -63,7 +63,7 @@ func (multitenantStat *MultitenantStatsT) Start() {
 		multitenantStat.RouterDBs[dbPrefix].GetPileUpCounts(pileUpStatMap)
 		for workspace := range pileUpStatMap {
 			for destType := range pileUpStatMap[workspace] {
-				metric.GetPendingEventsMeasurement(dbPrefix, workspace, destType).Add(float64(pileUpStatMap[workspace][destType]))
+				metric.AddToPendingEventsMeasurement(dbPrefix, workspace, destType, float64(pileUpStatMap[workspace][destType]))
 			}
 		}
 	}
@@ -94,7 +94,7 @@ func NewStats(routerDBs map[string]jobsdb.MultiTenantJobsDB) *MultitenantStatsT 
 		routerDBs[dbPrefix].GetPileUpCounts(pileUpStatMap)
 		for workspace := range pileUpStatMap {
 			for destType := range pileUpStatMap[workspace] {
-				metric.GetPendingEventsMeasurement(dbPrefix, workspace, destType).Add(float64(pileUpStatMap[workspace][destType]))
+				metric.AddToPendingEventsMeasurement(dbPrefix, workspace, destType, float64(pileUpStatMap[workspace][destType]))
 			}
 		}
 	}
@@ -164,7 +164,7 @@ func (multitenantStat *MultitenantStatsT) ReportProcLoopAddStats(stats map[strin
 				multitenantStat.routerInputRates[dbPrefix][key][destType] = metric.NewMovingAverage()
 			}
 			multitenantStat.routerInputRates[dbPrefix][key][destType].Add((float64(stats[key][destType]) * float64(time.Second)) / float64(timeTaken))
-			metric.GetPendingEventsMeasurement(dbPrefix, key, destType).Add(float64(stats[key][destType]))
+			metric.AddToPendingEventsMeasurement(dbPrefix, key, destType, float64(stats[key][destType]))
 		}
 	}
 	for workspaceKey := range multitenantStat.routerInputRates[dbPrefix] {

--- a/services/multitenant/tenantstats.go
+++ b/services/multitenant/tenantstats.go
@@ -63,7 +63,7 @@ func (multitenantStat *MultitenantStatsT) Start() {
 		multitenantStat.RouterDBs[dbPrefix].GetPileUpCounts(pileUpStatMap)
 		for workspace := range pileUpStatMap {
 			for destType := range pileUpStatMap[workspace] {
-				metric.AddToPendingEventsMeasurement(dbPrefix, workspace, destType, float64(pileUpStatMap[workspace][destType]))
+				metric.IncreasePendingEvents(dbPrefix, workspace, destType, float64(pileUpStatMap[workspace][destType]))
 			}
 		}
 	}
@@ -94,7 +94,7 @@ func NewStats(routerDBs map[string]jobsdb.MultiTenantJobsDB) *MultitenantStatsT 
 		routerDBs[dbPrefix].GetPileUpCounts(pileUpStatMap)
 		for workspace := range pileUpStatMap {
 			for destType := range pileUpStatMap[workspace] {
-				metric.AddToPendingEventsMeasurement(dbPrefix, workspace, destType, float64(pileUpStatMap[workspace][destType]))
+				metric.IncreasePendingEvents(dbPrefix, workspace, destType, float64(pileUpStatMap[workspace][destType]))
 			}
 		}
 	}
@@ -164,7 +164,7 @@ func (multitenantStat *MultitenantStatsT) ReportProcLoopAddStats(stats map[strin
 				multitenantStat.routerInputRates[dbPrefix][key][destType] = metric.NewMovingAverage()
 			}
 			multitenantStat.routerInputRates[dbPrefix][key][destType].Add((float64(stats[key][destType]) * float64(time.Second)) / float64(timeTaken))
-			metric.AddToPendingEventsMeasurement(dbPrefix, key, destType, float64(stats[key][destType]))
+			metric.IncreasePendingEvents(dbPrefix, key, destType, float64(stats[key][destType]))
 		}
 	}
 	for workspaceKey := range multitenantStat.routerInputRates[dbPrefix] {
@@ -214,7 +214,7 @@ func (multitenantStat *MultitenantStatsT) GetRouterPickupJobs(destType string, n
 
 				if runningJobCount <= 0 || runningTimeCounter <= 0 {
 					//Adding BETA
-					if metric.GetPendingEventsMeasurement("rt", workspaceKey, destType).Value() > 0 {
+					if metric.PendingEvents("rt", workspaceKey, destType).Value() > 0 {
 						usedLatencies[workspaceKey] = multitenantStat.routerTenantLatencyStat[destType][workspaceKey].Value()
 						workspacePickUpCount[workspaceKey] = 1
 					}
@@ -222,7 +222,7 @@ func (multitenantStat *MultitenantStatsT) GetRouterPickupJobs(destType string, n
 				}
 				//TODO : Get rid of unReliableLatencyORInRate hack
 				unReliableLatencyORInRate := false
-				pendingEvents := metric.GetPendingEventsMeasurement("rt", workspaceKey, destType).IntValue()
+				pendingEvents := metric.PendingEvents("rt", workspaceKey, destType).IntValue()
 				if multitenantStat.routerTenantLatencyStat[destType][workspaceKey].Value() != 0 {
 					tmpPickCount := int(math.Min(destTypeCount.Value()*float64(routerTimeOut)/float64(time.Second), runningTimeCounter/(multitenantStat.routerTenantLatencyStat[destType][workspaceKey].Value())))
 					if tmpPickCount < 1 {
@@ -254,7 +254,7 @@ func (multitenantStat *MultitenantStatsT) GetRouterPickupJobs(destType string, n
 	secondaryScores := multitenantStat.getSortedWorkspaceSecondaryScoreList(workspacesWithJobs, workspacePickUpCount, destType, multitenantStat.routerTenantLatencyStat[destType])
 	for _, scoredWorkspace := range secondaryScores {
 		workspaceKey := scoredWorkspace.workspaceId
-		pendingEvents := metric.GetPendingEventsMeasurement("rt", workspaceKey, destType).IntValue()
+		pendingEvents := metric.PendingEvents("rt", workspaceKey, destType).IntValue()
 		if pendingEvents <= 0 {
 			continue
 		}
@@ -312,7 +312,7 @@ func (multitenantStat *MultitenantStatsT) getLastDrainedTimestamp(workspaceKey s
 func getWorkspacesWithPendingJobs(destType string, latencyMap map[string]metric.MovingAverage) []string {
 	workspacesWithJobs := make([]string, 0)
 	for workspaceKey := range latencyMap {
-		val := metric.GetPendingEventsMeasurement("rt", workspaceKey, destType).IntValue()
+		val := metric.PendingEvents("rt", workspaceKey, destType).IntValue()
 		if val > 0 {
 			workspacesWithJobs = append(workspacesWithJobs, workspaceKey)
 		} else if val < 0 {
@@ -375,7 +375,7 @@ func (multitenantStat *MultitenantStatsT) getSortedWorkspaceSecondaryScoreList(w
 	for i, workspaceKey := range workspacesWithJobs {
 		scores[i] = workspaceScore{}
 		scores[i].workspaceId = workspaceKey
-		pendingEvents := metric.GetPendingEventsMeasurement("rt", workspaceKey, destType).IntValue()
+		pendingEvents := metric.PendingEvents("rt", workspaceKey, destType).IntValue()
 		if pendingEvents-workspacePickUpCount[workspaceKey] <= 0 {
 			scores[i].score = math.MaxFloat64
 			scores[i].secondary_score = 0

--- a/services/multitenant/tenantstats_test.go
+++ b/services/multitenant/tenantstats_test.go
@@ -103,8 +103,8 @@ var _ = Describe("tenantStats", func() {
 
 			tenantStats.ReportProcLoopAddStats(input, "rt")
 
-			Expect(metric.GetPendingEventsMeasurement("rt", workspaceID1, destType1).IntValue()).To(Equal(addJobWID1))
-			Expect(metric.GetPendingEventsMeasurement("rt", workspaceID2, destType1).IntValue()).To(Equal(addJobWID2))
+			Expect(metric.PendingEvents("rt", workspaceID1, destType1).IntValue()).To(Equal(addJobWID1))
+			Expect(metric.PendingEvents("rt", workspaceID2, destType1).IntValue()).To(Equal(addJobWID2))
 		})
 
 		It("Should Correctly Calculate the Router PickUp Jobs", func() {
@@ -162,7 +162,7 @@ func Benchmark_Counts(b *testing.B) {
 	b.ResetTimer()
 	metric.GetManager().Reset()
 	const writeRatio = 1000
-	gauge := metric.GetPendingEventsMeasurement("rt", workspaceID1, destType1)
+	gauge := metric.PendingEvents("rt", workspaceID1, destType1)
 	errgroup := errgroup.Group{}
 	errgroup.Go(func() error {
 		for i := 0; i < b.N; i++ {


### PR DESCRIPTION
## Description of the change

Aggregating metrics for all workspaces in InfluxDB through Grafana using a subquery is suboptimal and essentially prohibitive, performance-wise.
Setting up separate alerts per workspace is also not possible due to the high cardinality of workspaces in the hosted environment.
For all the above reasons, we need to calculate aggregated metrics along with the high-granularity ones.


## Notion Link

https://www.notion.so/rudderstacks/Calculate-aggregated-pending_events-metrics-for-all-workspaces-57bb54cf65e94ebda818b62c1c6cbba9

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
