### PR TITLE
fix: disable bq dedup by default (#1855)

### DIFF
--- a/warehouse/bigquery/bigquery.go
+++ b/warehouse/bigquery/bigquery.go
@@ -325,7 +325,7 @@ func (bq *HandleT) loadTable(tableName string, forceLoad bool, getLoadFileLocFro
 			primaryKey = column
 		}
 
-		partitionKey := `"id"`
+		partitionKey := "id"
 		if column, ok := partitionKeyMap[tableName]; ok {
 			partitionKey = column
 		}
@@ -604,7 +604,7 @@ func loadConfig() {
 	config.RegisterBoolConfigVariable(true, &setUsersLoadPartitionFirstEventFilter, true, "Warehouse.bigquery.setUsersLoadPartitionFirstEventFilter")
 	config.RegisterBoolConfigVariable(false, &customPartitionsEnabled, true, "Warehouse.bigquery.customPartitionsEnabled")
 	config.RegisterBoolConfigVariable(false, &isUsersTableDedupEnabled, true, "Warehouse.bigquery.isUsersTableDedupEnabled") // TODO: Depricate with respect to isDedupEnabled
-	isDedupEnabled = config.GetBool("Warehouse.bigquery.isDedupEnabled", true) || isUsersTableDedupEnabled
+	isDedupEnabled = config.GetBool("Warehouse.bigquery.isDedupEnabled", false) || isUsersTableDedupEnabled
 }
 
 func Init() {


### PR DESCRIPTION
## Description of the change

* Disable bq dedup by default

## Notion Link

https://www.notion.so/rudderstacks/Number-of-records-in-custoemr-BigQuery-does-not-match-the-records-ingested-shown-in-syncs-dashboar-91b17ea63a064a1ca9c141e27d1d7a71

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
