### PR TITLE
chore(ci): add generate event script to image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,5 +7,7 @@ COPY go.sum .
 RUN go mod download
 COPY . .
 RUN go install
+COPY scripts/generate-event /scripts
+COPY scripts/batch.json /scripts
 ENTRYPOINT [ "rudder-server" ]
 EXPOSE 8080

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.17.8-alpine3.15
-RUN apk add --no-cache build-base
-RUN mkdir /app
+RUN apk add --no-cache build-base \
+&& mkdir /app
 WORKDIR /app
 COPY go.mod .
 COPY go.sum .

--- a/build/Dockerfile-aws
+++ b/build/Dockerfile-aws
@@ -7,5 +7,6 @@ ADD build/wait-for /
 ADD build/regulation-worker /
 ADD build/wait-for-go/wait-for-go /
 ADD build/docker-entrypoint.sh /
+COPY scripts/generate-event /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/rudder-server"]

--- a/build/Dockerfile-aws
+++ b/build/Dockerfile-aws
@@ -7,7 +7,7 @@ ADD build/wait-for /
 ADD build/regulation-worker /
 ADD build/wait-for-go/wait-for-go /
 ADD build/docker-entrypoint.sh /
-COPY scripts/generate-event /
-COPY scripts/batch.json /
+COPY scripts/generate-event /scripts
+COPY scripts/batch.json /scripts
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/rudder-server"]

--- a/build/Dockerfile-aws
+++ b/build/Dockerfile-aws
@@ -8,5 +8,6 @@ ADD build/regulation-worker /
 ADD build/wait-for-go/wait-for-go /
 ADD build/docker-entrypoint.sh /
 COPY scripts/generate-event /
+COPY scripts/batch.json /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/rudder-server"]

--- a/build/Dockerfile-aws-dev
+++ b/build/Dockerfile-aws-dev
@@ -8,5 +8,6 @@ ADD build/regulation-worker /
 ADD build/wait-for /
 ADD build/wait-for-go/wait-for-go /
 ADD build/docker-entrypoint.sh /
+COPY scripts/generate-event /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/rudder-server-with-race"]

--- a/build/Dockerfile-aws-dev
+++ b/build/Dockerfile-aws-dev
@@ -9,5 +9,6 @@ ADD build/wait-for /
 ADD build/wait-for-go/wait-for-go /
 ADD build/docker-entrypoint.sh /
 COPY scripts/generate-event /
+COPY scripts/batch.json /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/rudder-server-with-race"]

--- a/build/Dockerfile-aws-dev
+++ b/build/Dockerfile-aws-dev
@@ -8,7 +8,7 @@ ADD build/regulation-worker /
 ADD build/wait-for /
 ADD build/wait-for-go/wait-for-go /
 ADD build/docker-entrypoint.sh /
-COPY scripts/generate-event /
-COPY scripts/batch.json /
+COPY scripts/generate-event /scripts
+COPY scripts/batch.json /scripts
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/rudder-server-with-race"]

--- a/scripts/generate-event
+++ b/scripts/generate-event
@@ -1,14 +1,16 @@
 #!/bin/bash
 
-if [ $# != 2 ]
-then
-  echo "Usage: ./generate-event <write_key> <end_point>"
-  echo "Example: ./generate-event 1S0ibSaDlSSGkaQuHLi9feJqIUBNAE https://<data_plane_url>/v1/batch"
-  exit
+if [[ $# != 2 ]]; then
+	echo "Usage: ./generate-event <write_key> <end_point>"
+	echo "Example: ./generate-event 1S0ibSaDlSSGkaQuHLi9feJqIUBNAE https://<data_plane_url>/v1/batch"
+	exit
 fi
 
-dir=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+dir=$(
+	cd "$(dirname "${BASH_SOURCE[0]}")" || exit
+	pwd -P
+)
 
 #curl -u $1: -X POST http://$2:8080/v1/track -d @$dir/track.json --header "Content-Type: application/json"
 #curl -u $1: -X POST $2 -d @$dir/track.json --header "Content-Type: application/json"
-curl -u $1: -X POST $2 -d @$dir/batch.json --header "Content-Type: application/json" # give absolute path for batch.json to test on local machine
+curl -u "$1": -X POST "$2" -d @"${dir}"/batch.json --header "Content-Type: application/json" # give absolute path for batch.json to test on local machine


### PR DESCRIPTION
- Also lint fixes on script and dockerfiles

An example of the usage for now would be to open a terminal inside the running container and execute the script in the `scripts` directory.

# Description

Currently when open source users are asked to generate an event to test their deployed rudderstack data plane, they need to clone the whole repository and then run the script, or download it locally. Adding the script to the image allows for quicker and simpler interaction with the deployed rudder-server. 

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/Include-scripts-generate-event-in-OSS-docker-image-39079734c70d497bb0c4e98b0d9ea187)
## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
