### PR TITLE
feat(core): add support for transient sources

### DIFF
--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/gofrs/uuid"
 	"github.com/golang/mock/gomock"
 	"github.com/ory/dockertest/v3"
@@ -198,7 +199,7 @@ func TestDynamicClusterManager(t *testing.T) {
 		},
 	}
 
-	processor := processor.New(ctx, &clearDb, gwDB, rtDB, brtDB, errDB, mockMTI, &reportingNOOP{})
+	processor := processor.New(ctx, &clearDb, gwDB, rtDB, brtDB, errDB, mockMTI, &reportingNOOP{}, transientsource.NewEmptyService())
 	processor.BackendConfig = mockBackendConfig
 	processor.Transformer = mockTransformer
 	mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
@@ -207,18 +208,20 @@ func TestDynamicClusterManager(t *testing.T) {
 
 	tDb := &jobsdb.MultiTenantHandleT{HandleT: rtDB}
 	rtFactory := &router.Factory{
-		Reporting:     &reportingNOOP{},
-		Multitenant:   mockMTI,
-		BackendConfig: mockBackendConfig,
-		RouterDB:      tDb,
-		ProcErrorDB:   errDB,
+		Reporting:        &reportingNOOP{},
+		Multitenant:      mockMTI,
+		BackendConfig:    mockBackendConfig,
+		RouterDB:         tDb,
+		ProcErrorDB:      errDB,
+		TransientSources: transientsource.NewEmptyService(),
 	}
 	brtFactory := &batchrouter.Factory{
-		Reporting:     &reportingNOOP{},
-		Multitenant:   mockMTI,
-		BackendConfig: mockBackendConfig,
-		RouterDB:      brtDB,
-		ProcErrorDB:   errDB,
+		Reporting:        &reportingNOOP{},
+		Multitenant:      mockMTI,
+		BackendConfig:    mockBackendConfig,
+		RouterDB:         brtDB,
+		ProcErrorDB:      errDB,
+		TransientSources: transientsource.NewEmptyService(),
 	}
 	router := routermanager.New(rtFactory, brtFactory, mockBackendConfig)
 

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -408,7 +408,7 @@ func TestJobsDB(t *testing.T) {
 			},
 		}
 
-		jobDB.Setup(jobsdb.ReadWrite, true, "gw", dbRetention, migrationMode, true, queryFilters)
+		jobDB.Setup(jobsdb.ReadWrite, true, "gw", dbRetention, migrationMode, true, queryFilters, []prebackup.Handler{})
 		defer jobDB.TearDown()
 
 		jobs := genJobs(defaultWorkspaceID, customVal, 2, 1)
@@ -445,7 +445,7 @@ func TestJobsDB(t *testing.T) {
 				return triggerAddNewDS
 			},
 		}
-		jobDB.Setup(jobsdb.ReadWrite, false, "gw", dbRetention, migrationMode, true, queryFilters)
+		jobDB.Setup(jobsdb.ReadWrite, false, "gw", dbRetention, migrationMode, true, queryFilters, []prebackup.Handler{})
 		defer jobDB.TearDown()
 
 		jobs := genJobs(defaultWorkspaceID, customVal, 2, 1)
@@ -476,7 +476,7 @@ func TestJobsDB(t *testing.T) {
 				return triggerAddNewDS
 			},
 		}
-		jobDB.Setup(jobsdb.ReadWrite, true, "gw", dbRetention, migrationMode, true, queryFilters)
+		jobDB.Setup(jobsdb.ReadWrite, true, "gw", dbRetention, migrationMode, true, queryFilters, []prebackup.Handler{})
 		defer jobDB.TearDown()
 
 		jobs := genJobs(defaultWorkspaceID, customVal, 2, 4)
@@ -506,7 +506,7 @@ func TestJobsDB(t *testing.T) {
 			},
 		}
 
-		jobDB.Setup(jobsdb.ReadWrite, true, "gw", dbRetention, migrationMode, true, queryFilters)
+		jobDB.Setup(jobsdb.ReadWrite, true, "gw", dbRetention, migrationMode, true, queryFilters, []prebackup.Handler{})
 		defer jobDB.TearDown()
 
 		jobs := []*jobsdb.JobT{}
@@ -554,7 +554,7 @@ func TestMultiTenantLegacyGetAllJobs(t *testing.T) {
 	queryFilters := jobsdb.QueryFiltersT{
 		CustomVal: true,
 	}
-	jobDB.Setup(jobsdb.ReadWrite, false, strings.ToLower(customVal), dbRetention, migrationMode, true, queryFilters)
+	jobDB.Setup(jobsdb.ReadWrite, false, strings.ToLower(customVal), dbRetention, migrationMode, true, queryFilters, []prebackup.Handler{})
 	defer jobDB.TearDown()
 
 	mtl := jobsdb.MultiTenantLegacy{HandleT: &jobDB}
@@ -637,7 +637,7 @@ func TestMultiTenantGetAllJobs(t *testing.T) {
 	queryFilters := jobsdb.QueryFiltersT{
 		CustomVal: true,
 	}
-	jobDB.Setup(jobsdb.ReadWrite, false, strings.ToLower(customVal), dbRetention, migrationMode, true, queryFilters)
+	jobDB.Setup(jobsdb.ReadWrite, false, strings.ToLower(customVal), dbRetention, migrationMode, true, queryFilters, []prebackup.Handler{})
 	defer jobDB.TearDown()
 
 	mtl := jobsdb.MultiTenantHandleT{HandleT: &jobDB}

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
 	"github.com/rudderlabs/rudder-server/services/archiver"
 	"github.com/rudderlabs/rudder-server/services/stats"
 	"github.com/rudderlabs/rudder-server/utils/logger"
@@ -174,7 +175,7 @@ func TestJobsDB(t *testing.T) {
 		CustomVal: true,
 	}
 
-	jobDB.Setup(jobsdb.ReadWrite, false, "batch_rt", dbRetention, migrationMode, true, queryFilters)
+	jobDB.Setup(jobsdb.ReadWrite, false, "batch_rt", dbRetention, migrationMode, true, queryFilters, []prebackup.Handler{})
 	defer jobDB.TearDown()
 
 	customVal := "MOCKDS"
@@ -324,7 +325,7 @@ func TestJobsDB(t *testing.T) {
 			},
 		}
 
-		jobDB.Setup(jobsdb.ReadWrite, true, "gw", dbRetention, migrationMode, true, queryFilters)
+		jobDB.Setup(jobsdb.ReadWrite, true, "gw", dbRetention, migrationMode, true, queryFilters, []prebackup.Handler{})
 		defer jobDB.TearDown()
 
 		jobCountPerDS := 10
@@ -760,7 +761,7 @@ func TestJobsDB_IncompatiblePayload(t *testing.T) {
 		CustomVal: true,
 	}
 
-	jobDB.Setup(jobsdb.ReadWrite, false, "gw", dbRetention, migrationMode, true, queryFilters)
+	jobDB.Setup(jobsdb.ReadWrite, false, "gw", dbRetention, migrationMode, true, queryFilters, []prebackup.Handler{})
 	defer jobDB.TearDown()
 	customVal := "MOCKDS"
 	var sampleTestJob = jobsdb.JobT{
@@ -800,7 +801,7 @@ func BenchmarkJobsdb(b *testing.B) {
 		CustomVal: true,
 	}
 
-	jobDB.Setup(jobsdb.ReadWrite, false, "batch_rt", dbRetention, migrationMode, true, queryFilters)
+	jobDB.Setup(jobsdb.ReadWrite, false, "batch_rt", dbRetention, migrationMode, true, queryFilters, []prebackup.Handler{})
 	defer jobDB.TearDown()
 
 	customVal := "MOCKDS"

--- a/jobsdb/jobsdb_renameDs_test.go
+++ b/jobsdb/jobsdb_renameDs_test.go
@@ -1,0 +1,191 @@
+package jobsdb
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
+	"github.com/rudderlabs/rudder-server/testhelper"
+	"github.com/rudderlabs/rudder-server/testhelper/destination"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_mustRenameDS(t *testing.T) {
+	withPostgreSQL(t, func(postgresql *destination.PostgresResource) {
+
+		// Given I have a jobsdb with dropSourceIds prebackup handler for 2 sources
+		dbHandle := postgresql.DB
+		jobsdb := &HandleT{
+			dbHandle: dbHandle,
+			preBackupHandlers: []prebackup.Handler{
+				prebackup.DropSourceIds(func() []string { return []string{"one", "two"} }),
+			},
+		}
+		const (
+			jobsTable      = "jobs"
+			jobStatusTable = "job_status"
+		)
+
+		// And I have jobs and job status tables with events from 3 sources
+		createTables(t, dbHandle, jobsTable, jobStatusTable)
+		addJob(t, dbHandle, jobsTable, jobStatusTable, "one", "succeeded")
+		addJob(t, dbHandle, jobsTable, jobStatusTable, "two", "failed")
+		addJob(t, dbHandle, jobsTable, jobStatusTable, "three", "aborted")
+
+		requireRowsCount(t, dbHandle, jobsTable, 3)
+		requireRowsCount(t, dbHandle, jobStatusTable, 3)
+
+		// when I execute the renameDs method
+		err := jobsdb.mustRenameDS(dataSetT{
+			JobTable:       jobsTable,
+			JobStatusTable: jobStatusTable,
+		})
+		require.NoError(t, err)
+
+		// then I end up with one event on each pre_drop table
+		requireRowsCount(t, dbHandle, fmt.Sprintf("%s%s", preDropTablePrefix, jobsTable), 1)
+		requireRowsCount(t, dbHandle, fmt.Sprintf("%s%s", preDropTablePrefix, jobStatusTable), 1)
+	})
+
+}
+func Test_mustRenameDS_drops_table_if_left_empty(t *testing.T) {
+
+	withPostgreSQL(t, func(postgresql *destination.PostgresResource) {
+		dbHandle := postgresql.DB
+
+		// Given I have a jobsdb with dropSourceIds prebackup handler for 2 sources
+		jobsdb := &HandleT{
+			dbHandle: dbHandle,
+			preBackupHandlers: []prebackup.Handler{
+				prebackup.DropSourceIds(func() []string { return []string{"one", "two"} }),
+			},
+		}
+		const (
+			jobsTable      = "jobs"
+			jobStatusTable = "job_status"
+		)
+
+		// And I have jobs and job status tables with events from 2 sources
+		createTables(t, dbHandle, jobsTable, jobStatusTable)
+		addJob(t, dbHandle, jobsTable, jobStatusTable, "one", "succeeded")
+		addJob(t, dbHandle, jobsTable, jobStatusTable, "two", "failed")
+
+		requireRowsCount(t, dbHandle, jobsTable, 2)
+		requireRowsCount(t, dbHandle, jobStatusTable, 2)
+
+		// when I execute the renameDs method
+		err := jobsdb.mustRenameDS(dataSetT{
+			JobTable:       jobsTable,
+			JobStatusTable: jobStatusTable,
+		})
+		require.NoError(t, err)
+
+		// then I end up with no pre_drop tables
+		requireTableNotExists(t, dbHandle, fmt.Sprintf("%s%s", preDropTablePrefix, jobsTable))
+		requireTableNotExists(t, dbHandle, fmt.Sprintf("%s%s", preDropTablePrefix, jobStatusTable))
+		requireTableNotExists(t, dbHandle, jobsTable)
+		requireTableNotExists(t, dbHandle, jobStatusTable)
+	})
+}
+
+func withPostgreSQL(t *testing.T, f func(postgresql *destination.PostgresResource)) {
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		t.Fatalf("Could not connect to docker: %s", err)
+	}
+	cleanup := &testhelper.Cleanup{}
+	defer cleanup.Run()
+	postgresql, err := destination.SetupPostgres(pool, cleanup)
+	if err != nil {
+		t.Fatalf("Could not start postgres: %s", err)
+	}
+
+	fmt.Println("DB_DSN:", postgresql.DB_DSN)
+	f(postgresql)
+}
+
+func createTables(t *testing.T, db *sql.DB, jobsTable, jobStatusTable string) {
+	txn, err := db.Begin()
+	require.NoError(t, err)
+
+	sqlStatement := fmt.Sprintf(`CREATE TABLE "%s" (
+		job_id BIGSERIAL PRIMARY KEY,
+		workspace_id TEXT NOT NULL DEFAULT '',
+		uuid UUID NOT NULL,
+		user_id TEXT NOT NULL,
+		parameters JSONB NOT NULL,
+		custom_val VARCHAR(64) NOT NULL,
+		event_payload JSONB NOT NULL,
+		event_count INTEGER NOT NULL DEFAULT 1,
+		created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+		expire_at TIMESTAMP NOT NULL DEFAULT NOW());`, jobsTable)
+	_, err = txn.Exec(sqlStatement)
+	if err != nil {
+		t.Fatalf("Failed to create jobs table: %s", err)
+	}
+
+	sqlStatement = fmt.Sprintf(`CREATE TABLE "%s" (
+			id BIGSERIAL,
+			job_id BIGINT REFERENCES "%s"(job_id),
+			job_state VARCHAR(64),
+			attempt SMALLINT,
+			exec_time TIMESTAMP,
+			retry_time TIMESTAMP,
+			error_code VARCHAR(32),
+			error_response JSONB DEFAULT '{}'::JSONB,
+			parameters JSONB DEFAULT '{}'::JSONB,
+			PRIMARY KEY (job_id, job_state, id));`, jobStatusTable, jobsTable)
+	_, err = txn.Exec(sqlStatement)
+	if err != nil {
+		t.Fatalf("Failed to create job status table: %s", err)
+	}
+	require.NoError(t, txn.Commit())
+}
+
+func addJob(t *testing.T, db *sql.DB, jobsTable, jobStatusTable, sourceId, state string) {
+	txn, err := db.Begin()
+	require.NoError(t, err)
+
+	sqlStatement := fmt.Sprintf(`INSERT INTO "%s" (workspace_id, uuid, user_id, parameters, custom_val, event_payload, event_count) VALUES(
+		'workspace_id',
+		'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+		'uder_id',
+		'{ "source_id": "%s" }',
+		'custom_val',
+		'{}',
+		1);`, jobsTable, sourceId)
+	_, err = txn.Exec(sqlStatement)
+	if err != nil {
+		t.Fatalf("failed to insert job entry: %s", err)
+	}
+	sqlStatement = fmt.Sprintf(`INSERT INTO "%s" (job_id, job_state, attempt) VALUES(
+		(SELECT max(job_id) FROM "%s") ,
+		'%s',
+		1);`, jobStatusTable, jobsTable, state)
+	_, err = txn.Exec(sqlStatement)
+	if err != nil {
+		t.Fatalf("failed to insert job status entry: %s", err)
+	}
+	require.NoError(t, txn.Commit())
+}
+
+func requireRowsCount(t *testing.T, db *sql.DB, tableName string, expectedCount int) {
+	t.Helper()
+	rows := db.QueryRow(fmt.Sprintf("SELECT COUNT(*) as count FROM %s", tableName))
+	var count int
+	require.NoError(t, rows.Scan(&count))
+	require.EqualValues(t, expectedCount, count)
+}
+
+func requireTableNotExists(t *testing.T, db *sql.DB, tableName string) {
+	t.Helper()
+	stmt, err := db.Prepare("SELECT count(tablename) FROM pg_catalog.pg_tables where tablename = $1")
+	require.NoError(t, err)
+	defer stmt.Close()
+	row := stmt.QueryRow(tableName)
+	var count int
+	require.NoError(t, row.Scan(&count))
+	require.EqualValues(t, 0, count)
+}

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/config"
+	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
 	"github.com/rudderlabs/rudder-server/services/stats"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 )
@@ -136,7 +137,7 @@ var _ = Describe("Calculate newDSIdx for cluster migrations", func() {
 
 		Entry("ClusterMigration Case 1",
 			[]dataSetT{
-				dataSetT{
+				{
 					JobTable:       "",
 					JobStatusTable: "",
 					Index:          "1",
@@ -150,17 +151,17 @@ var _ = Describe("Calculate newDSIdx for cluster migrations", func() {
 
 		Entry("ClusterMigration Case 2",
 			[]dataSetT{
-				dataSetT{
+				{
 					JobTable:       "",
 					JobStatusTable: "",
 					Index:          "0_1",
 				},
-				dataSetT{
+				{
 					JobTable:       "",
 					JobStatusTable: "",
 					Index:          "1",
 				},
-				dataSetT{
+				{
 					JobTable:       "",
 					JobStatusTable: "",
 					Index:          "2",
@@ -181,7 +182,7 @@ var _ = Describe("Calculate newDSIdx for cluster migrations", func() {
 
 		Entry("ClusterMigration Case 1",
 			[]dataSetT{
-				dataSetT{
+				{
 					JobTable:       "",
 					JobStatusTable: "",
 					Index:          "1_1",
@@ -196,12 +197,12 @@ var _ = Describe("Calculate newDSIdx for cluster migrations", func() {
 
 		Entry("ClusterMigration Case 2",
 			[]dataSetT{
-				dataSetT{
+				{
 					JobTable:       "",
 					JobStatusTable: "",
 					Index:          "1",
 				},
-				dataSetT{
+				{
 					JobTable:       "",
 					JobStatusTable: "",
 					Index:          "1_1",
@@ -281,7 +282,7 @@ var _ = Describe("jobsdb", func() {
 			jd = &HandleT{}
 
 			jd.skipSetupDBSetup = true
-			jd.Setup(ReadWrite, false, "tt", 0*time.Hour, "", false, QueryFiltersT{})
+			jd.Setup(ReadWrite, false, "tt", 0*time.Hour, "", false, QueryFiltersT{}, []prebackup.Handler{})
 		})
 
 		AfterEach(func() {

--- a/jobsdb/prebackup/prebackup.go
+++ b/jobsdb/prebackup/prebackup.go
@@ -1,0 +1,59 @@
+package prebackup
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/lib/pq"
+)
+
+// Handler alters a jobsdb table before backup happens
+type Handler interface {
+	Handle(ctx context.Context, txn *sql.Tx, jobsTable, jobStatusTable string) error
+}
+
+// DropSourceIds provides a pre-backup handler who is responsible for removing events
+// from the tables which belong to a transient source id.
+// The list of source ids is dynamically provided by the transientSourceIds function
+func DropSourceIds(transientSourceIds func() []string) Handler {
+	return &dropSourceIds{
+		transientSourceIds: transientSourceIds,
+	}
+}
+
+type dropSourceIds struct {
+	transientSourceIds func() []string
+}
+
+func (r *dropSourceIds) Handle(ctx context.Context, txn *sql.Tx, jobsTable, jobStatusTable string) error {
+	sourceIds := r.transientSourceIds()
+	if len(sourceIds) == 0 {
+		// skip
+		return nil
+	}
+	sourceIdsParam := pq.Array(r.transientSourceIds())
+
+	// First cleanup events from the job status table since it relies on the jobs table
+	jsSql := fmt.Sprintf(`DELETE FROM "%[1]s" WHERE job_id IN (SELECT job_id FROM "%[2]s" WHERE parameters->>'source_id' = ANY ($1))`, jobStatusTable, jobsTable)
+	jsStmt, err := txn.Prepare(jsSql)
+	if err != nil {
+		return fmt.Errorf("could not prepare delete statement: %w", err)
+	}
+	_, err = jsStmt.ExecContext(ctx, sourceIdsParam)
+	if err != nil {
+		return fmt.Errorf("could not delete transient source events from table %s: %w", jobStatusTable, err)
+	}
+
+	// Last cleanup events from the jobs table
+	jSql := fmt.Sprintf(`DELETE FROM "%[1]s" WHERE parameters->>'source_id' = ANY($1)`, jobsTable)
+	jStmt, err := txn.Prepare(jSql)
+	if err != nil {
+		return fmt.Errorf("could not delete transient source events from table %s: %w", jobsTable, err)
+	}
+	_, err = jStmt.ExecContext(ctx, sourceIdsParam)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/jobsdb/prebackup/prebackup_test.go
+++ b/jobsdb/prebackup/prebackup_test.go
@@ -1,0 +1,23 @@
+package prebackup
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_DropSourceIdsHandler_Without_SourceIds(t *testing.T) {
+	handler := DropSourceIds(func() []string { return []string{} })
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var txn *sql.Tx
+
+	// when I execute the dropSourceIds handler for an empty source ids list, a canceled context and nil transaction
+	err := handler.Handle(ctx, txn, "jobs", "job_status")
+
+	// then handler doesn't do anything and no error is returned
+	require.NoError(t, err)
+
+}

--- a/jobsdb/unionQuery_test.go
+++ b/jobsdb/unionQuery_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	uuid "github.com/gofrs/uuid"
+	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
 	"github.com/rudderlabs/rudder-server/services/stats"
 	"github.com/rudderlabs/rudder-server/utils/bytesize"
 	"github.com/stretchr/testify/require"
@@ -23,7 +24,7 @@ func TestMultiTenantHandleT_GetAllJobs(t *testing.T) {
 		CustomVal: true,
 	}
 
-	jobDB.Setup(ReadWrite, false, "rt", dbRetention, migrationMode, true, queryFilters)
+	jobDB.Setup(ReadWrite, false, "rt", dbRetention, migrationMode, true, queryFilters, []prebackup.Handler{})
 	defer jobDB.TearDown()
 
 	customVal := "MOCKDS"

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
+	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/gofrs/uuid"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
@@ -173,7 +175,7 @@ func TestProcessorManager(t *testing.T) {
 	queryFilters := jobsdb.QueryFiltersT{
 		CustomVal: true,
 	}
-	tempDB.Setup(jobsdb.Write, true, "gw", dbRetention, migrationMode, true, queryFilters)
+	tempDB.Setup(jobsdb.Write, true, "gw", dbRetention, migrationMode, true, queryFilters, []prebackup.Handler{})
 	defer tempDB.TearDown()
 
 	customVal := "GW"
@@ -206,7 +208,7 @@ func TestProcessorManager(t *testing.T) {
 			"batch_rt": &jobsdb.MultiTenantLegacy{HandleT: brtDB},
 		},
 	}
-	processor := New(ctx, &clearDb, gwDB, rtDB, brtDB, errDB, mtStat, &reportingNOOP{})
+	processor := New(ctx, &clearDb, gwDB, rtDB, brtDB, errDB, mtStat, &reportingNOOP{}, transientsource.NewEmptyService())
 
 	t.Run("jobs are already there in GW DB before processor starts", func(t *testing.T) {
 		gwDB.Start()

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -36,6 +36,7 @@ import (
 	"github.com/rudderlabs/rudder-server/services/dedup"
 	"github.com/rudderlabs/rudder-server/services/multitenant"
 	"github.com/rudderlabs/rudder-server/services/stats"
+	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/bytesize"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -73,6 +74,7 @@ type HandleT struct {
 	statsFactory        stats.Stats
 	stats               processorStats
 	payloadLimit        int64
+	transientSources    transientsource.Service
 }
 
 type processorStats struct {
@@ -298,7 +300,7 @@ func (proc *HandleT) Status() interface{} {
 func (proc *HandleT) Setup(
 	backendConfig backendconfig.BackendConfig, gatewayDB jobsdb.JobsDB, routerDB jobsdb.JobsDB,
 	batchRouterDB jobsdb.JobsDB, errorDB jobsdb.JobsDB, clearDB *bool, reporting types.ReportingI,
-	multiTenantStat multitenant.MultiTenantI,
+	multiTenantStat multitenant.MultiTenantI, transientSources transientsource.Service,
 ) {
 	proc.reporting = reporting
 	config.RegisterBoolConfigVariable(types.DEFAULT_REPORTING_ENABLED, &proc.reportingEnabled, false, "Reporting.enabled")
@@ -315,6 +317,8 @@ func (proc *HandleT) Setup(
 	proc.routerDB = routerDB
 	proc.batchRouterDB = batchRouterDB
 	proc.errorDB = errorDB
+
+	proc.transientSources = transientSources
 
 	// Stats
 	proc.statsFactory = stats.DefaultStats
@@ -432,7 +436,7 @@ func (proc *HandleT) Start(ctx context.Context) {
 
 	g.Go(misc.WithBugsnag(func() error {
 		st := stash.New()
-		st.Setup(proc.errorDB)
+		st.Setup(proc.errorDB, proc.transientSources)
 		st.Start(ctx)
 		return nil
 	}))
@@ -975,6 +979,8 @@ func (proc *HandleT) getFailedEventJobs(response transformer.ResponseT, commonMe
 			sampleEvent, err := jsonfast.Marshal(message)
 			if err != nil {
 				proc.logger.Errorf(`[Processor: getFailedEventJobs] Failed to unmarshal first element in failed events: %v`, err)
+			}
+			if err != nil || proc.transientSources.Apply(commonMetaData.SourceID) {
 				sampleEvent = []byte(`{}`)
 			}
 			proc.updateMetricMaps(nil, failedCountMap, connectionDetailsMap, statusDetailsMap, failedEvent, jobsdb.Aborted.State, sampleEvent)

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rudderlabs/rudder-server/processor/transformer"
 	"github.com/rudderlabs/rudder-server/services/dedup"
 	"github.com/rudderlabs/rudder-server/services/stats"
+	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/bytesize"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -290,7 +291,7 @@ var _ = Describe("Processor", func() {
 			// crash recover returns empty list
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 
-			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, nil, c.MockMultitenantHandle)
+			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, nil, c.MockMultitenantHandle, transientsource.NewEmptyService())
 		})
 
 		It("should recover after crash", func() {
@@ -303,7 +304,7 @@ var _ = Describe("Processor", func() {
 
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 
-			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, nil, c.MockMultitenantHandle)
+			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, nil, c.MockMultitenantHandle, transientsource.NewEmptyService())
 		})
 	})
 
@@ -322,7 +323,7 @@ var _ = Describe("Processor", func() {
 				transformer: mockTransformer,
 			}
 
-			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, c.MockReportingI, c.MockMultitenantHandle)
+			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, c.MockReportingI, c.MockMultitenantHandle, transientsource.NewEmptyService())
 
 			payloadLimit := processor.payloadLimit
 			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(jobsdb.GetQueryParamsT{CustomValFilters: gatewayCustomVal, JobsLimit: c.dbReadBatchSize, EventsLimit: c.processEventSize, PayloadSizeLimit: payloadLimit}).Return(emptyJobsList).Times(1)
@@ -1082,7 +1083,7 @@ var _ = Describe("Processor", func() {
 			// crash recover returns empty list
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 			SetFeaturesRetryAttempts(0)
-			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, nil, c.MockMultitenantHandle)
+			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, nil, c.MockMultitenantHandle, transientsource.NewEmptyService())
 
 			SetMainLoopTimeout(1 * time.Second)
 
@@ -1108,7 +1109,7 @@ var _ = Describe("Processor", func() {
 			// crash recover returns empty list
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 			SetFeaturesRetryAttempts(0)
-			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, c.MockReportingI, c.MockMultitenantHandle)
+			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, c.MockReportingI, c.MockMultitenantHandle, transientsource.NewEmptyService())
 			defer processor.Shutdown()
 			c.MockReportingI.EXPECT().WaitForSetup(gomock.Any(), gomock.Any()).Times(1)
 
@@ -1558,7 +1559,7 @@ func processorSetupAndAssertJobHandling(processor *HandleT, c *testContext, enab
 func Setup(processor *HandleT, c *testContext, enableDedup, enableReporting bool) {
 	var clearDB = false
 	SetDisableDedupFeature(enableDedup)
-	processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, c.MockReportingI, c.MockMultitenantHandle)
+	processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, c.MockReportingI, c.MockMultitenantHandle, transientsource.NewEmptyService())
 	processor.reportingEnabled = enableReporting
 	// make sure the mock backend config has sent the configuration
 	testutils.RunTestWithTimeout(func() {

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -20,6 +20,7 @@ import (
 	router_utils "github.com/rudderlabs/rudder-server/router/utils"
 	"github.com/rudderlabs/rudder-server/services/filemanager"
 	"github.com/rudderlabs/rudder-server/services/stats"
+	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
@@ -152,7 +153,7 @@ var _ = Describe("BatchRouter", func() {
 
 			c.mockBatchRouterJobsDB.EXPECT().GetJournalEntries(gomock.Any()).Times(1).Return(emptyJournalEntries)
 
-			batchrouter.Setup(c.mockBackendConfig, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, s3DestinationDefinition.Name, nil, c.mockMultitenantI)
+			batchrouter.Setup(c.mockBackendConfig, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, s3DestinationDefinition.Name, nil, c.mockMultitenantI, transientsource.NewEmptyService())
 		})
 	})
 
@@ -165,7 +166,7 @@ var _ = Describe("BatchRouter", func() {
 		It("should send failed, unprocessed jobs to s3 destination", func() {
 			batchrouter := &HandleT{}
 
-			batchrouter.Setup(c.mockBackendConfig, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, s3DestinationDefinition.Name, nil, c.mockMultitenantI)
+			batchrouter.Setup(c.mockBackendConfig, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, s3DestinationDefinition.Name, nil, c.mockMultitenantI, transientsource.NewEmptyService())
 			readPerDestination = false
 			setQueryFilters()
 			batchrouter.fileManagerFactory = c.mockFileManagerFactory

--- a/router/batchrouter/factory.go
+++ b/router/batchrouter/factory.go
@@ -4,20 +4,22 @@ import (
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/services/multitenant"
+	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
 type Factory struct {
-	Reporting     types.ReportingI
-	Multitenant   multitenant.MultiTenantI
-	BackendConfig backendconfig.BackendConfig
-	RouterDB      jobsdb.JobsDB
-	ProcErrorDB   jobsdb.JobsDB
+	Reporting        types.ReportingI
+	Multitenant      multitenant.MultiTenantI
+	BackendConfig    backendconfig.BackendConfig
+	RouterDB         jobsdb.JobsDB
+	ProcErrorDB      jobsdb.JobsDB
+	TransientSources transientsource.Service
 }
 
 func (f *Factory) New(destType string) *HandleT {
 	r := &HandleT{}
 
-	r.Setup(f.BackendConfig, f.RouterDB, f.ProcErrorDB, destType, f.Reporting, f.Multitenant)
+	r.Setup(f.BackendConfig, f.RouterDB, f.ProcErrorDB, destType, f.Reporting, f.Multitenant, f.TransientSources)
 	return r
 }

--- a/router/factory.go
+++ b/router/factory.go
@@ -3,14 +3,16 @@ package router
 import (
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/services/transientsource"
 )
 
 type Factory struct {
-	Reporting     reporter
-	Multitenant   tenantStats
-	BackendConfig backendconfig.BackendConfig
-	RouterDB      jobsdb.MultiTenantJobsDB
-	ProcErrorDB   jobsdb.JobsDB
+	Reporting        reporter
+	Multitenant      tenantStats
+	BackendConfig    backendconfig.BackendConfig
+	RouterDB         jobsdb.MultiTenantJobsDB
+	ProcErrorDB      jobsdb.JobsDB
+	TransientSources transientsource.Service
 }
 
 func (f *Factory) New(destinationDefinition backendconfig.DestinationDefinitionT) *HandleT {
@@ -18,6 +20,6 @@ func (f *Factory) New(destinationDefinition backendconfig.DestinationDefinitionT
 		Reporting:    f.Reporting,
 		MultitenantI: f.Multitenant,
 	}
-	r.Setup(f.BackendConfig, f.RouterDB, f.ProcErrorDB, destinationDefinition)
+	r.Setup(f.BackendConfig, f.RouterDB, f.ProcErrorDB, destinationDefinition, f.TransientSources)
 	return r
 }

--- a/router/manager/manager_test.go
+++ b/router/manager/manager_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/rudderlabs/rudder-server/router/batchrouter"
 	"github.com/rudderlabs/rudder-server/services/archiver"
 	"github.com/rudderlabs/rudder-server/services/stats"
+	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 	testutils "github.com/rudderlabs/rudder-server/utils/tests"
@@ -209,18 +210,20 @@ func TestRouterManager(t *testing.T) {
 	defer errDB.Close()
 	tDb := &jobsdb.MultiTenantHandleT{HandleT: rtDB}
 	rtFactory := &router.Factory{
-		Reporting:     &reportingNOOP{},
-		Multitenant:   mockMTI,
-		BackendConfig: mockBackendConfig,
-		RouterDB:      tDb,
-		ProcErrorDB:   errDB,
+		Reporting:        &reportingNOOP{},
+		Multitenant:      mockMTI,
+		BackendConfig:    mockBackendConfig,
+		RouterDB:         tDb,
+		ProcErrorDB:      errDB,
+		TransientSources: transientsource.NewEmptyService(),
 	}
 	brtFactory := &batchrouter.Factory{
-		Reporting:     &reportingNOOP{},
-		Multitenant:   mockMTI,
-		BackendConfig: mockBackendConfig,
-		RouterDB:      brtDB,
-		ProcErrorDB:   errDB,
+		Reporting:        &reportingNOOP{},
+		Multitenant:      mockMTI,
+		BackendConfig:    mockBackendConfig,
+		RouterDB:         brtDB,
+		ProcErrorDB:      errDB,
+		TransientSources: transientsource.NewEmptyService(),
 	}
 	r := New(rtFactory, brtFactory, mockBackendConfig)
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rudderlabs/rudder-server/router/types"
 	routerUtils "github.com/rudderlabs/rudder-server/router/utils"
 	"github.com/rudderlabs/rudder-server/services/stats"
+	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 	testutils "github.com/rudderlabs/rudder-server/utils/tests"
@@ -150,7 +151,7 @@ var _ = Describe("Router", func() {
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
-			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition)
+			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition, transientsource.NewEmptyService())
 		})
 	})
 
@@ -170,7 +171,7 @@ var _ = Describe("Router", func() {
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
 
-			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition)
+			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition, transientsource.NewEmptyService())
 
 			gaPayload := `{"body": {"XML": {}, "FORM": {}, "JSON": {}}, "type": "REST", "files": {}, "method": "POST", "params": {"t": "event", "v": "1", "an": "RudderAndroidClient", "av": "1.0", "ds": "android-sdk", "ea": "Demo Track", "ec": "Demo Category", "el": "Demo Label", "ni": 0, "qt": 59268380964, "ul": "en-US", "cid": "anon_id", "tid": "UA-185645846-1", "uip": "[::1]", "aiid": "com.rudderlabs.android.sdk"}, "userId": "anon_id", "headers": {}, "version": "1", "endpoint": "https://www.google-analytics.com/collect"}`
 			parameters := fmt.Sprintf(`{"source_id": "1fMCVYZboDlYlauh4GFsEo2JU77", "destination_id": "%s", "message_id": "2f548e6d-60f6-44af-a1f4-62b3272445c3", "received_at": "2021-06-28T10:04:48.527+05:30", "transform_at": "processor"}`, gaDestinationID)
@@ -264,7 +265,7 @@ var _ = Describe("Router", func() {
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
 
-			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition)
+			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition, transientsource.NewEmptyService())
 
 			mockNetHandle := mocksRouter.NewMockNetHandleI(c.mockCtrl)
 			router.netHandle = mockNetHandle
@@ -358,7 +359,7 @@ var _ = Describe("Router", func() {
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
 
-			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition)
+			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition, transientsource.NewEmptyService())
 			mockNetHandle := mocksRouter.NewMockNetHandleI(c.mockCtrl)
 			router.netHandle = mockNetHandle
 			router.MultitenantI = mockMultitenantHandle
@@ -441,7 +442,7 @@ var _ = Describe("Router", func() {
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
-			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition)
+			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition, transientsource.NewEmptyService())
 
 			router.transformer = mockTransformer
 
@@ -589,7 +590,7 @@ var _ = Describe("Router", func() {
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
-			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition)
+			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition, transientsource.NewEmptyService())
 
 			//we have a job that has failed once(toRetryJobsList), it should aborted when picked up next
 			//Because we only allow one failure per job with this
@@ -766,7 +767,7 @@ var _ = Describe("Router", func() {
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
-			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition)
+			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition, transientsource.NewEmptyService())
 			router.transformer = mockTransformer
 			router.noOfWorkers = 1
 			router.noOfJobsToBatchInAWorker = 5
@@ -986,7 +987,7 @@ var _ = Describe("Router", func() {
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
-			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition)
+			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationDefinition, transientsource.NewEmptyService())
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			router.transformer = mockTransformer
 

--- a/router/utils/utils.go
+++ b/router/utils/utils.go
@@ -45,7 +45,7 @@ func loadConfig() {
 func getRetentionTimeForDestination(destID string) time.Duration {
 	destJobRetentionFound := config.IsSet("Router." + destID + ".jobRetention")
 	if destJobRetentionFound {
-		return config.GetDuration("Router"+"."+destID+"jobRetention", 720, time.Hour)
+		return config.GetDuration("Router."+destID+".jobRetention", 720, time.Hour)
 	}
 
 	return JobRetention

--- a/services/transientsource/transientsource.go
+++ b/services/transientsource/transientsource.go
@@ -1,0 +1,138 @@
+package transientsource
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/utils/pubsub"
+	"github.com/tidwall/gjson"
+)
+
+// Service provides services related to transient source ids
+type Service interface {
+
+	// SourceIdsSupplier provides an up-to-date supplier of transient source ids
+	SourceIdsSupplier() func() []string
+
+	// Apply performs transient source_id filtering logic against a single source_id.
+	// If it corresponds to a transient source_id, the result will be true, otherwise false.
+	Apply(sourceId string) bool
+
+	// ApplyJob performs transient source_id filtering logic against a single job.
+	// If the job corresponds to a transient source_id, the result will be true, otherwise false.
+	ApplyJob(job *jobsdb.JobT) bool
+
+	// ApplyParams performs transient source_id filtering logic against a job's parameters.
+	// If the parameters contain a transient source_id, the result will be true, otherwise false.
+	ApplyParams(params json.RawMessage) bool
+}
+
+// NewService creates a new service that updates its transient source ids while
+// backend configuration gets updated.
+func NewService(ctx context.Context, config backendconfig.BackendConfig) Service {
+	s := &service{
+		init: make(chan struct{}),
+	}
+	go s.updateLoop(ctx, config)
+	return s
+}
+
+// NewEmptyService creates a new service that operates against an empty list of transient source ids
+// Useful for tests, when you are not interested in testing for transient sources.
+func NewEmptyService() Service {
+	return NewStaticService([]string{})
+}
+
+// NewStaticService creates a new service that operates against a predefined list of transient source ids.
+// Useful for tests.
+func NewStaticService(sourceIds []string) Service {
+	s := &service{
+		init:         make(chan struct{}),
+		sourceIds:    sourceIds,
+		sourceIdsMap: asMap(sourceIds),
+	}
+	close(s.init)
+	return s
+}
+
+type service struct {
+	onceInit     sync.Once
+	init         chan struct{}
+	sourceIds    []string
+	sourceIdsMap map[string]struct{}
+}
+
+func (r *service) SourceIdsSupplier() func() []string {
+	return func() []string {
+		<-r.init
+		return r.sourceIds
+	}
+}
+
+func (r *service) Apply(sourceId string) bool {
+	<-r.init
+	_, ok := r.sourceIdsMap[sourceId]
+	return ok
+}
+
+func (r *service) ApplyParams(params json.RawMessage) bool {
+	sourceId := gjson.GetBytes(params, "source_id").String()
+	return r.Apply(sourceId)
+}
+
+func (r *service) ApplyJob(job *jobsdb.JobT) bool {
+	return r.ApplyParams(job.Parameters)
+}
+
+// updateLoop uses backend config to retrieve & keep up-to-date the list of transient source ids
+func (r *service) updateLoop(ctx context.Context, config backendconfig.BackendConfig) {
+
+	ch := make(chan pubsub.DataEvent)
+	config.Subscribe(ch, backendconfig.TopicBackendConfig)
+
+	for {
+		select {
+		case ev := <-ch:
+			c := ev.Data.(backendconfig.ConfigT)
+			newSourceIds := transientSourceIds(&c)
+			r.sourceIds = newSourceIds
+			r.sourceIdsMap = asMap(newSourceIds)
+			r.onceInit.Do(func() {
+				close(r.init)
+			})
+		case <-ctx.Done():
+			r.onceInit.Do(func() {
+				close(r.init)
+			})
+			return
+		}
+	}
+}
+
+// transientSourceIds scans a backend configuration and extracts
+// source ids which have the following configuration option
+//
+//    transient : true
+//
+func transientSourceIds(c *backendconfig.ConfigT) []string {
+	r := make([]string, 0)
+	for i := range c.Sources {
+		source := &c.Sources[i]
+		if source.Config["transient"] == true {
+			r = append(r, source.ID)
+		}
+	}
+	return r
+}
+
+// asMap converts a slice of strings to a set, i.e. a map of strings to empty structs
+func asMap(arr []string) map[string]struct{} {
+	res := map[string]struct{}{}
+	for _, excludedSourceId := range arr {
+		res[excludedSourceId] = struct{}{}
+	}
+	return res
+}

--- a/services/transientsource/transientsource_test.go
+++ b/services/transientsource/transientsource_test.go
@@ -1,0 +1,163 @@
+package transientsource
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	mock_backendconfig "github.com/rudderlabs/rudder-server/mocks/config/backend-config"
+	"github.com/rudderlabs/rudder-server/utils/pubsub"
+)
+
+func Test_Service_Apply(t *testing.T) {
+	RegisterTestingT(t)
+
+	service := NewStaticService([]string{"one"})
+
+	Expect(service.Apply("one")).To(Equal(true))
+	Expect(service.Apply("two")).To(Equal(false))
+}
+
+func Test_Service_ApplyJob(t *testing.T) {
+	RegisterTestingT(t)
+
+	service := NewStaticService([]string{"one"})
+
+	job := &jobsdb.JobT{
+		Parameters: json.RawMessage(`{"source_id": "one"}`),
+	}
+
+	Expect(service.ApplyJob(job)).To(Equal(true))
+
+	job = &jobsdb.JobT{
+		Parameters: json.RawMessage(`{"source_id": "two"}`),
+	}
+	Expect(service.ApplyJob(job)).To(Equal(false))
+}
+
+func Test_Service_ApplyParams(t *testing.T) {
+	RegisterTestingT(t)
+
+	service := NewStaticService([]string{"one"})
+
+	params := json.RawMessage(`{"source_id": "one"}`)
+
+	Expect(service.ApplyParams(params)).To(Equal(true))
+
+	params = json.RawMessage(`{"source_id": "two"}`)
+
+	Expect(service.ApplyParams(params)).To(Equal(false))
+}
+
+func Test_SourceIdsSupplier_Normal_Flow(t *testing.T) {
+	RegisterTestingT(t)
+	ctrl := gomock.NewController(t)
+	config := mock_backendconfig.NewMockBackendConfig(ctrl)
+
+	var ch chan pubsub.DataEvent
+
+	var ready sync.WaitGroup
+	ready.Add(2)
+
+	var gotSourceIds sync.WaitGroup
+	gotSourceIds.Add(1)
+
+	config.EXPECT().Subscribe(
+		gomock.Any(),
+		gomock.Eq(backendconfig.TopicBackendConfig),
+	).
+		Do(func(channel chan pubsub.DataEvent, topic backendconfig.Topic) {
+			ch = channel
+			ready.Done()
+		})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Given I have a service reading from the backend
+	service := NewService(ctx, config)
+	sourceIdsSupplier := service.SourceIdsSupplier()
+	var sourceIds []string
+
+	go func() {
+		ready.Done()
+		sourceIds = sourceIdsSupplier()
+		gotSourceIds.Done()
+	}()
+
+	// When the config backend has not published any event yet
+	ready.Wait()
+
+	// Then source ids are still empty
+	Expect(sourceIds).To(BeEmpty())
+
+	// When the config backend publishes an event with two skipped sources
+	ch <- pubsub.DataEvent{
+		Data: backendconfig.ConfigT{
+			Sources: []backendconfig.SourceT{
+				{
+					ID:     "one",
+					Config: map[string]interface{}{"transient": true},
+				},
+				{
+					ID:     "two",
+					Config: map[string]interface{}{"transient": true},
+				},
+			},
+		},
+		Topic: string(backendconfig.TopicBackendConfig),
+	}
+	gotSourceIds.Wait()
+	// Then source ids will contain the two expected elements
+	Expect(sourceIds).To(Equal([]string{"one", "two"}))
+}
+
+func Test_SourceIdsSupplier_Context_Cancelled(t *testing.T) {
+	RegisterTestingT(t)
+	ctrl := gomock.NewController(t)
+	config := mock_backendconfig.NewMockBackendConfig(ctrl)
+
+	var ready sync.WaitGroup
+	ready.Add(2)
+
+	var gotSourceIds sync.WaitGroup
+	gotSourceIds.Add(1)
+
+	config.EXPECT().Subscribe(
+		gomock.Any(),
+		gomock.Eq(backendconfig.TopicBackendConfig),
+	).
+		Do(func(channel chan pubsub.DataEvent, topic backendconfig.Topic) {
+			ready.Done()
+		})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Given I have a service reading from the backend
+	service := NewService(ctx, config)
+	sourceIdsSupplier := service.SourceIdsSupplier()
+	var sourceIds []string
+
+	go func() {
+		ready.Done()
+		sourceIds = sourceIdsSupplier()
+		gotSourceIds.Done()
+	}()
+
+	// When the config backend has not published any event yet
+	ready.Wait()
+
+	// Then source ids are still empty
+	Expect(sourceIds).To(BeEmpty())
+
+	// When the context is canceled
+	cancel()
+
+	// And source Ids are received from the provider
+	gotSourceIds.Wait()
+
+	// Then the source ids remain empty
+	Expect(sourceIds).To(BeEmpty())
+}

--- a/testhelper/destination/postgres.go
+++ b/testhelper/destination/postgres.go
@@ -17,6 +17,7 @@ type PostgresResource struct {
 	Database string
 	Password string
 	User     string
+	Host     string
 	Port     string
 }
 
@@ -61,6 +62,7 @@ func SetupPostgres(pool *dockertest.Pool, d deferer) (*PostgresResource, error) 
 		Database: database,
 		Password: password,
 		User:     user,
+		Host:     "localhost",
 		Port:     postgresContainer.GetPort("5432/tcp"),
 	}, nil
 }


### PR DESCRIPTION
# Description

A **Source** can now be configured as `transient`. The system treats events of transient sources in the following way:

1. Events will not be backed up to the object storage.
2. Failed processor events will not be backed up in `rudder-processor-errors` either, this process is a.k.a `stash` internally.
3. Sample events will not be sent to the reporting service.

## Design notes

- Introduced `transientsource.Service` which is responsible for providing all required services pertaining to transient sources. There are 3 ways you can create a `transientsource.Service`
   1. `transientsource.NewService` - creates a service which will listen for configuration changes and update its list of transient source ids automatically.
   2. `transientsource.NewStaticService` creates a service which uses a static list of transient source ids.
   3. `transientsource.NewEmptyService` creates a static service operating against an empty list of transient source ids.
- Introduced `prebackup.Handler`. Each `jobsdb` (reader or readWriter) instance, after creating a pre-drop table and before backing it up to the object storage, will call its list of pre-backup handlers, if any. Currently only a single type of pre-backup handler exists and is configured, which is responsible for deleting events whose `source_id` is transient.

## Notion Ticket

https://www.notion.so/rudderstacks/Disable-gateway-dumps-for-certain-sources-e32acf723d3e45b48af7bd707afb5262

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
