### PR TITLE
fix: added http client timeout in processor transformer

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -105,6 +105,7 @@ func NewTransformer() *HandleT {
 var (
 	maxConcurrency, maxHTTPConnections, maxHTTPIdleConnections, maxRetry int
 	retrySleep                                                           time.Duration
+	timeoutDuration                                                      time.Duration
 	pkgLogger                                                            logger.LoggerI
 )
 
@@ -120,6 +121,7 @@ func loadConfig() {
 
 	config.RegisterIntConfigVariable(30, &maxRetry, true, 1, "Processor.maxRetry")
 	config.RegisterDurationConfigVariable(time.Duration(100), &retrySleep, true, time.Millisecond, []string{"Processor.retrySleep", "Processor.retrySleepInMS"}...)
+	config.RegisterDurationConfigVariable(time.Duration(30), &timeoutDuration, false, time.Second, []string{"HttpClient.timeout"}...)
 }
 
 type TransformerResponseT struct {
@@ -156,6 +158,7 @@ func (trans *HandleT) Setup() {
 				MaxIdleConnsPerHost: maxHTTPIdleConnections,
 				IdleConnTimeout:     time.Minute,
 			},
+			Timeout: timeoutDuration,
 		}
 	}
 }


### PR DESCRIPTION
# Description

There were no timeout configured for transformer http client. This results in hanging client sometimes. Added client timeout to cancel the request after some duration.

## Notion Ticket

https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=f430b15138a240f483df677993553d72

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
