### PR TITLE
fix(warehouse): added ability to test destination credentials once the upload gets aborted

### DIFF
--- a/warehouse/configuration_testing/steps.go
+++ b/warehouse/configuration_testing/steps.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (ct *CTHandleT) validationStepsFunc(req json.RawMessage, _ string) (json.RawMessage, error) {
-	ct.infoRequest = &infoRequest{}
+	ct.infoRequest = &DestinationValidationRequest{}
 	if err := ct.parseOptions(req, ct.infoRequest); err != nil {
 		return nil, err
 	}
@@ -17,17 +17,19 @@ func (ct *CTHandleT) validationStepsFunc(req json.RawMessage, _ string) (json.Ra
 	})
 }
 
-// validationSteps returns validation step for a Destination
-func (ct *CTHandleT) validationSteps() (steps []*validationStep) {
-	steps = append(steps, &validationStep{
+// validationSteps returns series of validation steps for
+// a particular destination.
+func (ct *CTHandleT) validationSteps() []*validationStep {
+
+	steps := []*validationStep{{
 		ID:        1,
 		Name:      "Verifying Object Storage",
 		Validator: ct.verifyingObjectStorage,
-	})
+	}}
 
 	// Time window destination contains only object storage verification
 	if misc.ContainsString(warehouseutils.TimeWindowDestinations, ct.infoRequest.Destination.DestinationDefinition.Name) {
-		return
+		return steps
 	}
 
 	steps = append(steps,
@@ -52,5 +54,6 @@ func (ct *CTHandleT) validationSteps() (steps []*validationStep) {
 			Validator: ct.verifyingLoadTable,
 		},
 	)
-	return
+
+	return steps
 }

--- a/warehouse/configuration_testing/validate.go
+++ b/warehouse/configuration_testing/validate.go
@@ -17,13 +17,13 @@ import (
 )
 
 func (ct *CTHandleT) validateDestinationFunc(req json.RawMessage, step string) (json.RawMessage, error) {
-	ct.infoRequest = &infoRequest{}
+
+	ct.infoRequest = &DestinationValidationRequest{}
 	if err := ct.parseOptions(req, ct.infoRequest); err != nil {
 		return nil, err
 	}
 
-	resp := validationResponse{}
-
+	resp := DestinationValidationResponse{}
 	// check if req has specified a step in query params
 	if step != "" {
 		stepI, err := strconv.Atoi(step)

--- a/warehouse/identities.go
+++ b/warehouse/identities.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/rudderlabs/rudder-server/warehouse/configuration_testing"
 	"sync"
 
 	"github.com/rudderlabs/rudder-server/config"
@@ -296,11 +297,12 @@ func (wh *HandleT) populateHistoricIdentities(warehouse warehouseutils.Warehouse
 		}
 
 		job := UploadJobT{
-			upload:     &upload,
-			warehouse:  warehouse,
-			whManager:  whManager,
-			dbHandle:   wh.dbHandle,
-			pgNotifier: &wh.notifier,
+			upload:               &upload,
+			warehouse:            warehouse,
+			whManager:            whManager,
+			dbHandle:             wh.dbHandle,
+			pgNotifier:           &wh.notifier,
+			destinationValidator: configuration_testing.NewDestinationValidator(),
 		}
 
 		tableUploadsCreated := areTableUploadsCreated(job.upload.ID)

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/rudderlabs/rudder-server/warehouse/configuration_testing"
 	"strconv"
 	"strings"
 	"sync"
@@ -113,18 +114,19 @@ type UploadT struct {
 }
 
 type UploadJobT struct {
-	upload              *UploadT
-	dbHandle            *sql.DB
-	warehouse           warehouseutils.WarehouseT
-	whManager           manager.ManagerI
-	stagingFiles        []*StagingFileT
-	stagingFileIDs      []int64
-	pgNotifier          *pgnotifier.PgNotifierT
-	schemaHandle        *SchemaHandleT
-	schemaLock          sync.Mutex
-	uploadLock          sync.Mutex
-	hasAllTablesSkipped bool
-	tableUploadStatuses []*TableUploadStatusT
+	upload               *UploadT
+	dbHandle             *sql.DB
+	warehouse            warehouseutils.WarehouseT
+	whManager            manager.ManagerI
+	stagingFiles         []*StagingFileT
+	stagingFileIDs       []int64
+	pgNotifier           *pgnotifier.PgNotifierT
+	schemaHandle         *SchemaHandleT
+	schemaLock           sync.Mutex
+	uploadLock           sync.Mutex
+	hasAllTablesSkipped  bool
+	tableUploadStatuses  []*TableUploadStatusT
+	destinationValidator configuration_testing.DestinationValidator
 }
 
 type UploadColumnT struct {
@@ -1342,41 +1344,84 @@ func (job *UploadJobT) triggerUploadNow() (err error) {
 	return err
 }
 
-func (job *UploadJobT) setUploadError(statusError error, state string) (newstate string, err error) {
-	pkgLogger.Errorf("[WH]: Failed during %s stage: %v\n", state, statusError.Error())
-	job.counterStat(fmt.Sprintf("error_%s", state)).Count(1)
+// extractAndUpdateUploadErrorsByState extracts and augment errors in format
+// { "internal_processing_failed": { "errors": ["account-locked", "account-locked"] }}
+// from a particular upload.
+func extractAndUpdateUploadErrorsByState(message json.RawMessage, state string, statusError error) (map[string]map[string]interface{}, error) {
 
-	upload := job.upload
+	var uploadErrors map[string]map[string]interface{}
+	err := json.Unmarshal(message, &uploadErrors)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal error into upload errors: %v", err)
+	}
 
-	job.setUploadStatus(UploadStatusOpts{Status: state})
-	var e map[string]map[string]interface{}
-	json.Unmarshal(job.upload.Error, &e)
-	if e == nil {
-		e = make(map[string]map[string]interface{})
+	if uploadErrors == nil {
+		uploadErrors = make(map[string]map[string]interface{})
 	}
-	if _, ok := e[state]; !ok {
-		e[state] = make(map[string]interface{})
+
+	if _, ok := uploadErrors[state]; !ok {
+		uploadErrors[state] = make(map[string]interface{})
 	}
-	errorByState := e[state]
+	errorByState := uploadErrors[state]
+
 	// increment attempts for errored stage
 	if attempt, ok := errorByState["attempt"]; ok {
 		errorByState["attempt"] = int(attempt.(float64)) + 1
 	} else {
 		errorByState["attempt"] = 1
 	}
+
 	// append errors for errored stage
 	if errList, ok := errorByState["errors"]; ok {
 		errorByState["errors"] = append(errList.([]interface{}), statusError.Error())
 	} else {
 		errorByState["errors"] = []string{statusError.Error()}
 	}
-	// abort after configured retry attempts
-	if errorByState["attempt"].(int) > minRetryAttempts {
-		firstTiming := job.getUploadFirstAttemptTime()
-		// do not abort upload if the the error list has only skipped errors.
-		if !firstTiming.IsZero() && (timeutil.Now().Sub(firstTiming) > retryTimeWindow) && !job.hasAllTablesSkipped {
-			state = Aborted
-		}
+
+	return uploadErrors, nil
+}
+
+// Aborted makes a check that if the state of the job
+// should be aborted
+func (job *UploadJobT) Aborted(attempts int, startTime time.Time) bool {
+
+	// Defensive check to prevent garbage startTime
+	if startTime.IsZero() {
+		return false
+	}
+
+	// Do not mark aborted as tables skipped.
+	if job.hasAllTablesSkipped {
+		return false
+	}
+	return attempts > minRetryAttempts && timeutil.Now().Sub(startTime) > retryTimeWindow
+}
+
+func (job *UploadJobT) setUploadError(statusError error, state string) (string, error) {
+	pkgLogger.Errorf("[WH]: Failed during %s stage: %v\n", state, statusError.Error())
+
+	job.counterStat(fmt.Sprintf("error_%s", state)).Count(1)
+	upload := job.upload
+
+	err := job.setUploadStatus(UploadStatusOpts{Status: state})
+	if err != nil {
+		return "", fmt.Errorf("unable to set upload's job: %d status: %w", job.upload.ID, err)
+	}
+
+	uploadErrors, err := extractAndUpdateUploadErrorsByState(job.upload.Error, state, statusError)
+	if err != nil {
+		return "", fmt.Errorf("unable to handle upload errors in job: %d by state: %s, err: %v",
+			job.upload.ID,
+			state,
+			err)
+	}
+
+	// Reset the state as aborted if max retries
+	// exceeded.
+	uploadErrorAttempts := uploadErrors[state]["attempt"].(int)
+
+	if job.Aborted(uploadErrorAttempts, job.getUploadFirstAttemptTime()) {
+		state = Aborted
 	}
 
 	var metadata map[string]interface{}
@@ -1390,7 +1435,7 @@ func (job *UploadJobT) setUploadError(statusError error, state string) (newstate
 		metadataJSON = []byte("{}")
 	}
 
-	serializedErr, _ := json.Marshal(&e)
+	serializedErr, _ := json.Marshal(&uploadErrors)
 	// sqlStatement := fmt.Sprintf(`UPDATE %s SET status=$1, error=$2, metadata=$3, updated_at=$4 WHERE id=$5`, warehouseutils.WarehouseUploadsTable)
 
 	uploadColumns := []UploadColumnT{
@@ -1402,11 +1447,12 @@ func (job *UploadJobT) setUploadError(statusError error, state string) (newstate
 
 	txn, err := job.dbHandle.Begin()
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("unable to start transaction: %w", err)
 	}
+
 	err = job.setUploadColumns(UploadColumnsOpts{Fields: uploadColumns, Txn: txn})
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("unable to change upload columns: %w", err)
 	}
 
 	inputCount := job.getTotalRowsInStagingFiles()
@@ -1481,11 +1527,33 @@ func (job *UploadJobT) setUploadError(statusError error, state string) (newstate
 	if !job.hasAllTablesSkipped {
 		job.counterStat("warehouse_failed_uploads", tag{name: "attempt_number", value: strconv.Itoa(attempts)}).Count(1)
 	}
+
+	// On aborted state, validate credentials to allow
+	// us to differentiate between user caused abort vs platform issue.
 	if state == Aborted {
-		job.counterStat("upload_aborted", tag{name: "attempt_number", value: strconv.Itoa(attempts)}).Count(1)
+		// base tag to be sent as stat
+
+		tags := []tag{{name: "attempt_number", value: strconv.Itoa(attempts)}}
+		valid, err := job.validateDestinationCredentials()
+		if err == nil {
+			tags = append(tags, tag{name: "destination_creds_valid", value: strconv.FormatBool(valid)})
+		}
+
+		job.counterStat("upload_aborted", tags...).Count(1)
 	}
 
 	return state, err
+}
+
+func (job *UploadJobT) validateDestinationCredentials() (bool, error) {
+	validationResult, err := job.destinationValidator.ValidateCredentials(&configuration_testing.DestinationValidationRequest{Destination: job.warehouse.Destination})
+
+	if err != nil {
+		pkgLogger.Errorf("Unable to successfully validate destination: %s credentials, err: %v", job.warehouse.Destination.ID, err)
+		return false, err
+	}
+
+	return validationResult.Success, nil
 }
 
 func (job *UploadJobT) getAttemptNumber() int {
@@ -2055,29 +2123,3 @@ func (job *UploadJobT) GetLocalSchema() warehouseutils.SchemaT {
 func (job *UploadJobT) UpdateLocalSchema(schema warehouseutils.SchemaT) error {
 	return job.schemaHandle.updateLocalSchema(schema)
 }
-
-// func (job *UploadJobT) BatchStagingFilesOnTimeWindow(stagingFiles []*StagingFileT) map[string][]StagingFileEntryT {
-// 	var batchedStagingFiles = map[string][]StagingFileEntryT{}
-// 	if job.warehouse.Type != "S3_DATALAKE" {
-// 		var stagingFileEntries = []StagingFileEntryT{}
-// 		for _, stagingFile := range stagingFiles {
-// 			stagingFileEntries = append(stagingFileEntries, StagingFileEntryT{
-// 				ID:       stagingFile.ID,
-// 				Location: stagingFile.Location,
-// 			})
-// 		}
-// 		// return single batch with a zero value timeWindow for all whs except S3_DATALAKE
-// 		batchedStagingFiles[time.Time{}.Format(time.RFC3339)] = stagingFileEntries
-// 		return batchedStagingFiles
-// 	}
-// 	for _, stagingFile := range stagingFiles {
-// 		// td: take prefix from config
-// 		prefixFormat := time.RFC3339
-// 		timeWindow := stagingFile.TimeWindow.Format(prefixFormat)
-// 		batchedStagingFiles[timeWindow] = append(batchedStagingFiles[timeWindow], StagingFileEntryT{
-// 			ID:       stagingFile.ID,
-// 			Location: stagingFile.Location,
-// 		})
-// 	}
-// 	return batchedStagingFiles
-// }

--- a/warehouse/upload_test.go
+++ b/warehouse/upload_test.go
@@ -1,0 +1,64 @@
+package warehouse
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestExtractUploadErrorsByState(t *testing.T) {
+
+	input := []struct {
+		InitialErrorState []byte
+		CurrentErrorState string
+		CurrentError      error
+		ErrorCount        int
+	}{
+		{
+			InitialErrorState: []byte(`{}`),
+			CurrentErrorState: InternalProcessingFailed,
+			CurrentError:      errors.New("account locked"),
+			ErrorCount:        1,
+		},
+		{
+			InitialErrorState: []byte(`{"internal_processing_failed": {"errors": ["account locked"], "attempt": 1}}`),
+			CurrentErrorState: InternalProcessingFailed,
+			CurrentError:      errors.New("account locked again"),
+			ErrorCount:        2,
+		},
+		{
+			InitialErrorState: []byte(`{"internal_processing_failed": {"errors": ["account locked", "account locked again"], "attempt": 2}}`),
+			CurrentErrorState: TableUploadExportingFailed,
+			CurrentError:      errors.New("failed to load data because failed in earlier job"),
+			ErrorCount:        1,
+		},
+	}
+
+	for _, ip := range input {
+
+		uploadErrors, err := extractAndUpdateUploadErrorsByState(ip.InitialErrorState, ip.CurrentErrorState, ip.CurrentError)
+		if err != nil {
+			t.Errorf("extracting upload errors by state should have passed: %v", err)
+		}
+
+		stateErrors := uploadErrors[ip.CurrentErrorState]
+		// Below switch clause mirrors how we are
+		// adding data in generic interface.
+
+		var errorLength int
+		switch stateErrors["errors"].(type) {
+		case []string:
+			errorLength = len(stateErrors["errors"].([]string))
+		case []interface{}:
+			errorLength = len(stateErrors["errors"].([]interface{}))
+		}
+
+		if errorLength != ip.ErrorCount {
+			t.Errorf("expected error to be addded to list of state errors")
+		}
+
+		if stateErrors["attempt"].(int) != ip.ErrorCount {
+			t.Errorf("expected attempts to be: %d, got: %d", ip.ErrorCount, stateErrors["attempt"].(int))
+		}
+	}
+
+}

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/rudderlabs/rudder-server/warehouse/configuration_testing"
 	"io"
 	"net/http"
 	"runtime"
@@ -829,13 +830,14 @@ func (wh *HandleT) getUploadsToProcess(availableWorkers int, skipIdentifiers []s
 		}
 
 		uploadJob := UploadJobT{
-			upload:         &upload,
-			stagingFiles:   stagingFilesList,
-			stagingFileIDs: stagingFileIDs,
-			warehouse:      warehouse,
-			whManager:      whManager,
-			dbHandle:       wh.dbHandle,
-			pgNotifier:     &wh.notifier,
+			upload:               &upload,
+			stagingFiles:         stagingFilesList,
+			stagingFileIDs:       stagingFileIDs,
+			warehouse:            warehouse,
+			whManager:            whManager,
+			dbHandle:             wh.dbHandle,
+			pgNotifier:           &wh.notifier,
+			destinationValidator: configuration_testing.NewDestinationValidator(),
 		}
 
 		uploadJobs = append(uploadJobs, &uploadJob)


### PR DESCRIPTION
# Description
Added ability to test the destination credentials once we have an aborted upload. We do this to better classify the alerts that systems fires off on aborted uploads.

## Notion Ticket
[Ticket](https://www.notion.so/rudderstacks/Classify-upload_aborted-alert-as-user-vs-platform-caused-95a2a4ad15894c63809566210071362f)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
