### PR TITLE
fix: use the correct measurement name and tags for aggregated pending events metrics

### DIFF
--- a/services/metric/measurement.go
+++ b/services/metric/measurement.go
@@ -19,14 +19,14 @@ const ALL = "ALL"
 func IncreasePendingEvents(tablePrefix string, workspace string, destType string, value float64) {
 	PendingEvents(tablePrefix, workspace, destType).Add(value)
 	PendingEvents(tablePrefix, ALL, destType).Add(value)
-	PendingEvents(ALL, ALL, destType).Add(value)
+	PendingEvents(tablePrefix, ALL, ALL).Add(value)
 }
 
 // DecreasePendingEvents increments three gauges, the dest & workspace-specific gauge, plus two aggregate (global) gauges
 func DecreasePendingEvents(tablePrefix string, workspace string, destType string, value float64) {
 	PendingEvents(tablePrefix, workspace, destType).Sub(value)
 	PendingEvents(tablePrefix, ALL, destType).Sub(value)
-	PendingEvents(ALL, ALL, destType).Sub(value)
+	PendingEvents(tablePrefix, ALL, ALL).Sub(value)
 }
 
 // PendingEvents gets the measurement for pending events metric


### PR DESCRIPTION
# Description

Fix, using the correct measurement name and tags for aggregate metrics.

Previously the following measurement was recorded:

`jobsdb_ALL_pending_events_count workspace=ALL,destType=<type>`

Now:
`jobsdb_rt_pending_events_count workspace=ALL,destType=ALL`
`jobsdb_batch_rt_pending_events_count workspace=ALL,destType=ALL`

## Notion Ticket

https://www.notion.so/rudderstacks/Use-the-correct-measurement-name-and-tags-for-aggregated-pending-events-metrics-dbfc88275e9e4652ad4067f58c24c214

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
