### PR TITLE
feat(warehouse): added ability to capture stats around warehouse scheduler

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -105,6 +105,7 @@ func NewTransformer() *HandleT {
 var (
 	maxConcurrency, maxHTTPConnections, maxHTTPIdleConnections, maxRetry int
 	retrySleep                                                           time.Duration
+	timeoutDuration                                                      time.Duration
 	pkgLogger                                                            logger.LoggerI
 )
 
@@ -120,6 +121,7 @@ func loadConfig() {
 
 	config.RegisterIntConfigVariable(30, &maxRetry, true, 1, "Processor.maxRetry")
 	config.RegisterDurationConfigVariable(time.Duration(100), &retrySleep, true, time.Millisecond, []string{"Processor.retrySleep", "Processor.retrySleepInMS"}...)
+	config.RegisterDurationConfigVariable(time.Duration(30), &timeoutDuration, false, time.Second, []string{"HttpClient.timeout"}...)
 }
 
 type TransformerResponseT struct {
@@ -156,6 +158,7 @@ func (trans *HandleT) Setup() {
 				MaxIdleConnsPerHost: maxHTTPIdleConnections,
 				IdleConnTimeout:     time.Minute,
 			},
+			Timeout: timeoutDuration,
 		}
 	}
 }


### PR DESCRIPTION
# Description

Started capturing metrics for warehouse scheduling thus enabling deeper analysis into the operational efficiency.

## Notion Ticket

[Ticket](https://www.notion.so/rudderstacks/Create-metrics-for-warehouse-scheduler-lag-measurement-7e515ac773af4509b8c61529b4070103)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
