### PR TITLE
feat(warehouse): added metrics for capturing stats in warehouse scheduling

### DIFF
--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -715,10 +715,8 @@ func (wh *HandleT) mainLoop(ctx context.Context) {
 		wg := sync.WaitGroup{}
 		wg.Add(len(wh.warehouses))
 
-		// We will be measuring the overall lag
-		// as part of the process.
-		whSchedulerLag := stats.DefaultStats.NewStat("wh_scheduler.total_scheduling_time", stats.TimerType)
-		whSchedulerLag.Start()
+		whTotalSchedulingStats := stats.DefaultStats.NewStat("wh_scheduler.total_scheduling_time", stats.TimerType)
+		whTotalSchedulingStats.Start()
 
 		for _, warehouse := range wh.warehouses {
 			w := warehouse
@@ -739,7 +737,7 @@ func (wh *HandleT) mainLoop(ctx context.Context) {
 		wh.configSubscriberLock.RUnlock()
 		wg.Wait()
 
-		whSchedulerLag.End()
+		whTotalSchedulingStats.End()
 		select {
 		case <-ctx.Done():
 			return

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -630,17 +630,16 @@ func (wh *HandleT) createJobs(warehouse warehouseutils.WarehouseT) (err error) {
 		return nil
 	}
 
-	uploadStartAfter := getUploadStartAfterTime()
-	wh.createUploadJobsFromStagingFiles(warehouse, whManager, stagingFilesList, priority, uploadStartAfter)
-	setLastProcessedMarker(warehouse, uploadStartAfter)
-
 	uploadJobCreationStat := stats.DefaultStats.NewTaggedStat("wh_scheduler.create_upload_jobs", stats.TimerType, stats.Tags{
 		"destinationID": warehouse.Destination.ID,
 		"destType":      warehouse.Destination.DestinationDefinition.Name,
 	})
 	uploadJobCreationStat.Start()
-	wh.createUploadJobsFromStagingFiles(warehouse, whManager, stagingFilesList, priority)
-	setLastProcessedMarker(warehouse)
+
+	uploadStartAfter := getUploadStartAfterTime()
+	wh.createUploadJobsFromStagingFiles(warehouse, whManager, stagingFilesList, priority, uploadStartAfter)
+	setLastProcessedMarker(warehouse, uploadStartAfter)
+
 	uploadJobCreationStat.End()
 
 	return nil

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -738,6 +738,7 @@ func (wh *HandleT) mainLoop(ctx context.Context) {
 		wg.Wait()
 
 		whTotalSchedulingStats.End()
+		stats.DefaultStats.NewStat("wh_scheduler.warehouse_length", stats.CountType).Count(len(wh.warehouses)) // Correlation between number of warehouses and scheduling time.
 		select {
 		case <-ctx.Done():
 			return

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -17,8 +17,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rudderlabs/rudder-server/warehouse/deltalake"
-
 	"github.com/bugsnag/bugsnag-go/v2"
 	"github.com/lib/pq"
 	"github.com/rudderlabs/rudder-server/app"
@@ -30,12 +28,14 @@ import (
 	destinationdebugger "github.com/rudderlabs/rudder-server/services/debugger/destination"
 	"github.com/rudderlabs/rudder-server/services/pgnotifier"
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
+	"github.com/rudderlabs/rudder-server/services/stats"
 	"github.com/rudderlabs/rudder-server/services/validators"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 	"github.com/rudderlabs/rudder-server/utils/types"
+	"github.com/rudderlabs/rudder-server/warehouse/deltalake"
 	"github.com/rudderlabs/rudder-server/warehouse/manager"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 	"github.com/thoas/go-funk"
@@ -613,11 +613,18 @@ func (wh *HandleT) createJobs(warehouse warehouseutils.WarehouseT) (err error) {
 	}
 	wh.areBeingEnqueuedLock.Unlock()
 
+	stagingFilesFetchStat := stats.DefaultStats.NewTaggedStat("wh_scheduler.pending_staging_files", stats.TimerType, stats.Tags{
+		"destinationID": warehouse.Destination.ID,
+		"destType":      warehouse.Destination.DestinationDefinition.Name,
+	})
+	stagingFilesFetchStat.Start()
 	stagingFilesList, err := wh.getPendingStagingFiles(warehouse)
 	if err != nil {
 		pkgLogger.Errorf("[WH]: Failed to get pending staging files: %s with error %v", warehouse.Identifier, err)
 		return err
 	}
+	stagingFilesFetchStat.End()
+
 	if len(stagingFilesList) == 0 {
 		pkgLogger.Debugf("[WH]: Found no pending staging files for %s", warehouse.Identifier)
 		return nil
@@ -626,6 +633,16 @@ func (wh *HandleT) createJobs(warehouse warehouseutils.WarehouseT) (err error) {
 	uploadStartAfter := getUploadStartAfterTime()
 	wh.createUploadJobsFromStagingFiles(warehouse, whManager, stagingFilesList, priority, uploadStartAfter)
 	setLastProcessedMarker(warehouse, uploadStartAfter)
+
+	uploadJobCreationStat := stats.DefaultStats.NewTaggedStat("wh_scheduler.create_upload_jobs", stats.TimerType, stats.Tags{
+		"destinationID": warehouse.Destination.ID,
+		"destType":      warehouse.Destination.DestinationDefinition.Name,
+	})
+	uploadJobCreationStat.Start()
+	wh.createUploadJobsFromStagingFiles(warehouse, whManager, stagingFilesList, priority)
+	setLastProcessedMarker(warehouse)
+	uploadJobCreationStat.End()
+
 	return nil
 }
 
@@ -698,6 +715,12 @@ func (wh *HandleT) mainLoop(ctx context.Context) {
 		wh.configSubscriberLock.RLock()
 		wg := sync.WaitGroup{}
 		wg.Add(len(wh.warehouses))
+
+		// We will be measuring the overall lag
+		// as part of the process.
+		whSchedulerLag := stats.DefaultStats.NewStat("wh_scheduler.total_scheduling_time", stats.TimerType)
+		whSchedulerLag.Start()
+
 		for _, warehouse := range wh.warehouses {
 			w := warehouse
 			rruntime.GoForWarehouse(func() {
@@ -717,6 +740,7 @@ func (wh *HandleT) mainLoop(ctx context.Context) {
 		wh.configSubscriberLock.RUnlock()
 		wg.Wait()
 
+		whSchedulerLag.End()
 		select {
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
# Description

Started capturing metrics for warehouse scheduling thus enabling deeper analysis into the operational efficiency.

## Notion Ticket

[Ticket](https://www.notion.so/rudderstacks/Create-metrics-for-warehouse-scheduler-lag-measurement-7e515ac773af4509b8c61529b4070103)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
