### PR TITLE
fix: Force set lower version during pg notifier sql migration

### DIFF
--- a/services/pgnotifier/pgnotifier.go
+++ b/services/pgnotifier/pgnotifier.go
@@ -398,7 +398,7 @@ func (notifier *PgNotifierT) setupQueue() (err error) {
 	m := &migrator.Migrator{
 		Handle:                     notifier.dbHandle,
 		MigrationsTable:            "pg_notifier_queue_migrations",
-		ShouldForceSetLowerVersion: config.GetBool("SQLMigrator.forceSetLowerVersion", false),
+		ShouldForceSetLowerVersion: config.GetBool("SQLMigrator.forceSetLowerVersion", true),
 	}
 	err = m.Migrate("pg_notifier_queue")
 	if err != nil {


### PR DESCRIPTION
# Description

< Replace with adequate description for this PR as per [Pull Request document](https://www.notion.so/rudderstacks/Pull-Requests-40a4c6bd7a5e4387ba9029bab297c9e3) >

## Notion Ticket

< Replace with Notion Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
