### PR TITLE
[WIP] fix: Add tags for tags related to Network Layer

### DIFF
--- a/router/network.go
+++ b/router/network.go
@@ -37,6 +37,7 @@ type NetHandleT struct {
 //Network interface
 type NetHandleI interface {
 	SendPost(ctx context.Context, structData integrations.PostParametersT) *utils.SendPostResponse
+	SendPostMock(ctx context.Context, structData integrations.PostParametersT, timeInMs int) *utils.SendPostResponse
 }
 
 //temp solution for handling complex query params
@@ -223,6 +224,16 @@ func (network *NetHandleT) SendPost(ctx context.Context, structData integrations
 		ResponseBody: []byte{},
 	}
 
+}
+
+func (network *NetHandleT) SendPostMock(ctx context.Context, structData integrations.PostParametersT, timeInMs int) *utils.SendPostResponse {
+	// Sleep time
+	misc.SleepCtx(ctx, time.Duration(timeInMs)*time.Millisecond)
+	return &utils.SendPostResponse{
+		StatusCode:          200,
+		ResponseContentType: "application/json",
+		ResponseBody:        []byte(""),
+	}
 }
 
 //Setup initializes the module

--- a/router/router.go
+++ b/router/router.go
@@ -779,7 +779,7 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 									worker.routerProxyStat.SendTiming(proxyDuration)
 									// Print all the stats gathered from ProxyRequest
 									for _, logStat := range proxyStatsList {
-										pkgLogger.Errorf("[NwLayer Latency], %v, %v, %v, %v", logStat.Stat, logStat.CurrentTime.Format(time.StampNano), worker.rt.destName, logStat.Latency)
+										pkgLogger.Errorf("[NwLayer Latency], %v, %v, %v, %v", logStat.CurrentTime.Format(time.StampNano), logStat.Stat, worker.rt.destName, logStat.Latency)
 									}
 									pkgLogger.Errorf("[NwLayer Latency], %v, router_proxy_latency, %v, %v", time.Now().Format(time.StampNano), worker.rt.destName, proxyDuration.Milliseconds())
 									authType := router_utils.GetAuthType(destinationJob.Destination)

--- a/router/router.go
+++ b/router/router.go
@@ -772,10 +772,15 @@ func (worker *workerT) handleWorkerDestinationJobs(ctx context.Context) {
 								defer cancel()
 								//transformer proxy start
 								if worker.rt.transformerProxy {
+									var proxyStatsList []transformer.LogStats
 									rtl_time := time.Now()
-									respStatusCode, respBodyTemp = worker.rt.transformer.ProxyRequest(ctx, val, worker.rt.destName, worker.rt.destLatency)
+									respStatusCode, respBodyTemp, proxyStatsList = worker.rt.transformer.ProxyRequest(ctx, val, worker.rt.destName, worker.rt.destLatency)
 									proxyDuration := time.Since(rtl_time)
 									worker.routerProxyStat.SendTiming(proxyDuration)
+									// Print all the stats gathered from ProxyRequest
+									for _, logStat := range proxyStatsList {
+										pkgLogger.Errorf("[NwLayer Latency], %v, %v, %v, %v", logStat.Stat, logStat.CurrentTime.Format(time.StampNano), worker.rt.destName, logStat.Latency)
+									}
 									pkgLogger.Errorf("[NwLayer Latency], %v, router_proxy_latency, %v, %v", time.Now().Format(time.StampNano), worker.rt.destName, proxyDuration.Milliseconds())
 									authType := router_utils.GetAuthType(destinationJob.Destination)
 									if router_utils.IsNotEmptyString(authType) && authType == "OAuth" {

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -266,7 +266,7 @@ func (trans *HandleT) ProxyRequest(ctx context.Context, responseData integration
 	integrations.CollectDestErrorStats(respData)
 	err = jsonfast.Unmarshal(respData, &transformerResponse)
 	statsMap = append(statsMap, LogStats{
-		Stat:        "transformer_proxy_resp_marshal_time",
+		Stat:        "transformer_proxy_resp_unmarshal_time",
 		Latency:     time.Since(unmarshStTime).Milliseconds(),
 		CurrentTime: time.Now(),
 	})

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -40,11 +40,17 @@ type HandleT struct {
 	logger                             logger.LoggerI
 }
 
+type LogStats struct {
+	Stat        string
+	Latency     int64
+	CurrentTime time.Time
+}
+
 //Transformer provides methods to transform events
 type Transformer interface {
 	Setup()
 	Transform(transformType string, transformMessage *types.TransformMessageT) []types.DestinationJobT
-	ProxyRequest(ctx context.Context, responseData integrations.PostParametersT, destName string, mockDestLatencyTime int) (statusCode int, respBody string)
+	ProxyRequest(ctx context.Context, responseData integrations.PostParametersT, destName string, mockDestLatencyTime int) (statusCode int, respBody string, stats []LogStats)
 }
 
 //NewTransformer creates a new transformer
@@ -184,11 +190,18 @@ func (trans *HandleT) Transform(transformType string, transformMessage *types.Tr
 	return destinationJobs
 }
 
-func (trans *HandleT) ProxyRequest(ctx context.Context, responseData integrations.PostParametersT, destName string, mockDestLatencyTime int) (int, string) {
+func (trans *HandleT) ProxyRequest(ctx context.Context, responseData integrations.PostParametersT, destName string, mockDestLatencyTime int) (int, string, []LogStats) {
+	statsMap := []LogStats{}
+	marshStTime := time.Now()
 	rawJSON, err := jsonfast.Marshal(responseData)
 	if err != nil {
 		panic(err)
 	}
+	statsMap = append(statsMap, LogStats{
+		Stat:        "proxy_resp_data_marshal_time",
+		Latency:     time.Since(marshStTime).Milliseconds(),
+		CurrentTime: time.Now(),
+	})
 
 	var respData []byte
 	var respCode int
@@ -200,7 +213,7 @@ func (trans *HandleT) ProxyRequest(ctx context.Context, responseData integration
 		var requestError error
 		//start
 		rdl_time := time.Now()
-		respData, respCode, requestError = trans.makeHTTPRequest(ctx, url, payload, mockDestLatencyTime)
+		respData, respCode, requestError = trans.makeHTTPRequest(ctx, url, payload, mockDestLatencyTime, &statsMap)
 		// if requestError != nil {
 		// 	stats.NewTaggedStat("transformer_proxy.request_latency", stats.TimerType, stats.Tags{"requestSuccess": "false"}).SendTiming(time.Since(rdl_time))
 		// 	stats.NewTaggedStat("transformer_proxy.request_result", stats.CountType, stats.Tags{"requestSuccess": "false"}).Increment()
@@ -208,8 +221,14 @@ func (trans *HandleT) ProxyRequest(ctx context.Context, responseData integration
 		// 	stats.NewTaggedStat("transformer_proxy.request_latency", stats.TimerType, stats.Tags{"requestSuccess": "true"}).SendTiming(time.Since(rdl_time))
 		// 	stats.NewTaggedStat("transformer_proxy.request_result", stats.CountType, stats.Tags{"requestSuccess": "true"}).Increment()
 		// }
+		httpReqDuration := time.Since(rdl_time)
 		reqSuccessStr := strconv.FormatBool(requestError != nil)
-		stats.NewTaggedStat("transformer_proxy.request_latency", stats.TimerType, stats.Tags{"requestSuccess": reqSuccessStr, "destination": destName}).SendTiming(time.Since(rdl_time))
+		statsMap = append(statsMap, LogStats{
+			Stat:        "proxy_make_http_req_time",
+			Latency:     httpReqDuration.Milliseconds(),
+			CurrentTime: time.Now(),
+		})
+		stats.NewTaggedStat("transformer_proxy.request_latency", stats.TimerType, stats.Tags{"requestSuccess": reqSuccessStr, "destination": destName}).SendTiming(httpReqDuration)
 		stats.NewTaggedStat("transformer_proxy.request_result", stats.CountType, stats.Tags{"requestSuccess": reqSuccessStr, "destination": destName}).Increment()
 		//end
 		return requestError
@@ -224,7 +243,7 @@ func (trans *HandleT) ProxyRequest(ctx context.Context, responseData integration
 	if err != nil {
 		panic(fmt.Errorf("[Transformer Proxy] Proxy request failed after max retries Error:: %+v", err))
 	}
-
+	gjsonProcStTime := time.Now()
 	//Detecting content type of the respBody
 	contentTypeHeader := strings.ToLower(http.DetectContentType(respData))
 	//If content type is not of type "*text*", overriding it with empty string
@@ -238,23 +257,45 @@ func (trans *HandleT) ProxyRequest(ctx context.Context, responseData integration
 		Message: "[Transformer Proxy]:: Default Message TransResponseT",
 	}
 	respData = []byte(gjson.GetBytes(respData, "output").Raw)
+	statsMap = append(statsMap, LogStats{
+		Stat:        "transformer_proxy_gjson_proc_time",
+		Latency:     time.Since(gjsonProcStTime).Milliseconds(),
+		CurrentTime: time.Now(),
+	})
+	unmarshStTime := time.Now()
 	integrations.CollectDestErrorStats(respData)
 	err = jsonfast.Unmarshal(respData, &transformerResponse)
+	statsMap = append(statsMap, LogStats{
+		Stat:        "transformer_proxy_resp_marshal_time",
+		Latency:     time.Since(unmarshStTime).Milliseconds(),
+		CurrentTime: time.Now(),
+	})
 	// unmarshal failure
 	if err != nil {
+		unmarshErrStTime := time.Now()
 		errStr := string(respData) + " [Transformer Proxy Unmarshaling]::" + err.Error()
 		trans.logger.Errorf(errStr)
 		respData = []byte(errStr)
 		respCode = http.StatusBadRequest
-		return respCode, string(respData)
+		statsMap = append(statsMap, LogStats{
+			Stat:        "transformer_proxy_resp_error",
+			Latency:     time.Since(unmarshErrStTime).Milliseconds(),
+			CurrentTime: time.Now(),
+		})
+		return respCode, string(respData), statsMap
 	}
+	respMarshStTime := time.Now()
 	// unmarshal success
 	respData, err = jsonfast.Marshal(transformerResponse)
 	if err != nil {
 		panic(fmt.Errorf("[Transformer Proxy]:: failed to Marshal proxy response : %+v", err))
 	}
-
-	return respCode, string(respData)
+	statsMap = append(statsMap, LogStats{
+		Stat:        "transformer_proxy_resp_marshal_time",
+		Latency:     time.Since(respMarshStTime).Milliseconds(),
+		CurrentTime: time.Now(),
+	})
+	return respCode, string(respData), statsMap
 }
 
 //is it ok to use same client for network and transformer calls? need to understand timeout setup in router
@@ -268,9 +309,10 @@ func (trans *HandleT) Setup() {
 
 }
 
-func (trans *HandleT) makeHTTPRequest(ctx context.Context, url string, payload []byte, mockDestTime int) ([]byte, int, error) {
+func (trans *HandleT) makeHTTPRequest(ctx context.Context, url string, payload []byte, mockDestTime int, statsPtr *[]LogStats) ([]byte, int, error) {
 	var respData []byte
 	var respCode int
+	reqBuildStTime := time.Now()
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
 	if err != nil {
 		return []byte{}, http.StatusBadRequest, err
@@ -282,9 +324,21 @@ func (trans *HandleT) makeHTTPRequest(ctx context.Context, url string, payload [
 		q.Add("mockDestTime", strconv.Itoa(mockDestTime))
 		req.URL.RawQuery = q.Encode()
 	}
+	*statsPtr = append(*statsPtr, LogStats{
+		Stat:        "transformer_proxy_req_build_time",
+		Latency:     time.Since(reqBuildStTime).Milliseconds(),
+		CurrentTime: time.Now(),
+	})
 
+	reqStTime := time.Now()
 	resp, err := trans.client.Do(req)
+	*statsPtr = append(*statsPtr, LogStats{
+		Stat:        "transformer_proxy_req_round_trip_time",
+		Latency:     time.Since(reqStTime).Milliseconds(),
+		CurrentTime: time.Now(),
+	})
 
+	respProcStTime := time.Now()
 	if err != nil {
 		return []byte{}, http.StatusBadRequest, err
 	}
@@ -298,6 +352,13 @@ func (trans *HandleT) makeHTTPRequest(ctx context.Context, url string, payload [
 
 	respData, err = io.ReadAll(resp.Body)
 	defer resp.Body.Close()
+	defer func() {
+		*statsPtr = append(*statsPtr, LogStats{
+			Stat:        "transformer_proxy_resp_checks_io_readall_time",
+			Latency:     time.Since(respProcStTime).Milliseconds(),
+			CurrentTime: time.Now(),
+		})
+	}()
 	// error handling while reading from resp.Body
 	if err != nil {
 		respData = []byte(fmt.Sprintf(`[Transformer Proxy] :: failed to read response body, Error:: %+v`, err))

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -301,9 +301,7 @@ func (trans *HandleT) ProxyRequest(ctx context.Context, responseData integration
 //is it ok to use same client for network and transformer calls? need to understand timeout setup in router
 func (trans *HandleT) Setup() {
 	trans.logger = pkgLogger
-	// Just trying this out!! May not be the right solution
-	// http://tleyden.github.io/blog/2016/11/21/tuning-the-go-http-client-library-for-load-testing/
-	trans.tr = &http.Transport{MaxIdleConns: 120, MaxIdleConnsPerHost: 120}
+	trans.tr = &http.Transport{}
 	trans.client = &http.Client{Transport: trans.tr, Timeout: timeoutDuration}
 	trans.transformRequestTimerStat = stats.NewStat("router.processor.transformer_request_time", stats.TimerType)
 	trans.transformerNetworkRequestTimerStat = stats.NewStat("router.transformer_network_request_time", stats.TimerType)

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -301,7 +301,9 @@ func (trans *HandleT) ProxyRequest(ctx context.Context, responseData integration
 //is it ok to use same client for network and transformer calls? need to understand timeout setup in router
 func (trans *HandleT) Setup() {
 	trans.logger = pkgLogger
-	trans.tr = &http.Transport{}
+	// Just trying this out!! May not be the right solution
+	// http://tleyden.github.io/blog/2016/11/21/tuning-the-go-http-client-library-for-load-testing/
+	trans.tr = &http.Transport{MaxIdleConns: 120, MaxIdleConnsPerHost: 120}
 	trans.client = &http.Client{Transport: trans.tr, Timeout: timeoutDuration}
 	trans.transformRequestTimerStat = stats.NewStat("router.processor.transformer_request_time", stats.TimerType)
 	trans.transformerNetworkRequestTimerStat = stats.NewStat("router.transformer_network_request_time", stats.TimerType)


### PR DESCRIPTION
# Description

We are trying to test the Transformer Network Layer to see if auto-scaling solves the latency problem
As part of the testing, we have currently updated the metrics for making proxy request from server to transformer to include `destination` as one of the tags

## Notion Ticket

[Transformer Network Layer](https://www.notion.so/rudderstacks/N-W-Layer-Deployment-89d975c914a249a5a042555976141cc5)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
