### PR TITLE
fix(warehouse): skipping bigquery integration test for now

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - name: Integration test
-      run: go test -v ./docker_test.go -integration -bigqueryintegration -count 1
+      run: go test -v ./docker_test.go -integration -count 1
       env:
         RSERVER_ENABLE_MULTITENANCY: false
         BIGQUERY_INTEGRATION_TEST_USER_CRED: ${{ secrets.BIGQUERY_INTEGRATION_TEST_USER_CRED }}
@@ -40,7 +40,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Checkout enterprise 
+    - name: Checkout enterprise
       uses: actions/checkout@v3
       with:
         repository: rudderlabs/rudder-server-enterprise
@@ -62,7 +62,7 @@ jobs:
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: make enterprise-init
     - name: Integration test
-      run: go test -v ./docker_test.go -integration -bigqueryintegration -count 1
+      run: go test -v ./docker_test.go -integration -count 1
       env:
         RSERVER_ENABLE_MULTITENANCY: ${{ matrix.MULTITENANCY }}
         BIGQUERY_INTEGRATION_TEST_USER_CRED: ${{ secrets.BIGQUERY_INTEGRATION_TEST_USER_CRED }}
@@ -96,7 +96,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Checkout enterprise 
+    - name: Checkout enterprise
       uses: actions/checkout@v3
       with:
         repository: rudderlabs/rudder-server-enterprise


### PR DESCRIPTION
# Description

Disable big query integration test for now.

## Notion Ticket

https://www.notion.so/rudderstacks/Disable-big-query-integration-tests-for-now-a2c888eff448459ab46e0ec8886ca53a

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
