### PR TITLE
fix(warehouse): closing file while creating load file for warehouse configuration test

### DIFF
--- a/warehouse/configuration_testing/validate.go
+++ b/warehouse/configuration_testing/validate.go
@@ -209,6 +209,11 @@ func (ct *CTHandleT) createLoadFile() (filePath string, err error) {
 		pkgLogger.Errorf("[WH]: Failed to write event with error: %s", err.Error())
 		return
 	}
+	err = writer.Close()
+	if err != nil {
+		pkgLogger.Errorf("[WH]: Error while closing load file with error: %s", err.Error())
+		return
+	}
 	return
 }
 


### PR DESCRIPTION
# Description

Closing load file when creating load file during warehouse configuration test.

## Notion Ticket

https://www.notion.so/rudderstacks/Fix-warehouse-configuration-test-for-closing-load-file-eb17eb411e774c2489d5af68b5e4620e

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
