### PR TITLE
chore: fix for `chore.enrichTransformationsMetrics` branch PR

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -202,10 +202,14 @@ func (proc *HandleT) newUserTransformationStat(sourceID, workspaceID string, des
 
 	tags["transformation_id"] = destination.Transformations[0].ID
 	tags["transformation_version_id"] = destination.Transformations[0].VersionID
+	tags["error"] = "false"
 
 	numEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_in_count", stats.CountType, tags)
 	numOutputSuccessEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_out_count", stats.CountType, tags)
-	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_error_count", stats.CountType, tags)
+
+	errTags := tags
+	errTags["error"] = "true"
+	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_out_count", stats.CountType, tags)
 	transformTime := proc.statsFactory.NewTaggedStat("proc_transform_stage_duration", stats.TimerType, tags)
 
 	return &DestStatT{
@@ -220,10 +224,14 @@ func (proc *HandleT) newDestinationTransformationStat(sourceID, workspaceID, tra
 	tags := buildStatTags(sourceID, workspaceID, destination, DEST_TRANSFORMATION)
 
 	tags["transform_at"] = transformAt
+	tags["error"] = "false"
 
 	numEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_in_count", stats.CountType, tags)
 	numOutputSuccessEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_out_count", stats.CountType, tags)
-	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_error_count", stats.CountType, tags)
+
+	errTags := tags
+	errTags["error"] = "true"
+	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_out_count", stats.CountType, tags)
 	destTransform := proc.statsFactory.NewTaggedStat("proc_transform_stage_duration", stats.TimerType, tags)
 
 	return &DestStatT{
@@ -236,10 +244,14 @@ func (proc *HandleT) newDestinationTransformationStat(sourceID, workspaceID, tra
 
 func (proc *HandleT) newEventFilterStat(sourceID, workspaceID string, destination backendconfig.DestinationT) *DestStatT {
 	tags := buildStatTags(sourceID, workspaceID, destination, EVENT_FILTER)
+	tags["error"] = "false"
 
 	numEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_in_count", stats.CountType, tags)
-	numOutputSuccessEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_output_out_count", stats.CountType, tags)
-	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_output_error_count", stats.CountType, tags)
+	numOutputSuccessEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_out_count", stats.CountType, tags)
+
+	errTags := tags
+	errTags["error"] = "true"
+	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_out_count", stats.CountType, errTags)
 	eventFilterTime := proc.statsFactory.NewTaggedStat("proc_event_filter_time", stats.TimerType, tags)
 
 	return &DestStatT{

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -221,9 +221,9 @@ func (proc *HandleT) newDestinationTransformationStat(sourceID, workspaceID, tra
 
 	tags["transform_at"] = transformAt
 
-	numEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_input_events", stats.CountType, tags)
-	numOutputSuccessEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_success_events", stats.CountType, tags)
-	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_failed_events", stats.CountType, tags)
+	numEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_in_count", stats.CountType, tags)
+	numOutputSuccessEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_out_count", stats.CountType, tags)
+	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_error_count", stats.CountType, tags)
 	destTransform := proc.statsFactory.NewTaggedStat("proc_transform_stage_duration", stats.TimerType, tags)
 
 	return &DestStatT{
@@ -237,9 +237,9 @@ func (proc *HandleT) newDestinationTransformationStat(sourceID, workspaceID, tra
 func (proc *HandleT) newEventFilterStat(sourceID, workspaceID string, destination backendconfig.DestinationT) *DestStatT {
 	tags := buildStatTags(sourceID, workspaceID, destination, EVENT_FILTER)
 
-	numEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_input_events", stats.CountType, tags)
-	numOutputSuccessEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_output_success_events", stats.CountType, tags)
-	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_output_failed_events", stats.CountType, tags)
+	numEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_in_count", stats.CountType, tags)
+	numOutputSuccessEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_output_out_count", stats.CountType, tags)
+	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_output_error_count", stats.CountType, tags)
 	eventFilterTime := proc.statsFactory.NewTaggedStat("proc_event_filter_time", stats.TimerType, tags)
 
 	return &DestStatT{

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -207,9 +207,9 @@ func (proc *HandleT) newUserTransformationStat(sourceID, workspaceID string, des
 	numEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_in_count", stats.CountType, tags)
 	numOutputSuccessEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_out_count", stats.CountType, tags)
 
-	errTags := tags
+	errTags := misc.CopyStringMap(tags)
 	errTags["error"] = "true"
-	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_out_count", stats.CountType, tags)
+	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_out_count", stats.CountType, errTags)
 	transformTime := proc.statsFactory.NewTaggedStat("proc_transform_stage_duration", stats.TimerType, tags)
 
 	return &DestStatT{
@@ -229,9 +229,9 @@ func (proc *HandleT) newDestinationTransformationStat(sourceID, workspaceID, tra
 	numEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_in_count", stats.CountType, tags)
 	numOutputSuccessEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_out_count", stats.CountType, tags)
 
-	errTags := tags
+	errTags := misc.CopyStringMap(tags)
 	errTags["error"] = "true"
-	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_out_count", stats.CountType, tags)
+	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_transform_stage_out_count", stats.CountType, errTags)
 	destTransform := proc.statsFactory.NewTaggedStat("proc_transform_stage_duration", stats.TimerType, tags)
 
 	return &DestStatT{
@@ -249,7 +249,7 @@ func (proc *HandleT) newEventFilterStat(sourceID, workspaceID string, destinatio
 	numEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_in_count", stats.CountType, tags)
 	numOutputSuccessEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_out_count", stats.CountType, tags)
 
-	errTags := tags
+	errTags := misc.CopyStringMap(tags)
 	errTags["error"] = "true"
 	numOutputFailedEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_out_count", stats.CountType, errTags)
 	eventFilterTime := proc.statsFactory.NewTaggedStat("proc_event_filter_time", stats.TimerType, tags)

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -1411,3 +1411,11 @@ func MapLookup(mapToLookup map[string]interface{}, keys ...string) interface{} {
 	}
 	return nil
 }
+
+func CopyStringMap(originalMap map[string]string) map[string]string {
+	newMap := make(map[string]string)
+	for key, value := range originalMap {
+		newMap[key] = value
+	}
+	return newMap
+}


### PR DESCRIPTION
# Description
>In PR: https://github.com/rudderlabs/rudder-server/pull/1892,
 in func  `newUserTransformationStat`, we modified 
`proc_num_ut_input_events` -> `proc_transform_stage_in_count`
`proc_num_ut_output_success_events` -> `proc_transform_stage_out_count`
`proc_num_ut_output_failed_events` -> `proc_transform_stage_error_count` 

but forgot to make modification at other similar places. So, those are fixed in this PR.


## Notion Ticket

https://www.notion.so/rudderstacks/minor-metrics-name-fix-for-chore-enrichTransformationsMetrics-branch-PR-43f98884ee704f0ab42a1a57f41c9653

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
