### PR TITLE
fix: wrong routing of warehouse crash alerts

### DIFF
--- a/main.go
+++ b/main.go
@@ -293,7 +293,7 @@ func Run(ctx context.Context) {
 
 	// initialize warehouse service after core to handle non-normal recovery modes
 	if appTypeStr != app.GATEWAY && canStartWarehouse() {
-		g.Go(misc.WithBugsnag(func() error {
+		g.Go(misc.WithBugsnagForWarehouse(func() error {
 			return startWarehouseService(ctx, application)
 		}))
 	}


### PR DESCRIPTION
# Description
Currently, whenever warehouse pod crashes, Bugsnag sends alert to server team, instead of warehouse team. 
eg: https://app.squadcast.com/incident/627a4c7d1adea9000811385e
These alerts incorrect routing will be fixed with this PR.

## Notion Ticket
https://www.notion.so/rudderstacks/bugsnag-false-routing-warehouse-one-coming-to-us-d4e4d771f3404b5f9ac6a9a779b10009

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
