### PR TITLE
fix(multi-tenant): multitenanat backend config

### DIFF
--- a/app/cluster/dynamic.go
+++ b/app/cluster/dynamic.go
@@ -170,7 +170,7 @@ func (d *Dynamic) handleWorkspaceChange(ctx context.Context, workspaces string) 
 	}
 	d.BackendConfig.Stop()
 	d.BackendConfig.StartWithIDs(workspaces)
-
+	d.currentWorkspaceIDs = workspaces
 	return d.BackendConfig.WaitForConfig(ctx)
 }
 

--- a/config/backend-config/multitenant_workspaces.go
+++ b/config/backend-config/multitenant_workspaces.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -73,9 +74,15 @@ func (workspaceConfig *MultiTenantWorkspacesConfig) Get(workspaces string) (Conf
 
 // getFromApi gets the workspace config from api
 func (workspaceConfig *MultiTenantWorkspacesConfig) getFromAPI(workspaceArr string) (ConfigT, bool) {
-	url := fmt.Sprintf("%s/multitenantWorkspaceConfig?ids=[%s]", configBackendURL, workspaceArr)
-	workspacesString := ""
-	url = url + workspacesString
+	wIds := strings.Split(workspaceArr, ",")
+	for i := range wIds {
+		wIds[i] = strings.Trim(wIds[i], " ")
+	}
+	encodedWorkspaces, err := jsonfast.MarshalToString(wIds)
+	if err != nil {
+		return ConfigT{}, false
+	}
+	url := fmt.Sprintf("%s/multitenantWorkspaceConfig?workspaceIds=%s", configBackendURL, encodedWorkspaces)
 	url = url + "&fetchAll=true"
 	var respBody []byte
 	var statusCode int
@@ -87,7 +94,7 @@ func (workspaceConfig *MultiTenantWorkspacesConfig) getFromAPI(workspaceArr stri
 	}
 
 	backoffWithMaxRetry := backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 3)
-	err := backoff.RetryNotify(operation, backoffWithMaxRetry, func(err error, t time.Duration) {
+	err = backoff.RetryNotify(operation, backoffWithMaxRetry, func(err error, t time.Duration) {
 		pkgLogger.Errorf("Failed to fetch config from API with error: %v, retrying after %v", err, t)
 	})
 

--- a/config/backend-config/multitenant_workspaces.go
+++ b/config/backend-config/multitenant_workspaces.go
@@ -80,6 +80,7 @@ func (workspaceConfig *MultiTenantWorkspacesConfig) getFromAPI(workspaceArr stri
 	}
 	encodedWorkspaces, err := jsonfast.MarshalToString(wIds)
 	if err != nil {
+		pkgLogger.Errorf("Error fetching config: preparing request URL: %v", err)
 		return ConfigT{}, false
 	}
 	url := fmt.Sprintf("%s/multitenantWorkspaceConfig?workspaceIds=%s", configBackendURL, encodedWorkspaces)

--- a/config/backend-config/multitenant_workspaces_test.go
+++ b/config/backend-config/multitenant_workspaces_test.go
@@ -68,8 +68,7 @@ var _ = Describe("workspace-config", func() {
 			testRequest, _ := http.NewRequest("GET", server.URL, nil)
 			mockHttp.EXPECT().NewRequest("GET",
 				fmt.Sprintf("%s/multitenantWorkspaceConfig?workspaceIds=[\"testToken\"]&fetchAll=true",
-					configBackendURL),
-				nil).Return(testRequest, nil).Times(1)
+					configBackendURL), nil).Return(testRequest, nil).Times(1)
 
 			config, ok := backendConfig.Get("testToken")
 			Expect(backendConfig.GetWorkspaceIDForWriteKey("d2")).To(Equal("testWordSpaceId"))
@@ -91,8 +90,7 @@ var _ = Describe("workspace-config", func() {
 			testRequest, _ := http.NewRequest("GET", server.URL, nil)
 			mockHttp.EXPECT().NewRequest("GET",
 				fmt.Sprintf("%s/multitenantWorkspaceConfig?workspaceIds=[\"testToken\"]&fetchAll=true",
-					configBackendURL),
-				nil).Return(testRequest, nil).Times(1)
+					configBackendURL), nil).Return(testRequest, nil).Times(1)
 
 			mockLogger.EXPECT().Error("Error while parsing request", gomock.Any(), http.StatusNoContent).Times(1)
 			config, ok := backendConfig.Get("testToken")
@@ -102,8 +100,7 @@ var _ = Describe("workspace-config", func() {
 		It("Expect to make the correct actions if fail to create the request: Multitenant", func() {
 			mockHttp.EXPECT().NewRequest("GET",
 				fmt.Sprintf("%s/multitenantWorkspaceConfig?workspaceIds=[\"testToken\"]&fetchAll=true",
-					configBackendURL),
-				nil).Return(nil, errors.New("TestError")).AnyTimes()
+					configBackendURL), nil).Return(nil, errors.New("TestError")).AnyTimes()
 			mockLogger.EXPECT().Errorf("Failed to fetch config from API with error: %v, retrying after %v", gomock.Eq(errors.New("TestError")), gomock.Any()).AnyTimes()
 			mockLogger.EXPECT().Error("Error sending request to the server", gomock.Eq(errors.New("TestError"))).Times(1)
 			config, ok := backendConfig.Get("testToken")
@@ -114,8 +111,7 @@ var _ = Describe("workspace-config", func() {
 			testRequest, _ := http.NewRequest("GET", "", nil)
 			mockHttp.EXPECT().NewRequest("GET",
 				fmt.Sprintf("%s/multitenantWorkspaceConfig?workspaceIds=[\"testToken\"]&fetchAll=true",
-					configBackendURL),
-				nil).Return(testRequest, nil).AnyTimes()
+					configBackendURL), nil).Return(testRequest, nil).AnyTimes()
 			mockLogger.EXPECT().Errorf("Failed to fetch config from API with error: %v, retrying after %v", gomock.Any(), gomock.Any()).AnyTimes()
 			mockLogger.EXPECT().Error("Error sending request to the server", gomock.Any()).Times(1)
 			config, ok := backendConfig.Get("testToken")

--- a/config/backend-config/multitenant_workspaces_test.go
+++ b/config/backend-config/multitenant_workspaces_test.go
@@ -66,7 +66,10 @@ var _ = Describe("workspace-config", func() {
 			defer server.Close()
 
 			testRequest, _ := http.NewRequest("GET", server.URL, nil)
-			mockHttp.EXPECT().NewRequest("GET", fmt.Sprintf("%s/multitenantWorkspaceConfig?ids=[testToken]&fetchAll=true", configBackendURL), nil).Return(testRequest, nil).Times(1)
+			mockHttp.EXPECT().NewRequest("GET",
+				fmt.Sprintf("%s/multitenantWorkspaceConfig?workspaceIds=[\"testToken\"]&fetchAll=true",
+					configBackendURL),
+				nil).Return(testRequest, nil).Times(1)
 
 			config, ok := backendConfig.Get("testToken")
 			Expect(backendConfig.GetWorkspaceIDForWriteKey("d2")).To(Equal("testWordSpaceId"))
@@ -86,7 +89,10 @@ var _ = Describe("workspace-config", func() {
 			defer server.Close()
 
 			testRequest, _ := http.NewRequest("GET", server.URL, nil)
-			mockHttp.EXPECT().NewRequest("GET", fmt.Sprintf("%s/multitenantWorkspaceConfig?ids=[testToken]&fetchAll=true", configBackendURL), nil).Return(testRequest, nil).Times(1)
+			mockHttp.EXPECT().NewRequest("GET",
+				fmt.Sprintf("%s/multitenantWorkspaceConfig?workspaceIds=[\"testToken\"]&fetchAll=true",
+					configBackendURL),
+				nil).Return(testRequest, nil).Times(1)
 
 			mockLogger.EXPECT().Error("Error while parsing request", gomock.Any(), http.StatusNoContent).Times(1)
 			config, ok := backendConfig.Get("testToken")
@@ -94,7 +100,10 @@ var _ = Describe("workspace-config", func() {
 			Expect(ok).To(BeFalse())
 		})
 		It("Expect to make the correct actions if fail to create the request: Multitenant", func() {
-			mockHttp.EXPECT().NewRequest("GET", fmt.Sprintf("%s/multitenantWorkspaceConfig?ids=[testToken]&fetchAll=true", configBackendURL), nil).Return(nil, errors.New("TestError")).AnyTimes()
+			mockHttp.EXPECT().NewRequest("GET",
+				fmt.Sprintf("%s/multitenantWorkspaceConfig?workspaceIds=[\"testToken\"]&fetchAll=true",
+					configBackendURL),
+				nil).Return(nil, errors.New("TestError")).AnyTimes()
 			mockLogger.EXPECT().Errorf("Failed to fetch config from API with error: %v, retrying after %v", gomock.Eq(errors.New("TestError")), gomock.Any()).AnyTimes()
 			mockLogger.EXPECT().Error("Error sending request to the server", gomock.Eq(errors.New("TestError"))).Times(1)
 			config, ok := backendConfig.Get("testToken")
@@ -103,7 +112,10 @@ var _ = Describe("workspace-config", func() {
 		})
 		It("Expect to make the correct actions if fail to send the request: Multitenant", func() {
 			testRequest, _ := http.NewRequest("GET", "", nil)
-			mockHttp.EXPECT().NewRequest("GET", fmt.Sprintf("%s/multitenantWorkspaceConfig?ids=[testToken]&fetchAll=true", configBackendURL), nil).Return(testRequest, nil).AnyTimes()
+			mockHttp.EXPECT().NewRequest("GET",
+				fmt.Sprintf("%s/multitenantWorkspaceConfig?workspaceIds=[\"testToken\"]&fetchAll=true",
+					configBackendURL),
+				nil).Return(testRequest, nil).AnyTimes()
 			mockLogger.EXPECT().Errorf("Failed to fetch config from API with error: %v, retrying after %v", gomock.Any(), gomock.Any()).AnyTimes()
 			mockLogger.EXPECT().Error("Error sending request to the server", gomock.Any()).Times(1)
 			config, ok := backendConfig.Get("testToken")

--- a/main.go
+++ b/main.go
@@ -272,7 +272,7 @@ func Run(ctx context.Context) {
 		return
 	}
 
-	backendconfig.DefaultBackendConfig.StartWithIDs(backendconfig.DefaultBackendConfig.AccessToken())
+	backendconfig.DefaultBackendConfig.StartWithIDs("")
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		return admin.StartServer(ctx)


### PR DESCRIPTION
# Description

Changes related to backend config URL for multi tenant backend config

## Notion Ticket

https://www.notion.so/rudderstacks/Enhance-docker-compose-file-etcd-service-to-enable-rudder-server-testing-locally-14f0b3119d3d410f8c18331001196454

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
