### PR TITLE
feat(multi-tenant): add mode provider in docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - multi-tenant
     environment:
       - ALLOW_NONE_AUTHENTICATION=yes
-      - ETCD_NAME=mode-provider-etcd
+      - ETCD_NAME=mode-provider
       - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
       - ETCD_ADVERTISE_CLIENT_URLS=http://mode-provider:2379
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,3 +39,15 @@ services:
   #     - MINIO_ROOT_USER=root
   #     - MINIO_ROOT_PASSWORD=password
   #   command: server --console-address :9001 /data
+
+  mode-provider:
+    image: docker.io/bitnami/etcd:3
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yesq:q
+      - ETCD_NAME=mode-provider-etcd
+      - ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380
+      - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd1:2379
+    ports:
+      - "2379:2379"
+      - "2380:2380"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,6 @@ services:
       - ALLOW_NONE_AUTHENTICATION=yes
       - ETCD_NAME=mode-provider-etcd
       - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
-      - ETCD_ADVERTISE_CLIENT_URLS=http://mode-provider-etcd:2379
+      - ETCD_ADVERTISE_CLIENT_URLS=http://mode-provider:2379
     ports:
       - "2379:2379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,16 +30,17 @@ services:
       dockerfile: Dockerfile
     ports:
       - "9090:9090"
-  # minio:
-  #   image: minio/minio
-  #   ports:
-  #     - "9000:9000"
-  #     - "9001:9001"
-  #   environment:
-  #     - MINIO_ROOT_USER=root
-  #     - MINIO_ROOT_PASSWORD=password
-  #   command: server --console-address :9001 /data
-
+  minio:
+    image: minio/minio
+    profiles:
+      - storage
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      - MINIO_ROOT_USER=root
+      - MINIO_ROOT_PASSWORD=password
+    command: server --console-address :9001 /data
   mode-provider:
     image: docker.io/bitnami/etcd:3
     profiles:
@@ -47,9 +48,7 @@ services:
     environment:
       - ALLOW_NONE_AUTHENTICATION=yes
       - ETCD_NAME=mode-provider-etcd
-      - ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380
       - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
       - ETCD_ADVERTISE_CLIENT_URLS=http://mode-provider-etcd:2379
     ports:
       - "2379:2379"
-      - "2380:2380"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,12 +42,14 @@ services:
 
   mode-provider:
     image: docker.io/bitnami/etcd:3
+    profiles:
+      - multi-tenant
     environment:
-      - ALLOW_NONE_AUTHENTICATION=yesq:q
+      - ALLOW_NONE_AUTHENTICATION=yes
       - ETCD_NAME=mode-provider-etcd
       - ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380
       - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
-      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd1:2379
+      - ETCD_ADVERTISE_CLIENT_URLS=http://mode-provider-etcd:2379
     ports:
       - "2379:2379"
       - "2380:2380"


### PR DESCRIPTION
# Description

Added ETCD Based mode provider in docker-compose file. If you want to bring the mode provider service up then use `multi-tenant` profile with docker compose command. 
[Reference](https://docs.docker.com/compose/profiles/)

## Notion Ticket

[Ticket](https://www.notion.so/rudderstacks/Enhance-docker-compose-file-etcd-service-to-enable-rudder-server-testing-locally-14f0b3119d3d410f8c18331001196454)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
