### PR TITLE
fix: ovverride arm64 check

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -282,10 +282,13 @@ func SendEvent(payload *strings.Reader, callType string, writeKey string) {
 }
 
 func TestMain(m *testing.M) {
+	if os.Getenv("OVERRIDE_ARM64_CHECK") == "1" {
+		overrideArm64Check = true
+	}
+
 	flag.BoolVar(&hold, "hold", false, "hold environment clean-up after test execution until Ctrl+C is provided")
 	flag.BoolVar(&runIntegration, "integration", false, "run integration level tests")
 	flag.BoolVar(&runBigQueryTest, "bigqueryintegration", false, "run big query test")
-	flag.BoolVar(&overrideArm64Check, "override-arm64", false, "override arm64 check")
 	flag.Parse()
 
 	if !runIntegration {

--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -32,9 +31,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	flag.BoolVar(&overrideArm64Check, "override-arm64", false, "override arm64 check")
-	flag.Parse()
-
+	if os.Getenv("OVERRIDE_ARM64_CHECK") == "1" {
+		overrideArm64Check = true
+	}
 	if runtime.GOARCH == "arm64" && !overrideArm64Check {
 		fmt.Println("arm64 is not supported yet")
 		os.Exit(0)

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -3,7 +3,6 @@ package kafka
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"os"
 	"runtime"
@@ -25,9 +24,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	flag.BoolVar(&overrideArm64Check, "override-arm64", false, "override arm64 check")
-	flag.Parse()
-
+	if os.Getenv("OVERRIDE_ARM64_CHECK") == "1" {
+		overrideArm64Check = true
+	}
 	pkgLogger = &nopLogger{}
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
# Description

Converting flag to simple `os.Getenv`.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
