### PR TITLE
fix: enabling earlier usage of stats in other components

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,6 +155,7 @@ func runAllInit() {
 	logger.Init()
 	misc.Init()
 	stats.Init()
+	stats.Setup()
 	db.Init()
 	diagnostics.Init()
 	backendconfig.Init()
@@ -254,9 +255,6 @@ func Run(ctx context.Context) {
 	})
 	ctx = bugsnag.StartSession(ctx)
 	defer misc.BugsnagNotify(ctx, "Core")()
-
-	//Creating Stats Client should be done right after setting up logger and before setting up other modules.
-	stats.Setup()
 
 	if !enableSuppressUserFeature || application.Features().SuppressUser == nil {
 		pkgLogger.Info("Suppress User feature is either disabled or enterprise only. Unable to poll regulations.")


### PR DESCRIPTION
# Description

Fix to allow usage of stats in Kafka manager. `kafka.Init()` was called after `stats.Setup()` causing a `panic`.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
