### PR TITLE
fix(warehouse): fixing timeout issue for snowflake

### DIFF
--- a/warehouse/snowflake/snowflake.go
+++ b/warehouse/snowflake/snowflake.go
@@ -574,7 +574,7 @@ func connectWithTimeout(cred SnowflakeCredentialsT, timeout time.Duration) (*sql
 		Database:     cred.dbName,
 		Schema:       cred.schemaName,
 		Warehouse:    cred.whName,
-		LoginTimeout: timeout / time.Second,
+		LoginTimeout: timeout,
 		Application:  "Rudderstack",
 	}
 


### PR DESCRIPTION
# Description

Fixing timeout issue for snowflake. By default snowflake GO SDK expects the timeout to be seconds which can be found from [here](https://github.com/snowflakedb/gosnowflake/blob/d34ce5fe3a421fc2a2d9283b703ad670bbc2a0e5/dsn.go#L160)

## Notion Ticket

https://www.notion.so/rudderstacks/Verify-snowflake-timeouts-for-validation-f924ebbef7c643d5b2857fbf446cff4f

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
