### PR TITLE
chore(multi-tenant): change workspace change ETCD key

### DIFF
--- a/app/cluster/state/etcd.go
+++ b/app/cluster/state/etcd.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"fmt"
+	"github.com/rudderlabs/rudder-server/app"
 	"strings"
 	"sync"
 	"time"
@@ -30,8 +31,8 @@ var (
 )
 
 const (
-	modeRequestKeyPattern        = `/%s/server/%s/mode`       // /<releaseName>/server/<serverIndex>/mode
-	workspacesRequestsKeyPattern = `/%s/server/%s/workspaces` // /<releaseName>/server/<serverIndex>/workspaces
+	modeRequestKeyPattern        = `/%s/server/%s/mode`          // /<releaseName>/server/<serverIndex>/mode
+	workspacesRequestsKeyPattern = `/%s/server/%s/%s/workspaces` // /<releaseName>/server/<serverIndex>/<app_type>/workspaces
 
 	defaultACKTimeout = 15 * time.Second
 )
@@ -262,7 +263,8 @@ func (manager *ETCDManager) WorkspaceIDs(ctx context.Context) <-chan workspace.C
 		return errChWorkspacesRequest(err)
 	}
 
-	modeRequestKey := fmt.Sprintf(workspacesRequestsKeyPattern, manager.Config.Namespace, manager.Config.ServerIndex)
+	appTypeStr := strings.ToUpper(config.GetEnv("APP_TYPE", app.PROCESSOR))
+	modeRequestKey := fmt.Sprintf(workspacesRequestsKeyPattern, manager.Config.Namespace, manager.Config.ServerIndex, appTypeStr)
 
 	resultChan := make(chan workspace.ChangeEvent, 1)
 	resp, err := manager.Client.Get(ctx, modeRequestKey)

--- a/app/cluster/state/etcd_test.go
+++ b/app/cluster/state/etcd_test.go
@@ -256,7 +256,8 @@ func Test_Workspaces(t *testing.T) {
 		}
 		defer provider.Close()
 		appType := strings.ToUpper(config.GetEnv("APP_TYPE", app.PROCESSOR))
-		requestKey := fmt.Sprintf("/%s/server/%s/%s/workspaces", provider.Config.Namespace, provider.Config.ServerIndex, appType)
+		requestKey := fmt.Sprintf("/%s/server/%s/%s/workspaces", provider.Config.Namespace,
+			provider.Config.ServerIndex, appType)
 
 		ch := provider.WorkspaceIDs(ctx)
 
@@ -279,7 +280,8 @@ func Test_Workspaces(t *testing.T) {
 	defer provider.Close()
 
 	appType := strings.ToUpper(config.GetEnv("APP_TYPE", app.PROCESSOR))
-	requestKey := fmt.Sprintf("/%s/server/%s/%s/workspaces", provider.Config.Namespace, provider.Config.ServerIndex, appType)
+	requestKey := fmt.Sprintf("/%s/server/%s/%s/workspaces", provider.Config.Namespace, provider.Config.ServerIndex,
+		appType)
 
 	t.Run("key is missing initially", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)

--- a/app/cluster/state/etcd_test.go
+++ b/app/cluster/state/etcd_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/rudderlabs/rudder-server/app"
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -253,8 +255,8 @@ func Test_Workspaces(t *testing.T) {
 			},
 		}
 		defer provider.Close()
-
-		requestKey := fmt.Sprintf("/%s/server/%s/workspaces", provider.Config.Namespace, provider.Config.ServerIndex)
+		appType := strings.ToUpper(config.GetEnv("APP_TYPE", app.PROCESSOR))
+		requestKey := fmt.Sprintf("/%s/server/%s/%s/workspaces", provider.Config.Namespace, provider.Config.ServerIndex, appType)
 
 		ch := provider.WorkspaceIDs(ctx)
 
@@ -276,7 +278,8 @@ func Test_Workspaces(t *testing.T) {
 	}
 	defer provider.Close()
 
-	requestKey := fmt.Sprintf("/%s/server/%s/workspaces", provider.Config.Namespace, provider.Config.ServerIndex)
+	appType := strings.ToUpper(config.GetEnv("APP_TYPE", app.PROCESSOR))
+	requestKey := fmt.Sprintf("/%s/server/%s/%s/workspaces", provider.Config.Namespace, provider.Config.ServerIndex, appType)
 
 	t.Run("key is missing initially", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)


### PR DESCRIPTION
# Description
Changed the ETCD key for workspace ID changes to `/<releaseName>/server/<serverIndex>/<app_type>/workspaces` from `/<releaseName>/server/<serverIndex>/workspaces` to include the app type also.

This is to give control to the schedular to first change the workspace IDs for Processor and then for the Gateway so that we don't loose any data. This include a risk of having dirty value (not consistent IDs for both the apps) but this is once in a million kind if possibility. 

## Notion Ticket

[< Notion Link >](https://www.notion.so/rudderstacks/Change-workspace-ID-change-ETCD-Key-74b92e2a62664132816a4f4475563c60)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
