### PR TITLE
chore(multi-tenant): add hack for MT to use hosted backend config

### DIFF
--- a/app/cluster/dynamic.go
+++ b/app/cluster/dynamic.go
@@ -90,6 +90,9 @@ func (d *Dynamic) Run(ctx context.Context) error {
 
 	serverModeChan := d.Provider.ServerMode(ctx)
 	workspaceIDsChan := d.Provider.WorkspaceIDs(ctx)
+	if d.GatewayComponent {
+		d.currentMode = servermode.NormalMode
+	}
 
 	for {
 		select {
@@ -186,7 +189,7 @@ func (d *Dynamic) handleModeChange(newMode servermode.Mode) error {
 	}
 
 	if d.currentMode == newMode {
-		// TODO add logging
+		d.logger.Info("New mode is same as old mode: %s, not switching the mode.", string(newMode))
 		return nil
 	}
 	switch d.currentMode {

--- a/app/cluster/state/etcd.go
+++ b/app/cluster/state/etcd.go
@@ -167,8 +167,10 @@ func (manager *ETCDManager) unmarshalMode(raw []byte) servermode.ChangeEvent {
 			if err != nil {
 				return fmt.Errorf("marshal ack value: %w", err)
 			}
+			manager.logger.Infof("Mode Change Acknowledgement Key: %s", req.AckKey)
 			_, err = manager.Client.Put(ctx, req.AckKey, ackValue)
 			if err != nil {
+				manager.logger.Errorf("Failed to acknowledge mode change for key: %s", req.AckKey)
 				return fmt.Errorf("put value to ack key %q: %w", req.AckKey, err)
 			}
 			return err
@@ -256,6 +258,9 @@ func (manager *ETCDManager) unmarshalWorkspace(raw []byte) workspace.ChangeEvent
 			}
 			manager.logger.Infof("Workspace ID Change Acknowledgement Key: %s", req.AckKey)
 			_, err = manager.Client.Put(ctx, req.AckKey, ackValue)
+			if err != nil {
+				manager.logger.Errorf("Failed to acknowledge workspace ID change for key: %s", req.AckKey)
+			}
 			return err
 		})
 }

--- a/app/cluster/state/etcd.go
+++ b/app/cluster/state/etcd.go
@@ -254,6 +254,7 @@ func (manager *ETCDManager) unmarshalWorkspace(raw []byte) workspace.ChangeEvent
 			if err != nil {
 				return fmt.Errorf("marshal ack value: %w", err)
 			}
+			manager.logger.Infof("Workspace ID Change Acknowledgement Key: %s", req.AckKey)
 			_, err = manager.Client.Put(ctx, req.AckKey, ackValue)
 			return err
 		})

--- a/config/backend-config/multitenant_workspaces.go
+++ b/config/backend-config/multitenant_workspaces.go
@@ -74,16 +74,16 @@ func (workspaceConfig *MultiTenantWorkspacesConfig) Get(workspaces string) (Conf
 
 // getFromApi gets the workspace config from api
 func (workspaceConfig *MultiTenantWorkspacesConfig) getFromAPI(workspaceArr string) (ConfigT, bool) {
+	// added this to avoid unnecessary calls to backend config and log better until workspace IDs are not present
+	if workspaceArr == workspaceConfig.Token {
+		pkgLogger.Infof("no workspace IDs provided, skipping backend config fetch")
+		return ConfigT{}, false
+	}
 	var url string
 	// TODO: hacky way to get the backend config for multi tenant through older hosted backed config
 	if config.GetBool("BackendConfig.useHostedBackendConfig", false) {
 		url = fmt.Sprintf("%s/hostedWorkspaceConfig?fetchAll=true", configBackendURL)
 	} else {
-		// added this to avoid unnecessary calls to backend config and log better until workspace IDs are not present
-		if workspaceArr == workspaceConfig.Token {
-			pkgLogger.Infof("no workspace IDs provided, skipping backend config fetch")
-			return ConfigT{}, false
-		}
 		wIds := strings.Split(workspaceArr, ",")
 		for i := range wIds {
 			wIds[i] = strings.Trim(wIds[i], " ")

--- a/config/backend-config/multitenant_workspaces.go
+++ b/config/backend-config/multitenant_workspaces.go
@@ -76,7 +76,7 @@ func (workspaceConfig *MultiTenantWorkspacesConfig) Get(workspaces string) (Conf
 func (workspaceConfig *MultiTenantWorkspacesConfig) getFromAPI(workspaceArr string) (ConfigT, bool) {
 	var url string
 	// TODO: hacky way to get the backend config for multi tenant through older hosted backed config
-	if config.GetBool("BackendConfig.useHostedBackendConfig", true) {
+	if config.GetBool("BackendConfig.useHostedBackendConfig", false) {
 		url = fmt.Sprintf("%s/hostedWorkspaceConfig?fetchAll=true", configBackendURL)
 	} else {
 		// added this to avoid unnecessary calls to backend config and log better until workspace IDs are not present
@@ -153,7 +153,7 @@ func (workspaceConfig *MultiTenantWorkspacesConfig) makeHTTPRequest(url string) 
 		return []byte{}, 400, err
 	}
 	// TODO: hacky way to get the backend config for multi tenant through older hosted backed config
-	if config.GetBool("BackendConfig.useHostedBackendConfig", true) {
+	if config.GetBool("BackendConfig.useHostedBackendConfig", false) {
 		req.SetBasicAuth(config.GetEnv("HOSTED_SERVICE_SECRET", ""), "")
 	} else {
 		req.SetBasicAuth(workspaceConfig.Token, "")

--- a/config/backend-config/multitenant_workspaces.go
+++ b/config/backend-config/multitenant_workspaces.go
@@ -74,22 +74,28 @@ func (workspaceConfig *MultiTenantWorkspacesConfig) Get(workspaces string) (Conf
 
 // getFromApi gets the workspace config from api
 func (workspaceConfig *MultiTenantWorkspacesConfig) getFromAPI(workspaceArr string) (ConfigT, bool) {
-	// added this to avoid unnecessary calls to backend config and log better until workspace IDs are not present
-	if workspaceArr == workspaceConfig.Token {
-		pkgLogger.Infof("no workspace IDs provided, skipping backend config fetch")
-		return ConfigT{}, false
+	var url string
+	// TODO: hacky way to get the backend config for multi tenant through older hosted backed config
+	if config.GetBool("BackendConfig.useHostedBackendConfig", true) {
+		url = fmt.Sprintf("%s/hostedWorkspaceConfig?fetchAll=true", configBackendURL)
+	} else {
+		// added this to avoid unnecessary calls to backend config and log better until workspace IDs are not present
+		if workspaceArr == workspaceConfig.Token {
+			pkgLogger.Infof("no workspace IDs provided, skipping backend config fetch")
+			return ConfigT{}, false
+		}
+		wIds := strings.Split(workspaceArr, ",")
+		for i := range wIds {
+			wIds[i] = strings.Trim(wIds[i], " ")
+		}
+		encodedWorkspaces, err := jsonfast.MarshalToString(wIds)
+		if err != nil {
+			pkgLogger.Errorf("Error fetching config: preparing request URL: %v", err)
+			return ConfigT{}, false
+		}
+		url = fmt.Sprintf("%s/multitenantWorkspaceConfig?workspaceIds=%s", configBackendURL, encodedWorkspaces)
+		url = url + "&fetchAll=true"
 	}
-	wIds := strings.Split(workspaceArr, ",")
-	for i := range wIds {
-		wIds[i] = strings.Trim(wIds[i], " ")
-	}
-	encodedWorkspaces, err := jsonfast.MarshalToString(wIds)
-	if err != nil {
-		pkgLogger.Errorf("Error fetching config: preparing request URL: %v", err)
-		return ConfigT{}, false
-	}
-	url := fmt.Sprintf("%s/multitenantWorkspaceConfig?workspaceIds=%s", configBackendURL, encodedWorkspaces)
-	url = url + "&fetchAll=true"
 	var respBody []byte
 	var statusCode int
 
@@ -100,7 +106,7 @@ func (workspaceConfig *MultiTenantWorkspacesConfig) getFromAPI(workspaceArr stri
 	}
 
 	backoffWithMaxRetry := backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 3)
-	err = backoff.RetryNotify(operation, backoffWithMaxRetry, func(err error, t time.Duration) {
+	err := backoff.RetryNotify(operation, backoffWithMaxRetry, func(err error, t time.Duration) {
 		pkgLogger.Errorf("Failed to fetch config from API with error: %v, retrying after %v", err, t)
 	})
 
@@ -146,7 +152,12 @@ func (workspaceConfig *MultiTenantWorkspacesConfig) makeHTTPRequest(url string) 
 	if err != nil {
 		return []byte{}, 400, err
 	}
-	req.SetBasicAuth(workspaceConfig.Token, "")
+	// TODO: hacky way to get the backend config for multi tenant through older hosted backed config
+	if config.GetBool("BackendConfig.useHostedBackendConfig", true) {
+		req.SetBasicAuth(config.GetEnv("HOSTED_SERVICE_SECRET", ""), "")
+	} else {
+		req.SetBasicAuth(workspaceConfig.Token, "")
+	}
 
 	req.Header.Set("Content-Type", "application/json")
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -207,6 +207,7 @@ BackendConfig:
   Regulations:
     pageSize: 50
     pollInterval: 300s
+  useHostedBackendConfig: true
 recovery:
   enabled: true
   errorStorePath: /tmp/error_store.json


### PR DESCRIPTION
# Description
Use hosted backend config URL to fetch the backend config for multi-tenant as well because multi-tenant backend config cannot handle the requests with more than 250 workspace IDs. 
[Slack Thread](https://rudderlabs.slack.com/archives/C01HTT66UMB/p1652791374640159)

To enable this flow, we have introduced a config variable with the name `BackendConfig.useHostedBackendConfig` which if true, multi-tenant will use hosted backend config URL.

## Notion Ticket

[Notion](https://www.notion.so/rudderstacks/Use-hosted-backend-config-for-multi-tenant-230fa4c9e83b48fa9f940ea6ffc3310f)

[Slack](https://rudderlabs.slack.com/archives/C01HTT66UMB/p1652797690847909?thread_ts=1652796871.012809&cid=C01HTT66UMB)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
