### PR TITLE
chore(multi-tenant): not stop gateway from cluster manager

### DIFF
--- a/app/cluster/dynamic.go
+++ b/app/cluster/dynamic.go
@@ -138,6 +138,9 @@ func (d *Dynamic) Run(ctx context.Context) error {
 }
 
 func (d *Dynamic) start() {
+	if d.GatewayComponent {
+		return
+	}
 	d.logger.Info("Starting the server")
 	start := time.Now()
 	d.ErrorDB.Start()
@@ -154,6 +157,10 @@ func (d *Dynamic) start() {
 }
 
 func (d *Dynamic) stop() {
+	if d.GatewayComponent {
+		d.logger.Info("Stopping the gateway")
+		return
+	}
 	d.logger.Info("Stopping the server")
 	start := time.Now()
 	d.serverStopTimeStat.Start()


### PR DESCRIPTION
# Description
In case of gateway app, processor and router doesn't gets initialized in cluster manager so in we stop the cluster manager we have to skip stopping processor and router.

## Notion Ticket

[ Notion Link ](https://www.notion.so/rudderstacks/Don-t-stop-gateway-from-cluster-manager-b4abf33dcef2452fbddde69798bf6929)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
