### PR TITLE
chore(warehouse): new gcs datalake load file storage path format

### DIFF
--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -4,12 +4,13 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/cenkalti/backoff/v4"
-	"github.com/rudderlabs/rudder-server/warehouse/configuration_testing"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/rudderlabs/rudder-server/warehouse/configuration_testing"
 
 	"github.com/lib/pq"
 	"github.com/rudderlabs/rudder-server/config"
@@ -1758,7 +1759,11 @@ func (job *UploadJobT) createLoadFiles(generateAll bool) (startLoadFileID int64,
 			}
 
 			if misc.ContainsString(warehouseutils.TimeWindowDestinations, job.warehouse.Type) {
-				payload.LoadFilePrefix = stagingFile.TimeWindow.Format(warehouseutils.DatalakeTimeWindowFormat)
+				if job.warehouse.Type == warehouseutils.GCS_DATALAKE {
+					payload.LoadFilePrefix = stagingFile.TimeWindow.Format(warehouseutils.GCSDatalakeTimeWindowFormat)
+				} else {
+					payload.LoadFilePrefix = stagingFile.TimeWindow.Format(warehouseutils.DatalakeTimeWindowFormat)
+				}
 			}
 
 			// set merged schema as upload schema if the load file type is parquet

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -78,9 +78,10 @@ const (
 )
 
 const (
-	BQLoadedAtFormat         = "2006-01-02 15:04:05.999999 Z"
-	BQUuidTSFormat           = "2006-01-02 15:04:05 Z"
-	DatalakeTimeWindowFormat = "2006/01/02/15"
+	BQLoadedAtFormat            = "2006-01-02 15:04:05.999999 Z"
+	BQUuidTSFormat              = "2006-01-02 15:04:05 Z"
+	GCSDatalakeTimeWindowFormat = "year=2006/month=01/day=02/hour=15"
+	DatalakeTimeWindowFormat    = "2006/01/02/15"
 )
 
 const (


### PR DESCRIPTION
# Description

chore(warehouse): new gcs datalake load file storage path format

## Notion Ticket

https://www.notion.so/rudderstacks/Dice-S3-Datalake-Glue-Partitioning-d597c4d24e6e49a2a8807d366b300c9f#bc71e5d31592468ca3337c2652feb098

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
