### PR TITLE
fix(warehouse): deltalake users table getting populated corruptly.

### DIFF
--- a/warehouse/deltalake/deltalake.go
+++ b/warehouse/deltalake/deltalake.go
@@ -581,7 +581,6 @@ func (dl *HandleT) loadUserTables() (errorMap map[string]error) {
 		userColNames = append(userColNames, colName)
 		firstValProps = append(firstValProps, fmt.Sprintf(`FIRST_VALUE(%[1]s , TRUE) OVER (PARTITION BY id ORDER BY received_at DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS %[1]s`, colName))
 	}
-	quotedUserColNames := warehouseutils.DoubleQuoteAndJoinByComma(userColNames)
 	stagingTableName := misc.TruncateStr(fmt.Sprintf(`%s%s_%s`, stagingTablePrefix, strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", ""), warehouseutils.UsersTable), 127)
 	// Creating create table sql statement for staging users table
 	sqlStatement := fmt.Sprintf(`CREATE TABLE %[1]s.%[2]s USING DELTA AS (SELECT DISTINCT * FROM
@@ -603,7 +602,7 @@ func (dl *HandleT) loadUserTables() (errorMap map[string]error) {
 		strings.Join(firstValProps, ","),
 		warehouseutils.UsersTable,
 		identifyStagingTable,
-		quotedUserColNames,
+		columnNames(userColNames),
 	)
 
 	// Executing create sql statement


### PR DESCRIPTION
# Description
HotFix for warehouse deltalake users table getting populated corruptly.

## Notion Ticket

https://www.notion.so/rudderstacks/Deltalake-users-table-corrupt-data-9c9069da5e1049ca94827e7a08473562

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
