### PR TITLE
chore(jobsdb): skip zero assertion for multitenant internal migrations

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -629,6 +629,7 @@ var (
 	backupRowsBatchSize                          int64
 	pkgLogger                                    logger.LoggerI
 	useNewCacheBurst                             bool
+	skipZeroAssertionForMultitenant              bool
 )
 
 // Loads db config and migration related config from config file
@@ -669,6 +670,7 @@ func loadConfig() {
 	config.RegisterDurationConfigVariable(60, &cacheExpiration, true, time.Minute, []string{"JobsDB.cacheExpiration"}...)
 	useJoinForUnprocessed = config.GetBool("JobsDB.useJoinForUnprocessed", true)
 	config.RegisterBoolConfigVariable(true, &useNewCacheBurst, true, "JobsDB.useNewCacheBurst")
+	config.RegisterBoolConfigVariable(false, &skipZeroAssertionForMultitenant, true, "JobsDB.skipZeroAssertionForMultitenant")
 }
 
 func Init2() {
@@ -1437,7 +1439,7 @@ func computeInsertIdx(beforeIndex, afterIndex string) (string, error) {
 
 	// No dataset should have 0 as the index.
 	// 0_1, 0_2 are allowed.
-	if beforeIndex == "0" {
+	if beforeIndex == "0" && !skipZeroAssertionForMultitenant {
 		return "", fmt.Errorf("Unsupported beforeIndex: %s", beforeIndex)
 	}
 


### PR DESCRIPTION
# Description
With the new multi-tenant migrator approach we will have tables created with index 0 which might undergo internal migrations but the current new calculation assumes that we cannot have `_0` indices and can have only `_0_1` indices. This PR aims to skip this assert behind a flag before we find a cleaner approach to maintain backwards compatibility

## Notion Ticket

 [Notion Link](https://www.notion.so/rudderstacks/Don-t-create-0_0_1-index-for-tables-fcc14c3da3cf47c6a0e9da79dde99b51)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
