### PR TITLE
fix: reporting the drained events to the reports table

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -552,6 +552,7 @@ var (
 	//Valid, Terminal
 	Succeeded   = jobStateT{isValid: true, isTerminal: true, State: "succeeded"}
 	Aborted     = jobStateT{isValid: true, isTerminal: true, State: "aborted"}
+	Drained     = jobStateT{isValid: true, isTerminal: true, State: "drained"}
 	Migrated    = jobStateT{isValid: true, isTerminal: true, State: "migrated"}
 	WontMigrate = jobStateT{isValid: true, isTerminal: true, State: "wont_migrate"}
 )

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -552,7 +552,6 @@ var (
 	//Valid, Terminal
 	Succeeded   = jobStateT{isValid: true, isTerminal: true, State: "succeeded"}
 	Aborted     = jobStateT{isValid: true, isTerminal: true, State: "aborted"}
-	Drained     = jobStateT{isValid: true, isTerminal: true, State: "drained"}
 	Migrated    = jobStateT{isValid: true, isTerminal: true, State: "migrated"}
 	WontMigrate = jobStateT{isValid: true, isTerminal: true, State: "wont_migrate"}
 )

--- a/router/router.go
+++ b/router/router.go
@@ -1963,7 +1963,6 @@ func (rt *HandleT) readAndProcess() int {
 		rt.configSubscriberLock.RLock()
 		drain, reason := router_utils.ToBeDrained(job, destID, toAbortDestinationIDs, rt.destinationsMap)
 		rt.configSubscriberLock.RUnlock()
-		const drainErrorCode int = 401
 		if drain {
 			status := jobsdb.JobStatusT{
 				JobID:         job.JobID,
@@ -1971,7 +1970,7 @@ func (rt *HandleT) readAndProcess() int {
 				JobState:      jobsdb.Aborted.State,
 				ExecTime:      time.Now(),
 				RetryTime:     time.Now(),
-				ErrorCode:     strconv.Itoa(drainErrorCode),
+				ErrorCode:     strconv.Itoa(router_utils.DRAIN_ERROR_CODE),
 				Parameters:    []byte(`{}`),
 				ErrorResponse: router_utils.EnhanceJSON([]byte(`{}`), "reason", reason),
 				WorkspaceId:   job.WorkspaceId,
@@ -2021,7 +2020,7 @@ func (rt *HandleT) readAndProcess() int {
 				if rt.transientSources.Apply(parameters.SourceID) {
 					sampleEvent = []byte(`{}`)
 				}
-				sd = utilTypes.CreateStatusDetail(status.JobState, 0, drainErrorCode, string(status.ErrorResponse), sampleEvent, eventName, eventType)
+				sd = utilTypes.CreateStatusDetail(status.JobState, 0, router_utils.DRAIN_ERROR_CODE, string(status.ErrorResponse), sampleEvent, eventName, eventType)
 				statusDetailsMap[key] = sd
 			}
 			sd.Count++

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -402,11 +402,17 @@ var _ = Describe("Router", func() {
 
 			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(drainList []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
-					assertJobStatus(unprocessedJobsList[0], drainList[0], jobsdb.Aborted.State, "", `{"reason": "job expired"}`, 0)
+					assertJobStatus(unprocessedJobsList[0], drainList[0], jobsdb.Drained.State, "", `{"reason": "job expired"}`, 0)
 				})
+
+			done := make(chan struct{})
+			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+				close(done)
+			}).Return(nil)
 
 			<-router.backendConfigInitialized
 			count := router.readAndProcess()
+			<-done
 			Expect(count).To(Equal(0))
 		})
 	})

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -402,7 +402,7 @@ var _ = Describe("Router", func() {
 
 			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(_ interface{}, drainList []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
-					assertJobStatus(unprocessedJobsList[0], drainList[0], jobsdb.Aborted.State, "", `{"reason": "job expired"}`, 0)
+					assertJobStatus(unprocessedJobsList[0], drainList[0], jobsdb.Aborted.State, "401", `{"reason": "job expired"}`, 0)
 				})
 
 			done := make(chan struct{})

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -400,13 +400,14 @@ var _ = Describe("Router", func() {
 					Expect(job.UserID).To(Equal(unprocessedJobsList[0].UserID))
 				})
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
-				Do(func(drainList []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
-					assertJobStatus(unprocessedJobsList[0], drainList[0], jobsdb.Drained.State, "", `{"reason": "job expired"}`, 0)
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+				Do(func(_ interface{}, drainList []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
+					assertJobStatus(unprocessedJobsList[0], drainList[0], jobsdb.Aborted.State, "", `{"reason": "job expired"}`, 0)
 				})
 
 			done := make(chan struct{})
 			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"strconv"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -402,7 +403,7 @@ var _ = Describe("Router", func() {
 
 			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(_ interface{}, drainList []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
-					assertJobStatus(unprocessedJobsList[0], drainList[0], jobsdb.Aborted.State, "401", `{"reason": "job expired"}`, 0)
+					assertJobStatus(unprocessedJobsList[0], drainList[0], jobsdb.Aborted.State, strconv.Itoa(routerUtils.DRAIN_ERROR_CODE), `{"reason": "job expired"}`, 0)
 				})
 
 			done := make(chan struct{})

--- a/router/utils/utils.go
+++ b/router/utils/utils.go
@@ -19,7 +19,7 @@ var (
 )
 
 const (
-	DRAIN_ERROR_CODE int = 401
+	DRAIN_ERROR_CODE int = 410
 )
 
 type BatchDestinationT struct {

--- a/router/utils/utils.go
+++ b/router/utils/utils.go
@@ -17,6 +17,10 @@ var (
 	JobRetention time.Duration
 )
 
+const (
+	DRAIN_ERROR_CODE int = 401
+)
+
 type BatchDestinationT struct {
 	Destination backendconfig.DestinationT
 	Sources     []backendconfig.SourceT

--- a/router/utils/utils.go
+++ b/router/utils/utils.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	JobRetention time.Duration
+	EmptyPayload = []byte(`{}`)
 )
 
 const (


### PR DESCRIPTION
# Description

The events which got drained by the router were not being reported to the *reports* table inside the
jobsdb database. This PR fixes that 

## Notion Ticket

https://www.notion.so/rudderstacks/Report-drained-jobs-to-reporting-service-c8ce3d048e2945a797be3e31f8542ac2
## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
