### PR TITLE
chore(jobsdb): fix migration sequence number for multitenant migration

### DIFF
--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/gofrs/uuid"
 	"github.com/golang/mock/gomock"
 	"github.com/ory/dockertest/v3"
+	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-server/admin"

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -157,6 +157,18 @@ var _ = Describe("Calculate newDSIdx for internal migrations", func() {
 	})
 
 	Context("computeInsertVals - bad input tests", func() {
+		It("Should throw error for nil inputs", func() {
+			_, err := computeInsertVals(nil, nil)
+			Expect(err).To(HaveOccurred())
+		})
+		It("Should throw error for nil before input", func() {
+			_, err := computeInsertVals(nil, []string{"1"})
+			Expect(err).To(HaveOccurred())
+		})
+		It("Should throw error for nil after input", func() {
+			_, err := computeInsertVals([]string{"1"}, nil)
+			Expect(err).To(HaveOccurred())
+		})
 		It("Should throw error for input 1, 1_1", func() {
 			_, err := computeInsertVals([]string{"1"}, []string{"1", "1"})
 			Expect(err).To(HaveOccurred())

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -106,6 +106,48 @@ var _ = Describe("Calculate newDSIdx for internal migrations", func() {
 		})
 	})
 
+	var _ = DescribeTable("newDSIdx tests with skipZeroAssertionForMultitenant",
+		func(before, after, expected string) {
+			setSkipZeroAssertionForMultitenant(true)
+			computedIdx, err := computeInsertIdx(before, after)
+			Expect(computedIdx).To(Equal(expected))
+			Expect(err).To(BeNil())
+			setSkipZeroAssertionForMultitenant(false)
+		},
+		//dList => 1 2 3 4 5
+		Entry("Internal Migration for regular tables 1 Test 1 with skipZeroAssertionForMultitenant: ", "1", "2", "1_1"),
+		Entry("Internal Migration for regular tables 1 Test 2 with skipZeroAssertionForMultitenant: ", "2", "3", "2_1"),
+
+		//dList => 1_1 2 3 4 5
+		Entry("Internal Migration for regular tables 2 Test 1 with skipZeroAssertionForMultitenant: ", "1_1", "2", "1_2"),
+		Entry("Internal Migration for regular tables 2 Test 2 with skipZeroAssertionForMultitenant: ", "2", "3", "2_1"),
+
+		//dList => 1 2_1 3 4 5
+		Entry("Internal Migration for regular tables 3 Test 1 with skipZeroAssertionForMultitenant: ", "1", "2_1", "1_1"),
+		Entry("Internal Migration for regular tables 3 Test 2 with skipZeroAssertionForMultitenant: ", "2_1", "3", "2_2"),
+		Entry("Internal Migration for regular tables 3 Test 3 with skipZeroAssertionForMultitenant: ", "3", "4", "3_1"),
+
+		//dList => 1_1 2_1 3 4 5
+		Entry("Internal Migration for regular tables 4 Test 1 with skipZeroAssertionForMultitenant: ", "1_1", "2_1", "1_2"),
+
+		//dList => 0_1 1 2 3 4 5
+		Entry("Internal Migration for import tables Case 1 Test 2 with skipZeroAssertionForMultitenant: ", "1", "2", "1_1"),
+
+		Entry("Internal Migration for import tables Case 2 Test 3 with skipZeroAssertionForMultitenant: ", "1", "2", "1_1"),
+
+		Entry("OrderTest Case 1 Test 1 with skipZeroAssertionForMultitenant: ", "9", "10", "9_1"),
+
+		Entry("Internal Migration for tables with skipZeroAssertionForMultitenant: ", "10_1", "11_3", "10_2"),
+		Entry("Internal Migration for tables with skipZeroAssertionForMultitenant: ", "0_1", "1", "0_2"),
+		Entry("Internal Migration for tables with skipZeroAssertionForMultitenant: ", "0_1", "20", "0_2"),
+		Entry("Internal Migration for tables with Negative Indexes and skipZeroAssertionForMultitenant: ", "-1", "0", "-1_1"),
+		Entry("Internal Migration for tables with Negative Indexes and skipZeroAssertionForMultitenant: ", "0", "1", "0_1"),
+		Entry("Internal Migration for tables with Negative Indexes and skipZeroAssertionForMultitenant: ", "-2_1", "-1_1", "-2_2"),
+		Entry("Internal Migration for tables with Negative Indexes and skipZeroAssertionForMultitenant: ", "-2_1", "-1", "-2_2"),
+		Entry("Internal Migration for tables with Negative Indexes and skipZeroAssertionForMultitenant: ", "-2_1", "0", "-2_2"),
+		Entry("Internal Migration for tables with Negative Indexes and skipZeroAssertionForMultitenant: ", "-2_1", "20", "-2_2"),
+	)
+
 	Context("computeInsertVals - good input tests", func() {
 		It("Should not throw error for input 0_1, 0_2", func() {
 			calculatedIdx, err := computeInsertVals([]string{"0", "1"}, []string{"0", "2"})
@@ -402,4 +444,8 @@ var sanitizeRegexp = regexp.MustCompile(`\\u0000`)
 
 func sanitizedJsonUsingRegexp(input json.RawMessage) json.RawMessage {
 	return json.RawMessage(sanitizeRegexp.ReplaceAllString(string(input), ""))
+}
+
+func setSkipZeroAssertionForMultitenant(b bool) {
+	skipZeroAssertionForMultitenant = b
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -576,23 +576,8 @@ func (proc *HandleT) makeFeaturesFetchCall() bool {
 	return false
 }
 
-//SetDisableDedupFeature overrides SetDisableDedupFeature configuration and returns previous value
-func SetDisableDedupFeature(b bool) bool {
-	prev := enableDedup
-	enableDedup = b
-	return prev
-}
-
-func SetMainLoopTimeout(timeout time.Duration) {
-	mainLoopTimeout = timeout
-}
-
 func SetFeaturesRetryAttempts(overrideAttempts int) {
 	featuresRetryMaxAttempts = overrideAttempts
-}
-
-func SetIsUnlocked(unlockVar bool) {
-	isUnLocked = unlockVar
 }
 
 func (proc *HandleT) backendConfigSubscriber() {

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -118,6 +118,17 @@ func setEnableEventSchemasFeature(b bool) bool {
 	return prev
 }
 
+//SetDisableDedupFeature overrides SetDisableDedupFeature configuration and returns previous value
+func setDisableDedupFeature(b bool) bool {
+	prev := enableDedup
+	enableDedup = b
+	return prev
+}
+
+func setMainLoopTimeout(timeout time.Duration) {
+	mainLoopTimeout = timeout
+}
+
 // This configuration is assumed by all processor tests and, is returned on Subscribe of mocked backend config
 var sampleBackendConfig = backendconfig.ConfigT{
 	Sources: []backendconfig.SourceT{
@@ -1082,7 +1093,7 @@ var _ = Describe("Processor", func() {
 			SetFeaturesRetryAttempts(0)
 			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, nil, c.MockMultitenantHandle, transientsource.NewEmptyService())
 
-			SetMainLoopTimeout(1 * time.Second)
+			setMainLoopTimeout(1 * time.Second)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			defer cancel()
@@ -1555,7 +1566,7 @@ func processorSetupAndAssertJobHandling(processor *HandleT, c *testContext, enab
 
 func Setup(processor *HandleT, c *testContext, enableDedup, enableReporting bool) {
 	var clearDB = false
-	SetDisableDedupFeature(enableDedup)
+	setDisableDedupFeature(enableDedup)
 	processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, c.MockReportingI, c.MockMultitenantHandle, transientsource.NewEmptyService())
 	processor.reportingEnabled = enableReporting
 	// make sure the mock backend config has sent the configuration


### PR DESCRIPTION
# Description

With the new multi-tenant migrator approach we will have tables created with index 0 which might undergo internal migrations but the current new calculation assumes that we cannot have _0_1 indices and can have only _0_0_1 indices. This PR aims to generate the _0_1 indices behind a flag 

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/Don-t-create-0_0_1-index-for-tables-fcc14c3da3cf47c6a0e9da79dde99b51)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
