### PR TITLE
chore: appropriate response at Gateway to incoming request

### DIFF
--- a/gateway/admin.go
+++ b/gateway/admin.go
@@ -19,8 +19,8 @@ var prefix = "gw_jobs_"
 func (g *GatewayAdmin) Status() interface{} {
 	configSubscriberLock.RLock()
 	defer configSubscriberLock.RUnlock()
-	writeKeys := make([]string, 0, len(enabledWriteKeysSourceMap))
-	for k := range enabledWriteKeysSourceMap {
+	writeKeys := make([]string, 0, len(writeKeysSourceMap))
+	for k := range writeKeysSourceMap {
 		writeKeys = append(writeKeys, k)
 	}
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -715,9 +715,7 @@ func (gateway *HandleT) eventSchemaWebHandler(wrappedFunc func(http.ResponseWrit
 }
 
 func (gateway *HandleT) getPayloadFromRequest(r *http.Request) ([]byte, error) {
-	// fmt.Println("---request body: ", r.Body)
 	if r.Body == nil {
-		fmt.Println("---r.Body is nil---")
 		return []byte{}, errors.New(response.RequestBodyNil)
 	}
 
@@ -1091,13 +1089,7 @@ func (gateway *HandleT) webRequestHandler(rh RequestHandler, w http.ResponseWrit
 	var errorMessage string
 	defer func() {
 		if errorMessage != "" {
-			// if strings.Contains(errorMessage, response.GetStatus(response.TooManyRequests)) {
-			// 	gateway.logger.Infof("IP: %s -- %s -- Response: %d, %s", misc.GetIPFromReq(r), r.URL.Path, http.StatusTooManyRequests, errorMessage)
-			// 	http.Error(w, errorMessage, response.GetStatusCode(errorMessage))
-			// 	return
-			// }
 			gateway.logger.Infof("IP: %s -- %s -- Response: %d, %s", misc.GetIPFromReq(r), r.URL.Path, response.GetStatusCode(errorMessage), errorMessage)
-			fmt.Println("---status code: ", response.GetStatusCode(errorMessage))
 			http.Error(w, errorMessage, response.GetStatusCode(errorMessage))
 		}
 	}()

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -691,7 +691,9 @@ func (gateway *HandleT) eventSchemaWebHandler(wrappedFunc func(http.ResponseWrit
 }
 
 func (gateway *HandleT) getPayloadFromRequest(r *http.Request) ([]byte, error) {
+	// fmt.Println("---request body: ", r.Body)
 	if r.Body == nil {
+		fmt.Println("---r.Body is nil---")
 		return []byte{}, errors.New(response.RequestBodyNil)
 	}
 
@@ -1042,7 +1044,7 @@ func (gateway *HandleT) getPayloadAndWriteKey(w http.ResponseWriter, r *http.Req
 		misc.IncrementMapByKey(sourceFailStats, sourceTag, 1)
 		gateway.updateSourceStats(sourceFailStats, "gateway.write_key_failed_requests", map[string]string{sourceTag: writeKey, "reqType": reqType})
 		gateway.updateSourceStats(sourceFailStats, "gateway.write_key_requests", map[string]string{sourceTag: writeKey, "reqType": reqType})
-		return []byte{}, writeKey, fmt.Errorf("read payload from request: %w", err)
+		return []byte{}, writeKey, err
 	}
 	return payload, writeKey, err
 }
@@ -1065,13 +1067,14 @@ func (gateway *HandleT) webRequestHandler(rh RequestHandler, w http.ResponseWrit
 	var errorMessage string
 	defer func() {
 		if errorMessage != "" {
-			if strings.Contains(errorMessage, response.GetStatus(response.TooManyRequests)) {
-				gateway.logger.Infof("IP: %s -- %s -- Response: %d, %s", misc.GetIPFromReq(r), r.URL.Path, http.StatusTooManyRequests, errorMessage)
-				http.Error(w, errorMessage, http.StatusTooManyRequests)
-				return
-			}
-			gateway.logger.Infof("IP: %s -- %s -- Response: 400, %s", misc.GetIPFromReq(r), r.URL.Path, errorMessage)
-			http.Error(w, errorMessage, 400)
+			// if strings.Contains(errorMessage, response.GetStatus(response.TooManyRequests)) {
+			// 	gateway.logger.Infof("IP: %s -- %s -- Response: %d, %s", misc.GetIPFromReq(r), r.URL.Path, http.StatusTooManyRequests, errorMessage)
+			// 	http.Error(w, errorMessage, response.GetStatusCode(errorMessage))
+			// 	return
+			// }
+			gateway.logger.Infof("IP: %s -- %s -- Response: %d, %s", misc.GetIPFromReq(r), r.URL.Path, response.GetStatusCode(errorMessage), errorMessage)
+			fmt.Println("---status code: ", response.GetStatusCode(errorMessage))
+			http.Error(w, errorMessage, response.GetStatusCode(errorMessage))
 		}
 	}()
 	payload, writeKey, err := gateway.getPayloadAndWriteKey(w, r, reqType)

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -428,11 +428,11 @@ var _ = Describe("Gateway", func() {
 		// common tests for all web handlers
 		assertHandler := func(handlerType string, handler http.HandlerFunc) {
 			It("should reject requests without Authorization header", func() {
-				expectHandlerResponse(handler, unauthorizedRequest(nil), 400, response.NoWriteKeyInBasicAuth+"\n")
+				expectHandlerResponse(handler, unauthorizedRequest(nil), 401, response.NoWriteKeyInBasicAuth+"\n")
 			})
 
 			It("should reject requests without username in Authorization header", func() {
-				expectHandlerResponse(handler, authorizedRequest(WriteKeyEmpty, nil), 400, response.NoWriteKeyInBasicAuth+"\n")
+				expectHandlerResponse(handler, authorizedRequest(WriteKeyEmpty, nil), 401, response.NoWriteKeyInBasicAuth+"\n")
 			})
 
 			It("should reject requests with both userId and anonymousId not present", func() {
@@ -444,7 +444,7 @@ var _ = Describe("Gateway", func() {
 			})
 
 			It("should reject requests without request body", func() {
-				expectHandlerResponse(handler, authorizedRequest(WriteKeyInvalid, nil), 400, fmt.Sprintf("read payload from request: %s\n", response.RequestBodyNil))
+				expectHandlerResponse(handler, authorizedRequest(WriteKeyInvalid, nil), 400, response.RequestBodyNil+"\n")
 			})
 
 			It("should reject requests without valid json in request body", func() {
@@ -465,7 +465,7 @@ var _ = Describe("Gateway", func() {
 					body = fmt.Sprintf(`{"batch":[%s]}`, body)
 				}
 				if handlerType != "audiencelist" {
-					expectHandlerResponse(handler, authorizedRequest(WriteKeyEnabled, bytes.NewBufferString(body)), 400, response.RequestBodyTooLarge+"\n")
+					expectHandlerResponse(handler, authorizedRequest(WriteKeyEnabled, bytes.NewBufferString(body)), 413, response.RequestBodyTooLarge+"\n")
 				}
 			})
 
@@ -474,15 +474,15 @@ var _ = Describe("Gateway", func() {
 				if handlerType == "batch" || handlerType == "import" {
 					validBody = `{"batch":[{"data":"valid-json"}]}`
 				}
-				expectHandlerResponse(handler, authorizedRequest(WriteKeyInvalid, bytes.NewBufferString(validBody)), 400, response.InvalidWriteKey+"\n")
+				expectHandlerResponse(handler, authorizedRequest(WriteKeyInvalid, bytes.NewBufferString(validBody)), 401, response.InvalidWriteKey+"\n")
 			})
 
-			It("should reject requests with disabled write keys", func() {
+			It("should reject requests with disabled write keys (source)", func() {
 				validBody := `{"data":"valid-json"}`
 				if handlerType == "batch" || handlerType == "import" {
 					validBody = `{"batch":[{"data":"valid-json"}]}`
 				}
-				expectHandlerResponse(handler, authorizedRequest(WriteKeyDisabled, bytes.NewBufferString(validBody)), 400, response.InvalidWriteKey+"\n")
+				expectHandlerResponse(handler, authorizedRequest(WriteKeyDisabled, bytes.NewBufferString(validBody)), 404, response.SourceDisabled+"\n")
 			})
 		}
 

--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -80,7 +80,7 @@ func loadStatusMap() {
 	statusMap[SourceDisabled] = ResponseStatus{message: SourceDisabled, code: http.StatusNotFound}
 	statusMap[InvalidJSON] = ResponseStatus{message: InvalidJSON, code: http.StatusBadRequest}
 	// webhook specific status
-	statusMap[InvalidWebhookSource] = ResponseStatus{message: InvalidWebhookSource, code: http.StatusNotAcceptable}
+	statusMap[InvalidWebhookSource] = ResponseStatus{message: InvalidWebhookSource, code: http.StatusNotFound}
 	statusMap[SourceTransformerFailed] = ResponseStatus{message: SourceTransformerFailed, code: http.StatusBadRequest}
 	statusMap[SourceTransformerResponseErrorReadFailed] = ResponseStatus{message: SourceTransformerResponseErrorReadFailed, code: http.StatusBadRequest}
 	statusMap[SourceTransformerFailedToReadOutput] = ResponseStatus{message: SourceTransformerFailedToReadOutput, code: http.StatusBadRequest}
@@ -88,7 +88,7 @@ func loadStatusMap() {
 	statusMap[SourceTransformerInvalidOutputFormatInResponse] = ResponseStatus{message: SourceTransformerInvalidOutputFormatInResponse, code: http.StatusBadRequest}
 	statusMap[SourceTransformerInvalidOutputJSON] = ResponseStatus{message: SourceTransformerInvalidOutputJSON, code: http.StatusBadRequest}
 	statusMap[NonIdentifiableRequest] = ResponseStatus{message: NonIdentifiableRequest, code: http.StatusBadRequest}
-	statusMap[ErrorInMarshal] = ResponseStatus{message: ErrorInMarshal, code: http.StatusBadRequest}
+	statusMap[ErrorInMarshal] = ResponseStatus{message: ErrorInMarshal, code: http.StatusInternalServerError}
 	statusMap[ErrorInParseForm] = ResponseStatus{message: ErrorInParseForm, code: http.StatusBadRequest}
 	statusMap[ErrorInParseMultiform] = ResponseStatus{message: ErrorInParseMultiform, code: http.StatusBadRequest}
 }

--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -30,6 +30,8 @@ const (
 	InvalidWebhookSource = "Source does not accept webhook events"
 	//SourceTransformerResponseErrorReadFailed - Failed to read error from source transformer response
 	SourceTransformerResponseErrorReadFailed = "Failed to read error from source transformer response"
+	//SourceDisabled - write key is present, but the source for it is disabled.
+	SourceDisabled = "Source is disabled"
 	//SourceTransformerFailed - Internal server error in source transformer
 	SourceTransformerFailed = "Internal server error in source transformer"
 	//SourceTransformerFailedToReadOutput - Output not found in source transformer response
@@ -75,9 +77,10 @@ func loadStatusMap() {
 	statusMap[RequestBodyReadFailed] = ResponseStatus{message: RequestBodyReadFailed, code: http.StatusBadRequest}
 	statusMap[RequestBodyTooLarge] = ResponseStatus{message: RequestBodyTooLarge, code: http.StatusRequestEntityTooLarge}
 	statusMap[InvalidWriteKey] = ResponseStatus{message: InvalidWriteKey, code: http.StatusUnauthorized}
+	statusMap[SourceDisabled] = ResponseStatus{message: SourceDisabled, code: http.StatusNotFound}
 	statusMap[InvalidJSON] = ResponseStatus{message: InvalidJSON, code: http.StatusBadRequest}
 	// webhook specific status
-	statusMap[InvalidWebhookSource] = ResponseStatus{message: InvalidWebhookSource, code: http.StatusBadRequest}
+	statusMap[InvalidWebhookSource] = ResponseStatus{message: InvalidWebhookSource, code: http.StatusNotAcceptable}
 	statusMap[SourceTransformerFailed] = ResponseStatus{message: SourceTransformerFailed, code: http.StatusBadRequest}
 	statusMap[SourceTransformerResponseErrorReadFailed] = ResponseStatus{message: SourceTransformerResponseErrorReadFailed, code: http.StatusBadRequest}
 	statusMap[SourceTransformerFailedToReadOutput] = ResponseStatus{message: SourceTransformerFailedToReadOutput, code: http.StatusBadRequest}

--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -90,7 +90,7 @@ func loadStatusMap() {
 	statusMap[SourceTransformerInvalidOutputFormatInResponse] = ResponseStatus{message: SourceTransformerInvalidOutputFormatInResponse, code: http.StatusBadRequest}
 	statusMap[SourceTransformerInvalidOutputJSON] = ResponseStatus{message: SourceTransformerInvalidOutputJSON, code: http.StatusBadRequest}
 	statusMap[NonIdentifiableRequest] = ResponseStatus{message: NonIdentifiableRequest, code: http.StatusBadRequest}
-	statusMap[ErrorInMarshal] = ResponseStatus{message: ErrorInMarshal, code: http.StatusInternalServerError}
+	statusMap[ErrorInMarshal] = ResponseStatus{message: ErrorInMarshal, code: http.StatusBadRequest}
 	statusMap[ErrorInParseForm] = ResponseStatus{message: ErrorInParseForm, code: http.StatusBadRequest}
 	statusMap[ErrorInParseMultiform] = ResponseStatus{message: ErrorInParseMultiform, code: http.StatusBadRequest}
 	statusMap[NotRudderEvent] = ResponseStatus{message: NotRudderEvent, code: http.StatusBadRequest}


### PR DESCRIPTION
# Description
List of response changes at Gateway:-
- previously we were not using `statusMap` which has list of all possible response code and body. And, irrespective of the issue type with the request we simply returned `400` for all, except `429` for too many request. In this PR, we modified this behaviour get appropriate response code and body by making use of `statusMap` in `response.go`.
- `SourceDisabled` response is introduced. modified response for "disabled sources" from `401` to `404`, by storing the config for those source in `map`.
- `InvalidWebhookSource` status code changed from `400` to `404`.

## Notion Ticket
https://www.notion.so/rudderstacks/Revisit-http-status-codes-returned-by-gateway-0cdda93d350b437589872237c7405af2

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
