### PR TITLE
chore: identify transient sources through a top-level configuration field

### DIFF
--- a/config/backend-config/backend-config.go
+++ b/config/backend-config/backend-config.go
@@ -105,6 +105,7 @@ type SourceT struct {
 	Destinations               []DestinationT
 	WriteKey                   string
 	DgSourceTrackingPlanConfig DgSourceTrackingPlanConfigT
+	Transient                  bool
 }
 
 type WorkspaceRegulationT struct {

--- a/services/transientsource/transientsource.go
+++ b/services/transientsource/transientsource.go
@@ -92,7 +92,6 @@ func (r *service) updateLoop(ctx context.Context, config backendconfig.BackendCo
 
 	ch := make(chan pubsub.DataEvent)
 	config.Subscribe(ch, backendconfig.TopicBackendConfig)
-
 	for {
 		select {
 		case ev := <-ch:
@@ -121,7 +120,7 @@ func transientSourceIds(c *backendconfig.ConfigT) []string {
 	r := make([]string, 0)
 	for i := range c.Sources {
 		source := &c.Sources[i]
-		if source.Config["transient"] == true {
+		if source.Transient {
 			r = append(r, source.ID)
 		}
 	}

--- a/services/transientsource/transientsource_test.go
+++ b/services/transientsource/transientsource_test.go
@@ -99,12 +99,12 @@ func Test_SourceIdsSupplier_Normal_Flow(t *testing.T) {
 		Data: backendconfig.ConfigT{
 			Sources: []backendconfig.SourceT{
 				{
-					ID:     "one",
-					Config: map[string]interface{}{"transient": true},
+					ID:        "one",
+					Transient: true,
 				},
 				{
-					ID:     "two",
-					Config: map[string]interface{}{"transient": true},
+					ID:        "two",
+					Transient: true,
 				},
 			},
 		},


### PR DESCRIPTION
# Description

Instead of relying to the source's generic config, use a static, top-level field for identifying transient sources.

## Notion Ticket

[Identify transient sources through a top-level configuration field](https://www.notion.so/rudderstacks/Identify-transient-sources-through-a-top-level-configuration-field-2d03022b25564dbaac90421ec2f21afd)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
