### PR TITLE
refactor(jobsdb): support lazy transaction initiation

### DIFF
--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -1166,7 +1166,9 @@ func consume(t testing.TB, db *jobsdb.HandleT, count int) {
 func getPayloadSize(t *testing.T, jobsDB jobsdb.JobsDB, job *jobsdb.JobT) (int64, error) {
 	var size int64
 	var tables []string
-	err := jobsDB.WithTx(func(tx *sql.Tx) error {
+	err := jobsDB.WithTx(func(txGetter jobsdb.TxGetter) error {
+		tx, err := txGetter.Tx()
+		require.NoError(t, err)
 		rows, err := tx.Query(fmt.Sprintf("SELECT tablename FROM pg_catalog.pg_tables where tablename like '%s_jobs_%%'", jobsDB.Identifier()))
 		require.NoError(t, err)
 		for rows.Next() {

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"compress/gzip"
 	"context"
-	"database/sql"
 	"io"
 	"io/ioutil"
 	"os"
@@ -173,7 +172,11 @@ func (*backupTestCase) insertRTData(t *testing.T, jobs []*JobT, statusList []*Jo
 	// defer jobDB.TearDown()
 
 	rtDS := newDataSet("rt", "1")
-	err := jobsDB.WithTx(func(tx *sql.Tx) error {
+	err := jobsDB.WithTx(func(txGetter TxGetter) error {
+		tx, err := txGetter.Tx()
+		if err != nil {
+			return err
+		}
 		if err := jobsDB.copyJobsDS(tx, rtDS, jobs); err != nil {
 			return err
 		}
@@ -186,7 +189,11 @@ func (*backupTestCase) insertRTData(t *testing.T, jobs []*JobT, statusList []*Jo
 	jobsDB.dsListLock.WithLock(func(l lock.DSListLockToken) {
 		jobsDB.addNewDS(l, rtDS2)
 	})
-	err = jobsDB.WithTx(func(tx *sql.Tx) error {
+	err = jobsDB.WithTx(func(txGetter TxGetter) error {
+		tx, err := txGetter.Tx()
+		if err != nil {
+			return err
+		}
 		if err := jobsDB.copyJobsDS(tx, rtDS2, jobs); err != nil {
 			return err
 		}
@@ -215,7 +222,11 @@ func (*backupTestCase) insertBatchRTData(t *testing.T, jobs []*JobT, statusList 
 	jobsDB.Setup(ReadWrite, false, "batch_rt", dbRetention, migrationMode, true, queryFilters, []prebackup.Handler{})
 
 	ds := newDataSet("batch_rt", "1")
-	err := jobsDB.WithTx(func(tx *sql.Tx) error {
+	err := jobsDB.WithTx(func(txGetter TxGetter) error {
+		tx, err := txGetter.Tx()
+		if err != nil {
+			return err
+		}
 		if err := jobsDB.copyJobsDS(tx, ds, jobs); err != nil {
 			t.Log("error while copying jobs to ds: ", err)
 			return err
@@ -228,7 +239,11 @@ func (*backupTestCase) insertBatchRTData(t *testing.T, jobs []*JobT, statusList 
 	jobsDB.dsListLock.WithLock(func(l lock.DSListLockToken) {
 		jobsDB.addNewDS(l, ds2)
 	})
-	err = jobsDB.WithTx(func(tx *sql.Tx) error {
+	err = jobsDB.WithTx(func(txGetter TxGetter) error {
+		tx, err := txGetter.Tx()
+		if err != nil {
+			return err
+		}
 		if err := jobsDB.copyJobsDS(tx, ds2, jobs); err != nil {
 			t.Log("error while copying jobs to ds: ", err)
 			return err

--- a/jobsdb/tx.go
+++ b/jobsdb/tx.go
@@ -1,0 +1,106 @@
+package jobsdb
+
+import (
+	"database/sql"
+	"errors"
+	"sync"
+)
+
+// ErrEmptyxTx sentinel error indicating an Empty Tx
+var ErrEmptyxTx = errors.New("jobsdb: empty tx")
+
+// TxGetter provides access to an sql.Tx
+type TxGetter interface {
+	// Tx retrieves the tx or returns an error if the tx could not be retrieved (started)
+	Tx() (*sql.Tx, error)
+	// MustTx retrieves the tx or panics in case of an error
+	MustTx() *sql.Tx
+}
+
+type noTx struct{}
+
+// EmptyTx returns an empty interface usable only for tests
+func EmptyTx() TxGetter {
+	return &noTx{}
+}
+
+func (*noTx) Tx() (*sql.Tx, error) {
+	return nil, ErrEmptyxTx
+}
+
+func (*noTx) MustTx() *sql.Tx {
+	return nil
+}
+
+type eagerTx struct {
+	tx *sql.Tx
+}
+
+func (r *eagerTx) Tx() (*sql.Tx, error) {
+	return r.tx, nil
+}
+
+func (r *eagerTx) MustTx() *sql.Tx {
+	return r.tx
+}
+
+type lazyTx struct {
+	dbHandle *sql.DB
+	once     sync.Once
+	tx       *sql.Tx
+	err      error
+}
+
+func (r *lazyTx) Tx() (*sql.Tx, error) {
+	r.once.Do(func() {
+		r.tx, r.err = r.dbHandle.Begin()
+	})
+	return r.tx, r.err
+}
+
+func (r *lazyTx) MustTx() *sql.Tx {
+	tx, err := r.Tx()
+	if err != nil {
+		panic(err)
+	}
+	return tx
+}
+
+// StoreSafeTx sealed interface
+type StoreSafeTx interface {
+	TxGetter
+	storeSafeTxIdentifier() string
+}
+
+type storeSafeTx struct {
+	TxGetter
+	identity string
+}
+
+func (r *storeSafeTx) storeSafeTxIdentifier() string {
+	return r.identity
+}
+
+// EmptyStoreSafeTx returns an empty interface usable only for tests
+func EmptyStoreSafeTx() StoreSafeTx {
+	return &storeSafeTx{TxGetter: &noTx{}}
+}
+
+// UpdateSafeTx sealed interface
+type UpdateSafeTx interface {
+	TxGetter
+	updateSafeTxSealIdentifier() string
+}
+type updateSafeTx struct {
+	TxGetter
+	identity string
+}
+
+func (r *updateSafeTx) updateSafeTxSealIdentifier() string {
+	return r.identity
+}
+
+// EmptyUpdateSafeTx returns an empty interface usable only for tests
+func EmptyUpdateSafeTx() UpdateSafeTx {
+	return &updateSafeTx{TxGetter: &noTx{}}
+}

--- a/jobsdb/tx.go
+++ b/jobsdb/tx.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 )
 
-// ErrEmptyxTx sentinel error indicating an Empty Tx
-var ErrEmptyxTx = errors.New("jobsdb: empty tx")
+// ErrEmptyTx sentinel error indicating an Empty Tx
+var ErrEmptyTx = errors.New("jobsdb: empty tx")
 
 // TxGetter provides access to an sql.Tx
 type TxGetter interface {
@@ -25,7 +25,7 @@ func EmptyTx() TxGetter {
 }
 
 func (*noTx) Tx() (*sql.Tx, error) {
-	return nil, ErrEmptyxTx
+	return nil, ErrEmptyTx
 }
 
 func (*noTx) MustTx() *sql.Tx {

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -5,7 +5,6 @@
 package mocks_jobsdb
 
 import (
-	sql "database/sql"
 	json "encoding/json"
 	reflect "reflect"
 
@@ -326,7 +325,7 @@ func (mr *MockJobsDBMockRecorder) WithStoreSafeTx(arg0 interface{}) *gomock.Call
 }
 
 // WithTx mocks base method.
-func (m *MockJobsDB) WithTx(arg0 func(*sql.Tx) error) error {
+func (m *MockJobsDB) WithTx(arg0 func(jobsdb.TxGetter) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithTx", arg0)
 	ret0, _ := ret[0].(error)

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -939,8 +938,8 @@ var _ = Describe("Processor", func() {
 				})
 
 			// will be used to save failed events to failed keys table
-			c.mockProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(tx *sql.Tx) error) {
-				_ = f(nil)
+			c.mockProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(txGetter jobsdb.TxGetter) error) {
+				_ = f(jobsdb.EmptyTx())
 			}).Times(1)
 
 			// One Store call is expected for all events
@@ -1073,8 +1072,8 @@ var _ = Describe("Processor", func() {
 					assertJobStatus(unprocessedJobsList[0], statuses[0], jobsdb.Succeeded.State, "200", `{"success":"OK"}`, 1)
 				})
 
-			c.mockProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(tx *sql.Tx) error) {
-				_ = f(nil)
+			c.mockProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(txGetter jobsdb.TxGetter) error) {
+				_ = f(jobsdb.EmptyTx())
 			}).Return(nil).Times(1)
 
 			// One Store call is expected for all events


### PR DESCRIPTION
# Description

Instead of starting a transaction eagerly, the default behaviour now defers it creation until the transaction is actually requested by the receiver funtion.
This way, we no longer have outstanding transactions waiting their turn to come in the read & write queues of jobsDB.

## Notion Ticket

[Support lazy transaction initiation in jobsdb commands](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=8085e64339274e72b975479c6f35f0b6)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
