### PR TITLE
chore(ci): introduce a single multi-stage dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+
+# syntax=docker/dockerfile:1
+FROM golang:1.17 AS builder
+ARG VERSION
+ARG REVISION
+ARG COMMIT_HASH
+ARG BUILD_DATE
+ARG RACE_ENABLED=false
+ARG CGO_ENABLED=0
+ARG PKG_NAME=github.com/rudderlabs/release-demo
+
+WORKDIR /rudder-server
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download 
+
+COPY . . 
+
+RUN LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$COMMIT_HASH -X main.buildDate=$DATE -X main.builtBy=${REVISION} " \
+    make build
+
+FROM frolvlad/alpine-glibc:alpine-3.15_glibc-2.34
+RUN apk add --no-cache ca-certificates postgresql-client curl bash
+
+COPY --from=builder rudder-server/rudder-server .
+COPY --from=builder rudder-server/build/wait-for-go/wait-for-go .
+COPY --from=builder rudder-server/build/regulation-worker . 
+
+COPY build/docker-entrypoint.sh /
+COPY build/wait-for /
+COPY ./rudder-cli/rudder-cli.linux.x86_64 /usr/bin/rudder-cli
+COPY scripts/generate-event /scripts
+COPY scripts/batch.json /scripts
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/rudder-server"]

--- a/build/buildspec.docker.dev-ent.yml
+++ b/build/buildspec.docker.dev-ent.yml
@@ -6,12 +6,6 @@ env:
     dockerhub_passwd: "/dev/codebuild/dockerhub-password"
 
 phases:
-  install:
-    commands:
-      # Make sure goenv is up to date
-      - cd $HOME/.goenv && git pull --ff-only && cd -
-      # Install Go 1.17
-      - goenv install 1.17.8 && goenv global 1.17.8
   pre_build:
     commands:
       - env
@@ -21,19 +15,17 @@ phases:
       - chmod 600 ~/.ssh/ssh_key
       - eval "$(ssh-agent -s)"
       - ssh-add ~/.ssh/ssh_key
-      - GO111MODULE=on go mod download
 
   build:
     commands:
-      - export GO111MODULE=on
       - DATE=$(date "+%F,%T")
       - VERSION=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed 's/refs\/heads\///g' | tr "/" .)
       # Build Enterprise version
       - make enterprise-init
-      - docker build -t rudderstack/develop-rudder-server-enterprise:$VERSION-codebuild . \
-        --build-arg VERSION=$VERSION \
-        --build-arg BUILD_DATE=$DATE \
-        --build-arg COMMIT_HASH=$CODEBUILD_RESOLVED_SOURCE_VERSION \
+      - docker build -t rudderstack/develop-rudder-server-enterprise:$VERSION-codebuild .
+        --build-arg VERSION=$VERSION
+        --build-arg BUILD_DATE=$DATE
+        --build-arg COMMIT_HASH=$CODEBUILD_RESOLVED_SOURCE_VERSION
         --build-arg REVISION=codebuild-$CODEBUILD_BUILD_ID
   post_build:
     commands:

--- a/build/buildspec.docker.dev-ent.yml
+++ b/build/buildspec.docker.dev-ent.yml
@@ -30,12 +30,14 @@ phases:
       - VERSION=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed 's/refs\/heads\///g' | tr "/" .)
       # Build Enterprise version
       - make enterprise-init
-      - GOOS=linux GOARCH=amd64 CGO_ENABLED=1 RACE_ENABLED=TRUE LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
-      - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
-      - docker build -t rudderstack/develop-rudder-server-enterprise:$VERSION -f build/Dockerfile-aws-dev .
+      - docker build -t rudderstack/develop-rudder-server-enterprise:$VERSION-codebuild . \
+        --build-arg VERSION=$VERSION \
+        --build-arg BUILD_DATE=$DATE \
+        --build-arg COMMIT_HASH=$CODEBUILD_RESOLVED_SOURCE_VERSION \
+        --build-arg REVISION=codebuild-$CODEBUILD_BUILD_ID
   post_build:
     commands:
-      - docker push rudderstack/develop-rudder-server-enterprise:$VERSION
+      - docker push rudderstack/develop-rudder-server-enterprise:$VERSION-codebuild
 artifacts:
   files:
     - "**/*"

--- a/build/buildspec.docker.dev-ent.yml
+++ b/build/buildspec.docker.dev-ent.yml
@@ -22,19 +22,13 @@ phases:
       - VERSION=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed 's/refs\/heads\///g' | tr "/" .)
       # Build Enterprise version
       - make enterprise-init
-      - docker build -t rudderstack/develop-rudder-server-enterprise:$VERSION-codebuild .
+      - docker build -t rudderstack/develop-rudder-server-enterprise:$VERSION .
         --build-arg VERSION=$VERSION
-        --build-arg BUILD_DATE=$DATE
         --build-arg COMMIT_HASH=$CODEBUILD_RESOLVED_SOURCE_VERSION
         --build-arg REVISION=codebuild-$CODEBUILD_BUILD_ID
   post_build:
     commands:
-      - docker push rudderstack/develop-rudder-server-enterprise:$VERSION-codebuild
+      - docker push rudderstack/develop-rudder-server-enterprise:$VERSION
 artifacts:
   files:
     - "**/*"
-
-cache:
-  paths: |
-    ~/.cache/go-build
-    ~/go/pkg/mod

--- a/build/buildspec.docker.dev.yml
+++ b/build/buildspec.docker.dev.yml
@@ -28,13 +28,14 @@ phases:
       - export GO111MODULE=on
       - DATE=$(date "+%F,%T")
       - VERSION=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed 's/refs\/heads\///g' | tr "/" .)
-      # Build Open source version
-      - GOOS=linux GOARCH=amd64 CGO_ENABLED=1 RACE_ENABLED=TRUE LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
-      - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
-      - docker build -t rudderlabs/develop-rudder-server:$VERSION -f build/Dockerfile-aws-dev .
+      - docker build -t rudderlabs/develop-rudder-server:$VERSION-codebuild . \
+        --build-arg VERSION=$VERSION \
+        --build-arg BUILD_DATE=$DATE \
+        --build-arg COMMIT_HASH=$CODEBUILD_RESOLVED_SOURCE_VERSION \
+        --build-arg REVISION=codebuild-$CODEBUILD_BUILD_ID
   post_build:
     commands:
-      - docker push rudderlabs/develop-rudder-server:$VERSION
+      - docker push rudderlabs/develop-rudder-server:$VERSION-codebuild
 artifacts:
   files:
     - "**/*"

--- a/build/buildspec.docker.dev.yml
+++ b/build/buildspec.docker.dev.yml
@@ -6,12 +6,6 @@ env:
     dockerhub_passwd: "/dev/codebuild/dockerhub-password"
 
 phases:
-  install:
-    commands:
-      # Make sure goenv is up to date
-      - cd $HOME/.goenv && git pull --ff-only && cd -
-      # Install Go 1.17
-      - goenv install 1.17.8 && goenv global 1.17.8
   pre_build:
     commands:
       - env
@@ -21,17 +15,15 @@ phases:
       - chmod 600 ~/.ssh/ssh_key
       - eval "$(ssh-agent -s)"
       - ssh-add ~/.ssh/ssh_key
-      - GO111MODULE=on go mod download
 
   build:
     commands:
-      - export GO111MODULE=on
       - DATE=$(date "+%F,%T")
       - VERSION=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed 's/refs\/heads\///g' | tr "/" .)
-      - docker build -t rudderlabs/develop-rudder-server:$VERSION-codebuild . \
-        --build-arg VERSION=$VERSION \
-        --build-arg BUILD_DATE=$DATE \
-        --build-arg COMMIT_HASH=$CODEBUILD_RESOLVED_SOURCE_VERSION \
+      - docker build -t rudderlabs/develop-rudder-server:$VERSION-codebuild .
+        --build-arg VERSION=$VERSION
+        --build-arg BUILD_DATE=$DATE
+        --build-arg COMMIT_HASH=$CODEBUILD_RESOLVED_SOURCE_VERSION
         --build-arg REVISION=codebuild-$CODEBUILD_BUILD_ID
   post_build:
     commands:

--- a/build/buildspec.docker.dev.yml
+++ b/build/buildspec.docker.dev.yml
@@ -18,21 +18,14 @@ phases:
 
   build:
     commands:
-      - DATE=$(date "+%F,%T")
       - VERSION=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed 's/refs\/heads\///g' | tr "/" .)
-      - docker build -t rudderlabs/develop-rudder-server:$VERSION-codebuild .
+      - docker build -t rudderlabs/develop-rudder-server:$VERSION .
         --build-arg VERSION=$VERSION
-        --build-arg BUILD_DATE=$DATE
         --build-arg COMMIT_HASH=$CODEBUILD_RESOLVED_SOURCE_VERSION
         --build-arg REVISION=codebuild-$CODEBUILD_BUILD_ID
   post_build:
     commands:
-      - docker push rudderlabs/develop-rudder-server:$VERSION-codebuild
+      - docker push rudderlabs/develop-rudder-server:$VERSION
 artifacts:
   files:
     - "**/*"
-
-cache:
-  paths: |
-    ~/.cache/go-build
-    ~/go/pkg/mod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       - d-transformer
     build:
       context: ./
-      dockerfile: build/Dockerfile
-    entrypoint: sh -c './build/wait-for db:5432 -- go run main.go'
+      dockerfile: Dockerfile
+    entrypoint: sh -c '/wait-for db:5432 -- ./rudder-server'
     ports:
       - "8080:8080"
     env_file:


### PR DESCRIPTION
# Description

Part of our release 2.0 process

## Issues

1.  Multi docker files `Dockerfile`, `Dockerfile-aws`, `Dockerfile-aws-dev` that we have to test and maintain.
2.  In most cases, the build process happens outside Dockerfile. Making it hard to build docker images outside code build.

## Changes

A new `Dockerfile` is introduced in this PR, used for local `docker-compose` usage and PR builds.

The new image has a multi-stage build, and `make build` step is moved inside dockerimage. That makes it easy to build images locally and support different architectures.

Also, with the usage of ARGS we can control the go version, build info and switch on/off the race detector.

## Next steps

Once we ensure PR builds work correctly, master and release will use the new image as well and all the other Dockerfiles will be removed.

## Testing
To ensure that the image created with new dockerfile is compatible with existing one, I used [container-diff](https://github.com/GoogleContainerTools/container-diff)
```bash
❯ container-diff diff rudderstack/develop-rudder-server-enterprise:dependabot.go_modules.google.golang.org.protobuf-1.28.0 rudderstack/develop-rudder-server-enterprise:chore.dockerfile  -t file

-----File-----

These entries have been added to rudderstack/develop-rudder-server-enterprise:dependabot.go_modules.google.golang.org.protobuf-1.28.0: None

These entries have been deleted from rudderstack/develop-rudder-server-enterprise:dependabot.go_modules.google.golang.org.protobuf-1.28.0:
FILE                                           SIZE
/rudder-server-with-race                       72.9M
/var/cache/apk/APKINDEX.0488e555.tar.gz        622.1K
/var/cache/apk/APKINDEX.a754f5eb.tar.gz        1.6M

These entries have been changed between rudderstack/develop-rudder-server-enterprise:dependabot.go_modules.google.golang.org.protobuf-1.28.0 and rudderstack/develop-rudder-server-enterprise:chore.dockerfile:
FILE                                 SIZE1        SIZE2
/rudder-server                       49.2M        49.2M
/regulation-worker                   29.3M        29.3M
/wait-for-go                         2.5M         2.5M
/lib/apk/db/installed                38.7K        38.7K
/var/cache/ldconfig/aux-cache        3.2K         3.2K
```

## Notion Ticket

https://www.notion.so/rudderstacks/Improved-Dockerfile-d49f91382cf147758c3961a77c4cb9e7

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
