### PR TITLE
feat(multi-tenant): use cached backend config

### DIFF
--- a/config/backend-config/hosted_workspaces.go
+++ b/config/backend-config/hosted_workspaces.go
@@ -79,7 +79,12 @@ func (multiWorkspaceConfig *HostedWorkspacesConfig) GetWorkspaceLibrariesForWork
 
 //Get returns sources from all hosted workspaces
 func (multiWorkspaceConfig *HostedWorkspacesConfig) Get(_ string) (ConfigT, bool) {
-	url := fmt.Sprintf("%s/hostedWorkspaceConfig?fetchAll=true", configBackendURL)
+	var url string
+	if config.GetBool("BackendConfig.cachedHostedWorkspaceConfig", true) {
+		url = fmt.Sprintf("%s/cachedHostedWorkspaceConfig", configBackendURL)
+	} else {
+		url = fmt.Sprintf("%s/hostedWorkspaceConfig?fetchAll=true", configBackendURL)
+	}
 
 	var respBody []byte
 	var statusCode int

--- a/config/backend-config/hosted_workspaces_test.go
+++ b/config/backend-config/hosted_workspaces_test.go
@@ -67,7 +67,7 @@ var _ = Describe("workspace-config", func() {
 			defer server.Close()
 
 			testRequest, _ := http.NewRequest("GET", server.URL, nil)
-			mockHttp.EXPECT().NewRequest("GET", fmt.Sprintf("%s/hostedWorkspaceConfig?fetchAll=true", configBackendURL), nil).Return(testRequest, nil).Times(1)
+			mockHttp.EXPECT().NewRequest("GET", fmt.Sprintf("%s/cachedHostedWorkspaceConfig", configBackendURL), nil).Return(testRequest, nil).Times(1)
 
 			config, ok := backendConfig.Get("testToken")
 			Expect(backendConfig.GetWorkspaceIDForWriteKey("d2")).To(Equal("testWordSpaceId"))
@@ -88,7 +88,7 @@ var _ = Describe("workspace-config", func() {
 			defer server.Close()
 
 			testRequest, _ := http.NewRequest("GET", server.URL, nil)
-			mockHttp.EXPECT().NewRequest("GET", fmt.Sprintf("%s/hostedWorkspaceConfig?fetchAll=true", configBackendURL), nil).Return(testRequest, nil).Times(1)
+			mockHttp.EXPECT().NewRequest("GET", fmt.Sprintf("%s/cachedHostedWorkspaceConfig", configBackendURL), nil).Return(testRequest, nil).Times(1)
 
 			mockLogger.EXPECT().Error("Error while parsing request", gomock.Any(), http.StatusNoContent).Times(1)
 			config, ok := backendConfig.Get("testToken")
@@ -96,7 +96,7 @@ var _ = Describe("workspace-config", func() {
 			Expect(ok).To(BeFalse())
 		})
 		It("Expect to make the correct actions if fail to create the request", func() {
-			mockHttp.EXPECT().NewRequest("GET", fmt.Sprintf("%s/hostedWorkspaceConfig?fetchAll=true", configBackendURL), nil).Return(nil, errors.New("TestError")).AnyTimes()
+			mockHttp.EXPECT().NewRequest("GET", fmt.Sprintf("%s/cachedHostedWorkspaceConfig", configBackendURL), nil).Return(nil, errors.New("TestError")).AnyTimes()
 			mockLogger.EXPECT().Errorf("[[ Multi-workspace-config ]] Failed to fetch multi workspace config from API with error: %v, retrying after %v", gomock.Eq(errors.New("TestError")), gomock.Any()).AnyTimes()
 			mockLogger.EXPECT().Error("Error sending request to the server", gomock.Eq(errors.New("TestError"))).Times(1)
 			config, ok := backendConfig.Get("testToken")
@@ -105,7 +105,7 @@ var _ = Describe("workspace-config", func() {
 		})
 		It("Expect to make the correct actions if fail to send the request", func() {
 			testRequest, _ := http.NewRequest("GET", "", nil)
-			mockHttp.EXPECT().NewRequest("GET", fmt.Sprintf("%s/hostedWorkspaceConfig?fetchAll=true", configBackendURL), nil).Return(testRequest, nil).AnyTimes()
+			mockHttp.EXPECT().NewRequest("GET", fmt.Sprintf("%s/cachedHostedWorkspaceConfig", configBackendURL), nil).Return(testRequest, nil).AnyTimes()
 			mockLogger.EXPECT().Errorf("[[ Multi-workspace-config ]] Failed to fetch multi workspace config from API with error: %v, retrying after %v", gomock.Any(), gomock.Any()).AnyTimes()
 			mockLogger.EXPECT().Error("Error sending request to the server", gomock.Any()).Times(1)
 			config, ok := backendConfig.Get("testToken")

--- a/config/backend-config/multitenant_workspaces.go
+++ b/config/backend-config/multitenant_workspaces.go
@@ -82,7 +82,11 @@ func (workspaceConfig *MultiTenantWorkspacesConfig) getFromAPI(workspaceArr stri
 	var url string
 	// TODO: hacky way to get the backend config for multi tenant through older hosted backed config
 	if config.GetBool("BackendConfig.useHostedBackendConfig", false) {
-		url = fmt.Sprintf("%s/hostedWorkspaceConfig?fetchAll=true", configBackendURL)
+		if config.GetBool("BackendConfig.cachedHostedWorkspaceConfig", true) {
+			url = fmt.Sprintf("%s/cachedHostedWorkspaceConfig", configBackendURL)
+		} else {
+			url = fmt.Sprintf("%s/hostedWorkspaceConfig?fetchAll=true", configBackendURL)
+		}
 	} else {
 		wIds := strings.Split(workspaceArr, ",")
 		for i := range wIds {


### PR DESCRIPTION
# Use cached config backend to reduce the load on config backend. [Reference](https://github.com/rudderlabs/rudder-config-backend/blob/18169c409dc9b0dce137c7467da99b26112af758/src/swagger3/paths/dataPlanePaths.yaml#L166)

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/Use-cached-endpoint-for-hosted-configs-11a9ce59c6fa4917a94ad2a363c733ba)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
