### PR TITLE
chore(gateway): reject the event if it's not valid map

### DIFF
--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -48,6 +48,8 @@ const (
 	ErrorInParseForm = "Error during parsing form"
 	//ErrorInParseMultiform - Error during parsing multiform
 	ErrorInParseMultiform = "Error during parsing multiform"
+	// NonRudderEvent = Event is not a Valid Rudder Event
+	NotRudderEvent = "Event is not a valid rudder event"
 )
 
 var (
@@ -88,6 +90,7 @@ func loadStatusMap() {
 	statusMap[ErrorInMarshal] = ResponseStatus{message: ErrorInMarshal, code: http.StatusBadRequest}
 	statusMap[ErrorInParseForm] = ResponseStatus{message: ErrorInParseForm, code: http.StatusBadRequest}
 	statusMap[ErrorInParseMultiform] = ResponseStatus{message: ErrorInParseMultiform, code: http.StatusBadRequest}
+	statusMap[NotRudderEvent] = ResponseStatus{message: NotRudderEvent, code: http.StatusBadRequest}
 }
 
 func GetStatus(key string) string {


### PR DESCRIPTION
# Description
We try to type cast the event to a map[string]interface but do not check if the typecast was a success or a failure. This PR rejects the events at gateway if the typecast fails

```
panic: interface conversion: interface {} is []interface {}, not map[string]interface {}

goroutine 570 [running]:
github.com/rudderlabs/rudder-server/gateway.(*HandleT).userWebRequestWorkerProcess.func1({0xc000e36a00, {0x0, 0x4c5}, {0x7fc3d3744d01, 0x500}, 0x3325de0, 0xc000e36a00, {0x0, 0x0, 0xc00c842950}}, ...)
	/codebuild/output/src654764301/src/github.com/rudderlabs/rudder-server/gateway/gateway.go:499 +0x85a
github.com/tidwall/gjson.Result.ForEach({0x5, {0xc000e36a00, 0x4c5}, {0x0, 0x0}, 0x0, 0x9, {0x0, 0x0, 0x0}}, ...)
	/go/pkg/mod/github.com/tidwall/gjson@v1.10.2/gjson.go:282 +0x485
github.com/rudderlabs/rudder-server/gateway.(*HandleT).userWebRequestWorkerProcess(0xc0007c4400, 0xc00c22d900)
	/codebuild/output/src654764301/src/github.com/rudderlabs/rudder-server/gateway/gateway.go:474 +0x10f3
github.com/rudderlabs/rudder-server/gateway.(*HandleT).runUserWebRequestWorkers.func1()
	/codebuild/output/src654764301/src/github.com/rudderlabs/rudder-server/gateway/gateway.go:229 +0x25
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x67
created by golang.org/x/sync/errgroup.(*Group).Go
	/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x92

```
## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=e63e2ba77ade4a5ba66987545538815c)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
