### PR TITLE
fix(jobsdb): mark MIGRATE_COPY done and POST_MIGRATE_DS_OP start atomically

### DIFF
--- a/jobsdb/internal/lock/lock.go
+++ b/jobsdb/internal/lock/lock.go
@@ -1,0 +1,38 @@
+package lock
+
+import "sync"
+
+// DSListLockToken represents proof that a list lock has been acquired
+type DSListLockToken interface {
+	listLockToken()
+}
+
+// DSListLocker
+type DSListLocker struct {
+	m sync.RWMutex
+}
+
+// RLock acquires a read lock
+func (r *DSListLocker) RLock() {
+	r.m.RLock()
+}
+
+// RLock releases a read lock
+func (r *DSListLocker) RUnlock() {
+	r.m.RUnlock()
+}
+
+// WithLock acquires a lock for the duration that the provided function
+// is being executed. A token as proof of the lock is passed to the function.
+func (r *DSListLocker) WithLock(f func(l DSListLockToken)) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	f(&listLockToken{})
+}
+
+type listLockToken struct {
+}
+
+func (*listLockToken) listLockToken() {
+	// no-op
+}

--- a/jobsdb/jobsdb_export.go
+++ b/jobsdb/jobsdb_export.go
@@ -45,7 +45,7 @@ func (jd *HandleT) GetNonMigratedAndMarkMigrating(count int) []*JobT {
 	defer jd.dsListLock.RUnlock()
 	jd.logger.Debugf("[[ %s-JobsDB export ]] Inside GetNonMigrated and got locks", jd.GetTablePrefix())
 
-	dsList := jd.getDSList(false)
+	dsList := jd.getDSList()
 	pkgLogger.Debugf("[[ %s-JobsDB export ]] Inside GetNonMigrated - dsList: %+v", jd.tablePrefix, dsList)
 	outJobs := make([]*JobT, 0)
 	jd.assert(count >= 0, fmt.Sprintf("count:%d received is less than 0", count))
@@ -257,7 +257,7 @@ func (jd *HandleT) IsMigrating() bool {
 	defer jd.dsMigrationLock.RUnlock()
 	defer jd.dsListLock.RUnlock()
 
-	dsList := jd.getDSList(false)
+	dsList := jd.getDSList()
 
 	if jd.migrationState.lastDsForExport.Index == "" {
 		return false
@@ -316,7 +316,7 @@ func (jd *HandleT) PreExportCleanup() {
 	jd.dsListLock.RLock()
 	defer jd.dsListLock.RUnlock()
 
-	dsList := jd.getDSList(false)
+	dsList := jd.getDSList()
 
 	for _, ds := range dsList {
 		jd.deleteMigratingJobStatusDS(ds)
@@ -331,7 +331,7 @@ func (jd *HandleT) PostExportCleanup() {
 	jd.dsListLock.RLock()
 	defer jd.dsListLock.RUnlock()
 
-	dsList := jd.getDSList(false)
+	dsList := jd.getDSList()
 
 	for _, ds := range dsList {
 		jd.deleteWontMigrateJobStatusDS(ds)

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -349,7 +349,7 @@ var _ = Describe("jobsdb", func() {
 		It("doesn't make db calls if !refreshFromDB", func() {
 			jd.datasetList = dsListInMemory
 
-			Expect(jd.getDSList(false)).To(Equal(dsListInMemory))
+			Expect(jd.getDSList()).To(Equal(dsListInMemory))
 		})
 	})
 })

--- a/jobsdb/setup.go
+++ b/jobsdb/setup.go
@@ -63,9 +63,9 @@ func (jd *HandleT) dropDatabaseTables() {
 
 	jd.logger.Infof("[JobsDB:%v] Dropping all database tables", jd.tablePrefix)
 	jd.dropSchemaMigrationTables()
-	jd.dropAllDS()
+	jd.assertError(jd.dropAllDS())
 	jd.dropJournal()
-	jd.dropAllBackupDS()
+	jd.assertError(jd.dropAllBackupDS())
 	jd.dropMigrationCheckpointTables()
 }
 

--- a/jobsdb/setup.go
+++ b/jobsdb/setup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/rudderlabs/rudder-server/config"
+	"github.com/rudderlabs/rudder-server/jobsdb/internal/lock"
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 )
 
@@ -19,13 +20,13 @@ func (jd *HandleT) SchemaMigrationTable() string {
 // - Prefix: The table prefix used by this jobsdb instance.
 // - Datasets: Array of existing dataset indices.
 // If clearAll is set to true, all existing jobsdb tables will be removed first.
-func (jd *HandleT) setupDatabaseTables(clearAll bool) {
+func (jd *HandleT) setupDatabaseTables(l lock.DSListLockToken, clearAll bool) {
 	if clearAll {
-		jd.dropDatabaseTables()
+		jd.dropDatabaseTables(l)
 	}
 
 	// collect all existing dataset indices, and create template data
-	datasets := jd.getDSList(true)
+	datasets := jd.refreshDSList(l)
 
 	datasetIndices := make([]string, 0)
 	for _, dataset := range datasets {
@@ -59,11 +60,11 @@ func (jd *HandleT) setupDatabaseTables(clearAll bool) {
 	}
 }
 
-func (jd *HandleT) dropDatabaseTables() {
+func (jd *HandleT) dropDatabaseTables(l lock.DSListLockToken) {
 
 	jd.logger.Infof("[JobsDB:%v] Dropping all database tables", jd.tablePrefix)
 	jd.dropSchemaMigrationTables()
-	jd.assertError(jd.dropAllDS())
+	jd.assertError(jd.dropAllDS(l))
 	jd.dropJournal()
 	jd.assertError(jd.dropAllBackupDS())
 	jd.dropMigrationCheckpointTables()

--- a/jobsdb/unionQuery.go
+++ b/jobsdb/unionQuery.go
@@ -70,7 +70,7 @@ func (mj *MultiTenantHandleT) GetAllJobs(workspaceCount map[string]int, params G
 	defer mj.dsMigrationLock.RUnlock()
 	defer mj.dsListLock.RUnlock()
 
-	dsList := mj.getDSList(false)
+	dsList := mj.getDSList()
 	outJobs := make([]*JobT, 0)
 
 	workspacePayloadLimitMap := make(map[string]int64)


### PR DESCRIPTION
# Description

Recovery doesn't delete new tables if a crash happens after the `MIGRATE_COPY` operation has completed, but before
`POST_MIGRATE_DS_OP` operation has started. As a result both old and new tables exist both containing the same jobs

- `MIGRATE_COPY` creates new tables 
- `POST_MIGRATE_DS_OP` drops or backups old ones

## Additional changes

- Replaced some panics by returning errors instead
- Functions requiring a `dsListLock` to be acquired have been refactored in order to enforce callers acquire such a lock instead of relying exclusively on good intention. For that purpose, `DSListLockToken` and `DSListLocker` have been introduced

## Notion Ticket

[Internal migration not recovering from crash happening after MIGRATE_COPY operation has completed, but before
POST_MIGRATE_DS_OP operation has started](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=68d1088e74804d448aacafd88c700a48)

[Update getDS(Range)List API to enforce proper locking](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=b9f77faa87c74a74bf15b5cbabde8f1d)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
