### PR TITLE
fix: disable support for Google Developers Console client_credentials.json file

### DIFF
--- a/services/filemanager/gcsmanager.go
+++ b/services/filemanager/gcsmanager.go
@@ -107,7 +107,7 @@ func (manager *GCSManager) getClient(ctx context.Context) (*storage.Client, erro
 		}
 
 		if manager.Config.Credentials != "" {
-			if err = googleutils.CompatibleGoogleCredentialsJson([]byte(manager.Config.Credentials)); err != nil {
+			if err = googleutils.CompatibleGoogleCredentialsJSON([]byte(manager.Config.Credentials)); err != nil {
 				return manager.client, err
 			}
 			options = append(options, option.WithCredentialsJSON([]byte(manager.Config.Credentials)))

--- a/services/filemanager/gcsmanager.go
+++ b/services/filemanager/gcsmanager.go
@@ -99,21 +99,22 @@ func (manager *GCSManager) getClient(ctx context.Context) (*storage.Client, erro
 
 	ctx, cancel := context.WithTimeout(ctx, getSafeTimeout(manager.Timeout))
 	defer cancel()
-	if manager.client == nil {
-		options := []option.ClientOption{}
-
-		if manager.Config.EndPoint != nil && *manager.Config.EndPoint != "" {
-			options = append(options, option.WithEndpoint(*manager.Config.EndPoint))
-		}
-
-		if manager.Config.Credentials != "" {
-			if err = googleutils.CompatibleGoogleCredentialsJSON([]byte(manager.Config.Credentials)); err != nil {
-				return manager.client, err
-			}
-			options = append(options, option.WithCredentialsJSON([]byte(manager.Config.Credentials)))
-		}
-		manager.client, err = storage.NewClient(ctx, options...)
+	if manager.client != nil {
+		return manager.client, err
 	}
+	options := []option.ClientOption{}
+
+	if manager.Config.EndPoint != nil && *manager.Config.EndPoint != "" {
+		options = append(options, option.WithEndpoint(*manager.Config.EndPoint))
+	}
+	if manager.Config.Credentials != "" {
+		if err = googleutils.CompatibleGoogleCredentialsJSON([]byte(manager.Config.Credentials)); err != nil {
+			return manager.client, err
+		}
+		options = append(options, option.WithCredentialsJSON([]byte(manager.Config.Credentials)))
+	}
+
+	manager.client, err = storage.NewClient(ctx, options...)
 	return manager.client, err
 }
 

--- a/services/streammanager/bqstream/bqstreammanager.go
+++ b/services/streammanager/bqstream/bqstreammanager.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/rudderlabs/rudder-server/utils/googleutils"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/tidwall/gjson"
 	gbq "google.golang.org/api/bigquery/v2"
@@ -67,7 +68,10 @@ func NewProducer(destinationConfig interface{}, o Opts) (*Client, error) {
 	}
 	var confCreds []byte
 	if config.Credentials == "" {
-		return nil, createErr(err, "Credentials not being sent")
+		return nil, createErr(err, "credentials not being sent")
+	}
+	if err = googleutils.CompatibleGoogleCredentialsJson([]byte(config.Credentials)); err != nil {
+		return nil, createErr(err, "incompatible credentials")
 	}
 	confCreds = []byte(config.Credentials)
 	err = json.Unmarshal(confCreds, &credentialsFile)

--- a/services/streammanager/bqstream/bqstreammanager.go
+++ b/services/streammanager/bqstream/bqstreammanager.go
@@ -70,7 +70,7 @@ func NewProducer(destinationConfig interface{}, o Opts) (*Client, error) {
 	if config.Credentials == "" {
 		return nil, createErr(err, "credentials not being sent")
 	}
-	if err = googleutils.CompatibleGoogleCredentialsJson([]byte(config.Credentials)); err != nil {
+	if err = googleutils.CompatibleGoogleCredentialsJSON([]byte(config.Credentials)); err != nil {
 		return nil, createErr(err, "incompatible credentials")
 	}
 	confCreds = []byte(config.Credentials)

--- a/services/streammanager/bqstream/bqstreammanager_test.go
+++ b/services/streammanager/bqstream/bqstreammanager_test.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mock_logger "github.com/rudderlabs/rudder-server/mocks/utils/logger"
+	"github.com/stretchr/testify/assert"
 )
 
 type BigQueryCredentials struct {
-	ProjectID   string            `json:"projectID"`
-	Credentials map[string]string `json:"credentials"`
+	ProjectID   string                 `json:"projectID"`
+	Credentials map[string]interface{} `json:"credentials"`
 }
 
 func TestTimeout(t *testing.T) {
@@ -67,4 +68,42 @@ func TestTimeout(t *testing.T) {
 		t.Errorf("Expected response message %s, got %s.", expectedResponseMessage, responseMessage)
 	}
 
+}
+
+func TestUnsupportedCredentials(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	mockLogger := mock_logger.NewMockLoggerI(mockCtrl)
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+	pkgLogger = mockLogger
+
+	var bqCredentials BigQueryCredentials
+	var err error
+	err = json.Unmarshal(
+		[]byte(`{
+			"projectID": "my-project",
+			"credentials": {
+				"installed": {
+					"client_id": "1234.apps.googleusercontent.com",
+					"project_id": "project_id",
+					"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+					"token_uri": "https://oauth2.googleapis.com/token",
+					"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+					"client_secret": "client_secret",
+					"redirect_uris": [
+						"urn:ietf:wg:oauth:2.0:oob",
+						"http://localhost"
+					]
+				}
+			}
+		}`), &bqCredentials)
+	assert.NoError(t, err)
+	credentials, _ := json.Marshal(bqCredentials.Credentials)
+	config := Config{
+		Credentials: string(credentials),
+		ProjectId:   bqCredentials.ProjectID,
+	}
+	_, err = NewProducer(config, Opts{Timeout: 1 * time.Microsecond})
+
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "[BQStream] error :: incompatible credentials:: Google Developers Console client_credentials.json file is not supported")
 }

--- a/services/streammanager/googlepubsub/googlepubsubmanager.go
+++ b/services/streammanager/googlepubsub/googlepubsubmanager.go
@@ -61,7 +61,7 @@ func NewProducer(destinationConfig interface{}, o Opts) (*PubsubClient, error) {
 	}
 	var client *pubsub.Client
 	if config.Credentials != "" { // Normal configuration requires credentials
-		if err = googleutils.CompatibleGoogleCredentialsJson([]byte(config.Credentials)); err != nil {
+		if err = googleutils.CompatibleGoogleCredentialsJSON([]byte(config.Credentials)); err != nil {
 			return nil, err
 		}
 		if client, err = pubsub.NewClient(ctx, config.ProjectId, option.WithCredentialsJSON([]byte(config.Credentials))); err != nil {

--- a/services/streammanager/googlepubsub/googlepubsubmanager.go
+++ b/services/streammanager/googlepubsub/googlepubsubmanager.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
+	"github.com/rudderlabs/rudder-server/utils/googleutils"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/tidwall/gjson"
 	"google.golang.org/api/option"
@@ -60,6 +61,9 @@ func NewProducer(destinationConfig interface{}, o Opts) (*PubsubClient, error) {
 	}
 	var client *pubsub.Client
 	if config.Credentials != "" { // Normal configuration requires credentials
+		if err = googleutils.CompatibleGoogleCredentialsJson([]byte(config.Credentials)); err != nil {
+			return nil, err
+		}
 		if client, err = pubsub.NewClient(ctx, config.ProjectId, option.WithCredentialsJSON([]byte(config.Credentials))); err != nil {
 			return nil, err
 		}

--- a/services/streammanager/googlepubsub/googlepubsubmanager_test.go
+++ b/services/streammanager/googlepubsub/googlepubsubmanager_test.go
@@ -14,6 +14,7 @@ import (
 	"cloud.google.com/go/pubsub"
 	"github.com/ory/dockertest/v3"
 	"github.com/rudderlabs/rudder-server/testhelper"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -60,6 +61,23 @@ func Test_Timeout(t *testing.T) {
 	if responseMessage != expectedResponseMessage {
 		t.Errorf("Expected response message %s, got %s.", expectedResponseMessage, responseMessage)
 	}
+}
+
+func TestUnsupportedCredentials(t *testing.T) {
+
+	config := Config{
+		ProjectId: projectId,
+		EventToTopicMap: []map[string]string{
+			{"to": topic},
+		},
+		Credentials: "{\"installed\":{\"client_id\":\"1234.apps.googleusercontent.com\",\"project_id\":\"project_id\",\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"token_uri\":\"https://oauth2.googleapis.com/token\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\",\"client_secret\":\"client_secret\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"http://localhost\"]}}",
+	}
+
+	_, err := NewProducer(config, Opts{})
+
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "Google Developers Console client_credentials.json file is not supported")
+
 }
 
 func TestMain(m *testing.M) {

--- a/utils/googleutils/googleutils.go
+++ b/utils/googleutils/googleutils.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
-func CompatibleGoogleCredentialsJson(jsonKey []byte) error {
+func CompatibleGoogleCredentialsJSON(jsonKey []byte) error {
 	if _, err := google.ConfigFromJSON(jsonKey); err == nil {
 		return fmt.Errorf("Google Developers Console client_credentials.json file is not supported")
 	}

--- a/utils/googleutils/googleutils.go
+++ b/utils/googleutils/googleutils.go
@@ -1,0 +1,14 @@
+package googleutils
+
+import (
+	"fmt"
+
+	"golang.org/x/oauth2/google"
+)
+
+func CompatibleGoogleCredentialsJson(jsonKey []byte) error {
+	if _, err := google.ConfigFromJSON(jsonKey); err == nil {
+		return fmt.Errorf("Google Developers Console client_credentials.json file is not supported")
+	}
+	return nil
+}

--- a/warehouse/bigquery/bigquery.go
+++ b/warehouse/bigquery/bigquery.go
@@ -12,6 +12,7 @@ import (
 	"cloud.google.com/go/bigquery"
 	"github.com/gofrs/uuid"
 	"github.com/rudderlabs/rudder-server/config"
+	"github.com/rudderlabs/rudder-server/utils/googleutils"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/client"
@@ -606,6 +607,9 @@ type BQCredentialsT struct {
 }
 
 func Connect(context context.Context, cred *BQCredentialsT) (*bigquery.Client, error) {
+	if err := googleutils.CompatibleGoogleCredentialsJson([]byte(cred.Credentials)); err != nil {
+		return nil, err
+	}
 	client, err := bigquery.NewClient(context, cred.ProjectID, option.WithCredentialsJSON([]byte(cred.Credentials)))
 	return client, err
 }

--- a/warehouse/bigquery/bigquery.go
+++ b/warehouse/bigquery/bigquery.go
@@ -607,7 +607,7 @@ type BQCredentialsT struct {
 }
 
 func Connect(context context.Context, cred *BQCredentialsT) (*bigquery.Client, error) {
-	if err := googleutils.CompatibleGoogleCredentialsJson([]byte(cred.Credentials)); err != nil {
+	if err := googleutils.CompatibleGoogleCredentialsJSON([]byte(cred.Credentials)); err != nil {
 		return nil, err
 	}
 	client, err := bigquery.NewClient(context, cred.ProjectID, option.WithCredentialsJSON([]byte(cred.Credentials)))

--- a/warehouse/bigquery/bigquery_test.go
+++ b/warehouse/bigquery/bigquery_test.go
@@ -1,0 +1,22 @@
+package bigquery_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rudderlabs/rudder-server/warehouse/bigquery"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnsupportedCredentials(t *testing.T) {
+	credentials := bigquery.BQCredentialsT{
+		ProjectID:   "projectId",
+		Credentials: "{\"installed\":{\"client_id\":\"1234.apps.googleusercontent.com\",\"project_id\":\"project_id\",\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"token_uri\":\"https://oauth2.googleapis.com/token\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\",\"client_secret\":\"client_secret\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"http://localhost\"]}}",
+	}
+
+	_, err := bigquery.Connect(context.Background(), &credentials)
+
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "Google Developers Console client_credentials.json file is not supported")
+
+}


### PR DESCRIPTION
# Description

In the latest `oauth2` library releases, support was [added](https://github.com/golang/oauth2/commit/81ed05c6b58c5509b83ac75450e38d97242e7168) for Google Developers Console `client_credentials.json` files.

However, this type of files is associated with a 3-legged OAuth flow and no environment-specific `AuthorizationHandler` is available, which results in a server panic (nil pointer dereference).

This fix, disables support for `client_credentials.json` files by returning an appropriate error.

## Notion Ticket

[Disable support for Google Developers Console client_credentials json file](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=52d0d703a5fd4cadaf59b8c008c8b02e)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
