### PR TITLE
chore: introduce timeout and retry in jobs db

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -163,7 +163,7 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 			enableProcessor = false
 			enableGateway = migrationMode != db.EXPORT
 
-			embedded.App.Features().Migrator.PrepareJobsdbsForImport(gwDBForProcessor, routerDB, batchRouterDB)
+			embedded.App.Features().Migrator.PrepareJobsdbsForImport(ctx, gwDBForProcessor, routerDB, batchRouterDB)
 
 			g.Go(func() error {
 				embedded.App.Features().Migrator.Run(ctx, gwDBForProcessor, routerDB, batchRouterDB, startProcessorFunc,
@@ -215,7 +215,7 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 		var replayDB jobsdb.HandleT
 		replayDB.Setup(jobsdb.ReadWrite, options.ClearDB, "replay", routerDBRetention, migrationMode, true, jobsdb.QueryFiltersT{}, prebackupHandlers)
 		defer replayDB.TearDown()
-		embedded.App.Features().Replay.Setup(&replayDB, gwDBForProcessor, routerDB, batchRouterDB)
+		embedded.App.Features().Replay.Setup(ctx, &replayDB, gwDBForProcessor, routerDB, batchRouterDB)
 	}
 
 	if enableGateway {

--- a/app/apphandlers/gatewayAppHandler.go
+++ b/app/apphandlers/gatewayAppHandler.go
@@ -65,7 +65,7 @@ func (gatewayApp *GatewayApp) StartRudderCore(ctx context.Context, options *app.
 		if migrationMode == db.IMPORT || migrationMode == db.EXPORT || migrationMode == db.IMPORT_EXPORT {
 			enableGateway = (migrationMode != db.EXPORT)
 
-			gatewayApp.App.Features().Migrator.PrepareJobsdbsForImport(gatewayDB, nil, nil)
+			gatewayApp.App.Features().Migrator.PrepareJobsdbsForImport(ctx, gatewayDB, nil, nil)
 		}
 	}
 

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -183,7 +183,7 @@ func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app
 			enableRouter = false
 			enableProcessor = false
 
-			processor.App.Features().Migrator.PrepareJobsdbsForImport(nil, routerDB, batchRouterDB)
+			processor.App.Features().Migrator.PrepareJobsdbsForImport(ctx, nil, routerDB, batchRouterDB)
 			g.Go(func() error {
 				processor.App.Features().Migrator.Run(ctx, gwDBForProcessor, routerDB, batchRouterDB, startProcessorFunc, startRouterFunc) //TODO
 				return nil
@@ -250,7 +250,7 @@ func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app
 		var replayDB jobsdb.HandleT
 		replayDB.Setup(jobsdb.ReadWrite, options.ClearDB, "replay", routerDBRetention, migrationMode, true, jobsdb.QueryFiltersT{}, prebackupHandlers)
 		defer replayDB.TearDown()
-		processor.App.Features().Replay.Setup(&replayDB, gwDBForProcessor, routerDB, batchRouterDB)
+		processor.App.Features().Replay.Setup(ctx, &replayDB, gwDBForProcessor, routerDB, batchRouterDB)
 	}
 
 	g.Go(func() error {

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -173,8 +173,8 @@ func monitorDestRouters(ctx context.Context, routerFactory *router.Factory, batc
 	//rt / batch_rt tables and there would be a delay reading from channel `ch`
 	//However, this shouldn't be the problem since backend config pushes config
 	//to its subscribers in separate goroutines to prevent blocking.
-	routerFactory.RouterDB.DeleteExecuting()
-	batchRouterFactory.RouterDB.DeleteExecuting()
+	routerFactory.RouterDB.DeleteExecuting(ctx)
+	batchRouterFactory.RouterDB.DeleteExecuting(ctx)
 
 loop:
 	for {
@@ -196,7 +196,7 @@ loop:
 						_, ok := dstToBatchRouter[destination.DestinationDefinition.Name]
 						if !ok {
 							pkgLogger.Info("Starting a new Batch Destination Router ", destination.DestinationDefinition.Name)
-							brt := batchRouterFactory.New(destination.DestinationDefinition.Name)
+							brt := batchRouterFactory.New(ctx, destination.DestinationDefinition.Name)
 							brt.Start()
 							cleanup = append(cleanup, brt.Shutdown)
 							dstToBatchRouter[destination.DestinationDefinition.Name] = brt

--- a/app/features.go
+++ b/app/features.go
@@ -15,7 +15,7 @@ import (
 // MigratorFeature handles migration of nodes during cluster's scale up/down.
 type MigratorFeature interface {
 	Run(context.Context, *jobsdb.HandleT, *jobsdb.HandleT, *jobsdb.HandleT, func(), func())
-	PrepareJobsdbsForImport(*jobsdb.HandleT, *jobsdb.HandleT, *jobsdb.HandleT)
+	PrepareJobsdbsForImport(context.Context, *jobsdb.HandleT, *jobsdb.HandleT, *jobsdb.HandleT)
 }
 
 // MigratorFeatureSetup is a function that initializes a Migrator feature, based on application instance
@@ -119,7 +119,7 @@ Replay Feature
 
 // ReplayFeature handles inserting of failed jobs into repsective gw/rt jobsdb
 type ReplayFeature interface {
-	Setup(replayDB, gwDB, routerDB, batchRouterDB *jobsdb.HandleT)
+	Setup(ctx context.Context, replayDB, gwDB, routerDB, batchRouterDB *jobsdb.HandleT)
 }
 
 // ReplayFeatureSetup is a function that initializes a Replay feature

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -231,7 +232,7 @@ var _ = Describe("Gateway Enterprise", func() {
 		It("should accept events from normal users", func() {
 			allowedUserEventData := fmt.Sprintf("{\"batch\":[{\"userId\": \"%s\"}]}", NormalUserID)
 
-			mockCall := c.mockJobsDB.EXPECT().StoreWithRetryEach(gomock.Any()).DoAndReturn(jobsToEmptyErrors).Times(1)
+			mockCall := c.mockJobsDB.EXPECT().StoreWithRetryEach(context.Background(), gomock.Any()).DoAndReturn(jobsToEmptyErrors).Times(1)
 			tFunc := c.asyncHelper.ExpectAndNotifyCallbackWithName("store-job")
 			mockCall.Do(func(interface{}) { tFunc() })
 
@@ -344,7 +345,7 @@ var _ = Describe("Gateway", func() {
 				validBody := createValidBody("custom-property", "custom-value")
 
 				c.mockJobsDB.
-					EXPECT().StoreWithRetryEach(gomock.Any()).
+					EXPECT().StoreWithRetryEach(context.Background(), gomock.Any()).
 					DoAndReturn(func(jobs []*jobsdb.JobT) map[uuid.UUID]string {
 						for _, job := range jobs {
 							// each call should be included in a separate batch, with a separate batch_id
@@ -398,7 +399,7 @@ var _ = Describe("Gateway", func() {
 			tFunc = c.asyncHelper.ExpectAndNotifyCallbackWithName("")
 			mockCall.Do(func(interface{}) { tFunc() })
 
-			mockCall = c.mockJobsDB.EXPECT().StoreWithRetryEach(gomock.Any()).DoAndReturn(jobsToEmptyErrors).Times(1)
+			mockCall = c.mockJobsDB.EXPECT().StoreWithRetryEach(context.Background(), gomock.Any()).DoAndReturn(jobsToEmptyErrors).Times(1)
 			tFunc = c.asyncHelper.ExpectAndNotifyCallbackWithName("")
 			mockCall.Do(func(interface{}) { tFunc() })
 

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -194,7 +194,7 @@ func TestJobsDB(t *testing.T) {
 	})
 	unprocessedListEmpty := unprocessedJobEmpty.Jobs
 	require.Equal(t, 0, len(unprocessedListEmpty))
-	err := jobDB.Store([]*jobsdb.JobT{&sampleTestJob})
+	err := jobDB.Store(context.Background(), []*jobsdb.JobT{&sampleTestJob})
 	require.NoError(t, err)
 
 	unprocessedJob := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
@@ -217,7 +217,7 @@ func TestJobsDB(t *testing.T) {
 		WorkspaceId:   defaultWorkspaceID,
 	}
 
-	err = jobDB.UpdateJobStatus([]*jobsdb.JobStatusT{&status}, []string{customVal}, []jobsdb.ParameterFilterT{})
+	err = jobDB.UpdateJobStatus(context.Background(), []*jobsdb.JobStatusT{&status}, []string{customVal}, []jobsdb.ParameterFilterT{})
 	require.NoError(t, err)
 
 	uj := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
@@ -237,7 +237,7 @@ func TestJobsDB(t *testing.T) {
 
 		t.Logf("spread %d jobs into %d data sets", jobCount, dsCount)
 		for i := 0; i < dsCount; i++ {
-			require.NoError(t, jobDB.Store(genJobs(defaultWorkspaceID, customVal, jobCountPerDS, eventsPerJob)))
+			require.NoError(t, jobDB.Store(context.Background(), genJobs(defaultWorkspaceID, customVal, jobCountPerDS, eventsPerJob)))
 			triggerAddNewDS <- time.Now()
 			triggerAddNewDS <- time.Now() //Second time, waits for the first loop to finish
 		}
@@ -291,7 +291,7 @@ func TestJobsDB(t *testing.T) {
 			}
 		}
 		t.Log("Mark some jobs as failed")
-		err = jobDB.UpdateJobStatus(statuses, []string{customVal}, []jobsdb.ParameterFilterT{})
+		err = jobDB.UpdateJobStatus(context.Background(), statuses, []string{customVal}, []jobsdb.ParameterFilterT{})
 		require.NoError(t, err)
 
 		t.Log("GetUnprocessed with job count limit")
@@ -336,11 +336,11 @@ func TestJobsDB(t *testing.T) {
 		eventsPerJob_ds2 := 20
 
 		t.Log("First jobs table with jobs of 60 events, second with jobs of 20 events")
-		require.NoError(t, jobDB.Store(genJobs(defaultWorkspaceID, customVal, jobCountPerDS, eventsPerJob_ds1)))
+		require.NoError(t, jobDB.Store(context.Background(), genJobs(defaultWorkspaceID, customVal, jobCountPerDS, eventsPerJob_ds1)))
 		triggerAddNewDS <- time.Now()
 		triggerAddNewDS <- time.Now() //Second time, waits for the first loop to finish
 
-		require.NoError(t, jobDB.Store(genJobs(defaultWorkspaceID, customVal, jobCountPerDS, eventsPerJob_ds2)))
+		require.NoError(t, jobDB.Store(context.Background(), genJobs(defaultWorkspaceID, customVal, jobCountPerDS, eventsPerJob_ds2)))
 		triggerAddNewDS <- time.Now()
 		triggerAddNewDS <- time.Now() //Second time, waits for the first loop to finish
 
@@ -380,7 +380,7 @@ func TestJobsDB(t *testing.T) {
 				}
 			}
 			t.Log("Mark all jobs as failed")
-			err = jobDB.UpdateJobStatus(statuses, []string{customVal}, []jobsdb.ParameterFilterT{})
+			err = jobDB.UpdateJobStatus(context.Background(), statuses, []string{customVal}, []jobsdb.ParameterFilterT{})
 			require.NoError(t, err)
 		}
 
@@ -415,13 +415,13 @@ func TestJobsDB(t *testing.T) {
 		defer jobDB.TearDown()
 
 		jobs := genJobs(defaultWorkspaceID, customVal, 2, 1)
-		require.NoError(t, jobDB.Store(jobs))
+		require.NoError(t, jobDB.Store(context.Background(), jobs))
 		payloadSize, err := getPayloadSize(t, &jobDB, jobs[0])
 		require.NoError(t, err)
 		triggerAddNewDS <- time.Now()
 		triggerAddNewDS <- time.Now() //Second time, waits for the first loop to finish
 
-		require.NoError(t, jobDB.Store(genJobs(defaultWorkspaceID, customVal, 2, 1)))
+		require.NoError(t, jobDB.Store(context.Background(), genJobs(defaultWorkspaceID, customVal, 2, 1)))
 		triggerAddNewDS <- time.Now()
 		triggerAddNewDS <- time.Now() //Second time, waits for the first loop to finish
 
@@ -452,7 +452,7 @@ func TestJobsDB(t *testing.T) {
 		defer jobDB.TearDown()
 
 		jobs := genJobs(defaultWorkspaceID, customVal, 2, 1)
-		require.NoError(t, jobDB.Store(jobs))
+		require.NoError(t, jobDB.Store(context.Background(), jobs))
 		payloadSize, err := getPayloadSize(t, &jobDB, jobs[0])
 		require.NoError(t, err)
 
@@ -483,7 +483,7 @@ func TestJobsDB(t *testing.T) {
 		defer jobDB.TearDown()
 
 		jobs := genJobs(defaultWorkspaceID, customVal, 2, 4)
-		require.NoError(t, jobDB.Store(jobs))
+		require.NoError(t, jobDB.Store(context.Background(), jobs))
 
 		eventCountLimit := 1
 		eventLimitList := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
@@ -517,11 +517,11 @@ func TestJobsDB(t *testing.T) {
 		jobs = append(jobs, genJobs(defaultWorkspaceID, customVal, 1, 2)...)
 		jobs = append(jobs, genJobs(defaultWorkspaceID, customVal, 1, 3)...)
 		jobs = append(jobs, genJobs(defaultWorkspaceID, customVal, 1, 10)...)
-		require.NoError(t, jobDB.Store(jobs))
+		require.NoError(t, jobDB.Store(context.Background(), jobs))
 		triggerAddNewDS <- time.Now()
 		triggerAddNewDS <- time.Now() //Second time, waits for the first loop to finish
 
-		require.NoError(t, jobDB.Store(jobs))
+		require.NoError(t, jobDB.Store(context.Background(), jobs))
 		triggerAddNewDS <- time.Now()
 		triggerAddNewDS <- time.Now() //Second time, waits for the first loop to finish
 
@@ -565,7 +565,7 @@ func TestMultiTenantLegacyGetAllJobs(t *testing.T) {
 	eventsPerJob := 10
 	// Create 30 jobs
 	jobs := genJobs(defaultWorkspaceID, customVal, 30, eventsPerJob)
-	require.NoError(t, jobDB.Store(jobs))
+	require.NoError(t, jobDB.Store(context.Background(), jobs))
 	payloadSize, err := getPayloadSize(t, &jobDB, jobs[0])
 	require.NoError(t, err)
 	j := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{JobsLimit: 100}) // read to get Ids
@@ -573,10 +573,10 @@ func TestMultiTenantLegacyGetAllJobs(t *testing.T) {
 	require.Equal(t, 30, len(jobs), "should get all 30 jobs")
 
 	// Mark 1-10 as failed
-	require.NoError(t, jobDB.UpdateJobStatus(genJobStatuses(jobs[0:10], jobsdb.Failed.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
+	require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(jobs[0:10], jobsdb.Failed.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
 
 	// Mark 11-20 as waiting
-	require.NoError(t, jobDB.UpdateJobStatus(genJobStatuses(jobs[10:20], jobsdb.Waiting.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
+	require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(jobs[10:20], jobsdb.Waiting.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
 
 	t.Run("GetAllJobs with large limits", func(t *testing.T) {
 		params := jobsdb.GetQueryParamsT{JobsLimit: 30}
@@ -655,13 +655,13 @@ func TestMultiTenantGetAllJobs(t *testing.T) {
 	)
 	// Create 30 jobs in each of 3 workspaces
 	jobs := genJobs(workspaceA, customVal, 30, eventsPerJob)
-	require.NoError(t, jobDB.Store(jobs))
+	require.NoError(t, jobDB.Store(context.Background(), jobs))
 	payloadSize, err := getPayloadSize(t, &jobDB, jobs[0])
 	require.NoError(t, err)
 	jobs = genJobs(workspaceB, customVal, 30, eventsPerJob)
-	require.NoError(t, jobDB.Store(jobs))
+	require.NoError(t, jobDB.Store(context.Background(), jobs))
 	jobs = genJobs(workspaceC, customVal, 30, eventsPerJob)
-	require.NoError(t, jobDB.Store(jobs))
+	require.NoError(t, jobDB.Store(context.Background(), jobs))
 
 	unprocessedJobs := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{JobsLimit: 90}) // read to get all Ids
 	allJobs := unprocessedJobs.Jobs
@@ -671,14 +671,14 @@ func TestMultiTenantGetAllJobs(t *testing.T) {
 	workspaceCJobs := filterWorkspaceJobs(allJobs, workspaceC)
 
 	// Mark 1-10 as failed for each workspace
-	require.NoError(t, jobDB.UpdateJobStatus(genJobStatuses(workspaceAJobs[0:10], jobsdb.Failed.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
-	require.NoError(t, jobDB.UpdateJobStatus(genJobStatuses(workspaceBJobs[0:10], jobsdb.Failed.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
-	require.NoError(t, jobDB.UpdateJobStatus(genJobStatuses(workspaceCJobs[0:10], jobsdb.Failed.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
+	require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(workspaceAJobs[0:10], jobsdb.Failed.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
+	require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(workspaceBJobs[0:10], jobsdb.Failed.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
+	require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(workspaceCJobs[0:10], jobsdb.Failed.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
 
 	// Mark 11-20 as waiting for each workspace
-	require.NoError(t, jobDB.UpdateJobStatus(genJobStatuses(workspaceAJobs[10:20], jobsdb.Waiting.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
-	require.NoError(t, jobDB.UpdateJobStatus(genJobStatuses(workspaceBJobs[10:20], jobsdb.Waiting.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
-	require.NoError(t, jobDB.UpdateJobStatus(genJobStatuses(workspaceCJobs[10:20], jobsdb.Waiting.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
+	require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(workspaceAJobs[10:20], jobsdb.Waiting.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
+	require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(workspaceBJobs[10:20], jobsdb.Waiting.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
+	require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(workspaceCJobs[10:20], jobsdb.Waiting.State), []string{customVal}, []jobsdb.ParameterFilterT{}))
 
 	t.Run("GetAllJobs with large limits", func(t *testing.T) {
 		workspaceLimits := map[string]int{
@@ -778,7 +778,7 @@ func TestJobsDB_IncompatiblePayload(t *testing.T) {
 		WorkspaceId:  defaultWorkspaceID,
 		EventCount:   1,
 	}
-	err := jobDB.StoreWithRetryEach([]*jobsdb.JobT{&sampleTestJob})
+	err := jobDB.StoreWithRetryEach(context.Background(), []*jobsdb.JobT{&sampleTestJob})
 	for _, val := range err {
 		require.Equal(t, "", val)
 	}
@@ -876,7 +876,7 @@ func benchmarkJobsdbConcurrently(b *testing.B, jobsDB *jobsdb.HandleT, totalJobs
 				chunks := chunkJobs(expectedJobs, pageSize)
 				start.Wait()
 				for i := range chunks {
-					err := jobsDB.Store(chunks[i])
+					err := jobsDB.Store(context.Background(), chunks[i])
 					if err != nil {
 						return err
 					}
@@ -909,7 +909,7 @@ func benchmarkJobsdbConcurrently(b *testing.B, jobsDB *jobsdb.HandleT, totalJobs
 						}
 					}
 
-					err := jobsDB.UpdateJobStatus(status, []string{customVal}, []jobsdb.ParameterFilterT{})
+					err := jobsDB.UpdateJobStatus(context.Background(), status, []string{customVal}, []jobsdb.ParameterFilterT{})
 					require.NoError(b, err)
 
 					for _, j := range unprocessedList {
@@ -989,7 +989,7 @@ func BenchmarkLifecycle(b *testing.B) {
 			wg.Add(writeConcurrency)
 			for j := 0; j < writeConcurrency; j++ {
 				go func() {
-					jobDB.Store(genJobs(defaultWorkspaceID, "", newJobs, 10))
+					jobDB.Store(context.Background(), genJobs(defaultWorkspaceID, "", newJobs, 10))
 					wg.Done()
 				}()
 			}
@@ -1024,7 +1024,7 @@ func consume(t testing.TB, db *jobsdb.HandleT, count int) {
 		}
 	}
 
-	err := db.UpdateJobStatus(status, []string{}, []jobsdb.ParameterFilterT{})
+	err := db.UpdateJobStatus(context.Background(), status, []string{}, []jobsdb.ParameterFilterT{})
 	require.NoError(t, err)
 }
 

--- a/jobsdb/jobsdb_migration_checkpoints.go
+++ b/jobsdb/jobsdb_migration_checkpoints.go
@@ -1,6 +1,7 @@
 package jobsdb
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -201,7 +202,7 @@ func (jd *HandleT) findDsFromSetupCheckpoint(migrationType MigrationOp) (dataSet
 	return ds, true
 }
 
-func (jd *HandleT) createSetupCheckpointAndGetDs(migrationType MigrationOp) dataSetT {
+func (jd *HandleT) createSetupCheckpointAndGetDs(ctx context.Context, migrationType MigrationOp) dataSetT {
 	jd.dsListLock.Lock()
 	defer jd.dsListLock.Unlock()
 
@@ -215,7 +216,7 @@ func (jd *HandleT) createSetupCheckpointAndGetDs(migrationType MigrationOp) data
 	case AcceptNewEventsOp:
 		ds = jd.getDsForNewEvents(dsList)
 	case ImportOp:
-		ds = jd.getDsForImport(dsList)
+		ds = jd.getDsForImport(ctx, dsList)
 	}
 
 	var err error
@@ -227,10 +228,10 @@ func (jd *HandleT) createSetupCheckpointAndGetDs(migrationType MigrationOp) data
 	return ds
 }
 
-func (jd *HandleT) findOrCreateDsFromSetupCheckpoint(migrationType MigrationOp) dataSetT {
+func (jd *HandleT) findOrCreateDsFromSetupCheckpoint(ctx context.Context, migrationType MigrationOp) dataSetT {
 	ds, found := jd.findDsFromSetupCheckpoint(migrationType)
 	if !found {
-		ds = jd.createSetupCheckpointAndGetDs(migrationType)
+		ds = jd.createSetupCheckpointAndGetDs(ctx, migrationType)
 	}
 	return ds
 }

--- a/jobsdb/jobsdb_renameDs_test.go
+++ b/jobsdb/jobsdb_renameDs_test.go
@@ -1,6 +1,7 @@
 package jobsdb
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"testing"
@@ -38,7 +39,7 @@ func Test_mustRenameDS(t *testing.T) {
 		requireRowsCount(t, dbHandle, jobStatusTable, 3)
 
 		// when I execute the renameDs method
-		err := jobsdb.mustRenameDS(dataSetT{
+		err := jobsdb.mustRenameDS(context.Background(), dataSetT{
 			JobTable:       jobsTable,
 			JobStatusTable: jobStatusTable,
 		})
@@ -76,7 +77,7 @@ func Test_mustRenameDS_drops_table_if_left_empty(t *testing.T) {
 		requireRowsCount(t, dbHandle, jobStatusTable, 2)
 
 		// when I execute the renameDs method
-		err := jobsdb.mustRenameDS(dataSetT{
+		err := jobsdb.mustRenameDS(context.Background(), dataSetT{
 			JobTable:       jobsTable,
 			JobStatusTable: jobStatusTable,
 		})

--- a/jobsdb/setup.go
+++ b/jobsdb/setup.go
@@ -1,6 +1,7 @@
 package jobsdb
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -19,9 +20,9 @@ func (jd *HandleT) SchemaMigrationTable() string {
 // - Prefix: The table prefix used by this jobsdb instance.
 // - Datasets: Array of existing dataset indices.
 // If clearAll is set to true, all existing jobsdb tables will be removed first.
-func (jd *HandleT) setupDatabaseTables(clearAll bool) {
+func (jd *HandleT) setupDatabaseTables(ctx context.Context, clearAll bool) {
 	if clearAll {
-		jd.dropDatabaseTables()
+		jd.dropDatabaseTables(ctx)
 	}
 
 	// collect all existing dataset indices, and create template data
@@ -59,14 +60,14 @@ func (jd *HandleT) setupDatabaseTables(clearAll bool) {
 	}
 }
 
-func (jd *HandleT) dropDatabaseTables() {
+func (jd *HandleT) dropDatabaseTables(ctx context.Context) {
 
 	jd.logger.Infof("[JobsDB:%v] Dropping all database tables", jd.tablePrefix)
 	jd.dropSchemaMigrationTables()
-	jd.dropAllDS()
-	jd.dropJournal()
-	jd.dropAllBackupDS()
-	jd.dropMigrationCheckpointTables()
+	jd.dropAllDS(ctx)
+	jd.dropJournal(ctx)
+	jd.dropAllBackupDS(ctx)
+	jd.dropMigrationCheckpointTables(ctx)
 }
 
 func (jd *HandleT) dropSchemaMigrationTables() {

--- a/jobsdb/unionQuery.go
+++ b/jobsdb/unionQuery.go
@@ -3,6 +3,7 @@
 package jobsdb
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -19,14 +20,14 @@ type MultiTenantJobsDB interface {
 	GetAllJobs(map[string]int, GetQueryParamsT, int) []*JobT
 
 	WithUpdateSafeTx(func(tx UpdateSafeTx) error) error
-	UpdateJobStatusInTx(tx UpdateSafeTx, statusList []*JobStatusT, customValFilters []string, parameterFilters []ParameterFilterT) error
-	UpdateJobStatus(statusList []*JobStatusT, customValFilters []string, parameterFilters []ParameterFilterT) error
+	UpdateJobStatusInTx(ctx context.Context, tx UpdateSafeTx, statusList []*JobStatusT, customValFilters []string, parameterFilters []ParameterFilterT) error
+	UpdateJobStatus(ctx context.Context, statusList []*JobStatusT, customValFilters []string, parameterFilters []ParameterFilterT) error
 
-	DeleteExecuting()
+	DeleteExecuting(ctx context.Context)
 
 	GetJournalEntries(opType string) (entries []JournalEntryT)
 	JournalMarkStart(opType string, opPayload json.RawMessage) int64
-	JournalDeleteEntry(opID int64)
+	JournalDeleteEntry(ctx context.Context, opID int64)
 	GetPileUpCounts(map[string]map[string]int)
 }
 

--- a/jobsdb/unionQuery_test.go
+++ b/jobsdb/unionQuery_test.go
@@ -1,6 +1,7 @@
 package jobsdb
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -65,7 +66,7 @@ func TestMultiTenantHandleT_GetAllJobs(t *testing.T) {
 	}, 10)
 
 	require.Equal(t, 0, len(unprocessedListEmpty))
-	err := jobDB.Store([]*JobT{&sampleTestJob1, &sampleTestJob2, &sampleTestJob3})
+	err := jobDB.Store(context.Background(), []*JobT{&sampleTestJob1, &sampleTestJob2, &sampleTestJob3})
 	require.NoError(t, err)
 
 	payloadLimit = 100 * bytesize.MB
@@ -101,7 +102,7 @@ func TestMultiTenantHandleT_GetAllJobs(t *testing.T) {
 		WorkspaceId:   "testWorkspace",
 	}
 
-	err = jobDB.UpdateJobStatus([]*JobStatusT{&status1, &status2}, []string{customVal}, []ParameterFilterT{})
+	err = jobDB.UpdateJobStatus(context.Background(), []*JobStatusT{&status1, &status2}, []string{customVal}, []ParameterFilterT{})
 	require.NoError(t, err)
 
 	payloadLimit = 100 * bytesize.MB

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -5,6 +5,7 @@
 package mocks_jobsdb
 
 import (
+	context "context"
 	sql "database/sql"
 	json "encoding/json"
 	reflect "reflect"
@@ -38,15 +39,15 @@ func (m *MockJobsDB) EXPECT() *MockJobsDBMockRecorder {
 }
 
 // DeleteExecuting mocks base method.
-func (m *MockJobsDB) DeleteExecuting() {
+func (m *MockJobsDB) DeleteExecuting(arg0 context.Context) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteExecuting")
+	m.ctrl.Call(m, "DeleteExecuting", arg0)
 }
 
 // DeleteExecuting indicates an expected call of DeleteExecuting.
-func (mr *MockJobsDBMockRecorder) DeleteExecuting() *gomock.Call {
+func (mr *MockJobsDBMockRecorder) DeleteExecuting(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExecuting", reflect.TypeOf((*MockJobsDB)(nil).DeleteExecuting))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExecuting", reflect.TypeOf((*MockJobsDB)(nil).DeleteExecuting), arg0)
 }
 
 // GetExecuting mocks base method.
@@ -174,15 +175,15 @@ func (mr *MockJobsDBMockRecorder) Identifier() *gomock.Call {
 }
 
 // JournalDeleteEntry mocks base method.
-func (m *MockJobsDB) JournalDeleteEntry(arg0 int64) {
+func (m *MockJobsDB) JournalDeleteEntry(arg0 context.Context, arg1 int64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "JournalDeleteEntry", arg0)
+	m.ctrl.Call(m, "JournalDeleteEntry", arg0, arg1)
 }
 
 // JournalDeleteEntry indicates an expected call of JournalDeleteEntry.
-func (mr *MockJobsDBMockRecorder) JournalDeleteEntry(arg0 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) JournalDeleteEntry(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JournalDeleteEntry", reflect.TypeOf((*MockJobsDB)(nil).JournalDeleteEntry), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JournalDeleteEntry", reflect.TypeOf((*MockJobsDB)(nil).JournalDeleteEntry), arg0, arg1)
 }
 
 // JournalMarkStart mocks base method.
@@ -228,87 +229,87 @@ func (mr *MockJobsDBMockRecorder) Status() *gomock.Call {
 }
 
 // Store mocks base method.
-func (m *MockJobsDB) Store(arg0 []*jobsdb.JobT) error {
+func (m *MockJobsDB) Store(arg0 context.Context, arg1 []*jobsdb.JobT) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Store", arg0)
+	ret := m.ctrl.Call(m, "Store", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Store indicates an expected call of Store.
-func (mr *MockJobsDBMockRecorder) Store(arg0 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) Store(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockJobsDB)(nil).Store), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockJobsDB)(nil).Store), arg0, arg1)
 }
 
 // StoreInTx mocks base method.
-func (m *MockJobsDB) StoreInTx(arg0 jobsdb.StoreSafeTx, arg1 []*jobsdb.JobT) error {
+func (m *MockJobsDB) StoreInTx(arg0 context.Context, arg1 jobsdb.StoreSafeTx, arg2 []*jobsdb.JobT) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreInTx", arg0, arg1)
+	ret := m.ctrl.Call(m, "StoreInTx", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StoreInTx indicates an expected call of StoreInTx.
-func (mr *MockJobsDBMockRecorder) StoreInTx(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) StoreInTx(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreInTx", reflect.TypeOf((*MockJobsDB)(nil).StoreInTx), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreInTx", reflect.TypeOf((*MockJobsDB)(nil).StoreInTx), arg0, arg1, arg2)
 }
 
 // StoreWithRetryEach mocks base method.
-func (m *MockJobsDB) StoreWithRetryEach(arg0 []*jobsdb.JobT) map[uuid.UUID]string {
+func (m *MockJobsDB) StoreWithRetryEach(arg0 context.Context, arg1 []*jobsdb.JobT) map[uuid.UUID]string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreWithRetryEach", arg0)
+	ret := m.ctrl.Call(m, "StoreWithRetryEach", arg0, arg1)
 	ret0, _ := ret[0].(map[uuid.UUID]string)
 	return ret0
 }
 
 // StoreWithRetryEach indicates an expected call of StoreWithRetryEach.
-func (mr *MockJobsDBMockRecorder) StoreWithRetryEach(arg0 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) StoreWithRetryEach(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreWithRetryEach", reflect.TypeOf((*MockJobsDB)(nil).StoreWithRetryEach), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreWithRetryEach", reflect.TypeOf((*MockJobsDB)(nil).StoreWithRetryEach), arg0, arg1)
 }
 
 // StoreWithRetryEachInTx mocks base method.
-func (m *MockJobsDB) StoreWithRetryEachInTx(arg0 jobsdb.StoreSafeTx, arg1 []*jobsdb.JobT) map[uuid.UUID]string {
+func (m *MockJobsDB) StoreWithRetryEachInTx(arg0 context.Context, arg1 jobsdb.StoreSafeTx, arg2 []*jobsdb.JobT) map[uuid.UUID]string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreWithRetryEachInTx", arg0, arg1)
+	ret := m.ctrl.Call(m, "StoreWithRetryEachInTx", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[uuid.UUID]string)
 	return ret0
 }
 
 // StoreWithRetryEachInTx indicates an expected call of StoreWithRetryEachInTx.
-func (mr *MockJobsDBMockRecorder) StoreWithRetryEachInTx(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) StoreWithRetryEachInTx(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreWithRetryEachInTx", reflect.TypeOf((*MockJobsDB)(nil).StoreWithRetryEachInTx), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreWithRetryEachInTx", reflect.TypeOf((*MockJobsDB)(nil).StoreWithRetryEachInTx), arg0, arg1, arg2)
 }
 
 // UpdateJobStatus mocks base method.
-func (m *MockJobsDB) UpdateJobStatus(arg0 []*jobsdb.JobStatusT, arg1 []string, arg2 []jobsdb.ParameterFilterT) error {
+func (m *MockJobsDB) UpdateJobStatus(arg0 context.Context, arg1 []*jobsdb.JobStatusT, arg2 []string, arg3 []jobsdb.ParameterFilterT) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateJobStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UpdateJobStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateJobStatus indicates an expected call of UpdateJobStatus.
-func (mr *MockJobsDBMockRecorder) UpdateJobStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) UpdateJobStatus(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateJobStatus", reflect.TypeOf((*MockJobsDB)(nil).UpdateJobStatus), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateJobStatus", reflect.TypeOf((*MockJobsDB)(nil).UpdateJobStatus), arg0, arg1, arg2, arg3)
 }
 
 // UpdateJobStatusInTx mocks base method.
-func (m *MockJobsDB) UpdateJobStatusInTx(arg0 jobsdb.UpdateSafeTx, arg1 []*jobsdb.JobStatusT, arg2 []string, arg3 []jobsdb.ParameterFilterT) error {
+func (m *MockJobsDB) UpdateJobStatusInTx(arg0 context.Context, arg1 jobsdb.UpdateSafeTx, arg2 []*jobsdb.JobStatusT, arg3 []string, arg4 []jobsdb.ParameterFilterT) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateJobStatusInTx", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "UpdateJobStatusInTx", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateJobStatusInTx indicates an expected call of UpdateJobStatusInTx.
-func (mr *MockJobsDBMockRecorder) UpdateJobStatusInTx(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) UpdateJobStatusInTx(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateJobStatusInTx", reflect.TypeOf((*MockJobsDB)(nil).UpdateJobStatusInTx), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateJobStatusInTx", reflect.TypeOf((*MockJobsDB)(nil).UpdateJobStatusInTx), arg0, arg1, arg2, arg3, arg4)
 }
 
 // WithStoreSafeTx mocks base method.

--- a/mocks/jobsdb/mock_unionQuery.go
+++ b/mocks/jobsdb/mock_unionQuery.go
@@ -5,6 +5,7 @@
 package mocks_jobsdb
 
 import (
+	context "context"
 	json "encoding/json"
 	reflect "reflect"
 
@@ -36,15 +37,15 @@ func (m *MockMultiTenantJobsDB) EXPECT() *MockMultiTenantJobsDBMockRecorder {
 }
 
 // DeleteExecuting mocks base method.
-func (m *MockMultiTenantJobsDB) DeleteExecuting() {
+func (m *MockMultiTenantJobsDB) DeleteExecuting(arg0 context.Context) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteExecuting")
+	m.ctrl.Call(m, "DeleteExecuting", arg0)
 }
 
 // DeleteExecuting indicates an expected call of DeleteExecuting.
-func (mr *MockMultiTenantJobsDBMockRecorder) DeleteExecuting() *gomock.Call {
+func (mr *MockMultiTenantJobsDBMockRecorder) DeleteExecuting(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExecuting", reflect.TypeOf((*MockMultiTenantJobsDB)(nil).DeleteExecuting))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExecuting", reflect.TypeOf((*MockMultiTenantJobsDB)(nil).DeleteExecuting), arg0)
 }
 
 // GetAllJobs mocks base method.
@@ -88,15 +89,15 @@ func (mr *MockMultiTenantJobsDBMockRecorder) GetPileUpCounts(arg0 interface{}) *
 }
 
 // JournalDeleteEntry mocks base method.
-func (m *MockMultiTenantJobsDB) JournalDeleteEntry(arg0 int64) {
+func (m *MockMultiTenantJobsDB) JournalDeleteEntry(arg0 context.Context, arg1 int64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "JournalDeleteEntry", arg0)
+	m.ctrl.Call(m, "JournalDeleteEntry", arg0, arg1)
 }
 
 // JournalDeleteEntry indicates an expected call of JournalDeleteEntry.
-func (mr *MockMultiTenantJobsDBMockRecorder) JournalDeleteEntry(arg0 interface{}) *gomock.Call {
+func (mr *MockMultiTenantJobsDBMockRecorder) JournalDeleteEntry(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JournalDeleteEntry", reflect.TypeOf((*MockMultiTenantJobsDB)(nil).JournalDeleteEntry), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JournalDeleteEntry", reflect.TypeOf((*MockMultiTenantJobsDB)(nil).JournalDeleteEntry), arg0, arg1)
 }
 
 // JournalMarkStart mocks base method.
@@ -114,31 +115,31 @@ func (mr *MockMultiTenantJobsDBMockRecorder) JournalMarkStart(arg0, arg1 interfa
 }
 
 // UpdateJobStatus mocks base method.
-func (m *MockMultiTenantJobsDB) UpdateJobStatus(arg0 []*jobsdb.JobStatusT, arg1 []string, arg2 []jobsdb.ParameterFilterT) error {
+func (m *MockMultiTenantJobsDB) UpdateJobStatus(arg0 context.Context, arg1 []*jobsdb.JobStatusT, arg2 []string, arg3 []jobsdb.ParameterFilterT) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateJobStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UpdateJobStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateJobStatus indicates an expected call of UpdateJobStatus.
-func (mr *MockMultiTenantJobsDBMockRecorder) UpdateJobStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMultiTenantJobsDBMockRecorder) UpdateJobStatus(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateJobStatus", reflect.TypeOf((*MockMultiTenantJobsDB)(nil).UpdateJobStatus), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateJobStatus", reflect.TypeOf((*MockMultiTenantJobsDB)(nil).UpdateJobStatus), arg0, arg1, arg2, arg3)
 }
 
 // UpdateJobStatusInTx mocks base method.
-func (m *MockMultiTenantJobsDB) UpdateJobStatusInTx(arg0 jobsdb.UpdateSafeTx, arg1 []*jobsdb.JobStatusT, arg2 []string, arg3 []jobsdb.ParameterFilterT) error {
+func (m *MockMultiTenantJobsDB) UpdateJobStatusInTx(arg0 context.Context, arg1 jobsdb.UpdateSafeTx, arg2 []*jobsdb.JobStatusT, arg3 []string, arg4 []jobsdb.ParameterFilterT) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateJobStatusInTx", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "UpdateJobStatusInTx", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateJobStatusInTx indicates an expected call of UpdateJobStatusInTx.
-func (mr *MockMultiTenantJobsDBMockRecorder) UpdateJobStatusInTx(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockMultiTenantJobsDBMockRecorder) UpdateJobStatusInTx(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateJobStatusInTx", reflect.TypeOf((*MockMultiTenantJobsDB)(nil).UpdateJobStatusInTx), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateJobStatusInTx", reflect.TypeOf((*MockMultiTenantJobsDB)(nil).UpdateJobStatusInTx), arg0, arg1, arg2, arg3, arg4)
 }
 
 // WithUpdateSafeTx mocks base method.

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -188,7 +188,7 @@ func TestProcessorManager(t *testing.T) {
 
 	jobCountPerDS := 10
 	eventsPerJob := 10
-	err := tempDB.Store(genJobs(customVal, jobCountPerDS, eventsPerJob))
+	err := tempDB.Store(context.Background(), genJobs(customVal, jobCountPerDS, eventsPerJob))
 	require.NoError(t, err)
 
 	gwDB := jobsdb.NewForReadWrite("gw")
@@ -252,7 +252,7 @@ func TestProcessorManager(t *testing.T) {
 			processor.HandleT.transformerFeatures = json.RawMessage(defaultTransformerFeatures)
 		})
 		processor.Start()
-		err = tempDB.Store(genJobs(customVal, jobCountPerDS, eventsPerJob))
+		err = tempDB.Store(context.Background(), genJobs(customVal, jobCountPerDS, eventsPerJob))
 		require.NoError(t, err)
 		unprocessedListEmpty = tempDB.GetUnprocessed(jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{customVal},

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -1,6 +1,7 @@
 package batchrouter
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -153,7 +154,7 @@ var _ = Describe("BatchRouter", func() {
 
 			c.mockBatchRouterJobsDB.EXPECT().GetJournalEntries(gomock.Any()).Times(1).Return(emptyJournalEntries)
 
-			batchrouter.Setup(c.mockBackendConfig, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, s3DestinationDefinition.Name, nil, c.mockMultitenantI, transientsource.NewEmptyService())
+			batchrouter.Setup(context.Background(), c.mockBackendConfig, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, s3DestinationDefinition.Name, nil, c.mockMultitenantI, transientsource.NewEmptyService())
 		})
 	})
 
@@ -166,7 +167,7 @@ var _ = Describe("BatchRouter", func() {
 		It("should send failed, unprocessed jobs to s3 destination", func() {
 			batchrouter := &HandleT{}
 
-			batchrouter.Setup(c.mockBackendConfig, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, s3DestinationDefinition.Name, nil, c.mockMultitenantI, transientsource.NewEmptyService())
+			batchrouter.Setup(context.Background(), c.mockBackendConfig, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, s3DestinationDefinition.Name, nil, c.mockMultitenantI, transientsource.NewEmptyService())
 			readPerDestination = false
 			setQueryFilters()
 			batchrouter.fileManagerFactory = c.mockFileManagerFactory
@@ -229,7 +230,7 @@ var _ = Describe("BatchRouter", func() {
 			callRetry := c.mockBatchRouterJobsDB.EXPECT().GetToRetry(jobsdb.GetQueryParamsT{CustomValFilters: []string{CustomVal["S3"]}, JobsLimit: c.jobQueryBatchSize, PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: toRetryJobsList}).Times(1)
 			c.mockBatchRouterJobsDB.EXPECT().GetUnprocessed(jobsdb.GetQueryParamsT{CustomValFilters: []string{CustomVal["S3"]}, JobsLimit: c.jobQueryBatchSize - len(toRetryJobsList), PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}).Times(1).After(callRetry)
 
-			c.mockBatchRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), []string{CustomVal["S3"]}, gomock.Any()).Times(1).
+			c.mockBatchRouterJobsDB.EXPECT().UpdateJobStatus(context.Background(), gomock.Any(), []string{CustomVal["S3"]}, gomock.Any()).Times(1).
 				Do(func(statuses []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 2)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Executing.State, "", `{}`, 1)
@@ -240,13 +241,13 @@ var _ = Describe("BatchRouter", func() {
 			c.mockBatchRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(nil)
 			}).Return(nil)
-			c.mockBatchRouterJobsDB.EXPECT().UpdateJobStatusInTx(nil, gomock.Any(), []string{CustomVal["S3"]}, nil).Times(1).
+			c.mockBatchRouterJobsDB.EXPECT().UpdateJobStatusInTx(context.Background(), nil, gomock.Any(), []string{CustomVal["S3"]}, nil).Times(1).
 				Do(func(_ interface{}, statuses []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Succeeded.State, "", `{"firstAttemptedAt": "2021-06-28T15:57:30.742+05:30", "success": "OK"}`, 2)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Succeeded.State, "", `{"firstAttemptedAt": "2021-06-28T15:57:30.742+05:30, "success": "OK""}`, 1)
 				}).Return(nil)
 
-			c.mockBatchRouterJobsDB.EXPECT().JournalDeleteEntry(gomock.Any()).Times(1)
+			c.mockBatchRouterJobsDB.EXPECT().JournalDeleteEntry(context.Background(), gomock.Any()).Times(1)
 
 			<-batchrouter.backendConfigInitialized
 			batchrouter.readAndProcess()

--- a/router/batchrouter/factory.go
+++ b/router/batchrouter/factory.go
@@ -1,6 +1,8 @@
 package batchrouter
 
 import (
+	"context"
+
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/services/multitenant"
@@ -17,9 +19,9 @@ type Factory struct {
 	TransientSources transientsource.Service
 }
 
-func (f *Factory) New(destType string) *HandleT {
+func (f *Factory) New(ctx context.Context, destType string) *HandleT {
 	r := &HandleT{}
 
-	r.Setup(f.BackendConfig, f.RouterDB, f.ProcErrorDB, destType, f.Reporting, f.Multitenant, f.TransientSources)
+	r.Setup(ctx, f.BackendConfig, f.RouterDB, f.ProcErrorDB, destType, f.Reporting, f.Multitenant, f.TransientSources)
 	return r
 }

--- a/router/manager/manager.go
+++ b/router/manager/manager.go
@@ -76,8 +76,8 @@ func (r *LifecycleManager) monitorDestRouters(ctx context.Context, routerFactory
 	//rt / batch_rt tables and there would be a delay readin from channel `ch`
 	//However, this shouldn't be the problem since backend config pushes config
 	//to its subscribers in separate goroutines to prevent blocking.
-	routerFactory.RouterDB.DeleteExecuting()
-	batchrouterFactory.RouterDB.DeleteExecuting()
+	routerFactory.RouterDB.DeleteExecuting(ctx)
+	batchrouterFactory.RouterDB.DeleteExecuting(ctx)
 
 loop:
 	for {
@@ -95,7 +95,7 @@ loop:
 						_, ok := dstToBatchRouter[destination.DestinationDefinition.Name]
 						if !ok {
 							pkgLogger.Info("Starting a new Batch Destination Router ", destination.DestinationDefinition.Name)
-							brt := batchrouterFactory.New(destination.DestinationDefinition.Name)
+							brt := batchrouterFactory.New(ctx, destination.DestinationDefinition.Name)
 							brt.Start()
 							cleanup = append(cleanup, brt.Shutdown)
 							dstToBatchRouter[destination.DestinationDefinition.Name] = brt

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -220,7 +220,7 @@ var _ = Describe("Router", func() {
 			callGetAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(workspaceCount,
 				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: workspaceCount[workspaceID]}, 10).Times(1).Return(allJobs).After(callGetRouterPickupJobs)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(context.Background(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(statuses []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 1)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Executing.State, "", `{}`, 0)
@@ -237,14 +237,14 @@ var _ = Describe("Router", func() {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(context.Background(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(_ interface{}, statuses []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Succeeded.State, "200", `{"content-type":"","response": "","firstAttemptedAt":"2021-06-28T15:57:30.742+05:30"}`, 2)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Succeeded.State, "200", `{"content-type":"","response": "","firstAttemptedAt":"2021-06-28T15:57:30.742+05:30"}`, 1)
 				})
 
 			<-router.backendConfigInitialized
-			count := router.readAndProcess()
+			count := router.readAndProcess(context.Background())
 			Expect(count).To(Equal(2))
 			<-done
 			router.Shutdown()
@@ -295,7 +295,7 @@ var _ = Describe("Router", func() {
 			callGetAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(workspaceCount, jobsdb.GetQueryParamsT{
 				CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: workspaceCount[workspaceID]}, 10).Times(1).Return(unprocessedJobsList).After(callGetRouterPickupJobs)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(context.Background(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(statuses []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
 					assertJobStatus(unprocessedJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 0)
 				}).After(callGetAllJobs)
@@ -303,7 +303,7 @@ var _ = Describe("Router", func() {
 			mockNetHandle.EXPECT().SendPost(gomock.Any(), gomock.Any()).Times(1).Return(&routerUtils.SendPostResponse{StatusCode: 400, ResponseBody: []byte("")})
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-			c.mockProcErrorsDB.EXPECT().Store(gomock.Any()).Times(1).
+			c.mockProcErrorsDB.EXPECT().Store(context.Background(), gomock.Any()).Times(1).
 				Do(func(jobList []*jobsdb.JobT) {
 					job := jobList[0]
 					var parameters map[string]interface{}
@@ -324,13 +324,13 @@ var _ = Describe("Router", func() {
 				close(done)
 			}).Return(nil)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(context.Background(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(_ interface{}, statuses []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
 					assertJobStatus(unprocessedJobsList[0], statuses[0], jobsdb.Aborted.State, "400", `{"content-type":"","response":"","firstAttemptedAt":"2021-06-28T15:57:30.742+05:30"}`, 1)
 				})
 
 			<-router.backendConfigInitialized
-			count := router.readAndProcess()
+			count := router.readAndProcess(context.Background())
 			Expect(count).To(Equal(1))
 			<-done
 			router.Shutdown()
@@ -384,9 +384,9 @@ var _ = Describe("Router", func() {
 			mockMultitenantHandle.EXPECT().CalculateSuccessFailureCounts(gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any()).Times(1)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), []string{customVal["GA"]}, nil).Times(1)
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(context.Background(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1)
 
-			c.mockProcErrorsDB.EXPECT().Store(gomock.Any()).Times(1).
+			c.mockProcErrorsDB.EXPECT().Store(context.Background(), gomock.Any()).Times(1).
 				Do(func(jobList []*jobsdb.JobT) {
 					job := jobList[0]
 					var parameters map[string]interface{}
@@ -400,13 +400,13 @@ var _ = Describe("Router", func() {
 					Expect(job.UserID).To(Equal(unprocessedJobsList[0].UserID))
 				})
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(context.Background(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(drainList []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
 					assertJobStatus(unprocessedJobsList[0], drainList[0], jobsdb.Aborted.State, "", `{"reason": "job expired"}`, 0)
 				})
 
 			<-router.backendConfigInitialized
-			count := router.readAndProcess()
+			count := router.readAndProcess(context.Background())
 			Expect(count).To(Equal(0))
 		})
 	})
@@ -500,7 +500,7 @@ var _ = Describe("Router", func() {
 			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(workspaceCount, jobsdb.GetQueryParamsT{
 				CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(jobsList)}, 10).Times(1).Return(jobsList).After(callGetRouterPickupJobs)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(context.Background(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(statuses []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 1)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Executing.State, "", `{}`, 0)
@@ -548,7 +548,7 @@ var _ = Describe("Router", func() {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(context.Background(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(_ interface{}, statuses []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
 					assertTransformJobStatuses(toRetryJobsList[0], statuses[0], jobsdb.Succeeded.State, "200", 1)
 					assertTransformJobStatuses(unprocessedJobsList[0], statuses[1], jobsdb.Succeeded.State, "200", 1)
@@ -556,7 +556,7 @@ var _ = Describe("Router", func() {
 				})
 
 			<-router.backendConfigInitialized
-			count := router.readAndProcess()
+			count := router.readAndProcess(context.Background())
 			Expect(count).To(Equal(3))
 			<-done
 
@@ -640,7 +640,7 @@ var _ = Describe("Router", func() {
 				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Return(toRetryJobsList).Times(
 				1).Return(allJobs).After(callGetRouterPickupJobs)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(context.Background(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(statuses []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 1)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Executing.State, "", `{}`, 0)
@@ -700,7 +700,7 @@ var _ = Describe("Router", func() {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(context.Background(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(_ interface{}, statuses []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
 					assertTransformJobStatuses(toRetryJobsList[0], statuses[0], jobsdb.Failed.State, "500", 1)
 					assertTransformJobStatuses(unprocessedJobsList[0], statuses[1], jobsdb.Waiting.State, "", 0)
@@ -708,7 +708,7 @@ var _ = Describe("Router", func() {
 				})
 
 			<-router.backendConfigInitialized
-			count := router.readAndProcess()
+			count := router.readAndProcess(context.Background())
 			Expect(count).To(Equal(3))
 			<-done
 		})
@@ -837,7 +837,7 @@ var _ = Describe("Router", func() {
 				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Times(1).Return(allJobs).After(
 				callGetRouterPickupJobs)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(context.Background(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(statuses []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 1)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Executing.State, "", `{}`, 0)
@@ -933,10 +933,10 @@ var _ = Describe("Router", func() {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1)
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(context.Background(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1)
 
 			<-router.backendConfigInitialized
-			count := router.readAndProcess()
+			count := router.readAndProcess(context.Background())
 			Expect(count).To(Equal(5))
 			router.Shutdown()
 			<-done
@@ -1028,7 +1028,7 @@ var _ = Describe("Router", func() {
 			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(workspaceCount,
 				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Times(1).Return(allJobs).After(callGetRouterPickupJobs)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(context.Background(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(statuses []*jobsdb.JobStatusT, _ interface{}, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 1)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Executing.State, "", `{}`, 0)
@@ -1094,10 +1094,10 @@ var _ = Describe("Router", func() {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1)
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(context.Background(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1)
 
 			<-router.backendConfigInitialized
-			count := router.readAndProcess()
+			count := router.readAndProcess(context.Background())
 			Expect(count).To(Equal(3))
 			router.Shutdown()
 			<-done


### PR DESCRIPTION
# Description
Currently, when we execute any query jobsDB, we don't make it with timeout (using context) & retry. And, this sometimes leads to rudder-sever getting stuck for long time (maybe because of deadlock or any other reason). In this PR, we attempt to introduce timeout & retry for all `store` & `update` type queries of jobsDB.

## Notion Ticket

https://www.notion.so/rudderstacks/Introduce-context-in-jobsdb-Store-UpdateJobStatus-commands-6c2685d91dd04c3a87cecb252a4758b0