### PR TITLE
feat: kafka publishTime stat

### DIFF
--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -131,6 +131,7 @@ type logger interface {
 type managerStats struct {
 	missingUserID  stats.RudderStats
 	missingMessage stats.RudderStats
+	publishTime    stats.RudderStats
 }
 
 const (
@@ -149,6 +150,9 @@ var (
 
 	kafkaStats managerStats
 	pkgLogger  logger
+
+	now   = func() time.Time { return time.Now() }
+	since = func(t time.Time) time.Duration { return time.Since(t) }
 )
 
 func Init() {
@@ -187,6 +191,7 @@ func Init() {
 	kafkaStats = managerStats{
 		missingUserID:  stats.DefaultStats.NewStat("router.kafka.missing_user_id", stats.CountType),
 		missingMessage: stats.DefaultStats.NewStat("router.kafka.missing_message", stats.CountType),
+		publishTime:    stats.DefaultStats.NewStat("router.kafka.publish_time", stats.TimerType),
 	}
 }
 
@@ -454,7 +459,7 @@ func sendBatchedMessage(ctx context.Context, jsonData json.RawMessage, p produce
 		return 400, "Failure", "Error while preparing batched message: " + err.Error()
 	}
 
-	err = p.Publish(ctx, batchOfMessages...)
+	err = publish(ctx, p, batchOfMessages...)
 	if err != nil {
 		return makeErrorResponse(err) // would retry the messages in batch in case brokers are down
 	}
@@ -479,12 +484,18 @@ func sendMessage(ctx context.Context, jsonData json.RawMessage, p producer, topi
 	timestamp := time.Now()
 	userID, _ := parsedJSON.Get("userId").Value().(string)
 	message := prepareMessage(topic, userID, value, timestamp)
-	if err = p.Publish(ctx, message); err != nil {
+	if err = publish(ctx, p, message); err != nil {
 		return makeErrorResponse(err)
 	}
 
 	returnMessage := fmt.Sprintf("Message delivered to topic: %s", topic)
 	return 200, returnMessage, returnMessage
+}
+
+func publish(ctx context.Context, p producer, msgs ...client.Message) error {
+	start := now()
+	defer func() { kafkaStats.publishTime.SendTiming(since(start)) }()
+	return p.Publish(ctx, msgs...)
 }
 
 func makeErrorResponse(err error) (int, string, string) {

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -151,8 +151,8 @@ var (
 	kafkaStats managerStats
 	pkgLogger  logger
 
-	now   = func() time.Time { return time.Now() }
-	since = func(t time.Time) time.Duration { return time.Since(t) }
+	now   = func() time.Time { return time.Now() }                   // skipcq: CRT-A0018
+	since = func(t time.Time) time.Duration { return time.Since(t) } // skipcq: CRT-A0018
 )
 
 func Init() {


### PR DESCRIPTION
# Description

We need to start collecting the real publishing time to Kafka because we're seeing delivery times of ~41s despite having a timeout of 10s. The reason for this PR is that the [current router deliveryTimeStat](https://github.com/rudderlabs/rudder-server/blob/6f27f4b9cc1190949123808b5df38db544795dc6/router/router.go#L820) includes several things, and not just the `client.Publish()` time.

I started looking at having all the Segment Writer stats as exposed by the Segment underlying library but given the urgency to get the alerts right for the CFDs I'm going with the simplest approach, which is to just get this single metric for now.

## Alternatives

One alternative would be to leverage the [writer.Stats()](https://pkg.go.dev/github.com/segmentio/kafka-go#Writer.Stats) method but we would have to keep the following in mind:
1. We would need to create a polling routine that periodically calls the `writer.Stats()` method (additional complexity).
2. The `writer.Stats()` method returns a very specific `struct` so we would need to map its attributes to [our own stats types](https://github.com/rudderlabs/rudder-server/blob/6f27f4b9cc1190949123808b5df38db544795dc6/services/stats/stats.go#L17).
3. Snapshotting behaviour that adds complexity in case we were to send those metrics to Prometheus, [more here](https://github.com/segmentio/kafka-go/issues/307).
4. If we were to migrate to some other library it would be quite hard to provide the same metrics, and that would be very annoying considering that we might end up building dashboards and metrics on top of them.

Another important consideration is that the Segment library might not always honour the context as timely as one would expect. I'm saying this because the `WriteMessages` method [calls batchMessages](https://github.com/segmentio/kafka-go/blob/v0.4.31/writer.go#L651) without propagating the context, and we know that `batchMessages` [is using a mutex](https://github.com/segmentio/kafka-go/blob/v0.4.31/writer.go#L689) inside. The mutex could potentially lock for longer than the context deadline. So for now I'd like to avoid relying also on their stats and get some data on our own before deciding what's next.

_Also the mutex issue described above, or some other issue internal to Segment, could very well be the reason why we see 41s with a 10s timeout, so I think it's best if we measure it our way for now._

## Notion Ticket

[< Notion Link >](https://www.notion.so/rudderstacks/Add-more-precise-metrics-to-Kafka-manager-3a07a78f21924e129d61b2cb1f0aa37a)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
