### PR TITLE
feat(router): use a circuit breaker while producing custom destination clients

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/segmentio/kafka-go v0.4.31
 	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546
 	github.com/snowflakedb/gosnowflake v1.6.3
+	github.com/sony/gobreaker v0.5.0
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/viper v1.8.0
@@ -67,6 +68,7 @@ require (
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
+
 )
 
 replace github.com/segmentio/kafka-go => github.com/fracasula/kafka-go v0.4.32-0.20220509075905-7ccc623033ba

--- a/go.sum
+++ b/go.sum
@@ -1211,6 +1211,8 @@ github.com/snowflakedb/gosnowflake v1.6.3 h1:EJDdDi74YbYt1ty164ge3fMZ0eVZ6KA7b1z
 github.com/snowflakedb/gosnowflake v1.6.3/go.mod h1:6hLajn6yxuJ4xUHZegMekpq9rnQbGJ7TMwXjgTmA6lg=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
+github.com/sony/gobreaker v0.5.0 h1:dRCvqm0P490vZPmy7ppEk2qCnCieBooFJ+YoXGYB+yg=
+github.com/sony/gobreaker v0.5.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/router/customdestinationmanager/customdestinationmanager.go
+++ b/router/customdestinationmanager/customdestinationmanager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
+	"github.com/sony/gobreaker"
 )
 
 const (
@@ -24,12 +25,13 @@ const (
 )
 
 var (
-	ObjectStreamDestinations []string
-	KVStoreDestinations      []string
-	Destinations             []string
-	customManagerMap         map[string]*CustomManagerT
-	pkgLogger                logger.LoggerI
-	disableEgress            bool
+	ObjectStreamDestinations    []string
+	KVStoreDestinations         []string
+	Destinations                []string
+	customManagerMap            map[string]*CustomManagerT
+	pkgLogger                   logger.LoggerI
+	disableEgress               bool
+	skipBackendConfigSubscriber bool
 )
 
 // DestinationManager implements the method to send the events to custom destinations
@@ -39,19 +41,26 @@ type DestinationManager interface {
 
 // CustomManagerT handles this module
 type CustomManagerT struct {
-	destType             string
-	managerType          string
-	destinationsMap      map[string]*CustomDestination
-	destinationLockMap   map[string]*sync.RWMutex
-	latestConfig         map[string]backendconfig.DestinationT
-	configSubscriberLock sync.RWMutex
-	timeout              time.Duration
+	destType       string
+	managerType    string
+	mapLock        sync.RWMutex
+	clientLock     map[string]*sync.RWMutex
+	client         map[string]*clientHolder
+	config         map[string]backendconfig.DestinationT
+	breaker        map[string]breakerHolder
+	timeout        time.Duration
+	breakerTimeout time.Duration
 }
 
-//CustomDestination keeps the config of a destination and corresponding producer for a stream destination
-type CustomDestination struct {
-	Config interface{}
-	Client interface{}
+//clientHolder keeps the config of a destination and corresponding producer for a stream destination
+type clientHolder struct {
+	config interface{}
+	client interface{}
+}
+
+type breakerHolder struct {
+	config  map[string]interface{}
+	breaker *gobreaker.CircuitBreaker
 }
 
 func Init() {
@@ -70,33 +79,36 @@ func loadConfig() {
 // newClient delegates the call to the appropriate manager
 func (customManager *CustomManagerT) newClient(destID string) error {
 
-	destConfig := customManager.latestConfig[destID].Config
-	var customDestination *CustomDestination
-	var err error
+	destConfig := customManager.config[destID].Config
+	_, err := customManager.breaker[destID].breaker.Execute(func() (interface{}, error) {
+		var customDestination *clientHolder
+		var err error
 
-	switch customManager.managerType {
-	case STREAM:
-		var producer interface{}
-		producer, err = streammanager.NewProducer(destConfig, customManager.destType, streammanager.Opts{
-			Timeout: customManager.timeout,
-		})
-		if err == nil {
-			customDestination = &CustomDestination{
-				Config: destConfig,
-				Client: producer,
+		switch customManager.managerType {
+		case STREAM:
+			var producer interface{}
+			producer, err = streammanager.NewProducer(destConfig, customManager.destType, streammanager.Opts{
+				Timeout: customManager.timeout,
+			})
+			if err == nil {
+				customDestination = &clientHolder{
+					config: destConfig,
+					client: producer,
+				}
+				customManager.client[destID] = customDestination
 			}
-			customManager.destinationsMap[destID] = customDestination
+		case KV:
+			kvManager := kvstoremanager.New(customManager.destType, destConfig)
+			customDestination = &clientHolder{
+				config: destConfig,
+				client: kvManager,
+			}
+			customManager.client[destID] = customDestination
+		default:
+			return nil, fmt.Errorf("No provider configured for Custom Destination Manager")
 		}
-	case KV:
-		kvManager := kvstoremanager.New(customManager.destType, destConfig)
-		customDestination = &CustomDestination{
-			Config: destConfig,
-			Client: kvManager,
-		}
-		customManager.destinationsMap[destID] = customDestination
-	default:
-		return fmt.Errorf("No provider configured for Custom Destination Manager")
-	}
+		return nil, err
+	})
 	return err
 }
 
@@ -128,42 +140,45 @@ func (customManager *CustomManagerT) SendData(jsonData json.RawMessage, destID s
 		return 200, `200: outgoing disabled`
 	}
 
-	customManager.configSubscriberLock.RLock()
-	destLock, ok := customManager.destinationLockMap[destID]
-	customManager.configSubscriberLock.RUnlock()
+	customManager.mapLock.RLock()
+	clientLock, ok := customManager.clientLock[destID]
+	customManager.mapLock.RUnlock()
 	if !ok {
 		return 500, fmt.Sprintf("[CDM %s] Unexpected state: Lock missing for %s. Config might not have been updated. Please wait for a min before sending events.", customManager.destType, destID)
 	}
 
-	destLock.RLock()
-	customDestination, ok := customManager.destinationsMap[destID]
+	clientLock.RLock()
+	customDestination, ok := customManager.client[destID]
 
 	if !ok {
-		destLock.RUnlock()
-		destLock.Lock()
-		err := customManager.newClient(destID)
-		destLock.Unlock()
+		clientLock.RUnlock()
+		clientLock.Lock()
+		var err error
+		if _, ok := customManager.client[destID]; !ok {
+			err = customManager.newClient(destID)
+		}
+		clientLock.Unlock()
 		if err != nil {
 			return 400, fmt.Sprintf("[CDM %s] Unable to create client for %s %s", customManager.destType, destID, err.Error())
 		}
-		destLock.RLock()
-		customDestination = customManager.destinationsMap[destID]
+		clientLock.RLock()
+		customDestination = customManager.client[destID]
 	}
-	destLock.RUnlock()
+	clientLock.RUnlock()
 
-	respStatusCode, respBody := customManager.send(jsonData, customManager.destType, customDestination.Client, customDestination.Config)
+	respStatusCode, respBody := customManager.send(jsonData, customManager.destType, customDestination.client, customDestination.config)
 
 	if respStatusCode == CLIENT_EXPIRED_CODE {
-		destLock.Lock()
+		clientLock.Lock()
 		err := customManager.refreshClient(destID)
-		destLock.Unlock()
+		clientLock.Unlock()
 		if err != nil {
 			return 400, fmt.Sprintf("[CDM %s] Unable to refresh client for %s %s", customManager.destType, destID, err.Error())
 		}
-		destLock.RLock()
-		customDestination = customManager.destinationsMap[destID]
-		destLock.RUnlock()
-		respStatusCode, respBody = customManager.send(jsonData, customManager.destType, customDestination.Client, customDestination.Config)
+		clientLock.RLock()
+		customDestination = customManager.client[destID]
+		clientLock.RUnlock()
+		respStatusCode, respBody = customManager.send(jsonData, customManager.destType, customDestination.client, customDestination.config)
 	}
 
 	return respStatusCode, respBody
@@ -171,28 +186,28 @@ func (customManager *CustomManagerT) SendData(jsonData json.RawMessage, destID s
 
 func (customManager *CustomManagerT) close(destination backendconfig.DestinationT) {
 	destID := destination.ID
-	customDestination := customManager.destinationsMap[destID]
+	customDestination := customManager.client[destID]
 	switch customManager.managerType {
 	case STREAM:
-		_ = streammanager.CloseProducer(customDestination.Client, customManager.destType)
+		_ = streammanager.CloseProducer(customDestination.client, customManager.destType)
 	case KV:
-		kvManager, _ := customDestination.Client.(kvstoremanager.KVStoreManager)
+		kvManager, _ := customDestination.client.(kvstoremanager.KVStoreManager)
 		kvManager.Close()
 	}
-	delete(customManager.destinationsMap, destID)
+	delete(customManager.client, destID)
 }
 
 func (customManager *CustomManagerT) refreshClient(destID string) error {
-	customDestination, ok := customManager.destinationsMap[destID]
+	customDestination, ok := customManager.client[destID]
 
 	if ok {
 
 		pkgLogger.Infof("[CDM %s] [Token Expired] Closing Existing client for destination id: %s", customManager.destType, destID)
 		switch customManager.managerType {
 		case STREAM:
-			_ = streammanager.CloseProducer(customDestination.Client, customManager.destType)
+			_ = streammanager.CloseProducer(customDestination.client, customManager.destType)
 		case KV:
-			kvManager, _ := customDestination.Client.(kvstoremanager.KVStoreManager)
+			kvManager, _ := customDestination.client.(kvstoremanager.KVStoreManager)
 			kvManager.Close()
 		}
 	}
@@ -205,24 +220,44 @@ func (customManager *CustomManagerT) refreshClient(destID string) error {
 	return nil
 }
 
+func (customManager *CustomManagerT) onNewDestination(destination backendconfig.DestinationT) error {
+	var err error
+	clientLock, ok := customManager.clientLock[destination.ID]
+	if !ok {
+		clientLock = &sync.RWMutex{}
+		customManager.clientLock[destination.ID] = clientLock
+	}
+	clientLock.Lock()
+	defer clientLock.Unlock()
+	customManager.config[destination.ID] = destination
+	err = customManager.onConfigChange(destination)
+	return err
+}
 func (customManager *CustomManagerT) onConfigChange(destination backendconfig.DestinationT) error {
 	newDestConfig := destination.Config
-	customDestination, ok := customManager.destinationsMap[destination.ID]
-
-	if ok {
+	_, hasOpenClient := customManager.client[destination.ID]
+	breaker, hasCircuitBreaker := customManager.breaker[destination.ID]
+	if hasCircuitBreaker {
 		hasDestConfigChanged := !reflect.DeepEqual(
-			customManager.genComparisonConfig(customDestination.Config),
+			customManager.genComparisonConfig(breaker.config),
 			customManager.genComparisonConfig(newDestConfig),
 		)
 
 		if !hasDestConfigChanged {
 			return nil
 		}
-
-		pkgLogger.Infof("[CDM %s] Config changed. Closing Existing client for destination: %s", customManager.destType, destination.Name)
-		customManager.close(destination)
+		if hasOpenClient {
+			pkgLogger.Infof("[CDM %s] Config changed. Closing Existing client for destination: %s", customManager.destType, destination.Name)
+			customManager.close(destination)
+		}
 	}
-
+	customManager.breaker[destination.ID] = breakerHolder{
+		config: newDestConfig,
+		breaker: gobreaker.NewCircuitBreaker(gobreaker.Settings{
+			Name:    destination.ID,
+			Timeout: customManager.breakerTimeout,
+		}),
+	}
 	if err := customManager.newClient(destination.ID); err != nil {
 		pkgLogger.Errorf("[CDM %s] DestID: %s, Error while creating new customer client: %v", customManager.destType, destination.ID, err)
 		return err
@@ -250,16 +285,20 @@ func New(destType string, o Opts) DestinationManager {
 		}
 
 		customManager = &CustomManagerT{
-			timeout:            o.Timeout,
-			destType:           destType,
-			managerType:        managerType,
-			destinationsMap:    make(map[string]*CustomDestination),
-			destinationLockMap: make(map[string]*sync.RWMutex),
-			latestConfig:       make(map[string]backendconfig.DestinationT),
+			timeout:     o.Timeout,
+			destType:    destType,
+			managerType: managerType,
+			client:      make(map[string]*clientHolder),
+			clientLock:  make(map[string]*sync.RWMutex),
+			config:      make(map[string]backendconfig.DestinationT),
+			breaker:     make(map[string]breakerHolder),
 		}
-		rruntime.Go(func() {
-			customManager.backendConfigSubscriber()
-		})
+		if !skipBackendConfigSubscriber {
+			rruntime.Go(func() {
+				customManager.backendConfigSubscriber()
+			})
+		}
+
 		return customManager
 	}
 
@@ -271,24 +310,16 @@ func (customManager *CustomManagerT) backendConfigSubscriber() {
 	backendconfig.Subscribe(ch, "backendConfig")
 	for {
 		config := <-ch
-		customManager.configSubscriberLock.Lock()
+		customManager.mapLock.Lock()
 		allSources := config.Data.(backendconfig.ConfigT)
 		for _, source := range allSources.Sources {
 			for _, destination := range source.Destinations {
 				if destination.DestinationDefinition.Name == customManager.destType {
-					destLock, ok := customManager.destinationLockMap[destination.ID]
-					if !ok {
-						destLock = &sync.RWMutex{}
-						customManager.destinationLockMap[destination.ID] = destLock
-					}
-					destLock.Lock()
-					customManager.latestConfig[destination.ID] = destination
-					_ = customManager.onConfigChange(destination)
-					destLock.Unlock()
+					_ = customManager.onNewDestination(destination)
 				}
 			}
 		}
-		customManager.configSubscriberLock.Unlock()
+		customManager.mapLock.Unlock()
 	}
 }
 

--- a/router/customdestinationmanager/customdestinationmanager_test.go
+++ b/router/customdestinationmanager/customdestinationmanager_test.go
@@ -71,7 +71,7 @@ func TestCircuitBreaker(t *testing.T) {
 	newClientAttempt(t, manager, dest.ID, count, breakerError)
 }
 
-func newDestination(t *testing.T, manager *CustomManagerT, dest backendconfig.DestinationT, attempt int, errorString string) {
+func newDestination(t *testing.T, manager *CustomManagerT, dest backendconfig.DestinationT, attempt int, errorString string) { // skipcq: CRT-P0003
 	err := manager.onNewDestination(dest)
 	assert.EqualError(t, err, errorString, fmt.Sprintf("wrong error for attempt no %d", attempt))
 }

--- a/router/customdestinationmanager/customdestinationmanager_test.go
+++ b/router/customdestinationmanager/customdestinationmanager_test.go
@@ -46,13 +46,14 @@ func TestCircuitBreaker(t *testing.T) {
 	// after the 6th failed attempt the circuit opens
 	newClientAttempt(t, manager, dest.ID, count, breakerError)
 	count++
-	time.Sleep(breakerTimeout)
-	// after a timeout the circuit becomes half-open
+	<-time.After(breakerTimeout)
+	// after the circuit breaker's timeout passes the circuit becomes half-open
 	newClientAttempt(t, manager, dest.ID, count, normalError)
 	count++
 	// after another failure the circuit opens again
 	newClientAttempt(t, manager, dest.ID, count, breakerError)
 	count++
+
 	// sending the same destination again should not try to create a client
 	assert.Nil(t, manager.onNewDestination(dest))
 	// and shouldn't reset the circuit breaker either

--- a/router/customdestinationmanager/customdestinationmanager_test.go
+++ b/router/customdestinationmanager/customdestinationmanager_test.go
@@ -1,0 +1,100 @@
+package customdestinationmanager
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/config"
+	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
+	"github.com/rudderlabs/rudder-server/services/stats"
+	"github.com/rudderlabs/rudder-server/services/streammanager/kafka"
+	"github.com/rudderlabs/rudder-server/utils/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCircuitBreaker(t *testing.T) {
+	const (
+		normalError  = "could not ping: could not dial tcp/unknown.example.com:9999: failed to dial: failed to open connection to unknown.example.com:9999: dial tcp: lookup unknown.example.com: no such host"
+		breakerError = "circuit breaker is open"
+	)
+
+	// init various packages
+	config.Load()
+	Init()
+	logger.Init()
+	stats.Setup()
+	kafka.Init()
+
+	// don't let manager subscribe to backend-config
+	skipBackendConfigSubscriber = true
+
+	// set a custom circuit breaker timeout (default is 60 seconds)
+	breakerTimeout := 1 * time.Second
+
+	manager := New("KAFKA", Opts{Timeout: 1 * time.Microsecond}).(*CustomManagerT)
+	manager.breakerTimeout = breakerTimeout
+
+	dest := getDestConfig()
+	// during the first 6 failed attempts the circuit is closed
+	count := 1
+	newDestination(t, manager, dest, count, normalError)
+	count++
+	for ; count <= 6; count++ {
+		newClientAttempt(t, manager, dest.ID, count, normalError)
+	}
+	// after the 6th failed attempt the circuit opens
+	newClientAttempt(t, manager, dest.ID, count, breakerError)
+	count++
+	time.Sleep(breakerTimeout)
+	// after a timeout the circuit becomes half-open
+	newClientAttempt(t, manager, dest.ID, count, normalError)
+	count++
+	// after another failure the circuit opens again
+	newClientAttempt(t, manager, dest.ID, count, breakerError)
+	count++
+	// sending the same destination again should not try to create a client
+	assert.Nil(t, manager.onNewDestination(dest))
+	// and shouldn't reset the circuit breaker either
+	newClientAttempt(t, manager, dest.ID, count, breakerError)
+
+	// sending a modified destination should reset the circuit breaker
+	dest = getDestConfig()
+	dest.Config["modified"] = true
+	count = 1
+	newDestination(t, manager, dest, count, normalError)
+	count++
+	for ; count <= 6; count++ {
+		newClientAttempt(t, manager, dest.ID, count, normalError)
+	}
+	// after the 6th attempt the new circuit opens
+	newClientAttempt(t, manager, dest.ID, count, breakerError)
+}
+
+func newDestination(t *testing.T, manager *CustomManagerT, dest backendconfig.DestinationT, attempt int, errorString string) {
+	err := manager.onNewDestination(dest)
+	assert.EqualError(t, err, errorString, fmt.Sprintf("wrong error for attempt no %d", attempt))
+}
+func newClientAttempt(t *testing.T, manager *CustomManagerT, destId string, attempt int, errorString string) {
+	err := manager.newClient(destId)
+	assert.EqualError(t, err, errorString, fmt.Sprintf("wrong error for attempt no %d", attempt))
+}
+
+func getDestConfig() backendconfig.DestinationT {
+	return backendconfig.DestinationT{
+		ID:   "test",
+		Name: "test",
+		Config: map[string]interface{}{
+			"hostName":      "unknown.example.com",
+			"port":          "9999",
+			"topic":         "topic",
+			"sslEnabled":    true,
+			"useSASL":       true,
+			"caCertificate": "",
+			"saslType":      "plain",
+			"username":      "username",
+			"password":      "password",
+		},
+		Enabled: true,
+	}
+}


### PR DESCRIPTION
# Description

In case of wrong configuration, clients are not being created successfully and their creation is being retried on every new event that arrives at the router.
Any delay in client creation causes cascading delays, since there can be multiple workers for the same destination, all of them waiting their turn to acquire a lock so that they can try to create the missing client introducing additional delays for the next workers in the queue.

For that reason we are introducing a circuit breaker in the client creation process. If the system fails to create a client for 6 consecutive times, it will stop trying (immediately returning an error) for the next 60 seconds. After this timeout, it will try once, if it fails again the circuit will reopen for another 60 seconds etc.

## Notion Ticket

[Use a circuit breaker while producing router custom destination clients](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=1f01380bf8364347993dbcfbdad5bebc)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
