### PR TITLE
fix(warehouse): use correct locks for dateformat in processor

### DIFF
--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -949,24 +949,28 @@ func GetFullPrefix(manager filemanager.FileManager, prefix string) (fullPrefix s
 	return
 }
 
-func isDateFormatExists(connIdentifier string) bool {
+func getDateFormat(connIdentifier string) (dateFormat string, exists bool) {
 	dateFormatMapLock.RLock()
 	defer dateFormatMapLock.RUnlock()
-	_, ok := dateFormatMap[connIdentifier]
-	return ok
+	dateFormat, exists = dateFormatMap[connIdentifier]
+	return
+}
+
+func setDateFormat(connIdentifier, dateFormat string) {
+	dateFormatMapLock.Lock()
+	defer dateFormatMapLock.Unlock()
+	dateFormatMap[connIdentifier] = dateFormat
 }
 
 func GetStorageDateFormat(manager filemanager.FileManager, destination *DestinationT, folderName string) (dateFormat string, err error) {
 	connIdentifier := connectionIdentifier(DestinationT{Destination: destination.Destination, Source: destination.Source})
-	if isDateFormatExists(connIdentifier) {
-		return dateFormatMap[connIdentifier], err
+	if format, exists := getDateFormat(connIdentifier); exists {
+		return format, err
 	}
 
 	defer func() {
 		if err == nil {
-			dateFormatMapLock.RLock()
-			defer dateFormatMapLock.RUnlock()
-			dateFormatMap[connIdentifier] = dateFormat
+			setDateFormat(connIdentifier, dateFormat)
 		}
 	}()
 

--- a/router/batchrouter/batchrouterBenchmark_test.go
+++ b/router/batchrouter/batchrouterBenchmark_test.go
@@ -1,10 +1,12 @@
 package batchrouter
 
 import (
+	"github.com/gofrs/uuid"
 	"github.com/golang/mock/gomock"
 	"github.com/rudderlabs/rudder-server/config"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	mocksFileManager "github.com/rudderlabs/rudder-server/mocks/services/filemanager"
+	"strings"
 	"testing"
 )
 
@@ -15,21 +17,24 @@ func Benchmark_GetStorageDateFormat(b *testing.B) {
 	mockCtrl := gomock.NewController(b)
 	mockFileManager := mocksFileManager.NewMockFileManager(mockCtrl)
 	destination := &DestinationT{
-		Source: backendconfig.SourceT{
-			ID: "sourceID",
-		},
-		Destination: backendconfig.DestinationT{
-			ID: "destinationID",
-		},
+		Source:      backendconfig.SourceT{},
+		Destination: backendconfig.DestinationT{},
 	}
 	folderName := ""
 
 	b.SetParallelism(2)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
+			destination.Destination.ID = randomString()
+			destination.Source.ID = randomString()
+
 			mockFileManager.EXPECT().GetConfiguredPrefix().AnyTimes()
 			mockFileManager.EXPECT().ListFilesWithPrefix(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			_, _ = GetStorageDateFormat(mockFileManager, destination, folderName)
 		}
 	})
+}
+
+func randomString() string {
+	return strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")
 }

--- a/router/batchrouter/batchrouterBenchmark_test.go
+++ b/router/batchrouter/batchrouterBenchmark_test.go
@@ -1,0 +1,35 @@
+package batchrouter
+
+import (
+	"github.com/golang/mock/gomock"
+	"github.com/rudderlabs/rudder-server/config"
+	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
+	mocksFileManager "github.com/rudderlabs/rudder-server/mocks/services/filemanager"
+	"testing"
+)
+
+func Benchmark_GetStorageDateFormat(b *testing.B) {
+	config.Load()
+	Init()
+
+	mockCtrl := gomock.NewController(b)
+	mockFileManager := mocksFileManager.NewMockFileManager(mockCtrl)
+	destination := &DestinationT{
+		Source: backendconfig.SourceT{
+			ID: "sourceID",
+		},
+		Destination: backendconfig.DestinationT{
+			ID: "destinationID",
+		},
+	}
+	folderName := ""
+
+	b.SetParallelism(2)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			mockFileManager.EXPECT().GetConfiguredPrefix().AnyTimes()
+			mockFileManager.EXPECT().ListFilesWithPrefix(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			_, _ = GetStorageDateFormat(mockFileManager, destination, folderName)
+		}
+	})
+}


### PR DESCRIPTION
# Description

Concurrent map writes fix for getting storage date format

## Notion Ticket

https://www.notion.so/rudderstacks/Adhoc-Instamart-concurrent-map-issue-b78f52924ee44d6fb41b872df934747a

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
