### PR TITLE
chore: add rudder-transformer in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage.txt
 coverage.html
 *.orig
 build/wait-for-go/wait-for-go
+rudder-transformer

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "rudder-transformer"]
 	path = rudder-transformer
 	url = git@github.com:rudderlabs/rudder-transformer.git
+	ignore = dirty


### PR DESCRIPTION
# Description

Ignoring rudder-transformer submodule from local & PR diffs

## Notion Ticket

[add rudder-transformer in .gitignore](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=28412e0913934cc3bc54d65e18f24f64) 

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
