### PR TITLE
fix(warehouse): columns need to be provided during copy command for deltalake

### DIFF
--- a/warehouse/deltalake/deltalake.go
+++ b/warehouse/deltalake/deltalake.go
@@ -429,7 +429,7 @@ func (dl *HandleT) sortedColumnNames(tableSchemaInUpload warehouseutils.TableSch
 		formatString := warehouseutils.JoinWithFormatting(sortedColumnKeys, format, ",")
 		if len(diff.ColumnMap) > 0 {
 			diffCols := make([]string, 0, len(diff.ColumnMap))
-			for key, _ := range diff.ColumnMap {
+			for key := range diff.ColumnMap {
 				diffCols = append(diffCols, key)
 			}
 			diffFormat := func(index int, value string) string {

--- a/warehouse/deltalake/deltalake.go
+++ b/warehouse/deltalake/deltalake.go
@@ -415,7 +415,7 @@ func (dl *HandleT) dropStagingTables(tableNames []string) {
 }
 
 // sortedColumnNames returns sorted column names
-func (dl *HandleT) sortedColumnNames(tableSchemaInUpload warehouseutils.TableSchemaT, sortedColumnKeys []string) (sortedColumnNames string) {
+func (dl *HandleT) sortedColumnNames(tableSchemaInUpload warehouseutils.TableSchemaT, sortedColumnKeys []string, diff warehouseutils.TableSchemaDiffT) (sortedColumnNames string) {
 	if dl.Uploader.GetLoadFileType() == warehouseutils.LOAD_FILE_TYPE_PARQUET {
 		sortedColumnNames = strings.Join(sortedColumnKeys[:], ",")
 	} else {
@@ -426,7 +426,19 @@ func (dl *HandleT) sortedColumnNames(tableSchemaInUpload warehouseutils.TableSch
 			columnType := getDeltaLakeDataType(tableSchemaInUpload[columnName])
 			return fmt.Sprintf(`CAST ( %s AS %s ) AS %s`, csvColumnIndex, columnType, columnName)
 		}
-		return warehouseutils.JoinWithFormatting(sortedColumnKeys, format, ",")
+		formatString := warehouseutils.JoinWithFormatting(sortedColumnKeys, format, ",")
+		if len(diff.ColumnMap) > 0 {
+			diffCols := make([]string, 0, len(diff.ColumnMap))
+			for key, _ := range diff.ColumnMap {
+				diffCols = append(diffCols, key)
+			}
+			diffFormat := func(index int, value string) string {
+				return fmt.Sprintf(`NULL AS %s`, value)
+			}
+			diffString := warehouseutils.JoinWithFormatting(diffCols, diffFormat, ",")
+			return fmt.Sprintf("%s, %s", formatString, diffString)
+		}
+		return formatString
 	}
 	return
 }
@@ -466,6 +478,19 @@ func (dl *HandleT) getLoadFolder(tableName string, location string) (loadFolder 
 	return
 }
 
+func getTableSchemaDiff(tableSchemaInUpload, tableSchemaAfterUpload warehouseutils.TableSchemaT) (diff warehouseutils.TableSchemaDiffT) {
+	diff = warehouseutils.TableSchemaDiffT{
+		ColumnMap: make(map[string]string),
+	}
+	diff.ColumnMap = make(map[string]string)
+	for columnName, columnType := range tableSchemaAfterUpload {
+		if _, ok := tableSchemaInUpload[columnName]; !ok {
+			diff.ColumnMap[columnName] = columnType
+		}
+	}
+	return diff
+}
+
 // loadTable Loads table with table name
 func (dl *HandleT) loadTable(tableName string, tableSchemaInUpload warehouseutils.TableSchemaT, tableSchemaAfterUpload warehouseutils.TableSchemaT, skipTempTableDelete bool) (stagingTableName string, err error) {
 	// Getting sorted column keys from tableSchemaInUpload
@@ -501,7 +526,8 @@ func (dl *HandleT) loadTable(tableName string, tableSchemaInUpload warehouseutil
 	}
 
 	// Creating copy sql statement to copy from load folder to the staging table
-	var sortedColumnNames = dl.sortedColumnNames(tableSchemaInUpload, sortedColumnKeys)
+	var tableSchemaDiff = getTableSchemaDiff(tableSchemaInUpload, tableSchemaAfterUpload)
+	var sortedColumnNames = dl.sortedColumnNames(tableSchemaInUpload, sortedColumnKeys, tableSchemaDiff)
 	var sqlStatement string
 	if dl.Uploader.GetLoadFileType() == warehouseutils.LOAD_FILE_TYPE_PARQUET {
 		sqlStatement = fmt.Sprintf("COPY INTO %v FROM ( SELECT %v FROM '%v' ) "+


### PR DESCRIPTION
# Description

Handle extra columns when creating COPY command for deltalake destination because since we are using auto generated columns we are forced to do it.
Added corresponding integration test at [here](https://github.com/rudderlabs/rudder-server/blob/959c850294365c4a6a798d7baa17fdff278caa1e/warehouse/deltalake/deltalake_test.go).

## Notion Ticket

https://www.notion.so/rudderstacks/Adhoc-Deltalake-columns-issue-8c10aa27a58a422dbcf2495c072fd076

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
