### PR TITLE
fix(warehouse): dsiable reporting setup for slave

### DIFF
--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"os"
 	"runtime"
 	"sort"
 	"strconv"
@@ -87,8 +88,8 @@ var (
 )
 
 var (
-	host, user, password, dbname, sslmode string
-	port                                  int
+	host, user, password, dbname, sslmode, appName string
+	port                                           int
 )
 
 // warehouses worker modes
@@ -180,6 +181,7 @@ func loadConfig() {
 	config.RegisterBoolConfigVariable(false, &skipDeepEqualSchemas, true, "Warehouse.skipDeepEqualSchemas")
 	config.RegisterIntConfigVariable(8, &maxParallelJobCreation, true, 1, "Warehouse.maxParallelJobCreation")
 	config.RegisterBoolConfigVariable(false, &enableJitterForSyncs, true, "Warehouse.enableJitterForSyncs")
+	appName = misc.DefaultString("rudder-server").OnError(os.Hostname())
 }
 
 // get name of the worker (`destID_namespace`) to be stored in map wh.workerChannelMap
@@ -1610,8 +1612,8 @@ func getConnectionString() string {
 		return jobsdb.GetConnectionString()
 	}
 	return fmt.Sprintf("host=%s port=%d user=%s "+
-		"password=%s dbname=%s sslmode=%s",
-		host, port, user, password, dbname, sslmode)
+		"password=%s dbname=%s sslmode=%s application_name=%s",
+		host, port, user, password, dbname, sslmode, appName)
 }
 
 func startWebHandler(ctx context.Context) error {


### PR DESCRIPTION
# Description

Reporting should only be done by Warehouse Master and should not be setup for slave

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=fbc420fced1d47499f7e9d4d6252cdd4) 

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
