### PR TITLE
chore: fix release please action parameters

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -14,7 +14,9 @@ jobs:
         id: extract_branch
       - uses: google-github-actions/release-please-action@v3
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GH_PAT }}
           release-type: go
-          package-name: lean-realeaser
+          package-name: rudder-server
           default-branch: ${{ steps.extract_branch.outputs.branch }}
+          bump-minor-pre-major: true
+          bump-patch-pre-minor: true


### PR DESCRIPTION
# Description

Some fixes in relation to this [PR](https://github.com/rudderlabs/rudder-server/pull/2009):
* Use `bump-minor-pre-major` and `bump-patch-pre-minor` to avoid a 1.0.0 release 
* Use `secrets.GH_PAT` as token to use a github bot instead of sivashanmukh 

## Notion Ticket

[Notion link](https://www.notion.so/rudderstacks/release-2-0-for-oss-images-c26b66dbf5ef4bc69f250cc287d26657)
## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
