### PR TITLE
feat: integration tags

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - name: Integration test
-      run: go test -v ./docker_test.go -integration -count 1
+      run: go test -v ./docker_test.go -slow -tags=integration -count 1
       env:
         RSERVER_ENABLE_MULTITENANCY: false
         BIGQUERY_INTEGRATION_TEST_USER_CRED: ${{ secrets.BIGQUERY_INTEGRATION_TEST_USER_CRED }}
@@ -62,7 +62,7 @@ jobs:
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: make enterprise-init
     - name: Integration test
-      run: go test -v ./docker_test.go -integration -count 1
+      run: go test -v ./docker_test.go -slow -tags=integration -count 1
       env:
         RSERVER_ENABLE_MULTITENANCY: ${{ matrix.MULTITENANCY }}
         BIGQUERY_INTEGRATION_TEST_USER_CRED: ${{ secrets.BIGQUERY_INTEGRATION_TEST_USER_CRED }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ enterprise
 *.coverprofile
 junit*.xml
 **/profile.out
+**/*.test
 .idea/*
 build/regulation-worker
 *.out.*

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,11 @@ mocks: install-tools ## Generate all mocks
 
 test: enterprise-prepare-build mocks ## Run all unit tests
 ifdef package
-	$(GINKGO) -p --randomize-all --randomize-suites --fail-on-pending --cover -coverprofile=profile.out -covermode=atomic --trace -keep-separate-coverprofiles $(package)
+	$(GINKGO) -p --randomize-all --randomize-suites --fail-on-pending --cover -tags=integration \
+		-coverprofile=profile.out -covermode=atomic --trace -keep-separate-coverprofiles $(package)
 else
-	$(GINKGO) -p --randomize-all --randomize-suites --fail-on-pending --cover -coverprofile=profile.out -covermode=atomic --trace -keep-separate-coverprofiles ./...
+	$(GINKGO) -p --randomize-all --randomize-suites --fail-on-pending --cover -tags=integration \
+		-coverprofile=profile.out -covermode=atomic --trace -keep-separate-coverprofiles ./...
 endif
 	echo "mode: atomic" > coverage.txt
 	find . -name "profile.out" | while read file;do grep -v 'mode: atomic' $${file} >> coverage.txt; rm $${file};done

--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package cluster_test
 
 import (

--- a/build/buildspec.docker.master.yml
+++ b/build/buildspec.docker.master.yml
@@ -47,7 +47,7 @@ phases:
       # Build Enterprise version
       - make enterprise-init
       - make test
-      - go test -v ./docker_test.go -integration -count 1
+      - go test -v ./docker_test.go -slow -tags=integration -count 1
       - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - docker build -t rudderstack/rudder-server-enterprise:$VERSION -f build/Dockerfile-aws .
   post_build:

--- a/build/buildspec.pr.yml
+++ b/build/buildspec.pr.yml
@@ -42,7 +42,7 @@ phases:
       - echo Build started on `date`
       - echo Building the Docker image...
       - make test
-      - go test -v ./docker_test.go -integration -count 1
+      - go test -v ./docker_test.go -slow -tags=integration -count 1
       - bash build/codecov.sh
       - TAG=$(echo $CODEBUILD_WEBHOOK_HEAD_REF | sed 's/refs\/heads\///g' | tr "/" .)
       - echo tag.. $TAG
@@ -57,7 +57,7 @@ phases:
       # Build Enterprise version
       - make enterprise-init
       - make test
-      - go test -v ./docker_test.go -integration -count 1
+      - go test -v ./docker_test.go -slow -tags=integration -count 1
       - GOOS=linux GOARCH=amd64 CGO_ENABLED=1 RACE_ENABLED=TRUE LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 LDFLAGS="-s -w -X main.version=$VERSION -X main.commit=$CODEBUILD_RESOLVED_SOURCE_VERSION -X main.buildDate=$DATE -X main.builtBy=codebuild-$CODEBUILD_BUILD_ID " make build
       - docker build -t rudderstack/develop-rudder-server-enterprise:$VERSION -f build/Dockerfile-aws-dev .

--- a/docker_test.go
+++ b/docker_test.go
@@ -3,6 +3,8 @@
 // It then runs the service ensuring it is configured to use the dependencies.
 // Finally, it sends events and observe the destinations expecting to get the events back.
 
+//go:build integration
+
 package main_test
 
 import (
@@ -61,7 +63,7 @@ var (
 	disableDestinationWebhookURL string
 	webhook                      *WebhookRecorder
 	disableDestinationWebhook    *WebhookRecorder
-	runIntegration               bool
+	runSlow                      bool
 	overrideArm64Check           bool
 	writeKey                     string
 	workspaceID                  string
@@ -288,12 +290,12 @@ func TestMain(m *testing.M) {
 	}
 
 	flag.BoolVar(&hold, "hold", false, "hold environment clean-up after test execution until Ctrl+C is provided")
-	flag.BoolVar(&runIntegration, "integration", false, "run integration level tests")
+	flag.BoolVar(&runSlow, "slow", false, "run slow tests")
 	flag.BoolVar(&runBigQueryTest, "bigqueryintegration", false, "run big query test")
 	flag.Parse()
 
-	if !runIntegration {
-		log.Println("Skipping integration test. Use `-integration` to run them.")
+	if !runSlow {
+		log.Println("Skipping tests. Use `-slow` to run them.")
 		return
 	}
 

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package jobsdb_test
 
 import (

--- a/jobsdb/jobsdb_renameDs_test.go
+++ b/jobsdb/jobsdb_renameDs_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package jobsdb
 
 import (
@@ -14,7 +16,6 @@ import (
 
 func Test_mustRenameDS(t *testing.T) {
 	withPostgreSQL(t, func(postgresql *destination.PostgresResource) {
-
 		// Given I have a jobsdb with dropSourceIds prebackup handler for 2 sources
 		dbHandle := postgresql.DB
 		jobsdb := &HandleT{
@@ -51,7 +52,6 @@ func Test_mustRenameDS(t *testing.T) {
 
 }
 func Test_mustRenameDS_drops_table_if_left_empty(t *testing.T) {
-
 	withPostgreSQL(t, func(postgresql *destination.PostgresResource) {
 		dbHandle := postgresql.DB
 

--- a/jobsdb/jobsdb_suite_test.go
+++ b/jobsdb/jobsdb_suite_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package jobsdb_test
 
 import (

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package jobsdb
 
 import (
@@ -11,15 +13,15 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/gofrs/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
+
 	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/config"
 	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
 	"github.com/rudderlabs/rudder-server/services/stats"
 	"github.com/rudderlabs/rudder-server/utils/logger"
-	"github.com/stretchr/testify/require"
 )
 
 var _ = Describe("Calculate newDSIdx for internal migrations", func() {
@@ -306,14 +308,6 @@ var _ = Describe("Calculate newDSIdx for cluster migrations", func() {
 		),
 	)
 })
-
-var sampleTestJob = JobT{
-	Parameters:   []byte(`{"batch_id":1,"source_id":"sourceID","source_job_run_id":""}`),
-	EventPayload: []byte(`{"receivedAt":"2021-06-06T20:26:39.598+05:30","writeKey":"writeKey","requestIP":"[::1]",  "batch": [{"anonymousId":"anon_id","channel":"android-sdk","context":{"app":{"build":"1","name":"RudderAndroidClient","namespace":"com.rudderlabs.android.sdk","version":"1.0"},"device":{"id":"49e4bdd1c280bc00","manufacturer":"Google","model":"Android SDK built for x86","name":"generic_x86"},"library":{"name":"com.rudderstack.android.sdk.core"},"locale":"en-US","network":{"carrier":"Android"},"screen":{"density":420,"height":1794,"width":1080},"traits":{"anonymousId":"49e4bdd1c280bc00"},"user_agent":"Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.075)"},"event":"Demo Track","integrations":{"All":true},"messageId":"b96f3d8a-7c26-4329-9671-4e3202f42f15","originalTimestamp":"2019-08-12T05:08:30.909Z","properties":{"category":"Demo Category","floatVal":4.501,"label":"Demo Label","testArray":[{"id":"elem1","value":"e1"},{"id":"elem2","value":"e2"}],"testMap":{"t1":"a","t2":4},"value":5},"rudderId":"a-292e-4e79-9880-f8009e0ae4a3","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}]}`),
-	UserID:       "a-292e-4e79-9880-f8009e0ae4a3",
-	UUID:         uuid.Must(uuid.NewV4()),
-	CustomVal:    "MOCKDS",
-}
 
 func initJobsDB() {
 	config.Load()

--- a/jobsdb/readonly_jobsdb_test.go
+++ b/jobsdb/readonly_jobsdb_test.go
@@ -1,12 +1,12 @@
+//go:build integration
+
 package jobsdb
 
 import (
-	"fmt"
-
-	uuid "github.com/gofrs/uuid"
+	"github.com/gofrs/uuid"
 	. "github.com/onsi/ginkgo/v2"
-
 	. "github.com/onsi/gomega"
+
 	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/config"
 	"github.com/rudderlabs/rudder-server/services/stats"
@@ -87,16 +87,4 @@ var userJobs = []*JobT{
 		UUID:         uuid.Must(uuid.NewV4()),
 		CustomVal:    "MOCKDS",
 	},
-}
-
-var jobsForUser = func() string {
-	var userJobList string
-	for _, userjob := range userJobs {
-		userJobList += fmt.Sprint(userjob.JobID) + "\n"
-	}
-	return userJobList
-}
-
-var jobsForUser2 = func() string {
-	return fmt.Sprint(userJobs[len(userJobs)-1].JobID) + "\n"
 }

--- a/jobsdb/unionQuery_test.go
+++ b/jobsdb/unionQuery_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package jobsdb
 
 import (


### PR DESCRIPTION
# Description

I'm adding the possibility to run unit tests without the burden of bootstrapping containers that are setup just because in the same package we have a `TestMain` that is creating them.

Here I'm proposing to differentiate between the two by using build tags.

Additionally, I added a `slow` CLI argument to for `docker_test.go`.

## Example

At the moment we cannot run [these](https://github.com/rudderlabs/rudder-server/blob/10913e65702f26e5e4ab591d072a15dd4ea0e64d/app/cluster/dynamic_test.go) unit tests without also executing the `TestMain` from [here](https://github.com/rudderlabs/rudder-server/blob/10913e65702f26e5e4ab591d072a15dd4ea0e64d/app/cluster/integration_test.go#L50).

## Additional notes

If you like the approach I can add the tag to all tests that are using Docker.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
