### PR TITLE
chore: make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,3 +75,8 @@ enterprise-is-at-master: ## Checks if enterprise repo commit matches the origin 
 install-tools:
 	go install github.com/golang/mock/mockgen@v1.6.0 || \
 	GO111MODULE=on go install github.com/golang/mock/mockgen@v1.6.0
+
+.PHONY: lint
+lint:
+	docker run --rm -v $(shell pwd):/app:ro -w /app golangci/golangci-lint:v1.46.2 bash -e -c \
+		'golangci-lint run -v --timeout 5m'


### PR DESCRIPTION
# Description

Adding `make` recipe to run `golangci-lint` locally. I'm using Docker so that we don't have to do weird `go install`s or use the `.ONESHELL` in the Makefile given how certain GNU systems handle shells in Makefiles.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
