### PR TITLE
chore: removing TestMain from docker_test.go

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
     - name: Integration test
-      run: go test -v ./docker_test.go -slow -tags=integration -count 1
+      run: SLOW=1 go test -v ./docker_test.go -tags=integration -count 1
       env:
         RSERVER_ENABLE_MULTITENANCY: false
         BIGQUERY_INTEGRATION_TEST_USER_CRED: ${{ secrets.BIGQUERY_INTEGRATION_TEST_USER_CRED }}
@@ -62,7 +62,7 @@ jobs:
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: make enterprise-init
     - name: Integration test
-      run: go test -v ./docker_test.go -slow -tags=integration -count 1
+      run: SLOW=1 go test -v ./docker_test.go -tags=integration -count 1
       env:
         RSERVER_ENABLE_MULTITENANCY: ${{ matrix.MULTITENANCY }}
         BIGQUERY_INTEGRATION_TEST_USER_CRED: ${{ secrets.BIGQUERY_INTEGRATION_TEST_USER_CRED }}

--- a/docker_test.go
+++ b/docker_test.go
@@ -14,7 +14,6 @@ import (
 	"database/sql"
 	b64 "encoding/base64"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -33,27 +32,25 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/rudderlabs/rudder-server/utils/types/deployment"
-
 	"github.com/gofrs/uuid"
 	redigo "github.com/gomodule/redigo/redis"
 	"github.com/joho/godotenv"
 	_ "github.com/lib/pq"
 	"github.com/ory/dockertest/v3"
 	"github.com/phayes/freeport"
-	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
 	main "github.com/rudderlabs/rudder-server"
 	"github.com/rudderlabs/rudder-server/config"
-	kafkaclient "github.com/rudderlabs/rudder-server/services/streammanager/kafka/client"
+	kafkaClient "github.com/rudderlabs/rudder-server/services/streammanager/kafka/client"
 	"github.com/rudderlabs/rudder-server/services/streammanager/kafka/client/testutil"
-	"github.com/rudderlabs/rudder-server/testhelper"
 	"github.com/rudderlabs/rudder-server/testhelper/destination"
 	wht "github.com/rudderlabs/rudder-server/testhelper/warehouse"
 	"github.com/rudderlabs/rudder-server/utils/logger"
+	"github.com/rudderlabs/rudder-server/utils/types/deployment"
 	bq "github.com/rudderlabs/rudder-server/warehouse/bigquery"
 	"github.com/rudderlabs/rudder-server/warehouse/client"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -68,11 +65,11 @@ var (
 	overrideArm64Check           bool
 	writeKey                     string
 	workspaceID                  string
-	KafkaContainer               *destination.KafkaResource
-	RedisContainer               *destination.RedisResource
-	PostgresContainer            *destination.PostgresResource
-	TransformerContainer         *destination.TransformerResource
-	MINIOContainer               *destination.MINIOResource
+	kafkaContainer               *destination.KafkaResource
+	redisContainer               *destination.RedisResource
+	postgresContainer            *destination.PostgresResource
+	transformerContainer         *destination.TransformerResource
+	minioContainer               *destination.MINIOResource
 	EventID                      string
 	VersionID                    string
 	runBigQueryTest              bool
@@ -123,9 +120,8 @@ func (whr *WebhookRecorder) Requests() []*http.Request {
 func (whr *WebhookRecorder) Close() {
 	whr.Server.Close()
 }
-
 func randString(n int) string {
-	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
 	s := make([]rune, n)
 	for i := range s {
@@ -202,10 +198,10 @@ func blockOnHold() {
 
 	<-c
 }
-
-func GetEvent(url, method string) (string, error) {
+func GetEvent(url string, method string) (string, error) {
 	httpClient := &http.Client{}
 	req, err := http.NewRequest(method, url, nil)
+
 	if err != nil {
 		return "", err
 	}
@@ -247,12 +243,13 @@ func SendPixelEvents(writeKey string) {
 	}
 }
 
-func SendEvent(payload *strings.Reader, callType, writeKey string) {
+func SendEvent(payload *strings.Reader, callType string, writeKey string) {
 	log.Println(fmt.Sprintf("Sending %s Event", callType))
 	url := fmt.Sprintf("http://localhost:%s/v1/%s", httpPort, callType)
 	method := "POST"
 	httpClient := &http.Client{}
 	req, err := http.NewRequest(method, url, payload)
+
 	if err != nil {
 		log.Println(err)
 		return
@@ -285,99 +282,671 @@ func SendEvent(payload *strings.Reader, callType, writeKey string) {
 	log.Println("Event Sent Successfully")
 }
 
-func TestMain(m *testing.M) {
+func TestMainFlow(t *testing.T) {
+	runSlow = config.GetEnvAsBool("SLOW", false)
+	if !runSlow {
+		t.Skip("Skipping tests. Use 'SLOW=1' env var to run them.")
+	}
+
+	hold = config.GetEnvAsBool("HOLD", false)
+	runBigQueryTest = config.GetEnvAsBool("BIGQUERYINTEGRATION", false)
 	if os.Getenv("OVERRIDE_ARM64_CHECK") == "1" {
 		overrideArm64Check = true
 	}
 
-	flag.BoolVar(&hold, "hold", false, "hold environment clean-up after test execution until Ctrl+C is provided")
-	flag.BoolVar(&runSlow, "slow", false, "run slow tests")
-	flag.BoolVar(&runBigQueryTest, "bigqueryintegration", false, "run big query test")
-	flag.Parse()
-
-	if !runSlow {
-		log.Println("Skipping tests. Use `-slow` to run them.")
-		return
-	}
-
-	// hack to make defer work, without being affected by the os.Exit in TestMain
-	exitCode, err := run(m)
-	if err != nil {
-		log.Fatal(err)
-	}
-	os.Exit(exitCode)
-}
-
-func run(m *testing.M) (int, error) {
-	setupStart := time.Now()
-
 	var tearDownStart time.Time
 	defer func() {
 		if tearDownStart == (time.Time{}) {
-			fmt.Printf("--- Teardown done (unexpected)\n")
+			t.Log("--- Teardown done (unexpected)")
 		} else {
-			fmt.Printf("--- Teardown done (%s)\n", time.Since(tearDownStart))
+			t.Logf("--- Teardown done (%s)", time.Since(tearDownStart))
 		}
 	}()
+
+	svcCtx, svcCancel := context.WithCancel(context.Background())
+	svcDone := setupMainFlow(svcCtx, t)
+
+	t.Run("webhook", func(t *testing.T) {
+		var err error
+		require.Empty(t, webhook.Requests(), "webhook should have no request before sending the event")
+		payload1 := strings.NewReader(`{
+			"userId": "identified_user_id",
+			"anonymousId":"anonymousId_1",
+			"messageId":"messageId_1",
+			"type": "identify",
+			"eventOrderNo":"1",
+			"context": {
+			  "traits": {
+				 "trait1": "new-val"
+			  },
+			  "ip": "14.5.67.21",
+			  "library": {
+				  "name": "http"
+			  }
+			},
+			"timestamp": "2020-02-02T00:23:09.544Z"
+		  }`)
+		SendEvent(payload1, "identify", writeKey)
+		payload2 := strings.NewReader(`{
+			"userId": "identified_user_id",
+			"anonymousId":"anonymousId_1",
+			"messageId":"messageId_1",
+			"type": "identify",
+			"eventOrderNo":"2",
+			"context": {
+			  "traits": {
+				 "trait1": "new-val"
+			  },
+			  "ip": "14.5.67.21",
+			  "library": {
+				  "name": "http"
+			  }
+			},
+			"timestamp": "2020-02-02T00:23:09.544Z"
+		  }`)
+		SendEvent(payload2, "identify", writeKey) //sending duplicate event to check dedup
+
+		// Sending Batch event
+		payloadBatch := strings.NewReader(`{
+			"batch":
+			[
+				{
+					"userId": "identified_user_id",
+					"anonymousId": "anonymousId_1",
+					"type": "identify",
+					"context":
+					{
+						"traits":
+						{
+							"trait1": "new-val"
+						},
+						"ip": "14.5.67.21",
+						"library":
+						{
+							"name": "http"
+						}
+					},
+					"timestamp": "2020-02-02T00:23:09.544Z"
+				}
+			]
+		}`)
+		SendEvent(payloadBatch, "batch", writeKey)
+
+		// Sending track event
+		payloadTrack := strings.NewReader(`{
+			"userId": "identified_user_id",
+			"anonymousId":"anonymousId_1",
+			"messageId":"messageId_1",
+			"type": "track",
+			"event": "Product Reviewed",
+			"properties": {
+			  "review_id": "12345",
+			  "product_id" : "123",
+			  "rating" : 3.0,
+			  "review_body" : "Average product, expected much more."
+			}
+		  }`)
+		SendEvent(payloadTrack, "track", writeKey)
+
+		// Sending page event
+		payloadPage := strings.NewReader(`{
+			"userId": "identified_user_id",
+			"anonymousId":"anonymousId_1",
+			"messageId":"messageId_1",
+			"type": "page",
+			"name": "Home",
+			"properties": {
+			  "title": "Home | RudderStack",
+			  "url": "http://www.rudderstack.com"
+			}
+		  }`)
+		SendEvent(payloadPage, "page", writeKey)
+
+		// Sending screen event
+		payloadScreen := strings.NewReader(`{
+			"userId": "identified_user_id",
+			"anonymousId":"anonymousId_1",
+			"messageId":"messageId_1",
+			"type": "screen",
+			"name": "Main",
+			"properties": {
+			  "prop_key": "prop_value"
+			}
+		  }`)
+		SendEvent(payloadScreen, "screen", writeKey)
+
+		// Sending alias event
+		payloadAlias := strings.NewReader(`{
+			"userId": "identified_user_id",
+			"anonymousId":"anonymousId_1",
+			"messageId":"messageId_1",
+			"type": "alias",
+			"previousId": "name@surname.com",
+			"userId": "12345"
+		  }`)
+		SendEvent(payloadAlias, "alias", writeKey)
+
+		// Sending group event
+		payloadGroup := strings.NewReader(`{
+			"userId": "identified_user_id",
+			"anonymousId":"anonymousId_1",
+			"messageId":"messageId_1",
+			"type": "group",
+			"groupId": "12345",
+			"traits": {
+			  "name": "MyGroup",
+			  "industry": "IT",
+			  "employees": 450,
+			  "plan": "basic"
+			}
+		  }`)
+		SendEvent(payloadGroup, "group", writeKey)
+		SendPixelEvents(writeKey)
+
+		require.Eventually(t, func() bool {
+			return len(webhook.Requests()) == 10
+		}, time.Minute, 30*time.Millisecond)
+
+		i := -1
+		require.Eventually(t, func() bool {
+			i = i + 1
+			req := webhook.Requests()[i]
+			body, _ := io.ReadAll(req.Body)
+			return gjson.GetBytes(body, "anonymousId").Str == "anonymousId_1"
+		}, time.Minute, 10*time.Millisecond)
+
+		req := webhook.Requests()[i]
+		body, err := io.ReadAll(req.Body)
+
+		require.NoError(t, err)
+		require.Equal(t, "POST", req.Method)
+		require.Equal(t, "/", req.URL.Path)
+		require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+		require.Equal(t, "RudderLabs", req.Header.Get("User-Agent"))
+
+		require.Equal(t, gjson.GetBytes(body, "anonymousId").Str, "anonymousId_1")
+		require.Equal(t, gjson.GetBytes(body, "messageId").Str, "messageId_1")
+		require.Equal(t, gjson.GetBytes(body, "eventOrderNo").Str, "1")
+		require.Equal(t, gjson.GetBytes(body, "userId").Str, "identified_user_id")
+		require.Equal(t, gjson.GetBytes(body, "rudderId").Str, "e4cab80e-2f0e-4fa2-87e0-3a4af182634c")
+		require.Equal(t, gjson.GetBytes(body, "type").Str, "identify")
+		// Verify User Transformation
+		require.Equal(t, gjson.GetBytes(body, "myuniqueid").Str, "identified_user_idanonymousId_1")
+		require.Equal(t, gjson.GetBytes(body, "context.myuniqueid").Str, "identified_user_idanonymousId_1")
+		require.Equal(t, gjson.GetBytes(body, "context.id").Str, "0.0.0.0")
+		require.Equal(t, gjson.GetBytes(body, "context.ip").Str, "0.0.0.0")
+
+		// Verify Disabled destination doesn't receive any event.
+		require.Equal(t, 0, len(disableDestinationWebhook.Requests()))
+	})
+
+	t.Run("postgres", func(t *testing.T) {
+		var myEvent Event
+		require.Eventually(t, func() bool {
+			eventSql := "select anonymous_id, user_id from dev_integration_test_1.identifies limit 1"
+			_ = db.QueryRow(eventSql).Scan(&myEvent.anonymousID, &myEvent.userID)
+			return myEvent.anonymousID == "anonymousId_1"
+		}, time.Minute, 10*time.Millisecond)
+		eventSql := "select count(*) from dev_integration_test_1.identifies"
+		_ = db.QueryRow(eventSql).Scan(&myEvent.count)
+		require.Equal(t, myEvent.count, "2")
+
+		// Verify User Transformation
+		eventSql = "select context_myuniqueid,context_id,context_ip from dev_integration_test_1.identifies"
+		_ = db.QueryRow(eventSql).Scan(&myEvent.contextMyUniqueID, &myEvent.contextID, &myEvent.contextIP)
+		require.Equal(t, myEvent.contextMyUniqueID, "identified_user_idanonymousId_1")
+		require.Equal(t, myEvent.contextID, "0.0.0.0")
+		require.Equal(t, myEvent.contextIP, "0.0.0.0")
+
+		require.Eventually(t, func() bool {
+			eventSql := "select anonymous_id, user_id from dev_integration_test_1.users limit 1"
+			_ = db.QueryRow(eventSql).Scan(&myEvent.anonymousID, &myEvent.userID)
+			return myEvent.anonymousID == "anonymousId_1"
+		}, time.Minute, 10*time.Millisecond)
+
+		require.Eventually(t, func() bool {
+			eventSql = "select count(*) from dev_integration_test_1.users"
+			_ = db.QueryRow(eventSql).Scan(&myEvent.count)
+			return myEvent.count == "1"
+		}, time.Minute, 10*time.Millisecond)
+
+		// Verify User Transformation
+		eventSql = "select context_myuniqueid,context_id,context_ip from dev_integration_test_1.users "
+		_ = db.QueryRow(eventSql).Scan(&myEvent.contextMyUniqueID, &myEvent.contextID, &myEvent.contextIP)
+		require.Equal(t, myEvent.contextMyUniqueID, "identified_user_idanonymousId_1")
+		require.Equal(t, myEvent.contextID, "0.0.0.0")
+		require.Equal(t, myEvent.contextIP, "0.0.0.0")
+
+		require.Eventually(t, func() bool {
+			eventSql := "select anonymous_id, user_id from dev_integration_test_1.screens limit 1"
+			_ = db.QueryRow(eventSql).Scan(&myEvent.anonymousID, &myEvent.userID)
+			return myEvent.anonymousID == "anonymousId_1"
+		}, time.Minute, 10*time.Millisecond)
+		require.Eventually(t, func() bool {
+			eventSql = "select count(*) from dev_integration_test_1.screens"
+			_ = db.QueryRow(eventSql).Scan(&myEvent.count)
+			return myEvent.count == "1"
+		}, time.Minute, 10*time.Millisecond)
+
+		// Verify User Transformation
+		require.Eventually(t, func() bool {
+			eventSql = "select prop_key,myuniqueid,ip from dev_integration_test_1.screens;"
+			_ = db.QueryRow(eventSql).Scan(&myEvent.propKey, &myEvent.myUniqueID, &myEvent.ip)
+			return myEvent.myUniqueID == "identified_user_idanonymousId_1"
+		}, time.Minute, 10*time.Millisecond)
+
+		require.Equal(t, myEvent.propKey, "prop_value_edited")
+		require.Equal(t, myEvent.ip, "0.0.0.0")
+	})
+
+	t.Run("redis", func(t *testing.T) {
+		conn, err := redigo.Dial("tcp", redisContainer.RedisAddress)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+		require.Eventually(t, func() bool {
+			// Similarly, get the trait1 and convert it to a string.
+			event, _ := redigo.String(conn.Do("HGET", "user:identified_user_id", "trait1"))
+			return event == "new-val"
+		}, time.Minute, 10*time.Millisecond)
+	})
+
+	t.Run("kafka", func(t *testing.T) {
+		if runtime.GOARCH == "arm64" && !overrideArm64Check {
+			t.Skip("arm64 is not supported yet")
+		}
+
+		kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
+
+		// Create new consumer
+		tc := testutil.New("tcp", kafkaHost)
+		topics, err := tc.ListTopics(context.TODO())
+		require.NoError(t, err)
+
+		c, err := kafkaClient.New("tcp", []string{kafkaHost}, kafkaClient.Config{})
+		require.NoError(t, err)
+
+		messages, errors := consume(t, c, topics)
+
+		signals := make(chan os.Signal, 1)
+		signal.Notify(signals, os.Interrupt)
+
+		// Count how many message processed
+		msgCount := 0
+		// Get signal for finish
+		expectedCount := 10
+	out:
+		for {
+			select {
+			case msg := <-messages:
+				msgCount++
+				require.Equal(t, "identified_user_id", string(msg.Key))
+				require.Contains(t, string(msg.Value), "identified_user_id")
+
+				if msgCount == expectedCount {
+					break out
+				}
+			case consumerError := <-errors:
+				msgCount++
+				t.Log("Received consumerError", consumerError)
+			case <-time.After(time.Minute):
+				t.Error("timeout waiting on Kafka message")
+			}
+		}
+
+		t.Log("Processed", msgCount, "messages")
+	})
+
+	t.Run("event-models", func(t *testing.T) {
+		// GET /schemas/event-models
+		url := fmt.Sprintf("http://localhost:%s/schemas/event-models", httpPort)
+		method := "GET"
+		resBody, _ := GetEvent(url, method)
+		require.Eventually(t, func() bool {
+			// Similarly, pole until the Event Schema Tables are updated
+			resBody, _ = GetEvent(url, method)
+			return resBody != "[]"
+		}, time.Minute, 10*time.Millisecond)
+		require.NotEqual(t, resBody, "[]")
+		b := []byte(resBody)
+		var eventSchemas []eventSchemasObject
+
+		err := json.Unmarshal(b, &eventSchemas)
+		if err != nil {
+			log.Println(err)
+		}
+		for k := range eventSchemas {
+			if eventSchemas[k].EventType == "page" {
+				EventID = eventSchemas[k].EventID
+			}
+		}
+		require.NotEqual(t, EventID, "")
+	})
+
+	t.Run("event-versions", func(t *testing.T) {
+		// GET /schemas/event-versions
+		url := fmt.Sprintf("http://localhost:%s/schemas/event-versions?EventID=%s", httpPort, EventID)
+		method := "GET"
+		resBody, _ := GetEvent(url, method)
+		require.Contains(t, resBody, EventID)
+
+		b := []byte(resBody)
+		var eventSchemas []eventSchemasObject
+
+		err := json.Unmarshal(b, &eventSchemas)
+		if err != nil {
+			log.Println(err)
+		}
+		VersionID = eventSchemas[0].VersionID
+		log.Println("Test Schemas Event ID's VersionID: ", VersionID)
+	})
+
+	t.Run("event-model-key-counts", func(t *testing.T) {
+		// GET schemas/event-model/{EventID}/key-counts
+		url := fmt.Sprintf("http://localhost:%s/schemas/event-model/%s/key-counts", httpPort, EventID)
+		method := "GET"
+		resBody, _ := GetEvent(url, method)
+		require.Contains(t, resBody, "messageId")
+	})
+
+	t.Run("event-model-metadata", func(t *testing.T) {
+		// GET /schemas/event-model/{EventID}/metadata
+		url := fmt.Sprintf("http://localhost:%s/schemas/event-model/%s/metadata", httpPort, EventID)
+		method := "GET"
+		resBody, _ := GetEvent(url, method)
+		require.Contains(t, resBody, "messageId")
+	})
+
+	t.Run("event-version-metadata", func(t *testing.T) {
+		// GET /schemas/event-version/{VersionID}/metadata
+		url := fmt.Sprintf("http://localhost:%s/schemas/event-version/%s/metadata", httpPort, VersionID)
+		method := "GET"
+		resBody, _ := GetEvent(url, method)
+		require.Contains(t, resBody, "messageId")
+	})
+
+	t.Run("event-version-missing-keys", func(t *testing.T) {
+		// GET /schemas/event-version/{VersionID}/metadata
+		url := fmt.Sprintf("http://localhost:%s/schemas/event-version/%s/missing-keys", httpPort, VersionID)
+		method := "GET"
+		resBody, _ := GetEvent(url, method)
+		require.Contains(t, resBody, "originalTimestamp")
+		require.Contains(t, resBody, "sentAt")
+		require.Contains(t, resBody, "channel")
+		require.Contains(t, resBody, "integrations.All")
+	})
+
+	t.Run("event-models-json-schemas", func(t *testing.T) {
+		// GET /schemas/event-models/json-schemas
+		url := fmt.Sprintf("http://localhost:%s/schemas/event-models/json-schemas", httpPort)
+		method := "GET"
+		resBody, _ := GetEvent(url, method)
+		require.Eventually(t, func() bool {
+			// Similarly, pole until the Event Schema Tables are updated
+			resBody, _ = GetEvent(url, method)
+			return resBody != "[]"
+		}, time.Minute, 10*time.Millisecond)
+		require.NotEqual(t, resBody, "[]")
+	})
+
+	t.Run("beacon-batch", func(t *testing.T) {
+		payload := strings.NewReader(`{
+			"batch":[
+				{
+				   "userId": "identified_user_id",
+				   "anonymousId":"anonymousId_1",
+				   "messageId":"messageId_1"
+				}
+			]
+		}`)
+		SendEvent(payload, "beacon/v1/batch", writeKey)
+	})
+
+	t.Run("warehouse-postgres-destination", func(t *testing.T) {
+		pgTest := wht.Test.PGTest
+
+		whDestTest := &wht.WareHouseDestinationTest{
+			Client: &client.Client{
+				SQL:  pgTest.DB,
+				Type: client.SQLClient,
+			},
+			EventsCountMap:     pgTest.EventsMap,
+			WriteKey:           pgTest.WriteKey,
+			UserId:             "userId_postgres",
+			Schema:             "postgres_wh_integration",
+			TableTestQueryFreq: pgTest.TableTestQueryFreq,
+		}
+		sendWHEvents(whDestTest)
+		whDestinationTest(t, whDestTest)
+
+		whDestTest.UserId = "userId_postgres_1"
+		sendUpdatedWHEvents(whDestTest)
+		whDestinationTest(t, whDestTest)
+	})
+
+	t.Run("warehouse-clickhouse-destination", func(t *testing.T) {
+		chTest := wht.Test.CHTest
+
+		whDestTest := &wht.WareHouseDestinationTest{
+			Client: &client.Client{
+				SQL:  chTest.DB,
+				Type: client.SQLClient,
+			},
+			EventsCountMap:     chTest.EventsMap,
+			WriteKey:           chTest.WriteKey,
+			UserId:             "userId_clickhouse",
+			Schema:             "rudderdb",
+			TableTestQueryFreq: chTest.TableTestQueryFreq,
+		}
+		sendWHEvents(whDestTest)
+		whDestinationTest(t, whDestTest)
+
+		whDestTest.UserId = "userId_clickhouse_1"
+		sendUpdatedWHEvents(whDestTest)
+		whDestinationTest(t, whDestTest)
+	})
+
+	t.Run("warehouse-clickhouse-cluster-destination", func(t *testing.T) {
+		chClusterTest := wht.Test.CHClusterTest
+
+		whDestTest := &wht.WareHouseDestinationTest{
+			Client: &client.Client{
+				SQL:  chClusterTest.GetResource().DB,
+				Type: client.SQLClient,
+			},
+			EventsCountMap:     chClusterTest.EventsMap,
+			WriteKey:           chClusterTest.WriteKey,
+			UserId:             "userId_clickhouse_cluster",
+			Schema:             "rudderdb",
+			TableTestQueryFreq: chClusterTest.TableTestQueryFreq,
+		}
+		sendWHEvents(whDestTest)
+		whDestinationTest(t, whDestTest)
+
+		initWHClickHouseClusterModeSetup(t)
+
+		whDestTest.UserId = "userId_clickhouse_cluster_1"
+		sendUpdatedWHEvents(whDestTest)
+
+		// Update events count Map
+		// This is required as because of the cluster mode setup and distributed view, events are getting duplicated.
+		whDestTest.EventsCountMap = wht.EventsCountMap{
+			"identifies":    2,
+			"users":         2,
+			"tracks":        2,
+			"product_track": 2,
+			"pages":         2,
+			"screens":       2,
+			"aliases":       2,
+			"groups":        2,
+			"gateway":       6,
+			"batchRT":       8,
+		}
+		whDestinationTest(t, whDestTest)
+	})
+
+	t.Run("warehouse-bigquery", func(t *testing.T) {
+		if runBigQueryTest == false {
+			t.Skip("Big query integration skipped. use -bigqueryintegration to add this test ")
+
+		}
+		if wht.Test.BQTest == nil {
+			fmt.Println("Error in ENV variable BIGQUERY_INTEGRATION_TEST_USER_CRED")
+			t.FailNow()
+		}
+		//Disabling big query dedup
+		config.SetBool("Warehouse.bigquery.isDedupEnabled", false)
+		bq.Init()
+		bqTest := wht.Test.BQTest
+		randomness := strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")
+
+		whDestTest := &wht.WareHouseDestinationTest{
+			Client: &client.Client{
+				BQ:   bqTest.DB,
+				Type: client.BQClient,
+			},
+			EventsCountMap:     bqTest.EventsMap,
+			WriteKey:           bqTest.WriteKey,
+			UserId:             fmt.Sprintf("userId_bq_%s", randomness),
+			Schema:             "rudderstack_sample_http_source",
+			BQContext:          bqTest.Context,
+			Tables:             bqTest.Tables,
+			PrimaryKeys:        bqTest.PrimaryKeys,
+			TableTestQueryFreq: bqTest.TableTestQueryFreq,
+		}
+
+		whDestTest.MessageId = uuid.Must(uuid.NewV4()).String()
+
+		whDestTest.EventsCountMap = wht.EventsCountMap{
+			"identifies": 2,
+			"tracks":     2,
+			"pages":      2,
+			"screens":    2,
+			"aliases":    2,
+			"groups":     2,
+		}
+		sendWHEvents(whDestTest)
+
+		whDestTest.EventsCountMap = wht.EventsCountMap{
+			"identifies":    2,
+			"users":         1,
+			"tracks":        2,
+			"product_track": 2,
+			"pages":         2,
+			"screens":       2,
+			"aliases":       2,
+			"_groups":       2,
+			"gateway":       12,
+			"batchRT":       16,
+		}
+
+		whDestinationTest(t, whDestTest)
+		//Enabling big query dedup
+		config.SetBool("Warehouse.bigquery.isDedupEnabled", true)
+		bq.Init()
+
+		whDestTest.EventsCountMap = wht.EventsCountMap{
+			"identifies": 2,
+			"tracks":     2,
+			"pages":      2,
+			"screens":    2,
+			"aliases":    2,
+			"groups":     2,
+		}
+
+		sendWHEvents(whDestTest)
+
+		whDestTest.EventsCountMap = wht.EventsCountMap{
+			"identifies":    2,
+			"users":         1,
+			"tracks":        2,
+			"product_track": 2,
+			"pages":         2,
+			"screens":       2,
+			"aliases":       2,
+			"_groups":       2,
+			"gateway":       24,
+			"batchRT":       32,
+		}
+
+		whDestinationTest(t, whDestTest)
+	})
+
+	t.Run("warehouse-mssql-destination", func(t *testing.T) {
+		msSqlTest := wht.Test.MSSQLTest
+
+		whDestTest := &wht.WareHouseDestinationTest{
+			Client: &client.Client{
+				SQL:  msSqlTest.DB,
+				Type: client.SQLClient,
+			},
+			EventsCountMap:     msSqlTest.EventsMap,
+			WriteKey:           msSqlTest.WriteKey,
+			UserId:             "userId_mssql",
+			Schema:             "mssql_wh_integration",
+			TableTestQueryFreq: msSqlTest.TableTestQueryFreq,
+		}
+		sendWHEvents(whDestTest)
+		whDestinationTest(t, whDestTest)
+
+		whDestTest.UserId = "userId_mssql_1"
+		sendUpdatedWHEvents(whDestTest)
+		whDestinationTest(t, whDestTest)
+	})
+
+	blockOnHold()
+	svcCancel()
+	t.Log("Waiting for service to stop")
+	<-svcDone
+
+	tearDownStart = time.Now()
+}
+
+func setupMainFlow(svcCtx context.Context, t *testing.T) <-chan struct{} {
+	setupStart := time.Now()
 
 	config.Load()
 	logger.Init()
 
 	// uses a sensible default on windows (tcp/http) and linux/osx (socket)
 	pool, err := dockertest.NewPool("")
-	if err != nil {
-		return 0, fmt.Errorf("could not connect to docker: %w", err)
-	}
-
-	cleanup := &testhelper.Cleanup{}
-	defer cleanup.Run()
+	require.NoError(t, err)
 
 	if runtime.GOARCH != "arm64" || overrideArm64Check {
-		KafkaContainer, err = destination.SetupKafka(pool, cleanup,
+		kafkaContainer, err = destination.SetupKafka(pool, t,
 			destination.WithLogger(&testLogger{logger.NewLogger().Child("kafka")}),
 			destination.WithBrokers(3),
 		)
-		if err != nil {
-			return 0, fmt.Errorf("setup Kafka Destination container: %w", err)
-		}
+		require.NoError(t, err)
 	}
 
-	RedisContainer, err = destination.SetupRedis(pool, cleanup)
-	if err != nil {
-		return 0, fmt.Errorf("setup Redis Destination container: %w", err)
-	}
+	redisContainer, err = destination.SetupRedis(pool, t)
+	require.NoError(t, err)
 
-	PostgresContainer, err = destination.SetupPostgres(pool, cleanup)
-	if err != nil {
-		return 0, fmt.Errorf("setup Postgres Destination container: %w", err)
-	}
-	db = PostgresContainer.DB
+	postgresContainer, err = destination.SetupPostgres(pool, t)
+	require.NoError(t, err)
+	db = postgresContainer.DB
 
-	TransformerContainer, err = destination.SetupTransformer(pool, cleanup)
-	if err != nil {
-		return 0, fmt.Errorf("setup Transformer container : %w", err)
-	}
+	transformerContainer, err = destination.SetupTransformer(pool, t)
+	require.NoError(t, err)
 
 	waitUntilReady(
 		context.Background(),
-		fmt.Sprintf("%s/health", TransformerContainer.TransformURL),
+		fmt.Sprintf("%s/health", transformerContainer.TransformURL),
 		time.Minute,
 		time.Second,
 		"transformer",
 	)
 
-	MINIOContainer, err = destination.SetupMINIO(pool, cleanup)
-	if err != nil {
-		return 0, fmt.Errorf("setup MINIO Container : %w", err)
-	}
+	minioContainer, err = destination.SetupMINIO(pool, t)
+	require.NoError(t, err)
 
 	if err := godotenv.Load("testhelper/.env"); err != nil {
-		fmt.Println("INFO: No .env file found.")
+		t.Log("INFO: No .env file found.")
 	}
 
-	_ = os.Setenv("JOBS_DB_PORT", PostgresContainer.Port)
-	_ = os.Setenv("WAREHOUSE_JOBS_DB_PORT", PostgresContainer.Port)
-	_ = os.Setenv("DEST_TRANSFORM_URL", TransformerContainer.TransformURL)
+	_ = os.Setenv("JOBS_DB_PORT", postgresContainer.Port)
+	_ = os.Setenv("WAREHOUSE_JOBS_DB_PORT", postgresContainer.Port)
+	_ = os.Setenv("DEST_TRANSFORM_URL", transformerContainer.TransformURL)
 	_ = os.Setenv("DEPLOYMENT_TYPE", string(deployment.DedicatedType))
 
 	wht.InitWHConfig()
@@ -388,18 +957,15 @@ func run(m *testing.M) (int, error) {
 	defer wht.SetWHMssqlDestination(pool)()
 	defer wht.SetWHBigQueryDestination()()
 
-	AddWHSpecificSqlFunctionsToJobsDb()
+	addWHSpecificSqlFunctionsToJobsDb()
 
 	httpPortInt, err := freeport.GetFreePort()
-	if err != nil {
-		return 0, fmt.Errorf("could not get free port for http: %w", err)
-	}
+	require.NoError(t, err)
+
 	httpPort = strconv.Itoa(httpPortInt)
 	_ = os.Setenv("RSERVER_GATEWAY_WEB_PORT", httpPort)
 	httpAdminPort, err := freeport.GetFreePort()
-	if err != nil {
-		return 0, fmt.Errorf("could not get free port for http admin: %w", err)
-	}
+	require.NoError(t, err)
 
 	_ = os.Setenv("RSERVER_GATEWAY_ADMIN_WEB_PORT", strconv.Itoa(httpAdminPort))
 	_ = os.Setenv("RSERVER_ENABLE_STATS", "false")
@@ -419,10 +985,10 @@ func run(m *testing.M) (int, error) {
 		"disableDestinationwebhookUrl":        disableDestinationWebhookURL,
 		"writeKey":                            writeKey,
 		"workspaceId":                         workspaceID,
-		"postgresPort":                        PostgresContainer.Port,
-		"address":                             RedisContainer.RedisAddress,
-		"minioEndpoint":                       MINIOContainer.MinioEndpoint,
-		"minioBucketName":                     MINIOContainer.MinioBucketName,
+		"postgresPort":                        postgresContainer.Port,
+		"address":                             redisContainer.RedisAddress,
+		"minioEndpoint":                       minioContainer.MinioEndpoint,
+		"minioBucketName":                     minioContainer.MinioBucketName,
 		"postgresEventWriteKey":               wht.Test.PGTest.WriteKey,
 		"clickHouseEventWriteKey":             wht.Test.CHTest.WriteKey,
 		"clickHouseClusterEventWriteKey":      wht.Test.CHClusterTest.WriteKey,
@@ -433,7 +999,7 @@ func run(m *testing.M) (int, error) {
 		"rwhMSSqlDestinationPort":             wht.Test.MSSQLTest.Credentials.Port,
 	}
 	if runtime.GOARCH != "arm64" || overrideArm64Check {
-		mapWorkspaceConfig["kafkaPort"] = KafkaContainer.Port
+		mapWorkspaceConfig["kafkaPort"] = kafkaContainer.Port
 	}
 	if runBigQueryTest && wht.Test.BQTest != nil {
 		mapWorkspaceConfig["bqEventWriteKey"] = wht.Test.BQTest.WriteKey
@@ -446,23 +1012,21 @@ func run(m *testing.M) (int, error) {
 		"testdata/workspaceConfigTemplate.json",
 		mapWorkspaceConfig,
 	)
-	defer func() {
-		err := os.Remove(workspaceConfigPath)
-		log.Println(err)
-	}()
-	log.Println("workspace config path:", workspaceConfigPath)
+	t.Cleanup(func() {
+		if err := os.Remove(workspaceConfigPath); err != nil {
+			t.Logf("Error while removing workspace config path: %v", err)
+		}
+	})
+	t.Log("workspace config path:", workspaceConfigPath)
 	_ = os.Setenv("RSERVER_BACKEND_CONFIG_CONFIG_JSONPATH", workspaceConfigPath)
 
 	rudderTmpDir, err := os.MkdirTemp("", "rudder_server_test")
-	if err != nil {
-		return 0, err
-	}
-	defer func() { _ = os.RemoveAll(rudderTmpDir) }()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(rudderTmpDir) })
 	_ = os.Setenv("RUDDER_TMPDIR", rudderTmpDir)
 
-	fmt.Printf("--- Setup done (%s)\n", time.Since(setupStart))
+	t.Logf("--- Setup done (%s)", time.Since(setupStart))
 
-	svcCtx, svcCancel := context.WithCancel(context.Background())
 	svcDone := make(chan struct{})
 	go func() {
 		main.Run(svcCtx)
@@ -478,322 +1042,23 @@ func run(m *testing.M) (int, error) {
 		time.Second,
 		"serviceHealthEndpoint",
 	)
-	code := m.Run()
-	blockOnHold()
 
-	svcCancel()
-	fmt.Println("waiting for service to stop")
-	<-svcDone
-
-	tearDownStart = time.Now()
-	return code, nil
+	return svcDone
 }
 
-func TestWebhook(t *testing.T) {
-	var err error
-	require.Empty(t, webhook.Requests(), "webhook should have no request before sending the event")
-	payload1 := strings.NewReader(`{
-		"userId": "identified_user_id",
-		"anonymousId":"anonymousId_1",
-		"messageId":"messageId_1",
-		"type": "identify",
-		"eventOrderNo":"1",
-		"context": {
-		  "traits": {
-			 "trait1": "new-val"
-		  },
-		  "ip": "14.5.67.21",
-		  "library": {
-			  "name": "http"
-		  }
-		},
-		"timestamp": "2020-02-02T00:23:09.544Z"
-	  }`)
-	SendEvent(payload1, "identify", writeKey)
-	payload2 := strings.NewReader(`{
-		"userId": "identified_user_id",
-		"anonymousId":"anonymousId_1",
-		"messageId":"messageId_1",
-		"type": "identify",
-		"eventOrderNo":"2",
-		"context": {
-		  "traits": {
-			 "trait1": "new-val"
-		  },
-		  "ip": "14.5.67.21",
-		  "library": {
-			  "name": "http"
-		  }
-		},
-		"timestamp": "2020-02-02T00:23:09.544Z"
-	  }`)
-	SendEvent(payload2, "identify", writeKey) // sending duplicate event to check dedup
-
-	// Sending Batch event
-	payloadBatch := strings.NewReader(`{
-		"batch":
-		[
-			{
-				"userId": "identified_user_id",
-				"anonymousId": "anonymousId_1",
-				"type": "identify",
-				"context":
-				{
-					"traits":
-					{
-						"trait1": "new-val"
-					},
-					"ip": "14.5.67.21",
-					"library":
-					{
-						"name": "http"
-					}
-				},
-				"timestamp": "2020-02-02T00:23:09.544Z"
-			}
-		]
-	}`)
-	SendEvent(payloadBatch, "batch", writeKey)
-
-	// Sending track event
-	payloadTrack := strings.NewReader(`{
-		"userId": "identified_user_id",
-		"anonymousId":"anonymousId_1",
-		"messageId":"messageId_1",
-		"type": "track",
-		"event": "Product Reviewed",
-		"properties": {
-		  "review_id": "12345",
-		  "product_id" : "123",
-		  "rating" : 3.0,
-		  "review_body" : "Average product, expected much more."
-		}
-	  }`)
-	SendEvent(payloadTrack, "track", writeKey)
-
-	// Sending page event
-	payloadPage := strings.NewReader(`{
-		"userId": "identified_user_id",
-		"anonymousId":"anonymousId_1",
-		"messageId":"messageId_1",
-		"type": "page",
-		"name": "Home",
-		"properties": {
-		  "title": "Home | RudderStack",
-		  "url": "http://www.rudderstack.com"
-		}
-	  }`)
-	SendEvent(payloadPage, "page", writeKey)
-
-	// Sending screen event
-	payloadScreen := strings.NewReader(`{
-		"userId": "identified_user_id",
-		"anonymousId":"anonymousId_1",
-		"messageId":"messageId_1",
-		"type": "screen",
-		"name": "Main",
-		"properties": {
-		  "prop_key": "prop_value"
-		}
-	  }`)
-	SendEvent(payloadScreen, "screen", writeKey)
-
-	// Sending alias event
-	payloadAlias := strings.NewReader(`{
-		"userId": "identified_user_id",
-		"anonymousId":"anonymousId_1",
-		"messageId":"messageId_1",
-		"type": "alias",
-		"previousId": "name@surname.com",
-		"userId": "12345"
-	  }`)
-	SendEvent(payloadAlias, "alias", writeKey)
-
-	// Sending group event
-	payloadGroup := strings.NewReader(`{
-		"userId": "identified_user_id",
-		"anonymousId":"anonymousId_1",
-		"messageId":"messageId_1",
-		"type": "group",
-		"groupId": "12345",
-		"traits": {
-		  "name": "MyGroup",
-		  "industry": "IT",
-		  "employees": 450,
-		  "plan": "basic"
-		}
-	  }`)
-	SendEvent(payloadGroup, "group", writeKey)
-	SendPixelEvents(writeKey)
-
-	require.Eventually(t, func() bool {
-		return len(webhook.Requests()) == 10
-	}, time.Minute, 30*time.Millisecond)
-
-	i := -1
-	require.Eventually(t, func() bool {
-		i = i + 1
-		req := webhook.Requests()[i]
-		body, _ := io.ReadAll(req.Body)
-		return gjson.GetBytes(body, "anonymousId").Str == "anonymousId_1"
-	}, time.Minute, 10*time.Millisecond)
-
-	req := webhook.Requests()[i]
-	body, err := io.ReadAll(req.Body)
-
-	require.NoError(t, err)
-	require.Equal(t, "POST", req.Method)
-	require.Equal(t, "/", req.URL.Path)
-	require.Equal(t, "application/json", req.Header.Get("Content-Type"))
-	require.Equal(t, "RudderLabs", req.Header.Get("User-Agent"))
-
-	require.Equal(t, gjson.GetBytes(body, "anonymousId").Str, "anonymousId_1")
-	require.Equal(t, gjson.GetBytes(body, "messageId").Str, "messageId_1")
-	require.Equal(t, gjson.GetBytes(body, "eventOrderNo").Str, "1")
-	require.Equal(t, gjson.GetBytes(body, "userId").Str, "identified_user_id")
-	require.Equal(t, gjson.GetBytes(body, "rudderId").Str, "e4cab80e-2f0e-4fa2-87e0-3a4af182634c")
-	require.Equal(t, gjson.GetBytes(body, "type").Str, "identify")
-	// Verify User Transformation
-	require.Equal(t, gjson.GetBytes(body, "myuniqueid").Str, "identified_user_idanonymousId_1")
-	require.Equal(t, gjson.GetBytes(body, "context.myuniqueid").Str, "identified_user_idanonymousId_1")
-	require.Equal(t, gjson.GetBytes(body, "context.id").Str, "0.0.0.0")
-	require.Equal(t, gjson.GetBytes(body, "context.ip").Str, "0.0.0.0")
-
-	// Verify Disabled destination doesn't receive any event.
-	require.Equal(t, 0, len(disableDestinationWebhook.Requests()))
-}
-
-// Verify Event in POSTGRES
-func TestPostgres(t *testing.T) {
-	var myEvent Event
-	require.Eventually(t, func() bool {
-		eventSql := "select anonymous_id, user_id from dev_integration_test_1.identifies limit 1"
-		_ = db.QueryRow(eventSql).Scan(&myEvent.anonymousID, &myEvent.userID)
-		return myEvent.anonymousID == "anonymousId_1"
-	}, time.Minute, 10*time.Millisecond)
-	eventSql := "select count(*) from dev_integration_test_1.identifies"
-	_ = db.QueryRow(eventSql).Scan(&myEvent.count)
-	require.Equal(t, myEvent.count, "2")
-
-	// Verify User Transformation
-	eventSql = "select context_myuniqueid,context_id,context_ip from dev_integration_test_1.identifies"
-	_ = db.QueryRow(eventSql).Scan(&myEvent.contextMyUniqueID, &myEvent.contextID, &myEvent.contextIP)
-	require.Equal(t, myEvent.contextMyUniqueID, "identified_user_idanonymousId_1")
-	require.Equal(t, myEvent.contextID, "0.0.0.0")
-	require.Equal(t, myEvent.contextIP, "0.0.0.0")
-
-	require.Eventually(t, func() bool {
-		eventSql := "select anonymous_id, user_id from dev_integration_test_1.users limit 1"
-		_ = db.QueryRow(eventSql).Scan(&myEvent.anonymousID, &myEvent.userID)
-		return myEvent.anonymousID == "anonymousId_1"
-	}, time.Minute, 10*time.Millisecond)
-
-	require.Eventually(t, func() bool {
-		eventSql = "select count(*) from dev_integration_test_1.users"
-		_ = db.QueryRow(eventSql).Scan(&myEvent.count)
-		return myEvent.count == "1"
-	}, time.Minute, 10*time.Millisecond)
-
-	// Verify User Transformation
-	eventSql = "select context_myuniqueid,context_id,context_ip from dev_integration_test_1.users "
-	_ = db.QueryRow(eventSql).Scan(&myEvent.contextMyUniqueID, &myEvent.contextID, &myEvent.contextIP)
-	require.Equal(t, myEvent.contextMyUniqueID, "identified_user_idanonymousId_1")
-	require.Equal(t, myEvent.contextID, "0.0.0.0")
-	require.Equal(t, myEvent.contextIP, "0.0.0.0")
-
-	require.Eventually(t, func() bool {
-		eventSql := "select anonymous_id, user_id from dev_integration_test_1.screens limit 1"
-		_ = db.QueryRow(eventSql).Scan(&myEvent.anonymousID, &myEvent.userID)
-		return myEvent.anonymousID == "anonymousId_1"
-	}, time.Minute, 10*time.Millisecond)
-	require.Eventually(t, func() bool {
-		eventSql = "select count(*) from dev_integration_test_1.screens"
-		_ = db.QueryRow(eventSql).Scan(&myEvent.count)
-		return myEvent.count == "1"
-	}, time.Minute, 10*time.Millisecond)
-
-	// Verify User Transformation
-	require.Eventually(t, func() bool {
-		eventSql = "select prop_key,myuniqueid,ip from dev_integration_test_1.screens;"
-		_ = db.QueryRow(eventSql).Scan(&myEvent.propKey, &myEvent.myUniqueID, &myEvent.ip)
-		return myEvent.myUniqueID == "identified_user_idanonymousId_1"
-	}, time.Minute, 10*time.Millisecond)
-
-	require.Equal(t, myEvent.propKey, "prop_value_edited")
-	require.Equal(t, myEvent.ip, "0.0.0.0")
-}
-
-// Verify Event in Redis
-func TestRedis(t *testing.T) {
-	conn, err := redigo.Dial("tcp", RedisContainer.RedisAddress)
-	require.NoError(t, err)
-	defer func() { _ = conn.Close() }()
-	require.Eventually(t, func() bool {
-		// Similarly, get the trait1 and convert it to a string.
-		event, _ := redigo.String(conn.Do("HGET", "user:identified_user_id", "trait1"))
-		return event == "new-val"
-	}, time.Minute, 10*time.Millisecond)
-}
-
-func TestKafka(t *testing.T) {
-	if runtime.GOARCH == "arm64" && !overrideArm64Check {
-		t.Skip("arm64 is not supported yet")
-	}
-
-	kafkaHost := fmt.Sprintf("localhost:%s", KafkaContainer.Port)
-
-	// Create new consumer
-	tc := testutil.New("tcp", kafkaHost)
-	topics, err := tc.ListTopics(context.TODO())
-	require.NoError(t, err)
-
-	c, err := kafkaclient.New("tcp", []string{kafkaHost}, kafkaclient.Config{})
-	require.NoError(t, err)
-
-	messages, errors := consume(t, c, topics)
-
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt)
-
-	// Count how many message processed
-	msgCount := 0
-	// Get signal for finish
-	expectedCount := 10
-out:
-	for {
-		select {
-		case msg := <-messages:
-			msgCount++
-			require.Equal(t, "identified_user_id", string(msg.Key))
-			require.Contains(t, string(msg.Value), "identified_user_id")
-
-			if msgCount == expectedCount {
-				break out
-			}
-		case consumerError := <-errors:
-			msgCount++
-			t.Log("Received consumerError", consumerError)
-		case <-time.After(time.Minute):
-			t.Error("timeout waiting on Kafka message")
-		}
-	}
-
-	t.Log("Processed", msgCount, "messages")
-}
-
-func consume(t *testing.T, client *kafkaclient.Client, topics []testutil.TopicPartition) (<-chan kafkaclient.Message, <-chan error) {
+func consume(t *testing.T, client *kafkaClient.Client, topics []testutil.TopicPartition) (<-chan kafkaClient.Message, <-chan error) {
 	t.Helper()
 	errors := make(chan error)
-	messages := make(chan kafkaclient.Message)
+	messages := make(chan kafkaClient.Message)
 
 	for _, topic := range topics {
-		consumer := client.NewConsumer(topic.Topic, kafkaclient.ConsumerConfig{
+		consumer := client.NewConsumer(topic.Topic, kafkaClient.ConsumerConfig{
 			Partition:   topic.Partition,
-			StartOffset: kafkaclient.FirstOffset,
+			StartOffset: kafkaClient.FirstOffset,
 		})
 
 		t.Logf("Start consuming topic %s:%d", topic.Topic, topic.Partition)
-		go func(topic testutil.TopicPartition, consumer *kafkaclient.Consumer) {
+		go func(topic testutil.TopicPartition, consumer *kafkaClient.Consumer) {
 			for {
 				msg, err := consumer.Receive(context.TODO())
 				if err != nil {
@@ -808,121 +1073,8 @@ func consume(t *testing.T, client *kafkaclient.Client, topics []testutil.TopicPa
 	return messages, errors
 }
 
-// Verify Event Models EndPoint
-func TestEventModels(t *testing.T) {
-	// GET /schemas/event-models
-	url := fmt.Sprintf("http://localhost:%s/schemas/event-models", httpPort)
-	method := "GET"
-	resBody, _ := GetEvent(url, method)
-	require.Eventually(t, func() bool {
-		// Similarly, pole until the Event Schema Tables are updated
-		resBody, _ = GetEvent(url, method)
-		return resBody != "[]"
-	}, time.Minute, 10*time.Millisecond)
-	require.NotEqual(t, resBody, "[]")
-	b := []byte(resBody)
-	var eventSchemas []eventSchemasObject
-
-	err := json.Unmarshal(b, &eventSchemas)
-	if err != nil {
-		log.Println(err)
-	}
-	for k := range eventSchemas {
-		if eventSchemas[k].EventType == "page" {
-			EventID = eventSchemas[k].EventID
-		}
-	}
-	require.NotEqual(t, EventID, "")
-}
-
-// Verify Event Versions EndPoint
-func TestEventVersions(t *testing.T) {
-	// GET /schemas/event-versions
-	url := fmt.Sprintf("http://localhost:%s/schemas/event-versions?EventID=%s", httpPort, EventID)
-	method := "GET"
-	resBody, _ := GetEvent(url, method)
-	require.Contains(t, resBody, EventID)
-
-	b := []byte(resBody)
-	var eventSchemas []eventSchemasObject
-
-	err := json.Unmarshal(b, &eventSchemas)
-	if err != nil {
-		log.Println(err)
-	}
-	VersionID = eventSchemas[0].VersionID
-	log.Println("Test Schemas Event ID's VersionID: ", VersionID)
-}
-
-// Verify schemas/event-model/{EventID}/key-counts EndPoint
-func TestEventModelKeyCounts(t *testing.T) {
-	// GET schemas/event-model/{EventID}/key-counts
-	url := fmt.Sprintf("http://localhost:%s/schemas/event-model/%s/key-counts", httpPort, EventID)
-	method := "GET"
-	resBody, _ := GetEvent(url, method)
-	require.Contains(t, resBody, "messageId")
-}
-
-// Verify /schemas/event-model/{EventID}/metadata EndPoint
-func TestEventModelMetadata(t *testing.T) {
-	// GET /schemas/event-model/{EventID}/metadata
-	url := fmt.Sprintf("http://localhost:%s/schemas/event-model/%s/metadata", httpPort, EventID)
-	method := "GET"
-	resBody, _ := GetEvent(url, method)
-	require.Contains(t, resBody, "messageId")
-}
-
-// Verify /schemas/event-version/{VersionID}/metadata EndPoint
-func TestEventVersionMetadata(t *testing.T) {
-	// GET /schemas/event-version/{VersionID}/metadata
-	url := fmt.Sprintf("http://localhost:%s/schemas/event-version/%s/metadata", httpPort, VersionID)
-	method := "GET"
-	resBody, _ := GetEvent(url, method)
-	require.Contains(t, resBody, "messageId")
-}
-
-// Verify /schemas/event-version/{VersionID}/missing-keys EndPoint
-func TestEventVersionMissingKeys(t *testing.T) {
-	// GET /schemas/event-version/{VersionID}/metadata
-	url := fmt.Sprintf("http://localhost:%s/schemas/event-version/%s/missing-keys", httpPort, VersionID)
-	method := "GET"
-	resBody, _ := GetEvent(url, method)
-	require.Contains(t, resBody, "originalTimestamp")
-	require.Contains(t, resBody, "sentAt")
-	require.Contains(t, resBody, "channel")
-	require.Contains(t, resBody, "integrations.All")
-}
-
-// Verify /schemas/event-models/json-schemas EndPoint
-func TestEventModelsJsonSchemas(t *testing.T) {
-	// GET /schemas/event-models/json-schemas
-	url := fmt.Sprintf("http://localhost:%s/schemas/event-models/json-schemas", httpPort)
-	method := "GET"
-	resBody, _ := GetEvent(url, method)
-	require.Eventually(t, func() bool {
-		// Similarly, pole until the Event Schema Tables are updated
-		resBody, _ = GetEvent(url, method)
-		return resBody != "[]"
-	}, time.Minute, 10*time.Millisecond)
-	require.NotEqual(t, resBody, "[]")
-}
-
-// Verify beacon EndPoint
-func TestBeaconBatch(_ *testing.T) {
-	payload := strings.NewReader(`{
-		"batch":[
-			{
-			   "userId": "identified_user_id",
-			   "anonymousId":"anonymousId_1",
-			   "messageId":"messageId_1"
-			}
-		]
-	}`)
-	SendEvent(payload, "beacon/v1/batch", writeKey)
-}
-
 // Adding necessary sql functions which needs to be used during warehouse testing
-func AddWHSpecificSqlFunctionsToJobsDb() {
+func addWHSpecificSqlFunctionsToJobsDb() {
 	var err error
 	_, err = db.Exec(wht.Test.GatewayJobsSqlFunction)
 	if err != nil {
@@ -933,201 +1085,6 @@ func AddWHSpecificSqlFunctionsToJobsDb() {
 	if err != nil {
 		panic(fmt.Errorf("error occurred with executing brt jobs function for events count with err %s", err.Error()))
 	}
-}
-
-// Verify Event in WareHouse Postgres
-func TestWHPostgresDestination(t *testing.T) {
-	pgTest := wht.Test.PGTest
-
-	whDestTest := &wht.WareHouseDestinationTest{
-		Client: &client.Client{
-			SQL:  pgTest.DB,
-			Type: client.SQLClient,
-		},
-		EventsCountMap:     pgTest.EventsMap,
-		WriteKey:           pgTest.WriteKey,
-		UserId:             "userId_postgres",
-		Schema:             "postgres_wh_integration",
-		TableTestQueryFreq: pgTest.TableTestQueryFreq,
-	}
-	sendWHEvents(whDestTest)
-	whDestinationTest(t, whDestTest)
-
-	whDestTest.UserId = "userId_postgres_1"
-	sendUpdatedWHEvents(whDestTest)
-	whDestinationTest(t, whDestTest)
-}
-
-// Verify Event in WareHouse ClickHouse
-func TestWHClickHouseDestination(t *testing.T) {
-	chTest := wht.Test.CHTest
-
-	whDestTest := &wht.WareHouseDestinationTest{
-		Client: &client.Client{
-			SQL:  chTest.DB,
-			Type: client.SQLClient,
-		},
-		EventsCountMap:     chTest.EventsMap,
-		WriteKey:           chTest.WriteKey,
-		UserId:             "userId_clickhouse",
-		Schema:             "rudderdb",
-		TableTestQueryFreq: chTest.TableTestQueryFreq,
-	}
-	sendWHEvents(whDestTest)
-	whDestinationTest(t, whDestTest)
-
-	whDestTest.UserId = "userId_clickhouse_1"
-	sendUpdatedWHEvents(whDestTest)
-	whDestinationTest(t, whDestTest)
-}
-
-// Verify Event in WareHouse ClickHouse Cluster
-func TestWHClickHouseClusterDestination(t *testing.T) {
-	chClusterTest := wht.Test.CHClusterTest
-
-	whDestTest := &wht.WareHouseDestinationTest{
-		Client: &client.Client{
-			SQL:  chClusterTest.GetResource().DB,
-			Type: client.SQLClient,
-		},
-		EventsCountMap:     chClusterTest.EventsMap,
-		WriteKey:           chClusterTest.WriteKey,
-		UserId:             "userId_clickhouse_cluster",
-		Schema:             "rudderdb",
-		TableTestQueryFreq: chClusterTest.TableTestQueryFreq,
-	}
-	sendWHEvents(whDestTest)
-	whDestinationTest(t, whDestTest)
-
-	initWHClickHouseClusterModeSetup(t)
-
-	whDestTest.UserId = "userId_clickhouse_cluster_1"
-	sendUpdatedWHEvents(whDestTest)
-
-	// Update events count Map
-	// This is required as because of the cluster mode setup and distributed view, events are getting duplicated.
-	whDestTest.EventsCountMap = wht.EventsCountMap{
-		"identifies":    2,
-		"users":         2,
-		"tracks":        2,
-		"product_track": 2,
-		"pages":         2,
-		"screens":       2,
-		"aliases":       2,
-		"groups":        2,
-		"gateway":       6,
-		"batchRT":       8,
-	}
-	whDestinationTest(t, whDestTest)
-}
-
-func TestWHBigQuery(t *testing.T) {
-	if runBigQueryTest == false {
-		t.Skip("Big query integration skipped. use -bigqueryintegration to add this test ")
-	}
-	if wht.Test.BQTest == nil {
-		fmt.Println("Error in ENV variable BIGQUERY_INTEGRATION_TEST_USER_CRED")
-		t.FailNow()
-	}
-	// Disabling big query dedup
-	config.SetBool("Warehouse.bigquery.isDedupEnabled", false)
-	bq.Init()
-	bqTest := wht.Test.BQTest
-	randomness := strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")
-
-	whDestTest := &wht.WareHouseDestinationTest{
-		Client: &client.Client{
-			BQ:   bqTest.DB,
-			Type: client.BQClient,
-		},
-		EventsCountMap:     bqTest.EventsMap,
-		WriteKey:           bqTest.WriteKey,
-		UserId:             fmt.Sprintf("userId_bq_%s", randomness),
-		Schema:             "rudderstack_sample_http_source",
-		BQContext:          bqTest.Context,
-		Tables:             bqTest.Tables,
-		PrimaryKeys:        bqTest.PrimaryKeys,
-		TableTestQueryFreq: bqTest.TableTestQueryFreq,
-	}
-
-	whDestTest.MessageId = uuid.Must(uuid.NewV4()).String()
-
-	whDestTest.EventsCountMap = wht.EventsCountMap{
-		"identifies": 2,
-		"tracks":     2,
-		"pages":      2,
-		"screens":    2,
-		"aliases":    2,
-		"groups":     2,
-	}
-	sendWHEvents(whDestTest)
-
-	whDestTest.EventsCountMap = wht.EventsCountMap{
-		"identifies":    2,
-		"users":         1,
-		"tracks":        2,
-		"product_track": 2,
-		"pages":         2,
-		"screens":       2,
-		"aliases":       2,
-		"_groups":       2,
-		"gateway":       12,
-		"batchRT":       16,
-	}
-
-	whDestinationTest(t, whDestTest)
-	// Enabling big query dedup
-	config.SetBool("Warehouse.bigquery.isDedupEnabled", true)
-	bq.Init()
-
-	whDestTest.EventsCountMap = wht.EventsCountMap{
-		"identifies": 2,
-		"tracks":     2,
-		"pages":      2,
-		"screens":    2,
-		"aliases":    2,
-		"groups":     2,
-	}
-
-	sendWHEvents(whDestTest)
-
-	whDestTest.EventsCountMap = wht.EventsCountMap{
-		"identifies":    2,
-		"users":         1,
-		"tracks":        2,
-		"product_track": 2,
-		"pages":         2,
-		"screens":       2,
-		"aliases":       2,
-		"_groups":       2,
-		"gateway":       24,
-		"batchRT":       32,
-	}
-
-	whDestinationTest(t, whDestTest)
-}
-
-// Verify Event in WareHouse MSSQL
-func TestWHMssqlDestination(t *testing.T) {
-	MssqlTest := wht.Test.MSSQLTest
-
-	whDestTest := &wht.WareHouseDestinationTest{
-		Client: &client.Client{
-			SQL:  MssqlTest.DB,
-			Type: client.SQLClient,
-		},
-		EventsCountMap:     MssqlTest.EventsMap,
-		WriteKey:           MssqlTest.WriteKey,
-		UserId:             "userId_mssql",
-		Schema:             "mssql_wh_integration",
-		TableTestQueryFreq: MssqlTest.TableTestQueryFreq,
-	}
-	sendWHEvents(whDestTest)
-	whDestinationTest(t, whDestTest)
-
-	whDestTest.UserId = "userId_mssql_1"
-	sendUpdatedWHEvents(whDestTest)
-	whDestinationTest(t, whDestTest)
 }
 
 func getMessageId(wdt *wht.WareHouseDestinationTest) string {

--- a/docker_test.go
+++ b/docker_test.go
@@ -118,15 +118,12 @@ func TestMainFlow(t *testing.T) {
 			return webhook.RequestsCount() == 10
 		}, time.Minute, 300*time.Millisecond)
 
-		i := 0
+		i := -1
 		require.Eventually(t, func() bool {
+			i = i + 1
 			req := webhook.Requests()[i]
 			body, _ := io.ReadAll(req.Body)
-			result := gjson.GetBytes(body, "anonymousId").Str == "anonymousId_1"
-			if result {
-				i++
-			}
-			return result
+			return gjson.GetBytes(body, "anonymousId").Str == "anonymousId_1"
 		}, time.Minute, 100*time.Millisecond)
 
 		req := webhook.Requests()[i]

--- a/docker_test.go
+++ b/docker_test.go
@@ -460,7 +460,7 @@ func TestMainFlow(t *testing.T) {
 			t.Skip("Big query integration skipped. use -bigqueryintegration to add this test ")
 		}
 		if wht.Test.BQTest == nil {
-			fmt.Println("Error in ENV variable BIGQUERY_INTEGRATION_TEST_USER_CRED")
+			t.Log("Error in ENV variable BIGQUERY_INTEGRATION_TEST_USER_CRED")
 			t.FailNow()
 		}
 		//Disabling big query dedup

--- a/docker_test.go
+++ b/docker_test.go
@@ -465,7 +465,7 @@ func TestMainFlow(t *testing.T) {
 			t.Log("Error in ENV variable BIGQUERY_INTEGRATION_TEST_USER_CRED")
 			t.FailNow()
 		}
-		//Disabling big query dedup
+		// Disabling big query dedup
 		config.SetBool("Warehouse.bigquery.isDedupEnabled", false)
 		bq.Init()
 		bqTest := wht.Test.BQTest
@@ -512,7 +512,7 @@ func TestMainFlow(t *testing.T) {
 		}
 
 		whDestinationTest(t, whDestTest)
-		//Enabling big query dedup
+		// Enabling big query dedup
 		config.SetBool("Warehouse.bigquery.isDedupEnabled", true)
 		bq.Init()
 
@@ -755,7 +755,7 @@ func sendEventsToGateway(t *testing.T) {
 		},
 		"timestamp": "2020-02-02T00:23:09.544Z"
 	}`)
-	sendEvent(t, payload2, "identify", writeKey) //sending duplicate event to check dedup
+	sendEvent(t, payload2, "identify", writeKey) // sending duplicate event to check dedup
 
 	// Sending Batch event
 	payloadBatch := strings.NewReader(`{
@@ -856,7 +856,7 @@ func sendEventsToGateway(t *testing.T) {
 }
 
 func randString(n int) string {
-	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 	s := make([]rune, n)
 	for i := range s {
 		s[i] = letters[rand.Intn(len(letters))]
@@ -923,10 +923,9 @@ func blockOnHold(t *testing.T) {
 	<-c
 }
 
-func getEvent(url string, method string) (string, error) {
+func getEvent(url, method string) (string, error) {
 	httpClient := &http.Client{}
 	req, err := http.NewRequest(method, url, nil)
-
 	if err != nil {
 		return "", err
 	}
@@ -973,7 +972,7 @@ func sendPixelEvents(t *testing.T, writeKey string) {
 	}
 }
 
-func sendEvent(t *testing.T, payload *strings.Reader, callType string, writeKey string) {
+func sendEvent(t *testing.T, payload *strings.Reader, callType, writeKey string) {
 	t.Helper()
 	t.Logf("Sending %s Event", callType)
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -118,13 +118,16 @@ func TestMainFlow(t *testing.T) {
 			return webhook.RequestsCount() == 10
 		}, time.Minute, 300*time.Millisecond)
 
-		i := -1
+		i := 0
 		require.Eventually(t, func() bool {
-			i = i + 1
 			req := webhook.Requests()[i]
 			body, _ := io.ReadAll(req.Body)
-			return gjson.GetBytes(body, "anonymousId").Str == "anonymousId_1"
-		}, time.Minute, 10*time.Millisecond)
+			result := gjson.GetBytes(body, "anonymousId").Str == "anonymousId_1"
+			if result {
+				i++
+			}
+			return result
+		}, time.Minute, 100*time.Millisecond)
 
 		req := webhook.Requests()[i]
 		body, err := io.ReadAll(req.Body)

--- a/services/streammanager/googlesheets/googlesheetsmanager_test.go
+++ b/services/streammanager/googlesheets/googlesheetsmanager_test.go
@@ -126,21 +126,21 @@ func blockOnHold() {
 	<-c
 }
 
-type deferer interface {
-	Defer(func() error)
+type cleaner interface {
+	Cleanup(func())
+	Log(...interface{})
 }
 
-func SetupTestGoogleSheets(pool *dockertest.Pool, d deferer) (*TestConfig, error) {
+func SetupTestGoogleSheets(pool *dockertest.Pool, cln cleaner) (*TestConfig, error) {
 	var config TestConfig
 	dockerContainer, err := pool.Run("atzoum/simulator-google-sheets", "latest", []string{})
 	if err != nil {
 		return nil, fmt.Errorf("Could not start resource: %s", err)
 	}
-	d.Defer(func() error {
+	cln.Cleanup(func() {
 		if err := pool.Purge(dockerContainer); err != nil {
-			return fmt.Errorf("Could not purge resource: %s \n", err)
+			cln.Log(fmt.Errorf("could not purge resource: %v", err))
 		}
-		return nil
 	})
 	config.Endpoint = fmt.Sprintf("https://127.0.0.1:%s/", dockerContainer.GetPort("8443/tcp"))
 	config.AccessToken = "cd887efc-7c7d-4e8e-9580-f7502123badf"

--- a/testhelper/cleanup.go
+++ b/testhelper/cleanup.go
@@ -6,7 +6,7 @@ type Cleanup struct {
 	fns []func()
 }
 
-func (c *Cleanup) Log(a ...interface{}) {
+func (*Cleanup) Log(a ...interface{}) {
 	fmt.Println(a...)
 }
 

--- a/testhelper/cleanup.go
+++ b/testhelper/cleanup.go
@@ -6,7 +6,7 @@ type Cleanup struct {
 	fns []func()
 }
 
-func (c *Cleanup) Log(a ...any) {
+func (c *Cleanup) Log(a ...interface{}) {
 	fmt.Println(a...)
 }
 

--- a/testhelper/cleanup.go
+++ b/testhelper/cleanup.go
@@ -1,20 +1,22 @@
 package testhelper
 
-import "log"
+import "fmt"
 
 type Cleanup struct {
-	fns []func() error
+	fns []func()
 }
 
-func (c *Cleanup) Defer(fn func() error) {
+func (c *Cleanup) Log(a ...any) {
+	fmt.Println(a...)
+}
+
+func (c *Cleanup) Cleanup(fn func()) {
 	c.fns = append(c.fns, fn)
 }
 
 func (c *Cleanup) Run() {
 	l := len(c.fns) - 1
 	for i := range c.fns {
-		if err := c.fns[l-i](); err != nil {
-			log.Println(err)
-		}
+		c.fns[l-i]()
 	}
 }

--- a/testhelper/destination/minio.go
+++ b/testhelper/destination/minio.go
@@ -20,7 +20,7 @@ type MINIOResource struct {
 	Port            string
 }
 
-func SetupMINIO(pool *dockertest.Pool, d deferer) (*MINIOResource, error) {
+func SetupMINIO(pool *dockertest.Pool, d cleaner) (*MINIOResource, error) {
 	minioPortInt, err := freeport.GetFreePort()
 	if err != nil {
 		fmt.Println(err)
@@ -44,11 +44,10 @@ func SetupMINIO(pool *dockertest.Pool, d deferer) (*MINIOResource, error) {
 	if err != nil {
 		return nil, err
 	}
-	d.Defer(func() error {
+	d.Cleanup(func() {
 		if err := pool.Purge(minioContainer); err != nil {
-			log.Printf("Could not purge resource: %s \n", err)
+			d.Log("Could not purge resource:", err)
 		}
-		return nil
 	})
 
 	minioEndpoint := fmt.Sprintf("localhost:%s", minioContainer.GetPort("9000/tcp"))

--- a/testhelper/destination/postgres.go
+++ b/testhelper/destination/postgres.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	_ "encoding/json"
 	"fmt"
-	"log"
 
 	_ "github.com/lib/pq"
 	"github.com/ory/dockertest/v3"
@@ -20,7 +19,7 @@ type PostgresResource struct {
 	Port     string
 }
 
-func SetupPostgres(pool *dockertest.Pool, d deferer) (*PostgresResource, error) {
+func SetupPostgres(pool *dockertest.Pool, d cleaner) (*PostgresResource, error) {
 	database := "jobsdb"
 	password := "password"
 	user := "rudder"
@@ -35,11 +34,10 @@ func SetupPostgres(pool *dockertest.Pool, d deferer) (*PostgresResource, error) 
 		return nil, err
 	}
 
-	d.Defer(func() error {
+	d.Cleanup(func() {
 		if err := pool.Purge(postgresContainer); err != nil {
-			log.Printf("Could not purge resource: %s \n", err)
+			d.Log("Could not purge resource:", err)
 		}
-		return nil
 	})
 
 	db_dns := fmt.Sprintf("postgres://rudder:password@localhost:%s/%s?sslmode=disable", postgresContainer.GetPort("5432/tcp"), database)

--- a/testhelper/destination/transformer.go
+++ b/testhelper/destination/transformer.go
@@ -3,7 +3,6 @@ package destination
 import (
 	_ "encoding/json"
 	"fmt"
-	"log"
 
 	_ "github.com/lib/pq"
 	"github.com/ory/dockertest/v3"
@@ -14,7 +13,7 @@ type TransformerResource struct {
 	Port         string
 }
 
-func SetupTransformer(pool *dockertest.Pool, d deferer) (*TransformerResource, error) {
+func SetupTransformer(pool *dockertest.Pool, d cleaner) (*TransformerResource, error) {
 	// Set Rudder Transformer
 	// pulls an image, creates a container based on it and runs it
 	transformerContainer, err := pool.RunWithOptions(&dockertest.RunOptions{
@@ -29,11 +28,10 @@ func SetupTransformer(pool *dockertest.Pool, d deferer) (*TransformerResource, e
 		return nil, err
 	}
 
-	d.Defer(func() error {
+	d.Cleanup(func() {
 		if err := pool.Purge(transformerContainer); err != nil {
-			log.Printf("Could not purge resource: %s \n", err)
+			d.Log("Could not purge resource:", err)
 		}
-		return nil
 	})
 
 	return &TransformerResource{

--- a/testhelper/webhook/recorder.go
+++ b/testhelper/webhook/recorder.go
@@ -1,0 +1,57 @@
+package webhook
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"sync"
+)
+
+type Recorder struct {
+	Server     *httptest.Server
+	requests   [][]byte
+	requestsMu sync.RWMutex
+}
+
+func NewRecorder() *Recorder {
+	whr := Recorder{}
+	whr.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dump, err := httputil.DumpRequest(r, true)
+		if err != nil {
+			http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
+			return
+		}
+		whr.requestsMu.Lock()
+		whr.requests = append(whr.requests, dump)
+		whr.requestsMu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+
+	return &whr
+}
+
+func (whr *Recorder) RequestsCount() int {
+	whr.requestsMu.RLock()
+	defer whr.requestsMu.RUnlock()
+	return len(whr.requests)
+}
+
+func (whr *Recorder) Requests() []*http.Request {
+	whr.requestsMu.RLock()
+	defer whr.requestsMu.RUnlock()
+
+	requests := make([]*http.Request, len(whr.requests))
+	for i, d := range whr.requests {
+		requests[i], _ = http.ReadRequest(bufio.NewReader(bytes.NewReader(d)))
+	}
+	return requests
+}
+
+func (whr *Recorder) Close() {
+	whr.Server.Close()
+}


### PR DESCRIPTION
# Description

I need to write more integration tests that involve running `main` and unfortunately that is not possible from another package since `main` packages are not importable:

```go
package something

import (
	"context"
	"testing"

	main "github.com/rudderlabs/rudder-server"
)

func TestSomethingInMain(t *testing.T) {
	main.Run(context.TODO())
}
```

Produces:

> import "github.com/rudderlabs/rudder-server" is a program, not an importable package

Having said that and considering that I need to write additional tests that setup different containers, I had to get rid of `TestMain`.

## Additional changes

* made the `Cleanup` struct similar to `testing.T.Cleanup` to simplify some tests that don't really need the `Cleanup` struct and can use `testing.T`
* removed arguments in favour of environment variables (see `SLOW`) due to the fact that the `flag` package complains if we have unknown arguments which makes it compatible with `TestMain` but not with regular tests (see below)

```go
package something

import (
	"flag"
	"testing"
)

var hold bool

func TestSomething(t *testing.T) {
	flag.BoolVar(&hold, "hold", false, "hold environment clean-up after test execution until Ctrl+C is provided")
	flag.Parse()
}
```

Produces:

```
$ go test . -v -count 1 -hold                                                                                                                                                                                             
flag provided but not defined: -hold
FAIL	github.com/rudderlabs/rudder-server/testhelper/something	0.001s
FAIL
```

## Notion Ticket

[< Notion Link >](https://www.notion.so/rudderstacks/Test-case-for-rudder-server-c3212a02955b416a81e1e962ba5fa2bf#66ef8d48b6d64bc08ca746cdba3edc09)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
