### PR TITLE
fix: properly start a new badgerdb transaction on ErrTxnTooBig

### DIFF
--- a/mocks/services/dedup/mock_dedup.go
+++ b/mocks/services/dedup/mock_dedup.go
@@ -60,9 +60,11 @@ func (mr *MockDedupIMockRecorder) FindDuplicates(arg0, arg1 interface{}) *gomock
 }
 
 // MarkProcessed mocks base method.
-func (m *MockDedupI) MarkProcessed(arg0 []string) {
+func (m *MockDedupI) MarkProcessed(arg0 []string) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "MarkProcessed", arg0)
+	ret := m.ctrl.Call(m, "MarkProcessed", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // MarkProcessed indicates an expected call of MarkProcessed.

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1668,7 +1668,10 @@ func (proc *HandleT) Store(in storeMessage) {
 				for k := range in.uniqueMessageIds {
 					dedupedMessageIdsAcrossJobs = append(dedupedMessageIdsAcrossJobs, k)
 				}
-				proc.dedupHandler.MarkProcessed(dedupedMessageIdsAcrossJobs)
+				err = proc.dedupHandler.MarkProcessed(dedupedMessageIdsAcrossJobs)
+				if err != nil {
+					return err
+				}
 			}
 		}
 		return nil

--- a/services/dedup/dedup_test.go
+++ b/services/dedup/dedup_test.go
@@ -46,7 +46,8 @@ func Test_Dedup(t *testing.T) {
 	})
 
 	t.Run("duplicate after marked as processed", func(t *testing.T) {
-		d.MarkProcessed([]string{"a", "b", "c"})
+		err := d.MarkProcessed([]string{"a", "b", "c"})
+		require.NoError(t, err)
 		dups := d.FindDuplicates([]string{"a", "b", "c"}, nil)
 		require.Equal(t, []int{0, 1, 2}, dups)
 
@@ -74,7 +75,8 @@ func Test_Dedup_Window(t *testing.T) {
 	d := dedup.New(dbPath, dedup.WithClearDB(), dedup.WithWindow(time.Second))
 	defer d.Close()
 
-	d.MarkProcessed([]string{"to be deleted"})
+	err := d.MarkProcessed([]string{"to be deleted"})
+	require.NoError(t, err)
 
 	dups := d.FindDuplicates([]string{"to be deleted"}, nil)
 	require.Equal(t, []int{0}, dups)
@@ -97,7 +99,8 @@ func Test_Dedup_ClearDB(t *testing.T) {
 
 	{
 		d := dedup.New(dbPath, dedup.WithClearDB(), dedup.WithWindow(time.Hour))
-		d.MarkProcessed([]string{"a"})
+		err := d.MarkProcessed([]string{"a"})
+		require.NoError(t, err)
 		d.Close()
 	}
 	{
@@ -112,6 +115,25 @@ func Test_Dedup_ClearDB(t *testing.T) {
 		require.Equal(t, []int{}, dupsAgain)
 		dWithClear.Close()
 	}
+}
+
+func Test_Dedup_ErrTxnTooBig(t *testing.T) {
+	config.Load()
+	logger.Init()
+
+	dbPath := os.TempDir() + "/dedup_test_errtxntoobig"
+	defer os.RemoveAll(dbPath)
+	os.RemoveAll(dbPath)
+	d := dedup.New(dbPath, dedup.WithClearDB(), dedup.WithWindow(time.Hour))
+	defer d.Close()
+
+	size := 105_000
+	messageIDs := make([]string, size)
+	for i := 0; i < size; i++ {
+		messageIDs[i] = uuid.New().String()
+	}
+	err := d.MarkProcessed(messageIDs)
+	require.NoError(t, err)
 }
 
 var duplicateIndexes []int
@@ -136,7 +158,8 @@ func Benchmark_Dedup(b *testing.B) {
 
 			if i%batchSize == batchSize-1 || i == b.N-1 {
 				duplicateIndexes = d.FindDuplicates(msgIDs[:i%batchSize], nil)
-				d.MarkProcessed(msgIDs[:i%batchSize])
+				err := d.MarkProcessed(msgIDs[:i%batchSize])
+				require.NoError(b, err)
 			}
 		}
 		b.ReportMetric(float64(b.N), "events")


### PR DESCRIPTION
# Description

Using `badgerDB.NewTransaction` instead of `badgerDB.Update` which results in a **_Trying to commit a discarded txn_** error whenever a `ErrTxnTooBig` is returned by the `SetEntry` method.


## Notion Ticket

[BadgerDB misuse](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=edc933e2190143119e369fedcdb244eb)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
