### PR TITLE
fix: update failedJobIDMap after draining a job in router

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -2138,17 +2138,12 @@ func (rt *HandleT) readAndProcess() int {
 				partition := rt.getWorkerPartition(drainedUserID)
 				drainWorker := rt.workers[partition]
 
-				drainWorker.failedJobIDMutex.RLock()
+				drainWorker.failedJobIDMutex.Lock()
 				lastJobID, ok := drainWorker.failedJobIDMap[drainedUserID]
-				drainWorker.failedJobIDMutex.RUnlock()
-
 				if ok && lastJobID == drainedJob.JobID {
-
-					drainWorker.failedJobIDMutex.Lock()
 					delete(drainWorker.failedJobIDMap, drainedUserID)
-					drainWorker.failedJobIDMutex.Unlock()
-
 				}
+				drainWorker.failedJobIDMutex.Unlock()
 			}
 		}
 

--- a/router/router.go
+++ b/router/router.go
@@ -1491,7 +1491,7 @@ func (worker *workerT) canBackoff(job *jobsdb.JobT, userID string) (shouldBackof
 }
 
 func (rt *HandleT) getWorkerPartition(userID string) int {
-	return int(math.Abs(float64(misc.GetHash(userID) % rt.noOfWorkers)))
+	return misc.GetHash(userID) % rt.noOfWorkers
 }
 
 func (rt *HandleT) shouldThrottle(destID, userID string, throttledAtTime time.Time) (canBeThrottled bool) {


### PR DESCRIPTION
# Description

After draining a job from router's jobsdb we also need to remove the job's userID from the failedJobIDMap, if present.

## Router pipeline
The following diagram captures the current router pipeline design (not including changes introduced by this fix)

![router drawio](https://user-images.githubusercontent.com/2481587/174118610-22daed8b-e961-4168-888e-5f34ccd1414b.png)

## Notion Ticket

[Drained jobs should be properly removed from failedJobIDMap
](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=94188b8363e04b708996d351bec622e1)
## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
