### PR TITLE
chore: update readme and docker compose

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -26,6 +26,7 @@ jobs:
             name=rudderlabs/rudder-server,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
           tags: |
             type=ref,event=branch
+            type=raw,value=1-alpine,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ github.head_ref }}
             type=semver,pattern={{version}}

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@
 <p align="center"><b>The Customer Data Platform for Developers</b></p>
 
 <p align="center">
-  <a href="https://rudderstack.com/">
-    <img src="https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT01EQkVPc0NBbDJLV2txTURidkRTMTNmWFRZWUY2dEtia3FRVmFXdXhWeUwzaC9aV3dsWWNNT0NwaVZKd1hKTFVMazB2cDQ5UHlaZTgvbFRER3R5SXRvPSIsIml2UGFyYW1ldGVyU3BlYyI6IktJQVMveHIzQnExZVE5b0YiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master">
+  <a href="https://github.com/rudderlabs/rudder-server/actions/workflows/tests.yaml">
+    <img src="https://github.com/rudderlabs/rudder-server/actions/workflows/tests.yaml/badge.svg">
+  </a>
+  <a href="https://github.com/rudderlabs/rudder-server/actions/workflows/builds.yml">
+    <img src="https://github.com/rudderlabs/rudder-server/actions/workflows/builds.yml/badge.svg">
   </a>
   <a href="https://github.com/rudderlabs/rudder-server/releases">
     <img src="https://img.shields.io/github/v/release/rudderlabs/rudder-server?color=blue&sort=semver">
@@ -26,6 +29,8 @@
     <a href="https://rudderstack.com">Website</a>
     ·
     <a href="https://rudderstack.com/docs">Documentation</a>
+    ·
+    <a href="https://github.com/rudderlabs/rudder-server/blob/master/CHANGELOG.md">Changelog</a>
     ·
     <a href="https://rudderstack.com/blog">Blog</a>
     ·

--- a/rudder-docker.yml
+++ b/rudder-docker.yml
@@ -14,7 +14,7 @@ services:
       - db
       - metrics-exporter
       - d-transformer
-    image: rudderlabs/rudder-server:1-alpine
+    image: rudderlabs/rudder-server:0 # latest version that matches 0.*.*
     entrypoint: sh -c '/wait-for db:5432 -- /rudder-server'
     ports:
       - "8080:8080"

--- a/rudder-docker.yml
+++ b/rudder-docker.yml
@@ -14,7 +14,7 @@ services:
       - db
       - metrics-exporter
       - d-transformer
-    image: rudderlabs/rudder-server:0 # latest version that matches 0.*.*
+    image: rudderlabs/rudder-server:latest # latest version that matches 0.*.*
     entrypoint: sh -c '/wait-for db:5432 -- /rudder-server'
     ports:
       - "8080:8080"


### PR DESCRIPTION
# Description

* Replace AWS build badges with GitHub actions
* Change open-source image tag from `1-alpine` to `latest`
* Tag release images with `1-alpine` for existing references

## Notion Ticket

[Minor-OSS-release-improvements](https://www.notion.so/rudderstacks/Minor-OSS-release-improvements-a203a6e2087d4b7d96a15fe11fb7db88) 

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
