### PR TITLE
fix(multi-tenant): removed unused mock calls

### DIFF
--- a/app/cluster/dynamic.go
+++ b/app/cluster/dynamic.go
@@ -223,3 +223,7 @@ func (d *Dynamic) handleModeChange(newMode servermode.Mode) error {
 	d.currentMode = newMode
 	return nil
 }
+
+func (d *Dynamic) Mode() servermode.Mode {
+	return d.currentMode
+}

--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -279,9 +279,18 @@ func TestDynamicClusterManager(t *testing.T) {
 
 	chACK := make(chan bool)
 	provider.SendMode(servermode.NewChangeEvent(servermode.NormalMode, func(_ context.Context) error {
+		return nil
+	}))
+	require.Eventually(t, func() bool {
+		return dCM.Mode() == servermode.NormalMode
+	}, time.Second, time.Millisecond)
+	provider.SendMode(servermode.NewChangeEvent(servermode.DegradedMode, func(_ context.Context) error {
 		close(chACK)
 		return nil
 	}))
+	require.Eventually(t, func() bool {
+		return dCM.Mode() == servermode.DegradedMode
+	}, time.Second, time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		<-chACK

--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -213,7 +213,6 @@ func TestDynamicClusterManager(t *testing.T) {
 	processor.BackendConfig = mockBackendConfig
 	processor.Transformer = mockTransformer
 	mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
-	mockBackendConfig.EXPECT().AccessToken().AnyTimes()
 	mockTransformer.EXPECT().Setup().Times(1)
 
 	tDb := &jobsdb.MultiTenantHandleT{HandleT: rtDB}


### PR DESCRIPTION
# Description

Removed unnecessary backend config AccessToken call. 

## Notion Ticket

[ Notion Link ](https://www.notion.so/rudderstacks/Fix-flaky-test-app-cluster-integration_test-ce8e0d1984f7480f93ac53cf86d75ab4)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
