### PR TITLE
fix: removed the output of goRoutine count from the HTTP GET / of the server

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -148,6 +148,6 @@ func HealthHandler(w http.ResponseWriter, r *http.Request, jobsDB jobsdb.JobsDB)
 	}
 
 	appTypeStr := strings.ToUpper(config.GetEnv("APP_TYPE", EMBEDDED))
-	healthVal := fmt.Sprintf(`{"appType": "%s", "server":"UP", "db":"%s","acceptingEvents":"TRUE","routingEvents":"%s","mode":"%s","goroutines":"%d", "backendConfigMode": "%s", "lastSync":"%s", "lastRegulationSync":"%s"}`, appTypeStr, dbService, enabledRouter, strings.ToUpper(db.CurrentMode), runtime.NumGoroutine(), backendConfigMode, backendconfig.LastSync, backendconfig.LastRegulationSync)
+	healthVal := fmt.Sprintf(`{"appType": "%s", "server":"UP", "db":"%s","acceptingEvents":"TRUE","routingEvents":"%s","mode":"%s", "backendConfigMode": "%s", "lastSync":"%s", "lastRegulationSync":"%s"}`, appTypeStr, dbService, enabledRouter, strings.ToUpper(db.CurrentMode), backendConfigMode, backendconfig.LastSync, backendconfig.LastRegulationSync)
 	_, _ = w.Write([]byte(healthVal))
 }


### PR DESCRIPTION
When we call HTTP GET / for the rudder server - we get the below output

```json
{"appType": "EMBEDDED", "server":"UP", "db":"UP","acceptingEvents":"TRUE","routingEvents":"TRUE","mode":"NORMAL","goroutines":"636", "backendConfigMode": "API", "lastSync":"2022-06-18T14:58:11Z", "lastRegulationSync":""}
```

Exposing values such as `goroutines` might be helpful information for harmful agents. This PR removes it from being shown by the server.

