### PR TITLE
chore: remove issues event on notion pr sync github action

### DIFF
--- a/.github/workflows/notion-pr-sync.yaml
+++ b/.github/workflows/notion-pr-sync.yaml
@@ -1,8 +1,6 @@
 name: Notion PR Sync
 
 on:
-  issues:
-    types: [opened, edited, deleted, transferred, pinned, unpinned, closed, reopened, assigned, unassigned, labeled, unlabeled, locked, unlocked, milestoned, demilestoned]
   pull_request:
     types: [assigned, unassigned, labeled, unlabeled, opened, edited, closed, reopened, synchronize, converted_to_draft, ready_for_review, locked, unlocked, review_requested, review_request_removed, auto_merge_enabled, auto_merge_disabled]
 


### PR DESCRIPTION
# Description

This PR removes unused notion sync github action

## Notion Ticket

https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=e2ba0e5dcec241eb9a46480b533074cd

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
