### PR TITLE
chore(gateway): start gateway before setting up replay

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -234,13 +234,6 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 		MultiTenantStat: multitenantStats,
 	}
 
-	if enableReplay && embedded.App.Features().Replay != nil {
-		var replayDB jobsdb.HandleT
-		replayDB.Setup(jobsdb.ReadWrite, options.ClearDB, "replay", routerDBRetention, migrationMode, true, jobsdb.QueryFiltersT{}, prebackupHandlers)
-		defer replayDB.TearDown()
-		embedded.App.Features().Replay.Setup(&replayDB, gwDBForProcessor, routerDB, batchRouterDB)
-	}
-
 	if enableGateway {
 		rateLimiter := ratelimiter.HandleT{}
 		rateLimiter.SetUp()
@@ -274,6 +267,13 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 		g.Go(func() error {
 			return gw.StartWebHandler(ctx)
 		})
+	}
+
+	if enableReplay && embedded.App.Features().Replay != nil {
+		var replayDB jobsdb.HandleT
+		replayDB.Setup(jobsdb.ReadWrite, options.ClearDB, "replay", routerDBRetention, migrationMode, true, jobsdb.QueryFiltersT{}, prebackupHandlers)
+		defer replayDB.TearDown()
+		embedded.App.Features().Replay.Setup(&replayDB, gwDBForProcessor, routerDB, batchRouterDB)
 	}
 
 	g.Go(func() error {


### PR DESCRIPTION
# Description

Replay can either write to `gw` DB or `rt` DB, So it is essential to `gw` DB setup before the replay setup is called

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=977ff0511b5844d1a5dec1699aaec983)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
