### PR TITLE
fix: use a writer jobsdb for writing to gw tables during replay

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -273,7 +273,7 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 		var replayDB jobsdb.HandleT
 		replayDB.Setup(jobsdb.ReadWrite, options.ClearDB, "replay", routerDBRetention, migrationMode, true, jobsdb.QueryFiltersT{}, prebackupHandlers)
 		defer replayDB.TearDown()
-		embedded.App.Features().Replay.Setup(&replayDB, gwDBForProcessor, routerDB, batchRouterDB)
+		embedded.App.Features().Replay.Setup(&replayDB, gatewayDB, routerDB, batchRouterDB)
 	}
 
 	g.Go(func() error {

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -252,13 +252,6 @@ func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app
 		MultiTenantStat:  multitenantStats,
 	}
 
-	if enableReplay && processor.App.Features().Replay != nil {
-		var replayDB jobsdb.HandleT
-		replayDB.Setup(jobsdb.ReadWrite, options.ClearDB, "replay", routerDBRetention, migrationMode, true, jobsdb.QueryFiltersT{}, prebackupHandlers)
-		defer replayDB.TearDown()
-		processor.App.Features().Replay.Setup(&replayDB, gwDBForProcessor, routerDB, batchRouterDB)
-	}
-
 	g.Go(func() error {
 		return startHealthWebHandler(ctx)
 	})


### PR DESCRIPTION
# Description

Fixing a regression introduced during `cluster.Dynamic` refactoring. During event replay, a writer jobsdb is required as a target. Instead, for `gw` we were using a reader jobsdb. 

Additionally, removed the replay feature when the app starts with `APP_TYPE=PROCESSOR` since no gw events can be replayed using this app type. To perform event replay, only `APP_TYPE=EMBEDDED` can be used.

## Notion Ticket

[Use a writer jobsdb for writing to gw tables during replay](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=19e5fa5f34114ddf9b33525e04958f0f)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
