### PR TITLE
feat(core): add support for managing failed records in rsources.JobService

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -283,6 +283,10 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 		return dm.Run(ctx)
 	})
 
+	g.Go(func() error {
+		return rsourcesService.CleanupLoop(ctx)
+	})
+
 	return g.Wait()
 }
 

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -263,6 +263,10 @@ func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app
 		return dm.Run(ctx)
 	})
 
+	g.Go(func() error {
+		return rsourcesService.CleanupLoop(ctx)
+	})
+
 	return g.Wait()
 }
 

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -117,7 +117,7 @@ func (*sourcesHandler) AddFailedRecords(ctx context.Context, tx *sql.Tx, jobRunI
 	if err != nil {
 		return err
 	}
-	defer stmt.Close()
+	defer func() { _ = stmt.Close() }()
 
 	for i := range records {
 		_, err = stmt.ExecContext(
@@ -165,7 +165,7 @@ func (sh *sourcesHandler) GetFailedRecords(ctx context.Context, jobRunId string,
 	if err != nil {
 		return FailedRecords{}, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var failedRecord FailedRecord
 		err := rows.Scan(
@@ -316,7 +316,7 @@ func setupFailedKeysTable(ctx context.Context, db *sql.DB, defaultDbName string)
 		_ = tx.Rollback()
 		return err
 	}
-	_, err = tx.ExecContext(ctx, `create index if not exists failed_keys_job_run_id_idx on "rsources_failed_keys" (job_run_id)`)
+	_, err = tx.ExecContext(ctx, `create index if not exists rsources_failed_keys_job_run_id_idx on "rsources_failed_keys" (job_run_id)`)
 	if err != nil {
 		_ = tx.Rollback()
 		return err

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -274,7 +274,7 @@ func setupFailedKeysTable(ctx context.Context, db *sql.DB) error {
 		source_id text not null,
 		destination_id text not null,
 		record_id jsonb not null,
-		created_at timestamp not null default NOW(),
+		created_at timestamp not null default NOW()
 	)`
 	_, err = tx.ExecContext(ctx, sqlStatement)
 	if err != nil {

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -369,7 +369,7 @@ func (sh *sourcesHandler) setupLogicalReplication(ctx context.Context) error {
 	if err != nil {
 		pqError, ok := err.(*pq.Error)
 		if !ok || pqError.Code != pq.ErrorCode("42710") { // duplicate
-			return fmt.Errorf("failed to create publication on local database: %w", err)
+			return fmt.Errorf("failed to alter publication on local database to add failed_keys table: %w", err)
 		}
 	}
 
@@ -391,6 +391,9 @@ func (sh *sourcesHandler) setupLogicalReplication(ctx context.Context) error {
 
 	refreshSubscriptionQuery := fmt.Sprintf(`ALTER SUBSCRIPTION %s REFRESH PUBLICATION`, subscriptionName)
 	_, err = sh.sharedDB.ExecContext(ctx, refreshSubscriptionQuery)
+	if err != nil {
+		return fmt.Errorf("failed to refresh subscription on shared database: %w", err)
+	}
 
-	return err
+	return nil
 }

--- a/services/rsources/mock_rsources.go
+++ b/services/rsources/mock_rsources.go
@@ -116,18 +116,18 @@ func (mr *MockJobServiceMockRecorder) Delete(ctx, jobRunId interface{}) *gomock.
 }
 
 // GetFailedRecords mocks base method.
-func (m *MockJobService) GetFailedRecords(ctx context.Context, tx *sql.Tx, jobRunId string, filter JobFilter) (FailedRecords, error) {
+func (m *MockJobService) GetFailedRecords(ctx context.Context, jobRunId string, filter JobFilter) (FailedRecords, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFailedRecords", ctx, tx, jobRunId, filter)
+	ret := m.ctrl.Call(m, "GetFailedRecords", ctx, jobRunId, filter)
 	ret0, _ := ret[0].(FailedRecords)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFailedRecords indicates an expected call of GetFailedRecords.
-func (mr *MockJobServiceMockRecorder) GetFailedRecords(ctx, tx, jobRunId, filter interface{}) *gomock.Call {
+func (mr *MockJobServiceMockRecorder) GetFailedRecords(ctx, jobRunId, filter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFailedRecords", reflect.TypeOf((*MockJobService)(nil).GetFailedRecords), ctx, tx, jobRunId, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFailedRecords", reflect.TypeOf((*MockJobService)(nil).GetFailedRecords), ctx, jobRunId, filter)
 }
 
 // GetStatus mocks base method.

--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 )
 
 //go:generate mockgen -source=rsources.go -destination=mock_rsources.go -package=rsources github.com/rudderlabs/rudder-server/services/rsources JobService
@@ -68,7 +69,16 @@ type DestinationStatus struct {
 	Stats     Stats  `json:"stats"`
 }
 
-type FailedRecords struct{}
+type FailedRecords []FailedRecord
+
+type FailedRecord struct {
+	DestinationID string          `json:"destination_id"`
+	RecordID      json.RawMessage `json:"record_id"`
+	JobRunID      string          `json:"job_run_id"`
+	TaskRunID     string          `json:"task_run_id"`
+	SourceID      string          `json:"source_id"`
+	CreatedAt     time.Time       `json:"createdAt"`
+}
 
 var StatusNotFoundError = errors.New("Status not found")
 

--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -72,11 +72,11 @@ type DestinationStatus struct {
 type FailedRecords []FailedRecord
 
 type FailedRecord struct {
-	DestinationID string          `json:"destination_id"`
-	RecordID      json.RawMessage `json:"record_id"`
 	JobRunID      string          `json:"job_run_id"`
 	TaskRunID     string          `json:"task_run_id"`
 	SourceID      string          `json:"source_id"`
+	DestinationID string          `json:"destination_id"`
+	RecordID      json.RawMessage `json:"record_id"`
 	CreatedAt     time.Time       `json:"createdAt"`
 }
 
@@ -111,7 +111,7 @@ type JobService interface {
 	AddFailedRecords(ctx context.Context, tx *sql.Tx, jobRunId string, key JobTargetKey, records []json.RawMessage) error
 
 	// TODO: future extension
-	GetFailedRecords(ctx context.Context, tx *sql.Tx, jobRunId string, filter JobFilter) (FailedRecords, error)
+	GetFailedRecords(ctx context.Context, jobRunId string, filter JobFilter) (FailedRecords, error)
 
 	// CleanupLoop starts the cleanup loop in the background which will stop upon context termination or in case of an error
 	CleanupLoop(ctx context.Context) error
@@ -166,7 +166,7 @@ func (*noopService) AddFailedRecords(_ context.Context, _ *sql.Tx, _ string, _ J
 	return nil
 }
 
-func (*noopService) GetFailedRecords(_ context.Context, _ *sql.Tx, _ string, _ JobFilter) (FailedRecords, error) {
+func (*noopService) GetFailedRecords(_ context.Context, _ string, _ JobFilter) (FailedRecords, error) {
 	return FailedRecords{}, nil
 }
 

--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -107,10 +107,10 @@ type JobService interface {
 	// GetStatus gets the current status of a job
 	GetStatus(ctx context.Context, jobRunId string, filter JobFilter) (JobStatus, error)
 
-	// TODO: future extension
+	// AddFailedRecords adds failed records to the database as part of a transaction
 	AddFailedRecords(ctx context.Context, tx *sql.Tx, jobRunId string, key JobTargetKey, records []json.RawMessage) error
 
-	// TODO: future extension
+	// GetFailedRecords gets the failed records for a jobRunID, with filters on taskRunId and sourceId
 	GetFailedRecords(ctx context.Context, jobRunId string, filter JobFilter) (FailedRecords, error)
 
 	// CleanupLoop starts the cleanup loop in the background which will stop upon context termination or in case of an error


### PR DESCRIPTION
# Description

rsources.JobService now provides support for adding/deleting and getting failed records.

## Notion Ticket

[Failed records support](https://www.notion.so/rudderstacks/Failed-records-support-in-rsources-JobService-6a44ebf12aba4fd7b5b9099d334fd28a)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
