### PR TITLE
chore(core): suppress/debug-level logs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -799,7 +799,6 @@ func GetReleaseName() string {
 func GetInstanceID() string {
 	instance := GetEnv("INSTANCE_ID", "")
 	if instance == "" {
-		fmt.Println("wrong INSTANCE_ID provided")
 		return ""
 	}
 	instanceArr := strings.Split(instance, "-")

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -2352,7 +2352,7 @@ func (jd *HandleT) dropDSFromCache(ds dataSetT) {
 func (jd *HandleT) markClearEmptyResult(ds dataSetT, workspace string, stateFilters, customValFilters []string, parameterFilters []ParameterFilterT, value cacheValue, checkAndSet *cacheValue) {
 	// Safe check. Every status must have a valid workspace id for the cache to work efficiently.
 	if workspace == "" {
-		jd.logger.Errorf("[%s] Empty workspace key provided while looking into jobsdb cachemap", jd.tablePrefix)
+		jd.logger.Debugf("[%s] Empty workspace key provided while looking into jobsdb cachemap", jd.tablePrefix)
 		jd.invalidCacheKeyStat.Increment()
 	}
 


### PR DESCRIPTION
# Description

Addressing https://rudderlabs.slack.com/archives/C02B0A38QQG/p1655839120236839 :
```
If not already done, can we suppress/debug-level these logs as requested by couple of people in the community

1. Empty workspace key provided while looking into jobsdb cachemap

2. wrong INSTANCE_ID provided
```

## Notion Ticket

[suppress/debug-level spammy logs](https://www.notion.so/rudderstacks/suppress-debug-level-spammy-logs-2a592deee73046299830c26c1af50b80)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
