### PR TITLE
feat: expose robots.txt to disable crawling

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1332,6 +1332,11 @@ func (gateway *HandleT) healthHandler(w http.ResponseWriter, r *http.Request) {
 	app.HealthHandler(w, r, gateway.jobsDB)
 }
 
+// Robots prevents robots from crawling the gateway endpoints
+func (gateway *HandleT) robots(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte("User-agent: * \nDisallow: / \n"))
+}
+
 func reflectOrigin(origin string) bool {
 	return true
 }
@@ -1367,9 +1372,11 @@ func (gateway *HandleT) StartWebHandler(ctx context.Context) error {
 	srvMux.HandleFunc("/", gateway.healthHandler).Methods("GET")
 	srvMux.HandleFunc("/pixel/v1/track", gateway.pixelTrackHandler).Methods("GET")
 	srvMux.HandleFunc("/pixel/v1/page", gateway.pixelPageHandler).Methods("GET")
-	srvMux.HandleFunc("/version", gateway.versionHandler).Methods("GET")
 	srvMux.HandleFunc("/v1/webhook", gateway.webhookHandler.RequestHandler).Methods("POST", "GET")
 	srvMux.HandleFunc("/beacon/v1/batch", gateway.beaconBatchHandler).Methods("POST")
+
+	srvMux.HandleFunc("/version", gateway.versionHandler).Methods("GET")
+	srvMux.HandleFunc("/robots.txt", gateway.robots).Methods("GET")
 
 	if enableEventSchemasFeature {
 		srvMux.HandleFunc("/schemas/event-models", gateway.eventSchemaWebHandler(gateway.eventSchemaHandler.GetEventModels)).Methods("GET")

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -516,8 +516,24 @@ var _ = Describe("Gateway", func() {
 		}
 
 		for handlerType, handler := range allHandlers(gateway) {
-			assertHandler(handlerType, handler)
+			Context(handlerType, func() {
+				assertHandler(handlerType, handler)
+			})
 		}
+	})
+
+	Context("Robots", func() {
+		gateway := &HandleT{}
+
+		BeforeEach(func() {
+			gateway.Setup(c.mockApp, c.mockBackendConfig, c.mockJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService())
+		})
+
+		It("should return a robots.txt", func() {
+			expectHandlerResponse(gateway.robots, nil, 200, "User-agent: * \nDisallow: / \n")
+
+		})
+
 	})
 })
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -531,9 +531,7 @@ var _ = Describe("Gateway", func() {
 
 		It("should return a robots.txt", func() {
 			expectHandlerResponse(gateway.robots, nil, 200, "User-agent: * \nDisallow: / \n")
-
 		})
-
 	})
 })
 


### PR DESCRIPTION
# Description

We want data-plane URLs to stop appearing in Google searches and avoid being crawled in general.


The common way to do this is using [robots.txt](https://www.cloudflare.com/en-gb/learning/bots/what-is-robots.txt/):
The simplest rules that exclude all:
```
User-agent: * 
Disallow: / 
```
Any bot is not allowed to scrape paths under `/` -> everything.

## Notion Ticket

[Avoid-data-plane-URL-indexing](https://www.notion.so/rudderstacks/Avoid-data-plane-URL-indexing-b4dd98584cd344c3921ebf633d21262a)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
