### PR TITLE
chore(warehouse): add tracking plan version when populating context violations

### DIFF
--- a/processor/trackingplan_test.go
+++ b/processor/trackingplan_test.go
@@ -61,4 +61,5 @@ func TestReportViolations(t *testing.T) {
 	assert.True(t, castOk)
 	assert.Nil(t, eventContext["trackingPlanId"])
 	assert.Nil(t, eventContext["trackingPlanVersion"])
+	assert.Nil(t, eventContext["violationErrors"])
 }

--- a/processor/trackingplan_test.go
+++ b/processor/trackingplan_test.go
@@ -1,9 +1,10 @@
 package processor
 
 import (
+	"testing"
+
 	"github.com/rudderlabs/rudder-server/processor/transformer"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestReportViolations(t *testing.T) {

--- a/processor/trackingplan_test.go
+++ b/processor/trackingplan_test.go
@@ -8,59 +8,112 @@ import (
 )
 
 func TestReportViolations(t *testing.T) {
-	var (
-		validateEvent       *transformer.TransformerResponseT
-		trackingPlanId      string
-		trackingPlanVersion int
-	)
+	eventsFromTransformerResponse := func(response *transformer.ResponseT) (events []transformer.TransformerResponseT) {
+		events = append(events, response.Events...)
+		events = append(events, response.FailedEvents...)
+		return
+	}
 
-	// Propagate validation errors
-	validateEvent = &transformer.TransformerResponseT{
-		Metadata: transformer.MetadataT{
-			MergedTpConfig: map[string]interface{}{
-				"propagateValidationErrors": "true",
-			},
-		},
-		Output: map[string]interface{}{
-			"context": map[string]interface{}{},
-		},
-		ValidationErrors: []transformer.ValidationErrorT{
-			{
-				Type: "Datatype-Mismatch",
-				Meta: map[string]string{
-					"schemaPath":  "#/properties/properties/properties/price/type",
-					"instacePath": "/properties/price",
+	t.Run("Not propagating validation errors", func(t *testing.T) {
+		var (
+			trackingPlanId      string
+			trackingPlanVersion int
+		)
+
+		response := transformer.ResponseT{
+			Events: []transformer.TransformerResponseT{
+				{
+					Metadata: transformer.MetadataT{
+						MergedTpConfig: map[string]interface{}{
+							"propagateValidationErrors": "false",
+						},
+					},
+					Output: map[string]interface{}{
+						"context": map[string]interface{}{},
+					},
 				},
-				Message: "must be number",
 			},
-		},
-	}
-
-	trackingPlanId = "tp_2BFrdaslxH9A7B2hSDFKxw8wPN6knOb57"
-	trackingPlanVersion = 1
-
-	reportViolations(validateEvent, trackingPlanId, trackingPlanVersion)
-	eventContext, castOk := validateEvent.Output["context"].(map[string]interface{})
-	assert.True(t, castOk)
-	assert.Equal(t, eventContext["trackingPlanId"], trackingPlanId)
-	assert.Equal(t, eventContext["trackingPlanVersion"], trackingPlanVersion)
-	assert.Equal(t, eventContext["violationErrors"], validateEvent.ValidationErrors)
-
-	// Don't propagate validation error
-	validateEvent = &transformer.TransformerResponseT{
-		Metadata: transformer.MetadataT{
-			MergedTpConfig: map[string]interface{}{
-				"propagateValidationErrors": "false",
+			FailedEvents: []transformer.TransformerResponseT{
+				{
+					Metadata: transformer.MetadataT{
+						MergedTpConfig: map[string]interface{}{
+							"propagateValidationErrors": "false",
+						},
+					},
+					Output: map[string]interface{}{
+						"context": map[string]interface{}{},
+					},
+				},
 			},
-		},
-		Output: map[string]interface{}{
-			"context": map[string]interface{}{},
-		},
-	}
-	reportViolations(validateEvent, trackingPlanId, trackingPlanVersion)
-	eventContext, castOk = validateEvent.Output["context"].(map[string]interface{})
-	assert.True(t, castOk)
-	assert.Nil(t, eventContext["trackingPlanId"])
-	assert.Nil(t, eventContext["trackingPlanVersion"])
-	assert.Nil(t, eventContext["violationErrors"])
+		}
+
+		enhanceWithViolation(response, trackingPlanId, trackingPlanVersion)
+		for _, event := range eventsFromTransformerResponse(&response) {
+			eventContext, castOk := event.Output["context"].(map[string]interface{})
+			assert.True(t, castOk)
+			assert.Nil(t, eventContext["trackingPlanId"])
+			assert.Nil(t, eventContext["trackingPlanVersion"])
+			assert.Nil(t, eventContext["violationErrors"])
+		}
+	})
+
+	t.Run("Propagate validation errors", func(t *testing.T) {
+		response := transformer.ResponseT{
+			Events: []transformer.TransformerResponseT{
+				{
+					Metadata: transformer.MetadataT{
+						MergedTpConfig: map[string]interface{}{
+							"propagateValidationErrors": "true",
+						},
+					},
+					Output: map[string]interface{}{
+						"context": map[string]interface{}{},
+					},
+					ValidationErrors: []transformer.ValidationErrorT{
+						{
+							Type: "Datatype-Mismatch",
+							Meta: map[string]string{
+								"schemaPath":  "#/properties/properties/properties/price/type",
+								"instacePath": "/properties/price",
+							},
+							Message: "must be number",
+						},
+					},
+				},
+			},
+			FailedEvents: []transformer.TransformerResponseT{
+				{
+					Metadata: transformer.MetadataT{
+						MergedTpConfig: map[string]interface{}{
+							"propagateValidationErrors": "true",
+						},
+					},
+					Output: map[string]interface{}{
+						"context": map[string]interface{}{},
+					},
+					ValidationErrors: []transformer.ValidationErrorT{
+						{
+							Type: "Datatype-Mismatch",
+							Meta: map[string]string{
+								"schemaPath":  "#/properties/properties/properties/price/type",
+								"instacePath": "/properties/price",
+							},
+							Message: "must be number",
+						},
+					},
+				},
+			},
+		}
+		trackingPlanId := "tp_2BFrdaslxH9A7B2hSDFKxw8wPN6knOb57"
+		trackingPlanVersion := 1
+
+		enhanceWithViolation(response, trackingPlanId, trackingPlanVersion)
+		for _, event := range eventsFromTransformerResponse(&response) {
+			eventContext, castOk := event.Output["context"].(map[string]interface{})
+			assert.True(t, castOk)
+			assert.Equal(t, eventContext["trackingPlanId"], trackingPlanId)
+			assert.Equal(t, eventContext["trackingPlanVersion"], trackingPlanVersion)
+			assert.Equal(t, eventContext["violationErrors"], event.ValidationErrors)
+		}
+	})
 }

--- a/processor/trackingplan_test.go
+++ b/processor/trackingplan_test.go
@@ -1,0 +1,64 @@
+package processor
+
+import (
+	"github.com/rudderlabs/rudder-server/processor/transformer"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestReportViolations(t *testing.T) {
+	var (
+		validateEvent       *transformer.TransformerResponseT
+		trackingPlanId      string
+		trackingPlanVersion int
+	)
+
+	// Propagate validation errors
+	validateEvent = &transformer.TransformerResponseT{
+		Metadata: transformer.MetadataT{
+			MergedTpConfig: map[string]interface{}{
+				"propagateValidationErrors": "true",
+			},
+		},
+		Output: map[string]interface{}{
+			"context": map[string]interface{}{},
+		},
+		ValidationErrors: []transformer.ValidationErrorT{
+			{
+				Type: "Datatype-Mismatch",
+				Meta: map[string]string{
+					"schemaPath":  "#/properties/properties/properties/price/type",
+					"instacePath": "/properties/price",
+				},
+				Message: "must be number",
+			},
+		},
+	}
+
+	trackingPlanId = "tp_2BFrdaslxH9A7B2hSDFKxw8wPN6knOb57"
+	trackingPlanVersion = 1
+
+	reportViolations(validateEvent, trackingPlanId, trackingPlanVersion)
+	eventContext, castOk := validateEvent.Output["context"].(map[string]interface{})
+	assert.True(t, castOk)
+	assert.Equal(t, eventContext["trackingPlanId"], trackingPlanId)
+	assert.Equal(t, eventContext["trackingPlanVersion"], trackingPlanVersion)
+	assert.Equal(t, eventContext["violationErrors"], validateEvent.ValidationErrors)
+
+	// Don't propagate validation error
+	validateEvent = &transformer.TransformerResponseT{
+		Metadata: transformer.MetadataT{
+			MergedTpConfig: map[string]interface{}{
+				"propagateValidationErrors": "false",
+			},
+		},
+		Output: map[string]interface{}{
+			"context": map[string]interface{}{},
+		},
+	}
+	reportViolations(validateEvent, trackingPlanId, trackingPlanVersion)
+	eventContext, castOk = validateEvent.Output["context"].(map[string]interface{})
+	assert.True(t, castOk)
+	assert.Nil(t, eventContext["trackingPlanId"])
+	assert.Nil(t, eventContext["trackingPlanVersion"])
+}


### PR DESCRIPTION
# Description

Add tracking plan version when populating context violations

## Notion Ticket

https://www.notion.so/rudderstacks/Add-tracking-plan-version-Id-during-context-population-fdaa08e9936b4d409a81dc33f07b3200

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
