### PR TITLE
feat(core): report data-plane config to control-plane

### DIFF
--- a/config/config-reporting/connector.go
+++ b/config/config-reporting/connector.go
@@ -3,12 +3,13 @@ package config_reporting
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/cenkalti/backoff"
 	"github.com/rudderlabs/rudder-server/config"
 	"github.com/rudderlabs/rudder-server/utils/httpconnector"
 	"github.com/rudderlabs/rudder-server/utils/logger"
-	"os"
-	"time"
 )
 
 var (

--- a/config/config-reporting/connector.go
+++ b/config/config-reporting/connector.go
@@ -1,0 +1,51 @@
+package config_reporting
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/cenkalti/backoff"
+	"github.com/rudderlabs/rudder-server/config"
+	"github.com/rudderlabs/rudder-server/utils/httpconnector"
+	"github.com/rudderlabs/rudder-server/utils/logger"
+	"os"
+	"time"
+)
+
+var (
+	pkgLogger        logger.LoggerI
+	configBackendURL string
+)
+
+func Init() {
+	pkgLogger = logger.NewLogger().Child("config-reporting")
+	loadConfig()
+}
+
+func loadConfig() {
+	configBackendURL = config.GetEnv("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
+}
+
+// ReportDataPlaneConfig sends the data-plane information to the control-plane.
+func ReportDataPlaneConfig() error {
+	planeConfig := dataPlaneConfig{
+		Namespace: os.Getenv("NAMESPACE"),
+	}
+	rawJson, err := json.Marshal(planeConfig)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/data-plane-planeConfig", configBackendURL)
+	op := func() error {
+		return httpconnector.MakeHTTPPostRequest(url, rawJson)
+	}
+	backoffWithMaxRetry := backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 3)
+	err = backoff.RetryNotify(op, backoffWithMaxRetry, func(err error, t time.Duration) {
+		pkgLogger.Errorf("Failed to report data-plane planeConfig to control-plane with error: %s, retrying after: %v",
+			err.Error(), t)
+	})
+	if err != nil {
+		pkgLogger.Error("Error reporting data-plane planeConfig to the control-plane", err)
+		return err
+	}
+	return nil
+}

--- a/config/config-reporting/connector.go
+++ b/config/config-reporting/connector.go
@@ -3,7 +3,6 @@ package config_reporting
 import (
 	"encoding/json"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -13,8 +12,9 @@ import (
 )
 
 var (
-	pkgLogger        logger.LoggerI
-	configBackendURL string
+	pkgLogger                    logger.LoggerI
+	configBackendURL             string
+	dpConfigReportingAPIEndpoint string = "data-plane-planeConfig"
 )
 
 func Init() {
@@ -28,10 +28,10 @@ func loadConfig() {
 
 // ReportDataPlaneConfig sends the data-plane information to the control-plane.
 func ReportDataPlaneConfig() error {
-	planeConfig := dataPlaneConfig{
-		Namespace: os.Getenv("NAMESPACE"),
+	dpConfig := dataPlaneConfig{
+		Namespace: config.GetEnv("NAMESPACE", "non-k8s-deployment"),
 	}
-	rawJson, err := json.Marshal(planeConfig)
+	rawJson, err := json.Marshal(dpConfig)
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func ReportDataPlaneConfig() error {
 	if err != nil {
 		pkgLogger.Errorf("Failed to get the control plane host URL to report the data-plane config: %s", err.Error())
 	}
-	parsedURL.Path = "data-plane-planeConfig"
+	parsedURL.Path = dpConfigReportingAPIEndpoint
 	op := func() error {
 		return httpconnector.MakeHTTPPostRequest(parsedURL.String(), rawJson)
 	}

--- a/config/config-reporting/models.go
+++ b/config/config-reporting/models.go
@@ -1,0 +1,5 @@
+package config_reporting
+
+type dataPlaneConfig struct {
+	Namespace string `json:"namespace"`
+}

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/rudderlabs/rudder-server/app/apphandlers"
 	"github.com/rudderlabs/rudder-server/config"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
+	"github.com/rudderlabs/rudder-server/config/config-reporting"
 	"github.com/rudderlabs/rudder-server/services/alert"
 	"github.com/rudderlabs/rudder-server/services/archiver"
 	"github.com/rudderlabs/rudder-server/services/db"
@@ -158,6 +159,7 @@ func runAllInit() {
 	db.Init()
 	diagnostics.Init()
 	backendconfig.Init()
+	config_reporting.Init()
 	warehouseutils.Init()
 	bigquery.Init()
 	clickhouse.Init()
@@ -238,6 +240,8 @@ func Run(ctx context.Context) {
 
 	appTypeStr := strings.ToUpper(config.GetEnv("APP_TYPE", app.EMBEDDED))
 	appHandler = apphandlers.GetAppHandler(application, appTypeStr, versionHandler)
+
+	_ = config_reporting.ReportDataPlaneConfig()
 
 	version := versionInfo()
 	bugsnag.Configure(bugsnag.Configuration{

--- a/utils/httpconnector/connector.go
+++ b/utils/httpconnector/connector.go
@@ -1,0 +1,34 @@
+package httpconnector
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/rudderlabs/rudder-server/config"
+	"net/http"
+	"time"
+)
+
+// MakeHTTPPostRequest makes HTTP Post call to the url with the body as payload and returns the error if any.
+//This uses basic authentication
+func MakeHTTPPostRequest(url string, payload []byte) error {
+	rawJSON, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: config.GetDuration("HttpClient.timeout", 30, time.Second)}
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(rawJSON))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(config.GetWorkspaceToken(), "")
+
+	resp, err := client.Do(req)
+	if resp == nil {
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/utils/httpconnector/connector.go
+++ b/utils/httpconnector/connector.go
@@ -3,13 +3,14 @@ package httpconnector
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/rudderlabs/rudder-server/config"
 	"net/http"
 	"time"
+
+	"github.com/rudderlabs/rudder-server/config"
 )
 
 // MakeHTTPPostRequest makes HTTP Post call to the url with the body as payload and returns the error if any.
-//This uses basic authentication
+// This uses basic authentication
 func MakeHTTPPostRequest(url string, payload []byte) error {
 	rawJSON, err := json.Marshal(payload)
 	if err != nil {


### PR DESCRIPTION
# Description

Rudder Server will report it's configuration to the control-plane in order to enable transparency for control-plane and maintain backward compatibility. [Pull Request document](https://www.notion.so/rudderstacks/Feature-flags-Tech-Spec-d5e7e041c02543e99e7bbcfcec63e9e4#cf2ee37a64084794a91e3d930b1715d5)

## Notion Ticket

[Technical Requirement Document](https://www.notion.so/rudderstacks/Feature-flags-Tech-Spec-d5e7e041c02543e99e7bbcfcec63e9e4#cf2ee37a64084794a91e3d930b1715d5) 

[Sprint Ticket](https://www.notion.so/rudderstacks/Data-Plane-Config-Report-to-Control-Plane-5ce6abc2c65c423a9e24fd6f5e7fe5ef)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
