### PR TITLE
fix: recordId lookup

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -688,7 +688,7 @@ func makeCommonMetadataFromSingularEvent(singularEvent types.SingularEventT, bat
 	commonMetadata.SourceJobRunID, _ = misc.MapLookup(singularEvent, "context", "sources", "job_run_id").(string)
 	commonMetadata.SourceJobID, _ = misc.MapLookup(singularEvent, "context", "sources", "job_id").(string)
 	commonMetadata.SourceTaskRunID, _ = misc.MapLookup(singularEvent, "context", "sources", "task_run_id").(string)
-	commonMetadata.RecordID = misc.MapLookup(singularEvent, "context", "record_id")
+	commonMetadata.RecordID = misc.MapLookup(singularEvent, "recordId")
 
 	commonMetadata.EventName, _ = misc.MapLookup(singularEvent, "event").(string)
 	commonMetadata.EventType, _ = misc.MapLookup(singularEvent, "type").(string)


### PR DESCRIPTION
# Description

This is a hotfix for a regression introduced [in the last release](https://github.com/rudderlabs/rudder-server/pull/1829/files#diff-63264a27291123a1413bf5e86a8dcd368b9214681cafd30426fafbdaa2a182fa). The record ID was incorrectly mapped, leading to null being added to DB and returned to fail-request endpoint.

 
## Notion Ticket

https://www.notion.so/rudderstacks/Fix-missing-record_id-439a6cb7d63c4e09ab72ffc69327baaa

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
