### PR TITLE
fix: kafka multiple hosts

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -233,7 +233,7 @@ func TestMainFlow(t *testing.T) {
 		topics, err := tc.ListTopics(context.TODO())
 		require.NoError(t, err)
 
-		c, err := kafkaClient.New("tcp", []string{kafkaHost}, kafkaClient.Config{})
+		c, err := kafkaClient.New("tcp", []string{kafkaHost, kafkaHost}, kafkaClient.Config{})
 		require.NoError(t, err)
 
 		messages, errors := consume(t, c, topics)

--- a/router/customdestinationmanager/customdestinationmanager_test.go
+++ b/router/customdestinationmanager/customdestinationmanager_test.go
@@ -5,17 +5,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/rudderlabs/rudder-server/config"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/services/stats"
 	"github.com/rudderlabs/rudder-server/services/streammanager/kafka"
 	"github.com/rudderlabs/rudder-server/utils/logger"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCircuitBreaker(t *testing.T) {
 	const (
-		normalError  = "could not ping: could not dial tcp/unknown.example.com:9999: failed to dial: failed to open connection to unknown.example.com:9999: dial tcp: lookup unknown.example.com: no such host"
+		normalError  = "could not ping: could not dial any of the addresses"
 		breakerError = "circuit breaker is open"
 	)
 
@@ -74,12 +75,12 @@ func TestCircuitBreaker(t *testing.T) {
 
 func newDestination(t *testing.T, manager *CustomManagerT, dest backendconfig.DestinationT, attempt int, errorString string) { // skipcq: CRT-P0003
 	err := manager.onNewDestination(dest)
-	assert.EqualError(t, err, errorString, fmt.Sprintf("wrong error for attempt no %d", attempt))
+	assert.ErrorContains(t, err, errorString, fmt.Sprintf("wrong error for attempt no %d", attempt))
 }
 
 func newClientAttempt(t *testing.T, manager *CustomManagerT, destId string, attempt int, errorString string) {
 	err := manager.newClient(destId)
-	assert.EqualError(t, err, errorString, fmt.Sprintf("wrong error for attempt no %d", attempt))
+	assert.ErrorContains(t, err, errorString, fmt.Sprintf("wrong error for attempt no %d", attempt))
 }
 
 func getDestConfig() backendconfig.DestinationT {

--- a/services/streammanager/kafka/client/client.go
+++ b/services/streammanager/kafka/client/client.go
@@ -99,7 +99,7 @@ func NewAzureEventHubs(addresses []string, connectionString string, conf Config)
 }
 
 // Ping is used to check the connectivity only, then it discards the connection
-// Ping ensures that at least one of the provide addresses is reachable.
+// Ping ensures that at least one of the provided addresses is reachable.
 func (c *Client) Ping(ctx context.Context) error {
 	var lastErr error
 

--- a/services/streammanager/kafka/client/client.go
+++ b/services/streammanager/kafka/client/client.go
@@ -102,16 +102,17 @@ func NewAzureEventHubs(addresses []string, connectionString string, conf Config)
 // Ping ensures that at least one of the provided addresses is reachable.
 func (c *Client) Ping(ctx context.Context) error {
 	var lastErr error
-
 	for _, addr := range c.addresses {
 		conn, err := c.dialer.DialContext(ctx, c.network, kafka.TCP(addr).String())
 		if err == nil {
 			go func() { _ = conn.Close() }()
-			// we can connect with first available address, no need to check all
+			// we can connect to at least one address, no need to check all of them
 			return nil
 		}
 		lastErr = err
 	}
 
-	return fmt.Errorf("could not dial any of the addresses %s/%s: %w", c.network, kafka.TCP(c.addresses...).String(), lastErr)
+	return fmt.Errorf(
+		"could not dial any of the addresses %s/%s: %w", c.network, kafka.TCP(c.addresses...).String(), lastErr,
+	)
 }

--- a/services/streammanager/kafka/client/client.go
+++ b/services/streammanager/kafka/client/client.go
@@ -73,7 +73,7 @@ func New(network string, addresses []string, conf Config) (*Client, error) {
 }
 
 // NewConfluentCloud returns a Kafka client pre-configured to connect to Confluent Cloud
-func NewConfluentCloud(address, key, secret string, conf Config) (*Client, error) {
+func NewConfluentCloud(addresses []string, key, secret string, conf Config) (*Client, error) {
 	conf.SASL = &SASL{
 		ScramHashGen: ScramPlainText,
 		Username:     key,
@@ -82,11 +82,11 @@ func NewConfluentCloud(address, key, secret string, conf Config) (*Client, error
 	conf.TLS = &TLS{
 		WithSystemCertPool: true,
 	}
-	return New("tcp", []string{address}, conf)
+	return New("tcp", addresses, conf)
 }
 
 // NewAzureEventHubs returns a Kafka client pre-configured to connect to Azure Event Hubs
-func NewAzureEventHubs(address, connectionString string, conf Config) (*Client, error) {
+func NewAzureEventHubs(addresses []string, connectionString string, conf Config) (*Client, error) {
 	conf.SASL = &SASL{
 		ScramHashGen: ScramPlainText,
 		Username:     "$ConnectionString",
@@ -95,7 +95,7 @@ func NewAzureEventHubs(address, connectionString string, conf Config) (*Client, 
 	conf.TLS = &TLS{
 		WithSystemCertPool: true,
 	}
-	return New("tcp", []string{address}, conf)
+	return New("tcp", addresses, conf)
 }
 
 // Ping is used to check the connectivity only, then it discards the connection

--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -47,7 +47,7 @@ func TestClient_Ping(t *testing.T) {
 	require.NoError(t, err)
 
 	kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
-	c, err := New("tcp", []string{kafkaHost, kafkaHost}, Config{})
+	c, err := New("tcp", []string{"bad-host", kafkaHost}, Config{})
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -47,7 +47,7 @@ func TestClient_Ping(t *testing.T) {
 	require.NoError(t, err)
 
 	kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
-	c, err := New("tcp", []string{kafkaHost}, Config{})
+	c, err := New("tcp", []string{kafkaHost, kafkaHost}, Config{})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -71,7 +71,7 @@ func TestProducerBatchConsumerGroup(t *testing.T) {
 	require.NoError(t, err)
 
 	kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
-	c, err := New("tcp", []string{kafkaHost}, Config{ClientID: "some-client", DialTimeout: 5 * time.Second})
+	c, err := New("tcp", []string{kafkaHost, kafkaHost}, Config{ClientID: "some-client", DialTimeout: 5 * time.Second})
 	require.NoError(t, err)
 
 	var (
@@ -211,7 +211,7 @@ func TestConsumer_Partition(t *testing.T) {
 	require.NoError(t, err)
 
 	kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
-	c, err := New("tcp", []string{kafkaHost}, Config{ClientID: "some-client", DialTimeout: 5 * time.Second})
+	c, err := New("tcp", []string{kafkaHost, kafkaHost}, Config{ClientID: "some-client", DialTimeout: 5 * time.Second})
 	require.NoError(t, err)
 
 	var (
@@ -371,7 +371,7 @@ func TestWithSASL(t *testing.T) {
 			require.NoError(t, err)
 
 			kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
-			c, err := New("tcp", []string{kafkaHost}, Config{
+			c, err := New("tcp", []string{kafkaHost, kafkaHost}, Config{
 				ClientID:    "some-client",
 				DialTimeout: 10 * time.Second,
 				SASL: &SASL{

--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -624,7 +624,7 @@ func TestConfluentAzureCloud(t *testing.T) {
 		t.Skip("Skipping because credentials or host are not provided")
 	}
 
-	c, err := NewConfluentCloud(kafkaHost, confluentCloudKey, confluentCloudSecret, Config{
+	c, err := NewConfluentCloud([]string{kafkaHost}, confluentCloudKey, confluentCloudSecret, Config{
 		ClientID:    "some-client",
 		DialTimeout: 45 * time.Second,
 	})
@@ -650,7 +650,7 @@ func TestConfluentAzureCloud(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 
-	c, err = NewConfluentCloud(kafkaHost, "A BAD KEY", confluentCloudSecret, Config{
+	c, err = NewConfluentCloud([]string{kafkaHost}, "A BAD KEY", confluentCloudSecret, Config{
 		ClientID:    "some-client",
 		DialTimeout: 45 * time.Second,
 	})
@@ -669,7 +669,7 @@ func TestAzureEventHubsCloud(t *testing.T) {
 		t.Skip("Skipping because credentials or host are not provided")
 	}
 
-	c, err := NewAzureEventHubs(kafkaHost, azureEventHubsConnString, Config{
+	c, err := NewAzureEventHubs([]string{kafkaHost}, azureEventHubsConnString, Config{
 		ClientID:    "some-client",
 		DialTimeout: 45 * time.Second,
 	})
@@ -692,7 +692,7 @@ func TestAzureEventHubsCloud(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 
-	c, err = NewAzureEventHubs(kafkaHost, "A BAD CONNECTION STRING", Config{
+	c, err = NewAzureEventHubs([]string{kafkaHost}, "A BAD CONNECTION STRING", Config{
 		ClientID:    "some-client",
 		DialTimeout: 45 * time.Second,
 	})

--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -53,6 +53,11 @@ func TestClient_Ping(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, c.Ping(ctx))
 
+	// shuffling hosts
+	c, err = New("tcp", []string{kafkaHost, "bad-host", kafkaHost}, Config{})
+	require.NoError(t, err)
+	require.NoError(t, c.Ping(ctx))
+
 	require.NoError(t, kafkaContainer.Destroy())
 	err = c.Ping(ctx)
 	require.Error(t, err)
@@ -71,7 +76,7 @@ func TestProducerBatchConsumerGroup(t *testing.T) {
 	require.NoError(t, err)
 
 	kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
-	c, err := New("tcp", []string{kafkaHost, kafkaHost}, Config{ClientID: "some-client", DialTimeout: 5 * time.Second})
+	c, err := New("tcp", []string{"bad-host", kafkaHost}, Config{ClientID: "some-client", DialTimeout: 5 * time.Second})
 	require.NoError(t, err)
 
 	var (
@@ -211,7 +216,7 @@ func TestConsumer_Partition(t *testing.T) {
 	require.NoError(t, err)
 
 	kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
-	c, err := New("tcp", []string{kafkaHost, kafkaHost}, Config{ClientID: "some-client", DialTimeout: 5 * time.Second})
+	c, err := New("tcp", []string{"bad-host", kafkaHost}, Config{ClientID: "some-client", DialTimeout: 5 * time.Second})
 	require.NoError(t, err)
 
 	var (
@@ -371,7 +376,7 @@ func TestWithSASL(t *testing.T) {
 			require.NoError(t, err)
 
 			kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
-			c, err := New("tcp", []string{kafkaHost, kafkaHost}, Config{
+			c, err := New("tcp", []string{"bad-host", kafkaHost}, Config{
 				ClientID:    "some-client",
 				DialTimeout: 10 * time.Second,
 				SASL: &SASL{
@@ -452,7 +457,7 @@ func TestWithSASLBadCredentials(t *testing.T) {
 	require.NoError(t, err)
 
 	kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
-	c, err := New("tcp", []string{kafkaHost}, Config{
+	c, err := New("tcp", []string{"bad-host", kafkaHost}, Config{
 		ClientID:    "some-client",
 		DialTimeout: 10 * time.Second,
 		SASL: &SASL{
@@ -486,7 +491,7 @@ func TestProducer_Timeout(t *testing.T) {
 	require.NoError(t, err)
 
 	kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
-	c, err := New("tcp", []string{kafkaHost}, Config{ClientID: "some-client", DialTimeout: 5 * time.Second})
+	c, err := New("tcp", []string{"bad-host", kafkaHost}, Config{ClientID: "some-client", DialTimeout: 5 * time.Second})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -554,7 +559,7 @@ func TestIsProducerErrTemporary(t *testing.T) {
 	require.NoError(t, err)
 
 	kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
-	c, err := New("tcp", []string{kafkaHost}, Config{ClientID: "some-client", DialTimeout: 5 * time.Second})
+	c, err := New("tcp", []string{"bad-host", kafkaHost}, Config{ClientID: "some-client", DialTimeout: 5 * time.Second})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -624,7 +629,7 @@ func TestConfluentAzureCloud(t *testing.T) {
 		t.Skip("Skipping because credentials or host are not provided")
 	}
 
-	c, err := NewConfluentCloud([]string{kafkaHost}, confluentCloudKey, confluentCloudSecret, Config{
+	c, err := NewConfluentCloud([]string{"bad-host", kafkaHost}, confluentCloudKey, confluentCloudSecret, Config{
 		ClientID:    "some-client",
 		DialTimeout: 45 * time.Second,
 	})
@@ -692,7 +697,7 @@ func TestAzureEventHubsCloud(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 
-	c, err = NewAzureEventHubs([]string{kafkaHost}, "A BAD CONNECTION STRING", Config{
+	c, err = NewAzureEventHubs([]string{"bad-host", kafkaHost}, "A BAD CONNECTION STRING", Config{
 		ClientID:    "some-client",
 		DialTimeout: 45 * time.Second,
 	})

--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -85,7 +85,7 @@ func TestProducerBatchConsumerGroup(t *testing.T) {
 		c01Count, c02Count  int32
 		noOfMessages        = 50
 		ctx, cancel         = context.WithCancel(context.Background())
-		tc                  = testutil.NewWithDialer(c.dialer, c.network, c.addresses[0])
+		tc                  = testutil.NewWithDialer(c.dialer, c.network, c.addresses...)
 	)
 
 	t.Cleanup(gracefulTermination.Wait)
@@ -225,7 +225,7 @@ func TestConsumer_Partition(t *testing.T) {
 		c01Count, c02Count  int32
 		noOfMessages        = 50
 		ctx, cancel         = context.WithCancel(context.Background())
-		tc                  = testutil.NewWithDialer(c.dialer, c.network, c.addresses[0])
+		tc                  = testutil.NewWithDialer(c.dialer, c.network, c.addresses...)
 	)
 
 	t.Cleanup(gracefulTermination.Wait)
@@ -497,7 +497,7 @@ func TestProducer_Timeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	tc := testutil.NewWithDialer(c.dialer, c.network, c.addresses[0])
+	tc := testutil.NewWithDialer(c.dialer, c.network, c.addresses...)
 
 	// Check connectivity and try to create the desired topic until the brokers are up and running (max 30s)
 	require.NoError(t, c.Ping(ctx))
@@ -568,7 +568,7 @@ func TestIsProducerErrTemporary(t *testing.T) {
 	// Check connectivity and try to create the desired topic until the brokers are up and running (max 30s)
 	require.NoError(t, c.Ping(ctx))
 
-	tc := testutil.NewWithDialer(c.dialer, c.network, c.addresses[0])
+	tc := testutil.NewWithDialer(c.dialer, c.network, c.addresses...)
 	require.Eventually(t, func() bool {
 		err := tc.CreateTopic(ctx, t.Name(), 1, 1) // partitions = 2, replication factor = 1
 		if err != nil {

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -311,8 +311,9 @@ func NewProducerForAzureEventHubs(destinationConfig interface{}, o Opts) (*produ
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
+	addresses := strings.Split(destConfig.BootstrapServer, ",")
 	c, err := client.NewAzureEventHubs(
-		destConfig.BootstrapServer, destConfig.EventHubsConnectionString, client.Config{
+		addresses, destConfig.EventHubsConnectionString, client.Config{
 			DialTimeout: kafkaDialTimeout,
 		},
 	)
@@ -362,8 +363,9 @@ func NewProducerForConfluentCloud(destinationConfig interface{}, o Opts) (*produ
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
+	addresses := strings.Split(destConfig.BootstrapServer, ",")
 	c, err := client.NewConfluentCloud(
-		destConfig.BootstrapServer, destConfig.APIKey, destConfig.APISecret, client.Config{
+		addresses, destConfig.APIKey, destConfig.APISecret, client.Config{
 			DialTimeout: kafkaDialTimeout,
 		},
 	)

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -276,8 +276,8 @@ func TestProducerForConfluentCloud(t *testing.T) {
 			"apiSecret":       confluentCloudSecret,
 		}
 		p, err := NewProducerForConfluentCloud(destConfig, Opts{})
-		require.NotNil(t, p)
 		require.NoError(t, err)
+		require.NotNil(t, p)
 
 		require.Eventually(t, func() bool {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -187,7 +187,7 @@ func TestNewProducerForAzureEventHubs(t *testing.T) {
 
 		destConfig := map[string]interface{}{
 			"topic":                     azureEventHubName,
-			"bootstrapServer":           kafkaHost + "," + kafkaHost,
+			"bootstrapServer":           "bad-host," + kafkaHost + "," + kafkaHost,
 			"eventHubsConnectionString": azureEventHubsConnString,
 		}
 		p, err := NewProducerForAzureEventHubs(destConfig, Opts{})
@@ -271,7 +271,7 @@ func TestProducerForConfluentCloud(t *testing.T) {
 
 		destConfig := map[string]interface{}{
 			"topic":           "TestConfluentAzureCloud",
-			"bootstrapServer": kafkaHost + "," + kafkaHost,
+			"bootstrapServer": "bad-host," + kafkaHost + "," + kafkaHost,
 			"apiKey":          confluentCloudKey,
 			"apiSecret":       confluentCloudSecret,
 		}

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -187,7 +187,7 @@ func TestNewProducerForAzureEventHubs(t *testing.T) {
 
 		destConfig := map[string]interface{}{
 			"topic":                     azureEventHubName,
-			"bootstrapServer":           kafkaHost,
+			"bootstrapServer":           kafkaHost + "," + kafkaHost,
 			"eventHubsConnectionString": azureEventHubsConnString,
 		}
 		p, err := NewProducerForAzureEventHubs(destConfig, Opts{})
@@ -271,7 +271,7 @@ func TestProducerForConfluentCloud(t *testing.T) {
 
 		destConfig := map[string]interface{}{
 			"topic":           "TestConfluentAzureCloud",
-			"bootstrapServer": kafkaHost,
+			"bootstrapServer": kafkaHost + "," + kafkaHost,
 			"apiKey":          confluentCloudKey,
 			"apiSecret":       confluentCloudSecret,
 		}


### PR DESCRIPTION
# Description

Some parts of the Kafka manager didn't support multiple hosts/addresses.

The only part I couldn't test is the Azure producers because I ran out of free credit (and e-mails to create accounts there). Confluent Cloud and traditional Kafka are tested.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
