### PR TITLE
fix: calculate consistent tagStr cache keys in stats

### DIFF
--- a/services/stats/stats.go
+++ b/services/stats/stats.go
@@ -70,7 +70,6 @@ type Tags map[string]string
 
 // Strings returns all key value pairs as an ordered list of strings, sorted by increasing key order
 func (t Tags) Strings() []string {
-
 	res := make([]string, 0, len(t)*2)
 	// sorted by tag name (!important for consistent map iteration order)
 	tagNames := make([]string, 0, len(t))

--- a/services/stats/stats.go
+++ b/services/stats/stats.go
@@ -3,6 +3,7 @@ package stats
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -66,6 +67,28 @@ func Init() {
 }
 
 type Tags map[string]string
+
+// Strings returns all key value pairs as an ordered list of strings, sorted by increasing key order
+func (t Tags) Strings() []string {
+
+	res := make([]string, 0, len(t)*2)
+	// sorted by tag name (!important for consistent map iteration order)
+	tagNames := make([]string, 0, len(t))
+	for n := range t {
+		tagNames = append(tagNames, n)
+	}
+	sort.Strings(tagNames)
+	for _, tagName := range tagNames {
+		tagVal := t[tagName]
+		res = append(res, strings.ReplaceAll(tagName, ":", "-"), strings.ReplaceAll(tagVal, ":", "-"))
+	}
+	return res
+}
+
+// String returns all key value pairs as a single string, separated by commas, sorted by increasing key order
+func (t Tags) String() string {
+	return strings.Join(t.Strings(), ",")
+}
 
 // Stats manages provisioning of RudderStats
 type Stats interface {
@@ -202,34 +225,27 @@ func newTaggedStat(Name, StatType string, tags Tags, samplingRate float32) (rSta
 			dontProcess: true,
 		}
 	}
-
-	tagStr := StatType
-	for tagName, tagVal := range tags {
-		tagName = strings.ReplaceAll(tagName, ":", "-")
-		tagStr += fmt.Sprintf(`|%s|%s`, tagName, tagVal)
+	if tags == nil {
+		tags = make(Tags)
 	}
+	// key comprises of the measurement name plus all tag-value pairs
+	taggedClientKey := StatType + tags.String()
 
 	taggedClientsMapLock.RLock()
-	taggedClient, found := taggedClientsMap[tagStr]
+	taggedClient, found := taggedClientsMap[taggedClientKey]
 	taggedClientsMapLock.RUnlock()
 
 	if !found {
-
-		tagVals := make([]string, 0, len(tags)*2)
-		for tagName, tagVal := range tags {
-			tagName = strings.ReplaceAll(tagName, ":", "-")
-			tagVal = strings.ReplaceAll(tagVal, ":", "-")
-			tagVals = append(tagVals, tagName, tagVal)
-		}
-
 		taggedClientsMapLock.Lock()
-		if !connEstablished {
-			taggedClientPendingTags = append(taggedClientPendingTags, tagStr)
-			taggedClientPendingKeys = append(taggedClientPendingKeys, tagVals)
+		if taggedClient, found = taggedClientsMap[taggedClientKey]; !found { // double check for race
+			tagVals := tags.Strings()
+			if !connEstablished {
+				taggedClientPendingTags = append(taggedClientPendingTags, taggedClientKey)
+				taggedClientPendingKeys = append(taggedClientPendingKeys, tagVals)
+			}
+			taggedClient = client.Clone(conn, statsd.TagsFormat(getTagsFormat()), defaultTags(), statsd.Tags(tagVals...), statsd.SampleRate(samplingRate))
+			taggedClientsMap[taggedClientKey] = taggedClient
 		}
-		taggedClient = client.Clone(conn, statsd.TagsFormat(getTagsFormat()), defaultTags(), statsd.Tags(tagVals...), statsd.SampleRate(samplingRate))
-
-		taggedClientsMap[tagStr] = taggedClient
 		taggedClientsMapLock.Unlock()
 	}
 

--- a/services/stats/stats.go
+++ b/services/stats/stats.go
@@ -70,6 +70,9 @@ type Tags map[string]string
 
 // Strings returns all key value pairs as an ordered list of strings, sorted by increasing key order
 func (t Tags) Strings() []string {
+	if len(t) == 0 {
+		return nil
+	}
 	res := make([]string, 0, len(t)*2)
 	// sorted by tag name (!important for consistent map iteration order)
 	tagNames := make([]string, 0, len(t))

--- a/services/stats/stats_test.go
+++ b/services/stats/stats_test.go
@@ -1,0 +1,40 @@
+package stats_test
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-server/services/stats"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTags(t *testing.T) {
+	tags := stats.Tags{
+		"b": "value1",
+		"a": "value2",
+	}
+
+	t.Run("strings method", func(t *testing.T) {
+		for i := 0; i < 100; i++ { // just making sure we are not just lucky with the order
+			require.Equal(t, []string{"a", "value2", "b", "value1"}, tags.Strings())
+		}
+	})
+
+	t.Run("string method", func(t *testing.T) {
+		require.Equal(t, "a,value2,b,value1", tags.String())
+	})
+
+	t.Run("special character replacement", func(t *testing.T) {
+		specialTags := stats.Tags{
+			"b:1": "value1:1",
+			"a:1": "value2:2",
+		}
+		require.Equal(t, []string{"a-1", "value2-2", "b-1", "value1-1"}, specialTags.Strings())
+	})
+
+	t.Run("empty tags", func(t *testing.T) {
+		emptyTags := stats.Tags{}
+		require.Equal(t, []string{}, emptyTags.Strings())
+		require.Equal(t, "", emptyTags.String())
+	})
+
+}

--- a/services/stats/stats_test.go
+++ b/services/stats/stats_test.go
@@ -33,7 +33,7 @@ func TestTags(t *testing.T) {
 
 	t.Run("empty tags", func(t *testing.T) {
 		emptyTags := stats.Tags{}
-		require.Equal(t, []string{}, emptyTags.Strings())
+		require.Nil(t, emptyTags.Strings())
 		require.Equal(t, "", emptyTags.String())
 	})
 }

--- a/services/stats/stats_test.go
+++ b/services/stats/stats_test.go
@@ -36,5 +36,4 @@ func TestTags(t *testing.T) {
 		require.Equal(t, []string{}, emptyTags.Strings())
 		require.Equal(t, "", emptyTags.String())
 	})
-
 }


### PR DESCRIPTION
# Description

Previously we were calculating a cache key by iterating over the map using the default random order of the map. This meant that for 1 distinct set of 10 tags we ended up with 10! = 3628800 different key combinations in our cache map for the same thing.

Here I'm therefore introducing `stats.Tags#Strings` and `stats.Tags#String` methods. Both of them return tag key value pairs sorted by increasing key order.

Fixes an issue with inconsistent (unsorted) cache keys being calculated while populating an in-memory cache holding tagged stats clients.

## Notion Ticket

[Calculate consistent tagStr cache keys in stats](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=80a1a01c2df4434da3b347f5177fef86)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
