### PR TITLE
chore(multi-tenant): mt flow to dos

### DIFF
--- a/app/cluster/state/static.go
+++ b/app/cluster/state/static.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/rudderlabs/rudder-server/app/cluster"
+	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/utils/types/servermode"
 	"github.com/rudderlabs/rudder-server/utils/types/workspace"
 )
@@ -37,10 +38,11 @@ func (s *StaticProvider) ServerMode(ctx context.Context) <-chan servermode.Chang
 }
 
 // WorkspaceIDs returns an empty channel, since we don't expect workspaceIDs updates with static provider
-// TODO: This method should return proper workspaceIDs for backend config, even with static provide.
 func (s *StaticProvider) WorkspaceIDs(ctx context.Context) <-chan workspace.ChangeEvent {
-	ch := make(chan workspace.ChangeEvent)
-
+	ch := make(chan workspace.ChangeEvent, 1)
+	wId := backendconfig.DefaultBackendConfig.AccessToken()
+	ackFn := func(_ context.Context) error { return nil }
+	ch <- workspace.NewWorkspacesRequest([]string{wId}, ackFn)
 	go func() {
 		<-ctx.Done()
 		close(ch)

--- a/app/cluster/state/static_test.go
+++ b/app/cluster/state/static_test.go
@@ -2,13 +2,14 @@ package state_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/rudderlabs/rudder-server/app/cluster/state"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/config/backend-config"
 	"github.com/rudderlabs/rudder-server/utils/types/servermode"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestStatic_ServerMode(t *testing.T) {

--- a/app/cluster/state/static_test.go
+++ b/app/cluster/state/static_test.go
@@ -35,7 +35,7 @@ func TestStatic_WorkspaceIDs(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockBackendConfig := mocksBackendConfig.NewMockBackendConfig(mockCtrl)
 	backendconfig.DefaultBackendConfig = mockBackendConfig
-	mockBackendConfig.EXPECT().AccessToken().AnyTimes()
+	mockBackendConfig.EXPECT().AccessToken().Times(2)
 	s := state.NewStaticProvider(servermode.DegradedMode)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/app/cluster/state/static_test.go
+++ b/app/cluster/state/static_test.go
@@ -2,11 +2,13 @@ package state_test
 
 import (
 	"context"
-	"testing"
-
+	"github.com/golang/mock/gomock"
 	"github.com/rudderlabs/rudder-server/app/cluster/state"
+	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
+	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/config/backend-config"
 	"github.com/rudderlabs/rudder-server/utils/types/servermode"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestStatic_ServerMode(t *testing.T) {
@@ -29,12 +31,18 @@ func TestStatic_ServerMode(t *testing.T) {
 }
 
 func TestStatic_WorkspaceIDs(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	mockBackendConfig := mocksBackendConfig.NewMockBackendConfig(mockCtrl)
+	backendconfig.DefaultBackendConfig = mockBackendConfig
+	mockBackendConfig.EXPECT().AccessToken().AnyTimes()
 	s := state.NewStaticProvider(servermode.DegradedMode)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	ch := s.WorkspaceIDs(ctx)
-	require.Empty(t, ch)
+	chEvent := <-ch
+	wIds := chEvent.WorkspaceIDs()
+	require.Equal(t, []string{mockBackendConfig.AccessToken()}, wIds)
 
 	t.Log("cancel context should close channel")
 	cancel()

--- a/config/backend-config/backend-config.go
+++ b/config/backend-config/backend-config.go
@@ -420,6 +420,7 @@ func newForDeployment(deploymentType deployment.Type, configEnvHandler types.Con
 		}
 	// Fallback to dedicated
 	default:
+		cancel()
 		return nil, fmt.Errorf("Deployment type %q not supported", deploymentType)
 	}
 

--- a/main.go
+++ b/main.go
@@ -267,8 +267,6 @@ func Run(ctx context.Context) {
 			pkgLogger.Errorf("Unable to setup backend config: %s", err)
 			return
 		}
-
-		backendconfig.DefaultBackendConfig.StartWithIDs(backendconfig.DefaultBackendConfig.AccessToken())
 	}
 
 	g, ctx := errgroup.WithContext(ctx)

--- a/main.go
+++ b/main.go
@@ -267,6 +267,7 @@ func Run(ctx context.Context) {
 			pkgLogger.Errorf("Unable to setup backend config: %s", err)
 			return
 		}
+		backendconfig.DefaultBackendConfig.StartWithIDs(backendconfig.DefaultBackendConfig.AccessToken())
 	}
 
 	g, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
# Description
Following changes are introduced:
1. Earlier the three members `ctx` `cancel` and `blockChan` of `CommonBackendConfig` were being populated into the struct during the `CommonBackendConfig.StartWithIDs()` function call. This is not intuitive and expected behaviour from the `CommonBackendConfig.StartWithIDs()` function. As populating these should be the part of creation of backendConfig during the setup process, so now this is happening with the help of `Setup()` function. 
2. `WorkspaceIDs(ctx context.Context) <-chan workspace.ChangeEvent` of `StaticProvider` 
     - Previous behaviour: This method was returning `<-chan workspace.ChangeEvent` without any workspace IDs or acknowledgement function. The assumption was that `StaticProvider` will only be used for dedicated or hosted type of deployment. In hosted type of deployments, we do not need workspace IDs to poll the backend config and in dedicated we poll backend config only for one workspace ID which was being done in `main`. This was creating an anti-pattern between Static and ETCD based provider.
     - New Behaviour: Now the channel will have the workspace ID in case of dedicated deployment and that will be used to poll the backend config. 
     
     Advantage: This will make sure that the implementation is uniform for the interface (`ChangeEventProvider`) across ETCD based provider and Static provider.

3. `WorkspaceIDs(ctx context.Context) <-chan workspace.ChangeEvent` function of `ETCDManager` was not consistent every time the context gets cancelled.


## Notion Ticket

[< Notion Ticket >](https://www.notion.so/rudderstacks/Document-mt-dev-deployment-5d624eb63cc34ccd8f81c8be01018a93)

## Security

- [*] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
