### PR TITLE
chore(warehouse): handle ErrNoRows during pgnotifier claim

### DIFF
--- a/services/pgnotifier/pgnotifier.go
+++ b/services/pgnotifier/pgnotifier.go
@@ -294,8 +294,11 @@ func (notifier *PgNotifierT) claim(workerID string) (claim ClaimT, err error) {
 			}
 		}
 	}()
+	if err == sql.ErrNoRows {
+		return
+	}
 	if err != nil {
-		pkgLogger.Errorf("PgNotifier: Claim failed: %v, query: %s, connInfo: %s", err, stmt, notifier.URI)
+		pkgLogger.Debugf("PgNotifier: Claim failed: %v, query: %s, connInfo: %s", err, stmt, notifier.URI)
 		return
 	}
 

--- a/services/pgnotifier/pgnotifier.go
+++ b/services/pgnotifier/pgnotifier.go
@@ -295,10 +295,13 @@ func (notifier *PgNotifierT) claim(workerID string) (claim ClaimT, err error) {
 		}
 	}()
 	if err == sql.ErrNoRows {
+		tx.Rollback()
 		return
 	}
 	if err != nil {
 		pkgLogger.Errorf("PgNotifier: Claim failed: %v, query: %s, connInfo: %s", err, stmt, notifier.URI)
+
+		tx.Rollback()
 		return
 	}
 

--- a/services/pgnotifier/pgnotifier.go
+++ b/services/pgnotifier/pgnotifier.go
@@ -295,13 +295,10 @@ func (notifier *PgNotifierT) claim(workerID string) (claim ClaimT, err error) {
 		}
 	}()
 	if err == sql.ErrNoRows {
-		_ = tx.Rollback()
 		return
 	}
 	if err != nil {
 		pkgLogger.Errorf("PgNotifier: Claim failed: %v, query: %s, connInfo: %s", err, stmt, notifier.URI)
-
-		_ = tx.Rollback()
 		return
 	}
 

--- a/services/pgnotifier/pgnotifier.go
+++ b/services/pgnotifier/pgnotifier.go
@@ -298,7 +298,7 @@ func (notifier *PgNotifierT) claim(workerID string) (claim ClaimT, err error) {
 		return
 	}
 	if err != nil {
-		pkgLogger.Debugf("PgNotifier: Claim failed: %v, query: %s, connInfo: %s", err, stmt, notifier.URI)
+		pkgLogger.Errorf("PgNotifier: Claim failed: %v, query: %s, connInfo: %s", err, stmt, notifier.URI)
 		return
 	}
 

--- a/services/pgnotifier/pgnotifier.go
+++ b/services/pgnotifier/pgnotifier.go
@@ -295,13 +295,13 @@ func (notifier *PgNotifierT) claim(workerID string) (claim ClaimT, err error) {
 		}
 	}()
 	if err == sql.ErrNoRows {
-		tx.Rollback()
+		_ = tx.Rollback()
 		return
 	}
 	if err != nil {
 		pkgLogger.Errorf("PgNotifier: Claim failed: %v, query: %s, connInfo: %s", err, stmt, notifier.URI)
 
-		tx.Rollback()
+		_ = tx.Rollback()
 		return
 	}
 


### PR DESCRIPTION
# Description

Handle errNoRows during a claim for pgNotifier. Here we don't intend to put debug/error logs when claim is failed for No updates because it is going to mess up the logs when we enable the Debug mode.

## Notion Ticket

https://www.notion.so/rudderstacks/Handle-errNoRows-during-claim-for-pg-notifier-8a2702f2e5da4e4e88b033f8f5864b58

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
