### PR TITLE
fix(core): deletion API response type

### DIFF
--- a/regulation-worker/internal/delete/api/api_test.go
+++ b/regulation-worker/internal/delete/api/api_test.go
@@ -147,7 +147,7 @@ type deleteAPI struct {
 	payload        string
 	respStatusCode int
 	respBodyStatus model.JobStatus
-	respBodyErr    error
+	respBodyErr    string
 }
 
 func (d *deleteAPI) deleteMockServer(w http.ResponseWriter, r *http.Request) {

--- a/regulation-worker/internal/delete/api/schema.go
+++ b/regulation-worker/internal/delete/api/schema.go
@@ -15,5 +15,5 @@ type apiDeletionPayloadSchema struct {
 
 type JobRespSchema struct {
 	Status string `json:"status"`
-	Error  error  `json:"error"`
+	Error  string `json:"error"`
 }


### PR DESCRIPTION
# Description

Deletion API (endpoint `/deleteUsers`) had wrong response type in case of failures. 

## Notion Ticket

[Notion Ticket](https://www.notion.so/rudderstacks/regulation-worker-transformer-response-parsing-issue-be82e1ccf1474e1e900b3179fe349168)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
