### PR TITLE
chore(router): improve collect metrics performance

### DIFF
--- a/mocks/router/oauthResponseHandler/mock_oauthResponseHandler.go
+++ b/mocks/router/oauthResponseHandler/mock_oauthResponseHandler.go
@@ -36,7 +36,7 @@ func (m *MockAuthorizer) EXPECT() *MockAuthorizerMockRecorder {
 }
 
 // DisableDestination mocks base method.
-func (m *MockAuthorizer) DisableDestination(arg0 backendconfig.DestinationT, arg1, arg2 string) (int, string) {
+func (m *MockAuthorizer) DisableDestination(arg0 *backendconfig.DestinationT, arg1, arg2 string) (int, string) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableDestination", arg0, arg1, arg2)
 	ret0, _ := ret[0].(int)

--- a/router/oauthResponseHandler/oauthResponseHandler.go
+++ b/router/oauthResponseHandler/oauthResponseHandler.go
@@ -71,7 +71,7 @@ type OAuthErrResHandler struct {
 
 type Authorizer interface {
 	Setup()
-	DisableDestination(destination backendconfig.DestinationT, workspaceId, rudderAccountId string) (statusCode int, resBody string)
+	DisableDestination(destination *backendconfig.DestinationT, workspaceId, rudderAccountId string) (statusCode int, resBody string)
 	RefreshToken(refTokenParams *RefreshTokenParams) (int, *AuthResponse)
 	FetchToken(fetchTokenParams *RefreshTokenParams) (int, *AuthResponse)
 }
@@ -178,8 +178,8 @@ func (authErrHandler *OAuthErrResHandler) GetTokenInfo(refTokenParams *RefreshTo
 	accountMutex.RLock()
 	refVal, ok := authErrHandler.destAuthInfoMap[refTokenParams.AccountId]
 	if ok {
-		isInvalidAccountSecretForRefresh := (router_utils.IsNotEmptyString(string(refVal.Account.Secret)) &&
-			!bytes.Equal(refVal.Account.Secret, refTokenParams.Secret))
+		isInvalidAccountSecretForRefresh := router_utils.IsNotEmptyString(string(refVal.Account.Secret)) &&
+			!bytes.Equal(refVal.Account.Secret, refTokenParams.Secret)
 		if isInvalidAccountSecretForRefresh {
 			accountMutex.RUnlock()
 			authErrHandler.logger.Debugf("[%s request] [Cache] :: (Read) %s response received(rt-worker-%d): %s\n", loggerNm, logTypeName, refTokenParams.WorkerId, refVal.Account.Secret)
@@ -343,7 +343,7 @@ func (refStats *OAuthStats) SendCountStat() {
 	}).Increment()
 }
 
-func (authErrHandler *OAuthErrResHandler) DisableDestination(destination backendconfig.DestinationT, workspaceId, rudderAccountId string) (statusCode int, respBody string) {
+func (authErrHandler *OAuthErrResHandler) DisableDestination(destination *backendconfig.DestinationT, workspaceId, rudderAccountId string) (statusCode int, respBody string) {
 	authErrHandlerTimeStart := time.Now()
 	destinationId := destination.ID
 	disableDestMutex := authErrHandler.getKeyMutex(authErrHandler.destLockMap, destinationId)

--- a/router/router.go
+++ b/router/router.go
@@ -16,6 +16,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/cenkalti/backoff/v4"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/processor/integrations"
@@ -32,7 +34,6 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/bytesize"
 	utilTypes "github.com/rudderlabs/rudder-server/utils/types"
 	"github.com/tidwall/gjson"
-	"github.com/tidwall/sjson"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-server/config"
@@ -98,7 +99,7 @@ type HandleT struct {
 	failureMetricLock                      sync.RWMutex
 	diagnosisTicker                        *time.Ticker
 	requestsMetric                         []requestMetric
-	failuresMetric                         map[string][]failureMetric
+	failuresMetric                         map[string]map[string]int
 	customDestinationManager               customdestinationmanager.DestinationManager
 	throttler                              throttler.Throttler
 	guaranteeUserEventOrder                bool
@@ -231,6 +232,8 @@ var (
 	disableEgress                                                 bool
 )
 
+var jsonfast = jsoniter.ConfigCompatibleWithStandardLibrary
+
 type requestMetric struct {
 	RequestRetries       int
 	RequestAborted       int
@@ -238,23 +241,15 @@ type requestMetric struct {
 	RequestCompletedTime time.Duration
 }
 
-type failureMetric struct {
-	RouterDestination string          `json:"router_destination"`
-	UserId            string          `json:"user_id"`
-	RouterAttemptNum  int             `json:"router_attempt_num"`
-	ErrorCode         string          `json:"error_code"`
-	ErrorResponse     json.RawMessage `json:"error_response"`
-}
-
 type resultSetT struct {
 	id                 int64
 	resultSetBeginTime time.Time
-	timeAlloted        time.Duration
+	timeAllotted       time.Duration
 }
 
-func (rt *HandleT) initResultSet(timeAlloted time.Duration) {
+func (rt *HandleT) initResultSet(timeAllotted time.Duration) {
 	rt.lastResultSet.id++
-	rt.lastResultSet.timeAlloted = timeAlloted
+	rt.lastResultSet.timeAllotted = timeAllotted
 	rt.addResultSetMeta(rt.lastResultSet)
 }
 
@@ -268,7 +263,7 @@ func (rt *HandleT) addResultSetMeta(resultSet *resultSetT) {
 
 	newResultSet := resultSetT{}
 	newResultSet.id = resultSet.id
-	newResultSet.timeAlloted = resultSet.timeAlloted
+	newResultSet.timeAllotted = resultSet.timeAllotted
 
 	rt.resultSetMeta[resultSet.id] = &newResultSet
 
@@ -670,14 +665,14 @@ func (worker *workerT) processDestinationJobs() {
 					resultSet := worker.rt.getResultSet(resultSetID)
 					worker.localResultSet.id = resultSetID
 					worker.localResultSet.resultSetBeginTime = time.Now()
-					worker.localResultSet.timeAlloted = resultSet.timeAlloted
+					worker.localResultSet.timeAllotted = resultSet.timeAllotted
 				}
 
 				// Assuming twice the overhead - defensive: 30% was just fine though
 				// In fact, the timeout should be more than the maximum latency allowed by these workers.
 				// Assuming 10s maximum latency
 				elapsed := time.Since(worker.localResultSet.resultSetBeginTime)
-				threshold := time.Duration(2.0 * math.Max(float64(worker.localResultSet.timeAlloted), float64(10*time.Second)))
+				threshold := time.Duration(2.0 * math.Max(float64(worker.localResultSet.timeAllotted), float64(10*time.Second)))
 				if elapsed > threshold {
 					respStatusCode = types.RouterTimedOutStatusCode
 					respBody = fmt.Sprintf("%d Jobs took more time than expected. Will be retried", types.RouterTimedOutStatusCode)
@@ -1594,8 +1589,11 @@ func (rt *HandleT) commitStatusList(responseList *[]jobResponseT) {
 				}
 
 				rt.failureMetricLock.Lock()
-				failureMetricVal := failureMetric{RouterDestination: rt.destName, UserId: resp.userID, RouterAttemptNum: resp.status.AttemptNum, ErrorCode: resp.status.ErrorCode, ErrorResponse: resp.status.ErrorResponse}
-				rt.failuresMetric[event] = append(rt.failuresMetric[event], failureMetricVal)
+				_, ok := rt.failuresMetric[event][string(resp.status.ErrorResponse)]
+				if !ok {
+					rt.failuresMetric[event] = make(map[string]int)
+				}
+				rt.failuresMetric[event][string(resp.status.ErrorResponse)] += 1
 				rt.failureMetricLock.Unlock()
 			}
 		}
@@ -1801,30 +1799,24 @@ func (rt *HandleT) collectMetrics(ctx context.Context) {
 		rt.requestsMetric = nil
 		rt.requestsMetricLock.RUnlock()
 
-		// This lock will ensure we dont send out Track Request while filling up the
+		// This lock will ensure we don't send out Track Request while filling up the
 		// failureMetric struct
-		rt.failureMetricLock.RLock()
-		for key, values := range rt.failuresMetric {
-			var stringValue string
+		rt.failureMetricLock.Lock()
+		for key, value := range rt.failuresMetric {
 			var err error
-			errorMap := make(map[string]int)
-			for _, value := range values {
-				errorMap[string(value.ErrorResponse)] = errorMap[string(value.ErrorResponse)] + 1
+			stringValueBytes, err := jsonfast.Marshal(value)
+			if err != nil {
+				stringValueBytes = []byte{}
 			}
-			for k, v := range errorMap {
-				stringValue, err = sjson.Set(stringValue, k, v)
-				if err != nil {
-					stringValue = ""
-				}
-			}
+
 			Diagnostics.Track(key, map[string]interface{}{
 				diagnostics.RouterDestination: rt.destName,
-				diagnostics.Count:             len(values),
-				diagnostics.ErrorCountMap:     stringValue,
+				diagnostics.Count:             len(value),
+				diagnostics.ErrorCountMap:     string(stringValueBytes),
 			})
 		}
-		rt.failuresMetric = make(map[string][]failureMetric)
-		rt.failureMetricLock.RUnlock()
+		rt.failuresMetric = make(map[string]map[string]int)
+		rt.failureMetricLock.Unlock()
 	}
 }
 
@@ -2229,7 +2221,7 @@ func (rt *HandleT) Setup(backendConfig backendconfig.BackendConfig, jobsDB jobsd
 	rt.customDestinationManager = customDestinationManager.New(destName, customDestinationManager.Opts{
 		Timeout: rt.netClientTimeout,
 	})
-	rt.failuresMetric = make(map[string][]failureMetric)
+	rt.failuresMetric = make(map[string]map[string]int)
 
 	rt.destinationResponseHandler = New(destinationDefinition.ResponseRules)
 	if value, ok := destinationDefinition.Config["saveDestinationResponse"].(bool); ok {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -6,7 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"testing"
 	"time"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/tidwall/sjson"
 
 	"github.com/gofrs/uuid"
 	"github.com/golang/mock/gomock"
@@ -54,6 +59,24 @@ var (
 		ID:          gaDestinationDefinitionID,
 		Name:        "GA",
 		DisplayName: "Google Analytics",
+	}
+	collectMetricsErrorMap = map[string]int{
+		"Error Response 1":  1,
+		"Error Response 2":  2,
+		"Error Response 3":  3,
+		"Error Response 4":  4,
+		"Error Response 5":  1,
+		"Error Response 6":  2,
+		"Error Response 7":  3,
+		"Error Response 8":  4,
+		"Error Response 9":  1,
+		"Error Response 10": 2,
+		"Error Response 11": 3,
+		"Error Response 12": 4,
+		"Error Response 13": 1,
+		"Error Response 14": 2,
+		"Error Response 15": 3,
+		"Error Response 16": 4,
 	}
 	// This configuration is assumed by all router tests and, is returned on Subscribe of mocked backend config
 	sampleBackendConfig = backendconfig.ConfigT{
@@ -1140,4 +1163,33 @@ func assertTransformJobStatuses(job *jobsdb.JobT, status *jobsdb.JobStatusT, exp
 	Expect(status.RetryTime).To(BeTemporally("~", time.Now(), 10*time.Second))
 	Expect(status.ExecTime).To(BeTemporally("~", time.Now(), 10*time.Second))
 	Expect(status.AttemptNum).To(Equal(attemptNum))
+}
+
+func Benchmark_SJSON_SET(b *testing.B) {
+	var stringValue string
+	var err error
+	for i := 0; i < b.N; i++ {
+		for k, v := range collectMetricsErrorMap {
+			stringValue, err = sjson.Set(stringValue, k, v)
+			if err != nil {
+				stringValue = ""
+			}
+		}
+	}
+}
+
+func Benchmark_JSON_MARSHAL(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		val, _ := json.Marshal(collectMetricsErrorMap)
+		_ = string(val)
+	}
+}
+
+func Benchmark_FASTJSON_MARSHAL(b *testing.B) {
+	jsonfast := jsoniter.ConfigCompatibleWithStandardLibrary
+
+	for i := 0; i < b.N; i++ {
+		val, _ := jsonfast.Marshal(collectMetricsErrorMap)
+		_ = string(val)
+	}
 }


### PR DESCRIPTION
# Description

Moving from `sjson` to `jsonfast` gives us both memory and performance improvement. This is to address growing memory 
footprint of this function

```
goos: darwin
goarch: arm64
pkg: github.com/rudderlabs/rudder-server/router

Benchmark_SJSON_SET-8             144646              7980 ns/op           15336 B/op         64 allocs/op
Benchmark_JSON_MARSHAL-8          469032              2776 ns/op            2376 B/op         39 allocs/op
Benchmark_FASTJSON_MARSHAL-8      458791              2827 ns/op            2416 B/op         27 allocs/op
```

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=c8b968f0ec424e8b9cba64979bd55289)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
