### PR TITLE
fix(processor): include test for sources fields in transform event metadata

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -694,7 +694,7 @@ func makeCommonMetadataFromSingularEvent(singularEvent types.SingularEventT, bat
 	commonMetadata.SourceJobRunID, _ = misc.MapLookup(singularEvent, "context", "sources", "job_run_id").(string)
 	commonMetadata.SourceJobID, _ = misc.MapLookup(singularEvent, "context", "sources", "job_id").(string)
 	commonMetadata.SourceTaskRunID, _ = misc.MapLookup(singularEvent, "context", "sources", "task_run_id").(string)
-	commonMetadata.RecordID = misc.MapLookup(singularEvent, "context", "record_id")
+	commonMetadata.RecordID = misc.MapLookup(singularEvent, "recordId")
 
 	commonMetadata.EventName, _ = misc.MapLookup(singularEvent, "event").(string)
 	commonMetadata.EventType, _ = misc.MapLookup(singularEvent, "type").(string)

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -1404,7 +1404,7 @@ type transformExpectation struct {
 
 func createMessagePayload(e mockEventData) string {
 	integrations, _ := json.Marshal(e.integrations)
-	return fmt.Sprintf(`{"rudderId": "some-rudder-id", "messageId":"message-%s","integrations":%s,"some-property":"property-%s","originalTimestamp":"%s","sentAt":"%s","recordId":{"id":"record_id_1"},"context":{"sources": {"task_run_id":"task_run_id_1","batch_id":"batch_id_1","job_run_id":"job_run_id_1"}}}`, e.id, integrations, e.id, e.originalTimestamp, e.sentAt)
+	return fmt.Sprintf(`{"rudderId": "some-rudder-id", "messageId":"message-%s","integrations":%s,"some-property":"property-%s","originalTimestamp":"%s","sentAt":"%s","recordId":{"id":"record_id_1"},"context":{"sources": {"task_run_id":"task_run_id_1","batch_id":"batch_id_1","job_run_id":"job_run_id_1","task_id":"task_id_1","job_id":"job_id_1"}}}`, e.id, integrations, e.id, e.originalTimestamp, e.sentAt)
 }
 
 func createMessagePayloadWithSameMessageId(e mockEventData) string {
@@ -1516,6 +1516,10 @@ func assertDestinationTransform(messages map[string]mockEventData, sourceId, des
 				Expect(event.Metadata.SourceJobRunID).To(Equal(jobRunID))
 				taskRunID := gjson.GetBytes(rawEvent, "message.context.sources.task_run_id").String()
 				Expect(event.Metadata.SourceTaskRunID).To(Equal(taskRunID))
+				taskID := gjson.GetBytes(rawEvent, "message.context.sources.task_id").String()
+				Expect(event.Metadata.SourceTaskID).To(Equal(taskID))
+				sourcesJobID := gjson.GetBytes(rawEvent, "message.context.sources.job_id").String()
+				Expect(event.Metadata.SourceJobID).To(Equal(sourcesJobID))
 			} else {
 				// Expect(event.Metadata.DestinationType).To(Equal(""))
 				Expect(event.Metadata.JobID).To(Equal(int64(0)))

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/tidwall/gjson"
 
 	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/config"
@@ -1403,7 +1404,7 @@ type transformExpectation struct {
 
 func createMessagePayload(e mockEventData) string {
 	integrations, _ := json.Marshal(e.integrations)
-	return fmt.Sprintf(`{"rudderId": "some-rudder-id", "messageId":"message-%s","integrations":%s,"some-property":"property-%s","originalTimestamp":"%s","sentAt":"%s"}`, e.id, integrations, e.id, e.originalTimestamp, e.sentAt)
+	return fmt.Sprintf(`{"rudderId": "some-rudder-id", "messageId":"message-%s","integrations":%s,"some-property":"property-%s","originalTimestamp":"%s","sentAt":"%s","recordId":{"id":"record_id_1"},"context":{"sources": {"task_run_id":"task_run_id_1","batch_id":"batch_id_1","job_run_id":"job_run_id_1"}}}`, e.id, integrations, e.id, e.originalTimestamp, e.sentAt)
 }
 
 func createMessagePayloadWithSameMessageId(e mockEventData) string {
@@ -1505,6 +1506,16 @@ func assertDestinationTransform(messages map[string]mockEventData, sourceId, des
 				Expect(event.Metadata.JobID).To(Equal(messages[messageID].jobid))
 				Expect(event.Metadata.MessageID).To(Equal(messageID))
 				Expect(event.Metadata.SourceID).To(Equal(sourceId)) // ???
+				rawEvent, err := json.Marshal(event)
+				Expect(err).ToNot(HaveOccurred())
+				recordID := gjson.GetBytes(rawEvent, "message.recordId").Value()
+				Expect(event.Metadata.RecordID).To(Equal(recordID))
+				batchID := gjson.GetBytes(rawEvent, "message.context.sources.batch_id").String()
+				Expect(event.Metadata.SourceBatchID).To(Equal(batchID))
+				jobRunID := gjson.GetBytes(rawEvent, "message.context.sources.job_run_id").String()
+				Expect(event.Metadata.SourceJobRunID).To(Equal(jobRunID))
+				taskRunID := gjson.GetBytes(rawEvent, "message.context.sources.task_run_id").String()
+				Expect(event.Metadata.SourceTaskRunID).To(Equal(taskRunID))
 			} else {
 				// Expect(event.Metadata.DestinationType).To(Equal(""))
 				Expect(event.Metadata.JobID).To(Equal(int64(0)))


### PR DESCRIPTION
# Description

Added sources fields to existing tests in processor along with asserts to make sure fields are populated.

## Notion Ticket

[Add test scenario for verifying rudder-sources specific json fields](https://www.notion.so/rudderstacks/Add-test-scenario-for-verifying-rudder-sources-specific-json-fields-ffd8489f84e64869b7d14f28521a0953)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
