### PR TITLE
fix(router): transformer proxy alerts

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -747,7 +747,7 @@ func (worker *workerT) processDestinationJobs() {
 								"workspace":     workspaceID,
 							}).Count(len(result))
 
-							pkgLogger.Infof(`[TransformerProxy] (Dest-%v) {Job - %v} Input Router Events: %v, Out router events: %v`, worker.rt.destName,
+							pkgLogger.Debugf(`[TransformerProxy] (Dest-%v) {Job - %v} Input Router Events: %v, Out router events: %v`, worker.rt.destName,
 								destinationJob.JobMetadataArray[0].JobID,
 								len(result),
 								len(respBodyArr),


### PR DESCRIPTION
# Description

- Changed the tag to `destType` to make it easier to group on the same tag for better alerting
- Changed the info log to debug log to not spam our logs with transformer proxy related details


## Notion Ticket

[Proxy Alert Parameters](https://www.notion.so/rudderstacks/Setting-Transformer-Proxy-Alert-s-Parameters-5c32ef6abbc941448fa63b0d1a89d350)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
