### PR TITLE
chore: use `T.Setenv` to set env vars in tests

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,7 +15,7 @@ func TestStatic_checkAndHotReloadConfig(t *testing.T) {
 	configVar2 := newConfigVar(&var2, 1, "var2", true, []string{"KEY_VAR"})
 
 	configMap["KEY_VAR"] = []*ConfigVar{configVar1, configVar2}
-	require.NoError(t, os.Setenv("RSERVER_KEY_VAR", "value_changed"))
+	t.Setenv("RSERVER_KEY_VAR", "value_changed")
 
 	checkAndHotReloadConfig(configMap)
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -616,10 +616,10 @@ func setupMainFlow(svcCtx context.Context, t *testing.T) <-chan struct{} {
 		t.Log("INFO: No .env file found.")
 	}
 
-	_ = os.Setenv("JOBS_DB_PORT", postgresContainer.Port)
-	_ = os.Setenv("WAREHOUSE_JOBS_DB_PORT", postgresContainer.Port)
-	_ = os.Setenv("DEST_TRANSFORM_URL", transformerContainer.TransformURL)
-	_ = os.Setenv("DEPLOYMENT_TYPE", string(deployment.DedicatedType))
+	t.Setenv("JOBS_DB_PORT", postgresContainer.Port)
+	t.Setenv("WAREHOUSE_JOBS_DB_PORT", postgresContainer.Port)
+	t.Setenv("DEST_TRANSFORM_URL", transformerContainer.TransformURL)
+	t.Setenv("DEPLOYMENT_TYPE", string(deployment.DedicatedType))
 
 	wht.InitWHConfig()
 
@@ -635,12 +635,12 @@ func setupMainFlow(svcCtx context.Context, t *testing.T) <-chan struct{} {
 	require.NoError(t, err)
 
 	httpPort = strconv.Itoa(httpPortInt)
-	_ = os.Setenv("RSERVER_GATEWAY_WEB_PORT", httpPort)
+	t.Setenv("RSERVER_GATEWAY_WEB_PORT", httpPort)
 	httpAdminPort, err := freeport.GetFreePort()
 	require.NoError(t, err)
 
-	_ = os.Setenv("RSERVER_GATEWAY_ADMIN_WEB_PORT", strconv.Itoa(httpAdminPort))
-	_ = os.Setenv("RSERVER_ENABLE_STATS", "false")
+	t.Setenv("RSERVER_GATEWAY_ADMIN_WEB_PORT", strconv.Itoa(httpAdminPort))
+	t.Setenv("RSERVER_ENABLE_STATS", "false")
 
 	webhook = whUtil.NewRecorder()
 	t.Cleanup(webhook.Close)
@@ -690,12 +690,9 @@ func setupMainFlow(svcCtx context.Context, t *testing.T) <-chan struct{} {
 		}
 	})
 	t.Log("workspace config path:", workspaceConfigPath)
-	_ = os.Setenv("RSERVER_BACKEND_CONFIG_CONFIG_JSONPATH", workspaceConfigPath)
+	t.Setenv("RSERVER_BACKEND_CONFIG_CONFIG_JSONPATH", workspaceConfigPath)
 
-	rudderTmpDir, err := os.MkdirTemp("", "rudder_server_test")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(rudderTmpDir) })
-	_ = os.Setenv("RUDDER_TMPDIR", rudderTmpDir)
+	t.Setenv("RUDDER_TMPDIR", t.TempDir())
 
 	t.Logf("--- Setup done (%s)", time.Since(setupStart))
 

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -48,9 +48,7 @@ func TestBackupTable(t *testing.T) {
 	require.NoError(t, err)
 
 	// create a unique temporary directory to allow for parallel test execution
-	tmpDir, err := ioutil.TempDir("", "TestBackupTable")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	{ // skipcq: CRT-A0008
 		t.Setenv("RSERVER_JOBS_DB_BACKUP_ENABLED", "true")

--- a/regulation-worker/internal/delete/api/api_test.go
+++ b/regulation-worker/internal/delete/api/api_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -131,7 +130,7 @@ func TestDelete(t *testing.T) {
 			svr := httptest.NewServer(d.handler())
 
 			defer svr.Close()
-			os.Setenv("DEST_TRANSFORM_URL", svr.URL)
+			t.Setenv("DEST_TRANSFORM_URL", svr.URL)
 			api := api.APIManager{
 				Client:           &http.Client{},
 				DestTransformURL: svr.URL,


### PR DESCRIPTION
# Description

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

## Notion Ticket


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
