### PR TITLE
fix: only tag images with `:latest` if they are part of a release

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -26,8 +26,8 @@ jobs:
             name=rudderlabs/rudder-server,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
           tags: |
             type=ref,event=branch
-            type=raw,value=1-alpine,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=1-alpine,enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=raw,value=${{ github.head_ref }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -68,7 +68,7 @@ jobs:
             name=rudderstack/rudder-server-enterprise,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
           tags: |
             type=ref,event=branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=raw,value=${{ github.head_ref }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -20,4 +20,3 @@ jobs:
           package-name: rudder-server
           default-branch: ${{ steps.extract_branch.outputs.branch }}
           bump-minor-pre-major: true
-          bump-patch-for-minor-pre-major: true


### PR DESCRIPTION
# Description

Currently, an image was tagged with `latest` or `1-alpha` if it was a release or merged to master. As `latest` images are used by open-source customers, this behaviour can be problematic as master is not considered very stable at this point. It is better for `latest` to pinpoint our latest release.

## Notion Ticket

https://www.notion.so/CI-fixes-62049a66091840bd8d18a714676af9b3

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
