### PR TITLE
feat(core): secure customer s3 bucket access for backups using cross-account role

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -3215,7 +3215,7 @@ func (jd *HandleT) getBackUpQuery(backupDSRange *dataSetRangeT, isJobStatusTable
 	if jd.BackupSettings.FailedOnly {
 		// check failed and aborted state, order the output based on destination, job_id, exec_time
 		stmt = fmt.Sprintf(
-			`SELECT 
+			`SELECT
 				json_build_object(
 					'job_id', failed_jobs.job_id,
 					'workspace_id',failed_jobs.workspace_id,
@@ -3237,66 +3237,66 @@ func (jd *HandleT) getBackUpQuery(backupDSRange *dataSetRangeT, isJobStatusTable
 					'error_response',failed_jobs.error_response,
 					'parameters',failed_jobs.status_parameters
 				)
-			FROM 
+			FROM
 				(
-				SELECT 
-					* 
-				FROM 
+				SELECT
+					*
+				FROM
 					(
-					SELECT *, 
+					SELECT *,
 					sum(
 					pg_column_size(jobs.event_payload)
 					) OVER (
-					ORDER BY 
-						jobs.custom_val, 
-						jobs.status_job_id, 
+					ORDER BY
+						jobs.custom_val,
+						jobs.status_job_id,
 						jobs.exec_time
 					) AS running_payload_size,
-					ROW_NUMBER() 
+					ROW_NUMBER()
 					OVER (
-					ORDER BY 
-						jobs.custom_val, 
-						jobs.status_job_id, 
+					ORDER BY
+						jobs.custom_val,
+						jobs.status_job_id,
 						jobs.exec_time
-					) AS row_num 
+					) AS row_num
 					FROM
 						(
-						SELECT 
-							job.job_id, 
-							job.workspace_id, 
-							job.uuid, 
-							job.user_id, 
-							job.parameters, 
-							job.custom_val, 
-							job.event_payload, 
-							job.event_count, 
-							job.created_at, 
-							job.expire_at, 
-							job_status.id, 
-							job_status.job_id AS status_job_id, 
-							job_status.job_state, 
-							job_status.attempt, 
-							job_status.exec_time, 
-							job_status.retry_time, 
-							job_status.error_code, 
-							job_status.error_response, 
+						SELECT
+							job.job_id,
+							job.workspace_id,
+							job.uuid,
+							job.user_id,
+							job.parameters,
+							job.custom_val,
+							job.event_payload,
+							job.event_count,
+							job.created_at,
+							job.expire_at,
+							job_status.id,
+							job_status.job_id AS status_job_id,
+							job_status.job_state,
+							job_status.attempt,
+							job_status.exec_time,
+							job_status.retry_time,
+							job_status.error_code,
+							job_status.error_response,
 							job_status.parameters AS status_parameters
-						FROM 
-							"%[1]s" "job_status" 
-							INNER JOIN "%[2]s" "job" ON job_status.job_id = job.job_id 
-						WHERE 
-							job_status.job_state IN ('%[3]s', '%[4]s') 
-						ORDER BY 
-						job.custom_val, 
-							job_status.job_id, 
+						FROM
+							"%[1]s" "job_status"
+							INNER JOIN "%[2]s" "job" ON job_status.job_id = job.job_id
+						WHERE
+							job_status.job_state IN ('%[3]s', '%[4]s')
+						ORDER BY
+						job.custom_val,
+							job_status.job_id,
 							job_status.exec_time ASC
-						LIMIT 
+						LIMIT
 							%[5]d
 						OFFSET
 							%[6]d
 						) jobs
-					) subquery 
-				WHERE 
+					) subquery
+				WHERE
 					subquery.running_payload_size <= %[7]d OR subquery.row_num = 1
 				) AS failed_jobs
 		  `, backupDSRange.ds.JobStatusTable, backupDSRange.ds.JobTable, Failed.State, Aborted.State, backupRowsBatchSize, offset, backupMaxTotalPayloadSize)
@@ -3315,70 +3315,70 @@ func (jd *HandleT) getBackUpQuery(backupDSRange *dataSetRangeT, isJobStatusTable
 			 		'error_response', dump_table.error_response,
 			 		'parameters', dump_table.parameters
 	)
-			FROM 
+			FROM
 				(
-				SELECT 
+				SELECT
 					*
-				FROM 
-					"%[1]s" 
-				ORDER BY 
-					job_id ASC 
-				LIMIT 
-					%[2]d 
-				OFFSET 
+				FROM
+					"%[1]s"
+				ORDER BY
+					job_id ASC
+				LIMIT
+					%[2]d
+				OFFSET
 					%[3]d
-				) 
+				)
 				AS dump_table
 			`, backupDSRange.ds.JobStatusTable, backupRowsBatchSize, offset)
 		} else {
 			stmt = fmt.Sprintf(`
-			SELECT 
+			SELECT
 				jsonb_build_object(
 					'job_id', dump_table.job_id,
-					'workspace_id', dump_table.workspace_id, 
+					'workspace_id', dump_table.workspace_id,
 					'uuid', dump_table.uuid,
-					'user_id', dump_table.user_id, 
+					'user_id', dump_table.user_id,
 					'parameters', dump_table.parameters,
-					'custom_val', dump_table.custom_val, 
+					'custom_val', dump_table.custom_val,
 					'event_payload', dump_table.event_payload,
-					'event_count', dump_table.event_count, 
+					'event_count', dump_table.event_count,
 					'created_at', dump_table.created_at,
 					'expire_at', dump_table.expire_at
-				) 
-		  	FROM 
+				)
+		  	FROM
 				(
-				SELECT 
-					* 
-				FROM 
+				SELECT
+					*
+				FROM
 					(
 						SELECT
-							*, 
+							*,
 							sum(
 							pg_column_size(jobs.event_payload)
 							) OVER (
-							ORDER BY 
+							ORDER BY
 								jobs.job_id
 							) AS running_payload_size,
-							ROW_NUMBER() 
+							ROW_NUMBER()
 							OVER (
-							ORDER BY 
+							ORDER BY
 								job_id ASC
-							) AS row_num  
+							) AS row_num
 						FROM
 							(
-							SELECT 
+							SELECT
 								*
-							FROM 
-								"%[1]s" job 
-							ORDER BY 
+							FROM
+								"%[1]s" job
+							ORDER BY
 								job_id ASC
-							LIMIT 
+							LIMIT
 								%[2]d
 							OFFSET
 								%[3]d
 							) jobs
-					) subquery 
-				WHERE 
+					) subquery
+				WHERE
 					subquery.running_payload_size <= %[4]d OR subquery.row_num = 1
 			) AS dump_table
 			`, backupDSRange.ds.JobTable, backupRowsBatchSize, offset, backupMaxTotalPayloadSize)
@@ -3395,7 +3395,7 @@ func (jd *HandleT) getFileUploader() (filemanager.FileManager, error) {
 	}
 	return filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
 		Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
-		Config:   filemanager.GetProviderConfigFromEnv(),
+		Config:   filemanager.GetProviderConfigForBackupsFromEnv(),
 	})
 }
 

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -113,7 +113,7 @@ func (st *HandleT) setupFileUploader() {
 			var err error
 			st.errFileUploader, err = filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
 				Provider: provider,
-				Config:   filemanager.GetProviderConfigFromEnv(),
+				Config:   filemanager.GetProviderConfigForBackupsFromEnv(),
 			})
 			if err != nil {
 				panic(err)

--- a/services/archiver/archiver.go
+++ b/services/archiver/archiver.go
@@ -81,7 +81,7 @@ func ArchiveOldRecords(tableName, tsColumn string, archivalTimeInDays int, dbHan
 
 	fManager, err := filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
 		Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
-		Config:   filemanager.GetProviderConfigFromEnv(),
+		Config:   filemanager.GetProviderConfigForBackupsFromEnv(),
 	})
 	if err != nil {
 		pkgLogger.Errorf("[Archiver]: Error in creating a file manager for :%s: , %v", config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"), err)

--- a/services/filemanager/azureBlobStoragemanager.go
+++ b/services/filemanager/azureBlobStoragemanager.go
@@ -11,14 +11,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
-	"github.com/rudderlabs/rudder-server/utils/logger"
 )
-
-var pkgLogger logger.LoggerI
-
-func init() {
-	pkgLogger = logger.NewLogger().Child("filemanager").Child("azureBlobStorage")
-}
 
 func supressMinorErrors(err error) error {
 	if err != nil {

--- a/services/filemanager/filemanager.go
+++ b/services/filemanager/filemanager.go
@@ -112,8 +112,6 @@ func GetProviderConfigForBackupsFromEnv() map[string]interface{} {
 		providerConfig["enableSSE"] = config.GetEnvAsBool("AWS_ENABLE_SSE", false)
 		providerConfig["iamRoleArn"] = config.GetEnv("BACKUP_IAM_ROLE_ARN", "")
 		if providerConfig["iamRoleArn"] != "" {
-			// TODO: move this check to startup
-			backendconfig.WaitForConfig(context.TODO())
 			providerConfig["externalId"] = backendconfig.GetWorkspaceIDForWriteKey("")
 		}
 	case "GCS":

--- a/services/filemanager/s3manager.go
+++ b/services/filemanager/s3manager.go
@@ -203,10 +203,8 @@ func (manager *S3Manager) getSession(ctx context.Context) (*session.Session, err
 		DisableSSL:                    manager.Config.DisableSSL, // TODO: get rid of this options as its risky
 	}
 	if manager.Config.AccessKey != "" && manager.Config.AccessKeyID != "" {
-		pkgLogger.Debug("Credentials found in the destination's config")
 		awsConfig.Credentials = credentials.NewStaticCredentials(manager.Config.AccessKeyID, manager.Config.AccessKey, "")
 	} else if manager.Config.IAMRoleARN != "" {
-		pkgLogger.Debugf("Assuming - %s found in the filemanager config", manager.Config.IAMRoleARN)
 		stsSession := session.Must(session.NewSession(&awsConfig))
 		awsConfig.Credentials = stscreds.NewCredentials(stsSession, manager.Config.IAMRoleARN, func(p *stscreds.AssumeRoleProvider) {
 			p.ExternalID = aws.String(manager.Config.ExternalID)

--- a/services/filemanager/s3manager.go
+++ b/services/filemanager/s3manager.go
@@ -20,6 +20,8 @@ import (
 	appConfig "github.com/rudderlabs/rudder-server/config"
 )
 
+const crossAccountSTSRoleSessionName = "rudderstack-s3-access"
+
 // Upload passed in file to s3
 func (manager *S3Manager) Upload(ctx context.Context, file *os.File, prefixes ...string) (UploadOutput, error) {
 	splitFileName := strings.Split(file.Name(), "/")
@@ -208,6 +210,7 @@ func (manager *S3Manager) getSession(ctx context.Context) (*session.Session, err
 		stsSession := session.Must(session.NewSession(&awsConfig))
 		awsConfig.Credentials = stscreds.NewCredentials(stsSession, manager.Config.IAMRoleARN, func(p *stscreds.AssumeRoleProvider) {
 			p.ExternalID = aws.String(manager.Config.ExternalID)
+			p.RoleSessionName = crossAccountSTSRoleSessionName
 		})
 	}
 

--- a/warehouse/archiver.go
+++ b/warehouse/archiver.go
@@ -82,7 +82,7 @@ func backupRecords(args backupRecordsArgs) (backupLocation string, err error) {
 
 	fManager, err := filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
 		Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
-		Config:   filemanager.GetProviderConfigFromEnv(),
+		Config:   filemanager.GetProviderConfigForBackupsFromEnv(),
 	})
 	if err != nil {
 		err = errors.New(fmt.Sprintf(`Error in creating a file manager for:%s. Error: %v`, config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"), err))


### PR DESCRIPTION
# Description
If `BACKUP_IAM_ROLE_ARN` env is specified, sts creds are generated assuming the role for backups to customer bucket.  `BACKUP_IAM_ROLE_ARN` is the ARN of the role the customer creates with a trust policy principal being our AWS acccount and allowing necessary S3 actions on their bucket

More details: https://rudderlabs.slack.com/archives/C03KSBL7JM7/p1657156293344469

## Notion Ticket
https://www.notion.so/rudderstacks/Secure-connection-to-customer-S3-buckets-for-backups-47fa67c7cd1c40fc9edbdf9118a39703

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
