### PR TITLE
refactor: use path pkg in s3 manager to make s3 filename

### DIFF
--- a/app/cluster/state/etcd.go
+++ b/app/cluster/state/etcd.go
@@ -172,6 +172,8 @@ func (manager *ETCDManager) unmarshalMode(raw []byte) servermode.ChangeEvent {
 			if err != nil {
 				manager.logger.Errorf("Failed to acknowledge mode change for key: %s", req.AckKey)
 				return fmt.Errorf("put value to ack key %q: %w", req.AckKey, err)
+			} else {
+				manager.logger.Debugf("Mode change for key %q acknowledged", req.AckKey)
 			}
 			return err
 		})

--- a/services/filemanager/azureBlobStoragemanager.go
+++ b/services/filemanager/azureBlobStoragemanager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -99,19 +100,7 @@ func (manager *AzureBlobStorageManager) Upload(ctx context.Context, file *os.Fil
 		return UploadOutput{}, err
 	}
 
-	splitFileName := strings.Split(file.Name(), "/")
-	fileName := ""
-	if len(prefixes) > 0 {
-		fileName = strings.Join(prefixes[:], "/") + "/"
-	}
-	fileName += splitFileName[len(splitFileName)-1]
-	if manager.Config.Prefix != "" {
-		if manager.Config.Prefix[len(manager.Config.Prefix)-1:] == "/" {
-			fileName = manager.Config.Prefix + fileName
-		} else {
-			fileName = manager.Config.Prefix + "/" + fileName
-		}
-	}
+	fileName := path.Join(manager.Config.Prefix, path.Join(prefixes...), path.Base(file.Name()))
 
 	// Here's how to upload a blob.
 	blobURL := containerURL.NewBlockBlobURL(fileName)

--- a/services/filemanager/digitalOceanSpacesManager.go
+++ b/services/filemanager/digitalOceanSpacesManager.go
@@ -168,10 +168,7 @@ func (manager *DOSpacesManager) DeleteObjects(ctx context.Context, keys []string
 		_, err := svc.DeleteObjectsWithContext(_ctx, input)
 		if err != nil {
 			if aerr, ok := err.(awserr.Error); ok {
-				switch aerr.Code() {
-				default:
-					pkgLogger.Errorf(`Error while deleting digital ocean spaces objects: %v, error code: %v`, aerr.Error(), aerr.Code())
-				}
+				pkgLogger.Errorf(`Error while deleting digital ocean spaces objects: %v, error code: %v`, aerr.Error(), aerr.Code())
 			} else {
 				// Print the error, cast err to awserr.Error to get the Code and
 				// Message from an error.

--- a/services/filemanager/digitalOceanSpacesManager.go
+++ b/services/filemanager/digitalOceanSpacesManager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -40,19 +41,7 @@ func (manager *DOSpacesManager) Upload(ctx context.Context, file *os.File, prefi
 		return UploadOutput{}, errors.New("no storage bucket configured to uploader")
 	}
 
-	splitFileName := strings.Split(file.Name(), "/")
-	fileName := ""
-	if len(prefixes) > 0 {
-		fileName = strings.Join(prefixes[:], "/") + "/"
-	}
-	fileName += splitFileName[len(splitFileName)-1]
-	if manager.Config.Prefix != "" {
-		if manager.Config.Prefix[len(manager.Config.Prefix)-1:] == "/" {
-			fileName = manager.Config.Prefix + fileName
-		} else {
-			fileName = manager.Config.Prefix + "/" + fileName
-		}
-	}
+	fileName := path.Join(manager.Config.Prefix, path.Join(prefixes...), path.Base(file.Name()))
 
 	uploadInput := &SpacesManager.UploadInput{
 		ACL:    aws.String("bucket-owner-full-control"),

--- a/services/filemanager/fileManager_test.go
+++ b/services/filemanager/fileManager_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -283,10 +284,12 @@ func TestFileManager(t *testing.T) {
 			for _, file := range fileList {
 				filePtr, err := os.Open(file)
 				require.NoError(t, err, "error while opening testData file to upload")
-				uploadOutput, err := fm.Upload(context.TODO(), filePtr)
+				uploadOutput, err := fm.Upload(context.TODO(), filePtr, "another-prefix1", "another-prefix2")
 				if err != nil {
 					t.Fatal(err)
 				}
+				require.Equal(t, path.Join("some-prefix/another-prefix1/another-prefix2/", path.Base(file)),
+					uploadOutput.ObjectName)
 				uploadOutputs = append(uploadOutputs, uploadOutput)
 				filePtr.Close()
 			}

--- a/services/filemanager/gcsmanager.go
+++ b/services/filemanager/gcsmanager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -23,19 +24,7 @@ func (manager *GCSManager) objectURL(objAttrs *storage.ObjectAttrs) string {
 }
 
 func (manager *GCSManager) Upload(ctx context.Context, file *os.File, prefixes ...string) (UploadOutput, error) {
-	splitFileName := strings.Split(file.Name(), "/")
-	fileName := ""
-	if len(prefixes) > 0 {
-		fileName = strings.Join(prefixes[:], "/") + "/"
-	}
-	fileName += splitFileName[len(splitFileName)-1]
-	if manager.Config.Prefix != "" {
-		if manager.Config.Prefix[len(manager.Config.Prefix)-1:] == "/" {
-			fileName = manager.Config.Prefix + fileName
-		} else {
-			fileName = manager.Config.Prefix + "/" + fileName
-		}
-	}
+	fileName := path.Join(manager.Config.Prefix, path.Join(prefixes...), path.Base(file.Name()))
 
 	client, err := manager.getClient(ctx)
 	if err != nil {

--- a/services/filemanager/miniomanager.go
+++ b/services/filemanager/miniomanager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -40,20 +41,7 @@ func (manager *MinioManager) Upload(ctx context.Context, file *os.File, prefixes
 		}
 	}
 
-	fileName := ""
-	splitFileName := strings.Split(file.Name(), "/")
-	if len(prefixes) > 0 {
-		fileName = strings.Join(prefixes[:], "/") + "/"
-	}
-
-	fileName += splitFileName[len(splitFileName)-1]
-	if manager.Config.Prefix != "" {
-		if manager.Config.Prefix[len(manager.Config.Prefix)-1:] == "/" {
-			fileName = manager.Config.Prefix + fileName
-		} else {
-			fileName = manager.Config.Prefix + "/" + fileName
-		}
-	}
+	fileName := path.Join(manager.Config.Prefix, path.Join(prefixes...), path.Base(file.Name()))
 
 	_, err = minioClient.FPutObjectWithContext(ctx, manager.Config.Bucket, fileName, file.Name(), minio.PutObjectOptions{})
 	if err != nil {

--- a/services/filemanager/s3manager.go
+++ b/services/filemanager/s3manager.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	awsS3Manager "github.com/aws/aws-sdk-go/service/s3/s3manager"
 	appConfig "github.com/rudderlabs/rudder-server/config"
 )
@@ -60,7 +59,7 @@ func (manager *S3Manager) Download(ctx context.Context, output *os.File, key str
 		return fmt.Errorf(`error starting S3 session: %v`, err)
 	}
 
-	downloader := s3manager.NewDownloader(sess)
+	downloader := awsS3Manager.NewDownloader(sess)
 
 	ctx, cancel := context.WithTimeout(ctx, getSafeTimeout(manager.Timeout))
 	defer cancel()

--- a/services/filemanager/s3manager.go
+++ b/services/filemanager/s3manager.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"time"
 

--- a/services/filemanager/s3manager.go
+++ b/services/filemanager/s3manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 	"net/url"
 	"os"
 	"strings"
@@ -21,20 +22,7 @@ import (
 
 // Upload passed in file to s3
 func (manager *S3Manager) Upload(ctx context.Context, file *os.File, prefixes ...string) (UploadOutput, error) {
-	splitFileName := strings.Split(file.Name(), "/")
-	fileName := ""
-
-	if len(prefixes) > 0 {
-		fileName = strings.Join(prefixes[:], "/") + "/"
-	}
-	fileName += splitFileName[len(splitFileName)-1]
-	if manager.Config.Prefix != "" {
-		if manager.Config.Prefix[len(manager.Config.Prefix)-1:] == "/" {
-			fileName = manager.Config.Prefix + fileName
-		} else {
-			fileName = manager.Config.Prefix + "/" + fileName
-		}
-	}
+	fileName := path.Join(manager.Config.Prefix, path.Join(prefixes...), path.Base(file.Name()))
 
 	uploadInput := &awsS3Manager.UploadInput{
 		ACL:    aws.String("bucket-owner-full-control"),


### PR DESCRIPTION
This avoids manually checking and if conditions.
Mainly started with a small change to get an idea about the process.

# Description
Improves S3 file name generation logic.

## Notion Ticket
This minor refactor, no particular bug fix, do we still need a notion ticket?

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
