### PR TITLE
chore: rsources integration improvements

### DIFF
--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -231,6 +231,7 @@ func NewRsourcesService(deploymentType deployment.Type) (rsources.JobService, er
 	rsourcesConfig.LocalConn = jobsdb.GetConnectionString()
 	rsourcesConfig.LocalHostname = config.GetEnv("JOBS_DB_HOST", "localhost")
 	rsourcesConfig.SharedConn = config.GetEnv("SHARED_DB_DSN", "")
+	rsourcesConfig.SkipFailedRecordsCollection = !config.GetBool("Router.failedKeysEnabled", false)
 
 	switch deploymentType {
 	case deployment.HostedType, deployment.MultiTenantType:

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -392,7 +392,7 @@ func (sh *sourcesHandler) setupLogicalReplication(ctx context.Context) error {
 	if subscriptionConn == "" {
 		subscriptionConn = sh.config.LocalConn
 	}
-	subscriptionQuery := fmt.Sprintf(`CREATE SUBSCRIPTION "%s" CONNECTION '%s' PUBLICATION "rsources_stats_pub"`, subscriptionName, subscriptionConn)
+	subscriptionQuery := fmt.Sprintf(`CREATE SUBSCRIPTION "%s" CONNECTION '%s' PUBLICATION "rsources_stats_pub"`, subscriptionName, subscriptionConn) // skipcq: GO-R4002
 	_, err = sh.sharedDB.ExecContext(ctx, subscriptionQuery)
 	if err != nil {
 		pqError, ok := err.(*pq.Error)

--- a/services/rsources/http/http.go
+++ b/services/rsources/http/http.go
@@ -98,7 +98,11 @@ func (h *handler) failedRecords(w http.ResponseWriter, r *http.Request) {
 		},
 	)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httpStatus := http.StatusInternalServerError
+		if errors.Is(err, rsources.ErrOperationNotSupported) {
+			httpStatus = http.StatusBadRequest
+		}
+		http.Error(w, err.Error(), httpStatus)
 		return
 	}
 

--- a/services/rsources/http/http_test.go
+++ b/services/rsources/http/http_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -54,13 +54,13 @@ func TestDelete(t *testing.T) {
 			service.EXPECT().Delete(gomock.Any(), tt.jobRunId).Return(tt.serviceReturnError).Times(1)
 
 			url := fmt.Sprintf("http://localhost:8080%s", tt.endpoint)
-			req, err := http.NewRequest(tt.method, url, nil)
+			req, err := http.NewRequest(tt.method, url, http.NoBody)
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
 			resp := httptest.NewRecorder()
 
 			handler.ServeHTTP(resp, req)
-			_, err = ioutil.ReadAll(resp.Body)
+			_, err = io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			require.Equal(t, tt.expectedResponseCode, resp.Code, "required error different than expected")
@@ -191,13 +191,13 @@ func TestGetStatus(t *testing.T) {
 
 			basicUrl := fmt.Sprintf("http://localhost:8080%s", tt.endpoint)
 			url := withFilter(basicUrl, tt.filter)
-			req, err := http.NewRequest(tt.method, url, nil)
+			req, err := http.NewRequest(tt.method, url, http.NoBody)
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
 			resp := httptest.NewRecorder()
 
 			handler.ServeHTTP(resp, req)
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			require.Equal(t, tt.expectedResponseCode, resp.Code, "actual response code different than expected")
@@ -283,13 +283,13 @@ func TestGetFailedRecords(t *testing.T) {
 
 			basicUrl := fmt.Sprintf("http://localhost:8080%s", tt.endpoint)
 			url := withFilter(basicUrl, tt.filter)
-			req, err := http.NewRequest(tt.method, url, nil)
+			req, err := http.NewRequest(tt.method, url, http.NoBody)
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
 			resp := httptest.NewRecorder()
 
 			handler.ServeHTTP(resp, req)
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			require.Equal(t, tt.expectedResponseCode, resp.Code, "actual response code different than expected")
@@ -307,13 +307,13 @@ func TestFailedRecordsDisabled(t *testing.T) {
 	service.EXPECT().GetFailedRecords(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, rsources.ErrOperationNotSupported).Times(1)
 
 	url := fmt.Sprintf("http://localhost:8080%s", prepURL("/v1/job-status/{job_run_id}/failed-records", "123"))
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", url, http.NoBody)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
 
 	handler.ServeHTTP(resp, req)
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	require.Equal(t, 400, resp.Code, "actual response code different than expected")

--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -90,11 +90,12 @@ type StatsIncrementer interface {
 }
 
 type JobServiceConfig struct {
-	LocalHostname          string
-	LocalConn              string
-	MaxPoolSize            int
-	SharedConn             string
-	SubscriptionTargetConn string
+	LocalHostname               string
+	LocalConn                   string
+	MaxPoolSize                 int
+	SharedConn                  string
+	SubscriptionTargetConn      string
+	SkipFailedRecordsCollection bool
 }
 
 // JobService manages information about jobs created by rudder-sources


### PR DESCRIPTION
# Description

- Add support for disabling failed keys collection.
- Respond with `HTTP 400` if failed keys collection is disabled on server and client performs a `GET /v1/job-status/{job_run_id}/failed-records` request.
- Increase default retention period of stats to 3 days.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=97a78100d41f47a1afbe3bbde41591d0&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
