### PR TITLE
feat: added source specific delete rows by jobrunid in upload state machine

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -198,7 +198,7 @@ Processor:
   Stats:
     captureEventName: false
 Dedup:
-  enableDedup: false
+  enableDedup: true
   dedupWindow: 3600s
   memOptimized: true
 BackendConfig:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -198,7 +198,7 @@ Processor:
   Stats:
     captureEventName: false
 Dedup:
-  enableDedup: true
+  enableDedup: false
   dedupWindow: 3600s
   memOptimized: true
 BackendConfig:

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1374,7 +1374,6 @@ func (gateway *HandleT) StartWebHandler(ctx context.Context) error {
 	srvMux.HandleFunc("/pixel/v1/page", gateway.pixelPageHandler).Methods("GET")
 	srvMux.HandleFunc("/v1/webhook", gateway.webhookHandler.RequestHandler).Methods("POST", "GET")
 	srvMux.HandleFunc("/beacon/v1/batch", gateway.beaconBatchHandler).Methods("POST")
-
 	srvMux.HandleFunc("/version", gateway.versionHandler).Methods("GET")
 	srvMux.HandleFunc("/robots.txt", gateway.robots).Methods("GET")
 

--- a/warehouse/azure-synapse/azure-synapse.go
+++ b/warehouse/azure-synapse/azure-synapse.go
@@ -661,6 +661,21 @@ func (as *HandleT) DropTable(tableName string) (err error) {
 	return
 }
 
+func (as *HandleT) DeleteByJobRunID(tableNames []string, jobRunID string, startTime string) (success bool, err error) {
+	pkgLogger.Infof("AS: Cleaning up the followng tables in postgres for PG:%s : %v", tableNames)
+	for _, tb := range tableNames {
+		if tb != "rudder_discards" {
+			sqlStatement := fmt.Sprintf(`DELETE FROM "%[1]s"."%[2]s" WHERE %[3]s <> '%[4]s'`, as.Namespace, tb, "context_sources_job_run_id", jobRunID)
+			pkgLogger.Infof("AS: Deleting rows in table in azure synapse for AS:%s : %v", as.Warehouse.Destination.ID, sqlStatement)
+			_, err = as.Db.Exec(sqlStatement)
+			if err != nil {
+				return false, err
+			}
+		}
+	}
+	return true, nil
+}
+
 func (as *HandleT) AddColumn(tableName, columnName, columnType string) (err error) {
 	err = as.addColumn(as.Namespace+"."+tableName, columnName, columnType)
 	return err

--- a/warehouse/clickhouse/clickhouse.go
+++ b/warehouse/clickhouse/clickhouse.go
@@ -842,6 +842,10 @@ func (ch *HandleT) DropTable(tableName string) (err error) {
 	return
 }
 
+func (ch *HandleT) DeleteByJobRunID(tableNames []string, jobRunID string, startTime string) (success bool, err error) {
+	return false, fmt.Errorf("click err :not implemented")
+}
+
 // AddColumn adds column:columnName with dataType columnType to the tableName
 func (ch *HandleT) AddColumn(tableName, columnName, columnType string) (err error) {
 	cluster := warehouseutils.GetConfigValue(Cluster, ch.Warehouse)

--- a/warehouse/datalake/datalake.go
+++ b/warehouse/datalake/datalake.go
@@ -55,6 +55,10 @@ func (wh *HandleT) DropTable(tableName string) (err error) {
 	return fmt.Errorf("datalake err :not implemented")
 }
 
+func (wh *HandleT) DeleteByJobRunID(tableNames []string, jobRunID string, startTime string) (success bool, err error) {
+	return false, fmt.Errorf("datalake err :not implemented")
+}
+
 func (wh *HandleT) AddColumn(tableName, columnName, columnType string) (err error) {
 	return wh.SchemaRepository.AddColumn(tableName, columnName, columnType)
 }

--- a/warehouse/dedup/types.go
+++ b/warehouse/dedup/types.go
@@ -1,0 +1,71 @@
+package dedup
+
+import (
+	"time"
+
+	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
+	"github.com/rudderlabs/rudder-server/warehouse/manager"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+type DedupRequest struct {
+	Destination backendconfig.DestinationT `json:"destination"`
+}
+
+type DedupJob struct {
+	DedupR *DedupRequest
+}
+
+type DedupHandleT struct {
+	infoRequest *DedupRequest
+	warehouse   warehouseutils.WarehouseT
+	manager     manager.WarehouseOperations
+}
+
+func (job *DedupJob) GetSchemaInWarehouse() warehouseutils.SchemaT {
+	return warehouseutils.SchemaT{}
+}
+
+func (job *DedupJob) GetLocalSchema() warehouseutils.SchemaT {
+	return warehouseutils.SchemaT{}
+}
+
+func (job *DedupJob) UpdateLocalSchema(schema warehouseutils.SchemaT) error {
+	return nil
+}
+
+func (job *DedupJob) GetTableSchemaInWarehouse(tableName string) warehouseutils.TableSchemaT {
+	return warehouseutils.TableSchemaT{}
+}
+
+func (job *DedupJob) GetTableSchemaInUpload(tableName string) warehouseutils.TableSchemaT {
+	return warehouseutils.TableSchemaT{}
+}
+
+func (job *DedupJob) GetLoadFilesMetadata(options warehouseutils.GetLoadFilesOptionsT) []warehouseutils.LoadFileT {
+	return []warehouseutils.LoadFileT{}
+}
+
+func (job *DedupJob) GetSampleLoadFileLocation(tableName string) (string, error) {
+	return "", nil
+}
+
+func (job *DedupJob) GetSingleLoadFile(tableName string) (warehouseutils.LoadFileT, error) {
+	return warehouseutils.LoadFileT{}, nil
+}
+
+func (job *DedupJob) ShouldOnDedupUseNewRecord() bool {
+	return false
+}
+
+func (job *DedupJob) UseRudderStorage() bool {
+	return false
+}
+
+func (job *DedupJob) GetLoadFileGenStartTIme() time.Time {
+	return time.Time{}
+}
+
+func (job *DedupJob) GetLoadFileType() string {
+	return ""
+}

--- a/warehouse/deltalake/deltalake.go
+++ b/warehouse/deltalake/deltalake.go
@@ -793,6 +793,10 @@ func (dl *HandleT) DropTable(tableName string) (err error) {
 	return
 }
 
+func (dl *HandleT) DeleteByJobRunID(tableNames []string, jobRunID string, startTime string) (success bool, err error) {
+	return false, fmt.Errorf("delta lake err :not implemented")
+}
+
 // AddColumn adds column for column name and type
 func (dl *HandleT) AddColumn(name, columnName, columnType string) (err error) {
 	tableName := fmt.Sprintf(`%s.%s`, dl.Namespace, name)

--- a/warehouse/manager/manager.go
+++ b/warehouse/manager/manager.go
@@ -43,6 +43,7 @@ type ManagerI interface {
 
 type WarehouseDelete interface {
 	DropTable(tableName string) (err error)
+	DeleteByJobRunID(tableNames []string, jobRunID string, StartTime string) (success bool, err error)
 }
 
 type WarehouseOperations interface {

--- a/warehouse/mssql/mssql.go
+++ b/warehouse/mssql/mssql.go
@@ -654,6 +654,22 @@ func (ms *HandleT) DropTable(tableName string) (err error) {
 	return
 }
 
+func (ms *HandleT) DeleteByJobRunID(tableNames []string, jobRunID string, startTime string) (success bool, err error) {
+	pkgLogger.Infof("PG: Cleaning up the followng tables in mysql for MS:%s : %v", tableNames)
+	for _, tb := range tableNames {
+		if tb != "rudder_discards" {
+			sqlStatement := fmt.Sprintf(`DELETE FROM "%[1]s"."%[2]s" WHERE %[3]s <> '%[4]s'`, ms.Namespace, tb, "context_sources_job_run_id", jobRunID)
+			pkgLogger.Infof("MYSQL: Deleting rows in table in mysql for MS:%s : %v", ms.Warehouse.Destination.ID, sqlStatement)
+			_, err = ms.Db.Exec(sqlStatement)
+			if err != nil {
+				pkgLogger.Errorf("Error %s", err)
+				return false, err
+			}
+		}
+	}
+	return true, nil
+}
+
 func (ms *HandleT) AddColumn(tableName, columnName, columnType string) (err error) {
 	err = ms.addColumn(ms.Namespace+"."+tableName, columnName, columnType)
 	return err

--- a/warehouse/postgres/postgres.go
+++ b/warehouse/postgres/postgres.go
@@ -619,6 +619,23 @@ func (as *HandleT) DropTable(tableName string) (err error) {
 	return
 }
 
+func (pq *HandleT) DeleteByJobRunID(tableNames []string, jobRunID string, startTime string) (success bool, err error) {
+	pkgLogger.Infof("PG: Cleaning up the followng tables in postgres for PG:%s : %v", tableNames)
+	for _, tb := range tableNames {
+		if tb != "rudder_discards" {
+			sqlStatement := fmt.Sprintf(`DELETE FROM "%[1]s"."%[2]s" WHERE %[3]s <> '%[4]s'`, pq.Namespace, tb, "context_sources_job_run_id", jobRunID)
+			pkgLogger.Infof("PG: Deleting rows in table in postgres for PG:%s : %v", pq.Warehouse.Destination.ID, sqlStatement)
+			_, err = pq.Db.Exec(sqlStatement)
+			if err != nil {
+				fmt.Printf("Error %s", err)
+				return false, err
+			}
+		}
+
+	}
+	return true, nil
+}
+
 func (pg *HandleT) AddColumn(tableName, columnName, columnType string) (err error) {
 	// set the schema in search path. so that we can query table with unqualified name which is just the table name rather than using schema.table in queries
 	sqlStatement := fmt.Sprintf(`SET search_path to "%s"`, pg.Namespace)

--- a/warehouse/redshift/redshift.go
+++ b/warehouse/redshift/redshift.go
@@ -161,6 +161,22 @@ func (rs *HandleT) DropTable(tableName string) (err error) {
 	return
 }
 
+func (rs *HandleT) DeleteByJobRunID(tableNames []string, jobRunID string, startTime string) (success bool, err error) {
+	pkgLogger.Infof("RS: Cleaning up the followng tables in redshift for RS:%s : %v", tableNames)
+	for _, tb := range tableNames {
+		if tb != "rudder_discards" {
+			sqlStatement := fmt.Sprintf(`DELETE FROM "%[1]s"."%[2]s" WHERE %[3]s <> '%[4]s'`, rs.Namespace, tb, "context_sources_job_run_id", jobRunID)
+			pkgLogger.Infof("RS: Deleting rows in table in redshift for RS:%s : %v", rs.Warehouse.Destination.ID, sqlStatement)
+			_, err = rs.Db.Exec(sqlStatement)
+			if err != nil {
+				pkgLogger.Errorf("Error in executing the query %s", err.Error)
+				return false, err
+			}
+		}
+	}
+	return true, nil
+}
+
 func (rs *HandleT) schemaExists(schemaname string) (exists bool, err error) {
 	sqlStatement := fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = '%s');`, rs.Namespace)
 	err = rs.Db.QueryRow(sqlStatement).Scan(&exists)

--- a/warehouse/snowflake/snowflake.go
+++ b/warehouse/snowflake/snowflake.go
@@ -626,6 +626,22 @@ func (sf *HandleT) DropTable(tableName string) (err error) {
 	return
 }
 
+func (sf *HandleT) DeleteByJobRunID(tableNames []string, jobRunID string, startTime string) (success bool, err error) {
+	pkgLogger.Infof("SF: Cleaning up the followng tables in snowflake for SF:%s : %v", tableNames)
+	for _, tb := range tableNames {
+		if tb != "rudder_discards" {
+			sqlStatement := fmt.Sprintf(`DELETE FROM "%[1]s"."%[2]s" WHERE %[3]s <> '%[4]s'`, sf.Namespace, tb, "context_sources_job_run_id", jobRunID)
+			pkgLogger.Infof("SF: Deleting rows in table in postgres for SF:%s : %v", sf.Warehouse.Destination.ID, sqlStatement)
+			_, err = sf.Db.Exec(sqlStatement)
+			if err != nil {
+				pkgLogger.Errorf("Error %s", err)
+				return false, err
+			}
+		}
+	}
+	return true, nil
+}
+
 func (sf *HandleT) AddColumn(tableName, columnName, columnType string) (err error) {
 	sqlStatement := fmt.Sprintf(`USE SCHEMA "%s"`, sf.Namespace)
 	_, err = sf.Db.Exec(sqlStatement)

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/rudderlabs/rudder-server/warehouse/deltalake"
 
-	"github.com/rudderlabs/rudder-server/warehouse/configuration_testing"
-
 	"github.com/bugsnag/bugsnag-go/v2"
 	"github.com/lib/pq"
 	"github.com/rudderlabs/rudder-server/app"
@@ -39,6 +37,7 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 	"github.com/rudderlabs/rudder-server/utils/types"
+	"github.com/rudderlabs/rudder-server/warehouse/configuration_testing"
 	"github.com/rudderlabs/rudder-server/warehouse/manager"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 	"github.com/thoas/go-funk"
@@ -1263,7 +1262,7 @@ func processHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	var stagingFile warehouseutils.StagingFileT
-	json.Unmarshal(body, &stagingFile)
+	_ = json.Unmarshal(body, &stagingFile)
 
 	var firstEventAt, lastEventAt interface{}
 	firstEventAt = stagingFile.FirstEventAt


### PR DESCRIPTION
# Description

Google Sheets require mirror sync at the destination. The following PR implements a method to deleting all the previous job runs at the destinations so that only the current job runs stay at the destination.

Notion Link
https://www.notion.so/rudderstacks/Google-Sheets-dedup-logic-in-warehouse-de7487aba64e488bb05004695fe02540

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
