### PR TITLE
chore: using workspaceId as the tag everywhere

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -204,7 +204,7 @@ func buildStatTags(sourceID, workspaceID string, destination backendconfig.Desti
 		"destination":        destination.ID,
 		"destType":           destination.DestinationDefinition.Name,
 		"source":             sourceID,
-		"workspace":          workspaceID,
+		"workspaceId":        workspaceID,
 		"transformationType": transformationType,
 	}
 }

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1540,7 +1540,7 @@ func (brt *HandleT) recordUploadStats(destination DestinationT, output StorageUp
 		"module":      "batch_router",
 		"destType":    brt.destType,
 		"destination": destinationTag,
-		"workspace":   destination.Source.WorkspaceID,
+		"workspaceId": destination.Source.WorkspaceID,
 	})
 	eventDeliveryStat.Count(output.TotalEvents)
 
@@ -1550,7 +1550,7 @@ func (brt *HandleT) recordUploadStats(destination DestinationT, output StorageUp
 			"module":      "batch_router",
 			"destType":    brt.destType,
 			"destination": destinationTag,
-			"workspace":   destination.Source.WorkspaceID,
+			"workspaceId": destination.Source.WorkspaceID,
 		})
 		eventDeliveryTimeStat.SendTiming(time.Since(receivedTime))
 	}
@@ -1734,11 +1734,11 @@ func (worker *workerT) workerProcess() {
 				brt.updateProcessedEventsMetrics(statusList)
 				for destID, destDrainStat := range drainStatsbyDest {
 					brt.drainedJobsStat = stats.NewTaggedStat("drained_events", stats.CountType, stats.Tags{
-						"destType":  brt.destType,
-						"destId":    destID,
-						"module":    "batchrouter",
-						"reasons":   strings.Join(destDrainStat.Reasons, ", "),
-						"workspace": destDrainStat.Workspace,
+						"destType":    brt.destType,
+						"destId":      destID,
+						"module":      "batchrouter",
+						"reasons":     strings.Join(destDrainStat.Reasons, ", "),
+						"workspaceId": destDrainStat.Workspace,
 					})
 					brt.drainedJobsStat.Count(destDrainStat.Count)
 					metric.DecreasePendingEvents("batch_rt", destDrainStat.Workspace, brt.destType, float64(drainStatsbyDest[destID].Count))

--- a/router/router.go
+++ b/router/router.go
@@ -648,7 +648,7 @@ func (worker *workerT) processDestinationJobs() {
 					"module":      "router",
 					"destType":    worker.rt.destName,
 					"destination": misc.GetTagName(destinationJob.Destination.ID, destinationJob.Destination.Name),
-					"workspace":   workspaceID,
+					"workspaceId": workspaceID,
 				})
 				deliveryLatencyStat.Start()
 				startedAt := time.Now()
@@ -742,7 +742,7 @@ func (worker *workerT) processDestinationJobs() {
 							stats.NewTaggedStat("transformer_proxy.input_events_count", stats.CountType, stats.Tags{
 								"destType":      worker.rt.destName,
 								"destinationId": destinationJob.Destination.ID,
-								"workspace":     workspaceID,
+								"workspaceId":   workspaceID,
 							}).Count(len(result))
 
 							pkgLogger.Debugf(`[TransformerProxy] (Dest-%v) {Job - %v} Input Router Events: %v, Out router events: %v`, worker.rt.destName,
@@ -754,7 +754,7 @@ func (worker *workerT) processDestinationJobs() {
 							stats.NewTaggedStat("transformer_proxy.output_events_count", stats.CountType, stats.Tags{
 								"destType":      worker.rt.destName,
 								"destinationId": destinationJob.Destination.ID,
-								"workspace":     workspaceID,
+								"workspaceId":   workspaceID,
 							}).Count(len(respBodyArr))
 						}
 					}
@@ -1216,7 +1216,7 @@ func (worker *workerT) sendRouterResponseCountStat(destinationJobMetadata *types
 		"respStatusCode": status.ErrorCode,
 		"destination":    destinationTag,
 		"attempt_number": strconv.Itoa(status.AttemptNum),
-		"workspace":      status.WorkspaceId,
+		"workspaceId":    status.WorkspaceId,
 	})
 	routerResponseStat.Count(1)
 }
@@ -1229,7 +1229,7 @@ func (worker *workerT) sendEventDeliveryStat(destinationJobMetadata *types.JobMe
 			"destType":       worker.rt.destName,
 			"destination":    destinationTag,
 			"attempt_number": strconv.Itoa(status.AttemptNum),
-			"workspace":      status.WorkspaceId,
+			"workspaceId":    status.WorkspaceId,
 		})
 		eventsDeliveredStat.Count(1)
 		if destinationJobMetadata.ReceivedAt != "" {
@@ -1241,7 +1241,7 @@ func (worker *workerT) sendEventDeliveryStat(destinationJobMetadata *types.JobMe
 						"destType":       worker.rt.destName,
 						"destination":    destinationTag,
 						"attempt_number": strconv.Itoa(status.AttemptNum),
-						"workspace":      status.WorkspaceId,
+						"workspaceId":    status.WorkspaceId,
 					})
 
 				eventsDeliveryTimeStat.SendTiming(time.Since(receivedTime))
@@ -2108,11 +2108,11 @@ func (rt *HandleT) readAndProcess() int {
 		rt.updateProcessedEventsMetrics(drainList)
 		for destID, destDrainStat := range drainStatsbyDest {
 			drainedJobsStat := stats.NewTaggedStat(`drained_events`, stats.CountType, stats.Tags{
-				"destType":  rt.destName,
-				"destId":    destID,
-				"module":    "router",
-				"reasons":   strings.Join(destDrainStat.Reasons, ", "),
-				"workspace": destDrainStat.Workspace,
+				"destType":    rt.destName,
+				"destId":      destID,
+				"module":      "router",
+				"reasons":     strings.Join(destDrainStat.Reasons, ", "),
+				"workspaceId": destDrainStat.Workspace,
 			})
 			drainedJobsStat.Count(destDrainStat.Count)
 			metric.DecreasePendingEvents("rt", destDrainStat.Workspace, rt.destName, float64(drainStatsbyDest[destID].Count))

--- a/router/router.go
+++ b/router/router.go
@@ -742,6 +742,7 @@ func (worker *workerT) processDestinationJobs() {
 							stats.NewTaggedStat("transformer_proxy.input_events_count", stats.CountType, stats.Tags{
 								"destType":      worker.rt.destName,
 								"destinationId": destinationJob.Destination.ID,
+								"workspace":     workspaceID,
 								"workspaceId":   workspaceID,
 							}).Count(len(result))
 
@@ -754,6 +755,7 @@ func (worker *workerT) processDestinationJobs() {
 							stats.NewTaggedStat("transformer_proxy.output_events_count", stats.CountType, stats.Tags{
 								"destType":      worker.rt.destName,
 								"destinationId": destinationJob.Destination.ID,
+								"workspace":     workspaceID,
 								"workspaceId":   workspaceID,
 							}).Count(len(respBodyArr))
 						}

--- a/services/metric/measurement.go
+++ b/services/metric/measurement.go
@@ -48,8 +48,8 @@ func (r pendingEventsMeasurement) GetName() string {
 
 func (r pendingEventsMeasurement) GetTags() map[string]string {
 	res := map[string]string{
-		"workspace": r.workspace,
-		"destType":  r.destType,
+		"workspaceId": r.workspace,
+		"destType":    r.destType,
 	}
 	return res
 }

--- a/services/metric/measurement.go
+++ b/services/metric/measurement.go
@@ -48,6 +48,7 @@ func (r pendingEventsMeasurement) GetName() string {
 
 func (r pendingEventsMeasurement) GetTags() map[string]string {
 	res := map[string]string{
+		"workspace":   r.workspace,
 		"workspaceId": r.workspace,
 		"destType":    r.destType,
 	}


### PR DESCRIPTION
# Description

We use both `workspace` and `workspaceId` as tags for the metrics. Replacing with `workspaceId` to be consistent.

## Notion Ticket

https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=4c71cd5376fe4515a28dc96e438aa134&pm=s

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
