### PR TITLE
feat: introduce context, timeout and retries in jobsDB queries

### DIFF
--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -192,13 +192,10 @@ func TestDynamicClusterManager(t *testing.T) {
 
 	clearDb := false
 	ctx := context.Background()
-
-	mtStat := &multitenant.Stats{
-		RouterDBs: map[string]jobsdb.MultiTenantJobsDB{
-			"rt":       &jobsdb.MultiTenantHandleT{HandleT: rtDB},
-			"batch_rt": &jobsdb.MultiTenantLegacy{HandleT: brtDB},
-		},
-	}
+	mtStat := multitenant.NewStats(map[string]jobsdb.MultiTenantJobsDB{
+		"rt":       &jobsdb.MultiTenantHandleT{HandleT: rtDB},
+		"batch_rt": &jobsdb.MultiTenantLegacy{HandleT: brtDB},
+	})
 
 	processor := processor.New(ctx, &clearDb, gwDB, rtDB, brtDB, errDB, mockMTI, &reporting.NOOP{}, transientsource.NewEmptyService(), rsources.NewNoOpService())
 	processor.BackendConfig = mockBackendConfig

--- a/enterprise/replay/replay.go
+++ b/enterprise/replay/replay.go
@@ -39,19 +39,31 @@ func (handle *Handler) generatorLoop(ctx context.Context) {
 			CustomValFilters: []string{"replay"},
 			JobsLimit:        handle.dbReadSize,
 		}
-		toRetry := handle.db.GetToRetry(queryParams)
+		toRetry, err := handle.db.GetToRetry(context.TODO(), queryParams)
+		if err != nil {
+			pkgLogger.Errorf("Error getting to retry jobs: %v", err)
+			panic(err)
+		}
 		combinedList := toRetry.Jobs
 
 		if !toRetry.LimitsReached {
 			queryParams.JobsLimit -= len(combinedList)
-			unprocessed := handle.db.GetUnprocessed(queryParams)
+			unprocessed, err := handle.db.GetUnprocessed(context.TODO(), queryParams)
+			if err != nil {
+				pkgLogger.Errorf("Error getting unprocessed jobs: %v", err)
+				panic(err)
+			}
 			combinedList = append(combinedList, unprocessed.Jobs...)
 		}
 		pkgLogger.Infof("length of combinedList : %d", len(combinedList))
 
 		if len(combinedList) == 0 {
 			if breakLoop {
-				executingList := handle.db.GetExecuting(jobsdb.GetQueryParamsT{CustomValFilters: []string{"replay"}, JobsLimit: handle.dbReadSize})
+				executingList, err := handle.db.GetExecuting(context.TODO(), jobsdb.GetQueryParamsT{CustomValFilters: []string{"replay"}, JobsLimit: handle.dbReadSize})
+				if err != nil {
+					pkgLogger.Errorf("Error getting executing jobs: %v", err)
+					panic(err)
+				}
 				pkgLogger.Infof("breakLoop is set. Pending executing: %d", len(executingList.Jobs))
 				if len(executingList.Jobs) == 0 {
 					break

--- a/enterprise/replay/replay.go
+++ b/enterprise/replay/replay.go
@@ -108,7 +108,7 @@ func (handle *Handler) generatorLoop(ctx context.Context) {
 		}
 
 		// Mark the jobs as executing
-		err := handle.db.UpdateJobStatus(ctx, statusList, []string{"replay"}, nil)
+		err = handle.db.UpdateJobStatus(ctx, statusList, []string{"replay"}, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -1,3 +1,4 @@
+// go:build integration
 package jobsdb_test
 
 import (
@@ -618,11 +619,12 @@ func TestJobsDB(t *testing.T) {
 		require.Equal(t, int(2), jobDBInspector.DSListSize())
 		require.Equal(t, int64(2), jobDB.GetMaxDSIndex())
 
-		jobsResult := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+		jobsResult, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{customVal},
 			JobsLimit:        100,
 			ParameterFilters: []jobsdb.ParameterFilterT{},
 		})
+		require.NoError(t, err, "GetUnprocessed failed")
 		fetchedJobs := jobsResult.Jobs
 		require.Equal(t, 1, len(fetchedJobs))
 

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -190,21 +190,23 @@ func TestJobsDB(t *testing.T) {
 		CustomVal:    customVal,
 	}
 
-	unprocessedJobEmpty := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+	unprocessedJobEmpty, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 		CustomValFilters: []string{customVal},
 		JobsLimit:        1,
 		ParameterFilters: []jobsdb.ParameterFilterT{},
 	})
+	require.NoError(t, err, "GetUnprocessed failed")
 	unprocessedListEmpty := unprocessedJobEmpty.Jobs
 	require.Equal(t, 0, len(unprocessedListEmpty))
 	err = jobDB.Store(context.Background(), []*jobsdb.JobT{&sampleTestJob})
 	require.NoError(t, err)
 
-	unprocessedJob := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+	unprocessedJob, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 		CustomValFilters: []string{customVal},
 		JobsLimit:        1,
 		ParameterFilters: []jobsdb.ParameterFilterT{},
 	})
+	require.NoError(t, err, "GetUnprocessed failed")
 	unprocessedList := unprocessedJob.Jobs
 	require.Equal(t, 1, len(unprocessedList))
 
@@ -223,11 +225,12 @@ func TestJobsDB(t *testing.T) {
 	err = jobDB.UpdateJobStatus(context.Background(), []*jobsdb.JobStatusT{&status}, []string{customVal}, []jobsdb.ParameterFilterT{})
 	require.NoError(t, err)
 
-	uj := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+	uj, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 		CustomValFilters: []string{customVal},
 		JobsLimit:        1,
 		ParameterFilters: []jobsdb.ParameterFilterT{},
 	})
+	require.NoError(t, err, "GetUnprocessed failed")
 	unprocessedList = uj.Jobs
 	require.Equal(t, 0, len(unprocessedList))
 
@@ -246,21 +249,23 @@ func TestJobsDB(t *testing.T) {
 		}
 
 		t.Log("GetUnprocessed with job count limit")
-		JobLimitJob := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+		JobLimitJob, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{customVal},
 			JobsLimit:        100,
 			ParameterFilters: []jobsdb.ParameterFilterT{},
 		})
+		require.NoError(t, err, "GetUnprocessed failed")
 		JobLimitList := JobLimitJob.Jobs
 		require.Equal(t, jobCount, len(JobLimitList))
 
 		t.Log("GetUnprocessed with event count limit")
-		eventLimitJob := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+		eventLimitJob, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{customVal},
 			JobsLimit:        100,
 			EventsLimit:      eventsPerJob * 20,
 			ParameterFilters: []jobsdb.ParameterFilterT{},
 		})
+		require.NoError(t, err, "GetUnprocessed failed")
 		eventLimitList := eventLimitJob.Jobs
 		require.Equal(t, 20, len(eventLimitList))
 		t.Log("GetUnprocessed jobs should have the expected event count")
@@ -269,12 +274,13 @@ func TestJobsDB(t *testing.T) {
 		}
 
 		t.Log("Repeat read")
-		eventLimitListRepeat := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+		eventLimitListRepeat, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{customVal},
 			JobsLimit:        100,
 			EventsLimit:      eventsPerJob * 20,
 			ParameterFilters: []jobsdb.ParameterFilterT{},
 		})
+		require.NoError(t, err, "GetUnprocessed failed")
 		require.Equal(t, 20, len(eventLimitListRepeat.Jobs))
 		require.Equal(t, eventLimitList, eventLimitListRepeat.Jobs)
 
@@ -298,18 +304,20 @@ func TestJobsDB(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Log("GetUnprocessed with job count limit")
-		retryJobLimitList := jobDB.GetToRetry(jobsdb.GetQueryParamsT{
+		retryJobLimitList, err := jobDB.GetToRetry(context.Background(), jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{customVal},
 			JobsLimit:        100,
 		})
+		require.NoError(t, err, "GetToRetry failed")
 		require.Equal(t, jobCount, len(retryJobLimitList.Jobs))
 
 		t.Log("GetToRetry with event count limit")
-		retryEventLimitList := jobDB.GetToRetry(jobsdb.GetQueryParamsT{
+		retryEventLimitList, err := jobDB.GetToRetry(context.Background(), jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{customVal},
 			JobsLimit:        100,
 			EventsLimit:      eventsPerJob * 20,
 		})
+		require.NoError(t, err, "GetToRetry failed")
 		require.Equal(t, 20, len(retryEventLimitList.Jobs))
 		t.Log("GetToRetry jobs should have the expected event count")
 		for _, j := range eventLimitList {
@@ -351,22 +359,24 @@ func TestJobsDB(t *testing.T) {
 		t.Log("Using event count that will cause spill-over, not exact for ds1, but remainder suitable for ds2")
 		trickyEventCount := (eventsPerJob_ds1 * (jobCountPerDS - 1)) + eventsPerJob_ds2
 
-		eventLimitList := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+		eventLimitList, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{customVal},
 			JobsLimit:        100,
 			EventsLimit:      trickyEventCount,
 			ParameterFilters: []jobsdb.ParameterFilterT{},
 		})
+		require.NoError(t, err, "GetUnprocessed failed")
 		requireSequential(t, eventLimitList.Jobs)
 		require.Equal(t, jobCountPerDS-1, len(eventLimitList.Jobs))
 
 		t.Log("Prepare GetToRetry")
 		{
-			allJobs := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+			allJobs, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 				CustomValFilters: []string{customVal},
 				JobsLimit:        1000,
 				ParameterFilters: []jobsdb.ParameterFilterT{},
 			})
+			require.NoError(t, err, "GetUnprocessed failed")
 
 			statuses := make([]*jobsdb.JobStatusT, len(allJobs.Jobs))
 			n := time.Now().Add(time.Hour * -1)
@@ -389,12 +399,13 @@ func TestJobsDB(t *testing.T) {
 
 		t.Log("Test spill over with GetToRetry")
 		{
-			eventLimitList := jobDB.GetToRetry(jobsdb.GetQueryParamsT{
+			eventLimitList, err := jobDB.GetToRetry(context.Background(), jobsdb.GetQueryParamsT{
 				CustomValFilters: []string{customVal},
 				JobsLimit:        100,
 				EventsLimit:      trickyEventCount,
 				ParameterFilters: []jobsdb.ParameterFilterT{},
 			})
+			require.NoError(t, err, "GetToRetry failed")
 			requireSequential(t, eventLimitList.Jobs)
 			require.Equal(t, jobCountPerDS-1, len(eventLimitList.Jobs))
 		}
@@ -429,12 +440,13 @@ func TestJobsDB(t *testing.T) {
 		triggerAddNewDS <- time.Now() // Second time, waits for the first loop to finish
 
 		payloadLimit := 3 * payloadSize
-		payloadLimitList := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+		payloadLimitList, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{customVal},
 			JobsLimit:        100,
 			PayloadSizeLimit: payloadLimit,
 			ParameterFilters: []jobsdb.ParameterFilterT{},
 		})
+		require.NoError(t, err, "GetUnprocessed failed")
 
 		requireSequential(t, payloadLimitList.Jobs)
 		require.Equal(t, 3, len(payloadLimitList.Jobs))
@@ -461,12 +473,13 @@ func TestJobsDB(t *testing.T) {
 		require.NoError(t, err)
 
 		payloadLimit := payloadSize / 2
-		payloadLimitList := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+		payloadLimitList, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{customVal},
 			JobsLimit:        100,
 			PayloadSizeLimit: payloadLimit,
 			ParameterFilters: []jobsdb.ParameterFilterT{},
 		})
+		require.NoError(t, err, "GetUnprocessed failed")
 
 		requireSequential(t, payloadLimitList.Jobs)
 		require.Equal(t, 1, len(payloadLimitList.Jobs))
@@ -491,12 +504,13 @@ func TestJobsDB(t *testing.T) {
 		require.NoError(t, jobDB.Store(context.Background(), jobs))
 
 		eventCountLimit := 1
-		eventLimitList := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+		eventLimitList, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{customVal},
 			JobsLimit:        100,
 			EventsLimit:      eventCountLimit,
 			ParameterFilters: []jobsdb.ParameterFilterT{},
 		})
+		require.NoError(t, err, "GetUnprocessed failed")
 
 		requireSequential(t, eventLimitList.Jobs)
 		require.Equal(t, 1, len(eventLimitList.Jobs))
@@ -532,12 +546,13 @@ func TestJobsDB(t *testing.T) {
 		triggerAddNewDS <- time.Now() // Second time, waits for the first loop to finish
 
 		eventCountLimit := 10
-		eventLimitList := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+		eventLimitList, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{customVal},
 			JobsLimit:        100,
 			EventsLimit:      eventCountLimit,
 			ParameterFilters: []jobsdb.ParameterFilterT{},
 		})
+		require.NoError(t, err, "GetUnprocessed failed")
 
 		requireSequential(t, eventLimitList.Jobs)
 		require.Equal(t, 3, len(eventLimitList.Jobs))
@@ -663,7 +678,8 @@ func TestMultiTenantLegacyGetAllJobs(t *testing.T) {
 	require.NoError(t, jobDB.Store(context.Background(), jobs))
 	payloadSize, err := getPayloadSize(t, &jobDB, jobs[0])
 	require.NoError(t, err)
-	j := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{JobsLimit: 100}) // read to get Ids
+	j, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{JobsLimit: 100}) // read to get Ids
+	require.NoError(t, err, "failed to get unprocessed jobs")
 	jobs = j.Jobs
 	require.Equal(t, 30, len(jobs), "should get all 30 jobs")
 
@@ -675,42 +691,48 @@ func TestMultiTenantLegacyGetAllJobs(t *testing.T) {
 
 	t.Run("GetAllJobs with large limits", func(t *testing.T) {
 		params := jobsdb.GetQueryParamsT{JobsLimit: 30}
-		allJobs := mtl.GetAllJobs(map[string]int{defaultWorkspaceID: 30}, params, 0)
+		allJobs, err := mtl.GetAllJobs(context.Background(), map[string]int{defaultWorkspaceID: 30}, params, 0)
+		require.NoError(t, err, "failed to get all jobs")
 		require.Equal(t, 30, len(allJobs), "should get all 30 jobs")
 	})
 
 	t.Run("GetAllJobs with only jobs limit", func(t *testing.T) {
 		jobsLimit := 10
 		params := jobsdb.GetQueryParamsT{JobsLimit: 10}
-		allJobs := mtl.GetAllJobs(map[string]int{defaultWorkspaceID: jobsLimit}, params, 0)
+		allJobs, err := mtl.GetAllJobs(context.Background(), map[string]int{defaultWorkspaceID: jobsLimit}, params, 0)
+		require.NoError(t, err, "failed to get all jobs")
 		require.Truef(t, len(allJobs)-jobsLimit == 0, "should get %d jobs", jobsLimit)
 	})
 
 	t.Run("GetAllJobs with events limit", func(t *testing.T) {
 		jobsLimit := 10
 		params := jobsdb.GetQueryParamsT{JobsLimit: 10, EventsLimit: 3 * eventsPerJob}
-		allJobs := mtl.GetAllJobs(map[string]int{defaultWorkspaceID: jobsLimit}, params, 0)
+		allJobs, err := mtl.GetAllJobs(context.Background(), map[string]int{defaultWorkspaceID: jobsLimit}, params, 0)
+		require.NoError(t, err, "failed to get all jobs")
 		require.Equal(t, 3, len(allJobs), "should get 3 jobs")
 	})
 
 	t.Run("GetAllJobs with events limit less than the events of the first job get one job", func(t *testing.T) {
 		jobsLimit := 10
 		params := jobsdb.GetQueryParamsT{JobsLimit: jobsLimit, EventsLimit: eventsPerJob - 1}
-		allJobs := mtl.GetAllJobs(map[string]int{defaultWorkspaceID: jobsLimit}, params, 0)
+		allJobs, err := mtl.GetAllJobs(context.Background(), map[string]int{defaultWorkspaceID: jobsLimit}, params, 0)
+		require.NoError(t, err, "failed to get all jobs")
 		require.Equal(t, 1, len(allJobs), "should get 1 overflown job")
 	})
 
 	t.Run("GetAllJobs with payload limit", func(t *testing.T) {
 		jobsLimit := 10
 		params := jobsdb.GetQueryParamsT{JobsLimit: jobsLimit, PayloadSizeLimit: 3 * payloadSize}
-		allJobs := mtl.GetAllJobs(map[string]int{defaultWorkspaceID: jobsLimit}, params, 0)
+		allJobs, err := mtl.GetAllJobs(context.Background(), map[string]int{defaultWorkspaceID: jobsLimit}, params, 0)
+		require.NoError(t, err, "failed to get all jobs")
 		require.Equal(t, 3, len(allJobs), "should get 3 jobs")
 	})
 
 	t.Run("GetAllJobs with payload limit less than the payload size should get one job", func(t *testing.T) {
 		jobsLimit := 10
 		params := jobsdb.GetQueryParamsT{JobsLimit: jobsLimit, PayloadSizeLimit: payloadSize - 1}
-		allJobs := mtl.GetAllJobs(map[string]int{defaultWorkspaceID: jobsLimit}, params, 0)
+		allJobs, err := mtl.GetAllJobs(context.Background(), map[string]int{defaultWorkspaceID: jobsLimit}, params, 0)
+		require.NoError(t, err, "failed to get all jobs")
 		require.Equal(t, 1, len(allJobs), "should get 1 overflown job")
 	})
 }
@@ -756,7 +778,8 @@ func TestMultiTenantGetAllJobs(t *testing.T) {
 	jobs = genJobs(workspaceC, customVal, 30, eventsPerJob)
 	require.NoError(t, jobDB.Store(context.Background(), jobs))
 
-	unprocessedJobs := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{JobsLimit: 90}) // read to get all Ids
+	unprocessedJobs, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{JobsLimit: 90}) // read to get all Ids
+	require.NoError(t, err, "failed to get unprocessed jobs")
 	allJobs := unprocessedJobs.Jobs
 	require.Equal(t, 90, len(allJobs), "should get all 90 jobs")
 	workspaceAJobs := filterWorkspaceJobs(allJobs, workspaceA)
@@ -780,7 +803,8 @@ func TestMultiTenantGetAllJobs(t *testing.T) {
 			workspaceC: 30,
 		}
 		params := jobsdb.GetQueryParamsT{JobsLimit: 90}
-		allJobs := mtl.GetAllJobs(workspaceLimits, params, 100)
+		allJobs, err := mtl.GetAllJobs(context.Background(), workspaceLimits, params, 100)
+		require.NoError(t, err, "failed to get all jobs")
 		require.Equal(t, 90, len(allJobs), "should get all 90 jobs")
 	})
 
@@ -792,7 +816,8 @@ func TestMultiTenantGetAllJobs(t *testing.T) {
 			workspaceC: 0,
 		}
 		params := jobsdb.GetQueryParamsT{JobsLimit: jobsLimit * 2}
-		allJobs := mtl.GetAllJobs(workspaceLimits, params, 100)
+		allJobs, err := mtl.GetAllJobs(context.Background(), workspaceLimits, params, 100)
+		require.NoError(t, err, "failed to get all jobs")
 		require.Truef(t, len(allJobs)-2*jobsLimit == 0, "should get %d jobs", 2*jobsLimit)
 	})
 
@@ -803,7 +828,8 @@ func TestMultiTenantGetAllJobs(t *testing.T) {
 			workspaceC: 30,
 		}
 		params := jobsdb.GetQueryParamsT{JobsLimit: 90, PayloadSizeLimit: 6 * payloadSize}
-		allJobs := mtl.GetAllJobs(workspaceLimits, params, 100)
+		allJobs, err := mtl.GetAllJobs(context.Background(), workspaceLimits, params, 100)
+		require.NoError(t, err, "failed to get all jobs")
 		require.Equal(t, 6+3, len(allJobs), "should get limit jobs +1 (overflow) per workspace")
 	})
 
@@ -814,7 +840,8 @@ func TestMultiTenantGetAllJobs(t *testing.T) {
 			workspaceC: 30,
 		}
 		params := jobsdb.GetQueryParamsT{JobsLimit: 90, PayloadSizeLimit: payloadSize - 1}
-		allJobs := mtl.GetAllJobs(workspaceLimits, params, 100)
+		allJobs, err := mtl.GetAllJobs(context.Background(), workspaceLimits, params, 100)
+		require.NoError(t, err, "failed to get all jobs")
 		require.Equal(t, 3, len(allJobs), "should get limit+1 jobs")
 	})
 }
@@ -847,11 +874,12 @@ func TestStoreAndUpdateStatusExceedingAnalyzeThreshold(t *testing.T) {
 	}
 	err = jobDB.Store(context.Background(), []*jobsdb.JobT{&sampleTestJob})
 	require.NoError(t, err)
-	unprocessedJob := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+	unprocessedJob, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 		CustomValFilters: []string{customVal},
 		JobsLimit:        1,
 		ParameterFilters: []jobsdb.ParameterFilterT{},
 	})
+	require.NoError(t, err, "should get unprocessed job")
 	unprocessedList := unprocessedJob.Jobs
 	require.Equal(t, 1, len(unprocessedList))
 	j := unprocessedList[0]
@@ -1014,11 +1042,13 @@ func TestJobsDB_IncompatiblePayload(t *testing.T) {
 	for _, val := range errMap {
 		require.Equal(t, "", val)
 	}
-	unprocessedJob := jobDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+	unprocessedJob, err := jobDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 		CustomValFilters: []string{customVal},
 		JobsLimit:        1,
 		ParameterFilters: []jobsdb.ParameterFilterT{},
 	})
+	require.NoError(t, err, "should not error")
+
 	unprocessedList := unprocessedJob.Jobs
 	require.Equal(t, 1, len(unprocessedList))
 
@@ -1120,10 +1150,11 @@ func benchmarkJobsdbConcurrently(b *testing.B, jobsDB *jobsdb.HandleT, totalJobs
 			g.Go(func() error {
 				start.Wait()
 				for {
-					unprocessedJob := jobsDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+					unprocessedJob, err := jobsDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 						CustomValFilters: []string{customVal},
 						JobsLimit:        pageSize,
 					})
+					require.NoError(b, err, "failed to get unprocessed jobs")
 					unprocessedList := unprocessedJob.Jobs
 					status := make([]*jobsdb.JobStatusT, len(unprocessedList))
 					for i, j := range unprocessedList {
@@ -1140,7 +1171,7 @@ func benchmarkJobsdbConcurrently(b *testing.B, jobsDB *jobsdb.HandleT, totalJobs
 						}
 					}
 
-					err := jobsDB.UpdateJobStatus(context.Background(), status, []string{customVal}, []jobsdb.ParameterFilterT{})
+					err = jobsDB.UpdateJobStatus(context.Background(), status, []string{customVal}, []jobsdb.ParameterFilterT{})
 					require.NoError(b, err)
 
 					for _, j := range unprocessedList {
@@ -1238,9 +1269,10 @@ func BenchmarkLifecycle(b *testing.B) {
 func consume(t testing.TB, db *jobsdb.HandleT, count int) {
 	t.Helper()
 
-	unprocessedList := db.GetUnprocessed(jobsdb.GetQueryParamsT{
+	unprocessedList, err := db.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 		JobsLimit: count,
 	})
+	require.NoError(t, err, "failed to get unprocessed jobs")
 
 	status := make([]*jobsdb.JobStatusT, len(unprocessedList.Jobs))
 	for i, j := range unprocessedList.Jobs {
@@ -1257,7 +1289,7 @@ func consume(t testing.TB, db *jobsdb.HandleT, count int) {
 		}
 	}
 
-	err := db.UpdateJobStatus(context.Background(), status, []string{}, []jobsdb.ParameterFilterT{})
+	err = db.UpdateJobStatus(context.Background(), status, []string{}, []jobsdb.ParameterFilterT{})
 	require.NoError(t, err)
 }
 

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -232,26 +232,26 @@ type JobsDB interface {
 
 	// GetUnprocessed finds unprocessed jobs. Unprocessed are new
 	// jobs whose state hasn't been marked in the database yet
-	GetUnprocessed(params GetQueryParamsT) JobsResult
+	GetUnprocessed(ctx context.Context, params GetQueryParamsT) (JobsResult, error)
 
 	// GetProcessed finds jobs in some state, i.e. not unprocessed
-	GetProcessed(params GetQueryParamsT) JobsResult
+	GetProcessed(ctx context.Context, params GetQueryParamsT) (JobsResult, error)
 
 	// GetToRetry finds jobs in failed state
-	GetToRetry(params GetQueryParamsT) JobsResult
+	GetToRetry(ctx context.Context, params GetQueryParamsT) (JobsResult, error)
 
 	// GetToRetry finds jobs in waiting state
-	GetWaiting(params GetQueryParamsT) JobsResult
+	GetWaiting(ctx context.Context, params GetQueryParamsT) (JobsResult, error)
 
 	// GetExecuting finds jobs in executing state
-	GetExecuting(params GetQueryParamsT) JobsResult
+	GetExecuting(ctx context.Context, params GetQueryParamsT) (JobsResult, error)
 
 	// GetImporting finds jobs in importing state
-	GetImporting(params GetQueryParamsT) JobsResult
+	GetImporting(ctx context.Context, params GetQueryParamsT) (JobsResult, error)
 
 	// GetPileUpCounts returns statistics (counters) of incomplete jobs
 	// grouped by workspaceId and destination type
-	GetPileUpCounts(statMap map[string]map[string]int)
+	GetPileUpCounts(ctx context.Context) (statMap map[string]map[string]int, err error)
 
 	/* Admin */
 
@@ -1906,11 +1906,16 @@ func (jd *HandleT) migrateJobs(ctx context.Context, srcDS, destDS dataSetT) (noJ
 	defer jd.dsListLock.RUnlock()
 
 	// Unprocessed jobs
-	unprocessedList := jd.getUnprocessedJobsDS(srcDS, false, GetQueryParamsT{})
-
+	unprocessedList, err := jd.getUnprocessedJobsDS(context.TODO(), srcDS, false, GetQueryParamsT{})
+	if err != nil {
+		return 0, err
+	}
 	// Jobs which haven't finished processing
-	retryList := jd.getProcessedJobsDS(srcDS, true,
+	retryList, err := jd.getProcessedJobsDS(context.TODO(), srcDS, true,
 		GetQueryParamsT{StateFilters: getValidNonTerminalStates()})
+	if err != nil {
+		return 0, err
+	}
 	jobsToMigrate := append(unprocessedList.Jobs, retryList.Jobs...)
 	noJobsMigrated = len(jobsToMigrate)
 
@@ -1936,8 +1941,10 @@ func (jd *HandleT) migrateJobs(ctx context.Context, srcDS, destDS dataSetT) (noJ
 		}
 		return jd.copyJobStatusDS(ctx, tx, destDS, statusList, []string{}, nil)
 	})
-	jd.assertError(err)
-	return
+	if err != nil {
+		return 0, err
+	}
+	return noJobsMigrated, nil
 }
 
 func (jd *HandleT) postMigrateHandleDS(l lock.DSListLockToken, migrateFrom []dataSetT) error {
@@ -2174,12 +2181,13 @@ func (jd *HandleT) doClearCache(ds dataSetT, CVPMap map[string]map[string]map[st
 	}
 }
 
-func (jd *HandleT) GetPileUpCounts(statMap map[string]map[string]int) {
+func (jd *HandleT) GetPileUpCounts(ctx context.Context) (map[string]map[string]int, error) {
 	jd.dsMigrationLock.RLock()
 	jd.dsListLock.RLock()
 	defer jd.dsMigrationLock.RUnlock()
 	defer jd.dsListLock.RUnlock()
 	dsList := jd.getDSList()
+	statMap := make(map[string]map[string]int)
 
 	for _, ds := range dsList {
 		queryString := fmt.Sprintf(`with joined as (
@@ -2223,24 +2231,29 @@ func (jd *HandleT) GetPileUpCounts(statMap map[string]map[string]int) {
 		  group by
 			customVal,
 			workspace;`, ds.JobTable, ds.JobStatusTable)
-		rows, err := jd.dbHandle.Query(queryString)
-		jd.assertError(err)
+		rows, err := jd.dbHandle.QueryContext(ctx, queryString)
+		if err != nil {
+			return nil, err
+		}
 
 		for rows.Next() {
 			var count sql.NullInt64
 			var customVal string
 			var workspace string
 			err := rows.Scan(&count, &customVal, &workspace)
-			jd.assertError(err)
+			if err != nil {
+				return statMap, err
+			}
 			if _, ok := statMap[workspace]; !ok {
 				statMap[workspace] = make(map[string]int)
 			}
 			statMap[workspace][customVal] += int(count.Int64)
 		}
 		if err = rows.Err(); err != nil {
-			jd.assertError(err)
+			return statMap, err
 		}
 	}
+	return statMap, nil
 }
 
 func (*HandleT) copyJobsDSInTx(txHandler transactionHandler, ds dataSetT, jobList []*JobT) error {
@@ -2528,7 +2541,7 @@ stateFilters and customValFilters do a OR query on values passed in array
 parameterFilters do a AND query on values included in the map.
 A JobsLimit less than or equal to zero indicates no limit.
 */
-func (jd *HandleT) getProcessedJobsDS(ds dataSetT, getAll bool, params GetQueryParamsT) JobsResult {
+func (jd *HandleT) getProcessedJobsDS(ctx context.Context, ds dataSetT, getAll bool, params GetQueryParamsT) (JobsResult, error) {
 	stateFilters := params.StateFilters
 	customValFilters := params.CustomValFilters
 	parameterFilters := params.ParameterFilters
@@ -2537,7 +2550,7 @@ func (jd *HandleT) getProcessedJobsDS(ds dataSetT, getAll bool, params GetQueryP
 
 	if jd.isEmptyResult(ds, allWorkspaces, stateFilters, customValFilters, parameterFilters) {
 		jd.logger.Debugf("[getProcessedJobsDS] Empty cache hit for ds: %v, stateFilters: %v, customValFilters: %v, parameterFilters: %v", ds, stateFilters, customValFilters, parameterFilters)
-		return JobsResult{}
+		return JobsResult{}, nil
 	}
 
 	tags := statTags{CustomValFilters: params.CustomValFilters, StateFilters: params.StateFilters, ParameterFilters: params.ParameterFilters}
@@ -2598,8 +2611,11 @@ func (jd *HandleT) getProcessedJobsDS(ds dataSetT, getAll bool, params GetQueryP
 			ds.JobTable, ds.JobStatusTable, stateQuery)
 		var err error
 		rows, err = jd.dbHandle.Query(sqlStatement)
-		jd.assertError(err)
+		if err != nil {
+			return JobsResult{}, err
+		}
 		defer rows.Close()
+
 	} else {
 		sqlStatement := fmt.Sprintf(`SELECT
 									jobs.job_id, jobs.uuid, jobs.user_id, jobs.parameters, jobs.custom_val, jobs.event_payload, jobs.event_count,
@@ -2643,12 +2659,18 @@ func (jd *HandleT) getProcessedJobsDS(ds dataSetT, getAll bool, params GetQueryP
 			sqlStatement = `SELECT * FROM (` + sqlStatement + `) t WHERE ` + strings.Join(wrapQuery, " AND ")
 		}
 
-		stmt, err := jd.dbHandle.Prepare(sqlStatement)
-		jd.assertError(err)
+		stmt, err := jd.dbHandle.PrepareContext(ctx, sqlStatement)
+		if err != nil {
+			return JobsResult{}, err
+		}
 		defer stmt.Close()
-		rows, err = stmt.Query(args...)
-		jd.assertError(err)
+
+		rows, err = stmt.QueryContext(ctx, args...)
+		if err != nil {
+			return JobsResult{}, err
+		}
 		defer rows.Close()
+
 	}
 
 	var runningEventCount int
@@ -2667,7 +2689,9 @@ func (jd *HandleT) getProcessedJobsDS(ds dataSetT, getAll bool, params GetQueryP
 			&job.LastJobStatus.JobState, &job.LastJobStatus.AttemptNum,
 			&job.LastJobStatus.ExecTime, &job.LastJobStatus.RetryTime,
 			&job.LastJobStatus.ErrorCode, &job.LastJobStatus.ErrorResponse, &job.LastJobStatus.Parameters)
-		jd.assertError(err)
+		if err != nil {
+			return JobsResult{}, err
+		}
 
 		if !getAll { // if getAll is true, limits do not apply
 			if params.EventsLimit > 0 && runningEventCount > params.EventsLimit && len(jobList) > 0 {
@@ -2707,7 +2731,7 @@ func (jd *HandleT) getProcessedJobsDS(ds dataSetT, getAll bool, params GetQueryP
 		LimitsReached: limitsReached,
 		PayloadSize:   payloadSize,
 		EventsCount:   eventCount,
-	}
+	}, nil
 }
 
 /*
@@ -2716,13 +2740,13 @@ stateFilters and customValFilters do a OR query on values passed in array
 parameterFilters do a AND query on values included in the map.
 A JobsLimit less than or equal to zero indicates no limit.
 */
-func (jd *HandleT) getUnprocessedJobsDS(ds dataSetT, order bool, params GetQueryParamsT) JobsResult {
+func (jd *HandleT) getUnprocessedJobsDS(ctx context.Context, ds dataSetT, order bool, params GetQueryParamsT) (JobsResult, error) {
 	customValFilters := params.CustomValFilters
 	parameterFilters := params.ParameterFilters
 
 	if jd.isEmptyResult(ds, allWorkspaces, []string{NotProcessed.State}, customValFilters, parameterFilters) {
 		jd.logger.Debugf("[getUnprocessedJobsDS] Empty cache hit for ds: %v, stateFilters: NP, customValFilters: %v, parameterFilters: %v", ds, customValFilters, parameterFilters)
-		return JobsResult{}
+		return JobsResult{}, nil
 	}
 
 	tags := statTags{CustomValFilters: params.CustomValFilters, ParameterFilters: params.ParameterFilters}
@@ -2797,10 +2821,14 @@ func (jd *HandleT) getUnprocessedJobsDS(ds dataSetT, order bool, params GetQuery
 		sqlStatement = `SELECT * FROM (` + sqlStatement + `) subquery WHERE ` + strings.Join(wrapQuery, " AND ")
 	}
 
-	rows, err = jd.dbHandle.Query(sqlStatement, args...)
-	jd.assertError(err)
+	rows, err = jd.dbHandle.QueryContext(ctx, sqlStatement, args...)
+	if err != nil {
+		return JobsResult{}, err
+	}
 	defer rows.Close()
-
+	if err != nil {
+		return JobsResult{}, err
+	}
 	var runningEventCount int
 	var runningPayloadSize int64
 
@@ -2813,8 +2841,9 @@ func (jd *HandleT) getUnprocessedJobsDS(ds dataSetT, order bool, params GetQuery
 		var job JobT
 		err := rows.Scan(&job.JobID, &job.UUID, &job.UserID, &job.Parameters, &job.CustomVal,
 			&job.EventPayload, &job.EventCount, &job.CreatedAt, &job.ExpireAt, &job.WorkspaceId, &job.PayloadSize, &runningEventCount, &runningPayloadSize)
-		jd.assertError(err)
-
+		if err != nil {
+			return JobsResult{}, err
+		}
 		if params.EventsLimit > 0 && runningEventCount > params.EventsLimit && len(jobList) > 0 {
 			// events limit overflow is triggered as long as we have read at least one job
 			limitsReached = true
@@ -2854,7 +2883,7 @@ func (jd *HandleT) getUnprocessedJobsDS(ds dataSetT, order bool, params GetQuery
 		LimitsReached: limitsReached,
 		PayloadSize:   payloadSize,
 		EventsCount:   eventCount,
-	}
+	}, nil
 }
 
 // copyJobStatusDS is expected to be called only during a migration
@@ -4104,26 +4133,26 @@ GetUnprocessed returns the unprocessed events. Unprocessed events are
 those whose state hasn't been marked in the DB.
 If enableReaderQueue is true, this goes through worker pool, else calls getUnprocessed directly.
 */
-func (jd *HandleT) GetUnprocessed(params GetQueryParamsT) JobsResult {
+func (jd *HandleT) GetUnprocessed(ctx context.Context, params GetQueryParamsT) (JobsResult, error) {
 	if params.JobsLimit <= 0 {
-		return JobsResult{}
+		return JobsResult{}, nil
 	}
 
 	tags := statTags{CustomValFilters: params.CustomValFilters, ParameterFilters: params.ParameterFilters}
 	command := func() interface{} {
-		return jd.getUnprocessed(params)
+		return queryResultWrapper(jd.getUnprocessed(ctx, params))
 	}
-	res, _ := jd.executeDbRequest(newReadDbRequest("unprocessed", &tags, command)).(JobsResult)
-	return res
+	res, _ := jd.executeDbRequest(newReadDbRequest("unprocessed", &tags, command)).(queryResult)
+	return res.JobsResult, res.err
 }
 
 /*
 getUnprocessed returns the unprocessed events. Unprocessed events are
 those whose state hasn't been marked in the DB
 */
-func (jd *HandleT) getUnprocessed(params GetQueryParamsT) JobsResult {
+func (jd *HandleT) getUnprocessed(ctx context.Context, params GetQueryParamsT) (JobsResult, error) {
 	if params.JobsLimit <= 0 {
-		return JobsResult{}
+		return JobsResult{}, nil
 	}
 
 	tags := statTags{CustomValFilters: params.CustomValFilters, ParameterFilters: params.ParameterFilters}
@@ -4153,7 +4182,10 @@ func (jd *HandleT) getUnprocessed(params GetQueryParamsT) JobsResult {
 
 	var completeUnprocessedJobs JobsResult
 	for _, ds := range dsList {
-		unprocessedJobs := jd.getUnprocessedJobsDS(ds, true, params)
+		unprocessedJobs, err := jd.getUnprocessedJobsDS(ctx, ds, true, params)
+		if err != nil {
+			return JobsResult{}, err
+		}
 		completeUnprocessedJobs.Jobs = append(completeUnprocessedJobs.Jobs, unprocessedJobs.Jobs...)
 		completeUnprocessedJobs.EventsCount += unprocessedJobs.EventsCount
 		completeUnprocessedJobs.PayloadSize += unprocessedJobs.PayloadSize
@@ -4174,28 +4206,28 @@ func (jd *HandleT) getUnprocessed(params GetQueryParamsT) JobsResult {
 		}
 	}
 	// Release lock
-	return completeUnprocessedJobs
+	return completeUnprocessedJobs, nil
 }
 
-func (jd *HandleT) GetImporting(params GetQueryParamsT) JobsResult {
+func (jd *HandleT) GetImporting(ctx context.Context, params GetQueryParamsT) (JobsResult, error) {
 	if params.JobsLimit == 0 {
-		return JobsResult{}
+		return JobsResult{}, nil
 	}
 	params.StateFilters = []string{Importing.State}
 	tags := statTags{CustomValFilters: params.CustomValFilters, StateFilters: params.StateFilters, ParameterFilters: params.ParameterFilters}
 	command := func() interface{} {
-		return jd.getImportingList(params)
+		return queryResultWrapper(jd.getImportingList(ctx, params))
 	}
-	res, _ := jd.executeDbRequest(newReadDbRequest("importing", &tags, command)).(JobsResult)
-	return res
+	res, _ := jd.executeDbRequest(newReadDbRequest("importing", &tags, command)).(queryResult)
+	return res.JobsResult, res.err
 }
 
 /*
 getImportingList returns events which need are Importing.
 This is a wrapper over GetProcessed call above
 */
-func (jd *HandleT) getImportingList(params GetQueryParamsT) JobsResult {
-	return jd.GetProcessed(params)
+func (jd *HandleT) getImportingList(ctx context.Context, params GetQueryParamsT) (JobsResult, error) {
+	return jd.GetProcessed(ctx, params)
 }
 
 /*
@@ -4325,9 +4357,9 @@ realises on the caller to update it. That means that successive calls to GetProc
 can return the same set of events. It is the responsibility of the caller to call it from
 one thread, update the state (to "waiting") in the same thread and pass on the the processors
 */
-func (jd *HandleT) GetProcessed(params GetQueryParamsT) JobsResult {
+func (jd *HandleT) GetProcessed(ctx context.Context, params GetQueryParamsT) (JobsResult, error) {
 	if params.JobsLimit <= 0 {
-		return JobsResult{}
+		return JobsResult{}, nil
 	}
 
 	tags := statTags{CustomValFilters: params.CustomValFilters, StateFilters: params.StateFilters, ParameterFilters: params.ParameterFilters}
@@ -4354,12 +4386,15 @@ func (jd *HandleT) GetProcessed(params GetQueryParamsT) JobsResult {
 	if params.PayloadSizeLimit > 0 {
 		limitByPayloadSize = true
 	} else if params.PayloadSizeLimit < 0 {
-		return JobsResult{}
+		return JobsResult{}, nil
 	}
 
 	var completeProcessedJobs JobsResult
 	for _, ds := range dsList {
-		processedJobs := jd.getProcessedJobsDS(ds, false, params)
+		processedJobs, err := jd.getProcessedJobsDS(ctx, ds, false, params)
+		if err != nil {
+			return JobsResult{}, err
+		}
 		completeProcessedJobs.Jobs = append(completeProcessedJobs.Jobs, processedJobs.Jobs...)
 		completeProcessedJobs.EventsCount += processedJobs.EventsCount
 		completeProcessedJobs.PayloadSize += processedJobs.PayloadSize
@@ -4380,77 +4415,89 @@ func (jd *HandleT) GetProcessed(params GetQueryParamsT) JobsResult {
 		}
 	}
 
-	return completeProcessedJobs
+	return completeProcessedJobs, nil
+}
+
+type queryResult struct {
+	JobsResult
+	err error
+}
+
+func queryResultWrapper(res JobsResult, err error) queryResult {
+	return queryResult{
+		JobsResult: res,
+		err:        err,
+	}
 }
 
 /*
 GetToRetry returns events which need to be retried.
 If enableReaderQueue is true, this goes through worker pool, else calls getUnprocessed directly.
 */
-func (jd *HandleT) GetToRetry(params GetQueryParamsT) JobsResult {
+func (jd *HandleT) GetToRetry(ctx context.Context, params GetQueryParamsT) (JobsResult, error) {
 	if params.JobsLimit == 0 {
-		return JobsResult{}
+		return JobsResult{}, nil
 	}
 	params.StateFilters = []string{Failed.State}
 	tags := statTags{CustomValFilters: params.CustomValFilters, StateFilters: params.StateFilters, ParameterFilters: params.ParameterFilters}
 	command := func() interface{} {
-		return jd.getToRetry(params)
+		return queryResultWrapper(jd.getToRetry(ctx, params))
 	}
-	res, _ := jd.executeDbRequest(newReadDbRequest("processed", &tags, command)).(JobsResult)
-	return res
+	res, _ := jd.executeDbRequest(newReadDbRequest("processed", &tags, command)).(queryResult)
+	return res.JobsResult, res.err
 }
 
 /*
 getToRetry returns events which need to be retried.
 This is a wrapper over GetProcessed call above
 */
-func (jd *HandleT) getToRetry(params GetQueryParamsT) JobsResult {
-	return jd.GetProcessed(params)
+func (jd *HandleT) getToRetry(ctx context.Context, params GetQueryParamsT) (JobsResult, error) {
+	return jd.GetProcessed(ctx, params)
 }
 
 /*
 GetWaiting returns events which are under processing
 If enableReaderQueue is true, this goes through worker pool, else calls getUnprocessed directly.
 */
-func (jd *HandleT) GetWaiting(params GetQueryParamsT) JobsResult {
+func (jd *HandleT) GetWaiting(ctx context.Context, params GetQueryParamsT) (JobsResult, error) {
 	if params.JobsLimit == 0 {
-		return JobsResult{}
+		return JobsResult{}, nil
 	}
 	params.StateFilters = []string{Waiting.State}
 	tags := statTags{CustomValFilters: params.CustomValFilters, StateFilters: params.StateFilters, ParameterFilters: params.ParameterFilters}
 	command := func() interface{} {
-		return jd.getWaiting(params)
+		return queryResultWrapper(jd.getWaiting(ctx, params))
 	}
-	res, _ := jd.executeDbRequest(newReadDbRequest("processed", &tags, command)).(JobsResult)
-	return res
+	res, _ := jd.executeDbRequest(newReadDbRequest("processed", &tags, command)).(queryResult)
+	return res.JobsResult, res.err
 }
 
 /*
 GetWaiting returns events which are under processing
 This is a wrapper over GetProcessed call above
 */
-func (jd *HandleT) getWaiting(params GetQueryParamsT) JobsResult {
-	return jd.GetProcessed(params)
+func (jd *HandleT) getWaiting(ctx context.Context, params GetQueryParamsT) (JobsResult, error) {
+	return jd.GetProcessed(ctx, params)
 }
 
-func (jd *HandleT) GetExecuting(params GetQueryParamsT) JobsResult {
+func (jd *HandleT) GetExecuting(ctx context.Context, params GetQueryParamsT) (JobsResult, error) {
 	if params.JobsLimit == 0 {
-		return JobsResult{}
+		return JobsResult{}, nil
 	}
 	params.StateFilters = []string{Executing.State}
 	tags := statTags{CustomValFilters: params.CustomValFilters, StateFilters: params.StateFilters, ParameterFilters: params.ParameterFilters}
 	command := func() interface{} {
-		return jd.getExecuting(params)
+		return queryResultWrapper(jd.getExecuting(ctx, params))
 	}
-	res, _ := jd.executeDbRequest(newReadDbRequest("processed", &tags, command)).(JobsResult)
-	return res
+	res, _ := jd.executeDbRequest(newReadDbRequest("processed", &tags, command)).(queryResult)
+	return res.JobsResult, res.err
 }
 
 /*
 getExecuting returns events which  in executing state
 */
-func (jd *HandleT) getExecuting(params GetQueryParamsT) JobsResult {
-	return jd.GetProcessed(params)
+func (jd *HandleT) getExecuting(ctx context.Context, params GetQueryParamsT) (JobsResult, error) {
+	return jd.GetProcessed(ctx, params)
 }
 
 /*

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -2610,7 +2610,7 @@ func (jd *HandleT) getProcessedJobsDS(ctx context.Context, ds dataSetT, getAll b
                                 WHERE jobs.job_id=job_latest_state.job_id`,
 			ds.JobTable, ds.JobStatusTable, stateQuery)
 		var err error
-		rows, err = jd.dbHandle.Query(sqlStatement)
+		rows, err = jd.dbHandle.QueryContext(ctx, sqlStatement)
 		if err != nil {
 			return JobsResult{}, err
 		}
@@ -4558,4 +4558,34 @@ func sanitizeJson(input json.RawMessage) json.RawMessage {
 		v = []byte(`{}`)
 	}
 	return v
+}
+
+func QueryJobsWithRetries(parentContext context.Context, timeout time.Duration, maxAttempts int, f func(ctx context.Context) ([]*JobT, error)) ([]*JobT, error) {
+	res, err := misc.QueryWithRetries(parentContext, timeout, maxAttempts, func(ctx context.Context) (interface{}, error) {
+		return f(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.([]*JobT), err
+}
+
+func QueryJobsResultWithRetries(parentContext context.Context, timeout time.Duration, maxAttempts int, f func(ctx context.Context) (JobsResult, error)) (JobsResult, error) {
+	res, err := misc.QueryWithRetries(parentContext, timeout, maxAttempts, func(ctx context.Context) (interface{}, error) {
+		return f(ctx)
+	})
+	if err != nil {
+		return JobsResult{}, err
+	}
+	return res.(JobsResult), err
+}
+
+func QueryWorkspacePileupWithRetries(parentContext context.Context, timeout time.Duration, maxAttempts int, f func(ctx context.Context) (map[string]map[string]int, error)) (map[string]map[string]int, error) {
+	res, err := misc.QueryWithRetries(parentContext, timeout, maxAttempts, func(ctx context.Context) (interface{}, error) {
+		return f(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(map[string]map[string]int), err
 }

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -177,7 +177,7 @@ func (*backupTestCase) insertRTData(t *testing.T, jobs []*JobT, statusList []*Jo
 			return err
 		}
 
-		return jobsDB.copyJobStatusDS(context.Background(), tx, rtDS, statusList, []string{}, nil)
+		return jobsDB.copyJobStatusDS(context.Background(), tx, rtDS, statusList, []string{})
 	})
 	require.NoError(t, err)
 
@@ -189,7 +189,7 @@ func (*backupTestCase) insertRTData(t *testing.T, jobs []*JobT, statusList []*Jo
 		if err := jobsDB.copyJobsDS(tx, rtDS2, jobs); err != nil {
 			return err
 		}
-		return jobsDB.copyJobStatusDS(context.Background(), tx, rtDS2, statusList, []string{}, nil)
+		return jobsDB.copyJobStatusDS(context.Background(), tx, rtDS2, statusList, []string{})
 	})
 	require.NoError(t, err)
 	cleanup.Cleanup(func() {
@@ -219,7 +219,7 @@ func (*backupTestCase) insertBatchRTData(t *testing.T, jobs []*JobT, statusList 
 			t.Log("error while copying jobs to ds: ", err)
 			return err
 		}
-		return jobsDB.copyJobStatusDS(context.Background(), tx, ds, statusList, []string{}, nil)
+		return jobsDB.copyJobStatusDS(context.Background(), tx, ds, statusList, []string{})
 	})
 	require.NoError(t, err)
 
@@ -233,7 +233,7 @@ func (*backupTestCase) insertBatchRTData(t *testing.T, jobs []*JobT, statusList 
 			return err
 		}
 
-		return jobsDB.copyJobStatusDS(context.Background(), tx, ds2, statusList, []string{}, nil)
+		return jobsDB.copyJobStatusDS(context.Background(), tx, ds2, statusList, []string{})
 	})
 	require.NoError(t, err)
 	cleanup.Cleanup(func() {

--- a/jobsdb/jobsdb_import.go
+++ b/jobsdb/jobsdb_import.go
@@ -42,7 +42,7 @@ func (jd *HandleT) GetLastJobIDBeforeImport() int64 {
 
 // getDsForNewEvents always returns the jobs_1 table to which all the new events are written.
 // In place migration is not supported anymore, so this should suffice.
-func (jd *HandleT) getDsForNewEvents(dsList []dataSetT) dataSetT {
+func (jd *HandleT) getDsForNewEvents() dataSetT {
 	return dataSetT{JobTable: fmt.Sprintf("%s_jobs_1", jd.tablePrefix), JobStatusTable: fmt.Sprintf("%s_job_status_1", jd.tablePrefix), Index: "1"}
 }
 

--- a/jobsdb/jobsdb_migration_checkpoints.go
+++ b/jobsdb/jobsdb_migration_checkpoints.go
@@ -216,7 +216,7 @@ func (jd *HandleT) createSetupCheckpointAndGetDs(migrationType MigrationOp) data
 		case ExportOp:
 			ds = jd.getLastDsForExport(dsList)
 		case AcceptNewEventsOp:
-			ds = jd.getDsForNewEvents(dsList)
+			ds = jd.getDsForNewEvents()
 		case ImportOp:
 			ds = jd.getDsForImport(l)
 		}

--- a/jobsdb/queued_db_request.go
+++ b/jobsdb/queued_db_request.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-func (jd *HandleT) executeDbRequest(c *dbRequest) interface{} {
+func (jd *HandleT) executeDbRequest(c *dbRequest) (interface{}) {
 	totalTimeStat := jd.getTimerStat(fmt.Sprintf("%s_total_time", c.name), c.tags)
 	totalTimeStat.Start()
 	defer totalTimeStat.End()

--- a/jobsdb/queued_db_request.go
+++ b/jobsdb/queued_db_request.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-func (jd *HandleT) executeDbRequest(c *dbRequest) (interface{}) {
+func (jd *HandleT) executeDbRequest(c *dbRequest) interface{} {
 	totalTimeStat := jd.getTimerStat(fmt.Sprintf("%s_total_time", c.name), c.tags)
 	totalTimeStat.Start()
 	defer totalTimeStat.End()

--- a/jobsdb/unionQuery.go
+++ b/jobsdb/unionQuery.go
@@ -61,7 +61,7 @@ func (*MultiTenantHandleT) getSingleWorkspaceQueryString(workspace string, jobsL
 
 // All Jobs
 
-func (mj *MultiTenantHandleT) GetAllJobs(ctx context.Context, workspaceCount map[string]int, params GetQueryParamsT, maxDSQuerySize int) ([]*JobT, error) {
+func (mj *MultiTenantHandleT) GetAllJobs(ctx context.Context, workspaceCount map[string]int, params GetQueryParamsT, maxDSQuerySize int) ([]*JobT, error) { // skipcq: CRT-P0003
 	// The order of lock is very important. The migrateDSLoop
 	// takes lock in this order so reversing this will cause
 	// deadlocks
@@ -114,7 +114,7 @@ func (mj *MultiTenantHandleT) GetAllJobs(ctx context.Context, workspaceCount map
 	return outJobs, nil
 }
 
-func (mj *MultiTenantHandleT) getUnionDS(ctx context.Context, ds dataSetT, workspaceCount map[string]int, workspacePayloadLimitMap map[string]int64, conditions QueryConditions) ([]*JobT, error) {
+func (mj *MultiTenantHandleT) getUnionDS(ctx context.Context, ds dataSetT, workspaceCount map[string]int, workspacePayloadLimitMap map[string]int64, conditions QueryConditions) ([]*JobT, error) { // skipcq: CRT-P0003
 	var jobList []*JobT
 	queryString, workspacesToQuery := mj.getUnionQuerystring(workspaceCount, workspacePayloadLimitMap, ds, conditions)
 

--- a/jobsdb/unionQuery.go
+++ b/jobsdb/unionQuery.go
@@ -17,7 +17,7 @@ type MultiTenantHandleT struct {
 }
 
 type MultiTenantJobsDB interface {
-	GetAllJobs(map[string]int, GetQueryParamsT, int) []*JobT
+	GetAllJobs(context.Context, map[string]int, GetQueryParamsT, int) ([]*JobT, error)
 
 	WithUpdateSafeTx(func(tx UpdateSafeTx) error) error
 	UpdateJobStatusInTx(ctx context.Context, tx UpdateSafeTx, statusList []*JobStatusT, customValFilters []string, parameterFilters []ParameterFilterT) error
@@ -28,7 +28,7 @@ type MultiTenantJobsDB interface {
 	GetJournalEntries(opType string) (entries []JournalEntryT)
 	JournalMarkStart(opType string, opPayload json.RawMessage) int64
 	JournalDeleteEntry(opID int64)
-	GetPileUpCounts(map[string]map[string]int)
+	GetPileUpCounts(context.Context) (map[string]map[string]int, error)
 }
 
 func (*MultiTenantHandleT) getSingleWorkspaceQueryString(workspace string, jobsLimit int, payloadLimit int64) string {
@@ -61,7 +61,7 @@ func (*MultiTenantHandleT) getSingleWorkspaceQueryString(workspace string, jobsL
 
 // All Jobs
 
-func (mj *MultiTenantHandleT) GetAllJobs(workspaceCount map[string]int, params GetQueryParamsT, maxDSQuerySize int) []*JobT {
+func (mj *MultiTenantHandleT) GetAllJobs(ctx context.Context, workspaceCount map[string]int, params GetQueryParamsT, maxDSQuerySize int) ([]*JobT, error) {
 	// The order of lock is very important. The migrateDSLoop
 	// takes lock in this order so reversing this will cause
 	// deadlocks
@@ -90,7 +90,10 @@ func (mj *MultiTenantHandleT) GetAllJobs(workspaceCount map[string]int, params G
 	}
 	start := time.Now()
 	for _, ds := range dsList {
-		jobs := mj.getUnionDS(ds, workspaceCount, workspacePayloadLimitMap, conditions)
+		jobs, err := mj.getUnionDS(ctx, ds, workspaceCount, workspacePayloadLimitMap, conditions)
+		if err != nil {
+			return nil, err
+		}
 		outJobs = append(outJobs, jobs...)
 		if len(jobs) > 0 {
 			tablesQueried++
@@ -108,15 +111,15 @@ func (mj *MultiTenantHandleT) GetAllJobs(workspaceCount map[string]int, params G
 
 	mj.tablesQueriedStat.Gauge(tablesQueried)
 
-	return outJobs
+	return outJobs, nil
 }
 
-func (mj *MultiTenantHandleT) getUnionDS(ds dataSetT, workspaceCount map[string]int, workspacePayloadLimitMap map[string]int64, conditions QueryConditions) []*JobT {
+func (mj *MultiTenantHandleT) getUnionDS(ctx context.Context, ds dataSetT, workspaceCount map[string]int, workspacePayloadLimitMap map[string]int64, conditions QueryConditions) ([]*JobT, error) {
 	var jobList []*JobT
 	queryString, workspacesToQuery := mj.getUnionQuerystring(workspaceCount, workspacePayloadLimitMap, ds, conditions)
 
 	if len(workspacesToQuery) == 0 {
-		return jobList
+		return jobList, nil
 	}
 	for _, workspace := range workspacesToQuery {
 		mj.markClearEmptyResult(ds, workspace, conditions.StateFilters, conditions.CustomValFilters, conditions.ParameterFilters,
@@ -131,9 +134,11 @@ func (mj *MultiTenantHandleT) getUnionDS(ds dataSetT, workspaceCount map[string]
 	var rows *sql.Rows
 	var err error
 
-	stmt, err := mj.dbHandle.Prepare(queryString)
+	stmt, err := mj.dbHandle.PrepareContext(ctx, queryString)
 	mj.logger.Debug(queryString)
-	mj.assertError(err)
+	if err != nil {
+		return jobList, err
+	}
 	defer func(stmt *sql.Stmt) {
 		err := stmt.Close()
 		if err != nil {
@@ -141,8 +146,10 @@ func (mj *MultiTenantHandleT) getUnionDS(ds dataSetT, workspaceCount map[string]
 		}
 	}(stmt)
 
-	rows, err = stmt.Query(getTimeNowFunc())
-	mj.assertError(err)
+	rows, err = stmt.QueryContext(ctx, getTimeNowFunc())
+	if err != nil {
+		return jobList, err
+	}
 	defer func(rows *sql.Rows) {
 		err := rows.Close()
 		if err != nil {
@@ -167,8 +174,9 @@ func (mj *MultiTenantHandleT) getUnionDS(ds dataSetT, workspaceCount map[string]
 		err = rows.Scan(&job.JobID, &job.UUID, &job.UserID, &job.Parameters, &job.CustomVal,
 			&job.EventPayload, &job.EventCount, &job.CreatedAt, &job.ExpireAt, &job.WorkspaceId, &job.PayloadSize, &_null,
 			&_nullJS, &_nullA, &_nullET, &_nullRT, &_nullEC, &_nullER, &_nullSP)
-
-		mj.assertError(err)
+		if err != nil {
+			return jobList, err
+		}
 
 		job.LastJobStatus = JobStatusT{}
 		if _nullJS.Valid {
@@ -213,7 +221,7 @@ func (mj *MultiTenantHandleT) getUnionDS(ds dataSetT, workspaceCount map[string]
 		cacheUpdateByWorkspace[job.WorkspaceId] = string(hasJobs)
 	}
 	if err = rows.Err(); err != nil {
-		mj.assertError(err)
+		return jobList, err
 	}
 
 	// do cache stuff here
@@ -223,7 +231,7 @@ func (mj *MultiTenantHandleT) getUnionDS(ds dataSetT, workspaceCount map[string]
 			cacheValue(cacheUpdate), &_willTryToSet)
 	}
 
-	return jobList
+	return jobList, err
 }
 
 func (mj *MultiTenantHandleT) getUnionQuerystring(workspaceCount map[string]int, workspacePayloadLimitMap map[string]int64, ds dataSetT, conditions QueryConditions) (string, []string) {

--- a/jobsdb/unionQueryLegacy.go
+++ b/jobsdb/unionQueryLegacy.go
@@ -6,7 +6,7 @@ type MultiTenantLegacy struct {
 	*HandleT
 }
 
-func (mj *MultiTenantLegacy) GetAllJobs(ctx context.Context, workspaceCount map[string]int, params GetQueryParamsT, _ int) ([]*JobT, error) {
+func (mj *MultiTenantLegacy) GetAllJobs(ctx context.Context, workspaceCount map[string]int, params GetQueryParamsT, _ int) ([]*JobT, error) { // skipcq: CRT-P0003
 	var list []*JobT
 	toQuery := 0
 	for workspace := range workspaceCount {

--- a/jobsdb/unionQueryLegacy.go
+++ b/jobsdb/unionQueryLegacy.go
@@ -1,10 +1,12 @@
 package jobsdb
 
+import "context"
+
 type MultiTenantLegacy struct {
 	*HandleT
 }
 
-func (mj *MultiTenantLegacy) GetAllJobs(workspaceCount map[string]int, params GetQueryParamsT, _ int) []*JobT {
+func (mj *MultiTenantLegacy) GetAllJobs(ctx context.Context, workspaceCount map[string]int, params GetQueryParamsT, _ int) ([]*JobT, error) {
 	var list []*JobT
 	toQuery := 0
 	for workspace := range workspaceCount {
@@ -12,23 +14,32 @@ func (mj *MultiTenantLegacy) GetAllJobs(workspaceCount map[string]int, params Ge
 	}
 	params.JobsLimit = toQuery
 
-	toRetry := mj.GetToRetry(params)
+	toRetry, err := mj.GetToRetry(ctx, params)
+	if err != nil {
+		return nil, err
+	}
 	list = append(list, toRetry.Jobs...)
 	if toRetry.LimitsReached {
-		return list
+		return list, nil
 	}
 	updateParams(&params, toRetry)
 
-	waiting := mj.GetWaiting(params)
+	waiting, err := mj.GetWaiting(ctx, params)
+	if err != nil {
+		return nil, err
+	}
 	list = append(list, waiting.Jobs...)
 	if waiting.LimitsReached {
-		return list
+		return list, nil
 	}
 	updateParams(&params, waiting)
 
-	unprocessed := mj.GetUnprocessed(params)
+	unprocessed, err := mj.GetUnprocessed(ctx, params)
+	if err != nil {
+		return nil, err
+	}
 	list = append(list, unprocessed.Jobs...)
-	return list
+	return list, nil
 }
 
 func updateParams(params *GetQueryParamsT, jobs JobsResult) {

--- a/jobsdb/unionQuery_test.go
+++ b/jobsdb/unionQuery_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package jobsdb
 
 import (
@@ -59,25 +57,27 @@ func TestMultiTenantHandleT_GetAllJobs(t *testing.T) {
 	workspaceCountMap := make(map[string]int)
 	workspaceCountMap[testWID] = 1
 	payloadLimit := 100 * bytesize.MB
-	unprocessedListEmpty := jobDB.GetAllJobs(workspaceCountMap, GetQueryParamsT{
+	unprocessedListEmpty, err := jobDB.GetAllJobs(context.Background(), workspaceCountMap, GetQueryParamsT{
 		CustomValFilters: []string{customVal},
 		JobsLimit:        1,
 		ParameterFilters: []ParameterFilterT{},
 		PayloadSizeLimit: payloadLimit,
 	}, 10)
-
+	require.NoError(t, err)
 	require.Equal(t, 0, len(unprocessedListEmpty))
-	err := jobDB.Store(context.Background(), []*JobT{&sampleTestJob1, &sampleTestJob2, &sampleTestJob3})
+
+	err = jobDB.Store(context.Background(), []*JobT{&sampleTestJob1, &sampleTestJob2, &sampleTestJob3})
 	require.NoError(t, err)
 
 	payloadLimit = 100 * bytesize.MB
 	workspaceCountMap[testWID] = 3
-	unprocessedList := jobDB.GetAllJobs(workspaceCountMap, GetQueryParamsT{
+	unprocessedList, err := jobDB.GetAllJobs(context.Background(), workspaceCountMap, GetQueryParamsT{
 		CustomValFilters: []string{customVal},
 		JobsLimit:        3,
 		ParameterFilters: []ParameterFilterT{},
 		PayloadSizeLimit: payloadLimit,
 	}, 10)
+	require.NoError(t, err)
 	require.Equal(t, 3, len(unprocessedList))
 
 	status1 := JobStatusT{
@@ -108,11 +108,12 @@ func TestMultiTenantHandleT_GetAllJobs(t *testing.T) {
 
 	payloadLimit = 100 * bytesize.MB
 	workspaceCountMap[testWID] = 3
-	jobs := jobDB.GetAllJobs(workspaceCountMap, GetQueryParamsT{
+	jobs, err := jobDB.GetAllJobs(context.Background(), workspaceCountMap, GetQueryParamsT{
 		CustomValFilters: []string{customVal},
 		JobsLimit:        3,
 		ParameterFilters: []ParameterFilterT{},
 		PayloadSizeLimit: payloadLimit,
 	}, 10)
+	require.NoError(t, err)
 	require.Equal(t, 3, len(jobs))
 }

--- a/jobsdb/unionQuery_test.go
+++ b/jobsdb/unionQuery_test.go
@@ -24,7 +24,8 @@ func TestMultiTenantHandleT_GetAllJobs(t *testing.T) {
 		CustomVal: true,
 	}
 
-	jobDB.Setup(ReadWrite, false, "rt", migrationMode, true, queryFilters, []prebackup.Handler{})
+	err := jobDB.Setup(ReadWrite, false, "rt", migrationMode, true, queryFilters, []prebackup.Handler{})
+	require.NoError(t, err, "expected no error while jobsDB setup")
 	defer jobDB.TearDown()
 
 	customVal := "MOCKDS"

--- a/jobsdb/unionQuery_test.go
+++ b/jobsdb/unionQuery_test.go
@@ -63,7 +63,7 @@ func TestMultiTenantHandleT_GetAllJobs(t *testing.T) {
 		ParameterFilters: []ParameterFilterT{},
 		PayloadSizeLimit: payloadLimit,
 	}, 10)
-	require.NoError(t, err)
+	require.NoError(t, err, "Error getting All jobs")
 	require.Equal(t, 0, len(unprocessedListEmpty))
 
 	err = jobDB.Store(context.Background(), []*JobT{&sampleTestJob1, &sampleTestJob2, &sampleTestJob3})
@@ -77,7 +77,7 @@ func TestMultiTenantHandleT_GetAllJobs(t *testing.T) {
 		ParameterFilters: []ParameterFilterT{},
 		PayloadSizeLimit: payloadLimit,
 	}, 10)
-	require.NoError(t, err)
+	require.NoError(t, err, "Error getting All jobs")
 	require.Equal(t, 3, len(unprocessedList))
 
 	status1 := JobStatusT{
@@ -114,6 +114,6 @@ func TestMultiTenantHandleT_GetAllJobs(t *testing.T) {
 		ParameterFilters: []ParameterFilterT{},
 		PayloadSizeLimit: payloadLimit,
 	}, 10)
-	require.NoError(t, err)
+	require.NoError(t, err, "Error getting All jobs")
 	require.Equal(t, 3, len(jobs))
 }

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -51,31 +51,33 @@ func (mr *MockJobsDBMockRecorder) DeleteExecuting() *gomock.Call {
 }
 
 // GetExecuting mocks base method.
-func (m *MockJobsDB) GetExecuting(arg0 jobsdb.GetQueryParamsT) jobsdb.JobsResult {
+func (m *MockJobsDB) GetExecuting(arg0 context.Context, arg1 jobsdb.GetQueryParamsT) (jobsdb.JobsResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetExecuting", arg0)
+	ret := m.ctrl.Call(m, "GetExecuting", arg0, arg1)
 	ret0, _ := ret[0].(jobsdb.JobsResult)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetExecuting indicates an expected call of GetExecuting.
-func (mr *MockJobsDBMockRecorder) GetExecuting(arg0 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) GetExecuting(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExecuting", reflect.TypeOf((*MockJobsDB)(nil).GetExecuting), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExecuting", reflect.TypeOf((*MockJobsDB)(nil).GetExecuting), arg0, arg1)
 }
 
 // GetImporting mocks base method.
-func (m *MockJobsDB) GetImporting(arg0 jobsdb.GetQueryParamsT) jobsdb.JobsResult {
+func (m *MockJobsDB) GetImporting(arg0 context.Context, arg1 jobsdb.GetQueryParamsT) (jobsdb.JobsResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImporting", arg0)
+	ret := m.ctrl.Call(m, "GetImporting", arg0, arg1)
 	ret0, _ := ret[0].(jobsdb.JobsResult)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetImporting indicates an expected call of GetImporting.
-func (mr *MockJobsDBMockRecorder) GetImporting(arg0 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) GetImporting(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImporting", reflect.TypeOf((*MockJobsDB)(nil).GetImporting), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImporting", reflect.TypeOf((*MockJobsDB)(nil).GetImporting), arg0, arg1)
 }
 
 // GetJournalEntries mocks base method.
@@ -93,9 +95,12 @@ func (mr *MockJobsDBMockRecorder) GetJournalEntries(arg0 interface{}) *gomock.Ca
 }
 
 // GetPileUpCounts mocks base method.
-func (m *MockJobsDB) GetPileUpCounts(arg0 map[string]map[string]int) {
+func (m *MockJobsDB) GetPileUpCounts(arg0 context.Context) (map[string]map[string]int, error) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "GetPileUpCounts", arg0)
+	ret := m.ctrl.Call(m, "GetPileUpCounts", arg0)
+	ret0, _ := ret[0].(map[string]map[string]int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetPileUpCounts indicates an expected call of GetPileUpCounts.
@@ -105,59 +110,63 @@ func (mr *MockJobsDBMockRecorder) GetPileUpCounts(arg0 interface{}) *gomock.Call
 }
 
 // GetProcessed mocks base method.
-func (m *MockJobsDB) GetProcessed(arg0 jobsdb.GetQueryParamsT) jobsdb.JobsResult {
+func (m *MockJobsDB) GetProcessed(arg0 context.Context, arg1 jobsdb.GetQueryParamsT) (jobsdb.JobsResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProcessed", arg0)
+	ret := m.ctrl.Call(m, "GetProcessed", arg0, arg1)
 	ret0, _ := ret[0].(jobsdb.JobsResult)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetProcessed indicates an expected call of GetProcessed.
-func (mr *MockJobsDBMockRecorder) GetProcessed(arg0 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) GetProcessed(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProcessed", reflect.TypeOf((*MockJobsDB)(nil).GetProcessed), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProcessed", reflect.TypeOf((*MockJobsDB)(nil).GetProcessed), arg0, arg1)
 }
 
 // GetToRetry mocks base method.
-func (m *MockJobsDB) GetToRetry(arg0 jobsdb.GetQueryParamsT) jobsdb.JobsResult {
+func (m *MockJobsDB) GetToRetry(arg0 context.Context, arg1 jobsdb.GetQueryParamsT) (jobsdb.JobsResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetToRetry", arg0)
+	ret := m.ctrl.Call(m, "GetToRetry", arg0, arg1)
 	ret0, _ := ret[0].(jobsdb.JobsResult)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetToRetry indicates an expected call of GetToRetry.
-func (mr *MockJobsDBMockRecorder) GetToRetry(arg0 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) GetToRetry(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToRetry", reflect.TypeOf((*MockJobsDB)(nil).GetToRetry), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToRetry", reflect.TypeOf((*MockJobsDB)(nil).GetToRetry), arg0, arg1)
 }
 
 // GetUnprocessed mocks base method.
-func (m *MockJobsDB) GetUnprocessed(arg0 jobsdb.GetQueryParamsT) jobsdb.JobsResult {
+func (m *MockJobsDB) GetUnprocessed(arg0 context.Context, arg1 jobsdb.GetQueryParamsT) (jobsdb.JobsResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnprocessed", arg0)
+	ret := m.ctrl.Call(m, "GetUnprocessed", arg0, arg1)
 	ret0, _ := ret[0].(jobsdb.JobsResult)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetUnprocessed indicates an expected call of GetUnprocessed.
-func (mr *MockJobsDBMockRecorder) GetUnprocessed(arg0 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) GetUnprocessed(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnprocessed", reflect.TypeOf((*MockJobsDB)(nil).GetUnprocessed), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnprocessed", reflect.TypeOf((*MockJobsDB)(nil).GetUnprocessed), arg0, arg1)
 }
 
 // GetWaiting mocks base method.
-func (m *MockJobsDB) GetWaiting(arg0 jobsdb.GetQueryParamsT) jobsdb.JobsResult {
+func (m *MockJobsDB) GetWaiting(arg0 context.Context, arg1 jobsdb.GetQueryParamsT) (jobsdb.JobsResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWaiting", arg0)
+	ret := m.ctrl.Call(m, "GetWaiting", arg0, arg1)
 	ret0, _ := ret[0].(jobsdb.JobsResult)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetWaiting indicates an expected call of GetWaiting.
-func (mr *MockJobsDBMockRecorder) GetWaiting(arg0 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) GetWaiting(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWaiting", reflect.TypeOf((*MockJobsDB)(nil).GetWaiting), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWaiting", reflect.TypeOf((*MockJobsDB)(nil).GetWaiting), arg0, arg1)
 }
 
 // Identifier mocks base method.

--- a/mocks/jobsdb/mock_unionQuery.go
+++ b/mocks/jobsdb/mock_unionQuery.go
@@ -49,17 +49,18 @@ func (mr *MockMultiTenantJobsDBMockRecorder) DeleteExecuting() *gomock.Call {
 }
 
 // GetAllJobs mocks base method.
-func (m *MockMultiTenantJobsDB) GetAllJobs(arg0 map[string]int, arg1 jobsdb.GetQueryParamsT, arg2 int) []*jobsdb.JobT {
+func (m *MockMultiTenantJobsDB) GetAllJobs(arg0 context.Context, arg1 map[string]int, arg2 jobsdb.GetQueryParamsT, arg3 int) ([]*jobsdb.JobT, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllJobs", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetAllJobs", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*jobsdb.JobT)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetAllJobs indicates an expected call of GetAllJobs.
-func (mr *MockMultiTenantJobsDBMockRecorder) GetAllJobs(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMultiTenantJobsDBMockRecorder) GetAllJobs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllJobs", reflect.TypeOf((*MockMultiTenantJobsDB)(nil).GetAllJobs), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllJobs", reflect.TypeOf((*MockMultiTenantJobsDB)(nil).GetAllJobs), arg0, arg1, arg2, arg3)
 }
 
 // GetJournalEntries mocks base method.
@@ -77,9 +78,12 @@ func (mr *MockMultiTenantJobsDBMockRecorder) GetJournalEntries(arg0 interface{})
 }
 
 // GetPileUpCounts mocks base method.
-func (m *MockMultiTenantJobsDB) GetPileUpCounts(arg0 map[string]map[string]int) {
+func (m *MockMultiTenantJobsDB) GetPileUpCounts(arg0 context.Context) (map[string]map[string]int, error) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "GetPileUpCounts", arg0)
+	ret := m.ctrl.Call(m, "GetPileUpCounts", arg0)
+	ret0, _ := ret[0].(map[string]map[string]int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetPileUpCounts indicates an expected call of GetPileUpCounts.

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -187,11 +187,12 @@ func TestProcessorManager(t *testing.T) {
 	defer tempDB.TearDown()
 
 	customVal := "GW"
-	unprocessedListEmpty := tempDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+	unprocessedListEmpty, err := tempDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 		CustomValFilters: []string{customVal},
 		JobsLimit:        1,
 		ParameterFilters: []jobsdb.ParameterFilterT{},
 	})
+	require.NoError(t, err, "GetUnprocessed failed")
 	require.Equal(t, 0, len(unprocessedListEmpty.Jobs))
 
 	jobCountPerDS := 10
@@ -238,11 +239,13 @@ func TestProcessorManager(t *testing.T) {
 		require.NoError(t, processor.Start())
 		defer processor.Stop()
 		Eventually(func() int {
-			return len(tempDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+			res, err := tempDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 				CustomValFilters: []string{customVal},
 				JobsLimit:        20,
 				ParameterFilters: []jobsdb.ParameterFilterT{},
-			}).Jobs)
+			})
+			require.NoError(t, err)
+			return len(res.Jobs)
 		}, 10*time.Minute, 100*time.Millisecond).Should(Equal(0))
 	})
 
@@ -265,18 +268,20 @@ func TestProcessorManager(t *testing.T) {
 		require.NoError(t, processor.Start())
 		err = tempDB.Store(context.Background(), genJobs(customVal, jobCountPerDS, eventsPerJob))
 		require.NoError(t, err)
-		unprocessedListEmpty = tempDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+		unprocessedListEmpty, err = tempDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{customVal},
 			JobsLimit:        20,
 			ParameterFilters: []jobsdb.ParameterFilterT{},
 		})
-
+		require.NoError(t, err, "failed to get unprocessed jobs")
 		Eventually(func() int {
-			return len(tempDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+			res, err := tempDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 				CustomValFilters: []string{customVal},
 				JobsLimit:        20,
 				ParameterFilters: []jobsdb.ParameterFilterT{},
-			}).Jobs)
+			})
+			require.NoError(t, err)
+			return len(res.Jobs)
 		}, time.Minute, 100*time.Millisecond).Should(Equal(0))
 		processor.Stop()
 	})

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2194,12 +2194,16 @@ func (proc *HandleT) getJobs() jobsdb.JobsResult {
 		eventCount = 0
 	}
 
-	unprocessedList := proc.gatewayDB.GetUnprocessed(jobsdb.GetQueryParamsT{
+	unprocessedList, err := proc.gatewayDB.GetUnprocessed(context.TODO(), jobsdb.GetQueryParamsT{
 		CustomValFilters: []string{GWCustomVal},
 		JobsLimit:        maxEventsToProcess,
 		EventsLimit:      eventCount,
 		PayloadSizeLimit: proc.payloadLimit,
 	})
+	if err != nil {
+		proc.logger.Errorf("Failed to get unprocessed jobs: %v", err)
+		panic(err)
+	}
 	totalPayloadBytes := 0
 	for _, job := range unprocessedList.Jobs {
 		totalPayloadBytes += len(job.EventPayload)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -318,7 +318,7 @@ func (proc *HandleT) Setup(
 	proc.reporting = reporting
 	config.RegisterBoolConfigVariable(types.DEFAULT_REPORTING_ENABLED, &proc.reportingEnabled, false, "Reporting.enabled")
 	config.RegisterInt64ConfigVariable(100*bytesize.MB, &proc.payloadLimit, true, 1, "Processor.payloadLimit")
-	config.RegisterDurationConfigVariable(60, &proc.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB." + "Processor." + "QueryRequestTimeout", "JobsDB." + "QueryRequestTimeout"}...)
+	config.RegisterDurationConfigVariable(60, &proc.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB.Processor.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
 	config.RegisterDurationConfigVariable(90, &proc.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.Processor.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
 	config.RegisterIntConfigVariable(3, &proc.jobdDBMaxRetries, true, 1, []string{"JobsDB.Processor.MaxRetries", "JobsDB.MaxRetries"}...)
 	proc.logger = pkgLogger

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -384,7 +384,7 @@ var _ = Describe("Processor", func() {
 			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, c.MockReportingI, c.MockMultitenantHandle, transientsource.NewEmptyService(), c.MockRsourcesService)
 
 			payloadLimit := processor.payloadLimit
-			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{CustomValFilters: gatewayCustomVal, JobsLimit: c.dbReadBatchSize, EventsLimit: c.processEventSize, PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: emptyJobsList}, nil).Times(1)
+			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), jobsdb.GetQueryParamsT{CustomValFilters: gatewayCustomVal, JobsLimit: c.dbReadBatchSize, EventsLimit: c.processEventSize, PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: emptyJobsList}, nil).Times(1)
 
 			didWork := processor.handlePendingGatewayJobs()
 			Expect(didWork).To(Equal(false))
@@ -507,7 +507,7 @@ var _ = Describe("Processor", func() {
 			mockTransformer.EXPECT().Setup().Times(1)
 
 			payloadLimit := 100 * bytesize.MB
-			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
+			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), jobsdb.GetQueryParamsT{
 				CustomValFilters: gatewayCustomVal,
 				JobsLimit:        c.dbReadBatchSize,
 				EventsLimit:      c.processEventSize,
@@ -686,7 +686,7 @@ var _ = Describe("Processor", func() {
 			mockTransformer.EXPECT().Setup().Times(1)
 
 			payloadLimit := 100 * bytesize.MB
-			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
+			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), jobsdb.GetQueryParamsT{
 				CustomValFilters: gatewayCustomVal,
 				JobsLimit:        c.dbReadBatchSize,
 				EventsLimit:      c.processEventSize,
@@ -835,7 +835,7 @@ var _ = Describe("Processor", func() {
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			mockTransformer.EXPECT().Setup().Times(1)
 
-			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), gomock.Any()).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1)
+			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), gomock.Any()).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1)
 			c.MockDedup.EXPECT().FindDuplicates(gomock.Any(), gomock.Any()).Return([]int{1}).After(callUnprocessed).Times(2)
 			c.MockDedup.EXPECT().MarkProcessed(gomock.Any()).Times(1)
 
@@ -954,7 +954,7 @@ var _ = Describe("Processor", func() {
 			mockTransformer.EXPECT().Setup().Times(1)
 
 			payloadLimit := 100 * bytesize.MB
-			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
+			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), jobsdb.GetQueryParamsT{
 				CustomValFilters: gatewayCustomVal,
 				JobsLimit:        c.dbReadBatchSize,
 				EventsLimit:      c.processEventSize,
@@ -1088,7 +1088,7 @@ var _ = Describe("Processor", func() {
 			mockTransformer.EXPECT().Setup().Times(1)
 
 			payloadLimit := 100 * bytesize.MB
-			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
+			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), jobsdb.GetQueryParamsT{
 				CustomValFilters: gatewayCustomVal,
 				JobsLimit:        c.dbReadBatchSize,
 				EventsLimit:      c.processEventSize,
@@ -1256,11 +1256,11 @@ var _ = Describe("Processor", func() {
 			processor.readLoopSleep = time.Millisecond
 
 			c.mockProcErrorsDB.EXPECT().DeleteExecuting()
-			c.mockProcErrorsDB.EXPECT().GetToRetry(context.Background(), gomock.Any()).Return(jobsdb.JobsResult{}, nil).AnyTimes()
-			c.mockProcErrorsDB.EXPECT().GetUnprocessed(context.Background(), gomock.Any()).Return(jobsdb.JobsResult{}, nil).AnyTimes()
+			c.mockProcErrorsDB.EXPECT().GetToRetry(gomock.Any(), gomock.Any()).Return(jobsdb.JobsResult{}, nil).AnyTimes()
+			c.mockProcErrorsDB.EXPECT().GetUnprocessed(gomock.Any(), gomock.Any()).Return(jobsdb.JobsResult{}, nil).AnyTimes()
 			c.mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
 
-			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), gomock.Any()).Times(0)
+			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), gomock.Any()).Times(0)
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 			defer cancel()
 

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -384,7 +384,7 @@ var _ = Describe("Processor", func() {
 			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, &clearDB, c.MockReportingI, c.MockMultitenantHandle, transientsource.NewEmptyService(), c.MockRsourcesService)
 
 			payloadLimit := processor.payloadLimit
-			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(jobsdb.GetQueryParamsT{CustomValFilters: gatewayCustomVal, JobsLimit: c.dbReadBatchSize, EventsLimit: c.processEventSize, PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: emptyJobsList}).Times(1)
+			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{CustomValFilters: gatewayCustomVal, JobsLimit: c.dbReadBatchSize, EventsLimit: c.processEventSize, PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: emptyJobsList}, nil).Times(1)
 
 			didWork := processor.handlePendingGatewayJobs()
 			Expect(didWork).To(Equal(false))
@@ -507,12 +507,12 @@ var _ = Describe("Processor", func() {
 			mockTransformer.EXPECT().Setup().Times(1)
 
 			payloadLimit := 100 * bytesize.MB
-			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(jobsdb.GetQueryParamsT{
+			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 				CustomValFilters: gatewayCustomVal,
 				JobsLimit:        c.dbReadBatchSize,
 				EventsLimit:      c.processEventSize,
 				PayloadSizeLimit: payloadLimit,
-			}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}).Times(1)
+			}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1)
 
 			transformExpectations := map[string]transformExpectation{
 				DestinationIDEnabledA: {
@@ -686,12 +686,12 @@ var _ = Describe("Processor", func() {
 			mockTransformer.EXPECT().Setup().Times(1)
 
 			payloadLimit := 100 * bytesize.MB
-			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(jobsdb.GetQueryParamsT{
+			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 				CustomValFilters: gatewayCustomVal,
 				JobsLimit:        c.dbReadBatchSize,
 				EventsLimit:      c.processEventSize,
 				PayloadSizeLimit: payloadLimit,
-			}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}).Times(1)
+			}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1)
 
 			transformExpectations := map[string]transformExpectation{
 				DestinationIDEnabledB: {
@@ -835,7 +835,7 @@ var _ = Describe("Processor", func() {
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			mockTransformer.EXPECT().Setup().Times(1)
 
-			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any()).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}).Times(1)
+			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), gomock.Any()).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1)
 			c.MockDedup.EXPECT().FindDuplicates(gomock.Any(), gomock.Any()).Return([]int{1}).After(callUnprocessed).Times(2)
 			c.MockDedup.EXPECT().MarkProcessed(gomock.Any()).Times(1)
 
@@ -954,12 +954,12 @@ var _ = Describe("Processor", func() {
 			mockTransformer.EXPECT().Setup().Times(1)
 
 			payloadLimit := 100 * bytesize.MB
-			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(jobsdb.GetQueryParamsT{
+			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 				CustomValFilters: gatewayCustomVal,
 				JobsLimit:        c.dbReadBatchSize,
 				EventsLimit:      c.processEventSize,
 				PayloadSizeLimit: payloadLimit,
-			}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}).Times(1)
+			}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1)
 			// Test transformer failure
 			mockTransformer.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
 				Return(transformer.ResponseT{
@@ -1088,12 +1088,12 @@ var _ = Describe("Processor", func() {
 			mockTransformer.EXPECT().Setup().Times(1)
 
 			payloadLimit := 100 * bytesize.MB
-			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(jobsdb.GetQueryParamsT{
+			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{
 				CustomValFilters: gatewayCustomVal,
 				JobsLimit:        c.dbReadBatchSize,
 				EventsLimit:      c.processEventSize,
 				PayloadSizeLimit: payloadLimit,
-			}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}).Times(1)
+			}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1)
 
 			// Test transformer failure
 			mockTransformer.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
@@ -1256,11 +1256,11 @@ var _ = Describe("Processor", func() {
 			processor.readLoopSleep = time.Millisecond
 
 			c.mockProcErrorsDB.EXPECT().DeleteExecuting()
-			c.mockProcErrorsDB.EXPECT().GetToRetry(gomock.Any()).Return(jobsdb.JobsResult{}).AnyTimes()
-			c.mockProcErrorsDB.EXPECT().GetUnprocessed(gomock.Any()).Return(jobsdb.JobsResult{}).AnyTimes()
+			c.mockProcErrorsDB.EXPECT().GetToRetry(context.Background(), gomock.Any()).Return(jobsdb.JobsResult{}, nil).AnyTimes()
+			c.mockProcErrorsDB.EXPECT().GetUnprocessed(context.Background(), gomock.Any()).Return(jobsdb.JobsResult{}, nil).AnyTimes()
 			c.mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
 
-			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any()).Times(0)
+			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(context.Background(), gomock.Any()).Times(0)
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 			defer cancel()
 

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -1172,12 +1172,12 @@ var _ = Describe("Processor", func() {
 			mockTransformer.EXPECT().Setup().Times(1)
 
 			payloadLimit := 100 * bytesize.MB
-			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(jobsdb.GetQueryParamsT{
+			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), jobsdb.GetQueryParamsT{
 				CustomValFilters: gatewayCustomVal,
 				JobsLimit:        c.dbReadBatchSize,
 				EventsLimit:      c.processEventSize,
 				PayloadSizeLimit: payloadLimit,
-			}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}).Times(1)
+			}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1)
 
 			// Test transformer failure
 			mockTransformer.EXPECT().Transform(gomock.Any(), gomock.Len(0), gomock.Any(), gomock.Any()).Times(0)

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -73,7 +73,7 @@ func (st *HandleT) Setup(errorDB jobsdb.JobsDB, transientSource transientsource.
 	st.statErrDBR = stats.DefaultStats.NewStat("processor.err_db_read_time", stats.TimerType)
 	st.transientSource = transientSource
 	config.RegisterIntConfigVariable(3, &st.jobdDBMaxRetries, true, 1, []string{"JobsDB.Processor.MaxRetries", "JobsDB.MaxRetries"}...)
-	config.RegisterDurationConfigVariable(60, &st.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB." + "Processor." + "QueryRequestTimeout", "JobsDB." + "QueryRequestTimeout"}...)
+	config.RegisterDurationConfigVariable(60, &st.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB.Processor.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
 	config.RegisterDurationConfigVariable(90, &st.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.Processor.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
 	st.crashRecover()
 }

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -72,9 +72,9 @@ func (st *HandleT) Setup(errorDB jobsdb.JobsDB, transientSource transientsource.
 	st.errorDB = errorDB
 	st.statErrDBR = stats.DefaultStats.NewStat("processor.err_db_read_time", stats.TimerType)
 	st.transientSource = transientSource
-	config.RegisterDurationConfigVariable(90, &st.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.Processor.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
 	config.RegisterIntConfigVariable(3, &st.jobdDBMaxRetries, true, 1, []string{"JobsDB.Processor.MaxRetries", "JobsDB.MaxRetries"}...)
 	config.RegisterDurationConfigVariable(60, &st.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB." + "Processor." + "QueryRequestTimeout", "JobsDB." + "QueryRequestTimeout"}...)
+	config.RegisterDurationConfigVariable(90, &st.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.Processor.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
 	st.crashRecover()
 }
 
@@ -257,24 +257,27 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 				JobsLimit:                     errDBReadBatchSize,
 				PayloadSizeLimit:              payloadLimit,
 			}
-			getQueryCtx, cancelCtx := context.WithTimeout(ctx, st.jobdDBQueryRequestTimeout)
-			toRetry, err := st.errorDB.GetToRetry(getQueryCtx, queryParams)
+			toRetry, err := jobsdb.QueryJobsResultWithRetries(ctx, st.jobdDBQueryRequestTimeout, st.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+				return st.errorDB.GetToRetry(ctx, queryParams)
+			})
 			if err != nil {
+				st.logger.Errorf("Error occurred while reading proc error jobs. Err: %v", err)
 				panic(err)
 			}
-			cancelCtx()
+
 			combinedList := toRetry.Jobs
 			if !toRetry.LimitsReached {
 				queryParams.JobsLimit -= len(toRetry.Jobs)
 				if queryParams.PayloadSizeLimit > 0 {
 					queryParams.PayloadSizeLimit -= toRetry.PayloadSize
 				}
-				getUnprocessedQueryCtx, cancelCtx := context.WithTimeout(ctx, st.jobdDBQueryRequestTimeout)
-				unprocessed, err := st.errorDB.GetUnprocessed(getUnprocessedQueryCtx, queryParams)
+				unprocessed, err := jobsdb.QueryJobsResultWithRetries(ctx, st.jobdDBQueryRequestTimeout, st.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+					return st.errorDB.GetUnprocessed(ctx, queryParams)
+				})
 				if err != nil {
+					st.logger.Errorf("Error occurred while reading proc error jobs. Err: %v", err)
 					panic(err)
 				}
-				cancelCtx()
 				combinedList = append(combinedList, unprocessed.Jobs...)
 			}
 

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1640,9 +1640,6 @@ func (worker *workerT) workerProcess() {
 				}
 				brtQueryStat.End()
 				brt.logger.Debugf("BRT: %s: DB Read Complete for parameter Filters: %v retryList: %v, unprocessedList: %v, total: %v", brt.destType, parameterFilters, len(toRetry.Jobs), len(combinedList)-len(toRetry.Jobs), len(combinedList))
-
-				brtQueryStat.End()
-				brt.logger.Debugf("BRT: %s: DB Read Complete for parameter Filters: %v retryList: %v, unprocessedList: %v, total: %v", brt.destType, parameterFilters, len(toRetry.Jobs), len(combinedList)-len(toRetry.Jobs), len(combinedList))
 			}
 		} else {
 			for _, job := range batchDestData.jobs {
@@ -2315,7 +2312,7 @@ func (brt *HandleT) Setup(backendConfig backendconfig.BackendConfig, jobsDB, err
 	config.RegisterDurationConfigVariable(30, &brt.asyncUploadTimeout, true, time.Minute, []string{"BatchRouter." + brt.destType + "." + "asyncUploadTimeout", "BatchRouter." + "asyncUploadTimeout"}...)
 	config.RegisterInt64ConfigVariable(1*bytesize.GB, &brt.payloadLimit, true, 1, []string{"BatchRouter." + brt.destType + "." + "PayloadLimit", "BatchRouter.PayloadLimit"}...)
 	config.RegisterIntConfigVariable(3, &brt.jobdDBMaxRetries, true, 1, []string{"JobsDB.BatchRouter.MaxRetries", "JobsDB.MaxRetries"}...)
-	config.RegisterDurationConfigVariable(60, &brt.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB." + "BatchRouter." + "QueryRequestTimeout", "JobsDB." + "QueryRequestTimeout"}...)
+	config.RegisterDurationConfigVariable(60, &brt.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB.BatchRouter.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
 	config.RegisterDurationConfigVariable(90, &brt.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.BatchRouter.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
 	brt.uploadIntervalMap = map[string]time.Duration{}
 

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -235,8 +235,8 @@ var _ = Describe("BatchRouter", func() {
 			}
 
 			payloadLimit := batchrouter.payloadLimit
-			callRetry := c.mockBatchRouterJobsDB.EXPECT().GetToRetry(context.Background(), jobsdb.GetQueryParamsT{CustomValFilters: []string{CustomVal["S3"]}, JobsLimit: c.jobQueryBatchSize, PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: toRetryJobsList}, nil).Times(1)
-			c.mockBatchRouterJobsDB.EXPECT().GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{CustomValFilters: []string{CustomVal["S3"]}, JobsLimit: c.jobQueryBatchSize - len(toRetryJobsList), PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1).After(callRetry)
+			callRetry := c.mockBatchRouterJobsDB.EXPECT().GetToRetry(gomock.Any(), jobsdb.GetQueryParamsT{CustomValFilters: []string{CustomVal["S3"]}, JobsLimit: c.jobQueryBatchSize, PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: toRetryJobsList}, nil).Times(1)
+			c.mockBatchRouterJobsDB.EXPECT().GetUnprocessed(gomock.Any(), jobsdb.GetQueryParamsT{CustomValFilters: []string{CustomVal["S3"]}, JobsLimit: c.jobQueryBatchSize - len(toRetryJobsList), PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1).After(callRetry)
 
 			c.mockBatchRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{CustomVal["S3"]}, gomock.Any()).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -235,8 +235,8 @@ var _ = Describe("BatchRouter", func() {
 			}
 
 			payloadLimit := batchrouter.payloadLimit
-			callRetry := c.mockBatchRouterJobsDB.EXPECT().GetToRetry(jobsdb.GetQueryParamsT{CustomValFilters: []string{CustomVal["S3"]}, JobsLimit: c.jobQueryBatchSize, PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: toRetryJobsList}).Times(1)
-			c.mockBatchRouterJobsDB.EXPECT().GetUnprocessed(jobsdb.GetQueryParamsT{CustomValFilters: []string{CustomVal["S3"]}, JobsLimit: c.jobQueryBatchSize - len(toRetryJobsList), PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}).Times(1).After(callRetry)
+			callRetry := c.mockBatchRouterJobsDB.EXPECT().GetToRetry(context.Background(), jobsdb.GetQueryParamsT{CustomValFilters: []string{CustomVal["S3"]}, JobsLimit: c.jobQueryBatchSize, PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: toRetryJobsList}, nil).Times(1)
+			c.mockBatchRouterJobsDB.EXPECT().GetUnprocessed(context.Background(), jobsdb.GetQueryParamsT{CustomValFilters: []string{CustomVal["S3"]}, JobsLimit: c.jobQueryBatchSize - len(toRetryJobsList), PayloadSizeLimit: payloadLimit}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1).After(callRetry)
 
 			c.mockBatchRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{CustomVal["S3"]}, gomock.Any()).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {

--- a/router/router.go
+++ b/router/router.go
@@ -96,6 +96,8 @@ type HandleT struct {
 	netClientTimeout                       time.Duration
 	backendProxyTimeout                    time.Duration
 	jobdDBQueryRequestTimeout              time.Duration
+	jobsDBCommandTimeout                   time.Duration
+	jobdDBMaxRetries                       int
 	enableBatching                         bool
 	transformer                            transformer.Transformer
 	configSubscriberLock                   sync.RWMutex
@@ -117,8 +119,6 @@ type HandleT struct {
 	noOfJobsToBatchInAWorker               int
 	retryTimeWindow                        time.Duration
 	routerTimeout                          time.Duration
-	jobsDBCommandTimeout                   time.Duration
-	jobdDBMaxRetries                       int
 	destinationResponseHandler             ResponseHandlerI
 	saveDestinationResponse                bool
 	Reporting                              reporter
@@ -1826,22 +1826,22 @@ func (rt *HandleT) readAndProcess() int {
 	}
 	rt.timeGained = 0
 	rt.logger.Debugf("[%v Router] :: pickupMap: %+v", rt.destName, pickupMap)
-	ctx, cancelCtx := context.WithTimeout(context.Background(), rt.jobdDBQueryRequestTimeout)
-	combinedList, err := rt.jobsDB.GetAllJobs(
-		ctx,
-		pickupMap,
-		jobsdb.GetQueryParamsT{
-			CustomValFilters: []string{rt.destName},
-			PayloadSizeLimit: rt.payloadLimit,
-			JobsLimit:        totalPickupCount,
-		},
-		rt.maxDSQuerySize,
-	)
+	combinedList, err := jobsdb.QueryJobsWithRetries(context.Background(), rt.jobdDBQueryRequestTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) ([]*jobsdb.JobT, error) {
+		return rt.jobsDB.GetAllJobs(
+			ctx,
+			pickupMap,
+			jobsdb.GetQueryParamsT{
+				CustomValFilters: []string{rt.destName},
+				PayloadSizeLimit: rt.payloadLimit,
+				JobsLimit:        totalPickupCount,
+			},
+			rt.maxDSQuerySize,
+		)
+	})
 	if err != nil {
 		rt.logger.Errorf("[%v Router] :: Error getting jobs from DB: %v", rt.destName, err)
 		panic(err)
 	}
-	cancelCtx()
 
 	if len(combinedList) == 0 {
 		rt.logger.Debugf("RT: DB Read Complete. No RT Jobs to process for destination: %s", rt.destName)
@@ -2108,6 +2108,8 @@ func (rt *HandleT) Setup(backendConfig backendconfig.BackendConfig, jobsDB jobsd
 	config.RegisterDurationConfigVariable(10, &rt.netClientTimeout, false, time.Second, netClientTimeoutKeys...)
 	config.RegisterDurationConfigVariable(30, &rt.backendProxyTimeout, false, time.Second, "HttpClient.backendProxy.timeout")
 	config.RegisterDurationConfigVariable(60, &rt.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB." + "Router." + "QueryRequestTimeout", "JobsDB." + "QueryRequestTimeout"}...)
+	config.RegisterDurationConfigVariable(90, &rt.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.Router.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
+	config.RegisterIntConfigVariable(3, &rt.jobdDBMaxRetries, true, 1, []string{"JobsDB." + "Router." + "MaxRetries", "JobsDB." + "MaxRetries"}...)
 	rt.crashRecover()
 	rt.responseQ = make(chan jobResponseT, jobQueryBatchSize)
 	rt.toClearFailJobIDMap = make(map[int][]string)
@@ -2156,8 +2158,6 @@ func (rt *HandleT) Setup(backendConfig backendconfig.BackendConfig, jobsDB jobsd
 	config.RegisterBoolConfigVariable(false, &rt.savePayloadOnError, true, savePayloadOnErrorKeys...)
 	config.RegisterBoolConfigVariable(false, &rt.transformerProxy, true, transformerProxyKeys...)
 	config.RegisterBoolConfigVariable(false, &rt.saveDestinationResponseOverride, true, saveDestinationResponseOverrideKeys...)
-	config.RegisterDurationConfigVariable(90, &rt.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.Router.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
-	config.RegisterIntConfigVariable(3, &rt.jobdDBMaxRetries, true, 1, []string{"JobsDB.Router.MaxRetries", "JobsDB.MaxRetries"}...)
 	rt.allowAbortedUserJobsCountForProcessing = getRouterConfigInt("allowAbortedUserJobsCountForProcessing", destName, 1)
 
 	rt.batchInputCountStat = stats.NewTaggedStat("router_batch_num_input_jobs", stats.CountType, stats.Tags{

--- a/router/router.go
+++ b/router/router.go
@@ -2107,7 +2107,7 @@ func (rt *HandleT) Setup(backendConfig backendconfig.BackendConfig, jobsDB jobsd
 	netClientTimeoutKeys := []string{"Router." + rt.destName + "." + "httpTimeout", "Router." + rt.destName + "." + "httpTimeoutInS", "Router." + "httpTimeout", "Router." + "httpTimeoutInS"}
 	config.RegisterDurationConfigVariable(10, &rt.netClientTimeout, false, time.Second, netClientTimeoutKeys...)
 	config.RegisterDurationConfigVariable(30, &rt.backendProxyTimeout, false, time.Second, "HttpClient.backendProxy.timeout")
-	config.RegisterDurationConfigVariable(60, &rt.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB." + "Router." + "QueryRequestTimeout", "JobsDB." + "QueryRequestTimeout"}...)
+	config.RegisterDurationConfigVariable(60, &rt.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB.Router.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
 	config.RegisterDurationConfigVariable(90, &rt.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.Router.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
 	config.RegisterIntConfigVariable(3, &rt.jobdDBMaxRetries, true, 1, []string{"JobsDB." + "Router." + "MaxRetries", "JobsDB." + "MaxRetries"}...)
 	rt.crashRecover()

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -247,8 +247,8 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(workspaceCountOut, map[string]float64{}).Times(1)
 
 			payloadLimit := router.payloadLimit
-			callGetAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(workspaceCount,
-				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: workspaceCount[workspaceID]}, 10).Times(1).Return(allJobs).After(callGetRouterPickupJobs)
+			callGetAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount,
+				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: workspaceCount[workspaceID]}, 10).Times(1).Return(allJobs, nil).After(callGetRouterPickupJobs)
 
 			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
@@ -321,9 +321,9 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(workspaceCountOut, map[string]float64{}).Times(1)
 
 			payloadLimit := router.payloadLimit
-			callGetAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(workspaceCount, jobsdb.GetQueryParamsT{
+			callGetAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount, jobsdb.GetQueryParamsT{
 				CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: workspaceCount[workspaceID],
-			}, 10).Times(1).Return(unprocessedJobsList).After(callGetRouterPickupJobs)
+			}, 10).Times(1).Return(unprocessedJobsList, nil).After(callGetRouterPickupJobs)
 
 			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
@@ -407,9 +407,9 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(workspaceCountOut, map[string]float64{}).Times(1)
 
 			payloadLimit := router.payloadLimit
-			c.mockRouterJobsDB.EXPECT().GetAllJobs(workspaceCount, jobsdb.GetQueryParamsT{
+			c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount, jobsdb.GetQueryParamsT{
 				CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: workspaceCount[workspaceID],
-			}, 10).Times(1).Return(unprocessedJobsList).After(callGetRouterPickupJobs)
+			}, 10).Times(1).Return(unprocessedJobsList, nil).After(callGetRouterPickupJobs)
 
 			mockMultitenantHandle.EXPECT().CalculateSuccessFailureCounts(gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any()).Times(1)
@@ -656,9 +656,9 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(workspaceCountOut, map[string]float64{}).Times(1)
 
 			payloadLimit := router.payloadLimit
-			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(workspaceCount, jobsdb.GetQueryParamsT{
+			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount, jobsdb.GetQueryParamsT{
 				CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(jobsList),
-			}, 10).Times(1).Return(jobsList).After(callGetRouterPickupJobs)
+			}, 10).Times(1).Return(jobsList, nil).After(callGetRouterPickupJobs)
 
 			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
@@ -795,9 +795,9 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(workspaceCountOut, map[string]float64{})
 
 			payloadLimit := router.payloadLimit
-			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(workspaceCount,
-				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Return(toRetryJobsList).Times(
-				1).Return(allJobs).After(callGetRouterPickupJobs)
+			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount,
+				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Return(toRetryJobsList, nil).Times(
+				1).Return(allJobs, nil).After(callGetRouterPickupJobs)
 
 			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
@@ -992,8 +992,8 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(workspaceCountOut, map[string]float64{}).Times(1)
 
 			payloadLimit := router.payloadLimit
-			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(workspaceCount,
-				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Times(1).Return(allJobs).After(
+			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount,
+				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Times(1).Return(allJobs, nil).After(
 				callGetRouterPickupJobs)
 
 			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
@@ -1182,8 +1182,8 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(workspaceCountOut, map[string]float64{}).Times(1)
 
 			payloadLimit := router.payloadLimit
-			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(workspaceCount,
-				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Times(1).Return(allJobs).After(callGetRouterPickupJobs)
+			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount,
+				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Times(1).Return(allJobs, nil).After(callGetRouterPickupJobs)
 
 			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -544,8 +544,8 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(workspaceCountOut, map[string]float64{}).Times(1)
 
 			payloadLimit := router.payloadLimit
-			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(workspaceCount,
-				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Times(1).Return(allJobs).After(
+			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(gomock.Any(), workspaceCount,
+				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Times(1).Return(allJobs, nil).After(
 				callGetRouterPickupJobs)
 
 			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -247,7 +247,7 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(workspaceCountOut, map[string]float64{}).Times(1)
 
 			payloadLimit := router.payloadLimit
-			callGetAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount,
+			callGetAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(gomock.Any(), workspaceCount,
 				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: workspaceCount[workspaceID]}, 10).Times(1).Return(allJobs, nil).After(callGetRouterPickupJobs)
 
 			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
@@ -321,7 +321,7 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(workspaceCountOut, map[string]float64{}).Times(1)
 
 			payloadLimit := router.payloadLimit
-			callGetAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount, jobsdb.GetQueryParamsT{
+			callGetAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(gomock.Any(), workspaceCount, jobsdb.GetQueryParamsT{
 				CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: workspaceCount[workspaceID],
 			}, 10).Times(1).Return(unprocessedJobsList, nil).After(callGetRouterPickupJobs)
 
@@ -407,7 +407,7 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(workspaceCountOut, map[string]float64{}).Times(1)
 
 			payloadLimit := router.payloadLimit
-			c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount, jobsdb.GetQueryParamsT{
+			c.mockRouterJobsDB.EXPECT().GetAllJobs(gomock.Any(), workspaceCount, jobsdb.GetQueryParamsT{
 				CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: workspaceCount[workspaceID],
 			}, 10).Times(1).Return(unprocessedJobsList, nil).After(callGetRouterPickupJobs)
 
@@ -656,7 +656,7 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(workspaceCountOut, map[string]float64{}).Times(1)
 
 			payloadLimit := router.payloadLimit
-			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount, jobsdb.GetQueryParamsT{
+			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(gomock.Any(), workspaceCount, jobsdb.GetQueryParamsT{
 				CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(jobsList),
 			}, 10).Times(1).Return(jobsList, nil).After(callGetRouterPickupJobs)
 
@@ -795,7 +795,7 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(workspaceCountOut, map[string]float64{})
 
 			payloadLimit := router.payloadLimit
-			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount,
+			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(gomock.Any(), workspaceCount,
 				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Return(toRetryJobsList, nil).Times(
 				1).Return(allJobs, nil).After(callGetRouterPickupJobs)
 
@@ -992,7 +992,7 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(workspaceCountOut, map[string]float64{}).Times(1)
 
 			payloadLimit := router.payloadLimit
-			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount,
+			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(gomock.Any(), workspaceCount,
 				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Times(1).Return(allJobs, nil).After(
 				callGetRouterPickupJobs)
 
@@ -1182,7 +1182,7 @@ var _ = Describe("Router", func() {
 			callGetRouterPickupJobs := mockMultitenantHandle.EXPECT().GetRouterPickupJobs(customVal["GA"], gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(workspaceCountOut, map[string]float64{}).Times(1)
 
 			payloadLimit := router.payloadLimit
-			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(context.Background(), workspaceCount,
+			callAllJobs := c.mockRouterJobsDB.EXPECT().GetAllJobs(gomock.Any(), workspaceCount,
 				jobsdb.GetQueryParamsT{CustomValFilters: []string{customVal["GA"]}, PayloadSizeLimit: payloadLimit, JobsLimit: len(allJobs)}, 10).Times(1).Return(allJobs, nil).After(callGetRouterPickupJobs)
 
 			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).

--- a/services/multitenant/tenantstats.go
+++ b/services/multitenant/tenantstats.go
@@ -56,8 +56,6 @@ func (*Stats) Stop() {
 }
 
 func (t *Stats) Start() error {
-	config.RegisterDurationConfigVariable(60, &t.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB." + "Multitenant." + "QueryRequestTimeout", "JobsDB." + "QueryRequestTimeout"}...)
-	config.RegisterIntConfigVariable(3, &t.jobdDBMaxRetries, true, 1, []string{"JobsDB." + "Router." + "MaxRetries", "JobsDB." + "MaxRetries"}...)
 	t.routerInputRates = make(map[string]map[string]map[string]metric.MovingAverage)
 	t.lastDrainedTimestamps = make(map[string]map[string]time.Time)
 	t.failureRate = make(map[string]map[string]metric.MovingAverage)
@@ -98,6 +96,9 @@ func Init() {
 
 func NewStats(routerDBs map[string]jobsdb.MultiTenantJobsDB) *Stats {
 	t := Stats{}
+	config.RegisterDurationConfigVariable(60, &t.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB.Multitenant.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
+	config.RegisterIntConfigVariable(3, &t.jobdDBMaxRetries, true, 1, []string{"JobsDB." + "Router." + "MaxRetries", "JobsDB." + "MaxRetries"}...)
+
 	t.routerInputRates = make(map[string]map[string]map[string]metric.MovingAverage)
 	t.lastDrainedTimestamps = make(map[string]map[string]time.Time)
 	t.failureRate = make(map[string]map[string]metric.MovingAverage)

--- a/services/multitenant/tenantstats_test.go
+++ b/services/multitenant/tenantstats_test.go
@@ -1,6 +1,7 @@
 package multitenant
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -53,7 +54,7 @@ var _ = Describe("tenantStats", func() {
 				mockCtrl := gomock.NewController(GinkgoT())
 				mockRouterJobsDB := mocksJobsDB.NewMockMultiTenantJobsDB(mockCtrl)
 				// crash recovery check
-				mockRouterJobsDB.EXPECT().GetPileUpCounts(gomock.Any()).Times(1)
+				mockRouterJobsDB.EXPECT().GetPileUpCounts(context.Background()).Times(1)
 				tenantStats = NewStats(map[string]jobsdb.MultiTenantJobsDB{"rt": mockRouterJobsDB})
 			})
 

--- a/services/multitenant/tenantstats_test.go
+++ b/services/multitenant/tenantstats_test.go
@@ -1,7 +1,6 @@
 package multitenant
 
 import (
-	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -54,7 +53,7 @@ var _ = Describe("tenantStats", func() {
 				mockCtrl := gomock.NewController(GinkgoT())
 				mockRouterJobsDB := mocksJobsDB.NewMockMultiTenantJobsDB(mockCtrl)
 				// crash recovery check
-				mockRouterJobsDB.EXPECT().GetPileUpCounts(context.Background()).Times(1)
+				mockRouterJobsDB.EXPECT().GetPileUpCounts(gomock.Any()).Times(1)
 				tenantStats = NewStats(map[string]jobsdb.MultiTenantJobsDB{"rt": mockRouterJobsDB})
 			})
 

--- a/utils/misc/retry.go
+++ b/utils/misc/retry.go
@@ -50,7 +50,7 @@ func QueryWithRetries(parentContext context.Context, timeout time.Duration, maxA
 			return res, nil
 		}
 		// only retry if the child context's deadline was exceeded
-		if !errors.Is(err, context.DeadlineExceeded) || parentContext.Err() != nil {
+		if !errors.Is(ctx.Err(), context.DeadlineExceeded) || parentContext.Err() != nil {
 			return res, err
 		}
 		attempt++

--- a/utils/misc/retry.go
+++ b/utils/misc/retry.go
@@ -31,3 +31,29 @@ func RetryWith(parentContext context.Context, timeout time.Duration, maxAttempts
 	}
 	return err
 }
+
+func QueryWithRetries(parentContext context.Context, timeout time.Duration, maxAttempts int, f func(ctx context.Context) (interface{}, error)) (interface{}, error) {
+	if parentContext.Err() != nil {
+		return nil, parentContext.Err()
+	}
+	attempt := 1
+	if maxAttempts < 1 {
+		return nil, fmt.Errorf("invalid parameter maxAttempts: %d", maxAttempts)
+	}
+	var err error
+	var res interface{}
+	for attempt <= maxAttempts {
+		ctx, cancel := context.WithTimeout(parentContext, timeout)
+		defer cancel()
+		res, err = f(ctx)
+		if err == nil {
+			return res, nil
+		}
+		// only retry if the child context's deadline was exceeded
+		if !errors.Is(err, context.DeadlineExceeded) || parentContext.Err() != nil {
+			return res, err
+		}
+		attempt++
+	}
+	return res, err
+}

--- a/utils/misc/retry_test.go
+++ b/utils/misc/retry_test.go
@@ -72,3 +72,61 @@ func (o *operation) do(ctx context.Context) error {
 		return nil
 	}
 }
+
+func TestQueryWithRetries(t *testing.T) {
+	t.Run("ideal case: no timeout", func(t *testing.T) {
+		var op operation
+		_, err := misc.QueryWithRetries(context.Background(), time.Millisecond, 3, op.doAndReturn)
+		require.NoError(t, err)
+	})
+
+	t.Run("error returned after maximum retry i.e. 3", func(t *testing.T) {
+		op := operation{
+			timeout: time.Second,
+		}
+		_, err := misc.QueryWithRetries(context.Background(), time.Millisecond, 3, op.doAndReturn)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, context.DeadlineExceeded))
+		require.Equal(t, 3, op.attempts)
+	})
+
+	t.Run("parent context canceled", func(t *testing.T) {
+		op := operation{
+			timeout: time.Second,
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := misc.QueryWithRetries(ctx, time.Millisecond, 5, op.doAndReturn)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, context.Canceled))
+		require.Equal(t, 0, op.attempts)
+	})
+
+	t.Run("1st attempt failed & 2nd attempt succeeded", func(t *testing.T) {
+		op := operation{
+			timeout:             time.Second,
+			timeoutAfterAttempt: 1,
+		}
+		_, err := misc.QueryWithRetries(context.Background(), time.Millisecond, 3, op.doAndReturn)
+		require.Equal(t, 2, op.attempts)
+		require.NoError(t, err)
+	})
+}
+
+func (o *operation) doAndReturn(ctx context.Context) (interface{}, error) {
+	o.attempts++
+	var err error
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if o.timeoutAfterAttempt > 0 && o.attempts > o.timeoutAfterAttempt {
+		return nil, err
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(o.timeout):
+		return nil, err
+	}
+}


### PR DESCRIPTION
## Description

Currently, when any `query` method is called in jobsDB, we don't make the query with timeout (using context) & retry. And, this sometimes leads to rudder-sever getting stuck for long time (maybe because of deadlock or any other reason). Also, rudder-server panics immediately, if jobsDB server goes down.
 In this PR, we attempt to introduce `timeout` & `retry` for all `query` methods in jobsDB.

## Notion Ticket

https://www.notion.so/rudderstacks/Introduce-timeouts-and-retries-during-jobsdb-Get-Processed-Unprocessed-6c7b3c43762b46feb4642f8fde071564