### PR TITLE
fix(core): filter failed events in processor based on response codes

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -951,7 +951,7 @@ func (proc *HandleT) getFailedEventJobs(response transformer.ResponseT, commonMe
 	failedCountMap := make(map[string]int64)
 	var failedEventsToStore []*jobsdb.JobT
 	for _, failedEvent := range response.FailedEvents {
-		if failedEvent.StatusCode == transformer.DROP_STATUS_CODE {
+		if failedEvent.StatusCode == transformer.DropStatusCode {
 			continue
 		}
 		var messages []types.SingularEventT

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1765,7 +1765,18 @@ func (proc *HandleT) transformSrcDest(
 				inCountMap[key] = 0
 			}
 			if _, ok := inCountMetadataMap[key]; !ok {
-				inCountMetadataMap[key] = MetricMetadata{sourceID: event.Metadata.SourceID, destinationID: event.Metadata.DestinationID, sourceBatchID: event.Metadata.SourceBatchID, sourceTaskID: event.Metadata.SourceTaskID, sourceTaskRunID: event.Metadata.SourceTaskRunID, sourceJobID: event.Metadata.SourceJobID, sourceJobRunID: event.Metadata.SourceJobRunID, sourceDefinitionID: event.Metadata.SourceDefinitionID, destinationDefinitionID: event.Metadata.DestinationDefinitionID, sourceCategory: event.Metadata.SourceCategory}
+				inCountMetadataMap[key] = MetricMetadata{
+					sourceID:                event.Metadata.SourceID,
+					destinationID:           event.Metadata.DestinationID,
+					sourceBatchID:           event.Metadata.SourceBatchID,
+					sourceTaskID:            event.Metadata.SourceTaskID,
+					sourceTaskRunID:         event.Metadata.SourceTaskRunID,
+					sourceJobID:             event.Metadata.SourceJobID,
+					sourceJobRunID:          event.Metadata.SourceJobRunID,
+					sourceDefinitionID:      event.Metadata.SourceDefinitionID,
+					destinationDefinitionID: event.Metadata.DestinationDefinitionID,
+					sourceCategory:          event.Metadata.SourceCategory,
+				}
 			}
 			inCountMap[key] = inCountMap[key] + 1
 		}
@@ -1880,7 +1891,14 @@ func (proc *HandleT) transformSrcDest(
 			}
 		}
 
-		diffMetrics := getDiffMetrics(inPU, types.EVENT_FILTER, inCountMetadataMap, inCountMap, successCountMap, failedCountMap)
+		diffMetrics := getDiffMetrics(
+			inPU,
+			types.EVENT_FILTER,
+			inCountMetadataMap,
+			inCountMap,
+			successCountMap,
+			failedCountMap,
+		)
 		reportMetrics = append(reportMetrics, successMetrics...)
 		reportMetrics = append(reportMetrics, failedMetrics...)
 		reportMetrics = append(reportMetrics, diffMetrics...)
@@ -1972,7 +1990,14 @@ func (proc *HandleT) transformSrcDest(
 					successMetrics = append(successMetrics, m)
 				}
 
-				diffMetrics := getDiffMetrics(types.EVENT_FILTER, types.DEST_TRANSFORMER, inCountMetadataMap, inCountMap, successCountMap, failedCountMap)
+				diffMetrics := getDiffMetrics(
+					types.EVENT_FILTER,
+					types.DEST_TRANSFORMER,
+					inCountMetadataMap,
+					inCountMap,
+					successCountMap,
+					failedCountMap,
+				)
 
 				reportMetrics = append(reportMetrics, failedMetrics...)
 				reportMetrics = append(reportMetrics, successMetrics...)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -951,6 +951,9 @@ func (proc *HandleT) getFailedEventJobs(response transformer.ResponseT, commonMe
 	failedCountMap := make(map[string]int64)
 	var failedEventsToStore []*jobsdb.JobT
 	for _, failedEvent := range response.FailedEvents {
+		if failedEvent.StatusCode == transformer.DROP_STATUS_CODE {
+			continue
+		}
 		var messages []types.SingularEventT
 		if len(failedEvent.Metadata.MessageIDs) > 0 {
 			messageIds := failedEvent.Metadata.MessageIDs
@@ -981,10 +984,6 @@ func (proc *HandleT) getFailedEventJobs(response transformer.ResponseT, commonMe
 			"[Processor: getFailedEventJobs] Error [%d] for source %q and destination %q: %s",
 			failedEvent.StatusCode, commonMetaData.SourceID, commonMetaData.DestinationID, failedEvent.Error,
 		)
-
-		if failedEvent.StatusCode == transformer.DROP_STATUS_CODE {
-			continue
-		}
 
 		id := misc.FastUUID()
 		params := map[string]interface{}{

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -982,7 +982,7 @@ func (proc *HandleT) getFailedEventJobs(response transformer.ResponseT, commonMe
 			failedEvent.StatusCode, commonMetaData.SourceID, commonMetaData.DestinationID, failedEvent.Error,
 		)
 
-		if failedEvent.StatusCode == 722 {
+		if failedEvent.StatusCode == transformer.DROP_STATUS_CODE {
 			continue
 		}
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -982,6 +982,10 @@ func (proc *HandleT) getFailedEventJobs(response transformer.ResponseT, commonMe
 			failedEvent.StatusCode, commonMetaData.SourceID, commonMetaData.DestinationID, failedEvent.Error,
 		)
 
+		if failedEvent.StatusCode == 722 {
+			continue
+		}
+
 		id := misc.FastUUID()
 		params := map[string]interface{}{
 			"source_id":          commonMetaData.SourceID,

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -29,6 +29,7 @@ const (
 	EventFilterStage            = "event_filter"
 	DestTransformerStage        = "dest_transformer"
 	TrackingPlanValidationStage = "trackingPlan_validation"
+	DROP_STATUS_CODE            = 722
 )
 
 var jsonfast = jsoniter.ConfigCompatibleWithStandardLibrary

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -29,7 +29,7 @@ const (
 	EventFilterStage            = "event_filter"
 	DestTransformerStage        = "dest_transformer"
 	TrackingPlanValidationStage = "trackingPlan_validation"
-	DROP_STATUS_CODE            = 722
+	DropStatusCode              = 722
 )
 
 var jsonfast = jsoniter.ConfigCompatibleWithStandardLibrary

--- a/router/router.go
+++ b/router/router.go
@@ -1599,6 +1599,7 @@ func (rt *HandleT) commitStatusList(responseList *[]jobResponseT) {
 			rt.MultitenantI.CalculateSuccessFailureCounts(workspaceID, rt.destName, false, true)
 		case utilTypes.DiffStatus:
 			sd.Count--
+			completedJobsList = append(completedJobsList, resp.JobT)
 			routerWorkspaceJobStatusCount[workspaceID] += 1
 		}
 

--- a/router/router.go
+++ b/router/router.go
@@ -1521,15 +1521,17 @@ func (rt *HandleT) commitStatusList(responseList *[]jobResponseT) {
 		workspaceID := resp.status.WorkspaceId
 		eventName := gjson.GetBytes(resp.JobT.Parameters, "event_name").String()
 		eventType := gjson.GetBytes(resp.JobT.Parameters, "event_type").String()
-		key := fmt.Sprintf(
-			"%s:%s:%s:%s:%s:%s:%s",
-			parameters.SourceID,
-			parameters.DestinationID,
-			parameters.SourceBatchID,
-			resp.status.JobState,
-			resp.status.ErrorCode,
-			eventName,
-			eventType,
+		key := strings.Join(
+			[]string{
+				parameters.SourceID,
+				parameters.DestinationID,
+				parameters.SourceBatchID,
+				resp.status.JobState,
+				resp.status.ErrorCode,
+				eventName,
+				eventType,
+			},
+			":",
 		)
 		_, ok := connectionDetailsMap[key]
 		if !ok {

--- a/router/router.go
+++ b/router/router.go
@@ -1123,6 +1123,7 @@ func (worker *workerT) postStatusOnResponseQ(respStatusCode int, respBody string
 		switch respStatusCode {
 		case transformer.DropStatusCode:
 			status.JobState = jobsdb.Aborted.State
+			addToAbortMap = false
 		case types.RouterTimedOutStatusCode, types.RouterUnMarshalErrorCode:
 			addToFailedMap = false
 			addToAbortMap = false

--- a/router/router.go
+++ b/router/router.go
@@ -1236,9 +1236,9 @@ func (*workerT) sendDestinationResponseToConfigBackend(payload json.RawMessage, 
 	// Sending destination response to config backend
 	switch status.ErrorCode {
 	// no live event in case of internal errors
-	case strconv.Itoa(transformer.DropStatusCode):
-	case strconv.Itoa(types.RouterUnMarshalErrorCode):
-	case strconv.Itoa(types.RouterTimedOutStatusCode):
+	case strconv.Itoa(transformer.DropStatusCode),
+		strconv.Itoa(types.RouterUnMarshalErrorCode),
+		strconv.Itoa(types.RouterTimedOutStatusCode):
 	default:
 		deliveryStatus := destinationdebugger.DeliveryStatusT{
 			DestinationID: destinationJobMetadata.DestinationID,

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -30,6 +30,8 @@ const (
 	ROUTER_TRANSFORM = "ROUTER_TRANSFORM"
 )
 
+const DROP_STATUS_CODE = 722
+
 // HandleT is the handle for this class
 type HandleT struct {
 	tr                                 *http.Transport

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -30,7 +30,7 @@ const (
 	ROUTER_TRANSFORM = "ROUTER_TRANSFORM"
 )
 
-const DROP_STATUS_CODE = 722
+const DropStatusCode = 722
 
 // HandleT is the handle for this class
 type HandleT struct {


### PR DESCRIPTION
# Description

Filter failed events and simply drop in case of special response codes.
Cases include `GA - server side identify not on` etc.

## Notion Ticket

[Filter identify if serverside identify is not on](https://www.notion.so/rudderstacks/Filter-identify-if-serverside-identify-is-not-on-3e415f20abab41f1a644cfb932ddfb55)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
