### PR TITLE
fix: restore / endpoint

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1368,6 +1368,7 @@ func (gateway *HandleT) StartWebHandler(ctx context.Context) error {
 	srvMux.HandleFunc("/v1/merge", gateway.webMergeHandler).Methods("POST")
 	srvMux.HandleFunc("/v1/group", gateway.webGroupHandler).Methods("POST")
 	srvMux.HandleFunc("/health", app.LivenessHandler(gateway.jobsDB)).Methods("GET")
+	srvMux.HandleFunc("/", app.LivenessHandler(gateway.jobsDB)).Methods("GET")
 	srvMux.HandleFunc("/v1/import", gateway.webImportHandler).Methods("POST")
 	srvMux.HandleFunc("/v1/audiencelist", gateway.webAudienceListHandler).Methods("POST")
 	srvMux.HandleFunc("/pixel/v1/track", gateway.pixelTrackHandler).Methods("GET")


### PR DESCRIPTION
# Description

Fixing 404s on `/` as per https://rudderlabs.slack.com/archives/C01HTT66UMB/p1659516020173379

Restoring this that was merged by mistake: https://github.com/rudderlabs/rudder-server/commit/e242c7d5d94ecc903f2565639a1b43b4a3d31ffa#diff-17cb8b37eda9018fe1c6cdb5f96b3fc948fc8ba49bc516987b8269576db9fcd4L1376

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
