### PR TITLE
fix: parse JSON error field as a string

### DIFF
--- a/regulation-worker/internal/delete/api/api_test.go
+++ b/regulation-worker/internal/delete/api/api_test.go
@@ -163,7 +163,9 @@ func (d *deleteAPI) deleteMockServer(w http.ResponseWriter, r *http.Request) {
 
 	var resp api.JobRespSchema
 	resp.Status = string(d.respBodyStatus)
-	resp.Error = d.respBodyErr
+	if d.respBodyErr != nil {
+		resp.Error = d.respBodyErr.Error()
+	}
 
 	body, err := json.Marshal([]api.JobRespSchema{resp})
 	if err != nil {

--- a/regulation-worker/internal/delete/api/schema.go
+++ b/regulation-worker/internal/delete/api/schema.go
@@ -15,5 +15,5 @@ type apiDeletionPayloadSchema struct {
 
 type JobRespSchema struct {
 	Status string `json:"status"`
-	Error  error  `json:"error"`
+	Error  string `json:"error"`
 }


### PR DESCRIPTION
# Description

When the API was returning with an error, and the `error` field of the response was set, we were getting the following unmarshal error.

This is because, you can not unmarshal a JSON string into an error field.
```
ERROR	api/api.go:82	error while decoding response body: json: cannot unmarshal string into Go struct field JobRespSchema.error of type error
```

So I change the type and update the tests.

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/Proper-error-parsing-or-regulation-worker-cba8f92e8c48436e92eb88521de3d6ab) 

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
