### PR TITLE
fix: multi_tenant_test.go improvements

### DIFF
--- a/multi_tenant_test.go
+++ b/multi_tenant_test.go
@@ -176,7 +176,13 @@ func testMultiTenantByAppType(t *testing.T, appType string) {
 		}
 		t.Log("main.go exited")
 	}()
-	t.Cleanup(func() { cancel(); <-done })
+	t.Cleanup(func() {
+		t.Log("Running cleanup")
+		cancel()
+		t.Log("Context canceled")
+		<-done
+		t.Log("Cleanup done")
+	})
 
 	// The Gateway will not become healthy until we trigger a valid configuration via ETCD
 	healthEndpoint := fmt.Sprintf("http://localhost:%d/health", httpPort)

--- a/multi_tenant_test.go
+++ b/multi_tenant_test.go
@@ -43,7 +43,7 @@ func TestMultiTenant(t *testing.T) {
 
 func testMultiTenantByAppType(t *testing.T, appType string) {
 	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
 	defer cancel()
 
 	pool, err := dockertest.NewPool("")
@@ -171,10 +171,10 @@ func testMultiTenantByAppType(t *testing.T, appType string) {
 		if err = cmd.Wait(); err != nil {
 			if err.Error() != "signal: killed" {
 				t.Logf("Error running main.go: %v", err)
+				return
 			}
-			return
 		}
-		t.Log("main.go exited successfully")
+		t.Log("main.go exited")
 	}()
 	t.Cleanup(func() { cancel(); <-done })
 

--- a/multi_tenant_test.go
+++ b/multi_tenant_test.go
@@ -150,6 +150,7 @@ func testMultiTenantByAppType(t *testing.T, appType string) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
+		defer cancel()
 		cmd := exec.CommandContext(ctx, "go", "run", "main.go")
 		cmd.Env = os.Environ()
 
@@ -176,13 +177,7 @@ func testMultiTenantByAppType(t *testing.T, appType string) {
 		}
 		t.Log("main.go exited")
 	}()
-	t.Cleanup(func() {
-		t.Log("Running cleanup")
-		cancel()
-		t.Log("Context canceled")
-		<-done
-		t.Log("Cleanup done")
-	})
+	t.Cleanup(func() { cancel(); <-done })
 
 	// The Gateway will not become healthy until we trigger a valid configuration via ETCD
 	healthEndpoint := fmt.Sprintf("http://localhost:%d/health", httpPort)

--- a/testhelper/etcd/etcd.go
+++ b/testhelper/etcd/etcd.go
@@ -21,7 +21,7 @@ type Resource struct {
 }
 
 func Setup(pool *dockertest.Pool, cln cleaner) (*Resource, error) {
-	container, err := pool.Run("bitnami/etcd", "3.4", []string{
+	container, err := pool.Run("bitnami/etcd", "3.5.2", []string{
 		"ALLOW_NONE_AUTHENTICATION=yes",
 	})
 	if err != nil {

--- a/testhelper/etcd/etcd.go
+++ b/testhelper/etcd/etcd.go
@@ -21,7 +21,7 @@ type Resource struct {
 }
 
 func Setup(pool *dockertest.Pool, cln cleaner) (*Resource, error) {
-	container, err := pool.Run("bitnami/etcd", "3.5.2", []string{
+	container, err := pool.Run("bitnami/etcd", "3", []string{
 		"ALLOW_NONE_AUTHENTICATION=yes",
 	})
 	if err != nil {


### PR DESCRIPTION
# Description

Fixing old version of ETCD plus case where `main.go` could terminate before the test.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.