### PR TITLE
feat(core): secure customer s3 bucket access for backups using cross-account role

### DIFF
--- a/enterprise/replay/setup.go
+++ b/enterprise/replay/setup.go
@@ -40,7 +40,7 @@ func initFileManager() (filemanager.FileManager, string, error) {
 		return nil, "", err
 	}
 
-	configFromEnv := filemanager.GetProviderConfigForBackupsFromEnv()
+	configFromEnv := filemanager.GetProviderConfigForBackupsFromEnv(context.TODO())
 	configFromEnv["startAfter"] = startTime.UnixNano() / int64(time.Millisecond)
 	uploader, err := fileManagerFactory.New(&filemanager.SettingsT{
 		Provider: provider,

--- a/enterprise/replay/setup.go
+++ b/enterprise/replay/setup.go
@@ -40,7 +40,7 @@ func initFileManager() (filemanager.FileManager, string, error) {
 		return nil, "", err
 	}
 
-	configFromEnv := filemanager.GetProviderConfigFromEnv()
+	configFromEnv := filemanager.GetProviderConfigForBackupsFromEnv()
 	configFromEnv["startAfter"] = startTime.UnixNano() / int64(time.Millisecond)
 	uploader, err := fileManagerFactory.New(&filemanager.SettingsT{
 		Provider: provider,

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -943,7 +943,7 @@ func (jd *HandleT) setUpForOwnerType(ctx context.Context, ownerType OwnerType, c
 
 func (jd *HandleT) startBackupDSLoop(ctx context.Context) {
 	var err error
-	jd.jobsFileUploader, err = jd.getFileUploader()
+	jd.jobsFileUploader, err = jd.getFileUploader(ctx)
 	if err != nil {
 		jd.logger.Errorf("failed to get a file uploader for %s", jd.tablePrefix)
 		return
@@ -3421,12 +3421,12 @@ func (jd *HandleT) getBackUpQuery(backupDSRange *dataSetRangeT, isJobStatusTable
 }
 
 // getFileUploader get a file uploader
-func (jd *HandleT) getFileUploader() (filemanager.FileManager, error) {
+func (jd *HandleT) getFileUploader(ctx context.Context) (filemanager.FileManager, error) {
 	var err error
 	if jd.jobsFileUploader == nil {
 		jd.jobsFileUploader, err = filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
 			Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
-			Config:   filemanager.GetProviderConfigForBackupsFromEnv(),
+			Config:   filemanager.GetProviderConfigForBackupsFromEnv(ctx),
 		})
 	}
 	return jd.jobsFileUploader, err
@@ -3586,7 +3586,7 @@ func (jd *HandleT) backupTable(ctx context.Context, backupDSRange *dataSetRangeT
 
 func (jd *HandleT) backupUploadWithExponentialBackoff(ctx context.Context, file *os.File, pathPrefixes ...string) (filemanager.UploadOutput, error) {
 	// get a file uploader
-	fileUploader, err := jd.getFileUploader()
+	fileUploader, err := jd.getFileUploader(ctx)
 	if err != nil {
 		return filemanager.UploadOutput{}, err
 	}

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -3426,7 +3426,7 @@ func (jd *HandleT) getFileUploader() (filemanager.FileManager, error) {
 	if jd.jobsFileUploader == nil {
 		jd.jobsFileUploader, err = filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
 			Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
-			Config:   filemanager.GetProviderConfigFromEnv(),
+			Config:   filemanager.GetProviderConfigForBackupsFromEnv(),
 		})
 	}
 	return jd.jobsFileUploader, err

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -117,7 +117,7 @@ func (st *HandleT) setupFileUploader() {
 			var err error
 			st.errFileUploader, err = filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
 				Provider: provider,
-				Config:   filemanager.GetProviderConfigFromEnv(),
+				Config:   filemanager.GetProviderConfigForBackupsFromEnv(),
 			})
 			if err != nil {
 				panic(err)

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -81,7 +81,7 @@ func (st *HandleT) crashRecover() {
 }
 
 func (st *HandleT) Start(ctx context.Context) {
-	st.setupFileUploader()
+	st.setupFileUploader(ctx)
 	st.errProcessQ = make(chan []*jobsdb.JobT)
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -98,9 +98,9 @@ func (st *HandleT) Start(ctx context.Context) {
 	_ = g.Wait()
 }
 
-func (st *HandleT) getFileUploader() filemanager.FileManager {
+func (st *HandleT) getFileUploader(ctx context.Context) filemanager.FileManager {
 	if st.errFileUploader == nil && backupEnabled() {
-		st.setupFileUploader()
+		st.setupFileUploader(ctx)
 	}
 	return st.errFileUploader
 }
@@ -109,7 +109,7 @@ func backupEnabled() bool {
 	return errorStashEnabled && jobsdb.IsMasterBackupEnabled()
 }
 
-func (st *HandleT) setupFileUploader() {
+func (st *HandleT) setupFileUploader(ctx context.Context) {
 	if backupEnabled() {
 		provider := config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "")
 		bucket := config.GetEnv("JOBS_BACKUP_BUCKET", "")
@@ -117,7 +117,7 @@ func (st *HandleT) setupFileUploader() {
 			var err error
 			st.errFileUploader, err = filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
 				Provider: provider,
-				Config:   filemanager.GetProviderConfigForBackupsFromEnv(),
+				Config:   filemanager.GetProviderConfigForBackupsFromEnv(ctx),
 			})
 			if err != nil {
 				panic(err)
@@ -273,7 +273,7 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 				continue
 			}
 
-			canUpload := backupEnabled() && st.getFileUploader() != nil
+			canUpload := backupEnabled() && st.getFileUploader(ctx) != nil
 
 			jobState := jobsdb.Executing.State
 

--- a/services/archiver/archiver.go
+++ b/services/archiver/archiver.go
@@ -81,7 +81,7 @@ func ArchiveOldRecords(tableName, tsColumn string, archivalTimeInDays int, dbHan
 
 	fManager, err := filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
 		Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
-		Config:   filemanager.GetProviderConfigFromEnv(),
+		Config:   filemanager.GetProviderConfigForBackupsFromEnv(),
 	})
 	if err != nil {
 		pkgLogger.Errorf("[Archiver]: Error in creating a file manager for :%s: , %v", config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"), err)

--- a/services/archiver/archiver.go
+++ b/services/archiver/archiver.go
@@ -1,6 +1,7 @@
 package archiver
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
@@ -81,7 +82,7 @@ func ArchiveOldRecords(tableName, tsColumn string, archivalTimeInDays int, dbHan
 
 	fManager, err := filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
 		Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
-		Config:   filemanager.GetProviderConfigForBackupsFromEnv(),
+		Config:   filemanager.GetProviderConfigForBackupsFromEnv(context.TODO()),
 	})
 	if err != nil {
 		pkgLogger.Errorf("[Archiver]: Error in creating a file manager for :%s: , %v", config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"), err)

--- a/services/filemanager/azureBlobStoragemanager.go
+++ b/services/filemanager/azureBlobStoragemanager.go
@@ -12,14 +12,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
-	"github.com/rudderlabs/rudder-server/utils/logger"
 )
-
-var pkgLogger logger.LoggerI
-
-func init() {
-	pkgLogger = logger.NewLogger().Child("filemanager").Child("azureBlobStorage")
-}
 
 func supressMinorErrors(err error) error {
 	if err != nil {

--- a/services/filemanager/filemanager.go
+++ b/services/filemanager/filemanager.go
@@ -88,7 +88,7 @@ func (factory *FileManagerFactoryT) New(settings *SettingsT) (FileManager, error
 }
 
 // GetProviderConfigForBackupsFromEnv returns the provider config
-func GetProviderConfigForBackupsFromEnv() map[string]interface{} {
+func GetProviderConfigForBackupsFromEnv(ctx context.Context) map[string]interface{} {
 	providerConfig := make(map[string]interface{})
 	provider := config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3")
 	switch provider {
@@ -101,6 +101,7 @@ func GetProviderConfigForBackupsFromEnv() map[string]interface{} {
 		providerConfig["regionHint"] = config.GetEnv("AWS_S3_REGION_HINT", "us-east-1")
 		providerConfig["iamRoleArn"] = config.GetEnv("BACKUP_IAM_ROLE_ARN", "")
 		if providerConfig["iamRoleArn"] != "" {
+			backendconfig.DefaultBackendConfig.WaitForConfig(ctx)
 			providerConfig["externalId"] = backendconfig.DefaultBackendConfig.GetWorkspaceIDForWriteKey("")
 		}
 	case "GCS":

--- a/services/filemanager/filemanager.go
+++ b/services/filemanager/filemanager.go
@@ -10,10 +10,13 @@ import (
 	"time"
 
 	"github.com/rudderlabs/rudder-server/config"
+	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/router/rterror"
+	"github.com/rudderlabs/rudder-server/utils/logger"
 )
 
 var (
+	pkgLogger                 logger.LoggerI
 	DefaultFileManagerFactory FileManagerFactory
 	ErrKeyNotFound            = errors.New("NoSuchKey")
 )
@@ -54,6 +57,7 @@ type SettingsT struct {
 
 func init() {
 	DefaultFileManagerFactory = &FileManagerFactoryT{}
+	pkgLogger = logger.NewLogger().Child("filemanager")
 }
 
 // New returns FileManager backed by configured provider
@@ -83,8 +87,8 @@ func (factory *FileManagerFactoryT) New(settings *SettingsT) (FileManager, error
 	return nil, fmt.Errorf("%w: %s", rterror.InvalidServiceProvider, settings.Provider)
 }
 
-// GetProviderConfigFromEnv returns the provider config
-func GetProviderConfigFromEnv() map[string]interface{} {
+// GetProviderConfigForBackupsFromEnv returns the provider config
+func GetProviderConfigForBackupsFromEnv() map[string]interface{} {
 	providerConfig := make(map[string]interface{})
 	provider := config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3")
 	switch provider {
@@ -95,6 +99,10 @@ func GetProviderConfigFromEnv() map[string]interface{} {
 		providerConfig["accessKey"] = config.GetEnv("AWS_SECRET_ACCESS_KEY", "")
 		providerConfig["enableSSE"] = config.GetEnvAsBool("AWS_ENABLE_SSE", false)
 		providerConfig["regionHint"] = config.GetEnv("AWS_S3_REGION_HINT", "us-east-1")
+		providerConfig["iamRoleArn"] = config.GetEnv("BACKUP_IAM_ROLE_ARN", "")
+		if providerConfig["iamRoleArn"] != "" {
+			providerConfig["externalId"] = backendconfig.GetWorkspaceIDForWriteKey("")
+		}
 	case "GCS":
 		providerConfig["bucketName"] = config.GetEnv("JOBS_BACKUP_BUCKET", "")
 		providerConfig["prefix"] = config.GetEnv("JOBS_BACKUP_PREFIX", "")

--- a/services/filemanager/filemanager.go
+++ b/services/filemanager/filemanager.go
@@ -101,7 +101,7 @@ func GetProviderConfigForBackupsFromEnv() map[string]interface{} {
 		providerConfig["regionHint"] = config.GetEnv("AWS_S3_REGION_HINT", "us-east-1")
 		providerConfig["iamRoleArn"] = config.GetEnv("BACKUP_IAM_ROLE_ARN", "")
 		if providerConfig["iamRoleArn"] != "" {
-			providerConfig["externalId"] = backendconfig.GetWorkspaceIDForWriteKey("")
+			providerConfig["externalId"] = backendconfig.DefaultBackendConfig.GetWorkspaceIDForWriteKey("")
 		}
 	case "GCS":
 		providerConfig["bucketName"] = config.GetEnv("JOBS_BACKUP_BUCKET", "")

--- a/services/filemanager/s3manager.go
+++ b/services/filemanager/s3manager.go
@@ -193,9 +193,6 @@ func (manager *S3Manager) getSession(ctx context.Context) (*session.Session, err
 		manager.Config.Region = aws.String(region)
 	}
 
-	if manager.Config.Region == nil {
-		return nil, errors.New("no storage bucket region configured")
-	}
 	return awsutils.CreateSession(manager.getSessionConfig())
 }
 

--- a/warehouse/archiver.go
+++ b/warehouse/archiver.go
@@ -81,7 +81,7 @@ func backupRecords(args backupRecordsArgs) (backupLocation string, err error) {
 
 	fManager, err := filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
 		Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
-		Config:   filemanager.GetProviderConfigFromEnv(),
+		Config:   filemanager.GetProviderConfigForBackupsFromEnv(),
 	})
 	if err != nil {
 		err = fmt.Errorf("Error in creating a file manager for:%s. Error: %w", config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"), err)

--- a/warehouse/archiver.go
+++ b/warehouse/archiver.go
@@ -81,7 +81,7 @@ func backupRecords(args backupRecordsArgs) (backupLocation string, err error) {
 
 	fManager, err := filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
 		Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
-		Config:   filemanager.GetProviderConfigForBackupsFromEnv(),
+		Config:   filemanager.GetProviderConfigForBackupsFromEnv(context.TODO()),
 	})
 	if err != nil {
 		err = fmt.Errorf("Error in creating a file manager for:%s. Error: %w", config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"), err)


### PR DESCRIPTION
# Description

If BACKUP_IAM_ROLE_ARN env is specified, sts creds are generated assuming the role for backups to customer bucket. BACKUP_IAM_ROLE_ARN is the ARN of the role the customer creates with a trust policy principal being our AWS acccount and allowing necessary S3 actions on their bucket

More details: https://rudderlabs.slack.com/archives/C03KSBL7JM7/p1657156293344469

## Notion Ticket

https://www.notion.so/rudderstacks/Secure-connection-to-customer-S3-buckets-for-backups-47fa67c7cd1c40fc9edbdf9118a39703

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
