### PR TITLE
chore(warehouse): revert schemaExist changes to follow statement execution for snowflake

### DIFF
--- a/warehouse/snowflake/snowflake.go
+++ b/warehouse/snowflake/snowflake.go
@@ -159,8 +159,9 @@ func (sf *HandleT) columnExists(columnName, tableName string) (exists bool, err 
 }
 
 func (sf *HandleT) schemaExists() (exists bool, err error) {
-	sqlStatement := "SELECT EXISTS ( SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = $1 )"
-	err = sf.Db.QueryRow(sqlStatement, sf.Namespace).Scan(&exists)
+	sqlStatement := fmt.Sprintf("SELECT EXISTS ( SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '%s' )", sf.Namespace)
+	r := sf.Db.QueryRow(sqlStatement)
+	err = r.Scan(&exists)
 	// ignore err if no results for query
 	if err == sql.ErrNoRows {
 		err = nil


### PR DESCRIPTION
# Description

Do do not create schema Query if the schema is already present for Snowflake.

## Notion Ticket

https://www.notion.so/rudderstacks/One-Medical-says-they-re-still-experiencing-this-bug-despite-the-hotfix-deployed-in-the-original-th-1aeb6b7af4f54d8cba3f04c7d67c88b9

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
