### PR TITLE
fix: stream manager logging format string

### DIFF
--- a/services/streammanager/eventbridge/eventbridgemanager.go
+++ b/services/streammanager/eventbridge/eventbridgemanager.go
@@ -62,7 +62,7 @@ func (producer *EventBridgeProducer) Produce(jsonData json.RawMessage, _ interfa
 	putEventsOutput, err := client.PutEvents(&requestInput)
 	if err != nil {
 		statusCode, respStatus, responseMessage := common.ParseAWSError(err)
-		pkgLogger.Errorf("[EventBridge] error  :: %s : %s : %s", statusCode, respStatus, responseMessage)
+		pkgLogger.Errorf("[EventBridge] error  :: %d : %s : %s", statusCode, respStatus, responseMessage)
 		return statusCode, respStatus, responseMessage
 	}
 

--- a/services/streammanager/firehose/firehosemanager.go
+++ b/services/streammanager/firehose/firehosemanager.go
@@ -78,7 +78,7 @@ func (producer *FireHoseProducer) Produce(jsonData json.RawMessage, _ interface{
 
 	if errorRec != nil {
 		statusCode, respStatus, responseMessage := common.ParseAWSError(errorRec)
-		pkgLogger.Errorf("[FireHose] error  :: %s : %s : %s", statusCode, respStatus, responseMessage)
+		pkgLogger.Errorf("[FireHose] error  :: %d : %s : %s", statusCode, respStatus, responseMessage)
 		return statusCode, respStatus, responseMessage
 	}
 

--- a/services/streammanager/kinesis/kinesismanager.go
+++ b/services/streammanager/kinesis/kinesismanager.go
@@ -95,7 +95,7 @@ func (producer *KinesisProducer) Produce(jsonData json.RawMessage, destConfig in
 	putOutput, err := client.PutRecord(&putInput)
 	if err != nil {
 		statusCode, respStatus, responseMessage := common.ParseAWSError(err)
-		pkgLogger.Errorf("[Kinesis] error  :: %s : %s : %s", statusCode, respStatus, responseMessage)
+		pkgLogger.Errorf("[Kinesis] error  :: %d : %s : %s", statusCode, respStatus, responseMessage)
 		return statusCode, respStatus, responseMessage
 	}
 	message := fmt.Sprintf("Message delivered at SequenceNumber: %v , shard Id: %v", putOutput.SequenceNumber, putOutput.ShardId)

--- a/services/streammanager/personalize/personalizemanager.go
+++ b/services/streammanager/personalize/personalizemanager.go
@@ -95,7 +95,7 @@ func (producer *PersonalizeProducer) Produce(jsonData json.RawMessage, _ interfa
 
 	if err != nil {
 		statusCode, respStatus, responseMessage := common.ParseAWSError(err)
-		pkgLogger.Errorf("[Personalize] error  :: %s : %s : %s", statusCode, respStatus, responseMessage)
+		pkgLogger.Errorf("[Personalize] error  :: %d : %s : %s", statusCode, respStatus, responseMessage)
 		return statusCode, respStatus, responseMessage
 	}
 


### PR DESCRIPTION
# Description
To print int used %s instead of %d so this comming fixes it.
It is breaking anything but it is printing like this  %!s(int=400).

## Notion Ticket
[FTR Streaming Destinations](https://www.notion.so/rudderstacks/AWS-FTR-for-streaming-destination-PoC-78b63869ac904ba49b0018a527ccb343)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
