### PR TITLE
fix: reinstate bugsnag notifications

### DIFF
--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -1247,8 +1247,7 @@ func BugsnagNotify(ctx context.Context, team string) func() {
 	return func() {
 		if r := recover(); r != nil {
 			notifyOnce.Do(func() {
-				RecordAppError(fmt.Errorf("%v", r))
-				bugsnag.AutoNotify(ctx, bugsnag.SeverityError, bugsnag.MetaData{
+				defer bugsnag.AutoNotify(ctx, bugsnag.SeverityError, bugsnag.MetaData{
 					"GoRoutines": {
 						"Number": runtime.NumGoroutine(),
 					},
@@ -1256,10 +1255,10 @@ func BugsnagNotify(ctx context.Context, team string) func() {
 						"Name": team,
 					},
 				})
+				RecordAppError(fmt.Errorf("%v", r))
+				pkgLogger.Fatal(r)
+				panic(r)
 			})
-
-			pkgLogger.Fatal(r)
-			panic(r)
 		}
 	}
 }


### PR DESCRIPTION
# Description

`bugsnag.AutoNotify` performs recovery itself too, thus its call needs be deferred and followed by a panic within the same function.


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
