### PR TITLE
fix(warehouse): reset priority if earlier upload is already in progress

### DIFF
--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -620,16 +620,17 @@ func (wh *HandleT) createJobs(warehouse warehouseutils.WarehouseT) (err error) {
 	}
 
 	wh.areBeingEnqueuedLock.Lock()
-	uploadID, uploadStatus, priority := wh.getLatestUploadStatus(&warehouse)
+
+	priority := 0
+	uploadID, uploadStatus, uploadPriority := wh.getLatestUploadStatus(&warehouse)
 	if uploadStatus == Waiting {
 		// If it is present do nothing else delete it
 		if _, inProgess := wh.isUploadJobInProgress(warehouse, uploadID); !inProgess {
 			wh.deleteWaitingUploadJob(uploadID)
-		} else {
-			// reset priority if the upload is already in progress
-			priority = 0
+			priority = uploadPriority // copy the priority from the latest upload job.
 		}
 	}
+
 	wh.areBeingEnqueuedLock.Unlock()
 
 	stagingFilesFetchStat := stats.DefaultStats.NewTaggedStat("wh_scheduler.pending_staging_files", stats.TimerType, stats.Tags{

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -625,6 +625,9 @@ func (wh *HandleT) createJobs(warehouse warehouseutils.WarehouseT) (err error) {
 		// If it is present do nothing else delete it
 		if _, inProgess := wh.isUploadJobInProgress(warehouse, uploadID); !inProgess {
 			wh.deleteWaitingUploadJob(uploadID)
+		} else {
+			// reset priority if the upload is already in progress
+			priority = 0
 		}
 	}
 	wh.areBeingEnqueuedLock.Unlock()


### PR DESCRIPTION
# Description
Reset priority if uploads are already in progress

## Notion Ticket

https://www.notion.so/rudderstacks/Reset-priority-for-if-uploads-are-in-progress-fb4cb2af50484b069ac1cff30585feb3

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
