### PR TITLE
refactor: destination config from interface{} to map[string]interface{}

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/minio/md5-simd v1.1.0 // indirect
 	github.com/minio/sha256-simd v0.1.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/mitchellh/mapstructure v1.4.1
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/services/streammanager/eventbridge/eventbridgemanager.go
+++ b/services/streammanager/eventbridge/eventbridgemanager.go
@@ -28,7 +28,7 @@ type EventBridgeClient interface {
 }
 
 // NewProducer creates a producer based on destination config
-func NewProducer(destinationConfig interface{}, o common.Opts) (*EventBridgeProducer, error) {
+func NewProducer(destinationConfig map[string]interface{}, o common.Opts) (*EventBridgeProducer, error) {
 	sessionConfig, err := awsutils.NewSessionConfig(destinationConfig, o.Timeout, eventbridge.ServiceName)
 	if err != nil {
 		return nil, err

--- a/services/streammanager/eventbridge/eventbridgemanager_test.go
+++ b/services/streammanager/eventbridge/eventbridgemanager_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestNewProducer(t *testing.T) {
-	destinationConfig := map[string]string{
+	destinationConfig := map[string]interface{}{
 		"Region":     "us-east-1",
 		"IAMRoleARN": "sampleRoleArn",
 		"ExternalID": "sampleExternalID",

--- a/services/streammanager/firehose/firehosemanager.go
+++ b/services/streammanager/firehose/firehosemanager.go
@@ -29,7 +29,7 @@ type FireHoseClient interface {
 }
 
 // NewProducer creates a producer based on destination config
-func NewProducer(destinationConfig interface{}, o common.Opts) (*FireHoseProducer, error) {
+func NewProducer(destinationConfig map[string]interface{}, o common.Opts) (*FireHoseProducer, error) {
 	sessionConfig, err := awsutils.NewSessionConfig(destinationConfig, o.Timeout, firehose.ServiceName)
 	if err != nil {
 		return nil, err

--- a/services/streammanager/firehose/firehosemanager_test.go
+++ b/services/streammanager/firehose/firehosemanager_test.go
@@ -24,7 +24,7 @@ var (
 )
 
 func TestNewProducer(t *testing.T) {
-	destinationConfig := map[string]string{
+	destinationConfig := map[string]interface{}{
 		"Region":     "us-east-1",
 		"IAMRoleARN": "sampleRoleArn",
 		"ExternalID": "sampleExternalID",

--- a/services/streammanager/kinesis/kinesis_suite_test.go
+++ b/services/streammanager/kinesis/kinesis_suite_test.go
@@ -25,7 +25,7 @@ func TestKinesis(t *testing.T) {
 }
 
 func TestNewProducer(t *testing.T) {
-	destinationConfig := map[string]string{
+	destinationConfig := map[string]interface{}{
 		"Region":     "us-east-1",
 		"IAMRoleARN": "sampleRoleArn",
 		"ExternalID": "sampleExternalID",

--- a/services/streammanager/kinesis/kinesismanager.go
+++ b/services/streammanager/kinesis/kinesismanager.go
@@ -36,7 +36,7 @@ type KinesisClient interface {
 }
 
 // NewProducer creates a producer based on destination config
-func NewProducer(destinationConfig interface{}, o common.Opts) (*KinesisProducer, error) {
+func NewProducer(destinationConfig map[string]interface{}, o common.Opts) (*KinesisProducer, error) {
 	sessionConfig, err := awsutils.NewSessionConfig(destinationConfig, o.Timeout, kinesis.ServiceName)
 	if err != nil {
 		return nil, err

--- a/services/streammanager/personalize/personalizamanager_test.go
+++ b/services/streammanager/personalize/personalizamanager_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestNewProducer(t *testing.T) {
-	destinationConfig := map[string]string{
+	destinationConfig := map[string]interface{}{
 		"Region":     "us-east-1",
 		"IAMRoleARN": "sampleRoleArn",
 		"ExternalID": "sampleExternalID",

--- a/services/streammanager/personalize/personalizemanager.go
+++ b/services/streammanager/personalize/personalizemanager.go
@@ -29,7 +29,7 @@ type PersonalizeClient interface {
 	PutItems(input *personalizeevents.PutItemsInput) (*personalizeevents.PutItemsOutput, error)
 }
 
-func NewProducer(destinationConfig interface{}, o common.Opts) (*PersonalizeProducer, error) {
+func NewProducer(destinationConfig map[string]interface{}, o common.Opts) (*PersonalizeProducer, error) {
 	sessionConfig, err := awsutils.NewSessionConfig(destinationConfig, o.Timeout, personalizeevents.ServiceName)
 	if err != nil {
 		return nil, err

--- a/services/streammanager/streammanager.go
+++ b/services/streammanager/streammanager.go
@@ -17,7 +17,7 @@ import (
 )
 
 // NewProducer delegates the call to the appropriate based on parameter destination for creating producer
-func NewProducer(destinationConfig interface{}, destType string, opts common.Opts) (common.StreamProducer, error) {
+func NewProducer(destinationConfig map[string]interface{}, destType string, opts common.Opts) (common.StreamProducer, error) {
 	switch destType {
 	case "AZURE_EVENT_HUB":
 		return kafka.NewProducerForAzureEventHubs(destinationConfig, opts)

--- a/utils/awsutils/session.go
+++ b/utils/awsutils/session.go
@@ -70,8 +70,10 @@ func NewSessionConfig(destinationConfig map[string]interface{}, timeout time.Dur
 		return nil, errors.New("destinationConfig should not be nil")
 	}
 	sessionConfig := SessionConfig{}
-	mapstructure.Decode(destinationConfig, &sessionConfig)
-
+	err := mapstructure.Decode(destinationConfig, &sessionConfig)
+	if err != nil {
+		return nil, errors.New("unable to populate session config using destinationConfig")
+	}
 	sessionConfig.Timeout = timeout
 	sessionConfig.Service = serviceName
 	return &sessionConfig, nil

--- a/utils/awsutils/session.go
+++ b/utils/awsutils/session.go
@@ -1,7 +1,7 @@
 package awsutils
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -64,16 +64,36 @@ func CreateSession(config *SessionConfig) *session.Session {
 	}))
 }
 
-func NewSessionConfig(destinationConfig interface{}, timeout time.Duration, serviceName string) (*SessionConfig, error) {
+func NewSessionConfig(destinationConfig map[string]interface{}, timeout time.Duration, serviceName string) (*SessionConfig, error) {
+	if destinationConfig == nil {
+		return nil, errors.New("destinationConfig should not be nil")
+	}
 	sessionConfig := SessionConfig{}
 
-	jsonConfig, err := json.Marshal(destinationConfig)
-	if err != nil {
-		return nil, fmt.Errorf("[%s] Error while marshalling destination config :: %w", serviceName, err)
+	if region, ok := destinationConfig["Region"].(string); ok {
+		sessionConfig.Region = region
+	} else if region, ok := destinationConfig["region"].(string); ok {
+		sessionConfig.Region = region
 	}
-	err = json.Unmarshal(jsonConfig, &sessionConfig)
-	if err != nil {
-		return nil, fmt.Errorf("[%s] Error while unmarshalling destination config :: %w", serviceName, err)
+	if roleArn, ok := destinationConfig["IAMRoleARN"].(string); ok {
+		sessionConfig.IAMRoleARN = roleArn
+	} else if roleArn, ok := destinationConfig["iamRoleARN"].(string); ok {
+		sessionConfig.IAMRoleARN = roleArn
+	}
+	if externalID, ok := destinationConfig["ExternalID"].(string); ok {
+		sessionConfig.ExternalID = externalID
+	} else if externalID, ok := destinationConfig["externalID"].(string); ok {
+		sessionConfig.ExternalID = externalID
+	}
+	if accessKeyID, ok := destinationConfig["AccessKeyID"].(string); ok {
+		sessionConfig.AccessKeyID = accessKeyID
+	} else if accessKeyID, ok := destinationConfig["accessKeyID"].(string); ok {
+		sessionConfig.AccessKeyID = accessKeyID
+	}
+	if accessKey, ok := destinationConfig["AccessKey"].(string); ok {
+		sessionConfig.AccessKey = accessKey
+	} else if accessKey, ok := destinationConfig["accessKey"].(string); ok {
+		sessionConfig.AccessKey = accessKey
 	}
 	sessionConfig.Timeout = timeout
 	sessionConfig.Service = serviceName

--- a/utils/awsutils/session.go
+++ b/utils/awsutils/session.go
@@ -11,14 +11,15 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/mitchellh/mapstructure"
 )
 
 type SessionConfig struct {
-	Region      string
-	AccessKeyID string
-	AccessKey   string
-	IAMRoleARN  string
-	ExternalID  string
+	Region      string `mapstructure:"region"`
+	AccessKeyID string `mapstructure:"accessKeyID"`
+	AccessKey   string `mapstructure:"accessKey"`
+	IAMRoleARN  string `mapstructure:"iamRoleARN"`
+	ExternalID  string `mapstructure:"externalID"`
 	Service     string
 	Timeout     time.Duration
 }
@@ -69,32 +70,8 @@ func NewSessionConfig(destinationConfig map[string]interface{}, timeout time.Dur
 		return nil, errors.New("destinationConfig should not be nil")
 	}
 	sessionConfig := SessionConfig{}
+	mapstructure.Decode(destinationConfig, &sessionConfig)
 
-	if region, ok := destinationConfig["Region"].(string); ok {
-		sessionConfig.Region = region
-	} else if region, ok := destinationConfig["region"].(string); ok {
-		sessionConfig.Region = region
-	}
-	if roleArn, ok := destinationConfig["IAMRoleARN"].(string); ok {
-		sessionConfig.IAMRoleARN = roleArn
-	} else if roleArn, ok := destinationConfig["iamRoleARN"].(string); ok {
-		sessionConfig.IAMRoleARN = roleArn
-	}
-	if externalID, ok := destinationConfig["ExternalID"].(string); ok {
-		sessionConfig.ExternalID = externalID
-	} else if externalID, ok := destinationConfig["externalID"].(string); ok {
-		sessionConfig.ExternalID = externalID
-	}
-	if accessKeyID, ok := destinationConfig["AccessKeyID"].(string); ok {
-		sessionConfig.AccessKeyID = accessKeyID
-	} else if accessKeyID, ok := destinationConfig["accessKeyID"].(string); ok {
-		sessionConfig.AccessKeyID = accessKeyID
-	}
-	if accessKey, ok := destinationConfig["AccessKey"].(string); ok {
-		sessionConfig.AccessKey = accessKey
-	} else if accessKey, ok := destinationConfig["accessKey"].(string); ok {
-		sessionConfig.AccessKey = accessKey
-	}
 	sessionConfig.Timeout = timeout
 	sessionConfig.Service = serviceName
 	return &sessionConfig, nil

--- a/utils/awsutils/session_test.go
+++ b/utils/awsutils/session_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 var (
-	destinationConfigWithRole map[string]string = map[string]string{
+	destinationConfigWithRole map[string]interface{} = map[string]interface{}{
 		"Region":     "us-east-1",
 		"IAMRoleARN": "role-arn",
 		"ExternalID": "ExternalID",
 	}
-	destinationConfigWithAccessKey map[string]string = map[string]string{
+	destinationConfigWithAccessKey map[string]interface{} = map[string]interface{}{
 		"Region":      "us-east-1",
 		"AccessKeyID": "AccessKeyID",
 		"AccessKey":   "AccessKey",
@@ -27,9 +27,9 @@ func TestNewSessionConfigWithAccessKey(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, sessionConfig)
 	assert.Equal(t, *sessionConfig, SessionConfig{
-		Region:      destinationConfigWithAccessKey["Region"],
-		AccessKeyID: destinationConfigWithAccessKey["AccessKeyID"],
-		AccessKey:   destinationConfigWithAccessKey["AccessKey"],
+		Region:      destinationConfigWithAccessKey["Region"].(string),
+		AccessKeyID: destinationConfigWithAccessKey["AccessKeyID"].(string),
+		AccessKey:   destinationConfigWithAccessKey["AccessKey"].(string),
 		Timeout:     timeOut,
 		Service:     serviceName,
 	})
@@ -41,9 +41,9 @@ func TestNewSessionConfigWithRole(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, sessionConfig)
 	assert.Equal(t, *sessionConfig, SessionConfig{
-		Region:     destinationConfigWithRole["Region"],
-		IAMRoleARN: destinationConfigWithRole["IAMRoleARN"],
-		ExternalID: destinationConfigWithRole["ExternalID"],
+		Region:     destinationConfigWithRole["Region"].(string),
+		IAMRoleARN: destinationConfigWithRole["IAMRoleARN"].(string),
+		ExternalID: destinationConfigWithRole["ExternalID"].(string),
 		Timeout:    timeOut,
 		Service:    serviceName,
 	})
@@ -51,16 +51,16 @@ func TestNewSessionConfigWithRole(t *testing.T) {
 
 func TestNewSessionConfigBadConfig(t *testing.T) {
 	serviceName := "s3"
-	sessionConfig, err := NewSessionConfig("Bad config", timeOut, serviceName)
-	assert.Contains(t, err.Error(), "marshalling")
+	sessionConfig, err := NewSessionConfig(nil, timeOut, serviceName)
+	assert.Equal(t, "destinationConfig should not be nil", err.Error())
 	assert.Nil(t, sessionConfig)
 }
 
 func TestCreateSessionWithRole(t *testing.T) {
 	sessionConfig := SessionConfig{
-		Region:     destinationConfigWithRole["Region"],
-		IAMRoleARN: destinationConfigWithRole["IAMRoleARN"],
-		ExternalID: destinationConfigWithRole["ExternalID"],
+		Region:     destinationConfigWithRole["Region"].(string),
+		IAMRoleARN: destinationConfigWithRole["IAMRoleARN"].(string),
+		ExternalID: destinationConfigWithRole["ExternalID"].(string),
 		Timeout:    10 * time.Second,
 	}
 	awsSession := CreateSession(&sessionConfig)
@@ -72,9 +72,9 @@ func TestCreateSessionWithRole(t *testing.T) {
 
 func TestCreateSessionWithAccessKeys(t *testing.T) {
 	sessionConfig := SessionConfig{
-		Region:      destinationConfigWithAccessKey["Region"],
-		AccessKeyID: destinationConfigWithAccessKey["AccessKeyID"],
-		AccessKey:   destinationConfigWithAccessKey["AccessKey"],
+		Region:      destinationConfigWithAccessKey["Region"].(string),
+		AccessKeyID: destinationConfigWithAccessKey["AccessKeyID"].(string),
+		AccessKey:   destinationConfigWithAccessKey["AccessKey"].(string),
 		Timeout:     10 * time.Second,
 	}
 	awsSession := CreateSession(&sessionConfig)
@@ -86,7 +86,7 @@ func TestCreateSessionWithAccessKeys(t *testing.T) {
 
 func TestCreateSessionWithoutAccessKeysOrRole(t *testing.T) {
 	sessionConfig := SessionConfig{
-		Region:  destinationConfigWithAccessKey["Region"],
+		Region:  destinationConfigWithAccessKey["Region"].(string),
 		Timeout: 10 * time.Second,
 	}
 	awsSession := CreateSession(&sessionConfig)

--- a/utils/awsutils/session_test.go
+++ b/utils/awsutils/session_test.go
@@ -9,14 +9,14 @@ import (
 
 var (
 	destinationConfigWithRole map[string]interface{} = map[string]interface{}{
-		"Region":     "us-east-1",
-		"IAMRoleARN": "role-arn",
-		"ExternalID": "ExternalID",
+		"region":     "us-east-1",
+		"iamRoleARN": "role-arn",
+		"externalID": "ExternalID",
 	}
 	destinationConfigWithAccessKey map[string]interface{} = map[string]interface{}{
-		"Region":      "us-east-1",
-		"AccessKeyID": "AccessKeyID",
-		"AccessKey":   "AccessKey",
+		"region":      "us-east-1",
+		"accessKeyID": "AccessKeyID",
+		"accessKey":   "AccessKey",
 	}
 	timeOut time.Duration = 10 * time.Second
 )
@@ -27,9 +27,9 @@ func TestNewSessionConfigWithAccessKey(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, sessionConfig)
 	assert.Equal(t, *sessionConfig, SessionConfig{
-		Region:      destinationConfigWithAccessKey["Region"].(string),
-		AccessKeyID: destinationConfigWithAccessKey["AccessKeyID"].(string),
-		AccessKey:   destinationConfigWithAccessKey["AccessKey"].(string),
+		Region:      destinationConfigWithAccessKey["region"].(string),
+		AccessKeyID: destinationConfigWithAccessKey["accessKeyID"].(string),
+		AccessKey:   destinationConfigWithAccessKey["accessKey"].(string),
 		Timeout:     timeOut,
 		Service:     serviceName,
 	})
@@ -41,9 +41,9 @@ func TestNewSessionConfigWithRole(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, sessionConfig)
 	assert.Equal(t, *sessionConfig, SessionConfig{
-		Region:     destinationConfigWithRole["Region"].(string),
-		IAMRoleARN: destinationConfigWithRole["IAMRoleARN"].(string),
-		ExternalID: destinationConfigWithRole["ExternalID"].(string),
+		Region:     destinationConfigWithRole["region"].(string),
+		IAMRoleARN: destinationConfigWithRole["iamRoleARN"].(string),
+		ExternalID: destinationConfigWithRole["externalID"].(string),
 		Timeout:    timeOut,
 		Service:    serviceName,
 	})
@@ -58,9 +58,9 @@ func TestNewSessionConfigBadConfig(t *testing.T) {
 
 func TestCreateSessionWithRole(t *testing.T) {
 	sessionConfig := SessionConfig{
-		Region:     destinationConfigWithRole["Region"].(string),
-		IAMRoleARN: destinationConfigWithRole["IAMRoleARN"].(string),
-		ExternalID: destinationConfigWithRole["ExternalID"].(string),
+		Region:     destinationConfigWithRole["region"].(string),
+		IAMRoleARN: destinationConfigWithRole["iamRoleARN"].(string),
+		ExternalID: destinationConfigWithRole["externalID"].(string),
 		Timeout:    10 * time.Second,
 	}
 	awsSession := CreateSession(&sessionConfig)
@@ -72,9 +72,9 @@ func TestCreateSessionWithRole(t *testing.T) {
 
 func TestCreateSessionWithAccessKeys(t *testing.T) {
 	sessionConfig := SessionConfig{
-		Region:      destinationConfigWithAccessKey["Region"].(string),
-		AccessKeyID: destinationConfigWithAccessKey["AccessKeyID"].(string),
-		AccessKey:   destinationConfigWithAccessKey["AccessKey"].(string),
+		Region:      destinationConfigWithAccessKey["region"].(string),
+		AccessKeyID: destinationConfigWithAccessKey["accessKeyID"].(string),
+		AccessKey:   destinationConfigWithAccessKey["accessKey"].(string),
 		Timeout:     10 * time.Second,
 	}
 	awsSession := CreateSession(&sessionConfig)
@@ -86,7 +86,7 @@ func TestCreateSessionWithAccessKeys(t *testing.T) {
 
 func TestCreateSessionWithoutAccessKeysOrRole(t *testing.T) {
 	sessionConfig := SessionConfig{
-		Region:  destinationConfigWithAccessKey["Region"].(string),
+		Region:  destinationConfigWithAccessKey["region"].(string),
 		Timeout: 10 * time.Second,
 	}
 	awsSession := CreateSession(&sessionConfig)


### PR DESCRIPTION
# Description
We were using slightly inefficient way to populate SessionConfig from
destination config so in order to improve this, we need to take destination
config as map[string]interface{}.

Rohith suggested this change in the PR#2241

## Notion Ticket

[FTR for Streaming Destinations](https://www.notion.so/rudderstacks/AWS-FTR-for-streaming-destination-78b63869ac904ba49b0018a527ccb343)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
