### PR TITLE
chore:govet/fieldalignment

### DIFF
--- a/gateway/admin.go
+++ b/gateway/admin.go
@@ -43,9 +43,9 @@ type SqlRunner struct {
 }
 
 type SourceEvents struct {
-	Count int
 	Name  string
 	ID    string
+	Count int
 }
 
 func (r *SqlRunner) getUniqueSources() ([]SourceEvents, error) {
@@ -182,7 +182,7 @@ func (g *GatewayRPCHandler) GetDSStats(dsName string, result *string) (err error
 	for _, sourceEvent := range sources {
 		name, found := sourceIDToNameMap[sourceEvent.ID[1:len(sourceEvent.ID)-1]]
 		if found {
-			sourcesEventToCounts = append(sourcesEventToCounts, SourceEvents{sourceEvent.Count, name, sourceEvent.ID})
+			sourcesEventToCounts = append(sourcesEventToCounts, SourceEvents{name, sourceEvent.ID, sourceEvent.Count})
 		}
 	}
 	configSubscriberLock.RUnlock()

--- a/jobsdb/jobsdb_export.go
+++ b/jobsdb/jobsdb_export.go
@@ -146,13 +146,13 @@ func BuildStatus(job *JobT, jobState string) *JobStatusT {
 
 // SQLJobStatusT is a temporary struct to handle nulls from postgres query
 type SQLJobStatusT struct {
-	JobID         sql.NullInt64
-	JobState      sql.NullString // ENUM waiting, executing, succeeded, waiting_retry,  failed, aborted, migrated
-	AttemptNum    sql.NullInt64
 	ExecTime      sql.NullTime
 	RetryTime     sql.NullTime
-	ErrorCode     sql.NullString
 	ErrorResponse sql.NullString
+	JobState      sql.NullString
+	ErrorCode     sql.NullString
+	AttemptNum    sql.NullInt64
+	JobID         sql.NullInt64
 }
 
 func (jd *HandleT) getNonMigratedJobsFromDS(ds dataSetT, count int) ([]*JobT, error) {

--- a/jobsdb/jobsdb_export.go
+++ b/jobsdb/jobsdb_export.go
@@ -149,7 +149,7 @@ type SQLJobStatusT struct {
 	ExecTime      sql.NullTime
 	RetryTime     sql.NullTime
 	ErrorResponse sql.NullString
-	JobState      sql.NullString
+	JobState      sql.NullString // ENUM waiting, executing, succeeded, waiting_retry,  failed, aborted, migrated
 	ErrorCode     sql.NullString
 	AttemptNum    sql.NullInt64
 	JobID         sql.NullInt64

--- a/jobsdb/jobsdb_migration_checkpoints.go
+++ b/jobsdb/jobsdb_migration_checkpoints.go
@@ -13,8 +13,8 @@ import (
 // MigrationCheckpointT captures an event of export/import to recover from incase of a crash during migration
 type MigrationCheckpointT struct {
 	TimeStamp     time.Time       `json:"TimeStamp"`
-	Status        string          `json:"Status"`
-	MigrationType MigrationOp     `json:"MigrationType"`
+	Status        string          `json:"Status"`        // ENUM : Look up 'Values for Status'
+	MigrationType MigrationOp     `json:"MigrationType"` // ENUM : export, import, acceptNewEvents
 	FromNode      string          `json:"FromNode"`
 	FileLocation  string          `json:"FileLocation"`
 	ToNode        string          `json:"ToNode"`

--- a/jobsdb/jobsdb_migration_checkpoints.go
+++ b/jobsdb/jobsdb_migration_checkpoints.go
@@ -12,16 +12,16 @@ import (
 
 // MigrationCheckpointT captures an event of export/import to recover from incase of a crash during migration
 type MigrationCheckpointT struct {
-	ID            int64           `json:"ID"`
-	MigrationType MigrationOp     `json:"MigrationType"` // ENUM : export, import, acceptNewEvents
-	FromNode      string          `json:"FromNode"`
-	ToNode        string          `json:"ToNode"`
-	JobsCount     int64           `json:"JobsCount"`
-	FileLocation  string          `json:"FileLocation"`
-	Status        string          `json:"Status"` // ENUM : Look up 'Values for Status'
-	StartSeq      int64           `json:"StartSeq"`
-	Payload       json.RawMessage `json:"Payload"`
 	TimeStamp     time.Time       `json:"TimeStamp"`
+	Status        string          `json:"Status"`
+	MigrationType MigrationOp     `json:"MigrationType"`
+	FromNode      string          `json:"FromNode"`
+	FileLocation  string          `json:"FileLocation"`
+	ToNode        string          `json:"ToNode"`
+	Payload       json.RawMessage `json:"Payload"`
+	JobsCount     int64           `json:"JobsCount"`
+	ID            int64           `json:"ID"`
+	StartSeq      int64           `json:"StartSeq"`
 }
 
 // MigrationOp is a custom type for supported types in migrationCheckpoint
@@ -156,7 +156,18 @@ func NewSetupCheckpointEvent(migrationType MigrationOp, node string) MigrationCh
 
 // NewMigrationCheckpoint is a constructor for MigrationCheckpoint struct
 func NewMigrationCheckpoint(migrationType MigrationOp, fromNode, toNode string, jobsCount int64, fileLocation, status string, startSeq int64) MigrationCheckpointT {
-	return MigrationCheckpointT{0, migrationType, fromNode, toNode, jobsCount, fileLocation, status, startSeq, []byte("{}"), time.Now()}
+	return MigrationCheckpointT{
+		time.Now(),
+		status,
+		migrationType,
+		fromNode,
+		fileLocation,
+		toNode,
+		[]byte("{}"),
+		jobsCount,
+		0,
+		startSeq,
+	}
 }
 
 // SetupForMigration prepares jobsdb to start migrations

--- a/jobsdb/queued_db_request.go
+++ b/jobsdb/queued_db_request.go
@@ -44,10 +44,10 @@ const (
 )
 
 type dbRequest struct {
-	reqType dbReqType
-	name    string
 	tags    *statTags
 	command func() interface{}
+	name    string
+	reqType dbReqType
 }
 
 func newReadDbRequest(name string, tags *statTags, command func() interface{}) *dbRequest {

--- a/jobsdb/readonly_jobsdb.go
+++ b/jobsdb/readonly_jobsdb.go
@@ -34,9 +34,9 @@ type ReadonlyJobsDB interface {
 }
 
 type ReadonlyHandleT struct {
+	logger      logger.LoggerI
 	DbHandle    *sql.DB
 	tablePrefix string
-	logger      logger.LoggerI
 }
 
 type DSPair struct {
@@ -53,24 +53,24 @@ type EventStatusDetailed struct {
 }
 
 type EventStatusStats struct {
-	StatsNums []EventStatusDetailed
 	DSList    string
+	StatsNums []EventStatusDetailed
 }
 
 type FailedJobs struct {
-	JobID         int
+	ExecTime      time.Time
 	UserID        string
 	CustomVal     string
-	ExecTime      time.Time
 	ErrorCode     string
 	ErrorResponse string
+	JobID         int
 }
 
 type ErrorCodeCountsByDestination struct {
-	Count         int
 	ErrorCode     string
 	Destination   string
 	DestinationID string
+	Count         int
 }
 
 type ErrorCodeCountStats struct {

--- a/processor/integrations/integrations.go
+++ b/processor/integrations/integrations.go
@@ -53,9 +53,10 @@ type PostParametersT struct {
 	Headers       map[string]interface{} `json:"headers"`
 	QueryParams   map[string]interface{} `json:"params"`
 	RequestMethod string                 `json:"method"`
-	UserID        string                 `json:"userId,,optional"`
-	Type          string                 `json:"type"`
-	URL           string                 `json:"endpoint"`
+	// Invalid tag used in struct. skipcq: SCC-SA5008
+	UserID string `json:"userId,,optional"` //nolint:staticcheck
+	Type   string `json:"type"`
+	URL    string `json:"endpoint"`
 }
 
 type TransStatsT struct {

--- a/processor/integrations/integrations.go
+++ b/processor/integrations/integrations.go
@@ -48,15 +48,14 @@ const (
 // optional is a custom tag introduced by us and is handled by GetMandatoryJSONFieldNames. Its intentionally added
 // after two commas because the tag that comes after the first comma should be known by json parser
 type PostParametersT struct {
-	Type          string `json:"type"`
-	URL           string `json:"endpoint"`
-	RequestMethod string `json:"method"`
-	// Invalid tag used in struct. skipcq: SCC-SA5008
-	UserID      string                 `json:"userId,,optional"` //nolint:staticcheck
-	Headers     map[string]interface{} `json:"headers"`
-	QueryParams map[string]interface{} `json:"params"`
-	Body        map[string]interface{} `json:"body"`
-	Files       map[string]interface{} `json:"files"`
+	Body          map[string]interface{} `json:"body"`
+	Files         map[string]interface{} `json:"files"`
+	Headers       map[string]interface{} `json:"headers"`
+	QueryParams   map[string]interface{} `json:"params"`
+	RequestMethod string                 `json:"method"`
+	UserID        string                 `json:"userId,,optional"`
+	Type          string                 `json:"type"`
+	URL           string                 `json:"endpoint"`
 }
 
 type TransStatsT struct {

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -34,36 +34,35 @@ const (
 var jsonfast = jsoniter.ConfigCompatibleWithStandardLibrary
 
 type MetadataT struct {
-	SourceID            string                            `json:"sourceId"`
-	WorkspaceID         string                            `json:"workspaceId"`
-	Namespace           string                            `json:"namespace"`
-	InstanceID          string                            `json:"instanceId"`
-	SourceType          string                            `json:"sourceType"`
-	SourceCategory      string                            `json:"sourceCategory"`
-	TrackingPlanId      string                            `json:"trackingPlanId"`
-	TrackingPlanVersion int                               `json:"trackingPlanVersion"`
-	SourceTpConfig      map[string]map[string]interface{} `json:"sourceTpConfig"`
-	MergedTpConfig      map[string]interface{}            `json:"mergedTpConfig"`
-	DestinationID       string                            `json:"destinationId"`
-	JobRunID            string                            `json:"jobRunId"`
-	JobID               int64                             `json:"jobId"`
-	SourceBatchID       string                            `json:"sourceBatchId"`
-	SourceJobID         string                            `json:"sourceJobId"`
-	SourceJobRunID      string                            `json:"sourceJobRunId"`
-	SourceTaskID        string                            `json:"sourceTaskId"`
-	SourceTaskRunID     string                            `json:"sourceTaskRunId"`
-	RecordID            interface{}                       `json:"recordId"`
-	DestinationType     string                            `json:"destinationType"`
-	MessageID           string                            `json:"messageId"`
-	OAuthAccessToken    string                            `json:"oauthAccessToken"`
-	// set by user_transformer to indicate transformed event is part of group indicated by messageIDs
-	MessageIDs              []string `json:"messageIds"`
-	RudderID                string   `json:"rudderId"`
-	ReceivedAt              string   `json:"receivedAt"`
-	EventName               string   `json:"eventName"`
-	EventType               string   `json:"eventType"`
-	SourceDefinitionID      string   `json:"sourceDefinitionId"`
-	DestinationDefinitionID string   `json:"destinationDefinitionId"`
+	RecordID                interface{}                       `json:"recordId"`
+	SourceTpConfig          map[string]map[string]interface{} `json:"sourceTpConfig"`
+	MergedTpConfig          map[string]interface{}            `json:"mergedTpConfig"`
+	SourceID                string                            `json:"sourceId"`
+	SourceType              string                            `json:"sourceType"`
+	SourceCategory          string                            `json:"sourceCategory"`
+	TrackingPlanId          string                            `json:"trackingPlanId"`
+	SourceDefinitionID      string                            `json:"sourceDefinitionId"`
+	InstanceID              string                            `json:"instanceId"`
+	Namespace               string                            `json:"namespace"`
+	DestinationID           string                            `json:"destinationId"`
+	JobRunID                string                            `json:"jobRunId"`
+	EventType               string                            `json:"eventType"`
+	SourceBatchID           string                            `json:"sourceBatchId"`
+	SourceJobID             string                            `json:"sourceJobId"`
+	SourceJobRunID          string                            `json:"sourceJobRunId"`
+	SourceTaskID            string                            `json:"sourceTaskId"`
+	SourceTaskRunID         string                            `json:"sourceTaskRunId"`
+	WorkspaceID             string                            `json:"workspaceId"`
+	DestinationType         string                            `json:"destinationType"`
+	MessageID               string                            `json:"messageId"`
+	OAuthAccessToken        string                            `json:"oauthAccessToken"`
+	EventName               string                            `json:"eventName"`
+	RudderID                string                            `json:"rudderId"`
+	ReceivedAt              string                            `json:"receivedAt"`
+	DestinationDefinitionID string                            `json:"destinationDefinitionId"`
+	MessageIDs              []string                          `json:"messageIds"`
+	JobID                   int64                             `json:"jobId"`
+	TrackingPlanVersion     int                               `json:"trackingPlanVersion"`
 }
 
 type TransformerEventT struct {
@@ -121,18 +120,17 @@ func loadConfig() {
 }
 
 type TransformerResponseT struct {
-	// Not marking this Singular Event, since this not a RudderEvent
 	Output           map[string]interface{} `json:"output"`
 	Metadata         MetadataT              `json:"metadata"`
-	StatusCode       int                    `json:"statusCode"`
 	Error            string                 `json:"error"`
 	ValidationErrors []ValidationErrorT     `json:"validationErrors"`
+	StatusCode       int                    `json:"statusCode"`
 }
 
 type ValidationErrorT struct {
+	Meta    map[string]string `json:"meta"`
 	Type    string            `json:"type"`
 	Message string            `json:"message"`
-	Meta    map[string]string `json:"meta"`
 }
 
 // Setup initializes this class

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -60,9 +60,10 @@ type MetadataT struct {
 	RudderID                string                            `json:"rudderId"`
 	ReceivedAt              string                            `json:"receivedAt"`
 	DestinationDefinitionID string                            `json:"destinationDefinitionId"`
-	MessageIDs              []string                          `json:"messageIds"`
-	JobID                   int64                             `json:"jobId"`
-	TrackingPlanVersion     int                               `json:"trackingPlanVersion"`
+	// set by user_transformer to indicate transformed event is part of group indicated by messageIDs
+	MessageIDs          []string `json:"messageIds"`
+	JobID               int64    `json:"jobId"`
+	TrackingPlanVersion int      `json:"trackingPlanVersion"`
 }
 
 type TransformerEventT struct {
@@ -120,6 +121,7 @@ func loadConfig() {
 }
 
 type TransformerResponseT struct {
+	// Not marking this Singular Event, since this not a RudderEvent
 	Output           map[string]interface{} `json:"output"`
 	Metadata         MetadataT              `json:"metadata"`
 	Error            string                 `json:"error"`

--- a/processor/transformqueue.go
+++ b/processor/transformqueue.go
@@ -7,8 +7,8 @@ import (
 )
 
 type TransformRequestT struct {
-	Event          []transformer.TransformerEventT
 	Stage          string
+	Event          []transformer.TransformerEventT
 	ProcessingTime float64
 	Index          int
 }

--- a/router/admin.go
+++ b/router/admin.go
@@ -71,33 +71,33 @@ func (ra *Admin) Status() interface{} {
 }
 
 type RouterRpcHandler struct {
-	jobsDBPrefix          string
 	readonlyRouterDB      jobsdb.ReadonlyJobsDB
 	readonlyBatchRouterDB jobsdb.ReadonlyJobsDB
+	jobsDBPrefix          string
 }
 
 type JobCountsByStateAndDestination struct {
-	Count       int
 	State       string
 	Destination string
+	Count       int
 }
 
 type ErrorCodeCountsByDestination struct {
-	Count         int
 	ErrorCode     string
 	Destination   string
 	DestinationID string
+	Count         int
 }
 
 type JobCountByConnections struct {
-	Count         int
 	SourceId      string
 	DestinationId string
+	Count         int
 }
 
 type LatestJobStatusCounts struct {
-	Count int
 	State string
+	Count int
 	Rank  int
 }
 

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -96,9 +96,9 @@ type HandleT struct {
 	asyncDestinationStruct      map[string]*asyncdestinationmanager.AsyncDestinationStruct
 	processQ                    chan *BatchDestinationDataT
 	netHandle                   *http.Client
-	connectionWHNamespaceMap    map[string]string
+	connectionWHNamespaceMap    map[string]string // connectionIdentifier -> warehouseConnectionIdentifier(+namepsace)
 	inProgressMap               map[string]bool
-	destinationsMap             map[string]*router_utils.BatchDestinationT
+	destinationsMap             map[string]*router_utils.BatchDestinationT // destinationID -> destination
 	lastExecMap                 map[string]int64
 	backendConfigInitialized    chan bool
 	uploadedRawDataJobsCache    map[string]map[string]bool

--- a/router/customdestinationmanager/customdestinationmanager.go
+++ b/router/customdestinationmanager/customdestinationmanager.go
@@ -43,18 +43,16 @@ type DestinationManager interface {
 
 // CustomManagerT handles this module
 type CustomManagerT struct {
-	destType    string
-	managerType string
-
-	stateMu  sync.RWMutex // protecting all 4 maps below
-	config   map[string]backendconfig.DestinationT
-	breaker  map[string]breakerHolder
-	clientMu map[string]*sync.RWMutex
-	client   map[string]*clientHolder
-
-	timeout                  time.Duration
-	breakerTimeout           time.Duration
+	client                   map[string]*clientHolder
+	config                   map[string]backendconfig.DestinationT
+	breaker                  map[string]breakerHolder
+	clientMu                 map[string]*sync.RWMutex
 	backendConfigInitialized chan struct{}
+	managerType              string
+	destType                 string
+	breakerTimeout           time.Duration
+	timeout                  time.Duration
+	stateMu                  sync.RWMutex
 }
 
 // clientHolder keeps the config of a destination and corresponding producer for a stream destination

--- a/router/customdestinationmanager/customdestinationmanager.go
+++ b/router/customdestinationmanager/customdestinationmanager.go
@@ -52,7 +52,7 @@ type CustomManagerT struct {
 	destType                 string
 	breakerTimeout           time.Duration
 	timeout                  time.Duration
-	stateMu                  sync.RWMutex
+	stateMu                  sync.RWMutex // protecting all 4 maps above
 }
 
 // clientHolder keeps the config of a destination and corresponding producer for a stream destination


### PR DESCRIPTION
# Description

From the recent golang-weekly edition: https://www.ribice.ba/golang-memory-savings/

> govet/fieldalignment: A part of gotools and govet linter, fieldalignment prints out misaligned structs and the current/ideal size of struct.

```
➜  go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest
➜  jobsdb git:(master) ✗ fieldalignment -fix  .
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb.go:64:21: struct with 16 pointer bytes could be 8
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb.go:79:22: struct with 64 pointer bytes could be 56
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb.go:90:22: struct with 64 pointer bytes could be 56
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb.go:323:17: struct with 152 pointer bytes could be 128
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb.go:345:11: struct with 336 pointer bytes could be 288
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb.go:376:20: struct with 72 pointer bytes could be 40
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb.go:385:21: struct with 200 pointer bytes could be 176
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb.go:401:14: struct of size 728 could be 704
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb.go:459:20: struct with 16 pointer bytes could be 8
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb.go:465:24: struct with 64 pointer bytes could be 56
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb.go:564:16: struct with 16 pointer bytes could be 8
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb.go:2367:17: struct with 40 pointer bytes could be 32
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb.go:3672:20: struct with 40 pointer bytes could be 24
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb_export.go:148:20: struct with 152 pointer bytes could be 120
/Users/sid/bup-rudder/rudder-server/jobsdb/jobsdb_migration_checkpoints.go:14:27: struct with 152 pointer bytes could be 112
/Users/sid/bup-rudder/rudder-server/jobsdb/queued_db_request.go:46:16: struct with 40 pointer bytes could be 24
/Users/sid/bup-rudder/rudder-server/jobsdb/readonly_jobsdb.go:36:22: struct with 40 pointer bytes could be 32
/Users/sid/bup-rudder/rudder-server/jobsdb/readonly_jobsdb.go:55:23: struct with 32 pointer bytes could be 24
/Users/sid/bup-rudder/rudder-server/jobsdb/readonly_jobsdb.go:60:17: struct with 88 pointer bytes could be 80
/Users/sid/bup-rudder/rudder-server/jobsdb/readonly_jobsdb.go:69:35: struct with 48 pointer bytes could be 40
```


## Notion Ticket

< Replace with Notion Link >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
