### PR TITLE
fix(router): handle transformer in/out inconsistencies

### DIFF
--- a/mocks/router/transformer/mock_transformer.go
+++ b/mocks/router/transformer/mock_transformer.go
@@ -7,7 +7,6 @@ package mocks_transformer
 import (
 	context "context"
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	transformer "github.com/rudderlabs/rudder-server/router/transformer"
@@ -51,18 +50,6 @@ func (m *MockTransformer) ProxyRequest(arg0 context.Context, arg1 *transformer.P
 func (mr *MockTransformerMockRecorder) ProxyRequest(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProxyRequest", reflect.TypeOf((*MockTransformer)(nil).ProxyRequest), arg0, arg1)
-}
-
-// Setup mocks base method.
-func (m *MockTransformer) Setup(arg0, arg1 time.Duration) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Setup", arg0, arg1)
-}
-
-// Setup indicates an expected call of Setup.
-func (mr *MockTransformerMockRecorder) Setup(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setup", reflect.TypeOf((*MockTransformer)(nil).Setup), arg0, arg1)
 }
 
 // Transform mocks base method.

--- a/router/admin.go
+++ b/router/admin.go
@@ -332,7 +332,8 @@ func getFailedStatusErrorCodeCountsByDestination(dbHandle *sql.DB, dsName, jobsD
 	return err
 }
 
-/*JobCountByConnections
+/*
+JobCountByConnections
 ================================================================================
 │───────│───────────────────────────────│───────────────────────────────│
 │ COUNT │ SOURCEID                      │ DESTINATIONID                 │

--- a/router/router.go
+++ b/router/router.go
@@ -316,22 +316,6 @@ func (worker *workerT) batch(routerJobs []types.RouterJobT) []types.DestinationJ
 	worker.rt.batchOutputCountStat.Count(len(destinationJobs))
 	worker.recordStatsForFailedTransforms("batch", destinationJobs)
 
-	var totalJobMetadataCount int
-	for _, destinationJob := range destinationJobs {
-		totalJobMetadataCount += len(destinationJob.JobMetadataArray)
-	}
-
-	if inputJobsLength != totalJobMetadataCount {
-		worker.rt.batchInputOutputDiffCountStat.Count(inputJobsLength - totalJobMetadataCount)
-
-		worker.rt.logger.Errorf("[%v Router] :: Total input jobs count:%d did not match total job metadata count:%d returned from batch transformer", worker.rt.destName, inputJobsLength, totalJobMetadataCount)
-		jobIDs := make([]string, len(routerJobs))
-		for idx, routerJob := range routerJobs {
-			jobIDs[idx] = fmt.Sprintf("%v", routerJob.JobMetadata.JobID)
-		}
-		worker.rt.logger.Errorf("[%v Router] :: Job ids : %s", worker.rt.destName, strings.Join(jobIDs, ", "))
-	}
-
 	return destinationJobs
 }
 
@@ -491,7 +475,6 @@ func (worker *workerT) processDestinationJobs() {
 	var respStatusCode, prevRespStatusCode int
 	var respBody string
 	var respBodyTemp string
-	handledJobMetadatas := make(map[int64]*types.JobMetadataT)
 
 	var destinationResponseHandler ResponseHandlerI
 	worker.rt.configSubscriberLock.RLock()
@@ -729,7 +712,6 @@ func (worker *workerT) processDestinationJobs() {
 
 		for _, destinationJobMetadata := range _destinationJob.JobMetadataArray {
 			_destinationJobMetadata := destinationJobMetadata
-			handledJobMetadatas[destinationJobMetadata.JobID] = &_destinationJobMetadata
 			// assigning the destinationJobMetadata to a local variable (_destinationJobMetadata), so that
 			// elements in routerJobResponses have pointer to the right destinationJobMetadata.
 
@@ -740,28 +722,6 @@ func (worker *workerT) processDestinationJobs() {
 				respStatusCode:         respStatusCode,
 				respBody:               respBody,
 				attemptedToSendTheJob:  attemptedToSendTheJob,
-			})
-		}
-	}
-
-	// if batching/routerTransform is enabled, we need to make sure that all the routerJobs status are written to DB.
-	// if in any case transformer doesn't send all the job ids back, setting their statuses as failed
-	for _, routerJob := range worker.routerJobs {
-		// assigning the routerJob to a local variable (_routerJob), so that
-		// elements in routerJobResponses have pointer to the right job.
-		_routerJob := routerJob
-		if _, ok := handledJobMetadatas[_routerJob.JobMetadata.JobID]; !ok {
-			routerJobResponses = append(routerJobResponses, &JobResponse{
-				jobID: _routerJob.JobMetadata.JobID,
-				destinationJob: &types.DestinationJobT{
-					Destination:      _routerJob.Destination,
-					Message:          _routerJob.Message,
-					JobMetadataArray: []types.JobMetadataT{_routerJob.JobMetadata},
-				},
-				destinationJobMetadata: &_routerJob.JobMetadata,
-				respStatusCode:         500,
-				respBody:               "transformer failed to handle this job",
-				attemptedToSendTheJob:  false,
 			})
 		}
 	}
@@ -2167,8 +2127,7 @@ func (rt *HandleT) Setup(backendConfig backendconfig.BackendConfig, jobsDB jobsd
 
 	rt.routerResponseTransformStat = stats.NewTaggedStat("response_transform_latency", stats.TimerType, stats.Tags{"destType": rt.destName})
 
-	rt.transformer = transformer.NewTransformer()
-	rt.transformer.Setup(rt.netClientTimeout, rt.backendProxyTimeout)
+	rt.transformer = transformer.NewTransformer(rt.netClientTimeout, rt.backendProxyTimeout)
 
 	rt.oauth = oauth.NewOAuthErrorHandler(backendConfig)
 	rt.oauth.Setup()

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -30,23 +30,22 @@ var jsonfast = jsoniter.ConfigCompatibleWithStandardLibrary
 const (
 	BATCH            = "BATCH"
 	ROUTER_TRANSFORM = "ROUTER_TRANSFORM"
+	apiVersionHeader = "apiVersion"
 )
 
-// HandleT is the handle for this class
-type HandleT struct {
+// handle is the handle for this class
+type handle struct {
 	tr *http.Transport
 	// http client for router transformation request
 	client *http.Client
 	// Mockable http.client for transformer proxy request
-	tfProxyClient sysUtils.HTTPClientI
+	proxyClient sysUtils.HTTPClientI
 	// http client timeout for transformer proxy request
-	tfProxyTimeout time.Duration
+	destinationTimeout time.Duration
 	// http client timeout for server-transformer request
-	serverTfTimeout                    time.Duration
-	transformRequestTimerStat          stats.RudderStats
-	transformerNetworkRequestTimerStat stats.RudderStats
-	transformerProxyRequestTime        stats.RudderStats
-	logger                             logger.LoggerI
+	transformTimeout          time.Duration
+	transformRequestTimerStat stats.RudderStats
+	logger                    logger.LoggerI
 }
 
 type ProxyRequestParams struct {
@@ -56,22 +55,17 @@ type ProxyRequestParams struct {
 	BaseUrl      string
 }
 
-type httpProxyResponse struct {
-	respData   []byte
-	statusCode int
-	err        error
-}
-
 // Transformer provides methods to transform events
 type Transformer interface {
-	Setup(timeout, srvTfTimeout time.Duration)
 	Transform(transformType string, transformMessage *types.TransformMessageT) []types.DestinationJobT
 	ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequestParams) (statusCode int, respBody, contentType string)
 }
 
 // NewTransformer creates a new transformer
-func NewTransformer() *HandleT {
-	return &HandleT{}
+func NewTransformer(netClientTimeout, backendProxyTimeout time.Duration) Transformer {
+	handle := &handle{}
+	handle.setup(netClientTimeout, backendProxyTimeout)
+	return handle
 }
 
 var (
@@ -91,7 +85,7 @@ func Init() {
 }
 
 // Transform transforms router jobs to destination jobs
-func (trans *HandleT) Transform(transformType string, transformMessage *types.TransformMessageT) []types.DestinationJobT {
+func (trans *handle) Transform(transformType string, transformMessage *types.TransformMessageT) []types.DestinationJobT {
 	// Call remote transformation
 	rawJSON, err := jsonfast.Marshal(transformMessage)
 	if err != nil {
@@ -154,7 +148,7 @@ func (trans *HandleT) Transform(transformType string, transformMessage *types.Tr
 
 	var destinationJobs []types.DestinationJobT
 	if resp.StatusCode == http.StatusOK {
-		transformerAPIVersion, convErr := strconv.Atoi(resp.Header.Get("apiVersion"))
+		transformerAPIVersion, convErr := strconv.Atoi(resp.Header.Get(apiVersionHeader))
 		if convErr != nil {
 			transformerAPIVersion = 0
 		}
@@ -172,17 +166,49 @@ func (trans *HandleT) Transform(transformType string, transformMessage *types.Tr
 			integrations.CollectIntgTransformErrorStats([]byte(gjson.GetBytes(respData, "output").Raw))
 			err = jsonfast.Unmarshal([]byte(gjson.GetBytes(respData, "output").Raw), &destinationJobs)
 		}
-		// This is returned by our JS engine so should  be parsable
-		// but still handling it
+
+		// Validate the response received from the transformer
+		in := transformMessage.JobIDs()
+		out := make(map[int64]struct{})
+		invalid := make(map[int64]struct{}) // invalid jobIDs are the ones that are in the response but were not included in the request
+		for i := range destinationJobs {
+			for k, v := range destinationJobs[i].JobIDs() {
+				out[k] = v
+				if _, ok := in[k]; !ok {
+					invalid[k] = v
+				}
+			}
+		}
+		var invalidResponseReason, invalidResponseError string
 		if err != nil {
-			// NOTE: Transformer failed to give response in the right format
+			invalidResponseReason = "unmarshal error"
+			invalidResponseError = fmt.Sprintf("Transformer returned invalid response: %s for input: %s", string(respData), string(rawJSON))
+		} else if len(in) != len(out) {
+			invalidResponseReason = "in out mismatch"
+			invalidResponseError = fmt.Sprintf("Transformer returned invalid output size: %d for input size: %d", len(out), len(in))
+		} else if len(invalid) > 0 {
+			var invalidSlice []int64
+			for k := range invalid {
+				invalidSlice = append(invalidSlice, k)
+			}
+			invalidResponseReason = "invalid jobIDs"
+			invalidResponseError = fmt.Sprintf("Transformer returned invalid jobIDs: %v", invalidSlice)
+		}
+
+		if invalidResponseReason != "" {
+
+			trans.logger.Error(invalidResponseError)
+			stats.DefaultStats.NewTaggedStat(`router.transformer.invalid.response`, stats.CountType, stats.Tags{
+				"destType": transformMessage.DestType,
+				"reason":   invalidResponseReason,
+			}).Increment()
+
 			// Retrying. Go and fix transformer.
-			destinationJobs = []types.DestinationJobT{}
 			statusCode := 500
-			errorResp := fmt.Sprintf("Transformer returned invalid response: %s for input: %s", string(respData), string(rawJSON))
-			trans.logger.Error(errorResp)
-			for _, routerJob := range transformMessage.Data {
-				resp := types.DestinationJobT{Message: routerJob.Message, JobMetadataArray: []types.JobMetadataT{routerJob.JobMetadata}, Destination: routerJob.Destination, Batched: false, StatusCode: statusCode, Error: errorResp}
+			destinationJobs = []types.DestinationJobT{}
+			for i := range transformMessage.Data {
+				routerJob := &transformMessage.Data[i]
+				resp := types.DestinationJobT{Message: routerJob.Message, JobMetadataArray: []types.JobMetadataT{routerJob.JobMetadata}, Destination: routerJob.Destination, StatusCode: statusCode, Error: invalidResponseError}
 				destinationJobs = append(destinationJobs, resp)
 			}
 		}
@@ -191,8 +217,9 @@ func (trans *HandleT) Transform(transformType string, transformMessage *types.Tr
 		if resp.StatusCode == http.StatusNotFound {
 			statusCode = 404
 		}
-		for _, routerJob := range transformMessage.Data {
-			resp := types.DestinationJobT{Message: routerJob.Message, JobMetadataArray: []types.JobMetadataT{routerJob.JobMetadata}, Destination: routerJob.Destination, Batched: false, StatusCode: statusCode, Error: string(respData)}
+		for i := range transformMessage.Data {
+			routerJob := &transformMessage.Data[i]
+			resp := types.DestinationJobT{Message: routerJob.Message, JobMetadataArray: []types.JobMetadataT{routerJob.JobMetadata}, Destination: routerJob.Destination, StatusCode: statusCode, Error: string(respData)}
 			destinationJobs = append(destinationJobs, resp)
 		}
 	}
@@ -201,12 +228,12 @@ func (trans *HandleT) Transform(transformType string, transformMessage *types.Tr
 	return destinationJobs
 }
 
-func (trans *HandleT) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequestParams) (int, string, string) {
+func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequestParams) (int, string, string) {
 	stats.NewTaggedStat("transformer_proxy.delivery_request", stats.CountType, stats.Tags{"destType": proxyReqParams.DestName}).Increment()
 	trans.logger.Debugf(`[TransformerProxy] (Dest-%[1]v) {Job - %[2]v} Proxy Request starts - %[1]v`, proxyReqParams.DestName, proxyReqParams.JobID)
 
 	rdlTime := time.Now()
-	httpPrxResp := trans.makeTfProxyRequest(ctx, proxyReqParams)
+	httpPrxResp := trans.doProxyRequest(ctx, proxyReqParams)
 	respData, respCode, requestError := httpPrxResp.respData, httpPrxResp.statusCode, httpPrxResp.err
 	reqSuccessStr := strconv.FormatBool(requestError == nil)
 	stats.NewTaggedStat("transformer_proxy.request_latency", stats.TimerType, stats.Tags{"requestSuccess": reqSuccessStr, "destType": proxyReqParams.DestName}).SendTiming(time.Since(rdlTime))
@@ -244,25 +271,29 @@ func (trans *HandleT) ProxyRequest(ctx context.Context, proxyReqParams *ProxyReq
 	return respCode, string(respData), "application/json"
 }
 
-func (trans *HandleT) Setup(netClientTimeout, serverTfTimeout time.Duration) {
+func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration) {
 	trans.logger = pkgLogger
 	trans.tr = &http.Transport{}
 	// The timeout between server and transformer
 	// Basically this timeout is more for communication between transformer and server
-	trans.serverTfTimeout = serverTfTimeout
+	trans.transformTimeout = transformTimeout
 	// Destination API timeout
 	// Basically this timeout we will configure when we make final call to destination to send event
-	trans.tfProxyTimeout = netClientTimeout
+	trans.destinationTimeout = destinationTimeout
 	// This client is used for Router Transformation
-	trans.client = &http.Client{Transport: trans.tr, Timeout: trans.serverTfTimeout}
+	trans.client = &http.Client{Transport: trans.tr, Timeout: trans.transformTimeout}
 	// This client is used for Transformer Proxy(delivered from transformer to destination)
-	trans.tfProxyClient = &http.Client{Transport: trans.tr, Timeout: trans.tfProxyTimeout + trans.serverTfTimeout}
+	trans.proxyClient = &http.Client{Transport: trans.tr, Timeout: trans.destinationTimeout + trans.transformTimeout}
 	trans.transformRequestTimerStat = stats.DefaultStats.NewStat("router.transformer_request_time", stats.TimerType)
-	trans.transformerNetworkRequestTimerStat = stats.DefaultStats.NewStat("router.transformer_network_request_time", stats.TimerType)
-	trans.transformerProxyRequestTime = stats.DefaultStats.NewStat("router.transformer_response_transform_time", stats.TimerType)
 }
 
-func (trans *HandleT) makeTfProxyRequest(ctx context.Context, proxyReqParams *ProxyRequestParams) httpProxyResponse {
+type httpProxyResponse struct {
+	respData   []byte
+	statusCode int
+	err        error
+}
+
+func (trans *handle) doProxyRequest(ctx context.Context, proxyReqParams *ProxyRequestParams) httpProxyResponse {
 	var respData []byte
 
 	baseUrl := proxyReqParams.BaseUrl
@@ -284,13 +315,13 @@ func (trans *HandleT) makeTfProxyRequest(ctx context.Context, proxyReqParams *Pr
 		}
 	}
 	req.Header.Set("Content-Type", "application/json")
-	trans.logger.Debugf("[TransformerProxy] Timeout for %[1]s = %[2]v ms \n", destName, strconv.FormatInt((trans.tfProxyTimeout+trans.serverTfTimeout).Milliseconds(), 10))
+	trans.logger.Debugf("[TransformerProxy] Timeout for %[1]s = %[2]v ms \n", destName, strconv.FormatInt((trans.destinationTimeout+trans.transformTimeout).Milliseconds(), 10))
 	// Make use of this header to set timeout in the transfomer's http client
 	// The header name may be worked out ?
-	req.Header.Set("RdProxy-Timeout", strconv.FormatInt(trans.tfProxyTimeout.Milliseconds(), 10))
+	req.Header.Set("RdProxy-Timeout", strconv.FormatInt(trans.destinationTimeout.Milliseconds(), 10))
 
 	httpReqStTime := time.Now()
-	resp, err := trans.tfProxyClient.Do(req)
+	resp, err := trans.proxyClient.Do(req)
 	reqRoundTripTime := time.Since(httpReqStTime)
 	// This stat will be useful in understanding the round trip time taken for the http req
 	// between server and transformer

--- a/router/types/types.go
+++ b/router/types/types.go
@@ -24,11 +24,20 @@ type RouterJobT struct {
 // and metadata of all the router jobs from which this job is cooked up
 type DestinationJobT struct {
 	Message          json.RawMessage            `json:"batchedRequest"`
-	JobMetadataArray []JobMetadataT             `json:"metadata"`
+	JobMetadataArray []JobMetadataT             `json:"metadata"` // multiple jobs may be batched in a single message
 	Destination      backendconfig.DestinationT `json:"destination"`
 	Batched          bool                       `json:"batched"`
 	StatusCode       int                        `json:"statusCode"`
 	Error            string                     `json:"error"`
+}
+
+// JobIDs returns the set of all job ids contained in the message
+func (dj *DestinationJobT) JobIDs() map[int64]struct{} {
+	jobIDs := make(map[int64]struct{})
+	for i := range dj.JobMetadataArray {
+		jobIDs[dj.JobMetadataArray[i].JobID] = struct{}{}
+	}
+	return jobIDs
 }
 
 // JobMetadataT holds the job metadata
@@ -52,4 +61,13 @@ type JobMetadataT struct {
 type TransformMessageT struct {
 	Data     []RouterJobT `json:"input"`
 	DestType string       `json:"destType"`
+}
+
+// JobIDs returns the set of all job ids of the jobs in the message
+func (tm *TransformMessageT) JobIDs() map[int64]struct{} {
+	jobIDs := make(map[int64]struct{})
+	for i := range tm.Data {
+		jobIDs[tm.Data[i].JobMetadata.JobID] = struct{}{}
+	}
+	return jobIDs
 }


### PR DESCRIPTION
# Description

During router transform, the transformer may erroneously return more than 1 job per input jobID. This results in: 
- sending the same event multiple times to the destination, 
- messing with our statistics (negative pending events & rsources in/out inconsistency)

This change introduces two additional validations during router's `transformer.Transform`:
1. Validate that job numbers match (`in` equals `out`)
2. Validate that job ids match between `in` and `out` jobs

If any of the above validations fail, all jobs of this transformation request will be marked as failed (HTTP 500) so that they can be retried later.
Additionally, a new counter has been introduced `router.transformer.invalid.response` against which an alert can be configured to get notified about such errors.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=b3ef63c8b066467ba9dd6dcaf3bef09b&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
