### PR TITLE
chore(warehouse): batching clickhouse cluster alter statements

### DIFF
--- a/warehouse/clickhouse/clickhouse_test.go
+++ b/warehouse/clickhouse/clickhouse_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/rudderlabs/rudder-server/warehouse/clickhouse"
@@ -264,22 +265,21 @@ func initializeClickhouseClusterMode(t *testing.T) {
 	// Alter columns to all the cluster tables
 	for _, clusterDB := range handle.ClusterDBs {
 		for tableName, columnInfos := range tableColumnInfoMap {
+			sqlStatement := fmt.Sprintf(`
+			ALTER TABLE rudderdb.%[1]s_shard`,
+				tableName,
+			)
 			for _, columnInfo := range columnInfos {
-				sqlStatement := fmt.Sprintf(`
-					ALTER TABLE
-					  rudderdb.% [1]s_shard
-					ADD
-					  COLUMN IF NOT EXISTS % [2]s % [3]s;
-				`,
-					tableName,
+				sqlStatement += fmt.Sprintf(`
+					ADD COLUMN IF NOT EXISTS %[1]s %[2]s,`,
 					columnInfo.ColumnName,
 					columnInfo.ColumnType,
 				)
-				log.Printf("Altering columns for distribution view for clickhouse cluster with sqlStatement: %s", sqlStatement)
-
-				_, err := clusterDB.Exec(sqlStatement)
-				require.NoError(t, err)
 			}
+			sqlStatement = strings.TrimSuffix(sqlStatement, ",")
+			log.Printf("Altering columns for distribution view for clickhouse cluster with sqlStatement: %s", sqlStatement)
+			_, err := clusterDB.Exec(sqlStatement)
+			require.NoError(t, err)
 		}
 	}
 }

--- a/warehouse/clickhouse/clickhouse_test.go
+++ b/warehouse/clickhouse/clickhouse_test.go
@@ -286,7 +286,6 @@ func initializeClickhouseClusterMode(t *testing.T) {
 
 func TestClickHouseIntegration(t *testing.T) {
 	t.Run("Single Setup", func(t *testing.T) {
-		t.Skip()
 		t.Parallel()
 
 		// Setting up the warehouseTest

--- a/warehouse/clickhouse/clickhouse_test.go
+++ b/warehouse/clickhouse/clickhouse_test.go
@@ -266,7 +266,7 @@ func initializeClickhouseClusterMode(t *testing.T) {
 	for _, clusterDB := range handle.ClusterDBs {
 		for tableName, columnInfos := range tableColumnInfoMap {
 			sqlStatement := fmt.Sprintf(`
-			ALTER TABLE rudderdb.%[1]s_shard`,
+				ALTER TABLE rudderdb.%[1]s_shard`,
 				tableName,
 			)
 			for _, columnInfo := range columnInfos {
@@ -278,6 +278,7 @@ func initializeClickhouseClusterMode(t *testing.T) {
 			}
 			sqlStatement = strings.TrimSuffix(sqlStatement, ",")
 			log.Printf("Altering columns for distribution view for clickhouse cluster with sqlStatement: %s", sqlStatement)
+			
 			_, err := clusterDB.Exec(sqlStatement)
 			require.NoError(t, err)
 		}

--- a/warehouse/clickhouse/clickhouse_test.go
+++ b/warehouse/clickhouse/clickhouse_test.go
@@ -278,7 +278,7 @@ func initializeClickhouseClusterMode(t *testing.T) {
 			}
 			sqlStatement = strings.TrimSuffix(sqlStatement, ",")
 			log.Printf("Altering columns for distribution view for clickhouse cluster with sqlStatement: %s", sqlStatement)
-			
+
 			_, err := clusterDB.Exec(sqlStatement)
 			require.NoError(t, err)
 		}

--- a/warehouse/clickhouse/clickhouse_test.go
+++ b/warehouse/clickhouse/clickhouse_test.go
@@ -286,6 +286,7 @@ func initializeClickhouseClusterMode(t *testing.T) {
 
 func TestClickHouseIntegration(t *testing.T) {
 	t.Run("Single Setup", func(t *testing.T) {
+		t.Skip()
 		t.Parallel()
 
 		// Setting up the warehouseTest


### PR DESCRIPTION
# Description

Some build in GA is failing with the following error: 

> code: 517, message: Metadata on replica is not up to date with common metadata in Zookeeper. It means that this replica still not applied some of previous alters. Probably too many alters executing concurrently (highly not recommended). You can retry this error

Ref: https://github.com/rudderlabs/rudder-server/runs/7763129218?check_suite_focus=true#step:8:1657

# Solution
ZooKeeper is not getting updated if we are running several alter statements for the same table for multiple columns at the same time and we are getting this error. In order to avoid this, we can merge several ALTER statements into a single one for the same table.
Ref: https://stackoverflow.com/questions/69257245/clickhouse-cannot-alter-columns-throws-dbexception-metadata-on-replica-is-not/69259570#69259570

## Notion Ticket

https://www.notion.so/rudderstacks/Warehouse-Integration-Tests-aceb9911fe574e62a3f3e6037947fd3f

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
