### PR TITLE
chore: fix flaky integration test

### DIFF
--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -286,6 +286,8 @@ func TestDynamicClusterManager(t *testing.T) {
 		return dCM.Mode() == servermode.NormalMode
 	}, time.Second, time.Millisecond)
 
+	time.Sleep(2 * time.Second)
+
 	provider.sendMode(servermode.NewChangeEvent(servermode.DegradedMode, func(_ context.Context) error {
 		close(chACK)
 		return nil


### PR DESCRIPTION
# Description

Fix deadlock happening in concurrent start-stop scenarios during the integration tests

## Notion Ticket

https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=f89bbfd437584ec7938f523f599195e4&pm=s

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
