### PR TITLE
chore(destination): change dest def name to destType for stats

### DIFF
--- a/router/oauthResponseHandler/oauthResponseHandler.go
+++ b/router/oauthResponseHandler/oauthResponseHandler.go
@@ -326,7 +326,7 @@ func (authStats *OAuthStats) SendTimerStats(startTime time.Time) {
 		"rudderCategory":  authStats.rudderCategory,
 		"isCallToCpApi":   strconv.FormatBool(authStats.isCallToCpApi),
 		"authErrCategory": authStats.authErrCategory,
-		"destDefName":     authStats.destDefName,
+		"destType":        authStats.destDefName,
 	}).SendTiming(time.Since(startTime))
 }
 
@@ -339,7 +339,7 @@ func (refStats *OAuthStats) SendCountStat() {
 		"errorMessage":    refStats.errorMessage,
 		"isCallToCpApi":   strconv.FormatBool(refStats.isCallToCpApi),
 		"authErrCategory": refStats.authErrCategory,
-		"destDefName":     refStats.destDefName,
+		"destType":        refStats.destDefName,
 		"isTokenFetch":    strconv.FormatBool(refStats.isTokenFetch),
 	}).Increment()
 }

--- a/router/router.go
+++ b/router/router.go
@@ -611,7 +611,7 @@ func (worker *workerT) processDestinationJobs() {
 									jobID := destinationJob.JobMetadataArray[0].JobID
 									pkgLogger.Debugf(`[TransformerProxy] (Dest-%[1]v) {Job - %[2]v} Request started`, worker.rt.destName, jobID)
 									proxyReqparams := &transformer.ProxyRequestParams{
-										DestName:     strings.ToLower(worker.rt.destName),
+										DestName:     worker.rt.destName,
 										JobID:        jobID,
 										ResponseData: val,
 									}
@@ -653,7 +653,7 @@ func (worker *workerT) processDestinationJobs() {
 						respBody = strings.Join(respBodyArr, " ")
 						if worker.rt.transformerProxy {
 							stats.NewTaggedStat("transformer_proxy.input_events_count", stats.CountType, stats.Tags{
-								"destType":      strings.ToLower(worker.rt.destName),
+								"destType":      worker.rt.destName,
 								"destinationId": destinationJob.Destination.ID,
 								"workspace":     workspaceID,
 								"workspaceId":   workspaceID,
@@ -666,7 +666,7 @@ func (worker *workerT) processDestinationJobs() {
 							)
 
 							stats.NewTaggedStat("transformer_proxy.output_events_count", stats.CountType, stats.Tags{
-								"destType":      strings.ToLower(worker.rt.destName),
+								"destType":      worker.rt.destName,
 								"destinationId": destinationJob.Destination.ID,
 								"workspace":     workspaceID,
 								"workspaceId":   workspaceID,
@@ -2311,7 +2311,7 @@ func (rt *HandleT) HandleOAuthDestResponse(params *HandleDestOAuthRespParamsT) (
 				Secret:          params.secret,
 				WorkspaceId:     workspaceID,
 				AccountId:       rudderAccountID,
-				DestDefName:     strings.ToLower(destinationJob.Destination.DestinationDefinition.Name),
+				DestDefName:     destinationJob.Destination.DestinationDefinition.Name,
 				EventNamePrefix: "refresh_token",
 				WorkerId:        params.workerID,
 			}
@@ -2327,7 +2327,7 @@ func (rt *HandleT) HandleOAuthDestResponse(params *HandleDestOAuthRespParamsT) (
 					"destinationId": destinationJob.Destination.ID,
 					"workspaceId":   refTokenParams.WorkspaceId,
 					"accountId":     refTokenParams.AccountId,
-					"destType":      strings.ToLower(refTokenParams.DestDefName),
+					"destType":      refTokenParams.DestDefName,
 				}).Increment()
 				rt.logger.Errorf(`[OAuth request] Aborting the event as %v`, oauth.INVALID_REFRESH_TOKEN_GRANT)
 				return disableStCd, refSec.Err
@@ -2347,7 +2347,7 @@ func (rt *HandleT) HandleOAuthDestResponse(params *HandleDestOAuthRespParamsT) (
 func (rt *HandleT) ExecDisableDestination(destination *backendconfig.DestinationT, workspaceId, destResBody, rudderAccountId string) (int, string) {
 	disableDestStatTags := stats.Tags{
 		"id":          destination.ID,
-		"destType":    strings.ToLower(destination.DestinationDefinition.Name),
+		"destType":    destination.DestinationDefinition.Name,
 		"workspaceId": workspaceId,
 		"success":     "true",
 	}

--- a/router/router.go
+++ b/router/router.go
@@ -2400,7 +2400,7 @@ func (rt *HandleT) HandleOAuthDestResponse(params *HandleDestOAuthRespParamsT) (
 					"destinationId": destinationJob.Destination.ID,
 					"workspaceId":   refTokenParams.WorkspaceId,
 					"accountId":     refTokenParams.AccountId,
-					"destName":      refTokenParams.DestDefName,
+					"destType":      refTokenParams.DestDefName,
 				}).Increment()
 				rt.logger.Errorf(`[OAuth request] Aborting the event as %v`, oauth.INVALID_REFRESH_TOKEN_GRANT)
 				return disableStCd, refSec.Err
@@ -2420,6 +2420,7 @@ func (rt *HandleT) HandleOAuthDestResponse(params *HandleDestOAuthRespParamsT) (
 func (rt *HandleT) ExecDisableDestination(destination *backendconfig.DestinationT, workspaceId, destResBody, rudderAccountId string) (int, string) {
 	disableDestStatTags := stats.Tags{
 		"id":          destination.ID,
+		"destType":    destination.DestinationDefinition.Name,
 		"workspaceId": workspaceId,
 		"success":     "true",
 	}

--- a/router/router.go
+++ b/router/router.go
@@ -611,7 +611,7 @@ func (worker *workerT) processDestinationJobs() {
 									jobID := destinationJob.JobMetadataArray[0].JobID
 									pkgLogger.Debugf(`[TransformerProxy] (Dest-%[1]v) {Job - %[2]v} Request started`, worker.rt.destName, jobID)
 									proxyReqparams := &transformer.ProxyRequestParams{
-										DestName:     worker.rt.destName,
+										DestName:     strings.ToLower(worker.rt.destName),
 										JobID:        jobID,
 										ResponseData: val,
 									}
@@ -653,7 +653,7 @@ func (worker *workerT) processDestinationJobs() {
 						respBody = strings.Join(respBodyArr, " ")
 						if worker.rt.transformerProxy {
 							stats.NewTaggedStat("transformer_proxy.input_events_count", stats.CountType, stats.Tags{
-								"destType":      worker.rt.destName,
+								"destType":      strings.ToLower(worker.rt.destName),
 								"destinationId": destinationJob.Destination.ID,
 								"workspace":     workspaceID,
 								"workspaceId":   workspaceID,
@@ -666,7 +666,7 @@ func (worker *workerT) processDestinationJobs() {
 							)
 
 							stats.NewTaggedStat("transformer_proxy.output_events_count", stats.CountType, stats.Tags{
-								"destType":      worker.rt.destName,
+								"destType":      strings.ToLower(worker.rt.destName),
 								"destinationId": destinationJob.Destination.ID,
 								"workspace":     workspaceID,
 								"workspaceId":   workspaceID,
@@ -2311,7 +2311,7 @@ func (rt *HandleT) HandleOAuthDestResponse(params *HandleDestOAuthRespParamsT) (
 				Secret:          params.secret,
 				WorkspaceId:     workspaceID,
 				AccountId:       rudderAccountID,
-				DestDefName:     destinationJob.Destination.DestinationDefinition.Name,
+				DestDefName:     strings.ToLower(destinationJob.Destination.DestinationDefinition.Name),
 				EventNamePrefix: "refresh_token",
 				WorkerId:        params.workerID,
 			}
@@ -2327,7 +2327,7 @@ func (rt *HandleT) HandleOAuthDestResponse(params *HandleDestOAuthRespParamsT) (
 					"destinationId": destinationJob.Destination.ID,
 					"workspaceId":   refTokenParams.WorkspaceId,
 					"accountId":     refTokenParams.AccountId,
-					"destType":      refTokenParams.DestDefName,
+					"destType":      strings.ToLower(refTokenParams.DestDefName),
 				}).Increment()
 				rt.logger.Errorf(`[OAuth request] Aborting the event as %v`, oauth.INVALID_REFRESH_TOKEN_GRANT)
 				return disableStCd, refSec.Err
@@ -2347,7 +2347,7 @@ func (rt *HandleT) HandleOAuthDestResponse(params *HandleDestOAuthRespParamsT) (
 func (rt *HandleT) ExecDisableDestination(destination *backendconfig.DestinationT, workspaceId, destResBody, rudderAccountId string) (int, string) {
 	disableDestStatTags := stats.Tags{
 		"id":          destination.ID,
-		"destType":    destination.DestinationDefinition.Name,
+		"destType":    strings.ToLower(destination.DestinationDefinition.Name),
 		"workspaceId": workspaceId,
 		"success":     "true",
 	}

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -202,15 +202,15 @@ func (trans *HandleT) Transform(transformType string, transformMessage *types.Tr
 }
 
 func (trans *HandleT) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequestParams) (int, string, string) {
-	stats.NewTaggedStat("transformer_proxy.delivery_request", stats.CountType, stats.Tags{"destination": proxyReqParams.DestName}).Increment()
+	stats.NewTaggedStat("transformer_proxy.delivery_request", stats.CountType, stats.Tags{"destType": proxyReqParams.DestName}).Increment()
 	trans.logger.Debugf(`[TransformerProxy] (Dest-%[1]v) {Job - %[2]v} Proxy Request starts - %[1]v`, proxyReqParams.DestName, proxyReqParams.JobID)
 
 	rdlTime := time.Now()
 	httpPrxResp := trans.makeTfProxyRequest(ctx, proxyReqParams)
 	respData, respCode, requestError := httpPrxResp.respData, httpPrxResp.statusCode, httpPrxResp.err
 	reqSuccessStr := strconv.FormatBool(requestError == nil)
-	stats.NewTaggedStat("transformer_proxy.request_latency", stats.TimerType, stats.Tags{"requestSuccess": reqSuccessStr, "destination": proxyReqParams.DestName}).SendTiming(time.Since(rdlTime))
-	stats.NewTaggedStat("transformer_proxy.request_result", stats.CountType, stats.Tags{"requestSuccess": reqSuccessStr, "destination": proxyReqParams.DestName}).Increment()
+	stats.NewTaggedStat("transformer_proxy.request_latency", stats.TimerType, stats.Tags{"requestSuccess": reqSuccessStr, "destType": proxyReqParams.DestName}).SendTiming(time.Since(rdlTime))
+	stats.NewTaggedStat("transformer_proxy.request_result", stats.CountType, stats.Tags{"requestSuccess": reqSuccessStr, "destType": proxyReqParams.DestName}).Increment()
 
 	if requestError != nil {
 		return respCode, requestError.Error(), "text/plain; charset=utf-8"
@@ -295,7 +295,7 @@ func (trans *HandleT) makeTfProxyRequest(ctx context.Context, proxyReqParams *Pr
 	// This stat will be useful in understanding the round trip time taken for the http req
 	// between server and transformer
 	stats.NewTaggedStat("transformer_proxy.req_round_trip_time", stats.TimerType, stats.Tags{
-		"destination": destName,
+		"destType": destName,
 	}).SendTiming(reqRoundTripTime)
 
 	if os.IsTimeout(err) {


### PR DESCRIPTION
# Description

In this PR, we want to change the stats which have the destination definition name detail to be `destType` as this is the convention followed in `rudder-server`

## Notion Ticket

https://www.notion.so/rudderstacks/Transformer-alerts-Revamp-5af8ab9e12bc4247b24515504dd74f9f

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
