### PR TITLE
fix: dockerfile issues related to scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ WORKDIR /rudder-server
 COPY go.mod .
 COPY go.sum .
 
-RUN go mod download 
+RUN go mod download
 
-COPY . . 
+COPY . .
 
 RUN BUILD_DATE=$(date "+%F,%T") \
     LDFLAGS="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT_HASH} -X main.buildDate=$BUILD_DATE -X main.builtBy=${REVISION} -X main.builtBy=${REVISION} -X main.enterpriseToken=${ENTERPRISE_TOKEN} " \
@@ -29,13 +29,13 @@ RUN apk -U --no-cache upgrade && \
 
 COPY --from=builder rudder-server/rudder-server .
 COPY --from=builder rudder-server/build/wait-for-go/wait-for-go .
-COPY --from=builder rudder-server/build/regulation-worker . 
+COPY --from=builder rudder-server/build/regulation-worker .
 
 COPY build/docker-entrypoint.sh /
 COPY build/wait-for /
 COPY ./rudder-cli/rudder-cli.linux.x86_64 /usr/bin/rudder-cli
-COPY scripts/generate-event /scripts
-COPY scripts/batch.json /scripts
+COPY scripts/generate-event /scripts/generate-event
+COPY scripts/batch.json /scripts/batch.json
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/rudder-server"]


### PR DESCRIPTION
## Description
The below copy in dockerfile is overriding `generate-event` script
```
COPY scripts/generate-event /scripts
COPY scripts/batch.json /scripts
```
Batch.json is getting overwritten into scripts. Note that scripts has created as file instead of folder. Hence the generate-events first gets copied into scripts file after that copy batch.json overwrites the scripts