### PR TITLE
fix: awsutils to support secretAccessKey

### DIFF
--- a/utils/awsutils/session.go
+++ b/utils/awsutils/session.go
@@ -16,10 +16,12 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+// Some AWS destinations are using SecretAccessKey instead of accessKey
 type SessionConfig struct {
 	Region           string        `mapstructure:"region"`
 	AccessKeyID      string        `mapstructure:"accessKeyID"`
 	AccessKey        string        `mapstructure:"accessKey"`
+	SecretAccessKey  string        `mapstructure:"secretAccessKey"`
 	IAMRoleARN       string        `mapstructure:"iamRoleARN"`
 	ExternalID       string        `mapstructure:"externalID"`
 	Endpoint         *string       `mapstructure:"endpoint"`
@@ -101,6 +103,10 @@ func NewSessionConfig(destinationConfig map[string]interface{}, timeout time.Dur
 	sessionConfig := SessionConfig{}
 	if err := mapstructure.Decode(destinationConfig, &sessionConfig); err != nil {
 		return nil, fmt.Errorf("unable to populate session config using destinationConfig: %w", err)
+	}
+	// Some AWS destinations are using SecretAccessKey instead of accessKey
+	if sessionConfig.SecretAccessKey != "" {
+		sessionConfig.AccessKey = sessionConfig.SecretAccessKey
 	}
 	sessionConfig.Timeout = timeout
 	sessionConfig.Service = serviceName

--- a/utils/awsutils/session_test.go
+++ b/utils/awsutils/session_test.go
@@ -18,6 +18,11 @@ var (
 		"accessKeyID": "AccessKeyID",
 		"accessKey":   "AccessKey",
 	}
+	destinationConfigWithSecretAccessKey map[string]interface{} = map[string]interface{}{
+		"region":          "us-east-1",
+		"accessKeyID":     "AccessKeyID",
+		"secretAccessKey": "AccessKey",
+	}
 	timeOut time.Duration = 10 * time.Second
 )
 
@@ -32,6 +37,21 @@ func TestNewSessionConfigWithAccessKey(t *testing.T) {
 		AccessKey:   destinationConfigWithAccessKey["accessKey"].(string),
 		Timeout:     timeOut,
 		Service:     serviceName,
+	})
+}
+
+func TestNewSessionConfigWithSecretAccessKey(t *testing.T) {
+	serviceName := "kinesis"
+	sessionConfig, err := NewSessionConfig(destinationConfigWithSecretAccessKey, timeOut, serviceName)
+	assert.Nil(t, err)
+	assert.NotNil(t, sessionConfig)
+	assert.Equal(t, *sessionConfig, SessionConfig{
+		Region:          destinationConfigWithSecretAccessKey["region"].(string),
+		AccessKeyID:     destinationConfigWithSecretAccessKey["accessKeyID"].(string),
+		AccessKey:       destinationConfigWithSecretAccessKey["secretAccessKey"].(string),
+		SecretAccessKey: destinationConfigWithSecretAccessKey["secretAccessKey"].(string),
+		Timeout:         timeOut,
+		Service:         serviceName,
 	})
 }
 


### PR DESCRIPTION
# Description

Some AWS destinations are using accessKey to represent AWS access Key and others using secretAccessKey but current awsutils are supporting only accessKey so added support so that those destinations doesn't break when deployed.

## Notion Ticket
https://www.notion.so/rudderstacks/AWS-FTR-for-streaming-destination-78b63869ac904ba49b0018a527ccb343

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
