### PR TITLE
chore(router): fix defect in validating in/out inconsistencies

### DIFF
--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -169,11 +169,11 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 
 		// Validate the response received from the transformer
 		in := transformMessage.JobIDs()
-		out := make(map[int64]struct{})
+		var out []int64
 		invalid := make(map[int64]struct{}) // invalid jobIDs are the ones that are in the response but were not included in the request
 		for i := range destinationJobs {
 			for k, v := range destinationJobs[i].JobIDs() {
-				out[k] = v
+				out = append(out, k)
 				if _, ok := in[k]; !ok {
 					invalid[k] = v
 				}

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -413,7 +413,7 @@ func TestTransformValidationInOutMismatchError(t *testing.T) {
 		{JobMetadataArray: []types.JobMetadataT{{JobID: 1}}},
 		{JobMetadataArray: []types.JobMetadataT{{JobID: 2}}},
 		{JobMetadataArray: []types.JobMetadataT{{JobID: 3}}},
-		{JobMetadataArray: []types.JobMetadataT{{JobID: 4}}},
+		{JobMetadataArray: []types.JobMetadataT{{JobID: 3}}},
 	}
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add(apiVersionHeader, strconv.Itoa(utilTypes.SUPPORTED_TRANSFORMER_API_VERSION))


### PR DESCRIPTION
# Description

Not using a set for collecting transformer's out stats in order to capture duplicates

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
