### PR TITLE
fix: group errors swallowed + honouring ctx

### DIFF
--- a/main.go
+++ b/main.go
@@ -252,7 +252,7 @@ func Run(ctx context.Context) int {
 	g.Go(func() (err error) {
 		if err = admin.StartServer(ctx); err != nil {
 			if !errors.Is(err, context.Canceled) {
-				pkgLogger.Errorf("Error starting admin server: %v", err)
+				pkgLogger.Errorf("Error in Admin server routine: %v", err)
 			}
 		}
 		return err
@@ -261,7 +261,7 @@ func Run(ctx context.Context) int {
 	g.Go(func() (err error) {
 		p := &profiler.Profiler{}
 		if err = p.StartServer(ctx); err != nil {
-			pkgLogger.Errorf("Error starting profiler server: %v", err)
+			pkgLogger.Errorf("Error in Profiler server routine: %v", err)
 		}
 		return err
 	})
@@ -271,7 +271,7 @@ func Run(ctx context.Context) int {
 		appHandler.HandleRecovery(options)
 		g.Go(misc.WithBugsnag(func() (err error) {
 			if err = appHandler.StartRudderCore(ctx, options); err != nil {
-				pkgLogger.Errorf("Error starting Rudder Core: %v", err)
+				pkgLogger.Errorf("Error in Rudder Core routine: %v", err)
 			}
 			return err
 		}))
@@ -281,7 +281,7 @@ func Run(ctx context.Context) int {
 	if appTypeStr != app.GATEWAY && canStartWarehouse() {
 		g.Go(misc.WithBugsnagForWarehouse(func() (err error) {
 			if err = startWarehouseService(ctx, application); err != nil {
-				pkgLogger.Errorf("Error starting Warehouse Service: %v", err)
+				pkgLogger.Errorf("Error in Warehouse Service routine: %v", err)
 			}
 			return err
 		}))

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -248,35 +249,43 @@ func Run(ctx context.Context) int {
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		return admin.StartServer(ctx)
+	g.Go(func() (err error) {
+		if err = admin.StartServer(ctx); err != nil {
+			if !errors.Is(err, context.Canceled) {
+				pkgLogger.Errorf("Error starting admin server: %v", err)
+			}
+		}
+		return err
 	})
 
-	g.Go(func() error {
+	g.Go(func() (err error) {
 		p := &profiler.Profiler{}
-		return p.StartServer(ctx)
+		if err = p.StartServer(ctx); err != nil {
+			pkgLogger.Errorf("Error starting profiler server: %v", err)
+		}
+		return err
 	})
 
 	misc.AppStartTime = time.Now().Unix()
 	if canStartServer() {
 		appHandler.HandleRecovery(options)
-		g.Go(misc.WithBugsnag(func() error {
-			return appHandler.StartRudderCore(ctx, options)
+		g.Go(misc.WithBugsnag(func() (err error) {
+			if err = appHandler.StartRudderCore(ctx, options); err != nil {
+				pkgLogger.Errorf("Error starting Rudder Core: %v", err)
+			}
+			return err
 		}))
 	}
 
 	// initialize warehouse service after core to handle non-normal recovery modes
 	if appTypeStr != app.GATEWAY && canStartWarehouse() {
-		g.Go(misc.WithBugsnagForWarehouse(func() error {
-			return startWarehouseService(ctx, application)
+		g.Go(misc.WithBugsnagForWarehouse(func() (err error) {
+			if err = startWarehouseService(ctx, application); err != nil {
+				pkgLogger.Errorf("Error starting Warehouse Service: %v", err)
+			}
+			return err
 		}))
 	}
-
-	g.Go(func() error {
-		<-ctx.Done()
-		backendconfig.DefaultBackendConfig.Stop()
-		return nil
-	})
 
 	shutdownDone := make(chan struct{})
 	go func() {
@@ -284,6 +293,8 @@ func Run(ctx context.Context) int {
 		if err != nil && err != context.Canceled {
 			pkgLogger.Error(err)
 		}
+
+		backendconfig.DefaultBackendConfig.Stop()
 		close(shutdownDone)
 	}()
 

--- a/services/validators/envValidator.go
+++ b/services/validators/envValidator.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -191,9 +192,9 @@ func killDanglingDBConnections(db *sql.DB) {
 }
 
 // IsPostgresCompatible checks the if the version of postgres is greater than minPostgresVersion
-func IsPostgresCompatible(db *sql.DB) (bool, error) {
+func IsPostgresCompatible(ctx context.Context, db *sql.DB) (bool, error) {
 	var versionNum int
-	err := db.QueryRow("SHOW server_version_num;").Scan(&versionNum)
+	err := db.QueryRowContext(ctx, "SHOW server_version_num;").Scan(&versionNum)
 	if err != nil {
 		return false, err
 	}
@@ -205,7 +206,7 @@ func ValidateEnv() {
 	dbHandle := createDBConnection()
 	defer closeDBConnection(dbHandle)
 
-	isDBCompatible, err := IsPostgresCompatible(dbHandle)
+	isDBCompatible, err := IsPostgresCompatible(context.TODO(), dbHandle)
 	if err != nil {
 		panic(err)
 	}

--- a/services/validators/envValidator.go
+++ b/services/validators/envValidator.go
@@ -89,7 +89,7 @@ func setWHSchemaVersionIfNotExists(dbHandle *sql.DB) {
 
 	if !parameters.Valid {
 		// insert current version
-		sqlStatement = fmt.Sprintf(`UPDATE workspace SET parameters = '{"wh_schema_version":"%s"}' WHERE token = '%s'`, whSchemaVersion, hashedToken)
+		sqlStatement = fmt.Sprintf(`UPDATE workspace SET parameters = '{"wh_schema_version":%q}' WHERE token = '%s'`, whSchemaVersion, hashedToken)
 		_, err := dbHandle.Exec(sqlStatement)
 		if err != nil {
 			panic(err)

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -11,24 +11,23 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
-	"github.com/rudderlabs/rudder-server/warehouse/configuration_testing"
-
+	"github.com/gofrs/uuid"
 	"github.com/lib/pq"
+	"github.com/tidwall/gjson"
+
 	"github.com/rudderlabs/rudder-server/config"
+	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/rruntime"
 	"github.com/rudderlabs/rudder-server/services/pgnotifier"
 	"github.com/rudderlabs/rudder-server/services/stats"
 	"github.com/rudderlabs/rudder-server/utils/misc"
-
-	uuid "github.com/gofrs/uuid"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 	"github.com/rudderlabs/rudder-server/utils/types"
+	"github.com/rudderlabs/rudder-server/warehouse/configuration_testing"
 	"github.com/rudderlabs/rudder-server/warehouse/identity"
 	"github.com/rudderlabs/rudder-server/warehouse/manager"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
-	"github.com/tidwall/gjson"
 )
 
 // Upload Status

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -17,11 +17,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rudderlabs/rudder-server/warehouse/deltalake"
-
-	"github.com/rudderlabs/rudder-server/warehouse/configuration_testing"
-
 	"github.com/bugsnag/bugsnag-go/v2"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/lib/pq"
 	"github.com/thoas/go-funk"
 	"github.com/tidwall/gjson"
@@ -43,6 +40,8 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 	"github.com/rudderlabs/rudder-server/utils/types"
+	"github.com/rudderlabs/rudder-server/warehouse/configuration_testing"
+	"github.com/rudderlabs/rudder-server/warehouse/deltalake"
 	"github.com/rudderlabs/rudder-server/warehouse/manager"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
@@ -1236,17 +1235,25 @@ func onConfigDataEvent(config pubsub.DataEvent, dstToWhRouter map[string]*Handle
 	}
 }
 
-func setupTables(dbHandle *sql.DB) {
+func setupTables(dbHandle *sql.DB) error {
 	m := &migrator.Migrator{
 		Handle:                     dbHandle,
 		MigrationsTable:            "wh_schema_migrations",
 		ShouldForceSetLowerVersion: ShouldForceSetLowerVersion,
 	}
 
-	err := m.Migrate("warehouse")
-	if err != nil {
-		panic(fmt.Errorf("Could not run warehouse database migrations: %w", err))
+	operation := func() error {
+		return m.Migrate("warehouse")
 	}
+
+	backoffWithMaxRetry := backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 3)
+	err := backoff.RetryNotify(operation, backoffWithMaxRetry, func(err error, t time.Duration) {
+		pkgLogger.Warnf("Failed to setup WH db tables: %v, retrying after %v", err, t)
+	})
+	if err != nil {
+		return fmt.Errorf("could not run warehouse database migrations: %w", err)
+	}
+	return nil
 }
 
 func CheckPGHealth(dbHandle *sql.DB) bool {
@@ -1720,33 +1727,38 @@ func isStandAloneSlave() bool {
 	return warehouseMode == config.SlaveMode
 }
 
-func setupDB(connInfo string) {
+func setupDB(ctx context.Context, connInfo string) error {
 	if isStandAloneSlave() {
-		return
+		return nil
 	}
 
 	var err error
 	dbHandle, err = sql.Open("postgres", connInfo)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
-	isDBCompatible, err := validators.IsPostgresCompatible(dbHandle)
+	isDBCompatible, err := validators.IsPostgresCompatible(ctx, dbHandle)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	if !isDBCompatible {
 		err := errors.New("Rudder Warehouse Service needs postgres version >= 10. Exiting")
 		pkgLogger.Error(err)
-		panic(err)
+		return err
 	}
-	setupTables(dbHandle)
+
+	if err = dbHandle.PingContext(ctx); err != nil {
+		return fmt.Errorf("could not ping WH db: %w", err)
+	}
+
+	return setupTables(dbHandle)
 }
 
 func Start(ctx context.Context, app app.Interface) error {
 	application = app
-	time.Sleep(1 * time.Second)
+
 	// do not start warehouse service if rudder core is not in normal mode and warehouse is running in same process as rudder core
 	if !isStandAlone() && !db.IsNormalMode() {
 		pkgLogger.Infof("Skipping start of warehouse service...")
@@ -1756,7 +1768,9 @@ func Start(ctx context.Context, app app.Interface) error {
 	pkgLogger.Infof("WH: Starting Warehouse service...")
 	psqlInfo := getConnectionString()
 
-	setupDB(psqlInfo)
+	if err := setupDB(ctx, psqlInfo); err != nil {
+		return fmt.Errorf("cannot setup warehouse db: %w", err)
+	}
 	defer func() {
 		if r := recover(); r != nil {
 			pkgLogger.Fatal(r)


### PR DESCRIPTION
# Description

When using an `errgroup.Group`, if more than one routine returns an error it is swallowed: https://go.dev/play/p/5f6nHLHEEwu
I'm therefore making sure that we log all errors in each routine just in case more than one would return an error.
This is also useful in case one of them gets stuck and doesn't return while another prints an error immediately. In fact if the context gets canceled and one of the routines doesn't return, we would just get some log entries with a `context canceled` error printed by other components, but the `g.Wait()` would never get a chance to run so we would not know why the context was canceled in the first place.

Additionally, I removed a `time.Sleep(time.Second)` in the Warehouse `Setup()` method and I replaced it with a retry policy with an exponential backoff. While doing so I also propagated the context further down in some functions.

## Notion Ticket

< [Notion Link](https://www.notion.so/rudderstacks/main-go-errgroup-error-f8dfc3f52ce541ebaf140b64c35be43e) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.