### PR TITLE
chore: introduce go report card

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
   <a href="https://rudderstack.com/docs/get-started/installing-and-setting-up-rudderstack/docker/">
     <img src="https://img.shields.io/docker/pulls/rudderlabs/rudder-server">
   </a>
+  <a href="https://goreportcard.com/report/github.com/rudderlabs/rudder-server">
+    <img src="https://goreportcard.com/badge/github.com/rudderlabs/rudder-server">
+  </a>
   <a href="https://github.com/rudderlabs/rudder-server/blob/master/LICENSE">
     <img src="https://img.shields.io/github/license/rudderlabs/rudder-server">
   </a>


### PR DESCRIPTION
# Description

I have noticed [go report-card](https://goreportcard.com/)  is used around go projects. We have a good score (and a few things to fix), so added it to our readme.

## Notion Ticket

https://www.notion.so/rudderstacks/Add-go-card-banner-in-readme-df884a21fc54454a9ea725946b7d29aa

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
