### PR TITLE
feat: perform ADD_DS operation in a single transaction

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1044,28 +1044,6 @@ func (jd *HandleT) Close() {
 	jd.dbHandle.Close()
 }
 
-// removeExtraKey : removes extra key present in map1 and not in map2
-// Assumption is keys in map1 and map2 are same, except that map1 has one key more than map2
-func removeExtraKey(map1, map2 map[string]string) string {
-	var deleteKey, key string
-	for key = range map1 {
-		if _, ok := map2[key]; !ok {
-			deleteKey = key
-			break
-		}
-	}
-
-	if deleteKey != "" {
-		delete(map1, deleteKey)
-	}
-
-	return deleteKey
-}
-
-func remove(slice []string, idx int) []string {
-	return append(slice[:idx], slice[idx+1:]...)
-}
-
 /*
 Function to return an ordered list of datasets and datasetRanges
 Most callers use the in-memory list of dataset and datasetRanges
@@ -1109,6 +1087,7 @@ func (jd *HandleT) refreshDSRangeList(l lock.DSListLockToken) []dataSetRangeT {
 
 	// At this point we must have write-locked dsListLock
 	dsList := jd.refreshDSList(l)
+
 	jd.datasetRangeList = nil
 
 	for idx, ds := range dsList {
@@ -1144,7 +1123,8 @@ func (jd *HandleT) refreshDSRangeList(l lock.DSListLockToken) []dataSetRangeT {
 			jd.datasetRangeList = append(jd.datasetRangeList,
 				dataSetRangeT{
 					minJobID: minID.Int64,
-					maxJobID: maxID.Int64, ds: ds,
+					maxJobID: maxID.Int64,
+					ds:       ds,
 				})
 			prevMax = maxID.Int64
 		}
@@ -1535,11 +1515,27 @@ type transactionHandler interface {
 }
 
 func (jd *HandleT) createDS(newDS dataSetT, l lock.DSListLockToken) {
+	err := jd.WithTx(func(tx *sql.Tx) error {
+		return jd.createDSInTx(tx, newDS, l)
+	})
+	jd.assertError(err)
+	// to refresh the DS list in the cache after transaction has been committed.
+	_ = jd.refreshDSList(l)
+	_ = jd.refreshDSRangeList(l)
+}
+
+func (jd *HandleT) createDSInTx(tx *sql.Tx, newDS dataSetT, l lock.DSListLockToken) error {
 	// Mark the start of operation. If we crash somewhere here, we delete the
 	// DS being added
 	opPayload, err := json.Marshal(&journalOpPayloadT{To: newDS})
-	jd.assertError(err)
-	opID := jd.JournalMarkStart(addDSOperation, opPayload)
+	if err != nil {
+		return err
+	}
+
+	opID, err := jd.JournalMarkStartInTx(tx, addDSOperation, opPayload)
+	if err != nil {
+		return err
+	}
 
 	// Create the jobs and job_status tables
 	sqlStatement := fmt.Sprintf(`CREATE TABLE %q (
@@ -1554,14 +1550,18 @@ func (jd *HandleT) createDS(newDS dataSetT, l lock.DSListLockToken) {
                                       created_at TIMESTAMP NOT NULL DEFAULT NOW(),
                                       expire_at TIMESTAMP NOT NULL DEFAULT NOW());`, newDS.JobTable)
 
-	_, err = jd.dbHandle.Exec(sqlStatement)
-	jd.assertError(err)
+	_, err = tx.ExecContext(context.TODO(), sqlStatement)
+	if err != nil {
+		return err
+	}
 
 	// TODO : Evaluate a way to handle indexes only for particular tables
 	if jd.tablePrefix == "rt" {
 		sqlStatement = fmt.Sprintf(`CREATE INDEX IF NOT EXISTS "customval_workspace_%s" ON %q (custom_val,workspace_id)`, newDS.Index, newDS.JobTable)
-		_, err = jd.dbHandle.Exec(sqlStatement)
-		jd.assertError(err)
+		_, err = tx.ExecContext(context.TODO(), sqlStatement)
+		if err != nil {
+			return err
+		}
 	}
 
 	sqlStatement = fmt.Sprintf(`CREATE TABLE %q (
@@ -1575,38 +1575,50 @@ func (jd *HandleT) createDS(newDS dataSetT, l lock.DSListLockToken) {
                                      error_response JSONB DEFAULT '{}'::JSONB,
 									 parameters JSONB DEFAULT '{}'::JSONB,
 									 PRIMARY KEY (job_id, job_state, id));`, newDS.JobStatusTable, newDS.JobTable)
-	_, err = jd.dbHandle.Exec(sqlStatement)
-	jd.assertError(err)
+
+	_, err = tx.ExecContext(context.TODO(), sqlStatement)
+	if err != nil {
+		return err
+	}
 
 	// In case of a migration, we don't yet update the in-memory list till
 	// we finish the migration
 	if l != nil {
-		jd.setSequenceNumber(l, newDS.Index)
+		err := jd.setSequenceNumberInTx(tx, l, newDS.Index)
+		if err != nil {
+			return err
+		}
 	}
-	jd.JournalMarkDone(opID)
+
+	err = jd.journalMarkDoneInTx(tx, opID)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func (jd *HandleT) setSequenceNumber(l lock.DSListLockToken, newDSIdx string) dataSetT {
-	// Refresh the in-memory list. We only need to refresh the
-	// last DS, not the entire but we do it anyway.
-	// For the range list, we use the cached data. Internally
-	// it queries the new dataset which was added.
+func (jd *HandleT) setSequenceNumberInTx(tx *sql.Tx, l lock.DSListLockToken, newDSIdx string) error {
 	dList := jd.refreshDSList(l)
-	dRangeList := jd.refreshDSRangeList(l)
-
-	// We should not have range values for the last element (the new DS) and migrationTargetDS (if found)
-	jd.assert(len(dList) == len(dRangeList)+1 || len(dList) == len(dRangeList)+2, fmt.Sprintf("len(dList):%d != len(dRangeList):%d (+1 || +2)", len(dList), len(dRangeList)))
+	var maxID sql.NullInt64
 
 	// Now set the min JobID for the new DS just added to be 1 more than previous max
-	if len(dRangeList) > 0 {
-		newDSMin := dRangeList[len(dRangeList)-1].maxJobID + 1
-		// jd.assert(newDSMin > 0, fmt.Sprintf("newDSMin:%d <= 0", newDSMin))
-		sqlStatement := fmt.Sprintf(`ALTER SEQUENCE "%[1]s_jobs_%[2]s_job_id_seq" MINVALUE %[3]d START %[3]d RESTART %[3]d`,
+	if len(dList) > 0 {
+		sqlStatement := fmt.Sprintf(`SELECT MAX(job_id) FROM %q`, dList[len(dList)-1].JobTable)
+		err := tx.QueryRowContext(context.TODO(), sqlStatement).Scan(&maxID)
+		if err != nil {
+			return err
+		}
+
+		newDSMin := maxID.Int64 + 1
+		sqlStatement = fmt.Sprintf(`ALTER SEQUENCE "%[1]s_jobs_%[2]s_job_id_seq" MINVALUE %[3]d START %[3]d RESTART %[3]d`,
 			jd.tablePrefix, newDSIdx, newDSMin)
-		_, err := jd.dbHandle.Exec(sqlStatement)
-		jd.assertError(err)
+		_, err = tx.ExecContext(context.TODO(), sqlStatement)
+		if err != nil {
+			return err
+		}
 	}
-	return dList[len(dList)-1]
+	return nil
 }
 
 /*
@@ -3041,7 +3053,6 @@ func (jd *HandleT) migrateDSLoop(ctx context.Context) {
 		var migrateDSProbeCount int
 		// we don't want `maxDSSize` value to change, during dsList loop
 		maxDSSize := *jd.MaxDSSize
-
 		for idx, ds := range dsList {
 
 			var idxCheck bool

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -191,9 +191,6 @@ func (*backupTestCase) insertRTData(t *testing.T, jobs []*JobT, statusList []*Jo
 		}
 		return jobsDB.copyJobStatusDS(context.Background(), tx, rtDS2, statusList, []string{}, nil)
 	})
-	jobsDB.dsListLock.WithLock(func(l lock.DSListLockToken) {
-		jobsDB.refreshDSList(l)
-	})
 	require.NoError(t, err)
 	cleanup.Cleanup(func() {
 		jobsDB.TearDown()

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -191,6 +191,9 @@ func (*backupTestCase) insertRTData(t *testing.T, jobs []*JobT, statusList []*Jo
 		}
 		return jobsDB.copyJobStatusDS(context.Background(), tx, rtDS2, statusList, []string{}, nil)
 	})
+	jobsDB.dsListLock.WithLock(func(l lock.DSListLockToken) {
+		jobsDB.refreshDSList(l)
+	})
 	require.NoError(t, err)
 	cleanup.Cleanup(func() {
 		jobsDB.TearDown()

--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -45,25 +45,6 @@ func getDSList(jd assertInterface, dbHandle *sql.DB, tablePrefix string) []dataS
 
 	sortDnumList(jd, dnumList)
 
-	// If any service has crashed while creating DS, this may happen. Handling such case gracefully.
-	if len(jobNameMap) != len(jobStatusNameMap) {
-		jd.assert(len(jobNameMap) == len(jobStatusNameMap)+1, fmt.Sprintf("Length of jobNameMap(%d) - length of jobStatusNameMap(%d) is more than 1", len(jobNameMap), len(jobStatusNameMap)))
-		deletedDNum := removeExtraKey(jobNameMap, jobStatusNameMap)
-		// remove deletedDNum from dnumList
-		var idx int
-		var dnum string
-		var foundDeletedDNum bool
-		for idx, dnum = range dnumList {
-			if dnum == deletedDNum {
-				foundDeletedDNum = true
-				break
-			}
-		}
-		if foundDeletedDNum {
-			dnumList = remove(dnumList, idx)
-		}
-	}
-
 	// Create the structure
 	for _, dnum := range dnumList {
 		jobName, ok := jobNameMap[dnum]
@@ -73,7 +54,8 @@ func getDSList(jd assertInterface, dbHandle *sql.DB, tablePrefix string) []dataS
 		datasetList = append(datasetList,
 			dataSetT{
 				JobTable:       jobName,
-				JobStatusTable: jobStatusName, Index: dnum,
+				JobStatusTable: jobStatusName,
+				Index:          dnum,
 			})
 	}
 


### PR DESCRIPTION
# Description

Currently, `ADD_DS` operation to add new jobs table & job status table doesn't happen in a single transaction. Since, we are journaling, so any crash in middle of the addition would be reverted during recovery. But, this might create a problem in case of multiple writer to a single DB, i.e. in case of Gateway HA. So, we here we are performing the complete operation in a single transaction to avoid any problem in case of multiple writers.

## Notion Ticket

https://www.notion.so/rudderstacks/Perform-ADD_DS-operation-in-a-single-transaction-4cc30f0bdd17473ab1f2acba59afe653
