### PR TITLE
chore: upgrade actions runner to ubuntu 20.04

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration:
     name: Integrations
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-20.04'
     strategy:
       matrix:
         FEATURES: [oss ,enterprise]
@@ -44,7 +44,7 @@ jobs:
 
   warehouse-integration:
     name: Warehouse Service Integration
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -75,7 +75,7 @@ jobs:
 
   unit:
     name: Unit
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-20.04'
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2


### PR DESCRIPTION
# Description

https://github.com/actions/runner-images/issues/6002

## Notion Ticket

https://www.notion.so/rudderstacks/Upgrade-actions-runner-image-400f14fcb48f40f4a6a5b47b88ae07fb

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
