### PR TITLE
fix(router): event ordering algorithm with proper aborted job limiting support

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -44,6 +44,7 @@ import (
 	"runtime/pprof"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/spf13/viper"
 
@@ -260,8 +261,10 @@ func StartServer(ctx context.Context) error {
 		pkgLogger.Fatal("listen error:", e) // @TODO return?
 	}
 	defer func() {
-		if err := l.Close(); err != nil {
-			pkgLogger.Warn(err)
+		if l != nil {
+			if err := l.Close(); err != nil {
+				pkgLogger.Warn(err)
+			}
 		}
 	}()
 
@@ -269,7 +272,7 @@ func StartServer(ctx context.Context) error {
 	srvMux := http.NewServeMux()
 	srvMux.Handle(rpc.DefaultRPCPath, instance.rpcServer)
 
-	srv := &http.Server{Handler: srvMux}
+	srv := &http.Server{Handler: srvMux, ReadHeaderTimeout: 3 * time.Second}
 	go func() {
 		<-ctx.Done()
 		_ = srv.Shutdown(context.Background()) // @TODO no wait nor timeout on shutdown

--- a/config/backend-config/single_workspace.go
+++ b/config/backend-config/single_workspace.go
@@ -17,6 +17,7 @@ import (
 )
 
 type singleWorkspaceConfig struct {
+	logOnce          sync.Once
 	Token            string
 	workspaceID      string
 	configBackendURL *url.URL
@@ -129,7 +130,9 @@ func (wc *singleWorkspaceConfig) getFromAPI(ctx context.Context, _ string) (Conf
 
 // getFromFile reads the workspace config from JSON file
 func (wc *singleWorkspaceConfig) getFromFile() (ConfigT, error) {
-	pkgLogger.Info("Reading workspace config from JSON file")
+	wc.logOnce.Do(func() {
+		pkgLogger.Info("Reading workspace config from JSON file")
+	})
 	data, err := IoUtil.ReadFile(wc.configJSONPath)
 	if err != nil {
 		pkgLogger.Errorf("Unable to read backend config from file: %s with error : %s", wc.configJSONPath, err.Error())

--- a/eventorder_test.go
+++ b/eventorder_test.go
@@ -1,0 +1,401 @@
+//go:build integration
+
+package main_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/phayes/freeport"
+	main "github.com/rudderlabs/rudder-server"
+	"github.com/rudderlabs/rudder-server/testhelper/destination"
+	trand "github.com/rudderlabs/rudder-server/testhelper/rand"
+	"github.com/rudderlabs/rudder-server/testhelper/workspaceConfig"
+	"github.com/rudderlabs/rudder-server/utils/types/deployment"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestEventOrderGuarantee tests that order delivery guarantees are honoured by the server
+// regardless the behaviour of the destination.
+// To achieve that we generate a number of jobs per user with each job having a prescribed number
+// of responses until it is done (succeeded or aborted)
+
+// e.g.
+//
+//	user1, job1, responses: [500, 500, 200]
+//	user1, job2, responses: [200]
+//	user1, job3, responses: [400]
+//	user1, job4, responses: [500, 400]
+
+// After sending the jobs to the server, we verify that the destination has received the jobs in the
+// correct order. We also verify that the server has not sent any job twice.
+func TestEventOrderGuarantee(t *testing.T) {
+	const (
+		users         = 50                   // how many different userIDs we will send jobs for
+		jobsPerUser   = 40                   // how many jobs per user we will send
+		batchSize     = 10                   // how many jobs for the same user we will send in each batch request
+		responseDelay = 0 * time.Millisecond // how long we will the webhook wait before sending a response
+	)
+	var (
+		m      eventOrderMethods
+		passed bool
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// generate the spec we are going to use
+	// this will create a number of jobs for a number of users
+	// and prescribe the sequence of status codes that the webhook will return for each one e.g. 500, 500, 200
+	spec := m.newTestSpec(users, jobsPerUser)
+	spec.responseDelay = responseDelay
+
+	t.Logf("Starting docker services (postgres & transformer)")
+	var (
+		postgresContainer    *destination.PostgresResource
+		transformerContainer *destination.TransformerResource
+		gatewayPort          string
+	)
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	containersGroup, _ := errgroup.WithContext(ctx)
+	containersGroup.Go(func() (err error) {
+		postgresContainer, err = destination.SetupPostgres(pool, t)
+		return err
+	})
+	containersGroup.Go(func() (err error) {
+		transformerContainer, err = destination.SetupTransformer(pool, t)
+		return err
+	})
+	require.NoError(t, containersGroup.Wait())
+	t.Logf("Started docker services")
+
+	t.Logf("Starting webhook destination server")
+	webhook := m.newWebhook(t, spec)
+	defer webhook.Server.Close()
+
+	t.Logf("Preparing rudder-server config")
+	writeKey := trand.String(27)
+	workspaceID := trand.String(27)
+	templateCtx := map[string]string{
+		"webhookUrl":  webhook.Server.URL,
+		"writeKey":    writeKey,
+		"workspaceId": workspaceID,
+	}
+	configJsonPath := workspaceConfig.CreateTempFile(t, "testdata/eventOrderTestTemplate.json", templateCtx)
+	t.Setenv("RSERVER_BACKEND_CONFIG_CONFIG_FROM_FILE", "true")
+	t.Setenv("RSERVER_BACKEND_CONFIG_CONFIG_JSONPATH", configJsonPath)
+
+	t.Logf("Starting rudder-server")
+	t.Setenv("DEPLOYMENT_TYPE", string(deployment.DedicatedType))
+
+	t.Setenv("JOBS_DB_PORT", postgresContainer.Port)
+	t.Setenv("JOBS_DB_USER", postgresContainer.User)
+	t.Setenv("JOBS_DB_DB_NAME", postgresContainer.Database)
+	t.Setenv("JOBS_DB_PASSWORD", postgresContainer.Password)
+	t.Setenv("DEST_TRANSFORM_URL", transformerContainer.TransformURL)
+
+	t.Setenv("RSERVER_WAREHOUSE_MODE", "off")
+	t.Setenv("RSERVER_ENABLE_STATS", "false")
+	t.Setenv("RSERVER_JOBS_DB_BACKUP_ENABLED", "false")
+
+	// generatorLoop
+	t.Setenv("RSERVER_ROUTER_JOB_QUERY_BATCH_SIZE", "500")
+	t.Setenv("RSERVER_ROUTER_READ_SLEEP", "10ms")
+	t.Setenv("RSERVER_ROUTER_MIN_RETRY_BACKOFF", "5ms")
+	t.Setenv("RSERVER_ROUTER_MAX_RETRY_BACKOFF", "10ms")
+	t.Setenv("RSERVER_ROUTER_ALLOW_ABORTED_USER_JOBS_COUNT_FOR_PROCESSING", "1")
+
+	// worker
+	t.Setenv("RSERVER_ROUTER_NO_OF_JOBS_PER_CHANNEL", "100")
+	t.Setenv("RSERVER_ROUTER_JOBS_BATCH_TIMEOUT", "100ms")
+
+	// statusInsertLoop
+	t.Setenv("RSERVER_ROUTER_UPDATE_STATUS_BATCH_SIZE", "100")
+	t.Setenv("RSERVER_ROUTER_MAX_STATUS_UPDATE_WAIT", "10ms")
+
+	// hack
+	// t.Setenv("RSERVER_ROUTER_GUARANTEE_USER_EVENT_ORDER", "false")
+
+	// find free port for gateway http server to listen on
+	httpPortInt, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	gatewayPort = strconv.Itoa(httpPortInt)
+
+	t.Setenv("RSERVER_GATEWAY_WEB_PORT", gatewayPort)
+	t.Setenv("RUDDER_TMPDIR", os.TempDir())
+
+	svcDone := make(chan struct{})
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				if passed {
+					t.Logf("server panicked: %v", r)
+					close(svcDone)
+				} else {
+					t.Errorf("server panicked: %v", r)
+				}
+			}
+		}()
+		_ = main.Run(ctx)
+		close(svcDone)
+	}()
+
+	t.Logf("waiting rudder-server to start properly")
+	require.Eventually(t, func() bool {
+		url := fmt.Sprintf("http://localhost:%s/health", gatewayPort)
+		if resp, err := http.Get(url); err == nil {
+			resp.Body.Close()
+			return resp.StatusCode == 200
+		}
+		return false
+	}, 20*time.Second, 100*time.Millisecond, "server should be able to start")
+
+	t.Logf("rudder-server started")
+
+	batches := m.splitInBatches(spec.jobsOrdered, batchSize)
+	t.Logf("Sending %d total events for %d total users in %d batches", len(spec.jobsOrdered), users, len(batches))
+	client := &http.Client{}
+	for _, payload := range batches {
+		url := fmt.Sprintf("http://localhost:%s/v1/batch", gatewayPort)
+		req, err := http.NewRequest("POST", url, bytes.NewReader(payload))
+		req.SetBasicAuth(writeKey, "password")
+		resp, err := client.Do(req)
+		require.NoError(t, err, "should be able to send the request to gateway")
+		require.Equal(t, http.StatusOK, resp.StatusCode, "should be able to send the request to gateway successfully", payload)
+		resp.Body.Close()
+	}
+
+	t.Logf("Waiting for the magic to happen... eventually")
+
+	var done int
+	require.Eventually(t, func() bool {
+		if t.Failed() { // webhook failed, no point in keep retrying
+			return true
+		}
+		total := len(spec.jobs)
+		if done != len(spec.done) {
+			done = len(spec.done)
+			t.Logf("%d/%d done", done, total)
+		}
+		return done == total
+	}, 180*time.Second, 2*time.Second, "webhook should receive all events and process them till the end")
+
+	require.False(t, t.Failed(), "webhook shouldn't have failed")
+
+	for userID, jobs := range spec.doneOrdered {
+		var previousJobID int
+		for _, jobID := range jobs {
+			require.Greater(t, jobID, previousJobID, "%s: jobID %d should be greater than previous jobID %d", userID, jobID, previousJobID)
+			previousJobID = jobID
+		}
+	}
+
+	t.Logf("All jobs arrived in expected order - test passed!")
+	passed = true
+	cancel()
+	<-svcDone
+}
+
+// Using a struct to keep main_test package clean and
+// avoid method collisions with other tests
+// TODO: Move server's Run() out of main package
+type eventOrderMethods struct{}
+
+func (m eventOrderMethods) newTestSpec(users, jobsPerUser int) *eventOrderSpec {
+	rand.Seed(time.Now().UnixNano())
+	var s eventOrderSpec
+	s.jobsOrdered = make([]*eventOrderJobSpec, jobsPerUser*users)
+	s.jobs = map[int]*eventOrderJobSpec{}
+	s.received = map[int]int{}
+	s.done = map[int]struct{}{}
+	s.doneOrdered = map[string][]int{}
+
+	var idx int
+	for u := 0; u < users; u++ {
+		userID := trand.String(27)
+		for i := 0; i < jobsPerUser; i++ {
+			jobID := idx + 1
+
+			var statuses []int
+			var terminal bool
+			for !terminal {
+				var status int
+				status, terminal = m.randomStatus()
+				statuses = append(statuses, status)
+			}
+			js := eventOrderJobSpec{
+				id:        jobID,
+				userID:    userID,
+				responses: statuses,
+			}
+			s.jobsOrdered[idx] = &js
+			s.jobs[jobID] = &js
+			idx++
+		}
+	}
+	return &s
+}
+
+func (eventOrderMethods) randomStatus() (status int, terminal bool) {
+	// playing with probabilities: 50% HTTP 500, 40% HTTP 200, 10% HTTP 400
+	statuses := []int{
+		http.StatusBadRequest, http.StatusBadRequest, http.StatusBadRequest, http.StatusBadRequest, http.StatusBadRequest,
+		http.StatusOK, http.StatusOK, http.StatusOK, http.StatusOK,
+		http.StatusInternalServerError,
+	}
+	status = statuses[rand.Intn(len(statuses))]
+	terminal = status != http.StatusInternalServerError
+	return status, terminal
+}
+
+func (eventOrderMethods) newWebhook(t *testing.T, spec *eventOrderSpec) *eventOrderWebhook {
+	var wh eventOrderWebhook
+	wh.spec = spec
+
+	wh.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err, "should be able to read the request body")
+		testJobId := gjson.GetBytes(body, "testJobId")
+		require.True(t, testJobId.Exists(), "should have testJobId in the request", body)
+		require.Equal(t, gjson.Number, testJobId.Type, "testJobId should be a number", body)
+		jobID := int(gjson.GetBytes(body, "testJobId").Int())
+
+		userIdResult := gjson.GetBytes(body, "userId")
+		require.True(t, userIdResult.Exists(), "should have userId in the request", body)
+		require.Equal(t, gjson.String, userIdResult.Type, "userId should be a string", body)
+		userID := userIdResult.String()
+
+		wh.mu.Lock()
+		defer wh.mu.Unlock()
+
+		jobSpec, ok := wh.spec.jobs[jobID]
+		require.True(t, ok, "should be able to find the job spec for job: %d", jobID)
+		_, ok = wh.spec.done[jobID]
+		require.False(t, ok, "shouldn't receive a request for a job that is already done: %d", jobID)
+		times, _ := wh.spec.received[jobID]
+		require.True(t, times < len(jobSpec.responses), "shouldn't receive more requests than the number of responses for job: %d", jobID)
+		responseCode := jobSpec.responses[times]
+		require.NotEqual(t, 0, responseCode, "should be able to find the next response code to send for job: %d", jobID)
+		wh.spec.received[jobID] = times + 1
+
+		if responseCode != 500 { // job is now done
+			require.Equal(t, len(jobSpec.responses), wh.spec.received[jobID], "should have received all the expected requests for job %d before marking it as done", jobID)
+
+			var lastDoneId int
+			if len(wh.spec.doneOrdered[userID]) > 0 {
+				lastDoneId = wh.spec.doneOrdered[userID][len(wh.spec.doneOrdered[userID])-1]
+			}
+			require.Greater(t, jobID, lastDoneId, "received out-of-order event for job %d after job %d", jobID, lastDoneId)
+			wh.spec.done[jobID] = struct{}{}
+			wh.spec.doneOrdered[userID] = append(wh.spec.doneOrdered[userID], jobID)
+			// t.Logf("job %d done", jobID)
+		}
+		if spec.responseDelay > 0 {
+			time.Sleep(time.Duration(rand.Intn(int(spec.responseDelay.Milliseconds()))) * time.Millisecond)
+		}
+
+		w.WriteHeader(responseCode)
+		_, error := w.Write([]byte(fmt.Sprintf("%d", responseCode)))
+		require.NoError(t, error, "should be able to write the response code to the response")
+	}))
+	return &wh
+}
+
+// splitInBatches creates batches of jobs from the same user and shuffles them so that batches
+// for the same user do not appear one after the other. The shuffling algorithm respects ordering of
+// batches at user level
+func (eventOrderMethods) splitInBatches(jobs []*eventOrderJobSpec, batchSize int) [][]byte {
+	var payloads map[string][]string = map[string][]string{}
+	for _, job := range jobs {
+		payloads[job.userID] = append(payloads[job.userID], job.payload())
+	}
+
+	batches := map[string][][]byte{}
+	for userID, userPayloads := range payloads {
+		var userBatches [][]string
+
+		for batchSize < len(userPayloads) {
+			userPayloads, userBatches = userPayloads[batchSize:], append(userBatches, userPayloads[0:batchSize])
+		}
+		userBatches = append(userBatches, userPayloads)
+		var userJsonBatches [][]byte
+		for _, batch := range userBatches {
+			userJsonBatches = append(userJsonBatches, []byte(fmt.Sprintf(`{"batch":[%s]}`, strings.Join(batch, ","))))
+		}
+		batches[userID] = userJsonBatches
+	}
+	var jsonBatches [][]byte
+	var done bool
+	for i := 0; !done; i++ {
+		previousLength := len(jsonBatches)
+		for _, userJsonBatches := range batches {
+			if len(userJsonBatches) > i {
+				jsonBatches = append(jsonBatches, userJsonBatches[i])
+			}
+		}
+		if len(jsonBatches) == previousLength {
+			done = true
+		}
+	}
+
+	return jsonBatches
+}
+
+type eventOrderWebhook struct {
+	mu     sync.Mutex
+	Server *httptest.Server
+	spec   *eventOrderSpec
+}
+
+type eventOrderSpec struct {
+	jobs          map[int]*eventOrderJobSpec
+	jobsOrdered   []*eventOrderJobSpec
+	received      map[int]int
+	responseDelay time.Duration
+	done          map[int]struct{}
+	doneOrdered   map[string][]int
+}
+
+type eventOrderJobSpec struct {
+	id        int
+	userID    string
+	responses []int
+}
+
+func (jobSpec *eventOrderJobSpec) payload() string {
+	template := `{
+				"userId": %q,
+				"anonymousId": %q,
+				"testJobId": %d,
+				"type": "identify",
+				"context":
+				{
+					"traits":
+					{
+						"trait1": "new-val"
+					},
+					"ip": "14.5.67.21",
+					"library":
+					{
+						"name": "http"
+					}
+				},
+				"timestamp": "2020-02-02T00:23:09.544Z"
+			}`
+	return fmt.Sprintf(template, jobSpec.userID, jobSpec.userID, jobSpec.id)
+}

--- a/main.go
+++ b/main.go
@@ -253,7 +253,7 @@ func Run(ctx context.Context) int {
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() (err error) {
-		if err = admin.StartServer(ctx); err != nil {
+		if err = admin.StartServer(ctx); err != nil && ctx.Err() == nil {
 			if !errors.Is(err, context.Canceled) {
 				pkgLogger.Errorf("Error in Admin server routine: %v", err)
 			}
@@ -263,7 +263,7 @@ func Run(ctx context.Context) int {
 
 	g.Go(func() (err error) {
 		p := &profiler.Profiler{}
-		if err = p.StartServer(ctx); err != nil {
+		if err = p.StartServer(ctx); err != nil && ctx.Err() == nil {
 			pkgLogger.Errorf("Error in Profiler server routine: %v", err)
 		}
 		return err
@@ -273,7 +273,7 @@ func Run(ctx context.Context) int {
 	if canStartServer() {
 		appHandler.HandleRecovery(options)
 		g.Go(misc.WithBugsnag(func() (err error) {
-			if err = appHandler.StartRudderCore(ctx, options); err != nil {
+			if err = appHandler.StartRudderCore(ctx, options); err != nil && ctx.Err() == nil {
 				pkgLogger.Errorf("Error in Rudder Core routine: %v", err)
 			}
 			return err
@@ -293,7 +293,7 @@ func Run(ctx context.Context) int {
 	shutdownDone := make(chan struct{})
 	go func() {
 		err := g.Wait()
-		if err != nil && err != context.Canceled {
+		if err != nil && ctx.Err() == nil {
 			pkgLogger.Error(err)
 		}
 

--- a/router/admin.go
+++ b/router/admin.go
@@ -57,7 +57,7 @@ func (ra *Admin) Status() interface{} {
 		for _, worker := range router.workers {
 			worker.abortedUserMutex.RLock()
 			for k, v := range worker.abortedUserIDMap {
-				abortedUsersMap[k] = v
+				abortedUsersMap[k] = len(v)
 			}
 			worker.abortedUserMutex.RUnlock()
 		}

--- a/router/router.go
+++ b/router/router.go
@@ -66,21 +66,25 @@ type HandleDestOAuthRespParamsT struct {
 
 // HandleT is the handle to this module.
 type HandleT struct {
-	responseQ                              chan jobResponseT
-	jobsDB                                 jobsdb.MultiTenantJobsDB
-	errorDB                                jobsdb.JobsDB
-	netHandle                              NetHandleI
-	MultitenantI                           tenantStats
-	destName                               string
-	workers                                []*workerT
-	perfStats                              *misc.PerfStats
-	successCount                           uint64
-	failCount                              uint64
-	failedEventsListMutex                  sync.RWMutex
-	failedEventsList                       *list.List
-	failedEventsChan                       chan jobsdb.JobStatusT
-	toClearFailJobIDMutex                  sync.Mutex
-	toClearFailJobIDMap                    map[int][]string
+	responseQ             chan jobResponseT
+	jobsDB                jobsdb.MultiTenantJobsDB
+	errorDB               jobsdb.JobsDB
+	netHandle             NetHandleI
+	MultitenantI          tenantStats
+	destName              string
+	workers               []*workerT
+	perfStats             *misc.PerfStats
+	successCount          uint64
+	failCount             uint64
+	failedEventsListMutex sync.RWMutex
+	failedEventsList      *list.List
+	failedEventsChan      chan jobsdb.JobStatusT
+
+	eventOrderSyncMu        sync.Mutex                            // protects all maps below
+	toClearFailJobIDMap     map[int][]string                      // list of userIDs to clear from failedJobIDMap for each worker
+	toClearAbortedJobIDMap  map[int][]string                      // list of userIDs to clear from abortedUserIDMap for each worker
+	toRemoveAbortedJobIDMap map[int]map[string]map[int64]struct{} // list of jobIDs to remove from each userID contained in the abortedUserIDMap for each worker
+
 	requestsMetricLock                     sync.RWMutex
 	failureMetricLock                      sync.RWMutex
 	diagnosisTicker                        *time.Ticker
@@ -188,7 +192,7 @@ type workerT struct {
 	routerDeliveryLatencyStat  stats.RudderStats
 	routerProxyStat            stats.RudderStats
 	batchTimeStat              stats.RudderStats
-	abortedUserIDMap           map[string]int // aborted user to count of jobs allowed map
+	abortedUserIDMap           map[string]map[int64]struct{} // aborted user to list of accepted jobs map
 	abortedUserMutex           sync.RWMutex
 	jobCountsByDestAndUser     map[string]*destJobCountsT
 	throttledAtTime            time.Time
@@ -985,13 +989,6 @@ func (worker *workerT) postStatusOnResponseQ(respStatusCode int, respBody string
 		worker.rt.logger.Debugf("[%v Router] :: sending success status to response", worker.rt.destName)
 		worker.rt.responseQ <- jobResponseT{status: status, worker: worker, userID: destinationJobMetadata.UserID, JobT: destinationJobMetadata.JobT}
 
-		if worker.rt.guaranteeUserEventOrder {
-			// Removing the user from aborted user map
-			worker.abortedUserMutex.Lock()
-			delete(worker.abortedUserIDMap, destinationJobMetadata.UserID)
-			worker.abortedUserMutex.Unlock()
-		}
-
 		// Deleting jobID from retryForJobMap. jobID goes into retryForJobMap if it is failed with 5xx or 429.
 		// It's safe to delete from the map, even if jobID is not present.
 		worker.retryForJobMapMutex.Lock()
@@ -1011,10 +1008,6 @@ func (worker *workerT) postStatusOnResponseQ(respStatusCode int, respBody string
 		worker.failedJobs++
 		atomic.AddUint64(&worker.rt.failCount, 1)
 
-		// addToFailedMap is used to decide whether the jobID has to be added to the failedJobIDMap.
-		// If the job is aborted then there is no point in adding it to the failedJobIDMap.
-		addToFailedMap := true
-		addToAbortMap := true
 		status.JobState = jobsdb.Failed.State
 
 		worker.rt.failedEventsChan <- *status
@@ -1032,9 +1025,6 @@ func (worker *workerT) postStatusOnResponseQ(respStatusCode int, respBody string
 					worker.retryForJobMap[destinationJobMetadata.JobID] = time.Now().Add(durationBeforeNextAttempt(status.AttemptNum))
 					worker.retryForJobMapMutex.Unlock()
 				}
-			} else {
-				addToFailedMap = false
-				addToAbortMap = false
 			}
 		} else if respStatusCode == 429 {
 			worker.retryForJobMapMutex.Lock()
@@ -1045,39 +1035,31 @@ func (worker *workerT) postStatusOnResponseQ(respStatusCode int, respBody string
 		}
 
 		if status.JobState == jobsdb.Aborted.State {
-			addToFailedMap = false
 			worker.updateAbortedMetrics(destinationJobMetadata.DestinationID, status.ErrorCode)
 			destinationJobMetadata.JobT.Parameters = misc.UpdateJSONWithNewKeyVal(destinationJobMetadata.JobT.Parameters, "stage", "router")
 			destinationJobMetadata.JobT.Parameters = misc.UpdateJSONWithNewKeyVal(destinationJobMetadata.JobT.Parameters, "reason", status.ErrorResponse) // NOTE: Old key used was "error_response"
 		}
 
 		if worker.rt.guaranteeUserEventOrder {
-			if addToFailedMap {
+			if status.JobState == jobsdb.Failed.State {
 				//#JobOrder (see other #JobOrder comment)
-				worker.failedJobIDMutex.RLock()
+				worker.failedJobIDMutex.Lock()
 				_, isPrevFailedUser := worker.failedJobIDMap[destinationJobMetadata.UserID]
-				worker.failedJobIDMutex.RUnlock()
 				if !isPrevFailedUser && destinationJobMetadata.UserID != "" {
 					worker.rt.logger.Debugf("[%v Router] :: userId %v failed for the first time adding to map", worker.rt.destName, destinationJobMetadata.UserID)
-					worker.failedJobIDMutex.Lock()
 					worker.failedJobIDMap[destinationJobMetadata.UserID] = destinationJobMetadata.JobID
-					worker.failedJobIDMutex.Unlock()
 				}
-			} else if addToAbortMap {
+				worker.failedJobIDMutex.Unlock()
+			} else if status.JobState == jobsdb.Aborted.State {
 				// Job is aborted.
 				// So, adding the user to aborted map, if not already present.
 				// If user is present in the aborted map, decrementing the count.
 				// This map is used to limit the pickup of aborted user's job.
 				worker.abortedUserMutex.Lock()
 				worker.rt.logger.Debugf("[%v Router] :: adding userID to abortedUserMap : %s", worker.rt.destName, destinationJobMetadata.UserID)
-				count, ok := worker.abortedUserIDMap[destinationJobMetadata.UserID]
-				if !ok {
-					worker.abortedUserIDMap[destinationJobMetadata.UserID] = 0
-				} else {
-					// Decrementing the count.
-					// This is necessary to let other jobs of the same user to get a worker.
-					count--
-					worker.abortedUserIDMap[destinationJobMetadata.UserID] = count
+				if _, ok := worker.abortedUserIDMap[destinationJobMetadata.UserID]; !ok {
+					// this will enable the concurrency limiter
+					worker.abortedUserIDMap[destinationJobMetadata.UserID] = map[int64]struct{}{}
 				}
 				worker.abortedUserMutex.Unlock()
 			}
@@ -1229,7 +1211,7 @@ func (rt *HandleT) initWorkers() {
 			batchTimeStat:             stats.NewTaggedStat("router_batch_time", stats.TimerType, stats.Tags{"destType": rt.destName}),
 			routerDeliveryLatencyStat: stats.NewTaggedStat("router_delivery_latency", stats.TimerType, stats.Tags{"destType": rt.destName}),
 			routerProxyStat:           stats.NewTaggedStat("router_proxy_latency", stats.TimerType, stats.Tags{"destType": rt.destName}),
-			abortedUserIDMap:          make(map[string]int),
+			abortedUserIDMap:          make(map[string]map[int64]struct{}),
 			jobCountsByDestAndUser:    make(map[string]*destJobCountsT),
 		}
 		rt.workers[i] = worker
@@ -1306,19 +1288,22 @@ func (rt *HandleT) findWorker(job *jobsdb.JobT, throttledAtTime time.Time) (toSe
 		// if yes returning worker only for 1 job
 		worker.abortedUserMutex.Lock()
 		defer worker.abortedUserMutex.Unlock()
-		if count, ok := worker.abortedUserIDMap[userID]; ok {
-			if count >= rt.allowAbortedUserJobsCountForProcessing {
+		if runningJobIDs, ok := worker.abortedUserIDMap[userID]; ok {
+			count := len(runningJobIDs)
+			_, hasJobID := runningJobIDs[job.JobID]
+
+			if !hasJobID && count >= rt.allowAbortedUserJobsCountForProcessing {
 				rt.logger.Debugf("[%v Router] :: allowed jobs count(%d) >= allowAbortedUserJobsCountForProcessing(%d) for userID %s. returning nil worker", rt.destName, count, rt.allowAbortedUserJobsCountForProcessing, userID)
 				return nil
 			}
 
 			rt.logger.Debugf("[%v Router] :: userID found in abortedUserIDtoJobMap: %s. Allowing jobID: %d. returning worker", rt.destName, userID, job.JobID)
-			// incrementing abortedUserIDMap after all checks of backoff, throttle etc are made
+			// adding job to abortedUserIDMap after all checks of backoff, throttle etc are made
 			// We don't need lock inside this defer func, because we already hold the lock above and this
 			// defer is called before defer Unlock
 			defer func() {
 				if toSendWorker != nil {
-					toSendWorker.abortedUserIDMap[userID] = toSendWorker.abortedUserIDMap[userID] + 1
+					toSendWorker.abortedUserIDMap[userID][job.JobID] = struct{}{}
 				}
 			}()
 		}
@@ -1337,7 +1322,7 @@ func (rt *HandleT) findWorker(job *jobsdb.JobT, throttledAtTime time.Time) (toSe
 	// checking if this job can be backoff
 	if toSendWorker != nil {
 		if toSendWorker.canBackoff(job) {
-			return nil
+			toSendWorker = nil
 		}
 	}
 
@@ -1544,21 +1529,49 @@ func (rt *HandleT) commitStatusList(responseList *[]jobResponseT) {
 			status := resp.status.JobState
 			userID := resp.userID
 			worker := resp.worker
+			rt.eventOrderSyncMu.Lock()
+
 			if status == jobsdb.Succeeded.State || status == jobsdb.Aborted.State {
 				worker.failedJobIDMutex.RLock()
 				lastJobID, ok := worker.failedJobIDMap[userID]
 				worker.failedJobIDMutex.RUnlock()
 				if ok && lastJobID == resp.status.JobID {
-					rt.toClearFailJobIDMutex.Lock()
 					rt.logger.Debugf("[%v Router] :: clearing failedJobIDMap for userID: %v", rt.destName, userID)
 					_, ok := rt.toClearFailJobIDMap[worker.workerID]
 					if !ok {
 						rt.toClearFailJobIDMap[worker.workerID] = make([]string, 0)
 					}
 					rt.toClearFailJobIDMap[worker.workerID] = append(rt.toClearFailJobIDMap[worker.workerID], userID)
-					rt.toClearFailJobIDMutex.Unlock()
 				}
 			}
+
+			// aborted jobIDs
+			worker.abortedUserMutex.RLock()
+			if runningJobs, ok := worker.abortedUserIDMap[userID]; ok {
+				if status == jobsdb.Succeeded.State {
+					// clear the map in the next generatorLoop
+					_, ok := rt.toClearAbortedJobIDMap[worker.workerID]
+					if !ok {
+						rt.toClearAbortedJobIDMap[worker.workerID] = make([]string, 0)
+					}
+					rt.toClearAbortedJobIDMap[worker.workerID] = append(rt.toClearAbortedJobIDMap[worker.workerID], userID)
+				} else { // any other state
+					if _, ok = runningJobs[resp.status.JobID]; ok {
+						// remove the jobID from the concurrency map during the next generatorLoop
+						_, ok := rt.toRemoveAbortedJobIDMap[worker.workerID]
+						if !ok {
+							rt.toRemoveAbortedJobIDMap[worker.workerID] = map[string]map[int64]struct{}{}
+						}
+						if _, ok := rt.toRemoveAbortedJobIDMap[worker.workerID][userID]; !ok {
+							rt.toRemoveAbortedJobIDMap[worker.workerID][userID] = make(map[int64]struct{})
+						}
+						rt.toRemoveAbortedJobIDMap[worker.workerID][userID][resp.status.JobID] = struct{}{}
+					}
+				}
+			}
+			worker.abortedUserMutex.RUnlock()
+
+			rt.eventOrderSyncMu.Unlock()
 		}
 		// End #JobOrder
 	}
@@ -1749,7 +1762,9 @@ func (rt *HandleT) generatorLoop(ctx context.Context) {
 func (rt *HandleT) readAndProcess() int {
 	if rt.guaranteeUserEventOrder {
 		//#JobOrder (See comment marked #JobOrder
-		rt.toClearFailJobIDMutex.Lock()
+		rt.eventOrderSyncMu.Lock()
+
+		// clearing failed job ids
 		for idx := range rt.toClearFailJobIDMap {
 			wrk := rt.workers[idx]
 			wrk.failedJobIDMutex.Lock()
@@ -1759,7 +1774,35 @@ func (rt *HandleT) readAndProcess() int {
 			wrk.failedJobIDMutex.Unlock()
 		}
 		rt.toClearFailJobIDMap = make(map[int][]string)
-		rt.toClearFailJobIDMutex.Unlock()
+
+		// clearing aborted job concurrency maps (disabling concurrency limiter for aborted jobs)
+		for idx := range rt.toClearAbortedJobIDMap {
+			wrk := rt.workers[idx]
+			wrk.abortedUserMutex.Lock()
+			for _, userID := range rt.toClearAbortedJobIDMap[idx] {
+				delete(wrk.abortedUserIDMap, userID)
+			}
+			wrk.abortedUserMutex.Unlock()
+		}
+		rt.toClearAbortedJobIDMap = make(map[int][]string)
+
+		// removing jobs from aborted job concurrency maps (letting room for new jobs to be picked up)
+		for idx := range rt.toRemoveAbortedJobIDMap {
+			wrk := rt.workers[idx]
+			wrk.abortedUserMutex.Lock()
+			for userID, jobIDs := range rt.toRemoveAbortedJobIDMap[idx] {
+				abortedJobs, ok := wrk.abortedUserIDMap[userID]
+				if ok {
+					for jobID := range jobIDs {
+						delete(abortedJobs, jobID)
+					}
+				}
+			}
+			wrk.abortedUserMutex.Unlock()
+		}
+		rt.toRemoveAbortedJobIDMap = make(map[int]map[string]map[int64]struct{})
+
+		rt.eventOrderSyncMu.Unlock()
 		// End of #JobOrder
 	}
 
@@ -2059,6 +2102,9 @@ func (rt *HandleT) Setup(backendConfig backendconfig.BackendConfig, jobsDB jobsd
 	rt.crashRecover()
 	rt.responseQ = make(chan jobResponseT, jobQueryBatchSize)
 	rt.toClearFailJobIDMap = make(map[int][]string)
+	rt.toClearAbortedJobIDMap = make(map[int][]string)
+	rt.toRemoveAbortedJobIDMap = make(map[int]map[string]map[int64]struct{})
+
 	rt.failedEventsList = list.New()
 	rt.failedEventsChan = make(chan jobsdb.JobStatusT)
 

--- a/services/multitenant/tenantstats.go
+++ b/services/multitenant/tenantstats.go
@@ -241,6 +241,7 @@ func (t *Stats) GetRouterPickupJobs(destType string, noOfWorkers int, routerTime
 					timeRequired = 0
 				}
 				runningTimeCounter = runningTimeCounter - timeRequired
+				workspacePickUpCount[workspaceKey] = misc.MinInt(workspacePickUpCount[workspaceKey], runningJobCount)
 				runningJobCount = runningJobCount - workspacePickUpCount[workspaceKey]
 				usedLatencies[workspaceKey] = t.routerTenantLatencyStat[destType][workspaceKey].Value()
 				pkgLogger.Debugf("Time Calculated : %v , Remaining Time : %v , Workspace : %v ,runningJobCount : %v , moving_average_latency : %v, routerInRate : %v ,DestType : %v,InRateLoop ", timeRequired, runningTimeCounter, workspaceKey, runningJobCount, t.routerTenantLatencyStat[destType][workspaceKey].Value(), destTypeCount.Value(), destType)

--- a/testdata/eventOrderTestTemplate.json
+++ b/testdata/eventOrderTestTemplate.json
@@ -1,0 +1,111 @@
+{
+    "enableMetrics": false,
+    "workspaceId": "{{.workspaceId}}",
+    "sources": [
+        {
+            "config": {},
+            "id": "xxxyyyzzEaEurW247ad9WYZLUyk",
+            "name": "Dev Integration Test 1",
+            "writeKey": "{{.writeKey}}",
+            "enabled": true,
+            "sourceDefinitionId": "xxxyyyzzpWDzNxgGUYzq9sZdZZB",
+            "createdBy": "xxxyyyzzueyoBz4jb7bRdOzDxai",
+            "workspaceId": "{{.workspaceId}}",
+            "deleted": false,
+            "createdAt": "2021-08-27T06:33:00.305Z",
+            "updatedAt": "2021-08-27T06:33:00.305Z",
+            "destinations": [
+                {
+                    "config": {
+                        "webhookUrl": "{{.webhookUrl}}",
+                        "webhookMethod": "POST"
+                    },
+                    "secretConfig": {},
+                    "id": "xxxyyyzzP9kQfzOoKd1tuxchYAG",
+                    "name": "Des WebHook Integration Test 1",
+                    "enabled": true,
+                    "workspaceId": "{{.workspaceId}}",
+                    "deleted": false,
+                    "createdAt": "2021-08-27T06:49:38.546Z",
+                    "updatedAt": "2021-08-27T06:49:38.546Z",
+                    "transformations": [
+                        {
+                            "versionId": "23hZ5VLGt0Yl7Hxk9ysBGi5baud",
+                            "config": {},
+                            "id": "23VJjP3bbHMzUhWjI7bvNL5S9xx"
+                        }
+                    ],
+                    "destinationDefinition": {
+                        "config": {
+                            "destConfig": {
+                                "defaultConfig": [
+                                    "webhookUrl",
+                                    "webhookMethod",
+                                    "headers"
+                                ]
+                            },
+                            "secretKeys": [
+                                "headers.to"
+                            ],
+                            "excludeKeys": [],
+                            "includeKeys": [],
+                            "transformAt": "processor",
+                            "transformAtV1": "processor",
+                            "supportedSourceTypes": [
+                                "android",
+                                "ios",
+                                "web",
+                                "unity",
+                                "amp",
+                                "cloud",
+                                "warehouse",
+                                "reactnative",
+                                "flutter"
+                            ],
+                            "supportedMessageTypes": [
+                                "alias",
+                                "group",
+                                "identify",
+                                "page",
+                                "screen",
+                                "track"
+                            ],
+                            "saveDestinationResponse": false
+                        },
+                        "configSchema": null,
+                        "responseRules": null,
+                        "id": "xxxyyyzzSOU9pLRavMf0GuVnWV3",
+                        "name": "WEBHOOK",
+                        "displayName": "Webhook",
+                        "category": null,
+                        "createdAt": "2020-03-16T19:25:28.141Z",
+                        "updatedAt": "2021-08-26T07:06:01.445Z"
+                    },
+                    "isConnectionEnabled": true,
+                    "isProcessorEnabled": true
+                }
+            ],
+            "sourceDefinition": {
+                "id": "xxxyyyzzpWDzNxgGUYzq9sZdZZB",
+                "name": "HTTP",
+                "options": null,
+                "displayName": "HTTP",
+                "category": "",
+                "createdAt": "2020-06-12T06:35:35.962Z",
+                "updatedAt": "2020-06-12T06:35:35.962Z"
+            },
+            "dgSourceTrackingPlanConfig": null
+        }
+    ],
+    "libraries": [
+        {
+            "versionId": "def"
+        },
+        {
+            "versionId": "ghi"
+        },
+        {
+            "versionId": "23Uxw7QEiOg8e0KkQV8LmNfWaWh"
+        }
+    ]
+}


### PR DESCRIPTION
# Description
Fixed a bug with respect to event ordering when there are aborted jobs. The issue was that the algorithm was modifying its relevant `abortedUserIDMap` state in the wrong place at the wrong time, instead of waiting for the next iteration of `generatorLoop` to start, which is the pipeline's entry point and the proper synchronisation barrier.

Additionally
- Introduced an integration test to verify that ordering guarantees are respected in practice.

Side jobs
- Did some minor modification in logs in order to mute some false positive errors such as **_"Server closed"_**
- Modified tenantstats algorithm to make it respect the `jobQueryBatchSize` limit in case of a single workspace

**_Note_**
We are redesigning the event order algorithm in #2344

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=6f2b5742f6964d20adf673407888f9fb&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
