### PR TITLE
fix(jobsdb): report correct table count metrics from gateway writer

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1082,6 +1082,10 @@ func (jd *HandleT) refreshDSList(l lock.DSListLockToken) []dataSetT {
 	jd.datasetList = nil
 	jd.datasetList = getDSList(jd, jd.dbHandle, jd.tablePrefix)
 
+	// report table count metrics before shrinking the datasetList
+	jd.statTableCount.Gauge(len(jd.datasetList))
+	jd.statDSCount.Gauge(len(jd.datasetList))
+
 	// if the owner of this jobsdb is a writer, then shrinking datasetList to have only last two datasets
 	// this shrank datasetList is used to compute DSRangeList
 	// This is done because, writers don't care about the left datasets in the sorted datasetList
@@ -1091,8 +1095,6 @@ func (jd *HandleT) refreshDSList(l lock.DSListLockToken) []dataSetT {
 		}
 	}
 
-	jd.statTableCount.Gauge(len(jd.datasetList))
-	jd.statDSCount.Gauge(len(jd.datasetList))
 	return jd.datasetList
 }
 


### PR DESCRIPTION
# Description

Gateway's jobsdb is operating in writer mode and always reports at most two tables even though there are more gw table.
With this fix we are reporting the table count metrics before shrinking the dataset list for writer dbs.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=65986a9f6c374adcabec389b2af6b1c7&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
