### PR TITLE
chore(warehouse): update errorMap for deltalake partition query

### DIFF
--- a/warehouse/deltalake/deltalake.go
+++ b/warehouse/deltalake/deltalake.go
@@ -723,11 +723,11 @@ func (dl *HandleT) loadUserTables() (errorMap map[string]error) {
 		)
 	} else {
 		// Partition query
-		// Partition query
 		var partitionQuery string
 		partitionQuery, err = dl.partitionQuery(warehouseutils.UsersTable)
 		if err != nil {
 			err = fmt.Errorf("failed getting partition query during load users table, error: %w", err)
+			errorMap[warehouseutils.UsersTable] = err
 			return
 		}
 


### PR DESCRIPTION
# Description

Update errorMap for deltalake partition Query.

## Notion Ticket

https://www.notion.so/rudderstacks/Deltalake-Partitioning-Pruning-36b3999668d244b39045c14d2a6aae5d

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
