### PR TITLE
chore: include all supported pr types in changelog

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -19,4 +19,5 @@ jobs:
           release-type: go
           package-name: rudder-server
           default-branch: ${{ steps.extract_branch.outputs.branch }}
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false},{"type":"refactor","section":"Miscellaneous","hidden":false},{"type":"test","section":"Miscellaneous","hidden":false},{"type":"doc","section":"Documentation","hidden":false}]'
           bump-minor-pre-major: true


### PR DESCRIPTION
# Description

Not all PR types were included in the release PR and changelog. This was creating confusion as to what will be included in the next release. In the case of debugging, the hidden PRs might be critical for the investigation. For example, a simple chore could introduce a bug.

This PR changes release-please yaml file to include all our supported types in the release PR and changelog.
This is how those types map to changelog sections:

Section -> PR types 
--------------------
Features -> feat
Bug Fixes -> fix
Miscellaneous -> chore, refactor, test 
Documentation -> doc

Type `exp` is not expected to be merged on master, and thus it will be hidden.


## Notion Ticket

https://www.notion.so/rudderstacks/Include-all-types-in-release-PRs-689e5a8cba5043b6b4cc2d461aaa59aa

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
