### PR TITLE
refactor(router): new event ordering algorithm with proper aborted job limiting

### DIFF
--- a/router/admin.go
+++ b/router/admin.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/jobsdb"
@@ -53,16 +54,14 @@ func (ra *Admin) Status() interface{} {
 		if len(routerFailedList) > 0 {
 			routerStatus["recent-failedstatuses"] = routerFailedList
 		}
-		abortedUsersMap := make(map[string]int, 0)
-		for _, worker := range router.workers {
-			worker.abortedUserMutex.RLock()
-			for k, v := range worker.abortedUserIDMap {
-				abortedUsersMap[k] = len(v)
+		barriersMap := make(map[string]string, 0)
+		for i, worker := range router.workers {
+			if worker.barrier.Size() > 0 {
+				barriersMap[strconv.Itoa(i)] = worker.barrier.String()
 			}
-			worker.abortedUserMutex.RUnlock()
 		}
-		if len(abortedUsersMap) > 0 {
-			routerStatus["aborted-usersmap"] = abortedUsersMap
+		if len(barriersMap) > 0 {
+			routerStatus["worker-barriers"] = barriersMap
 		}
 
 		statusList = append(statusList, routerStatus)

--- a/router/internal/eventorder/eventorder.go
+++ b/router/internal/eventorder/eventorder.go
@@ -1,0 +1,260 @@
+package eventorder
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+)
+
+var ErrUnsupportedState = errors.New("unsupported state")
+
+// NewBarrier creates a new properly initialized Barrier
+func NewBarrier(abortConcurrencyLimit int) *Barrier {
+	return &Barrier{
+		concurrencyLimit: abortConcurrencyLimit,
+		barriers:         make(map[string]*barrierInfo),
+	}
+}
+
+// Barrier is an abstraction for applying event ordering guarantees in the router.
+//
+// Events for the same userID need to be processed in order, thus when an event fails but will be retried later by the router,
+// we need to put all subsequent events for that userID on hold until the failed event succeeds or fails
+// in a terminal way.
+//
+// A barrier controls the concurrency of events in two places:
+//
+// 1. At entrance, before the event enters the pipeline.
+//
+// 2. Before actually trying to send the event, since events after being accepted by the router, they are
+// processed asynchronously through buffered channels by separate goroutine(s) aka workers.
+type Barrier struct {
+	concurrencyLimit int
+	mu               sync.RWMutex
+	queue            []command
+	barriers         map[string]*barrierInfo
+}
+
+// Enter the barrier for this userID and jobID. If there is not already a barrier for this userID
+// returns true, otherwise false along with the previous failed jobID if this is the cause of the barrier.
+// Another scenario where a barrier might exist for a user is when the previous job has failed in an unrecoverable manner and the concurrency limiter is enabled.
+func (b *Barrier) Enter(userID string, jobID int64) (accepted bool, previousFailedJobID *int64) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	barrier, ok := b.barriers[userID]
+	if !ok {
+		return true, nil // no barrier, accept
+	}
+
+	// if there is a failed job in the barrier, only this job can enter the barrier
+	if barrier.failedJobID != nil {
+		failedJob := *barrier.failedJobID
+		return jobID == failedJob, &failedJob
+	}
+
+	// if the concurrency limiter is enabled, only the configured number of concurrent jobs can enter the barrier
+	if barrier.concurrencyLimiter != nil {
+		barrier.mu.Lock()
+		defer barrier.mu.Unlock()
+		if _, ok := barrier.concurrencyLimiter[jobID]; ok {
+			return true, nil // if the job is already in the concurrent jobs map, accept it (poor job... it forgot to notify the barrier before leaving!)
+		}
+		if len(barrier.concurrencyLimiter) >= b.concurrencyLimit {
+			return false, nil // if the concurrent jobs map is full, reject it
+		}
+
+		// add the job to the concurrent jobs map and accept it
+		barrier.concurrencyLimiter[jobID] = struct{}{}
+		return true, nil
+	}
+
+	return true, nil
+}
+
+// Wait returns true if the job for this userID shouldn't continue, but wait (transition to a waiting state)
+func (b *Barrier) Wait(userID string, jobID int64) (wait bool, previousFailedJobID *int64) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	barrier, ok := b.barriers[userID]
+	if !ok {
+		return false, nil // no barrier, don't wait
+	}
+	if barrier.failedJobID != nil {
+		failedJob := *barrier.failedJobID
+		if failedJob > jobID {
+			panic(fmt.Errorf("previousFailedJob:%d > jobID:%d", failedJob, jobID))
+		}
+		return jobID > failedJob, &failedJob // wait if this is not the failed job
+	}
+	// no failed job, don't wait
+	return false, nil
+}
+
+// StateChanged must be called at the end, after the job state change has been persisted.
+// The only exception to this rule is when a job has failed in a retryable manner, in this scenario you should notify the barrier immediately after the failure.
+// An [ErrUnsupportedState] error will be returned if the state is not supported.
+func (b *Barrier) StateChanged(userID string, jobID int64, state string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var command command
+	jsCmd := &cmd{userID: userID, jobID: jobID}
+	switch state {
+	case jobsdb.Succeeded.State:
+		command = &jobSucceededCmd{jsCmd}
+	case jobsdb.Failed.State:
+		command = &jobFailedCommand{jsCmd}
+	case jobsdb.Aborted.State:
+		command = &jobAbortedCommand{jsCmd}
+	case jobsdb.Waiting.State:
+		command = jsCmd
+	default:
+		return ErrUnsupportedState
+	}
+
+	if command.enqueue(b.barriers) {
+		b.queue = append(b.queue, command)
+	} else {
+		command.execute(b.barriers)
+	}
+	return nil
+}
+
+// Sync applies any enqueued commands to the barrier's state. It should be called at the beginning of every new iteration of the main loop
+func (b *Barrier) Sync() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, c := range b.queue {
+		c.execute(b.barriers)
+	}
+	flushed := len(b.queue)
+	b.queue = nil
+	return flushed
+}
+
+// Size returns the number of active user barriers
+func (b *Barrier) Size() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.barriers)
+}
+
+// String returns a string representation of the barrier
+func (b *Barrier) String() string {
+	var sb strings.Builder
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	sb.WriteString("Barrier{[")
+	for userID, barrier := range b.barriers {
+		failedJobID := "<nil>"
+		if barrier.failedJobID != nil {
+			failedJobID = fmt.Sprintf("%d", *barrier.failedJobID)
+		}
+		sb.WriteString(fmt.Sprintf("{userID: %s, failedJobID: %v, concurrentJobs: %v}", userID, failedJobID, barrier.concurrencyLimiter))
+	}
+	sb.WriteString("]}")
+	return sb.String()
+}
+
+type barrierInfo struct {
+	failedJobID        *int64             // nil if no failed job
+	mu                 sync.RWMutex       // protects concurrentJobs
+	concurrencyLimiter map[int64]struct{} // nil if concurrency limiter is off
+}
+
+type command interface {
+	enqueue(barriers map[string]*barrierInfo) bool
+	execute(barriers map[string]*barrierInfo)
+}
+
+type cmd struct {
+	userID string
+	jobID  int64
+}
+
+// default behaviour is to try and remove the jobID from the concurrent jobs map
+func (c *cmd) execute(barriers map[string]*barrierInfo) {
+	if barrier, ok := barriers[c.userID]; ok {
+		barrier.mu.Lock()
+		defer barrier.mu.Unlock()
+		delete(barrier.concurrencyLimiter, c.jobID)
+	}
+}
+
+// default behaviour is to enqueue the command if a barrier for this userID already exists
+func (c *cmd) enqueue(barriers map[string]*barrierInfo) bool {
+	_, ok := barriers[c.userID]
+	return ok
+}
+
+// jobFailedCommand is a command that is executed when a job has failed.
+type jobFailedCommand struct {
+	*cmd
+}
+
+// If no failed jobID is in the barrier make this jobID the failed job for this userID. Removes the job from the concurrent jobs map if it exists there
+func (c *jobFailedCommand) execute(barriers map[string]*barrierInfo) {
+	barrier, ok := barriers[c.userID]
+	if !ok {
+		barrier = &barrierInfo{}
+		barriers[c.userID] = barrier
+	}
+	barrier.mu.Lock()
+	defer barrier.mu.Unlock()
+
+	if barrier.failedJobID == nil {
+		barrier.failedJobID = &c.jobID
+	} else if *barrier.failedJobID > c.jobID {
+		panic(fmt.Errorf("previousFailedJob:%d > jobID:%d", *barrier.failedJobID, c.jobID))
+	}
+	// reset concurrency limiter
+	barrier.concurrencyLimiter = nil
+}
+
+// a failed command never gets enqueued
+func (*jobFailedCommand) enqueue(_ map[string]*barrierInfo) bool {
+	return false
+}
+
+// jobSucceededCmd is a command that is executed when a job has succeeded.
+type jobSucceededCmd struct {
+	*cmd
+}
+
+// removes the barrier for this userID, if it exists
+func (c *jobSucceededCmd) execute(barriers map[string]*barrierInfo) {
+	if barrier, ok := barriers[c.userID]; ok {
+		if barrier.failedJobID != nil && *barrier.failedJobID != c.jobID { // out-of-sync command (failed commands get executed immediately)
+			return
+		}
+	}
+	delete(barriers, c.userID)
+}
+
+// jobAbortedCommand is a command that is executed when a job has aborted.
+type jobAbortedCommand struct {
+	*cmd
+}
+
+// Creates a concurrent jobs map if none exists. Also removes the jobID from the concurrent jobs map if it exists there
+func (c *jobAbortedCommand) execute(barriers map[string]*barrierInfo) {
+	if barrier, ok := barriers[c.userID]; ok {
+		if barrier.failedJobID == nil {
+			// no previously failed job, simply remove the barrier
+			delete(barriers, c.userID)
+			return
+		}
+		if *barrier.failedJobID != c.jobID {
+			// out-of-sync command (failed commands get executed immediately)
+			return
+		}
+		// remove the failed jobID and enable the concurrency limiter
+		barrier.failedJobID = nil
+		barrier.mu.Lock()
+		barrier.concurrencyLimiter = make(map[int64]struct{})
+		barrier.mu.Unlock()
+	}
+}

--- a/router/internal/eventorder/eventorder.go
+++ b/router/internal/eventorder/eventorder.go
@@ -33,7 +33,7 @@ func NewBarrier(abortConcurrencyLimit int) *Barrier {
 // processed asynchronously through buffered channels by separate goroutine(s) aka workers.
 type Barrier struct {
 	concurrencyLimit int
-	mu               sync.RWMutex
+	mu               sync.RWMutex // mutex to synchronize concurrent access to the barrier's methods
 	queue            []command
 	barriers         map[string]*barrierInfo
 }

--- a/router/internal/eventorder/eventorder_simulation_test.go
+++ b/router/internal/eventorder/eventorder_simulation_test.go
@@ -1,0 +1,312 @@
+package eventorder_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/router/internal/eventorder"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	bufferSize = 20
+)
+
+func TestSimulateBarrier(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	const (
+		channelSize = 200
+		batchSize   = 10
+	)
+	workerQueue := make(chan *job, channelSize)
+	statusQueue := make(chan *job, channelSize)
+
+	jobs := newRandomJobs(100)
+	for _, job := range jobs {
+		t.Logf("%+v", *job)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var logger log = t
+	barrier := eventorder.NewBarrier(2)
+	generator := &generatorLoop{ctx: ctx, barrier: barrier, batchSize: batchSize, pending: jobs, out: workerQueue, logger: logger}
+	worker := &workerProcess{ctx: ctx, barrier: barrier, in: workerQueue, out: statusQueue, logger: logger}
+	commit := &commitStatusLoop{ctx: ctx, barrier: barrier, in: statusQueue, putBack: generator.putBack, logger: logger}
+
+	go generator.run()
+	go worker.run()
+	go commit.run()
+
+	require.Eventually(t, func() bool {
+		committed := commit.getCommitted()
+		return len(committed) == len(jobs)
+	}, 60*time.Second, 1*time.Second, "all jobs should be committed")
+
+	committed := commit.getCommitted()
+	var previous int64
+	for _, id := range committed {
+		require.True(t, id >= previous, "job ids should be committed in order", committed)
+		previous = id
+	}
+}
+
+type job struct {
+	id      int64
+	user    string
+	states  []string
+	retries int
+	loop    int
+}
+
+type generatorLoop struct {
+	ctx       context.Context
+	barrier   *eventorder.Barrier
+	logger    log
+	batchSize int
+	pendingMu sync.Mutex
+	pending   []*job
+	out       chan *job
+	runtime   struct {
+		batchSize int
+		minJobID  int64
+	}
+}
+
+func (g *generatorLoop) run() {
+	var loop int
+	g.runtime.batchSize = g.batchSize
+	for {
+		select {
+		case <-g.ctx.Done():
+			return
+		case <-time.After(10 * time.Millisecond):
+			batchSize := g.runtime.batchSize
+			g.pendingMu.Lock()
+			var toProcess []*job
+			if len(g.pending) < batchSize {
+				toProcess = make([]*job, len(g.pending))
+				copy(toProcess, g.pending)
+				g.pending = nil
+			} else {
+				toProcess = g.pending[0:batchSize]
+				g.pending = g.pending[batchSize:]
+			}
+
+			var acceptedJobs []*job
+			g.barrier.Sync()
+
+			var lastBlockJobID int64
+			for i, job := range toProcess {
+				if i == 0 {
+					g.runtime.minJobID = job.id
+				}
+				if accept, blockJobID := g.barrier.Enter(job.user, job.id); accept {
+					if blockJobID != nil && *blockJobID > job.id {
+						panic(fmt.Errorf("job.JobID:%d < blockJobID:%d", job.id, *blockJobID))
+					}
+					job.loop = loop
+					acceptedJobs = append(acceptedJobs, job)
+				} else {
+					if blockJobID != nil && job.id == *blockJobID {
+						panic(fmt.Errorf("job.JobID:%d == blockJobID:%d", job.id, *blockJobID))
+					}
+					if blockJobID != nil {
+						lastBlockJobID = *blockJobID
+					}
+					g.pending = append(g.pending, job)
+				}
+			}
+			sort.Slice(g.pending, func(i, j int) bool {
+				return g.pending[i].id < g.pending[j].id
+			})
+			g.pendingMu.Unlock()
+
+			if len(acceptedJobs) == 0 && lastBlockJobID > g.runtime.minJobID {
+				newBatchSize := int(lastBlockJobID-g.runtime.minJobID) + 1
+				if newBatchSize > g.batchSize {
+					g.runtime.batchSize = newBatchSize
+					// need to make batch size at least as large as the difference of the last block job id and the min job id
+					g.logger.Logf("adapted runtime batch size to %d (lastBlockJobID: %d, minJobID: %d)", g.runtime.batchSize, lastBlockJobID, g.runtime.minJobID)
+				}
+			} else if g.runtime.batchSize != g.batchSize {
+				g.runtime.batchSize = g.batchSize
+				g.logger.Logf("reverted runtime batch size back to %d", g.runtime.batchSize)
+			}
+			for _, job := range acceptedJobs {
+				g.out <- job
+			}
+		}
+		loop++
+	}
+}
+
+func (g *generatorLoop) putBack(jobs []*job) {
+	g.pendingMu.Lock()
+	defer g.pendingMu.Unlock()
+	g.pending = append(g.pending, jobs...)
+	sort.Slice(g.pending, func(i, j int) bool {
+		return g.pending[i].id < g.pending[j].id
+	})
+}
+
+type workerProcess struct {
+	ctx     context.Context
+	barrier *eventorder.Barrier
+	logger  log
+	in      chan *job
+	out     chan *job
+	jobs    []*job
+}
+
+func (wp *workerProcess) run() {
+	for {
+		select {
+		case <-wp.ctx.Done():
+			return
+		case job := <-wp.in:
+			wp.jobs = append(wp.jobs, job)
+			if len(wp.jobs) >= bufferSize {
+				wp.processJobs()
+			}
+		case <-time.After(10 * time.Millisecond):
+			if len(wp.jobs) > 0 {
+				wp.processJobs()
+			}
+		}
+	}
+}
+
+func (wp *workerProcess) processJobs() {
+	for _, job := range wp.jobs {
+
+		if wait, _ := wp.barrier.Wait(job.user, job.id); wait {
+			job.states = append([]string{jobsdb.Waiting.State}, job.states...)
+			wp.out <- job
+			continue
+		}
+		// simulate request delay
+		time.Sleep(5 * time.Millisecond)
+		if job.states[0] == jobsdb.Failed.State {
+			_ = wp.barrier.StateChanged(job.user, job.id, jobsdb.Failed.State)
+		}
+		wp.out <- job
+	}
+	wp.jobs = nil
+}
+
+type commitStatusLoop struct {
+	ctx     context.Context
+	barrier *eventorder.Barrier
+	logger  log
+	in      chan *job
+	jobs    []*job
+	putBack func(jobs []*job)
+	doneMu  sync.Mutex
+	done    []int64
+	runtime struct {
+		lastCommitID int64
+	}
+}
+
+func (cl *commitStatusLoop) getCommitted() []int64 {
+	cl.doneMu.Lock()
+	defer cl.doneMu.Unlock()
+	dst := make([]int64, len(cl.done))
+	copy(dst, cl.done)
+	return dst
+}
+
+func (cl *commitStatusLoop) run() {
+	for {
+		select {
+		case <-cl.ctx.Done():
+			return
+		case job := <-cl.in:
+			cl.jobs = append(cl.jobs, job)
+			if len(cl.jobs) >= bufferSize {
+				cl.commit()
+			}
+		case <-time.After(10 * time.Millisecond):
+			if len(cl.jobs) > 0 {
+				cl.commit()
+			}
+		}
+	}
+}
+
+func (cl *commitStatusLoop) commit() {
+	var putBack []*job
+	for _, job := range cl.jobs {
+
+		switch job.states[0] {
+		case "aborted", "succeeded", "waiting":
+			_ = cl.barrier.StateChanged(job.user, job.id, job.states[0])
+		}
+		if len(job.states) == 1 {
+			if job.states[0] != "succeeded" && job.states[0] != "aborted" {
+				panic(fmt.Errorf("invalid job %d terminal state: %q", job.id, job.states[0]))
+			}
+			if cl.runtime.lastCommitID > job.id {
+				panic(fmt.Errorf("trying to commit job %d after %d", job.id, cl.runtime.lastCommitID))
+			}
+			cl.runtime.lastCommitID = job.id
+			cl.logger.Logf("job: %d state: %q retries: %d", job.id, job.states[0], job.retries)
+			cl.doneMu.Lock()
+			cl.done = append(cl.done, job.id)
+			cl.doneMu.Unlock()
+		} else {
+			job.states = job.states[1:]
+			job.retries++
+			putBack = append(putBack, job)
+		}
+	}
+
+	if len(putBack) > 0 {
+		cl.putBack(putBack)
+	}
+
+	cl.jobs = nil
+}
+
+func newRandomJobs(num int) []*job {
+	jobs := make([]*job, num)
+	for i := 0; i < num; i++ {
+
+		var states []string
+		var terminal bool
+		for !terminal {
+			var state string
+			state, terminal = randomState()
+			states = append(states, state)
+		}
+		jobs[i] = &job{
+			id:     int64(i),
+			user:   "user1",
+			states: states,
+		}
+	}
+	return jobs
+}
+
+func randomState() (state string, terminal bool) {
+	states := []string{
+		jobsdb.Failed.State,
+		jobsdb.Aborted.State, jobsdb.Aborted.State, jobsdb.Aborted.State,
+		jobsdb.Succeeded.State, jobsdb.Succeeded.State, jobsdb.Succeeded.State,
+	}
+	state = states[rand.Intn(len(states))] // skipcq: GSC-G404
+	terminal = state == jobsdb.Succeeded.State || state == jobsdb.Aborted.State
+	return state, terminal
+}
+
+type log interface {
+	Logf(format string, args ...interface{})
+}

--- a/router/internal/eventorder/eventorder_test.go
+++ b/router/internal/eventorder/eventorder_test.go
@@ -1,0 +1,237 @@
+package eventorder
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Job_Failed_Scenario(t *testing.T) {
+	barrier := NewBarrier(0)
+
+	enter, previousFailedJobID := barrier.Enter("user1", 1)
+	require.True(t, enter, "job 1 for user1 should be accepted since no barrier exists")
+	require.Nil(t, previousFailedJobID)
+
+	enter, previousFailedJobID = barrier.Enter("user1", 2)
+	require.True(t, enter, "job 2 for user1 should be accepted since no barrier exists")
+	require.Nil(t, previousFailedJobID)
+
+	require.False(t, firstBool(barrier.Wait("user1", 1)), "job 1 for user1 shouldn't wait since no barrier exists")
+	require.False(t, firstBool(barrier.Wait("user1", 2)), "job 2 for user1 shouldn't wait since no barrier exists")
+
+	require.NoError(t, barrier.StateChanged("user1", 1, jobsdb.Failed.State))
+
+	require.True(t, firstBool(barrier.Wait("user1", 2)), "job 2 for user1 should wait after job 1 has failed")
+	require.Equal(t, 1, barrier.Size(), "barrier should have size of 1")
+	require.Equal(t, `Barrier{[{userID: user1, failedJobID: 1, concurrentJobs: map[]}]}`, barrier.String(), "the barrier's string representation should be human readable")
+	require.NoError(t, barrier.StateChanged("user1", 2, jobsdb.Waiting.State))
+
+	barrier.Sync()
+
+	enter, previousFailedJobID = barrier.Enter("user1", 1)
+	require.True(t, enter, "job 1 for user1 should be accepted even if previously failed")
+	require.NotNil(t, previousFailedJobID)
+	require.Equal(t, int64(1), *previousFailedJobID, "previously failed job id should be 1")
+
+	require.False(t, firstBool(barrier.Wait("user1", 1)), "job 1 for user1 shouldn't wait since it is the previously failed one")
+
+	require.NoError(t, barrier.StateChanged("user1", 1, jobsdb.Succeeded.State))
+
+	enter, previousFailedJobID = barrier.Enter("user1", 2)
+	require.False(t, enter, "job 2 for user1 shouldn't be accepted even after job 1 has succeeded until barrier is synced")
+	require.NotNil(t, previousFailedJobID)
+	require.Equal(t, int64(1), *previousFailedJobID, "previously failed job id should be 1")
+
+	barrier.Sync()
+	enter, previousFailedJobID = barrier.Enter("user1", 2)
+	require.True(t, enter, "job 2 for user1 should be accepted after barrier is synced")
+	require.Nil(t, previousFailedJobID)
+}
+
+func Test_Job_Aborted_Scenario(t *testing.T) {
+	barrier := NewBarrier(1)
+
+	// Fail job 1 then enter again
+	enter, previousFailedJobID := barrier.Enter("user1", 1)
+	require.Nil(t, previousFailedJobID)
+	require.True(t, enter, "job 1 for user1 should be accepted since no barrier exists")
+	require.False(t, firstBool(barrier.Wait("user1", 1)), "job 1 for user1 shouldn't wait since no barrier exists")
+	require.Equal(t, 0, barrier.Sync())
+	require.NoError(t, barrier.StateChanged("user1", 1, jobsdb.Failed.State))
+	enter, previousFailedJobID = barrier.Enter("user1", 1)
+	require.True(t, enter, "job 1 for user1 should be accepted even if previously failed")
+	require.NotNil(t, previousFailedJobID)
+	require.Equal(t, int64(1), *previousFailedJobID, "previously failed job id should be 1")
+	require.False(t, firstBool(barrier.Wait("user1", 1)), "job 1 for user1 shouldn't wait since it is the previously failed one")
+
+	// Abort job 1
+	enter, previousFailedJobID = barrier.Enter("user1", 1)
+	require.True(t, enter, "job 1 for user1 should be accepted even if previously failed")
+	require.NotNil(t, previousFailedJobID)
+	require.Equal(t, int64(1), *previousFailedJobID, "previously failed job id should be 1")
+	require.False(t, firstBool(barrier.Wait("user1", 1)), "job 1 for user1 shouldn't wait since it is the previously failed one")
+	require.NoError(t, barrier.StateChanged("user1", 1, jobsdb.Aborted.State))
+
+	// Try to enter job 2
+	enter, previousFailedJobID = barrier.Enter("user1", 2)
+	require.False(t, enter, "job 2 for user1 shouldn't be accepted before the barrier is synced")
+	require.NotNil(t, previousFailedJobID)
+	require.Equal(t, int64(1), *previousFailedJobID, "previously failed job id should be 1")
+
+	// Try to enter job 2 after sync
+	require.Equal(t, 1, barrier.Sync())
+	enter, previousFailedJobID = barrier.Enter("user1", 2)
+	require.True(t, enter, "job 2 for user1 should be accepted after job 1 has aborted")
+	require.Nil(t, previousFailedJobID)
+
+	// Try to enter job 3
+	enter, previousFailedJobID = barrier.Enter("user1", 3)
+	require.False(t, enter, "job 3 for user1 shouldn't be accepted since it is above the concurrency limit")
+	require.Nil(t, previousFailedJobID)
+
+	// Job 2 aborted
+	require.False(t, firstBool(barrier.Wait("user1", 2)), "job 2 for user1 shouldn't wait")
+
+	require.NoError(t, barrier.StateChanged("user1", 2, jobsdb.Aborted.State))
+
+	enter, previousFailedJobID = barrier.Enter("user1", 3)
+	require.False(t, enter, "job 3 for user1 shouldn't be accepted after job 2 aborted before the barrier is synced")
+	require.Nil(t, previousFailedJobID)
+	require.Equal(t, 1, barrier.Sync(), "barrier should sync 1 command")
+	require.Equal(t, 0, barrier.Sync(), "barrier should empty the sync queue after syncing")
+
+	enter, previousFailedJobID = barrier.Enter("user1", 3)
+	require.True(t, enter, "job 3 for user1 should be accepted after job 2 aborted and barrier is synced: %v", barrier)
+	require.Nil(t, previousFailedJobID)
+
+	enter, previousFailedJobID = barrier.Enter("user1", 4)
+	require.True(t, enter, "job 4 for user1 should be accepted after job 2 aborted and barrier is synced (no concurrency limit)")
+	require.Nil(t, previousFailedJobID)
+	enter, previousFailedJobID = barrier.Enter("user1", 5)
+	require.True(t, enter, "job 5 for user1 should be accepted after job 2 aborted and barrier is synced (no concurrency limit)")
+	require.Nil(t, previousFailedJobID)
+	enter, previousFailedJobID = barrier.Enter("user1", 6)
+	require.True(t, enter, "job 6 for user1 should be accepted after job 2 aborted and barrier is synced (no concurrency limit)")
+	require.Nil(t, previousFailedJobID)
+}
+
+func Test_Job_Abort_then_Fail(t *testing.T) {
+	barrier := NewBarrier(2)
+
+	enter, previousFailedJobID := barrier.Enter("user1", 1)
+	require.True(t, enter, "job 1 for user1 should be accepted since no barrier exists")
+	require.Nil(t, previousFailedJobID)
+
+	require.False(t, firstBool(barrier.Wait("user1", 1)), "job 3 for user1 shouldn't wait")
+	require.NoError(t, barrier.StateChanged("user1", 1, jobsdb.Aborted.State))
+
+	require.Equal(t, 0, barrier.Sync())
+
+	enter, previousFailedJobID = barrier.Enter("user1", 2)
+	require.True(t, enter, "job 2 for user1 should be accepted after job 1 has aborted (no barrier)")
+	require.Nil(t, previousFailedJobID)
+	enter, previousFailedJobID = barrier.Enter("user1", 3)
+	require.True(t, enter, "job 3 for user1 should be accepted after job 1 has aborted (no barrier)")
+	require.Nil(t, previousFailedJobID)
+	enter, previousFailedJobID = barrier.Enter("user1", 4)
+	require.True(t, enter, "job 4 for user1 should be accepted after job 1 has aborted (no barrier)")
+	require.Nil(t, previousFailedJobID)
+
+	require.False(t, firstBool(barrier.Wait("user1", 2)), "job 2 for user1 shouldn't wait")
+	require.NoError(t, barrier.StateChanged("user1", 2, jobsdb.Failed.State))
+
+	require.True(t, firstBool(barrier.Wait("user1", 3)), "job 3 for user1 should wait since job 2 has failed")
+	require.NoError(t, barrier.StateChanged("user1", 3, jobsdb.Waiting.State))
+
+	require.True(t, firstBool(barrier.Wait("user1", 4)), "job 4 for user1 should wait since job 2 has failed")
+	require.NoError(t, barrier.StateChanged("user1", 4, jobsdb.Waiting.State))
+
+	require.Equal(t, 2, barrier.Sync())
+	enter, previousFailedJobID = barrier.Enter("user1", 2)
+	require.True(t, enter, "job 2 for user1 should be accepted")
+	require.NotNil(t, previousFailedJobID)
+	require.Equal(t, int64(2), *previousFailedJobID, "previously failed job id should be 2")
+}
+
+func Test_Job_Fail_then_Abort(t *testing.T) {
+	barrier := NewBarrier(2)
+
+	enter, previousFailedJobID := barrier.Enter("user1", 1)
+	require.True(t, enter, "job 1 for user1 should be accepted since no barrier exists")
+	require.Nil(t, previousFailedJobID)
+
+	require.False(t, firstBool(barrier.Wait("user1", 1)), "job 1 for user1 shouldn't wait")
+	require.NoError(t, barrier.StateChanged("user1", 1, jobsdb.Failed.State))
+
+	require.Equal(t, 0, barrier.Sync())
+
+	enter, previousFailedJobID = barrier.Enter("user1", 1)
+	require.True(t, enter, "job 1 for user1 should be accepted after job 1 has failed")
+	require.Equal(t, int64(1), *previousFailedJobID, "previously failed job id should be 1")
+
+	enter, previousFailedJobID = barrier.Enter("user1", 2)
+	require.False(t, enter, "job 2 for user1 shouldn't be accepted after job 1 has failed")
+	require.Equal(t, int64(1), *previousFailedJobID, "previously failed job id should be 1")
+
+	require.False(t, firstBool(barrier.Wait("user1", 1)), "job 1 for user1 shouldn't wait")
+	require.NoError(t, barrier.StateChanged("user1", 1, jobsdb.Aborted.State))
+
+	enter, previousFailedJobID = barrier.Enter("user1", 2)
+	require.False(t, enter, "job 2 for user1 shouldn't be accepted after job 1 has aborted until it is synced")
+	require.NotNil(t, previousFailedJobID)
+	require.Equal(t, int64(1), *previousFailedJobID)
+
+	require.Equal(t, 1, barrier.Sync(), "barrier should sync 1 command")
+
+	enter, previousFailedJobID = barrier.Enter("user1", 2)
+	require.True(t, enter, "job 2 for user1 should be accepted after job 1 has aborted and it is synced")
+	require.Nil(t, previousFailedJobID)
+
+	enter, previousFailedJobID = barrier.Enter("user1", 3)
+	require.True(t, enter, "job 3 for user1 should be accepted after job 1 has aborted and it is synced")
+	require.Nil(t, previousFailedJobID)
+
+	enter, previousFailedJobID = barrier.Enter("user1", 4)
+	require.False(t, enter, "job 4 for user1 shouldn't be accepted since it violates the concurrency limit")
+	require.Nil(t, previousFailedJobID)
+
+	require.False(t, firstBool(barrier.Wait("user1", 2)), "job 2 for user1 shouldn't wait")
+	require.NoError(t, barrier.StateChanged("user1", 2, jobsdb.Failed.State))
+
+	require.True(t, firstBool(barrier.Wait("user1", 3)), "job 3 for user1 should wait after job 2 has failed")
+	require.NoError(t, barrier.StateChanged("user1", 3, jobsdb.Waiting.State))
+	require.Equal(t, 1, barrier.Sync(), "barrier should sync 1 command")
+}
+
+func Test_Panic_Scenarios(t *testing.T) {
+	barrier := NewBarrier(0)
+
+	enter, _ := barrier.Enter("user1", 2)
+	require.True(t, enter, "job 2 for user1 should be accepted since no barrier exists")
+	require.NoError(t, barrier.StateChanged("user1", 2, jobsdb.Failed.State))
+	require.Error(t, barrier.StateChanged("user1", 2, "other state"))
+
+	// panicking during wait
+	func() {
+		defer func() {
+			err := recover()
+			require.NotNil(t, err, "barrier should panic when asking it if you should wait for a job with a previous job id than the currently failed one")
+		}()
+		_, _ = barrier.Wait("user1", 1)
+	}()
+
+	// panicking during state changed
+	func() {
+		defer func() {
+			err := recover()
+			require.NotNil(t, err, "barrier should panic when posting a state for a job with a previous job id than the currently failed one")
+		}()
+		_ = barrier.StateChanged("user1", 1, jobsdb.Failed.State)
+	}()
+}
+
+func firstBool(v bool, _ ...interface{}) bool {
+	return v
+}

--- a/router/internal/eventorder/eventorder_test.go
+++ b/router/internal/eventorder/eventorder_test.go
@@ -124,7 +124,7 @@ func Test_Job_Abort_then_Fail(t *testing.T) {
 	require.True(t, enter, "job 1 for user1 should be accepted since no barrier exists")
 	require.Nil(t, previousFailedJobID)
 
-	require.False(t, firstBool(barrier.Wait("user1", 1)), "job 3 for user1 shouldn't wait")
+	require.False(t, firstBool(barrier.Wait("user1", 1)), "job 1 for user1 shouldn't wait")
 	require.NoError(t, barrier.StateChanged("user1", 1, jobsdb.Aborted.State))
 
 	require.Equal(t, 0, barrier.Sync())


### PR DESCRIPTION
# Description

- Introduced a new `eventorder.Barrier` abstraction for implementing the event ordering algorithm.
- Replaced previous event ordering implementation with the new one in `router` component.

## Note
The following behavioral change is introduced by the new algorithm: 
**_The concurrency limiter will only be enabled if an `aborted `state is recorded for a job whose previous state was `failed`._**
In the previous implementation, the concurrency limiter was enabled whenever an `aborted `state was encountered for a job, regardless of the job's previous state history.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=d5a293e7a4c34b6399ab914bb1e879ae&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
