### PR TITLE
chore: remove build tags from tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,13 +32,13 @@ jobs:
 
     - name: Integration test for enterprise
       if: matrix.FEATURES == 'enterprise'
-      run: go test -v ./docker_test.go -tags=integration -count 1
+      run: go test -v ./docker_test.go -count 1
       env:
         ENTERPRISE_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
 
     - name: Integration test for oss
       if: matrix.FEATURES == 'oss'
-      run: go test -v ./docker_test.go -tags=integration -count 1
+      run: go test -v ./docker_test.go -count 1
       env:
         RSERVER_ENABLE_MULTITENANCY: ${{ matrix.MULTITENANCY }}
 

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ mocks: install-tools ## Generate all mocks
 
 test: ## Run all unit tests
 ifdef package
-	SLOW=0 $(GINKGO) -p --randomize-all --randomize-suites --fail-on-pending --cover -tags=integration \
+	SLOW=0 $(GINKGO) -p --randomize-all --randomize-suites --fail-on-pending --cover  \
 		-coverprofile=profile.out -covermode=atomic --trace -keep-separate-coverprofiles $(package)
 else
-	SLOW=0 $(GINKGO) -p --randomize-all --randomize-suites --fail-on-pending --cover -tags=integration \
+	SLOW=0 $(GINKGO) -p --randomize-all --randomize-suites --fail-on-pending --cover  \
 		-coverprofile=profile.out -covermode=atomic --trace -keep-separate-coverprofiles ./...
 endif
 	echo "mode: atomic" > coverage.txt

--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-server/enterprise/reporting"
 	"github.com/rudderlabs/rudder-server/services/rsources"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 
@@ -38,7 +39,6 @@ import (
 	"github.com/rudderlabs/rudder-server/services/stats"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
-	utilTypes "github.com/rudderlabs/rudder-server/utils/types"
 	"github.com/rudderlabs/rudder-server/utils/types/servermode"
 )
 
@@ -60,7 +60,8 @@ func run(m *testing.M) int {
 	// uses a sensible default on windows (tcp/http) and linux/osx (socket)
 	pool, err := dockertest.NewPool("")
 	if err != nil {
-		log.Fatalf("Could not connect to docker: %s", err)
+		log.Printf("Could not connect to docker: %s", err)
+		return 1
 	}
 
 	database := "jobsdb"
@@ -71,7 +72,8 @@ func run(m *testing.M) int {
 		"POSTGRES_USER=rudder",
 	})
 	if err != nil {
-		log.Fatalf("Could not start resource: %s", err)
+		log.Printf("Could not start resource: %s", err)
+		return 1
 	}
 	defer func() {
 		if err := pool.Purge(resourcePostgres); err != nil {
@@ -97,7 +99,8 @@ func run(m *testing.M) int {
 		}
 		return db.Ping()
 	}); err != nil {
-		log.Fatalf("Could not connect to docker: %s", err)
+		log.Printf("Could not connect to docker: %s", err)
+		return 1
 	}
 
 	code := m.Run()
@@ -118,17 +121,6 @@ func blockOnHold() {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 
 	<-c
-}
-
-type reportingNOOP struct{}
-
-func (*reportingNOOP) WaitForSetup(ctx context.Context, clientName string) {
-}
-
-func (*reportingNOOP) Report(metrics []*utilTypes.PUReportedMetric, txn *sql.Tx) {
-}
-
-func (*reportingNOOP) AddClient(ctx context.Context, c utilTypes.Config) {
 }
 
 const (
@@ -208,7 +200,7 @@ func TestDynamicClusterManager(t *testing.T) {
 		},
 	}
 
-	processor := processor.New(ctx, &clearDb, gwDB, rtDB, brtDB, errDB, mockMTI, &reportingNOOP{}, transientsource.NewEmptyService(), rsources.NewNoOpService())
+	processor := processor.New(ctx, &clearDb, gwDB, rtDB, brtDB, errDB, mockMTI, &reporting.NOOP{}, transientsource.NewEmptyService(), rsources.NewNoOpService())
 	processor.BackendConfig = mockBackendConfig
 	processor.Transformer = mockTransformer
 	mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
@@ -216,7 +208,7 @@ func TestDynamicClusterManager(t *testing.T) {
 
 	tDb := &jobsdb.MultiTenantHandleT{HandleT: rtDB}
 	rtFactory := &router.Factory{
-		Reporting:        &reportingNOOP{},
+		Reporting:        &reporting.NOOP{},
 		Multitenant:      mockMTI,
 		BackendConfig:    mockBackendConfig,
 		RouterDB:         tDb,
@@ -225,7 +217,7 @@ func TestDynamicClusterManager(t *testing.T) {
 		RsourcesService:  mockRsourcesService,
 	}
 	brtFactory := &batchrouter.Factory{
-		Reporting:        &reportingNOOP{},
+		Reporting:        &reporting.NOOP{},
 		Multitenant:      mockMTI,
 		BackendConfig:    mockBackendConfig,
 		RouterDB:         brtDB,

--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package cluster_test
 
 import (

--- a/docker_test.go
+++ b/docker_test.go
@@ -235,7 +235,7 @@ func TestMainFlow(t *testing.T) {
 		messages, errors := consume(t, c, topics)
 
 		signals := make(chan os.Signal, 1)
-		signal.Notify(signals, os.Interrupt, os.Kill) // Get signal for finish
+		signal.Notify(signals, os.Interrupt, syscall.SIGTERM) // Get signal for finish
 
 		var (
 			msgCount      = 0 // Count how many message processed

--- a/docker_test.go
+++ b/docker_test.go
@@ -3,8 +3,6 @@
 // It then runs the service ensuring it is configured to use the dependencies.
 // Finally, it sends events and observe the destinations expecting to get the events back.
 
-//go:build integration
-
 package main_test
 
 import (

--- a/docker_test.go
+++ b/docker_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
@@ -473,7 +472,7 @@ func setupMainFlow(svcCtx context.Context, t *testing.T) <-chan struct{} {
 		mapWorkspaceConfig,
 	)
 	if testing.Verbose() {
-		data, err := ioutil.ReadFile(workspaceConfigPath)
+		data, err := os.ReadFile(workspaceConfigPath)
 		require.NoError(t, err)
 		t.Logf("Workspace config: %s", string(data))
 	}

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -1,5 +1,3 @@
-// go:build integration
-
 package jobsdb_test
 
 import (

--- a/jobsdb/jobsdb_renameDs_test.go
+++ b/jobsdb/jobsdb_renameDs_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package jobsdb
 
 import (

--- a/jobsdb/jobsdb_suite_test.go
+++ b/jobsdb/jobsdb_suite_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package jobsdb_test
 
 import (

--- a/jobsdb/readonly_jobsdb_test.go
+++ b/jobsdb/readonly_jobsdb_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package jobsdb
 
 import (

--- a/jobsdb/readonly_jobsdb_test.go
+++ b/jobsdb/readonly_jobsdb_test.go
@@ -1,7 +1,6 @@
 package jobsdb
 
 import (
-	"github.com/gofrs/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -51,38 +50,3 @@ var _ = Describe("readonly_jobsdb", func() {
 		})
 	})
 })
-
-var userJobs = []*JobT{
-	{
-		JobID:        1,
-		Parameters:   []byte(`{"batch_id":1,"source_id":"sourceID","source_job_run_id":""}`),
-		EventPayload: []byte(`{"receivedAt":"2021-06-06T20:26:39.598+05:30","writeKey":"writeKey","requestIP":"[::1]",  "batch": [{"anonymousId":"anon_id","channel":"android-sdk","context":{"app":{"build":"1","name":"RudderAndroidClient","namespace":"com.rudderlabs.android.sdk","version":"1.0"},"device":{"id":"49e4bdd1c280bc00","manufacturer":"Google","model":"Android SDK built for x86","name":"generic_x86"},"library":{"name":"com.rudderstack.android.sdk.core"},"locale":"en-US","network":{"carrier":"Android"},"screen":{"density":420,"height":1794,"width":1080},"traits":{"anonymousId":"49e4bdd1c280bc00"},"user_agent":"Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.075)"},"event":"Demo Track","integrations":{"All":true},"messageId":"b96f3d8a-7c26-4329-9671-4e3202f42f15","originalTimestamp":"2019-08-12T05:08:30.909Z","properties":{"category":"Demo Category","floatVal":4.501,"label":"Demo Label","testArray":[{"id":"elem1","value":"e1"},{"id":"elem2","value":"e2"}],"testMap":{"t1":"a","t2":4},"value":5},"rudderId":"a-292e-4e79-9880-f8009e0ae4a3","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}]}`),
-		UserID:       "dummy_a-292e-4e79-9880-f8009e0ae4a3",
-		UUID:         uuid.Must(uuid.NewV4()),
-		CustomVal:    "MOCKDS",
-	},
-	{
-		JobID:        2,
-		Parameters:   []byte(`{"batch_id":2,"source_id":"sourceID","source_job_run_id":"random_sourceJobRunID"}`),
-		EventPayload: []byte(`{"receivedAt":"2021-06-06T20:26:39.598+05:30","writeKey":"writeKey","requestIP":"[::1]",  "batch": [{"anonymousId":"anon_id","channel":"android-sdk","context":{"app":{"build":"1","name":"RudderAndroidClient","namespace":"com.rudderlabs.android.sdk","version":"1.0"},"device":{"id":"49e4bdd1c280bc00","manufacturer":"Google","model":"Android SDK built for x86","name":"generic_x86"},"library":{"name":"com.rudderstack.android.sdk.core"},"locale":"en-US","network":{"carrier":"Android"},"screen":{"density":420,"height":1794,"width":1080},"traits":{"anonymousId":"49e4bdd1c280bc00"},"user_agent":"Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.075)"},"event":"Demo Track","integrations":{"All":true},"messageId":"b96f3d8a-7c26-4329-9671-4e3202f42f15","originalTimestamp":"2019-08-12T05:08:30.909Z","properties":{"category":"Demo Category","floatVal":4.501,"label":"Demo Label","testArray":[{"id":"elem1","value":"e1"},{"id":"elem2","value":"e2"}],"testMap":{"t1":"a","t2":4},"value":5},"rudderId":"a-292e-4e79-9880-f8009e0ae4a3","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}]}`),
-		UserID:       "dummy_a-292e-4e79-9880-f8009e0ae4a3",
-		UUID:         uuid.Must(uuid.NewV4()),
-		CustomVal:    "MOCKDS",
-	},
-	{
-		JobID:        5,
-		Parameters:   []byte(`{"batch_id":2,"source_id":"sourceID","source_job_run_id":"random_sourceJobRunID"}`),
-		EventPayload: []byte(`{"receivedAt":"2021-06-06T20:26:39.598+05:30","writeKey":"writeKey","requestIP":"[::1]",  "batch": [{"anonymousId":"anon_id","channel":"android-sdk","context":{"app":{"build":"1","name":"RudderAndroidClient","namespace":"com.rudderlabs.android.sdk","version":"1.0"},"device":{"id":"49e4bdd1c280bc00","manufacturer":"Google","model":"Android SDK built for x86","name":"generic_x86"},"library":{"name":"com.rudderstack.android.sdk.core"},"locale":"en-US","network":{"carrier":"Android"},"screen":{"density":420,"height":1794,"width":1080},"traits":{"anonymousId":"49e4bdd1c280bc00"},"user_agent":"Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.075)"},"event":"Demo Track","integrations":{"All":true},"messageId":"b96f3d8a-7c26-4329-9671-4e3202f42f15","originalTimestamp":"2019-08-12T05:08:30.909Z","properties":{"category":"Demo Category","floatVal":4.501,"label":"Demo Label","testArray":[{"id":"elem1","value":"e1"},{"id":"elem2","value":"e2"}],"testMap":{"t1":"a","t2":4},"value":5},"rudderId":"a-292e-4e79-9880-f8009e0ae4a3","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}]}`),
-		UserID:       "dummy_a-292e-4e79-9880-f8009e0ae4a3",
-		UUID:         uuid.Must(uuid.NewV4()),
-		CustomVal:    "MOCKDS",
-	},
-	{
-		JobID:        11,
-		Parameters:   []byte(`{"batch_id":2,"source_id":"sourceID","source_job_run_id":"random_sourceJobRunID"}`),
-		EventPayload: []byte(`{"receivedAt":"2021-06-06T20:26:39.598+05:30","writeKey":"writeKey","requestIP":"[::1]",  "batch": [{"anonymousId":"anon_id","channel":"android-sdk","context":{"app":{"build":"1","name":"RudderAndroidClient","namespace":"com.rudderlabs.android.sdk","version":"1.0"},"device":{"id":"49e4bdd1c280bc00","manufacturer":"Google","model":"Android SDK built for x86","name":"generic_x86"},"library":{"name":"com.rudderstack.android.sdk.core"},"locale":"en-US","network":{"carrier":"Android"},"screen":{"density":420,"height":1794,"width":1080},"traits":{"anonymousId":"49e4bdd1c280bc00"},"user_agent":"Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.075)"},"event":"Demo Track","integrations":{"All":true},"messageId":"b96f3d8a-7c26-4329-9671-4e3202f42f15","originalTimestamp":"2019-08-12T05:08:30.909Z","properties":{"category":"Demo Category","floatVal":4.501,"label":"Demo Label","testArray":[{"id":"elem1","value":"e1"},{"id":"elem2","value":"e2"}],"testMap":{"t1":"a","t2":4},"value":5},"rudderId":"a-292e-4e79-9880-f8009e0ae4a3","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}]}`),
-		UserID:       "dummy_a-292e-4e79-9880-f8009e0ae4a3",
-		UUID:         uuid.Must(uuid.NewV4()),
-		CustomVal:    "MOCKDS",
-	},
-}


### PR DESCRIPTION
# Description

The usage of build tags to enable/disable specific tests files `//go:build integration` is problematic:
1. By default, most go tools will skip those files if not configured correctly. Linting and formatting tools won't fix or report issues on those files. This applies to cli invocations, IDEs and services like deepsource.
2. Testsuites do not warn/ complain about those files being skipped; you might run `go test` or `gingko` it will return without reporting any problem. This can create confusion, or tests end up skipped at worst.


When running `make test` we were already running the tests under `integration` tag.

## Notion Ticket

https://www.notion.so/rudderstacks/remove-integration-tag-2fa2eb23004146b4a19b5821a6f6ca8a

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
