### PR TITLE
fix(warehouse): upload validations should happen when validator is set

### DIFF
--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -1549,6 +1550,9 @@ func (job *UploadJobT) setUploadError(statusError error, state string) (string, 
 }
 
 func (job *UploadJobT) validateDestinationCredentials() (bool, error) {
+	if job.destinationValidator == nil {
+		return false, errors.New("failed to validate as destinationValidator is not set")
+	}
 	validationResult, err := job.destinationValidator.ValidateCredentials(&configuration_testing.DestinationValidationRequest{Destination: job.warehouse.Destination})
 	if err != nil {
 		pkgLogger.Errorf("Unable to successfully validate destination: %s credentials, err: %v", job.warehouse.Destination.ID, err)


### PR DESCRIPTION
# Description

Destination validation should happen only if validators are set

## Notion Ticket

https://www.notion.so/rudderstacks/destination-validation-should-happen-only-if-validators-are-set-14b50c9ab667454c81b18cee66c93940

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
