### PR TITLE
feat(jobsdb): thread safe addNewDSLoop

### DIFF
--- a/jobsdb/internal/lock/lock.go
+++ b/jobsdb/internal/lock/lock.go
@@ -30,7 +30,7 @@ func (r *DSListLocker) WithLock(f func(l DSListLockToken)) {
 	f(&listLockToken{})
 }
 
-// AsyncLock acquires a lock unitl the token is returned to the receiving channel
+// AsyncLock acquires a lock until the token is returned to the receiving channel
 func (r *DSListLocker) AsyncLock() (DSListLockToken, chan<- DSListLockToken) {
 	acquireDsListLock := make(chan DSListLockToken)
 	releaseDsListLock := make(chan DSListLockToken)

--- a/jobsdb/internal/lock/lock_test.go
+++ b/jobsdb/internal/lock/lock_test.go
@@ -1,0 +1,41 @@
+package lock_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/jobsdb/internal/lock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsyncLock(t *testing.T) {
+	locker := &lock.DSListLocker{}
+
+	l, c := locker.AsyncLock()
+	require.NotNil(t, l)
+
+	secondLock := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		wg.Done()
+		locker.WithLock(func(l lock.DSListLockToken) {
+			secondLock <- struct{}{}
+		})
+	}()
+	wg.Wait()
+
+	select {
+	case <-secondLock:
+		t.Fatal("second lock should not have been acquired")
+	case <-time.After(100 * time.Millisecond):
+		c <- l
+	}
+
+	select {
+	case <-secondLock:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("second lock should have been acquired")
+	}
+}

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1210,30 +1210,43 @@ func (jd *HandleT) getTableSize(jobTable string) int64 {
 }
 
 func (jd *HandleT) checkIfFullDS(ds dataSetT) bool {
+	var full bool
+	jd.assertError(jd.WithTx(func(tx *sql.Tx) error {
+		var err error
+		full, err = jd.checkIfFullDSInTx(tx, ds)
+		if err != nil {
+			return err
+		}
+		return nil
+	}))
+	return full
+}
+
+func (jd *HandleT) checkIfFullDSInTx(tx *sql.Tx, ds dataSetT) (bool, error) {
 	var minJobCreatedAt sql.NullTime
 	sqlStatement := fmt.Sprintf(`SELECT MIN(created_at) FROM %q`, ds.JobTable)
-	row := jd.dbHandle.QueryRow(sqlStatement)
+	row := tx.QueryRow(sqlStatement)
 	err := row.Scan(&minJobCreatedAt)
 	if err != nil && err != sql.ErrNoRows {
-		jd.assertError(err)
+		return false, err
 	}
 	if err == nil && minJobCreatedAt.Valid && time.Since(minJobCreatedAt.Time) > jd.MaxDSRetentionPeriod {
-		return true
+		return true, nil
 	}
 
 	tableSize := jd.getTableSize(ds.JobTable)
 	if tableSize > maxTableSize {
 		jd.logger.Infof("[JobsDB] %s is full in size. Count: %v, Size: %v", ds.JobTable, jd.getTableRowCount(ds.JobTable), tableSize)
-		return true
+		return true, nil
 	}
 
 	totalCount := jd.getTableRowCount(ds.JobTable)
 	if totalCount > *jd.MaxDSSize {
 		jd.logger.Infof("[JobsDB] %s is full by rows. Count: %v, Size: %v", ds.JobTable, totalCount, jd.getTableSize(ds.JobTable))
-		return true
+		return true, nil
 	}
 
-	return false
+	return false, nil
 }
 
 /*
@@ -1289,17 +1302,38 @@ func newDataSet(tablePrefix, dsIdx string) dataSetT {
 }
 
 func (jd *HandleT) addNewDS(l lock.DSListLockToken, ds dataSetT) {
+	err := jd.WithTx(func(tx *sql.Tx) error {
+		return jd.addNewDSInTx(tx, l, jd.refreshDSList(l), ds)
+	})
+	jd.assertError(err)
+	jd.refreshDSRangeList(l)
+}
+
+// NOTE: If addNewDSInTx is directly called, make sure to explicitly call refreshDSRangeList(l) to update the DS list in cache, once transaction has completed.
+func (jd *HandleT) addNewDSInTx(tx *sql.Tx, l lock.DSListLockToken, dsList []dataSetT, ds dataSetT) error {
+	if l == nil {
+		return errors.New("nil ds list lock token provided")
+	}
 	jd.logger.Infof("Creating new DS %+v", ds)
 	queryStat := stats.NewTaggedStat("add_new_ds", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix})
 	queryStat.Start()
 	defer queryStat.End()
-	jd.createDS(ds, l)
+	err := jd.createDSInTx(tx, ds)
+	if err != nil {
+		return err
+	}
+	err = jd.setSequenceNumberInTx(tx, l, dsList, ds.Index)
+	if err != nil {
+		return err
+	}
 	// Tracking time interval between new ds creations. Hence calling end before start
 	if jd.isStatNewDSPeriodInitialized {
 		jd.statNewDSPeriod.End()
 	}
 	jd.statNewDSPeriod.Start()
 	jd.isStatNewDSPeriodInitialized = true
+
+	return nil
 }
 
 func (jd *HandleT) addDS(ds dataSetT) {
@@ -1307,11 +1341,17 @@ func (jd *HandleT) addDS(ds dataSetT) {
 	queryStat := stats.NewTaggedStat("add_new_ds", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix})
 	queryStat.Start()
 	defer queryStat.End()
-	jd.createDS(ds, nil)
+	jd.assertError(jd.WithTx(func(tx *sql.Tx) error {
+		return jd.createDSInTx(tx, ds)
+	}))
 }
 
 func (jd *HandleT) computeNewIdxForAppend(l lock.DSListLockToken) string {
 	dList := jd.refreshDSList(l)
+	return jd.doComputeNewIdxForAppend(dList)
+}
+
+func (jd *HandleT) doComputeNewIdxForAppend(dList []dataSetT) string {
 	newDSIdx := ""
 	if len(dList) == 0 {
 		newDSIdx = "1"
@@ -1511,20 +1551,7 @@ type transactionHandler interface {
 	// Only the function that passes *sql.Tx should do the commit or rollback based on the error it receives
 }
 
-func (jd *HandleT) createDS(newDS dataSetT, l lock.DSListLockToken) {
-	err := jd.WithTx(func(tx *sql.Tx) error {
-		return jd.createDSInTx(tx, newDS, l)
-	})
-	jd.assertError(err)
-
-	// In case of a migration, we don't yet update the in-memory list till we finish the migration
-	if l != nil {
-		// to get the updated DS list in the cache after createDS transaction has been committed.
-		jd.refreshDSRangeList(l)
-	}
-}
-
-func (jd *HandleT) createDSInTx(tx *sql.Tx, newDS dataSetT, l lock.DSListLockToken) error {
+func (jd *HandleT) createDSInTx(tx *sql.Tx, newDS dataSetT) error {
 	// Mark the start of operation. If we crash somewhere here, we delete the
 	// DS being added
 	opPayload, err := json.Marshal(&journalOpPayloadT{To: newDS})
@@ -1581,13 +1608,6 @@ func (jd *HandleT) createDSInTx(tx *sql.Tx, newDS dataSetT, l lock.DSListLockTok
 		return err
 	}
 
-	if l != nil {
-		err = jd.setSequenceNumberInTx(tx, l, newDS.Index)
-		if err != nil {
-			return err
-		}
-	}
-
 	err = jd.journalMarkDoneInTx(tx, opID)
 	if err != nil {
 		return err
@@ -1596,17 +1616,16 @@ func (jd *HandleT) createDSInTx(tx *sql.Tx, newDS dataSetT, l lock.DSListLockTok
 	return nil
 }
 
-func (jd *HandleT) setSequenceNumberInTx(tx *sql.Tx, l lock.DSListLockToken, newDSIdx string) error {
+func (jd *HandleT) setSequenceNumberInTx(tx *sql.Tx, l lock.DSListLockToken, dsList []dataSetT, newDSIdx string) error {
 	if l == nil {
-		return fmt.Errorf("ds list lock cannot be nil")
+		return errors.New("nil ds list lock token provided")
 	}
 
-	dList := jd.getDSList()
 	var maxID sql.NullInt64
 
 	// Now set the min JobID for the new DS just added to be 1 more than previous max
-	if len(dList) > 0 {
-		sqlStatement := fmt.Sprintf(`SELECT MAX(job_id) FROM %q`, dList[len(dList)-1].JobTable)
+	if len(dsList) > 0 {
+		sqlStatement := fmt.Sprintf(`SELECT MAX(job_id) FROM %q`, dsList[len(dsList)-1].JobTable)
 		err := tx.QueryRowContext(context.TODO(), sqlStatement).Scan(&maxID)
 		if err != nil {
 			return err
@@ -3027,20 +3046,46 @@ func (jd *HandleT) addNewDSLoop(ctx context.Context) {
 		case <-jd.TriggerAddNewDS():
 		}
 
-		jd.logger.Debugf("[[ %s : addNewDSLoop ]]: Start", jd.tablePrefix)
-		jd.dsListLock.RLock()
-		dsList := jd.getDSList()
-		jd.dsListLock.RUnlock()
-		latestDS := dsList[len(dsList)-1]
-		if jd.checkIfFullDS(latestDS) {
-			// Adding a new DS updates the list
-			// Doesn't move any data so we only
-			// take the list lock
-			jd.dsListLock.WithLock(func(l lock.DSListLockToken) {
+		// Adding a new DS only creates a new DS & updates the cache. It doesn't move any data so we only take the list lock.
+		var dsListLock lock.DSListLockToken
+		var releaseDsListLock chan<- lock.DSListLockToken
+		// start a transaction
+		err := jd.WithTx(func(tx *sql.Tx) error {
+			// acquire a advisory transaction level blocking lock, which is released once the transaction ends.
+			sqlStatement := fmt.Sprintf(`SELECT pg_advisory_xact_lock(%d);`, misc.JobsDBAddDsAdvisoryLock)
+			_, err := tx.ExecContext(context.TODO(), sqlStatement)
+			if err != nil {
+				return err
+			}
+
+			// We acquire the list lock only after we have acquired the advisory lock.
+			// We will release the list lock after the transaction ends, that's why we need to use an async lock
+			dsListLock, releaseDsListLock = jd.dsListLock.AsyncLock()
+			// refresh ds list
+			var dsList []dataSetT
+			var nextDSIdx string
+			// make sure we are operating on the latest version of the list
+			dsList = getDSList(jd, tx, jd.tablePrefix)
+			latestDS := dsList[len(dsList)-1]
+			full, err := jd.checkIfFullDSInTx(tx, latestDS)
+			if err != nil {
+				return err
+			}
+			// checkIfFullDS is true for last DS in the list
+			if full {
+				nextDSIdx = jd.doComputeNewIdxForAppend(dsList)
 				jd.logger.Infof("[[ %s : addNewDSLoop ]]: NewDS", jd.tablePrefix)
-				jd.addNewDS(l, newDataSet(jd.tablePrefix, jd.computeNewIdxForAppend(l)))
-			})
-		}
+				if err := jd.addNewDSInTx(tx, dsListLock, dsList, newDataSet(jd.tablePrefix, nextDSIdx)); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		jd.assertError(err)
+
+		// to get the updated DS list in the cache after createDS transaction has been committed.
+		jd.refreshDSRangeList(dsListLock)
+		releaseDsListLock <- dsListLock
 	}
 }
 

--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -11,11 +11,15 @@ import (
 	"github.com/rudderlabs/rudder-server/services/stats"
 )
 
+type sqlDbOrTx interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+}
+
 /*
 Function to return an ordered list of datasets and datasetRanges
 Most callers use the in-memory list of dataset and datasetRanges
 */
-func getDSList(jd assertInterface, dbHandle *sql.DB, tablePrefix string) []dataSetT {
+func getDSList(jd assertInterface, dbHandle sqlDbOrTx, tablePrefix string) []dataSetT {
 	datasetList := []dataSetT{}
 
 	// Read the table names from PG
@@ -123,14 +127,14 @@ var dsComparitor = func(src, dst []string) (bool, error) {
 }
 
 // mustGetAllTableNames gets all table names from Postgres and panics in case of an error
-func mustGetAllTableNames(jd assertInterface, dbHandle *sql.DB) []string {
+func mustGetAllTableNames(jd assertInterface, dbHandle sqlDbOrTx) []string {
 	tableNames, err := getAllTableNames(dbHandle)
 	jd.assertError(err)
 	return tableNames
 }
 
 // getAllTableNames gets all table names from Postgres
-func getAllTableNames(dbHandle *sql.DB) ([]string, error) {
+func getAllTableNames(dbHandle sqlDbOrTx) ([]string, error) {
 	var tableNames []string
 	rows, err := dbHandle.Query(`SELECT tablename
 									FROM pg_catalog.pg_tables

--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -10,6 +10,12 @@ import (
 	"github.com/rudderlabs/rudder-server/config"
 )
 
+type AdvisoryLock int
+
+const (
+	JobsDBAddDsAdvisoryLock = 11
+)
+
 var (
 	host, user, password, sslmode string
 	port                          int

--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -13,7 +13,7 @@ import (
 type AdvisoryLock int
 
 const (
-	JobsDBAddDsAdvisoryLock = 11
+	JobsDBAddDsAdvisoryLock AdvisoryLock = 11
 )
 
 var (


### PR DESCRIPTION
# Description
Currently, `addNewDSLoop` that is responsible for continuously checking if latest DS is full or not & creates a new one if it is full is not thread safe, i.e if two instance of JobsDB are running in parallel & both found that the last DS is full then both the instance will try to add a new DS & one will succeed & other will panic. 

In this PR, we solved the above described problem & made it thread safe.

TLDR:

- Essentially, to coordinate between multiple jobsDB instances we are using advisory lock, i.e. to add a new DS, jobsDB has to first acquire an advisory lock `JobsDBAddDsAdvisoryLock`. Once acquired, only then it can add new DS. 
- Also, to make sure that no one else adds a new DS from the time we checked if the latest DS is full & actually add a DS we are doing the following:-  
   1. start a transaction
   2. acquire `JobsDBAddDsAdvisoryLock` lock
   3. get refreshed DS
   4. check if latest DS is full
   5. if yes, add new DS
   6. end transaction
   7. refresh cache to get new DS. 
   8. release `JobsDBAddDsAdvisoryLock` lock
   
## Notion Ticket
 https://www.notion.so/rudderstacks/Thread-safe-addNewDSLoop-5955828ee79f4f96b5a6685f3b10b613

