### PR TITLE
chore(warehouse): remove tokens from logs for redshift and snowflake

### DIFF
--- a/warehouse/redshift/redshift.go
+++ b/warehouse/redshift/redshift.go
@@ -332,6 +332,7 @@ func (rs *HandleT) loadTable(tableName string, tableSchemaInUpload, tableSchemaA
 	sanitisedSQLStmt, regexErr := misc.ReplaceMultiRegex(sqlStatement, map[string]string{
 		"ACCESS_KEY_ID '[^']*'":     "ACCESS_KEY_ID '***'",
 		"SECRET_ACCESS_KEY '[^']*'": "SECRET_ACCESS_KEY '***'",
+		"SESSION_TOKEN '[^']*'":     "SESSION_TOKEN '***'",
 	})
 	if regexErr == nil {
 		pkgLogger.Infof("RS: Running COPY command for table:%s at %s\n", tableName, sanitisedSQLStmt)
@@ -805,6 +806,7 @@ func (rs *HandleT) LoadTestTable(location, tableName string, payloadMap map[stri
 	sanitisedSQLStmt, regexErr := misc.ReplaceMultiRegex(sqlStatement, map[string]string{
 		"ACCESS_KEY_ID '[^']*'":     "ACCESS_KEY_ID '***'",
 		"SECRET_ACCESS_KEY '[^']*'": "SECRET_ACCESS_KEY '***'",
+		"SESSION_TOKEN '[^']*'":     "SESSION_TOKEN '***'",
 	})
 	if regexErr == nil {
 		pkgLogger.Infof("RS: Running COPY command for load test table: %s with sqlStatement: %s", tableName, sanitisedSQLStmt)

--- a/warehouse/snowflake/snowflake.go
+++ b/warehouse/snowflake/snowflake.go
@@ -380,6 +380,7 @@ func (sf *HandleT) LoadIdentityMergeRulesTable() (err error) {
 	sanitisedSQLStmt, regexErr := misc.ReplaceMultiRegex(sqlStatement, map[string]string{
 		"AWS_KEY_ID='[^']*'":     "AWS_KEY_ID='***'",
 		"AWS_SECRET_KEY='[^']*'": "AWS_SECRET_KEY='***'",
+		"AWS_TOKEN='[^']*'":      "AWS_TOKEN='***'",
 	})
 	if regexErr == nil {
 		pkgLogger.Infof("SF: Dedup records for table:%s using staging table: %s\n", identityMergeRulesTable, sanitisedSQLStmt)


### PR DESCRIPTION
# Description

Tokens are getting exposed in logs. It shouldn't be. Removing those from logs for Redshift and Snowflake.

## Notion Ticket

https://www.notion.so/rudderstacks/Tokens-are-getting-exposed-in-logs-e5ecac1ab38b42ca99823bc5faf4333a

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
