### PR TITLE
chore: added metrics to track failed DS backup

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -3229,6 +3229,7 @@ func (jd *HandleT) backupDSLoop(ctx context.Context) {
 			opID = jd.JournalMarkStart(backupDSOperation, opPayload)
 			err := jd.backupDS(ctx, backupDSRange)
 			if err != nil {
+				stats.NewTaggedStat("backup_ds_failed", stats.CountType, stats.Tags{"customVal": jd.tablePrefix, "provider": config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3")}).Increment()
 				jd.logger.Errorf("[JobsDB] :: Failed to backup jobs table %v. Err: %v", backupDSRange.ds.JobStatusTable, err)
 			}
 			jd.JournalMarkDone(opID)


### PR DESCRIPTION
# Description
>Added stats `backup_DS_failed` with tags for table prefix & provider to track DS backup failure.

## Notion Ticket

https://www.notion.so/rudderstacks/add-alert-if-backup-fails-e424b94f8ce24186887449d2b749b979
