### PR TITLE
chore(router): include original client creation error when circuit breaker is open

### DIFF
--- a/router/customdestinationmanager/customdestinationmanager_test.go
+++ b/router/customdestinationmanager/customdestinationmanager_test.go
@@ -2,6 +2,7 @@ package customdestinationmanager
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ import (
 func TestCircuitBreaker(t *testing.T) {
 	const (
 		normalError  = "could not ping: could not dial any of the addresses"
-		breakerError = "circuit breaker is open"
+		breakerError = "circuit breaker is open, last error: could not ping: could not dial any of the addresses"
 	)
 
 	// init various packages
@@ -75,12 +76,14 @@ func TestCircuitBreaker(t *testing.T) {
 
 func newDestination(t *testing.T, manager *CustomManagerT, dest backendconfig.DestinationT, attempt int, errorString string) { // skipcq: CRT-P0003
 	err := manager.onNewDestination(dest)
-	assert.ErrorContains(t, err, errorString, fmt.Sprintf("wrong error for attempt no %d", attempt))
+	assert.NotNil(t, err, "it should return an error for attempt no %d", attempt)
+	assert.True(t, strings.HasPrefix(err.Error(), errorString), fmt.Sprintf("error %s should start with %s for attempt no %d", err.Error(), errorString, attempt))
 }
 
 func newClientAttempt(t *testing.T, manager *CustomManagerT, destId string, attempt int, errorString string) {
 	err := manager.newClient(destId)
-	assert.ErrorContains(t, err, errorString, fmt.Sprintf("wrong error for attempt no %d", attempt))
+	assert.NotNil(t, err, "it should return an error for attempt no %d", attempt)
+	assert.True(t, strings.HasPrefix(err.Error(), errorString), fmt.Sprintf("error %s should start with %s for attempt no %d", err.Error(), errorString, attempt))
 }
 
 func getDestConfig() backendconfig.DestinationT {


### PR DESCRIPTION
# Description

After a number of failed attempts to create a client for a specific destination, the circuit breaker opens and fails with an error that doesn't convey anything about the original error:

```
circuit breaker is open
```

This change includes the original error in the circuit breaker's error, e.g.

```
circuit breaker is open, last error: could not ping: could not dial any of the addresses
```

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=542d9035f86c49da95f4d6e7169e1fa0&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
