### PR TITLE
fix: use jsoniter when unmarshaling to avoid perfromance issues

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/asyncdestinationmanager.go
+++ b/router/batchrouter/asyncdestinationmanager/asyncdestinationmanager.go
@@ -2,12 +2,13 @@ package asyncdestinationmanager
 
 import (
 	"bufio"
-	"encoding/json"
+	stdjson "encoding/json"
 	"os"
 	"strings"
 	"sync"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/rudderlabs/rudder-server/config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/services/rsources"
@@ -20,7 +21,7 @@ import (
 type AsyncUploadOutput struct {
 	Key                 string
 	ImportingJobIDs     []int64
-	ImportingParameters json.RawMessage
+	ImportingParameters stdjson.RawMessage
 	SuccessJobIDs       []int64
 	FailedJobIDs        []int64
 	SucceededJobIDs     []int64
@@ -82,6 +83,8 @@ type Parameters struct {
 	PollUrl  string    `json:"pollURL"`
 	MetaData MetaDataT `json:"metadata"`
 }
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 var (
 	HTTPTimeout time.Duration
@@ -207,7 +210,7 @@ func Upload(url, filePath string, config map[string]interface{}, destType string
 			ImportingJobIDs:     successfulJobIDs,
 			FailedJobIDs:        append(failedJobIDs, failedJobIDsTrans...),
 			FailedReason:        `{"error":"Jobs flowed over the prescribed limit"}`,
-			ImportingParameters: json.RawMessage(importParameters),
+			ImportingParameters: stdjson.RawMessage(importParameters),
 			importingCount:      len(importingJobIDs),
 			FailedCount:         len(failedJobIDs) + len(failedJobIDsTrans),
 			DestinationID:       destinationID,
@@ -244,7 +247,7 @@ func Upload(url, filePath string, config map[string]interface{}, destType string
 	return uploadResponse
 }
 
-func GetTransformedData(payload json.RawMessage) string {
+func GetTransformedData(payload stdjson.RawMessage) string {
 	return gjson.Get(string(payload), "body.JSON").String()
 }
 

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/json"
+	stdjson "encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/rudderlabs/rudder-server/router"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager"
 	"github.com/rudderlabs/rudder-server/router/rterror"
@@ -47,6 +48,8 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 var (
 	mainLoopSleep, diagnosisTickerTime time.Duration
@@ -739,7 +742,7 @@ func (brt *HandleT) copyJobsToStorage(provider string, batchJobs *BatchJobsT, ma
 	_, fileName := filepath.Split(gzipFilePath)
 	var (
 		opID      int64
-		opPayload json.RawMessage
+		opPayload stdjson.RawMessage
 	)
 	if !isWarehouse {
 		opPayload, _ = json.Marshal(&ObjectStorageT{
@@ -1412,7 +1415,7 @@ func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.Asy
 				ExecTime:      time.Now(),
 				RetryTime:     time.Now(),
 				ErrorCode:     "200",
-				ErrorResponse: json.RawMessage(asyncOutput.SuccessResponse),
+				ErrorResponse: stdjson.RawMessage(asyncOutput.SuccessResponse),
 				Parameters:    []byte(`{}`),
 				WorkspaceId:   workspace,
 			}
@@ -1427,7 +1430,7 @@ func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.Asy
 				ExecTime:      time.Now(),
 				RetryTime:     time.Now(),
 				ErrorCode:     "500",
-				ErrorResponse: json.RawMessage(asyncOutput.FailedReason),
+				ErrorResponse: stdjson.RawMessage(asyncOutput.FailedReason),
 				Parameters:    []byte(`{}`),
 				WorkspaceId:   workspace,
 			}
@@ -1442,7 +1445,7 @@ func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.Asy
 				ExecTime:      time.Now(),
 				RetryTime:     time.Now(),
 				ErrorCode:     "400",
-				ErrorResponse: json.RawMessage(asyncOutput.AbortReason),
+				ErrorResponse: stdjson.RawMessage(asyncOutput.AbortReason),
 				Parameters:    []byte(`{}`),
 				WorkspaceId:   workspace,
 			}


### PR DESCRIPTION
# Description

We have seen significant performance improvement by using jsoniter library in the past, and it is safe as a drop-in replacement.

We have observe significant CPU usage by batchrouter component for marshaling / unmarshaling:

<img width="1326" alt="Screenshot 2022-09-01 at 7 48 40 PM" src="https://user-images.githubusercontent.com/733195/187969484-1bd48582-214d-43cf-930b-31da7cd0140c.png">


 

## Notion Ticket

https://www.notion.so/rudderstacks/jsoniter-for-batchrouter-4c8a2d0a54d14310b2ed4cc5fd5c6a39


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
