### PR TITLE
chore: add destType in tags and remove from name

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -408,8 +408,8 @@ type HandleT struct {
 	dsCacheLock                   sync.Mutex
 	BackupSettings                *backupSettings
 	jobsFileUploader              filemanager.FileManager
-	statTableCount                stats.RudderStats
 	statDSCount                   stats.RudderStats
+	statTableCount                stats.RudderStats
 	statNewDSPeriod               stats.RudderStats
 	invalidCacheKeyStat           stats.RudderStats
 	isStatNewDSPeriodInitialized  bool
@@ -861,6 +861,7 @@ func (jd *HandleT) workersAndAuxSetup() {
 
 	jd.logger.Infof("Connected to %s DB", jd.tablePrefix)
 
+	// TODO: Get rid of statTableCount after changing the alerts appropriately
 	jd.statTableCount = stats.DefaultStats.NewStat(fmt.Sprintf("jobsdb.%s_tables_count", jd.tablePrefix), stats.GaugeType)
 	jd.statDSCount = stats.NewTaggedStat("jobsdb.tables_count", stats.GaugeType, stats.Tags{"customVal": jd.tablePrefix})
 	jd.tablesQueriedStat = stats.NewTaggedStat("tables_queried_gauge", stats.GaugeType, stats.Tags{

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -30,7 +30,7 @@ import (
 	"github.com/thoas/go-funk"
 	"golang.org/x/sync/errgroup"
 
-	uuid "github.com/gofrs/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/rudderlabs/rudder-server/config"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
@@ -1249,7 +1249,7 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 			// Update metrics maps
 			errorCode := getBRTErrorCode(jobState)
 			var cd *types.ConnectionDetails
-			workspaceID := brt.backendConfig.GetWorkspaceIDForSourceID((parameters.SourceID))
+			workspaceID := brt.backendConfig.GetWorkspaceIDForSourceID(parameters.SourceID)
 			_, ok := batchRouterWorkspaceJobStatusCount[workspaceID]
 			if !ok {
 				batchRouterWorkspaceJobStatusCount[workspaceID] = make(map[string]int)
@@ -1797,7 +1797,7 @@ func (worker *workerT) workerProcess() {
 			rruntime.Go(func() {
 				switch {
 				case misc.ContainsString(objectStorageDestinations, brt.destType):
-					destUploadStat := stats.DefaultStats.NewStat(fmt.Sprintf(`batch_router.%s_dest_upload_time`, brt.destType), stats.TimerType)
+					destUploadStat := stats.NewTaggedStat(`batch_router.dest_upload_time`, stats.TimerType, map[string]string{"destType": brt.destType})
 					destUploadStat.Start()
 					output := brt.copyJobsToStorage(brt.destType, &batchJobs, false)
 					brt.recordDeliveryStatus(*batchJobs.BatchDestination, output, false)
@@ -1814,7 +1814,7 @@ func (worker *workerT) workerProcess() {
 				case misc.ContainsString(warehouseutils.WarehouseDestinations, brt.destType):
 					useRudderStorage := misc.IsConfiguredToUseRudderObjectStorage(batchJobs.BatchDestination.Destination.Config)
 					objectStorageType := warehouseutils.ObjectStorageType(brt.destType, batchJobs.BatchDestination.Destination.Config, useRudderStorage)
-					destUploadStat := stats.DefaultStats.NewStat(fmt.Sprintf(`batch_router.%s_%s_dest_upload_time`, brt.destType, objectStorageType), stats.TimerType)
+					destUploadStat := stats.NewTaggedStat(`batch_router.dest_upload_time`, stats.TimerType, map[string]string{"destType": brt.destType, "objectStorageType": objectStorageType})
 					destUploadStat.Start()
 					splitBatchJobs := brt.splitBatchJobsOnTimeWindow(batchJobs)
 					for _, batchJob := range splitBatchJobs {
@@ -1834,7 +1834,7 @@ func (worker *workerT) workerProcess() {
 					}
 					destUploadStat.End()
 				case misc.ContainsString(asyncDestinations, brt.destType):
-					destUploadStat := stats.DefaultStats.NewStat(fmt.Sprintf(`batch_router.%s_dest_upload_time`, brt.destType), stats.TimerType)
+					destUploadStat := stats.NewTaggedStat(`batch_router.dest_upload_time`, stats.TimerType, map[string]string{"destType": brt.destType})
 					destUploadStat.Start()
 					brt.sendJobsToStorage(batchJobs)
 					destUploadStat.End()


### PR DESCRIPTION
# Description
Batch Router stats have the destinationType in the stat name causing difficulty in grouping by destType on Grafana. This PR attempts to add them as tags.

Also removed a redundant table count stat from jobsdb 

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=6059f6a105144d47b59d7be7d4c3a839&pm=s)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
