### PR TITLE
chore: disable parallel test execution and refactor jobsdb tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ mocks: install-tools ## Generate all mocks
 
 test: ## Run all unit tests
 ifdef package
-	SLOW=0 $(GINKGO) -p --randomize-all --randomize-suites --fail-on-pending --cover  \
+	SLOW=0 $(GINKGO) --fail-on-pending --cover  \
 		-coverprofile=profile.out -covermode=atomic --trace -keep-separate-coverprofiles $(package) ;
 else
-	SLOW=0 $(GINKGO) -p --randomize-all --randomize-suites --fail-on-pending --cover  \
+	SLOW=0 $(GINKGO) --fail-on-pending --cover  \
 		-coverprofile=profile.out -covermode=atomic --trace -keep-separate-coverprofiles ./... ;
 endif
 	echo "mode: atomic" > coverage.txt

--- a/docker_test.go
+++ b/docker_test.go
@@ -22,13 +22,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/testhelper"
 	"github.com/rudderlabs/rudder-server/testhelper/workspaceConfig"
 
 	redigo "github.com/gomodule/redigo/redis"
 	"github.com/joho/godotenv"
 	_ "github.com/lib/pq"
 	"github.com/ory/dockertest/v3"
-	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 	"golang.org/x/sync/errgroup"
@@ -433,12 +433,12 @@ func setupMainFlow(svcCtx context.Context, t *testing.T) <-chan struct{} {
 	t.Setenv("DEST_TRANSFORM_URL", transformerContainer.TransformURL)
 	t.Setenv("DEPLOYMENT_TYPE", string(deployment.DedicatedType))
 
-	httpPortInt, err := freeport.GetFreePort()
+	httpPortInt, err := testhelper.GetFreePort()
 	require.NoError(t, err)
 
 	httpPort = strconv.Itoa(httpPortInt)
 	t.Setenv("RSERVER_GATEWAY_WEB_PORT", httpPort)
-	httpAdminPort, err := freeport.GetFreePort()
+	httpAdminPort, err := testhelper.GetFreePort()
 	require.NoError(t, err)
 
 	t.Setenv("RSERVER_GATEWAY_ADMIN_WEB_PORT", strconv.Itoa(httpAdminPort))

--- a/eventorder_test.go
+++ b/eventorder_test.go
@@ -18,10 +18,9 @@ import (
 
 	"github.com/rudderlabs/rudder-server/testhelper/health"
 
-	"github.com/rudderlabs/rudder-server/testhelper"
-
 	"github.com/ory/dockertest/v3"
 	main "github.com/rudderlabs/rudder-server"
+	"github.com/rudderlabs/rudder-server/testhelper"
 	"github.com/rudderlabs/rudder-server/testhelper/destination"
 	trand "github.com/rudderlabs/rudder-server/testhelper/rand"
 	"github.com/rudderlabs/rudder-server/testhelper/workspaceConfig"

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -4129,7 +4129,7 @@ func (jd *HandleT) doUpdateJobStatusInTx(ctx context.Context, tx *sql.Tx, status
 		dsList := jd.getDSList()
 		jd.assert(len(dsRangeList) >= len(dsList)-2, fmt.Sprintf("len(dsRangeList):%d < len(dsList):%d-2", len(dsRangeList), len(dsList)))
 		// Update status in the last element
-		jd.logger.Debug("RangeEnd", statusList[lastPos].JobID, lastPos, len(statusList))
+		jd.logger.Debug("RangeEnd ", statusList[lastPos].JobID, lastPos, len(statusList))
 		var updatedStates map[string][]string
 		updatedStates, err = jd.updateJobStatusDSInTx(ctx, tx, dsList[len(dsList)-1], statusList[lastPos:], tags)
 		if err != nil {

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -29,7 +29,6 @@ func TestBackupTable(t *testing.T) {
 	var (
 		tc                       backupTestCase
 		prefix                   = "some-prefix"
-		postgresResource         *destination.PostgresResource
 		minioResource            *destination.MINIOResource
 		goldenFileJobsFileName   = "testdata/backupJobs.json.gz"
 		goldenFileStatusFileName = "testdata/backupStatus.json.gz"
@@ -41,7 +40,7 @@ func TestBackupTable(t *testing.T) {
 	cleanup := &testhelper.Cleanup{}
 	defer cleanup.Run()
 
-	postgresResource, err = destination.SetupPostgres(pool, cleanup)
+	postgresResource, err := destination.SetupPostgres(pool, cleanup)
 	require.NoError(t, err)
 
 	minioResource, err = destination.SetupMINIO(pool, cleanup)
@@ -74,6 +73,7 @@ func TestBackupTable(t *testing.T) {
 		t.Setenv("JOBS_DB_PORT", postgresResource.Port)
 		t.Setenv("JOBS_DB_USER", postgresResource.User)
 		t.Setenv("JOBS_DB_PASSWORD", postgresResource.Password)
+
 		initJobsDB()
 		stats.Setup()
 	}

--- a/jobsdb/readonly_jobsdb_test.go
+++ b/jobsdb/readonly_jobsdb_test.go
@@ -3,29 +3,9 @@ package jobsdb
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/rudderlabs/rudder-server/admin"
-	"github.com/rudderlabs/rudder-server/config"
-	"github.com/rudderlabs/rudder-server/services/stats"
-	"github.com/rudderlabs/rudder-server/utils/logger"
 )
 
-func initReadonlyJobsDB() {
-	config.Load()
-	logger.Init()
-	admin.Init()
-	Init()
-	Init2()
-	Init3()
-}
-
 var _ = Describe("readonly_jobsdb", func() {
-	initReadonlyJobsDB()
-
-	BeforeEach(func() {
-		stats.Setup()
-	})
-
 	Context("getJobPrefix", func() {
 		It("should return prefix for job tables", func() {
 			Expect(getJobPrefix("gw")).To(Equal("gw_jobs_"))

--- a/jobsdb/unionQuery_test.go
+++ b/jobsdb/unionQuery_test.go
@@ -7,14 +7,12 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
-	"github.com/rudderlabs/rudder-server/services/stats"
 	"github.com/rudderlabs/rudder-server/utils/bytesize"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMultiTenantHandleT_GetAllJobs(t *testing.T) {
-	initJobsDB()
-	stats.Setup()
+	_ = startPostgres(t)
 
 	migrationMode := ""
 

--- a/testhelper/destination/kafka.go
+++ b/testhelper/destination/kafka.go
@@ -8,7 +8,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/ory/dockertest/v3"
 	dc "github.com/ory/dockertest/v3/docker"
-	"github.com/phayes/freeport"
+	"github.com/rudderlabs/rudder-server/testhelper"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -120,6 +120,7 @@ func (k *KafkaResource) Destroy() error {
 }
 
 func SetupKafka(pool *dockertest.Pool, cln cleaner, opts ...Option) (*KafkaResource, error) {
+	// lock so no two tests can run at the same time and try to listen on the same port
 	var c config
 	for _, opt := range opts {
 		opt.apply(&c)
@@ -136,7 +137,7 @@ func SetupKafka(pool *dockertest.Pool, cln cleaner, opts ...Option) (*KafkaResou
 		}
 	})
 
-	zookeeperPortInt, err := freeport.GetFreePort()
+	zookeeperPortInt, err := testhelper.GetFreePort()
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +246,7 @@ func SetupKafka(pool *dockertest.Pool, cln cleaner, opts ...Option) (*KafkaResou
 	containers := make([]*dockertest.Resource, c.brokers)
 	for i := uint(0); i < c.brokers; i++ {
 		i := i
-		localhostPortInt, err := freeport.GetFreePort()
+		localhostPortInt, err := testhelper.GetFreePort()
 		if err != nil {
 			return nil, err
 		}

--- a/testhelper/destination/minio.go
+++ b/testhelper/destination/minio.go
@@ -11,7 +11,7 @@ import (
 	"github.com/minio/minio-go"
 	"github.com/ory/dockertest/v3"
 	dc "github.com/ory/dockertest/v3/docker"
-	"github.com/phayes/freeport"
+	"github.com/rudderlabs/rudder-server/testhelper"
 )
 
 type MINIOResource struct {
@@ -25,7 +25,7 @@ type MINIOResource struct {
 }
 
 func SetupMINIO(pool *dockertest.Pool, d cleaner) (*MINIOResource, error) {
-	minioPortInt, err := freeport.GetFreePort()
+	minioPortInt, err := testhelper.GetFreePort()
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/testhelper/freeport.go
+++ b/testhelper/freeport.go
@@ -12,13 +12,14 @@ var (
 )
 
 func GetFreePort() (int, error) {
+	usedPortsMu.Lock()
+	defer usedPortsMu.Unlock()
 	for {
 		port, err := freeport.GetFreePort()
 		if err != nil {
 			return 0, err
 		}
 
-		usedPortsMu.Lock()
 		if usedPorts == nil {
 			usedPorts = make(map[int]struct{})
 		}
@@ -27,7 +28,6 @@ func GetFreePort() (int, error) {
 			continue
 		}
 		usedPorts[port] = struct{}{}
-		usedPortsMu.Unlock()
 		return port, nil
 	}
 }


### PR DESCRIPTION
# Description
As long as we are depending on global and environment variables for initialization, it is not safe to execute tests in parallel, e.g.
1. One test might pick up the configuration of another test
2. One test might override the configuration of another test
3. One test's initialization (config, logging, admin, etc.) might cause a panic to another running test.

Even though parallel test execution is desirable, however it is unsafe and constantly requires effort for debugging, retrying, etc. Thus disabling it.

Furthermore, the following refactoring was performed in jobsdb tests
- Using a common function for starting the postgresql container, setting required environment variables and initializing global variables across go tests, benchmarks & ginkgo tests
- Using a different postgresql container in most test cases
- Using a random table prefix for each separate test
- Various other small fixes

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
