### PR TITLE
chore: introduced log & stats for retry of  jobsDB execute & query methods

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -4706,30 +4706,30 @@ func sanitizeJson(input json.RawMessage) json.RawMessage {
 	return v
 }
 
-func QueryJobsWithRetries(parentContext context.Context, timeout time.Duration, maxAttempts int, f func(ctx context.Context) ([]*JobT, error)) ([]*JobT, error) {
-	res, err := misc.QueryWithRetries(parentContext, timeout, maxAttempts, func(ctx context.Context) (interface{}, error) {
+func QueryJobsWithRetriesAndNotify(parentContext context.Context, timeout time.Duration, maxAttempts int, f func(ctx context.Context) ([]*JobT, error), notify misc.Notify) ([]*JobT, error) {
+	res, err := misc.QueryWithRetriesAndNotify(parentContext, timeout, maxAttempts, func(ctx context.Context) (interface{}, error) {
 		return f(ctx)
-	})
+	}, notify)
 	if err != nil {
 		return nil, err
 	}
 	return res.([]*JobT), err
 }
 
-func QueryJobsResultWithRetries(parentContext context.Context, timeout time.Duration, maxAttempts int, f func(ctx context.Context) (JobsResult, error)) (JobsResult, error) {
-	res, err := misc.QueryWithRetries(parentContext, timeout, maxAttempts, func(ctx context.Context) (interface{}, error) {
+func QueryJobsResultWithRetriesAndNotify(parentContext context.Context, timeout time.Duration, maxAttempts int, f func(ctx context.Context) (JobsResult, error), notify misc.Notify) (JobsResult, error) {
+	res, err := misc.QueryWithRetriesAndNotify(parentContext, timeout, maxAttempts, func(ctx context.Context) (interface{}, error) {
 		return f(ctx)
-	})
+	}, notify)
 	if err != nil {
 		return JobsResult{}, err
 	}
 	return res.(JobsResult), err
 }
 
-func QueryWorkspacePileupWithRetries(parentContext context.Context, timeout time.Duration, maxAttempts int, f func(ctx context.Context) (map[string]map[string]int, error)) (map[string]map[string]int, error) {
-	res, err := misc.QueryWithRetries(parentContext, timeout, maxAttempts, func(ctx context.Context) (interface{}, error) {
+func QueryWorkspacePileupWithRetriesAndNotify(parentContext context.Context, timeout time.Duration, maxAttempts int, f func(ctx context.Context) (map[string]map[string]int, error), notify misc.Notify) (map[string]map[string]int, error) {
+	res, err := misc.QueryWithRetriesAndNotify(parentContext, timeout, maxAttempts, func(ctx context.Context) (interface{}, error) {
 		return f(ctx)
-	})
+	}, notify)
 	if err != nil {
 		return nil, err
 	}

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -4706,36 +4706,6 @@ func sanitizeJson(input json.RawMessage) json.RawMessage {
 	return v
 }
 
-func QueryJobsWithRetriesAndNotify(parentContext context.Context, timeout time.Duration, maxAttempts int, f func(ctx context.Context) ([]*JobT, error), notify misc.Notify) ([]*JobT, error) {
-	res, err := misc.QueryWithRetriesAndNotify(parentContext, timeout, maxAttempts, func(ctx context.Context) (interface{}, error) {
-		return f(ctx)
-	}, notify)
-	if err != nil {
-		return nil, err
-	}
-	return res.([]*JobT), err
-}
-
-func QueryJobsResultWithRetriesAndNotify(parentContext context.Context, timeout time.Duration, maxAttempts int, f func(ctx context.Context) (JobsResult, error), notify misc.Notify) (JobsResult, error) {
-	res, err := misc.QueryWithRetriesAndNotify(parentContext, timeout, maxAttempts, func(ctx context.Context) (interface{}, error) {
-		return f(ctx)
-	}, notify)
-	if err != nil {
-		return JobsResult{}, err
-	}
-	return res.(JobsResult), err
-}
-
-func QueryWorkspacePileupWithRetriesAndNotify(parentContext context.Context, timeout time.Duration, maxAttempts int, f func(ctx context.Context) (map[string]map[string]int, error), notify misc.Notify) (map[string]map[string]int, error) {
-	res, err := misc.QueryWithRetriesAndNotify(parentContext, timeout, maxAttempts, func(ctx context.Context) (interface{}, error) {
-		return f(ctx)
-	}, notify)
-	if err != nil {
-		return nil, err
-	}
-	return res.(map[string]map[string]int), err
-}
-
 type smallDS struct {
 	ds          dataSetT
 	recordsLeft int

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -625,7 +625,7 @@ func TestJobsDBTimeout(t *testing.T) {
 		expectedRetries := 2
 		var errorsCount int
 
-		jobs, err := QueryJobsResultWithRetries(context.Background(), 10*time.Millisecond, expectedRetries, func(ctx context.Context) (JobsResult, error) {
+		jobs, err := QueryJobsResultWithRetriesAndNotify(context.Background(), 10*time.Millisecond, expectedRetries, func(ctx context.Context) (JobsResult, error) {
 			jobs, err := jobDB.GetUnprocessed(ctx, GetQueryParamsT{
 				CustomValFilters: []string{customVal},
 				JobsLimit:        1,
@@ -635,7 +635,7 @@ func TestJobsDBTimeout(t *testing.T) {
 				errorsCount++
 			}
 			return jobs, err
-		})
+		}, nil)
 		require.True(t, len(jobs.Jobs) == 0, "Error in getting unprocessed jobs")
 		require.Error(t, err)
 		require.True(t, errors.Is(ctx.Err(), context.DeadlineExceeded))

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -625,7 +625,7 @@ func TestJobsDBTimeout(t *testing.T) {
 		expectedRetries := 2
 		var errorsCount int
 
-		jobs, err := QueryJobsResultWithRetriesAndNotify(context.Background(), 10*time.Millisecond, expectedRetries, func(ctx context.Context) (JobsResult, error) {
+		jobs, err := misc.QueryWithRetries(context.Background(), 10*time.Millisecond, expectedRetries, func(ctx context.Context) (JobsResult, error) {
 			jobs, err := jobDB.GetUnprocessed(ctx, GetQueryParamsT{
 				CustomValFilters: []string{customVal},
 				JobsLimit:        1,
@@ -635,7 +635,7 @@ func TestJobsDBTimeout(t *testing.T) {
 				errorsCount++
 			}
 			return jobs, err
-		}, nil)
+		})
 		require.True(t, len(jobs.Jobs) == 0, "Error in getting unprocessed jobs")
 		require.Error(t, err)
 		require.True(t, errors.Is(ctx.Err(), context.DeadlineExceeded))

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1552,6 +1552,21 @@ type storeMessage struct {
 	rsourcesStats rsources.StatsCollector
 }
 
+func sendRetryStoreStats(attempt int) {
+	pkgLogger.Errorf("Processor: Retrying store: attempt: %d", attempt)
+	stats.NewTaggedStat("proc_store_retry_count", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt)}).Count(1)
+}
+
+func sendRetryUpdateStats(attempt int) {
+	pkgLogger.Errorf("Processor: Retrying store: attempt: %d", attempt)
+	stats.NewTaggedStat("proc_update_retry_count", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt)}).Count(1)
+}
+
+func sendQueryRetryStats(attempt int) {
+	pkgLogger.Errorf("Processor: Retrying GET jobs: attempt: %d", attempt)
+	stats.NewTaggedStat("proc_query_retry_count", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt)}).Count(1)
+}
+
 func (proc *HandleT) Store(in *storeMessage) {
 	statusList, destJobs, batchDestJobs := in.statusList, in.destJobs, in.batchDestJobs
 	processorLoopStats := make(map[string]map[string]map[string]int)
@@ -1560,7 +1575,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 	if len(batchDestJobs) > 0 {
 		proc.logger.Debug("[Processor] Total jobs written to batch router : ", len(batchDestJobs))
 
-		err := misc.RetryWith(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
+		err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
 			return proc.batchRouterDB.WithStoreSafeTx(func(tx jobsdb.StoreSafeTx) error {
 				err := proc.batchRouterDB.StoreInTx(ctx, tx, batchDestJobs)
 				if err != nil {
@@ -1574,7 +1589,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 				}
 				return nil
 			})
-		})
+		}, sendRetryStoreStats)
 		if err != nil {
 			panic(err)
 		}
@@ -1599,7 +1614,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 	if len(destJobs) > 0 {
 		proc.logger.Debug("[Processor] Total jobs written to router : ", len(destJobs))
 
-		err := misc.RetryWith(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
+		err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
 			return proc.routerDB.WithStoreSafeTx(func(tx jobsdb.StoreSafeTx) error {
 				err := proc.routerDB.StoreInTx(ctx, tx, destJobs)
 				if err != nil {
@@ -1613,7 +1628,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 				}
 				return nil
 			})
-		})
+		}, sendRetryStoreStats)
 		if err != nil {
 			panic(err)
 		}
@@ -1640,9 +1655,9 @@ func (proc *HandleT) Store(in *storeMessage) {
 	}
 	if len(in.procErrorJobs) > 0 {
 		proc.logger.Debug("[Processor] Total jobs written to proc_error: ", len(in.procErrorJobs))
-		err := misc.RetryWith(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
+		err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
 			return proc.errorDB.Store(ctx, in.procErrorJobs)
-		})
+		}, sendRetryStoreStats)
 		if err != nil {
 			proc.logger.Errorf("Store into proc error table failed with error: %v", err)
 			proc.logger.Errorf("procErrorJobs: %v", in.procErrorJobs)
@@ -1653,7 +1668,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 	writeJobsTime := time.Since(beforeStoreStatus)
 
 	txnStart := time.Now()
-	err := misc.RetryWith(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
+	err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
 		return proc.gatewayDB.WithUpdateSafeTx(func(tx jobsdb.UpdateSafeTx) error {
 			err := proc.gatewayDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{GWCustomVal}, nil)
 			if err != nil {
@@ -1686,7 +1701,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 			}
 			return nil
 		})
-	})
+	}, sendRetryUpdateStats)
 	if err != nil {
 		panic(err)
 	}
@@ -2194,14 +2209,14 @@ func (proc *HandleT) getJobs() jobsdb.JobsResult {
 	if !enableEventCount {
 		eventCount = 0
 	}
-	unprocessedList, err := jobsdb.QueryJobsResultWithRetries(context.Background(), proc.jobdDBQueryRequestTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+	unprocessedList, err := jobsdb.QueryJobsResultWithRetriesAndNotify(context.Background(), proc.jobdDBQueryRequestTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
 		return proc.gatewayDB.GetUnprocessed(ctx, jobsdb.GetQueryParamsT{
 			CustomValFilters: []string{GWCustomVal},
 			JobsLimit:        maxEventsToProcess,
 			EventsLimit:      eventCount,
 			PayloadSizeLimit: proc.payloadLimit,
 		})
-	})
+	}, sendQueryRetryStats)
 	if err != nil {
 		proc.logger.Errorf("Failed to get unprocessed jobs from DB. Error: %v", err)
 		panic(err)
@@ -2270,9 +2285,9 @@ func (proc *HandleT) markExecuting(jobs []*jobsdb.JobT) error {
 		}
 	}
 	// Mark the jobs as executing
-	err := misc.RetryWith(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
+	err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
 		return proc.gatewayDB.UpdateJobStatus(ctx, statusList, []string{GWCustomVal}, nil)
-	})
+	}, sendRetryUpdateStats)
 	if err != nil {
 		return fmt.Errorf("marking jobs as executing: %w", err)
 	}

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -100,6 +100,16 @@ func (st *HandleT) Start(ctx context.Context) {
 	_ = g.Wait()
 }
 
+func sendRetryUpdateStats(attempt int) {
+	pkgLogger.Errorf("Stash: Retrying store: attempt: %d", attempt)
+	stats.NewTaggedStat("stash_update_retry_count", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt)}).Count(1)
+}
+
+func sendQueryRetryStats(attempt int) {
+	pkgLogger.Errorf("Stash: Retrying GET jobs: attempt: %d", attempt)
+	stats.NewTaggedStat("stash_query_retry_count", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt)}).Count(1)
+}
+
 func (st *HandleT) getFileUploader(ctx context.Context) filemanager.FileManager {
 	if st.errFileUploader == nil && backupEnabled() {
 		st.setupFileUploader(ctx)
@@ -230,9 +240,9 @@ func (st *HandleT) setErrJobStatus(jobs []*jobsdb.JobT, output StoreErrorOutputT
 		}
 		statusList = append(statusList, &status)
 	}
-	err := misc.RetryWith(context.Background(), st.jobsDBCommandTimeout, st.jobdDBMaxRetries, func(ctx context.Context) error {
+	err := misc.RetryWithNotify(context.Background(), st.jobsDBCommandTimeout, st.jobdDBMaxRetries, func(ctx context.Context) error {
 		return st.errorDB.UpdateJobStatus(ctx, statusList, nil, nil)
-	})
+	}, sendRetryUpdateStats)
 	if err != nil {
 		pkgLogger.Errorf("Error occurred while updating proc error jobs statuses. Panicking. Err: %v", err)
 		panic(err)
@@ -257,9 +267,9 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 				JobsLimit:                     errDBReadBatchSize,
 				PayloadSizeLimit:              payloadLimit,
 			}
-			toRetry, err := jobsdb.QueryJobsResultWithRetries(ctx, st.jobdDBQueryRequestTimeout, st.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+			toRetry, err := jobsdb.QueryJobsResultWithRetriesAndNotify(ctx, st.jobdDBQueryRequestTimeout, st.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
 				return st.errorDB.GetToRetry(ctx, queryParams)
-			})
+			}, sendQueryRetryStats)
 			if err != nil {
 				st.logger.Errorf("Error occurred while reading proc error jobs. Err: %v", err)
 				panic(err)
@@ -271,9 +281,9 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 				if queryParams.PayloadSizeLimit > 0 {
 					queryParams.PayloadSizeLimit -= toRetry.PayloadSize
 				}
-				unprocessed, err := jobsdb.QueryJobsResultWithRetries(ctx, st.jobdDBQueryRequestTimeout, st.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+				unprocessed, err := jobsdb.QueryJobsResultWithRetriesAndNotify(ctx, st.jobdDBQueryRequestTimeout, st.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
 					return st.errorDB.GetUnprocessed(ctx, queryParams)
-				})
+				}, sendQueryRetryStats)
 				if err != nil {
 					st.logger.Errorf("Error occurred while reading proc error jobs. Err: %v", err)
 					panic(err)
@@ -326,9 +336,9 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 				}
 				statusList = append(statusList, &status)
 			}
-			err = misc.RetryWith(context.Background(), st.jobsDBCommandTimeout, st.jobdDBMaxRetries, func(ctx context.Context) error {
+			err = misc.RetryWithNotify(context.Background(), st.jobsDBCommandTimeout, st.jobdDBMaxRetries, func(ctx context.Context) error {
 				return st.errorDB.UpdateJobStatus(ctx, statusList, nil, nil)
-			})
+			}, sendRetryUpdateStats)
 			if err != nil {
 				pkgLogger.Errorf("Error occurred while marking proc error jobs statuses as %v. Panicking. Err: %v", jobState, err)
 				panic(err)

--- a/router/router.go
+++ b/router/router.go
@@ -255,6 +255,21 @@ func loadConfig() {
 	failedKeysEnabled = config.GetBool("Router.failedKeysEnabled", false)
 }
 
+func sendRetryStoreStats(attempt int) {
+	pkgLogger.Errorf("Router: Retrying store: attempt: %d", attempt)
+	stats.NewTaggedStat("rt_store_retry_count", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt)}).Count(1)
+}
+
+func sendRetryUpdateStats(attempt int) {
+	pkgLogger.Errorf("Router: Retrying store: attempt: %d", attempt)
+	stats.NewTaggedStat("rt_update_retry_count", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt)}).Count(1)
+}
+
+func sendQueryRetryStats(attempt int) {
+	pkgLogger.Errorf("Router: Retrying GET jobs: attempt: %d", attempt)
+	stats.NewTaggedStat("rt_query_retry_count", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt)}).Count(1)
+}
+
 func (worker *workerT) trackStuckDelivery() chan struct{} {
 	var d time.Duration
 	if worker.rt.transformerProxy {
@@ -1420,15 +1435,15 @@ func (rt *HandleT) commitStatusList(responseList *[]jobResponseT) {
 		})
 		// Store the aborted jobs to errorDB
 		if routerAbortedJobs != nil {
-			err := misc.RetryWith(context.Background(), rt.jobsDBCommandTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) error {
+			err := misc.RetryWithNotify(context.Background(), rt.jobsDBCommandTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) error {
 				return rt.errorDB.Store(ctx, routerAbortedJobs)
-			})
+			}, sendRetryStoreStats)
 			if err != nil {
 				panic(fmt.Errorf("storing jobs into ErrorDB: %w", err))
 			}
 		}
 		// Update the status
-		err := misc.RetryWith(context.Background(), rt.jobsDBCommandTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) error {
+		err := misc.RetryWithNotify(context.Background(), rt.jobsDBCommandTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) error {
 			return rt.jobsDB.WithUpdateSafeTx(func(tx jobsdb.UpdateSafeTx) error {
 				err := rt.jobsDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{rt.destName}, nil)
 				if err != nil {
@@ -1448,7 +1463,7 @@ func (rt *HandleT) commitStatusList(responseList *[]jobResponseT) {
 				rt.Reporting.Report(reportMetrics, tx.Tx())
 				return nil
 			})
-		})
+		}, sendRetryStoreStats)
 		if err != nil {
 			panic(err)
 		}
@@ -1703,14 +1718,14 @@ func (rt *HandleT) readAndProcess() int {
 	}
 	rt.timeGained = 0
 	rt.logger.Debugf("[%v Router] :: pickupMap: %+v", rt.destName, pickupMap)
-	combinedList, err := jobsdb.QueryJobsWithRetries(context.Background(), rt.jobdDBQueryRequestTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) ([]*jobsdb.JobT, error) {
+	combinedList, err := jobsdb.QueryJobsWithRetriesAndNotify(context.Background(), rt.jobdDBQueryRequestTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) ([]*jobsdb.JobT, error) {
 		return rt.jobsDB.GetAllJobs(
 			ctx,
 			pickupMap,
 			rt.getQueryParams(totalPickupCount),
 			rt.maxDSQuerySize,
 		)
-	})
+	}, sendQueryRetryStats)
 	if err != nil {
 		rt.logger.Errorf("[%v Router] :: Error getting jobs from DB: %v", rt.destName, err)
 		panic(err)
@@ -1840,9 +1855,9 @@ func (rt *HandleT) readAndProcess() int {
 	rt.throttledUserMap = nil
 
 	// Mark the jobs as executing
-	err = misc.RetryWith(context.Background(), rt.jobsDBCommandTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) error {
+	err = misc.RetryWithNotify(context.Background(), rt.jobsDBCommandTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) error {
 		return rt.jobsDB.UpdateJobStatus(ctx, statusList, []string{rt.destName}, nil)
-	})
+	}, sendRetryUpdateStats)
 	if err != nil {
 		pkgLogger.Errorf("Error occurred while marking %s jobs statuses as executing. Panicking. Err: %v", rt.destName, err)
 		panic(err)
@@ -1850,9 +1865,9 @@ func (rt *HandleT) readAndProcess() int {
 
 	// Mark the jobs as aborted
 	if len(drainList) > 0 {
-		err := misc.RetryWith(context.Background(), rt.jobsDBCommandTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) error {
+		err := misc.RetryWithNotify(context.Background(), rt.jobsDBCommandTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) error {
 			return rt.errorDB.Store(ctx, drainJobList)
-		})
+		}, sendRetryStoreStats)
 		if err != nil {
 			pkgLogger.Errorf("Error occurred while storing %s jobs into ErrorDB. Panicking. Err: %v", rt.destName, err)
 			panic(err)
@@ -1878,7 +1893,7 @@ func (rt *HandleT) readAndProcess() int {
 		}
 		// REPORTING - ROUTER - END
 
-		err = misc.RetryWith(context.Background(), rt.jobsDBCommandTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) error {
+		err = misc.RetryWithNotify(context.Background(), rt.jobsDBCommandTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) error {
 			return rt.jobsDB.WithUpdateSafeTx(func(tx jobsdb.UpdateSafeTx) error {
 				err := rt.jobsDB.UpdateJobStatusInTx(ctx, tx, drainList, []string{rt.destName}, nil)
 				if err != nil {
@@ -1893,7 +1908,7 @@ func (rt *HandleT) readAndProcess() int {
 				rt.Reporting.Report(reportMetrics, tx.Tx())
 				return nil
 			})
-		})
+		}, sendRetryUpdateStats)
 		if err != nil {
 			panic(err)
 		}

--- a/router/router.go
+++ b/router/router.go
@@ -256,18 +256,18 @@ func loadConfig() {
 }
 
 func sendRetryStoreStats(attempt int) {
-	pkgLogger.Errorf("Router: Retrying store: attempt: %d", attempt)
-	stats.NewTaggedStat("rt_store_retry_count", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt)}).Count(1)
+	pkgLogger.Warnf("Timeout during store jobs in router module, attempt %d", attempt)
+	stats.NewTaggedStat("jobsdb_store_timeout", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt), "module": "router"}).Count(1)
 }
 
 func sendRetryUpdateStats(attempt int) {
-	pkgLogger.Errorf("Router: Retrying store: attempt: %d", attempt)
-	stats.NewTaggedStat("rt_update_retry_count", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt)}).Count(1)
+	pkgLogger.Warnf("Timeout during update job status in router module, attempt %d", attempt)
+	stats.NewTaggedStat("jobsdb_update_timeout", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt), "module": "router"}).Count(1)
 }
 
 func sendQueryRetryStats(attempt int) {
-	pkgLogger.Errorf("Router: Retrying GET jobs: attempt: %d", attempt)
-	stats.NewTaggedStat("rt_query_retry_count", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt)}).Count(1)
+	pkgLogger.Warnf("Timeout during query jobs in router module, attempt %d", attempt)
+	stats.NewTaggedStat("jobsdb_query_timeout", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt), "module": "router"}).Count(1)
 }
 
 func (worker *workerT) trackStuckDelivery() chan struct{} {
@@ -1718,7 +1718,7 @@ func (rt *HandleT) readAndProcess() int {
 	}
 	rt.timeGained = 0
 	rt.logger.Debugf("[%v Router] :: pickupMap: %+v", rt.destName, pickupMap)
-	combinedList, err := jobsdb.QueryJobsWithRetriesAndNotify(context.Background(), rt.jobdDBQueryRequestTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) ([]*jobsdb.JobT, error) {
+	combinedList, err := misc.QueryWithRetriesAndNotify(context.Background(), rt.jobdDBQueryRequestTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) ([]*jobsdb.JobT, error) {
 		return rt.jobsDB.GetAllJobs(
 			ctx,
 			pickupMap,

--- a/services/multitenant/tenantstats.go
+++ b/services/multitenant/tenantstats.go
@@ -4,6 +4,7 @@ package multitenant
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sort"
 	"sync"
@@ -12,6 +13,7 @@ import (
 	"github.com/rudderlabs/rudder-server/config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/services/metric"
+	"github.com/rudderlabs/rudder-server/services/stats"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
@@ -62,12 +64,12 @@ func (t *Stats) Start() error {
 
 	for dbPrefix := range t.RouterDBs {
 		t.routerInputRates[dbPrefix] = make(map[string]map[string]metric.MovingAverage)
-		pileUpStatMap, err := jobsdb.QueryWorkspacePileupWithRetries(context.Background(),
+		pileUpStatMap, err := jobsdb.QueryWorkspacePileupWithRetriesAndNotify(context.Background(),
 			t.jobdDBQueryRequestTimeout,
 			t.jobdDBMaxRetries,
 			func(ctx context.Context) (map[string]map[string]int, error) {
 				return t.RouterDBs[dbPrefix].GetPileUpCounts(ctx)
-			})
+			}, sendQueryRetryStats)
 		if err != nil {
 			return err
 		}
@@ -94,6 +96,11 @@ func Init() {
 	pkgLogger = logger.NewLogger().Child("services").Child("multiTenant")
 }
 
+func sendQueryRetryStats(attempt int) {
+	pkgLogger.Errorf("Multitenant: Retrying GET jobs: attempt: %d", attempt)
+	stats.NewTaggedStat("multitenant_query_retry_count", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt)}).Count(1)
+}
+
 func NewStats(routerDBs map[string]jobsdb.MultiTenantJobsDB) *Stats {
 	t := Stats{}
 	config.RegisterDurationConfigVariable(60, &t.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB.Multitenant.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
@@ -107,12 +114,12 @@ func NewStats(routerDBs map[string]jobsdb.MultiTenantJobsDB) *Stats {
 	for dbPrefix := range routerDBs {
 		t.routerInputRates[dbPrefix] = make(map[string]map[string]metric.MovingAverage)
 
-		pileUpStatMap, err := jobsdb.QueryWorkspacePileupWithRetries(context.Background(),
+		pileUpStatMap, err := jobsdb.QueryWorkspacePileupWithRetriesAndNotify(context.Background(),
 			t.jobdDBQueryRequestTimeout,
 			t.jobdDBMaxRetries,
 			func(ctx context.Context) (map[string]map[string]int, error) {
 				return routerDBs[dbPrefix].GetPileUpCounts(ctx)
-			})
+			}, sendQueryRetryStats)
 		if err != nil {
 			pkgLogger.Error("Error while getting pile up counts", "error", err)
 			panic(err)

--- a/utils/misc/retry_test.go
+++ b/utils/misc/retry_test.go
@@ -51,6 +51,23 @@ func TestRetryWith(t *testing.T) {
 	})
 }
 
+func TestRetryWithNotify(t *testing.T) {
+	t.Run("test if notify func is called", func(t *testing.T) {
+		expectedAttempt := []int{1, 2}
+		receivedAttempt := make([]int, 0)
+		notify := func(attempt int) {
+			receivedAttempt = append(receivedAttempt, attempt)
+		}
+		op := operation{
+			timeout:             time.Second,
+			timeoutAfterAttempt: 2,
+		}
+		err := misc.RetryWithNotify(context.Background(), time.Millisecond, 3, op.do, notify)
+		require.NoError(t, err)
+		require.Equal(t, expectedAttempt, receivedAttempt)
+	})
+}
+
 type operation struct {
 	attempts            int
 	timeout             time.Duration
@@ -111,6 +128,23 @@ func TestQueryWithRetries(t *testing.T) {
 		_, err := misc.QueryWithRetries(context.Background(), time.Millisecond, 3, op.doAndReturn)
 		require.Equal(t, 2, op.attempts)
 		require.NoError(t, err)
+	})
+}
+
+func TestQueryWithRetriesNotify(t *testing.T) {
+	t.Run("test if notify func is called", func(t *testing.T) {
+		expectedAttempt := []int{1, 2}
+		receivedAttempt := make([]int, 0)
+		notify := func(attempt int) {
+			receivedAttempt = append(receivedAttempt, attempt)
+		}
+		op := operation{
+			timeout:             time.Second,
+			timeoutAfterAttempt: 2,
+		}
+		_, err := misc.QueryWithRetriesAndNotify(context.Background(), time.Millisecond, 3, op.doAndReturn, notify)
+		require.NoError(t, err)
+		require.Equal(t, expectedAttempt, receivedAttempt)
 	})
 }
 


### PR DESCRIPTION
# Description
>Here we have introduced logs & metrics for retry of `query` & `execute` methods of jobsDB. This is done by passing `notify` func while calling `RetryWithNotify` & `QueryWithRetriesAndNotify`.  `notify` is called whenever an attempt fails.

## Notion Ticket

https://www.notion.so/rudderstacks/Introduce-logs-and-alerts-for-jobsDB-retries-f20f44ddb5a7492a9c99fa49dba5cf3c
