### PR TITLE
refactor: config package

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -235,9 +235,8 @@ func (a *Admin) GetLoggingConfig(_ struct{}, reply *string) (err error) {
 	return err
 }
 
-// GetFormattedEnv return the formatted env
 func (a *Admin) GetFormattedEnv(env string, reply *string) (err error) {
-	*reply = config.TransformKey(env)
+	*reply = config.ConfigKeyToEnvRudder(env)
 	return nil
 }
 

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -237,7 +237,7 @@ func (a *Admin) GetLoggingConfig(_ struct{}, reply *string) (err error) {
 
 // GetFormattedEnv return the formatted env
 func (a *Admin) GetFormattedEnv(env string, reply *string) (err error) {
-	*reply = config.ConfigKeyToEnvRudder(env)
+	*reply = config.ConfigKeyToEnv(env)
 	return nil
 }
 

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -235,6 +235,7 @@ func (a *Admin) GetLoggingConfig(_ struct{}, reply *string) (err error) {
 	return err
 }
 
+// GetFormattedEnv return the formatted env
 func (a *Admin) GetFormattedEnv(env string, reply *string) (err error) {
 	*reply = config.ConfigKeyToEnvRudder(env)
 	return nil

--- a/app/app.go
+++ b/app/app.go
@@ -160,7 +160,7 @@ func getHealthVal(jobsDB jobsdb.JobsDB) string {
 		backendConfigMode = "JSON"
 	}
 
-	appTypeStr := strings.ToUpper(config.GetEnv("APP_TYPE", EMBEDDED))
+	appTypeStr := strings.ToUpper(config.GetString("APP_TYPE", EMBEDDED))
 	return fmt.Sprintf(
 		`{"appType":"%s","server":"UP","db":"%s","acceptingEvents":"TRUE","routingEvents":"%s","mode":"%s",`+
 			`"backendConfigMode":"%s","lastSync":"%s","lastRegulationSync":"%s"}`,

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -230,15 +230,15 @@ func NewRsourcesService(deploymentType deployment.Type) (rsources.JobService, er
 	var rsourcesConfig rsources.JobServiceConfig
 	rsourcesConfig.MaxPoolSize = config.GetInt("Rsources.PoolSize", 5)
 	rsourcesConfig.LocalConn = jobsdb.GetConnectionString()
-	rsourcesConfig.LocalHostname = config.GetEnv("JOBS_DB_HOST", "localhost")
-	rsourcesConfig.SharedConn = config.GetEnv("SHARED_DB_DSN", "")
+	rsourcesConfig.LocalHostname = config.GetString("DB.host", "localhost")
+	rsourcesConfig.SharedConn = config.GetString("SharedDB.dsn", "")
 	rsourcesConfig.SkipFailedRecordsCollection = !config.GetBool("Router.failedKeysEnabled", false)
 
 	if deploymentType == deployment.MultiTenantType {
 		// For multitenant deployment type we shall require the existence of a SHARED_DB
 		// TODO: change default value of Rsources.FailOnMissingSharedDB to true, when shared DB is provisioned
 		if rsourcesConfig.SharedConn == "" && config.GetBool("Rsources.FailOnMissingSharedDB", false) {
-			return nil, fmt.Errorf("deployment type %s requires SHARED_DB_DSN to be provided", deploymentType)
+			return nil, fmt.Errorf("deployment type %s requires SharedDB.dsn to be provided", deploymentType)
 		}
 	}
 

--- a/app/cluster/dynamic_test.go
+++ b/app/cluster/dynamic_test.go
@@ -58,7 +58,7 @@ func (m *mockLifecycle) Stop() {
 }
 
 func Init() {
-	config.Load()
+	config.Reset()
 	stats.Setup()
 	logger.Init()
 }

--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -154,7 +154,7 @@ var (
 )
 
 func initJobsDB() {
-	config.Load()
+	config.Reset()
 	logger.Init()
 	stash.Init()
 	admin.Init()

--- a/app/cluster/state/etcd.go
+++ b/app/cluster/state/etcd.go
@@ -68,7 +68,7 @@ type workspacesAckValue struct {
 }
 
 func EnvETCDConfig() *ETCDConfig {
-	endpoints := strings.Split(config.GetEnv("ETCD_HOSTS", "127.0.0.1:2379"), `,`)
+	endpoints := strings.Split(config.GetString("ETCD_HOSTS", "127.0.0.1:2379"), `,`)
 	releaseName := config.GetReleaseName()
 	serverIndex := config.GetInstanceID()
 	var ackTimeout time.Duration
@@ -284,7 +284,7 @@ func (manager *ETCDManager) WorkspaceIDs(ctx context.Context) <-chan workspace.C
 		return errChWorkspacesRequest(err)
 	}
 
-	appTypeStr := strings.ToUpper(config.GetEnv("APP_TYPE", app.PROCESSOR))
+	appTypeStr := strings.ToUpper(config.GetString("APP_TYPE", app.PROCESSOR))
 	modeRequestKey := fmt.Sprintf(workspacesRequestsKeyPattern, manager.Config.ReleaseName, manager.Config.ServerIndex, appTypeStr)
 	manager.logger.Infof("Workspace ID Lookup Key: %s", modeRequestKey)
 

--- a/app/cluster/state/etcd_test.go
+++ b/app/cluster/state/etcd_test.go
@@ -81,7 +81,7 @@ func blockOnHold() {
 }
 
 func Init() {
-	config.Load()
+	config.Reset()
 	stats.Setup()
 	logger.Init()
 }
@@ -238,7 +238,7 @@ func Test_Workspaces(t *testing.T) {
 			},
 		}
 		defer provider.Close()
-		appType := strings.ToUpper(config.GetEnv("APP_TYPE", app.PROCESSOR))
+		appType := strings.ToUpper(config.GetString("APP_TYPE", app.PROCESSOR))
 		requestKey := fmt.Sprintf("/%s/SERVER/%s/%s/WORKSPACES", provider.Config.ReleaseName,
 			provider.Config.ServerIndex, appType)
 
@@ -263,7 +263,7 @@ func Test_Workspaces(t *testing.T) {
 	}
 	defer provider.Close()
 
-	appType := strings.ToUpper(config.GetEnv("APP_TYPE", app.PROCESSOR))
+	appType := strings.ToUpper(config.GetString("APP_TYPE", app.PROCESSOR))
 	requestKey := fmt.Sprintf("/%s/SERVER/%s/%s/WORKSPACES", provider.Config.ReleaseName, provider.Config.ServerIndex,
 		appType)
 

--- a/app/options.go
+++ b/app/options.go
@@ -50,5 +50,5 @@ func LoadOptions() *Options {
 }
 
 func getMigrationMode() string {
-	return config.GetEnv("MIGRATION_MODE", "")
+	return config.GetString("MIGRATION_MODE", "")
 }

--- a/config/backend-config/backend-config.go
+++ b/config/backend-config/backend-config.go
@@ -77,8 +77,8 @@ type backendConfigImpl struct {
 }
 
 func loadConfig() {
-	configBackendURL = config.GetEnv("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
-	cpRouterURL = config.GetEnv("CP_ROUTER_URL", "https://cp-router.rudderlabs.com")
+	configBackendURL = config.GetString("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
+	cpRouterURL = config.GetString("CP_ROUTER_URL", "https://cp-router.rudderlabs.com")
 	config.RegisterDurationConfigVariable(5, &pollInterval, true, time.Second, []string{"BackendConfig.pollInterval", "BackendConfig.pollIntervalInS"}...)
 	config.RegisterDurationConfigVariable(300, &regulationsPollInterval, true, time.Second, []string{"BackendConfig.regulationsPollInterval", "BackendConfig.regulationsPollIntervalInS"}...)
 	config.RegisterStringConfigVariable("/etc/rudderstack/workspaceConfig.json", &configJSONPath, false, "BackendConfig.configJSONPath")

--- a/config/backend-config/backend_config_test.go
+++ b/config/backend-config/backend_config_test.go
@@ -329,7 +329,7 @@ func TestWaitForConfig(t *testing.T) {
 }
 
 func initBackendConfig() {
-	config.Load()
+	config.Reset()
 	adminpkg.Init()
 	diagnostics.Init()
 	logger.Init()

--- a/config/backend-config/namespace_config.go
+++ b/config/backend-config/namespace_config.go
@@ -2,6 +2,7 @@ package backendconfig
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -41,19 +42,19 @@ func (nc *namespaceConfig) SetUp() (err error) {
 	nc.writeKeyToWorkspaceIDMap = make(map[string]string)
 
 	if nc.Namespace == "" {
-		nc.Namespace, err = config.GetEnvErr("WORKSPACE_NAMESPACE")
-		if err != nil {
-			return err
+		if !config.IsSet("WORKSPACE_NAMESPACE") {
+			return errors.New("workspaceNamespace is not configured")
 		}
+		nc.Namespace = config.GetString("WORKSPACE_NAMESPACE", "")
 	}
 	if nc.HostedServiceSecret == "" {
-		nc.HostedServiceSecret, err = config.GetEnvErr("HOSTED_SERVICE_SECRET")
-		if err != nil {
-			return err
+		if !config.IsSet("HOSTED_SERVICE_SECRET") {
+			return errors.New("hostedServiceSecret is not configured")
 		}
+		nc.HostedServiceSecret = config.GetString("HOSTED_SERVICE_SECRET", "")
 	}
 	if nc.ConfigBackendURL == nil {
-		configBackendURL := config.GetEnv("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
+		configBackendURL := config.GetString("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
 		nc.ConfigBackendURL, err = url.Parse(configBackendURL)
 		if err != nil {
 			return err

--- a/config/backend-config/namespace_config_test.go
+++ b/config/backend-config/namespace_config_test.go
@@ -37,7 +37,7 @@ func Test_Namespace_SetUp(t *testing.T) {
 }
 
 func Test_Namespace_Get(t *testing.T) {
-	config.Load()
+	config.Reset()
 	logger.Init()
 
 	var (

--- a/config/backend-config/namespace_config_test.go
+++ b/config/backend-config/namespace_config_test.go
@@ -134,7 +134,7 @@ func Test_Namespace_Get(t *testing.T) {
 }
 
 func Test_Namespace_Identity(t *testing.T) {
-	config.Load()
+	config.Reset()
 	logger.Init()
 
 	var (

--- a/config/config.go
+++ b/config/config.go
@@ -54,13 +54,12 @@ func New() *Config {
 
 // Config is the entry point for accessing configuration
 type Config struct {
-	vLock                  sync.RWMutex // protects reading and writing to the config (viper is not thread-safe)
-	v                      *viper.Viper
-	mapLock                sync.RWMutex // protects maps holding registered config keys
-	hotReloadableConfig    map[string][]*configValue
-	nonHotReloadableConfig map[string][]*configValue
-	envsLock               sync.RWMutex // protects the envs map below
-	envs                   map[string]string
+	vLock                   sync.RWMutex // protects reading and writing to the config (viper is not thread-safe)
+	v                       *viper.Viper
+	hotReloadableConfigLock sync.RWMutex // protects map holding hot reloadable config keys
+	hotReloadableConfig     map[string][]*configValue
+	envsLock                sync.RWMutex // protects the envs map below
+	envs                    map[string]string
 }
 
 // GetBool gets bool value from config

--- a/config/config.go
+++ b/config/config.go
@@ -34,15 +34,15 @@ var camelCaseMatch = regexp.MustCompile("([a-z0-9])([A-Z])")
 var upperCaseMatch = regexp.MustCompile("^[A-Z0-9_]+$")
 
 // default, singleton config instance
-var c *Config
+var defaultConfig *Config
 
 func init() {
-	c = New()
+	defaultConfig = New()
 }
 
 // Reset resets configuration
 func Reset() {
-	c = New()
+	defaultConfig = New()
 }
 
 // New creates a new config instance
@@ -64,7 +64,7 @@ type Config struct {
 
 // GetBool gets bool value from config
 func GetBool(key string, defaultValue bool) (value bool) {
-	return c.GetBool(key, defaultValue)
+	return defaultConfig.GetBool(key, defaultValue)
 }
 
 // GetBool gets bool value from config
@@ -79,7 +79,7 @@ func (c *Config) GetBool(key string, defaultValue bool) (value bool) {
 
 // GetInt gets int value from config
 func GetInt(key string, defaultValue int) (value int) {
-	return c.GetInt(key, defaultValue)
+	return defaultConfig.GetInt(key, defaultValue)
 }
 
 // GetInt gets int value from config
@@ -94,7 +94,7 @@ func (c *Config) GetInt(key string, defaultValue int) (value int) {
 
 // MustGetInt gets int value from config or panics if the config doesn't exist
 func MustGetInt(key string) (value int) {
-	return c.MustGetInt(key)
+	return defaultConfig.MustGetInt(key)
 }
 
 // MustGetInt gets int value from config or panics if the config doesn't exist
@@ -109,7 +109,7 @@ func (c *Config) MustGetInt(key string) (value int) {
 
 // GetInt64 gets int64 value from config
 func GetInt64(key string, defaultValue int64) (value int64) {
-	return c.GetInt64(key, defaultValue)
+	return defaultConfig.GetInt64(key, defaultValue)
 }
 
 // GetInt64 gets int64 value from config
@@ -124,7 +124,7 @@ func (c *Config) GetInt64(key string, defaultValue int64) (value int64) {
 
 // GetFloat64 gets float64 value from config
 func GetFloat64(key string, defaultValue float64) (value float64) {
-	return c.GetFloat64(key, defaultValue)
+	return defaultConfig.GetFloat64(key, defaultValue)
 }
 
 // GetFloat64 gets float64 value from config
@@ -139,7 +139,7 @@ func (c *Config) GetFloat64(key string, defaultValue float64) (value float64) {
 
 // GetString gets string value from config
 func GetString(key, defaultValue string) (value string) {
-	return c.GetString(key, defaultValue)
+	return defaultConfig.GetString(key, defaultValue)
 }
 
 // GetString gets string value from config
@@ -154,7 +154,7 @@ func (c *Config) GetString(key, defaultValue string) (value string) {
 
 // MustGetString gets string value from config or panics if the config doesn't exist
 func MustGetString(key string) (value string) {
-	return c.MustGetString(key)
+	return defaultConfig.MustGetString(key)
 }
 
 // MustGetString gets string value from config or panics if the config doesn't exist
@@ -179,7 +179,7 @@ func (c *Config) GetStringSlice(key string, defaultValue []string) (value []stri
 
 // GetDuration gets duration value from config
 func GetDuration(key string, defaultValueInTimescaleUnits int64, timeScale time.Duration) (value time.Duration) {
-	return c.GetDuration(key, defaultValueInTimescaleUnits, timeScale)
+	return defaultConfig.GetDuration(key, defaultValueInTimescaleUnits, timeScale)
 }
 
 // GetDuration gets duration value from config
@@ -206,7 +206,7 @@ func (c *Config) GetDuration(key string, defaultValueInTimescaleUnits int64, tim
 
 // IsSet checks if config is set for a key
 func IsSet(key string) bool {
-	return c.IsSet(key)
+	return defaultConfig.IsSet(key)
 }
 
 // IsSet checks if config is set for a key
@@ -221,7 +221,7 @@ func (c *Config) IsSet(key string) bool {
 
 // Set override existing config
 func Set(key string, value interface{}) {
-	c.Set(key, value)
+	defaultConfig.Set(key, value)
 }
 
 // Set override existing config

--- a/config/config.go
+++ b/config/config.go
@@ -72,7 +72,7 @@ func GetBool(key string, defaultValue bool) (value bool) {
 func (c *Config) GetBool(key string, defaultValue bool) (value bool) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.viperIsSet(key) {
+	if !c.IsSet(key) {
 		return defaultValue
 	}
 	return c.v.GetBool(key)
@@ -87,7 +87,7 @@ func GetInt(key string, defaultValue int) (value int) {
 func (c *Config) GetInt(key string, defaultValue int) (value int) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.viperIsSet(key) {
+	if !c.IsSet(key) {
 		return defaultValue
 	}
 	return c.v.GetInt(key)
@@ -102,7 +102,7 @@ func MustGetInt(key string) (value int) {
 func (c *Config) MustGetInt(key string) (value int) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.viperIsSet(key) {
+	if !c.IsSet(key) {
 		panic(fmt.Errorf("config key %s not found", key))
 	}
 	return c.v.GetInt(key)
@@ -117,7 +117,7 @@ func GetInt64(key string, defaultValue int64) (value int64) {
 func (c *Config) GetInt64(key string, defaultValue int64) (value int64) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.viperIsSet(key) {
+	if !c.IsSet(key) {
 		return defaultValue
 	}
 	return c.v.GetInt64(key)
@@ -132,7 +132,7 @@ func GetFloat64(key string, defaultValue float64) (value float64) {
 func (c *Config) GetFloat64(key string, defaultValue float64) (value float64) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.viperIsSet(key) {
+	if !c.IsSet(key) {
 		return defaultValue
 	}
 	return c.v.GetFloat64(key)
@@ -147,7 +147,7 @@ func GetString(key, defaultValue string) (value string) {
 func (c *Config) GetString(key, defaultValue string) (value string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.viperIsSet(key) {
+	if !c.IsSet(key) {
 		return defaultValue
 	}
 	return c.v.GetString(key)
@@ -162,7 +162,7 @@ func MustGetString(key string) (value string) {
 func (c *Config) MustGetString(key string) (value string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.viperIsSet(key) {
+	if !c.IsSet(key) {
 		panic(fmt.Errorf("config key %s not found", key))
 	}
 	return c.v.GetString(key)
@@ -177,7 +177,7 @@ func GetStringSlice(key string, defaultValue []string) (value []string) {
 func (c *Config) GetStringSlice(key string, defaultValue []string) (value []string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.viperIsSet(key) {
+	if !c.IsSet(key) {
 		return defaultValue
 	}
 	return c.v.GetStringSlice(key)
@@ -192,7 +192,7 @@ func GetDuration(key string, defaultValueInTimescaleUnits int64, timeScale time.
 func (c *Config) GetDuration(key string, defaultValueInTimescaleUnits int64, timeScale time.Duration) (value time.Duration) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.viperIsSet(key) {
+	if !c.IsSet(key) {
 		return time.Duration(defaultValueInTimescaleUnits) * timeScale
 	} else {
 		v := c.v.GetString(key)
@@ -219,11 +219,6 @@ func IsSet(key string) bool {
 func (c *Config) IsSet(key string) bool {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	return c.viperIsSet(key)
-}
-
-// viperIsSet checks if config is set for a key without acquiring a lock
-func (c *Config) viperIsSet(key string) bool {
 	c.bindEnv(key)
 	return c.v.IsSet(key)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,675 +1,208 @@
+// Package config uses the exact same precedence order as Viper, where
+// each item takes precedence over the item below it:
+//
+//   - explicit call to Set (case insensitive)
+//   - flag (case insensitive)
+//   - env (case sensitive - see notes below)
+//   - config (case insensitive)
+//   - key/value store (case insensitive)
+//   - default (case insensitive)
+//
+// Environment variable resolution is performed based on the following rules:
+//   - If the key contains only uppercase characters, numbers and underscores, the environment variable is looked up in its entirety, e.g. SOME_VARIABLE -> SOME_VARIABLE
+//   - In all other cases, the environment variable is transformed before being looked up as following:
+//     1. camelCase is converted to snake_case, e.g. someVariable -> some_variable
+//     2. dots (.) are replaced with underscores (_), e.g. some.variable -> some_variable
+//     3. the resulting string is uppercased and prefixed with RSERVER_, e.g. some_variable -> RSERVER_SOME_VARIABLE
 package config
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/fsnotify/fsnotify"
-	"github.com/joho/godotenv"
-	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 )
 
-var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+// regular expression matching lowecase letter followed by an uppercase letter
+var camelCaseMatch = regexp.MustCompile("([a-z0-9])([A-Z])")
 
-var (
-	whSchemaVersion        string
-	hotReloadableConfig    map[string][]*ConfigVar
-	nonHotReloadableConfig map[string][]*ConfigVar
-	configVarLock          sync.RWMutex
-)
+// regular expression matching uppercase letters contained in environment variable names
+var upperCaseMatch = regexp.MustCompile("^[A-Z0-9_]+$")
 
-type ConfigVar struct {
-	value           interface{}
-	multiplier      interface{}
-	isHotReloadable bool
-	defaultValue    interface{}
-	keys            []string
+// default, singleton config instance
+var c *Config
+
+func init() {
+	c = New()
 }
 
-func newConfigVar(value, multiplier, defaultValue interface{}, isHotReloadable bool, keys []string) *ConfigVar {
-	return &ConfigVar{
-		value:           value,
-		multiplier:      multiplier,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValue,
-		keys:            keys,
-	}
+// Reset resets configuration
+func Reset() {
+	c = New()
 }
 
-func getConfigValue(configVar *ConfigVar) interface{} {
-	return configVar.value
+// New creates a new config instance
+func New() *Config {
+	c := &Config{}
+	c.load()
+	return c
 }
 
-// Rudder server supported config constants
-const (
-	EmbeddedMode      = "embedded"
-	MasterMode        = "master"
-	MasterSlaveMode   = "master_and_slave"
-	SlaveMode         = "slave"
-	OffMode           = "off"
-	PooledWHSlaveMode = "embedded_master"
-)
-
-// TransformKey as package method to get the formatted env from a give string
-func TransformKey(s string) string {
-	snake := matchAllCap.ReplaceAllString(s, "${1}_${2}")
-	snake = strings.ReplaceAll(snake, ".", "_")
-	return "RSERVER_" + strings.ToUpper(snake)
+// Config is the entry point for accessing configuration
+type Config struct {
+	vLock                  sync.RWMutex // protects reading and writing to the config (viper is not thread-safe)
+	v                      *viper.Viper
+	mapLock                sync.RWMutex // protects maps holding registered condig keys
+	hotReloadableConfig    map[string][]*configValue
+	nonHotReloadableConfig map[string][]*configValue
+	envLock                sync.RWMutex // protects the envs map below
+	envs                   map[string]string
 }
 
-func Load() {
-	if err := godotenv.Load(); err != nil {
-		fmt.Println("INFO: No .env file found.")
-	}
-	hotReloadableConfig = make(map[string][]*ConfigVar)
-	nonHotReloadableConfig = make(map[string][]*ConfigVar)
-	configPath := GetEnv("CONFIG_PATH", "./config/config.yaml")
-	viper.SetConfigFile(configPath)
-	err := viper.ReadInConfig() // Find and read the config file
-	UpdateConfig()
-	// Don't panic if config.yaml is not found or error with parsing. Use the default config values instead
-	if err != nil {
-		fmt.Println("[Config] :: Failed to parse Config Yaml, using default values:", err)
-	}
-}
-
-func UpdateConfig() {
-	viper.WatchConfig()
-	viper.OnConfigChange(func(e fsnotify.Event) {
-		watchForConfigChange()
-	})
-}
-
-func watchForConfigChange() {
-	defer func() {
-		if r := recover(); r != nil {
-			err := fmt.Errorf("cannot update Config Variables: %v", r)
-			fmt.Println(err)
-		}
-	}()
-	configVarLock.RLock()
-	defer configVarLock.RUnlock()
-	_ = checkAndHotReloadConfig(hotReloadableConfig)
-	isChanged := checkAndHotReloadConfig(nonHotReloadableConfig)
-	if isChanged && GetEnvAsBool("RESTART_ON_CONFIG_CHANGE", false) {
-		os.Exit(1)
-	}
-}
-
-func checkAndHotReloadConfig(configMap map[string][]*ConfigVar) (hasConfigChanged bool) {
-	for key, configValArr := range configMap {
-		for _, configVal := range configValArr {
-			value := configVal.value
-			switch value := value.(type) {
-			case *int:
-				var _value int
-				var isSet bool
-				for _, key := range configVal.keys {
-					envVal := GetEnv(TransformKey(key), "")
-					if envVal != "" {
-						isSet = true
-						_value = cast.ToInt(envVal)
-						break
-					}
-				}
-
-				if !isSet {
-					for _, key := range configVal.keys {
-						if viper.IsSet(key) {
-							isSet = true
-							_value = GetInt(key, configVal.defaultValue.(int))
-							break
-						}
-					}
-				}
-				if !isSet {
-					_value = configVal.defaultValue.(int)
-				}
-				_value = _value * configVal.multiplier.(int)
-				if _value != *value {
-					hasConfigChanged = true
-					if configVal.isHotReloadable {
-						fmt.Printf("The value of key:%s & variable:%p changed from %d to %d\n", key, configVal, *value, _value)
-						*value = _value
-					}
-				}
-			case *int64:
-				var _value int64
-				var isSet bool
-				for _, key := range configVal.keys {
-					envVal := GetEnv(TransformKey(key), "")
-					if envVal != "" {
-						isSet = true
-						_value = cast.ToInt64(envVal)
-						break
-					}
-				}
-				if !isSet {
-					for _, key := range configVal.keys {
-						if viper.IsSet(key) {
-							isSet = true
-							_value = GetInt64(key, configVal.defaultValue.(int64))
-							break
-						}
-					}
-				}
-				if !isSet {
-					_value = configVal.defaultValue.(int64)
-				}
-				_value = _value * configVal.multiplier.(int64)
-				if _value != *value {
-					hasConfigChanged = true
-					if configVal.isHotReloadable {
-						fmt.Printf("The value of key:%s & variable:%p changed from %d to %d\n", key, configVal, *value, _value)
-						*value = _value
-					}
-				}
-			case *string:
-				var _value string
-				var isSet bool
-				for _, key := range configVal.keys {
-					envVal := GetEnv(TransformKey(key), "")
-					if envVal != "" {
-						isSet = true
-						_value = cast.ToString(envVal)
-						break
-					}
-				}
-				if !isSet {
-					for _, key := range configVal.keys {
-						if viper.IsSet(key) {
-							isSet = true
-							_value = GetString(key, configVal.defaultValue.(string))
-							break
-						}
-					}
-				}
-				if !isSet {
-					_value = configVal.defaultValue.(string)
-				}
-				if _value != *value {
-					hasConfigChanged = true
-					if configVal.isHotReloadable {
-						fmt.Printf("The value of key:%s & variable:%p changed from %v to %v\n", key, configVal, *value, _value)
-						*value = _value
-					}
-				}
-			case *time.Duration:
-				var _value time.Duration
-				var isSet bool
-				for _, key := range configVal.keys {
-					envVal := GetEnv(TransformKey(key), "")
-					if envVal != "" {
-						isSet = true
-						_value = GetDuration(key, configVal.defaultValue.(int64), configVal.multiplier.(time.Duration))
-						break
-					}
-				}
-				if !isSet {
-					for _, key := range configVal.keys {
-						if viper.IsSet(key) {
-							isSet = true
-							_value = GetDuration(key, configVal.defaultValue.(int64), configVal.multiplier.(time.Duration))
-							break
-						}
-					}
-				}
-				if !isSet {
-					_value = time.Duration(configVal.defaultValue.(int64)) * configVal.multiplier.(time.Duration)
-				}
-				if _value != *value {
-					hasConfigChanged = true
-					if configVal.isHotReloadable {
-						fmt.Printf("The value of key:%s & variable:%p changed from %v to %v\n", key, configVal, *value, _value)
-						*value = _value
-					}
-				}
-			case *bool:
-				var _value bool
-				var isSet bool
-				for _, key := range configVal.keys {
-					envVal := GetEnv(TransformKey(key), "")
-					if envVal != "" {
-						isSet = true
-						_value = cast.ToBool(envVal)
-						break
-					}
-				}
-				if !isSet {
-					for _, key := range configVal.keys {
-						if viper.IsSet(key) {
-							isSet = true
-							_value = GetBool(key, configVal.defaultValue.(bool))
-							break
-						}
-					}
-				}
-				if !isSet {
-					_value = configVal.defaultValue.(bool)
-				}
-				if _value != *value {
-					hasConfigChanged = true
-					if configVal.isHotReloadable {
-						fmt.Printf("The value of key:%s & variable:%p changed from %v to %v\n", key, configVal, *value, _value)
-						*value = _value
-					}
-				}
-			case *float64:
-				var _value float64
-				var isSet bool
-				for _, key := range configVal.keys {
-					envVal := GetEnv(TransformKey(key), "")
-					if envVal != "" {
-						isSet = true
-						_value = cast.ToFloat64(envVal)
-						break
-					}
-				}
-				if !isSet {
-					for _, key := range configVal.keys {
-						if viper.IsSet(key) {
-							isSet = true
-							_value = GetFloat64(key, configVal.defaultValue.(float64))
-							break
-						}
-					}
-				}
-				if !isSet {
-					_value = configVal.defaultValue.(float64)
-				}
-				_value = _value * configVal.multiplier.(float64)
-				if _value != *value {
-					hasConfigChanged = true
-					if configVal.isHotReloadable {
-						fmt.Printf("The value of key:%s & variable:%p changed from %v to %v\n", key, configVal, *value, _value)
-						*value = _value
-					}
-				}
-			}
-		}
-	}
-	return hasConfigChanged
-}
-
-// GetBool is a wrapper for viper's GetBool
+// GetBool gets bool value from config
 func GetBool(key string, defaultValue bool) (value bool) {
-	envVal := GetEnv(TransformKey(key), "")
-	if envVal != "" {
-		return cast.ToBool(envVal)
-	}
-
-	if !viper.IsSet(key) {
-		return defaultValue
-	}
-	return viper.GetBool(key)
+	return c.GetBool(key, defaultValue)
 }
 
-// GetInt is wrapper for viper's GetInt
+// GetBool gets bool value from config
+func (c *Config) GetBool(key string, defaultValue bool) (value bool) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	if !c.isSet(key) {
+		return defaultValue
+	}
+	return c.v.GetBool(key)
+}
+
+// GetInt gets int value from config
 func GetInt(key string, defaultValue int) (value int) {
-	envVal := GetEnv(TransformKey(key), "")
-	if envVal != "" {
-		return cast.ToInt(envVal)
-	}
+	return c.GetInt(key, defaultValue)
+}
 
-	if !viper.IsSet(key) {
+// GetInt gets int value from config
+func (c *Config) GetInt(key string, defaultValue int) (value int) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	if !c.isSet(key) {
 		return defaultValue
 	}
-	return viper.GetInt(key)
+	return c.v.GetInt(key)
 }
 
-func appendVarToConfigMaps(isHotReloadable bool, key string, configVar *ConfigVar) {
-	if isHotReloadable {
-		if _, ok := hotReloadableConfig[key]; !ok {
-			hotReloadableConfig[key] = make([]*ConfigVar, 0)
-		}
-		hotReloadableConfig[key] = append(hotReloadableConfig[key], configVar)
-	} else {
-		if _, ok := nonHotReloadableConfig[key]; !ok {
-			nonHotReloadableConfig[key] = make([]*ConfigVar, 0)
-		}
-		nonHotReloadableConfig[key] = append(nonHotReloadableConfig[key], configVar)
-	}
+// MustGetInt gets int value from config or panics if the config doesn't exist
+func MustGetInt(key string) (value int) {
+	return c.MustGetInt(key)
 }
 
-func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, keys ...string) {
-	configVarLock.Lock()
-	defer configVarLock.Unlock()
-	var isSet bool
-	configVar := ConfigVar{
-		value:           ptr,
-		multiplier:      valueScale,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValue,
-		keys:            keys,
+// MustGetString gets int value from config or panics if the config doesn't exist
+func (c *Config) MustGetInt(key string) (value int) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	if !c.isSet(key) {
+		panic(fmt.Errorf("config key %s not found", key))
 	}
-
-	appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
-
-	for _, key := range keys {
-		if IsTransformedEnvSet(key) {
-			isSet = true
-			*ptr = GetInt(key, defaultValue) * valueScale
-			break
-		}
-	}
-	if !isSet {
-		for _, key := range keys {
-			if viper.IsSet(key) {
-				isSet = true
-				*ptr = GetInt(key, defaultValue) * valueScale
-				break
-			}
-		}
-	}
-
-	if !isSet {
-		*ptr = defaultValue * valueScale
-	}
+	return c.v.GetInt(key)
 }
 
-func RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, keys ...string) {
-	configVarLock.Lock()
-	defer configVarLock.Unlock()
-	var isSet bool
-	configVar := ConfigVar{
-		value:           ptr,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValue,
-		keys:            keys,
-	}
-
-	appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
-
-	for _, key := range keys {
-		if IsTransformedEnvSet(key) {
-			isSet = true
-			*ptr = GetBool(key, defaultValue)
-			break
-		}
-	}
-	if !isSet {
-		for _, key := range keys {
-			if viper.IsSet(key) {
-				isSet = true
-				*ptr = GetBool(key, defaultValue)
-				break
-			}
-		}
-	}
-
-	if !isSet {
-		*ptr = defaultValue
-	}
-}
-
-func RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotReloadable bool, keys ...string) {
-	configVarLock.Lock()
-	defer configVarLock.Unlock()
-	var isSet bool
-	configVar := ConfigVar{
-		value:           ptr,
-		multiplier:      1.0,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValue,
-		keys:            keys,
-	}
-
-	appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
-
-	for _, key := range keys {
-		if IsTransformedEnvSet(key) {
-			isSet = true
-			*ptr = GetFloat64(key, defaultValue)
-			break
-		}
-	}
-	if !isSet {
-		for _, key := range keys {
-			if viper.IsSet(key) {
-				isSet = true
-				*ptr = GetFloat64(key, defaultValue)
-				break
-			}
-		}
-	}
-
-	if !isSet {
-		*ptr = defaultValue
-	}
-}
-
-func RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, keys ...string) {
-	configVarLock.Lock()
-	defer configVarLock.Unlock()
-	var isSet bool
-	configVar := ConfigVar{
-		value:           ptr,
-		multiplier:      valueScale,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValue,
-		keys:            keys,
-	}
-
-	appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
-
-	for _, key := range keys {
-		if IsTransformedEnvSet(key) {
-			isSet = true
-			*ptr = GetInt64(key, defaultValue) * valueScale
-			break
-		}
-	}
-	if !isSet {
-		for _, key := range keys {
-			if viper.IsSet(key) {
-				isSet = true
-				*ptr = GetInt64(key, defaultValue) * valueScale
-				break
-			}
-		}
-	}
-
-	if !isSet {
-		*ptr = defaultValue * valueScale
-	}
-}
-
-func RegisterDurationConfigVariable(defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, keys ...string) {
-	configVarLock.Lock()
-	defer configVarLock.Unlock()
-	var isSet bool
-	configVar := ConfigVar{
-		value:           ptr,
-		multiplier:      timeScale,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValueInTimescaleUnits,
-		keys:            keys,
-	}
-
-	appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
-
-	for _, key := range keys {
-		if IsTransformedEnvSet(key) {
-			isSet = true
-			*ptr = GetDuration(key, defaultValueInTimescaleUnits, timeScale)
-			break
-		}
-	}
-
-	if !isSet {
-		for _, key := range keys {
-			if viper.IsSet(key) {
-				isSet = true
-				*ptr = GetDuration(key, defaultValueInTimescaleUnits, timeScale)
-				break
-			}
-		}
-	}
-
-	if !isSet {
-		*ptr = time.Duration(defaultValueInTimescaleUnits) * timeScale
-	}
-}
-
-func RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloadable bool, keys ...string) {
-	configVarLock.Lock()
-	defer configVarLock.Unlock()
-	var isSet bool
-	configVar := ConfigVar{
-		value:           ptr,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValue,
-		keys:            keys,
-	}
-
-	appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
-
-	for _, key := range keys {
-		if IsTransformedEnvSet(key) {
-			isSet = true
-			*ptr = GetString(key, defaultValue)
-			break
-		}
-	}
-	if !isSet {
-		for _, key := range keys {
-			if viper.IsSet(key) {
-				isSet = true
-				*ptr = GetString(key, defaultValue)
-				break
-			}
-		}
-	}
-
-	if !isSet {
-		*ptr = defaultValue
-	}
-}
-
-func RegisterStringSliceConfigVariable(defaultValue []string, ptr *[]string, isHotReloadable bool, keys ...string) {
-	configVarLock.Lock()
-	defer configVarLock.Unlock()
-	var isSet bool
-	configVar := ConfigVar{
-		value:           ptr,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValue,
-		keys:            keys,
-	}
-
-	appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
-
-	for _, key := range keys {
-		if IsTransformedEnvSet(key) {
-			isSet = true
-			*ptr = GetStringSlice(key, defaultValue)
-			break
-		}
-	}
-	if !isSet {
-		for _, key := range keys {
-			if viper.IsSet(key) {
-				isSet = true
-				*ptr = GetStringSlice(key, defaultValue)
-				break
-			}
-		}
-	}
-
-	if !isSet {
-		*ptr = defaultValue
-	}
-}
-
-// GetInt64 is wrapper for viper's GetInt
+// GetInt64 gets int64 value from config
 func GetInt64(key string, defaultValue int64) (value int64) {
-	envVal := GetEnv(TransformKey(key), "")
-	if envVal != "" {
-		return cast.ToInt64(envVal)
-	}
-
-	if !viper.IsSet(key) {
-		return defaultValue
-	}
-	return viper.GetInt64(key)
+	return c.GetInt64(key, defaultValue)
 }
 
-// GetFloat64 is wrapper for viper's GetFloat64
+// GetInt64 gets int64 value from config
+func (c *Config) GetInt64(key string, defaultValue int64) (value int64) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	if !c.isSet(key) {
+		return defaultValue
+	}
+	return c.v.GetInt64(key)
+}
+
+// GetFloat64 gets float64 value from config
 func GetFloat64(key string, defaultValue float64) (value float64) {
-	envVal := GetEnv(TransformKey(key), "")
-	if envVal != "" {
-		return cast.ToFloat64(envVal)
-	}
-
-	if !viper.IsSet(key) {
-		return defaultValue
-	}
-	return viper.GetFloat64(key)
+	return c.GetFloat64(key, defaultValue)
 }
 
-// GetString is wrapper for viper's GetString
+// GetFloat64 gets float64 value from config
+func (c *Config) GetFloat64(key string, defaultValue float64) (value float64) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	if !c.isSet(key) {
+		return defaultValue
+	}
+	return c.v.GetFloat64(key)
+}
+
+// GetString gets string value from config
 func GetString(key, defaultValue string) (value string) {
-	envVal := GetEnv(TransformKey(key), "")
-	if envVal != "" {
-		return envVal
-	}
-
-	if !viper.IsSet(key) {
-		return defaultValue
-	}
-	return viper.GetString(key)
+	return c.GetString(key, defaultValue)
 }
 
-// GetStringSlice is wrapper for viper's GetStringSlice
+// GetString gets string value from config
+func (c *Config) GetString(key, defaultValue string) (value string) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	if !c.isSet(key) {
+		return defaultValue
+	}
+	return c.v.GetString(key)
+}
+
+// MustGetString gets string value from config or panics if the config doesn't exist
+func MustGetString(key string) (value string) {
+	return c.MustGetString(key)
+}
+
+// MustGetString gets string value from config or panics if the config doesn't exist
+func (c *Config) MustGetString(key string) (value string) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	if !c.isSet(key) {
+		panic(fmt.Errorf("config key %s not found", key))
+	}
+	return c.v.GetString(key)
+}
+
+// GetStringSlice gets string slice value from config
 func GetStringSlice(key string, defaultValue []string) (value []string) {
-	envVal := GetEnv(TransformKey(key), "")
-
-	// parsing comma separated string from env and populating a slice
-	if envVal != "" {
-		envValList := strings.Split(envVal, ",")
-		for i, elem := range envValList {
-			envValList[i] = strings.ToLower(strings.Trim(elem, " "))
-		}
-		return envValList
-	}
-
-	if !viper.IsSet(key) {
-		return defaultValue
-	}
-	return viper.GetStringSlice(key)
+	return c.GetStringSlice(key, defaultValue)
 }
 
-// GetDuration is wrapper for viper's GetDuration
-func GetDuration(key string, defaultValueInTimescaleUnits int64, timeScale time.Duration) (value time.Duration) {
-	var envValue string
-	envVal := GetEnv(TransformKey(key), "")
-	if envVal != "" {
-		envValue = cast.ToString(envVal)
-		parseDuration, err := time.ParseDuration(envValue)
-		if err == nil {
-			return parseDuration
-		} else {
-			return cast.ToDuration(envVal) * timeScale
-		}
+// GetStringSlice gets string slice value from config
+func (c *Config) GetStringSlice(key string, defaultValue []string) (value []string) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	if !c.isSet(key) {
+		return defaultValue
 	}
+	return c.v.GetStringSlice(key)
+}
 
-	if !viper.IsSet(key) {
+// GetDuration gets duration value from config
+func GetDuration(key string, defaultValueInTimescaleUnits int64, timeScale time.Duration) (value time.Duration) {
+	return c.GetDuration(key, defaultValueInTimescaleUnits, timeScale)
+}
+
+// GetDuration gets duration value from config
+func (c *Config) GetDuration(key string, defaultValueInTimescaleUnits int64, timeScale time.Duration) (value time.Duration) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	if !c.isSet(key) {
 		return time.Duration(defaultValueInTimescaleUnits) * timeScale
 	} else {
-		envValue = viper.GetString(key)
-		parseDuration, err := time.ParseDuration(envValue)
+		v := c.v.GetString(key)
+		parseDuration, err := time.ParseDuration(v)
 		if err == nil {
 			return parseDuration
 		} else {
-			_, err = strconv.ParseFloat(envValue, 64)
+			_, err = strconv.ParseFloat(v, 64)
 			if err == nil {
-				return viper.GetDuration(key) * timeScale
+				return c.v.GetDuration(key) * timeScale
 			} else {
 				return time.Duration(defaultValueInTimescaleUnits) * timeScale
 			}
@@ -679,159 +212,77 @@ func GetDuration(key string, defaultValueInTimescaleUnits int64, timeScale time.
 
 // IsSet checks if config is set for a key
 func IsSet(key string) bool {
-	if _, exists := os.LookupEnv(TransformKey(key)); exists {
-		return true
-	}
-
-	return viper.IsSet(key)
+	return c.IsSet(key)
 }
 
-func IsTransformedEnvSet(key string) bool {
-	if _, exists := os.LookupEnv(TransformKey(key)); exists {
-		return true
-	}
-	return false
+// IsSet checks if config is set for a key
+func (c *Config) IsSet(key string) bool {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	return c.isSet(key)
 }
 
-// IsEnvSet checks if an environment variable is set
-func IsEnvSet(key string) bool {
-	_, exists := os.LookupEnv(key)
-	return exists
-}
-
-// GetEnv returns the environment value stored in key variable
-func GetEnv(key, defaultVal string) string {
-	if value, exists := os.LookupEnv(key); exists {
-		return value
-	}
-	return defaultVal
-}
-
-func MustGetEnv(key string) string {
-	if value, exists := os.LookupEnv(key); exists {
-		return value
-	}
-	panic(fmt.Sprintf("environment variable not found: %q", key))
-}
-
-// GetEnvAsInt returns the int value of environment value stored in the key variable
-// If not set, default value will be return. If set but unparsable, returns 0
-func GetEnvAsInt(key string, defaultVal int) int {
-	stringValue, exists := os.LookupEnv(key)
-	if !exists {
-		return defaultVal
-	}
-	if value, err := strconv.Atoi(stringValue); err == nil {
-		return value
-	}
-	return 0
-}
-
-// GetRequiredEnvAsInt returns the environment value stored in key variable as int, no default
-func GetRequiredEnvAsInt(key string) int {
-	stringValue, exists := os.LookupEnv(key)
-	if !exists {
-		panic(fmt.Errorf("fatal error, no required environment variable: %s", key))
-	}
-	if value, err := strconv.Atoi(stringValue); err == nil {
-		return value
-	}
-	panic(fmt.Sprintf("Unable to parse the value of %s env variable. Value : %s", key, stringValue))
-}
-
-// GetEnvAsBool returns the boolean environment value stored in key variable
-func GetEnvAsBool(name string, defaultVal bool) bool {
-	valueStr := GetEnv(name, "")
-	if value, err := strconv.ParseBool(valueStr); err == nil {
-		return value
-	}
-
-	return defaultVal
-}
-
-// GetRequiredEnv returns the environment value stored in key variable, no default
-func GetRequiredEnv(key string) string {
-	if value, exists := os.LookupEnv(key); exists {
-		return value
-	}
-	panic(fmt.Errorf("fatal error, no required environment variable: %s", key))
-}
-
-// GetEnvErr returns the value of environment variable, error if not exists
-func GetEnvErr(key string) (string, error) {
-	if value, exists := os.LookupEnv(key); exists {
-		return value, nil
-	}
-	return "", fmt.Errorf("missing required environment variable: %s", key)
+func (c *Config) isSet(key string) bool {
+	c.bindEnv(key)
+	return c.v.IsSet(key)
 }
 
 // Override Config by application or command line
 
-// SetBool override existing config
-func SetBool(key string, value bool) {
-	viper.Set(key, value)
+// Set override existing config
+func Set(key string, value interface{}) {
+	c.Set(key, value)
 }
 
-func SetString(key, value string) {
-	viper.Set(key, value)
+// Set override existing config
+func (c *Config) Set(key string, value interface{}) {
+	c.vLock.Lock()
+	c.v.Set(key, value)
+	c.vLock.Unlock()
+	c.onConfigChange()
 }
 
-func SetHotReloadablesForcefully(key string, value interface{}) {
-	viper.Set(key, value)
-	configVarLock.RLock()
-	defer configVarLock.RUnlock()
-	_ = checkAndHotReloadConfig(hotReloadableConfig)
-}
-
-// GetWorkspaceToken returns the workspace token provided in the environment variables
-// Env variable CONFIG_BACKEND_TOKEN is deprecating soon
-// WORKSPACE_TOKEN is newly introduced. This will override CONFIG_BACKEND_TOKEN
-func GetWorkspaceToken() string {
-	token := GetEnv("WORKSPACE_TOKEN", "")
-	if token != "" && token != "<your_token_here>" {
-		return token
+// bindEnv handles rudder server's unique snake case replacement by registering
+// the environment variables to viper, that would otherwise be ignored.
+// Viper uppercases keys before sending them to its EnvKeyReplacer, thus
+// the replacer cannot detect camelCase keys.
+func (c *Config) bindEnv(key string) {
+	envVar := key
+	if !upperCaseMatch.MatchString(key) {
+		envVar = ConfigKeyToEnvRudder(key)
 	}
-	return GetEnv("CONFIG_BACKEND_TOKEN", "")
-}
-
-func GetNamespaceIdentifier() string {
-	k8sNamespace := GetKubeNamespace()
-	if k8sNamespace != "" {
-		return k8sNamespace
+	// bind once
+	c.envLock.RLock()
+	if _, ok := c.envs[key]; !ok {
+		c.envLock.RUnlock()
+		c.envLock.Lock() // don't really care about race here, setting the same value
+		c.envs[strings.ToUpper(key)] = envVar
+		c.envLock.Unlock()
+	} else {
+		c.envLock.RUnlock()
 	}
-	return "none"
 }
 
-// GetKubeNamespace returns value stored in KUBE_NAMESPACE env var
-func GetKubeNamespace() string {
-	return GetEnv("KUBE_NAMESPACE", "")
+type envReplacer struct {
+	c *Config
 }
 
-func GetReleaseName() string {
-	return GetEnv("RELEASE_NAME", "")
-}
-
-func GetInstanceID() string {
-	instance := GetEnv("INSTANCE_ID", "")
-	if instance == "" {
-		return ""
+func (r *envReplacer) Replace(s string) string {
+	r.c.envLock.RLock()
+	defer r.c.envLock.RUnlock()
+	if v, ok := r.c.envs[s]; ok {
+		return v
 	}
-	instanceArr := strings.Split(instance, "-")
-	return instanceArr[len(instanceArr)-1]
+	return s // bound environment variables
 }
 
-func SetWHSchemaVersion(version string) {
-	whSchemaVersion = version
-}
-
-func GetWHSchemaVersion() string {
-	return whSchemaVersion
-}
-
-func GetVarCharMaxForRS() bool {
-	return GetBool("Warehouse.redshift.setVarCharMax", false)
-}
-
-func GetArraySupportForCH() bool {
-	return GetBool("Warehouse.clickhouse.enableArraySupport", false)
+// Fallback environment variables supported (historically) by rudder-server
+func bindLegacyEnv(v *viper.Viper) {
+	_ = v.BindEnv("DB.host", "JOBS_DB_HOST")
+	_ = v.BindEnv("DB.user", "JOBS_DB_USER")
+	_ = v.BindEnv("DB.name", "JOBS_DB_DB_NAME")
+	_ = v.BindEnv("DB.port", "JOBS_DB_PORT")
+	_ = v.BindEnv("DB.password", "JOBS_DB_PASSWORD")
+	_ = v.BindEnv("DB.sslMode", "JOBS_DB_SSL_MODE")
+	_ = v.BindEnv("SharedDB.dsn", "SHARED_DB_DSN")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -72,7 +72,7 @@ func GetBool(key string, defaultValue bool) (value bool) {
 func (c *Config) GetBool(key string, defaultValue bool) (value bool) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.isSet(key) {
+	if !c.viperIsSet(key) {
 		return defaultValue
 	}
 	return c.v.GetBool(key)
@@ -87,7 +87,7 @@ func GetInt(key string, defaultValue int) (value int) {
 func (c *Config) GetInt(key string, defaultValue int) (value int) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.isSet(key) {
+	if !c.viperIsSet(key) {
 		return defaultValue
 	}
 	return c.v.GetInt(key)
@@ -102,7 +102,7 @@ func MustGetInt(key string) (value int) {
 func (c *Config) MustGetInt(key string) (value int) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.isSet(key) {
+	if !c.viperIsSet(key) {
 		panic(fmt.Errorf("config key %s not found", key))
 	}
 	return c.v.GetInt(key)
@@ -117,7 +117,7 @@ func GetInt64(key string, defaultValue int64) (value int64) {
 func (c *Config) GetInt64(key string, defaultValue int64) (value int64) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.isSet(key) {
+	if !c.viperIsSet(key) {
 		return defaultValue
 	}
 	return c.v.GetInt64(key)
@@ -132,7 +132,7 @@ func GetFloat64(key string, defaultValue float64) (value float64) {
 func (c *Config) GetFloat64(key string, defaultValue float64) (value float64) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.isSet(key) {
+	if !c.viperIsSet(key) {
 		return defaultValue
 	}
 	return c.v.GetFloat64(key)
@@ -147,7 +147,7 @@ func GetString(key, defaultValue string) (value string) {
 func (c *Config) GetString(key, defaultValue string) (value string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.isSet(key) {
+	if !c.viperIsSet(key) {
 		return defaultValue
 	}
 	return c.v.GetString(key)
@@ -162,7 +162,7 @@ func MustGetString(key string) (value string) {
 func (c *Config) MustGetString(key string) (value string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.isSet(key) {
+	if !c.viperIsSet(key) {
 		panic(fmt.Errorf("config key %s not found", key))
 	}
 	return c.v.GetString(key)
@@ -177,7 +177,7 @@ func GetStringSlice(key string, defaultValue []string) (value []string) {
 func (c *Config) GetStringSlice(key string, defaultValue []string) (value []string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.isSet(key) {
+	if !c.viperIsSet(key) {
 		return defaultValue
 	}
 	return c.v.GetStringSlice(key)
@@ -192,7 +192,7 @@ func GetDuration(key string, defaultValueInTimescaleUnits int64, timeScale time.
 func (c *Config) GetDuration(key string, defaultValueInTimescaleUnits int64, timeScale time.Duration) (value time.Duration) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.isSet(key) {
+	if !c.viperIsSet(key) {
 		return time.Duration(defaultValueInTimescaleUnits) * timeScale
 	} else {
 		v := c.v.GetString(key)
@@ -219,10 +219,11 @@ func IsSet(key string) bool {
 func (c *Config) IsSet(key string) bool {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	return c.isSet(key)
+	return c.viperIsSet(key)
 }
 
-func (c *Config) isSet(key string) bool {
+// viperIsSet checks if config is set for a key without acquiring a lock
+func (c *Config) viperIsSet(key string) bool {
 	c.bindEnv(key)
 	return c.v.IsSet(key)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -48,14 +48,7 @@ func Test_MustGet(t *testing.T) {
 
 	tc.Set("int", 0)
 	require.Equal(t, 0, tc.MustGetInt("int"), "it should return the key value")
-	func() {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Errorf("The code did not panic")
-			}
-		}()
-		tc.MustGetInt("other")
-	}()
+	require.Panics(t, func() { tc.MustGetInt("other") })
 }
 
 func Test_Register_Existing_and_Default(t *testing.T) {
@@ -132,6 +125,15 @@ func TestStatic_checkAndHotReloadConfig(t *testing.T) {
 	varptr2 := configVar2.value.(*string)
 	require.Equal(t, *varptr1, "value_changed")
 	require.Equal(t, *varptr2, "value_changed")
+}
+
+func TestConfigKeyToEnv(t *testing.T) {
+	expected := "RSERVER_KEY_VAR1_VAR2"
+	require.Equal(t, expected, ConfigKeyToEnv("Key.Var1.Var2"))
+	require.Equal(t, expected, ConfigKeyToEnv("key.var1.var2"))
+	require.Equal(t, expected, ConfigKeyToEnv("KeyVar1Var2"))
+	require.Equal(t, expected, ConfigKeyToEnv("RSERVER_KEY_VAR1_VAR2"))
+	require.Equal(t, "KEY_VAR1_VAR2", ConfigKeyToEnv("KEY_VAR1_VAR2"))
 }
 
 func TestGetEnvThroughViper(t *testing.T) {
@@ -212,12 +214,6 @@ func Test_Set_CaseInsensitive(t *testing.T) {
 	tc := New()
 	tc.Set("sTrIng.One", "string")
 	require.Equal(t, "string", tc.GetString("String.one", "default"), "it should return the key value")
-}
-
-func Test_ConfigKeyToEnvRudder(t *testing.T) {
-	require.Equal(t, "RSERVER_KEYVAL", ConfigKeyToEnv("keyval"))
-	require.Equal(t, "RSERVER_KEY_VAL", ConfigKeyToEnv("keyVal"))
-	require.Equal(t, "RSERVER_KEY_VAL", ConfigKeyToEnv("Key.val"))
 }
 
 func Test_Misc(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,14 +44,7 @@ func Test_MustGet(t *testing.T) {
 	tc := New()
 	tc.Set("string", "string")
 	require.Equal(t, "string", tc.MustGetString("string"), "it should return the key value")
-	func() {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Errorf("The code did not panic")
-			}
-		}()
-		tc.MustGetString("other")
-	}()
+	require.Panics(t, func() { tc.MustGetString("other") })
 
 	tc.Set("int", 0)
 	require.Equal(t, 0, tc.MustGetInt("int"), "it should return the key value")
@@ -222,9 +215,9 @@ func Test_Set_CaseInsensitive(t *testing.T) {
 }
 
 func Test_ConfigKeyToEnvRudder(t *testing.T) {
-	require.Equal(t, "RSERVER_KEYVAL", ConfigKeyToEnvRudder("keyval"))
-	require.Equal(t, "RSERVER_KEY_VAL", ConfigKeyToEnvRudder("keyVal"))
-	require.Equal(t, "RSERVER_KEY_VAL", ConfigKeyToEnvRudder("Key.val"))
+	require.Equal(t, "RSERVER_KEYVAL", ConfigKeyToEnv("keyval"))
+	require.Equal(t, "RSERVER_KEY_VAL", ConfigKeyToEnv("keyVal"))
+	require.Equal(t, "RSERVER_KEY_VAL", ConfigKeyToEnv("Key.val"))
 }
 
 func Test_Misc(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -119,7 +119,7 @@ func TestStatic_checkAndHotReloadConfig(t *testing.T) {
 	configMap["keyVar"] = []*configValue{configVar1, configVar2}
 	t.Setenv("RSERVER_KEY_VAR", "value_changed")
 
-	c.checkAndHotReloadConfig(configMap)
+	defaultConfig.checkAndHotReloadConfig(configMap)
 
 	varptr1 := configVar1.value.(*string)
 	varptr2 := configVar2.value.(*string)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,25 +2,246 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
+func Test_Getters_Existing_and_Default(t *testing.T) {
+	tc := New()
+	tc.Set("string", "string")
+	require.Equal(t, "string", tc.GetString("string", "default"), "it should return the key value")
+	require.Equal(t, "default", tc.GetString("other", "default"), "it should return the default value")
+
+	tc.Set("bool", false)
+	require.Equal(t, false, tc.GetBool("bool", true), "it should return the key value")
+	require.Equal(t, true, tc.GetBool("other", true), "it should return the default value")
+
+	tc.Set("int", 0)
+	require.Equal(t, 0, tc.GetInt("int", 1), "it should return the key value")
+	require.Equal(t, 1, tc.GetInt("other", 1), "it should return the default value")
+	require.EqualValues(t, 0, tc.GetInt64("int", 1), "it should return the key value")
+	require.EqualValues(t, 1, tc.GetInt64("other", 1), "it should return the default value")
+
+	tc.Set("float", 0.0)
+	require.EqualValues(t, 0, tc.GetFloat64("float", 1), "it should return the key value")
+	require.EqualValues(t, 1, tc.GetFloat64("other", 1), "it should return the default value")
+
+	tc.Set("stringslice", []string{"string", "string"})
+	require.Equal(t, []string{"string", "string"}, tc.GetStringSlice("stringslice", []string{"default"}), "it should return the key value")
+	require.Equal(t, []string{"default"}, tc.GetStringSlice("other", []string{"default"}), "it should return the default value")
+
+	tc.Set("duration", "2ms")
+	require.Equal(t, 2*time.Millisecond, tc.GetDuration("duration", 1, time.Second), "it should return the key value")
+	require.Equal(t, time.Second, tc.GetDuration("other", 1, time.Second), "it should return the default value")
+
+	tc.Set("duration", "2")
+	require.Equal(t, 2*time.Second, tc.GetDuration("duration", 1, time.Second), "it should return the key value")
+	require.Equal(t, time.Second, tc.GetDuration("other", 1, time.Second), "it should return the default value")
+}
+
+func Test_MustGet(t *testing.T) {
+	tc := New()
+	tc.Set("string", "string")
+	require.Equal(t, "string", tc.MustGetString("string"), "it should return the key value")
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("The code did not panic")
+			}
+		}()
+		tc.MustGetString("other")
+	}()
+
+	tc.Set("int", 0)
+	require.Equal(t, 0, tc.MustGetInt("int"), "it should return the key value")
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("The code did not panic")
+			}
+		}()
+		tc.MustGetInt("other")
+	}()
+}
+
+func Test_Register_Existing_and_Default(t *testing.T) {
+	tc := New()
+	tc.Set("string", "string")
+	var stringValue string
+	var otherStringValue string
+	tc.RegisterStringConfigVariable("default", &stringValue, false, "string")
+	require.Equal(t, "string", stringValue, "it should return the key value")
+	tc.RegisterStringConfigVariable("default", &otherStringValue, false, "other")
+	require.Equal(t, "default", otherStringValue, "it should return the default value")
+
+	tc.Set("bool", false)
+	var boolValue bool
+	var otherBoolValue bool
+	tc.RegisterBoolConfigVariable(true, &boolValue, false, "bool")
+	require.Equal(t, false, boolValue, "it should return the key value")
+	tc.RegisterBoolConfigVariable(true, &otherBoolValue, false, "other")
+	require.Equal(t, true, otherBoolValue, "it should return the default value")
+
+	tc.Set("int", 0)
+	var intValue int
+	var otherIntValue int
+	var int64Value int64
+	var otherInt64Value int64
+	tc.RegisterIntConfigVariable(1, &intValue, false, 1, "int")
+	require.Equal(t, 0, intValue, "it should return the key value")
+	tc.RegisterIntConfigVariable(1, &otherIntValue, false, 1, "other")
+	require.Equal(t, 1, otherIntValue, "it should return the default value")
+	tc.RegisterInt64ConfigVariable(1, &int64Value, false, 1, "int")
+	require.EqualValues(t, 0, int64Value, "it should return the key value")
+	tc.RegisterInt64ConfigVariable(1, &otherInt64Value, false, 1, "other")
+	require.EqualValues(t, 1, otherInt64Value, "it should return the default value")
+
+	tc.Set("float", 0.0)
+	var floatValue float64
+	var otherFloatValue float64
+	tc.RegisterFloat64ConfigVariable(1, &floatValue, false, "float")
+	require.EqualValues(t, 0, floatValue, "it should return the key value")
+	tc.RegisterFloat64ConfigVariable(1, &otherFloatValue, false, "other")
+	require.EqualValues(t, 1, otherFloatValue, "it should return the default value")
+
+	tc.Set("stringslice", []string{"string", "string"})
+	var stringSliceValue []string
+	var otherStringSliceValue []string
+	tc.RegisterStringSliceConfigVariable([]string{"default"}, &stringSliceValue, false, "stringslice")
+	require.Equal(t, []string{"string", "string"}, stringSliceValue, "it should return the key value")
+	tc.RegisterStringSliceConfigVariable([]string{"default"}, &otherStringSliceValue, false, "other")
+	require.Equal(t, []string{"default"}, otherStringSliceValue, "it should return the default value")
+
+	tc.Set("duration", "2ms")
+	var durationValue time.Duration
+	var otherDurationValue time.Duration
+	tc.RegisterDurationConfigVariable(1, &durationValue, false, time.Second, "duration")
+	require.Equal(t, 2*time.Millisecond, durationValue, "it should return the key value")
+	tc.RegisterDurationConfigVariable(1, &otherDurationValue, false, time.Second, "other")
+	require.Equal(t, time.Second, otherDurationValue, "it should return the default value")
+}
+
 func TestStatic_checkAndHotReloadConfig(t *testing.T) {
-	configMap := make(map[string][]*ConfigVar)
+	configMap := make(map[string][]*configValue)
 
 	var var1 string
 	var var2 string
-	configVar1 := newConfigVar(&var1, 1, "var1", true, []string{"KEY_VAR"})
-	configVar2 := newConfigVar(&var2, 1, "var2", true, []string{"KEY_VAR"})
+	configVar1 := newConfigValue(&var1, 1, "var1", true, []string{"keyVar"})
+	configVar2 := newConfigValue(&var2, 1, "var2", true, []string{"keyVar"})
 
-	configMap["KEY_VAR"] = []*ConfigVar{configVar1, configVar2}
+	configMap["keyVar"] = []*configValue{configVar1, configVar2}
 	t.Setenv("RSERVER_KEY_VAR", "value_changed")
 
-	checkAndHotReloadConfig(configMap)
+	c.checkAndHotReloadConfig(configMap)
 
-	varptr1 := getConfigValue(configVar1).(*string)
-	varptr2 := getConfigValue(configVar2).(*string)
+	varptr1 := configVar1.value.(*string)
+	varptr2 := configVar2.value.(*string)
 	require.Equal(t, *varptr1, "value_changed")
 	require.Equal(t, *varptr2, "value_changed")
+}
+
+func TestGetEnvThroughViper(t *testing.T) {
+	expectedValue := "VALUE"
+
+	t.Run("detects dots", func(t *testing.T) {
+		t.Setenv("RSERVER_KEY_VAR1_VAR2", expectedValue)
+		tc := New()
+		require.Equal(t, expectedValue, tc.GetString("Key.Var1.Var2", ""))
+	})
+
+	t.Run("detects camelcase", func(t *testing.T) {
+		t.Setenv("RSERVER_KEY_VAR1_VAR2", expectedValue)
+		tc := New()
+		require.Equal(t, expectedValue, tc.GetString("KeyVar1Var2", ""))
+	})
+
+	t.Run("detects dots with camelcase", func(t *testing.T) {
+		t.Setenv("RSERVER_KEY_VAR1_VAR_VAR", expectedValue)
+		tc := New()
+		require.Equal(t, expectedValue, tc.GetString("Key.Var1VarVar", ""))
+	})
+
+	t.Run("detects uppercase env variables", func(t *testing.T) {
+		t.Setenv("SOMEENVVARIABLE", expectedValue)
+		tc := New()
+		require.Equal(t, expectedValue, tc.GetString("SOMEENVVARIABLE", ""))
+
+		t.Setenv("SOME_ENV_VARIABLE", expectedValue)
+		require.Equal(t, expectedValue, tc.GetString("SOME_ENV_VARIABLE", ""))
+
+		t.Setenv("SOME_ENV_VARIABLE12", expectedValue)
+		require.Equal(t, expectedValue, tc.GetString("SOME_ENV_VARIABLE12", ""))
+	})
+
+	t.Run("doesn't use viper's default env var matcher (uppercase)", func(t *testing.T) {
+		t.Setenv("KEYVAR1VARVAR", expectedValue)
+		tc := New()
+		require.Equal(t, "", tc.GetString("KeyVar1VarVar", ""))
+	})
+
+	t.Run("can retrieve legacy env", func(t *testing.T) {
+		t.Setenv("JOBS_DB_HOST", expectedValue)
+		tc := New()
+		require.Equal(t, expectedValue, tc.GetString("DB.host", ""))
+	})
+}
+
+func TestRegisterEnvThroughViper(t *testing.T) {
+	expectedValue := "VALUE"
+
+	t.Run("detects dots", func(t *testing.T) {
+		t.Setenv("RSERVER_KEY_VAR1_VAR2", expectedValue)
+		tc := New()
+		var v string
+		tc.RegisterStringConfigVariable("", &v, true, "Key.Var1.Var2")
+		require.Equal(t, expectedValue, v)
+	})
+
+	t.Run("detects camelcase", func(t *testing.T) {
+		t.Setenv("RSERVER_KEY_VAR_VAR", expectedValue)
+		tc := New()
+		var v string
+		tc.RegisterStringConfigVariable("", &v, true, "KeyVarVar")
+		require.Equal(t, expectedValue, v)
+	})
+
+	t.Run("detects dots with camelcase", func(t *testing.T) {
+		t.Setenv("RSERVER_KEY_VAR1_VAR_VAR", expectedValue)
+		tc := New()
+		var v string
+		tc.RegisterStringConfigVariable("", &v, true, "Key.Var1VarVar")
+		require.Equal(t, expectedValue, v)
+	})
+}
+
+func Test_Set_CaseInsensitive(t *testing.T) {
+	tc := New()
+	tc.Set("sTrIng.One", "string")
+	require.Equal(t, "string", tc.GetString("String.one", "default"), "it should return the key value")
+}
+
+func Test_ConfigKeyToEnvRudder(t *testing.T) {
+	require.Equal(t, "RSERVER_KEYVAL", ConfigKeyToEnvRudder("keyval"))
+	require.Equal(t, "RSERVER_KEY_VAL", ConfigKeyToEnvRudder("keyVal"))
+	require.Equal(t, "RSERVER_KEY_VAL", ConfigKeyToEnvRudder("Key.val"))
+}
+
+func Test_Misc(t *testing.T) {
+	t.Setenv("KUBE_NAMESPACE", "value")
+	require.Equal(t, "value", GetKubeNamespace())
+
+	t.Setenv("KUBE_NAMESPACE", "")
+	require.Equal(t, "none", GetNamespaceIdentifier())
+
+	t.Setenv("WORKSPACE_TOKEN", "value1")
+	t.Setenv("CONFIG_BACKEND_TOKEN", "value2")
+	require.Equal(t, "value1", GetWorkspaceToken())
+
+	t.Setenv("WORKSPACE_TOKEN", "")
+	t.Setenv("CONFIG_BACKEND_TOKEN", "value2")
+	require.Equal(t, "value2", GetWorkspaceToken())
+
+	t.Setenv("RELEASE_NAME", "value")
+	require.Equal(t, "value", GetReleaseName())
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -113,8 +113,8 @@ func TestStatic_checkAndHotReloadConfig(t *testing.T) {
 
 	var var1 string
 	var var2 string
-	configVar1 := newConfigValue(&var1, 1, "var1", true, []string{"keyVar"})
-	configVar2 := newConfigValue(&var2, 1, "var2", true, []string{"keyVar"})
+	configVar1 := newConfigValue(&var1, 1, "var1", []string{"keyVar"})
+	configVar2 := newConfigValue(&var2, 1, "var2", []string{"keyVar"})
 
 	configMap["keyVar"] = []*configValue{configVar1, configVar2}
 	t.Setenv("RSERVER_KEY_VAR", "value_changed")

--- a/config/env.go
+++ b/config/env.go
@@ -1,0 +1,35 @@
+package config
+
+// TODO: everything in this file should be either removed or unexported
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// ConfigKeyToEnvRudder as package method to get the formatted env from a given string
+func ConfigKeyToEnvRudder(s string) string {
+	if upperCaseMatch.MatchString(s) {
+		return s
+	}
+	snake := camelCaseMatch.ReplaceAllString(s, "${1}_${2}")
+	return "RSERVER_" + strings.ToUpper(strings.ReplaceAll(snake, ".", "_"))
+}
+
+// getEnv returns the environment value stored in key variable
+func getEnv(key, defaultVal string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultVal
+}
+
+// getEnvAsBool returns the boolean environment value stored in key variable
+func getEnvAsBool(name string, defaultVal bool) bool {
+	valueStr := getEnv(name, "")
+	if value, err := strconv.ParseBool(valueStr); err == nil {
+		return value
+	}
+
+	return defaultVal
+}

--- a/config/env.go
+++ b/config/env.go
@@ -3,7 +3,6 @@ package config
 // TODO: everything in this file should be either removed or unexported
 import (
 	"os"
-	"strconv"
 	"strings"
 )
 
@@ -21,15 +20,5 @@ func getEnv(key, defaultVal string) string {
 	if value, exists := os.LookupEnv(key); exists {
 		return value
 	}
-	return defaultVal
-}
-
-// getEnvAsBool returns the boolean environment value stored in key variable
-func getEnvAsBool(name string, defaultVal bool) bool {
-	valueStr := getEnv(name, "")
-	if value, err := strconv.ParseBool(valueStr); err == nil {
-		return value
-	}
-
 	return defaultVal
 }

--- a/config/env.go
+++ b/config/env.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 )
 
-// ConfigKeyToEnvRudder as package method to get the formatted env from a given string
-func ConfigKeyToEnvRudder(s string) string {
+// ConfigKeyToEnv gets the env variable name from a given config key
+func ConfigKeyToEnv(s string) string {
 	if upperCaseMatch.MatchString(s) {
 		return s
 	}

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -24,7 +24,7 @@ func (c *Config) RegisterIntConfigVariable(defaultValue int, ptr *int, isHotRelo
 	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
 
 	for _, key := range keys {
-		if c.isSet(key) {
+		if c.viperIsSet(key) {
 			*ptr = c.GetInt(key, defaultValue) * valueScale
 			return
 		}
@@ -54,7 +54,7 @@ func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotR
 
 	for _, key := range keys {
 		c.bindEnv(key)
-		if c.isSet(key) {
+		if c.viperIsSet(key) {
 			*ptr = c.GetBool(key, defaultValue)
 			return
 		}
@@ -85,7 +85,7 @@ func (c *Config) RegisterFloat64ConfigVariable(defaultValue float64, ptr *float6
 
 	for _, key := range keys {
 		c.bindEnv(key)
-		if c.isSet(key) {
+		if c.viperIsSet(key) {
 			*ptr = c.GetFloat64(key, defaultValue)
 			return
 		}
@@ -116,7 +116,7 @@ func (c *Config) RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isH
 
 	for _, key := range keys {
 		c.bindEnv(key)
-		if c.isSet(key) {
+		if c.viperIsSet(key) {
 			*ptr = c.GetInt64(key, defaultValue) * valueScale
 			return
 		}
@@ -146,7 +146,7 @@ func (c *Config) RegisterDurationConfigVariable(defaultValueInTimescaleUnits int
 	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
 
 	for _, key := range keys {
-		if c.isSet(key) {
+		if c.viperIsSet(key) {
 			*ptr = c.GetDuration(key, defaultValueInTimescaleUnits, timeScale)
 			return
 		}
@@ -175,7 +175,7 @@ func (c *Config) RegisterStringConfigVariable(defaultValue string, ptr *string, 
 	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
 
 	for _, key := range keys {
-		if c.isSet(key) {
+		if c.viperIsSet(key) {
 			*ptr = c.GetString(key, defaultValue)
 			return
 		}
@@ -204,7 +204,7 @@ func (c *Config) RegisterStringSliceConfigVariable(defaultValue []string, ptr *[
 	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
 
 	for _, key := range keys {
-		if c.isSet(key) {
+		if c.viperIsSet(key) {
 			*ptr = c.GetStringSlice(key, defaultValue)
 			return
 		}

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -24,7 +24,7 @@ func (c *Config) RegisterIntConfigVariable(defaultValue int, ptr *int, isHotRelo
 	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
 
 	for _, key := range keys {
-		if c.viperIsSet(key) {
+		if c.IsSet(key) {
 			*ptr = c.GetInt(key, defaultValue) * valueScale
 			return
 		}
@@ -54,7 +54,7 @@ func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotR
 
 	for _, key := range keys {
 		c.bindEnv(key)
-		if c.viperIsSet(key) {
+		if c.IsSet(key) {
 			*ptr = c.GetBool(key, defaultValue)
 			return
 		}
@@ -85,7 +85,7 @@ func (c *Config) RegisterFloat64ConfigVariable(defaultValue float64, ptr *float6
 
 	for _, key := range keys {
 		c.bindEnv(key)
-		if c.viperIsSet(key) {
+		if c.IsSet(key) {
 			*ptr = c.GetFloat64(key, defaultValue)
 			return
 		}
@@ -116,7 +116,7 @@ func (c *Config) RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isH
 
 	for _, key := range keys {
 		c.bindEnv(key)
-		if c.viperIsSet(key) {
+		if c.IsSet(key) {
 			*ptr = c.GetInt64(key, defaultValue) * valueScale
 			return
 		}
@@ -146,7 +146,7 @@ func (c *Config) RegisterDurationConfigVariable(defaultValueInTimescaleUnits int
 	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
 
 	for _, key := range keys {
-		if c.viperIsSet(key) {
+		if c.IsSet(key) {
 			*ptr = c.GetDuration(key, defaultValueInTimescaleUnits, timeScale)
 			return
 		}
@@ -175,7 +175,7 @@ func (c *Config) RegisterStringConfigVariable(defaultValue string, ptr *string, 
 	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
 
 	for _, key := range keys {
-		if c.viperIsSet(key) {
+		if c.IsSet(key) {
 			*ptr = c.GetString(key, defaultValue)
 			return
 		}
@@ -204,7 +204,7 @@ func (c *Config) RegisterStringSliceConfigVariable(defaultValue []string, ptr *[
 	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
 
 	for _, key := range keys {
-		if c.viperIsSet(key) {
+		if c.IsSet(key) {
 			*ptr = c.GetStringSlice(key, defaultValue)
 			return
 		}

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -11,17 +11,18 @@ func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool,
 func (c *Config) RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, keys ...string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	c.mapLock.Lock()
-	defer c.mapLock.Unlock()
+	c.hotReloadableConfigLock.Lock()
+	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
-		value:           ptr,
-		multiplier:      valueScale,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValue,
-		keys:            keys,
+		value:        ptr,
+		multiplier:   valueScale,
+		defaultValue: defaultValue,
+		keys:         keys,
 	}
 
-	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+	if isHotReloadable {
+		c.appendVarToConfigMaps(keys[0], &configVar)
+	}
 
 	for _, key := range keys {
 		if c.IsSet(key) {
@@ -41,16 +42,17 @@ func RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bo
 func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, keys ...string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	c.mapLock.Lock()
-	defer c.mapLock.Unlock()
+	c.hotReloadableConfigLock.Lock()
+	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
-		value:           ptr,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValue,
-		keys:            keys,
+		value:        ptr,
+		defaultValue: defaultValue,
+		keys:         keys,
 	}
 
-	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+	if isHotReloadable {
+		c.appendVarToConfigMaps(keys[0], &configVar)
+	}
 
 	for _, key := range keys {
 		c.bindEnv(key)
@@ -71,17 +73,18 @@ func RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotRelo
 func (c *Config) RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotReloadable bool, keys ...string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	c.mapLock.Lock()
-	defer c.mapLock.Unlock()
+	c.hotReloadableConfigLock.Lock()
+	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
-		value:           ptr,
-		multiplier:      1.0,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValue,
-		keys:            keys,
+		value:        ptr,
+		multiplier:   1.0,
+		defaultValue: defaultValue,
+		keys:         keys,
 	}
 
-	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+	if isHotReloadable {
+		c.appendVarToConfigMaps(keys[0], &configVar)
+	}
 
 	for _, key := range keys {
 		c.bindEnv(key)
@@ -102,17 +105,18 @@ func RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable
 func (c *Config) RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, keys ...string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	c.mapLock.Lock()
-	defer c.mapLock.Unlock()
+	c.hotReloadableConfigLock.Lock()
+	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
-		value:           ptr,
-		multiplier:      valueScale,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValue,
-		keys:            keys,
+		value:        ptr,
+		multiplier:   valueScale,
+		defaultValue: defaultValue,
+		keys:         keys,
 	}
 
-	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+	if isHotReloadable {
+		c.appendVarToConfigMaps(keys[0], &configVar)
+	}
 
 	for _, key := range keys {
 		c.bindEnv(key)
@@ -133,17 +137,18 @@ func RegisterDurationConfigVariable(defaultValueInTimescaleUnits int64, ptr *tim
 func (c *Config) RegisterDurationConfigVariable(defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, keys ...string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	c.mapLock.Lock()
-	defer c.mapLock.Unlock()
+	c.hotReloadableConfigLock.Lock()
+	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
-		value:           ptr,
-		multiplier:      timeScale,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValueInTimescaleUnits,
-		keys:            keys,
+		value:        ptr,
+		multiplier:   timeScale,
+		defaultValue: defaultValueInTimescaleUnits,
+		keys:         keys,
 	}
 
-	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+	if isHotReloadable {
+		c.appendVarToConfigMaps(keys[0], &configVar)
+	}
 
 	for _, key := range keys {
 		if c.IsSet(key) {
@@ -163,16 +168,17 @@ func RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloada
 func (c *Config) RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloadable bool, keys ...string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	c.mapLock.Lock()
-	defer c.mapLock.Unlock()
+	c.hotReloadableConfigLock.Lock()
+	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
-		value:           ptr,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValue,
-		keys:            keys,
+		value:        ptr,
+		defaultValue: defaultValue,
+		keys:         keys,
 	}
 
-	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+	if isHotReloadable {
+		c.appendVarToConfigMaps(keys[0], &configVar)
+	}
 
 	for _, key := range keys {
 		if c.IsSet(key) {
@@ -192,16 +198,17 @@ func RegisterStringSliceConfigVariable(defaultValue []string, ptr *[]string, isH
 func (c *Config) RegisterStringSliceConfigVariable(defaultValue []string, ptr *[]string, isHotReloadable bool, keys ...string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	c.mapLock.Lock()
-	defer c.mapLock.Unlock()
+	c.hotReloadableConfigLock.Lock()
+	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
-		value:           ptr,
-		isHotReloadable: isHotReloadable,
-		defaultValue:    defaultValue,
-		keys:            keys,
+		value:        ptr,
+		defaultValue: defaultValue,
+		keys:         keys,
 	}
 
-	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+	if isHotReloadable {
+		c.appendVarToConfigMaps(keys[0], &configVar)
+	}
 
 	for _, key := range keys {
 		if c.IsSet(key) {
@@ -212,16 +219,9 @@ func (c *Config) RegisterStringSliceConfigVariable(defaultValue []string, ptr *[
 	*ptr = defaultValue
 }
 
-func (c *Config) appendVarToConfigMaps(isHotReloadable bool, key string, configVar *configValue) {
-	if isHotReloadable {
-		if _, ok := c.hotReloadableConfig[key]; !ok {
-			c.hotReloadableConfig[key] = make([]*configValue, 0)
-		}
-		c.hotReloadableConfig[key] = append(c.hotReloadableConfig[key], configVar)
-	} else {
-		if _, ok := c.nonHotReloadableConfig[key]; !ok {
-			c.nonHotReloadableConfig[key] = make([]*configValue, 0)
-		}
-		c.nonHotReloadableConfig[key] = append(c.nonHotReloadableConfig[key], configVar)
+func (c *Config) appendVarToConfigMaps(key string, configVar *configValue) {
+	if _, ok := c.hotReloadableConfig[key]; !ok {
+		c.hotReloadableConfig[key] = make([]*configValue, 0)
 	}
+	c.hotReloadableConfig[key] = append(c.hotReloadableConfig[key], configVar)
 }

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -4,7 +4,7 @@ import "time"
 
 // RegisterIntConfigVariable registers int config variable
 func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, keys ...string) {
-	c.RegisterIntConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, keys...)
+	defaultConfig.RegisterIntConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, keys...)
 }
 
 // RegisterIntConfigVariable registers int config variable
@@ -35,7 +35,7 @@ func (c *Config) RegisterIntConfigVariable(defaultValue int, ptr *int, isHotRelo
 
 // RegisterBoolConfigVariable registers bool config variable
 func RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, keys ...string) {
-	c.RegisterBoolConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
+	defaultConfig.RegisterBoolConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
 }
 
 // RegisterBoolConfigVariable registers bool config variable
@@ -66,7 +66,7 @@ func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotR
 
 // RegisterFloat64ConfigVariable registers float64 config variable
 func RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotReloadable bool, keys ...string) {
-	c.RegisterFloat64ConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
+	defaultConfig.RegisterFloat64ConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
 }
 
 // RegisterFloat64ConfigVariable registers float64 config variable
@@ -98,7 +98,7 @@ func (c *Config) RegisterFloat64ConfigVariable(defaultValue float64, ptr *float6
 
 // RegisterInt64ConfigVariable registers int64 config variable
 func RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, keys ...string) {
-	c.RegisterInt64ConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, keys...)
+	defaultConfig.RegisterInt64ConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, keys...)
 }
 
 // RegisterInt64ConfigVariable registers int64 config variable
@@ -130,7 +130,7 @@ func (c *Config) RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isH
 
 // RegisterDurationConfigVariable registers duration config variable
 func RegisterDurationConfigVariable(defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, keys ...string) {
-	c.RegisterDurationConfigVariable(defaultValueInTimescaleUnits, ptr, isHotReloadable, timeScale, keys...)
+	defaultConfig.RegisterDurationConfigVariable(defaultValueInTimescaleUnits, ptr, isHotReloadable, timeScale, keys...)
 }
 
 // RegisterDurationConfigVariable registers duration config variable
@@ -161,7 +161,7 @@ func (c *Config) RegisterDurationConfigVariable(defaultValueInTimescaleUnits int
 
 // RegisterStringConfigVariable registers string config variable
 func RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloadable bool, keys ...string) {
-	c.RegisterStringConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
+	defaultConfig.RegisterStringConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
 }
 
 // RegisterStringConfigVariable registers string config variable
@@ -191,7 +191,7 @@ func (c *Config) RegisterStringConfigVariable(defaultValue string, ptr *string, 
 
 // RegisterStringSliceConfigVariable registers string slice config variable
 func RegisterStringSliceConfigVariable(defaultValue []string, ptr *[]string, isHotReloadable bool, keys ...string) {
-	c.RegisterStringSliceConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
+	defaultConfig.RegisterStringSliceConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
 }
 
 // RegisterStringSliceConfigVariable registers string slice config variable

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -1,0 +1,227 @@
+package config
+
+import "time"
+
+// RegisterIntConfigVariable registers int config variable
+func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, keys ...string) {
+	c.RegisterIntConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, keys...)
+}
+
+// RegisterIntConfigVariable registers int config variable
+func (c *Config) RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, keys ...string) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	c.mapLock.Lock()
+	defer c.mapLock.Unlock()
+	configVar := configValue{
+		value:           ptr,
+		multiplier:      valueScale,
+		isHotReloadable: isHotReloadable,
+		defaultValue:    defaultValue,
+		keys:            keys,
+	}
+
+	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+
+	for _, key := range keys {
+		if c.isSet(key) {
+			*ptr = c.GetInt(key, defaultValue) * valueScale
+			return
+		}
+	}
+	*ptr = defaultValue * valueScale
+}
+
+// RegisterBoolConfigVariable registers bool config variable
+func RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, keys ...string) {
+	c.RegisterBoolConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
+}
+
+// RegisterBoolConfigVariable registers bool config variable
+func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, keys ...string) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	c.mapLock.Lock()
+	defer c.mapLock.Unlock()
+	configVar := configValue{
+		value:           ptr,
+		isHotReloadable: isHotReloadable,
+		defaultValue:    defaultValue,
+		keys:            keys,
+	}
+
+	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+
+	for _, key := range keys {
+		c.bindEnv(key)
+		if c.isSet(key) {
+			*ptr = c.GetBool(key, defaultValue)
+			return
+		}
+	}
+	*ptr = defaultValue
+}
+
+// RegisterFloat64ConfigVariable registers float64 config variable
+func RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotReloadable bool, keys ...string) {
+	c.RegisterFloat64ConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
+}
+
+// RegisterFloat64ConfigVariable registers float64 config variable
+func (c *Config) RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotReloadable bool, keys ...string) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	c.mapLock.Lock()
+	defer c.mapLock.Unlock()
+	configVar := configValue{
+		value:           ptr,
+		multiplier:      1.0,
+		isHotReloadable: isHotReloadable,
+		defaultValue:    defaultValue,
+		keys:            keys,
+	}
+
+	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+
+	for _, key := range keys {
+		c.bindEnv(key)
+		if c.isSet(key) {
+			*ptr = c.GetFloat64(key, defaultValue)
+			return
+		}
+	}
+	*ptr = defaultValue
+}
+
+// RegisterInt64ConfigVariable registers int64 config variable
+func RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, keys ...string) {
+	c.RegisterInt64ConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, keys...)
+}
+
+// RegisterInt64ConfigVariable registers int64 config variable
+func (c *Config) RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, keys ...string) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	c.mapLock.Lock()
+	defer c.mapLock.Unlock()
+	configVar := configValue{
+		value:           ptr,
+		multiplier:      valueScale,
+		isHotReloadable: isHotReloadable,
+		defaultValue:    defaultValue,
+		keys:            keys,
+	}
+
+	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+
+	for _, key := range keys {
+		c.bindEnv(key)
+		if c.isSet(key) {
+			*ptr = c.GetInt64(key, defaultValue) * valueScale
+			return
+		}
+	}
+	*ptr = defaultValue * valueScale
+}
+
+// RegisterDurationConfigVariable registers duration config variable
+func RegisterDurationConfigVariable(defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, keys ...string) {
+	c.RegisterDurationConfigVariable(defaultValueInTimescaleUnits, ptr, isHotReloadable, timeScale, keys...)
+}
+
+// RegisterDurationConfigVariable registers duration config variable
+func (c *Config) RegisterDurationConfigVariable(defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, keys ...string) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	c.mapLock.Lock()
+	defer c.mapLock.Unlock()
+	configVar := configValue{
+		value:           ptr,
+		multiplier:      timeScale,
+		isHotReloadable: isHotReloadable,
+		defaultValue:    defaultValueInTimescaleUnits,
+		keys:            keys,
+	}
+
+	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+
+	for _, key := range keys {
+		if c.isSet(key) {
+			*ptr = c.GetDuration(key, defaultValueInTimescaleUnits, timeScale)
+			return
+		}
+	}
+	*ptr = time.Duration(defaultValueInTimescaleUnits) * timeScale
+}
+
+// RegisterStringConfigVariable registers string config variable
+func RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloadable bool, keys ...string) {
+	c.RegisterStringConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
+}
+
+// RegisterStringConfigVariable registers string config variable
+func (c *Config) RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloadable bool, keys ...string) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	c.mapLock.Lock()
+	defer c.mapLock.Unlock()
+	configVar := configValue{
+		value:           ptr,
+		isHotReloadable: isHotReloadable,
+		defaultValue:    defaultValue,
+		keys:            keys,
+	}
+
+	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+
+	for _, key := range keys {
+		if c.isSet(key) {
+			*ptr = c.GetString(key, defaultValue)
+			return
+		}
+	}
+	*ptr = defaultValue
+}
+
+// RegisterStringSliceConfigVariable registers string slice config variable
+func RegisterStringSliceConfigVariable(defaultValue []string, ptr *[]string, isHotReloadable bool, keys ...string) {
+	c.RegisterStringSliceConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
+}
+
+// RegisterStringSliceConfigVariable registers string slice config variable
+func (c *Config) RegisterStringSliceConfigVariable(defaultValue []string, ptr *[]string, isHotReloadable bool, keys ...string) {
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	c.mapLock.Lock()
+	defer c.mapLock.Unlock()
+	configVar := configValue{
+		value:           ptr,
+		isHotReloadable: isHotReloadable,
+		defaultValue:    defaultValue,
+		keys:            keys,
+	}
+
+	c.appendVarToConfigMaps(isHotReloadable, keys[0], &configVar)
+
+	for _, key := range keys {
+		if c.isSet(key) {
+			*ptr = c.GetStringSlice(key, defaultValue)
+			return
+		}
+	}
+	*ptr = defaultValue
+}
+
+func (c *Config) appendVarToConfigMaps(isHotReloadable bool, key string, configVar *configValue) {
+	if isHotReloadable {
+		if _, ok := c.hotReloadableConfig[key]; !ok {
+			c.hotReloadableConfig[key] = make([]*configValue, 0)
+		}
+		c.hotReloadableConfig[key] = append(c.hotReloadableConfig[key], configVar)
+	} else {
+		if _, ok := c.nonHotReloadableConfig[key]; !ok {
+			c.nonHotReloadableConfig[key] = make([]*configValue, 0)
+		}
+		c.nonHotReloadableConfig[key] = append(c.nonHotReloadableConfig[key], configVar)
+	}
+}

--- a/config/load.go
+++ b/config/load.go
@@ -66,7 +66,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) (h
 				var _value int
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.viperIsSet(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetInt(key, configVal.defaultValue.(int))
 						break
@@ -87,7 +87,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) (h
 				var _value int64
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.viperIsSet(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetInt64(key, configVal.defaultValue.(int64))
 						break
@@ -108,7 +108,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) (h
 				var _value string
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.viperIsSet(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetString(key, configVal.defaultValue.(string))
 						break
@@ -128,7 +128,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) (h
 				var _value time.Duration
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.viperIsSet(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetDuration(key, configVal.defaultValue.(int64), configVal.multiplier.(time.Duration))
 						break
@@ -148,7 +148,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) (h
 				var _value bool
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.viperIsSet(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetBool(key, configVal.defaultValue.(bool))
 						break
@@ -168,7 +168,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) (h
 				var _value float64
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.viperIsSet(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetFloat64(key, configVal.defaultValue.(float64))
 						break

--- a/config/load.go
+++ b/config/load.go
@@ -66,7 +66,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) (h
 				var _value int
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSet(key) {
+					if c.viperIsSet(key) {
 						isSet = true
 						_value = c.GetInt(key, configVal.defaultValue.(int))
 						break
@@ -87,7 +87,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) (h
 				var _value int64
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSet(key) {
+					if c.viperIsSet(key) {
 						isSet = true
 						_value = c.GetInt64(key, configVal.defaultValue.(int64))
 						break
@@ -108,7 +108,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) (h
 				var _value string
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSet(key) {
+					if c.viperIsSet(key) {
 						isSet = true
 						_value = c.GetString(key, configVal.defaultValue.(string))
 						break
@@ -128,7 +128,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) (h
 				var _value time.Duration
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSet(key) {
+					if c.viperIsSet(key) {
 						isSet = true
 						_value = c.GetDuration(key, configVal.defaultValue.(int64), configVal.multiplier.(time.Duration))
 						break
@@ -148,7 +148,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) (h
 				var _value bool
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSet(key) {
+					if c.viperIsSet(key) {
 						isSet = true
 						_value = c.GetBool(key, configVal.defaultValue.(bool))
 						break
@@ -168,7 +168,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) (h
 				var _value float64
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSet(key) {
+					if c.viperIsSet(key) {
 						isSet = true
 						_value = c.GetFloat64(key, configVal.defaultValue.(float64))
 						break

--- a/config/load.go
+++ b/config/load.go
@@ -1,0 +1,210 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/joho/godotenv"
+	"github.com/spf13/viper"
+)
+
+func (c *Config) load() {
+	c.hotReloadableConfig = make(map[string][]*configValue)
+	c.nonHotReloadableConfig = make(map[string][]*configValue)
+	c.envs = make(map[string]string)
+
+	if err := godotenv.Load(); err != nil {
+		fmt.Println("INFO: No .env file found.")
+	}
+
+	configPath := getEnv("CONFIG_PATH", "./config/config.yaml")
+
+	v := viper.NewWithOptions(viper.EnvKeyReplacer(&envReplacer{c: c}))
+	v.AutomaticEnv()
+	bindLegacyEnv(v)
+
+	v.SetConfigFile(configPath)
+	err := v.ReadInConfig() // Find and read the config file
+	// Don't panic if config.yaml is not found or error with parsing. Use the default config values instead
+	if err != nil {
+		fmt.Printf("[Config] :: Failed to parse config file from path %q, using default values: %v\n", configPath, err)
+	}
+	v.OnConfigChange(func(e fsnotify.Event) {
+		c.onConfigChange()
+	})
+	v.WatchConfig()
+
+	c.v = v
+}
+
+func (c *Config) onConfigChange() {
+	defer func() {
+		if r := recover(); r != nil {
+			err := fmt.Errorf("cannot update Config Variables: %v", r)
+			fmt.Println(err)
+		}
+	}()
+	c.vLock.RLock()
+	defer c.vLock.RUnlock()
+	c.mapLock.RLock()
+	defer c.mapLock.RUnlock()
+	_ = c.checkAndHotReloadConfig(c.hotReloadableConfig)
+	isChanged := c.checkAndHotReloadConfig(c.nonHotReloadableConfig)
+	if isChanged && getEnvAsBool("RESTART_ON_CONFIG_CHANGE", false) {
+		os.Exit(1)
+	}
+}
+
+func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) (hasConfigChanged bool) {
+	for key, configValArr := range configMap {
+		for _, configVal := range configValArr {
+			value := configVal.value
+			switch value := value.(type) {
+			case *int:
+				var _value int
+				var isSet bool
+				for _, key := range configVal.keys {
+					if c.isSet(key) {
+						isSet = true
+						_value = c.GetInt(key, configVal.defaultValue.(int))
+						break
+					}
+				}
+				if !isSet {
+					_value = configVal.defaultValue.(int)
+				}
+				_value = _value * configVal.multiplier.(int)
+				if _value != *value {
+					hasConfigChanged = true
+					if configVal.isHotReloadable {
+						fmt.Printf("The value of key:%s & variable:%p changed from %d to %d\n", key, configVal, *value, _value)
+						*value = _value
+					}
+				}
+			case *int64:
+				var _value int64
+				var isSet bool
+				for _, key := range configVal.keys {
+					if c.isSet(key) {
+						isSet = true
+						_value = c.GetInt64(key, configVal.defaultValue.(int64))
+						break
+					}
+				}
+				if !isSet {
+					_value = configVal.defaultValue.(int64)
+				}
+				_value = _value * configVal.multiplier.(int64)
+				if _value != *value {
+					hasConfigChanged = true
+					if configVal.isHotReloadable {
+						fmt.Printf("The value of key:%s & variable:%p changed from %d to %d\n", key, configVal, *value, _value)
+						*value = _value
+					}
+				}
+			case *string:
+				var _value string
+				var isSet bool
+				for _, key := range configVal.keys {
+					if c.isSet(key) {
+						isSet = true
+						_value = c.GetString(key, configVal.defaultValue.(string))
+						break
+					}
+				}
+				if !isSet {
+					_value = configVal.defaultValue.(string)
+				}
+				if _value != *value {
+					hasConfigChanged = true
+					if configVal.isHotReloadable {
+						fmt.Printf("The value of key:%s & variable:%p changed from %v to %v\n", key, configVal, *value, _value)
+						*value = _value
+					}
+				}
+			case *time.Duration:
+				var _value time.Duration
+				var isSet bool
+				for _, key := range configVal.keys {
+					if c.isSet(key) {
+						isSet = true
+						_value = c.GetDuration(key, configVal.defaultValue.(int64), configVal.multiplier.(time.Duration))
+						break
+					}
+				}
+				if !isSet {
+					_value = time.Duration(configVal.defaultValue.(int64)) * configVal.multiplier.(time.Duration)
+				}
+				if _value != *value {
+					hasConfigChanged = true
+					if configVal.isHotReloadable {
+						fmt.Printf("The value of key:%s & variable:%p changed from %v to %v\n", key, configVal, *value, _value)
+						*value = _value
+					}
+				}
+			case *bool:
+				var _value bool
+				var isSet bool
+				for _, key := range configVal.keys {
+					if c.isSet(key) {
+						isSet = true
+						_value = c.GetBool(key, configVal.defaultValue.(bool))
+						break
+					}
+				}
+				if !isSet {
+					_value = configVal.defaultValue.(bool)
+				}
+				if _value != *value {
+					hasConfigChanged = true
+					if configVal.isHotReloadable {
+						fmt.Printf("The value of key:%s & variable:%p changed from %v to %v\n", key, configVal, *value, _value)
+						*value = _value
+					}
+				}
+			case *float64:
+				var _value float64
+				var isSet bool
+				for _, key := range configVal.keys {
+					if c.isSet(key) {
+						isSet = true
+						_value = c.GetFloat64(key, configVal.defaultValue.(float64))
+						break
+					}
+				}
+				if !isSet {
+					_value = configVal.defaultValue.(float64)
+				}
+				_value = _value * configVal.multiplier.(float64)
+				if _value != *value {
+					hasConfigChanged = true
+					if configVal.isHotReloadable {
+						fmt.Printf("The value of key:%s & variable:%p changed from %v to %v\n", key, configVal, *value, _value)
+						*value = _value
+					}
+				}
+			}
+		}
+	}
+	return hasConfigChanged
+}
+
+type configValue struct {
+	value           interface{}
+	multiplier      interface{}
+	isHotReloadable bool
+	defaultValue    interface{}
+	keys            []string
+}
+
+func newConfigValue(value, multiplier, defaultValue interface{}, isHotReloadable bool, keys []string) *configValue {
+	return &configValue{
+		value:           value,
+		multiplier:      multiplier,
+		isHotReloadable: isHotReloadable,
+		defaultValue:    defaultValue,
+		keys:            keys,
+	}
+}

--- a/config/misc.go
+++ b/config/misc.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+// GetWorkspaceToken returns the workspace token provided in the environment variables
+// Env variable CONFIG_BACKEND_TOKEN is deprecating soon
+// WORKSPACE_TOKEN is newly introduced. This will override CONFIG_BACKEND_TOKEN
+func GetWorkspaceToken() string {
+	token := GetString("WORKSPACE_TOKEN", "")
+	if token != "" && token != "<your_token_here>" {
+		return token
+	}
+	return GetString("CONFIG_BACKEND_TOKEN", "")
+}
+
+// GetNamespaceIdentifier
+func GetNamespaceIdentifier() string {
+	k8sNamespace := GetKubeNamespace()
+	if k8sNamespace != "" {
+		return k8sNamespace
+	}
+	return "none"
+}
+
+// GetKubeNamespace returns value stored in KUBE_NAMESPACE env var
+func GetKubeNamespace() string {
+	return os.Getenv("KUBE_NAMESPACE")
+}
+
+func GetInstanceID() string {
+	instance := GetString("INSTANCE_ID", "")
+	if instance == "" {
+		return ""
+	}
+	instanceArr := strings.Split(instance, "-")
+	return instanceArr[len(instanceArr)-1]
+}
+
+func GetReleaseName() string {
+	return os.Getenv("RELEASE_NAME")
+}

--- a/config/mode.go
+++ b/config/mode.go
@@ -1,0 +1,11 @@
+package config
+
+// Rudder server supported config constants
+const (
+	EmbeddedMode      = "embedded"
+	MasterMode        = "master"
+	MasterSlaveMode   = "master_and_slave"
+	SlaveMode         = "slave"
+	OffMode           = "off"
+	PooledWHSlaveMode = "embedded_master"
+)

--- a/docker_test.go
+++ b/docker_test.go
@@ -53,7 +53,6 @@ var (
 	disableDestinationWebhookURL string
 	webhook                      *whUtil.Recorder
 	disableDestinationWebhook    *whUtil.Recorder
-	runSlow                      bool
 	overrideArm64Check           bool
 	writeKey                     string
 	workspaceID                  string
@@ -85,12 +84,11 @@ type event struct {
 }
 
 func TestMainFlow(t *testing.T) {
-	runSlow = config.GetEnvAsBool("SLOW", true)
-	if !runSlow {
+	if os.Getenv("SLOW") == "0" {
 		t.Skip("Skipping tests. Remove 'SLOW=0' env var to run them.")
 	}
 
-	hold = config.GetEnvAsBool("HOLD", false)
+	hold = os.Getenv("HOLD") == "true"
 	if os.Getenv("OVERRIDE_ARM64_CHECK") == "1" {
 		overrideArm64Check = true
 	}
@@ -383,7 +381,7 @@ func setupMainFlow(svcCtx context.Context, t *testing.T) <-chan struct{} {
 		t.Setenv("LOG_LEVEL", "DEBUG")
 	}
 
-	config.Load()
+	config.Reset()
 	logger.Init()
 
 	// uses a sensible default on windows (tcp/http) and linux/osx (socket)

--- a/enterprise/config-env/configEnv.go
+++ b/enterprise/config-env/configEnv.go
@@ -3,6 +3,7 @@ package configenv
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 
@@ -47,7 +48,7 @@ func (handle *HandleT) ReplaceConfigWithEnvVariables(workspaceConfig []byte) (up
 			shouldReplace := strings.HasPrefix(strings.TrimSpace(valString), configEnvReplacer)
 			if shouldReplace {
 				envVariable := valString[len(configEnvReplacer):]
-				envVarValue := config.GetEnv(envVariable, "")
+				envVarValue := os.Getenv(envVariable)
 				if envVarValue == "" {
 					errorMessage := fmt.Sprintf("[ConfigEnv] Missing envVariable: %s. Either set it as envVariable or remove %s from the destination config.", envVariable, configEnvReplacer)
 					pkgLogger.Errorf(errorMessage)

--- a/enterprise/migrator/migrator.go
+++ b/enterprise/migrator/migrator.go
@@ -86,10 +86,10 @@ func (migrator *MigratorT) getURI(uri string) string {
 
 func (migrator *MigratorT) setupFileManager() filemanager.FileManager {
 	versionPrefix := fmt.Sprintf("%d-%d", migrator.fromClusterVersion, migrator.toClusterVersion)
-	provider := config.GetEnv("MIGRATOR_STORAGE_PROVIDER", "S3")
+	provider := config.GetString("MIGRATOR_STORAGE_PROVIDER", "S3")
 	conf := map[string]interface{}{}
-	conf["bucketName"] = config.GetRequiredEnv("MIGRATOR_BUCKET")
-	bucketPrefix := config.GetEnv("MIGRATOR_BUCKET_PREFIX", "")
+	conf["bucketName"] = config.MustGetString("MIGRATOR_BUCKET")
+	bucketPrefix := config.GetString("MIGRATOR_BUCKET_PREFIX", "")
 
 	if bucketPrefix != "" {
 		bucketPrefix = fmt.Sprintf("%s/%s", bucketPrefix, versionPrefix)
@@ -99,10 +99,10 @@ func (migrator *MigratorT) setupFileManager() filemanager.FileManager {
 	conf["prefix"] = bucketPrefix
 	switch provider {
 	case "S3":
-		conf["accessKeyID"] = config.GetEnv("MIGRATOR_ACCESS_KEY_ID", "")
-		conf["accessKey"] = config.GetEnv("MIGRATOR_SECRET_ACCESS_KEY", "")
+		conf["accessKeyID"] = config.GetString("MIGRATOR_ACCESS_KEY_ID", "")
+		conf["accessKey"] = config.GetString("MIGRATOR_SECRET_ACCESS_KEY", "")
 	case "GCS":
-		credentialsFilePath := config.GetRequiredEnv("GOOGLE_APPLICATION_CREDENTIALS")
+		credentialsFilePath := config.MustGetString("GOOGLE_APPLICATION_CREDENTIALS")
 		credentials, err := os.ReadFile(credentialsFilePath)
 		if err != nil {
 			panic(fmt.Sprintf("Error when reading GCS credentials file: %s", credentialsFilePath))
@@ -123,10 +123,10 @@ func (migrator *MigratorT) setupFileManager() filemanager.FileManager {
 
 // GetMigratingFromVersion gives the from version during migration
 func GetMigratingFromVersion() int {
-	return config.GetRequiredEnvAsInt("MIGRATING_FROM_CLUSTER_VERSION")
+	return config.MustGetInt("MIGRATING_FROM_CLUSTER_VERSION")
 }
 
 // GetMigratingToVersion gives the from version during migration
 func GetMigratingToVersion() int {
-	return config.GetRequiredEnvAsInt("MIGRATING_TO_CLUSTER_VERSION")
+	return config.MustGetInt("MIGRATING_TO_CLUSTER_VERSION")
 }

--- a/enterprise/migrator/setup.go
+++ b/enterprise/migrator/setup.go
@@ -40,12 +40,12 @@ func (m *Migrator) Run(ctx context.Context, gatewayDB, routerDB, batchRouterDB *
 
 	var pf pathfinder.ClusterStateT
 
-	migratorPort = config.GetEnvAsInt("MIGRATOR_PORT", 8084)
+	migratorPort = config.GetInt("MIGRATOR_PORT", 8084)
 	if forExport {
-		nextClusterBackendCount := config.GetRequiredEnvAsInt("MIGRATING_TO_BACKEND_COUNT")
-		nextClusterVersion := config.GetRequiredEnvAsInt("MIGRATING_TO_CLUSTER_VERSION")
-		dnsPattern := config.GetEnv("URL_PATTERN", "http://backend-<CLUSTER_VERSION><NODENUM>")
-		instanceIDPattern := config.GetEnv("INSTANCE_ID_PATTERN", "hosted-v<CLUSTER_VERSION>-rudderstack-<NODENUM>")
+		nextClusterBackendCount := config.MustGetInt("MIGRATING_TO_BACKEND_COUNT")
+		nextClusterVersion := config.MustGetInt("MIGRATING_TO_CLUSTER_VERSION")
+		dnsPattern := config.GetString("URL_PATTERN", "http://backend-<CLUSTER_VERSION><NODENUM>")
+		instanceIDPattern := config.GetString("INSTANCE_ID_PATTERN", "hosted-v<CLUSTER_VERSION>-rudderstack-<NODENUM>")
 		pf = pathfinder.New(nextClusterBackendCount, nextClusterVersion, migratorPort, dnsPattern, instanceIDPattern)
 	}
 

--- a/enterprise/replay/dumpsloader.go
+++ b/enterprise/replay/dumpsloader.go
@@ -234,17 +234,17 @@ func (handle *dumpsLoaderHandleT) Setup(ctx context.Context, db *jobsdb.HandleT,
 	handle.startAfterKey = gjson.GetBytes(lastJob.EventPayload, "location").String()
 	handle.bucket = bucket
 	handle.uploader = uploader
-	startTimeStr := strings.TrimSpace(config.GetEnv("START_TIME", "2000-10-02T15:04:05.000Z"))
+	startTimeStr := strings.TrimSpace(config.GetString("START_TIME", "2000-10-02T15:04:05.000Z"))
 	handle.startTime, err = time.Parse(misc.RFC3339Milli, startTimeStr)
 	if err != nil {
 		panic("invalid start time format provided")
 	}
-	handle.prefix = strings.TrimSpace(config.GetEnv("JOBS_BACKUP_PREFIX", ""))
+	handle.prefix = strings.TrimSpace(config.GetString("JOBS_BACKUP_PREFIX", ""))
 	handle.tablePrefix = tablePrefix
 	handle.procError = &ProcErrorRequestHandler{tablePrefix: tablePrefix, handle: handle}
 	handle.gwReplay = &GWReplayRequestHandler{tablePrefix: tablePrefix, handle: handle}
 
-	endTimeStr := strings.TrimSpace(config.GetEnv("END_TIME", ""))
+	endTimeStr := strings.TrimSpace(config.GetString("END_TIME", ""))
 	if endTimeStr == "" {
 		handle.endTime = time.Now()
 	} else {

--- a/enterprise/replay/replay.go
+++ b/enterprise/replay/replay.go
@@ -149,9 +149,9 @@ func (handle *Handler) Setup(ctx context.Context, dumpsLoader *dumpsLoaderHandle
 	handle.toDB = toDB
 	handle.bucket = bucket
 	handle.uploader = uploader
-	handle.noOfWorkers = config.GetEnvAsInt("WORKERS_PER_SOURCE", 4)
+	handle.noOfWorkers = config.GetInt("WORKERS_PER_SOURCE", 4)
 	handle.dumpsLoader = dumpsLoader
-	handle.dbReadSize = config.GetEnvAsInt("DB_READ_SIZE", 10)
+	handle.dbReadSize = config.GetInt("DB_READ_SIZE", 10)
 	handle.tablePrefix = tablePrefix
 	handle.initSourceWorkersChannel = make(chan bool)
 

--- a/enterprise/replay/setup.go
+++ b/enterprise/replay/setup.go
@@ -23,13 +23,13 @@ func loadConfig() {
 }
 
 func initFileManager() (filemanager.FileManager, string, error) {
-	bucket := strings.TrimSpace(config.GetEnv("JOBS_BACKUP_BUCKET", ""))
+	bucket := strings.TrimSpace(config.GetString("JOBS_BACKUP_BUCKET", ""))
 	if bucket == "" {
 		pkgLogger.Error("[[ Replay ]] JOBS_BACKUP_BUCKET is not set")
 		panic("Bucket is not configured.")
 	}
 
-	provider := config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3")
+	provider := config.GetString("JOBS_BACKUP_STORAGE_PROVIDER", "S3")
 	fileManagerFactory := filemanager.DefaultFileManagerFactory
 
 	configFromEnv := filemanager.GetProviderConfigForBackupsFromEnv(context.TODO())
@@ -50,8 +50,8 @@ func initFileManager() (filemanager.FileManager, string, error) {
 }
 
 func setup(ctx context.Context, replayDB, gwDB, routerDB, batchRouterDB *jobsdb.HandleT) error {
-	tablePrefix := config.GetEnv("TO_REPLAY", "gw")
-	replayToDB := config.GetEnv("REPLAY_TO_DB", "gw")
+	tablePrefix := config.GetString("TO_REPLAY", "gw")
+	replayToDB := config.GetString("REPLAY_TO_DB", "gw")
 	pkgLogger.Infof("TO_REPLAY=%s and REPLAY_TO_DB=%s", tablePrefix, replayToDB)
 	var dumpsLoader dumpsLoaderHandleT
 	uploader, bucket, err := initFileManager()

--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -62,7 +62,7 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 
 	var err error
 	dumpDownloadPathDirName := "/rudder-s3-dumps/"
-	tmpdirPath := strings.TrimSuffix(config.GetEnv("RUDDER_TMPDIR", "/tmp"), "/")
+	tmpdirPath := strings.TrimSuffix(config.GetString("RUDDER_TMPDIR", "/tmp"), "/")
 	if tmpdirPath == "" {
 		tmpdirPath, err = os.UserHomeDir()
 		if err != nil {
@@ -110,7 +110,7 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 	var jobs []*jobsdb.JobT
 
 	var transEvents []transformer.TransformerEventT
-	transformationVersionID := config.GetEnv("TRANSFORMATION_VERSION_ID", "")
+	transformationVersionID := config.GetString("TRANSFORMATION_VERSION_ID", "")
 
 	for sc.Scan() {
 		lineBytes := sc.Bytes()
@@ -151,7 +151,7 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 			DestinationID: gjson.GetBytes(copyLineBytes, "parameters.destination_id").String(),
 		}
 
-		transformation := backendconfig.TransformationT{VersionID: config.GetEnv("TRANSFORMATION_VERSION_ID", "")}
+		transformation := backendconfig.TransformationT{VersionID: config.GetString("TRANSFORMATION_VERSION_ID", "")}
 
 		transEvent := transformer.TransformerEventT{
 			Message:     message,

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -69,7 +69,7 @@ func NewFromEnvConfig() *HandleT {
 	config.RegisterIntConfigVariable(32, &maxConcurrentRequests, true, 1, "Reporting.maxConcurrentRequests")
 	reportingLogger := logger.NewLogger().Child("enterprise").Child("reporting")
 	// only send reports for wh actions sources if whActionsOnly is configured
-	whActionsOnly := config.GetEnvAsBool("REPORTING_WH_ACTIONS_ONLY", false)
+	whActionsOnly := config.GetBool("REPORTING_WH_ACTIONS_ONLY", false)
 	if whActionsOnly {
 		reportingLogger.Info("REPORTING_WH_ACTIONS_ONLY enabled.only sending reports relevant to wh actions.")
 	}
@@ -79,7 +79,7 @@ func NewFromEnvConfig() *HandleT {
 		clients:                   make(map[string]*types.Client),
 		reportingServiceURL:       reportingServiceURL,
 		namespace:                 config.GetKubeNamespace(),
-		instanceID:                config.GetEnv("INSTANCE_ID", "1"),
+		instanceID:                config.GetString("INSTANCE_ID", "1"),
 		workspaceIDForSourceIDMap: make(map[string]string),
 		whActionsOnly:             whActionsOnly,
 		sleepInterval:             sleepInterval,

--- a/enterprise/reporting/setup_test.go
+++ b/enterprise/reporting/setup_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestFeatureSetup(t *testing.T) {
-	config.Load()
+	config.Reset()
 	logger.Init()
 
 	f := &Factory{

--- a/enterprise/suppress-user/setup.go
+++ b/enterprise/suppress-user/setup.go
@@ -24,7 +24,7 @@ var (
 func loadConfig() {
 	config.RegisterDurationConfigVariable(300, &regulationsPollInterval, true, time.Second, "BackendConfig.Regulations.pollInterval")
 	config.RegisterIntConfigVariable(50, &suppressionApiPageSize, false, 1, "BackendConfig.Regulations.pageSize")
-	configBackendURL = config.GetEnv("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
+	configBackendURL = config.GetString("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
 }
 
 // Setup initializes Suppress User feature

--- a/enterprise/suppress-user/suppressUser.go
+++ b/enterprise/suppress-user/suppressUser.go
@@ -152,7 +152,7 @@ func (suppressUser *SuppressRegulationHandler) regulationSyncLoop(ctx context.Co
 }
 
 func (suppressUser *SuppressRegulationHandler) getSourceRegulationsFromRegulationService() ([]sourceRegulation, error) {
-	if config.GetEnvAsBool("HOSTED_SERVICE", false) {
+	if config.GetBool("HOSTED_SERVICE", false) {
 		pkgLogger.Info("[Regulations] Regulations on free tier are not supported at the moment.")
 		return []sourceRegulation{}, nil
 	}

--- a/enterprise/suppress-user/suppressUser_test.go
+++ b/enterprise/suppress-user/suppressUser_test.go
@@ -20,7 +20,7 @@ import (
 var _ = Describe("SuppressUser Test", func() {
 	testSuppressUser := new(SuppressRegulationHandler)
 	BeforeEach(func() {
-		config.Load()
+		config.Reset()
 		logger.Init()
 		backendconfig.Init()
 		pkgLogger = logger.NewLogger().Child("enterprise").Child("suppress-user")
@@ -264,7 +264,7 @@ func createSimpleTestServer(inp *serverInp) *httptest.Server {
 }
 
 func TestSuppressRegulationHandler_IsSuppressedUser(t *testing.T) {
-	config.Load()
+	config.Reset()
 	logger.Init()
 	pkgLogger = logger.NewLogger().Child("enterprise").Child("suppress-user")
 

--- a/event-schema/event_schema.go
+++ b/event-schema/event_schema.go
@@ -186,8 +186,8 @@ type EventPayloadT struct {
 }
 
 func loadConfig() {
-	adminUser = config.GetEnv("RUDDER_ADMIN_USER", "rudder")
-	adminPassword = config.GetEnv("RUDDER_ADMIN_PASSWORD", "rudderstack")
+	adminUser = config.GetString("RUDDER_ADMIN_USER", "rudder")
+	adminPassword = config.GetString("RUDDER_ADMIN_PASSWORD", "rudderstack")
 	noOfWorkers = config.GetInt("EventSchemas.noOfWorkers", 128)
 	config.RegisterDurationConfigVariable(240, &flushInterval, true, time.Second, []string{"EventSchemas.syncInterval", "EventSchemas.syncIntervalInS"}...)
 

--- a/event-schema/event_schema_test.go
+++ b/event-schema/event_schema_test.go
@@ -53,7 +53,7 @@ func setupDB(es envSetter, cleanup *testhelper.Cleanup) (*destination.PostgresRe
 	}
 
 	// Load self configuration.
-	config.Load()
+	config.Reset()
 
 	logger.Init() // Initialize the logger
 	Init2()

--- a/event-schema/setup.go
+++ b/event-schema/setup.go
@@ -20,7 +20,7 @@ func GetInstance() types.EventSchemasI {
 	eventSchemaManagerLock.Lock()
 	defer eventSchemaManagerLock.Unlock()
 	if eventSchemaManager == nil {
-		appTypeStr := strings.ToUpper(config.GetEnv("APP_TYPE", app.EMBEDDED))
+		appTypeStr := strings.ToUpper(config.GetString("APP_TYPE", app.EMBEDDED))
 		schemaManager := getEventSchemaManager(
 			createDBConnection(),
 			appTypeStr == app.GATEWAY)

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Reconstructing JSON for ServerSide SDK", func() {
 })
 
 func initGW() {
-	config.Load()
+	config.Reset()
 	admin.Init()
 	logger.Init()
 	misc.Init()

--- a/gateway/webhook/configuration.go
+++ b/gateway/webhook/configuration.go
@@ -8,7 +8,7 @@ import (
 )
 
 func loadConfig() {
-	sourceTransformerURL = strings.TrimSuffix(config.GetEnv("DEST_TRANSFORM_URL", "http://localhost:9090"), "/") + "/v0/sources"
+	sourceTransformerURL = strings.TrimSuffix(config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090"), "/") + "/v0/sources"
 	// Number of incoming webhooks that are batched before calling source transformer
 	config.RegisterIntConfigVariable(32, &maxWebhookBatchSize, true, 1, "Gateway.webhook.maxBatchSize")
 	// Timeout after which batch is formed anyway with whatever webhooks are available

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -39,7 +39,7 @@ var (
 
 func initWebhook() {
 	once.Do(func() {
-		config.Load()
+		config.Reset()
 		logger.Init()
 		misc.Init()
 		Init()

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/snowflakedb/gosnowflake v1.6.3
 	github.com/sony/gobreaker v0.5.0
 	github.com/spaolacci/murmur3 v1.1.0
-	github.com/spf13/cast v1.3.1
+	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/viper v1.8.0
 	github.com/stretchr/testify v1.7.1
 	github.com/thoas/go-funk v0.9.1

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -57,8 +57,8 @@ func TestBackupTable(t *testing.T) {
 		t.Setenv("RSERVER_JOBS_DB_BACKUP_RT_ENABLED", "true")
 		t.Setenv("JOBS_BACKUP_BUCKET", "backup-test")
 		t.Setenv("RUDDER_TMPDIR", tmpDir)
-		t.Setenv(config.ConfigKeyToEnvRudder("JobsDB.maxDSSize"), "10")
-		t.Setenv(config.ConfigKeyToEnvRudder("JobsDB.migrateDSLoopSleepDuration"), "3")
+		t.Setenv(config.ConfigKeyToEnv("JobsDB.maxDSSize"), "10")
+		t.Setenv(config.ConfigKeyToEnv("JobsDB.migrateDSLoopSleepDuration"), "3")
 		t.Setenv("JOBS_BACKUP_BUCKET", minioResource.BucketName)
 		t.Setenv("JOBS_BACKUP_PREFIX", prefix)
 

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -57,8 +57,8 @@ func TestBackupTable(t *testing.T) {
 		t.Setenv("RSERVER_JOBS_DB_BACKUP_RT_ENABLED", "true")
 		t.Setenv("JOBS_BACKUP_BUCKET", "backup-test")
 		t.Setenv("RUDDER_TMPDIR", tmpDir)
-		t.Setenv(config.TransformKey("JobsDB.maxDSSize"), "10")
-		t.Setenv(config.TransformKey("JobsDB.migrateDSLoopSleepDuration"), "3")
+		t.Setenv(config.ConfigKeyToEnvRudder("JobsDB.maxDSSize"), "10")
+		t.Setenv(config.ConfigKeyToEnvRudder("JobsDB.migrateDSLoopSleepDuration"), "3")
 		t.Setenv("JOBS_BACKUP_BUCKET", minioResource.BucketName)
 		t.Setenv("JOBS_BACKUP_PREFIX", prefix)
 

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -1202,7 +1202,7 @@ func startPostgres(t testingT) *destination.PostgresResource {
 }
 
 func initJobsDB() {
-	config.Load()
+	config.Reset()
 	logger.Init()
 	admin.Init()
 	misc.Init()

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func loadConfig() {
 	config.RegisterDurationConfigVariable(15, &gracefulShutdownTimeout, false, time.Second, "GracefulShutdownTimeout")
 	config.RegisterIntConfigVariable(524288, &MaxHeaderBytes, false, 1, "MaxHeaderBytes")
 
-	enterpriseToken = config.GetEnv("ENTERPRISE_TOKEN", enterpriseToken)
+	enterpriseToken = config.GetString("ENTERPRISE_TOKEN", enterpriseToken)
 }
 
 func Init() {
@@ -138,7 +138,6 @@ func canStartWarehouse() bool {
 }
 
 func runAllInit() {
-	config.Load()
 	admin.Init()
 	app.Init()
 	logger.Init()
@@ -224,14 +223,14 @@ func Run(ctx context.Context) int {
 	// application & backend setup should be done before starting any new goroutines.
 	application.Setup()
 
-	appTypeStr := strings.ToUpper(config.GetEnv("APP_TYPE", app.EMBEDDED))
+	appTypeStr := strings.ToUpper(config.GetString("APP_TYPE", app.EMBEDDED))
 	appHandler = apphandlers.GetAppHandler(application, appTypeStr, versionHandler)
 
 	versionDetail := versionInfo()
 	stats.NewTaggedStat("rudder_server_config", stats.GaugeType, stats.Tags{"version": version, "major": major, "minor": minor, "patch": patch, "commit": commit, "buildDate": buildDate, "builtBy": builtBy, "gitUrl": gitURL, "TransformerVersion": transformer.GetVersion(), "DatabricksVersion": misc.GetDatabricksVersion()}).Gauge(1)
 	bugsnag.Configure(bugsnag.Configuration{
-		APIKey:       config.GetEnv("BUGSNAG_KEY", ""),
-		ReleaseStage: config.GetEnv("GO_ENV", "development"),
+		APIKey:       config.GetString("BUGSNAG_KEY", ""),
+		ReleaseStage: config.GetString("GO_ENV", "development"),
 		// The import paths for the Go packages containing your source files
 		ProjectPackages: []string{"main", "github.com/rudderlabs/rudder-server"},
 		// more configuration options
@@ -244,7 +243,7 @@ func Run(ctx context.Context) int {
 
 	configEnvHandler := application.Features().ConfigEnv.Setup()
 
-	if config.GetEnv("RSERVER_WAREHOUSE_MODE", "") != "slave" {
+	if config.GetString("Warehouse.mode", "") != "slave" {
 		if err := backendconfig.Setup(configEnvHandler); err != nil {
 			pkgLogger.Errorf("Unable to setup backend config: %s", err)
 			return 1
@@ -350,7 +349,7 @@ func Run(ctx context.Context) int {
 			_ = logger.Log.Sync()
 		}
 		stats.StopPeriodicStats()
-		if config.GetEnvAsBool("RUDDER_GRACEFUL_SHUTDOWN_TIMEOUT_EXIT", true) {
+		if config.GetBool("RUDDER_GRACEFUL_SHUTDOWN_TIMEOUT_EXIT", true) {
 			return 1
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -281,7 +281,7 @@ func Run(ctx context.Context) int {
 			backendconfig.DefaultBackendConfig.WaitForConfig(ctx)
 
 			c := features.NewClient(
-				config.GetEnv("CONFIG_BACKEND_URL", "https://api.rudderlabs.com"),
+				config.GetString("CONFIG_BACKEND_URL", "https://api.rudderlabs.com"),
 				backendconfig.DefaultBackendConfig.Identity(),
 			)
 

--- a/processor/integrations/integrations.go
+++ b/processor/integrations/integrations.go
@@ -32,7 +32,7 @@ func Init() {
 }
 
 func loadConfig() {
-	destTransformURL = config.GetEnv("DEST_TRANSFORM_URL", "http://localhost:9090")
+	destTransformURL = config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
 }
 
 const (
@@ -167,13 +167,13 @@ func GetTransformerURL() string {
 func GetDestinationURL(destType string) string {
 	destinationEndPoint := fmt.Sprintf("%s/v0/%s", destTransformURL, strings.ToLower(destType))
 	if misc.Contains(warehouseutils.WarehouseDestinations, destType) {
-		whSchemaVersionQueryParam := fmt.Sprintf("whSchemaVersion=%s&whIDResolve=%v", config.GetWHSchemaVersion(), warehouseutils.IDResolutionEnabled())
+		whSchemaVersionQueryParam := fmt.Sprintf("whSchemaVersion=%s&whIDResolve=%v", config.GetString("Warehouse.schemaVersion", "v1"), warehouseutils.IDResolutionEnabled())
 		if destType == "RS" {
-			rsAlterStringToTextQueryParam := fmt.Sprintf("rsAlterStringToText=%s", fmt.Sprintf("%v", config.GetVarCharMaxForRS()))
+			rsAlterStringToTextQueryParam := fmt.Sprintf("rsAlterStringToText=%s", fmt.Sprintf("%v", config.GetBool("Warehouse.redshift.setVarCharMax", false)))
 			return destinationEndPoint + "?" + whSchemaVersionQueryParam + "&" + rsAlterStringToTextQueryParam
 		}
 		if destType == "CLICKHOUSE" {
-			enableArraySupport := fmt.Sprintf("chEnableArraySupport=%s", fmt.Sprintf("%v", config.GetArraySupportForCH()))
+			enableArraySupport := fmt.Sprintf("chEnableArraySupport=%s", fmt.Sprintf("%v", config.GetBool("Warehouse.clickhouse.enableArraySupport", false)))
 			return destinationEndPoint + "?" + whSchemaVersionQueryParam + "&" + enableArraySupport
 		}
 		return destinationEndPoint + "?" + whSchemaVersionQueryParam

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -129,7 +129,7 @@ func blockOnHold() {
 }
 
 func initJobsDB() {
-	config.Load()
+	config.Reset()
 	logger.Init()
 	stash.Init()
 	admin.Init()

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -520,7 +520,7 @@ func loadConfig() {
 	config.RegisterIntConfigVariable(5, &transformTimesPQLength, false, 1, "Processor.transformTimesPQLength")
 	// Capture event name as a tag in event level stats
 	config.RegisterBoolConfigVariable(false, &captureEventNameStats, true, "Processor.Stats.captureEventName")
-	transformerURL = config.GetEnv("DEST_TRANSFORM_URL", "http://localhost:9090")
+	transformerURL = config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
 	config.RegisterDurationConfigVariable(5, &pollInterval, false, time.Second, []string{"Processor.pollInterval", "Processor.pollIntervalInS"}...)
 	// GWCustomVal is used as a key in the jobsDB customval column
 	config.RegisterStringConfigVariable("GW", &GWCustomVal, false, "Gateway.CustomVal")

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -305,7 +305,7 @@ var sampleBackendConfig = backendconfig.ConfigT{
 }
 
 func initProcessor() {
-	config.Load()
+	config.Reset()
 	logger.Init()
 	stash.Init()
 	admin.Init()

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -123,8 +123,8 @@ func backupEnabled() bool {
 
 func (st *HandleT) setupFileUploader(ctx context.Context) {
 	if backupEnabled() {
-		provider := config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "")
-		bucket := config.GetEnv("JOBS_BACKUP_BUCKET", "")
+		provider := config.GetString("JOBS_BACKUP_STORAGE_PROVIDER", "")
+		bucket := config.GetString("JOBS_BACKUP_BUCKET", "")
 		if provider != "" && bucket != "" {
 			var err error
 			st.errFileUploader, err = filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
@@ -168,7 +168,7 @@ func (st *HandleT) storeErrorsToObjectStorage(jobs []*jobsdb.JobT) StoreErrorOut
 	if err != nil {
 		panic(err)
 	}
-	path := fmt.Sprintf("%v%v.json", tmpDirPath+localTmpDirName, fmt.Sprintf("%v.%v.%v.%v", time.Now().Unix(), config.GetEnv("INSTANCE_ID", "1"), fmt.Sprintf("%v-%v", jobs[0].JobID, jobs[len(jobs)-1].JobID), uuid))
+	path := fmt.Sprintf("%v%v.json", tmpDirPath+localTmpDirName, fmt.Sprintf("%v.%v.%v.%v", time.Now().Unix(), config.GetString("INSTANCE_ID", "1"), fmt.Sprintf("%v-%v", jobs[0].JobID, jobs[len(jobs)-1].JobID), uuid))
 
 	gzipFilePath := fmt.Sprintf(`%v.gz`, path)
 	err = os.MkdirAll(filepath.Dir(gzipFilePath), os.ModePerm)

--- a/processor/transformer/transformer_test.go
+++ b/processor/transformer/transformer_test.go
@@ -49,7 +49,7 @@ func (t *fakeTransformer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func Test_Transformer(t *testing.T) {
-	config.Load()
+	config.Reset()
 	logger.Init()
 	stats.Setup()
 	transformer.Init()

--- a/regulation-worker/cmd/main.go
+++ b/regulation-worker/cmd/main.go
@@ -61,8 +61,8 @@ func Run(ctx context.Context) {
 	svc := service.JobSvc{
 		API: &client.JobAPI{
 			Client:         &http.Client{Timeout: config.GetDuration("HttpClient.regulationWorker.timeout", 30, time.Second)},
-			URLPrefix:      config.MustGetEnv("CONFIG_BACKEND_URL"),
-			WorkspaceToken: config.MustGetEnv("CONFIG_BACKEND_TOKEN"),
+			URLPrefix:      config.MustGetString("CONFIG_BACKEND_URL"),
+			WorkspaceToken: config.MustGetString("CONFIG_BACKEND_TOKEN"),
 			WorkspaceID:    workspaceId,
 		},
 		DestDetail: dest,
@@ -73,7 +73,7 @@ func Run(ctx context.Context) {
 			},
 			&api.APIManager{
 				Client:           &http.Client{Timeout: config.GetDuration("HttpClient.regulationWorker.timeout", 30, time.Second)},
-				DestTransformURL: config.MustGetEnv("DEST_TRANSFORM_URL"),
+				DestTransformURL: config.MustGetString("DEST_TRANSFORM_URL"),
 			}),
 	}
 

--- a/regulation-worker/internal/delete/batch/batch.go
+++ b/regulation-worker/internal/delete/batch/batch.go
@@ -500,7 +500,7 @@ func (bm *BatchManager) Delete(ctx context.Context, job model.Job, destConfig ma
 
 		g, gCtx := errgroup.WithContext(ctx)
 
-		procAllocated, err := strconv.Atoi(config.GetEnv("GOMAXPROCS", "32"))
+		procAllocated, err := strconv.Atoi(config.GetString("GOMAXPROCS", "32"))
 		if err != nil {
 			pkgLogger.Errorf("error while getting maximum number of go routines to be created: %v", err)
 			return model.JobStatusFailed

--- a/regulation-worker/internal/initialize/initialize.go
+++ b/regulation-worker/internal/initialize/initialize.go
@@ -12,7 +12,7 @@ var once sync.Once
 
 func Init() {
 	once.Do(func() {
-		config.Load()
+		config.Reset()
 		logger.Init()
 		stats.Init()
 		stats.Setup()

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -732,9 +732,9 @@ func (brt *HandleT) copyJobsToStorage(provider string, batchJobs *BatchJobsT, is
 	brt.logger.Debugf("BRT: Starting upload to %s", provider)
 	folderName := ""
 	if isWarehouse {
-		folderName = config.GetEnv("WAREHOUSE_STAGING_BUCKET_FOLDER_NAME", "rudder-warehouse-staging-logs")
+		folderName = config.GetString("WAREHOUSE_STAGING_BUCKET_FOLDER_NAME", "rudder-warehouse-staging-logs")
 	} else {
-		folderName = config.GetEnv("DESTINATION_BUCKET_FOLDER_NAME", "rudder-logs")
+		folderName = config.GetString("DESTINATION_BUCKET_FOLDER_NAME", "rudder-logs")
 	}
 
 	var datePrefixLayout string
@@ -2265,7 +2265,7 @@ func loadConfig() {
 	config.RegisterBoolConfigVariable(true, &readPerDestination, false, "BatchRouter.readPerDestination")
 	config.RegisterStringConfigVariable("", &toAbortDestinationIDs, true, "BatchRouter.toAbortDestinationIDs")
 	config.RegisterDurationConfigVariable(10, &netClientTimeout, false, time.Second, "BatchRouter.httpTimeout")
-	transformerURL = config.GetEnv("DEST_TRANSFORM_URL", "http://localhost:9090")
+	transformerURL = config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
 	config.RegisterStringConfigVariable("", &datePrefixOverride, true, "BatchRouter.datePrefixOverride")
 	dateFormatLayouts = map[string]string{
 		"01-02-2006": "MM-DD-YYYY",

--- a/router/batchrouter/batchrouterBenchmark_test.go
+++ b/router/batchrouter/batchrouterBenchmark_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Benchmark_GetStorageDateFormat(b *testing.B) {
-	config.Load()
+	config.Reset()
 	Init()
 
 	mockCtrl := gomock.NewController(b)

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -130,7 +130,7 @@ var (
 )
 
 func initBatchRouter() {
-	config.Load()
+	config.Reset()
 	admin.Init()
 	logger.Init()
 	misc.Init()

--- a/router/customdestinationmanager/customdestinationmanager_test.go
+++ b/router/customdestinationmanager/customdestinationmanager_test.go
@@ -24,7 +24,7 @@ var once sync.Once
 
 func initCustomerManager() {
 	once.Do(func() {
-		config.Load()
+		config.Reset()
 		Init()
 		logger.Init()
 		stats.Setup()

--- a/router/manager/manager_test.go
+++ b/router/manager/manager_test.go
@@ -171,7 +171,7 @@ var (
 )
 
 func initRouter() {
-	config.Load()
+	config.Reset()
 	logger.Init()
 	stash.Init()
 	admin.Init()

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -177,7 +177,7 @@ func (c *testContext) Finish() {
 }
 
 func initRouter() {
-	config.Load()
+	config.Reset()
 	admin.Init()
 	logger.Init()
 	Init()

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -389,16 +389,16 @@ func (trans *handle) doProxyRequest(ctx context.Context, proxyReqParams *ProxyRe
 }
 
 func getBatchURL() string {
-	return strings.TrimSuffix(config.GetEnv("DEST_TRANSFORM_URL", "http://localhost:9090"), "/") + "/batch"
+	return strings.TrimSuffix(config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090"), "/") + "/batch"
 }
 
 func getRouterTransformURL() string {
-	return strings.TrimSuffix(config.GetEnv("DEST_TRANSFORM_URL", "http://localhost:9090"), "/") + "/routerTransform"
+	return strings.TrimSuffix(config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090"), "/") + "/routerTransform"
 }
 
 func getProxyURL(destName, baseUrl string) string {
 	if !router_utils.IsNotEmptyString(baseUrl) { // empty string check
-		baseUrl = strings.TrimSuffix(config.GetEnv("DEST_TRANSFORM_URL", "http://localhost:9090"), "/")
+		baseUrl = strings.TrimSuffix(config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090"), "/")
 	}
 	return baseUrl + "/v0/destinations/" + strings.ToLower(destName) + "/proxy"
 }

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -337,7 +337,7 @@ func mockProxyHandler(timeout time.Duration, code int, response string) *mux.Rou
 
 func TestTransformNoValidationErrors(t *testing.T) {
 	initMocks(t)
-	config.Load()
+	config.Reset()
 	pkgLogger = logger.NOP{}
 	expectedTransformerResponse := []types.DestinationJobT{
 		{JobMetadataArray: []types.JobMetadataT{{JobID: 1}}, StatusCode: http.StatusOK},
@@ -369,7 +369,7 @@ func TestTransformNoValidationErrors(t *testing.T) {
 
 func TestTransformValidationUnmarshallingError(t *testing.T) {
 	initMocks(t)
-	config.Load()
+	config.Reset()
 	pkgLogger = logger.NOP{}
 	expectedErrorTxt := "Transformer returned invalid response: invalid json for input:"
 	expectedTransformerResponse := []types.DestinationJobT{
@@ -401,7 +401,7 @@ func TestTransformValidationUnmarshallingError(t *testing.T) {
 
 func TestTransformValidationInOutMismatchError(t *testing.T) {
 	initMocks(t)
-	config.Load()
+	config.Reset()
 	pkgLogger = logger.NOP{}
 	expectedErrorTxt := "Transformer returned invalid output size: 4 for input size: 3"
 	expectedTransformerResponse := []types.DestinationJobT{
@@ -441,7 +441,7 @@ func TestTransformValidationInOutMismatchError(t *testing.T) {
 
 func TestTransformValidationJobIDMismatchError(t *testing.T) {
 	initMocks(t)
-	config.Load()
+	config.Reset()
 	pkgLogger = logger.NOP{}
 	expectedErrorTxt := "Transformer returned invalid jobIDs: [4]"
 	expectedTransformerResponse := []types.DestinationJobT{

--- a/services/alert/alertmanager.go
+++ b/services/alert/alertmanager.go
@@ -20,10 +20,10 @@ func Init() {
 }
 
 func loadConfig() {
-	alertProvider = config.GetEnv("ALERT_PROVIDER", "victorops")
-	pagerDutyRoutingKey = config.GetEnv("PG_ROUTING_KEY", "")
-	instanceName = config.GetEnv("INSTANCE_ID", "")
-	victorOpsRoutingKey = config.GetEnv("VICTOROPS_ROUTING_KEY", "")
+	alertProvider = config.GetString("ALERT_PROVIDER", "victorops")
+	pagerDutyRoutingKey = config.GetString("PG_ROUTING_KEY", "")
+	instanceName = config.GetString("INSTANCE_ID", "")
+	victorOpsRoutingKey = config.GetString("VICTOROPS_ROUTING_KEY", "")
 }
 
 // AlertManager interface

--- a/services/archiver/archiver.go
+++ b/services/archiver/archiver.go
@@ -30,8 +30,8 @@ func loadConfig() {
 }
 
 func IsArchiverObjectStorageConfigured() bool {
-	provider := config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "")
-	bucket := config.GetEnv("JOBS_BACKUP_BUCKET", "")
+	provider := config.GetString("JOBS_BACKUP_STORAGE_PROVIDER", "")
+	bucket := config.GetString("JOBS_BACKUP_BUCKET", "")
 	return provider != "" && bucket != ""
 }
 
@@ -81,11 +81,11 @@ func ArchiveOldRecords(tableName, tsColumn string, archivalTimeInDays int, dbHan
 	defer os.Remove(path)
 
 	fManager, err := filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
-		Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
+		Provider: config.GetString("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
 		Config:   filemanager.GetProviderConfigForBackupsFromEnv(context.TODO()),
 	})
 	if err != nil {
-		pkgLogger.Errorf("[Archiver]: Error in creating a file manager for :%s: , %v", config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"), err)
+		pkgLogger.Errorf("[Archiver]: Error in creating a file manager for :%s: , %v", config.GetString("JOBS_BACKUP_STORAGE_PROVIDER", "S3"), err)
 	}
 
 	tableJSONArchiver := tablearchiver.TableJSONArchiver{

--- a/services/db/degradedModeHandler.go
+++ b/services/db/degradedModeHandler.go
@@ -8,8 +8,8 @@ import (
 )
 
 func setupDegradedMode() {
-	config.SetBool("enableProcessor", false)
-	config.SetBool("enableRouter", false)
+	config.Set("enableProcessor", false)
+	config.Set("enableRouter", false)
 }
 
 func (handler *DegradedModeHandler) RecordAppStart(currTime int64) {

--- a/services/db/recovery.go
+++ b/services/db/recovery.go
@@ -148,7 +148,7 @@ func NewRecoveryHandler(recoveryData *RecoveryDataT) RecoveryHandler {
 }
 
 func alertOps(mode string) {
-	instanceName := config.GetEnv("INSTANCE_ID", "")
+	instanceName := config.GetString("INSTANCE_ID", "")
 
 	alertManager, err := alert.New()
 	if err != nil {

--- a/services/debugger/destination/eventDeliveryStatusUploader.go
+++ b/services/debugger/destination/eventDeliveryStatusUploader.go
@@ -48,7 +48,7 @@ func Init() {
 }
 
 func loadConfig() {
-	configBackendURL = config.GetEnv("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
+	configBackendURL = config.GetString("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
 	config.RegisterBoolConfigVariable(false, &disableEventDeliveryStatusUploads, true, "DestinationDebugger.disableEventDeliveryStatusUploads")
 }
 

--- a/services/debugger/destination/eventDeliveryStatusUploader_test.go
+++ b/services/debugger/destination/eventDeliveryStatusUploader_test.go
@@ -174,7 +174,7 @@ func (c *eventDeliveryStatusUploaderContext) Setup() {
 }
 
 func initEventDeliveryStatusUploader() {
-	config.Load()
+	config.Reset()
 	logger.Init()
 	Init()
 }

--- a/services/debugger/source/eventUploader.go
+++ b/services/debugger/source/eventUploader.go
@@ -51,7 +51,7 @@ func Init() {
 }
 
 func loadConfig() {
-	configBackendURL = config.GetEnv("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
+	configBackendURL = config.GetString("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
 	config.RegisterBoolConfigVariable(false, &disableEventUploads, true, "SourceDebugger.disableEventUploads")
 }
 

--- a/services/debugger/source/eventUploader_test.go
+++ b/services/debugger/source/eventUploader_test.go
@@ -49,7 +49,7 @@ func (c *eventUploaderContext) Finish() {
 }
 
 func initEventUploader() {
-	config.Load()
+	config.Reset()
 	logger.Init()
 	Init()
 }

--- a/services/debugger/transformation/transformationStatusUploader.go
+++ b/services/debugger/transformation/transformationStatusUploader.go
@@ -84,7 +84,7 @@ func Init() {
 }
 
 func loadConfig() {
-	configBackendURL = config.GetEnv("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
+	configBackendURL = config.GetString("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
 	config.RegisterBoolConfigVariable(false, &disableTransformationUploads, true, "TransformationDebugger.disableTransformationStatusUploads")
 }
 

--- a/services/debugger/uploader_test.go
+++ b/services/debugger/uploader_test.go
@@ -34,7 +34,7 @@ func (c *uploaderContext) Finish() {
 }
 
 func initUploader() {
-	config.Load()
+	config.Reset()
 	logger.Init()
 }
 

--- a/services/dedup/dedup_test.go
+++ b/services/dedup/dedup_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Test_Dedup(t *testing.T) {
-	config.Load()
+	config.Reset()
 	logger.Init()
 
 	dbPath := os.TempDir() + "/dedup_test"
@@ -55,7 +55,7 @@ func Test_Dedup(t *testing.T) {
 }
 
 func Test_Dedup_Window(t *testing.T) {
-	config.Load()
+	config.Reset()
 	logger.Init()
 
 	dbPath := os.TempDir() + "/dedup_test"
@@ -80,7 +80,7 @@ func Test_Dedup_Window(t *testing.T) {
 }
 
 func Test_Dedup_ClearDB(t *testing.T) {
-	config.Load()
+	config.Reset()
 	logger.Init()
 
 	dbPath := os.TempDir() + "/dedup_test"
@@ -108,7 +108,7 @@ func Test_Dedup_ClearDB(t *testing.T) {
 }
 
 func Test_Dedup_ErrTxnTooBig(t *testing.T) {
-	config.Load()
+	config.Reset()
 	logger.Init()
 
 	dbPath := os.TempDir() + "/dedup_test_errtxntoobig"
@@ -129,7 +129,7 @@ func Test_Dedup_ErrTxnTooBig(t *testing.T) {
 var duplicateIndexes []int
 
 func Benchmark_Dedup(b *testing.B) {
-	config.Load()
+	config.Reset()
 	logger.Init()
 	dbPath := path.Join("./testdata", "tmp", rand.String(10), "/DB_Benchmark_Dedup")
 	b.Logf("using path %s, since tmpDir has issues in macOS\n", dbPath)

--- a/services/dedup/setup_test.go
+++ b/services/dedup/setup_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_GetInstance(t *testing.T) {
-	config.Load()
+	config.Reset()
 	logger.Init()
 	misc.Init()
 	dedup.Init()

--- a/services/destination-connection-tester/destination_connection_tester.go
+++ b/services/destination-connection-tester/destination_connection_tester.go
@@ -46,11 +46,11 @@ func Init() {
 }
 
 func loadConfig() {
-	configBackendURL = config.GetEnv("CONFIG_BACKEND_URL", "https://api.rudderstack.com")
+	configBackendURL = config.GetString("CONFIG_BACKEND_URL", "https://api.rudderstack.com")
 	maxRetry = config.GetInt("DestinationConnectionTester.maxRetry", 3)
 	config.RegisterDurationConfigVariable(100, &retrySleep, false, time.Millisecond, []string{"DestinationConnectionTester.retrySleep", "DestinationConnectionTester.retrySleepInMS"}...)
-	instanceID = config.GetEnv("INSTANCE_ID", "1")
-	rudderConnectionTestingFolder = config.GetEnv("RUDDER_CONNECTION_TESTING_BUCKET_FOLDER_NAME", misc.RudderTestPayload)
+	instanceID = config.GetString("INSTANCE_ID", "1")
+	rudderConnectionTestingFolder = config.GetString("RUDDER_CONNECTION_TESTING_BUCKET_FOLDER_NAME", misc.RudderTestPayload)
 }
 
 func UploadDestinationConnectionTesterResponse(testResponse, destinationId string) {
@@ -162,7 +162,7 @@ func uploadTestFileForBatchDestination(filename string, keyPrefixes []string, pr
 
 func TestBatchDestinationConnection(destination backendconfig.DestinationT) string {
 	testFileName := createTestFileForBatchDestination(destination.ID)
-	keyPrefixes := []string{config.GetEnv("RUDDER_CONNECTION_TESTING_BUCKET_FOLDER_NAME", misc.RudderTestPayload), destination.ID, time.Now().Format("01-02-2006")}
+	keyPrefixes := []string{config.GetString("RUDDER_CONNECTION_TESTING_BUCKET_FOLDER_NAME", misc.RudderTestPayload), destination.ID, time.Now().Format("01-02-2006")}
 	_, err := uploadTestFileForBatchDestination(testFileName, keyPrefixes, destination.DestinationDefinition.Name, destination)
 	if err != nil {
 		return err.Error()

--- a/services/diagnostics/diagnostics.go
+++ b/services/diagnostics/diagnostics.go
@@ -89,7 +89,7 @@ func loadConfig() {
 
 // newDiagnostics return new instace of diagnostics
 func newDiagnostics() *diagnostics {
-	instanceId := config.GetEnv("INSTANCE_ID", "1")
+	instanceId := config.GetString("INSTANCE_ID", "1")
 
 	client := analytics.New(writekey, endpoint)
 	return &diagnostics{

--- a/services/filemanager/fileManager_test.go
+++ b/services/filemanager/fileManager_test.go
@@ -45,7 +45,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	config.Load()
+	config.Reset()
 	logger.Init()
 
 	os.Exit(run(m))

--- a/services/filemanager/filemanager.go
+++ b/services/filemanager/filemanager.go
@@ -90,45 +90,45 @@ func (factory *FileManagerFactoryT) New(settings *SettingsT) (FileManager, error
 // GetProviderConfigForBackupsFromEnv returns the provider config
 func GetProviderConfigForBackupsFromEnv(ctx context.Context) map[string]interface{} {
 	providerConfig := make(map[string]interface{})
-	provider := config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3")
+	provider := config.GetString("JOBS_BACKUP_STORAGE_PROVIDER", "S3")
 	switch provider {
 	case "S3":
-		providerConfig["bucketName"] = config.GetEnv("JOBS_BACKUP_BUCKET", "")
-		providerConfig["prefix"] = config.GetEnv("JOBS_BACKUP_PREFIX", "")
-		providerConfig["accessKeyID"] = config.GetEnv("AWS_ACCESS_KEY_ID", "")
-		providerConfig["accessKey"] = config.GetEnv("AWS_SECRET_ACCESS_KEY", "")
-		providerConfig["enableSSE"] = config.GetEnvAsBool("AWS_ENABLE_SSE", false)
-		providerConfig["regionHint"] = config.GetEnv("AWS_S3_REGION_HINT", "us-east-1")
-		providerConfig["iamRoleArn"] = config.GetEnv("BACKUP_IAM_ROLE_ARN", "")
+		providerConfig["bucketName"] = config.GetString("JOBS_BACKUP_BUCKET", "")
+		providerConfig["prefix"] = config.GetString("JOBS_BACKUP_PREFIX", "")
+		providerConfig["accessKeyID"] = config.GetString("AWS_ACCESS_KEY_ID", "")
+		providerConfig["accessKey"] = config.GetString("AWS_SECRET_ACCESS_KEY", "")
+		providerConfig["enableSSE"] = config.GetBool("AWS_ENABLE_SSE", false)
+		providerConfig["regionHint"] = config.GetString("AWS_S3_REGION_HINT", "us-east-1")
+		providerConfig["iamRoleArn"] = config.GetString("BACKUP_IAM_ROLE_ARN", "")
 		if providerConfig["iamRoleArn"] != "" {
 			backendconfig.DefaultBackendConfig.WaitForConfig(ctx)
 			providerConfig["externalId"] = backendconfig.DefaultBackendConfig.GetWorkspaceIDForWriteKey("")
 		}
 	case "GCS":
-		providerConfig["bucketName"] = config.GetEnv("JOBS_BACKUP_BUCKET", "")
-		providerConfig["prefix"] = config.GetEnv("JOBS_BACKUP_PREFIX", "")
-		credentials, err := os.ReadFile(config.GetEnv("GOOGLE_APPLICATION_CREDENTIALS", ""))
+		providerConfig["bucketName"] = config.GetString("JOBS_BACKUP_BUCKET", "")
+		providerConfig["prefix"] = config.GetString("JOBS_BACKUP_PREFIX", "")
+		credentials, err := os.ReadFile(config.GetString("GOOGLE_APPLICATION_CREDENTIALS", ""))
 		if err == nil {
 			providerConfig["credentials"] = string(credentials)
 		}
 	case "AZURE_BLOB":
-		providerConfig["containerName"] = config.GetEnv("JOBS_BACKUP_BUCKET", "")
-		providerConfig["prefix"] = config.GetEnv("JOBS_BACKUP_PREFIX", "")
-		providerConfig["accountName"] = config.GetEnv("AZURE_STORAGE_ACCOUNT", "")
-		providerConfig["accountKey"] = config.GetEnv("AZURE_STORAGE_ACCESS_KEY", "")
+		providerConfig["containerName"] = config.GetString("JOBS_BACKUP_BUCKET", "")
+		providerConfig["prefix"] = config.GetString("JOBS_BACKUP_PREFIX", "")
+		providerConfig["accountName"] = config.GetString("AZURE_STORAGE_ACCOUNT", "")
+		providerConfig["accountKey"] = config.GetString("AZURE_STORAGE_ACCESS_KEY", "")
 	case "MINIO":
-		providerConfig["bucketName"] = config.GetEnv("JOBS_BACKUP_BUCKET", "")
-		providerConfig["prefix"] = config.GetEnv("JOBS_BACKUP_PREFIX", "")
-		providerConfig["endPoint"] = config.GetEnv("MINIO_ENDPOINT", "localhost:9000")
-		providerConfig["accessKeyID"] = config.GetEnv("MINIO_ACCESS_KEY_ID", "minioadmin")
-		providerConfig["secretAccessKey"] = config.GetEnv("MINIO_SECRET_ACCESS_KEY", "minioadmin")
-		providerConfig["useSSL"] = config.GetEnvAsBool("MINIO_SSL", false)
+		providerConfig["bucketName"] = config.GetString("JOBS_BACKUP_BUCKET", "")
+		providerConfig["prefix"] = config.GetString("JOBS_BACKUP_PREFIX", "")
+		providerConfig["endPoint"] = config.GetString("MINIO_ENDPOINT", "localhost:9000")
+		providerConfig["accessKeyID"] = config.GetString("MINIO_ACCESS_KEY_ID", "minioadmin")
+		providerConfig["secretAccessKey"] = config.GetString("MINIO_SECRET_ACCESS_KEY", "minioadmin")
+		providerConfig["useSSL"] = config.GetBool("MINIO_SSL", false)
 	case "DIGITAL_OCEAN_SPACES":
-		providerConfig["bucketName"] = config.GetEnv("JOBS_BACKUP_BUCKET", "")
-		providerConfig["prefix"] = config.GetEnv("JOBS_BACKUP_PREFIX", "")
-		providerConfig["endPoint"] = config.GetEnv("DO_SPACES_ENDPOINT", "")
-		providerConfig["accessKeyID"] = config.GetEnv("DO_SPACES_ACCESS_KEY_ID", "")
-		providerConfig["accessKey"] = config.GetEnv("DO_SPACES_SECRET_ACCESS_KEY", "")
+		providerConfig["bucketName"] = config.GetString("JOBS_BACKUP_BUCKET", "")
+		providerConfig["prefix"] = config.GetString("JOBS_BACKUP_PREFIX", "")
+		providerConfig["endPoint"] = config.GetString("DO_SPACES_ENDPOINT", "")
+		providerConfig["accessKeyID"] = config.GetString("DO_SPACES_ACCESS_KEY_ID", "")
+		providerConfig["accessKey"] = config.GetString("DO_SPACES_SECRET_ACCESS_KEY", "")
 	}
 	return providerConfig
 }

--- a/services/filemanager/s3manager.go
+++ b/services/filemanager/s3manager.go
@@ -283,7 +283,7 @@ func GetS3Config(config map[string]interface{}) *S3Config {
 		pkgLogger.Errorf("unable to code config into S3Config: %w", err)
 		s3Config = S3Config{}
 	}
-	regionHint := appConfig.GetEnv("AWS_S3_REGION_HINT", "us-east-1")
+	regionHint := appConfig.GetString("AWS_S3_REGION_HINT", "us-east-1")
 	s3Config.RegionHint = regionHint
 	s3Config.IsTruncated = true
 

--- a/services/multitenant/tenantstats_test.go
+++ b/services/multitenant/tenantstats_test.go
@@ -40,7 +40,7 @@ var (
 var _ = Describe("tenantStats", func() {
 	BeforeEach(func() {
 		metric.GetManager().Reset()
-		config.Load()
+		config.Reset()
 		logger.Init()
 		Init()
 	})

--- a/services/pgnotifier/pgnotifier.go
+++ b/services/pgnotifier/pgnotifier.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"strconv"
 	"time"
 
 	"github.com/allisson/go-pglock/v2"
@@ -84,12 +83,12 @@ type ClaimResponseT struct {
 }
 
 func loadPGNotifierConfig() {
-	pgNotifierDBhost = config.GetEnv("PGNOTIFIER_DB_HOST", "localhost")
-	pgNotifierDBuser = config.GetEnv("PGNOTIFIER_DB_USER", "ubuntu")
-	pgNotifierDBname = config.GetEnv("PGNOTIFIER_DB_NAME", "ubuntu")
-	pgNotifierDBport, _ = strconv.Atoi(config.GetEnv("PGNOTIFIER_DB_PORT", "5432"))
-	pgNotifierDBpassword = config.GetEnv("PGNOTIFIER_DB_PASSWORD", "ubuntu") // Reading secrets from
-	pgNotifierDBsslmode = config.GetEnv("PGNOTIFIER_DB_SSL_MODE", "disable")
+	pgNotifierDBhost = config.GetString("PGNOTIFIER_DB_HOST", "localhost")
+	pgNotifierDBuser = config.GetString("PGNOTIFIER_DB_USER", "ubuntu")
+	pgNotifierDBname = config.GetString("PGNOTIFIER_DB_NAME", "ubuntu")
+	pgNotifierDBport = config.GetInt("PGNOTIFIER_DB_PORT", 5432)
+	pgNotifierDBpassword = config.GetString("PGNOTIFIER_DB_PASSWORD", "ubuntu") // Reading secrets from
+	pgNotifierDBsslmode = config.GetString("PGNOTIFIER_DB_SSL_MODE", "disable")
 	config.RegisterIntConfigVariable(3, &maxAttempt, false, 1, "PgNotifier.maxAttempt")
 	trackBatchInterval = time.Duration(config.GetInt("PgNotifier.trackBatchIntervalInS", 2)) * time.Second
 	config.RegisterDurationConfigVariable(5000, &maxPollSleep, true, time.Millisecond, "PgNotifier.maxPollSleep")
@@ -153,10 +152,10 @@ func (notifier PgNotifierT) ClearJobs(ctx context.Context) (err error) {
 
 // CheckForPGNotifierEnvVars Checks if all the required Env Variables for PG Notifier are present
 func CheckForPGNotifierEnvVars() bool {
-	return config.IsEnvSet("PGNOTIFIER_DB_HOST") &&
-		config.IsEnvSet("PGNOTIFIER_DB_USER") &&
-		config.IsEnvSet("PGNOTIFIER_DB_NAME") &&
-		config.IsEnvSet("PGNOTIFIER_DB_PASSWORD")
+	return config.IsSet("PGNOTIFIER_DB_HOST") &&
+		config.IsSet("PGNOTIFIER_DB_USER") &&
+		config.IsSet("PGNOTIFIER_DB_NAME") &&
+		config.IsSet("PGNOTIFIER_DB_PASSWORD")
 }
 
 // GetPGNotifierConnectionString Returns PG Notifier DB Connection Configuration

--- a/services/stats/stats.go
+++ b/services/stats/stats.go
@@ -55,8 +55,8 @@ var DefaultStats Stats
 func Init() {
 	config.RegisterBoolConfigVariable(true, &statsEnabled, false, "enableStats")
 	config.RegisterStringConfigVariable("influxdb", &statsTagsFormat, false, "statsTagsFormat")
-	statsdServerURL = config.GetEnv("STATSD_SERVER_URL", "localhost:8125")
-	instanceID = config.GetEnv("INSTANCE_ID", "")
+	statsdServerURL = config.GetString("STATSD_SERVER_URL", "localhost:8125")
+	instanceID = config.GetString("INSTANCE_ID", "")
 	config.RegisterBoolConfigVariable(true, &enabled, false, "RuntimeStats.enabled")
 	config.RegisterInt64ConfigVariable(10, &statsCollectionInterval, false, 1, "RuntimeStats.statsCollectionInterval")
 	config.RegisterBoolConfigVariable(true, &enableCPUStats, false, "RuntimeStats.enableCPUStats")
@@ -219,8 +219,8 @@ func CleanupTagsBasedOnDeploymentType(tags Tags, key string) Tags {
 	}
 
 	if deploymentType == deployment.MultiTenantType {
-		isNamespaced := config.IsEnvSet("WORKSPACE_NAMESPACE")
-		if !isNamespaced || (isNamespaced && strings.Contains(config.GetEnv("WORKSPACE_NAMESPACE", ""), "free")) {
+		isNamespaced := config.IsSet("WORKSPACE_NAMESPACE")
+		if !isNamespaced || (isNamespaced && strings.Contains(config.GetString("WORKSPACE_NAMESPACE", ""), "free")) {
 			delete(tags, key)
 		}
 	}

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -179,8 +179,8 @@ var (
 )
 
 func Init() {
-	clientCertFile := config.GetEnv("KAFKA_SSL_CERTIFICATE_FILE_PATH", "")
-	clientKeyFile := config.GetEnv("KAFKA_SSL_KEY_FILE_PATH", "")
+	clientCertFile := config.GetString("KAFKA_SSL_CERTIFICATE_FILE_PATH", "")
+	clientKeyFile := config.GetString("KAFKA_SSL_KEY_FILE_PATH", "")
 	if clientCertFile != "" && clientKeyFile != "" {
 		var err error
 		clientCert, err = os.ReadFile(clientCertFile)

--- a/services/streammanager/streammanager_suite_test.go
+++ b/services/streammanager/streammanager_suite_test.go
@@ -28,7 +28,7 @@ var once sync.Once
 
 func initStreamManager() {
 	once.Do(func() {
-		config.Load()
+		config.Reset()
 		logger.Init()
 		stats.Setup()
 		kafka.Init()

--- a/services/validators/envValidator.go
+++ b/services/validators/envValidator.go
@@ -74,7 +74,6 @@ func insertTokenIfNotExists(dbHandle *sql.DB) {
 func setWHSchemaVersionIfNotExists(dbHandle *sql.DB) {
 	hashedToken := misc.GetMD5Hash(config.GetWorkspaceToken())
 	whSchemaVersion := config.GetString("Warehouse.schemaVersion", "v1")
-	config.SetWHSchemaVersion(whSchemaVersion)
 
 	var parameters sql.NullString
 	sqlStatement := fmt.Sprintf(`SELECT parameters FROM workspace WHERE token = '%s'`, hashedToken)
@@ -102,7 +101,7 @@ func setWHSchemaVersionIfNotExists(dbHandle *sql.DB) {
 		}
 		if version, ok := parametersMap["wh_schema_version"]; ok {
 			whSchemaVersion = version.(string)
-			config.SetWHSchemaVersion(whSchemaVersion)
+			config.Set("Warehouse.schemaVersion", whSchemaVersion)
 			return
 		}
 		parametersMap["wh_schema_version"] = whSchemaVersion
@@ -258,7 +257,7 @@ func CheckAndValidateWorkspaceToken() {
 
 	pkgLogger.Warn("Previous workspace token is not same as the current workspace token. Parking current jobsdb aside and creating a new one")
 
-	dbName := config.GetEnv("JOBS_DB_DB_NAME", "ubuntu")
+	dbName := config.GetString("DB.name", "ubuntu")
 	misc.ReplaceDB(dbName, dbName+"_"+strconv.FormatInt(time.Now().Unix(), 10)+"_"+workspaceTokenHashInDB)
 
 	dbHandle = createDBConnection()

--- a/utils/logger/level.go
+++ b/utils/logger/level.go
@@ -1,0 +1,19 @@
+package logger
+
+const (
+	levelEvent = iota // Logs Event
+	levelDebug        // Most verbose logging level
+	levelInfo         // Logs about state of the application
+	levelWarn         // Logs about warnings
+	levelError        // Logs about errors which dont immediately halt the application
+	levelFatal        // Logs which crashes the application
+)
+
+var levelMap = map[string]int{
+	"EVENT": levelEvent,
+	"DEBUG": levelDebug,
+	"INFO":  levelInfo,
+	"WARN":  levelWarn,
+	"ERROR": levelError,
+	"FATAL": levelFatal,
+}

--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -3,7 +3,6 @@ package misc
 import (
 	"database/sql"
 	"fmt"
-	"strconv"
 
 	"github.com/lib/pq"
 
@@ -22,11 +21,11 @@ var (
 )
 
 func loadConfig() {
-	host = config.GetEnv("JOBS_DB_HOST", "localhost")
-	user = config.GetEnv("JOBS_DB_USER", "ubuntu")
-	port, _ = strconv.Atoi(config.GetEnv("JOBS_DB_PORT", "5432"))
-	password = config.GetEnv("JOBS_DB_PASSWORD", "ubuntu") // Reading secrets from
-	sslmode = config.GetEnv("JOBS_DB_SSL_MODE", "disable")
+	host = config.GetString("DB.host", "localhost")
+	user = config.GetString("DB.user", "ubuntu")
+	port = config.GetInt("DB.port", 5432)
+	password = config.GetString("DB.password", "ubuntu") // Reading secrets from
+	sslmode = config.GetString("DB.sslMode", "disable")
 }
 
 /*

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -331,7 +331,7 @@ func GetReservedFolderPaths() []*RFP {
 		{path: RudderIdentityMappingsTmp, levelsToKeep: 1},
 		{path: RudderRedshiftManifests, levelsToKeep: 0},
 		{path: RudderWarehouseJsonUploadsTmp, levelsToKeep: 2},
-		{path: config.GetEnv("RUDDER_CONNECTION_TESTING_BUCKET_FOLDER_NAME", RudderTestPayload), levelsToKeep: 0},
+		{path: config.GetString("RUDDER_CONNECTION_TESTING_BUCKET_FOLDER_NAME", RudderTestPayload), levelsToKeep: 0},
 	}
 }
 
@@ -401,7 +401,7 @@ var logOnce sync.Once
 
 // CreateTMPDIR creates tmp dir at path configured via RUDDER_TMPDIR env var
 func CreateTMPDIR() (string, error) {
-	tmpdirPath := strings.TrimSuffix(config.GetEnv("RUDDER_TMPDIR", ""), "/")
+	tmpdirPath := strings.TrimSuffix(config.GetString("RUDDER_TMPDIR", ""), "/")
 	// second chance: fallback to /tmp if this folder exists
 	if tmpdirPath == "" {
 		fallbackPath := "/tmp"
@@ -977,25 +977,25 @@ func HasAWSRegionInConfig(config interface{}) bool {
 }
 
 func GetRudderObjectStorageAccessKeys() (accessKeyID, accessKey string) {
-	return config.GetEnv("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY_ID", ""), config.GetEnv("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY", "")
+	return config.GetString("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY_ID", ""), config.GetString("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY", "")
 }
 
 func GetRudderObjectStoragePrefix() (prefix string) {
-	return config.GetEnv("RUDDER_WAREHOUSE_BUCKET_PREFIX", config.GetNamespaceIdentifier())
+	return config.GetString("RUDDER_WAREHOUSE_BUCKET_PREFIX", config.GetNamespaceIdentifier())
 }
 
 func GetRudderObjectStorageConfig(prefixOverride string) (storageConfig map[string]interface{}) {
 	// TODO: add error log if s3 keys are not available
 	storageConfig = make(map[string]interface{})
-	storageConfig["bucketName"] = config.GetEnv("RUDDER_WAREHOUSE_BUCKET", "rudder-warehouse-storage")
-	storageConfig["accessKeyID"] = config.GetEnv("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY_ID", "")
-	storageConfig["accessKey"] = config.GetEnv("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY", "")
-	storageConfig["enableSSE"] = config.GetEnvAsBool("RUDDER_WAREHOUSE_BUCKET_SSE", true)
+	storageConfig["bucketName"] = config.GetString("RUDDER_WAREHOUSE_BUCKET", "rudder-warehouse-storage")
+	storageConfig["accessKeyID"] = config.GetString("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY_ID", "")
+	storageConfig["accessKey"] = config.GetString("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY", "")
+	storageConfig["enableSSE"] = config.GetBool("RUDDER_WAREHOUSE_BUCKET_SSE", true)
 	// set prefix from override for shared slave type nodes
 	if prefixOverride != "" {
 		storageConfig["prefix"] = prefixOverride
 	} else {
-		storageConfig["prefix"] = config.GetEnv("RUDDER_WAREHOUSE_BUCKET_PREFIX", config.GetNamespaceIdentifier())
+		storageConfig["prefix"] = config.GetString("RUDDER_WAREHOUSE_BUCKET_PREFIX", config.GetNamespaceIdentifier())
 	}
 	return
 }
@@ -1029,8 +1029,8 @@ func GetObjectStorageConfig(opts ObjectStorageOptsT) map[string]interface{} {
 		}
 		clonedObjectStorageConfig["externalID"] = opts.WorkspaceID
 		if !HasAWSKeysInConfig(objectStorageConfigMap) {
-			clonedObjectStorageConfig["accessKeyID"] = config.GetEnv("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY_ID", "")
-			clonedObjectStorageConfig["accessKey"] = config.GetEnv("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY", "")
+			clonedObjectStorageConfig["accessKeyID"] = config.GetString("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY_ID", "")
+			clonedObjectStorageConfig["accessKey"] = config.GetString("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY", "")
 		}
 		objectStorageConfigMap = clonedObjectStorageConfig
 	}
@@ -1049,7 +1049,7 @@ func GetSpacesLocation(location string) (region string) {
 
 // GetNodeID returns the nodeId of the current node
 func GetNodeID() string {
-	nodeID := config.GetRequiredEnv("INSTANCE_ID")
+	nodeID := config.MustGetString("INSTANCE_ID")
 	return nodeID
 }
 
@@ -1193,7 +1193,7 @@ func GetWarehouseURL() (url string) {
 	if isWarehouseMasterEnabled() {
 		url = fmt.Sprintf(`http://localhost:%d`, config.GetInt("Warehouse.webPort", 8082))
 	} else {
-		url = config.GetEnv("WAREHOUSE_URL", "http://localhost:8082")
+		url = config.GetString("WAREHOUSE_URL", "http://localhost:8082")
 	}
 	return
 }

--- a/utils/misc/misc_test.go
+++ b/utils/misc/misc_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func initMisc() {
-	config.Load()
+	config.Reset()
 	logger.Init()
 	Init()
 }

--- a/utils/types/deployment/deployment.go
+++ b/utils/types/deployment/deployment.go
@@ -1,6 +1,7 @@
 package deployment
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/rudderlabs/rudder-server/utils/logger"
@@ -27,7 +28,7 @@ const defaultClusterType = DedicatedType
 var pkgLogger = logger.NewLogger().Child("deployment")
 
 func GetFromEnv() (Type, error) {
-	t := Type(config.GetEnv("DEPLOYMENT_TYPE", ""))
+	t := Type(config.GetString("DEPLOYMENT_TYPE", ""))
 	if t == "" {
 		t = defaultClusterType
 	}
@@ -60,24 +61,20 @@ func GetConnectionToken() (string, string, bool, error) {
 	case MultiTenantType:
 		isMultiWorkspace = true
 		tokenType = namespace
-		isNamespaced := config.IsEnvSet("WORKSPACE_NAMESPACE")
+		isNamespaced := config.IsSet("WORKSPACE_NAMESPACE")
 		if isNamespaced {
-			connectionToken, err = config.GetEnvErr("WORKSPACE_NAMESPACE")
-			if err != nil {
-				pkgLogger.Errorf("error getting workspace namespace: %v", err)
-				return "", "", false, err
-			}
+			connectionToken = config.GetString("WORKSPACE_NAMESPACE", "")
 			if connectionToken == hostedNamespace {
 				// CP Router still has some things hardcoded for hosted
 				// which needs to be supported
-				connectionToken = config.GetEnv("HOSTED_SERVICE_SECRET", "")
+				connectionToken = config.GetString("HOSTED_SERVICE_SECRET", "")
 			}
 		} else {
-			connectionToken, err = config.GetEnvErr("HOSTED_SERVICE_SECRET")
-			if err != nil {
-				pkgLogger.Errorf("error getting hosted service secret: %v", err)
-				return "", "", false, err
+			if !config.IsSet("HOSTED_SERVICE_SECRET") {
+				pkgLogger.Error("hosted service secret not set")
+				return "", "", false, errors.New("hosted service secret not set")
 			}
+			connectionToken = config.GetString("HOSTED_SERVICE_SECRET", "")
 		}
 	}
 	return connectionToken, tokenType, isMultiWorkspace, nil

--- a/utils/types/deployment/deployment_test.go
+++ b/utils/types/deployment/deployment_test.go
@@ -91,7 +91,7 @@ func Test_GetFromEnv(t *testing.T) {
 }
 
 func Test_GetConnectionToken(t *testing.T) {
-	config.Load()
+	config.Reset()
 	admin.Init()
 	logger.Init()
 	logger.Init()

--- a/warehouse/api.go
+++ b/warehouse/api.go
@@ -110,11 +110,11 @@ func InitWarehouseAPI(dbHandle *sql.DB, log logger.LoggerI) error {
 			AuthInfo: controlplane.AuthInfo{
 				Service:         "warehouse",
 				ConnectionToken: connectionToken,
-				InstanceID:      config.GetEnv("instance_id", "1"),
+				InstanceID:      config.GetString("INSTANCE_ID", "1"),
 				TokenType:       tokenType,
 			},
 			RetryInterval: 0,
-			UseTLS:        config.GetEnvAsBool("CP_ROUTER_USE_TLS", true),
+			UseTLS:        config.GetBool("CP_ROUTER_USE_TLS", true),
 			Logger:        log,
 			RegisterService: func(srv *grpc.Server) {
 				proto.RegisterWarehouseServer(srv, &warehousegrpc{})

--- a/warehouse/archiver.go
+++ b/warehouse/archiver.go
@@ -80,11 +80,11 @@ func backupRecords(args backupRecordsArgs) (backupLocation string, err error) {
 	defer misc.RemoveFilePaths(path)
 
 	fManager, err := filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
-		Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
+		Provider: config.GetString("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
 		Config:   filemanager.GetProviderConfigForBackupsFromEnv(context.TODO()),
 	})
 	if err != nil {
-		err = fmt.Errorf("Error in creating a file manager for:%s. Error: %w", config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"), err)
+		err = fmt.Errorf("Error in creating a file manager for:%s. Error: %w", config.GetString("JOBS_BACKUP_STORAGE_PROVIDER", "S3"), err)
 		return
 	}
 

--- a/warehouse/configuration_testing/configuration_testing.go
+++ b/warehouse/configuration_testing/configuration_testing.go
@@ -20,7 +20,7 @@ var (
 )
 
 func Init() {
-	connectionTestingFolder = config.GetEnv("RUDDER_CONNECTION_TESTING_BUCKET_FOLDER_NAME", misc.RudderTestPayload)
+	connectionTestingFolder = config.GetString("RUDDER_CONNECTION_TESTING_BUCKET_FOLDER_NAME", misc.RudderTestPayload)
 	pkgLogger = logger.NewLogger().Child("warehouse").Child("configuration_testing")
 	fileManagerFactory = filemanager.DefaultFileManagerFactory
 	fileManagerTimeout = 15 * time.Second

--- a/warehouse/constraint_test.go
+++ b/warehouse/constraint_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var _ = Describe("Constraint", func() {
-	config.Load()
+	config.Reset()
 	logger.Init()
 	Init6()
 

--- a/warehouse/deltalake/deltalake.go
+++ b/warehouse/deltalake/deltalake.go
@@ -186,7 +186,7 @@ func columnsWithValues(keys []string) string {
 
 // GetDatabricksConnectorURL returns databricks connector url.
 func GetDatabricksConnectorURL() string {
-	return config.GetEnv("DATABRICKS_CONNECTOR_URL", "localhost:50051")
+	return config.GetString("DATABRICKS_CONNECTOR_URL", "localhost:50051")
 }
 
 // checkAndIgnoreAlreadyExistError checks and ignores native errors.

--- a/warehouse/identity/identity.go
+++ b/warehouse/identity/identity.go
@@ -418,7 +418,7 @@ func (idr *HandleT) uploadFile(filePath string, txn *sql.Tx, tableName string, t
 		pkgLogger.Errorf("IDR: Error in creating a file manager for :%s: , %v", idr.Warehouse.Destination.DestinationDefinition.Name, err)
 		return err
 	}
-	output, err := uploader.Upload(context.TODO(), outputFile, config.GetEnv("WAREHOUSE_BUCKET_LOAD_OBJECTS_FOLDER_NAME", "rudder-warehouse-load-objects"), tableName, idr.Warehouse.Source.ID, tableName)
+	output, err := uploader.Upload(context.TODO(), outputFile, config.GetString("WAREHOUSE_BUCKET_LOAD_OBJECTS_FOLDER_NAME", "rudder-warehouse-load-objects"), tableName, idr.Warehouse.Source.ID, tableName)
 	if err != nil {
 		return
 	}

--- a/warehouse/redshift/redshift.go
+++ b/warehouse/redshift/redshift.go
@@ -507,8 +507,8 @@ func (rs *HandleT) getTemporaryCredForCopy() (string, string, string, error) {
 		accessKey = warehouseutils.GetConfigValue(AWSAccessKey, rs.Warehouse)
 		accessKeyID = warehouseutils.GetConfigValue(AWSAccessKeyID, rs.Warehouse)
 	} else {
-		accessKeyID = config.GetEnv("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY_ID", "")
-		accessKey = config.GetEnv("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY", "")
+		accessKeyID = config.GetString("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY_ID", "")
+		accessKey = config.GetString("RUDDER_AWS_S3_COPY_USER_ACCESS_KEY", "")
 	}
 	mySession := session.Must(session.NewSession())
 	// Create a STS client from just a session.

--- a/warehouse/scheduling_test.go
+++ b/warehouse/scheduling_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func initWarehouse() {
-	config.Load()
+	config.Reset()
 	admin.Init()
 	logger.Init()
 	Init()

--- a/warehouse/slave.go
+++ b/warehouse/slave.go
@@ -299,7 +299,7 @@ func (jobRun *JobRunT) uploadLoadFileToObjectStorage(uploader filemanager.FileMa
 	if misc.Contains(warehouseutils.TimeWindowDestinations, job.DestinationType) {
 		uploadLocation, err = uploader.Upload(context.TODO(), file, warehouseutils.GetTablePathInObjectStorage(jobRun.job.DestinationNamespace, tableName), job.LoadFilePrefix)
 	} else {
-		uploadLocation, err = uploader.Upload(context.TODO(), file, config.GetEnv("WAREHOUSE_BUCKET_LOAD_OBJECTS_FOLDER_NAME", "rudder-warehouse-load-objects"), tableName, job.SourceID, getBucketFolder(job.UniqueLoadGenID, tableName))
+		uploadLocation, err = uploader.Upload(context.TODO(), file, config.GetString("WAREHOUSE_BUCKET_LOAD_OBJECTS_FOLDER_NAME", "rudder-warehouse-load-objects"), tableName, job.SourceID, getBucketFolder(job.UniqueLoadGenID, tableName))
 	}
 	return uploadLocation, err
 }

--- a/warehouse/testhelper/setup.go
+++ b/warehouse/testhelper/setup.go
@@ -120,7 +120,7 @@ func loadEnv() {
 }
 
 func initialize() {
-	config.Load()
+	config.Reset()
 	admin.Init()
 	logger.Init()
 	misc.Init()
@@ -634,7 +634,7 @@ func Schema(provider, schemaKey string) string {
 		provider,
 		warehouseutils.ToSafeNamespace(
 			provider,
-			config.GetRequiredEnv(schemaKey),
+			config.MustGetString(schemaKey),
 		),
 	)
 }

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -695,7 +695,7 @@ func GetTimeWindow(ts time.Time) time.Time {
 // GetTablePathInObjectStorage returns the path of the table relative to the object storage bucket
 // <$WAREHOUSE_DATALAKE_FOLDER_NAME>/<namespace>/tableName
 func GetTablePathInObjectStorage(namespace, tableName string) string {
-	return fmt.Sprintf("%s/%s/%s", config.GetEnv("WAREHOUSE_DATALAKE_FOLDER_NAME", "rudder-datalake"), namespace, tableName)
+	return fmt.Sprintf("%s/%s/%s", config.GetString("WAREHOUSE_DATALAKE_FOLDER_NAME", "rudder-datalake"), namespace, tableName)
 }
 
 // JoinWithFormatting returns joined string for keys with the provided formatting function.

--- a/warehouse/utils/utils_test.go
+++ b/warehouse/utils/utils_test.go
@@ -30,7 +30,7 @@ func TestDestinationConfigKeys(t *testing.T) {
 
 			whName := WHDestNameMap[whType]
 			configKey := fmt.Sprintf("Warehouse.%s.feature", whName)
-			got := config.ConfigKeyToEnvRudder(configKey)
+			got := config.ConfigKeyToEnv(configKey)
 			expected := fmt.Sprintf("RSERVER_WAREHOUSE_%s_FEATURE", strings.ToUpper(whName))
 			require.Equal(t, got, expected)
 		})

--- a/warehouse/utils/utils_test.go
+++ b/warehouse/utils/utils_test.go
@@ -30,7 +30,7 @@ func TestDestinationConfigKeys(t *testing.T) {
 
 			whName := WHDestNameMap[whType]
 			configKey := fmt.Sprintf("Warehouse.%s.feature", whName)
-			got := config.TransformKey(configKey)
+			got := config.ConfigKeyToEnvRudder(configKey)
 			expected := fmt.Sprintf("RSERVER_WAREHOUSE_%s_FEATURE", strings.ToUpper(whName))
 			require.Equal(t, got, expected)
 		})
@@ -1205,7 +1205,7 @@ var _ = Describe("Utils", func() {
 })
 
 func TestMain(m *testing.M) {
-	config.Load()
+	config.Reset()
 	Init()
 	os.Exit(m.Run())
 }

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -1831,7 +1831,7 @@ func Start(ctx context.Context, app app.Interface) error {
 		backendconfig.DefaultBackendConfig.WaitForConfig(ctx)
 
 		c := features.NewClient(
-			config.GetEnv("CONFIG_BACKEND_URL", "https://api.rudderlabs.com"),
+			config.GetString("CONFIG_BACKEND_URL", "https://api.rudderlabs.com"),
 			backendconfig.DefaultBackendConfig.Identity(),
 		)
 

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -161,12 +161,12 @@ func loadConfig() {
 	inRecoveryMap = map[string]bool{}
 	lastProcessedMarkerMap = map[string]int64{}
 	config.RegisterStringConfigVariable("embedded", &warehouseMode, false, "Warehouse.mode")
-	host = config.GetEnv("WAREHOUSE_JOBS_DB_HOST", "localhost")
-	user = config.GetEnv("WAREHOUSE_JOBS_DB_USER", "ubuntu")
-	dbname = config.GetEnv("WAREHOUSE_JOBS_DB_DB_NAME", "ubuntu")
-	port, _ = strconv.Atoi(config.GetEnv("WAREHOUSE_JOBS_DB_PORT", "5432"))
-	password = config.GetEnv("WAREHOUSE_JOBS_DB_PASSWORD", "ubuntu") // Reading secrets from
-	sslmode = config.GetEnv("WAREHOUSE_JOBS_DB_SSL_MODE", "disable")
+	host = config.GetString("WAREHOUSE_JOBS_DB_HOST", "localhost")
+	user = config.GetString("WAREHOUSE_JOBS_DB_USER", "ubuntu")
+	dbname = config.GetString("WAREHOUSE_JOBS_DB_DB_NAME", "ubuntu")
+	port = config.GetInt("WAREHOUSE_JOBS_DB_PORT", 5432)
+	password = config.GetString("WAREHOUSE_JOBS_DB_PASSWORD", "ubuntu") // Reading secrets from
+	sslmode = config.GetString("WAREHOUSE_JOBS_DB_SSL_MODE", "disable")
 	config.RegisterIntConfigVariable(10, &warehouseSyncPreFetchCount, true, 1, "Warehouse.warehouseSyncPreFetchCount")
 	config.RegisterIntConfigVariable(100, &stagingFilesSchemaPaginationSize, true, 1, "Warehouse.stagingFilesSchemaPaginationSize")
 	config.RegisterBoolConfigVariable(false, &warehouseSyncFreqIgnore, true, "Warehouse.warehouseSyncFreqIgnore")
@@ -179,7 +179,7 @@ func loadConfig() {
 	config.RegisterDurationConfigVariable(120, &longRunningUploadStatThresholdInMin, true, time.Minute, []string{"Warehouse.longRunningUploadStatThreshold", "Warehouse.longRunningUploadStatThresholdInMin"}...)
 	config.RegisterDurationConfigVariable(10, &slaveUploadTimeout, true, time.Minute, []string{"Warehouse.slaveUploadTimeout", "Warehouse.slaveUploadTimeoutInMin"}...)
 	config.RegisterIntConfigVariable(8, &numLoadFileUploadWorkers, true, 1, "Warehouse.numLoadFileUploadWorkers")
-	runningMode = config.GetEnv("RSERVER_WAREHOUSE_RUNNING_MODE", "")
+	runningMode = config.GetString("Warehouse.runningMode", "")
 	config.RegisterDurationConfigVariable(30, &uploadStatusTrackFrequency, false, time.Minute, []string{"Warehouse.uploadStatusTrackFrequency", "Warehouse.uploadStatusTrackFrequencyInMin"}...)
 	config.RegisterIntConfigVariable(180, &uploadBufferTimeInMin, false, 1, "Warehouse.uploadBufferTimeInMin")
 	config.RegisterDurationConfigVariable(5, &uploadAllocatorSleep, false, time.Second, []string{"Warehouse.uploadAllocatorSleep", "Warehouse.uploadAllocatorSleepInS"}...)
@@ -190,7 +190,7 @@ func loadConfig() {
 	config.RegisterIntConfigVariable(8, &maxParallelJobCreation, true, 1, "Warehouse.maxParallelJobCreation")
 	config.RegisterBoolConfigVariable(false, &enableJitterForSyncs, true, "Warehouse.enableJitterForSyncs")
 	appName = misc.DefaultString("rudder-server").OnError(os.Hostname())
-	configBackendURL = config.GetEnv("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
+	configBackendURL = config.GetString("CONFIG_BACKEND_URL", "https://api.rudderlabs.com")
 }
 
 // get name of the worker (`destID_namespace`) to be stored in map wh.workerChannelMap
@@ -1354,7 +1354,7 @@ func setConfigHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, kv := range kvs {
-		config.SetHotReloadablesForcefully(kv.Key, kv.Value)
+		config.Set(kv.Key, kv.Value)
 	}
 	w.WriteHeader(http.StatusOK)
 }
@@ -1714,10 +1714,10 @@ func startWebHandler(ctx context.Context) error {
 
 // CheckForWarehouseEnvVars Checks if all the required Env Variables for Warehouse are present
 func CheckForWarehouseEnvVars() bool {
-	return config.IsEnvSet("WAREHOUSE_JOBS_DB_HOST") &&
-		config.IsEnvSet("WAREHOUSE_JOBS_DB_USER") &&
-		config.IsEnvSet("WAREHOUSE_JOBS_DB_DB_NAME") &&
-		config.IsEnvSet("WAREHOUSE_JOBS_DB_PASSWORD")
+	return config.IsSet("WAREHOUSE_JOBS_DB_HOST") &&
+		config.IsSet("WAREHOUSE_JOBS_DB_USER") &&
+		config.IsSet("WAREHOUSE_JOBS_DB_DB_NAME") &&
+		config.IsSet("WAREHOUSE_JOBS_DB_PASSWORD")
 }
 
 // This checks if gateway is running or not
@@ -1791,7 +1791,7 @@ func Start(ctx context.Context, app app.Interface) error {
 		}
 	}()
 
-	runningMode := config.GetEnv("RSERVER_WAREHOUSE_RUNNING_MODE", "")
+	runningMode := config.GetString("Warehouse.runningMode", "")
 	if runningMode == DegradedMode {
 		pkgLogger.Infof("WH: Running warehouse service in degraded mode...")
 		if isMaster() {


### PR DESCRIPTION
# Description

Refactoring the `config` package and introducing the following features:

1. Support for multiple, independent config instances
2. Thread-safe initialization & reinitialization of config instances (including the default, singleton instance). No more nil pointer dereference panics.
3. Rely exclusively on viper's precedence order (see [doc](https://github.com/rudderlabs/rudder-server/blob/2d9233d62d649c23a57add4868557e71b9b9f2ac/config/config.go#L1-L16) - explicit overrides have higher precedence than environment variables)
4. Support overriding config at runtime, without having to use environment variables, [example](https://github.com/rudderlabs/rudder-server/blob/2d9233d62d649c23a57add4868557e71b9b9f2ac/eventorder_test.go#L106-L135) (thread-safe, see [config.Set](https://github.com/rudderlabs/rudder-server/blob/2d9233d62d649c23a57add4868557e71b9b9f2ac/config/config.go#L238))
5. Remove warehouse-specific code
6. Test coverage is now >80%

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=7968e584d23444028eb75351255f4b30&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
