### PR TITLE
chore: added rudder-server config metrics with version and other details as tag

### DIFF
--- a/main.go
+++ b/main.go
@@ -225,7 +225,8 @@ func Run(ctx context.Context) int {
 	appTypeStr := strings.ToUpper(config.GetEnv("APP_TYPE", app.EMBEDDED))
 	appHandler = apphandlers.GetAppHandler(application, appTypeStr, versionHandler)
 
-	version := versionInfo()
+	versionDetail := versionInfo()
+	stats.NewTaggedStat("rudder_server_config", stats.GaugeType, stats.Tags{"version": version, "major": major, "minor": minor, "patch": patch, "commit": commit, "buildDate": buildDate, "builtBy": builtBy, "gitUrl": gitURL, "TransformerVersion": transformer.GetVersion(), "DatabricksVersion": misc.GetDatabricksVersion()}).Gauge(1)
 	bugsnag.Configure(bugsnag.Configuration{
 		APIKey:       config.GetEnv("BUGSNAG_KEY", ""),
 		ReleaseStage: config.GetEnv("GO_ENV", "development"),
@@ -233,7 +234,7 @@ func Run(ctx context.Context) int {
 		ProjectPackages: []string{"main", "github.com/rudderlabs/rudder-server"},
 		// more configuration options
 		AppType:      appHandler.GetAppType(),
-		AppVersion:   version["Version"].(string),
+		AppVersion:   versionDetail["Version"].(string),
 		PanicHandler: func() {},
 	})
 	ctx = bugsnag.StartSession(ctx)


### PR DESCRIPTION
## Description

Added metrics with following rudder-server config details as tag:-  

- Version
- Major
- Minor
- Patch
- Commit
- BuildDate
- BuiltBy
- GitUrl
- TransformerVersion
- DatabricksVersion

## Notion Ticket

https://www.notion.so/rudderstacks/Report-version-to-metrics-60b766e8186d48adb45621fbdee7e6be