### PR TITLE
fix: close http response body only if there is no error

### DIFF
--- a/services/destination-connection-tester/destination_connection_tester.go
+++ b/services/destination-connection-tester/destination_connection_tester.go
@@ -87,9 +87,9 @@ func makePostRequest(url string, payload interface{}) error {
 
 		resp, err = client.Do(req)
 		if err == nil {
+			resp.Body.Close()
 			break
 		}
-		defer resp.Body.Close()
 
 		pkgLogger.Errorf("DCT: Config Backend connection error", err)
 		if retryCount > maxRetry {


### PR DESCRIPTION
# Description
Treating improper (nil) body close

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
