### PR TITLE
chore: support for opt out from reporting sample event and response

### DIFF
--- a/config/backend-config/backend-config.go
+++ b/config/backend-config/backend-config.go
@@ -51,6 +51,7 @@ type workspaceConfig interface {
 	GetWorkspaceIDForWriteKey(string) string
 	GetWorkspaceIDForSourceID(string) string
 	GetWorkspaceLibrariesForWorkspaceID(string) LibrariesT
+	GetDataRetentionSettingsForWorkspaceID(string) DataRetention
 }
 
 type BackendConfig interface {

--- a/config/backend-config/backend-config.go
+++ b/config/backend-config/backend-config.go
@@ -51,7 +51,7 @@ type workspaceConfig interface {
 	GetWorkspaceIDForWriteKey(string) string
 	GetWorkspaceIDForSourceID(string) string
 	GetWorkspaceLibrariesForWorkspaceID(string) LibrariesT
-	GetDataRetentionSettingsForWorkspaceID(string) DataRetention
+	DataRetentionSettings(workspaceID string) DataRetention
 }
 
 type BackendConfig interface {

--- a/config/backend-config/mock_workspaceconfig.go
+++ b/config/backend-config/mock_workspaceconfig.go
@@ -64,6 +64,20 @@ func (mr *MockworkspaceConfigMockRecorder) Get(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockworkspaceConfig)(nil).Get), arg0, arg1)
 }
 
+// GetDataRetentionSettingsForWorkspaceID mocks base method.
+func (m *MockworkspaceConfig) GetDataRetentionSettingsForWorkspaceID(arg0 string) DataRetention {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDataRetentionSettingsForWorkspaceID", arg0)
+	ret0, _ := ret[0].(DataRetention)
+	return ret0
+}
+
+// GetDataRetentionSettingsForWorkspaceID indicates an expected call of GetDataRetentionSettingsForWorkspaceID.
+func (mr *MockworkspaceConfigMockRecorder) GetDataRetentionSettingsForWorkspaceID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataRetentionSettingsForWorkspaceID", reflect.TypeOf((*MockworkspaceConfig)(nil).GetDataRetentionSettingsForWorkspaceID), arg0)
+}
+
 // GetWorkspaceIDForSourceID mocks base method.
 func (m *MockworkspaceConfig) GetWorkspaceIDForSourceID(arg0 string) string {
 	m.ctrl.T.Helper()
@@ -170,6 +184,20 @@ func (m *MockBackendConfig) Get(arg0 context.Context, arg1 string) (ConfigT, err
 func (mr *MockBackendConfigMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBackendConfig)(nil).Get), arg0, arg1)
+}
+
+// GetDataRetentionSettingsForWorkspaceID mocks base method.
+func (m *MockBackendConfig) GetDataRetentionSettingsForWorkspaceID(arg0 string) DataRetention {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDataRetentionSettingsForWorkspaceID", arg0)
+	ret0, _ := ret[0].(DataRetention)
+	return ret0
+}
+
+// GetDataRetentionSettingsForWorkspaceID indicates an expected call of GetDataRetentionSettingsForWorkspaceID.
+func (mr *MockBackendConfigMockRecorder) GetDataRetentionSettingsForWorkspaceID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataRetentionSettingsForWorkspaceID", reflect.TypeOf((*MockBackendConfig)(nil).GetDataRetentionSettingsForWorkspaceID), arg0)
 }
 
 // GetWorkspaceIDForSourceID mocks base method.

--- a/config/backend-config/mock_workspaceconfig.go
+++ b/config/backend-config/mock_workspaceconfig.go
@@ -49,6 +49,20 @@ func (mr *MockworkspaceConfigMockRecorder) AccessToken() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccessToken", reflect.TypeOf((*MockworkspaceConfig)(nil).AccessToken))
 }
 
+// DataRetentionSettings mocks base method.
+func (m *MockworkspaceConfig) DataRetentionSettings(workspaceID string) DataRetention {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DataRetentionSettings", workspaceID)
+	ret0, _ := ret[0].(DataRetention)
+	return ret0
+}
+
+// DataRetentionSettings indicates an expected call of DataRetentionSettings.
+func (mr *MockworkspaceConfigMockRecorder) DataRetentionSettings(workspaceID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataRetentionSettings", reflect.TypeOf((*MockworkspaceConfig)(nil).DataRetentionSettings), workspaceID)
+}
+
 // Get mocks base method.
 func (m *MockworkspaceConfig) Get(arg0 context.Context, arg1 string) (ConfigT, error) {
 	m.ctrl.T.Helper()
@@ -62,20 +76,6 @@ func (m *MockworkspaceConfig) Get(arg0 context.Context, arg1 string) (ConfigT, e
 func (mr *MockworkspaceConfigMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockworkspaceConfig)(nil).Get), arg0, arg1)
-}
-
-// GetDataRetentionSettingsForWorkspaceID mocks base method.
-func (m *MockworkspaceConfig) GetDataRetentionSettingsForWorkspaceID(arg0 string) DataRetention {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDataRetentionSettingsForWorkspaceID", arg0)
-	ret0, _ := ret[0].(DataRetention)
-	return ret0
-}
-
-// GetDataRetentionSettingsForWorkspaceID indicates an expected call of GetDataRetentionSettingsForWorkspaceID.
-func (mr *MockworkspaceConfigMockRecorder) GetDataRetentionSettingsForWorkspaceID(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataRetentionSettingsForWorkspaceID", reflect.TypeOf((*MockworkspaceConfig)(nil).GetDataRetentionSettingsForWorkspaceID), arg0)
 }
 
 // GetWorkspaceIDForSourceID mocks base method.
@@ -171,6 +171,20 @@ func (mr *MockBackendConfigMockRecorder) AccessToken() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccessToken", reflect.TypeOf((*MockBackendConfig)(nil).AccessToken))
 }
 
+// DataRetentionSettings mocks base method.
+func (m *MockBackendConfig) DataRetentionSettings(workspaceID string) DataRetention {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DataRetentionSettings", workspaceID)
+	ret0, _ := ret[0].(DataRetention)
+	return ret0
+}
+
+// DataRetentionSettings indicates an expected call of DataRetentionSettings.
+func (mr *MockBackendConfigMockRecorder) DataRetentionSettings(workspaceID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataRetentionSettings", reflect.TypeOf((*MockBackendConfig)(nil).DataRetentionSettings), workspaceID)
+}
+
 // Get mocks base method.
 func (m *MockBackendConfig) Get(arg0 context.Context, arg1 string) (ConfigT, error) {
 	m.ctrl.T.Helper()
@@ -184,20 +198,6 @@ func (m *MockBackendConfig) Get(arg0 context.Context, arg1 string) (ConfigT, err
 func (mr *MockBackendConfigMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBackendConfig)(nil).Get), arg0, arg1)
-}
-
-// GetDataRetentionSettingsForWorkspaceID mocks base method.
-func (m *MockBackendConfig) GetDataRetentionSettingsForWorkspaceID(arg0 string) DataRetention {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDataRetentionSettingsForWorkspaceID", arg0)
-	ret0, _ := ret[0].(DataRetention)
-	return ret0
-}
-
-// GetDataRetentionSettingsForWorkspaceID indicates an expected call of GetDataRetentionSettingsForWorkspaceID.
-func (mr *MockBackendConfigMockRecorder) GetDataRetentionSettingsForWorkspaceID(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataRetentionSettingsForWorkspaceID", reflect.TypeOf((*MockBackendConfig)(nil).GetDataRetentionSettingsForWorkspaceID), arg0)
 }
 
 // GetWorkspaceIDForSourceID mocks base method.

--- a/config/backend-config/multitenant_workspaces.go
+++ b/config/backend-config/multitenant_workspaces.go
@@ -85,7 +85,7 @@ func (wc *multiTenantWorkspacesConfig) GetWorkspaceLibrariesForWorkspaceID(works
 	return LibrariesT{}
 }
 
-func (wc *multiTenantWorkspacesConfig) GetDataRetentionSettingsForWorkspaceID(workspaceID string) DataRetention {
+func (wc *multiTenantWorkspacesConfig) DataRetentionSettings(workspaceID string) DataRetention {
 	wc.workspaceWriteKeysMapLock.RLock()
 	defer wc.workspaceWriteKeysMapLock.RUnlock()
 

--- a/config/backend-config/multitenant_workspaces_test.go
+++ b/config/backend-config/multitenant_workspaces_test.go
@@ -91,6 +91,23 @@ func TestMultiTenantWorkspacesConfig_GetWorkspaceLibrariesForWorkspaceID(t *test
 	})
 }
 
+func TestMultiTenantWorkspacesConfig_GetDataRetentionSettingsForWorkspaceID(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		workspaceID1 := "some-workspace-id1"
+		workspaceID2 := "some-workspace-id2"
+		dataRetentionW1 := DataRetention{EnableReportingPii: true}
+		dataRetentionW2 := DataRetention{EnableReportingPii: false}
+		wc := &multiTenantWorkspacesConfig{
+			workspaceIDToDataRetentionMap: map[string]DataRetention{
+				workspaceID1: dataRetentionW1,
+				workspaceID2: dataRetentionW2,
+			},
+		}
+		require.Equal(t, dataRetentionW1, wc.GetDataRetentionSettingsForWorkspaceID(workspaceID1))
+		require.Equal(t, dataRetentionW2, wc.GetDataRetentionSettingsForWorkspaceID(workspaceID2))
+	})
+}
+
 func TestMultiTenantWorkspacesConfig_Get(t *testing.T) {
 	initBackendConfig()
 

--- a/config/backend-config/multitenant_workspaces_test.go
+++ b/config/backend-config/multitenant_workspaces_test.go
@@ -91,20 +91,20 @@ func TestMultiTenantWorkspacesConfig_GetWorkspaceLibrariesForWorkspaceID(t *test
 	})
 }
 
-func TestMultiTenantWorkspacesConfig_GetDataRetentionSettingsForWorkspaceID(t *testing.T) {
+func TestMultiTenantWorkspacesConfig_DataRetentionSettings(t *testing.T) {
 	t.Run("found", func(t *testing.T) {
 		workspaceID1 := "some-workspace-id1"
 		workspaceID2 := "some-workspace-id2"
-		dataRetentionW1 := DataRetention{EnableReportingPii: true}
-		dataRetentionW2 := DataRetention{EnableReportingPii: false}
+		dataRetentionW1 := DataRetention{EnableReportingPII: true}
+		dataRetentionW2 := DataRetention{EnableReportingPII: false}
 		wc := &multiTenantWorkspacesConfig{
 			workspaceIDToDataRetentionMap: map[string]DataRetention{
 				workspaceID1: dataRetentionW1,
 				workspaceID2: dataRetentionW2,
 			},
 		}
-		require.Equal(t, dataRetentionW1, wc.GetDataRetentionSettingsForWorkspaceID(workspaceID1))
-		require.Equal(t, dataRetentionW2, wc.GetDataRetentionSettingsForWorkspaceID(workspaceID2))
+		require.Equal(t, dataRetentionW1, wc.DataRetentionSettings(workspaceID1))
+		require.Equal(t, dataRetentionW2, wc.DataRetentionSettings(workspaceID2))
 	})
 }
 

--- a/config/backend-config/namespace_config.go
+++ b/config/backend-config/namespace_config.go
@@ -103,8 +103,8 @@ func (nc *namespaceConfig) GetWorkspaceLibrariesForWorkspaceID(workspaceID strin
 	return LibrariesT{}
 }
 
-// GetDataRetentionSettingsForWorkspaceID returns dataRetention settings for workspaceID
-func (nc *namespaceConfig) GetDataRetentionSettingsForWorkspaceID(workspaceID string) DataRetention {
+// DataRetentionSettings returns dataRetention settings for workspaceID
+func (nc *namespaceConfig) DataRetentionSettings(workspaceID string) DataRetention {
 	nc.mapsMutex.RLock()
 	defer nc.mapsMutex.RUnlock()
 

--- a/config/backend-config/namespace_config_test.go
+++ b/config/backend-config/namespace_config_test.go
@@ -100,10 +100,11 @@ func Test_Namespace_Get(t *testing.T) {
 	}
 
 	t.Log("correct workspaceID to dataRetention settings mapping")
-	w1DataRetention := DataRetention{EnableReportingPii: true}
-	w2DataRetention := DataRetention{EnableReportingPii: false}
-	require.Equal(t, w1DataRetention, client.GetDataRetentionSettingsForWorkspaceID(workspaceID1))
-	require.Equal(t, w2DataRetention, client.GetDataRetentionSettingsForWorkspaceID(workspaceID2))
+	w1DataRetention := DataRetention{EnableReportingPII: true}
+	w2DataRetention := DataRetention{EnableReportingPII: false}
+	require.Equal(t, w1DataRetention, client.DataRetentionSettings(workspaceID1))
+	require.Equal(t, w2DataRetention, client.DataRetentionSettings(workspaceID2))
+	require.Equal(t, w2DataRetention, client.DataRetentionSettings("NON-EXISTENT"))
 
 	t.Run("Invalid credentials", func(t *testing.T) {
 		client := &namespaceConfig{

--- a/config/backend-config/namespace_config_test.go
+++ b/config/backend-config/namespace_config_test.go
@@ -99,6 +99,12 @@ func Test_Namespace_Get(t *testing.T) {
 		)
 	}
 
+	t.Log("correct workspaceID to dataRetention settings mapping")
+	w1DataRetention := DataRetention{EnableReportingPii: true}
+	w2DataRetention := DataRetention{EnableReportingPii: false}
+	require.Equal(t, w1DataRetention, client.GetDataRetentionSettingsForWorkspaceID(workspaceID1))
+	require.Equal(t, w2DataRetention, client.GetDataRetentionSettingsForWorkspaceID(workspaceID2))
+
 	t.Run("Invalid credentials", func(t *testing.T) {
 		client := &namespaceConfig{
 			Client:           ts.Client(),

--- a/config/backend-config/single_workspace.go
+++ b/config/backend-config/single_workspace.go
@@ -73,8 +73,8 @@ func (wc *singleWorkspaceConfig) GetWorkspaceLibrariesForWorkspaceID(workspaceID
 	return wc.workspaceIDToLibrariesMap[workspaceID]
 }
 
-// GetDataRetentionSettingsForWorkspaceID returns dataRetention settings for workspaceID
-func (wc *singleWorkspaceConfig) GetDataRetentionSettingsForWorkspaceID(workspaceID string) DataRetention {
+// DataRetentionSettings returns dataRetention settings for workspaceID
+func (wc *singleWorkspaceConfig) DataRetentionSettings(workspaceID string) DataRetention {
 	wc.workspaceIDLock.RLock()
 	defer wc.workspaceIDLock.RUnlock()
 

--- a/config/backend-config/testdata/sample_namespace.json
+++ b/config/backend-config/testdata/sample_namespace.json
@@ -851,7 +851,12 @@
             {
                 "versionId": "2AWIMafC3YPKHXazWWvVn5hSGnR"
             }
-        ]
+        ],
+        "settings": {
+            "dataRetention": {
+                "enableReportingPii": true
+            }
+        }
     },
     "2CChLejq5aIWi3qsKVm1PjHkyTj": {
         "sources": [
@@ -989,6 +994,11 @@
             {
                 "versionId": "2AWIMafC3YPKHXazWWvVn5hSGnR"
             }
-        ]
+        ],
+        "settings": {
+            "dataRetention": {
+                "enableReportingPii": false
+            }
+        }
     }
 }

--- a/config/backend-config/types.go
+++ b/config/backend-config/types.go
@@ -100,7 +100,7 @@ type Settings struct {
 }
 
 type DataRetention struct {
-	EnableReportingPii     bool          `json:"enableReportingPii"`
+	EnableReportingPII     bool          `json:"enableReportingPii"`
 	UseRudderServerStorage bool          `json:"useRudderServerStorage"`
 	StorageBucket          StorageBucket `json:"storageBucket"`
 }

--- a/config/backend-config/types.go
+++ b/config/backend-config/types.go
@@ -87,11 +87,21 @@ type ConfigT struct {
 	Sources         []SourceT       `json:"sources"`
 	Libraries       LibrariesT      `json:"libraries"`
 	ConnectionFlags ConnectionFlags `json:"flags"`
+	Settings        Settings        `json:"settings"`
 }
 
 type ConnectionFlags struct {
 	URL      string          `json:"url"`
 	Services map[string]bool `json:"services"`
+}
+
+type Settings struct {
+	DataRetention DataRetention `json:"dataRetention"`
+}
+
+type DataRetention struct {
+	EnableReportingPii     bool `json:"enableReportingPii"`
+	UseRudderServerStorage bool `json:"useRudderServerStorage"`
 }
 
 type WRegulationsT struct {

--- a/config/backend-config/types.go
+++ b/config/backend-config/types.go
@@ -100,8 +100,14 @@ type Settings struct {
 }
 
 type DataRetention struct {
-	EnableReportingPii     bool `json:"enableReportingPii"`
-	UseRudderServerStorage bool `json:"useRudderServerStorage"`
+	EnableReportingPii     bool          `json:"enableReportingPii"`
+	UseRudderServerStorage bool          `json:"useRudderServerStorage"`
+	StorageBucket          StorageBucket `json:"storageBucket"`
+}
+
+type StorageBucket struct {
+	Provider string                 `json:"type"`
+	Config   map[string]interface{} `json:"config"`
 }
 
 type WRegulationsT struct {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -250,3 +250,5 @@ PgNotifier:
   retriggerCount: 500
   trackBatchInterval: 2s
   maxAttempt: 3
+Reporting:
+  piiColumnstoExclude: sample_event,sample_response

--- a/enterprise/replay/setup.go
+++ b/enterprise/replay/setup.go
@@ -29,10 +29,9 @@ func initFileManager() (filemanager.FileManager, string, error) {
 		panic("Bucket is not configured.")
 	}
 
-	provider := config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3")
 	fileManagerFactory := filemanager.DefaultFileManagerFactory
 
-	configFromEnv := filemanager.GetProviderConfigForBackupsFromEnv(context.TODO())
+	provider, configFromEnv := filemanager.GetBackupStorageConfig(context.TODO())
 	uploader, err := fileManagerFactory.New(&filemanager.SettingsT{
 		Provider: provider,
 		Config: misc.GetObjectStorageConfig(misc.ObjectStorageOptsT{

--- a/enterprise/reporting/config_noop_test.go
+++ b/enterprise/reporting/config_noop_test.go
@@ -35,6 +35,10 @@ func (*NOOPConfig) GetWorkspaceLibrariesForWorkspaceID(string) backendconfig.Lib
 	return backendconfig.LibrariesT{}
 }
 
+func (*NOOPConfig) GetDataRetentionSettingsForWorkspaceID(string) backendconfig.DataRetention {
+	return backendconfig.DataRetention{}
+}
+
 func (*NOOPConfig) WaitForConfig(_ context.Context) {}
 
 func (*NOOPConfig) Subscribe(ctx context.Context, _ backendconfig.Topic) pubsub.DataChannel {

--- a/enterprise/reporting/config_noop_test.go
+++ b/enterprise/reporting/config_noop_test.go
@@ -35,7 +35,7 @@ func (*NOOPConfig) GetWorkspaceLibrariesForWorkspaceID(string) backendconfig.Lib
 	return backendconfig.LibrariesT{}
 }
 
-func (*NOOPConfig) GetDataRetentionSettingsForWorkspaceID(string) backendconfig.DataRetention {
+func (*NOOPConfig) DataRetentionSettings(string) backendconfig.DataRetention {
 	return backendconfig.DataRetention{}
 }
 

--- a/enterprise/reporting/noop.go
+++ b/enterprise/reporting/noop.go
@@ -10,7 +10,7 @@ import (
 // NOOP reporting implementation that does nothing
 type NOOP struct{}
 
-func (n *NOOP) Report(metrics []*types.PUReportedMetric, txn *sql.Tx) {
+func (n *NOOP) Report(ctx context.Context, metrics []*types.PUReportedMetric, txn *sql.Tx) {
 }
 
 func (n *NOOP) WaitForSetup(ctx context.Context, clientName string) {

--- a/enterprise/reporting/noop.go
+++ b/enterprise/reporting/noop.go
@@ -10,7 +10,7 @@ import (
 // NOOP reporting implementation that does nothing
 type NOOP struct{}
 
-func (n *NOOP) Report(ctx context.Context, metrics []*types.PUReportedMetric, txn *sql.Tx) {
+func (*NOOP) Report(_ context.Context, _ []*types.PUReportedMetric, _ *sql.Tx) {
 }
 
 func (n *NOOP) WaitForSetup(ctx context.Context, clientName string) {

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -468,7 +468,7 @@ func (handle *HandleT) Report(ctx context.Context, metrics []*types.PUReportedMe
 	defer stmt.Close()
 
 	backendconfig.DefaultBackendConfig.WaitForConfig(ctx)
-	piiReportingEnabled := backendconfig.DefaultBackendConfig.GetDataRetentionSettingsForWorkspaceID(handle.workspaceID).EnableReportingPii
+	piiReportingEnabled := backendconfig.DefaultBackendConfig.DataRetentionSettings(handle.workspaceID).EnableReportingPII
 
 	reportedAt := time.Now().UTC().Unix() / 60
 	for _, metric := range metrics {

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -3609,9 +3609,10 @@ func (jd *HandleT) getBackUpQuery(backupDSRange *dataSetRangeT, isJobStatusTable
 func (jd *HandleT) getFileUploader(ctx context.Context) (filemanager.FileManager, error) {
 	var err error
 	if jd.jobsFileUploader == nil {
+		provider, config := filemanager.GetBackupStorageConfig(ctx)
 		jd.jobsFileUploader, err = filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
-			Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
-			Config:   filemanager.GetProviderConfigForBackupsFromEnv(ctx),
+			Provider: provider,
+			Config:   config,
 		})
 	}
 	return jd.jobsFileUploader, err

--- a/mocks/config/backend-config/mock_backendconfig.go
+++ b/mocks/config/backend-config/mock_backendconfig.go
@@ -50,6 +50,20 @@ func (mr *MockBackendConfigMockRecorder) AccessToken() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccessToken", reflect.TypeOf((*MockBackendConfig)(nil).AccessToken))
 }
 
+// DataRetentionSettings mocks base method.
+func (m *MockBackendConfig) DataRetentionSettings(arg0 string) backendconfig.DataRetention {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DataRetentionSettings", arg0)
+	ret0, _ := ret[0].(backendconfig.DataRetention)
+	return ret0
+}
+
+// DataRetentionSettings indicates an expected call of DataRetentionSettings.
+func (mr *MockBackendConfigMockRecorder) DataRetentionSettings(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataRetentionSettings", reflect.TypeOf((*MockBackendConfig)(nil).DataRetentionSettings), arg0)
+}
+
 // Get mocks base method.
 func (m *MockBackendConfig) Get(arg0 context.Context, arg1 string) (backendconfig.ConfigT, error) {
 	m.ctrl.T.Helper()
@@ -63,20 +77,6 @@ func (m *MockBackendConfig) Get(arg0 context.Context, arg1 string) (backendconfi
 func (mr *MockBackendConfigMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBackendConfig)(nil).Get), arg0, arg1)
-}
-
-// GetDataRetentionSettingsForWorkspaceID mocks base method.
-func (m *MockBackendConfig) GetDataRetentionSettingsForWorkspaceID(arg0 string) backendconfig.DataRetention {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDataRetentionSettingsForWorkspaceID", arg0)
-	ret0, _ := ret[0].(backendconfig.DataRetention)
-	return ret0
-}
-
-// GetDataRetentionSettingsForWorkspaceID indicates an expected call of GetDataRetentionSettingsForWorkspaceID.
-func (mr *MockBackendConfigMockRecorder) GetDataRetentionSettingsForWorkspaceID(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataRetentionSettingsForWorkspaceID", reflect.TypeOf((*MockBackendConfig)(nil).GetDataRetentionSettingsForWorkspaceID), arg0)
 }
 
 // GetWorkspaceIDForSourceID mocks base method.

--- a/mocks/config/backend-config/mock_backendconfig.go
+++ b/mocks/config/backend-config/mock_backendconfig.go
@@ -65,6 +65,20 @@ func (mr *MockBackendConfigMockRecorder) Get(arg0, arg1 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBackendConfig)(nil).Get), arg0, arg1)
 }
 
+// GetDataRetentionSettingsForWorkspaceID mocks base method.
+func (m *MockBackendConfig) GetDataRetentionSettingsForWorkspaceID(arg0 string) backendconfig.DataRetention {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDataRetentionSettingsForWorkspaceID", arg0)
+	ret0, _ := ret[0].(backendconfig.DataRetention)
+	return ret0
+}
+
+// GetDataRetentionSettingsForWorkspaceID indicates an expected call of GetDataRetentionSettingsForWorkspaceID.
+func (mr *MockBackendConfigMockRecorder) GetDataRetentionSettingsForWorkspaceID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataRetentionSettingsForWorkspaceID", reflect.TypeOf((*MockBackendConfig)(nil).GetDataRetentionSettingsForWorkspaceID), arg0)
+}
+
 // GetWorkspaceIDForSourceID mocks base method.
 func (m *MockBackendConfig) GetWorkspaceIDForSourceID(arg0 string) string {
 	m.ctrl.T.Helper()

--- a/mocks/utils/types/mock_types.go
+++ b/mocks/utils/types/mock_types.go
@@ -86,15 +86,15 @@ func (mr *MockReportingIMockRecorder) AddClient(arg0, arg1 interface{}) *gomock.
 }
 
 // Report mocks base method.
-func (m *MockReportingI) Report(arg0 []*types.PUReportedMetric, arg1 *sql.Tx) {
+func (m *MockReportingI) Report(arg0 context.Context, arg1 []*types.PUReportedMetric, arg2 *sql.Tx) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Report", arg0, arg1)
+	m.ctrl.Call(m, "Report", arg0, arg1, arg2)
 }
 
 // Report indicates an expected call of Report.
-func (mr *MockReportingIMockRecorder) Report(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockReportingIMockRecorder) Report(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockReportingI)(nil).Report), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockReportingI)(nil).Report), arg0, arg1, arg2)
 }
 
 // WaitForSetup mocks base method.

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -47,7 +47,7 @@ type reportingNOOP struct{}
 func (*reportingNOOP) WaitForSetup(_ context.Context, _ string) {
 }
 
-func (*reportingNOOP) Report(_ []*utilTypes.PUReportedMetric, _ *sql.Tx) {
+func (*reportingNOOP) Report(_ context.Context, _ []*utilTypes.PUReportedMetric, _ *sql.Tx) {
 }
 
 func (*reportingNOOP) AddClient(_ context.Context, _ utilTypes.Config) {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1668,7 +1668,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 			}
 
 			if proc.isReportingEnabled() {
-				proc.reporting.Report(in.reportMetrics, tx.Tx())
+				proc.reporting.Report(ctx, in.reportMetrics, tx.Tx())
 			}
 
 			if enableDedup {

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -113,16 +113,15 @@ func backupEnabled() bool {
 
 func (st *HandleT) setupFileUploader(ctx context.Context) {
 	if backupEnabled() {
-		provider := config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "")
-		bucket := config.GetEnv("JOBS_BACKUP_BUCKET", "")
-		if provider != "" && bucket != "" {
+		provider, config := filemanager.GetBackupStorageConfig(ctx)
+		if provider != "" {
 			var err error
 			st.errFileUploader, err = filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
 				Provider: provider,
-				Config:   filemanager.GetProviderConfigForBackupsFromEnv(ctx),
+				Config:   config,
 			})
 			if err != nil {
-				panic(err)
+				pkgLogger.Errorf("[[ Stash ]] Error creating file manager: %s", err.Error())
 			}
 		}
 	}

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1366,7 +1366,7 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 				router.GetFailedEventsManager().SaveFailedRecordIDs(jobRunIDAbortedEventsMap, tx.Tx())
 			}
 			if brt.reporting != nil && brt.reportingEnabled {
-				brt.reporting.Report(context.TODO(), reportMetrics, tx.Tx())
+				brt.reporting.Report(ctx, reportMetrics, tx.Tx())
 			}
 			return nil
 		})

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1366,7 +1366,7 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 				router.GetFailedEventsManager().SaveFailedRecordIDs(jobRunIDAbortedEventsMap, tx.Tx())
 			}
 			if brt.reporting != nil && brt.reportingEnabled {
-				brt.reporting.Report(reportMetrics, tx.Tx())
+				brt.reporting.Report(context.TODO(), reportMetrics, tx.Tx())
 			}
 			return nil
 		})

--- a/router/manager/manager_test.go
+++ b/router/manager/manager_test.go
@@ -121,7 +121,7 @@ type reportingNOOP struct{}
 func (*reportingNOOP) WaitForSetup(ctx context.Context, clientName string) {
 }
 
-func (*reportingNOOP) Report(metrics []*utilTypes.PUReportedMetric, txn *sql.Tx) {
+func (*reportingNOOP) Report(ctx context.Context, metrics []*utilTypes.PUReportedMetric, txn *sql.Tx) {
 }
 
 func (*reportingNOOP) AddClient(ctx context.Context, c utilTypes.Config) {

--- a/router/router.go
+++ b/router/router.go
@@ -46,7 +46,7 @@ import (
 
 type reporter interface {
 	WaitForSetup(ctx context.Context, clientName string)
-	Report(metrics []*utilTypes.PUReportedMetric, txn *sql.Tx)
+	Report(ctx context.Context, metrics []*utilTypes.PUReportedMetric, txn *sql.Tx)
 }
 
 type tenantStats interface {
@@ -1445,7 +1445,7 @@ func (rt *HandleT) commitStatusList(responseList *[]jobResponseT) {
 				if len(jobRunIDAbortedEventsMap) > 0 {
 					GetFailedEventsManager().SaveFailedRecordIDs(jobRunIDAbortedEventsMap, tx.Tx())
 				}
-				rt.Reporting.Report(reportMetrics, tx.Tx())
+				rt.Reporting.Report(ctx, reportMetrics, tx.Tx())
 				return nil
 			})
 		})
@@ -1890,7 +1890,7 @@ func (rt *HandleT) readAndProcess() int {
 					return err
 				}
 
-				rt.Reporting.Report(reportMetrics, tx.Tx())
+				rt.Reporting.Report(ctx, reportMetrics, tx.Tx())
 				return nil
 			})
 		})

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -132,8 +132,8 @@ var (
 
 type reportingNOOP struct{}
 
-func (*reportingNOOP) WaitForSetup(_ context.Context, _ string)          {}
-func (*reportingNOOP) Report(_ []*utilTypes.PUReportedMetric, _ *sql.Tx) {}
+func (*reportingNOOP) WaitForSetup(_ context.Context, _ string)                             {}
+func (*reportingNOOP) Report(_ context.Context, _ []*utilTypes.PUReportedMetric, _ *sql.Tx) {}
 
 type testContext struct {
 	asyncHelper     testutils.AsyncTestHelper

--- a/services/archiver/archiver.go
+++ b/services/archiver/archiver.go
@@ -80,12 +80,14 @@ func ArchiveOldRecords(tableName, tsColumn string, archivalTimeInDays int, dbHan
 	)
 	defer os.Remove(path)
 
+	provider, providerConfig := filemanager.GetBackupStorageConfig(context.TODO())
 	fManager, err := filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
-		Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
-		Config:   filemanager.GetProviderConfigForBackupsFromEnv(context.TODO()),
+		Provider: provider,
+		Config:   providerConfig,
 	})
 	if err != nil {
 		pkgLogger.Errorf("[Archiver]: Error in creating a file manager for :%s: , %v", config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"), err)
+		return
 	}
 
 	tableJSONArchiver := tablearchiver.TableJSONArchiver{

--- a/services/filemanager/filemanager.go
+++ b/services/filemanager/filemanager.go
@@ -92,18 +92,14 @@ func GetBackupStorageConfig(ctx context.Context) (string, map[string]interface{}
 	backendconfig.DefaultBackendConfig.WaitForConfig(ctx)
 	// TODO: Adapt for multi-tenancy
 	workspaceID := backendconfig.DefaultBackendConfig.GetWorkspaceIDForWriteKey("")
-	useRudderStorage := backendconfig.DefaultBackendConfig.GetDataRetentionSettingsForWorkspaceID(workspaceID).UseRudderServerStorage
 
+	retentionSettings := backendconfig.DefaultBackendConfig.DataRetentionSettings(workspaceID)
+	useRudderStorage := retentionSettings.UseRudderServerStorage
 	if useRudderStorage {
 		return getProviderAndConfigForBackupsFromEnv()
-	} else {
-		return getProviderAndConfigForBackupsFromWorkspaceSettings(backendconfig.DefaultBackendConfig.GetDataRetentionSettingsForWorkspaceID(workspaceID).StorageBucket)
 	}
-}
 
-// getProviderAndConfigForBackupsFromWorkspaceSettings returns the provider config from the workspace settings
-func getProviderAndConfigForBackupsFromWorkspaceSettings(bucket backendconfig.StorageBucket) (string, map[string]interface{}) {
-	return bucket.Provider, bucket.Config
+	return retentionSettings.StorageBucket.Provider, retentionSettings.StorageBucket.Config
 }
 
 // getProviderAndConfigForBackupsFromEnv returns the provider config from env

--- a/utils/types/types.go
+++ b/utils/types/types.go
@@ -48,7 +48,7 @@ type ConfigEnvI interface {
 type ReportingI interface {
 	WaitForSetup(ctx context.Context, clientName string)
 	AddClient(ctx context.Context, c Config)
-	Report(metrics []*PUReportedMetric, txn *sql.Tx)
+	Report(ctx context.Context, metrics []*PUReportedMetric, txn *sql.Tx)
 }
 
 // ConfigT simple map config structure

--- a/warehouse/archiver.go
+++ b/warehouse/archiver.go
@@ -79,9 +79,10 @@ func backupRecords(args backupRecordsArgs) (backupLocation string, err error) {
 	)
 	defer misc.RemoveFilePaths(path)
 
+	provider, providerConfig := filemanager.GetBackupStorageConfig(context.TODO())
 	fManager, err := filemanager.DefaultFileManagerFactory.New(&filemanager.SettingsT{
-		Provider: config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"),
-		Config:   filemanager.GetProviderConfigForBackupsFromEnv(context.TODO()),
+		Provider: provider,
+		Config:   providerConfig,
 	})
 	if err != nil {
 		err = fmt.Errorf("Error in creating a file manager for:%s. Error: %w", config.GetEnv("JOBS_BACKUP_STORAGE_PROVIDER", "S3"), err)

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -1239,7 +1239,7 @@ func (job *UploadJobT) setUploadStatus(statusOpts UploadStatusOpts) (err error) 
 		}
 
 		if config.GetBool("Reporting.enabled", types.DEFAULT_REPORTING_ENABLED) {
-			application.Features().Reporting.GetReportingInstance().Report([]*types.PUReportedMetric{&statusOpts.ReportingMetric}, txn)
+			application.Features().Reporting.GetReportingInstance().Report(context.TODO(), []*types.PUReportedMetric{&statusOpts.ReportingMetric}, txn)
 		}
 		err = txn.Commit()
 		return err
@@ -1516,7 +1516,7 @@ func (job *UploadJobT) setUploadError(statusError error, state string) (string, 
 		})
 	}
 	if config.GetBool("Reporting.enabled", types.DEFAULT_REPORTING_ENABLED) {
-		application.Features().Reporting.GetReportingInstance().Report(reportingMetrics, txn)
+		application.Features().Reporting.GetReportingInstance().Report(context.TODO(), reportingMetrics, txn)
 	}
 	err = txn.Commit()
 


### PR DESCRIPTION
# Description

Adds data retention support.
a. Filter columns before sending reports to reporting service based on user settings.
b. Use storage settings from workspace config.

Data retention notion doc: https://www.notion.so/rudderstacks/Data-Retention-8293118d1665485cbf11fee62b60b908

## Notion Ticket

https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=0c07cea477ad4f55812f10fda68589f7&pm=s

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
