### PR TITLE
feat: changes to support variadic keys for deletion from API dest.

### DIFF
--- a/regulation-worker/cmd/main_test.go
+++ b/regulation-worker/cmd/main_test.go
@@ -392,7 +392,7 @@ func insertRedisData(t *testing.T, address string) {
 func insertMinioData(t *testing.T) {
 	t.Helper()
 
-	// getting list of files in `testData` directory while will be used to testing filemanager.
+	// getting list of files in `testData` directory which will be used to test filemanager.
 	err := filepath.Walk(searchDir, func(path string, f os.FileInfo, err error) error {
 		if regexRequiredSuffix.MatchString(path) {
 			fileList = append(fileList, path)

--- a/regulation-worker/internal/client/client.go
+++ b/regulation-worker/internal/client/client.go
@@ -164,14 +164,14 @@ func prepURL(url string, params ...string) string {
 }
 
 func mapPayloadToJob(wjs jobSchema, workspaceID string) (model.Job, error) {
-	usrAttribute := make([]model.UserAttribute, len(wjs.UserAttributes))
+	usrAttribute := make([]model.User, len(wjs.UserAttributes))
 	for i, usrAttr := range wjs.UserAttributes {
-		usrAttribute[i].Opts = make(map[string]string)
+		usrAttribute[i].Attributes = make(map[string]string)
 		for key, value := range usrAttr {
 			if key == "userId" {
-				usrAttribute[i].UserID = value
+				usrAttribute[i].ID = value
 			} else {
-				usrAttribute[i].Opts[key] = value
+				usrAttribute[i].Attributes[key] = value
 			}
 		}
 	}

--- a/regulation-worker/internal/client/client.go
+++ b/regulation-worker/internal/client/client.go
@@ -182,10 +182,10 @@ func mapPayloadToJob(wjs jobSchema, workspaceID string) (model.Job, error) {
 	}
 
 	return model.Job{
-		ID:             jobID,
-		WorkspaceID:    workspaceID,
-		DestinationID:  wjs.DestinationID,
-		Status:         model.JobStatusRunning,
-		UserAttributes: usrAttribute,
+		ID:            jobID,
+		WorkspaceID:   workspaceID,
+		DestinationID: wjs.DestinationID,
+		Status:        model.JobStatusRunning,
+		Users:         usrAttribute,
 	}, nil
 }

--- a/regulation-worker/internal/client/client.go
+++ b/regulation-worker/internal/client/client.go
@@ -165,11 +165,14 @@ func prepURL(url string, params ...string) string {
 
 func mapPayloadToJob(wjs jobSchema, workspaceID string) (model.Job, error) {
 	usrAttribute := make([]model.UserAttribute, len(wjs.UserAttributes))
-	for i := 0; i < len(wjs.UserAttributes); i++ {
-		usrAttribute[i] = model.UserAttribute{
-			UserID: wjs.UserAttributes[i].UserID,
-			Phone:  wjs.UserAttributes[i].Phone,
-			Email:  wjs.UserAttributes[i].Email,
+	for i, usrAttr := range wjs.UserAttributes {
+		usrAttribute[i].Opts = make(map[string]string)
+		for key, value := range usrAttr {
+			if key == "userId" {
+				usrAttribute[i].UserID = value.(string)
+			} else {
+				usrAttribute[i].Opts[key] = value.(string)
+			}
 		}
 	}
 	jobID, err := strconv.Atoi(wjs.JobID)

--- a/regulation-worker/internal/client/client.go
+++ b/regulation-worker/internal/client/client.go
@@ -169,9 +169,9 @@ func mapPayloadToJob(wjs jobSchema, workspaceID string) (model.Job, error) {
 		usrAttribute[i].Opts = make(map[string]string)
 		for key, value := range usrAttr {
 			if key == "userId" {
-				usrAttribute[i].UserID = value.(string)
+				usrAttribute[i].UserID = value
 			} else {
-				usrAttribute[i].Opts[key] = value.(string)
+				usrAttribute[i].Opts[key] = value
 			}
 		}
 	}

--- a/regulation-worker/internal/client/client_test.go
+++ b/regulation-worker/internal/client/client_test.go
@@ -60,7 +60,7 @@ func TestGet(t *testing.T) {
 			}
 			job, err := c.Get(context.Background())
 			require.Equal(t, tt.expectedErr, err)
-			require.Equal(t, tt.expectedUsrAttributeCount, len(job.UserAttributes), "no of users different than expected")
+			require.Equal(t, tt.expectedUsrAttributeCount, len(job.Users), "no of users different than expected")
 			t.Log("actual job:", job)
 		})
 	}

--- a/regulation-worker/internal/client/client_test.go
+++ b/regulation-worker/internal/client/client_test.go
@@ -28,9 +28,9 @@ func TestGet(t *testing.T) {
 		{
 			name:                      "Get request to get job: successful",
 			workspaceID:               "1001",
-			respBody:                  `{"jobId":"1","destinationId":"23","userAttributes":[{"userId":"1","phone":"555-555-5555"},{"userId":"2","email":"john@example.com"}]}`,
+			respBody:                  `{"jobId":"1","destinationId":"23","userAttributes":[{"userId":"1","phone":"555-555-5555"},{"userId":"2","email":"john@example.com"},{"userId":"3","randomKey":"randomValue"}]}`,
 			respCode:                  200,
-			expectedUsrAttributeCount: 2,
+			expectedUsrAttributeCount: 3,
 		},
 		{
 			name:        "Get request to get job: NoRunnableJob found",

--- a/regulation-worker/internal/client/schema.go
+++ b/regulation-worker/internal/client/schema.go
@@ -10,4 +10,4 @@ type statusJobSchema struct {
 	Status string `json:"status"`
 }
 
-type userAttributesSchema map[string]interface{}
+type userAttributesSchema map[string]string

--- a/regulation-worker/internal/client/schema.go
+++ b/regulation-worker/internal/client/schema.go
@@ -10,8 +10,4 @@ type statusJobSchema struct {
 	Status string `json:"status"`
 }
 
-type userAttributesSchema struct {
-	UserID string  `json:"userId"`
-	Phone  *string `json:"phone,omitempty"`
-	Email  *string `json:"email,omitempty"`
-}
+type userAttributesSchema map[string]interface{}

--- a/regulation-worker/internal/delete/api/api.go
+++ b/regulation-worker/internal/delete/api/api.go
@@ -117,8 +117,8 @@ func mapJobToPayload(job model.Job, destName string, destConfig map[string]inter
 	uas := make([]userAttributesSchema, len(job.UserAttributes))
 	for i, ua := range job.UserAttributes {
 		uas[i] = make(map[string]string)
-		uas[i]["userId"] = ua.UserID
-		for k, v := range ua.Opts {
+		uas[i]["userId"] = ua.ID
+		for k, v := range ua.Attributes {
 			uas[i][k] = v
 		}
 	}

--- a/regulation-worker/internal/delete/api/api.go
+++ b/regulation-worker/internal/delete/api/api.go
@@ -116,11 +116,10 @@ func (bm *APIManager) GetSupportedDestinations() []string {
 func mapJobToPayload(job model.Job, destName string, destConfig map[string]interface{}) []apiDeletionPayloadSchema {
 	uas := make([]userAttributesSchema, len(job.UserAttributes))
 	for i, ua := range job.UserAttributes {
-		uas[i] = userAttributesSchema{
-			UserID: ua.UserID,
-
-			Phone: ua.Phone,
-			Email: ua.Email,
+		uas[i] = make(map[string]string)
+		uas[i]["userId"] = ua.UserID
+		for k, v := range ua.Opts {
+			uas[i][k] = v
 		}
 	}
 

--- a/regulation-worker/internal/delete/api/api.go
+++ b/regulation-worker/internal/delete/api/api.go
@@ -114,8 +114,8 @@ func (bm *APIManager) GetSupportedDestinations() []string {
 }
 
 func mapJobToPayload(job model.Job, destName string, destConfig map[string]interface{}) []apiDeletionPayloadSchema {
-	uas := make([]userAttributesSchema, len(job.UserAttributes))
-	for i, ua := range job.UserAttributes {
+	uas := make([]userAttributesSchema, len(job.Users))
+	for i, ua := range job.Users {
 		uas[i] = make(map[string]string)
 		uas[i]["userId"] = ua.ID
 		for k, v := range ua.Attributes {

--- a/regulation-worker/internal/delete/api/api_test.go
+++ b/regulation-worker/internal/delete/api/api_test.go
@@ -43,7 +43,7 @@ func TestDelete(t *testing.T) {
 				WorkspaceID:   "1001",
 				DestinationID: "1234",
 				Status:        model.JobStatusPending,
-				UserAttributes: []model.User{
+				Users: []model.User{
 					{
 						ID: "Jermaine1473336609491897794707338",
 						Attributes: map[string]string{

--- a/regulation-worker/internal/delete/api/api_test.go
+++ b/regulation-worker/internal/delete/api/api_test.go
@@ -43,24 +43,24 @@ func TestDelete(t *testing.T) {
 				WorkspaceID:   "1001",
 				DestinationID: "1234",
 				Status:        model.JobStatusPending,
-				UserAttributes: []model.UserAttribute{
+				UserAttributes: []model.User{
 					{
-						UserID: "Jermaine1473336609491897794707338",
-						Opts: map[string]string{
+						ID: "Jermaine1473336609491897794707338",
+						Attributes: map[string]string{
 							"phone":     "6463633841",
 							"email":     "dorowane8n285680461479465450293436@gmail.com",
 							"randomKey": "randomValue",
 						},
 					},
 					{
-						UserID: "Mercie8221821544021583104106123",
-						Opts: map[string]string{
+						ID: "Mercie8221821544021583104106123",
+						Attributes: map[string]string{
 							"email": "dshirilad8536019424659691213279980@gmail.com",
 						},
 					},
 					{
-						UserID: "Claiborn443446989226249191822329",
-						Opts: map[string]string{
+						ID: "Claiborn443446989226249191822329",
+						Attributes: map[string]string{
 							"phone": "8782905113",
 						},
 					},

--- a/regulation-worker/internal/delete/api/api_test.go
+++ b/regulation-worker/internal/delete/api/api_test.go
@@ -46,16 +46,22 @@ func TestDelete(t *testing.T) {
 				UserAttributes: []model.UserAttribute{
 					{
 						UserID: "Jermaine1473336609491897794707338",
-						Phone:  strPtr("6463633841"),
-						Email:  strPtr("dorowane8n285680461479465450293436@gmail.com"),
+						Opts: map[string]string{
+							"phone": "6463633841",
+							"email": "dorowane8n285680461479465450293436@gmail.com",
+						},
 					},
 					{
 						UserID: "Mercie8221821544021583104106123",
-						Email:  strPtr("dshirilad8536019424659691213279980@gmail.com"),
+						Opts: map[string]string{
+							"email": "dshirilad8536019424659691213279980@gmail.com",
+						},
 					},
 					{
 						UserID: "Claiborn443446989226249191822329",
-						Phone:  strPtr("8782905113"),
+						Opts: map[string]string{
+							"phone": "8782905113",
+						},
 					},
 				},
 			},
@@ -70,7 +76,7 @@ func TestDelete(t *testing.T) {
 			respCode:             200,
 			respBodyStatus:       "complete",
 			expectedDeleteStatus: model.JobStatusComplete,
-			expectedPayload:      `[{"jobId":"1","destType":"amplitude","config":{"accessKey":"xyz","accessKeyID":"abc","bucketName":"regulation-test-data","enableSSE":false,"prefix":"reg-original"},"userAttributes":[{"userId":"Jermaine1473336609491897794707338","phone":"6463633841","email":"dorowane8n285680461479465450293436@gmail.com"},{"userId":"Mercie8221821544021583104106123","email":"dshirilad8536019424659691213279980@gmail.com"},{"userId":"Claiborn443446989226249191822329","phone":"8782905113"}]}]`,
+			expectedPayload:      `[{"jobId":"1","destType":"amplitude","config":{"accessKey":"xyz","accessKeyID":"abc","bucketName":"regulation-test-data","enableSSE":false,"prefix":"reg-original"},"userAttributes":[{"email":"dorowane8n285680461479465450293436@gmail.com","phone":"6463633841","userId":"Jermaine1473336609491897794707338"},{"email":"dshirilad8536019424659691213279980@gmail.com","userId":"Mercie8221821544021583104106123"},{"phone":"8782905113","userId":"Claiborn443446989226249191822329"}]}]`,
 		},
 		{
 			name:                 "test deleter API client with expected status failed: error returned 429",
@@ -177,8 +183,4 @@ func (d *deleteAPI) deleteMockServer(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
-}
-
-func strPtr(str string) *string {
-	return &(str)
 }

--- a/regulation-worker/internal/delete/api/api_test.go
+++ b/regulation-worker/internal/delete/api/api_test.go
@@ -47,8 +47,9 @@ func TestDelete(t *testing.T) {
 					{
 						UserID: "Jermaine1473336609491897794707338",
 						Opts: map[string]string{
-							"phone": "6463633841",
-							"email": "dorowane8n285680461479465450293436@gmail.com",
+							"phone":     "6463633841",
+							"email":     "dorowane8n285680461479465450293436@gmail.com",
+							"randomKey": "randomValue",
 						},
 					},
 					{
@@ -76,7 +77,7 @@ func TestDelete(t *testing.T) {
 			respCode:             200,
 			respBodyStatus:       "complete",
 			expectedDeleteStatus: model.JobStatusComplete,
-			expectedPayload:      `[{"jobId":"1","destType":"amplitude","config":{"accessKey":"xyz","accessKeyID":"abc","bucketName":"regulation-test-data","enableSSE":false,"prefix":"reg-original"},"userAttributes":[{"email":"dorowane8n285680461479465450293436@gmail.com","phone":"6463633841","userId":"Jermaine1473336609491897794707338"},{"email":"dshirilad8536019424659691213279980@gmail.com","userId":"Mercie8221821544021583104106123"},{"phone":"8782905113","userId":"Claiborn443446989226249191822329"}]}]`,
+			expectedPayload:      `[{"jobId":"1","destType":"amplitude","config":{"accessKey":"xyz","accessKeyID":"abc","bucketName":"regulation-test-data","enableSSE":false,"prefix":"reg-original"},"userAttributes":[{"email":"dorowane8n285680461479465450293436@gmail.com","phone":"6463633841","randomKey":"randomValue","userId":"Jermaine1473336609491897794707338"},{"email":"dshirilad8536019424659691213279980@gmail.com","userId":"Mercie8221821544021583104106123"},{"phone":"8782905113","userId":"Claiborn443446989226249191822329"}]}]`,
 		},
 		{
 			name:                 "test deleter API client with expected status failed: error returned 429",

--- a/regulation-worker/internal/delete/api/schema.go
+++ b/regulation-worker/internal/delete/api/schema.go
@@ -1,10 +1,6 @@
 package api
 
-type userAttributesSchema struct {
-	UserID string  `json:"userId"`
-	Phone  *string `json:"phone,omitempty"`
-	Email  *string `json:"email,omitempty"`
-}
+type userAttributesSchema map[string]string
 
 type apiDeletionPayloadSchema struct {
 	JobID          string                 `json:"jobId"`

--- a/regulation-worker/internal/delete/batch/batch.go
+++ b/regulation-worker/internal/delete/batch/batch.go
@@ -338,7 +338,7 @@ func (b *Batch) upload(ctx context.Context, uploadFileAbsPath, actualFileName, a
 	return nil
 }
 
-func (b *Batch) createPatternFile(userAttributes []model.UserAttribute) (string, error) {
+func (b *Batch) createPatternFile(userAttributes []model.User) (string, error) {
 	pkgLogger.Debug("creating a file with pattern to be searched & deleted.")
 
 	searchObject := make([]byte, 0)
@@ -346,20 +346,20 @@ func (b *Batch) createPatternFile(userAttributes []model.UserAttribute) (string,
 	for _, users := range userAttributes {
 		searchObject = append(searchObject, "/"...)
 		searchObject = append(searchObject, "\"userId\": *\""...)
-		searchObject = append(searchObject, users.UserID...)
+		searchObject = append(searchObject, users.ID...)
 		searchObject = append(searchObject, "\"/d;"...)
 
-		if users.Opts["email"] != "" {
+		if users.Attributes["email"] != "" {
 			searchObject = append(searchObject, "/"...)
 			searchObject = append(searchObject, "\"email\": *\""...)
-			searchObject = append(searchObject, []byte(users.Opts["email"])...)
+			searchObject = append(searchObject, []byte(users.Attributes["email"])...)
 			searchObject = append(searchObject, "\"/d;"...)
 		}
 
-		if users.Opts["phone"] != "" {
+		if users.Attributes["phone"] != "" {
 			searchObject = append(searchObject, "/"...)
 			searchObject = append(searchObject, "\"phone\": *\""...)
-			searchObject = append(searchObject, []byte(users.Opts["phone"])...)
+			searchObject = append(searchObject, []byte(users.Attributes["phone"])...)
 			searchObject = append(searchObject, "\"/d;"...)
 		}
 	}

--- a/regulation-worker/internal/delete/batch/batch.go
+++ b/regulation-worker/internal/delete/batch/batch.go
@@ -423,7 +423,7 @@ func (bm *BatchManager) Delete(ctx context.Context, job model.Job, destConfig ma
 	defer batch.cleanup(destConfig["prefix"].(string))
 
 	// file with pattern to be searched & deleted from all downloaded files.
-	absPatternFile, err := batch.createPatternFile(job.UserAttributes)
+	absPatternFile, err := batch.createPatternFile(job.Users)
 	if err != nil {
 		pkgLogger.Errorf("error while creating pattern file: %v", err)
 		return model.JobStatusFailed

--- a/regulation-worker/internal/delete/batch/batch.go
+++ b/regulation-worker/internal/delete/batch/batch.go
@@ -349,17 +349,17 @@ func (b *Batch) createPatternFile(userAttributes []model.UserAttribute) (string,
 		searchObject = append(searchObject, users.UserID...)
 		searchObject = append(searchObject, "\"/d;"...)
 
-		if users.Email != nil {
+		if users.Opts["email"] != "" {
 			searchObject = append(searchObject, "/"...)
 			searchObject = append(searchObject, "\"email\": *\""...)
-			searchObject = append(searchObject, []byte(*users.Email)...)
+			searchObject = append(searchObject, []byte(users.Opts["email"])...)
 			searchObject = append(searchObject, "\"/d;"...)
 		}
 
-		if users.Phone != nil {
+		if users.Opts["phone"] != "" {
 			searchObject = append(searchObject, "/"...)
 			searchObject = append(searchObject, "\"phone\": *\""...)
-			searchObject = append(searchObject, []byte(*users.Phone)...)
+			searchObject = append(searchObject, []byte(users.Opts["phone"])...)
 			searchObject = append(searchObject, "\"/d;"...)
 		}
 	}

--- a/regulation-worker/internal/delete/batch/batch.go
+++ b/regulation-worker/internal/delete/batch/batch.go
@@ -348,20 +348,6 @@ func (b *Batch) createPatternFile(userAttributes []model.User) (string, error) {
 		searchObject = append(searchObject, "\"userId\": *\""...)
 		searchObject = append(searchObject, users.ID...)
 		searchObject = append(searchObject, "\"/d;"...)
-
-		if users.Attributes["email"] != "" {
-			searchObject = append(searchObject, "/"...)
-			searchObject = append(searchObject, "\"email\": *\""...)
-			searchObject = append(searchObject, []byte(users.Attributes["email"])...)
-			searchObject = append(searchObject, "\"/d;"...)
-		}
-
-		if users.Attributes["phone"] != "" {
-			searchObject = append(searchObject, "/"...)
-			searchObject = append(searchObject, "\"phone\": *\""...)
-			searchObject = append(searchObject, []byte(users.Attributes["phone"])...)
-			searchObject = append(searchObject, "\"/d;"...)
-		}
 	}
 
 	PatternFilePtr, err := os.CreateTemp(b.TmpDirPath, "")

--- a/regulation-worker/internal/delete/batch/batch_test.go
+++ b/regulation-worker/internal/delete/batch/batch_test.go
@@ -48,16 +48,22 @@ func TestBatchDelete(t *testing.T) {
 				UserAttributes: []model.UserAttribute{
 					{
 						UserID: "Jermaine1473336609491897794707338",
-						Phone:  strPtr("6463633841"),
-						Email:  strPtr("dorowane8n285680461479465450293436@gmail.com"),
+						Opts: map[string]string{
+							"phone": "6463633841",
+							"email": "dorowane8n285680461479465450293436@gmail.com",
+						},
 					},
 					{
 						UserID: "Mercie8221821544021583104106123",
-						Email:  strPtr("dshirilad8536019424659691213279980@gmail.com"),
+						Opts: map[string]string{
+							"email": "dshirilad8536019424659691213279980@gmail.com",
+						},
 					},
 					{
 						UserID: "Claiborn443446989226249191822329",
-						Phone:  strPtr("8782905113"),
+						Opts: map[string]string{
+							"phone": "8782905113",
+						},
 					},
 				},
 			},
@@ -136,10 +142,6 @@ func TestBatchDelete(t *testing.T) {
 			}
 		})
 	}
-}
-
-func strPtr(str string) *string {
-	return &(str)
 }
 
 type mockFileManagerFactory struct{}

--- a/regulation-worker/internal/delete/batch/batch_test.go
+++ b/regulation-worker/internal/delete/batch/batch_test.go
@@ -45,7 +45,7 @@ func TestBatchDelete(t *testing.T) {
 				WorkspaceID:   "1001",
 				DestinationID: "1234",
 				Status:        model.JobStatusPending,
-				UserAttributes: []model.User{
+				Users: []model.User{
 					{
 						ID: "Jermaine1473336609491897794707338",
 						Attributes: map[string]string{

--- a/regulation-worker/internal/delete/batch/batch_test.go
+++ b/regulation-worker/internal/delete/batch/batch_test.go
@@ -45,23 +45,23 @@ func TestBatchDelete(t *testing.T) {
 				WorkspaceID:   "1001",
 				DestinationID: "1234",
 				Status:        model.JobStatusPending,
-				UserAttributes: []model.UserAttribute{
+				UserAttributes: []model.User{
 					{
-						UserID: "Jermaine1473336609491897794707338",
-						Opts: map[string]string{
+						ID: "Jermaine1473336609491897794707338",
+						Attributes: map[string]string{
 							"phone": "6463633841",
 							"email": "dorowane8n285680461479465450293436@gmail.com",
 						},
 					},
 					{
-						UserID: "Mercie8221821544021583104106123",
-						Opts: map[string]string{
+						ID: "Mercie8221821544021583104106123",
+						Attributes: map[string]string{
 							"email": "dshirilad8536019424659691213279980@gmail.com",
 						},
 					},
 					{
-						UserID: "Claiborn443446989226249191822329",
-						Opts: map[string]string{
+						ID: "Claiborn443446989226249191822329",
+						Attributes: map[string]string{
 							"phone": "8782905113",
 						},
 					},

--- a/regulation-worker/internal/delete/kvstore/kvstore.go
+++ b/regulation-worker/internal/delete/kvstore/kvstore.go
@@ -28,7 +28,7 @@ func (kv *KVDeleteManager) Delete(ctx context.Context, job model.Job, destConfig
 	fileCleaningTime := stats.NewTaggedStat("file_cleaning_time", stats.TimerType, stats.Tags{"jobId": fmt.Sprintf("%d", job.ID), "workspaceId": job.WorkspaceID, "destType": "kvstore", "destName": destName})
 	fileCleaningTime.Start()
 	defer fileCleaningTime.End()
-	for _, user := range job.UserAttributes {
+	for _, user := range job.Users {
 		key := fmt.Sprintf("user:%s", user.ID)
 		err = kvm.DeleteKey(key)
 		if err != nil {

--- a/regulation-worker/internal/delete/kvstore/kvstore.go
+++ b/regulation-worker/internal/delete/kvstore/kvstore.go
@@ -29,10 +29,10 @@ func (kv *KVDeleteManager) Delete(ctx context.Context, job model.Job, destConfig
 	fileCleaningTime.Start()
 	defer fileCleaningTime.End()
 	for _, user := range job.UserAttributes {
-		key := fmt.Sprintf("user:%s", user.UserID)
+		key := fmt.Sprintf("user:%s", user.ID)
 		err = kvm.DeleteKey(key)
 		if err != nil {
-			pkgLogger.Errorf("failed to delete user: %v", user.UserID, "with error: %v", err)
+			pkgLogger.Errorf("failed to delete user: %v", user.ID, "with error: %v", err)
 			return model.JobStatusFailed
 		}
 	}

--- a/regulation-worker/internal/delete/kvstore/kvstore_test.go
+++ b/regulation-worker/internal/delete/kvstore/kvstore_test.go
@@ -143,10 +143,10 @@ func TestRedisDeletion(t *testing.T) {
 
 	deleteJob := model.Job{
 		ID: 1,
-		UserAttributes: []model.UserAttribute{
+		UserAttributes: []model.User{
 			{
-				UserID: "Jermaine1473336609491897794707338",
-				Opts: map[string]string{
+				ID: "Jermaine1473336609491897794707338",
+				Attributes: map[string]string{
 					"phone": "6463633841",
 					"email": "dorowane8n285680461479465450293436@gmail.com",
 				},

--- a/regulation-worker/internal/delete/kvstore/kvstore_test.go
+++ b/regulation-worker/internal/delete/kvstore/kvstore_test.go
@@ -143,7 +143,7 @@ func TestRedisDeletion(t *testing.T) {
 
 	deleteJob := model.Job{
 		ID: 1,
-		UserAttributes: []model.User{
+		Users: []model.User{
 			{
 				ID: "Jermaine1473336609491897794707338",
 				Attributes: map[string]string{

--- a/regulation-worker/internal/delete/kvstore/kvstore_test.go
+++ b/regulation-worker/internal/delete/kvstore/kvstore_test.go
@@ -146,8 +146,10 @@ func TestRedisDeletion(t *testing.T) {
 		UserAttributes: []model.UserAttribute{
 			{
 				UserID: "Jermaine1473336609491897794707338",
-				Phone:  strPtr("6463633841"),
-				Email:  strPtr("dorowane8n285680461479465450293436@gmail.com"),
+				Opts: map[string]string{
+					"phone": "6463633841",
+					"email": "dorowane8n285680461479465450293436@gmail.com",
+				},
 			},
 		},
 	}
@@ -177,8 +179,4 @@ func TestGetSupportedDestination(t *testing.T) {
 	kvm := kvstore.KVDeleteManager{}
 	actualSupportedDest := kvm.GetSupportedDestinations()
 	require.Equal(t, expectedDestinations, actualSupportedDest, "actual supported destinatins different than expected")
-}
-
-func strPtr(str string) *string {
-	return &str
 }

--- a/regulation-worker/internal/model/model.go
+++ b/regulation-worker/internal/model/model.go
@@ -26,12 +26,12 @@ const (
 )
 
 type Job struct {
-	ID             int
-	WorkspaceID    string
-	DestinationID  string
-	Status         JobStatus
-	UserAttributes []User
-	UpdatedAt      time.Time
+	ID            int
+	WorkspaceID   string
+	DestinationID string
+	Status        JobStatus
+	Users         []User
+	UpdatedAt     time.Time
 }
 
 type User struct {

--- a/regulation-worker/internal/model/model.go
+++ b/regulation-worker/internal/model/model.go
@@ -30,13 +30,13 @@ type Job struct {
 	WorkspaceID    string
 	DestinationID  string
 	Status         JobStatus
-	UserAttributes []UserAttribute
+	UserAttributes []User
 	UpdatedAt      time.Time
 }
 
-type UserAttribute struct {
-	UserID string
-	Opts   map[string]string
+type User struct {
+	ID         string
+	Attributes map[string]string
 }
 
 type Destination struct {

--- a/regulation-worker/internal/model/model.go
+++ b/regulation-worker/internal/model/model.go
@@ -36,8 +36,7 @@ type Job struct {
 
 type UserAttribute struct {
 	UserID string
-	Phone  *string
-	Email  *string
+	Opts   map[string]string
 }
 
 type Destination struct {


### PR DESCRIPTION
# Description
>Currently, when we sent request to transformer to further call down stream destination to perform deletion, the `userAttributes` section of the request can only have `userID` (required), `phone` (optional) & `email` (optional). We are modifying it to support variadic keys with only `userID` as required field.

## Notion Ticket

https://www.notion.so/rudderstacks/data-regulation-worker-support-key-value-user-attributes-1771ea8b38ac43d1a09e6ada68f2ce83
