### PR TITLE
feat(warehouse): added error handling for syncs errors

### DIFF
--- a/warehouse/errors.go
+++ b/warehouse/errors.go
@@ -32,10 +32,11 @@ func (err *SyncsErr) Error() string {
 }
 
 func (err *SyncsErr) canSkipError() bool {
-	if err.DestinationType == "" {
+	skipErrorCodes, ok := skipErrorCodesMap[DestinationType(err.DestinationType)]
+	if !ok {
 		return false
 	}
-	for _, errorCode := range skipErrorCodesMap[DestinationType(err.DestinationType)] {
+	for _, errorCode := range skipErrorCodes {
 		if ErrorCode(err.Code) == errorCode {
 			return true
 		}

--- a/warehouse/errors.go
+++ b/warehouse/errors.go
@@ -1,0 +1,54 @@
+package warehouse
+
+import (
+	"errors"
+	"fmt"
+	"github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+type ErrorCode int
+
+type DestinationType string
+
+type SyncsErr struct {
+	Base            error
+	Code            int
+	Operation       string
+	DestinationType string
+}
+
+var skipErrorCodesMap = map[DestinationType][]ErrorCode{
+	warehouseutils.SNOWFLAKE: {
+		42501,
+	},
+}
+
+func (err *SyncsErr) Error() string {
+	if err.Operation != "" {
+		return fmt.Sprintf("failed with err: %s for operation: %s", err.Base.Error(), err.Operation)
+	}
+	return fmt.Sprintf("failed with err: %s", err.Base.Error())
+}
+
+func (err *SyncsErr) canSkipError() bool {
+	if err.DestinationType == "" {
+		return false
+	}
+	for _, errorCode := range skipErrorCodesMap[DestinationType(err.DestinationType)] {
+		if ErrorCode(err.Code) == errorCode {
+			return true
+		}
+	}
+	return false
+}
+
+func extractSyncError(err error) error {
+	var syncsErr *SyncsErr
+	if errors.As(err, &syncsErr) {
+		return syncsErr
+	}
+
+	return &SyncsErr{
+		Base: err,
+	}
+}

--- a/warehouse/errors.go
+++ b/warehouse/errors.go
@@ -3,6 +3,7 @@ package warehouse
 import (
 	"errors"
 	"fmt"
+
 	"github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 


### PR DESCRIPTION
# Description

Proper error handling for warehouse modules to handle these cases:

- Customer doesn’t need to be exposed about the internal of the Rudderstack error **where and what** it is happening in the Rudderstack codebase.
- We also wanted to capture these error so that we can categorize them as customer specific ot not. Since not 100% of the errors can be captured with the confgiration tests we are running after getting some error during the syncs. [[CFD](https://www.notion.so/Snowflake-Insufficient-Privilege-1a28817ff72a46aabe7548dc3c22cc89)](https://www.notion.so/Snowflake-Insufficient-Privilege-1a28817ff72a46aabe7548dc3c22cc89).
- Currently there is no difference between what should be shown to the customers and what we should log it.
- How should we expose the defaults error which is happening during the processing of syncs on the Rudderstacks end.
- Error exposed to the customer around the syncs dashboard. Since these looks like cryptic errors and customer doesn’t know what going behind the scenes. We should just show plain vanilla errors for the actions we are getting.

## Notion Ticket

https://www.notion.so/rudderstacks/Error-handling-f8245e749399460eb271b7cba0e01589

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
