### PR TITLE
chore: introduced context aware locking mechanism.

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -315,7 +315,7 @@ func (gateway *HandleT) dbWriterWorkerProcess() {
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), WriteTimeout)
-		err := gateway.jobsDB.WithStoreSafeTx(func(tx jobsdb.StoreSafeTx) error {
+		err := gateway.jobsDB.WithStoreSafeTx(ctx, func(tx jobsdb.StoreSafeTx) error {
 			if gwAllowPartialWriteWithErrors {
 				var err error
 				errorMessagesMap, err = gateway.jobsDB.StoreWithRetryEachInTx(ctx, tx, jobList)

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Gateway Enterprise", func() {
 		It("should accept events from normal users", func() {
 			allowedUserEventData := fmt.Sprintf(`{"batch":[{"userId":%q}]}`, NormalUserID)
 
-			c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+			c.mockJobsDB.EXPECT().WithStoreSafeTx(context.Background(), gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())
 			}).Return(nil)
 			mockCall := c.mockJobsDB.EXPECT().StoreWithRetryEachInTx(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(jobsToEmptyErrors).Times(1)
@@ -342,7 +342,7 @@ var _ = Describe("Gateway", func() {
 
 					validBody := createValidBody("custom-property", "custom-value")
 
-					c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+					c.mockJobsDB.EXPECT().WithStoreSafeTx(context.Background(), gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
 						_ = f(jobsdb.EmptyStoreSafeTx())
 					}).Return(nil)
 					c.mockJobsDB.
@@ -400,7 +400,7 @@ var _ = Describe("Gateway", func() {
 			tFunc = c.asyncHelper.ExpectAndNotifyCallbackWithName("")
 			mockCall.Do(func(interface{}) { tFunc() })
 
-			c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+			c.mockJobsDB.EXPECT().WithStoreSafeTx(context.Background(), gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())
 			}).Return(nil)
 			mockCall = c.mockJobsDB.EXPECT().StoreWithRetryEachInTx(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(jobsToEmptyErrors).Times(1)
@@ -538,7 +538,7 @@ var _ = Describe("Gateway", func() {
 				if handlerType != "import" {
 					validBody := createJSONBody("custom-property", "custom-value")
 
-					c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+					c.mockJobsDB.EXPECT().WithStoreSafeTx(context.Background(), gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
 						_ = f(jobsdb.EmptyStoreSafeTx())
 					}).Return(nil)
 					c.mockJobsDB.

--- a/jobsdb/internal/lock/lock_test.go
+++ b/jobsdb/internal/lock/lock_test.go
@@ -1,6 +1,7 @@
 package lock_test
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -38,4 +39,77 @@ func TestAsyncLock(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("second lock should have been acquired")
 	}
+}
+
+func TestWithCtxAwareLock(t *testing.T) {
+	locker := &lock.DSListLocker{}
+	syncChan := make(chan struct{})
+
+	var wg sync.WaitGroup
+	t.Run("context timeout should be triggered while acquiring lock.", func(t *testing.T) {
+		var counter int
+		wg.Add(1)
+		go func() {
+			wg.Done()
+			locker.WithLock(func(l lock.DSListLockToken) {
+				<-syncChan
+			})
+		}()
+		wg.Wait()
+		timeout := time.Second
+		start := time.Now()
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		lockAcquired := locker.WithCtxAwareLock(ctx, func(l lock.DSListLockToken) {
+			counter++
+			t.Fatal("lock should not have been acquired")
+		})
+		totalTime := time.Since(start)
+		require.GreaterOrEqual(t, totalTime, timeout, "total time should be greater than or equal to timeout")
+		require.Equal(t, 0, counter, "expected locker.WithTimeoutLock to timeout & not execute the function")
+		require.False(t, lockAcquired)
+		syncChan <- struct{}{}
+	})
+
+	t.Run("context timeout shouldn't be triggered, and should successfully acquire the lock.", func(t *testing.T) {
+		var counter int
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		lockAcquired := locker.WithCtxAwareLock(ctx, func(l lock.DSListLockToken) {
+			counter++
+		})
+		require.Equal(t, 1, counter, "expected locker.WithTimeoutLock to acquire the lock & execute the function")
+		require.True(t, lockAcquired)
+	})
+}
+
+func TestAsyncLockWithCtx(t *testing.T) {
+	t.Run("context timeout should be triggered while acquiring lock.", func(t *testing.T) {
+		locker := &lock.DSListLocker{}
+
+		l1, c1 := locker.AsyncLock()
+		require.NotNil(t, l1)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		start := time.Now()
+		l2, c2 := locker.AsyncLockWithCtx(ctx)
+		require.Nil(t, l2)
+		require.Nil(t, c2)
+		totalTime := time.Since(start)
+		require.GreaterOrEqual(t, totalTime, time.Second, "total time should be greater than or equal to timeout")
+		c1 <- l1
+	})
+	t.Run("context timeout shouldn't be triggered while acquiring lock.", func(t *testing.T) {
+		locker := &lock.DSListLocker{}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		start := time.Now()
+		l2, c2 := locker.AsyncLockWithCtx(ctx)
+		require.NotNil(t, l2)
+		require.NotNil(t, c2)
+		totalTime := time.Since(start)
+		require.LessOrEqual(t, totalTime, time.Second, "total time should be greater than or equal to timeout")
+		c2 <- l2
+	})
 }

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -179,7 +179,7 @@ func (*backupTestCase) insertRTData(t *testing.T, jobs []*JobT, statusList []*Jo
 	require.NoError(t, err)
 
 	rtDS2 := newDataSet("rt", "2")
-	jobsDB.dsListLock.WithLock(func(l lock.DSListLockToken) {
+	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
 		jobsDB.addNewDS(l, rtDS2)
 	})
 	err = jobsDB.WithTx(func(tx *sql.Tx) error {
@@ -218,7 +218,7 @@ func (*backupTestCase) insertBatchRTData(t *testing.T, jobs []*JobT, statusList 
 	require.NoError(t, err)
 
 	ds2 := newDataSet("batch_rt", "2")
-	jobsDB.dsListLock.WithLock(func(l lock.DSListLockToken) {
+	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
 		jobsDB.addNewDS(l, ds2)
 	})
 	err = jobsDB.WithTx(func(tx *sql.Tx) error {

--- a/jobsdb/jobsdb_import.go
+++ b/jobsdb/jobsdb_import.go
@@ -27,7 +27,7 @@ func (jd *HandleT) getDsForImport(l lock.DSListLockToken) dataSetT {
 func (jd *HandleT) GetLastJobIDBeforeImport() int64 {
 	jd.assert(jd.migrationState.dsForNewEvents.Index != "", "dsForNewEvents must be setup before calling this")
 	var lastJobIDBeforeNewImports int64
-	jd.dsListLock.WithLock(func(l lock.DSListLockToken) {
+	jd.dsListLock.WithCtxAwareLock(context.Background(), func(l lock.DSListLockToken) {
 		dsList := jd.refreshDSList(l)
 		for idx, dataSet := range dsList {
 			if dataSet.Index == jd.migrationState.dsForNewEvents.Index {
@@ -70,7 +70,7 @@ func (jd *HandleT) StoreJobsAndCheckpoint(jobList []*JobT, migrationCheckpoint M
 		jd.assertError(err)
 		opID = jd.JournalMarkStart(migrateImportOperation, opPayload)
 	} else if jd.checkIfFullDS(jd.migrationState.dsForImport) {
-		jd.dsListLock.WithLock(func(l lock.DSListLockToken) {
+		jd.dsListLock.WithCtxAwareLock(context.Background(), func(l lock.DSListLockToken) {
 			jd.migrationState.dsForImport = newDataSet(jd.tablePrefix, jd.computeNewIdxForInterNodeMigration(l, jd.migrationState.dsForNewEvents))
 			jd.addDS(jd.migrationState.dsForImport)
 			setupCheckpoint, found := jd.GetSetupCheckpoint(ImportOp)
@@ -148,7 +148,7 @@ func (jd *HandleT) GetMaxIDForDs(ds dataSetT) int64 {
 }
 
 func (jd *HandleT) UpdateSequenceNumberOfLatestDS(seqNoForNewDS int64) {
-	jd.dsListLock.WithLock(func(l lock.DSListLockToken) {
+	jd.dsListLock.WithCtxAwareLock(context.Background(), func(l lock.DSListLockToken) {
 		jd.updateSequenceNumberOfLatestDSWithLock(l, seqNoForNewDS)
 	})
 }

--- a/jobsdb/jobsdb_migration_checkpoints.go
+++ b/jobsdb/jobsdb_migration_checkpoints.go
@@ -1,6 +1,7 @@
 package jobsdb
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -208,7 +209,7 @@ func (jd *HandleT) findDsFromSetupCheckpoint(migrationType MigrationOp) (dataSet
 
 func (jd *HandleT) createSetupCheckpointAndGetDs(migrationType MigrationOp) dataSetT {
 	var ds dataSetT
-	jd.dsListLock.WithLock(func(l lock.DSListLockToken) {
+	jd.dsListLock.WithCtxAwareLock(context.Background(), func(l lock.DSListLockToken) {
 		dsList := jd.refreshDSList(l)
 		checkpoint := NewSetupCheckpointEvent(migrationType, misc.GetNodeID())
 

--- a/jobsdb/jobsdb_migration_checkpoints.go
+++ b/jobsdb/jobsdb_migration_checkpoints.go
@@ -209,7 +209,7 @@ func (jd *HandleT) findDsFromSetupCheckpoint(migrationType MigrationOp) (dataSet
 
 func (jd *HandleT) createSetupCheckpointAndGetDs(migrationType MigrationOp) dataSetT {
 	var ds dataSetT
-	jd.dsListLock.WithCtxAwareLock(context.Background(), func(l lock.DSListLockToken) {
+	jd.dsListLock.WithCtxAwareLock(context.Background(), func(l lock.LockToken) {
 		dsList := jd.refreshDSList(l)
 		checkpoint := NewSetupCheckpointEvent(migrationType, misc.GetNodeID())
 

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -579,7 +579,7 @@ func TestRefreshDSList(t *testing.T) {
 	require.Equal(t, 1, len(jobsDB.getDSList()), "jobsDB should start with a ds list size of 1")
 	jobsDB.addDS(newDataSet(prefix, "2"))
 	require.Equal(t, 1, len(jobsDB.getDSList()), "addDS should not refresh the ds list")
-	jobsDB.dsListLock.WithLock(func(l lock.DSListLockToken) {
+	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
 		require.Equal(t, 2, len(jobsDB.refreshDSList(l)), "after refreshing the ds list jobsDB should have a ds list size of 2")
 	})
 }

--- a/jobsdb/setup.go
+++ b/jobsdb/setup.go
@@ -20,7 +20,7 @@ func (jd *HandleT) SchemaMigrationTable() string {
 // - Prefix: The table prefix used by this jobsdb instance.
 // - Datasets: Array of existing dataset indices.
 // If clearAll is set to true, all existing jobsdb tables will be removed first.
-func (jd *HandleT) setupDatabaseTables(l lock.DSListLockToken, clearAll bool) {
+func (jd *HandleT) setupDatabaseTables(l lock.LockToken, clearAll bool) {
 	if clearAll {
 		jd.dropDatabaseTables(l)
 	}
@@ -60,7 +60,7 @@ func (jd *HandleT) setupDatabaseTables(l lock.DSListLockToken, clearAll bool) {
 	}
 }
 
-func (jd *HandleT) dropDatabaseTables(l lock.DSListLockToken) {
+func (jd *HandleT) dropDatabaseTables(l lock.LockToken) {
 	jd.logger.Infof("[JobsDB:%v] Dropping all database tables", jd.tablePrefix)
 	jd.dropSchemaMigrationTables()
 	jd.assertError(jd.dropAllDS(l))

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -323,17 +323,17 @@ func (mr *MockJobsDBMockRecorder) UpdateJobStatusInTx(arg0, arg1, arg2, arg3, ar
 }
 
 // WithStoreSafeTx mocks base method.
-func (m *MockJobsDB) WithStoreSafeTx(arg0 func(jobsdb.StoreSafeTx) error) error {
+func (m *MockJobsDB) WithStoreSafeTx(arg0 context.Context, arg1 func(jobsdb.StoreSafeTx) error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WithStoreSafeTx", arg0)
+	ret := m.ctrl.Call(m, "WithStoreSafeTx", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WithStoreSafeTx indicates an expected call of WithStoreSafeTx.
-func (mr *MockJobsDBMockRecorder) WithStoreSafeTx(arg0 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) WithStoreSafeTx(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithStoreSafeTx", reflect.TypeOf((*MockJobsDB)(nil).WithStoreSafeTx), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithStoreSafeTx", reflect.TypeOf((*MockJobsDB)(nil).WithStoreSafeTx), arg0, arg1)
 }
 
 // WithTx mocks base method.

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1576,7 +1576,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 		proc.logger.Debug("[Processor] Total jobs written to batch router : ", len(batchDestJobs))
 
 		err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
-			return proc.batchRouterDB.WithStoreSafeTx(func(tx jobsdb.StoreSafeTx) error {
+			return proc.batchRouterDB.WithStoreSafeTx(ctx, func(tx jobsdb.StoreSafeTx) error {
 				err := proc.batchRouterDB.StoreInTx(ctx, tx, batchDestJobs)
 				if err != nil {
 					return fmt.Errorf("storing batch router jobs: %w", err)
@@ -1615,7 +1615,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 		proc.logger.Debug("[Processor] Total jobs written to router : ", len(destJobs))
 
 		err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
-			return proc.routerDB.WithStoreSafeTx(func(tx jobsdb.StoreSafeTx) error {
+			return proc.routerDB.WithStoreSafeTx(ctx, func(tx jobsdb.StoreSafeTx) error {
 				err := proc.routerDB.StoreInTx(ctx, tx, destJobs)
 				if err != nil {
 					return fmt.Errorf("storing router jobs: %w", err)

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -537,7 +537,7 @@ var _ = Describe("Processor", func() {
 				Expect(string(job.Parameters)).To(Equal(`{"source_id":"source-from-transformer","destination_id":"destination-from-transformer","received_at":"","transform_at":"processor","message_id":"","gateway_job_id":0,"source_batch_id":"","source_task_id":"","source_task_run_id":"","source_job_id":"","source_job_run_id":"","event_name":"","event_type":"","source_definition_id":"","destination_definition_id":"","source_category":"","record_id":null,"workspaceId":""}`))
 			}
 			// One Store call is expected for all events
-			c.mockRouterJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+			c.mockRouterJobsDB.EXPECT().WithStoreSafeTx(context.Background(), gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())
 			}).Return(nil)
 
@@ -737,7 +737,7 @@ var _ = Describe("Processor", func() {
 				Expect(string(job.Parameters)).To(Equal(`{"source_id":"source-from-transformer","destination_id":"destination-from-transformer","received_at":"","transform_at":"processor","message_id":"","gateway_job_id":0,"source_batch_id":"","source_task_id":"","source_task_run_id":"","source_job_id":"","source_job_run_id":"","event_name":"","event_type":"","source_definition_id":"","destination_definition_id":"","source_category":"","record_id":null,"workspaceId":""}`))
 			}
 
-			c.mockBatchRouterJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+			c.mockBatchRouterJobsDB.EXPECT().WithStoreSafeTx(context.Background(), gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())
 			}).Return(nil)
 			callStoreBatchRouter := c.mockBatchRouterJobsDB.EXPECT().StoreInTx(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
@@ -842,7 +842,7 @@ var _ = Describe("Processor", func() {
 			// We expect one transform call to destination A, after callUnprocessed.
 			mockTransformer.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0).After(callUnprocessed)
 			// One Store call is expected for all events
-			c.mockRouterJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+			c.mockRouterJobsDB.EXPECT().WithStoreSafeTx(context.Background(), gomock.Any()).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())
 			}).Return(nil).Times(1)
 			callStoreRouter := c.mockRouterJobsDB.EXPECT().StoreInTx(gomock.Any(), gomock.Any(), gomock.Len(2)).Times(1)


### PR DESCRIPTION
# Description

> introduced context aware locking mechanism for `dsListLock`.

## Notion Ticket

https://www.notion.so/rudderstacks/Postpone-jobsdb-operations-migrate-addDS-that-cannot-acquire-a-mutex-lock-after-a-timeout-311d74d6eb624e62a4cb7bbb163f01ed