### PR TITLE
fix: snowflake identifier issue

### DIFF
--- a/warehouse/snowflake/snowflake.go
+++ b/warehouse/snowflake/snowflake.go
@@ -132,9 +132,7 @@ func ColumnsWithDataTypes(columns map[string]string, prefix string) string {
 
 // schemaIdentifier returns [DATABASE_NAME].[NAMESPACE] format to access the schema directly.
 func (sf *HandleT) schemaIdentifier() string {
-	DatabaseName := warehouseutils.GetConfigValue(SFDbName, sf.Warehouse)
-	return fmt.Sprintf(`"%s"."%s"`,
-		DatabaseName,
+	return fmt.Sprintf(`"%s"`,
 		sf.Namespace,
 	)
 }


### PR DESCRIPTION
# Description

Use namespace as an identifier for snowflake queries. No need to add a database since we are already adding that in the connection itself.

## Notion Ticket

https://www.notion.so/rudderstacks/Schema-identifier-for-Snowflake-d3a9c90bd69f44a893e600c869958f6d

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
