### PR TITLE
chore: disable semantic PR single commit validation

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -60,10 +60,10 @@ jobs:
           # will suggest using that commit message instead of the PR title for the
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
-          validateSingleCommit: true
+          validateSingleCommit: false
           # Related to `validateSingleCommit` you can opt-in to validate that the PR
           # title matches a single commit to avoid confusion.
-          validateSingleCommitMatchesPrTitle: true
+          validateSingleCommitMatchesPrTitle: false
           # If the PR contains one of these labels, the validation is skipped.
           # Multiple labels can be separated by newlines.
           # If you want to rerun the validation when labels change, you might want


### PR DESCRIPTION
# Description


## yes 

The semantic PR, was complaining in PRs with a single commit - when that commit didn't follow the standards and that it was matching the PR title. This was inconvenient, but necessary since: 

>   When using "Squash and merge" on a PR with only one commit, GitHub
>   will suggest using that commit message instead of the PR title for the
>   merge commit, and it's easy to commit this by mistake.

## but

However, after github [introduced some options](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-squashing-for-pull-requests) and we chose the following,:
<img width="901" alt="Screenshot 2022-09-27 at 11 13 19 AM" src="https://user-images.githubusercontent.com/733195/192471929-08f31a46-b9b4-443b-ba2e-d7df082df3d8.png">


This is no longer the case:
<img width="779" alt="Screenshot 2022-09-27 at 11 16 40 AM" src="https://user-images.githubusercontent.com/733195/192472091-d778ab0d-c4d0-455a-af8a-839ea5b3308d.png">
(this is a PR with a single commit, trust me)


## Notion Ticket

https://www.notion.so/rudderstacks/semantic-PR-improvements-40fb40bdc73648aca1f4b50041210f2e

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
