### PR TITLE
chore: kafka cloud platform CI integration

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -93,6 +93,12 @@ jobs:
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: (cd /tmp && go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest)
     - run: ginkgo version
-    - run: make test
+    - env:
+        TEST_KAFKA_CONFLUENT_CLOUD_HOST: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_HOST }}
+        TEST_KAFKA_CONFLUENT_CLOUD_KEY: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_KEY }}
+        TEST_KAFKA_CONFLUENT_CLOUD_SECRET: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_SECRET }}
+        TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_HOST: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_HOST }}
+        TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_EVENTHUB_NAME: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_EVENTHUB_NAME }}
+        TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_CONNECTION_STRING: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_CONNECTION_STRING }}
+      run: make test
     - uses: codecov/codecov-action@v2
-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,6 +76,13 @@ jobs:
   unit:
     name: Unit
     runs-on: 'ubuntu-20.04'
+    env:
+      TEST_KAFKA_CONFLUENT_CLOUD_HOST: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_HOST }}
+      TEST_KAFKA_CONFLUENT_CLOUD_KEY: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_KEY }}
+      TEST_KAFKA_CONFLUENT_CLOUD_SECRET: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_SECRET }}
+      TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_HOST: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_HOST }}
+      TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_EVENTHUB_NAME: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_EVENTHUB_NAME }}
+      TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_CONNECTION_STRING: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_CONNECTION_STRING }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
@@ -93,12 +100,5 @@ jobs:
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: (cd /tmp && go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest)
     - run: ginkgo version
-    - env:
-        TEST_KAFKA_CONFLUENT_CLOUD_HOST: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_HOST }}
-        TEST_KAFKA_CONFLUENT_CLOUD_KEY: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_KEY }}
-        TEST_KAFKA_CONFLUENT_CLOUD_SECRET: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_SECRET }}
-        TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_HOST: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_HOST }}
-        TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_EVENTHUB_NAME: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_EVENTHUB_NAME }}
-        TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_CONNECTION_STRING: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_CONNECTION_STRING }}
-      run: make test
+    - run: make test
     - uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,13 +76,6 @@ jobs:
   unit:
     name: Unit
     runs-on: 'ubuntu-20.04'
-    env:
-      TEST_KAFKA_CONFLUENT_CLOUD_HOST: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_HOST }}
-      TEST_KAFKA_CONFLUENT_CLOUD_KEY: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_KEY }}
-      TEST_KAFKA_CONFLUENT_CLOUD_SECRET: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_SECRET }}
-      TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_HOST: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_HOST }}
-      TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_EVENTHUB_NAME: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_EVENTHUB_NAME }}
-      TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_CONNECTION_STRING: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_CONNECTION_STRING }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
@@ -100,5 +93,12 @@ jobs:
     - run: go mod download # Not required, used to segregate module download vs test times
     - run: (cd /tmp && go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest)
     - run: ginkgo version
-    - run: make test
+    - env:
+        TEST_KAFKA_CONFLUENT_CLOUD_HOST: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_HOST }}
+        TEST_KAFKA_CONFLUENT_CLOUD_KEY: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_KEY }}
+        TEST_KAFKA_CONFLUENT_CLOUD_SECRET: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_SECRET }}
+        TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_HOST: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_HOST }}
+        TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_EVENTHUB_NAME: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_EVENTHUB_NAME }}
+        TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_CONNECTION_STRING: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_CONNECTION_STRING }}
+      run: make test
     - uses: codecov/codecov-action@v2

--- a/services/streammanager/kafka/client/client.go
+++ b/services/streammanager/kafka/client/client.go
@@ -86,6 +86,8 @@ func NewConfluentCloud(addresses []string, key, secret string, conf Config) (*Cl
 }
 
 // NewAzureEventHubs returns a Kafka client pre-configured to connect to Azure Event Hubs
+// addresses should be in the form of "host:port" where the port is usually 9093 on Azure Event Hubs
+// Also make sure to select at least the Standard tier since the Basic tier does not support Kafka
 func NewAzureEventHubs(addresses []string, connectionString string, conf Config) (*Client, error) {
 	conf.SASL = &SASL{
 		ScramHashGen: ScramPlainText,

--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -629,7 +629,7 @@ func TestConfluentAzureCloud(t *testing.T) {
 		t.Skip("Skipping because credentials or host are not provided")
 	}
 
-	c, err := NewConfluentCloud([]string{kafkaHost}, confluentCloudKey, confluentCloudSecret, Config{
+	c, err := NewConfluentCloud([]string{"bad-host", kafkaHost}, confluentCloudKey, confluentCloudSecret, Config{
 		ClientID:    "some-client",
 		DialTimeout: 45 * time.Second,
 	})

--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -629,6 +629,8 @@ func TestConfluentAzureCloud(t *testing.T) {
 		t.Skip("Skipping because credentials or host are not provided")
 	}
 
+	t.Logf("REMOVE ME: host(%s) cloudkey(%s) cloudsecret(%s)", kafkaHost, confluentCloudKey, confluentCloudSecret)
+
 	c, err := NewConfluentCloud([]string{"bad-host", kafkaHost}, confluentCloudKey, confluentCloudSecret, Config{
 		ClientID:    "some-client",
 		DialTimeout: 45 * time.Second,
@@ -673,6 +675,8 @@ func TestAzureEventHubsCloud(t *testing.T) {
 	if kafkaHost == "" || azureEventHubName == "" || azureEventHubsConnString == "" {
 		t.Skip("Skipping because credentials or host are not provided")
 	}
+
+	t.Logf("REMOVE ME: host(%s) eventhub(%s) connstring(%s)", kafkaHost, azureEventHubName, azureEventHubsConnString)
 
 	c, err := NewAzureEventHubs([]string{kafkaHost}, azureEventHubsConnString, Config{
 		ClientID:    "some-client",

--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -629,9 +629,7 @@ func TestConfluentAzureCloud(t *testing.T) {
 		t.Skip("Skipping because credentials or host are not provided")
 	}
 
-	t.Logf("REMOVE ME: host(%s) cloudkey(%s) cloudsecret(%s)", kafkaHost, confluentCloudKey, confluentCloudSecret)
-
-	c, err := NewConfluentCloud([]string{"bad-host", kafkaHost}, confluentCloudKey, confluentCloudSecret, Config{
+	c, err := NewConfluentCloud([]string{kafkaHost}, confluentCloudKey, confluentCloudSecret, Config{
 		ClientID:    "some-client",
 		DialTimeout: 45 * time.Second,
 	})
@@ -675,8 +673,6 @@ func TestAzureEventHubsCloud(t *testing.T) {
 	if kafkaHost == "" || azureEventHubName == "" || azureEventHubsConnString == "" {
 		t.Skip("Skipping because credentials or host are not provided")
 	}
-
-	t.Logf("REMOVE ME: host(%s) eventhub(%s) connstring(%s)", kafkaHost, azureEventHubName, azureEventHubsConnString)
 
 	c, err := NewAzureEventHubs([]string{kafkaHost}, azureEventHubsConnString, Config{
 		ClientID:    "some-client",

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -58,10 +58,14 @@ func (c *configuration) validate() error {
 	return nil
 }
 
-// azureEventHubConfig is the config that is required to send data to Azure Event Hub
+// azureEventHubConfig is the config that is required to send data to Azure Event Hub.
+// Make sure to select at least the Standard tier since the Basic tier does not support Kafka.
 type azureEventHubConfig struct {
-	Topic                     string
-	BootstrapServer           string
+	// Topic is the name of the Event Hub on Azure (not the Event Hubs Namespace)
+	Topic string
+	// BootstrapServer should be in the form of "host:port" (the port is usually 9093 on Azure Event Hubs)
+	BootstrapServer string
+	// EventHubsConnectionString starts with "Endpoint=sb://" and contains the SharedAccessKey
 	EventHubsConnectionString string
 }
 

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -106,39 +107,36 @@ func (c *confluentCloudConfig) validate() error {
 	return nil
 }
 
-type producer interface {
-	Close(context.Context) error
+type publisher interface {
 	Publish(context.Context, ...client.Message) error
+}
 
+type producerManager interface {
+	io.Closer
+	publisher
 	getTimeout() time.Duration
 	getCodecs() map[string]*goavro.Codec
 }
 
-type producerImpl struct {
-	p       *client.Producer
+type internalProducer interface {
+	publisher
+	Close(context.Context) error
+}
+
+type ProducerManager struct {
+	p       internalProducer
 	timeout time.Duration
 	codecs  map[string]*goavro.Codec
 }
 
-func (p *producerImpl) getTimeout() time.Duration {
+func (p *ProducerManager) getTimeout() time.Duration {
 	if p.timeout < 1 {
 		return defaultPublishTimeout
 	}
 	return p.timeout
 }
 
-func (p *producerImpl) Close(ctx context.Context) error {
-	if p == nil || p.p == nil {
-		return nil
-	}
-	return p.p.Close(ctx)
-}
-
-func (p *producerImpl) Publish(ctx context.Context, msgs ...client.Message) error {
-	return p.p.Publish(ctx, msgs...)
-}
-
-func (p *producerImpl) getCodecs() map[string]*goavro.Codec {
+func (p *ProducerManager) getCodecs() map[string]*goavro.Codec {
 	return p.codecs
 }
 
@@ -166,7 +164,7 @@ const (
 )
 
 var (
-	_ producer = &producerImpl{}
+	_ producerManager = &ProducerManager{}
 
 	clientCert, clientKey                []byte
 	kafkaDialTimeout                     = 10 * time.Second
@@ -230,12 +228,8 @@ func Init() {
 	}
 }
 
-type KafkaProducer struct {
-	client producer
-}
-
 // NewProducer creates a producer based on destination config
-func NewProducer(destination *backendconfig.DestinationT, o common.Opts) (*KafkaProducer, error) { // skipcq: RVV-B0011
+func NewProducer(destination *backendconfig.DestinationT, o common.Opts) (*ProducerManager, error) {
 	start := now()
 	defer func() { kafkaStats.creationTime.SendTiming(since(start)) }()
 
@@ -325,11 +319,11 @@ func NewProducer(destination *backendconfig.DestinationT, o common.Opts) (*Kafka
 	if err != nil {
 		return nil, err
 	}
-	return &KafkaProducer{client: &producerImpl{p: p, timeout: o.Timeout, codecs: codecs}}, nil
+	return &ProducerManager{p: p, timeout: o.Timeout, codecs: codecs}, nil
 }
 
 // NewProducerForAzureEventHubs creates a producer for Azure event hub based on destination config
-func NewProducerForAzureEventHubs(destination *backendconfig.DestinationT, o common.Opts) (*KafkaProducer, error) { // skipcq: RVV-B0011
+func NewProducerForAzureEventHubs(destination *backendconfig.DestinationT, o common.Opts) (*ProducerManager, error) {
 	start := now()
 	defer func() { kafkaStats.creationTimeAzureEventHubs.SendTiming(since(start)) }()
 
@@ -376,11 +370,11 @@ func NewProducerForAzureEventHubs(destination *backendconfig.DestinationT, o com
 	if err != nil {
 		return nil, err
 	}
-	return &KafkaProducer{client: &producerImpl{p: p, timeout: o.Timeout}}, nil
+	return &ProducerManager{p: p, timeout: o.Timeout}, nil
 }
 
 // NewProducerForConfluentCloud creates a producer for Confluent cloud based on destination config
-func NewProducerForConfluentCloud(destination *backendconfig.DestinationT, o common.Opts) (*KafkaProducer, error) { // skipcq: RVV-B0011
+func NewProducerForConfluentCloud(destination *backendconfig.DestinationT, o common.Opts) (*ProducerManager, error) {
 	start := now()
 	defer func() { kafkaStats.creationTimeConfluentCloud.SendTiming(since(start)) }()
 
@@ -428,7 +422,7 @@ func NewProducerForConfluentCloud(destination *backendconfig.DestinationT, o com
 	if err != nil {
 		return nil, err
 	}
-	return &KafkaProducer{client: &producerImpl{p: p, timeout: o.Timeout}}, nil
+	return &ProducerManager{p: p, timeout: o.Timeout}, nil
 }
 
 func prepareMessage(topic, key string, message []byte, timestamp time.Time) client.Message {
@@ -456,7 +450,7 @@ func serializeAvroMessage(value []byte, codec goavro.Codec) ([]byte, error) {
 	return binary, nil
 }
 
-func prepareBatchOfMessages(topic string, batch []map[string]interface{}, timestamp time.Time, p producer) (
+func prepareBatchOfMessages(topic string, batch []map[string]interface{}, timestamp time.Time, p producerManager) (
 	[]client.Message, error,
 ) {
 	start := now()
@@ -512,33 +506,36 @@ func prepareBatchOfMessages(topic string, batch []map[string]interface{}, timest
 }
 
 // Close closes a given producer
-func (producer *KafkaProducer) Close() error {
+func (p *ProducerManager) Close() error {
+	if p == nil || p.p == nil {
+		return nil
+	}
+
 	start := now()
 	defer func() { kafkaStats.closeProducerTime.SendTiming(since(start)) }()
 
-	client := producer.client
-	if client == nil {
-		return fmt.Errorf("error while closing producer")
-	}
-
 	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
-	err := client.Close(ctx)
-	cancel()
-	if err != nil {
-		pkgLogger.Errorf("error in closing Kafka producer: %v", err)
+	defer cancel()
+	if err := p.p.Close(ctx); err != nil {
+		return fmt.Errorf("failed to close producer: %w", err)
 	}
-	return err
+	return nil
+}
+
+// Publish publishes a given message to Kafka
+func (p *ProducerManager) Publish(ctx context.Context, msgs ...client.Message) error {
+	return p.p.Publish(ctx, msgs...)
 }
 
 // Produce creates a producer and send data to Kafka.
-func (producer *KafkaProducer) Produce(jsonData json.RawMessage, destConfig interface{}) (int, string, string) {
-	start := now()
-	defer func() { kafkaStats.produceTime.SendTiming(since(start)) }()
-	client := producer.client
-	if client == nil {
+func (p *ProducerManager) Produce(jsonData json.RawMessage, destConfig interface{}) (int, string, string) {
+	if p.p == nil {
 		// return 400 if producer is invalid
 		return 400, "Could not create producer", "Could not create producer"
 	}
+
+	start := now()
+	defer func() { kafkaStats.produceTime.SendTiming(since(start)) }()
 
 	conf := configuration{}
 	jsonConfig, err := json.Marshal(destConfig)
@@ -554,15 +551,15 @@ func (producer *KafkaProducer) Produce(jsonData json.RawMessage, destConfig inte
 		return makeErrorResponse(fmt.Errorf("invalid destination configuration: no topic"))
 	}
 
-	ctx, cancel := context.WithTimeout(context.TODO(), client.getTimeout())
+	ctx, cancel := context.WithTimeout(context.TODO(), p.getTimeout())
 	defer cancel()
 	if kafkaBatchingEnabled {
-		return sendBatchedMessage(ctx, jsonData, client, conf.Topic)
+		return sendBatchedMessage(ctx, jsonData, p, conf.Topic)
 	}
-	return sendMessage(ctx, jsonData, client, conf.Topic)
+	return sendMessage(ctx, jsonData, p, conf.Topic)
 }
 
-func sendBatchedMessage(ctx context.Context, jsonData json.RawMessage, p producer, topic string) (int, string, string) {
+func sendBatchedMessage(ctx context.Context, jsonData json.RawMessage, p producerManager, topic string) (int, string, string) {
 	var batch []map[string]interface{}
 	err := json.Unmarshal(jsonData, &batch)
 	if err != nil {
@@ -584,7 +581,7 @@ func sendBatchedMessage(ctx context.Context, jsonData json.RawMessage, p produce
 	return 200, returnMessage, returnMessage
 }
 
-func sendMessage(ctx context.Context, jsonData json.RawMessage, p producer, topic string) (int, string, string) {
+func sendMessage(ctx context.Context, jsonData json.RawMessage, p producerManager, topic string) (int, string, string) {
 	parsedJSON := gjson.ParseBytes(jsonData)
 	messageValue := parsedJSON.Get("message").Value()
 	if messageValue == nil {
@@ -623,7 +620,7 @@ func sendMessage(ctx context.Context, jsonData json.RawMessage, p producer, topi
 	return 200, returnMessage, returnMessage
 }
 
-func publish(ctx context.Context, p producer, msgs ...client.Message) error {
+func publish(ctx context.Context, p producerManager, msgs ...client.Message) error {
 	start := now()
 	defer func() { kafkaStats.publishTime.SendTiming(since(start)) }()
 	return p.Publish(ctx, msgs...)

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -284,7 +284,7 @@ func TestProducerForConfluentCloud(t *testing.T) {
 		kafkaStats.creationTimeConfluentCloud = getMockedTimer(t, gomock.NewController(t))
 
 		destConfig := map[string]interface{}{
-			"topic":           "TestConfluentAzureCloud",
+			"topic":           "TestProducerForConfluentCloud_OK",
 			"bootstrapServer": "bad-host," + kafkaHost + "," + kafkaHost,
 			"apiKey":          confluentCloudKey,
 			"apiSecret":       confluentCloudSecret,

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -51,8 +51,8 @@ func TestNewProducer(t *testing.T) {
 		t.Run("missing topic", func(t *testing.T) {
 			kafkaStats.creationTime = getMockedTimer(t, gomock.NewController(t))
 
-			destination := backendconfig.DestinationT{}
-			p, err := NewProducer(&destination, common.Opts{})
+			dest := backendconfig.DestinationT{}
+			p, err := NewProducer(&dest, common.Opts{})
 			require.Nil(t, p)
 			require.ErrorContains(t, err, "invalid configuration: topic cannot be empty")
 		})
@@ -62,9 +62,9 @@ func TestNewProducer(t *testing.T) {
 			destConfig := map[string]interface{}{
 				"topic": "some-topic",
 			}
-			destination := backendconfig.DestinationT{Config: destConfig}
+			dest := backendconfig.DestinationT{Config: destConfig}
 
-			p, err := NewProducer(&destination, common.Opts{})
+			p, err := NewProducer(&dest, common.Opts{})
 			require.Nil(t, p)
 			require.ErrorContains(t, err, "invalid configuration: hostname cannot be empty")
 		})
@@ -75,9 +75,9 @@ func TestNewProducer(t *testing.T) {
 				"topic":    "some-topic",
 				"hostname": "some-hostname",
 			}
-			destination := backendconfig.DestinationT{Config: destConfig}
+			dest := backendconfig.DestinationT{Config: destConfig}
 
-			p, err := NewProducer(&destination, common.Opts{})
+			p, err := NewProducer(&dest, common.Opts{})
 			require.Nil(t, p)
 			require.ErrorContains(t, err, `invalid configuration: invalid port: strconv.Atoi: parsing "": invalid syntax`)
 		})
@@ -89,9 +89,9 @@ func TestNewProducer(t *testing.T) {
 				"hostname": "some-hostname",
 				"port":     "0",
 			}
-			destination := backendconfig.DestinationT{Config: destConfig}
+			dest := backendconfig.DestinationT{Config: destConfig}
 
-			p, err := NewProducer(&destination, common.Opts{})
+			p, err := NewProducer(&dest, common.Opts{})
 			require.Nil(t, p)
 			require.ErrorContains(t, err, `invalid configuration: invalid port: 0`)
 		})
@@ -110,9 +110,9 @@ func TestNewProducer(t *testing.T) {
 					},
 				},
 			}
-			destination := backendconfig.DestinationT{Config: destConfig}
+			dest := backendconfig.DestinationT{Config: destConfig}
 
-			p, err := NewProducer(&destination, common.Opts{})
+			p, err := NewProducer(&dest, common.Opts{})
 			require.Nil(t, p)
 			require.EqualError(t, err, `[Kafka] Error while unmarshalling destination configuration map[avroSchemas:[map[schemaId:schema001] map[schema:map[name:MyClass]]] convertToAvro:true hostname:some-hostname port:9090 topic:some-topic], got error: json: cannot unmarshal object into Go struct field avroSchema.AvroSchemas.Schema of type string`)
 		})
@@ -138,15 +138,15 @@ func TestNewProducer(t *testing.T) {
 			"hostname": "localhost",
 			"port":     kafkaContainer.Port,
 		}
-		destination := backendconfig.DestinationT{Config: destConfig}
+		dest := backendconfig.DestinationT{Config: destConfig}
 
-		p, err := NewProducer(&destination, common.Opts{})
+		p, err := NewProducer(&dest, common.Opts{})
 		require.NotNil(t, p)
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			err = p.client.Publish(ctx, client.Message{Key: []byte("key-01"), Value: []byte("message-01")})
+			err = p.p.Publish(ctx, client.Message{Key: []byte("key-01"), Value: []byte("message-01")})
 			cancel()
 			return err == nil
 		}, 60*time.Second, 100*time.Millisecond)
@@ -158,8 +158,8 @@ func TestNewProducerForAzureEventHubs(t *testing.T) {
 		t.Run("missing topic", func(t *testing.T) {
 			kafkaStats.creationTimeAzureEventHubs = getMockedTimer(t, gomock.NewController(t))
 
-			destination := backendconfig.DestinationT{}
-			p, err := NewProducerForAzureEventHubs(&destination, common.Opts{})
+			dest := backendconfig.DestinationT{}
+			p, err := NewProducerForAzureEventHubs(&dest, common.Opts{})
 			require.Nil(t, p)
 			require.ErrorContains(t, err, "invalid configuration: topic cannot be empty")
 		})
@@ -169,9 +169,9 @@ func TestNewProducerForAzureEventHubs(t *testing.T) {
 			destConfig := map[string]interface{}{
 				"topic": "some-topic",
 			}
-			destination := backendconfig.DestinationT{Config: destConfig}
+			dest := backendconfig.DestinationT{Config: destConfig}
 
-			p, err := NewProducerForAzureEventHubs(&destination, common.Opts{})
+			p, err := NewProducerForAzureEventHubs(&dest, common.Opts{})
 			require.Nil(t, p)
 			require.ErrorContains(t, err, "invalid configuration: bootstrap server cannot be empty")
 		})
@@ -182,9 +182,9 @@ func TestNewProducerForAzureEventHubs(t *testing.T) {
 				"topic":           "some-topic",
 				"bootstrapServer": "some-server",
 			}
-			destination := backendconfig.DestinationT{Config: destConfig}
+			dest := backendconfig.DestinationT{Config: destConfig}
 
-			p, err := NewProducerForAzureEventHubs(&destination, common.Opts{})
+			p, err := NewProducerForAzureEventHubs(&dest, common.Opts{})
 			require.Nil(t, p)
 			require.ErrorContains(t, err, "invalid configuration: connection string cannot be empty")
 		})
@@ -206,15 +206,15 @@ func TestNewProducerForAzureEventHubs(t *testing.T) {
 			"bootstrapServer":           "bad-host," + kafkaHost + "," + kafkaHost,
 			"eventHubsConnectionString": azureEventHubsConnString,
 		}
-		destination := backendconfig.DestinationT{Config: destConfig}
+		dest := backendconfig.DestinationT{Config: destConfig}
 
-		p, err := NewProducerForAzureEventHubs(&destination, common.Opts{})
+		p, err := NewProducerForAzureEventHubs(&dest, common.Opts{})
 		require.NotNil(t, p)
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			err = p.client.Publish(ctx, client.Message{Key: []byte("key-01"), Value: []byte("message-01")})
+			err = p.p.Publish(ctx, client.Message{Key: []byte("key-01"), Value: []byte("message-01")})
 			cancel()
 			return err == nil
 		}, 60*time.Second, 100*time.Millisecond)
@@ -226,8 +226,8 @@ func TestProducerForConfluentCloud(t *testing.T) {
 		t.Run("missing topic", func(t *testing.T) {
 			kafkaStats.creationTimeConfluentCloud = getMockedTimer(t, gomock.NewController(t))
 
-			destination := backendconfig.DestinationT{}
-			p, err := NewProducerForConfluentCloud(&destination, common.Opts{})
+			dest := backendconfig.DestinationT{}
+			p, err := NewProducerForConfluentCloud(&dest, common.Opts{})
 			require.Nil(t, p)
 			require.ErrorContains(t, err, "invalid configuration: topic cannot be empty")
 		})
@@ -237,9 +237,9 @@ func TestProducerForConfluentCloud(t *testing.T) {
 			destConfig := map[string]interface{}{
 				"topic": "some-topic",
 			}
-			destination := backendconfig.DestinationT{Config: destConfig}
+			dest := backendconfig.DestinationT{Config: destConfig}
 
-			p, err := NewProducerForConfluentCloud(&destination, common.Opts{})
+			p, err := NewProducerForConfluentCloud(&dest, common.Opts{})
 			require.Nil(t, p)
 			require.ErrorContains(t, err, "invalid configuration: bootstrap server cannot be empty")
 		})
@@ -250,9 +250,9 @@ func TestProducerForConfluentCloud(t *testing.T) {
 				"topic":           "some-topic",
 				"bootstrapServer": "some-server",
 			}
-			destination := backendconfig.DestinationT{Config: destConfig}
+			dest := backendconfig.DestinationT{Config: destConfig}
 
-			p, err := NewProducerForConfluentCloud(&destination, common.Opts{})
+			p, err := NewProducerForConfluentCloud(&dest, common.Opts{})
 			require.Nil(t, p)
 			require.ErrorContains(t, err, "invalid configuration: API key cannot be empty")
 		})
@@ -264,9 +264,9 @@ func TestProducerForConfluentCloud(t *testing.T) {
 				"bootstrapServer": "some-server",
 				"apiKey":          "secret-key",
 			}
-			destination := backendconfig.DestinationT{Config: destConfig}
+			dest := backendconfig.DestinationT{Config: destConfig}
 
-			p, err := NewProducerForConfluentCloud(&destination, common.Opts{})
+			p, err := NewProducerForConfluentCloud(&dest, common.Opts{})
 			require.Nil(t, p)
 			require.ErrorContains(t, err, "invalid configuration: API secret cannot be empty")
 		})
@@ -289,15 +289,15 @@ func TestProducerForConfluentCloud(t *testing.T) {
 			"apiKey":          confluentCloudKey,
 			"apiSecret":       confluentCloudSecret,
 		}
-		destination := backendconfig.DestinationT{Config: destConfig}
+		dest := backendconfig.DestinationT{Config: destConfig}
 
-		p, err := NewProducerForConfluentCloud(&destination, common.Opts{})
+		p, err := NewProducerForConfluentCloud(&dest, common.Opts{})
 		require.NoError(t, err)
 		require.NotNil(t, p)
 
 		require.Eventually(t, func() bool {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			err = p.client.Publish(ctx, client.Message{Key: []byte("key-01"), Value: []byte("message-01")})
+			err = p.p.Publish(ctx, client.Message{Key: []byte("key-01"), Value: []byte("message-01")})
 			cancel()
 			return err == nil
 		}, 60*time.Second, 100*time.Millisecond)
@@ -319,8 +319,8 @@ func TestPrepareBatchOfMessages(t *testing.T) {
 		mockPrepareBatchTime.EXPECT().SendTiming(sinceDuration).Times(1)
 
 		var data []map[string]interface{}
-		p := &pMockErr{error: nil}
-		batch, err := prepareBatchOfMessages("some-topic", data, time.Now(), p)
+		pm := &ProducerManager{p: &pMockErr{error: nil}}
+		batch, err := prepareBatchOfMessages("some-topic", data, time.Now(), pm)
 		require.Equal(t, []client.Message(nil), batch)
 		require.Equal(t, fmt.Errorf("unable to process any of the event in the batch"), err)
 	})
@@ -328,11 +328,11 @@ func TestPrepareBatchOfMessages(t *testing.T) {
 	t.Run("no message", func(t *testing.T) {
 		mockSkippedDueToMessage.EXPECT().Increment().Times(1)
 		mockPrepareBatchTime.EXPECT().SendTiming(sinceDuration).Times(1)
-		p := &pMockErr{error: nil}
+		pm := &ProducerManager{p: &pMockErr{error: nil}}
 		data := []map[string]interface{}{{
 			"not-interesting": "some value",
 		}}
-		batch, err := prepareBatchOfMessages("some-topic", data, time.Now(), p)
+		batch, err := prepareBatchOfMessages("some-topic", data, time.Now(), pm)
 		require.Equal(t, []client.Message(nil), batch)
 		require.Equal(t, fmt.Errorf("unable to process any of the event in the batch"), err)
 	})
@@ -349,8 +349,8 @@ func TestPrepareBatchOfMessages(t *testing.T) {
 			{"message": "msg02", "userId": "123"},
 			{"message": map[string]interface{}{"a": 1, "b": 2}, "userId": "456"},
 		}
-		p := &pMockErr{error: nil}
-		batch, err := prepareBatchOfMessages("some-topic", data, now, p)
+		pm := &ProducerManager{p: &pMockErr{error: nil}}
+		batch, err := prepareBatchOfMessages("some-topic", data, now, pm)
 		require.NoError(t, err)
 		require.ElementsMatch(t, []client.Message{
 			{
@@ -378,8 +378,8 @@ func TestPrepareBatchOfMessages(t *testing.T) {
 			{"not-interesting": "some value"},
 			{"message": "msg01"},
 		}
-		p := &pMockErr{error: nil}
-		batch, err := prepareBatchOfMessages("some-topic", data, now, p)
+		pm := &ProducerManager{p: &pMockErr{error: nil}}
+		batch, err := prepareBatchOfMessages("some-topic", data, now, pm)
 		require.NoError(t, err)
 		require.ElementsMatch(t, []client.Message{
 			{
@@ -395,17 +395,14 @@ func TestPrepareBatchOfMessages(t *testing.T) {
 func TestClose(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		kafkaStats.closeProducerTime = getMockedTimer(t, gomock.NewController(t))
-		kp := &KafkaProducer{}
-		err := kp.Close()
-		require.EqualError(t, err, "error while closing producer")
+		pm := &ProducerManager{}
+		require.NoError(t, pm.Close())
 	})
 	t.Run("not initialized", func(t *testing.T) {
 		kafkaStats.closeProducerTime = getMockedTimer(t, gomock.NewController(t))
 
-		client := &producerImpl{p: &client.Producer{}}
-		kp := &KafkaProducer{client}
-		err := kp.Close()
-		require.NoError(t, err)
+		pm := &ProducerManager{p: &client.Producer{}}
+		require.NoError(t, pm.Close())
 	})
 	t.Run("correct", func(t *testing.T) {
 		kafkaStats.closeProducerTime = getMockedTimer(t, gomock.NewController(t))
@@ -414,25 +411,22 @@ func TestClose(t *testing.T) {
 		require.NoError(t, err)
 		p, err := c.NewProducer("some-topic", client.ProducerConfig{})
 		require.NoError(t, err)
-		kp := &KafkaProducer{&producerImpl{p: p}}
-		err = kp.Close()
-		require.NoError(t, err)
+		pm := &ProducerManager{p: p}
+		require.NoError(t, pm.Close())
 	})
 	t.Run("error", func(t *testing.T) {
 		kafkaStats.closeProducerTime = getMockedTimer(t, gomock.NewController(t))
 
-		var p producer = &pMockErr{error: fmt.Errorf("a bad error")}
-		kp := &KafkaProducer{p}
-		err := kp.Close()
-		require.EqualError(t, err, "a bad error")
+		var pm producerManager = &ProducerManager{p: &pMockErr{error: fmt.Errorf("a bad error")}}
+		require.EqualError(t, pm.Close(), "a bad error")
 	})
 }
 
 func TestProduce(t *testing.T) {
 	t.Run("invalid producer", func(t *testing.T) {
 		kafkaStats.produceTime = getMockedTimer(t, gomock.NewController(t))
-		kp := KafkaProducer{}
-		sc, res, err := kp.Produce(nil, nil)
+		pm := ProducerManager{}
+		sc, res, err := pm.Produce(nil, nil)
 		require.Equal(t, 400, sc)
 		require.Equal(t, "Could not create producer", res)
 		require.Equal(t, "Could not create producer", err)
@@ -441,9 +435,9 @@ func TestProduce(t *testing.T) {
 	t.Run("invalid destination configuration", func(t *testing.T) {
 		kafkaStats.produceTime = getMockedTimer(t, gomock.NewController(t))
 
-		kp := KafkaProducer{client: &pMockErr{}}
+		pm := ProducerManager{p: &client.Producer{}}
 		destConfig := make(chan struct{}) // channels cannot be JSON marshalled
-		sc, res, err := kp.Produce(nil, destConfig)
+		sc, res, err := pm.Produce(nil, destConfig)
 		require.Equal(t, 400, sc)
 		require.Equal(t, "json: unsupported type: chan struct {} error occurred.", res)
 		require.Equal(t, "json: unsupported type: chan struct {}", err)
@@ -452,9 +446,9 @@ func TestProduce(t *testing.T) {
 	t.Run("empty destination configuration", func(t *testing.T) {
 		kafkaStats.produceTime = getMockedTimer(t, gomock.NewController(t))
 
-		kp := KafkaProducer{client: &pMockErr{}}
+		pm := ProducerManager{p: &client.Producer{}}
 		destConfig := map[string]interface{}{"foo": "bar"}
-		sc, res, err := kp.Produce(json.RawMessage(""), destConfig)
+		sc, res, err := pm.Produce(json.RawMessage(""), destConfig)
 		require.Equal(t, 400, sc)
 		require.Equal(t, "invalid destination configuration: no topic error occurred.", res)
 		require.Equal(t, "invalid destination configuration: no topic", err)
@@ -463,9 +457,9 @@ func TestProduce(t *testing.T) {
 	t.Run("invalid message", func(t *testing.T) {
 		kafkaStats.produceTime = getMockedTimer(t, gomock.NewController(t))
 
-		kp := &KafkaProducer{client: &pMockErr{}}
+		pm := ProducerManager{p: &client.Producer{}}
 		destConfig := map[string]interface{}{"topic": "foo-bar"}
-		sc, res, err := kp.Produce(json.RawMessage(""), destConfig)
+		sc, res, err := pm.Produce(json.RawMessage(""), destConfig)
 		require.Equal(t, 400, sc)
 		require.Equal(t, "Failure", res)
 		require.Equal(t, "Invalid message", err)
@@ -476,9 +470,9 @@ func TestProduce(t *testing.T) {
 		kafkaStats.publishTime = getMockedTimer(t, ctrl)
 		kafkaStats.produceTime = getMockedTimer(t, ctrl)
 
-		kp := &KafkaProducer{client: &pMockErr{error: fmt.Errorf("super bad")}}
+		pm := &ProducerManager{p: &pMockErr{error: fmt.Errorf("super bad")}}
 		destConfig := map[string]interface{}{"topic": "foo-bar"}
-		sc, res, err := kp.Produce(json.RawMessage(`{"message":"ciao"}`), destConfig)
+		sc, res, err := pm.Produce(json.RawMessage(`{"message":"ciao"}`), destConfig)
 		require.Equal(t, 400, sc)
 		require.Contains(t, res, "super bad error occurred.")
 		require.Contains(t, err, "super bad")
@@ -489,9 +483,9 @@ func TestProduce(t *testing.T) {
 		kafkaStats.publishTime = getMockedTimer(t, ctrl)
 		kafkaStats.produceTime = getMockedTimer(t, ctrl)
 
-		kp := &KafkaProducer{client: &pMockErr{error: kafka.LeaderNotAvailable}}
+		pm := &ProducerManager{p: &pMockErr{error: kafka.LeaderNotAvailable}}
 		destConfig := map[string]interface{}{"topic": "foo-bar"}
-		sc, res, err := kp.Produce(json.RawMessage(`{"message":"ciao"}`), destConfig)
+		sc, res, err := pm.Produce(json.RawMessage(`{"message":"ciao"}`), destConfig)
 		require.Equal(t, 500, sc)
 		require.Contains(t, res, kafka.LeaderNotAvailable.Error()+" error occurred.")
 		require.Contains(t, err, kafka.LeaderNotAvailable.Error())
@@ -502,9 +496,9 @@ func TestProduce(t *testing.T) {
 		kafkaStats.publishTime = getMockedTimer(t, ctrl)
 		kafkaStats.produceTime = getMockedTimer(t, ctrl)
 
-		kp := &KafkaProducer{client: &pMockErr{}}
+		pm := &ProducerManager{p: &pMockErr{}}
 		destConfig := map[string]interface{}{"topic": "foo-bar"}
-		sc, res, err := kp.Produce(json.RawMessage(`{"message":"ciao"}`), destConfig)
+		sc, res, err := pm.Produce(json.RawMessage(`{"message":"ciao"}`), destConfig)
 		require.Equal(t, 200, sc)
 		require.Equal(t, "Message delivered to topic: foo-bar", res)
 		require.Equal(t, "Message delivered to topic: foo-bar", err)
@@ -544,10 +538,11 @@ func TestSendBatchedMessage(t *testing.T) {
 		kafkaStats.prepareBatchTime = getMockedTimer(t, ctrl)
 
 		p := &pMockErr{error: fmt.Errorf("something bad")}
+		pm := &ProducerManager{p: p}
 		sc, res, err := sendBatchedMessage(
 			context.Background(),
 			json.RawMessage(`[{"message":"ciao","userId":"123"}]`),
-			p,
+			pm,
 			"some-topic",
 		)
 		require.Equal(t, 400, sc)
@@ -567,10 +562,11 @@ func TestSendBatchedMessage(t *testing.T) {
 		kafkaStats.prepareBatchTime = getMockedTimer(t, ctrl)
 
 		p := &pMockErr{error: kafka.LeaderNotAvailable}
+		pm := &ProducerManager{p: p}
 		sc, res, err := sendBatchedMessage(
 			context.Background(),
 			json.RawMessage(`[{"message":"ciao","userId":"123"}]`),
-			p,
+			pm,
 			"some-topic",
 		)
 		require.Equal(t, 500, sc)
@@ -590,10 +586,11 @@ func TestSendBatchedMessage(t *testing.T) {
 		kafkaStats.prepareBatchTime = getMockedTimer(t, ctrl)
 
 		p := &pMockErr{error: nil}
+		pm := &ProducerManager{p: p}
 		sc, res, err := sendBatchedMessage(
 			context.Background(),
 			json.RawMessage(`[{"message":"ciao","userId":"123"}]`),
-			p,
+			pm,
 			"some-topic",
 		)
 		require.Equal(t, 200, sc)
@@ -625,10 +622,11 @@ func TestSendBatchedMessage(t *testing.T) {
 				"schemaId001": codec,
 			},
 		}
+		pm := &ProducerManager{p: p}
 		sc, res, err := sendBatchedMessage(
 			context.Background(),
 			json.RawMessage(`[{"message":{"messageId":"message001","data":"ciao"},"userId":"123"}]`),
-			p,
+			pm,
 			"some-topic",
 		)
 		require.Equal(t, 400, sc)
@@ -654,10 +652,11 @@ func TestSendBatchedMessage(t *testing.T) {
 				"schemaId001": codec,
 			},
 		}
+		pm := &ProducerManager{p: p}
 		sc, res, err := sendBatchedMessage(
 			context.Background(),
 			json.RawMessage(`[{"message":{"messageId":"message001","data":"ciao"},"userId":"123","schemaId":"schemaId001"}]`),
-			p,
+			pm,
 			"some-topic",
 		)
 		require.Equal(t, 400, sc)
@@ -683,10 +682,11 @@ func TestSendBatchedMessage(t *testing.T) {
 				"schemaId001": codec,
 			},
 		}
+		pm := &ProducerManager{p: p}
 		sc, res, err := sendBatchedMessage(
 			context.Background(),
 			json.RawMessage(`[{"message":{"messageId":"message001","data":"ciao"},"userId":"123","schemaId":"schemaId002"}]`),
-			p,
+			pm,
 			"some-topic",
 		)
 		require.Equal(t, 400, sc)
@@ -714,7 +714,8 @@ func TestSendMessage(t *testing.T) {
 		kafkaStats.publishTime = getMockedTimer(t, gomock.NewController(t))
 
 		p := &pMockErr{error: nil}
-		sc, res, err := sendMessage(context.Background(), json.RawMessage(`{"message":"ciao"}`), p, "some-topic")
+		pm := &ProducerManager{p: p}
+		sc, res, err := sendMessage(context.Background(), json.RawMessage(`{"message":"ciao"}`), pm, "some-topic")
 		require.Equal(t, 200, sc)
 		require.Equal(t, "Message delivered to topic: some-topic", res)
 		require.Equal(t, "Message delivered to topic: some-topic", err)
@@ -730,10 +731,11 @@ func TestSendMessage(t *testing.T) {
 		kafkaStats.publishTime = getMockedTimer(t, gomock.NewController(t))
 
 		p := &pMockErr{error: fmt.Errorf("something bad")}
+		pm := &ProducerManager{p: p}
 		sc, res, err := sendMessage(
 			context.Background(),
 			json.RawMessage(`{"message":"ciao","userId":"123"}`),
-			p,
+			pm,
 			"some-topic",
 		)
 		require.Equal(t, 400, sc)
@@ -762,10 +764,11 @@ func TestSendMessage(t *testing.T) {
 				"schemaId001": codec,
 			},
 		}
+		pm := &ProducerManager{p: p}
 		sc, res, err := sendMessage(
 			context.Background(),
 			json.RawMessage(`{"message":{"messageId":"message001","data":"ciao"},"userId":"123"}`),
-			p,
+			pm,
 			"some-topic",
 		)
 		require.Equal(t, 400, sc)
@@ -788,10 +791,11 @@ func TestSendMessage(t *testing.T) {
 				"schemaId001": codec,
 			},
 		}
+		pm := &ProducerManager{p: p}
 		sc, res, err := sendMessage(
 			context.Background(),
 			json.RawMessage(`{"message":{"messageId":"message001","data":"ciao"},"userId":"123","schemaId":"schemaId001"}`),
-			p,
+			pm,
 			"some-topic",
 		)
 		require.Equal(t, 400, sc)
@@ -821,15 +825,10 @@ type pMockErr struct {
 	codecs map[string]*goavro.Codec
 }
 
-func (*pMockErr) getTimeout() time.Duration       { return 0 }
 func (p *pMockErr) Close(_ context.Context) error { return p.error }
 func (p *pMockErr) Publish(_ context.Context, msgs ...client.Message) error {
 	p.calls = append(p.calls, msgs)
 	return p.error
-}
-
-func (p *pMockErr) getCodecs() map[string]*goavro.Codec {
-	return p.codecs
 }
 
 type nopLogger struct{}


### PR DESCRIPTION
# Description

PR to add comments and test CI integration. Some tests like `TestAzureEventHubsCloud` are skipped unless some environment variables with credentials are set. I'm creating this PR to inject the secrets accordingly.

### List of tests that are not skipped anymore
* `TestAzureEventHubsCloud`
* `TestNewProducerForAzureEventHubs/ok`
* `TestConfluentAzureCloud`
* `TestProducerForConfluentCloud/ok`

:point_up: the above now connect to real clusters.

### Additional changes

Small refactoring to simplify a few things and added a few assertions here and there.

## Notion Ticket

< [Notion Link](https://www.notion.so/rudderstacks/Azure-Event-Hubs-and-Confuent-Cloud-CI-integration-a18134e3b807438e8969c9d1479aaff2) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
