### PR TITLE
refactor(jobsdb): introduce context aware mutex locks,  transactional migrations & cancelable maintenance operations

### DIFF
--- a/eventorder_test.go
+++ b/eventorder_test.go
@@ -278,7 +278,6 @@ func (eventOrderMethods) newWebhook(t *testing.T, spec *eventOrderSpec) *eventOr
 		require.True(t, testJobId.Exists(), "should have testJobId in the request", body)
 		require.Equal(t, gjson.Number, testJobId.Type, "testJobId should be a number", body)
 		jobID := int(gjson.GetBytes(body, "testJobId").Int())
-
 		userIdResult := gjson.GetBytes(body, "userId")
 		require.True(t, userIdResult.Exists(), "should have userId in the request", body)
 		require.Equal(t, gjson.String, userIdResult.Type, "userId should be a string", body)

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -315,7 +315,7 @@ func (gateway *HandleT) dbWriterWorkerProcess() {
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), WriteTimeout)
-		err := gateway.jobsDB.WithStoreSafeTx(func(tx jobsdb.StoreSafeTx) error {
+		err := gateway.jobsDB.WithStoreSafeTx(ctx, func(tx jobsdb.StoreSafeTx) error {
 			if gwAllowPartialWriteWithErrors {
 				var err error
 				errorMessagesMap, err = gateway.jobsDB.StoreWithRetryEachInTx(ctx, tx, jobList)

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -213,7 +213,7 @@ var _ = Describe("Gateway Enterprise", func() {
 		It("should accept events from normal users", func() {
 			allowedUserEventData := fmt.Sprintf(`{"batch":[{"userId":%q}]}`, NormalUserID)
 
-			c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+			c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())
 			}).Return(nil)
 			mockCall := c.mockJobsDB.EXPECT().StoreWithRetryEachInTx(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(jobsToEmptyErrors).Times(1)
@@ -335,7 +335,7 @@ var _ = Describe("Gateway", func() {
 
 					validBody := createValidBody("custom-property", "custom-value")
 
-					c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+					c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.StoreSafeTx) error) {
 						_ = f(jobsdb.EmptyStoreSafeTx())
 					}).Return(nil)
 					c.mockJobsDB.
@@ -393,7 +393,7 @@ var _ = Describe("Gateway", func() {
 			tFunc = c.asyncHelper.ExpectAndNotifyCallbackWithName("")
 			mockCall.Do(func(interface{}) { tFunc() })
 
-			c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+			c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())
 			}).Return(nil)
 			mockCall = c.mockJobsDB.EXPECT().StoreWithRetryEachInTx(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(jobsToEmptyErrors).Times(1)
@@ -531,7 +531,7 @@ var _ = Describe("Gateway", func() {
 				if handlerType != "import" {
 					validBody := createJSONBody("custom-property", "custom-value")
 
-					c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+					c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.StoreSafeTx) error) {
 						_ = f(jobsdb.EmptyStoreSafeTx())
 					}).Return(nil)
 					c.mockJobsDB.

--- a/go.mod
+++ b/go.mod
@@ -201,7 +201,6 @@ require (
 	github.com/miekg/dns v1.1.25 // indirect
 	github.com/rs/xid v1.4.0 // indirect
 	golang.org/x/exp v0.0.0-20210220032938-85be41e4509f // indirect
-	github.com/viney-shih/go-lock v1.1.2 // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -206,5 +206,6 @@ require (
 
 require (
 	github.com/foxcpp/go-mockdns v1.0.0
+	github.com/viney-shih/go-lock v1.1.2
 	github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04
 )

--- a/go.mod
+++ b/go.mod
@@ -201,6 +201,7 @@ require (
 	github.com/miekg/dns v1.1.25 // indirect
 	github.com/rs/xid v1.4.0 // indirect
 	golang.org/x/exp v0.0.0-20210220032938-85be41e4509f // indirect
+	github.com/viney-shih/go-lock v1.1.2 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1361,6 +1361,8 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.17.1 h1:UzjDEw2dJQUE3iRaiNQ1VrVFbyAtKGH3VdkMoHA58V0=
 github.com/urfave/cli/v2 v2.17.1/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
+github.com/viney-shih/go-lock v1.1.2 h1:3TdGTiHZCPqBdTvFbQZQN/TRZzKF3KWw2rFEyKz3YqA=
+github.com/viney-shih/go-lock v1.1.2/go.mod h1:Yijm78Ljteb3kRiJrbLAxVntkUukGu5uzSxq/xV7OO8=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -467,12 +467,12 @@ func TestJobsDB(t *testing.T) {
 		jobs := genJobs(defaultWorkspaceID, customVal, 1, 1)
 		require.NoError(t, jobDB.Store(context.Background(), jobs))
 
-		require.Equal(t, int64(1), jobDB.GetMaxDSIndex(context.Background()))
+		require.Equal(t, int64(1), jobDB.GetMaxDSIndex())
 		time.Sleep(time.Second * 2)   // wait for some time to pass
 		triggerAddNewDS <- time.Now() // trigger addNewDSLoop to run
 		triggerAddNewDS <- time.Now() // Second time, waits for the first loop to finish
 
-		require.Equal(t, int64(2), jobDB.GetMaxDSIndex(context.Background()))
+		require.Equal(t, int64(2), jobDB.GetMaxDSIndex())
 	})
 
 	t.Run("should migrate the datasets after maxDSRetentionPeriod (except the right most one)", func(t *testing.T) {
@@ -498,14 +498,14 @@ func TestJobsDB(t *testing.T) {
 		jobs := genJobs(defaultWorkspaceID, customVal, 1, 1)
 		require.NoError(t, jobDB.Store(context.Background(), jobs))
 
-		require.EqualValues(t, 1, jobDB.GetMaxDSIndex(context.Background()))
+		require.EqualValues(t, 1, jobDB.GetMaxDSIndex())
 		time.Sleep(time.Second * 2)   // wait for some time to pass
 		triggerAddNewDS <- time.Now() // trigger addNewDSLoop to run
 		triggerAddNewDS <- time.Now() // Second time, waits for the first loop to finish
 
 		jobDBInspector := HandleInspector{HandleT: &jobDB}
-		require.EqualValues(t, 2, jobDBInspector.DSListSize(context.Background()))
-		require.EqualValues(t, 2, jobDB.GetMaxDSIndex(context.Background()))
+		require.EqualValues(t, 2, jobDBInspector.DSListSize())
+		require.EqualValues(t, 2, jobDB.GetMaxDSIndex())
 
 		jobsResult, err := jobDB.GetUnprocessed(context.Background(), GetQueryParamsT{
 			CustomValFilters: []string{customVal},
@@ -533,8 +533,8 @@ func TestJobsDB(t *testing.T) {
 		triggerMigrateDS <- time.Now() // trigger migrateDSLoop to run
 		triggerMigrateDS <- time.Now() // Second time, waits for the first loop to finish
 
-		require.EqualValues(t, 1, jobDBInspector.DSListSize(context.Background()))
-		require.EqualValues(t, 2, jobDB.GetMaxDSIndex(context.Background()))
+		require.EqualValues(t, 1, jobDBInspector.DSListSize())
+		require.EqualValues(t, 2, jobDB.GetMaxDSIndex())
 	})
 
 	t.Run("should migrate small datasets that have been migrated at least once (except right most one)", func(t *testing.T) {

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -467,12 +467,12 @@ func TestJobsDB(t *testing.T) {
 		jobs := genJobs(defaultWorkspaceID, customVal, 1, 1)
 		require.NoError(t, jobDB.Store(context.Background(), jobs))
 
-		require.Equal(t, int64(1), jobDB.GetMaxDSIndex())
+		require.Equal(t, int64(1), jobDB.GetMaxDSIndex(context.Background()))
 		time.Sleep(time.Second * 2)   // wait for some time to pass
 		triggerAddNewDS <- time.Now() // trigger addNewDSLoop to run
 		triggerAddNewDS <- time.Now() // Second time, waits for the first loop to finish
 
-		require.Equal(t, int64(2), jobDB.GetMaxDSIndex())
+		require.Equal(t, int64(2), jobDB.GetMaxDSIndex(context.Background()))
 	})
 
 	t.Run("should migrate the datasets after maxDSRetentionPeriod (except the right most one)", func(t *testing.T) {
@@ -498,14 +498,14 @@ func TestJobsDB(t *testing.T) {
 		jobs := genJobs(defaultWorkspaceID, customVal, 1, 1)
 		require.NoError(t, jobDB.Store(context.Background(), jobs))
 
-		require.EqualValues(t, 1, jobDB.GetMaxDSIndex())
+		require.EqualValues(t, 1, jobDB.GetMaxDSIndex(context.Background()))
 		time.Sleep(time.Second * 2)   // wait for some time to pass
 		triggerAddNewDS <- time.Now() // trigger addNewDSLoop to run
 		triggerAddNewDS <- time.Now() // Second time, waits for the first loop to finish
 
 		jobDBInspector := HandleInspector{HandleT: &jobDB}
-		require.EqualValues(t, 2, jobDBInspector.DSListSize())
-		require.EqualValues(t, 2, jobDB.GetMaxDSIndex())
+		require.EqualValues(t, 2, jobDBInspector.DSListSize(context.Background()))
+		require.EqualValues(t, 2, jobDB.GetMaxDSIndex(context.Background()))
 
 		jobsResult, err := jobDB.GetUnprocessed(context.Background(), GetQueryParamsT{
 			CustomValFilters: []string{customVal},
@@ -533,8 +533,8 @@ func TestJobsDB(t *testing.T) {
 		triggerMigrateDS <- time.Now() // trigger migrateDSLoop to run
 		triggerMigrateDS <- time.Now() // Second time, waits for the first loop to finish
 
-		require.EqualValues(t, 1, jobDBInspector.DSListSize())
-		require.EqualValues(t, 2, jobDB.GetMaxDSIndex())
+		require.EqualValues(t, 1, jobDBInspector.DSListSize(context.Background()))
+		require.EqualValues(t, 2, jobDB.GetMaxDSIndex(context.Background()))
 	})
 
 	t.Run("should migrate small datasets that have been migrated at least once (except right most one)", func(t *testing.T) {

--- a/jobsdb/internal/lock/lock.go
+++ b/jobsdb/internal/lock/lock.go
@@ -27,8 +27,8 @@ func (r *DSListLocker) RLock() {
 	r.m.RLock()
 }
 
-// TryRLockWithCtx tries to acquires a read lock with context and returns false if context times out, otherwise returns true.
-func (r *DSListLocker) TryRLockWithCtx(ctx context.Context) bool {
+// RTryLockWithCtx tries to acquires a read lock with context and returns false if context times out, otherwise returns true.
+func (r *DSListLocker) RTryLockWithCtx(ctx context.Context) bool {
 	return r.m.RTryLockWithContext(ctx)
 }
 

--- a/jobsdb/internal/lock/lock.go
+++ b/jobsdb/internal/lock/lock.go
@@ -1,6 +1,10 @@
 package lock
 
-import "sync"
+import (
+	"context"
+
+	golock "github.com/viney-shih/go-lock"
+)
 
 // DSListLockToken represents proof that a list lock has been acquired
 type DSListLockToken interface {
@@ -9,12 +13,23 @@ type DSListLockToken interface {
 
 // DSListLocker
 type DSListLocker struct {
-	m sync.RWMutex
+	m *golock.CASMutex
+}
+
+func NewDSListLocker() *DSListLocker {
+	return &DSListLocker{
+		m: golock.NewCASMutex(),
+	}
 }
 
 // RLock acquires a read lock
 func (r *DSListLocker) RLock() {
 	r.m.RLock()
+}
+
+// TryRLockWithCtx tries to acquires a read lock with context and returns false if context times out, otherwise returns true.
+func (r *DSListLocker) TryRLockWithCtx(ctx context.Context) bool {
+	return r.m.RTryLockWithContext(ctx)
 }
 
 // RLock releases a read lock
@@ -28,6 +43,17 @@ func (r *DSListLocker) WithLock(f func(l DSListLockToken)) {
 	r.m.Lock()
 	defer r.m.Unlock()
 	f(&listLockToken{})
+}
+
+// TryWithCtxAwareLock tries to acquires a lock until it succeeds or context times out. If it fails, return value is false otherwise true. And, executes the function `f`, if lock is acquired.
+// A token as proof of the lock is passed to the function.
+func (r *DSListLocker) TryWithCtxAwareLock(ctx context.Context, f func(l DSListLockToken)) bool {
+	if r.m.TryLockWithContext(ctx) {
+		defer r.m.Unlock()
+		f(&listLockToken{})
+		return true
+	}
+	return false
 }
 
 // AsyncLock acquires a lock until the token is returned to the receiving channel

--- a/jobsdb/internal/lock/lock_test.go
+++ b/jobsdb/internal/lock/lock_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAsyncLock(t *testing.T) {
-	locker := lock.NewDSListLocker()
+	locker := lock.NewLocker()
 
 	l, c := locker.AsyncLock()
 	require.NotNil(t, l)
@@ -20,7 +20,7 @@ func TestAsyncLock(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		wg.Done()
-		locker.WithLock(func(l lock.DSListLockToken) {
+		locker.WithLock(func(l lock.LockToken) {
 			secondLock <- struct{}{}
 		})
 	}()

--- a/jobsdb/internal/lock/lock_test.go
+++ b/jobsdb/internal/lock/lock_test.go
@@ -1,6 +1,7 @@
 package lock_test
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -9,10 +10,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRLock(t *testing.T) {
+	locker := lock.NewLocker()
+	locker.RLock()
+
+	t.Run("Multiple read locks can be acquired", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+		defer cancel()
+		require.True(t, locker.RTryLockWithCtx(ctx))
+		locker.RUnlock()
+	})
+
+	t.Run("A write lock cannot be acquired if a read lock is already acquired", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+		defer cancel()
+		require.False(t, locker.TryLockWithCtx(ctx))
+	})
+
+	t.Run("A write lock can be acquired after a read lock is released", func(t *testing.T) {
+		locker.RUnlock()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		require.True(t, locker.TryLockWithCtx(ctx))
+		locker.Unlock()
+	})
+}
+
 func TestAsyncLock(t *testing.T) {
 	locker := lock.NewLocker()
 
-	l, c := locker.AsyncLock()
+	l, c, err := locker.AsyncLockWithCtx(context.Background())
+	require.NoError(t, err)
 	require.NotNil(t, l)
 
 	secondLock := make(chan struct{})
@@ -38,4 +66,16 @@ func TestAsyncLock(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("second lock should have been acquired")
 	}
+}
+
+func TestAsyncLockTimeout(t *testing.T) {
+	locker := lock.NewLocker()
+	locker.RLock()
+	defer locker.RUnlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	l, c, err := locker.AsyncLockWithCtx(ctx)
+	require.Error(t, err)
+	require.Nil(t, l)
+	require.Nil(t, c)
 }

--- a/jobsdb/internal/lock/lock_test.go
+++ b/jobsdb/internal/lock/lock_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAsyncLock(t *testing.T) {
-	locker := &lock.DSListLocker{}
+	locker := lock.NewDSListLocker()
 
 	l, c := locker.AsyncLock()
 	require.NotNil(t, l)

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -3188,6 +3188,7 @@ func (jd *HandleT) migrateDSLoop(ctx context.Context) {
 						jd.inProgressMigrationTargetDS = nil
 					})
 					if !success {
+						jd.JournalMarkDone(opID)
 						continue
 					}
 				}

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -187,7 +187,7 @@ func (*backupTestCase) insertRTData(t *testing.T, jobs []*JobT, statusList []*Jo
 	require.NoError(t, err)
 
 	rtDS2 := newDataSet("rt", "2")
-	jobsDB.dsListLock.WithLock(func(l lock.DSListLockToken) {
+	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
 		jobsDB.addNewDS(l, rtDS2)
 	})
 	err = jobsDB.WithTx(func(tx *sql.Tx) error {
@@ -224,7 +224,7 @@ func (*backupTestCase) insertBatchRTData(t *testing.T, jobs []*JobT, statusList 
 	require.NoError(t, err)
 
 	ds2 := newDataSet("batch_rt", "2")
-	jobsDB.dsListLock.WithLock(func(l lock.DSListLockToken) {
+	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
 		jobsDB.addNewDS(l, ds2)
 	})
 	err = jobsDB.WithTx(func(tx *sql.Tx) error {

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -3,6 +3,7 @@ package jobsdb
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -452,7 +453,9 @@ func TestRefreshDSList(t *testing.T) {
 	defer jobsDB.TearDown()
 
 	require.Equal(t, 1, len(jobsDB.getDSList()), "jobsDB should start with a ds list size of 1")
-	jobsDB.addDS(newDataSet(prefix, "2"))
+	require.NoError(t, jobsDB.WithTx(func(tx *sql.Tx) error {
+		return jobsDB.addDSInTx(tx, newDataSet(prefix, "2"))
+	}))
 	require.Equal(t, 1, len(jobsDB.getDSList()), "addDS should not refresh the ds list")
 	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
 		require.Equal(t, 2, len(jobsDB.refreshDSList(l)), "after refreshing the ds list jobsDB should have a ds list size of 2")

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -454,7 +454,7 @@ func TestRefreshDSList(t *testing.T) {
 	require.Equal(t, 1, len(jobsDB.getDSList()), "jobsDB should start with a ds list size of 1")
 	jobsDB.addDS(newDataSet(prefix, "2"))
 	require.Equal(t, 1, len(jobsDB.getDSList()), "addDS should not refresh the ds list")
-	jobsDB.dsListLock.WithLock(func(l lock.DSListLockToken) {
+	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
 		require.Equal(t, 2, len(jobsDB.refreshDSList(l)), "after refreshing the ds list jobsDB should have a ds list size of 2")
 	})
 }

--- a/jobsdb/setup.go
+++ b/jobsdb/setup.go
@@ -20,7 +20,7 @@ func (jd *HandleT) SchemaMigrationTable() string {
 // - Prefix: The table prefix used by this jobsdb instance.
 // - Datasets: Array of existing dataset indices.
 // If clearAll is set to true, all existing jobsdb tables will be removed first.
-func (jd *HandleT) setupDatabaseTables(l lock.DSListLockToken, clearAll bool) {
+func (jd *HandleT) setupDatabaseTables(l lock.LockToken, clearAll bool) {
 	if clearAll {
 		jd.dropDatabaseTables(l)
 	}
@@ -60,7 +60,7 @@ func (jd *HandleT) setupDatabaseTables(l lock.DSListLockToken, clearAll bool) {
 	}
 }
 
-func (jd *HandleT) dropDatabaseTables(l lock.DSListLockToken) {
+func (jd *HandleT) dropDatabaseTables(l lock.LockToken) {
 	jd.logger.Infof("[JobsDB:%v] Dropping all database tables", jd.tablePrefix)
 	jd.dropSchemaMigrationTables()
 	jd.assertError(jd.dropAllDS(l))

--- a/jobsdb/unionQuery.go
+++ b/jobsdb/unionQuery.go
@@ -21,7 +21,7 @@ type MultiTenantHandleT struct {
 type MultiTenantJobsDB interface {
 	GetAllJobs(context.Context, map[string]int, GetQueryParamsT, int) ([]*JobT, error)
 
-	WithUpdateSafeTx(func(tx UpdateSafeTx) error) error
+	WithUpdateSafeTx(context.Context, func(tx UpdateSafeTx) error) error
 	UpdateJobStatusInTx(ctx context.Context, tx UpdateSafeTx, statusList []*JobStatusT, customValFilters []string, parameterFilters []ParameterFilterT) error
 	UpdateJobStatus(ctx context.Context, statusList []*JobStatusT, customValFilters []string, parameterFilters []ParameterFilterT) error
 

--- a/jobsdb/unionQuery.go
+++ b/jobsdb/unionQuery.go
@@ -67,64 +67,63 @@ func (mj *MultiTenantHandleT) GetAllJobs(ctx context.Context, workspaceCount map
 	// The order of lock is very important. The migrateDSLoop
 	// takes lock in this order so reversing this will cause
 	// deadlocks
-	if mj.dsMigrationLock.RTryLockWithCtx(ctx) {
-		defer mj.dsMigrationLock.RUnlock()
-
-		if mj.dsListLock.RTryLockWithCtx(ctx) {
-			defer mj.dsListLock.RUnlock()
-
-			dsList := mj.getDSList()
-			outJobs := make([]*JobT, 0)
-
-			workspacePayloadLimitMap := make(map[string]int64)
-			for workspace, count := range workspaceCount {
-				percentage := math.Max(float64(count), 0) / float64(params.JobsLimit)
-				payloadLimit := percentage * float64(params.PayloadSizeLimit)
-				workspacePayloadLimitMap[workspace] = int64(payloadLimit)
-			}
-
-			var tablesQueried int
-			params.StateFilters = []string{NotProcessed.State, Waiting.State, Failed.State}
-			conditions := QueryConditions{
-				IgnoreCustomValFiltersInQuery: params.IgnoreCustomValFiltersInQuery,
-				CustomValFilters:              params.CustomValFilters,
-				ParameterFilters:              params.ParameterFilters,
-				StateFilters:                  params.StateFilters,
-			}
-			start := time.Now()
-			for _, ds := range dsList {
-				jobs, err := mj.getUnionDS(ctx, ds, workspaceCount, workspacePayloadLimitMap, conditions)
-				if err != nil {
-					return nil, err
-				}
-				outJobs = append(outJobs, jobs...)
-				if len(jobs) > 0 {
-					tablesQueried++
-				}
-
-				if len(workspaceCount) == 0 {
-					break
-				}
-				if tablesQueried >= maxDSQuerySize {
-					break
-				}
-			}
-
-			mj.unionQueryTime.SendTiming(time.Since(start))
-
-			unionQueryTablesQueriedStat := stats.Default.NewTaggedStat("tables_queried_gauge", stats.GaugeType, stats.Tags{
-				"state":     "nonterminal",
-				"query":     "union",
-				"customVal": mj.tablePrefix,
-			})
-			unionQueryTablesQueriedStat.Gauge(tablesQueried)
-
-			return outJobs, nil
-
-		}
-		return nil, fmt.Errorf("could not acquire DS Rlock")
+	if !mj.dsMigrationLock.RTryLockWithCtx(ctx) {
+		return nil, fmt.Errorf("could not acquire a migration read lock: %w", ctx.Err())
 	}
-	return nil, fmt.Errorf("could not acquire DS migration Rlock")
+	defer mj.dsMigrationLock.RUnlock()
+
+	if !mj.dsListLock.RTryLockWithCtx(ctx) {
+		return nil, fmt.Errorf("could not acquire a dslist read lock: %w", ctx.Err())
+	}
+	defer mj.dsListLock.RUnlock()
+
+	dsList := mj.getDSList()
+	outJobs := make([]*JobT, 0)
+
+	workspacePayloadLimitMap := make(map[string]int64)
+	for workspace, count := range workspaceCount {
+		percentage := math.Max(float64(count), 0) / float64(params.JobsLimit)
+		payloadLimit := percentage * float64(params.PayloadSizeLimit)
+		workspacePayloadLimitMap[workspace] = int64(payloadLimit)
+	}
+
+	var tablesQueried int
+	params.StateFilters = []string{NotProcessed.State, Waiting.State, Failed.State}
+	conditions := QueryConditions{
+		IgnoreCustomValFiltersInQuery: params.IgnoreCustomValFiltersInQuery,
+		CustomValFilters:              params.CustomValFilters,
+		ParameterFilters:              params.ParameterFilters,
+		StateFilters:                  params.StateFilters,
+	}
+	start := time.Now()
+	for _, ds := range dsList {
+		jobs, err := mj.getUnionDS(ctx, ds, workspaceCount, workspacePayloadLimitMap, conditions)
+		if err != nil {
+			return nil, err
+		}
+		outJobs = append(outJobs, jobs...)
+		if len(jobs) > 0 {
+			tablesQueried++
+		}
+
+		if len(workspaceCount) == 0 {
+			break
+		}
+		if tablesQueried >= maxDSQuerySize {
+			break
+		}
+	}
+
+	mj.unionQueryTime.SendTiming(time.Since(start))
+
+	unionQueryTablesQueriedStat := stats.Default.NewTaggedStat("tables_queried_gauge", stats.GaugeType, stats.Tags{
+		"state":     "nonterminal",
+		"query":     "union",
+		"customVal": mj.tablePrefix,
+	})
+	unionQueryTablesQueriedStat.Gauge(tablesQueried)
+
+	return outJobs, nil
 }
 
 func (mj *MultiTenantHandleT) getUnionDS(ctx context.Context, ds dataSetT, workspaceCount map[string]int, workspacePayloadLimitMap map[string]int64, conditions QueryConditions) ([]*JobT, error) { // skipcq: CRT-P0003

--- a/jobsdb/unionQuery.go
+++ b/jobsdb/unionQuery.go
@@ -68,57 +68,61 @@ func (mj *MultiTenantHandleT) GetAllJobs(ctx context.Context, workspaceCount map
 	// takes lock in this order so reversing this will cause
 	// deadlocks
 	mj.dsMigrationLock.RLock()
-	mj.dsListLock.RLock()
 	defer mj.dsMigrationLock.RUnlock()
-	defer mj.dsListLock.RUnlock()
 
-	dsList := mj.getDSList()
-	outJobs := make([]*JobT, 0)
+	if mj.dsListLock.RTryLockWithCtx(ctx) {
+		defer mj.dsListLock.RUnlock()
 
-	workspacePayloadLimitMap := make(map[string]int64)
-	for workspace, count := range workspaceCount {
-		percentage := math.Max(float64(count), 0) / float64(params.JobsLimit)
-		payloadLimit := percentage * float64(params.PayloadSizeLimit)
-		workspacePayloadLimitMap[workspace] = int64(payloadLimit)
+		dsList := mj.getDSList()
+		outJobs := make([]*JobT, 0)
+
+		workspacePayloadLimitMap := make(map[string]int64)
+		for workspace, count := range workspaceCount {
+			percentage := math.Max(float64(count), 0) / float64(params.JobsLimit)
+			payloadLimit := percentage * float64(params.PayloadSizeLimit)
+			workspacePayloadLimitMap[workspace] = int64(payloadLimit)
+		}
+
+		var tablesQueried int
+		params.StateFilters = []string{NotProcessed.State, Waiting.State, Failed.State}
+		conditions := QueryConditions{
+			IgnoreCustomValFiltersInQuery: params.IgnoreCustomValFiltersInQuery,
+			CustomValFilters:              params.CustomValFilters,
+			ParameterFilters:              params.ParameterFilters,
+			StateFilters:                  params.StateFilters,
+		}
+		start := time.Now()
+		for _, ds := range dsList {
+			jobs, err := mj.getUnionDS(ctx, ds, workspaceCount, workspacePayloadLimitMap, conditions)
+			if err != nil {
+				return nil, err
+			}
+			outJobs = append(outJobs, jobs...)
+			if len(jobs) > 0 {
+				tablesQueried++
+			}
+
+			if len(workspaceCount) == 0 {
+				break
+			}
+			if tablesQueried >= maxDSQuerySize {
+				break
+			}
+		}
+
+		mj.unionQueryTime.SendTiming(time.Since(start))
+
+		unionQueryTablesQueriedStat := stats.Default.NewTaggedStat("tables_queried_gauge", stats.GaugeType, stats.Tags{
+			"state":     "nonterminal",
+			"query":     "union",
+			"customVal": mj.tablePrefix,
+		})
+		unionQueryTablesQueriedStat.Gauge(tablesQueried)
+
+		return outJobs, nil
+
 	}
-
-	var tablesQueried int
-	params.StateFilters = []string{NotProcessed.State, Waiting.State, Failed.State}
-	conditions := QueryConditions{
-		IgnoreCustomValFiltersInQuery: params.IgnoreCustomValFiltersInQuery,
-		CustomValFilters:              params.CustomValFilters,
-		ParameterFilters:              params.ParameterFilters,
-		StateFilters:                  params.StateFilters,
-	}
-	start := time.Now()
-	for _, ds := range dsList {
-		jobs, err := mj.getUnionDS(ctx, ds, workspaceCount, workspacePayloadLimitMap, conditions)
-		if err != nil {
-			return nil, err
-		}
-		outJobs = append(outJobs, jobs...)
-		if len(jobs) > 0 {
-			tablesQueried++
-		}
-
-		if len(workspaceCount) == 0 {
-			break
-		}
-		if tablesQueried >= maxDSQuerySize {
-			break
-		}
-	}
-
-	mj.unionQueryTime.SendTiming(time.Since(start))
-
-	unionQueryTablesQueriedStat := stats.Default.NewTaggedStat("tables_queried_gauge", stats.GaugeType, stats.Tags{
-		"state":     "nonterminal",
-		"query":     "union",
-		"customVal": mj.tablePrefix,
-	})
-	unionQueryTablesQueriedStat.Gauge(tablesQueried)
-
-	return outJobs, nil
+	return nil, fmt.Errorf("could not acquire Rlock")
 }
 
 func (mj *MultiTenantHandleT) getUnionDS(ctx context.Context, ds dataSetT, workspaceCount map[string]int, workspacePayloadLimitMap map[string]int64, conditions QueryConditions) ([]*JobT, error) { // skipcq: CRT-P0003

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -323,17 +323,17 @@ func (mr *MockJobsDBMockRecorder) UpdateJobStatusInTx(arg0, arg1, arg2, arg3, ar
 }
 
 // WithStoreSafeTx mocks base method.
-func (m *MockJobsDB) WithStoreSafeTx(arg0 func(jobsdb.StoreSafeTx) error) error {
+func (m *MockJobsDB) WithStoreSafeTx(arg0 context.Context, arg1 func(jobsdb.StoreSafeTx) error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WithStoreSafeTx", arg0)
+	ret := m.ctrl.Call(m, "WithStoreSafeTx", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WithStoreSafeTx indicates an expected call of WithStoreSafeTx.
-func (mr *MockJobsDBMockRecorder) WithStoreSafeTx(arg0 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) WithStoreSafeTx(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithStoreSafeTx", reflect.TypeOf((*MockJobsDB)(nil).WithStoreSafeTx), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithStoreSafeTx", reflect.TypeOf((*MockJobsDB)(nil).WithStoreSafeTx), arg0, arg1)
 }
 
 // WithTx mocks base method.
@@ -351,15 +351,15 @@ func (mr *MockJobsDBMockRecorder) WithTx(arg0 interface{}) *gomock.Call {
 }
 
 // WithUpdateSafeTx mocks base method.
-func (m *MockJobsDB) WithUpdateSafeTx(arg0 func(jobsdb.UpdateSafeTx) error) error {
+func (m *MockJobsDB) WithUpdateSafeTx(arg0 context.Context, arg1 func(jobsdb.UpdateSafeTx) error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WithUpdateSafeTx", arg0)
+	ret := m.ctrl.Call(m, "WithUpdateSafeTx", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WithUpdateSafeTx indicates an expected call of WithUpdateSafeTx.
-func (mr *MockJobsDBMockRecorder) WithUpdateSafeTx(arg0 interface{}) *gomock.Call {
+func (mr *MockJobsDBMockRecorder) WithUpdateSafeTx(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithUpdateSafeTx", reflect.TypeOf((*MockJobsDB)(nil).WithUpdateSafeTx), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithUpdateSafeTx", reflect.TypeOf((*MockJobsDB)(nil).WithUpdateSafeTx), arg0, arg1)
 }

--- a/mocks/jobsdb/mock_unionQuery.go
+++ b/mocks/jobsdb/mock_unionQuery.go
@@ -147,15 +147,15 @@ func (mr *MockMultiTenantJobsDBMockRecorder) UpdateJobStatusInTx(arg0, arg1, arg
 }
 
 // WithUpdateSafeTx mocks base method.
-func (m *MockMultiTenantJobsDB) WithUpdateSafeTx(arg0 func(jobsdb.UpdateSafeTx) error) error {
+func (m *MockMultiTenantJobsDB) WithUpdateSafeTx(arg0 context.Context, arg1 func(jobsdb.UpdateSafeTx) error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WithUpdateSafeTx", arg0)
+	ret := m.ctrl.Call(m, "WithUpdateSafeTx", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WithUpdateSafeTx indicates an expected call of WithUpdateSafeTx.
-func (mr *MockMultiTenantJobsDBMockRecorder) WithUpdateSafeTx(arg0 interface{}) *gomock.Call {
+func (mr *MockMultiTenantJobsDBMockRecorder) WithUpdateSafeTx(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithUpdateSafeTx", reflect.TypeOf((*MockMultiTenantJobsDB)(nil).WithUpdateSafeTx), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithUpdateSafeTx", reflect.TypeOf((*MockMultiTenantJobsDB)(nil).WithUpdateSafeTx), arg0, arg1)
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1576,7 +1576,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 		proc.logger.Debug("[Processor] Total jobs written to batch router : ", len(batchDestJobs))
 
 		err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
-			return proc.batchRouterDB.WithStoreSafeTx(func(tx jobsdb.StoreSafeTx) error {
+			return proc.batchRouterDB.WithStoreSafeTx(ctx, func(tx jobsdb.StoreSafeTx) error {
 				err := proc.batchRouterDB.StoreInTx(ctx, tx, batchDestJobs)
 				if err != nil {
 					return fmt.Errorf("storing batch router jobs: %w", err)
@@ -1615,7 +1615,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 		proc.logger.Debug("[Processor] Total jobs written to router : ", len(destJobs))
 
 		err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
-			return proc.routerDB.WithStoreSafeTx(func(tx jobsdb.StoreSafeTx) error {
+			return proc.routerDB.WithStoreSafeTx(ctx, func(tx jobsdb.StoreSafeTx) error {
 				err := proc.routerDB.StoreInTx(ctx, tx, destJobs)
 				if err != nil {
 					return fmt.Errorf("storing router jobs: %w", err)
@@ -1669,7 +1669,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 
 	txnStart := time.Now()
 	err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
-		return proc.gatewayDB.WithUpdateSafeTx(func(tx jobsdb.UpdateSafeTx) error {
+		return proc.gatewayDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
 			err := proc.gatewayDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{GWCustomVal}, nil)
 			if err != nil {
 				return fmt.Errorf("updating gateway jobs statuses: %w", err)

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -533,7 +533,7 @@ var _ = Describe("Processor", func() {
 				Expect(string(job.Parameters)).To(Equal(`{"source_id":"source-from-transformer","destination_id":"destination-from-transformer","received_at":"","transform_at":"processor","message_id":"","gateway_job_id":0,"source_batch_id":"","source_task_id":"","source_task_run_id":"","source_job_id":"","source_job_run_id":"","event_name":"","event_type":"","source_definition_id":"","destination_definition_id":"","source_category":"","record_id":null,"workspaceId":""}`))
 			}
 			// One Store call is expected for all events
-			c.mockRouterJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+			c.mockRouterJobsDB.EXPECT().WithStoreSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())
 			}).Return(nil)
 
@@ -547,7 +547,7 @@ var _ = Describe("Processor", func() {
 
 			c.MockMultitenantHandle.EXPECT().ReportProcLoopAddStats(gomock.Any(), gomock.Any()).Times(1)
 
-			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
 			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(unprocessedJobsList)), gatewayCustomVal, nil).Times(1).After(callStoreRouter).
@@ -733,7 +733,7 @@ var _ = Describe("Processor", func() {
 				Expect(string(job.Parameters)).To(Equal(`{"source_id":"source-from-transformer","destination_id":"destination-from-transformer","received_at":"","transform_at":"processor","message_id":"","gateway_job_id":0,"source_batch_id":"","source_task_id":"","source_task_run_id":"","source_job_id":"","source_job_run_id":"","event_name":"","event_type":"","source_definition_id":"","destination_definition_id":"","source_category":"","record_id":null,"workspaceId":""}`))
 			}
 
-			c.mockBatchRouterJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+			c.mockBatchRouterJobsDB.EXPECT().WithStoreSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())
 			}).Return(nil)
 			callStoreBatchRouter := c.mockBatchRouterJobsDB.EXPECT().StoreInTx(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
@@ -746,7 +746,7 @@ var _ = Describe("Processor", func() {
 
 			c.MockMultitenantHandle.EXPECT().ReportProcLoopAddStats(gomock.Any(), gomock.Any()).Times(1)
 
-			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
 			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(unprocessedJobsList)), gatewayCustomVal, nil).Times(1).After(callStoreBatchRouter).
@@ -838,14 +838,14 @@ var _ = Describe("Processor", func() {
 			// We expect one transform call to destination A, after callUnprocessed.
 			mockTransformer.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0).After(callUnprocessed)
 			// One Store call is expected for all events
-			c.mockRouterJobsDB.EXPECT().WithStoreSafeTx(gomock.Any()).Do(func(f func(tx jobsdb.StoreSafeTx) error) {
+			c.mockRouterJobsDB.EXPECT().WithStoreSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())
 			}).Return(nil).Times(1)
 			callStoreRouter := c.mockRouterJobsDB.EXPECT().StoreInTx(gomock.Any(), gomock.Any(), gomock.Len(2)).Times(1)
 
 			c.MockMultitenantHandle.EXPECT().ReportProcLoopAddStats(gomock.Any(), gomock.Any()).Times(1)
 
-			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
 			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(unprocessedJobsList)), gatewayCustomVal, nil).Times(1).After(callStoreRouter)
@@ -965,7 +965,7 @@ var _ = Describe("Processor", func() {
 
 			c.MockMultitenantHandle.EXPECT().ReportProcLoopAddStats(gomock.Any(), gomock.Any()).Times(0)
 
-			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
 			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(unprocessedJobsList)), gatewayCustomVal, nil).Times(1).
@@ -1100,7 +1100,7 @@ var _ = Describe("Processor", func() {
 
 			c.MockMultitenantHandle.EXPECT().ReportProcLoopAddStats(gomock.Any(), gomock.Any()).Times(0)
 
-			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
 			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(toRetryJobsList)+len(unprocessedJobsList)), gatewayCustomVal, nil).Times(1).
@@ -1180,7 +1180,7 @@ var _ = Describe("Processor", func() {
 
 			c.MockMultitenantHandle.EXPECT().ReportProcLoopAddStats(gomock.Any(), gomock.Any()).Times(0)
 
-			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
 			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(toRetryJobsList)+len(unprocessedJobsList)), gatewayCustomVal, nil).Times(1).

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -855,7 +855,9 @@ func (brt *HandleT) sendJobsToStorage(batchJobs BatchJobsT) {
 	if err != nil {
 		panic(fmt.Errorf("BRT: %s: file open failed : %s", brt.destType, err.Error()))
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 	var jobString string
 	writeAtBytes := brt.asyncDestinationStruct[destinationID].Size
 
@@ -1517,8 +1519,8 @@ func (brt *HandleT) trackRequestMetrics(batchReqDiagnostics batchRequestMetric) 
 	if diagnostics.EnableBatchRouterMetric {
 		brt.batchRequestsMetricLock.Lock()
 		if brt.batchRequestsMetric == nil {
-			var batchRequestsMetric []batchRequestMetric
-			brt.batchRequestsMetric = append(batchRequestsMetric, batchReqDiagnostics)
+			brt.batchRequestsMetric = []batchRequestMetric{}
+			brt.batchRequestsMetric = append(brt.batchRequestsMetric, batchReqDiagnostics)
 		} else {
 			brt.batchRequestsMetric = append(brt.batchRequestsMetric, batchReqDiagnostics)
 		}

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -855,9 +855,7 @@ func (brt *HandleT) sendJobsToStorage(batchJobs BatchJobsT) {
 	if err != nil {
 		panic(fmt.Errorf("BRT: %s: file open failed : %s", brt.destType, err.Error()))
 	}
-	defer func() {
-		_ = file.Close()
-	}()
+	defer func() { _ = file.Close() }()
 	var jobString string
 	writeAtBytes := brt.asyncDestinationStruct[destinationID].Size
 
@@ -1518,12 +1516,7 @@ func getBRTErrorCode(state string) int {
 func (brt *HandleT) trackRequestMetrics(batchReqDiagnostics batchRequestMetric) {
 	if diagnostics.EnableBatchRouterMetric {
 		brt.batchRequestsMetricLock.Lock()
-		if brt.batchRequestsMetric == nil {
-			brt.batchRequestsMetric = []batchRequestMetric{}
-			brt.batchRequestsMetric = append(brt.batchRequestsMetric, batchReqDiagnostics)
-		} else {
-			brt.batchRequestsMetric = append(brt.batchRequestsMetric, batchReqDiagnostics)
-		}
+		brt.batchRequestsMetric = append(brt.batchRequestsMetric, batchReqDiagnostics)
 		brt.batchRequestsMetricLock.Unlock()
 	}
 }

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -450,7 +450,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 										}
 										brt.failedJobCount.Count(len(statusList))
 										err := misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) error {
-											return brt.jobsDB.WithUpdateSafeTx(func(tx jobsdb.UpdateSafeTx) error {
+											return brt.jobsDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
 												err = brt.jobsDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{brt.destType}, parameterFilters)
 												if err != nil {
 													return fmt.Errorf("updating %s job statuses: %w", brt.destType, err)
@@ -507,7 +507,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 									}
 								}
 								err = misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) error {
-									return brt.jobsDB.WithUpdateSafeTx(func(tx jobsdb.UpdateSafeTx) error {
+									return brt.jobsDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
 										err = brt.jobsDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{brt.destType}, parameterFilters)
 										if err != nil {
 											return fmt.Errorf("updating %s job statuses: %w", brt.destType, err)
@@ -581,7 +581,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 								}
 
 								err = misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) error {
-									return brt.jobsDB.WithUpdateSafeTx(func(tx jobsdb.UpdateSafeTx) error {
+									return brt.jobsDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
 										err = brt.jobsDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{brt.destType}, parameterFilters)
 										if err != nil {
 											return fmt.Errorf("updating %s job statuses: %w", brt.destType, err)
@@ -1366,7 +1366,7 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 
 	// Mark the status of the jobs
 	err = misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) error {
-		return brt.jobsDB.WithUpdateSafeTx(func(tx jobsdb.UpdateSafeTx) error {
+		return brt.jobsDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
 			err = brt.jobsDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{brt.destType}, parameterFilters)
 			if err != nil {
 				brt.logger.Errorf("[Batch Router] Error occurred while updating %s jobs statuses. Panicking. Err: %v", brt.destType, err)
@@ -1484,7 +1484,7 @@ func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.Asy
 
 	// Mark the status of the jobs
 	err := misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) error {
-		return brt.jobsDB.WithUpdateSafeTx(func(tx jobsdb.UpdateSafeTx) error {
+		return brt.jobsDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
 			err := brt.jobsDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{brt.destType}, parameterFilters)
 			if err != nil {
 				brt.logger.Errorf("[Batch Router] Error occurred while updating %s jobs statuses. Panicking. Err: %v", brt.destType, err)
@@ -1756,7 +1756,7 @@ func (worker *workerT) workerProcess() {
 			}
 
 			err = misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) error {
-				return brt.jobsDB.WithUpdateSafeTx(func(tx jobsdb.UpdateSafeTx) error {
+				return brt.jobsDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
 					err := brt.jobsDB.UpdateJobStatusInTx(ctx, tx, drainList, []string{brt.destType}, parameterFilters)
 					if err != nil {
 						return fmt.Errorf("marking %s job statuses as aborted: %w", brt.destType, err)

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -241,7 +241,7 @@ var _ = Describe("BatchRouter", func() {
 
 			c.mockBatchRouterJobsDB.EXPECT().JournalMarkStart(gomock.Any(), gomock.Any()).Times(1).Return(int64(1))
 
-			c.mockBatchRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockBatchRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil)
 			c.mockBatchRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{CustomVal["S3"]}, nil).Times(1).

--- a/router/router.go
+++ b/router/router.go
@@ -1444,7 +1444,7 @@ func (rt *HandleT) commitStatusList(responseList *[]jobResponseT) {
 		}
 		// Update the status
 		err := misc.RetryWithNotify(context.Background(), rt.jobsDBCommandTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) error {
-			return rt.jobsDB.WithUpdateSafeTx(func(tx jobsdb.UpdateSafeTx) error {
+			return rt.jobsDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
 				err := rt.jobsDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{rt.destName}, nil)
 				if err != nil {
 					return fmt.Errorf("updating %s jobs statuses: %w", rt.destName, err)
@@ -1894,7 +1894,7 @@ func (rt *HandleT) readAndProcess() int {
 		// REPORTING - ROUTER - END
 
 		err = misc.RetryWithNotify(context.Background(), rt.jobsDBCommandTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) error {
-			return rt.jobsDB.WithUpdateSafeTx(func(tx jobsdb.UpdateSafeTx) error {
+			return rt.jobsDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
 				err := rt.jobsDB.UpdateJobStatusInTx(ctx, tx, drainList, []string{rt.destName}, nil)
 				if err != nil {
 					return fmt.Errorf("marking %s job statuses as aborted: %w", rt.destName, err)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -284,7 +284,7 @@ var _ = Describe("Router", func() {
 			mockMultitenantHandle.EXPECT().CalculateSuccessFailureCounts(gomock.Any(), gomock.Any(), true, false).AnyTimes()
 			done := make(chan struct{})
 
-			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
@@ -370,7 +370,7 @@ var _ = Describe("Router", func() {
 				})
 			mockMultitenantHandle.EXPECT().CalculateSuccessFailureCounts(gomock.Any(), gomock.Any(), false, true).AnyTimes()
 			done := make(chan struct{})
-			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
@@ -451,7 +451,7 @@ var _ = Describe("Router", func() {
 					Expect(job.UserID).To(Equal(unprocessedJobsList[0].UserID))
 				})
 
-			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
 
@@ -580,7 +580,7 @@ var _ = Describe("Router", func() {
 			mockNetHandle.EXPECT().SendPost(gomock.Any(), gomock.Any()).Times(0)
 			done := make(chan struct{})
 			mockMultitenantHandle.EXPECT().CalculateSuccessFailureCounts(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
@@ -725,7 +725,7 @@ var _ = Describe("Router", func() {
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			done := make(chan struct{})
 			mockMultitenantHandle.EXPECT().CalculateSuccessFailureCounts(gomock.Any(), gomock.Any(), true, false).AnyTimes()
-			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
@@ -876,7 +876,7 @@ var _ = Describe("Router", func() {
 			done := make(chan struct{})
 			mockMultitenantHandle.EXPECT().CalculateSuccessFailureCounts(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
@@ -1108,7 +1108,7 @@ var _ = Describe("Router", func() {
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			done := make(chan struct{})
 			mockMultitenantHandle.EXPECT().CalculateSuccessFailureCounts(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
@@ -1267,7 +1267,7 @@ var _ = Describe("Router", func() {
 			done := make(chan struct{})
 			mockMultitenantHandle.EXPECT().CalculateSuccessFailureCounts(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any()).Times(1).Do(func(f func(tx jobsdb.UpdateSafeTx) error) {
+			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)


### PR DESCRIPTION
# Description

1. Introduced context aware lock for `dsListLock` & `dsMigrationLock`.
2. Modified `migrateDSLoop` to do migration in single transaction.
3. Introduced `migrateDSTimeout` & `refreshDSTimeout` to skip & continue, if failed to acquire lock in the required time.
4. Relevant code refactoring around migration.

## Notion Ticket

https://www.notion.so/rudderstacks/Postpone-jobsdb-operations-migrate-addDS-that-cannot-acquire-a-mutex-lock-after-a-timeout-311d74d6eb624e62a4cb7bbb163f01ed