### PR TITLE
fix: jobsDB backup query time

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -657,7 +657,7 @@ func loadConfig() {
 	config.RegisterIntConfigVariable(10, &maxMigrateOnce, true, 1, "JobsDB.maxMigrateOnce")
 	config.RegisterIntConfigVariable(10, &maxMigrateDSProbe, true, 1, "JobsDB.maxMigrateDSProbe")
 	config.RegisterInt64ConfigVariable(300, &maxTableSize, true, 1000000, "JobsDB.maxTableSizeInMB")
-	//Since, we are guarded by running payload size, setting default value of backupRowsBatchSize to large value.
+	// Since, we are guarded by running payload size, setting default value of backupRowsBatchSize to large value.
 	config.RegisterInt64ConfigVariable(100000, &backupRowsBatchSize, true, 1, "JobsDB.backupRowsBatchSize")
 	config.RegisterInt64ConfigVariable(64*bytesize.MB, &backupMaxTotalPayloadSize, true, 1, "JobsDB.maxBackupTotalPayloadSize")
 	config.RegisterDurationConfigVariable(30, &migrateDSLoopSleepDuration, true, time.Second, []string{"JobsDB.migrateDSLoopSleepDuration", "JobsDB.migrateDSLoopSleepDurationInS"}...)

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -657,7 +657,8 @@ func loadConfig() {
 	config.RegisterIntConfigVariable(10, &maxMigrateOnce, true, 1, "JobsDB.maxMigrateOnce")
 	config.RegisterIntConfigVariable(10, &maxMigrateDSProbe, true, 1, "JobsDB.maxMigrateDSProbe")
 	config.RegisterInt64ConfigVariable(300, &maxTableSize, true, 1000000, "JobsDB.maxTableSizeInMB")
-	config.RegisterInt64ConfigVariable(1000, &backupRowsBatchSize, true, 1, "JobsDB.backupRowsBatchSize")
+	//Since, we are guarded by running payload size, setting default value of backupRowsBatchSize to large value.
+	config.RegisterInt64ConfigVariable(100000, &backupRowsBatchSize, true, 1, "JobsDB.backupRowsBatchSize")
 	config.RegisterInt64ConfigVariable(64*bytesize.MB, &backupMaxTotalPayloadSize, true, 1, "JobsDB.maxBackupTotalPayloadSize")
 	config.RegisterDurationConfigVariable(30, &migrateDSLoopSleepDuration, true, time.Second, []string{"JobsDB.migrateDSLoopSleepDuration", "JobsDB.migrateDSLoopSleepDurationInS"}...)
 	config.RegisterDurationConfigVariable(5, &addNewDSLoopSleepDuration, true, time.Second, []string{"JobsDB.addNewDSLoopSleepDuration", "JobsDB.addNewDSLoopSleepDurationInS"}...)

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -657,8 +657,7 @@ func loadConfig() {
 	config.RegisterIntConfigVariable(10, &maxMigrateOnce, true, 1, "JobsDB.maxMigrateOnce")
 	config.RegisterIntConfigVariable(10, &maxMigrateDSProbe, true, 1, "JobsDB.maxMigrateDSProbe")
 	config.RegisterInt64ConfigVariable(300, &maxTableSize, true, 1000000, "JobsDB.maxTableSizeInMB")
-	// Since, we are guarded by running payload size, setting default value of backupRowsBatchSize to large value.
-	config.RegisterInt64ConfigVariable(100000, &backupRowsBatchSize, true, 1, "JobsDB.backupRowsBatchSize")
+	config.RegisterInt64ConfigVariable(10000, &backupRowsBatchSize, true, 1, "JobsDB.backupRowsBatchSize")
 	config.RegisterInt64ConfigVariable(64*bytesize.MB, &backupMaxTotalPayloadSize, true, 1, "JobsDB.maxBackupTotalPayloadSize")
 	config.RegisterDurationConfigVariable(30, &migrateDSLoopSleepDuration, true, time.Second, []string{"JobsDB.migrateDSLoopSleepDuration", "JobsDB.migrateDSLoopSleepDurationInS"}...)
 	config.RegisterDurationConfigVariable(5, &addNewDSLoopSleepDuration, true, time.Second, []string{"JobsDB.addNewDSLoopSleepDuration", "JobsDB.addNewDSLoopSleepDurationInS"}...)


### PR DESCRIPTION
# Description

> currently, we see `pre_drop` table pileup if a lot of jobs are failing. Since, we have a limit on number of rows read at a time to 1000 (by default). And, when failure is high we have a lot of columns in status table. Because of while taking backup of a single table requires querying DB a lot of time, which takes really really long time. 

So, to avoid this, we are setting the default value of `LIMIT` to a large value `100,000` since, we are already guarded by `running_payload_size`, to avoid OOM kill.

## Notion Ticket

https://www.notion.so/rudderstacks/remove-LIMIT-on-row-count-from-getBackUpQuery-bde1f44331d444f7a33e3b3f99904470
