### PR TITLE
chore: include matched template path in gateway's request metrics

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1368,7 +1368,7 @@ func (gateway *HandleT) StartWebHandler(ctx context.Context) error {
 
 	srvMux := mux.NewRouter()
 	srvMux.Use(
-		middleware.StatMiddleware(ctx),
+		middleware.StatMiddleware(ctx, srvMux),
 		middleware.LimitConcurrentRequests(maxConcurrentRequests),
 	)
 	srvMux.HandleFunc("/v1/batch", gateway.webBatchHandler).Methods("POST")
@@ -1444,7 +1444,7 @@ func (gateway *HandleT) StartAdminHandler(ctx context.Context) error {
 
 	srvMux := mux.NewRouter()
 	srvMux.Use(
-		middleware.StatMiddleware(ctx),
+		middleware.StatMiddleware(ctx, srvMux),
 		middleware.LimitConcurrentRequests(maxConcurrentRequests),
 	)
 	srvMux.HandleFunc("/v1/pending-events", gateway.pendingEventsHandler).Methods("POST")


### PR DESCRIPTION
# Description

Using the matched template's path instead the url's raw path in order to keep measurement cardinality under control, and be able to group requests for paths that contain path parameters, such as:

* /v1/job-status/{job_run_id}
* /schemas/event-model/{EventID}/key-counts
* /schemas/event-version/{VersionID}/metadata

<img width="336" alt="Screenshot 2022-10-07 at 10 14 14 AM" src="https://user-images.githubusercontent.com/2481587/194493966-c57acfa5-0f61-4d5e-afed-53013c026a88.png">

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=cbebdcd5d77e4a8f84151563e7483019&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
