### PR TITLE
fix(router): preserve event order while draining a previously failed job

### DIFF
--- a/eventorder_test.go
+++ b/eventorder_test.go
@@ -54,7 +54,7 @@ func TestEventOrderGuarantee(t *testing.T) {
 
 	const (
 		users         = 50                   // how many userIDs we will send jobs for
-		jobsPerUser   = 50                   // how many jobs per user we will send
+		jobsPerUser   = 40                   // how many jobs per user we will send
 		batchSize     = 10                   // how many jobs for the same user we will send in each batch request
 		responseDelay = 2 * time.Millisecond // how long we will the webhook wait before sending a response
 	)
@@ -173,7 +173,7 @@ func TestEventOrderGuarantee(t *testing.T) {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(50 * time.Millisecond):
+			case <-time.After(150 * time.Millisecond):
 				key := fmt.Sprintf("Router.%s.jobRetention", destinationID)
 				config.Set(key, "1s")
 				time.Sleep(1 * time.Millisecond)
@@ -227,7 +227,7 @@ func TestEventOrderGuarantee(t *testing.T) {
 			t.Logf("%d/%d done (%d drained)", done, total, drained)
 		}
 		return done == total
-	}, 180*time.Second, 2*time.Second, "webhook should receive all events and process them till the end")
+	}, 300*time.Second, 2*time.Second, "webhook should receive all events and process them till the end")
 
 	require.False(t, t.Failed(), "webhook shouldn't have failed")
 
@@ -288,9 +288,9 @@ func (m eventOrderMethods) newTestSpec(users, jobsPerUser int) *eventOrderSpec {
 func (eventOrderMethods) randomStatus() (status int, terminal bool) {
 	// playing with probabilities: 50% HTTP 500, 40% HTTP 200, 10% HTTP 400
 	statuses := []int{
-		http.StatusBadRequest, http.StatusBadRequest, http.StatusBadRequest,
-		http.StatusOK, http.StatusOK, http.StatusOK,
-		http.StatusInternalServerError, http.StatusInternalServerError, http.StatusInternalServerError,
+		http.StatusBadRequest, http.StatusBadRequest, http.StatusBadRequest, http.StatusBadRequest,
+		http.StatusOK, http.StatusOK, http.StatusOK, http.StatusOK,
+		http.StatusInternalServerError,
 	}
 	status = statuses[rand.Intn(len(statuses))]
 	terminal = status != http.StatusInternalServerError

--- a/eventorder_test.go
+++ b/eventorder_test.go
@@ -3,6 +3,7 @@ package main_test
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"fmt"
 	"io"
 	"math/rand"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/rudderlabs/rudder-server/config"
+	"github.com/rudderlabs/rudder-server/router/utils"
 	"github.com/rudderlabs/rudder-server/testhelper/health"
 
 	"github.com/ory/dockertest/v3"
@@ -52,9 +54,9 @@ func TestEventOrderGuarantee(t *testing.T) {
 
 	const (
 		users         = 50                   // how many userIDs we will send jobs for
-		jobsPerUser   = 40                   // how many jobs per user we will send
+		jobsPerUser   = 50                   // how many jobs per user we will send
 		batchSize     = 10                   // how many jobs for the same user we will send in each batch request
-		responseDelay = 0 * time.Millisecond // how long we will the webhook wait before sending a response
+		responseDelay = 2 * time.Millisecond // how long we will the webhook wait before sending a response
 	)
 	var (
 		m      eventOrderMethods
@@ -97,10 +99,12 @@ func TestEventOrderGuarantee(t *testing.T) {
 	t.Logf("Preparing rudder-server config")
 	writeKey := trand.String(27)
 	workspaceID := trand.String(27)
+	destinationID := trand.String(27)
 	templateCtx := map[string]string{
-		"webhookUrl":  webhook.Server.URL,
-		"writeKey":    writeKey,
-		"workspaceId": workspaceID,
+		"webhookUrl":    webhook.Server.URL,
+		"writeKey":      writeKey,
+		"workspaceId":   workspaceID,
+		"destinationId": destinationID,
 	}
 	configJsonPath := workspaceConfig.CreateTempFile(t, "testdata/eventOrderTestTemplate.json", templateCtx)
 	config.Set("BackendConfig.configFromFile", true)
@@ -156,8 +160,26 @@ func TestEventOrderGuarantee(t *testing.T) {
 				}
 			}
 		}()
-		_ = main.Run(ctx)
+		c := main.Run(ctx)
+		t.Logf("server stopped: %d", c)
+		if c != 0 {
+			t.Errorf("server exited with a non-0 exit code: %d", c)
+		}
 		close(svcDone)
+	}()
+
+	go func() { // randomly drain jobs
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+				key := fmt.Sprintf("Router.%s.jobRetention", destinationID)
+				config.Set(key, "1s")
+				time.Sleep(1 * time.Millisecond)
+				config.Set(key, "10m")
+			}
+		}
 	}()
 
 	t.Logf("waiting rudder-server to start properly")
@@ -171,33 +193,41 @@ func TestEventOrderGuarantee(t *testing.T) {
 	t.Logf("rudder-server started")
 
 	batches := m.splitInBatches(spec.jobsOrdered, batchSize)
-	t.Logf("Sending %d total events for %d total users in %d batches", len(spec.jobsOrdered), users, len(batches))
-	client := &http.Client{}
-	for _, payload := range batches {
+	go func() {
+		t.Logf("Sending %d total events for %d total users in %d batches", len(spec.jobsOrdered), users, len(batches))
+		client := &http.Client{}
 		url := fmt.Sprintf("http://localhost:%s/v1/batch", gatewayPort)
-		req, err := http.NewRequest("POST", url, bytes.NewReader(payload))
-		require.NoError(t, err, "should be able to create a new request")
-		req.SetBasicAuth(writeKey, "password")
-		resp, err := client.Do(req)
-		require.NoError(t, err, "should be able to send the request to gateway")
-		require.Equal(t, http.StatusOK, resp.StatusCode, "should be able to send the request to gateway successfully", payload)
-		resp.Body.Close()
-	}
+		for _, payload := range batches {
+			req, err := http.NewRequest("POST", url, bytes.NewReader(payload))
+			require.NoError(t, err, "should be able to create a new request")
+			req.SetBasicAuth(writeKey, "password")
+			resp, err := client.Do(req)
+			require.NoError(t, err, "should be able to send the request to gateway")
+			require.Equal(t, http.StatusOK, resp.StatusCode, "should be able to send the request to gateway successfully", payload)
+			resp.Body.Close()
+		}
+	}()
 
 	t.Logf("Waiting for the magic to happen... eventually")
 
 	var done int
 	require.Eventually(t, func() bool {
+		select {
+		case <-svcDone: // server has exited, no point in keep trying
+			return true
+		default:
+		}
 		if t.Failed() { // webhook failed, no point in keep retrying
 			return true
 		}
 		total := len(spec.jobs)
-		if done != len(spec.done) {
-			done = len(spec.done)
-			t.Logf("%d/%d done", done, total)
+		drained := m.countDrainedJobs(postgresContainer.DB)
+		if done != len(spec.done)+drained {
+			done = len(spec.done) + drained
+			t.Logf("%d/%d done (%d drained)", done, total, drained)
 		}
 		return done == total
-	}, 300*time.Second, 2*time.Second, "webhook should receive all events and process them till the end")
+	}, 180*time.Second, 2*time.Second, "webhook should receive all events and process them till the end")
 
 	require.False(t, t.Failed(), "webhook shouldn't have failed")
 
@@ -258,9 +288,9 @@ func (m eventOrderMethods) newTestSpec(users, jobsPerUser int) *eventOrderSpec {
 func (eventOrderMethods) randomStatus() (status int, terminal bool) {
 	// playing with probabilities: 50% HTTP 500, 40% HTTP 200, 10% HTTP 400
 	statuses := []int{
-		http.StatusBadRequest, http.StatusBadRequest, http.StatusBadRequest, http.StatusBadRequest,
-		http.StatusOK, http.StatusOK, http.StatusOK, http.StatusOK,
-		http.StatusInternalServerError,
+		http.StatusBadRequest, http.StatusBadRequest, http.StatusBadRequest,
+		http.StatusOK, http.StatusOK, http.StatusOK,
+		http.StatusInternalServerError, http.StatusInternalServerError, http.StatusInternalServerError,
 	}
 	status = statuses[rand.Intn(len(statuses))]
 	terminal = status != http.StatusInternalServerError
@@ -357,6 +387,30 @@ func (eventOrderMethods) splitInBatches(jobs []*eventOrderJobSpec, batchSize int
 	}
 
 	return jsonBatches
+}
+
+func (eventOrderMethods) countDrainedJobs(db *sql.DB) int {
+	var tables []string
+	var count int
+
+	rows, err := db.Query(`SELECT tablename
+									FROM pg_catalog.pg_tables
+									WHERE tablename like 'rt_job_status_%'`)
+	if err == nil {
+		for rows.Next() {
+			var table string
+			err = rows.Scan(&table)
+			if err == nil {
+				tables = append(tables, table)
+			}
+		}
+	}
+	for _, table := range tables {
+		var dsCount int
+		_ = db.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE error_code = '%s'`, table, strconv.Itoa(utils.DRAIN_ERROR_CODE))).Scan(&count)
+		count += dsCount
+	}
+	return count
 }
 
 type eventOrderWebhook struct {

--- a/router/internal/eventorder/eventorder_simulation_test.go
+++ b/router/internal/eventorder/eventorder_simulation_test.go
@@ -110,7 +110,7 @@ func (g *generatorLoop) run() {
 					g.runtime.minJobID = job.id
 				}
 				// randomly drain 0.1% of non-previously failed jobs (previously failed jobs cannot be drained at this stage)
-				if previousFailedJobID := g.barrier.Peek(job.user); previousFailedJobID != nil && *previousFailedJobID != job.id && rand.Intn(1000) < 1 {
+				if previousFailedJobID := g.barrier.Peek(job.user); previousFailedJobID != nil && *previousFailedJobID != job.id && rand.Intn(1000) < 1 { // skipcq: GSC-G404
 					if err := g.barrier.StateChanged(job.user, job.id, jobsdb.Aborted.State); err != nil {
 						panic(fmt.Errorf("could not drain job:%d: %w", job.id, err))
 					}
@@ -198,7 +198,7 @@ func (wp *workerProcess) run() {
 func (wp *workerProcess) processJobs() {
 	for _, job := range wp.jobs {
 		// introduce some random delay during processing so that buffers don't empty at a steady pace
-		time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+		time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond) // skipcq: GSC-G404
 		wait, previousFailedJobID := wp.barrier.Wait(job.user, job.id)
 
 		if wait {
@@ -208,7 +208,7 @@ func (wp *workerProcess) processJobs() {
 			continue
 		}
 		// randomly drain 10% of previously failed jobs in worker process
-		if previousFailedJobID != nil && *previousFailedJobID == job.id && rand.Intn(100) < 10 {
+		if previousFailedJobID != nil && *previousFailedJobID == job.id && rand.Intn(100) < 10 { // skipcq: GSC-G404
 			wp.logger.Logf("drained failed job:%d", job.id)
 			job.states = []string{jobsdb.Aborted.State}
 			wp.out <- job
@@ -265,7 +265,7 @@ func (cl *commitStatusLoop) run() {
 func (cl *commitStatusLoop) commit() {
 	var putBack []*job
 	for _, job := range cl.jobs {
-		time.Sleep(time.Duration(rand.Intn(2)) * time.Millisecond)
+		time.Sleep(time.Duration(rand.Intn(2)) * time.Millisecond) // skipcq: GSC-G404
 		switch job.states[0] {
 		case "aborted", "succeeded", "waiting":
 			_ = cl.barrier.StateChanged(job.user, job.id, job.states[0])

--- a/router/router.go
+++ b/router/router.go
@@ -1339,7 +1339,7 @@ func (rt *HandleT) findWorker(job *jobsdb.JobT, throttledAtTime time.Time) (toSe
 
 	if !rt.guaranteeUserEventOrder {
 		// if guaranteeUserEventOrder is false, assigning worker randomly and returning here.
-		toSendWorker = rt.workers[rand.Intn(rt.noOfWorkers)]
+		toSendWorker = rt.workers[rand.Intn(rt.noOfWorkers)] // skipcq: GSC-G404
 		return
 	}
 

--- a/router/utils/utils.go
+++ b/router/utils/utils.go
@@ -53,8 +53,7 @@ func loadConfig() {
 }
 
 func getRetentionTimeForDestination(destID string) time.Duration {
-	destJobRetentionFound := config.IsSet("Router." + destID + ".jobRetention")
-	if destJobRetentionFound {
+	if config.IsSet("Router." + destID + ".jobRetention") {
 		return config.GetDuration("Router."+destID+".jobRetention", 720, time.Hour)
 	}
 
@@ -62,7 +61,7 @@ func getRetentionTimeForDestination(destID string) time.Duration {
 }
 
 func ToBeDrained(job *jobsdb.JobT, destID, toAbortDestinationIDs string, destinationsMap map[string]*BatchDestinationT) (bool, string) {
-	// drain if job is older than a day
+	// drain if job is older than the destination's retention time
 	jobReceivedAt := gjson.GetBytes(job.Parameters, "received_at")
 	if jobReceivedAt.Exists() {
 		jobReceivedAtTime, err := time.Parse(misc.RFC3339Milli, jobReceivedAt.String())

--- a/testdata/eventOrderTestTemplate.json
+++ b/testdata/eventOrderTestTemplate.json
@@ -21,7 +21,7 @@
                         "webhookMethod": "POST"
                     },
                     "secretConfig": {},
-                    "id": "xxxyyyzzP9kQfzOoKd1tuxchYAG",
+                    "id": "{{.destinationId}}",
                     "name": "Des WebHook Integration Test 1",
                     "enabled": true,
                     "workspaceId": "{{.workspaceId}}",

--- a/warehouse/api.go
+++ b/warehouse/api.go
@@ -846,7 +846,6 @@ func overrideWithEnv(settings *filemanager.SettingsT) {
 	}
 }
 
-//
 func ifNotExistThenSet(keyToReplace string, replaceWith interface{}, configMap map[string]interface{}) {
 	if _, ok := configMap[keyToReplace]; !ok {
 		// In case we don't have the key, simply replace it with replaceWith

--- a/warehouse/jobs/runner.go
+++ b/warehouse/jobs/runner.go
@@ -133,7 +133,6 @@ func (asyncWhJob *AsyncJobWhT) InitAsyncJobRunner() error {
 	return errors.New("unable to enable warehouse Async Job")
 }
 
-//
 func (asyncWhJob *AsyncJobWhT) cleanUpAsyncTable(ctx context.Context) error {
 	if ctx.Err() != nil {
 		return ctx.Err()


### PR DESCRIPTION
# Description

When a job needs to be drained from the router, we cannot drain it early, but we need to push it to the worker's queue, so that all other (waiting) jobs for the same userID have time to flush from the pipeline's buffers, before the job is actually drained.

## Notion Ticket

[Link](https://www.notion.so/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=ca310400e89541129789bb20d104b93b&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
