### PR TITLE
fix(jobsdb): update cache after transaction completes

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -350,7 +350,7 @@ func (gateway *HandleT) dbWriterWorkerProcess() {
 			// rsources stats
 			rsourcesStats := rsources.NewStatsCollector(gateway.rsourcesService)
 			rsourcesStats.JobsStoredWithErrors(jobList, errorMessagesMap)
-			return rsourcesStats.Publish(ctx, tx.Tx())
+			return rsourcesStats.Publish(ctx, tx.SqlTx())
 		})
 		cancel()
 		if err != nil {

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -2,7 +2,6 @@ package jobsdb
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 	"sync"
@@ -1280,7 +1279,7 @@ func consume(t testing.TB, db *HandleT, count int) {
 func getPayloadSize(t *testing.T, jobsDB JobsDB, job *JobT) (int64, error) {
 	var size int64
 	var tables []string
-	err := jobsDB.WithTx(func(tx *sql.Tx) error {
+	err := jobsDB.WithTx(func(tx *Tx) error {
 		rows, err := tx.Query(fmt.Sprintf("SELECT tablename FROM pg_catalog.pg_tables where tablename like '%s_jobs_%%'", jobsDB.Identifier()))
 		require.NoError(t, err)
 		for rows.Next() {

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -701,7 +701,7 @@ func loadConfig() {
 	config.RegisterDurationConfigVariable(5, &addNewDSLoopSleepDuration, true, time.Second, []string{"JobsDB.addNewDSLoopSleepDuration", "JobsDB.addNewDSLoopSleepDurationInS"}...)
 	config.RegisterDurationConfigVariable(5, &refreshDSListLoopSleepDuration, true, time.Second, []string{"JobsDB.refreshDSListLoopSleepDuration", "JobsDB.refreshDSListLoopSleepDurationInS"}...)
 	config.RegisterDurationConfigVariable(5, &backupCheckSleepDuration, true, time.Second, []string{"JobsDB.backupCheckSleepDuration", "JobsDB.backupCheckSleepDurationIns"}...)
-	config.RegisterDurationConfigVariable(60, &cacheExpiration, true, time.Minute, []string{"JobsDB.cacheExpiration"}...)
+	config.RegisterDurationConfigVariable(5, &cacheExpiration, true, time.Minute, []string{"JobsDB.cacheExpiration"}...)
 	useJoinForUnprocessed = config.GetBool("JobsDB.useJoinForUnprocessed", true)
 }
 

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -124,14 +124,34 @@ type statTags struct {
 
 var getTimeNowFunc = time.Now
 
+type Tx struct {
+	*sql.Tx
+	completionListeners []func()
+}
+
+func (tx *Tx) AddCompletionListener(listener func()) {
+	tx.completionListeners = append(tx.completionListeners, listener)
+}
+
+func (tx *Tx) Commit() error {
+	err := tx.Tx.Commit()
+	if err == nil {
+		for _, listener := range tx.completionListeners {
+			listener()
+		}
+	}
+	return err
+}
+
 // StoreSafeTx sealed interface
 type StoreSafeTx interface {
-	Tx() *sql.Tx
+	Tx() *Tx
+	SqlTx() *sql.Tx
 	storeSafeTxIdentifier() string
 }
 
 type storeSafeTx struct {
-	tx       *sql.Tx
+	tx       *Tx
 	identity string
 }
 
@@ -139,22 +159,27 @@ func (r *storeSafeTx) storeSafeTxIdentifier() string {
 	return r.identity
 }
 
-func (r *storeSafeTx) Tx() *sql.Tx {
+func (r *storeSafeTx) Tx() *Tx {
 	return r.tx
+}
+
+func (r *storeSafeTx) SqlTx() *sql.Tx {
+	return r.tx.Tx
 }
 
 // EmptyStoreSafeTx returns an empty interface usable only for tests
 func EmptyStoreSafeTx() StoreSafeTx {
-	return &storeSafeTx{}
+	return &storeSafeTx{tx: &Tx{}}
 }
 
 // UpdateSafeTx sealed interface
 type UpdateSafeTx interface {
-	Tx() *sql.Tx
+	Tx() *Tx
+	SqlTx() *sql.Tx
 	updateSafeTxSealIdentifier() string
 }
 type updateSafeTx struct {
-	tx       *sql.Tx
+	tx       *Tx
 	identity string
 }
 
@@ -162,13 +187,17 @@ func (r *updateSafeTx) updateSafeTxSealIdentifier() string {
 	return r.identity
 }
 
-func (r *updateSafeTx) Tx() *sql.Tx {
+func (r *updateSafeTx) Tx() *Tx {
 	return r.tx
+}
+
+func (r *updateSafeTx) SqlTx() *sql.Tx {
+	return r.tx.Tx
 }
 
 // EmptyUpdateSafeTx returns an empty interface usable only for tests
 func EmptyUpdateSafeTx() UpdateSafeTx {
-	return &updateSafeTx{}
+	return &updateSafeTx{tx: &Tx{}}
 }
 
 // HandleInspector is only intended to be used by tests for verifying the handle's internal state
@@ -200,7 +229,7 @@ type JobsDB interface {
 	// WithTx begins a new transaction that can be used by the provided function.
 	// If the function returns an error, the transaction will be rollbacked and return the error,
 	// otherwise the transaction will be committed and a nil error will be returned.
-	WithTx(func(tx *sql.Tx) error) error
+	WithTx(func(tx *Tx) error) error
 
 	// WithStoreSafeTx prepares a store-safe environment and then starts a transaction
 	// that can be used by the provided function.
@@ -1201,7 +1230,7 @@ func (jd *HandleT) getTableSize(jobTable string) int64 {
 	return tableSize
 }
 
-func (jd *HandleT) checkIfFullDSInTx(tx *sql.Tx, ds dataSetT) (bool, error) {
+func (jd *HandleT) checkIfFullDSInTx(tx *Tx, ds dataSetT) (bool, error) {
 	if jd.MaxDSRetentionPeriod > 0 {
 		var minJobCreatedAt sql.NullTime
 		sqlStatement := fmt.Sprintf(`SELECT MIN(created_at) FROM %q`, ds.JobTable)
@@ -1284,7 +1313,7 @@ func newDataSet(tablePrefix, dsIdx string) dataSetT {
 }
 
 func (jd *HandleT) addNewDS(l lock.LockToken, ds dataSetT) {
-	err := jd.WithTx(func(tx *sql.Tx) error {
+	err := jd.WithTx(func(tx *Tx) error {
 		return jd.addNewDSInTx(tx, l, jd.refreshDSList(l), ds)
 	})
 	jd.assertError(err)
@@ -1292,7 +1321,7 @@ func (jd *HandleT) addNewDS(l lock.LockToken, ds dataSetT) {
 }
 
 // NOTE: If addNewDSInTx is directly called, make sure to explicitly call refreshDSRangeList(l) to update the DS list in cache, once transaction has completed.
-func (jd *HandleT) addNewDSInTx(tx *sql.Tx, l lock.LockToken, dsList []dataSetT, ds dataSetT) error {
+func (jd *HandleT) addNewDSInTx(tx *Tx, l lock.LockToken, dsList []dataSetT, ds dataSetT) error {
 	if l == nil {
 		return errors.New("nil ds list lock token provided")
 	}
@@ -1318,7 +1347,7 @@ func (jd *HandleT) addNewDSInTx(tx *sql.Tx, l lock.LockToken, dsList []dataSetT,
 	return nil
 }
 
-func (jd *HandleT) addDSInTx(tx *sql.Tx, ds dataSetT) error {
+func (jd *HandleT) addDSInTx(tx *Tx, ds dataSetT) error {
 	jd.logger.Infof("Creating DS %+v", ds)
 	queryStat := stats.Default.NewTaggedStat("add_new_ds", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix})
 	queryStat.Start()
@@ -1396,7 +1425,7 @@ type transactionHandler interface {
 	// Only the function that passes *sql.Tx should do the commit or rollback based on the error it receives
 }
 
-func (jd *HandleT) createDSInTx(tx *sql.Tx, newDS dataSetT) error {
+func (jd *HandleT) createDSInTx(tx *Tx, newDS dataSetT) error {
 	// Mark the start of operation. If we crash somewhere here, we delete the
 	// DS being added
 	opPayload, err := json.Marshal(&journalOpPayloadT{To: newDS})
@@ -1461,7 +1490,7 @@ func (jd *HandleT) createDSInTx(tx *sql.Tx, newDS dataSetT) error {
 	return nil
 }
 
-func (jd *HandleT) setSequenceNumberInTx(tx *sql.Tx, l lock.LockToken, dsList []dataSetT, newDSIdx string) error {
+func (jd *HandleT) setSequenceNumberInTx(tx *Tx, l lock.LockToken, dsList []dataSetT, newDSIdx string) error {
 	if l == nil {
 		return errors.New("nil ds list lock token provided")
 	}
@@ -1539,13 +1568,13 @@ func (jd *HandleT) prepareAndExecStmtInTxAllowMissing(tx *sql.Tx, sqlStatement s
 }
 
 func (jd *HandleT) dropDS(ds dataSetT) error {
-	return jd.WithTx(func(tx *sql.Tx) error {
+	return jd.WithTx(func(tx *Tx) error {
 		return jd.dropDSInTx(tx, ds)
 	})
 }
 
 // dropDS drops a dataset
-func (jd *HandleT) dropDSInTx(tx *sql.Tx, ds dataSetT) error {
+func (jd *HandleT) dropDSInTx(tx *Tx, ds dataSetT) error {
 	var err error
 	if _, err = tx.Exec(fmt.Sprintf(`LOCK TABLE %q IN ACCESS EXCLUSIVE MODE;`, ds.JobStatusTable)); err != nil {
 		return err
@@ -1610,13 +1639,13 @@ func (jd *HandleT) invalidateCache(ds dataSetT) {
 }
 
 func (jd *HandleT) mustRenameDS(ds dataSetT) error {
-	return jd.WithTx(func(tx *sql.Tx) error {
+	return jd.WithTx(func(tx *Tx) error {
 		return jd.mustRenameDSInTx(tx, ds)
 	})
 }
 
 // mustRenameDS renames a dataset
-func (jd *HandleT) mustRenameDSInTx(tx *sql.Tx, ds dataSetT) error {
+func (jd *HandleT) mustRenameDSInTx(tx *Tx, ds dataSetT) error {
 	var sqlStatement string
 	renamedJobStatusTable := fmt.Sprintf(`%s%s`, preDropTablePrefix, ds.JobStatusTable)
 	renamedJobTable := fmt.Sprintf(`%s%s`, preDropTablePrefix, ds.JobTable)
@@ -1631,7 +1660,7 @@ func (jd *HandleT) mustRenameDSInTx(tx *sql.Tx, ds dataSetT) error {
 		return fmt.Errorf("could not rename job table %s to %s: %w", ds.JobTable, renamedJobTable, err)
 	}
 	for _, preBackupHandler := range jd.preBackupHandlers {
-		err = preBackupHandler.Handle(context.TODO(), tx, renamedJobTable, renamedJobStatusTable)
+		err = preBackupHandler.Handle(context.TODO(), tx.Tx, renamedJobTable, renamedJobStatusTable)
 		if err != nil {
 			return err
 		}
@@ -1659,7 +1688,7 @@ func (jd *HandleT) renameDS(ds dataSetT) error {
 	var sqlStatement string
 	renamedJobStatusTable := fmt.Sprintf(`%s%s`, preDropTablePrefix, ds.JobStatusTable)
 	renamedJobTable := fmt.Sprintf(`%s%s`, preDropTablePrefix, ds.JobTable)
-	return jd.WithTx(func(tx *sql.Tx) error {
+	return jd.WithTx(func(tx *Tx) error {
 		sqlStatement = fmt.Sprintf(`ALTER TABLE IF EXISTS %q RENAME TO %q`, ds.JobStatusTable, renamedJobStatusTable)
 		_, err := tx.Exec(sqlStatement)
 		if err != nil {
@@ -1747,7 +1776,7 @@ completed (state is failed or waiting or waiting_retry or executiong) are copied
 over. Then the status (only the latest) is set for those jobs
 */
 
-func (jd *HandleT) migrateJobsInTx(ctx context.Context, tx *sql.Tx, srcDS, destDS dataSetT) (noJobsMigrated int, err error) {
+func (jd *HandleT) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) (noJobsMigrated int, err error) {
 	queryStat := stats.Default.NewTaggedStat("migration_jobs", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix})
 	queryStat.Start()
 	defer queryStat.End()
@@ -1796,7 +1825,7 @@ func (jd *HandleT) migrateJobsInTx(ctx context.Context, tx *sql.Tx, srcDS, destD
 	return noJobsMigrated, nil
 }
 
-func (jd *HandleT) postMigrateHandleDS(tx *sql.Tx, migrateFrom []dataSetT) error {
+func (jd *HandleT) postMigrateHandleDS(tx *Tx, migrateFrom []dataSetT) error {
 	// Rename datasets before dropping them, so that they can be uploaded to s3
 	for _, ds := range migrateFrom {
 		if jd.BackupSettings.isBackupEnabled() {
@@ -1814,14 +1843,14 @@ func (jd *HandleT) postMigrateHandleDS(tx *sql.Tx, migrateFrom []dataSetT) error
 	return nil
 }
 
-func (jd *HandleT) internalStoreJobsInTx(ctx context.Context, tx *sql.Tx, ds dataSetT, jobList []*JobT) error {
+func (jd *HandleT) internalStoreJobsInTx(ctx context.Context, tx *Tx, ds dataSetT, jobList []*JobT) error {
 	queryStat := jd.getTimerStat("store_jobs", nil)
 	queryStat.Start()
 	defer queryStat.End()
 
-	// Always clear cache even in case of an error,
-	// since we are not sure about the state of the db
-	defer jd.clearCache(ds, jobList)
+	tx.AddCompletionListener(func() {
+		jd.clearCache(ds, jobList)
+	})
 
 	return jd.doStoreJobsInTx(ctx, tx, ds, jobList)
 }
@@ -1830,20 +1859,20 @@ func (jd *HandleT) internalStoreJobsInTx(ctx context.Context, tx *sql.Tx, ds dat
 Next set of functions are for reading/writing jobs and job_status for
 a given dataset. The names should be self explainatory
 */
-func (jd *HandleT) copyJobsDS(tx *sql.Tx, ds dataSetT, jobList []*JobT) error { // When fixing callers make sure error is handled with assertError
+func (jd *HandleT) copyJobsDS(tx *Tx, ds dataSetT, jobList []*JobT) error { // When fixing callers make sure error is handled with assertError
 	queryStat := jd.getTimerStat("copy_jobs", nil)
 	queryStat.Start()
 	defer queryStat.End()
 
-	// Always clear cache even in case of an error,
-	// since we are not sure about the state of the db
-	defer jd.clearCache(ds, jobList)
+	tx.AddCompletionListener(func() {
+		jd.clearCache(ds, jobList)
+	})
 	return jd.copyJobsDSInTx(tx, ds, jobList)
 }
 
 func (jd *HandleT) WithStoreSafeTx(ctx context.Context, f func(tx StoreSafeTx) error) error {
 	return jd.inStoreSafeCtx(ctx, func() error {
-		return jd.WithTx(func(tx *sql.Tx) error { return f(&storeSafeTx{tx: tx, identity: jd.tablePrefix}) })
+		return jd.WithTx(func(tx *Tx) error { return f(&storeSafeTx{tx: tx, identity: jd.tablePrefix}) })
 	})
 }
 
@@ -1874,7 +1903,7 @@ func (jd *HandleT) inStoreSafeCtx(ctx context.Context, f func() error) error {
 
 func (jd *HandleT) WithUpdateSafeTx(ctx context.Context, f func(tx UpdateSafeTx) error) error {
 	return jd.inUpdateSafeCtx(ctx, func() error {
-		return jd.WithTx(func(tx *sql.Tx) error { return f(&updateSafeTx{tx: tx, identity: jd.tablePrefix}) })
+		return jd.WithTx(func(tx *Tx) error { return f(&updateSafeTx{tx: tx, identity: jd.tablePrefix}) })
 	})
 }
 
@@ -1894,11 +1923,12 @@ func (jd *HandleT) inUpdateSafeCtx(ctx context.Context, f func() error) error {
 	return f()
 }
 
-func (jd *HandleT) WithTx(f func(tx *sql.Tx) error) error {
-	tx, err := jd.dbHandle.Begin()
+func (jd *HandleT) WithTx(f func(tx *Tx) error) error {
+	sqltx, err := jd.dbHandle.Begin()
 	if err != nil {
 		return err
 	}
+	tx := &Tx{Tx: sqltx}
 	err = f(tx)
 	if err != nil {
 		if rollbackErr := tx.Rollback(); rollbackErr != nil {
@@ -1918,7 +1948,7 @@ func (jd *HandleT) clearCache(ds dataSetT, jobList []*JobT) {
 	jd.doClearCache(ds, customValParamMap)
 }
 
-func (jd *HandleT) internalStoreWithRetryEachInTx(ctx context.Context, tx *sql.Tx, ds dataSetT, jobList []*JobT) (errorMessagesMap map[uuid.UUID]string, staleDs error) {
+func (jd *HandleT) internalStoreWithRetryEachInTx(ctx context.Context, tx *Tx, ds dataSetT, jobList []*JobT) (errorMessagesMap map[uuid.UUID]string, staleDs error) {
 	const (
 		savepointSql = "SAVEPOINT storeWithRetryEach"
 		rollbackSql  = "ROLLBACK TO " + savepointSql
@@ -2149,7 +2179,7 @@ func (*HandleT) copyJobsDSInTx(txHandler transactionHandler, ds dataSetT, jobLis
 	return err
 }
 
-func (jd *HandleT) doStoreJobsInTx(ctx context.Context, tx *sql.Tx, ds dataSetT, jobList []*JobT) error {
+func (jd *HandleT) doStoreJobsInTx(ctx context.Context, tx *Tx, ds dataSetT, jobList []*JobT) error {
 	store := func() error {
 		var stmt *sql.Stmt
 		var err error
@@ -2206,7 +2236,7 @@ func (jd *HandleT) doStoreJobsInTx(ctx context.Context, tx *sql.Tx, ds dataSetT,
 	return err
 }
 
-func (jd *HandleT) storeJob(ctx context.Context, tx *sql.Tx, ds dataSetT, job *JobT) (err error) {
+func (jd *HandleT) storeJob(ctx context.Context, tx *Tx, ds dataSetT, job *JobT) (err error) {
 	sqlStatement := fmt.Sprintf(`INSERT INTO %q (uuid, user_id, custom_val, parameters, event_payload, workspace_id)
 		VALUES ($1, $2, $3, $4, $5, $6) RETURNING job_id`, ds.JobTable)
 	stmt, err := tx.PrepareContext(ctx, sqlStatement)
@@ -2217,9 +2247,11 @@ func (jd *HandleT) storeJob(ctx context.Context, tx *sql.Tx, ds dataSetT, job *J
 	job.sanitizeJson()
 	_, err = stmt.ExecContext(ctx, job.UUID, job.UserID, job.CustomVal, string(job.Parameters), string(job.EventPayload), job.WorkspaceId)
 	if err == nil {
-		// Empty customValFilters means we want to clear for all
-		jd.markClearEmptyResult(ds, allWorkspaces, []string{}, []string{}, nil, hasJobs, nil)
-		jd.markClearEmptyResult(ds, job.WorkspaceId, []string{}, []string{}, nil, hasJobs, nil)
+		tx.AddCompletionListener(func() {
+			// Empty customValFilters means we want to clear for all
+			jd.markClearEmptyResult(ds, allWorkspaces, []string{}, []string{}, nil, hasJobs, nil)
+			jd.markClearEmptyResult(ds, job.WorkspaceId, []string{}, []string{}, nil, hasJobs, nil)
+		})
 		return
 	}
 	pqErr, ok := err.(*pq.Error)
@@ -2788,7 +2820,7 @@ func (jd *HandleT) getUnprocessedJobsDS(ctx context.Context, ds dataSetT, order 
 }
 
 // copyJobStatusDS is expected to be called only during a migration
-func (jd *HandleT) copyJobStatusDS(ctx context.Context, tx *sql.Tx, ds dataSetT, statusList []*JobStatusT, customValFilters []string) (err error) {
+func (jd *HandleT) copyJobStatusDS(ctx context.Context, tx *Tx, ds dataSetT, statusList []*JobStatusT, customValFilters []string) (err error) {
 	var parameterFilters []ParameterFilterT
 	if len(statusList) == 0 {
 		return nil
@@ -2809,17 +2841,19 @@ func (jd *HandleT) copyJobStatusDS(ctx context.Context, tx *sql.Tx, ds dataSetT,
 		return err
 	}
 
-	allUpdatedStates := make([]string, 0)
-	for workspaceID, stateFilters := range stateFiltersByWorkspace {
-		jd.markClearEmptyResult(ds, workspaceID, stateFilters, customValFilters, parameterFilters, hasJobs, nil)
-		allUpdatedStates = append(allUpdatedStates, stateFilters...)
-	}
-	// NOTE: Along with clearing cache for a particular workspace key, we also have to clear for allWorkspaces key
-	jd.markClearEmptyResult(ds, allWorkspaces, misc.Unique(allUpdatedStates), customValFilters, parameterFilters, hasJobs, nil)
+	tx.AddCompletionListener(func() {
+		var allUpdatedStates []string
+		for workspaceID, stateFilters := range stateFiltersByWorkspace {
+			jd.markClearEmptyResult(ds, workspaceID, stateFilters, customValFilters, parameterFilters, hasJobs, nil)
+			allUpdatedStates = append(allUpdatedStates, stateFilters...)
+		}
+		// NOTE: Along with clearing cache for a particular workspace key, we also have to clear for allWorkspaces key
+		jd.markClearEmptyResult(ds, allWorkspaces, misc.Unique(allUpdatedStates), customValFilters, parameterFilters, hasJobs, nil)
+	})
 	return nil
 }
 
-func (jd *HandleT) updateJobStatusDSInTx(ctx context.Context, tx *sql.Tx, ds dataSetT, statusList []*JobStatusT, tags statTags) (updatedStates map[string][]string, err error) {
+func (jd *HandleT) updateJobStatusDSInTx(ctx context.Context, tx *Tx, ds dataSetT, statusList []*JobStatusT, tags statTags) (updatedStates map[string][]string, err error) {
 	if len(statusList) == 0 {
 		return
 	}
@@ -2928,7 +2962,7 @@ func (jd *HandleT) addNewDSLoop(ctx context.Context) {
 		var dsListLock lock.LockToken
 		var releaseDsListLock chan<- lock.LockToken
 		// start a transaction
-		err := jd.WithTx(func(tx *sql.Tx) error {
+		err := jd.WithTx(func(tx *Tx) error {
 			// acquire a advisory transaction level blocking lock, which is released once the transaction ends.
 			sqlStatement := fmt.Sprintf(`SELECT pg_advisory_xact_lock(%d);`, misc.JobsDBAddDsAdvisoryLock)
 			_, err := tx.ExecContext(context.TODO(), sqlStatement)
@@ -2979,7 +3013,7 @@ func (jd *HandleT) addNewDSLoop(ctx context.Context) {
 	}
 }
 
-func setReadonlyDsInTx(tx *sql.Tx, latestDS dataSetT) error {
+func setReadonlyDsInTx(tx *Tx, latestDS dataSetT) error {
 	sqlStatement := fmt.Sprintf(
 		`CREATE TRIGGER readonlyTableTrg
 		BEFORE INSERT
@@ -3046,7 +3080,7 @@ func (jd *HandleT) doMigrateDS(ctx context.Context) error {
 	}
 	var l lock.LockToken
 	var lockChan chan<- lock.LockToken
-	err := jd.WithTx(func(tx *sql.Tx) error {
+	err := jd.WithTx(func(tx *Tx) error {
 		// Take the lock and run actual migration
 		if !jd.dsMigrationLock.TryLockWithCtx(ctx) {
 			return fmt.Errorf("failed to acquire lock: %w", ctx.Err())
@@ -3708,7 +3742,7 @@ func (jd *HandleT) dropJournal() {
 
 func (jd *HandleT) JournalMarkStart(opType string, opPayload json.RawMessage) int64 {
 	var opID int64
-	err := jd.WithTx(func(tx *sql.Tx) error {
+	err := jd.WithTx(func(tx *Tx) error {
 		var err error
 		opID, err = jd.JournalMarkStartInTx(tx, opType, opPayload)
 		return err
@@ -3717,7 +3751,7 @@ func (jd *HandleT) JournalMarkStart(opType string, opPayload json.RawMessage) in
 	return opID
 }
 
-func (jd *HandleT) JournalMarkStartInTx(tx *sql.Tx, opType string, opPayload json.RawMessage) (int64, error) {
+func (jd *HandleT) JournalMarkStartInTx(tx *Tx, opType string, opPayload json.RawMessage) (int64, error) {
 	var opID int64
 	jd.assert(opType == addDSOperation ||
 		opType == migrateCopyOperation ||
@@ -3735,14 +3769,14 @@ func (jd *HandleT) JournalMarkStartInTx(tx *sql.Tx, opType string, opPayload jso
 
 // JournalMarkDone marks the end of a journal action
 func (jd *HandleT) JournalMarkDone(opID int64) {
-	err := jd.WithTx(func(tx *sql.Tx) error {
+	err := jd.WithTx(func(tx *Tx) error {
 		return jd.journalMarkDoneInTx(tx, opID)
 	})
 	jd.assertError(err)
 }
 
 // JournalMarkDoneInTx marks the end of a journal action in a transaction
-func (jd *HandleT) journalMarkDoneInTx(tx *sql.Tx, opID int64) error {
+func (jd *HandleT) journalMarkDoneInTx(tx *Tx, opID int64) error {
 	sqlStatement := fmt.Sprintf(`UPDATE %s_journal SET done=$2, end_time=$3 WHERE id=$1 AND owner=$4`, jd.tablePrefix)
 	_, err := tx.Exec(sqlStatement, opID, true, time.Now(), jd.ownerType)
 	return err
@@ -3908,7 +3942,7 @@ internalUpdateJobStatusInTx updates the status of a batch of jobs
 customValFilters[] is passed, so we can efficiently mark empty cache
 Later we can move this to query
 */
-func (jd *HandleT) internalUpdateJobStatusInTx(ctx context.Context, tx *sql.Tx, statusList []*JobStatusT, customValFilters []string, parameterFilters []ParameterFilterT) error {
+func (jd *HandleT) internalUpdateJobStatusInTx(ctx context.Context, tx *Tx, statusList []*JobStatusT, customValFilters []string, parameterFilters []ParameterFilterT) error {
 	// capture stats
 	tags := statTags{CustomValFilters: customValFilters, ParameterFilters: parameterFilters}
 	queryStat := jd.getTimerStat("update_job_status_time", &tags)
@@ -3922,16 +3956,18 @@ func (jd *HandleT) internalUpdateJobStatusInTx(ctx context.Context, tx *sql.Tx, 
 		return err
 	}
 
-	// clear cache
-	for ds, stateListByWorkspace := range updatedStatesByDS {
-		allUpdatedStates := make([]string, 0)
-		for workspace, stateList := range stateListByWorkspace {
-			jd.markClearEmptyResult(ds, workspace, stateList, customValFilters, parameterFilters, hasJobs, nil)
-			allUpdatedStates = append(allUpdatedStates, stateList...)
+	tx.AddCompletionListener(func() {
+		// clear cache
+		for ds, stateListByWorkspace := range updatedStatesByDS {
+			var allUpdatedStates []string
+			for workspace, stateList := range stateListByWorkspace {
+				jd.markClearEmptyResult(ds, workspace, stateList, customValFilters, parameterFilters, hasJobs, nil)
+				allUpdatedStates = append(allUpdatedStates, stateList...)
+			}
+			// NOTE: Along with clearing cache for a particular workspace key, we also have to clear for allWorkspaces key
+			jd.markClearEmptyResult(ds, allWorkspaces, misc.Unique(allUpdatedStates), customValFilters, parameterFilters, hasJobs, nil)
 		}
-		// NOTE: Along with clearing cache for a particular workspace key, we also have to clear for allWorkspaces key
-		jd.markClearEmptyResult(ds, allWorkspaces, misc.Unique(allUpdatedStates), customValFilters, parameterFilters, hasJobs, nil)
-	}
+	})
 
 	return nil
 }
@@ -3941,7 +3977,7 @@ doUpdateJobStatusInTx updates the status of a batch of jobs
 customValFilters[] is passed, so we can efficiently mark empty cache
 Later we can move this to query
 */
-func (jd *HandleT) doUpdateJobStatusInTx(ctx context.Context, tx *sql.Tx, statusList []*JobStatusT, tags statTags) (updatedStatesByDS map[dataSetT]map[string][]string, err error) {
+func (jd *HandleT) doUpdateJobStatusInTx(ctx context.Context, tx *Tx, statusList []*JobStatusT, tags statTags) (updatedStatesByDS map[dataSetT]map[string][]string, err error) {
 	if len(statusList) == 0 {
 		return
 	}

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"compress/gzip"
 	"context"
-	"database/sql"
 	"io"
 	"os"
 	"strings"
@@ -177,7 +176,7 @@ func (*backupTestCase) insertRTData(t *testing.T, jobs []*JobT, statusList []*Jo
 	require.NoError(t, err)
 
 	rtDS := newDataSet("rt", "1")
-	err = jobsDB.WithTx(func(tx *sql.Tx) error {
+	err = jobsDB.WithTx(func(tx *Tx) error {
 		if err := jobsDB.copyJobsDS(tx, rtDS, jobs); err != nil {
 			return err
 		}
@@ -190,7 +189,7 @@ func (*backupTestCase) insertRTData(t *testing.T, jobs []*JobT, statusList []*Jo
 	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
 		jobsDB.addNewDS(l, rtDS2)
 	})
-	err = jobsDB.WithTx(func(tx *sql.Tx) error {
+	err = jobsDB.WithTx(func(tx *Tx) error {
 		if err := jobsDB.copyJobsDS(tx, rtDS2, jobs); err != nil {
 			return err
 		}
@@ -214,7 +213,7 @@ func (*backupTestCase) insertBatchRTData(t *testing.T, jobs []*JobT, statusList 
 	require.NoError(t, err)
 
 	ds := newDataSet("batch_rt", "1")
-	err = jobsDB.WithTx(func(tx *sql.Tx) error {
+	err = jobsDB.WithTx(func(tx *Tx) error {
 		if err := jobsDB.copyJobsDS(tx, ds, jobs); err != nil {
 			t.Log("error while copying jobs to ds: ", err)
 			return err
@@ -227,7 +226,7 @@ func (*backupTestCase) insertBatchRTData(t *testing.T, jobs []*JobT, statusList 
 	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
 		jobsDB.addNewDS(l, ds2)
 	})
-	err = jobsDB.WithTx(func(tx *sql.Tx) error {
+	err = jobsDB.WithTx(func(tx *Tx) error {
 		if err := jobsDB.copyJobsDS(tx, ds2, jobs); err != nil {
 			t.Log("error while copying jobs to ds: ", err)
 			return err

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -3,7 +3,6 @@ package jobsdb
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -394,7 +393,7 @@ func TestRefreshDSList(t *testing.T) {
 	defer jobsDB.TearDown()
 
 	require.Equal(t, 1, len(jobsDB.getDSList()), "jobsDB should start with a ds list size of 1")
-	require.NoError(t, jobsDB.WithTx(func(tx *sql.Tx) error {
+	require.NoError(t, jobsDB.WithTx(func(tx *Tx) error {
 		return jobsDB.addDSInTx(tx, newDataSet(prefix, "2"))
 	}))
 	require.Equal(t, 1, len(jobsDB.getDSList()), "addDS should not refresh the ds list")

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -6,7 +6,6 @@ package mocks_jobsdb
 
 import (
 	context "context"
-	sql "database/sql"
 	json "encoding/json"
 	reflect "reflect"
 
@@ -337,7 +336,7 @@ func (mr *MockJobsDBMockRecorder) WithStoreSafeTx(arg0, arg1 interface{}) *gomoc
 }
 
 // WithTx mocks base method.
-func (m *MockJobsDB) WithTx(arg0 func(*sql.Tx) error) error {
+func (m *MockJobsDB) WithTx(arg0 func(*jobsdb.Tx) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithTx", arg0)
 	ret0, _ := ret[0].(error)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -3,7 +3,6 @@ package processor
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1688,13 +1687,13 @@ func (proc *HandleT) Store(in *storeMessage) {
 
 			// rsources stats
 			in.rsourcesStats.JobStatusesUpdated(statusList)
-			err = in.rsourcesStats.Publish(ctx, tx.Tx())
+			err = in.rsourcesStats.Publish(ctx, tx.SqlTx())
 			if err != nil {
 				return fmt.Errorf("publishing rsources stats: %w", err)
 			}
 
 			if proc.isReportingEnabled() {
-				proc.reporting.Report(in.reportMetrics, tx.Tx())
+				proc.reporting.Report(in.reportMetrics, tx.SqlTx())
 			}
 
 			if enableDedup {
@@ -2118,10 +2117,10 @@ func (proc *HandleT) saveFailedJobs(failedJobs []*jobsdb.JobT) {
 
 		rsourcesStats := rsources.NewFailedJobsCollector(proc.rsourcesService)
 		rsourcesStats.JobsFailed(failedJobs)
-		_ = proc.errorDB.WithTx(func(tx *sql.Tx) error {
+		_ = proc.errorDB.WithTx(func(tx *jobsdb.Tx) error {
 			// TODO: error propagation
-			router.GetFailedEventsManager().SaveFailedRecordIDs(jobRunIDAbortedEventsMap, tx)
-			return rsourcesStats.Publish(context.TODO(), tx)
+			router.GetFailedEventsManager().SaveFailedRecordIDs(jobRunIDAbortedEventsMap, tx.Tx)
+			return rsourcesStats.Publish(context.TODO(), tx.Tx)
 		})
 
 	}
@@ -2594,6 +2593,6 @@ func (proc *HandleT) isReportingEnabled() bool {
 func (proc *HandleT) updateRudderSourcesStats(ctx context.Context, tx jobsdb.StoreSafeTx, jobs []*jobsdb.JobT) error {
 	rsourcesStats := rsources.NewStatsCollector(proc.rsourcesService)
 	rsourcesStats.JobsStored(jobs)
-	err := rsourcesStats.Publish(ctx, tx.Tx())
+	err := rsourcesStats.Publish(ctx, tx.SqlTx())
 	return err
 }

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -973,8 +972,8 @@ var _ = Describe("Processor", func() {
 				})
 
 			// will be used to save failed events to failed keys table
-			c.mockProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(tx *sql.Tx) error) {
-				_ = f(nil)
+			c.mockProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(tx *jobsdb.Tx) error) {
+				_ = f(&jobsdb.Tx{})
 			}).Times(1)
 
 			// One Store call is expected for all events
@@ -1105,8 +1104,8 @@ var _ = Describe("Processor", func() {
 					assertJobStatus(unprocessedJobsList[0], statuses[0], jobsdb.Succeeded.State)
 				})
 
-			c.mockProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(tx *sql.Tx) error) {
-				_ = f(nil)
+			c.mockProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(tx *jobsdb.Tx) error) {
+				_ = f(&jobsdb.Tx{})
 			}).Return(nil).Times(1)
 
 			// One Store call is expected for all events
@@ -1183,8 +1182,8 @@ var _ = Describe("Processor", func() {
 					assertJobStatus(unprocessedJobsList[0], statuses[0], jobsdb.Succeeded.State)
 				})
 
-			c.mockProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(tx *sql.Tx) error) {
-				_ = f(nil)
+			c.mockProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(tx *jobsdb.Tx) error) {
+				_ = f(&jobsdb.Tx{})
 			}).Return(nil).Times(0)
 
 			// One Store call is expected for all events

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1384,10 +1384,10 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 
 			// Save msgids of aborted jobs
 			if len(jobRunIDAbortedEventsMap) > 0 {
-				router.GetFailedEventsManager().SaveFailedRecordIDs(jobRunIDAbortedEventsMap, tx.Tx())
+				router.GetFailedEventsManager().SaveFailedRecordIDs(jobRunIDAbortedEventsMap, tx.SqlTx())
 			}
 			if brt.reporting != nil && brt.reportingEnabled {
-				brt.reporting.Report(reportMetrics, tx.Tx())
+				brt.reporting.Report(reportMetrics, tx.SqlTx())
 			}
 			return nil
 		})
@@ -1495,7 +1495,7 @@ func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.Asy
 			}
 			// rsources stats
 			rsourcesStats.JobStatusesUpdated(statusList)
-			err = rsourcesStats.Publish(context.TODO(), tx.Tx())
+			err = rsourcesStats.Publish(context.TODO(), tx.SqlTx())
 			if err != nil {
 				brt.logger.Errorf("publishing rsources stats: %w", err)
 			}
@@ -2406,7 +2406,7 @@ func (brt *HandleT) updateRudderSourcesStats(ctx context.Context, tx jobsdb.Upda
 	rsourcesStats := rsources.NewStatsCollector(brt.rsourcesService)
 	rsourcesStats.BeginProcessing(jobs)
 	rsourcesStats.JobStatusesUpdated(jobStatuses)
-	err := rsourcesStats.Publish(ctx, tx.Tx())
+	err := rsourcesStats.Publish(ctx, tx.SqlTx())
 	if err != nil {
 		return fmt.Errorf("publishing rsources stats: %w", err)
 	}

--- a/router/router.go
+++ b/router/router.go
@@ -1536,9 +1536,9 @@ func (rt *HandleT) commitStatusList(responseList *[]jobResponseT) {
 
 				// Save msgids of aborted jobs
 				if len(jobRunIDAbortedEventsMap) > 0 {
-					GetFailedEventsManager().SaveFailedRecordIDs(jobRunIDAbortedEventsMap, tx.Tx())
+					GetFailedEventsManager().SaveFailedRecordIDs(jobRunIDAbortedEventsMap, tx.SqlTx())
 				}
-				rt.Reporting.Report(reportMetrics, tx.Tx())
+				rt.Reporting.Report(reportMetrics, tx.SqlTx())
 				return nil
 			})
 		}, sendRetryStoreStats)
@@ -2219,7 +2219,7 @@ func (rt *HandleT) updateRudderSourcesStats(ctx context.Context, tx jobsdb.Updat
 	rsourcesStats := rsources.NewStatsCollector(rt.rsourcesService)
 	rsourcesStats.BeginProcessing(jobs)
 	rsourcesStats.JobStatusesUpdated(jobStatuses)
-	err := rsourcesStats.Publish(ctx, tx.Tx())
+	err := rsourcesStats.Publish(ctx, tx.SqlTx())
 	if err != nil {
 		rt.logger.Errorf("publishing rsources stats: %w", err)
 	}


### PR DESCRIPTION
# Description

By updating (invalidating) the cache entries before the transaction commits and for the period until the transaction actually commits, we are risking to have other select queries who arrive during this timeframe to populate the cache with incorrect values: until the transaction commits, changes are not visible to other queries, thus they may erroneously put "no result" entries in the cache.

The above can have as a side-effect to: 
1. Delay processing of whole datasets until cache entries expire (observed with `proc_error` tables)
2. Cause out-of-order event delivery

This fix introduces a `jobsdb.Tx` that wraps a `sql.Tx`, adding support for registering success listeners. Now, all cache entries are updated after the transaction has been successfully committed.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=624bf10d7947440c90b7399e8f190086&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
