### PR TITLE
chore(jobsdb): use a different advisory lock for different table prefixes

### DIFF
--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -966,6 +966,21 @@ func Test_SortDnumList(t *testing.T) {
 	require.Equal(t, []string{"-2", "0_1", "0_1_1", "1"}, l)
 }
 
+func Test_GetAdvisoryLockForOperation_Unique(t *testing.T) {
+	calculated := map[int64]string{}
+	for _, operation := range []string{"add_ds", "migrate_ds"} {
+		for _, prefix := range []string{"gw", "rt", "batch_rt", "proc_error"} {
+			h := &HandleT{tablePrefix: prefix}
+			key := fmt.Sprintf("%s_%s", prefix, operation)
+			advLock := h.getAdvisoryLockForOperation(operation)
+			if dupKey, ok := calculated[advLock]; ok {
+				t.Errorf("Duplicate advisory lock calculated for different keys %s and %s: %d", key, dupKey, advLock)
+			}
+			calculated[advLock] = key
+		}
+	}
+}
+
 type testingT interface {
 	Errorf(format string, args ...interface{})
 	FailNow()

--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -10,12 +10,6 @@ import (
 	"github.com/rudderlabs/rudder-server/config"
 )
 
-type AdvisoryLock int
-
-const (
-	JobsDBAddDsAdvisoryLock AdvisoryLock = 11
-)
-
 // GetConnectionString Returns Jobs DB connection configuration
 func GetConnectionString() string {
 	host := config.GetString("DB.host", "localhost")


### PR DESCRIPTION
# Description

Different table prefixes shouldn't use the same advisory lock.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
