### PR TITLE
fix: router destinationsMap access

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -446,7 +446,6 @@ func (worker *workerT) workerProcess() {
 
 			worker.rt.configSubscriberLock.RLock()
 			batchDestination, ok := worker.rt.destinationsMap[parameters.DestinationID]
-			destination := batchDestination.Destination
 			worker.rt.configSubscriberLock.RUnlock()
 			if !ok {
 				status := jobsdb.JobStatusT{
@@ -463,6 +462,7 @@ func (worker *workerT) workerProcess() {
 				worker.rt.responseQ <- jobResponseT{status: &status, worker: worker, userID: userID, JobT: job}
 				continue
 			}
+			destination := batchDestination.Destination
 			if authType := routerutils.GetAuthType(destination); routerutils.IsNotEmptyString(authType) && authType == "OAuth" {
 				rudderAccountID := routerutils.GetRudderAccountId(&destination)
 				if routerutils.IsNotEmptyString(rudderAccountID) {

--- a/router/router.go
+++ b/router/router.go
@@ -451,11 +451,11 @@ func (worker *workerT) workerProcess() {
 				status := jobsdb.JobStatusT{
 					JobID:         job.JobID,
 					AttemptNum:    job.LastJobStatus.AttemptNum,
-					JobState:      jobsdb.Aborted.State,
+					JobState:      jobsdb.Failed.State,
 					ExecTime:      time.Now(),
 					RetryTime:     time.Now(),
 					ErrorCode:     "",
-					ErrorResponse: []byte(`{"reason": "Aborted because destination is not available in the config" }`),
+					ErrorResponse: []byte(`{"reason": "failed because destination is not available in the config" }`),
 					Parameters:    routerutils.EmptyPayload,
 					WorkspaceId:   job.WorkspaceId,
 				}


### PR DESCRIPTION
# Description

Accessing `destination` without checking for its existence first. Fixes that.

## Notion Ticket

[fix: router destination map access](https://www.notion.so/rudderstacks/fix-router-destination-map-access-2834a4985d0c4886aa080abe77174053)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
