### PR TITLE
fix(jobsdb): race - repeat job count calculation after acquiring migration lock

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -3090,6 +3090,11 @@ func (jd *HandleT) doMigrateDS(ctx context.Context) error {
 			return fmt.Errorf("failed to acquire lock: %w", ctx.Err())
 		}
 		defer jd.dsMigrationLock.Unlock()
+		// repeat the check after the dsMigrationLock is acquired to get correct pending jobs count.
+		// the pending jobs count cannot change after the dsMigrationLock is acquired
+		if migrateFrom, pendingJobsCount, insertBeforeDS = jd.getMigrationList(dsList); len(migrateFrom) == 0 {
+			return nil
+		}
 
 		if pendingJobsCount > 0 { // migrate incomplete jobs
 			var destination dataSetT


### PR DESCRIPTION
# Description

Fixes a race condition causing empty migrated tables getting created and leading to server panic

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=0a514ad1d34d4bf1bbfb10b31f002de1&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
