### PR TITLE
chore: use gotestsum for test execution

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,18 +72,8 @@ jobs:
         check-latest: true
         cache: true
 
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
     - run: go version
     - run: go mod download # Not required, used to segregate module download vs test times
-    - run: (cd /tmp && go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest)
-    - run: ginkgo version
     - env:
         TEST_KAFKA_CONFLUENT_CLOUD_HOST: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_HOST }}
         TEST_KAFKA_CONFLUENT_CLOUD_KEY: ${{ secrets.TEST_KAFKA_CONFLUENT_CLOUD_KEY }}


### PR DESCRIPTION
# Description

Running tests with `gotestsum` [simplifies the console's output](https://github.com/rudderlabs/rudder-server/actions/runs/3280212449/jobs/5400716707) and makes it easier to identify test failures, since only logs from the failed tests are included.

```sh
✓  . (1m43.657s) (coverage: 78.7% of statements)
∅  admin
∅  admin/profiler
∅  app
∅  app/apphandlers
✓  app/cluster (3.591s) (coverage: 71.6% of statements)
✓  app/cluster/state (1.677s) (coverage: 74.3% of statements)
∅  build/wait-for-go
∅  cmd/devtool
∅  cmd/devtool/commands
✓  config (7ms) (coverage: 69.5% of statements)
✓  config/backend-config (16.917s) (coverage: 59.8% of statements)
...
```
If still, for any reason, the full logs from all tests are required, you may enable [debug logging](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging)
<img width="643" alt="image" src="https://user-images.githubusercontent.com/2481587/196638765-d78fa842-7f98-450a-8865-b3b0fd183941.png">

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
