### PR TITLE
chore: fix defect with router destinations map access event order

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -459,6 +459,21 @@ func (worker *workerT) workerProcess() {
 					Parameters:    routerutils.EmptyPayload,
 					WorkspaceId:   job.WorkspaceId,
 				}
+				worker.rt.failedEventsChan <- status
+				if worker.rt.guaranteeUserEventOrder {
+					worker.rt.logger.Debugf(
+						"EventOrder: [%d] job %d for user %s failed",
+						worker.workerID, status.JobID, job.UserID,
+					)
+					err := worker.barrier.StateChanged(
+						job.UserID,
+						job.JobID,
+						status.JobState,
+					)
+					if err != nil {
+						panic(err)
+					}
+				}
 				worker.rt.responseQ <- jobResponseT{status: &status, worker: worker, userID: userID, JobT: job}
 				continue
 			}


### PR DESCRIPTION
# Description

Updating job status in the barrier. Regression introduced by #2582

## Notion Ticket

[fix: router destination map access](https://www.notion.so/rudderstacks/fix-router-destination-map-access-2834a4985d0c4886aa080abe77174053)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
