### PR TITLE
fix: only close response body in oauth handler in case of no error

### DIFF
--- a/router/oauthResponseHandler/oauthResponseHandler.go
+++ b/router/oauthResponseHandler/oauthResponseHandler.go
@@ -484,13 +484,13 @@ func (authErrHandler *OAuthErrResHandler) cpApiCall(cpReq *ControlPlaneRequestT)
 		"requestType": cpReq.RequestType,
 	}).SendTiming(time.Since(cpApiDoTimeStart))
 	authErrHandler.logger.Debugf("[%s request] :: destination request sent\n", loggerNm)
-	if res.Body != nil {
-		defer res.Body.Close()
-	}
 	if doErr != nil {
 		// Abort on receiving an error
 		authErrHandler.logger.Errorf("[%s request] :: destination request failed: %+v\n", loggerNm, doErr)
 		return http.StatusBadRequest, doErr.Error()
+	}
+	if res.Body != nil {
+		defer res.Body.Close()
 	}
 	statusCode, resp := processResponse(res)
 	return statusCode, resp


### PR DESCRIPTION
# Description

According to the doc, if a request fails with error the response must be ignored as it can be nil

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
