### PR TITLE
fix(warehouse): parquet oom and ftr changes

### DIFF
--- a/warehouse/slave.go
+++ b/warehouse/slave.go
@@ -454,6 +454,12 @@ func processStagingFile(job Payload, workerIndex int) (loadFileUploadOutputs []l
 		tableName := batchRouterEvent.Metadata.Table
 		columnData := batchRouterEvent.Data
 
+		if job.DestinationType == warehouseutils.S3_DATALAKE && len(sortedTableColumnMap[tableName]) > columnCountThresholds[warehouseutils.S3_DATALAKE] {
+			err = fmt.Errorf("WH: Staging file schema column limit exceeded")
+			pkgLogger.Errorf("[WH]: Huge staging file columns : columns in upload schema: %v for staging file id %v at %s for %s", len(sortedTableColumnMap[tableName]), job.StagingFileID, job.StagingFileLocation, jobRun.whIdentifier)
+			return nil, err
+		}
+
 		// Create separate load file for each table
 		writer, err := jobRun.GetWriter(tableName)
 		if err != nil {

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -185,6 +185,7 @@ func setMaxParallelLoads() {
 		warehouseutils.POSTGRES:      config.GetInt("Warehouse.postgres.columnCountThreshold", 1200),
 		warehouseutils.RS:            config.GetInt("Warehouse.redshift.columnCountThreshold", 1200),
 		warehouseutils.SNOWFLAKE:     config.GetInt("Warehouse.snowflake.columnCountThreshold", 1600),
+		warehouseutils.S3_DATALAKE:   config.GetInt("Warehouse.s3_datalake.columnCountThreshold", 10000),
 	}
 }
 


### PR DESCRIPTION
# Description

> parquet OOM fix: max limit on columns loading into parquet file 
> FTR fall back mechanism changes

## Notion Ticket

https://www.notion.so/rudderstacks/Warehouse-release-1-2-x-fixes-efedcf51c6d14428acb8bc07d0ff9ec1

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
