### PR TITLE
fix(warehouse): set default aws keys in case if configs doesn't exist

### DIFF
--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -380,14 +380,14 @@ func GetLoadFileGenTime(str sql.NullString) (t time.Time) {
 
 func GetNamespace(source backendconfig.SourceT, destination backendconfig.DestinationT, dbHandle *sql.DB) (namespace string, exists bool) {
 	sqlStatement := fmt.Sprintf(`
-		SELECT 
-		  namespace 
-		FROM 
-		  %s 
-		WHERE 
-		  source_id = '%s' 
-		  AND destination_id = '%s' 
-		ORDER BY 
+		SELECT
+		  namespace
+		FROM
+		  %s
+		WHERE
+		  source_id = '%s'
+		  AND destination_id = '%s'
+		ORDER BY
 		  id DESC;
 `,
 		WarehouseSchemasTable,
@@ -777,7 +777,8 @@ func JoinWithFormatting(keys []string, format func(idx int, str string) string, 
 }
 
 func CreateAWSSessionConfig(destination *backendconfig.DestinationT, serviceName string) (*awsutils.SessionConfig, error) {
-	if !misc.IsConfiguredToUseRudderObjectStorage(destination.Config) {
+	if !misc.IsConfiguredToUseRudderObjectStorage(destination.Config) &&
+		(misc.HasAWSRoleARNInConfig(destination.Config) || misc.HasAWSKeysInConfig(destination.Config)) {
 		return awsutils.NewSimpleSessionConfigForDestination(destination, serviceName)
 	}
 	accessKeyID, accessKey := misc.GetRudderObjectStorageAccessKeys()

--- a/warehouse/utils/utils_test.go
+++ b/warehouse/utils/utils_test.go
@@ -1250,6 +1250,18 @@ func TestCreateAWSSessionConfig(t *testing.T) {
 				Service:       "redshift",
 			},
 		},
+		{
+			destination: &backendconfig.DestinationT{
+				Config:      map[string]interface{}{},
+				WorkspaceID: someWorkspaceID,
+			},
+			service: "redshift",
+			expectedConfig: &awsutils.SessionConfig{
+				AccessKeyID: rudderAccessKeyID,
+				AccessKey:   rudderAccessKey,
+				Service:     "redshift",
+			},
+		},
 	}
 	for _, input := range inputs {
 		config, err := CreateAWSSessionConfig(input.destination, input.service)


### PR DESCRIPTION
# Description

Use default s3 config (s3-copy) when none of the configs (accessKey, accessKeyID, iamRole) are passed in the destination config.

## Notion Ticket

https://www.notion.so/rudderstacks/Warehouse-release-1-2-x-fixes-efedcf51c6d14428acb8bc07d0ff9ec1

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
