### PR TITLE
fix: page size fixed irrespectiveof suppressAPIToken

### DIFF
--- a/enterprise/suppress-user/suppressUser.go
+++ b/enterprise/suppress-user/suppressUser.go
@@ -159,9 +159,11 @@ func (suppressUser *SuppressRegulationHandler) getSourceRegulationsFromRegulatio
 
 	urlStr := fmt.Sprintf("%s/dataplane/workspaces/%s/regulations/suppressions", suppressUser.RegulationBackendURL, suppressUser.WorkspaceID)
 	urlValQuery := url.Values{}
+	if suppressUser.pageSize != "" {
+		urlValQuery.Set("pageSize", suppressUser.pageSize)
+	}
 	if suppressUser.suppressAPIToken != "" {
 		urlValQuery.Set("pageToken", suppressUser.suppressAPIToken)
-		urlValQuery.Set("pageSize", suppressUser.pageSize)
 	}
 	if len(urlValQuery) > 0 {
 		urlStr += "?" + urlValQuery.Encode()


### PR DESCRIPTION
# Description
Currently, `pageSize` is only set if `suppressAPIToken` is set, which is set only after we get response for 1st request from `gw`. So, the the 1st request url from gw doesn't have `pageSize` set. And, since the go routine sleep for 5 min if the number of suppression user received is less than `pageSize`. Because of this bug, there was an unnecessary delay in suppression sync at `gw` end.

This issue is fixed in this PR.

## Notion Ticket

https://www.notion.so/rudderstacks/GW-suppression-pageSize-bug-fix-71f965130db842d188ae265263f72fa1

