### PR TITLE
fix: remove gateway db write panic

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -323,8 +323,10 @@ func (gateway *HandleT) userWorkerRequestBatcher() {
 // This in turn sends the error over the done channel of each respective webRequest.
 func (gateway *HandleT) dbWriterWorkerProcess() {
 	for breq := range gateway.batchUserWorkerBatchRequestQ {
-		jobList := make([]*jobsdb.JobT, 0)
-		var errorMessagesMap map[uuid.UUID]string
+		var (
+			jobList          = make([]*jobsdb.JobT, 0)
+			errorMessagesMap = map[uuid.UUID]string{}
+		)
 
 		for _, userWorkerBatchRequest := range breq.batchUserWorkerBatchRequest {
 			jobList = append(jobList, userWorkerBatchRequest.jobList...)
@@ -352,10 +354,16 @@ func (gateway *HandleT) dbWriterWorkerProcess() {
 			rsourcesStats.JobsStoredWithErrors(jobList, errorMessagesMap)
 			return rsourcesStats.Publish(ctx, tx.SqlTx())
 		})
-		cancel()
 		if err != nil {
-			panic(err)
+			errorMessage := err.Error()
+			if ctx.Err() != nil {
+				errorMessage = ctx.Err().Error()
+			}
+			for _, job := range jobList {
+				errorMessagesMap[job.UUID] = errorMessage
+			}
 		}
+		cancel()
 		gateway.dbWritesStat.Count(1)
 
 		for _, userWorkerBatchRequest := range breq.batchUserWorkerBatchRequest {
@@ -1173,7 +1181,7 @@ func (gateway *HandleT) webRequestHandler(rh RequestHandler, w http.ResponseWrit
 	defer func() {
 		if errorMessage != "" {
 			gateway.logger.Infof("IP: %s -- %s -- Response: %d, %s", misc.GetIPFromReq(r), r.URL.Path, response.GetErrorStatusCode(errorMessage), errorMessage)
-			http.Error(w, errorMessage, response.GetErrorStatusCode(errorMessage))
+			http.Error(w, response.GetStatus(errorMessage), response.GetErrorStatusCode(errorMessage))
 		}
 	}()
 	payload, writeKey, err := gateway.getPayloadAndWriteKey(w, r, reqType)

--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -52,6 +52,10 @@ const (
 	ErrorInParseMultiform = "Error during parsing multiform"
 	// NotRudderEvent = Event is not a Valid Rudder Event
 	NotRudderEvent = "Event is not a valid rudder event"
+	// ContextDeadlineExceeded - context deadline exceeded
+	ContextDeadlineExceeded = "context deadline exceeded"
+	// GatewayTimeout - Gateway timeout
+	GatewayTimeout = "Gateway timeout"
 
 	transPixelResponse = "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x21\xF9\x04" +
 		"\x01\x00\x00\x00\x00\x2C\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3B"
@@ -82,6 +86,7 @@ var statusMap = map[string]status{
 	ErrorInParseForm:                               {message: ErrorInParseForm, code: http.StatusBadRequest},
 	ErrorInParseMultiform:                          {message: ErrorInParseMultiform, code: http.StatusBadRequest},
 	NotRudderEvent:                                 {message: NotRudderEvent, code: http.StatusBadRequest},
+	ContextDeadlineExceeded:                        {message: GatewayTimeout, code: http.StatusGatewayTimeout},
 }
 
 // status holds the gateway response status message and code


### PR DESCRIPTION
# Description

Remove panic in `gateway.dbWriterWorkerProcess` on store failure.

## Notion Ticket

[remove gateway panic on write failure](https://www.notion.so/rudderstacks/remove-gateway-panic-on-write-timeout-f65be5e734cc42718c37a0436b449308)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
