### PR TITLE
fix: use sum64 to avoid checkptr race bug

### DIFF
--- a/services/pgnotifier/pgnotifier.go
+++ b/services/pgnotifier/pgnotifier.go
@@ -643,7 +643,7 @@ func GetCurrentSQLTimestamp() string {
 // RunMaintenanceWorker (blocking - to be called from go routine) re-triggers zombie jobs
 // which were left behind by dead workers in executing state
 func (notifier *PgNotifierT) RunMaintenanceWorker(ctx context.Context) error {
-	maintenanceWorkerLockID := murmur3.Sum32([]byte(queueName))
+	maintenanceWorkerLockID := murmur3.Sum64([]byte(queueName))
 	maintenanceWorkerLock, err := pglock.NewLock(ctx, int64(maintenanceWorkerLockID), notifier.dbHandle)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

This fix addresses a panic when running with `--race` flag:
```
fatal error: checkptr: pointer arithmetic result points to invalid allocation
```

The culprit is the following line, which is called `murmur3.Sum64` 
```
k1 := *(*uint32)(unsafe.Pointer(p))
```

The usage of unsafe is being condemned in [this issue](https://github.com/spaolacci/murmur3/issues/29
) and we should probably consider changing the library all together 


Does it make sense to use int64 ?

Yes, both the pglock library and postgress supports this:

```go
pg_advisory_lock(key bigint)
```
https://www.postgresql.org/docs/9.1/functions-admin.html

It also works with negative numbers

To avoid code like this being added in the future, I am [considering](https://github.com/rudderlabs/rudder-server/pull/2646) enabling `--race` flag for all the tests, hoping the times are not going up.

## Notion Ticket

https://www.notion.so/rudderstacks/murmur-race-fix-25aa4f37c58047faa1ff7baed24c0960

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
