### PR TITLE
chore: by default enable max concurrent gw request limit.

### DIFF
--- a/gateway/configuration.go
+++ b/gateway/configuration.go
@@ -43,8 +43,8 @@ func loadConfig() {
 	config.RegisterDurationConfigVariable(10, &WriteTimeout, false, time.Second, []string{"WriteTimeout", "WriteTimeOutInSec"}...)
 	config.RegisterDurationConfigVariable(720, &IdleTimeout, false, time.Second, []string{"IdleTimeout", "IdleTimeoutInSec"}...)
 	config.RegisterIntConfigVariable(524288, &maxHeaderBytes, false, 1, "MaxHeaderBytes")
-	// default values is '0', which means disabled. So, if `maxActiveClients` is not set. We consider it to be disabled.
-	config.RegisterIntConfigVariable(0, &maxConcurrentRequests, false, 1, "Gateway.maxConcurrentRequests")
+	// if set to '0', it means disabled.
+	config.RegisterIntConfigVariable(50000, &maxConcurrentRequests, false, 1, "Gateway.maxConcurrentRequests")
 }
 
 // MaxReqSize is the maximum request body size, in bytes, accepted by gateway web handlers


### PR DESCRIPTION
# Description
Enable max concurrent gateway request limit with default value of 50000.

Discussion ref: https://rudderlabs.slack.com/archives/C01JF5MGUAG/p1667401042399559

## Notion Ticket
https://www.notion.so/rudderstacks/enable-max-concurrent-gw-request-limit-ce0781d221984678a0f843823d50d303


## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
