### PR TITLE
chore: use WriteTimeout instead of Gateway.pendingEventsQueryTimeout

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -937,7 +937,7 @@ func (gateway *HandleT) pendingEventsHandler(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), config.GetDuration("Gateway.pendingEventsQueryTimeout", 10, time.Second))
+	ctx, cancel := context.WithTimeout(r.Context(), WriteTimeout)
 	defer cancel()
 
 	var pending bool


### PR DESCRIPTION
# Description

Keeping it simple

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
