### PR TITLE
fix: use proper status code to handle warehouse process

### DIFF
--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1129,9 +1129,15 @@ func (brt *HandleT) postToWarehouse(batchJobs *BatchJobsT, output StorageUploadO
 		bytes.NewBuffer(jsonPayload))
 	if err != nil {
 		brt.logger.Errorf("BRT: Failed to route staging file URL to warehouse service@%v, error:%v", uri, err)
-	} else {
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == 200 {
 		brt.logger.Infof("BRT: Routed successfully staging file URL to warehouse service@%v", uri)
-		defer resp.Body.Close()
+	} else {
+		err = fmt.Errorf("BRT: Failed to route staging file URL to warehouse service@%v, status:%v", uri, resp.Status)
+		brt.logger.Error(err)
 	}
 
 	return


### PR DESCRIPTION
# Description

Handle status code when batch router hits warehouse` v1/process` URL.

## Notion Ticket

https://www.notion.so/rudderstacks/Handle-warehouse-process-9fa6aa8da88948999ea81bf5a34a352a

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
