### PR TITLE
fix: preferences should be false incase of invalid bucket

### DIFF
--- a/services/fileuploader/fileuploader.go
+++ b/services/fileuploader/fileuploader.go
@@ -85,12 +85,13 @@ func (p *provider) updateLoop(ctx context.Context, backendConfig backendconfig.B
 
 	settings := make(map[string]StorageSettings)
 
-	var bucket backendconfig.StorageBucket
-	var preferences backendconfig.StoragePreferences
-
 	for ev := range ch {
 		configs := ev.Data.(map[string]backendconfig.ConfigT)
 		for _, c := range configs {
+
+			var bucket backendconfig.StorageBucket
+			var preferences backendconfig.StoragePreferences
+
 			if c.Settings.DataRetention.UseSelfStorage {
 				settings := c.Settings.DataRetention.StorageBucket
 				defaultBucket := getDefaultBucket(ctx, settings.Type)
@@ -98,7 +99,10 @@ func (p *provider) updateLoop(ctx context.Context, backendConfig backendconfig.B
 			} else {
 				bucket = getDefaultBucket(ctx, config.GetString("JOBS_BACKUP_STORAGE_PROVIDER", "S3"))
 			}
-			preferences = c.Settings.DataRetention.StoragePreferences
+			// bucket type and configuration must not be empty
+			if bucket.Type != "" && len(bucket.Config) > 0 {
+				preferences = c.Settings.DataRetention.StoragePreferences
+			}
 			settings[c.WorkspaceID] = StorageSettings{
 				Bucket:      bucket,
 				Preferences: preferences,

--- a/services/fileuploader/fileuploader_test.go
+++ b/services/fileuploader/fileuploader_test.go
@@ -76,14 +76,12 @@ func TestFileUploaderUpdatingWithConfigBackend(t *testing.T) {
 					DataRetention: backendconfig.DataRetention{
 						UseSelfStorage: true,
 						StorageBucket: backendconfig.StorageBucket{
-							Type: "some-type",
-							Config: map[string]interface{}{
-								"some-key": "some-value",
-							},
+							Type:   "",
+							Config: map[string]interface{}{},
 						},
 						StoragePreferences: backendconfig.StoragePreferences{
-							ProcErrors:   true,
-							GatewayDumps: true,
+							ProcErrors:   false,
+							GatewayDumps: false,
 						},
 					},
 				},
@@ -102,6 +100,10 @@ func TestFileUploaderUpdatingWithConfigBackend(t *testing.T) {
 
 	preferences, err = fileUploaderProvider.GetStoragePreferences("testWorkspaceId-0")
 	Expect(err).To(HaveOccurred())
+	Expect(preferences).To(BeEquivalentTo(backendconfig.StoragePreferences{}))
+
+	preferences, err = fileUploaderProvider.GetStoragePreferences("testWorkspaceId-2")
+	Expect(err).To(BeNil())
 	Expect(preferences).To(BeEquivalentTo(backendconfig.StoragePreferences{}))
 }
 


### PR DESCRIPTION
# Description

Setting all backup preferences to false incase there is invalid bucket provided

## Notion Ticket

https://www.notion.so/rudderstacks/Allow-Customers-to-use-self-storage-26f45f75e38b4ef6bd872bea6187aa06

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
