### PR TITLE
fix: gcs manager cancels context

### DIFF
--- a/services/filemanager/gcsmanager.go
+++ b/services/filemanager/gcsmanager.go
@@ -66,9 +66,6 @@ func (manager *GCSManager) ListFilesWithPrefix(ctx context.Context, startAfter, 
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, manager.getTimeout())
-	defer cancel()
-
 	// Create GCS Bucket handle
 	if manager.Config.Iterator == nil {
 		manager.Config.Iterator = client.Bucket(manager.Config.Bucket).Objects(ctx, &storage.Query{


### PR DESCRIPTION
# Description

GCS Manager creates an iterator to fetch objects. Bug: We were passing context to it and later cancelling at the end of the function call although the iterator will be used for every call of the function

## Notion Ticket

https://www.notion.so/rudderstacks/Fix-GCS-Replay-2dd4e0f0e97942a5bcce282a5f61ea77

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
