### PR TITLE
fix: properly escape table name when querying for failed events

### DIFF
--- a/router/failed-events-manager.go
+++ b/router/failed-events-manager.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -55,7 +56,7 @@ func (*FailedEventsManagerT) SaveFailedRecordIDs(taskRunIDFailedEventsMap map[st
 	}
 
 	for taskRunID, failedEvents := range taskRunIDFailedEventsMap {
-		table := fmt.Sprintf(`%s_%s`, failedKeysTablePrefix, taskRunID)
+		table := `"` + strings.ReplaceAll(fmt.Sprintf(`%s_%s`, failedKeysTablePrefix, taskRunID), `"`, `""`) + `"`
 		sqlStatement := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 		destination_id TEXT NOT NULL,
 		record_id JSONB NOT NULL,
@@ -110,7 +111,7 @@ func (fem *FailedEventsManagerT) FetchFailedRecordIDs(taskRunID string) []*Faile
 
 	var rows *sql.Rows
 	var err error
-	table := fmt.Sprintf(`%s_%s`, failedKeysTablePrefix, taskRunID)
+	table := `"` + strings.ReplaceAll(fmt.Sprintf(`%s_%s`, failedKeysTablePrefix, taskRunID), `"`, `""`) + `"`
 	sqlStatement := fmt.Sprintf(`SELECT %[1]s.destination_id, %[1]s.record_id
                                              FROM %[1]s `, table)
 	rows, err = fem.dbHandle.Query(sqlStatement)


### PR DESCRIPTION
# Description

Using double quotes and escaping the table name when querying for failed events, until we drop support for the old endpoint.

[Reference](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#:~:text=Quoted%20identifiers%20can,limitation%20still%20applies)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
