### PR TITLE
fix: use enterprise token from env as fallback

### DIFF
--- a/integration_test/docker_test/docker_test.go
+++ b/integration_test/docker_test/docker_test.go
@@ -484,7 +484,7 @@ func setupMainFlow(svcCtx context.Context, t *testing.T) <-chan struct{} {
 
 	svcDone := make(chan struct{})
 	go func() {
-		r := runner.New(runner.ReleaseInfo{})
+		r := runner.New(runner.ReleaseInfo{EnterpriseToken: os.Getenv("ENTERPRISE_TOKEN")})
 		_ = r.Run(svcCtx, []string{"docker-test-rudder-server"})
 		close(svcDone)
 	}()

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	_ "go.uber.org/automaxprocs"
 
+	"github.com/rudderlabs/rudder-server/config"
 	"github.com/rudderlabs/rudder-server/runner"
 )
 
@@ -27,7 +28,7 @@ func main() {
 		BuildDate:       buildDate,
 		BuiltBy:         builtBy,
 		GitURL:          gitURL,
-		EnterpriseToken: enterpriseToken,
+		EnterpriseToken: config.GetString("ENTERPRISE_TOKEN", enterpriseToken),
 	})
 	exitCode := r.Run(ctx, os.Args)
 	cancel()

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -133,9 +133,6 @@ func (r *Runner) Run(ctx context.Context, args []string) int {
 		return 0
 	}
 
-	if r.releaseInfo.EnterpriseToken == "" {
-		r.releaseInfo.EnterpriseToken = os.Getenv("ENTERPRISE_TOKEN")
-	}
 	options.EnterpriseToken = r.releaseInfo.EnterpriseToken
 
 	r.application = app.New(options)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -133,6 +133,9 @@ func (r *Runner) Run(ctx context.Context, args []string) int {
 		return 0
 	}
 
+	if r.releaseInfo.EnterpriseToken == "" {
+		r.releaseInfo.EnterpriseToken = os.Getenv("ENTERPRISE_TOKEN")
+	}
 	options.EnterpriseToken = r.releaseInfo.EnterpriseToken
 
 	r.application = app.New(options)


### PR DESCRIPTION
# Description

Falling back to enterprise token read from env (if not provided as an ldflag)


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
