### PR TITLE
fix: removing the backup bucket env check to determine if backup is enabled

### DIFF
--- a/jobsdb/backup.go
+++ b/jobsdb/backup.go
@@ -29,7 +29,7 @@ type backupSettings struct {
 }
 
 func (b *backupSettings) isBackupEnabled() bool {
-	return masterBackupEnabled && b.instanceBackupEnabled && config.GetString("JOBS_BACKUP_BUCKET", "") != ""
+	return masterBackupEnabled && b.instanceBackupEnabled
 }
 
 func IsMasterBackupEnabled() bool {


### PR DESCRIPTION
# Description

Removing the backup bucket env check to determine if backup is enabled since bucket can be provided by customer as well

## Notion Ticket

< Replace with Notion Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
