### PR TITLE
test: using arm64 compatible images if necessary

### DIFF
--- a/integration_test/docker_test/docker_test.go
+++ b/integration_test/docker_test/docker_test.go
@@ -214,7 +214,6 @@ func TestMainFlow(t *testing.T) {
 	})
 
 	t.Run("kafka", func(t *testing.T) {
-
 		kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
 
 		// Create new consumer

--- a/integration_test/docker_test/docker_test.go
+++ b/integration_test/docker_test/docker_test.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -215,9 +214,6 @@ func TestMainFlow(t *testing.T) {
 	})
 
 	t.Run("kafka", func(t *testing.T) {
-		if runtime.GOARCH == "arm64" && !overrideArm64Check {
-			t.Skip("arm64 is not supported yet")
-		}
 
 		kafkaHost := fmt.Sprintf("localhost:%s", kafkaContainer.Port)
 
@@ -389,20 +385,18 @@ func setupMainFlow(svcCtx context.Context, t *testing.T) <-chan struct{} {
 	require.NoError(t, err)
 
 	containersGroup, containersCtx := errgroup.WithContext(context.TODO())
-	if runtime.GOARCH != "arm64" || overrideArm64Check {
-		containersGroup.Go(func() (err error) {
-			kafkaContainer, err = destination.SetupKafka(pool, t,
-				destination.WithLogger(&testLogger{logger.NewLogger().Child("kafka")}),
-				destination.WithBrokers(1),
-			)
-			if err != nil {
-				return err
-			}
-			kafkaCtx, kafkaCancel := context.WithTimeout(containersCtx, 3*time.Minute)
-			defer kafkaCancel()
-			return waitForKafka(kafkaCtx, t, kafkaContainer.Port)
-		})
-	}
+	containersGroup.Go(func() (err error) {
+		kafkaContainer, err = destination.SetupKafka(pool, t,
+			destination.WithLogger(&testLogger{logger.NewLogger().Child("kafka")}),
+			destination.WithBrokers(1),
+		)
+		if err != nil {
+			return err
+		}
+		kafkaCtx, kafkaCancel := context.WithTimeout(containersCtx, 3*time.Minute)
+		defer kafkaCancel()
+		return waitForKafka(kafkaCtx, t, kafkaContainer.Port)
+	})
 	containersGroup.Go(func() (err error) {
 		redisContainer, err = destination.SetupRedis(pool, t)
 		return err
@@ -462,9 +456,7 @@ func setupMainFlow(svcCtx context.Context, t *testing.T) <-chan struct{} {
 		"minioEndpoint":                minioContainer.Endpoint,
 		"minioBucketName":              minioContainer.BucketName,
 	}
-	if runtime.GOARCH != "arm64" || overrideArm64Check {
-		mapWorkspaceConfig["kafkaPort"] = kafkaContainer.Port
-	}
+	mapWorkspaceConfig["kafkaPort"] = kafkaContainer.Port
 	workspaceConfigPath := workspaceConfig.CreateTempFile(t,
 		"testdata/workspaceConfigTemplate.json",
 		mapWorkspaceConfig,

--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -31,10 +30,6 @@ var overrideArm64Check bool
 func TestMain(m *testing.M) {
 	if os.Getenv("OVERRIDE_ARM64_CHECK") == "1" {
 		overrideArm64Check = true
-	}
-	if runtime.GOARCH == "arm64" && !overrideArm64Check {
-		fmt.Println("arm64 is not supported yet")
-		os.Exit(0)
 	}
 	os.Exit(m.Run())
 }

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"runtime"
 	"testing"
 	"time"
 
@@ -119,9 +118,6 @@ func TestNewProducer(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		if runtime.GOARCH == "arm64" && !overrideArm64Check {
-			t.Skip("arm64 is not supported yet")
-		}
 
 		kafkaStats.creationTime = getMockedTimer(t, gomock.NewController(t))
 

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -118,7 +118,6 @@ func TestNewProducer(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-
 		kafkaStats.creationTime = getMockedTimer(t, gomock.NewController(t))
 
 		pool, err := dockertest.NewPool("")

--- a/testhelper/destination/kafka.go
+++ b/testhelper/destination/kafka.go
@@ -143,7 +143,7 @@ func SetupKafka(pool *dockertest.Pool, cln cleaner, opts ...Option) (*KafkaResou
 		return nil, err
 	}
 	zkImage := "bitnami/zookeeper"
-	if runtime.GOARCH != "arm64" {
+	if runtime.GOARCH == "arm64" {
 		zkImage = "zcube/bitnami-compat-zookeeper"
 	}
 	zookeeperPort := fmt.Sprintf("%s/tcp", strconv.Itoa(zookeeperPortInt))
@@ -261,7 +261,7 @@ func SetupKafka(pool *dockertest.Pool, cln cleaner, opts ...Option) (*KafkaResou
 		nodeID := fmt.Sprintf("%d", i+1)
 		hostname := "kafka" + nodeID
 		kImage := "bitnami/kafka"
-		if runtime.GOARCH != "arm64" {
+		if runtime.GOARCH == "arm64" {
 			kImage = "zcube/bitnami-compat-kafka"
 		}
 		containers[i], err = pool.RunWithOptions(&dockertest.RunOptions{

--- a/testhelper/destination/kafka.go
+++ b/testhelper/destination/kafka.go
@@ -3,6 +3,7 @@ package destination
 import (
 	_ "encoding/json"
 	"fmt"
+	"runtime"
 	"strconv"
 
 	_ "github.com/lib/pq"
@@ -141,9 +142,13 @@ func SetupKafka(pool *dockertest.Pool, cln cleaner, opts ...Option) (*KafkaResou
 	if err != nil {
 		return nil, err
 	}
+	zkImage := "bitnami/zookeeper"
+	if runtime.GOARCH != "arm64" {
+		zkImage = "zcube/bitnami-compat-zookeeper"
+	}
 	zookeeperPort := fmt.Sprintf("%s/tcp", strconv.Itoa(zookeeperPortInt))
 	zookeeperContainer, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: "bitnami/zookeeper",
+		Repository: zkImage,
 		Tag:        "latest",
 		NetworkID:  network.ID,
 		Hostname:   "zookeeper",
@@ -255,8 +260,12 @@ func SetupKafka(pool *dockertest.Pool, cln cleaner, opts ...Option) (*KafkaResou
 
 		nodeID := fmt.Sprintf("%d", i+1)
 		hostname := "kafka" + nodeID
+		kImage := "bitnami/kafka"
+		if runtime.GOARCH != "arm64" {
+			kImage = "zcube/bitnami-compat-kafka"
+		}
 		containers[i], err = pool.RunWithOptions(&dockertest.RunOptions{
-			Repository: "bitnami/kafka",
+			Repository: kImage,
 			Tag:        "latest",
 			NetworkID:  network.ID,
 			Hostname:   hostname,

--- a/testhelper/etcd/etcd.go
+++ b/testhelper/etcd/etcd.go
@@ -2,6 +2,7 @@ package etcd
 
 import (
 	"fmt"
+	"runtime"
 	"strconv"
 
 	"github.com/ory/dockertest/v3"
@@ -21,7 +22,11 @@ type Resource struct {
 }
 
 func Setup(pool *dockertest.Pool, cln cleaner) (*Resource, error) {
-	container, err := pool.Run("bitnami/etcd", "3", []string{
+	etcdImage := "bitnami/etcd"
+	if runtime.GOARCH != "arm64" {
+		etcdImage = "zcube/bitnami-compat-etcd"
+	}
+	container, err := pool.Run(etcdImage, "3.5", []string{
 		"ALLOW_NONE_AUTHENTICATION=yes",
 	})
 	if err != nil {

--- a/testhelper/etcd/etcd.go
+++ b/testhelper/etcd/etcd.go
@@ -23,7 +23,7 @@ type Resource struct {
 
 func Setup(pool *dockertest.Pool, cln cleaner) (*Resource, error) {
 	etcdImage := "bitnami/etcd"
-	if runtime.GOARCH != "arm64" {
+	if runtime.GOARCH == "arm64" {
 		etcdImage = "zcube/bitnami-compat-etcd"
 	}
 	container, err := pool.Run(etcdImage, "3.5", []string{


### PR DESCRIPTION
# Description

- Enabling all tests in arm64 machines (m1 macbooks)
- Fixing flaky multitenant test

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
