### PR TITLE
fix(destination): empty oauth account check

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -2087,48 +2087,48 @@ func (rt *HandleT) HandleOAuthDestResponse(params *HandleDestOAuthRespParamsT) (
 		}
 		workspaceID := destinationJob.JobMetadataArray[0].WorkspaceID
 		var errCatStatusCode int
-		// destErrDetailed := destErrOutput.Output
 		// Check the category
 		// Trigger the refresh endpoint/disable endpoint
 		rudderAccountID := routerutils.GetRudderAccountId(&destinationJob.Destination)
-		if strings.TrimSpace(rudderAccountID) != "" {
-			switch destErrOutput.AuthErrorCategory {
-			case oauth.DISABLE_DEST:
-				return rt.ExecDisableDestination(&destinationJob.Destination, workspaceID, trRespBody, rudderAccountID)
-			case oauth.REFRESH_TOKEN:
-				var refSecret *oauth.AuthResponse
-				refTokenParams := &oauth.RefreshTokenParams{
-					Secret:          params.secret,
-					WorkspaceId:     workspaceID,
-					AccountId:       rudderAccountID,
-					DestDefName:     destinationJob.Destination.DestinationDefinition.Name,
-					EventNamePrefix: "refresh_token",
-					WorkerId:        params.workerID,
-				}
-				errCatStatusCode, refSecret = rt.oauth.RefreshToken(refTokenParams)
-				refSec := *refSecret
-				if routerutils.IsNotEmptyString(refSec.Err) && refSec.Err == oauth.INVALID_REFRESH_TOKEN_GRANT {
-					// In-case the refresh token has been revoked, this error comes in
-					// Even trying to refresh the token also doesn't work here. Hence, this would be more ideal to Abort Events
-					// As well as to disable destination as well.
-					// Alert the user in this error as well, to check if the refresh token also has been revoked & fix it
-					disableStCd, _ := rt.ExecDisableDestination(&destinationJob.Destination, workspaceID, trRespBody, rudderAccountID)
-					stats.Default.NewTaggedStat(oauth.INVALID_REFRESH_TOKEN_GRANT, stats.CountType, stats.Tags{
-						"destinationId": destinationJob.Destination.ID,
-						"workspaceId":   refTokenParams.WorkspaceId,
-						"accountId":     refTokenParams.AccountId,
-						"destType":      refTokenParams.DestDefName,
-					}).Increment()
-					rt.logger.Errorf(`[OAuth request] Aborting the event as %v`, oauth.INVALID_REFRESH_TOKEN_GRANT)
-					return disableStCd, refSec.Err
-				}
-				// Error while refreshing the token or Has an error while refreshing or sending empty access token
-				if errCatStatusCode != http.StatusOK || routerutils.IsNotEmptyString(refSec.Err) {
-					return http.StatusTooManyRequests, refSec.Err
-				}
-				// Retry with Refreshed Token by failing with 5xx
-				return http.StatusInternalServerError, trRespBody
+		if strings.TrimSpace(rudderAccountID) == "" {
+			return trRespStatusCode, trRespBody
+		}
+		switch destErrOutput.AuthErrorCategory {
+		case oauth.DISABLE_DEST:
+			return rt.ExecDisableDestination(&destinationJob.Destination, workspaceID, trRespBody, rudderAccountID)
+		case oauth.REFRESH_TOKEN:
+			var refSecret *oauth.AuthResponse
+			refTokenParams := &oauth.RefreshTokenParams{
+				Secret:          params.secret,
+				WorkspaceId:     workspaceID,
+				AccountId:       rudderAccountID,
+				DestDefName:     destinationJob.Destination.DestinationDefinition.Name,
+				EventNamePrefix: "refresh_token",
+				WorkerId:        params.workerID,
 			}
+			errCatStatusCode, refSecret = rt.oauth.RefreshToken(refTokenParams)
+			refSec := *refSecret
+			if routerutils.IsNotEmptyString(refSec.Err) && refSec.Err == oauth.INVALID_REFRESH_TOKEN_GRANT {
+				// In-case the refresh token has been revoked, this error comes in
+				// Even trying to refresh the token also doesn't work here. Hence, this would be more ideal to Abort Events
+				// As well as to disable destination as well.
+				// Alert the user in this error as well, to check if the refresh token also has been revoked & fix it
+				disableStCd, _ := rt.ExecDisableDestination(&destinationJob.Destination, workspaceID, trRespBody, rudderAccountID)
+				stats.Default.NewTaggedStat(oauth.INVALID_REFRESH_TOKEN_GRANT, stats.CountType, stats.Tags{
+					"destinationId": destinationJob.Destination.ID,
+					"workspaceId":   refTokenParams.WorkspaceId,
+					"accountId":     refTokenParams.AccountId,
+					"destType":      refTokenParams.DestDefName,
+				}).Increment()
+				rt.logger.Errorf(`[OAuth request] Aborting the event as %v`, oauth.INVALID_REFRESH_TOKEN_GRANT)
+				return disableStCd, refSec.Err
+			}
+			// Error while refreshing the token or Has an error while refreshing or sending empty access token
+			if errCatStatusCode != http.StatusOK || routerutils.IsNotEmptyString(refSec.Err) {
+				return http.StatusTooManyRequests, refSec.Err
+			}
+			// Retry with Refreshed Token by failing with 5xx
+			return http.StatusInternalServerError, trRespBody
 		}
 	}
 	// By default, send the status code & response from transformed response directly


### PR DESCRIPTION
# Description

The oauth account id can be empty. Due to the changes we might do as part of the regulation-worker support for Universal Analytics.

This check serves as protection when `rudderAccountId` is missing. 

### Background:
As part of the changes for supporting OAuth in regulation-worker module. We need to have one more field in destination config known as `rudderUserDeleteAccountId` which indicates that this account information will be used for sending delete user request to destination

This user delete feature can sometimes only require OAuth and event-delivery for the same destination might not need OAuth, int this case, we don’t populate `rudderAccountId` but we populate `rudderUserDeleteAccountId` with the access token information(which will be used for user-deletion requests)

This can cause a problem while processing the transformer proxy response for OAuth destinations. We would need to add a check to prevent any errors for such things.


## Notion Ticket

https://www.notion.so/rudderstacks/Integrate-OAuth-in-regulation-worker-module-of-server-dae0cf6ef89e41eb91e9212ac524cf49

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
