### PR TITLE
chore: fixing a flaky rsources test

### DIFF
--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -170,7 +170,8 @@ func NewJobService(config JobServiceConfig) (JobService, error) {
 		localDB:  localDB,
 		sharedDB: sharedDB,
 	}
-	return handler, handler.init()
+	err = handler.init()
+	return handler, err
 }
 
 func NewNoOpService() JobService {

--- a/testhelper/log/log.go
+++ b/testhelper/log/log.go
@@ -1,0 +1,53 @@
+package log
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/rudderlabs/rudder-server/utils/logger"
+)
+
+var GinkgoLogger logger.Logger = &ginkgoLogger{logger.NOP}
+
+type ginkgoLogger struct {
+	logger.Logger
+}
+
+func (ginkgoLogger) Debug(args ...interface{}) { ginkgo.GinkgoT().Log(args...) }
+func (ginkgoLogger) Info(args ...interface{})  { ginkgo.GinkgoT().Log(args...) }
+func (ginkgoLogger) Warn(args ...interface{})  { ginkgo.GinkgoT().Log(args...) }
+func (ginkgoLogger) Error(args ...interface{}) { ginkgo.GinkgoT().Log(args...) }
+func (ginkgoLogger) Fatal(args ...interface{}) { ginkgo.GinkgoT().Log(args...) }
+func (ginkgoLogger) Debugf(format string, args ...interface{}) {
+	ginkgo.GinkgoT().Logf(format, args...)
+}
+func (ginkgoLogger) Infof(format string, args ...interface{}) { ginkgo.GinkgoT().Logf(format, args...) }
+func (ginkgoLogger) Warnf(format string, args ...interface{}) { ginkgo.GinkgoT().Logf(format, args...) }
+func (ginkgoLogger) Errorf(format string, args ...interface{}) {
+	ginkgo.GinkgoT().Logf(format, args...)
+}
+
+func (ginkgoLogger) Fatalf(format string, args ...interface{}) {
+	ginkgo.GinkgoT().Logf(format, args...)
+}
+
+func (ginkgoLogger) Debugw(format string, args ...interface{}) {
+	ginkgo.GinkgoT().Logf(format, args...)
+}
+
+func (ginkgoLogger) Infow(msg string, keysAndValues ...interface{}) {
+	ginkgo.GinkgoT().Log(append([]interface{}{msg}, keysAndValues...)...)
+}
+
+func (ginkgoLogger) Warnw(msg string, keysAndValues ...interface{}) {
+	ginkgo.GinkgoT().Log(append([]interface{}{msg}, keysAndValues...)...)
+}
+
+func (ginkgoLogger) Errorw(msg string, keysAndValues ...interface{}) {
+	ginkgo.GinkgoT().Log(append([]interface{}{msg}, keysAndValues...)...)
+}
+
+func (ginkgoLogger) Fatalw(msg string, keysAndValues ...interface{}) {
+	ginkgo.GinkgoT().Log(append([]interface{}{msg}, keysAndValues...)...)
+}
+func (ginkgoLogger) With(_ ...interface{}) logger.Logger { return GinkgoLogger }
+func (ginkgoLogger) Child(_ string) logger.Logger        { return GinkgoLogger }
+func (ginkgoLogger) IsDebugLevel() bool                  { return true }


### PR DESCRIPTION
# Description

Resolved 3 issues with the flaky tests:
1. Removed transactions and `if exists` clauses from `create table`, since it could lead to tables not being created in some scenarios, e.g. 2 concurrent transactions, 1st creates the table, 2nd skips, then 1st does a Tx rollback so table is not created.
2. Improper use of nested `Ordered` Ginkgo containers and `BeforeAll` which caused containers to be reused beyond the desired boundaries.
3. Assertion of expected response when retrieving failed records could fail due to ordering inconsistencies.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
