### PR TITLE
fix: take workpaceid from config backend key

### DIFF
--- a/services/fileuploader/fileuploader.go
+++ b/services/fileuploader/fileuploader.go
@@ -87,7 +87,7 @@ func (p *provider) updateLoop(ctx context.Context, backendConfig backendconfig.B
 
 	for ev := range ch {
 		configs := ev.Data.(map[string]backendconfig.ConfigT)
-		for _, c := range configs {
+		for workspaceId, c := range configs {
 
 			var bucket backendconfig.StorageBucket
 			var preferences backendconfig.StoragePreferences
@@ -95,7 +95,7 @@ func (p *provider) updateLoop(ctx context.Context, backendConfig backendconfig.B
 			if c.Settings.DataRetention.UseSelfStorage {
 				settings := c.Settings.DataRetention.StorageBucket
 				defaultBucket := getDefaultBucket(ctx, settings.Type)
-				bucket = overrideWithSettings(defaultBucket.Config, settings, c.WorkspaceID)
+				bucket = overrideWithSettings(defaultBucket.Config, settings, workspaceId)
 			} else {
 				bucket = getDefaultBucket(ctx, config.GetString("JOBS_BACKUP_STORAGE_PROVIDER", "S3"))
 			}
@@ -103,7 +103,7 @@ func (p *provider) updateLoop(ctx context.Context, backendConfig backendconfig.B
 			if bucket.Type != "" && len(bucket.Config) > 0 {
 				preferences = c.Settings.DataRetention.StoragePreferences
 			}
-			settings[c.WorkspaceID] = StorageSettings{
+			settings[workspaceId] = StorageSettings{
 				Bucket:      bucket,
 				Preferences: preferences,
 			}


### PR DESCRIPTION
# Description

workspaceId is taken from config backend key instead of workspaceId field from config backend value. Bug: workspaceId is being sent as empty in hosted but given for single tenant

## Notion Ticket

https://www.notion.so/rudderstacks/Allow-Customers-to-use-self-storage-26f45f75e38b4ef6bd872bea6187aa06

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
