### PR TITLE
feat: added MT support for regulation worker

### DIFF
--- a/config/backend-config/backend-config.go
+++ b/config/backend-config/backend-config.go
@@ -63,7 +63,7 @@ type workspaceConfig interface {
 	SetUp() error
 	// Deprecated: use Identity() instead.
 	AccessToken() string
-	Get(context.Context, string) (map[string]ConfigT, error)
+	Get(context.Context) (map[string]ConfigT, error)
 	Identity() identity.Identifier
 }
 
@@ -169,7 +169,7 @@ func (bc *backendConfigImpl) configUpdate(ctx context.Context, workspaces string
 		}
 	}()
 
-	sourceJSON, err = bc.workspaceConfig.Get(ctx, workspaces)
+	sourceJSON, err = bc.workspaceConfig.Get(ctx)
 	if err != nil {
 		statConfigBackendError.Increment()
 		pkgLogger.Warnf("Error fetching config from backend: %v", err)

--- a/config/backend-config/backend_config_test.go
+++ b/config/backend-config/backend_config_test.go
@@ -195,7 +195,7 @@ func TestConfigUpdate(t *testing.T) {
 		defer ctrl.Finish()
 
 		wc := NewMockworkspaceConfig(ctrl)
-		wc.EXPECT().Get(gomock.Eq(ctx), workspaces).Return(map[string]ConfigT{}, fakeError).Times(1)
+		wc.EXPECT().Get(gomock.Eq(ctx)).Return(map[string]ConfigT{}, fakeError).Times(1)
 
 		bc := &backendConfigImpl{
 			workspaceConfig: wc,
@@ -216,7 +216,7 @@ func TestConfigUpdate(t *testing.T) {
 		defer ctrl.Finish()
 
 		wc := NewMockworkspaceConfig(ctrl)
-		wc.EXPECT().Get(gomock.Eq(ctx), workspaces).Return(map[string]ConfigT{workspaces: sampleBackendConfig}, nil).Times(1)
+		wc.EXPECT().Get(gomock.Eq(ctx)).Return(map[string]ConfigT{workspaces: sampleBackendConfig}, nil).Times(1)
 
 		bc := &backendConfigImpl{
 			workspaceConfig: wc,
@@ -238,7 +238,7 @@ func TestConfigUpdate(t *testing.T) {
 		defer cancel()
 
 		wc := NewMockworkspaceConfig(ctrl)
-		wc.EXPECT().Get(gomock.Eq(ctx), workspaces).Return(map[string]ConfigT{workspaces: sampleBackendConfig}, nil).Times(1)
+		wc.EXPECT().Get(gomock.Eq(ctx)).Return(map[string]ConfigT{workspaces: sampleBackendConfig}, nil).Times(1)
 
 		pubSub := pubsub.PublishSubscriber{}
 		bc := &backendConfigImpl{
@@ -371,7 +371,7 @@ func TestCache(t *testing.T) {
 			mockID         = &mockIdentifier{key: workspaces, token: workspaceToken}
 		)
 		wc.EXPECT().Identity().Return(mockID).Times(1)
-		wc.EXPECT().Get(gomock.Any(), workspaces).
+		wc.EXPECT().Get(gomock.Any()).
 			Return(
 				map[string]ConfigT{sampleWorkspaceID: sampleBackendConfig},
 				nil,
@@ -440,7 +440,7 @@ func TestCache(t *testing.T) {
 		defer cancel()
 
 		wc := NewMockworkspaceConfig(ctrl)
-		wc.EXPECT().Get(gomock.Eq(ctx), workspaces).Return(map[string]ConfigT{}, errors.New("control plane down")).Times(1)
+		wc.EXPECT().Get(gomock.Eq(ctx)).Return(map[string]ConfigT{}, errors.New("control plane down")).Times(1)
 		sampleBackendConfigBytes, _ := json.Marshal(map[string]ConfigT{sampleWorkspaceID: sampleBackendConfig})
 		unmarshalledConfig := make(map[string]ConfigT)
 		err = json.Unmarshal(sampleBackendConfigBytes, &unmarshalledConfig)
@@ -474,7 +474,7 @@ func TestCache(t *testing.T) {
 		defer cancel()
 
 		wc := NewMockworkspaceConfig(ctrl)
-		wc.EXPECT().Get(gomock.Eq(ctx), workspaces).Return(map[string]ConfigT{}, errors.New("control plane down")).Times(1)
+		wc.EXPECT().Get(gomock.Eq(ctx)).Return(map[string]ConfigT{}, errors.New("control plane down")).Times(1)
 		cacheStore.EXPECT().Get(gomock.Eq(ctx)).Return([]byte{}, sql.ErrNoRows).Times(1)
 		pubSub := pubsub.PublishSubscriber{}
 		bc := &backendConfigImpl{
@@ -501,7 +501,7 @@ func TestCache(t *testing.T) {
 
 		wc := NewMockworkspaceConfig(ctrl)
 		wc.EXPECT().Identity().Return(mockID).Times(1)
-		wc.EXPECT().Get(gomock.Any(), workspaces).Return(map[string]ConfigT{sampleWorkspaceID: sampleBackendConfig}, nil).AnyTimes()
+		wc.EXPECT().Get(gomock.Any()).Return(map[string]ConfigT{sampleWorkspaceID: sampleBackendConfig}, nil).AnyTimes()
 		bc := &backendConfigImpl{
 			workspaceConfig: wc,
 			eb:              pubsub.New(),

--- a/config/backend-config/mock_workspaceconfig.go
+++ b/config/backend-config/mock_workspaceconfig.go
@@ -51,18 +51,18 @@ func (mr *MockworkspaceConfigMockRecorder) AccessToken() *gomock.Call {
 }
 
 // Get mocks base method.
-func (m *MockworkspaceConfig) Get(arg0 context.Context, arg1 string) (map[string]ConfigT, error) {
+func (m *MockworkspaceConfig) Get(arg0 context.Context) (map[string]ConfigT, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret := m.ctrl.Call(m, "Get", arg0)
 	ret0, _ := ret[0].(map[string]ConfigT)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockworkspaceConfigMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockworkspaceConfigMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockworkspaceConfig)(nil).Get), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockworkspaceConfig)(nil).Get), arg0)
 }
 
 // Identity mocks base method.
@@ -131,18 +131,18 @@ func (mr *MockBackendConfigMockRecorder) AccessToken() *gomock.Call {
 }
 
 // Get mocks base method.
-func (m *MockBackendConfig) Get(arg0 context.Context, arg1 string) (map[string]ConfigT, error) {
+func (m *MockBackendConfig) Get(arg0 context.Context) (map[string]ConfigT, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret := m.ctrl.Call(m, "Get", arg0)
 	ret0, _ := ret[0].(map[string]ConfigT)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockBackendConfigMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBackendConfigMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBackendConfig)(nil).Get), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBackendConfig)(nil).Get), arg0)
 }
 
 // Identity mocks base method.

--- a/config/backend-config/namespace_config.go
+++ b/config/backend-config/namespace_config.go
@@ -69,13 +69,13 @@ func (nc *namespaceConfig) SetUp() (err error) {
 	return nil
 }
 
-// Get returns sources from the workspace
-func (nc *namespaceConfig) Get(ctx context.Context, workspaces string) (map[string]ConfigT, error) {
-	return nc.getFromAPI(ctx, workspaces)
+// Get returns config for all the workspaces in the namespace
+func (nc *namespaceConfig) Get(ctx context.Context) (map[string]ConfigT, error) {
+	return nc.getFromAPI(ctx)
 }
 
 // getFromApi gets the workspace config from api
-func (nc *namespaceConfig) getFromAPI(ctx context.Context, _ string) (map[string]ConfigT, error) {
+func (nc *namespaceConfig) getFromAPI(ctx context.Context) (map[string]ConfigT, error) {
 	config := make(map[string]ConfigT)
 	if nc.namespace == "" {
 		return config, fmt.Errorf("namespace is not configured")

--- a/config/backend-config/namespace_config_test.go
+++ b/config/backend-config/namespace_config_test.go
@@ -41,9 +41,8 @@ func Test_Namespace_Get(t *testing.T) {
 	logger.Reset()
 
 	var (
-		namespace    = "free-us-1"
-		workspaceID1 = "2CCgbmvBSa8Mv81YaIgtR36M7aW"
-		cpRouterURL  = "mockCpRouterURL"
+		namespace   = "free-us-1"
+		cpRouterURL = "mockCpRouterURL"
 	)
 
 	be := &backendConfigServer{
@@ -69,7 +68,7 @@ func Test_Namespace_Get(t *testing.T) {
 	}
 	require.NoError(t, client.SetUp())
 
-	c, err := client.Get(context.Background(), workspaceID1)
+	c, err := client.Get(context.Background())
 	require.NoError(t, err)
 	require.Len(t, c, 2)
 
@@ -89,7 +88,7 @@ func Test_Namespace_Get(t *testing.T) {
 
 		require.NoError(t, client.SetUp())
 
-		c, err := client.Get(context.Background(), "")
+		c, err := client.Get(context.Background())
 		require.EqualError(t, err, `backend config request failed with 401: {"message":"Unauthorized"}`) // Unauthorized
 		require.Empty(t, c)
 	})
@@ -105,7 +104,7 @@ func Test_Namespace_Get(t *testing.T) {
 
 		require.NoError(t, client.SetUp())
 
-		c, err := client.Get(context.Background(), workspaceID1)
+		c, err := client.Get(context.Background())
 		require.EqualError(t, err, "backend config request failed with 404")
 		require.Empty(t, c)
 	})

--- a/config/backend-config/noop.go
+++ b/config/backend-config/noop.go
@@ -23,7 +23,7 @@ func (*NOOP) SetUp() error {
 	return nil
 }
 
-func (*NOOP) Get(_ context.Context, _ string) (map[string]ConfigT, error) {
+func (*NOOP) Get(_ context.Context) (map[string]ConfigT, error) {
 	return map[string]ConfigT{}, nil
 }
 

--- a/config/backend-config/single_workspace.go
+++ b/config/backend-config/single_workspace.go
@@ -49,17 +49,17 @@ func (wc *singleWorkspaceConfig) AccessToken() string {
 	return wc.token
 }
 
-// Get returns sources from the workspace
-func (wc *singleWorkspaceConfig) Get(ctx context.Context, workspace string) (map[string]ConfigT, error) {
+// Get returns config for the workspace
+func (wc *singleWorkspaceConfig) Get(ctx context.Context) (map[string]ConfigT, error) {
 	if configFromFile {
 		return wc.getFromFile()
 	} else {
-		return wc.getFromAPI(ctx, workspace)
+		return wc.getFromAPI(ctx)
 	}
 }
 
 // getFromApi gets the workspace config from api
-func (wc *singleWorkspaceConfig) getFromAPI(ctx context.Context, _ string) (map[string]ConfigT, error) {
+func (wc *singleWorkspaceConfig) getFromAPI(ctx context.Context) (map[string]ConfigT, error) {
 	config := make(map[string]ConfigT)
 	if wc.configBackendURL == nil {
 		return config, fmt.Errorf("single workspace: config backend url is nil")

--- a/config/backend-config/single_workspace_test.go
+++ b/config/backend-config/single_workspace_test.go
@@ -40,7 +40,7 @@ func TestSingleWorkspaceGetFromAPI(t *testing.T) {
 			token:            token,
 			configBackendURL: parsedSrvURL,
 		}
-		conf, err := wc.getFromAPI(context.Background(), "")
+		conf, err := wc.getFromAPI(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, map[string]ConfigT{sampleWorkspaceID: sampleBackendConfig}, conf)
 
@@ -59,7 +59,7 @@ func TestSingleWorkspaceGetFromAPI(t *testing.T) {
 			token:            "testToken",
 			configBackendURL: configBackendURL,
 		}
-		conf, err := wc.getFromAPI(context.Background(), "")
+		conf, err := wc.getFromAPI(context.Background())
 		require.ErrorContains(t, err, "unsupported protocol scheme")
 		require.Equal(t, map[string]ConfigT{}, conf)
 	})
@@ -69,7 +69,7 @@ func TestSingleWorkspaceGetFromAPI(t *testing.T) {
 			token:            "testToken",
 			configBackendURL: nil,
 		}
-		conf, err := wc.getFromAPI(context.Background(), "")
+		conf, err := wc.getFromAPI(context.Background())
 		require.ErrorContains(t, err, "config backend url is nil")
 		require.Equal(t, map[string]ConfigT{}, conf)
 	})

--- a/mocks/config/backend-config/mock_backendconfig.go
+++ b/mocks/config/backend-config/mock_backendconfig.go
@@ -52,18 +52,18 @@ func (mr *MockBackendConfigMockRecorder) AccessToken() *gomock.Call {
 }
 
 // Get mocks base method.
-func (m *MockBackendConfig) Get(arg0 context.Context, arg1 string) (map[string]backendconfig.ConfigT, error) {
+func (m *MockBackendConfig) Get(arg0 context.Context) (map[string]backendconfig.ConfigT, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret := m.ctrl.Call(m, "Get", arg0)
 	ret0, _ := ret[0].(map[string]backendconfig.ConfigT)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockBackendConfigMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBackendConfigMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBackendConfig)(nil).Get), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBackendConfig)(nil).Get), arg0)
 }
 
 // Identity mocks base method.

--- a/regulation-worker/cmd/main.go
+++ b/regulation-worker/cmd/main.go
@@ -93,8 +93,8 @@ func Run(ctx context.Context) error {
 		svc.API = &client.MultiTenantJobAPI{
 			Client:         managerClient,
 			URLPrefix:      urlPrefix,
-			NamespaceID:    config.MustGetString("NAMESPACE"),
-			NamespaceToken: config.MustGetString("WORKSPACE_NAMESPACE"),
+			NamespaceID:    config.MustGetString("WORKSPACE_NAMESPACE"),
+			NamespaceToken: config.MustGetString("HOSTED_SERVICE_SECRET"),
 		}
 	} else {
 		workspaceId, err := dest.GetWorkspaceId(ctx)

--- a/regulation-worker/cmd/main_test.go
+++ b/regulation-worker/cmd/main_test.go
@@ -177,7 +177,8 @@ func TestFlow(t *testing.T) {
 	go func() {
 		defer close(done)
 		defer svcCancel()
-		main.Run(svcCtx)
+		err = main.Run(svcCtx)
+		require.NoError(t, err)
 	}()
 
 	t.Run("test-flow", func(t *testing.T) {

--- a/regulation-worker/cmd/main_test.go
+++ b/regulation-worker/cmd/main_test.go
@@ -223,8 +223,8 @@ func getJob(w http.ResponseWriter, _ *http.Request) {
 			return
 		}
 	}
-	// for the time when testData is not initialized.
-	w.WriteHeader(404)
+	// for the time when testData is not initialized, to replicate the scenario of no job found.
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func updateJobStatus(w http.ResponseWriter, r *http.Request) {

--- a/regulation-worker/cmd/readme.md
+++ b/regulation-worker/cmd/readme.md
@@ -1,0 +1,26 @@
+## To run regulation-worker in multi-tenant mode. 
+Set env `DEPLOYMENT_TYPE` to "MULTITENANT", default mode is "DEDICATED".
+
+## Multitenant Mode
+
+# Compulsory Envs
+1. NAMESPACE=<namespaceID>
+2. WORKSPACE_NAMESPACE=<namespaceSecret>
+3. DEST_TRANSFORM_URL=<transformer URL> This is required in case of API deletion job.
+
+# Optinal Envs
+1. CONFIG_BACKEND_URL = <configBackendURL> default is https://api.rudderlabs.com
+2. CP_ROUTER_URL = <cpRouterURL> default is https://cp-router.rudderlabs.com
+
+## Dedicated Mode
+
+# Compulsory Envs
+1. CONFIG_BACKEND_TOKEN = <workspace Token>
+
+
+## Batch Destination Envs
+1. REGULATION_WORKER_FILES_LIMIT=<value> default: 1000, this is used to limit number of files to be listed at a time by an object storage manager.
+
+## API Destination Envs
+<!-- Use this to configure transformer Request timeout -->
+1. HttpClient.regulationWorker.transformer.timeout=<value in second> default value is 60 second. 

--- a/regulation-worker/internal/client/multiTenant.go
+++ b/regulation-worker/internal/client/multiTenant.go
@@ -8,54 +8,48 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
 	"github.com/rudderlabs/rudder-server/services/stats"
-	"github.com/rudderlabs/rudder-server/utils/httputil"
-	"github.com/rudderlabs/rudder-server/utils/logger"
 )
 
-var pkgLogger = logger.NewLogger().Child("client")
-
-type JobAPI struct {
+type MultiTenantJobAPI struct {
 	Client         *http.Client
-	WorkspaceID    string
+	NamespaceID    string
 	URLPrefix      string
-	WorkspaceToken string
+	NamespaceToken string
 }
 
-// Get sends http request with workspaceID in the url and receives a json payload
+// Get sends http request with namespaceID in the url and receives a json payload
 // which is decoded using schema and then mapped from schema to internal model.Job struct,
 // which is actually returned.
-func (j *JobAPI) Get(ctx context.Context) (model.Job, error) {
+func (j *MultiTenantJobAPI) Get(ctx context.Context) (model.Job, error) {
 	pkgLogger.Debugf("making http request to regulation manager to get new job")
-
-	url := fmt.Sprintf("%s/dataplane/workspaces/%s/regulations/workerJobs", j.URLPrefix, j.WorkspaceID)
-	pkgLogger.Debugf("making GET request to URL: %v", url)
+	url := fmt.Sprintf("%s/dataplane/namespaces/%s/regulations/workerJobs", j.URLPrefix, j.NamespaceID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		pkgLogger.Errorf("error while create new http request: %v", err)
 		return model.Job{}, err
 	}
 
-	req.SetBasicAuth(j.WorkspaceToken, "")
+	req.SetBasicAuth(j.NamespaceToken, "")
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := j.Client.Do(req)
 	if os.IsTimeout(err) {
-		stats.Default.NewStat("regulation_manager.request_timeout", stats.CountType).Count(1)
+		stats.Default.NewTaggedStat("regulation_manager.request_timeout", stats.CountType, stats.Tags{"namespace": j.NamespaceID}).Count(1)
 		return model.Job{}, model.ErrRequestTimeout
 	}
 	if err != nil {
 		return model.Job{}, err
 	}
-	defer func() { httputil.CloseResponse(resp) }()
-	pkgLogger.Debugf("obtained response code: %v", resp.StatusCode, "response body: ", resp.Body)
-
-	// if successful
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			pkgLogger.Errorf("error while closing response body: %v", err)
+		}
+	}()
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		if resp.StatusCode == http.StatusNoContent {
@@ -63,16 +57,16 @@ func (j *JobAPI) Get(ctx context.Context) (model.Job, error) {
 			return model.Job{}, model.ErrNoRunnableJob
 		}
 
-		var jobSchema jobSchema
+		var jobSchema multiTenantJobSchema
 		if err := json.NewDecoder(resp.Body).Decode(&jobSchema); err != nil {
 			pkgLogger.Errorf("error while decoding response body: %v", err)
 			return model.Job{}, fmt.Errorf("error while decoding job: %w", err)
 		}
 
-		userCountPerJob := stats.Default.NewTaggedStat("user_count_per_job", stats.CountType, stats.Tags{"jobId": jobSchema.JobID, "workspaceId": j.WorkspaceID})
+		userCountPerJob := stats.Default.NewTaggedStat("user_count_per_job", stats.CountType, stats.Tags{"jobId": jobSchema.JobID, "workspaceId": j.NamespaceID})
 		userCountPerJob.Count(len(jobSchema.UserAttributes))
 
-		job, err := mapPayloadToJob(jobSchema, j.WorkspaceID)
+		job, err := mapPayloadToJob(jobSchema.JobID, jobSchema.WorkspaceID, jobSchema.DestinationID, jobSchema.UserAttributes)
 		if err != nil {
 			pkgLogger.Errorf("error while mapping response payload to job: %v", err)
 			return model.Job{}, fmt.Errorf("error while getting job: %w", err)
@@ -81,12 +75,6 @@ func (j *JobAPI) Get(ctx context.Context) (model.Job, error) {
 		pkgLogger.Debugf("obtained job: %v", job)
 		return job, nil
 
-	} else if resp.StatusCode == http.StatusNotFound {
-		// NOTE: `http.StatusNotFound` has to be deprecated once,
-		// regulation manager is updated with the latest changes to respond with `http.StatusNoContent`204`
-		// when no job is found.
-		pkgLogger.Debugf("no runnable job found")
-		return model.Job{}, model.ErrNoRunnableJob
 	} else {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
@@ -101,15 +89,12 @@ func (j *JobAPI) Get(ctx context.Context) (model.Job, error) {
 
 // UpdateStatus marshals status into appropriate status schema, and sent as payload
 // checked for returned status code.
-func (j *JobAPI) UpdateStatus(ctx context.Context, status model.JobStatus, jobID int) error {
+func (j *MultiTenantJobAPI) UpdateStatus(ctx context.Context, status model.JobStatus, jobID int) error {
 	pkgLogger.Debugf("sending PATCH request to update job status for jobId: ", jobID, "with status: %v", status)
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
-	method := "PATCH"
-
-	genEndPoint := "/dataplane/workspaces/{workspace_id}/regulations/workerJobs/{job_id}"
-	url := fmt.Sprint(j.URLPrefix, prepURL(genEndPoint, j.WorkspaceID, fmt.Sprint(jobID)))
+	url := fmt.Sprintf("%s/dataplane/namespaces/%s/regulations/workerJobs/%s", j.URLPrefix, j.NamespaceID, fmt.Sprint(jobID))
 	pkgLogger.Debugf("sending request to URL: %v", url)
 
 	statusSchema := statusJobSchema{
@@ -120,12 +105,12 @@ func (j *JobAPI) UpdateStatus(ctx context.Context, status model.JobStatus, jobID
 		pkgLogger.Errorf("error while marshalling status schema: %v", err)
 		return fmt.Errorf("error while marshalling status: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
 	pkgLogger.Debugf("sending request: %v", req)
-	req.SetBasicAuth(j.WorkspaceToken, "")
+	req.SetBasicAuth(j.NamespaceToken, "")
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := j.Client.Do(req)
@@ -136,7 +121,7 @@ func (j *JobAPI) UpdateStatus(ctx context.Context, status model.JobStatus, jobID
 	if err != nil {
 		return err
 	}
-	defer func() { httputil.CloseResponse(resp) }()
+	defer func() { _ = resp.Body.Close() }()
 
 	pkgLogger.Debugf("response code: %v", resp.StatusCode, "response body: %v", resp.Body)
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
@@ -145,44 +130,4 @@ func (j *JobAPI) UpdateStatus(ctx context.Context, status model.JobStatus, jobID
 		pkgLogger.Errorf("update status failed with status code: %v", resp.StatusCode)
 		return fmt.Errorf("update status failed with status code: %d", resp.StatusCode)
 	}
-}
-
-func prepURL(url string, params ...string) string {
-	re := regexp.MustCompile(`{.*?}`)
-	i := 0
-	return string(re.ReplaceAllFunc([]byte(url), func(matched []byte) []byte {
-		if i >= len(params) {
-			pkgLogger.Errorf("value for %v not provided", matched)
-		}
-		v := params[i]
-		i++
-		return []byte(v)
-	}))
-}
-
-func mapPayloadToJob(wjs jobSchema, workspaceID string) (model.Job, error) {
-	usrAttribute := make([]model.User, len(wjs.UserAttributes))
-	for i, usrAttr := range wjs.UserAttributes {
-		usrAttribute[i].Attributes = make(map[string]string)
-		for key, value := range usrAttr {
-			if key == "userId" {
-				usrAttribute[i].ID = value
-			} else {
-				usrAttribute[i].Attributes[key] = value
-			}
-		}
-	}
-	jobID, err := strconv.Atoi(wjs.JobID)
-	if err != nil {
-		pkgLogger.Errorf("error while getting jobId: %v", err)
-		return model.Job{}, fmt.Errorf("error while get JobID:%w", err)
-	}
-
-	return model.Job{
-		ID:            jobID,
-		WorkspaceID:   workspaceID,
-		DestinationID: wjs.DestinationID,
-		Status:        model.JobStatusRunning,
-		Users:         usrAttribute,
-	}, nil
 }

--- a/regulation-worker/internal/client/schema.go
+++ b/regulation-worker/internal/client/schema.go
@@ -1,7 +1,14 @@
 package client
 
-type jobSchema struct {
+type singleTenantJobSchema struct {
 	JobID          string                 `json:"jobId"`
+	DestinationID  string                 `json:"destinationId"`
+	UserAttributes []userAttributesSchema `json:"userAttributes"`
+}
+
+type multiTenantJobSchema struct {
+	JobID          string                 `json:"jobId"`
+	WorkspaceID    string                 `json:"workspaceId"`
 	DestinationID  string                 `json:"destinationId"`
 	UserAttributes []userAttributesSchema `json:"userAttributes"`
 }

--- a/regulation-worker/internal/client/singleTenant.go
+++ b/regulation-worker/internal/client/singleTenant.go
@@ -1,0 +1,165 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
+	"github.com/rudderlabs/rudder-server/services/stats"
+	"github.com/rudderlabs/rudder-server/utils/httputil"
+	"github.com/rudderlabs/rudder-server/utils/logger"
+)
+
+var pkgLogger = logger.NewLogger().Child("client")
+
+type SingleTenantJobAPI struct {
+	Client         *http.Client
+	WorkspaceID    string
+	URLPrefix      string
+	WorkspaceToken string
+}
+
+// Get sends http request with workspaceID in the url and receives a json payload
+// which is decoded using schema and then mapped from schema to internal model.Job struct,
+// which is actually returned.
+func (j *SingleTenantJobAPI) Get(ctx context.Context) (model.Job, error) {
+	pkgLogger.Debugf("making http request to regulation manager to get new job")
+
+	url := fmt.Sprintf("%s/dataplane/workspaces/%s/regulations/workerJobs", j.URLPrefix, j.WorkspaceID)
+	pkgLogger.Debugf("making GET request to URL: %v", url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		pkgLogger.Errorf("error while create new http request: %v", err)
+		return model.Job{}, err
+	}
+
+	req.SetBasicAuth(j.WorkspaceToken, "")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := j.Client.Do(req)
+	if os.IsTimeout(err) {
+		stats.Default.NewTaggedStat("regulation_manager.request_timeout", stats.CountType, stats.Tags{"workspace": j.WorkspaceID}).Count(1)
+		return model.Job{}, model.ErrRequestTimeout
+	}
+	if err != nil {
+		return model.Job{}, err
+	}
+	defer func() { httputil.CloseResponse(resp) }()
+	pkgLogger.Debugf("obtained response code: %v", resp.StatusCode, "response body: ", resp.Body)
+
+	// if successful
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if resp.StatusCode == http.StatusNoContent {
+			pkgLogger.Debugf("no runnable job found")
+			return model.Job{}, model.ErrNoRunnableJob
+		}
+
+		var jobSchema singleTenantJobSchema
+		if err := json.NewDecoder(resp.Body).Decode(&jobSchema); err != nil {
+			pkgLogger.Errorf("error while decoding response body: %v", err)
+			return model.Job{}, fmt.Errorf("error while decoding job: %w", err)
+		}
+
+		userCountPerJob := stats.Default.NewTaggedStat("user_count_per_job", stats.CountType, stats.Tags{"jobId": jobSchema.JobID, "workspaceId": j.WorkspaceID})
+		userCountPerJob.Count(len(jobSchema.UserAttributes))
+
+		job, err := mapPayloadToJob(jobSchema.JobID, j.WorkspaceID, jobSchema.DestinationID, jobSchema.UserAttributes)
+		if err != nil {
+			pkgLogger.Errorf("error while mapping response payload to job: %v", err)
+			return model.Job{}, fmt.Errorf("error while getting job: %w", err)
+		}
+
+		pkgLogger.Debugf("obtained job: %v", job)
+		return job, nil
+
+	} else {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			pkgLogger.Errorf("error while reading response body: %v", err)
+			return model.Job{}, fmt.Errorf("error while reading response body: %w", err)
+		}
+		pkgLogger.Debugf("obtained response body: %v", string(body))
+
+		return model.Job{}, fmt.Errorf("unexpected response code: %d", resp.StatusCode)
+	}
+}
+
+// UpdateStatus marshals status into appropriate status schema, and sent as payload
+// checked for returned status code.
+func (j *SingleTenantJobAPI) UpdateStatus(ctx context.Context, status model.JobStatus, jobID int) error {
+	pkgLogger.Debugf("sending PATCH request to update job status for jobId: ", jobID, "with status: %v", status)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	url := fmt.Sprintf("%s/dataplane/workspaces/%s/regulations/workerJobs/%s", j.URLPrefix, j.WorkspaceID, fmt.Sprint(jobID))
+	pkgLogger.Debugf("sending request to URL: %v", url)
+
+	statusSchema := statusJobSchema{
+		Status: string(status),
+	}
+	body, err := json.Marshal(statusSchema)
+	if err != nil {
+		pkgLogger.Errorf("error while marshalling status schema: %v", err)
+		return fmt.Errorf("error while marshalling status: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	pkgLogger.Debugf("sending request: %v", req)
+	req.SetBasicAuth(j.WorkspaceToken, "")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := j.Client.Do(req)
+	if os.IsTimeout(err) {
+		stats.Default.NewStat("regulation_manager.request_timeout", stats.CountType).Count(1)
+		return model.ErrRequestTimeout
+	}
+	if err != nil {
+		return err
+	}
+	defer func() { httputil.CloseResponse(resp) }()
+
+	pkgLogger.Debugf("response code: %v", resp.StatusCode, "response body: %v", resp.Body)
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	} else {
+		pkgLogger.Errorf("update status failed with status code: %v", resp.StatusCode)
+		return fmt.Errorf("update status failed with status code: %d", resp.StatusCode)
+	}
+}
+
+func mapPayloadToJob(jobID, workspaceID, destinationID string, userAttributes []userAttributesSchema) (model.Job, error) {
+	usrAttribute := make([]model.User, len(userAttributes))
+	for i, usrAttr := range userAttributes {
+		usrAttribute[i].Attributes = make(map[string]string)
+		for key, value := range usrAttr {
+			if key == "userId" {
+				usrAttribute[i].ID = value
+			} else {
+				usrAttribute[i].Attributes[key] = value
+			}
+		}
+	}
+	ID, err := strconv.Atoi(jobID)
+	if err != nil {
+		pkgLogger.Errorf("error while getting jobId: %v", err)
+		return model.Job{}, fmt.Errorf("error while get JobID:%w", err)
+	}
+
+	return model.Job{
+		ID:            ID,
+		WorkspaceID:   workspaceID,
+		DestinationID: destinationID,
+		Status:        model.JobStatusRunning,
+		Users:         usrAttribute,
+	}, nil
+}

--- a/regulation-worker/internal/delete/kvstore/kvstore.go
+++ b/regulation-worker/internal/delete/kvstore/kvstore.go
@@ -35,7 +35,7 @@ func (*KVDeleteManager) Delete(_ context.Context, job model.Job, destDetail mode
 		key := fmt.Sprintf("user:%s", user.ID)
 		err = kvm.DeleteKey(key)
 		if err != nil {
-			pkgLogger.Errorf("failed to delete user: %v", user.ID, "with error: %v", err)
+			pkgLogger.Errorf("failed to delete user: %s with error: %w", user.ID, err)
 			return model.JobStatusFailed
 		}
 	}

--- a/regulation-worker/internal/destination/destination.go
+++ b/regulation-worker/internal/destination/destination.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cenkalti/backoff"
 
-	"github.com/rudderlabs/rudder-server/config"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
 	"github.com/rudderlabs/rudder-server/utils/logger"
@@ -17,22 +16,23 @@ var pkgLogger = logger.NewLogger().Child("client")
 
 //go:generate mockgen -source=destination.go -destination=mock_destination_test.go -package=destination github.com/rudderlabs/rudder-server/regulation-worker/internal/Destination/destination
 type destinationMiddleware interface {
-	Get(ctx context.Context, workspace string) (map[string]backendconfig.ConfigT, error)
+	Get(ctx context.Context) (map[string]backendconfig.ConfigT, error)
 }
 
 type DestMiddleware struct {
 	Dest destinationMiddleware
 }
 
+// This is supposed to be used in casae of singleTenant mode, it will use the set variable `WORKSPACE_TOKEN`.
 func (d *DestMiddleware) GetWorkspaceId(ctx context.Context) (string, error) {
 	pkgLogger.Debugf("getting destination Id")
-	destConfig, err := d.getDestDetails(ctx)
+	config, err := d.getWorkspacesDetail(ctx)
 	if err != nil {
 		pkgLogger.Errorf("error while getting destination details from backend config: %v", err)
 		return "", err
 	}
-	if len(destConfig) == 1 { // only single workspace configs are supported by regulation worker
-		for workspaceID := range destConfig {
+	if len(config) == 1 {
+		for workspaceID := range config {
 			pkgLogger.Debugf("workspaceId=", workspaceID)
 			return workspaceID, nil
 		}
@@ -45,46 +45,46 @@ func (d *DestMiddleware) GetWorkspaceId(ctx context.Context) (string, error) {
 // GetDestDetails makes api call to get json and then parse it to get destination related details
 // like: dest_type, auth details,
 // return destination Type enum{file, api}
-func (d *DestMiddleware) GetDestDetails(ctx context.Context, destID string) (model.Destination, error) {
+func (d *DestMiddleware) GetDestDetails(ctx context.Context, destID, workspaceID string) (model.Destination, error) {
 	pkgLogger.Debugf("getting destination details for destinationId: %v", destID)
-	destConf, err := d.getDestDetails(ctx)
+	configs, err := d.getWorkspacesDetail(ctx)
 	if err != nil {
 		return model.Destination{}, err
 	}
+	workspaceConfig, ok := configs[workspaceID]
+	if !ok {
+		pkgLogger.Errorf("workspaceId not found in config")
+		return model.Destination{}, fmt.Errorf("workspaceId not found in config")
+	}
 
-	for _, wConf := range destConf {
-		for _, source := range wConf.Sources {
-			for _, dest := range source.Destinations {
-				if dest.ID == destID {
-					var destDetail model.Destination
-					destDetail.Config = dest.Config
-					destDetail.DestinationID = dest.ID
-					destDetail.Name = dest.DestinationDefinition.Name
-					// Destination Definition Config would most likely be needed
-					destDetail.DestDefConfig = dest.DestinationDefinition.Config
-					pkgLogger.Debugf("obtained destination detail: %v", destDetail)
-					return destDetail, nil
-				}
+	for _, source := range workspaceConfig.Sources {
+		for _, dest := range source.Destinations {
+			if dest.ID == destID {
+				var destDetail model.Destination
+				destDetail.Config = dest.Config
+				destDetail.DestinationID = dest.ID
+				destDetail.Name = dest.DestinationDefinition.Name
+				pkgLogger.Debugf("obtained destination detail: %v", destDetail)
+				return destDetail, nil
 			}
 		}
 	}
 	return model.Destination{}, model.ErrInvalidDestination
 }
 
-func (d *DestMiddleware) getDestDetails(ctx context.Context) (map[string]backendconfig.ConfigT, error) {
+func (d *DestMiddleware) getWorkspacesDetail(ctx context.Context) (map[string]backendconfig.ConfigT, error) {
 	pkgLogger.Debugf("getting destination details with exponential backoff")
 
-	maxWait := time.Minute * 10
 	var err error
+	maxWait := time.Minute * 10
 	bo := backoff.NewExponentialBackOff()
 	boCtx := backoff.WithContext(bo, ctx)
 	bo.MaxInterval = time.Minute
 	bo.MaxElapsedTime = maxWait
-	var destConf map[string]backendconfig.ConfigT
+	var configs map[string]backendconfig.ConfigT
 	if err = backoff.Retry(func() error {
 		pkgLogger.Debugf("Fetching backend-config...")
-		// TODO : Revisit the Implementation for Regulation Worker in case of MultiTenant Deployment
-		destConf, err = d.Dest.Get(ctx, config.GetWorkspaceToken())
+		configs, err = d.Dest.Get(ctx)
 		if err != nil {
 			return fmt.Errorf("error while getting destination details: %w", err)
 		}
@@ -95,5 +95,5 @@ func (d *DestMiddleware) getDestDetails(ctx context.Context) (map[string]backend
 			return map[string]backendconfig.ConfigT{}, err
 		}
 	}
-	return destConf, nil
+	return configs, nil
 }

--- a/regulation-worker/internal/destination/destination_test.go
+++ b/regulation-worker/internal/destination/destination_test.go
@@ -78,13 +78,13 @@ func TestGetDestDetails(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockDestMiddleware := destination.NewMockdestinationMiddleware(mockCtrl)
-	mockDestMiddleware.EXPECT().Get(context.TODO(), "").Return(map[string]backendconfig.ConfigT{testConfig.WorkspaceID: testConfig}, nil).Times(1)
+	mockDestMiddleware.EXPECT().Get(context.TODO()).Return(map[string]backendconfig.ConfigT{testConfig.WorkspaceID: testConfig}, nil).Times(1)
 
 	dest := destination.DestMiddleware{
 		Dest: mockDestMiddleware,
 	}
 
-	destDetail, err := dest.GetDestDetails(ctx, testDestID)
+	destDetail, err := dest.GetDestDetails(ctx, testDestID, testConfig.WorkspaceID)
 
 	require.NoError(t, err, "expected no err")
 	require.Equal(t, expDest, destDetail, "actual dest detail different than expected")

--- a/regulation-worker/internal/destination/mock_destination_test.go
+++ b/regulation-worker/internal/destination/mock_destination_test.go
@@ -36,16 +36,16 @@ func (m *MockdestinationMiddleware) EXPECT() *MockdestinationMiddlewareMockRecor
 }
 
 // Get mocks base method.
-func (m *MockdestinationMiddleware) Get(ctx context.Context, workspace string) (map[string]backendconfig.ConfigT, error) {
+func (m *MockdestinationMiddleware) Get(ctx context.Context) (map[string]backendconfig.ConfigT, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", ctx, workspace)
+	ret := m.ctrl.Call(m, "Get", ctx)
 	ret0, _ := ret[0].(map[string]backendconfig.ConfigT)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockdestinationMiddlewareMockRecorder) Get(ctx, workspace interface{}) *gomock.Call {
+func (mr *MockdestinationMiddlewareMockRecorder) Get(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockdestinationMiddleware)(nil).Get), ctx, workspace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockdestinationMiddleware)(nil).Get), ctx)
 }

--- a/regulation-worker/internal/service/looper.go
+++ b/regulation-worker/internal/service/looper.go
@@ -33,12 +33,11 @@ func (l *Looper) Loop(ctx context.Context) error {
 	for {
 
 		err := l.Svc.JobSvc(ctx)
-
 		if err == model.ErrNoRunnableJob {
 			pkgLogger.Debugf("no runnable job found... sleeping")
 			if err := misc.SleepCtx(ctx, time.Duration(interval)*time.Minute); err != nil {
 				pkgLogger.Debugf("context cancelled... exiting infinite loop %v", err)
-				return nil
+				return err
 			}
 			continue
 		}
@@ -47,7 +46,7 @@ func (l *Looper) Loop(ctx context.Context) error {
 			pkgLogger.Errorf("context deadline exceeded... retrying after %d minute(s): %v", retryDelay, err)
 			if err := misc.SleepCtx(ctx, time.Duration(retryDelay)*time.Second); err != nil {
 				pkgLogger.Debugf("context cancelled... exiting infinite loop %v", err)
-				return nil
+				return err
 			}
 			continue
 		}

--- a/regulation-worker/internal/service/mock_service_test.go
+++ b/regulation-worker/internal/service/mock_service_test.go
@@ -88,18 +88,18 @@ func (m *MockdestDetail) EXPECT() *MockdestDetailMockRecorder {
 }
 
 // GetDestDetails mocks base method.
-func (m *MockdestDetail) GetDestDetails(ctx context.Context, destID string) (model.Destination, error) {
+func (m *MockdestDetail) GetDestDetails(ctx context.Context, destID, workspaceID string) (model.Destination, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDestDetails", ctx, destID)
+	ret := m.ctrl.Call(m, "GetDestDetails", ctx, destID, workspaceID)
 	ret0, _ := ret[0].(model.Destination)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDestDetails indicates an expected call of GetDestDetails.
-func (mr *MockdestDetailMockRecorder) GetDestDetails(ctx, destID interface{}) *gomock.Call {
+func (mr *MockdestDetailMockRecorder) GetDestDetails(ctx, destID, workspaceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDestDetails", reflect.TypeOf((*MockdestDetail)(nil).GetDestDetails), ctx, destID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDestDetails", reflect.TypeOf((*MockdestDetail)(nil).GetDestDetails), ctx, destID, workspaceID)
 }
 
 // GetWorkspaceId mocks base method.

--- a/regulation-worker/internal/service/service.go
+++ b/regulation-worker/internal/service/service.go
@@ -19,7 +19,7 @@ type APIClient interface {
 
 type destDetail interface {
 	GetWorkspaceId(ctx context.Context) (string, error)
-	GetDestDetails(ctx context.Context, destID string) (model.Destination, error)
+	GetDestDetails(ctx context.Context, destID, workspaceID string) (model.Destination, error)
 }
 type deleter interface {
 	Delete(ctx context.Context, job model.Job, destDetail model.Destination) model.JobStatus
@@ -51,7 +51,7 @@ func (js *JobSvc) JobSvc(ctx context.Context) error {
 		return err
 	}
 	// executing deletion
-	destDetail, err := js.DestDetail.GetDestDetails(ctx, job.DestinationID)
+	destDetail, err := js.DestDetail.GetDestDetails(ctx, job.DestinationID, job.WorkspaceID)
 	if err != nil {
 		pkgLogger.Errorf("error while getting destination details: %v", err)
 		if err == model.ErrInvalidDestination {

--- a/regulation-worker/internal/service/service.go
+++ b/regulation-worker/internal/service/service.go
@@ -56,9 +56,11 @@ func (js *JobSvc) JobSvc(ctx context.Context) error {
 		pkgLogger.Errorf("error while getting destination details: %v", err)
 		if err == model.ErrInvalidDestination {
 			stats.Default.NewSampledTaggedStat("regulation_worker.invalid_destination", stats.CountType, stats.Tags{"workspace_id": job.WorkspaceID, "destination_id": job.DestinationID}).Count(1)
-			return js.updateStatus(ctx, model.JobStatusAborted, job.ID)
+			js.updateStatus(ctx, model.JobStatusAborted, job.ID)
+			return err
 		}
-		return js.updateStatus(ctx, model.JobStatusFailed, job.ID)
+		js.updateStatus(ctx, model.JobStatusFailed, job.ID)
+		return err
 	}
 
 	deletionStart := time.Now()

--- a/regulation-worker/internal/service/service_test.go
+++ b/regulation-worker/internal/service/service_test.go
@@ -85,7 +85,7 @@ func TestJobSvc(t *testing.T) {
 			mockDeleter.EXPECT().Delete(ctx, tt.job, tt.dest).Return(tt.deleteJobStatus).Times(tt.deleteJobCallCount)
 
 			mockDestDetail := service.NewMockdestDetail(mockCtrl)
-			mockDestDetail.EXPECT().GetDestDetails(ctx, tt.job.DestinationID).Return(tt.dest, nil).Times(tt.getDestDetailsCount)
+			mockDestDetail.EXPECT().GetDestDetails(ctx, tt.job.DestinationID, tt.job.WorkspaceID).Return(tt.dest, nil).Times(tt.getDestDetailsCount)
 			svc := service.JobSvc{
 				API:        mockAPIClient,
 				Deleter:    mockDeleter,

--- a/warehouse/multitenant/manager_test.go
+++ b/warehouse/multitenant/manager_test.go
@@ -25,7 +25,7 @@ func (*mockBackendConfig) SetUp() error                             { return nil
 func (*mockBackendConfig) AccessToken() string                      { return "" }
 func (*mockBackendConfig) Identity() identity.Identifier            { return nil }
 
-func (m *mockBackendConfig) Get(context.Context, string) (map[string]backendconfig.ConfigT, error) {
+func (m *mockBackendConfig) Get(context.Context) (map[string]backendconfig.ConfigT, error) {
 	return m.config, nil
 }
 


### PR DESCRIPTION
# Description
This PR adds Multi-tenant mode support in regulation-worker.  
It also removes the unused argument from `Get` method of `backend-config` interface.

## Notion Ticket
https://www.notion.so/rudderstacks/regulation-worker-adaptations-for-multitenant-20ba9db9d45a443f9bc9f62def374413
