### PR TITLE
fix(warehouse): warehouse archiver initialize

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	warehousearchiver "github.com/rudderlabs/rudder-server/warehouse/archive"
+
 	"github.com/rudderlabs/rudder-server/info"
 	"github.com/rudderlabs/rudder-server/warehouse/datalake"
 
@@ -316,6 +318,7 @@ func runAllInit() {
 	warehouse.Init4()
 	warehouse.Init5()
 	warehouse.Init6()
+	warehousearchiver.Init()
 	validations.Init()
 	datalake.Init()
 	azuresynapse.Init()


### PR DESCRIPTION
# Description

Warehouse archiver Init() is not being called from anywhere. It needs to be initialized during the start of the application from the runner.

## Notion Ticket

https://www.notion.so/rudderstacks/Warehouse-archiver-Init-79b09dfb38ed4123ac6d7ac59f7ed656

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
