### PR TITLE
fix: capture router's iterator stats after iteration is complete

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -1761,11 +1761,6 @@ func (rt *HandleT) readAndProcess() int {
 		rt.logger.Debugf("RT: DB Read Complete. No RT Jobs to process for destination: %s", rt.destName)
 		time.Sleep(readSleep)
 		return 0
-	} else {
-		iteratorStats := iterator.Stats()
-		stats.Default.NewTaggedStat("router_iterator_stats_query_count", stats.GaugeType, stats.Tags{"destType": rt.destName}).Gauge(iteratorStats.QueryCount)
-		stats.Default.NewTaggedStat("router_iterator_stats_total_jobs", stats.GaugeType, stats.Tags{"destType": rt.destName}).Gauge(iteratorStats.TotalJobs)
-		stats.Default.NewTaggedStat("router_iterator_stats_discarded_jobs", stats.GaugeType, stats.Tags{"destType": rt.destName}).Gauge(iteratorStats.DiscardedJobs)
 	}
 
 	// List of jobs which can be processed mapped per channel
@@ -1801,6 +1796,10 @@ func (rt *HandleT) readAndProcess() int {
 			iterator.Discard(job)
 		}
 	}
+	iteratorStats := iterator.Stats()
+	stats.Default.NewTaggedStat("router_iterator_stats_query_count", stats.GaugeType, stats.Tags{"destType": rt.destName}).Gauge(iteratorStats.QueryCount)
+	stats.Default.NewTaggedStat("router_iterator_stats_total_jobs", stats.GaugeType, stats.Tags{"destType": rt.destName}).Gauge(iteratorStats.TotalJobs)
+	stats.Default.NewTaggedStat("router_iterator_stats_discarded_jobs", stats.GaugeType, stats.Tags{"destType": rt.destName}).Gauge(iteratorStats.DiscardedJobs)
 
 	// Mark the jobs as executing
 	err := misc.RetryWithNotify(context.Background(), rt.jobsDBCommandTimeout, rt.jobdDBMaxRetries, func(ctx context.Context) error {


### PR DESCRIPTION
# Description

Fixes a bug where iterator stats were captured early, just after the first query was performed, instead of waiting until the iteration was done.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
