### PR TITLE
fix: gw replay no timezone, workspaceID

### DIFF
--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -196,6 +196,7 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 				Parameters:   params,
 				CustomVal:    ev.Output[worker.getFieldIdentifier(customVal)].(string),
 				EventPayload: destEventJSON,
+				WorkspaceId: ev.Output[worker.getFieldIdentifier(workspaceID)].(string),
 			}
 			jobs = append(jobs, &job)
 		}
@@ -255,6 +256,8 @@ func (worker *SourceWorkerT) getFieldIdentifier(field string) string {
 		return "CustomVal"
 	case eventPayload:
 		return "EventPayload"
+	case workspaceID:
+		return "WorkspaceID"
 	case createdAt:
 		return "CreatedAt"
 	default:

--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -118,7 +118,8 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 		copy(copyLineBytes, lineBytes)
 
 		if transformationVersionID == "" {
-			createdAt, err := time.Parse(misc.POSTGRESTIMEFORMATPARSE, gjson.GetBytes(copyLineBytes, worker.getFieldIdentifier(createdAt)).String())
+			timeStamp := gjson.GetBytes(copyLineBytes, worker.getFieldIdentifier(createdAt)).String()
+			createdAt, err := time.Parse(misc.NOTIMEZONEFORMATPARSE, strings.TrimSuffix(timeStamp, "Z"))
 			if err != nil {
 				pkgLogger.Errorf("failed to parse created at: %s", err)
 				continue
@@ -176,7 +177,7 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 				pkgLogger.Errorf("Error getting created at from transformer output: %v", err)
 				continue
 			}
-			createdAt, err := time.Parse(misc.POSTGRESTIMEFORMATPARSE, createdAtString)
+			createdAt, err := time.Parse(misc.NOTIMEZONEFORMATPARSE, strings.TrimSuffix(createdAtString, "Z"))
 			if err != nil {
 				pkgLogger.Errorf("failed to parse created at: %s", err)
 				continue

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -61,6 +61,7 @@ const (
 	// RFC3339Milli with milli sec precision
 	RFC3339Milli            = "2006-01-02T15:04:05.000Z07:00"
 	POSTGRESTIMEFORMATPARSE = "2006-01-02T15:04:05Z"
+	NOTIMEZONEFORMATPARSE   = "2006-01-02T15:04:05"
 )
 
 const (


### PR DESCRIPTION
# Description

fix.replay: allow for gw dumps replay.

## Notion Ticket

[replay kogan](https://www.notion.so/rudderstacks/Replay-kogan-44e358ff8df44ea1ac7e94a9d8777f11)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
