### PR TITLE
fix: use local variable for workspaceId in stash backup

### DIFF
--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -231,7 +231,7 @@ func (st *HandleT) storeErrorsToObjectStorage(jobs []*jobsdb.JobT) (errorJob []E
 			prefixes := []string{"rudder-proc-err-logs", time.Now().Format("01-02-2006")}
 			uploadOutput, err := errFileUploader.Upload(context.TODO(), outputFile, prefixes...)
 			errorJobs = append(errorJobs, ErrorJob{
-				jobs: jobsPerWorkspace[workspaceID],
+				jobs: jobsPerWorkspace[wrkId],
 				errorOutput: StoreErrorOutputT{
 					Location: uploadOutput.Location,
 					Error:    err,


### PR DESCRIPTION
# Description

Use a variable copy inside the goroutine

## Notion Ticket

https://www.notion.so/rudderstacks/Fix-stash-backups-1-3-0-922b1b6a556a4379ba52f9c6c0bb14a1

## Security

- [X] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
