### PR TITLE
fix: batch router event delivery time

### DIFF
--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1590,7 +1590,7 @@ func (brt *HandleT) recordUploadStats(destination DestinationT, output StorageUp
 	eventDeliveryStat.Count(output.TotalEvents)
 
 	receivedTime, err := time.Parse(misc.RFC3339Milli, output.FirstEventAt)
-	if err != nil {
+	if err == nil {
 		eventDeliveryTimeStat := stats.Default.NewTaggedStat("event_delivery_time", stats.TimerType, map[string]string{
 			"module":      "batch_router",
 			"destType":    brt.destType,


### PR DESCRIPTION
# Description

Fix event delivery time for batch router.

## Notion Ticket

https://www.notion.so/rudderstacks/Batch-router-event-delivery-time-bug-0900f5fa5f604c67b82d2faabbbe4ae3

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
