### PR TITLE
fix: aws role session name

### DIFF
--- a/utils/awsutils/session.go
+++ b/utils/awsutils/session.go
@@ -32,7 +32,7 @@ type SessionConfig struct {
 }
 
 func createRoleSessionName(serviceName string) string {
-	return fmt.Sprintf("rudderstack-aws-%s-access", strings.ToLower(serviceName))
+	return fmt.Sprintf("rudderstack-aws-%s-access", strings.ToLower(strings.ReplaceAll(serviceName, " ", "-")))
 }
 
 func getHttpClient(config *SessionConfig) *http.Client {


### PR DESCRIPTION
# Description
AWS role session name should not contain any spaces so replacing space with hyphen.


## Notion Ticket
https://www.notion.so/rudderstacks/Add-AWS-IAM-role-option-for-S3-Lambda-Eventbridge-Kinesis-Firehose-Personalize-destinations-b67c98e8425f4ef8b1b6b906fff08484

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
