### PR TITLE
fix(warehouse): use correct config for columns batch size

### DIFF
--- a/warehouse/bigquery/bigquery.go
+++ b/warehouse/bigquery/bigquery.go
@@ -295,7 +295,7 @@ func (bq *HandleT) loadTable(tableName string, _, getLoadFileLocFromTableUploads
 		loadFiles = bq.uploader.GetLoadFilesMetadata(warehouseutils.GetLoadFilesOptionsT{Table: tableName})
 	}
 	gcsLocations := warehouseutils.GetGCSLocations(loadFiles, warehouseutils.GCSLocationOptionsT{})
-	pkgLogger.Infof("BQ: Loading data into table: %s in bigquery dataset: %s in project: %s from %v", tableName, bq.namespace, bq.projectID, loadFiles)
+	pkgLogger.Infof("BQ: Loading data into table: %s in bigquery dataset: %s in project: %s", tableName, bq.namespace, bq.projectID)
 	gcsRef := bigquery.NewGCSReference(gcsLocations...)
 	gcsRef.SourceFormat = bigquery.JSON
 	gcsRef.MaxBadRecords = 0

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -863,7 +863,7 @@ func (job *UploadJobT) addColumnsToWarehouse(tName string, columnsMap map[string
 	pkgLogger.Infof(`[WH]: Adding columns for table %s in namespace %s of destination %s:%s`, tName, job.warehouse.Namespace, job.warehouse.Type, job.warehouse.Destination.ID)
 
 	destType := job.upload.DestinationType
-	columnsBatchSize := config.GetInt(fmt.Sprintf("Warehouse.%s.customDatasetPrefix", warehouseutils.WHDestNameMap[destType]), 100)
+	columnsBatchSize := config.GetInt(fmt.Sprintf("Warehouse.%s.columnsBatchSize", warehouseutils.WHDestNameMap[destType]), 100)
 
 	var columnsToAdd []warehouseutils.ColumnInfo
 	for columnName, columnType := range columnsMap {


### PR DESCRIPTION
# Description

- We are using the wrong config for columnsBatchSize as `customDatasetPrefix`.
- Also we don't need to log the load files information for BiqQuery. It is polluting the logs. 

## Notion Ticket

https://www.notion.so/rudderstacks/Use-batching-to-run-several-of-alter-statements-81ae26d5db6f4b2ca8e0258e3ce0cba6

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
