### PR TITLE
fix(warehouse): deepsource fix for use of empty error string in errors.New

### DIFF
--- a/warehouse/upload_test.go
+++ b/warehouse/upload_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Upload", Ordered, func() {
 	},
 		Entry(nil, []error{}, true),
 		Entry(nil, []error{&TableSkipError{}}, true),
-		Entry(nil, []error{errors.New("")}, false),
+		Entry(nil, []error{errors.New("some-error")}, false),
 	)
 
 	DescribeTable("Get table upload status map", func(tableUploadStatuses []*TableUploadStatusT, expected map[int64]map[string]*TableUploadStatusInfoT) {


### PR DESCRIPTION
# Description

Added a fix for [deep-sources](https://deepsource.io/gh/rudderlabs/rudder-server/run/2284a648-4dd4-41a9-8dc3-c3d87c9e1fff/go/GO-W1024?listindex=0) issue `fix for use of empty error string in errors.New`.

## Notion Ticket

https://www.notion.so/rudderstacks/Test-cleanup-for-Datalakes-Integration-e6f8e3fd7b024b22aff23427d3e7d2c6

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
