### PR TITLE
refactor: safe database initialisation and schema migration during startup

### DIFF
--- a/app/apphandlers/apphandlers_test.go
+++ b/app/apphandlers/apphandlers_test.go
@@ -1,0 +1,70 @@
+package apphandlers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/rudderlabs/rudder-server/app"
+	"github.com/rudderlabs/rudder-server/config"
+	"github.com/rudderlabs/rudder-server/services/db"
+	"github.com/rudderlabs/rudder-server/testhelper/destination"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppHandlerStartSequence(t *testing.T) {
+	options := app.LoadOptions([]string{"app"})
+	application := app.New(options)
+	versionHandler := func(w http.ResponseWriter, _ *http.Request) {}
+
+	suite := func(t *testing.T, appHandler AppHandler) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		t.Run("it shouldn't be able to start without setup being called first", func(t *testing.T) {
+			require.Error(t, appHandler.StartRudderCore(ctx, options))
+		})
+
+		t.Run("it shouldn't be able to setup if database is down", func(t *testing.T) {
+			require.Error(t, appHandler.Setup(options))
+		})
+
+		t.Run("it should be able to setup if database is up", func(t *testing.T) {
+			startJobsDBPostgresql(t)
+			require.NoError(t, appHandler.Setup(options))
+		})
+	}
+
+	t.Run("embedded", func(t *testing.T) {
+		h, err := GetAppHandler(application, app.EMBEDDED, versionHandler)
+		require.NoError(t, err)
+		suite(t, h)
+	})
+
+	t.Run("gateway", func(t *testing.T) {
+		h, err := GetAppHandler(application, app.GATEWAY, versionHandler)
+		require.NoError(t, err)
+		suite(t, h)
+	})
+
+	t.Run("processor", func(t *testing.T) {
+		h, err := GetAppHandler(application, app.PROCESSOR, versionHandler)
+		require.NoError(t, err)
+		suite(t, h)
+	})
+}
+
+func startJobsDBPostgresql(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	r, err := destination.SetupPostgres(pool, t)
+	require.NoError(t, err)
+	config.Set("DB.port", r.Port)
+	config.Set("DB.user", r.User)
+	config.Set("DB.name", r.Database)
+	config.Set("DB.password", r.Password)
+}
+
+func init() {
+	db.Init()
+}

--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/rudderlabs/rudder-server/config"
+	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/types/deployment"
 
 	"golang.org/x/sync/errgroup"
@@ -34,23 +36,63 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/types/servermode"
 )
 
-// EmbeddedApp is the type for embedded type implementation
-type EmbeddedApp struct {
-	App            app.App
-	VersionHandler func(w http.ResponseWriter, r *http.Request)
+// embeddedApp is the type for embedded type implementation
+type embeddedApp struct {
+	setupDone      bool
+	app            app.App
+	versionHandler func(w http.ResponseWriter, r *http.Request)
+	log            logger.Logger
+	config         struct {
+		enableProcessor    bool
+		enableRouter       bool
+		enableReplay       bool
+		processorDSLimit   int
+		routerDSLimit      int
+		batchRouterDSLimit int
+		gatewayDSLimit     int
+	}
 }
 
-func (*EmbeddedApp) GetAppType() string {
-	return fmt.Sprintf("rudder-server-%s", app.EMBEDDED)
+func (a *embeddedApp) loadConfiguration() {
+	config.RegisterBoolConfigVariable(true, &a.config.enableProcessor, false, "enableProcessor")
+	config.RegisterBoolConfigVariable(types.DEFAULT_REPLAY_ENABLED, &a.config.enableReplay, false, "Replay.enabled")
+	config.RegisterBoolConfigVariable(true, &a.config.enableRouter, false, "enableRouter")
+	config.RegisterIntConfigVariable(0, &a.config.processorDSLimit, true, 1, "Processor.jobsDB.dsLimit", "JobsDB.dsLimit")
+	config.RegisterIntConfigVariable(0, &a.config.gatewayDSLimit, true, 1, "Gateway.jobsDB.dsLimit", "JobsDB.dsLimit")
+	config.RegisterIntConfigVariable(0, &a.config.routerDSLimit, true, 1, "Router.jobsDB.dsLimit", "JobsDB.dsLimit")
+	config.RegisterIntConfigVariable(0, &a.config.batchRouterDSLimit, true, 1, "BatchRouter.jobsDB.dsLimit", "JobsDB.dsLimit")
 }
 
-func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.Options) error {
-	pkgLogger.Info("Embedded mode: Starting Rudder Core")
+func (a *embeddedApp) Setup(options *app.Options) error {
+	a.loadConfiguration()
 
-	rudderCoreDBValidator()
-	rudderCoreWorkSpaceTableSetup()
-	rudderCoreNodeSetup()
-	rudderCoreBaseSetup()
+	if err := db.HandleEmbeddedRecovery(options.NormalMode, options.DegradedMode, misc.AppStartTime, app.EMBEDDED); err != nil {
+		return err
+	}
+
+	if err := rudderCoreDBValidator(); err != nil {
+		return err
+	}
+	if err := rudderCoreWorkSpaceTableSetup(); err != nil {
+		return err
+	}
+	if err := rudderCoreNodeSetup(); err != nil {
+		return err
+	}
+	a.setupDone = true
+	return nil
+}
+
+func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options) error {
+	if !a.setupDone {
+		return fmt.Errorf("embedded rudder core cannot start, database is not setup")
+	}
+	a.log.Info("Embedded mode: Starting Rudder Core")
+
+	readonlyGatewayDB, readonlyRouterDB, readonlyBatchRouterDB, err := setupReadonlyDBs()
+	if err != nil {
+		return err
+	}
 
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -58,22 +100,22 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 	if err != nil {
 		return fmt.Errorf("failed to get deployment type: %w", err)
 	}
-	pkgLogger.Infof("Configured deployment type: %q", deploymentType)
+	a.log.Infof("Configured deployment type: %q", deploymentType)
 
-	reporting := embedded.App.Features().Reporting.Setup(backendconfig.DefaultBackendConfig)
+	reporting := a.app.Features().Reporting.Setup(backendconfig.DefaultBackendConfig)
 
 	g.Go(func() error {
 		reporting.AddClient(ctx, types.Config{ConnInfo: misc.GetConnectionString()})
 		return nil
 	})
 
-	pkgLogger.Info("Clearing DB ", options.ClearDB)
+	a.log.Info("Clearing DB ", options.ClearDB)
 
 	transformationdebugger.Setup()
 	destinationdebugger.Setup(backendconfig.DefaultBackendConfig)
 	sourcedebugger.Setup(backendconfig.DefaultBackendConfig)
 
-	reportingI := embedded.App.Features().Reporting.GetReportingInstance()
+	reportingI := a.app.Features().Reporting.GetReportingInstance()
 	transientSources := transientsource.NewService(ctx, backendconfig.DefaultBackendConfig)
 	prebackupHandlers := []prebackup.Handler{
 		prebackup.DropSourceIds(transientSources.SourceIdsSupplier()),
@@ -93,7 +135,7 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithStatusHandler(),
 		jobsdb.WithPreBackupHandlers(prebackupHandlers),
-		jobsdb.WithDSLimit(&gatewayDSLimit),
+		jobsdb.WithDSLimit(&a.config.gatewayDSLimit),
 		jobsdb.WithFileUploaderProvider(fileUploaderProvider),
 	)
 	defer gwDBForProcessor.Close()
@@ -102,7 +144,7 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithStatusHandler(),
 		jobsdb.WithPreBackupHandlers(prebackupHandlers),
-		jobsdb.WithDSLimit(&routerDSLimit),
+		jobsdb.WithDSLimit(&a.config.routerDSLimit),
 		jobsdb.WithFileUploaderProvider(fileUploaderProvider),
 	)
 	defer routerDB.Close()
@@ -111,7 +153,7 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithStatusHandler(),
 		jobsdb.WithPreBackupHandlers(prebackupHandlers),
-		jobsdb.WithDSLimit(&batchRouterDSLimit),
+		jobsdb.WithDSLimit(&a.config.batchRouterDSLimit),
 		jobsdb.WithFileUploaderProvider(fileUploaderProvider),
 	)
 	defer batchRouterDB.Close()
@@ -120,7 +162,7 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithStatusHandler(),
 		jobsdb.WithPreBackupHandlers(prebackupHandlers),
-		jobsdb.WithDSLimit(&processorDSLimit),
+		jobsdb.WithDSLimit(&a.config.processorDSLimit),
 		jobsdb.WithFileUploaderProvider(fileUploaderProvider),
 	)
 
@@ -144,12 +186,12 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 
 	switch deploymentType {
 	case deployment.MultiTenantType:
-		pkgLogger.Info("using ETCD Based Dynamic Cluster Manager")
+		a.log.Info("using ETCD Based Dynamic Cluster Manager")
 		modeProvider = state.NewETCDDynamicProvider()
 	case deployment.DedicatedType:
 		// FIXME: hacky way to determine server mode
-		pkgLogger.Info("using Static Cluster Manager")
-		if enableProcessor && enableRouter {
+		a.log.Info("using Static Cluster Manager")
+		if a.config.enableProcessor && a.config.enableRouter {
 			modeProvider = state.NewStaticProvider(servermode.NormalMode)
 		} else {
 			modeProvider = state.NewStaticProvider(servermode.DegradedMode)
@@ -196,7 +238,7 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 	// This separate gateway db is created just to be used with gateway because in case of degraded mode,
 	// the earlier created gwDb (which was created to be used mainly with processor) will not be running, and it
 	// will cause issues for gateway because gateway is supposed to receive jobs even in degraded mode.
-	gatewayDB = jobsdb.NewForWrite(
+	gatewayDB := jobsdb.NewForWrite(
 		"gw",
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithStatusHandler(),
@@ -207,18 +249,18 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 	}
 	defer gatewayDB.Stop()
 
-	gw.SetReadonlyDBs(&readonlyGatewayDB, &readonlyRouterDB, &readonlyBatchRouterDB)
+	gw.SetReadonlyDBs(readonlyGatewayDB, readonlyRouterDB, readonlyBatchRouterDB)
 	err = gw.Setup(
 		ctx,
-		embedded.App, backendconfig.DefaultBackendConfig, gatewayDB,
-		&rateLimiter, embedded.VersionHandler, rsourcesService,
+		a.app, backendconfig.DefaultBackendConfig, gatewayDB,
+		&rateLimiter, a.versionHandler, rsourcesService,
 	)
 	if err != nil {
 		return fmt.Errorf("could not setup gateway: %w", err)
 	}
 	defer func() {
 		if err := gw.Shutdown(); err != nil {
-			pkgLogger.Warnf("Gateway shutdown error: %v", err)
+			a.log.Warnf("Gateway shutdown error: %v", err)
 		}
 	}()
 
@@ -228,7 +270,7 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 	g.Go(func() error {
 		return gw.StartWebHandler(ctx)
 	})
-	if enableReplay {
+	if a.config.enableReplay {
 		var replayDB jobsdb.HandleT
 		err := replayDB.Setup(
 			jobsdb.ReadWrite, options.ClearDB, "replay",
@@ -238,7 +280,7 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 			return fmt.Errorf("could not setup replayDB: %w", err)
 		}
 		defer replayDB.TearDown()
-		embedded.App.Features().Replay.Setup(ctx, &replayDB, gatewayDB, routerDB, batchRouterDB)
+		a.app.Features().Replay.Setup(ctx, &replayDB, gatewayDB, routerDB, batchRouterDB)
 	}
 
 	g.Go(func() error {
@@ -260,8 +302,4 @@ func (embedded *EmbeddedApp) StartRudderCore(ctx context.Context, options *app.O
 	})
 
 	return g.Wait()
-}
-
-func (*EmbeddedApp) HandleRecovery(options *app.Options) {
-	db.HandleEmbeddedRecovery(options.NormalMode, options.DegradedMode, misc.AppStartTime, app.EMBEDDED)
 }

--- a/app/apphandlers/gatewayAppHandler.go
+++ b/app/apphandlers/gatewayAppHandler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rudderlabs/rudder-server/app"
 	"github.com/rudderlabs/rudder-server/app/cluster"
 	"github.com/rudderlabs/rudder-server/app/cluster/state"
+	"github.com/rudderlabs/rudder-server/config"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/gateway"
 	"github.com/rudderlabs/rudder-server/jobsdb"
@@ -17,35 +18,64 @@ import (
 	"github.com/rudderlabs/rudder-server/services/db"
 	sourcedebugger "github.com/rudderlabs/rudder-server/services/debugger/source"
 	fileuploader "github.com/rudderlabs/rudder-server/services/fileuploader"
+	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/types/deployment"
 	"github.com/rudderlabs/rudder-server/utils/types/servermode"
 )
 
-// GatewayApp is the type for Gateway type implementation
-type GatewayApp struct {
-	App            app.App
-	VersionHandler func(w http.ResponseWriter, r *http.Request)
+// gatewayApp is the type for Gateway type implementation
+type gatewayApp struct {
+	setupDone      bool
+	app            app.App
+	versionHandler func(w http.ResponseWriter, r *http.Request)
+	log            logger.Logger
+	config         struct {
+		enableProcessor bool
+		enableRouter    bool
+		gatewayDSLimit  int
+	}
 }
 
-func (*GatewayApp) GetAppType() string {
-	return fmt.Sprintf("rudder-server-%s", app.GATEWAY)
+func (a *gatewayApp) loadConfiguration() {
+	config.RegisterBoolConfigVariable(true, &a.config.enableProcessor, false, "enableProcessor")
+	config.RegisterBoolConfigVariable(true, &a.config.enableRouter, false, "enableRouter")
+	config.RegisterIntConfigVariable(0, &a.config.gatewayDSLimit, true, 1, "Gateway.jobsDB.dsLimit", "JobsDB.dsLimit")
 }
 
-func (gatewayApp *GatewayApp) StartRudderCore(ctx context.Context, options *app.Options) error {
-	pkgLogger.Info("Gateway starting")
+func (a *gatewayApp) Setup(options *app.Options) error {
+	a.loadConfiguration()
+	if err := db.HandleNullRecovery(options.NormalMode, options.DegradedMode, misc.AppStartTime, app.GATEWAY); err != nil {
+		return err
+	}
+	if err := rudderCoreDBValidator(); err != nil {
+		return err
+	}
+	if err := rudderCoreWorkSpaceTableSetup(); err != nil {
+		return err
+	}
+	a.setupDone = true
+	return nil
+}
 
-	rudderCoreDBValidator()
-	rudderCoreWorkSpaceTableSetup()
-	rudderCoreBaseSetup()
+func (a *gatewayApp) StartRudderCore(ctx context.Context, options *app.Options) error {
+	if !a.setupDone {
+		return fmt.Errorf("gateway cannot start, database is not setup")
+	}
+	a.log.Info("Gateway starting")
+
+	readonlyGatewayDB, readonlyRouterDB, readonlyBatchRouterDB, err := setupReadonlyDBs()
+	if err != nil {
+		return err
+	}
 
 	deploymentType, err := deployment.GetFromEnv()
 	if err != nil {
 		return fmt.Errorf("failed to get deployment type: %v", err)
 	}
 
-	pkgLogger.Infof("Configured deployment type: %q", deploymentType)
-	pkgLogger.Info("Clearing DB ", options.ClearDB)
+	a.log.Infof("Configured deployment type: %q", deploymentType)
+	a.log.Info("Clearing DB ", options.ClearDB)
 
 	sourcedebugger.Setup(backendconfig.DefaultBackendConfig)
 
@@ -55,7 +85,7 @@ func (gatewayApp *GatewayApp) StartRudderCore(ctx context.Context, options *app.
 		"gw",
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithStatusHandler(),
-		jobsdb.WithDSLimit(&gatewayDSLimit),
+		jobsdb.WithDSLimit(&a.config.gatewayDSLimit),
 		jobsdb.WithFileUploaderProvider(fileUploaderProvider),
 	)
 	defer gatewayDB.Close()
@@ -70,11 +100,11 @@ func (gatewayApp *GatewayApp) StartRudderCore(ctx context.Context, options *app.
 
 	switch deploymentType {
 	case deployment.MultiTenantType:
-		pkgLogger.Info("using ETCD Based Dynamic Cluster Manager")
+		a.log.Info("using ETCD Based Dynamic Cluster Manager")
 		modeProvider = state.NewETCDDynamicProvider()
 	case deployment.DedicatedType:
-		pkgLogger.Info("using Static Cluster Manager")
-		if enableProcessor && enableRouter {
+		a.log.Info("using Static Cluster Manager")
+		if a.config.enableProcessor && a.config.enableRouter {
 			modeProvider = state.NewStaticProvider(servermode.NormalMode)
 		} else {
 			modeProvider = state.NewStaticProvider(servermode.DegradedMode)
@@ -95,22 +125,22 @@ func (gatewayApp *GatewayApp) StartRudderCore(ctx context.Context, options *app.
 	var rateLimiter ratelimiter.HandleT
 
 	rateLimiter.SetUp()
-	gw.SetReadonlyDBs(&readonlyGatewayDB, &readonlyRouterDB, &readonlyBatchRouterDB)
+	gw.SetReadonlyDBs(readonlyGatewayDB, readonlyRouterDB, readonlyBatchRouterDB)
 	rsourcesService, err := NewRsourcesService(deploymentType)
 	if err != nil {
 		return err
 	}
 	err = gw.Setup(
 		ctx,
-		gatewayApp.App, backendconfig.DefaultBackendConfig, gatewayDB,
-		&rateLimiter, gatewayApp.VersionHandler, rsourcesService,
+		a.app, backendconfig.DefaultBackendConfig, gatewayDB,
+		&rateLimiter, a.versionHandler, rsourcesService,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to setup gateway: %w", err)
 	}
 	defer func() {
 		if err := gw.Shutdown(); err != nil {
-			pkgLogger.Warnf("Gateway shutdown error: %v", err)
+			a.log.Warnf("Gateway shutdown error: %v", err)
 		}
 	}()
 
@@ -121,8 +151,4 @@ func (gatewayApp *GatewayApp) StartRudderCore(ctx context.Context, options *app.
 		return gw.StartWebHandler(ctx)
 	})
 	return g.Wait()
-}
-
-func (*GatewayApp) HandleRecovery(options *app.Options) {
-	db.HandleNullRecovery(options.NormalMode, options.DegradedMode, misc.AppStartTime, app.GATEWAY)
 }

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -7,7 +7,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/config"
 	"github.com/rudderlabs/rudder-server/utils/httputil"
+	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/types/deployment"
 	"github.com/rudderlabs/rudder-server/utils/types/servermode"
 
@@ -19,7 +21,6 @@ import (
 	"github.com/rudderlabs/rudder-server/app"
 	"github.com/rudderlabs/rudder-server/app/cluster"
 	"github.com/rudderlabs/rudder-server/app/cluster/state"
-	"github.com/rudderlabs/rudder-server/config"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
@@ -38,75 +39,95 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
-// ProcessorApp is the type for Processor type implemention
-type ProcessorApp struct {
-	App            app.App
-	VersionHandler func(w http.ResponseWriter, r *http.Request)
+// processorApp is the type for Processor type implemention
+type processorApp struct {
+	setupDone      bool
+	app            app.App
+	versionHandler func(w http.ResponseWriter, r *http.Request)
+	log            logger.Logger
+	config         struct {
+		enableProcessor    bool
+		enableRouter       bool
+		processorDSLimit   int
+		routerDSLimit      int
+		batchRouterDSLimit int
+		gatewayDSLimit     int
+		http               struct {
+			ReadTimeout       time.Duration
+			ReadHeaderTimeout time.Duration
+			WriteTimeout      time.Duration
+			IdleTimeout       time.Duration
+			webPort           int
+			MaxHeaderBytes    int
+		}
+	}
 }
 
-var (
-	gatewayDB          *jobsdb.HandleT
-	ReadTimeout        time.Duration
-	ReadHeaderTimeout  time.Duration
-	WriteTimeout       time.Duration
-	IdleTimeout        time.Duration
-	webPort            int
-	MaxHeaderBytes     int
-	processorDSLimit   int
-	routerDSLimit      int
-	batchRouterDSLimit int
-	gatewayDSLimit     int
-)
+func (a *processorApp) loadConfiguration() {
+	config.RegisterBoolConfigVariable(true, &a.config.enableProcessor, false, "enableProcessor")
+	config.RegisterBoolConfigVariable(true, &a.config.enableRouter, false, "enableRouter")
 
-func (*ProcessorApp) GetAppType() string {
-	return fmt.Sprintf("rudder-server-%s", app.PROCESSOR)
+	config.RegisterDurationConfigVariable(0, &a.config.http.ReadTimeout, false, time.Second, []string{"ReadTimeout", "ReadTimeOutInSec"}...)
+	config.RegisterDurationConfigVariable(0, &a.config.http.ReadHeaderTimeout, false, time.Second, []string{"ReadHeaderTimeout", "ReadHeaderTimeoutInSec"}...)
+	config.RegisterDurationConfigVariable(10, &a.config.http.WriteTimeout, false, time.Second, []string{"WriteTimeout", "WriteTimeOutInSec"}...)
+	config.RegisterDurationConfigVariable(720, &a.config.http.IdleTimeout, false, time.Second, []string{"IdleTimeout", "IdleTimeoutInSec"}...)
+	config.RegisterIntConfigVariable(8086, &a.config.http.webPort, false, 1, "Processor.webPort")
+	config.RegisterIntConfigVariable(524288, &a.config.http.MaxHeaderBytes, false, 1, "MaxHeaderBytes")
+	config.RegisterIntConfigVariable(0, &a.config.processorDSLimit, true, 1, "Processor.jobsDB.dsLimit", "JobsDB.dsLimit")
+	config.RegisterIntConfigVariable(0, &a.config.gatewayDSLimit, true, 1, "Gateway.jobsDB.dsLimit", "JobsDB.dsLimit")
+	config.RegisterIntConfigVariable(0, &a.config.routerDSLimit, true, 1, "Router.jobsDB.dsLimit", "JobsDB.dsLimit")
+	config.RegisterIntConfigVariable(0, &a.config.batchRouterDSLimit, true, 1, "BatchRouter.jobsDB.dsLimit", "JobsDB.dsLimit")
 }
 
-func Init() {
-	loadConfigHandler()
+func (a *processorApp) Setup(options *app.Options) error {
+	a.loadConfiguration()
+	if err := db.HandleNullRecovery(options.NormalMode, options.DegradedMode, misc.AppStartTime, app.PROCESSOR); err != nil {
+		return err
+	}
+	if err := rudderCoreDBValidator(); err != nil {
+		return err
+	}
+	if err := rudderCoreWorkSpaceTableSetup(); err != nil {
+		return err
+	}
+	if err := rudderCoreNodeSetup(); err != nil {
+		return err
+	}
+	a.setupDone = true
+	return nil
 }
 
-func loadConfigHandler() {
-	config.RegisterDurationConfigVariable(0, &ReadTimeout, false, time.Second, []string{"ReadTimeout", "ReadTimeOutInSec"}...)
-	config.RegisterDurationConfigVariable(0, &ReadHeaderTimeout, false, time.Second, []string{"ReadHeaderTimeout", "ReadHeaderTimeoutInSec"}...)
-	config.RegisterDurationConfigVariable(10, &WriteTimeout, false, time.Second, []string{"WriteTimeout", "WriteTimeOutInSec"}...)
-	config.RegisterDurationConfigVariable(720, &IdleTimeout, false, time.Second, []string{"IdleTimeout", "IdleTimeoutInSec"}...)
-	config.RegisterIntConfigVariable(8086, &webPort, false, 1, "Processor.webPort")
-	config.RegisterIntConfigVariable(524288, &MaxHeaderBytes, false, 1, "MaxHeaderBytes")
-	config.RegisterIntConfigVariable(0, &processorDSLimit, true, 1, "Processor.jobsDB.dsLimit", "JobsDB.dsLimit")
-	config.RegisterIntConfigVariable(0, &gatewayDSLimit, true, 1, "Gateway.jobsDB.dsLimit", "JobsDB.dsLimit")
-	config.RegisterIntConfigVariable(0, &routerDSLimit, true, 1, "Router.jobsDB.dsLimit", "JobsDB.dsLimit")
-	config.RegisterIntConfigVariable(0, &batchRouterDSLimit, true, 1, "BatchRouter.jobsDB.dsLimit", "JobsDB.dsLimit")
-}
+func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options) error {
+	if !a.setupDone {
+		return fmt.Errorf("processor service cannot start, database is not setup")
+	}
+	a.log.Info("Processor starting")
 
-func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app.Options) error {
-	pkgLogger.Info("Processor starting")
-
-	rudderCoreDBValidator()
-	rudderCoreWorkSpaceTableSetup()
-	rudderCoreNodeSetup()
-	rudderCoreBaseSetup()
+	_, _, _, err := setupReadonlyDBs()
+	if err != nil {
+		return err
+	}
 	g, ctx := errgroup.WithContext(ctx)
 
 	deploymentType, err := deployment.GetFromEnv()
 	if err != nil {
 		return fmt.Errorf("failed to get deployment type: %w", err)
 	}
-	pkgLogger.Infof("Configured deployment type: %q", deploymentType)
+	a.log.Infof("Configured deployment type: %q", deploymentType)
 
-	reporting := processor.App.Features().Reporting.Setup(backendconfig.DefaultBackendConfig)
+	reporting := a.app.Features().Reporting.Setup(backendconfig.DefaultBackendConfig)
 
 	g.Go(misc.WithBugsnag(func() error {
 		reporting.AddClient(ctx, types.Config{ConnInfo: misc.GetConnectionString()})
 		return nil
 	}))
 
-	pkgLogger.Info("Clearing DB ", options.ClearDB)
+	a.log.Info("Clearing DB ", options.ClearDB)
 
 	transformationdebugger.Setup()
 	destinationdebugger.Setup(backendconfig.DefaultBackendConfig)
 
-	reportingI := processor.App.Features().Reporting.GetReportingInstance()
+	reportingI := a.app.Features().Reporting.GetReportingInstance()
 	transientSources := transientsource.NewService(ctx, backendconfig.DefaultBackendConfig)
 	prebackupHandlers := []prebackup.Handler{
 		prebackup.DropSourceIds(transientSources.SourceIdsSupplier()),
@@ -124,17 +145,16 @@ func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithStatusHandler(),
 		jobsdb.WithPreBackupHandlers(prebackupHandlers),
-		jobsdb.WithDSLimit(&gatewayDSLimit),
+		jobsdb.WithDSLimit(&a.config.gatewayDSLimit),
 		jobsdb.WithFileUploaderProvider(fileUploaderProvider),
 	)
 	defer gwDBForProcessor.Close()
-	gatewayDB = gwDBForProcessor
 	routerDB := jobsdb.NewForReadWrite(
 		"rt",
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithStatusHandler(),
 		jobsdb.WithPreBackupHandlers(prebackupHandlers),
-		jobsdb.WithDSLimit(&routerDSLimit),
+		jobsdb.WithDSLimit(&a.config.routerDSLimit),
 		jobsdb.WithFileUploaderProvider(fileUploaderProvider),
 	)
 	defer routerDB.Close()
@@ -143,7 +163,7 @@ func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithStatusHandler(),
 		jobsdb.WithPreBackupHandlers(prebackupHandlers),
-		jobsdb.WithDSLimit(&batchRouterDSLimit),
+		jobsdb.WithDSLimit(&a.config.batchRouterDSLimit),
 		jobsdb.WithFileUploaderProvider(fileUploaderProvider),
 	)
 	defer batchRouterDB.Close()
@@ -152,7 +172,7 @@ func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithStatusHandler(),
 		jobsdb.WithPreBackupHandlers(prebackupHandlers),
-		jobsdb.WithDSLimit(&processorDSLimit),
+		jobsdb.WithDSLimit(&a.config.processorDSLimit),
 		jobsdb.WithFileUploaderProvider(fileUploaderProvider),
 	)
 	var tenantRouterDB jobsdb.MultiTenantJobsDB
@@ -175,12 +195,12 @@ func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app
 
 	switch deploymentType {
 	case deployment.MultiTenantType:
-		pkgLogger.Info("using ETCD Based Dynamic Cluster Manager")
+		a.log.Info("using ETCD Based Dynamic Cluster Manager")
 		modeProvider = state.NewETCDDynamicProvider()
 	case deployment.DedicatedType:
 		// FIXME: hacky way to determine servermode
-		pkgLogger.Info("using Static Cluster Manager")
-		if enableProcessor && enableRouter {
+		a.log.Info("using Static Cluster Manager")
+		if a.config.enableProcessor && a.config.enableRouter {
 			modeProvider = state.NewStaticProvider(servermode.NormalMode)
 		} else {
 			modeProvider = state.NewStaticProvider(servermode.DegradedMode)
@@ -224,7 +244,7 @@ func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app
 	}
 
 	g.Go(func() error {
-		return startHealthWebHandler(ctx)
+		return a.startHealthWebHandler(ctx, gwDBForProcessor)
 	})
 
 	g.Go(func() error {
@@ -248,24 +268,20 @@ func (processor *ProcessorApp) StartRudderCore(ctx context.Context, options *app
 	return g.Wait()
 }
 
-func (*ProcessorApp) HandleRecovery(options *app.Options) {
-	db.HandleNullRecovery(options.NormalMode, options.DegradedMode, misc.AppStartTime, app.PROCESSOR)
-}
-
-func startHealthWebHandler(ctx context.Context) error {
+func (a *processorApp) startHealthWebHandler(ctx context.Context, db *jobsdb.HandleT) error {
 	// Port where Processor health handler is running
-	pkgLogger.Infof("Starting in %d", webPort)
+	a.log.Infof("Starting in %d", a.config.http.webPort)
 	srvMux := mux.NewRouter()
-	srvMux.HandleFunc("/health", app.LivenessHandler(gatewayDB))
-	srvMux.HandleFunc("/", app.LivenessHandler(gatewayDB))
+	srvMux.HandleFunc("/health", app.LivenessHandler(db))
+	srvMux.HandleFunc("/", app.LivenessHandler(db))
 	srv := &http.Server{
-		Addr:              ":" + strconv.Itoa(webPort),
+		Addr:              ":" + strconv.Itoa(a.config.http.webPort),
 		Handler:           bugsnag.Handler(srvMux),
-		ReadTimeout:       ReadTimeout,
-		ReadHeaderTimeout: ReadHeaderTimeout,
-		WriteTimeout:      WriteTimeout,
-		IdleTimeout:       IdleTimeout,
-		MaxHeaderBytes:    MaxHeaderBytes,
+		ReadTimeout:       a.config.http.ReadTimeout,
+		ReadHeaderTimeout: a.config.http.ReadHeaderTimeout,
+		WriteTimeout:      a.config.http.WriteTimeout,
+		IdleTimeout:       a.config.http.IdleTimeout,
+		MaxHeaderBytes:    a.config.http.MaxHeaderBytes,
 	}
 
 	return httputil.ListenAndServe(ctx, srv)

--- a/config/mode.go
+++ b/config/mode.go
@@ -2,10 +2,10 @@ package config
 
 // Rudder server supported config constants
 const (
-	EmbeddedMode      = "embedded"
-	MasterMode        = "master"
-	MasterSlaveMode   = "master_and_slave"
-	SlaveMode         = "slave"
-	OffMode           = "off"
-	PooledWHSlaveMode = "embedded_master"
+	EmbeddedMode       = "embedded"
+	MasterMode         = "master"
+	MasterSlaveMode    = "master_and_slave"
+	SlaveMode          = "slave"
+	OffMode            = "off"
+	EmbeddedMasterMode = "embedded_master"
 )

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -866,7 +866,7 @@ func TestCacheScenarios(t *testing.T) {
 		defer jobsDB.TearDown()
 
 		readOnlyDB := &ReadonlyHandleT{}
-		readOnlyDB.Setup("readonly_cache")
+		require.NoError(t, readOnlyDB.Setup("readonly_cache"))
 
 		destinationID := "destinationID"
 

--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -194,7 +194,9 @@ func (*JobsdbUtilsHandler) RunSQLQuery(argString string, reply *string) (err err
 		args[0] = "batch_rt"
 	}
 
-	readOnlyJobsDB.Setup(args[0])
+	if err := readOnlyJobsDB.Setup(args[0]); err != nil {
+		return err
+	}
 
 	switch args[1] {
 	case "Jobs between JobID's of a User":

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1,0 +1,72 @@
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/rudderlabs/rudder-server/app"
+	"github.com/rudderlabs/rudder-server/config"
+	"github.com/rudderlabs/rudder-server/testhelper/destination"
+	"github.com/rudderlabs/rudder-server/testhelper/workspaceConfig"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunner(t *testing.T) {
+	config.Set("BackendConfig.configFromFile", true)
+	configJsonPath := workspaceConfig.CreateTempFile(t, "testdata/config.json", map[string]string{})
+	config.Set("BackendConfig.configJSONPath", configJsonPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	t.Run("embedded", func(t *testing.T) {
+		config.Set("APP_TYPE", app.EMBEDDED)
+		config.Set("Warehouse.mode", "embedded")
+
+		t.Run("it shouldn't be able to start if both databases are down", func(t *testing.T) {
+			exitCode := New(ReleaseInfo{}).Run(ctx, []string{"app"})
+			require.Equal(t, 1, exitCode)
+		})
+
+		t.Run("it shouldn't be able to start if jobsdb database is down", func(t *testing.T) {
+			startWarehousePostgresql(t)
+			exitCode := New(ReleaseInfo{}).Run(ctx, []string{"app"})
+			require.Equal(t, 1, exitCode)
+		})
+
+		t.Run("it shouldn't be able to start if warehouse database is down", func(t *testing.T) {
+			startJobsDBPostgresql(t)
+			exitCode := New(ReleaseInfo{}).Run(ctx, []string{"app"})
+			require.Equal(t, 1, exitCode)
+		})
+	})
+}
+
+func startJobsDBPostgresql(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	r, err := destination.SetupPostgres(pool, t)
+	require.NoError(t, err)
+	config.Set("DB.port", r.Port)
+	config.Set("DB.user", r.User)
+	config.Set("DB.name", r.Database)
+	config.Set("DB.password", r.Password)
+	// setting warehouse config values to their defaults
+	config.Set("WAREHOUSE_JOBS_DB_HOST", "localhost")
+	config.Set("WAREHOUSE_JOBS_DB_PORT", 5432)
+	config.Set("WAREHOUSE_JOBS_DB_USER", "ubuntu")
+	config.Set("WAREHOUSE_JOBS_DB_DB_NAME", "ubuntu")
+	config.Set("WAREHOUSE_JOBS_DB_PASSWORD", r.Password)
+}
+
+func startWarehousePostgresql(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	r, err := destination.SetupPostgres(pool, t)
+	require.NoError(t, err)
+	config.Set("WAREHOUSE_JOBS_DB_HOST", "localhost")
+	config.Set("WAREHOUSE_JOBS_DB_PORT", r.Port)
+	config.Set("WAREHOUSE_JOBS_DB_USER", r.User)
+	config.Set("WAREHOUSE_JOBS_DB_DB_NAME", r.Database)
+	config.Set("WAREHOUSE_JOBS_DB_PASSWORD", r.Password)
+}

--- a/runner/testdata/config.json
+++ b/runner/testdata/config.json
@@ -1,0 +1,16 @@
+{
+    "enableMetrics": false,
+    "workspaceId": "workspace",
+    "sources": [],
+    "libraries": [
+        {
+            "versionId": "def"
+        },
+        {
+            "versionId": "ghi"
+        },
+        {
+            "versionId": "23Uxw7QEiOg8e0KkQV8LmNfWaWh"
+        }
+    ]
+}

--- a/services/db/recovery.go
+++ b/services/db/recovery.go
@@ -46,15 +46,17 @@ func Init() {
 	pkgLogger = logger.NewLogger().Child("db").Child("recovery")
 }
 
-func getRecoveryData() RecoveryDataT {
+func getRecoveryData() (RecoveryDataT, error) {
+	var recoveryData RecoveryDataT
+
 	data, err := os.ReadFile(storagePath)
 	if os.IsNotExist(err) {
 		defaultRecoveryJSON := "{\"mode\":\"" + normalMode + "\"}"
 		data = []byte(defaultRecoveryJSON)
 	} else if err != nil {
-		panic(err)
+		return recoveryData, err
 	}
-	var recoveryData RecoveryDataT
+
 	err = json.Unmarshal(data, &recoveryData)
 	if err != nil {
 		pkgLogger.Errorf("Failed to Unmarshall %s. Error:  %v", storagePath, err)
@@ -63,18 +65,15 @@ func getRecoveryData() RecoveryDataT {
 		}
 		recoveryData = RecoveryDataT{Mode: normalMode}
 	}
-	return recoveryData
+	return recoveryData, nil
 }
 
-func saveRecoveryData(recoveryData RecoveryDataT) {
+func saveRecoveryData(recoveryData RecoveryDataT) error {
 	recoveryDataJSON, err := json.MarshalIndent(&recoveryData, "", " ")
 	if err != nil {
-		panic(err)
+		return err
 	}
-	err = os.WriteFile(storagePath, recoveryDataJSON, 0o644)
-	if err != nil {
-		panic(err)
-	}
+	return os.WriteFile(storagePath, recoveryDataJSON, 0o644)
 }
 
 // IsNormalMode checks if the current mode is normal

--- a/services/validators/envValidator.go
+++ b/services/validators/envValidator.go
@@ -28,7 +28,7 @@ func init() {
 	pkgLogger = logger.NewLogger().Child("validators").Child("envValidator")
 }
 
-func createWorkspaceTable(dbHandle *sql.DB) {
+func createWorkspaceTable(dbHandle *sql.DB) error {
 	// Create table to store workspace token
 	sqlStatement := `CREATE TABLE IF NOT EXISTS workspace (
 		token TEXT PRIMARY KEY,
@@ -37,40 +37,36 @@ func createWorkspaceTable(dbHandle *sql.DB) {
 
 	_, err := dbHandle.Exec(sqlStatement)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("error creating workspace table: %w", err)
 	}
+	return nil
 }
 
-func insertTokenIfNotExists(dbHandle *sql.DB) {
+func insertTokenIfNotExists(dbHandle *sql.DB) error {
 	// Read entries, if there are no entries insert hashed current workspace token
 	var totalCount int
 	sqlStatement := `SELECT COUNT(*) FROM workspace`
 	row := dbHandle.QueryRow(sqlStatement)
 	err := row.Scan(&totalCount)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("error reading workspace table: %w", err)
 	}
 
 	if totalCount > 0 {
-		return
+		return nil
 	}
 
 	// There are no entries in the table, hash current workspace token and insert
-	sqlStatement = `INSERT INTO workspace (token, created_at)
-									   VALUES ($1, $2)`
-	stmt, err := dbHandle.Prepare(sqlStatement)
-	if err != nil {
-		panic(err)
+	if _, err := dbHandle.Exec(`INSERT INTO workspace (token, created_at)
+									VALUES ($1, $2)`,
+		misc.GetMD5Hash(config.GetWorkspaceToken()),
+		time.Now()); err != nil {
+		return fmt.Errorf("error inserting workspace token: %w", err)
 	}
-	defer stmt.Close()
-
-	_, err = stmt.Exec(misc.GetMD5Hash(config.GetWorkspaceToken()), time.Now())
-	if err != nil {
-		panic(err)
-	}
+	return nil
 }
 
-func setWHSchemaVersionIfNotExists(dbHandle *sql.DB) {
+func setWHSchemaVersionIfNotExists(dbHandle *sql.DB) error {
 	hashedToken := misc.GetMD5Hash(config.GetWorkspaceToken())
 	whSchemaVersion := config.GetString("Warehouse.schemaVersion", "v1")
 
@@ -79,10 +75,10 @@ func setWHSchemaVersionIfNotExists(dbHandle *sql.DB) {
 	row := dbHandle.QueryRow(sqlStatement)
 	err := row.Scan(&parameters)
 	if err == sql.ErrNoRows {
-		return
+		return nil
 	}
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("error reading workspace table: %w", err)
 	}
 
 	if !parameters.Valid {
@@ -90,74 +86,74 @@ func setWHSchemaVersionIfNotExists(dbHandle *sql.DB) {
 		sqlStatement = fmt.Sprintf(`UPDATE workspace SET parameters = '{"wh_schema_version":%q}' WHERE token = '%s'`, whSchemaVersion, hashedToken)
 		_, err := dbHandle.Exec(sqlStatement)
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("error updating workspace table: %w", err)
 		}
 	} else {
 		var parametersMap map[string]interface{}
 		err = json.Unmarshal([]byte(parameters.String), &parametersMap)
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("error unmarshalling parameters: %w", err)
 		}
 		if version, ok := parametersMap["wh_schema_version"]; ok {
 			whSchemaVersion = version.(string)
 			config.Set("Warehouse.schemaVersion", whSchemaVersion)
-			return
+			return nil
 		}
 		parametersMap["wh_schema_version"] = whSchemaVersion
 		marshalledParameters, err := json.Marshal(parametersMap)
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("error marshalling parameters: %w", err)
 		}
 		sqlStatement = fmt.Sprintf(`UPDATE workspace SET parameters = '%s' WHERE token = '%s'`, marshalledParameters, hashedToken)
 		_, err = dbHandle.Exec(sqlStatement)
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("error updating workspace table: %w", err)
 		}
 	}
+	return nil
 }
 
-func getWorkspaceFromDB(dbHandle *sql.DB) string {
+func getWorkspaceFromDB(dbHandle *sql.DB) (string, error) {
 	sqlStatement := `SELECT token FROM workspace order by created_at desc limit 1`
 	var token string
 	row := dbHandle.QueryRow(sqlStatement)
-	err := row.Scan(&token)
-	if err != nil {
-		panic(err)
+	if err := row.Scan(&token); err != nil {
+		return token, fmt.Errorf("error reading workspace table: %w", err)
 	}
-
-	return token
+	return token, nil
 }
 
-func createDBConnection() *sql.DB {
+func createDBConnection() (*sql.DB, error) {
 	psqlInfo := misc.GetConnectionString()
 	var err error
 	dbHandle, err := sql.Open("postgres", psqlInfo)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("error opening db connection: %w", err)
 	}
 
 	err = dbHandle.Ping()
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("error pinging db: %w", err)
 	}
-	return dbHandle
+	return dbHandle, nil
 }
 
-func closeDBConnection(handle *sql.DB) {
+func closeDBConnection(handle *sql.DB) error {
 	err := handle.Close()
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("error closing db connection: %w", err)
 	}
+	return nil
 }
 
-func killDanglingDBConnections(db *sql.DB) {
+func killDanglingDBConnections(db *sql.DB) error {
 	rows, err := db.Query(`SELECT PID, QUERY_START, COALESCE(WAIT_EVENT_TYPE,''), COALESCE(WAIT_EVENT, ''), COALESCE(STATE, ''), QUERY, PG_TERMINATE_BACKEND(PID)
 							FROM PG_STAT_ACTIVITY
 							WHERE PID <> PG_BACKEND_PID()
 							AND APPLICATION_NAME = CURRENT_SETTING('APPLICATION_NAME')
 							AND APPLICATION_NAME <> ''`)
 	if err != nil {
-		panic(fmt.Errorf("error occurred when querying pg_stat_activity table for terminating dangling connections: %v", err.Error()))
+		return fmt.Errorf("error occurred when querying pg_stat_activity table for terminating dangling connections: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -176,7 +172,7 @@ func killDanglingDBConnections(db *sql.DB) {
 		var row danglingConnRow
 		err := rows.Scan(&row.pid, &row.queryStart, &row.waitEventType, &row.waitEvent, &row.state, &row.query, &row.terminated)
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("error occurred when scanning pg_stat_activity table for terminating dangling connections: %w", err)
 		}
 		dangling = append(dangling, &row)
 	}
@@ -187,6 +183,7 @@ func killDanglingDBConnections(db *sql.DB) {
 			pkgLogger.Warnf("dangling connection #%d: %+v", i+1, *rowPtr)
 		}
 	}
+	return nil
 }
 
 // IsPostgresCompatible checks the if the version of postgres is greater than minPostgresVersion
@@ -200,17 +197,19 @@ func IsPostgresCompatible(ctx context.Context, db *sql.DB) (bool, error) {
 }
 
 // ValidateEnv validates the current environment available for the server
-func ValidateEnv() {
-	dbHandle := createDBConnection()
-	defer closeDBConnection(dbHandle)
+func ValidateEnv() error {
+	dbHandle, err := createDBConnection()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = closeDBConnection(dbHandle) }()
 
 	isDBCompatible, err := IsPostgresCompatible(context.TODO(), dbHandle)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	if !isDBCompatible {
-		pkgLogger.Errorf("Rudder server needs postgres version >= 10. Exiting.")
-		panic(errors.New("Failed to start rudder-server"))
+		return errors.New("rudder server needs postgres version >= 10")
 	}
 
 	// SQL statements in rudder-server are not executed with a timeout context, instead we are letting them take as much time as they need :)
@@ -218,51 +217,76 @@ func ValidateEnv() {
 	// the server process will not manage to shutdown gracefully, since it will be blocked by the SQL statements.
 	// The container orchestrator will eventually kill the server process, leaving one or more dangling connections in the database.
 	// This will ensure that before a new rudder-server instance starts working, all previous dangling connections belonging to this server are being killed.
-	killDanglingDBConnections(dbHandle)
+	return killDanglingDBConnections(dbHandle)
 }
 
 // InitializeEnv initializes the environment for the server
-func InitializeNodeMigrations() {
-	dbHandle := createDBConnection()
-	defer closeDBConnection(dbHandle)
+func InitializeNodeMigrations() error {
+	dbHandle, err := createDBConnection()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = closeDBConnection(dbHandle) }()
 
 	m := &migrator.Migrator{
 		Handle:                     dbHandle,
 		MigrationsTable:            "node_migrations",
 		ShouldForceSetLowerVersion: config.GetBool("SQLMigrator.forceSetLowerVersion", true),
 	}
-	err := m.Migrate("node")
-	if err != nil {
-		panic(fmt.Errorf("Could not run node migrations: %w", err))
+	if err := m.Migrate("node"); err != nil {
+		return fmt.Errorf("could not run node schema migrations: %w", err)
 	}
+	return nil
 }
 
-func CheckAndValidateWorkspaceToken() {
-	dbHandle := createDBConnection()
-	defer closeDBConnection(dbHandle)
+func CheckAndValidateWorkspaceToken() error {
+	dbHandle, err := createDBConnection()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = closeDBConnection(dbHandle) }()
 
-	createWorkspaceTable(dbHandle)
-	insertTokenIfNotExists(dbHandle)
-	setWHSchemaVersionIfNotExists(dbHandle)
+	if err := createWorkspaceTable(dbHandle); err != nil {
+		return err
+	}
+	if err := insertTokenIfNotExists(dbHandle); err != nil {
+		return err
+	}
+	if err := setWHSchemaVersionIfNotExists(dbHandle); err != nil {
+		return err
+	}
 
-	workspaceTokenHashInDB := getWorkspaceFromDB(dbHandle)
+	workspaceTokenHashInDB, err := getWorkspaceFromDB(dbHandle)
+	if err != nil {
+		return err
+	}
 	if workspaceTokenHashInDB == misc.GetMD5Hash(config.GetWorkspaceToken()) {
-		return
+		return nil
 	}
 
 	// db connection should be closed. Else alter db fails.
 	// A new connection will be created again below, which will be closed on returning of this function (due to defer statement).
-	closeDBConnection(dbHandle)
+	_ = closeDBConnection(dbHandle)
 
 	pkgLogger.Warn("Previous workspace token is not same as the current workspace token. Parking current jobsdb aside and creating a new one")
 
 	dbName := config.GetString("DB.name", "ubuntu")
 	misc.ReplaceDB(dbName, dbName+"_"+strconv.FormatInt(time.Now().Unix(), 10)+"_"+workspaceTokenHashInDB)
 
-	dbHandle = createDBConnection()
+	dbHandle, err = createDBConnection()
+	if err != nil {
+		return err
+	}
 
 	// create workspace table and insert hashed token
-	createWorkspaceTable(dbHandle)
-	insertTokenIfNotExists(dbHandle)
-	setWHSchemaVersionIfNotExists(dbHandle)
+	if err := createWorkspaceTable(dbHandle); err != nil {
+		return err
+	}
+	if err := insertTokenIfNotExists(dbHandle); err != nil {
+		return err
+	}
+	if err := setWHSchemaVersionIfNotExists(dbHandle); err != nil {
+		return err
+	}
+	return nil
 }

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -1125,7 +1125,7 @@ func ConcatErrors(givenErrors []error) error {
 func isWarehouseMasterEnabled() bool {
 	warehouseMode := config.GetString("Warehouse.mode", "embedded")
 	return warehouseMode == config.EmbeddedMode ||
-		warehouseMode == config.PooledWHSlaveMode
+		warehouseMode == config.EmbeddedMasterMode
 }
 
 func GetWarehouseURL() (url string) {


### PR DESCRIPTION
# Description

When running in `embedded` mode (core & warehouse) and using separate database instances for core & warehouse data, it is possible that one database's unavailability panic may cause the other database's schema migration to become dirty (corrupted) due to the asynchronous nature of the two components' startup sequence.

To eliminate this, we are now initialising both databases sequentially and stop the process gracefully in case of an error. Database initialisation for reach component happens only if the component needs to be started.

Other improvements:
- removed a handful of panics for supporting graceful termination on failure scenarios
- refactored the `apphandlers` package to remove global variables
- introduced tests for some exceptional `runner` & `apphandler` scenarios

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=bdf94aeaedb84e5c985a3b6648bf45fb&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
