### PR TITLE
fix: metadata in event_schema table has TotalCount which exceeds 32bit integer limits

### DIFF
--- a/event-schema/event_schema.go
+++ b/event-schema/event_schema.go
@@ -1029,7 +1029,7 @@ func (manager *EventSchemaManagerT) populateSchemaVersionsMinimal(modelIDFilters
 }
 
 func (manager *EventSchemaManagerT) populateSchemaVersion(o *OffloadedSchemaVersionT) error {
-	schemaVersionsSelectSQL := fmt.Sprintf(`SELECT id, uuid, event_model_id, schema_hash, schema, private_data,first_seen, last_seen, total_count, (metadata->>'TotalCount')::int, metadata->'SampledEvents' FROM %s WHERE uuid = '%s'`, SCHEMA_VERSIONS_TABLE, o.UUID)
+	schemaVersionsSelectSQL := fmt.Sprintf(`SELECT id, uuid, event_model_id, schema_hash, schema, private_data,first_seen, last_seen, total_count, (metadata->>'TotalCount')::bigint, metadata->'SampledEvents' FROM %s WHERE uuid = '%s'`, SCHEMA_VERSIONS_TABLE, o.UUID)
 
 	var schemaVersion SchemaVersionT
 	var privateDataRaw json.RawMessage

--- a/event-schema/event_schema.go
+++ b/event-schema/event_schema.go
@@ -917,7 +917,7 @@ func (manager *EventSchemaManagerT) populateEventModels(uuidFilters ...string) e
 		uuidFilter = fmt.Sprintf(`WHERE uuid in ('%s')`, strings.Join(uuidFilters, "', '"))
 	}
 
-	eventModelsSelectSQL := fmt.Sprintf(`SELECT id, uuid, write_key, event_type, event_model_identifier, created_at, schema, private_data, total_count, last_seen, (metadata->>'TotalCount')::int, metadata->'SampledEvents' FROM %s %s`, EVENT_MODELS_TABLE, uuidFilter)
+	eventModelsSelectSQL := fmt.Sprintf(`SELECT id, uuid, write_key, event_type, event_model_identifier, created_at, schema, private_data, total_count, last_seen, (metadata->>'TotalCount')::bigint, metadata->'SampledEvents' FROM %s %s`, EVENT_MODELS_TABLE, uuidFilter)
 
 	rows, err := manager.dbHandle.Query(eventModelsSelectSQL)
 	if err == sql.ErrNoRows {


### PR DESCRIPTION
# Description

The event schema tables have a metadata column which contains a TotalCount field. This was being casted to a 32 bit integer. We exceeded those limits for one of our customers resulting in the value of TotalCount to be greater that the 32 bit integer range, and leading to a subsequent crash in the server pod. The SQL query has been modified to cast that into a 64 bit integer field.