### PR TITLE
fix: warehouse sync job queries for snowflake and bigquery

### DIFF
--- a/warehouse/bigquery/bigquery.go
+++ b/warehouse/bigquery/bigquery.go
@@ -239,14 +239,19 @@ func (bq *HandleT) dropStagingTable(stagingTableName string) {
 
 func (bq *HandleT) DeleteBy(tableNames []string, params warehouseutils.DeleteByParams) error {
 	pkgLogger.Infof("BQ: Cleaning up the following tables in bigquery for BQ:%s : %v", tableNames)
+
 	for _, tb := range tableNames {
-		sqlStatement := fmt.Sprintf(`DELETE FROM "%[1]s"."%[2]s" WHERE
-		context_sources_job_run_id <> @jobrunid AND
-		context_sources_task_run_id <> @taskrunid AND
-		context_source_id = @sourceid AND
-		received_at < @starttime`,
-			bq.namespace,
-			tb,
+		tableName := fmt.Sprintf("`%s`.`%s`", bq.namespace, tb)
+		sqlStatement := fmt.Sprintf(`
+			DELETE FROM
+				%[1]s
+			WHERE
+				context_sources_job_run_id <> @jobrunid AND
+				context_sources_task_run_id <> @taskrunid AND
+				context_source_id = @sourceid AND
+				received_at < @starttime;
+			`,
+			tableName,
 		)
 
 		pkgLogger.Infof("PG: Deleting rows in table in bigquery for BQ:%s", bq.warehouse.Destination.ID)
@@ -273,7 +278,6 @@ func (bq *HandleT) DeleteBy(tableNames []string, params warehouseutils.DeleteByP
 				return status.Err()
 			}
 		}
-
 	}
 	return nil
 }

--- a/warehouse/jobs/handlers.go
+++ b/warehouse/jobs/handlers.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // AddWarehouseJobHandler The following handler gets called for adding async
@@ -51,35 +52,40 @@ func (a *AsyncJobWhT) AddWarehouseJobHandler(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "Error extracting tableNames", http.StatusBadRequest)
 		return
 	}
+
 	var jobIds []int64
 	// Add to wh_async_job queue each of the tables
 	for _, th := range tableNames {
-		if !skipTable(th) {
-			jobsMetaData := WhJobsMetaData{
-				JobRunID:  startJobPayload.JobRunID,
-				TaskRunID: startJobPayload.TaskRunID,
-				StartTime: startJobPayload.StartTime,
-				JobType:   AsyncJobType,
-			}
-			metadataJson, err := json.Marshal(jobsMetaData)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			payload := AsyncJobPayloadT{
-				SourceID:      startJobPayload.SourceID,
-				DestinationID: startJobPayload.DestinationID,
-				TableName:     th,
-				AsyncJobType:  startJobPayload.AsyncJobType,
-				MetaData:      metadataJson,
-			}
-			id, err := a.addJobsToDB(a.context, &payload)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			jobIds = append(jobIds, id)
+
+		switch strings.ToLower(th) {
+		case "rudder_discards", "rudder_identity_mappings", "rudder_identity_merge_rules":
+			continue
 		}
+
+		jobsMetaData := WhJobsMetaData{
+			JobRunID:  startJobPayload.JobRunID,
+			TaskRunID: startJobPayload.TaskRunID,
+			StartTime: startJobPayload.StartTime,
+			JobType:   AsyncJobType,
+		}
+		metadataJson, err := json.Marshal(jobsMetaData)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		payload := AsyncJobPayloadT{
+			SourceID:      startJobPayload.SourceID,
+			DestinationID: startJobPayload.DestinationID,
+			TableName:     th,
+			AsyncJobType:  startJobPayload.AsyncJobType,
+			MetaData:      metadataJson,
+		}
+		id, err := a.addJobsToDB(a.context, &payload)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		jobIds = append(jobIds, id)
 	}
 	whAddJobResponse := WhAddJobResponse{
 		JobIds: jobIds,

--- a/warehouse/jobs/utils.go
+++ b/warehouse/jobs/utils.go
@@ -38,13 +38,6 @@ func validatePayload(payload StartJobReqPayload) bool {
 	return true
 }
 
-func skipTable(th string) bool {
-	if th == "RUDDER_DISCARDS" || th == "rudder_discards" {
-		return true
-	}
-	return false
-}
-
 func contains(sArray []string, s string) bool {
 	for _, s1 := range sArray {
 		if s1 == s {


### PR DESCRIPTION
# Description

We are getting the following error for BQ and SNOWFLAKE destinations for the Async Job Framework.

### For BigQuery
> ERROR	warehouse.bigquery	bigquery/bigquery.go:269	BQ: Error running job: googleapi: Error 400: Syntax error: Unexpected string literal "bwh_e_470_edf_7_0547_4_bf_3_b_896_29_cd_08_c_289..." at [1:13], invalidQuery

### For Snowflake
> 000904 (42000): SQL compilation error: error line 2 at position 2
> invalid identifier 'CONTEXT_SOURCES_JOB_RUN_ID'
> 
> 002049 (42601): SQL compilation error: error line 2 at position 32
> Bind variable:jobrunid not set.

## Notion Ticket

https://www.notion.so/rudderstacks/Async-JOB-Queries-are-failing-with-BigQuery-and-Snowflake-c1edd033a228426eb6d5108311152ddc

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
