### PR TITLE
feat: add support for request payloads using gzip content-encoding

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1447,6 +1447,7 @@ func (gateway *HandleT) StartWebHandler(ctx context.Context) error {
 	srvMux.Use(
 		middleware.StatMiddleware(ctx, srvMux, stats.Default, component),
 		middleware.LimitConcurrentRequests(maxConcurrentRequests),
+		middleware.UncompressMiddleware,
 	)
 	srvMux.HandleFunc("/v1/batch", gateway.webBatchHandler).Methods("POST")
 	srvMux.HandleFunc("/v1/identify", gateway.webIdentifyHandler).Methods("POST")

--- a/middleware/uncompress.go
+++ b/middleware/uncompress.go
@@ -1,0 +1,44 @@
+package middleware
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+)
+
+// UncompressMiddleware uncompresses gzipped HTTP requests carrying a 'Content-Encoding: gzip' header.
+var UncompressMiddleware = func(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Encoding") == "gzip" {
+			r.Body = &gzipReader{body: r.Body}
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
+// gzipReader wraps a response body so it can lazily
+// call gzip.NewReader on the first call to Read
+type gzipReader struct {
+	body io.ReadCloser // underlying request body
+	zr   *gzip.Reader  // lazily-initialized gzip reader
+	zerr error         // any error from gzip.NewReader; sticky
+}
+
+func (gz *gzipReader) Read(p []byte) (n int, err error) {
+	if gz.zr == nil {
+		if gz.zerr == nil {
+			gz.zr, gz.zerr = gzip.NewReader(gz.body)
+		}
+		if gz.zerr != nil {
+			return 0, gz.zerr
+		}
+	}
+	return gz.zr.Read(p)
+}
+
+func (gz *gzipReader) Close() error {
+	if gz.zr != nil {
+		_ = gz.zr.Close()
+	}
+	return gz.body.Close()
+}

--- a/middleware/uncompress.go
+++ b/middleware/uncompress.go
@@ -16,7 +16,7 @@ var UncompressMiddleware = func(h http.Handler) http.Handler {
 	})
 }
 
-// gzipReader wraps a response body so it can lazily
+// gzipReader wraps a body so it can lazily
 // call gzip.NewReader on the first call to Read
 type gzipReader struct {
 	body io.ReadCloser // underlying request body

--- a/middleware/uncompress_test.go
+++ b/middleware/uncompress_test.go
@@ -1,0 +1,83 @@
+package middleware_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rudderlabs/rudder-server/middleware"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUncompress(t *testing.T) {
+	json := `{"key": "value"}`
+
+	handler := middleware.UncompressMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, r.Body.Close())
+		fmt.Println(string(b))
+		require.NoError(t, err)
+		_, err = w.Write(b)
+		require.NoError(t, err)
+	}))
+
+	getGzipBody := func() *bytes.Buffer {
+		var gzippedJson bytes.Buffer
+		gz := gzip.NewWriter(&gzippedJson)
+		_, err := gz.Write([]byte(json))
+		require.NoError(t, err)
+		require.NoError(t, gz.Close())
+		return &gzippedJson
+	}
+
+	t.Run("sending a gzipped body with a Content-Encoding header", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/test", getGzipBody())
+		require.NoError(t, err)
+		req.Header.Set("Content-Encoding", "gzip")
+		res := httptest.NewRecorder()
+
+		handler.ServeHTTP(res, req)
+
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, json, res.Body.String(), "handler should receive the uncompressed body")
+	})
+
+	t.Run("sending a non-gzipped body without a Content-Encoding header", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/test", strings.NewReader(json))
+		require.NoError(t, err)
+		res := httptest.NewRecorder()
+
+		handler.ServeHTTP(res, req)
+
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, json, res.Body.String(), "handler should receive the non-compressed body")
+	})
+
+	t.Run("sending a gzipped body but without a Content-Encoding header", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/test", getGzipBody())
+		require.NoError(t, err)
+		res := httptest.NewRecorder()
+
+		handler.ServeHTTP(res, req)
+
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, getGzipBody().Bytes(), res.Body.Bytes(), "handler should receive the compressed body")
+	})
+
+	t.Run("sending a non-gzipped body but with a Content-Encoding header", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/test", strings.NewReader(json))
+		require.NoError(t, err)
+		res := httptest.NewRecorder()
+
+		handler.ServeHTTP(res, req)
+
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, json, res.Body.String(), "handler should receive the non-compressed body")
+	})
+}


### PR DESCRIPTION
# Description

Adding support for accepting requests using a gzipped body along with the appropriate `Content-Encoding: gzip` header.
Compressed request bodies are being uncompressed lazily and in a streaming fashion.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=e46c493fa108495cb6b9c85ad7594409&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
