### PR TITLE
chore: set max connections to readonly jobsdbs

### DIFF
--- a/jobsdb/readonly_jobsdb.go
+++ b/jobsdb/readonly_jobsdb.go
@@ -90,7 +90,6 @@ Setup is used to initialize the ReadonlyHandleT structure.
 */
 func (jd *ReadonlyHandleT) Setup(tablePrefix string) error {
 	jd.logger = pkgLogger.Child("readonly-" + tablePrefix)
-
 	var err error
 	psqlInfo := misc.GetConnectionString()
 	jd.tablePrefix = tablePrefix


### PR DESCRIPTION
# Description

Set max connections to readonly jobsdbs to prevent exhausting all the available connections.

## Notion Ticket

https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=a0094efc17da43c1a552d5ab636aa4a9&pm=s

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
