### PR TITLE
chore: ensure internal migration of large job-status datasets

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -651,6 +651,7 @@ var (
 	backupRowsBatchSize                          int64
 	backupMaxTotalPayloadSize                    int64
 	pkgLogger                                    logger.Logger
+	safegaurdMigration                           bool
 )
 
 // Loads db config and migration related config from config file
@@ -684,6 +685,7 @@ func loadConfig() {
 	config.RegisterDurationConfigVariable(5, &refreshDSListLoopSleepDuration, true, time.Second, []string{"JobsDB.refreshDSListLoopSleepDuration", "JobsDB.refreshDSListLoopSleepDurationInS"}...)
 	config.RegisterDurationConfigVariable(5, &backupCheckSleepDuration, true, time.Second, []string{"JobsDB.backupCheckSleepDuration", "JobsDB.backupCheckSleepDurationIns"}...)
 	config.RegisterDurationConfigVariable(5, &cacheExpiration, true, time.Minute, []string{"JobsDB.cacheExpiration"}...)
+	config.RegisterBoolConfigVariable(false, &safegaurdMigration, true, "JobsDB.safegaurdMigration")
 }
 
 func Init2() {

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -651,7 +651,7 @@ var (
 	backupRowsBatchSize                          int64
 	backupMaxTotalPayloadSize                    int64
 	pkgLogger                                    logger.Logger
-	safegaurdMigration                           bool
+	jobStatusCountMigrationCheck                 bool // TODO: Remove this in next release
 )
 
 // Loads db config and migration related config from config file
@@ -685,7 +685,7 @@ func loadConfig() {
 	config.RegisterDurationConfigVariable(5, &refreshDSListLoopSleepDuration, true, time.Second, []string{"JobsDB.refreshDSListLoopSleepDuration", "JobsDB.refreshDSListLoopSleepDurationInS"}...)
 	config.RegisterDurationConfigVariable(5, &backupCheckSleepDuration, true, time.Second, []string{"JobsDB.backupCheckSleepDuration", "JobsDB.backupCheckSleepDurationIns"}...)
 	config.RegisterDurationConfigVariable(5, &cacheExpiration, true, time.Minute, []string{"JobsDB.cacheExpiration"}...)
-	config.RegisterBoolConfigVariable(false, &safegaurdMigration, true, "JobsDB.safegaurdMigration")
+	config.RegisterBoolConfigVariable(false, &jobStatusCountMigrationCheck, true, "JobsDB.jobStatusCountMigrationCheck")
 }
 
 func Init2() {

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -433,13 +433,6 @@ func (jd *HandleT) checkIfMigrateDS(ds dataSetT) (
 		jd.assertError(err)
 	}
 
-	if totalCount == 0 {
-		jd.assert(
-			delCount == 0,
-			fmt.Sprintf("delCount: %d. Is not 0", delCount))
-		return false, false, 0
-	}
-
 	recordsLeft = totalCount - delCount
 
 	if jd.MinDSRetentionPeriod > 0 {


### PR DESCRIPTION
# Description

The status compaction step during `migrateDSLoop` might sometimes miss compacting some DSs due to some level of inaccuracy in postgres estimates. With `jobsdb. jobStatusCountMigrationCheck` flag, we can ensure that we check for status overload in a DS again(during `checkIfMigrateDS`) to ensure that DS is migrated(this time based on actual row count instead of estimates).

This behaviour is disabled by default.

## Notion Ticket

https://www.notion.so/rudderstacks/add-safeguard-for-status-estimates-during-migration-03be2fe46b134333b194d450048b9331

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
