### PR TITLE
chore: advertise server features in version endpoint

### DIFF
--- a/info/features.go
+++ b/info/features.go
@@ -9,7 +9,7 @@ type Component struct {
 var ServerComponent = Component{
 	Name: "server",
 	Features: []string{
-		"features",
+		"gzip-req-payload",
 	},
 }
 

--- a/integration_test/multi_tentant_test/testdata/expected_features.json
+++ b/integration_test/multi_tentant_test/testdata/expected_features.json
@@ -2,7 +2,7 @@
     "components": [
         {
             "name": "server",
-            "features": ["features"]
+            "features": ["gzip-req-payload"]
         }
     ]
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -391,6 +391,7 @@ func (r *Runner) versionInfo() map[string]interface{} {
 		"GitUrl":             r.releaseInfo.GitURL,
 		"TransformerVersion": transformer.GetVersion(),
 		"DatabricksVersion":  misc.GetDatabricksVersion(),
+		"Features":           info.ServerComponent.Features,
 	}
 }
 


### PR DESCRIPTION
# Description

Server features are now included in the `/version` endpoint to allow for SDK clients to have an easy way to discover whether the data plane they are sending events to supports (or not) a specific feature.

The first use case is `gzip-req-payload`, i.e. the ability of rudder-server to uncompress gzipped request payloads of requests carrying the `Content-Encoding: gzip` header.

Before any SDK starts compressing its request payloads using gzip, it needs to first make sure that the data plane that is going to receive these requests supports gzipped requests. Thus the SDK needs to perform a `GET /version` request, discover the server's features, configure itself accordingly and then start sending events.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=7259c23f616845949d0c46b754016e56&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
