### PR TITLE
fix: removed quote Identifier on sourceDestId

### DIFF
--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -1607,7 +1607,6 @@ func pendingEventsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func getPendingStagingFileCount(sourceOrDestId string, isSourceId bool) (fileCount int64, err error) {
-	sourceOrDestId = pq.QuoteIdentifier(sourceOrDestId)
 	sourceOrDestColumn := ""
 	if isSourceId {
 		sourceOrDestColumn = "source_id"


### PR DESCRIPTION
# Description
 Quote Identifier on sourceOrDestId is constructing a wrong SQL query resulting incorrect value for pendingstagingcount

## Notion Ticket

< Replace with Notion Link >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
