### PR TITLE
chore: remove deepsource badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@
   <a href="https://goreportcard.com/report/github.com/rudderlabs/rudder-server">
     <img src="https://goreportcard.com/badge/github.com/rudderlabs/rudder-server">
   </a>
-  <a href="https://deepsource.io/gh/rudderlabs/rudder-server/?ref=repository-badge}" target="_blank">
-    <img alt="DeepSource" title="DeepSource" src="https://deepsource.io/gh/rudderlabs/rudder-server.svg/?label=active+issues&show_trend=true&token=D0StFW4hMiC1YMmYQWyS7PQQ"/>
-  </a>
   <a href="https://github.com/rudderlabs/rudder-server/releases">
     <img src="https://img.shields.io/github/v/release/rudderlabs/rudder-server?color=blue&sort=semver">
   </a>


### PR DESCRIPTION
# Description

Removing deepsource badge.

## Notion Ticket

https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=003374f5d83f4a598d07142c6bfa6123&pm=s

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
