### PR TITLE
chore(warehouse): added support to fetch the ssh keys on destination level from control plane

### DIFF
--- a/config/backend-config/types.go
+++ b/config/backend-config/types.go
@@ -52,6 +52,12 @@ type DestinationT struct {
 	Transformations       []TransformationT
 	IsProcessorEnabled    bool
 	RevisionID            string
+	Tunnel                *Tunnelling
+}
+
+type Tunnelling struct {
+	Type   string
+	Config map[string]string
 }
 
 type SourceT struct {

--- a/warehouse/client/controlplane/client.go
+++ b/warehouse/client/controlplane/client.go
@@ -1,0 +1,99 @@
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type PublicPrivateKeyPair struct {
+	PublicKey  string
+	PrivateKey string
+}
+
+type BasicAuth struct {
+	Username string
+	Password string
+}
+
+type CPInternalAPI interface {
+	GetDestinationSSHKeys(ctx context.Context, id string) (*PublicPrivateKeyPair, error)
+}
+
+type cachedControlPlaneAPIImpl struct {
+	cpAPI CPInternalAPI
+	cache map[string]*PublicPrivateKeyPair
+}
+
+func NewControlPlaneAPI(baseURI string, auth BasicAuth) CPInternalAPI {
+	return &controlPlaneAPIImpl{
+		baseURI: baseURI,
+		auth:    auth,
+	}
+}
+
+type controlPlaneAPIImpl struct {
+	baseURI string
+	auth    BasicAuth
+}
+
+func (api *controlPlaneAPIImpl) GetDestinationSSHKeys(ctx context.Context, id string) (*PublicPrivateKeyPair, error) {
+	url := fmt.Sprintf("%s/dataplane/admin/destinations/%s/sshKeys", api.baseURI, id)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating new request with ctx: %w", err)
+	}
+
+	req.SetBasicAuth(
+		api.auth.Username,
+		api.auth.Password)
+
+	client := http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching response from http client: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return nil, nil
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("invalid status code: %d", resp.StatusCode)
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+
+	keypair := PublicPrivateKeyPair{}
+	if err := decoder.Decode(&keypair); err != nil {
+		return nil, fmt.Errorf("decoding upstream response body: %w", err)
+	}
+
+	return &keypair, nil
+}
+
+func NewCachedControlPlaneAPI(baseURI string, auth BasicAuth) CPInternalAPI {
+	apiClient := NewControlPlaneAPI(baseURI, auth)
+	return &cachedControlPlaneAPIImpl{
+		cpAPI: apiClient,
+		cache: make(map[string]*PublicPrivateKeyPair),
+	}
+}
+
+func (api *cachedControlPlaneAPIImpl) GetDestinationSSHKeys(ctx context.Context, id string) (*PublicPrivateKeyPair, error) {
+	if val, ok := api.cache[id]; ok {
+		return val, nil
+	}
+
+	keyPair, err := api.cpAPI.GetDestinationSSHKeys(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("fetching and caching destination ssh keys: %w", err)
+	}
+
+	api.cache[id] = keyPair
+	return keyPair, nil
+}

--- a/warehouse/client/controlplane/client.go
+++ b/warehouse/client/controlplane/client.go
@@ -49,6 +49,7 @@ func (api *internalClient) GetDestinationSSHKeys(ctx context.Context, id string)
 	}
 
 	req.SetBasicAuth(api.auth.Username, api.auth.Password)
+	req.Header.Set("Content-Type", "application/json")
 
 	client := http.Client{}
 	resp, err := client.Do(req)

--- a/warehouse/client/controlplane/client_test.go
+++ b/warehouse/client/controlplane/client_test.go
@@ -1,0 +1,82 @@
+package controlplane_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cp "github.com/rudderlabs/rudder-server/warehouse/client/controlplane"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchSSHKeys(t *testing.T) {
+	t.Log("running tests to fetch the ssh keys")
+
+	testcases := []struct {
+		name            string
+		responseBody    string
+		responseCode    int
+		destinationID   string
+		expectedError   error
+		expectedKeyPair *cp.PublicPrivateKeyPair
+	}{
+		{
+			name:          "fetch ssh keys returns the keys correctly",
+			responseBody:  `{"publicKey": "public_key", "privateKey": "private_key"}`,
+			responseCode:  http.StatusOK,
+			destinationID: "id",
+			expectedError: nil,
+			expectedKeyPair: &cp.PublicPrivateKeyPair{
+				PublicKey:  "public_key",
+				PrivateKey: "private_key",
+			},
+		},
+		{
+			name:            "fetch ssh keys returns no keys found",
+			responseBody:    ``,
+			responseCode:    http.StatusNotFound,
+			destinationID:   "id",
+			expectedError:   nil,
+			expectedKeyPair: nil,
+		},
+		{
+			name:            "fetch ssh keys fails unexpectedly",
+			responseBody:    ``,
+			responseCode:    http.StatusInternalServerError,
+			destinationID:   "id",
+			expectedError:   errors.New("invalid status code: 500"),
+			expectedKeyPair: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			svc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _, ok := r.BasicAuth()
+				require.True(t, ok)
+				require.Equal(t, http.MethodGet, r.Method)
+				require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+				w.WriteHeader(tc.responseCode)
+				w.Write([]byte(tc.responseBody))
+			}))
+
+			defer svc.Close()
+
+			client := cp.NewInternalClient(svc.URL, cp.BasicAuth{
+				Username: "username",
+				Password: "password",
+			})
+
+			keys, err := client.GetDestinationSSHKeys(context.TODO(), tc.destinationID)
+			require.Equal(t, tc.expectedError, err)
+			require.Equal(t, tc.expectedKeyPair, keys)
+		})
+	}
+
+}

--- a/warehouse/client/controlplane/client_test.go
+++ b/warehouse/client/controlplane/client_test.go
@@ -55,7 +55,6 @@ func TestFetchSSHKeys(t *testing.T) {
 
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-
 			svc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				_, _, ok := r.BasicAuth()
 				require.True(t, ok)
@@ -78,5 +77,4 @@ func TestFetchSSHKeys(t *testing.T) {
 			require.Equal(t, tc.expectedKeyPair, keys)
 		})
 	}
-
 }

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -292,7 +292,7 @@ func (wh *HandleT) backendConfigSubscriber(ctx context.Context) {
 		wh.workspaceBySourceIDsLock.Lock()
 		wh.workspaceBySourceIDs = map[string]string{}
 
-		controlPlaneAPI := cpclient.NewCachedControlPlaneAPI(
+		controlPlaneAPI := cpclient.NewInternalClientWithCache(
 			wh.configBackendURL,
 			wh.internalAuth)
 

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -2130,17 +2130,3 @@ func Start(ctx context.Context, app app.App) error {
 
 	return g.Wait()
 }
-
-func fetchSecrets(ctx context.Context, manager *multitenant.Manager) {
-	confCh := manager.WatchConfig(ctx)
-
-	for data := range confCh {
-		for workspaceId, workspaceConfig := range data {
-		}
-	}
-
-}
-
-type SecretManager interface {
-	GetDestinationKeyPair(ctx context.Context, Id string) (*PublicPrivateKeyPair, error)
-}

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -309,6 +309,7 @@ func (wh *HandleT) backendConfigSubscriber(ctx context.Context) {
 					continue
 				}
 				for idx, destination := range source.Destinations {
+
 					if destination.DestinationDefinition.Name != wh.destType {
 						continue
 					}
@@ -322,8 +323,13 @@ func (wh *HandleT) backendConfigSubscriber(ctx context.Context) {
 							pkgLogger.Warnf("fetching ssh keypair for destination: %s err: %w", destination.ID, err)
 						}
 
-						source.Destinations[idx].Tunnel.Config["private_key"] = keypair.PrivateKey
-						source.Destinations[idx].Tunnel.Config["public_key"] = keypair.PublicKey
+						if keypair == nil {
+							pkgLogger.Warnf("unable to locate keypair for destination: %s with valid tunnel info", destination.ID)
+						} else {
+							source.Destinations[idx].Tunnel.Config["private_key"] = keypair.PrivateKey
+							source.Destinations[idx].Tunnel.Config["public_key"] = keypair.PublicKey
+						}
+
 					}
 
 					namespace := wh.getNamespace(destination.Config, source, destination, wh.destType)

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -901,7 +901,7 @@ func (wh *HandleT) getUploadsToProcess(ctx context.Context, availableWorkers int
 			&lastEventAt,
 		)
 		if err != nil {
-			panic(fmt.Errorf("Failed to scan result from query: %s\nwith Error : %w", sqlStatement, err))
+			panic(fmt.Errorf("failed to scan result from query: %s\n with error : %w", sqlStatement, err))
 		}
 		upload.FirstEventAt = firstEventAt.Time
 		upload.LastEventAt = lastEventAt.Time
@@ -1223,7 +1223,7 @@ func (wh *HandleT) setInterruptedDestinations() {
 		var destID string
 		err := rows.Scan(&destID)
 		if err != nil {
-			panic(fmt.Errorf("Failed to scan result from query: %s\nwith Error : %w", sqlStatement, err))
+			panic(fmt.Errorf("failed to scan result from query: %s\nwith error : %w", sqlStatement, err))
 		}
 		inRecoveryMap[destID] = true
 	}


### PR DESCRIPTION
# Description
We have introduced an internal endpoint in control plane to allow for fetching the public private keypair at the destination level. As part of the change:

1. **Controlplane API Client**: We added a client for control plane API and also a cached client for the same. The purpose of the cached client is to prevent us to make network call everytime to fetch the secrets as it doesn't change that frequently.

2. **Warehouse Destination Data Augmentation**: Augmented the information of destination object by adding private and public keys into the config.

## Notion Ticket

https://www.notion.so/rudderstacks/Add-logic-to-fetch-keypair-from-control-plane-in-warehouse-while-fetching-backend-config-9e66144e05944ddfb26f782e7534c7a4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
