### PR TITLE
chore: remove redundant/duplicate add_ds distributed lock

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -2724,7 +2724,6 @@ Other functions are impacted by movement of data across DS in background
 so take both the list and data lock
 */
 func (jd *HandleT) addNewDSLoop(ctx context.Context) {
-	advisoryLock := jd.getAdvisoryLockForOperation("add_ds")
 	for {
 		select {
 		case <-ctx.Done():
@@ -2739,13 +2738,7 @@ func (jd *HandleT) addNewDSLoop(ctx context.Context) {
 		err := jd.WithTx(func(tx *Tx) error {
 			return jd.withDistributedSharedLock(context.TODO(), tx, "schema_migrate", func() error { // cannot run while schema migration is running
 				return jd.withDistributedLock(context.TODO(), tx, "add_ds", func() error { // only one add_ds can run at a time
-					// acquire a advisory transaction level blocking lock, which is released once the transaction ends.
-					sqlStatement := fmt.Sprintf(`SELECT pg_advisory_xact_lock(%d);`, advisoryLock)
-					_, err := tx.ExecContext(context.TODO(), sqlStatement)
-					if err != nil {
-						return fmt.Errorf("error while acquiring advisory lock %d: %w", advisoryLock, err)
-					}
-
+					var err error
 					// We acquire the list lock only after we have acquired the advisory lock.
 					// We will release the list lock after the transaction ends, that's why we need to use an async lock
 					dsListLock, releaseDsListLock, err = jd.dsListLock.AsyncLockWithCtx(ctx)


### PR DESCRIPTION
# Description

The `add_ds` advisory lock is already acquired, thus removing the second lock statement.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=accc62687a574edbb6b4bcff120107b5&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
