### PR TITLE
chore: remove shopify autoreload

### DIFF
--- a/gateway/webhook/configuration.go
+++ b/gateway/webhook/configuration.go
@@ -22,7 +22,7 @@ func loadConfig() {
 	// Max retry attempts to source transformer
 	config.RegisterIntConfigVariable(5, &webhookRetryMax, false, 1, "Gateway.webhook.maxRetry")
 	// Parse all query params from sources mentioned in this list
-	config.RegisterStringSliceConfigVariable(make([]string, 0), &sourceListForParsingParams, true, "Gateway.webhook.sourceListForParsingParams")
+	config.RegisterStringSliceConfigVariable(make([]string, 0), &sourceListForParsingParams, false, "Gateway.webhook.sourceListForParsingParams")
 	// lowercasing the strings in sourceListForParsingParams
 	for i, s := range sourceListForParsingParams {
 		sourceListForParsingParams[i] = strings.ToLower(s)


### PR DESCRIPTION
# Description

Making sourceListForParsingParams non hot reloadable

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
