### PR TITLE
fix: remove schema from stage file model

### DIFF
--- a/warehouse/internal/api/http_test.go
+++ b/warehouse/internal/api/http_test.go
@@ -22,11 +22,11 @@ import (
 )
 
 type memRepo struct {
-	files []model.StagingFile
+	files []model.StagingFileWithSchema
 	err   error
 }
 
-func (m *memRepo) Insert(_ context.Context, stagingFile *model.StagingFile) (int64, error) {
+func (m *memRepo) Insert(_ context.Context, stagingFile *model.StagingFileWithSchema) (int64, error) {
 	if m.err != nil {
 		return 0, m.err
 	}
@@ -56,16 +56,18 @@ func filterPayload(text, match string) string {
 
 func TestAPI_Process(t *testing.T) {
 	body := loadFile(t, "./testdata/process_request.json")
-	expectedStagingFile := model.StagingFile{
-		WorkspaceID:           "279L3V7FSpx43LaNJ0nIs9KRaNC",
-		Schema:                json.RawMessage("{\"product_track\":{\"context_destination_id\":\"string\",\"context_destination_type\":\"string\",\"context_ip\":\"string\",\"context_library_name\":\"string\",\"context_passed_ip\":\"string\",\"context_request_ip\":\"string\",\"context_source_id\":\"string\",\"context_source_type\":\"string\",\"event\":\"string\",\"event_text\":\"string\",\"id\":\"string\",\"original_timestamp\":\"datetime\",\"product_id\":\"string\",\"rating\":\"int\",\"received_at\":\"datetime\",\"revenue\":\"float\",\"review_body\":\"string\",\"review_id\":\"string\",\"sent_at\":\"datetime\",\"timestamp\":\"datetime\",\"user_id\":\"string\",\"uuid_ts\":\"datetime\"},\"tracks\":{\"context_destination_id\":\"string\",\"context_destination_type\":\"string\",\"context_ip\":\"string\",\"context_library_name\":\"string\",\"context_passed_ip\":\"string\",\"context_request_ip\":\"string\",\"context_source_id\":\"string\",\"context_source_type\":\"string\",\"event\":\"string\",\"event_text\":\"string\",\"id\":\"string\",\"original_timestamp\":\"datetime\",\"received_at\":\"datetime\",\"sent_at\":\"datetime\",\"timestamp\":\"datetime\",\"user_id\":\"string\",\"uuid_ts\":\"datetime\"}}"),
-		Location:              "rudder-warehouse-staging-logs/279L3gEKqwruBoKGsXZtSVX7vIy/2022-11-08/1667913810.279L3gEKqwruBoKGsXZtSVX7vIy.7a6e7785-7a75-4345-8d3c-d7a1ce49a43f.json.gz",
-		SourceID:              "279L3gEKqwruBoKGsXZtSVX7vIy",
-		DestinationID:         "27CHciD6leAhurSyFAeN4dp14qZ",
-		DestinationRevisionID: "2H1cLBvL3v0prRBNzpe8D34XTzU",
-		FirstEventAt:          time.Date(2022, time.November, 8, 13, 23, 7, 0, time.UTC),
-		LastEventAt:           time.Date(2022, time.November, 8, 13, 23, 7, 0, time.UTC),
-		TotalEvents:           2,
+	expectedStagingFile := model.StagingFileWithSchema{
+		StagingFile: model.StagingFile{
+			WorkspaceID:           "279L3V7FSpx43LaNJ0nIs9KRaNC",
+			Location:              "rudder-warehouse-staging-logs/279L3gEKqwruBoKGsXZtSVX7vIy/2022-11-08/1667913810.279L3gEKqwruBoKGsXZtSVX7vIy.7a6e7785-7a75-4345-8d3c-d7a1ce49a43f.json.gz",
+			SourceID:              "279L3gEKqwruBoKGsXZtSVX7vIy",
+			DestinationID:         "27CHciD6leAhurSyFAeN4dp14qZ",
+			DestinationRevisionID: "2H1cLBvL3v0prRBNzpe8D34XTzU",
+			FirstEventAt:          time.Date(2022, time.November, 8, 13, 23, 7, 0, time.UTC),
+			LastEventAt:           time.Date(2022, time.November, 8, 13, 23, 7, 0, time.UTC),
+			TotalEvents:           2,
+		},
+		Schema: json.RawMessage("{\"product_track\":{\"context_destination_id\":\"string\",\"context_destination_type\":\"string\",\"context_ip\":\"string\",\"context_library_name\":\"string\",\"context_passed_ip\":\"string\",\"context_request_ip\":\"string\",\"context_source_id\":\"string\",\"context_source_type\":\"string\",\"event\":\"string\",\"event_text\":\"string\",\"id\":\"string\",\"original_timestamp\":\"datetime\",\"product_id\":\"string\",\"rating\":\"int\",\"received_at\":\"datetime\",\"revenue\":\"float\",\"review_body\":\"string\",\"review_id\":\"string\",\"sent_at\":\"datetime\",\"timestamp\":\"datetime\",\"user_id\":\"string\",\"uuid_ts\":\"datetime\"},\"tracks\":{\"context_destination_id\":\"string\",\"context_destination_type\":\"string\",\"context_ip\":\"string\",\"context_library_name\":\"string\",\"context_passed_ip\":\"string\",\"context_request_ip\":\"string\",\"context_source_id\":\"string\",\"context_source_type\":\"string\",\"event\":\"string\",\"event_text\":\"string\",\"id\":\"string\",\"original_timestamp\":\"datetime\",\"received_at\":\"datetime\",\"sent_at\":\"datetime\",\"timestamp\":\"datetime\",\"user_id\":\"string\",\"uuid_ts\":\"datetime\"}}"),
 	}
 
 	testcases := []struct {
@@ -74,7 +76,7 @@ func TestAPI_Process(t *testing.T) {
 		degradedWorkspaceIDs []string
 		storeErr             error
 
-		storage []model.StagingFile
+		storage []model.StagingFileWithSchema
 
 		respBody string
 		respCode int
@@ -83,7 +85,7 @@ func TestAPI_Process(t *testing.T) {
 			name:    "normal process request",
 			reqBody: body,
 
-			storage: []model.StagingFile{expectedStagingFile},
+			storage: []model.StagingFileWithSchema{expectedStagingFile},
 
 			respCode: http.StatusOK,
 		},

--- a/warehouse/internal/model/staging.go
+++ b/warehouse/internal/model/staging.go
@@ -9,14 +9,13 @@ import (
 //
 //	The staging file contains events that should be loaded into a warehouse.
 //	It is located in a cloud storage bucket.
-//	The model includes ownership, file location, schema for included events, and other metadata.
+//	The model includes ownership, file location, and other metadata.
 type StagingFile struct {
 	ID                    int64
 	WorkspaceID           string
 	Location              string
 	SourceID              string
 	DestinationID         string
-	Schema                json.RawMessage
 	Status                string // enum
 	Error                 error
 	FirstEventAt          time.Time
@@ -34,4 +33,19 @@ type StagingFile struct {
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
+}
+
+// StagingFileWithSchema is a StagingFile with schema field for included events.
+//
+//	schema size can be really big, and thus it should be included only when required.
+type StagingFileWithSchema struct {
+	StagingFile
+	Schema json.RawMessage
+}
+
+func (s StagingFile) WithSchema(schema json.RawMessage) StagingFileWithSchema {
+	return StagingFileWithSchema{
+		StagingFile: s,
+		Schema:      schema,
+	}
 }

--- a/warehouse/internal/model/staging_test.go
+++ b/warehouse/internal/model/staging_test.go
@@ -1,0 +1,42 @@
+package model_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStagingFile_Builder(t *testing.T) {
+	now := time.Now()
+
+	stagingFile := model.StagingFile{
+		ID:                    1,
+		WorkspaceID:           "workspace_id",
+		Location:              "s3://path",
+		SourceID:              "source_id",
+		DestinationID:         "destination_id",
+		Status:                "waiting",
+		Error:                 nil,
+		FirstEventAt:          now,
+		LastEventAt:           now,
+		UseRudderStorage:      false,
+		DestinationRevisionID: "",
+		TotalEvents:           0,
+		SourceBatchID:         "",
+		SourceTaskID:          "",
+		SourceTaskRunID:       "",
+		SourceJobID:           "",
+		SourceJobRunID:        "",
+		TimeWindow:            time.Time{},
+		CreatedAt:             now,
+		UpdatedAt:             now,
+	}
+	wSchema := stagingFile.WithSchema([]byte("test"))
+
+	require.Equal(t, model.StagingFileWithSchema{
+		StagingFile: stagingFile,
+		Schema:      []byte("test"),
+	}, wSchema)
+}

--- a/warehouse/types.go
+++ b/warehouse/types.go
@@ -52,32 +52,6 @@ type LoadFileJobT struct {
 	TableToBucketFolderMapLock *sync.RWMutex
 }
 
-// type StagingFileT struct {
-// 	ID                    int64
-// 	WorkspaceID           string
-// 	Location              string
-// 	SourceID              string
-// 	DestinationID         string
-// 	Schema                json.RawMessage
-// 	Status                string // enum
-// 	Error                 error
-// 	FirstEventAt          time.Time
-// 	LastEventAt           time.Time
-// 	UseRudderStorage      bool
-// 	DestinationRevisionID string
-// 	TotalEvents           int
-// 	// cloud sources specific info
-// 	SourceBatchID   string
-// 	SourceTaskID    string
-// 	SourceTaskRunID string
-// 	SourceJobID     string
-// 	SourceJobRunID  string
-// 	TimeWindow      time.Time
-
-// 	CreatedAt time.Time
-// 	UpdatedAt time.Time
-// }
-
 type BatchRouterEventT struct {
 	Metadata MetadataT `json:"metadata"`
 	Data     DataT     `json:"data"`


### PR DESCRIPTION
# Issue 

In a recent PR, I introduced the repository & DTO pattern to access the database. I wanted the DTO to contain all the information about a staging file. However, the schema field requires a lot of memory for some customers (100Kbytes - 200Kbyes).

# Solution

We should avoid including the schema if not needed, but I didn't want to have a partial field DTO. Thus, I have introduced a new type, `StagingFileWithSchema`, which should be used when the schema is needed.

The HTTP API inserts staging file with schema, and all the get method return staging file without schema.

# Meme
![73ly9m](https://user-images.githubusercontent.com/733195/206484576-fa4651f2-0e2a-4994-b842-4e428008327b.jpeg)


## Notion Ticket

https://www.notion.so/rudderstacks/fix-OOM-staging-file-19d84c51d5be4251944b35531b4dd778

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
