### PR TITLE
fix: using a wrong datatype for pg_class.reltuples causes internal migration to fail

### DIFF
--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -174,10 +174,10 @@ func (jd *HandleT) getCleanUpCandidates(ctx context.Context, dsList []dataSetT) 
 	}
 	defer func() { _ = rows.Close() }()
 
-	estimates := map[string]int64{}
+	estimates := map[string]float64{}
 	for rows.Next() {
 		var (
-			estimate  int64
+			estimate  float64
 			tableName string
 		)
 		err = rows.Scan(&estimate, &tableName)
@@ -192,9 +192,9 @@ func (jd *HandleT) getCleanUpCandidates(ctx context.Context, dsList []dataSetT) 
 			statuses := estimates[ds.JobStatusTable]
 			jobs := estimates[ds.JobTable]
 			if jobs == 0 { // using max ds size if we have no stats for the number of jobs
-				jobs = int64(*jd.MaxDSSize)
+				jobs = float64(*jd.MaxDSSize)
 			}
-			return float64(statuses)/float64(jobs) > jobStatusMigrateThres
+			return statuses/jobs > jobStatusMigrateThres
 		})
 
 	return lo.Slice(datasets, 0, maxMigrateDSProbe), nil


### PR DESCRIPTION
# Description

converting postgres `reltuples` estimate to a float64 instead of int64.

`Failed to migrate ds: sql: Scan error on column index 0, name "estimate": converting driver.Value type float64 ("1.018263e+06") to a int64: invalid syntax`

## Notion Ticket

https://www.notion.so/rudderstacks/float64-status-cleanup-estimates-1d85800371d3467c884fa98e19d6363f

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
