### PR TITLE
fix: pending events stats incremented twice during startup due to tenantstats being initialized twice

### DIFF
--- a/services/multitenant/tenantstats.go
+++ b/services/multitenant/tenantstats.go
@@ -58,11 +58,7 @@ func (*Stats) Stop() {
 }
 
 func (t *Stats) Start() error {
-	metric.Instance.Reset()
-	t.routerInputRates = make(map[string]map[string]map[string]metric.MovingAverage)
-	t.lastDrainedTimestamps = make(map[string]map[string]time.Time)
-	t.failureRate = make(map[string]map[string]metric.MovingAverage)
-
+	t.reset()
 	for dbPrefix := range t.RouterDBs {
 		t.routerInputRates[dbPrefix] = make(map[string]map[string]metric.MovingAverage)
 		pileUpStatMap, err := misc.QueryWithRetriesAndNotify(context.Background(),
@@ -81,9 +77,6 @@ func (t *Stats) Start() error {
 			}
 		}
 	}
-
-	t.routerTenantLatencyStat = make(map[string]map[string]metric.MovingAverage)
-	t.processorStageTime = time.Now()
 	return nil
 }
 
@@ -107,7 +100,17 @@ func NewStats(routerDBs map[string]jobsdb.MultiTenantJobsDB) *Stats {
 	config.RegisterDurationConfigVariable(60, &t.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB.Multitenant.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
 	config.RegisterIntConfigVariable(3, &t.jobdDBMaxRetries, true, 1, []string{"JobsDB." + "Router." + "MaxRetries", "JobsDB." + "MaxRetries"}...)
 	t.RouterDBs = routerDBs
+	t.reset()
 	return &t
+}
+
+func (t *Stats) reset() {
+	metric.Instance.Reset()
+	t.routerInputRates = make(map[string]map[string]map[string]metric.MovingAverage)
+	t.lastDrainedTimestamps = make(map[string]map[string]time.Time)
+	t.failureRate = make(map[string]map[string]metric.MovingAverage)
+	t.routerTenantLatencyStat = make(map[string]map[string]metric.MovingAverage)
+	t.processorStageTime = time.Now()
 }
 
 func (t *Stats) UpdateWorkspaceLatencyMap(destType, workspaceID string, val float64) {

--- a/services/multitenant/tenantstats.go
+++ b/services/multitenant/tenantstats.go
@@ -58,6 +58,7 @@ func (*Stats) Stop() {
 }
 
 func (t *Stats) Start() error {
+	metric.Instance.Reset()
 	t.routerInputRates = make(map[string]map[string]map[string]metric.MovingAverage)
 	t.lastDrainedTimestamps = make(map[string]map[string]time.Time)
 	t.failureRate = make(map[string]map[string]metric.MovingAverage)

--- a/services/multitenant/tenantstats_test.go
+++ b/services/multitenant/tenantstats_test.go
@@ -54,6 +54,7 @@ var _ = Describe("tenantStats", func() {
 				// crash recovery check
 				mockRouterJobsDB.EXPECT().GetPileUpCounts(gomock.Any()).Times(1)
 				tenantStats = NewStats(map[string]jobsdb.MultiTenantJobsDB{"rt": mockRouterJobsDB})
+				Expect(tenantStats.Start()).To(BeNil())
 			})
 
 			It("TenantStats init", func() {


### PR DESCRIPTION
# Description

During application startup, we incremented pending events stats twice, once while creating the `tenantstats.Stats` and once more while starting `tenantstats.Stats`. This caused in-memory stats to be seeded incorrectly (x2 the actual stats) and, subsequently, causing erroneous firing of stuck-processing-pipeline alerts.

Removed stats initialization logic from `tenantstats.NewStats`.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=4ca5ea2d2f954b3e94356c713d1d2e01&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
