### PR TITLE
fix: aws session creation is failing for s3 manager when roles are used

### DIFF
--- a/services/filemanager/filemanager.go
+++ b/services/filemanager/filemanager.go
@@ -64,13 +64,9 @@ func init() {
 func (*FileManagerFactoryT) New(settings *SettingsT) (FileManager, error) {
 	switch settings.Provider {
 	case "S3_DATALAKE":
-		return &S3Manager{
-			Config: GetS3Config(settings.Config),
-		}, nil
+		return NewS3Manager(settings.Config)
 	case "S3":
-		return &S3Manager{
-			Config: GetS3Config(settings.Config),
-		}, nil
+		return NewS3Manager(settings.Config)
 	case "GCS":
 		return &GCSManager{
 			Config: GetGCSConfig(settings.Config),

--- a/services/filemanager/s3manager_test.go
+++ b/services/filemanager/s3manager_test.go
@@ -5,16 +5,99 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/rudderlabs/rudder-server/utils/awsutils"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestNewS3ManagerWithNil(t *testing.T) {
+	s3Manager, err := NewS3Manager(nil)
+	assert.EqualError(t, err, "config should not be nil")
+	assert.Nil(t, s3Manager)
+}
+
+func TestNewS3ManagerWithAccessKeys(t *testing.T) {
+	s3Manager, err := NewS3Manager(map[string]interface{}{
+		"bucketName":  "someBucket",
+		"region":      "someRegion",
+		"accessKeyID": "someAccessKeyId",
+		"accessKey":   "someSecretAccessKey",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, s3Manager)
+	assert.Equal(t, "someBucket", s3Manager.Config.Bucket)
+	assert.Equal(t, aws.String("someRegion"), s3Manager.Config.Region)
+	assert.Equal(t, "someAccessKeyId", s3Manager.SessionConfig.AccessKeyID)
+	assert.Equal(t, "someSecretAccessKey", s3Manager.SessionConfig.AccessKey)
+	assert.Equal(t, false, s3Manager.SessionConfig.RoleBasedAuth)
+}
+
+func TestNewS3ManagerWithRole(t *testing.T) {
+	s3Manager, err := NewS3Manager(map[string]interface{}{
+		"bucketName": "someBucket",
+		"region":     "someRegion",
+		"iamRoleARN": "someIAMRole",
+		"externalID": "someExternalID",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, s3Manager)
+	assert.Equal(t, "someBucket", s3Manager.Config.Bucket)
+	assert.Equal(t, aws.String("someRegion"), s3Manager.Config.Region)
+	assert.Equal(t, "someIAMRole", s3Manager.SessionConfig.IAMRoleARN)
+	assert.Equal(t, "someExternalID", s3Manager.SessionConfig.ExternalID)
+	assert.Equal(t, true, s3Manager.SessionConfig.RoleBasedAuth)
+}
+
+func TestNewS3ManagerWithBothAccessKeysAndRole(t *testing.T) {
+	s3Manager, err := NewS3Manager(map[string]interface{}{
+		"bucketName":  "someBucket",
+		"region":      "someRegion",
+		"iamRoleARN":  "someIAMRole",
+		"externalID":  "someExternalID",
+		"accessKeyID": "someAccessKeyId",
+		"accessKey":   "someSecretAccessKey",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, s3Manager)
+	assert.Equal(t, "someBucket", s3Manager.Config.Bucket)
+	assert.Equal(t, aws.String("someRegion"), s3Manager.Config.Region)
+	assert.Equal(t, "someAccessKeyId", s3Manager.SessionConfig.AccessKeyID)
+	assert.Equal(t, "someSecretAccessKey", s3Manager.SessionConfig.AccessKey)
+	assert.Equal(t, "someIAMRole", s3Manager.SessionConfig.IAMRoleARN)
+	assert.Equal(t, "someExternalID", s3Manager.SessionConfig.ExternalID)
+	assert.Equal(t, true, s3Manager.SessionConfig.RoleBasedAuth)
+}
+
+func TestNewS3ManagerWithBothAccessKeysAndRoleButRoleBasedAuthFalse(t *testing.T) {
+	s3Manager, err := NewS3Manager(map[string]interface{}{
+		"bucketName":    "someBucket",
+		"region":        "someRegion",
+		"iamRoleARN":    "someIAMRole",
+		"externalID":    "someExternalID",
+		"accessKeyID":   "someAccessKeyId",
+		"accessKey":     "someSecretAccessKey",
+		"roleBasedAuth": false,
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, s3Manager)
+	assert.Equal(t, "someBucket", s3Manager.Config.Bucket)
+	assert.Equal(t, aws.String("someRegion"), s3Manager.Config.Region)
+	assert.Equal(t, "someAccessKeyId", s3Manager.SessionConfig.AccessKeyID)
+	assert.Equal(t, "someSecretAccessKey", s3Manager.SessionConfig.AccessKey)
+	assert.Equal(t, "someIAMRole", s3Manager.SessionConfig.IAMRoleARN)
+	assert.Equal(t, "someExternalID", s3Manager.SessionConfig.ExternalID)
+	assert.Equal(t, false, s3Manager.SessionConfig.RoleBasedAuth)
+}
 
 func TestGetSessionWithAccessKeys(t *testing.T) {
 	s3Manager := S3Manager{
 		Config: &S3Config{
-			Bucket:      "someBucket",
+			Bucket: "someBucket",
+			Region: aws.String("someRegion"),
+		},
+		SessionConfig: &awsutils.SessionConfig{
 			AccessKeyID: "someAccessKeyId",
 			AccessKey:   "someSecretAccessKey",
-			Region:      aws.String("someRegion"),
+			Region:      "someRegion",
 		},
 	}
 	awsSession, err := s3Manager.getSession(context.TODO())
@@ -26,44 +109,17 @@ func TestGetSessionWithAccessKeys(t *testing.T) {
 func TestGetSessionWithIAMRole(t *testing.T) {
 	s3Manager := S3Manager{
 		Config: &S3Config{
-			Bucket:     "someBucket",
+			Bucket: "someBucket",
+			Region: aws.String("someRegion"),
+		},
+		SessionConfig: &awsutils.SessionConfig{
 			IAMRoleARN: "someIAMRole",
 			ExternalID: "someExternalID",
-			Region:     aws.String("someRegion"),
+			Region:     "someRegion",
 		},
 	}
 	awsSession, err := s3Manager.getSession(context.TODO())
 	assert.Nil(t, err)
 	assert.NotNil(t, awsSession)
 	assert.NotNil(t, s3Manager.session)
-}
-
-func TestGetSessionConfigWithAccessKeys(t *testing.T) {
-	s3Manager := S3Manager{
-		Config: &S3Config{
-			Bucket:      "someBucket",
-			AccessKeyID: "someAccessKeyId",
-			AccessKey:   "someSecretAccessKey",
-			Region:      aws.String("someRegion"),
-		},
-	}
-	awsSessionConfig := s3Manager.getSessionConfig()
-	assert.NotNil(t, awsSessionConfig)
-	assert.Equal(t, s3Manager.Config.AccessKey, awsSessionConfig.AccessKey)
-	assert.Equal(t, s3Manager.Config.AccessKeyID, awsSessionConfig.AccessKeyID)
-}
-
-func TestGetSessionConfigWithIAMRole(t *testing.T) {
-	s3Manager := S3Manager{
-		Config: &S3Config{
-			Bucket:     "someBucket",
-			IAMRoleARN: "someIAMRole",
-			ExternalID: "someExternalID",
-			Region:     aws.String("someRegion"),
-		},
-	}
-	awsSessionConfig := s3Manager.getSessionConfig()
-	assert.NotNil(t, awsSessionConfig)
-	assert.Equal(t, s3Manager.Config.IAMRoleARN, awsSessionConfig.IAMRoleARN)
-	assert.Equal(t, s3Manager.Config.ExternalID, awsSessionConfig.ExternalID)
 }

--- a/utils/awsutils/session_test.go
+++ b/utils/awsutils/session_test.go
@@ -26,6 +26,13 @@ var (
 	httpTimeout time.Duration = 10 * time.Second
 )
 
+func TestNewSessionConfigWithNilDestConfig(t *testing.T) {
+	serviceName := "kinesis"
+	sessionConfig, err := NewSessionConfigForDestination(&backendconfig.DestinationT{}, httpTimeout, serviceName)
+	assert.EqualError(t, err, "config should not be nil")
+	assert.Nil(t, sessionConfig)
+}
+
 func TestNewSessionConfigWithAccessKey(t *testing.T) {
 	serviceName := "kinesis"
 	sessionConfig, err := NewSessionConfigForDestination(&destinationWithAccessKey, httpTimeout, serviceName)

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -807,6 +807,16 @@ func GetTemporaryS3Cred(destination *backendconfig.DestinationT) (string, string
 		return "", "", "", err
 	}
 
+	// Role already provides temporary credentials
+	// so we shouldn't call sts.GetSessionToken again
+	if sessionConfig.RoleBasedAuth {
+		creds, err := awsSession.Config.Credentials.Get()
+		if err != nil {
+			return "", "", "", err
+		}
+		return creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken, nil
+	}
+
 	// Create an STS client from just a session.
 	svc := sts.New(awsSession)
 


### PR DESCRIPTION
# Description

Unify AWS session config creation process so that it is consistent across all AWS destinations. Earlier S3 has slightly different process to create SessionConfing so when updated the session config creation in aws utils to support RoleBasedAuth flag, it got missed for S3 manager as it was using different implementation so this unification should prevent such errors in the future.

## Notion Ticket

[Warehouse AWS Role support] https://www.notion.so/rudderstacks/Warehouse-destination-config-for-Role-base-Authentication-control-plane-db9198dce2024723959c224e91a11ef4
## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
