### PR TITLE
chore: fix table identifier in read only jobsdb

### DIFF
--- a/jobsdb/readonly_jobsdb.go
+++ b/jobsdb/readonly_jobsdb.go
@@ -219,7 +219,7 @@ func (jd *ReadonlyHandleT) getUnprocessedJobsDSCount(ctx context.Context, ds dat
 
 	var sqlStatement string
 
-	sqlStatement = fmt.Sprintf(`LOCK TABLE %s IN ACCESS SHARE MODE;`, ds.JobStatusTable)
+	sqlStatement = fmt.Sprintf(`LOCK TABLE %q IN ACCESS SHARE MODE;`, ds.JobStatusTable)
 	err = jd.prepareAndExecStmtInTxn(txn, sqlStatement)
 	if err != nil {
 		if rollbackErr := txn.Rollback(); rollbackErr != nil {
@@ -229,7 +229,7 @@ func (jd *ReadonlyHandleT) getUnprocessedJobsDSCount(ctx context.Context, ds dat
 		return 0, err
 	}
 
-	sqlStatement = fmt.Sprintf(`LOCK TABLE %s IN ACCESS SHARE MODE;`, ds.JobTable)
+	sqlStatement = fmt.Sprintf(`LOCK TABLE %q IN ACCESS SHARE MODE;`, ds.JobTable)
 	err = jd.prepareAndExecStmtInTxn(txn, sqlStatement)
 	if err != nil {
 		if rollbackErr := txn.Rollback(); rollbackErr != nil {
@@ -352,7 +352,7 @@ func (jd *ReadonlyHandleT) getProcessedJobsDSCount(ctx context.Context, ds dataS
 	}
 	if len(customValFilters) > 0 {
 		customValQuery = " AND " +
-			constructQueryOR(fmt.Sprintf("%s.custom_val", ds.JobTable), customValFilters)
+			constructQueryOR(fmt.Sprintf("%q.custom_val", ds.JobTable), customValFilters)
 	} else {
 		customValQuery = ""
 	}
@@ -371,7 +371,7 @@ func (jd *ReadonlyHandleT) getProcessedJobsDSCount(ctx context.Context, ds dataS
 
 	var sqlStatement string
 
-	sqlStatement = fmt.Sprintf(`LOCK TABLE %s IN ACCESS SHARE MODE;`, ds.JobStatusTable)
+	sqlStatement = fmt.Sprintf(`LOCK TABLE %q IN ACCESS SHARE MODE;`, ds.JobStatusTable)
 	err = jd.prepareAndExecStmtInTxn(txn, sqlStatement)
 	if err != nil {
 		if rollbackErr := txn.Rollback(); rollbackErr != nil {
@@ -381,7 +381,7 @@ func (jd *ReadonlyHandleT) getProcessedJobsDSCount(ctx context.Context, ds dataS
 		return 0, err
 	}
 
-	sqlStatement = fmt.Sprintf(`LOCK TABLE %s IN ACCESS SHARE MODE;`, ds.JobTable)
+	sqlStatement = fmt.Sprintf(`LOCK TABLE %q IN ACCESS SHARE MODE;`, ds.JobTable)
 	err = jd.prepareAndExecStmtInTxn(txn, sqlStatement)
 	if err != nil {
 		if rollbackErr := txn.Rollback(); rollbackErr != nil {


### PR DESCRIPTION
# Description

For tables with negative index,read-only jobs DB errors out with this error

`error preparing and executing statement. Sql: LOCK TABLE batch_rt_job_status_-1_1 IN ACCESS SHARE MODE;, Err: pq: syntax error at or near "-"`

This PR attempts to fix the issue

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=47af60cd5cb841769e640c3b9403c8fb&pm=s)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
