### PR TITLE
refactor(warehouse): use strings.builder for warehouse add columns

### DIFF
--- a/warehouse/clickhouse/clickhouse.go
+++ b/warehouse/clickhouse/clickhouse.go
@@ -846,6 +846,7 @@ func (ch *HandleT) DropTable(tableName string) (err error) {
 func (ch *HandleT) AddColumns(tableName string, columnsInfo []warehouseutils.ColumnInfo) (err error) {
 	var (
 		query         string
+		queryBuilder  strings.Builder
 		cluster       string
 		clusterClause string
 	)
@@ -855,20 +856,25 @@ func (ch *HandleT) AddColumns(tableName string, columnsInfo []warehouseutils.Col
 		clusterClause = fmt.Sprintf(`ON CLUSTER %q`, cluster)
 	}
 
-	query = fmt.Sprintf(`
+	queryBuilder.WriteString(fmt.Sprintf(`
 		ALTER TABLE
 		  %q.%q %s`,
 		ch.Namespace,
 		tableName,
 		clusterClause,
-	)
+	))
 
 	for _, columnInfo := range columnsInfo {
-		columnType := getClickHouseColumnTypeForSpecificTable(tableName, columnInfo.Name, rudderDataTypesMapToClickHouse[columnInfo.Type], false)
-		query += fmt.Sprintf(` ADD COLUMN IF NOT EXISTS %q %s,`, columnInfo.Name, columnType)
+		columnType := getClickHouseColumnTypeForSpecificTable(
+			tableName,
+			columnInfo.Name,
+			rudderDataTypesMapToClickHouse[columnInfo.Type],
+			false,
+		)
+		queryBuilder.WriteString(fmt.Sprintf(` ADD COLUMN IF NOT EXISTS %q %s,`, columnInfo.Name, columnType))
 	}
 
-	query = strings.TrimSuffix(query, ",")
+	query = strings.TrimSuffix(queryBuilder.String(), ",")
 	query += ";"
 
 	pkgLogger.Infof("CH: Adding columns for destinationID: %s, tableName: %s with query: %v", ch.Warehouse.Destination.ID, tableName, query)

--- a/warehouse/deltalake/deltalake.go
+++ b/warehouse/deltalake/deltalake.go
@@ -875,20 +875,24 @@ func (dl *HandleT) DropTable(tableName string) (err error) {
 }
 
 func (dl *HandleT) AddColumns(tableName string, columnsInfo []warehouseutils.ColumnInfo) (err error) {
-	var query string
-	query += fmt.Sprintf(`
+	var (
+		query        string
+		queryBuilder strings.Builder
+	)
+
+	queryBuilder.WriteString(fmt.Sprintf(`
 		ALTER TABLE
 		  %s.%s
 		ADD COLUMNS(`,
 		dl.Namespace,
 		tableName,
-	)
+	))
 
 	for _, columnInfo := range columnsInfo {
-		query += fmt.Sprintf(` %s %s,`, columnInfo.Name, getDeltaLakeDataType(columnInfo.Type))
+		queryBuilder.WriteString(fmt.Sprintf(` %s %s,`, columnInfo.Name, getDeltaLakeDataType(columnInfo.Type)))
 	}
 
-	query = strings.TrimSuffix(query, ",")
+	query = strings.TrimSuffix(queryBuilder.String(), ",")
 	query += ");"
 
 	pkgLogger.Infof("DL: Adding columns for destinationID: %s, tableName: %s with query: %v", dl.Warehouse.Destination.ID, tableName, query)

--- a/warehouse/snowflake/snowflake.go
+++ b/warehouse/snowflake/snowflake.go
@@ -645,24 +645,25 @@ func (sf *HandleT) DropTable(tableName string) (err error) {
 func (sf *HandleT) AddColumns(tableName string, columnsInfo []warehouseutils.ColumnInfo) (err error) {
 	var (
 		query            string
+		queryBuilder     strings.Builder
 		schemaIdentifier string
 	)
 
 	schemaIdentifier = sf.schemaIdentifier()
 
-	query = fmt.Sprintf(`
+	queryBuilder.WriteString(fmt.Sprintf(`
 		ALTER TABLE
 		  %s.%q
 		ADD COLUMN`,
 		schemaIdentifier,
 		tableName,
-	)
+	))
 
 	for _, columnInfo := range columnsInfo {
-		query += fmt.Sprintf(` %q %s,`, columnInfo.Name, dataTypesMap[columnInfo.Type])
+		queryBuilder.WriteString(fmt.Sprintf(` %q %s,`, columnInfo.Name, dataTypesMap[columnInfo.Type]))
 	}
 
-	query = strings.TrimSuffix(query, ",")
+	query = strings.TrimSuffix(queryBuilder.String(), ",")
 	query += ";"
 
 	pkgLogger.Infof("SF: Adding columns for destinationID: %s, tableName: %s with query: %v", sf.Warehouse.Destination.ID, tableName, query)


### PR DESCRIPTION
# Description

1. Use `strings.builder` for building up the query for adding columns instead of concatenating strings to create one.
2. Reserved keywords handling for Azure Synapse.

## Notion Ticket

https://www.notion.so/rudderstacks/use-strings-Builder-for-add-columns-7464daf2d48748f2a7e2ac960d132e93

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
