### PR TITLE
chore: enable failed keys by default

### DIFF
--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -92,7 +92,7 @@ func NewRsourcesService(deploymentType deployment.Type) (rsources.JobService, er
 	rsourcesConfig.LocalConn = misc.GetConnectionString()
 	rsourcesConfig.LocalHostname = config.GetString("DB.host", "localhost")
 	rsourcesConfig.SharedConn = config.GetString("SharedDB.dsn", "")
-	rsourcesConfig.SkipFailedRecordsCollection = !config.GetBool("Router.failedKeysEnabled", false)
+	rsourcesConfig.SkipFailedRecordsCollection = !config.GetBool("Router.failedKeysEnabled", true)
 
 	if deploymentType == deployment.MultiTenantType {
 		// For multitenant deployment type we shall require the existence of a SHARED_DB

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -110,7 +110,7 @@ Router:
   allowAbortedUserJobsCountForProcessing: 1
   maxFailedCountForJob: 3
   retryTimeWindow: 180m
-  failedKeysEnabled: false
+  failedKeysEnabled: true
   saveDestinationResponseOverride: false
   transformerProxy: false
   transformerProxyRetryCount: 15

--- a/router/router.go
+++ b/router/router.go
@@ -244,7 +244,7 @@ func loadConfig() {
 	// sources failed keys config
 	config.RegisterDurationConfigVariable(48, &failedKeysExpire, true, time.Hour, "Router.failedKeysExpire")
 	config.RegisterDurationConfigVariable(24, &failedKeysCleanUpSleep, true, time.Hour, "Router.failedKeysCleanUpSleep")
-	failedKeysEnabled = config.GetBool("Router.failedKeysEnabled", false)
+	failedKeysEnabled = config.GetBool("Router.failedKeysEnabled", true)
 }
 
 func sendRetryStoreStats(attempt int) {


### PR DESCRIPTION
# Description

Enable the failed keys by default.

## Notion Ticket

https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=fa820a352a7542d39d9d0c90bf82bc04&pm=s

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
