### PR TITLE
fix(destination): alert flag setting for router-aborted-count alert definition

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -1019,7 +1019,6 @@ func (worker *workerT) updateReqMetrics(respStatusCode int, diagnosisStartTime *
 }
 
 func (worker *workerT) allowRouterAbortedAlert(errorAt string) bool {
-
 	switch errorAt {
 	case routerutils.ERROR_AT_CUST:
 		return true
@@ -1030,7 +1029,6 @@ func (worker *workerT) allowRouterAbortedAlert(errorAt string) bool {
 	default:
 		return true
 	}
-
 }
 
 func (worker *workerT) updateAbortedMetrics(destinationID, workspaceId, statusCode, errorAt string) {

--- a/router/router.go
+++ b/router/router.go
@@ -1019,12 +1019,18 @@ func (worker *workerT) updateReqMetrics(respStatusCode int, diagnosisStartTime *
 }
 
 func (worker *workerT) allowRouterAbortedAlert(errorAt string) bool {
-	// when error occur during transformation(rt or batch) or when skipRtAbortAlertForTransformation is false(default)
-	allowTf := errorAt == routerutils.ERROR_AT_TF && !worker.rt.skipRtAbortAlertForTransformation
-	// (when error occur during delivery and (when proxy is not enabled and when skipRtAbortAlertForDelivery is false(default)))
-	// or when destination is managed custom destination manager
-	allowDel := (errorAt == routerutils.ERROR_AT_DEL && (!worker.rt.transformerProxy && !worker.rt.skipRtAbortAlertForDelivery)) || errorAt == routerutils.ERROR_AT_CUST
-	return allowTf || allowDel
+
+	switch errorAt {
+	case routerutils.ERROR_AT_CUST:
+		return true
+	case routerutils.ERROR_AT_TF:
+		return !worker.rt.skipRtAbortAlertForTransformation
+	case routerutils.ERROR_AT_DEL:
+		return !worker.rt.transformerProxy && !worker.rt.skipRtAbortAlertForDelivery
+	default:
+		return true
+	}
+
 }
 
 func (worker *workerT) updateAbortedMetrics(destinationID, workspaceId, statusCode, errorAt string) {

--- a/router/router.go
+++ b/router/router.go
@@ -1021,9 +1021,9 @@ func (worker *workerT) updateReqMetrics(respStatusCode int, diagnosisStartTime *
 func (worker *workerT) allowRouterAbortedAlert(errorAt string) bool {
 	// when error occur during transformation(rt or batch) or when skipRtAbortAlertForTransformation is false(default)
 	allowTf := errorAt == routerutils.ERROR_AT_TF && !worker.rt.skipRtAbortAlertForTransformation
-	// (when error occur during delivery and (when proxy is not enabled or when skipRtAbortAlertForDelivery is false(default)))
+	// (when error occur during delivery and (when proxy is not enabled and when skipRtAbortAlertForDelivery is false(default)))
 	// or when destination is managed custom destination manager
-	allowDel := (errorAt == routerutils.ERROR_AT_DEL && (!worker.rt.transformerProxy || !worker.rt.skipRtAbortAlertForDelivery)) || errorAt == routerutils.ERROR_AT_CUST
+	allowDel := (errorAt == routerutils.ERROR_AT_DEL && (!worker.rt.transformerProxy && !worker.rt.skipRtAbortAlertForDelivery)) || errorAt == routerutils.ERROR_AT_CUST
 	return allowTf || allowDel
 }
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1501,6 +1501,17 @@ func TestAllowRouterAbortAlert(t *testing.T) {
 			expectedAlertFlagValue: true,
 			errorAt:                routerUtils.ERROR_AT_CUST,
 		},
+		// empty errorAt
+		{
+			caseName:               "[emptyErrorAt] when transformerProxy is disabled & deliveryAlert is not to be skipped, the alert should be true",
+			skip:                   skipT{},
+			expectedAlertFlagValue: true,
+		},
+		{
+			caseName:               "[emptyErrorAt] when transformerProxy is disabled & deliveryAlert is to be skipped, the alert should be true",
+			skip:                   skipT{deliveryAlert: true},
+			expectedAlertFlagValue: true,
+		},
 	}
 	for _, tc := range cases {
 		wrk := &workerT{

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
 
 	"github.com/rudderlabs/rudder-server/enterprise/reporting"
@@ -1421,5 +1422,97 @@ func Benchmark_FASTJSON_MARSHAL(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		val, _ := jsonfast.Marshal(collectMetricsErrorMap)
 		_ = string(val)
+	}
+}
+
+func TestAllowRouterAbortAlert(t *testing.T) {
+	type skipT struct {
+		deliveryAlert       bool
+		transformationAlert bool
+	}
+	cases := []struct {
+		skip                   skipT
+		transformerProxy       bool
+		expectedAlertFlagValue bool
+		errorAt                string
+		caseName               string
+	}{
+		// normal destinations' delivery cases
+		{
+			caseName:               "[delivery] when deliveryAlert is to be skipped, proxy is enabled the alert should be false",
+			skip:                   skipT{deliveryAlert: true},
+			transformerProxy:       true,
+			expectedAlertFlagValue: false,
+			errorAt:                routerUtils.ERROR_AT_DEL,
+		},
+		{
+			caseName:               "[delivery] when deliveryAlert is to be skipped, proxy is disabled the alert should be false",
+			skip:                   skipT{deliveryAlert: true},
+			transformerProxy:       false,
+			expectedAlertFlagValue: false,
+			errorAt:                routerUtils.ERROR_AT_DEL,
+		},
+		{
+			caseName:               "[delivery] when deliveryAlert is not to be skipped, proxy is disabled the alert should be true",
+			skip:                   skipT{},
+			transformerProxy:       false,
+			expectedAlertFlagValue: true,
+			errorAt:                routerUtils.ERROR_AT_DEL,
+		},
+		{
+			caseName:               "[delivery] when deliveryAlert is to be skipped, proxy is enabled the alert should be false",
+			skip:                   skipT{},
+			transformerProxy:       true,
+			expectedAlertFlagValue: false,
+			errorAt:                routerUtils.ERROR_AT_DEL,
+		},
+		// transformation cases
+		{
+			caseName:               "[transformation] when transformationAlert is to be skipped, the alert should be false",
+			skip:                   skipT{transformationAlert: true},
+			expectedAlertFlagValue: false,
+			errorAt:                routerUtils.ERROR_AT_TF,
+		},
+		{
+			caseName:               "[transformation]when transformationAlert is not to be skipped, the alert should be true",
+			skip:                   skipT{},
+			expectedAlertFlagValue: true,
+			errorAt:                routerUtils.ERROR_AT_TF,
+		},
+		// Custom destination's delivery cases
+		{
+			caseName:               "[custom] when transformerProxy is enabled, the alert should be true",
+			skip:                   skipT{},
+			transformerProxy:       true,
+			expectedAlertFlagValue: true,
+			errorAt:                routerUtils.ERROR_AT_CUST,
+		},
+		{
+			caseName:               "[custom] when transformerProxy is disabled, the alert should be true",
+			skip:                   skipT{},
+			transformerProxy:       false,
+			expectedAlertFlagValue: true,
+			errorAt:                routerUtils.ERROR_AT_CUST,
+		},
+		{
+			caseName:               "[custom] when transformerProxy is enabled & deliveryAlert is to be skipped, the alert should be false",
+			skip:                   skipT{deliveryAlert: true},
+			transformerProxy:       true,
+			expectedAlertFlagValue: true,
+			errorAt:                routerUtils.ERROR_AT_CUST,
+		},
+	}
+	for _, tc := range cases {
+		wrk := &workerT{
+			rt: &HandleT{
+				transformerProxy:                  tc.transformerProxy,
+				skipRtAbortAlertForDelivery:       tc.skip.deliveryAlert,
+				skipRtAbortAlertForTransformation: tc.skip.transformationAlert,
+			},
+		}
+		t.Run(tc.caseName, func(testT *testing.T) {
+			output := wrk.allowRouterAbortedAlert(tc.errorAt)
+			assert.Equal(testT, tc.expectedAlertFlagValue, output)
+		})
 	}
 }


### PR DESCRIPTION
# Description

The issue is that, when `transformerProxy` was enabled and `skipRtAbortAlertForDelivery` configuration was not present, the `alert` tag(or flag) was coming out to be `true`, which is not expected
We want the alert to only be triggered when the following happens during delivery phase for cloud-mode destinations
|proxy|skipRtAbortAlertForDelivery(in configuration)|alert(in router_aborted_events or router_response_counts stat)|
|--|--|--|
|0|0|1
|0|1|0
|1|0|0
|1|1|0


## Notion Ticket

https://www.notion.so/rudderstacks/Kapacitor-alerts-configuration-Prometheus-migration-a0f65d8ff61e440a9f69f9884752bf51

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
