### PR TITLE
fix: get instance id using regex

### DIFF
--- a/config/misc.go
+++ b/config/misc.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"regexp"
 	"strings"
 )
 
@@ -35,8 +36,8 @@ func GetInstanceID() string {
 	if instance == "" {
 		return ""
 	}
-	instanceArr := strings.Split(instance, "-")
-	return instanceArr[len(instanceArr)-1]
+	re := regexp.MustCompile("-[0-9]+([A-Za-z0-9-]*)$")
+	return strings.TrimPrefix(string(re.Find([]byte(instance))), "-")
 }
 
 func GetReleaseName() string {

--- a/integration_test/multi_tentant_test/multi_tenant_test.go
+++ b/integration_test/multi_tentant_test/multi_tenant_test.go
@@ -161,7 +161,7 @@ func testMultiTenantByAppType(t *testing.T, appType string) {
 		cmd := exec.CommandContext(ctx, "go", "run", "../../main.go")
 		cmd.Env = append(os.Environ(),
 			"APP_TYPE="+appType,
-			"INSTANCE_ID="+serverInstanceID,
+			"INSTANCE_ID=rudder-"+serverInstanceID,
 			"RELEASE_NAME="+releaseName,
 			"ETCD_HOSTS="+etcdContainer.Hosts[0],
 			"JOBS_DB_PORT="+postgresContainer.Port,


### PR DESCRIPTION
# Description

Getting instance id using regex. This will help us fetch instance id properly for gw ha deployments as well.
Ex: for rudderstack-gw-ha-0-89gsas we now get `0-89gsas` instead of `89gsas` like before.

## Notion Ticket

https://www.notion.so/rudderstacks/Gateway-HA-support-for-multitenant-37b2158507a24ded81b5744269bc2038

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
