### PR TITLE
chore(warehouse): official and arm64 support clickhouse images for testing

### DIFF
--- a/warehouse/docker-compose.test.yml
+++ b/warehouse/docker-compose.test.yml
@@ -69,7 +69,7 @@ services:
       retries: 25
   wh-clickhouse:
     container_name: wh-clickhouse
-    image: yandex/clickhouse-server:21-alpine
+    image: clickhouse/clickhouse-server:22-alpine
     environment:
       - CLICKHOUSE_DB=rudderdb
       - CLICKHOUSE_PASSWORD=rudder-password
@@ -99,7 +99,7 @@ services:
       interval: 1s
       retries: 25
   wh-clickhouse01:
-    image: yandex/clickhouse-server:21-alpine
+    image: clickhouse/clickhouse-server:22-alpine
     container_name: wh-clickhouse01
     ports:
       - "9000"
@@ -112,7 +112,7 @@ services:
       interval: 1s
       retries: 25
   wh-clickhouse02:
-    image: yandex/clickhouse-server:21-alpine
+    image: clickhouse/clickhouse-server:22-alpine
     container_name: wh-clickhouse02
     hostname: wh-clickhouse02
     ports:
@@ -126,7 +126,7 @@ services:
       interval: 1s
       retries: 25
   wh-clickhouse03:
-    image: yandex/clickhouse-server:21-alpine
+    image: clickhouse/clickhouse-server:22-alpine
     container_name: wh-clickhouse03
     hostname: wh-clickhouse03
     ports:
@@ -140,7 +140,7 @@ services:
       interval: 1s
       retries: 25
   wh-clickhouse04:
-    image: yandex/clickhouse-server:21-alpine
+    image: clickhouse/clickhouse-server:22-alpine
     container_name: wh-clickhouse04
     hostname: wh-clickhouse04
     ports:


### PR DESCRIPTION
# Description


**Motivation**:  arm64 images perform better on apple silicon; since we were using multiple clickhouse containers for testing, there is an impact on integration tests performance.

In addition to that, the `yandex/` repository is no longer the official repo. 

**Changes**: I switch to the official repository and use the latest build that includes arm64 platform. 

<img width="1245" alt="Screenshot 2022-12-17 at 6 25 59 PM" src="https://user-images.githubusercontent.com/733195/208253934-37235e3f-49fb-482d-8c39-bbb4a1830220.png">


## Notion Ticket

https://www.notion.so/rudderstacks/upgrade-clickhouse-images-a5a10f8a7fd64283a6537f9a8285b309

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
