### PR TITLE
chore: abort jobs in regulation worker for unsupported destinations

### DIFF
--- a/regulation-worker/internal/delete/delete.go
+++ b/regulation-worker/internal/delete/delete.go
@@ -48,5 +48,5 @@ func (r *Router) Delete(ctx context.Context, job model.Job, dest model.Destinati
 	}
 
 	pkgLogger.Errorf("no deletion manager support deletion from destination: %v", dest.Name)
-	return model.JobStatusFailed
+	return model.JobStatusAborted
 }

--- a/regulation-worker/internal/delete/delete_test.go
+++ b/regulation-worker/internal/delete/delete_test.go
@@ -36,7 +36,7 @@ func TestDelete(t *testing.T) {
 			destDetail: model.Destination{
 				Name: "d5",
 			},
-			expectedStatus: model.JobStatusFailed,
+			expectedStatus: model.JobStatusAborted,
 		},
 	}
 


### PR DESCRIPTION
# Description

There is no point in retrying regulation deletion jobs for unsupported destination types

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=87a22e23ea624c5ca0772abc3b38cd19&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
