### PR TITLE
fix(warehouse): processing available workers to be gauge stats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -188,7 +188,7 @@ require (
 	github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/afero v1.9.2 // indirect
-	github.com/spf13/cast v1.5.0 // indirect
+	github.com/spf13/cast v1.5.0
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect

--- a/services/stats/memstats/stats.go
+++ b/services/stats/memstats/stats.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/spf13/cast"
+
 	"github.com/rudderlabs/rudder-server/services/stats"
 )
 
@@ -105,7 +107,7 @@ func (m *Measurement) Gauge(value interface{}) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.values = append(m.values, value.(float64))
+	m.values = append(m.values, cast.ToFloat64(value))
 }
 
 // Observe implements stats.Measurement

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -885,11 +885,11 @@ func (wh *HandleT) processingStats(ctx context.Context, availableWorkers int, sk
 	})
 	pendingJobsStat.Count(pendingJobs)
 
-	availableWorkersStat := wh.stats.NewTaggedStat("wh_processing_available_workers", stats.CountType, stats.Tags{
+	availableWorkersStat := wh.stats.NewTaggedStat("wh_processing_available_workers", stats.GaugeType, stats.Tags{
 		"module":   moduleName,
 		"destType": wh.destType,
 	})
-	availableWorkersStat.Count(availableWorkers)
+	availableWorkersStat.Gauge(availableWorkers)
 
 	pickupLagStat := wh.stats.NewTaggedStat("wh_processing_pickup_lag", stats.TimerType, stats.Tags{
 		"module":   moduleName,


### PR DESCRIPTION
# Description

The available number of workers to be Guage stats.

## Notion Ticket

https://www.notion.so/rudderstacks/fix-warehouse-processing-stats-to-be-guage-for-workers-3f9ad02af83541459ae1a3434d65561a

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
