### PR TITLE
feat: regulation worker support for parallel processing

### DIFF
--- a/regulation-worker/internal/service/service_test.go
+++ b/regulation-worker/internal/service/service_test.go
@@ -91,8 +91,11 @@ func TestJobSvc(t *testing.T) {
 				Deleter:    mockDeleter,
 				DestDetail: mockDestDetail,
 			}
-			err := svc.JobSvc(ctx)
+			job, err := svc.Pickup(ctx)
 			require.Equal(t, tt.expectedFinalErr, err, "actual error different than expected")
+			if err == nil {
+				require.NoError(t, svc.Process(ctx, job))
+			}
 		})
 	}
 }


### PR DESCRIPTION
# Description

A single regulation worker instance can now process multiple jobs in parallel

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=e9365dded761444b996aa1e79f2cc80e&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
