### PR TITLE
fix(warehouse): control plane client needs to be initialized for master mode

### DIFF
--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -2189,13 +2189,6 @@ func Start(ctx context.Context, app app.App) error {
 			reporting.AddClient(ctx, types.Config{ConnInfo: psqlInfo, ClientName: types.WAREHOUSE_REPORTING_CLIENT})
 			return nil
 		}))
-		region := config.GetString("region", "")
-
-		controlPlaneClient = controlplane.NewClient(
-			backendconfig.GetConfigBackendURL(),
-			backendconfig.DefaultBackendConfig.Identity(),
-			controlplane.WithRegion(region),
-		)
 	}
 
 	if isStandAlone() && isMaster() {
@@ -2206,7 +2199,7 @@ func Start(ctx context.Context, app app.App) error {
 			backendconfig.DefaultBackendConfig.WaitForConfig(ctx)
 
 			c := controlplane.NewClient(
-				config.GetString("CONFIG_BACKEND_URL", "https://api.rudderstack.com"),
+				backendconfig.GetConfigBackendURL(),
 				backendconfig.DefaultBackendConfig.Identity(),
 			)
 
@@ -2231,6 +2224,14 @@ func Start(ctx context.Context, app app.App) error {
 		pkgLogger.Infof("[WH]: Starting warehouse master...")
 
 		backendconfig.DefaultBackendConfig.WaitForConfig(ctx)
+
+		region := config.GetString("region", "")
+
+		controlPlaneClient = controlplane.NewClient(
+			backendconfig.GetConfigBackendURL(),
+			backendconfig.DefaultBackendConfig.Identity(),
+			controlplane.WithRegion(region),
+		)
 
 		tenantManager = &multitenant.Manager{
 			BackendConfig: backendconfig.DefaultBackendConfig,


### PR DESCRIPTION
# Description

The Control plane client needs to be initialized for all warehouse master modes not just for the stand-alone mode.

## Notion Ticket

https://www.notion.so/rudderstacks/control-plane-client-needs-to-be-initialized-for-master-mode-5fb54e30fdb640a4a6de4cf4b2a61823

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
