### PR TITLE
fix: unnecessary router pending event counts

### DIFF
--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1275,8 +1275,7 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 			var cd *types.ConnectionDetails
 			workspaceID := job.WorkspaceId
 			key := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s", parameters.SourceID, parameters.DestinationID, parameters.SourceBatchID, jobState, strconv.Itoa(errorCode), parameters.EventName, parameters.EventType)
-			_, ok := connectionDetailsMap[key]
-			if !ok {
+			if _, ok := connectionDetailsMap[key]; !ok {
 				cd = types.CreateConnectionDetail(parameters.SourceID, parameters.DestinationID, parameters.SourceBatchID, parameters.SourceTaskID, parameters.SourceTaskRunID, parameters.SourceJobID, parameters.SourceJobRunID, parameters.SourceDefinitionID, parameters.DestinationDefinitionID, parameters.SourceCategory)
 				connectionDetailsMap[key] = cd
 				transformedAtMap[key] = parameters.TransformAt

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1149,7 +1149,7 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 		batchJobState string
 		errorResp     []byte
 	)
-	batchRouterWorkspaceJobStatusCount := make(map[string]map[string]int)
+	batchRouterWorkspaceJobStatusCount := make(map[string]int)
 	var abortedEvents []*jobsdb.JobT
 	var batchReqMetric batchRequestMetric
 	if errOccurred != nil {
@@ -1274,12 +1274,8 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 			errorCode := getBRTErrorCode(jobState)
 			var cd *types.ConnectionDetails
 			workspaceID := job.WorkspaceId
-			_, ok := batchRouterWorkspaceJobStatusCount[workspaceID]
-			if !ok {
-				batchRouterWorkspaceJobStatusCount[workspaceID] = make(map[string]int)
-			}
 			key := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s", parameters.SourceID, parameters.DestinationID, parameters.SourceBatchID, jobState, strconv.Itoa(errorCode), parameters.EventName, parameters.EventType)
-			_, ok = connectionDetailsMap[key]
+			_, ok := connectionDetailsMap[key]
 			if !ok {
 				cd = types.CreateConnectionDetail(parameters.SourceID, parameters.DestinationID, parameters.SourceBatchID, parameters.SourceTaskID, parameters.SourceTaskRunID, parameters.SourceJobID, parameters.SourceJobRunID, parameters.SourceDefinitionID, parameters.DestinationDefinitionID, parameters.SourceCategory)
 				connectionDetailsMap[key] = cd
@@ -1299,7 +1295,7 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 			}
 			if status.JobState != jobsdb.Failed.State {
 				if status.JobState == jobsdb.Succeeded.State || status.JobState == jobsdb.Aborted.State {
-					batchRouterWorkspaceJobStatusCount[workspaceID][parameters.DestinationID] += 1
+					batchRouterWorkspaceJobStatusCount[workspaceID] += 1
 				}
 				sd.Count++
 			}
@@ -1307,10 +1303,13 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 		// REPORTING - END
 	}
 
-	for workspace := range batchRouterWorkspaceJobStatusCount {
-		for destID := range batchRouterWorkspaceJobStatusCount[workspace] {
-			metric.DecreasePendingEvents("batch_rt", workspace, brt.destType, float64(batchRouterWorkspaceJobStatusCount[workspace][destID]))
-		}
+	for workspace, jobCount := range batchRouterWorkspaceJobStatusCount {
+		metric.DecreasePendingEvents(
+			"batch_rt",
+			workspace,
+			brt.destType,
+			float64(jobCount),
+		)
 	}
 	// tracking batch router errors
 	if diagnostics.EnableDestinationFailuresMetric {
@@ -1766,7 +1765,12 @@ func (worker *workerT) workerProcess() {
 					"workspaceId": destDrainStat.Workspace,
 				})
 				brt.drainedJobsStat.Count(destDrainStat.Count)
-				metric.DecreasePendingEvents("batch_rt", destDrainStat.Workspace, brt.destType, float64(drainStatsbyDest[destID].Count))
+				metric.DecreasePendingEvents(
+					"batch_rt",
+					destDrainStat.Workspace,
+					brt.destType,
+					float64(destDrainStat.Count),
+				)
 			}
 		}
 		// Mark the jobs as executing

--- a/router/router.go
+++ b/router/router.go
@@ -1969,34 +1969,32 @@ func (rt *HandleT) backendConfigSubscriber() {
 			for i := range wConfig.Sources {
 				source := &wConfig.Sources[i]
 				rt.sourceIDWorkspaceMap[source.ID] = workspaceID
-				if len(source.Destinations) > 0 {
-					for i := range source.Destinations {
-						destination := &source.Destinations[i]
-						if destination.DestinationDefinition.Name == rt.destName {
-							if _, ok := rt.destinationsMap[destination.ID]; !ok {
-								rt.destinationsMap[destination.ID] = &routerutils.BatchDestinationT{
-									Destination: *destination,
-									Sources:     []backendconfig.SourceT{},
-								}
+				for i := range source.Destinations {
+					destination := &source.Destinations[i]
+					if destination.DestinationDefinition.Name == rt.destName {
+						if _, ok := rt.destinationsMap[destination.ID]; !ok {
+							rt.destinationsMap[destination.ID] = &routerutils.BatchDestinationT{
+								Destination: *destination,
+								Sources:     []backendconfig.SourceT{},
 							}
-							if _, ok := rt.workspaceSet[workspaceID]; !ok {
-								rt.workspaceSet[workspaceID] = struct{}{}
-								rt.MultitenantI.UpdateWorkspaceLatencyMap(rt.destName, workspaceID, 0)
-							}
-							rt.destinationsMap[destination.ID].Sources = append(rt.destinationsMap[destination.ID].Sources, *source)
+						}
+						if _, ok := rt.workspaceSet[workspaceID]; !ok {
+							rt.workspaceSet[workspaceID] = struct{}{}
+							rt.MultitenantI.UpdateWorkspaceLatencyMap(rt.destName, workspaceID, 0)
+						}
+						rt.destinationsMap[destination.ID].Sources = append(rt.destinationsMap[destination.ID].Sources, *source)
 
-							rt.destinationResponseHandler = New(destination.DestinationDefinition.ResponseRules)
-							if value, ok := destination.DestinationDefinition.Config["saveDestinationResponse"].(bool); ok {
-								rt.saveDestinationResponse = value
-							}
+						rt.destinationResponseHandler = New(destination.DestinationDefinition.ResponseRules)
+						if value, ok := destination.DestinationDefinition.Config["saveDestinationResponse"].(bool); ok {
+							rt.saveDestinationResponse = value
+						}
 
-							// Config key "throttlingCost" is expected to have the eventType as the first key and the call type
-							// as the second key (e.g. track, identify, etc...) or default to apply the cost to all call types:
-							// dDT["config"]["throttlingCost"] = `{"eventType":{"default":1,"track":2,"identify":3}}`
-							if value, ok := destination.DestinationDefinition.Config["throttlingCost"].(map[string]interface{}); ok {
-								m := types.NewEventTypeThrottlingCost(value)
-								rt.throttlingCosts.Store(&m)
-							}
+						// Config key "throttlingCost" is expected to have the eventType as the first key and the call type
+						// as the second key (e.g. track, identify, etc...) or default to apply the cost to all call types:
+						// dDT["config"]["throttlingCost"] = `{"eventType":{"default":1,"track":2,"identify":3}}`
+						if value, ok := destination.DestinationDefinition.Config["throttlingCost"].(map[string]interface{}); ok {
+							m := types.NewEventTypeThrottlingCost(value)
+							rt.throttlingCosts.Store(&m)
 						}
 					}
 				}

--- a/services/multitenant/tenantstats.go
+++ b/services/multitenant/tenantstats.go
@@ -72,8 +72,13 @@ func (t *Stats) Start() error {
 		}
 
 		for workspace := range pileUpStatMap {
-			for destType := range pileUpStatMap[workspace] {
-				metric.IncreasePendingEvents(dbPrefix, workspace, destType, float64(pileUpStatMap[workspace][destType]))
+			for destType, jobCount := range pileUpStatMap[workspace] {
+				metric.IncreasePendingEvents(
+					dbPrefix,
+					workspace,
+					destType,
+					float64(jobCount),
+				)
 			}
 		}
 	}

--- a/services/multitenant/tenantstats.go
+++ b/services/multitenant/tenantstats.go
@@ -101,7 +101,7 @@ func sendQueryRetryStats(attempt int) {
 }
 
 func NewStats(routerDBs map[string]jobsdb.MultiTenantJobsDB) *Stats {
-	t := Stats{}
+	var t Stats
 	config.RegisterDurationConfigVariable(60, &t.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB.Multitenant.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
 	config.RegisterIntConfigVariable(3, &t.jobdDBMaxRetries, true, 1, []string{"JobsDB." + "Router." + "MaxRetries", "JobsDB." + "MaxRetries"}...)
 	t.RouterDBs = routerDBs


### PR DESCRIPTION
# Description

Fixes unnecessary extra statistics captured at router level, where pending event Gauges were initialized for all destinations for all workspaces served by the server instance.

## Notion Ticket

[fix router pending event alerts](https://www.notion.so/rudderstacks/fix-router-pending-event-count-stats-935e387b59e24372b7a57e00338fedba)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
