### PR TITLE
[WIP] chore: use reuseconn linter instead of bodyclose

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,17 +7,14 @@ run:
 
 linters:
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
-    - bodyclose
+    - reuseconn
     - decorder
     - makezero
     - nilnil
@@ -40,17 +37,16 @@ issues:
     # False positive httptest.NewRecorder
     - path: 'gateway/webhook/webhook_test.go'
       linters:
-        - bodyclose
+        - reuseconn
   
-    # False positive .Close behind if
     - path: 'processor/transformer/transformer.go'
       linters:
-        - bodyclose
+        - reuseconn
     
     # False positive httptest.NewRecorder
     - path: 'gateway/gateway_test.go'
       linters:
-        - bodyclose
+        - reuseconn
 
     # Temporary disable until we fix the number of issues
     - path: 'warehouse'

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ install-tools:
 
 .PHONY: lint
 lint: fmt ## Run linters on all go files
-	docker run --rm -v $(shell pwd):/app:ro -w /app golangci/golangci-lint:v1.49.0 bash -e -c \
+	docker run --rm -v $(shell pwd):/app:ro -w /app atzoum/golangci-lint:reuseconn bash -e -c \
 		'golangci-lint run -v --timeout 5m'
 
 .PHONY: fmt

--- a/cmd/devtool/commands/event.go
+++ b/cmd/devtool/commands/event.go
@@ -89,7 +89,7 @@ func EventSend(c *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			defer func() { httputil.CloseResponse(resp) }()
+			defer httputil.CloseResponse(resp)
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return err

--- a/config/backend-config/namespace_config.go
+++ b/config/backend-config/namespace_config.go
@@ -139,7 +139,7 @@ func (nc *namespaceConfig) makeHTTPRequest(ctx context.Context, url string) ([]b
 		return nil, err
 	}
 
-	defer func() { httputil.CloseResponse(resp) }()
+	defer httputil.CloseResponse(resp)
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/config/backend-config/single_workspace.go
+++ b/config/backend-config/single_workspace.go
@@ -151,7 +151,7 @@ func (wc *singleWorkspaceConfig) makeHTTPRequest(ctx context.Context, url string
 		return nil, err
 	}
 
-	defer func() { httputil.CloseResponse(resp) }()
+	defer httputil.CloseResponse(resp)
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -420,7 +420,7 @@ func (r *HandleT) sendMetric(ctx context.Context, netClient *http.Client, client
 		httpStatTags["status"] = strconv.Itoa(resp.StatusCode)
 		stats.Default.NewTaggedStat(StatReportingHttpReq, stats.CountType, httpStatTags).Count(1)
 
-		defer func() { httputil.CloseResponse(resp) }()
+		defer httputil.CloseResponse(resp)
 		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			r.log.Error(err.Error())

--- a/enterprise/suppress-user/syncer.go
+++ b/enterprise/suppress-user/syncer.go
@@ -176,7 +176,7 @@ func (s *Syncer) sync(token []byte) ([]model.Suppression, []byte, error) {
 		if err != nil {
 			return err
 		}
-		defer func() { httputil.CloseResponse(resp) }()
+		defer httputil.CloseResponse(resp)
 
 		// If statusCode is not 2xx, then returning empty regulations
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/gateway/integration_test.go
+++ b/gateway/integration_test.go
@@ -184,7 +184,7 @@ func testGatewayByAppType(t *testing.T, appType string) {
 	resp, err := http.Get(healthEndpoint)
 	require.ErrorContains(t, err, "connection refused")
 	require.Nil(t, resp)
-	defer func() { httputil.CloseResponse(resp) }()
+	defer httputil.CloseResponse(resp)
 
 	// Checking now that the configuration has been processed and the server can start
 	t.Log("Checking health endpoint at", healthEndpoint)
@@ -317,7 +317,7 @@ func sendEvent(t *testing.T, httpPort int, payload *strings.Reader, callType, wr
 
 	res, err := httpClient.Do(req)
 	require.NoError(t, err)
-	defer func() { httputil.CloseResponse(res) }()
+	defer httputil.CloseResponse(res)
 
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)

--- a/integration_test/docker_test/docker_test.go
+++ b/integration_test/docker_test/docker_test.go
@@ -656,7 +656,7 @@ func getEvent(url, method string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() { httputil.CloseResponse(res) }()
+	defer httputil.CloseResponse(res)
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -720,7 +720,7 @@ func sendEvent(t *testing.T, payload *strings.Reader, callType, writeKey string)
 		t.Logf("sendEvent error: %v", err)
 		return
 	}
-	defer func() { httputil.CloseResponse(res) }()
+	defer httputil.CloseResponse(res)
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {

--- a/integration_test/multi_tentant_test/multi_tenant_test.go
+++ b/integration_test/multi_tentant_test/multi_tenant_test.go
@@ -216,7 +216,7 @@ func testMultiTenantByAppType(t *testing.T, appType string) {
 	require.ErrorContains(t, err, "connection refused")
 	require.Nil(t, resp)
 	if err == nil {
-		defer func() { httputil.CloseResponse(resp) }()
+		defer httputil.CloseResponse(resp)
 	}
 
 	// Pushing valid configuration via ETCD
@@ -416,7 +416,7 @@ func sendEvent(t *testing.T, httpPort int, payload *strings.Reader, callType, wr
 
 	res, err := httpClient.Do(req)
 	require.NoError(t, err)
-	defer func() { httputil.CloseResponse(res) }()
+	defer httputil.CloseResponse(res)
 
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -557,7 +557,7 @@ func (proc *HandleT) makeFeaturesFetchCall() bool {
 		return true
 	}
 
-	defer func() { httputil.CloseResponse(res) }()
+	defer httputil.CloseResponse(res)
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return true

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -182,7 +182,7 @@ func GetVersion() (transformerBuildVersion string) {
 		transformerBuildVersion = fmt.Sprintf("No response from transformer. %s", transformerBuildVersion)
 		return
 	}
-	defer func() { httputil.CloseResponse(resp) }()
+	defer httputil.CloseResponse(resp)
 	if resp.StatusCode == http.StatusOK {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
@@ -391,7 +391,7 @@ func (trans *HandleT) doPost(ctx context.Context, rawJSON []byte, url string, ta
 			if reqErr != nil {
 				return reqErr
 			}
-			defer func() { httputil.CloseResponse(resp) }()
+			defer httputil.CloseResponse(resp)
 			respData, reqErr = io.ReadAll(resp.Body)
 			return reqErr
 		},

--- a/regulation-worker/cmd/main_test.go
+++ b/regulation-worker/cmd/main_test.go
@@ -121,7 +121,7 @@ func startMinioServer(t *testing.T, pool *dockertest.Pool) {
 		if err != nil {
 			return err
 		}
-		defer func() { httputil.CloseResponse(resp) }()
+		defer httputil.CloseResponse(resp)
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("status code not OK")
 		}

--- a/regulation-worker/internal/client/client.go
+++ b/regulation-worker/internal/client/client.go
@@ -59,7 +59,7 @@ func (j *JobAPI) Get(ctx context.Context) (model.Job, error) {
 	if err != nil {
 		return model.Job{}, err
 	}
-	defer func() { httputil.CloseResponse(resp) }()
+	defer httputil.CloseResponse(resp)
 	pkgLogger.Debugf("obtained response code: %v", resp.StatusCode, "response body: ", resp.Body)
 
 	// if successful
@@ -132,7 +132,7 @@ func (j *JobAPI) UpdateStatus(ctx context.Context, status model.JobStatus, jobID
 	if err != nil {
 		return err
 	}
-	defer func() { httputil.CloseResponse(resp) }()
+	defer httputil.CloseResponse(resp)
 
 	pkgLogger.Debugf("response code: %v", resp.StatusCode, "response body: %v", resp.Body)
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {

--- a/regulation-worker/internal/delete/api/api.go
+++ b/regulation-worker/internal/delete/api/api.go
@@ -96,7 +96,7 @@ func (api *APIManager) deleteWithRetry(ctx context.Context, job model.Job, desti
 		}
 		return model.JobStatusFailed
 	}
-	defer func() { httputil.CloseResponse(resp) }()
+	defer httputil.CloseResponse(resp)
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return model.JobStatusFailed

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -1132,7 +1132,7 @@ func (brt *HandleT) postToWarehouse(batchJobs *BatchJobsT, output StorageUploadO
 		brt.logger.Errorf("BRT: Failed to route staging file URL to warehouse service@%v, error:%v", uri, err)
 		return
 	}
-	defer func() { httputil.CloseResponse(resp) }()
+	defer httputil.CloseResponse(resp)
 
 	if resp.StatusCode == http.StatusOK {
 		brt.logger.Infof("BRT: Routed successfully staging file URL to warehouse service@%v", uri)

--- a/router/eventorder_test.go
+++ b/router/eventorder_test.go
@@ -234,8 +234,8 @@ func TestEventOrderGuarantee(t *testing.T) {
 					req.SetBasicAuth(writeKey, "password")
 					resp, err := client.Do(req)
 					require.NoError(t, err, "should be able to send the request to gateway")
+					httputil.CloseResponse(resp)
 					require.Equal(t, http.StatusOK, resp.StatusCode, "should be able to send the request to gateway successfully", payload)
-					func() { httputil.CloseResponse(resp) }()
 				}
 			}()
 

--- a/router/network.go
+++ b/router/network.go
@@ -169,7 +169,7 @@ func (network *NetHandleT) SendPost(ctx context.Context, structData integrations
 			}
 		}
 
-		defer func() { httputil.CloseResponse(resp) }()
+		defer httputil.CloseResponse(resp)
 
 		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {

--- a/router/router_dest_isolation_test.go
+++ b/router/router_dest_isolation_test.go
@@ -161,8 +161,9 @@ func Test_RouterDestIsolation(t *testing.T) {
 		req.SetBasicAuth(writeKey, "password")
 		resp, err := client.Do(req)
 		require.NoError(t, err, "should be able to send the request to gateway")
+		httputil.CloseResponse(resp)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		func() { httputil.CloseResponse(resp) }()
+
 	}
 	require.Eventually(t, func() bool {
 		return atomic.LoadUint64(webhook2.count) == 100 && atomic.LoadUint64(webhook1.count) < 100

--- a/router/router_throttling_test.go
+++ b/router/router_throttling_test.go
@@ -202,8 +202,8 @@ func Test_RouterThrottling(t *testing.T) {
 		req.SetBasicAuth(writeKey, "password")
 		resp, err := client.Do(req)
 		require.NoError(t, err, "should be able to send the request to gateway")
+		httputil.CloseResponse(resp)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		func() { httputil.CloseResponse(resp) }()
 	}
 
 	require.Eventuallyf(t,

--- a/services/alert/pagerduty.go
+++ b/services/alert/pagerduty.go
@@ -38,13 +38,12 @@ func (ops *PagerDuty) Alert(message string) {
 		pkgLogger.Errorf("Alert: Failed to alert service: %s", err.Error())
 		return
 	}
+	defer httputil.CloseResponse(resp)
 
 	if resp.StatusCode != 200 && resp.StatusCode != 202 {
 		pkgLogger.Errorf("Alert: Got error response %d", resp.StatusCode)
 	}
-
 	body, err := io.ReadAll(resp.Body)
-	defer func() { httputil.CloseResponse(resp) }()
 	if err != nil {
 		pkgLogger.Errorf("Alert: Failed to read response body: %s", err.Error())
 		return

--- a/services/alert/victorops.go
+++ b/services/alert/victorops.go
@@ -27,13 +27,13 @@ func (ops *VictorOps) Alert(message string) {
 		pkgLogger.Errorf("Alert: Failed to alert service: %s", err.Error())
 		return
 	}
+	defer httputil.CloseResponse(resp)
 
 	if resp.StatusCode != 200 && resp.StatusCode != 202 {
 		pkgLogger.Errorf("Alert: Got error response %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
-	defer func() { httputil.CloseResponse(resp) }()
 	if err != nil {
 		pkgLogger.Errorf("Alert: Failed to read response body: %s", err.Error())
 		return

--- a/services/controlplane/client.go
+++ b/services/controlplane/client.go
@@ -147,7 +147,7 @@ func (c *Client) SendFeatures(ctx context.Context, component string, features []
 		if err != nil {
 			return fmt.Errorf("doing http request: %w", err)
 		}
-		defer func() { httputil.CloseResponse(resp) }()
+		defer httputil.CloseResponse(resp)
 
 		if resp.StatusCode != http.StatusNoContent {
 			// we don't expect a body, unless there is an error
@@ -194,7 +194,7 @@ func (c *Client) DestinationHistory(ctx context.Context, revisionID string) (bac
 		if err != nil {
 			return err
 		}
-		defer func() { httputil.CloseResponse(resp) }()
+		defer httputil.CloseResponse(resp)
 
 		if resp.StatusCode != http.StatusOK {
 			b, err := io.ReadAll(resp.Body)

--- a/services/debugger/uploader.go
+++ b/services/debugger/uploader.go
@@ -141,7 +141,7 @@ func (uploader *uploaderImpl[E]) uploadEvents(eventBuffer []E) {
 			// Refresh the connection
 			continue
 		}
-		func() { httputil.CloseResponse(resp) }()
+		httputil.CloseResponse(resp)
 		if resp.StatusCode != http.StatusOK {
 			pkgLogger.Errorf("[Uploader] Response Error from Config Backend: Status: %v, Body: %v ", resp.StatusCode, resp.Body)
 		}

--- a/services/destination-connection-tester/destination_connection_tester.go
+++ b/services/destination-connection-tester/destination_connection_tester.go
@@ -88,7 +88,7 @@ func makePostRequest(url string, payload interface{}) error {
 
 		resp, err = client.Do(req)
 		if err == nil {
-			func() { httputil.CloseResponse(resp) }()
+			httputil.CloseResponse(resp)
 			break
 		}
 

--- a/services/filemanager/fileManager_test.go
+++ b/services/filemanager/fileManager_test.go
@@ -92,7 +92,7 @@ func run(m *testing.M) int {
 		if err != nil {
 			return err
 		}
-		defer func() { httputil.CloseResponse(resp) }()
+		defer httputil.CloseResponse(resp)
 
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("status code not OK")

--- a/services/oauth/oauth.go
+++ b/services/oauth/oauth.go
@@ -498,7 +498,7 @@ func processResponse(resp *http.Response) (statusCode int, respBody string) {
 	var ioUtilReadErr error
 	if resp != nil && resp.Body != nil {
 		respData, ioUtilReadErr = io.ReadAll(resp.Body)
-		defer func() { httputil.CloseResponse(resp) }()
+		defer httputil.CloseResponse(resp)
 		if ioUtilReadErr != nil {
 			return http.StatusInternalServerError, ioUtilReadErr.Error()
 		}
@@ -558,7 +558,7 @@ func (authErrHandler *OAuthErrResHandler) cpApiCall(cpReq *ControlPlaneRequestT)
 		}
 		return http.StatusBadRequest, doErr.Error()
 	}
-	defer func() { httputil.CloseResponse(res) }()
+	defer httputil.CloseResponse(res)
 	statusCode, resp := processResponse(res)
 	return statusCode, resp
 }

--- a/testhelper/destination/minio.go
+++ b/testhelper/destination/minio.go
@@ -69,7 +69,7 @@ func SetupMINIO(pool *dockertest.Pool, d cleaner) (*MINIOResource, error) {
 		if err != nil {
 			return err
 		}
-		defer func() { httputil.CloseResponse(resp) }()
+		defer httputil.CloseResponse(resp)
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("status code not OK")
 		}

--- a/testhelper/destination/transformer.go
+++ b/testhelper/destination/transformer.go
@@ -56,7 +56,7 @@ func SetupTransformer(pool *dockertest.Pool, d cleaner) (*TransformerResource, e
 		if err != nil {
 			return err
 		}
-		defer func() { httputil.CloseResponse(resp) }()
+		defer httputil.CloseResponse(resp)
 		if resp.StatusCode != 200 {
 			return errors.New(resp.Status)
 		}

--- a/testhelper/health/checker.go
+++ b/testhelper/health/checker.go
@@ -28,7 +28,7 @@ func WaitUntilReady(
 			if err != nil {
 				continue
 			}
-			func() { httputil.CloseResponse(resp) }()
+			httputil.CloseResponse(resp)
 			if resp.StatusCode == http.StatusOK {
 				t.Log("Application ready")
 				return

--- a/utils/httputil/client_test.go
+++ b/utils/httputil/client_test.go
@@ -82,16 +82,16 @@ func TestReadAndCloseResponse(t *testing.T) {
 		resp, err := http.Get(httpServer.URL)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		func() { httputil.CloseResponse(resp) }()
+		httputil.CloseResponse(resp)
 	})
 
 	t.Run("it can read & close a non nil response that has already been read", func(t *testing.T) {
 		resp, err := http.Get(httpServer.URL)
+		defer httputil.CloseResponse(resp)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		_, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		func() { httputil.CloseResponse(resp) }()
 	})
 
 	t.Run("it won't panic if we try to read & close a nil response", func(t *testing.T) {

--- a/utils/httputil/server_test.go
+++ b/utils/httputil/server_test.go
@@ -86,6 +86,7 @@ func Test_ListenAndServe(t *testing.T) {
 
 			client := http.Client{}
 			resp, err := client.Get(fmt.Sprintf("http://%s/block", addr))
+			defer CloseResponse(resp)
 			if err != nil {
 				return err
 			}
@@ -161,6 +162,7 @@ func Test_ListenAndServe(t *testing.T) {
 			req, _ := http.NewRequestWithContext(clientCtx, http.MethodGet, fmt.Sprintf("http://%s/block", addr), http.NoBody)
 
 			resp, err := client.Do(req)
+			defer CloseResponse(resp)
 			if err != nil {
 				clientErrCh <- err
 				return
@@ -209,7 +211,7 @@ func pingServer(srv *http.Server) bool {
 	if err != nil {
 		return false
 	}
-	resp.Body.Close()
+	CloseResponse(resp)
 
 	return (resp.StatusCode == http.StatusOK)
 }

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -573,11 +573,11 @@ func MakeHTTPRequestWithTimeout(url string, payload io.Reader, timeout time.Dura
 	if err != nil {
 		return []byte{}, 400, err
 	}
+	defer httputil.CloseResponse(resp)
 
 	var respBody []byte
 	if resp != nil && resp.Body != nil {
 		respBody, _ = io.ReadAll(resp.Body)
-		defer func() { httputil.CloseResponse(resp) }()
 	}
 
 	return respBody, resp.StatusCode, nil
@@ -1001,10 +1001,9 @@ func MakeRetryablePostRequest(url, endpoint string, data interface{}) (response 
 	if err != nil {
 		return nil, -1, err
 	}
+	defer httputil.CloseResponse(resp)
 
 	body, err := io.ReadAll(resp.Body)
-	defer func() { httputil.CloseResponse(resp) }()
-
 	pkgLogger.Debugf("Post request: Successful %s", string(body))
 	return body, resp.StatusCode, nil
 }
@@ -1165,11 +1164,11 @@ func GetDatabricksVersion() (version string) {
 		pkgLogger.Errorf("Unable to make a warehouse databricks build version call with error : %s", err.Error())
 		return
 	}
+	defer httputil.CloseResponse(resp)
 	if resp == nil {
 		version = "No response from warehouse."
 		return
 	}
-	defer func() { httputil.CloseResponse(resp) }()
 	if resp.StatusCode == http.StatusOK {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {

--- a/warehouse/client/controlplane/client.go
+++ b/warehouse/client/controlplane/client.go
@@ -62,7 +62,7 @@ func (api *internalClient) GetDestinationSSHKeys(ctx context.Context, id string)
 		return nil, fmt.Errorf("fetching response from http client: %w", err)
 	}
 
-	defer func() { httputil.CloseResponse(resp) }()
+	defer httputil.CloseResponse(resp)
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("%w: key requested: %s", ErrKeyNotFound, id)

--- a/warehouse/testhelper/events.go
+++ b/warehouse/testhelper/events.go
@@ -754,7 +754,7 @@ func send(t testing.TB, payload *strings.Reader, eventType, writeKey, method str
 		t.Errorf("Error occurred while making http request for sending event with error: %s", err.Error())
 		return
 	}
-	defer func() { httputil.CloseResponse(res) }()
+	defer httputil.CloseResponse(res)
 
 	_, err = io.ReadAll(res.Body)
 	if err != nil {

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -1030,6 +1030,7 @@ func GetRequestWithTimeout(ctx context.Context, url string, timeout time.Duratio
 
 	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
+	defer httputil.CloseResponse(resp)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -1037,7 +1038,6 @@ func GetRequestWithTimeout(ctx context.Context, url string, timeout time.Duratio
 	var respBody []byte
 	if resp != nil && resp.Body != nil {
 		respBody, _ = io.ReadAll(resp.Body)
-		func() { httputil.CloseResponse(resp) }()
 	}
 
 	return respBody, nil
@@ -1057,11 +1057,10 @@ func PostRequestWithTimeout(ctx context.Context, url string, payload []byte, tim
 	if err != nil {
 		return []byte{}, err
 	}
-
+	defer httputil.CloseResponse(resp)
 	var respBody []byte
 	if resp != nil && resp.Body != nil {
 		respBody, _ = io.ReadAll(resp.Body)
-		func() { httputil.CloseResponse(resp) }()
 	}
 
 	return respBody, nil


### PR DESCRIPTION
# Description

Using `reuseconn` instead of `bodyclose`, to ensure that http response's are properly disposed (consumed & closed) by a single function call.

Need to wait until the linter is included in golangci-lint (relevant pr [here](https://github.com/golangci/golangci-lint/pull/3464))

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
