### PR TITLE
fix(destination): add proper stats for rt/batch transformation & proxy

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -294,7 +294,7 @@ func (worker *workerT) recordStatsForFailedTransforms(transformType string, tran
 			"transformType": transformType,
 			"statusCode":    strconv.Itoa(destJob.StatusCode),
 			"workspaceId":   destJob.Destination.WorkspaceID,
-			"destination":   destJob.Destination.ID,
+			"destinationId": destJob.Destination.ID,
 		}).Count(1)
 		if destJob.StatusCode != http.StatusOK {
 			transformFailedCountStat := stats.Default.NewTaggedStat("router_transform_num_failed_jobs", stats.CountType, stats.Tags{

--- a/router/router.go
+++ b/router/router.go
@@ -288,6 +288,14 @@ func (worker *workerT) trackStuckDelivery() chan struct{} {
 
 func (worker *workerT) recordStatsForFailedTransforms(transformType string, transformedJobs []types.DestinationJobT) {
 	for _, destJob := range transformedJobs {
+		// Input Stats for batch/router transformation
+		stats.Default.NewTaggedStat("router_transform_num_jobs", stats.CountType, stats.Tags{
+			"destType":      worker.rt.destName,
+			"transformType": transformType,
+			"statusCode":    strconv.Itoa(destJob.StatusCode),
+			"workspaceId":   destJob.Destination.WorkspaceID,
+			"destination":   destJob.Destination.ID,
+		}).Count(1)
 		if destJob.StatusCode != http.StatusOK {
 			transformFailedCountStat := stats.Default.NewTaggedStat("router_transform_num_failed_jobs", stats.CountType, stats.Tags{
 				"destType":      worker.rt.destName,

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -244,7 +244,10 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 }
 
 func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequestParams) (int, string, string) {
-	stats.Default.NewTaggedStat("transformer_proxy.delivery_request", stats.CountType, stats.Tags{"destType": proxyReqParams.DestName}).Increment()
+	stats.Default.NewTaggedStat("transformer_proxy.delivery_request", stats.CountType, stats.Tags{
+		"destType":    proxyReqParams.DestName,
+		"workspaceId": proxyReqParams.ResponseData.Metadata.WorkspaceID,
+	}).Increment()
 	trans.logger.Debugf(`[TransformerProxy] (Dest-%[1]v) {Job - %[2]v} Proxy Request starts - %[1]v`, proxyReqParams.DestName, proxyReqParams.JobID)
 
 	rdlTime := time.Now()

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -245,8 +245,9 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 
 func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequestParams) (int, string, string) {
 	stats.Default.NewTaggedStat("transformer_proxy.delivery_request", stats.CountType, stats.Tags{
-		"destType":    proxyReqParams.DestName,
-		"workspaceId": proxyReqParams.ResponseData.Metadata.WorkspaceID,
+		"destType":      proxyReqParams.DestName,
+		"workspaceId":   proxyReqParams.ResponseData.Metadata.WorkspaceID,
+		"destinationId": proxyReqParams.ResponseData.Metadata.DestinationID,
 	}).Increment()
 	trans.logger.Debugf(`[TransformerProxy] (Dest-%[1]v) {Job - %[2]v} Proxy Request starts - %[1]v`, proxyReqParams.DestName, proxyReqParams.JobID)
 


### PR DESCRIPTION
# Description

For the stats router_batch_num_output_jobs and router_transform_num_output_jobs we don't have workspaceId as one of the labels. And these stats are being used to calculate the percentage of failures
Without workspaceId information, in a multi-tenant kind of environment, it would be very difficult to find out from which workspace are we getting error from.
Also, for transformerProxy enabled destinations, we are using transformer_proxy.delivery_request to calculate the percentage of failures during delivery to destination. Even this stat doesn't have workspaceId

Hence made the changes below

Add workspaceId stat for transformer_proxy_delivery_request
Add a new stat router_transform_num_jobs which tracks the jobs for batch/router transformation, includes workspaceId

## Notion Ticket

https://www.notion.so/rudderstacks/Update-Prometheus-alert-definitions-9bd6abb291b94b61abd20fd52fbce806

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
