### PR TITLE
fix: shallow copy config in processor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,9 @@ test-with-coverage: test coverage
 
 build: ## Build rudder-server binary
 	$(eval BUILD_OPTIONS = )
+ifeq ($(RACE_ENABLED), TRUE)
 	$(eval BUILD_OPTIONS = $(BUILD_OPTIONS) -race -o rudder-server-with-race)
+endif
 	$(GO) build $(BUILD_OPTIONS) -a -installsuffix cgo -ldflags="$(LDFLAGS)"
 	$(GO) build -o build/wait-for-go/wait-for-go build/wait-for-go/wait-for.go
 	$(GO) build -o build/regulation-worker ./regulation-worker/cmd/

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"math"
 	"net/http"
-	"reflect"
 	"runtime/trace"
 	"strconv"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	"golang.org/x/sync/errgroup"
 
@@ -1371,14 +1371,14 @@ func (proc *HandleT) processJobsForDest(subJobs subJob, parsedEventList [][]type
 					destination := &enabledDestinationsList[idx]
 					shallowEventCopy := transformer.TransformerEventT{}
 					shallowEventCopy.Message = singularEvent
-					shallowEventCopy.Destination = reflect.ValueOf(*destination).Interface().(backendconfig.DestinationT)
+					shallowEventCopy.Destination = *destination
 					shallowEventCopy.Libraries = workspaceLibraries
 					shallowEventCopy.Metadata = event.Metadata
 
 					// At the TP flow we are not having destination information, so adding it here.
 					shallowEventCopy.Metadata.DestinationID = destination.ID
 					shallowEventCopy.Metadata.DestinationType = destination.DestinationDefinition.Name
-					filterConfig(&shallowEventCopy, destination)
+					filterConfig(&shallowEventCopy)
 					metadata := shallowEventCopy.Metadata
 					srcAndDestKey := getKeyFromSourceAndDest(metadata.SourceID, metadata.DestinationID)
 					// We have at-least one event so marking it good
@@ -2555,14 +2555,14 @@ func (proc *HandleT) updateRudderSourcesStats(ctx context.Context, tx jobsdb.Sto
 	return err
 }
 
-func filterConfig(eventCopy *transformer.TransformerEventT, destination *backendconfig.DestinationT) {
-	if configsToFilterI, ok := destination.DestinationDefinition.Config["configFilters"]; ok {
+func filterConfig(eventCopy *transformer.TransformerEventT) {
+	if configsToFilterI, ok := eventCopy.Destination.DestinationDefinition.Config["configFilters"]; ok {
 		if configsToFilter, ok := configsToFilterI.([]interface{}); ok {
-			for _, configKey := range configsToFilter {
-				if configKeyStr, ok := configKey.(string); ok {
-					eventCopy.Destination.Config[configKeyStr] = ""
-				}
-			}
+			omitKeys := lo.FilterMap(configsToFilter, func(configKey interface{}, _ int) (string, bool) {
+				configKeyStr, ok := configKey.(string)
+				return configKeyStr, ok
+			})
+			eventCopy.Destination.Config = lo.OmitByKeys(eventCopy.Destination.Config, omitKeys)
 		}
 	}
 }

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2436,9 +2436,7 @@ var _ = Describe("TestConfigFilter", func() {
 					ID:   "1",
 					Name: "test",
 					Config: map[string]interface{}{
-						"config_key":   "config_value",
-						"long_config1": "",
-						"long_config2": "",
+						"config_key": "config_value",
 					},
 					DestinationDefinition: backendconfig.DestinationDefinitionT{
 						Config: map[string]interface{}{
@@ -2455,7 +2453,7 @@ var _ = Describe("TestConfigFilter", func() {
 				},
 				Destination: intgConfig,
 			}
-			filterConfig(&event, &intgConfig)
+			filterConfig(&event)
 			Expect(event).To(Equal(expectedEvent))
 		})
 
@@ -2489,9 +2487,7 @@ var _ = Describe("TestConfigFilter", func() {
 					ID:   "1",
 					Name: "test",
 					Config: map[string]interface{}{
-						"config_key":   "config_value",
-						"long_config1": "",
-						"long_config2": "",
+						"config_key": "config_value",
 					},
 					DestinationDefinition: backendconfig.DestinationDefinitionT{
 						Config: map[string]interface{}{
@@ -2508,7 +2504,7 @@ var _ = Describe("TestConfigFilter", func() {
 				},
 				Destination: intgConfig,
 			}
-			filterConfig(&event, &intgConfig)
+			filterConfig(&event)
 			Expect(event).To(Equal(expectedEvent))
 		})
 
@@ -2556,7 +2552,7 @@ var _ = Describe("TestConfigFilter", func() {
 				},
 				Destination: intgConfig,
 			}
-			filterConfig(&event, &intgConfig)
+			filterConfig(&event)
 			Expect(event).To(Equal(expectedEvent))
 		})
 	})


### PR DESCRIPTION
# Description
Shallow copy destination config for config filters

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=e80d05de22cb4dc48f18741bb7072227&pm=s)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
