### PR TITLE
fix: stats.Timer#End panics with nil pointer

### DIFF
--- a/services/stats/measurement.go
+++ b/services/stats/measurement.go
@@ -128,7 +128,7 @@ func (g *statsdGauge) Gauge(value interface{}) {
 // statsdTimer represents a timer stat
 type statsdTimer struct {
 	*statsdMeasurement
-	timing statsd.Timing
+	timing *statsd.Timing
 }
 
 // Start starts a new timing for this stat. Only applies to TimerType stats
@@ -137,13 +137,14 @@ func (t *statsdTimer) Start() {
 	if t.skip() {
 		return
 	}
-	t.timing = t.client.statsd.NewTiming()
+	timing := t.client.statsd.NewTiming()
+	t.timing = &timing
 }
 
 // End send the time elapsed since the Start()  call of this stat. Only applies to TimerType stats
 // Deprecated: Use concurrent safe SendTiming() instead
 func (t *statsdTimer) End() {
-	if t.skip() {
+	if t.skip() || t.timing == nil {
 		return
 	}
 	t.timing.Send(t.name)

--- a/services/stats/stats_internal_test.go
+++ b/services/stats/stats_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rudderlabs/rudder-server/testhelper"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/alexcesaro/statsd.v2"
 )
 
 // Verifying that even though a Stats instance might initially
@@ -147,4 +148,32 @@ func newStatsdServer(t *testing.T, addr string, f func(string)) *statsdServer {
 func (s *statsdServer) Close() {
 	require.NoError(s.t, s.closer.Close())
 	<-s.closed
+}
+
+func TestTimerIncompleteStartStopScenarios(t *testing.T) {
+	t.Run("Calling Stop without having previously called Start", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			conf := &statsdConfig{
+				enabled: true,
+			}
+			client := &statsdClient{
+				statsd: &statsd.Client{},
+			}
+			m := newStatsdMeasurement(conf, "test", TimerType, client)
+			m.End()
+		})
+	})
+
+	t.Run("Calling Start before client is ready and Stop after client is ready", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			conf := &statsdConfig{
+				enabled: true,
+			}
+			client := &statsdClient{}
+			m := newStatsdMeasurement(conf, "test", TimerType, client)
+			m.Start()
+			client.statsd = &statsd.Client{}
+			m.End()
+		})
+	})
 }


### PR DESCRIPTION
# Description

Treating 2 edge cases where `Timer#Stop` might panic:

1. Calling `Stop` without calling `Start` first.
2. Calling `Start` first, before the statsd client is ready and calling `Stop` next, but after statsd client is ready.


## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=f655981f7a0946f29b613371ae05dd82&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
