### PR TITLE
refactor: timerStat.RecordDuration, Since instead of timerStat.Start, End

### DIFF
--- a/event-schema/event_schema.go
+++ b/event-schema/event_schema.go
@@ -313,8 +313,7 @@ func (manager *EventSchemaManagerT) handleEvent(writeKey string, event EventT) {
 	}
 
 	processingTimer := stats.Default.NewTaggedStat("archive_event_model", stats.TimerType, stats.Tags{"module": "event_schemas", "writeKey": writeKey, "eventIdentifier": eventIdentifier})
-	processingTimer.Start()
-	defer processingTimer.End()
+	defer processingTimer.RecordDuration()()
 
 	// TODO: Create locks on every event_model to improve scaling this
 	manager.eventModelLock.Lock()
@@ -1147,8 +1146,7 @@ func (manager *EventSchemaManagerT) Setup() {
 			defer setEventSchemasPopulated(true)
 
 			populateESTimer := stats.Default.NewTaggedStat("populate_event_schemas", stats.TimerType, stats.Tags{"module": "event_schemas"})
-			populateESTimer.Start()
-			defer populateESTimer.End()
+			defer populateESTimer.RecordDuration()()
 
 			manager.populateEventSchemas()
 		})

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -441,7 +441,7 @@ func (gateway *HandleT) userWebRequestWorkerProcess(userWebRequestWorker *userWe
 		// Saving the event data read from req.request.Body to the splice.
 		// Using this to send event schema to the config backend.
 		var eventBatchesToRecord []sourceDebugger
-		userWebRequestWorker.batchTimeStat.Start()
+		batchStart := time.Now()
 		for _, req := range breq.batchRequest {
 			writeKey := req.writeKey
 			sourceTag := gateway.getSourceTagFromWriteKey(writeKey)
@@ -496,7 +496,7 @@ func (gateway *HandleT) userWebRequestWorkerProcess(userWebRequestWorker *userWe
 			sourcedebugger.RecordEvent(eventBatch.writeKey, eventBatch.data)
 		}
 
-		userWebRequestWorker.batchTimeStat.End()
+		userWebRequestWorker.batchTimeStat.Since(batchStart)
 		gateway.batchSizeStat.Observe(float64(len(breq.batchRequest)))
 
 		for _, v := range sourceStats {

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -350,12 +350,12 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 
 		// stats
 		bt.stats.sourceStats[breq.sourceType].numEvents.Count(len(payloadArr))
-		bt.stats.sourceStats[breq.sourceType].sourceTransform.Start()
 
+		transformStart := time.Now()
 		batchResponse := bt.transform(payloadArr, breq.sourceType)
 
 		// stats
-		bt.stats.sourceStats[breq.sourceType].sourceTransform.End()
+		bt.stats.sourceStats[breq.sourceType].sourceTransform.Since(transformStart)
 
 		if batchResponse.batchError == nil && len(batchResponse.responses) != len(payloadArr) {
 			batchResponse.batchError = errors.New("webhook batch transform response events size does not equal sent events size")

--- a/internal/throttling/throttling.go
+++ b/internal/throttling/throttling.go
@@ -234,8 +234,8 @@ func (l *Limiter) getTimer(key, algo string, rate, window int64) func() {
 		"rate":   strconv.FormatInt(rate, 10),
 		"window": strconv.FormatInt(window, 10),
 	})
-	m.Start()
+	start := time.Now()
 	return func() {
-		m.End()
+		m.Since(start)
 	}
 }

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -77,11 +77,11 @@ So, we don't have to worry about dsEmptyResultCache
 */
 func (jd *HandleT) deleteJobStatus() {
 	err := jd.WithUpdateSafeTx(context.TODO(), func(tx UpdateSafeTx) error {
-		defer jd.sendTiming(
+		defer jd.getTimerStat(
 			"jobsdb_delete_job_status_time",
 			&statTags{
 				CustomValFilters: []string{jd.tablePrefix},
-			})()
+			}).RecordDuration()()
 
 		dsList := jd.getDSList()
 
@@ -101,11 +101,11 @@ func (jd *HandleT) deleteJobStatus() {
 }
 
 func (jd *HandleT) deleteJobStatusDSInTx(txHandler transactionHandler, ds dataSetT) error {
-	defer jd.sendTiming(
+	defer jd.getTimerStat(
 		"jobsdb_delete_job_status_ds_time",
 		&statTags{
 			CustomValFilters: []string{jd.tablePrefix},
-		})()
+		}).RecordDuration()()
 
 	_, err := txHandler.Exec(
 		fmt.Sprintf(
@@ -142,10 +142,10 @@ So, we don't have to worry about dsEmptyResultCache
 */
 func (jd *HandleT) failExecuting() {
 	err := jd.WithUpdateSafeTx(context.TODO(), func(tx UpdateSafeTx) error {
-		defer jd.sendTiming(
+		defer jd.getTimerStat(
 			"jobsdb_fail_executing_time",
 			&statTags{CustomValFilters: []string{jd.tablePrefix}},
-		)()
+		).RecordDuration()()
 
 		dsList := jd.getDSList()
 
@@ -165,10 +165,10 @@ func (jd *HandleT) failExecuting() {
 }
 
 func (jd *HandleT) failExecutingDSInTx(txHandler transactionHandler, ds dataSetT) error {
-	defer jd.sendTiming(
+	defer jd.getTimerStat(
 		"jobsdb_fail_executing_ds_time",
 		&statTags{CustomValFilters: []string{jd.tablePrefix}},
-	)()
+	).RecordDuration()()
 
 	_, err := txHandler.Exec(
 		fmt.Sprintf(

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -77,10 +77,11 @@ So, we don't have to worry about dsEmptyResultCache
 */
 func (jd *HandleT) deleteJobStatus() {
 	err := jd.WithUpdateSafeTx(context.TODO(), func(tx UpdateSafeTx) error {
-		tags := statTags{CustomValFilters: []string{jd.tablePrefix}}
-		queryStat := jd.getTimerStat("jobsdb_delete_job_status_time", &tags)
-		queryStat.Start()
-		defer queryStat.End()
+		defer jd.sendTiming(
+			"jobsdb_delete_job_status_time",
+			&statTags{
+				CustomValFilters: []string{jd.tablePrefix},
+			})()
 
 		dsList := jd.getDSList()
 
@@ -100,10 +101,11 @@ func (jd *HandleT) deleteJobStatus() {
 }
 
 func (jd *HandleT) deleteJobStatusDSInTx(txHandler transactionHandler, ds dataSetT) error {
-	tags := statTags{CustomValFilters: []string{jd.tablePrefix}}
-	queryStat := jd.getTimerStat("jobsdb_delete_job_status_ds_time", &tags)
-	queryStat.Start()
-	defer queryStat.End()
+	defer jd.sendTiming(
+		"jobsdb_delete_job_status_ds_time",
+		&statTags{
+			CustomValFilters: []string{jd.tablePrefix},
+		})()
 
 	_, err := txHandler.Exec(
 		fmt.Sprintf(
@@ -140,12 +142,10 @@ So, we don't have to worry about dsEmptyResultCache
 */
 func (jd *HandleT) failExecuting() {
 	err := jd.WithUpdateSafeTx(context.TODO(), func(tx UpdateSafeTx) error {
-		queryStat := jd.getTimerStat(
+		defer jd.sendTiming(
 			"jobsdb_fail_executing_time",
 			&statTags{CustomValFilters: []string{jd.tablePrefix}},
-		)
-		queryStat.Start()
-		defer queryStat.End()
+		)()
 
 		dsList := jd.getDSList()
 
@@ -165,12 +165,10 @@ func (jd *HandleT) failExecuting() {
 }
 
 func (jd *HandleT) failExecutingDSInTx(txHandler transactionHandler, ds dataSetT) error {
-	queryStat := jd.getTimerStat(
+	defer jd.sendTiming(
 		"jobsdb_fail_executing_ds_time",
 		&statTags{CustomValFilters: []string{jd.tablePrefix}},
-	)
-	queryStat.Start()
-	defer queryStat.End()
+	)()
 
 	_, err := txHandler.Exec(
 		fmt.Sprintf(

--- a/jobsdb/backup.go
+++ b/jobsdb/backup.go
@@ -495,10 +495,10 @@ func getStatusBackupQueryFn(backupDSRange *dataSetRangeT) func(int64) string {
 }
 
 func (jd *HandleT) createTableDumps(queryFunc func(int64) string, pathFunc func(string) (string, error), totalCount int64) (map[string]string, error) {
-	defer jd.sendTiming(
+	defer jd.getTimerStat(
 		"table_FileDump_TimeStat",
 		&statTags{CustomValFilters: []string{jd.tablePrefix}},
-	)()
+	).RecordDuration()()
 	filesWriter := fileuploader.NewGzMultiFileWriter()
 
 	var offset int64
@@ -564,10 +564,10 @@ func (jd *HandleT) createTableDumps(queryFunc func(int64) string, pathFunc func(
 }
 
 func (jd *HandleT) uploadTableDump(ctx context.Context, workspaceID, path string) error {
-	defer jd.sendTiming(
+	defer jd.getTimerStat(
 		"fileUpload_TimeStat",
 		&statTags{CustomValFilters: []string{jd.tablePrefix}},
-	)()
+	).RecordDuration()()
 
 	file, err := os.Open(path)
 	if err != nil {

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -3021,11 +3021,10 @@ Later we can move this to query
 */
 func (jd *HandleT) internalUpdateJobStatusInTx(ctx context.Context, tx *Tx, statusList []*JobStatusT, customValFilters []string, parameterFilters []ParameterFilterT) error {
 	// capture stats
-	tags :=
-		&statTags{
-			CustomValFilters: customValFilters,
-			ParameterFilters: parameterFilters,
-		}
+	tags := &statTags{
+		CustomValFilters: customValFilters,
+		ParameterFilters: parameterFilters,
+	}
 	defer jd.sendTiming(
 		"update_job_status_time",
 		tags,

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -427,9 +427,11 @@ type HandleT struct {
 	statPreDropTableCount         stats.Measurement
 	statDSCount                   stats.Measurement
 	statNewDSPeriod               stats.Measurement
+	newDSCreationTime             time.Time
 	invalidCacheKeyStat           stats.Measurement
 	isStatNewDSPeriodInitialized  bool
 	statDropDSPeriod              stats.Measurement
+	dsDropTime                    time.Time
 	unionQueryTime                stats.Measurement
 	isStatDropDSPeriodInitialized bool
 	logger                        logger.Logger
@@ -1229,9 +1231,9 @@ func (jd *HandleT) addNewDSInTx(tx *Tx, l lock.LockToken, dsList []dataSetT, ds 
 	}
 	// Tracking time interval between new ds creations. Hence calling end before start
 	if jd.isStatNewDSPeriodInitialized {
-		jd.statNewDSPeriod.End()
+		jd.statNewDSPeriod.Since(jd.newDSCreationTime)
 	}
-	jd.statNewDSPeriod.Start()
+	jd.newDSCreationTime = time.Now()
 	jd.isStatNewDSPeriodInitialized = true
 
 	return nil
@@ -1480,9 +1482,9 @@ func (jd *HandleT) postDropDs(ds dataSetT) {
 
 	// Tracking time interval between drop ds operations. Hence calling end before start
 	if jd.isStatDropDSPeriodInitialized {
-		jd.statDropDSPeriod.End()
+		jd.statDropDSPeriod.Since(jd.dsDropTime)
 	}
-	jd.statDropDSPeriod.Start()
+	jd.dsDropTime = time.Now()
 	jd.isStatDropDSPeriodInitialized = true
 }
 

--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/jobsdb/internal/dsindex"
@@ -230,4 +231,13 @@ func (jd *HandleT) getTimerStat(stat string, tags *statTags) stats.Measurement {
 	}
 
 	return stats.Default.NewTaggedStat(stat, stats.TimerType, timingTags)
+}
+
+func (jd *HandleT) sendTiming(statName string, tags *statTags) func() {
+	// https://stackoverflow.com/a/45766707/19093808
+	start := time.Now()
+	return func() {
+		stat := jd.getTimerStat(statName, tags)
+		stat.Since(start)
+	}
 }

--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/jobsdb/internal/dsindex"
@@ -231,13 +230,4 @@ func (jd *HandleT) getTimerStat(stat string, tags *statTags) stats.Measurement {
 	}
 
 	return stats.Default.NewTaggedStat(stat, stats.TimerType, timingTags)
-}
-
-func (jd *HandleT) sendTiming(statName string, tags *statTags) func() {
-	// https://stackoverflow.com/a/45766707/19093808
-	start := time.Now()
-	return func() {
-		stat := jd.getTimerStat(statName, tags)
-		stat.Since(start)
-	}
 }

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -307,10 +307,10 @@ func (jd *HandleT) getMigrationList(dsList []dataSetT) (migrateFrom []dataSetT, 
 }
 
 func (jd *HandleT) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) (int, error) {
-	defer jd.sendTiming(
+	defer jd.getTimerStat(
 		"migration_jobs",
 		&statTags{CustomValFilters: []string{jd.tablePrefix}},
-	)()
+	).RecordDuration()()
 
 	compactDSQuery := fmt.Sprintf(
 		`with last_status as (select * from "v_last_%[1]s"),
@@ -406,10 +406,10 @@ func computeInsertIdx(beforeIndex, afterIndex string) (string, error) {
 func (jd *HandleT) checkIfMigrateDS(ds dataSetT) (
 	migrate, small bool, recordsLeft int,
 ) {
-	defer jd.sendTiming(
+	defer jd.getTimerStat(
 		"migration_ds_check",
 		&statTags{CustomValFilters: []string{jd.tablePrefix}},
-	)()
+	).RecordDuration()()
 
 	var delCount, totalCount, statusCount int
 	sqlStatement := fmt.Sprintf(`SELECT COUNT(*) from %q`, ds.JobTable)

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -307,9 +307,10 @@ func (jd *HandleT) getMigrationList(dsList []dataSetT) (migrateFrom []dataSetT, 
 }
 
 func (jd *HandleT) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) (int, error) {
-	queryStat := stats.Default.NewTaggedStat("migration_jobs", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix})
-	queryStat.Start()
-	defer queryStat.End()
+	defer jd.sendTiming(
+		"migration_jobs",
+		&statTags{CustomValFilters: []string{jd.tablePrefix}},
+	)()
 
 	compactDSQuery := fmt.Sprintf(
 		`with last_status as (select * from "v_last_%[1]s"),
@@ -405,9 +406,10 @@ func computeInsertIdx(beforeIndex, afterIndex string) (string, error) {
 func (jd *HandleT) checkIfMigrateDS(ds dataSetT) (
 	migrate, small bool, recordsLeft int,
 ) {
-	queryStat := stats.Default.NewTaggedStat("migration_ds_check", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix})
-	queryStat.Start()
-	defer queryStat.End()
+	defer jd.sendTiming(
+		"migration_ds_check",
+		&statTags{CustomValFilters: []string{jd.tablePrefix}},
+	)()
 
 	var delCount, totalCount, statusCount int
 	sqlStatement := fmt.Sprintf(`SELECT COUNT(*) from %q`, ds.JobTable)

--- a/jobsdb/queued_db_request.go
+++ b/jobsdb/queued_db_request.go
@@ -2,12 +2,14 @@ package jobsdb
 
 import (
 	"fmt"
+	"time"
 )
 
 func (jd *HandleT) executeDbRequest(c *dbRequest) interface{} {
-	totalTimeStat := jd.getTimerStat(fmt.Sprintf("%s_total_time", c.name), c.tags)
-	totalTimeStat.Start()
-	defer totalTimeStat.End()
+	defer jd.sendTiming(
+		fmt.Sprintf("%s_total_time", c.name),
+		c.tags,
+	)()
 
 	var queueEnabled bool
 	var queueCap chan struct{}
@@ -25,11 +27,11 @@ func (jd *HandleT) executeDbRequest(c *dbRequest) interface{} {
 	}
 
 	if queueEnabled {
+		queuedAt := time.Now()
 		waitTimeStat := jd.getTimerStat(fmt.Sprintf("%s_wait_time", c.name), c.tags)
-		waitTimeStat.Start()
 		queueCap <- struct{}{}
 		defer func() { <-queueCap }()
-		waitTimeStat.End()
+		waitTimeStat.Since(queuedAt)
 	}
 
 	return c.command()

--- a/jobsdb/queued_db_request.go
+++ b/jobsdb/queued_db_request.go
@@ -6,10 +6,10 @@ import (
 )
 
 func (jd *HandleT) executeDbRequest(c *dbRequest) interface{} {
-	defer jd.sendTiming(
+	defer jd.getTimerStat(
 		fmt.Sprintf("%s_total_time", c.name),
 		c.tags,
-	)()
+	).RecordDuration()()
 
 	var queueEnabled bool
 	var queueCap chan struct{}

--- a/mocks/services/stats/mock_stats.go
+++ b/mocks/services/stats/mock_stats.go
@@ -185,6 +185,20 @@ func (mr *MockMeasurementMockRecorder) Observe(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Observe", reflect.TypeOf((*MockMeasurement)(nil).Observe), arg0)
 }
 
+// RecordDuration mocks base method.
+func (m *MockMeasurement) RecordDuration() func() {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RecordDuration")
+	ret0, _ := ret[0].(func())
+	return ret0
+}
+
+// RecordDuration indicates an expected call of RecordDuration.
+func (mr *MockMeasurementMockRecorder) RecordDuration() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordDuration", reflect.TypeOf((*MockMeasurement)(nil).RecordDuration))
+}
+
 // SendTiming mocks base method.
 func (m *MockMeasurement) SendTiming(arg0 time.Duration) {
 	m.ctrl.T.Helper()

--- a/mocks/services/stats/mock_stats.go
+++ b/mocks/services/stats/mock_stats.go
@@ -137,18 +137,6 @@ func (mr *MockMeasurementMockRecorder) Count(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockMeasurement)(nil).Count), arg0)
 }
 
-// End mocks base method.
-func (m *MockMeasurement) End() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "End")
-}
-
-// End indicates an expected call of End.
-func (mr *MockMeasurementMockRecorder) End() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "End", reflect.TypeOf((*MockMeasurement)(nil).End))
-}
-
 // Gauge mocks base method.
 func (m *MockMeasurement) Gauge(arg0 interface{}) {
 	m.ctrl.T.Helper()
@@ -221,16 +209,4 @@ func (m *MockMeasurement) Since(arg0 time.Time) {
 func (mr *MockMeasurementMockRecorder) Since(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Since", reflect.TypeOf((*MockMeasurement)(nil).Since), arg0)
-}
-
-// Start mocks base method.
-func (m *MockMeasurement) Start() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start")
-}
-
-// Start indicates an expected call of Start.
-func (mr *MockMeasurementMockRecorder) Start() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockMeasurement)(nil).Start))
 }

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -295,7 +295,7 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 			close(st.errProcessQ)
 			return
 		case <-time.After(errReadLoopSleep):
-			st.statErrDBR.Start()
+			start := time.Now()
 
 			// NOTE: sending custom val filters array of size 1 to take advantage of cache in jobsdb.
 			queryParams := jobsdb.GetQueryParamsT{
@@ -328,7 +328,7 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 				combinedList = append(combinedList, unprocessed.Jobs...)
 			}
 
-			st.statErrDBR.End()
+			st.statErrDBR.Since(start)
 
 			if len(combinedList) == 0 {
 				st.logger.Debug("[Processor: readErrJobsLoop]: DB Read Complete. No proc_err Jobs to process")

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -123,13 +123,13 @@ func (st *HandleT) runErrWorkers(ctx context.Context) {
 	for i := 0; i < noOfErrStashWorkers; i++ {
 		g.Go(misc.WithBugsnag(func() error {
 			for jobs := range st.errProcessQ {
+				uploadStart := time.Now()
 				uploadStat := stats.Default.NewStat("Processor.err_upload_time", stats.TimerType)
-				uploadStat.Start()
 				errorJobs := st.storeErrorsToObjectStorage(jobs)
 				for _, errorJob := range errorJobs {
 					st.setErrJobStatus(errorJob.jobs, errorJob.errorOutput)
 				}
-				uploadStat.End()
+				uploadStat.Since(uploadStart)
 			}
 
 			return nil

--- a/processor/trackingplan.go
+++ b/processor/trackingplan.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/rudderlabs/rudder-server/config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
@@ -75,9 +76,9 @@ func (proc *HandleT) validateEvents(groupedEventsByWriteKey map[WriteKeyT][]tran
 			continue
 		}
 
-		validationStat.tpValidationTime.Start()
+		validationStart := time.Now()
 		response := proc.transformer.Validate(eventList, integrations.GetTrackingPlanValidationURL(), userTransformBatchSize)
-		validationStat.tpValidationTime.End()
+		validationStat.tpValidationTime.Since(validationStart)
 
 		// If transformerInput does not match with transformerOutput then we do not consider transformerOutput
 		// This is a safety check we are adding so that if something unexpected comes from transformer

--- a/regulation-worker/internal/delete/api/api.go
+++ b/regulation-worker/internal/delete/api/api.go
@@ -80,14 +80,15 @@ func (api *APIManager) deleteWithRetry(ctx context.Context, job model.Job, desti
 		}
 	}
 
-	fileCleaningTime := stats.Default.NewTaggedStat("file_cleaning_time", stats.TimerType, stats.Tags{
-		"jobId":       fmt.Sprintf("%d", job.ID),
-		"workspaceId": job.WorkspaceID,
-		"destType":    "api",
-		"destName":    strings.ToLower(destination.Name),
-	})
-	fileCleaningTime.Start()
-	defer fileCleaningTime.End()
+	defer stats.Default.NewTaggedStat(
+		"file_cleaning_time",
+		stats.TimerType,
+		stats.Tags{
+			"jobId":       fmt.Sprintf("%d", job.ID),
+			"workspaceId": job.WorkspaceID,
+			"destType":    "api",
+			"destName":    strings.ToLower(destination.Name),
+		}).RecordDuration()()
 
 	resp, err := api.Client.Do(req)
 	if err != nil {

--- a/regulation-worker/internal/delete/batch/batch.go
+++ b/regulation-worker/internal/delete/batch/batch.go
@@ -405,8 +405,7 @@ func (bm *BatchManager) Delete(
 						"destType":    "batch",
 						"destName":    destName,
 					})
-				cleanTime.Start()
-				defer cleanTime.End()
+				defer cleanTime.RecordDuration()()
 
 				absPath, err := downloadWithExpBackoff(gCtx, batch.download, files[_i].Key)
 				if err != nil {

--- a/regulation-worker/internal/delete/kvstore/kvstore.go
+++ b/regulation-worker/internal/delete/kvstore/kvstore.go
@@ -29,8 +29,7 @@ func (*KVDeleteManager) Delete(_ context.Context, job model.Job, destDetail mode
 	kvm := kvstoremanager.New(destName, destConfig)
 	var err error
 	fileCleaningTime := stats.Default.NewTaggedStat("file_cleaning_time", stats.TimerType, stats.Tags{"jobId": fmt.Sprintf("%d", job.ID), "workspaceId": job.WorkspaceID, "destType": "kvstore", "destName": destName})
-	fileCleaningTime.Start()
-	defer fileCleaningTime.End()
+	defer fileCleaningTime.RecordDuration()()
 	for _, user := range job.Users {
 		key := fmt.Sprintf("user:%s", user.ID)
 		err = kvm.DeleteKey(key)

--- a/router/router.go
+++ b/router/router.go
@@ -740,7 +740,7 @@ func (worker *workerT) processDestinationJobs() {
 				}
 
 				worker.deliveryTimeStat.SendTiming(timeTaken)
-				deliveryLatencyStat.End()
+				deliveryLatencyStat.Since(startedAt)
 
 				// END: request to destination endpoint
 

--- a/services/stats/measurement.go
+++ b/services/stats/measurement.go
@@ -29,6 +29,7 @@ type Timer interface {
 	End()
 	SendTiming(duration time.Duration)
 	Since(start time.Time)
+	RecordDuration() func()
 }
 
 // Measurement provides all stat measurement functions
@@ -90,6 +91,11 @@ func (m *statsdMeasurement) SendTiming(_ time.Duration) {
 // Since default behavior is to panic as not supported operation
 func (m *statsdMeasurement) Since(_ time.Time) {
 	panic(fmt.Errorf("operation Since not supported for measurement type:%s", m.statType))
+}
+
+// RecordDuration default behavior is to panic as not supported operation
+func (m *statsdMeasurement) RecordDuration() func() {
+	panic(fmt.Errorf("operation RecordDuration not supported for measurement type:%s", m.statType))
 }
 
 // statsdCounter represents a counter stat
@@ -161,6 +167,13 @@ func (t *statsdTimer) SendTiming(duration time.Duration) {
 		return
 	}
 	t.client.statsd.Timing(t.name, int(duration/time.Millisecond))
+}
+
+func (t *statsdTimer) RecordDuration() func() {
+	start := time.Now()
+	return func() {
+		t.Since(start)
+	}
 }
 
 // statsdHistogram represents a histogram stat

--- a/services/stats/measurement.go
+++ b/services/stats/measurement.go
@@ -167,6 +167,9 @@ func (t *statsdTimer) SendTiming(duration time.Duration) {
 	t.client.statsd.Timing(t.name, int(duration/time.Millisecond))
 }
 
+// RecordDuration records the duration of time between
+// the call to this function and the execution of the function it returns.
+// Only applies to TimerType stats
 func (t *statsdTimer) RecordDuration() func() {
 	start := time.Now()
 	return func() {

--- a/services/stats/measurement.go
+++ b/services/stats/measurement.go
@@ -25,8 +25,6 @@ type Histogram interface {
 
 // Timer represents a timer metric
 type Timer interface {
-	Start()
-	End()
 	SendTiming(duration time.Duration)
 	Since(start time.Time)
 	RecordDuration() func()

--- a/services/stats/memstats/stats.go
+++ b/services/stats/memstats/stats.go
@@ -164,6 +164,19 @@ func (m *Measurement) SendTiming(duration time.Duration) {
 	m.durations = append(m.durations, duration)
 }
 
+// RecordDuration implements stats.Measurement
+func (m *Measurement) RecordDuration() func() {
+	if m.mType != stats.TimerType {
+		panic("operation RecordDuration not supported for measurement type:" + m.mType)
+	}
+
+	start := m.now()
+
+	return func() {
+		m.Since(start)
+	}
+}
+
 type Opts func(*Store)
 
 func WithNow(nowFn func() time.Time) Opts {

--- a/services/stats/memstats/stats.go
+++ b/services/stats/memstats/stats.go
@@ -21,9 +21,8 @@ type Store struct {
 }
 
 type Measurement struct {
-	mu        sync.Mutex
-	startTime time.Time
-	now       func() time.Time
+	mu  sync.Mutex
+	now func() time.Time
 
 	tags  stats.Tags
 	name  string
@@ -122,27 +121,6 @@ func (m *Measurement) Observe(value float64) {
 	m.values = append(m.values, value)
 }
 
-// Start implements stats.Measurement
-func (m *Measurement) Start() {
-	if m.mType != stats.TimerType {
-		panic("operation Start not supported for measurement type:" + m.mType)
-	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	m.startTime = m.now()
-}
-
-// End implements stats.Measurement
-func (m *Measurement) End() {
-	if m.mType != stats.TimerType {
-		panic("operation End not supported for measurement type:" + m.mType)
-	}
-
-	m.SendTiming(m.now().Sub(m.startTime))
-}
-
 // Since implements stats.Measurement
 func (m *Measurement) Since(start time.Time) {
 	if m.mType != stats.TimerType {
@@ -171,7 +149,6 @@ func (m *Measurement) RecordDuration() func() {
 	}
 
 	start := m.now()
-
 	return func() {
 		m.Since(start)
 	}

--- a/services/stats/memstats/stats_test.go
+++ b/services/stats/memstats/stats_test.go
@@ -83,19 +83,10 @@ func TestStats(t *testing.T) {
 			store.Get(name, commonTags).Durations(),
 		)
 
-		m.Start()
-		now = now.Add(time.Hour)
-		m.End()
-		require.Equal(t, time.Hour, store.Get(name, commonTags).LastDuration())
-		require.Equal(t,
-			[]time.Duration{time.Second, time.Minute, time.Hour},
-			store.Get(name, commonTags).Durations(),
-		)
-
 		m.Since(now.Add(-time.Minute))
 		require.Equal(t, time.Minute, store.Get(name, commonTags).LastDuration())
 		require.Equal(t,
-			[]time.Duration{time.Second, time.Minute, time.Hour, time.Minute},
+			[]time.Duration{time.Second, time.Minute, time.Minute},
 			store.Get(name, commonTags).Durations(),
 		)
 	})
@@ -112,12 +103,6 @@ func TestStats(t *testing.T) {
 		})
 		require.PanicsWithValue(t, "operation SendTiming not supported for measurement type:histogram", func() {
 			store.NewTaggedStat("invalid_send_timing", stats.HistogramType, commonTags).SendTiming(time.Second)
-		})
-		require.PanicsWithValue(t, "operation Start not supported for measurement type:histogram", func() {
-			store.NewTaggedStat("invalid_start", stats.HistogramType, commonTags).Start()
-		})
-		require.PanicsWithValue(t, "operation End not supported for measurement type:histogram", func() {
-			store.NewTaggedStat("invalid_end", stats.HistogramType, commonTags).End()
 		})
 		require.PanicsWithValue(t, "operation Since not supported for measurement type:histogram", func() {
 			store.NewTaggedStat("invalid_since", stats.HistogramType, commonTags).Since(time.Now())

--- a/services/stats/stats_internal_test.go
+++ b/services/stats/stats_internal_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rudderlabs/rudder-server/testhelper"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/alexcesaro/statsd.v2"
 )
 
 // Verifying that even though a Stats instance might initially
@@ -148,32 +147,4 @@ func newStatsdServer(t *testing.T, addr string, f func(string)) *statsdServer {
 func (s *statsdServer) Close() {
 	require.NoError(s.t, s.closer.Close())
 	<-s.closed
-}
-
-func TestTimerIncompleteStartStopScenarios(t *testing.T) {
-	t.Run("Calling Stop without having previously called Start", func(t *testing.T) {
-		require.NotPanics(t, func() {
-			conf := &statsdConfig{
-				enabled: true,
-			}
-			client := &statsdClient{
-				statsd: &statsd.Client{},
-			}
-			m := newStatsdMeasurement(conf, "test", TimerType, client)
-			m.End()
-		})
-	})
-
-	t.Run("Calling Start before client is ready and Stop after client is ready", func(t *testing.T) {
-		require.NotPanics(t, func() {
-			conf := &statsdConfig{
-				enabled: true,
-			}
-			client := &statsdClient{}
-			m := newStatsdMeasurement(conf, "test", TimerType, client)
-			m.Start()
-			client.statsd = &statsd.Client{}
-			m.End()
-		})
-	})
 }

--- a/services/stats/stats_test.go
+++ b/services/stats/stats_test.go
@@ -33,6 +33,9 @@ func Test_Measurement_Invalid_Operations(t *testing.T) {
 			s.NewStat("test", stats.CountType).Observe(1.2)
 		})
 		require.Panics(t, func() {
+			s.NewStat("test", stats.CountType).RecordDuration()
+		})
+		require.Panics(t, func() {
 			s.NewStat("test", stats.CountType).SendTiming(1)
 		})
 		require.Panics(t, func() {
@@ -51,6 +54,9 @@ func Test_Measurement_Invalid_Operations(t *testing.T) {
 			s.NewStat("test", stats.GaugeType).Observe(1.2)
 		})
 		require.Panics(t, func() {
+			s.NewStat("test", stats.GaugeType).RecordDuration()
+		})
+		require.Panics(t, func() {
 			s.NewStat("test", stats.GaugeType).SendTiming(1)
 		})
 		require.Panics(t, func() {
@@ -67,6 +73,9 @@ func Test_Measurement_Invalid_Operations(t *testing.T) {
 		})
 		require.Panics(t, func() {
 			s.NewStat("test", stats.HistogramType).Gauge(1)
+		})
+		require.Panics(t, func() {
+			s.NewStat("test", stats.HistogramType).RecordDuration()
 		})
 		require.Panics(t, func() {
 			s.NewStat("test", stats.HistogramType).SendTiming(1)

--- a/services/stats/stats_test.go
+++ b/services/stats/stats_test.go
@@ -181,6 +181,18 @@ func Test_Measurement_Operations(t *testing.T) {
 		}, 2*time.Second, time.Millisecond)
 	})
 
+	t.Run("timer RecordDuration", func(t *testing.T) {
+		func() {
+			defer s.NewStat("test-timer-4", stats.TimerType).RecordDuration()()
+			time.Sleep(1 * time.Second)
+		}()
+
+		require.Eventually(t, func() bool {
+			fmt.Println(lastReceived, "=")
+			return lastReceived == "test-timer-4,instanceName=test:1000|ms"
+		}, 2*time.Second, time.Millisecond)
+	})
+
 	t.Run("histogram", func(t *testing.T) {
 		s.NewStat("test-hist-1", stats.HistogramType).Observe(1.2)
 		require.Eventually(t, func() bool {

--- a/services/stats/stats_test.go
+++ b/services/stats/stats_test.go
@@ -33,12 +33,6 @@ func Test_Measurement_Invalid_Operations(t *testing.T) {
 			s.NewStat("test", stats.CountType).Observe(1.2)
 		})
 		require.Panics(t, func() {
-			s.NewStat("test", stats.CountType).Start()
-		})
-		require.Panics(t, func() {
-			s.NewStat("test", stats.CountType).End()
-		})
-		require.Panics(t, func() {
 			s.NewStat("test", stats.CountType).SendTiming(1)
 		})
 		require.Panics(t, func() {
@@ -57,12 +51,6 @@ func Test_Measurement_Invalid_Operations(t *testing.T) {
 			s.NewStat("test", stats.GaugeType).Observe(1.2)
 		})
 		require.Panics(t, func() {
-			s.NewStat("test", stats.GaugeType).Start()
-		})
-		require.Panics(t, func() {
-			s.NewStat("test", stats.GaugeType).End()
-		})
-		require.Panics(t, func() {
 			s.NewStat("test", stats.GaugeType).SendTiming(1)
 		})
 		require.Panics(t, func() {
@@ -79,12 +67,6 @@ func Test_Measurement_Invalid_Operations(t *testing.T) {
 		})
 		require.Panics(t, func() {
 			s.NewStat("test", stats.HistogramType).Gauge(1)
-		})
-		require.Panics(t, func() {
-			s.NewStat("test", stats.HistogramType).Start()
-		})
-		require.Panics(t, func() {
-			s.NewStat("test", stats.HistogramType).End()
 		})
 		require.Panics(t, func() {
 			s.NewStat("test", stats.HistogramType).SendTiming(1)
@@ -169,15 +151,6 @@ func Test_Measurement_Operations(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			return lastReceived == "test-timer-2,instanceName=test:0|ms"
-		}, 2*time.Second, time.Millisecond)
-	})
-
-	t.Run("timer start end", func(t *testing.T) {
-		timer := s.NewStat("test-timer-3", stats.TimerType)
-		timer.Start()
-		timer.End()
-		require.Eventually(t, func() bool {
-			return lastReceived == "test-timer-3,instanceName=test:0|ms"
 		}, 2*time.Second, time.Millisecond)
 	})
 

--- a/warehouse/deltalake/databricks/databricks.go
+++ b/warehouse/deltalake/databricks/databricks.go
@@ -40,8 +40,7 @@ func Init() {
 
 // Close closes sql connection as well as closes grpc connection
 func (dbT *DBHandleT) Close() {
-	dbT.CloseStats.Start()
-	defer dbT.CloseStats.End()
+	defer dbT.CloseStats.RecordDuration()()
 
 	closeConnectionResponse, err := dbT.Client.Close(dbT.Context, &proto.CloseRequest{
 		Config:     dbT.CredConfig,

--- a/warehouse/deltalake/deltalake.go
+++ b/warehouse/deltalake/deltalake.go
@@ -280,8 +280,7 @@ func (dl *HandleT) fetchTables(dbT *databricks.DBHandleT, schema string) (tableN
 		"identifier":  dl.Warehouse.Identifier,
 		"queryType":   "FetchTables",
 	})
-	fetchTablesExecTime.Start()
-	defer fetchTablesExecTime.End()
+	defer fetchTablesExecTime.RecordDuration()()
 
 	fetchTableResponse, err := dbT.Client.FetchTables(dbT.Context, &proto.FetchTablesRequest{
 		Config:     dbT.CredConfig,
@@ -365,8 +364,7 @@ func (dl *HandleT) ExecuteSQL(sqlStatement, queryType string) (err error) {
 		"identifier":  dl.Warehouse.Identifier,
 		"queryType":   queryType,
 	})
-	execSqlStatTime.Start()
-	defer execSqlStatTime.End()
+	defer execSqlStatTime.RecordDuration()()
 
 	err = dl.ExecuteSQLClient(dl.dbHandleT, sqlStatement)
 	return
@@ -400,8 +398,7 @@ func (dl *HandleT) schemaExists(schemaName string) (exists bool, err error) {
 		"identifier":  dl.Warehouse.Identifier,
 		"queryType":   "FetchSchemas",
 	})
-	fetchSchemasExecTime.Start()
-	defer fetchSchemasExecTime.End()
+	defer fetchSchemasExecTime.RecordDuration()()
 
 	sqlStatement := fmt.Sprintf(`SHOW SCHEMAS LIKE '%s';`, schemaName)
 	fetchSchemasResponse, err := dl.dbHandleT.Client.FetchSchemas(dl.dbHandleT.Context, &proto.FetchSchemasRequest{
@@ -439,8 +436,7 @@ func (dl *HandleT) dropStagingTables(tableNames []string) {
 		"identifier":  dl.Warehouse.Identifier,
 		"queryType":   "DropStagingTables",
 	})
-	dropTablesExecTime.Start()
-	defer dropTablesExecTime.End()
+	defer dropTablesExecTime.RecordDuration()()
 
 	for _, stagingTableName := range tableNames {
 		pkgLogger.Infof("%s Dropping table %+v\n", dl.GetLogIdentifier(), stagingTableName)
@@ -961,8 +957,7 @@ func (dl *HandleT) FetchSchema(warehouse warehouseutils.Warehouse) (schema, unre
 		"identifier":  dl.Warehouse.Identifier,
 		"queryType":   "FetchTableAttributes",
 	})
-	fetchTablesAttributesExecTime.Start()
-	defer fetchTablesAttributesExecTime.End()
+	defer fetchTablesAttributesExecTime.RecordDuration()()
 
 	// For each table we are generating schema
 	for _, tableName := range filteredTablesNames {
@@ -1084,8 +1079,7 @@ func (dl *HandleT) GetTotalCountInTable(ctx context.Context, tableName string) (
 		"identifier":  dl.Warehouse.Identifier,
 		"queryType":   "FetchTotalCountInTable",
 	})
-	fetchTotalCountExecTime.Start()
-	defer fetchTotalCountExecTime.End()
+	defer fetchTotalCountExecTime.RecordDuration()()
 
 	sqlStatement := fmt.Sprintf(`SELECT COUNT(*) FROM %[1]s.%[2]s;`, dl.Namespace, tableName)
 	response, err := dl.dbHandleT.Client.FetchTotalCountInTable(ctx, &proto.FetchTotalCountInTableRequest{

--- a/warehouse/deltalake/deltalake.go
+++ b/warehouse/deltalake/deltalake.go
@@ -813,8 +813,7 @@ func (dl *HandleT) connectToWarehouse() (dbHandleT *databricks.DBHandleT, err er
 		"identifier":  dl.Warehouse.Identifier,
 		"queryType":   "Connect",
 	})
-	connStat.Start()
-	defer connStat.End()
+	defer connStat.RecordDuration()()
 
 	closeConnStat := stats.Default.NewTaggedStat("warehouse.deltalake.grpcExecTime", stats.TimerType, stats.Tags{
 		"workspaceId": dl.Warehouse.WorkspaceID,

--- a/warehouse/slave.go
+++ b/warehouse/slave.go
@@ -144,8 +144,7 @@ func (jobRun *JobRunT) downloadStagingFile() error {
 			return err
 		}
 
-		timer := jobRun.timerStat("download_staging_file_time")
-		timer.Start()
+		downloadStart := time.Now()
 
 		err = downloader.Download(context.TODO(), file, job.StagingFileLocation)
 		if err != nil {
@@ -153,7 +152,7 @@ func (jobRun *JobRunT) downloadStagingFile() error {
 			return err
 		}
 		file.Close()
-		timer.End()
+		jobRun.timerStat("download_staging_file_time").Since(downloadStart)
 
 		fi, err := os.Stat(filePath)
 		if err != nil {
@@ -432,8 +431,7 @@ func processStagingFile(job Payload, workerIndex int) (loadFileUploadOutputs []l
 	discardsTable := job.getDiscardsTable()
 	jobRun.tableEventCountMap[discardsTable] = 0
 
-	timer := jobRun.timerStat("process_staging_file_time")
-	timer.Start()
+	processingStart := time.Now()
 
 	lineBytesCounter := 0
 	var interfaceSliceSample []interface{}
@@ -550,7 +548,7 @@ func processStagingFile(job Payload, workerIndex int) (loadFileUploadOutputs []l
 		}
 		jobRun.tableEventCountMap[tableName]++
 	}
-	timer.End()
+	jobRun.timerStat("process_staging_file_time").Since(processingStart)
 
 	pkgLogger.Debugf("[WH]: Process %v bytes from downloaded staging file: %s", lineBytesCounter, job.StagingFileLocation)
 	jobRun.counterStat("bytes_processed_in_staging_file").Count(lineBytesCounter)

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -786,7 +786,7 @@ func (wh *HandleT) mainLoop(ctx context.Context) {
 		wg.Add(len(wh.warehouses))
 
 		whTotalSchedulingStats := wh.stats.NewStat("wh_scheduler.total_scheduling_time", stats.TimerType)
-		whTotalSchedulingStats.Start()
+		whTotalSchedulingStart := time.Now()
 
 		for _, warehouse := range wh.warehouses {
 			w := warehouse
@@ -807,7 +807,7 @@ func (wh *HandleT) mainLoop(ctx context.Context) {
 		wh.configSubscriberLock.RUnlock()
 		wg.Wait()
 
-		whTotalSchedulingStats.End()
+		whTotalSchedulingStats.Since(whTotalSchedulingStart)
 		wh.stats.NewStat("wh_scheduler.warehouse_length", stats.CountType).Count(len(wh.warehouses)) // Correlation between number of warehouses and scheduling time.
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
# Description

Removes `statsdTimer.#Start,#End`
Introduces `statsdTimer.#RecordDuration` - a deferred call will record the duration of the calling function
```
func someFunction(...) error {
    defer timerStat.RecordDuration()()
    // do work
    return nil
}
```
[reference](https://stackoverflow.com/a/45766707/19093808)

## Notion Ticket

[Drop stats.Timer#{Start,Stop} interface](https://www.notion.so/rudderstacks/Drop-stats-Timer-Start-Stop-interface-70f43122b5f4447482d4304f6fab9fd3)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
