### PR TITLE
feat: create environment for every PR using Uffizzi 

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -1,0 +1,96 @@
+name: Build PR Image
+on:
+  pull_request:
+    types: [opened,synchronize,reopened,closed]
+
+jobs:
+
+  build-application:
+    name: Build and Push `application`
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.action != 'closed' }}
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Generate UUID image name
+        id: uuid
+        run: echo "UUID_TAG_APP=$(uuidgen)" >> $GITHUB_ENV
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: registry.uffizzi.com/${{ env.UUID_TAG_APP }}
+          tags: type=raw,value=60d
+      - name: Build and Push Image to registry.uffizzi.com ephemeral registry
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: ./
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: ./Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  render-compose-file:
+    name: Render Docker Compose File
+    # Pass output of this workflow to another triggered by `workflow_run` event.
+    runs-on: ubuntu-latest
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+    needs: 
+      - build-application
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Render Compose File
+        run: |
+          export UFFIZZI_URL=\$UFFIZZI_URL
+          APP_IMAGE=$(echo ${{ needs.build-application.outputs.tags }})
+          export APP_IMAGE
+          export WORKSPACE_TOKEN=${{ secrets.WORKSPACE_TOKEN }}
+          # Render simple template from environment variables.
+          envsubst < ./uffizzi/docker-compose.uffizzi.yml > docker-compose.rendered.yml
+          cat docker-compose.rendered.yml
+      - name: Upload Rendered Compose File as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: docker-compose.rendered.yml
+          retention-days: 2
+      - name: Serialize PR Event to File
+        run:  |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }} 
+          
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2
+
+  delete-preview:
+    name: Call for Preview Deletion
+    runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'closed' }}
+    steps:
+      # If this PR is closing, we will not render a compose file nor pass it to the next workflow.
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -1,0 +1,84 @@
+name: Deploy Uffizzi Preview
+
+on:
+  workflow_run:
+    workflows:
+      - "Build PR Image"
+    types:
+      - completed
+
+
+jobs:
+  cache-compose-file:
+    name: Cache Compose File
+    runs-on: ubuntu-latest
+    outputs:
+      compose-file-cache-key: ${{ env.COMPOSE_FILE_HASH }}
+      pr-number: ${{ env.PR_NUMBER }}
+    steps:
+      - name: 'Download artifacts'
+        # Fetch output (zip archive) from the workflow run that triggered this workflow.
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "preview-spec"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
+      - name: 'Unzip artifact'
+        run: unzip preview-spec.zip
+      - name: Read Event into ENV
+        run: |
+          echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
+          cat event.json >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - name: Hash Rendered Compose File
+        id: hash
+        # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        run: echo "COMPOSE_FILE_HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_ENV
+      - name: Cache Rendered Compose File
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        uses: actions/cache@v3
+        with:
+          path: docker-compose.rendered.yml
+          key: ${{ env.COMPOSE_FILE_HASH }}
+
+      - name: Read PR Number From Event Object
+        id: pr
+        run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
+
+      - name: DEBUG - Print Job Outputs
+        if: ${{ runner.debug }}
+        run: |
+          echo "PR number: ${{ env.PR_NUMBER }}"
+          echo "Compose file hash: ${{ env.COMPOSE_FILE_HASH }}"
+          cat event.json
+  deploy-uffizzi-preview:
+    name: Use Remote Workflow to Preview on Uffizzi
+    needs:
+      - cache-compose-file
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2
+    with:
+      # If this workflow was triggered by a PR close event, cache-key will be an empty string
+      # and this reusable workflow will delete the preview deployment.
+      compose-file-cache-key: ${{ needs.cache-compose-file.outputs.compose-file-cache-key }}
+      compose-file-cache-path: docker-compose.rendered.yml
+      server: https://app.uffizzi.com
+      pr-number: ${{ needs.cache-compose-file.outputs.pr-number }}
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write

--- a/uffizzi/docker-compose.uffizzi.yml
+++ b/uffizzi/docker-compose.uffizzi.yml
@@ -1,0 +1,70 @@
+version: '3.7'
+
+x-uffizzi:
+  ingress:
+    service: backend
+    port: 8080
+
+services:
+
+  db:
+    image: postgres:15-alpine
+    environment:
+      - POSTGRES_USER=rudder
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=jobsdb
+    ports:
+      - "6432:5432"
+    deploy:
+      resources:
+        limits:
+          memory: 500m
+
+  backend:
+    depends_on:
+      - db
+      - metrics-exporter
+      - d-transformer
+    image: ${APP_IMAGE}
+    ports:
+      - "8080:8080"
+    environment:
+      JOBS_DB_HOST: 127.0.0.1
+      JOBS_DB_USER: rudder
+      JOBS_DB_PORT: 5432
+      JOBS_DB_DB_NAME: jobsdb
+      JOBS_DB_PASSWORD: password
+      DEST_TRANSFORM_URL: http://127.0.0.1:9090
+      CONFIG_BACKEND_URL: https://api.rudderstack.com
+      WORKSPACE_TOKEN: "${WORKSPACE_TOKEN}"
+      STATSD_SERVER_URL: metrics-exporter:9125
+      # - RSERVER_BACKEND_CONFIG_CONFIG_FROM_FILE=true
+      # - RSERVER_BACKEND_CONFIG_CONFIG_JSONPATH=/etc/rudderstack/workspaceConfig.json
+    entrypoint: ["/bin/sh"]
+    command: ["-c", "/wait-for 127.0.0.1:5432 -- /rudder-server"]
+    deploy:
+      resources:
+        limits:
+          memory: 2000m
+
+  d-transformer:
+    depends_on:
+      - metrics-exporter
+    image: rudderlabs/rudder-transformer:latest
+    ports:
+      - "9090:9090"
+    environment:
+      - STATSD_SERVER_HOST=127.0.0.1
+      - STATSD_SERVER_PORT="9125"
+    deploy:
+      resources:
+        limits:
+          memory: 500m
+  metrics-exporter:
+    image: prom/statsd-exporter:v0.22.4
+    ports:
+      - "9102:9102"
+    deploy:
+      resources:
+        limits:
+          memory: 500m      


### PR DESCRIPTION
This PR is a part of https://github.com/rudderlabs/rudder-server/issues/2762 and helps demonstrate Uffizzi integration with **rudder-server**. 

This will help create preview environments on all of **rudder-server** Pull Requests and help contributors including the maintainers iterate faster on their PRs. 
I have created a PR over https://github.com/daramayis/f-rudder-server/pull/1#issuecomment-1380173320 to show what it looks like to have a preview environment deployed against your PR.

You can check out the preview over here [lnik](https://app.uffizzi.com/github.com/daramayis/f-rudder-server/pull/1) as well. (so it's the `data_plane_url` :rocket:  )

After the merge, please add in repository secrets the `WORKSPACE_TOKEN` — so the preview will use that `WORKSPACE_TOKEN`.


@waveywaves