### PR TITLE
refactor(processor): stop using global variables

### DIFF
--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -171,14 +171,11 @@ func initJobsDB() {
 	router.InitRouterAdmin()
 	batchrouter.Init()
 	batchrouter.Init2()
-	processor.Init()
 	Init()
 }
 
 func TestDynamicClusterManager(t *testing.T) {
 	initJobsDB()
-
-	processor.SetFeaturesRetryAttempts(0)
 
 	mockCtrl := gomock.NewController(t)
 	mockMTI := mock_tenantstats.NewMockMultiTenantI(mockCtrl)
@@ -202,7 +199,8 @@ func TestDynamicClusterManager(t *testing.T) {
 		"batch_rt": &jobsdb.MultiTenantLegacy{HandleT: brtDB},
 	})
 
-	processor := processor.New(ctx, &clearDb, gwDB, rtDB, brtDB, errDB, mockMTI, &reporting.NOOP{}, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), rsources.NewNoOpService(), destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService())
+	processor := processor.New(ctx, &clearDb, gwDB, rtDB, brtDB, errDB, mockMTI, &reporting.NOOP{}, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), rsources.NewNoOpService(), destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService(),
+		processor.WithFeaturesRetryMaxAttempts(0))
 	processor.BackendConfig = mockBackendConfig
 	processor.Transformer = mockTransformer
 	mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
 
+	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/enterprise/reporting"
 	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
 	"github.com/rudderlabs/rudder-server/services/fileuploader"
@@ -38,6 +39,7 @@ import (
 	"github.com/rudderlabs/rudder-server/services/archiver"
 	"github.com/rudderlabs/rudder-server/services/multitenant"
 	"github.com/rudderlabs/rudder-server/utils/logger"
+	"github.com/rudderlabs/rudder-server/utils/pubsub"
 )
 
 var (
@@ -130,7 +132,6 @@ func initJobsDB() {
 	jobsdb.Init2()
 	jobsdb.Init3()
 	archiver.Init()
-	Init()
 }
 
 func genJobs(customVal string, jobCount, eventsPerJob int) []*jobsdb.JobT {
@@ -149,16 +150,12 @@ func genJobs(customVal string, jobCount, eventsPerJob int) []*jobsdb.JobT {
 }
 
 func TestProcessorManager(t *testing.T) {
-	temp := isUnLocked
-	defer func() { isUnLocked = temp }()
 	initJobsDB()
 	mockCtrl := gomock.NewController(t)
 	mockBackendConfig := mocksBackendConfig.NewMockBackendConfig(mockCtrl)
 	mockTransformer := mocksTransformer.NewMockTransformer(mockCtrl)
 	mockRsourcesService := rsources.NewMockJobService(mockCtrl)
 
-	SetFeaturesRetryAttempts(0)
-	enablePipelining = false
 	RegisterTestingT(t)
 	triggerAddNewDS := make(chan time.Time)
 	maxDSSize := 10
@@ -205,7 +202,11 @@ func TestProcessorManager(t *testing.T) {
 			"batch_rt": &jobsdb.MultiTenantLegacy{HandleT: brtDB},
 		},
 	}
-	processor := New(ctx, &clearDb, gwDB, rtDB, brtDB, errDB, mtStat, &reporting.NOOP{}, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), mockRsourcesService, destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService())
+	processor := New(ctx, &clearDb, gwDB, rtDB, brtDB, errDB, mtStat, &reporting.NOOP{}, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), mockRsourcesService, destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService(),
+		func(m *LifecycleManager) {
+			m.Handle.config.enablePipelining = false
+			m.Handle.config.featuresRetryMaxAttempts = 0
+		})
 
 	t.Run("jobs are already there in GW DB before processor starts", func(t *testing.T) {
 		require.NoError(t, gwDB.Start())
@@ -216,14 +217,21 @@ func TestProcessorManager(t *testing.T) {
 		defer brtDB.Stop()
 		require.NoError(t, errDB.Start())
 		defer errDB.Stop()
-		mockBackendConfig.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1)
+		mockBackendConfig.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+			func(ctx context.Context, topic backendconfig.Topic) pubsub.DataChannel {
+				ch := make(chan pubsub.DataEvent, 1)
+				ch <- pubsub.DataEvent{Data: map[string]backendconfig.ConfigT{sampleWorkspaceID: sampleBackendConfig}, Topic: string(topic)}
+				close(ch)
+				return ch
+			},
+		)
 		mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
 		mockTransformer.EXPECT().Setup().Times(1).Do(func() {
-			processor.HandleT.transformerFeatures = json.RawMessage(defaultTransformerFeatures)
+			processor.Handle.transformerFeatures = json.RawMessage(defaultTransformerFeatures)
 		})
 		mockRsourcesService.EXPECT().IncrementStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), rsources.Stats{Out: 10}).Times(1)
 		processor.BackendConfig = mockBackendConfig
-		processor.HandleT.transformer = mockTransformer
+		processor.Handle.transformer = mockTransformer
 		require.NoError(t, processor.Start())
 		defer processor.Stop()
 		Eventually(func() int {
@@ -246,10 +254,18 @@ func TestProcessorManager(t *testing.T) {
 		defer brtDB.Stop()
 		require.NoError(t, errDB.Start())
 		defer errDB.Stop()
-		mockBackendConfig.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1)
+		mockBackendConfig.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+			func(ctx context.Context, topic backendconfig.Topic) pubsub.DataChannel {
+				ch := make(chan pubsub.DataEvent, 1)
+				ch <- pubsub.DataEvent{Data: map[string]backendconfig.ConfigT{sampleWorkspaceID: sampleBackendConfig}, Topic: string(topic)}
+				close(ch)
+				return ch
+			},
+		)
+
 		mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
 		mockTransformer.EXPECT().Setup().Times(1).Do(func() {
-			processor.HandleT.transformerFeatures = json.RawMessage(defaultTransformerFeatures)
+			processor.Handle.transformerFeatures = json.RawMessage(defaultTransformerFeatures)
 		})
 		mockRsourcesService.EXPECT().IncrementStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), rsources.Stats{Out: 10}).Times(1)
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -46,14 +46,27 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
+const (
+	MetricKeyDelimiter = "!<<#>>!"
+	UserTransformation = "USER_TRANSFORMATION"
+	DestTransformation = "DEST_TRANSFORMATION"
+	EventFilter        = "EVENT_FILTER"
+)
+
 var jsonfast = jsoniter.ConfigCompatibleWithStandardLibrary
 
 func RegisterAdminHandlers(readonlyProcErrorDB jobsdb.ReadonlyJobsDB) {
 	admin.RegisterAdminHandler("ProcErrors", &stash.StashRpcHandler{ReadOnlyJobsDB: readonlyProcErrorDB})
 }
 
-// HandleT is a handle to this object used in main.go
-type HandleT struct {
+func NewHandle(transformer transformer.Transformer) *Handle {
+	h := &Handle{transformer: transformer}
+	h.loadConfig()
+	return h
+}
+
+// Handle is a handle to the processor module
+type Handle struct {
 	backendConfig             backendconfig.BackendConfig
 	transformer               transformer.Transformer
 	lastJobID                 int64
@@ -70,9 +83,6 @@ type HandleT struct {
 	backgroundWait            func() error
 	backgroundCancel          context.CancelFunc
 	transformerFeatures       json.RawMessage
-	readLoopSleep             time.Duration
-	maxLoopSleep              time.Duration
-	storeTimeout              time.Duration
 	statsFactory              stats.Stats
 	stats                     processorStats
 	payloadLimit              int64
@@ -84,6 +94,37 @@ type HandleT struct {
 	rsourcesService           rsources.JobService
 	destDebugger              destinationdebugger.DestinationDebugger
 	transDebugger             transformationdebugger.TransformationDebugger
+	config                    struct {
+		mainLoopTimeout           time.Duration
+		featuresRetryMaxAttempts  int
+		enablePipelining          bool
+		pipelineBufferedItems     int
+		subJobSize                int
+		readLoopSleep             time.Duration
+		maxLoopSleep              time.Duration
+		storeTimeout              time.Duration
+		loopSleep                 time.Duration // DEPRECATED: used only on the old mainLoop
+		fixedLoopSleep            time.Duration // DEPRECATED: used only on the old mainLoop
+		maxEventsToProcess        int
+		transformBatchSize        int
+		userTransformBatchSize    int
+		writeKeyDestinationMap    map[string][]backendconfig.DestinationT
+		writeKeySourceMap         map[string]backendconfig.SourceT
+		workspaceLibrariesMap     map[string]backendconfig.LibrariesT
+		destinationIDtoTypeMap    map[string]string
+		batchDestinations         []string
+		configSubscriberLock      sync.RWMutex
+		enableEventSchemasFeature bool
+		enableEventSchemasAPIOnly bool
+		enableDedup               bool
+		enableEventCount          bool
+		transformTimesPQLength    int
+		captureEventNameStats     bool
+		transformerURL            string
+		pollInterval              time.Duration
+		GWCustomVal               string
+		asyncInit                 *misc.AsyncInit
+	}
 }
 
 type processorStats struct {
@@ -136,11 +177,6 @@ var defaultTransformerFeatures = `{
 	}
   }`
 
-var (
-	mainLoopTimeout          = 200 * time.Millisecond
-	featuresRetryMaxAttempts = 10
-)
-
 type DestStatT struct {
 	numEvents              stats.Measurement
 	numOutputSuccessEvents stats.Measurement
@@ -187,13 +223,6 @@ type (
 	SourceIDT string
 )
 
-const (
-	METRICKEYDELIMITER  = "!<<#>>!"
-	USER_TRANSFORMATION = "USER_TRANSFORMATION"
-	DEST_TRANSFORMATION = "DEST_TRANSFORMATION"
-	EVENT_FILTER        = "EVENT_FILTER"
-)
-
 func buildStatTags(sourceID, workspaceID string, destination *backendconfig.DestinationT, transformationType string) map[string]string {
 	module := "router"
 	if batchrouter.IsObjectStorageDestination(destination.DestinationDefinition.Name) {
@@ -213,8 +242,8 @@ func buildStatTags(sourceID, workspaceID string, destination *backendconfig.Dest
 	}
 }
 
-func (proc *HandleT) newUserTransformationStat(sourceID, workspaceID string, destination *backendconfig.DestinationT) *DestStatT {
-	tags := buildStatTags(sourceID, workspaceID, destination, USER_TRANSFORMATION)
+func (proc *Handle) newUserTransformationStat(sourceID, workspaceID string, destination *backendconfig.DestinationT) *DestStatT {
+	tags := buildStatTags(sourceID, workspaceID, destination, UserTransformation)
 
 	tags["transformation_id"] = destination.Transformations[0].ID
 	tags["transformation_version_id"] = destination.Transformations[0].VersionID
@@ -236,8 +265,8 @@ func (proc *HandleT) newUserTransformationStat(sourceID, workspaceID string, des
 	}
 }
 
-func (proc *HandleT) newDestinationTransformationStat(sourceID, workspaceID, transformAt string, destination *backendconfig.DestinationT) *DestStatT {
-	tags := buildStatTags(sourceID, workspaceID, destination, DEST_TRANSFORMATION)
+func (proc *Handle) newDestinationTransformationStat(sourceID, workspaceID, transformAt string, destination *backendconfig.DestinationT) *DestStatT {
+	tags := buildStatTags(sourceID, workspaceID, destination, DestTransformation)
 
 	tags["transform_at"] = transformAt
 	tags["error"] = "false"
@@ -258,8 +287,8 @@ func (proc *HandleT) newDestinationTransformationStat(sourceID, workspaceID, tra
 	}
 }
 
-func (proc *HandleT) newEventFilterStat(sourceID, workspaceID string, destination *backendconfig.DestinationT) *DestStatT {
-	tags := buildStatTags(sourceID, workspaceID, destination, EVENT_FILTER)
+func (proc *Handle) newEventFilterStat(sourceID, workspaceID string, destination *backendconfig.DestinationT) *DestStatT {
+	tags := buildStatTags(sourceID, workspaceID, destination, EventFilter)
 	tags["error"] = "false"
 
 	numEvents := proc.statsFactory.NewTaggedStat("proc_event_filter_in_count", stats.CountType, tags)
@@ -278,12 +307,7 @@ func (proc *HandleT) newEventFilterStat(sourceID, workspaceID string, destinatio
 	}
 }
 
-func Init() {
-	loadConfig()
-	pkgLogger = logger.NewLogger().Child("processor")
-}
-
-func (proc *HandleT) Status() interface{} {
+func (proc *Handle) Status() interface{} {
 	proc.stats.transformEventsByTimeMutex.RLock()
 	defer proc.stats.transformEventsByTimeMutex.RUnlock()
 	statusRes := make(map[string][]interface{})
@@ -293,8 +317,7 @@ func (proc *HandleT) Status() interface{} {
 	for _, pqUserEvent := range proc.stats.userTransformEventsByTimeTaken {
 		statusRes["user-transformer"] = append(statusRes["user-transformer"], *pqUserEvent)
 	}
-
-	if enableDedup {
+	if proc.config.enableDedup {
 		proc.dedupHandler.PrintHistogram()
 	}
 
@@ -302,7 +325,7 @@ func (proc *HandleT) Status() interface{} {
 }
 
 // Setup initializes the module
-func (proc *HandleT) Setup(
+func (proc *Handle) Setup(
 	backendConfig backendconfig.BackendConfig, gatewayDB, routerDB jobsdb.JobsDB,
 	batchRouterDB, errorDB jobsdb.JobsDB, clearDB *bool, reporting types.ReportingI,
 	multiTenantStat multitenant.MultiTenantI, transientSources transientsource.Service,
@@ -316,12 +339,8 @@ func (proc *HandleT) Setup(
 	config.RegisterDurationConfigVariable(60, &proc.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB.Processor.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
 	config.RegisterDurationConfigVariable(90, &proc.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.Processor.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
 	config.RegisterIntConfigVariable(3, &proc.jobdDBMaxRetries, true, 1, []string{"JobsDB.Processor.MaxRetries", "JobsDB.MaxRetries"}...)
-	proc.logger = pkgLogger
+	proc.logger = logger.NewLogger().Child("processor")
 	proc.backendConfig = backendConfig
-
-	proc.readLoopSleep = readLoopSleep
-	proc.maxLoopSleep = maxLoopSleep
-	proc.storeTimeout = storeTimeout
 
 	proc.multitenantI = multiTenantStat
 	proc.gatewayDB = gatewayDB
@@ -335,8 +354,8 @@ func (proc *HandleT) Setup(
 
 	// Stats
 	proc.statsFactory = stats.Default
-	proc.stats.userTransformEventsByTimeTaken = make([]*TransformRequestT, 0, transformTimesPQLength)
-	proc.stats.destTransformEventsByTimeTaken = make([]*TransformRequestT, 0, transformTimesPQLength)
+	proc.stats.userTransformEventsByTimeTaken = make([]*TransformRequestT, 0, proc.config.transformTimesPQLength)
+	proc.stats.destTransformEventsByTimeTaken = make([]*TransformRequestT, 0, proc.config.transformTimesPQLength)
 	proc.stats.statGatewayDBR = proc.statsFactory.NewStat("processor.gateway_db_read", stats.CountType)
 	proc.stats.statGatewayDBW = proc.statsFactory.NewStat("processor.gateway_db_write", stats.CountType)
 	proc.stats.statRouterDBW = proc.statsFactory.NewStat("processor.router_db_write", stats.CountType)
@@ -392,10 +411,10 @@ func (proc *HandleT) Setup(
 	proc.stats.transformationsThroughput = proc.statsFactory.NewStat("processor.transformations_throughput", stats.CountType)
 	proc.stats.DBWriteThroughput = proc.statsFactory.NewStat("processor.db_write_throughput", stats.CountType)
 	admin.RegisterStatusHandler("processor", proc)
-	if enableEventSchemasFeature {
+	if proc.config.enableEventSchemasFeature {
 		proc.eventSchemaHandler = event_schema.GetInstance()
 	}
-	if enableDedup {
+	if proc.config.enableDedup {
 		proc.dedupHandler = dedup.GetInstance(clearDB)
 	}
 
@@ -405,8 +424,9 @@ func (proc *HandleT) Setup(
 	proc.backgroundWait = g.Wait
 	proc.backgroundCancel = cancel
 
+	proc.config.asyncInit = misc.NewAsyncInit(2)
 	rruntime.Go(func() {
-		proc.backendConfigSubscriber()
+		proc.backendConfigSubscriber(ctx)
 	})
 
 	g.Go(misc.WithBugsnag(func() error {
@@ -415,17 +435,16 @@ func (proc *HandleT) Setup(
 	}))
 
 	proc.transformer.Setup()
-
 	proc.crashRecover()
 }
 
 // Start starts this processor's main loops.
-func (proc *HandleT) Start(ctx context.Context) error {
+func (proc *Handle) Start(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(misc.WithBugsnag(func() error {
 		proc.backendConfig.WaitForConfig(ctx)
-		if enablePipelining {
+		if proc.config.enablePipelining {
 			proc.mainPipeline(ctx)
 		} else {
 			proc.mainLoop(ctx)
@@ -443,72 +462,43 @@ func (proc *HandleT) Start(ctx context.Context) error {
 	return g.Wait()
 }
 
-func (proc *HandleT) Shutdown() {
+func (proc *Handle) Shutdown() {
 	proc.backgroundCancel()
 	_ = proc.backgroundWait()
 }
 
-var (
-	enablePipelining          bool
-	pipelineBufferedItems     int
-	subJobSize                int
-	readLoopSleep             time.Duration
-	maxLoopSleep              time.Duration
-	storeTimeout              time.Duration
-	loopSleep                 time.Duration // DEPRECATED: used only on the old mainLoop
-	fixedLoopSleep            time.Duration // DEPRECATED: used only on the old mainLoop
-	maxEventsToProcess        int
-	transformBatchSize        int
-	userTransformBatchSize    int
-	writeKeyDestinationMap    map[string][]backendconfig.DestinationT
-	writeKeySourceMap         map[string]backendconfig.SourceT
-	workspaceLibrariesMap     map[string]backendconfig.LibrariesT
-	destinationIDtoTypeMap    map[string]string
-	batchDestinations         []string
-	configSubscriberLock      sync.RWMutex
-	pkgLogger                 logger.Logger
-	enableEventSchemasFeature bool
-	enableEventSchemasAPIOnly bool
-	enableDedup               bool
-	enableEventCount          bool
-	transformTimesPQLength    int
-	captureEventNameStats     bool
-	transformerURL            string
-	pollInterval              time.Duration
-	isUnLocked                bool
-	GWCustomVal               string
-)
+func (proc *Handle) loadConfig() {
+	proc.config.mainLoopTimeout = 200 * time.Millisecond
+	proc.config.featuresRetryMaxAttempts = 10
+	config.RegisterBoolConfigVariable(true, &proc.config.enablePipelining, false, "Processor.enablePipelining")
+	config.RegisterIntConfigVariable(0, &proc.config.pipelineBufferedItems, false, 1, "Processor.pipelineBufferedItems")
+	config.RegisterIntConfigVariable(2000, &proc.config.subJobSize, false, 1, "Processor.subJobSize")
+	config.RegisterDurationConfigVariable(5000, &proc.config.maxLoopSleep, true, time.Millisecond, []string{"Processor.maxLoopSleep", "Processor.maxLoopSleepInMS"}...)
+	config.RegisterDurationConfigVariable(5, &proc.config.storeTimeout, true, time.Minute, "Processor.storeTimeout")
 
-func loadConfig() {
-	config.RegisterBoolConfigVariable(true, &enablePipelining, false, "Processor.enablePipelining")
-	config.RegisterIntConfigVariable(0, &pipelineBufferedItems, false, 1, "Processor.pipelineBufferedItems")
-	config.RegisterIntConfigVariable(2000, &subJobSize, false, 1, "Processor.subJobSize")
-	config.RegisterDurationConfigVariable(5000, &maxLoopSleep, true, time.Millisecond, []string{"Processor.maxLoopSleep", "Processor.maxLoopSleepInMS"}...)
-	config.RegisterDurationConfigVariable(5, &storeTimeout, true, time.Minute, "Processor.storeTimeout")
-
-	config.RegisterDurationConfigVariable(200, &readLoopSleep, true, time.Millisecond, "Processor.readLoopSleep")
+	config.RegisterDurationConfigVariable(200, &proc.config.readLoopSleep, true, time.Millisecond, "Processor.readLoopSleep")
 	// DEPRECATED: used only on the old mainLoop:
-	config.RegisterDurationConfigVariable(10, &loopSleep, true, time.Millisecond, []string{"Processor.loopSleep", "Processor.loopSleepInMS"}...)
+	config.RegisterDurationConfigVariable(10, &proc.config.loopSleep, true, time.Millisecond, []string{"Processor.loopSleep", "Processor.loopSleepInMS"}...)
 	// DEPRECATED: used only on the old mainLoop:
-	config.RegisterDurationConfigVariable(0, &fixedLoopSleep, true, time.Millisecond, []string{"Processor.fixedLoopSleep", "Processor.fixedLoopSleepInMS"}...)
-	config.RegisterIntConfigVariable(100, &transformBatchSize, true, 1, "Processor.transformBatchSize")
-	config.RegisterIntConfigVariable(200, &userTransformBatchSize, true, 1, "Processor.userTransformBatchSize")
+	config.RegisterDurationConfigVariable(0, &proc.config.fixedLoopSleep, true, time.Millisecond, []string{"Processor.fixedLoopSleep", "Processor.fixedLoopSleepInMS"}...)
+	config.RegisterIntConfigVariable(100, &proc.config.transformBatchSize, true, 1, "Processor.transformBatchSize")
+	config.RegisterIntConfigVariable(200, &proc.config.userTransformBatchSize, true, 1, "Processor.userTransformBatchSize")
 	// Enable dedup of incoming events by default
-	config.RegisterBoolConfigVariable(false, &enableDedup, false, "Dedup.enableDedup")
-	config.RegisterBoolConfigVariable(true, &enableEventCount, true, "Processor.enableEventCount")
+	config.RegisterBoolConfigVariable(false, &proc.config.enableDedup, false, "Dedup.enableDedup")
+	config.RegisterBoolConfigVariable(true, &proc.config.enableEventCount, true, "Processor.enableEventCount")
 	// EventSchemas feature. false by default
-	config.RegisterBoolConfigVariable(false, &enableEventSchemasFeature, false, "EventSchemas.enableEventSchemasFeature")
-	config.RegisterBoolConfigVariable(false, &enableEventSchemasAPIOnly, true, "EventSchemas.enableEventSchemasAPIOnly")
-	config.RegisterIntConfigVariable(10000, &maxEventsToProcess, true, 1, "Processor.maxLoopProcessEvents")
+	config.RegisterBoolConfigVariable(false, &proc.config.enableEventSchemasFeature, false, "EventSchemas.enableEventSchemasFeature")
+	config.RegisterBoolConfigVariable(false, &proc.config.enableEventSchemasAPIOnly, true, "EventSchemas.enableEventSchemasAPIOnly")
+	config.RegisterIntConfigVariable(10000, &proc.config.maxEventsToProcess, true, 1, "Processor.maxLoopProcessEvents")
 
-	batchDestinations = misc.BatchDestinations()
-	config.RegisterIntConfigVariable(5, &transformTimesPQLength, false, 1, "Processor.transformTimesPQLength")
+	proc.config.batchDestinations = misc.BatchDestinations()
+	config.RegisterIntConfigVariable(5, &proc.config.transformTimesPQLength, false, 1, "Processor.transformTimesPQLength")
 	// Capture event name as a tag in event level stats
-	config.RegisterBoolConfigVariable(false, &captureEventNameStats, true, "Processor.Stats.captureEventName")
-	transformerURL = config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
-	config.RegisterDurationConfigVariable(5, &pollInterval, false, time.Second, []string{"Processor.pollInterval", "Processor.pollIntervalInS"}...)
+	config.RegisterBoolConfigVariable(false, &proc.config.captureEventNameStats, true, "Processor.Stats.captureEventName")
+	proc.config.transformerURL = config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
+	config.RegisterDurationConfigVariable(5, &proc.config.pollInterval, false, time.Second, []string{"Processor.pollInterval", "Processor.pollIntervalInS"}...)
 	// GWCustomVal is used as a key in the jobsDB customval column
-	config.RegisterStringConfigVariable("GW", &GWCustomVal, false, "Gateway.CustomVal")
+	config.RegisterStringConfigVariable("GW", &proc.config.GWCustomVal, false, "Gateway.CustomVal")
 }
 
 // syncTransformerFeatureJson polls the transformer feature json endpoint,
@@ -516,14 +506,17 @@ func loadConfig() {
 //	updates the transformer feature map.
 //
 // It will set isUnLocked to true if it successfully fetches the transformer feature json at least once.
-func (proc *HandleT) syncTransformerFeatureJson(ctx context.Context) {
+func (proc *Handle) syncTransformerFeatureJson(ctx context.Context) {
+	var initDone bool
 	for {
-		for i := 0; i < featuresRetryMaxAttempts; i++ {
+		for i := 0; i < proc.config.featuresRetryMaxAttempts; i++ {
+			proc.logger.Infof("Fetching transformer features from %s", proc.config.transformerURL)
 			if ctx.Err() != nil {
 				return
 			}
 
 			retry := proc.makeFeaturesFetchCall()
+			proc.logger.Infof("Fetched transformer features from %s (retry: %v)", proc.config.transformerURL, retry)
 			if retry {
 				select {
 				case <-ctx.Done():
@@ -532,22 +525,24 @@ func (proc *HandleT) syncTransformerFeatureJson(ctx context.Context) {
 					continue
 				}
 			}
+			break
 		}
 
-		if proc.transformerFeatures != nil && !isUnLocked {
-			isUnLocked = true
+		if proc.transformerFeatures != nil && !initDone {
+			initDone = true
+			proc.config.asyncInit.Done()
 		}
 
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(pollInterval):
+		case <-time.After(proc.config.pollInterval):
 		}
 	}
 }
 
-func (proc *HandleT) makeFeaturesFetchCall() bool {
-	url := transformerURL + "/features"
+func (proc *Handle) makeFeaturesFetchCall() bool {
+	url := proc.config.transformerURL + "/features"
 	req, err := http.NewRequest("GET", url, bytes.NewReader([]byte{}))
 	if err != nil {
 		proc.logger.Error("error creating request - %s", err)
@@ -576,61 +571,62 @@ func (proc *HandleT) makeFeaturesFetchCall() bool {
 	return false
 }
 
-func SetFeaturesRetryAttempts(overrideAttempts int) {
-	featuresRetryMaxAttempts = overrideAttempts
-}
-
-func (proc *HandleT) backendConfigSubscriber() {
-	ch := proc.backendConfig.Subscribe(context.TODO(), backendconfig.TopicProcessConfig)
+func (proc *Handle) backendConfigSubscriber(ctx context.Context) {
+	var initDone bool
+	ch := proc.backendConfig.Subscribe(ctx, backendconfig.TopicProcessConfig)
 	for data := range ch {
 		config := data.Data.(map[string]backendconfig.ConfigT)
-		configSubscriberLock.Lock()
-		workspaceLibrariesMap = make(map[string]backendconfig.LibrariesT, len(config))
-		writeKeyDestinationMap = make(map[string][]backendconfig.DestinationT)
-		writeKeySourceMap = map[string]backendconfig.SourceT{}
-		destinationIDtoTypeMap = make(map[string]string)
+		proc.config.configSubscriberLock.Lock()
+		proc.config.workspaceLibrariesMap = make(map[string]backendconfig.LibrariesT, len(config))
+		proc.config.writeKeyDestinationMap = make(map[string][]backendconfig.DestinationT)
+		proc.config.writeKeySourceMap = map[string]backendconfig.SourceT{}
+		proc.config.destinationIDtoTypeMap = make(map[string]string)
 		for workspaceID, wConfig := range config {
 			for i := range wConfig.Sources {
 				source := &wConfig.Sources[i]
-				writeKeySourceMap[source.WriteKey] = *source
+				proc.config.writeKeySourceMap[source.WriteKey] = *source
 				if source.Enabled {
-					writeKeyDestinationMap[source.WriteKey] = source.Destinations
+					proc.config.writeKeyDestinationMap[source.WriteKey] = source.Destinations
 					for j := range source.Destinations {
 						destination := &source.Destinations[j]
-						destinationIDtoTypeMap[destination.ID] = destination.DestinationDefinition.Name
+						proc.config.destinationIDtoTypeMap[destination.ID] = destination.DestinationDefinition.Name
 					}
 				}
 			}
-			workspaceLibrariesMap[workspaceID] = wConfig.Libraries
+			proc.config.workspaceLibrariesMap[workspaceID] = wConfig.Libraries
 		}
-		configSubscriberLock.Unlock()
+		proc.config.configSubscriberLock.Unlock()
+		if !initDone {
+			initDone = true
+			proc.config.asyncInit.Done()
+		}
 	}
 }
 
-func getWorkspaceLibraries(workspaceID string) backendconfig.LibrariesT {
-	configSubscriberLock.RLock()
-	defer configSubscriberLock.RUnlock()
-	return workspaceLibrariesMap[workspaceID]
+func (proc *Handle) getWorkspaceLibraries(workspaceID string) backendconfig.LibrariesT {
+	proc.config.configSubscriberLock.RLock()
+	defer proc.config.configSubscriberLock.RUnlock()
+	return proc.config.workspaceLibrariesMap[workspaceID]
 }
 
-func getSourceByWriteKey(writeKey string) (*backendconfig.SourceT, error) {
+func (proc *Handle) getSourceByWriteKey(writeKey string) (*backendconfig.SourceT, error) {
 	var err error
-	configSubscriberLock.RLock()
-	defer configSubscriberLock.RUnlock()
-	source, ok := writeKeySourceMap[writeKey]
+	proc.config.configSubscriberLock.RLock()
+	defer proc.config.configSubscriberLock.RUnlock()
+	source, ok := proc.config.writeKeySourceMap[writeKey]
 	if !ok {
 		err = errors.New("source not found for writeKey")
-		pkgLogger.Errorf(`Processor : source not found for writeKey: %s`, writeKey)
+		proc.logger.Errorf(`Processor : source not found for writeKey: %s`, writeKey)
 	}
 	return &source, err
 }
 
-func getEnabledDestinations(writeKey, destinationName string) []backendconfig.DestinationT {
-	configSubscriberLock.RLock()
-	defer configSubscriberLock.RUnlock()
+func (proc *Handle) getEnabledDestinations(writeKey, destinationName string) []backendconfig.DestinationT {
+	proc.config.configSubscriberLock.RLock()
+	defer proc.config.configSubscriberLock.RUnlock()
 	var enabledDests []backendconfig.DestinationT
-	for i := range writeKeyDestinationMap[writeKey] {
-		dest := &writeKeyDestinationMap[writeKey][i]
+	for i := range proc.config.writeKeyDestinationMap[writeKey] {
+		dest := &proc.config.writeKeyDestinationMap[writeKey][i]
 		if destinationName == dest.DestinationDefinition.Name && dest.Enabled {
 			enabledDests = append(enabledDests, *dest)
 		}
@@ -638,12 +634,12 @@ func getEnabledDestinations(writeKey, destinationName string) []backendconfig.De
 	return enabledDests
 }
 
-func getBackendEnabledDestinationTypes(writeKey string) map[string]backendconfig.DestinationDefinitionT {
-	configSubscriberLock.RLock()
-	defer configSubscriberLock.RUnlock()
+func (proc *Handle) getBackendEnabledDestinationTypes(writeKey string) map[string]backendconfig.DestinationDefinitionT {
+	proc.config.configSubscriberLock.RLock()
+	defer proc.config.configSubscriberLock.RUnlock()
 	enabledDestinationTypes := make(map[string]backendconfig.DestinationDefinitionT)
-	for i := range writeKeyDestinationMap[writeKey] {
-		destination := &writeKeyDestinationMap[writeKey][i]
+	for i := range proc.config.writeKeyDestinationMap[writeKey] {
+		destination := &proc.config.writeKeyDestinationMap[writeKey][i]
 		if destination.Enabled {
 			enabledDestinationTypes[destination.DestinationDefinition.DisplayName] = destination.DestinationDefinition
 		}
@@ -745,7 +741,7 @@ func getSourceAndDestIDsFromKey(key string) (sourceID, destID string) {
 	return fields[0], fields[1]
 }
 
-func (proc *HandleT) recordEventDeliveryStatus(jobsByDestID map[string][]*jobsdb.JobT) {
+func (proc *Handle) recordEventDeliveryStatus(jobsByDestID map[string][]*jobsdb.JobT) {
 	for destID, jobs := range jobsByDestID {
 		if !proc.destDebugger.HasUploadEnabled(destID) {
 			continue
@@ -754,7 +750,7 @@ func (proc *HandleT) recordEventDeliveryStatus(jobsByDestID map[string][]*jobsdb
 			var params map[string]interface{}
 			err := jsonfast.Unmarshal(job.Parameters, &params)
 			if err != nil {
-				pkgLogger.Errorf("Error while UnMarshaling live event parameters: %w", err)
+				proc.logger.Errorf("Error while UnMarshaling live event parameters: %w", err)
 				continue
 			}
 
@@ -767,14 +763,14 @@ func (proc *HandleT) recordEventDeliveryStatus(jobsByDestID map[string][]*jobsdb
 			events := make([]map[string]interface{}, 0)
 			err = jsonfast.Unmarshal(job.EventPayload, &events)
 			if err != nil {
-				pkgLogger.Errorf("Error while UnMarshaling live event payload: %w", err)
+				proc.logger.Errorf("Error while UnMarshaling live event payload: %w", err)
 				continue
 			}
 			for i := range events {
 				event := &events[i]
 				eventPayload, err := jsonfast.Marshal(*event)
 				if err != nil {
-					pkgLogger.Errorf("Error while Marshaling live event payload: %w", err)
+					proc.logger.Errorf("Error while Marshaling live event payload: %w", err)
 					continue
 				}
 
@@ -798,7 +794,7 @@ func (proc *HandleT) recordEventDeliveryStatus(jobsByDestID map[string][]*jobsdb
 	}
 }
 
-func (proc *HandleT) getDestTransformerEvents(response transformer.ResponseT, commonMetaData *transformer.MetadataT, destination *backendconfig.DestinationT, stage string, trackingPlanEnabled, userTransformationEnabled bool) ([]transformer.TransformerEventT, []*types.PUReportedMetric, map[string]int64, map[string]MetricMetadata) {
+func (proc *Handle) getDestTransformerEvents(response transformer.ResponseT, commonMetaData *transformer.MetadataT, destination *backendconfig.DestinationT, stage string, trackingPlanEnabled, userTransformationEnabled bool) ([]transformer.TransformerEventT, []*types.PUReportedMetric, map[string]int64, map[string]MetricMetadata) {
 	successMetrics := make([]*types.PUReportedMetric, 0)
 	connectionDetailsMap := make(map[string]*types.ConnectionDetails)
 	statusDetailsMap := make(map[string]*types.StatusDetail)
@@ -877,7 +873,7 @@ func (proc *HandleT) getDestTransformerEvents(response transformer.ResponseT, co
 	return eventsToTransform, successMetrics, successCountMap, successCountMetadataMap
 }
 
-func (proc *HandleT) updateMetricMaps(countMetadataMap map[string]MetricMetadata, countMap map[string]int64, connectionDetailsMap map[string]*types.ConnectionDetails, statusDetailsMap map[string]*types.StatusDetail, event *transformer.TransformerResponseT, status string, payload json.RawMessage) {
+func (proc *Handle) updateMetricMaps(countMetadataMap map[string]MetricMetadata, countMap map[string]int64, connectionDetailsMap map[string]*types.ConnectionDetails, statusDetailsMap map[string]*types.StatusDetail, event *transformer.TransformerResponseT, status string, payload json.RawMessage) {
 	if proc.isReportingEnabled() {
 		var eventName string
 		var eventType string
@@ -890,7 +886,7 @@ func (proc *HandleT) updateMetricMaps(countMetadataMap map[string]MetricMetadata
 			event.Metadata.SourceBatchID,
 			eventName,
 			eventType,
-		}, METRICKEYDELIMITER)
+		}, MetricKeyDelimiter)
 
 		if _, ok := countMap[countKey]; !ok {
 			countMap[countKey] = 0
@@ -947,7 +943,7 @@ func (proc *HandleT) updateMetricMaps(countMetadataMap map[string]MetricMetadata
 	}
 }
 
-func (proc *HandleT) getFailedEventJobs(response transformer.ResponseT, commonMetaData *transformer.MetadataT, eventsByMessageID map[string]types.SingularEventWithReceivedAt, stage string, transformationEnabled, trackingPlanEnabled bool) ([]*jobsdb.JobT, []*types.PUReportedMetric, map[string]int64) {
+func (proc *Handle) getFailedEventJobs(response transformer.ResponseT, commonMetaData *transformer.MetadataT, eventsByMessageID map[string]types.SingularEventWithReceivedAt, stage string, transformationEnabled, trackingPlanEnabled bool) ([]*jobsdb.JobT, []*types.PUReportedMetric, map[string]int64) {
 	failedMetrics := make([]*types.PUReportedMetric, 0)
 	connectionDetailsMap := make(map[string]*types.ConnectionDetails)
 	statusDetailsMap := make(map[string]*types.StatusDetail)
@@ -981,7 +977,7 @@ func (proc *HandleT) getFailedEventJobs(response transformer.ResponseT, commonMe
 			proc.updateMetricMaps(nil, failedCountMap, connectionDetailsMap, statusDetailsMap, failedEvent, jobsdb.Aborted.State, sampleEvent)
 		}
 
-		pkgLogger.Debugf(
+		proc.logger.Debugf(
 			"[Processor: getFailedEventJobs] Error [%d] for source %q and destination %q: %s",
 			failedEvent.StatusCode, commonMetaData.SourceID, commonMetaData.DestinationID, failedEvent.Error,
 		)
@@ -1072,11 +1068,11 @@ func (proc *HandleT) getFailedEventJobs(response transformer.ResponseT, commonMe
 	return failedEventsToStore, failedMetrics, failedCountMap
 }
 
-func (proc *HandleT) updateSourceEventStatsDetailed(event types.SingularEventT, writeKey string) {
+func (proc *Handle) updateSourceEventStatsDetailed(event types.SingularEventT, writeKey string) {
 	// Any panics in this function are captured and ignore sending the stat
 	defer func() {
 		if r := recover(); r != nil {
-			pkgLogger.Error(r)
+			proc.logger.Error(r)
 		}
 	}()
 	var eventType string
@@ -1089,7 +1085,7 @@ func (proc *HandleT) updateSourceEventStatsDetailed(event types.SingularEventT, 
 		}
 		statEventType := proc.statsFactory.NewSampledTaggedStat("processor.event_type", stats.CountType, tags)
 		statEventType.Count(1)
-		if captureEventNameStats {
+		if proc.config.captureEventNameStats {
 			if eventType != "track" {
 				eventName = eventType
 			} else {
@@ -1116,7 +1112,7 @@ func getDiffMetrics(inPU, pu string, inCountMetadataMap map[string]MetricMetadat
 	diffMetrics := make([]*types.PUReportedMetric, 0)
 	for key, inCount := range inCountMap {
 		var eventName, eventType string
-		splitKey := strings.Split(key, METRICKEYDELIMITER)
+		splitKey := strings.Split(key, MetricKeyDelimiter)
 		if len(splitKey) < 5 {
 			eventName = ""
 			eventType = ""
@@ -1141,7 +1137,7 @@ func getDiffMetrics(inPU, pu string, inCountMetadataMap map[string]MetricMetadat
 	return diffMetrics
 }
 
-func (proc *HandleT) processJobsForDest(subJobs subJob, parsedEventList [][]types.SingularEventT) *transformationMessage {
+func (proc *Handle) processJobsForDest(subJobs subJob, parsedEventList [][]types.SingularEventT) *transformationMessage {
 	jobList := subJobs.subJobs
 	start := time.Now()
 
@@ -1198,7 +1194,7 @@ func (proc *HandleT) processJobsForDest(subJobs subJob, parsedEventList [][]type
 
 		if ok {
 			var duplicateIndexes []int
-			if enableDedup {
+			if proc.config.enableDedup {
 				var allMessageIdsInBatch []string
 				for _, singularEvent := range singularEvents {
 					allMessageIdsInBatch = append(allMessageIdsInBatch, misc.GetStringifiedData(singularEvent["messageId"]))
@@ -1209,7 +1205,7 @@ func (proc *HandleT) processJobsForDest(subJobs subJob, parsedEventList [][]type
 			// Iterate through all the events in the batch
 			for eventIndex, singularEvent := range singularEvents {
 				messageId := misc.GetStringifiedData(singularEvent["messageId"])
-				if enableDedup && misc.Contains(duplicateIndexes, eventIndex) {
+				if proc.config.enableDedup && misc.Contains(duplicateIndexes, eventIndex) {
 					proc.logger.Debugf("Dropping event with duplicate messageId: %s", messageId)
 					misc.IncrementMapByKey(sourceDupStats, writeKey, 1)
 					continue
@@ -1225,7 +1221,7 @@ func (proc *HandleT) processJobsForDest(subJobs subJob, parsedEventList [][]type
 					ReceivedAt:    receivedAt,
 				}
 
-				sourceForSingularEvent, sourceIdError := getSourceByWriteKey(writeKey)
+				sourceForSingularEvent, sourceIdError := proc.getSourceByWriteKey(writeKey)
 				if sourceIdError != nil {
 					proc.logger.Error("Dropping Job since Source not found for writeKey : ", writeKey)
 					continue
@@ -1249,7 +1245,7 @@ func (proc *HandleT) processJobsForDest(subJobs subJob, parsedEventList [][]type
 
 				// Getting all the destinations which are enabled for this
 				// event
-				backendEnabledDestTypes := getBackendEnabledDestinationTypes(writeKey)
+				backendEnabledDestTypes := proc.getBackendEnabledDestinationTypes(writeKey)
 				enabledDestTypes := integrations.FilterClientIntegrations(singularEvent, backendEnabledDestTypes)
 				if len(enabledDestTypes) == 0 {
 					proc.logger.Debug("No enabled destinations")
@@ -1266,7 +1262,7 @@ func (proc *HandleT) processJobsForDest(subJobs subJob, parsedEventList [][]type
 				enhanceWithTimeFields(&shallowEventCopy, singularEvent, receivedAt)
 				enhanceWithMetadata(commonMetadataFromSingularEvent, &shallowEventCopy, &backendconfig.DestinationT{})
 
-				source, sourceError := getSourceByWriteKey(writeKey)
+				source, sourceError := proc.getSourceByWriteKey(writeKey)
 				if sourceError != nil {
 					proc.logger.Error("Source not found for writeKey : ", writeKey)
 				} else {
@@ -1361,14 +1357,14 @@ func (proc *HandleT) processJobsForDest(subJobs subJob, parsedEventList [][]type
 			writeKey := string(writeKeyT)
 			singularEvent := event.Message
 
-			backendEnabledDestTypes := getBackendEnabledDestinationTypes(writeKey)
+			backendEnabledDestTypes := proc.getBackendEnabledDestinationTypes(writeKey)
 			enabledDestTypes := integrations.FilterClientIntegrations(singularEvent, backendEnabledDestTypes)
 			workspaceID := eventList[idx].Metadata.WorkspaceID
-			workspaceLibraries := getWorkspaceLibraries(workspaceID)
+			workspaceLibraries := proc.getWorkspaceLibraries(workspaceID)
 
 			for i := range enabledDestTypes {
 				destType := &enabledDestTypes[i]
-				enabledDestinationsList := getEnabledDestinations(writeKey, *destType)
+				enabledDestinationsList := proc.getEnabledDestinations(writeKey, *destType)
 				// Adding a singular event multiple times if there are multiple destinations of same type
 				for idx := range enabledDestinationsList {
 					destination := &enabledDestinationsList[idx]
@@ -1446,7 +1442,7 @@ type transformationMessage struct {
 	rsourcesStats rsources.StatsCollector
 }
 
-func (proc *HandleT) transformations(in *transformationMessage) *storeMessage {
+func (proc *Handle) transformations(in *transformationMessage) *storeMessage {
 	// Now do the actual transformation. We call it in batches, once
 	// for each destination ID
 
@@ -1536,22 +1532,22 @@ type storeMessage struct {
 	rsourcesStats rsources.StatsCollector
 }
 
-func sendRetryStoreStats(attempt int) {
-	pkgLogger.Warnf("Timeout during store jobs in processor module, attempt %d", attempt)
+func (proc *Handle) sendRetryStoreStats(attempt int) {
+	proc.logger.Warnf("Timeout during store jobs in processor module, attempt %d", attempt)
 	stats.Default.NewTaggedStat("jobsdb_store_timeout", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt), "module": "processor"}).Count(1)
 }
 
-func sendRetryUpdateStats(attempt int) {
-	pkgLogger.Warnf("Timeout during update job status in processor module, attempt %d", attempt)
+func (proc *Handle) sendRetryUpdateStats(attempt int) {
+	proc.logger.Warnf("Timeout during update job status in processor module, attempt %d", attempt)
 	stats.Default.NewTaggedStat("jobsdb_update_timeout", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt), "module": "processor"}).Count(1)
 }
 
-func sendQueryRetryStats(attempt int) {
-	pkgLogger.Warnf("Timeout during query jobs in processor module, attempt %d", attempt)
+func (proc *Handle) sendQueryRetryStats(attempt int) {
+	proc.logger.Warnf("Timeout during query jobs in processor module, attempt %d", attempt)
 	stats.Default.NewTaggedStat("jobsdb_query_timeout", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt), "module": "processor"}).Count(1)
 }
 
-func (proc *HandleT) Store(in *storeMessage) {
+func (proc *Handle) Store(in *storeMessage) {
 	statusList, destJobs, batchDestJobs := in.statusList, in.destJobs, in.batchDestJobs
 	beforeStoreStatus := time.Now()
 	// XX: Need to do this in a transaction
@@ -1578,7 +1574,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 						}
 						return nil
 					})
-			}, sendRetryStoreStats)
+			}, proc.sendRetryStoreStats)
 		if err != nil {
 			panic(err)
 		}
@@ -1617,7 +1613,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 						}
 						return nil
 					})
-			}, sendRetryStoreStats)
+			}, proc.sendRetryStoreStats)
 		if err != nil {
 			panic(err)
 		}
@@ -1640,7 +1636,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 		proc.logger.Debug("[Processor] Total jobs written to proc_error: ", len(in.procErrorJobs))
 		err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
 			return proc.errorDB.Store(ctx, in.procErrorJobs)
-		}, sendRetryStoreStats)
+		}, proc.sendRetryStoreStats)
 		if err != nil {
 			proc.logger.Errorf("Store into proc error table failed with error: %v", err)
 			proc.logger.Errorf("procErrorJobs: %v", in.procErrorJobs)
@@ -1653,7 +1649,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 	txnStart := time.Now()
 	err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
 		return proc.gatewayDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
-			err := proc.gatewayDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{GWCustomVal}, nil)
+			err := proc.gatewayDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{proc.config.GWCustomVal}, nil)
 			if err != nil {
 				return fmt.Errorf("updating gateway jobs statuses: %w", err)
 			}
@@ -1669,7 +1665,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 				proc.reporting.Report(in.reportMetrics, tx.SqlTx())
 			}
 
-			if enableDedup {
+			if proc.config.enableDedup {
 				proc.updateSourceStats(in.sourceDupStats, "processor.write_key_duplicate_events")
 				if len(in.uniqueMessageIds) > 0 {
 					var dedupedMessageIdsAcrossJobs []string
@@ -1684,7 +1680,7 @@ func (proc *HandleT) Store(in *storeMessage) {
 			}
 			return nil
 		})
-	}, sendRetryUpdateStats)
+	}, proc.sendRetryUpdateStats)
 	if err != nil {
 		panic(err)
 	}
@@ -1727,7 +1723,7 @@ type transformSrcDestOutput struct {
 	errorsPerDestID map[string][]*jobsdb.JobT
 }
 
-func (proc *HandleT) transformSrcDest(
+func (proc *Handle) transformSrcDest(
 	ctx context.Context,
 	// main inputs
 	srcAndDestKey string, eventList []transformer.TransformerEventT,
@@ -1758,10 +1754,10 @@ func (proc *HandleT) transformSrcDest(
 	destJobs := make([]*jobsdb.JobT, 0)
 	procErrorJobsByDestID := make(map[string][]*jobsdb.JobT)
 
-	configSubscriberLock.RLock()
-	destType := destinationIDtoTypeMap[destID]
+	proc.config.configSubscriberLock.RLock()
+	destType := proc.config.destinationIDtoTypeMap[destID]
 	transformationEnabled := len(destination.Transformations) > 0
-	configSubscriberLock.RUnlock()
+	proc.config.configSubscriberLock.RUnlock()
 
 	trackingPlanEnabled := trackingPlanEnabledMap[SourceIDT(sourceID)]
 
@@ -1781,7 +1777,7 @@ func (proc *HandleT) transformSrcDest(
 				event.Metadata.SourceBatchID,
 				event.Metadata.EventName,
 				event.Metadata.EventType,
-			}, METRICKEYDELIMITER)
+			}, MetricKeyDelimiter)
 			if _, ok := inCountMap[key]; !ok {
 				inCountMap[key] = 0
 			}
@@ -1804,7 +1800,7 @@ func (proc *HandleT) transformSrcDest(
 
 		trace.WithRegion(ctx, "UserTransform", func() {
 			startedAt := time.Now()
-			response = proc.transformer.Transform(ctx, eventList, integrations.GetUserTransformURL(), userTransformBatchSize)
+			response = proc.transformer.Transform(ctx, eventList, integrations.GetUserTransformURL(), proc.config.userTransformBatchSize)
 			d := time.Since(startedAt)
 			userTransformationStat.transformTime.SendTiming(d)
 			proc.addToTransformEventByTimePQ(&TransformRequestT{
@@ -1938,7 +1934,7 @@ func (proc *HandleT) transformSrcDest(
 			trace.Logf(ctx, "Dest Transform", "input size %d", len(eventsToTransform))
 			proc.logger.Debug("Dest Transform input size", len(eventsToTransform))
 			s := time.Now()
-			response = proc.transformer.Transform(ctx, eventsToTransform, url, transformBatchSize)
+			response = proc.transformer.Transform(ctx, eventsToTransform, url, proc.config.transformBatchSize)
 
 			destTransformationStat := proc.newDestinationTransformationStat(sourceID, workspaceID, transformAt, destination)
 			destTransformationStat.transformTime.Since(s)
@@ -2079,7 +2075,7 @@ func (proc *HandleT) transformSrcDest(
 				EventPayload: destEventJSON,
 				WorkspaceId:  workspaceId,
 			}
-			if misc.Contains(batchDestinations, newJob.CustomVal) {
+			if misc.Contains(proc.config.batchDestinations, newJob.CustomVal) {
 				batchDestJobs = append(batchDestJobs, &newJob)
 			} else {
 				destJobs = append(destJobs, &newJob)
@@ -2094,7 +2090,7 @@ func (proc *HandleT) transformSrcDest(
 	}
 }
 
-func (proc *HandleT) saveFailedJobs(failedJobs []*jobsdb.JobT) {
+func (proc *Handle) saveFailedJobs(failedJobs []*jobsdb.JobT) {
 	if len(failedJobs) > 0 {
 		rsourcesStats := rsources.NewFailedJobsCollector(proc.rsourcesService)
 		rsourcesStats.JobsFailed(failedJobs)
@@ -2174,10 +2170,10 @@ func ConvertToFilteredTransformerResponse(events []transformer.TransformerEventT
 	return transformer.ResponseT{Events: responses, FailedEvents: failedEvents}
 }
 
-func (proc *HandleT) addToTransformEventByTimePQ(event *TransformRequestT, pq *transformRequestPQ) {
+func (proc *Handle) addToTransformEventByTimePQ(event *TransformRequestT, pq *transformRequestPQ) {
 	proc.stats.transformEventsByTimeMutex.Lock()
 	defer proc.stats.transformEventsByTimeMutex.Unlock()
-	if pq.Len() < transformTimesPQLength {
+	if pq.Len() < proc.config.transformTimesPQLength {
 		pq.Add(event)
 		return
 	}
@@ -2188,23 +2184,23 @@ func (proc *HandleT) addToTransformEventByTimePQ(event *TransformRequestT, pq *t
 	}
 }
 
-func (proc *HandleT) getJobs() jobsdb.JobsResult {
+func (proc *Handle) getJobs() jobsdb.JobsResult {
 	s := time.Now()
 
-	proc.logger.Debugf("Processor DB Read size: %d", maxEventsToProcess)
+	proc.logger.Debugf("Processor DB Read size: %d", proc.config.maxEventsToProcess)
 
-	eventCount := maxEventsToProcess
-	if !enableEventCount {
+	eventCount := proc.config.maxEventsToProcess
+	if !proc.config.enableEventCount {
 		eventCount = 0
 	}
 	unprocessedList, err := misc.QueryWithRetriesAndNotify(context.Background(), proc.jobdDBQueryRequestTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
 		return proc.gatewayDB.GetUnprocessed(ctx, jobsdb.GetQueryParamsT{
-			CustomValFilters: []string{GWCustomVal},
-			JobsLimit:        maxEventsToProcess,
+			CustomValFilters: []string{proc.config.GWCustomVal},
+			JobsLimit:        proc.config.maxEventsToProcess,
 			EventsLimit:      eventCount,
 			PayloadSizeLimit: proc.payloadLimit,
 		})
-	}, sendQueryRetryStats)
+	}, proc.sendQueryRetryStats)
 	if err != nil {
 		proc.logger.Errorf("Failed to get unprocessed jobs from DB. Error: %v", err)
 		panic(err)
@@ -2233,7 +2229,7 @@ func (proc *HandleT) getJobs() jobsdb.JobsResult {
 	}
 
 	eventSchemasStart := time.Now()
-	if enableEventSchemasFeature && !enableEventSchemasAPIOnly {
+	if proc.config.enableEventSchemasFeature && !proc.config.enableEventSchemasAPIOnly {
 		for _, unprocessedJob := range unprocessedList.Jobs {
 			writeKey := gjson.GetBytes(unprocessedJob.EventPayload, "writeKey").Str
 			proc.eventSchemaHandler.RecordEventSchema(writeKey, string(unprocessedJob.EventPayload))
@@ -2252,7 +2248,7 @@ func (proc *HandleT) getJobs() jobsdb.JobsResult {
 	return unprocessedList
 }
 
-func (proc *HandleT) markExecuting(jobs []*jobsdb.JobT) error {
+func (proc *Handle) markExecuting(jobs []*jobsdb.JobT) error {
 	start := time.Now()
 	defer proc.stats.statMarkExecuting.Since(start)
 
@@ -2272,8 +2268,8 @@ func (proc *HandleT) markExecuting(jobs []*jobsdb.JobT) error {
 	}
 	// Mark the jobs as executing
 	err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) error {
-		return proc.gatewayDB.UpdateJobStatus(ctx, statusList, []string{GWCustomVal}, nil)
-	}, sendRetryUpdateStats)
+		return proc.gatewayDB.UpdateJobStatus(ctx, statusList, []string{proc.config.GWCustomVal}, nil)
+	}, proc.sendRetryUpdateStats)
 	if err != nil {
 		return fmt.Errorf("marking jobs as executing: %w", err)
 	}
@@ -2283,7 +2279,7 @@ func (proc *HandleT) markExecuting(jobs []*jobsdb.JobT) error {
 
 // handlePendingGatewayJobs is checking for any pending gateway jobs (failed and unprocessed), and routes them appropriately
 // Returns true if any job is handled, otherwise returns false.
-func (proc *HandleT) handlePendingGatewayJobs() bool {
+func (proc *Handle) handlePendingGatewayJobs() bool {
 	s := time.Now()
 
 	unprocessedList := proc.getJobs()
@@ -2310,12 +2306,20 @@ func (proc *HandleT) handlePendingGatewayJobs() bool {
 }
 
 // mainLoop: legacy way of handling jobs
-func (proc *HandleT) mainLoop(ctx context.Context) {
+func (proc *Handle) mainLoop(ctx context.Context) {
 	// waiting for reporting client setup
 	if proc.reporting != nil && proc.reportingEnabled {
 		if err := proc.reporting.WaitForSetup(ctx, types.CoreReportingClient); err != nil {
 			return
 		}
+	}
+
+	// waiting for init group
+	select {
+	case <-ctx.Done():
+		return
+	case <-proc.config.asyncInit.Wait():
+		// proceed
 	}
 
 	proc.logger.Info("Processor loop started")
@@ -2324,24 +2328,20 @@ func (proc *HandleT) mainLoop(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(mainLoopTimeout):
-			if isUnLocked {
-				found := proc.handlePendingGatewayJobs()
-				if found {
-					currLoopSleep = 0
-				} else {
-					currLoopSleep = 2*currLoopSleep + loopSleep
-					if currLoopSleep > maxLoopSleep {
-						currLoopSleep = maxLoopSleep
-					}
-					if sleepTrueOnDone(ctx, currLoopSleep) {
-						return
-					}
+		case <-time.After(proc.config.mainLoopTimeout):
+			found := proc.handlePendingGatewayJobs()
+			if found {
+				currLoopSleep = 0
+			} else {
+				currLoopSleep = 2*currLoopSleep + proc.config.loopSleep
+				if currLoopSleep > proc.config.maxLoopSleep {
+					currLoopSleep = proc.config.maxLoopSleep
 				}
-				if sleepTrueOnDone(ctx, fixedLoopSleep) { // adding sleep here to reduce cpu load on postgres when we have less rps
+				if sleepTrueOnDone(ctx, currLoopSleep) {
 					return
 				}
-			} else if sleepTrueOnDone(ctx, fixedLoopSleep) {
+			}
+			if sleepTrueOnDone(ctx, proc.config.fixedLoopSleep) { // adding sleep here to reduce cpu load on postgres when we have less rps
 				return
 			}
 		}
@@ -2367,11 +2367,11 @@ type subJob struct {
 	rsourcesStats rsources.StatsCollector
 }
 
-func jobSplitter(jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []subJob {
+func (proc *Handle) jobSplitter(jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []subJob {
 	subJobCount := 1
-	if len(jobs)/subJobSize > 1 {
-		subJobCount = len(jobs) / subJobSize
-		if len(jobs)%subJobSize != 0 {
+	if len(jobs)/proc.config.subJobSize > 1 {
+		subJobCount = len(jobs) / proc.config.subJobSize
+		if len(jobs)%proc.config.subJobSize != 0 {
 			subJobCount++
 		}
 	}
@@ -2387,11 +2387,11 @@ func jobSplitter(jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []s
 			continue
 		}
 		subJobs = append(subJobs, subJob{
-			subJobs:       jobs[:subJobSize],
+			subJobs:       jobs[:proc.config.subJobSize],
 			hasMore:       true,
 			rsourcesStats: rsourcesStats,
 		})
-		jobs = jobs[subJobSize:]
+		jobs = jobs[proc.config.subJobSize:]
 	}
 
 	return subJobs
@@ -2400,9 +2400,9 @@ func jobSplitter(jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []s
 // mainPipeline: new way of handling jobs
 //
 // [getJobs] -chProc-> [processJobsForDest] -chTrans-> [transformations] -chStore-> [Store]
-func (proc *HandleT) mainPipeline(ctx context.Context) {
+func (proc *Handle) mainPipeline(ctx context.Context) {
 	// waiting for reporting client setup
-	proc.logger.Infof("Processor mainPipeline started, subJobSize=%d pipelineBufferedItems=%d", subJobSize, pipelineBufferedItems)
+	proc.logger.Infof("Processor mainPipeline started, subJobSize=%d pipelineBufferedItems=%d", proc.config.subJobSize, proc.config.pipelineBufferedItems)
 
 	if proc.reporting != nil && proc.reportingEnabled {
 		if err := proc.reporting.WaitForSetup(ctx, types.CoreReportingClient); err != nil {
@@ -2410,7 +2410,7 @@ func (proc *HandleT) mainPipeline(ctx context.Context) {
 		}
 	}
 	wg := sync.WaitGroup{}
-	bufferSize := pipelineBufferedItems
+	bufferSize := proc.config.pipelineBufferedItems
 
 	chProc := make(chan subJob, bufferSize)
 	wg.Add(1)
@@ -2418,16 +2418,19 @@ func (proc *HandleT) mainPipeline(ctx context.Context) {
 		defer wg.Done()
 		defer close(chProc)
 		nextSleepTime := time.Duration(0)
+		// waiting for init group
+		select {
+		case <-ctx.Done():
+			return
+		case <-proc.config.asyncInit.Wait():
+			// proceed
+		}
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-time.After(nextSleepTime):
-				if !isUnLocked {
-					nextSleepTime = proc.maxLoopSleep
-					continue
-				}
 				dbReadStart := time.Now()
 				jobs := proc.getJobs()
 				rsourcesStats := rsources.NewStatsCollector(proc.rsourcesService)
@@ -2435,17 +2438,17 @@ func (proc *HandleT) mainPipeline(ctx context.Context) {
 				if len(jobs.Jobs) == 0 {
 					// no jobs found, double sleep time until maxLoopSleep
 					nextSleepTime = 2 * nextSleepTime
-					if nextSleepTime > proc.maxLoopSleep {
-						nextSleepTime = proc.maxLoopSleep
+					if nextSleepTime > proc.config.maxLoopSleep {
+						nextSleepTime = proc.config.maxLoopSleep
 					} else if nextSleepTime == 0 {
-						nextSleepTime = proc.readLoopSleep
+						nextSleepTime = proc.config.readLoopSleep
 					}
 					continue
 				}
 
 				err := proc.markExecuting(jobs.Jobs)
 				if err != nil {
-					pkgLogger.Error(err)
+					proc.logger.Error(err)
 					panic(err)
 				}
 				dbReadTime := time.Since(dbReadStart)
@@ -2455,10 +2458,10 @@ func (proc *HandleT) mainPipeline(ctx context.Context) {
 				proc.stats.DBReadThroughput.Count(dbReadThroughput)
 
 				// nextSleepTime is dependent on the number of events read in this loop
-				emptyRatio := 1.0 - math.Min(1, float64(events)/float64(maxEventsToProcess))
-				nextSleepTime = time.Duration(emptyRatio * float64(proc.readLoopSleep))
+				emptyRatio := 1.0 - math.Min(1, float64(events)/float64(proc.config.maxEventsToProcess))
+				nextSleepTime = time.Duration(emptyRatio * float64(proc.config.readLoopSleep))
 
-				subJobs := jobSplitter(jobs.Jobs, rsourcesStats)
+				subJobs := proc.jobSplitter(jobs.Jobs, rsourcesStats)
 				for _, subJob := range subJobs {
 					chProc <- subJob
 				}
@@ -2477,7 +2480,7 @@ func (proc *HandleT) mainPipeline(ctx context.Context) {
 	})
 
 	// we need the below buffer size to ensure that `proc.Store(*mergedJob)` is not blocking rest of the Go routines.
-	chStore := make(chan *storeMessage, (bufferSize+1)*(maxEventsToProcess/subJobSize+1))
+	chStore := make(chan *storeMessage, (bufferSize+1)*(proc.config.maxEventsToProcess/proc.config.subJobSize+1))
 	wg.Add(1)
 	rruntime.Go(func() {
 		defer wg.Done()
@@ -2548,11 +2551,11 @@ func throughputPerSecond(processedJob int, timeTaken time.Duration) int {
 	return int(float64(processedJob) / normalizedTime)
 }
 
-func (proc *HandleT) crashRecover() {
+func (proc *Handle) crashRecover() {
 	proc.gatewayDB.DeleteExecuting()
 }
 
-func (proc *HandleT) updateSourceStats(sourceStats map[string]int, bucket string) {
+func (proc *Handle) updateSourceStats(sourceStats map[string]int, bucket string) {
 	for sourceTag, count := range sourceStats {
 		tags := map[string]string{
 			"source": sourceTag,
@@ -2562,11 +2565,11 @@ func (proc *HandleT) updateSourceStats(sourceStats map[string]int, bucket string
 	}
 }
 
-func (proc *HandleT) isReportingEnabled() bool {
+func (proc *Handle) isReportingEnabled() bool {
 	return proc.reporting != nil && proc.reportingEnabled
 }
 
-func (proc *HandleT) updateRudderSourcesStats(ctx context.Context, tx jobsdb.StoreSafeTx, jobs []*jobsdb.JobT) error {
+func (proc *Handle) updateRudderSourcesStats(ctx context.Context, tx jobsdb.StoreSafeTx, jobs []*jobsdb.JobT) error {
 	rsourcesStats := rsources.NewStatsCollector(proc.rsourcesService)
 	rsourcesStats.JobsStored(jobs)
 	err := rsourcesStats.Publish(ctx, tx.SqlTx())

--- a/processor/trackingplan.go
+++ b/processor/trackingplan.go
@@ -55,7 +55,7 @@ func enhanceWithViolation(response transformer.ResponseT, trackingPlanId string,
 // The ResponseT will contain both the Events and FailedEvents
 // 1. eventsToTransform gets added to validatedEventsByWriteKey
 // 2. failedJobs gets added to validatedErrorJobs
-func (proc *HandleT) validateEvents(groupedEventsByWriteKey map[WriteKeyT][]transformer.TransformerEventT, eventsByMessageID map[string]types.SingularEventWithReceivedAt) (map[WriteKeyT][]transformer.TransformerEventT, []*types.PUReportedMetric, []*jobsdb.JobT, map[SourceIDT]bool) {
+func (proc *Handle) validateEvents(groupedEventsByWriteKey map[WriteKeyT][]transformer.TransformerEventT, eventsByMessageID map[string]types.SingularEventWithReceivedAt) (map[WriteKeyT][]transformer.TransformerEventT, []*types.PUReportedMetric, []*jobsdb.JobT, map[SourceIDT]bool) {
 	validatedEventsByWriteKey := make(map[WriteKeyT][]transformer.TransformerEventT)
 	validatedReportMetrics := make([]*types.PUReportedMetric, 0)
 	validatedErrorJobs := make([]*jobsdb.JobT, 0)
@@ -77,7 +77,7 @@ func (proc *HandleT) validateEvents(groupedEventsByWriteKey map[WriteKeyT][]tran
 		}
 
 		validationStart := time.Now()
-		response := proc.transformer.Validate(eventList, integrations.GetTrackingPlanValidationURL(), userTransformBatchSize)
+		response := proc.transformer.Validate(eventList, integrations.GetTrackingPlanValidationURL(), proc.config.userTransformBatchSize)
 		validationStat.tpValidationTime.Since(validationStart)
 
 		// If transformerInput does not match with transformerOutput then we do not consider transformerOutput
@@ -144,7 +144,7 @@ func makeCommonMetadataFromTransformerEvent(transformerEvent *transformer.Transf
 }
 
 // newValidationStat Creates a new TrackingPlanStatT instance
-func (proc *HandleT) newValidationStat(metadata *transformer.MetadataT) *TrackingPlanStatT {
+func (proc *Handle) newValidationStat(metadata *transformer.MetadataT) *TrackingPlanStatT {
 	tags := map[string]string{
 		"destination":         metadata.DestinationID,
 		"destType":            metadata.DestinationType,

--- a/processor/transformqueue.go
+++ b/processor/transformqueue.go
@@ -15,28 +15,28 @@ type TransformRequestT struct {
 
 type transformRequestPQ []*TransformRequestT
 
-func (pq transformRequestPQ) Len() int {
+func (pq transformRequestPQ) Len() int { // skipcq: GO-W1029
 	return len(pq)
 }
 
-func (pq transformRequestPQ) Less(i, j int) bool {
+func (pq transformRequestPQ) Less(i, j int) bool { // skipcq: GO-W1029
 	return pq[i].ProcessingTime < pq[j].ProcessingTime
 }
 
-func (pq transformRequestPQ) Swap(i, j int) {
+func (pq transformRequestPQ) Swap(i, j int) { // skipcq: GO-W1029
 	pq[i], pq[j] = pq[j], pq[i]
 	pq[i].Index = i
 	pq[j].Index = j
 }
 
-func (pq *transformRequestPQ) Push(x interface{}) {
+func (pq *transformRequestPQ) Push(x interface{}) { // skipcq: GO-W1029
 	n := len(*pq)
 	item := x.(*TransformRequestT)
 	item.Index = n
 	*pq = append(*pq, item)
 }
 
-func (pq *transformRequestPQ) Pop() interface{} {
+func (pq *transformRequestPQ) Pop() interface{} { // skipcq: GO-W1029
 	old := *pq
 	n := len(old)
 	item := old[n-1]
@@ -45,32 +45,26 @@ func (pq *transformRequestPQ) Pop() interface{} {
 	return item
 }
 
-func (pq *transformRequestPQ) Top() *TransformRequestT {
+func (pq *transformRequestPQ) Top() *TransformRequestT { // skipcq: GO-W1029
 	item := (*pq)[0]
 	return item
 }
 
-func (pq *transformRequestPQ) Remove(item *TransformRequestT) {
+func (pq *transformRequestPQ) Remove(item *TransformRequestT) { // skipcq: GO-W1029
 	heap.Remove(pq, item.Index)
 }
 
-func (pq *transformRequestPQ) Update(item, nextItem *TransformRequestT) {
+func (pq *transformRequestPQ) Update(item, nextItem *TransformRequestT) { // skipcq: GO-W1029
 	index := item.Index
 	item = nextItem
 	item.Index = index
 	heap.Fix(pq, item.Index)
 }
 
-func (pq *transformRequestPQ) Add(item *TransformRequestT) {
+func (pq *transformRequestPQ) Add(item *TransformRequestT) { // skipcq: GO-W1029
 	heap.Push(pq, item)
 }
 
-func (pq *transformRequestPQ) RemoveTop() {
+func (pq *transformRequestPQ) RemoveTop() { // skipcq: GO-W1029
 	heap.Pop(pq)
-}
-
-func (pq *transformRequestPQ) Print() {
-	for _, v := range *pq {
-		pkgLogger.Debug(*v)
-	}
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -30,7 +30,6 @@ import (
 	"github.com/rudderlabs/rudder-server/gateway"
 	"github.com/rudderlabs/rudder-server/gateway/webhook"
 	"github.com/rudderlabs/rudder-server/jobsdb"
-	"github.com/rudderlabs/rudder-server/processor"
 	"github.com/rudderlabs/rudder-server/processor/integrations"
 	"github.com/rudderlabs/rudder-server/processor/stash"
 	"github.com/rudderlabs/rudder-server/processor/transformer"
@@ -359,7 +358,6 @@ func runAllInit() {
 	eventschema.Init()
 	eventschema.Init2()
 	stash.Init()
-	processor.Init()
 	kafka.Init()
 	customdestinationmanager.Init()
 	routertransformer.Init()

--- a/utils/misc/asyncinit.go
+++ b/utils/misc/asyncinit.go
@@ -1,0 +1,54 @@
+package misc
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// NewAsyncInit returns a new AsyncInit object with the given expected initialization events count.
+func NewAsyncInit(count int64) *AsyncInit {
+	a := &AsyncInit{
+		c: make(chan struct{}),
+	}
+	a.count.Store(count)
+	return a
+}
+
+// AsyncInit is a helper object to wait for multiple asynchronous initialization events.
+type AsyncInit struct {
+	mu    sync.Mutex
+	count atomic.Int64
+	c     chan struct{}
+}
+
+// Done decrements the initialization events count
+func (ia *AsyncInit) Done() {
+	if ia.count.Add(-1) == 0 {
+		close(ia.channel())
+	}
+}
+
+// Wait returns the channel that will be closed when the initialization events count reaches zero.
+func (ia *AsyncInit) Wait() chan struct{} {
+	return ia.channel()
+}
+
+// WaitContext returns no error if initialization events happen before the provided context is done. It returns the context's error otherwise
+func (ia *AsyncInit) WaitContext(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-ia.Wait():
+		return nil
+	}
+}
+
+func (ia *AsyncInit) channel() chan struct{} {
+	ia.mu.Lock()
+	defer ia.mu.Unlock()
+	if ia.c == nil {
+		ia.c = make(chan struct{})
+	}
+	return ia.c
+}

--- a/utils/misc/asyncinit_test.go
+++ b/utils/misc/asyncinit_test.go
@@ -1,0 +1,48 @@
+package misc_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rudderlabs/rudder-server/utils/misc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsyncInit(t *testing.T) {
+	asyncInit := misc.NewAsyncInit(2)
+
+	select {
+	case <-asyncInit.Wait():
+		require.Fail(t, "should not be done yet")
+	default:
+	}
+
+	asyncInit.Done()
+	select {
+	case <-asyncInit.Wait():
+		require.Fail(t, "should not be done yet")
+	default:
+	}
+
+	asyncInit.Done()
+
+	select {
+	case <-asyncInit.Wait():
+	default:
+		require.Fail(t, "should be done already")
+	}
+}
+
+func TestAsyncInitContext(t *testing.T) {
+	asyncInit := misc.NewAsyncInit(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.Error(t, asyncInit.WaitContext(ctx), "the context error should be returned")
+
+	ctx, cancel = context.WithCancel(context.Background())
+	asyncInit.Done()
+	defer cancel()
+	require.NoError(t, asyncInit.WaitContext(ctx), "no error should be returned")
+}


### PR DESCRIPTION
# Description

Preparation steps before starting the actual work for introducing workspace isolation in processor:

- Removing global variables from the `processor` package
- Renaming `processor.HandleT` to `processor.Handle`
- Introducing `misc.AsyncInit` for streamlining how our components wait for their proper initialization before actually starting working (hint: `backendconfig.WaitForConfig` is not 100% safe)
- Make sure that processor is properly initialized before starting (using `misc.AsyncInit`)
- Fix issue with multiple successful HTTP requests performed for transformer features when starting up

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=4f93b562e40743fcad2ce119dcacdc84&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
