### PR TITLE
chore: abort retired jobs

### DIFF
--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -196,7 +196,7 @@ func (jd *HandleT) CleanUpRetiredJobs(ctx context.Context, retiredWorkspaces []s
 							"Aborted %d %s-%s jobs due to workspace retirement",
 							count, workspace, customVal,
 						)
-						metric.DeletePendingEvents(
+						rmetrics.DecreasePendingEvents(
 							jd.tablePrefix,
 							workspace,
 							customVal,

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -281,6 +281,7 @@ type JobsDB interface {
 	Ping() error
 	DeleteExecuting()
 	FailExecuting()
+	CleanUpRetiredJobs(ctx context.Context, retiredWorkspaces []string) error
 
 	/* Journal */
 

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -1382,7 +1382,7 @@ func TestCleanUpRetiredJobs(t *testing.T) {
 	)
 
 	require.Equal(t,
-		4,
+		5,
 		len(
 			metric.Instance.
 				GetRegistry(metric.PublishedMetrics).

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -37,6 +37,20 @@ func (m *MockJobsDB) EXPECT() *MockJobsDBMockRecorder {
 	return m.recorder
 }
 
+// CleanUpRetiredJobs mocks base method.
+func (m *MockJobsDB) CleanUpRetiredJobs(arg0 context.Context, arg1 []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanUpRetiredJobs", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanUpRetiredJobs indicates an expected call of CleanUpRetiredJobs.
+func (mr *MockJobsDBMockRecorder) CleanUpRetiredJobs(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanUpRetiredJobs", reflect.TypeOf((*MockJobsDB)(nil).CleanUpRetiredJobs), arg0, arg1)
+}
+
 // DeleteExecuting mocks base method.
 func (m *MockJobsDB) DeleteExecuting() {
 	m.ctrl.T.Helper()

--- a/mocks/services/multitenant/mock_tenantstats.go
+++ b/mocks/services/multitenant/mock_tenantstats.go
@@ -60,6 +60,18 @@ func (mr *MockMultiTenantIMockRecorder) GetRouterPickupJobs(arg0, arg1, arg2, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouterPickupJobs", reflect.TypeOf((*MockMultiTenantI)(nil).GetRouterPickupJobs), arg0, arg1, arg2, arg3)
 }
 
+// RemoveWorkspaceFromLatencyMap mocks base method.
+func (m *MockMultiTenantI) RemoveWorkspaceFromLatencyMap(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RemoveWorkspaceFromLatencyMap", arg0)
+}
+
+// RemoveWorkspaceFromLatencyMap indicates an expected call of RemoveWorkspaceFromLatencyMap.
+func (mr *MockMultiTenantIMockRecorder) RemoveWorkspaceFromLatencyMap(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveWorkspaceFromLatencyMap", reflect.TypeOf((*MockMultiTenantI)(nil).RemoveWorkspaceFromLatencyMap), arg0)
+}
+
 // ReportProcLoopAddStats mocks base method.
 func (m *MockMultiTenantI) ReportProcLoopAddStats(arg0 map[string]map[string]int, arg1 string) {
 	m.ctrl.T.Helper()

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -121,6 +121,7 @@ func WithAdaptiveLimit(adaptiveLimitFunction func(int64) int64) Opts {
 		l.Handle.adaptiveLimit = adaptiveLimitFunction
 	}
 }
+
 func (proc *Handle) cleanUpRetiredJobs(ctx context.Context) {
 	ch := proc.backendConfig.Subscribe(ctx, backendconfig.TopicProcessConfig)
 	for data := range ch {

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -157,6 +157,10 @@ func (proc *Handle) doCleanupRetiredJobs(ctx context.Context, workspaceMap map[s
 			retiredRouterWorkspaces,
 		); err != nil {
 			proc.logger.Errorf("Error cleaning up retired jobs for router: %v", err)
+		} else {
+			lo.ForEach(retiredRouterWorkspaces, func(workspace string, _ int) {
+				proc.multitenantI.RemoveWorkspaceFromLatencyMap(workspace)
+			})
 		}
 	}
 
@@ -184,6 +188,10 @@ func (proc *Handle) doCleanupRetiredJobs(ctx context.Context, workspaceMap map[s
 			retiredBatchRouterWorkspaces,
 		); err != nil {
 			proc.logger.Errorf("Error cleaning up retired jobs for batch router: %v", err)
+		} else {
+			lo.ForEach(retiredBatchRouterWorkspaces, func(workspace string, _ int) {
+				proc.multitenantI.RemoveWorkspaceFromLatencyMap(workspace)
+			})
 		}
 	}
 }

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -123,18 +123,13 @@ func WithAdaptiveLimit(adaptiveLimitFunction func(int64) int64) Opts {
 }
 func (proc *Handle) cleanUpRetiredJobs(ctx context.Context) {
 	ch := proc.backendConfig.Subscribe(ctx, backendconfig.TopicProcessConfig)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case data := <-ch:
-			config := data.Data.(map[string]backendconfig.ConfigT)
-			workspaceMap := make(map[string]struct{})
-			for workspace := range config {
-				workspaceMap[workspace] = struct{}{}
-			}
-			proc.doCleanupRetiredJobs(ctx, workspaceMap)
+	for data := range ch {
+		config := data.Data.(map[string]backendconfig.ConfigT)
+		workspaceMap := make(map[string]struct{})
+		for workspace := range config {
+			workspaceMap[workspace] = struct{}{}
 		}
+		proc.doCleanupRetiredJobs(ctx, workspaceMap)
 	}
 }
 

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -223,7 +223,7 @@ func TestProcessorManager(t *testing.T) {
 				close(ch)
 				return ch
 			},
-		)
+		).AnyTimes()
 		mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
 		mockTransformer.EXPECT().Setup().Times(1).Do(func() {
 			processor.Handle.transformerFeatures = json.RawMessage(defaultTransformerFeatures)
@@ -260,7 +260,7 @@ func TestProcessorManager(t *testing.T) {
 				close(ch)
 				return ch
 			},
-		)
+		).AnyTimes()
 
 		mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
 		mockTransformer.EXPECT().Setup().Times(1).Do(func() {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -412,6 +412,10 @@ func (proc *Handle) Setup(
 		proc.backendConfigSubscriber(ctx)
 	})
 
+	rruntime.Go(func() {
+		proc.cleanUpRetiredJobs(ctx)
+	})
+
 	g.Go(misc.WithBugsnag(func() error {
 		proc.syncTransformerFeatureJson(ctx)
 		return nil

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -80,7 +80,7 @@ func (c *testContext) Setup() {
 			ch <- pubsub.DataEvent{Data: map[string]backendconfig.ConfigT{sampleWorkspaceID: sampleBackendConfig}, Topic: string(topic)}
 			close(ch)
 			return ch
-		})
+		}).AnyTimes()
 	c.dbReadBatchSize = 10000
 	c.processEventSize = 10000
 	c.MockReportingI = mockReportingTypes.NewMockReportingI(c.mockCtrl)


### PR DESCRIPTION
# Description

aborting jobs of workspaces that do not belong to the server

## Notion Ticket

[abort jobs of workspaces that don't belong to the server](https://www.notion.so/rudderstacks/cleanup-jobs-whose-workspace-do-not-belong-to-server-36e96860696543d09b9e2c35e1564220)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
