### PR TITLE
chore: disable batch destinations by default in regulation worker

### DIFF
--- a/regulation-worker/cmd/main_test.go
+++ b/regulation-worker/cmd/main_test.go
@@ -179,6 +179,7 @@ func TestFlow(t *testing.T) {
 	t.Setenv("DEST_TRANSFORM_URL", "http://localhost:9090")
 	t.Setenv("URL_PREFIX", srv.URL)
 	t.Setenv("RSERVER_BACKEND_CONFIG_POLL_INTERVAL", "0.1")
+	t.Setenv("REGULATION_WORKER_BATCH_DESTINATIONS_ENABLED", "true")
 
 	// starting redis server to mock redis-destination
 	startRedisServer(t, pool)

--- a/regulation-worker/internal/delete/batch/batch.go
+++ b/regulation-worker/internal/delete/batch/batch.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
+	"github.com/rudderlabs/rudder-server/config"
 	"github.com/rudderlabs/rudder-server/regulation-worker/internal/delete/batch/filehandler"
 	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
 	"github.com/rudderlabs/rudder-server/services/filemanager"
@@ -308,7 +309,10 @@ type BatchManager struct {
 }
 
 func (*BatchManager) GetSupportedDestinations() []string {
-	return supportedDestinations
+	if config.Default.GetBool("REGULATION_WORKER_BATCH_DESTINATIONS_ENABLED", false) {
+		return supportedDestinations
+	}
+	return nil
 }
 
 // Delete users corresponding to input userAttributes from a given batch destination


### PR DESCRIPTION
# Description

Disable batch destinations by default through a configuration option

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
