### PR TITLE
fix(processor): wrong event filter in count stat captured

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1875,7 +1875,8 @@ func (proc *HandleT) transformSrcDest(
 
 	// Filtering events based on the supported message types - START
 	s := time.Now()
-	proc.logger.Debug("Supported messages filtering input size", len(eventsToTransform))
+	eventFilterInCount := len(eventsToTransform)
+	proc.logger.Debug("Supported messages filtering input size", eventFilterInCount)
 	response = ConvertToFilteredTransformerResponse(eventsToTransform, transformAt != "none")
 	var successMetrics []*types.PUReportedMetric
 	var successCountMap map[string]int64
@@ -1909,7 +1910,7 @@ func (proc *HandleT) transformSrcDest(
 	}
 	// REPORTING - END
 	eventFilterStat := proc.newEventFilterStat(sourceID, workspaceID, destination)
-	eventFilterStat.numEvents.Count(len(eventsToTransform))
+	eventFilterStat.numEvents.Count(eventFilterInCount)
 	eventFilterStat.numOutputSuccessEvents.Count(len(response.Events))
 	eventFilterStat.numOutputFailedEvents.Count(len(failedJobs))
 	eventFilterStat.transformTime.Since(s)


### PR DESCRIPTION
# Description

event filter in count was showing the successful output count. Fixes that

## Notion Ticket

[event filter in count fix](https://www.notion.so/rudderstacks/eventFilterInCount-fix-4bf937f8cb6b4144982172fa6d92456d)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
