### PR TITLE
feat(processor): add support for workspace-level isolation

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/rudderlabs/rudder-server/app"
 	"github.com/rudderlabs/rudder-server/app/cluster"
-	"github.com/rudderlabs/rudder-server/app/cluster/state"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/gateway"
 	"github.com/rudderlabs/rudder-server/jobsdb"
@@ -35,7 +34,6 @@ import (
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/types"
-	"github.com/rudderlabs/rudder-server/utils/types/servermode"
 )
 
 // embeddedApp is the type for embedded type implementation
@@ -45,26 +43,20 @@ type embeddedApp struct {
 	versionHandler func(w http.ResponseWriter, r *http.Request)
 	log            logger.Logger
 	config         struct {
-		enableProcessor    bool
-		enableRouter       bool
 		enableReplay       bool
 		processorDSLimit   int
 		routerDSLimit      int
 		batchRouterDSLimit int
 		gatewayDSLimit     int
-		forceStaticMode    bool
 	}
 }
 
 func (a *embeddedApp) loadConfiguration() {
-	config.RegisterBoolConfigVariable(true, &a.config.enableProcessor, false, "enableProcessor")
 	config.RegisterBoolConfigVariable(types.DefaultReplayEnabled, &a.config.enableReplay, false, "Replay.enabled")
-	config.RegisterBoolConfigVariable(true, &a.config.enableRouter, false, "enableRouter")
 	config.RegisterIntConfigVariable(0, &a.config.processorDSLimit, true, 1, "Processor.jobsDB.dsLimit", "JobsDB.dsLimit")
 	config.RegisterIntConfigVariable(0, &a.config.gatewayDSLimit, true, 1, "Gateway.jobsDB.dsLimit", "JobsDB.dsLimit")
 	config.RegisterIntConfigVariable(0, &a.config.routerDSLimit, true, 1, "Router.jobsDB.dsLimit", "JobsDB.dsLimit")
 	config.RegisterIntConfigVariable(0, &a.config.batchRouterDSLimit, true, 1, "BatchRouter.jobsDB.dsLimit", "JobsDB.dsLimit")
-	config.RegisterBoolConfigVariable(false, &a.config.forceStaticMode, false, "forceStaticModeProvider")
 }
 
 func (a *embeddedApp) Setup(options *app.Options) error {
@@ -198,30 +190,9 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 		}))
 	}
 
-	var modeProvider cluster.ChangeEventProvider
-
-	staticModeProvider := func() cluster.ChangeEventProvider {
-		// FIXME: hacky way to determine server mode
-		if a.config.enableProcessor && a.config.enableRouter {
-			return state.NewStaticProvider(servermode.NormalMode)
-		}
-		return state.NewStaticProvider(servermode.DegradedMode)
-	}
-
-	if a.config.forceStaticMode {
-		a.log.Info("forcing the use of Static Cluster Manager")
-		modeProvider = staticModeProvider()
-	} else {
-		switch deploymentType {
-		case deployment.MultiTenantType:
-			a.log.Info("using ETCD Based Dynamic Cluster Manager")
-			modeProvider = state.NewETCDDynamicProvider()
-		case deployment.DedicatedType:
-			a.log.Info("using Static Cluster Manager")
-			modeProvider = staticModeProvider()
-		default:
-			return fmt.Errorf("unsupported deployment type: %q", deploymentType)
-		}
+	modeProvider, err := resolveModeProvider(a.log, deploymentType)
+	if err != nil {
+		return err
 	}
 
 	adaptiveLimit := payload.SetupAdaptiveLimiter(ctx, g)

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"github.com/rudderlabs/rudder-server/utils/payload"
 	"github.com/rudderlabs/rudder-server/utils/types/deployment"
-	"github.com/rudderlabs/rudder-server/utils/types/servermode"
 
 	"golang.org/x/sync/errgroup"
 
@@ -22,7 +21,6 @@ import (
 
 	"github.com/rudderlabs/rudder-server/app"
 	"github.com/rudderlabs/rudder-server/app/cluster"
-	"github.com/rudderlabs/rudder-server/app/cluster/state"
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
@@ -48,13 +46,10 @@ type processorApp struct {
 	versionHandler func(w http.ResponseWriter, r *http.Request)
 	log            logger.Logger
 	config         struct {
-		enableProcessor    bool
-		enableRouter       bool
 		processorDSLimit   int
 		routerDSLimit      int
 		batchRouterDSLimit int
 		gatewayDSLimit     int
-		forceStaticMode    bool
 		http               struct {
 			ReadTimeout       time.Duration
 			ReadHeaderTimeout time.Duration
@@ -67,16 +62,12 @@ type processorApp struct {
 }
 
 func (a *processorApp) loadConfiguration() {
-	config.RegisterBoolConfigVariable(true, &a.config.enableProcessor, false, "enableProcessor")
-	config.RegisterBoolConfigVariable(true, &a.config.enableRouter, false, "enableRouter")
-
 	config.RegisterDurationConfigVariable(0, &a.config.http.ReadTimeout, false, time.Second, []string{"ReadTimeout", "ReadTimeOutInSec"}...)
 	config.RegisterDurationConfigVariable(0, &a.config.http.ReadHeaderTimeout, false, time.Second, []string{"ReadHeaderTimeout", "ReadHeaderTimeoutInSec"}...)
 	config.RegisterDurationConfigVariable(10, &a.config.http.WriteTimeout, false, time.Second, []string{"WriteTimeout", "WriteTimeOutInSec"}...)
 	config.RegisterDurationConfigVariable(720, &a.config.http.IdleTimeout, false, time.Second, []string{"IdleTimeout", "IdleTimeoutInSec"}...)
 	config.RegisterIntConfigVariable(8086, &a.config.http.webPort, false, 1, "Processor.webPort")
 	config.RegisterIntConfigVariable(524288, &a.config.http.MaxHeaderBytes, false, 1, "MaxHeaderBytes")
-	config.RegisterBoolConfigVariable(false, &a.config.forceStaticMode, false, "forceStaticModeProvider")
 	config.RegisterIntConfigVariable(0, &a.config.processorDSLimit, true, 1, "Processor.jobsDB.dsLimit", "JobsDB.dsLimit")
 	config.RegisterIntConfigVariable(0, &a.config.gatewayDSLimit, true, 1, "Gateway.jobsDB.dsLimit", "JobsDB.dsLimit")
 	config.RegisterIntConfigVariable(0, &a.config.routerDSLimit, true, 1, "Router.jobsDB.dsLimit", "JobsDB.dsLimit")
@@ -202,30 +193,9 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 		}))
 	}
 
-	var modeProvider cluster.ChangeEventProvider
-
-	staticModeProvider := func() cluster.ChangeEventProvider {
-		if a.config.enableProcessor && a.config.enableRouter {
-			return state.NewStaticProvider(servermode.NormalMode)
-		}
-		return state.NewStaticProvider(servermode.DegradedMode)
-	}
-
-	if a.config.forceStaticMode {
-		a.log.Info("forcing the use of Static Cluster Manager")
-		modeProvider = staticModeProvider()
-	} else {
-		switch deploymentType {
-		case deployment.MultiTenantType:
-			a.log.Info("using ETCD Based Dynamic Cluster Manager")
-			modeProvider = state.NewETCDDynamicProvider()
-		case deployment.DedicatedType:
-			// FIXME: hacky way to determine servermode
-			a.log.Info("using Static Cluster Manager")
-			modeProvider = staticModeProvider()
-		default:
-			return fmt.Errorf("unsupported deployment type: %q", deploymentType)
-		}
+	modeProvider, err := resolveModeProvider(a.log, deploymentType)
+	if err != nil {
+		return err
 	}
 
 	adaptiveLimit := payload.SetupAdaptiveLimiter(ctx, g)

--- a/gateway/internal/stats/stats_test.go
+++ b/gateway/internal/stats/stats_test.go
@@ -41,35 +41,35 @@ func TestReport(t *testing.T) {
 		sourceTag := fmt.Sprint(i)
 		sourceStat := statMap[sourceTag]
 
-		randInt := rand.Int() % 10 // skipcq: GSC-G404
+		randInt := 1 + rand.Int()%9 // skipcq: GSC-G404
 		for j := 0; j < randInt; j++ {
 			sourceStat.RequestSucceeded()
 		}
 		counterMap[sourceTag].succeeded += randInt
 		counterMap[sourceTag].total += randInt
 
-		randInt = rand.Int() % 10 // skipcq: GSC-G404
+		randInt = 1 + rand.Int()%9 // skipcq: GSC-G404
 		for j := 0; j < randInt; j++ {
 			sourceStat.RequestDropped()
 		}
 		counterMap[sourceTag].dropped += randInt
 		counterMap[sourceTag].total += randInt
 
-		randInt = rand.Int() % 10 // skipcq: GSC-G404
+		randInt = 1 + rand.Int()%9 // skipcq: GSC-G404
 		for j := 0; j < randInt; j++ {
 			sourceStat.RequestSuppressed()
 		}
 		counterMap[sourceTag].suppressed += randInt
 		counterMap[sourceTag].total += randInt
 
-		randInt = rand.Int() % 10 // skipcq: GSC-G404
+		randInt = 1 + rand.Int()%9 // skipcq: GSC-G404
 		for j := 0; j < randInt; j++ {
 			sourceStat.RequestFailed("reason")
 		}
 		counterMap[sourceTag].failed += randInt
 		counterMap[sourceTag].total += randInt
 
-		randInt = rand.Int() % 10 // skipcq: GSC-G404
+		randInt = 1 + rand.Int()%9 // skipcq: GSC-G404
 		for j := 0; j < randInt; j++ {
 			sourceStat.RequestEventsSucceeded(10)
 		}
@@ -78,7 +78,7 @@ func TestReport(t *testing.T) {
 		counterMap[sourceTag].total += randInt
 		counterMap[sourceTag].succeeded += randInt
 
-		randInt = rand.Int() % 10 // skipcq: GSC-G404
+		randInt = 1 + rand.Int()%9 // skipcq: GSC-G404
 		for j := 0; j < randInt; j++ {
 			sourceStat.RequestEventsFailed(10, "reason")
 		}

--- a/integration_test/docker_test/docker_test.go
+++ b/integration_test/docker_test/docker_test.go
@@ -446,7 +446,7 @@ func setupMainFlow(svcCtx context.Context, t *testing.T) <-chan struct{} {
 
 	writeKey = rand.String(27)
 	workspaceID = rand.String(27)
-	mapWorkspaceConfig := map[string]string{
+	mapWorkspaceConfig := map[string]any{
 		"webhookUrl":                   webhookURL,
 		"disableDestinationwebhookUrl": disableDestinationWebhookURL,
 		"writeKey":                     writeKey,

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -61,6 +61,21 @@ func (mr *MockJobsDBMockRecorder) FailExecuting() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailExecuting", reflect.TypeOf((*MockJobsDB)(nil).FailExecuting))
 }
 
+// GetActiveWorkspaces mocks base method.
+func (m *MockJobsDB) GetActiveWorkspaces(arg0 context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetActiveWorkspaces", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetActiveWorkspaces indicates an expected call of GetActiveWorkspaces.
+func (mr *MockJobsDBMockRecorder) GetActiveWorkspaces(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveWorkspaces", reflect.TypeOf((*MockJobsDB)(nil).GetActiveWorkspaces), arg0)
+}
+
 // GetExecuting mocks base method.
 func (m *MockJobsDB) GetExecuting(arg0 context.Context, arg1 jobsdb.GetQueryParamsT) (jobsdb.JobsResult, error) {
 	m.ctrl.T.Helper()

--- a/processor/isolation/isolation.go
+++ b/processor/isolation/isolation.go
@@ -1,0 +1,58 @@
+package isolation
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+)
+
+type Mode string
+
+const (
+	ModeNone      Mode = "none"
+	ModeWorkspace Mode = "workspace"
+)
+
+// GetStrategy returns the strategy for the given isolation mode. An error is returned if the mode is invalid
+func GetStrategy(mode Mode) (Strategy, error) {
+	switch mode {
+	case ModeNone:
+		return noneStrategy{}, nil
+	case ModeWorkspace:
+		return workspaceStrategy{}, nil
+	default:
+		return noneStrategy{}, errors.New("unsupported isolation mode")
+	}
+}
+
+// Strategy defines the operations that every different isolation strategy in processor must implement
+type Strategy interface {
+	// ActivePartitions returns the list of partitions that are active for the given strategy
+	ActivePartitions(ctx context.Context, db jobsdb.JobsDB) ([]string, error)
+	// AugmentQueryParams augments the given GetQueryParamsT with the strategy specific parameters
+	AugmentQueryParams(partition string, params *jobsdb.GetQueryParamsT)
+}
+
+// noneStrategy implements isolation at no level
+type noneStrategy struct{}
+
+func (noneStrategy) ActivePartitions(_ context.Context, _ jobsdb.JobsDB) ([]string, error) {
+	return []string{""}, nil
+}
+
+func (noneStrategy) AugmentQueryParams(_ string, _ *jobsdb.GetQueryParamsT) {
+	// no-op
+}
+
+// workspaceStrategy implements isolation at workspace level
+type workspaceStrategy struct{}
+
+// ActivePartitions returns the list of active workspaceIDs in jobsdb
+func (workspaceStrategy) ActivePartitions(ctx context.Context, db jobsdb.JobsDB) ([]string, error) {
+	return db.GetActiveWorkspaces(ctx)
+}
+
+func (workspaceStrategy) AugmentQueryParams(partition string, params *jobsdb.GetQueryParamsT) {
+	params.WorkspaceID = partition
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"runtime/trace"
 	"strconv"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
+	miscsync "github.com/rudderlabs/rudder-server/utils/sync"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	"golang.org/x/sync/errgroup"
@@ -27,6 +27,7 @@ import (
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/processor/eventfilter"
 	"github.com/rudderlabs/rudder-server/processor/integrations"
+	"github.com/rudderlabs/rudder-server/processor/isolation"
 	"github.com/rudderlabs/rudder-server/processor/stash"
 	"github.com/rudderlabs/rudder-server/processor/transformer"
 	"github.com/rudderlabs/rudder-server/router/batchrouter"
@@ -94,12 +95,21 @@ type Handle struct {
 	rsourcesService           rsources.JobService
 	destDebugger              destinationdebugger.DestinationDebugger
 	transDebugger             transformationdebugger.TransformationDebugger
-	config                    struct {
+	isolationStrategy         isolation.Strategy
+	limiter                   struct {
+		read       miscsync.Limiter
+		preprocess miscsync.Limiter
+		transform  miscsync.Limiter
+		store      miscsync.Limiter
+	}
+	config struct {
+		isolationMode             isolation.Mode
 		mainLoopTimeout           time.Duration
 		featuresRetryMaxAttempts  int
 		enablePipelining          bool
 		pipelineBufferedItems     int
 		subJobSize                int
+		pingerSleep               time.Duration
 		readLoopSleep             time.Duration
 		maxLoopSleep              time.Duration
 		storeTimeout              time.Duration
@@ -128,7 +138,6 @@ type Handle struct {
 
 	adaptiveLimit func(int64) int64
 }
-
 type processorStats struct {
 	transformEventsByTimeMutex     sync.RWMutex
 	destTransformEventsByTimeTaken transformRequestPQ
@@ -333,7 +342,6 @@ func (proc *Handle) Setup(
 	proc.destDebugger = destDebugger
 	proc.transDebugger = transDebugger
 	config.RegisterBoolConfigVariable(types.DefaultReportingEnabled, &proc.reportingEnabled, false, "Reporting.enabled")
-	config.RegisterInt64ConfigVariable(100*bytesize.MB, &proc.payloadLimit, true, 1, "Processor.payloadLimit")
 	config.RegisterDurationConfigVariable(60, &proc.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB.Processor.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
 	config.RegisterDurationConfigVariable(90, &proc.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.Processor.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
 	config.RegisterIntConfigVariable(3, &proc.jobdDBMaxRetries, true, 1, []string{"JobsDB.Processor.MaxRetries", "JobsDB.MaxRetries"}...)
@@ -443,17 +451,74 @@ func (proc *Handle) Setup(
 // Start starts this processor's main loops.
 func (proc *Handle) Start(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
+	var err error
+	proc.logger.Infof("Starting processor in isolation mode: %s", proc.config.isolationMode)
+	if proc.isolationStrategy, err = isolation.GetStrategy(proc.config.isolationMode); err != nil {
+		return fmt.Errorf("resolving isolation strategy for mode %q: %w", proc.config.isolationMode, err)
+	}
 
-	g.Go(misc.WithBugsnag(func() error {
-		proc.backendConfig.WaitForConfig(ctx)
-		if proc.config.enablePipelining {
-			proc.mainPipeline(ctx)
-		} else {
-			proc.mainLoop(ctx)
-		}
+	// limiters
+	s := stats.Default
+	var limiterGroup sync.WaitGroup
+	proc.limiter.read = miscsync.NewLimiter(ctx, &limiterGroup, "proc_read",
+		config.GetInt("Processor.Limiter.read.limit", 50),
+		s,
+		miscsync.WithLimiterDynamicPeriod(config.GetDuration("Processor.Limiter.read.dynamicPeriod", 1, time.Second)))
+	proc.limiter.preprocess = miscsync.NewLimiter(ctx, &limiterGroup, "proc_preprocess",
+		config.GetInt("Processor.Limiter.preprocess.limit", 50),
+		s,
+		miscsync.WithLimiterDynamicPeriod(config.GetDuration("Processor.Limiter.preprocess.dynamicPeriod", 1, time.Second)))
+	proc.limiter.transform = miscsync.NewLimiter(ctx, &limiterGroup, "proc_transform",
+		config.GetInt("Processor.Limiter.transform.limit", 50),
+		s,
+		miscsync.WithLimiterDynamicPeriod(config.GetDuration("Processor.Limiter.transform.dynamicPeriod", 1, time.Second)))
+	proc.limiter.store = miscsync.NewLimiter(ctx, &limiterGroup, "proc_store",
+		config.GetInt("Processor.Limiter.store.limit", 50),
+		s,
+		miscsync.WithLimiterDynamicPeriod(config.GetDuration("Processor.Limiter.store.dynamicPeriod", 1, time.Second)))
+	g.Go(func() error {
+		limiterGroup.Wait()
 		return nil
+	})
+
+	// pinger loop
+	g.Go(misc.WithBugsnag(func() error {
+		proc.logger.Info("Starting pinger loop")
+		proc.backendConfig.WaitForConfig(ctx)
+		proc.logger.Info("Backend config received")
+		// waiting for reporting client setup
+		if proc.reporting != nil && proc.reportingEnabled {
+			if err := proc.reporting.WaitForSetup(ctx, types.CoreReportingClient); err != nil {
+				return err
+			}
+		}
+
+		// waiting for init group
+		proc.logger.Info("Waiting for async init group")
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-proc.config.asyncInit.Wait():
+			// proceed
+		}
+		proc.logger.Info("Async init group done")
+
+		h := &workerHandleAdapter{proc}
+		pool := newWorkerPool(ctx, h)
+		defer pool.Shutdown()
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(proc.config.pingerSleep):
+			}
+			for _, partition := range proc.activePartitions(ctx) {
+				pool.PingWorker(partition)
+			}
+		}
 	}))
 
+	// stash loop
 	g.Go(misc.WithBugsnag(func() error {
 		st := stash.New()
 		st.Setup(
@@ -469,6 +534,17 @@ func (proc *Handle) Start(ctx context.Context) error {
 	return g.Wait()
 }
 
+func (proc *Handle) activePartitions(ctx context.Context) []string {
+	defer proc.statsFactory.NewStat("proc_active_partitions_time", stats.TimerType).RecordDuration()()
+	keys, err := proc.isolationStrategy.ActivePartitions(ctx, proc.gatewayDB)
+	if err != nil && ctx.Err() == nil {
+		// TODO: retry?
+		panic(err)
+	}
+	proc.statsFactory.NewStat("proc_active_partitions", stats.GaugeType).Gauge(len(keys))
+	return keys
+}
+
 func (proc *Handle) Shutdown() {
 	proc.backgroundCancel()
 	_ = proc.backgroundWait()
@@ -477,13 +553,36 @@ func (proc *Handle) Shutdown() {
 func (proc *Handle) loadConfig() {
 	proc.config.mainLoopTimeout = 200 * time.Millisecond
 	proc.config.featuresRetryMaxAttempts = 10
+
+	defaultSubJobSize := 2000
+	defaultMaxEventsToProcess := 10000
+	defaultPayloadLimit := 100 * bytesize.MB
+	defaultReadLoopSleepMs := int64(200)
+	defaultMaxLoopSleeppMs := int64(5000)
+
+	defaultIsolationMode := isolation.ModeNone
+	if config.IsSet("WORKSPACE_NAMESPACE") {
+		defaultIsolationMode = isolation.ModeWorkspace
+	}
+	proc.config.isolationMode = isolation.Mode(config.GetString("Processor.isolationMode", string(defaultIsolationMode)))
+	// If isolation mode is not none, we need to reduce the values for some of the config variables to more sensible defaults
+	if proc.config.isolationMode != isolation.ModeNone {
+		defaultSubJobSize = 400
+		defaultMaxEventsToProcess = 2000
+		defaultPayloadLimit = 20 * bytesize.MB
+		defaultReadLoopSleepMs = 10
+		defaultMaxLoopSleeppMs = 2000
+	}
+
+	config.RegisterInt64ConfigVariable(defaultPayloadLimit, &proc.payloadLimit, true, 1, "Processor.payloadLimit")
 	config.RegisterBoolConfigVariable(true, &proc.config.enablePipelining, false, "Processor.enablePipelining")
 	config.RegisterIntConfigVariable(0, &proc.config.pipelineBufferedItems, false, 1, "Processor.pipelineBufferedItems")
-	config.RegisterIntConfigVariable(2000, &proc.config.subJobSize, false, 1, "Processor.subJobSize")
-	config.RegisterDurationConfigVariable(5000, &proc.config.maxLoopSleep, true, time.Millisecond, []string{"Processor.maxLoopSleep", "Processor.maxLoopSleepInMS"}...)
+	config.RegisterIntConfigVariable(defaultSubJobSize, &proc.config.subJobSize, false, 1, "Processor.subJobSize")
+	config.RegisterDurationConfigVariable(defaultMaxLoopSleeppMs, &proc.config.maxLoopSleep, true, time.Millisecond, []string{"Processor.maxLoopSleep", "Processor.maxLoopSleepInMS"}...)
 	config.RegisterDurationConfigVariable(5, &proc.config.storeTimeout, true, time.Minute, "Processor.storeTimeout")
 
-	config.RegisterDurationConfigVariable(200, &proc.config.readLoopSleep, true, time.Millisecond, "Processor.readLoopSleep")
+	config.RegisterDurationConfigVariable(1000, &proc.config.pingerSleep, true, time.Millisecond, "Processor.pingerSleep")
+	config.RegisterDurationConfigVariable(defaultReadLoopSleepMs, &proc.config.readLoopSleep, true, time.Millisecond, "Processor.readLoopSleep")
 	// DEPRECATED: used only on the old mainLoop:
 	config.RegisterDurationConfigVariable(10, &proc.config.loopSleep, true, time.Millisecond, []string{"Processor.loopSleep", "Processor.loopSleepInMS"}...)
 	// DEPRECATED: used only on the old mainLoop:
@@ -496,7 +595,7 @@ func (proc *Handle) loadConfig() {
 	// EventSchemas feature. false by default
 	config.RegisterBoolConfigVariable(false, &proc.config.enableEventSchemasFeature, false, "EventSchemas.enableEventSchemasFeature")
 	config.RegisterBoolConfigVariable(false, &proc.config.enableEventSchemasAPIOnly, true, "EventSchemas.enableEventSchemasAPIOnly")
-	config.RegisterIntConfigVariable(10000, &proc.config.maxEventsToProcess, true, 1, "Processor.maxLoopProcessEvents")
+	config.RegisterIntConfigVariable(defaultMaxEventsToProcess, &proc.config.maxEventsToProcess, true, 1, "Processor.maxLoopProcessEvents")
 
 	proc.config.batchDestinations = misc.BatchDestinations()
 	config.RegisterIntConfigVariable(5, &proc.config.transformTimesPQLength, false, 1, "Processor.transformTimesPQLength")
@@ -515,15 +614,18 @@ func (proc *Handle) loadConfig() {
 // It will set isUnLocked to true if it successfully fetches the transformer feature json at least once.
 func (proc *Handle) syncTransformerFeatureJson(ctx context.Context) {
 	var initDone bool
+	proc.logger.Infof("Fetching transformer features from %s", proc.config.transformerURL)
 	for {
 		for i := 0; i < proc.config.featuresRetryMaxAttempts; i++ {
-			proc.logger.Infof("Fetching transformer features from %s", proc.config.transformerURL)
+
 			if ctx.Err() != nil {
 				return
 			}
 
 			retry := proc.makeFeaturesFetchCall()
-			proc.logger.Infof("Fetched transformer features from %s (retry: %v)", proc.config.transformerURL, retry)
+			if retry {
+				proc.logger.Infof("Fetched transformer features from %s (retry: %v)", proc.config.transformerURL, retry)
+			}
 			if retry {
 				select {
 				case <-ctx.Done():
@@ -1136,7 +1238,11 @@ func getDiffMetrics(inPU, pu string, inCountMetadataMap map[string]MetricMetadat
 	return diffMetrics
 }
 
-func (proc *Handle) processJobsForDest(subJobs subJob, parsedEventList [][]types.SingularEventT) *transformationMessage {
+func (proc *Handle) processJobsForDest(partition string, subJobs subJob, parsedEventList [][]types.SingularEventT) *transformationMessage {
+	if proc.limiter.preprocess != nil {
+		defer proc.limiter.preprocess.BeginWithPriority(partition, proc.getLimiterPriority(partition))()
+	}
+
 	jobList := subJobs.subJobs
 	start := time.Now()
 
@@ -1442,7 +1548,10 @@ type transformationMessage struct {
 	rsourcesStats rsources.StatsCollector
 }
 
-func (proc *Handle) transformations(in *transformationMessage) *storeMessage {
+func (proc *Handle) transformations(partition string, in *transformationMessage) *storeMessage {
+	if proc.limiter.transform != nil {
+		defer proc.limiter.transform.BeginWithPriority(partition, proc.getLimiterPriority(partition))()
+	}
 	// Now do the actual transformation. We call it in batches, once
 	// for each destination ID
 
@@ -1532,6 +1641,26 @@ type storeMessage struct {
 	rsourcesStats rsources.StatsCollector
 }
 
+func (sm *storeMessage) merge(subJob *storeMessage) {
+	sm.statusList = append(sm.statusList, subJob.statusList...)
+	sm.destJobs = append(sm.destJobs, subJob.destJobs...)
+	sm.batchDestJobs = append(sm.batchDestJobs, subJob.batchDestJobs...)
+
+	sm.procErrorJobs = append(sm.procErrorJobs, subJob.procErrorJobs...)
+	for id, job := range subJob.procErrorJobsByDestID {
+		sm.procErrorJobsByDestID[id] = append(sm.procErrorJobsByDestID[id], job...)
+	}
+
+	sm.reportMetrics = append(sm.reportMetrics, subJob.reportMetrics...)
+	for tag, count := range subJob.sourceDupStats {
+		sm.sourceDupStats[tag] += count
+	}
+	for id := range subJob.uniqueMessageIds {
+		sm.uniqueMessageIds[id] = struct{}{}
+	}
+	sm.totalEvents += subJob.totalEvents
+}
+
 func (proc *Handle) sendRetryStoreStats(attempt int) {
 	proc.logger.Warnf("Timeout during store jobs in processor module, attempt %d", attempt)
 	stats.Default.NewTaggedStat("jobsdb_store_timeout", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt), "module": "processor"}).Count(1)
@@ -1547,7 +1676,10 @@ func (proc *Handle) sendQueryRetryStats(attempt int) {
 	stats.Default.NewTaggedStat("jobsdb_query_timeout", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt), "module": "processor"}).Count(1)
 }
 
-func (proc *Handle) Store(in *storeMessage) {
+func (proc *Handle) Store(partition string, in *storeMessage) {
+	if proc.limiter.store != nil {
+		defer proc.limiter.store.BeginWithPriority(partition, proc.getLimiterPriority(partition))()
+	}
 	statusList, destJobs, batchDestJobs := in.statusList, in.destJobs, in.batchDestJobs
 	beforeStoreStatus := time.Now()
 	// XX: Need to do this in a transaction
@@ -2177,11 +2309,14 @@ func (proc *Handle) addToTransformEventByTimePQ(event *TransformRequestT, pq *tr
 	if pq.Top().ProcessingTime < event.ProcessingTime {
 		pq.RemoveTop()
 		pq.Add(event)
-
 	}
 }
 
-func (proc *Handle) getJobs() jobsdb.JobsResult {
+func (proc *Handle) getJobs(partition string) jobsdb.JobsResult {
+	if proc.limiter.read != nil {
+		defer proc.limiter.read.BeginWithPriority(partition, proc.getLimiterPriority(partition))()
+	}
+
 	s := time.Now()
 
 	proc.logger.Debugf("Processor DB Read size: %d", proc.config.maxEventsToProcess)
@@ -2190,13 +2325,16 @@ func (proc *Handle) getJobs() jobsdb.JobsResult {
 	if !proc.config.enableEventCount {
 		eventCount = 0
 	}
+	queryParams := jobsdb.GetQueryParamsT{
+		CustomValFilters: []string{proc.config.GWCustomVal},
+		JobsLimit:        proc.config.maxEventsToProcess,
+		EventsLimit:      eventCount,
+		PayloadSizeLimit: proc.adaptiveLimit(proc.payloadLimit),
+	}
+	proc.isolationStrategy.AugmentQueryParams(partition, &queryParams)
+
 	unprocessedList, err := misc.QueryWithRetriesAndNotify(context.Background(), proc.jobdDBQueryRequestTimeout, proc.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
-		return proc.gatewayDB.GetUnprocessed(ctx, jobsdb.GetQueryParamsT{
-			CustomValFilters: []string{proc.config.GWCustomVal},
-			JobsLimit:        proc.config.maxEventsToProcess,
-			EventsLimit:      eventCount,
-			PayloadSizeLimit: proc.adaptiveLimit(proc.payloadLimit),
-		})
+		return proc.gatewayDB.GetUnprocessed(ctx, queryParams)
 	}, proc.sendQueryRetryStats)
 	if err != nil {
 		proc.logger.Errorf("Failed to get unprocessed jobs from DB. Error: %v", err)
@@ -2276,10 +2414,10 @@ func (proc *Handle) markExecuting(jobs []*jobsdb.JobT) error {
 
 // handlePendingGatewayJobs is checking for any pending gateway jobs (failed and unprocessed), and routes them appropriately
 // Returns true if any job is handled, otherwise returns false.
-func (proc *Handle) handlePendingGatewayJobs() bool {
+func (proc *Handle) handlePendingGatewayJobs(partition string) bool {
 	s := time.Now()
 
-	unprocessedList := proc.getJobs()
+	unprocessedList := proc.getJobs(partition)
 
 	if len(unprocessedList.Jobs) == 0 {
 		return false
@@ -2288,9 +2426,9 @@ func (proc *Handle) handlePendingGatewayJobs() bool {
 	rsourcesStats := rsources.NewStatsCollector(proc.rsourcesService)
 	rsourcesStats.BeginProcessing(unprocessedList.Jobs)
 
-	proc.Store(
-		proc.transformations(
-			proc.processJobsForDest(subJob{
+	proc.Store(partition,
+		proc.transformations(partition,
+			proc.processJobsForDest(partition, subJob{
 				subJobs:       unprocessedList.Jobs,
 				hasMore:       false,
 				rsourcesStats: rsourcesStats,
@@ -2300,58 +2438,6 @@ func (proc *Handle) handlePendingGatewayJobs() bool {
 	proc.stats.statLoopTime.Since(s)
 
 	return true
-}
-
-// mainLoop: legacy way of handling jobs
-func (proc *Handle) mainLoop(ctx context.Context) {
-	// waiting for reporting client setup
-	if proc.reporting != nil && proc.reportingEnabled {
-		if err := proc.reporting.WaitForSetup(ctx, types.CoreReportingClient); err != nil {
-			return
-		}
-	}
-
-	// waiting for init group
-	select {
-	case <-ctx.Done():
-		return
-	case <-proc.config.asyncInit.Wait():
-		// proceed
-	}
-
-	proc.logger.Info("Processor loop started")
-	var currLoopSleep time.Duration
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(proc.config.mainLoopTimeout):
-			found := proc.handlePendingGatewayJobs()
-			if found {
-				currLoopSleep = 0
-			} else {
-				currLoopSleep = 2*currLoopSleep + proc.config.loopSleep
-				if currLoopSleep > proc.config.maxLoopSleep {
-					currLoopSleep = proc.config.maxLoopSleep
-				}
-				if sleepTrueOnDone(ctx, currLoopSleep) {
-					return
-				}
-			}
-			if sleepTrueOnDone(ctx, proc.config.fixedLoopSleep) { // adding sleep here to reduce cpu load on postgres when we have less rps
-				return
-			}
-		}
-	}
-}
-
-func sleepTrueOnDone(ctx context.Context, duration time.Duration) bool {
-	select {
-	case <-ctx.Done():
-		return true
-	case <-time.After(duration):
-		return false
-	}
 }
 
 // `jobSplitter` func Splits the read Jobs into sub-batches after reading from DB to process.
@@ -2364,161 +2450,15 @@ type subJob struct {
 	rsourcesStats rsources.StatsCollector
 }
 
-func (proc *Handle) jobSplitter(jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []subJob {
-	subJobCount := 1
-	if len(jobs)/proc.config.subJobSize > 1 {
-		subJobCount = len(jobs) / proc.config.subJobSize
-		if len(jobs)%proc.config.subJobSize != 0 {
-			subJobCount++
-		}
-	}
-	var subJobs []subJob
-	for i := 0; i < subJobCount; i++ {
-		if i == subJobCount-1 {
-			// all the remaining jobs are sent in last sub-job batch.
-			subJobs = append(subJobs, subJob{
-				subJobs:       jobs,
-				hasMore:       false,
-				rsourcesStats: rsourcesStats,
-			})
-			continue
-		}
-		subJobs = append(subJobs, subJob{
-			subJobs:       jobs[:proc.config.subJobSize],
-			hasMore:       true,
+func (proc *Handle) jobSplitter(jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []subJob { //nolint:unparam
+	chunks := lo.Chunk(jobs, proc.config.subJobSize)
+	return lo.Map(chunks, func(subJobs []*jobsdb.JobT, index int) subJob {
+		return subJob{
+			subJobs:       subJobs,
+			hasMore:       index+1 < len(chunks),
 			rsourcesStats: rsourcesStats,
-		})
-		jobs = jobs[proc.config.subJobSize:]
-	}
-
-	return subJobs
-}
-
-// mainPipeline: new way of handling jobs
-//
-// [getJobs] -chProc-> [processJobsForDest] -chTrans-> [transformations] -chStore-> [Store]
-func (proc *Handle) mainPipeline(ctx context.Context) {
-	// waiting for reporting client setup
-	proc.logger.Infof("Processor mainPipeline started, subJobSize=%d pipelineBufferedItems=%d", proc.config.subJobSize, proc.config.pipelineBufferedItems)
-
-	if proc.reporting != nil && proc.reportingEnabled {
-		if err := proc.reporting.WaitForSetup(ctx, types.CoreReportingClient); err != nil {
-			return
-		}
-	}
-	wg := sync.WaitGroup{}
-	bufferSize := proc.config.pipelineBufferedItems
-
-	chProc := make(chan subJob, bufferSize)
-	wg.Add(1)
-	rruntime.Go(func() {
-		defer wg.Done()
-		defer close(chProc)
-		nextSleepTime := time.Duration(0)
-		// waiting for init group
-		select {
-		case <-ctx.Done():
-			return
-		case <-proc.config.asyncInit.Wait():
-			// proceed
-		}
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(nextSleepTime):
-				dbReadStart := time.Now()
-				jobs := proc.getJobs()
-				rsourcesStats := rsources.NewStatsCollector(proc.rsourcesService)
-				rsourcesStats.BeginProcessing(jobs.Jobs)
-				if len(jobs.Jobs) == 0 {
-					// no jobs found, double sleep time until maxLoopSleep
-					nextSleepTime = 2 * nextSleepTime
-					if nextSleepTime > proc.config.maxLoopSleep {
-						nextSleepTime = proc.config.maxLoopSleep
-					} else if nextSleepTime == 0 {
-						nextSleepTime = proc.config.readLoopSleep
-					}
-					continue
-				}
-
-				err := proc.markExecuting(jobs.Jobs)
-				if err != nil {
-					proc.logger.Error(err)
-					panic(err)
-				}
-				dbReadTime := time.Since(dbReadStart)
-				events := jobs.EventsCount
-				dbReadThroughput := throughputPerSecond(events, dbReadTime)
-				// DB read throughput per second.
-				proc.stats.DBReadThroughput.Count(dbReadThroughput)
-
-				// nextSleepTime is dependent on the number of events read in this loop
-				emptyRatio := 1.0 - math.Min(1, float64(events)/float64(proc.config.maxEventsToProcess))
-				nextSleepTime = time.Duration(emptyRatio * float64(proc.config.readLoopSleep))
-
-				subJobs := proc.jobSplitter(jobs.Jobs, rsourcesStats)
-				for _, subJob := range subJobs {
-					chProc <- subJob
-				}
-			}
 		}
 	})
-
-	chTrans := make(chan *transformationMessage, bufferSize)
-	wg.Add(1)
-	rruntime.Go(func() {
-		defer wg.Done()
-		defer close(chTrans)
-		for jobs := range chProc {
-			chTrans <- proc.processJobsForDest(jobs, nil)
-		}
-	})
-
-	// we need the below buffer size to ensure that `proc.Store(*mergedJob)` is not blocking rest of the Go routines.
-	chStore := make(chan *storeMessage, (bufferSize+1)*(proc.config.maxEventsToProcess/proc.config.subJobSize+1))
-	wg.Add(1)
-	rruntime.Go(func() {
-		defer wg.Done()
-		defer close(chStore)
-		for msg := range chTrans {
-			chStore <- proc.transformations(msg)
-		}
-	})
-
-	wg.Add(1)
-	rruntime.Go(func() {
-		var mergedJob storeMessage
-		firstSubJob := true
-		defer wg.Done()
-		for subJob := range chStore {
-
-			if firstSubJob && !subJob.hasMore {
-				proc.Store(subJob)
-				continue
-			}
-
-			if firstSubJob {
-				mergedJob = storeMessage{}
-				mergedJob.rsourcesStats = subJob.rsourcesStats
-				mergedJob.uniqueMessageIds = make(map[string]struct{})
-				mergedJob.procErrorJobsByDestID = make(map[string][]*jobsdb.JobT)
-				mergedJob.sourceDupStats = make(map[string]int)
-
-				mergedJob.start = subJob.start
-				firstSubJob = false
-			}
-			mergedJob := subJobMerger(&mergedJob, subJob)
-
-			if !subJob.hasMore {
-				proc.Store(mergedJob)
-				firstSubJob = true
-			}
-		}
-	})
-
-	wg.Wait()
 }
 
 func subJobMerger(mergedJob, subJob *storeMessage) *storeMessage {
@@ -2583,4 +2523,8 @@ func filterConfig(eventCopy *transformer.TransformerEventT) {
 			eventCopy.Destination.Config = lo.OmitByKeys(eventCopy.Destination.Config, omitKeys)
 		}
 	}
+}
+
+func (proc *Handle) getLimiterPriority(partition string) miscsync.LimiterPriorityValue {
+	return miscsync.LimiterPriorityValue(config.GetInt(fmt.Sprintf("Processor.Limiter.%s.Priority", partition), 1))
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -458,7 +458,7 @@ func (proc *Handle) Start(ctx context.Context) error {
 	}
 
 	// limiters
-	s := stats.Default
+	s := proc.statsFactory
 	var limiterGroup sync.WaitGroup
 	proc.limiter.read = miscsync.NewLimiter(ctx, &limiterGroup, "proc_read",
 		config.GetInt("Processor.Limiter.read.limit", 50),

--- a/processor/processor_isolation_test.go
+++ b/processor/processor_isolation_test.go
@@ -1,0 +1,402 @@
+package processor_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/rudderlabs/rudder-server/config"
+	"github.com/rudderlabs/rudder-server/processor/isolation"
+	"github.com/rudderlabs/rudder-server/runner"
+	"github.com/rudderlabs/rudder-server/services/stats"
+	"github.com/rudderlabs/rudder-server/testhelper"
+	"github.com/rudderlabs/rudder-server/testhelper/destination"
+	"github.com/rudderlabs/rudder-server/testhelper/health"
+	trand "github.com/rudderlabs/rudder-server/testhelper/rand"
+	"github.com/rudderlabs/rudder-server/testhelper/workspaceConfig"
+	"github.com/rudderlabs/rudder-server/utils/httputil"
+	"github.com/rudderlabs/rudder-server/utils/logger"
+	"github.com/rudderlabs/rudder-server/utils/types/deployment"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestProcessorIsolation(t *testing.T) {
+	const (
+		workspaces       = 10
+		jobsPerWorkspace = 100
+	)
+	t.Run("no isolation", func(t *testing.T) {
+		spec := NewProcIsolationScenarioSpec(isolation.ModeNone, workspaces, jobsPerWorkspace)
+		ProcIsolationScenario(t, spec)
+	})
+
+	t.Run("workspace isolation", func(t *testing.T) {
+		spec := NewProcIsolationScenarioSpec(isolation.ModeWorkspace, workspaces, jobsPerWorkspace)
+		ProcIsolationScenario(t, spec)
+	})
+}
+
+// go test \
+// -timeout 3600s \
+// -run=^$ \
+// -bench ^BenchmarkProcessorIsolationModes$ \
+// github.com/rudderlabs/rudder-server/processor \
+// -v \
+// -count=1 |grep BenchmarkProcessorIsolationModes
+// BenchmarkProcessorIsolationModes
+// BenchmarkProcessorIsolationModes/no_isolation_10_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/no_isolation_10_workspaces_200000_total_jobs-10         	       1	59231884750 ns/op	        45.74 overall_duration_sec
+// BenchmarkProcessorIsolationModes/workspace_isolation_10_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/workspace_isolation_10_workspaces_200000_total_jobs-10  	       1	53940493625 ns/op	        42.09 overall_duration_sec
+// BenchmarkProcessorIsolationModes/no_isolation_50_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/no_isolation_50_workspaces_200000_total_jobs-10         	       1	61723605875 ns/op	        48.85 overall_duration_sec
+// BenchmarkProcessorIsolationModes/workspace_isolation_50_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/workspace_isolation_50_workspaces_200000_total_jobs-10  	       1	54179625166 ns/op	        43.46 overall_duration_sec
+// BenchmarkProcessorIsolationModes/no_isolation_100_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/no_isolation_100_workspaces_200000_total_jobs-10        	       1	60094660500 ns/op	        48.34 overall_duration_sec
+// BenchmarkProcessorIsolationModes/workspace_isolation_100_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/workspace_isolation_100_workspaces_200000_total_jobs-10 	       1	58543965292 ns/op	        47.58 overall_duration_sec
+// BenchmarkProcessorIsolationModes/no_isolation_200_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/no_isolation_200_workspaces_200000_total_jobs-10        	       1	59670751833 ns/op	        47.68 overall_duration_sec
+// BenchmarkProcessorIsolationModes/workspace_isolation_200_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/workspace_isolation_200_workspaces_200000_total_jobs-10 	       1	66366145500 ns/op	        51.19 overall_duration_sec
+// BenchmarkProcessorIsolationModes/no_isolation_500_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/no_isolation_500_workspaces_200000_total_jobs-10        	       1	69775513875 ns/op	        48.78 overall_duration_sec
+// BenchmarkProcessorIsolationModes/workspace_isolation_500_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/workspace_isolation_500_workspaces_200000_total_jobs-10 	       1	71046349167 ns/op	        57.88 overall_duration_sec
+// BenchmarkProcessorIsolationModes/no_isolation_1000_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/no_isolation_1000_workspaces_200000_total_jobs-10       	       1	62591102750 ns/op	        48.95 overall_duration_sec
+// BenchmarkProcessorIsolationModes/workspace_isolation_1000_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/workspace_isolation_1000_workspaces_200000_total_jobs-10   	       1	77994220792 ns/op	        64.62 overall_duration_sec
+// BenchmarkProcessorIsolationModes/no_isolation_10000_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/no_isolation_10000_workspaces_200000_total_jobs-10         	       1	66160071708 ns/op	        52.72 overall_duration_sec
+// BenchmarkProcessorIsolationModes/workspace_isolation_10000_workspaces_200000_total_jobs
+// BenchmarkProcessorIsolationModes/workspace_isolation_10000_workspaces_200000_total_jobs-10  	       1	148012983583 ns/op	       127.4 overall_duration_sec
+//
+// https://snapshots.raintank.io/dashboard/snapshot/9643HY7OqrsYae1HuAjAz167953NOCN3
+func BenchmarkProcessorIsolationModes(b *testing.B) {
+	benchmarkModes := func(b *testing.B, workspaces, totalJobs int) {
+		title := fmt.Sprintf("no isolation %d workspaces %d total jobs", workspaces, totalJobs)
+
+		b.Run(title, func(b *testing.B) {
+			stats.Default.NewTaggedStat("benchmark", stats.CountType, stats.Tags{"title": title, "action": "start"}).Increment()
+			defer stats.Default.NewTaggedStat("benchmark", stats.CountType, stats.Tags{"title": title, "action": "end"}).Increment()
+			spec := NewProcIsolationScenarioSpec(isolation.ModeNone, workspaces, totalJobs/workspaces)
+			overallDuration := ProcIsolationScenario(b, spec)
+			b.ReportMetric(overallDuration.Seconds(), "overall_duration_sec")
+		})
+
+		title = fmt.Sprintf("workspace isolation %d workspaces %d total jobs", workspaces, totalJobs)
+		b.Run(title, func(b *testing.B) {
+			stats.Default.NewTaggedStat("benchmark", stats.CountType, stats.Tags{"title": title, "action": "start"}).Increment()
+			defer stats.Default.NewTaggedStat("benchmark", stats.CountType, stats.Tags{"title": title, "action": "end"}).Increment()
+			spec := NewProcIsolationScenarioSpec(isolation.ModeWorkspace, workspaces, totalJobs/workspaces)
+			overallDuration := ProcIsolationScenario(b, spec)
+			b.ReportMetric(overallDuration.Seconds(), "overall_duration_sec")
+		})
+	}
+
+	benchmarkModes(b, 10, 200000)
+	benchmarkModes(b, 50, 200000)
+	benchmarkModes(b, 100, 200000)
+	benchmarkModes(b, 200, 200000)
+	benchmarkModes(b, 500, 200000)
+	benchmarkModes(b, 1000, 200000)
+	benchmarkModes(b, 10000, 200000)
+}
+
+// ProcIsolationScenarioSpec is a specification for a processor isolation scenario.
+// - isolationMode is the isolation mode to use.
+// - workspaces is the number of workspaces to use.
+// - eventsPerWorkspace is the number of events to send per workspace.
+func NewProcIsolationScenarioSpec(isolationMode isolation.Mode, workspaces, eventsPerWorkspace int) *ProcIsolationScenarioSpec {
+	rand.Seed(time.Now().UnixNano())
+	var s ProcIsolationScenarioSpec
+	s.isolationMode = isolationMode
+	s.jobs = make([]*procIsolationJobSpec, workspaces*eventsPerWorkspace)
+	s.received = map[int]struct{}{}
+
+	var idx int
+	for u := 0; u < workspaces; u++ {
+		workspaceID := "workspace-" + strconv.Itoa(u)
+		s.workspaces = append(s.workspaces, workspaceID)
+		for i := 0; i < eventsPerWorkspace; i++ {
+			jobID := idx + 1
+			js := procIsolationJobSpec{
+				id:          jobID,
+				workspaceID: workspaceID,
+				userID:      strconv.Itoa(jobID),
+			}
+			s.jobs[idx] = &js
+			idx++
+		}
+	}
+	return &s
+}
+
+// ProcIsolationScenario runs a scenario with the given spec which:
+// 1. Sends all events to gateway
+// 2. Waits for the events to be processed by processor
+// 3. Verifies that the correct number of events have been sent to router's jobsdb
+// 4. Returns the total processing duration (last event time - first event time).
+func ProcIsolationScenario(t testing.TB, spec *ProcIsolationScenarioSpec) (overallDuration time.Duration) {
+	var m procIsolationMethods
+
+	config.Reset()
+	defer logger.Reset()
+	defer config.Reset()
+	config.Set("LOG_LEVEL", "ERROR")
+	logger.Reset()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var (
+		postgresContainer    *destination.PostgresResource
+		transformerContainer *destination.TransformerResource
+		gatewayPort          string
+	)
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	containersGroup, _ := errgroup.WithContext(ctx)
+	containersGroup.Go(func() (err error) {
+		postgresContainer, err = destination.SetupPostgres(pool, t, "max_connections=1000")
+		return err
+	})
+	containersGroup.Go(func() (err error) {
+		transformerContainer, err = destination.SetupTransformer(pool, t)
+		return err
+	})
+	require.NoError(t, containersGroup.Wait())
+
+	destinationID := trand.String(27)
+
+	templateCtx := map[string]any{
+		"webhookUrl":    "http://localhost:1234", // not important
+		"workspaces":    spec.workspaces,
+		"destinationId": destinationID,
+	}
+	configJsonPath := workspaceConfig.CreateTempFile(t, "testdata/procIsolationTestTemplate.json.tpl", templateCtx)
+	mockCBE := m.newMockConfigBackend(t, configJsonPath)
+	config.Set("CONFIG_BACKEND_URL", mockCBE.URL)
+
+	config.Set("forceStaticModeProvider", true)
+	config.Set("DEPLOYMENT_TYPE", string(deployment.MultiTenantType))
+	config.Set("WORKSPACE_NAMESPACE", "proc_isolation_test")
+	config.Set("HOSTED_SERVICE_SECRET", "proc_isolation_secret")
+	config.Set("recovery.storagePath", path.Join(t.TempDir(), "/recovery_data.json"))
+
+	config.Set("DB.port", postgresContainer.Port)
+	config.Set("DB.user", postgresContainer.User)
+	config.Set("DB.name", postgresContainer.Database)
+	config.Set("DB.password", postgresContainer.Password)
+	config.Set("DEST_TRANSFORM_URL", transformerContainer.TransformURL)
+
+	config.Set("Warehouse.mode", "off")
+	config.Set("DestinationDebugger.disableEventDeliveryStatusUploads", true)
+	config.Set("SourceDebugger.disableEventUploads", true)
+	config.Set("TransformationDebugger.disableTransformationStatusUploads", true)
+	config.Set("JobsDB.backup.enabled", false)
+	config.Set("JobsDB.migrateDSLoopSleepDuration", "60m")
+	config.Set("Router.toAbortDestinationIDs", destinationID)
+
+	config.Set("Processor.isolationMode", string(spec.isolationMode))
+
+	config.Set("JobsDB.enableWriterQueue", false)
+
+	// find free port for gateway http server to listen on
+	httpPortInt, err := testhelper.GetFreePort()
+	require.NoError(t, err)
+	gatewayPort = strconv.Itoa(httpPortInt)
+
+	config.Set("Gateway.webPort", gatewayPort)
+	config.Set("RUDDER_TMPDIR", os.TempDir())
+
+	svcDone := make(chan struct{})
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("rudder-server panicked: %v", r)
+				close(svcDone)
+			}
+		}()
+		r := runner.New(runner.ReleaseInfo{})
+		c := r.Run(ctx, []string{"proc-isolation-test-rudder-server"})
+		if c != 0 {
+			t.Errorf("rudder-server exited with a non-0 exit code: %d", c)
+		}
+		close(svcDone)
+	}()
+
+	health.WaitUntilReady(ctx, t,
+		fmt.Sprintf("http://localhost:%s/health", gatewayPort),
+		200*time.Second,
+		100*time.Millisecond,
+		t.Name(),
+	)
+
+	batchSize := 5
+	batches := m.splitInBatches(spec.jobs, batchSize)
+
+	t.Logf("sending %d events in %d batches", len(spec.jobs), len(batches))
+	gzipPayload := func(data []byte) (io.Reader, error) {
+		var b bytes.Buffer
+		gz := gzip.NewWriter(&b)
+		_, err = gz.Write(data)
+		if err != nil {
+			return nil, err
+		}
+
+		if err = gz.Flush(); err != nil {
+			return nil, err
+		}
+
+		if err = gz.Close(); err != nil {
+			return nil, err
+		}
+
+		return &b, nil
+	}
+	g := &errgroup.Group{}
+	g.SetLimit(100)
+	client := &http.Client{}
+	url := fmt.Sprintf("http://localhost:%s/v1/batch", gatewayPort)
+	for _, payload := range batches {
+		payload := payload
+		g.Go(func() error {
+			writeKey := gjson.GetBytes(payload, "batch.0.workspaceID").String()
+			p, err := gzipPayload(payload)
+			require.NoError(t, err)
+			req, err := http.NewRequest("POST", url, p)
+			req.Header.Add("Content-Encoding", "gzip")
+			require.NoError(t, err, "should be able to create a new request")
+			req.SetBasicAuth(writeKey, "password")
+			resp, err := client.Do(req)
+			require.NoError(t, err, "should be able to send the request to gateway")
+			require.Equal(t, http.StatusOK, resp.StatusCode, "should be able to send the request to gateway successfully", payload)
+			func() { httputil.CloseResponse(resp) }()
+			return nil
+		})
+	}
+	require.NoError(t, g.Wait())
+
+	require.Eventually(t, func() bool {
+		var processedJobCount int
+		require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdb('gw',5) WHERE job_state = 'succeeded'").Scan(&processedJobCount))
+		return processedJobCount == len(spec.jobs)/batchSize
+	}, 300*time.Second, 1*time.Second, "all batches should be successfully processed")
+
+	var failedJobs int
+	require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdb('proc_error',5) where parameters->>'stage' != 'router'").Scan(&failedJobs))
+	require.Equal(t, 0, failedJobs, "should not have any failed jobs")
+
+	// count gw min and max job times
+	var gwMinJobTime, gwMaxJobTime time.Time
+	require.NoError(t, postgresContainer.DB.QueryRow("SELECT min(created_at), max(created_at) FROM unionjobsdb('gw',5)").Scan(&gwMinJobTime, &gwMaxJobTime))
+
+	// count min and max job times
+	var minJobTime, maxJobTime time.Time
+	var totalJobsCount int
+	require.NoError(t, postgresContainer.DB.QueryRow("SELECT min(created_at), max(created_at), count(*) FROM unionjobsdb('rt',5)").Scan(&minJobTime, &maxJobTime, &totalJobsCount))
+	require.Equal(t, len(spec.jobs), totalJobsCount)
+	overallDuration = maxJobTime.Sub(gwMinJobTime)
+
+	require.Eventually(t, func() bool {
+		var pendingJobsCount int
+		require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdb('rt',5) WHERE COALESCE(job_state, 'pending') != 'aborted'").Scan(&pendingJobsCount))
+		return pendingJobsCount == 0
+	}, 100*time.Second, 1*time.Second, "all rt jobs should be aborted")
+	cancel()
+	<-svcDone
+	return
+}
+
+type ProcIsolationScenarioSpec struct {
+	isolationMode isolation.Mode
+	workspaces    []string
+	jobs          []*procIsolationJobSpec
+	received      map[int]struct{}
+}
+
+type procIsolationJobSpec struct {
+	id          int
+	workspaceID string
+	userID      string
+}
+
+func (jobSpec *procIsolationJobSpec) payload() string {
+	template := `{
+				"userId": %q,
+				"anonymousId": %q,
+				"testJobId": %d,
+				"workspaceID": %q,
+				"type": "identify",
+				"context":
+				{
+					"traits":
+					{
+						"trait1": "new-val"
+					},
+					"ip": "14.5.67.21",
+					"library":
+					{
+						"name": "http"
+					}
+				},
+				"timestamp": "2020-02-02T00:23:09.544Z"
+			}`
+	return fmt.Sprintf(template, jobSpec.userID, jobSpec.userID, jobSpec.id, jobSpec.workspaceID)
+}
+
+// Using a struct to keep processor_test package clean and
+// avoid method collisions with other tests
+type procIsolationMethods struct{}
+
+func (procIsolationMethods) newMockConfigBackend(t testing.TB, path string) *httptest.Server {
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "should be able to read the config file")
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "features") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if strings.Contains(r.URL.Path, "settings") {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(data)
+		require.NoError(t, err, "should be able to write the response code to the response")
+	}))
+}
+
+// splitInBatches creates batches of jobs from the same workspace, shuffled so that
+// batches for the same workspace are not consecutive.
+func (procIsolationMethods) splitInBatches(jobs []*procIsolationJobSpec, batchSize int) [][]byte {
+	payloads := map[string][]string{}
+	for _, job := range jobs {
+		payloads[job.workspaceID] = append(payloads[job.workspaceID], job.payload())
+	}
+
+	var batches [][]byte
+	for _, payload := range payloads {
+		chunks := lo.Chunk(payload, batchSize)
+		batches = append(batches, lo.Map(chunks, func(chunk []string, _ int) []byte {
+			return []byte(fmt.Sprintf(`{"batch":[%s]}`, strings.Join(chunk, ",")))
+		})...)
+	}
+	return lo.Shuffle(batches)
+}

--- a/processor/testdata/procIsolationTestTemplate.json.tpl
+++ b/processor/testdata/procIsolationTestTemplate.json.tpl
@@ -1,0 +1,106 @@
+{
+{{- range $index, $workspace := .workspaces}}
+    {{if $index }},{{ end }}
+    "{{$workspace}}" : {
+        "enableMetrics": false,
+        "workspaceId": "{{$workspace}}",
+        "sources": [
+            {
+                "config": {},
+                "id": "xxxyyyzzEaEurW247ad9WYZLUyk",
+                "name": "Dev Integration Test 1",
+                "writeKey": "{{$workspace}}",
+                "enabled": true,
+                "sourceDefinitionId": "xxxyyyzzpWDzNxgGUYzq9sZdZZB",
+                "createdBy": "xxxyyyzzueyoBz4jb7bRdOzDxai",
+                "workspaceId": "{{$workspace}}",
+                "deleted": false,
+                "createdAt": "2021-08-27T06:33:00.305Z",
+                "updatedAt": "2021-08-27T06:33:00.305Z",
+                "destinations": [
+                    {
+                        "config": {
+                            "webhookUrl": "{{$.webhookUrl}}",
+                            "webhookMethod": "POST"
+                        },
+                        "secretConfig": {},
+                        "id": "{{$.destinationId}}",
+                        "name": "Des WebHook Integration Test 1",
+                        "enabled": true,
+                        "workspaceId": "{{$workspace}}",
+                        "deleted": false,
+                        "createdAt": "2021-08-27T06:49:38.546Z",
+                        "updatedAt": "2021-08-27T06:49:38.546Z",
+                        "transformations": [
+                            {
+                                "versionId": "23hZ5VLGt0Yl7Hxk9ysBGi5baud",
+                                "config": {},
+                                "id": "23VJjP3bbHMzUhWjI7bvNL5S9xx"
+                            }
+                        ],
+                        "destinationDefinition": {
+                            "config": {
+                                "destConfig": {
+                                    "defaultConfig": [
+                                        "webhookUrl",
+                                        "webhookMethod",
+                                        "headers"
+                                    ]
+                                },
+                                "secretKeys": [
+                                    "headers.to"
+                                ],
+                                "excludeKeys": [],
+                                "includeKeys": [],
+                                "transformAt": "processor",
+                                "transformAtV1": "processor",
+                                "supportedSourceTypes": [
+                                    "android",
+                                    "ios",
+                                    "web",
+                                    "unity",
+                                    "amp",
+                                    "cloud",
+                                    "warehouse",
+                                    "reactnative",
+                                    "flutter"
+                                ],
+                                "supportedMessageTypes": [
+                                    "alias",
+                                    "group",
+                                    "identify",
+                                    "page",
+                                    "screen",
+                                    "track"
+                                ],
+                                "saveDestinationResponse": false
+                            },
+                            "configSchema": null,
+                            "responseRules": null,
+                            "id": "xxxyyyzzSOU9pLRavMf0GuVnWV3",
+                            "name": "WEBHOOK",
+                            "displayName": "Webhook",
+                            "category": null,
+                            "createdAt": "2020-03-16T19:25:28.141Z",
+                            "updatedAt": "2021-08-26T07:06:01.445Z"
+                        },
+                        "isConnectionEnabled": true,
+                        "isProcessorEnabled": true
+                    }
+                ],
+                "sourceDefinition": {
+                    "id": "xxxyyyzzpWDzNxgGUYzq9sZdZZB",
+                    "name": "HTTP",
+                    "options": null,
+                    "displayName": "HTTP",
+                    "category": "",
+                    "createdAt": "2020-06-12T06:35:35.962Z",
+                    "updatedAt": "2020-06-12T06:35:35.962Z"
+                },
+                "dgSourceTrackingPlanConfig": null
+            }
+        ],
+        "libraries": []
+    }
+{{- end }}
+}

--- a/processor/worker.go
+++ b/processor/worker.go
@@ -1,0 +1,211 @@
+package processor
+
+import (
+	"context"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/rruntime"
+	"github.com/rudderlabs/rudder-server/services/rsources"
+	"github.com/rudderlabs/rudder-server/utils/logger"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+)
+
+// newWorker creates a new worker
+func newWorker(ctx context.Context, partition string, h workerHandle) *worker {
+	w := &worker{
+		handle:    h,
+		logger:    h.logger().Child(partition),
+		partition: partition,
+	}
+	w.lifecycle.ctx, w.lifecycle.cancel = context.WithCancel(ctx)
+	w.channel.ping = make(chan struct{}, 1)
+	w.channel.preproccess = make(chan subJob, w.handle.config().pipelineBufferedItems)
+	w.channel.transform = make(chan *transformationMessage, w.handle.config().pipelineBufferedItems)
+	w.channel.store = make(chan *storeMessage, (w.handle.config().pipelineBufferedItems+1)*(w.handle.config().maxEventsToProcess/w.handle.config().subJobSize+1))
+	w.start()
+
+	return w
+}
+
+// worker picks jobs from jobsdb for the appropriate partition and performs all processing steps for them
+//  1. preproccess
+//  2. transform
+//  3. store
+type worker struct {
+	partition string
+	handle    workerHandle
+	logger    logger.Logger
+
+	lifecycle struct { // worker lifecycle related fields
+		ctx    context.Context    // worker context
+		cancel context.CancelFunc // worker context cancel function
+		wg     sync.WaitGroup     // worker wait group
+
+		idleMu    sync.RWMutex // idle mutex
+		idleSince time.Time    // idle since
+	}
+
+	channel struct { // worker channels
+		ping        chan struct{}               // ping channel triggers the worker to start working
+		preproccess chan subJob                 // preproccess channel is used to send jobs to preproccess asynchronously when pipelining is enabled
+		transform   chan *transformationMessage // transform channel is used to send jobs to transform asynchronously when pipelining is enabled
+		store       chan *storeMessage          // store channel is used to send jobs to store asynchronously when pipelining is enabled
+	}
+}
+
+// start starts the various worker goroutines
+func (w *worker) start() {
+	// ping loop
+	w.lifecycle.wg.Add(1)
+	rruntime.Go(func() {
+		var exponentialSleep misc.ExponentialNumber[time.Duration]
+		defer w.lifecycle.wg.Done()
+		defer close(w.channel.preproccess)
+		defer close(w.channel.ping)
+		defer w.logger.Debugf("ping loop stopped for worker: %s", w.partition)
+		for {
+			select {
+			case <-w.lifecycle.ctx.Done():
+				return
+			case <-w.channel.ping:
+			}
+
+			w.setIdleSince(time.Time{})
+			if w.pickJobs() {
+				exponentialSleep.Reset()
+			} else {
+				if err := misc.SleepCtx(w.lifecycle.ctx, exponentialSleep.Next(w.handle.config().readLoopSleep, w.handle.config().maxLoopSleep)); err != nil {
+					w.logger.Info("ping loop stopped for worker: ", w.partition, " due to: ", err)
+					return
+				}
+				w.setIdleSince(time.Now())
+			}
+		}
+	})
+
+	if !w.handle.config().enablePipelining {
+		return
+	}
+
+	// preproccess jobs
+	w.lifecycle.wg.Add(1)
+	rruntime.Go(func() {
+		defer w.lifecycle.wg.Done()
+		defer close(w.channel.transform)
+		defer w.logger.Debugf("preproccessing routine stopped for worker: %s", w.partition)
+		for jobs := range w.channel.preproccess {
+			w.channel.transform <- w.handle.processJobsForDest(w.partition, jobs, nil)
+		}
+	})
+
+	// transform jobs
+	w.lifecycle.wg.Add(1)
+	rruntime.Go(func() {
+		defer w.lifecycle.wg.Done()
+		defer close(w.channel.store)
+		defer w.logger.Debugf("transform routine stopped for worker: %s", w.partition)
+		for msg := range w.channel.transform {
+			w.channel.store <- w.handle.transformations(w.partition, msg)
+		}
+	})
+
+	// store jobs
+	w.lifecycle.wg.Add(1)
+	rruntime.Go(func() {
+		var mergedJob *storeMessage
+		firstSubJob := true
+		defer w.lifecycle.wg.Done()
+		defer w.logger.Debugf("store routine stopped for worker: %s", w.partition)
+		for subJob := range w.channel.store {
+
+			if firstSubJob && !subJob.hasMore {
+				w.handle.Store(w.partition, subJob)
+				continue
+			}
+
+			if firstSubJob {
+				mergedJob = &storeMessage{
+					rsourcesStats:         subJob.rsourcesStats,
+					uniqueMessageIds:      make(map[string]struct{}),
+					procErrorJobsByDestID: make(map[string][]*jobsdb.JobT),
+					sourceDupStats:        make(map[string]int),
+					start:                 subJob.start,
+				}
+				firstSubJob = false
+			}
+			mergedJob.merge(subJob)
+
+			if !subJob.hasMore {
+				w.handle.Store(w.partition, mergedJob)
+				firstSubJob = true
+			}
+		}
+	})
+}
+
+// pickJobs picks the next set of jobs from the jobsdb and returns [true] if jobs were picked, [false] otherwise
+func (w *worker) pickJobs() (picked bool) {
+	if w.handle.config().enablePipelining {
+		start := time.Now()
+		jobs := w.handle.getJobs(w.partition)
+
+		if len(jobs.Jobs) == 0 {
+			return
+		}
+		picked = true
+
+		if err := w.handle.markExecuting(jobs.Jobs); err != nil {
+			w.logger.Error(err)
+			panic(err)
+		}
+
+		w.handle.stats().DBReadThroughput.Count(throughputPerSecond(jobs.EventsCount, time.Since(start)))
+
+		rsourcesStats := rsources.NewStatsCollector(w.handle.rsourcesService())
+		rsourcesStats.BeginProcessing(jobs.Jobs)
+		subJobs := w.handle.jobSplitter(jobs.Jobs, rsourcesStats)
+		for _, subJob := range subJobs {
+			w.channel.preproccess <- subJob
+		}
+
+		// sleepRatio is dependent on the number of events read in this loop
+		sleepRatio := 1.0 - math.Min(1, float64(jobs.EventsCount)/float64(w.handle.config().maxEventsToProcess))
+		if err := misc.SleepCtx(w.lifecycle.ctx, time.Duration(sleepRatio*float64(w.handle.config().readLoopSleep))); err != nil {
+			return
+		}
+		return
+	} else {
+		return w.handle.handlePendingGatewayJobs(w.partition)
+	}
+}
+
+func (w *worker) setIdleSince(t time.Time) {
+	w.lifecycle.idleMu.Lock()
+	defer w.lifecycle.idleMu.Unlock()
+	w.lifecycle.idleSince = t
+}
+
+// Ping triggers the worker to pick more jobs
+func (w *worker) Ping() {
+	select {
+	case w.channel.ping <- struct{}{}:
+	default:
+	}
+}
+
+// IdleSince returns the time when the worker was last idle. If the worker is not idle, it returns a zero time.
+func (w *worker) IdleSince() time.Time {
+	w.lifecycle.idleMu.RLock()
+	defer w.lifecycle.idleMu.RUnlock()
+	return w.lifecycle.idleSince
+}
+
+// Stop stops the worker and waits until all its goroutines have stopped
+func (w *worker) Stop() {
+	w.lifecycle.cancel()
+	w.lifecycle.wg.Wait()
+	w.logger.Debugf("Stopped worker: %s", w.partition)
+}

--- a/processor/worker_handle.go
+++ b/processor/worker_handle.go
@@ -1,0 +1,38 @@
+package processor
+
+import (
+	"time"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/services/rsources"
+	"github.com/rudderlabs/rudder-server/utils/logger"
+	"github.com/rudderlabs/rudder-server/utils/types"
+)
+
+// workerHandle is the interface trying to abstract processor's [Handle] implememtation from the worker
+type workerHandle interface {
+	logger() logger.Logger
+	config() workerHandleConfig
+	rsourcesService() rsources.JobService
+	handlePendingGatewayJobs(key string) bool
+	stats() *processorStats
+
+	getJobs(partition string) jobsdb.JobsResult
+	markExecuting(jobs []*jobsdb.JobT) error
+	jobSplitter(jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []subJob
+	processJobsForDest(partition string, subJobs subJob, parsedEventList [][]types.SingularEventT) *transformationMessage
+	transformations(partition string, in *transformationMessage) *storeMessage
+	Store(partition string, in *storeMessage)
+}
+
+// workerHandleConfig is a struct containing the processor.Handle configuration relevant for workers
+type workerHandleConfig struct {
+	maxEventsToProcess int
+
+	enablePipelining      bool
+	pipelineBufferedItems int
+	subJobSize            int
+
+	readLoopSleep time.Duration
+	maxLoopSleep  time.Duration
+}

--- a/processor/worker_handle_adapter.go
+++ b/processor/worker_handle_adapter.go
@@ -1,0 +1,34 @@
+package processor
+
+import (
+	"github.com/rudderlabs/rudder-server/services/rsources"
+	"github.com/rudderlabs/rudder-server/utils/logger"
+)
+
+// workerHandleAdapter is a wrapper around processor.Handle that implements the workerHandle interface
+type workerHandleAdapter struct {
+	*Handle
+}
+
+func (h *workerHandleAdapter) logger() logger.Logger {
+	return h.Handle.logger
+}
+
+func (h *workerHandleAdapter) config() workerHandleConfig {
+	return workerHandleConfig{
+		enablePipelining:      h.Handle.config.enablePipelining,
+		pipelineBufferedItems: h.Handle.config.pipelineBufferedItems,
+		maxEventsToProcess:    h.Handle.config.maxEventsToProcess,
+		subJobSize:            h.Handle.config.subJobSize,
+		readLoopSleep:         h.Handle.config.readLoopSleep,
+		maxLoopSleep:          h.Handle.config.maxLoopSleep,
+	}
+}
+
+func (h *workerHandleAdapter) rsourcesService() rsources.JobService {
+	return h.Handle.rsourcesService
+}
+
+func (h *workerHandleAdapter) stats() *processorStats {
+	return &h.Handle.stats
+}

--- a/processor/worker_pool.go
+++ b/processor/worker_pool.go
@@ -1,0 +1,119 @@
+package processor
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/rruntime"
+	"github.com/rudderlabs/rudder-server/utils/logger"
+)
+
+// withWorkerPoolCleanupPeriod option sets the cleanup period for the worker pool
+func withWorkerPoolCleanupPeriod(cleanupPeriod time.Duration) func(*workerPool) {
+	return func(wp *workerPool) {
+		wp.cleanupPeriod = cleanupPeriod
+	}
+}
+
+// withWorkerPoolIdleTimeout option sets the idle timeout for the worker pool
+func withWorkerPoolIdleTimeout(idleTimeout time.Duration) func(*workerPool) {
+	return func(wp *workerPool) {
+		wp.idleTimeout = idleTimeout
+	}
+}
+
+// newWorkerPool creates a new worker pool
+func newWorkerPool(ctx context.Context, handle workerHandle, opts ...func(*workerPool)) *workerPool {
+	wp := &workerPool{
+		handle:        handle,
+		logger:        handle.logger().Child("worker-pool"),
+		workers:       make(map[string]*worker),
+		cleanupPeriod: 10 * time.Second,
+		idleTimeout:   5 * time.Minute,
+	}
+	for _, opt := range opts {
+		opt(wp)
+	}
+	wp.lifecycle.ctx, wp.lifecycle.cancel = context.WithCancel(ctx)
+	wp.startCleanupLoop()
+	return wp
+}
+
+// workerPool manages a pool of workers
+type workerPool struct {
+	handle workerHandle
+	logger logger.Logger
+
+	cleanupPeriod time.Duration
+	idleTimeout   time.Duration
+
+	workersMu sync.RWMutex
+	workers   map[string]*worker
+
+	lifecycle struct {
+		ctx    context.Context
+		cancel context.CancelFunc
+		wg     sync.WaitGroup
+	}
+}
+
+// PingWorker pings the worker for the given partition
+func (wp *workerPool) PingWorker(partition string) {
+	wp.worker(partition).Ping()
+}
+
+// Shutdown stops all workers in the pull and waits for them to stop
+func (wp *workerPool) Shutdown() {
+	for _, w := range wp.workers {
+		w.Stop()
+	}
+	wp.lifecycle.cancel()
+	wp.lifecycle.wg.Wait()
+}
+
+// Size returns the number of workers in the pool
+func (wp *workerPool) Size() int {
+	wp.workersMu.RLock()
+	defer wp.workersMu.RUnlock()
+	return len(wp.workers)
+}
+
+// worker gets or creates a worker for the given partition
+func (wp *workerPool) worker(partition string) *worker {
+	wp.workersMu.Lock()
+	defer wp.workersMu.Unlock()
+	w, ok := wp.workers[partition]
+	if !ok {
+		wp.logger.Infof("Adding worker in the pool for partition: %s", partition)
+		w = newWorker(wp.lifecycle.ctx, partition, wp.handle)
+		wp.workers[partition] = w
+	}
+	return w
+}
+
+// startCleanupLoop starts a loop that cleans up idle workers
+func (wp *workerPool) startCleanupLoop() {
+	wp.lifecycle.wg.Add(1)
+	rruntime.Go(func() {
+		defer wp.lifecycle.wg.Done()
+		for {
+			select {
+			case <-wp.lifecycle.ctx.Done():
+				return
+			case <-time.After(wp.cleanupPeriod):
+			}
+			wp.workersMu.Lock()
+			for partition, w := range wp.workers {
+				idleTime := w.IdleSince()
+				if !idleTime.IsZero() && time.Since(idleTime) > wp.idleTimeout {
+					wp.logger.Infof("Destroying idle worker for partition: %s", partition)
+					w.Stop()
+					delete(wp.workers, partition)
+					wp.logger.Infof("Removed idle worker from pool for partition: %s", partition)
+				}
+			}
+			wp.workersMu.Unlock()
+		}
+	})
+}

--- a/processor/worker_pool_test.go
+++ b/processor/worker_pool_test.go
@@ -1,0 +1,286 @@
+package processor
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/services/rsources"
+	"github.com/rudderlabs/rudder-server/services/stats"
+	"github.com/rudderlabs/rudder-server/utils/logger"
+	utilsync "github.com/rudderlabs/rudder-server/utils/sync"
+	"github.com/rudderlabs/rudder-server/utils/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkerPool(t *testing.T) {
+	run := func(t *testing.T, pipelining bool) {
+		wh := &mockWorkerHandle{
+			pipelining: pipelining,
+			log:        logger.NOP,
+			loopEvents: 100,
+			partitionStats: map[string]struct {
+				queried     int
+				marked      int
+				processed   int
+				transformed int
+				stored      int
+			}{},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		poolCtx, poolCancel := context.WithCancel(context.Background())
+
+		if pipelining {
+			var limiterWg sync.WaitGroup
+			wh.limiters.query = utilsync.NewLimiter(poolCtx, &limiterWg, "query", 2, stats.Default)
+			wh.limiters.process = utilsync.NewLimiter(poolCtx, &limiterWg, "process", 2, stats.Default)
+			wh.limiters.store = utilsync.NewLimiter(poolCtx, &limiterWg, "store", 2, stats.Default)
+			wh.limiters.transform = utilsync.NewLimiter(poolCtx, &limiterWg, "transform", 2, stats.Default)
+			defer limiterWg.Wait()
+		}
+
+		defer poolCancel()
+
+		// create a worker pool
+		wp := newWorkerPool(poolCtx, wh)
+
+		// start pinging for work for 100 partitions
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			partition := "p-" + strconv.Itoa(i)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-time.After(10 * time.Millisecond):
+						wp.PingWorker(partition)
+					}
+				}
+			}()
+		}
+		// stop pinging after 5 seconds
+		time.Sleep(5 * time.Second)
+		cancel()
+		wg.Wait()
+
+		// wait for all workers to finish
+		wp.Shutdown()
+
+		// validate that all jobs were processed
+		wh.validate(t)
+	}
+
+	t.Run("work without pipelining", func(t *testing.T) {
+		run(t, false)
+	})
+
+	t.Run("work with pipelining", func(t *testing.T) {
+		run(t, true)
+	})
+}
+
+func TestWorkerPoolIdle(t *testing.T) {
+	wh := &mockWorkerHandle{
+		pipelining: true,
+		log:        logger.NewLogger(),
+		loopEvents: 0,
+		partitionStats: map[string]struct {
+			queried     int
+			marked      int
+			processed   int
+			transformed int
+			stored      int
+		}{},
+	}
+
+	poolCtx, poolCancel := context.WithCancel(context.Background())
+	defer poolCancel()
+
+	// create a worker pool
+	wp := newWorkerPool(poolCtx, wh,
+		withWorkerPoolCleanupPeriod(200*time.Millisecond),
+		withWorkerPoolIdleTimeout(200*time.Millisecond))
+
+	require.Equal(t, 0, wp.Size())
+
+	// start pinging for work for 1 partition
+	wp.PingWorker("p-1")
+
+	require.Equal(t, 1, wp.Size())
+
+	require.Eventually(t, func() bool {
+		return wp.Size() == 0
+	}, 2*time.Second, 10*time.Millisecond, "worker pool should be emptyied since worker will be idle (no jobs to process)")
+
+	wp.Shutdown()
+}
+
+type mockWorkerHandle struct {
+	pipelining     bool
+	loopEvents     int
+	statsMu        sync.RWMutex
+	log            logger.Logger
+	partitionStats map[string]struct {
+		queried     int
+		marked      int
+		processed   int
+		transformed int
+		stored      int
+	}
+
+	limiters struct {
+		query     utilsync.Limiter
+		process   utilsync.Limiter
+		transform utilsync.Limiter
+		store     utilsync.Limiter
+	}
+}
+
+func (m *mockWorkerHandle) validate(t *testing.T) {
+	m.statsMu.RLock()
+	defer m.statsMu.RUnlock()
+	for partition, s := range m.partitionStats {
+		require.Equalf(t, s.queried, s.marked, "Partition %s: Queried %d, Marked %d", partition, s.queried, s.marked)
+		require.Equalf(t, s.marked, s.processed, "Partition %s: Marked %d, Processed %d", partition, s.queried, s.marked)
+		require.Equalf(t, s.processed, s.transformed, "Partition %s: Processed %d, Transformed %d", partition, s.queried, s.marked)
+		require.Equalf(t, s.transformed, s.stored, "Partition %s: Transformed %d, Stored %d", partition, s.queried, s.marked)
+	}
+}
+
+func (m *mockWorkerHandle) logger() logger.Logger {
+	return m.log
+}
+
+func (m *mockWorkerHandle) config() workerHandleConfig {
+	return workerHandleConfig{
+		enablePipelining:      m.pipelining,
+		maxEventsToProcess:    m.loopEvents,
+		pipelineBufferedItems: 1,
+		subJobSize:            10,
+		readLoopSleep:         1 * time.Millisecond,
+		maxLoopSleep:          100 * time.Millisecond,
+	}
+}
+
+func (*mockWorkerHandle) rsourcesService() rsources.JobService {
+	return nil
+}
+
+func (m *mockWorkerHandle) handlePendingGatewayJobs(key string) bool {
+	jobs := m.getJobs(key)
+	if len(jobs.Jobs) > 0 {
+		_ = m.markExecuting(jobs.Jobs)
+	}
+	rsourcesStats := rsources.NewStatsCollector(m.rsourcesService())
+	for _, subJob := range m.jobSplitter(jobs.Jobs, rsourcesStats) {
+		m.Store(key,
+			m.transformations(key,
+				m.processJobsForDest(key, subJob, nil),
+			),
+		)
+	}
+	return len(jobs.Jobs) > 0
+}
+
+func (*mockWorkerHandle) stats() *processorStats {
+	return &processorStats{
+		DBReadThroughput: stats.Default.NewStat("db_read_throughput", stats.CountType),
+	}
+}
+
+func (m *mockWorkerHandle) getJobs(partition string) jobsdb.JobsResult {
+	if m.limiters.query != nil {
+		defer m.limiters.query.Begin(partition)()
+	}
+	m.statsMu.Lock()
+	defer m.statsMu.Unlock()
+	s := m.partitionStats[partition]
+	s.queried += m.loopEvents
+	m.partitionStats[partition] = s
+
+	m.log.Infof("getJobs partition: %s stats: %+v", partition, s)
+
+	var jobs []*jobsdb.JobT
+	for i := 0; i < m.loopEvents; i++ {
+		jobs = append(jobs, &jobsdb.JobT{
+			CustomVal: partition,
+		})
+	}
+	return jobsdb.JobsResult{
+		Jobs:        jobs,
+		EventsCount: m.loopEvents,
+	}
+}
+
+func (m *mockWorkerHandle) markExecuting(jobs []*jobsdb.JobT) error {
+	m.statsMu.Lock()
+	defer m.statsMu.Unlock()
+	partition := jobs[0].CustomVal
+	s := m.partitionStats[partition]
+	s.marked += len(jobs)
+	m.partitionStats[partition] = s
+	m.log.Infof("markExecuting partition: %s stats: %+v", partition, s)
+
+	return nil
+}
+
+func (*mockWorkerHandle) jobSplitter(jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []subJob {
+	return []subJob{
+		{
+			subJobs:       jobs,
+			hasMore:       false,
+			rsourcesStats: rsourcesStats,
+		},
+	}
+}
+
+func (m *mockWorkerHandle) processJobsForDest(partition string, subJobs subJob, _ [][]types.SingularEventT) *transformationMessage {
+	if m.limiters.process != nil {
+		defer m.limiters.process.Begin(partition)()
+	}
+	m.statsMu.Lock()
+	defer m.statsMu.Unlock()
+	s := m.partitionStats[partition]
+	s.processed += len(subJobs.subJobs)
+	m.partitionStats[partition] = s
+	m.log.Infof("processJobsForDest partition: %s stats: %+v", partition, s)
+
+	return &transformationMessage{
+		totalEvents: len(subJobs.subJobs),
+	}
+}
+
+func (m *mockWorkerHandle) transformations(partition string, in *transformationMessage) *storeMessage {
+	if m.limiters.transform != nil {
+		defer m.limiters.transform.Begin(partition)()
+	}
+	m.statsMu.Lock()
+	defer m.statsMu.Unlock()
+	s := m.partitionStats[partition]
+	s.transformed += in.totalEvents
+	m.partitionStats[partition] = s
+	m.log.Infof("transformations partition: %s stats: %+v", partition, s)
+
+	return &storeMessage{
+		totalEvents: in.totalEvents,
+	}
+}
+
+func (m *mockWorkerHandle) Store(partition string, in *storeMessage) {
+	if m.limiters.store != nil {
+		defer m.limiters.store.Begin(partition)()
+	}
+	m.statsMu.Lock()
+	defer m.statsMu.Unlock()
+	s := m.partitionStats[partition]
+	s.stored += in.totalEvents
+	m.partitionStats[partition] = s
+	m.log.Infof("Store partition: %s stats: %+v", partition, s)
+}

--- a/router/eventorder_test.go
+++ b/router/eventorder_test.go
@@ -104,7 +104,7 @@ func TestEventOrderGuarantee(t *testing.T) {
 			writeKey := trand.String(27)
 			workspaceID := trand.String(27)
 			destinationID := trand.String(27)
-			templateCtx := map[string]string{
+			templateCtx := map[string]any{
 				"webhookUrl":    webhook.Server.URL,
 				"writeKey":      writeKey,
 				"workspaceId":   workspaceID,

--- a/router/router_dest_isolation_test.go
+++ b/router/router_dest_isolation_test.go
@@ -87,7 +87,7 @@ func Test_RouterDestIsolation(t *testing.T) {
 	webhook2 := createNewWebhook(t, 200)
 	defer webhook2.webhook.Close()
 
-	templateCtx := map[string]string{
+	templateCtx := map[string]any{
 		"webhookUrl1": webhook1.webhook.URL,
 		"webhookUrl2": webhook2.webhook.URL,
 		"writeKey":    writeKey,

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestRunner(t *testing.T) {
 	config.Set("BackendConfig.configFromFile", true)
-	configJsonPath := workspaceConfig.CreateTempFile(t, "testdata/config.json", map[string]string{})
+	configJsonPath := workspaceConfig.CreateTempFile(t, "testdata/config.json", map[string]any{})
 	config.Set("BackendConfig.configJSONPath", configJsonPath)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/sql/migrations/jobsdb/000011_add_workspace_id_index.up.tmpl
+++ b/sql/migrations/jobsdb/000011_add_workspace_id_index.up.tmpl
@@ -1,0 +1,3 @@
+{{range .Datasets}}
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_{{$.Prefix}}_jobs_{{.}}_ws" ON "{{$.Prefix}}_jobs_{{.}}" (workspace_id);
+{{end}}

--- a/sql/migrations/jobsdb_always/000011_add_workspace_id_index.up.tmpl
+++ b/sql/migrations/jobsdb_always/000011_add_workspace_id_index.up.tmpl
@@ -1,0 +1,3 @@
+{{range .Datasets}}
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_{{$.Prefix}}_jobs_{{.}}_ws" ON "{{$.Prefix}}_jobs_{{.}}" (workspace_id);
+{{end}}

--- a/testhelper/destination/postgres.go
+++ b/testhelper/destination/postgres.go
@@ -25,12 +25,21 @@ type PostgresResource struct {
 	Port     string
 }
 
-func SetupPostgres(pool *dockertest.Pool, d cleaner) (*PostgresResource, error) {
+func SetupPostgres(pool *dockertest.Pool, d cleaner, opts ...string) (*PostgresResource, error) {
+	cmd := []string{"postgres"}
+	for _, opt := range opts {
+		cmd = append(cmd, "-c", opt)
+	}
 	// pulls an image, creates a container based on it and runs it
-	postgresContainer, err := pool.Run("postgres", "15-alpine", []string{
-		"POSTGRES_DB=" + postgresDefaultDB,
-		"POSTGRES_USER=" + postgresDefaultUser,
-		"POSTGRES_PASSWORD=" + postgresDefaultPassword,
+	postgresContainer, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: "postgres",
+		Tag:        "15-alpine",
+		Env: []string{
+			"POSTGRES_PASSWORD=" + postgresDefaultPassword,
+			"POSTGRES_DB=" + postgresDefaultDB,
+			"POSTGRES_USER=" + postgresDefaultUser,
+		},
+		Cmd: cmd,
 	})
 	if err != nil {
 		return nil, err

--- a/testhelper/health/checker.go
+++ b/testhelper/health/checker.go
@@ -10,7 +10,7 @@ import (
 )
 
 func WaitUntilReady(
-	ctx context.Context, t *testing.T, endpoint string, atMost, interval time.Duration, caller string,
+	ctx context.Context, t testing.TB, endpoint string, atMost, interval time.Duration, caller string,
 ) {
 	t.Helper()
 	probe := time.NewTicker(interval)

--- a/testhelper/workspaceConfig/workspaceConfig.go
+++ b/testhelper/workspaceConfig/workspaceConfig.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func CreateTempFile(t *testing.T, templatePath string, values map[string]string) string {
+func CreateTempFile(t testing.TB, templatePath string, values map[string]any) string {
 	t.Helper()
 	tpl, err := template.ParseFiles(templatePath)
 	require.NoError(t, err)

--- a/utils/misc/exponential.go
+++ b/utils/misc/exponential.go
@@ -1,0 +1,31 @@
+package misc
+
+import (
+	"golang.org/x/exp/constraints"
+)
+
+type Number interface {
+	constraints.Integer | constraints.Float
+}
+
+// ExponentialNumber is a simple exponentially increasing number.
+type ExponentialNumber[T Number] struct {
+	value T
+}
+
+// Reset resets the number to zero.
+func (expo *ExponentialNumber[T]) Reset() {
+	expo.value = 0
+}
+
+// Next returns the next number, which is the previous one multiplied by 2, always abiding by the min and max provided.
+func (expo *ExponentialNumber[T]) Next(min, max T) T {
+	expo.value *= 2
+	if expo.value > max {
+		expo.value = max
+	}
+	if expo.value < min {
+		expo.value = min
+	}
+	return expo.value
+}

--- a/utils/misc/exponential_test.go
+++ b/utils/misc/exponential_test.go
@@ -32,4 +32,15 @@ func TestExponentialNumber(t *testing.T) {
 		exp.Reset()
 		require.Equal(t, 1*time.Second, exp.Next(time.Second, 10*time.Second))
 	})
+
+	t.Run("exponential float", func(t *testing.T) {
+		var exp misc.ExponentialNumber[float64]
+		require.EqualValues(t, 0.9, exp.Next(0.9, 5))
+		require.EqualValues(t, 1.8, exp.Next(0.9, 5))
+		require.EqualValues(t, 3.6, exp.Next(0.9, 5))
+		require.EqualValues(t, 5, exp.Next(0.9, 5))
+		require.EqualValues(t, 5, exp.Next(0.9, 5))
+		exp.Reset()
+		require.EqualValues(t, 0.9, exp.Next(0.9, 5))
+	})
 }

--- a/utils/misc/exponential_test.go
+++ b/utils/misc/exponential_test.go
@@ -1,0 +1,35 @@
+package misc_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/utils/misc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExponentialNumber(t *testing.T) {
+	t.Run("exponential int", func(t *testing.T) {
+		var exp misc.ExponentialNumber[int]
+		require.Equal(t, 1, exp.Next(1, 10))
+		require.Equal(t, 2, exp.Next(1, 10))
+		require.Equal(t, 4, exp.Next(1, 10))
+		require.Equal(t, 8, exp.Next(1, 10))
+		require.Equal(t, 10, exp.Next(1, 10))
+		require.Equal(t, 10, exp.Next(1, 10))
+		exp.Reset()
+		require.Equal(t, 1, exp.Next(1, 10))
+	})
+
+	t.Run("exponential duration", func(t *testing.T) {
+		var exp misc.ExponentialNumber[time.Duration]
+		require.Equal(t, 1*time.Second, exp.Next(time.Second, 10*time.Second))
+		require.Equal(t, 2*time.Second, exp.Next(time.Second, 10*time.Second))
+		require.Equal(t, 4*time.Second, exp.Next(time.Second, 10*time.Second))
+		require.Equal(t, 8*time.Second, exp.Next(time.Second, 10*time.Second))
+		require.Equal(t, 10*time.Second, exp.Next(time.Second, 10*time.Second))
+		require.Equal(t, 10*time.Second, exp.Next(time.Second, 10*time.Second))
+		exp.Reset()
+		require.Equal(t, 1*time.Second, exp.Next(time.Second, 10*time.Second))
+	})
+}

--- a/utils/queue/priorityQueue.go
+++ b/utils/queue/priorityQueue.go
@@ -13,7 +13,8 @@ type Item[T any] struct {
 	index     int
 }
 
-// PriorityQueue ....
+// PriorityQueue provides a heap.Interface compatible priority queue for the Item type.
+// The actual Item.index in the queue is controlled by the Item.Priority and Item.timeStamp.
 type PriorityQueue[T any] []*Item[T]
 
 // Len: Size of the priority queue . Used to satisfy the heap interface...

--- a/utils/queue/priorityQueue.go
+++ b/utils/queue/priorityQueue.go
@@ -1,0 +1,84 @@
+package queue
+
+import (
+	"container/heap"
+	"time"
+)
+
+// Item stores the attributes which will be pushed to the priority queue..
+type Item[T any] struct {
+	Value     T
+	Priority  int
+	timeStamp int64
+	index     int
+}
+
+// PriorityQueue ....
+type PriorityQueue[T any] []*Item[T]
+
+// Len: Size of the priority queue . Used to satisfy the heap interface...
+func (pq PriorityQueue[T]) Len() int { return len(pq) }
+
+// Less is used to compare elements and store them in the proper order in
+// priority queue.
+func (pq PriorityQueue[T]) Less(i, j int) bool {
+	if pq[i].Priority == pq[j].Priority {
+		return pq[i].timeStamp <= pq[j].timeStamp
+	}
+	return pq[i].Priority > pq[j].Priority
+}
+
+// Swap is used to swap the values in the priority queue.
+func (pq PriorityQueue[T]) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+// Push adds elements to the priority queue
+func (pq *PriorityQueue[T]) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*Item[T])
+	item.index = n
+	item.timeStamp = makeTimestamp()
+	*pq = append(*pq, item)
+}
+
+// Pop removes elements from the priority queue
+func (pq *PriorityQueue[T]) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	if n == 0 {
+		return nil
+	}
+	item := old[n-1]
+	old[n-1] = nil
+	item.index = -1
+	*pq = old[0 : n-1]
+	return item
+}
+
+// Top returns the topmost element in the priority queue
+func (pq *PriorityQueue[T]) Top() interface{} {
+	if len(*pq) == 0 {
+		return nil
+	}
+	ol := *pq
+	return *ol[0]
+}
+
+// GetIndex returns the index of the corresponding element.
+func (pq *PriorityQueue[T]) GetIndex(x interface{}) int {
+	item := x.(*Item[T])
+	return item.index
+}
+
+// Update updates the attributes of an element in the priority queue.
+func (pq *PriorityQueue[T]) Update(item *Item[T], priority int) {
+	item.Priority = priority
+	heap.Fix(pq, item.index)
+}
+
+func makeTimestamp() int64 {
+	return time.Now().UnixNano() / int64(time.Millisecond)
+}

--- a/utils/queue/priorityQueue_test.go
+++ b/utils/queue/priorityQueue_test.go
@@ -1,0 +1,57 @@
+package queue
+
+import (
+	"container/heap"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPriorityQueue(t *testing.T) {
+	t.Run("different priorities", func(t *testing.T) {
+		pq := make(PriorityQueue[any], 0)
+		heap.Init(&pq)
+		for i := 0; i < 3; i++ {
+			item := &Item[any]{
+				Priority: i * 2,
+			}
+			heap.Push(&pq, item)
+		}
+		expectedVals := []int{4, 2, 0}
+		actualVals := make([]int, 0)
+		for len(pq) > 0 {
+			topEle := pq.Top().(Item[any])
+			_ = pq.GetIndex(&topEle)
+			_ = heap.Pop(&pq).(*Item[any])
+			actualVals = append(actualVals, topEle.Priority)
+		}
+		require.Equal(t, expectedVals, actualVals)
+	})
+
+	t.Run("same priorities", func(t *testing.T) {
+		pq := make(PriorityQueue[any], 3)
+
+		for i := 0; i < 3; i++ {
+			pq[i] = &Item[any]{
+				Priority:  1,
+				timeStamp: int64(i),
+			}
+		}
+
+		pq.Update(pq[2], 3)
+		expectedVals := []int64{2, 0, 1}
+		actualVals := make([]int64, 0)
+		for pq.Len() > 0 {
+			item := heap.Pop(&pq).(*Item[any])
+			actualVals = append(actualVals, item.timeStamp)
+		}
+		require.Equal(t, expectedVals, actualVals)
+	})
+
+	t.Run("nil operations", func(t *testing.T) {
+		var pq PriorityQueue[any]
+		require.Nil(t, pq.Top())
+		require.Nil(t, pq.Pop())
+		require.Equal(t, 0, pq.Len())
+	})
+}

--- a/utils/sync/limiter.go
+++ b/utils/sync/limiter.go
@@ -1,0 +1,192 @@
+package sync
+
+import (
+	"container/heap"
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/rruntime"
+	"github.com/rudderlabs/rudder-server/services/stats"
+	"github.com/rudderlabs/rudder-server/utils/queue"
+)
+
+// LimiterPriorityValue defines the priority values supported by Limiter.
+// Greater priority value means higher priority
+type LimiterPriorityValue int
+
+const (
+	_ LimiterPriorityValue = iota
+	// LimiterPriorityValueLow Priority....
+	LimiterPriorityValueLow
+	// LimiterPriorityValueMedium Priority....
+	LimiterPriorityValueMedium
+	// LimiterPriorityValueMediumHigh Priority....
+	LimiterPriorityValueMediumHigh
+	// LimiterPriorityValueHigh Priority.....
+	LimiterPriorityValueHigh
+)
+
+// Limiter limits the number of concurrent operations that can be performed
+type Limiter interface {
+	// Do executes the function f, but only if there are available slots.
+	// Otherwise blocks until a slot becomes available
+	Do(key string, f func())
+
+	// DoWithPriority executes the function f, but only if there are available slots.
+	// Otherwise blocks until a slot becomes available, respecting the priority
+	DoWithPriority(key string, priority LimiterPriorityValue, f func())
+
+	// Begin starts a new operation, blocking until a slot becomes available.
+	// Caller is expected to call the returned function to end the operation, otherwise
+	// the slot will be reserved indefinitely
+	Begin(key string) (end func())
+
+	// BeginWithPriority starts a new operation, blocking until a slot becomes available, respecting the priority.
+	// Caller is expected to call the returned function to end the operation, otherwise
+	// the slot will be reserved indefinitely
+	BeginWithPriority(key string, priority LimiterPriorityValue) (end func())
+}
+
+var WithLimiterStatsTriggerFunc = func(triggerFunc func() <-chan time.Time) func(*limiter) {
+	return func(l *limiter) {
+		l.stats.triggerFunc = triggerFunc
+	}
+}
+
+var WithLimiterDynamicPeriod = func(dynamicPeriod time.Duration) func(*limiter) {
+	return func(l *limiter) {
+		l.dynamicPeriod = dynamicPeriod
+	}
+}
+
+// NewLimiter creates a new limiter
+func NewLimiter(ctx context.Context, wg *sync.WaitGroup, name string, limit int, statsf stats.Stats, opts ...func(*limiter)) Limiter {
+	l := &limiter{
+		name:     name,
+		limit:    limit,
+		waitList: make(queue.PriorityQueue[chan struct{}], 0),
+	}
+	heap.Init(&l.waitList)
+	l.stats.triggerFunc = func() <-chan time.Time {
+		return time.After(15 * time.Second)
+	}
+	l.stats.stat = statsf
+	l.stats.waitGauge = statsf.NewStat(name+"_limiter_waiting_routines", stats.GaugeType)
+	l.stats.activeGauge = statsf.NewStat(name+"_limiter_active_routines", stats.GaugeType)
+	l.stats.availabilityGauge = statsf.NewStat(name+"_limiter_availability", stats.GaugeType)
+
+	for _, opt := range opts {
+		opt(l)
+	}
+	wg.Add(1)
+	rruntime.Go(func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-l.stats.triggerFunc():
+			}
+			l.mu.Lock()
+			l.stats.activeGauge.Gauge(l.count)
+			l.stats.waitGauge.Gauge(len(l.waitList))
+			availability := float64(l.limit-l.count) / float64(l.limit)
+			l.stats.availabilityGauge.Gauge(availability)
+			l.mu.Unlock()
+		}
+	})
+	return l
+}
+
+type limiter struct {
+	name          string
+	limit         int
+	count         int
+	mu            sync.Mutex
+	waitList      queue.PriorityQueue[chan struct{}]
+	dynamicPeriod time.Duration
+	stats         struct {
+		triggerFunc       func() <-chan time.Time
+		stat              stats.Stats
+		waitGauge         stats.Measurement // gauge showing number of operations waiting in the queue
+		activeGauge       stats.Measurement // gauge showing active number of operations
+		availabilityGauge stats.Measurement // gauge showing availability percentage of limiter (0.0 to 1.0)
+	}
+}
+
+func (l *limiter) Do(key string, f func()) {
+	l.DoWithPriority(key, LimiterPriorityValueLow, f)
+}
+
+func (l *limiter) DoWithPriority(key string, priority LimiterPriorityValue, f func()) {
+	defer l.BeginWithPriority(key, priority)()
+	f()
+}
+
+func (l *limiter) Begin(key string) (end func()) {
+	return l.BeginWithPriority(key, LimiterPriorityValueLow)
+}
+
+func (l *limiter) BeginWithPriority(key string, priority LimiterPriorityValue) (end func()) {
+	start := time.Now()
+	l.wait(priority)
+	l.stats.stat.NewTaggedStat(l.name+"_limiter_waiting", stats.TimerType, stats.Tags{"key": key}).Since(start)
+	start = time.Now()
+	end = func() {
+		defer l.stats.stat.NewTaggedStat(l.name+"_limiter_working", stats.TimerType, stats.Tags{"key": key}).Since(start)
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		l.count--
+		if len(l.waitList) == 0 {
+			return
+		}
+		next := heap.Pop(&l.waitList).(*queue.Item[chan struct{}])
+		next.Value <- struct{}{}
+		l.count++
+		close(next.Value)
+	}
+	return end
+}
+
+// wait until a slot becomes available
+func (l *limiter) wait(priority LimiterPriorityValue) {
+	l.mu.Lock()
+	if l.count < l.limit {
+		l.count++
+		l.mu.Unlock()
+		return
+	}
+	w := &queue.Item[chan struct{}]{
+		Priority: int(priority),
+		Value:    make(chan struct{}),
+	}
+	heap.Push(&l.waitList, w)
+	l.mu.Unlock()
+
+	// no dynamic priority
+	if l.dynamicPeriod == 0 || priority == LimiterPriorityValueHigh {
+		<-w.Value
+		return
+	}
+
+	// dynamic priority (increment priority every dynamicPeriod)
+	ticker := time.NewTicker(l.dynamicPeriod)
+	for {
+		select {
+		case <-w.Value:
+			ticker.Stop()
+			return
+		case <-ticker.C:
+			if w.Priority < int(LimiterPriorityValueHigh) {
+				l.mu.Lock()
+				l.waitList.Update(w, w.Priority+1)
+				l.mu.Unlock()
+			} else {
+				ticker.Stop()
+				<-w.Value
+				return
+			}
+		}
+	}
+}

--- a/utils/sync/limiter.go
+++ b/utils/sync/limiter.go
@@ -172,6 +172,7 @@ func (l *limiter) wait(priority LimiterPriorityValue) {
 
 	// dynamic priority (increment priority every dynamicPeriod)
 	ticker := time.NewTicker(l.dynamicPeriod)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-w.Value:

--- a/utils/sync/limiter_test.go
+++ b/utils/sync/limiter_test.go
@@ -1,0 +1,152 @@
+package sync_test
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/services/stats/memstats"
+	miscsync "github.com/rudderlabs/rudder-server/utils/sync"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimiter(t *testing.T) {
+	t.Run("without priority", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+		ms := memstats.New()
+
+		statsTriggerCh := make(chan time.Time)
+		triggerFn := func() <-chan time.Time {
+			return statsTriggerCh
+		}
+
+		limiter := miscsync.NewLimiter(ctx, &wg, "test", 1, ms, miscsync.WithLimiterStatsTriggerFunc(triggerFn))
+		var counter int
+		statsTriggerCh <- time.Now()
+		statsTriggerCh <- time.Now()
+
+		require.NotNil(t, ms.Get("test_limiter_active_routines", nil))
+		require.EqualValues(t, 0, ms.Get("test_limiter_active_routines", nil).LastValue(), "shouldn't have any active")
+
+		require.NotNil(t, ms.Get("test_limiter_availability", nil))
+		require.EqualValues(t, 1, ms.Get("test_limiter_availability", nil).LastValue(), "should be available")
+
+		require.Nil(t, ms.Get("test_limiter_working", nil))
+
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			key := strconv.Itoa(i)
+			go func() {
+				limiter.Do(key, func() {
+					counter++ // since the limiter's limit is 1, we shouldn't need an atomic counter
+					wg.Done()
+				})
+			}()
+		}
+
+		cancel()
+		wg.Wait()
+
+		require.EqualValues(t, 100, counter, "counter should be 100")
+
+		select {
+		case statsTriggerCh <- time.Now():
+			require.Fail(t, "shouldn't be listening to triggerCh anymore")
+		default:
+		}
+		for i := 0; i < 100; i++ {
+			m := ms.Get("test_limiter_working", map[string]string{"key": strconv.Itoa(i)})
+			require.NotNil(t, m)
+			require.Lenf(t, m.Durations(), 1, "should have recorded 1 timer duration for key %d", i)
+		}
+	})
+
+	t.Run("with priority", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+		ms := memstats.New()
+
+		limiter := miscsync.NewLimiter(ctx, &wg, "test", 1, ms)
+		var counterLow int
+		var counterHigh int
+		sleepTime := 100 * time.Microsecond
+		for i := 0; i < 1000; i++ {
+			wg.Add(1)
+			key := strconv.Itoa(i)
+			go func() {
+				limiter.DoWithPriority(key, miscsync.LimiterPriorityValueHigh, func() {
+					time.Sleep(sleepTime)
+					counterHigh++ // since the limiter's limit is 1, we shouldn't need an atomic counter
+					require.Equal(t, 0, counterLow, "counterLow should be 0")
+					wg.Done()
+				})
+			}()
+		}
+
+		time.Sleep(10 * sleepTime)
+		for i := 0; i < 1000; i++ {
+			wg.Add(1)
+			key := strconv.Itoa(i)
+			go func() {
+				limiter.DoWithPriority(key, miscsync.LimiterPriorityValueLow, func() {
+					counterLow++ // since the limiter's limit is 1, we shouldn't need an atomic counter
+					wg.Done()
+				})
+			}()
+		}
+
+		cancel()
+		wg.Wait()
+
+		require.EqualValues(t, 1000, counterHigh, "high priority counter should be 1000")
+		require.EqualValues(t, 1000, counterLow, "low priority counter should be 1000")
+	})
+
+	t.Run("with dynamic priority", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+		ms := memstats.New()
+
+		sleepTime := 1 * time.Millisecond
+		limiter := miscsync.NewLimiter(ctx, &wg, "test", 1, ms, miscsync.WithLimiterDynamicPeriod(sleepTime/100))
+		var counterLow int
+		var counterHigh int
+
+		var dynamicPriorityVerified bool
+		for i := 0; i < 1000; i++ {
+			wg.Add(1)
+			key := strconv.Itoa(i)
+			go func() {
+				limiter.DoWithPriority(key, miscsync.LimiterPriorityValueHigh, func() {
+					time.Sleep(sleepTime)
+					counterHigh++ // since the limiter's limit is 1, we shouldn't need an atomic counter
+					if counterLow > 0 {
+						dynamicPriorityVerified = true
+					}
+					wg.Done()
+				})
+			}()
+		}
+
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			key := strconv.Itoa(i)
+			go func() {
+				limiter.DoWithPriority(key, miscsync.LimiterPriorityValueLow, func() {
+					counterLow++ // since the limiter's limit is 1, we shouldn't need an atomic counter
+					wg.Done()
+				})
+			}()
+		}
+
+		cancel()
+		wg.Wait()
+
+		require.True(t, dynamicPriorityVerified, "dynamic priority should have been verified")
+		require.EqualValues(t, 1000, counterHigh, "high priority counter should be 1000")
+		require.EqualValues(t, 10, counterLow, "low priority counter should be 10")
+	})
+}


### PR DESCRIPTION
# Description

Introducing support for workspace isolation in the processor module.

## Design Doc
[Link](https://www.notion.so/rudderstacks/Design-Proposal-Processor-Isolation-2db79f6c5b0f4a9fb14465b62aaaf54a)

![Untitled](https://user-images.githubusercontent.com/2481587/215871876-1ac51093-c2df-4f60-ae84-e1692d2f67f2.png)


## New Components

### `utils` package
- `misc.ExponentialNumber` is used by processor to  sleep for exponentially increasing durations while no jobs are being picked up.
- `queue.PriorityQueue` implements a priority queue pretty close to the standard one [here](https://pkg.go.dev/container/heap#example-package-PriorityQueue).
- `sync.Limiter` provides a concurrency limiter which supports dynamic priorities (i.e. priority increases periodically as time goes by for avoiding starvation of lower priority routines) and captures useful statistics. It is inspired by [vivek-ng/concurrency-limiter](https://github.com/vivek-ng/concurrency-limiter).

### `processor` package
- `isolation.Strategy` provides both the interface and the 2 different isolation strategy implementations. This shall be the only extension point for introducing additional isolation strategies in the future.
- `processor.worker`  implements the processor worker as described in the design doc.
- `processor.workerPool` implements the worker pool as described in the design doc.
- `processor.workerHandle` is the interface that abstracts `processor.Handle` implementation from the worker by including only the required methods.
- `processor.Handle#Start` starts the pinger loop as described in the design doc.

## Workspace Priorities

By default, all workspace have the same (low) priority with respect to their chance of getting picked up by the various concurrency limiters (get jobs, preprocess, transform, store) when there is a waiting queue. It is possible though to treat a workspace with higher priority, by setting the `Processor.Limiter.<WorkspaceID>.Priority` configuration property to a value between 2-4:
- 1: low priority
- 2: medium priority
- 3: medium/high priority
- 4: high priority

To make sure that low-priority workspaces will not be starved, every second, their priority will be increasing by 1 until it reaches to 4.

## Testing & Benchmarks

To ease testing of multi-workspace deployments (a.k.a multi-tenant) without the need for a properly seeded etcd server, support has been added for forcing the use of a static `ModeProvider` through the `forceStaticModeProvider` config property.

Workspace isolation overall behaviour and performance testing is performed in `processor_isolation_test.go`.  In comparison to the "no isolation" mode, workspace isolation:
- Performs **equally well** with up to **200 active** workspaces. 
- With **500 active** workspaces it is **18% slower**.
- With **1000 active** workspaces it is **30% slower**. 
- With **10000 active** workspaces it is **150% slower**.

To provide some perspective, in our current production workloads, the average number of active workspaces is not greater than 50 & the same number for destinations is between100-150.

A visualisation dashboard which demonstrates both the new statistics that are being captured, as well as the server's performance during the benchmarks can be found [here](https://snapshots.raintank.io/dashboard/snapshot/9643HY7OqrsYae1HuAjAz167953NOCN3).

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=1bd87345dc654c26ab2fb9e92d98f7df&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
