### PR TITLE
chore: handling wrapped temporary errors for Kafka destinations

### DIFF
--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -612,6 +612,22 @@ func TestIsProducerErrTemporary(t *testing.T) {
 	pubCancel()
 }
 
+func TestIsProducerWrappedErrTemporary(t *testing.T) {
+	err := kafka.WriteErrors{
+		fmt.Errorf("some error: %w", kafka.LeaderNotAvailable),
+		fmt.Errorf("some error: %w", kafka.RequestTimedOut),
+		fmt.Errorf("some error: %w", kafka.OffsetOutOfRange),
+		fmt.Errorf("some error: %w", kafka.Unknown),
+	}
+	require.True(t, IsProducerErrTemporary(err))
+
+	wrappedErr := fmt.Errorf("could not publish to %q: %w", "some topic", err)
+	require.True(t, IsProducerErrTemporary(wrappedErr))
+
+	wrappedErr = fmt.Errorf("wrapping again: %w", wrappedErr)
+	require.True(t, IsProducerErrTemporary(wrappedErr))
+}
+
 func TestWriteErrors(t *testing.T) {
 	err := make(kafka.WriteErrors, 0)
 	err = append(err, kafka.PolicyViolation)

--- a/services/streammanager/kafka/client/logger.go
+++ b/services/streammanager/kafka/client/logger.go
@@ -1,0 +1,19 @@
+package client
+
+type logger interface {
+	Infof(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+}
+
+type KafkaLogger struct {
+	Logger        logger
+	IsErrorLogger bool
+}
+
+func (l *KafkaLogger) Printf(format string, args ...interface{}) {
+	if l.IsErrorLogger {
+		l.Logger.Errorf(format, args...)
+	} else {
+		l.Logger.Infof(format, args...)
+	}
+}

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -143,6 +143,7 @@ func (p *ProducerManager) getCodecs() map[string]*goavro.Codec {
 type logger interface {
 	Error(args ...interface{})
 	Errorf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
 }
 
 type managerStats struct {
@@ -315,6 +316,8 @@ func NewProducer(destination *backendconfig.DestinationT, o common.Opts) (*Produ
 	p, err := c.NewProducer(client.ProducerConfig{
 		ReadTimeout:  kafkaReadTimeout,
 		WriteTimeout: kafkaWriteTimeout,
+		Logger:       &client.KafkaLogger{Logger: pkgLogger},
+		ErrorLogger:  &client.KafkaLogger{Logger: pkgLogger, IsErrorLogger: true},
 	})
 	if err != nil {
 		return nil, err
@@ -366,6 +369,8 @@ func NewProducerForAzureEventHubs(destination *backendconfig.DestinationT, o com
 	p, err := c.NewProducer(client.ProducerConfig{
 		ReadTimeout:  kafkaReadTimeout,
 		WriteTimeout: kafkaWriteTimeout,
+		Logger:       &client.KafkaLogger{Logger: pkgLogger},
+		ErrorLogger:  &client.KafkaLogger{Logger: pkgLogger, IsErrorLogger: true},
 	})
 	if err != nil {
 		return nil, err
@@ -418,6 +423,8 @@ func NewProducerForConfluentCloud(destination *backendconfig.DestinationT, o com
 	p, err := c.NewProducer(client.ProducerConfig{
 		ReadTimeout:  kafkaReadTimeout,
 		WriteTimeout: kafkaWriteTimeout,
+		Logger:       &client.KafkaLogger{Logger: pkgLogger},
+		ErrorLogger:  &client.KafkaLogger{Logger: pkgLogger, IsErrorLogger: true},
 	})
 	if err != nil {
 		return nil, err
@@ -628,7 +635,6 @@ func sendMessage(ctx context.Context, jsonData json.RawMessage, p producerManage
 	if err = publish(ctx, p, message); err != nil {
 		return makeErrorResponse(fmt.Errorf("could not publish to %q: %w", topic, err))
 	}
-
 	returnMessage := fmt.Sprintf("Message delivered to topic: %s", topic)
 	return 200, returnMessage, returnMessage
 }

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 var (
-	overrideArm64Check bool
-	sinceDuration      = time.Second
+	sinceDuration = time.Second
 )
 
 func TestMain(m *testing.M) {
@@ -38,9 +37,6 @@ func TestMain(m *testing.M) {
 		return sinceDuration
 	}
 
-	if os.Getenv("OVERRIDE_ARM64_CHECK") == "1" {
-		overrideArm64Check = true
-	}
 	pkgLogger = &nopLogger{}
 	os.Exit(m.Run())
 }
@@ -884,6 +880,7 @@ func (p *pMockErr) Publish(_ context.Context, msgs ...client.Message) error {
 type nopLogger struct{}
 
 func (*nopLogger) Error(...interface{})          {}
+func (*nopLogger) Infof(string, ...interface{})  {}
 func (*nopLogger) Errorf(string, ...interface{}) {}
 
 type testCleanup struct{ *testing.T }

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -21,9 +21,7 @@ import (
 	"github.com/rudderlabs/rudder-server/testhelper/destination"
 )
 
-var (
-	sinceDuration = time.Second
-)
+var sinceDuration = time.Second
 
 func TestMain(m *testing.M) {
 	kafkaStats = managerStats{}


### PR DESCRIPTION
# Description

When `WriteErrors` from the Segment Kafka library are wrapped they don't result as temporary anymore. This PR aims to fix this issue.

## Notion Ticket

< [Notion Link](https://www.notion.so/rudderstacks/Handling-wrapped-temporary-errors-for-Kafka-destinations-0959d007cbc64dcc82baaf02ec187007) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
