### PR TITLE
chore: handling wrapped temporary errors for Kafka destinations

### DIFF
--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -612,6 +612,22 @@ func TestIsProducerErrTemporary(t *testing.T) {
 	pubCancel()
 }
 
+func TestIsProducerWrappedErrTemporary(t *testing.T) {
+	err := kafka.WriteErrors{
+		fmt.Errorf("some error: %w", kafka.LeaderNotAvailable),
+		fmt.Errorf("some error: %w", kafka.RequestTimedOut),
+		fmt.Errorf("some error: %w", kafka.OffsetOutOfRange),
+		fmt.Errorf("some error: %w", kafka.Unknown),
+	}
+	require.True(t, IsProducerErrTemporary(err))
+
+	wrappedErr := fmt.Errorf("could not publish to %q: %w", "some topic", err)
+	require.True(t, IsProducerErrTemporary(wrappedErr))
+
+	wrappedErr = fmt.Errorf("wrapping again: %w", wrappedErr)
+	require.True(t, IsProducerErrTemporary(wrappedErr))
+}
+
 func TestWriteErrors(t *testing.T) {
 	err := make(kafka.WriteErrors, 0)
 	err = append(err, kafka.PolicyViolation)

--- a/services/streammanager/kafka/client/logger.go
+++ b/services/streammanager/kafka/client/logger.go
@@ -1,0 +1,19 @@
+package client
+
+type logger interface {
+	Infof(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+}
+
+type KafkaLogger struct {
+	Logger        logger
+	IsErrorLogger bool
+}
+
+func (l *KafkaLogger) Printf(format string, args ...interface{}) {
+	if l.IsErrorLogger {
+		l.Logger.Errorf(format, args...)
+	} else {
+		l.Logger.Infof(format, args...)
+	}
+}

--- a/services/streammanager/kafka/client/producer.go
+++ b/services/streammanager/kafka/client/producer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"syscall"
 	"time"
 
@@ -152,9 +153,8 @@ func isErrTemporary(err error) bool {
 	if errors.As(err, &tempError) {
 		return tempError.Temporary()
 	}
-	var timeoutError interface{ Timeout() bool }
-	if errors.As(err, &timeoutError) {
-		return timeoutError.Timeout()
+	if os.IsTimeout(err) {
+		return true
 	}
 	return false
 }

--- a/services/streammanager/kafka/client/producer.go
+++ b/services/streammanager/kafka/client/producer.go
@@ -139,9 +139,6 @@ func headers(msg Message) (headers []kafka.Header) {
 }
 
 func isErrTemporary(err error) bool {
-	if errors.Is(err, context.DeadlineExceeded) {
-		return true
-	}
 	isTransientNetworkError := errors.Is(err, io.ErrUnexpectedEOF) ||
 		errors.Is(err, syscall.ECONNREFUSED) ||
 		errors.Is(err, syscall.ECONNRESET) ||

--- a/services/streammanager/kafka/client/producer.go
+++ b/services/streammanager/kafka/client/producer.go
@@ -173,9 +173,8 @@ func IsProducerErrTemporary(err error) bool {
 		}
 		return isErrTemporary(err)
 	}
-	var isUnwrappedErrorTemporary bool
 	if ue := errors.Unwrap(err); ue != nil {
-		isUnwrappedErrorTemporary = IsProducerErrTemporary(ue)
+		return f(err) || IsProducerErrTemporary(ue)
 	}
-	return f(err) || isUnwrappedErrorTemporary
+	return f(err)
 }

--- a/services/streammanager/kafka/client/producer.go
+++ b/services/streammanager/kafka/client/producer.go
@@ -138,11 +138,13 @@ func headers(msg Message) (headers []kafka.Header) {
 }
 
 func isErrTemporary(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
 	isTransientNetworkError := errors.Is(err, io.ErrUnexpectedEOF) ||
 		errors.Is(err, syscall.ECONNREFUSED) ||
 		errors.Is(err, syscall.ECONNRESET) ||
-		errors.Is(err, syscall.EPIPE) ||
-		errors.Is(err, context.DeadlineExceeded)
+		errors.Is(err, syscall.EPIPE)
 	if isTransientNetworkError {
 		return true
 	}

--- a/services/streammanager/kafka/client/producer.go
+++ b/services/streammanager/kafka/client/producer.go
@@ -160,9 +160,6 @@ func isErrTemporary(err error) bool {
 }
 
 func IsProducerErrTemporary(err error) bool {
-	if err == nil {
-		return false
-	}
 	var we kafka.WriteErrors
 	if errors.As(err, &we) {
 		for _, err := range we {

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -143,6 +143,7 @@ func (p *ProducerManager) getCodecs() map[string]*goavro.Codec {
 type logger interface {
 	Error(args ...interface{})
 	Errorf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
 }
 
 type managerStats struct {
@@ -315,6 +316,8 @@ func NewProducer(destination *backendconfig.DestinationT, o common.Opts) (*Produ
 	p, err := c.NewProducer(client.ProducerConfig{
 		ReadTimeout:  kafkaReadTimeout,
 		WriteTimeout: kafkaWriteTimeout,
+		Logger:       &client.KafkaLogger{Logger: pkgLogger},
+		ErrorLogger:  &client.KafkaLogger{Logger: pkgLogger, IsErrorLogger: true},
 	})
 	if err != nil {
 		return nil, err
@@ -366,6 +369,8 @@ func NewProducerForAzureEventHubs(destination *backendconfig.DestinationT, o com
 	p, err := c.NewProducer(client.ProducerConfig{
 		ReadTimeout:  kafkaReadTimeout,
 		WriteTimeout: kafkaWriteTimeout,
+		Logger:       &client.KafkaLogger{Logger: pkgLogger},
+		ErrorLogger:  &client.KafkaLogger{Logger: pkgLogger, IsErrorLogger: true},
 	})
 	if err != nil {
 		return nil, err
@@ -418,6 +423,8 @@ func NewProducerForConfluentCloud(destination *backendconfig.DestinationT, o com
 	p, err := c.NewProducer(client.ProducerConfig{
 		ReadTimeout:  kafkaReadTimeout,
 		WriteTimeout: kafkaWriteTimeout,
+		Logger:       &client.KafkaLogger{Logger: pkgLogger},
+		ErrorLogger:  &client.KafkaLogger{Logger: pkgLogger, IsErrorLogger: true},
 	})
 	if err != nil {
 		return nil, err

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -21,10 +21,7 @@ import (
 	"github.com/rudderlabs/rudder-server/testhelper/destination"
 )
 
-var (
-	overrideArm64Check bool
-	sinceDuration      = time.Second
-)
+var sinceDuration = time.Second
 
 func TestMain(m *testing.M) {
 	kafkaStats = managerStats{}
@@ -38,9 +35,6 @@ func TestMain(m *testing.M) {
 		return sinceDuration
 	}
 
-	if os.Getenv("OVERRIDE_ARM64_CHECK") == "1" {
-		overrideArm64Check = true
-	}
 	pkgLogger = &nopLogger{}
 	os.Exit(m.Run())
 }
@@ -884,6 +878,7 @@ func (p *pMockErr) Publish(_ context.Context, msgs ...client.Message) error {
 type nopLogger struct{}
 
 func (*nopLogger) Error(...interface{})          {}
+func (*nopLogger) Infof(string, ...interface{})  {}
 func (*nopLogger) Errorf(string, ...interface{}) {}
 
 type testCleanup struct{ *testing.T }


### PR DESCRIPTION
# Description

When `WriteErrors` from the Segment Kafka library are wrapped they don't result as temporary anymore. This PR aims to fix this issue.

## Notion Ticket

< [Notion Link](https://www.notion.so/rudderstacks/Handling-wrapped-temporary-errors-for-Kafka-destinations-0959d007cbc64dcc82baaf02ec187007) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
