### PR TITLE
chore(jobsdb): support query filter by workspaceID

### DIFF
--- a/enterprise/replay/replay.go
+++ b/enterprise/replay/replay.go
@@ -61,7 +61,13 @@ func (handle *Handler) generatorLoop(ctx context.Context) {
 
 		if len(combinedList) == 0 {
 			if breakLoop {
-				executingList, err := handle.db.GetExecuting(context.TODO(), jobsdb.GetQueryParamsT{CustomValFilters: []string{"replay"}, JobsLimit: handle.dbReadSize})
+				executingList, err := handle.db.GetExecuting(
+					context.TODO(),
+					jobsdb.GetQueryParamsT{
+						CustomValFilters: []string{"replay"},
+						JobsLimit:        handle.dbReadSize,
+					},
+				)
 				if err != nil {
 					handle.log.Errorf("Error getting executing jobs: %v", err)
 					panic(err)


### PR DESCRIPTION
# Description

Jobsdb queries to support filtering by `workspace_id`.

## Notion Ticket

[jobsdb adaptations for workspace isolation](https://www.notion.so/rudderstacks/Processor-isolation-jobsdb-adaptations-86a6151e51dd469fa32e674c2b33dfe1)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
