### PR TITLE
fix: add workspace id in wh  async jobs table

### DIFF
--- a/sql/migrations/warehouse/000019_add_wh_async_jobs_workspace_id.up.sql
+++ b/sql/migrations/warehouse/000019_add_wh_async_jobs_workspace_id.up.sql
@@ -1,0 +1,6 @@
+
+--
+-- wh_async_jobs
+--
+
+ALTER TABLE wh_async_jobs ADD COLUMN IF NOT EXISTS workspace_id VARCHAR NOT NULL DEFAULT '';

--- a/warehouse/jobs/handlers.go
+++ b/warehouse/jobs/handlers.go
@@ -28,7 +28,11 @@ func (a *AsyncJobWhT) AddWarehouseJobHandler(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "can't read body", http.StatusBadRequest)
 		return
 	}
-	defer r.Body.Close()
+	err = r.Body.Close()
+	if err != nil {
+		a.logger.Errorf("[WH-Jobs]: Error reading body: %v", err)
+		http.Error(w, "can't read body", http.StatusBadRequest)
+	}
 	var startJobPayload StartJobReqPayload
 	err = json.Unmarshal(body, &startJobPayload)
 	if err != nil {
@@ -79,6 +83,7 @@ func (a *AsyncJobWhT) AddWarehouseJobHandler(w http.ResponseWriter, r *http.Requ
 			TableName:     th,
 			AsyncJobType:  startJobPayload.AsyncJobType,
 			MetaData:      metadataJson,
+			WorkspaceID:   startJobPayload.WorkspaceID,
 		}
 		id, err := a.addJobsToDB(a.context, &payload)
 		if err != nil {
@@ -108,11 +113,13 @@ func (a *AsyncJobWhT) StatusWarehouseJobHandler(w http.ResponseWriter, r *http.R
 
 		sourceId := r.URL.Query().Get("source_id")
 		destinationId := r.URL.Query().Get("destination_id")
+		workspaceId := r.URL.Query().Get("workspace_id")
 		payload := StartJobReqPayload{
 			TaskRunID:     taskRunId,
 			JobRunID:      jobRunId,
 			SourceID:      sourceId,
 			DestinationID: destinationId,
+			WorkspaceID:   workspaceId,
 		}
 		if !validatePayload(payload) {
 

--- a/warehouse/jobs/runner.go
+++ b/warehouse/jobs/runner.go
@@ -45,7 +45,19 @@ func (a *AsyncJobWhT) getTableNamesBy(sourceID, destinationID, jobRunID, taskRun
 	a.logger.Infof("[WH-Jobs]: Extracting table names for the job run id %s", jobRunID)
 	var tableNames []string
 	var err error
-	query := fmt.Sprintf(`SELECT id from %s where metadata->>'%s'=$1 and metadata->>'%s'=$2 and metadata in (SELECT metadata FROM wh_uploads where source_id=$3 and destination_id=$4)`, warehouseutils.WarehouseUploadsTable, "source_job_run_id", "source_task_run_id")
+	query := `SELECT id 
+		FROM 
+		` + warehouseutils.WarehouseUploadsTable + `
+		WHERE metadata->>'source_job_run_id'=$1 
+			AND metadata->>'source_task_run_id'=$2 
+			AND metadata in (
+				SELECT 
+					metadata 
+				FROM 
+				` + warehouseutils.WarehouseUploadsTable + ` 
+				WHERE source_id=$3 
+				AND destination_id=$4
+			)`
 	a.logger.Debugf("[WH-Jobs]: Query is %s\n", query)
 	rows, err := a.dbHandle.Query(query, jobRunID, taskRunID, sourceID, destinationID)
 	if err != nil {
@@ -90,8 +102,13 @@ func (a *AsyncJobWhT) addJobsToDB(ctx context.Context, payload *AsyncJobPayloadT
 	}
 	a.logger.Infof("[WH-Jobs]: Adding job to the wh_async_jobs %s for tableName: %s", payload.MetaData, payload.TableName)
 
-	sqlStatement := fmt.Sprintf(`INSERT INTO %s (source_id, destination_id, tablename, status, created_at, updated_at, async_job_type, metadata)
-	VALUES ($1, $2, $3, $4, $5, $6 ,$7, $8 ) RETURNING id`, warehouseutils.WarehouseAsyncJobTable)
+	sqlStatement := `INSERT INTO ` + warehouseutils.WarehouseAsyncJobTable + ` (
+		source_id, destination_id, tablename, 
+		status, created_at, updated_at, async_job_type, 
+		workspace_id, metadata
+	)
+	VALUES 
+		($1, $2, $3, $4, $5, $6 ,$7, $8, $9 ) RETURNING id`
 
 	stmt, err := a.dbHandle.Prepare(sqlStatement)
 	if err != nil {
@@ -102,7 +119,7 @@ func (a *AsyncJobWhT) addJobsToDB(ctx context.Context, payload *AsyncJobPayloadT
 
 	defer stmt.Close()
 	now := timeutil.Now()
-	row := stmt.QueryRow(payload.SourceID, payload.DestinationID, payload.TableName, WhJobWaiting, now, now, payload.AsyncJobType, payload.MetaData)
+	row := stmt.QueryRow(payload.SourceID, payload.DestinationID, payload.TableName, WhJobWaiting, now, now, payload.AsyncJobType, payload.WorkspaceID, payload.MetaData)
 	err = row.Scan(&jobId)
 	if err != nil {
 		a.logger.Errorf("[WH-Jobs]: Error processing the %s, %s ", sqlStatement, err.Error())
@@ -202,7 +219,7 @@ func (a *AsyncJobWhT) startAsyncJobRunner(ctx context.Context) error {
 				Jobs:    notifierClaims,
 				JobType: AsyncJobType,
 			}
-			schema := warehouseutils.SchemaT{}
+			var schema warehouseutils.SchemaT
 			ch, err := a.pgnotifier.Publish(messagePayload, &schema, 100)
 			if err != nil {
 				a.logger.Errorf("[WH-Jobs]: unable to get publish async jobs to pgnotifier. Task failed with error %s", err.Error())

--- a/warehouse/jobs/types.go
+++ b/warehouse/jobs/types.go
@@ -20,6 +20,7 @@ type StartJobReqPayload struct {
 	JobRunID      string `json:"job_run_id"`
 	TaskRunID     string `json:"task_run_id"`
 	AsyncJobType  string `json:"async_job_type"`
+	WorkspaceID   string `json:"workspace_id"`
 }
 
 type AsyncJobWhT struct {
@@ -50,6 +51,7 @@ type AsyncJobPayloadT struct {
 	DestinationID string          `json:"destination_id"`
 	TableName     string          `json:"tablename"`
 	AsyncJobType  string          `json:"async_job_type"`
+	WorkspaceID   string          `json:"workspace_id"`
 	MetaData      json.RawMessage `json:"metadata"`
 }
 

--- a/warehouse/jobs/utils_test.go
+++ b/warehouse/jobs/utils_test.go
@@ -22,6 +22,7 @@ func TestValidatePayload(t *testing.T) {
 				TaskRunID:     "bbc",
 				SourceID:      "cbc",
 				DestinationID: "dbc",
+				WorkspaceID:   "ebc",
 			},
 			true,
 		},

--- a/warehouse/testhelper/events.go
+++ b/warehouse/testhelper/events.go
@@ -46,7 +46,8 @@ const (
 		"channel":"sources",
 		"async_job_type":"deletebyjobrunid",
 		"destination_id":"%s",
-		"start_time":"%s"
+		"start_time":"%s",
+		"workspace_id":"%s"
 	}`
 	IdentifyPayload = `{
 	  "userId": "%s",

--- a/warehouse/testhelper/setup.go
+++ b/warehouse/testhelper/setup.go
@@ -487,6 +487,7 @@ func verifyAsyncJob(t testing.TB, wareHouseTest *WareHouseTest) {
 	t.Helper()
 	t.Logf("Started verifying async job")
 
+	workspaceID := "BpLnfgDsc2WD8F2qNfHK5a84jjJ"
 	asyncPayload := strings.NewReader(
 		fmt.Sprintf(
 			AsyncWhPayload,
@@ -495,6 +496,7 @@ func verifyAsyncJob(t testing.TB, wareHouseTest *WareHouseTest) {
 			wareHouseTest.TaskRunID,
 			wareHouseTest.DestinationID,
 			time.Now().UTC().Format("2006-01-02 15:04:05"),
+			workspaceID,
 		),
 	)
 	t.Logf("Run async job for sourceID: %s, DestinationID: %s, jobRunID: %s, taskRunID: %s",
@@ -507,11 +509,12 @@ func verifyAsyncJob(t testing.TB, wareHouseTest *WareHouseTest) {
 	send(t, asyncPayload, "warehouse/jobs", wareHouseTest.WriteKey, "POST")
 
 	var (
-		path = fmt.Sprintf("warehouse/jobs/status?job_run_id=%s&task_run_id=%s&source_id=%s&destination_id=%s",
+		path = fmt.Sprintf("warehouse/jobs/status?job_run_id=%s&task_run_id=%s&source_id=%s&destination_id=%s&workspace_id=%s",
 			wareHouseTest.JobRunID,
 			wareHouseTest.TaskRunID,
 			wareHouseTest.SourceID,
 			wareHouseTest.DestinationID,
+			workspaceID,
 		)
 		url        = fmt.Sprintf("http://localhost:%s/v1/%s", "8080", path)
 		method     = "GET"


### PR DESCRIPTION
# Description

We need to add the workspace id in the WH async jobs table for supporting multitenant deployment. 
Sources will provide the workspace when registering a new job through the API.

## Notion Ticket

[ticket](https://www.notion.so/rudderstacks/Support-wh-multi-tenant-for-wh-async-jobs-api-4c8172eb09bc4b6c9eec2efcc93d4a53)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
