### PR TITLE
fix: limit entire transformationStatus struct when caching them

### DIFF
--- a/services/debugger/destination/eventDeliveryStatusUploader.go
+++ b/services/debugger/destination/eventDeliveryStatusUploader.go
@@ -63,7 +63,7 @@ func NewHandle(backendConfig backendconfig.BackendConfig, opts ...Opt) (Destinat
 		log:              logger.NewLogger().Child("debugger").Child("destination"),
 	}
 	var err error
-	url := fmt.Sprintf("%s/dataplane/v2/eventUploads", h.configBackendURL)
+	url := fmt.Sprintf("%s/dataplane/v2/eventDeliveryStatus", h.configBackendURL)
 	eventUploader := NewEventDeliveryStatusUploader(h.log)
 	h.uploader = debugger.New[*DeliveryStatusT](url, eventUploader)
 	h.uploader.Start()


### PR DESCRIPTION
# Description

update cache with only the `messageID`s of events that are put into the cache.
Done to avoid an issue scene recently where successful events were being displayed as `dropped` in live events.
[context](https://rudderlabs.slack.com/archives/C018SGKA998/p1674657597947759)

## Notion Ticket

[notion ticket](https://www.notion.so/rudderstacks/live-events-cache-messageIDs-fix-ebdcb3068a354861a68ded5186d82033)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
