### PR TITLE
fix(warehouse): warehouse successful upload exists

### DIFF
--- a/warehouse/tracker.go
+++ b/warehouse/tracker.go
@@ -156,7 +156,7 @@ func (wh *HandleT) Track(ctx context.Context, warehouse *warehouseutils.Warehous
 	}
 
 	if !exists {
-		wh.Logger.Warn("pending staging files not picked",
+		wh.Logger.Errorw("pending staging files not picked",
 			warehouseutils.SourceID, source.ID,
 			warehouseutils.DestinationID, destination.ID,
 			warehouseutils.WorkspaceID, warehouse.WorkspaceID,

--- a/warehouse/tracker.go
+++ b/warehouse/tracker.go
@@ -53,7 +53,6 @@ func (wh *HandleT) Track(ctx context.Context, warehouse *warehouseutils.Warehous
 		queryArgs         []interface{}
 		createdAt         sql.NullTime
 		exists            bool
-		uploaded          int
 		syncFrequency     = "1440"
 		Now               = timeutil.Now
 		NowSQL            = "NOW()"
@@ -156,20 +155,21 @@ func (wh *HandleT) Track(ctx context.Context, warehouse *warehouseutils.Warehous
 		return fmt.Errorf("fetching last upload status for source: %s and destination: %s: %w", source.ID, destination.ID, err)
 	}
 
-	if exists {
-		uploaded = 1
+	if !exists {
+		wh.Logger.Info("upload is not picked for source: ", source.ID, " and destination: ", destination.ID)
 	}
 
 	tags := stats.Tags{
 		"workspaceId": warehouse.WorkspaceID,
 		"module":      moduleName,
 		"destType":    wh.destType,
+		"ok":          strconv.FormatBool(exists),
 		"warehouseID": misc.GetTagName(
 			destination.ID,
 			source.Name,
 			destination.Name,
 			misc.TailTruncateStr(source.ID, 6)),
 	}
-	wh.stats.NewTaggedStat("warehouse_successful_upload_exists", stats.CountType, tags).Count(uploaded)
+	wh.stats.NewTaggedStat("warehouse_successful_upload_exists", stats.GaugeType, tags).Gauge(1)
 	return nil
 }

--- a/warehouse/tracker.go
+++ b/warehouse/tracker.go
@@ -156,9 +156,11 @@ func (wh *HandleT) Track(ctx context.Context, warehouse *warehouseutils.Warehous
 	}
 
 	if !exists {
-		wh.Logger.Errorw("pending staging files not picked",
+		wh.Logger.Warnw("pending staging files not picked",
 			warehouseutils.SourceID, source.ID,
+			warehouseutils.SourceType, source.SourceDefinition.Name,
 			warehouseutils.DestinationID, destination.ID,
+			warehouseutils.DestinationType, destination.DestinationDefinition.Name,
 			warehouseutils.WorkspaceID, warehouse.WorkspaceID,
 		)
 	}

--- a/warehouse/tracker.go
+++ b/warehouse/tracker.go
@@ -156,7 +156,7 @@ func (wh *HandleT) Track(ctx context.Context, warehouse *warehouseutils.Warehous
 	}
 
 	if !exists {
-		wh.Logger.Warn("upload is not picked for ",
+		wh.Logger.Warn("pending staging files not picked",
 			warehouseutils.SourceID, source.ID,
 			warehouseutils.DestinationID, destination.ID,
 			warehouseutils.WorkspaceID, warehouse.WorkspaceID,

--- a/warehouse/tracker.go
+++ b/warehouse/tracker.go
@@ -159,9 +159,8 @@ func (wh *HandleT) Track(ctx context.Context, warehouse *warehouseutils.Warehous
 		wh.Logger.Warn("upload is not picked for ",
 			warehouseutils.SourceID, source.ID,
 			warehouseutils.DestinationID, destination.ID,
-			warehouseutils.DestinationID, warehouse.WorkspaceID,
+			warehouseutils.WorkspaceID, warehouse.WorkspaceID,
 		)
-		wh.Logger.Info("upload is not picked for source: ", source.ID, " and destination: ", destination.ID)
 	}
 
 	tags := stats.Tags{

--- a/warehouse/tracker.go
+++ b/warehouse/tracker.go
@@ -156,6 +156,11 @@ func (wh *HandleT) Track(ctx context.Context, warehouse *warehouseutils.Warehous
 	}
 
 	if !exists {
+		wh.Logger.Warn("upload is not picked for ",
+			warehouseutils.SourceID, source.ID,
+			warehouseutils.DestinationID, destination.ID,
+			warehouseutils.DestinationID, warehouse.WorkspaceID,
+		)
 		wh.Logger.Info("upload is not picked for source: ", source.ID, " and destination: ", destination.ID)
 	}
 

--- a/warehouse/tracker_test.go
+++ b/warehouse/tracker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -36,9 +37,9 @@ func TestHandleT_Track(t *testing.T) {
 		name             string
 		destID           string
 		destDisabled     bool
-		uploaded         int
 		wantErr          error
 		wantStats        bool
+		ok               bool
 		NowSQL           string
 		exclusionWindow  map[string]any
 		uploadBufferTime string
@@ -56,13 +57,13 @@ func TestHandleT_Track(t *testing.T) {
 			name:      "successful upload exists",
 			destID:    destID,
 			wantStats: true,
-			uploaded:  1,
+			ok:        true,
 		},
 		{
 			name:             "successful upload exists with upload buffer time",
 			destID:           destID,
 			wantStats:        true,
-			uploaded:         1,
+			ok:               true,
 			uploadBufferTime: "0m",
 		},
 		{
@@ -169,6 +170,7 @@ func TestHandleT_Track(t *testing.T) {
 				"module":      moduleName,
 				"workspaceId": warehouse.WorkspaceID,
 				"destType":    handle.destType,
+				"ok":          strconv.FormatBool(tc.ok),
 				"warehouseID": misc.GetTagName(
 					warehouse.Destination.ID,
 					warehouse.Source.Name,
@@ -177,7 +179,7 @@ func TestHandleT_Track(t *testing.T) {
 			})
 
 			if tc.wantStats {
-				require.EqualValues(t, m.LastValue(), tc.uploaded)
+				require.EqualValues(t, m.LastValue(), 1)
 			} else {
 				require.Nil(t, m)
 			}

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -37,9 +37,11 @@ import (
 )
 
 const (
-	SourceID      = "sourceID"
-	DestinationID = "destinationID"
-	WorkspaceID   = "workspaceID"
+	SourceID        = "sourceID"
+	SourceType      = "sourceType"
+	DestinationID   = "destinationID"
+	DestinationType = "destinationType"
+	WorkspaceID     = "workspaceID"
 )
 
 const (

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -37,6 +37,12 @@ import (
 )
 
 const (
+	SourceID      = "sourceID"
+	DestinationID = "destinationID"
+	WorkspaceID   = "workspaceID"
+)
+
+const (
 	RS             = "RS"
 	BQ             = "BQ"
 	SNOWFLAKE      = "SNOWFLAKE"


### PR DESCRIPTION
# Description

- Use gauge instead of the counter
- Instead of reporting 0 or 1, we are going to report always 1 and use a flag ok=true/false to capture the problematic uploads.
- We are going to log every time a problem is detected


## Notion Ticket

https://www.notion.so/rudderstacks/Make-the-alert-for-stuck-wh-pipelines-warehouse-successful-upload-exist-as-P0-d69f679ee0d04907ae0ed76b7a482ac7

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
