### PR TITLE
fix: runtime error: slice bounds out of range [:-1]

### DIFF
--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+
 	gwstats "github.com/rudderlabs/rudder-server/gateway/internal/stats"
 	"github.com/rudderlabs/rudder-server/gateway/response"
 	"github.com/rudderlabs/rudder-server/services/stats"
@@ -309,7 +310,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 		var webRequests []*webhookT
 		for _, req := range breq.batchRequest {
 			body, err := io.ReadAll(req.request.Body)
-			req.request.Body.Close()
+			_ = req.request.Body.Close()
 
 			if err != nil {
 				req.done <- transformerResponse{Err: response.GetStatus(response.RequestBodyReadFailed)}
@@ -325,6 +326,10 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 				}
 
 				closingBraceIdx := bytes.LastIndexByte(body, '}')
+				if closingBraceIdx == -1 {
+					req.done <- transformerResponse{Err: response.GetStatus(response.InvalidJSON)}
+					continue
+				}
 				appendData := []byte(`, "query_parameters": `)
 				appendData = append(appendData, paramsBytes...)
 				body = append(body[:closingBraceIdx], appendData...)
@@ -405,7 +410,7 @@ func (webhook *HandleT) enqueueInGateway(req *webhookT, payload []byte) string {
 	// set write key in basic auth header
 	req.request.SetBasicAuth(req.writeKey, "")
 	payload, err := io.ReadAll(req.request.Body)
-	req.request.Body.Close()
+	_ = req.request.Body.Close()
 	if err != nil {
 		return err.Error()
 	}
@@ -436,7 +441,7 @@ func (webhook *HandleT) Shutdown() error {
 	}
 	webhook.batchRequestsWg.Wait()
 	close(webhook.batchRequestQ)
-	webhook.requestQ = make(map[string](chan *webhookT))
+	webhook.requestQ = make(map[string]chan *webhookT)
 
 	return webhook.backgroundWait()
 }


### PR DESCRIPTION
# Description

Fixing the following error:
> runtime error: slice bounds out of range [:-1] 

### Stack trace

```
BugsnagNotify.func1.1 in /rudder-server/utils/misc/misc.go 1207
(*Once).doSlow in sync/once.go 74
BugsnagNotify.func1 in /rudder-server/utils/misc/misc.go 1196
gopanic in runtime/panic.go 884
goPanicSliceAcap in runtime/panic.go 139
(*batchWebhookTransformerT).batchTransformLoop in /rudder-server/gateway/webhook/webhook.go 330
Setup.func1 in /rudder-server/gateway/webhook/setup.go 67
WithBugsnag.func1 in /rudder-server/utils/misc/misc.go 1217
(*Group).Go.func1 in /go/pkg/mod/golang.org/x/sync@v0.1.0/errgroup/errgroup.go 75
```

[Squadcast incident](https://app.squadcast.com/incident/63dbc5176511482a359539c6)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
