### PR TITLE
fix: suppression syncer using wrong credentials in multi-tenant mode

### DIFF
--- a/enterprise/suppress-user/syncer.go
+++ b/enterprise/suppress-user/syncer.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-	"github.com/rudderlabs/rudder-server/config"
 	"github.com/rudderlabs/rudder-server/enterprise/suppress-user/model"
 	"github.com/rudderlabs/rudder-server/services/controlplane/identity"
 	"github.com/rudderlabs/rudder-server/utils/httputil"
@@ -75,6 +74,7 @@ func NewSyncer(baseURL string, identifier identity.Identifier, r Repository, opt
 
 	s := &Syncer{
 		url:                url,
+		id:                 identifier,
 		r:                  r,
 		log:                logger.NOP,
 		client:             &http.Client{},
@@ -91,6 +91,7 @@ func NewSyncer(baseURL string, identifier identity.Identifier, r Repository, opt
 // Syncer is responsible for syncing suppressions from the backend to the repository
 type Syncer struct {
 	url string
+	id  identity.Identifier
 	r   Repository
 
 	client             *http.Client
@@ -168,8 +169,7 @@ func (s *Syncer) sync(token []byte) ([]model.Suppression, []byte, error) {
 		if err != nil {
 			return err
 		}
-		workspaceToken := config.GetWorkspaceToken()
-		req.SetBasicAuth(workspaceToken, "")
+		req.SetBasicAuth(s.id.BasicAuth())
 		req.Header.Set("Content-Type", "application/json")
 
 		resp, err = s.client.Do(req)


### PR DESCRIPTION
# Description

Using the appropriate credentials depending on the deployment mode

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=82e8f8920320483d8c8c4d02f9bdda51&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
