### PR TITLE
fix(warehouse): use single protocol source category while doing dedup for new record

### DIFF
--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -56,7 +56,8 @@ const (
 )
 
 const (
-	CloudSourceCateogry = "cloud"
+	CloudSourceCategory          = "cloud"
+	SingerProtocolSourceCategory = "singer-protocol"
 )
 
 var stateTransitions map[string]*uploadStateT
@@ -2260,7 +2261,8 @@ func (job *UploadJobT) GetSingleLoadFile(tableName string) (warehouseutils.LoadF
 }
 
 func (job *UploadJobT) ShouldOnDedupUseNewRecord() bool {
-	return job.upload.SourceCategory == CloudSourceCateogry
+	category := job.upload.SourceCategory
+	return category == SingerProtocolSourceCategory || category == CloudSourceCategory
 }
 
 func (job *UploadJobT) UseRudderStorage() bool {


### PR DESCRIPTION
# Description

use single protocol source category while doing dedup for new record

## Notion Ticket

https://www.notion.so/rudderstacks/d8ea6e5cd7b2481db207d6b239676688?v=799e76e4eabd45b3ad80c87fdebdb765&p=df40e0715c0f4a12addeb849174d9e36&pm=c

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
