### PR TITLE
chore(warehouse): use warn while getting total count in warehouse

### DIFF
--- a/warehouse/logfield/logfield.go
+++ b/warehouse/logfield/logfield.go
@@ -1,0 +1,11 @@
+package logfield
+
+const (
+	SourceID        = "sourceID"
+	SourceType      = "sourceType"
+	DestinationID   = "destinationID"
+	DestinationType = "destinationType"
+	WorkspaceID     = "workspaceID"
+	Error           = "error"
+	TableName       = "tableName"
+)

--- a/warehouse/tracker.go
+++ b/warehouse/tracker.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/warehouse/logfield"
+
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 
 	"github.com/rudderlabs/rudder-server/config"
@@ -157,11 +159,11 @@ func (wh *HandleT) Track(ctx context.Context, warehouse *warehouseutils.Warehous
 
 	if !exists {
 		wh.Logger.Warnw("pending staging files not picked",
-			warehouseutils.SourceID, source.ID,
-			warehouseutils.SourceType, source.SourceDefinition.Name,
-			warehouseutils.DestinationID, destination.ID,
-			warehouseutils.DestinationType, destination.DestinationDefinition.Name,
-			warehouseutils.WorkspaceID, warehouse.WorkspaceID,
+			logfield.SourceID, source.ID,
+			logfield.SourceType, source.SourceDefinition.Name,
+			logfield.DestinationID, destination.ID,
+			logfield.DestinationType, destination.DestinationDefinition.Name,
+			logfield.WorkspaceID, warehouse.WorkspaceID,
 		)
 	}
 

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/warehouse/logfield"
+
 	"github.com/rudderlabs/rudder-server/services/alerta"
 
 	schemarepository "github.com/rudderlabs/rudder-server/warehouse/integrations/datalake/schema-repository"
@@ -1097,12 +1099,12 @@ func (job *UploadJobT) loadTable(tName string) (alteredSchema bool, err error) {
 		totalBeforeLoad, errTotalCount = job.getTotalCount(tName)
 		if errTotalCount != nil {
 			pkgLogger.Warnw("total count in table before loading",
-				warehouseutils.SourceID, job.upload.SourceID,
-				warehouseutils.DestinationID, job.upload.DestinationID,
-				warehouseutils.DestinationType, job.upload.DestinationType,
-				warehouseutils.WorkspaceID, job.upload.WorkspaceID,
-				warehouseutils.ERROR, errTotalCount,
-				warehouseutils.TABLE_NAME, tName,
+				logfield.SourceID, job.upload.SourceID,
+				logfield.DestinationID, job.upload.DestinationID,
+				logfield.DestinationType, job.upload.DestinationType,
+				logfield.WorkspaceID, job.upload.WorkspaceID,
+				logfield.Error, errTotalCount,
+				logfield.TableName, tName,
 			)
 		}
 	}
@@ -1121,12 +1123,12 @@ func (job *UploadJobT) loadTable(tName string) (alteredSchema bool, err error) {
 		totalAfterLoad, errTotalCount = job.getTotalCount(tName)
 		if errTotalCount != nil {
 			pkgLogger.Warnw("total count in table after loading",
-				warehouseutils.SourceID, job.upload.SourceID,
-				warehouseutils.DestinationID, job.upload.DestinationID,
-				warehouseutils.DestinationType, job.upload.DestinationType,
-				warehouseutils.WorkspaceID, job.upload.WorkspaceID,
-				warehouseutils.ERROR, errTotalCount,
-				warehouseutils.TABLE_NAME, tName,
+				logfield.SourceID, job.upload.SourceID,
+				logfield.DestinationID, job.upload.DestinationID,
+				logfield.DestinationType, job.upload.DestinationType,
+				logfield.WorkspaceID, job.upload.WorkspaceID,
+				logfield.Error, errTotalCount,
+				logfield.TableName, tName,
 			)
 			return
 		}

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -1096,11 +1096,13 @@ func (job *UploadJobT) loadTable(tName string) (alteredSchema bool, err error) {
 		var errTotalCount error
 		totalBeforeLoad, errTotalCount = job.getTotalCount(tName)
 		if errTotalCount != nil {
-			pkgLogger.Warnw(fmt.Sprintf("total count in table: %s before loading with err: %s", tName, errTotalCount),
+			pkgLogger.Warnw("total count in table before loading",
 				warehouseutils.SourceID, job.upload.SourceID,
 				warehouseutils.DestinationID, job.upload.DestinationID,
 				warehouseutils.DestinationType, job.upload.DestinationType,
 				warehouseutils.WorkspaceID, job.upload.WorkspaceID,
+				warehouseutils.ERROR, errTotalCount,
+				warehouseutils.TABLE_NAME, tName,
 			)
 		}
 	}
@@ -1118,11 +1120,13 @@ func (job *UploadJobT) loadTable(tName string) (alteredSchema bool, err error) {
 		var errTotalCount error
 		totalAfterLoad, errTotalCount = job.getTotalCount(tName)
 		if errTotalCount != nil {
-			pkgLogger.Warnw(fmt.Sprintf("total count in table: %s after loading with err: %s", tName, errTotalCount),
+			pkgLogger.Warnw("total count in table after loading",
 				warehouseutils.SourceID, job.upload.SourceID,
 				warehouseutils.DestinationID, job.upload.DestinationID,
 				warehouseutils.DestinationType, job.upload.DestinationType,
 				warehouseutils.WorkspaceID, job.upload.WorkspaceID,
+				warehouseutils.ERROR, errTotalCount,
+				warehouseutils.TABLE_NAME, tName,
 			)
 			return
 		}

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -42,6 +42,8 @@ const (
 	DestinationID   = "destinationID"
 	DestinationType = "destinationType"
 	WorkspaceID     = "workspaceID"
+	ERROR           = "error"
+	TABLE_NAME      = "tableName"
 )
 
 const (

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -37,16 +37,6 @@ import (
 )
 
 const (
-	SourceID        = "sourceID"
-	SourceType      = "sourceType"
-	DestinationID   = "destinationID"
-	DestinationType = "destinationType"
-	WorkspaceID     = "workspaceID"
-	ERROR           = "error"
-	TABLE_NAME      = "tableName"
-)
-
-const (
 	RS             = "RS"
 	BQ             = "BQ"
 	SNOWFLAKE      = "SNOWFLAKE"

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -37,6 +37,10 @@ import (
 )
 
 const (
+	DestinationType = "destinationType"
+)
+
+const (
 	RS             = "RS"
 	BQ             = "BQ"
 	SNOWFLAKE      = "SNOWFLAKE"


### PR DESCRIPTION
# Description

**Log Improvement**: Make total count error to Warning instead of Error

## Notion Ticket
 
https://www.notion.so/rudderstacks/Make-total-count-in-table-as-Warning-instead-of-Error-277b88c979ae41bbaed0ff63d202e37b

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
