### PR TITLE
chore: protect measurement & tag names from empty strings

### DIFF
--- a/services/stats/measurement.go
+++ b/services/stats/measurement.go
@@ -2,8 +2,11 @@ package stats
 
 import (
 	"fmt"
+	"runtime"
+	"strings"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/utils/logger"
 	"gopkg.in/alexcesaro/statsd.v2"
 )
 
@@ -191,7 +194,14 @@ func (h *statsdHistogram) Observe(value float64) {
 }
 
 // newStatsdMeasurement creates a new measurement of the specific type
-func newStatsdMeasurement(conf *statsdConfig, name, statType string, client *statsdClient) Measurement {
+func newStatsdMeasurement(conf *statsdConfig, log logger.Logger, name, statType string, client *statsdClient) Measurement {
+	if strings.Trim(name, " ") == "" {
+		byteArr := make([]byte, 2048)
+		n := runtime.Stack(byteArr, false)
+		stackTrace := string(byteArr[:n])
+		log.Warnf("detected missing stat measurement name, using 'novalue':\n%v", stackTrace)
+		name = "novalue"
+	}
 	baseMeasurement := &statsdMeasurement{
 		conf:     conf,
 		name:     name,

--- a/services/stats/stats_test.go
+++ b/services/stats/stats_test.go
@@ -214,6 +214,22 @@ func Test_Measurement_Operations(t *testing.T) {
 			return false
 		}, 2*time.Second, time.Millisecond)
 	})
+
+	t.Run("measurement with empty name", func(t *testing.T) {
+		s.NewStat("", stats.CountType).Increment()
+
+		require.Eventually(t, func() bool {
+			return lastReceived == "novalue,instanceName=test:1|c"
+		}, 2*time.Second, time.Millisecond)
+	})
+
+	t.Run("measurement with empty name and empty tag key", func(t *testing.T) {
+		s.NewTaggedStat(" ", stats.GaugeType, stats.Tags{"key": "value", "": "value2"}).Gauge(22)
+
+		require.Eventually(t, func() bool {
+			return lastReceived == "novalue,instanceName=test,key=value:22|g"
+		}, 2*time.Second, time.Millisecond)
+	})
 }
 
 func Test_Periodic_stats(t *testing.T) {


### PR DESCRIPTION
# Description

Protecting `stats` package from invalid measurements:

1. If the measurement's name is empty, a warning will be logged and the measurement's name will be set to `novalue`.
2. If an empty tag key is found, a warning will be logged and the empty tag will be removed from the measurment's set of tags.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=698b01a23d824197bf154fccee6143ce&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
