### PR TITLE
fix: upload missing metric

### DIFF
--- a/warehouse/tracker.go
+++ b/warehouse/tracker.go
@@ -69,6 +69,19 @@ func (wh *HandleT) Track(ctx context.Context, warehouse *warehouseutils.Warehous
 		Now = wh.Now
 	}
 
+	tags := stats.Tags{
+		"workspaceId": warehouse.WorkspaceID,
+		"module":      moduleName,
+		"destType":    wh.destType,
+		"warehouseID": misc.GetTagName(
+			destination.ID,
+			source.Name,
+			destination.Name,
+			misc.TailTruncateStr(source.ID, 6)),
+	}
+	statKey := "warehouse_track_upload_missing"
+	wh.stats.NewTaggedStat(statKey, stats.GaugeType, tags).Gauge(0)
+
 	if !source.Enabled || !destination.Enabled {
 		return nil
 	}
@@ -163,19 +176,8 @@ func (wh *HandleT) Track(ctx context.Context, warehouse *warehouseutils.Warehous
 			warehouseutils.DestinationType, destination.DestinationDefinition.Name,
 			warehouseutils.WorkspaceID, warehouse.WorkspaceID,
 		)
+		wh.stats.NewTaggedStat(statKey, stats.GaugeType, tags).Gauge(1)
 	}
 
-	tags := stats.Tags{
-		"workspaceId": warehouse.WorkspaceID,
-		"module":      moduleName,
-		"destType":    wh.destType,
-		"ok":          strconv.FormatBool(exists),
-		"warehouseID": misc.GetTagName(
-			destination.ID,
-			source.Name,
-			destination.Name,
-			misc.TailTruncateStr(source.ID, 6)),
-	}
-	wh.stats.NewTaggedStat("warehouse_successful_upload_exists", stats.GaugeType, tags).Gauge(1)
 	return nil
 }


### PR DESCRIPTION
# Description

* Resetting the gauge before tracking logic runs. Since the gauge will stick to the last value otherwise.
* Value will always be set in every run, either as 0 or 1.
* A new name is used to better reassemble what we want to measure/check.

## Notion Ticket

< Replace with Notion Link >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
