### PR TITLE
feat: adaptive payload size limits

### DIFF
--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rudderlabs/rudder-server/router/throttler"
 	"github.com/rudderlabs/rudder-server/utils/httputil"
 	"github.com/rudderlabs/rudder-server/utils/logger"
+	"github.com/rudderlabs/rudder-server/utils/payload"
 	"github.com/rudderlabs/rudder-server/utils/types/deployment"
 	"github.com/rudderlabs/rudder-server/utils/types/servermode"
 
@@ -217,7 +218,24 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 		return fmt.Errorf("unsupported deployment type: %q", deploymentType)
 	}
 
-	p := proc.New(ctx, &options.ClearDB, gwDBForProcessor, routerDB, batchRouterDB, errDB, multitenantStats, reportingI, transientSources, fileUploaderProvider, rsourcesService, destinationHandle, transformationhandle)
+	adaptiveLimit := payload.SetupAdaptiveLimiter(ctx, g)
+
+	p := proc.New(
+		ctx,
+		&options.ClearDB,
+		gwDBForProcessor,
+		routerDB,
+		batchRouterDB,
+		errDB,
+		multitenantStats,
+		reportingI,
+		transientSources,
+		fileUploaderProvider,
+		rsourcesService,
+		destinationHandle,
+		transformationhandle,
+		proc.WithAdaptiveLimit(adaptiveLimit),
+	)
 	throttlerFactory, err := throttler.New(stats.Default)
 	if err != nil {
 		return fmt.Errorf("failed to create throttler factory: %w", err)
@@ -232,6 +250,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 		RsourcesService:  rsourcesService,
 		ThrottlerFactory: throttlerFactory,
 		Debugger:         destinationHandle,
+		AdaptiveLimit:    adaptiveLimit,
 	}
 	brtFactory := &batchrouter.Factory{
 		Reporting:        reportingI,
@@ -242,6 +261,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 		TransientSources: transientSources,
 		RsourcesService:  rsourcesService,
 		Debugger:         destinationHandle,
+		AdaptiveLimit:    adaptiveLimit,
 	}
 	rt := routerManager.New(rtFactory, brtFactory, backendconfig.DefaultBackendConfig)
 

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -85,7 +85,7 @@ func WithFeaturesRetryMaxAttempts(maxAttempts int) func(l *LifecycleManager) {
 func New(ctx context.Context, clearDb *bool, gwDb, rtDb, brtDb, errDb *jobsdb.HandleT,
 	tenantDB multitenant.MultiTenantI, reporting types.ReportingI, transientSources transientsource.Service, fileuploader fileuploader.Provider,
 	rsourcesService rsources.JobService, destDebugger destinationdebugger.DestinationDebugger, transDebugger transformationdebugger.TransformationDebugger,
-	opts ...func(l *LifecycleManager),
+	opts ...Opts,
 ) *LifecycleManager {
 	proc := &LifecycleManager{
 		Handle:           NewHandle(transformer.NewTransformer()),
@@ -108,4 +108,12 @@ func New(ctx context.Context, clearDb *bool, gwDb, rtDb, brtDb, errDb *jobsdb.Ha
 		opt(proc)
 	}
 	return proc
+}
+
+type Opts func(l *LifecycleManager)
+
+func WithAdaptiveLimit(adaptiveLimitFunction func(int64) int64) Opts {
+	return func(l *LifecycleManager) {
+		l.Handle.adaptiveLimit = adaptiveLimitFunction
+	}
 }

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -132,6 +132,8 @@ type HandleT struct {
 	jobsDBCommandTimeout      time.Duration
 	jobdDBQueryRequestTimeout time.Duration
 	jobdDBMaxRetries          int
+
+	adaptiveLimit func(int64) int64
 }
 
 type BatchDestinationDataT struct {
@@ -326,7 +328,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 								CustomValFilters: []string{brt.destType},
 								JobsLimit:        1,
 								ParameterFilters: parameterFilters,
-								PayloadSizeLimit: brt.payloadLimit,
+								PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit),
 							},
 						)
 					}, sendQueryRetryStats)
@@ -380,7 +382,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 											CustomValFilters: []string{brt.destType},
 											JobsLimit:        brt.maxEventsInABatch,
 											ParameterFilters: parameterFilters,
-											PayloadSizeLimit: brt.payloadLimit,
+											PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit),
 										},
 									)
 								}, sendQueryRetryStats)
@@ -532,7 +534,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 											CustomValFilters: []string{brt.destType},
 											JobsLimit:        brt.maxEventsInABatch,
 											ParameterFilters: parameterFilters,
-											PayloadSizeLimit: brt.payloadLimit,
+											PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit),
 										},
 									)
 								}, sendQueryRetryStats)
@@ -1618,7 +1620,7 @@ func (worker *workerT) workerProcess() {
 					JobsLimit:                     toQuery,
 					ParameterFilters:              parameterFilters,
 					IgnoreCustomValFiltersInQuery: true,
-					PayloadSizeLimit:              brt.payloadLimit,
+					PayloadSizeLimit:              brt.adaptiveLimit(brt.payloadLimit),
 				}
 
 				toRetry, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
@@ -1969,7 +1971,7 @@ func (brt *HandleT) readAndProcess() {
 			queryParams := jobsdb.GetQueryParamsT{
 				CustomValFilters: []string{brt.destType},
 				JobsLimit:        brt.jobQueryBatchSize,
-				PayloadSizeLimit: brt.payloadLimit,
+				PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit),
 			}
 			toRetry, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
 				return brt.jobsDB.GetToRetry(ctx, queryParams)
@@ -2138,7 +2140,7 @@ func (brt *HandleT) holdFetchingJobs(parameterFilters []jobsdb.ParameterFilterT)
 					CustomValFilters: []string{brt.destType},
 					JobsLimit:        1,
 					ParameterFilters: parameterFilters,
-					PayloadSizeLimit: brt.payloadLimit,
+					PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit),
 				},
 			)
 		}, sendQueryRetryStats)
@@ -2267,7 +2269,17 @@ func Init() {
 }
 
 // Setup initializes this module
-func (brt *HandleT) Setup(backendConfig backendconfig.BackendConfig, jobsDB, errorDB jobsdb.JobsDB, destType string, reporting types.ReportingI, multitenantStat multitenant.MultiTenantI, transientSources transientsource.Service, rsourcesService rsources.JobService, debugger destinationdebugger.DestinationDebugger) {
+func (brt *HandleT) Setup(
+	backendConfig backendconfig.BackendConfig,
+	jobsDB,
+	errorDB jobsdb.JobsDB,
+	destType string,
+	reporting types.ReportingI,
+	multitenantStat multitenant.MultiTenantI,
+	transientSources transientsource.Service,
+	rsourcesService rsources.JobService,
+	debugger destinationdebugger.DestinationDebugger,
+) {
 	brt.isBackendConfigInitialized = false
 	brt.backendConfigInitialized = make(chan bool)
 	brt.fileManagerFactory = filemanager.DefaultFileManagerFactory
@@ -2371,6 +2383,10 @@ func (brt *HandleT) Setup(backendConfig backendconfig.BackendConfig, jobsDB, err
 		brt.asyncUploadWorker(ctx)
 		return nil
 	}))
+
+	if brt.adaptiveLimit == nil {
+		brt.adaptiveLimit = func(limit int64) int64 { return limit }
+	}
 
 	rruntime.Go(func() {
 		brt.backendConfigSubscriber()

--- a/router/batchrouter/factory.go
+++ b/router/batchrouter/factory.go
@@ -19,11 +19,24 @@ type Factory struct {
 	TransientSources transientsource.Service
 	RsourcesService  rsources.JobService
 	Debugger         destinationdebugger.DestinationDebugger
+	AdaptiveLimit    func(int64) int64
 }
 
 func (f *Factory) New(destType string) *HandleT {
-	r := &HandleT{}
+	r := &HandleT{
+		adaptiveLimit: f.AdaptiveLimit,
+	}
 
-	r.Setup(f.BackendConfig, f.RouterDB, f.ProcErrorDB, destType, f.Reporting, f.Multitenant, f.TransientSources, f.RsourcesService, f.Debugger)
+	r.Setup(
+		f.BackendConfig,
+		f.RouterDB,
+		f.ProcErrorDB,
+		destType,
+		f.Reporting,
+		f.Multitenant,
+		f.TransientSources,
+		f.RsourcesService,
+		f.Debugger,
+	)
 	return r
 }

--- a/router/factory.go
+++ b/router/factory.go
@@ -19,6 +19,7 @@ type Factory struct {
 	RsourcesService  rsources.JobService
 	ThrottlerFactory *throttler.Factory
 	Debugger         destinationdebugger.DestinationDebugger
+	AdaptiveLimit    func(int64) int64
 }
 
 func (f *Factory) New(destination *backendconfig.DestinationT, identifier string) *HandleT {
@@ -26,9 +27,18 @@ func (f *Factory) New(destination *backendconfig.DestinationT, identifier string
 		Reporting:        f.Reporting,
 		MultitenantI:     f.Multitenant,
 		throttlerFactory: f.ThrottlerFactory,
+		adaptiveLimit:    f.AdaptiveLimit,
 	}
 	destConfig := getRouterConfig(destination, identifier)
-	r.Setup(f.BackendConfig, f.RouterDB, f.ProcErrorDB, destConfig, f.TransientSources, f.RsourcesService, f.Debugger)
+	r.Setup(
+		f.BackendConfig,
+		f.RouterDB,
+		f.ProcErrorDB,
+		destConfig,
+		f.TransientSources,
+		f.RsourcesService,
+		f.Debugger,
+	)
 	return r
 }
 

--- a/router/router_throttling_test.go
+++ b/router/router_throttling_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
+	"sort"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/ory/dockertest/v3"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
@@ -215,18 +217,25 @@ func Test_RouterThrottling(t *testing.T) {
 		atomic.LoadInt64(webhook1.count), atomic.LoadInt64(webhook2.count),
 	)
 
-	// with 100 events, 20 rps and a cost of 2 we expect 10-11 buckets tops
-	requireLengthInRange(t, webhook1.buckets, 10, 11)
-	for _, rate := range webhook1.buckets {
-		// throttling cost is 2 and rate is 20 per second, so we expect ~10 in each bucket
-		require.LessOrEqual(t, rate, 10)
+	verifyBucket := func(buckets map[int64]int, totalEvents, rps, burst, cost int) {
+		lowerLengthRange := (totalEvents*cost - burst) / rps
+		upperLengthRange := lowerLengthRange + 1
+		requireLengthInRange(t, buckets, lowerLengthRange, upperLengthRange)
+
+		maxEventsPerBucket := rps / cost
+		bucketKeys := lo.Map(lo.Keys(buckets), func(key int64, _ int) int {
+			return int(key)
+		})
+		sort.Ints(bucketKeys)
+		bucketKeys = lo.Drop(bucketKeys, 1) // drop the first bucket (burst)
+		for bucketKey := range bucketKeys {
+			rate := buckets[int64(bucketKey)]
+			require.LessOrEqual(t, rate, maxEventsPerBucket)
+		}
 	}
-	// with 100 events, 50 rps and a cost of 2 we expect 4-5 buckets tops
-	requireLengthInRange(t, webhook2.buckets, 4, 5)
-	for _, rate := range webhook2.buckets {
-		// throttling cost is 2 and rate is 50 per second, so we expect 25 in each bucket
-		require.LessOrEqual(t, rate, 25)
-	}
+
+	verifyBucket(webhook1.buckets, noOfEvents, 20, 20, 2)
+	verifyBucket(webhook2.buckets, noOfEvents, 50, 20, 2)
 }
 
 func requireLengthInRange(t *testing.T, x interface{}, min, max int) {

--- a/utils/payload/limiter.go
+++ b/utils/payload/limiter.go
@@ -1,0 +1,121 @@
+package payload
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// LimiterState represents the LimiterState of the adaptive payload limiter algorithm
+type LimiterState int
+
+const (
+	// LimiterStateNormal is the default state and the state when free memory is above the threshold
+	LimiterStateNormal LimiterState = iota
+	// LimiterStateThreshold is the state when free memory is below the LimiterStateThreshold but above the critical LimiterStateThreshold
+	LimiterStateThreshold
+	// LimiterStateCritical is the state when free memory is below the LimiterStateCritical threshold
+	LimiterStateCritical
+)
+
+type LimiterStats struct {
+	State           LimiterState
+	ThresholdFactor int
+}
+
+// Limit is a function that returns the current payload limit in bytes
+type Limiter interface {
+	RunLoop(ctx context.Context, frequency func() <-chan time.Time)
+	Limit(maxLimit int64) int64
+	Stats() LimiterStats
+	tick()
+}
+
+// NewAdaptiveLimiter creates a PayloadLimit function following an adaptive payload limiting algorithm
+func NewAdaptiveLimiter(config AdaptiveLimiterConfig) Limiter {
+	config.parse()
+	algo := adaptivePayloadLimitAlgorithm{
+		config:          config,
+		thresholdFactor: 1,
+	}
+	algo.tick()
+	return &algo
+}
+
+type adaptivePayloadLimitAlgorithm struct {
+	state           LimiterState
+	config          AdaptiveLimiterConfig
+	thresholdFactor int
+	freeMem         float64
+	mu              sync.Mutex
+}
+
+func (r *adaptivePayloadLimitAlgorithm) RunLoop(ctx context.Context, frequency func() <-chan time.Time) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-frequency():
+			r.tick()
+		}
+	}
+}
+
+func (r *adaptivePayloadLimitAlgorithm) Limit(maxLimit int64) int64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	switch r.state {
+	case LimiterStateNormal:
+		// during normal state we return the max limit
+		return maxLimit
+	case LimiterStateThreshold:
+		// during threshold state we return the max limit decremented by 10% times the threshold factor
+		return int64(float64(maxLimit) * (1.0 - (0.1 * float64(r.thresholdFactor))))
+	default:
+		// during critical state we return 1 byte as a limit, since 0 bytes is interpreted as unlimited
+		return 1
+	}
+}
+
+func (r *adaptivePayloadLimitAlgorithm) Stats() LimiterStats {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return LimiterStats{
+		State:           r.state,
+		ThresholdFactor: r.thresholdFactor,
+	}
+}
+
+func (r *adaptivePayloadLimitAlgorithm) tick() {
+	freeMem, err := r.config.FreeMemory()
+	if err != nil {
+		r.config.Log.Warnf("failed to get free memory: %v", err)
+		freeMem = 100
+	}
+	var newState LimiterState = LimiterStateCritical
+	if freeMem > r.config.FreeMemThresholdLimit {
+		newState = LimiterStateNormal
+	} else if freeMem > r.config.FreeMemCriticalLimit {
+		newState = LimiterStateThreshold
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.freeMem = freeMem
+	if r.state != newState {
+		r.state = newState
+		r.stateChanged(newState)
+	}
+}
+
+func (r *adaptivePayloadLimitAlgorithm) stateChanged(newState LimiterState) {
+	switch newState {
+	case LimiterStateNormal:
+		r.thresholdFactor = 1
+	case LimiterStateCritical:
+		r.config.Log.Warnf("critical memory state, free memory percentage: %f %", r.freeMem)
+		r.thresholdFactor = r.thresholdFactor + 1
+		if r.thresholdFactor > r.config.MaxThresholdFactor {
+			r.thresholdFactor = r.config.MaxThresholdFactor
+		}
+	}
+}

--- a/utils/payload/limiter_config.go
+++ b/utils/payload/limiter_config.go
@@ -1,0 +1,39 @@
+package payload
+
+import (
+	"github.com/rudderlabs/rudder-server/utils/logger"
+)
+
+// FreeMemory is a function that returns the free memory in percentage (0-100)
+type FreeMemory func() (float64, error)
+
+type AdaptiveLimiterConfig struct {
+	// FreeMemThresholdLimit is the threshold for the free memory in percentage. Default is 30%
+	FreeMemThresholdLimit float64
+	// CriticalFreeMemory is the critical threshold for the free memory in percentage. Default is 10%
+	FreeMemCriticalLimit float64
+	// MaxThresholdFactor is the maximum threshold factor. Values 1-9 are valid. Default is 9
+	MaxThresholdFactor int
+	// FreeMemory is the function to use for getting the free memory in percentage. Default implementation will be used if not provided
+	FreeMemory FreeMemory
+	// Log
+	Log logger.Logger
+}
+
+func (c *AdaptiveLimiterConfig) parse() {
+	if c.FreeMemThresholdLimit == 0 {
+		c.FreeMemThresholdLimit = 30
+	}
+	if c.FreeMemCriticalLimit == 0 {
+		c.FreeMemCriticalLimit = 10
+	}
+	if c.MaxThresholdFactor < 1 || c.MaxThresholdFactor > 9 {
+		c.MaxThresholdFactor = 9
+	}
+	if c.Log == nil {
+		c.Log = logger.NewLogger().Child("payload-limiter")
+	}
+	if c.FreeMemory == nil {
+		c.FreeMemory = func() (float64, error) { return 100.0, nil }
+	}
+}

--- a/utils/payload/limiter_setup.go
+++ b/utils/payload/limiter_setup.go
@@ -1,0 +1,70 @@
+package payload
+
+import (
+	"context"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/config"
+	"github.com/rudderlabs/rudder-server/services/stats"
+	"github.com/rudderlabs/rudder-server/utils/logger"
+	"github.com/rudderlabs/rudder-server/utils/mem"
+	"golang.org/x/sync/errgroup"
+)
+
+type AdaptiveLimiterFunc func(int64) int64
+
+// SetupAdaptiveLimiter creates a new AdaptiveLimiter, starts its RunLoop in a goroutine and periodically collects statistics.
+func SetupAdaptiveLimiter(ctx context.Context, g *errgroup.Group) AdaptiveLimiterFunc {
+	var freeMem FreeMemory
+	if config.GetBool("AdaptivePayloadLimiter.enabled", false) {
+		freeMem = func() (float64, error) {
+			s, err := mem.Get()
+			if err != nil {
+				return 0, err
+			}
+			return s.AvailablePercent, nil
+		}
+	}
+
+	limiterConfig := AdaptiveLimiterConfig{
+		FreeMemThresholdLimit: config.GetFloat64("AdaptivePayloadLimiter.freeMemThresholdLimit", 30),
+		FreeMemCriticalLimit:  config.GetFloat64("AdaptivePayloadLimiter.freeMemCriticalLimit", 10),
+		MaxThresholdFactor:    config.GetInt("AdaptivePayloadLimiter.maxThresholdFactor", 9),
+		Log:                   logger.NewLogger().Child("payload_limiter"),
+		FreeMemory:            freeMem,
+	}
+
+	// run tick periodically
+	tickFrequency := config.GetDuration("AdaptivePayloadLimiter.tickFrequency", 1, time.Second)
+	limiter := NewAdaptiveLimiter(limiterConfig)
+	g.Go(func() error {
+		limiter.RunLoop(ctx, func() <-chan time.Time {
+			return time.After(tickFrequency)
+		})
+		return nil
+	})
+
+	// collect statistics
+	statsFrequency := config.GetDuration("AdaptivePayloadLimiter.statsFrequency", 15, time.Second)
+	g.Go(func() error {
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(statsFrequency):
+				limiterStats := limiter.Stats()
+
+				stats.Default.NewStat("adaptive_payload_limiter_state", stats.GaugeType).Gauge(limiterStats.State)
+				stats.Default.NewStat("adaptive_payload_limiter_threshold_factor", stats.GaugeType).Gauge(limiterStats.ThresholdFactor)
+				if memStats, err := mem.Get(); err == nil {
+					stats.Default.NewStat("mem_total_bytes", stats.GaugeType).Gauge(memStats.Total)
+					stats.Default.NewStat("mem_available_bytes", stats.GaugeType).Gauge(memStats.Available)
+					stats.Default.NewStat("mem_available_percent", stats.GaugeType).Gauge(memStats.AvailablePercent)
+					stats.Default.NewStat("mem_used_bytes", stats.GaugeType).Gauge(memStats.Used)
+					stats.Default.NewStat("mem_used_percent", stats.GaugeType).Gauge(memStats.UsedPercent)
+				}
+			}
+		}
+	})
+	return limiter.Limit
+}

--- a/utils/payload/limiter_test.go
+++ b/utils/payload/limiter_test.go
@@ -1,0 +1,265 @@
+package payload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayloadLimiter(t *testing.T) {
+	t.Run("free memory ticker", func(t *testing.T) {
+		var freeMem float64
+		freeMemFunc := func() (float64, error) {
+			return freeMem, nil
+		}
+
+		limiter := NewAdaptiveLimiter(
+			AdaptiveLimiterConfig{
+				FreeMemory: freeMemFunc,
+			},
+		)
+
+		freeMem = 0 // 0% free memory -> critical state
+		limiter.tick()
+		require.EqualValues(
+			t,
+			LimiterStateCritical,
+			limiter.Stats().State,
+			"limiter should be in a critical state",
+		)
+		require.EqualValues(
+			t,
+			1,
+			limiter.Limit(100),
+			"payload limit should be 1",
+		)
+		require.EqualValues(
+			t,
+			2,
+			limiter.Stats().ThresholdFactor,
+			"threshold factor should be 2",
+		)
+
+		freeMem = 11 // 11% free memory -> above threshold
+		limiter.tick()
+		require.EqualValues(
+			t,
+			LimiterStateThreshold,
+			limiter.Stats().State,
+			"limiter should be in a threshold state",
+		)
+		require.EqualValues(
+			t,
+			2,
+			limiter.Stats().ThresholdFactor,
+			"threshold factor should be 2",
+		)
+		require.EqualValues(
+			t,
+			int64(80),
+			limiter.Limit(100),
+			"payload limit should be 80",
+		)
+
+		freeMem = 45 // 45% free memory -> below threshold -> normal mode -> should reset threshold factor
+		limiter.tick()
+		require.EqualValues(
+			t,
+			LimiterStateNormal,
+			limiter.Stats().State,
+			"limiter should be in a normal state",
+		)
+		require.EqualValues(
+			t,
+			100,
+			limiter.Limit(100),
+			"payload limit should be 100",
+		)
+		require.EqualValues(
+			t,
+			1,
+			limiter.Stats().ThresholdFactor,
+			"threshold factor should be 1",
+		)
+
+		freeMem = 15 // 15% free memory -> above threshold -> shouldn't increase threshold factor
+		limiter.tick()
+		require.EqualValues(
+			t,
+			LimiterStateThreshold,
+			limiter.Stats().State,
+			"limiter should be in a threshold state",
+		)
+		require.EqualValues(
+			t,
+			1,
+			limiter.Stats().ThresholdFactor,
+			"threshold factor should be 1",
+		)
+		require.EqualValues(
+			t,
+			90,
+			limiter.Limit(100),
+			"payload limit should be 90",
+		)
+
+		freeMem = 9 // 9% free memory -> critical state
+		limiter.tick()
+		require.EqualValues(
+			t,
+			LimiterStateCritical,
+			limiter.Stats().State,
+			"limiter should be in a critical state",
+		)
+		require.EqualValues(
+			t,
+			1,
+			limiter.Limit(100),
+			"payload limit should be 1",
+		)
+		require.EqualValues(
+			t,
+			2,
+			limiter.Stats().ThresholdFactor,
+			"threshold factor should be 2",
+		)
+
+		freeMem = 11 // 11% free memory -> above critical
+		limiter.tick()
+		require.EqualValues(
+			t,
+			LimiterStateThreshold,
+			limiter.Stats().State,
+			"limiter should be in a threshold state",
+		)
+		require.EqualValues(
+			t,
+			2,
+			limiter.Stats().ThresholdFactor,
+			"threshold factor should be 2",
+		)
+		require.EqualValues(
+			t,
+			80,
+			limiter.Limit(100),
+			"payload limit should be 80",
+		)
+
+		freeMem = 8 // 8% free memory -> critical state
+		limiter.tick()
+		require.EqualValues(
+			t,
+			LimiterStateCritical,
+			limiter.Stats().State,
+			"limiter should be in a critical state",
+		)
+		require.EqualValues(
+			t,
+			1,
+			limiter.Limit(100),
+			"payload limit should be 1 if freeMemory is 8%",
+		)
+		require.EqualValues(
+			t,
+			3,
+			limiter.Stats().ThresholdFactor,
+			"threshold factor increases because freeMem is critical",
+		)
+
+		freeMem = 11 // 11% free memory -> above critical
+		limiter.tick()
+		require.EqualValues(
+			t,
+			LimiterStateThreshold,
+			limiter.Stats().State,
+			"limiter should be in a threshold state",
+		)
+		require.EqualValues(
+			t,
+			70,
+			limiter.Limit(100),
+			"payload limit depend on threshold factor if freeMemory is 11%",
+		)
+		require.EqualValues(
+			t,
+			3,
+			limiter.Stats().ThresholdFactor,
+			"threshold factor should not change if freeMem goes from crit to threshold",
+		)
+
+		freeMem = 8 // 8% free memory -> critical state
+		limiter.tick()
+		require.EqualValues(
+			t,
+			LimiterStateCritical,
+			limiter.Stats().State,
+			"limiter should be in a critical state",
+		)
+		require.EqualValues(
+			t,
+			1,
+			limiter.Limit(100),
+			"payload limit should be 1 if freeMemory is 8%",
+		)
+		require.Equal(
+			t,
+			4,
+			limiter.Stats().ThresholdFactor,
+			"threshold factor increases because freeMem is critical",
+		)
+	})
+
+	t.Run("limiter reaches to maximum threshold factor", func(t *testing.T) {
+		var freeMem float64
+		freeMemFunc := func() (float64, error) {
+			return freeMem, nil
+		}
+		maxThresholdFactor := 8
+		limiter := NewAdaptiveLimiter(
+			AdaptiveLimiterConfig{
+				FreeMemory:         freeMemFunc,
+				MaxThresholdFactor: maxThresholdFactor,
+			},
+		)
+
+		for i := 2; i <= maxThresholdFactor; i++ {
+			freeMem = 9
+			limiter.tick()
+			freeMem = 20
+			limiter.tick()
+			require.EqualValuesf(
+				t,
+				i,
+				limiter.Stats().ThresholdFactor,
+				"threshold factor should be %d", i,
+			)
+			maxLimit := int64(100)
+			expectedLimit := int64(float64(maxLimit) * (1.0 - (0.1 * float64(i))))
+			require.EqualValuesf(
+				t,
+				expectedLimit,
+				limiter.Limit(maxLimit),
+				"limiter's output should be %d", expectedLimit,
+			)
+		}
+
+		freeMem = 9
+		limiter.tick()
+		freeMem = 20
+		limiter.tick()
+		require.EqualValuesf(
+			t,
+			maxThresholdFactor,
+			limiter.Stats().ThresholdFactor,
+			"threshold factor should remain %d", maxThresholdFactor,
+		)
+		maxLimit := int64(100)
+		expectedLimit := int64(float64(maxLimit) * (1.0 - (0.1 * float64(maxThresholdFactor))))
+		require.EqualValuesf(
+			t,
+			expectedLimit,
+			limiter.Limit(maxLimit),
+			"limiter's output should be %d", expectedLimit,
+		)
+	})
+}


### PR DESCRIPTION
# Description

Introduces utils/payload package.
1. utils mem package to fetch memory statistics(`available`, `free`, `used`) and publish them every fifteen seconds.
2. Further uses the free memory stat above to dynamically compute memory that can be safely used by various processes. This can be done optionally via `AdaptivePayloadLimiter.enabled`(disabled by default). Default behaviour is where all processes use their own pre-defined limits on memory.

Once enabled, there's three states that the limiter could be in - `normal`, `threshold`, `critical`.
`normal` state - all processes may use the maximum memory available(each usually has it's own pre-defined limit, so max here means each process may use the limit it imposes on itself)
`threshold` state - here each process uses a proportion of it's self-defined limits based on `thresholdFactor`: `(1 - (0.1*thresholdFactor))*limit`
`critical` state - every time limiter enters a critical state, the `thresholdFactor` increments by 1 with a cap of 9(min: 1). Also each process can use only minimum memory for its functions(1 byte).

The threshold factor can only go down once the limiter enters `normal` mode again.


## Notion Ticket

[adaptive memory](https://www.notion.so/rudderstacks/Adaptive-payload-size-limits-43e1c2f7fb914f66841bd0c122c22aa1)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
