### PR TITLE
fix(warehouse): warehouse validations fixed to lookup secrets using sshKeyId

### DIFF
--- a/warehouse/client/controlplane/client.go
+++ b/warehouse/client/controlplane/client.go
@@ -25,6 +25,7 @@ type BasicAuth struct {
 
 type InternalControlPlane interface {
 	GetDestinationSSHKeys(ctx context.Context, id string) (*PublicPrivateKeyPair, error)
+	GetSSHKeys(ctx context.Context, id string) (*PublicPrivateKeyPair, error)
 }
 
 type internalClientWithCache struct {
@@ -44,6 +45,42 @@ type internalClient struct {
 	baseURI    string
 	auth       BasicAuth
 	httpClient *http.Client
+}
+
+func (api *internalClient) GetSSHKeys(ctx context.Context, id string) (*PublicPrivateKeyPair, error) {
+	url := fmt.Sprintf("%s/dataplane/admin/sshKeys/%s", api.baseURI, id)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating new request with ctx: %w", err)
+	}
+
+	req.SetBasicAuth(api.auth.Username, api.auth.Password)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := api.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching response from http client: %w", err)
+	}
+
+	defer func() { httputil.CloseResponse(resp) }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("%w: key requested: %s", ErrKeyNotFound, id)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("invalid status code: %d", resp.StatusCode)
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+
+	var keypair PublicPrivateKeyPair
+	if err := decoder.Decode(&keypair); err != nil {
+		return nil, fmt.Errorf("decoding upstream response body: %w", err)
+	}
+
+	return &keypair, nil
 }
 
 func (api *internalClient) GetDestinationSSHKeys(ctx context.Context, id string) (*PublicPrivateKeyPair, error) {
@@ -87,6 +124,20 @@ func NewInternalClientWithCache(baseURI string, auth BasicAuth) InternalControlP
 		client: NewInternalClient(baseURI, auth),
 		cache:  sync.Map{},
 	}
+}
+
+func (cc *internalClientWithCache) GetSSHKeys(ctx context.Context, id string) (*PublicPrivateKeyPair, error) {
+	if val, ok := cc.cache.Load(id); ok {
+		return val.(*PublicPrivateKeyPair), nil
+	}
+
+	keypair, err := cc.client.GetSSHKeys(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("fetching and caching destination ssh keys: %w", err)
+	}
+
+	cc.cache.Store(id, keypair)
+	return keypair, nil
 }
 
 func (cc *internalClientWithCache) GetDestinationSSHKeys(ctx context.Context, id string) (*PublicPrivateKeyPair, error) {

--- a/warehouse/validations/validate.go
+++ b/warehouse/validations/validate.go
@@ -116,18 +116,35 @@ func (ct *CTHandleT) verifyingObjectStorage() (err error) {
 	return
 }
 
+func (ct *CTHandleT) manageTunnellingSecrets(config map[string]interface{}) error {
+
+	if !warehouseutils.ReadAsBool("useSSH", config) {
+		return nil
+	}
+
+	sshKeyId, ok := ct.warehouse.Destination.Config["sshKeyId"]
+	if !ok {
+		return fmt.Errorf("missing sshKeyId in validation payload")
+	}
+
+	keys, err := ct.CPClient.GetSSHKeys(context.TODO(), sshKeyId.(string))
+	if err != nil {
+		return fmt.Errorf("fetching destination ssh keys: %w", err)
+	}
+
+	ct.warehouse.Destination.Config["sshPrivateKey"] = keys.PrivateKey
+	return nil
+}
+
 func (ct *CTHandleT) initManager() (err error) {
 	ct.warehouse = warehouse(ct.infoRequest)
 
 	// adding ssh tunnelling info, given we have
 	// useSSH enabled from upstream
 	if ct.EnableTunnelling {
-		if warehouseutils.ReadAsBool("useSSH", ct.warehouse.Destination.Config) {
-			keys, err := ct.CPClient.GetDestinationSSHKeys(context.TODO(), ct.warehouse.Destination.ID)
-			if err != nil {
-				return fmt.Errorf("fetching destination ssh keys: %w", err)
-			}
-			ct.warehouse.Destination.Config["sshPrivateKey"] = keys.PrivateKey
+		err = ct.manageTunnellingSecrets(ct.warehouse.Destination.Config)
+		if err != nil {
+			return fmt.Errorf("handling secrets for tunnelling: %w", err)
 		}
 	}
 

--- a/warehouse/validations/validate.go
+++ b/warehouse/validations/validate.go
@@ -117,7 +117,6 @@ func (ct *CTHandleT) verifyingObjectStorage() (err error) {
 }
 
 func (ct *CTHandleT) manageTunnellingSecrets(config map[string]interface{}) error {
-
 	if !warehouseutils.ReadAsBool("useSSH", config) {
 		return nil
 	}


### PR DESCRIPTION
# Description
The warehouse validations are moved to use the sshKeyId which is injected from upstream when making a call to run validations. The benefit is to not depend on the warehouse destinationId the first time we have created a destination.

## Notion Ticket

https://www.notion.so/rudderstacks/Augment-the-warehouse-validation-flow-to-play-nicely-with-the-sql-tunnel-based-validations-eb71efa64fcc466bb28da64b2d64a0f0

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
