### PR TITLE
fix: move recovery from scheduler to upload

### DIFF
--- a/warehouse/internal/model/upload.go
+++ b/warehouse/internal/model/upload.go
@@ -21,6 +21,8 @@ const (
 	CreatedRemoteSchema       = "created_remote_schema"
 	ExportedUserTables        = "exported_user_tables"
 	ExportedData              = "exported_data"
+	ExportingData             = "exporting_data"
+	ExportingDataFailed       = "exporting_data_failed"
 	ExportedIdentities        = "exported_identities"
 	Aborted                   = "aborted"
 	Failed                    = "failed"

--- a/warehouse/internal/repo/upload.go
+++ b/warehouse/internal/repo/upload.go
@@ -464,10 +464,10 @@ func scanUpload(scan scanFn, upload *model.Upload) error {
 
 // InterruptedDestinations returns a list of destination IDs, which have uploads was interrupted.
 //
-//	And might require cleanup of intermediate upload tables.
+//	Interrupted upload might require cleanup of intermediate upload tables.
 func (uploads *Uploads) InterruptedDestinations(ctx context.Context, destinationType string) ([]string, error) {
 	destinationIDs := make([]string, 0)
-	rows, err := uploads.db.Query(`
+	rows, err := uploads.db.QueryContext(ctx, `
 		SELECT
 			destination_id
 		FROM

--- a/warehouse/internal/repo/upload.go
+++ b/warehouse/internal/repo/upload.go
@@ -461,3 +461,47 @@ func scanUpload(scan scanFn, upload *model.Upload) error {
 
 	return nil
 }
+
+// InterruptedDestinations returns a list of destination IDs, which have uploads was interrupted.
+//
+//	And might require cleanup of intermediate upload tables.
+func (uploads *Uploads) InterruptedDestinations(ctx context.Context, destinationType string) ([]string, error) {
+	destinationIDs := make([]string, 0)
+	rows, err := uploads.db.Query(`
+		SELECT
+			destination_id
+		FROM
+			`+uploadsTableName+`
+		WHERE
+			in_progress = TRUE
+			AND destination_type = $1
+			AND (
+				status = $2
+				OR status = $3
+			);
+	`,
+		destinationType,
+		model.ExportingData,
+		model.ExportingDataFailed,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query for interrupted destinations: %w", err)
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		var destID string
+		err := rows.Scan(&destID)
+		if err != nil {
+			return nil, fmt.Errorf("scanning: %w", err)
+		}
+		destinationIDs = append(destinationIDs, destID)
+	}
+
+	if rows.Err() != nil {
+		return nil, fmt.Errorf("iterating rows: %w", rows.Err())
+	}
+
+	return destinationIDs, nil
+}

--- a/warehouse/internal/repo/upload_test.go
+++ b/warehouse/internal/repo/upload_test.go
@@ -353,3 +353,27 @@ func TestUploads_Delete(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, files, 1)
 }
+
+func TestUploads_InterruptedDestinations(t *testing.T) {
+	t.Parallel()
+	db := setupDB(t)
+
+	_, err := db.Exec(`INSERT INTO wh_uploads (destination_id, source_id, in_progress, destination_type, status, namespace, schema, created_at, updated_at)
+		VALUES
+		(1, 1, true, 'RS', 'exporting_data', '', '{}', NOW(), NOW()),
+		(2, 1, true, 'RS', 'exporting_data_failed', '', '{}', NOW(), NOW()),
+		(3, 1, true, 'RS', 'exporting_data_failed', '', '{}', NOW(), NOW()),
+
+		(4, 1, true, 'RS', 'exported_data', '', '{}', NOW(), NOW()),
+		(5, 1, true, 'RS', 'aborted', '', '{}', NOW(), NOW()),
+		(6, 1, true, 'RS', 'failed', '', '{}', NOW(), NOW()),
+		(7, 1, true, 'SNOWFLAKE', 'exporting_data', '', '{}', NOW(), NOW())
+	`)
+	require.NoError(t, err)
+
+	repoUpload := repo.NewUploads(db)
+	ids, err := repoUpload.InterruptedDestinations(context.Background(), "RS")
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"1", "2", "3"}, ids)
+}

--- a/warehouse/internal/service/recovery.go
+++ b/warehouse/internal/service/recovery.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+	"golang.org/x/exp/slices"
+)
+
+var crashRecoverWarehouses = []string{
+	warehouseutils.RS,
+	warehouseutils.POSTGRES,
+	warehouseutils.MSSQL,
+	warehouseutils.AZURE_SYNAPSE,
+	warehouseutils.DELTALAKE,
+}
+
+type repo interface {
+	InterruptedDestinations(ctx context.Context, destinationType string) ([]string, error)
+}
+
+type Recovery struct {
+	detectOnce      sync.Once
+	detectErr       error
+	destinationType string
+	repo            repo
+	inRecovery      map[string]sync.Once
+}
+
+func NewRecovery(destinationType string, repo repo) *Recovery {
+	return &Recovery{
+		destinationType: destinationType,
+		repo:            repo,
+		inRecovery:      make(map[string]sync.Once),
+	}
+}
+
+// Detect detects if there are any warehouses that need to be recovered.
+func (r *Recovery) detect(ctx context.Context) error {
+	if !slices.Contains(crashRecoverWarehouses, r.destinationType) {
+		return nil
+	}
+
+	destIDs, err := r.repo.InterruptedDestinations(context.Background(), r.destinationType)
+	if err != nil {
+		return fmt.Errorf("repo interrupted destinations: %w", err)
+	}
+
+	for _, destID := range destIDs {
+		r.inRecovery[destID] = sync.Once{}
+	}
+
+	return nil
+}
+
+// Recover recovers a warehouse, for a non-graceful shutdown.
+func (r *Recovery) Recover(ctx context.Context, whManager manager.ManagerI, wh warehouseutils.Warehouse) error {
+	r.detectOnce.Do(func() {
+		r.detectErr = r.detect(ctx)
+	})
+	if r.detectErr != nil {
+		return r.detectErr
+	}
+
+	once, ok := r.inRecovery[wh.Destination.ID]
+	if !ok {
+		return nil
+	}
+
+	var err error
+	once.Do(func() {
+		err = whManager.CrashRecover(wh)
+	})
+
+	return err
+}

--- a/warehouse/internal/service/recovery_test.go
+++ b/warehouse/internal/service/recovery_test.go
@@ -1,0 +1,118 @@
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/service"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRepo struct {
+	m   map[string][]string
+	err error
+}
+
+type mockDestination struct {
+	recovered int
+	err       error
+}
+
+func (r *mockRepo) InterruptedDestinations(_ context.Context, destinationType string) ([]string, error) {
+	return r.m[destinationType], r.err
+}
+
+func (d *mockDestination) CrashRecover(_ warehouseutils.Warehouse) error {
+	d.recovered += 1
+	return d.err
+}
+
+func TestRecovery(t *testing.T) {
+	testCases := []struct {
+		name          string
+		whType        string
+		destinationID string
+
+		recovery bool
+
+		repoErr error
+		destErr error
+		wantErr error
+	}{
+		{
+			name:          "interrupted postgres warehouse",
+			whType:        warehouseutils.POSTGRES,
+			destinationID: "1",
+			recovery:      true,
+		},
+		{
+			name:          "non-interrupted postgres warehouse",
+			whType:        warehouseutils.POSTGRES,
+			destinationID: "3",
+			recovery:      false,
+		},
+		{
+			name:          "interrupted snowflake - skipped - warehouse",
+			whType:        warehouseutils.SNOWFLAKE,
+			destinationID: "6",
+			recovery:      false,
+		},
+
+		{
+			name:          "repo error",
+			whType:        warehouseutils.POSTGRES,
+			destinationID: "1",
+			repoErr:       fmt.Errorf("repo error"),
+			wantErr:       fmt.Errorf("repo interrupted destinations: repo error"),
+		},
+		{
+			name:          "destination error",
+			whType:        warehouseutils.POSTGRES,
+			destinationID: "1",
+			recovery:      true,
+			destErr:       fmt.Errorf("dest error"),
+			wantErr:       fmt.Errorf("dest error"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &mockRepo{
+				m: map[string][]string{
+					warehouseutils.POSTGRES:  {"1", "2"},
+					warehouseutils.SNOWFLAKE: {"6", "8"},
+				},
+				err: tc.repoErr,
+			}
+
+			d := &mockDestination{
+				err: tc.destErr,
+			}
+
+			recovery := service.NewRecovery(tc.whType, repo)
+
+			for i := 0; i < 2; i++ {
+				err := recovery.Recover(context.Background(), d, warehouseutils.Warehouse{
+					Destination: backendconfig.DestinationT{
+						ID: tc.destinationID,
+					},
+				})
+
+				if tc.wantErr != nil {
+					require.EqualError(t, err, tc.wantErr.Error())
+				} else {
+					require.NoError(t, err)
+				}
+			}
+
+			if tc.recovery {
+				require.Equal(t, 1, d.recovered)
+			} else {
+				require.Equal(t, 0, d.recovered)
+			}
+		})
+	}
+}

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -2033,14 +2033,6 @@ func getInProgressState(state string) string {
 	return uploadState.inProgress
 }
 
-func getFailedState(state string) string {
-	uploadState, ok := stateTransitions[state]
-	if !ok {
-		panic(fmt.Errorf("invalid Upload state : %s", state))
-	}
-	return uploadState.failed
-}
-
 func initializeStateMachine() {
 	stateTransitions = make(map[string]*uploadStateT)
 

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -68,7 +68,6 @@ var (
 	stagingFilesSchemaPaginationSize    int
 	mainLoopSleep                       time.Duration
 	stagingFilesBatchSize               int
-	crashRecoverWarehouses              []string
 	lastProcessedMarkerMap              map[string]int64
 	lastProcessedMarkerExp              = expvar.NewMap("lastProcessedMarkerMap")
 	lastProcessedMarkerMapLock          sync.RWMutex


### PR DESCRIPTION
# Description


## Context
Under some conditions, recovery can take time. We have seen cases from 30 minutes to 4 hours.

The recovery can block the scheduler loop for a particular destination type. Causing significant delays to upload creations.

## Mitigation

By moving recovery to the upload loop we mitigate the problem. A single blocking recovery process can not block other uploads from being processed. Multiple (>8) blocking recoveries can saturate the available workers, in this case, we will increase the available workers.


## Refactoring & Tests

The original was split into two parts:
* repo: querying the database to get interrupted destinations 
* service: the logic of triggering the recovery once, if it is needed

In an effort to simplify the recovery interface, the detection - querying the database -  happens just in time.

The logic is now thread-safe, expecting multiple warehouses to call for the same destinationID at the same time. This is why a map of `sync.Once` was introduced.

## Notion Ticket

https://www.notion.so/rudderstacks/Move-recovery-from-scheduler-to-upload-7617b94967cd4876b94bde6dc59f3616?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
