### PR TITLE
chore: use gauge for capturing pending events

### DIFF
--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -711,11 +711,11 @@ func (wh *HandleT) mainLoop(ctx context.Context) {
 
 func (wh *HandleT) processingStats(availableWorkers int, jobStats model.UploadJobsStats) {
 	// Get pending jobs
-	pendingJobsStat := wh.stats.NewTaggedStat("wh_processing_pending_jobs", stats.CountType, stats.Tags{
+	pendingJobsStat := wh.stats.NewTaggedStat("wh_processing_pending_jobs", stats.GaugeType, stats.Tags{
 		"module":   moduleName,
 		"destType": wh.destType,
 	})
-	pendingJobsStat.Count(int(jobStats.PendingJobs))
+	pendingJobsStat.Gauge(int(jobStats.PendingJobs))
 
 	availableWorkersStat := wh.stats.NewTaggedStat("wh_processing_available_workers", stats.GaugeType, stats.Tags{
 		"module":   moduleName,


### PR DESCRIPTION
# Description

Count was the incorrect metric type to capture the number of pending events. Since we were interested in the time value and not the rate of change. 


## Notion Ticket

https://www.notion.so/rudderstacks/Reduce-alert-noise-Improve-observability-5beff5b1a6e34a92a071b37ab117bf45?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
