### PR TITLE
fix(warehouse): deltalake client crashing when failing on connectionstep

### DIFF
--- a/warehouse/integrations/deltalake/client/client.go
+++ b/warehouse/integrations/deltalake/client/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	proto "github.com/rudderlabs/rudder-server/proto/databricks"
-	"github.com/rudderlabs/rudder-server/services/stats"
 	"github.com/rudderlabs/rudder-server/utils/logger"
 	"google.golang.org/grpc"
 )
@@ -23,13 +22,10 @@ type Client struct {
 	Context        context.Context
 	Conn           *grpc.ClientConn
 	Client         proto.DatabricksClient
-	CloseStats     stats.Measurement
 }
 
 // Close closes sql connection as well as closes grpc connection
 func (client *Client) Close() {
-	defer client.CloseStats.RecordDuration()()
-
 	closeConnectionResponse, err := client.Client.Close(client.Context, &proto.CloseRequest{
 		Config:     client.CredConfig,
 		Identifier: client.CredIdentifier,

--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -817,23 +817,7 @@ func (dl *Deltalake) connectToWarehouse() (Client *client.Client, err error) {
 	})
 	defer connStat.RecordDuration()()
 
-	closeConnStat := dl.Stats.NewTaggedStat("warehouse.deltalake.grpcExecTime", stats.TimerType, stats.Tags{
-		"workspaceId": dl.Warehouse.WorkspaceID,
-		"destination": dl.Warehouse.Destination.ID,
-		"destType":    dl.Warehouse.Type,
-		"source":      dl.Warehouse.Source.ID,
-		"namespace":   dl.Warehouse.Namespace,
-		"identifier":  dl.Warehouse.Identifier,
-		"queryType":   "Close",
-	})
-
-	Client, err = dl.NewClient(credT, dl.ConnectTimeout)
-	if err != nil {
-		return
-	}
-
-	Client.CloseStats = closeConnStat
-	return
+	return dl.NewClient(credT, dl.ConnectTimeout)
 }
 
 // CreateTable creates tables with table name and columns


### PR DESCRIPTION
# Description

- When the validation fails at the connection step and we try to do the cleanup, the client is not yet set up. Causing the nil pointer.
- **Also, now we don't need these stats as well. These we have added initially for the monitoring purpose for calls made to the data bricks connector during POC**.
- **Also, this is already fixed in https://github.com/rudderlabs/rudder-server/pull/2940**

## Notion Ticket

https://www.notion.so/rudderstacks/Unity-catalogue-for-Databricks-8898be7a27054896aae0f395c74b7d78?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
