### PR TITLE
fix: handle NULL on upload timings

### DIFF
--- a/warehouse/internal/repo/upload.go
+++ b/warehouse/internal/repo/upload.go
@@ -377,6 +377,35 @@ func (uploads *Uploads) UploadJobsStats(ctx context.Context, destType string, op
 	return stats, nil
 }
 
+func (uploads *Uploads) UploadTimings(ctx context.Context, uploadID int64) (model.Timings, error) {
+	var (
+		rawJSON jsoniter.RawMessage
+		timings model.Timings
+	)
+
+	err := uploads.db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(timings, '[]')::JSONB
+		FROM
+			`+uploadsTableName+`
+		WHERE
+			id = $1;
+	`, uploadID).Scan(&rawJSON)
+	if err == sql.ErrNoRows {
+		return timings, model.ErrUploadNotFound
+	}
+	if err != nil {
+		return timings, err
+	}
+
+	err = json.Unmarshal(rawJSON, &timings)
+	if err != nil {
+		return timings, err
+	}
+
+	return timings, nil
+}
+
 func (uploads *Uploads) DeleteWaiting(ctx context.Context, uploadID int64) error {
 	_, err := uploads.db.ExecContext(ctx,
 		`DELETE FROM `+uploadsTableName+` WHERE id = $1 AND status = $2`,

--- a/warehouse/internal/repo/upload.go
+++ b/warehouse/internal/repo/upload.go
@@ -377,6 +377,7 @@ func (uploads *Uploads) UploadJobsStats(ctx context.Context, destType string, op
 	return stats, nil
 }
 
+// UploadTimings returns the timings for an upload.
 func (uploads *Uploads) UploadTimings(ctx context.Context, uploadID int64) (model.Timings, error) {
 	var (
 		rawJSON jsoniter.RawMessage

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -1371,6 +1371,7 @@ type UploadStatusOpts struct {
 
 func (job *UploadJobT) setUploadStatus(statusOpts UploadStatusOpts) (err error) {
 	pkgLogger.Debugf("[WH]: Setting status of %s for wh_upload:%v", statusOpts.Status, job.upload.ID)
+	// TODO: fetch upload model instead of just timings
 	marshalledTimings, timings := job.getNewTimings(statusOpts.Status)
 	opts := []UploadColumnT{
 		{Column: UploadStatusField, Value: statusOpts.Status},

--- a/warehouse/upload_test.go
+++ b/warehouse/upload_test.go
@@ -317,12 +317,13 @@ var _ = Describe("Upload", Ordered, func() {
 	It("Get uploads timings", func() {
 		exportedData, _ := time.ParseDateTime("2020-04-21T15:26:34.344356")
 		exportingData, _ := time.ParseDateTime("2020-04-21T15:16:19.687716")
-		Expect(job.getUploadTimings()).To(BeEquivalentTo(model.Timings{
-			{
-				"exported_data":  exportedData,
-				"exporting_data": exportingData,
-			},
-		}))
+		Expect(repo.NewUploads(job.dbHandle).UploadTimings(context.TODO(), job.upload.ID)).
+			To(BeEquivalentTo(model.Timings{
+				{
+					"exported_data":  exportedData,
+					"exporting_data": exportingData,
+				},
+			}))
 	})
 
 	Describe("Staging files and load files events match", func() {


### PR DESCRIPTION
# Description

The original code didn't handle NULL correctly, but since the error has not been handled we weren't aware of the issue.
After a recent refactoring, the error code was exposed as a log.

In this PR, I have moved the SQL-related code to repo, added tests and handle the NULL case using `COALESCE(timings, '[]')::JSONB`

## Notion Ticket

https://www.notion.so/rudderstacks/Handle-NULL-timings-0e2e23f055c54ee2abb6e19420ee88e3?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
