### PR TITLE
[WIP] chore(router): validate transformer responses for duplicate job ids

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
-	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	"golang.org/x/sync/errgroup"
 
@@ -780,11 +779,7 @@ func (worker *workerT) processDestinationJobs() {
 		// elements in routerJobResponses have pointer to the right job.
 		_destinationJob := destinationJob
 
-		// TODO: remove this once we enforce the necessary validations in the transformer's response
-		dedupedJobMetadata := lo.UniqBy(_destinationJob.JobMetadataArray, func(jobMetadata types.JobMetadataT) int64 {
-			return jobMetadata.JobID
-		})
-		for _, destinationJobMetadata := range dedupedJobMetadata {
+		for _, destinationJobMetadata := range _destinationJob.JobMetadataArray {
 			_destinationJobMetadata := destinationJobMetadata
 			// assigning the destinationJobMetadata to a local variable (_destinationJobMetadata), so that
 			// elements in routerJobResponses have pointer to the right destinationJobMetadata.

--- a/router/types/types.go
+++ b/router/types/types.go
@@ -47,6 +47,12 @@ func (dj *DestinationJobT) JobIDs() map[int64]struct{} {
 	return jobIDs
 }
 
+func (dj *DestinationJobT) DuplicateJobIDs() []int64 {
+	return lo.FindDuplicates(lo.Map(dj.JobMetadataArray, func(m JobMetadataT, _ int) int64 {
+		return m.JobID
+	}))
+}
+
 // JobMetadataT holds the job metadata
 type JobMetadataT struct {
 	UserID             string          `json:"userId"`


### PR DESCRIPTION
# Description

Transformer shouldn't include the same job id more than once in the metadata field

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=5228050c2a6248189dcd738b151449bf&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
