### PR TITLE
fix(warehouse): added support for filtering on the uploads and calculating aborted events for task_run_id

### DIFF
--- a/warehouse/internal/repo/upload_test.go
+++ b/warehouse/internal/repo/upload_test.go
@@ -124,7 +124,6 @@ func TestUploads_Count(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(2), count)
 	})
-
 }
 
 func TestUploads_Get(t *testing.T) {

--- a/warehouse/internal/repo/upload_test.go
+++ b/warehouse/internal/repo/upload_test.go
@@ -81,7 +81,7 @@ func TestUploads_Count(t *testing.T) {
 		stagingID, err := repoStaging.Insert(ctx, &model.StagingFileWithSchema{})
 		require.NoError(t, err)
 
-		id, err := repoUpload.CreateWithStagingFiles(ctx, uploads[i], []model.StagingFile{{
+		id, err := repoUpload.CreateWithStagingFiles(ctx, uploads[i], []*model.StagingFile{{
 			ID:              stagingID,
 			SourceID:        uploads[i].SourceID,
 			DestinationID:   uploads[i].DestinationID,

--- a/warehouse/internal/repo/upload_test.go
+++ b/warehouse/internal/repo/upload_test.go
@@ -15,6 +15,118 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestUploads_Count(t *testing.T) {
+	db, ctx := setupDB(t), context.Background()
+
+	now := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	repoUpload := repo.NewUploads(db, repo.WithNow(func() time.Time {
+		return now
+	}))
+	repoStaging := repo.NewStagingFiles(db, repo.WithNow(func() time.Time {
+		return now
+	}))
+
+	destType := "RS"
+
+	uploads := []model.Upload{
+		{
+			WorkspaceID:     "workspace_id",
+			Namespace:       "namespace",
+			SourceID:        "source_id",
+			DestinationID:   "destination_id",
+			DestinationType: destType,
+			Status:          model.ExportedData,
+			SourceTaskRunID: "task_run_id",
+		},
+		{
+			WorkspaceID:     "workspace_id",
+			Namespace:       "namespace",
+			SourceID:        "source_id",
+			DestinationID:   "destination_id",
+			DestinationType: destType,
+			Status:          model.Aborted,
+			SourceTaskRunID: "task_run_id",
+		},
+		{
+			WorkspaceID:     "workspace_id",
+			Namespace:       "namespace",
+			SourceID:        "source_id",
+			DestinationID:   "destination_id",
+			DestinationType: destType,
+			Status:          model.ExportingData,
+			SourceTaskRunID: "task_run_id",
+		},
+		{
+			WorkspaceID:     "workspace_id_1",
+			Namespace:       "namespace",
+			SourceID:        "source_id_1",
+			DestinationID:   "destination_id_1",
+			DestinationType: destType,
+			Status:          model.Aborted,
+			SourceTaskRunID: "task_run_id_1",
+		},
+		{
+			WorkspaceID:     "workspace_id_1",
+			Namespace:       "namespace",
+			SourceID:        "source_id_1",
+			DestinationID:   "destination_id_1",
+			DestinationType: destType,
+			Status:          model.Aborted,
+			SourceTaskRunID: "task_run_id_1",
+		},
+	}
+
+	for i := range uploads {
+
+		stagingID, err := repoStaging.Insert(ctx, &model.StagingFileWithSchema{})
+		require.NoError(t, err)
+
+		id, err := repoUpload.CreateWithStagingFiles(ctx, uploads[i], []model.StagingFile{{
+			ID:              stagingID,
+			SourceID:        uploads[i].SourceID,
+			DestinationID:   uploads[i].DestinationID,
+			SourceTaskRunID: uploads[i].SourceTaskRunID,
+		}})
+
+		require.NoError(t, err)
+
+		uploads[i].ID = id
+		uploads[i].Error = []byte("{}")
+		uploads[i].UploadSchema = model.Schema{}
+		uploads[i].MergedSchema = model.Schema{}
+		uploads[i].LoadFileType = "csv"
+		uploads[i].StagingFileStartID = int64(i + 1)
+		uploads[i].StagingFileEndID = int64(i + 1)
+	}
+
+	t.Run("query to count with not equal filters works correctly", func(t *testing.T) {
+		t.Parallel()
+
+		count, err := repoUpload.Count(ctx, []repo.FilterBy{
+			{Key: "source_id", Value: "source_id"},
+			{Key: "metadata->>'source_task_run_id'", Value: "task_run_id"},
+			{Key: "status", NotEquals: true, Value: model.ExportedData},
+			{Key: "status", NotEquals: true, Value: model.Aborted},
+		}...)
+
+		require.NoError(t, err)
+		require.Equal(t, int64(1), count)
+	})
+
+	t.Run("query to count with equal filters works correctly", func(t *testing.T) {
+		t.Parallel()
+		count, err := repoUpload.Count(ctx, []repo.FilterBy{
+			{Key: "source_id", Value: "source_id_1"},
+			{Key: "metadata->>'source_task_run_id'", Value: "task_run_id_1"},
+			{Key: "status", Value: model.Aborted},
+		}...)
+
+		require.NoError(t, err)
+		require.Equal(t, int64(2), count)
+	})
+
+}
+
 func TestUploads_Get(t *testing.T) {
 	ctx := context.Background()
 

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -297,6 +297,7 @@ type PendingEventsResponse struct {
 	PendingEvents            bool  `json:"pending_events"`
 	PendingStagingFilesCount int64 `json:"pending_staging_files"`
 	PendingUploadCount       int64 `json:"pending_uploads"`
+	AbortedEvents            bool  `json:"aborted_events"`
 }
 
 type TriggerUploadRequest struct {

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -1161,8 +1161,8 @@ func pendingEventsHandler(w http.ResponseWriter, r *http.Request) {
 	sourceID, taskRunID := pendingEventsReq.SourceID, pendingEventsReq.TaskRunID
 	// return error if source id is empty
 	if sourceID == "" || taskRunID == "" {
-		pkgLogger.Errorf("[WH]: pending-events:  Empty source_id or task_run_id ")
-		http.Error(w, "empty source id", http.StatusBadRequest)
+		pkgLogger.Errorf("empty source_id or task_run_id in the pending events request")
+		http.Error(w, "empty source_id or task_run_id", http.StatusBadRequest)
 		return
 	}
 
@@ -1205,9 +1205,10 @@ func pendingEventsHandler(w http.ResponseWriter, r *http.Request) {
 	pendingUploadCount, err = getFilteredCount(ctx, filters...)
 
 	if err != nil {
-		err := fmt.Errorf("getting pending uploads count: %v", err)
-		pkgLogger.Errorf("[WH]: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		pkgLogger.Errorf("getting pending uploads count", "error", err)
+		http.Error(w, fmt.Sprintf(
+			"getting pending uploads count: %s", err.Error()),
+			http.StatusInternalServerError)
 		return
 	}
 
@@ -1219,9 +1220,8 @@ func pendingEventsHandler(w http.ResponseWriter, r *http.Request) {
 
 	abortedUploadCount, err := getFilteredCount(ctx, filters...)
 	if err != nil {
-		err := fmt.Errorf("getting aborted uploads count : %v", err)
-		pkgLogger.Errorf("[WH]: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		pkgLogger.Errorf("getting aborted uploads count", "error", err.Error())
+		http.Error(w, fmt.Sprintf("getting aborted uploads count: %s", err), http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION

# Description

The PR augments the capability of repo to count over wh_uploads using generic filters which gets used in the pending events API when calculating pending events and aborted events.

## Notion Ticket

https://www.notion.so/rudderstacks/Fix-the-Pending-Events-API-to-return-always-if-the-events-have-been-aborted-in-a-boolean-flag-e251b60a20484513ad802fe4ed50d790

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
