### PR TITLE
chore(warehouse): log improvements for total count in warehouse integrations

### DIFF
--- a/warehouse/integrations/azure-synapse/azure-synapse.go
+++ b/warehouse/integrations/azure-synapse/azure-synapse.go
@@ -81,7 +81,7 @@ var mssqlDataTypesMapToRudder = map[string]string{
 }
 
 type HandleT struct {
-	Db             *sql.DB
+	DB             *sql.DB
 	Namespace      string
 	ObjectStorage  string
 	Warehouse      warehouseutils.Warehouse
@@ -257,13 +257,13 @@ func (as *HandleT) loadTable(tableName string, tableSchemaInUpload warehouseutil
 	sqlStatement := fmt.Sprintf(`select top 0 * into %[1]s.%[2]s from %[1]s.%[3]s`, as.Namespace, stagingTableName, tableName)
 
 	pkgLogger.Debugf("AZ: Creating temporary table for table:%s at %s\n", tableName, sqlStatement)
-	_, err = as.Db.Exec(sqlStatement)
+	_, err = as.DB.Exec(sqlStatement)
 	if err != nil {
 		pkgLogger.Errorf("AZ: Error creating temporary table for table:%s: %v\n", tableName, err)
 		return
 	}
 
-	txn, err := as.Db.Begin()
+	txn, err := as.DB.Begin()
 	if err != nil {
 		pkgLogger.Errorf("AZ: Error while beginning a transaction in db for loading in table:%s: %v", tableName, err)
 		return
@@ -538,7 +538,7 @@ func (as *HandleT) loadUserTables() (errorMap map[string]error) {
 											`, as.Namespace, as.Namespace+"."+warehouseutils.UsersTable, as.Namespace+"."+identifyStagingTable, strings.Join(userColNames, ","), as.Namespace+"."+unionStagingTableName)
 
 	pkgLogger.Debugf("AZ: Creating staging table for union of users table with identify staging table: %s\n", sqlStatement)
-	_, err = as.Db.Exec(sqlStatement)
+	_, err = as.DB.Exec(sqlStatement)
 	if err != nil {
 		errorMap[warehouseutils.UsersTable] = err
 		return
@@ -557,7 +557,7 @@ func (as *HandleT) loadUserTables() (errorMap map[string]error) {
 	)
 
 	pkgLogger.Debugf("AZ: Creating staging table for users: %s\n", sqlStatement)
-	_, err = as.Db.Exec(sqlStatement)
+	_, err = as.DB.Exec(sqlStatement)
 	if err != nil {
 		pkgLogger.Errorf("AZ: Error Creating staging table for users: %s\n", sqlStatement)
 		errorMap[warehouseutils.UsersTable] = err
@@ -565,7 +565,7 @@ func (as *HandleT) loadUserTables() (errorMap map[string]error) {
 	}
 
 	// BEGIN TRANSACTION
-	tx, err := as.Db.Begin()
+	tx, err := as.DB.Begin()
 	if err != nil {
 		errorMap[warehouseutils.UsersTable] = err
 		return
@@ -612,7 +612,7 @@ func (as *HandleT) CreateSchema() (err error) {
     EXEC('CREATE SCHEMA [%s]');
 `, as.Namespace, as.Namespace)
 	pkgLogger.Infof("SYNAPSE: Creating schema name in synapse for AZ:%s : %v", as.Warehouse.Destination.ID, sqlStatement)
-	_, err = as.Db.Exec(sqlStatement)
+	_, err = as.DB.Exec(sqlStatement)
 	if err == io.EOF {
 		return nil
 	}
@@ -621,7 +621,7 @@ func (as *HandleT) CreateSchema() (err error) {
 
 func (as *HandleT) dropStagingTable(stagingTableName string) {
 	pkgLogger.Infof("AZ: dropping table %+v\n", stagingTableName)
-	_, err := as.Db.Exec(fmt.Sprintf(`IF OBJECT_ID ('%[1]s','U') IS NOT NULL DROP TABLE %[1]s;`, as.Namespace+"."+stagingTableName))
+	_, err := as.DB.Exec(fmt.Sprintf(`IF OBJECT_ID ('%[1]s','U') IS NOT NULL DROP TABLE %[1]s;`, as.Namespace+"."+stagingTableName))
 	if err != nil {
 		pkgLogger.Errorf("AZ:  Error dropping staging table %s in synapse: %v", as.Namespace+"."+stagingTableName, err)
 	}
@@ -632,7 +632,7 @@ func (as *HandleT) createTable(name string, columns map[string]string) (err erro
 	CREATE TABLE %[1]s ( %v )`, name, columnsWithDataTypes(columns, ""))
 
 	pkgLogger.Infof("AZ: Creating table in synapse for AZ:%s : %v", as.Warehouse.Destination.ID, sqlStatement)
-	_, err = as.Db.Exec(sqlStatement)
+	_, err = as.DB.Exec(sqlStatement)
 	return
 }
 
@@ -645,7 +645,7 @@ func (as *HandleT) CreateTable(tableName string, columnMap map[string]string) (e
 func (as *HandleT) DropTable(tableName string) (err error) {
 	sqlStatement := `DROP TABLE "%[1]s"."%[2]s"`
 	pkgLogger.Infof("AZ: Dropping table in synapse for AZ:%s : %v", as.Warehouse.Destination.ID, sqlStatement)
-	_, err = as.Db.Exec(fmt.Sprintf(sqlStatement, as.Namespace, tableName))
+	_, err = as.DB.Exec(fmt.Sprintf(sqlStatement, as.Namespace, tableName))
 	return
 }
 
@@ -689,7 +689,7 @@ func (as *HandleT) AddColumns(tableName string, columnsInfo []warehouseutils.Col
 	query += ";"
 
 	pkgLogger.Infof("AZ: Adding columns for destinationID: %s, tableName: %s with query: %v", as.Warehouse.Destination.ID, tableName, query)
-	_, err = as.Db.Exec(query)
+	_, err = as.DB.Exec(query)
 	return
 }
 
@@ -699,16 +699,16 @@ func (*HandleT) AlterColumn(_, _, _ string) (model.AlterTableResponse, error) {
 
 func (as *HandleT) TestConnection(warehouse warehouseutils.Warehouse) (err error) {
 	as.Warehouse = warehouse
-	as.Db, err = connect(as.getConnectionCredentials())
+	as.DB, err = connect(as.getConnectionCredentials())
 	if err != nil {
 		return
 	}
-	defer as.Db.Close()
+	defer as.DB.Close()
 
 	ctx, cancel := context.WithTimeout(context.TODO(), as.ConnectTimeout)
 	defer cancel()
 
-	err = as.Db.PingContext(ctx)
+	err = as.DB.PingContext(ctx)
 	if err == context.DeadlineExceeded {
 		return fmt.Errorf("connection testing timed out after %d sec", as.ConnectTimeout/time.Second)
 	}
@@ -725,18 +725,18 @@ func (as *HandleT) Setup(warehouse warehouseutils.Warehouse, uploader warehouseu
 	as.Uploader = uploader
 	as.ObjectStorage = warehouseutils.ObjectStorageType(warehouseutils.AZURE_SYNAPSE, warehouse.Destination.Config, as.Uploader.UseRudderStorage())
 
-	as.Db, err = connect(as.getConnectionCredentials())
+	as.DB, err = connect(as.getConnectionCredentials())
 	return err
 }
 
 func (as *HandleT) CrashRecover(warehouse warehouseutils.Warehouse) (err error) {
 	as.Warehouse = warehouse
 	as.Namespace = warehouse.Namespace
-	as.Db, err = connect(as.getConnectionCredentials())
+	as.DB, err = connect(as.getConnectionCredentials())
 	if err != nil {
 		return err
 	}
-	defer as.Db.Close()
+	defer as.DB.Close()
 	as.dropDanglingStagingTables()
 	return
 }
@@ -754,7 +754,7 @@ func (as *HandleT) dropDanglingStagingTables() bool {
 		as.Namespace,
 		fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider)),
 	)
-	rows, err := as.Db.Query(sqlStatement)
+	rows, err := as.DB.Query(sqlStatement)
 	if err != nil {
 		pkgLogger.Errorf("WH: SYNAPSE: Error dropping dangling staging tables in synapse: %v\nQuery: %s\n", err, sqlStatement)
 		return false
@@ -773,7 +773,7 @@ func (as *HandleT) dropDanglingStagingTables() bool {
 	pkgLogger.Infof("WH: SYNAPSE: Dropping dangling staging tables: %+v  %+v\n", len(stagingTableNames), stagingTableNames)
 	delSuccess := true
 	for _, stagingTableName := range stagingTableNames {
-		_, err := as.Db.Exec(fmt.Sprintf(`DROP TABLE "%[1]s"."%[2]s"`, as.Namespace, stagingTableName))
+		_, err := as.DB.Exec(fmt.Sprintf(`DROP TABLE "%[1]s"."%[2]s"`, as.Namespace, stagingTableName))
 		if err != nil {
 			pkgLogger.Errorf("WH: SYNAPSE:  Error dropping dangling staging table: %s in redshift: %v\n", stagingTableName, err)
 			delSuccess = false
@@ -854,10 +854,10 @@ func (as *HandleT) LoadTable(tableName string) error {
 }
 
 func (as *HandleT) Cleanup() {
-	if as.Db != nil {
+	if as.DB != nil {
 		// extra check aside dropStagingTable(table)
 		as.dropDanglingStagingTables()
-		as.Db.Close()
+		as.DB.Close()
 	}
 }
 
@@ -873,13 +873,20 @@ func (*HandleT) DownloadIdentityRules(*misc.GZipWriter) (err error) {
 	return
 }
 
-func (as *HandleT) GetTotalCountInTable(ctx context.Context, tableName string) (total int64, err error) {
-	sqlStatement := fmt.Sprintf(`SELECT count(*) FROM "%[1]s"."%[2]s"`, as.Namespace, tableName)
-	err = as.Db.QueryRowContext(ctx, sqlStatement).Scan(&total)
-	if err != nil {
-		pkgLogger.Errorf(`AZ: Error getting total count in table %s:%s`, as.Namespace, tableName)
-	}
-	return
+func (as *HandleT) GetTotalCountInTable(ctx context.Context, tableName string) (int64, error) {
+	var (
+		total        int64
+		err          error
+		sqlStatement string
+	)
+	sqlStatement = fmt.Sprintf(`
+		SELECT count(*) FROM "%[1]s"."%[2]s";
+	`,
+		as.Namespace,
+		tableName,
+	)
+	err = as.DB.QueryRowContext(ctx, sqlStatement).Scan(&total)
+	return total, err
 }
 
 func (as *HandleT) Connect(warehouse warehouseutils.Warehouse) (client.Client, error) {
@@ -900,7 +907,7 @@ func (as *HandleT) LoadTestTable(_, tableName string, payloadMap map[string]inte
 		fmt.Sprintf(`"%s", "%s"`, "id", "val"),
 		fmt.Sprintf(`'%d', '%s'`, payloadMap["id"], payloadMap["val"]),
 	)
-	_, err = as.Db.Exec(sqlStatement)
+	_, err = as.DB.Exec(sqlStatement)
 	return
 }
 

--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -1129,23 +1129,40 @@ func (bq *HandleT) DownloadIdentityRules(gzWriter *misc.GZipWriter) (err error) 
 	return
 }
 
-func (bq *HandleT) GetTotalCountInTable(ctx context.Context, tableName string) (total int64, err error) {
-	sqlStatement := fmt.Sprintf(`SELECT count(*) FROM %[1]s.%[2]s`, bq.namespace, tableName)
-	it, err := bq.db.Query(sqlStatement).Read(ctx)
-	if err != nil {
-		return 0, err
+func (bq *HandleT) GetTotalCountInTable(ctx context.Context, tableName string) (int64, error) {
+	var (
+		total        int64
+		err          error
+		sqlStatement string
+		ok           bool
+
+		it     *bigquery.RowIterator
+		values []bigquery.Value
+	)
+	sqlStatement = fmt.Sprintf(`
+		SELECT count(*) FROM %[1]s.%[2]s;
+	`,
+		bq.namespace,
+		tableName,
+	)
+
+	if it, err = bq.db.Query(sqlStatement).Read(ctx); err != nil {
+		return 0, fmt.Errorf("creating row iterator: %w", err)
 	}
-	var values []bigquery.Value
+
 	err = it.Next(&values)
 	if err == iterator.Done {
 		return 0, nil
 	}
 	if err != nil {
-		pkgLogger.Errorf("BQ: Error in processing totalRowsCount: %v", err)
-		return
+		return 0, fmt.Errorf("iterating through rows: %w", err)
 	}
-	total, _ = values[0].(int64)
-	return
+
+	if total, ok = values[0].(int64); !ok {
+		return 0, fmt.Errorf("converting value to int64: %w", err)
+	}
+
+	return total, nil
 }
 
 func (bq *HandleT) Connect(warehouse warehouseutils.Warehouse) (client.Client, error) {

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -1165,13 +1165,20 @@ func (*Clickhouse) IsEmpty(_ warehouseutils.Warehouse) (empty bool, err error) {
 	return
 }
 
-func (ch *Clickhouse) GetTotalCountInTable(ctx context.Context, tableName string) (total int64, err error) {
-	sqlStatement := fmt.Sprintf(`SELECT count(*) FROM "%[1]s"."%[2]s"`, ch.Namespace, tableName)
+func (ch *Clickhouse) GetTotalCountInTable(ctx context.Context, tableName string) (int64, error) {
+	var (
+		total        int64
+		err          error
+		sqlStatement string
+	)
+	sqlStatement = fmt.Sprintf(`
+		SELECT count(*) FROM "%[1]s"."%[2]s";
+	`,
+		ch.Namespace,
+		tableName,
+	)
 	err = ch.DB.QueryRowContext(ctx, sqlStatement).Scan(&total)
-	if err != nil {
-		ch.Logger.Errorf(`CH: Error getting total count in table %s:%s`, ch.Namespace, tableName)
-	}
-	return
+	return total, err
 }
 
 func (ch *Clickhouse) Connect(warehouse warehouseutils.Warehouse) (client.Client, error) {

--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -1090,7 +1090,9 @@ func (dl *Deltalake) GetTotalCountInTable(ctx context.Context, tableName string)
 	if err != nil {
 		return 0, fmt.Errorf("fetching table count: %w", err)
 	}
-
+	if response.GetErrorCode() != "" {
+		return 0, fmt.Errorf("fetching table count: %s", response.GetErrorMessage())
+	}
 	return response.GetCount(), nil
 }
 

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -650,7 +650,7 @@ func TestDeltalake_GetTotalCountInTable(t *testing.T) {
 				ErrorCode:    "42xxx",
 				ErrorMessage: "permission error",
 			},
-			wantError: errors.New("fetching table count with response: permission error"),
+			wantError: errors.New("fetching table count: permission error"),
 		},
 		{
 			name:  "Success",

--- a/warehouse/integrations/mssql/mssql.go
+++ b/warehouse/integrations/mssql/mssql.go
@@ -85,7 +85,7 @@ var mssqlDataTypesMapToRudder = map[string]string{
 }
 
 type HandleT struct {
-	Db             *sql.DB
+	DB             *sql.DB
 	Namespace      string
 	ObjectStorage  string
 	Warehouse      warehouseutils.Warehouse
@@ -268,7 +268,7 @@ func (ms *HandleT) DeleteBy(tableNames []string, params warehouseutils.DeleteByP
 		pkgLogger.Debugf("MSSQL: Executing the statement %v", sqlStatement)
 
 		if enableDeleteByJobs {
-			_, err = ms.Db.Exec(sqlStatement,
+			_, err = ms.DB.Exec(sqlStatement,
 				sql.Named("jobrunid", params.JobRunId),
 				sql.Named("taskrunid", params.TaskRunId),
 				sql.Named("sourceid", params.SourceId),
@@ -296,7 +296,7 @@ func (ms *HandleT) loadTable(tableName string, tableSchemaInUpload warehouseutil
 		return
 	}
 
-	txn, err := ms.Db.Begin()
+	txn, err := ms.DB.Begin()
 	if err != nil {
 		pkgLogger.Errorf("MS: Error while beginning a transaction in db for loading in table:%s: %v", tableName, err)
 		return
@@ -592,7 +592,7 @@ func (ms *HandleT) loadUserTables() (errorMap map[string]error) {
 											`, ms.Namespace, ms.Namespace+"."+warehouseutils.UsersTable, ms.Namespace+"."+identifyStagingTable, strings.Join(userColNames, ","), ms.Namespace+"."+unionStagingTableName)
 
 	pkgLogger.Debugf("MS: Creating staging table for union of users table with identify staging table: %s\n", sqlStatement)
-	_, err = ms.Db.Exec(sqlStatement)
+	_, err = ms.DB.Exec(sqlStatement)
 	if err != nil {
 		errorMap[warehouseutils.UsersTable] = err
 		return
@@ -611,7 +611,7 @@ func (ms *HandleT) loadUserTables() (errorMap map[string]error) {
 	)
 
 	pkgLogger.Debugf("MS: Creating staging table for users: %s\n", sqlStatement)
-	_, err = ms.Db.Exec(sqlStatement)
+	_, err = ms.DB.Exec(sqlStatement)
 	if err != nil {
 		pkgLogger.Errorf("MS: Error Creating staging table for users: %s\n", sqlStatement)
 		errorMap[warehouseutils.UsersTable] = err
@@ -619,7 +619,7 @@ func (ms *HandleT) loadUserTables() (errorMap map[string]error) {
 	}
 
 	// BEGIN TRANSACTION
-	tx, err := ms.Db.Begin()
+	tx, err := ms.DB.Begin()
 	if err != nil {
 		errorMap[warehouseutils.UsersTable] = err
 		return
@@ -662,7 +662,7 @@ func (ms *HandleT) CreateSchema() (err error) {
     EXEC('CREATE SCHEMA [%s]');
 `, ms.Namespace, ms.Namespace)
 	pkgLogger.Infof("MSSQL: Creating schema name in mssql for MS:%s : %v", ms.Warehouse.Destination.ID, sqlStatement)
-	_, err = ms.Db.Exec(sqlStatement)
+	_, err = ms.DB.Exec(sqlStatement)
 	if err == io.EOF {
 		return nil
 	}
@@ -671,7 +671,7 @@ func (ms *HandleT) CreateSchema() (err error) {
 
 func (ms *HandleT) dropStagingTable(stagingTableName string) {
 	pkgLogger.Infof("MS: dropping table %+v\n", stagingTableName)
-	_, err := ms.Db.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %s`, ms.Namespace+"."+stagingTableName))
+	_, err := ms.DB.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %s`, ms.Namespace+"."+stagingTableName))
 	if err != nil {
 		pkgLogger.Errorf("MS:  Error dropping staging table %s in mssql: %v", ms.Namespace+"."+stagingTableName, err)
 	}
@@ -682,7 +682,7 @@ func (ms *HandleT) createTable(name string, columns map[string]string) (err erro
 	CREATE TABLE %[1]s ( %v )`, name, ColumnsWithDataTypes(columns, ""))
 
 	pkgLogger.Infof("MS: Creating table in mssql for MS:%s : %v", ms.Warehouse.Destination.ID, sqlStatement)
-	_, err = ms.Db.Exec(sqlStatement)
+	_, err = ms.DB.Exec(sqlStatement)
 	return
 }
 
@@ -695,7 +695,7 @@ func (ms *HandleT) CreateTable(tableName string, columnMap map[string]string) (e
 func (ms *HandleT) DropTable(tableName string) (err error) {
 	sqlStatement := `DROP TABLE "%[1]s"."%[2]s"`
 	pkgLogger.Infof("AZ: Dropping table in synapse for AZ:%s : %v", ms.Warehouse.Destination.ID, sqlStatement)
-	_, err = ms.Db.Exec(fmt.Sprintf(sqlStatement, ms.Namespace, tableName))
+	_, err = ms.DB.Exec(fmt.Sprintf(sqlStatement, ms.Namespace, tableName))
 	return
 }
 
@@ -739,7 +739,7 @@ func (ms *HandleT) AddColumns(tableName string, columnsInfo []warehouseutils.Col
 	query += ";"
 
 	pkgLogger.Infof("MS: Adding columns for destinationID: %s, tableName: %s with query: %v", ms.Warehouse.Destination.ID, tableName, query)
-	_, err = ms.Db.Exec(query)
+	_, err = ms.DB.Exec(query)
 	return
 }
 
@@ -755,16 +755,16 @@ func (ms *HandleT) TestConnection(warehouse warehouseutils.Warehouse) (err error
 		warehouse.Destination.Config,
 		misc.IsConfiguredToUseRudderObjectStorage(ms.Warehouse.Destination.Config),
 	)
-	ms.Db, err = Connect(ms.getConnectionCredentials())
+	ms.DB, err = Connect(ms.getConnectionCredentials())
 	if err != nil {
 		return
 	}
-	defer ms.Db.Close()
+	defer ms.DB.Close()
 
 	ctx, cancel := context.WithTimeout(context.TODO(), ms.ConnectTimeout)
 	defer cancel()
 
-	err = ms.Db.PingContext(ctx)
+	err = ms.DB.PingContext(ctx)
 	if err == context.DeadlineExceeded {
 		return fmt.Errorf("connection testing timed out after %d sec", ms.ConnectTimeout/time.Second)
 	}
@@ -781,18 +781,18 @@ func (ms *HandleT) Setup(warehouse warehouseutils.Warehouse, uploader warehouseu
 	ms.Uploader = uploader
 	ms.ObjectStorage = warehouseutils.ObjectStorageType(warehouseutils.MSSQL, warehouse.Destination.Config, ms.Uploader.UseRudderStorage())
 
-	ms.Db, err = Connect(ms.getConnectionCredentials())
+	ms.DB, err = Connect(ms.getConnectionCredentials())
 	return err
 }
 
 func (ms *HandleT) CrashRecover(warehouse warehouseutils.Warehouse) (err error) {
 	ms.Warehouse = warehouse
 	ms.Namespace = warehouse.Namespace
-	ms.Db, err = Connect(ms.getConnectionCredentials())
+	ms.DB, err = Connect(ms.getConnectionCredentials())
 	if err != nil {
 		return err
 	}
-	defer ms.Db.Close()
+	defer ms.DB.Close()
 	ms.dropDanglingStagingTables()
 	return
 }
@@ -810,7 +810,7 @@ func (ms *HandleT) dropDanglingStagingTables() bool {
 		ms.Namespace,
 		fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider)),
 	)
-	rows, err := ms.Db.Query(sqlStatement)
+	rows, err := ms.DB.Query(sqlStatement)
 	if err != nil {
 		pkgLogger.Errorf("WH: MSSQL: Error dropping dangling staging tables in MSSQL: %v\nQuery: %s\n", err, sqlStatement)
 		return false
@@ -829,7 +829,7 @@ func (ms *HandleT) dropDanglingStagingTables() bool {
 	pkgLogger.Infof("WH: MSSQL: Dropping dangling staging tables: %+v  %+v\n", len(stagingTableNames), stagingTableNames)
 	delSuccess := true
 	for _, stagingTableName := range stagingTableNames {
-		_, err := ms.Db.Exec(fmt.Sprintf(`DROP TABLE "%[1]s"."%[2]s"`, ms.Namespace, stagingTableName))
+		_, err := ms.DB.Exec(fmt.Sprintf(`DROP TABLE "%[1]s"."%[2]s"`, ms.Namespace, stagingTableName))
 		if err != nil {
 			pkgLogger.Errorf("WH: MSSQL:  Error dropping dangling staging table: %s in redshift: %v\n", stagingTableName, err)
 			delSuccess = false
@@ -909,10 +909,10 @@ func (ms *HandleT) LoadTable(tableName string) error {
 }
 
 func (ms *HandleT) Cleanup() {
-	if ms.Db != nil {
+	if ms.DB != nil {
 		// extra check aside dropStagingTable(table)
 		ms.dropDanglingStagingTables()
-		ms.Db.Close()
+		ms.DB.Close()
 	}
 }
 
@@ -928,13 +928,20 @@ func (*HandleT) DownloadIdentityRules(*misc.GZipWriter) (err error) {
 	return
 }
 
-func (ms *HandleT) GetTotalCountInTable(ctx context.Context, tableName string) (total int64, err error) {
-	sqlStatement := fmt.Sprintf(`SELECT count(*) FROM "%[1]s"."%[2]s"`, ms.Namespace, tableName)
-	err = ms.Db.QueryRowContext(ctx, sqlStatement).Scan(&total)
-	if err != nil {
-		pkgLogger.Errorf(`MS: Error getting total count in table %s:%s`, ms.Namespace, tableName)
-	}
-	return
+func (ms *HandleT) GetTotalCountInTable(ctx context.Context, tableName string) (int64, error) {
+	var (
+		total        int64
+		err          error
+		sqlStatement string
+	)
+	sqlStatement = fmt.Sprintf(`
+		SELECT count(*) FROM "%[1]s"."%[2]s";
+	`,
+		ms.Namespace,
+		tableName,
+	)
+	err = ms.DB.QueryRowContext(ctx, sqlStatement).Scan(&total)
+	return total, err
 }
 
 func (ms *HandleT) Connect(warehouse warehouseutils.Warehouse) (client.Client, error) {
@@ -960,7 +967,7 @@ func (ms *HandleT) LoadTestTable(_, tableName string, payloadMap map[string]inte
 		fmt.Sprintf(`"%s", "%s"`, "id", "val"),
 		fmt.Sprintf(`'%d', '%s'`, payloadMap["id"], payloadMap["val"]),
 	)
-	_, err = ms.Db.Exec(sqlStatement)
+	_, err = ms.DB.Exec(sqlStatement)
 	return
 }
 

--- a/warehouse/integrations/postgres/postgres.go
+++ b/warehouse/integrations/postgres/postgres.go
@@ -974,13 +974,20 @@ func (*Handle) DownloadIdentityRules(*misc.GZipWriter) (err error) {
 	return
 }
 
-func (pg *Handle) GetTotalCountInTable(ctx context.Context, tableName string) (total int64, err error) {
-	sqlStatement := fmt.Sprintf(`SELECT count(*) FROM "%[1]s"."%[2]s"`, pg.Namespace, tableName)
+func (pg *Handle) GetTotalCountInTable(ctx context.Context, tableName string) (int64, error) {
+	var (
+		total        int64
+		err          error
+		sqlStatement string
+	)
+	sqlStatement = fmt.Sprintf(`
+		SELECT count(*) FROM "%[1]s"."%[2]s";
+	`,
+		pg.Namespace,
+		tableName,
+	)
 	err = pg.DB.QueryRowContext(ctx, sqlStatement).Scan(&total)
-	if err != nil {
-		pg.logger.Errorf(`PG: Error getting total count in table %s:%s`, pg.Namespace, tableName)
-	}
-	return
+	return total, err
 }
 
 func (pg *Handle) Connect(warehouse warehouseutils.Warehouse) (client.Client, error) {

--- a/warehouse/integrations/postgres/postgres.go
+++ b/warehouse/integrations/postgres/postgres.go
@@ -142,7 +142,7 @@ type Handle struct {
 	EnableSQLStatementExecutionPlanWorkspaceIDs []string
 }
 
-type CredentialsT struct {
+type Credentials struct {
 	Host       string
 	DBName     string
 	User       string
@@ -181,7 +181,7 @@ func WithConfig(h *Handle, config *config.Config) {
 	h.EnableSQLStatementExecutionPlanWorkspaceIDs = config.GetStringSlice("Warehouse.postgres.EnableSQLStatementExecutionPlanWorkspaceIDs", nil)
 }
 
-func Connect(cred CredentialsT) (*sql.DB, error) {
+func Connect(cred Credentials) (*sql.DB, error) {
 	dsn := url.URL{
 		Scheme: "postgres",
 		Host:   fmt.Sprintf("%s:%s", cred.Host, cred.Port),
@@ -229,9 +229,9 @@ func Init() {
 	pkgLogger = logger.NewLogger().Child("warehouse").Child("postgres")
 }
 
-func (pg *Handle) getConnectionCredentials() CredentialsT {
+func (pg *Handle) getConnectionCredentials() Credentials {
 	sslMode := warehouseutils.GetConfigValue(sslMode, pg.Warehouse)
-	creds := CredentialsT{
+	creds := Credentials{
 		Host:     warehouseutils.GetConfigValue(host, pg.Warehouse),
 		DBName:   warehouseutils.GetConfigValue(dbName, pg.Warehouse),
 		User:     warehouseutils.GetConfigValue(user, pg.Warehouse),

--- a/warehouse/integrations/postgres/postgres_test.go
+++ b/warehouse/integrations/postgres/postgres_test.go
@@ -32,7 +32,7 @@ func TestIntegrationPostgresThroughTunnelling(t *testing.T) {
 	postgres.Init()
 
 	configurations := testhelper.PopulateTemplateConfigurations()
-	db, err := postgres.Connect(postgres.CredentialsT{
+	db, err := postgres.Connect(postgres.Credentials{
 		DBName:   configurations["privatePostgresDatabase"],
 		Password: configurations["privatePostgresPassword"],
 		User:     configurations["privatePostgresUser"],
@@ -127,7 +127,7 @@ func TestIntegrationPostgres(t *testing.T) {
 
 	postgres.Init()
 
-	db, err := postgres.Connect(postgres.CredentialsT{
+	db, err := postgres.Connect(postgres.Credentials{
 		DBName:   "rudderdb",
 		Password: "rudder-password",
 		User:     "rudder",

--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -1019,13 +1019,20 @@ func (*Redshift) DownloadIdentityRules(*misc.GZipWriter) (err error) {
 	return
 }
 
-func (rs *Redshift) GetTotalCountInTable(ctx context.Context, tableName string) (total int64, err error) {
-	sqlStatement := fmt.Sprintf(`SELECT count(*) FROM "%[1]s"."%[2]s"`, rs.Namespace, tableName)
+func (rs *Redshift) GetTotalCountInTable(ctx context.Context, tableName string) (int64, error) {
+	var (
+		total        int64
+		err          error
+		sqlStatement string
+	)
+	sqlStatement = fmt.Sprintf(`
+		SELECT count(*) FROM "%[1]s"."%[2]s";
+	`,
+		rs.Namespace,
+		tableName,
+	)
 	err = rs.DB.QueryRowContext(ctx, sqlStatement).Scan(&total)
-	if err != nil {
-		rs.Logger.Errorf(`RS: Error getting total count in table %s:%s`, rs.Namespace, tableName)
-	}
-	return
+	return total, err
 }
 
 func (rs *Redshift) Connect(warehouse warehouseutils.Warehouse) (client.Client, error) {

--- a/warehouse/integrations/testhelper/setup.go
+++ b/warehouse/integrations/testhelper/setup.go
@@ -188,7 +188,7 @@ func (w *WareHouseTest) VerifyModifiedEvents(t testing.TB) {
 func SetUpJobsDB(t testing.TB) *sql.DB {
 	t.Helper()
 
-	pgCredentials := &postgres.CredentialsT{
+	pgCredentials := &postgres.Credentials{
 		DBName:   "jobsdb",
 		Password: "password",
 		User:     "rudder",


### PR DESCRIPTION
# Description

Since we are already logging the error at the caller function, we don't want to log it twice. This is creating too much noise for the `ERROR` logs.

## Notion Ticket

https://www.notion.so/rudderstacks/Log-improvement-for-Total-count-in-warehouse-integrations-fce52fb18a0d4b16947ea2900e1ba02e?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
