### PR TITLE
chore: drop column only if exists

### DIFF
--- a/sql/migrations/reports/000003_alter_reports_remove_source_batch_id.up.sql
+++ b/sql/migrations/reports/000003_alter_reports_remove_source_batch_id.up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE reports
-DROP COLUMN source_batch_id,
-DROP COLUMN source_task_id;
+DROP COLUMN IF EXISTS source_batch_id,
+DROP COLUMN IF EXISTS source_task_id;


### PR DESCRIPTION
# Description
Drop Column only if it exists in reports migration

## Notion Ticket

https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=94f69f8b3ab84461adf0aab881da2cde&pm=s

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
