### PR TITLE
chore: dedup destination metadata in router based on job id

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	"golang.org/x/sync/errgroup"
 
@@ -781,7 +782,11 @@ func (worker *workerT) processDestinationJobs() {
 		// elements in routerJobResponses have pointer to the right job.
 		_destinationJob := destinationJob
 
-		for _, destinationJobMetadata := range _destinationJob.JobMetadataArray {
+		// TODO: remove this once we enforce the necessary validations in the transformer's response
+		dedupedJobMetadata := lo.UniqBy(_destinationJob.JobMetadataArray, func(jobMetadata types.JobMetadataT) int64 {
+			return jobMetadata.JobID
+		})
+		for _, destinationJobMetadata := range dedupedJobMetadata {
 			_destinationJobMetadata := destinationJobMetadata
 			// assigning the destinationJobMetadata to a local variable (_destinationJobMetadata), so that
 			// elements in routerJobResponses have pointer to the right destinationJobMetadata.


### PR DESCRIPTION
# Description

Workaround until transformer adaptations are ready so that we can enforce validations introduced by #2970

## Notion Ticket
[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=5228050c2a6248189dcd738b151449bf&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
