### PR TITLE
[WIP] chore: job order guarantee improvements

### DIFF
--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -134,11 +134,7 @@ func constructParameterJSONQuery(alias string, parameterFilters []ParameterFilte
 	var allKeyValues, mandatoryKeyValues, opNullConditions []string
 	for _, parameter := range parameterFilters {
 		allKeyValues = append(allKeyValues, fmt.Sprintf(`%q:%q`, parameter.Name, parameter.Value))
-		if parameter.Optional {
-			opNullConditions = append(opNullConditions, fmt.Sprintf(`%q.parameters -> '%s' IS NULL`, alias, parameter.Name))
-		} else {
-			mandatoryKeyValues = append(mandatoryKeyValues, fmt.Sprintf(`%q:%q`, parameter.Name, parameter.Value))
-		}
+		mandatoryKeyValues = append(mandatoryKeyValues, fmt.Sprintf(`%q:%q`, parameter.Name, parameter.Value))
 	}
 	opQuery := ""
 	if len(opNullConditions) > 0 {

--- a/jobsdb/unionQuery.go
+++ b/jobsdb/unionQuery.go
@@ -182,12 +182,14 @@ func (mj *MultiTenantHandleT) getUnionDS(ctx context.Context, ds dataSetT, picku
 	if len(workspacesToQuery) == 0 {
 		return jobList, nil
 	}
+	mj.dsCacheLock.Lock()
 	for _, workspace := range workspacesToQuery {
 		if _, ok := skipCache[workspace]; !ok {
 			mj.markClearEmptyResult(ds, workspace, conditions.StateFilters, conditions.CustomValFilters, conditions.ParameterFilters,
 				willTryToSet, nil)
 		}
 	}
+	mj.dsCacheLock.Unlock()
 
 	cacheUpdateByWorkspace := make(map[string]string)
 	for _, workspace := range workspacesToQuery {
@@ -269,12 +271,14 @@ func (mj *MultiTenantHandleT) getUnionDS(ctx context.Context, ds dataSetT, picku
 
 	// do cache stuff here
 	_willTryToSet := willTryToSet
+	mj.dsCacheLock.Lock()
 	for workspace, cacheUpdate := range cacheUpdateByWorkspace {
 		if _, ok := skipCache[workspace]; !ok {
 			mj.markClearEmptyResult(ds, workspace, conditions.StateFilters, conditions.CustomValFilters, conditions.ParameterFilters,
 				cacheValue(cacheUpdate), &_willTryToSet)
 		}
 	}
+	mj.dsCacheLock.Unlock()
 
 	return jobList, err
 }

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -315,9 +315,8 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 					parameterFilters := make([]jobsdb.ParameterFilterT, 0)
 					for _, param := range jobsdb.CacheKeyParameterFilters {
 						parameterFilter := jobsdb.ParameterFilterT{
-							Name:     param,
-							Value:    key,
-							Optional: false,
+							Name:  param,
+							Value: key,
 						}
 						parameterFilters = append(parameterFilters, parameterFilter)
 					}
@@ -1314,9 +1313,8 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 	if readPerDestination {
 		parameterFilters = []jobsdb.ParameterFilterT{
 			{
-				Name:     "destination_id",
-				Value:    batchJobs.BatchDestination.Destination.ID,
-				Optional: false,
+				Name:  "destination_id",
+				Value: batchJobs.BatchDestination.Destination.ID,
 			},
 		}
 	}
@@ -1467,9 +1465,8 @@ func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.Asy
 
 	parameterFilters := []jobsdb.ParameterFilterT{
 		{
-			Name:     "destination_id",
-			Value:    asyncOutput.DestinationID,
-			Optional: false,
+			Name:  "destination_id",
+			Value: asyncOutput.DestinationID,
 		},
 	}
 
@@ -1593,9 +1590,8 @@ func (worker *workerT) constructParameterFilters(batchDest router_utils.BatchDes
 	parameterFilters := make([]jobsdb.ParameterFilterT, 0)
 	for _, key := range jobsdb.CacheKeyParameterFilters {
 		parameterFilter := jobsdb.ParameterFilterT{
-			Name:     key,
-			Value:    worker.getValueForParameter(batchDest, key),
-			Optional: false,
+			Name:  key,
+			Value: worker.getValueForParameter(batchDest, key),
 		}
 		parameterFilters = append(parameterFilters, parameterFilter)
 	}

--- a/router/types/types.go
+++ b/router/types/types.go
@@ -6,6 +6,7 @@ import (
 
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/samber/lo"
 )
 
 const (
@@ -29,6 +30,12 @@ type DestinationJobT struct {
 	Batched          bool                       `json:"batched"`
 	StatusCode       int                        `json:"statusCode"`
 	Error            string                     `json:"error"`
+}
+
+func (dj *DestinationJobT) MinJobID() int64 {
+	return lo.Min(lo.Map(dj.JobMetadataArray, func(item JobMetadataT, _ int) int64 {
+		return item.JobID
+	}))
 }
 
 // JobIDs returns the set of all job ids contained in the message


### PR DESCRIPTION
# Description

Introducing a number of improvements in an attempt to minimise occurrences of `detected illegal job sequence` even further:

1. There are occasions where jobsdb's empty result cache is being updated repeatedly by iterating over a map containing datasets as keys. The iteration order over maps is neither specified nor guaranteed, i.e. the cache of a higher index dataset can be updated before the cache of a lower index one. To rectify this, we are now updating the cache's state atomically, by extending the scope of the `cacheLock` to cover the whole iteration. This way, no partial/inconsistent changes can be observed in jobsdb's empty result cache.
2. Sorting the list of responses by job id ascending during `router.commitStatusList` so that `barrier.StateChanged` is also called in ascending job order.
3. Using the correct job order key during throttling

_**Note:**_ Since jobsdb can query multiple datasets while retrieving jobs, and since non-terminal job statuses can be recorded while jobsdb is in the middle of iterating over datasets for querying jobs, it is still theoretically possible to return jobs out-of-order between two consecutive queries, however practically, given how the current algorithm works, this shouldn't be a problem:
- If a failed job exists, this job is guaranteed to be processed again without any other jobs for the same order key existing in the queue after it.
- the barrier is synced once just before the job query happens, so it is not really important what job statuses get committed afterwards, since these won't be reflected in the barrier's state.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=376415a0ffae4122ad94c9e08cf56f39&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
