### PR TITLE
refactor: prefer using lo.BufferWithTimeout

### DIFF
--- a/gateway/admin.go
+++ b/gateway/admin.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -25,8 +26,8 @@ func (g *GatewayAdmin) Status() interface{} {
 	}
 
 	return map[string]interface{}{
-		"ack-count":          g.handle.ackCount,
-		"recv-count":         g.handle.recvCount,
+		"ack-count":          atomic.LoadUint64(&g.handle.ackCount),
+		"recv-count":         atomic.LoadUint64(&g.handle.recvCount),
 		"enabled-write-keys": writeKeys,
 		"jobsdb":             g.handle.jobsDB.Status(),
 	}

--- a/router/router_throttling_test.go
+++ b/router/router_throttling_test.go
@@ -217,8 +217,8 @@ func Test_RouterThrottling(t *testing.T) {
 		atomic.LoadInt64(webhook1.count), atomic.LoadInt64(webhook2.count),
 	)
 
-	verifyBucket := func(buckets map[int64]int, totalEvents, rps, burst, cost int) {
-		lowerLengthRange := (totalEvents*cost - burst) / rps
+	verifyBucket := func(buckets map[int64]int, totalEvents, rps, cost int) {
+		lowerLengthRange := (totalEvents * cost) / rps
 		upperLengthRange := lowerLengthRange + 1
 		requireLengthInRange(t, buckets, lowerLengthRange, upperLengthRange)
 
@@ -234,8 +234,8 @@ func Test_RouterThrottling(t *testing.T) {
 		}
 	}
 
-	verifyBucket(webhook1.buckets, noOfEvents, 20, 20, 2)
-	verifyBucket(webhook2.buckets, noOfEvents, 50, 20, 2)
+	verifyBucket(webhook1.buckets, noOfEvents, 20, 2)
+	verifyBucket(webhook2.buckets, noOfEvents, 50, 2)
 }
 
 func requireLengthInRange(t *testing.T, x interface{}, min, max int) {


### PR DESCRIPTION
# Description

Using `lo.BufferWithTimeout` that either waits for a number of objects to receive from a channel or a timeout whichever's first.

## Notion Ticket

[BufferWithTimeout](https://github.com/samber/lo#bufferwithtimeout)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
