### PR TITLE
fix(warehouse): skipping deprecated columns

### DIFF
--- a/warehouse/identities.go
+++ b/warehouse/identities.go
@@ -454,6 +454,9 @@ func (wh *HandleT) populateHistoricIdentities(warehouse warehouseutils.Warehouse
 			return
 		}
 
+		schemaHandle.SkipDeprecatedColumns(job.schemaHandle.schemaInWarehouse)
+		schemaHandle.SkipDeprecatedColumns(job.schemaHandle.unrecognizedSchemaInWarehouse)
+
 		job.setUploadStatus(UploadStatusOpts{Status: getInProgressState(model.ExportedData)})
 		loadErrors, err := job.loadIdentityTables(true)
 		if err != nil {

--- a/warehouse/logfield/logfield.go
+++ b/warehouse/logfield/logfield.go
@@ -13,6 +13,7 @@ const (
 	Namespace             = "namespace"
 	Error                 = "error"
 	TableName             = "tableName"
+	ColumnName            = "columnName"
 	Priority              = "priority"
 	Retried               = "retried"
 	Attempt               = "attempt"

--- a/warehouse/schema.go
+++ b/warehouse/schema.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
+	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
+	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
@@ -173,7 +174,30 @@ func (sh *SchemaHandleT) fetchSchemaFromWarehouse(whManager manager.Manager) (sc
 		pkgLogger.Errorf(`[WH]: Failed fetching schema from warehouse: %v`, err)
 		return warehouseutils.SchemaT{}, warehouseutils.SchemaT{}, err
 	}
+
+	sh.SkipDeprecatedColumns(schemaInWarehouse)
+	sh.SkipDeprecatedColumns(unrecognizedSchemaInWarehouse)
 	return schemaInWarehouse, unrecognizedSchemaInWarehouse, nil
+}
+
+func (sh *SchemaHandleT) SkipDeprecatedColumns(schema warehouseutils.SchemaT) {
+	for tableName, columnMap := range schema {
+		for columnName := range columnMap {
+			if warehouseutils.DeprecatedColumnsRegex.MatchString(columnName) {
+				pkgLogger.Debugw("skipping deprecated column",
+					logfield.SourceID, sh.warehouse.Source.ID,
+					logfield.DestinationID, sh.warehouse.Destination.ID,
+					logfield.DestinationType, sh.warehouse.Destination.DestinationDefinition.Name,
+					logfield.WorkspaceID, sh.warehouse.WorkspaceID,
+					logfield.Namespace, sh.warehouse.Namespace,
+					logfield.TableName, tableName,
+					logfield.ColumnName, columnName,
+				)
+				delete(schema[tableName], columnName)
+				continue
+			}
+		}
+	}
 }
 
 func MergeSchema(currentSchema warehouseutils.SchemaT, schemaList []warehouseutils.SchemaT, currentMergedSchema warehouseutils.SchemaT, warehouseType string) warehouseutils.SchemaT {

--- a/warehouse/schema.go
+++ b/warehouse/schema.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/rudderlabs/rudder-server/warehouse/logfield"
-
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -135,6 +135,8 @@ const (
 	MinioSecretAccessKey = "secretAccessKey"
 )
 
+var DeprecatedColumnsRegex = regexp.MustCompile(`.*-deprecated-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
 var (
 	IdentityEnabledWarehouses []string
 	enableIDResolution        bool

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -135,6 +135,9 @@ const (
 	MinioSecretAccessKey = "secretAccessKey"
 )
 
+// DeprecatedColumnsRegex
+// This regex is used to identify deprecated columns in the warehouse
+// Example: abc-deprecated-dba626a7-406a-4757-b3e0-3875559c5840
 var DeprecatedColumnsRegex = regexp.MustCompile(`.*-deprecated-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 var (


### PR DESCRIPTION
# Description

- Users tables have a hard dependency on `identifies` tables to have a similar schema. 
- Since in the `ALTER` column flow, if there is a dependent column, we are leaving the dependent columns as it is asking for customers to drop it.
- This is causing differences in the schema for users and identifies and it's causing failure for the creation of staging users table in [here](https://github.com/rudderlabs/rudder-server/blob/47a12bd3a270d76da8e2509bd59746ddd078a04d/warehouse/integrations/redshift/redshift.go#L566).
- Corresponding error logs:
`pq: column "context_<prop>-deprecated-<uuid>" does not exist in rudder_staging_identifies_73ffe05a67886765c9f0ebb64fe8a1e01`


## Notion Ticket

https://www.notion.so/rudderstacks/skipping-deprecated-columns-14e79ea3e5ac4a3280b71aead9634f76?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
