### PR TITLE
chore: abort job after 5 attempts at deletion-worker

### DIFF
--- a/regulation-worker/cmd/main.go
+++ b/regulation-worker/cmd/main.go
@@ -92,6 +92,7 @@ func Run(ctx context.Context) error {
 				OAuth:                        OAuth,
 				MaxOAuthRefreshRetryAttempts: config.GetInt("RegulationWorker.oauth.maxRefreshRetryAttempts", 1),
 			}),
+		MaxFailedAttempts: config.GetInt("REGULATION_DELETION_MAX_FAILED_ATTEMPTS", 4),
 	}
 
 	pkgLogger.Infof("calling looper with service: %v", svc)

--- a/regulation-worker/internal/client/client.go
+++ b/regulation-worker/internal/client/client.go
@@ -43,7 +43,7 @@ func (j *JobAPI) Get(ctx context.Context) (model.Job, error) {
 	pkgLogger.Debugf("making http request to regulation manager to get new job")
 	url := j.URL()
 	pkgLogger.Debugf("making GET request to URL: %v", url)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		pkgLogger.Errorf("error while create new http request: %v", err)
 		return model.Job{}, err

--- a/regulation-worker/internal/client/client.go
+++ b/regulation-worker/internal/client/client.go
@@ -169,10 +169,11 @@ func mapPayloadToJob(wjs jobSchema) (model.Job, error) {
 	}
 
 	return model.Job{
-		ID:            jobID,
-		WorkspaceID:   wjs.WorkspaceId,
-		DestinationID: wjs.DestinationID,
-		Status:        model.JobStatusRunning,
-		Users:         usrAttribute,
+		ID:             jobID,
+		WorkspaceID:    wjs.WorkspaceId,
+		DestinationID:  wjs.DestinationID,
+		Status:         model.JobStatusRunning,
+		Users:          usrAttribute,
+		FailedAttempts: wjs.FailedAttempts,
 	}, nil
 }

--- a/regulation-worker/internal/client/schema.go
+++ b/regulation-worker/internal/client/schema.go
@@ -5,6 +5,7 @@ type jobSchema struct {
 	WorkspaceId    string                 `json:"workspaceId"`
 	DestinationID  string                 `json:"destinationId"`
 	UserAttributes []userAttributesSchema `json:"userAttributes"`
+	FailedAttempts int                    `json:"failedAttempts"`
 }
 
 type statusJobSchema struct {

--- a/regulation-worker/internal/model/model.go
+++ b/regulation-worker/internal/model/model.go
@@ -27,12 +27,13 @@ const (
 )
 
 type Job struct {
-	ID            int
-	WorkspaceID   string
-	DestinationID string
-	Status        JobStatus
-	Users         []User
-	UpdatedAt     time.Time
+	ID             int
+	WorkspaceID    string
+	DestinationID  string
+	Status         JobStatus
+	Users          []User
+	UpdatedAt      time.Time
+	FailedAttempts int
 }
 
 type User struct {

--- a/regulation-worker/internal/service/service.go
+++ b/regulation-worker/internal/service/service.go
@@ -62,6 +62,9 @@ func (js *JobSvc) JobSvc(ctx context.Context) error {
 	deletionStart := time.Now()
 
 	status = js.Deleter.Delete(ctx, job, destDetail)
+	if status == model.JobStatusFailed && job.FailedAttempts >= 4 {
+		status = model.JobStatusAborted
+	}
 
 	stats.Default.NewTaggedStat("regulation_worker_deletion_time", stats.TimerType, stats.Tags{"workspaceId": job.WorkspaceID, "destinationid": destDetail.DestinationID, "destinationType": destDetail.Name, "status": string(status)}).Since(deletionStart)
 	if status == model.JobStatusComplete {

--- a/regulation-worker/internal/service/service.go
+++ b/regulation-worker/internal/service/service.go
@@ -25,9 +25,10 @@ type deleter interface {
 }
 
 type JobSvc struct {
-	API        APIClient
-	Deleter    deleter
-	DestDetail destDetail
+	API               APIClient
+	Deleter           deleter
+	DestDetail        destDetail
+	MaxFailedAttempts int
 }
 
 // called by looper
@@ -62,7 +63,7 @@ func (js *JobSvc) JobSvc(ctx context.Context) error {
 	deletionStart := time.Now()
 
 	status = js.Deleter.Delete(ctx, job, destDetail)
-	if status == model.JobStatusFailed && job.FailedAttempts >= 4 {
+	if status == model.JobStatusFailed && job.FailedAttempts >= js.MaxFailedAttempts {
 		status = model.JobStatusAborted
 	}
 


### PR DESCRIPTION
# Description
Logic to `abort` deletion job after 5 failed_attempts is added.

regulation-manager changes can be found here: https://github.com/rudderlabs/data-regulation-service/pull/79

## Notion Ticket
https://www.notion.so/rudderstacks/after-5-retires-of-deletion-job-change-mark-it-as-aborted-129b7ab0838140308fa032f00992a575?pvs=4

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
