### PR TITLE
fix(router): wrong job order keys used in batching job order logic

### DIFF
--- a/router/types/types.go
+++ b/router/types/types.go
@@ -6,6 +6,7 @@ import (
 
 	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/samber/lo"
 )
 
 const (
@@ -29,6 +30,12 @@ type DestinationJobT struct {
 	Batched          bool                       `json:"batched"`
 	StatusCode       int                        `json:"statusCode"`
 	Error            string                     `json:"error"`
+}
+
+func (dj *DestinationJobT) MinJobID() int64 {
+	return lo.Min(lo.Map(dj.JobMetadataArray, func(item JobMetadataT, _ int) int64 {
+		return item.JobID
+	}))
 }
 
 // JobIDs returns the set of all job ids contained in the message


### PR DESCRIPTION
# Description

The `destinationID` was not taken into consideration in router's job ordering logic when doing batching, which caused invalid state to be captured in barriers. 

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=acf43fb2f6cb46909cb8fcbb42e24833&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
