### PR TITLE
chore(warehouse): default warehouse priority set to 100

### DIFF
--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -107,6 +107,8 @@ var (
 	port                                           int
 )
 
+var defaultUploadPriority = 100
+
 // warehouses worker modes
 const (
 	MasterMode         = "master"
@@ -587,7 +589,7 @@ func (wh *HandleT) createJobs(ctx context.Context, warehouse warehouseutils.Ware
 
 	wh.areBeingEnqueuedLock.Lock()
 
-	priority := 0
+	priority := defaultUploadPriority
 	uploadID, uploadStatus, uploadPriority := wh.getLatestUploadStatus(&warehouse)
 	if uploadStatus == model.Waiting {
 		// If it is present do nothing else delete it


### PR DESCRIPTION
# Description

Since the warehouse processor expects priority orders by ASC, setting the default value to 100.

## Notion Ticket

https://www.notion.so/rudderstacks/Warehouse-default-priority-to-set-to-100-20f47a2db688451d97710842496972c2?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
