### PR TITLE
fix: processor read of dest consent categories

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -686,15 +686,20 @@ func getConsentCategories(dest *backendconfig.DestinationT) []string {
 	cookieCategories, _ := misc.MapLookup(
 		config,
 		"oneTrustCookieCategories",
-	).([]map[string]interface{})
+	).([]interface{})
 	if len(cookieCategories) == 0 {
 		return nil
 	}
 	return lo.FilterMap(
 		cookieCategories,
-		func(cookieCategory map[string]interface{}, _ int) (string, bool) {
-			category, ok := cookieCategory["oneTrustCookieCategory"].(string)
-			return category, ok && category != ""
+		func(cookieCategory interface{}, _ int) (string, bool) {
+			switch category := cookieCategory.(type) {
+			case map[string]interface{}:
+				cCategory, ok := category["oneTrustCookieCategory"].(string)
+				return cCategory, ok && cCategory != ""
+			default:
+				return "", false
+			}
 		},
 	)
 }

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -315,9 +315,9 @@ var sampleBackendConfig = backendconfig.ConfigT{
 					Enabled:            true,
 					IsProcessorEnabled: true,
 					Config: map[string]interface{}{
-						"oneTrustCookieCategories": []map[string]interface{}{
-							{"oneTrustCookieCategory": "category1"},
-							{"oneTrustCookieCategory": "category2"},
+						"oneTrustCookieCategories": []interface{}{
+							map[string]interface{}{"oneTrustCookieCategory": "category1"},
+							map[string]interface{}{"oneTrustCookieCategory": "category2"},
 						},
 						"enableServerSideIdentify": false,
 					},
@@ -334,8 +334,8 @@ var sampleBackendConfig = backendconfig.ConfigT{
 					Enabled:            true,
 					IsProcessorEnabled: true,
 					Config: map[string]interface{}{
-						"oneTrustCookieCategories": []map[string]interface{}{
-							{"oneTrustCookieCategory": ""},
+						"oneTrustCookieCategories": []interface{}{
+							map[string]interface{}{"oneTrustCookieCategory": ""},
 						},
 						"enableServerSideIdentify": false,
 					},
@@ -367,8 +367,8 @@ var sampleBackendConfig = backendconfig.ConfigT{
 					Enabled:            true,
 					IsProcessorEnabled: true,
 					Config: map[string]interface{}{
-						"oneTrustCookieCategories": []map[string]interface{}{
-							{"oneTrustCookieCategory": "category2"},
+						"oneTrustCookieCategories": []interface{}{
+							map[string]interface{}{"oneTrustCookieCategory": "category2"},
 						},
 						"enableServerSideIdentify": false,
 					},


### PR DESCRIPTION
# Description

Corrected reading the destination config in processor.
Gets the consent categories pertinent to event filtering.

## Notion Ticket

[relevant thread](https://rudderlabs.slack.com/archives/C04JAHUEP1B/p1677060333492419)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
