### PR TITLE
fix: job ordering inconsistencies with router destination isolation

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -476,9 +476,8 @@ type journalOpPayloadT struct {
 }
 
 type ParameterFilterT struct {
-	Name     string
-	Value    string
-	Optional bool
+	Name  string
+	Value string
 }
 
 var dbInvalidJsonErrors = map[string]struct{}{

--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -156,11 +156,7 @@ func constructParameterJSONQuery(alias string, parameterFilters []ParameterFilte
 	var allKeyValues, mandatoryKeyValues, opNullConditions []string
 	for _, parameter := range parameterFilters {
 		allKeyValues = append(allKeyValues, fmt.Sprintf(`%q:%q`, parameter.Name, parameter.Value))
-		if parameter.Optional {
-			opNullConditions = append(opNullConditions, fmt.Sprintf(`%q.parameters -> '%s' IS NULL`, alias, parameter.Name))
-		} else {
-			mandatoryKeyValues = append(mandatoryKeyValues, fmt.Sprintf(`%q:%q`, parameter.Name, parameter.Value))
-		}
+		mandatoryKeyValues = append(mandatoryKeyValues, fmt.Sprintf(`%q:%q`, parameter.Name, parameter.Value))
 	}
 	opQuery := ""
 	if len(opNullConditions) > 0 {

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -315,9 +315,8 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 					parameterFilters := make([]jobsdb.ParameterFilterT, 0)
 					for _, param := range jobsdb.CacheKeyParameterFilters {
 						parameterFilter := jobsdb.ParameterFilterT{
-							Name:     param,
-							Value:    key,
-							Optional: false,
+							Name:  param,
+							Value: key,
 						}
 						parameterFilters = append(parameterFilters, parameterFilter)
 					}
@@ -1314,9 +1313,8 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 	if readPerDestination {
 		parameterFilters = []jobsdb.ParameterFilterT{
 			{
-				Name:     "destination_id",
-				Value:    batchJobs.BatchDestination.Destination.ID,
-				Optional: false,
+				Name:  "destination_id",
+				Value: batchJobs.BatchDestination.Destination.ID,
 			},
 		}
 	}
@@ -1467,9 +1465,8 @@ func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.Asy
 
 	parameterFilters := []jobsdb.ParameterFilterT{
 		{
-			Name:     "destination_id",
-			Value:    asyncOutput.DestinationID,
-			Optional: false,
+			Name:  "destination_id",
+			Value: asyncOutput.DestinationID,
 		},
 	}
 
@@ -1593,9 +1590,8 @@ func (worker *workerT) constructParameterFilters(batchDest router_utils.BatchDes
 	parameterFilters := make([]jobsdb.ParameterFilterT, 0)
 	for _, key := range jobsdb.CacheKeyParameterFilters {
 		parameterFilter := jobsdb.ParameterFilterT{
-			Name:     key,
-			Value:    worker.getValueForParameter(batchDest, key),
-			Optional: false,
+			Name:  key,
+			Value: worker.getValueForParameter(batchDest, key),
 		}
 		parameterFilters = append(parameterFilters, parameterFilter)
 	}


### PR DESCRIPTION
# Description

Invalid parameter filters caused no jobs cache to not get invalidated properly, ultimately leading to out-of-order jobs.

Additionally using a proper order key during throttling, so that same userIDs of different destinationIDs are not throttled together.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=376415a0ffae4122ad94c9e08cf56f39&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
