### PR TITLE
fix: config hot reloadable race

### DIFF
--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -20,7 +20,7 @@ func (c *Config) RegisterIntConfigVariable(defaultValue int, ptr *int, isHotRelo
 
 // RegisterIntConfigVar registers int config variable
 func (c *Config) RegisterIntConfigVar(defaultValue int, ptr *int, valueScale int, keys ...string) {
-	c.registerIntConfigVar(defaultValue, ptr, true, valueScale, func(v int) {
+	c.registerIntConfigVar(defaultValue, ptr, false, valueScale, func(v int) {
 		*ptr = v
 	}, keys...)
 }

--- a/config/load.go
+++ b/config/load.go
@@ -61,7 +61,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 		for _, configVal := range configValArr {
 			value := configVal.value
 			switch value := value.(type) {
-			case *int, *Atomic[int]:
+			case *int, *Atomic[int]: // @TODO remove *int once all configs are migrated to atomic
 				var _value int
 				var isSet bool
 				for _, key := range configVal.keys {
@@ -75,7 +75,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 					_value = configVal.defaultValue.(int)
 				}
 				_value = _value * configVal.multiplier.(int)
-				if value, ok := value.(*int); ok {
+				if value, ok := value.(*int); ok { // @TODO remove this IF once all configs are migrated to atomic
 					if _value != *value {
 						fmt.Printf("The value of key:%s & variable:%p changed from %d to %d\n", key, configVal, *value, _value)
 						*value = _value

--- a/config/race_test.go
+++ b/config/race_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestIntRace(t *testing.T) {
+	var myInt int
+
+	conf := New()
+	conf.RegisterIntConfigVariable(1, &myInt, true, 1, "key-1")
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				t.Log(myInt)
+			}
+		}
+	}()
+
+	runFor := time.NewTimer(100 * time.Millisecond)
+loop:
+	for {
+		select {
+		case <-runFor.C:
+			close(stop)
+			break loop
+		default:
+			conf.Set("key-1", rand.Intn(100))
+		}
+	}
+	<-done
+}
+
+func TestAtomicIntRace(t *testing.T) {
+	var myInt Atomic[int]
+
+	conf := New()
+	conf.RegisterAtomicIntConfigVar(1, &myInt, 1, "key-1")
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				t.Log(myInt.Load())
+			}
+		}
+	}()
+
+	runFor := time.NewTimer(100 * time.Millisecond)
+loop:
+	for {
+		select {
+		case <-runFor.C:
+			close(stop)
+			break loop
+		default:
+			conf.Set("key-1", rand.Intn(100))
+		}
+	}
+	<-done
+}


### PR DESCRIPTION
# Description

This is an exploratory PR to understand if we might be willing to fix the data race that we have with hot reloadable config variables.

This came up while helping @itsdebs with [his PR](https://github.com/rudderlabs/device-mode-transformation-server/pull/18) where he was trying to build an integration test with the `-race` flag enabled. In the `device-mode-transformation-server` repository they had an outdated copy of our `config` package and so I thought that we could:
1. introduce a new method to handle atomic hot reloadable changes
2. deprecate old method without doing an extensive refactoring in our codebase
3. have `device-mode-transformation-server` use the RS `config` instead of copying it over

Beware that the two tests are meant to be run with `-race` on. One will give you a data race, the other one won't. They are not meant to be merged or anything, they are just there as a demo.

## Sidenote

Even though these data races might be seen as "safe" given that Golang compiler isn't really like C++ where **anything** could happen, I would suggest to fix these data races with time or at least have a way to stop introducing them. It is also important to be able to run our tests with the `-race` enabled and not have noise when we do so.

As recommended by the Golang team:
> Go programmers writing data-race-free programs can rely on sequentially consistent execution of those programs, just as in essentially all other modern programming languages.
>
> When it comes to programs with races, both programmers and compilers should remember the advice: don't be clever.

Generally speaking there are cases where we might end up in an incorrect synchronization scenario like:

```go
var a, b int

func f() {
	a = 1
	b = 2
}

func g() {
	print(b)
	print(a)
}

func main() {
	go f()
	g()
}
```

It can happen that g prints 2 and then 0. This is because there is no synchronization between threads.

More (scary) examples can be found [here](https://go.dev/ref/mem).

## What's next

If you like the approach, the rest of the `config` package can be adapted. I think that the way I'm proposing doesn't lead to a usability nightmare where everything needs to be wrapped around a mutex.

## Notion Ticket

< Replace with Notion Link >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
