### PR TITLE
chore(warehouse): use first_event_at while pickup for warehouse processing jobs

### DIFF
--- a/warehouse/internal/repo/upload.go
+++ b/warehouse/internal/repo/upload.go
@@ -242,7 +242,6 @@ func (uploads *Uploads) GetToProcess(ctx context.Context, destType string, limit
 		partitionIdentifierSQL = fmt.Sprintf(`%s, %s`, "source_id", partitionIdentifierSQL)
 	}
 
-	//					COALESCE(metadata->>'nextRetryTime', NOW()::text)::timestamptz <= NOW() AND
 	sqlStatement := fmt.Sprintf(`
 			SELECT
 			`+uploadColumns+`

--- a/warehouse/internal/repo/upload.go
+++ b/warehouse/internal/repo/upload.go
@@ -242,6 +242,7 @@ func (uploads *Uploads) GetToProcess(ctx context.Context, destType string, limit
 		partitionIdentifierSQL = fmt.Sprintf(`%s, %s`, "source_id", partitionIdentifierSQL)
 	}
 
+	//					COALESCE(metadata->>'nextRetryTime', NOW()::text)::timestamptz <= NOW() AND
 	sqlStatement := fmt.Sprintf(`
 			SELECT
 			`+uploadColumns+`
@@ -263,7 +264,7 @@ func (uploads *Uploads) GetToProcess(ctx context.Context, destType string, limit
 				grouped_uploads.row_number = 1
 			ORDER BY
 				COALESCE(metadata->>'priority', '100')::int ASC,
-				id ASC
+				COALESCE(first_event_at, NOW()) ASC
 			LIMIT %d;
 `,
 		partitionIdentifierSQL,


### PR DESCRIPTION
# Description

Use first_event_at while pickup for warehouse processing jobs 

## Notion Ticket

https://www.notion.so/rudderstacks/Use-first_event_at-while-pickup-from-processing-31c841fcdecc4ea8b6139ee0cb4d8daa?pvs=4

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
