### PR TITLE
feat: default retention period set to 7 days for rudder backups

### DIFF
--- a/config/backend-config/types.go
+++ b/config/backend-config/types.go
@@ -100,6 +100,7 @@ type DataRetention struct {
 	UseSelfStorage      bool               `json:"useSelfStorage"`
 	StorageBucket       StorageBucket      `json:"storageBucket"`
 	StoragePreferences  StoragePreferences `json:"storagePreferences"`
+	RetentionPeriod     string             `json:"retentionPeriod"`
 }
 
 type StorageBucket struct {


### PR DESCRIPTION
# Description

in case of default backup retention period(7 days for now) to rudder-storage, jobs must be uploaded to `bucket/7dayretention` prefix(configurable via env - `JOBS_BACKUP_STORAGE_DEFAULT_PREFIX`).

## Notion Ticket

[Implement 7-day data retention policy ](https://www.notion.so/rudderstacks/Implement-7-day-data-retention-policy-84be80a3881947df932ff664a45ed672?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
