### PR TITLE
fix: enabled data race

### DIFF
--- a/services/stats/config.go
+++ b/services/stats/config.go
@@ -2,14 +2,16 @@ package stats
 
 import (
 	"sync"
+	"sync/atomic"
+
+	"gopkg.in/alexcesaro/statsd.v2"
 
 	"github.com/rudderlabs/rudder-server/config"
 	"github.com/rudderlabs/rudder-server/services/metric"
-	"gopkg.in/alexcesaro/statsd.v2"
 )
 
 type statsdConfig struct {
-	enabled         bool
+	enabled         atomic.Bool
 	tagsFormat      string
 	excludedTags    []string
 	statsdServerURL string

--- a/services/stats/measurement.go
+++ b/services/stats/measurement.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rudderlabs/rudder-server/utils/logger"
 	"gopkg.in/alexcesaro/statsd.v2"
+
+	"github.com/rudderlabs/rudder-server/utils/logger"
 )
 
 // Counter represents a counter metric
@@ -52,7 +53,7 @@ type statsdMeasurement struct {
 
 // skip returns true if the stat should be skipped (stats disabled or client not ready)
 func (m *statsdMeasurement) skip() bool {
-	return !m.conf.enabled || !m.client.ready()
+	return !m.conf.enabled.Load() || !m.client.ready()
 }
 
 // Count default behavior is to panic as not supported operation


### PR DESCRIPTION
# Description

Don't mind the stack trace that says v1.5.0, this happens on the latest of RudderServer as well.

Quick fix for:

```
==================
WARNING: DATA RACE
Write at 0x00c000195be0 by goroutine 905:
  github.com/rudderlabs/rudder-server/services/stats.(*statsdStats).Start()
      /Users/debanjanchatterjee/.go/pkg/mod/github.com/rudderlabs/rudder-server@v1.5.0-preview.2/services/stats/stats.go:126 +0x3de
  github.com/rudderlabs/device-mode-transformation-server/cmd/server.Run()
      /Users/debanjanchatterjee/backend/device-mode-transformation-server/cmd/server/main.go:51 +0x2c3
  github.com/rudderlabs/device-mode-transformation-server/cmd/server_test.beforeEach.func1()
      /Users/debanjanchatterjee/backend/device-mode-transformation-server/cmd/server/main_test.go:51 +0x3c
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/debanjanchatterjee/.go/pkg/mod/golang.org/x/sync@v0.1.0/errgroup/errgroup.go:75 +0x82

Previous read at 0x00c000195be0 by goroutine 463:
  github.com/rudderlabs/rudder-server/services/stats.(*statsdStats).collectPeriodicStats.func1()
      /Users/debanjanchatterjee/.go/pkg/mod/github.com/rudderlabs/rudder-server@v1.5.0-preview.2/services/stats/stats.go:177 +0xa4
  github.com/rudderlabs/rudder-server/services/stats.runtimeStatsCollector.outputGCStats()
      /Users/debanjanchatterjee/.go/pkg/mod/github.com/rudderlabs/rudder-server@v1.5.0-preview.2/services/stats/periodic.go:155 +0x255
  github.com/rudderlabs/rudder-server/services/stats.runtimeStatsCollector.zeroStats()
      /Users/debanjanchatterjee/.go/pkg/mod/github.com/rudderlabs/rudder-server@v1.5.0-preview.2/services/stats/periodic.go:92 +0x1b2
  github.com/rudderlabs/rudder-server/services/stats.runtimeStatsCollector.run.func1()
      /Users/debanjanchatterjee/.go/pkg/mod/github.com/rudderlabs/rudder-server@v1.5.0-preview.2/services/stats/periodic.go:59 +0x65
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:476 +0x32
  github.com/rudderlabs/rudder-server/services/stats.(*statsdStats).collectPeriodicStats.func2()
      /Users/debanjanchatterjee/.go/pkg/mod/github.com/rudderlabs/rudder-server@v1.5.0-preview.2/services/stats/stats.go:191 +0x117
```

## Notion Ticket

< [Notion Link](https://www.notion.so/rudderstacks/Stats-enabled-data-race-babc5c7b1a6341ce9e1e20247a9e9ac5) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
