### PR TITLE
fix: user/anonymous id read at gateway

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -581,8 +581,8 @@ func (gateway *HandleT) getJobDataFromRequest(req *webRequestT) (jobData *jobFro
 			return
 		}
 
-		anonIDFromReq, _ := toSet["anonymousId"].(string)
-		userIDFromReq, _ := toSet["userId"].(string)
+		anonIDFromReq := strings.TrimSpace(misc.GetStringifiedData(toSet["anonymousId"]))
+		userIDFromReq := strings.TrimSpace(misc.GetStringifiedData(toSet["userId"]))
 		if isNonIdentifiable(anonIDFromReq, userIDFromReq) {
 			err = errors.New(response.NonIdentifiableRequest)
 			return

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -941,6 +941,51 @@ var _ = Describe("Gateway", func() {
 			Expect(err).To(Equal(errors.New(response.NonIdentifiableRequest)))
 			Expect(jobData.job).To(BeNil())
 		})
+
+		It("accepts events with non-string type anonymousId and/or userId", func() {
+			// map type usreId
+			payloadMap := map[string]interface{}{
+				"batch": []interface{}{
+					map[string]interface{}{
+						"type":   "track",
+						"userId": map[string]interface{}{"id": 456},
+					},
+				},
+			}
+			payload, err := json.Marshal(payloadMap)
+			Expect(err).To(BeNil())
+			req := &webRequestT{
+				reqType:        "batch",
+				writeKey:       WriteKeyEnabled,
+				done:           make(chan<- string),
+				userIDHeader:   userIDHeader,
+				requestPayload: payload,
+			}
+			_, err = gateway.getJobDataFromRequest(req)
+			Expect(err).To(BeNil())
+
+			// int type anonymousId
+			payloadMap = map[string]interface{}{
+				"batch": []interface{}{
+					map[string]interface{}{
+						"type":   "track",
+						"userId": 456,
+					},
+				},
+			}
+			payload, err = json.Marshal(payloadMap)
+			Expect(err).To(BeNil())
+			Expect(err).To(BeNil())
+			req = &webRequestT{
+				reqType:        "batch",
+				writeKey:       WriteKeyEnabled,
+				done:           make(chan<- string),
+				userIDHeader:   userIDHeader,
+				requestPayload: payload,
+			}
+			_, err = gateway.getJobDataFromRequest(req)
+			Expect(err).To(BeNil())
+		})
 	})
 })
 


### PR DESCRIPTION
# Description

Losing typecase to avoid missing out on events where `userId`/`anonymousId` is not of type string.

## Notion Ticket

[gateway userId read fix](https://www.notion.so/rudderstacks/gateway-userId-read-fix-6b190ee8f1f24f6089664295ee54174c?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
