### PR TITLE
chore: perform rss/wss-aware cgroups memory usage calculation

### DIFF
--- a/utils/mem/internal/cgroup/mem.go
+++ b/utils/mem/internal/cgroup/mem.go
@@ -6,20 +6,20 @@ import (
 
 // GetMemoryUsage returns cgroup (v1 or v2) memory usage
 func GetMemoryUsage(basePath string) int64 {
-	n, err := getMemStat(basePath, "memory.usage_in_bytes")
+	n, err := getMemStatCgroup1(basePath, "memory.usage_in_bytes")
 	if err == nil {
-		wss := getWSSMemory(basePath, n)
-		rss := getRSSMemory(basePath)
+		wss := getWSSMemoryCgroup1(basePath, n)
+		rss := getRSSMemoryCgroup1(basePath)
 		if wss > rss {
 			return wss
 		}
 		return rss
 	}
-	n, err = getMemStatV2(basePath, "memory.current")
+	n, err = getMemStatCgroup2(basePath, "memory.current")
 	if err != nil {
 		return 0
 	}
-	return getWSSMemoryV2(basePath, n)
+	return getWSSMemoryCgroup2(basePath, n)
 }
 
 // GetMemoryLimit returns the cgroup's (v1 or v2) memory limit, or [totalMem] if there is no limit set.
@@ -31,17 +31,17 @@ func GetMemoryUsage(basePath string) int64 {
 func GetMemoryLimit(basePath string, totalMem int) int {
 	getLimit := func() int64 {
 		// cgroups v1
-		n, err := getMemStat(basePath, "memory.limit_in_bytes")
+		n, err := getMemStatCgroup1(basePath, "memory.limit_in_bytes")
 		if err == nil {
 			if n <= 0 || int64(int(n)) != n || int(n) > totalMem {
 				// try to get hierarchical limit
-				n = GetHierarchicalMemoryLimit(basePath)
+				n = GetHierarchicalMemoryLimitCgroup1(basePath)
 			}
 			return n
 		}
 
 		// cgroups v2
-		n, err = getMemStatV2(basePath, "memory.max")
+		n, err = getMemStatCgroup2(basePath, "memory.max")
 		if err != nil {
 			return 0
 		}
@@ -56,42 +56,42 @@ func GetMemoryLimit(basePath string, totalMem int) int {
 	return int(limit)
 }
 
-func getMemStatV2(basePath, statName string) (int64, error) {
+func getMemStatCgroup2(basePath, statName string) (int64, error) {
 	// See https: //www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html#memory-interface-files
 	return getStatGeneric(statName, basePath+"/sys/fs/cgroup", basePath+"/proc/self/cgroup", "")
 }
 
-func getMemStat(basePath, statName string) (int64, error) {
+func getMemStatCgroup1(basePath, statName string) (int64, error) {
 	return getStatGeneric(statName, basePath+"/sys/fs/cgroup/memory", basePath+"/proc/self/cgroup", "memory")
 }
 
-// GetHierarchicalMemoryLimit returns hierarchical memory limit
+// GetHierarchicalMemoryLimitCgroup1 returns hierarchical memory limit
 // https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
-func GetHierarchicalMemoryLimit(basePath string) int64 {
-	return memStat(basePath, "hierarchical_memory_limit")
+func GetHierarchicalMemoryLimitCgroup1(basePath string) int64 {
+	return memStatCgroup1(basePath, "hierarchical_memory_limit")
 }
 
-func getRSSMemory(basePath string) int64 {
-	return memStat(basePath, "total_rss")
+func getRSSMemoryCgroup1(basePath string) int64 {
+	return memStatCgroup1(basePath, "total_rss")
 }
 
-func getWSSMemory(basePath string, used int64) int64 {
-	inactive := memStat(basePath, "total_inactive_file")
+func getWSSMemoryCgroup1(basePath string, used int64) int64 {
+	inactive := memStatCgroup1(basePath, "total_inactive_file")
 	if used < inactive {
 		return 0
 	}
 	return used - inactive
 }
 
-func getWSSMemoryV2(basePath string, used int64) int64 {
-	inactive := memStatV2(basePath, "inactive_file")
+func getWSSMemoryCgroup2(basePath string, used int64) int64 {
+	inactive := memStatCgroup2(basePath, "inactive_file")
 	if used < inactive {
 		return 0
 	}
 	return used - inactive
 }
 
-func memStat(basePath, key string) int64 {
+func memStatCgroup1(basePath, key string) int64 {
 	data, err := getFileContents("memory.stat", basePath+"/sys/fs/cgroup/memory", basePath+"/proc/self/cgroup", "memory")
 	if err != nil {
 		return 0
@@ -107,7 +107,7 @@ func memStat(basePath, key string) int64 {
 	return n
 }
 
-func memStatV2(basePath, key string) int64 {
+func memStatCgroup2(basePath, key string) int64 {
 	data, err := getFileContents("memory.stat", basePath+"/sys/fs/cgroup", basePath+"/proc/self/cgroup", "")
 	if err != nil {
 		return 0

--- a/utils/mem/internal/cgroup/mem_test.go
+++ b/utils/mem/internal/cgroup/mem_test.go
@@ -15,7 +15,7 @@ func TestCgroupMemory(t *testing.T) {
 		limit := cgroup.GetMemoryLimit(basePath, totalMem)
 
 		require.EqualValues(t, 25*bytesize.GB, limit, "when a limit is set, this limit should be returned")
-		require.EqualValues(t, 9456156672, cgroup.GetMemoryUsage(basePath))
+		require.EqualValues(t, 7873486848, cgroup.GetMemoryUsage(basePath))
 	})
 
 	t.Run("cgroups v1 with self limit", func(t *testing.T) {
@@ -24,7 +24,7 @@ func TestCgroupMemory(t *testing.T) {
 		limit := cgroup.GetMemoryLimit(basePath, totalMem)
 
 		require.EqualValues(t, 25*bytesize.GB, limit, "when a limit is set, this limit should be returned")
-		require.EqualValues(t, 9456156672, cgroup.GetMemoryUsage(basePath))
+		require.EqualValues(t, 9456156572, cgroup.GetMemoryUsage(basePath))
 	})
 
 	t.Run("cgroups v1 with hierarchical limit", func(t *testing.T) {
@@ -33,7 +33,7 @@ func TestCgroupMemory(t *testing.T) {
 		limit := cgroup.GetMemoryLimit(basePath, totalMem)
 
 		require.EqualValues(t, 25*bytesize.GB, limit, "when a hierarchical limit is set, this limit should be returned")
-		require.EqualValues(t, 9456156672, cgroup.GetMemoryUsage(basePath))
+		require.EqualValues(t, 7873486848, cgroup.GetMemoryUsage(basePath))
 	})
 
 	t.Run("cgroups v1 no limit", func(t *testing.T) {
@@ -42,7 +42,7 @@ func TestCgroupMemory(t *testing.T) {
 		limit := cgroup.GetMemoryLimit(basePath, totalMem)
 
 		require.EqualValues(t, totalMem, limit, "when no limit is set, total memory should be returned")
-		require.EqualValues(t, 9456156672, cgroup.GetMemoryUsage(basePath))
+		require.EqualValues(t, 7873486848, cgroup.GetMemoryUsage(basePath))
 	})
 
 	t.Run("cgroups v2 with limit", func(t *testing.T) {
@@ -51,7 +51,7 @@ func TestCgroupMemory(t *testing.T) {
 		limit := cgroup.GetMemoryLimit(basePath, totalMem)
 
 		require.EqualValues(t, 32*bytesize.GB, limit, "when a limit is set, this limit should be returned")
-		require.EqualValues(t, 34263040, cgroup.GetMemoryUsage(basePath))
+		require.EqualValues(t, 26071040, cgroup.GetMemoryUsage(basePath))
 	})
 
 	t.Run("cgroups v2 no limit", func(t *testing.T) {
@@ -60,7 +60,7 @@ func TestCgroupMemory(t *testing.T) {
 		limit := cgroup.GetMemoryLimit(basePath, totalMem)
 
 		require.EqualValues(t, totalMem, limit, "when no limit is set, total memory should be returned")
-		require.EqualValues(t, 34263040, cgroup.GetMemoryUsage(basePath))
+		require.EqualValues(t, 26071040, cgroup.GetMemoryUsage(basePath))
 	})
 
 	t.Run("no cgroups info", func(t *testing.T) {

--- a/utils/mem/internal/cgroup/testdata/cgroups_v1_mem_limit_proc_self/sys/fs/cgroup/memory/pid1/memory.stat
+++ b/utils/mem/internal/cgroup/testdata/cgroups_v1_mem_limit_proc_self/sys/fs/cgroup/memory/pid1/memory.stat
@@ -18,7 +18,7 @@ unevictable 0
 hierarchical_memory_limit 26843545600
 hierarchical_memsw_limit 26843545600
 total_cache 1853911040
-total_rss 7873486848
+total_rss 100
 total_rss_huge 2638217216
 total_shmem 0
 total_mapped_file 0
@@ -31,6 +31,6 @@ total_pgfault 903519144
 total_pgmajfault 0
 total_inactive_anon 0
 total_active_anon 7873806336
-total_inactive_file 1599037440
+total_inactive_file 100
 total_active_file 253980672
 total_unevictable 0

--- a/utils/mem/mem.go
+++ b/utils/mem/mem.go
@@ -48,6 +48,9 @@ func (c *collector) Get() (*Stat, error) {
 	if cgroupLimit < int(mem.Total) { // if cgroup limit is set read memory statistics from cgroup
 		stat.Total = uint64(cgroupLimit)
 		stat.Used = uint64(cgroup.GetMemoryUsage(c.basePath))
+		if stat.Used > stat.Total {
+			stat.Used = stat.Total
+		}
 		stat.Available = stat.Total - stat.Used
 	} else {
 		stat.Total = mem.Total

--- a/utils/mem/mem_test.go
+++ b/utils/mem/mem_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMemCollector(t *testing.T) {
 	const expectedCgroupsTotal = 100000 // setting a pretty low value to make sure the system running the test will have more memory than this
-	const expectedCgroupsUsed = 10000
+	const expectedCgroupsUsed = 9000
 	mem, err := gomem.VirtualMemory()
 	require.NoError(t, err)
 	require.Greater(t, mem.Total, uint64(expectedCgroupsTotal), "cgroups total should be less than the actual total memory of the system running the tests")

--- a/utils/mem/testdata/cgroups_v1_mem_limit/sys/fs/cgroup/memory/memory.stat
+++ b/utils/mem/testdata/cgroups_v1_mem_limit/sys/fs/cgroup/memory/memory.stat
@@ -18,7 +18,7 @@ unevictable 0
 hierarchical_memory_limit 100000
 hierarchical_memsw_limit 100000
 total_cache 1853911040
-total_rss 7873486848
+total_rss 8000
 total_rss_huge 2638217216
 total_shmem 0
 total_mapped_file 0
@@ -31,6 +31,6 @@ total_pgfault 903519144
 total_pgmajfault 0
 total_inactive_anon 0
 total_active_anon 7873806336
-total_inactive_file 1599037440
+total_inactive_file 1000
 total_active_file 253980672
 total_unevictable 0


### PR DESCRIPTION
# Description

Previous calculation of memory usage under cgroups was not taking into consideration RSS & WSS memory, it was relying only to `memory.usage_in_bytes` which can be imprecise under circumstances. [This article](https://mohamedmsaeed.medium.com/memory-working-set-vs-memory-rss-in-kubernetes-which-one-you-should-monitor-8ef77bf0acee) explains how k8s actually calculates RSS & WSS memory respectively. 
With this change, we are now calculating both RSS & WSS values and consider the greatest one to be equal to the actual memory usage.

**_Note:_** verified in `prousmt` environment where this inconsistency was initially observed.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=dfc827ae9677450b9f2a5b8e7ce4a742&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
