### PR TITLE
fix: limiter deadlock while trying to notify a dynamic priority item

### DIFF
--- a/utils/queue/priorityQueue.go
+++ b/utils/queue/priorityQueue.go
@@ -76,6 +76,9 @@ func (pq *PriorityQueue[T]) GetIndex(x interface{}) int {
 
 // Update updates the attributes of an element in the priority queue.
 func (pq *PriorityQueue[T]) Update(item *Item[T], priority int) {
+	if item.index == -1 {
+		return
+	}
 	item.Priority = priority
 	heap.Fix(pq, item.index)
 }

--- a/utils/queue/priorityQueue_test.go
+++ b/utils/queue/priorityQueue_test.go
@@ -54,4 +54,19 @@ func TestPriorityQueue(t *testing.T) {
 		require.Nil(t, pq.Pop())
 		require.Equal(t, 0, pq.Len())
 	})
+
+	t.Run("pop then try to update", func(t *testing.T) {
+		pq := make(PriorityQueue[any], 3)
+
+		for i := 0; i < 3; i++ {
+			pq[i] = &Item[any]{
+				Priority:  1,
+				timeStamp: int64(i),
+			}
+		}
+		i1 := pq.Pop().((*Item[any])) // remove the item
+		require.Len(t, pq, 2, "pq should have 2 elements after pop")
+		pq.Update(i1, i1.Priority+1) // try to update the removed item
+		require.Len(t, pq, 2, "pq should still have 2 elements after updating the popped item")
+	})
 }


### PR DESCRIPTION
# Description

In case of high contention, a deadlock was possible if the limiter was trying to notify a dynamic priority item which in turn was trying to increase its priority in the queue.
The limiter now releases the lock earlier, just before notifying the item's channel. The (removed) item will no longer block trying to increase its priority in the queue, it will execute this no-op and then get properly notified.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=feb16db615794204a0c3d9810073f2fb&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
