### PR TITLE
chore(warehouse): warehouse integration tests improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ setup-warehouse-integration: cleanup-warehouse-integration
 		echo "Warehouse integration setup successful"; \
 	else \
 	  	echo "Warehouse integration setup failed" ;\
-      	docker logs wh-backend; \
+      	docker-compose -f warehouse/integrations/docker-compose.test.yml logs; \
         make cleanup-warehouse-integration; \
       	exit 1 ;\
     fi

--- a/warehouse/integrations/docker-compose.test.yml
+++ b/warehouse/integrations/docker-compose.test.yml
@@ -50,7 +50,7 @@ services:
     ports:
       - "9090"
   wh-databricks-connector:
-    image: rudderstack/rudder-databricks-connector:v1.3.0
+    image: rudderstack/rudder-databricks-connector:v1.4.2
     container_name: wh-databricks-connector
     ports:
       - "50051"

--- a/warehouse/integrations/docker-compose.test.yml
+++ b/warehouse/integrations/docker-compose.test.yml
@@ -254,7 +254,7 @@ services:
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
       interval: 5s
-      retries: 50
+      retries: 100
   start_warehouse_integration:
     image: alpine:latest
     depends_on:


### PR DESCRIPTION
# Description

1. increase timeouts for the backend container
2. improve logs in case of a failed setup
3. update databricks connector to v1.4.2

## Notion Ticket

https://www.notion.so/rudderstacks/Warehouse-integration-tests-fix-c45039d9faa2481b9772d00beebfdd4c?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
