### PR TITLE
chore(jobsdb): omit workspaceId tag when it doesn't correspond to an actual workspace

### DIFF
--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -236,10 +236,8 @@ func (tags *statTags) getStatsTags(tablePrefix string) stats.Tags {
 			statTagsMap["stateFilters"] = stateFiltersTag
 		}
 
-		if tags.WorkspaceID != "" {
+		if tags.WorkspaceID != "" && tags.WorkspaceID != allWorkspaces {
 			statTagsMap["workspaceId"] = tags.WorkspaceID
-		} else {
-			statTagsMap["workspaceId"] = allWorkspaces
 		}
 
 		for _, paramTag := range tags.ParameterFilters {

--- a/services/metric/measurement.go
+++ b/services/metric/measurement.go
@@ -52,7 +52,6 @@ func (r pendingEventsMeasurement) GetName() string {
 
 func (r pendingEventsMeasurement) GetTags() map[string]string {
 	res := map[string]string{
-		"workspace":   r.workspace,
 		"workspaceId": r.workspace,
 		"destType":    r.destType,
 	}

--- a/services/stats/stats_test.go
+++ b/services/stats/stats_test.go
@@ -350,7 +350,7 @@ func Test_Periodic_stats(t *testing.T) {
 			c.Set("RuntimeStats.enableGCStats", false)
 			m.GetRegistry(metric.PUBLISHED_METRICS).MustGetGauge(metric.PendingEventsMeasurement("table", "workspace", "destType")).Set(1.0)
 		}, []string{
-			"jobsdb_table_pending_events_count,instanceName=test,destType=destType,workspace=workspace,workspaceId=workspace",
+			"jobsdb_table_pending_events_count,instanceName=test,destType=destType,workspaceId=workspace",
 		})
 	})
 }


### PR DESCRIPTION
# Description

Not including a workspaceId tag in jobsdb metrics when its value is empty or _all_

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=ad24c6fda36e4a37b4640ba50d1f364a&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
