### PR TITLE
fix: pending events all

### DIFF
--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -22,7 +22,7 @@ func (jd *HandleT) Status() interface{} {
 
 	pendingEventMetrics := metric.Instance.
 		GetRegistry(metric.PublishedMetrics).
-		GetMetricsByName(fmt.Sprintf(metric.JOBSDB_PENDING_EVENTS_COUNT, jd.tablePrefix))
+		GetMetricsByName(fmt.Sprintf(metric.JobsdbPendingEventsCount, jd.tablePrefix))
 
 	if len(pendingEventMetrics) == 0 {
 		return statusObj

--- a/services/metric/measurement.go
+++ b/services/metric/measurement.go
@@ -23,6 +23,7 @@ func IncreasePendingEvents(tablePrefix, workspace, destType string, value float6
 	PendingEvents(tablePrefix, All, destType).Add(value)
 	PendingEvents(tablePrefix, All, All).Add(value)
 	Instance.GetRegistry(PublishedMetrics).MustGetGauge(pendingEventsMeasurementAll{tablePrefix, destType}).Add(value)
+	Instance.GetRegistry(PublishedMetrics).MustGetGauge(pendingEventsMeasurementAll{tablePrefix, All}).Add(value)
 }
 
 // DecreasePendingEvents increments three gauges, the dest & workspace-specific gauge, plus two aggregate (global) gauges
@@ -31,6 +32,7 @@ func DecreasePendingEvents(tablePrefix, workspace, destType string, value float6
 	PendingEvents(tablePrefix, All, destType).Sub(value)
 	PendingEvents(tablePrefix, All, All).Sub(value)
 	Instance.GetRegistry(PublishedMetrics).MustGetGauge(pendingEventsMeasurementAll{tablePrefix, destType}).Sub(value)
+	Instance.GetRegistry(PublishedMetrics).MustGetGauge(pendingEventsMeasurementAll{tablePrefix, All}).Sub(value)
 }
 
 // PendingEvents gets the measurement for pending events metric

--- a/services/metric/measurement.go
+++ b/services/metric/measurement.go
@@ -13,22 +13,24 @@ type Measurement interface {
 }
 
 const (
-	JOBSDB_PENDING_EVENTS_COUNT = "jobsdb_%s_pending_events_count"
-	ALL                         = "ALL"
+	JobsdbPendingEventsCount = "jobsdb_%s_pending_events_count"
+	All                      = "ALL"
 )
 
 // IncreasePendingEvents increments three gauges, the dest & workspace-specific gauge, plus two aggregate (global) gauges
 func IncreasePendingEvents(tablePrefix, workspace, destType string, value float64) {
 	PendingEvents(tablePrefix, workspace, destType).Add(value)
-	PendingEvents(tablePrefix, ALL, destType).Add(value)
-	PendingEvents(tablePrefix, ALL, ALL).Add(value)
+	PendingEvents(tablePrefix, All, destType).Add(value)
+	PendingEvents(tablePrefix, All, All).Add(value)
+	Instance.GetRegistry(PublishedMetrics).MustGetGauge(pendingEventsMeasurementAll{tablePrefix, destType}).Add(value)
 }
 
 // DecreasePendingEvents increments three gauges, the dest & workspace-specific gauge, plus two aggregate (global) gauges
 func DecreasePendingEvents(tablePrefix, workspace, destType string, value float64) {
 	PendingEvents(tablePrefix, workspace, destType).Sub(value)
-	PendingEvents(tablePrefix, ALL, destType).Sub(value)
-	PendingEvents(tablePrefix, ALL, ALL).Sub(value)
+	PendingEvents(tablePrefix, All, destType).Sub(value)
+	PendingEvents(tablePrefix, All, All).Sub(value)
+	Instance.GetRegistry(PublishedMetrics).MustGetGauge(pendingEventsMeasurementAll{tablePrefix, destType}).Sub(value)
 }
 
 // PendingEvents gets the measurement for pending events metric
@@ -47,13 +49,27 @@ type pendingEventsMeasurement struct {
 }
 
 func (r pendingEventsMeasurement) GetName() string {
-	return fmt.Sprintf(JOBSDB_PENDING_EVENTS_COUNT, r.tablePrefix)
+	return fmt.Sprintf(JobsdbPendingEventsCount, r.tablePrefix)
 }
 
 func (r pendingEventsMeasurement) GetTags() map[string]string {
-	res := map[string]string{
+	return map[string]string{
 		"workspaceId": r.workspace,
 		"destType":    r.destType,
 	}
-	return res
+}
+
+type pendingEventsMeasurementAll struct {
+	tablePrefix string
+	destType    string
+}
+
+func (r pendingEventsMeasurementAll) GetName() string {
+	return fmt.Sprintf(JobsdbPendingEventsCount, r.tablePrefix) + "_all"
+}
+
+func (r pendingEventsMeasurementAll) GetTags() map[string]string {
+	return map[string]string{
+		"destType": r.destType,
+	}
 }


### PR DESCRIPTION
# Description

Adding new metric to query pending events on hosted given that `workspaceId` gets filtered out for free users.
Router pickup jobs won't be affected since they use their own in memory implementation.

Tested on dev.

## Notion Ticket

< [Notion Link](https://www.notion.so/rudderstacks/Fix-workspaceId-ALL-efc7524f29574cd496b9547c3aa0557c) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
