### PR TITLE
chore: use token on protoc setup to avoid rate-limit

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,6 +36,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: make proto
       - run: git diff -I '^\/\/\s+-?\s+protoc\s+v' --exit-code ## Ignore protoc version comment
       - name: Error message


### PR DESCRIPTION
# Description

Our CI checks sometimes fails with the following error:
<img width="1243" alt="Screenshot 2023-03-08 at 12 41 58 PM" src="https://user-images.githubusercontent.com/733195/223704534-fb70645e-f106-41f4-bd8c-dbb508633e16.png">

As suggested by [setup-protoc's README](https://github.com/arduino/setup-protoc#usage), the following option can be used to avoid rate-limit:

```
  with:
    repo-token: ${{ secrets.GITHUB_TOKEN }}
```

## Notion Ticket

https://www.notion.so/rudderstacks/Fix-CI-setup-protoc-rate-limit-90e1c06be0464184bb6aaf7e53e3fade?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
