### PR TITLE
chore(warehouse): allow empty properties schema for event models

### DIFF
--- a/event-schema/event_schema_api.go
+++ b/event-schema/event_schema_api.go
@@ -144,22 +144,15 @@ func generateJsonSchFromEM(eventModels []*EventModelT) ([]byte, error) {
 }
 
 // getETSchProp Get Event Type schema from Event Model Schema
-// Empty map schema is allowed for event types
+// Empty map schema is allowed for event json schema
 func getETSchProp(eventType string, eventModelSch map[string]interface{}) (map[string]interface{}, error) {
-	emptyMap := map[string]interface{}{}
 	switch eventType {
 	case "track", "screen", "page":
-		filtered, ok := eventModelSch["properties"].(map[string]interface{})
-		if ok {
-			return filtered, nil
-		}
-		return emptyMap, nil
+		filtered, _ := eventModelSch["properties"].(map[string]interface{})
+		return filtered, nil
 	case "identify", "group":
-		filtered, ok := eventModelSch["traits"].(map[string]interface{})
-		if ok {
-			return filtered, nil
-		}
-		return emptyMap, nil
+		filtered, _ := eventModelSch["traits"].(map[string]interface{})
+		return filtered, nil
 	}
 	return nil, fmt.Errorf("invalid eventType")
 }

--- a/event-schema/event_schema_api.go
+++ b/event-schema/event_schema_api.go
@@ -124,10 +124,6 @@ func generateJsonSchFromEM(eventModels []*EventModelT) ([]byte, error) {
 			pkgLogger.Errorf("Error while getting schema properties: %v for ID: %v", err, eventModel.ID)
 			continue
 		}
-		if len(schemaProperties) == 0 {
-			pkgLogger.Error("Error schema properties doesn't exists for ID: %v", eventModel.ID)
-			continue
-		}
 
 		jsonSchema := generateJsonSchFromSchProp(schemaProperties)
 		jsonSchema["additionalProperties"] = false
@@ -148,20 +144,22 @@ func generateJsonSchFromEM(eventModels []*EventModelT) ([]byte, error) {
 }
 
 // getETSchProp Get Event Type schema from Event Model Schema
+// Empty map schema is allowed for event types
 func getETSchProp(eventType string, eventModelSch map[string]interface{}) (map[string]interface{}, error) {
+	emptyMap := map[string]interface{}{}
 	switch eventType {
 	case "track", "screen", "page":
 		filtered, ok := eventModelSch["properties"].(map[string]interface{})
 		if ok {
 			return filtered, nil
 		}
-		return nil, fmt.Errorf("invalid properties")
+		return emptyMap, nil
 	case "identify", "group":
 		filtered, ok := eventModelSch["traits"].(map[string]interface{})
 		if ok {
 			return filtered, nil
 		}
-		return nil, fmt.Errorf("invalid traits")
+		return emptyMap, nil
 	}
 	return nil, fmt.Errorf("invalid eventType")
 }


### PR DESCRIPTION
# Description
> Empty schema is allowed in json schema obtained from event models

## Notion Ticket

https://www.notion.so/rudderstacks/Spreadsheet-Show-all-events-from-event-models-irrespective-of-no-properties-10c9bb3afe4e4340b1a0bf95c10e154e?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
