### PR TITLE
fix(router): retry backoff causing out-of-order job processing

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -1212,7 +1212,8 @@ func (rt *HandleT) findWorker(job *jobsdb.JobT, throttledOrderKeys map[string]st
 	//#JobOrder (see other #JobOrder comment)
 	index := rt.getWorkerPartition(orderKey)
 	worker := rt.workers[index]
-	if time.Until(job.LastJobStatus.RetryTime) > 0 { // backoff
+	if job.LastJobStatus.JobState == jobsdb.Failed.State && job.LastJobStatus.AttemptNum > 0 && time.Until(job.LastJobStatus.RetryTime) > 0 { // backoff
+		throttledOrderKeys[orderKey] = struct{}{}
 		return
 	}
 	enter, previousFailedJobID := worker.barrier.Enter(orderKey, job.JobID)


### PR DESCRIPTION
# Description

Since job retry time is now persisted in the database and survives server restarts we need to adapt the backoff mechanism so that:

1. backoff logic is only performed if previous job status is failed and attempt number is greater than 0, and
2. if backoff is indeed performed for a job, then avoid picking subsequent jobs for the same ordering key in the same loop

_**Note:** During server startup, jobsdb recovery updates jobs marked as `executing` to `failed`._

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=c67732015ce349e5b402df9df0b7bbbc&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
