### PR TITLE
fix(warehouse): snowflake default timestamp to timestamp with time zone

### DIFF
--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -49,7 +49,7 @@ var dataTypesMap = map[string]string{
 	"bigint":   "number",
 	"float":    "double precision",
 	"string":   "varchar",
-	"datetime": "timestamp",
+	"datetime": "timestamp_tz",
 	"json":     "variant",
 }
 


### PR DESCRIPTION
# Description

- Snowflake default timestamp to timestamp with time zone

## Notion Ticket

https://www.notion.so/rudderstacks/Snowflake-default-timestamp-to-timestamp_tz-69f60cef979841a5b3fbcdc805d7ce95?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
