### PR TITLE
chore: badgerDB improvements for debugger

### DIFF
--- a/services/debugger/cache/internal/badger/badger_test.go
+++ b/services/debugger/cache/internal/badger/badger_test.go
@@ -24,7 +24,7 @@ var _ = Describe("cache", func() {
 
 		BeforeEach(func() {
 			misc.Init()
-			config.Set("LiveEvent.cache.clearFreq", "1s")
+			config.Set("LiveEvent.cache.ttl", "1s")
 			e, err = New[[]byte]("test", logger.NewLogger())
 			Expect(err).To(BeNil())
 		})
@@ -36,7 +36,7 @@ var _ = Describe("cache", func() {
 
 		It("Cache Init", func() {
 			Expect(e.db).NotTo(BeNil())
-			Expect(e.cleanupFreq).NotTo(Equal(0))
+			Expect(e.ttl).NotTo(Equal(0))
 		})
 
 		It("Cache update", func() {
@@ -119,7 +119,7 @@ var _ = Describe("cache", func() {
 
 		It("Cache expiry", func() {
 			Expect(e.Update(testKey, testValue1)).To(BeNil())
-			time.Sleep(e.cleanupFreq)
+			time.Sleep(e.ttl)
 			Expect(e.Update(testKey, testValue2)).To(BeNil())
 			v, err := e.Read(testKey)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
# Description

1. Using `1MB` as `valueThreshold` by default (this is what we are using now through an override)
2. Using 5 minutes as ttl by default (30 seconds is too short)
3. Cleanup badgerDB folder on startup by default (transitive data)

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/8aac9087df644365acdf64e28e290153?v=6e06b0a5ade24f0aa5ffe05dc2972e84&p=cb3e9166a6d149af8845dd11ed433234&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
