### PR TITLE
chore: fix namespace bug

### DIFF
--- a/warehouse/testdata/sql/namespace_test.sql
+++ b/warehouse/testdata/sql/namespace_test.sql
@@ -1,0 +1,6 @@
+BEGIN;
+INSERT INTO wh_schemas(id,wh_upload_id, source_id, namespace, destination_id, destination_type,
+                        schema, error, created_at, updated_at)
+VALUES (1,1, 'test-sourceID', 'test-namespace', 'test-destinationID', 'POSTGRES','{}', NULL,
+        '2022-12-06 15:23:37.100685', '2022-12-06 15:23:37.100685');
+COMMIT;

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -303,7 +303,7 @@ func (wh *HandleT) backendConfigSubscriber(ctx context.Context) {
 						destination = wh.attachSSHTunnellingInfo(ctx, destination)
 					}
 
-					namespace := wh.getNamespace(destination.Config, source, destination, wh.destType)
+					namespace := wh.getNamespace(source, destination)
 					warehouse := model.Warehouse{
 						WorkspaceID: workspaceID,
 						Source:      source,
@@ -400,9 +400,9 @@ func deepCopy(src, dest interface{}) error {
 //  1. user set name from destinationConfig
 //  2. from existing record in wh_schemas with same source + dest combo
 //  3. convert source name
-func (wh *HandleT) getNamespace(configI interface{}, source backendconfig.SourceT, destination backendconfig.DestinationT, destType string) string {
-	configMap := configI.(map[string]interface{})
-	if destType == warehouseutils.CLICKHOUSE {
+func (wh *HandleT) getNamespace(source backendconfig.SourceT, destination backendconfig.DestinationT) string {
+	configMap := destination.Config
+	if wh.destType == warehouseutils.CLICKHOUSE {
 		if _, ok := configMap["database"].(string); ok {
 			return configMap["database"].(string)
 		}
@@ -411,20 +411,20 @@ func (wh *HandleT) getNamespace(configI interface{}, source backendconfig.Source
 	if configMap["namespace"] != nil {
 		namespace, _ := configMap["namespace"].(string)
 		if len(strings.TrimSpace(namespace)) > 0 {
-			return warehouseutils.ToProviderCase(destType, warehouseutils.ToSafeNamespace(destType, namespace))
+			return warehouseutils.ToProviderCase(wh.destType, warehouseutils.ToSafeNamespace(wh.destType, namespace))
 		}
 	}
 	// TODO: Move config to global level based on use case
-	namespacePrefix := config.GetString(fmt.Sprintf("Warehouse.%s.customDatasetPrefix", warehouseutils.WHDestNameMap[destType]), "")
+	namespacePrefix := config.GetString(fmt.Sprintf("Warehouse.%s.customDatasetPrefix", warehouseutils.WHDestNameMap[wh.destType]), "")
 	if namespacePrefix != "" {
-		return warehouseutils.ToProviderCase(destType, warehouseutils.ToSafeNamespace(destType, fmt.Sprintf(`%s_%s`, namespacePrefix, source.Name)))
+		return warehouseutils.ToProviderCase(wh.destType, warehouseutils.ToSafeNamespace(wh.destType, fmt.Sprintf(`%s_%s`, namespacePrefix, source.Name)))
 	}
 	var (
 		namespace string
 		exists    bool
 	)
 	if namespace, exists = warehouseutils.GetNamespace(source, destination, wh.dbHandle); !exists {
-		return warehouseutils.ToProviderCase(destType, warehouseutils.ToSafeNamespace(destType, source.Name))
+		return warehouseutils.ToProviderCase(wh.destType, warehouseutils.ToSafeNamespace(wh.destType, source.Name))
 	}
 	return namespace
 }
@@ -972,7 +972,7 @@ func minimalConfigSubscriber() {
 							dbHandle: dbHandle,
 							destType: destination.DestinationDefinition.Name,
 						}
-						namespace := wh.getNamespace(destination.Config, source, destination, wh.destType)
+						namespace := wh.getNamespace(source, destination)
 						connectionsMapLock.Lock()
 						if connectionsMap[destination.ID] == nil {
 							connectionsMap[destination.ID] = map[string]model.Warehouse{}

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -401,6 +401,7 @@ func deepCopy(src, dest interface{}) error {
 //  2. from existing record in wh_schemas with same source + dest combo
 //  3. convert source name
 func (wh *HandleT) getNamespace(configI interface{}, source backendconfig.SourceT, destination backendconfig.DestinationT, destType string) string {
+
 	configMap := configI.(map[string]interface{})
 	if destType == warehouseutils.CLICKHOUSE {
 		if _, ok := configMap["database"].(string); ok {
@@ -419,10 +420,14 @@ func (wh *HandleT) getNamespace(configI interface{}, source backendconfig.Source
 	if namespacePrefix != "" {
 		return warehouseutils.ToProviderCase(destType, warehouseutils.ToSafeNamespace(destType, fmt.Sprintf(`%s_%s`, namespacePrefix, source.Name)))
 	}
-	if _, exists := warehouseutils.GetNamespace(source, destination, wh.dbHandle); !exists {
+	var (
+		namespace string
+		exists    bool
+	)
+	if namespace, exists = warehouseutils.GetNamespace(source, destination, wh.dbHandle); !exists {
 		return warehouseutils.ToProviderCase(destType, warehouseutils.ToSafeNamespace(destType, source.Name))
 	}
-	return ""
+	return namespace
 }
 
 func (wh *HandleT) setDestInProgress(warehouse model.Warehouse, jobID int64) {

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -401,7 +401,6 @@ func deepCopy(src, dest interface{}) error {
 //  2. from existing record in wh_schemas with same source + dest combo
 //  3. convert source name
 func (wh *HandleT) getNamespace(configI interface{}, source backendconfig.SourceT, destination backendconfig.DestinationT, destType string) string {
-
 	configMap := configI.(map[string]interface{})
 	if destType == warehouseutils.CLICKHOUSE {
 		if _, ok := configMap["database"].(string); ok {

--- a/warehouse/warehouse_test.go
+++ b/warehouse/warehouse_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	backendconfig "github.com/rudderlabs/rudder-server/config/backend-config"
 	postgreslegacy "github.com/rudderlabs/rudder-server/warehouse/integrations/postgres-legacy"
 
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/postgres"
@@ -184,6 +185,116 @@ func TestUploadJob_ProcessingStats(t *testing.T) {
 				"destType": tc.destType,
 			})
 			require.EqualValues(t, m4.LastDuration(), tc.pickupWaitTime)
+		})
+	}
+}
+
+func Test_GetNamespace(t *testing.T) {
+	testcases := []struct {
+		config      map[string]interface{}
+		source      backendconfig.SourceT
+		destination backendconfig.DestinationT
+		destType    string
+		result      string
+		setConfig   bool
+	}{
+		{
+			config: map[string]interface{}{
+				"database": "test_db",
+			},
+			source:      backendconfig.SourceT{},
+			destination: backendconfig.DestinationT{},
+			destType:    warehouseutils.CLICKHOUSE,
+			result:      "test_db",
+			setConfig:   false,
+		},
+		{
+			config:      map[string]interface{}{},
+			source:      backendconfig.SourceT{},
+			destination: backendconfig.DestinationT{},
+			destType:    warehouseutils.CLICKHOUSE,
+			result:      "rudder",
+			setConfig:   false,
+		},
+		{
+			config: map[string]interface{}{
+				"namespace": "test_namespace",
+			},
+			source:      backendconfig.SourceT{},
+			destination: backendconfig.DestinationT{},
+			destType:    "test-destinationType-1",
+			result:      "test_namespace",
+			setConfig:   false,
+		},
+		{
+			config: map[string]interface{}{
+				"namespace": "      test_namespace        ",
+			},
+			source:      backendconfig.SourceT{},
+			destination: backendconfig.DestinationT{},
+			destType:    "test-destinationType-1",
+			result:      "test_namespace",
+			setConfig:   false,
+		},
+		{
+			config: map[string]interface{}{
+				"namespace": "##",
+			},
+			source:      backendconfig.SourceT{},
+			destination: backendconfig.DestinationT{},
+			destType:    "test-destinationType-1",
+			result:      "stringempty",
+			setConfig:   false,
+		},
+		{
+			config: map[string]interface{}{
+				"namespace": "##evrnvrv$vtr&^",
+			},
+			source:      backendconfig.SourceT{},
+			destination: backendconfig.DestinationT{},
+			destType:    "test-destinationType-1",
+			result:      "evrnvrv_vtr",
+			setConfig:   false,
+		},
+		{
+			config:      map[string]interface{}{},
+			source:      backendconfig.SourceT{},
+			destination: backendconfig.DestinationT{},
+			destType:    "test-destinationType-1",
+			result:      "config_result",
+			setConfig:   true,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run("should return namespace", func(t *testing.T) {
+			t.Parallel()
+
+			pool, err := dockertest.NewPool("")
+			require.NoError(t, err)
+
+			pgResource, err := destination.SetupPostgres(pool, t)
+			require.NoError(t, err)
+
+			err = (&migrator.Migrator{
+				Handle:          pgResource.DB,
+				MigrationsTable: "wh_schema_migrations",
+			}).Migrate("warehouse")
+
+			require.NoError(t, err)
+			store := memstats.New()
+			wh := HandleT{
+				destType: tc.destType,
+				stats:    store,
+				dbHandle: pgResource.DB,
+			}
+			if tc.setConfig {
+				config.Set(fmt.Sprintf("Warehouse.%s.customDatasetPrefix", warehouseutils.WHDestNameMap[tc.destType]), "config_result")
+			}
+			namespace := wh.getNamespace(tc.config, tc.source, tc.destination, tc.destType)
+			require.Equal(t, tc.result, namespace)
+			config.Reset()
 		})
 	}
 }


### PR DESCRIPTION
# Description
Fixing the bug introduced in the previous refactoring of `getNamespace` function which returned an empty namespace even though there was a valid namespace present in the `schema` table also adding tests for the same

## Notion Ticket
[ Notion Link ](https://www.notion.so/rudderstacks/Fix-getNamespace-bug-a21a74603ef14372bf9aa4d0c51c67b5?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
