### PR TITLE
chore(router): don't include job in metadata during transformation requests

### DIFF
--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -104,8 +104,7 @@ func Init() {
 // Transform transforms router jobs to destination jobs
 func (trans *handle) Transform(transformType string, transformMessage *types.TransformMessageT) []types.DestinationJobT {
 	var destinationJobs types.DestinationJobs
-	transformMessageCopy := *transformMessage
-	jobs := transformMessageCopy.Dehydrate()
+	transformMessageCopy, jobs := transformMessage.Dehydrate()
 
 	// Call remote transformation
 	rawJSON, err := jsonfast.Marshal(&transformMessageCopy)

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -106,7 +106,6 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 	var destinationJobs types.DestinationJobs
 	transformMessageCopy := *transformMessage
 	jobs := transformMessageCopy.Dehydrate()
-	defer destinationJobs.Hydrate(jobs)
 
 	// Call remote transformation
 	rawJSON, err := jsonfast.Marshal(&transformMessageCopy)

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -103,8 +103,13 @@ func Init() {
 
 // Transform transforms router jobs to destination jobs
 func (trans *handle) Transform(transformType string, transformMessage *types.TransformMessageT) []types.DestinationJobT {
+	var destinationJobs types.DestinationJobs
+	transformMessageCopy := *transformMessage
+	jobs := transformMessageCopy.Dehydrate()
+	defer destinationJobs.Hydrate(jobs)
+
 	// Call remote transformation
-	rawJSON, err := jsonfast.Marshal(transformMessage)
+	rawJSON, err := jsonfast.Marshal(&transformMessageCopy)
 	if err != nil {
 		trans.logger.Errorf("problematic input for marshalling: %#v", transformMessage)
 		panic(err)
@@ -162,7 +167,6 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 		trans.logger.Errorf("[Router Transfomrer] :: Transformer returned status code: %v reason: %v", resp.StatusCode, resp.Status)
 	}
 
-	var destinationJobs []types.DestinationJobT
 	if resp.StatusCode == http.StatusOK {
 		transformerAPIVersion, convErr := strconv.Atoi(resp.Header.Get(apiVersionHeader))
 		if convErr != nil {
@@ -241,6 +245,7 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 	}
 	func() { httputil.CloseResponse(resp) }()
 
+	destinationJobs.Hydrate(jobs)
 	return destinationJobs
 }
 

--- a/router/types/types.go
+++ b/router/types/types.go
@@ -84,14 +84,17 @@ type TransformMessageT struct {
 	DestType string       `json:"destType"`
 }
 
-// Dehydrate JobT information from RouterJobT.JobMetadata
-func (tm *TransformMessageT) Dehydrate() map[int64]*jobsdb.JobT {
+// Dehydrate JobT information from RouterJobT.JobMetadata returning the dehydrated message along with the jobs
+func (tm *TransformMessageT) Dehydrate() (*TransformMessageT, map[int64]*jobsdb.JobT) {
 	jobs := make(map[int64]*jobsdb.JobT)
+	tmCopy := *tm
+	tmCopy.Data = nil
 	for i := range tm.Data {
-		jobs[tm.Data[i].JobMetadata.JobID] = tm.Data[i].JobMetadata.JobT
-		tm.Data[i].JobMetadata.JobT = nil
+		tmCopy.Data = append(tmCopy.Data, tm.Data[i])
+		jobs[tmCopy.Data[i].JobMetadata.JobID] = tmCopy.Data[i].JobMetadata.JobT
+		tmCopy.Data[i].JobMetadata.JobT = nil
 	}
-	return jobs
+	return &tmCopy, jobs
 }
 
 // JobIDs returns the set of all job ids of the jobs in the message

--- a/router/types/types.go
+++ b/router/types/types.go
@@ -21,6 +21,19 @@ type RouterJobT struct {
 	Destination backendconfig.DestinationT `json:"destination"`
 }
 
+type DestinationJobs []DestinationJobT
+
+// Hydrate jobs in the destination jobs' job metadata array
+func (djs DestinationJobs) Hydrate(jobs map[int64]*jobsdb.JobT) {
+	for i := range djs {
+		for j := range djs[i].JobMetadataArray {
+			if djs[i].JobMetadataArray[j].JobT == nil {
+				djs[i].JobMetadataArray[j].JobT = jobs[djs[i].JobMetadataArray[j].JobID]
+			}
+		}
+	}
+}
+
 // DestinationJobT holds the job to be sent to destination
 // and metadata of all the router jobs from which this job is cooked up
 type DestinationJobT struct {
@@ -60,7 +73,7 @@ type JobMetadataT struct {
 	TransformAt        string          `json:"transformAt"`
 	WorkspaceID        string          `json:"workspaceId"`
 	Secret             json.RawMessage `json:"secret"`
-	JobT               *jobsdb.JobT    `json:"jobsT"`
+	JobT               *jobsdb.JobT    `json:"jobsT,omitempty"`
 	WorkerAssignedTime time.Time       `json:"workerAssignedTime"`
 	DestInfo           json.RawMessage `json:"destInfo,omitempty"`
 }
@@ -69,6 +82,16 @@ type JobMetadataT struct {
 type TransformMessageT struct {
 	Data     []RouterJobT `json:"input"`
 	DestType string       `json:"destType"`
+}
+
+// Dehydrate JobT information from RouterJobT.JobMetadata
+func (tm *TransformMessageT) Dehydrate() map[int64]*jobsdb.JobT {
+	jobs := make(map[int64]*jobsdb.JobT)
+	for i := range tm.Data {
+		jobs[tm.Data[i].JobMetadata.JobID] = tm.Data[i].JobMetadata.JobT
+		tm.Data[i].JobMetadata.JobT = nil
+	}
+	return jobs
 }
 
 // JobIDs returns the set of all job ids of the jobs in the message

--- a/router/types/types_test.go
+++ b/router/types/types_test.go
@@ -1,0 +1,39 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/router/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDehydrateAndHydrate(t *testing.T) {
+	msg := types.TransformMessageT{
+		Data: []types.RouterJobT{
+			{JobMetadata: types.JobMetadataT{JobID: 1, JobT: &jobsdb.JobT{JobID: 1}}},
+			{JobMetadata: types.JobMetadataT{JobID: 2, JobT: &jobsdb.JobT{JobID: 2}}},
+			{JobMetadata: types.JobMetadataT{JobID: 3, JobT: &jobsdb.JobT{JobID: 3}}},
+		},
+	}
+
+	msgCopy, jobs := msg.Dehydrate()
+
+	require.Equal(t, len(msg.Data), len(jobs))
+	require.Equal(t, len(msg.Data), len(msgCopy.Data))
+	for i := range msg.Data {
+		require.NotNil(t, msg.Data[i].JobMetadata.JobT, "JobT should not be nil")
+		require.Nil(t, msgCopy.Data[i].JobMetadata.JobT, "JobT should be nil")
+	}
+
+	destJobs := types.DestinationJobs{
+		{JobMetadataArray: []types.JobMetadataT{{JobID: 1}}},
+		{JobMetadataArray: []types.JobMetadataT{{JobID: 2}}},
+		{JobMetadataArray: []types.JobMetadataT{{JobID: 3}}},
+	}
+	destJobs.Hydrate(jobs)
+
+	for i := range destJobs {
+		require.NotNil(t, destJobs[i].JobMetadataArray[0].JobT, "JobT should not be nil")
+	}
+}


### PR DESCRIPTION
# Description

Job information in metadata is not of any use to transformer, thus excluding it from the request.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=655d85119e6e4b07ac4abe1c8991df3d&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
