### PR TITLE
chore: add metrics for file sizes for badgerDB

### DIFF
--- a/enterprise/suppress-user/internal/badgerdb/badgerdb.go
+++ b/enterprise/suppress-user/internal/badgerdb/badgerdb.go
@@ -12,7 +12,9 @@ import (
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/badger/v3/options"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/enterprise/suppress-user/model"
+	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/samber/lo"
 )
 
@@ -57,15 +59,17 @@ type Repository struct {
 	restoring     bool
 	closeOnce     sync.Once
 	closed        chan struct{}
+	stats         stats.Stats
 }
 
 // NewRepository returns a new repository backed by badgerdb.
-func NewRepository(basePath string, log logger.Logger, opts ...Opt) (*Repository, error) {
+func NewRepository(basePath string, log logger.Logger, stats stats.Stats, opts ...Opt) (*Repository, error) {
 	b := &Repository{
 		log:           log,
 		path:          path.Join(basePath, "badgerdbv3"),
 		maxGoroutines: 1,
 		maxSeedWait:   10 * time.Second,
+		stats:         stats,
 	}
 	for _, opt := range opts {
 		opt(b)
@@ -239,6 +243,15 @@ func (b *Repository) start() error {
 			if err == nil {
 				goto again
 			}
+			lsmSize, vlogSize, totSize, err := misc.GetBadgerDBUsage(b.db.Opts().Dir)
+			if err != nil {
+				b.log.Errorf("Error while getting badgerDB usage: %v", err)
+				continue
+			}
+			statName := "suppress-user"
+			b.stats.NewTaggedStat("badger_db_size", stats.GaugeType, stats.Tags{"name": statName, "type": "lsm"}).Gauge((lsmSize))
+			b.stats.NewTaggedStat("badger_db_size", stats.GaugeType, stats.Tags{"name": statName, "type": "vlog"}).Gauge((vlogSize))
+			b.stats.NewTaggedStat("badger_db_size", stats.GaugeType, stats.Tags{"name": statName, "type": "total"}).Gauge((totSize))
 		}
 	}()
 	return nil

--- a/enterprise/suppress-user/internal/badgerdb/badgerdb_backup_bench_test.go
+++ b/enterprise/suppress-user/internal/badgerdb/badgerdb_backup_bench_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/enterprise/suppress-user/internal/badgerdb"
 	"github.com/rudderlabs/rudder-server/enterprise/suppress-user/model"
 	"github.com/stretchr/testify/require"
@@ -23,7 +24,7 @@ func BenchmarkBackupRestore(b *testing.B) {
 	backupFilename := path.Join(b.TempDir(), "backup.badger")
 
 	repo1Path := path.Join(b.TempDir(), "repo-1")
-	repo1, err := badgerdb.NewRepository(repo1Path, logger.NOP)
+	repo1, err := badgerdb.NewRepository(repo1Path, logger.NOP, stats.Default)
 	require.NoError(b, err)
 
 	for i := 0; i < totalSuppressions/batchSize; i++ {
@@ -54,7 +55,7 @@ func BenchmarkBackupRestore(b *testing.B) {
 	b.Run("restore", func(b *testing.B) {
 		b.StopTimer()
 		repo2Path := path.Join(b.TempDir(), "repo-2")
-		repo2, err := badgerdb.NewRepository(repo2Path, logger.NOP)
+		repo2, err := badgerdb.NewRepository(repo2Path, logger.NOP, stats.Default)
 		require.NoError(b, err)
 
 		f, err := os.Open(backupFilename)

--- a/enterprise/suppress-user/internal/badgerdb/badgerdb_repo_test.go
+++ b/enterprise/suppress-user/internal/badgerdb/badgerdb_repo_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/enterprise/suppress-user/internal/badgerdb"
 	"github.com/rudderlabs/rudder-server/enterprise/suppress-user/internal/repotest"
 	"github.com/stretchr/testify/require"
@@ -12,7 +13,7 @@ import (
 // TestBadgerRepoSpec tests the badgerdb repository implementation.
 func TestBadgerRepoSpec(t *testing.T) {
 	path := t.TempDir()
-	repo, err := badgerdb.NewRepository(path, logger.NOP)
+	repo, err := badgerdb.NewRepository(path, logger.NOP, stats.Default)
 	require.NoError(t, err)
 	repotest.RunRepositoryTestSuite(t, repo)
 }

--- a/enterprise/suppress-user/internal/badgerdb/badgerdb_test.go
+++ b/enterprise/suppress-user/internal/badgerdb/badgerdb_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/enterprise/suppress-user/internal/badgerdb"
 	"github.com/rudderlabs/rudder-server/enterprise/suppress-user/model"
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,7 @@ func (f readerFunc) Read(p []byte) (n int, err error) {
 func TestBadgerRepository(t *testing.T) {
 	basePath := path.Join(t.TempDir(), strings.ReplaceAll(uuid.New().String(), "-", ""))
 	token := []byte("token")
-	repo, err := badgerdb.NewRepository(basePath, logger.NOP)
+	repo, err := badgerdb.NewRepository(basePath, logger.NOP, stats.Default)
 	require.NoError(t, err)
 
 	t.Run("trying to use a repository during restore", func(t *testing.T) {
@@ -86,7 +87,7 @@ func TestBadgerRepository(t *testing.T) {
 	defer func() { _ = repo.Stop() }()
 
 	t.Run("trying to start a second repository using the same path", func(t *testing.T) {
-		_, err := badgerdb.NewRepository(basePath, logger.NOP)
+		_, err := badgerdb.NewRepository(basePath, logger.NOP, stats.Default)
 		require.Error(t, err, "it should return an error when trying to start a second repository using the same path")
 	})
 
@@ -102,7 +103,7 @@ func TestBadgerRepository(t *testing.T) {
 
 	t.Run("new with seeder", func(t *testing.T) {
 		basePath := path.Join(t.TempDir(), "badger-test-2")
-		_, err := badgerdb.NewRepository(basePath, logger.NOP, badgerdb.WithSeederSource(func() (io.Reader, error) {
+		_, err := badgerdb.NewRepository(basePath, logger.NOP, stats.Default, badgerdb.WithSeederSource(func() (io.Reader, error) {
 			return buffer, nil
 		}), badgerdb.WithMaxSeedWait(1*time.Millisecond))
 		require.NoError(t, err)
@@ -132,7 +133,7 @@ func TestBadgerRepository(t *testing.T) {
 	})
 
 	t.Run("trying to use a closed repository", func(t *testing.T) {
-		repo, err := badgerdb.NewRepository(basePath, logger.NOP)
+		repo, err := badgerdb.NewRepository(basePath, logger.NOP, stats.Default)
 		require.NoError(t, err)
 		require.NoError(t, repo.Stop())
 

--- a/enterprise/suppress-user/repository.go
+++ b/enterprise/suppress-user/repository.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/enterprise/suppress-user/internal/badgerdb"
 	"github.com/rudderlabs/rudder-server/enterprise/suppress-user/internal/memory"
 	"github.com/rudderlabs/rudder-server/enterprise/suppress-user/model"
@@ -42,5 +43,5 @@ var (
 
 // NewBadgerRepository returns a new repository backed by badgerDB.
 func NewBadgerRepository(path string, log logger.Logger, opts ...badgerdb.Opt) (Repository, error) {
-	return badgerdb.NewRepository(path, log, opts...)
+	return badgerdb.NewRepository(path, log, stats.Default, opts...)
 }

--- a/services/debugger/cache/cache.go
+++ b/services/debugger/cache/cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/services/debugger/cache/internal/badger"
 	"github.com/rudderlabs/rudder-server/services/debugger/cache/internal/memory"
 )
@@ -23,7 +24,7 @@ func New[T any](ct CacheType, origin string, l logger.Logger) (Cache[T], error) 
 	switch ct {
 	case BadgerCacheType:
 		l.Info("Using badger cache")
-		return badger.New[T](origin, l)
+		return badger.New[T](origin, l, stats.Default)
 	default:
 		l.Info("Using in-memory cache")
 		return memory.New[T]()

--- a/services/debugger/cache/internal/badger/badger_test.go
+++ b/services/debugger/cache/internal/badger/badger_test.go
@@ -8,6 +8,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	svcMetric "github.com/rudderlabs/rudder-go-kit/stats/metric"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,7 +27,8 @@ var _ = Describe("cache", func() {
 		BeforeEach(func() {
 			misc.Init()
 			config.Set("LiveEvent.cache.ttl", "1s")
-			e, err = New[[]byte]("test", logger.NewLogger())
+			s := stats.NewStats(config.Default, logger.Default, svcMetric.Instance)
+			e, err = New[[]byte]("test", logger.NewLogger(), s)
 			Expect(err).To(BeNil())
 		})
 

--- a/services/dedup/dedup.go
+++ b/services/dedup/dedup.go
@@ -167,6 +167,16 @@ func (d *DedupHandleT) gcBadgerDB() {
 		if err == nil {
 			goto again
 		}
+		lsmSize, vlogSize, totSize, err := misc.GetBadgerDBUsage(d.path)
+		if err != nil {
+			d.logger.Errorf("Error while getting badgerDB usage: %v", err)
+			continue
+		}
+		statName := "dedup"
+		d.stats.NewTaggedStat("badger_db_size", stats.GaugeType, stats.Tags{"name": statName, "type": "lsm"}).Gauge((lsmSize))
+		d.stats.NewTaggedStat("badger_db_size", stats.GaugeType, stats.Tags{"name": statName, "type": "vlog"}).Gauge((vlogSize))
+		d.stats.NewTaggedStat("badger_db_size", stats.GaugeType, stats.Tags{"name": statName, "type": "total"}).Gauge((totSize))
+
 	}
 }
 

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -1328,3 +1328,58 @@ func CopyStringMap(originalMap map[string]string) map[string]string {
 	}
 	return newMap
 }
+
+func GetDiskUsageOfFile(path string) (int64, error) {
+	// Notes
+	// 1. stat.Blocks is the number of stat.Blksize blocks allocated to the file
+	// 2. stat.Blksize is the filesystem block size for this filesystem
+	// 3. We compute the actual disk usage of a (sparse) file by multiplying the number of blocks allocated to the file with the block size. This computes a different value than the one returned by stat.Size particularly for sparse files.
+	var stat syscall.Stat_t
+	err := syscall.Stat(path, &stat)
+	if err != nil {
+		return 0, fmt.Errorf("Unable to get file size %w", err)
+	}
+	return stat.Blocks * int64(stat.Blksize) / 8, nil
+}
+
+// DiskUsage calculates the path's disk usage recursively in bytes. If exts are provided, only files with matching extensions will be included in the result.
+func DiskUsage(path string, ext ...string) (int64, error) {
+	var totSize int64
+	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		size, _ := GetDiskUsageOfFile(path)
+		if len(ext) == 0 {
+			totSize += size
+		} else {
+			for _, e := range ext {
+				if filepath.Ext(path) == e {
+					totSize += size
+				}
+			}
+		}
+		return nil
+	})
+	return totSize, err
+}
+
+func GetBadgerDBUsage(dir string) (int64, int64, int64, error) {
+	// Notes
+	// Instead of using BadgerDB's internal function to get the disk usage, we are writing our own implementation because of the following reasons:
+	// 1. BadgerDB internally creates a sparse memory backed file to store the data
+	// 2. The size returned by the filepath.Walk used internally gives a misleading size because the file is mostly empty and doesn't consume any disk space
+	lsmSize, err := DiskUsage(dir, ".sst")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	vlogSize, err := DiskUsage(dir, ".vlog")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	totSize, err := DiskUsage(dir)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return lsmSize, vlogSize, totSize, nil
+}

--- a/utils/misc/misc_test.go
+++ b/utils/misc/misc_test.go
@@ -680,10 +680,10 @@ func TestGetDiskUsage(t *testing.T) {
 	// Create a temp file
 	tmpDirPath := t.TempDir()
 	tempFilePath := filepath.Join(tmpDirPath, "tempFileForDiskUsage")
-	f, err := os.OpenFile(tempFilePath, os.O_CREATE|os.O_RDWR, 0o755)
+	f, err := os.OpenFile(tempFilePath, os.O_CREATE|os.O_RDWR, 0o755) // skipcq: GSC-G302
 	require.NoError(t, err)
 
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	defer os.Remove(tempFilePath)
 
 	err = f.Truncate(1024 * 1024)
@@ -697,7 +697,7 @@ func TestGetDiskUsage(t *testing.T) {
 	require.Equal(t, int64(0), fileDiskUsage)
 
 	// write some bytes into the file
-	_, err = f.Write([]byte("test"))
+	_, err = f.WriteString("test")
 	require.NoError(t, err)
 	fileSize, err = os.Stat(tempFilePath)
 	require.NoError(t, err)

--- a/utils/misc/misc_test.go
+++ b/utils/misc/misc_test.go
@@ -674,3 +674,36 @@ func TestMapLookup(t *testing.T) {
 	}
 	require.Nil(t, MapLookup(m, "foo"))
 }
+
+func TestGetDiskUsage(t *testing.T) {
+	initMisc()
+	// Create a temp file
+	tmpDirPath := t.TempDir()
+	tempFilePath := filepath.Join(tmpDirPath, "tempFileForDiskUsage")
+	f, err := os.OpenFile(tempFilePath, os.O_CREATE|os.O_RDWR, 0o755)
+	require.NoError(t, err)
+
+	defer f.Close()
+	defer os.Remove(tempFilePath)
+
+	err = f.Truncate(1024 * 1024)
+	require.NoError(t, err)
+
+	fileSize, err := os.Stat(tempFilePath)
+	require.NoError(t, err)
+	fileDiskUsage, err := GetDiskUsageOfFile(tempFilePath)
+	require.NoError(t, err)
+	require.Equal(t, int64(1024*1024), fileSize.Size())
+	require.Equal(t, int64(0), fileDiskUsage)
+
+	// write some bytes into the file
+	_, err = f.Write([]byte("test"))
+	require.NoError(t, err)
+	fileSize, err = os.Stat(tempFilePath)
+	require.NoError(t, err)
+	fileDiskUsage, err = GetDiskUsageOfFile(tempFilePath)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(1024*1024), fileSize.Size())
+	require.Greater(t, fileDiskUsage, int64(0))
+}


### PR DESCRIPTION
# Description

Introduce metrics to monitor the disk usage of badgerDB for various services (dedup, live-events, suppress-user)

## Notion Ticket
https://www.notion.so/rudderstacks/measure-file-sizes-per-badgerDB-9e908f82c9fc448db466b021b950a87a?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
