### PR TITLE
chore(warehouse): updating snowflake application identifier

### DIFF
--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -38,7 +38,7 @@ const (
 	User               = "user"
 	Role               = "role"
 	Password           = "password"
-	Application        = "Rudderstack"
+	Application        = "Rudderstack_Warehouse"
 )
 
 var pkgLogger logger.Logger


### PR DESCRIPTION
# Description

Change the snowflake application identifier to `Rudderstack_Warehouse`

## Notion Ticket

https://www.notion.so/rudderstacks/Snowflake-connection-application-identifier-47b9edd4cc764caea3b3cb66994ced15?pvs=4

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
