### PR TITLE
fix(warehouse): table uploads were not getting updated during errors

### DIFF
--- a/warehouse/internal/repo/table_upload.go
+++ b/warehouse/internal/repo/table_upload.go
@@ -295,9 +295,6 @@ func (repo *TableUploads) Set(ctx context.Context, uploadId int64, tableName str
 		tableName,
 	}
 
-	setQuery.WriteString(fmt.Sprintf(`updated_at = $%d,`, len(queryArgs)+1))
-	queryArgs = append(queryArgs, repo.now())
-
 	if options.Status != nil {
 		setQuery.WriteString(fmt.Sprintf(`status = $%d,`, len(queryArgs)+1))
 		queryArgs = append(queryArgs, *options.Status)
@@ -322,6 +319,9 @@ func (repo *TableUploads) Set(ctx context.Context, uploadId int64, tableName str
 	if setQuery.Len() == 0 {
 		return fmt.Errorf(`no set options provided`)
 	}
+
+	setQuery.WriteString(fmt.Sprintf(`updated_at = $%d,`, len(queryArgs)+1))
+	queryArgs = append(queryArgs, repo.now())
 
 	// remove trailing comma
 	setQueryString := strings.TrimSuffix(setQuery.String(), ",")

--- a/warehouse/internal/repo/table_upload.go
+++ b/warehouse/internal/repo/table_upload.go
@@ -295,6 +295,9 @@ func (repo *TableUploads) Set(ctx context.Context, uploadId int64, tableName str
 		tableName,
 	}
 
+	setQuery.WriteString(fmt.Sprintf(`updated_at = $%d,`, len(queryArgs)+1))
+	queryArgs = append(queryArgs, repo.now())
+
 	if options.Status != nil {
 		setQuery.WriteString(fmt.Sprintf(`status = $%d,`, len(queryArgs)+1))
 		queryArgs = append(queryArgs, *options.Status)

--- a/warehouse/internal/repo/table_upload_test.go
+++ b/warehouse/internal/repo/table_upload_test.go
@@ -122,7 +122,12 @@ func TestTableUploadRepo(t *testing.T) {
 			location     = "test_location"
 			table        = tables[0]
 			totalEvents  = int64(100)
+			now          = now.Add(time.Second)
 		)
+
+		r := repo.NewTableUploads(db, repo.WithNow(func() time.Time {
+			return now
+		}))
 
 		t.Run("no set options", func(t *testing.T) {
 			err := r.Set(ctx, uploadID, table, repo.TableUploadSetOptions{})

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -1048,7 +1048,7 @@ func (job *UploadJob) loadTable(tName string) (bool, error) {
 		errorsString := misc.QuoteLiteral(err.Error())
 		_ = job.tableUploadsRepo.Set(context.TODO(), job.upload.ID, tName, repo.TableUploadSetOptions{
 			Status: &status,
-			Error: &errorsString,
+			Error:  &errorsString,
 		})
 		return alteredSchema, fmt.Errorf("load table: %w", err)
 	}

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -993,8 +993,10 @@ func (job *UploadJob) loadTable(tName string) (bool, error) {
 	alteredSchema, err := job.updateSchema(tName)
 	if err != nil {
 		status := model.TableUploadUpdatingSchemaFailed
+		errorsString := misc.QuoteLiteral(err.Error())
 		_ = job.tableUploadsRepo.Set(context.TODO(), job.upload.ID, tName, repo.TableUploadSetOptions{
 			Status: &status,
+			Error:  &errorsString,
 		})
 		return alteredSchema, fmt.Errorf("update schema: %w", err)
 	}
@@ -1043,8 +1045,10 @@ func (job *UploadJob) loadTable(tName string) (bool, error) {
 	err = job.whManager.LoadTable(tName)
 	if err != nil {
 		status := model.TableUploadExportingFailed
+		errorsString := misc.QuoteLiteral(err.Error())
 		_ = job.tableUploadsRepo.Set(context.TODO(), job.upload.ID, tName, repo.TableUploadSetOptions{
 			Status: &status,
+			Error: &errorsString,
 		})
 		return alteredSchema, fmt.Errorf("load table: %w", err)
 	}


### PR DESCRIPTION
# Description

Table uploads are not getting updated in case of load failures.

## Notion Ticket

https://www.notion.so/rudderstacks/Table-uploads-not-updates-errors-41e6eee090fc4957a528221ecc1c07f9?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
