### PR TITLE
fix: roleBasedAuth parameter wasn't being set correctly

### DIFF
--- a/utils/awsutils/session.go
+++ b/utils/awsutils/session.go
@@ -106,12 +106,12 @@ func NewSimpleSessionConfig(config map[string]interface{}, serviceName string) (
 		return nil, fmt.Errorf("unable to populate session config using destinationConfig: %w", err)
 	}
 
-	if sessionConfig.RoleBasedAuth && sessionConfig.IAMRoleARN == "" {
-		return nil, errors.New("incompatible role configuration")
-	}
-
 	if !isRoleBasedAuthFieldExist(config) {
 		sessionConfig.RoleBasedAuth = sessionConfig.IAMRoleARN != ""
+	}
+
+	if sessionConfig.RoleBasedAuth && sessionConfig.IAMRoleARN == "" {
+		return nil, errors.New("incompatible role configuration")
 	}
 
 	// Some AWS destinations are using SecretAccessKey instead of accessKey

--- a/utils/awsutils/session.go
+++ b/utils/awsutils/session.go
@@ -110,8 +110,8 @@ func NewSimpleSessionConfig(config map[string]interface{}, serviceName string) (
 		sessionConfig.RoleBasedAuth = sessionConfig.IAMRoleARN != ""
 	}
 
-	if sessionConfig.RoleBasedAuth && sessionConfig.IAMRoleARN == "" {
-		return nil, errors.New("incompatible role configuration")
+	if  sessionConfig.IAMRoleARN == "" {
+		sessionConfig.RoleBasedAuth = false
 	}
 
 	// Some AWS destinations are using SecretAccessKey instead of accessKey

--- a/utils/awsutils/session.go
+++ b/utils/awsutils/session.go
@@ -110,7 +110,7 @@ func NewSimpleSessionConfig(config map[string]interface{}, serviceName string) (
 		sessionConfig.RoleBasedAuth = sessionConfig.IAMRoleARN != ""
 	}
 
-	if  sessionConfig.IAMRoleARN == "" {
+	if sessionConfig.IAMRoleARN == "" {
 		sessionConfig.RoleBasedAuth = false
 	}
 

--- a/utils/awsutils/session_test.go
+++ b/utils/awsutils/session_test.go
@@ -162,8 +162,7 @@ func TestNewSessionConfigWithRoleBasedAuth(t *testing.T) {
 			WorkspaceID: someWorkspaceID,
 		}
 		_, err := NewSessionConfigForDestination(&destinationWithRole, httpTimeout, serviceName)
-		assert.NotNil(t, err)
-		assert.EqualError(t, err, "incompatible role configuration")
+		assert.Nil(t, err)
 	})
 }
 


### PR DESCRIPTION
# Description

Setting the sessionConfig.RoleConfigAuth parameter before throwing an error for incompatible configs

