### PR TITLE
fix(warehouse): all staging files processing failed

### DIFF
--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -285,6 +285,10 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 				successfulStagingFileIDs = append(successfulStagingFileIDs, resp.JobID)
 			}
 
+			if len(loadFiles) == 0 {
+				return nil
+			}
+
 			err = lf.LoadRepo.Insert(ctx, loadFiles)
 			if err != nil {
 				return fmt.Errorf("inserting load files: %w", err)


### PR DESCRIPTION
# Description

In case when all the staging files are getting aborted, an Update of the staging file's status is failing with `no staging files to update`. 
We need to skip updates in case there are no staging files processed successfully.

## Notion Ticket

https://www.notion.so/rudderstacks/no-staging-files-to-update-33aca1cfdcf6459fb02e1dc05cc13c81?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
