### PR TITLE
fix: identity tables load files are not generated

### DIFF
--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -1814,12 +1814,20 @@ func (job *UploadJob) areIdentityTablesLoadFilesGenerated() (bool, error) {
 	var (
 		mergeRulesTable = warehouseutils.ToProviderCase(job.warehouse.Type, warehouseutils.IdentityMergeRulesTable)
 		mappingsTable   = warehouseutils.ToProviderCase(job.warehouse.Type, warehouseutils.IdentityMappingsTable)
+		tu              model.TableUpload
+		err             error
 	)
 
-	if tu, err := job.tableUploadsRepo.GetByUploadIDAndTableName(context.TODO(), job.upload.ID, mergeRulesTable); err != nil && tu.Location == "" {
+	if tu, err = job.tableUploadsRepo.GetByUploadIDAndTableName(context.TODO(), job.upload.ID, mergeRulesTable); err != nil {
+		return false, fmt.Errorf("table upload not found for merge rules table: %w", err)
+	}
+	if tu.Location == "" {
 		return false, fmt.Errorf("merge rules location not found: %w", err)
 	}
-	if tu, err := job.tableUploadsRepo.GetByUploadIDAndTableName(context.TODO(), job.upload.ID, mappingsTable); err != nil && tu.Location == "" {
+	if tu, err = job.tableUploadsRepo.GetByUploadIDAndTableName(context.TODO(), job.upload.ID, mappingsTable); err != nil {
+		return false, fmt.Errorf("table upload not found for mappings table: %w", err)
+	}
+	if tu.Location == "" {
 		return false, fmt.Errorf("mappings location not found: %w", err)
 	}
 	return true, nil


### PR DESCRIPTION
# Description

identity tables load files are not generated

## Notion Ticket

https://www.notion.so/rudderstacks/identity-tables-load-files-are-not-generated-a93496fff93e40c2bcc46f8d565e7a7d?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
