### PR TITLE
fix: controller conn

### DIFF
--- a/services/streammanager/kafka/client/testutil/util.go
+++ b/services/streammanager/kafka/client/testutil/util.go
@@ -97,7 +97,7 @@ func (c *Client) CreateTopic(ctx context.Context, topic string, numPartitions, r
 	}()
 
 	go func() { // doing it asynchronously because controllerConn.CreateTopics() does not honour the context
-		errors <- conn.CreateTopics(kafka.TopicConfig{
+		errors <- controllerConn.CreateTopics(kafka.TopicConfig{
 			Topic:             topic,
 			NumPartitions:     numPartitions,
 			ReplicationFactor: replicationFactor,


### PR DESCRIPTION
# Description

This PR is to fix these kind of errors in our tests:

```
client_test.go:782: Could not create topic: create topic: cannot create topic with controller "kafka2:9092" and addresses [kafka1:9092 kafka2:9092 kafka3:9092]: [41] Not Controller: this is not the correct controller for this cluster
```

## Notion Ticket

< [Notion Link](https://www.notion.so/rudderstacks/Controller-conn-kafka-test-bug-96886f4c03164b32a25286fe33c45852) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
