### PR TITLE
chore: disable KeepAlives by default in transformer HTTP clients

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -104,6 +104,7 @@ func NewTransformer() *HandleT {
 
 var (
 	maxConcurrency, maxHTTPConnections, maxHTTPIdleConnections, maxRetry int
+	disableKeepAlives                                                    bool
 	retrySleep                                                           time.Duration
 	timeoutDuration                                                      time.Duration
 	pkgLogger                                                            logger.Logger
@@ -117,7 +118,8 @@ func Init() {
 func loadConfig() {
 	config.RegisterIntConfigVariable(200, &maxConcurrency, false, 1, "Processor.maxConcurrency")
 	config.RegisterIntConfigVariable(100, &maxHTTPConnections, false, 1, "Processor.maxHTTPConnections")
-	config.RegisterIntConfigVariable(50, &maxHTTPIdleConnections, false, 1, "Processor.maxHTTPIdleConnections")
+	config.RegisterIntConfigVariable(5, &maxHTTPIdleConnections, false, 1, "Processor.maxHTTPIdleConnections")
+	config.RegisterBoolConfigVariable(true, &disableKeepAlives, false, "Transformer.Client.disableKeepAlives")
 
 	config.RegisterIntConfigVariable(30, &maxRetry, true, 1, "Processor.maxRetry")
 	config.RegisterDurationConfigVariable(100, &retrySleep, true, time.Millisecond, []string{"Processor.retrySleep", "Processor.retrySleepInMS"}...)
@@ -151,6 +153,7 @@ func (trans *HandleT) Setup() {
 	if trans.Client == nil {
 		trans.Client = &http.Client{
 			Transport: &http.Transport{
+				DisableKeepAlives:   disableKeepAlives,
 				MaxConnsPerHost:     maxHTTPConnections,
 				MaxIdleConnsPerHost: maxHTTPIdleConnections,
 				IdleConnTimeout:     time.Minute,

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -86,14 +86,16 @@ func NewTransformer(netClientTimeout, backendProxyTimeout time.Duration) Transfo
 }
 
 var (
-	maxRetry   int
-	retrySleep time.Duration
-	pkgLogger  logger.Logger
+	maxRetry          int
+	disableKeepAlives bool
+	retrySleep        time.Duration
+	pkgLogger         logger.Logger
 )
 
 func loadConfig() {
 	config.RegisterIntConfigVariable(30, &maxRetry, true, 1, "Processor.maxRetry")
 	config.RegisterDurationConfigVariable(100, &retrySleep, true, time.Millisecond, []string{"Processor.retrySleep", "Processor.retrySleepInMS"}...)
+	config.RegisterBoolConfigVariable(true, &disableKeepAlives, false, "Transformer.Client.disableKeepAlives")
 }
 
 func Init() {
@@ -296,7 +298,7 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 
 func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration) {
 	trans.logger = pkgLogger
-	trans.tr = &http.Transport{}
+	trans.tr = &http.Transport{DisableKeepAlives: disableKeepAlives}
 	// The timeout between server and transformer
 	// Basically this timeout is more for communication between transformer and server
 	trans.transformTimeout = transformTimeout


### PR DESCRIPTION
# Description

Disabling keep-alives for load-balancing reasons. [This article](https://learnk8s.io/kubernetes-long-lived-connections) explains the issue.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=b15943ec4c6a4ec0a977f3331e926254&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
