### PR TITLE
fix: add externalID(workspace-id) to S3 file uploader config

### DIFF
--- a/services/fileuploader/fileuploader.go
+++ b/services/fileuploader/fileuploader.go
@@ -173,8 +173,8 @@ func overrideWithSettings(defaultConfig map[string]interface{}, settings backend
 	for k, v := range settings.Config {
 		config[k] = v
 	}
-	if _, ok := config["externalId"]; ok && settings.Type == "S3" {
-		config["externalId"] = workspaceID
+	if settings.Type == "S3" {
+		config["externalID"] = workspaceID
 	}
 	return backendconfig.StorageBucket{
 		Type:   settings.Type,

--- a/services/fileuploader/fileuploader_test.go
+++ b/services/fileuploader/fileuploader_test.go
@@ -218,10 +218,9 @@ func TestDefaultProvider(t *testing.T) {
 func TestOverride(t *testing.T) {
 	RegisterTestingT(t)
 	config := map[string]interface{}{
-		"a":          "1",
-		"b":          "2",
-		"c":          "3",
-		"externalId": "externalId",
+		"a": "1",
+		"b": "2",
+		"c": "3",
 	}
 	settings := backendconfig.StorageBucket{
 		Type: "S3",
@@ -236,6 +235,6 @@ func TestOverride(t *testing.T) {
 		"b":          "4",
 		"c":          "3",
 		"d":          "5",
-		"externalId": "wrk-1",
+		"externalID": "wrk-1",
 	}))
 }


### PR DESCRIPTION
# Description

adds `externalID`(workspaceID) to S3 fileuploader config.
The `externalID` was spelled wrong([ref](https://github.com/rudderlabs/rudder-server/blob/master/utils/misc/misc.go#L931))
Also it is a required for IAM role.
Proc_error job status:
```
{
  "Error": "error starting S3 session: externalID is required for IAM role"
}
```
Going with what's being done at batch-router as jobs uploaded to destination with same credentials succeeds but dumps being uploaded to the same bucket fails.

## Notion Ticket

[data-retention role based auth](https://www.notion.so/rudderstacks/testing-data-retention-changes-0aeba1ea3a5d4c7c80b31ec55fb3fedb?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
