### PR TITLE
fix: add externalID to S3 file uploader config

### DIFF
--- a/services/filemanager/filemanager.go
+++ b/services/filemanager/filemanager.go
@@ -101,7 +101,7 @@ func GetProviderConfigFromEnv(ctx context.Context, provider string) map[string]i
 		providerConfig["iamRoleArn"] = config.GetString("BACKUP_IAM_ROLE_ARN", "")
 		if providerConfig["iamRoleArn"] != "" {
 			backendconfig.DefaultBackendConfig.WaitForConfig(ctx)
-			providerConfig["externalId"] = backendconfig.DefaultBackendConfig.Identity().ID()
+			providerConfig["externalID"] = backendconfig.DefaultBackendConfig.Identity().ID()
 		}
 
 	case "GCS":

--- a/services/fileuploader/fileuploader.go
+++ b/services/fileuploader/fileuploader.go
@@ -173,8 +173,8 @@ func overrideWithSettings(defaultConfig map[string]interface{}, settings backend
 	for k, v := range settings.Config {
 		config[k] = v
 	}
-	if _, ok := config["externalId"]; ok && settings.Type == "S3" {
-		config["externalId"] = workspaceID
+	if settings.Type == "S3" && config["iamRoleArn"] != nil {
+		config["externalID"] = workspaceID
 	}
 	return backendconfig.StorageBucket{
 		Type:   settings.Type,

--- a/services/fileuploader/fileuploader_test.go
+++ b/services/fileuploader/fileuploader_test.go
@@ -218,10 +218,9 @@ func TestDefaultProvider(t *testing.T) {
 func TestOverride(t *testing.T) {
 	RegisterTestingT(t)
 	config := map[string]interface{}{
-		"a":          "1",
-		"b":          "2",
-		"c":          "3",
-		"externalId": "externalId",
+		"a": "1",
+		"b": "2",
+		"c": "3",
 	}
 	settings := backendconfig.StorageBucket{
 		Type: "S3",
@@ -232,10 +231,32 @@ func TestOverride(t *testing.T) {
 	}
 	bucket := overrideWithSettings(config, settings, "wrk-1")
 	Expect(bucket.Config).To(Equal(map[string]interface{}{
+		"a": "1",
+		"b": "4",
+		"c": "3",
+		"d": "5",
+	}))
+
+	config = map[string]interface{}{
+		"a":          "1",
+		"b":          "2",
+		"c":          "3",
+		"iamRoleArn": "abc",
+	}
+	settings = backendconfig.StorageBucket{
+		Type: "S3",
+		Config: map[string]interface{}{
+			"b": "4",
+			"d": "5",
+		},
+	}
+	bucket = overrideWithSettings(config, settings, "wrk-1")
+	Expect(bucket.Config).To(Equal(map[string]interface{}{
 		"a":          "1",
 		"b":          "4",
 		"c":          "3",
 		"d":          "5",
-		"externalId": "wrk-1",
+		"iamRoleArn": "abc",
+		"externalID": "wrk-1",
 	}))
 }

--- a/warehouse/api.go
+++ b/warehouse/api.go
@@ -894,7 +894,7 @@ func overrideWithEnv(settings *filemanager.SettingsT) {
 		ifNotExistThenSet("accessKey", envConfig["accessKey"], settings.Config)
 		ifNotExistThenSet("enableSSE", envConfig["enableSSE"], settings.Config)
 		ifNotExistThenSet("iamRoleARN", envConfig["iamRoleArn"], settings.Config)
-		ifNotExistThenSet("externalID", envConfig["externalId"], settings.Config)
+		ifNotExistThenSet("externalID", envConfig["externalID"], settings.Config)
 		ifNotExistThenSet("regionHint", envConfig["regionHint"], settings.Config)
 	}
 }


### PR DESCRIPTION
# Description
adds externalID(workspaceID) to S3 fileuploader config.
The externalID was [spelled wrong](https://github.com/rudderlabs/rudder-server/blob/master/utils/awsutils/session.go#L26)([correct usage](https://github.com/rudderlabs/rudder-server/blob/master/utils/misc/misc.go#L931))
Also it is a required for IAM role.
Proc_error job status:
```
{
  "Error": "error starting S3 session: externalID is required for IAM role"
}
```
Going with what's being done at batch-router as jobs uploaded to destination with same credentials succeeds but dumps being uploaded to the same bucket fails.

## Notion Ticket
[data-retention role based auth](https://www.notion.so/rudderstacks/testing-data-retention-changes-0aeba1ea3a5d4c7c80b31ec55fb3fedb?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
