### PR TITLE
fix: stats come first

### DIFF
--- a/regulation-worker/cmd/main.go
+++ b/regulation-worker/cmd/main.go
@@ -49,11 +49,6 @@ func main() {
 func Run(ctx context.Context) error {
 	config.Set("Diagnostics.enableDiagnostics", false)
 
-	admin.Init()
-	misc.Init()
-	diagnostics.Init()
-	backendconfig.Init()
-
 	stats.Default = stats.NewStats(config.Default, logger.Default, svcMetric.Instance,
 		stats.WithServiceName("regulation-worker"),
 	)
@@ -61,6 +56,11 @@ func Run(ctx context.Context) error {
 		return fmt.Errorf("failed to start stats: %w", err)
 	}
 	defer stats.Default.Stop()
+
+	admin.Init()
+	misc.Init()
+	diagnostics.Init()
+	backendconfig.Init()
 
 	if err := backendconfig.Setup(nil); err != nil {
 		return fmt.Errorf("setting up backend config: %w", err)


### PR DESCRIPTION
# Description

Some components (e.g. kafka manager from the custom destination manager workflow) were creating measurements in their `Init` and they were initialized before we overwrote `stats.Default` with `stats.NewStats()`. That caused the loss of those metrics.

This PR is an attempt to fix that issue by making sure that `stats.Default` is created before the other "inits" are called.

## Notion Ticket

< [Notion Link](https://www.notion.so/rudderstacks/Stats-order-bug-f40f6526fb18464b81453ffbbab7e8ef) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
