### PR TITLE
feat: support for incremental updates while fetching backend config

### DIFF
--- a/backend-config/backend-config.go
+++ b/backend-config/backend-config.go
@@ -42,11 +42,12 @@ var (
 	LastRegulationSync string
 
 	// DefaultBackendConfig will be initialized be Setup to either a WorkspaceConfig or MultiWorkspaceConfig.
-	DefaultBackendConfig BackendConfig
-	pkgLogger            = logger.NewLogger().Child("backend-config")
-	IoUtil               = sysUtils.NewIoUtil()
-	Diagnostics          diagnostics.DiagnosticsI
-	cacheOverride        cache.Cache
+	DefaultBackendConfig        BackendConfig
+	pkgLogger                   = logger.NewLogger().Child("backend-config")
+	IoUtil                      = sysUtils.NewIoUtil()
+	Diagnostics                 diagnostics.DiagnosticsI
+	cacheOverride               cache.Cache
+	useIncrementalConfigUpdates bool
 )
 
 func disableCache() {
@@ -98,6 +99,7 @@ func loadConfig() {
 	config.RegisterBoolConfigVariable(false, &configFromFile, false, "BackendConfig.configFromFile")
 	config.RegisterIntConfigVariable(1000, &maxRegulationsPerRequest, true, 1, "BackendConfig.maxRegulationsPerRequest")
 	config.RegisterBoolConfigVariable(true, &configEnvReplacementEnabled, false, "BackendConfig.envReplacementEnabled")
+	config.RegisterBoolConfigVariable(false, &useIncrementalConfigUpdates, false, "BackendConfig.useIncrementalConfigUpdates")
 	config.RegisterBoolConfigVariable(true, &dbCacheEnabled, false, "BackendConfig.dbCacheEnabled")
 }
 
@@ -284,10 +286,11 @@ func newForDeployment(deploymentType deployment.Type, region string, configEnvHa
 		}
 	case deployment.MultiTenantType:
 		backendConfig.workspaceConfig = &namespaceConfig{
-			configBackendURL: parsedConfigBackendURL,
-			configEnvHandler: configEnvHandler,
-			cpRouterURL:      cpRouterURL,
-			region:           region,
+			configBackendURL:            parsedConfigBackendURL,
+			configEnvHandler:            configEnvHandler,
+			cpRouterURL:                 cpRouterURL,
+			region:                      region,
+			useIncrementalConfigUpdates: useIncrementalConfigUpdates,
 		}
 	default:
 		return nil, fmt.Errorf("deployment type %q not supported", deploymentType)

--- a/backend-config/backend-config.go
+++ b/backend-config/backend-config.go
@@ -42,12 +42,12 @@ var (
 	LastRegulationSync string
 
 	// DefaultBackendConfig will be initialized be Setup to either a WorkspaceConfig or MultiWorkspaceConfig.
-	DefaultBackendConfig        BackendConfig
-	pkgLogger                   = logger.NewLogger().Child("backend-config")
-	IoUtil                      = sysUtils.NewIoUtil()
-	Diagnostics                 diagnostics.DiagnosticsI
-	cacheOverride               cache.Cache
-	useIncrementalConfigUpdates bool
+	DefaultBackendConfig     BackendConfig
+	pkgLogger                = logger.NewLogger().Child("backend-config")
+	IoUtil                   = sysUtils.NewIoUtil()
+	Diagnostics              diagnostics.DiagnosticsI
+	cacheOverride            cache.Cache
+	incrementalConfigUpdates bool
 )
 
 func disableCache() {
@@ -99,7 +99,7 @@ func loadConfig() {
 	config.RegisterBoolConfigVariable(false, &configFromFile, false, "BackendConfig.configFromFile")
 	config.RegisterIntConfigVariable(1000, &maxRegulationsPerRequest, true, 1, "BackendConfig.maxRegulationsPerRequest")
 	config.RegisterBoolConfigVariable(true, &configEnvReplacementEnabled, false, "BackendConfig.envReplacementEnabled")
-	config.RegisterBoolConfigVariable(false, &useIncrementalConfigUpdates, false, "BackendConfig.useIncrementalConfigUpdates")
+	config.RegisterBoolConfigVariable(false, &incrementalConfigUpdates, false, "BackendConfig.incrementalConfigUpdates")
 	config.RegisterBoolConfigVariable(true, &dbCacheEnabled, false, "BackendConfig.dbCacheEnabled")
 }
 
@@ -286,11 +286,11 @@ func newForDeployment(deploymentType deployment.Type, region string, configEnvHa
 		}
 	case deployment.MultiTenantType:
 		backendConfig.workspaceConfig = &namespaceConfig{
-			configBackendURL:            parsedConfigBackendURL,
-			configEnvHandler:            configEnvHandler,
-			cpRouterURL:                 cpRouterURL,
-			region:                      region,
-			useIncrementalConfigUpdates: useIncrementalConfigUpdates,
+			configBackendURL:         parsedConfigBackendURL,
+			configEnvHandler:         configEnvHandler,
+			cpRouterURL:              cpRouterURL,
+			region:                   region,
+			incrementalConfigUpdates: incrementalConfigUpdates,
 		}
 	default:
 		return nil, fmt.Errorf("deployment type %q not supported", deploymentType)

--- a/backend-config/backend_config_test.go
+++ b/backend-config/backend_config_test.go
@@ -584,14 +584,6 @@ type mockIdentifier struct {
 	token string
 }
 
-func (m *mockIdentifier) ID() string {
-	return m.key
-}
-
-func (m *mockIdentifier) BasicAuth() (string, string) {
-	return m.token, ""
-}
-
-func (*mockIdentifier) Type() deployment.Type {
-	return deployment.Type(`mockType`)
-}
+func (m *mockIdentifier) ID() string                  { return m.key }
+func (m *mockIdentifier) BasicAuth() (string, string) { return m.token, "" }
+func (*mockIdentifier) Type() deployment.Type         { return "mockType" }

--- a/backend-config/namespace_config.go
+++ b/backend-config/namespace_config.go
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	jsonfast              = jsoniter.ConfigCompatibleWithStandardLibrary
-	updateAfterTimeFormat = "2006-01-02T15:04:05Z"
+	jsonfast               = jsoniter.ConfigCompatibleWithStandardLibrary
+	updatedAfterTimeFormat = "2006-01-02T15:04:05Z"
 )
 
 type namespaceConfig struct {
@@ -97,7 +97,7 @@ func (nc *namespaceConfig) getFromAPI(ctx context.Context) (map[string]ConfigT, 
 	u.Path = fmt.Sprintf("/data-plane/v1/namespaces/%s/config", nc.namespace)
 	if useUpdateAfter {
 		values := u.Query()
-		values.Add("updatedAfter", nc.lastUpdatedAt.Format(updateAfterTimeFormat))
+		values.Add("updatedAfter", nc.lastUpdatedAt.Format(updatedAfterTimeFormat))
 		u.RawQuery = values.Encode()
 	}
 	operation := func() (fetchError error) {

--- a/backend-config/namespace_config.go
+++ b/backend-config/namespace_config.go
@@ -100,13 +100,14 @@ func (nc *namespaceConfig) getFromAPI(ctx context.Context) (map[string]ConfigT, 
 		u.RawQuery = values.Encode()
 	}
 
-	req, err := nc.prepareHTTPRequest(ctx, u.String())
+	urlString := u.String()
+	req, err := nc.prepareHTTPRequest(ctx, urlString)
 	if err != nil {
 		return configOnError, fmt.Errorf("error preparing request: %w", err)
 	}
 
 	operation := func() (fetchError error) {
-		nc.logger.Debugf("Fetching config from %s", u.String())
+		nc.logger.Debugf("Fetching config from %s", urlString)
 		respBody, fetchError = nc.makeHTTPRequest(req)
 		return fetchError
 	}

--- a/backend-config/namespace_config.go
+++ b/backend-config/namespace_config.go
@@ -103,7 +103,7 @@ func (nc *namespaceConfig) getFromAPI(ctx context.Context) (map[string]ConfigT, 
 	urlString := u.String()
 	req, err := nc.prepareHTTPRequest(ctx, urlString)
 	if err != nil {
-		return configOnError, fmt.Errorf("error preparing request: %w", err)
+		return configOnError, fmt.Errorf("error preparing request: %s: %w", urlString, err)
 	}
 
 	operation := func() (fetchError error) {

--- a/backend-config/namespace_config.go
+++ b/backend-config/namespace_config.go
@@ -90,12 +90,11 @@ func (nc *namespaceConfig) getFromAPI(ctx context.Context) (map[string]ConfigT, 
 	if nc.namespace == "" {
 		return configOnError, fmt.Errorf("namespace is not configured")
 	}
-	useUpdateAfter := nc.useIncrementalConfigUpdates && !nc.lastUpdatedAt.IsZero()
 
 	var respBody []byte
 	u := *nc.configBackendURL
 	u.Path = fmt.Sprintf("/data-plane/v1/namespaces/%s/config", nc.namespace)
-	if useUpdateAfter {
+	if nc.useIncrementalConfigUpdates && !nc.lastUpdatedAt.IsZero() {
 		values := u.Query()
 		values.Add("updatedAfter", nc.lastUpdatedAt.Format(updatedAfterTimeFormat))
 		u.RawQuery = values.Encode()

--- a/backend-config/namespace_config.go
+++ b/backend-config/namespace_config.go
@@ -34,12 +34,12 @@ type namespaceConfig struct {
 
 	hostedServiceSecret string
 
-	namespace                   string
-	configBackendURL            *url.URL
-	region                      string
-	useIncrementalConfigUpdates bool
-	lastUpdatedAt               time.Time
-	workspacesConfig            map[string]ConfigT
+	namespace                string
+	configBackendURL         *url.URL
+	region                   string
+	incrementalConfigUpdates bool
+	lastUpdatedAt            time.Time
+	workspacesConfig         map[string]ConfigT
 }
 
 func (nc *namespaceConfig) SetUp() (err error) {
@@ -94,7 +94,7 @@ func (nc *namespaceConfig) getFromAPI(ctx context.Context) (map[string]ConfigT, 
 	var respBody []byte
 	u := *nc.configBackendURL
 	u.Path = fmt.Sprintf("/data-plane/v1/namespaces/%s/config", nc.namespace)
-	if nc.useIncrementalConfigUpdates && !nc.lastUpdatedAt.IsZero() {
+	if nc.incrementalConfigUpdates && !nc.lastUpdatedAt.IsZero() {
 		values := u.Query()
 		values.Add("updatedAfter", nc.lastUpdatedAt.Format(updatedAfterTimeFormat))
 		u.RawQuery = values.Encode()
@@ -151,7 +151,7 @@ func (nc *namespaceConfig) getFromAPI(ctx context.Context) (map[string]ConfigT, 
 		workspace.ConnectionFlags.URL = nc.cpRouterURL
 		workspace.ConnectionFlags.Services = map[string]bool{"warehouse": true}
 		workspacesConfig[workspaceID] = *workspace
-		if nc.useIncrementalConfigUpdates && workspace.UpdatedAt.After(nc.lastUpdatedAt) {
+		if nc.incrementalConfigUpdates && workspace.UpdatedAt.After(nc.lastUpdatedAt) {
 			nc.lastUpdatedAt = workspace.UpdatedAt
 		}
 	}

--- a/backend-config/namespace_config.go
+++ b/backend-config/namespace_config.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	jsonfast               = jsoniter.ConfigCompatibleWithStandardLibrary
-	updatedAfterTimeFormat = "2006-01-02T15:04:05Z"
+	updatedAfterTimeFormat = "2006-01-02T15:04:05.000Z"
 )
 
 type namespaceConfig struct {

--- a/backend-config/namespace_config_test.go
+++ b/backend-config/namespace_config_test.go
@@ -210,10 +210,10 @@ func Test_Namespace_IncrementalUpdates(t *testing.T) {
 		client:           ts.Client(),
 		configBackendURL: httpSrvURL,
 
-		namespace:                   namespace,
-		hostedServiceSecret:         secret,
-		cpRouterURL:                 cpRouterURL,
-		useIncrementalConfigUpdates: true,
+		namespace:                namespace,
+		hostedServiceSecret:      secret,
+		cpRouterURL:              cpRouterURL,
+		incrementalConfigUpdates: true,
 	}
 	require.NoError(t, client.SetUp())
 

--- a/backend-config/testdata/sample_namespace.json
+++ b/backend-config/testdata/sample_namespace.json
@@ -1,5 +1,6 @@
 {
     "2CCgbmvBSa8Mv81YaIgtR36M7aW": {
+        "updatedAt" : "2022-07-20T10:00:00.000Z",
         "sources": [
             {
                 "config": {},

--- a/backend-config/types.go
+++ b/backend-config/types.go
@@ -1,6 +1,8 @@
 package backendconfig
 
 import (
+	"time"
+
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
@@ -91,6 +93,7 @@ type ConfigT struct {
 	Libraries       LibrariesT      `json:"libraries"`
 	ConnectionFlags ConnectionFlags `json:"flags"`
 	Settings        Settings        `json:"settings"`
+	UpdatedAt       time.Time       `json:"updatedAt"`
 }
 
 type Settings struct {


### PR DESCRIPTION
# Description

We have added support to fetch incremental updates from the control-plane while getting the workspace configs for a particular workspace. The way it works is when we first fetch the config from the control-plane, the config corresponding to every workspace has the **updateAt** field set. The control-plane api also supports a parameter called **updatedAfter** , which if passed, is expected to return only those workspaces which have seen a change. The semantics of the behavior is such that we keep track of the last value of the **updateAt** field in the various workspaces and pass that in subsequent request to only get the updates which are then applied on top of the previously maintained state of the configs. 

## Notion Ticket

https://www.notion.so/rudderstacks/use-test-updatedAt-for-backend-config-1701f037ed644f36b2a8fe37b143a0e2?pvs=4
