### PR TITLE
chore: redshift changes

### DIFF
--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -641,6 +641,8 @@ func (rs *Redshift) loadTable(tableName string, tableSchemaInUpload, tableSchema
 		)
 
 		if result, err = txn.Exec(query); err != nil {
+			err = warehouseutils.NormalizePQError(err)
+
 			rs.Logger.Warnw("deleting from original table for dedup",
 				logfield.SourceID, rs.Warehouse.Source.ID,
 				logfield.SourceType, rs.Warehouse.Source.SourceDefinition.Name,
@@ -723,6 +725,8 @@ func (rs *Redshift) loadTable(tableName string, tableSchemaInUpload, tableSchema
 	)
 
 	if _, err = txn.Exec(query); err != nil {
+		err = warehouseutils.NormalizePQError(err)
+
 		rs.Logger.Warnw("failed inserting into original table",
 			logfield.SourceID, rs.Warehouse.Source.ID,
 			logfield.SourceType, rs.Warehouse.Source.SourceDefinition.Name,

--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -456,7 +456,7 @@ func (rs *Redshift) loadTable(tableName string, tableSchemaInUpload, tableSchema
 	}
 
 	if !skipTempTableDelete {
-		//defer rs.dropStagingTables([]string{stagingTableName})
+		// defer rs.dropStagingTables([]string{stagingTableName})
 	}
 
 	manifestS3Location, region := warehouseutils.GetS3Location(manifestLocation)
@@ -800,7 +800,7 @@ func (rs *Redshift) loadUserTables() map[string]error {
 		}
 	}
 
-	//defer rs.dropStagingTables([]string{identifyStagingTable})
+	// defer rs.dropStagingTables([]string{identifyStagingTable})
 
 	if len(rs.Uploader.GetTableSchemaInUpload(warehouseutils.UsersTable)) == 0 {
 		return map[string]error{
@@ -913,7 +913,7 @@ func (rs *Redshift) loadUserTables() map[string]error {
 			warehouseutils.UsersTable:      fmt.Errorf("creating staging table for users: %w", err),
 		}
 	}
-	//defer rs.dropStagingTables([]string{stagingTableName})
+	// defer rs.dropStagingTables([]string{stagingTableName})
 
 	primaryKey := "id"
 	query = fmt.Sprintf(`
@@ -1378,7 +1378,7 @@ func (rs *Redshift) TestConnection(warehouse model.Warehouse) (err error) {
 
 func (rs *Redshift) Cleanup() {
 	if rs.DB != nil {
-		//rs.dropDanglingStagingTables()
+		// rs.dropDanglingStagingTables()
 		_ = rs.DB.Close()
 	}
 }
@@ -1391,7 +1391,7 @@ func (rs *Redshift) CrashRecover(warehouse model.Warehouse) (err error) {
 		return err
 	}
 	defer func() { _ = rs.DB.Close() }()
-	//rs.dropDanglingStagingTables()
+	// rs.dropDanglingStagingTables()
 	return
 }
 

--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -456,7 +456,7 @@ func (rs *Redshift) loadTable(tableName string, tableSchemaInUpload, tableSchema
 	}
 
 	if !skipTempTableDelete {
-		defer rs.dropStagingTables([]string{stagingTableName})
+		//defer rs.dropStagingTables([]string{stagingTableName})
 	}
 
 	manifestS3Location, region := warehouseutils.GetS3Location(manifestLocation)
@@ -800,7 +800,7 @@ func (rs *Redshift) loadUserTables() map[string]error {
 		}
 	}
 
-	defer rs.dropStagingTables([]string{identifyStagingTable})
+	//defer rs.dropStagingTables([]string{identifyStagingTable})
 
 	if len(rs.Uploader.GetTableSchemaInUpload(warehouseutils.UsersTable)) == 0 {
 		return map[string]error{
@@ -913,7 +913,7 @@ func (rs *Redshift) loadUserTables() map[string]error {
 			warehouseutils.UsersTable:      fmt.Errorf("creating staging table for users: %w", err),
 		}
 	}
-	defer rs.dropStagingTables([]string{stagingTableName})
+	//defer rs.dropStagingTables([]string{stagingTableName})
 
 	primaryKey := "id"
 	query = fmt.Sprintf(`
@@ -1378,7 +1378,7 @@ func (rs *Redshift) TestConnection(warehouse model.Warehouse) (err error) {
 
 func (rs *Redshift) Cleanup() {
 	if rs.DB != nil {
-		rs.dropDanglingStagingTables()
+		//rs.dropDanglingStagingTables()
 		_ = rs.DB.Close()
 	}
 }
@@ -1391,7 +1391,7 @@ func (rs *Redshift) CrashRecover(warehouse model.Warehouse) (err error) {
 		return err
 	}
 	defer func() { _ = rs.DB.Close() }()
-	rs.dropDanglingStagingTables()
+	//rs.dropDanglingStagingTables()
 	return
 }
 

--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -559,6 +559,8 @@ func (rs *Redshift) loadTable(tableName string, tableSchemaInUpload, tableSchema
 	)
 
 	if _, err := txn.Exec(query); err != nil {
+		err = warehouseutils.NormalizePQError(err)
+
 		rs.Logger.Warnw("failure running copy command",
 			logfield.SourceID, rs.Warehouse.Source.ID,
 			logfield.SourceType, rs.Warehouse.Source.SourceDefinition.Name,

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -994,11 +994,24 @@ func ReadAsBool(key string, config map[string]interface{}) bool {
 
 func NormalizePQError(err error) error {
 	if pqErr, ok := err.(*pq.Error); ok {
-		return fmt.Errorf("pq: severity: %s, code: %s, message: %s, detail: %s",
+		return fmt.Errorf("pq: severity: %s, code: %s, message: %s, detail: %s, hint: %s, position: %s, internal position: %s, internal query: %s, where: %s, schema: %s, table: %s, column: %s, datatype: %s, constraint: %s, file: %s, line: %s, routine: %s",
 			pqErr.Severity,
 			pqErr.Code,
 			pqErr.Message,
 			pqErr.Detail,
+			pqErr.Hint,
+			pqErr.Position,
+			pqErr.InternalPosition,
+			pqErr.InternalQuery,
+			pqErr.Where,
+			pqErr.Schema,
+			pqErr.Table,
+			pqErr.Column,
+			pqErr.DataTypeName,
+			pqErr.Constraint,
+			pqErr.File,
+			pqErr.Line,
+			pqErr.Routine,
 		)
 	}
 	return err

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lib/pq"
+
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
@@ -988,4 +990,16 @@ func ReadAsBool(key string, config map[string]interface{}) bool {
 		}
 	}
 	return false
+}
+
+func NormalizePQError(err error) error {
+	if pqErr, ok := err.(*pq.Error); ok {
+		return fmt.Errorf("pq: severity: %s, code: %s, message: %s, detail: %s",
+			pqErr.Severity,
+			pqErr.Code,
+			pqErr.Message,
+			pqErr.Detail,
+		)
+	}
+	return err
 }

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -108,7 +108,7 @@ const (
 )
 
 const (
-	stagingTablePrefix = "rudder_staging_"
+	stagingTablePrefix = "test_rudder_staging_"
 )
 
 // Object storages


### PR DESCRIPTION
# Description

### Before normalizing

 `load table: running copy command: severity: Spectrum Scan Error`

### After normalizing
`load table: running copy command: severity: ERROR, code: XX000, message: Spectrum Scan Error, detail: \n  -----------------------------------------------\n  error:  Spectrum Scan Error\n  code:      15007\n  context:   Unmatched number of columns between table and file. Table columns: 20, Data columns: 16, File name: https://s3.us-east-1.amazonaws.com/akash-dev/rudder-warehouse-load-objects/test_truncated/279L3gEKqwruBoKGsXZtSVX7vIy/876dd8c6-d98e-492d-8c03-fbb5da865d7b-t\n  query:     26301369\n  location:  dory_util.cpp:1450\n  process:   worker_thread [pid=10836]`

## Notion Ticket

https://www.notion.so/rudderstacks/redshift-error-handling-cad6b54563d54e9da480a7badb9fd73c?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
