### PR TITLE
chore: error enrichment for redshift

### DIFF
--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -654,7 +654,7 @@ func (rs *Redshift) loadTable(tableName string, tableSchemaInUpload, tableSchema
 				logfield.Query, query,
 				logfield.Error, err.Error(),
 			)
-			return "", fmt.Errorf("deleting from original table for dedup: %w", err)
+			return "", fmt.Errorf("deleting from original table for dedup: %w", normalizeError(err))
 		}
 
 		if rowsAffected, err = result.RowsAffected(); err != nil {
@@ -943,7 +943,7 @@ func (rs *Redshift) loadUserTables() map[string]error {
 			logfield.Error, err.Error(),
 		)
 		return map[string]error{
-			warehouseutils.UsersTable: fmt.Errorf("deleting from original table for dedup: %w", err),
+			warehouseutils.UsersTable: fmt.Errorf("deleting from original table for dedup: %w", normalizeError(err)),
 		}
 	}
 


### PR DESCRIPTION
# Description

### Before normalizing

 `'load table: running copy command: pq: Spectrum Scan Error'`

### After normalizing
```
'load table: running copy command: pq: message: Spectrum Scan Error, detail: 
  -----------------------------------------------
  error:  Spectrum Scan Error
  code:      15007
  context:   File ''https://s3.us-east-1.amazonaws.com/akash-dev/rudder-warehouse-load-objects/test_varchar_512/279L3gEKqwruBoKGsXZtSVX7vIy/79adf26f-0c8b-45b3-a021-56f168c50fc3-test_varchar_512/1681051854.279L3gEKqwruBoKGsXZtSVX7vIy.9511b0dc-f4ec-4f36-a197-15571560d6f8.
  query:     26599180
  location:  dory_util.cpp:1450
  process:   worker_thread [pid=10160]
  -----------------------------------------------
'
```

## Notion Ticket

https://www.notion.so/rudderstacks/Redshift-error-handling-cad6b54563d54e9da480a7badb9fd73c?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
