### PR TITLE
feat: source level isolation at processor

### DIFF
--- a/enterprise/replay/replay.go
+++ b/enterprise/replay/replay.go
@@ -110,6 +110,7 @@ func (handle *Handler) generatorLoop(ctx context.Context) {
 				ErrorCode:     "",
 				ErrorResponse: []byte(`{}`), // check
 				Parameters:    []byte(`{}`), // check
+				JobParameters: job.Parameters,
 			}
 			statusList = append(statusList, &status)
 			toProcess = append(toProcess, workerJobT{worker: w, job: job})

--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -51,6 +51,7 @@ func (worker *SourceWorkerT) workerProcess(ctx context.Context) {
 			ErrorCode:     "",
 			ErrorResponse: []byte(`{}`), // check
 			Parameters:    []byte(`{}`), // check
+			JobParameters: job.Parameters,
 		}
 		err := worker.replayHandler.db.UpdateJobStatus(ctx, []*jobsdb.JobStatusT{&status}, []string{"replay"}, nil)
 		if err != nil {

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
@@ -317,7 +318,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 				continue
 			}
 
-			if misc.Contains(sourceListForParsingParams, strings.ToLower(breq.sourceType)) {
+			if slices.Contains(sourceListForParsingParams, strings.ToLower(breq.sourceType)) {
 				queryParams := req.request.URL.Query()
 				paramsBytes, err := json.Marshal(queryParams)
 				if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,6 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
-	github.com/thoas/go-funk v0.9.3
 	github.com/tidwall/gjson v1.14.4
 	github.com/tidwall/sjson v1.2.5
 	github.com/urfave/cli/v2 v2.25.1

--- a/go.sum
+++ b/go.sum
@@ -1941,8 +1941,6 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/testcontainers/testcontainers-go v0.14.0 h1:h0D5GaYG9mhOWr2qHdEKDXpkce/VlvaYOCzTRi6UBi8=
 github.com/testcontainers/testcontainers-go v0.14.0/go.mod h1:hSRGJ1G8Q5Bw2gXgPulJOLlEBaYJHeBSOkQM5JLG+JQ=
-github.com/thoas/go-funk v0.9.3 h1:7+nAEx3kn5ZJcnDm2Bh23N2yOtweO14bi//dvRtgLpw=
-github.com/thoas/go-funk v0.9.3/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/throttled/throttled/v2 v2.11.0 h1:/udbW8pGpm5SutM3OvAk6ygAC3/PbmoVvSkq9xbzjxI=
 github.com/throttled/throttled/v2 v2.11.0/go.mod h1:qT849G1rYAXypqSrqtSCewU1p7lNmWDZNBBBSAZUvj8=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -33,11 +33,7 @@ func (jd *HandleT) DeleteExecuting() {
 	_ = jd.executeDbRequest(newWriteDbRequest("delete_job_status", &tags, command))
 }
 
-/*
-deleteJobStatus deletes the latest status of a batch of jobs
-This is only done during recovery, which happens during the server start.
-So, we don't have to worry about dsEmptyResultCache
-*/
+// deleteJobStatus deletes the latest status of a batch of jobs
 func (jd *HandleT) deleteJobStatus() {
 	err := jd.WithUpdateSafeTx(context.TODO(), func(tx UpdateSafeTx) error {
 		defer jd.getTimerStat(
@@ -54,7 +50,7 @@ func (jd *HandleT) deleteJobStatus() {
 				return err
 			}
 			tx.Tx().AddSuccessListener(func() {
-				jd.dropDSFromCache(ds)
+				jd.noResultsCache.InvalidateDataset(ds.Index)
 			})
 		}
 
@@ -98,11 +94,7 @@ func (jd *HandleT) FailExecuting() {
 	_ = jd.executeDbRequest(newWriteDbRequest("fail_executing", &tags, command))
 }
 
-/*
-failExecuting sets the state of the executing jobs to failed
-This is only done during recovery, which happens during the server start.
-So, we don't have to worry about dsEmptyResultCache
-*/
+// failExecuting sets the state of the executing jobs to failed
 func (jd *HandleT) failExecuting() {
 	err := jd.WithUpdateSafeTx(context.TODO(), func(tx UpdateSafeTx) error {
 		defer jd.getTimerStat(
@@ -119,7 +111,7 @@ func (jd *HandleT) failExecuting() {
 				return err
 			}
 			tx.Tx().AddSuccessListener(func() {
-				jd.dropDSFromCache(ds)
+				jd.noResultsCache.InvalidateDataset(ds.Index)
 			})
 		}
 		return nil

--- a/jobsdb/internal/cache/cache.go
+++ b/jobsdb/internal/cache/cache.go
@@ -1,0 +1,313 @@
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"golang.org/x/exp/slices"
+)
+
+const (
+	wildcard = "*"
+)
+
+// NewNoResultsCache creates a new, properly initialised NoResultsCache.
+func NewNoResultsCache[T ParameterFilter](supportedParams []string, ttlFn func() time.Duration) *NoResultsCache[T] {
+	return &NoResultsCache[T]{
+		ttl:             ttlFn,
+		supportedParams: supportedParams,
+		cacheTree:       make(cacheTree),
+	}
+}
+
+type ParameterFilter interface {
+	GetName() string
+	GetValue() string
+}
+
+type NoResultsCache[T ParameterFilter] struct {
+	ttl             func() time.Duration // returns the time to live for a cache entry
+	supportedParams []string             // a list of parameters that are supported by the cache
+
+	cacheTreeMu sync.RWMutex // protects the cacheTree
+	cacheTree   cacheTree    // a hierarchical tree of cache entries
+}
+
+// Get returns true if the cache contains a valid entry for the provided dataset, workspace, customVals, states and parameters filters.
+func (c *NoResultsCache[T]) Get(dataset, workspace string, customVals, states []string, parameters []T) bool {
+	if c.skipCache(states, parameters) {
+		return false
+	}
+	workspace, states, customVals, params := filtersToCacheKeys(workspace, states, customVals, parameters)
+
+	c.cacheTreeMu.RLock()
+	defer c.cacheTreeMu.RUnlock()
+
+	if _, ok := c.cacheTree[dataset]; !ok {
+		return false
+	}
+	if _, ok := c.cacheTree[dataset][workspace]; !ok {
+		return false
+	}
+	for _, customVal := range customVals {
+		if _, ok := c.cacheTree[dataset][workspace][customVal]; !ok {
+			return false
+		}
+		for _, state := range states {
+			if _, ok := c.cacheTree[dataset][workspace][customVal][state]; !ok {
+				return false
+			}
+			for _, param := range params {
+				if mark, ok := c.cacheTree[dataset][workspace][customVal][state][param]; !ok || !mark.noJobs || time.Now().After(mark.t.Add(c.ttl())) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+// Invalidate invalidates all cache entries for the provided dataset, workspace, customVals, states and parameters.
+func (c *NoResultsCache[T]) Invalidate(dataset, workspace string, customVals, states []string, parameters []T) {
+	c.cacheTreeMu.Lock()
+	defer c.cacheTreeMu.Unlock()
+	workspaces, states, customVals, params := c.filtersToInvalidationKeys(workspace, states, customVals, parameters)
+
+	if len(workspaces) == 0 { // if no workspace is provided, invalidate all by deleting the workspace's parent node
+		delete(c.cacheTree, dataset)
+		return
+	}
+	if _, ok := c.cacheTree[dataset]; !ok {
+		return
+	}
+	for _, workspace := range workspaces {
+		if len(customVals) == 0 { // if no custom value is provided, invalidate all by deleting the customVal's parent node
+			delete(c.cacheTree[dataset], workspace)
+			continue
+		}
+		if _, ok := c.cacheTree[dataset][workspace]; !ok {
+			continue
+		}
+		for _, customVal := range customVals {
+			if len(states) == 0 { // if no state is provided, invalidate all by deleting the state's parent node
+				delete(c.cacheTree[dataset][workspace], customVal)
+				continue
+			}
+			if _, ok := c.cacheTree[dataset][workspace][customVal]; !ok {
+				continue
+			}
+			for _, state := range states {
+				if len(params) == 0 { // if no parameter is provided, invalidate all by deleting the param's parent node
+					delete(c.cacheTree[dataset][workspace][customVal], state)
+					continue
+				}
+				if _, ok := c.cacheTree[dataset][workspace][customVal][state]; !ok {
+					continue
+				}
+				for _, param := range params {
+					delete(c.cacheTree[dataset][workspace][customVal][state], param)
+				}
+			}
+		}
+	}
+}
+
+// InvalidateDataset invalidates all cache entries for a given dataset.
+func (c *NoResultsCache[T]) InvalidateDataset(dataset string) {
+	c.Invalidate(dataset, "", nil, nil, nil)
+}
+
+// StartNoResultTx prepares the cache for accepting new no result entries.
+// The cache uses a special marker to prevent synchronisation issues between competing calls of Invalidate & SetNoResult.
+func (c *NoResultsCache[T]) StartNoResultTx(dataset, workspace string, customVals, states []string, parameters []T) (tx *NoResultTx[T]) {
+	tx = &NoResultTx[T]{
+		id:         uuid.New().String(),
+		dataset:    dataset,
+		workspace:  workspace,
+		customVals: customVals,
+		states:     states,
+		parameters: parameters,
+		c:          c,
+	}
+	if c.skipCache(states, parameters) {
+		return
+	}
+	workspace, states, customVals, params := filtersToCacheKeys(workspace, states, customVals, parameters)
+
+	c.cacheTreeMu.Lock()
+	defer c.cacheTreeMu.Unlock()
+
+	if _, ok := c.cacheTree[dataset]; !ok {
+		c.cacheTree[dataset] = map[string]map[string]map[string]map[string]cacheEntry{}
+	}
+	if _, ok := c.cacheTree[dataset][workspace]; !ok {
+		c.cacheTree[dataset][workspace] = map[string]map[string]map[string]cacheEntry{}
+	}
+	for _, customVal := range customVals {
+		if _, ok := c.cacheTree[dataset][workspace][customVal]; !ok {
+			c.cacheTree[dataset][workspace][customVal] = map[string]map[string]cacheEntry{}
+		}
+		for _, state := range states {
+			if _, ok := c.cacheTree[dataset][workspace][customVal][state]; !ok {
+				c.cacheTree[dataset][workspace][customVal][state] = map[string]cacheEntry{}
+			}
+			for _, param := range params {
+				e := c.cacheTree[dataset][workspace][customVal][state][param]
+				e.AddToken(tx.id)
+				c.cacheTree[dataset][workspace][customVal][state][param] = e
+			}
+		}
+	}
+	return
+}
+
+// NoResultTx is a transaction for the NoResultsCache.
+type NoResultTx[T ParameterFilter] struct {
+	id                 string
+	dataset, workspace string
+	customVals, states []string
+	parameters         []T
+	c                  *NoResultsCache[T]
+}
+
+// Commit sets the necessary cache entries for the relevant dataset, workspace, states, customVals and parameters filters.
+func (tx *NoResultTx[T]) Commit() {
+	if tx.c.skipCache(tx.states, tx.parameters) {
+		return
+	}
+	workspace, states, customVals, params := filtersToCacheKeys(tx.workspace, tx.states, tx.customVals, tx.parameters)
+
+	tx.c.cacheTreeMu.Lock()
+	defer tx.c.cacheTreeMu.Unlock()
+
+	if _, ok := tx.c.cacheTree[tx.dataset]; !ok {
+		return
+	}
+	if _, ok := tx.c.cacheTree[tx.dataset][workspace]; !ok {
+		return
+	}
+	for _, customVal := range customVals {
+		if _, ok := tx.c.cacheTree[tx.dataset][workspace][customVal]; !ok {
+			continue
+		}
+		for _, state := range states {
+			if _, ok := tx.c.cacheTree[tx.dataset][workspace][customVal][state]; !ok {
+				continue
+			}
+			for _, param := range params {
+				e := tx.c.cacheTree[tx.dataset][workspace][customVal][state][param]
+				if e.SetNoJobs(tx.id) {
+					tx.c.cacheTree[tx.dataset][workspace][customVal][state][param] = e
+				}
+			}
+		}
+	}
+}
+
+// skipCache returns true if the cache should be skipped for the provided states and parameters.
+func (c *NoResultsCache[T]) skipCache(states []string, parameters []T) bool {
+	// if no state filters are provided, we don't use the cache
+	if len(states) == 0 {
+		return true
+	}
+	// if not all parameter filters are a subset of the supported parameters, we don't use the cache
+	if !lo.EveryBy(parameters, func(pf T) bool {
+		return slices.Contains(c.supportedParams, pf.GetName())
+	}) {
+		return true
+	}
+	return false
+}
+
+// filtersToCacheKeys returns the cache keys for the provided workspace, states, customVals and parameters filters.
+// Wildcards are used if empty parameters are provided.
+func filtersToCacheKeys[T ParameterFilter](workspaceFilter string, statesFilter, customValsFilter []string, parametersFilter []T) (workspaceKey string, stateKeys, customValKeys, paramKeys []string) {
+	workspaceKey = workspaceFilter
+	if workspaceKey == "" { // if no workspace is provided, we use the wildcard
+		workspaceKey = wildcard
+	}
+	stateKeys = statesFilter
+
+	customValKeys = customValsFilter
+	if len(customValKeys) == 0 { // if no custom value is provided, use the wildcard
+		customValKeys = []string{wildcard}
+	}
+	paramKeys = lo.Map(parametersFilter, func(pf T, _ int) string {
+		return pf.GetName() + ":" + pf.GetValue()
+	})
+	if len(paramKeys) == 0 { // if no parameter is provided, we use the wildcard
+		paramKeys = []string{wildcard}
+	}
+	return workspaceKey, stateKeys, customValKeys, paramKeys
+}
+
+// filtersToInvalidationKeys returns the cache keys that need to be invalidated for the provided workspace, states, customVals and parameters filters.
+// Wildcard keys are also returned if needed. An empty slice is returned if all keys need to be invalidated at that level.
+func (c *NoResultsCache[T]) filtersToInvalidationKeys(workspaceFilter string, statesFilter, customValsFilter []string, parametersFilter []T) (workspaceKeys, stateKeys, customValKeys, paramKeys []string) {
+	if workspaceFilter != "" {
+		workspaceKeys = []string{workspaceFilter, wildcard}
+	}
+	stateKeys = statesFilter
+	if len(customValsFilter) > 0 { // include customVals along with the wildcard
+		customValKeys = make([]string, len(customValsFilter)+1)
+		copy(customValKeys, customValsFilter)
+		customValKeys[len(customValsFilter)] = wildcard
+	}
+
+	paramKeys = lo.FilterMap(parametersFilter, func(pf T, _ int) (string, bool) {
+		return pf.GetName() + ":" + pf.GetValue(), slices.Contains(c.supportedParams, pf.GetName())
+	})
+	if len(paramKeys) > 0 { // include params along with the wildcard
+		paramKeys = append(paramKeys, wildcard)
+	}
+	return workspaceKeys, stateKeys, customValKeys, paramKeys
+}
+
+// String returns a string representation of the cache's tree contents.
+func (c *NoResultsCache[T]) String() string {
+	if c == nil {
+		return "Cache is nil"
+	}
+	c.cacheTreeMu.RLock()
+	defer c.cacheTreeMu.RUnlock()
+	return fmt.Sprintf("%+v", c.cacheTree)
+}
+
+type (
+	datasetKey   = string
+	workspaceKey = string
+	customValKey = string
+	stateKey     = string
+	paramKey     = string
+	cacheTree    map[datasetKey]map[workspaceKey]map[customValKey]map[stateKey]map[paramKey]cacheEntry
+)
+
+type cacheEntry struct {
+	noJobs bool
+	tokens []string
+	t      time.Time
+}
+
+// AddToken adds a token to the cache entry and removes the oldest one if there are more than 10.
+func (ce *cacheEntry) AddToken(token string) {
+	ce.tokens = append(ce.tokens, token)
+	if len(ce.tokens) > 10 {
+		ce.tokens = lo.Slice(ce.tokens, 0, 10)
+	}
+}
+
+// SetNoJobs sets the noJobs flag to true if the provided token is found in the cache entry.
+func (ce *cacheEntry) SetNoJobs(token string) bool {
+	for i := len(ce.tokens) - 1; i >= 0; i-- {
+		if ce.tokens[i] == token {
+			ce.noJobs = true
+			ce.t = time.Now()
+			ce.tokens = slices.Delete(ce.tokens, i, i+1)
+			return true
+		}
+	}
+	return false
+}

--- a/jobsdb/internal/cache/cache_internal_test.go
+++ b/jobsdb/internal/cache/cache_internal_test.go
@@ -1,0 +1,30 @@
+package cache
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheEntry(t *testing.T) {
+	t.Run("AddToken", func(t *testing.T) {
+		e := cacheEntry{}
+		for i := 0; i < 10; i++ {
+			e.AddToken(fmt.Sprintf("token-%d", i))
+			require.Len(t, e.tokens, i+1)
+		}
+		e.AddToken("token1")
+		require.Len(t, e.tokens, 10)
+	})
+
+	t.Run("SetNoJobs", func(t *testing.T) {
+		e := cacheEntry{}
+		token := "token"
+		e.AddToken(token)
+		require.True(t, e.SetNoJobs(token))
+		require.True(t, e.noJobs)
+		require.Len(t, e.tokens, 0)
+		require.False(t, e.SetNoJobs(token), "it shouldn't be able to set no jobs twice with the same token")
+	})
+}

--- a/jobsdb/internal/cache/cache_test.go
+++ b/jobsdb/internal/cache/cache_test.go
@@ -1,0 +1,296 @@
+package cache_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/jobsdb/internal/cache"
+	"github.com/stretchr/testify/require"
+)
+
+type paramFilter struct {
+	name  string
+	value string
+}
+
+func (p paramFilter) GetName() string {
+	return p.name
+}
+
+func (p paramFilter) GetValue() string {
+	return p.value
+}
+
+func TestNoResultsCache(t *testing.T) {
+	const (
+		dataset   = "dataset"
+		workspace = "workspace"
+		customVal = "customVal"
+		state     = "state"
+	)
+	supportedParamFilters := []string{"param1", "param2"}
+	ttl := 10 * time.Millisecond
+	ttlFunc := func() time.Duration {
+		return ttl
+	}
+
+	t.Run("Prepare, Set, Get", func(t *testing.T) {
+		c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, ttlFunc)
+
+		t.Run("calling Get without having set anything", func(t *testing.T) {
+			require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}), "it should return false if noresult is not set")
+		})
+
+		c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+		require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}), "it should return true if no result is set for valid token")
+
+		t.Run("expiration", func(t *testing.T) {
+			require.Eventually(t, func() bool {
+				return !c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+			}, 2*ttl, 1*time.Millisecond, "it should eventually expire after ttl and return false")
+		})
+
+		t.Run("A Prepare doesn't affect the existing state", func(t *testing.T) {
+			c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+			require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}), "it should return true if no result is set for valid token")
+
+			_ = c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+			require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}), "it should return true if no result is set for valid token")
+		})
+	})
+
+	t.Run("Invalidation", func(t *testing.T) {
+		t.Run("between StartNoResultTx and SetNoResult", func(t *testing.T) {
+			c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, func() time.Duration { return time.Hour })
+			tx := c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+			c.Invalidate(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+			tx.Commit()
+			require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}), "it should return false if invalidation is called before SetNoResult")
+		})
+
+		t.Run("after SetNoResult", func(t *testing.T) {
+			c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, func() time.Duration { return time.Hour })
+			c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+			require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+			c.Invalidate(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+			require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}), "it should return false after invalidation")
+		})
+
+		t.Run("InvalidateDataset", func(t *testing.T) {
+			c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, func() time.Duration { return time.Hour })
+
+			// set for 2 workspaces
+			c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+			require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+
+			c.StartNoResultTx(dataset, "other", []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+			require.True(t, c.Get(dataset, "other", []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+
+			// set for another dataset
+			c.StartNoResultTx("other", workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+			require.True(t, c.Get("other", workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+
+			c.InvalidateDataset(dataset)
+			require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+			require.False(t, c.Get(dataset, "other", []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+			require.True(t, c.Get("other", workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+		})
+
+		t.Run("Wildcard", func(t *testing.T) {
+			c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, func() time.Duration { return time.Hour })
+			c.StartNoResultTx(dataset, "", []string{}, []string{state}, []paramFilter{}).Commit()
+			require.True(t, c.Get(dataset, "", []string{}, []string{state}, []paramFilter{}))
+
+			c.Invalidate(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+			require.False(t, c.Get(dataset, "", []string{}, []string{state}, []paramFilter{}))
+		})
+
+		t.Run("Missing information during invalidate causes to invalidate parents", func(t *testing.T) {
+			t.Run("no workspace provided", func(t *testing.T) {
+				c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, func() time.Duration { return time.Hour })
+
+				// set for 2 workspaces
+				c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+				require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+
+				c.StartNoResultTx(dataset, "other", []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+				require.True(t, c.Get(dataset, "other", []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+
+				// set for another dataset
+				c.StartNoResultTx("other", workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+				require.True(t, c.Get("other", workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+
+				c.Invalidate(dataset, "", []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+				require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+				require.False(t, c.Get(dataset, "other", []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+				require.True(t, c.Get("other", workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+			})
+
+			t.Run("no customVal provided", func(t *testing.T) {
+				c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, func() time.Duration { return time.Hour })
+
+				// set for 2 customVals
+				c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+				require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+
+				c.StartNoResultTx(dataset, workspace, []string{"other"}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+				require.True(t, c.Get(dataset, workspace, []string{"other"}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+
+				// set for another workspace
+				c.StartNoResultTx(dataset, "other", []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+				require.True(t, c.Get(dataset, "other", []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+
+				c.Invalidate(dataset, workspace, []string{}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+				require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+				require.False(t, c.Get(dataset, workspace, []string{"other"}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+				require.True(t, c.Get(dataset, "other", []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+			})
+
+			t.Run("no state provided", func(t *testing.T) {
+				c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, func() time.Duration { return time.Hour })
+
+				// set for 2 states
+				c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+				require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+
+				c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{"other"}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+				require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{"other"}, []paramFilter{{name: "param1", value: "value1"}}))
+
+				// set for another customVal
+				c.StartNoResultTx(dataset, workspace, []string{"other"}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+				require.True(t, c.Get(dataset, workspace, []string{"other"}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+
+				c.Invalidate(dataset, workspace, []string{customVal}, []string{}, []paramFilter{{name: "param1", value: "value1"}})
+				require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+				require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{"other"}, []paramFilter{{name: "param1", value: "value1"}}))
+				require.True(t, c.Get(dataset, workspace, []string{"other"}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+			})
+
+			t.Run("no param provided", func(t *testing.T) {
+				c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, func() time.Duration { return time.Hour })
+
+				// set for 2 params
+				c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+				require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+
+				c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param2", value: "value1"}}).Commit()
+				require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param2", value: "value1"}}))
+
+				// set for another state
+				c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{"other"}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+				require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{"other"}, []paramFilter{{name: "param1", value: "value1"}}))
+
+				c.Invalidate(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{})
+				require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+				require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param2", value: "value1"}}))
+				require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{"other"}, []paramFilter{{name: "param1", value: "value1"}}))
+			})
+		})
+
+		t.Run("Missing noResult keys", func(t *testing.T) {
+			c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, func() time.Duration { return time.Hour })
+			c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+			require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+
+			t.Run("different dataset", func(t *testing.T) {
+				c.Invalidate("other", workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+				require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+			})
+
+			t.Run("different workspace", func(t *testing.T) {
+				c.Invalidate(dataset, "other", []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+				require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+			})
+
+			t.Run("different customVal", func(t *testing.T) {
+				c.Invalidate(dataset, workspace, []string{"other"}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+				require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+			})
+
+			t.Run("different state", func(t *testing.T) {
+				c.Invalidate(dataset, workspace, []string{customVal}, []string{"other"}, []paramFilter{{name: "param1", value: "value1"}})
+				require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+			})
+
+			t.Run("different param", func(t *testing.T) {
+				c.Invalidate(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param2", value: "value1"}})
+				require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+			})
+		})
+	})
+
+	t.Run("Ignore caching", func(t *testing.T) {
+		c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, ttlFunc)
+
+		t.Run("no states are used", func(t *testing.T) {
+			c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+			require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{}, []paramFilter{{name: "param1", value: "value1"}}))
+		})
+
+		t.Run("invalid parameters are used", func(t *testing.T) {
+			c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}, {name: "param3", value: "value3"}}).Commit()
+			require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}, {name: "param3", value: "value3"}}))
+		})
+	})
+
+	t.Run("Get exceptions", func(t *testing.T) {
+		c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, ttlFunc)
+		c.StartNoResultTx(dataset, "", []string{}, []string{state}, []paramFilter{}).Commit()
+
+		t.Run("using an non-existent workspace", func(t *testing.T) {
+			require.False(t, c.Get(dataset, "other", []string{}, []string{state}, []paramFilter{}))
+		})
+
+		t.Run("using an non-existent customVal", func(t *testing.T) {
+			require.False(t, c.Get(dataset, "", []string{"other"}, []string{state}, []paramFilter{}))
+		})
+
+		t.Run("using an non-existent state", func(t *testing.T) {
+			require.False(t, c.Get(dataset, "", []string{}, []string{"other"}, []paramFilter{}))
+		})
+
+		t.Run("using a valid but non-existent param", func(t *testing.T) {
+			require.False(t, c.Get(dataset, "", []string{}, []string{state}, []paramFilter{{name: "param2", value: "value1"}}))
+		})
+	})
+
+	t.Run("Set exceptions", func(t *testing.T) {
+		c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, ttlFunc)
+		c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+
+		t.Run("using an non-existent workspace", func(t *testing.T) {
+			tx := c.StartNoResultTx(dataset, "other", []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+			c.Invalidate(dataset, "other", nil, nil, nil)
+			tx.Commit()
+			require.False(t, c.Get(dataset, "other", []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+		})
+
+		t.Run("using an non-existent customVal", func(t *testing.T) {
+			tx := c.StartNoResultTx(dataset, workspace, []string{"other"}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
+			c.Invalidate(dataset, workspace, []string{"other"}, nil, nil)
+			tx.Commit()
+			require.False(t, c.Get(dataset, workspace, []string{"other"}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+		})
+
+		t.Run("using an non-existent state", func(t *testing.T) {
+			tx := c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{"other"}, []paramFilter{{name: "param1", value: "value1"}})
+			c.Invalidate(dataset, workspace, []string{customVal}, []string{"other"}, nil)
+			tx.Commit()
+			require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{"other"}, []paramFilter{{name: "param1", value: "value1"}}))
+		})
+
+		t.Run("using a valid but non-existent param", func(t *testing.T) {
+			tx := c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param2", value: "value1"}})
+			c.Invalidate(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param2", value: "value1"}})
+			tx.Commit()
+			require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param2", value: "value1"}}))
+		})
+	})
+
+	t.Run("Print", func(t *testing.T) {
+		c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, ttlFunc)
+		c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+		require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}))
+		require.Contains(t, c.String(), "map[dataset:map[workspace:map[customVal:map[state:map[param1:value1:{noJobs:true tokens:[] t:")
+	})
+}

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"compress/gzip"
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -481,8 +483,8 @@ func (*backupTestCase) getJobsFromAbortedJobs(t *testing.T, file *os.File) ([]*J
 	buf := make([]byte, maxCapacity)
 	sc.Buffer(buf, maxCapacity)
 
-	jobs := []*JobT{}
-	statusList := []*JobStatusT{}
+	var jobs []*JobT
+	var statusList []*JobStatusT
 
 	for sc.Scan() {
 		lineByte := sc.Bytes()
@@ -553,7 +555,7 @@ func (*backupTestCase) readGzipJobFile(filename string) ([]*JobT, error) {
 	buf := make([]byte, maxCapacity)
 	sc.Buffer(buf, maxCapacity)
 
-	jobs := []*JobT{}
+	var jobs []*JobT
 	for sc.Scan() {
 		lineByte := sc.Bytes()
 		uuid := uuid.MustParse("69359037-9599-48e7-b8f2-48393c019135")
@@ -592,7 +594,7 @@ func (*backupTestCase) readGzipStatusFile(fileName string) ([]*JobStatusT, error
 	buf := make([]byte, maxCapacity)
 	sc.Buffer(buf, maxCapacity)
 
-	statusList := []*JobStatusT{}
+	var statusList []*JobStatusT
 	for sc.Scan() {
 		lineByte := sc.Bytes()
 		jobStatus := &JobStatusT{
@@ -630,4 +632,75 @@ func getStatusByWorkspace(jobStatus []*JobStatusT, jobsByWorkspace map[string][]
 		}
 	}
 	return jobStatusByWorkspace
+}
+
+func (jd *HandleT) copyJobStatusDS(ctx context.Context, tx *Tx, ds dataSetT, statusList []*JobStatusT, customValFilters []string) (err error) {
+	if len(statusList) == 0 {
+		return nil
+	}
+	tags := statTags{CustomValFilters: customValFilters, ParameterFilters: nil}
+	_, err = jd.updateJobStatusDSInTx(ctx, tx, ds, statusList, tags)
+	if err != nil {
+		return err
+	}
+	// We are manually triggering ANALYZE to help with query planning since a large
+	// amount of rows are being copied in the table in a very short time and
+	// AUTOVACUUM might not have a chance to do its work before we start querying
+	// this table
+	_, err = tx.ExecContext(ctx, fmt.Sprintf(`ANALYZE %q`, ds.JobStatusTable))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (jd *HandleT) copyJobsDS(tx *Tx, ds dataSetT, jobList []*JobT) error { // When fixing callers make sure error is handled with assertError
+	defer jd.getTimerStat(
+		"copy_jobs",
+		&statTags{CustomValFilters: []string{jd.tablePrefix}},
+	).RecordDuration()()
+
+	tx.AddSuccessListener(func() {
+		jd.invalidateCacheForJobs(ds, jobList)
+	})
+	return jd.copyJobsDSInTx(tx, ds, jobList)
+}
+
+func (*HandleT) copyJobsDSInTx(txHandler transactionHandler, ds dataSetT, jobList []*JobT) error {
+	var stmt *sql.Stmt
+	var err error
+
+	stmt, err = txHandler.Prepare(pq.CopyIn(ds.JobTable, "job_id", "uuid", "user_id", "custom_val", "parameters",
+		"event_payload", "event_count", "created_at", "expire_at", "workspace_id"))
+
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = stmt.Close() }()
+
+	for _, job := range jobList {
+		eventCount := 1
+		if job.EventCount > 1 {
+			eventCount = job.EventCount
+		}
+
+		_, err = stmt.Exec(job.JobID, job.UUID, job.UserID, job.CustomVal, string(job.Parameters),
+			string(job.EventPayload), eventCount, job.CreatedAt, job.ExpireAt, job.WorkspaceId)
+
+		if err != nil {
+			return err
+		}
+	}
+	if _, err = stmt.Exec(); err != nil {
+		return err
+	}
+
+	// We are manually triggering ANALYZE to help with query planning since a large
+	// amount of rows are being copied in the table in a very short time and
+	// AUTOVACUUM might not have a chance to do its work before we start querying
+	// this table
+	_, err = txHandler.Exec(fmt.Sprintf(`ANALYZE %q`, ds.JobTable))
+	return err
 }

--- a/jobsdb/jobsdb_renameDs_test.go
+++ b/jobsdb/jobsdb_renameDs_test.go
@@ -38,8 +38,14 @@ func Test_mustRenameDS(t *testing.T) {
 	requireRowsCount(t, dbHandle, jobsTable, 3)
 	requireRowsCount(t, dbHandle, jobStatusTable, 3)
 
+	mustRenameDS := func(ds dataSetT) error {
+		return jobsdb.WithTx(func(tx *Tx) error {
+			return jobsdb.mustRenameDSInTx(tx, ds)
+		})
+	}
+
 	// when I execute the renameDs method
-	err := jobsdb.mustRenameDS(dataSetT{
+	err := mustRenameDS(dataSetT{
 		JobTable:       jobsTable,
 		JobStatusTable: jobStatusTable,
 	})
@@ -77,8 +83,14 @@ func Test_mustRenameDS_drops_table_if_left_empty(t *testing.T) {
 	requireRowsCount(t, dbHandle, jobsTable, 2)
 	requireRowsCount(t, dbHandle, jobStatusTable, 2)
 
+	mustRenameDS := func(ds dataSetT) error {
+		return jobsdb.WithTx(func(tx *Tx) error {
+			return jobsdb.mustRenameDSInTx(tx, ds)
+		})
+	}
+
 	// when I execute the renameDs method
-	err := jobsdb.mustRenameDS(dataSetT{
+	err := mustRenameDS(dataSetT{
 		JobTable:       jobsTable,
 		JobStatusTable: jobStatusTable,
 	})

--- a/jobsdb/unionQuery.go
+++ b/jobsdb/unionQuery.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-server/jobsdb/internal/cache"
 )
 
 type MultiTenantHandleT struct {
@@ -182,16 +183,17 @@ func (mj *MultiTenantHandleT) getUnionDS(ctx context.Context, ds dataSetT, picku
 	if len(workspacesToQuery) == 0 {
 		return jobList, nil
 	}
+	cacheTXs := map[string]*cache.NoResultTx[ParameterFilterT]{}
 	for _, workspace := range workspacesToQuery {
 		if _, ok := skipCache[workspace]; !ok {
-			mj.markClearEmptyResult(ds, workspace, conditions.StateFilters, conditions.CustomValFilters, conditions.ParameterFilters,
-				willTryToSet, nil)
+			cacheTx := mj.noResultsCache.StartNoResultTx(ds.Index, workspace, conditions.CustomValFilters, conditions.StateFilters, conditions.ParameterFilters)
+			cacheTXs[workspace] = cacheTx
 		}
 	}
 
-	cacheUpdateByWorkspace := make(map[string]string)
+	cacheNoJobsByWorkspace := make(map[string]bool)
 	for _, workspace := range workspacesToQuery {
-		cacheUpdateByWorkspace[workspace] = string(noJobs)
+		cacheNoJobsByWorkspace[workspace] = true
 	}
 
 	var rows *sql.Rows
@@ -223,7 +225,9 @@ func (mj *MultiTenantHandleT) getUnionDS(ctx context.Context, ds dataSetT, picku
 			return jobList, err
 		}
 
-		job.LastJobStatus = JobStatusT{}
+		job.LastJobStatus = JobStatusT{
+			JobParameters: job.Parameters,
+		}
 		if _nullJS.Valid {
 			job.LastJobStatus.JobState = _nullJS.String
 		}
@@ -261,18 +265,15 @@ func (mj *MultiTenantHandleT) getUnionDS(ctx context.Context, ds dataSetT, picku
 				}
 			}
 		}
-		cacheUpdateByWorkspace[job.WorkspaceId] = string(hasJobs)
+		cacheNoJobsByWorkspace[job.WorkspaceId] = false
 	}
 	if err = rows.Err(); err != nil {
 		return jobList, err
 	}
 
-	// do cache stuff here
-	_willTryToSet := willTryToSet
-	for workspace, cacheUpdate := range cacheUpdateByWorkspace {
-		if _, ok := skipCache[workspace]; !ok {
-			mj.markClearEmptyResult(ds, workspace, conditions.StateFilters, conditions.CustomValFilters, conditions.ParameterFilters,
-				cacheValue(cacheUpdate), &_willTryToSet)
+	for workspace, noJobs := range cacheNoJobsByWorkspace {
+		if _, ok := skipCache[workspace]; !ok && noJobs {
+			cacheTXs[workspace].Commit()
 		}
 	}
 
@@ -285,7 +286,7 @@ func (mj *MultiTenantHandleT) getUnionQuerystring(pickup map[string]*workspacePi
 
 	for workspace, wp := range pickup {
 		count := wp.Limit
-		if mj.isEmptyResult(ds, workspace, conditions.StateFilters, conditions.CustomValFilters, conditions.ParameterFilters) {
+		if mj.noResultsCache.Get(ds.Index, workspace, conditions.CustomValFilters, conditions.StateFilters, conditions.ParameterFilters) {
 			continue
 		}
 		if count <= 0 {

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -76,6 +76,21 @@ func (mr *MockJobsDBMockRecorder) GetActiveWorkspaces(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveWorkspaces", reflect.TypeOf((*MockJobsDB)(nil).GetActiveWorkspaces), arg0)
 }
 
+// GetDistinctParameterValues mocks base method.
+func (m *MockJobsDB) GetDistinctParameterValues(arg0 context.Context, arg1 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDistinctParameterValues", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDistinctParameterValues indicates an expected call of GetDistinctParameterValues.
+func (mr *MockJobsDBMockRecorder) GetDistinctParameterValues(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDistinctParameterValues", reflect.TypeOf((*MockJobsDB)(nil).GetDistinctParameterValues), arg0, arg1)
+}
+
 // GetExecuting mocks base method.
 func (m *MockJobsDB) GetExecuting(arg0 context.Context, arg1 jobsdb.GetQueryParamsT) (jobsdb.JobsResult, error) {
 	m.ctrl.T.Helper()

--- a/processor/integrations/integrations.go
+++ b/processor/integrations/integrations.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/types"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 	"github.com/tidwall/gjson"
+	"golang.org/x/exp/slices"
 )
 
 var (
@@ -167,7 +168,7 @@ func GetTransformerURL() string {
 // GetDestinationURL returns node URL
 func GetDestinationURL(destType string) string {
 	destinationEndPoint := fmt.Sprintf("%s/v0/destinations/%s", destTransformURL, strings.ToLower(destType))
-	if misc.Contains(warehouseutils.WarehouseDestinations, destType) {
+	if slices.Contains(warehouseutils.WarehouseDestinations, destType) {
 		whSchemaVersionQueryParam := fmt.Sprintf("whSchemaVersion=%s&whIDResolve=%v", config.GetString("Warehouse.schemaVersion", "v1"), warehouseutils.IDResolutionEnabled())
 		if destType == "RS" {
 			return destinationEndPoint + "?" + whSchemaVersionQueryParam

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -17,6 +17,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
@@ -544,7 +545,7 @@ func (proc *Handle) loadConfig() {
 	defaultReadLoopSleepMs := int64(200)
 	defaultMaxLoopSleeppMs := int64(5000)
 
-	defaultIsolationMode := isolation.ModeNone
+	defaultIsolationMode := isolation.ModeSource
 	if config.IsSet("WORKSPACE_NAMESPACE") {
 		defaultIsolationMode = isolation.ModeWorkspace
 	}
@@ -1420,7 +1421,7 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob, parsedE
 					continue
 				}
 
-				if proc.config.enableDedup && misc.Contains(duplicateIndexes, eventIndex) {
+				if proc.config.enableDedup && slices.Contains(duplicateIndexes, eventIndex) {
 					proc.logger.Debugf("Dropping event with duplicate messageId: %s", messageId)
 					misc.IncrementMapByKey(sourceDupStats, writeKey, 1)
 					continue
@@ -1538,6 +1539,7 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob, parsedE
 			ErrorCode:     "200",
 			ErrorResponse: []byte(`{"success":"OK"}`),
 			Parameters:    []byte(`{}`),
+			JobParameters: batchEvent.Parameters,
 			WorkspaceId:   batchEvent.WorkspaceId,
 		}
 		statusList = append(statusList, &newStatus)
@@ -2373,7 +2375,7 @@ func (proc *Handle) transformSrcDest(
 				EventPayload: destEventJSON,
 				WorkspaceId:  workspaceId,
 			}
-			if misc.Contains(proc.config.batchDestinations, newJob.CustomVal) {
+			if slices.Contains(proc.config.batchDestinations, newJob.CustomVal) {
 				batchDestJobs = append(batchDestJobs, &newJob)
 			} else {
 				destJobs = append(destJobs, &newJob)
@@ -2433,7 +2435,7 @@ func ConvertToFilteredTransformerResponse(events []transformer.TransformerEventT
 					continue
 				}
 				messageType = strings.TrimSpace(strings.ToLower(messageType))
-				if !misc.Contains(supportedTypes.values, messageType) {
+				if !slices.Contains(supportedTypes.values, messageType) {
 					continue
 				}
 			}
@@ -2454,7 +2456,7 @@ func ConvertToFilteredTransformerResponse(events []transformer.TransformerEventT
 					failedEvents = append(failedEvents, resp)
 					continue
 				}
-				if !misc.Contains(supportedEvents.values, messageEvent) {
+				if !slices.Contains(supportedEvents.values, messageEvent) {
 					continue
 				}
 			}
@@ -2554,6 +2556,7 @@ func (proc *Handle) markExecuting(jobs []*jobsdb.JobT) error {
 			ErrorCode:     "",
 			ErrorResponse: []byte(`{}`),
 			Parameters:    []byte(`{}`),
+			JobParameters: job.Parameters,
 			WorkspaceId:   job.WorkspaceId,
 		}
 	}

--- a/processor/processor_isolation_test.go
+++ b/processor/processor_isolation_test.go
@@ -61,65 +61,73 @@ func TestProcessorIsolation(t *testing.T) {
 // -v \
 // -count=1 |grep BenchmarkProcessorIsolationModes
 // BenchmarkProcessorIsolationModes
-// BenchmarkProcessorIsolationModes/no_isolation_10_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/no_isolation_10_workspaces_200000_total_jobs-10         	       1	59231884750 ns/op	        45.74 overall_duration_sec
-// BenchmarkProcessorIsolationModes/workspace_isolation_10_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/workspace_isolation_10_workspaces_200000_total_jobs-10  	       1	53940493625 ns/op	        42.09 overall_duration_sec
-// BenchmarkProcessorIsolationModes/no_isolation_50_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/no_isolation_50_workspaces_200000_total_jobs-10         	       1	61723605875 ns/op	        48.85 overall_duration_sec
-// BenchmarkProcessorIsolationModes/workspace_isolation_50_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/workspace_isolation_50_workspaces_200000_total_jobs-10  	       1	54179625166 ns/op	        43.46 overall_duration_sec
-// BenchmarkProcessorIsolationModes/no_isolation_100_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/no_isolation_100_workspaces_200000_total_jobs-10        	       1	60094660500 ns/op	        48.34 overall_duration_sec
-// BenchmarkProcessorIsolationModes/workspace_isolation_100_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/workspace_isolation_100_workspaces_200000_total_jobs-10 	       1	58543965292 ns/op	        47.58 overall_duration_sec
-// BenchmarkProcessorIsolationModes/no_isolation_200_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/no_isolation_200_workspaces_200000_total_jobs-10        	       1	59670751833 ns/op	        47.68 overall_duration_sec
-// BenchmarkProcessorIsolationModes/workspace_isolation_200_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/workspace_isolation_200_workspaces_200000_total_jobs-10 	       1	66366145500 ns/op	        51.19 overall_duration_sec
-// BenchmarkProcessorIsolationModes/no_isolation_500_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/no_isolation_500_workspaces_200000_total_jobs-10        	       1	69775513875 ns/op	        48.78 overall_duration_sec
-// BenchmarkProcessorIsolationModes/workspace_isolation_500_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/workspace_isolation_500_workspaces_200000_total_jobs-10 	       1	71046349167 ns/op	        57.88 overall_duration_sec
-// BenchmarkProcessorIsolationModes/no_isolation_1000_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/no_isolation_1000_workspaces_200000_total_jobs-10       	       1	62591102750 ns/op	        48.95 overall_duration_sec
-// BenchmarkProcessorIsolationModes/workspace_isolation_1000_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/workspace_isolation_1000_workspaces_200000_total_jobs-10   	       1	77994220792 ns/op	        64.62 overall_duration_sec
-// BenchmarkProcessorIsolationModes/no_isolation_10000_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/no_isolation_10000_workspaces_200000_total_jobs-10         	       1	66160071708 ns/op	        52.72 overall_duration_sec
-// BenchmarkProcessorIsolationModes/workspace_isolation_10000_workspaces_200000_total_jobs
-// BenchmarkProcessorIsolationModes/workspace_isolation_10000_workspaces_200000_total_jobs-10  	       1	148012983583 ns/op	       127.4 overall_duration_sec
-//
-// https://snapshots.raintank.io/dashboard/snapshot/9643HY7OqrsYae1HuAjAz167953NOCN3
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_10_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_10_total_jobs_200000-10         	       1	73042697042 ns/op	        43.55 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_10_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_10_total_jobs_200000-10    	       1	69209445166 ns/op	        56.55 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_10_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_10_total_jobs_200000-10       	       1	71106239750 ns/op	        56.47 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_50_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_50_total_jobs_200000-10         	       1	82385831083 ns/op	        69.61 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_50_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_50_total_jobs_200000-10    	       1	72104657333 ns/op	        56.94 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_50_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_50_total_jobs_200000-10       	       1	68407738000 ns/op	        54.77 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_100_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_100_total_jobs_200000-10        	       1	77992348375 ns/op	        65.44 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_100_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_100_total_jobs_200000-10   	       1	68580986375 ns/op	        55.83 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_100_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_100_total_jobs_200000-10      	       1	69483415750 ns/op	        55.81 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_200_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_200_total_jobs_200000-10        	       1	83725871750 ns/op	        72.55 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_200_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_200_total_jobs_200000-10   	       1	67370016208 ns/op	        56.02 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_200_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_200_total_jobs_200000-10      	       1	68468731833 ns/op	        57.48 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_500_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_500_total_jobs_200000-10        	       1	112563037291 ns/op	        99.25 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_500_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_500_total_jobs_200000-10   	       1	66369215792 ns/op	        55.00 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_500_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_500_total_jobs_200000-10      	       1	67725539583 ns/op	        56.37 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_1000_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_1000_total_jobs_200000-10       	       1	160692931875 ns/op	       148.7 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_1000_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_1000_total_jobs_200000-10  	       1	73783787083 ns/op	        57.48 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_1000_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_1000_total_jobs_200000-10     	       1	72094473125 ns/op	        57.55 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_10000_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_none_workspaces_10000_total_jobs_200000-10      	       1	264327524125 ns/op	       251.5 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_10000_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_workspace_workspaces_10000_total_jobs_200000-10 	       1	170777786959 ns/op	       145.3 overall_duration_sec
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_10000_total_jobs_200000
+// BenchmarkProcessorIsolationModes/isolation_mode_source_workspaces_10000_total_jobs_200000-10    	       1	167364648542 ns/op	       144.3 overall_duration_sec
+// https://snapshots.raintank.io/dashboard/snapshot/xugaw44VT5dYMQ2ynyBbvM4FZfxFvD5D
 func BenchmarkProcessorIsolationModes(b *testing.B) {
-	benchmarkModes := func(b *testing.B, workspaces, totalJobs int) {
-		title := fmt.Sprintf("no isolation %d workspaces %d total jobs", workspaces, totalJobs)
-
-		b.Run(title, func(b *testing.B) {
-			stats.Default.NewTaggedStat("benchmark", stats.CountType, stats.Tags{"title": title, "action": "start"}).Increment()
-			defer stats.Default.NewTaggedStat("benchmark", stats.CountType, stats.Tags{"title": title, "action": "end"}).Increment()
-			spec := NewProcIsolationScenarioSpec(isolation.ModeNone, workspaces, totalJobs/workspaces)
-			overallDuration := ProcIsolationScenario(b, spec)
-			b.ReportMetric(overallDuration.Seconds(), "overall_duration_sec")
-		})
-
-		title = fmt.Sprintf("workspace isolation %d workspaces %d total jobs", workspaces, totalJobs)
-		b.Run(title, func(b *testing.B) {
-			stats.Default.NewTaggedStat("benchmark", stats.CountType, stats.Tags{"title": title, "action": "start"}).Increment()
-			defer stats.Default.NewTaggedStat("benchmark", stats.CountType, stats.Tags{"title": title, "action": "end"}).Increment()
-			spec := NewProcIsolationScenarioSpec(isolation.ModeWorkspace, workspaces, totalJobs/workspaces)
-			overallDuration := ProcIsolationScenario(b, spec)
-			b.ReportMetric(overallDuration.Seconds(), "overall_duration_sec")
-		})
+	benchModes := func(b *testing.B, workspaces, totalJobs int) {
+		bench := func(mode isolation.Mode) {
+			title := fmt.Sprintf("isolation mode %s workspaces %d total jobs %d", mode, workspaces, totalJobs)
+			b.Run(title, func(b *testing.B) {
+				stats.Default.NewTaggedStat("benchmark", stats.CountType, stats.Tags{"title": title, "action": "start"}).Increment()
+				defer stats.Default.NewTaggedStat("benchmark", stats.CountType, stats.Tags{"title": title, "action": "end"}).Increment()
+				spec := NewProcIsolationScenarioSpec(mode, workspaces, totalJobs/workspaces)
+				overallDuration := ProcIsolationScenario(b, spec)
+				b.ReportMetric(overallDuration.Seconds(), "overall_duration_sec")
+			})
+		}
+		bench(isolation.ModeNone)
+		bench(isolation.ModeWorkspace)
+		bench(isolation.ModeSource)
 	}
 
-	benchmarkModes(b, 10, 200000)
-	benchmarkModes(b, 50, 200000)
-	benchmarkModes(b, 100, 200000)
-	benchmarkModes(b, 200, 200000)
-	benchmarkModes(b, 500, 200000)
-	benchmarkModes(b, 1000, 200000)
-	benchmarkModes(b, 10000, 200000)
+	benchModes(b, 10, 200000)
+	benchModes(b, 50, 200000)
+	benchModes(b, 100, 200000)
+	benchModes(b, 200, 200000)
+	benchModes(b, 500, 200000)
+	benchModes(b, 1000, 200000)
+	benchModes(b, 10000, 200000)
 }
 
 // ProcIsolationScenarioSpec is a specification for a processor isolation scenario.

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -287,6 +287,7 @@ func (st *HandleT) setErrJobStatus(jobs []*jobsdb.JobT, output StoreErrorOutputT
 			ErrorCode:     "",
 			ErrorResponse: errorResp,
 			Parameters:    []byte(`{}`),
+			JobParameters: job.Parameters,
 			WorkspaceId:   job.WorkspaceId,
 		}
 		statusList = append(statusList, &status)
@@ -374,6 +375,7 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 					ErrorCode:     "",
 					ErrorResponse: []byte(`{}`),
 					Parameters:    []byte(`{}`),
+					JobParameters: job.Parameters,
 					WorkspaceId:   job.WorkspaceId,
 				}
 

--- a/processor/testdata/procIsolationTestTemplate.json.tpl
+++ b/processor/testdata/procIsolationTestTemplate.json.tpl
@@ -7,7 +7,7 @@
         "sources": [
             {
                 "config": {},
-                "id": "xxxyyyzzEaEurW247ad9WYZLUyk",
+                "id": "{{$workspace}}",
                 "name": "Dev Integration Test 1",
                 "writeKey": "{{$workspace}}",
                 "enabled": true,

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -21,9 +21,9 @@ import (
 	"github.com/google/uuid"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/samber/lo"
-	"github.com/thoas/go-funk"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager"
 	"github.com/rudderlabs/rudder-server/router/rterror"
@@ -191,7 +191,7 @@ func (brt *HandleT) backendConfigSubscriber() {
 							brt.destinationsMap[destination.ID].Sources = append(brt.destinationsMap[destination.ID].Sources, source)
 
 							// initialize map to track encountered anonymousIds for a warehouse destination
-							if warehouseutils.IDResolutionEnabled() && misc.Contains(warehouseutils.IdentityEnabledWarehouses, brt.destType) {
+							if warehouseutils.IDResolutionEnabled() && slices.Contains(warehouseutils.IdentityEnabledWarehouses, brt.destType) {
 								connIdentifier := connectionIdentifier(DestinationT{Destination: destination, Source: source})
 								warehouseConnIdentifier := brt.warehouseConnectionIdentifier(connIdentifier, source, destination)
 								brt.connectionWHNamespaceMap[connIdentifier] = warehouseConnIdentifier
@@ -304,14 +304,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 			for key := range destinationsMap {
 				if IsAsyncDestination(brt.destType) {
 					pkgLogger.Debugf("pollAsyncStatus Started for Dest type: %s", brt.destType)
-					parameterFilters := make([]jobsdb.ParameterFilterT, 0)
-					for _, param := range jobsdb.CacheKeyParameterFilters {
-						parameterFilter := jobsdb.ParameterFilterT{
-							Name:  param,
-							Value: key,
-						}
-						parameterFilters = append(parameterFilters, parameterFilter)
-					}
+					parameterFilters := []jobsdb.ParameterFilterT{{Name: "destination_id", Value: key}}
 					job, err := misc.QueryWithRetriesAndNotify(ctx, brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
 						return brt.jobsDB.GetImporting(
 							ctx,
@@ -392,6 +385,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 											ErrorCode:     "",
 											ErrorResponse: []byte(`{}`),
 											Parameters:    []byte(`{}`),
+											JobParameters: job.Parameters,
 											WorkspaceId:   job.WorkspaceId,
 										}
 										statusList = append(statusList, &status)
@@ -439,6 +433,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 												ErrorCode:     strconv.Itoa(statusCode),
 												ErrorResponse: []byte(`{}`),
 												Parameters:    []byte(`{}`),
+												JobParameters: job.Parameters,
 												WorkspaceId:   job.WorkspaceId,
 											}
 											statusList = append(statusList, status)
@@ -462,7 +457,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 									}
 									for _, job := range importingList {
 										jobID := job.JobID
-										if misc.Contains(append(succeededKeys, warningKeys...), jobID) {
+										if slices.Contains(append(succeededKeys, warningKeys...), jobID) {
 											status = &jobsdb.JobStatusT{
 												JobID:         jobID,
 												JobState:      jobsdb.Succeeded.State,
@@ -471,9 +466,10 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 												ErrorCode:     "200",
 												ErrorResponse: []byte(`{}`),
 												Parameters:    []byte(`{}`),
+												JobParameters: job.Parameters,
 												WorkspaceId:   job.WorkspaceId,
 											}
-										} else if misc.Contains(failedKeys, job.JobID) {
+										} else if slices.Contains(failedKeys, job.JobID) {
 											errorResp, _ := json.Marshal(ErrorResponseT{Error: gjson.GetBytes(failedBodyBytes, fmt.Sprintf("metadata.failedReasons.%v", job.JobID)).String()})
 											status = &jobsdb.JobStatusT{
 												JobID:         jobID,
@@ -483,6 +479,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 												ErrorCode:     "",
 												ErrorResponse: errorResp,
 												Parameters:    []byte(`{}`),
+												JobParameters: job.Parameters,
 												WorkspaceId:   job.WorkspaceId,
 											}
 											abortedJobs = append(abortedJobs, job)
@@ -544,6 +541,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 											ErrorCode:     "",
 											ErrorResponse: []byte(`{}`),
 											Parameters:    []byte(`{}`),
+											JobParameters: job.Parameters,
 											WorkspaceId:   job.WorkspaceId,
 										}
 										statusList = append(statusList, &status)
@@ -560,6 +558,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 											ErrorCode:     "",
 											ErrorResponse: []byte(`{}`),
 											Parameters:    []byte(`{}`),
+											JobParameters: job.Parameters,
 											WorkspaceId:   job.WorkspaceId,
 										}
 										statusList = append(statusList, &status)
@@ -1112,7 +1111,7 @@ func (brt *HandleT) postToWarehouse(batchJobs *BatchJobsT, output StorageUploadO
 		DestinationRevisionID: batchJobs.BatchDestination.Destination.RevisionID,
 	}
 
-	if misc.Contains(warehouseutils.TimeWindowDestinations, brt.destType) {
+	if slices.Contains(warehouseutils.TimeWindowDestinations, brt.destType) {
 		payload.TimeWindow = batchJobs.TimeWindow
 	}
 
@@ -1241,6 +1240,7 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 			ErrorCode:     "",
 			ErrorResponse: errorResp,
 			Parameters:    []byte(`{}`),
+			JobParameters: job.Parameters,
 			WorkspaceId:   job.WorkspaceId,
 		}
 		statusList = append(statusList, &status)
@@ -1388,6 +1388,7 @@ func (brt *HandleT) GetWorkspaceIDForDestID(destID string) string {
 }
 
 func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.AsyncUploadOutput, rsourcesStats rsources.StatsCollector) {
+	jobParameters := []byte(fmt.Sprintf(`{"destination_id": %q}`, asyncOutput.DestinationID)) // TODO: there should be a consistent way of finding the actual job parameters
 	workspace := brt.GetWorkspaceIDForDestID(asyncOutput.DestinationID)
 	var statusList []*jobsdb.JobStatusT
 	if len(asyncOutput.ImportingJobIDs) > 0 {
@@ -1400,6 +1401,7 @@ func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.Asy
 				ErrorCode:     "200",
 				ErrorResponse: []byte(`{}`),
 				Parameters:    asyncOutput.ImportingParameters,
+				JobParameters: jobParameters,
 				WorkspaceId:   workspace,
 			}
 			statusList = append(statusList, &status)
@@ -1415,6 +1417,7 @@ func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.Asy
 				ErrorCode:     "200",
 				ErrorResponse: stdjson.RawMessage(asyncOutput.SuccessResponse),
 				Parameters:    []byte(`{}`),
+				JobParameters: jobParameters,
 				WorkspaceId:   workspace,
 			}
 			statusList = append(statusList, &status)
@@ -1430,6 +1433,7 @@ func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.Asy
 				ErrorCode:     "500",
 				ErrorResponse: stdjson.RawMessage(asyncOutput.FailedReason),
 				Parameters:    []byte(`{}`),
+				JobParameters: jobParameters,
 				WorkspaceId:   workspace,
 			}
 			statusList = append(statusList, &status)
@@ -1445,6 +1449,7 @@ func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.Asy
 				ErrorCode:     "400",
 				ErrorResponse: stdjson.RawMessage(asyncOutput.AbortReason),
 				Parameters:    []byte(`{}`),
+				JobParameters: jobParameters,
 				WorkspaceId:   workspace,
 			}
 			statusList = append(statusList, &status)
@@ -1569,33 +1574,11 @@ func (brt *HandleT) recordUploadStats(destination DestinationT, output StorageUp
 	}
 }
 
-func (worker *workerT) getValueForParameter(batchDest router_utils.BatchDestinationT, parameter string) string {
-	switch {
-	case parameter == "destination_id":
-		return batchDest.Destination.ID
-	default:
-		panic(fmt.Errorf("BRT: %s: Unknown parameter(%s) to find value from batchDest %+v", worker.brt.destType, parameter, batchDest))
-	}
-}
-
-func (worker *workerT) constructParameterFilters(batchDest router_utils.BatchDestinationT) []jobsdb.ParameterFilterT {
-	parameterFilters := make([]jobsdb.ParameterFilterT, 0)
-	for _, key := range jobsdb.CacheKeyParameterFilters {
-		parameterFilter := jobsdb.ParameterFilterT{
-			Name:  key,
-			Value: worker.getValueForParameter(batchDest, key),
-		}
-		parameterFilters = append(parameterFilters, parameterFilter)
-	}
-
-	return parameterFilters
-}
-
 func (worker *workerT) workerProcess() {
 	brt := worker.brt
 	for batchDestData := range brt.processQ {
 		batchDest := batchDestData.batchDestination
-		parameterFilters := worker.constructParameterFilters(batchDest)
+		parameterFilters := []jobsdb.ParameterFilterT{{Name: "destination_id", Value: batchDest.Destination.ID}}
 		var combinedList []*jobsdb.JobT
 		if readPerDestination {
 			toQuery := worker.brt.jobQueryBatchSize
@@ -1671,6 +1654,7 @@ func (worker *workerT) workerProcess() {
 					ErrorCode:     "",
 					ErrorResponse: router_utils.EnhanceJSON([]byte(`{}`), "reason", reason),
 					Parameters:    []byte(`{}`), // check
+					JobParameters: job.Parameters,
 					WorkspaceId:   job.WorkspaceId,
 				}
 				// Enhancing job parameter with the drain reason.
@@ -1686,7 +1670,7 @@ func (worker *workerT) workerProcess() {
 					}
 				}
 				drainStatsbyDest[batchDest.Destination.ID].Count = drainStatsbyDest[batchDest.Destination.ID].Count + 1
-				if !misc.Contains(drainStatsbyDest[batchDest.Destination.ID].Reasons, reason) {
+				if !slices.Contains(drainStatsbyDest[batchDest.Destination.ID].Reasons, reason) {
 					drainStatsbyDest[batchDest.Destination.ID].Reasons = append(drainStatsbyDest[batchDest.Destination.ID].Reasons, reason)
 				}
 			} else {
@@ -1705,6 +1689,7 @@ func (worker *workerT) workerProcess() {
 					ErrorCode:     "",
 					ErrorResponse: []byte(`{}`), // check
 					Parameters:    []byte(`{}`), // check
+					JobParameters: job.Parameters,
 					WorkspaceId:   job.WorkspaceId,
 				}
 				statusList = append(statusList, &status)
@@ -1763,9 +1748,9 @@ func (worker *workerT) workerProcess() {
 		wg.Add(len(jobsBySource))
 
 		for sourceID, jobs := range jobsBySource {
-			source, ok := funk.Find(batchDest.Sources, func(s backendconfig.SourceT) bool {
+			source, found := lo.Find(batchDest.Sources, func(s backendconfig.SourceT) bool {
 				return s.ID == sourceID
-			}).(backendconfig.SourceT)
+			})
 			batchJobs := BatchJobsT{
 				Jobs: jobs,
 				BatchDestination: &DestinationT{
@@ -1773,7 +1758,7 @@ func (worker *workerT) workerProcess() {
 					Source:      source,
 				},
 			}
-			if !ok {
+			if !found {
 				// TODO: Should not happen. Handle this
 				err := fmt.Errorf("BRT: Batch destination source not found in config for sourceID: %s", sourceID)
 				brt.setJobStatus(&batchJobs, false, err, false)
@@ -1782,7 +1767,7 @@ func (worker *workerT) workerProcess() {
 			}
 			rruntime.Go(func() {
 				switch {
-				case misc.Contains(objectStorageDestinations, brt.destType):
+				case slices.Contains(objectStorageDestinations, brt.destType):
 					destUploadStat := stats.Default.NewStat(fmt.Sprintf(`batch_router.%s_dest_upload_time`, brt.destType), stats.TimerType)
 					destUploadStart := time.Now()
 					output := brt.copyJobsToStorage(brt.destType, &batchJobs, false)
@@ -1797,7 +1782,7 @@ func (worker *workerT) workerProcess() {
 					}
 
 					destUploadStat.Since(destUploadStart)
-				case misc.Contains(warehouseutils.WarehouseDestinations, brt.destType):
+				case slices.Contains(warehouseutils.WarehouseDestinations, brt.destType):
 					useRudderStorage := misc.IsConfiguredToUseRudderObjectStorage(batchJobs.BatchDestination.Destination.Config)
 					objectStorageType := warehouseutils.ObjectStorageType(brt.destType, batchJobs.BatchDestination.Destination.Config, useRudderStorage)
 					destUploadStat := stats.Default.NewStat(fmt.Sprintf(`batch_router.%s_%s_dest_upload_time`, brt.destType, objectStorageType), stats.TimerType)
@@ -1819,7 +1804,7 @@ func (worker *workerT) workerProcess() {
 						misc.RemoveFilePaths(output.LocalFilePaths...)
 					}
 					destUploadStat.Since(destUploadStart)
-				case misc.Contains(asyncDestinations, brt.destType):
+				case slices.Contains(asyncDestinations, brt.destType):
 					destUploadStat := stats.Default.NewStat(fmt.Sprintf(`batch_router.%s_dest_upload_time`, brt.destType), stats.TimerType)
 					destUploadStart := time.Now()
 					brt.sendJobsToStorage(batchJobs)
@@ -2142,26 +2127,26 @@ func (brt *HandleT) holdFetchingJobs(parameterFilters []jobsdb.ParameterFilterT)
 }
 
 func IsAsyncDestination(destType string) bool {
-	return misc.Contains(asyncDestinations, destType)
+	return slices.Contains(asyncDestinations, destType)
 }
 
 func (brt *HandleT) crashRecover() {
-	if misc.Contains(objectStorageDestinations, brt.destType) {
+	if slices.Contains(objectStorageDestinations, brt.destType) {
 		brt.dedupRawDataDestJobsOnCrash()
 	}
 }
 
 func IsObjectStorageDestination(destType string) bool {
-	return misc.Contains(objectStorageDestinations, destType)
+	return slices.Contains(objectStorageDestinations, destType)
 }
 
 func IsWarehouseDestination(destType string) bool {
-	return misc.Contains(warehouseutils.WarehouseDestinations, destType)
+	return slices.Contains(warehouseutils.WarehouseDestinations, destType)
 }
 
 func (brt *HandleT) splitBatchJobsOnTimeWindow(batchJobs BatchJobsT) map[time.Time]*BatchJobsT {
 	splitBatches := map[time.Time]*BatchJobsT{}
-	if !misc.Contains(warehouseutils.TimeWindowDestinations, brt.destType) {
+	if !slices.Contains(warehouseutils.TimeWindowDestinations, brt.destType) {
 		// return only one batchJob if the destination type is not time window destinations
 		splitBatches[time.Time{}] = &batchJobs
 		return splitBatches

--- a/router/customdestinationmanager/customdestinationmanager.go
+++ b/router/customdestinationmanager/customdestinationmanager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sony/gobreaker"
+	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -18,7 +19,6 @@ import (
 	"github.com/rudderlabs/rudder-server/services/kvstoremanager"
 	"github.com/rudderlabs/rudder-server/services/streammanager"
 	"github.com/rudderlabs/rudder-server/services/streammanager/common"
-	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
 const (
@@ -285,10 +285,10 @@ type Opts struct {
 
 // New returns CustomdestinationManager
 func New(destType string, o Opts) DestinationManager {
-	if misc.Contains(Destinations, destType) {
+	if slices.Contains(Destinations, destType) {
 
 		managerType := STREAM
-		if misc.Contains(KVStoreDestinations, destType) {
+		if slices.Contains(KVStoreDestinations, destType) {
 			managerType = KV
 		}
 

--- a/router/manager/manager.go
+++ b/router/manager/manager.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/router"
 	"github.com/rudderlabs/rudder-server/router/batchrouter"
-	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
 var (
@@ -118,9 +118,9 @@ loop:
 					for k := range source.Destinations {
 						destination := &source.Destinations[k]
 						// For batch router destinations
-						if misc.Contains(objectStorageDestinations, destination.DestinationDefinition.Name) ||
-							misc.Contains(warehouseDestinations, destination.DestinationDefinition.Name) ||
-							misc.Contains(asyncDestinations, destination.DestinationDefinition.Name) {
+						if slices.Contains(objectStorageDestinations, destination.DestinationDefinition.Name) ||
+							slices.Contains(warehouseDestinations, destination.DestinationDefinition.Name) ||
+							slices.Contains(asyncDestinations, destination.DestinationDefinition.Name) {
 							_, ok := dstToBatchRouter[destination.DestinationDefinition.Name]
 							if !ok {
 								pkgLogger.Infof("Starting a new Batch Destination Router: %s", destination.DestinationDefinition.Name)

--- a/router/utils/utils.go
+++ b/router/utils/utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"golang.org/x/exp/slices"
 )
 
 var (
@@ -78,7 +79,7 @@ func ToBeDrained(job *jobsdb.JobT, destID, toAbortDestinationIDs string, destina
 
 	if toAbortDestinationIDs != "" {
 		abortIDs := strings.Split(toAbortDestinationIDs, ",")
-		if misc.Contains(abortIDs, destID) {
+		if slices.Contains(abortIDs, destID) {
 			return true, "destination configured to abort"
 		}
 	}

--- a/schema-forwarder/internal/forwarder/abortingforwarder.go
+++ b/schema-forwarder/internal/forwarder/abortingforwarder.go
@@ -57,6 +57,7 @@ func (nf *AbortingForwarder) Start() error {
 						ErrorCode:     "400",
 						ErrorResponse: []byte(`{"success":false,"message":"JobsForwarder is disabled"}`),
 						Parameters:    []byte(`{}`),
+						JobParameters: job.Parameters,
 						WorkspaceId:   job.WorkspaceId,
 					})
 				}

--- a/schema-forwarder/internal/forwarder/baseforwarder_test.go
+++ b/schema-forwarder/internal/forwarder/baseforwarder_test.go
@@ -124,6 +124,7 @@ func TestBaseForwarder_MarkJobStautses(t *testing.T) {
 			ErrorCode:     "200",
 			ErrorResponse: []byte(`{"success":true}`),
 			Parameters:    []byte(`{}`),
+			JobParameters: job.Parameters,
 		})
 	}
 	err = bf.MarkJobStatuses(context.Background(), statuses)

--- a/schema-forwarder/internal/forwarder/jobsforwarder.go
+++ b/schema-forwarder/internal/forwarder/jobsforwarder.go
@@ -123,6 +123,7 @@ func (jf *JobsForwarder) Start() error {
 								RetryTime:     time.Now(),
 								ErrorCode:     "400",
 								Parameters:    []byte{},
+								JobParameters: job.Parameters,
 								ErrorResponse: json.RawMessage(fmt.Sprintf(`{"transform_error": %q}`, err.Error())),
 							})
 							jf.stat.NewTaggedStat("schema_forwarder_jobs", stats.CountType, stats.Tags{"state": "invalid"}).Increment()
@@ -141,10 +142,11 @@ func (jf *JobsForwarder) Start() error {
 									defer mu.Unlock()
 									jobDone(job)
 									statuses = append(statuses, &jobsdb.JobStatusT{
-										JobID:      job.JobID,
-										AttemptNum: job.LastJobStatus.AttemptNum + 1,
-										JobState:   jobsdb.Succeeded.State,
-										ExecTime:   time.Now(),
+										JobID:         job.JobID,
+										AttemptNum:    job.LastJobStatus.AttemptNum + 1,
+										JobState:      jobsdb.Succeeded.State,
+										ExecTime:      time.Now(),
+										JobParameters: job.Parameters,
 									})
 									jf.stat.NewTaggedStat("schema_forwarder_processed_jobs", stats.CountType, stats.Tags{"state": "succeeded"}).Increment()
 								} else {
@@ -177,6 +179,7 @@ func (jf *JobsForwarder) Start() error {
 							RetryTime:     time.Now(),
 							ErrorCode:     "400",
 							Parameters:    []byte{},
+							JobParameters: job.Parameters,
 							ErrorResponse: json.RawMessage(fmt.Sprintf(`{"error": %q}`, err.Error())),
 						})
 					}

--- a/services/debugger/source/eventUploader.go
+++ b/services/debugger/source/eventUploader.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rudderlabs/rudder-server/services/debugger"
 	"github.com/rudderlabs/rudder-server/services/debugger/cache"
 	"github.com/rudderlabs/rudder-server/utils/misc"
+	"golang.org/x/exp/slices"
 )
 
 // GatewayEventBatchT is a structure to hold batch of events
@@ -122,7 +123,7 @@ func (h *Handle) RecordEvent(writeKey string, eventBatch []byte) bool {
 	// Check if writeKey part of enabled sources
 	h.uploadEnabledWriteKeysMu.RLock()
 	defer h.uploadEnabledWriteKeysMu.RUnlock()
-	if !misc.Contains(h.uploadEnabledWriteKeys, writeKey) {
+	if !slices.Contains(h.uploadEnabledWriteKeys, writeKey) {
 		err := h.eventsCache.Update(writeKey, eventBatch)
 		if err != nil {
 			h.log.Errorf("Error while updating cache: %v", err)

--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -807,9 +807,15 @@ func TestSSH(t *testing.T) {
 
 	pubCtx, pubCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer pubCancel()
-	require.NoError(t, p.Publish(pubCtx,
-		Message{Key: []byte("key-01"), Value: []byte("value-01"), Topic: t.Name()},
-	))
+	require.Eventually(t, func() bool {
+		err = p.Publish(pubCtx,
+			Message{Key: []byte("key-01"), Value: []byte("value-01"), Topic: t.Name()},
+		)
+		if err != nil {
+			t.Logf("Could not publish message: %v", err)
+		}
+		return err == nil
+	}, 30*time.Second, time.Second, "could not publish message: %v", err)
 
 	// Verify that the message has been published and it's readable
 	consumer := c.NewConsumer(t.Name(), ConsumerConfig{})

--- a/sql/migrations/jobsdb/000012_add_param_indexes.up.tmpl
+++ b/sql/migrations/jobsdb/000012_add_param_indexes.up.tmpl
@@ -1,0 +1,5 @@
+{{range .Datasets}}
+    CREATE INDEX IF NOT EXISTS "idx_{{$.Prefix}}_jobs_{{.}}_cv" ON "{{$.Prefix}}_jobs_{{.}}" (custom_val);
+    CREATE INDEX IF NOT EXISTS "idx_{{$.Prefix}}_jobs_{{.}}_source_id" ON "{{$.Prefix}}_jobs_{{.}}" USING BTREE ((parameters->>'source_id'));
+    CREATE INDEX IF NOT EXISTS "idx_{{$.Prefix}}_jobs_{{.}}_destination_id" ON "{{$.Prefix}}_jobs_{{.}}" USING BTREE ((parameters->>'destination_id'));
+{{end}}

--- a/sql/migrations/jobsdb_always/000012_add_param_indexes.up.tmpl
+++ b/sql/migrations/jobsdb_always/000012_add_param_indexes.up.tmpl
@@ -1,0 +1,5 @@
+{{range .Datasets}}
+    CREATE INDEX IF NOT EXISTS "idx_{{$.Prefix}}_jobs_{{.}}_cv" ON "{{$.Prefix}}_jobs_{{.}}" (custom_val);
+    CREATE INDEX IF NOT EXISTS "idx_{{$.Prefix}}_jobs_{{.}}_source_id" ON "{{$.Prefix}}_jobs_{{.}}" USING BTREE ((parameters->>'source_id'));
+    CREATE INDEX IF NOT EXISTS "idx_{{$.Prefix}}_jobs_{{.}}_destination_id" ON "{{$.Prefix}}_jobs_{{.}}" USING BTREE ((parameters->>'destination_id'));
+{{end}}

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -44,8 +44,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats/metric"
 	"github.com/rudderlabs/rudder-server/utils/httputil"
 
-	"github.com/thoas/go-funk"
-
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
@@ -214,7 +212,7 @@ func GetHash(s string) int {
 
 // GetMD5Hash returns EncodeToString(md5 hash of the input string)
 func GetMD5Hash(input string) string {
-	hash := md5.Sum([]byte(input))
+	hash := md5.Sum([]byte(input)) // skipcq: GO-S1023
 	return hex.EncodeToString(hash[:])
 }
 
@@ -472,15 +470,6 @@ func GetIPFromReq(req *http.Request) string {
 	return strings.ReplaceAll(addresses[0], " ", "")
 }
 
-func Contains[K comparable](slice []K, item K) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
-}
-
 // IncrementMapByKey starts with 1 and increments the counter of a key
 func IncrementMapByKey(m map[string]int, key string, increment int) {
 	_, found := m[key]
@@ -495,12 +484,6 @@ func IncrementMapByKey(m map[string]int, key string, increment int) {
 //  timestamp = receivedAt - (sentAt - originalTimestamp)
 func GetChronologicalTimeStamp(receivedAt, sentAt, originalTimestamp time.Time) time.Time {
 	return receivedAt.Add(-sentAt.Sub(originalTimestamp))
-}
-
-func StringKeys(input interface{}) []string {
-	keys := funk.Keys(input)
-	stringKeys := keys.([]string)
-	return stringKeys
 }
 
 func MapStringKeys(input map[string]interface{}) []string {
@@ -943,7 +926,7 @@ func GetObjectStorageConfig(opts ObjectStorageOptsT) map[string]interface{} {
 }
 
 func GetSpacesLocation(location string) (region string) {
-	r, _ := regexp.Compile(`\.*.*\.digitaloceanspaces\.com`)
+	r, _ := regexp.Compile(`\.*.*\.digitaloceanspaces\.com`) // skipcq: GO-S1009
 	subLocation := r.FindString(location)
 	regionTokens := strings.Split(subLocation, ".")
 	if len(regionTokens) == 3 {
@@ -991,7 +974,7 @@ func GetMD5UUID(str string) (uuid.UUID, error) {
 
 	// google/uuid doesn't allow us to modify the version and variant
 	// so we are doing it manually, using gofrs/uuid library implementation.
-	md5Sum := md5.Sum([]byte(str))
+	md5Sum := md5.Sum([]byte(str)) // skipcq: GO-S1023
 	// SetVariant: VariantRFC4122
 	md5Sum[8] = md5Sum[8]&(0xff>>2) | (0x02 << 6)
 	// SetVersion: Version 4

--- a/utils/misc/misc_test.go
+++ b/utils/misc/misc_test.go
@@ -45,8 +45,7 @@ var _ = Describe("Misc", func() {
 			Expect(err).To(BeNil())
 			Expect(FileExists(path)).To(BeTrue())
 			Expect(FolderExists(targetDir)).To(BeTrue())
-
-			defer file.Close()
+			_ = file.Close()
 		}
 		onPostFileCreation := func(sourceFile, targetDir string) {
 			RemoveFilePaths(sourceFile)
@@ -502,28 +501,6 @@ var _ = Describe("Misc", func() {
 		Entry("Unique Test 2 : ", []string{"a", "b", "c"}, []string{"a", "b", "c"}),
 	)
 })
-
-func TestContains(t *testing.T) {
-	t.Run("strings", func(t *testing.T) {
-		list := []string{"a", "b", "c"}
-
-		for _, item := range list {
-			require.True(t, Contains(list, item))
-		}
-
-		require.False(t, Contains(list, "0"))
-	})
-
-	t.Run("int", func(t *testing.T) {
-		list := []int{1, 2, 3}
-
-		for _, item := range list {
-			require.True(t, Contains(list, item))
-		}
-
-		require.False(t, Contains(list, -1))
-	})
-}
 
 func TestHasAWSRoleARNInConfig(t *testing.T) {
 	t.Run("Config has valid IAM Role ARN", func(t *testing.T) {

--- a/warehouse/api.go
+++ b/warehouse/api.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/exp/slices"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -529,7 +530,7 @@ func (uploadReq *UploadReq) authorizeSource(sourceID string) bool {
 		return false
 	}
 	pkgLogger.Debugf(`Authorized sourceId's for workspace:%s - %v`, uploadReq.WorkspaceID, authorizedSourceIDs)
-	return misc.Contains(authorizedSourceIDs, sourceID)
+	return slices.Contains(authorizedSourceIDs, sourceID)
 }
 
 func (uploadsReq *UploadsReq) authorizedSources() (sourceIDs []string) {
@@ -692,7 +693,7 @@ func (uploadsReq *UploadsReq) warehouseUploadsForHosted(authorizedSourceIDs []st
 	)
 	if uploadsReq.SourceID == "" {
 		whereClauses = append(whereClauses, fmt.Sprintf(`source_id IN (%v)`, misc.SingleQuoteLiteralJoin(authorizedSourceIDs)))
-	} else if misc.Contains(authorizedSourceIDs, uploadsReq.SourceID) {
+	} else if slices.Contains(authorizedSourceIDs, uploadsReq.SourceID) {
 		whereClauses = append(whereClauses, fmt.Sprintf(`source_id = '%s'`, uploadsReq.SourceID))
 	}
 	if uploadsReq.DestinationID != "" {

--- a/warehouse/integrations/azure-synapse/azure-synapse.go
+++ b/warehouse/integrations/azure-synapse/azure-synapse.go
@@ -18,6 +18,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/rudderlabs/rudder-server/warehouse/internal/service/loadfiles/downloader"
+	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
@@ -191,7 +192,7 @@ func (as *AzureSynapse) loadTable(tableName string, tableSchemaInUpload model.Ta
 
 	var extraColumns []string
 	for _, column := range previousColumnKeys {
-		if !misc.Contains(sortedColumnKeys, column) {
+		if !slices.Contains(sortedColumnKeys, column) {
 			extraColumns = append(extraColumns, column)
 		}
 	}
@@ -840,6 +841,6 @@ func (as *AzureSynapse) SetConnectionTimeout(timeout time.Duration) {
 	as.ConnectTimeout = timeout
 }
 
-func (as *AzureSynapse) ErrorMappings() []model.JobError {
+func (*AzureSynapse) ErrorMappings() []model.JobError {
 	return errorsMappings
 }

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -280,7 +280,7 @@ registerTLSConfig will create a global map, use different names for the differen
 clickhouse will access the config by mentioning the key in connection string
 */
 func registerTLSConfig(key, certificate string) {
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{} // skipcq: GO-S1020
 	caCert := []byte(certificate)
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)
@@ -316,7 +316,7 @@ func (ch *Clickhouse) ColumnsWithDataTypes(tableName string, columns model.Table
 	var arr []string
 	for columnName, dataType := range columns {
 		codec := ch.getClickHouseCodecForColumnType(dataType, tableName)
-		columnType := ch.getClickHouseColumnTypeForSpecificTable(tableName, columnName, rudderDataTypesMapToClickHouse[dataType], misc.Contains(notNullableColumns, columnName))
+		columnType := ch.getClickHouseColumnTypeForSpecificTable(tableName, columnName, rudderDataTypesMapToClickHouse[dataType], slices.Contains(notNullableColumns, columnName))
 		arr = append(arr, fmt.Sprintf(`%q %s %s`, columnName, columnType, codec))
 	}
 	return strings.Join(arr, ",")
@@ -1136,6 +1136,6 @@ func (ch *Clickhouse) SetConnectionTimeout(timeout time.Duration) {
 	ch.ConnectTimeout = timeout
 }
 
-func (ch *Clickhouse) ErrorMappings() []model.JobError {
+func (*Clickhouse) ErrorMappings() []model.JobError {
 	return errorsMappings
 }

--- a/warehouse/integrations/deltalake-native/deltalake.go
+++ b/warehouse/integrations/deltalake-native/deltalake.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	warehouseclient "github.com/rudderlabs/rudder-server/warehouse/client"
+	"golang.org/x/exp/slices"
 
 	dbsqllog "github.com/databricks/databricks-sql-go/logger"
 
@@ -898,7 +899,7 @@ func (d *Deltalake) partitionQuery(tableName string) (string, error) {
 
 // partitionedByEventDate returns true if the table is partitioned by event_date
 func partitionedByEventDate(columns []string) bool {
-	return misc.Contains(columns, "event_date")
+	return slices.Contains(columns, "event_date")
 }
 
 // LoadUserTables loads user tables

--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -320,7 +321,7 @@ func (dl *Deltalake) fetchPartitionColumns(dbT *client.Client, tableName string)
 }
 
 func isPartitionedByEventDate(partitionedColumns []string) bool {
-	return misc.Contains(partitionedColumns, "event_date")
+	return slices.Contains(partitionedColumns, "event_date")
 }
 
 // partitionQuery
@@ -952,7 +953,7 @@ func (dl *Deltalake) Setup(warehouse model.Warehouse, uploader warehouseutils.Up
 }
 
 // TestConnection test the connection for the warehouse
-func (dl *Deltalake) TestConnection(context.Context, model.Warehouse) error {
+func (*Deltalake) TestConnection(context.Context, model.Warehouse) error {
 	return nil
 }
 
@@ -1211,6 +1212,6 @@ func appendableLTSQLStatement(namespace, tableName, stagingTableName string, col
 	return sqlStatement
 }
 
-func (dl *Deltalake) ErrorMappings() []model.JobError {
+func (*Deltalake) ErrorMappings() []model.JobError {
 	return errorsMappings
 }

--- a/warehouse/retry.go
+++ b/warehouse/retry.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 
 	"github.com/lib/pq"
-	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"golang.org/x/exp/slices"
 )
 
 type RetryRequest struct {
@@ -58,7 +58,7 @@ func (retryReq *RetryRequest) RetryWHUploads(ctx context.Context) (response Retr
 		err = fmt.Errorf("unauthorized request")
 		return
 	}
-	if retryReq.SourceID != "" && !misc.Contains(sourceIDs, retryReq.SourceID) {
+	if retryReq.SourceID != "" && !slices.Contains(sourceIDs, retryReq.SourceID) {
 		err = fmt.Errorf("no such sourceID exists")
 		return
 	}
@@ -109,7 +109,7 @@ func (retryReq *RetryRequest) UploadsToRetry(ctx context.Context) (response Retr
 		err = fmt.Errorf("unauthorized request")
 		return
 	}
-	if retryReq.SourceID != "" && !misc.Contains(sourceIDs, retryReq.SourceID) {
+	if retryReq.SourceID != "" && !slices.Contains(sourceIDs, retryReq.SourceID) {
 		err = fmt.Errorf("no such sourceID exists")
 		return
 	}

--- a/warehouse/schema.go
+++ b/warehouse/schema.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/rudderlabs/rudder-server/warehouse/internal/repo"
+	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
@@ -236,7 +237,7 @@ func (sh *SchemaHandle) getIdentitiesMappingsSchema() model.TableSchema {
 }
 
 func (sh *SchemaHandle) isIDResolutionEnabled() bool {
-	return warehouseutils.IDResolutionEnabled() && misc.Contains(warehouseutils.IdentityEnabledWarehouses, sh.warehouse.Type)
+	return warehouseutils.IDResolutionEnabled() && slices.Contains(warehouseutils.IdentityEnabledWarehouses, sh.warehouse.Type)
 }
 
 func (sh *SchemaHandle) consolidateStagingFilesSchemaUsingWarehouseSchema() model.Schema {

--- a/warehouse/slave.go
+++ b/warehouse/slave.go
@@ -29,6 +29,7 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 	"github.com/rudderlabs/rudder-server/warehouse/jobs"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -305,7 +306,7 @@ func (jobRun *JobRun) uploadLoadFileToObjectStorage(uploader filemanager.FileMan
 	defer file.Close()
 	pkgLogger.Debugf("[WH]: %s: Uploading load_file to %s for table: %s with staging_file id: %v", job.DestinationType, warehouseutils.ObjectStorageType(job.DestinationType, job.DestinationConfig, job.UseRudderStorage), tableName, job.StagingFileID)
 	var uploadLocation filemanager.UploadOutput
-	if misc.Contains(warehouseutils.TimeWindowDestinations, job.DestinationType) {
+	if slices.Contains(warehouseutils.TimeWindowDestinations, job.DestinationType) {
 		uploadLocation, err = uploader.Upload(context.TODO(), file, warehouseutils.GetTablePathInObjectStorage(jobRun.job.DestinationNamespace, tableName), job.LoadFilePrefix)
 	} else {
 		uploadLocation, err = uploader.Upload(context.TODO(), file, config.GetString("WAREHOUSE_BUCKET_LOAD_OBJECTS_FOLDER_NAME", "rudder-warehouse-load-objects"), tableName, job.SourceID, getBucketFolder(job.UniqueLoadGenID, tableName))

--- a/warehouse/stats.go
+++ b/warehouse/stats.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/rudderlabs/rudder-server/warehouse/logfield"
+	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/stats"
@@ -205,7 +206,7 @@ func (job *UploadJob) generateUploadAbortedMetrics() {
 
 func (job *UploadJob) recordTableLoad(tableName string, numEvents int64) {
 	rudderAPISupportedEventTypes := []string{"tracks", "identifies", "pages", "screens", "aliases", "groups"}
-	if misc.Contains(rudderAPISupportedEventTypes, strings.ToLower(tableName)) {
+	if slices.Contains(rudderAPISupportedEventTypes, strings.ToLower(tableName)) {
 		// record total events synced (ignoring additional row synced to the event table for e.g.track call)
 		job.counterStat(`event_delivery`, Tag{
 			Name:  "tableName",
@@ -216,7 +217,7 @@ func (job *UploadJob) recordTableLoad(tableName string, numEvents int64) {
 	skipMetricTagForEachEventTable := config.GetBool("Warehouse.skipMetricTagForEachEventTable", false)
 	if skipMetricTagForEachEventTable {
 		standardTablesToRecordEventsMetric := []string{"tracks", "users", "identifies", "pages", "screens", "aliases", "groups", "rudder_discards"}
-		if !misc.Contains(standardTablesToRecordEventsMetric, strings.ToLower(tableName)) {
+		if !slices.Contains(standardTablesToRecordEventsMetric, strings.ToLower(tableName)) {
 			// club all event table metric tags under one tag to avoid too many tags
 			tableName = "others"
 		}

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -19,12 +19,13 @@ import (
 	"time"
 
 	"github.com/rudderlabs/rudder-server/warehouse/logfield"
+	"github.com/samber/lo"
 
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/bugsnag/bugsnag-go/v2"
 	"github.com/cenkalti/backoff/v4"
-	"github.com/thoas/go-funk"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -341,7 +342,7 @@ func (wh *HandleT) backendConfigSubscriber(ctx context.Context) {
 					connectionsMap[destination.ID][source.ID] = warehouse
 					connectionsMapLock.Unlock()
 
-					if warehouseutils.IDResolutionEnabled() && misc.Contains(warehouseutils.IdentityEnabledWarehouses, warehouse.Type) {
+					if warehouseutils.IDResolutionEnabled() && slices.Contains(warehouseutils.IdentityEnabledWarehouses, warehouse.Type) {
 						wh.setupIdentityTables(warehouse)
 						if shouldPopulateHistoricIdentities && warehouse.Destination.Enabled {
 							// non-blocking populate historic identities
@@ -734,14 +735,14 @@ func (wh *HandleT) getUploadsToProcess(ctx context.Context, availableWorkers int
 			}
 		}
 
-		warehouse, ok := funk.Find(wh.warehouses, func(w model.Warehouse) bool {
+		warehouse, found := lo.Find(wh.warehouses, func(w model.Warehouse) bool {
 			return w.Source.ID == upload.SourceID && w.Destination.ID == upload.DestinationID
-		}).(model.Warehouse)
+		})
 		wh.configSubscriberLock.RUnlock()
 
 		upload.UseRudderStorage = warehouse.GetBoolDestinationConfig("useRudderStorage")
 
-		if !ok {
+		if !found {
 			uploadJob := wh.uploadJobFactory.NewUploadJob(&model.UploadJob{
 				Upload: upload,
 			}, nil)
@@ -983,7 +984,7 @@ func minimalConfigSubscriber() {
 				}
 				sourceIDsByWorkspaceTemp[workspaceID] = append(sourceIDsByWorkspaceTemp[workspaceID], source.ID)
 				for _, destination := range source.Destinations {
-					if misc.Contains(warehouseutils.WarehouseDestinations, destination.DestinationDefinition.Name) {
+					if slices.Contains(warehouseutils.WarehouseDestinations, destination.DestinationDefinition.Name) {
 						wh := &HandleT{
 							dbHandle: dbHandle,
 							destType: destination.DestinationDefinition.Name,
@@ -1048,7 +1049,7 @@ func onConfigDataEvent(config map[string]backendconfig.ConfigT, dstToWhRouter ma
 		for _, source := range wConfig.Sources {
 			for _, destination := range source.Destinations {
 				enabledDestinations[destination.DestinationDefinition.Name] = true
-				if misc.Contains(warehouseutils.WarehouseDestinations, destination.DestinationDefinition.Name) {
+				if slices.Contains(warehouseutils.WarehouseDestinations, destination.DestinationDefinition.Name) {
 					wh, ok := dstToWhRouter[destination.DestinationDefinition.Name]
 					if !ok {
 						pkgLogger.Info("Starting a new Warehouse Destination Router: ", destination.DestinationDefinition.Name)
@@ -1075,7 +1076,7 @@ func onConfigDataEvent(config map[string]backendconfig.ConfigT, dstToWhRouter ma
 		}
 	}
 
-	keys := misc.StringKeys(dstToWhRouter)
+	keys := lo.Keys(dstToWhRouter)
 	for _, key := range keys {
 		if _, ok := enabledDestinations[key]; !ok {
 			if wh, ok := dstToWhRouter[key]; ok {


### PR DESCRIPTION
# Description

## Source level isolation at processor

Adding a new strategy at the processor for achieving source-level isolation. This new strategy is also the default one for non-multitenant deployments. The performance characteristics of the newly introduced strategy are [quite similar](https://snapshots.raintank.io/dashboard/snapshot/xugaw44VT5dYMQ2ynyBbvM4FZfxFvD5D) to the recently introduced workspace-level isolation strategy.
To achieve similar performance, it was necessary to add jsonb field indexes in the database (for `source_id` & `destination_id`) and change the way that we are querying parameter fields, i.e. instead of using the contains `@>` operator, we are now using the text `->>` operator.

## JobsDB's no-jobs cache refactoring - dealing with technical debt

Adaptations were also required in jobsDB's no jobs cache, in order to add support for dynamic parameters. The cache has been refactored with the following goals:
- **Extensibility:** Easily support additional job parameters in the future.
- **Consistency:**
  - Rely mostly on the job statuses themselves while performing cache invalidation, instead of using additional function parameters. For that purpose, a new `JobStatusT#JobParameters` field has been added and is being populated properly whenever a new job status is created.
  - We are performing defensive invalidation of cache keys, e.g. when a level's cache key is missing , the whole tree level is being invalidated (if we don't know what to invalidate at a level, we need to invalidate all possible combinations).
  - Execution of parallel queries don't negatively affect the cache's state. Previously, a single query was causing some cache keys to be invalidated for (at least) a short period while it was being executed.

## Indexes and query performance
Apart from the new indexes for the job parameter fields, another index has been added for the `custom_val` column, which is especially important during batchrouter's queries.
Additionally, the parameter field index for `destination_id`, even though it is not currently being used by any isolation strategy at the moment, it is much needed when router's destination isolation mode is enabled.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=3f58a2e7b572480eb77d167ebf60917e&pm=s)
[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=1f434434e79d4fe68b67c746efcd5e88&pm=s)
[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=d7a349d2d37c4781932091aa4012a464&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
