### PR TITLE
fix: error messages map !initialized in gateway

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -297,7 +297,7 @@ func (gateway *HandleT) dbWriterWorkerProcess() {
 	for breq := range gateway.batchUserWorkerBatchRequestQ {
 		var (
 			jobList          = make([]*jobsdb.JobT, 0)
-			errorMessagesMap = map[uuid.UUID]string{}
+			errorMessagesMap = make(map[uuid.UUID]string)
 		)
 
 		for _, userWorkerBatchRequest := range breq.batchUserWorkerBatchRequest {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -297,7 +297,7 @@ func (gateway *HandleT) dbWriterWorkerProcess() {
 	for breq := range gateway.batchUserWorkerBatchRequestQ {
 		var (
 			jobList          = make([]*jobsdb.JobT, 0)
-			errorMessagesMap = make(map[uuid.UUID]string)
+			errorMessagesMap map[uuid.UUID]string
 		)
 
 		for _, userWorkerBatchRequest := range breq.batchUserWorkerBatchRequest {
@@ -330,6 +330,9 @@ func (gateway *HandleT) dbWriterWorkerProcess() {
 			errorMessage := err.Error()
 			if ctx.Err() != nil {
 				errorMessage = ctx.Err().Error()
+			}
+			if errorMessagesMap == nil {
+				errorMessagesMap = make(map[uuid.UUID]string, len(jobList))
 			}
 			for _, job := range jobList {
 				errorMessagesMap[job.UUID] = errorMessage

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1739,24 +1739,23 @@ func (jd *HandleT) clearCache(ds dataSetT, jobList []*JobT) {
 	jd.doClearCache(ds, customValParamMap)
 }
 
-func (jd *HandleT) internalStoreWithRetryEachInTx(ctx context.Context, tx *Tx, ds dataSetT, jobList []*JobT) (errorMessagesMap map[uuid.UUID]string, staleDs error) {
+func (jd *HandleT) internalStoreWithRetryEachInTx(ctx context.Context, tx *Tx, ds dataSetT, jobList []*JobT) (
+	errorMessagesMap map[uuid.UUID]string,
+	staleDs error,
+) {
 	const (
 		savepointSql = "SAVEPOINT storeWithRetryEach"
 		rollbackSql  = "ROLLBACK TO " + savepointSql
 	)
 
 	failAll := func(err error) map[uuid.UUID]string {
-		errorMessagesMap = make(map[uuid.UUID]string)
+		errorMessagesMap = make(map[uuid.UUID]string, len(jobList))
 		for i := range jobList {
-			job := jobList[i]
-			errorMessagesMap[job.UUID] = err.Error()
+			errorMessagesMap[jobList[i].UUID] = err.Error()
 		}
 		return errorMessagesMap
 	}
-	defer jd.getTimerStat(
-		"store_jobs_retry_each",
-		nil,
-	).RecordDuration()()
+	defer jd.getTimerStat("store_jobs_retry_each", nil).RecordDuration()()
 
 	_, err := tx.ExecContext(ctx, savepointSql)
 	if err != nil {
@@ -3250,8 +3249,10 @@ func (jd *HandleT) StoreWithRetryEach(ctx context.Context, jobList []*JobT) map[
 }
 
 func (jd *HandleT) StoreWithRetryEachInTx(ctx context.Context, tx StoreSafeTx, jobList []*JobT) (map[uuid.UUID]string, error) {
-	var res map[uuid.UUID]string
-	var err error
+	var (
+		err error
+		res map[uuid.UUID]string
+	)
 	storeCmd := func() error {
 		command := func() interface{} {
 			dsList := jd.getDSList()
@@ -3271,7 +3272,7 @@ func (jd *HandleT) StoreWithRetryEachInTx(ctx context.Context, tx StoreSafeTx, j
 }
 
 /*
-printLists is a debuggging function used to print
+printLists is a debugging function used to print
 the current in-memory copy of jobs and job ranges
 */
 func (jd *HandleT) printLists(console bool) {


### PR DESCRIPTION
# Description

The `errorMessagesMap` might not be initialized if `gwAllowPartialWriteWithErrors` is `false` which would lead to a `panic` in [line 337](https://github.com/rudderlabs/rudder-server/blob/release/1.7.x/gateway/gateway.go#L337).

It could also be that `internalStoreWithRetryEachInTx` returns a `nil` map with a non-nil error (i.e. `errStaleDsList`) [here](https://github.com/rudderlabs/rudder-server/blob/release/1.7.x/jobsdb/jobsdb.go#L1775).

Given that there might be multiple places where a wrong pair (i.e. map+error) can be returned, I'm proposing to do a final check right before the assignment to simplify things and to be 100% this won't break again in the future.

## Notion Ticket

< [Notion Link](https://www.notion.so/rudderstacks/nana-gateway-nil-map-assignment-33fddcc13cd64fbd9af027dfbba9cb78) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
