### PR TITLE
fix: remove logging in messages potentially leaking creds

### DIFF
--- a/warehouse/internal/api/http.go
+++ b/warehouse/internal/api/http.go
@@ -109,8 +109,6 @@ func (api *WarehouseAPI) Handler() http.Handler {
 }
 
 func (api *WarehouseAPI) processHandler(w http.ResponseWriter, r *http.Request) {
-	api.Logger.LogRequest(r)
-
 	ctx := r.Context()
 	defer r.Body.Close()
 

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -1125,8 +1125,6 @@ func CheckPGHealth(dbHandle *sql.DB) bool {
 }
 
 func setConfigHandler(w http.ResponseWriter, r *http.Request) {
-	pkgLogger.LogRequest(r)
-
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		pkgLogger.Errorf("[WH]: Error reading body: %v", err)


### PR DESCRIPTION
# Description

Remove logging in LogRequest messages potentially leaking credentials. 

## Notion Ticket
https://www.notion.so/rudderstacks/Warehouse-logging-credentials-835d5e39ef3d4971a13616c67b1069a3?pvs=4

## Security

- [X] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
