### PR TITLE
feat: modifed kafka to use config received from config-be.

### DIFF
--- a/services/controlplane/client.go
+++ b/services/controlplane/client.go
@@ -67,7 +67,7 @@ type componentSchema struct {
 	Features []string `json:"features"`
 }
 
-type PublicPrivateKeyPair struct {
+type SSHKey struct {
 	PublicKey  string
 	PrivateKey string
 }
@@ -111,10 +111,10 @@ func (c *Client) retry(ctx context.Context, fn func() error) error {
 	return backoff.Retry(fn, opts)
 }
 
-func (c *Client) GetDestinationSSHKeys(ctx context.Context, destinationID string) (string, error) {
+func (c *Client) GetDestinationSSHKeys(ctx context.Context, destinationID string) (SSHKey, error) {
 	url := fmt.Sprintf("%s/destinations/%s/sshKeys", c.url, destinationID)
 
-	var pair PublicPrivateKeyPair
+	var sshKey SSHKey
 
 	err := c.retry(ctx, func() error {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
@@ -137,14 +137,14 @@ func (c *Client) GetDestinationSSHKeys(ctx context.Context, destinationID string
 			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 		}
 
-		if err := json.NewDecoder(resp.Body).Decode(&pair); err != nil {
+		if err := json.NewDecoder(resp.Body).Decode(&sshKey); err != nil {
 			return fmt.Errorf("decoding response: %w", err)
 		}
 
 		return nil
 	})
 
-	return pair.PrivateKey, err
+	return sshKey, err
 }
 
 func (c *Client) SendFeatures(ctx context.Context, component string, features []string) error {

--- a/services/controlplane/client_test.go
+++ b/services/controlplane/client_test.go
@@ -368,7 +368,7 @@ func TestGetDestinationSSHKeys(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		require.NoError(t, json.NewEncoder(w).Encode(controlplane.PublicPrivateKeyPair{PrivateKey: "test-private-key", PublicKey: "test-public-key"}))
+		require.NoError(t, json.NewEncoder(w).Encode(controlplane.SSHKey{PrivateKey: "test-private-key", PublicKey: "test-public-key"}))
 	}))
 
 	defer mockServer.Close()

--- a/services/streammanager/kafka/client/client.go
+++ b/services/streammanager/kafka/client/client.go
@@ -73,12 +73,10 @@ func New(network string, addresses []string, conf Config) (*Client, error) {
 		}
 
 		sshConfig := &ssh.ClientConfig{
-			User:    conf.SSHConfig.User,
-			Auth:    []ssh.AuthMethod{ssh.PublicKeys(signer)},
-			Timeout: conf.DialTimeout,
-		}
-		if conf.SSHConfig.AcceptAnyHostKey {
-			sshConfig.HostKeyCallback = ssh.InsecureIgnoreHostKey() // skipcq: GSC-G106
+			User:            conf.SSHConfig.User,
+			Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+			Timeout:         conf.DialTimeout,
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(), // skipcq: GSC-G106
 		}
 
 		dialer.DialFunc = func(ctx context.Context, network, address string) (net.Conn, error) {

--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -763,10 +763,9 @@ func TestSSH(t *testing.T) {
 	ctx := context.Background()
 	c, err := New("tcp", []string{"kafka1:9092", "kafka2:9092", "kafka3:9092"}, Config{
 		SSHConfig: &SSHConfig{
-			User:             "linuxserver.io",
-			Host:             sshServerHost,
-			PrivateKey:       string(privateKey),
-			AcceptAnyHostKey: true,
+			User:       "linuxserver.io",
+			Host:       sshServerHost,
+			PrivateKey: string(privateKey),
 		},
 	})
 	require.NoError(t, err)

--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -733,7 +733,7 @@ func TestSSH(t *testing.T) {
 		}
 	})
 
-	// Start Kafka cluster with ZooKeeper and one broker
+	// Start Kafka cluster with ZooKeeper and three brokers
 	_, err = dockerKafka.Setup(pool, &testCleanup{t},
 		dockerKafka.WithBrokers(3),
 		dockerKafka.WithLogger(t),

--- a/services/streammanager/kafka/client/config.go
+++ b/services/streammanager/kafka/client/config.go
@@ -56,7 +56,6 @@ type Config struct {
 
 type SSHConfig struct {
 	User, Host, PrivateKey string
-	AcceptAnyHostKey       bool
 }
 
 func (c *Config) defaults() {

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -826,5 +826,6 @@ func getSSHPrivateKey(ctx context.Context, destinationID string) (string, error)
 		config.GetString("CONFIG_BACKEND_URL", "https://api.rudderstack.com"),
 		backendconfig.DefaultBackendConfig.Identity(),
 	)
-	return c.GetDestinationSSHKeys(ctx, destinationID)
+	keyPair, err := c.GetDestinationSSHKeys(ctx, destinationID)
+	return keyPair.PrivateKey, err
 }

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -811,10 +811,9 @@ func getSSHConfig(destinationID string, c *config.Config) (*client.SSHConfig, er
 	}
 
 	return &client.SSHConfig{
-		User:             c.GetString("ROUTER_KAFKA_SSH_USER", ""),
-		Host:             c.GetString("ROUTER_KAFKA_SSH_HOST", ""),
-		PrivateKey:       string(rawPrivateKey),
-		AcceptAnyHostKey: c.GetBool("ROUTER_KAFKA_SSH_ACCEPT_ANY_HOST_KEY", false),
+		User:       c.GetString("ROUTER_KAFKA_SSH_USER", ""),
+		Host:       c.GetString("ROUTER_KAFKA_SSH_HOST", ""),
+		PrivateKey: string(rawPrivateKey),
 	}, nil
 }
 

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -826,6 +826,6 @@ func getSSHPrivateKey(ctx context.Context, destinationID string) (string, error)
 		config.GetString("CONFIG_BACKEND_URL", "https://api.rudderstack.com"),
 		backendconfig.DefaultBackendConfig.Identity(),
 	)
-	keyPair, err := c.GetDestinationSSHKeys(ctx, destinationID)
+	keyPair, err := c.GetDestinationSSHKeyPair(ctx, destinationID)
 	return keyPair.PrivateKey, err
 }

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -98,7 +98,7 @@ func TestNewProducer(t *testing.T) {
 
 			p, err := NewProducer(&dest, common.Opts{})
 			require.Nil(t, p)
-			require.ErrorContains(t, err, `invalid configuration: invalid port: 0`)
+			require.ErrorContains(t, err, "invalid port")
 		})
 		t.Run("invalid schema", func(t *testing.T) {
 			kafkaStats.creationTime = getMockedTimer(t, gomock.NewController(t), false)

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -52,6 +52,17 @@ func TestMain(m *testing.M) {
 }
 
 func TestNewProducer(t *testing.T) {
+	requiredFields := map[string]interface{}{
+		"hostname": "some-hostname",
+		"topic":    "some-topic",
+		"port":     "1234",
+	}
+	withRequired := func(m map[string]interface{}) map[string]interface{} {
+		for k, v := range requiredFields {
+			m[k] = v
+		}
+		return m
+	}
 	buildTest := func(destConfig map[string]interface{}, expectedErr string) func(*testing.T) {
 		return func(t *testing.T) {
 			kafkaStats.creationTime = getMockedTimer(t, gomock.NewController(t), false)
@@ -89,10 +100,7 @@ func TestNewProducer(t *testing.T) {
 			"invalid configuration: invalid port"),
 		)
 		t.Run("invalid schema", buildTest(
-			map[string]interface{}{
-				"topic":         "some-topic",
-				"hostname":      "some-hostname",
-				"port":          "9090",
+			withRequired(map[string]interface{}{
 				"convertToAvro": true,
 				"avroSchemas": []interface{}{
 					map[string]string{"schemaId": "schema001"},
@@ -100,55 +108,43 @@ func TestNewProducer(t *testing.T) {
 						"schema": map[string]string{"name": "MyClass"},
 					},
 				},
-			},
+			}),
 			"Error while unmarshalling destination configuration "+
 				"map[avroSchemas:[map[schemaId:schema001] map[schema:map[name:MyClass]]] "+
-				"convertToAvro:true hostname:some-hostname port:9090 topic:some-topic], "+
+				"convertToAvro:true hostname:some-hostname port:1234 topic:some-topic], "+
 				"got error: json: cannot unmarshal object into Go struct field "+
 				"avroSchema.AvroSchemas.Schema of type string"),
 		)
 		t.Run("invalid ssh config", func(t *testing.T) {
 			t.Run("missing ssh host", buildTest(
-				map[string]interface{}{
-					"topic":    "some-topic",
-					"hostname": "localhost",
-					"port":     "1234",
-					"useSSH":   true,
-				},
+				withRequired(map[string]interface{}{
+					"useSSH": true,
+				}),
 				"invalid configuration: ssh host cannot be empty",
 			))
 			t.Run("missing ssh port", buildTest(
-				map[string]interface{}{
-					"topic":    "some-topic",
-					"hostname": "localhost",
-					"port":     "1234",
-					"useSSH":   true,
-					"sshHost":  "random-host",
-					"sshUser":  "johnDoe",
-				},
+				withRequired(map[string]interface{}{
+					"useSSH":  true,
+					"sshHost": "random-host",
+					"sshUser": "johnDoe",
+				}),
 				"invalid configuration: invalid ssh port",
 			))
 			t.Run("invalid ssh port", buildTest(
-				map[string]interface{}{
-					"topic":    "some-topic",
-					"hostname": "localhost",
-					"port":     "1234",
-					"useSSH":   true,
-					"sshHost":  "random-host",
-					"sshUser":  "johnDoe",
-					"sshPort":  "65536",
-				},
+				withRequired(map[string]interface{}{
+					"useSSH":  true,
+					"sshHost": "random-host",
+					"sshUser": "johnDoe",
+					"sshPort": "65536",
+				}),
 				"invalid configuration: invalid ssh port",
 			))
 			t.Run("missing ssh user", buildTest(
-				map[string]interface{}{
-					"topic":    "some-topic",
-					"hostname": "localhost",
-					"port":     "1234",
-					"useSSH":   true,
-					"sshHost":  "random-host",
-					"sshPort":  "1234",
-				},
+				withRequired(map[string]interface{}{
+					"useSSH":  true,
+					"sshHost": "random-host",
+					"sshPort": "1234",
+				}),
 				"invalid configuration: ssh user cannot be empty",
 			))
 		})

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -130,6 +130,21 @@ func TestNewProducer(t *testing.T) {
 			_, err := NewProducer(&dest, common.Opts{})
 			require.EqualError(t, err, `[Kafka] invalid configuration: ssh host cannot be empty`)
 		})
+		t.Run("invalid ssh config: missing sshUser", func(t *testing.T) {
+			kafkaStats.creationTime = getMockedTimer(t, gomock.NewController(t), false)
+			destConfig := map[string]interface{}{
+				"topic":    "some-topic",
+				"hostname": "localhost",
+				"port":     "1234",
+				"useSSH":   true,
+				"sshHost":  "random-host",
+				"sshPort":  "1234",
+			}
+			dest := backendconfig.DestinationT{Config: destConfig}
+
+			_, err := NewProducer(&dest, common.Opts{})
+			require.EqualError(t, err, `[Kafka] invalid configuration: ssh user cannot be empty`)
+		})
 	})
 
 	t.Run("ok", func(t *testing.T) {


### PR DESCRIPTION
# Description
Modified kafka to get ssh config from config-BE in addition to from env. 
NOTE: getting config via env has to be deprecated in future. 

## Notion Ticket

https://www.notion.so/rudderstacks/Kafka-with-SSH-control-plane-config-8a25b92171464903a2a5db9e40645290?pvs=4

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
