### PR TITLE
exp: event counter cache

### DIFF
--- a/app/apphandlers/gatewayAppHandler.go
+++ b/app/apphandlers/gatewayAppHandler.go
@@ -80,6 +80,7 @@ func (a *gatewayApp) StartRudderCore(ctx context.Context, options *app.Options) 
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithDSLimit(&a.config.gatewayDSLimit),
 		jobsdb.WithFileUploaderProvider(fileUploaderProvider),
+		jobsdb.WithInsertCountNotifier(),
 	)
 	defer gatewayDB.Close()
 	if err := gatewayDB.Start(); err != nil {

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -148,6 +148,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 		jobsdb.WithPreBackupHandlers(prebackupHandlers),
 		jobsdb.WithDSLimit(&a.config.gatewayDSLimit),
 		jobsdb.WithFileUploaderProvider(fileUploaderProvider),
+		jobsdb.WithInsertCountListener(),
 	)
 	defer gwDBForProcessor.Close()
 	routerDB := jobsdb.NewForReadWrite(

--- a/cmd/postgresListen/listen.go
+++ b/cmd/postgresListen/listen.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+)
+
+func main() {
+	log := logger.NewLogger().Child("postgresListen")
+
+	pool, err := pgxpool.New(context.Background(), misc.GetConnectionString())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Unable to connect to database:", err)
+		os.Exit(1)
+	}
+	defer pool.Close()
+	log.Info("acquired connection pool")
+
+	conn, err := pool.Acquire(context.Background())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error acquiring connection:", err)
+		os.Exit(1)
+	}
+	defer conn.Release()
+	log.Info("acquired connection")
+
+	_, err = conn.Exec(context.Background(), "listen counts")
+	if err != nil {
+		log.Error(os.Stderr, "Error listening to counts channel:", err)
+		os.Exit(1)
+	}
+	log.Info("listening on counts channel...")
+
+	for {
+		notification, err := conn.Conn().WaitForNotification(context.Background())
+		if err != nil {
+			log.Error(os.Stderr, "Error waiting for notification:", err)
+			os.Exit(1)
+		}
+
+		log.Info("PID:", notification.PID, "Channel:", notification.Channel, "Payload:", notification.Payload)
+	}
+}

--- a/cmd/postgresListen/listen.go
+++ b/cmd/postgresListen/listen.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -15,32 +13,28 @@ func main() {
 
 	pool, err := pgxpool.New(context.Background(), misc.GetConnectionString())
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Unable to connect to database:", err)
-		os.Exit(1)
+		log.Fatal("Unable to connect to database:", err)
 	}
 	defer pool.Close()
 	log.Info("acquired connection pool")
 
 	conn, err := pool.Acquire(context.Background())
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error acquiring connection:", err)
-		os.Exit(1)
+		log.Fatal("Error acquiring connection:", err)
 	}
 	defer conn.Release()
 	log.Info("acquired connection")
 
 	_, err = conn.Exec(context.Background(), "listen counts")
 	if err != nil {
-		log.Error(os.Stderr, "Error listening to counts channel:", err)
-		os.Exit(1)
+		log.Fatal("Error listening to counts channel:", err)
 	}
 	log.Info("listening on counts channel...")
 
 	for {
 		notification, err := conn.Conn().WaitForNotification(context.Background())
 		if err != nil {
-			log.Error(os.Stderr, "Error waiting for notification:", err)
-			os.Exit(1)
+			log.Fatal("Error waiting for notification:", err)
 		}
 
 		log.Info("PID:", notification.PID, "Channel:", notification.Channel, "Payload:", notification.Payload)

--- a/cmd/postgresListen/listen.go
+++ b/cmd/postgresListen/listen.go
@@ -13,28 +13,32 @@ func main() {
 
 	pool, err := pgxpool.New(context.Background(), misc.GetConnectionString())
 	if err != nil {
-		log.Fatal("Unable to connect to database:", err)
+		log.Error("Unable to connect to database:", err)
+		return
 	}
 	defer pool.Close()
 	log.Info("acquired connection pool")
 
 	conn, err := pool.Acquire(context.Background())
 	if err != nil {
-		log.Fatal("Error acquiring connection:", err)
+		log.Error("Error acquiring connection:", err)
+		return
 	}
 	defer conn.Release()
 	log.Info("acquired connection")
 
 	_, err = conn.Exec(context.Background(), "listen counts")
 	if err != nil {
-		log.Fatal("Error listening to counts channel:", err)
+		log.Error("Error listening to counts channel:", err)
+		return
 	}
 	log.Info("listening on counts channel...")
 
 	for {
 		notification, err := conn.Conn().WaitForNotification(context.Background())
 		if err != nil {
-			log.Fatal("Error waiting for notification:", err)
+			log.Error("Error waiting for notification:", err)
+			return
 		}
 
 		log.Info("PID:", notification.PID, "Channel:", notification.Channel, "Payload:", notification.Payload)

--- a/enterprise/replay/replay.go
+++ b/enterprise/replay/replay.go
@@ -103,7 +103,7 @@ func (handle *Handler) generatorLoop(ctx context.Context) {
 		for _, job := range combinedList {
 			w := handle.workers[rand.Intn(handle.noOfWorkers)]
 			status := jobsdb.JobStatusT{
-				JobID:         job.JobID,
+				Job:           job,
 				JobState:      jobsdb.Executing.State,
 				ExecTime:      time.Now(),
 				RetryTime:     time.Now(),

--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -44,7 +44,7 @@ func (worker *SourceWorkerT) workerProcess(ctx context.Context) {
 		worker.replayJobsInFile(ctx, gjson.GetBytes(job.EventPayload, "location").String())
 
 		status := jobsdb.JobStatusT{
-			JobID:         job.JobID,
+			Job:           job,
 			JobState:      jobsdb.Succeeded.State,
 			ExecTime:      time.Now(),
 			RetryTime:     time.Now(),

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -679,6 +679,7 @@ func (gateway *HandleT) getJobDataFromRequest(req *webRequestT) (jobData *jobFro
 		EventPayload: body,
 		EventCount:   jobData.numEvents,
 		WorkspaceId:  workspaceId,
+		SourceID:     sourceID,
 	}
 	jobData.job = job
 	return

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/hashicorp/yamux v0.1.1
 	github.com/iancoleman/strcase v0.2.0
+	github.com/jackc/pgx/v5 v5.3.1
 	github.com/jeremywohl/flatten v1.0.1
 	github.com/joho/godotenv v1.5.1
 	github.com/json-iterator/go v1.1.12
@@ -198,6 +199,9 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/heetch/avro v0.4.4 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
+	github.com/jackc/puddle/v2 v2.2.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1442,6 +1442,7 @@ github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bY
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=
 github.com/jackc/pgmock v0.0.0-20201204152224-4fe30f7445fd/go.mod h1:hrBW0Enj2AZTNpt/7Y5rr2xe/9Mn757Wtb2xeBzPv2c=
 github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65/go.mod h1:5R2h2EEX+qri8jOWMbJCtaPWkrrNc7OHwsp2TCqp7ak=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
@@ -1455,6 +1456,8 @@ github.com/jackc/pgproto3/v2 v2.1.1/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwX
 github.com/jackc/pgproto3/v2 v2.2.0/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgservicefile v0.0.0-20200307190119-3430c5407db8/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
 github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
+github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
+github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgtype v0.0.0-20190421001408-4ed0de4755e0/go.mod h1:hdSHsc1V01CGwFsrv11mJRHWJ6aifDLfdV3aVjFF0zg=
 github.com/jackc/pgtype v0.0.0-20190824184912-ab885b375b90/go.mod h1:KcahbBH1nCMSo2DXpzsoWOAfFkdEtEJpPbVLq8eE+mc=
 github.com/jackc/pgtype v0.0.0-20190828014616-a8802b16cc59/go.mod h1:MWlu30kVJrUS8lot6TQqcg7mtthZ9T0EoIBFiJcmcyw=
@@ -1473,12 +1476,16 @@ github.com/jackc/pgx/v4 v4.6.1-0.20200606145419-4e5062306904/go.mod h1:ZDaNWkt9s
 github.com/jackc/pgx/v4 v4.10.1/go.mod h1:QlrWebbs3kqEZPHCTGyxecvzG6tvIsYu+A5b1raylkA=
 github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgSXP7iUjYm9C1NxKhny7lq6ee99u/z+IHFcgs=
 github.com/jackc/pgx/v4 v4.15.0/go.mod h1:D/zyOyXiaM1TmVWnOM18p0xdDtdakRBa0RsVGI3U3bw=
+github.com/jackc/pgx/v5 v5.3.1 h1:Fcr8QJ1ZeLi5zsPZqQeUZhNhxfkkKBOgJuYkJHoBOtU=
+github.com/jackc/pgx/v5 v5.3.1/go.mod h1:t3JDKnCBlYIc0ewLF0Q7B8MXmoIaBOZj/ic7iHozM/8=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.2.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle/v2 v2.2.0 h1:RdcDk92EJBuBS55nQMMYFXTxwstHug4jkhT5pq8VxPk=
+github.com/jackc/puddle/v2 v2.2.0/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jawher/mow.cli v1.0.4/go.mod h1:5hQj2V8g+qYmLUVWqu4Wuja1pI57M83EChYLVZ0sMKk=
 github.com/jawher/mow.cli v1.2.0/go.mod h1:y+pcA3jBAdo/GIZx/0rFjw/K2bVEODP9rfZOfaiq8Ko=
 github.com/jcmturner/gofork v0.0.0-20180107083740-2aebee971930/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -50,7 +50,7 @@ func (jd *HandleT) deleteJobStatus() {
 				return err
 			}
 			tx.Tx().AddSuccessListener(func() {
-				jd.noResultsCache.InvalidateDataset(ds.Index)
+				deleteExecuting(ds.Index, jd.tablePrefix)
 			})
 		}
 
@@ -111,7 +111,7 @@ func (jd *HandleT) failExecuting() {
 				return err
 			}
 			tx.Tx().AddSuccessListener(func() {
-				jd.noResultsCache.InvalidateDataset(ds.Index)
+				failExecuting(ds.Index, jd.tablePrefix)
 			})
 		}
 		return nil

--- a/jobsdb/counterCache.go
+++ b/jobsdb/counterCache.go
@@ -1,8 +1,6 @@
 package jobsdb
 
 import (
-	"strings"
-
 	"github.com/rudderlabs/rudder-go-kit/stats/metric"
 	"github.com/samber/lo"
 )
@@ -20,69 +18,96 @@ type cacheSubject struct {
 	jobState      string
 }
 
-// tablePrefix.dsIndex.workspaceID.customVal.sourceID.destinationID.jobState
-func getSubject(cs cacheSubject) subject {
-	return subject(
-		cs.tablePrefix +
-			"." +
-			wildCard(cs.dsIndex) +
-			"." +
-			wildCard(cs.workspaceID) +
-			"." +
-			wildCard(cs.customVal) +
-			"." +
-			wildCard(cs.sourceID) +
-			"." +
-			wildCard(cs.destinationID) +
-			"." +
-			wildCard(cs.jobState),
-	)
+func (cs cacheSubject) GetName() string {
+	return cs.tablePrefix +
+		"." +
+		wildCard(cs.dsIndex) +
+		"." +
+		wildCard(cs.workspaceID) +
+		"." +
+		wildCard(cs.customVal) +
+		"." +
+		wildCard(cs.sourceID) +
+		"." +
+		wildCard(cs.destinationID) +
+		"." +
+		wildCard(cs.jobState)
 }
 
-func getComposites(cs cacheSubject) []string {
-	return []string{
-		wildCard(cs.tablePrefix),
-		wildCard(cs.dsIndex),
-		wildCard(cs.workspaceID),
-		wildCard(cs.customVal),
-		wildCard(cs.sourceID),
-		wildCard(cs.destinationID),
-		wildCard(cs.jobState),
+func (cs cacheSubject) GetTags() map[string]string {
+	return map[string]string{
+		"tablePrefix":   cs.tablePrefix,
+		"dsIndex":       cs.dsIndex,
+		"workspaceID":   cs.workspaceID,
+		"customVal":     cs.customVal,
+		"sourceID":      cs.sourceID,
+		"destinationID": cs.destinationID,
+		"jobState":      cs.jobState,
 	}
 }
 
-func getSubjectPowerSet(cs cacheSubject) []subject {
-	composites := getComposites(cs)
-	// need not take tablePrefix into consideration here because while all the
-	// other composites may/may not be wildcards,
-	// tablePrefix is always guaranteed to be non wildcard
-	tablePrefix := composites[0]
-	comps := composites[1:]
-	nonWildCardCompIndices := lo.Filter(
-		lo.Range(len(comps)),
-		func(i, _ int) bool {
-			return comps[i] != "*"
-		},
+func getCacheSubjectPowerSet(cs cacheSubject) []cacheSubject {
+	var (
+		dsIndices    []string
+		workspaceIDS []string
+		customVals   []string
+		sourceIDS    []string
+		destIDS      []string
+		jobStates    []string
 	)
-	if len(nonWildCardCompIndices) == 0 {
-		return []subject{getSubject(cs)}
+	if cs.dsIndex == "" {
+		dsIndices = []string{"*"}
+	} else {
+		dsIndices = []string{"*", cs.dsIndex}
 	}
-	// get powerset (composites could be either wildcard or non-wildcard)
-	indexPowerSet := powerSet(nonWildCardCompIndices)
-	subjects := make([]subject, len(indexPowerSet))
-	for i := range indexPowerSet {
-		subSet := make([]string, len(composites))
-		subSet[0] = tablePrefix
-		for j := 0; j < len(comps); j++ {
-			if lo.Contains(indexPowerSet[i], j) {
-				subSet[j+1] = "*"
-			} else {
-				subSet[j+1] = comps[j]
+	if cs.workspaceID == "" {
+		workspaceIDS = []string{"*"}
+	} else {
+		workspaceIDS = []string{"*", cs.workspaceID}
+	}
+	if cs.customVal == "" {
+		customVals = []string{"*"}
+	} else {
+		customVals = []string{"*", cs.customVal}
+	}
+	if cs.sourceID == "" {
+		sourceIDS = []string{"*"}
+	} else {
+		sourceIDS = []string{"*", cs.sourceID}
+	}
+	if cs.destinationID == "" {
+		destIDS = []string{"*"}
+	} else {
+		destIDS = []string{"*", cs.destinationID}
+	}
+	if cs.jobState == "" {
+		jobStates = []string{"*"}
+	} else {
+		jobStates = []string{"*", cs.jobState}
+	}
+	var cacheSubjects []cacheSubject
+	for _, dsIndex := range dsIndices {
+		for _, workspaceID := range workspaceIDS {
+			for _, customVal := range customVals {
+				for _, sourceID := range sourceIDS {
+					for _, destID := range destIDS {
+						for _, jobState := range jobStates {
+							cacheSubjects = append(cacheSubjects, cacheSubject{
+								tablePrefix:   cs.tablePrefix,
+								dsIndex:       dsIndex,
+								workspaceID:   workspaceID,
+								customVal:     customVal,
+								sourceID:      sourceID,
+								destinationID: destID,
+								jobState:      jobState,
+							})
+						}
+					}
+				}
 			}
 		}
-		subjects[i] = subject(strings.Join(subSet, "."))
 	}
-	return subjects
+	return cacheSubjects
 }
 
 func wildCard(atom string) string {
@@ -92,38 +117,12 @@ func wildCard(atom string) string {
 	return atom
 }
 
-type subject string
-
-func (s subject) GetName() string {
-	return string(s)
-}
-
-func (s subject) GetTags() map[string]string {
-	return map[string]string{}
-}
-
-func powerSet[T any](s []T) [][]T {
-	var ps [][]T
-	ps = append(ps, []T{})
-	for _, e := range s {
-		setsWithE := make([][]T, len(ps))
-		for i, subset := range ps {
-			newSet := make([]T, 0)
-			newSet = append(newSet, subset...)
-			newSet = append(newSet, e)
-			setsWithE[i] = newSet
-		}
-		ps = append(ps, setsWithE...)
-	}
-	return ps
-}
-
 var instance = metric.Instance.GetRegistry(metric.PublishedMetrics)
 
 func increaseCount(cs cacheSubject, count int) {
 	lo.ForEach(
-		getSubjectPowerSet(cs),
-		func(subject subject, _ int) {
+		getCacheSubjectPowerSet(cs),
+		func(subject cacheSubject, _ int) {
 			instance.MustGetGauge(subject).Add(float64(count))
 		},
 	)
@@ -131,15 +130,41 @@ func increaseCount(cs cacheSubject, count int) {
 
 func decreaseCount(cs cacheSubject, count int) {
 	lo.ForEach(
-		getSubjectPowerSet(cs),
-		func(subject subject, _ int) {
+		getCacheSubjectPowerSet(cs),
+		func(subject cacheSubject, _ int) {
 			instance.MustGetGauge(subject).Sub(float64(count))
 		},
 	)
 }
 
 func jobsExist(cs cacheSubject) bool {
-	return instance.MustGetGauge(getSubject(cs)).IntValue() > 0
+	return getJobCount(cs) > 0
+}
+
+func getJobCount(cs cacheSubject) int {
+	return instance.MustGetGauge(setWildCardInCacheSubject(cs)).IntValue()
+}
+
+func setWildCardInCacheSubject(cs cacheSubject) cacheSubject {
+	if cs.dsIndex == "" {
+		cs.dsIndex = "*"
+	}
+	if cs.workspaceID == "" {
+		cs.workspaceID = "*"
+	}
+	if cs.customVal == "" {
+		cs.customVal = "*"
+	}
+	if cs.sourceID == "" {
+		cs.sourceID = "*"
+	}
+	if cs.destinationID == "" {
+		cs.destinationID = "*"
+	}
+	if cs.jobState == "" {
+		cs.jobState = "*"
+	}
+	return cs
 }
 
 // check counters and return true if any of the following is non-zero
@@ -222,42 +247,67 @@ func getLookupSubjects(
 // migration/fail executing/ delete executing
 
 func failExecuting(dsIndex, tablePrefix string) {
+	// this sets all DS-executing counters to 0 and returns previous counts
 	failedCountersMap := removeState(dsIndex, tablePrefix, Executing.State)
 	for sub, count := range failedCountersMap {
-		instance.MustGetGauge(
-			subject(
-				strings.Replace(sub, Executing.State, Failed.State, 1),
-			),
-		).Add(float64(count))
+		// add to DS failed counter
+		sub.jobState = Failed.State
+		instance.MustGetGauge(sub).Add(float64(count))
+		// add to wildcard DS failed counter
+		sub.dsIndex = "*"
+		instance.MustGetGauge(sub).Add(float64(count))
+		// subtract from wildcard DS executing counter
+		sub.jobState = Executing.State
+		instance.MustGetGauge(sub).Sub(float64(count))
 	}
 }
 
 func deleteExecuting(dsIndex, tablePrefix string) {
+	// this sets all DS-executing counters to 0 and returns previous counts
 	executingCountsMap := removeState(dsIndex, tablePrefix, Executing.State)
 	for sub, count := range executingCountsMap {
-		instance.MustGetGauge(
-			subject(
-				strings.Replace(sub, Executing.State, NotProcessed.State, 1),
-			),
-		).Add(float64(count))
+		// add to DS NotPickedYet counter
+		sub.jobState = NotProcessed.State
+		instance.MustGetGauge(sub).Add(float64(count))
+		// add to wildcard DS NotPickedYet counter
+		sub.dsIndex = "*"
+		instance.MustGetGauge(sub).Add(float64(count))
+		// subtract from wildcard DS executing counter
+		sub.jobState = Executing.State
+		instance.MustGetGauge(sub).Sub(float64(count))
 	}
 }
 
-// clear termnial counters for old DS
+// for terminal jobs - clear those jobs entirely from everywhere
 //
 // update non-terminal counters from old to migrated(new) DS
-func postMigrationCounterUpdate(oldDS, newDS, tablePrefix string) {
+func postMigrationCounterUpdate(oldDSIndex, newDSIndex, tablePrefix string) {
 	for _, state := range validTerminalStates {
-		_ = removeState(oldDS, tablePrefix, state)
+		clearedTerminalCounts := removeState(oldDSIndex, tablePrefix, state)
+		for sub, count := range clearedTerminalCounts {
+			// clear wildcard DS state
+			sub.dsIndex = "*"
+			instance.MustGetGauge(sub).Sub(float64(count))
+			// clear old DS wildcard states
+			sub.dsIndex = oldDSIndex
+			sub.jobState = "*"
+			instance.MustGetGauge(sub).Sub(float64(count))
+			// clear wildcard DS wildcard states
+			sub.dsIndex = "*"
+			instance.MustGetGauge(sub).Sub(float64(count))
+		}
 	}
 	for _, state := range validNonTerminalStates {
-		clearedCountsMap := removeState(oldDS, tablePrefix, state)
-		for sub, count := range clearedCountsMap {
-			instance.MustGetGauge(
-				subject(
-					strings.Replace(sub, oldDS, newDS, 1),
-				),
-			).Add(float64(count))
+		clearedNonTerminalCountsMap := removeState(oldDSIndex, tablePrefix, state)
+		for sub, count := range clearedNonTerminalCountsMap {
+			// clear Old DS wildcard state
+			instance.MustGetGauge(sub).Sub(float64(count))
+			// add to new DS state
+			sub.dsIndex = newDSIndex
+			instance.MustGetGauge(sub).Add(float64(count))
+			// add to new DS wildcard states
+			sub.jobState = "*"
+			instance.MustGetGauge(sub).Add(float64(count))
 		}
 	}
 }
@@ -265,18 +315,17 @@ func postMigrationCounterUpdate(oldDS, newDS, tablePrefix string) {
 // sets count to 0 for all counters with the given dsIndex, tablePrefix and jobState
 //
 // and returns a map of the counters that were cleared
-func removeState(dsIndex, tablePrefix, jobState string) map[string]int {
-	subjectPrefix := tablePrefix + "." + dsIndex
-	clearedCountsMap := make(map[string]int)
+func removeState(dsIndex, tablePrefix, jobState string) map[cacheSubject]int {
+	clearedCountsMap := make(map[cacheSubject]int)
 	instance.Range(
 		func(key, value interface{}) bool {
-			if m, ok := key.(subject); ok {
+			if m, ok := key.(cacheSubject); ok {
 				if gauge, ok := value.(metric.Gauge); ok {
-					subjectString := string(m)
-					if strings.HasPrefix(subjectString, subjectPrefix) &&
-						strings.HasSuffix(subjectString, jobState) {
+					if m.tablePrefix == tablePrefix &&
+						m.dsIndex == dsIndex &&
+						m.jobState == jobState {
 						preStatusDeleteCount := gauge.IntValue()
-						clearedCountsMap[subjectString] = preStatusDeleteCount
+						clearedCountsMap[m] = preStatusDeleteCount
 						gauge.Set(0)
 					}
 				}
@@ -285,4 +334,27 @@ func removeState(dsIndex, tablePrefix, jobState string) map[string]int {
 		},
 	)
 	return clearedCountsMap
+}
+
+// TODO
+//
+// ignore MinDSRetentionPeriod, MaxDSRetentionPeriod?
+func checkIfMigrateDS(dsIndex, tablePrefix string) bool {
+	allJobsCount := getJobCount(cacheSubject{
+		tablePrefix: tablePrefix,
+		dsIndex:     dsIndex,
+	})
+	if allJobsCount == 0 {
+		return false
+	}
+	var terminalJobsCount int
+	for _, state := range validTerminalStates {
+		terminalJobsCount += getJobCount(cacheSubject{
+			tablePrefix: tablePrefix,
+			dsIndex:     dsIndex,
+			jobState:    state,
+		})
+	}
+	// TODO
+	return false
 }

--- a/jobsdb/counterCache.go
+++ b/jobsdb/counterCache.go
@@ -7,21 +7,6 @@ import (
 	"github.com/samber/lo"
 )
 
-// The struct fields need to be exposed to JSON package
-type dataSetT struct {
-	JobTable       string `json:"job"`
-	JobStatusTable string `json:"status"`
-	Index          string `json:"index"`
-}
-
-type dataSetRangeT struct {
-	minJobID  int64
-	maxJobID  int64
-	startTime int64
-	endTime   int64
-	ds        dataSetT
-}
-
 // cache subject structure
 // workspaceID.sourceID.destinationID.jobState
 
@@ -74,7 +59,7 @@ func getSubjectPowerSet(cs cacheSubject) []subject {
 	comps := composites[1:]
 	nonWildCardCompIndices := lo.Filter(
 		lo.Range(len(comps)),
-		func(i int, _ int) bool {
+		func(i, _ int) bool {
 			return comps[i] != "*"
 		},
 	)

--- a/jobsdb/counterCache.go
+++ b/jobsdb/counterCache.go
@@ -297,7 +297,7 @@ func postMigrationCounterUpdate(oldDSIndex, newDSIndex, tablePrefix string) {
 			instance.MustGetGauge(sub).Sub(float64(count))
 		}
 	}
-	for _, state := range validNonTerminalStates {
+	for _, state := range append(validNonTerminalStates, NotProcessed.State) {
 		clearedNonTerminalCountsMap := removeState(oldDSIndex, tablePrefix, state)
 		for sub, count := range clearedNonTerminalCountsMap {
 			// clear Old DS wildcard state
@@ -339,22 +339,22 @@ func removeState(dsIndex, tablePrefix, jobState string) map[cacheSubject]int {
 // TODO
 //
 // ignore MinDSRetentionPeriod, MaxDSRetentionPeriod?
-func checkIfMigrateDS(dsIndex, tablePrefix string) bool {
-	allJobsCount := getJobCount(cacheSubject{
-		tablePrefix: tablePrefix,
-		dsIndex:     dsIndex,
-	})
-	if allJobsCount == 0 {
-		return false
-	}
-	var terminalJobsCount int
-	for _, state := range validTerminalStates {
-		terminalJobsCount += getJobCount(cacheSubject{
-			tablePrefix: tablePrefix,
-			dsIndex:     dsIndex,
-			jobState:    state,
-		})
-	}
-	// TODO
-	return false
-}
+// func checkIfMigrateDS(dsIndex, tablePrefix string) bool {
+// 	allJobsCount := getJobCount(cacheSubject{
+// 		tablePrefix: tablePrefix,
+// 		dsIndex:     dsIndex,
+// 	})
+// 	if allJobsCount == 0 {
+// 		return false
+// 	}
+// 	var terminalJobsCount int
+// 	for _, state := range validTerminalStates {
+// 		terminalJobsCount += getJobCount(cacheSubject{
+// 			tablePrefix: tablePrefix,
+// 			dsIndex:     dsIndex,
+// 			jobState:    state,
+// 		})
+// 	}
+// 	// TODO
+// 	return false
+// }

--- a/jobsdb/dataSet.go
+++ b/jobsdb/dataSet.go
@@ -1,0 +1,155 @@
+package jobsdb
+
+import (
+	"strings"
+
+	"github.com/rudderlabs/rudder-go-kit/stats/metric"
+	"github.com/samber/lo"
+)
+
+// The struct fields need to be exposed to JSON package
+type dataSetT struct {
+	JobTable       string `json:"job"`
+	JobStatusTable string `json:"status"`
+	Index          string `json:"index"`
+}
+
+type dataSetRangeT struct {
+	minJobID  int64
+	maxJobID  int64
+	startTime int64
+	endTime   int64
+	ds        dataSetT
+}
+
+// cache subject structure
+// workspaceID.sourceID.destinationID.jobState
+
+type cacheSubject struct {
+	tablePrefix   string
+	dsIndex       string
+	workspaceID   string
+	customVal     string
+	sourceID      string
+	destinationID string
+	jobState      string
+}
+
+// tablePrefix.dsIndex.workspaceID.customVal.sourceID.destinationID.jobState
+func getSubject(cs cacheSubject) subject {
+	return subject(
+		cs.tablePrefix +
+			"." +
+			wildCard(cs.dsIndex) +
+			"." +
+			wildCard(cs.workspaceID) +
+			"." +
+			wildCard(cs.customVal) +
+			"." +
+			wildCard(cs.sourceID) +
+			"." +
+			wildCard(cs.destinationID) +
+			"." +
+			wildCard(cs.jobState),
+	)
+}
+
+func getComposites(cs cacheSubject) []string {
+	return []string{
+		wildCard(cs.tablePrefix),
+		wildCard(cs.dsIndex),
+		wildCard(cs.workspaceID),
+		wildCard(cs.customVal),
+		wildCard(cs.sourceID),
+		wildCard(cs.destinationID),
+		wildCard(cs.jobState),
+	}
+}
+
+func getSubjectPowerSet(cs cacheSubject) []subject {
+	composites := getComposites(cs)
+	// need not take tablePrefix into consideration here because while all the
+	// other composites may/may not be wildcards,
+	// tablePrefix is always guaranteed to be non wildcard
+	comps := composites[1:]
+	nonWildCardCompIndices := lo.Filter(
+		lo.Range(len(comps)),
+		func(i int, _ int) bool {
+			return comps[i] != "*"
+		},
+	)
+	if len(nonWildCardCompIndices) == 0 {
+		return []subject{getSubject(cs)}
+	}
+	// get powerset (composites could be either wildcard or non-wildcard)
+	indexPowerSet := powerSet(nonWildCardCompIndices)
+	subjects := make([]subject, len(indexPowerSet))
+	subjects[0] = getSubject(cs)
+	for i := range indexPowerSet[1:] { // first one is empty
+		subSet := make([]string, len(composites))
+		subSet[0] = composites[0]
+		for j := range comps {
+			if lo.Contains(indexPowerSet[i], j) {
+				subSet[j] = "*"
+			} else {
+				subSet[j] = comps[j]
+			}
+		}
+		subjects[i] = subject(strings.Join(subSet, "."))
+	}
+	return subjects
+}
+
+func wildCard(atom string) string {
+	if atom == "" {
+		return "*"
+	}
+	return atom
+}
+
+type subject string
+
+func (s subject) GetName() string {
+	return string(s)
+}
+
+func (s subject) GetTags() map[string]string {
+	return map[string]string{}
+}
+
+func powerSet[T any](s []T) [][]T {
+	var ps [][]T
+	ps = append(ps, []T{})
+	for _, e := range s {
+		setsWithE := make([][]T, len(ps))
+		for i, subset := range ps {
+			newSet := make([]T, 0)
+			newSet = append(newSet, subset...)
+			newSet = append(newSet, e)
+			setsWithE[i] = newSet
+		}
+		ps = append(ps, setsWithE...)
+	}
+	return ps
+}
+
+func increaseCount(cs cacheSubject, count int) {
+	subjects := getSubjectPowerSet(cs)
+	for _, subject := range subjects {
+		metric.Instance.GetRegistry(metric.PublishedMetrics).
+			MustGetGauge(subject).Add(float64(count))
+	}
+}
+
+func decreaseCount(cs cacheSubject, count int) {
+	subjects := getSubjectPowerSet(cs)
+	for _, subject := range subjects {
+		metric.Instance.GetRegistry(metric.PublishedMetrics).
+			MustGetGauge(subject).Sub(float64(count))
+	}
+}
+
+func getCount(cs cacheSubject) int {
+	return metric.Instance.GetRegistry(metric.PublishedMetrics).
+		MustGetGauge(getSubject(cs)).IntValue()
+}

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -43,7 +43,7 @@ func genJobStatuses(jobs []*JobT, state string) []*JobStatusT {
 	for i := range jobs {
 		job := jobs[i]
 		statuses = append(statuses, &JobStatusT{
-			JobID:         job.JobID,
+			Job:           job,
 			JobState:      state,
 			AttemptNum:    1,
 			ExecTime:      time.Now(),
@@ -102,7 +102,7 @@ func TestJobsDB(t *testing.T) {
 	require.Equal(t, 1, len(unprocessedList))
 
 	status := JobStatusT{
-		JobID:         unprocessedList[0].JobID,
+		Job:           unprocessedList[0],
 		JobState:      "succeeded",
 		AttemptNum:    1,
 		ExecTime:      time.Now(),
@@ -180,7 +180,7 @@ func TestJobsDB(t *testing.T) {
 		n := time.Now().Add(time.Hour * -1)
 		for i := range statuses {
 			statuses[i] = &JobStatusT{
-				JobID:         JobLimitList[i].JobID,
+				Job:           JobLimitList[i],
 				JobState:      Failed.State,
 				AttemptNum:    1,
 				ExecTime:      n,
@@ -273,7 +273,7 @@ func TestJobsDB(t *testing.T) {
 			n := time.Now().Add(time.Hour * -1)
 			for i := range statuses {
 				statuses[i] = &JobStatusT{
-					JobID:         allJobs.Jobs[i].JobID,
+					Job:           allJobs.Jobs[i],
 					JobState:      Failed.State,
 					AttemptNum:    1,
 					ExecTime:      n,
@@ -521,7 +521,7 @@ func TestJobsDB(t *testing.T) {
 		require.Equal(t, 20, len(fetchedJobs))
 
 		status := JobStatusT{
-			JobID:         fetchedJobs[0].JobID,
+			Job:           fetchedJobs[0],
 			JobState:      "succeeded",
 			AttemptNum:    1,
 			ExecTime:      time.Now(),
@@ -617,7 +617,7 @@ func TestJobsDB(t *testing.T) {
 		// process some jobs
 		for _, job := range jobsResult.Jobs[:15] {
 			status := JobStatusT{
-				JobID:         job.JobID,
+				Job:           job,
 				JobState:      "succeeded",
 				AttemptNum:    1,
 				ExecTime:      time.Now(),
@@ -658,7 +658,7 @@ func TestJobsDB(t *testing.T) {
 		require.NoError(t, err)
 		for _, job := range jobsResult.Jobs[5:20] {
 			status := JobStatusT{
-				JobID:         job.JobID,
+				Job:           job,
 				JobState:      Succeeded.State,
 				AttemptNum:    1,
 				ExecTime:      time.Now(),
@@ -1011,7 +1011,7 @@ func TestStoreAndUpdateStatusExceedingAnalyzeThreshold(t *testing.T) {
 	require.Equal(t, 1, len(unprocessedList))
 	j := unprocessedList[0]
 	jobStatus := &JobStatusT{
-		JobID:         j.JobID,
+		Job:           j,
 		JobState:      "succeeded",
 		AttemptNum:    1,
 		ExecTime:      time.Now(),
@@ -1257,7 +1257,7 @@ func benchmarkJobsdbConcurrently(b *testing.B, jobsDB *HandleT, totalJobs, pageS
 					status := make([]*JobStatusT, len(unprocessedList))
 					for i, j := range unprocessedList {
 						status[i] = &JobStatusT{
-							JobID:         j.JobID,
+							Job:           j,
 							JobState:      "succeeded",
 							AttemptNum:    1,
 							ExecTime:      time.Now(),
@@ -1373,7 +1373,7 @@ func consume(t testing.TB, db *HandleT, count int) {
 	status := make([]*JobStatusT, len(unprocessedList.Jobs))
 	for i, j := range unprocessedList.Jobs {
 		status[i] = &JobStatusT{
-			JobID:         j.JobID,
+			Job:           j,
 			JobState:      "succeeded",
 			AttemptNum:    1,
 			ExecTime:      time.Now(),

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -25,14 +25,16 @@ func genJobs(workspaceId, customVal string, jobCount, eventsPerJob int) []*JobT 
 	js := make([]*JobT, jobCount)
 	for i := range js {
 		js[i] = &JobT{
-			JobID:        int64(i) + 1,
-			Parameters:   []byte(`{"batch_id":1,"source_id":"sourceID","source_job_run_id":""}`),
-			EventPayload: []byte(`{"receivedAt":"2021-06-06T20:26:39.598+05:30","writeKey":"writeKey","requestIP":"[::1]",  "batch": [{"anonymousId":"anon_id","channel":"android-sdk","context":{"app":{"build":"1","name":"RudderAndroidClient","namespace":"com.rudderlabs.android.sdk","version":"1.0"},"device":{"id":"49e4bdd1c280bc00","manufacturer":"Google","model":"Android SDK built for x86","name":"generic_x86"},"library":{"name":"com.rudderstack.android.sdk.core"},"locale":"en-US","network":{"carrier":"Android"},"screen":{"density":420,"height":1794,"width":1080},"traits":{"anonymousId":"49e4bdd1c280bc00"},"user_agent":"Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.075)"},"event":"Demo Track","integrations":{"All":true},"messageId":"b96f3d8a-7c26-4329-9671-4e3202f42f15","originalTimestamp":"2019-08-12T05:08:30.909Z","properties":{"category":"Demo Category","floatVal":4.501,"label":"Demo Label","testArray":[{"id":"elem1","value":"e1"},{"id":"elem2","value":"e2"}],"testMap":{"t1":"a","t2":4},"value":5},"rudderId":"a-292e-4e79-9880-f8009e0ae4a3","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}]}`),
-			UserID:       "a-292e-4e79-9880-f8009e0ae4a3",
-			UUID:         uuid.New(),
-			CustomVal:    customVal,
-			EventCount:   eventsPerJob,
-			WorkspaceId:  workspaceId,
+			JobID:         int64(i) + 1,
+			Parameters:    []byte(`{"batch_id":1,"source_id":"sourceID","source_job_run_id":""}`),
+			EventPayload:  []byte(`{"receivedAt":"2021-06-06T20:26:39.598+05:30","writeKey":"writeKey","requestIP":"[::1]",  "batch": [{"anonymousId":"anon_id","channel":"android-sdk","context":{"app":{"build":"1","name":"RudderAndroidClient","namespace":"com.rudderlabs.android.sdk","version":"1.0"},"device":{"id":"49e4bdd1c280bc00","manufacturer":"Google","model":"Android SDK built for x86","name":"generic_x86"},"library":{"name":"com.rudderstack.android.sdk.core"},"locale":"en-US","network":{"carrier":"Android"},"screen":{"density":420,"height":1794,"width":1080},"traits":{"anonymousId":"49e4bdd1c280bc00"},"user_agent":"Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.075)"},"event":"Demo Track","integrations":{"All":true},"messageId":"b96f3d8a-7c26-4329-9671-4e3202f42f15","originalTimestamp":"2019-08-12T05:08:30.909Z","properties":{"category":"Demo Category","floatVal":4.501,"label":"Demo Label","testArray":[{"id":"elem1","value":"e1"},{"id":"elem2","value":"e2"}],"testMap":{"t1":"a","t2":4},"value":5},"rudderId":"a-292e-4e79-9880-f8009e0ae4a3","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}]}`),
+			UserID:        "a-292e-4e79-9880-f8009e0ae4a3",
+			UUID:          uuid.New(),
+			CustomVal:     customVal,
+			EventCount:    eventsPerJob,
+			WorkspaceId:   workspaceId,
+			SourceID:      "sourceID",
+			DestinationID: "destinationID",
 		}
 	}
 	return js

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -2659,6 +2659,8 @@ func (jd *HandleT) updateJobStatusDSInTx(ctx context.Context, tx *Tx, ds dataSet
 				cs,
 				1,
 			)
+			status.Job.LastJobStatus.JobState = status.JobState
+			status.Job.LastJobStatus.AttemptNum = status.AttemptNum
 		}
 	})
 	return

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -968,14 +968,17 @@ func (jd *HandleT) init() {
 							tablePrefix: jd.tablePrefix,
 							dsIndex:     ds.Index,
 						}
-						var count sql.NullInt64
-						var state sql.NullString
-						var destinationID sql.NullString
+						var (
+							count         sql.NullInt64
+							state         sql.NullString
+							destinationID sql.NullString
+							sourceID      sql.NullString
+						)
 						err := rows.Scan(
 							&count,
 							&row.customVal,
 							&row.workspaceID,
-							&row.sourceID,
+							&sourceID,
 							&destinationID,
 							&state,
 						)
@@ -984,6 +987,9 @@ func (jd *HandleT) init() {
 						}
 						if destinationID.Valid {
 							row.destinationID = destinationID.String
+						}
+						if sourceID.Valid {
+							row.sourceID = sourceID.String
 						}
 						if state.Valid {
 							row.jobState = state.String

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -502,7 +502,7 @@ func (*backupTestCase) getJobsFromAbortedJobs(t *testing.T, file *os.File) ([]*J
 		jobs = append(jobs, job)
 
 		jobStatus := &JobStatusT{
-			JobID:         gjson.GetBytes(lineByte, "job_id").Int(),
+			Job:           &JobT{JobID: gjson.GetBytes(lineByte, "job_id").Int()},
 			JobState:      gjson.GetBytes(lineByte, "job_state").String(),
 			AttemptNum:    int(gjson.GetBytes(lineByte, "attempt").Int()),
 			ErrorCode:     gjson.GetBytes(lineByte, "error_code").String(),
@@ -598,7 +598,7 @@ func (*backupTestCase) readGzipStatusFile(fileName string) ([]*JobStatusT, error
 	for sc.Scan() {
 		lineByte := sc.Bytes()
 		jobStatus := &JobStatusT{
-			JobID:         gjson.GetBytes(lineByte, "job_id").Int(),
+			Job:           &JobT{JobID: gjson.GetBytes(lineByte, "job_id").Int()},
 			JobState:      gjson.GetBytes(lineByte, "job_state").String(),
 			AttemptNum:    int(gjson.GetBytes(lineByte, "attempt").Int()),
 			ErrorCode:     gjson.GetBytes(lineByte, "error_code").String(),
@@ -622,7 +622,7 @@ func getStatusByWorkspace(jobStatus []*JobStatusT, jobsByWorkspace map[string][]
 	jobStatusByWorkspace := make(map[string][]*JobStatusT)
 	jobStatusByJobID := make(map[int64]*JobStatusT)
 	for _, status := range jobStatus {
-		jobStatusByJobID[status.JobID] = status
+		jobStatusByJobID[status.Job.JobID] = status
 	}
 	for workspaceId, job := range jobsByWorkspace {
 		for _, job := range job {

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -1386,7 +1386,7 @@ func TestGetDistinctParameterValues(t *testing.T) {
 	require.NoError(t, err)
 	statuses := lo.Map(res.Jobs, func(job *JobT, _ int) *JobStatusT {
 		return &JobStatusT{
-			JobID:       job.JobID,
+			Job:         job,
 			JobState:    Succeeded.State,
 			AttemptNum:  1,
 			WorkspaceId: "workspace",

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -1062,7 +1062,7 @@ func TestAfterJobIDQueryParam(t *testing.T) {
 		var statuses []*JobStatusT
 		for _, job := range unprocessed.Jobs {
 			statuses = append(statuses, &JobStatusT{
-				JobID:         job.JobID,
+				Job:           job,
 				JobState:      Failed.State,
 				AttemptNum:    1,
 				ExecTime:      time.Now(),
@@ -1116,7 +1116,7 @@ func TestDeleteExecuting(t *testing.T) {
 	var statuses []*JobStatusT
 	for _, job := range unprocessed.Jobs {
 		statuses = append(statuses, &JobStatusT{
-			JobID:         job.JobID,
+			Job:           job,
 			JobState:      Executing.State,
 			AttemptNum:    1,
 			ExecTime:      time.Now(),
@@ -1171,7 +1171,7 @@ func TestFailExecuting(t *testing.T) {
 	var statuses []*JobStatusT
 	for _, job := range unprocessed.Jobs {
 		statuses = append(statuses, &JobStatusT{
-			JobID:         job.JobID,
+			Job:           job,
 			JobState:      Executing.State,
 			AttemptNum:    1,
 			ExecTime:      time.Now(),
@@ -1284,7 +1284,7 @@ func TestGetActiveWorkspaces(t *testing.T) {
 	require.NoError(t, err)
 	statuses := lo.Map(res.Jobs, func(job *JobT, _ int) *JobStatusT {
 		return &JobStatusT{
-			JobID:       job.JobID,
+			Job:         job,
 			JobState:    Succeeded.State,
 			AttemptNum:  1,
 			WorkspaceId: "ws-3",

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -762,12 +762,14 @@ func TestCacheScenarios(t *testing.T) {
 		js := make([]*JobT, numOfJob)
 		for i := 0; i < numOfJob; i++ {
 			js[i] = &JobT{
-				Parameters:   []byte(fmt.Sprintf(`{"batch_id":1,"source_id":"sourceID","destination_id":%q}`, destinationID)),
-				EventPayload: []byte(`{"testKey":"testValue"}`),
-				UserID:       "a-292e-4e79-9880-f8009e0ae4a3",
-				UUID:         uuid.New(),
-				CustomVal:    customVal,
-				EventCount:   1,
+				Parameters:    []byte(fmt.Sprintf(`{"batch_id":1,"source_id":"sourceID","destination_id":%q}`, destinationID)),
+				EventPayload:  []byte(`{"testKey":"testValue"}`),
+				UserID:        "a-292e-4e79-9880-f8009e0ae4a3",
+				UUID:          uuid.New(),
+				CustomVal:     customVal,
+				EventCount:    1,
+				SourceID:      "sourceID",
+				DestinationID: destinationID,
 			}
 		}
 		return js
@@ -1015,12 +1017,14 @@ func TestAfterJobIDQueryParam(t *testing.T) {
 		js := make([]*JobT, numOfJob)
 		for i := 0; i < numOfJob; i++ {
 			js[i] = &JobT{
-				Parameters:   []byte(fmt.Sprintf(`{"batch_id":1,"source_id":"sourceID","destination_id":%q}`, destinationID)),
-				EventPayload: []byte(`{"testKey":"testValue"}`),
-				UserID:       "a-292e-4e79-9880-f8009e0ae4a3",
-				UUID:         uuid.New(),
-				CustomVal:    customVal,
-				EventCount:   1,
+				Parameters:    []byte(fmt.Sprintf(`{"batch_id":1,"source_id":"sourceID","destination_id":%q}`, destinationID)),
+				EventPayload:  []byte(`{"testKey":"testValue"}`),
+				UserID:        "a-292e-4e79-9880-f8009e0ae4a3",
+				UUID:          uuid.New(),
+				CustomVal:     customVal,
+				EventCount:    1,
+				SourceID:      "sourceID",
+				DestinationID: destinationID,
 			}
 		}
 		return js
@@ -1092,12 +1096,14 @@ func TestDeleteExecuting(t *testing.T) {
 		js := make([]*JobT, numOfJob)
 		for i := 0; i < numOfJob; i++ {
 			js[i] = &JobT{
-				Parameters:   []byte(fmt.Sprintf(`{"batch_id":1,"source_id":"sourceID","destination_id":%q}`, destinationID)),
-				EventPayload: []byte(`{"testKey":"testValue"}`),
-				UserID:       "a-292e-4e79-9880-f8009e0ae4a3",
-				UUID:         uuid.New(),
-				CustomVal:    customVal,
-				EventCount:   1,
+				Parameters:    []byte(fmt.Sprintf(`{"batch_id":1,"source_id":"sourceID","destination_id":%q}`, destinationID)),
+				EventPayload:  []byte(`{"testKey":"testValue"}`),
+				UserID:        "a-292e-4e79-9880-f8009e0ae4a3",
+				UUID:          uuid.New(),
+				CustomVal:     customVal,
+				EventCount:    1,
+				SourceID:      "sourceID",
+				DestinationID: destinationID,
 			}
 		}
 		return js
@@ -1146,12 +1152,14 @@ func TestFailExecuting(t *testing.T) {
 		js := make([]*JobT, numOfJob)
 		for i := 0; i < numOfJob; i++ {
 			js[i] = &JobT{
-				Parameters:   []byte(fmt.Sprintf(`{"batch_id":1,"source_id":"sourceID","destination_id":%q}`, destinationID)),
-				EventPayload: []byte(`{"testKey":"testValue"}`),
-				UserID:       "a-292e-4e79-9880-f8009e0ae4a3",
-				UUID:         uuid.New(),
-				CustomVal:    customVal,
-				EventCount:   1,
+				Parameters:    []byte(fmt.Sprintf(`{"batch_id":1,"source_id":"sourceID","destination_id":%q}`, destinationID)),
+				EventPayload:  []byte(`{"testKey":"testValue"}`),
+				UserID:        "a-292e-4e79-9880-f8009e0ae4a3",
+				UUID:          uuid.New(),
+				CustomVal:     customVal,
+				EventCount:    1,
+				SourceID:      "sourceID",
+				DestinationID: destinationID,
 			}
 		}
 		return js

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -343,6 +343,13 @@ func (jd *HandleT) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS da
 	if _, err := tx.Exec(fmt.Sprintf(`ANALYZE %q, %q`, destDS.JobTable, destDS.JobStatusTable)); err != nil {
 		return 0, err
 	}
+	tx.AddSuccessListener(func() {
+		postMigrationCounterUpdate(
+			srcDS.Index,
+			destDS.Index,
+			jd.tablePrefix,
+		)
+	})
 	return int(numJobsMigrated), nil
 }
 

--- a/jobsdb/migration_test.go
+++ b/jobsdb/migration_test.go
@@ -46,7 +46,7 @@ func TestMigration(t *testing.T) {
 	jobs := genJobs(defaultWorkspaceID, customVal, 30, 1)
 	require.NoError(t, jobDB.Store(context.Background(), jobs[:10]))
 
-	// let 8 jobs succeed, and 2 repeatedly fail
+	// let 9 jobs succeed, and 1 repeatedly fail
 	require.NoError(
 		t,
 		jobDB.UpdateJobStatus(

--- a/jobsdb/unionQuery.go
+++ b/jobsdb/unionQuery.go
@@ -225,9 +225,7 @@ func (mj *MultiTenantHandleT) getUnionDS(ctx context.Context, ds dataSetT, picku
 			return jobList, err
 		}
 
-		job.LastJobStatus = JobStatusT{
-			JobParameters: job.Parameters,
-		}
+		job.LastJobStatus = LastStateT{}
 		if _nullJS.Valid {
 			job.LastJobStatus.JobState = _nullJS.String
 		}

--- a/jobsdb/unionQuery_test.go
+++ b/jobsdb/unionQuery_test.go
@@ -75,7 +75,7 @@ func TestMultiTenantHandleT_GetAllJobs(t *testing.T) {
 	require.Equal(t, 3, len(unprocessedList.Jobs))
 
 	status1 := JobStatusT{
-		JobID:         unprocessedList.Jobs[0].JobID,
+		Job:           unprocessedList.Jobs[0],
 		JobState:      "waiting",
 		AttemptNum:    1,
 		ExecTime:      time.Now(),
@@ -86,7 +86,7 @@ func TestMultiTenantHandleT_GetAllJobs(t *testing.T) {
 		WorkspaceId:   "testWorkspace",
 	}
 	status2 := JobStatusT{
-		JobID:         unprocessedList.Jobs[1].JobID,
+		Job:           unprocessedList.Jobs[1],
 		JobState:      "failed",
 		AttemptNum:    1,
 		ExecTime:      time.Now(),

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -143,6 +143,7 @@ func genJobs(customVal string, jobCount, eventsPerJob int) []*jobsdb.JobT {
 			UUID:         uuid.New(),
 			CustomVal:    customVal,
 			EventCount:   eventsPerJob,
+			SourceID:     "sourceID",
 		}
 	}
 	return js

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1210,14 +1210,16 @@ func (proc *Handle) getFailedEventJobs(response transformer.ResponseT, commonMet
 		}
 
 		newFailedJob := jobsdb.JobT{
-			UUID:         id,
-			EventPayload: payload,
-			Parameters:   marshalledParams,
-			CreatedAt:    time.Now(),
-			ExpireAt:     time.Now(),
-			CustomVal:    commonMetaData.DestinationType,
-			UserID:       failedEvent.Metadata.RudderID,
-			WorkspaceId:  failedEvent.Metadata.WorkspaceID,
+			UUID:          id,
+			EventPayload:  payload,
+			Parameters:    marshalledParams,
+			CreatedAt:     time.Now(),
+			ExpireAt:      time.Now(),
+			CustomVal:     commonMetaData.DestinationType,
+			UserID:        failedEvent.Metadata.RudderID,
+			WorkspaceId:   failedEvent.Metadata.WorkspaceID,
+			SourceID:      commonMetaData.SourceID,
+			DestinationID: commonMetaData.DestinationID,
 		}
 		failedEventsToStore = append(failedEventsToStore, &newFailedJob)
 
@@ -1534,7 +1536,7 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob, parsedE
 
 		// Mark the batch event as processed
 		newStatus := jobsdb.JobStatusT{
-			JobID:         batchEvent.JobID,
+			Job:           batchEvent,
 			JobState:      jobsdb.Succeeded.State,
 			AttemptNum:    1,
 			ExecTime:      time.Now(),
@@ -2375,14 +2377,16 @@ func (proc *Handle) transformSrcDest(
 			}
 
 			newJob := jobsdb.JobT{
-				UUID:         id,
-				UserID:       rudderID,
-				Parameters:   marshalledParams,
-				CreatedAt:    time.Now(),
-				ExpireAt:     time.Now(),
-				CustomVal:    destType,
-				EventPayload: destEventJSON,
-				WorkspaceId:  workspaceId,
+				UUID:          id,
+				UserID:        rudderID,
+				Parameters:    marshalledParams,
+				CreatedAt:     time.Now(),
+				ExpireAt:      time.Now(),
+				CustomVal:     destType,
+				EventPayload:  destEventJSON,
+				WorkspaceId:   workspaceId,
+				SourceID:      sourceID,
+				DestinationID: destID,
 			}
 			if slices.Contains(proc.config.batchDestinations, newJob.CustomVal) {
 				batchDestJobs = append(batchDestJobs, &newJob)
@@ -2552,7 +2556,7 @@ func (proc *Handle) markExecuting(jobs []*jobsdb.JobT) error {
 	statusList := make([]*jobsdb.JobStatusT, len(jobs))
 	for i, job := range jobs {
 		statusList[i] = &jobsdb.JobStatusT{
-			JobID:         job.JobID,
+			Job:           job,
 			AttemptNum:    job.LastJobStatus.AttemptNum,
 			JobState:      jobsdb.Executing.State,
 			ExecTime:      time.Now(),

--- a/processor/processorBenchmark_test.go
+++ b/processor/processorBenchmark_test.go
@@ -63,7 +63,7 @@ var dummyBatchEvent jobsdb.JobT = jobsdb.JobT{
 	CustomVal:     "GW",
 	EventCount:    1,
 	EventPayload:  payload,
-	LastJobStatus: jobsdb.JobStatusT{},
+	LastJobStatus: jobsdb.LastStateT{},
 	Parameters:    gwParameters,
 	WorkspaceId:   "test",
 }

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -749,7 +749,7 @@ var _ = Describe("Processor", Ordered, func() {
 					CustomVal:     gatewayCustomVal[0],
 					EventPayload:  nil,
 					EventCount:    1,
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    nil,
 				},
 				{
@@ -767,7 +767,7 @@ var _ = Describe("Processor", Ordered, func() {
 						}, createMessagePayload,
 					),
 					EventCount:    2,
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    createBatchParameters(SourceIDEnabledNoUT),
 				},
 				{
@@ -778,7 +778,7 @@ var _ = Describe("Processor", Ordered, func() {
 					CustomVal:     gatewayCustomVal[0],
 					EventPayload:  nil,
 					EventCount:    1,
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    nil,
 				},
 				{
@@ -789,7 +789,7 @@ var _ = Describe("Processor", Ordered, func() {
 					CustomVal:     gatewayCustomVal[0],
 					EventPayload:  nil,
 					EventCount:    1,
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    nil,
 				},
 				{
@@ -945,7 +945,7 @@ var _ = Describe("Processor", Ordered, func() {
 					CustomVal:     gatewayCustomVal[0],
 					EventPayload:  nil,
 					EventCount:    1,
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    nil,
 				},
 				{
@@ -964,7 +964,7 @@ var _ = Describe("Processor", Ordered, func() {
 						createMessagePayload,
 					),
 					EventCount:    1,
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    createBatchParameters(SourceIDEnabledOnlyUT),
 				},
 				{
@@ -1141,7 +1141,7 @@ var _ = Describe("Processor", Ordered, func() {
 						createMessagePayloadWithSameMessageId,
 					),
 					EventCount:    2,
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    createBatchParameters(SourceIDEnabled),
 				},
 				{
@@ -1238,7 +1238,7 @@ var _ = Describe("Processor", Ordered, func() {
 						},
 						createMessagePayload,
 					),
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    createBatchParameters(SourceIDEnabled),
 				},
 			}
@@ -1376,7 +1376,7 @@ var _ = Describe("Processor", Ordered, func() {
 						},
 						createMessagePayload,
 					),
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    createBatchParameters(SourceIDEnabled),
 				},
 			}
@@ -1504,7 +1504,7 @@ var _ = Describe("Processor", Ordered, func() {
 					ExpireAt:      time.Date(2020, 0o4, 28, 23, 26, 0o0, 0o0, time.UTC),
 					CustomVal:     gatewayCustomVal[0],
 					EventPayload:  payload,
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    createBatchParameters(SourceIDEnabledNoUT2),
 				},
 			}
@@ -2874,7 +2874,7 @@ func createBatchParameters(sourceId string) []byte {
 }
 
 func assertJobStatus(job *jobsdb.JobT, status *jobsdb.JobStatusT, expectedState string) {
-	Expect(status.JobID).To(Equal(job.JobID))
+	Expect(status.Job.JobID).To(Equal(job.JobID))
 	Expect(status.JobState).To(Equal(expectedState))
 	Expect(status.RetryTime).To(BeTemporally("~", time.Now(), 200*time.Millisecond))
 	Expect(status.ExecTime).To(BeTemporally("~", time.Now(), 200*time.Millisecond))

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -3206,10 +3206,10 @@ var _ = Describe("TestSubJobMerger", func() {
 	expectedMergedJob := storeMessage{
 		statusList: []*jobsdb.JobStatusT{
 			{
-				JobID: 1,
+				Job: &jobsdb.JobT{JobID: 1},
 			},
 			{
-				JobID: 2,
+				Job: &jobsdb.JobT{JobID: 2},
 			},
 		},
 		destJobs: []*jobsdb.JobT{
@@ -3266,7 +3266,7 @@ var _ = Describe("TestSubJobMerger", func() {
 				{
 					statusList: []*jobsdb.JobStatusT{
 						{
-							JobID: 1,
+							Job: &jobsdb.JobT{JobID: 1},
 						},
 					},
 					destJobs: []*jobsdb.JobT{
@@ -3306,7 +3306,7 @@ var _ = Describe("TestSubJobMerger", func() {
 				{
 					statusList: []*jobsdb.JobStatusT{
 						{
-							JobID: 2,
+							Job: &jobsdb.JobT{JobID: 2},
 						},
 					},
 					destJobs: []*jobsdb.JobT{
@@ -3368,10 +3368,10 @@ var _ = Describe("TestSubJobMerger", func() {
 				{
 					statusList: []*jobsdb.JobStatusT{
 						{
-							JobID: 1,
+							Job: &jobsdb.JobT{JobID: 1},
 						},
 						{
-							JobID: 2,
+							Job: &jobsdb.JobT{JobID: 2},
 						},
 					},
 					destJobs: []*jobsdb.JobT{

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -496,7 +496,7 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 					CustomVal:     gatewayCustomVal[0],
 					EventPayload:  nil,
 					EventCount:    1,
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    nil,
 				},
 				{
@@ -515,7 +515,7 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 						createMessagePayloadWithoutSources,
 					),
 					EventCount:    2,
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    createBatchParameters(SourceIDEnabledNoUT),
 				},
 				{
@@ -526,7 +526,7 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 					CustomVal:     gatewayCustomVal[0],
 					EventPayload:  nil,
 					EventCount:    1,
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    nil,
 				},
 				{
@@ -537,7 +537,7 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 					CustomVal:     gatewayCustomVal[0],
 					EventPayload:  nil,
 					EventCount:    1,
-					LastJobStatus: jobsdb.JobStatusT{},
+					LastJobStatus: jobsdb.LastStateT{},
 					Parameters:    nil,
 				},
 				{

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -277,7 +277,7 @@ func (st *HandleT) setErrJobStatus(jobs []*jobsdb.JobT, output StoreErrorOutputT
 			}
 		}
 		status := jobsdb.JobStatusT{
-			JobID:         job.JobID,
+			Job:           job,
 			AttemptNum:    job.LastJobStatus.AttemptNum + 1,
 			JobState:      state,
 			ExecTime:      time.Now(),
@@ -374,7 +374,7 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 			for _, job := range combinedList {
 
 				status := jobsdb.JobStatusT{
-					JobID:         job.JobID,
+					Job:           job,
 					AttemptNum:    job.LastJobStatus.AttemptNum + 1,
 					JobState:      jobState,
 					ExecTime:      time.Now(),

--- a/router/batchrouter/batchrouter.go
+++ b/router/batchrouter/batchrouter.go
@@ -378,7 +378,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 								if !asyncResponse.HasFailed {
 									for _, job := range importingList {
 										status := jobsdb.JobStatusT{
-											JobID:         job.JobID,
+											Job:           job,
 											JobState:      jobsdb.Succeeded.State,
 											ExecTime:      time.Now(),
 											RetryTime:     time.Now(),
@@ -424,9 +424,8 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 									var status *jobsdb.JobStatusT
 									if errFailed != nil || errWarning != nil || errSuccess != nil || statusCode != 200 {
 										for _, job := range importingList {
-											jobID := job.JobID
 											status = &jobsdb.JobStatusT{
-												JobID:         jobID,
+												Job:           job,
 												JobState:      jobsdb.Failed.State,
 												ExecTime:      time.Now(),
 												RetryTime:     time.Now(),
@@ -459,7 +458,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 										jobID := job.JobID
 										if slices.Contains(append(succeededKeys, warningKeys...), jobID) {
 											status = &jobsdb.JobStatusT{
-												JobID:         jobID,
+												Job:           job,
 												JobState:      jobsdb.Succeeded.State,
 												ExecTime:      time.Now(),
 												RetryTime:     time.Now(),
@@ -472,7 +471,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 										} else if slices.Contains(failedKeys, job.JobID) {
 											errorResp, _ := json.Marshal(ErrorResponseT{Error: gjson.GetBytes(failedBodyBytes, fmt.Sprintf("metadata.failedReasons.%v", job.JobID)).String()})
 											status = &jobsdb.JobStatusT{
-												JobID:         jobID,
+												Job:           job,
 												JobState:      jobsdb.Aborted.State,
 												ExecTime:      time.Now(),
 												RetryTime:     time.Now(),
@@ -534,7 +533,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 								if isJobTerminated(statusCode) {
 									for _, job := range importingList {
 										status := jobsdb.JobStatusT{
-											JobID:         job.JobID,
+											Job:           job,
 											JobState:      jobsdb.Aborted.State,
 											ExecTime:      time.Now(),
 											RetryTime:     time.Now(),
@@ -551,7 +550,7 @@ func (brt *HandleT) pollAsyncStatus(ctx context.Context) {
 								} else {
 									for _, job := range importingList {
 										status := jobsdb.JobStatusT{
-											JobID:         job.JobID,
+											Job:           job,
 											JobState:      jobsdb.Failed.State,
 											ExecTime:      time.Now(),
 											RetryTime:     time.Now(),
@@ -1232,7 +1231,7 @@ func (brt *HandleT) setJobStatus(batchJobs *BatchJobsT, isWarehouse bool, errOcc
 		}
 		attemptNum := job.LastJobStatus.AttemptNum + 1
 		status := jobsdb.JobStatusT{
-			JobID:         job.JobID,
+			Job:           job,
 			AttemptNum:    attemptNum,
 			JobState:      jobState,
 			ExecTime:      time.Now(),
@@ -1394,7 +1393,7 @@ func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.Asy
 	if len(asyncOutput.ImportingJobIDs) > 0 {
 		for _, jobId := range asyncOutput.ImportingJobIDs {
 			status := jobsdb.JobStatusT{
-				JobID:         jobId,
+				Job:           job,
 				JobState:      jobsdb.Importing.State,
 				ExecTime:      time.Now(),
 				RetryTime:     time.Now(),
@@ -1410,7 +1409,7 @@ func (brt *HandleT) setMultipleJobStatus(asyncOutput asyncdestinationmanager.Asy
 	if len(asyncOutput.SucceededJobIDs) > 0 {
 		for _, jobId := range asyncOutput.FailedJobIDs {
 			status := jobsdb.JobStatusT{
-				JobID:         jobId,
+				Job:           job,
 				JobState:      jobsdb.Succeeded.State,
 				ExecTime:      time.Now(),
 				RetryTime:     time.Now(),

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -211,7 +211,7 @@ var _ = Describe("BatchRouter", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    CustomVal["S3"],
 					EventPayload: []byte(s3Payload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum:    1,
 						ErrorResponse: []byte(`{"firstAttemptedAt": "2021-06-28T15:57:30.742+05:30"}`),
 					},
@@ -228,7 +228,7 @@ var _ = Describe("BatchRouter", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    CustomVal["S3"],
 					EventPayload: []byte(s3Payload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -265,7 +265,7 @@ var _ = Describe("BatchRouter", func() {
 })
 
 func assertJobStatus(job *jobsdb.JobT, status *jobsdb.JobStatusT, expectedState, errorResponse string, attemptNum int) {
-	Expect(status.JobID).To(Equal(job.JobID))
+	Expect(status.Job.JobID).To(Equal(job.JobID))
 	Expect(status.JobState).To(Equal(expectedState))
 	if attemptNum > 1 {
 		Expect(status.ErrorResponse).To(MatchJSON(errorResponse))

--- a/router/internal/jobiterator/jobiterator_test.go
+++ b/router/internal/jobiterator/jobiterator_test.go
@@ -295,8 +295,8 @@ func TestJobIterator(t *testing.T) {
 		it := New(initialPickup, jobsdb.GetQueryParamsT{}, m.GetJobs, WithLegacyOrderGroupKey(true))
 		// first batch will return 2 jobs from workspace A
 		m.jobs = []*jobsdb.JobT{
-			{JobID: 1, WorkspaceId: "A", LastJobStatus: jobsdb.JobStatusT{}},
-			{JobID: 3, WorkspaceId: "A", LastJobStatus: jobsdb.JobStatusT{JobState: jobsdb.Waiting.State}},
+			{JobID: 1, WorkspaceId: "A", LastJobStatus: jobsdb.LastStateT{}},
+			{JobID: 3, WorkspaceId: "A", LastJobStatus: jobsdb.LastStateT{JobState: jobsdb.Waiting.State}},
 		}
 
 		m.expectedParams = &jobsdb.GetQueryParamsT{JobsLimit: 5}
@@ -306,7 +306,7 @@ func TestJobIterator(t *testing.T) {
 
 		// 2nd batch should return 1 job from workspace A, but it's out of order
 		m.jobs = []*jobsdb.JobT{
-			{JobID: 2, WorkspaceId: "A", LastJobStatus: jobsdb.JobStatusT{JobState: jobsdb.Waiting.State}},
+			{JobID: 2, WorkspaceId: "A", LastJobStatus: jobsdb.LastStateT{JobState: jobsdb.Waiting.State}},
 		}
 
 		discardedJobID := int64(3)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -179,7 +179,7 @@ func TestBackoff(t *testing.T) {
 		backoffJob := &jobsdb.JobT{
 			JobID:      1,
 			Parameters: []byte(`{"destination_id": "destination"}`),
-			LastJobStatus: jobsdb.JobStatusT{
+			LastJobStatus: jobsdb.LastStateT{
 				JobState:   jobsdb.Failed.State,
 				AttemptNum: 1,
 				RetryTime:  time.Now().Add(1 * time.Hour),
@@ -188,7 +188,7 @@ func TestBackoff(t *testing.T) {
 		noBackoffJob1 := &jobsdb.JobT{
 			JobID:      2,
 			Parameters: []byte(`{"destination_id": "destination"}`),
-			LastJobStatus: jobsdb.JobStatusT{
+			LastJobStatus: jobsdb.LastStateT{
 				JobState:   jobsdb.Waiting.State,
 				AttemptNum: 1,
 				RetryTime:  time.Now().Add(1 * time.Hour),
@@ -197,7 +197,7 @@ func TestBackoff(t *testing.T) {
 		noBackoffJob2 := &jobsdb.JobT{
 			JobID:      3,
 			Parameters: []byte(`{"destination_id": "destination"}`),
-			LastJobStatus: jobsdb.JobStatusT{
+			LastJobStatus: jobsdb.LastStateT{
 				JobState:   jobsdb.Failed.State,
 				AttemptNum: 0,
 				RetryTime:  time.Now().Add(1 * time.Hour),
@@ -206,7 +206,7 @@ func TestBackoff(t *testing.T) {
 		noBackoffJob3 := &jobsdb.JobT{
 			JobID:      4,
 			Parameters: []byte(`{"destination_id": "destination"}`),
-			LastJobStatus: jobsdb.JobStatusT{
+			LastJobStatus: jobsdb.LastStateT{
 				JobState:   jobsdb.Failed.State,
 				AttemptNum: 0,
 				RetryTime:  time.Now().Add(-1 * time.Hour),
@@ -297,7 +297,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum:    1,
 						ErrorResponse: []byte(`{"firstAttemptedAt": "2021-06-28T15:57:30.742+05:30"}`),
 					},
@@ -315,7 +315,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters:  []byte(parameters),
@@ -390,7 +390,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters:  []byte(parameters),
@@ -476,7 +476,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters:  []byte(parameters),
@@ -559,10 +559,10 @@ var _ = Describe("Router", func() {
 					ExpireAt:     firstAttemptedAt.Add(-time.Minute),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(`{"body": {"XML": {}, "FORM": {}, "JSON": {}}, "type": "REST", "files": {}, "method": "POST", "params": {"t": "event", "v": "1", "an": "RudderAndroidClient", "av": "1.0", "ds": "android-sdk", "ea": "Demo Track", "ec": "Demo Category", "el": "Demo Label", "ni": 0, "qt": 59268380964, "ul": "en-US", "cid": "anon_id", "tid": "UA-185645846-1", "uip": "[::1]", "aiid": "com.rudderlabs.android.sdk"}, "userId": "anon_id", "headers": {}, "version": "1", "endpoint": "https://www.google-analytics.com/collect"}`),
-					LastJobStatus: jobsdb.JobStatusT{
-						AttemptNum:    router.maxFailedCountForJob,
-						JobState:      jobsdb.Failed.State,
-						ErrorCode:     "500",
+					LastJobStatus: jobsdb.LastStateT{
+						AttemptNum: router.maxFailedCountForJob,
+						JobState:   jobsdb.Failed.State,
+						// ErrorCode:     "500",
 						ErrorResponse: []byte(fmt.Sprintf(`{"firstAttemptedAt": %q}`, firstAttemptedAt.Format(misc.RFC3339Milli))),
 					},
 					Parameters: []byte(fmt.Sprintf(`{
@@ -656,7 +656,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum:    1,
 						ErrorResponse: []byte(`{"firstAttemptedAt": "2021-06-28T15:57:30.742+05:30"}`),
 					},
@@ -673,7 +673,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -686,7 +686,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -699,7 +699,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -712,7 +712,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -783,7 +783,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 3, // done only to check the error response assertion(assertJobStatus) as well
 					},
 					Parameters: []byte(parameters),
@@ -893,7 +893,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum:    1,
 						ErrorResponse: []byte(`{"firstAttemptedAt": "2021-06-28T15:57:30.742+05:30"}`),
 					},
@@ -910,7 +910,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -923,7 +923,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 27, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -1037,7 +1037,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum:    1,
 						ErrorResponse: []byte(`{"firstAttemptedAt": "2021-06-28T15:57:30.742+05:30"}`),
 					},
@@ -1053,7 +1053,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -1066,7 +1066,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 27, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -1206,7 +1206,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum:    1,
 						ErrorResponse: []byte(`{"firstAttemptedAt": "2021-06-28T15:57:30.742+05:30"}`),
 					},
@@ -1223,7 +1223,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -1236,7 +1236,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -1249,7 +1249,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -1262,7 +1262,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -1422,7 +1422,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum:    1,
 						ErrorResponse: []byte(`{"firstAttemptedAt": "2021-06-28T15:57:30.742+05:30"}`),
 					},
@@ -1439,7 +1439,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -1452,7 +1452,7 @@ var _ = Describe("Router", func() {
 					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
 					CustomVal:    customVal["GA"],
 					EventPayload: []byte(gaPayload),
-					LastJobStatus: jobsdb.JobStatusT{
+					LastJobStatus: jobsdb.LastStateT{
 						AttemptNum: 0,
 					},
 					Parameters: []byte(parameters),
@@ -1550,7 +1550,7 @@ func assertRouterJobs(routerJob *types.RouterJobT, job *jobsdb.JobT) {
 }
 
 func assertJobStatus(job *jobsdb.JobT, status *jobsdb.JobStatusT, expectedState, errorCode, errorResponse string, attemptNum int) {
-	Expect(status.JobID).To(Equal(job.JobID))
+	Expect(status.Job.JobID).To(Equal(job.JobID))
 	Expect(status.JobState).To(Equal(expectedState))
 	Expect(status.ErrorCode).To(Equal(errorCode))
 	if attemptNum >= 1 {
@@ -1564,7 +1564,7 @@ func assertJobStatus(job *jobsdb.JobT, status *jobsdb.JobStatusT, expectedState,
 }
 
 func assertTransformJobStatuses(job *jobsdb.JobT, status *jobsdb.JobStatusT, expectedState, errorCode string, attemptNum int) {
-	Expect(status.JobID).To(Equal(job.JobID))
+	Expect(status.Job.JobID).To(Equal(job.JobID))
 	Expect(status.JobState).To(Equal(expectedState))
 	Expect(status.ErrorCode).To(Equal(errorCode))
 	Expect(status.ExecTime).To(BeTemporally("~", time.Now(), 10*time.Second))

--- a/schema-forwarder/internal/forwarder/abortingforwarder.go
+++ b/schema-forwarder/internal/forwarder/abortingforwarder.go
@@ -49,7 +49,7 @@ func (nf *AbortingForwarder) Start() error {
 				var statusList []*jobsdb.JobStatusT
 				for _, job := range jobList {
 					statusList = append(statusList, &jobsdb.JobStatusT{
-						JobID:         job.JobID,
+						Job:           job,
 						JobState:      jobsdb.Aborted.State,
 						AttemptNum:    0,
 						ExecTime:      time.Now(),

--- a/schema-forwarder/internal/forwarder/baseforwarder_test.go
+++ b/schema-forwarder/internal/forwarder/baseforwarder_test.go
@@ -116,7 +116,7 @@ func TestBaseForwarder_MarkJobStautses(t *testing.T) {
 	var statuses []*jobsdb.JobStatusT
 	for _, job := range jobs {
 		statuses = append(statuses, &jobsdb.JobStatusT{
-			JobID:         job.JobID,
+			Job:           job,
 			JobState:      jobsdb.Succeeded.State,
 			AttemptNum:    1,
 			ExecTime:      time.Now(),

--- a/schema-forwarder/internal/forwarder/jobsforwarder.go
+++ b/schema-forwarder/internal/forwarder/jobsforwarder.go
@@ -116,7 +116,7 @@ func (jf *JobsForwarder) Start() error {
 							mu.Lock()
 							jobDone(job)
 							statuses = append(statuses, &jobsdb.JobStatusT{
-								JobID:         job.JobID,
+								Job:           job,
 								AttemptNum:    job.LastJobStatus.AttemptNum + 1,
 								JobState:      jobsdb.Aborted.State,
 								ExecTime:      time.Now(),
@@ -142,7 +142,7 @@ func (jf *JobsForwarder) Start() error {
 									defer mu.Unlock()
 									jobDone(job)
 									statuses = append(statuses, &jobsdb.JobStatusT{
-										JobID:         job.JobID,
+										Job:           job,
 										AttemptNum:    job.LastJobStatus.AttemptNum + 1,
 										JobState:      jobsdb.Succeeded.State,
 										ExecTime:      time.Now(),
@@ -172,7 +172,7 @@ func (jf *JobsForwarder) Start() error {
 				if err = backoff.Retry(tryForwardJobs, backoff.WithContext(expB, ctx)); err != nil {
 					for _, job := range toRetry { // mark all to retry jobs as aborted
 						statuses = append(statuses, &jobsdb.JobStatusT{
-							JobID:         job.JobID,
+							Job:           job,
 							AttemptNum:    job.LastJobStatus.AttemptNum + 1,
 							JobState:      jobsdb.Aborted.State,
 							ExecTime:      time.Now(),

--- a/schema-forwarder/internal/transformer/transformer_test.go
+++ b/schema-forwarder/internal/transformer/transformer_test.go
@@ -151,7 +151,7 @@ func generateTestJob(t *testing.T, time time.Time) *jobsdb.JobT {
 		CustomVal:     "event-schema",
 		EventCount:    1,
 		PayloadSize:   100,
-		LastJobStatus: jobsdb.JobStatusT{},
+		LastJobStatus: jobsdb.LastStateT{},
 		WorkspaceId:   testdata.SampleWorkspaceID,
 		Parameters:    []byte(`{"source_id": "enabled-source"}`),
 	}

--- a/services/rsources/stats_collector.go
+++ b/services/rsources/stats_collector.go
@@ -121,7 +121,7 @@ func (r *statsCollector) JobsFailed(jobs []*jobsdb.JobT) {
 	jobStatuses := make([]*jobsdb.JobStatusT, 0, len(jobs))
 	for i := range jobs {
 		jobStatuses = append(jobStatuses, &jobsdb.JobStatusT{
-			JobID:    jobs[i].JobID,
+			Job:      jobs[i],
 			JobState: jobsdb.Aborted.State,
 		})
 	}
@@ -146,7 +146,7 @@ func (r *statsCollector) JobStatusesUpdated(jobStatuses []*jobsdb.JobStatusT) {
 	}
 	for i := range jobStatuses {
 		jobStatus := jobStatuses[i]
-		if statKey, statKeyOk := r.jobIdsToStatKeyIndex[jobStatus.JobID]; statKeyOk {
+		if statKey, statKeyOk := r.jobIdsToStatKeyIndex[jobStatus.Job.JobID]; statKeyOk {
 			stats, ok := r.statsIndex[statKey]
 			if ok {
 				switch jobStatus.JobState {
@@ -154,7 +154,7 @@ func (r *statsCollector) JobStatusesUpdated(jobStatuses []*jobsdb.JobStatusT) {
 					stats.Out++
 				case jobsdb.Aborted.State:
 					stats.Failed++
-					recordId := r.jobIdsToRecordIdIndex[jobStatus.JobID]
+					recordId := r.jobIdsToRecordIdIndex[jobStatus.Job.JobID]
 					if len(recordId) > 0 {
 						r.failedRecordsIndex[statKey] = append(r.failedRecordsIndex[statKey], recordId)
 					}

--- a/services/rsources/stats_collector_test.go
+++ b/services/rsources/stats_collector_test.go
@@ -303,7 +303,7 @@ var _ = Describe("Using StatsCollector", Serial, func() {
 								}).
 							Times(1)
 
-						failedRecords := []json.RawMessage{}
+						var failedRecords []json.RawMessage
 						for i := 0; i < len(jobs)/2; i++ {
 							failedRecords = append(failedRecords, []byte(`"recordId"`))
 						}
@@ -361,7 +361,7 @@ var _ = Describe("Using StatsCollector", Serial, func() {
 						}).
 					Times(1)
 
-				failedRecords := []json.RawMessage{}
+				var failedRecords []json.RawMessage
 				for i := 0; i < len(jobs); i++ {
 					failedRecords = append(failedRecords, []byte(`"recordId"`))
 				}

--- a/services/rsources/stats_collector_test.go
+++ b/services/rsources/stats_collector_test.go
@@ -466,21 +466,21 @@ func newJob(id int64, params jobParams) *jobsdb.JobT { // skipcq: CRT-P0003
 
 func newSucceededStatus(jobId int64) *jobsdb.JobStatusT {
 	return &jobsdb.JobStatusT{
-		JobID:    jobId,
+		Job:      &jobsdb.JobT{JobID: jobId},
 		JobState: jobsdb.Succeeded.State,
 	}
 }
 
 func newFailedStatus(jobId int64) *jobsdb.JobStatusT {
 	return &jobsdb.JobStatusT{
-		JobID:    jobId,
+		Job:      &jobsdb.JobT{JobID: jobId},
 		JobState: jobsdb.Failed.State,
 	}
 }
 
 func newAbortedStatus(jobId int64) *jobsdb.JobStatusT {
 	return &jobsdb.JobStatusT{
-		JobID:    jobId,
+		Job:      &jobsdb.JobT{JobID: jobId},
 		JobState: jobsdb.Aborted.State,
 	}
 }


### PR DESCRIPTION
# Description

using a pending-event gauge per DS in place of a cache map like we have now.
lookup key(`cacheSubject`) is of the form `tablePrefix.dsIndex.workspaceID.customVal.sourceID.destinationID.jobState`, and is composed of `composite`s separated by `.`.
Any of them could be a wildcard(`*`), **except** for the `tablePrefix`.

Every `store` call to the jobsdb increments counters for the `power-set` of given job's subjects.
`power-set` of a particular subject is the set of all subjects where none or more(except `tablePrefix`) composites can be replaced by a wildcard.
Eg of a powerset:
```
subject = "rt.1.ws1.GA.src1.dest1.not_picked_yet" -> a new job is stored with said connection
then
superset = []cacheSubject{
"rt.1.ws1.GA.src1.dest1.not_picked_yet",
"rt.1.ws1.GA.src1.dest1.*",
"rt.1.ws1.GA.src1.*.not_picked_yet"}....
.
.
"rt.1.*.*.*.*.*",
"rt.*.*.*.*.*.*",
}
```
Similarly, every update status call(`jobState1` -> `jobState2`) also increments counter for `jobState2`, and also decrements counter for `jobState1`.

To make sure that during job insert/status update, the counters are updated for subjects with all composites present(no wildcard - except at gateway where destinationID is null), things have been moved around(`JobID` in `JobStatusT` replaced by `JobT`). Also done to avoid router having to send parameter filters along with the update status call etc.

If counter returns 0 value, need not query the database. No need to take care of setting/update and set before and after querying for jobs.

In case of gw-proc setup: 
1. the gw(writer jobsdb) creates a `trigger after insert` on the jobs table which notify the counts inserted grouped by custom_val, workspace, source, destination(although this is null at the gateway).
2. the processor listens on said notify channel for the counts to increment its own counter(which could further be used as a cache by the processor while querying gateway tables).
```
One pitfall right now is if there's multiple concurrent notifications, 
how does processor deal with them?
Does it end up losing them? 
In which case the processor would fail to query the database(which has to be avoided at any cost).

Update: Apparently they're buffered.
```

Pending: 
1. counters during/after external migrations and tests.
2. leveraging counters to check if it's time to compact/migrate a `DataSetT`.

## Notion Ticket

[jobsdb cache improvement](https://www.notion.so/rudderstacks/Jobsdb-cache-improvement-da6b86ed57684128b4bd0cd575e44b27?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
