### PR TITLE
fix: add mandatory env for shopify oss

### DIFF
--- a/rudder-docker.yml
+++ b/rudder-docker.yml
@@ -28,7 +28,8 @@ services:
       - CONFIG_BACKEND_URL=https://api.rudderstack.com
       - WORKSPACE_TOKEN=<your_workspace_token> # Must be written without quotes e.g. WORKSPACE_TOKEN=20TokEO34NWitou2t3quO8teS7
       - STATSD_SERVER_URL=metrics-exporter:9125
-      - RSERVER_GATEWAY_WEBHOOK_SOURCE_LIST_FOR_PARSING_PARAMS=Shopify
+      # DO NOT REMOVE - Mandatory env for Shopify
+      - RSERVER_GATEWAY_WEBHOOK_SOURCE_LIST_FOR_PARSING_PARAMS=Shopify 
       # - RSERVER_BACKEND_CONFIG_CONFIG_FROM_FILE=true
       # - RSERVER_BACKEND_CONFIG_CONFIG_JSONPATH=<workspace_config_filepath_in_container> # For ex., /etc/rudderstack/workspaceConfig.json
     # Uncomment the following lines to mount workspaceConfig file


### PR DESCRIPTION
# Description

We recently had an open source user who was facing issues in running Shopify in their OSS deployment. On debugging, we found that an env that we set automatically in our deployments, was not done for in case of OSS users, leading to failure in Shopify Cloud mode.

`WEBHOOK_SOURCE_LIST_FOR_PARSING_PARAMS` is needed for parsing shopify webhook subscription topics which was missing when an OSS user would set up their server deployment using docker compose.

## Notion Ticket

https://www.notion.so/rudderstacks/Add-mandatory-env-in-Shopify-for-OSS-users-in-server-and-helm-4fd94abba82f4dd5b55774a357f7d181?pvs=4

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
