### PR TITLE
fix: update lo to slices in eventfilter package

### DIFF
--- a/processor/eventfilter/eventfilter.go
+++ b/processor/eventfilter/eventfilter.go
@@ -8,7 +8,6 @@ import (
 	"github.com/rudderlabs/rudder-server/processor/transformer"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/types"
-	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
 )
 
@@ -137,7 +136,7 @@ func AllowEventToDestTransformation(transformerEvent *transformer.TransformerEve
 		return false, resp
 	}
 
-	isSupportedMsgType := lo.Contains(supportedMsgTypes, messageType)
+	isSupportedMsgType := slices.Contains(supportedMsgTypes, messageType)
 	if !isSupportedMsgType {
 		pkgLogger.Debug("event filtered out due to unsupported msg types")
 		// We will not allow the event


### PR DESCRIPTION
# Description

We want to maintain convention of using `slices` over `lo` package across the repository

## Notion Ticket

https://www.notion.so/rudderstacks/GA4-page-calls-error-is-displaying-in-live-events-tab-for-hybrid-mode-connection-52c58ee1924941f1b037fb8f63fc2445?pvs=4


## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
