### PR TITLE
fix: add numeric scale precision to snowflake

### DIFF
--- a/warehouse/integrations/snowflake/datatype_mapper.go
+++ b/warehouse/integrations/snowflake/datatype_mapper.go
@@ -1,0 +1,55 @@
+package snowflake
+
+import "database/sql"
+
+var dataTypesMap = map[string]string{
+	"boolean":  "boolean",
+	"int":      "number",
+	"bigint":   "number",
+	"float":    "double precision",
+	"string":   "varchar",
+	"datetime": "timestamp_tz",
+	"json":     "variant",
+}
+
+var dataTypesMapToRudder = map[string]string{
+	"NUMBER":           "int",
+	"DECIMAL":          "int",
+	"NUMERIC":          "int",
+	"INT":              "int",
+	"INTEGER":          "int",
+	"BIGINT":           "int",
+	"SMALLINT":         "int",
+	"FLOAT":            "float",
+	"FLOAT4":           "float",
+	"FLOAT8":           "float",
+	"DOUBLE":           "float",
+	"REAL":             "float",
+	"DOUBLE PRECISION": "float",
+	"BOOLEAN":          "boolean",
+	"TEXT":             "string",
+	"VARCHAR":          "string",
+	"CHAR":             "string",
+	"CHARACTER":        "string",
+	"STRING":           "string",
+	"BINARY":           "string",
+	"VARBINARY":        "string",
+	"TIMESTAMP_NTZ":    "datetime",
+	"DATE":             "datetime",
+	"DATETIME":         "datetime",
+	"TIME":             "datetime",
+	"TIMESTAMP":        "datetime",
+	"TIMESTAMP_LTZ":    "datetime",
+	"TIMESTAMP_TZ":     "datetime",
+	"VARIANT":          "json",
+}
+
+func calculateDataType(columnType string, numericScale sql.NullInt64) (string, bool) {
+	if datatype, ok := dataTypesMapToRudder[columnType]; ok {
+		if datatype == "int" && numericScale.Valid && numericScale.Int64 > 0 {
+			datatype = "float"
+		}
+		return datatype, true
+	}
+	return "", false
+}

--- a/warehouse/integrations/snowflake/datatype_mapper_test.go
+++ b/warehouse/integrations/snowflake/datatype_mapper_test.go
@@ -2,8 +2,9 @@ package snowflake
 
 import (
 	"database/sql"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCalculateDataType(t *testing.T) {

--- a/warehouse/integrations/snowflake/datatype_mapper_test.go
+++ b/warehouse/integrations/snowflake/datatype_mapper_test.go
@@ -1,0 +1,27 @@
+package snowflake
+
+import (
+	"database/sql"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCalculateDataType(t *testing.T) {
+	testCases := []struct {
+		columnType   string
+		numericScale sql.NullInt64
+		expected     string
+		exists       bool
+	}{
+		{"VARCHAR", sql.NullInt64{}, "string", true},
+		{"INT", sql.NullInt64{}, "int", true},
+		{"INT", sql.NullInt64{Int64: 2, Valid: true}, "float", true},
+		{"UNKNOWN", sql.NullInt64{}, "", false},
+	}
+
+	for _, tc := range testCases {
+		dataType, exists := calculateDataType(tc.columnType, tc.numericScale)
+		require.Equal(t, tc.expected, dataType)
+		require.Equal(t, tc.exists, exists)
+	}
+}

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -43,48 +43,6 @@ const (
 	Application        = "Rudderstack_Warehouse"
 )
 
-var dataTypesMap = map[string]string{
-	"boolean":  "boolean",
-	"int":      "number",
-	"bigint":   "number",
-	"float":    "double precision",
-	"string":   "varchar",
-	"datetime": "timestamp_tz",
-	"json":     "variant",
-}
-
-var dataTypesMapToRudder = map[string]string{
-	"NUMBER":           "int",
-	"DECIMAL":          "int",
-	"NUMERIC":          "int",
-	"INT":              "int",
-	"INTEGER":          "int",
-	"BIGINT":           "int",
-	"SMALLINT":         "int",
-	"FLOAT":            "float",
-	"FLOAT4":           "float",
-	"FLOAT8":           "float",
-	"DOUBLE":           "float",
-	"REAL":             "float",
-	"DOUBLE PRECISION": "float",
-	"BOOLEAN":          "boolean",
-	"TEXT":             "string",
-	"VARCHAR":          "string",
-	"CHAR":             "string",
-	"CHARACTER":        "string",
-	"STRING":           "string",
-	"BINARY":           "string",
-	"VARBINARY":        "string",
-	"TIMESTAMP_NTZ":    "datetime",
-	"DATE":             "datetime",
-	"DATETIME":         "datetime",
-	"TIME":             "datetime",
-	"TIMESTAMP":        "datetime",
-	"TIMESTAMP_LTZ":    "datetime",
-	"TIMESTAMP_TZ":     "datetime",
-	"VARIANT":          "json",
-}
-
 var primaryKeyMap = map[string]string{
 	usersTable:      "ID",
 	identifiesTable: "ID",
@@ -1340,16 +1298,6 @@ func (sf *Snowflake) FetchSchema(model.Warehouse) (model.Schema, model.Schema, e
 	}
 
 	return schema, unrecognizedSchema, nil
-}
-
-func calculateDataType(columnType string, numericScale sql.NullInt64) (string, bool) {
-	if datatype, ok := dataTypesMapToRudder[columnType]; ok {
-		if datatype == "int" && numericScale.Valid && numericScale.Int64 > 0 {
-			datatype = "float"
-		}
-		return datatype, true
-	}
-	return "", false
 }
 
 func (sf *Snowflake) Cleanup() {


### PR DESCRIPTION
# Description

When mapping the Snowflake numeric datatype with the Rudder datatype, it is recommended to include the scale information, as Snowflake supports scales. This can help map the Snowflake numeric datatype with the float datatype in Rudder, instead of the integer datatype.

https://docs.snowflake.com/en/sql-reference/data-types-numeric#number

## Notion Ticket

https://www.notion.so/rudderstacks/Add-precision-support-for-numeric-type-in-snowflake-724401dbf9d54314a36589d8d5445a96?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
