### PR TITLE
feat(router): limit number of jobs with the same ordering key in worker's queue

### DIFF
--- a/router/eventorder_test.go
+++ b/router/eventorder_test.go
@@ -258,7 +258,7 @@ func TestEventOrderGuarantee(t *testing.T) {
 					t.Logf("%d/%d done (%d drained)", done, total, drained)
 				}
 				return done == total
-			}, 300*time.Second, 2*time.Second, "webhook should receive all events and process them till the end")
+			}, 360*time.Second, 2*time.Second, "webhook should receive all events and process them till the end")
 
 			require.False(t, t.Failed(), "webhook shouldn't have failed")
 

--- a/router/internal/eventorder/eventorder.go
+++ b/router/internal/eventorder/eventorder.go
@@ -72,8 +72,8 @@ type Barrier struct {
 // returns true, otherwise false along with the previous failed jobID if this is the cause of the barrier.
 // Another scenario where a barrier might exist for a key is when the previous job has failed in an unrecoverable manner and the concurrency limiter is enabled.
 func (b *Barrier) Enter(key string, jobID int64) (accepted bool, previousFailedJobID *int64) {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	barrier, ok := b.barriers[key]
 	if !ok {
 		if b.concurrencyLimit == 0 { // if not concurrency limit is set accept the job

--- a/router/router.go
+++ b/router/router.go
@@ -78,39 +78,42 @@ type DiagnosticT struct {
 
 // HandleT is the handle to this module.
 type HandleT struct {
-	responseQ                               chan jobResponseT
-	jobsDB                                  jobsdb.MultiTenantJobsDB
-	errorDB                                 jobsdb.JobsDB
-	netHandle                               NetHandleI
-	MultitenantI                            tenantStats
-	destName                                string
-	destinationId                           string
-	workers                                 []*worker
-	telemetry                               *DiagnosticT
-	customDestinationManager                customDestinationManager.DestinationManager
-	throttlingCosts                         atomic.Pointer[types.EventTypeThrottlingCost]
-	throttlerFactory                        *rtThrottler.Factory
-	guaranteeUserEventOrder                 bool
-	netClientTimeout                        time.Duration
-	backendProxyTimeout                     time.Duration
-	jobsDBCommandTimeout                    time.Duration
-	jobdDBMaxRetries                        int
-	enableBatching                          bool
-	transformer                             transformer.Transformer
-	configSubscriberLock                    sync.RWMutex
-	destinationsMap                         map[string]*routerutils.BatchDestinationT // destinationID -> destination
-	logger                                  logger.Logger
-	batchInputCountStat                     stats.Measurement
-	batchOutputCountStat                    stats.Measurement
-	routerTransformInputCountStat           stats.Measurement
-	routerTransformOutputCountStat          stats.Measurement
-	batchInputOutputDiffCountStat           stats.Measurement
-	routerResponseTransformStat             stats.Measurement
-	throttlingErrorStat                     stats.Measurement
-	throttledStat                           stats.Measurement
-	noOfWorkers                             int
-	workerInputBufferSize                   int
-	allowAbortedUserJobsCountForProcessing  int
+	responseQ                      chan jobResponseT
+	jobsDB                         jobsdb.MultiTenantJobsDB
+	errorDB                        jobsdb.JobsDB
+	netHandle                      NetHandleI
+	MultitenantI                   tenantStats
+	destName                       string
+	destinationId                  string
+	workers                        []*worker
+	telemetry                      *DiagnosticT
+	customDestinationManager       customDestinationManager.DestinationManager
+	throttlingCosts                atomic.Pointer[types.EventTypeThrottlingCost]
+	throttlerFactory               *rtThrottler.Factory
+	guaranteeUserEventOrder        bool
+	netClientTimeout               time.Duration
+	backendProxyTimeout            time.Duration
+	jobsDBCommandTimeout           time.Duration
+	jobdDBMaxRetries               int
+	enableBatching                 bool
+	transformer                    transformer.Transformer
+	configSubscriberLock           sync.RWMutex
+	destinationsMap                map[string]*routerutils.BatchDestinationT // destinationID -> destination
+	logger                         logger.Logger
+	batchInputCountStat            stats.Measurement
+	batchOutputCountStat           stats.Measurement
+	routerTransformInputCountStat  stats.Measurement
+	routerTransformOutputCountStat stats.Measurement
+	batchInputOutputDiffCountStat  stats.Measurement
+	routerResponseTransformStat    stats.Measurement
+	throttlingErrorStat            stats.Measurement
+	throttledStat                  stats.Measurement
+	noOfWorkers                    int
+	workerInputBufferSize          int
+
+	barrierConcurrencyLimit int
+	drainConcurrencyLimit   int
+
 	isBackendConfigInitialized              bool
 	backendConfig                           backendconfig.BackendConfig
 	backendConfigInitialized                chan bool
@@ -283,15 +286,17 @@ func (rt *HandleT) initWorkers() {
 
 	g, _ := errgroup.WithContext(context.Background())
 	for i := 0; i < rt.noOfWorkers; i++ {
+
 		worker := &worker{
 			input: make(chan workerMessageT, rt.workerInputBufferSize),
-			barrier: eventorder.NewBarrier(
-				eventorder.WithConcurrencyLimit(rt.allowAbortedUserJobsCountForProcessing),
-				eventorder.WithMetadata(map[string]string{
-					"destType":         rt.destName,
-					"batching":         strconv.FormatBool(rt.enableBatching),
-					"transformerProxy": strconv.FormatBool(rt.transformerProxy),
-				})),
+			barrier: eventorder.NewBarrier(eventorder.WithMetadata(map[string]string{
+				"destType":         rt.destName,
+				"batching":         strconv.FormatBool(rt.enableBatching),
+				"transformerProxy": strconv.FormatBool(rt.transformerProxy),
+			}),
+				eventorder.WithConcurrencyLimit(rt.barrierConcurrencyLimit),
+				eventorder.WithDrainConcurrencyLimit(rt.drainConcurrencyLimit),
+			),
 			id:                        i,
 			rt:                        rt,
 			deliveryTimeStat:          stats.Default.NewTaggedStat("router_delivery_time", stats.TimerType, stats.Tags{"destType": rt.destName}),
@@ -976,7 +981,8 @@ func (rt *HandleT) Setup(
 	config.RegisterBoolConfigVariable(false, &rt.skipRtAbortAlertForTransformation, true, rtAbortTransformationKeys...)
 	config.RegisterBoolConfigVariable(false, &rt.skipRtAbortAlertForDelivery, true, rtAbortDeliveryKeys...)
 	// END: Alert configuration
-	rt.allowAbortedUserJobsCountForProcessing = getRouterConfigInt("allowAbortedUserJobsCountForProcessing", destName, 1)
+	rt.drainConcurrencyLimit = getRouterConfigInt("drainedConcurrencyLimit", destName, 1)
+	rt.barrierConcurrencyLimit = getRouterConfigInt("barrierConcurrencyLimit", destName, 100)
 
 	statTags := stats.Tags{"destType": rt.destName}
 	rt.batchInputCountStat = stats.Default.NewTaggedStat("router_batch_num_input_jobs", stats.CountType, statTags)

--- a/schema-forwarder/internal/forwarder/abortingforwarder.go
+++ b/schema-forwarder/internal/forwarder/abortingforwarder.go
@@ -45,7 +45,7 @@ func (nf *AbortingForwarder) Start() error {
 					nf.terminalErrFn(err) // we are signaling to shutdown the app
 					return err
 				}
-				nf.log.Infof("NoopForwarder: Got %d jobs", len(jobList))
+				nf.log.Debugf("NoopForwarder: Got %d jobs", len(jobList))
 				var statusList []*jobsdb.JobStatusT
 				for _, job := range jobList {
 					statusList = append(statusList, &jobsdb.JobStatusT{


### PR DESCRIPTION
# Description

Until now, a single concurrency limiter existed in router's barrier, i.e. our event ordering mechanism, which was there to ensure that when a failed job got drained (aborted), in the next router generator loop only a single job would be picked up by the router for the same ordering key. This happens so as not to flood the worker's queue with jobs which are most probably going to be marked as `waiting` later on.

We are now introducing an additional concurrency limiter, which is responsible for limiting the overall maximum number of jobs that can enter the barrier for the same ordering key, regardless of failures. This barrier will protect us from a single "chatty" ordering key saturating the worker’s queue, so that jobs for other ordering keys can have a fair chance of being picked up by router.

The new concurrency limiter can be disabled by setting the limit to 0.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=74682dae510f457b91e992cf04e8effa&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
