### PR TITLE
chore: gateway stores singular events

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -954,7 +954,7 @@ var _ = Describe("Gateway", func() {
 			}
 			jobData, err := gateway.getJobDataFromRequest(req)
 			Expect(errors.New(response.InvalidJSON)).To(Equal(err))
-			Expect(jobData.job).To(BeNil())
+			Expect(jobData.jobs).To(BeNil())
 		})
 
 		It("drops non-identifiable requests if userID and anonID are not present in the request payload", func() {
@@ -967,7 +967,7 @@ var _ = Describe("Gateway", func() {
 			}
 			jobData, err := gateway.getJobDataFromRequest(req)
 			Expect(err).To(Equal(errors.New(response.NonIdentifiableRequest)))
-			Expect(jobData.job).To(BeNil())
+			Expect(jobData.jobs).To(BeNil())
 		})
 
 		It("accepts events with non-string type anonymousId and/or userId", func() {

--- a/integration_test/multi_tenant_test/multi_tenant_test.go
+++ b/integration_test/multi_tenant_test/multi_tenant_test.go
@@ -270,19 +270,13 @@ func testMultiTenantByAppType(t *testing.T, appType string) {
 		}, time.Minute, 50*time.Millisecond)
 		require.NoError(t, json.Unmarshal([]byte(eventPayload), &message))
 
-		batch, ok := message["batch"].([]interface{})
-		require.True(t, ok)
-		require.Len(t, batch, 1)
 		require.Equal(t, message["writeKey"], writeKey)
-		for _, msg := range batch {
-			m, ok := msg.(map[string]interface{})
-			require.True(t, ok)
-			require.Equal(t, "anonymousId_1", m["anonymousId"])
-			require.Equal(t, "identified_user_id", m["userId"])
-			require.Equal(t, "identify", m["type"])
-			require.Equal(t, "1", m["eventOrderNo"])
-			require.Equal(t, "messageId_1", m["messageId"])
-		}
+		m := message
+		require.Equal(t, "anonymousId_1", m["anonymousId"])
+		require.Equal(t, "identified_user_id", m["userId"])
+		require.Equal(t, "identify", m["type"])
+		require.Equal(t, "1", m["eventOrderNo"])
+		require.Equal(t, "messageId_1", m["messageId"])
 
 		// Only the Gateway is running, so we don't expect any destinations to be hit.
 		require.Empty(t, webhook.Requests(), "webhook should have no requests because there is no processor")

--- a/processor/processor_isolation_test.go
+++ b/processor/processor_isolation_test.go
@@ -305,7 +305,7 @@ func ProcIsolationScenario(t testing.TB, spec *ProcIsolationScenarioSpec) (overa
 	require.Eventually(t, func() bool {
 		var processedJobCount int
 		require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdb('gw',5) WHERE job_state = 'succeeded'").Scan(&processedJobCount))
-		return processedJobCount == len(spec.jobs)/batchSize
+		return processedJobCount == len(spec.jobs)
 	}, 300*time.Second, 1*time.Second, "all batches should be successfully processed")
 
 	var failedJobs int

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -591,7 +591,6 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 				subJob{
 					subJobs: unprocessedJobsList,
 				},
-				nil,
 			)
 		})
 	})

--- a/processor/worker.go
+++ b/processor/worker.go
@@ -97,7 +97,7 @@ func (w *worker) start() {
 		defer close(w.channel.transform)
 		defer w.logger.Debugf("preprocessing routine stopped for worker: %s", w.partition)
 		for jobs := range w.channel.preprocess {
-			w.channel.transform <- w.handle.processJobsForDest(w.partition, jobs, nil)
+			w.channel.transform <- w.handle.processJobsForDest(w.partition, jobs)
 		}
 	})
 

--- a/processor/worker_handle.go
+++ b/processor/worker_handle.go
@@ -6,7 +6,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/services/rsources"
-	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
 // workerHandle is the interface trying to abstract processor's [Handle] implememtation from the worker
@@ -20,7 +19,7 @@ type workerHandle interface {
 	getJobs(partition string) jobsdb.JobsResult
 	markExecuting(jobs []*jobsdb.JobT) error
 	jobSplitter(jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []subJob
-	processJobsForDest(partition string, subJobs subJob, parsedEventList [][]types.SingularEventT) *transformationMessage
+	processJobsForDest(partition string, subJobs subJob) *transformationMessage
 	transformations(partition string, in *transformationMessage) *storeMessage
 	Store(partition string, in *storeMessage)
 }

--- a/processor/worker_pool_test.go
+++ b/processor/worker_pool_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/services/rsources"
 	utilsync "github.com/rudderlabs/rudder-server/utils/sync"
-	"github.com/rudderlabs/rudder-server/utils/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -182,7 +181,7 @@ func (m *mockWorkerHandle) handlePendingGatewayJobs(key string) bool {
 	for _, subJob := range m.jobSplitter(jobs.Jobs, rsourcesStats) {
 		m.Store(key,
 			m.transformations(key,
-				m.processJobsForDest(key, subJob, nil),
+				m.processJobsForDest(key, subJob),
 			),
 		)
 	}
@@ -241,7 +240,7 @@ func (*mockWorkerHandle) jobSplitter(jobs []*jobsdb.JobT, rsourcesStats rsources
 	}
 }
 
-func (m *mockWorkerHandle) processJobsForDest(partition string, subJobs subJob, _ [][]types.SingularEventT) *transformationMessage {
+func (m *mockWorkerHandle) processJobsForDest(partition string, subJobs subJob) *transformationMessage {
 	if m.limiters.process != nil {
 		defer m.limiters.process.Begin(partition)()
 	}

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -237,6 +237,17 @@ func ParseRudderEventBatch(eventPayload json.RawMessage) ([]types.SingularEventT
 	return gatewayBatchEvent.Batch, true
 }
 
+func ParseRudderEvent(eventPayload json.RawMessage) (types.SingularEventT, bool) {
+	var rudderEvent types.SingularEventT
+	err := jsonfast.Unmarshal(eventPayload, &rudderEvent)
+	if err != nil {
+		pkgLogger.Debug("json parsing of event payload failed ", string(eventPayload))
+		return nil, false
+	}
+
+	return rudderEvent, true
+}
+
 // GetRudderID return the UserID from the object
 func GetRudderID(event types.SingularEventT) (string, bool) {
 	userID, ok := GetRudderEventVal("rudderId", event)


### PR DESCRIPTION
# Description

gateway now stores singular events to jobsdb.

gateway receives:
```
{
  "batch": [
    {event-1},
    {event-2}
  ]
}
```
gateway stores:
```
jobid - 1:
{event-1}

jobid - 2:
{event-2}
```

## Notion Ticket

[relevant slack thread](https://rudderlabs.slack.com/archives/C01HTT66UMB/p1682402259238799)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
