### PR TITLE
chore: gateway stores singular event batches

### DIFF
--- a/gateway/configuration.go
+++ b/gateway/configuration.go
@@ -38,6 +38,7 @@ func loadConfig() {
 	// Enables accepting requests without user id and anonymous id. This is added to prevent client 4xx retries.
 	config.RegisterBoolConfigVariable(false, &allowReqsWithoutUserIDAndAnonymousID, true, "Gateway.allowReqsWithoutUserIDAndAnonymousID")
 	config.RegisterBoolConfigVariable(true, &gwAllowPartialWriteWithErrors, true, "Gateway.allowPartialWriteWithErrors")
+	config.RegisterBoolConfigVariable(true, &allowBatchSplitting, true, "Gateway.allowBatchSplitting")
 	config.RegisterDurationConfigVariable(0, &ReadTimeout, false, time.Second, []string{"ReadTimeout", "ReadTimeOutInSec"}...)
 	config.RegisterDurationConfigVariable(0, &ReadHeaderTimeout, false, time.Second, []string{"ReadHeaderTimeout", "ReadHeaderTimeoutInSec"}...)
 	config.RegisterDurationConfigVariable(10, &WriteTimeout, false, time.Second, []string{"WriteTimeout", "WriteTimeOutInSec"}...)

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -450,17 +450,22 @@ func (gateway *HandleT) userWebRequestWorkerProcess(userWebRequestWorker *userWe
 				}
 				continue
 			}
-			jobBatches = append(jobBatches, jobData.jobs)
-			jobIDReqMap[jobData.jobs[0].UUID] = req
-			jobSourceTagMap[jobData.jobs[0].UUID] = sourceTag
-			for _, job := range jobData.jobs {
-				eventBatchesToRecord = append(
-					eventBatchesToRecord,
-					sourceDebugger{
-						data:     job.EventPayload,
-						writeKey: writeKey,
-					},
-				)
+			if len(jobData.jobs) > 0 {
+				jobBatches = append(jobBatches, jobData.jobs)
+				jobIDReqMap[jobData.jobs[0].UUID] = req
+				jobSourceTagMap[jobData.jobs[0].UUID] = sourceTag
+				for _, job := range jobData.jobs {
+					eventBatchesToRecord = append(
+						eventBatchesToRecord,
+						sourceDebugger{
+							data:     job.EventPayload,
+							writeKey: writeKey,
+						},
+					)
+				}
+			} else {
+				req.done <- response.InvalidJSON
+				sourceStats[sourceTag].RequestFailed(response.InvalidJSON)
 			}
 		}
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -503,8 +503,6 @@ func (gateway *HandleT) userWebRequestWorkerProcess(userWebRequestWorker *userWe
 		gateway.batchSizeStat.Observe(float64(len(breq.batchRequest)))
 
 		for _, v := range sourceStats {
-			gateway.logger.Info(`@@@@@@@`)
-			gateway.logger.Info(v)
 			v.Report(gateway.stats)
 		}
 	}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -730,6 +730,7 @@ func (gateway *HandleT) getJobDataFromRequest(req *webRequestT) (jobData *jobFro
 			WorkspaceId:  workspaceId,
 		})
 	}
+	err = nil
 	jobData.jobs = jobs
 	return
 }

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -451,7 +451,7 @@ var _ = Describe("Gateway", func() {
 			Expect(err).To(BeNil())
 		})
 
-		assertJobMetadata := func(job *jobsdb.JobT, batchLength int) {
+		assertJobMetadata := func(job *jobsdb.JobT) {
 			Expect(misc.IsValidUUID(job.UUID.String())).To(Equal(true))
 
 			var paramsMap, expectedParamsMap map[string]interface{}
@@ -472,7 +472,7 @@ var _ = Describe("Gateway", func() {
 			Expect(time.Parse(misc.RFC3339Milli, receivedAt.String())).To(BeTemporally("~", time.Now(), 100*time.Millisecond))
 			Expect(writeKey.String()).To(Equal(WriteKeyEnabled))
 			Expect(requestIP.String()).To(Equal(TestRemoteAddress))
-			Expect(batch.Array()).To(HaveLen(batchLength))
+			Expect(batch.Array()).To(HaveLen(1)) // each batch split into multiple batches of 1 event
 		}
 
 		createValidBody := func(customProperty, customValue string) []byte {
@@ -533,7 +533,7 @@ var _ = Describe("Gateway", func() {
 							) (map[uuid.UUID]string, error) {
 								for _, job := range jobs {
 									// each call should be included in a separate batch, with a separate batch_id
-									assertJobMetadata(job, 1)
+									assertJobMetadata(job)
 
 									responseData := []byte(job.EventPayload)
 									payload := gjson.GetBytes(responseData, "batch.0")
@@ -1049,7 +1049,7 @@ var _ = Describe("Gateway", func() {
 			}
 			jobData, err := gateway.getJobDataFromRequest(req)
 			Expect(errors.New(response.InvalidJSON)).To(Equal(err))
-			Expect(jobData.job).To(BeNil())
+			Expect(jobData.jobs).To(BeNil())
 		})
 
 		It("drops non-identifiable requests if userID and anonID are not present in the request payload", func() {
@@ -1062,7 +1062,7 @@ var _ = Describe("Gateway", func() {
 			}
 			jobData, err := gateway.getJobDataFromRequest(req)
 			Expect(err).To(Equal(errors.New(response.NonIdentifiableRequest)))
-			Expect(jobData.job).To(BeNil())
+			Expect(jobData.jobs).To(BeNil())
 		})
 
 		It("accepts events with non-string type anonymousId and/or userId", func() {

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -506,7 +506,6 @@ var _ = Describe("Gateway", func() {
 
 		// common tests for all web handlers
 		It("should accept valid requests on a single endpoint (except batch), and store to jobsdb", func() {
-			workspaceID := gateway.getWorkspaceForWriteKey(WriteKeyEnabled)
 			for handlerType, handler := range allHandlers(gateway) {
 				if !(handlerType == "batch" || handlerType == "import") {
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -507,8 +507,6 @@ var _ = Describe("Gateway", func() {
 		// common tests for all web handlers
 		It("should accept valid requests on a single endpoint (except batch), and store to jobsdb", func() {
 			workspaceID := gateway.getWorkspaceForWriteKey(WriteKeyEnabled)
-			fmt.Println(`################## - `, workspaceID, ` - ##################`)
-			fmt.Println(workspaceID)
 			for handlerType, handler := range allHandlers(gateway) {
 				if !(handlerType == "batch" || handlerType == "import") {
 

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -1146,7 +1146,7 @@ func TestJobsDB_IncompatiblePayload(t *testing.T) {
 		WorkspaceId:  defaultWorkspaceID,
 		EventCount:   1,
 	}
-	errMap := jobDB.StoreWithRetryEach(context.Background(), []*JobT{&sampleTestJob})
+	errMap := jobDB.StoreEachBatchRetry(context.Background(), [][]*JobT{{&sampleTestJob}})
 	for _, val := range errMap {
 		require.Equal(t, "", val)
 	}

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -2989,7 +2989,8 @@ func (jd *HandleT) StoreWithRetryEachInTx(ctx context.Context, tx StoreSafeTx, j
 func (jd *HandleT) StoreEachBatchRetryInTx(
 	ctx context.Context,
 	tx StoreSafeTx,
-	jobBatches [][]*JobT) (map[uuid.UUID]string, error) {
+	jobBatches [][]*JobT,
+) (map[uuid.UUID]string, error) {
 	var (
 		err error
 		res map[uuid.UUID]string
@@ -3016,7 +3017,8 @@ func (jd *HandleT) internalStoreEachBatchRetryInTx(
 	tx *Tx,
 	ds dataSetT,
 	jobBatches [][]*JobT) (
-	errorMessagesMap map[uuid.UUID]string, err error) {
+	errorMessagesMap map[uuid.UUID]string, err error,
+) {
 	const (
 		savepointSql = "SAVEPOINT storeWithRetryEach"
 		rollbackSql  = "ROLLBACK TO " + savepointSql

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -735,7 +735,7 @@ func TestThreadSafeJobStorage(t *testing.T) {
 		require.Equal(t, 2, len(jobsDB2.getDSList()), "expected jobsDB2 to have refreshed its ds list")
 
 		require.Equal(t, 1, len(jobsDB3.getDSList()), "expected jobsDB3 to still have a list length of 1")
-		errorsMap := jobsDB3.StoreWithRetryEach(context.Background(), generateJobs(2))
+		errorsMap := jobsDB3.StoreEachBatchRetry(context.Background(), [][]*JobT{generateJobs(2)})
 		require.Equal(t, 0, len(errorsMap))
 
 		require.Equal(t, 2, len(jobsDB3.getDSList()), "expected jobsDB3 to have refreshed its ds list")

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -278,6 +278,21 @@ func (mr *MockJobsDBMockRecorder) Store(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockJobsDB)(nil).Store), arg0, arg1)
 }
 
+// StoreEachBatchRetryInTx mocks base method.
+func (m *MockJobsDB) StoreEachBatchRetryInTx(arg0 context.Context, arg1 jobsdb.StoreSafeTx, arg2 [][]*jobsdb.JobT) (map[uuid.UUID]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StoreEachBatchRetryInTx", arg0, arg1, arg2)
+	ret0, _ := ret[0].(map[uuid.UUID]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StoreEachBatchRetryInTx indicates an expected call of StoreEachBatchRetryInTx.
+func (mr *MockJobsDBMockRecorder) StoreEachBatchRetryInTx(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreEachBatchRetryInTx", reflect.TypeOf((*MockJobsDB)(nil).StoreEachBatchRetryInTx), arg0, arg1, arg2)
+}
+
 // StoreInTx mocks base method.
 func (m *MockJobsDB) StoreInTx(arg0 context.Context, arg1 jobsdb.StoreSafeTx, arg2 []*jobsdb.JobT) error {
 	m.ctrl.T.Helper()

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -278,6 +278,20 @@ func (mr *MockJobsDBMockRecorder) Store(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockJobsDB)(nil).Store), arg0, arg1)
 }
 
+// StoreEachBatchRetry mocks base method.
+func (m *MockJobsDB) StoreEachBatchRetry(arg0 context.Context, arg1 [][]*jobsdb.JobT) map[uuid.UUID]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StoreEachBatchRetry", arg0, arg1)
+	ret0, _ := ret[0].(map[uuid.UUID]string)
+	return ret0
+}
+
+// StoreEachBatchRetry indicates an expected call of StoreEachBatchRetry.
+func (mr *MockJobsDBMockRecorder) StoreEachBatchRetry(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreEachBatchRetry", reflect.TypeOf((*MockJobsDB)(nil).StoreEachBatchRetry), arg0, arg1)
+}
+
 // StoreEachBatchRetryInTx mocks base method.
 func (m *MockJobsDB) StoreEachBatchRetryInTx(arg0 context.Context, arg1 jobsdb.StoreSafeTx, arg2 [][]*jobsdb.JobT) (map[uuid.UUID]string, error) {
 	m.ctrl.T.Helper()
@@ -305,35 +319,6 @@ func (m *MockJobsDB) StoreInTx(arg0 context.Context, arg1 jobsdb.StoreSafeTx, ar
 func (mr *MockJobsDBMockRecorder) StoreInTx(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreInTx", reflect.TypeOf((*MockJobsDB)(nil).StoreInTx), arg0, arg1, arg2)
-}
-
-// StoreWithRetryEach mocks base method.
-func (m *MockJobsDB) StoreWithRetryEach(arg0 context.Context, arg1 []*jobsdb.JobT) map[uuid.UUID]string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreWithRetryEach", arg0, arg1)
-	ret0, _ := ret[0].(map[uuid.UUID]string)
-	return ret0
-}
-
-// StoreWithRetryEach indicates an expected call of StoreWithRetryEach.
-func (mr *MockJobsDBMockRecorder) StoreWithRetryEach(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreWithRetryEach", reflect.TypeOf((*MockJobsDB)(nil).StoreWithRetryEach), arg0, arg1)
-}
-
-// StoreWithRetryEachInTx mocks base method.
-func (m *MockJobsDB) StoreWithRetryEachInTx(arg0 context.Context, arg1 jobsdb.StoreSafeTx, arg2 []*jobsdb.JobT) (map[uuid.UUID]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreWithRetryEachInTx", arg0, arg1, arg2)
-	ret0, _ := ret[0].(map[uuid.UUID]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// StoreWithRetryEachInTx indicates an expected call of StoreWithRetryEachInTx.
-func (mr *MockJobsDBMockRecorder) StoreWithRetryEachInTx(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreWithRetryEachInTx", reflect.TypeOf((*MockJobsDB)(nil).StoreWithRetryEachInTx), arg0, arg1, arg2)
 }
 
 // UpdateJobStatus mocks base method.

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1354,7 +1354,7 @@ type dupStatKey struct {
 	equalSize bool
 }
 
-func (proc *Handle) processJobsForDest(partition string, subJobs subJob, parsedEventList [][]types.SingularEventT) *transformationMessage {
+func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transformationMessage {
 	if proc.limiter.preprocess != nil {
 		defer proc.limiter.preprocess.BeginWithPriority(partition, proc.getLimiterPriority(partition))()
 	}
@@ -1371,9 +1371,6 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob, parsedE
 	var procErrorJobs []*jobsdb.JobT
 	eventSchemaJobs := make([]*jobsdb.JobT, 0)
 
-	if !(parsedEventList == nil || len(jobList) == len(parsedEventList)) {
-		panic(fmt.Errorf("parsedEventList != nil and len(jobList):%d != len(parsedEventList):%d", len(jobList), len(parsedEventList)))
-	}
 	// Each block we receive from a client has a bunch of
 	// requests. We parse the block and take out individual
 	// requests, call the destination specific transformation
@@ -1400,16 +1397,11 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob, parsedE
 	outCountMap := make(map[string]int64) // destinations enabled
 	destFilterStatusDetailMap := make(map[string]map[string]*types.StatusDetail)
 
-	for idx, batchEvent := range jobList {
+	for _, batchEvent := range jobList {
 
 		var singularEvents []types.SingularEventT
 		var ok bool
-		if parsedEventList == nil {
-			singularEvents, ok = misc.ParseRudderEventBatch(batchEvent.EventPayload)
-		} else {
-			singularEvents = parsedEventList[idx]
-			ok = singularEvents != nil
-		}
+		singularEvents, ok = misc.ParseRudderEventBatch(batchEvent.EventPayload)
 		writeKey := gjson.Get(string(batchEvent.EventPayload), "writeKey").Str
 		requestIP := gjson.Get(string(batchEvent.EventPayload), "requestIP").Str
 		receivedAt := gjson.Get(string(batchEvent.EventPayload), "receivedAt").Time()
@@ -1512,15 +1504,18 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob, parsedE
 					continue
 				}
 
-				_, ok = groupedEventsByWriteKey[WriteKeyT(writeKey)]
-				if !ok {
+				if _, ok := groupedEventsByWriteKey[WriteKeyT(writeKey)]; !ok {
 					groupedEventsByWriteKey[WriteKeyT(writeKey)] = make([]transformer.TransformerEventT, 0)
 				}
 				shallowEventCopy := transformer.TransformerEventT{}
 				shallowEventCopy.Message = singularEvent
 				shallowEventCopy.Message["request_ip"] = requestIP
 				enhanceWithTimeFields(&shallowEventCopy, singularEvent, receivedAt)
-				enhanceWithMetadata(commonMetadataFromSingularEvent, &shallowEventCopy, &backendconfig.DestinationT{})
+				enhanceWithMetadata(
+					commonMetadataFromSingularEvent,
+					&shallowEventCopy,
+					&backendconfig.DestinationT{},
+				)
 
 				// TODO: TP ID preference 1.event.context set by rudderTyper   2.From WorkSpaceConfig (currently being used)
 				shallowEventCopy.Metadata.TrackingPlanId = source.DgSourceTrackingPlanConfig.TrackingPlan.Id
@@ -2595,7 +2590,8 @@ func (proc *Handle) handlePendingGatewayJobs(partition string) bool {
 				subJobs:       unprocessedList.Jobs,
 				hasMore:       false,
 				rsourcesStats: rsourcesStats,
-			}, nil),
+			},
+			),
 		),
 	)
 	proc.stats.statLoopTime.Since(s)
@@ -2689,7 +2685,7 @@ func filterConfig(eventCopy *transformer.TransformerEventT) {
 	}
 }
 
-func (proc *Handle) getLimiterPriority(partition string) miscsync.LimiterPriorityValue {
+func (*Handle) getLimiterPriority(partition string) miscsync.LimiterPriorityValue {
 	return miscsync.LimiterPriorityValue(config.GetInt(fmt.Sprintf("Processor.Limiter.%s.Priority", partition), 1))
 }
 

--- a/processor/processor_isolation_test.go
+++ b/processor/processor_isolation_test.go
@@ -310,7 +310,7 @@ func ProcIsolationScenario(t testing.TB, spec *ProcIsolationScenarioSpec) (overa
 	require.Eventually(t, func() bool {
 		var processedJobCount int
 		require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('gw',5) WHERE job_state = 'succeeded'").Scan(&processedJobCount))
-		return processedJobCount == len(spec.jobs)/batchSize
+		return processedJobCount == len(spec.jobs)
 	}, 300*time.Second, 1*time.Second, "all batches should be successfully processed")
 
 	var failedJobs int

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -589,7 +589,6 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 				subJob{
 					subJobs: unprocessedJobsList,
 				},
-				nil,
 			)
 		})
 	})

--- a/processor/worker.go
+++ b/processor/worker.go
@@ -70,7 +70,7 @@ func (w *worker) start() {
 		defer close(w.channel.transform)
 		defer w.logger.Debugf("preprocessing routine stopped for worker: %s", w.partition)
 		for jobs := range w.channel.preprocess {
-			w.channel.transform <- w.handle.processJobsForDest(w.partition, jobs, nil)
+			w.channel.transform <- w.handle.processJobsForDest(w.partition, jobs)
 		}
 	})
 

--- a/processor/worker_handle.go
+++ b/processor/worker_handle.go
@@ -6,7 +6,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/services/rsources"
-	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
 // workerHandle is the interface trying to abstract processor's [Handle] implememtation from the worker
@@ -20,7 +19,7 @@ type workerHandle interface {
 	getJobs(partition string) jobsdb.JobsResult
 	markExecuting(jobs []*jobsdb.JobT) error
 	jobSplitter(jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []subJob
-	processJobsForDest(partition string, subJobs subJob, parsedEventList [][]types.SingularEventT) *transformationMessage
+	processJobsForDest(partition string, subJobs subJob) *transformationMessage
 	transformations(partition string, in *transformationMessage) *storeMessage
 	Store(partition string, in *storeMessage)
 }

--- a/processor/worker_test.go
+++ b/processor/worker_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/services/rsources"
 	utilsync "github.com/rudderlabs/rudder-server/utils/sync"
-	"github.com/rudderlabs/rudder-server/utils/types"
 	"github.com/rudderlabs/rudder-server/utils/workerpool"
 	"github.com/stretchr/testify/require"
 )
@@ -197,7 +196,7 @@ func (m *mockWorkerHandle) handlePendingGatewayJobs(key string) bool {
 	for _, subJob := range m.jobSplitter(jobs.Jobs, rsourcesStats) {
 		m.Store(key,
 			m.transformations(key,
-				m.processJobsForDest(key, subJob, nil),
+				m.processJobsForDest(key, subJob),
 			),
 		)
 	}
@@ -257,7 +256,7 @@ func (*mockWorkerHandle) jobSplitter(jobs []*jobsdb.JobT, rsourcesStats rsources
 	}
 }
 
-func (m *mockWorkerHandle) processJobsForDest(partition string, subJobs subJob, _ [][]types.SingularEventT) *transformationMessage {
+func (m *mockWorkerHandle) processJobsForDest(partition string, subJobs subJob) *transformationMessage {
 	if m.limiters.process != nil {
 		defer m.limiters.process.Begin(partition)()
 	}


### PR DESCRIPTION
# Description

gateway opens a batch of event, stores each event inside as its own batch.

gateway receives:
```
{
  "batch": [
    {event-1},
    {event-2}
  ]
}
```
gateway stores:
```
jobid - 1:
{
  "batch": [
    {event-1}
  ]
}

jobid - 2:
{
  "batch": [
    {event-2}
  ]
}
```
Tangential to another [PR](https://github.com/rudderlabs/rudder-server/pull/3251) where gateway simply stores the singular event to gateway table.
The current approach avoids changing things at processor, and does not bear the burden of transitioning from previous behaviour which is evident from the other PR.

## Notion Ticket

[relevant slack thread](https://rudderlabs.slack.com/archives/C01HTT66UMB/p1682402259238799)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
