### PR TITLE
chore: fix typecast panic

### DIFF
--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -107,7 +107,12 @@ func WithConfig(ld *LoadFileGenerator, config *config.Config) {
 
 	ld.publishBatchSizePerWorkspace = make(map[string]int, len(mapConfig))
 	for k, v := range mapConfig {
-		ld.publishBatchSizePerWorkspace[k] = int(v.(float64))
+		val, ok := v.(float64)
+		if !ok {
+			ld.publishBatchSizePerWorkspace[k] = defaultPublishBatchSize
+			continue
+		}
+		ld.publishBatchSizePerWorkspace[k] = int(val)
 	}
 }
 


### PR DESCRIPTION
# Description
Fix the panic caused on proeumt

```
panic: interface conversion: interface {} is int, not float64 [recovered]
	panic: interface conversion: interface {} is int, not float64 [recovered]
	panic: interface conversion: interface {} is int, not float64

goroutine 110 [running]:
github.com/bugsnag/bugsnag-go/v2.AutoNotify({0xc001db5310, 0x3, 0xc000100c00?})
	/go/pkg/mod/github.com/bugsnag/bugsnag-go/v2@v2.2.0/bugsnag.go:112 +0x3ec
panic({0x25c2f00, 0xc001148f90})
	/usr/local/go/src/runtime/panic.go:884 +0x213
github.com/rudderlabs/rudder-server/utils/misc.BugsnagNotify.func1.1()
	/rudder-server/utils/misc/misc.go:1173 +0x35c
sync.(*Once).doSlow(0xc0016095e8?, 0x40e087?)
	/usr/local/go/src/sync/once.go:74 +0xc2
sync.(*Once).Do(...)
	/usr/local/go/src/sync/once.go:65
github.com/rudderlabs/rudder-server/utils/misc.BugsnagNotify.func1()
	/rudder-server/utils/misc/misc.go:1162 +0xbc
panic({0x25c2f00, 0xc001148f90})
	/usr/local/go/src/runtime/panic.go:884 +0x213
github.com/rudderlabs/rudder-server/warehouse/internal/loadfiles.WithConfig(0xc000e60180, 0x29ec7d4?)
	/rudder-server/warehouse/internal/loadfiles/loadfiles.go:110 +0x17a
github.com/rudderlabs/rudder-server/warehouse.(*HandleT).Setup(0xc001bb8000, {0xc0004359f0, 0xe})
	/rudder-server/warehouse/warehouse.go:880 +0x92a
github.com/rudderlabs/rudder-server/warehouse.onConfigDataEvent(0xc00115a180, 0x3033b10?)
	/rudder-server/warehouse/warehouse.go:1041 +0x765
github.com/rudderlabs/rudder-server/warehouse.monitorDestRouters({0x3033b10, 0xc001194370})
	/rudder-server/warehouse/warehouse.go:1011 +0x9c
github.com/rudderlabs/rudder-server/warehouse.Start.func8()
	/rudder-server/warehouse/warehouse.go:1705 +0x25
github.com/rudderlabs/rudder-server/utils/misc.WithBugsnagForWarehouse.func1()
	/rudder-server/utils/misc/misc.go:1155 +0x70
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/go/pkg/mod/golang.org/x/sync@v0.1.0/errgroup/errgroup.go:75 +0x64
created by golang.org/x/sync/errgroup.(*Group).Go
	/go/pkg/mod/golang.org/x/sync@v0.1.0/errgroup/errgroup.go:72 +0xa5
```

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/Fix-typecast-panic-loadfiles-7b0ccb4c8757474d8a0b5f299bac76b6?pvs=4)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
