### PR TITLE
feat: add error extraction logic

### DIFF
--- a/enterprise/reporting/error-detail-extractor.go
+++ b/enterprise/reporting/error-detail-extractor.go
@@ -169,6 +169,14 @@ func getFirstNonNilValue(keys []string, jsonObj map[string]interface{}) interfac
 	return nil
 }
 
+func convertInterfaceArrToStrArrWithDelimitter(arrI []interface{}, delimitter string) string {
+	s := make([]string, len(arrI))
+	for i, v := range arrI {
+		s[i] = fmt.Sprint(v)
+	}
+	return strings.Join(s, delimitter)
+}
+
 func getErrorMessageFromResponse(resp interface{}, messageKeys []string) string {
 	var respMap map[string]interface{}
 	respMap, isMap := resp.(map[string]interface{})
@@ -204,11 +212,7 @@ func getErrorMessageFromResponse(resp interface{}, messageKeys []string) string 
 
 errorsBlock:
 	if errors, ok := getFirstNonNilValue([]string{errorsKey}, findKeys([]string{errorsKey}, resp)).([]interface{}); ok && len(errors) > 0 {
-		s := make([]string, len(errors))
-		for i, v := range errors {
-			s[i] = fmt.Sprint(v)
-		}
-		return strings.Join(s, ".")
+		return convertInterfaceArrToStrArrWithDelimitter(errors, ".")
 	}
 
 	return ""
@@ -224,11 +228,7 @@ func getErrorFromWarehouse(resp map[string]interface{}) string {
 		return ""
 	}
 	errors := lo.Uniq(arrOfErrs)
-	errorStrings := make([]string, len(errors))
-	for i, v := range errors {
-		errorStrings[i] = fmt.Sprint(v)
-	}
-	return strings.Join(errorStrings, ".")
+	return convertInterfaceArrToStrArrWithDelimitter(errors, ".")
 }
 
 func IsJSON(s string) bool {

--- a/enterprise/reporting/error-detail-extractor.go
+++ b/enterprise/reporting/error-detail-extractor.go
@@ -14,8 +14,10 @@ const (
 	destinationResponse = "destinationResponse"
 )
 
-var WildcardKeys []string = []string{}
-var defaultErrorMessageKeys = []string{"message", "description", "detail", "title", "Error", "error", "error_message"}
+var (
+	WildcardKeys            []string = []string{}
+	defaultErrorMessageKeys          = []string{"message", "description", "detail", "title", "Error", "error", "error_message"}
+)
 
 type ExtractorT struct {
 	WildcardKeys     []string
@@ -35,7 +37,7 @@ func NewErrorDetailExtractor() *ExtractorT {
 	return extractor
 }
 
-func generateCombinations(symbols []string, res []string, prefix string, level int) []string {
+func generateCombinations(symbols, res []string, prefix string, level int) []string {
 	if level <= 0 {
 		// fmt.Printf("Prefix:%s\n", prefix)
 		res = append(res, prefix)
@@ -55,7 +57,6 @@ func generateCombinations(symbols []string, res []string, prefix string, level i
 // This function is to be executed only once
 // as these keys will be same across destinations
 func (t *ExtractorT) BuildMessageKeysPermutations() {
-
 	var level int
 	// sts := []string{"", objectKeyWildcard, arrayWildcard}
 
@@ -113,7 +114,6 @@ func (t *ExtractorT) GetErrorMessageFromResponse(response string) string {
 	prelimResults := gjson.GetMany(response, probableKeyList...)
 	for _, prelimResult := range prelimResults {
 		if prelimResult.Exists() {
-
 			switch prelimResult.Type {
 			case gjson.String:
 				return prelimResult.String()
@@ -131,7 +131,6 @@ func (t *ExtractorT) GetErrorMessageFromResponse(response string) string {
 					return t.GetErrorMessageFromResponse(prelimResult.String())
 				}
 			}
-
 		}
 	}
 

--- a/enterprise/reporting/error-detail-extractor.go
+++ b/enterprise/reporting/error-detail-extractor.go
@@ -159,14 +159,14 @@ func findKeys(keys []string, jsonObj interface{}) map[string]interface{} {
 // This function takes a list of keys and a JSON object as input, and returns the value of the first key that exists in the JSON object.
 func findFirstExistingKey(keys []string, jsonObj interface{}) interface{} {
 	keyValues := findKeys(keys, jsonObj)
-	result := getValue(keys, keyValues)
+	result := getFirstNonNilValue(keys, keyValues)
 	if checkForGoMapOrList(result) {
 		return findFirstExistingKey(keys, result)
 	}
 	return result
 }
 
-func getValue(keys []string, jsonObj map[string]interface{}) interface{} {
+func getFirstNonNilValue(keys []string, jsonObj map[string]interface{}) interface{} {
 	for _, key := range keys {
 		if value, ok := jsonObj[key]; ok && value != nil {
 			return value
@@ -197,7 +197,7 @@ func getErrorMessageFromResponse(resp interface{}, messageKeys []string) string 
 	}
 
 skipToSome:
-	if errors, ok := getValue([]string{errorsKey}, findKeys([]string{errorsKey}, resp)).([]interface{}); ok && len(errors) > 0 {
+	if errors, ok := getFirstNonNilValue([]string{errorsKey}, findKeys([]string{errorsKey}, resp)).([]interface{}); ok && len(errors) > 0 {
 		s := make([]string, len(errors))
 		for i, v := range errors {
 			s[i] = fmt.Sprint(v)

--- a/enterprise/reporting/error-detail-extractor.go
+++ b/enterprise/reporting/error-detail-extractor.go
@@ -63,23 +63,6 @@ func checkForGoMapOrList(value interface{}) bool {
 	return false
 }
 
-func unmarshalJsonToMap(jsonStr string, logger *logger.Logger) map[string]interface{} {
-	var j map[string]interface{}
-	err := json.Unmarshal([]byte(jsonStr), &j)
-	if err != nil {
-		errStr := fmt.Sprintf("Unmarshal Err: %v\nJsonStr:%v\n", err, jsonStr)
-		// For proper logging
-		if logger != nil {
-			(*logger).Errorf(errStr)
-		} else {
-			fmt.Println(errStr)
-		}
-
-		return nil
-	}
-	return j
-}
-
 func (ext *ExtractorT) getSimpleMessage(jsonStr string) string {
 	if !IsJSON(jsonStr) {
 		return jsonStr
@@ -149,32 +132,28 @@ func findKeys(keys []string, jsonObj interface{}) map[string]interface{} {
 		return values
 	}
 	// recursively search for keys in nested JSON objects
-	if checkForGoMapOrList(jsonObj) {
-		switch jsonObj := jsonObj.(type) {
-		case map[string]interface{}: // if jsonObj is a map
-			for _, key := range keys {
-				if value, ok := jsonObj[key]; ok && value != nil {
-					values[key] = value
-				}
-			}
-			for _, value := range jsonObj {
-				subResults := findKeys(keys, value)
-				for k, v := range subResults {
-					values[k] = v
-				}
-			}
-		case []interface{}: // if jsonObj is a slice
-			for _, item := range jsonObj {
-				subResults := findKeys(keys, item)
-				for k, v := range subResults {
-					values[k] = v
-				}
+	switch jsonObj := jsonObj.(type) {
+	case map[string]interface{}: // if jsonObj is a map
+		for _, key := range keys {
+			if value, ok := jsonObj[key]; ok && value != nil {
+				values[key] = value
 			}
 		}
-		return values // return the map of keys and values
+		for _, value := range jsonObj {
+			subResults := findKeys(keys, value)
+			for k, v := range subResults {
+				values[k] = v
+			}
+		}
+	case []interface{}: // if jsonObj is a slice
+		for _, item := range jsonObj {
+			subResults := findKeys(keys, item)
+			for k, v := range subResults {
+				values[k] = v
+			}
+		}
 	}
-	// if jsonObj is not a map or slice, return an empty map
-	return values
+	return values // return the map of keys and values
 }
 
 // This function takes a list of keys and a JSON object as input, and returns the value of the first key that exists in the JSON object.

--- a/enterprise/reporting/error-detail-extractor.go
+++ b/enterprise/reporting/error-detail-extractor.go
@@ -1,0 +1,139 @@
+package reporting
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	objectKeyWildcard   = "*"
+	arrayWildcard       = "#"
+	destinationResponse = "destinationResponse"
+)
+
+var WildcardKeys []string = []string{}
+var defaultErrorMessageKeys = []string{"message", "description", "detail", "title", "Error", "error", "error_message"}
+
+type ExtractorT struct {
+	WildcardKeys     []string
+	MaxLevel         int      // Max level of wild-card search
+	ErrorMessageKeys []string // the keys where in we may have error message
+}
+
+func NewErrorDetailExtractor() *ExtractorT {
+	errMsgKeys := config.GetStringSlice("Reporting.ErrorDetail.ErrorMessageKeys", []string{})
+	maxLevel := config.GetInt("Reporting.ErrorDetail.MaxLevel", 2)
+	defaultErrorMessageKeys = append(defaultErrorMessageKeys, errMsgKeys...)
+	extractor := &ExtractorT{
+		ErrorMessageKeys: defaultErrorMessageKeys,
+		MaxLevel:         maxLevel,
+	}
+	extractor.BuildMessageKeysPermutations()
+	return extractor
+}
+
+func generateCombinations(symbols []string, res []string, prefix string, level int) []string {
+	if level <= 0 {
+		// fmt.Printf("Prefix:%s\n", prefix)
+		res = append(res, prefix)
+		return res
+	}
+	// var combinedStr string
+	for _, sym := range symbols {
+		newPrefix := fmt.Sprintf("%s%s", prefix, sym)
+		// fmt.Printf("NewPrefix:%s\n", newPrefix)
+		res = generateCombinations(symbols, res, newPrefix, level-1)
+	}
+
+	// return strings.Join(strings.Split(combinedStr, ""), ".")
+	return res
+}
+
+// This function is to be executed only once
+// as these keys will be same across destinations
+func (t *ExtractorT) BuildMessageKeysPermutations() {
+
+	var level int
+	// sts := []string{"", objectKeyWildcard, arrayWildcard}
+
+	results := []string{}
+	for level <= t.MaxLevel {
+		results = append(results, generateCombinations([]string{objectKeyWildcard, arrayWildcard}, []string{}, "", level)...)
+		// sts = append(sts, combinations)
+		level++
+	}
+
+	correctedCombinations := []string{}
+	for _, comb := range results {
+		correctedCombinations = append(correctedCombinations, strings.Join(strings.Split(comb, ""), "."))
+	}
+
+	wildcardKeys := []string{}
+
+	for _, probableKey := range t.ErrorMessageKeys {
+		for _, comb := range correctedCombinations {
+			if len(comb) == 0 {
+				wildcardKeys = append(wildcardKeys, probableKey)
+				continue
+			}
+			wildcardKeys = append(wildcardKeys, fmt.Sprintf("%s.%s", comb, probableKey))
+		}
+	}
+
+	// We want to check the same combinations in transformer proxy destination's response
+	// proxy return `{message: "", destinationResponse: "{}", ...}`
+	// destinationResponse in returned response, contains the raw destination response
+	// Preference given destinationResponse.* than any other probable error message keys
+	destRespIncludedWildcardKeys := []string{}
+	for _, wildCardKey := range wildcardKeys {
+		destRespWildcardKey := fmt.Sprintf("%s.%s", destinationResponse, wildCardKey)
+		destRespIncludedWildcardKeys = append(destRespIncludedWildcardKeys, destRespWildcardKey)
+	}
+	destRespIncludedWildcardKeys = append(destRespIncludedWildcardKeys, wildcardKeys...)
+
+	t.WildcardKeys = destRespIncludedWildcardKeys
+}
+
+func (t *ExtractorT) GetErrorMessageFromResponse(response string) string {
+	if len(t.WildcardKeys) == 0 {
+		panic(fmt.Errorf("BuildMessageKeysPermutations method has to be executed before we can execute any methods"))
+	}
+	// For now we will be getting error message
+
+	// invalid json string case
+	if !gjson.Valid(response) {
+		return response
+	}
+	probableKeyList := []string{"response", "response.error", "response.message"}
+	probableKeyList = append(probableKeyList, t.WildcardKeys...)
+
+	prelimResults := gjson.GetMany(response, probableKeyList...)
+	for _, prelimResult := range prelimResults {
+		if prelimResult.Exists() {
+
+			switch prelimResult.Type {
+			case gjson.String:
+				return prelimResult.String()
+			case gjson.JSON:
+				if prelimResult.IsArray() {
+					// returning the first result
+					arr := prelimResult.Array()
+					if len(arr) == 0 {
+						continue
+					}
+					// if there are multiple error strings inside
+					return t.GetErrorMessageFromResponse(prelimResult.Array()[0].String())
+				}
+				if prelimResult.IsObject() {
+					return t.GetErrorMessageFromResponse(prelimResult.String())
+				}
+			}
+
+		}
+	}
+
+	return ""
+}

--- a/enterprise/reporting/error-detail-extractor.go
+++ b/enterprise/reporting/error-detail-extractor.go
@@ -22,15 +22,14 @@ const (
 )
 
 var (
-	urlRegex     = regexp.MustCompile(`\b((?:https?://|www\.)\S+)\b`)
-	ipRegex      = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}\b`)
-	emailRegex   = regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`)
-	notWordRegex = regexp.MustCompile(`\W+`)
-	// idRegex      = regexp.MustCompile(`\b(?=\w*\d)[\w-]+\b`)
-	idRegex = regexp.MustCompile(`\b([a-zA-Z0-9-]*\d[a-zA-Z0-9-]*)\b`)
-	sRegex  = regexp.MustCompile(`\s+`)
+	urlRegex         = regexp.MustCompile(`\b((?:https?://|www\.)\S+)\b`)
+	ipRegex          = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}\b`)
+	emailRegex       = regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`)
+	notWordRegex     = regexp.MustCompile(`\W+`)
+	idRegex          = regexp.MustCompile(`\b([a-zA-Z0-9-]*\d[a-zA-Z0-9-]*)\b`)
+	sRegex           = regexp.MustCompile(`\s+`)
+	WhitespacesRegex = regexp.MustCompile("[ \t\n\r]*") // used in checking if string is a valid json to remove extra-spaces
 
-	WhitespacesRegex          = regexp.MustCompile("[ \t\n\r]*") // used in checking if string is a valid json to remove extra-spaces
 	defaultErrorMessageKeys   = []string{"message", "description", "detail", "title", "error", "error_message"}
 	defaultWhErrorMessageKeys = []string{"internal_processing_failed", "fetching_remote_schema_failed", "exporting_data_failed"}
 )
@@ -83,19 +82,15 @@ func unmarshalJsonToMap(jsonStr string, logger *logger.Logger) map[string]interf
 }
 
 func (ext *ExtractorT) getJsonResponse(sampleResponse string) string {
-	// json_response
-	// parses the []byte json
 	if !IsJSON(sampleResponse) {
 		return sampleResponse
 	}
-	// if sampleResponse is indeed json
 	sampleResp := gjson.Parse(sampleResponse)
 	respRes := gjson.GetBytes([]byte(sampleResp.String()), responseKey)
 	if respRes.Exists() && IsJSON(respRes.Str) {
 		var j json.RawMessage
 		e := json.Unmarshal([]byte(respRes.String()), &j)
 		if e != nil {
-			// panic(e)
 			ext.log.Errorf("(GetJsonResponse)UnmarshalErr: %v\tResponse:%v\n", e, respRes.String())
 			return respRes.String()
 		}
@@ -243,7 +238,6 @@ func getErrorMessageFromResponse(resp map[string]interface{}, messageKeys []stri
 		}
 		return strings.Join(s, ".")
 	}
-	// split the error message by newline and take the first entry
 
 	return ""
 }

--- a/enterprise/reporting/error-detail-extractor.go
+++ b/enterprise/reporting/error-detail-extractor.go
@@ -68,23 +68,17 @@ func (ext *ExtractorT) getSimpleMessage(jsonStr string) string {
 		return jsonStr
 	}
 
-	var jsonI interface{}
-	er := json.Unmarshal([]byte(jsonStr), &jsonI)
+	var jsonMap map[string]interface{}
+	er := json.Unmarshal([]byte(jsonStr), &jsonMap)
 	if er != nil {
 		ext.log.Debugf("%v is not a unmarshallable into interface{}", jsonStr)
-		return jsonStr
-	}
-
-	jsonMap, isJsonMap := jsonI.(map[string]interface{})
-	if !isJsonMap {
-		ext.log.Debugf("%v is not a json map", jsonI)
 		return jsonStr
 	}
 
 	for key, erRes := range jsonMap {
 		erResStr, isString := erRes.(string)
 		if !isString {
-			ext.log.Errorf("Type-assertion failed for %v with value %v: not a string", key, erRes)
+			ext.log.Debugf("Type-assertion failed for %v with value %v: not a string", key, erRes)
 		}
 		switch key {
 		case "reason":

--- a/enterprise/reporting/error-detail-extractor.go
+++ b/enterprise/reporting/error-detail-extractor.go
@@ -85,8 +85,8 @@ func (ext *ExtractorT) getJsonResponse(sampleResponse string) string {
 	if !IsJSON(sampleResponse) {
 		return sampleResponse
 	}
-	sampleResp := gjson.Parse(sampleResponse)
-	respRes := gjson.GetBytes([]byte(sampleResp.String()), responseKey)
+	sampleRespResult := gjson.Parse(sampleResponse)
+	respRes := gjson.GetBytes([]byte(sampleRespResult.String()), responseKey)
 	if respRes.Exists() && IsJSON(respRes.Str) {
 		var j json.RawMessage
 		e := json.Unmarshal([]byte(respRes.String()), &j)
@@ -94,7 +94,7 @@ func (ext *ExtractorT) getJsonResponse(sampleResponse string) string {
 			ext.log.Errorf("(GetJsonResponse)UnmarshalErr: %v\tResponse:%v\n", e, respRes.String())
 			return respRes.String()
 		}
-		byteArr, setErr := sjson.SetBytes([]byte(sampleResp.String()), responseKey, string(j))
+		byteArr, setErr := sjson.SetBytes([]byte(sampleRespResult.String()), responseKey, string(j))
 		if setErr != nil {
 			ext.log.Errorf("SetBytesError: %v\tWill return empty string as error response\n", setErr)
 			return ""
@@ -102,7 +102,7 @@ func (ext *ExtractorT) getJsonResponse(sampleResponse string) string {
 		return string(byteArr)
 	}
 
-	return sampleResp.String()
+	return sampleRespResult.String()
 }
 
 func (ext *ExtractorT) getSimpleMessage(jsonStr string) string {
@@ -260,15 +260,15 @@ func getErrorFromWarehouse(resp map[string]interface{}) string {
 }
 
 func IsJSON(s string) bool {
-	parsedBytes := gjson.ParseBytes([]byte(s))
+	parsedBytesResult := gjson.ParseBytes([]byte(s))
 
-	s = string(WhitespacesRegex.ReplaceAllLiteral([]byte(parsedBytes.String()), []byte("")))
+	s = string(WhitespacesRegex.ReplaceAllLiteral([]byte(parsedBytesResult.String()), []byte("")))
 	var isEndingFlowerBrace, isEndingArrBrace bool
 	if len(s) > 0 {
 		isEndingFlowerBrace = s[len(s)-1] == '}'
 		isEndingArrBrace = s[len(s)-1] == ']'
 	}
-	return ((parsedBytes.IsObject() && isEndingFlowerBrace) || (parsedBytes.IsArray() && isEndingArrBrace))
+	return ((parsedBytesResult.IsObject() && isEndingFlowerBrace) || (parsedBytesResult.IsArray() && isEndingArrBrace))
 }
 
 func (ext *ExtractorT) CleanUpErrorMessage(errMsg string) string {

--- a/enterprise/reporting/error-detail-extractor.go
+++ b/enterprise/reporting/error-detail-extractor.go
@@ -2,11 +2,15 @@ package reporting
 
 import (
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/samber/lo"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 const (
@@ -21,31 +25,142 @@ var (
 	numRegex   = regexp.MustCompile(`\d+`)
 	// notWordRegex = regexp.MustCompile(`\W+`)
 	// idRegex                 = regexp.MustCompile(`\b(?\=\w*\d)[\w-]+\b`)
-	defaultErrorMessageKeys = []string{"message", "description", "detail", "title", "Error", "error", "error_message"}
+
+	WhitespacesRegex          = regexp.MustCompile("[ \t\n\r]*") // used in checking if string is a valid json to remove extra-spaces
+	defaultErrorMessageKeys   = []string{"message", "description", "detail", "title", "error", "error_message"}
+	defaultWhErrorMessageKeys = []string{"internal_processing_failed", "fetching_remote_schema_failed", "exporting_data_failed"}
 )
 
 type ExtractorT struct {
-	log              logger.Logger
-	ErrorMessageKeys []string // the keys where in we may have error message
+	log                logger.Logger
+	ErrorMessageKeys   []string // the keys where in we may have error message
+	WhErrorMessageKeys []string // the keys where in we may have error message for warehouse destinations
 }
 
 func NewErrorDetailExtractor(log logger.Logger) *ExtractorT {
 	errMsgKeys := config.GetStringSlice("Reporting.ErrorDetail.ErrorMessageKeys", []string{})
+	whErrMsgKeys := config.GetStringSlice("Reporting.ErrorDetail.WhErrorMessageKeys", []string{})
+	// adding to default message keys
 	defaultErrorMessageKeys = append(defaultErrorMessageKeys, errMsgKeys...)
+	defaultWhErrorMessageKeys = append(defaultWhErrorMessageKeys, whErrMsgKeys...)
+
 	extractor := &ExtractorT{
-		ErrorMessageKeys: defaultErrorMessageKeys,
-		log:              log.Child("ErrorDetailExtractor"),
+		ErrorMessageKeys:   defaultErrorMessageKeys,
+		WhErrorMessageKeys: defaultWhErrorMessageKeys,
+		log:                log.Child("ErrorDetailExtractor"),
 	}
 	return extractor
 }
 
 // Functions used for error message extraction -- STARTS
-func isMapOrArray(value interface{}) bool {
+func checkForGoMapOrList(value interface{}) bool {
 	switch value.(type) {
 	case map[string]interface{}, []interface{}:
 		return true
 	}
 	return false
+}
+
+func unmarshalJsonToMap(jsonStr string, logger *logger.Logger) map[string]interface{} {
+	var j map[string]interface{}
+	err := json.Unmarshal([]byte(jsonStr), &j)
+	if err != nil {
+		errStr := fmt.Sprintf("Unmarshal Err: %v\nJsonStr:%v\n", err, jsonStr)
+		// For proper logging
+		if logger != nil {
+			(*logger).Errorf(errStr)
+		} else {
+			fmt.Println(errStr)
+		}
+
+		return nil
+	}
+	return j
+}
+
+func (ext *ExtractorT) getJsonResponse(sampleResponse string) string {
+	// json_response
+	// parses the []byte json
+	if !IsJSON(sampleResponse) {
+		return sampleResponse
+	}
+	// if sampleResponse is indeed json
+	sampleResp := gjson.Parse(sampleResponse)
+	respRes := gjson.GetBytes([]byte(sampleResp.String()), "response")
+	if respRes.Exists() && IsJSON(respRes.Str) {
+		var j json.RawMessage
+		e := json.Unmarshal([]byte(respRes.String()), &j)
+		if e != nil {
+			// panic(e)
+			ext.log.Errorf("(GetJsonResponse)UnmarshalErr: %v\tResponse:%v\n", e, respRes.String())
+			return respRes.String()
+		}
+		byteArr, setErr := sjson.SetBytes([]byte(sampleResp.String()), "response", string(j))
+		if setErr != nil {
+			ext.log.Errorf("SetBytesError: %v\tWill return empty string as error response\n", setErr)
+			return ""
+		}
+		return string(byteArr)
+	}
+
+	return sampleResp.String()
+}
+
+func (ext *ExtractorT) getSimpleMessage(jsonStr string) string {
+	if !IsJSON(jsonStr) {
+		return jsonStr
+	}
+	error_reason_result := gjson.GetMany(jsonStr, "reason", "Error", "response")
+	for _, erRes := range error_reason_result {
+		if erRes.Exists() {
+			erResStr := erRes.String()
+			switch erRes.Path(jsonStr) {
+			case "reason":
+				return erResStr
+			case "Error":
+				if !IsJSON(erResStr) {
+					return strings.Split(erResStr, "\n")[0]
+				}
+				return ""
+			case "response":
+				if len(erResStr) == 0 {
+					return "EMPTY"
+				}
+				if !IsJSON(erResStr) {
+					return erResStr
+				}
+
+				// recursively search for common error message patterns
+				j := unmarshalJsonToMap(erResStr, &ext.log)
+				if j == nil {
+					return ""
+				}
+				return getErrorMessageFromResponse(j, ext.ErrorMessageKeys)
+			}
+		}
+	}
+
+	// For warehouse related errors
+	whJson := unmarshalJsonToMap(jsonStr, &ext.log)
+	if whJson == nil {
+		return jsonStr
+	}
+	for _, whKey := range ext.WhErrorMessageKeys {
+		if val, ok := whJson[whKey]; ok {
+			valAsMap, isMap := val.(map[string]interface{})
+			if !isMap {
+				ext.log.Debugf("Failed while type asserting to map[string]interface{} warehouse error with whKey:%s", whKey)
+				return ""
+			}
+			return getErrorFromWarehouse(valAsMap)
+		}
+	}
+	return ""
+}
+
+func (ext *ExtractorT) GetErrorMessage(sampleResponse string) string {
+	jsonResp := ext.getJsonResponse(sampleResponse)
+	return ext.getSimpleMessage(jsonResp)
 }
 
 func findKeys(keys []string, jsonObj interface{}) map[string]interface{} {
@@ -54,42 +169,44 @@ func findKeys(keys []string, jsonObj interface{}) map[string]interface{} {
 		return values
 	}
 	// recursively search for keys in nested JSON objects
-	switch jsonObject := jsonObj.(type) {
-	case map[string]interface{}: // if jsonObj is a map
-		for _, key := range keys {
-			if value, ok := jsonObject[key]; ok && value != nil {
-				values[key] = value
+	if checkForGoMapOrList(jsonObj) {
+		switch jsonObj := jsonObj.(type) {
+		case map[string]interface{}: // if jsonObj is a map
+			for _, key := range keys {
+				if value, ok := jsonObj[key]; ok && value != nil {
+					values[key] = value
+				}
+			}
+			for _, value := range jsonObj {
+				subResults := findKeys(keys, value)
+				for k, v := range subResults {
+					values[k] = v
+				}
+			}
+		case []interface{}: // if jsonObj is a slice
+			for _, item := range jsonObj {
+				subResults := findKeys(keys, item)
+				for k, v := range subResults {
+					values[k] = v
+				}
 			}
 		}
-		for _, value := range jsonObject {
-			subResults := findKeys(keys, value)
-			for k, v := range subResults {
-				values[k] = v
-			}
-		}
-	case []interface{}: // if jsonObj is a slice
-		for _, item := range jsonObject {
-			subResults := findKeys(keys, item)
-			for k, v := range subResults {
-				values[k] = v
-			}
-		}
+		return values // return the map of keys and values
 	}
 	// if jsonObj is not a map or slice, return an empty map
-	return values // return the map of keys and values
+	return values
 }
 
 // This function takes a list of keys and a JSON object as input, and returns the value of the first key that exists in the JSON object.
 func findFirstExistingKey(keys []string, jsonObj interface{}) interface{} {
 	keyValues := findKeys(keys, jsonObj)
 	result := getValue(keys, keyValues)
-	if isMapOrArray(result) {
+	if checkForGoMapOrList(result) {
 		return findFirstExistingKey(keys, result)
 	}
 	return result
 }
 
-// get value
 func getValue(keys []string, jsonObj map[string]interface{}) interface{} {
 	for _, key := range keys {
 		if value, ok := jsonObj[key]; ok && value != nil {
@@ -99,53 +216,61 @@ func getValue(keys []string, jsonObj map[string]interface{}) interface{} {
 	return nil
 }
 
-// Functions used for error message extraction -- ENDS
-
-func (ext *ExtractorT) getErrorMessageFromResponse(resp map[string]interface{}) string {
+func getErrorMessageFromResponse(resp map[string]interface{}, messageKeys []string) string {
 	if _, ok := resp["msg"]; ok {
 		return resp["msg"].(string)
 	}
 
-	// warehouseKeys := []string{"internal_processing_failed", "fetching_remote_schema_failed", "exporting_data_failed"}
-
-	if destinationResponse, ok := resp[destinationResponseKey].(map[string]interface{}); ok {
-		if result := findFirstExistingKey(ext.ErrorMessageKeys, destinationResponse); result != nil {
+	if destinationResponse, ok := resp["destinationResponse"].(map[string]interface{}); ok {
+		if result := findFirstExistingKey(messageKeys, destinationResponse); result != nil {
 			return result.(string)
 		}
 	}
-	if message := findFirstExistingKey(ext.ErrorMessageKeys, resp); message != nil {
+	if message := findFirstExistingKey(messageKeys, resp); message != nil {
 		if s, ok := message.(string); ok {
 			return s
 		}
 	}
 
-	if errors, ok := getValue([]string{errorsKey}, findKeys([]string{errorsKey}, resp)).([]interface{}); ok && len(errors) > 0 {
-		if message := findFirstExistingKey(ext.ErrorMessageKeys, resp); message != nil {
-			if s, ok := message.(string); ok {
-				return s
-			}
+	if errors, ok := getValue([]string{"errors"}, findKeys([]string{"errors"}, resp)).([]interface{}); ok && len(errors) > 0 {
+		s := make([]string, len(errors))
+		for i, v := range errors {
+			s[i] = fmt.Sprint(v)
 		}
+		return strings.Join(s, ".")
 	}
 	// split the error message by newline and take the first entry
-
-	// for _, whKey := range warehouseKeys {
-	//  if val, ok := row["json"].(map[string]interface{})[whKey]; ok {
-	//      return getErrorFromWarehouse(val)
-	//  }
-	// }
 
 	return ""
 }
 
-func (ext *ExtractorT) GetErrorMessage(jsonObject string) string {
-	var m map[string]interface{}
-	e := json.Unmarshal([]byte(jsonObject), &m)
-	if e != nil {
-		ext.log.Errorf("Problem in unmarshalling: %v", e)
-		// TODO: Check with team if this is desirable
-		return jsonObject
+func getErrorFromWarehouse(resp map[string]interface{}) string {
+	errorsI, ok := resp["errors"]
+	if !ok {
+		return ""
 	}
-	return ext.getErrorMessageFromResponse(m)
+	arrOfErrs, isIntfArr := errorsI.([]interface{})
+	if !isIntfArr {
+		return ""
+	}
+	errors := lo.Uniq(arrOfErrs)
+	errorStrings := make([]string, len(errors))
+	for i, v := range errors {
+		errorStrings[i] = fmt.Sprint(v)
+	}
+	return strings.Join(errorStrings, ".")
+}
+
+func IsJSON(s string) bool {
+	parsedBytes := gjson.ParseBytes([]byte(s))
+
+	s = string(WhitespacesRegex.ReplaceAllLiteral([]byte(parsedBytes.String()), []byte("")))
+	var isEndingFlowerBrace, isEndingArrBrace bool
+	if len(s) > 0 {
+		isEndingFlowerBrace = s[len(s)-1] == '}'
+		isEndingArrBrace = s[len(s)-1] == ']'
+	}
+	return ((parsedBytes.IsObject() && isEndingFlowerBrace) || (parsedBytes.IsArray() && isEndingArrBrace))
 }
 
 func (ext *ExtractorT) CleanUpErrorMessage(errMsg string) string {

--- a/enterprise/reporting/error-detail-extractor.go
+++ b/enterprise/reporting/error-detail-extractor.go
@@ -2,6 +2,8 @@ package reporting
 
 import (
 	"encoding/json"
+	"regexp"
+	"strings"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -12,7 +14,15 @@ const (
 	errorsKey              = "errors"
 )
 
-var defaultErrorMessageKeys = []string{"message", "description", "detail", "title", "Error", "error", "error_message"}
+var (
+	urlRegex   = regexp.MustCompile(`\b((?:https?://|www\.)\S+)\b`)
+	ipRegex    = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}\b`)
+	emailRegex = regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`)
+	numRegex   = regexp.MustCompile(`\d+`)
+	// notWordRegex = regexp.MustCompile(`\W+`)
+	// idRegex                 = regexp.MustCompile(`\b(?\=\w*\d)[\w-]+\b`)
+	defaultErrorMessageKeys = []string{"message", "description", "detail", "title", "Error", "error", "error_message"}
+)
 
 type ExtractorT struct {
 	log              logger.Logger
@@ -136,4 +146,15 @@ func (ext *ExtractorT) GetErrorMessage(jsonObject string) string {
 		return jsonObject
 	}
 	return ext.getErrorMessageFromResponse(m)
+}
+
+func (ext *ExtractorT) CleanUpErrorMessage(errMsg string) string {
+	replacedStr := urlRegex.ReplaceAllString(errMsg, "")
+	replacedStr = ipRegex.ReplaceAllString(replacedStr, "")
+	replacedStr = emailRegex.ReplaceAllString(replacedStr, "")
+	replacedStr = numRegex.ReplaceAllString(replacedStr, "")
+	// replacedStr = notWordRegex.ReplaceAllString(replacedStr, "")
+	// replacedStr = idRegex.ReplaceAllString(replacedStr, "")
+
+	return strings.TrimSpace(replacedStr)
 }

--- a/enterprise/reporting/error-detail-extractor.go
+++ b/enterprise/reporting/error-detail-extractor.go
@@ -173,7 +173,7 @@ func getErrorMessageFromResponse(resp interface{}, messageKeys []string) string 
 	var respMap map[string]interface{}
 	respMap, isMap := resp.(map[string]interface{})
 
-	var getMessage = func(msgKeys []string, response interface{}) string {
+	getMessage := func(msgKeys []string, response interface{}) string {
 		if result := findFirstExistingKey(msgKeys, response); result != nil {
 			if s, ok := result.(string); ok {
 				return s

--- a/enterprise/reporting/error-detail-extractor.go
+++ b/enterprise/reporting/error-detail-extractor.go
@@ -15,18 +15,20 @@ import (
 
 const (
 	responseKey = "response"
+	spaceStr    = " "
 
 	destinationResponseKey = "destinationResponse"
 	errorsKey              = "errors"
 )
 
 var (
-	urlRegex   = regexp.MustCompile(`\b((?:https?://|www\.)\S+)\b`)
-	ipRegex    = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}\b`)
-	emailRegex = regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`)
-	numRegex   = regexp.MustCompile(`\d+`)
-	// notWordRegex = regexp.MustCompile(`\W+`)
-	// idRegex                 = regexp.MustCompile(`\b(?\=\w*\d)[\w-]+\b`)
+	urlRegex     = regexp.MustCompile(`\b((?:https?://|www\.)\S+)\b`)
+	ipRegex      = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}\b`)
+	emailRegex   = regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`)
+	notWordRegex = regexp.MustCompile(`\W+`)
+	// idRegex      = regexp.MustCompile(`\b(?=\w*\d)[\w-]+\b`)
+	idRegex = regexp.MustCompile(`\b([a-zA-Z0-9-]*\d[a-zA-Z0-9-]*)\b`)
+	sRegex  = regexp.MustCompile(`\s+`)
 
 	WhitespacesRegex          = regexp.MustCompile("[ \t\n\r]*") // used in checking if string is a valid json to remove extra-spaces
 	defaultErrorMessageKeys   = []string{"message", "description", "detail", "title", "error", "error_message"}
@@ -276,12 +278,13 @@ func IsJSON(s string) bool {
 }
 
 func (ext *ExtractorT) CleanUpErrorMessage(errMsg string) string {
-	replacedStr := urlRegex.ReplaceAllString(errMsg, "")
-	replacedStr = ipRegex.ReplaceAllString(replacedStr, "")
-	replacedStr = emailRegex.ReplaceAllString(replacedStr, "")
-	replacedStr = numRegex.ReplaceAllString(replacedStr, "")
-	// replacedStr = notWordRegex.ReplaceAllString(replacedStr, "")
-	// replacedStr = idRegex.ReplaceAllString(replacedStr, "")
+	var regexdMsg string
+	regexdMsg = urlRegex.ReplaceAllLiteralString(errMsg, spaceStr)
+	regexdMsg = ipRegex.ReplaceAllLiteralString(regexdMsg, spaceStr)
+	regexdMsg = emailRegex.ReplaceAllLiteralString(regexdMsg, spaceStr)
+	regexdMsg = notWordRegex.ReplaceAllLiteralString(regexdMsg, spaceStr)
+	regexdMsg = idRegex.ReplaceAllLiteralString(regexdMsg, spaceStr)
+	regexdMsg = sRegex.ReplaceAllLiteralString(regexdMsg, spaceStr)
 
-	return strings.TrimSpace(replacedStr)
+	return regexdMsg
 }

--- a/enterprise/reporting/error_detail_reporting.go
+++ b/enterprise/reporting/error_detail_reporting.go
@@ -92,12 +92,13 @@ func NewEdReporterFromEnvConfig() *ErrorDetailReporter {
 	config.RegisterDurationConfigVariable(30, &sleepInterval, true, time.Second, "Reporting.sleepInterval")
 	config.RegisterIntConfigVariable(32, &maxConcurrentRequests, true, 1, "Reporting.maxConcurrentRequests")
 
-	extractor := NewErrorDetailExtractor()
+	log := logger.NewLogger().Child("enterprise").Child("error-detail-reporting")
+	extractor := NewErrorDetailExtractor(log)
 
 	return &ErrorDetailReporter{
 		reportingServiceURL:   reportingServiceURL,
 		Table:                 ErrorDetailReportsTable,
-		log:                   logger.NewLogger().Child("enterprise").Child("error-detail-reporting"),
+		log:                   log,
 		sleepInterval:         sleepInterval,
 		mainLoopSleepInterval: mainLoopSleepInterval,
 		maxConcurrentRequests: maxConcurrentRequests,
@@ -278,7 +279,7 @@ func (edRep *ErrorDetailReporter) getWorkspaceID(sourceID string) string {
 func (edRep *ErrorDetailReporter) extractErrorDetails(sampleResponse string) errorDetails {
 	// TODO: to extract information
 	return errorDetails{
-		ErrorMessage: edRep.errorDetailExtractor.GetErrorMessageFromResponse(sampleResponse),
+		ErrorMessage: edRep.errorDetailExtractor.GetErrorMessage(sampleResponse),
 	}
 }
 

--- a/enterprise/reporting/error_detail_reporting.go
+++ b/enterprise/reporting/error_detail_reporting.go
@@ -84,7 +84,7 @@ func NewEdReporterFromEnvConfig() *ErrorDetailReporter {
 	var sleepInterval, mainLoopSleepInterval time.Duration
 	var maxConcurrentRequests int
 	tr := &http.Transport{}
-	reportingServiceURL := config.GetString("REPORTING_URL", "https://reporting.rudderstack.com/")
+	reportingServiceURL := config.GetString("REPORTING_URL", "https://reporting.dev.rudderlabs.com")
 	reportingServiceURL = strings.TrimSuffix(reportingServiceURL, "/")
 
 	netClient := &http.Client{Transport: tr, Timeout: config.GetDuration("HttpClient.reporting.timeout", 60, time.Second)}
@@ -538,6 +538,7 @@ func (edRep *ErrorDetailReporter) sendMetric(ctx context.Context, clientName str
 
 		defer func() { httputil.CloseResponse(resp) }()
 		respBody, err := io.ReadAll(resp.Body)
+		edRep.log.Debugf("[ErrorDetailReporting]Response from ReportingAPI: %v\n", string(respBody))
 		if err != nil {
 			edRep.log.Error(err.Error())
 			return err
@@ -545,6 +546,7 @@ func (edRep *ErrorDetailReporter) sendMetric(ctx context.Context, clientName str
 
 		if !isMetricPosted(resp.StatusCode) {
 			err = fmt.Errorf(`received response: statusCode:%d error:%v`, resp.StatusCode, string(respBody))
+			edRep.log.Error(err.Error())
 		}
 		return err
 	}

--- a/enterprise/reporting/error_detail_reporting.go
+++ b/enterprise/reporting/error_detail_reporting.go
@@ -199,11 +199,6 @@ func (edRep *ErrorDetailReporter) Report(metrics []*types.PUReportedMetric, txn 
 		workspaceID := edRep.getWorkspaceID(metric.ConnectionDetails.SourceID)
 		metric := *metric
 
-		// TODO: Think through with team on if PII exclusion is required
-		// if edRep.IsPIIReportingDisabled(workspaceID) {
-		// 	metric = transformMetricForPII(metric, getPIIColumnsToExclude())
-		// }
-
 		// extract error-message & error-code
 		errDets := edRep.extractErrorDetails(metric.StatusDetail.SampleResponse)
 		_, err = stmt.Exec(
@@ -277,7 +272,6 @@ func (edRep *ErrorDetailReporter) getWorkspaceID(sourceID string) string {
 }
 
 func (edRep *ErrorDetailReporter) extractErrorDetails(sampleResponse string) errorDetails {
-	// TODO: to extract information
 	errMsg := edRep.errorDetailExtractor.GetErrorMessage(sampleResponse)
 	cleanedErrMsg := edRep.errorDetailExtractor.CleanUpErrorMessage(errMsg)
 	return errorDetails{

--- a/enterprise/reporting/error_detail_reporting.go
+++ b/enterprise/reporting/error_detail_reporting.go
@@ -278,8 +278,10 @@ func (edRep *ErrorDetailReporter) getWorkspaceID(sourceID string) string {
 
 func (edRep *ErrorDetailReporter) extractErrorDetails(sampleResponse string) errorDetails {
 	// TODO: to extract information
+	errMsg := edRep.errorDetailExtractor.GetErrorMessage(sampleResponse)
+	cleanedErrMsg := edRep.errorDetailExtractor.CleanUpErrorMessage(errMsg)
 	return errorDetails{
-		ErrorMessage: edRep.errorDetailExtractor.GetErrorMessage(sampleResponse),
+		ErrorMessage: cleanedErrMsg,
 	}
 }
 

--- a/enterprise/reporting/reporting_test.go
+++ b/enterprise/reporting/reporting_test.go
@@ -2,6 +2,7 @@ package reporting
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -13,6 +14,8 @@ import (
 	mock_backendconfig "github.com/rudderlabs/rudder-server/mocks/backend-config"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 	"github.com/rudderlabs/rudder-server/utils/types"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 var _ = Describe("Reporting", func() {
@@ -286,4 +289,54 @@ func TestReportingBasedOnConfigBackend(t *testing.T) {
 
 	reportingSettings.Wait()
 	Expect(reportingDisabled).To(BeTrue())
+}
+
+var jsonBenchCases = []string{
+	`{"message": "message-1"}`,
+	`{ "a" : { "b": { "message": "messge-2" }}}`,
+	`[{ "a" : { "b": { "message": "messge-2-0" }}}, { "a" : { "b": { "message": "messge-2-1" }}}]`,
+	`{"errors": [{"error": { "message": "message-4-1" }}, {"error": { "message": "message-4-2" }} ]}`,
+	`{"errors": [{"message": { "error" : "message-5-0" } }, {"message": { "error" : "message-5-1" } }]}`,
+}
+
+func TestGetErrorMessageFromResponse(t *testing.T) {
+	extractor := NewErrorDetailExtractor()
+
+	t.Run("should contain *.#.*.message", func(t *testing.T) {
+		require.Contains(t, extractor.WildcardKeys, "*.#.*.message")
+		require.Contains(t, extractor.WildcardKeys, "#.*.*.message")
+	})
+	t.Run("should contain #.*.*.message", func(t *testing.T) {
+		require.Contains(t, extractor.WildcardKeys, "#.*.*.message")
+	})
+	expectedVals := []string{
+		"message-1", "messge-2", "messge-2-0",
+		"message-4-1", "message-5-0",
+	}
+	for i, response := range jsonBenchCases {
+		t.Run(fmt.Sprintf("case for payload-%d", i), func(t *testing.T) {
+			require.Equal(t, extractor.GetErrorMessageFromResponse(response), expectedVals[i])
+		})
+	}
+	t.Run("check outputs from gjson", func(t *testing.T) {
+		caseStr := `[{ "a" : { "b": { "message": "messge-2-0" }}}, { "a" : { "b": { "message": "messge-2-1" }}}]`
+		results := gjson.GetMany(caseStr, WildcardKeys...)
+		for _, res := range results {
+			l := len(res.Array())
+			if res.Exists() && l > 0 {
+				require.Equal(t, res.Path(caseStr), "#.*.*.message")
+				require.EqualValues(t, res.Array(), []string{"messge-2-0", "messge-2-1"})
+			}
+		}
+	})
+}
+
+func BenchmarkJsonNestedSearch(b *testing.B) {
+	extractor := NewErrorDetailExtractor()
+
+	b.Run("Gjson used fn", func(b *testing.B) {
+		for i := 0; i < len(jsonBenchCases); i++ {
+			extractor.GetErrorMessageFromResponse(jsonBenchCases[i])
+		}
+	})
 }

--- a/enterprise/reporting/reporting_test.go
+++ b/enterprise/reporting/reporting_test.go
@@ -290,26 +290,128 @@ func TestReportingBasedOnConfigBackend(t *testing.T) {
 	Expect(reportingDisabled).To(BeTrue())
 }
 
-var jsonBenchCases = []string{
-	`{"message": "message-1"}`,
-	`{ "a" : { "b": { "message": "messge-2" }}}`,
-	// `[{ "a" : { "b": { "message": "messge-2-0" }}}, { "a" : { "b": { "message": "messge-2-1" }}}]`,
-	`{"errors": [{"error": { "message": "message-4-1" }}, {"error": { "message": "message-4-2" }} ]}`,
-	`{"errors": [{"message": { "error" : "message-5-0" } }, {"message": { "error" : "message-5-1" } }]}`,
+type getValTc struct {
+	inputStr string
+	expected string
+}
+
+var tcs = []getValTc{
+	{
+		inputStr: `{"response":"{\"message\":\"Primary key 'Contact Key' does not exist.\",\"errorcode\":10000,\"documentation\":\"\"}"}`,
+		expected: "Primary key 'Contact Key' does not exist.",
+	},
+	{
+		inputStr: `{"response":"Event Edit_Order_Button_Clicked doesn't match with Snapchat Events!","firstAttemptedAt":"2023-03-30T16:58:05.628Z","content-type":"application/json"}`,
+		expected: "Event Edit_Order_Button_Clicked doesn't match with Snapchat Events!",
+	},
+	{
+		inputStr: `{"response":"{\"status\":400,\"message\":\"Failed with Unsupported post request. Object with ID '669556453669016' does not exist, cannot be loaded due to missing permissions, or does not support this operation. Please read the Graph API documentation at https://developers.facebook.com/docs/graph-api during response transformation\",\"destinationResponse\":{\"error\":{\"message\":\"Unsupported post request. Object with ID '669556453669016' does not exist, cannot be loaded due to missing permissions, or does not support this operation. Please read the Graph API documentation at https://developers.facebook.com/docs/graph-api\",\"type\":\"GraphMethodException\",\"code\":100,\"error_subcode\":33,\"fbtrace_id\":\"AAjsXHCiypjAV50Vg-dZx4D\"},\"status\":400},\"statTags\":{\"errorCategory\":\"network\",\"errorType\":\"aborted\",\"destType\":\"FACEBOOK_PIXEL\",\"module\":\"destination\",\"implementation\":\"native\",\"feature\":\"dataDelivery\",\"destinationId\":\"2EXmEugZiMykYfFzoPnXjq6bJ6D\",\"workspaceId\":\"1vTJeDNwZx4bJF7c5ZUWPqJpMVx\",\"context\":\"[Native Integration Service] Failure During Processor Transform\"}}","firstAttemptedAt":"2023-03-30T17:39:17.638Z","content-type":"application/json"}`,
+		expected: "Unsupported post request. Object with ID '669556453669016' does not exist, cannot be loaded due to missing permissions, or does not support this operation. Please read the Graph API documentation at https://developers.facebook.com/docs/graph-api",
+	},
+	{
+		inputStr: `{"response":"{\n  \"meta\": {\n    \"error\": \"Unauthorized request\"\n  }\n}\n","firstAttemptedAt":"2023-03-30T17:39:00.377Z","content-type":"application/json; charset=utf-8"}`,
+		expected: "Unauthorized request",
+	},
+	{
+		inputStr: `TypeError: Cannot set property 'event_name' of undefined`,
+		expected: `TypeError: Cannot set property 'event_name' of undefined`,
+	},
+	{
+		inputStr: `{"response":"{\"code\":400,\"error\":\"Invalid API key: 88ea3fd9e15f74491ac6dd401c8733c9\"}\r\r\r\n","firstAttemptedAt":"2023-03-30T17:39:36.755Z","content-type":"application/json"}`,
+		expected: `Invalid API key: 88ea3fd9e15f74491ac6dd401c8733c9`,
+	},
+	{
+		inputStr: `{"response":"{\"status\":\"error\",\"message\":\"Invalid input JSON on line 1, column 54: Cannot deserialize value of type ` + "`" + `java.lang.String` + "`" + ` from Object value (token ` + "`" + `JsonToken.START_OBJECT` + "`" + `)\",\"correlationId\":\"c73c9759-e9fe-4061-8da6-3d7a10159f54\"}","firstAttemptedAt":"2023-03-30T17:39:12.397Z","content-type":"application/json;charset=utf-8"}`,
+		expected: `Invalid input JSON on line 1, column 54: Cannot deserialize value of type ` + "`" + `java.lang.String` + "`" + ` from Object value (token ` + "`" + `JsonToken.START_OBJECT` + "`" + `)`,
+	},
+	{
+		inputStr: `{"response":"{\"error\":\"Event request failed (Invalid callback parameters)\"}","firstAttemptedAt":"2023-03-30T17:38:36.152Z","content-type":"application/json; charset=utf-8"}`,
+		expected: `Event request failed (Invalid callback parameters)`,
+	},
+	{
+		inputStr: `{"response":"{\"type\":\"error.list\",\"request_id\":\"0000ib5themn9npuifdg\",\"errors\":[{\"code\":\"not_found\",\"message\":\"User Not Found\"}]}","firstAttemptedAt":"2023-03-30T17:38:47.857Z","content-type":"application/json; charset=utf-8"}`,
+		expected: `User Not Found`,
+	},
+	{
+		inputStr: `{"response":"{\"type\":\"error.list\",\"request_id\":\"0000ohm9i1s3euaavmmg\",\"errors\":[{\"code\":\"unauthorized\",\"message\":\"Access Token Invalid\"}]}","firstAttemptedAt":"2023-03-30T16:59:37.973Z","content-type":"application/json; charset=utf-8"}`,
+		expected: `Access Token Invalid`,
+	},
+	{
+		inputStr: `{"response":"[CDM GOOGLESHEETS] Unable to create client for 21xmYbMXCovrqQn5BIszNvcYmur circuit breaker is open, last error: [GoogleSheets] error :: [GoogleSheets] error  :: error in GoogleSheets while unmarshalling credentials json:: invalid character 'v' looking for beginning of value","firstAttemptedAt":"2023-03-30T16:58:32.010Z","content-type":""}`,
+		expected: `[CDM GOOGLESHEETS] Unable to create client for 21xmYbMXCovrqQn5BIszNvcYmur circuit breaker is open, last error: [GoogleSheets] error :: [GoogleSheets] error  :: error in GoogleSheets while unmarshalling credentials json:: invalid character 'v' looking for beginning of value`,
+	},
+	{
+		inputStr: `{"response":"{\n  \"meta\": {\n    \"errors\": [\n      \"id attribute and identifier are not the same value\",\n      \"value for attribute 'token' cannot be longer than 1000 bytes\"\n    ]\n  }\n}\n","firstAttemptedAt":"2023-03-30T17:31:01.599Z","content-type":"application/json; charset=utf-8"}`,
+		expected: `id attribute and identifier are not the same value.value for attribute 'token' cannot be longer than 1000 bytes`,
+	},
+	{
+		inputStr: `{"response":"{\"errors\":[\"No users with this external_id found\"]}","firstAttemptedAt":"2023-03-30T17:37:58.184Z","content-type":"application/json; charset=utf-8"}`,
+		expected: `No users with this external_id found`,
+	},
+	{
+		inputStr: `{"response":"{\"status\":500,\"destinationResponse\":{\"response\":\"[ECONNRESET] :: Connection reset by peer\",\"status\":500,\"rudderJobMetadata\":{\"jobId\":2942260148,\"attemptNum\":0,\"userId\":\"\",\"sourceId\":\"1qWeSkIiAhg3O96KzVVU5MieZHM\",\"destinationId\":\"2IpcvzcMgbLfXgGA4auDrtfEMuI\",\"workspaceId\":\"1nnEnc0tt7k9eFf7bz1GsiU0MFC\",\"secret\":null}},\"message\":\"[GA4 Response Handler] Request failed for destination ga4 with status: 500\",\"statTags\":{\"errorCategory\":\"network\",\"errorType\":\"retryable\",\"destType\":\"GA4\",\"module\":\"destination\",\"implementation\":\"native\",\"feature\":\"dataDelivery\",\"destinationId\":\"2IpcvzcMgbLfXgGA4auDrtfEMuI\",\"workspaceId\":\"1nnEnc0tt7k9eFf7bz1GsiU0MFC\"}}","firstAttemptedAt":"2023-03-30T17:22:26.488Z","content-type":"application/json"}`,
+		expected: `[GA4 Response Handler] Request failed for destination ga4 with status: 500`,
+	},
+	{
+		inputStr: `{"response":"{\"status\":502,\"destinationResponse\":{\"response\":\"\u003chtml\u003e\\r\\n\u003chead\u003e\u003ctitle\u003e502 Bad Gateway\u003c/title\u003e\u003c/head\u003e\\r\\n\u003cbody\u003e\\r\\n\u003ccenter\u003e\u003ch1\u003e502 Bad Gateway\u003c/h1\u003e\u003c/center\u003e\\r\\n\u003c/body\u003e\\r\\n\u003c/html\u003e\\r\\n\",\"status\":502,\"rudderJobMetadata\":{\"jobId\":4946423471,\"attemptNum\":0,\"userId\":\"\",\"sourceId\":\"2CRIZp4OS10sjjGF3uF4guZuGmj\",\"destinationId\":\"2DstxLWX7Oi7gPdPM1CR9CikOko\",\"workspaceId\":\"1yaBlqltp5Y4V2NK8qePowlyafu\",\"secret\":null}},\"message\":\"Request failed  with status: 502\",\"statTags\":{\"errorCategory\":\"network\",\"errorType\":\"retryable\",\"destType\":\"CLEVERTAP\",\"module\":\"destination\",\"implementation\":\"native\",\"feature\":\"dataDelivery\",\"destinationId\":\"2DstxLWX7Oi7gPdPM1CR9CikOko\",\"workspaceId\":\"1yaBlqltp5Y4V2NK8qePowlyafu\"}}","firstAttemptedAt":"2023-03-30T17:11:55.326Z","content-type":"application/json"}`,
+		expected: "Request failed  with status: 502",
+	},
+	{
+		inputStr: `{"response":"{\"status\":400,\"destinationResponse\":{\"response\":\"\u003c!DOCTYPE html\u003e\\n\u003chtml lang=en\u003e\\n  \u003cmeta charset=utf-8\u003e\\n  \u003cmeta name=viewport content=\\\"initial-scale=1, minimum-scale=1, width=device-width\\\"\u003e\\n  \u003ctitle\u003eError 400 (Bad Request)!!1\u003c/title\u003e\\n  \u003cstyle\u003e\\n    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* \u003e body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}\\n  \u003c/style\u003e\\n  \u003ca href=//www.google.com/\u003e\u003cspan id=logo aria-label=Google\u003e\u003c/span\u003e\u003c/a\u003e\\n  \u003cp\u003e\u003cb\u003e400.\u003c/b\u003e \u003cins\u003eThat’s an error.\u003c/ins\u003e\\n  \u003cp\u003eYour client has issued a malformed or illegal request.  \u003cins\u003eThat’s all we know.\u003c/ins\u003e\\n\",\"status\":400,\"rudderJobMetadata\":{\"jobId\":597438246,\"attemptNum\":0,\"userId\":\"\",\"sourceId\":\"2E2b60bs1ybmIKuGvaVxtLT5lYo\",\"destinationId\":\"2E5xYQkj5OVrA3CWexvRLV4b7RH\",\"workspaceId\":\"1sUXvPs0hYgjBxSfjG4gqnRFNoP\",\"secret\":null}},\"message\":\"[GA4 Response Handler] Request failed for destination ga4 with status: 400\",\"statTags\":{\"errorCategory\":\"network\",\"errorType\":\"aborted\",\"destType\":\"GA4\",\"module\":\"destination\",\"implementation\":\"native\",\"feature\":\"dataDelivery\",\"destinationId\":\"2E5xYQkj5OVrA3CWexvRLV4b7RH\",\"workspaceId\":\"1sUXvPs0hYgjBxSfjG4gqnRFNoP\"}}","firstAttemptedAt":"2023-03-30T17:11:25.524Z","content-type":"application/json"}`,
+		expected: "[GA4 Response Handler] Request failed for destination ga4 with status: 400",
+	},
+	{
+		inputStr: `{"response":"[GoogleSheets] error :: Failed to insert Payload :: This action would increase the number of cells in the workbook above the limit of 10000000 cells.","firstAttemptedAt":"2023-03-30T17:14:18.737Z","content-type":""}`,
+		expected: `[GoogleSheets] error :: Failed to insert Payload :: This action would increase the number of cells in the workbook above the limit of 10000000 cells.`,
+	},
+	{
+		inputStr: `{"response":"{\"msg\":\"Project 9434: The request would increase the number of object fields to 19434 by adding [Application: Invoke Use Positions By Category Mutation, Application: Invoke Use Positions By Category Mutation.request, Application: Invoke Use Positions By Category Mutation.request.cacheID, Application: Invoke Use Positions By Category Mutation.request.metadata, Application: Invoke Use Positions By Category Mutation.request.name, Application: Invoke Use Positions By Category Mutation.request.operationKind, Application: Invoke Use Positions By Category Mutation.request.text, Application: Invoke Use Positions By Category Mutation.variables, Application: Invoke Use Positions By Category Mutation.variables.input, Application: Invoke Use Positions By Category Mutation.variables.input.gigPositionId, Application: Invoke Use Positions By Category Mutation.variables.input.status, Application: Invoke Use Positions By Category Mutation.variables.input.workerId, Application: Pressed  Action Row, Application: Pressed Checkbox], which exceeds the limit of 15000\",\"code\":\"UniqueFieldsLimitExceeded\",\"params\":{\"limit\":15000,\"requestedTotal\":19434,\"newFields\":[\"Application: Invoke Use Positions By Category Mutation\",\"Application: Invoke Use Positions By Category Mutation.request\",\"Application: Invoke Use Positions By Category Mutation.request.cacheID\",\"Application: Invoke Use Positions By Category Mutation.request.metadata\",\"Application: Invoke Use Positions By Category Mutation.request.name\",\"Application: Invoke Use Positions By Category Mutation.request.operationKind\",\"Application: Invoke Use Positions By Category Mutation.request.text\",\"Application: Invoke Use Positions By Category Mutation.variables\",\"Application: Invoke Use Positions By Category Mutation.variables.input\",\"Application: Invoke Use Positions By Category Mutation.variables.input.gigPositionId\",\"Application: Invoke Use Positions By Category Mutation.variables.input.status\",\"Application: Invoke Use Positions By Category Mutation.variables.input.workerId\",\"Application: Pressed  Action Row\",\"Application: Pressed Checkbox\"]}}","firstAttemptedAt":"2023-03-30T17:39:32.189Z","content-type":"application/json"}`,
+		expected: `Project 9434: The request would increase the number of object fields to 19434 by adding [Application: Invoke Use Positions By Category Mutation, Application: Invoke Use Positions By Category Mutation.request, Application: Invoke Use Positions By Category Mutation.request.cacheID, Application: Invoke Use Positions By Category Mutation.request.metadata, Application: Invoke Use Positions By Category Mutation.request.name, Application: Invoke Use Positions By Category Mutation.request.operationKind, Application: Invoke Use Positions By Category Mutation.request.text, Application: Invoke Use Positions By Category Mutation.variables, Application: Invoke Use Positions By Category Mutation.variables.input, Application: Invoke Use Positions By Category Mutation.variables.input.gigPositionId, Application: Invoke Use Positions By Category Mutation.variables.input.status, Application: Invoke Use Positions By Category Mutation.variables.input.workerId, Application: Pressed  Action Row, Application: Pressed Checkbox], which exceeds the limit of 15000`,
+	},
+	{
+		inputStr: `{"response":"{\"status\":400,\"destinationResponse\":\"\",\"message\":\"Unable to find conversionActionId for conversion:Order Completed\",\"statTags\":{\"errorCategory\":\"network\",\"errorType\":\"aborted\",\"meta\":\"instrumentation\",\"destType\":\"GOOGLE_ADWORDS_ENHANCED_CONVERSIONS\",\"module\":\"destination\",\"implementation\":\"native\",\"feature\":\"dataDelivery\",\"destinationId\":\"2DiY9INMJbBzfCdjgRlvYzsUl57\",\"workspaceId\":\"1zffyLlFcWBMmv4vvtYldWxEdGg\"}}","firstAttemptedAt":"2023-03-30T17:32:47.268Z","content-type":"application/json"}`,
+		expected: `Unable to find conversionActionId for conversion:Order Completed`,
+	},
+	{
+		inputStr: `{"response":"{\"status\":400,\"destinationResponse\":{\"response\":[{\"duplicateResut\":{\"allowSave\":true,\"duplicateRule\":\"Contacts_DR\",\"duplicateRuleEntityType\":\"Contact\",\"errorMessage\":\"You're creating a duplicate record. We recommend you use an existing record instead.\",\"matchResults\":[{\"entityType\":\"Contact\",\"errors\":[],\"matchEngine\":\"ExactMatchEngine\",\"matchRecords\":[{\"additionalInformation\":[],\"fieldDiffs\":[],\"matchConfidence\":100,\"record\":{\"attributes\":{\"type\":\"Contact\",\"url\":\"/services/data/v50.0/sobjects/Contact/0031i000013x2TEAAY\"},\"Id\":\"0031i000013x2TEAAY\"}}],\"rule\":\"Contact_MR\",\"size\":1,\"success\":true}]},\"errorCode\":\"DUPLICATES_DETECTED\",\"message\":\"You're creating a duplicate record. We recommend you use an existing record instead.\"}],\"status\":400,\"rudderJobMetadata\":{\"jobId\":1466739020,\"attemptNum\":0,\"userId\":\"\",\"sourceId\":\"2JF2LaBUedeOfAyt9EoIVJylkKS\",\"destinationId\":\"2JJDsqHbkuIZ89ldOBMaBjPi9L7\",\"workspaceId\":\"26TTcz2tQucRs2xZiGThQzGRk2l\",\"secret\":null,\"destInfo\":{\"authKey\":\"2JJDsqHbkuIZ89ldOBMaBjPi9L7\"}}},\"message\":\"Salesforce Request Failed: \\\"400\\\" due to \\\"You're creating a duplicate record. We recommend you use an existing record instead.\\\", (Aborted) during Salesforce Response Handling\",\"statTags\":{\"errorCategory\":\"network\",\"errorType\":\"aborted\",\"destType\":\"SALESFORCE\",\"module\":\"destination\",\"implementation\":\"native\",\"feature\":\"dataDelivery\",\"destinationId\":\"2JJDsqHbkuIZ89ldOBMaBjPi9L7\",\"workspaceId\":\"26TTcz2tQucRs2xZiGThQzGRk2l\"}}","firstAttemptedAt":"2023-03-30T17:07:52.359Z","content-type":"application/json"}`,
+		expected: `You're creating a duplicate record. We recommend you use an existing record instead.`,
+	},
+	{
+		inputStr: `{"response":"{\"destinationResponse\":\"\u003c!DOCTYPE html\u003e\\n\u003chtml lang=\\\"en\\\" id=\\\"facebook\\\"\u003e\\n  \u003chead\u003e\\n    \u003ctitle\u003eFacebook | Error\u003c/title\u003e\\n    \u003cmeta charset=\\\"utf-8\\\"\u003e\\n    \u003cmeta http-equiv=\\\"cache-control\\\" content=\\\"no-cache\\\"\u003e\\n    \u003cmeta http-equiv=\\\"cache-control\\\" content=\\\"no-store\\\"\u003e\\n    \u003cmeta http-equiv=\\\"cache-control\\\" content=\\\"max-age=0\\\"\u003e\\n    \u003cmeta http-equiv=\\\"expires\\\" content=\\\"-1\\\"\u003e\\n    \u003cmeta http-equiv=\\\"pragma\\\" content=\\\"no-cache\\\"\u003e\\n    \u003cmeta name=\\\"robots\\\" content=\\\"noindex,nofollow\\\"\u003e\\n    \u003cstyle\u003e\\n      html, body {\\n        color: #141823;\\n        background-color: #e9eaed;\\n        font-family: Helvetica, Lucida Grande, Arial,\\n                     Tahoma, Verdana, sans-serif;\\n        margin: 0;\\n        padding: 0;\\n        text-align: center;\\n      }\\n\\n      #header {\\n        height: 30px;\\n        padding-bottom: 10px;\\n        padding-top: 10px;\\n        text-align: center;\\n      }\\n\\n      #icon {\\n        width: 30px;\\n      }\\n\\n      h1 {\\n        font-size: 18px;\\n      }\\n\\n      p {\\n        font-size: 13px;\\n      }\\n\\n      #footer {\\n        border-top: 1px solid #ddd;\\n        color: #9197a3;\\n        font-size: 12px;\\n        padding: 5px 8px 6px 0;\\n      }\\n    \u003c/style\u003e\\n  \u003c/head\u003e\\n  \u003cbody\u003e\\n    \u003cdiv id=\\\"header\\\"\u003e\\n      \u003ca href=\\\"//www.facebook.com/\\\"\u003e\\n        \u003cimg id=\\\"icon\\\" src=\\\"//static.facebook.com/images/logos/facebook_2x.png\\\" /\u003e\\n      \u003c/a\u003e\\n    \u003c/div\u003e\\n    \u003cdiv id=\\\"core\\\"\u003e\\n      \u003ch1 id=\\\"sorry\\\"\u003eSorry, something went wrong.\u003c/h1\u003e\\n      \u003cp id=\\\"promise\\\"\u003e\\n        We're working on it and we'll get it fixed as soon as we can.\\n      \u003c/p\u003e\\n      \u003cp id=\\\"back-link\\\"\u003e\\n        \u003ca id=\\\"back\\\" href=\\\"//www.facebook.com/\\\"\u003eGo Back\u003c/a\u003e\\n      \u003c/p\u003e\\n      \u003cdiv id=\\\"footer\\\"\u003e\\n        Facebook\\n        \u003cspan id=\\\"copyright\\\"\u003e\\n          \u0026copy; 2022\\n        \u003c/span\u003e\\n        \u003cspan id=\\\"help-link\\\"\u003e\\n          \u0026#183;\\n          \u003ca id=\\\"help\\\" href=\\\"//www.facebook.com/help/\\\"\u003eHelp Center\u003c/a\u003e\\n        \u003c/span\u003e\\n      \u003c/div\u003e\\n    \u003c/div\u003e\\n    \u003cscript\u003e\\n      document.getElementById('back').onclick = function() {\\n        if (history.length \u003e 1) {\\n          history.back();\\n          return false;\\n        }\\n      };\\n\\n      // Adjust the display based on the window size\\n      if (window.innerHeight \u003c 80 || window.innerWidth \u003c 80) {\\n        // Blank if window is too small\\n        document.body.style.display = 'none';\\n      };\\n      if (window.innerWidth \u003c 200 || window.innerHeight \u003c 150) {\\n        document.getElementById('back-link').style.display = 'none';\\n        document.getElementById('help-link').style.display = 'none';\\n      };\\n      if (window.innerWidth \u003c 200) {\\n        document.getElementById('sorry').style.fontSize = '16px';\\n      };\\n      if (window.innerWidth \u003c 150) {\\n        document.getElementById('promise').style.display = 'none';\\n      };\\n      if (window.innerHeight \u003c 150) {\\n        document.getElementById('sorry').style.margin = '4px 0 0 0';\\n        document.getElementById('sorry').style.fontSize = '14px';\\n        document.getElementById('promise').style.display = 'none';\\n      };\\n    \u003c/script\u003e\\n  \u003c/body\u003e\\n\u003c/html\u003e\\n\",\"message\":\"Request Processed Successfully\",\"status\":502}","firstAttemptedAt":"2023-03-30T17:31:41.884Z","content-type":"application/json"}`,
+		expected: "Request Processed Successfully",
+	},
+	{
+		inputStr: `{"response":"{\"status\":402,\"message\":\"[Generic Response Handler] Request failed for destination active_campaign with status: 402\",\"destinationResponse\":{\"response\":\"\",\"status\":402,\"rudderJobMetadata\":{\"jobId\":38065100,\"attemptNum\":0,\"userId\":\"\",\"sourceId\":\"1tzHYMqZp5Cogqe4EeagdfpM7Y3\",\"destinationId\":\"1uFSe3P8gJnacuYQIhWFhRfvCGQ\",\"workspaceId\":\"1tyLn8D94vS107gQwxsmhZaFfP2\",\"secret\":null}},\"statTags\":{\"errorCategory\":\"network\",\"errorType\":\"aborted\",\"destType\":\"ACTIVE_CAMPAIGN\",\"module\":\"destination\",\"implementation\":\"native\",\"feature\":\"dataDelivery\",\"destinationId\":\"1uFSe3P8gJnacuYQIhWFhRfvCGQ\",\"workspaceId\":\"1tyLn8D94vS107gQwxsmhZaFfP2\",\"context\":\"[Native Integration Service] Failure During Processor Transform\"}}","firstAttemptedAt":"2023-03-30T17:03:40.883Z","content-type":"application/json"}`,
+		expected: "[Generic Response Handler] Request failed for destination active_campaign with status: 402",
+	},
+	{
+		inputStr: `{"response":"{\"message\":\"Valid data must be provided in the 'attributes', 'events', or 'purchases' fields.\",\"errors\":[{\"type\":\"'external_id' or 'braze_id' or 'user_alias' is required\",\"input_array\":\"attributes\",\"index\":0}]}","firstAttemptedAt":"2023-03-30T17:26:36.847Z","content-type":"application/json"}`,
+		expected: "Valid data must be provided in the 'attributes', 'events', or 'purchases' fields.",
+	},
+	{
+		inputStr: `{"fetching_remote_schema_failed":{"attempt":6,"errors":["dial tcp 159.223.171.199:38649: connect: connection refused","dial tcp 159.223.171.199:38649: connect: connection refused","dial tcp 159.223.171.199:38649: connect: connection refused","dial tcp 159.223.171.199:38649: connect: connection refused","dial tcp 159.223.171.199:38649: connect: connection refused","dial tcp 159.223.171.199:38649: connect: connection refused"]}}`,
+		expected: `dial tcp 159.223.171.199:38649: connect: connection refused`,
+	},
+	{
+		inputStr: `{"exporting_data_failed":{"attempt":5,"errors":["2 errors occurred:\n1 errors occurred:\nloading identifies table: inserting into original table: pq: Value out of range for 4 bytes.\n1 errors occurred:\nupdate schema: adding columns to warehouse: failed to add columns for table logout in namespace raw_gtm of destination RS:2MeRrhS670OOhZv6gBezLipeVtm with error: pq: must be owner of relation logout","2 errors occurred:\n1 errors occurred:\nupdate schema: adding columns to warehouse: failed to add columns for table logout in namespace raw_gtm of destination RS:2MeRrhS670OOhZv6gBezLipeVtm with error: pq: must be owner of relation logout\n1 errors occurred:\nloading identifies table: inserting into original table: pq: Value out of range for 4 bytes.","2 errors occurred:\n1 errors occurred:\nupdate schema: adding columns to warehouse: failed to add columns for table logout in namespace raw_gtm of destination RS:2MeRrhS670OOhZv6gBezLipeVtm with error: pq: must be owner of relation logout\n1 errors occurred:\nloading identifies table: inserting into original table: pq: Value out of range for 4 bytes.","2 errors occurred:\n1 errors occurred:\nupdate schema: adding columns to warehouse: failed to add columns for table logout in namespace raw_gtm of destination RS:2MeRrhS670OOhZv6gBezLipeVtm with error: pq: must be owner of relation logout\n1 errors occurred:\nloading identifies table: inserting into original table: pq: Value out of range for 4 bytes.","2 errors occurred:\n1 errors occurred:\nupdate schema: adding columns to warehouse: failed to add columns for table logout in namespace raw_gtm of destination RS:2MeRrhS670OOhZv6gBezLipeVtm with error: pq: must be owner of relation logout\n1 errors occurred:\nloading identifies table: inserting into original table: pq: Value out of range for 4 bytes."]}}`,
+		expected: "2 errors occurred:\n1 errors occurred:\nloading identifies table: inserting into original table: pq: Value out of range for 4 bytes.\n1 errors occurred:\nupdate schema: adding columns to warehouse: failed to add columns for table logout in namespace raw_gtm of destination RS:2MeRrhS670OOhZv6gBezLipeVtm with error: pq: must be owner of relation logout.2 errors occurred:\n1 errors occurred:\nupdate schema: adding columns to warehouse: failed to add columns for table logout in namespace raw_gtm of destination RS:2MeRrhS670OOhZv6gBezLipeVtm with error: pq: must be owner of relation logout\n1 errors occurred:\nloading identifies table: inserting into original table: pq: Value out of range for 4 bytes.",
+	},
+	{
+		inputStr: `{"response":"{\n\t\t\t\tError: invalid character 'P' looking for beginning of value,\n\t\t\t\t(trRespStCd, trRespBody): (504, Post \"http://transformer.rudder-us-east-1b-blue/v0/destinations/google_adwords_enhanced_conversions/proxy\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)),\n\t\t\t}","firstAttemptedAt":"2023-03-30T17:24:58.068Z","content-type":"text/plain; charset=utf-8"}`,
+		expected: "{\n\t\t\t\tError: invalid character 'P' looking for beginning of value,\n\t\t\t\t(trRespStCd, trRespBody): (504, Post \"http://transformer.rudder-us-east-1b-blue/v0/destinations/google_adwords_enhanced_conversions/proxy\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)),\n\t\t\t}",
+	},
 }
 
 func TestGetErrorMessageFromResponse(t *testing.T) {
-	extractor := NewErrorDetailExtractor(logger.NOP)
+	ext := NewErrorDetailExtractor(logger.NOP)
 
-	expectedVals := []string{
-		"message-1", "messge-2",
-		// "messge-2-0",
-		"message-4-2", "message-5-1",
-	}
-	for i, response := range jsonBenchCases {
-		t.Run(fmt.Sprintf("case for payload-%d", i), func(t *testing.T) {
-			require.Equal(t, extractor.GetErrorMessage(response), expectedVals[i])
+	for i, tc := range tcs {
+		t.Run(fmt.Sprintf("payload-%v", i), func(t *testing.T) {
+
+			msg := ext.GetErrorMessage(tc.inputStr)
+			require.Equal(t, tc.expected, msg)
 		})
+
 	}
 }
 
@@ -340,9 +442,8 @@ func BenchmarkJsonNestedSearch(b *testing.B) {
 	extractor := NewErrorDetailExtractor(logger.NOP)
 
 	b.Run("JsonNested used fn", func(b *testing.B) {
-		for i := 0; i < len(jsonBenchCases); i++ {
-			// GetErrorMessage(m.Value().(map[string]interface{}))
-			extractor.GetErrorMessage(jsonBenchCases[i])
+		for i := 0; i < len(tcs); i++ {
+			extractor.GetErrorMessage(tcs[i].inputStr)
 		}
 	})
 }

--- a/enterprise/reporting/reporting_test.go
+++ b/enterprise/reporting/reporting_test.go
@@ -407,11 +407,9 @@ func TestGetErrorMessageFromResponse(t *testing.T) {
 
 	for i, tc := range tcs {
 		t.Run(fmt.Sprintf("payload-%v", i), func(t *testing.T) {
-
 			msg := ext.GetErrorMessage(tc.inputStr)
 			require.Equal(t, tc.expected, msg)
 		})
-
 	}
 }
 

--- a/enterprise/reporting/reporting_test.go
+++ b/enterprise/reporting/reporting_test.go
@@ -313,6 +313,29 @@ func TestGetErrorMessageFromResponse(t *testing.T) {
 	}
 }
 
+func TestCleanUpErrorMessage(t *testing.T) {
+	ext := NewErrorDetailExtractor(logger.NOP)
+	type testCase struct {
+		inputStr string
+		expected string
+	}
+
+	testCases := []testCase{
+		{inputStr: "Object with ID '123983489734' is not a valid object", expected: "Object with ID '' is not a valid object"},
+		{inputStr: "http://xyz-rudder.com/v1/endpoint not reachable: context deadline exceeded", expected: "not reachable: context deadline exceeded"},
+		{inputStr: "http://xyz-rudder.com/v1/endpoint not reachable 172.22.22.10: EOF", expected: "not reachable : EOF"},
+		{inputStr: "Request failed to process from 16-12-2022:19:30:23T+05:30 due to internal server error", expected: "Request failed to process from --:::T+: due to internal server error"},
+		{inputStr: "User with email 'vagor12@bing.com' is not valid", expected: "User with email '' is not valid"},
+		{inputStr: "Allowed timestamp is [15 minutes] into the future", expected: "Allowed timestamp is [ minutes] into the future"},
+	}
+	for i, tCase := range testCases {
+		t.Run(fmt.Sprintf("Case-%d", i), func(t *testing.T) {
+			actual := ext.CleanUpErrorMessage(tCase.inputStr)
+			require.Equal(t, tCase.expected, actual)
+		})
+	}
+}
+
 func BenchmarkJsonNestedSearch(b *testing.B) {
 	extractor := NewErrorDetailExtractor(logger.NOP)
 

--- a/enterprise/reporting/reporting_test.go
+++ b/enterprise/reporting/reporting_test.go
@@ -421,12 +421,12 @@ func TestCleanUpErrorMessage(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		{inputStr: "Object with ID '123983489734' is not a valid object", expected: "Object with ID '' is not a valid object"},
-		{inputStr: "http://xyz-rudder.com/v1/endpoint not reachable: context deadline exceeded", expected: "not reachable: context deadline exceeded"},
-		{inputStr: "http://xyz-rudder.com/v1/endpoint not reachable 172.22.22.10: EOF", expected: "not reachable : EOF"},
-		{inputStr: "Request failed to process from 16-12-2022:19:30:23T+05:30 due to internal server error", expected: "Request failed to process from --:::T+: due to internal server error"},
-		{inputStr: "User with email 'vagor12@bing.com' is not valid", expected: "User with email '' is not valid"},
-		{inputStr: "Allowed timestamp is [15 minutes] into the future", expected: "Allowed timestamp is [ minutes] into the future"},
+		{inputStr: "Object with ID '123983489734' is not a valid object", expected: "Object with ID is not a valid object"},
+		{inputStr: "http://xyz-rudder.com/v1/endpoint not reachable: context deadline exceeded", expected: " not reachable context deadline exceeded"},
+		{inputStr: "http://xyz-rudder.com/v1/endpoint not reachable 172.22.22.10: EOF", expected: " not reachable EOF"},
+		{inputStr: "Request failed to process from 16-12-2022:19:30:23T+05:30 due to internal server error", expected: "Request failed to process from due to internal server error"},
+		{inputStr: "User with email 'vagor12@bing.com' is not valid", expected: "User with email is not valid"},
+		{inputStr: "Allowed timestamp is [15 minutes] into the future", expected: "Allowed timestamp is minutes into the future"},
 	}
 	for i, tCase := range testCases {
 		t.Run(fmt.Sprintf("Case-%d", i), func(t *testing.T) {


### PR DESCRIPTION
# Description

~~Add error extraction logic using `gjson`~~
Updated the logic a bit used json in some parts for more concrete evaluation of json & parsing the json itself before we go for recursive search of probable error message keys


## Notion Ticket

https://www.notion.so/rudderstacks/Adding-errorMessage-field-in-reports-table-of-rudder-server-e584e48c6959476abc5b5b72dd8693c3?pvs=4

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
