### PR TITLE
chore: fix deadlock issue uploader

### DIFF
--- a/services/debugger/destination/eventDeliveryStatusUploader.go
+++ b/services/debugger/destination/eventDeliveryStatusUploader.go
@@ -124,8 +124,6 @@ func (h *Handle) RecordEventDeliveryStatus(destinationID string, deliveryStatus 
 	}
 	<-h.initialized
 	// Check if destinationID part of enabled destinations, if not then push the job in cache to keep track
-	h.uploadEnabledDestinationIDsMu.RLock()
-	defer h.uploadEnabledDestinationIDsMu.RUnlock()
 	if !h.HasUploadEnabled(destinationID) {
 		err := h.eventsDeliveryCache.Update(destinationID, deliveryStatus)
 		if err != nil {
@@ -203,8 +201,6 @@ func (h *Handle) backendConfigSubscriber(backendConfig backendconfig.BackendConf
 }
 
 func (h *Handle) recordHistoricEventsDelivery(destinationIDs []string) {
-	h.uploadEnabledDestinationIDsMu.RLock()
-	defer h.uploadEnabledDestinationIDsMu.RUnlock()
 	for _, destinationID := range destinationIDs {
 		historicEventsDelivery, err := h.eventsDeliveryCache.Read(destinationID)
 		if err != nil {

--- a/services/debugger/transformation/transformationStatusUploader.go
+++ b/services/debugger/transformation/transformationStatusUploader.go
@@ -328,8 +328,6 @@ func getEventsAfterTransform(singularEvent types.SingularEventT, receivedAt time
 }
 
 func (h *Handle) recordHistoricTransformations(tIDs []string) {
-	h.uploadEnabledTransformationsMu.RLock()
-	defer h.uploadEnabledTransformationsMu.RUnlock()
 	for _, tID := range tIDs {
 		tStatuses, err := h.transformationCacheMap.Read(tID)
 		if err != nil {


### PR DESCRIPTION
# Description
Fixes the Deadlock described below as described clearly by @atzoum 

- goroutine-1 acquires a read lock [here](https://github.com/rudderlabs/rudder-server/blob/0ad29a3222b68d7cb82a6395672b91f12d363840/services/debugger/destination/eventDeliveryStatusUploader.go#L127) successfully!
- goroutine-2 tries to acquire a full lock [here](https://github.com/rudderlabs/rudder-server/blob/0ad29a3222b68d7cb82a6395672b91f12d363840/services/debugger/destination/eventDeliveryStatusUploader.go#L185), but is waiting since goroutine-1 already has a read lock.
- goroutine-1 proceeds and calls HasUploadEnabled, which in turn tries to acquire a read lock again [here](https://github.com/rudderlabs/rudder-server/blob/0ad29a3222b68d7cb82a6395672b91f12d363840/services/debugger/destination/eventDeliveryStatusUploader.go#L143). This read lock is now blocked by the full lock request issued by goroutine-2 earlier.
- deadlock!

## Notion Ticket

[ Notion Link ](https://www.notion.so/rudderstacks/Fix-deadlock-eventUploader-cf0be292f6484fe5ad313ad5f735ed06?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
