### PR TITLE
fix: stash loop is not sleeping even though query limits are not being reached

### DIFF
--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -420,5 +420,4 @@ func (*HandleT) calculateSleepTime(limitReached bool) time.Duration {
 		return time.Duration(0)
 	}
 	return config.GetDuration("Processor.errReadLoopSleep", 30, time.Second)
-
 }

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -417,7 +417,8 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 
 func (*HandleT) calculateSleepTime(limitReached bool) time.Duration {
 	if limitReached {
-		return config.GetDuration("Processor.errReadLoopSleep", 30, time.Second)
+		return time.Duration(0)
 	}
-	return time.Duration(0)
+	return config.GetDuration("Processor.errReadLoopSleep", 30, time.Second)
+
 }


### PR DESCRIPTION
# Description

The stash loop should sleep if query limits are not reached. The previous logic was inverse, i.e. stash kept querying the database continuously for more jobs even though no jobs were present

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
