### PR TITLE
fix: databricks retries

### DIFF
--- a/warehouse/integrations/deltalake-native/deltalake.go
+++ b/warehouse/integrations/deltalake-native/deltalake.go
@@ -134,6 +134,9 @@ type Deltalake struct {
 	LoadTableStrategy      string
 	EnablePartitionPruning bool
 	SlowQueryThreshold     time.Duration
+	MaxRetry               int
+	MaxWaitRetry           time.Duration
+	MinWaitRetry           time.Duration
 }
 
 func New() *Deltalake {
@@ -147,6 +150,9 @@ func WithConfig(h *Deltalake, config *config.Config) {
 	h.LoadTableStrategy = config.GetString("Warehouse.deltalake.loadTableStrategy", mergeMode)
 	h.EnablePartitionPruning = config.GetBool("Warehouse.deltalake.enablePartitionPruning", true)
 	h.SlowQueryThreshold = config.GetDuration("Warehouse.deltalake.slowQueryThreshold", 5, time.Minute)
+	h.MaxRetry = config.GetInt("Warehouse.deltalake.retries", 25)
+	h.MaxWaitRetry = config.GetDuration("Warehouse.deltalake.retryMaxWait", 5, time.Second)
+	h.MinWaitRetry = config.GetDuration("Warehouse.deltalake.retryMinWait", 60, time.Second)
 }
 
 // Setup sets up the warehouse
@@ -191,6 +197,7 @@ func (d *Deltalake) connect() (*sqlmiddleware.DB, error) {
 			warehouseutils.GetConfigValue(catalog, d.Warehouse),
 			"",
 		),
+		dbsql.WithRetries(d.MaxRetry, d.MaxWaitRetry, d.MinWaitRetry),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating connector: %w", err)

--- a/warehouse/integrations/deltalake-native/deltalake.go
+++ b/warehouse/integrations/deltalake-native/deltalake.go
@@ -133,10 +133,10 @@ type Deltalake struct {
 	Stats                  stats.Stats
 	LoadTableStrategy      string
 	EnablePartitionPruning bool
-	SlowQueryThreshold     time.Duration
-	MaxRetry               int
-	MaxWaitRetry           time.Duration
-	MinWaitRetry           time.Duration
+	SlowQueryThreshold time.Duration
+	Retries            int
+	RetryMaxWait       time.Duration
+	RetryMinWait time.Duration
 }
 
 func New() *Deltalake {
@@ -150,9 +150,9 @@ func WithConfig(h *Deltalake, config *config.Config) {
 	h.LoadTableStrategy = config.GetString("Warehouse.deltalake.loadTableStrategy", mergeMode)
 	h.EnablePartitionPruning = config.GetBool("Warehouse.deltalake.enablePartitionPruning", true)
 	h.SlowQueryThreshold = config.GetDuration("Warehouse.deltalake.slowQueryThreshold", 5, time.Minute)
-	h.MaxRetry = config.GetInt("Warehouse.deltalake.retries", 25)
-	h.MaxWaitRetry = config.GetDuration("Warehouse.deltalake.retryMaxWait", 5, time.Second)
-	h.MinWaitRetry = config.GetDuration("Warehouse.deltalake.retryMinWait", 60, time.Second)
+	h.Retries = config.GetInt("Warehouse.deltalake.retries", 25)
+	h.RetryMaxWait = config.GetDuration("Warehouse.deltalake.retryMaxWait", 5, time.Second)
+	h.RetryMinWait = config.GetDuration("Warehouse.deltalake.retryMinWait", 60, time.Second)
 }
 
 // Setup sets up the warehouse
@@ -197,7 +197,7 @@ func (d *Deltalake) connect() (*sqlmiddleware.DB, error) {
 			warehouseutils.GetConfigValue(catalog, d.Warehouse),
 			"",
 		),
-		dbsql.WithRetries(d.MaxRetry, d.MaxWaitRetry, d.MinWaitRetry),
+		dbsql.WithRetries(d.Retries, d.RetryMaxWait, d.RetryMinWait),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating connector: %w", err)


### PR DESCRIPTION
# Description

- Add `databricks` retries policy to the `databricks` client. This is basically used as a cold start time in order to connect to the `databricks` cluster.

## Notion Ticket

https://www.notion.so/rudderstacks/Databricks-intermittent-failures-d5e939f3749543888b8f070a4c14c7e2?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
