### PR TITLE
fix: kafka secret comes first

### DIFF
--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -325,8 +325,12 @@ func NewProducer(destination *backendconfig.DestinationT, o common.Opts) (*Produ
 		}
 	}
 
-	var sshConfig *client.SSHConfig
-	if destConfig.UseSSH {
+	// TODO: once the latest control-plane changes are in production we can safely remove this
+	sshConfig, err := getSSHConfig(destination.ID, config.Default)
+	if err != nil {
+		return nil, fmt.Errorf("[Kafka] invalid SSH configuration: %w", err)
+	}
+	if sshConfig == nil && destConfig.UseSSH {
 		privateKey, err := getSSHPrivateKey(context.Background(), destination.ID)
 		if err != nil {
 			return nil, fmt.Errorf("[Kafka] invalid SSH private key: %w", err)
@@ -335,11 +339,6 @@ func NewProducer(destination *backendconfig.DestinationT, o common.Opts) (*Produ
 			Host:       destConfig.SSHHost + ":" + destConfig.SSHPort,
 			User:       destConfig.SSHUser,
 			PrivateKey: privateKey,
-		}
-	} else { // TODO: once the latest control-plane changes are in production we can safely remove this
-		sshConfig, err = getSSHConfig(destination.ID, config.Default)
-		if err != nil {
-			return nil, fmt.Errorf("[Kafka] invalid SSH configuration: %w", err)
 		}
 	}
 


### PR DESCRIPTION
# Description

SSH is enabled for Cars so the SSH keys that are read are now those ones although for backwards compatibility, if present, the ones from the secret should be read first.

## Notion Ticket

< [Notion Link](https://www.notion.so/rudderstacks/Kafka-SSH-fixes-df083da3e3564dd0bdfcddcefda0c838) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
