### PR TITLE
chore: support to skip caching backendConfig

### DIFF
--- a/backend-config/backend_config_test.go
+++ b/backend-config/backend_config_test.go
@@ -132,7 +132,7 @@ func TestBadResponse(t *testing.T) {
 				workspaceConfig: conf,
 				eb:              pubsub.New(),
 			}
-			bc.StartWithIDs(ctx, "")
+			bc.StartWithIDs(ctx, "", true)
 			go bc.WaitForConfig(ctx)
 
 			timeout := time.NewTimer(3 * time.Second)
@@ -381,7 +381,7 @@ func TestCache(t *testing.T) {
 			eb:              pubsub.New(),
 			curSourceJSON:   map[string]ConfigT{},
 		}
-		bc.StartWithIDs(ctx, workspaces)
+		bc.StartWithIDs(ctx, workspaces, true)
 
 		cacheVal, err := bc.cache.Get(ctx)
 		require.Equal(t, fmt.Errorf(`noCache: cache disabled`), err)
@@ -507,7 +507,7 @@ func TestCache(t *testing.T) {
 			eb:              pubsub.New(),
 			curSourceJSON:   map[string]ConfigT{},
 		}
-		bc.StartWithIDs(ctx, workspaces)
+		bc.StartWithIDs(ctx, workspaces, true)
 		bc.WaitForConfig(ctx)
 		var (
 			configBytes []byte
@@ -566,7 +566,7 @@ func TestCache(t *testing.T) {
 			eb:              pubsub.New(),
 			curSourceJSON:   map[string]ConfigT{},
 		}
-		require.Panics(t, func() { bc.StartWithIDs(ctx, workspaces) })
+		require.Panics(t, func() { bc.StartWithIDs(ctx, workspaces, true) })
 	})
 }
 

--- a/backend-config/mock_workspaceconfig.go
+++ b/backend-config/mock_workspaceconfig.go
@@ -174,15 +174,15 @@ func (mr *MockBackendConfigMockRecorder) SetUp() *gomock.Call {
 }
 
 // StartWithIDs mocks base method.
-func (m *MockBackendConfig) StartWithIDs(ctx context.Context, workspaces string) {
+func (m *MockBackendConfig) StartWithIDs(ctx context.Context, workspaces string, canUseCache bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartWithIDs", ctx, workspaces)
+	m.ctrl.Call(m, "StartWithIDs", ctx, workspaces, canUseCache)
 }
 
 // StartWithIDs indicates an expected call of StartWithIDs.
-func (mr *MockBackendConfigMockRecorder) StartWithIDs(ctx, workspaces interface{}) *gomock.Call {
+func (mr *MockBackendConfigMockRecorder) StartWithIDs(ctx, workspaces, canUseCache interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithIDs", reflect.TypeOf((*MockBackendConfig)(nil).StartWithIDs), ctx, workspaces)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithIDs", reflect.TypeOf((*MockBackendConfig)(nil).StartWithIDs), ctx, workspaces, canUseCache)
 }
 
 // Stop mocks base method.

--- a/backend-config/noop.go
+++ b/backend-config/noop.go
@@ -39,7 +39,7 @@ func (*NOOP) Subscribe(ctx context.Context, _ Topic) pubsub.DataChannel {
 	return ch
 }
 
-func (*NOOP) StartWithIDs(_ context.Context, _ string) {}
+func (*NOOP) StartWithIDs(_ context.Context, _ string, _ bool) {}
 
 func (*NOOP) Stop() {
 }

--- a/enterprise/suppress-user/factory_test.go
+++ b/enterprise/suppress-user/factory_test.go
@@ -40,7 +40,7 @@ func TestSuppressionSetup(t *testing.T) {
 
 	require.NoError(t, backendconfig.Setup(nil))
 	defer backendconfig.DefaultBackendConfig.Stop()
-	backendconfig.DefaultBackendConfig.StartWithIDs(context.TODO(), "")
+	backendconfig.DefaultBackendConfig.StartWithIDs(context.TODO(), "", true)
 
 	t.Run(
 		"should setup badgerdb and syncer successfully after getting suppression from backup service",

--- a/mocks/backend-config/mock_backendconfig.go
+++ b/mocks/backend-config/mock_backendconfig.go
@@ -95,15 +95,15 @@ func (mr *MockBackendConfigMockRecorder) SetUp() *gomock.Call {
 }
 
 // StartWithIDs mocks base method.
-func (m *MockBackendConfig) StartWithIDs(arg0 context.Context, arg1 string) {
+func (m *MockBackendConfig) StartWithIDs(arg0 context.Context, arg1 string, arg2 bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartWithIDs", arg0, arg1)
+	m.ctrl.Call(m, "StartWithIDs", arg0, arg1, arg2)
 }
 
 // StartWithIDs indicates an expected call of StartWithIDs.
-func (mr *MockBackendConfigMockRecorder) StartWithIDs(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBackendConfigMockRecorder) StartWithIDs(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithIDs", reflect.TypeOf((*MockBackendConfig)(nil).StartWithIDs), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithIDs", reflect.TypeOf((*MockBackendConfig)(nil).StartWithIDs), arg0, arg1, arg2)
 }
 
 // Stop mocks base method.

--- a/regulation-worker/cmd/main.go
+++ b/regulation-worker/cmd/main.go
@@ -74,7 +74,7 @@ func Run(ctx context.Context) error {
 		return fmt.Errorf("getting deployment type: %w", err)
 	}
 	pkgLogger.Infof("Running regulation worker in %s mode", deploymentType)
-	backendconfig.DefaultBackendConfig.StartWithIDs(ctx, "")
+	backendconfig.DefaultBackendConfig.StartWithIDs(ctx, "", true)
 	backendconfig.DefaultBackendConfig.WaitForConfig(ctx)
 	identity := backendconfig.DefaultBackendConfig.Identity()
 	dest.Start(ctx)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -195,12 +195,12 @@ func (r *Runner) Run(ctx context.Context, args []string) int {
 		}).Gauge(1)
 
 	configEnvHandler := r.application.Features().ConfigEnv.Setup()
-
+	canUseBackendConfigCache := config.GetBool("BackendConfigCache.enabled", true)
 	if err := backendconfig.Setup(configEnvHandler); err != nil {
 		r.logger.Errorf("Unable to setup backend config: %s", err)
 		return 1
 	}
-	backendconfig.DefaultBackendConfig.StartWithIDs(ctx, "")
+	backendconfig.DefaultBackendConfig.StartWithIDs(ctx, "", canUseBackendConfigCache)
 
 	// Prepare databases in sequential order, so that failure in one doesn't affect others (leaving dirty schema migration state)
 	if r.canStartServer() {

--- a/suppression-backup-service/cmd/main.go
+++ b/suppression-backup-service/cmd/main.go
@@ -11,6 +11,8 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
@@ -23,7 +25,6 @@ import (
 	"github.com/rudderlabs/rudder-server/suppression-backup-service/exporter"
 	"github.com/rudderlabs/rudder-server/suppression-backup-service/model"
 	"github.com/rudderlabs/rudder-server/utils/misc"
-	"golang.org/x/sync/errgroup"
 )
 
 var pkgLogger = logger.NewLogger().Child("suppression-backup-service")
@@ -123,7 +124,7 @@ func getIdentity(ctx context.Context) (identity.Identifier, error) {
 	}
 	defer backendconfig.DefaultBackendConfig.Stop()
 
-	backendconfig.DefaultBackendConfig.StartWithIDs(context.TODO(), "")
+	backendconfig.DefaultBackendConfig.StartWithIDs(context.TODO(), "", true)
 	backendconfig.DefaultBackendConfig.WaitForConfig(ctx)
 
 	id := backendconfig.DefaultBackendConfig.Identity()


### PR DESCRIPTION
# Description

Adding the support to be able to skip caching backendConfig based on an environment variable

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/Skip-caching-backend-config-56fe33e447f44c44b917689742e81378?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
