### PR TITLE
chore: add toggle for backendconfig db caching

### DIFF
--- a/backend-config/backend-config.go
+++ b/backend-config/backend-config.go
@@ -36,6 +36,7 @@ var (
 	configFromFile                        bool
 	maxRegulationsPerRequest              int
 	configEnvReplacementEnabled           bool
+	dbCacheEnabled                        bool
 
 	LastSync           string
 	LastRegulationSync string
@@ -97,6 +98,7 @@ func loadConfig() {
 	config.RegisterBoolConfigVariable(false, &configFromFile, false, "BackendConfig.configFromFile")
 	config.RegisterIntConfigVariable(1000, &maxRegulationsPerRequest, true, 1, "BackendConfig.maxRegulationsPerRequest")
 	config.RegisterBoolConfigVariable(true, &configEnvReplacementEnabled, false, "BackendConfig.envReplacementEnabled")
+	config.RegisterBoolConfigVariable(true, &dbCacheEnabled, false, "BackendConfig.dbCacheEnabled")
 }
 
 func Init() {
@@ -319,6 +321,10 @@ func (bc *backendConfigImpl) StartWithIDs(ctx context.Context, workspaces string
 	bc.cancel = cancel
 	bc.blockChan = make(chan struct{})
 	bc.cache = cacheOverride
+
+	if !dbCacheEnabled {
+		bc.cache = &noCache{}
+	}
 	if bc.cache == nil {
 		identifier := bc.Identity()
 		u, _ := identifier.BasicAuth()


### PR DESCRIPTION
# Description

Add the ability to disable db caching. 

In environments with large config files (~600Mbs uncompressed) having multiple instances (warehouse masters + N x slaves) can potentially impact database performance. Moreover caching in these environments is not as important, as warehouse doesn't have the same availability requirements as gateway.


## Notion Ticket

https://www.notion.so/rudderstacks/Toggle-for-config-db-caching-52b551ad354e437d8265b82ef59e9547?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
