### PR TITLE
chore: fix flaky test

### DIFF
--- a/warehouse/warehouse_test.go
+++ b/warehouse/warehouse_test.go
@@ -72,6 +72,8 @@ func getMockStats(g GinkgoTInterface) (*mock_stats.MockStats, *mock_stats.MockMe
 var _ = Describe("Warehouse", func() {})
 
 func TestUploadJob_ProcessingStats(t *testing.T) {
+	t.Parallel()
+
 	testcases := []struct {
 		name            string
 		destType        string
@@ -186,6 +188,8 @@ func TestUploadJob_ProcessingStats(t *testing.T) {
 }
 
 func Test_GetNamespace(t *testing.T) {
+	t.Parallel()
+
 	testcases := []struct {
 		config      map[string]interface{}
 		source      backendconfig.SourceT
@@ -323,17 +327,20 @@ func Test_GetNamespace(t *testing.T) {
 				Handle:          pgResource.DB,
 				MigrationsTable: "wh_schema_migrations",
 			}).Migrate("warehouse")
-
 			require.NoError(t, err)
+
+			conf := config.New()
 			store := memstats.New()
+
 			wh := HandleT{
 				destType:     tc.destType,
 				stats:        store,
 				dbHandle:     pgResource.DB,
 				whSchemaRepo: repo.NewWHSchemas(pgResource.DB),
+				conf:         conf,
 			}
 			if tc.setConfig {
-				config.Set(fmt.Sprintf("Warehouse.%s.customDatasetPrefix", warehouseutils.WHDestNameMap[tc.destType]), "config_result")
+				conf.Set(fmt.Sprintf("Warehouse.%s.customDatasetPrefix", warehouseutils.WHDestNameMap[tc.destType]), "config_result")
 			}
 
 			sqlStatement, err := os.ReadFile("testdata/sql/namespace_test.sql")
@@ -344,7 +351,6 @@ func Test_GetNamespace(t *testing.T) {
 
 			namespace := wh.getNamespace(tc.source, tc.destination)
 			require.Equal(t, tc.result, namespace)
-			config.Reset()
 		})
 	}
 }


### PR DESCRIPTION
# Description

- Fix flaky test for Test_GetNamespace
```
=== Failed
=== FAIL: warehouse Test_GetNamespace/should_return_namespace#06 (3.68s)
    warehouse_test.go:346: 
        	Error Trace:	/home/runner/work/rudder-server/rudder-server/warehouse/warehouse_test.go:346
        	Error:      	Not equal: 
        	            	expected: "config_result"
        	            	actual  : "stringempty"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-config_result
        	            	+stringempty
        	Test:       	Test_GetNamespace/should_return_namespace#06
    --- FAIL: Test_GetNamespace/should_return_namespace#06 (3.68s)

=== FAIL: warehouse Test_GetNamespace (0.00s)

```

## Notion Ticket

https://www.notion.so/rudderstacks/Flaky-test-f0de0f027e8c4c22ba7c05be4ce46100?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
