### PR TITLE
fix: staging files status when insert

### DIFF
--- a/warehouse/internal/repo/staging.go
+++ b/warehouse/internal/repo/staging.go
@@ -150,7 +150,7 @@ func (repo *StagingFiles) Insert(ctx context.Context, stagingFile *model.Staging
 		stagingFile.WorkspaceID,
 		stagingFile.SourceID,
 		stagingFile.DestinationID,
-		stagingFile.Status,
+		warehouseutils.StagingFileWaitingState,
 		stagingFile.TotalEvents,
 		stagingFile.TotalBytes,
 		firstEventAt,


### PR DESCRIPTION
# Description

- Set staging files status to waiting instead of an empty string when inserting.

## Notion Ticket

https://www.notion.so/rudderstacks/Staging-files-status-set-to-waiting-when-insert-8ccbac193d234598a2937ca051938ef6?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
