### PR TITLE
fix: include source definition type when destination has UT

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2052,14 +2052,15 @@ func (proc *Handle) transformSrcDest(
 	destination := &eventList[0].Destination
 	workspaceID := eventList[0].Metadata.WorkspaceID
 	commonMetaData := &transformer.MetadataT{
-		SourceID:        sourceID,
-		SourceType:      eventList[0].Metadata.SourceType,
-		SourceCategory:  eventList[0].Metadata.SourceCategory,
-		WorkspaceID:     workspaceID,
-		Namespace:       config.GetKubeNamespace(),
-		InstanceID:      misc.GetInstanceID(),
-		DestinationID:   destID,
-		DestinationType: destination.DestinationDefinition.Name,
+		SourceID:             sourceID,
+		SourceType:           eventList[0].Metadata.SourceType,
+		SourceCategory:       eventList[0].Metadata.SourceCategory,
+		WorkspaceID:          workspaceID,
+		Namespace:            config.GetKubeNamespace(),
+		InstanceID:           misc.GetInstanceID(),
+		DestinationID:        destID,
+		DestinationType:      destination.DestinationDefinition.Name,
+		SourceDefinitionType: eventList[0].Metadata.SourceDefinitionType,
 	}
 
 	reportMetrics := make([]*types.PUReportedMetric, 0)


### PR DESCRIPTION
# Description

Source definition type was being sent as empty string("") when user transformation is connected to a destination.
As `SourceDefinitionType` was not being populated in the metadata(`commonMetadata`) before sending to user transformation.

We are aiming to fix.

## Notion Ticket

https://www.notion.so/rudderstacks/GA4-page-calls-error-is-displaying-in-live-events-tab-for-hybrid-mode-connection-52c58ee1924941f1b037fb8f63fc2445?pvs=4

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
