### PR TITLE
fix: max connections for warehouse slaves

### DIFF
--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -1604,10 +1604,6 @@ func setupDB(ctx context.Context, connInfo string) error {
 		return err
 	}
 
-	if isStandAloneSlave() {
-		dbHandle.SetMaxOpenConns(1)
-	}
-
 	if err = dbHandle.PingContext(ctx); err != nil {
 		return fmt.Errorf("could not ping WH db: %w", err)
 	}


### PR DESCRIPTION
# Description

- Queries are getting blocked on GetNamespace waiting for the connection to be free.

## Notion Ticket

https://www.notion.so/rudderstacks/Max-connections-e8600736c8934804abf187849dfac51e?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
