### PR TITLE
fix: schema forwarder records invalid json in statuses

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -2379,6 +2379,8 @@ func (jd *HandleT) updateJobStatusDSInTx(ctx context.Context, tx *Tx, ds dataSet
 		if err != nil {
 			return err
 		}
+
+		defer func() { _ = stmt.Close() }()
 		for _, status := range statusList {
 			//  Handle the case when google analytics returns gif in response
 			if _, ok := updatedStates[status.WorkspaceId]; !ok {

--- a/schema-forwarder/internal/forwarder/jobsforwarder.go
+++ b/schema-forwarder/internal/forwarder/jobsforwarder.go
@@ -123,6 +123,7 @@ func (jf *JobsForwarder) Start() error {
 								ExecTime:      time.Now(),
 								RetryTime:     time.Now(),
 								ErrorCode:     "400",
+								Parameters:    []byte(`{}`),
 								JobParameters: job.Parameters,
 								ErrorResponse: errorResponse,
 							})
@@ -146,6 +147,7 @@ func (jf *JobsForwarder) Start() error {
 										AttemptNum:    job.LastJobStatus.AttemptNum + 1,
 										JobState:      jobsdb.Succeeded.State,
 										ExecTime:      time.Now(),
+										Parameters:    []byte(`{}`),
 										JobParameters: job.Parameters,
 									})
 									jf.stat.NewTaggedStat("schema_forwarder_processed_jobs", stats.CountType, stats.Tags{"state": "succeeded"}).Increment()
@@ -179,6 +181,7 @@ func (jf *JobsForwarder) Start() error {
 							ExecTime:      time.Now(),
 							RetryTime:     time.Now(),
 							ErrorCode:     "400",
+							Parameters:    []byte(`{}`),
 							JobParameters: job.Parameters,
 							ErrorResponse: errorResponse,
 						})


### PR DESCRIPTION
# Description

A missing close statement in jobsdb, in combination with schema forwarder using invalid jsonb data in job status rows, caused rudder-server's processor to get stuck, waiting for a ROLLBACK query to complete, in vain, until the context timed out.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
