### PR TITLE
chore: gateway health endpoint should return 503 if db is down

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -149,9 +149,10 @@ func LivenessHandler(jobsDB jobsdb.JobsDB) http.HandlerFunc {
 
 func getHealthVal(jobsDB jobsdb.JobsDB) (bool, string) {
 	dbService := "UP"
+	healthy := true
 	if jobsDB.Ping() != nil {
 		dbService = "DOWN"
-		return false, ""
+		healthy = false
 	}
 	enabledRouter := "TRUE"
 	if !config.GetBool("enableRouter", true) {
@@ -163,7 +164,7 @@ func getHealthVal(jobsDB jobsdb.JobsDB) (bool, string) {
 	}
 
 	appTypeStr := strings.ToUpper(config.GetString("APP_TYPE", EMBEDDED))
-	return true, fmt.Sprintf(
+	return healthy, fmt.Sprintf(
 		`{"appType":"%s","server":"UP","db":"%s","acceptingEvents":"TRUE","routingEvents":"%s","mode":"%s",`+
 			`"backendConfigMode":"%s","lastSync":"%s","lastRegulationSync":"%s"}`,
 		appTypeStr, dbService, enabledRouter, strings.ToUpper(db.CurrentMode),


### PR DESCRIPTION
# Description

`/health` returns 503 if db is down

## Notion Ticket

https://www.notion.so/rudderstacks/Improve-gateway-health-endpoint-86bae24700cc424ca7e44d7b9cde4bd9

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
