### PR TITLE
chore: flaky downloader test

### DIFF
--- a/warehouse/internal/service/loadfiles/downloader/downloader_test.go
+++ b/warehouse/internal/service/loadfiles/downloader/downloader_test.go
@@ -58,7 +58,6 @@ func TestDownloader(t *testing.T) {
 	require.NoError(t, err)
 
 	var (
-		minioResource *destination.MINIOResource
 		destType      = "POSTGRES"
 		provider      = "MINIO"
 		workers       = 12
@@ -115,7 +114,7 @@ func TestDownloader(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			minioResource, err = destination.SetupMINIO(pool, t)
+			minioResource, err := destination.SetupMINIO(pool, t)
 			require.NoError(t, err)
 
 			conf := map[string]any{


### PR DESCRIPTION
# Description

- Flaky test
```
    downloader_test.go:119: 
        	Error Trace:	/home/runner/work/rudder-server/rudder-server/warehouse/internal/service/loadfiles/downloader/downloader_test.go:119
        	Error:      	Received unexpected error:
        	            	Your previous request to create the named bucket succeeded and you already own it.
        	Test:       	TestDownloader/invalid_bucket_provider
    --- FAIL: TestDownloader/invalid_bucket_provider (1.00s)
```


## Notion Ticket

https://www.notion.so/rudderstacks/Flaky-test-e6affd12b9cf4e469d135e4dc71f7738?pvs=4

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
