### PR TITLE
chore: replace announcement header with data learning centre link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-💬 Join <b><a href="https://rudderstack.com/join-rudderstack-slack-community">Join the commmunity of Data Engineers on Slack</a></b>
+📖 Just launched <b><a href="https://www.rudderstack.com/learn/">Data Learning Center</a></b> - Resources on data engineering and data infrastructure
   <br/>
  </p>
 


### PR DESCRIPTION
# Description

Data Learning Center is a great resource for Data Engineers. Replace current slack link in announcement with the link to Data Learning Center.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
