### PR TITLE
fix: batchrouter acquiring a read lock twice

### DIFF
--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -82,7 +82,7 @@ func (brt *Handle) Setup(
 	var err error
 	if brt.isolationStrategy, err = isolation.GetStrategy(isolation.Mode(isolationMode), destType, func(destinationID string) bool {
 		brt.configSubscriberMu.RLock()
-		defer brt.configSubscriberMu.RLock()
+		defer brt.configSubscriberMu.RUnlock()
 		_, ok := brt.destinationsMap[destinationID]
 		return ok
 	}); err != nil {


### PR DESCRIPTION
# Description

Instead of releasing the read lock batchrouter was acquiring a second read lock, causing a deadlock the next time a new configuration arrived

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=69479a67439a441fba477d3e1f880cc7&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
