### PR TITLE
fix: databricks external table validations

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -94,6 +94,11 @@ jobs:
           SNOWFLAKE_RBAC_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.SNOWFLAKE_RBAC_INTEGRATION_TEST_CREDENTIALS }}
           RSERVER_WAREHOUSE_POSTGRES_USE_LEGACY: ${{ matrix.useLegacy }}
           RSERVER_WAREHOUSE_DELTALAKE_USE_NATIVE: ${{ matrix.useNative }}
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.destination }}
+          path: coverage.txt
 
   unit:
     name: Unit
@@ -117,6 +122,30 @@ jobs:
           TEST_S3_DATALAKE_CREDENTIALS: ${{ secrets.TEST_S3_DATALAKE_CREDENTIALS }}
           BIGQUERY_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.BIGQUERY_INTEGRATION_TEST_CREDENTIALS }}
         run: make test
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: unit
+          path: coverage.txt
+
+  coverage:
+    needs: [warehouse-integration, unit]
+    runs-on: 'ubuntu-20.04'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '~1.20.3'
+          check-latest: true
+      - name: Download coverage reports
+        uses: actions/download-artifact@v3
+      - name: Merge Coverage
+        run: |
+          go install github.com/wadey/gocovmerge@latest
+          gocovmerge */coverage.txt > coverage.txt
       - uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
+          files: ./coverage.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -149,3 +149,15 @@ jobs:
         with:
           fail_ci_if_error: true
           files: ./coverage.txt
+
+  all-tests-successful:
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - integration
+      - warehouse-integration
+      - unit
+    steps:
+      - uses: re-actors/alls-green@v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ test: install-tools test-run test-teardown
 test-run: ## Run all unit tests
 ifeq ($(filter 1,$(debug) $(RUNNER_DEBUG)),)
 	$(eval TEST_CMD = SLOW=0 gotestsum --format pkgname-and-test-fails --)
-	$(eval TEST_OPTIONS = -p=1 -v -failfast -shuffle=on -coverprofile=profile.out -covermode=count -coverpkg=./... -vet=all --timeout=15m)
+	$(eval TEST_OPTIONS = -p=1 -v -failfast -shuffle=on -coverprofile=profile.out -covermode=atomic -coverpkg=./... -vet=all --timeout=15m)
 else
 	$(eval TEST_CMD = SLOW=0 go test)
-	$(eval TEST_OPTIONS = -p=1 -v -failfast -shuffle=on -coverprofile=profile.out -covermode=count -coverpkg=./... -vet=all --timeout=15m)
+	$(eval TEST_OPTIONS = -p=1 -v -failfast -shuffle=on -coverprofile=profile.out -covermode=atomic -coverpkg=./... -vet=all --timeout=15m)
 endif
 ifdef package
 	$(TEST_CMD) $(TEST_OPTIONS) $(package) && touch $(TESTFILE) || true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-💬 Join <b><a href="https://rudderstack.com/join-rudderstack-slack-community">Join the commmunity of Data Engineers on Slack</a></b>
+📖 Just launched <b><a href="https://www.rudderstack.com/learn/">Data Learning Center</a></b> - Resources on data engineering and data infrastructure
   <br/>
  </p>
 

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/sony/gobreaker v0.5.0
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/spf13/viper v1.15.0
-	github.com/stretchr/testify v1.8.2
+	github.com/stretchr/testify v1.8.3
 	github.com/tidwall/gjson v1.14.4
 	github.com/tidwall/sjson v1.2.5
 	github.com/urfave/cli/v2 v2.25.3

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	golang.org/x/exp v0.0.0-20230418202329-0354be287a23
 	golang.org/x/oauth2 v0.8.0
 	golang.org/x/sync v0.2.0
-	google.golang.org/api v0.122.0
+	google.golang.org/api v0.123.0
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.55.0
 	google.golang.org/protobuf v1.30.0

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mkmik/multierror v0.3.0
 	github.com/onsi/ginkgo/v2 v2.9.5
-	github.com/onsi/gomega v1.27.6
+	github.com/onsi/gomega v1.27.7
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/prometheus/client_model v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/linkedin/goavro/v2 v2.12.0
 	github.com/minio/minio-go v6.0.14+incompatible
 	github.com/minio/minio-go/v6 v6.0.57
-	github.com/minio/minio-go/v7 v7.0.52
+	github.com/minio/minio-go/v7 v7.0.53
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mkmik/multierror v0.3.0
 	github.com/onsi/ginkgo/v2 v2.9.5

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/allisson/go-pglock/v2 v2.0.1
 	github.com/apache/pulsar-client-go v0.10.0
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
-	github.com/aws/aws-sdk-go v1.44.265
+	github.com/aws/aws-sdk-go v1.44.266
 	github.com/bugsnag/bugsnag-go/v2 v2.2.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/allisson/go-pglock/v2 v2.0.1
 	github.com/apache/pulsar-client-go v0.10.0
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
-	github.com/aws/aws-sdk-go v1.44.264
+	github.com/aws/aws-sdk-go v1.44.265
 	github.com/bugsnag/bugsnag-go/v2 v2.2.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1

--- a/go.sum
+++ b/go.sum
@@ -1742,8 +1742,8 @@ github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDs
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
-github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
-github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
+github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
+github.com/onsi/gomega v1.27.7/go.mod h1:1p8OOlwo2iUUDsHnOrjE5UKYJ+e3W8eQ3qSlRahPmr4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=

--- a/go.sum
+++ b/go.sum
@@ -2554,8 +2554,8 @@ google.golang.org/api v0.108.0/go.mod h1:2Ts0XTHNVWxypznxWOYUeI4g3WdP9Pk2Qk58+a/
 google.golang.org/api v0.110.0/go.mod h1:7FC4Vvx1Mooxh8C5HWjzZHcavuS2f6pmJpZx60ca7iI=
 google.golang.org/api v0.111.0/go.mod h1:qtFHvU9mhgTJegR31csQ+rwxyUTHOKFqCKWp1J0fdw0=
 google.golang.org/api v0.114.0/go.mod h1:ifYI2ZsFK6/uGddGfAD5BMxlnkBqCmqHSDUVi45N5Yg=
-google.golang.org/api v0.122.0 h1:zDobeejm3E7pEG1mNHvdxvjs5XJoCMzyNH+CmwL94Es=
-google.golang.org/api v0.122.0/go.mod h1:gcitW0lvnyWjSp9nKxAbdHKIZ6vF4aajGueeslZOyms=
+google.golang.org/api v0.123.0 h1:yHVU//vA+qkOhm4reEC9LtzHVUCN/IqqNRl1iQ9xE20=
+google.golang.org/api v0.123.0/go.mod h1:gcitW0lvnyWjSp9nKxAbdHKIZ6vF4aajGueeslZOyms=
 google.golang.org/appengine v1.0.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/go.sum
+++ b/go.sum
@@ -1939,8 +1939,9 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
+github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/go.sum
+++ b/go.sum
@@ -768,8 +768,8 @@ github.com/aws/aws-sdk-go v1.30.19/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZve
 github.com/aws/aws-sdk-go v1.32.6/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.43.31/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/aws-sdk-go v1.44.265 h1:rlBuD8OYjM5Vfcf7jDa264oVHqlPqY7y7o+JmrjNFUc=
-github.com/aws/aws-sdk-go v1.44.265/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.44.266 h1:MWd775dcYf7NrwgcHLtlsIbWoWkX8p4vomfNHr88zH0=
+github.com/aws/aws-sdk-go v1.44.266/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.8.0/go.mod h1:xEFuWz+3TYdlPRuo+CqATbeDWIWyaT5uAPwPaWtgse0=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.16.2/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=

--- a/go.sum
+++ b/go.sum
@@ -1653,8 +1653,8 @@ github.com/minio/minio-go v6.0.14+incompatible/go.mod h1:7guKYtitv8dktvNUGrhzmNl
 github.com/minio/minio-go/v6 v6.0.57 h1:ixPkbKkyD7IhnluRgQpGSpHdpvNVaW6OD5R9IAO/9Tw=
 github.com/minio/minio-go/v6 v6.0.57/go.mod h1:5+R/nM9Pwrh0vqF+HbYYDQ84wdUFPyXHkrdT4AIkifM=
 github.com/minio/minio-go/v7 v7.0.34/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=
-github.com/minio/minio-go/v7 v7.0.52 h1:8XhG36F6oKQUDDSuz6dY3rioMzovKjW40W6ANuN0Dps=
-github.com/minio/minio-go/v7 v7.0.52/go.mod h1:IbbodHyjUAguneyucUaahv+VMNs/EOTV9du7A7/Z3HU=
+github.com/minio/minio-go/v7 v7.0.53 h1:qtPyQ+b0Cc1ums3LsnVMAYULPNdAGz8qdX8R2zl9XMU=
+github.com/minio/minio-go/v7 v7.0.53/go.mod h1:IbbodHyjUAguneyucUaahv+VMNs/EOTV9du7A7/Z3HU=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=

--- a/go.sum
+++ b/go.sum
@@ -768,8 +768,8 @@ github.com/aws/aws-sdk-go v1.30.19/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZve
 github.com/aws/aws-sdk-go v1.32.6/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.43.31/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/aws-sdk-go v1.44.264 h1:5klL62ebn6uv3oJ0ixF7K12hKItj8lV3QqWeQPlkFSs=
-github.com/aws/aws-sdk-go v1.44.264/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.44.265 h1:rlBuD8OYjM5Vfcf7jDa264oVHqlPqY7y7o+JmrjNFUc=
+github.com/aws/aws-sdk-go v1.44.265/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.8.0/go.mod h1:xEFuWz+3TYdlPRuo+CqATbeDWIWyaT5uAPwPaWtgse0=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.16.2/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=

--- a/warehouse/errors.go
+++ b/warehouse/errors.go
@@ -9,11 +9,7 @@ import (
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 )
 
-var (
-	ErrIncompatibleSchemaConversion = errors.New("incompatible schema conversion")
-	ErrSchemaConversionNotSupported = errors.New("schema conversion not supported")
-	ErrCancellingStatement          = errors.New("[error] pq: canceling statement due to user request")
-)
+var ErrCancellingStatement = errors.New("[error] pq: canceling statement due to user request")
 
 type InvalidDestinationCredErr struct {
 	Base      error

--- a/warehouse/integrations/deltalake-native/deltalake_test.go
+++ b/warehouse/integrations/deltalake-native/deltalake_test.go
@@ -328,6 +328,7 @@ func TestIntegration(t *testing.T) {
 		testCases := []struct {
 			name                string
 			useParquetLoadFiles bool
+			conf                map[string]interface{}
 		}{
 			{
 				name:                "Parquet load files",
@@ -337,6 +338,14 @@ func TestIntegration(t *testing.T) {
 				name:                "CSV load files",
 				useParquetLoadFiles: false,
 			},
+			{
+				name:                "External location",
+				useParquetLoadFiles: true,
+				conf: map[string]interface{}{
+					"enableExternalLocation": true,
+					"externalLocation":       "/path/to/delta/table",
+				},
+			},
 		}
 
 		for _, tc := range testCases {
@@ -344,6 +353,11 @@ func TestIntegration(t *testing.T) {
 
 			t.Run(tc.name, func(t *testing.T) {
 				t.Setenv("RSERVER_WAREHOUSE_DELTALAKE_USE_PARQUET_LOAD_FILES", strconv.FormatBool(tc.useParquetLoadFiles))
+
+				for k, v := range tc.conf {
+					dest.Config[k] = v
+				}
+
 				testhelper.VerifyConfigurationTest(t, dest)
 			})
 		}

--- a/warehouse/internal/loadfiles/loadfiles_test.go
+++ b/warehouse/internal/loadfiles/loadfiles_test.go
@@ -1,5 +1,3 @@
-//go:build !warehouse_integration
-
 package loadfiles_test
 
 import (

--- a/warehouse/internal/repo/load_test.go
+++ b/warehouse/internal/repo/load_test.go
@@ -1,5 +1,3 @@
-//go:build !warehouse_integration
-
 package repo_test
 
 import (

--- a/warehouse/internal/repo/staging.go
+++ b/warehouse/internal/repo/staging.go
@@ -251,22 +251,42 @@ func (repo *StagingFiles) GetByID(ctx context.Context, ID int64) (model.StagingF
 	return *entries[0], err
 }
 
-// GetSchemaByID returns staging file schema field the given ID.
-func (repo *StagingFiles) GetSchemaByID(ctx context.Context, ID int64) (jsonstd.RawMessage, error) {
-	query := `SELECT schema FROM ` + stagingTableName + ` WHERE id = $1`
+// GetSchemasByIDs returns staging file schemas for the given IDs.
+func (repo *StagingFiles) GetSchemasByIDs(ctx context.Context, ids []int64) ([]model.Schema, error) {
+	query := `SELECT schema FROM ` + stagingTableName + ` WHERE id = ANY ($1);`
 
-	row := repo.db.QueryRowContext(ctx, query, ID)
-	if row.Err() != nil {
-		return nil, fmt.Errorf("querying staging files: %w", row.Err())
-	}
-
-	var schema jsonstd.RawMessage
-	err := row.Scan(&schema)
+	rows, err := repo.db.QueryContext(ctx, query, pq.Array(ids))
 	if err != nil {
-		return nil, fmt.Errorf("parsing rows: %w", err)
+		return nil, fmt.Errorf("querying schemas: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	schemas := make([]model.Schema, 0, len(ids))
+
+	for rows.Next() {
+		var (
+			rawSchema jsonstd.RawMessage
+			schema    model.Schema
+		)
+
+		if err := rows.Scan(&rawSchema); err != nil {
+			return nil, fmt.Errorf("cannot get schemas by ids: scanning row: %w", err)
+		}
+		if err := json.Unmarshal(rawSchema, &schema); err != nil {
+			return nil, fmt.Errorf("cannot get schemas by ids: unmarshal staging schema: %w", err)
+		}
+
+		schemas = append(schemas, schema)
 	}
 
-	return schema, err
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot get schemas by ids: iterating rows: %w", err)
+	}
+	if len(schemas) != len(ids) {
+		return nil, fmt.Errorf("cannot get schemas by ids: not all schemas were found")
+	}
+
+	return schemas, nil
 }
 
 // GetForUploadID returns all the staging files for that uploadID

--- a/warehouse/internal/repo/staging_test.go
+++ b/warehouse/internal/repo/staging_test.go
@@ -1,5 +1,3 @@
-//go:build !warehouse_integration
-
 package repo_test
 
 import (
@@ -127,11 +125,6 @@ func TestStagingFileRepo(t *testing.T) {
 			expected.UpdatedAt = now
 
 			require.Equal(t, expected.StagingFile, retrieved)
-
-			schema, err := r.GetSchemaByID(ctx, id)
-			require.NoError(t, err)
-
-			require.Equal(t, expected.Schema, schema)
 		})
 	}
 
@@ -166,6 +159,8 @@ func manyStagingFiles(size int, now time.Time) []*model.StagingFile {
 }
 
 func TestStagingFileRepo_Many(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	now := time.Now().Truncate(time.Second).UTC()
@@ -178,7 +173,7 @@ func TestStagingFileRepo_Many(t *testing.T) {
 
 	stagingFiles := manyStagingFiles(10, now)
 	for i := range stagingFiles {
-		file := stagingFiles[i].WithSchema([]byte(`{"type": "object"}`))
+		file := stagingFiles[i].WithSchema([]byte(`{"table": {"column": "type"} }`))
 		id, err := r.Insert(ctx, &file)
 		require.NoError(t, err)
 		stagingFiles[i].ID = id
@@ -230,6 +225,69 @@ func TestStagingFileRepo_Many(t *testing.T) {
 				require.Equal(t, tc.expected, retrieved)
 			})
 		}
+	})
+
+	t.Run("GetSchemasByIDs", func(t *testing.T) {
+		t.Run("get all", func(t *testing.T) {
+			t.Parallel()
+
+			stagingIDs := repo.StagingFileIDs(stagingFiles)
+			expectedSchemas, err := r.GetSchemasByIDs(ctx, stagingIDs)
+			require.NoError(t, err)
+			require.Len(t, expectedSchemas, len(stagingFiles))
+
+			for _, es := range expectedSchemas {
+				require.EqualValues(t, model.Schema{
+					"table": model.TableSchema{
+						"column": "type",
+					},
+				}, es)
+			}
+		})
+
+		t.Run("missing id", func(t *testing.T) {
+			t.Parallel()
+
+			expectedSchemas, err := r.GetSchemasByIDs(ctx, []int64{1, 2, 3, 101, 102, 103})
+			require.EqualError(t, err, "cannot get schemas by ids: not all schemas were found")
+			require.Nil(t, expectedSchemas)
+		})
+
+		t.Run("context canceled", func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			stagingIDs := repo.StagingFileIDs(stagingFiles)
+			expectedSchemas, err := r.GetSchemasByIDs(ctx, stagingIDs)
+			require.EqualError(t, err, "querying schemas: context canceled")
+			require.Nil(t, expectedSchemas)
+		})
+
+		t.Run("invalid JSON", func(t *testing.T) {
+			db := setupDB(t)
+
+			_, err := db.ExecContext(ctx, `
+				INSERT INTO wh_staging_files (
+				  location, source_id, destination_id,
+				  schema, created_at, updated_at, workspace_id
+				)
+				VALUES
+				  (
+					's3://bucket/path/to/file', 'source_id',
+					'destination_id', '1', NOW(), NOW(),
+					'workspace_id'
+				  );
+			`)
+			require.NoError(t, err)
+
+			r := repo.NewStagingFiles(db)
+
+			expectedSchemas, err := r.GetSchemasByIDs(ctx, []int64{1})
+			require.EqualError(t, err, "cannot get schemas by ids: unmarshal staging schema: ReadMapCB: expect { or n, but found 1, error found in #1 byte of ...|1|..., bigger context ...|1|...")
+			require.Nil(t, expectedSchemas)
+		})
 	})
 }
 

--- a/warehouse/schema.go
+++ b/warehouse/schema.go
@@ -3,92 +3,79 @@ package warehouse
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 
-	"github.com/rudderlabs/rudder-server/warehouse/internal/repo"
 	"golang.org/x/exp/slices"
 
-	"github.com/rudderlabs/rudder-server/utils/misc"
-	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/samber/lo"
+
+	"github.com/rudderlabs/rudder-server/warehouse/internal/repo"
+
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
-type SchemaHandle struct {
-	dbHandle                      *sql.DB
-	stagingFiles                  []*model.StagingFile
-	warehouse                     model.Warehouse
-	localSchema                   model.Schema
-	schemaInWarehouse             model.Schema
-	unrecognizedSchemaInWarehouse model.Schema
-	uploadSchema                  model.Schema
-	whSchemaRepo                  *repo.WHSchema
+var (
+	errIncompatibleSchemaConversion = errors.New("incompatible schema conversion")
+	errSchemaConversionNotSupported = errors.New("schema conversion not supported")
+)
+
+// deprecatedColumnsRegex
+// This regex is used to identify deprecated columns in the warehouse
+// Example: abc-deprecated-dba626a7-406a-4757-b3e0-3875559c5840
+var deprecatedColumnsRegex = regexp.MustCompile(`.*-deprecated-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+type schemaRepo interface {
+	GetForNamespace(ctx context.Context, sourceID, destID, namespace string) (model.WHSchema, error)
+	Insert(ctx context.Context, whSchema *model.WHSchema) (int64, error)
 }
 
-func HandleSchemaChange(existingDataType, currentDataType model.SchemaType, value any) (any, error) {
-	var (
-		newColumnVal any
-		err          error
-	)
-
-	if existingDataType == model.StringDataType || existingDataType == model.TextDataType {
-		// only stringify if the previous type is non-string/text/json
-		if currentDataType != model.StringDataType && currentDataType != model.TextDataType && currentDataType != model.JSONDataType {
-			newColumnVal = fmt.Sprintf("%v", value)
-		} else {
-			newColumnVal = value
-		}
-	} else if (currentDataType == model.IntDataType || currentDataType == model.BigIntDataType) && existingDataType == model.FloatDataType {
-		intVal, ok := value.(int)
-		if !ok {
-			err = ErrIncompatibleSchemaConversion
-		} else {
-			newColumnVal = float64(intVal)
-		}
-	} else if currentDataType == model.FloatDataType && (existingDataType == model.IntDataType || existingDataType == model.BigIntDataType) {
-		floatVal, ok := value.(float64)
-		if !ok {
-			err = ErrIncompatibleSchemaConversion
-		} else {
-			newColumnVal = int(floatVal)
-		}
-	} else if existingDataType == model.JSONDataType {
-		var interfaceSliceSample []any
-		if currentDataType == model.IntDataType || currentDataType == model.FloatDataType || currentDataType == model.BooleanDataType {
-			newColumnVal = fmt.Sprintf("%v", value)
-		} else if reflect.TypeOf(value) == reflect.TypeOf(interfaceSliceSample) {
-			newColumnVal = value
-		} else {
-			newColumnVal = fmt.Sprintf(`"%v"`, value)
-		}
-	} else {
-		err = ErrSchemaConversionNotSupported
-	}
-
-	return newColumnVal, err
+type stagingFileRepo interface {
+	GetSchemasByIDs(ctx context.Context, ids []int64) ([]model.Schema, error)
 }
 
-func (sh *SchemaHandle) getLocalSchema() (model.Schema, error) {
-	whSchema, err := sh.whSchemaRepo.GetForNamespace(
-		context.TODO(),
-		sh.warehouse.Source.ID,
-		sh.warehouse.Destination.ID,
-		sh.warehouse.Namespace,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("get schema for namespace: %w", err)
-	}
-	if whSchema.Schema == nil {
-		return model.Schema{}, nil
-	}
-	return whSchema.Schema, nil
+type fetchSchemaRepo interface {
+	FetchSchema() (model.Schema, model.Schema, error)
 }
 
-func (sh *SchemaHandle) updateLocalSchema(uploadId int64, updatedSchema model.Schema) error {
-	_, err := sh.whSchemaRepo.Insert(context.TODO(), &model.WHSchema{
+type Schema struct {
+	warehouse                        model.Warehouse
+	localSchema                      model.Schema
+	schemaInWarehouse                model.Schema
+	unrecognizedSchemaInWarehouse    model.Schema
+	uploadSchema                     model.Schema
+	schemaRepo                       schemaRepo
+	stagingFileRepo                  stagingFileRepo
+	log                              logger.Logger
+	stagingFilesSchemaPaginationSize int
+	skipDeepEqualSchemas             bool
+	enableIDResolution               bool
+}
+
+func NewSchema(
+	db *sql.DB,
+	warehouse model.Warehouse,
+	conf *config.Config,
+) *Schema {
+	return &Schema{
+		warehouse:                        warehouse,
+		schemaRepo:                       repo.NewWHSchemas(db),
+		stagingFileRepo:                  repo.NewStagingFiles(db),
+		log:                              logger.NewLogger().Child("warehouse").Child("schema"),
+		stagingFilesSchemaPaginationSize: conf.GetInt("Warehouse.stagingFilesSchemaPaginationSize", 100),
+		skipDeepEqualSchemas:             conf.GetBool("Warehouse.skipDeepEqualSchemas", false),
+		enableIDResolution:               conf.GetBool("Warehouse.enableIDResolution", false),
+	}
+}
+
+func (sh *Schema) updateLocalSchema(uploadId int64, updatedSchema model.Schema) error {
+	_, err := sh.schemaRepo.Insert(context.TODO(), &model.WHSchema{
 		UploadID:        uploadId,
 		SourceID:        sh.warehouse.Source.ID,
 		Namespace:       sh.warehouse.Namespace,
@@ -96,26 +83,65 @@ func (sh *SchemaHandle) updateLocalSchema(uploadId int64, updatedSchema model.Sc
 		DestinationType: sh.warehouse.Type,
 		Schema:          updatedSchema,
 	})
-	return err
-}
-
-func (sh *SchemaHandle) fetchSchemaFromWarehouse(whManager manager.Manager) (schemaInWarehouse, unrecognizedSchemaInWarehouse model.Schema, err error) {
-	schemaInWarehouse, unrecognizedSchemaInWarehouse, err = whManager.FetchSchema()
 	if err != nil {
-		pkgLogger.Errorf(`[WH]: Failed fetching schema from warehouse: %v`, err)
-		return model.Schema{}, model.Schema{}, err
+		return fmt.Errorf("updating local schema: %w", err)
 	}
 
-	sh.SkipDeprecatedColumns(schemaInWarehouse)
-	sh.SkipDeprecatedColumns(unrecognizedSchemaInWarehouse)
-	return schemaInWarehouse, unrecognizedSchemaInWarehouse, nil
+	sh.localSchema = updatedSchema
+
+	return nil
 }
 
-func (sh *SchemaHandle) SkipDeprecatedColumns(schema model.Schema) {
+// fetchSchemaFromLocal fetches schema from local
+func (sh *Schema) fetchSchemaFromLocal() error {
+	localSchema, err := sh.getLocalSchema()
+	if err != nil {
+		return fmt.Errorf("fetching schema from local: %w", err)
+	}
+
+	sh.localSchema = localSchema
+
+	return nil
+}
+
+func (sh *Schema) getLocalSchema() (model.Schema, error) {
+	whSchema, err := sh.schemaRepo.GetForNamespace(
+		context.TODO(),
+		sh.warehouse.Source.ID,
+		sh.warehouse.Destination.ID,
+		sh.warehouse.Namespace,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("getting schema for namespace: %w", err)
+	}
+	if whSchema.Schema == nil {
+		return model.Schema{}, nil
+	}
+	return whSchema.Schema, nil
+}
+
+// fetchSchemaFromWarehouse fetches schema from warehouse
+func (sh *Schema) fetchSchemaFromWarehouse(repo fetchSchemaRepo) error {
+	warehouseSchema, unrecognizedWarehouseSchema, err := repo.FetchSchema()
+	if err != nil {
+		return fmt.Errorf("fetching schema from warehouse: %w", err)
+	}
+
+	sh.skipDeprecatedColumns(warehouseSchema)
+	sh.skipDeprecatedColumns(unrecognizedWarehouseSchema)
+
+	sh.schemaInWarehouse = warehouseSchema
+	sh.unrecognizedSchemaInWarehouse = unrecognizedWarehouseSchema
+
+	return nil
+}
+
+// skipDeprecatedColumns skips deprecated columns from the schema
+func (sh *Schema) skipDeprecatedColumns(schema model.Schema) {
 	for tableName, columnMap := range schema {
 		for columnName := range columnMap {
-			if warehouseutils.DeprecatedColumnsRegex.MatchString(columnName) {
-				pkgLogger.Debugw("skipping deprecated column",
+			if deprecatedColumnsRegex.MatchString(columnName) {
+				sh.log.Debugw("skipping deprecated column",
 					logfield.SourceID, sh.warehouse.Source.ID,
 					logfield.DestinationID, sh.warehouse.Destination.ID,
 					logfield.DestinationType, sh.warehouse.Destination.DestinationDefinition.Name,
@@ -131,198 +157,174 @@ func (sh *SchemaHandle) SkipDeprecatedColumns(schema model.Schema) {
 	}
 }
 
-func MergeSchema(currentSchema model.Schema, schemaList []model.Schema, currentMergedSchema model.Schema, warehouseType string) model.Schema {
-	if len(currentMergedSchema) == 0 {
-		currentMergedSchema = model.Schema{}
+func (sh *Schema) prepareUploadSchema(stagingFiles []*model.StagingFile) error {
+	consolidatedSchema, err := sh.consolidateStagingFilesSchemaUsingWarehouseSchema(stagingFiles)
+	if err != nil {
+		return fmt.Errorf("consolidating staging files schema: %w", err)
 	}
 
-	setColumnTypeFromExistingSchema := func(refSchema model.Schema, tableName, refTableName, columnName, refColumnName, columnType string) bool {
-		columnTypeInDB, ok := refSchema[refTableName][refColumnName]
-		if !ok {
-			return false
+	sh.uploadSchema = consolidatedSchema
+	return nil
+}
+
+// consolidateStagingFilesSchemaUsingWarehouseSchema consolidates staging files schema with warehouse schema
+func (sh *Schema) consolidateStagingFilesSchemaUsingWarehouseSchema(stagingFiles []*model.StagingFile) (model.Schema, error) {
+	consolidatedSchema := model.Schema{}
+	batches := lo.Chunk(stagingFiles, sh.stagingFilesSchemaPaginationSize)
+	for _, batch := range batches {
+		schemas, err := sh.stagingFileRepo.GetSchemasByIDs(
+			context.TODO(),
+			repo.StagingFileIDs(batch),
+		)
+		if err != nil {
+			return model.Schema{}, fmt.Errorf("getting staging files schema: %v", err)
 		}
-		if columnTypeInDB == "string" && columnType == "text" {
-			currentMergedSchema[tableName][columnName] = columnType
-			return true
-		}
-		// if columnTypeInDB is text, then we should not change it to string
-		if currentMergedSchema[tableName][columnName] == "text" {
-			return true
-		}
-		currentMergedSchema[tableName][columnName] = columnTypeInDB
-		return true
+
+		consolidatedSchema = consolidateStagingSchemas(consolidatedSchema, schemas)
 	}
+	consolidatedSchema = consolidateWarehouseSchema(consolidatedSchema, sh.localSchema)
+	consolidatedSchema = overrideUsersWithIdentifiesSchema(consolidatedSchema, sh.warehouse.Type)
+	consolidatedSchema = enhanceDiscardsSchema(consolidatedSchema, sh.warehouse.Type)
+	consolidatedSchema = enhanceSchemaWithIDResolution(consolidatedSchema, sh.isIDResolutionEnabled(), sh.warehouse.Type)
+	return consolidatedSchema, nil
+}
 
-	usersTableName := warehouseutils.ToProviderCase(warehouseType, "users")
-	identifiesTableName := warehouseutils.ToProviderCase(warehouseType, "identifies")
-
-	for _, schema := range schemaList {
+// consolidateStagingSchemas merges multiple schemas into one
+// Prefer the type of the first schema, If the type is text, prefer text
+func consolidateStagingSchemas(consolidatedSchema model.Schema, schemas []model.Schema) model.Schema {
+	for _, schema := range schemas {
 		for tableName, columnMap := range schema {
-			if currentMergedSchema[tableName] == nil {
-				currentMergedSchema[tableName] = make(model.TableSchema)
-			}
-			var toInferFromIdentifies bool
-			var refSchema model.Schema
-			if tableName == usersTableName {
-				if _, ok := currentSchema[identifiesTableName]; ok {
-					toInferFromIdentifies = true
-					refSchema = currentSchema
-				} else if _, ok := currentMergedSchema[identifiesTableName]; ok { // also check in identifies of currentMergedSchema if identifies table not present in warehouse
-					toInferFromIdentifies = true
-					refSchema = currentMergedSchema
-				}
+			if _, ok := consolidatedSchema[tableName]; !ok {
+				consolidatedSchema[tableName] = model.TableSchema{}
 			}
 			for columnName, columnType := range columnMap {
-				// if column already has a type in db, use that
-				// check for data type in identifies for users table before check in users table
-				// to ensure same data type is set for the same column in both users and identifies
-				if tableName == usersTableName && toInferFromIdentifies {
-					refColumnName := columnName
-					if columnName == warehouseutils.ToProviderCase(warehouseType, "id") {
-						refColumnName = warehouseutils.ToProviderCase(warehouseType, "user_id")
-					}
-					if setColumnTypeFromExistingSchema(refSchema, tableName, identifiesTableName, columnName, refColumnName, columnType) {
-						continue
-					}
+				if model.SchemaType(columnType) == model.TextDataType {
+					consolidatedSchema[tableName][columnName] = string(model.TextDataType)
+					continue
 				}
 
-				if _, ok := currentSchema[tableName]; ok {
-					if setColumnTypeFromExistingSchema(currentSchema, tableName, tableName, columnName, columnName, columnType) {
-						continue
-					}
-				}
-				// check if we already set the columnType in currentMergedSchema
-				if _, ok := currentMergedSchema[tableName][columnName]; !ok {
-					currentMergedSchema[tableName][columnName] = columnType
+				if _, ok := consolidatedSchema[tableName][columnName]; !ok {
+					consolidatedSchema[tableName][columnName] = columnType
 				}
 			}
 		}
 	}
-	return currentMergedSchema
+	return consolidatedSchema
 }
 
-func (sh *SchemaHandle) safeName(columnName string) string {
-	return warehouseutils.ToProviderCase(sh.warehouse.Type, columnName)
-}
-
-func (sh *SchemaHandle) getDiscardsSchema() model.TableSchema {
-	discards := model.TableSchema{}
-	for colName, colType := range warehouseutils.DiscardsSchema {
-		discards[sh.safeName(colName)] = colType
-	}
-
-	// add loaded_at for bq to be segment compatible
-	if sh.warehouse.Type == warehouseutils.BQ {
-		discards[sh.safeName("loaded_at")] = "datetime"
-	}
-	return discards
-}
-
-func (sh *SchemaHandle) getMergeRulesSchema() model.TableSchema {
-	return model.TableSchema{
-		sh.safeName("merge_property_1_type"):  "string",
-		sh.safeName("merge_property_1_value"): "string",
-		sh.safeName("merge_property_2_type"):  "string",
-		sh.safeName("merge_property_2_value"): "string",
-	}
-}
-
-func (sh *SchemaHandle) getIdentitiesMappingsSchema() model.TableSchema {
-	return model.TableSchema{
-		sh.safeName("merge_property_type"):  "string",
-		sh.safeName("merge_property_value"): "string",
-		sh.safeName("rudder_id"):            "string",
-		sh.safeName("updated_at"):           "datetime",
-	}
-}
-
-func (sh *SchemaHandle) isIDResolutionEnabled() bool {
-	return warehouseutils.IDResolutionEnabled() && slices.Contains(warehouseutils.IdentityEnabledWarehouses, sh.warehouse.Type)
-}
-
-func (sh *SchemaHandle) consolidateStagingFilesSchemaUsingWarehouseSchema() model.Schema {
-	schemaInLocalDB := sh.localSchema
-
-	consolidatedSchema := model.Schema{}
-	count := 0
-	for {
-		lastIndex := count + stagingFilesSchemaPaginationSize
-		if lastIndex >= len(sh.stagingFiles) {
-			lastIndex = len(sh.stagingFiles)
+// consolidateWarehouseSchema overwrites the consolidatedSchema with the schemaInWarehouse
+// Prefer the type of the schemaInWarehouse, If the type is text, prefer text
+func consolidateWarehouseSchema(consolidatedSchema, warehouseSchema model.Schema) model.Schema {
+	for tableName, columnMap := range warehouseSchema {
+		if _, ok := consolidatedSchema[tableName]; !ok {
+			continue
 		}
 
-		var ids []int64
-		for _, stagingFile := range sh.stagingFiles[count:lastIndex] {
-			ids = append(ids, stagingFile.ID)
-		}
-
-		sqlStatement := fmt.Sprintf(`
-			SELECT
-			  schema
-			FROM
-			  %s
-			WHERE
-			  id IN (%s);
-`,
-			warehouseutils.WarehouseStagingFilesTable,
-			misc.IntArrayToString(ids, ","),
-		)
-		rows, err := sh.dbHandle.Query(sqlStatement)
-		if err != nil && err != sql.ErrNoRows {
-			panic(fmt.Errorf("Query: %s\nfailed with Error : %w", sqlStatement, err))
-		}
-
-		var schemas []model.Schema
-		for rows.Next() {
-			var s json.RawMessage
-			err := rows.Scan(&s)
-			if err != nil {
-				panic(fmt.Errorf("Failed to scan result from query: %s\nwith Error : %w", sqlStatement, err))
-			}
-			var schema model.Schema
-			err = json.Unmarshal(s, &schema)
-			if err != nil {
-				panic(fmt.Errorf("unmarshalling: %s failed with Error : %w", string(s), err))
+		for columnName, columnType := range columnMap {
+			if _, ok := consolidatedSchema[tableName][columnName]; !ok {
+				continue
 			}
 
-			schemas = append(schemas, schema)
-		}
-		_ = rows.Close()
+			var (
+				consolidatedSchemaType = model.SchemaType(consolidatedSchema[tableName][columnName])
+				warehouseSchemaType    = model.SchemaType(columnType)
+			)
 
-		consolidatedSchema = MergeSchema(schemaInLocalDB, schemas, consolidatedSchema, sh.warehouse.Type)
+			if consolidatedSchemaType == model.TextDataType && warehouseSchemaType == model.StringDataType {
+				continue
+			}
 
-		count += stagingFilesSchemaPaginationSize
-		if count >= len(sh.stagingFiles) {
-			break
-		}
-	}
-
-	// add rudder_discards Schema
-	consolidatedSchema[sh.safeName(warehouseutils.DiscardsTable)] = sh.getDiscardsSchema()
-
-	// add rudder_identity_mappings Schema
-	if sh.isIDResolutionEnabled() {
-		if _, ok := consolidatedSchema[sh.safeName(warehouseutils.IdentityMergeRulesTable)]; ok {
-			consolidatedSchema[sh.safeName(warehouseutils.IdentityMergeRulesTable)] = sh.getMergeRulesSchema()
-			consolidatedSchema[sh.safeName(warehouseutils.IdentityMappingsTable)] = sh.getIdentitiesMappingsSchema()
+			consolidatedSchema[tableName][columnName] = columnType
 		}
 	}
+	return consolidatedSchema
+}
+
+// overrideUsersWithIdentifiesSchema overrides the users table with the identifies table
+// users(id) <-> identifies(user_id)
+// Removes the user_id column from the users table
+func overrideUsersWithIdentifiesSchema(consolidatedSchema model.Schema, warehouseType string) model.Schema {
+	var (
+		usersTable      = warehouseutils.ToProviderCase(warehouseType, warehouseutils.UsersTable)
+		identifiesTable = warehouseutils.ToProviderCase(warehouseType, warehouseutils.IdentifiesTable)
+		userIDColumn    = warehouseutils.ToProviderCase(warehouseType, "user_id")
+		IDColumn        = warehouseutils.ToProviderCase(warehouseType, "id")
+	)
+
+	if _, ok := consolidatedSchema[usersTable]; !ok {
+		return consolidatedSchema
+	}
+	if _, ok := consolidatedSchema[identifiesTable]; !ok {
+		return consolidatedSchema
+	}
+
+	for k, v := range consolidatedSchema[identifiesTable] {
+		consolidatedSchema[usersTable][k] = v
+	}
+
+	consolidatedSchema[usersTable][IDColumn] = consolidatedSchema[identifiesTable][userIDColumn]
+	delete(consolidatedSchema[usersTable], userIDColumn)
 
 	return consolidatedSchema
 }
 
-// hasSchemaChanged Default behaviour is to do the deep equals.
-// If we are skipping deep equals, then we are validating local schemas against warehouse schemas only.
-// Not the other way around.
-func hasSchemaChanged(localSchema, schemaInWarehouse model.Schema) bool {
-	if !skipDeepEqualSchemas {
-		eq := reflect.DeepEqual(localSchema, schemaInWarehouse)
+// enhanceDiscardsSchema adds the discards table to the schema
+// For bq, adds the loaded_at column to be segment compatible
+func enhanceDiscardsSchema(consolidatedSchema model.Schema, warehouseType string) model.Schema {
+	discards := model.TableSchema{}
+
+	for colName, colType := range warehouseutils.DiscardsSchema {
+		discards[warehouseutils.ToProviderCase(warehouseType, colName)] = colType
+	}
+
+	if warehouseType == warehouseutils.BQ {
+		discards[warehouseutils.ToProviderCase(warehouseType, "loaded_at")] = "datetime"
+	}
+
+	consolidatedSchema[warehouseutils.ToProviderCase(warehouseType, warehouseutils.DiscardsTable)] = discards
+	return consolidatedSchema
+}
+
+// enhanceSchemaWithIDResolution adds the merge rules and mappings table to the schema if IDResolution is enabled
+func enhanceSchemaWithIDResolution(consolidatedSchema model.Schema, isIDResolutionEnabled bool, warehouseType string) model.Schema {
+	if !isIDResolutionEnabled {
+		return consolidatedSchema
+	}
+	var (
+		mergeRulesTable = warehouseutils.ToProviderCase(warehouseType, warehouseutils.IdentityMergeRulesTable)
+		mappingsTable   = warehouseutils.ToProviderCase(warehouseType, warehouseutils.IdentityMappingsTable)
+	)
+	if _, ok := consolidatedSchema[mergeRulesTable]; ok {
+		consolidatedSchema[mergeRulesTable] = model.TableSchema{
+			warehouseutils.ToProviderCase(warehouseType, "merge_property_1_type"):  "string",
+			warehouseutils.ToProviderCase(warehouseType, "merge_property_1_value"): "string",
+			warehouseutils.ToProviderCase(warehouseType, "merge_property_2_type"):  "string",
+			warehouseutils.ToProviderCase(warehouseType, "merge_property_2_value"): "string",
+		}
+		consolidatedSchema[mappingsTable] = model.TableSchema{
+			warehouseutils.ToProviderCase(warehouseType, "merge_property_type"):  "string",
+			warehouseutils.ToProviderCase(warehouseType, "merge_property_value"): "string",
+			warehouseutils.ToProviderCase(warehouseType, "rudder_id"):            "string",
+			warehouseutils.ToProviderCase(warehouseType, "updated_at"):           "datetime",
+		}
+	}
+	return consolidatedSchema
+}
+
+func (sh *Schema) isIDResolutionEnabled() bool {
+	return sh.enableIDResolution && slices.Contains(warehouseutils.IdentityEnabledWarehouses, sh.warehouse.Type)
+}
+
+// hasSchemaChanged compares the localSchema with the schemaInWarehouse
+func (sh *Schema) hasSchemaChanged() bool {
+	if !sh.skipDeepEqualSchemas {
+		eq := reflect.DeepEqual(sh.localSchema, sh.schemaInWarehouse)
 		return !eq
 	}
 	// Iterating through all tableName in the localSchema
-	for tableName := range localSchema {
-		localColumns := localSchema[tableName]
-		warehouseColumns, whColumnsExist := schemaInWarehouse[tableName]
+	for tableName := range sh.localSchema {
+		localColumns := sh.localSchema[tableName]
+		warehouseColumns, whColumnsExist := sh.schemaInWarehouse[tableName]
 
 		// If warehouse does  not contain the specified table return true.
 		if !whColumnsExist {
@@ -342,32 +344,32 @@ func hasSchemaChanged(localSchema, schemaInWarehouse model.Schema) bool {
 	return false
 }
 
-func getTableSchemaDiff(tableName string, currentSchema, uploadSchema model.Schema) (diff warehouseutils.TableSchemaDiff) {
-	diff = warehouseutils.TableSchemaDiff{
+// generateTableSchemaDiff returns the diff between the warehouse schema and the upload schema
+func (sh *Schema) generateTableSchemaDiff(tableName string) warehouseutils.TableSchemaDiff {
+	diff := warehouseutils.TableSchemaDiff{
 		ColumnMap:        make(model.TableSchema),
 		UpdatedSchema:    make(model.TableSchema),
 		AlteredColumnMap: make(model.TableSchema),
 	}
 
-	var currentTableSchema model.TableSchema
-	var ok bool
-	if currentTableSchema, ok = currentSchema[tableName]; !ok {
-		if _, ok := uploadSchema[tableName]; !ok {
-			return
+	currentTableSchema, ok := sh.schemaInWarehouse[tableName]
+	if !ok {
+		if _, ok := sh.uploadSchema[tableName]; !ok {
+			return diff
 		}
 		diff.Exists = true
 		diff.TableToBeCreated = true
-		diff.ColumnMap = uploadSchema[tableName]
-		diff.UpdatedSchema = uploadSchema[tableName]
+		diff.ColumnMap = sh.uploadSchema[tableName]
+		diff.UpdatedSchema = sh.uploadSchema[tableName]
 		return diff
 	}
 
-	for columnName, columnType := range currentSchema[tableName] {
+	for columnName, columnType := range currentTableSchema {
 		diff.UpdatedSchema[columnName] = columnType
 	}
 
 	diff.ColumnMap = make(model.TableSchema)
-	for columnName, columnType := range uploadSchema[tableName] {
+	for columnName, columnType := range sh.uploadSchema[tableName] {
 		if _, ok := currentTableSchema[columnName]; !ok {
 			diff.ColumnMap[columnName] = columnType
 			diff.UpdatedSchema[columnName] = columnType
@@ -379,4 +381,48 @@ func getTableSchemaDiff(tableName string, currentSchema, uploadSchema model.Sche
 		}
 	}
 	return diff
+}
+
+// handleSchemaChange checks if the existing column type is compatible with the new column type
+func handleSchemaChange(existingDataType, currentDataType model.SchemaType, value any) (any, error) {
+	var (
+		newColumnVal any
+		err          error
+	)
+
+	if existingDataType == model.StringDataType || existingDataType == model.TextDataType {
+		// only stringify if the previous type is non-string/text/json
+		if currentDataType != model.StringDataType && currentDataType != model.TextDataType && currentDataType != model.JSONDataType {
+			newColumnVal = fmt.Sprintf("%v", value)
+		} else {
+			newColumnVal = value
+		}
+	} else if (currentDataType == model.IntDataType || currentDataType == model.BigIntDataType) && existingDataType == model.FloatDataType {
+		intVal, ok := value.(int)
+		if !ok {
+			err = errIncompatibleSchemaConversion
+		} else {
+			newColumnVal = float64(intVal)
+		}
+	} else if currentDataType == model.FloatDataType && (existingDataType == model.IntDataType || existingDataType == model.BigIntDataType) {
+		floatVal, ok := value.(float64)
+		if !ok {
+			err = errIncompatibleSchemaConversion
+		} else {
+			newColumnVal = int(floatVal)
+		}
+	} else if existingDataType == model.JSONDataType {
+		var interfaceSliceSample []any
+		if currentDataType == model.IntDataType || currentDataType == model.FloatDataType || currentDataType == model.BooleanDataType {
+			newColumnVal = fmt.Sprintf("%v", value)
+		} else if reflect.TypeOf(value) == reflect.TypeOf(interfaceSliceSample) {
+			newColumnVal = value
+		} else {
+			newColumnVal = fmt.Sprintf(`"%v"`, value)
+		}
+	} else {
+		err = errSchemaConversionNotSupported
+	}
+
+	return newColumnVal, err
 }

--- a/warehouse/schema_test.go
+++ b/warehouse/schema_test.go
@@ -1,13 +1,17 @@
 package warehouse
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
 
-	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/rudderlabs/rudder-go-kit/logger"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+
+	"github.com/samber/lo"
+
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 	"github.com/stretchr/testify/require"
@@ -119,140 +123,140 @@ func TestHandleSchemaChange(t *testing.T) {
 			existingDatatype: "boolean",
 			currentDataType:  "int",
 			value:            1,
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is boolean, new datatype is float",
 			existingDatatype: "boolean",
 			currentDataType:  "float",
 			value:            1.501,
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is boolean, new datatype is string",
 			existingDatatype: "boolean",
 			currentDataType:  "string",
 			value:            "string value",
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is boolean, new datatype is datetime",
 			existingDatatype: "boolean",
 			currentDataType:  "datetime",
 			value:            "2022-05-05T00:00:00.000Z",
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is boolean, new datatype is json",
 			existingDatatype: "boolean",
 			currentDataType:  "json",
 			value:            `{"json":true}`,
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is int, new datatype is boolean",
 			existingDatatype: "int",
 			currentDataType:  "boolean",
 			value:            false,
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is int, new datatype is string",
 			existingDatatype: "int",
 			currentDataType:  "string",
 			value:            "string value",
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is int, new datatype is datetime",
 			existingDatatype: "int",
 			currentDataType:  "datetime",
 			value:            "2022-05-05T00:00:00.000Z",
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is int, new datatype is json",
 			existingDatatype: "int",
 			currentDataType:  "json",
 			value:            `{"json":true}`,
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is int, new datatype is float",
 			existingDatatype: "int",
 			currentDataType:  "float",
 			value:            1,
-			convError:        ErrIncompatibleSchemaConversion,
+			convError:        errIncompatibleSchemaConversion,
 		},
 		{
 			name:             "existing datatype is float, new datatype is boolean",
 			existingDatatype: "float",
 			currentDataType:  "boolean",
 			value:            false,
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is float, new datatype is int",
 			existingDatatype: "float",
 			currentDataType:  "int",
 			value:            1.0,
-			convError:        ErrIncompatibleSchemaConversion,
+			convError:        errIncompatibleSchemaConversion,
 		},
 		{
 			name:             "existing datatype is float, new datatype is string",
 			existingDatatype: "float",
 			currentDataType:  "string",
 			value:            "string value",
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is float, new datatype is datetime",
 			existingDatatype: "float",
 			currentDataType:  "datetime",
 			value:            "2022-05-05T00:00:00.000Z",
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is float, new datatype is json",
 			existingDatatype: "float",
 			currentDataType:  "json",
 			value:            `{"json":true}`,
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is datetime, new datatype is boolean",
 			existingDatatype: "datetime",
 			currentDataType:  "boolean",
 			value:            false,
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is datetime, new datatype is string",
 			existingDatatype: "datetime",
 			currentDataType:  "string",
 			value:            "string value",
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is datetime, new datatype is int",
 			existingDatatype: "datetime",
 			currentDataType:  "int",
 			value:            1,
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is datetime, new datatype is float",
 			existingDatatype: "datetime",
 			currentDataType:  "float",
 			value:            1.501,
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 		{
 			name:             "existing datatype is datetime, new datatype is json",
 			existingDatatype: "datetime",
 			currentDataType:  "json",
 			value:            `{"json":true}`,
-			convError:        ErrSchemaConversionNotSupported,
+			convError:        errSchemaConversionNotSupported,
 		},
 	}
 	for _, ip := range inputs {
@@ -261,427 +265,113 @@ func TestHandleSchemaChange(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			newColumnVal, convError := HandleSchemaChange(
+			newColumnVal, convError := handleSchemaChange(
 				model.SchemaType(tc.existingDatatype),
 				model.SchemaType(tc.currentDataType),
 				tc.value,
 			)
 			require.Equal(t, newColumnVal, tc.newColumnVal)
-			require.Equal(t, convError, tc.convError)
+			require.ErrorIs(t, convError, tc.convError)
 		})
 	}
 }
 
-var _ = Describe("Schema", func() {
-	DescribeTable("Get table schema diff", func(tableName string, currentSchema, uploadSchema model.Schema, expected warehouseutils.TableSchemaDiff) {
-		Expect(getTableSchemaDiff(tableName, currentSchema, uploadSchema)).To(BeEquivalentTo(expected))
-	},
-		Entry(nil, "test-table", model.Schema{}, model.Schema{}, warehouseutils.TableSchemaDiff{
-			ColumnMap:        model.TableSchema{},
-			UpdatedSchema:    model.TableSchema{},
-			AlteredColumnMap: model.TableSchema{},
-		}),
+type mockSchemaRepo struct {
+	err       error
+	schemaMap map[string]model.WHSchema
+}
 
-		Entry(nil, "test-table", model.Schema{}, model.Schema{
-			"test-table": model.TableSchema{
-				"test-column": "test-value",
-			},
-		}, warehouseutils.TableSchemaDiff{
-			Exists:           true,
-			TableToBeCreated: true,
-			ColumnMap: model.TableSchema{
-				"test-column": "test-value",
-			},
-			UpdatedSchema: model.TableSchema{
-				"test-column": "test-value",
-			},
-			AlteredColumnMap: model.TableSchema{},
-		}),
+func (m *mockSchemaRepo) GetForNamespace(_ context.Context, sourceID, destID, namespace string) (model.WHSchema, error) {
+	key := fmt.Sprintf("%s_%s_%s", sourceID, destID, namespace)
 
-		Entry(nil, "test-table", model.Schema{
-			"test-table": model.TableSchema{
-				"test-column": "test-value-1",
-			},
-		}, model.Schema{
-			"test-table": model.TableSchema{
-				"test-column": "test-value-2",
-			},
-		}, warehouseutils.TableSchemaDiff{
-			Exists:           false,
-			TableToBeCreated: false,
-			ColumnMap:        model.TableSchema{},
-			UpdatedSchema: model.TableSchema{
-				"test-column": "test-value-1",
-			},
-			AlteredColumnMap: model.TableSchema{},
-		}),
+	return m.schemaMap[key], m.err
+}
 
-		Entry(nil, "test-table", model.Schema{
-			"test-table": model.TableSchema{
-				"test-column-1": "test-value-1",
-				"test-column-2": "test-value-2",
-			},
-		}, model.Schema{
-			"test-table": model.TableSchema{
-				"test-column": "test-value-2",
-			},
-		}, warehouseutils.TableSchemaDiff{
-			Exists:           true,
-			TableToBeCreated: false,
-			ColumnMap: model.TableSchema{
-				"test-column": "test-value-2",
-			},
-			UpdatedSchema: model.TableSchema{
-				"test-column-1": "test-value-1",
-				"test-column-2": "test-value-2",
-				"test-column":   "test-value-2",
-			},
-			AlteredColumnMap: model.TableSchema{},
-		}),
+func (m *mockSchemaRepo) Insert(_ context.Context, schema *model.WHSchema) (int64, error) {
+	if schema == nil {
+		return 0, m.err
+	}
+	key := fmt.Sprintf("%s_%s_%s", schema.SourceID, schema.DestinationID, schema.Namespace)
 
-		Entry(nil, "test-table", model.Schema{
-			"test-table": model.TableSchema{
-				"test-column":   "string",
-				"test-column-2": "test-value-2",
-			},
-		}, model.Schema{
-			"test-table": model.TableSchema{
-				"test-column": "text",
-			},
-		}, warehouseutils.TableSchemaDiff{
-			Exists:           true,
-			TableToBeCreated: false,
-			ColumnMap:        model.TableSchema{},
-			UpdatedSchema: model.TableSchema{
-				"test-column-2": "test-value-2",
-				"test-column":   "text",
-			},
-			AlteredColumnMap: model.TableSchema{
-				"test-column": "text",
-			},
-		}),
+	m.schemaMap[key] = *schema
+	return int64(len(m.schemaMap)), m.err
+}
+
+type mockFetchSchemaFromWarehouse struct {
+	schemaInWarehouse             model.Schema
+	unrecognizedSchemaInWarehouse model.Schema
+	err                           error
+}
+
+func (m *mockFetchSchemaFromWarehouse) FetchSchema() (model.Schema, model.Schema, error) {
+	return m.schemaInWarehouse, m.unrecognizedSchemaInWarehouse, m.err
+}
+
+type mockStagingFileRepo struct {
+	schemas []model.Schema
+	err     error
+}
+
+func (m *mockStagingFileRepo) GetSchemasByIDs(context.Context, []int64) ([]model.Schema, error) {
+	return m.schemas, m.err
+}
+
+func TestSchema_GetUpdateLocalSchema(t *testing.T) {
+	const (
+		sourceID      = "test_source"
+		destID        = "test_dest"
+		namespace     = "test_namespace"
+		warehouseType = warehouseutils.RS
+		uploadID      = 1
 	)
 
-	Describe("Has schema changed", func() {
-		g := GinkgoT()
-
-		Context("when skipping deep equals", func() {
-			BeforeEach(func() {
-				g.Setenv("RSERVER_WAREHOUSE_SKIP_DEEP_EQUAL_SCHEMAS", "true")
-				Init4()
-			})
-
-			DescribeTable("Check has schema changed", func(localSchema, schemaInWarehouse model.Schema, expected bool) {
-				Expect(hasSchemaChanged(localSchema, schemaInWarehouse)).To(Equal(expected))
-			},
-
-				Entry(nil, model.Schema{}, model.Schema{}, false),
-
-				Entry(nil, model.Schema{}, model.Schema{
-					"test-table": model.TableSchema{
-						"test-column": "test-value",
-					},
-				}, false),
-
-				Entry(nil, model.Schema{
-					"test-table": model.TableSchema{
-						"test-column": "test-value-1",
-					},
-				}, model.Schema{
-					"test-table": model.TableSchema{
-						"test-column": "test-value-2",
-					},
-				}, true),
-
-				Entry(nil, model.Schema{
-					"test-table": model.TableSchema{
-						"test-column-1": "test-value-1",
-						"test-column-2": "test-value-2",
-					},
-				}, model.Schema{
-					"test-table": model.TableSchema{
-						"test-column": "test-value-2",
-					},
-				}, true),
-
-				Entry(nil, model.Schema{
-					"test-table": model.TableSchema{
-						"test-column": "string",
-					},
-				}, model.Schema{
-					"test-table-1": model.TableSchema{
-						"test-column": "text",
-					},
-				}, true),
-			)
-		})
-
-		Context("when not skipping deep equals", func() {
-			BeforeEach(func() {
-				g.Setenv("RSERVER_WAREHOUSE_SKIP_DEEP_EQUAL_SCHEMAS", "false")
-				Init4()
-			})
-
-			DescribeTable("Check has schema changed", func(localSchema, schemaInWarehouse model.Schema, expected bool) {
-				Expect(hasSchemaChanged(localSchema, schemaInWarehouse)).To(Equal(expected))
-			},
-
-				Entry(nil, model.Schema{}, model.Schema{}, false),
-
-				Entry(nil, model.Schema{}, model.Schema{
-					"test-table": model.TableSchema{
-						"test-column": "test-value",
-					},
-				}, true),
-			)
-		})
-	})
-
-	DescribeTable("Safe name", func(warehouseType, columnName, expected string) {
-		handle := SchemaHandle{
-			warehouse: model.Warehouse{
-				Type: warehouseType,
-			},
-		}
-		Expect(handle.safeName(columnName)).To(Equal(expected))
-	},
-		Entry(nil, "BQ", "test-column", "test-column"),
-		Entry(nil, "SNOWFLAKE", "test-column", "TEST-COLUMN"),
-	)
-
-	DescribeTable("Merge rules schema", func(warehouseType string, expected model.TableSchema) {
-		handle := SchemaHandle{
-			warehouse: model.Warehouse{
-				Type: warehouseType,
-			},
-		}
-		Expect(handle.getMergeRulesSchema()).To(Equal(expected))
-	},
-		Entry(nil, "BQ", model.TableSchema{
-			"merge_property_1_type":  "string",
-			"merge_property_1_value": "string",
-			"merge_property_2_type":  "string",
-			"merge_property_2_value": "string",
-		}),
-		Entry(nil, "SNOWFLAKE", model.TableSchema{
-			"MERGE_PROPERTY_1_TYPE":  "string",
-			"MERGE_PROPERTY_1_VALUE": "string",
-			"MERGE_PROPERTY_2_TYPE":  "string",
-			"MERGE_PROPERTY_2_VALUE": "string",
-		}),
-	)
-
-	DescribeTable("Identities Mappings schema", func(warehouseType string, expected model.TableSchema) {
-		handle := SchemaHandle{
-			warehouse: model.Warehouse{
-				Type: warehouseType,
-			},
-		}
-		Expect(handle.getIdentitiesMappingsSchema()).To(Equal(expected))
-	},
-		Entry(nil, "BQ", model.TableSchema{
-			"merge_property_type":  "string",
-			"merge_property_value": "string",
-			"rudder_id":            "string",
-			"updated_at":           "datetime",
-		}),
-		Entry(nil, "SNOWFLAKE", model.TableSchema{
-			"MERGE_PROPERTY_TYPE":  "string",
-			"MERGE_PROPERTY_VALUE": "string",
-			"RUDDER_ID":            "string",
-			"UPDATED_AT":           "datetime",
-		}),
-	)
-
-	DescribeTable("Discards schema", func(warehouseType string, expected model.TableSchema) {
-		handle := SchemaHandle{
-			warehouse: model.Warehouse{
-				Type: warehouseType,
-			},
-		}
-		Expect(handle.getDiscardsSchema()).To(Equal(expected))
-	},
-		Entry(nil, "BQ", model.TableSchema{
-			"table_name":   "string",
-			"row_id":       "string",
-			"column_name":  "string",
-			"column_value": "string",
-			"received_at":  "datetime",
-			"uuid_ts":      "datetime",
-			"loaded_at":    "datetime",
-		}),
-		Entry(nil, "SNOWFLAKE", model.TableSchema{
-			"TABLE_NAME":   "string",
-			"ROW_ID":       "string",
-			"COLUMN_NAME":  "string",
-			"COLUMN_VALUE": "string",
-			"RECEIVED_AT":  "datetime",
-			"UUID_TS":      "datetime",
-		}),
-	)
-
-	DescribeTable("Merge schema", func(currentSchema model.Schema, schemaList []model.Schema, currentMergedSchema model.Schema, warehouseType string, expected model.Schema) {
-		Expect(MergeSchema(currentSchema, schemaList, currentMergedSchema, warehouseType)).To(Equal(expected))
-	},
-		Entry(nil, model.Schema{}, []model.Schema{}, model.Schema{}, "BQ", model.Schema{}),
-		Entry(nil, model.Schema{}, []model.Schema{
-			{
-				"test-table": model.TableSchema{
-					"test-column": "test-value",
-				},
-			},
-		}, model.Schema{}, "BQ", model.Schema{
-			"test-table": model.TableSchema{
-				"test-column": "test-value",
-			},
-		}),
-		Entry(nil, model.Schema{}, []model.Schema{
-			{
-				"users": model.TableSchema{
-					"test-column": "test-value",
-				},
-				"identifies": model.TableSchema{
-					"test-column": "test-value",
-				},
-			},
-		}, model.Schema{}, "BQ", model.Schema{
-			"users": model.TableSchema{
-				"test-column": "test-value",
-			},
-			"identifies": model.TableSchema{
-				"test-column": "test-value",
-			},
-		}),
-		Entry(nil, model.Schema{
-			"users": model.TableSchema{
-				"test-column": "test-value",
-			},
-			"identifies": model.TableSchema{
-				"test-column": "test-value",
-			},
-		}, []model.Schema{
-			{
-				"users": model.TableSchema{
-					"test-column": "test-value",
-				},
-				"identifies": model.TableSchema{
-					"test-column": "test-value",
-				},
-			},
-		}, model.Schema{}, "BQ", model.Schema{
-			"users": model.TableSchema{
-				"test-column": "test-value",
-			},
-			"identifies": model.TableSchema{
-				"test-column": "test-value",
-			},
-		}),
-		Entry(nil, model.Schema{}, []model.Schema{
-			{
-				"test-table": model.TableSchema{
-					"test-column":   "string",
-					"test-column-2": "test-value-2",
-				},
-			},
-		}, model.Schema{
-			"test-table": model.TableSchema{
-				"test-column": "text",
-			},
-		}, "BQ", model.Schema{
-			"test-table": {
-				"test-column":   "text",
-				"test-column-2": "test-value-2",
-			},
-		}),
-	)
-})
-
-func TestMergeSchema(t *testing.T) {
 	testCases := []struct {
-		name           string
-		schemaList     []model.Schema
-		localSchema    model.Schema
-		expectedSchema model.Schema
+		name          string
+		mockSchema    model.WHSchema
+		mockSchemaErr error
+		wantSchema    model.Schema
+		wantError     error
 	}{
 		{
-			name: "local schema contains the property and schema list contains data types in text-string order",
-			schemaList: []model.Schema{
-				{
-					"test-table": model.TableSchema{
-						"test-column": "text",
-					},
-				},
-				{
-					"test-table": model.TableSchema{
-						"test-column": "string",
-					},
-				},
-			},
-			localSchema: model.Schema{
-				"test-table": model.TableSchema{
-					"test-column": "string",
-				},
-			},
-			expectedSchema: model.Schema{
-				"test-table": model.TableSchema{
-					"test-column": "text",
-				},
-			},
+			name:          "no schema in db",
+			mockSchema:    model.WHSchema{},
+			mockSchemaErr: nil,
+			wantSchema:    model.Schema{},
+			wantError:     nil,
 		},
 		{
-			name: "local schema contains the property and schema list contains data types in string-text order",
-			schemaList: []model.Schema{
-				{
-					"test-table": model.TableSchema{
-						"test-column": "string",
-					},
-				},
-				{
-					"test-table": model.TableSchema{
-						"test-column": "text",
-					},
-				},
-			},
-
-			localSchema: model.Schema{
-				"test-table": model.TableSchema{
-					"test-column": "string",
-				},
-			},
-			expectedSchema: model.Schema{
-				"test-table": model.TableSchema{
-					"test-column": "text",
-				},
-			},
+			name:          "error in fetching schema from db",
+			mockSchema:    model.WHSchema{},
+			mockSchemaErr: errors.New("test error"),
+			wantSchema:    nil,
+			wantError:     errors.New("test error"),
 		},
 		{
-			name: "local schema does not contain the property",
-			schemaList: []model.Schema{
-				{
-					"test-table": model.TableSchema{
-						"test-column": "int",
+			name: "schema in db",
+			mockSchema: model.WHSchema{
+				Schema: model.Schema{
+					"table1": model.TableSchema{
+						"column1": "string",
+						"column2": "int",
+						"column3": "float",
+						"column4": "datetime",
+						"column5": "json",
 					},
 				},
-				{
-					"test-table": model.TableSchema{
-						"test-column": "text",
-					},
+			},
+			mockSchemaErr: nil,
+			wantSchema: model.Schema{
+				"table1": model.TableSchema{
+					"column1": "string",
+					"column2": "int",
+					"column3": "float",
+					"column4": "datetime",
+					"column5": "json",
 				},
 			},
-			localSchema: model.Schema{
-				"test-table": model.TableSchema{
-					"test-column-1": "string",
-				},
-			},
-			expectedSchema: model.Schema{
-				"test-table": model.TableSchema{
-					"test-column": "int",
-				},
-			},
+			wantError: nil,
 		},
 	}
-
-	destType := "RS"
 
 	for _, tc := range testCases {
 		tc := tc
@@ -689,23 +379,67 @@ func TestMergeSchema(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			actualSchema := MergeSchema(tc.localSchema, tc.schemaList, model.Schema{}, destType)
-			require.Equal(t, actualSchema, tc.expectedSchema)
+			mockSchemaRepo := &mockSchemaRepo{
+				err:       tc.mockSchemaErr,
+				schemaMap: map[string]model.WHSchema{},
+			}
+
+			sch := Schema{
+				warehouse: model.Warehouse{
+					Source: backendconfig.SourceT{
+						ID: sourceID,
+					},
+					Destination: backendconfig.DestinationT{
+						ID: destID,
+					},
+					Namespace: namespace,
+					Type:      warehouseType,
+				},
+				schemaRepo: mockSchemaRepo,
+			}
+
+			err := sch.updateLocalSchema(uploadID, tc.mockSchema.Schema)
+			if tc.wantError == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.wantError.Error())
+			}
+
+			err = sch.fetchSchemaFromLocal()
+			require.Equal(t, tc.wantSchema, sch.localSchema)
+			if tc.wantError == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.wantError.Error())
+			}
 		})
 	}
 }
 
-func TestSchemaHandleT_SkipDeprecatedColumns(t *testing.T) {
+func TestSchema_FetchSchemaFromWarehouse(t *testing.T) {
 	Init4()
 
 	testCases := []struct {
 		name           string
-		schema         model.Schema
+		mockSchema     model.Schema
+		mockErr        error
 		expectedSchema model.Schema
+		wantError      error
 	}{
 		{
+			name:           "no schema in warehouse",
+			mockSchema:     model.Schema{},
+			expectedSchema: model.Schema{},
+		},
+		{
+			name:       "error in fetching schema from warehouse",
+			mockSchema: model.Schema{},
+			mockErr:    errors.New("test error"),
+			wantError:  errors.New("fetching schema from warehouse: test error"),
+		},
+		{
 			name: "no deprecated columns",
-			schema: model.Schema{
+			mockSchema: model.Schema{
 				"test-table": model.TableSchema{
 					"test_int":       "int",
 					"test_str":       "string",
@@ -730,7 +464,7 @@ func TestSchemaHandleT_SkipDeprecatedColumns(t *testing.T) {
 		},
 		{
 			name: "invalid deprecated column format",
-			schema: model.Schema{
+			mockSchema: model.Schema{
 				"test-table": model.TableSchema{
 					"test_int":                 "int",
 					"test_str":                 "string",
@@ -761,7 +495,7 @@ func TestSchemaHandleT_SkipDeprecatedColumns(t *testing.T) {
 		},
 		{
 			name: "valid deprecated column format",
-			schema: model.Schema{
+			mockSchema: model.Schema{
 				"test-table": model.TableSchema{
 					"test_int":                 "int",
 					"test_str":                 "string",
@@ -809,7 +543,13 @@ func TestSchemaHandleT_SkipDeprecatedColumns(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			sh := &SchemaHandle{
+			fechSchemaRepo := mockFetchSchemaFromWarehouse{
+				schemaInWarehouse:             tc.mockSchema,
+				unrecognizedSchemaInWarehouse: tc.mockSchema,
+				err:                           tc.mockErr,
+			}
+
+			sh := &Schema{
 				warehouse: model.Warehouse{
 					Source: backendconfig.SourceT{
 						ID: sourceID,
@@ -823,11 +563,1241 @@ func TestSchemaHandleT_SkipDeprecatedColumns(t *testing.T) {
 					WorkspaceID: workspaceID,
 					Namespace:   namespace,
 				},
+				log: logger.NOP,
 			}
 
-			sh.SkipDeprecatedColumns(tc.schema)
+			err := sh.fetchSchemaFromWarehouse(&fechSchemaRepo)
+			if tc.wantError != nil {
+				require.EqualError(t, err, tc.wantError.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expectedSchema, sh.schemaInWarehouse)
+			require.Equal(t, tc.expectedSchema, sh.unrecognizedSchemaInWarehouse)
+		})
+	}
+}
 
-			require.Equal(t, tc.schema, tc.expectedSchema)
+func TestSchema_GetUploadSchemaDiff(t *testing.T) {
+	testCases := []struct {
+		name          string
+		tableName     string
+		currentSchema model.Schema
+		uploadSchema  model.Schema
+		expected      warehouseutils.TableSchemaDiff
+	}{
+		{
+			name:          "empty current and upload schema",
+			tableName:     "test-table",
+			currentSchema: model.Schema{},
+			uploadSchema:  model.Schema{},
+			expected: warehouseutils.TableSchemaDiff{
+				ColumnMap:        model.TableSchema{},
+				UpdatedSchema:    model.TableSchema{},
+				AlteredColumnMap: model.TableSchema{},
+			},
+		},
+		{
+			name:          "empty current schema",
+			tableName:     "test-table",
+			currentSchema: model.Schema{},
+			uploadSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "test-value",
+				},
+			},
+			expected: warehouseutils.TableSchemaDiff{
+				Exists:           true,
+				TableToBeCreated: true,
+				ColumnMap: model.TableSchema{
+					"test-column": "test-value",
+				},
+				UpdatedSchema: model.TableSchema{
+					"test-column": "test-value",
+				},
+				AlteredColumnMap: model.TableSchema{},
+			},
+		},
+		{
+			name:      "override existing column",
+			tableName: "test-table",
+			currentSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "test-value-1",
+				},
+			},
+			uploadSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "test-value-2",
+				},
+			},
+			expected: warehouseutils.TableSchemaDiff{
+				Exists:           false,
+				TableToBeCreated: false,
+				ColumnMap:        model.TableSchema{},
+				UpdatedSchema: model.TableSchema{
+					"test-column": "test-value-1",
+				},
+				AlteredColumnMap: model.TableSchema{},
+			},
+		},
+		{
+			name:      "union of current and upload schema",
+			tableName: "test-table",
+			currentSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column-1": "test-value-1",
+					"test-column-2": "test-value-2",
+				},
+			},
+			uploadSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "test-value-2",
+				},
+			},
+			expected: warehouseutils.TableSchemaDiff{
+				Exists:           true,
+				TableToBeCreated: false,
+				ColumnMap: model.TableSchema{
+					"test-column": "test-value-2",
+				},
+				UpdatedSchema: model.TableSchema{
+					"test-column-1": "test-value-1",
+					"test-column-2": "test-value-2",
+					"test-column":   "test-value-2",
+				},
+				AlteredColumnMap: model.TableSchema{},
+			},
+		},
+		{
+			name:      "override text column with string column",
+			tableName: "test-table",
+			currentSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column":   "string",
+					"test-column-2": "test-value-2",
+				},
+			},
+			uploadSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "text",
+				},
+			},
+			expected: warehouseutils.TableSchemaDiff{
+				Exists:           true,
+				TableToBeCreated: false,
+				ColumnMap:        model.TableSchema{},
+				UpdatedSchema: model.TableSchema{
+					"test-column-2": "test-value-2",
+					"test-column":   "text",
+				},
+				AlteredColumnMap: model.TableSchema{
+					"test-column": "text",
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sch := Schema{
+				schemaInWarehouse: tc.currentSchema,
+				uploadSchema:      tc.uploadSchema,
+			}
+			diff := sch.generateTableSchemaDiff(tc.tableName)
+			require.EqualValues(t, diff, tc.expected)
+		})
+	}
+}
+
+func TestSchema_HasLocalSchemaChanged(t *testing.T) {
+	testCases := []struct {
+		name              string
+		localSchema       model.Schema
+		schemaInWarehouse model.Schema
+		skipDeepEquals    bool
+		expected          bool
+	}{
+		{
+			name:              "When both schemas are empty and skipDeepEquals is true",
+			localSchema:       model.Schema{},
+			schemaInWarehouse: model.Schema{},
+			skipDeepEquals:    true,
+			expected:          false,
+		},
+		{
+			name:        "When local schema is empty and skipDeepEquals is true",
+			localSchema: model.Schema{},
+			schemaInWarehouse: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "test-value",
+				},
+			},
+			skipDeepEquals: true,
+			expected:       false,
+		},
+		{
+			name: "same table, same column, different datatype and skipDeepEquals is true",
+			localSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "test-value-1",
+				},
+			},
+			schemaInWarehouse: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "test-value-2",
+				},
+			},
+			skipDeepEquals: true,
+			expected:       true,
+		},
+		{
+			name: "same table, different columns and skipDeepEquals is true",
+			localSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column-1": "test-value-1",
+					"test-column-2": "test-value-2",
+				},
+			},
+			schemaInWarehouse: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "test-value-2",
+				},
+			},
+			skipDeepEquals: true,
+			expected:       true,
+		},
+		{
+			name: "different table and skipDeepEquals is true",
+			localSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "string",
+				},
+			},
+			schemaInWarehouse: model.Schema{
+				"test-table-1": model.TableSchema{
+					"test-column": "text",
+				},
+			},
+			skipDeepEquals: true,
+			expected:       true,
+		},
+		{
+			name:              "When both schemas are empty and skipDeepEquals is false",
+			localSchema:       model.Schema{},
+			schemaInWarehouse: model.Schema{},
+			skipDeepEquals:    false,
+			expected:          false,
+		},
+		{
+			name:        "When local schema is empty and skipDeepEquals is false",
+			localSchema: model.Schema{},
+			schemaInWarehouse: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "test-value",
+				},
+			},
+			skipDeepEquals: false,
+			expected:       true,
+		},
+		{
+			name: "same table, same column, different datatype and skipDeepEquals is false",
+			localSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "test-value-1",
+				},
+			},
+			schemaInWarehouse: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "test-value-2",
+				},
+			},
+			skipDeepEquals: false,
+			expected:       true,
+		},
+		{
+			name: "same table, different columns and skipDeepEquals is false",
+			localSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column-1": "test-value-1",
+					"test-column-2": "test-value-2",
+				},
+			},
+			schemaInWarehouse: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "test-value-2",
+				},
+			},
+			skipDeepEquals: false,
+			expected:       true,
+		},
+		{
+			name: "different table and skipDeepEquals is false",
+			localSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test-column": "string",
+				},
+			},
+			schemaInWarehouse: model.Schema{
+				"test-table-1": model.TableSchema{
+					"test-column": "text",
+				},
+			},
+			skipDeepEquals: false,
+			expected:       true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sch := &Schema{
+				warehouse: model.Warehouse{
+					Type: warehouseutils.SNOWFLAKE,
+				},
+				skipDeepEqualSchemas: tc.skipDeepEquals,
+				localSchema:          tc.localSchema,
+				schemaInWarehouse:    tc.schemaInWarehouse,
+			}
+			require.Equal(t, tc.expected, sch.hasSchemaChanged())
+		})
+	}
+}
+
+func TestSchema_PrepareUploadSchema(t *testing.T) {
+	warehouseutils.Init()
+
+	const (
+		sourceID    = "test-source-id"
+		destID      = "test-dest-id"
+		destType    = "BQ"
+		workspaceID = "test-workspace-id"
+		namespace   = "test-namespace"
+	)
+
+	stagingFiles := lo.RepeatBy(100, func(index int) *model.StagingFile {
+		return &model.StagingFile{
+			ID: int64(index),
+		}
+	})
+
+	testsCases := []struct {
+		name                string
+		warehouseType       string
+		warehouseSchema     model.Schema
+		mockSchemas         []model.Schema
+		mockErr             error
+		expectedSchema      model.Schema
+		wantError           error
+		idResolutionEnabled bool
+	}{
+		{
+			name:          "error fetching staging schema",
+			warehouseType: warehouseutils.RS,
+			mockSchemas:   []model.Schema{},
+			mockErr:       errors.New("test error"),
+			wantError:     errors.New("consolidating staging files schema: getting staging files schema: test error"),
+		},
+
+		{
+			name:          "discards schema for bigquery",
+			warehouseType: warehouseutils.BQ,
+			mockSchemas:   []model.Schema{},
+			expectedSchema: model.Schema{
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+					"loaded_at":    "datetime",
+				},
+			},
+		},
+		{
+			name:          "discards schema for all destinations",
+			warehouseType: warehouseutils.RS,
+			mockSchemas:   []model.Schema{},
+			expectedSchema: model.Schema{
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:          "users and identifies should have similar schema except for id and user_id",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"identifies": model.TableSchema{
+						"id":               "string",
+						"user_id":          "int",
+						"anonymous_id":     "string",
+						"received_at":      "datetime",
+						"sent_at":          "datetime",
+						"timestamp":        "datetime",
+						"source_id":        "string",
+						"destination_id":   "string",
+						"source_type":      "string",
+						"destination_type": "string",
+					},
+					"users": model.TableSchema{
+						"id":               "string",
+						"anonymous_id":     "string",
+						"received_at":      "datetime",
+						"sent_at":          "datetime",
+						"timestamp":        "datetime",
+						"source_id":        "string",
+						"destination_id":   "string",
+						"source_type":      "string",
+						"destination_type": "string",
+					},
+				},
+			},
+			expectedSchema: model.Schema{
+				"identifies": model.TableSchema{
+					"id":               "string",
+					"user_id":          "int",
+					"anonymous_id":     "string",
+					"received_at":      "datetime",
+					"sent_at":          "datetime",
+					"timestamp":        "datetime",
+					"source_id":        "string",
+					"destination_id":   "string",
+					"source_type":      "string",
+					"destination_type": "string",
+				},
+				"users": model.TableSchema{
+					"id":               "int",
+					"anonymous_id":     "string",
+					"received_at":      "datetime",
+					"sent_at":          "datetime",
+					"timestamp":        "datetime",
+					"source_id":        "string",
+					"destination_id":   "string",
+					"source_type":      "string",
+					"destination_type": "string",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:          "users have extra properties as compared to identifies",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"identifies": model.TableSchema{
+						"id":               "string",
+						"user_id":          "int",
+						"anonymous_id":     "string",
+						"received_at":      "datetime",
+						"sent_at":          "datetime",
+						"timestamp":        "datetime",
+						"source_id":        "string",
+						"destination_id":   "string",
+						"source_type":      "string",
+						"destination_type": "string",
+					},
+					"users": model.TableSchema{
+						"id":               "string",
+						"anonymous_id":     "string",
+						"received_at":      "datetime",
+						"sent_at":          "datetime",
+						"timestamp":        "datetime",
+						"source_id":        "string",
+						"destination_id":   "string",
+						"source_type":      "string",
+						"destination_type": "string",
+						"extra_property_1": "string",
+						"extra_property_2": "string",
+					},
+				},
+			},
+			expectedSchema: model.Schema{
+				"identifies": model.TableSchema{
+					"id":               "string",
+					"user_id":          "int",
+					"anonymous_id":     "string",
+					"received_at":      "datetime",
+					"sent_at":          "datetime",
+					"timestamp":        "datetime",
+					"source_id":        "string",
+					"destination_id":   "string",
+					"source_type":      "string",
+					"destination_type": "string",
+				},
+				"users": model.TableSchema{
+					"id":               "int",
+					"anonymous_id":     "string",
+					"received_at":      "datetime",
+					"sent_at":          "datetime",
+					"timestamp":        "datetime",
+					"source_id":        "string",
+					"destination_id":   "string",
+					"source_type":      "string",
+					"destination_type": "string",
+					"extra_property_1": "string",
+					"extra_property_2": "string",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:          "users without identifies",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"users": model.TableSchema{
+						"id":               "string",
+						"anonymous_id":     "string",
+						"received_at":      "datetime",
+						"sent_at":          "datetime",
+						"timestamp":        "datetime",
+						"source_id":        "string",
+						"destination_id":   "string",
+						"source_type":      "string",
+						"destination_type": "string",
+					},
+				},
+			},
+			expectedSchema: model.Schema{
+				"users": model.TableSchema{
+					"id":               "string",
+					"anonymous_id":     "string",
+					"received_at":      "datetime",
+					"sent_at":          "datetime",
+					"timestamp":        "datetime",
+					"source_id":        "string",
+					"destination_id":   "string",
+					"source_type":      "string",
+					"destination_type": "string",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:          "unknown table in warehouse schema",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"test-table": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+			},
+			warehouseSchema: model.Schema{
+				"test-table-1": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+			},
+			expectedSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:          "unknown properties in warehouse schema",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"test-table": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+			},
+			warehouseSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test_warehouse_int":       "int",
+					"test_warehouse_str":       "string",
+					"test_warehouse_bool":      "boolean",
+					"test_warehouse_float":     "float",
+					"test_warehouse_timestamp": "timestamp",
+					"test_warehouse_date":      "date",
+				},
+			},
+			expectedSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:          "single staging schema with empty warehouse schema",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"test-table": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+			},
+			expectedSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:          "single staging schema with warehouse schema and text data type override",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"test-table": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_text":      "text",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+			},
+			warehouseSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_text":      "string",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+			},
+			expectedSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_text":      "text",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:                "id resolution without merge schema",
+			warehouseType:       warehouseutils.BQ,
+			idResolutionEnabled: true,
+			mockSchemas: []model.Schema{
+				{
+					"test-table": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+			},
+			expectedSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+					"loaded_at":    "datetime",
+				},
+			},
+		},
+		{
+			name:                "id resolution with merge schema",
+			warehouseType:       warehouseutils.BQ,
+			idResolutionEnabled: true,
+			mockSchemas: []model.Schema{
+				{
+					"test-table": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+					"rudder_identity_merge_rules": model.TableSchema{},
+					"rudder_identity_mappings":    model.TableSchema{},
+				},
+			},
+			expectedSchema: model.Schema{
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"loaded_at":    "datetime",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+				"rudder_identity_mappings": model.TableSchema{
+					"merge_property_type":  "string",
+					"merge_property_value": "string",
+					"rudder_id":            "string",
+					"updated_at":           "datetime",
+				},
+				"rudder_identity_merge_rules": model.TableSchema{
+					"merge_property_1_type":  "string",
+					"merge_property_1_value": "string",
+					"merge_property_2_type":  "string",
+					"merge_property_2_value": "string",
+				},
+				"test-table": model.TableSchema{
+					"test_bool":      "boolean",
+					"test_date":      "date",
+					"test_float":     "float",
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_timestamp": "timestamp",
+				},
+			},
+		},
+		{
+			name:          "multiple staging schemas with empty warehouse schema",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"test-table-1": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+				{
+					"test-table-2": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+			},
+			expectedSchema: model.Schema{
+				"test-table-1": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+				"test-table-2": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:          "multiple staging schemas with empty warehouse schema and text datatype",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"test-table-1": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_text":      "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+				{
+					"test-table-1": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_text":      "text",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+				{
+					"test-table-1": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_text":      "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+				{
+					"test-table-2": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+			},
+			expectedSchema: model.Schema{
+				"test-table-1": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_text":      "text",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+				"test-table-2": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:          "multiple staging schemas with warehouse schema and text datatype",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"test-table-1": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_text":      "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+				{
+					"test-table-1": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_text":      "text",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+				{
+					"test-table-1": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_text":      "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+				{
+					"test-table-2": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+			},
+			warehouseSchema: model.Schema{
+				"test-table-1": model.TableSchema{
+					"test_int":  "warehouse_int",
+					"test_str":  "warehouse_string",
+					"test_text": "warehouse_text",
+				},
+				"test-table-2": model.TableSchema{
+					"test_float":     "warehouse_float",
+					"test_timestamp": "warehouse_timestamp",
+					"test_date":      "warehouse_date",
+				},
+			},
+			expectedSchema: model.Schema{
+				"test-table-1": model.TableSchema{
+					"test_int":       "warehouse_int",
+					"test_str":       "warehouse_string",
+					"test_text":      "warehouse_text",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+				"test-table-2": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_bool":      "boolean",
+					"test_float":     "warehouse_float",
+					"test_timestamp": "warehouse_timestamp",
+					"test_date":      "warehouse_date",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:          "multiple schemas with same table and empty warehouse schema",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"test-table": model.TableSchema{
+						"test_int":  "int",
+						"test_str":  "string",
+						"test_bool": "boolean",
+					},
+				},
+				{
+					"test-table": model.TableSchema{
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+			},
+			expectedSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:          "multiple schemas with same table and warehouse schema",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"test-table": model.TableSchema{
+						"test_int":  "int",
+						"test_str":  "string",
+						"test_bool": "boolean",
+					},
+				},
+				{
+					"test-table": model.TableSchema{
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+			},
+			warehouseSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test_int":   "warehouse_int",
+					"test_float": "warehouse_float",
+				},
+			},
+			expectedSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test_int":       "warehouse_int",
+					"test_str":       "string",
+					"test_bool":      "boolean",
+					"test_float":     "warehouse_float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:          "multiple schemas with preference to first schema and empty warehouse schema",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"test-table": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+				{
+					"test-table": model.TableSchema{
+						"test_int":       "new_int",
+						"test_str":       "new_string",
+						"test_bool":      "new_boolean",
+						"test_float":     "new_float",
+						"test_timestamp": "new_timestamp",
+						"test_date":      "new_date",
+					},
+				},
+			},
+			expectedSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test_int":       "int",
+					"test_str":       "string",
+					"test_bool":      "boolean",
+					"test_float":     "float",
+					"test_timestamp": "timestamp",
+					"test_date":      "date",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+		{
+			name:          "multiple schemas with preference to warehouse schema",
+			warehouseType: warehouseutils.RS,
+			mockSchemas: []model.Schema{
+				{
+					"test-table": model.TableSchema{
+						"test_int":       "int",
+						"test_str":       "string",
+						"test_bool":      "boolean",
+						"test_float":     "float",
+						"test_timestamp": "timestamp",
+						"test_date":      "date",
+					},
+				},
+				{
+					"test-table": model.TableSchema{
+						"test_int":       "new_int",
+						"test_str":       "new_string",
+						"test_bool":      "new_boolean",
+						"test_float":     "new_float",
+						"test_timestamp": "new_timestamp",
+						"test_date":      "new_date",
+					},
+				},
+			},
+			warehouseSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test_int":       "warehouse_int",
+					"test_str":       "warehouse_string",
+					"test_bool":      "warehouse_boolean",
+					"test_float":     "warehouse_float",
+					"test_timestamp": "warehouse_timestamp",
+					"test_date":      "warehouse_date",
+				},
+			},
+			expectedSchema: model.Schema{
+				"test-table": model.TableSchema{
+					"test_int":       "warehouse_int",
+					"test_str":       "warehouse_string",
+					"test_bool":      "warehouse_boolean",
+					"test_float":     "warehouse_float",
+					"test_timestamp": "warehouse_timestamp",
+					"test_date":      "warehouse_date",
+				},
+				"rudder_discards": model.TableSchema{
+					"column_name":  "string",
+					"column_value": "string",
+					"received_at":  "datetime",
+					"row_id":       "string",
+					"table_name":   "string",
+					"uuid_ts":      "datetime",
+				},
+			},
+		},
+	}
+	for _, tc := range testsCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sh := &Schema{
+				warehouse: model.Warehouse{
+					Source: backendconfig.SourceT{
+						ID: sourceID,
+					},
+					Destination: backendconfig.DestinationT{
+						ID: destID,
+						DestinationDefinition: backendconfig.DestinationDefinitionT{
+							Name: destType,
+						},
+					},
+					WorkspaceID: workspaceID,
+					Namespace:   namespace,
+					Type:        tc.warehouseType,
+				},
+				log: logger.NOP,
+				stagingFileRepo: &mockStagingFileRepo{
+					schemas: tc.mockSchemas,
+					err:     tc.mockErr,
+				},
+				enableIDResolution:               tc.idResolutionEnabled,
+				localSchema:                      tc.warehouseSchema,
+				stagingFilesSchemaPaginationSize: 2,
+			}
+
+			err := sh.prepareUploadSchema(stagingFiles)
+			if tc.wantError != nil {
+				require.EqualError(t, err, tc.wantError.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expectedSchema, sh.uploadSchema)
 		})
 	}
 }

--- a/warehouse/slave.go
+++ b/warehouse/slave.go
@@ -523,7 +523,7 @@ func processStagingFile(job Payload, workerIndex int) (loadFileUploadOutputs []l
 			dataTypeInSchema, ok := job.UploadSchema[tableName][columnName]
 			violatedConstraints := ViolatedConstraints(job.DestinationType, &batchRouterEvent, columnName)
 			if ok && ((columnType != dataTypeInSchema) || (violatedConstraints.IsViolated)) {
-				newColumnVal, convError := HandleSchemaChange(
+				newColumnVal, convError := handleSchemaChange(
 					model.SchemaType(dataTypeInSchema),
 					model.SchemaType(columnType),
 					columnVal,

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -84,7 +84,7 @@ type UploadJob struct {
 	recovery             *service.Recovery
 	whManager            manager.Manager
 	pgNotifier           *pgnotifier.PGNotifier
-	schemaHandle         *SchemaHandle
+	schemaHandle         *Schema
 	stats                stats.Stats
 	LoadFileGenStartTime time.Time
 
@@ -181,6 +181,7 @@ func (f *UploadJobFactory) NewUploadJob(dto *model.UploadJob, whManager manager.
 		destinationValidator: f.destinationValidator,
 		stats:                f.stats,
 		tableUploadsRepo:     repo.NewTableUploads(f.dbHandle),
+		schemaHandle:         NewSchema(f.dbHandle, dto.Warehouse, config.Default),
 
 		upload:         dto.Upload,
 		warehouse:      dto.Warehouse,
@@ -241,12 +242,22 @@ func (job *UploadJob) trackLongRunningUpload() chan struct{} {
 	return ch
 }
 
-func (job *UploadJob) generateUploadSchema(schemaHandle *SchemaHandle) error {
-	schemaHandle.uploadSchema = schemaHandle.consolidateStagingFilesSchemaUsingWarehouseSchema()
-	// set upload schema
-	_ = job.setMergedSchema(schemaHandle.uploadSchema)
-	err := job.setUploadSchema(schemaHandle.uploadSchema)
-	return err
+func (job *UploadJob) generateUploadSchema() error {
+	err := job.schemaHandle.prepareUploadSchema(
+		job.stagingFiles,
+	)
+	if err != nil {
+		return fmt.Errorf("consolidate staging files schema using warehouse schema: %w", err)
+	}
+
+	if err := job.setMergedSchema(job.schemaHandle.uploadSchema); err != nil {
+		return fmt.Errorf("set merged schema: %w", err)
+	}
+	if err := job.setUploadSchema(job.schemaHandle.uploadSchema); err != nil {
+		return fmt.Errorf("set upload schema: %w", err)
+	}
+
+	return nil
 }
 
 func (job *UploadJob) initTableUploads() error {
@@ -270,34 +281,32 @@ func (job *UploadJob) initTableUploads() error {
 	)
 }
 
-func (job *UploadJob) syncRemoteSchema() (schemaChanged bool, err error) {
-	schemaHandle := SchemaHandle{
-		warehouse:    job.warehouse,
-		stagingFiles: job.stagingFiles,
-		dbHandle:     job.dbHandle,
-		whSchemaRepo: repo.NewWHSchemas(job.dbHandle),
-	}
-	job.schemaHandle = &schemaHandle
-
-	localSchema, err := schemaHandle.getLocalSchema()
+func (job *UploadJob) syncRemoteSchema() (bool, error) {
+	err := job.schemaHandle.fetchSchemaFromLocal()
 	if err != nil {
-		return false, fmt.Errorf("getting local schema: %w", err)
+		return false, fmt.Errorf("fetching schema from local: %w", err)
 	}
 
-	schemaHandle.localSchema = localSchema
-	schemaHandle.schemaInWarehouse, schemaHandle.unrecognizedSchemaInWarehouse, err = schemaHandle.fetchSchemaFromWarehouse(job.whManager)
+	err = job.schemaHandle.fetchSchemaFromWarehouse(job.whManager)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("fetching schema from warehouse: %w", err)
 	}
 
-	schemaChanged = hasSchemaChanged(schemaHandle.localSchema, schemaHandle.schemaInWarehouse)
+	schemaChanged := job.schemaHandle.hasSchemaChanged()
 	if schemaChanged {
-		pkgLogger.Infof("syncRemoteSchema: schema changed - updating local schema for %s", job.warehouse.Identifier)
-		err = schemaHandle.updateLocalSchema(job.upload.ID, schemaHandle.schemaInWarehouse)
+		pkgLogger.Infow("schema changed",
+			logfield.SourceID, job.warehouse.Source.ID,
+			logfield.SourceType, job.warehouse.Source.SourceDefinition.Name,
+			logfield.DestinationID, job.warehouse.Destination.ID,
+			logfield.DestinationType, job.warehouse.Destination.DestinationDefinition.Name,
+			logfield.WorkspaceID, job.warehouse.WorkspaceID,
+			logfield.Namespace, job.warehouse.Namespace,
+		)
+
+		err = job.schemaHandle.updateLocalSchema(job.upload.ID, job.schemaHandle.schemaInWarehouse)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("updating local schema: %w", err)
 		}
-		schemaHandle.localSchema = schemaHandle.schemaInWarehouse
 	}
 
 	return schemaChanged, nil
@@ -396,8 +405,8 @@ func (job *UploadJob) run() (err error) {
 	if hasSchemaChanged {
 		pkgLogger.Infof("[WH] Remote schema changed for Warehouse: %s", job.warehouse.Identifier)
 	}
-	schemaHandle := job.schemaHandle
-	schemaHandle.uploadSchema = job.upload.UploadSchema
+
+	job.schemaHandle.uploadSchema = job.upload.UploadSchema
 
 	userTables := []string{job.identifiesTableName(), job.usersTableName()}
 	identityTables := []string{job.identityMergeRulesTableName(), job.identityMappingsTableName()}
@@ -427,7 +436,7 @@ func (job *UploadJob) run() (err error) {
 		switch targetStatus {
 		case model.GeneratedUploadSchema:
 			newStatus = nextUploadState.failed
-			err = job.generateUploadSchema(schemaHandle)
+			err = job.generateUploadSchema()
 			if err != nil {
 				break
 			}
@@ -490,7 +499,7 @@ func (job *UploadJob) run() (err error) {
 
 		case model.CreatedRemoteSchema:
 			newStatus = nextUploadState.failed
-			if len(schemaHandle.schemaInWarehouse) == 0 {
+			if len(job.schemaHandle.schemaInWarehouse) == 0 {
 				err = whManager.CreateSchema()
 				if err != nil {
 					break
@@ -962,7 +971,7 @@ func (job *UploadJob) loadAllTablesExcept(skipLoadForTables []string, loadFilesT
 }
 
 func (job *UploadJob) updateSchema(tName string) (alteredSchema bool, err error) {
-	tableSchemaDiff := getTableSchemaDiff(tName, job.schemaHandle.schemaInWarehouse, job.upload.UploadSchema)
+	tableSchemaDiff := job.schemaHandle.generateTableSchemaDiff(tName)
 	if tableSchemaDiff.Exists {
 		err = job.UpdateTableSchema(tName, tableSchemaDiff)
 		if err != nil {
@@ -1258,7 +1267,7 @@ func (job *UploadJob) loadIdentityTables(populateHistoricIdentities bool) (loadE
 
 		errorMap[tableName] = nil
 
-		tableSchemaDiff := getTableSchemaDiff(tableName, job.schemaHandle.schemaInWarehouse, job.upload.UploadSchema)
+		tableSchemaDiff := job.schemaHandle.generateTableSchemaDiff(tableName)
 		if tableSchemaDiff.Exists {
 			err := job.UpdateTableSchema(tableName, tableSchemaDiff)
 			if err != nil {

--- a/warehouse/upload_test.go
+++ b/warehouse/upload_test.go
@@ -155,7 +155,7 @@ func TestColumnCountStat(t *testing.T) {
 					},
 				},
 				stats: store,
-				schemaHandle: &SchemaHandle{
+				schemaHandle: &Schema{
 					schemaInWarehouse: model.Schema{
 						tableName: model.TableSchema{
 							"test-column-1": "string",

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -69,7 +69,6 @@ var (
 	controlPlaneClient                  *controlplane.Client
 	noOfSlaveWorkerRoutines             int
 	uploadFreqInS                       int64
-	stagingFilesSchemaPaginationSize    int
 	mainLoopSleep                       time.Duration
 	stagingFilesBatchSize               int
 	lastProcessedMarkerMap              map[string]int64
@@ -99,7 +98,6 @@ var (
 	waitForConfig                       time.Duration
 	waitForWorkerSleep                  time.Duration
 	ShouldForceSetLowerVersion          bool
-	skipDeepEqualSchemas                bool
 	maxParallelJobCreation              int
 	enableJitterForSyncs                bool
 	asyncWh                             *jobs.AsyncJobWh
@@ -188,7 +186,6 @@ func loadConfig() {
 	configBackendURL = config.GetString("CONFIG_BACKEND_URL", "api.rudderlabs.com")
 	enableTunnelling = config.GetBool("ENABLE_TUNNELLING", true)
 	config.RegisterIntConfigVariable(10, &warehouseSyncPreFetchCount, true, 1, "Warehouse.warehouseSyncPreFetchCount")
-	config.RegisterIntConfigVariable(100, &stagingFilesSchemaPaginationSize, true, 1, "Warehouse.stagingFilesSchemaPaginationSize")
 	config.RegisterBoolConfigVariable(false, &warehouseSyncFreqIgnore, true, "Warehouse.warehouseSyncFreqIgnore")
 	config.RegisterIntConfigVariable(3, &minRetryAttempts, true, 1, "Warehouse.minRetryAttempts")
 	config.RegisterDurationConfigVariable(180, &retryTimeWindow, true, time.Minute, []string{"Warehouse.retryTimeWindow", "Warehouse.retryTimeWindowInMins"}...)
@@ -206,7 +203,6 @@ func loadConfig() {
 	config.RegisterDurationConfigVariable(5, &waitForConfig, false, time.Second, []string{"Warehouse.waitForConfig", "Warehouse.waitForConfigInS"}...)
 	config.RegisterDurationConfigVariable(5, &waitForWorkerSleep, false, time.Second, []string{"Warehouse.waitForWorkerSleep", "Warehouse.waitForWorkerSleepInS"}...)
 	config.RegisterBoolConfigVariable(true, &ShouldForceSetLowerVersion, false, "SQLMigrator.forceSetLowerVersion")
-	config.RegisterBoolConfigVariable(false, &skipDeepEqualSchemas, true, "Warehouse.skipDeepEqualSchemas")
 	config.RegisterIntConfigVariable(8, &maxParallelJobCreation, true, 1, "Warehouse.maxParallelJobCreation")
 	config.RegisterBoolConfigVariable(false, &enableJitterForSyncs, true, "Warehouse.enableJitterForSyncs")
 	config.RegisterDurationConfigVariable(30, &tableCountQueryTimeout, true, time.Second, []string{"Warehouse.tableCountQueryTimeout", "Warehouse.tableCountQueryTimeoutInS"}...)


### PR DESCRIPTION
# Description

- In case of databricks external table, since we are using the same table and performing alter on it, We can't create the table again because there will be a mismatch in the schema. It is basically returning the following error:
  ```
  The specified schema does not match the existing schema at s3://acorns-rudderstack-s3-sink-staging/rudder/delta/tables/rudderstack_setup_test/setup_test_staging.
  
  == Specified ==
  root
  |-- id: long (nullable = true)
  |-- val: string (nullable = true)
  
  
  == Existing ==
  root
  |-- id: long (nullable = true)
  |-- val: string (nullable = true)
  |-- val_alter: string (nullable = true)
  
  
  == Differences ==
  - Specified schema is missing field(s): val_alter
  
  If your intention is to keep the existing schema, you can omit the
  schema from the create table command. Otherwise please ensure that
  the schema matches.
  ```
- Therefore adding random `uuid` to the table in case of **databricks external location configured**.

## Notion Ticket

https://www.notion.so/rudderstacks/Deltalake-validations-fails-configured-with-external-location-e299460400a8464ab4deeb25261e552a?pvs=4

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
