### PR TITLE
fix: external table support for databricks validations

### DIFF
--- a/warehouse/integrations/deltalake-native/deltalake_test.go
+++ b/warehouse/integrations/deltalake-native/deltalake_test.go
@@ -328,6 +328,7 @@ func TestIntegration(t *testing.T) {
 		testCases := []struct {
 			name                string
 			useParquetLoadFiles bool
+			conf                map[string]interface{}
 		}{
 			{
 				name:                "Parquet load files",
@@ -337,6 +338,14 @@ func TestIntegration(t *testing.T) {
 				name:                "CSV load files",
 				useParquetLoadFiles: false,
 			},
+			{
+				name:                "External location",
+				useParquetLoadFiles: true,
+				conf: map[string]interface{}{
+					"enableExternalLocation": true,
+					"externalLocation":       "/path/to/delta/table",
+				},
+			},
 		}
 
 		for _, tc := range testCases {
@@ -344,6 +353,11 @@ func TestIntegration(t *testing.T) {
 
 			t.Run(tc.name, func(t *testing.T) {
 				t.Setenv("RSERVER_WAREHOUSE_DELTALAKE_USE_PARQUET_LOAD_FILES", strconv.FormatBool(tc.useParquetLoadFiles))
+
+				for k, v := range tc.conf {
+					dest.Config[k] = v
+				}
+
 				testhelper.VerifyConfigurationTest(t, dest)
 			})
 		}

--- a/warehouse/validations/validations.go
+++ b/warehouse/validations/validations.go
@@ -15,6 +15,11 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
+const (
+	namespace = "rudderstack_setup_test"
+	table     = "setup_test_staging"
+)
+
 var (
 	connectionTestingFolder        string
 	pkgLogger                      logger.Logger
@@ -23,19 +28,17 @@ var (
 )
 
 var (
-	TableSchemaMap = model.TableSchema{
+	tableSchemaMap = model.TableSchema{
 		"id":  "int",
 		"val": "string",
 	}
-	PayloadMap = map[string]interface{}{
+	payloadMap = map[string]interface{}{
 		"id":  1,
 		"val": "RudderStack",
 	}
-	AlterColumnMap = model.TableSchema{
+	alterColumnMap = model.TableSchema{
 		"val_alter": "string",
 	}
-	Namespace = "rudderstack_setup_test"
-	Table     = "setup_test_staging"
 )
 
 type validationFunc struct {


### PR DESCRIPTION
# Description

- In case of databricks external table, since we are using the same table and performing alter on it, We can't create the table again because there will be a mismatch in the schema. It is basically returning the following error:
  ```
  The specified schema does not match the existing schema at s3://acorns-rudderstack-s3-sink-staging/rudder/delta/tables/rudderstack_setup_test/setup_test_staging.
  
  == Specified ==
  root
  |-- id: long (nullable = true)
  |-- val: string (nullable = true)
  
  
  == Existing ==
  root
  |-- id: long (nullable = true)
  |-- val: string (nullable = true)
  |-- val_alter: string (nullable = true)
  
  
  == Differences ==
  - Specified schema is missing field(s): val_alter
  
  If your intention is to keep the existing schema, you can omit the
  schema from the create table command. Otherwise please ensure that
  the schema matches.
  ```
- Therefore adding random `uuid` to the table in case of **databricks external location configured**.

## Notion Ticket

https://www.notion.so/rudderstacks/Deltalake-validations-fails-configured-with-external-location-e299460400a8464ab4deeb25261e552a?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
