### PR TITLE
fix: use isAdjustedToUTC=true for parquet timestamp datatype

### DIFF
--- a/warehouse/encoding/parquetwriter.go
+++ b/warehouse/encoding/parquetwriter.go
@@ -19,7 +19,7 @@ const (
 	ParquetBoolean         = "type=BOOLEAN, repetitiontype=OPTIONAL"
 	ParquetDouble          = "type=DOUBLE, repetitiontype=OPTIONAL"
 	ParquetString          = "type=BYTE_ARRAY, convertedtype=UTF8, repetitiontype=OPTIONAL"
-	ParquetTimestampMicros = "type=INT64, convertedtype=TIMESTAMP_MICROS, repetitiontype=OPTIONAL"
+	ParquetTimestampMicros = "type=INT64, convertedtype=TIMESTAMP_MICROS, repetitiontype=OPTIONAL, isAdjustedToUTC=true"
 )
 
 var rudderDataTypeToParquetDataType = map[string]map[string]string{


### PR DESCRIPTION
# Description

< Replace with adequate description for this PR as per [Pull Request document](https://www.notion.so/rudderstacks/Pull-Requests-40a4c6bd7a5e4387ba9029bab297c9e3) >

## Notion Ticket

< Replace with Notion Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
