### PR TITLE
fix: clickhouse flaky test

### DIFF
--- a/warehouse/archive/archiver_test.go
+++ b/warehouse/archive/archiver_test.go
@@ -75,6 +75,8 @@ func TestArchiver(t *testing.T) {
 				pgResource, err = resource.SetupPostgres(pool, t)
 				require.NoError(t, err)
 
+				t.Log("db:", pgResource.DBDsn)
+
 				err = (&migrator.Migrator{
 					Handle:          pgResource.DB,
 					MigrationsTable: "wh_schema_migrations",
@@ -92,6 +94,8 @@ func TestArchiver(t *testing.T) {
 			g.Go(func() error {
 				minioResource, err = destination.SetupMINIO(pool, t)
 				require.NoError(t, err)
+
+				t.Log("minio:", minioResource.Endpoint)
 
 				return nil
 			})

--- a/warehouse/integrations/clickhouse/testdata/docker-compose.clickhouse-cluster.yml
+++ b/warehouse/integrations/clickhouse/testdata/docker-compose.clickhouse-cluster.yml
@@ -1,18 +1,6 @@
 version: "3.9"
 
 services:
-  clickhouse:
-    image: yandex/clickhouse-server:21-alpine
-    environment:
-      - CLICKHOUSE_DB=rudderdb
-      - CLICKHOUSE_PASSWORD=rudder-password
-      - CLICKHOUSE_USER=rudder
-    ports:
-      - "9000"
-    healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
-      interval: 1s
-      retries: 25
   zookeeper:
     image: zookeeper:3.5
     healthcheck:

--- a/warehouse/integrations/clickhouse/testdata/docker-compose.clickhouse.yml
+++ b/warehouse/integrations/clickhouse/testdata/docker-compose.clickhouse.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+
+services:
+  clickhouse:
+    image: yandex/clickhouse-server:21-alpine
+    environment:
+      - CLICKHOUSE_DB=rudderdb
+      - CLICKHOUSE_PASSWORD=rudder-password
+      - CLICKHOUSE_USER=rudder
+    ports:
+      - "9000"
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
+      interval: 1s
+      retries: 25

--- a/warehouse/integrations/middleware/sqlquerywrapper/sql_test.go
+++ b/warehouse/integrations/middleware/sqlquerywrapper/sql_test.go
@@ -28,6 +28,8 @@ func TestQueryWrapper(t *testing.T) {
 	pgResource, err := resource.SetupPostgres(pool, t)
 	require.NoError(t, err)
 
+	t.Log("db:", pgResource.DBDsn)
+
 	testCases := []struct {
 		name               string
 		executionTimeInSec time.Duration

--- a/warehouse/integrations/postgres/load_test.go
+++ b/warehouse/integrations/postgres/load_test.go
@@ -194,6 +194,8 @@ func TestLoadTable(t *testing.T) {
 				pgResource, err := resource.SetupPostgres(pool, t)
 				require.NoError(t, err)
 
+				t.Log("db:", pgResource.DBDsn)
+
 				db := sqlmiddleware.New(pgResource.DB)
 
 				store := memstats.New()
@@ -319,6 +321,8 @@ func TestLoadTable(t *testing.T) {
 
 				pgResource, err := resource.SetupPostgres(pool, t)
 				require.NoError(t, err)
+
+				t.Log("db:", pgResource.DBDsn)
 
 				db := sqlmiddleware.New(pgResource.DB)
 
@@ -491,6 +495,8 @@ func TestLoadUsersTable(t *testing.T) {
 
 			pgResource, err := resource.SetupPostgres(pool, t)
 			require.NoError(t, err)
+
+			t.Log("db:", pgResource.DBDsn)
 
 			db := sqlmiddleware.New(pgResource.DB)
 

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -396,6 +396,8 @@ func TestRedshift_AlterColumn(t *testing.T) {
 			pgResource, err := resource.SetupPostgres(pool, t)
 			require.NoError(t, err)
 
+			t.Log("db:", pgResource.DBDsn)
+
 			rs := redshift.New()
 			redshift.WithConfig(rs, config.Default)
 

--- a/warehouse/internal/service/loadfiles/downloader/downloader_test.go
+++ b/warehouse/internal/service/loadfiles/downloader/downloader_test.go
@@ -118,6 +118,8 @@ func TestDownloader(t *testing.T) {
 			minioResource, err = destination.SetupMINIO(pool, t)
 			require.NoError(t, err)
 
+			t.Log("minio:", minioResource.Endpoint)
+
 			conf := map[string]any{
 				"bucketName":       minioResource.BucketName,
 				"accessKeyID":      minioResource.AccessKey,

--- a/warehouse/tracker_test.go
+++ b/warehouse/tracker_test.go
@@ -99,6 +99,8 @@ func TestHandleT_Track(t *testing.T) {
 			pgResource, err := resource.SetupPostgres(pool, t)
 			require.NoError(t, err)
 
+			t.Log("db:", pgResource.DBDsn)
+
 			err = (&migrator.Migrator{
 				Handle:          pgResource.DB,
 				MigrationsTable: "wh_schema_migrations",
@@ -222,6 +224,8 @@ func TestHandleT_CronTracker(t *testing.T) {
 
 		pgResource, err := resource.SetupPostgres(pool, t)
 		require.NoError(t, err)
+
+		t.Log("db:", pgResource.DBDsn)
 
 		err = (&migrator.Migrator{
 			Handle:          pgResource.DB,

--- a/warehouse/upload_test.go
+++ b/warehouse/upload_test.go
@@ -364,12 +364,13 @@ func TestUploadJobT_UpdateTableSchema(t *testing.T) {
 
 					pgResource, err := resource.SetupPostgres(pool, t)
 					require.NoError(t, err)
-					sqlmiddleware := sqlmiddleware.New(pgResource.DB)
+
+					t.Log("db:", pgResource.DBDsn)
 
 					rs := redshift.New()
 					redshift.WithConfig(rs, config.Default)
 
-					rs.DB = sqlmiddleware
+					rs.DB = sqlmiddleware.New(pgResource.DB)
 					rs.Namespace = testNamespace
 
 					job := &UploadJob{
@@ -432,12 +433,13 @@ func TestUploadJobT_UpdateTableSchema(t *testing.T) {
 
 			pgResource, err := resource.SetupPostgres(pool, t)
 			require.NoError(t, err)
-			sqlmiddleware := sqlmiddleware.New(pgResource.DB)
+
+			t.Log("db:", pgResource.DBDsn)
 
 			rs := redshift.New()
 			redshift.WithConfig(rs, config.Default)
 
-			rs.DB = sqlmiddleware
+			rs.DB = sqlmiddleware.New(pgResource.DB)
 			rs.Namespace = testNamespace
 
 			job := &UploadJob{

--- a/warehouse/validations/validate_test.go
+++ b/warehouse/validations/validate_test.go
@@ -37,11 +37,15 @@ func setup(t *testing.T, pool *dockertest.Pool) testResource {
 		pgResource, err = resource.SetupPostgres(pool, t)
 		require.NoError(t, err)
 
+		t.Log("db:", pgResource.DBDsn)
+
 		return nil
 	})
 	g.Go(func() error {
 		minioResource, err = destination.SetupMINIO(pool, t)
 		require.NoError(t, err)
+
+		t.Log("minio:", minioResource.Endpoint)
 
 		return nil
 	})
@@ -104,6 +108,8 @@ func TestValidator(t *testing.T) {
 
 			minioResource, err = destination.SetupMINIO(pool, t)
 			require.NoError(t, err)
+
+			t.Log("minio:", minioResource.Endpoint)
 
 			var (
 				bucket = "s3-datalake-test"

--- a/warehouse/warehouse_test.go
+++ b/warehouse/warehouse_test.go
@@ -40,6 +40,8 @@ func setupWarehouseJobs(pool *dockertest.Pool, t testingT) *resource.PostgresRes
 	pgResource, err := resource.SetupPostgres(pool, t)
 	Expect(err).To(BeNil())
 
+	t.Log("db:", pgResource.DBDsn)
+
 	t.Setenv("WAREHOUSE_JOBS_DB_HOST", pgResource.Host)
 	t.Setenv("WAREHOUSE_JOBS_DB_USER", pgResource.User)
 	t.Setenv("WAREHOUSE_JOBS_DB_PASSWORD", pgResource.Password)
@@ -124,6 +126,8 @@ func TestUploadJob_ProcessingStats(t *testing.T) {
 
 			pgResource, err := resource.SetupPostgres(pool, t)
 			require.NoError(t, err)
+
+			t.Log("db:", pgResource.DBDsn)
 
 			err = (&migrator.Migrator{
 				Handle:          pgResource.DB,
@@ -322,6 +326,8 @@ func Test_GetNamespace(t *testing.T) {
 
 			pgResource, err := resource.SetupPostgres(pool, t)
 			require.NoError(t, err)
+
+			t.Log("db:", pgResource.DBDsn)
 
 			err = (&migrator.Migrator{
 				Handle:          pgResource.DB,

--- a/warehouse/warehousegrpc_test.go
+++ b/warehouse/warehousegrpc_test.go
@@ -54,6 +54,8 @@ var _ = Describe("WarehouseGrpc", func() {
 				minioResource, err = destination.SetupMINIO(pool, cleanup)
 				Expect(err).To(BeNil())
 
+				fmt.Println("minio:", minioResource.Endpoint)
+
 				initWarehouse()
 
 				err = setupDB(context.TODO(), getConnectionString())


### PR DESCRIPTION
# Description

- Added some debugging logs.
- Use a simpler setup for bringing up the dependencies using compose.
  ```
  clickhouse_test.go:451: could not remove clickhouse minio network: API error (403): error while removing network: network 
  clickhouse-minio-network id 58d24af95ecd9660a51954f61f41e52ddf875124fd998199e87b80c872543f87 has active endpoints
  ```

## Notion Ticket

https://www.notion.so/rudderstacks/fix-removal-of-clickhouse-network-properly-0a34e4e2c72448d49556df09ff65c8e3?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
