### PR TITLE
fix: deltalake parquet datatype support

### DIFF
--- a/warehouse/integrations/deltalake-native/deltalake.go
+++ b/warehouse/integrations/deltalake-native/deltalake.go
@@ -814,7 +814,11 @@ func primaryKey(tableName string) string {
 // sortedColumnNames returns the column names in the order of sortedColumnKeys
 func (d *Deltalake) sortedColumnNames(tableSchemaInUpload model.TableSchema, sortedColumnKeys []string, diff warehouseutils.TableSchemaDiff) string {
 	if d.Uploader.GetLoadFileType() == warehouseutils.LOAD_FILE_TYPE_PARQUET {
-		return strings.Join(sortedColumnKeys, ",")
+		return warehouseutils.JoinWithFormatting(sortedColumnKeys, func(_ int, value string) string {
+			columnName := value
+			columnType := dataTypesMap[tableSchemaInUpload[columnName]]
+			return fmt.Sprintf(`%s::%s`, columnName, columnType)
+		}, ",")
 	}
 
 	format := func(index int, value string) string {

--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -423,7 +423,11 @@ func (dl *Deltalake) dropStagingTables(tableNames []string) {
 // sortedColumnNames returns sorted column names
 func (dl *Deltalake) sortedColumnNames(tableSchemaInUpload model.TableSchema, sortedColumnKeys []string, diff warehouseutils.TableSchemaDiff) (sortedColumnNames string) {
 	if dl.Uploader.GetLoadFileType() == warehouseutils.LOAD_FILE_TYPE_PARQUET {
-		sortedColumnNames = strings.Join(sortedColumnKeys, ",")
+		sortedColumnNames = warehouseutils.JoinWithFormatting(sortedColumnKeys, func(_ int, value string) string {
+			columnName := value
+			columnType := dataTypesMap[tableSchemaInUpload[columnName]]
+			return fmt.Sprintf(`%s::%s`, columnName, columnType)
+		}, ",")
 	} else {
 		// TODO: Explore adding headers to csv.
 		format := func(index int, value string) string {


### PR DESCRIPTION
# Description

- Since during the loading of the data from parquet using the **COPY command**, there is a default type that is inferred from the data. 
- It's better to typecast the data into the one which we used while we generate the load files to avoid having a mismatch.

## Notion Ticket

https://www.notion.so/rudderstacks/Databricks-TIMESTAMP_NTZ-issue-a0a478b30e01457fbd2002db68dbfe9d?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
