### PR TITLE
fix: processor panicking during shutdown

### DIFF
--- a/processor/manager.go
+++ b/processor/manager.go
@@ -72,8 +72,8 @@ func (proc *LifecycleManager) Start() error {
 // Stop stops the processor, this is a blocking call.
 func (proc *LifecycleManager) Stop() {
 	proc.currentCancel()
-	proc.Handle.Shutdown()
 	proc.waitGroup.Wait()
+	proc.Handle.Shutdown()
 }
 
 func WithFeaturesRetryMaxAttempts(maxAttempts int) func(l *LifecycleManager) {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -424,9 +424,10 @@ func (proc *Handle) Setup(
 	proc.backgroundCancel = cancel
 
 	proc.config.asyncInit = misc.NewAsyncInit(2)
-	rruntime.Go(func() {
+	g.Go(misc.WithBugsnag(func() error {
 		proc.backendConfigSubscriber(ctx)
-	})
+		return nil
+	}))
 
 	g.Go(misc.WithBugsnag(func() error {
 		proc.syncTransformerFeatureJson(ctx)


### PR DESCRIPTION
# Description

Processor must call shutdown after waitgroup returns. 
Issue surfaced after changes in https://github.com/rudderlabs/rudder-server/pull/3289 where badgerDB is being shut down.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
