### PR TITLE
chore: applying 1.9.x fixes to the main branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/prometheus/client_model v0.4.0
 	github.com/rs/cors v1.9.0
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
-	github.com/rudderlabs/rudder-go-kit v0.13.4
+	github.com/rudderlabs/rudder-go-kit v0.13.5
 	github.com/rudderlabs/sql-tunnels v0.1.3
 	github.com/samber/lo v1.38.1
 	github.com/segmentio/kafka-go v0.4.40

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/prometheus/client_model v0.4.0
 	github.com/rs/cors v1.9.0
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
-	github.com/rudderlabs/rudder-go-kit v0.13.3
+	github.com/rudderlabs/rudder-go-kit v0.13.4
 	github.com/rudderlabs/sql-tunnels v0.1.3
 	github.com/samber/lo v1.38.1
 	github.com/segmentio/kafka-go v0.4.40

--- a/go.sum
+++ b/go.sum
@@ -1841,8 +1841,8 @@ github.com/rudderlabs/analytics-go v3.3.3+incompatible h1:OG0XlKoXfr539e2t1dXtTB
 github.com/rudderlabs/analytics-go v3.3.3+incompatible/go.mod h1:LF8/ty9kUX4PTY3l5c97K3nZZaX5Hwsvt+NBaRL/f30=
 github.com/rudderlabs/compose-test v0.1.1 h1:YJn30Fg0+pk9abKTBbWssiofwPuOEfe7Nb2UxKkC+FA=
 github.com/rudderlabs/compose-test v0.1.1/go.mod h1:z2dUBgcXaOhhMUcG09lZpqdz5S8bYOIX2wAx4itEr1o=
-github.com/rudderlabs/rudder-go-kit v0.13.4 h1:U8B/moa2VxdPncQ8CmIDetLDYBA8GUj+vs02wmkWixg=
-github.com/rudderlabs/rudder-go-kit v0.13.4/go.mod h1:3P7g4yt8TxiN6zSGvl2h/9dh1ae6GQi5zRP02rva+28=
+github.com/rudderlabs/rudder-go-kit v0.13.5 h1:Zyfu4b1mfxenHKWsMPyksVQmOBSn+K1O+bgwydsvnM0=
+github.com/rudderlabs/rudder-go-kit v0.13.5/go.mod h1:3P7g4yt8TxiN6zSGvl2h/9dh1ae6GQi5zRP02rva+28=
 github.com/rudderlabs/sql-tunnels v0.1.3 h1:o7/MX4Yj0WpAaw0uxkRmkagtzedGxUPRwyho4SMbWMQ=
 github.com/rudderlabs/sql-tunnels v0.1.3/go.mod h1:1TolUkSsrQxdXS0iyGlbLADsgkebmPcz1MxU5xBl6dE=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=

--- a/go.sum
+++ b/go.sum
@@ -1841,8 +1841,8 @@ github.com/rudderlabs/analytics-go v3.3.3+incompatible h1:OG0XlKoXfr539e2t1dXtTB
 github.com/rudderlabs/analytics-go v3.3.3+incompatible/go.mod h1:LF8/ty9kUX4PTY3l5c97K3nZZaX5Hwsvt+NBaRL/f30=
 github.com/rudderlabs/compose-test v0.1.1 h1:YJn30Fg0+pk9abKTBbWssiofwPuOEfe7Nb2UxKkC+FA=
 github.com/rudderlabs/compose-test v0.1.1/go.mod h1:z2dUBgcXaOhhMUcG09lZpqdz5S8bYOIX2wAx4itEr1o=
-github.com/rudderlabs/rudder-go-kit v0.13.3 h1:Tl1yN7TZXjVXYe7TBkMYV2yv6tfdOZpDvRxUrH74C/0=
-github.com/rudderlabs/rudder-go-kit v0.13.3/go.mod h1:3P7g4yt8TxiN6zSGvl2h/9dh1ae6GQi5zRP02rva+28=
+github.com/rudderlabs/rudder-go-kit v0.13.4 h1:U8B/moa2VxdPncQ8CmIDetLDYBA8GUj+vs02wmkWixg=
+github.com/rudderlabs/rudder-go-kit v0.13.4/go.mod h1:3P7g4yt8TxiN6zSGvl2h/9dh1ae6GQi5zRP02rva+28=
 github.com/rudderlabs/sql-tunnels v0.1.3 h1:o7/MX4Yj0WpAaw0uxkRmkagtzedGxUPRwyho4SMbWMQ=
 github.com/rudderlabs/sql-tunnels v0.1.3/go.mod h1:1TolUkSsrQxdXS0iyGlbLADsgkebmPcz1MxU5xBl6dE=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -72,8 +72,8 @@ func (proc *LifecycleManager) Start() error {
 // Stop stops the processor, this is a blocking call.
 func (proc *LifecycleManager) Stop() {
 	proc.currentCancel()
-	proc.Handle.Shutdown()
 	proc.waitGroup.Wait()
+	proc.Handle.Shutdown()
 }
 
 func WithFeaturesRetryMaxAttempts(maxAttempts int) func(l *LifecycleManager) {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -424,9 +424,10 @@ func (proc *Handle) Setup(
 	proc.backgroundCancel = cancel
 
 	proc.config.asyncInit = misc.NewAsyncInit(2)
-	rruntime.Go(func() {
+	g.Go(misc.WithBugsnag(func() error {
 		proc.backendConfigSubscriber(ctx)
-	})
+		return nil
+	}))
 
 	g.Go(misc.WithBugsnag(func() error {
 		proc.syncTransformerFeatureJson(ctx)

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -82,6 +82,7 @@ type Handle struct {
 	jobdDBMaxRetries             int
 	minIdleSleep                 time.Duration
 	uploadFreq                   time.Duration
+	forceHonorUploadFrequency    bool
 	readPerDestination           bool
 	disableEgress                bool
 	toAbortDestinationIDs        string
@@ -223,7 +224,7 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 		if batchDest, ok := destinationsMap[destID]; ok {
 			var processJobs bool
 			brt.lastExecTimesMu.Lock()
-			if limitsReached { // if limits are reached, process all jobs regardless of their upload frequency
+			if limitsReached && !brt.forceHonorUploadFrequency { // if limits are reached, process all jobs regardless of their upload frequency
 				processJobs = true
 			} else { // honour upload frequency
 				lastExecTime := brt.lastExecTimes[destID]

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -102,6 +102,7 @@ func (brt *Handle) Setup(
 	config.RegisterIntConfigVariable(2, &brt.jobdDBMaxRetries, true, 1, []string{"JobsDB.BatchRouter.MaxRetries", "JobsDB.MaxRetries"}...)
 	config.RegisterDurationConfigVariable(2, &brt.minIdleSleep, true, time.Second, []string{"BatchRouter.minIdleSleep"}...)
 	config.RegisterDurationConfigVariable(30, &brt.uploadFreq, true, time.Second, []string{"BatchRouter.uploadFreqInS", "BatchRouter.uploadFreq"}...)
+	config.RegisterBoolConfigVariable(false, &brt.forceHonorUploadFrequency, true, "BatchRouter.forceHonorUploadFrequency")
 	config.RegisterBoolConfigVariable(false, &brt.disableEgress, false, "disableEgress")
 	config.RegisterStringConfigVariable("", &brt.toAbortDestinationIDs, true, "BatchRouter.toAbortDestinationIDs")
 	config.RegisterDurationConfigVariable(3, &brt.warehouseServiceMaxRetryTime, true, time.Hour, []string{"BatchRouter.warehouseServiceMaxRetryTime", "BatchRouter.warehouseServiceMaxRetryTimeinHr"}...)

--- a/utils/sync/limiter.go
+++ b/utils/sync/limiter.go
@@ -78,14 +78,13 @@ func NewLimiter(ctx context.Context, wg *sync.WaitGroup, name string, limit int,
 	l.stats.triggerFunc = func() <-chan time.Time {
 		return time.After(15 * time.Second)
 	}
+	for _, opt := range opts {
+		opt(l)
+	}
 	l.stats.stat = statsf
 	l.stats.waitGauge = statsf.NewTaggedStat(name+"_limiter_waiting_routines", stats.GaugeType, l.tags)
 	l.stats.activeGauge = statsf.NewTaggedStat(name+"_limiter_active_routines", stats.GaugeType, l.tags)
 	l.stats.availabilityGauge = statsf.NewTaggedStat(name+"_limiter_availability", stats.GaugeType, l.tags)
-
-	for _, opt := range opts {
-		opt(l)
-	}
 	wg.Add(1)
 	rruntime.Go(func() {
 		defer wg.Done()

--- a/warehouse/integrations/deltalake-native/deltalake.go
+++ b/warehouse/integrations/deltalake-native/deltalake.go
@@ -814,7 +814,11 @@ func primaryKey(tableName string) string {
 // sortedColumnNames returns the column names in the order of sortedColumnKeys
 func (d *Deltalake) sortedColumnNames(tableSchemaInUpload model.TableSchema, sortedColumnKeys []string, diff warehouseutils.TableSchemaDiff) string {
 	if d.Uploader.GetLoadFileType() == warehouseutils.LOAD_FILE_TYPE_PARQUET {
-		return strings.Join(sortedColumnKeys, ",")
+		return warehouseutils.JoinWithFormatting(sortedColumnKeys, func(_ int, value string) string {
+			columnName := value
+			columnType := dataTypesMap[tableSchemaInUpload[columnName]]
+			return fmt.Sprintf(`%s::%s`, columnName, columnType)
+		}, ",")
 	}
 
 	format := func(index int, value string) string {

--- a/warehouse/integrations/deltalake-native/deltalake_test.go
+++ b/warehouse/integrations/deltalake-native/deltalake_test.go
@@ -328,6 +328,7 @@ func TestIntegration(t *testing.T) {
 		testCases := []struct {
 			name                string
 			useParquetLoadFiles bool
+			conf                map[string]interface{}
 		}{
 			{
 				name:                "Parquet load files",
@@ -337,6 +338,14 @@ func TestIntegration(t *testing.T) {
 				name:                "CSV load files",
 				useParquetLoadFiles: false,
 			},
+			{
+				name:                "External location",
+				useParquetLoadFiles: true,
+				conf: map[string]interface{}{
+					"enableExternalLocation": true,
+					"externalLocation":       "/path/to/delta/table",
+				},
+			},
 		}
 
 		for _, tc := range testCases {
@@ -344,6 +353,11 @@ func TestIntegration(t *testing.T) {
 
 			t.Run(tc.name, func(t *testing.T) {
 				t.Setenv("RSERVER_WAREHOUSE_DELTALAKE_USE_PARQUET_LOAD_FILES", strconv.FormatBool(tc.useParquetLoadFiles))
+
+				for k, v := range tc.conf {
+					dest.Config[k] = v
+				}
+
 				testhelper.VerifyConfigurationTest(t, dest)
 			})
 		}

--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -423,7 +423,11 @@ func (dl *Deltalake) dropStagingTables(tableNames []string) {
 // sortedColumnNames returns sorted column names
 func (dl *Deltalake) sortedColumnNames(tableSchemaInUpload model.TableSchema, sortedColumnKeys []string, diff warehouseutils.TableSchemaDiff) (sortedColumnNames string) {
 	if dl.Uploader.GetLoadFileType() == warehouseutils.LOAD_FILE_TYPE_PARQUET {
-		sortedColumnNames = strings.Join(sortedColumnKeys, ",")
+		sortedColumnNames = warehouseutils.JoinWithFormatting(sortedColumnKeys, func(_ int, value string) string {
+			columnName := value
+			columnType := dataTypesMap[tableSchemaInUpload[columnName]]
+			return fmt.Sprintf(`%s::%s`, columnName, columnType)
+		}, ",")
 	} else {
 		// TODO: Explore adding headers to csv.
 		format := func(index int, value string) string {

--- a/warehouse/validations/validations.go
+++ b/warehouse/validations/validations.go
@@ -15,6 +15,11 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
+const (
+	namespace = "rudderstack_setup_test"
+	table     = "setup_test_staging"
+)
+
 var (
 	connectionTestingFolder        string
 	pkgLogger                      logger.Logger
@@ -23,19 +28,17 @@ var (
 )
 
 var (
-	TableSchemaMap = model.TableSchema{
+	tableSchemaMap = model.TableSchema{
 		"id":  "int",
 		"val": "string",
 	}
-	PayloadMap = map[string]interface{}{
+	payloadMap = map[string]interface{}{
 		"id":  1,
 		"val": "RudderStack",
 	}
-	AlterColumnMap = model.TableSchema{
+	alterColumnMap = model.TableSchema{
 		"val_alter": "string",
 	}
-	Namespace = "rudderstack_setup_test"
-	Table     = "setup_test_staging"
 )
 
 type validationFunc struct {


### PR DESCRIPTION
# Description

Applying 1.9.x fixes to the main branch

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

BEGIN_COMMIT_OVERRIDE
chore: tests coverage (#3349)
chore(deps): bump github.com/aws/aws-sdk-go from 1.44.264 to 1.44.265 (#3361)
chore(deps): bump google.golang.org/api from 0.122.0 to 0.123.0 (#3362)
chore(deps): bump github.com/stretchr/testify from 1.8.2 to 1.8.3 (#3359)
chore(deps): bump github.com/onsi/gomega from 1.27.6 to 1.27.7 (#3360)
chore: replace announcement header with data learning centre link (#3358)
feat(warehouse): staging file schema consolidation (#3088)
chore: make tests required for passing (#3347)
chore(deps): bump github.com/minio/minio-go/v7 from 7.0.52 to 7.0.53 (#3370)
chore(deps): bump github.com/aws/aws-sdk-go from 1.44.265 to 1.44.266 (#3368)
fix: gateway flaky test (#3356)
chore: getUploadsToProcess error handling (#3380)
fix: regulation-worker flaky test (#3374)
END_COMMIT_OVERRIDE
