### PR TITLE
chore: store historic message ids

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -312,7 +312,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 			return fmt.Errorf("could not setup replayDB: %w", err)
 		}
 		defer replayDB.TearDown()
-		a.app.Features().Replay.Setup(ctx, &replayDB, gatewayDB, routerDB, batchRouterDB)
+		a.app.Features().Replay.Setup(ctx, &replayDB)
 	}
 
 	g.Go(func() error {

--- a/app/features.go
+++ b/app/features.go
@@ -40,7 +40,7 @@ Replay Feature
 
 // ReplayFeature handles inserting of failed jobs into respective gw/rt jobsdb
 type ReplayFeature interface {
-	Setup(ctx context.Context, replayDB, gwDB, routerDB, batchRouterDB *jobsdb.HandleT)
+	Setup(ctx context.Context, replayDB *jobsdb.HandleT)
 }
 
 // ReplayFeatureSetup is a function that initializes a Replay feature

--- a/enterprise/replay/db.go
+++ b/enterprise/replay/db.go
@@ -1,0 +1,74 @@
+package replay
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+)
+
+var MessageTableName = "historic_message_id"
+
+type DBHandle struct {
+	db *sql.DB
+}
+
+type MessageJob struct {
+	UserAgent   string
+	MessageID   string
+	WorkspaceID string
+	SourceID    string
+	SDKVersion  string
+	AnonymousID string
+	UserID      string
+	CreatedAt   time.Time
+}
+
+func (h *DBHandle) SetupTables(ctx context.Context) error {
+	sqlStatement := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q (
+    	id SERIAL PRIMARY KEY,
+		user_agent TEXT NOT NULL DEFAULT '',
+		message_id TEXT NOT NULL DEFAULT '',
+		workspace_id TEXT NOT NULL,
+		source_id TEXT NOT NULL,
+		sdk_version TEXT NOT NULL DEFAULT '',
+		anonymous_id TEXT NOT NULL DEFAULT '',
+		user_id TEXT NOT NULL DEFAULT '',
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW());`, MessageTableName)
+	_, err := h.db.ExecContext(ctx, sqlStatement)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *DBHandle) Store(ctx context.Context, jobs []*MessageJob) error {
+	tx, err := h.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	stmt, err := tx.PrepareContext(ctx, pq.CopyIn("historic_message_id", "user_agent", "message_id", "workspace_id", "source_id", "sdk_version", "anonymous_id", "user_id", "created_At"))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = stmt.Close() }()
+	for _, job := range jobs {
+		if _, err = stmt.ExecContext(ctx, job.UserAgent, job.MessageID, job.WorkspaceID, job.SourceID, job.SDKVersion, job.AnonymousID, job.UserID, job.CreatedAt); err != nil {
+			return err
+		}
+	}
+	err = tx.Commit()
+	return err
+}
+
+func setupMessageDB(_ context.Context) (*DBHandle, error) {
+	psqlInfo := misc.GetConnectionString()
+	sqlDB, err := sql.Open("postgres", psqlInfo)
+	if err != nil {
+		return nil, err
+	}
+	return &DBHandle{db: sqlDB}, nil
+}

--- a/enterprise/replay/db.go
+++ b/enterprise/replay/db.go
@@ -50,7 +50,7 @@ func (h *DBHandle) Store(ctx context.Context, jobs []*MessageJob) error {
 	if err != nil {
 		return err
 	}
-	stmt, err := tx.PrepareContext(ctx, pq.CopyIn("historic_message_id", "user_agent", "message_id", "workspace_id", "source_id", "sdk_version", "anonymous_id", "user_id", "created_At"))
+	stmt, err := tx.PrepareContext(ctx, pq.CopyIn("historic_message_id", "user_agent", "message_id", "workspace_id", "source_id", "sdk_version", "anonymous_id", "user_id", "created_at"))
 	if err != nil {
 		return err
 	}

--- a/enterprise/replay/db.go
+++ b/enterprise/replay/db.go
@@ -23,8 +23,11 @@ type MessageJob struct {
 	WorkspaceID string
 	SourceID    string
 	SDKVersion  string
+	SDKName     string
 	AnonymousID string
 	UserID      string
+	FilePath    string
+	LineNumber  int
 	CreatedAt   time.Time
 }
 
@@ -36,8 +39,11 @@ func (h *DBHandle) SetupTables(ctx context.Context) error {
 		workspace_id TEXT NOT NULL,
 		source_id TEXT NOT NULL,
 		sdk_version TEXT NOT NULL DEFAULT '',
+		sdk_name TEXT NOT NULL DEFAULT '',
 		anonymous_id TEXT NOT NULL DEFAULT '',
 		user_id TEXT NOT NULL DEFAULT '',
+		file_path TEXT NOT NULL DEFAULT '',
+		line_number INTEGER NOT NULL DEFAULT 0,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW());`, MessageTableName)
 	_, err := h.db.ExecContext(ctx, sqlStatement)
 	if err != nil {
@@ -48,9 +54,9 @@ func (h *DBHandle) SetupTables(ctx context.Context) error {
 }
 
 func (h *DBHandle) Store(ctx context.Context, jobs []*MessageJob) error {
-	sqlStatement := fmt.Sprintf(`INSERT INTO %q (user_agent, message_id, workspace_id, source_id, sdk_version, anonymous_id, user_id, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`, MessageTableName)
+	sqlStatement := fmt.Sprintf(`INSERT INTO %q (user_agent, message_id, workspace_id, source_id, sdk_version,sdk_name, anonymous_id, user_id,file_path,line_number, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10,$)`, MessageTableName)
 	for _, job := range jobs {
-		_, err := h.db.ExecContext(ctx, sqlStatement, job.UserAgent, job.MessageID, job.WorkspaceID, job.SourceID, job.SDKVersion, job.AnonymousID, job.UserID, job.CreatedAt)
+		_, err := h.db.ExecContext(ctx, sqlStatement, job.UserAgent, job.MessageID, job.WorkspaceID, job.SourceID, job.SDKVersion, job.SDKName, job.AnonymousID, job.UserID, job.FilePath, job.LineNumber, job.CreatedAt)
 		if err != nil {
 			h.log.Info("Error inserting row: ", err)
 		}

--- a/enterprise/replay/db.go
+++ b/enterprise/replay/db.go
@@ -54,11 +54,12 @@ func (h *DBHandle) SetupTables(ctx context.Context) error {
 }
 
 func (h *DBHandle) Store(ctx context.Context, jobs []*MessageJob) error {
-	sqlStatement := fmt.Sprintf(`INSERT INTO %q (user_agent, message_id, workspace_id, source_id, sdk_version,sdk_name, anonymous_id, user_id,file_path,line_number, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10,$)`, MessageTableName)
+	sqlStatement := fmt.Sprintf(`INSERT INTO %q (user_agent, message_id, workspace_id, source_id, sdk_version,sdk_name, anonymous_id, user_id,file_path,line_number, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10,$11)`, MessageTableName)
 	for _, job := range jobs {
 		_, err := h.db.ExecContext(ctx, sqlStatement, job.UserAgent, job.MessageID, job.WorkspaceID, job.SourceID, job.SDKVersion, job.SDKName, job.AnonymousID, job.UserID, job.FilePath, job.LineNumber, job.CreatedAt)
 		if err != nil {
 			h.log.Info("Error inserting row: ", err)
+			return err
 		}
 	}
 	return nil

--- a/enterprise/replay/replay.go
+++ b/enterprise/replay/replay.go
@@ -17,7 +17,7 @@ type Handler struct {
 	log                      logger.Logger
 	bucket                   string
 	db                       *jobsdb.HandleT
-	toDB                     *jobsdb.HandleT
+	toDB                     *DBHandle
 	noOfWorkers              int
 	workers                  []*SourceWorkerT
 	dumpsLoader              *dumpsLoaderHandleT
@@ -154,7 +154,7 @@ func (handle *Handler) initSourceWorkers(ctx context.Context) {
 	handle.initSourceWorkersChannel <- true
 }
 
-func (handle *Handler) Setup(ctx context.Context, dumpsLoader *dumpsLoaderHandleT, db, toDB *jobsdb.HandleT, tablePrefix string, uploader filemanager.FileManager, bucket string, log logger.Logger) {
+func (handle *Handler) Setup(ctx context.Context, dumpsLoader *dumpsLoaderHandleT, db *jobsdb.HandleT, toDB *DBHandle, tablePrefix string, uploader filemanager.FileManager, bucket string, log logger.Logger) {
 	handle.log = log
 	handle.db = db
 	handle.toDB = toDB

--- a/enterprise/replay/setup.go
+++ b/enterprise/replay/setup.go
@@ -61,7 +61,7 @@ func setup(ctx context.Context, replayDB *jobsdb.HandleT, log logger.Logger) err
 	dumpsLoader.Setup(ctx, replayDB, tablePrefix, uploader, bucket, log)
 
 	var replayer Handler
-	toDB, err := setupMessageDB(ctx)
+	toDB, err := setupMessageDB(ctx, log)
 	if err != nil {
 		return err
 	}

--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -135,7 +135,14 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 			userIDString := gjson.GetBytes([]byte(event.Raw), "userId").String()
 			messageID := gjson.GetBytes([]byte(event.Raw), "messageId").String()
 			sentAt := gjson.GetBytes([]byte(event.Raw), "originalTimestamp").String()
-			sentAtFormatted, err := time.Parse(misc.NOTIMEZONEFORMATPARSE, getFormattedTimeStamp(sentAt))
+			var sentAtFormatted time.Time
+			var err error
+			if sentAt != "" {
+				sentAtFormatted, err = time.Parse(misc.NOTIMEZONEFORMATPARSE, getFormattedTimeStamp(sentAt))
+			} else {
+				sentAt := gjson.GetBytes([]byte(event.Raw), "timestamp").String()
+				sentAtFormatted, err = time.Parse(misc.NOTIMEZONEFORMATPARSE, getFormattedTimeStamp(sentAt))
+			}
 			if err != nil {
 				worker.log.Errorf("failed to parse sent at: %s sentAt : %s", err, event.Raw)
 				continue

--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -215,5 +215,9 @@ func (worker *SourceWorkerT) getFieldIdentifier(field string) string {
 }
 
 func getFormattedTimeStamp(timeStamp string) string {
-	return strings.Split(strings.TrimSuffix(timeStamp, "Z"), ".")[0][:19]
+	stringsArr := strings.Split(strings.TrimSuffix(timeStamp, "Z"), ".")[0]
+	if len(stringsArr) == 19 {
+		return stringsArr
+	}
+	return timeStamp
 }

--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -82,7 +82,8 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 
 	err = worker.uploader.Download(ctx, file, filePath)
 	if err != nil {
-		panic(err) // failed to download
+		worker.log.Errorf("failed to download file: %s", err)
+		continue // failed to download
 	}
 	worker.log.Debugf("file downloaded at %s", path)
 	defer func() { _ = file.Close() }()

--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -137,7 +137,7 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 			sentAt := gjson.GetBytes([]byte(event.Raw), "originalTimestamp").String()
 			sentAtFormatted, err := time.Parse(misc.NOTIMEZONEFORMATPARSE, getFormattedTimeStamp(sentAt))
 			if err != nil {
-				worker.log.Errorf("failed to parse sent at: %s sentAt : %s", err, sentAt)
+				worker.log.Errorf("failed to parse sent at: %s sentAt : %s", err, event.Raw)
 				continue
 			}
 			job := MessageJob{

--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -83,7 +83,7 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 	err = worker.uploader.Download(ctx, file, filePath)
 	if err != nil {
 		worker.log.Errorf("failed to download file: %s", err)
-		continue // failed to download
+		return
 	}
 	worker.log.Debugf("file downloaded at %s", path)
 	defer func() { _ = file.Close() }()


### PR DESCRIPTION
# Description
Fetch all GW dumps to extract information relevant for messageID duplicates

## Notion Ticket

[ Notion Link 
](https://www.notion.so/rudderstacks/Script-to-find-duplicates-in-gateway-dumps-7fcdd679f2584df2ba9ffa13ba6b7f27?pvs=4)
## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
