### PR TITLE
chore: cleanup for integration tests for warehouse

### DIFF
--- a/warehouse/integrations/azure-synapse/azure_synapse_test.go
+++ b/warehouse/integrations/azure-synapse/azure_synapse_test.go
@@ -33,10 +33,6 @@ func TestIntegration(t *testing.T) {
 	}
 
 	c := testcompose.New(t, compose.FilePaths([]string{"testdata/docker-compose.yml", "../testdata/docker-compose.jobsdb.yml", "../testdata/docker-compose.minio.yml"}))
-
-	t.Cleanup(func() {
-		c.Stop(context.Background())
-	})
 	c.Start(context.Background())
 
 	misc.Init()

--- a/warehouse/integrations/bigquery/bigquery_test.go
+++ b/warehouse/integrations/bigquery/bigquery_test.go
@@ -50,10 +50,6 @@ func TestIntegration(t *testing.T) {
 	}
 
 	c := testcompose.New(t, compose.FilePaths([]string{"../testdata/docker-compose.jobsdb.yml"}))
-
-	t.Cleanup(func() {
-		c.Stop(context.Background())
-	})
 	c.Start(context.Background())
 
 	misc.Init()

--- a/warehouse/integrations/clickhouse/clickhouse_test.go
+++ b/warehouse/integrations/clickhouse/clickhouse_test.go
@@ -46,10 +46,6 @@ func TestIntegration(t *testing.T) {
 	}
 
 	c := testcompose.New(t, compose.FilePaths([]string{"testdata/docker-compose.clickhouse.yml", "testdata/docker-compose.clickhouse-cluster.yml", "../testdata/docker-compose.jobsdb.yml", "../testdata/docker-compose.minio.yml"}))
-
-	t.Cleanup(func() {
-		c.Stop(context.Background())
-	})
 	c.Start(context.Background())
 
 	misc.Init()
@@ -406,10 +402,6 @@ func (m *mockUploader) GetLoadFilesMetadata(context.Context, warehouseutils.GetL
 
 func TestClickhouse_LoadTableRoundTrip(t *testing.T) {
 	c := testcompose.New(t, compose.FilePaths([]string{"testdata/docker-compose.clickhouse.yml", "../testdata/docker-compose.minio.yml"}))
-
-	t.Cleanup(func() {
-		c.Stop(context.Background())
-	})
 	c.Start(context.Background())
 
 	misc.Init()
@@ -676,10 +668,6 @@ func TestClickhouse_LoadTableRoundTrip(t *testing.T) {
 
 func TestClickhouse_TestConnection(t *testing.T) {
 	c := testcompose.New(t, compose.FilePaths([]string{"testdata/docker-compose.clickhouse.yml"}))
-
-	t.Cleanup(func() {
-		c.Stop(context.Background())
-	})
 	c.Start(context.Background())
 
 	misc.Init()
@@ -782,10 +770,6 @@ func TestClickhouse_TestConnection(t *testing.T) {
 
 func TestClickhouse_LoadTestTable(t *testing.T) {
 	c := testcompose.New(t, compose.FilePaths([]string{"testdata/docker-compose.clickhouse.yml"}))
-
-	t.Cleanup(func() {
-		c.Stop(context.Background())
-	})
 	c.Start(context.Background())
 
 	misc.Init()
@@ -891,10 +875,6 @@ func TestClickhouse_LoadTestTable(t *testing.T) {
 
 func TestClickhouse_FetchSchema(t *testing.T) {
 	c := testcompose.New(t, compose.FilePaths([]string{"testdata/docker-compose.clickhouse.yml"}))
-
-	t.Cleanup(func() {
-		c.Stop(context.Background())
-	})
 	c.Start(context.Background())
 
 	misc.Init()

--- a/warehouse/integrations/datalake/datalake_test.go
+++ b/warehouse/integrations/datalake/datalake_test.go
@@ -65,10 +65,6 @@ func TestIntegration(t *testing.T) {
 	}
 
 	c := testcompose.New(t, compose.FilePaths([]string{"testdata/docker-compose.yml", "../testdata/docker-compose.jobsdb.yml", "../testdata/docker-compose.minio.yml"}))
-
-	t.Cleanup(func() {
-		c.Stop(context.Background())
-	})
 	c.Start(context.Background())
 
 	misc.Init()

--- a/warehouse/integrations/deltalake-native/deltalake_test.go
+++ b/warehouse/integrations/deltalake-native/deltalake_test.go
@@ -76,10 +76,6 @@ func TestIntegration(t *testing.T) {
 	}
 
 	c := testcompose.New(t, compose.FilePaths([]string{"testdata/docker-compose.yml", "../testdata/docker-compose.jobsdb.yml"}))
-
-	t.Cleanup(func() {
-		c.Stop(context.Background())
-	})
 	c.Start(context.Background())
 
 	misc.Init()

--- a/warehouse/integrations/mssql/mssql_test.go
+++ b/warehouse/integrations/mssql/mssql_test.go
@@ -34,10 +34,6 @@ func TestIntegration(t *testing.T) {
 	}
 
 	c := testcompose.New(t, compose.FilePaths([]string{"testdata/docker-compose.yml", "../testdata/docker-compose.jobsdb.yml", "../testdata/docker-compose.minio.yml"}))
-
-	t.Cleanup(func() {
-		c.Stop(context.Background())
-	})
 	c.Start(context.Background())
 
 	misc.Init()

--- a/warehouse/integrations/postgres/postgres_test.go
+++ b/warehouse/integrations/postgres/postgres_test.go
@@ -40,10 +40,6 @@ func TestIntegration(t *testing.T) {
 	}
 
 	c := testcompose.New(t, compose.FilePaths([]string{"testdata/docker-compose.yml", "../testdata/docker-compose.jobsdb.yml", "../testdata/docker-compose.minio.yml"}))
-
-	t.Cleanup(func() {
-		c.Stop(context.Background())
-	})
 	c.Start(context.Background())
 
 	misc.Init()

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -85,10 +85,6 @@ func TestIntegration(t *testing.T) {
 	}
 
 	c := testcompose.New(t, compose.FilePaths([]string{"../testdata/docker-compose.jobsdb.yml"}))
-
-	t.Cleanup(func() {
-		c.Stop(context.Background())
-	})
 	c.Start(context.Background())
 
 	misc.Init()

--- a/warehouse/integrations/snowflake/snowflake_test.go
+++ b/warehouse/integrations/snowflake/snowflake_test.go
@@ -90,10 +90,6 @@ func TestIntegration(t *testing.T) {
 	}
 
 	c := testcompose.New(t, compose.FilePaths([]string{"../testdata/docker-compose.jobsdb.yml"}))
-
-	t.Cleanup(func() {
-		c.Stop(context.Background())
-	})
 	c.Start(context.Background())
 
 	misc.Init()


### PR DESCRIPTION
# Description

Since [cleanup](https://github.com/rudderlabs/compose-test/blob/a2cf79de282196159ab0b4ce8ba11cd29f3fbe14/testcompose/compose.go#L36) is already being called from within [Start](https://github.com/rudderlabs/compose-test/blob/a2cf79de282196159ab0b4ce8ba11cd29f3fbe14/testcompose/compose.go#L29) of compose library, no need to call it twice.

## Notion Ticket

https://www.notion.so/rudderstacks/Cleanup-for-warehouse-integration-tests-1820ba3fdc1646309b88d83ec384b5a8?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
