### PR TITLE
fix: jobsforwarder panics with slice bounds out of range

### DIFF
--- a/schema-forwarder/internal/batcher/batcher.go
+++ b/schema-forwarder/internal/batcher/batcher.go
@@ -8,6 +8,7 @@ import (
 
 // A batch of jobs that share the same schema.
 type EventSchemaMessageBatch struct {
+	Index   int
 	Message *proto.EventSchemaMessage
 	Jobs    []*jobsdb.JobT
 }
@@ -59,6 +60,7 @@ func (sb *EventSchemaMessageBatcher) GetMessageBatches() []*EventSchemaMessageBa
 	batches := make([]*EventSchemaMessageBatch, len(sb.batchOrder))
 	for i, key := range sb.batchOrder {
 		batches[i] = sb.batchIndex[key]
+		batches[i].Index = i
 	}
 	return batches
 }


### PR DESCRIPTION
# Description

Slice index changes as we are removing elements from it, thus reverting to the previous behaviour. Regression of #3406

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
