### PR TITLE
chore: fix flaky dedup test

### DIFF
--- a/services/dedup/dedup_test.go
+++ b/services/dedup/dedup_test.go
@@ -61,6 +61,7 @@ func Test_Dedup(t *testing.T) {
 func Test_Dedup_Window(t *testing.T) {
 	config.Reset()
 	logger.Reset()
+	misc.Init()
 
 	dbPath := os.TempDir() + "/dedup_test"
 	defer func() { _ = os.RemoveAll(dbPath) }()
@@ -87,6 +88,7 @@ func Test_Dedup_Window(t *testing.T) {
 func Test_Dedup_ClearDB(t *testing.T) {
 	config.Reset()
 	logger.Reset()
+	misc.Init()
 
 	dbPath := os.TempDir() + "/dedup_test"
 	defer func() { _ = os.RemoveAll(dbPath) }()


### PR DESCRIPTION
# Description

Fixing the flaky dedup test where the logger would be a nil pointer in misc package if misc hasn't been initialised

## Notion Ticket

[ Notion Link ](https://www.notion.so/rudderstacks/upgrade-to-badgerV4-86d09c352df94fd5b6c6c109eafc1271?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
