### PR TITLE
chore: jobsdb max age for jobs, cleanup routine

### DIFF
--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -148,7 +148,6 @@ func (jd *HandleT) startCleanupLoop(ctx context.Context) {
 }
 
 func (jd *HandleT) oldJobsCleanupRoutine(ctx context.Context) {
-	jd.doCleanupOldJobs(ctx)
 	for {
 		select {
 		case <-ctx.Done():
@@ -193,9 +192,11 @@ func (jd *HandleT) doCleanupOldJobs(ctx context.Context) {
 			}
 			if len(unprocessed.Jobs) > 0 {
 				unprocessedAfterJobID = &(unprocessed.Jobs[len(unprocessed.Jobs)-1].JobID)
-				unprocessedJobsToCleanup := lo.Filter(unprocessed.Jobs, func(job *JobT, _ int) bool {
-					return job.CreatedAt.Before(time.Now().Add(-jd.JobMaxAge))
-				})
+				unprocessedJobsToCleanup := lo.Filter(
+					unprocessed.Jobs,
+					func(job *JobT, _ int) bool {
+						return job.CreatedAt.Before(time.Now().Add(-jd.JobMaxAge))
+					})
 				jobsToCleanup = append(jobsToCleanup, unprocessedJobsToCleanup...)
 				if len(unprocessedJobsToCleanup) < batchSize {
 					queryUnprocessed = false

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -175,7 +175,7 @@ func (jd *HandleT) doCleanupOldJobs(ctx context.Context) {
 	)
 
 	for {
-		var jobsToCleanup = make([]*JobT, 0)
+		jobsToCleanup := make([]*JobT, 0)
 		if queryUnprocessed {
 			unprocessed, err := jd.GetUnprocessed(ctx, GetQueryParamsT{
 				IgnoreCustomValFiltersInQuery: true,

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -187,7 +187,7 @@ func (jd *HandleT) doCleanupDSInTx(ctx context.Context, tx *Tx, ds dataSetT) err
 			where jobs.created_at < $1 and (
 				status.job_state = ANY('{%[3]s}')
 				or
-				status.job_state is null
+				status.job_id is null
 			)
 		),
 		inserted_status as (

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rudderlabs/rudder-server/services/rmetrics"
 	"github.com/rudderlabs/rudder-server/utils/misc"
+	"github.com/samber/lo"
 )
 
 /*
@@ -163,7 +164,12 @@ func (jd *HandleT) doCleanupOldJobs(ctx context.Context) {
 	tags := statTags{CustomValFilters: []string{jd.tablePrefix}}
 	command := func() interface{} {
 		return jd.WithUpdateSafeTx(ctx, func(tx UpdateSafeTx) error {
-			dsList := jd.getDSList()
+			dsList := lo.FilterMap(jd.getDSRangeList(), func(dsRange dataSetRangeT, _ int) (dataSetT, bool) {
+				return dsRange.ds,
+					time.Now().Add(-jd.JobMaxAge).After(
+						time.Unix(dsRange.startTime*int64(time.Millisecond), 0),
+					)
+			})
 			for _, ds := range dsList {
 				if err := jd.doCleanupDSInTx(ctx, tx.Tx(), ds); err != nil {
 					return err

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -1201,6 +1201,95 @@ func TestFailExecuting(t *testing.T) {
 	require.Equal(t, 2, len(failed.Jobs))
 }
 
+func TestMaxAgeCleanup(t *testing.T) {
+	_ = startPostgres(t)
+	customVal := "CUSTOMVAL"
+	workspaceID := "workspaceID"
+	generateJobs := func(numOfJob int, destinationID string) []*JobT {
+		js := make([]*JobT, numOfJob)
+		for i := 0; i < numOfJob; i++ {
+			js[i] = &JobT{
+				Parameters: []byte(fmt.Sprintf(
+					`{"batch_id":1,"source_id":"sourceID","destination_id":%q}`,
+					destinationID,
+				)),
+				EventPayload: []byte(`{"testKey":"testValue"}`),
+				UserID:       "a-292e-4e79-9880-f8009e0ae4a3",
+				UUID:         uuid.New(),
+				CustomVal:    customVal,
+				EventCount:   1,
+				WorkspaceId:  workspaceID,
+			}
+		}
+		return js
+	}
+
+	destinationID := strings.ToLower(rsRand.String(5))
+	t.Setenv("JobsDB.jobMaxAge", "1ns")
+	triggerJobCleanup := make(chan time.Time)
+	jobsDB := &HandleT{
+		TriggerJobCleanUp: func() <-chan time.Time {
+			return triggerJobCleanup
+		},
+	}
+	err := jobsDB.Setup(
+		ReadWrite,
+		true,
+		strings.ToLower(rsRand.String(5)),
+		[]prebackup.Handler{},
+		fileuploader.NewDefaultProvider(),
+	)
+	require.NoError(t, err)
+	defer jobsDB.TearDown()
+
+	require.NoError(
+		t,
+		jobsDB.Store(
+			context.Background(),
+			generateJobs(2, destinationID),
+		),
+	)
+
+	unprocessed, err := jobsDB.getUnprocessed(
+		context.Background(),
+		GetQueryParamsT{
+			CustomValFilters: []string{customVal},
+			ParameterFilters: []ParameterFilterT{
+				{Name: "destination_id", Value: destinationID},
+			},
+			JobsLimit: 100,
+		})
+	require.NoError(t, err)
+	require.Equal(t, 2, len(unprocessed.Jobs))
+
+	triggerJobCleanup <- time.Now()
+	triggerJobCleanup <- time.Now()
+
+	unprocessed, err = jobsDB.getUnprocessed(
+		context.Background(),
+		GetQueryParamsT{
+			CustomValFilters: []string{customVal},
+			ParameterFilters: []ParameterFilterT{
+				{Name: "destination_id", Value: destinationID},
+			},
+			JobsLimit: 100,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(unprocessed.Jobs))
+
+	abortedJobs, err := jobsDB.GetProcessed(
+		context.Background(),
+		GetQueryParamsT{
+			CustomValFilters: []string{customVal},
+			StateFilters:     []string{Aborted.State},
+			JobsLimit:        100,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(abortedJobs.Jobs))
+}
+
 func TestConstructParameterJSONQuery(t *testing.T) {
 	q := constructParameterJSONQuery("alias", []ParameterFilterT{{Name: "name", Value: "value"}})
 	require.Equal(t, `(alias.parameters->>'name'='value')`, q)


### PR DESCRIPTION
# Description

introduces `MaxAge` for jobs.(default 720h)
A new routine(that runs once a day by default) cleans up jobs that have exceeded said duration by inserting an `aborted` status for said jobs.

## Notion Ticket

[cleanup jobs whose workspace do not belong to server](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?pvs=4)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
