### PR TITLE
fix(batchrouter): batchrouter stops processing events for destinations where a destType-specific config option is set

### DIFF
--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -142,7 +142,7 @@ func (brt *Handle) Setup(
 	var limiterGroup sync.WaitGroup
 	limiterStatsPeriod := config.GetDuration("BatchRouter.Limiter.statsPeriod", 15, time.Second)
 	brt.limiter.read = miscsync.NewLimiter(ctx, &limiterGroup, "brt_read",
-		getBatchRouterConfigInt(brt.destType, "Limiter.read.limit", 20),
+		getBatchRouterConfigInt("Limiter.read.limit", brt.destType, 20),
 		stats.Default,
 		miscsync.WithLimiterDynamicPeriod(config.GetDuration("BatchRouter.Limiter.read.dynamicPeriod", 1, time.Second)),
 		miscsync.WithLimiterTags(map[string]string{"destType": brt.destType}),
@@ -151,7 +151,7 @@ func (brt *Handle) Setup(
 		}),
 	)
 	brt.limiter.process = miscsync.NewLimiter(ctx, &limiterGroup, "brt_process",
-		getBatchRouterConfigInt(brt.destType, "Limiter.process.limit", 20),
+		getBatchRouterConfigInt("Limiter.process.limit", brt.destType, 20),
 		stats.Default,
 		miscsync.WithLimiterDynamicPeriod(config.GetDuration("BatchRouter.Limiter.process.dynamicPeriod", 1, time.Second)),
 		miscsync.WithLimiterTags(map[string]string{"destType": brt.destType}),
@@ -160,7 +160,7 @@ func (brt *Handle) Setup(
 		}),
 	)
 	brt.limiter.upload = miscsync.NewLimiter(ctx, &limiterGroup, "brt_upload",
-		getBatchRouterConfigInt(brt.destType, "Limiter.upload.limit", 50),
+		getBatchRouterConfigInt("Limiter.upload.limit", brt.destType, 50),
 		stats.Default,
 		miscsync.WithLimiterDynamicPeriod(config.GetDuration("BatchRouter.Limiter.upload.dynamicPeriod", 1, time.Second)),
 		miscsync.WithLimiterTags(map[string]string{"destType": brt.destType}),

--- a/utils/sync/limiter.go
+++ b/utils/sync/limiter.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"container/heap"
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -68,6 +69,9 @@ var WithLimiterTags = func(tags stats.Tags) func(*limiter) {
 
 // NewLimiter creates a new limiter
 func NewLimiter(ctx context.Context, wg *sync.WaitGroup, name string, limit int, statsf stats.Stats, opts ...func(*limiter)) Limiter {
+	if limit <= 0 {
+		panic(fmt.Errorf("limit for %q needs to be greater than 0", name))
+	}
 	l := &limiter{
 		name:     name,
 		limit:    limit,


### PR DESCRIPTION
# Description

Wrong order of arguments passed to the function calculating the config option key caused limiter's limit to be calculated as zero, leading batchrouter to not being able to enter the limiter.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
