### PR TITLE
chore(processor): support multiple jobsdb writers when source isolation is enabled

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/ro"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	kit_sync "github.com/rudderlabs/rudder-go-kit/sync"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	eventschema "github.com/rudderlabs/rudder-server/event-schema"
 	"github.com/rudderlabs/rudder-server/jobsdb"
@@ -139,6 +140,7 @@ type Handle struct {
 	}
 
 	adaptiveLimit func(int64) int64
+	storePlocker  kit_sync.PartitionLocker
 }
 type processorStats struct {
 	statGatewayDBR                stats.Measurement
@@ -348,6 +350,7 @@ func (proc *Handle) Setup(
 	if proc.adaptiveLimit == nil {
 		proc.adaptiveLimit = func(limit int64) int64 { return limit }
 	}
+	proc.storePlocker = *kit_sync.NewPartitionLocker()
 
 	// Stats
 	proc.statsFactory = stats.Default
@@ -1733,6 +1736,7 @@ func (proc *Handle) transformations(partition string, in *transformationMessage)
 	procErrorJobsByDestID := make(map[string][]*jobsdb.JobT)
 	var batchDestJobs []*jobsdb.JobT
 	var destJobs []*jobsdb.JobT
+	routerDestIDs := make(map[string]struct{})
 
 	destProcStart := time.Now()
 
@@ -1763,7 +1767,7 @@ func (proc *Handle) transformations(partition string, in *transformationMessage)
 	for o := range chOut {
 		destJobs = append(destJobs, o.destJobs...)
 		batchDestJobs = append(batchDestJobs, o.batchDestJobs...)
-
+		routerDestIDs = lo.Assign(routerDestIDs, o.routerDestIDs)
 		in.reportMetrics = append(in.reportMetrics, o.reportMetrics...)
 		for k, v := range o.errorsPerDestID {
 			procErrorJobsByDestID[k] = append(procErrorJobsByDestID[k], v...)
@@ -1776,6 +1780,7 @@ func (proc *Handle) transformations(partition string, in *transformationMessage)
 	// this tells us how many transformations we are doing per second.
 	transformationsThroughput := throughputPerSecond(in.totalEvents, destProcTime)
 	proc.stats.transformationsThroughput.Count(transformationsThroughput)
+
 	return &storeMessage{
 		in.statusList,
 		destJobs,
@@ -1783,6 +1788,7 @@ func (proc *Handle) transformations(partition string, in *transformationMessage)
 
 		procErrorJobsByDestID,
 		in.procErrorJobs,
+		lo.Keys(routerDestIDs),
 
 		in.reportMetrics,
 		in.sourceDupStats,
@@ -1801,6 +1807,7 @@ type storeMessage struct {
 
 	procErrorJobsByDestID map[string][]*jobsdb.JobT
 	procErrorJobs         []*jobsdb.JobT
+	routerDestIDs         []string
 
 	reportMetrics    []*types.PUReportedMetric
 	sourceDupStats   map[dupStatKey]int
@@ -1852,6 +1859,7 @@ func (proc *Handle) Store(partition string, in *storeMessage) {
 	if proc.limiter.store != nil {
 		defer proc.limiter.store.BeginWithPriority(partition, proc.getLimiterPriority(partition))()
 	}
+
 	statusList, destJobs, batchDestJobs := in.statusList, in.destJobs, in.batchDestJobs
 	beforeStoreStatus := time.Now()
 	// XX: Need to do this in a transaction
@@ -1894,41 +1902,50 @@ func (proc *Handle) Store(partition string, in *storeMessage) {
 	}
 
 	if len(destJobs) > 0 {
-		err := misc.RetryWithNotify(
-			context.Background(),
-			proc.jobsDBCommandTimeout,
-			proc.jobdDBMaxRetries,
-			func(ctx context.Context) error {
-				return proc.routerDB.WithStoreSafeTx(
-					ctx,
-					func(tx jobsdb.StoreSafeTx) error {
-						err := proc.routerDB.StoreInTx(ctx, tx, destJobs)
-						if err != nil {
-							return fmt.Errorf("storing router jobs: %w", err)
-						}
+		func() {
+			// Only one goroutine can store to a router destination at a time, otherwise we may have different transactions
+			// committing at different timestamps which can cause events with lower jobIDs to appear after events with higher ones.
+			// For that purpose, before storing, we lock the relevant destination IDs (in sorted order to avoid deadlocks).
+			if len(in.routerDestIDs) > 0 {
+				destIDs := lo.Uniq(in.routerDestIDs)
+				slices.Sort(destIDs)
+				for _, destID := range destIDs {
+					proc.storePlocker.Lock(destID)
+					defer proc.storePlocker.Unlock(destID)
+				}
+			}
+			err := misc.RetryWithNotify(
+				context.Background(),
+				proc.jobsDBCommandTimeout,
+				proc.jobdDBMaxRetries,
+				func(ctx context.Context) error {
+					return proc.routerDB.WithStoreSafeTx(
+						ctx,
+						func(tx jobsdb.StoreSafeTx) error {
+							err := proc.routerDB.StoreInTx(ctx, tx, destJobs)
+							if err != nil {
+								return fmt.Errorf("storing router jobs: %w", err)
+							}
 
-						// rsources stats
-						err = proc.updateRudderSourcesStats(ctx, tx, destJobs)
-						if err != nil {
-							return fmt.Errorf("publishing rsources stats for router: %w", err)
-						}
-						return nil
-					})
-			}, proc.sendRetryStoreStats)
-		if err != nil {
-			panic(err)
-		}
-		proc.logger.Debug("[Processor] Total jobs written to router : ", len(destJobs))
-
-		proc.multitenantI.ReportProcLoopAddStats(
-			getJobCountsByWorkspaceDestType(destJobs),
-			"rt",
-		)
-		proc.stats.statDestNumOutputEvents.Count(len(destJobs))
-		proc.stats.statDBWriteRouterEvents.Observe(float64(len(destJobs)))
-		proc.stats.statDBWriteRouterPayloadBytes.Observe(
-			float64(lo.SumBy(destJobs, func(j *jobsdb.JobT) int { return len(j.EventPayload) })),
-		)
+							// rsources stats
+							err = proc.updateRudderSourcesStats(ctx, tx, destJobs)
+							if err != nil {
+								return fmt.Errorf("publishing rsources stats for router: %w", err)
+							}
+							return nil
+						})
+				}, proc.sendRetryStoreStats)
+			if err != nil {
+				panic(err)
+			}
+			proc.logger.Debug("[Processor] Total jobs written to router : ", len(destJobs))
+			proc.multitenantI.ReportProcLoopAddStats(getJobCountsByWorkspaceDestType(destJobs), "rt")
+			proc.stats.statDestNumOutputEvents.Count(len(destJobs))
+			proc.stats.statDBWriteRouterEvents.Observe(float64(len(destJobs)))
+			proc.stats.statDBWriteRouterPayloadBytes.Observe(
+				float64(lo.SumBy(destJobs, func(j *jobsdb.JobT) int { return len(j.EventPayload) })),
+			)
+		}()
 	}
 
 	for _, jobs := range in.procErrorJobsByDestID {
@@ -2019,6 +2036,7 @@ type transformSrcDestOutput struct {
 	destJobs        []*jobsdb.JobT
 	batchDestJobs   []*jobsdb.JobT
 	errorsPerDestID map[string][]*jobsdb.JobT
+	routerDestIDs   map[string]struct{}
 }
 
 func (proc *Handle) transformSrcDest(
@@ -2051,6 +2069,7 @@ func (proc *Handle) transformSrcDest(
 	reportMetrics := make([]*types.PUReportedMetric, 0)
 	batchDestJobs := make([]*jobsdb.JobT, 0)
 	destJobs := make([]*jobsdb.JobT, 0)
+	routerDestIDs := make(map[string]struct{})
 	procErrorJobsByDestID := make(map[string][]*jobsdb.JobT)
 
 	proc.config.configSubscriberLock.RLock()
@@ -2164,6 +2183,7 @@ func (proc *Handle) transformSrcDest(
 			batchDestJobs:   batchDestJobs,
 			errorsPerDestID: procErrorJobsByDestID,
 			reportMetrics:   reportMetrics,
+			routerDestIDs:   routerDestIDs,
 		}
 	}
 
@@ -2228,6 +2248,7 @@ func (proc *Handle) transformSrcDest(
 			batchDestJobs:   batchDestJobs,
 			errorsPerDestID: procErrorJobsByDestID,
 			reportMetrics:   reportMetrics,
+			routerDestIDs:   routerDestIDs,
 		}
 	}
 
@@ -2374,6 +2395,7 @@ func (proc *Handle) transformSrcDest(
 				batchDestJobs = append(batchDestJobs, &newJob)
 			} else {
 				destJobs = append(destJobs, &newJob)
+				routerDestIDs[destID] = struct{}{}
 			}
 		}
 	})
@@ -2382,6 +2404,7 @@ func (proc *Handle) transformSrcDest(
 		batchDestJobs:   batchDestJobs,
 		errorsPerDestID: procErrorJobsByDestID,
 		reportMetrics:   reportMetrics,
+		routerDestIDs:   routerDestIDs,
 	}
 }
 


### PR DESCRIPTION
# Description

Since multiple goroutines might be trying to store jobs in router's jobsdb for the same destinationID and to avoid job ordering guarantee panics (router encountering a job with id less than a job it has previously encountered), we are introducing a partition locker to serialise write access.
Now, before writing a batch of jobs in router, the goroutine in processor will acquire all required partition locks (using an ascending lock order for avoiding deadlocks) and release them after store is completed.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=326809a9d1dd409d9786fb70ac9389ce&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
