### PR TITLE
chore: set limits for event schema messages and discard messages above these limits

### DIFF
--- a/schema-forwarder/internal/transformer/transformer.go
+++ b/schema-forwarder/internal/transformer/transformer.go
@@ -30,8 +30,8 @@ func New(backendConfig backendconfig.BackendConfig, config *config.Config) Trans
 	return &transformer{
 		backendConfig:        backendConfig,
 		captureNilAsUnknowns: config.GetBool("EventSchemas.captureUnknowns", false),
-		keysLimit:            config.GetInt("EventSchemas.keysLimit", 1000),
-		identifierLimit:      config.GetInt("EventSchemas.identifierLimit", 500),
+		keysLimit:            config.GetInt("EventSchemas.keysLimit", 500),
+		identifierLimit:      config.GetInt("EventSchemas.identifierLimit", 100),
 	}
 }
 

--- a/schema-forwarder/internal/transformer/transformer_test.go
+++ b/schema-forwarder/internal/transformer/transformer_test.go
@@ -3,6 +3,7 @@ package transformer
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/backend-config"
@@ -23,7 +25,9 @@ import (
 func Test_SchemaTransformer_NoDataRetention(t *testing.T) {
 	mockBackendConfig := mocksBackendConfig.NewMockBackendConfig(gomock.NewController(t))
 	schemaTransformer := transformer{
-		backendConfig: mockBackendConfig,
+		backendConfig:   mockBackendConfig,
+		identifierLimit: 10000,
+		keysLimit:       10000,
 	}
 	mockBackendConfig.EXPECT().Subscribe(gomock.Any(), backendconfig.TopicProcessConfig).
 		DoAndReturn(func(ctx context.Context, topic backendconfig.Topic) pubsub.DataChannel {
@@ -91,6 +95,31 @@ func Test_SchemaTransformer_NoDataRetention(t *testing.T) {
 		require.Equal(t, eventSchemaMessage.WorkspaceID, testSchemaMessage.WorkspaceID)
 		require.Equal(t, eventSchemaMessage.Key, testSchemaMessage.Key)
 		require.Equal(t, eventSchemaMessage.ObservedAt.AsTime(), testSchemaMessage.ObservedAt.AsTime())
+	})
+
+	t.Run("Test Transform limits", func(t *testing.T) {
+		event1 := generateTestJob(t, time.Now())
+		event1.EventPayload = []byte(fmt.Sprintf(`{"type": "track", "event": %q}`, rand.String(schemaTransformer.identifierLimit+1)))
+
+		e, err := schemaTransformer.Transform(event1)
+		require.Nil(t, e)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "event identifier size is greater than")
+
+		event2 := generateTestJob(t, time.Now())
+		payload := map[string]string{
+			"type": "identify",
+		}
+		for i := 0; i < schemaTransformer.keysLimit; i++ {
+			payload[fmt.Sprintf("key-%d", i)] = "value"
+		}
+		event2.EventPayload, err = json.Marshal(payload)
+		require.NoError(t, err)
+
+		e, err = schemaTransformer.Transform(event2)
+		require.Nil(t, e)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "event schema has more than")
 	})
 }
 

--- a/schema-forwarder/internal/transformer/types.go
+++ b/schema-forwarder/internal/transformer/types.go
@@ -19,5 +19,7 @@ type transformer struct {
 	sourceWriteKeyMap       map[string]string // map of sourceID to writeKey
 	newPIIReportingSettings map[string]bool   // map of writeKey to PII protection enabled setting
 
+	keysLimit            int
+	identifierLimit      int
 	captureNilAsUnknowns bool // if true, nil values will be captured as unknowns
 }


### PR DESCRIPTION
# Description

Setting maximum limits in event properties while capturing schemas:
- Events with identifiers larger than **100 characters** will be discarded (0.3% of existing schemas)
- Events with schemas containing more than **500 keys** will be discarded (1% of existing versions)

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=a34916c6bd7b4ffcacfe7ec3a9d11985&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
