### PR TITLE
feat: facade implementation for reporting

### DIFF
--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -215,7 +215,6 @@ func TestDynamicClusterManager(t *testing.T) {
 		rsources.NewNoOpService(),
 		destinationdebugger.NewNoOpService(),
 		transformationdebugger.NewNoOpService(),
-		&reporting.NOOP{},
 		processor.WithFeaturesRetryMaxAttempts(0))
 	processor.BackendConfig = mockBackendConfig
 	processor.Transformer = mockTransformer
@@ -225,7 +224,6 @@ func TestDynamicClusterManager(t *testing.T) {
 	tDb := &jobsdb.MultiTenantHandleT{HandleT: rtDB}
 	rtFactory := &router.Factory{
 		Reporting:        &reporting.NOOP{},
-		ErrorReporting:   &reporting.NOOP{},
 		Multitenant:      mockMTI,
 		BackendConfig:    mockBackendConfig,
 		RouterDB:         tDb,

--- a/app/features.go
+++ b/app/features.go
@@ -30,8 +30,8 @@ Reporting Feature
 
 // ReportingFeature handles reporting statuses / errors to reporting service
 type ReportingFeature interface {
-	Setup(backendConfig backendconfig.BackendConfig) types.ReportingInstances
-	GetReportingInstance(reporter types.ReporterType) types.ReportingI
+	Setup(backendConfig backendconfig.BackendConfig) types.MasterReportingI
+	GetReportingInstance() types.MasterReportingI
 }
 
 /*********************************

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -627,7 +627,7 @@ func (edRep *ErrorDetailReporter) sendMetric(ctx context.Context, clientName str
 		}
 
 		if !isMetricPosted(resp.StatusCode) {
-			err = fmt.Errorf(`received response: statusCode: %d error: %w`, resp.StatusCode, string(respBody))
+			err = fmt.Errorf(`received response: statusCode: %d error: %v`, resp.StatusCode, string(respBody))
 			edRep.log.Error(err.Error())
 		}
 		return err

--- a/enterprise/reporting/mediator.go
+++ b/enterprise/reporting/mediator.go
@@ -21,7 +21,7 @@ type ReportingMediator struct {
 	errorReporting  types.ReporterI
 }
 
-func (med *ReportingMediator) formReportInstance(backendConfig backendconfig.BackendConfig) types.ReporterI {
+func (med *ReportingMediator) createReportInstance(backendConfig backendconfig.BackendConfig) types.ReporterI {
 	med.log.Debug("Forming reporting instance")
 	reportingEnabled := config.GetBool("Reporting.enabled", types.DefaultReportingEnabled)
 	if !reportingEnabled || med.enterpriseToken == "" {
@@ -34,7 +34,7 @@ func (med *ReportingMediator) formReportInstance(backendConfig backendconfig.Bac
 	return reportingHandle
 }
 
-func (med *ReportingMediator) formErrorReportInstance(backendConfig backendconfig.BackendConfig) types.ReporterI {
+func (med *ReportingMediator) createErrorReportInstance(backendConfig backendconfig.BackendConfig) types.ReporterI {
 	med.log.Debug("Forming error reporting instance")
 	reportingEnabled := config.GetBool("Reporting.enabled", types.DefaultReportingEnabled)
 	errorReportingEnabled := config.GetBool("Reporting.errorReporting.enabled", false)
@@ -58,8 +58,8 @@ func NewReportingMediator(log logger.Logger, enterpriseToken string) *ReportingM
 
 func (med *ReportingMediator) Setup(backendConfig backendconfig.BackendConfig) *ReportingMediator {
 	med.once.Do(func() {
-		med.reporting = med.formReportInstance(backendConfig)
-		med.errorReporting = med.formErrorReportInstance(backendConfig)
+		med.reporting = med.createReportInstance(backendConfig)
+		med.errorReporting = med.createErrorReportInstance(backendConfig)
 	})
 	return med
 }

--- a/enterprise/reporting/mediator.go
+++ b/enterprise/reporting/mediator.go
@@ -1,0 +1,107 @@
+package reporting
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/rruntime"
+	"github.com/rudderlabs/rudder-server/utils/types"
+)
+
+type ReportingMediator struct {
+	log             logger.Logger
+	once            sync.Once
+	enterpriseToken string
+	reporting       types.ReporterI
+	errorReporting  types.ReporterI
+}
+
+func (med *ReportingMediator) formReportInstance(backendConfig backendconfig.BackendConfig) types.ReporterI {
+	med.log.Debug("Forming reporting instance")
+	reportingEnabled := config.GetBool("Reporting.enabled", types.DefaultReportingEnabled)
+	if !reportingEnabled || med.enterpriseToken == "" {
+		return &NOOP{}
+	}
+	reportingHandle := NewFromEnvConfig(med.log)
+	rruntime.Go(func() {
+		reportingHandle.setup(backendConfig)
+	})
+	return reportingHandle
+}
+
+func (med *ReportingMediator) formErrorReportInstance(backendConfig backendconfig.BackendConfig) types.ReporterI {
+	med.log.Debug("Forming error reporting instance")
+	reportingEnabled := config.GetBool("Reporting.enabled", types.DefaultReportingEnabled)
+	errorReportingEnabled := config.GetBool("Reporting.errorReporting.enabled", false)
+
+	if !(reportingEnabled && errorReportingEnabled) || med.enterpriseToken == "" {
+		return &NOOP{}
+	}
+	errorReporter := NewEdReporterFromEnvConfig()
+	rruntime.Go(func() {
+		errorReporter.setup(backendConfig)
+	})
+	return errorReporter
+}
+
+func NewReportingMediator(log logger.Logger, enterpriseToken string) *ReportingMediator {
+	return &ReportingMediator{
+		log:             log,
+		enterpriseToken: enterpriseToken,
+	}
+}
+
+func (med *ReportingMediator) Setup(backendConfig backendconfig.BackendConfig) *ReportingMediator {
+	med.once.Do(func() {
+		med.reporting = med.formReportInstance(backendConfig)
+		med.errorReporting = med.formErrorReportInstance(backendConfig)
+	})
+	return med
+}
+
+func (med *ReportingMediator) WaitForSetup(ctx context.Context, clientName string) error {
+	var err error
+	err = med.reporting.WaitForSetup(ctx, clientName)
+	if err != nil {
+		// TODO: Should we panic here ?
+		med.log.Errorf("Error while waiting to setup reporting instance: %w", err)
+	}
+	err = med.errorReporting.WaitForSetup(ctx, clientName)
+	return err
+}
+
+func (med *ReportingMediator) Report(metrics []*types.PUReportedMetric, txn *sql.Tx) {
+	med.reporting.Report(metrics, txn)
+	med.errorReporting.Report(metrics, txn)
+}
+
+func (med *ReportingMediator) AddClient(ctx context.Context, c types.Config) {
+	rruntime.Go(func() {
+		med.reporting.AddClient(ctx, c)
+	})
+	rruntime.Go(func() {
+		med.errorReporting.AddClient(ctx, c)
+	})
+}
+
+func (med *ReportingMediator) GetReportingInstance(reporterType types.ReporterType) types.ReporterI {
+	// Inner fn
+	returnReportingI := func(repI types.ReporterI) types.ReporterI {
+		if repI == nil {
+			panic(fmt.Errorf("reporting instance not initialised. You should call Setup before GetReportingInstance"))
+		}
+		return repI
+	}
+	switch reporterType {
+	case types.ErrorDetailReport:
+		return returnReportingI(med.errorReporting)
+	case types.Report:
+		return returnReportingI(med.reporting)
+	}
+	panic(fmt.Errorf("valid reporter type is not provided"))
+}

--- a/enterprise/reporting/reporting_test.go
+++ b/enterprise/reporting/reporting_test.go
@@ -258,7 +258,8 @@ func TestReportingBasedOnConfigBackend(t *testing.T) {
 		EnterpriseToken: "dummy-token",
 	}
 	f.Setup(config)
-	reporting := f.GetReportingInstance(types.Report)
+	mstReporting := f.GetReportingInstance()
+	reporting := mstReporting.GetReportingInstance(types.Report)
 
 	var reportingDisabled bool
 

--- a/enterprise/reporting/setup.go
+++ b/enterprise/reporting/setup.go
@@ -4,77 +4,37 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
-	"github.com/rudderlabs/rudder-server/rruntime"
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
 type Factory struct {
-	EnterpriseToken        string
-	Log                    logger.Logger
-	once                   sync.Once
-	reportingInstance      types.ReportingI
-	errorReportingInstance types.ReportingI
-}
-
-func (m *Factory) formReportInstance(backendConfig backendconfig.BackendConfig) types.ReportingI {
-	m.Log.Debug("Forming reporting instance")
-	reportingEnabled := config.GetBool("Reporting.enabled", types.DefaultReportingEnabled)
-	if !reportingEnabled || m.EnterpriseToken == "" {
-		return &NOOP{}
-	}
-	reportingHandle := NewFromEnvConfig(m.Log)
-	rruntime.Go(func() {
-		reportingHandle.setup(backendConfig)
-	})
-	return reportingHandle
-}
-
-func (m *Factory) formErrorReportInstance(backendConfig backendconfig.BackendConfig) types.ReportingI {
-	m.Log.Debug("Forming error reporting instance")
-	reportingEnabled := config.GetBool("Reporting.enabled", types.DefaultReportingEnabled)
-	errorReportingEnabled := config.GetBool("Reporting.errorReporting.enabled", false)
-
-	if !(reportingEnabled && errorReportingEnabled) || m.EnterpriseToken == "" {
-		return &NOOP{}
-	}
-	errorReporter := NewEdReporterFromEnvConfig()
-	rruntime.Go(func() {
-		errorReporter.setup(backendConfig)
-	})
-	return errorReporter
+	EnterpriseToken string
+	Log             logger.Logger
+	once            sync.Once
+	// reportingInstance      types.ReportingI
+	// errorReportingInstance types.ReportingI
+	reportingInstance types.MasterReportingI
 }
 
 // Setup initializes Suppress User feature
-func (m *Factory) Setup(backendConfig backendconfig.BackendConfig) types.ReportingInstances {
+func (m *Factory) Setup(backendConfig backendconfig.BackendConfig) types.MasterReportingI {
 	if m.Log == nil {
 		m.Log = logger.NewLogger().Child("enterprise").Child("reporting")
 	}
+	mediator := NewReportingMediator(m.Log, m.EnterpriseToken)
 	m.once.Do(func() {
-		m.reportingInstance = m.formReportInstance(backendConfig)
-		m.errorReportingInstance = m.formErrorReportInstance(backendConfig)
+		mediator.Setup(backendConfig)
+		m.reportingInstance = mediator
 	})
-	return types.ReportingInstances{
-		ReportingInstance:      m.reportingInstance,
-		ErrorReportingInstance: m.errorReportingInstance,
-	}
+	return m.reportingInstance
 }
 
-func (m *Factory) GetReportingInstance(reporterType types.ReporterType) types.ReportingI {
-	// Inner fn
-	returnReportingI := func(repI types.ReportingI) types.ReportingI {
-		if repI == nil {
-			panic(fmt.Errorf("reporting instance not initialised. You should call Setup before GetReportingInstance"))
-		}
-		return repI
+func (m *Factory) GetReportingInstance() types.MasterReportingI {
+	if m.reportingInstance == nil {
+		panic(fmt.Errorf("reporting instance not initialised. You should call Setup before GetReportingInstance"))
 	}
-	switch reporterType {
-	case types.ErrorDetailReport:
-		return returnReportingI(m.errorReportingInstance)
-	case types.Report:
-		return returnReportingI(m.reportingInstance)
-	}
-	panic(fmt.Errorf("valid reporter type is not provided"))
+
+	return m.reportingInstance
 }

--- a/enterprise/reporting/setup_test.go
+++ b/enterprise/reporting/setup_test.go
@@ -21,20 +21,23 @@ func TestFeatureSetup(t *testing.T) {
 		EnterpriseToken: "dummy-token",
 	}
 	instanceA := f.Setup(&backendconfig.NOOP{})
-	instanceB := f.GetReportingInstance(types.Report)
+	mstInstA := f.GetReportingInstance()
+	instanceB := mstInstA.GetReportingInstance(types.Report)
 
-	instanceC := f.Setup(&backendconfig.NOOP{})
-	instanceD := f.GetReportingInstance(types.Report)
+	mstInstanceC := f.Setup(&backendconfig.NOOP{})
+	instanceC := mstInstanceC.GetReportingInstance(types.Report)
+	instanceD := f.Setup(&backendconfig.NOOP{}).GetReportingInstance(types.Report)
 
-	require.Equal(t, instanceA.ReportingInstance, instanceB)
-	require.Equal(t, instanceB, instanceC.ReportingInstance)
-	require.Equal(t, instanceC.ReportingInstance, instanceD)
+	require.Equal(t, instanceA.GetReportingInstance(types.Report), instanceB)
+	require.Equal(t, instanceB, instanceC)
+	require.Equal(t, instanceC, instanceD)
 
 	f = &Factory{}
-	instanceE := f.Setup(&backendconfig.NOOP{})
-	instanceF := f.GetReportingInstance(types.Report)
-	require.Equal(t, instanceE.ReportingInstance, instanceF)
-	require.NotEqual(t, instanceE.ReportingInstance, backendconfig.NOOP{})
+	mstE := f.Setup(&backendconfig.NOOP{})
+	instanceE := f.Setup(&backendconfig.NOOP{}).GetReportingInstance(types.Report)
+	instanceF := mstE.GetReportingInstance(types.Report)
+	require.Equal(t, instanceE, instanceF)
+	require.NotEqual(t, instanceE, backendconfig.NOOP{})
 }
 
 func TestSetupForNoop(t *testing.T) {
@@ -78,8 +81,8 @@ func TestSetupForNoop(t *testing.T) {
 				}
 			}
 			f.Setup(&backendconfig.NOOP{})
-			instance := f.GetReportingInstance(types.ErrorDetailReport)
-			require.Equal(t, instance, &NOOP{})
+			instance := f.GetReportingInstance()
+			require.Equal(t, instance.GetReportingInstance(types.ErrorDetailReport), &NOOP{})
 		})
 
 	}

--- a/mocks/utils/types/mock_types.go
+++ b/mocks/utils/types/mock_types.go
@@ -85,20 +85,6 @@ func (mr *MockReportingIMockRecorder) AddClient(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddClient", reflect.TypeOf((*MockReportingI)(nil).AddClient), arg0, arg1)
 }
 
-// IsPIIReportingDisabled mocks base method.
-func (m *MockReportingI) IsPIIReportingDisabled(arg0 string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPIIReportingDisabled", arg0)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsPIIReportingDisabled indicates an expected call of IsPIIReportingDisabled.
-func (mr *MockReportingIMockRecorder) IsPIIReportingDisabled(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPIIReportingDisabled", reflect.TypeOf((*MockReportingI)(nil).IsPIIReportingDisabled), arg0)
-}
-
 // Report mocks base method.
 func (m *MockReportingI) Report(arg0 []*types.PUReportedMetric, arg1 *sql.Tx) {
 	m.ctrl.T.Helper()

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -31,7 +31,6 @@ type LifecycleManager struct {
 	clearDB          *bool
 	MultitenantStats multitenant.MultiTenantI // need not initialize again
 	ReportingI       types.ReportingI         // need not initialize again
-	ErrorReportingI  types.ReportingI         // need not initialize again
 	BackendConfig    backendconfig.BackendConfig
 	Transformer      transformer.Transformer
 	transientSources transientsource.Service
@@ -51,7 +50,7 @@ func (proc *LifecycleManager) Start() error {
 
 	proc.Handle.Setup(
 		proc.BackendConfig, proc.gatewayDB, proc.routerDB, proc.batchRouterDB, proc.errDB, proc.esDB,
-		proc.ReportingI, proc.ErrorReportingI, proc.MultitenantStats, proc.transientSources, proc.fileuploader, proc.rsourcesService, proc.destDebugger, proc.transDebugger,
+		proc.ReportingI, proc.MultitenantStats, proc.transientSources, proc.fileuploader, proc.rsourcesService, proc.destDebugger, proc.transDebugger,
 	)
 
 	currentCtx, cancel := context.WithCancel(context.Background())
@@ -87,7 +86,6 @@ func WithFeaturesRetryMaxAttempts(maxAttempts int) func(l *LifecycleManager) {
 func New(ctx context.Context, clearDb *bool, gwDb, rtDb, brtDb, errDb, esDB *jobsdb.HandleT,
 	tenantDB multitenant.MultiTenantI, reporting types.ReportingI, transientSources transientsource.Service, fileuploader fileuploader.Provider,
 	rsourcesService rsources.JobService, destDebugger destinationdebugger.DestinationDebugger, transDebugger transformationdebugger.TransformationDebugger,
-	errorReporting types.ReportingI,
 	opts ...Opts,
 ) *LifecycleManager {
 	proc := &LifecycleManager{
@@ -102,7 +100,6 @@ func New(ctx context.Context, clearDb *bool, gwDb, rtDb, brtDb, errDb, esDB *job
 		MultitenantStats: tenantDB,
 		BackendConfig:    backendconfig.DefaultBackendConfig,
 		ReportingI:       reporting,
-		ErrorReportingI:  errorReporting,
 		transientSources: transientSources,
 		fileuploader:     fileuploader,
 		rsourcesService:  rsourcesService,

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -218,7 +218,6 @@ func TestProcessorManager(t *testing.T) {
 		mockRsourcesService,
 		destinationdebugger.NewNoOpService(),
 		transformationdebugger.NewNoOpService(),
-		&reporting.NOOP{},
 		func(m *LifecycleManager) {
 			m.Handle.config.enablePipelining = false
 			m.Handle.config.featuresRetryMaxAttempts = 0

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -81,7 +81,6 @@ type Handle struct {
 	eventSchemaHandler        types.EventSchemasI
 	dedup                     dedup.Dedup
 	reporting                 types.ReportingI
-	errorReporting            types.ReportingI
 	reportingEnabled          bool
 	multitenantI              multitenant.MultiTenantI
 	backgroundWait            func() error

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -323,12 +323,10 @@ func (proc *Handle) newEventFilterStat(sourceID, workspaceID string, destination
 func (proc *Handle) Setup(
 	backendConfig backendconfig.BackendConfig, gatewayDB, routerDB,
 	batchRouterDB, errorDB, eventSchemaDB jobsdb.JobsDB, reporting types.ReportingI,
-	errorReporting types.ReportingI,
 	multiTenantStat multitenant.MultiTenantI, transientSources transientsource.Service,
 	fileuploader fileuploader.Provider, rsourcesService rsources.JobService, destDebugger destinationdebugger.DestinationDebugger, transDebugger transformationdebugger.TransformationDebugger,
 ) {
 	proc.reporting = reporting
-	proc.errorReporting = errorReporting
 
 	proc.destDebugger = destDebugger
 	proc.transDebugger = transDebugger
@@ -1972,8 +1970,6 @@ func (proc *Handle) Store(partition string, in *storeMessage) {
 			if proc.isReportingEnabled() {
 				proc.reporting.Report(in.reportMetrics, tx.SqlTx())
 			}
-
-			proc.errorReporting.Report(in.reportMetrics, tx.SqlTx())
 
 			return nil
 		})

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rudderlabs/rudder-server/enterprise/reporting"
 	transformationdebugger "github.com/rudderlabs/rudder-server/services/debugger/transformation"
 
 	destinationdebugger "github.com/rudderlabs/rudder-server/services/debugger/destination"
@@ -58,7 +57,6 @@ type testContext struct {
 	mockProcErrorsDB      *mocksJobsDB.MockJobsDB
 	mockEventSchemasDB    *mocksJobsDB.MockJobsDB
 	MockReportingI        *mockReportingTypes.MockReportingI
-	MockErrorReportingI   *mockReportingTypes.MockReportingI
 	MockDedup             *mockDedup.MockDedup
 	MockMultitenantHandle *mocksMultitenant.MockMultiTenantI
 	MockRsourcesService   *rsources.MockJobService
@@ -636,7 +634,7 @@ var _ = Describe("Processor", Ordered, func() {
 			// crash recover returns empty list
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 
-			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, nil, nil, nil, c.MockMultitenantHandle, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), c.MockRsourcesService, destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService())
+			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, nil, nil, c.MockMultitenantHandle, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), c.MockRsourcesService, destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService())
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
@@ -650,7 +648,7 @@ var _ = Describe("Processor", Ordered, func() {
 
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 
-			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, nil, nil, nil, c.MockMultitenantHandle, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), c.MockRsourcesService, destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService())
+			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, nil, nil, c.MockMultitenantHandle, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), c.MockRsourcesService, destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService())
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
@@ -669,7 +667,7 @@ var _ = Describe("Processor", Ordered, func() {
 
 			processor := prepareHandle(NewHandle(mockTransformer))
 
-			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, nil, c.MockReportingI, &reporting.NOOP{}, c.MockMultitenantHandle, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), c.MockRsourcesService, destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService())
+			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, nil, c.MockReportingI, c.MockMultitenantHandle, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), c.MockRsourcesService, destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService())
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
@@ -1558,7 +1556,7 @@ var _ = Describe("Processor", Ordered, func() {
 			// crash recover returns empty list
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 			processor.config.featuresRetryMaxAttempts = 0
-			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, nil, nil, nil, c.MockMultitenantHandle, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), c.MockRsourcesService, destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService())
+			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, nil, nil, c.MockMultitenantHandle, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), c.MockRsourcesService, destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService())
 
 			setMainLoopTimeout(processor, 1*time.Second)
 
@@ -1600,7 +1598,7 @@ var _ = Describe("Processor", Ordered, func() {
 			// crash recover returns empty list
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 			processor.config.featuresRetryMaxAttempts = 0
-			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, nil, c.MockReportingI, &reporting.NOOP{}, c.MockMultitenantHandle, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), c.MockRsourcesService, destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService())
+			processor.Setup(c.mockBackendConfig, c.mockGatewayJobsDB, c.mockRouterJobsDB, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, nil, c.MockReportingI, c.MockMultitenantHandle, transientsource.NewEmptyService(), fileuploader.NewDefaultProvider(), c.MockRsourcesService, destinationdebugger.NewNoOpService(), transformationdebugger.NewNoOpService())
 			defer processor.Shutdown()
 			c.MockReportingI.EXPECT().WaitForSetup(gomock.Any(), gomock.Any()).Times(1)
 
@@ -3047,7 +3045,6 @@ func Setup(processor *Handle, c *testContext, enableDedup, enableReporting bool)
 		c.mockProcErrorsDB,
 		c.mockEventSchemasDB,
 		c.MockReportingI,
-		&reporting.NOOP{},
 		c.MockMultitenantHandle,
 		transientsource.NewEmptyService(),
 		fileuploader.NewDefaultProvider(),

--- a/router/factory.go
+++ b/router/factory.go
@@ -13,7 +13,6 @@ import (
 
 type Factory struct {
 	Reporting        reporter
-	ErrorReporting   reporter
 	Multitenant      tenantStats
 	BackendConfig    backendconfig.BackendConfig
 	RouterDB         jobsdb.MultiTenantJobsDB
@@ -30,7 +29,6 @@ func (f *Factory) New(destination *backendconfig.DestinationT, identifier string
 	config.RegisterBoolConfigVariable(types.DefaultReportingEnabled, &reportingEnabled, false, "Reporting.enabled")
 	r := &HandleT{
 		Reporting:        f.Reporting,
-		ErrorReporting:   f.ErrorReporting,
 		MultitenantI:     f.Multitenant,
 		throttlerFactory: f.ThrottlerFactory,
 		adaptiveLimit:    f.AdaptiveLimit,

--- a/router/manager/manager_test.go
+++ b/router/manager/manager_test.go
@@ -215,7 +215,6 @@ func TestRouterManager(t *testing.T) {
 	tDb := &jobsdb.MultiTenantHandleT{HandleT: rtDB}
 	rtFactory := &router.Factory{
 		Reporting:        &reporting.NOOP{},
-		ErrorReporting:   &reporting.NOOP{},
 		Multitenant:      mockMTI,
 		BackendConfig:    mockBackendConfig,
 		RouterDB:         tDb,

--- a/router/router.go
+++ b/router/router.go
@@ -124,7 +124,6 @@ type HandleT struct {
 	destinationResponseHandler              ResponseHandlerI
 	saveDestinationResponse                 bool
 	Reporting                               reporter
-	ErrorReporting                          reporter
 	savePayloadOnError                      bool
 	oauth                                   oauth.Authorizer
 	transformerProxy                        bool
@@ -566,8 +565,6 @@ func (rt *HandleT) commitStatusList(responseList *[]jobResponseT) {
 					return err
 				}
 				rt.Reporting.Report(reportMetrics, tx.SqlTx())
-				// Error reporting
-				rt.ErrorReporting.Report(reportMetrics, tx.SqlTx())
 				return nil
 			})
 		}, sendRetryStoreStats)
@@ -918,12 +915,6 @@ func (rt *HandleT) Setup(
 
 	// waiting for reporting client setup
 	err := rt.Reporting.WaitForSetup(context.TODO(), utilTypes.CoreReportingClient)
-	if err != nil {
-		return
-	}
-
-	// waiting for error-reporting client setup
-	err = rt.ErrorReporting.WaitForSetup(context.TODO(), utilTypes.CoreReportingClient)
 	if err != nil {
 		return
 	}

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -274,9 +274,8 @@ var _ = Describe("Router", func() {
 		It("should initialize and recover after crash", func() {
 			mockMultitenantHandle := mocksMultitenant.NewMockMultiTenantI(c.mockCtrl)
 			router := &HandleT{
-				Reporting:      &reporting.NOOP{},
-				ErrorReporting: &reporting.NOOP{},
-				MultitenantI:   mockMultitenantHandle,
+				Reporting:    &reporting.NOOP{},
+				MultitenantI: mockMultitenantHandle,
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
@@ -293,10 +292,9 @@ var _ = Describe("Router", func() {
 			mockMultitenantHandle := mocksMultitenant.NewMockMultiTenantI(c.mockCtrl)
 			mockNetHandle := mocksRouter.NewMockNetHandleI(c.mockCtrl)
 			router := &HandleT{
-				Reporting:      &reporting.NOOP{},
-				ErrorReporting: &reporting.NOOP{},
-				MultitenantI:   mockMultitenantHandle,
-				netHandle:      mockNetHandle,
+				Reporting:    &reporting.NOOP{},
+				MultitenantI: mockMultitenantHandle,
+				netHandle:    mockNetHandle,
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
@@ -384,9 +382,8 @@ var _ = Describe("Router", func() {
 			mockMultitenantHandle := mocksMultitenant.NewMockMultiTenantI(c.mockCtrl)
 
 			router := &HandleT{
-				Reporting:      &reporting.NOOP{},
-				ErrorReporting: &reporting.NOOP{},
-				MultitenantI:   mockMultitenantHandle,
+				Reporting:    &reporting.NOOP{},
+				MultitenantI: mockMultitenantHandle,
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
@@ -471,9 +468,8 @@ var _ = Describe("Router", func() {
 			routerUtils.JobRetention = time.Duration(24) * time.Hour
 			mockMultitenantHandle := mocksMultitenant.NewMockMultiTenantI(c.mockCtrl)
 			router := &HandleT{
-				Reporting:      &reporting.NOOP{},
-				ErrorReporting: &reporting.NOOP{},
-				MultitenantI:   mockMultitenantHandle,
+				Reporting:    &reporting.NOOP{},
+				MultitenantI: mockMultitenantHandle,
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
@@ -561,9 +557,8 @@ var _ = Describe("Router", func() {
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
 
 			router := &HandleT{
-				Reporting:      &reporting.NOOP{},
-				ErrorReporting: &reporting.NOOP{},
-				MultitenantI:   mockMultitenantHandle,
+				Reporting:    &reporting.NOOP{},
+				MultitenantI: mockMultitenantHandle,
 			}
 			router.Setup(c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, gaDestinationConfig, transientsource.NewEmptyService(), rsources.NewNoOpService(), destinationdebugger.NewNoOpService())
 			router.netHandle = mockNetHandle
@@ -652,10 +647,9 @@ var _ = Describe("Router", func() {
 			mockNetHandle := mocksRouter.NewMockNetHandleI(c.mockCtrl)
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			router := &HandleT{
-				Reporting:      &reporting.NOOP{},
-				ErrorReporting: &reporting.NOOP{},
-				MultitenantI:   mockMultitenantHandle,
-				netHandle:      mockNetHandle,
+				Reporting:    &reporting.NOOP{},
+				MultitenantI: mockMultitenantHandle,
+				netHandle:    mockNetHandle,
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
@@ -779,10 +773,9 @@ var _ = Describe("Router", func() {
 			mockNetHandle := mocksRouter.NewMockNetHandleI(c.mockCtrl)
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			router := &HandleT{
-				Reporting:      &reporting.NOOP{},
-				ErrorReporting: &reporting.NOOP{},
-				MultitenantI:   mockMultitenantHandle,
-				netHandle:      mockNetHandle,
+				Reporting:    &reporting.NOOP{},
+				MultitenantI: mockMultitenantHandle,
+				netHandle:    mockNetHandle,
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
@@ -888,10 +881,9 @@ var _ = Describe("Router", func() {
 			mockNetHandle := mocksRouter.NewMockNetHandleI(c.mockCtrl)
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			router := &HandleT{
-				Reporting:      &reporting.NOOP{},
-				ErrorReporting: &reporting.NOOP{},
-				MultitenantI:   mockMultitenantHandle,
-				netHandle:      mockNetHandle,
+				Reporting:    &reporting.NOOP{},
+				MultitenantI: mockMultitenantHandle,
+				netHandle:    mockNetHandle,
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
@@ -1033,10 +1025,9 @@ var _ = Describe("Router", func() {
 			mockNetHandle := mocksRouter.NewMockNetHandleI(c.mockCtrl)
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			router := &HandleT{
-				Reporting:      &reporting.NOOP{},
-				ErrorReporting: &reporting.NOOP{},
-				MultitenantI:   mockMultitenantHandle,
-				netHandle:      mockNetHandle,
+				Reporting:    &reporting.NOOP{},
+				MultitenantI: mockMultitenantHandle,
+				netHandle:    mockNetHandle,
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
@@ -1206,10 +1197,9 @@ var _ = Describe("Router", func() {
 			mockNetHandle := mocksRouter.NewMockNetHandleI(c.mockCtrl)
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			router := &HandleT{
-				Reporting:      &reporting.NOOP{},
-				ErrorReporting: &reporting.NOOP{},
-				MultitenantI:   mockMultitenantHandle,
-				netHandle:      mockNetHandle,
+				Reporting:    &reporting.NOOP{},
+				MultitenantI: mockMultitenantHandle,
+				netHandle:    mockNetHandle,
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
@@ -1422,10 +1412,9 @@ var _ = Describe("Router", func() {
 			mockMultitenantHandle := mocksMultitenant.NewMockMultiTenantI(c.mockCtrl)
 			mockNetHandle := mocksRouter.NewMockNetHandleI(c.mockCtrl)
 			router := &HandleT{
-				Reporting:      &reporting.NOOP{},
-				ErrorReporting: &reporting.NOOP{},
-				MultitenantI:   mockMultitenantHandle,
-				netHandle:      mockNetHandle,
+				Reporting:    &reporting.NOOP{},
+				MultitenantI: mockMultitenantHandle,
+				netHandle:    mockNetHandle,
 			}
 			mockMultitenantHandle.EXPECT().UpdateWorkspaceLatencyMap(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()

--- a/utils/types/reporting_types.go
+++ b/utils/types/reporting_types.go
@@ -90,7 +90,7 @@ type EDConnectionDetails struct {
 	DestinationID           string `json:"destinationId"`
 	SourceDefinitionId      string `json:"sourceDefinitionId"`
 	DestinationDefinitionId string `json:"destinationDefinitionId"`
-	DestType                string `json:"destType"`
+	DestType                string `json:"destinationDefinitionName"`
 }
 
 type EDInstanceDetails struct {

--- a/utils/types/types.go
+++ b/utils/types/types.go
@@ -59,8 +59,18 @@ type ConfigEnvI interface {
 // ReportingI is interface to report metrics
 type ReportingI interface {
 	WaitForSetup(ctx context.Context, clientName string) error
-	AddClient(ctx context.Context, c Config)
 	Report(metrics []*PUReportedMetric, txn *sql.Tx)
+	AddClient(ctx context.Context, c Config)
+}
+
+// FacadeInterface for reporting
+type MasterReportingI interface {
+	ReportingI
+	GetReportingInstance(reporterType ReporterType) ReporterI
+}
+
+type ReporterI interface {
+	ReportingI
 	IsPIIReportingDisabled(string) bool
 }
 

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -1438,7 +1438,7 @@ func (job *UploadJob) setUploadStatus(statusOpts UploadStatusOpts) (err error) {
 		}
 
 		if config.GetBool("Reporting.enabled", types.DefaultReportingEnabled) {
-			application.Features().Reporting.GetReportingInstance(types.Report).Report([]*types.PUReportedMetric{&statusOpts.ReportingMetric}, txn)
+			application.Features().Reporting.GetReportingInstance().Report([]*types.PUReportedMetric{&statusOpts.ReportingMetric}, txn)
 		}
 		err = txn.Commit()
 		return err
@@ -1735,7 +1735,7 @@ func (job *UploadJob) setUploadError(statusError error, state string) (string, e
 		})
 	}
 	if config.GetBool("Reporting.enabled", types.DefaultReportingEnabled) {
-		application.Features().Reporting.GetReportingInstance(types.Report).Report(reportingMetrics, txn)
+		application.Features().Reporting.GetReportingInstance().Report(reportingMetrics, txn)
 	}
 	err = txn.Commit()
 

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -1692,7 +1692,7 @@ func Start(ctx context.Context, app app.App) error {
 		reporting := application.Features().Reporting.Setup(backendconfig.DefaultBackendConfig)
 
 		g.Go(misc.WithBugsnagForWarehouse(func() error {
-			reporting.ReportingInstance.AddClient(ctx, types.Config{ConnInfo: psqlInfo, ClientName: types.WarehouseReportingClient})
+			reporting.AddClient(ctx, types.Config{ConnInfo: psqlInfo, ClientName: types.WarehouseReportingClient})
 			return nil
 		}))
 	}


### PR DESCRIPTION
# Description

We are implementing a facade or mediator for reporting to make it easier for us to integrate

This is how things look at high-level
![Screenshot 2023-06-01 at 9 06 40 AM](https://github.com/rudderlabs/rudder-server/assets/18283111/42319780-319a-4bed-8f43-47794cf0f0cd)

We have created a new component that is responsible for:
 - calling multiple error reporting implementations
 - only call them if they are enabled

Advantages:
- This will simplify the code in the processor, router, and warehouse
- They will just call a single interface, and no need to check if reporting is enabled or not

**Credits**: @lvrach for the image, the following content

## Notion Ticket
https://www.notion.so/rudderstacks/Design-for-errorCode-and-errorMessage-in-reports-table-3d5db2e4d485459f9b4f98b601c7a5e5?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
