### PR TITLE
feat: new backup routine - processor

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -137,9 +137,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 	gwDBForProcessor := jobsdb.NewForRead(
 		"gw",
 		jobsdb.WithClearDB(options.ClearDB),
-		jobsdb.WithPreBackupHandlers(prebackupHandlers),
 		jobsdb.WithDSLimit(&a.config.gatewayDSLimit),
-		jobsdb.WithFileUploaderProvider(fileUploaderProvider),
 		jobsdb.WithSkipMaintenanceErr(config.GetBool("Gateway.jobsDB.skipMaintenanceError", true)),
 	)
 	defer gwDBForProcessor.Close()
@@ -226,6 +224,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 		destinationHandle,
 		transformationhandle,
 		processor.WithAdaptiveLimit(adaptiveLimit),
+		processor.WithBackup(!a.config.enableReplay), // don't want backup if replay server
 	)
 	throttlerFactory, err := rtThrottler.New(stats.Default)
 	if err != nil {

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -234,6 +234,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 		destinationHandle,
 		transformationhandle,
 		proc.WithAdaptiveLimit(adaptiveLimit),
+		proc.WithBackup(true),
 	)
 	throttlerFactory, err := throttler.New(stats.Default)
 	if err != nil {

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -17,9 +17,7 @@ import (
 	"github.com/samber/lo"
 )
 
-var (
-	successfulBackupResponse = []byte(`{"status": "backup successful"}`)
-)
+var successfulBackupResponse = []byte(`{"status": "backup successful"}`)
 
 type jobQueue interface {
 	GetProcessed(
@@ -201,7 +199,7 @@ func writeJobsToFile(
 	if err != nil {
 		panic(err)
 	}
-	defer gzWriter.CloseGZ()
+	defer func() { _ = gzWriter.CloseGZ() }()
 
 	// gzWriter.Write([]byte(jobs[0].Headings()))
 	for _, item := range jobs {

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -2,9 +2,19 @@ package backup
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
 
+	"github.com/cenkalti/backoff"
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/services/filemanager"
 	"github.com/rudderlabs/rudder-server/services/fileuploader"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+	"github.com/samber/lo"
 )
 
 type jobQueue interface {
@@ -21,17 +31,127 @@ type jobQueue interface {
 	) error
 }
 
+type BackupContext struct {
+	QueryParams          jobsdb.GetQueryParamsT
+	Queue                jobQueue
+	FileUploaderProvider fileuploader.Provider
+}
+
 func Backup(
 	ctx context.Context,
-	queryParams jobsdb.GetQueryParamsT,
-	jobsDB jobQueue,
-	fileUploaderProvider fileuploader.Provider,
+	backupContext BackupContext,
+	log logger.Logger,
 ) {
 	// retry and backoff applied to all the steps below
 
 	// 1. Get the jobs from the jobsdb
-
+	jobs, err := backupContext.Queue.GetProcessed(ctx, backupContext.QueryParams)
+	if err != nil {
+		log.Infof("backup Error: Error getting jobs from jobsdb: %w", err)
+		panic(err)
+	}
+	workspaceJobsMap := lo.GroupBy(jobs.Jobs, func(job *jobsdb.JobT) string {
+		return job.WorkspaceId
+	})
 	// 2. Upload the jobs to the file uploader
+	for workspaceID, wJobs := range workspaceJobsMap {
+		// write to file
+		backupPathDirName := "/rudder-s3-dumps/"
+		tmpDirPath, err := misc.CreateTMPDIR()
+		if err != nil {
+			panic(err)
+		}
+		// pathPrefix := strings.TrimPrefix("gw_jobs", preDropTablePrefix)
+		pathPrefix := "gw_jobs" //TODO: remove
+		path := fmt.Sprintf(
+			"%v%v.%v.%v.%v.%v.%v.gz",
+			tmpDirPath+backupPathDirName,
+			pathPrefix,
+			wJobs[0].JobID,
+			wJobs[len(wJobs)-1].JobID,
+			wJobs[0].CreatedAt.UnixNano()/int64(time.Millisecond),
+			wJobs[len(wJobs)-1].CreatedAt.UnixNano()/int64(time.Millisecond),
+			workspaceID,
+		)
 
-	// 3. Update the job status in the jobsdb
+		err = WriteJobsToFile(wJobs, path)
+		if err != nil {
+			panic(err)
+		}
+
+		// upload file
+		pathPrefixes := make([]string, 0) // TOOO
+		var output filemanager.UploadOutput
+		fileUploader, err := backupContext.FileUploaderProvider.GetFileManager(workspaceID)
+		if err != nil {
+			panic(err)
+		}
+		bo := backoff.NewExponentialBackOff()
+		bo.MaxInterval = time.Minute
+		bo.MaxElapsedTime = config.GetDuration("backup.maxRetryTime", 5, time.Minute)
+		boRetries := backoff.WithMaxRetries(bo, uint64(config.GetInt64("backup.maxRetries", 3)))
+		boCtx := backoff.WithContext(boRetries, ctx)
+		file, err := os.Open(path)
+		if err != nil {
+			panic(err)
+		}
+		defer func() { _ = file.Close() }()
+		backup := func() error {
+			output, err = fileUploader.Upload(ctx, file, pathPrefixes...)
+			return err
+		}
+		if err = backoff.Retry(backup, boCtx); err != nil {
+			panic(err)
+		}
+		log.Infof("[JobsDB] :: Backed up table at %s for workspaceId %s", output.Location, workspaceID)
+		// 3. Update the job status in the jobsdb
+		err = backupContext.Queue.UpdateJobStatus(
+			ctx,
+			lo.Map(
+				wJobs,
+				func(job *jobsdb.JobT, _ int) *jobsdb.JobStatusT {
+					js := &jobsdb.JobStatusT{
+						JobID:         job.JobID,
+						ExecTime:      time.Now(),
+						RetryTime:     time.Now(),
+						ErrorCode:     "",
+						ErrorResponse: []byte(`{}`), // check
+						Parameters:    []byte(`{}`), // check
+						JobParameters: job.Parameters,
+					}
+					if job.LastJobStatus.ErrorCode == "200" {
+						js.JobState = jobsdb.Succeeded.State
+					}
+					js.JobState = jobsdb.Aborted.State
+					return js
+				},
+			),
+			nil,
+			nil,
+		)
+	}
+}
+
+// Writes a list of jobs to a .gz file at given path
+func WriteJobsToFile(jobs []*jobsdb.JobT, path string) error {
+	gzipFilePath := fmt.Sprintf(`%v.gz`, path)
+	err := os.MkdirAll(filepath.Dir(gzipFilePath), os.ModePerm)
+	if err != nil {
+		panic(err)
+	}
+	gzWriter, err := misc.CreateGZ(gzipFilePath)
+	if err != nil {
+		panic(err)
+	}
+	defer gzWriter.CloseGZ()
+
+	// gzWriter.Write([]byte(jobs[0].Headings()))
+	for _, item := range jobs {
+		err = gzWriter.WriteGZ(item.ToCSV())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -1,0 +1,37 @@
+package backup
+
+import (
+	"context"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/services/fileuploader"
+)
+
+type jobQueue interface {
+	GetProcessed(
+		ctx context.Context,
+		params jobsdb.GetQueryParamsT,
+	) (jobsdb.JobsResult, error)
+
+	UpdateJobStatus(
+		ctx context.Context,
+		statusList []*jobsdb.JobStatusT,
+		customValFilters []string,
+		parameterFilters []jobsdb.ParameterFilterT,
+	) error
+}
+
+func Backup(
+	ctx context.Context,
+	queryParams jobsdb.GetQueryParamsT,
+	jobsDB jobQueue,
+	fileUploaderProvider fileuploader.Provider,
+) {
+	// retry and backoff applied to all the steps below
+
+	// 1. Get the jobs from the jobsdb
+
+	// 2. Upload the jobs to the file uploader
+
+	// 3. Update the job status in the jobsdb
+}

--- a/backup/types.go
+++ b/backup/types.go
@@ -1,0 +1,33 @@
+package backup
+
+import (
+	"context"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/services/fileuploader"
+)
+
+var successfulBackupResponse = []byte(`{"status": "backup successful"}`)
+
+type jobQueue interface {
+	GetProcessed(
+		ctx context.Context,
+		params jobsdb.GetQueryParamsT,
+	) (jobsdb.JobsResult, error)
+
+	UpdateJobStatus(
+		ctx context.Context,
+		statusList []*jobsdb.JobStatusT,
+		customValFilters []string,
+		parameterFilters []jobsdb.ParameterFilterT,
+	) error
+
+	Identifier() string
+}
+
+type BackupContext struct {
+	QueryParams          jobsdb.GetQueryParamsT
+	Queue                jobQueue
+	FileUploaderProvider fileuploader.Provider
+	Marshaller           func(*jobsdb.JobT) ([]byte, error)
+}

--- a/enterprise/replay/dumpsloader.go
+++ b/enterprise/replay/dumpsloader.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-server/services/filemanager"
+	"github.com/samber/lo"
 
 	"github.com/google/uuid"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -85,15 +86,14 @@ func storeJobs(ctx context.Context, objects []OrderedJobs, dbHandle *jobsdb.Hand
 		return objects[i].SortIndex < objects[j].SortIndex
 	})
 
-	var jobs []*jobsdb.JobT
-	for _, object := range objects {
-		jobs = append(jobs, object.Job)
-	}
+	jobs := lo.Map(objects, func(object OrderedJobs, _ int) *jobsdb.JobT {
+		return object.Job
+	})
 
 	log.Info("Total dumps count : ", len(objects))
 	err := dbHandle.Store(ctx, jobs)
 	if err != nil {
-		panic(fmt.Errorf("Failed to write dumps locations to DB with error: %w", err))
+		panic(fmt.Errorf("failed to write dumps locations to DB with error: %w", err))
 	}
 }
 

--- a/jobsdb/backup.go
+++ b/jobsdb/backup.go
@@ -430,14 +430,14 @@ func getFailedOnlyBackupQueryFn(backupDSRange *dataSetRangeT) func(int64) string
 }
 
 func getJobsBackupQueryFn(backupDSRange *dataSetRangeT) func(int64) string {
-	var params GetQueryParamsT
-	var filters []string
-	if params.WorkspaceID != "" {
-		filters = append(filters, fmt.Sprintf("workspace_id = '%s'", params.WorkspaceID))
-	}
-	if params.AfterJobID != nil {
-		filters = append(filters, fmt.Sprintf("job_id > %d", *params.AfterJobID))
-	}
+	// var params GetQueryParamsT
+	// var filters []string
+	// if params.WorkspaceID != "" {
+	// 	filters = append(filters, fmt.Sprintf("workspace_id = '%s'", params.WorkspaceID))
+	// }
+	// if params.AfterJobID != nil {
+	// 	filters = append(filters, fmt.Sprintf("job_id > %d", *params.AfterJobID))
+	// }
 
 	return func(offSet int64) string {
 		return fmt.Sprintf(`

--- a/jobsdb/backup.go
+++ b/jobsdb/backup.go
@@ -430,6 +430,15 @@ func getFailedOnlyBackupQueryFn(backupDSRange *dataSetRangeT) func(int64) string
 }
 
 func getJobsBackupQueryFn(backupDSRange *dataSetRangeT) func(int64) string {
+	var params GetQueryParamsT
+	var filters []string
+	if params.WorkspaceID != "" {
+		filters = append(filters, fmt.Sprintf("workspace_id = '%s'", params.WorkspaceID))
+	}
+	if params.AfterJobID != nil {
+		filters = append(filters, fmt.Sprintf("job_id > %d", *params.AfterJobID))
+	}
+
 	return func(offSet int64) string {
 		return fmt.Sprintf(`
 			SELECT

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -619,6 +619,7 @@ var (
 	Succeeded = jobStateT{isValid: true, isTerminal: true, State: "succeeded"}
 	Aborted   = jobStateT{isValid: true, isTerminal: true, State: "aborted"}
 	Migrated  = jobStateT{isValid: true, isTerminal: true, State: "migrated"}
+	Completed = jobStateT{isValid: true, isTerminal: true, State: "completed"}
 
 	validTerminalStates    []string
 	validNonTerminalStates []string
@@ -635,6 +636,7 @@ var jobStates = []jobStateT{
 	Migrated,
 	Importing,
 	ToBackup,
+	Completed,
 }
 
 // OwnerType for this jobsdb instance

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -398,6 +398,34 @@ func (job *JobT) String() string {
 	)
 }
 
+func MarshalGWJob(job *JobT) ([]byte, error) {
+	jobMap := map[string]interface{}{
+		"job_id":        job.JobID,
+		"workspace_id":  job.WorkspaceId,
+		"uuid":          job.UUID.String(),
+		"user_id":       job.UserID,
+		"parameters":    job.Parameters,
+		"custom_val":    job.CustomVal,
+		"event_payload": job.EventPayload,
+		"event_count":   job.EventCount,
+		"created_at":    job.CreatedAt,
+		"expires_at":    job.ExpireAt,
+	}
+	jobBytes, err := json.Marshal(jobMap)
+	if err != nil {
+		return nil, err
+	}
+	return jobBytes, nil
+}
+
+func MarshalJob(job *JobT) ([]byte, error) {
+	jobBytes, err := json.Marshal(job)
+	if err != nil {
+		return nil, err
+	}
+	return jobBytes, nil
+}
+
 func (job *JobT) Headings() string {
 	return "job_id,workspace_id,uuid,user_id,parameters,custom_val,event_payload,event_count,created_at,expire_at"
 }

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -555,6 +555,7 @@ var (
 	Executing = jobStateT{isValid: true, isTerminal: false, State: "executing"}
 	Waiting   = jobStateT{isValid: true, isTerminal: false, State: "waiting"}
 	Importing = jobStateT{isValid: true, isTerminal: false, State: "importing"}
+	ToBackup  = jobStateT{isValid: true, isTerminal: false, State: "to_backup"}
 
 	// Valid, Terminal
 	Succeeded = jobStateT{isValid: true, isTerminal: true, State: "succeeded"}
@@ -959,7 +960,6 @@ func (jd *HandleT) readerSetup(ctx context.Context, l lock.LockToken) {
 		return nil
 	}))
 
-	jd.startBackupDSLoop(ctx)
 	jd.startMigrateDSLoop(ctx)
 
 	g.Go(misc.WithBugsnag(func() error {

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -385,7 +385,37 @@ type JobT struct {
 }
 
 func (job *JobT) String() string {
-	return fmt.Sprintf("JobID=%v, UserID=%v, CreatedAt=%v, ExpireAt=%v, CustomVal=%v, Parameters=%v, EventPayload=%v EventCount=%d", job.JobID, job.UserID, job.CreatedAt, job.ExpireAt, job.CustomVal, string(job.Parameters), string(job.EventPayload), job.EventCount)
+	return fmt.Sprintf(
+		"JobID=%v, UserID=%v, CreatedAt=%v, ExpireAt=%v, CustomVal=%v, Parameters=%v, EventPayload=%v EventCount=%d",
+		job.JobID,
+		job.UserID,
+		job.CreatedAt,
+		job.ExpireAt,
+		job.CustomVal,
+		string(job.Parameters),
+		string(job.EventPayload),
+		job.EventCount,
+	)
+}
+
+func (job *JobT) Headings() string {
+	return "job_id,workspace_id,uuid,user_id,parameters,custom_val,event_payload,event_count,created_at,expire_at"
+}
+
+func (job *JobT) ToCSV() string {
+	return fmt.Sprintf(
+		"%d,%s,%s,%s,%s,%s,%s,%d,%s,%s\n",
+		job.JobID,
+		job.WorkspaceId,
+		job.UUID.String(),
+		job.UserID,
+		job.Parameters,
+		job.CustomVal,
+		job.EventPayload,
+		job.EventCount,
+		job.CreatedAt,
+		job.ExpireAt,
+	)
 }
 
 func (job *JobT) sanitizeJson() {
@@ -576,6 +606,7 @@ var jobStates = []jobStateT{
 	Aborted,
 	Migrated,
 	Importing,
+	ToBackup,
 }
 
 // OwnerType for this jobsdb instance

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -119,3 +119,9 @@ func WithAdaptiveLimit(adaptiveLimitFunction func(int64) int64) Opts {
 		l.Handle.adaptiveLimit = adaptiveLimitFunction
 	}
 }
+
+func WithBackup(backupEnabled bool) Opts {
+	return func(l *LifecycleManager) {
+		l.Handle.jobBackupEnabled = backupEnabled
+	}
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -567,6 +567,7 @@ func (proc *Handle) Start(ctx context.Context) error {
 						},
 						Queue:                proc.gatewayDB,
 						FileUploaderProvider: proc.fileuploader,
+						Marshaller:           jobsdb.MarshalGWJob,
 					},
 					proc.logger,
 				)

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -168,7 +168,7 @@ func (st *HandleT) storeErrorsToObjectStorage(jobs []*jobsdb.JobT) (errorJob []E
 	for workspaceID, jobsForWorkspace := range jobsPerWorkspace {
 		preferences, err := st.fileuploader.GetStoragePreferences(workspaceID)
 		if err != nil {
-			st.logger.Errorf("Skipping Storing errors for workspace: %s since no storage preferences are found", workspaceID)
+			st.logger.Errorf("Skipping Storing errors for workspace: %s - error finding storage preferences: %w", workspaceID, err)
 			errorJobs = append(errorJobs, ErrorJob{
 				jobs: jobsForWorkspace,
 				errorOutput: StoreErrorOutputT{

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -168,7 +168,7 @@ func (st *HandleT) storeErrorsToObjectStorage(jobs []*jobsdb.JobT) (errorJob []E
 	for workspaceID, jobsForWorkspace := range jobsPerWorkspace {
 		preferences, err := st.fileuploader.GetStoragePreferences(workspaceID)
 		if err != nil {
-			st.logger.Errorf("Skipping Storing errors for workspace: %s - error finding storage preferences: %w", workspaceID, err)
+			st.logger.Errorf("Skipping Storing errors for workspace: %s since no storage preferences are found", workspaceID)
 			errorJobs = append(errorJobs, ErrorJob{
 				jobs: jobsForWorkspace,
 				errorOutput: StoreErrorOutputT{


### PR DESCRIPTION
# Description

Introduce `backup` package that different users of `jobsdb` can call to backup jobs of importance.
Long term idea is to separate backup from jobsdb. jobsdb would only be a mechanism to fetch jobs and then update status post successful backup.
For now, introducing said functionality for gateway dumps.

## Notion Ticket

[jobsdb support archive state](https://www.notion.so/rudderstacks/jobsdb-support-archive-state-a9c85931f711407a9cc0415f2c75ed83?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
