### PR TITLE
chore: upgrade golangci version and lint fixes

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,5 +60,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.52
           args: -v

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ install-tools:
 
 .PHONY: lint
 lint: fmt ## Run linters on all go files
-	docker run --rm -v $(shell pwd):/app:ro -w /app golangci/golangci-lint:v1.51.2 bash -e -c \
+	docker run --rm -v $(shell pwd):/app:ro -w /app golangci/golangci-lint:v1.52 bash -e -c \
 		'golangci-lint run -v --timeout 5m'
 
 .PHONY: fmt

--- a/build/wait-for-go/wait-for.go
+++ b/build/wait-for-go/wait-for.go
@@ -28,7 +28,6 @@ func canConnect(host, port, protocol string) bool {
 				fmt.Println("UDP error:", err)
 				if err != nil {
 					_ = conn.Close()
-					conn = nil
 					return false
 				}
 			}

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -12,11 +12,10 @@ Ping returns health check for pg database
 func (jd *HandleT) Ping() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	rows, err := jd.dbHandle.QueryContext(ctx, `SELECT 'Rudder DB Health Check'::text as message`)
+	_, err := jd.dbHandle.ExecContext(ctx, `SELECT 'Rudder DB Health Check'::text as message`)
 	if err != nil {
 		return err
 	}
-	_ = rows.Close()
 	return nil
 }
 

--- a/jobsdb/backup.go
+++ b/jobsdb/backup.go
@@ -544,6 +544,9 @@ func (jd *HandleT) createTableDumps(queryFunc func(int64) string, pathFunc func(
 			}
 			offset++
 		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("error while iterating rows: %w", err)
+		}
 		return nil
 	}
 

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -1090,6 +1090,9 @@ func TestCreateDS(t *testing.T) {
 				require.NoError(t, err)
 				tableNames = append(tableNames, tableName)
 			}
+			if err = tables.Err(); err != nil {
+				require.NoError(t, err)
+			}
 			require.Equal(t, len(tableNames), 2, `should find two tables`)
 			require.Equal(t, tableNames[0], prefix+"_jobs_-2")
 			require.Equal(t, tableNames[1], prefix+"_jobs_-1")
@@ -1401,6 +1404,7 @@ func getPayloadSize(t *testing.T, jobsDB JobsDB, job *JobT) (int64, error) {
 			require.NoError(t, err)
 			tables = append(tables, table)
 		}
+		require.NoError(t, rows.Err())
 		_ = rows.Close()
 
 		for _, table := range tables {

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1067,7 +1067,6 @@ func (jd *HandleT) refreshDSRangeList(l lock.LockToken) {
 		sqlStatement := fmt.Sprintf(`SELECT MIN(job_id), MAX(job_id) FROM %q`, ds.JobTable)
 		// Note: Using Query instead of QueryRow, because the sqlmock library doesn't have support for QueryRow
 		row := jd.dbHandle.QueryRow(sqlStatement)
-		jd.assertError(row.Err())
 
 		err := row.Scan(&minID, &maxID)
 		jd.assertError(err)

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1066,14 +1066,12 @@ func (jd *HandleT) refreshDSRangeList(l lock.LockToken) {
 		jd.assert(ds.Index != "", "ds.Index is empty")
 		sqlStatement := fmt.Sprintf(`SELECT MIN(job_id), MAX(job_id) FROM %q`, ds.JobTable)
 		// Note: Using Query instead of QueryRow, because the sqlmock library doesn't have support for QueryRow
-		rows, err := jd.dbHandle.Query(sqlStatement)
+		row := jd.dbHandle.QueryRow(sqlStatement)
+		jd.assertError(row.Err())
+
+		err := row.Scan(&minID, &maxID)
 		jd.assertError(err)
-		for rows.Next() {
-			err := rows.Scan(&minID, &maxID)
-			jd.assertError(err)
-			break
-		}
-		_ = rows.Close()
+
 		jd.logger.Debug(sqlStatement, minID, maxID)
 		// We store ranges EXCEPT for
 		// 1. the last element (which is being actively written to)
@@ -1261,7 +1259,7 @@ func (jd *HandleT) computeNewIdxForAppend(l lock.LockToken) string {
 }
 
 func (jd *HandleT) doComputeNewIdxForAppend(dList []dataSetT) string {
-	newDSIdx := ""
+	var newDSIdx string
 	if len(dList) == 0 {
 		newDSIdx = "1"
 	} else {
@@ -1845,6 +1843,9 @@ func (jd *HandleT) GetActiveWorkspaces(ctx context.Context, customVal string) ([
 		}
 		workspaceIds = append(workspaceIds, workspaceId)
 	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
 	return workspaceIds, nil
 }
 
@@ -1885,6 +1886,9 @@ func (jd *HandleT) GetDistinctParameterValues(ctx context.Context, parameterName
 			return nil, err
 		}
 		values = append(values, value)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
 	}
 	return values, nil
 }
@@ -2105,6 +2109,9 @@ func (jd *HandleT) getProcessedJobsDS(ctx context.Context, ds dataSetT, params G
 		payloadSize = runningPayloadSize
 		eventCount = runningEventCount
 	}
+	if err := rows.Err(); err != nil {
+		return JobsResult{}, false, err
+	}
 	if !limitsReached &&
 		(params.JobsLimit > 0 && len(jobList) == params.JobsLimit) || // we reached the jobs limit
 		(params.EventsLimit > 0 && eventCount >= params.EventsLimit) || // we reached the events limit
@@ -2213,9 +2220,6 @@ func (jd *HandleT) getUnprocessedJobsDS(ctx context.Context, ds dataSetT, params
 		return JobsResult{}, false, err
 	}
 	defer func() { _ = rows.Close() }()
-	if err != nil {
-		return JobsResult{}, false, err
-	}
 	var runningEventCount int
 	var runningPayloadSize int64
 
@@ -2247,6 +2251,9 @@ func (jd *HandleT) getUnprocessedJobsDS(ctx context.Context, ds dataSetT, params
 		payloadSize = runningPayloadSize
 		eventCount = runningEventCount
 
+	}
+	if err := rows.Err(); err != nil {
+		return JobsResult{}, false, err
 	}
 	if !limitsReached &&
 		(params.JobsLimit > 0 && len(jobList) == params.JobsLimit) || // we reached the jobs limit
@@ -2575,6 +2582,9 @@ func (jd *HandleT) GetJournalEntries(opType string) (entries []JournalEntryT) {
 		jd.assertError(err)
 		count++
 	}
+	if err = rows.Err(); err != nil {
+		jd.assertError(err)
+	}
 	return
 }
 
@@ -2620,6 +2630,9 @@ func (jd *HandleT) recoverFromCrash(owner OwnerType, goRoutineType string) {
 		jd.assertError(err)
 		jd.assert(!opDone, "opDone is true")
 		count++
+	}
+	if err = rows.Err(); err != nil {
+		jd.assertError(err)
 	}
 	jd.assert(count <= 1, fmt.Sprintf("count:%d > 1", count))
 

--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -103,6 +103,9 @@ func getAllTableNames(dbHandle sqlDbOrTx) ([]string, error) {
 		}
 		tableNames = append(tableNames, tbName)
 	}
+	if err = rows.Err(); err != nil {
+		return tableNames, err
+	}
 	return tableNames, nil
 }
 

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -186,6 +186,9 @@ func (jd *HandleT) getCleanUpCandidates(ctx context.Context, dsList []dataSetT) 
 		}
 		estimates[tableName] = estimate
 	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
 
 	datasets := lo.Filter(dsList,
 		func(ds dataSetT, idx int) bool {

--- a/router/eventorder_test.go
+++ b/router/eventorder_test.go
@@ -440,6 +440,9 @@ func (eventOrderMethods) countDrainedJobs(db *sql.DB) int {
 				tables = append(tables, table)
 			}
 		}
+		if err = rows.Err(); err != nil {
+			panic(err)
+		}
 	}
 	for _, table := range tables {
 		var dsCount int

--- a/services/multitenant/tenantstats.go
+++ b/services/multitenant/tenantstats.go
@@ -273,7 +273,7 @@ func (t *Stats) GetRouterPickupJobs(destType string, noOfWorkers int, routerTime
 			break
 		}
 
-		pickUpCount := 0
+		var pickUpCount int
 		if t.routerTenantLatencyStat[destType][workspaceKey].Value() == 0 {
 			pickUpCount = misc.MinInt(pendingEvents-workspacePickUpCount[workspaceKey], runningJobCount)
 		} else {

--- a/services/pgnotifier/pgnotifier.go
+++ b/services/pgnotifier/pgnotifier.go
@@ -717,6 +717,10 @@ func (notifier *PGNotifier) RunMaintenanceWorker(ctx context.Context) error {
 			}
 			ids = append(ids, id)
 		}
+		if err := rows.Err(); err != nil {
+			panic(err)
+		}
+
 		_ = rows.Close()
 		pkgLogger.Debugf("PgNotifier: Re-triggered job ids: %v", ids)
 

--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -46,11 +46,10 @@ func ReplaceDB(dbName, targetName string) {
 
 	// Killing sessions on the db
 	sqlStatement := fmt.Sprintf("SELECT pid, pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid();", dbName)
-	rows, err := db.Query(sqlStatement)
+	_, err = db.Exec(sqlStatement)
 	if err != nil {
 		panic(err)
 	}
-	rows.Close()
 
 	renameDBStatement := fmt.Sprintf(`ALTER DATABASE %q RENAME TO %q`,
 		dbName, targetName)

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -945,6 +945,9 @@ func MakeRetryablePostRequest(url, endpoint string, data interface{}) (response 
 	}
 
 	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, -1, err
+	}
 	defer func() { httputil.CloseResponse(resp) }()
 
 	pkgLogger.Debugf("Post request: Successful %s", string(body))

--- a/warehouse/api.go
+++ b/warehouse/api.go
@@ -464,6 +464,11 @@ func (tableUploadReq TableUploadReq) GetWhTableUploads(ctx context.Context) ([]*
 		}
 		tableUploads = append(tableUploads, &tableUpload)
 	}
+	if err = rows.Err(); err != nil {
+		tableUploadReq.API.log.Errorf(err.Error())
+		return []*proto.WHTable{}, err
+	}
+
 	return tableUploads, nil
 }
 
@@ -649,6 +654,10 @@ func (uploadsReq *UploadsReq) getUploadsFromDB(ctx context.Context, isMultiWorks
 		upload.Tables = make([]*proto.WHTable, 0)
 		uploads = append(uploads, &upload)
 	}
+	if err = rows.Err(); err != nil {
+		return nil, 0, err
+	}
+
 	return uploads, totalUploadCount, err
 }
 

--- a/warehouse/client/client.go
+++ b/warehouse/client/client.go
@@ -67,6 +67,10 @@ func (cl *Client) sqlQuery(statement string) (result warehouseutils.QueryResult,
 		}
 		result.Values = append(result.Values, stringRow)
 	}
+	if err = rows.Err(); err != nil {
+		return result, err
+	}
+
 	return result, err
 }
 

--- a/warehouse/integrations/azure-synapse/azure-synapse.go
+++ b/warehouse/integrations/azure-synapse/azure-synapse.go
@@ -697,6 +697,9 @@ func (as *AzureSynapse) dropDanglingStagingTables(ctx context.Context) bool {
 		}
 		stagingTableNames = append(stagingTableNames, tableName)
 	}
+	if err := rows.Err(); err != nil {
+		panic(fmt.Errorf("iterating result from query: %s\nwith Error : %w", sqlStatement, err))
+	}
 	as.Logger.Infof("WH: SYNAPSE: Dropping dangling staging tables: %+v  %+v\n", len(stagingTableNames), stagingTableNames)
 	delSuccess := true
 	for _, stagingTableName := range stagingTableNames {

--- a/warehouse/integrations/clickhouse/clickhouse_test.go
+++ b/warehouse/integrations/clickhouse/clickhouse_test.go
@@ -621,6 +621,7 @@ func TestClickhouse_LoadTableRoundTrip(t *testing.T) {
 						require.Fail(t, fmt.Sprintf("table %s column %s is of Nullable type even when disableNullable is set to true", tableName, columnName))
 					}
 				}
+				require.NoError(t, rows.Err())
 			}
 
 			t.Log("Loading data into table")

--- a/warehouse/integrations/deltalake-native/deltalake.go
+++ b/warehouse/integrations/deltalake-native/deltalake.go
@@ -905,6 +905,8 @@ func (d *Deltalake) partitionQuery(ctx context.Context, tableName string) (strin
 	}
 	defer func() { _ = rows.Close() }()
 
+	_ = rows.Err() // ignore error
+
 	partitionColumns, err := rows.Columns()
 	if err != nil {
 		return "", fmt.Errorf("scanning partition columns: %w", err)

--- a/warehouse/integrations/middleware/sqlquerywrapper/sql_test.go
+++ b/warehouse/integrations/middleware/sqlquerywrapper/sql_test.go
@@ -94,16 +94,16 @@ func TestQueryWrapper(t *testing.T) {
 			_, err = qw.ExecContext(ctx, query)
 			require.NoError(t, err)
 
-			_, err = qw.Query(query)
+			_, err = qw.Query(query) //nolint:rowserrcheck
 			require.NoError(t, err)
 
-			_, err = qw.QueryContext(ctx, query)
+			_, err = qw.QueryContext(ctx, query) //nolint:rowserrcheck
 			require.NoError(t, err)
 
-			_ = qw.QueryRow(query)
+			_ = qw.QueryRow(query) //nolint:rowserrcheck
 			require.NoError(t, err)
 
-			_ = qw.QueryRowContext(ctx, query)
+			_ = qw.QueryRowContext(ctx, query) //nolint:rowserrcheck
 			require.NoError(t, err)
 		})
 
@@ -280,10 +280,10 @@ func TestQueryWrapper(t *testing.T) {
 				tx, err := qw.Begin()
 				require.NoError(t, err)
 
-				_, err = tx.Query(query)
+				_, err = tx.Query(query) // nolint:rowserrcheck
 				require.NoError(t, err)
 
-				err = tx.Commit()
+				err = tx.Commit() // nolint:rowserrcheck
 				require.NoError(t, err)
 			})
 
@@ -291,7 +291,7 @@ func TestQueryWrapper(t *testing.T) {
 				tx, err := qw.Begin()
 				require.NoError(t, err)
 
-				_, err = tx.QueryContext(ctx, query)
+				_, err = tx.QueryContext(ctx, query) // nolint:rowserrcheck
 				require.NoError(t, err)
 
 				err = tx.Commit()

--- a/warehouse/integrations/mssql/mssql.go
+++ b/warehouse/integrations/mssql/mssql.go
@@ -737,6 +737,9 @@ func (ms *MSSQL) dropDanglingStagingTables(ctx context.Context) bool {
 		}
 		stagingTableNames = append(stagingTableNames, tableName)
 	}
+	if err := rows.Err(); err != nil {
+		panic(fmt.Errorf("iterating result from query: %s\nwith Error : %w", sqlStatement, err))
+	}
 	ms.Logger.Infof("WH: MSSQL: Dropping dangling staging tables: %+v  %+v\n", len(stagingTableNames), stagingTableNames)
 	delSuccess := true
 	for _, stagingTableName := range stagingTableNames {

--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -1104,9 +1104,12 @@ func (rs *Redshift) dropDanglingStagingTables(ctx context.Context) bool {
 		var tableName string
 		err := rows.Scan(&tableName)
 		if err != nil {
-			panic(fmt.Errorf("Failed to scan result from query: %s\nwith Error : %w", sqlStatement, err))
+			panic(fmt.Errorf("scan result from query: %s\nwith Error : %w", sqlStatement, err))
 		}
 		stagingTableNames = append(stagingTableNames, tableName)
+	}
+	if err := rows.Err(); err != nil {
+		panic(fmt.Errorf("iterate result from query: %s\nwith Error : %w", sqlStatement, err))
 	}
 	rs.Logger.Infof("WH: RS: Dropping dangling staging tables: %+v  %+v\n", len(stagingTableNames), stagingTableNames)
 	delSuccess := true

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -1151,6 +1151,9 @@ func (sf *Snowflake) DownloadIdentityRules(ctx context.Context, gzWriter *misc.G
 				csvWriter.Flush()
 				_ = gzWriter.WriteGZ(buff.String())
 			}
+			if err = rows.Err(); err != nil {
+				return
+			}
 
 			offset += batchSize
 			if offset >= totalRows {

--- a/warehouse/internal/repo/staging.go
+++ b/warehouse/internal/repo/staging.go
@@ -454,6 +454,9 @@ func (repo *StagingFiles) DestinationRevisionIDs(ctx context.Context, upload mod
 		}
 		revisionIDs = append(revisionIDs, revisionID)
 	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate destination revisionID: %w", err)
+	}
 
 	return revisionIDs, nil
 }

--- a/warehouse/internal/repo/upload.go
+++ b/warehouse/internal/repo/upload.go
@@ -343,6 +343,9 @@ func (uploads *Uploads) GetToProcess(ctx context.Context, destType string, limit
 		}
 		uploadJobs = append(uploadJobs, upload)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return uploadJobs, nil
 }

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -1834,6 +1834,9 @@ func (job *UploadJob) getLoadFilesTableMap() (loadFilesMap map[tableNameT]bool, 
 		}
 		loadFilesMap[tableNameT(tableName)] = true
 	}
+	if err = rows.Err(); err != nil {
+		err = fmt.Errorf("interate distinct table name query for jobId: %d, sourceId: %s, destinationId: %s, err: %w", job.upload.ID, job.warehouse.Source.ID, job.warehouse.Destination.ID, err)
+	}
 	return
 }
 
@@ -1920,6 +1923,9 @@ func (job *UploadJob) GetLoadFilesMetadata(ctx context.Context, options warehous
 			Location: location,
 			Metadata: metadata,
 		})
+	}
+	if err = rows.Err(); err != nil {
+		panic(fmt.Errorf("iterate query results: %s\nwith Error : %w", sqlStatement, err))
 	}
 	return
 }


### PR DESCRIPTION
# Description

I have upgraded golangci to `version: v1.52`, I have only specified up to minor versions so that patch upgrades will happen automatically.

With the upgrade, the following linters were reenabled again (disabled before due to generics)
* [rowserrcheck](https://github.com/golangci/golangci-lint/pull/3691)
* [wastedassign](https://github.com/golangci/golangci-lint/pull/3689)


## Linting fixes

rowserrcheck: After `rows.Next()` iteration we need to check for `rows.Err()`.
wastedassign: Assign and value and not use it. In most cases `x := 0` -> `var x int`

## Notion Ticket

https://www.notion.so/rudderstacks/Upgrade-golangci-version-lint-fixes-7abe589fec944d16b16ca378363ac8d1?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
