### PR TITLE
chore: add resp body status check

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -118,6 +118,13 @@ func Init() {
 	pkgLogger = logger.NewLogger().Child("processor").Child("transformer")
 }
 
+func isJobTerminated(status int) bool {
+	if status == http.StatusTooManyRequests {
+		return false
+	}
+	return status >= http.StatusOK && status < http.StatusInternalServerError
+}
+
 func loadConfig() {
 	config.RegisterIntConfigVariable(200, &maxConcurrency, false, 1, "Processor.maxConcurrency")
 	config.RegisterIntConfigVariable(100, &maxHTTPConnections, false, 1, "Processor.maxHTTPConnections")
@@ -390,6 +397,9 @@ func (trans *HandleT) doPost(ctx context.Context, rawJSON []byte, url string, ta
 				return reqErr
 			}
 			defer func() { httputil.CloseResponse(resp) }()
+			if !isJobTerminated(resp.StatusCode) {
+				return fmt.Errorf("transformer returned status code: %v", resp.StatusCode)
+			}
 			respData, reqErr = io.ReadAll(resp.Body)
 			return reqErr
 		},


### PR DESCRIPTION
# Description

Handle non 2xx response codes in processor transformer and retry the events

## Notion Ticket

[ Notion Link ](https://www.notion.so/rudderstacks/Retry-non-2xx-responses-processor-transformer-58ee7768907c4a61bc48f40b63653dc9?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
