### PR TITLE
fix: kafka flaky batching test

### DIFF
--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -318,7 +318,7 @@ func TestIntegration(t *testing.T) {
 				{"message":"three","topic":"foo-bar","userId":"1234"}
 			]`), destConfig)
 			return statusCode == http.StatusOK
-		}, 10*time.Second, 100*time.Millisecond)
+		}, 30*time.Second, 100*time.Millisecond)
 		require.Equal(t, "Kafka: Message delivered in batch", returnMessage)
 		require.Equal(t, "Kafka: Message delivered in batch", errMessage)
 


### PR DESCRIPTION
# Description

Increasing timeout since [I can't find any failure](https://github.com/rudderlabs/rudder-server/actions/runs/5184540788/jobs/9343545830?pr=3397) I'm guessing that simply Kafka was not ready yet.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
