### PR TITLE
fix: migration fails with error pq: VACUUM cannot run inside a transaction block

### DIFF
--- a/jobsdb/backup.go
+++ b/jobsdb/backup.go
@@ -88,7 +88,8 @@ func (jd *HandleT) backupDSLoop(ctx context.Context) {
 // backupDS writes both jobs and job_staus table to JOBS_BACKUP_STORAGE_PROVIDER
 func (jd *HandleT) backupDS(ctx context.Context, backupDSRange *dataSetRangeT) error {
 	if err := jd.WithTx(func(tx *Tx) error {
-		return jd.cleanStatusTable(ctx, tx, backupDSRange.ds.JobStatusTable, true)
+		_, err := jd.cleanStatusTable(ctx, tx, backupDSRange.ds.JobStatusTable, false)
+		return err
 	}); err != nil {
 		return fmt.Errorf("error while cleaning status table: %w", err)
 	}

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -252,11 +252,7 @@ func (jd *HandleT) getCleanUpCandidates(ctx context.Context, dsList []dataSetT) 
 
 // based on an estimate cleans up the status tables
 func (jd *HandleT) cleanupStatusTables(ctx context.Context, dsList []dataSetT) error {
-	toCompact, err := jd.getCleanUpCandidates(ctx, dsList)
-	if err != nil {
-		return err
-	}
-
+	var toVacuum []string
 	toVacuumFull, err := jd.getVacuumFullCandidates(ctx, dsList)
 	if err != nil {
 		return err
@@ -264,6 +260,10 @@ func (jd *HandleT) cleanupStatusTables(ctx context.Context, dsList []dataSetT) e
 	toVacuumFullMap := lo.Associate(toVacuumFull, func(k string) (string, struct{}) {
 		return k, struct{}{}
 	})
+	toCompact, err := jd.getCleanUpCandidates(ctx, dsList)
+	if err != nil {
+		return err
+	}
 	start := time.Now()
 	defer stats.Default.NewTaggedStat(
 		"jobsdb_compact_status_tables",
@@ -271,32 +271,43 @@ func (jd *HandleT) cleanupStatusTables(ctx context.Context, dsList []dataSetT) e
 		stats.Tags{"customVal": jd.tablePrefix},
 	).Since(start)
 
-	return jd.WithTx(func(tx *Tx) error {
+	if err := jd.WithTx(func(tx *Tx) error {
 		for _, statusTable := range toCompact {
 			table := statusTable.JobStatusTable
 			// clean up and vacuum if not present in toVacuumFullMap
 			_, ok := toVacuumFullMap[table]
-			if err := jd.cleanStatusTable(
-				ctx,
-				tx,
-				table,
-				!ok,
-			); err != nil {
+			vacuum, err := jd.cleanStatusTable(ctx, tx, table, !ok)
+			if err != nil {
 				return err
 			}
-		}
-		// vacuum full if present in toVacuumFull
-		for _, table := range toVacuumFull {
-			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`VACUUM FULL %[1]q`, table)); err != nil {
-				return err
+			if vacuum {
+				toVacuum = append(toVacuum, table)
 			}
 		}
+
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	// vacuum full
+	for _, table := range toVacuumFull {
+		jd.logger.Infof("vacuuming full %q", table)
+		if _, err := jd.dbHandle.ExecContext(ctx, fmt.Sprintf(`VACUUM FULL %[1]q`, table)); err != nil {
+			return err
+		}
+	}
+	// vacuum analyze
+	for _, table := range toVacuum {
+		jd.logger.Infof("vacuuming %q", table)
+		if _, err := jd.dbHandle.ExecContext(ctx, fmt.Sprintf(`VACUUM ANALYZE %[1]q`, table)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // cleanStatusTable deletes all rows except for the latest status for each job
-func (*HandleT) cleanStatusTable(ctx context.Context, tx *Tx, table string, canBeVacuumed bool) error {
+func (*HandleT) cleanStatusTable(ctx context.Context, tx *Tx, table string, canBeVacuumed bool) (vacuum bool, err error) {
 	result, err := tx.ExecContext(
 		ctx,
 		fmt.Sprintf(`DELETE FROM %[1]q
@@ -305,23 +316,21 @@ func (*HandleT) cleanStatusTable(ctx context.Context, tx *Tx, table string, canB
 						)`, table),
 	)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	numJobStatusDeleted, err := result.RowsAffected()
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	query := fmt.Sprintf(`ANALYZE %q`, table)
 	if numJobStatusDeleted > vacuumAnalyzeStatusTableThreshold && canBeVacuumed {
-		query = fmt.Sprintf(`VACUUM ANALYZE %q`, table)
+		vacuum = true
+	} else {
+		_, err = tx.ExecContext(ctx, fmt.Sprintf(`ANALYZE %q`, table))
 	}
-	_, err = tx.ExecContext(
-		ctx,
-		query,
-	)
-	return err
+
+	return
 }
 
 // getMigrationList returns the list of datasets to migrate from,

--- a/jobsdb/migration_test.go
+++ b/jobsdb/migration_test.go
@@ -10,197 +10,317 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
 	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
 	fileuploader "github.com/rudderlabs/rudder-server/services/fileuploader"
-	"github.com/rudderlabs/rudder-server/utils/bytesize"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMigration(t *testing.T) {
-	maxDSSize := 1
-	_ = startPostgres(t)
+	t.Run("main", func(t *testing.T) {
+		maxDSSize := 1
+		_ = startPostgres(t)
 
-	triggerAddNewDS := make(chan time.Time)
-	triggerMigrateDS := make(chan time.Time)
+		triggerAddNewDS := make(chan time.Time)
+		triggerMigrateDS := make(chan time.Time)
 
-	jobDB := HandleT{
-		TriggerAddNewDS: func() <-chan time.Time {
-			return triggerAddNewDS
-		},
-		TriggerMigrateDS: func() <-chan time.Time {
-			return triggerMigrateDS
-		},
-		MaxDSSize: &maxDSSize,
-	}
-	tablePrefix := strings.ToLower(rand.String(5))
-	err := jobDB.Setup(
-		ReadWrite,
-		true,
-		tablePrefix,
-		[]prebackup.Handler{},
-		fileuploader.NewDefaultProvider(),
-	)
-	require.NoError(t, err)
-	defer jobDB.TearDown()
+		jobDB := HandleT{
+			TriggerAddNewDS: func() <-chan time.Time {
+				return triggerAddNewDS
+			},
+			TriggerMigrateDS: func() <-chan time.Time {
+				return triggerMigrateDS
+			},
+			MaxDSSize: &maxDSSize,
+		}
+		tablePrefix := strings.ToLower(rand.String(5))
+		err := jobDB.Setup(
+			ReadWrite,
+			true,
+			tablePrefix,
+			[]prebackup.Handler{},
+			fileuploader.NewDefaultProvider(),
+		)
+		require.NoError(t, err)
+		defer jobDB.TearDown()
 
-	jobDB.MaxDSRetentionPeriod = time.Millisecond
+		jobDB.MaxDSRetentionPeriod = time.Millisecond
 
-	customVal := rand.String(5)
-	jobs := genJobs(defaultWorkspaceID, customVal, 30, 1)
-	require.NoError(t, jobDB.Store(context.Background(), jobs[:10]))
+		customVal := rand.String(5)
+		jobs := genJobs(defaultWorkspaceID, customVal, 30, 1)
+		require.NoError(t, jobDB.Store(context.Background(), jobs[:10]))
 
-	// let 8 jobs succeed, and 2 repeatedly fail
-	require.NoError(
-		t,
-		jobDB.UpdateJobStatus(
-			context.Background(),
-			genJobStatuses(jobs[:9], "executing"),
-			[]string{customVal},
-			[]ParameterFilterT{},
-		),
-	)
-	require.NoError(
-		t,
-		jobDB.UpdateJobStatus(
-			context.Background(),
-			genJobStatuses(jobs[:9], "succeeded"),
-			[]string{customVal},
-			[]ParameterFilterT{},
-		),
-	)
-
-	require.NoError(
-		t,
-		jobDB.UpdateJobStatus(
-			context.Background(),
-			genJobStatuses(jobs[9:10], "executing"),
-			[]string{customVal},
-			[]ParameterFilterT{},
-		),
-		`status update failed in 1st DS`,
-	)
-	require.NoError(
-		t,
-		jobDB.UpdateJobStatus(
-			context.Background(),
-			genJobStatuses(jobs[9:10], "failed"),
-			[]string{customVal},
-			[]ParameterFilterT{},
-		),
-		`status update failed in 1st DS`,
-	)
-
-	require.EqualValues(t, 1, jobDB.GetMaxDSIndex())
-	triggerAddNewDS <- time.Now() // trigger addNewDSLoop to run
-	triggerAddNewDS <- time.Now() // Second time, waits for the first loop to finish
-	require.EqualValues(t, 2, jobDB.GetMaxDSIndex())
-
-	// add some more jobs to the new DS
-	require.NoError(t, jobDB.Store(context.Background(), jobs[10:20]))
-
-	triggerAddNewDS <- time.Now() // trigger addNewDSLoop to run
-	triggerAddNewDS <- time.Now() // Second time, waits for the first loop to finish
-	require.EqualValues(t, 3, jobDB.GetMaxDSIndex())
-
-	// last DS
-	// should have enough statuses for a clean up to be triggered
-	// all non-terminal
-	require.NoError(t, jobDB.Store(context.Background(), jobs[20:30]))
-	for i := 0; i < 10; i++ {
+		// let 8 jobs succeed, and 2 repeatedly fail
 		require.NoError(
 			t,
 			jobDB.UpdateJobStatus(
 				context.Background(),
-				genJobStatuses(jobs[20:30], "executing"),
+				genJobStatuses(jobs[:9], "executing"),
 				[]string{customVal},
 				[]ParameterFilterT{},
 			),
-			`status update failed in 3rd DS`,
 		)
 		require.NoError(
 			t,
 			jobDB.UpdateJobStatus(
 				context.Background(),
-				genJobStatuses(jobs[20:30], "failed"),
+				genJobStatuses(jobs[:9], "succeeded"),
 				[]string{customVal},
 				[]ParameterFilterT{},
 			),
-			`status update failed in 3rd DS`,
 		)
-	}
-	_, err = jobDB.dbHandle.Exec(
-		fmt.Sprintf(
-			`ANALYZE %[1]s_jobs_1, %[1]s_jobs_2, %[1]s_jobs_3,
-			%[1]s_job_status_1, %[1]s_job_status_2, %[1]s_job_status_3`,
+
+		require.NoError(
+			t,
+			jobDB.UpdateJobStatus(
+				context.Background(),
+				genJobStatuses(jobs[9:10], "executing"),
+				[]string{customVal},
+				[]ParameterFilterT{},
+			),
+			`status update failed in 1st DS`,
+		)
+		require.NoError(
+			t,
+			jobDB.UpdateJobStatus(
+				context.Background(),
+				genJobStatuses(jobs[9:10], "failed"),
+				[]string{customVal},
+				[]ParameterFilterT{},
+			),
+			`status update failed in 1st DS`,
+		)
+
+		require.EqualValues(t, 1, jobDB.GetMaxDSIndex())
+		triggerAddNewDS <- time.Now() // trigger addNewDSLoop to run
+		triggerAddNewDS <- time.Now() // Second time, waits for the first loop to finish
+		require.EqualValues(t, 2, jobDB.GetMaxDSIndex())
+
+		// add some more jobs to the new DS
+		require.NoError(t, jobDB.Store(context.Background(), jobs[10:20]))
+
+		triggerAddNewDS <- time.Now() // trigger addNewDSLoop to run
+		triggerAddNewDS <- time.Now() // Second time, waits for the first loop to finish
+		require.EqualValues(t, 3, jobDB.GetMaxDSIndex())
+
+		// last DS
+		// should have enough statuses for a clean up to be triggered
+		// all non-terminal
+		require.NoError(t, jobDB.Store(context.Background(), jobs[20:30]))
+		for i := 0; i < 10; i++ {
+			require.NoError(
+				t,
+				jobDB.UpdateJobStatus(
+					context.Background(),
+					genJobStatuses(jobs[20:30], "executing"),
+					[]string{customVal},
+					[]ParameterFilterT{},
+				),
+				`status update failed in 3rd DS`,
+			)
+			require.NoError(
+				t,
+				jobDB.UpdateJobStatus(
+					context.Background(),
+					genJobStatuses(jobs[20:30], "failed"),
+					[]string{customVal},
+					[]ParameterFilterT{},
+				),
+				`status update failed in 3rd DS`,
+			)
+		}
+		_, err = jobDB.dbHandle.Exec(
+			fmt.Sprintf(
+				`ANALYZE %[1]s_jobs_1, %[1]s_jobs_2, %[1]s_jobs_3,
+				%[1]s_job_status_1, %[1]s_job_status_2, %[1]s_job_status_3`,
+				tablePrefix,
+			),
+		)
+		require.NoError(t, err)
+		triggerMigrateDS <- time.Now() // trigger migrateDSLoop to run
+		triggerMigrateDS <- time.Now() // waits for last loop to finish
+
+		// we should see that in the three DSs we have,
+		// the first one should only have non-terminal jobs left now(with only the last status) in an jobs_1_1
+		// the second one should have all jobs
+		// the third DS should have all jobs with only the last status per job
+
+		// check that the first DS has only non-terminal jobs
+		dsList := jobDB.getDSList()
+		require.Equal(t, `1_1`, dsList[0].Index)
+		var count int64
+		err = jobDB.dbHandle.QueryRow(
+			fmt.Sprintf(
+				`SELECT COUNT(*) FROM %[1]s_jobs_1_1 WHERE %[1]s_jobs_1_1.custom_val = $1`,
+				tablePrefix,
+			),
+			customVal,
+		).Scan(&count)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, count)
+
+		// second DS must be untouched by this migrationLoop
+		require.Equal(t, `2`, dsList[1].Index)
+		err = jobDB.dbHandle.QueryRow(
+			fmt.Sprintf(
+				`SELECT COUNT(*) FROM %[1]s_jobs_2 WHERE %[1]s_jobs_2.custom_val = $1`,
+				tablePrefix,
+			),
+			customVal,
+		).Scan(&count)
+		require.NoError(t, err)
+		require.EqualValues(t, 10, count)
+
+		err = jobDB.dbHandle.QueryRow(
+			fmt.Sprintf(
+				`SELECT COUNT(*) FROM %[1]s_job_status_2`,
+				tablePrefix,
+			),
+		).Scan(&count)
+		require.NoError(t, err)
+		require.EqualValues(t, 0, count)
+
+		// third DS's status table must've been cleaned up
+		require.Equal(t, `3`, dsList[2].Index)
+		err = jobDB.dbHandle.QueryRow(
+			fmt.Sprintf(
+				`SELECT COUNT(*) FROM %[1]s_jobs_3 WHERE %[1]s_jobs_3.custom_val = $1`,
+				tablePrefix,
+			),
+			customVal,
+		).Scan(&count)
+		require.NoError(t, err)
+		require.EqualValues(t, 10, count)
+
+		err = jobDB.dbHandle.QueryRow(
+			fmt.Sprintf(
+				`SELECT COUNT(*) FROM %[1]s_job_status_3 where job_state = 'failed';`,
+				tablePrefix,
+			),
+		).Scan(&count)
+		require.NoError(t, err)
+		require.EqualValues(t, 10, count)
+	})
+
+	t.Run("cleanup status tables", func(t *testing.T) {
+		maxDSSize := 1
+		_ = startPostgres(t)
+
+		triggerAddNewDS := make(chan time.Time)
+		triggerMigrateDS := make(chan time.Time)
+
+		jobDB := HandleT{
+			TriggerAddNewDS: func() <-chan time.Time {
+				return triggerAddNewDS
+			},
+			TriggerMigrateDS: func() <-chan time.Time {
+				return triggerMigrateDS
+			},
+			MaxDSSize: &maxDSSize,
+		}
+		tablePrefix := strings.ToLower(rand.String(5))
+		require.NoError(t, jobDB.Setup(
+			ReadWrite,
+			true,
 			tablePrefix,
-		),
-	)
-	require.NoError(t, err)
-	triggerMigrateDS <- time.Now() // trigger migrateDSLoop to run
-	triggerMigrateDS <- time.Now() // waits for last loop to finish
+			[]prebackup.Handler{},
+			fileuploader.NewDefaultProvider(),
+		))
+		defer jobDB.TearDown()
 
-	// we should see that in the three DSs we have,
-	// the first one should only have non-terminal jobs left now(with only the last status) in an jobs_1_1
-	// the second one should have all jobs
-	// the third DS should have all jobs with only the last status per job
+		jobDB.MaxDSRetentionPeriod = time.Millisecond
 
-	// check that the first DS has only non-terminal jobs
-	dsList := jobDB.getDSList()
-	require.Equal(t, `1_1`, dsList[0].Index)
-	var count int64
-	err = jobDB.dbHandle.QueryRow(
-		fmt.Sprintf(
-			`SELECT COUNT(*) FROM %[1]s_jobs_1_1 WHERE %[1]s_jobs_1_1.custom_val = $1`,
-			tablePrefix,
-		),
-		customVal,
-	).Scan(&count)
-	require.NoError(t, err)
-	require.EqualValues(t, 1, count)
+		// 3 datasets with 10 jobs each, 1 dataset with 0 jobs
+		for i := 0; i < 3; i++ {
+			require.NoError(t, jobDB.Store(context.Background(), genJobs(defaultWorkspaceID, "test", 10, 1)))
+			triggerAddNewDS <- time.Now() // trigger addNewDSLoop to run
+			triggerAddNewDS <- time.Now() // waits for last loop to finish
+			require.Equal(t, i+2, len(jobDB.getDSList()))
+		}
 
-	// second DS must be untouched by this migrationLoop
-	require.Equal(t, `2`, dsList[1].Index)
-	err = jobDB.dbHandle.QueryRow(
-		fmt.Sprintf(
-			`SELECT COUNT(*) FROM %[1]s_jobs_2 WHERE %[1]s_jobs_2.custom_val = $1`,
-			tablePrefix,
-		),
-		customVal,
-	).Scan(&count)
-	require.NoError(t, err)
-	require.EqualValues(t, 10, count)
+		// 1st ds 5 statuses each
+		var jobs []*JobT
+		for i := 0; i < 10; i++ {
+			jobs = append(jobs, &JobT{JobID: int64(i + 1)})
+		}
+		for i := 0; i < 5; i++ {
+			require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(jobs, "failed"), []string{"test"}, []ParameterFilterT{}))
+		}
+		var count int
+		require.NoError(t, jobDB.dbHandle.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %[1]s_job_status_1 `, tablePrefix)).Scan(&count))
+		require.EqualValues(t, 5*10, count)
 
-	err = jobDB.dbHandle.QueryRow(
-		fmt.Sprintf(
-			`SELECT COUNT(*) FROM %[1]s_job_status_2`,
-			tablePrefix,
-		),
-	).Scan(&count)
-	require.NoError(t, err)
-	require.EqualValues(t, 0, count)
+		// 2nd ds 10 statuses each
+		jobs = nil
+		for i := 0; i < 10; i++ {
+			jobs = append(jobs, &JobT{JobID: int64(i + 11)})
+		}
+		for i := 0; i < 10; i++ {
+			require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(jobs, "failed"), []string{"test"}, []ParameterFilterT{}))
+		}
+		require.NoError(t, jobDB.dbHandle.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %[1]s_job_status_2 `, tablePrefix)).Scan(&count))
+		require.EqualValues(t, 10*10, count)
 
-	// third DS's status table must've been cleaned up
-	require.Equal(t, `3`, dsList[2].Index)
-	err = jobDB.dbHandle.QueryRow(
-		fmt.Sprintf(
-			`SELECT COUNT(*) FROM %[1]s_jobs_3 WHERE %[1]s_jobs_3.custom_val = $1`,
-			tablePrefix,
-		),
-		customVal,
-	).Scan(&count)
-	require.NoError(t, err)
-	require.EqualValues(t, 10, count)
+		getTableSizes := func(dsList []dataSetT) map[string]int64 {
+			for _, ds := range dsList { // first analyze all tables so that we get correct table sizes
+				_, err := jobDB.dbHandle.Exec(fmt.Sprintf(`ANALYZE %q`, ds.JobStatusTable))
+				require.NoError(t, err)
+				_, err = jobDB.dbHandle.Exec(fmt.Sprintf(`ANALYZE %q`, ds.JobTable))
+				require.NoError(t, err)
+			}
+			tableSizes := make(map[string]int64)
+			rows, err := jobDB.dbHandle.QueryContext(context.Background(),
+				`SELECT relname, pg_table_size(oid) AS size
+				FROM pg_class
+				where relname = ANY(
+					SELECT tablename
+						FROM pg_catalog.pg_tables
+						WHERE schemaname NOT IN ('pg_catalog','information_schema')
+						AND tablename like $1
+				) order by relname;`,
+				tablePrefix+"_job_status%",
+			)
+			require.NoError(t, err)
+			defer func() { _ = rows.Close() }()
+			for rows.Next() {
+				var (
+					tableName string
+					tableSize int64
+				)
+				require.NoError(t, rows.Scan(&tableName, &tableSize))
+				tableSizes[tableName] = tableSize
+			}
+			require.NoError(t, rows.Err())
+			return tableSizes
+		}
+		// capture table sizes
+		originalTableSizes := getTableSizes(jobDB.getDSList())
 
-	err = jobDB.dbHandle.QueryRow(
-		fmt.Sprintf(
-			`SELECT COUNT(*) FROM %[1]s_job_status_3 where job_state = 'failed';`,
-			tablePrefix,
-		),
-	).Scan(&count)
-	require.NoError(t, err)
-	require.EqualValues(t, 10, count)
+		jobStatusMigrateThres = 1
+		vacuumAnalyzeStatusTableThreshold = 4
+		vacuumFullStatusTableThreshold = originalTableSizes[fmt.Sprintf("%s_job_status_2", tablePrefix)] - 1
 
-	vacuumFullStatusTableThreshold = 8 * bytesize.KB // 8KB is common value for toast size in postgres
-	toVacuum, err := jobDB.getVacuumFullCandidates(context.Background(), dsList)
-	require.NoError(t, err)
-	require.EqualValues(t, 4, len(dsList))   // total 4 DSs
-	require.EqualValues(t, 2, len(toVacuum)) // 2 DSs to vacuum since 2nd and 4th DSs have status tables with no entries
+		// run cleanup status tables
+		require.NoError(t, jobDB.cleanupStatusTables(context.Background(), jobDB.getDSList()))
+
+		newTableSizes := getTableSizes(jobDB.getDSList())
+
+		// 1st DS should have 10 jobs with 1 status each
+		require.NoError(t, jobDB.dbHandle.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %[1]s_job_status_1`, tablePrefix)).Scan(&count))
+		require.EqualValues(t, 10, count)
+		require.GreaterOrEqual(t, newTableSizes[fmt.Sprintf("%s_job_status_1", tablePrefix)], originalTableSizes[fmt.Sprintf("%s_job_status_1", tablePrefix)])
+
+		// 2nd DS should have 10 jobs with 1 status each
+		require.NoError(t, jobDB.dbHandle.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %[1]s_job_status_2`, tablePrefix)).Scan(&count))
+		require.EqualValues(t, 10, count)
+		require.Less(t, newTableSizes[fmt.Sprintf("%s_job_status_2", tablePrefix)], originalTableSizes[fmt.Sprintf("%s_job_status_2", tablePrefix)])
+
+		// after adding some statuses to the 1st DS its table size shouldn't increase
+		for i := 0; i < 10; i++ {
+			jobs = append(jobs, &JobT{JobID: int64(i + 1)})
+		}
+		for i := 0; i < 4; i++ {
+			require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(jobs, "failed"), []string{"test"}, []ParameterFilterT{}))
+		}
+
+		updatedTableSizes := getTableSizes(jobDB.getDSList())
+		require.Equal(t, newTableSizes[fmt.Sprintf("%s_job_status_1", tablePrefix)], updatedTableSizes[fmt.Sprintf("%s_job_status_1", tablePrefix)])
+	})
 }

--- a/services/dedup/dedup_test.go
+++ b/services/dedup/dedup_test.go
@@ -21,6 +21,7 @@ func Test_Dedup(t *testing.T) {
 	config.Reset()
 	logger.Reset()
 	misc.Init()
+
 	dbPath := os.TempDir() + "/dedup_test"
 	defer func() { _ = os.RemoveAll(dbPath) }()
 	_ = os.RemoveAll(dbPath)
@@ -114,6 +115,7 @@ func Test_Dedup_ClearDB(t *testing.T) {
 func Test_Dedup_ErrTxnTooBig(t *testing.T) {
 	config.Reset()
 	logger.Reset()
+	misc.Init()
 
 	dbPath := os.TempDir() + "/dedup_test_errtxntoobig"
 	defer os.RemoveAll(dbPath)
@@ -134,6 +136,8 @@ func Test_Dedup_ErrTxnTooBig(t *testing.T) {
 func Benchmark_Dedup(b *testing.B) {
 	config.Reset()
 	logger.Reset()
+	misc.Init()
+
 	dbPath := path.Join("./testdata", "tmp", rand.String(10), "/DB_Benchmark_Dedup")
 	b.Logf("using path %s, since tmpDir has issues in macOS\n", dbPath)
 	defer func() { _ = os.RemoveAll(dbPath) }()


### PR DESCRIPTION
# Description

Issue introduced by #3434, since a VACUUM command cannot be executed inside a transaction. Vacuum or vacuum full are now being executed, if necessary, after the transaction completes. Added the necessary test case to verify proper behaviour.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=3a8df920ee344586b44817a490e58ddb&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
