### PR TITLE
fix: router panics with limit for rt_pickup must be greater than 0

### DIFF
--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -159,7 +159,7 @@ func (rt *Handle) Setup(
 	var limiterGroup sync.WaitGroup
 	limiterStatsPeriod := config.GetDuration("Router.Limiter.statsPeriod", 15, time.Second)
 	rt.limiter.pickup = kitsync.NewLimiter(ctx, &limiterGroup, "rt_pickup",
-		getRouterConfigInt(rt.destType, "Limiter.pickup.limit", 100),
+		getRouterConfigInt("Limiter.pickup.limit", rt.destType, 100),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Router.Limiter.pickup.dynamicPeriod", 1, time.Second)),
 		kitsync.WithLimiterTags(map[string]string{"destType": rt.destType}),
@@ -170,7 +170,7 @@ func (rt *Handle) Setup(
 	rt.limiter.stats.pickup = partition.NewStats()
 
 	rt.limiter.transform = kitsync.NewLimiter(ctx, &limiterGroup, "rt_transform",
-		getRouterConfigInt(rt.destType, "Limiter.transform.limit", 200),
+		getRouterConfigInt("Limiter.transform.limit", rt.destType, 200),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Router.Limiter.transform.dynamicPeriod", 1, time.Second)),
 		kitsync.WithLimiterTags(map[string]string{"destType": rt.destType}),
@@ -181,7 +181,7 @@ func (rt *Handle) Setup(
 	rt.limiter.stats.transform = partition.NewStats()
 
 	rt.limiter.batch = kitsync.NewLimiter(ctx, &limiterGroup, "rt_batch",
-		getRouterConfigInt(rt.destType, "Limiter.batch.limit", 200),
+		getRouterConfigInt("Limiter.batch.limit", rt.destType, 200),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Router.Limiter.batch.dynamicPeriod", 1, time.Second)),
 		kitsync.WithLimiterTags(map[string]string{"destType": rt.destType}),
@@ -192,7 +192,7 @@ func (rt *Handle) Setup(
 	rt.limiter.stats.batch = partition.NewStats()
 
 	rt.limiter.process = kitsync.NewLimiter(ctx, &limiterGroup, "rt_process",
-		getRouterConfigInt(rt.destType, "Limiter.process.limit", 200),
+		getRouterConfigInt("Limiter.process.limit", rt.destType, 200),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Router.Limiter.process.dynamicPeriod", 1, time.Second)),
 		kitsync.WithLimiterTags(map[string]string{"destType": rt.destType}),


### PR DESCRIPTION
# Description

Wrong order of arguments while calling `getRouterConfigInt` caused issues with configurations containing destination type specific configuration overrides in router module.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=31d3bf3af81c42a293bb08ef4d93c169&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
