### PR TITLE
chore: avoid querying a dataset in case AfterJobID falls after said dataset

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -3105,7 +3105,7 @@ func (jd *HandleT) getUnprocessed(ctx context.Context, params GetQueryParamsT) (
 	}
 	defer jd.dsListLock.RUnlock()
 
-	dsList := jd.getDSList()
+	dsRangeList := jd.getDSRangeList()
 
 	limitByEventCount := false
 	if params.EventsLimit > 0 {
@@ -3124,11 +3124,17 @@ func (jd *HandleT) getUnprocessed(ctx context.Context, params GetQueryParamsT) (
 	if jd.dsLimit != nil {
 		dsLimit = *jd.dsLimit
 	}
-	for _, ds := range dsList {
+	for _, dsRange := range dsRangeList {
+		if params.AfterJobID != nil {
+			if dsRange.maxJobID < *params.AfterJobID {
+				// cacheHitCount++ ?
+				continue
+			}
+		}
 		if dsLimit > 0 && dsQueryCount >= dsLimit {
 			break
 		}
-		unprocessedJobs, dsHit, err := jd.getUnprocessedJobsDS(ctx, ds, params)
+		unprocessedJobs, dsHit, err := jd.getUnprocessedJobsDS(ctx, dsRange.ds, params)
 		if err != nil {
 			return JobsResult{}, err
 		}
@@ -3224,7 +3230,7 @@ func (jd *HandleT) GetProcessed(ctx context.Context, params GetQueryParamsT) (Jo
 	}
 	defer jd.dsListLock.RUnlock()
 
-	dsList := jd.getDSList()
+	dsRangeList := jd.getDSRangeList()
 
 	limitByEventCount := false
 	if params.EventsLimit > 0 {
@@ -3245,11 +3251,17 @@ func (jd *HandleT) GetProcessed(ctx context.Context, params GetQueryParamsT) (Jo
 	if jd.dsLimit != nil {
 		dsLimit = *jd.dsLimit
 	}
-	for _, ds := range dsList {
+	for _, dsRange := range dsRangeList {
+		if params.AfterJobID != nil {
+			if dsRange.maxJobID < *params.AfterJobID {
+				// cacheHitCount++ ?
+				continue
+			}
+		}
 		if dsLimit > 0 && dsQueryCount >= dsLimit {
 			break
 		}
-		processedJobs, dsHit, err := jd.getProcessedJobsDS(ctx, ds, params)
+		processedJobs, dsHit, err := jd.getProcessedJobsDS(ctx, dsRange.ds, params)
 		if err != nil {
 			return JobsResult{}, err
 		}

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -3106,6 +3106,7 @@ func (jd *HandleT) getUnprocessed(ctx context.Context, params GetQueryParamsT) (
 	defer jd.dsListLock.RUnlock()
 
 	dsRangeList := jd.getDSRangeList()
+	dsList := jd.getDSList()
 
 	limitByEventCount := false
 	if params.EventsLimit > 0 {
@@ -3124,17 +3125,18 @@ func (jd *HandleT) getUnprocessed(ctx context.Context, params GetQueryParamsT) (
 	if jd.dsLimit != nil {
 		dsLimit = *jd.dsLimit
 	}
-	for _, dsRange := range dsRangeList {
+	for idx, ds := range dsList {
 		if params.AfterJobID != nil {
-			if dsRange.maxJobID < *params.AfterJobID {
-				// cacheHitCount++ ?
-				continue
+			if idx < len(dsRangeList) {
+				if *params.AfterJobID > dsRangeList[idx].maxJobID {
+					continue
+				}
 			}
 		}
 		if dsLimit > 0 && dsQueryCount >= dsLimit {
 			break
 		}
-		unprocessedJobs, dsHit, err := jd.getUnprocessedJobsDS(ctx, dsRange.ds, params)
+		unprocessedJobs, dsHit, err := jd.getUnprocessedJobsDS(ctx, ds, params)
 		if err != nil {
 			return JobsResult{}, err
 		}
@@ -3231,6 +3233,7 @@ func (jd *HandleT) GetProcessed(ctx context.Context, params GetQueryParamsT) (Jo
 	defer jd.dsListLock.RUnlock()
 
 	dsRangeList := jd.getDSRangeList()
+	dsList := jd.getDSList()
 
 	limitByEventCount := false
 	if params.EventsLimit > 0 {
@@ -3251,17 +3254,18 @@ func (jd *HandleT) GetProcessed(ctx context.Context, params GetQueryParamsT) (Jo
 	if jd.dsLimit != nil {
 		dsLimit = *jd.dsLimit
 	}
-	for _, dsRange := range dsRangeList {
+	for idx, ds := range dsList {
 		if params.AfterJobID != nil {
-			if dsRange.maxJobID < *params.AfterJobID {
-				// cacheHitCount++ ?
-				continue
+			if idx < len(dsRangeList) {
+				if *params.AfterJobID > dsRangeList[idx].maxJobID {
+					continue
+				}
 			}
 		}
 		if dsLimit > 0 && dsQueryCount >= dsLimit {
 			break
 		}
-		processedJobs, dsHit, err := jd.getProcessedJobsDS(ctx, dsRange.ds, params)
+		processedJobs, dsHit, err := jd.getProcessedJobsDS(ctx, ds, params)
 		if err != nil {
 			return JobsResult{}, err
 		}

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -3127,7 +3127,8 @@ func (jd *HandleT) getUnprocessed(ctx context.Context, params GetQueryParamsT) (
 	}
 	for idx, ds := range dsList {
 		if params.AfterJobID != nil {
-			if idx < len(dsRangeList) {
+			if idx < len(dsRangeList) { // ranges are not stored for the last ds
+				// so the following condition cannot be applied the last ds
 				if *params.AfterJobID > dsRangeList[idx].maxJobID {
 					continue
 				}
@@ -3256,7 +3257,8 @@ func (jd *HandleT) GetProcessed(ctx context.Context, params GetQueryParamsT) (Jo
 	}
 	for idx, ds := range dsList {
 		if params.AfterJobID != nil {
-			if idx < len(dsRangeList) {
+			if idx < len(dsRangeList) { // ranges are not stored for the last ds
+				// so the following condition cannot be applied the last ds
 				if *params.AfterJobID > dsRangeList[idx].maxJobID {
 					continue
 				}


### PR DESCRIPTION
# Description

Avoid querying a dataset if `params.AfterJobID != nil && *params.AfterJobID > dsRange.maxJobID`.
Added said logic to `jobsdb.GetProcessed(...)` and `jobsdb.GetUnprocessed(...)`

## Notion Ticket

[update archive status](https://www.notion.so/rudderstacks/jobsdb-support-archive-state-a9c85931f711407a9cc0415f2c75ed83?pvs=4)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
