### PR TITLE
fix: error extraction for errors in destination transformation

### DIFF
--- a/enterprise/reporting/error_extractor.go
+++ b/enterprise/reporting/error_extractor.go
@@ -83,7 +83,7 @@ func (ext *ExtractorHandle) getSimpleMessage(jsonStr string) string {
 				return strings.Split(erResStr, "\n")[0]
 			}
 			return ""
-		case responseKey:
+		case responseKey, "error":
 			if IsJSON(erResStr) {
 				var unmarshalledJson interface{}
 				unmarshalledErr := json.Unmarshal([]byte(erResStr), &unmarshalledJson)

--- a/enterprise/reporting/error_extractor.go
+++ b/enterprise/reporting/error_extractor.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	responseKey = "response"
+	errorKey    = "error"
 	spaceStr    = " "
 
 	destinationResponseKey = "destinationResponse"
@@ -29,7 +30,7 @@ var (
 	spaceRegex       = regexp.MustCompile(`\s+`)
 	whitespacesRegex = regexp.MustCompile("[ \t\n\r]*") // used in checking if string is a valid json to remove extra-spaces
 
-	defaultErrorMessageKeys = []string{"message", "description", "detail", "title", "error", "error_message"}
+	defaultErrorMessageKeys = []string{"message", "description", "detail", "title", errorKey, "error_message"}
 )
 
 type ExtractorHandle struct {
@@ -83,7 +84,7 @@ func (ext *ExtractorHandle) getSimpleMessage(jsonStr string) string {
 				return strings.Split(erResStr, "\n")[0]
 			}
 			return ""
-		case responseKey, "error":
+		case responseKey, errorKey:
 			if IsJSON(erResStr) {
 				var unmarshalledJson interface{}
 				unmarshalledErr := json.Unmarshal([]byte(erResStr), &unmarshalledJson)

--- a/enterprise/reporting/reporting_test.go
+++ b/enterprise/reporting/reporting_test.go
@@ -405,6 +405,14 @@ var tcs = []getValTc{
 		inputStr: `{"response":"{\n\t\t\t\tError: invalid character 'P' looking for beginning of value,\n\t\t\t\t(trRespStCd, trRespBody): (504, Post \"http://transformer.rudder-us-east-1b-blue/v0/destinations/google_adwords_enhanced_conversions/proxy\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)),\n\t\t\t}","firstAttemptedAt":"2023-03-30T17:24:58.068Z","content-type":"text/plain; charset=utf-8"}`,
 		expected: "{\n\t\t\t\tError: invalid character 'P' looking for beginning of value,\n\t\t\t\t(trRespStCd, trRespBody): (504, Post \"http://transformer.rudder-us-east-1b-blue/v0/destinations/google_adwords_enhanced_conversions/proxy\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)),\n\t\t\t}",
 	},
+	{
+		inputStr: `{"error":"{\"message\":\"some random message\",\"destinationResponse\":{\"error\":{\"message\":\"Unhandled random error\",\"type\":\"RandomException\",\"code\":5,\"error_subcode\":12,\"fbtrace_id\":\"facebook_px_trace_id_10\"},\"status\":412}}","firstAttemptedAt":"2023-04-20T17:24:58.068Z","content-type":"text/plain; charset=utf-8"}`,
+		expected: "Unhandled random error",
+	},
+	{
+		inputStr: `{"error":"unknown error occurred","firstAttemptedAt":"2023-04-21T17:24:58.068Z","content-type":"text/plain; charset=utf-8"}`,
+		expected: "unknown error occurred",
+	},
 }
 
 func TestGetErrorMessageFromResponse(t *testing.T) {


### PR DESCRIPTION
# Description

The error message during transformation was not getting captured correctly in our error extraction logic. Through this PR we are aiming to fix it

## Notion Ticket

https://www.notion.so/rudderstacks/Research-Integrate-generic-errorMsg-extractor-in-rudder-transformer-6a6775b37c8241a49cf7bfb655f3bf8e?pvs=4

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
