### PR TITLE
chore: move suppression-backup-service from rudderlabs to rudderstack directory in dockerhub

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -106,8 +106,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            name=rudderlabs/develop-suppression-backup-service
-            name=rudderlabs/suppression-backup-service,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
+            name=rudderstack/develop-suppression-backup-service
+            name=rudderstack/suppression-backup-service,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
           tags: |
             type=ref,event=branch
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}


### PR DESCRIPTION
# Description
Since, `rudderlabs` is our open source organisation where the snyk dependency does not run.


## Notion Ticket

< Replace with Notion Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
