### PR TITLE
fix(router): using wrong partition tag in limiter stats

### DIFF
--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -214,7 +214,7 @@ func (rt *Handle) Setup(
 			for _, pstat := range allPStats {
 				statTags := stats.Tags{
 					"destType":  rt.destType,
-					"partition": key,
+					"partition": pstat.Partition,
 				}
 				stats.Default.NewTaggedStat("rt_"+key+"_limiter_stats_throughput", stats.GaugeType, statTags).Gauge(pstat.Throughput)
 				stats.Default.NewTaggedStat("rt_"+key+"_limiter_stats_errors", stats.GaugeType, statTags).Gauge(pstat.Errors)


### PR DESCRIPTION
# Description

Using the actual partition value for the partition tag

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=9677d2d1656745dab3c5a5137157f088&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
