### PR TITLE
chore: add missing index warehouse load files table

### DIFF
--- a/sql/migrations/warehouse/000023_alter_wh_add_index_wh_load_files.up.sql
+++ b/sql/migrations/warehouse/000023_alter_wh_add_index_wh_load_files.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS wh_load_files_staging_file_id_index ON wh_load_files (staging_file_id);


### PR DESCRIPTION
# Description
Dropped an INDEX in staging file id which was required for the archival queries. Reinstated the Index now

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/Remove-unused-indexes-for-warehouse-189a3d29f60247aca91035f5199e6cb4?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
