### PR TITLE
chore: source transformation failures stat

### DIFF
--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -474,8 +474,7 @@ func (webhook *HandleT) recordSourceTransformationErrors(reqs []*webhookT, statu
 		return request.writeKey
 	})
 
-	for _, reqs := range reqsGroupedByWriteKey {
-		writeKey := reqs[0].writeKey
+	for writeKey, reqs := range reqsGroupedByWriteKey {
 		webhook.countSourceTransformationErrors(writeKey, statusCode, len(reqs))
 	}
 }

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -381,7 +382,8 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 			}
 			pkgLogger.Errorf("webhook %s source transformation failed with error: %w and status code: %s", breq.sourceType, batchResponse.batchError, statusCode)
 			countWebhookErrors(breq.sourceType, statusCode, len(breq.batchRequest))
-			countSourceTransformationErrors(breq.sourceType, statusCode, len(breq.batchRequest))
+			bt.webhook.recordSourceTransformationErrors(webRequests, statusCode)
+
 			for _, req := range breq.batchRequest {
 				req.done <- transformerResponse{StatusCode: statusCode, Err: batchResponse.batchError.Error()}
 			}
@@ -397,7 +399,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 				outputPayload, err := json.Marshal(resp.Output)
 				if err != nil {
 					errMessage = response.SourceTransformerInvalidOutputFormatInResponse
-					countSourceTransformationErrors(breq.sourceType, response.GetErrorStatusCode(errMessage), 1)
+					bt.webhook.countSourceTransformationErrors(webRequest.writeKey, response.GetErrorStatusCode(errMessage), 1)
 				} else {
 					errMessage = bt.webhook.enqueueInGateway(webRequest, outputPayload)
 				}
@@ -410,7 +412,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 			} else if resp.StatusCode != http.StatusOK {
 				pkgLogger.Errorf("webhook %s source transformation failed with error: %s and status code: %s", breq.sourceType, resp.Err, resp.StatusCode)
 				countWebhookErrors(breq.sourceType, resp.StatusCode, 1)
-				countSourceTransformationErrors(breq.sourceType, resp.StatusCode, 1)
+				bt.webhook.countSourceTransformationErrors(webRequest.writeKey, resp.StatusCode, 1)
 			}
 
 			webRequest.done <- resp
@@ -467,10 +469,25 @@ func countWebhookErrors(sourceType string, statusCode, count int) {
 	}).Count(count)
 }
 
-func countSourceTransformationErrors(sourceType string, statusCode, count int) {
-	stats.Default.NewTaggedStat("source_transformation_errors", stats.CountType, stats.Tags{
-		"sourceType": sourceType,
-		"statusCode": strconv.Itoa(statusCode),
+func (webhook *HandleT) recordSourceTransformationErrors(reqs []*webhookT, statusCode int) {
+	reqsGroupedByWriteKey := lo.GroupBy(reqs, func(request *webhookT) string {
+		return request.writeKey
+	})
+
+	for _, reqs := range reqsGroupedByWriteKey {
+		writeKey := reqs[0].writeKey
+		webhook.countSourceTransformationErrors(writeKey, statusCode, len(reqs))
+	}
+}
+
+func (webhook *HandleT) countSourceTransformationErrors(writeKey string, statusCode, count int) {
+	stat := webhook.gwHandle.NewSourceStat(writeKey, "webhook")
+	webhook.stats.NewTaggedStat("source_transformation_errors", stats.CountType, stats.Tags{
+		"writeKey":    writeKey,
+		"workspaceId": stat.WorkspaceID,
+		"sourceID":    stat.SourceID,
+		"statusCode":  strconv.Itoa(statusCode),
+		"sourceType":  stat.SourceType,
 	}).Count(count)
 }
 

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -66,7 +66,7 @@ func TestWebhookRequestHandlerWithTransformerBatchGeneralError(t *testing.T) {
 	mockGW.EXPECT().IncrementAckCount(gomock.Any()).Times(1)
 	mockGW.EXPECT().GetWebhookSourceDefName(sampleWriteKey).Return(sourceDefName, true)
 	mockGW.EXPECT().TrackRequestMetrics(gomock.Any()).Times(1)
-	mockGW.EXPECT().NewSourceStat(gomock.Any(), gomock.Any()).Return(&gwStats.SourceStat{}).Times(1)
+	mockGW.EXPECT().NewSourceStat(gomock.Any(), gomock.Any()).Return(&gwStats.SourceStat{}).Times(2)
 
 	webhookHandler.Register(sourceDefName)
 	req := httptest.NewRequest(http.MethodPost, "/v1/webhook?writeKey="+sampleWriteKey, bytes.NewBufferString(sampleJson))
@@ -107,7 +107,7 @@ func TestWebhookRequestHandlerWithTransformerBatchPayloadLengthMismatchError(t *
 	mockGW.EXPECT().IncrementAckCount(gomock.Any()).Times(1)
 	mockGW.EXPECT().GetWebhookSourceDefName(sampleWriteKey).Return(sourceDefName, true)
 	mockGW.EXPECT().TrackRequestMetrics(gomock.Any()).Times(1)
-	mockGW.EXPECT().NewSourceStat(gomock.Any(), gomock.Any()).Return(&gwStats.SourceStat{}).Times(1)
+	mockGW.EXPECT().NewSourceStat(gomock.Any(), gomock.Any()).Return(&gwStats.SourceStat{}).Times(2)
 
 	webhookHandler.Register(sourceDefName)
 	req := httptest.NewRequest(http.MethodPost, "/v1/webhook?writeKey="+sampleWriteKey, bytes.NewBufferString(sampleJson))
@@ -147,7 +147,7 @@ func TestWebhookRequestHandlerWithTransformerRequestError(t *testing.T) {
 	mockGW.EXPECT().IncrementAckCount(gomock.Any()).Times(1)
 	mockGW.EXPECT().GetWebhookSourceDefName(sampleWriteKey).Return(sourceDefName, true)
 	mockGW.EXPECT().TrackRequestMetrics(gomock.Any()).Times(1)
-	mockGW.EXPECT().NewSourceStat(gomock.Any(), gomock.Any()).Return(&gwStats.SourceStat{}).Times(1)
+	mockGW.EXPECT().NewSourceStat(gomock.Any(), gomock.Any()).Return(&gwStats.SourceStat{}).Times(2)
 
 	webhookHandler.Register(sourceDefName)
 	req := httptest.NewRequest(http.MethodPost, "/v1/webhook?writeKey="+sampleWriteKey, bytes.NewBufferString(sampleJson))

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -293,7 +293,7 @@ func TestRecordSourceTransformationErrors(t *testing.T) {
 	reqs := []*webhookT{
 		{writeKey: "w1"}, {writeKey: "w2"}, {writeKey: "w1"}, {writeKey: "w3"}, {writeKey: "w2"}, {writeKey: "w1"},
 	}
-	mockGW.EXPECT().NewSourceStat(gomock.Any(), gomock.Any()).DoAndReturn(func(writeKey string, reqType string) *gwStats.SourceStat {
+	mockGW.EXPECT().NewSourceStat(gomock.Any(), gomock.Any()).DoAndReturn(func(writeKey, reqType string) *gwStats.SourceStat {
 		if writeKey == "w1" {
 			return &gwStats.SourceStat{
 				Source:      "source1",

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -294,8 +294,8 @@ func TestRecordSourceTransformationErrors(t *testing.T) {
 		{writeKey: "w1"}, {writeKey: "w2"}, {writeKey: "w1"}, {writeKey: "w3"}, {writeKey: "w2"}, {writeKey: "w1"},
 	}
 	mockGW.EXPECT().NewSourceStat(gomock.Any(), gomock.Any()).DoAndReturn(func(writeKey, reqType string) *gwStats.SourceStat {
-        switch writeKey {
-        case "w1":
+		switch writeKey {
+		case "w1":
 			return &gwStats.SourceStat{
 				Source:      "source1",
 				SourceID:    "sourceID1",
@@ -304,7 +304,7 @@ func TestRecordSourceTransformationErrors(t *testing.T) {
 				WorkspaceID: "workspaceID1",
 				SourceType:  "webhook1",
 			}
-        case "w2":
+		case "w2":
 			return &gwStats.SourceStat{
 				Source:      "source2",
 				SourceID:    "sourceID2",
@@ -313,7 +313,7 @@ func TestRecordSourceTransformationErrors(t *testing.T) {
 				WorkspaceID: "workspaceID2",
 				SourceType:  "webhook2",
 			}
-        case "w3":
+		case "w3":
 			return &gwStats.SourceStat{
 				Source:      "source3",
 				SourceID:    "sourceID3",

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -294,7 +294,8 @@ func TestRecordSourceTransformationErrors(t *testing.T) {
 		{writeKey: "w1"}, {writeKey: "w2"}, {writeKey: "w1"}, {writeKey: "w3"}, {writeKey: "w2"}, {writeKey: "w1"},
 	}
 	mockGW.EXPECT().NewSourceStat(gomock.Any(), gomock.Any()).DoAndReturn(func(writeKey, reqType string) *gwStats.SourceStat {
-		if writeKey == "w1" {
+        switch writeKey {
+        case "w1":
 			return &gwStats.SourceStat{
 				Source:      "source1",
 				SourceID:    "sourceID1",
@@ -303,7 +304,7 @@ func TestRecordSourceTransformationErrors(t *testing.T) {
 				WorkspaceID: "workspaceID1",
 				SourceType:  "webhook1",
 			}
-		} else if writeKey == "w2" {
+        case "w2":
 			return &gwStats.SourceStat{
 				Source:      "source2",
 				SourceID:    "sourceID2",
@@ -312,7 +313,7 @@ func TestRecordSourceTransformationErrors(t *testing.T) {
 				WorkspaceID: "workspaceID2",
 				SourceType:  "webhook2",
 			}
-		} else if writeKey == "w3" {
+        case "w3":
 			return &gwStats.SourceStat{
 				Source:      "source3",
 				SourceID:    "sourceID3",


### PR DESCRIPTION
# Description

Add a metric to count the number of source transformation errors.

We currently have webhook_num_errors metric. But this is not a true depiction of number of errors occurring during source transformation. Alerts defined on webhook_num_errors are noisy. This metric is added to prevent the alert noise on source transformation errors.

## Notion Ticket

https://www.notion.so/rudderstacks/d5d15ce4be354e3caae11d4ea9f41477?v=2ad23dce1aeb431a82f783e6607d3cb0&p=79b89517ca0b47c39074944b922d6971&pm=c

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
