### PR TITLE
fix(gateway): use get method for /fetch-tables

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1331,7 +1331,7 @@ func (gateway *HandleT) StartWebHandler(ctx context.Context) error {
 			r.Post("/pending-events", gateway.whProxy.ServeHTTP)
 			r.Post("/trigger-upload", gateway.whProxy.ServeHTTP)
 			r.Post("/jobs", gateway.whProxy.ServeHTTP)
-			r.Post("/fetch-tables", gateway.whProxy.ServeHTTP)
+			r.Get("/fetch-tables", gateway.whProxy.ServeHTTP)
 
 			r.Get("/jobs/status", gateway.whProxy.ServeHTTP)
 		})

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1250,6 +1250,7 @@ func endpointsToVerify() ([]string, []string, []string) {
 		"/v1/job-status/123",
 		"/v1/job-status/123/failed-records",
 		"/v1/warehouse/jobs/status",
+		"/v1/warehouse/fetch-tables",
 	}
 
 	postEndpoints := []string{
@@ -1269,7 +1270,6 @@ func endpointsToVerify() ([]string, []string, []string) {
 		"/v1/warehouse/pending-events",
 		"/v1/warehouse/trigger-upload",
 		"/v1/warehouse/jobs",
-		"/v1/warehouse/fetch-tables",
 	}
 
 	deleteEndpoints := []string{


### PR DESCRIPTION
# Description

Fix the HTTP method for the warehouse `/fetch-tables` endpoint. It should be `GET` 


## Notion Ticket

[ticket](https://www.notion.so/rudderstacks/Fix-for-warehouse-endpoint-for-fetching-endpoints-0b86acfaa10c494587259a45ab17c6c9)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

