### PR TITLE
chore: increase golangci lint execution timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 5m
+  timeout: 7m
   go: '1.20'
   skip-dirs:
     - enterprise


### PR DESCRIPTION
# Description

Increase lint timeout to prevent github [actions](https://github.com/rudderlabs/rudder-server/actions/runs/5344164222/jobs/9688210263?pr=3536) from failing:

<img width="1291" alt="Screenshot 2023-06-22 at 12 50 10 PM" src="https://github.com/rudderlabs/rudder-server/assets/733195/e40ec9b5-1593-49c3-8111-46e1a43d2604">


## Notion Ticket

https://www.notion.so/rudderstacks/inc-lint-timeout-2effb94a84444f6aaaaad79d982ad33f?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
