### PR TITLE
chore(gateway): move warehouse fetch tables under internal

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1332,6 +1332,7 @@ func (gateway *HandleT) StartWebHandler(ctx context.Context) error {
 			r.Post("/pending-events", gateway.whProxy.ServeHTTP)
 			r.Post("/trigger-upload", gateway.whProxy.ServeHTTP)
 			r.Post("/jobs", gateway.whProxy.ServeHTTP)
+			/// TODO: Remove this endpoint once sources chaneage is released
 			r.Get("/fetch-tables", gateway.whProxy.ServeHTTP)
 
 			r.Get("/jobs/status", gateway.whProxy.ServeHTTP)

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1332,7 +1332,7 @@ func (gateway *HandleT) StartWebHandler(ctx context.Context) error {
 			r.Post("/pending-events", gateway.whProxy.ServeHTTP)
 			r.Post("/trigger-upload", gateway.whProxy.ServeHTTP)
 			r.Post("/jobs", gateway.whProxy.ServeHTTP)
-			/// TODO: Remove this endpoint once sources chaneage is released
+			// TODO: Remove this endpoint once sources change is released
 			r.Get("/fetch-tables", gateway.whProxy.ServeHTTP)
 
 			r.Get("/jobs/status", gateway.whProxy.ServeHTTP)

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1310,6 +1310,7 @@ func (gateway *HandleT) StartWebHandler(ctx context.Context) error {
 	)
 	srvMux.Route("/internal", func(r chi.Router) {
 		r.Post("/v1/extract", gateway.webExtractHandler)
+		r.Get("/v1/warehouse/fetch-tables", gateway.whProxy.ServeHTTP)
 	})
 
 	srvMux.Route("/v1", func(r chi.Router) {

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1250,7 +1250,9 @@ func endpointsToVerify() ([]string, []string, []string) {
 		"/v1/job-status/123",
 		"/v1/job-status/123/failed-records",
 		"/v1/warehouse/jobs/status",
+		// TODO: Remove this endpoint once sources change is released
 		"/v1/warehouse/fetch-tables",
+		"/internal/v1/warehouse/fetch-tables",
 	}
 
 	postEndpoints := []string{

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -1571,7 +1571,7 @@ func startWebHandler(ctx context.Context) error {
 			srvMux.Get("/v1/warehouse/jobs/status", asyncWh.StatusWarehouseJobHandler) // FIXME: add degraded mode
 
 			// fetch schema info
-			/// TODO: Remove this endpoint once sources chaneage is released
+			// TODO: Remove this endpoint once sources change is released
 			srvMux.Get("/v1/warehouse/fetch-tables", fetchTablesHandler)
 			srvMux.Get("/internal/v1/warehouse/fetch-tables", fetchTablesHandler)
 

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -1571,6 +1571,7 @@ func startWebHandler(ctx context.Context) error {
 			srvMux.Get("/v1/warehouse/jobs/status", asyncWh.StatusWarehouseJobHandler) // FIXME: add degraded mode
 
 			// fetch schema info
+			/// TODO: Remove this endpoint once sources chaneage is released
 			srvMux.Get("/v1/warehouse/fetch-tables", fetchTablesHandler)
 			srvMux.Get("/internal/v1/warehouse/fetch-tables", fetchTablesHandler)
 

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -1572,6 +1572,7 @@ func startWebHandler(ctx context.Context) error {
 
 			// fetch schema info
 			srvMux.Get("/v1/warehouse/fetch-tables", fetchTablesHandler)
+			srvMux.Get("/internal/v1/warehouse/fetch-tables", fetchTablesHandler)
 
 			pkgLogger.Infof("WH: Starting warehouse master service in %d", webPort)
 		} else {


### PR DESCRIPTION
# Description

Move warehouse fetch tables under internal.

## Notion Ticket

[ticket](https://www.notion.so/rudderstacks/Move-fetch-tables-endpoint-to-internal-endpoints-117e9b2261b54f51817b64d6ada285cb)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
