### PR TITLE
chore: source transformation failures stat tag correction

### DIFF
--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -399,6 +399,10 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 				outputPayload, err := json.Marshal(resp.Output)
 				if err != nil {
 					errMessage = response.SourceTransformerInvalidOutputFormatInResponse
+					stats.Default.NewTaggedStat(`source.transformer.invalid.response`, stats.CountType, stats.Tags{
+						"sourceType": breq.sourceType,
+						"writeKey":   webRequest.writeKey,
+					}).Increment()
 					bt.webhook.countSourceTransformationErrors(breq.sourceType, webRequest.writeKey, response.GetErrorStatusCode(errMessage), 1)
 				} else {
 					errMessage = bt.webhook.enqueueInGateway(webRequest, outputPayload)

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -382,7 +382,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 			}
 			pkgLogger.Errorf("webhook %s source transformation failed with error: %w and status code: %s", breq.sourceType, batchResponse.batchError, statusCode)
 			countWebhookErrors(breq.sourceType, statusCode, len(breq.batchRequest))
-			bt.webhook.recordSourceTransformationErrors(webRequests, statusCode)
+			bt.webhook.recordSourceTransformationErrors(breq.sourceType, webRequests, statusCode)
 
 			for _, req := range breq.batchRequest {
 				req.done <- transformerResponse{StatusCode: statusCode, Err: batchResponse.batchError.Error()}
@@ -399,7 +399,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 				outputPayload, err := json.Marshal(resp.Output)
 				if err != nil {
 					errMessage = response.SourceTransformerInvalidOutputFormatInResponse
-					bt.webhook.countSourceTransformationErrors(webRequest.writeKey, response.GetErrorStatusCode(errMessage), 1)
+					bt.webhook.countSourceTransformationErrors(breq.sourceType, webRequest.writeKey, response.GetErrorStatusCode(errMessage), 1)
 				} else {
 					errMessage = bt.webhook.enqueueInGateway(webRequest, outputPayload)
 				}
@@ -412,7 +412,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 			} else if resp.StatusCode != http.StatusOK {
 				pkgLogger.Errorf("webhook %s source transformation failed with error: %s and status code: %s", breq.sourceType, resp.Err, resp.StatusCode)
 				countWebhookErrors(breq.sourceType, resp.StatusCode, 1)
-				bt.webhook.countSourceTransformationErrors(webRequest.writeKey, resp.StatusCode, 1)
+				bt.webhook.countSourceTransformationErrors(breq.sourceType, webRequest.writeKey, resp.StatusCode, 1)
 			}
 
 			webRequest.done <- resp
@@ -469,24 +469,24 @@ func countWebhookErrors(sourceType string, statusCode, count int) {
 	}).Count(count)
 }
 
-func (webhook *HandleT) recordSourceTransformationErrors(reqs []*webhookT, statusCode int) {
+func (webhook *HandleT) recordSourceTransformationErrors(sourceType string, reqs []*webhookT, statusCode int) {
 	reqsGroupedByWriteKey := lo.GroupBy(reqs, func(request *webhookT) string {
 		return request.writeKey
 	})
 
 	for writeKey, reqs := range reqsGroupedByWriteKey {
-		webhook.countSourceTransformationErrors(writeKey, statusCode, len(reqs))
+		webhook.countSourceTransformationErrors(sourceType, writeKey, statusCode, len(reqs))
 	}
 }
 
-func (webhook *HandleT) countSourceTransformationErrors(writeKey string, statusCode, count int) {
+func (webhook *HandleT) countSourceTransformationErrors(sourceType, writeKey string, statusCode, count int) {
 	stat := webhook.gwHandle.NewSourceStat(writeKey, "webhook")
 	webhook.stats.NewTaggedStat("source_transformation_errors", stats.CountType, stats.Tags{
 		"writeKey":    writeKey,
 		"workspaceId": stat.WorkspaceID,
 		"sourceID":    stat.SourceID,
 		"statusCode":  strconv.Itoa(statusCode),
-		"sourceType":  stat.SourceType,
+		"sourceType":  sourceType,
 	}).Count(count)
 }
 

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -326,14 +326,14 @@ func TestRecordSourceTransformationErrors(t *testing.T) {
 		return nil
 	}).Times(3)
 
-	webhookHandler.recordSourceTransformationErrors(reqs, 400)
+	webhookHandler.recordSourceTransformationErrors("cio", reqs, 400)
 
 	m := statsStore.Get("source_transformation_errors", stats.Tags{
 		"writeKey":    "w1",
 		"workspaceId": "workspaceID1",
 		"sourceID":    "sourceID1",
 		"statusCode":  "400",
-		"sourceType":  "webhook1",
+		"sourceType":  "cio",
 	})
 	require.EqualValues(t, m.LastValue(), 3)
 	m = statsStore.Get("source_transformation_errors", stats.Tags{
@@ -341,7 +341,7 @@ func TestRecordSourceTransformationErrors(t *testing.T) {
 		"workspaceId": "workspaceID2",
 		"sourceID":    "sourceID2",
 		"statusCode":  "400",
-		"sourceType":  "webhook2",
+		"sourceType":  "cio",
 	})
 	require.EqualValues(t, m.LastValue(), 2)
 	m = statsStore.Get("source_transformation_errors", stats.Tags{
@@ -349,7 +349,7 @@ func TestRecordSourceTransformationErrors(t *testing.T) {
 		"workspaceId": "workspaceID3",
 		"sourceID":    "sourceID3",
 		"statusCode":  "400",
-		"sourceType":  "webhook3",
+		"sourceType":  "cio",
 	})
 	require.EqualValues(t, m.LastValue(), 1)
 }

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -284,7 +284,7 @@ func TestWebhookRequestHandlerWithOutputToGatewayAndSource(t *testing.T) {
 	_ = webhookHandler.Shutdown()
 }
 
-func TestRecordSourceTransformationErrors(t *testing.T) {
+func TestRecordWebhookErrors(t *testing.T) {
 	initWebhook()
 	ctrl := gomock.NewController(t)
 	mockGW := mockWebhook.NewMockGatewayI(ctrl)
@@ -326,30 +326,33 @@ func TestRecordSourceTransformationErrors(t *testing.T) {
 		return nil
 	}).Times(3)
 
-	webhookHandler.recordSourceTransformationErrors("cio", reqs, 400)
+	webhookHandler.recordWebhookErrors("cio", "err1", reqs, 400)
 
-	m := statsStore.Get("source_transformation_errors", stats.Tags{
+	m := statsStore.Get("webhook_num_errors", stats.Tags{
 		"writeKey":    "w1",
 		"workspaceId": "workspaceID1",
 		"sourceID":    "sourceID1",
 		"statusCode":  "400",
 		"sourceType":  "cio",
+		"reason":      "err1",
 	})
 	require.EqualValues(t, m.LastValue(), 3)
-	m = statsStore.Get("source_transformation_errors", stats.Tags{
+	m = statsStore.Get("webhook_num_errors", stats.Tags{
 		"writeKey":    "w2",
 		"workspaceId": "workspaceID2",
 		"sourceID":    "sourceID2",
 		"statusCode":  "400",
 		"sourceType":  "cio",
+		"reason":      "err1",
 	})
 	require.EqualValues(t, m.LastValue(), 2)
-	m = statsStore.Get("source_transformation_errors", stats.Tags{
+	m = statsStore.Get("webhook_num_errors", stats.Tags{
 		"writeKey":    "w3",
 		"workspaceId": "workspaceID3",
 		"sourceID":    "sourceID3",
 		"statusCode":  "400",
 		"sourceType":  "cio",
+		"reason":      "err1",
 	})
 	require.EqualValues(t, m.LastValue(), 1)
 }


### PR DESCRIPTION
# Description

Got rid of recently introduced `source_transformation_errors` metric and using the existing `webhook_num_errors` metric after enriching the `webhook_num_errors` metric with more labels. This (reason label) makes debugging the webhook errors easy.

## Notion Ticket

https://www.notion.so/rudderstacks/d5d15ce4be354e3caae11d4ea9f41477?v=2ad23dce1aeb431a82f783e6607d3cb0&p=79b89517ca0b47c39074944b922d6971&pm=c

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
