### PR TITLE
chore: drop attempt_number tag from metrics

### DIFF
--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -581,7 +581,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 	connectionDetailsMap := make(map[string]*types.ConnectionDetails)
 	transformedAtMap := make(map[string]string)
 	statusDetailsMap := make(map[string]*types.StatusDetail)
-	jobStateCounts := make(map[string]map[string]int)
+	jobStateCounts := make(map[string]int)
 	for _, job := range batchJobs.Jobs {
 		jobState := batchJobState
 		var firstAttemptedAt time.Time
@@ -647,10 +647,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 			WorkspaceId:   job.WorkspaceId,
 		}
 		statusList = append(statusList, &status)
-		if jobStateCounts[jobState] == nil {
-			jobStateCounts[jobState] = make(map[string]int)
-		}
-		jobStateCounts[jobState][strconv.Itoa(attemptNum)] = jobStateCounts[jobState][strconv.Itoa(attemptNum)] + 1
+		jobStateCounts[jobState] = jobStateCounts[jobState] + 1
 
 		// REPORTING - START
 		if brt.reporting != nil && brt.reportingEnabled {

--- a/router/batchrouter/handle_observability.go
+++ b/router/batchrouter/handle_observability.go
@@ -52,7 +52,7 @@ func (brt *Handle) collectMetrics(ctx context.Context) {
 	}
 }
 
-func sendDestStatusStats(batchDestination *Connection, jobStateCounts map[string]map[string]int, destType string, isWarehouse bool) {
+func sendDestStatusStats(batchDestination *Connection, jobStateCounts map[string]int, destType string, isWarehouse bool) {
 	tags := map[string]string{
 		"module":        "batch_router",
 		"destType":      destType,
@@ -61,14 +61,9 @@ func sendDestStatusStats(batchDestination *Connection, jobStateCounts map[string
 		"sourceId":      misc.GetTagName(batchDestination.Source.ID, batchDestination.Source.Name),
 	}
 
-	for jobState, countByAttemptMap := range jobStateCounts {
+	for jobState, count := range jobStateCounts {
 		tags["job_state"] = jobState
-		for attempt, count := range countByAttemptMap {
-			tags["attempt_number"] = attempt
-			if count > 0 {
-				stats.Default.NewTaggedStat("event_status", stats.CountType, tags).Count(count)
-			}
-		}
+		stats.Default.NewTaggedStat("event_status", stats.CountType, tags).Count(count)
 	}
 }
 

--- a/router/worker.go
+++ b/router/worker.go
@@ -816,7 +816,6 @@ func (w *worker) sendRouterResponseCountStat(status *jobsdb.JobStatusT, destinat
 		"respStatusCode": status.ErrorCode,
 		"destination":    destinationTag,
 		"destId":         destination.ID,
-		"attempt_number": strconv.Itoa(status.AttemptNum),
 		"workspaceId":    status.WorkspaceId,
 		// To indicate if the failure should be alerted for router-aborted-count
 		"alert": strconv.FormatBool(alert),
@@ -830,13 +829,12 @@ func (w *worker) sendEventDeliveryStat(destinationJobMetadata *types.JobMetadata
 	destinationTag := misc.GetTagName(destination.ID, destination.Name)
 	if status.JobState == jobsdb.Succeeded.State {
 		eventsDeliveredStat := stats.Default.NewTaggedStat("event_delivery", stats.CountType, stats.Tags{
-			"module":         "router",
-			"destType":       w.rt.destType,
-			"destID":         destination.ID,
-			"destination":    destinationTag,
-			"attempt_number": strconv.Itoa(status.AttemptNum),
-			"workspaceId":    status.WorkspaceId,
-			"source":         destinationJobMetadata.SourceID,
+			"module":      "router",
+			"destType":    w.rt.destType,
+			"destID":      destination.ID,
+			"destination": destinationTag,
+			"workspaceId": status.WorkspaceId,
+			"source":      destinationJobMetadata.SourceID,
 		})
 		eventsDeliveredStat.Count(1)
 		if destinationJobMetadata.ReceivedAt != "" {
@@ -844,12 +842,11 @@ func (w *worker) sendEventDeliveryStat(destinationJobMetadata *types.JobMetadata
 			if err == nil {
 				eventsDeliveryTimeStat := stats.Default.NewTaggedStat(
 					"event_delivery_time", stats.TimerType, map[string]string{
-						"module":         "router",
-						"destType":       w.rt.destType,
-						"destID":         destination.ID,
-						"destination":    destinationTag,
-						"attempt_number": strconv.Itoa(status.AttemptNum),
-						"workspaceId":    status.WorkspaceId,
+						"module":      "router",
+						"destType":    w.rt.destType,
+						"destID":      destination.ID,
+						"destination": destinationTag,
+						"workspaceId": status.WorkspaceId,
 					})
 
 				eventsDeliveryTimeStat.SendTiming(time.Since(receivedTime))

--- a/services/diagnostics/diagnostics.go
+++ b/services/diagnostics/diagnostics.go
@@ -26,7 +26,6 @@ const (
 	RouterSuccess          = "router_success"
 	RouterFailed           = "router_failed"
 	RouterDestination      = "router_destination"
-	RouterAttemptNum       = "router_attempt_num"
 	RouterCompletedTime    = "router_average_job_time"
 	BatchRouterEvents      = "batch_router_events"
 	BatchRouterSuccess     = "batch_router_success"


### PR DESCRIPTION
# Description

Removing the `attempt_number` tag as this can cause serious metric cardinality issues.

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=47b856c6a77542b4bf3ffbe3aca5ef75&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
