### PR TITLE
chore: standardize warehouse timeout config name

### DIFF
--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -1003,16 +1003,10 @@ func ReadAsBool(key string, config map[string]interface{}) bool {
 	return false
 }
 
-func WithTimeout(ctx context.Context, timeout time.Duration, function func(context.Context) error) error {
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	return function(ctxWithTimeout)
-}
-
 func GetConnectionTimeout(destType, destID string) time.Duration {
-	destIDLevelConfig := fmt.Sprintf("warehouse.%s.%s.connectionTimeout", destType, destID)
-	destTypeLevelConfig := fmt.Sprintf("warehouse.%s.connectionTimeout", destType)
-	warehouseLevelConfig := "warehouse.connectionTimeout"
+	destIDLevelConfig := fmt.Sprintf("Warehouse.%s.%s.connectionTimeout", destType, destID)
+	destTypeLevelConfig := fmt.Sprintf("Warehouse.%s.connectionTimeout", destType)
+	warehouseLevelConfig := "Warehouse.connectionTimeout"
 
 	defaultTimeout := int64(3)
 	defaultTimeoutUnits := time.Hour


### PR DESCRIPTION
# Description

edit warehouse timeout config name to maintain consistency.

## Notion Ticket

[warehouse timeout](https://www.notion.so/rudderstacks/Timeout-for-all-SQL-queries-in-warehouse-7fb3196d38684ef483079f971c7719f4?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
