### PR TITLE
chore: gateway_response_time buckets

### DIFF
--- a/integration_test/kafka_batching/kafka_batching_test.go
+++ b/integration_test/kafka_batching/kafka_batching_test.go
@@ -319,7 +319,7 @@ func TestKafkaBatching(t *testing.T) {
 			{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(2.5)},
 			{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(5.0)},
 			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(10.0)}, // 10 is the number of messages we sent
-			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(30.0)}, // 10 is the number of messages we sent
+			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(30.0)},
 			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(60.0)},
 			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(300.0)},
 			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(600.0)},

--- a/integration_test/kafka_batching/kafka_batching_test.go
+++ b/integration_test/kafka_batching/kafka_batching_test.go
@@ -307,6 +307,7 @@ func TestKafkaBatching(t *testing.T) {
 	requireHistogramEqual(t, metrics["router_kafka_batch_size"], histogram{
 		name: "router_kafka_batch_size", count: 1, sum: 10,
 		buckets: []*promClient.Bucket{
+			{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(0.002)},
 			{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(0.005)},
 			{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(0.01)},
 			{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(0.025)},
@@ -318,16 +319,11 @@ func TestKafkaBatching(t *testing.T) {
 			{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(2.5)},
 			{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(5.0)},
 			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(10.0)}, // 10 is the number of messages we sent
+			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(30.0)}, // 10 is the number of messages we sent
 			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(60.0)},
 			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(300.0)},
 			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(600.0)},
 			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(1800.0)},
-			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(10800.0)},
-			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(36000.0)},
-			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(86400.0)},
-			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(259200.0)},
-			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(604800.0)},
-			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(1209600.0)},
 			{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(math.Inf(1))},
 		},
 		labels: expectedDefaultAttrs,

--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -1,0 +1,8 @@
+package runner
+
+var customBuckets = map[string][]float64{
+	"gateway.response_time": {
+		0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60,
+		300, /* 5 mins */
+	},
+}

--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -3,6 +3,5 @@ package runner
 var customBuckets = map[string][]float64{
 	"gateway.response_time": {
 		0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60,
-		300, /* 5 mins */
 	},
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -55,11 +55,17 @@ import (
 	"github.com/rudderlabs/rudder-server/warehouse/validations"
 )
 
-var defaultHistogramBuckets = []float64{
-	0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60,
-	300 /* 5 mins */, 600 /* 10 mins */, 1800 /* 30 mins */, 10800 /* 3 hours */, 36000, /* 10 hours */
-	86400 /* 1 day */, 259200 /* 3 days */, 604800 /* 7 days */, 1209600, /* 2 weeks */
-}
+var (
+	defaultHistogramBuckets = []float64{
+		0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60,
+		300 /* 5 mins */, 600 /* 10 mins */, 1800, /* 30 mins */
+	}
+	defaultWarehouseHistogramBuckets = []float64{
+		0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60,
+		300 /* 5 mins */, 600 /* 10 mins */, 1800 /* 30 mins */, 10800 /* 3 hours */, 36000, /* 10 hours */
+		86400 /* 1 day */, 259200 /* 3 days */, 604800 /* 7 days */, 1209600, /* 2 weeks */
+	}
+)
 
 // ReleaseInfo holds the release information
 type ReleaseInfo struct {
@@ -133,7 +139,11 @@ func (r *Runner) Run(ctx context.Context, args []string) int {
 	statsOptions := []stats.Option{
 		stats.WithServiceName(r.appType),
 		stats.WithServiceVersion(r.releaseInfo.Version),
-		stats.WithDefaultHistogramBuckets(defaultHistogramBuckets),
+	}
+	if r.canStartWarehouse() {
+		statsOptions = append(statsOptions, stats.WithDefaultHistogramBuckets(defaultWarehouseHistogramBuckets))
+	} else {
+		statsOptions = append(statsOptions, stats.WithDefaultHistogramBuckets(defaultHistogramBuckets))
 	}
 	for histogramName, buckets := range customBuckets {
 		statsOptions = append(statsOptions, stats.WithHistogramBuckets(histogramName, buckets))


### PR DESCRIPTION
# Description

I don't think we need as many buckets as we do by default for the `gateway_response_time metric`. This task is to keep only the relevant buckets.

I propose we remove the boundaries for requests that take longer than 5 minutes. Data wise, knowing that it takes even longer isn't helpful in my opinion and we should try to avoid anything that goes above 1 minute and possibly look into anything that goes above 5.

Screenshot from `prousmt`:
![Screenshot from 2023-06-27 11-19-04](https://github.com/rudderlabs/rudder-server/assets/1288256/68d3499d-9f79-44a4-8c76-41ed1210ac1c)

Tested locally:
![Screenshot from 2023-06-27 14-59-57](https://github.com/rudderlabs/rudder-server/assets/1288256/327ac8ca-6b6d-467a-a048-ad823755e63b)

Let me know if the boundaries make sense to you and if you think we should have different ones.
Also, if you think we should do the same with other metrics we might as well add them here.

## Notion Ticket

< [Notion Link](https://www.notion.so/rudderstacks/gw-response-time-buckets-9ff53d3d1a334d359c61b5e914825a5d) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
