### PR TITLE
chore(jobsdb): dsList lock performance improvements

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -669,7 +669,7 @@ func loadConfig() {
 	*/
 	config.RegisterFloat64ConfigVariable(0.8, &jobDoneMigrateThres, true, "JobsDB.jobDoneMigrateThres")
 	config.RegisterFloat64ConfigVariable(3, &jobStatusMigrateThres, true, "JobsDB.jobStatusMigrateThres")
-	config.RegisterFloat64ConfigVariable(0.05, &jobMinRowsMigrateThres, true, "JobsDB.jobMinRowsMigrateThres")
+	config.RegisterFloat64ConfigVariable(0.2, &jobMinRowsMigrateThres, true, "JobsDB.jobMinRowsMigrateThres")
 	config.RegisterIntConfigVariable(100000, &maxDSSize, true, 1, "JobsDB.maxDSSize")
 	config.RegisterIntConfigVariable(10, &maxMigrateOnce, true, 1, "JobsDB.maxMigrateOnce")
 	config.RegisterIntConfigVariable(10, &maxMigrateDSProbe, true, 1, "JobsDB.maxMigrateDSProbe")

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -670,7 +670,7 @@ func loadConfig() {
 	config.RegisterDurationConfigVariable(5, &addNewDSLoopSleepDuration, true, time.Second, []string{"JobsDB.addNewDSLoopSleepDuration", "JobsDB.addNewDSLoopSleepDurationInS"}...)
 	config.RegisterDurationConfigVariable(5, &refreshDSListLoopSleepDuration, true, time.Second, []string{"JobsDB.refreshDSListLoopSleepDuration", "JobsDB.refreshDSListLoopSleepDurationInS"}...)
 	config.RegisterDurationConfigVariable(5, &backupCheckSleepDuration, true, time.Second, []string{"JobsDB.backupCheckSleepDuration", "JobsDB.backupCheckSleepDurationIns"}...)
-	config.RegisterDurationConfigVariable(10, &cacheExpiration, true, time.Minute, []string{"JobsDB.cacheExpiration"}...)
+	config.RegisterDurationConfigVariable(60, &cacheExpiration, true, time.Minute, []string{"JobsDB.cacheExpiration"}...)
 	config.RegisterDurationConfigVariable(24, &jobCleanupFrequency, true, time.Hour, []string{"JobsDB.jobCleanupFrequency"}...)
 	config.RegisterBoolConfigVariable(false, &jobStatusCountMigrationCheck, true, "JobsDB.jobStatusCountMigrationCheck")
 }

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -2565,8 +2565,10 @@ func (jd *HandleT) addNewDSLoop(ctx context.Context) {
 				return fmt.Errorf("addNewDSLoop: %w", err)
 			}
 			// to get the updated DS list in the cache after createDS transaction has been committed.
-			if err = jd.refreshDSRangeList(dsListLock); err != nil {
-				return fmt.Errorf("refreshDSRangeList: %w", err)
+			if dsListLock != nil {
+				if err = jd.refreshDSRangeList(dsListLock); err != nil {
+					return fmt.Errorf("refreshDSRangeList: %w", err)
+				}
 			}
 			return nil
 		}

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -873,7 +873,7 @@ func (jd *HandleT) init() {
 				jd.runAlwaysChangesets(templateData)
 
 				// finally refresh the dataset list to make sure [datasetList] field is populated
-				_, err := jd.doRefreshDSList(l)
+				err := jd.doRefreshDSRangeList(l)
 				jd.assertError(err)
 			})
 			return nil
@@ -1703,7 +1703,7 @@ func (jd *HandleT) inStoreSafeCtx(ctx context.Context, f func() error) error {
 		if err != nil && errors.Is(err, errStaleDsList) {
 			jd.logger.Errorf("[JobsDB] :: Store failed: %v. Retrying after refreshing DS cache", errStaleDsList)
 			if err := jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
-				_, err = jd.doRefreshDSList(l)
+				err = jd.doRefreshDSRangeList(l)
 				if err != nil {
 					return fmt.Errorf("refreshing ds list: %w", err)
 				}

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1863,8 +1863,8 @@ func (jd *HandleT) GetPileUpCounts(ctx context.Context) (map[string]map[string]i
 	if !jd.dsListLock.RTryLockWithCtx(ctx) {
 		return nil, fmt.Errorf("could not acquire a dslist read lock: %w", ctx.Err())
 	}
-	defer jd.dsListLock.RUnlock()
 	dsList := jd.getDSList()
+	jd.dsListLock.RUnlock()
 	statMap := make(map[string]map[string]int)
 
 	for _, ds := range dsList {
@@ -1925,9 +1925,8 @@ func (jd *HandleT) GetActiveWorkspaces(ctx context.Context, customVal string) ([
 	if !jd.dsListLock.RTryLockWithCtx(ctx) {
 		return nil, fmt.Errorf("could not acquire a dslist read lock: %w", ctx.Err())
 	}
-	defer jd.dsListLock.RUnlock()
 	dsList := jd.getDSList()
-
+	jd.dsListLock.RUnlock()
 	var workspaceIds []string
 	var queries []string
 	for _, ds := range dsList {
@@ -1981,8 +1980,8 @@ func (jd *HandleT) GetDistinctParameterValues(ctx context.Context, parameterName
 	if !jd.dsListLock.RTryLockWithCtx(ctx) {
 		return nil, fmt.Errorf("could not acquire a dslist read lock: %w", ctx.Err())
 	}
-	defer jd.dsListLock.RUnlock()
 	dsList := jd.getDSList()
+	jd.dsListLock.RUnlock()
 
 	var values []string
 	var queries []string
@@ -3214,10 +3213,9 @@ func (jd *HandleT) getUnprocessed(ctx context.Context, params GetQueryParamsT) (
 	if !jd.dsListLock.RTryLockWithCtx(ctx) {
 		return JobsResult{}, fmt.Errorf("could not acquire a dslist read lock: %w", ctx.Err())
 	}
-	defer jd.dsListLock.RUnlock()
-
 	dsRangeList := jd.getDSRangeList()
 	dsList := jd.getDSList()
+	jd.dsListLock.RUnlock()
 
 	limitByEventCount := false
 	if params.EventsLimit > 0 {
@@ -3342,10 +3340,9 @@ func (jd *HandleT) GetProcessed(ctx context.Context, params GetQueryParamsT) (Jo
 	if !jd.dsListLock.RTryLockWithCtx(ctx) {
 		return JobsResult{}, fmt.Errorf("could not acquire a dslist read lock: %w", ctx.Err())
 	}
-	defer jd.dsListLock.RUnlock()
-
 	dsRangeList := jd.getDSRangeList()
 	dsList := jd.getDSList()
+	jd.dsListLock.RUnlock()
 
 	limitByEventCount := false
 	if params.EventsLimit > 0 {
@@ -3532,8 +3529,8 @@ func (jd *HandleT) GetLastJob() *JobT {
 	if !jd.dsListLock.RTryLockWithCtx(ctx) {
 		panic(fmt.Errorf("could not acquire a dslist lock: %w", ctx.Err()))
 	}
-	defer jd.dsListLock.RUnlock()
 	dsList := jd.getDSList()
+	jd.dsListLock.RUnlock()
 	maxID := jd.getMaxIDForDs(dsList[len(dsList)-1])
 	var job JobT
 	sqlStatement := fmt.Sprintf(`SELECT %[1]s.job_id, %[1]s.uuid, %[1]s.user_id, %[1]s.parameters, %[1]s.custom_val, %[1]s.event_payload, %[1]s.created_at, %[1]s.expire_at FROM %[1]s WHERE %[1]s.job_id = %[2]d`, dsList[len(dsList)-1].JobTable, maxID)

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1103,7 +1103,7 @@ func (jd *HandleT) refreshDSRangeList(l lock.LockToken) error {
 	if err != nil {
 		return fmt.Errorf("refreshDSList %w", err)
 	}
-	jd.datasetRangeList = nil
+	var datasetRangeList []dataSetRangeT
 
 	for idx, ds := range dsList {
 		jd.assert(ds.Index != "", "ds.Index is empty")
@@ -1139,7 +1139,7 @@ func (jd *HandleT) refreshDSRangeList(l lock.LockToken) error {
 			// TODO: Cleanup - Remove the line below and jd.inProgressMigrationTargetDS
 			jd.assert(minID.Valid && maxID.Valid, fmt.Sprintf("minID.Valid: %v, maxID.Valid: %v. Either of them is false for table: %s", minID.Valid, maxID.Valid, ds.JobTable))
 			jd.assert(idx == 0 || prevMax < minID.Int64, fmt.Sprintf("idx: %d != 0 and prevMax: %d >= minID.Int64: %v of table: %s", idx, prevMax, minID.Int64, ds.JobTable))
-			jd.datasetRangeList = append(jd.datasetRangeList,
+			datasetRangeList = append(datasetRangeList,
 				dataSetRangeT{
 					minJobID: minID.Int64,
 					maxJobID: maxID.Int64,
@@ -1148,6 +1148,7 @@ func (jd *HandleT) refreshDSRangeList(l lock.LockToken) error {
 			prevMax = maxID.Int64
 		}
 	}
+	jd.datasetRangeList = datasetRangeList
 	return nil
 }
 

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -2557,6 +2557,7 @@ func (jd *HandleT) addNewDSLoop(ctx context.Context) {
 								return fmt.Errorf("error making dataset read only: %w", err)
 							}
 						} else {
+							// maybe another node added a new DS that we need to make visible to us
 							if err := jd.refreshDSList(ctx); err != nil {
 								return fmt.Errorf("refreshDSList: %w", err)
 							}

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -400,7 +400,7 @@ func TestRefreshDSList(t *testing.T) {
 	}))
 	require.Equal(t, 1, len(jobsDB.getDSList()), "addDS should not refresh the ds list")
 	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
-		dsList, err := jobsDB.refreshDSList(l)
+		dsList, err := jobsDB.doRefreshDSList(l)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(dsList), "after refreshing the ds list jobsDB should have a ds list size of 2")
 	})

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -167,7 +167,7 @@ func (jd *HandleT) doMigrateDS(ctx context.Context) error {
 	if l != nil {
 		defer func() { lockChan <- l }()
 		if err == nil {
-			if err = jd.refreshDSRangeList(l); err != nil {
+			if err = jd.doRefreshDSRangeList(l); err != nil {
 				return fmt.Errorf("failed to refresh ds range list: %w", err)
 			}
 		}
@@ -461,7 +461,7 @@ func (jd *HandleT) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS da
 
 func (jd *HandleT) computeNewIdxForIntraNodeMigration(l lock.LockToken, insertBeforeDS dataSetT) (string, error) { // Within the node
 	jd.logger.Debugf("computeNewIdxForIntraNodeMigration, insertBeforeDS : %v", insertBeforeDS)
-	dList, err := jd.refreshDSList(l)
+	dList, err := jd.doRefreshDSList(l)
 	if err != nil {
 		return "", fmt.Errorf("refreshDSList: %w", err)
 	}


### PR DESCRIPTION
# Description
Acquiring a dsList write lock when not needed and while jobsdb queries are performing slow can have cascading effects on throughput, thus we now acquire one only when necessary and we are acquiring read locks for shorter periods as well:

- During `addNewDSLoop` jobsdb acquires a `dsList` lock only if its needs to add a new dataset.
- During `refreshDSListLoop` jobsdb acquires a `dsList` lock only if it detects a new dataset.
- While reading, jobsdb releases the `dsList` rlock early. The `migration` rlock that has already been acquired will make sure that no existing dataset will be removed from the list. Any new (rightmost) dataset can be added without any adverse effect.
- While updating job statuses, josdb releases the `dsList` rlock early. The `migration` rlock provides the same guarantees as above.
- Increase default values for jobsdb maxWriters (3) & maxReaders (6)
- Increase jobsdb cache ttl to 60 minutes
- Increase `jobMinRowsMigrateThres` to 20%

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=a5e82a768d524195a5aa34e0505fcc99&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
