### PR TITLE
chore: typo for workspaceId in stats

### DIFF
--- a/warehouse/internal/api/http.go
+++ b/warehouse/internal/api/http.go
@@ -138,9 +138,9 @@ func (api *WarehouseAPI) processHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	api.Stats.NewTaggedStat("rows_staged", stats.CountType, stats.Tags{
-		"workspace_id": stagingFile.WorkspaceID,
-		"module":       "warehouse",
-		"destType":     payload.BatchDestination.Destination.DestinationDefinition.Name,
+		"workspaceId": stagingFile.WorkspaceID,
+		"module":      "warehouse",
+		"destType":    payload.BatchDestination.Destination.DestinationDefinition.Name,
 		"warehouseID": misc.GetTagName(
 			payload.BatchDestination.Destination.ID,
 			payload.BatchDestination.Source.Name,


### PR DESCRIPTION
# Description

Use workspaceId instead of workspace_id for tags in metrics **rows_staged**

## Notion Ticket

https://www.notion.so/rudderstacks/workspace_id-tag-for-rows-staged-metrics-ec3505370e664686bbe729e87fe349bc?pvs=4

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
