### PR TITLE
fix: transformation does not retry indefinitely when control plane is down

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -397,7 +397,7 @@ func (trans *HandleT) doPost(ctx context.Context, rawJSON []byte, url string, ta
 				return reqErr
 			}
 			defer func() { httputil.CloseResponse(resp) }()
-			if !isJobTerminated(resp.StatusCode) {
+			if !isJobTerminated(resp.StatusCode) && resp.StatusCode != StatusCPDown {
 				return fmt.Errorf("transformer returned status code: %v", resp.StatusCode)
 			}
 			respData, reqErr = io.ReadAll(resp.Body)

--- a/processor/transformer/transformer_test.go
+++ b/processor/transformer/transformer_test.go
@@ -131,6 +131,7 @@ func Test_Transformer(t *testing.T) {
 
 func Test_EndlessLoopIf809(t *testing.T) {
 	config.Reset()
+	defer config.Reset()
 	logger.Reset()
 	config.Set("Processor.maxRetry", 1)
 	transformer.Init()

--- a/processor/transformer/transformer_test.go
+++ b/processor/transformer/transformer_test.go
@@ -130,6 +130,9 @@ func Test_Transformer(t *testing.T) {
 }
 
 func Test_EndlessLoopIf809(t *testing.T) {
+	config.Reset()
+	logger.Reset()
+	config.Set("Processor.maxRetry", 1)
 	transformer.Init()
 
 	ft := &endlessLoopTransformer{


### PR DESCRIPTION
# Description

Fixing a regression introduced by #3446

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=4f72cce4d22a48ac95feabb7875081d9&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
