### PR TITLE
fix: user transformations timeout

### DIFF
--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -12,8 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rudderlabs/rudder-go-kit/stats"
-
 	mock_jobs_forwarder "github.com/rudderlabs/rudder-server/mocks/jobs-forwarder"
 	transformationdebugger "github.com/rudderlabs/rudder-server/services/debugger/transformation"
 
@@ -212,7 +210,7 @@ func TestDynamicClusterManager(t *testing.T) {
 	processor.BackendConfig = mockBackendConfig
 	processor.Transformer = mockTransformer
 	mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
-	mockTransformer.EXPECT().Setup(config.Default, logger.Default, stats.Default).Times(1)
+	mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 	rtFactory := &router.Factory{
 		Logger:           logger.NOP,

--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -210,7 +210,6 @@ func TestDynamicClusterManager(t *testing.T) {
 	processor.BackendConfig = mockBackendConfig
 	processor.Transformer = mockTransformer
 	mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
-	mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 	rtFactory := &router.Factory{
 		Logger:           logger.NOP,

--- a/enterprise/replay/replay.go
+++ b/enterprise/replay/replay.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -148,7 +150,7 @@ func (handle *Handler) initSourceWorkers(ctx context.Context) {
 		}
 		handle.workers[i] = worker
 		worker.transformer = transformer.NewTransformer()
-		worker.transformer.Setup()
+		worker.transformer.Setup(config.Default, handle.log, stats.Default)
 		go worker.workerProcess(ctx)
 	}
 	handle.initSourceWorkersChannel <- true

--- a/enterprise/replay/replay.go
+++ b/enterprise/replay/replay.go
@@ -149,8 +149,7 @@ func (handle *Handler) initSourceWorkers(ctx context.Context) {
 			uploader:      handle.uploader,
 		}
 		handle.workers[i] = worker
-		worker.transformer = transformer.NewTransformer()
-		worker.transformer.Setup(config.Default, handle.log, stats.Default)
+		worker.transformer = transformer.NewTransformer(config.Default, handle.log, stats.Default)
 		go worker.workerProcess(ctx)
 	}
 	handle.initSourceWorkersChannel <- true

--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -168,7 +168,7 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 	}
 
 	if transformationVersionID != "" {
-		response := worker.transformer.Transform(context.TODO(), transEvents, integrations.GetUserTransformURL(), userTransformBatchSize)
+		response := worker.transformer.Transform(context.TODO(), transEvents, integrations.GetUserTransformURL(), userTransformBatchSize, transformer.UserTransformerStage)
 
 		for _, ev := range response.Events {
 			destEventJSON, err := json.Marshal(ev.Output[worker.getFieldIdentifier(eventPayload)])

--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -112,7 +112,7 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 
 	var jobs []*jobsdb.JobT
 
-	var transEvents []transformer.TransformerEventT
+	var transEvents []transformer.TransformerEvent
 	transformationVersionID := config.GetString("TRANSFORMATION_VERSION_ID", "")
 
 	for sc.Scan() {
@@ -150,14 +150,14 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 
 		messageID := uuid.New().String()
 
-		metadata := transformer.MetadataT{
+		metadata := transformer.Metadata{
 			MessageID:     messageID,
 			DestinationID: gjson.GetBytes(copyLineBytes, "parameters.destination_id").String(),
 		}
 
 		transformation := backendconfig.TransformationT{VersionID: config.GetString("TRANSFORMATION_VERSION_ID", "")}
 
-		transEvent := transformer.TransformerEventT{
+		transEvent := transformer.TransformerEvent{
 			Message:     message,
 			Metadata:    metadata,
 			Destination: backendconfig.DestinationT{Transformations: []backendconfig.TransformationT{transformation}},

--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -21,7 +21,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
-	"github.com/rudderlabs/rudder-server/processor/integrations"
 	"github.com/rudderlabs/rudder-server/processor/transformer"
 )
 
@@ -168,7 +167,7 @@ func (worker *SourceWorkerT) replayJobsInFile(ctx context.Context, filePath stri
 	}
 
 	if transformationVersionID != "" {
-		response := worker.transformer.Transform(context.TODO(), transEvents, integrations.GetUserTransformURL(), userTransformBatchSize, transformer.UserTransformerStage)
+		response := worker.transformer.UserTransform(context.TODO(), transEvents, userTransformBatchSize)
 
 		for _, ev := range response.Events {
 			destEventJSON, err := json.Marshal(ev.Output[worker.getFieldIdentifier(eventPayload)])

--- a/mocks/processor/transformer/mock_transformer.go
+++ b/mocks/processor/transformer/mock_transformer.go
@@ -51,15 +51,43 @@ func (mr *MockTransformerMockRecorder) Setup(arg0, arg1, arg2 interface{}) *gomo
 }
 
 // Transform mocks base method.
-func (m *MockTransformer) Transform(arg0 context.Context, arg1 []transformer.TransformerEventT, arg2 string, arg3 int, arg4 string) transformer.ResponseT {
+func (m *MockTransformer) Transform(arg0 context.Context, arg1 []transformer.TransformerEventT, arg2 int) transformer.ResponseT {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Transform", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Transform", arg0, arg1, arg2)
 	ret0, _ := ret[0].(transformer.ResponseT)
 	return ret0
 }
 
 // Transform indicates an expected call of Transform.
-func (mr *MockTransformerMockRecorder) Transform(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockTransformerMockRecorder) Transform(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transform", reflect.TypeOf((*MockTransformer)(nil).Transform), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transform", reflect.TypeOf((*MockTransformer)(nil).Transform), arg0, arg1, arg2)
+}
+
+// UserTransform mocks base method.
+func (m *MockTransformer) UserTransform(arg0 context.Context, arg1 []transformer.TransformerEventT, arg2 int) transformer.ResponseT {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UserTransform", arg0, arg1, arg2)
+	ret0, _ := ret[0].(transformer.ResponseT)
+	return ret0
+}
+
+// UserTransform indicates an expected call of UserTransform.
+func (mr *MockTransformerMockRecorder) UserTransform(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserTransform", reflect.TypeOf((*MockTransformer)(nil).UserTransform), arg0, arg1, arg2)
+}
+
+// Validate mocks base method.
+func (m *MockTransformer) Validate(arg0 context.Context, arg1 []transformer.TransformerEventT, arg2 int) transformer.ResponseT {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2)
+	ret0, _ := ret[0].(transformer.ResponseT)
+	return ret0
+}
+
+// Validate indicates an expected call of Validate.
+func (mr *MockTransformerMockRecorder) Validate(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockTransformer)(nil).Validate), arg0, arg1, arg2)
 }

--- a/mocks/processor/transformer/mock_transformer.go
+++ b/mocks/processor/transformer/mock_transformer.go
@@ -6,6 +6,9 @@ package mocks_transformer
 
 import (
 	context "context"
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -36,7 +39,7 @@ func (m *MockTransformer) EXPECT() *MockTransformerMockRecorder {
 }
 
 // Setup mocks base method.
-func (m *MockTransformer) Setup() {
+func (m *MockTransformer) Setup(*config.Config, logger.Logger, stats.Stats) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Setup")
 }
@@ -48,29 +51,15 @@ func (mr *MockTransformerMockRecorder) Setup() *gomock.Call {
 }
 
 // Transform mocks base method.
-func (m *MockTransformer) Transform(arg0 context.Context, arg1 []transformer.TransformerEventT, arg2 string, arg3 int) transformer.ResponseT {
+func (m *MockTransformer) Transform(arg0 context.Context, arg1 []transformer.TransformerEventT, arg2 string, arg3 int, arg4 string) transformer.ResponseT {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Transform", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Transform", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(transformer.ResponseT)
 	return ret0
 }
 
 // Transform indicates an expected call of Transform.
-func (mr *MockTransformerMockRecorder) Transform(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockTransformerMockRecorder) Transform(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transform", reflect.TypeOf((*MockTransformer)(nil).Transform), arg0, arg1, arg2, arg3)
-}
-
-// Validate mocks base method.
-func (m *MockTransformer) Validate(arg0 []transformer.TransformerEventT, arg1 string, arg2 int) transformer.ResponseT {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2)
-	ret0, _ := ret[0].(transformer.ResponseT)
-	return ret0
-}
-
-// Validate indicates an expected call of Validate.
-func (mr *MockTransformerMockRecorder) Validate(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockTransformer)(nil).Validate), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transform", reflect.TypeOf((*MockTransformer)(nil).Transform), arg0, arg1, arg2, arg3, arg4)
 }

--- a/mocks/processor/transformer/mock_transformer.go
+++ b/mocks/processor/transformer/mock_transformer.go
@@ -9,9 +9,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	config "github.com/rudderlabs/rudder-go-kit/config"
-	logger "github.com/rudderlabs/rudder-go-kit/logger"
-	stats "github.com/rudderlabs/rudder-go-kit/stats"
 	transformer "github.com/rudderlabs/rudder-server/processor/transformer"
 )
 
@@ -38,23 +35,11 @@ func (m *MockTransformer) EXPECT() *MockTransformerMockRecorder {
 	return m.recorder
 }
 
-// Setup mocks base method.
-func (m *MockTransformer) Setup(arg0 *config.Config, arg1 logger.Logger, arg2 stats.Stats) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Setup", arg0, arg1, arg2)
-}
-
-// Setup indicates an expected call of Setup.
-func (mr *MockTransformerMockRecorder) Setup(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setup", reflect.TypeOf((*MockTransformer)(nil).Setup), arg0, arg1, arg2)
-}
-
 // Transform mocks base method.
-func (m *MockTransformer) Transform(arg0 context.Context, arg1 []transformer.TransformerEventT, arg2 int) transformer.ResponseT {
+func (m *MockTransformer) Transform(arg0 context.Context, arg1 []transformer.TransformerEvent, arg2 int) transformer.Response {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Transform", arg0, arg1, arg2)
-	ret0, _ := ret[0].(transformer.ResponseT)
+	ret0, _ := ret[0].(transformer.Response)
 	return ret0
 }
 
@@ -65,10 +50,10 @@ func (mr *MockTransformerMockRecorder) Transform(arg0, arg1, arg2 interface{}) *
 }
 
 // UserTransform mocks base method.
-func (m *MockTransformer) UserTransform(arg0 context.Context, arg1 []transformer.TransformerEventT, arg2 int) transformer.ResponseT {
+func (m *MockTransformer) UserTransform(arg0 context.Context, arg1 []transformer.TransformerEvent, arg2 int) transformer.Response {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UserTransform", arg0, arg1, arg2)
-	ret0, _ := ret[0].(transformer.ResponseT)
+	ret0, _ := ret[0].(transformer.Response)
 	return ret0
 }
 
@@ -79,10 +64,10 @@ func (mr *MockTransformerMockRecorder) UserTransform(arg0, arg1, arg2 interface{
 }
 
 // Validate mocks base method.
-func (m *MockTransformer) Validate(arg0 context.Context, arg1 []transformer.TransformerEventT, arg2 int) transformer.ResponseT {
+func (m *MockTransformer) Validate(arg0 context.Context, arg1 []transformer.TransformerEvent, arg2 int) transformer.Response {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2)
-	ret0, _ := ret[0].(transformer.ResponseT)
+	ret0, _ := ret[0].(transformer.Response)
 	return ret0
 }
 

--- a/processor/eventfilter/eventfilter.go
+++ b/processor/eventfilter/eventfilter.go
@@ -85,7 +85,7 @@ func GetSupportedMessageEvents(destination *backendconfig.DestinationT) ([]strin
 }
 
 type AllowTransformerEventParams struct {
-	TransformerEvent      *transformer.TransformerEventT
+	TransformerEvent      *transformer.TransformerEvent
 	SupportedMessageTypes []string
 }
 
@@ -123,13 +123,13 @@ Currently this method supports below validations(executed in the same order):
 
 2. Validate if the event is sendable to destination based on connectionMode, sourceType & messageType
 */
-func AllowEventToDestTransformation(transformerEvent *transformer.TransformerEventT, supportedMsgTypes []string) (bool, *transformer.TransformerResponseT) {
+func AllowEventToDestTransformation(transformerEvent *transformer.TransformerEvent, supportedMsgTypes []string) (bool, *transformer.TransformerResponse) {
 	// MessageType filtering -- STARTS
 	messageType := strings.TrimSpace(strings.ToLower(getMessageType(&transformerEvent.Message)))
 	if messageType == "" {
 		// We will abort the event
 		errMessage := "Invalid message type. Type assertion failed"
-		resp := &transformer.TransformerResponseT{
+		resp := &transformer.TransformerResponse{
 			Output: transformerEvent.Message, StatusCode: 400,
 			Metadata: transformerEvent.Metadata,
 			Error:    errMessage,
@@ -193,7 +193,7 @@ Example:
 			...
 		}
 */
-func FilterEventsForHybridMode(connectionModeFilterParams ConnectionModeFilterParams) (bool, *transformer.TransformerResponseT) {
+func FilterEventsForHybridMode(connectionModeFilterParams ConnectionModeFilterParams) (bool, *transformer.TransformerResponse) {
 	destination := connectionModeFilterParams.Destination
 	srcType := strings.TrimSpace(connectionModeFilterParams.SrcType)
 	messageType := connectionModeFilterParams.Event.MessageType

--- a/processor/integrations/integrations.go
+++ b/processor/integrations/integrations.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	jsonFast              = jsoniter.ConfigCompatibleWithStandardLibrary
+	json                  = jsoniter.ConfigCompatibleWithStandardLibrary
 	postParametersTFields []string
 )
 
@@ -53,7 +53,7 @@ type TransResponseT struct {
 
 func CollectDestErrorStats(input []byte) {
 	var integrationStat TransStatsT
-	err := jsonFast.Unmarshal(input, &integrationStat)
+	err := json.Unmarshal(input, &integrationStat)
 	if err == nil {
 		if len(integrationStat.StatTags) > 0 {
 			stats.Default.NewTaggedStat("integration.failure_detailed", stats.CountType, integrationStat.StatTags).Increment()
@@ -63,7 +63,7 @@ func CollectDestErrorStats(input []byte) {
 
 func CollectIntgTransformErrorStats(input []byte) {
 	var integrationStats []TransStatsT
-	err := jsonFast.Unmarshal(input, &integrationStats)
+	err := json.Unmarshal(input, &integrationStats)
 	if err == nil {
 		for _, integrationStat := range integrationStats {
 			if len(integrationStat.StatTags) > 0 {
@@ -75,7 +75,7 @@ func CollectIntgTransformErrorStats(input []byte) {
 
 // GetPostInfo parses the transformer response
 func ValidatePostInfo(transformRawParams PostParametersT) error {
-	transformRaw, err := jsonFast.Marshal(transformRawParams)
+	transformRaw, err := json.Marshal(transformRawParams)
 	if err != nil {
 		return err
 	}

--- a/processor/integrations/integrations.go
+++ b/processor/integrations/integrations.go
@@ -7,45 +7,25 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/tidwall/gjson"
-	"golang.org/x/exp/slices"
 
-	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/types"
-	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
 var (
-	jsonfast              = jsoniter.ConfigCompatibleWithStandardLibrary
-	destTransformURL      string
-	userTransformURL      string
+	jsonFast              = jsoniter.ConfigCompatibleWithStandardLibrary
 	postParametersTFields []string
 )
 
-func Init() {
-	loadConfig()
+func init() {
 	// This is called in init and it should be a one time call. Making reflect calls during runtime is not a great idea.
 	// We unmarshal json response from transformer into PostParametersT struct.
 	// Since unmarshal doesn't check if the fields are present in the json or not and instead just initialze to zero value, we have to manually do this check on all fields before unmarshaling
 	// This function gets a list of fields tagged as json from the struct and populates in postParametersTFields
 	postParametersTFields = misc.GetMandatoryJSONFieldNames(PostParametersT{})
 }
-
-func loadConfig() {
-	destTransformURL = config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
-	userTransformURL = config.GetString("USER_TRANSFORM_URL", destTransformURL)
-}
-
-const (
-	// PostDataKV means post data is sent as KV
-	PostDataKV = iota + 1
-	// PostDataJSON means post data is sent as JSON
-	PostDataJSON
-	// PostDataXML means post data is sent as XML
-	PostDataXML
-)
 
 // PostParametersT is a struct for holding all the values from transformerResponse and use them to publish an event to a destination
 // optional is a custom tag introduced by us and is handled by GetMandatoryJSONFieldNames. Its intentionally added
@@ -73,7 +53,7 @@ type TransResponseT struct {
 
 func CollectDestErrorStats(input []byte) {
 	var integrationStat TransStatsT
-	err := jsonfast.Unmarshal(input, &integrationStat)
+	err := jsonFast.Unmarshal(input, &integrationStat)
 	if err == nil {
 		if len(integrationStat.StatTags) > 0 {
 			stats.Default.NewTaggedStat("integration.failure_detailed", stats.CountType, integrationStat.StatTags).Increment()
@@ -83,7 +63,7 @@ func CollectDestErrorStats(input []byte) {
 
 func CollectIntgTransformErrorStats(input []byte) {
 	var integrationStats []TransStatsT
-	err := jsonfast.Unmarshal(input, &integrationStats)
+	err := jsonFast.Unmarshal(input, &integrationStats)
 	if err == nil {
 		for _, integrationStat := range integrationStats {
 			if len(integrationStat.StatTags) > 0 {
@@ -95,7 +75,7 @@ func CollectIntgTransformErrorStats(input []byte) {
 
 // GetPostInfo parses the transformer response
 func ValidatePostInfo(transformRawParams PostParametersT) error {
-	transformRaw, err := jsonfast.Marshal(transformRawParams)
+	transformRaw, err := jsonFast.Marshal(transformRawParams)
 	if err != nil {
 		return err
 	}
@@ -159,36 +139,4 @@ func FilterClientIntegrations(clientEvent types.SingularEventT, destNameIDMap ma
 	}
 	retVal = outVal
 	return
-}
-
-// GetTransformerURL gets the transfomer base url endpoint
-func GetTransformerURL() string {
-	return destTransformURL
-}
-
-// GetDestinationURL returns node URL
-func GetDestinationURL(destType string) string {
-	destinationEndPoint := fmt.Sprintf("%s/v0/destinations/%s", destTransformURL, strings.ToLower(destType))
-	if slices.Contains(warehouseutils.WarehouseDestinations, destType) {
-		whSchemaVersionQueryParam := fmt.Sprintf("whSchemaVersion=%s&whIDResolve=%v", config.GetString("Warehouse.schemaVersion", "v1"), warehouseutils.IDResolutionEnabled())
-		if destType == "RS" {
-			return destinationEndPoint + "?" + whSchemaVersionQueryParam
-		}
-		if destType == "CLICKHOUSE" {
-			enableArraySupport := fmt.Sprintf("chEnableArraySupport=%s", fmt.Sprintf("%v", config.GetBool("Warehouse.clickhouse.enableArraySupport", false)))
-			return destinationEndPoint + "?" + whSchemaVersionQueryParam + "&" + enableArraySupport
-		}
-		return destinationEndPoint + "?" + whSchemaVersionQueryParam
-	}
-	return destinationEndPoint
-}
-
-// GetUserTransformURL returns the port of running user transform
-func GetUserTransformURL() string {
-	return userTransformURL + "/customTransform"
-}
-
-// GetTrackingPlanValidationURL returns the port of running tracking plan validation
-func GetTrackingPlanValidationURL() string {
-	return destTransformURL + "/v0/validate"
 }

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"sync"
 
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	transformationdebugger "github.com/rudderlabs/rudder-server/services/debugger/transformation"
 
 	destinationdebugger "github.com/rudderlabs/rudder-server/services/debugger/destination"
@@ -87,7 +91,7 @@ func New(ctx context.Context, clearDb *bool, gwDb, rtDb, brtDb, errDb, esDB *job
 	opts ...Opts,
 ) *LifecycleManager {
 	proc := &LifecycleManager{
-		Handle:           NewHandle(transformer.NewTransformer()),
+		Handle:           NewHandle(transformer.NewTransformer(config.Default, logger.NewLogger().Child("processor"), stats.Default)),
 		mainCtx:          ctx,
 		gatewayDB:        gwDb,
 		routerDB:         rtDb,

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -236,7 +236,7 @@ func TestProcessorManager(t *testing.T) {
 			},
 		)
 		mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
-		mockTransformer.EXPECT().Setup(config.Default, logger.Default, stats.Default).Times(1).Do(func() {
+		mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Do(func(*config.Config, logger.Logger, stats.Stats) {
 			processor.Handle.transformerFeatures = json.RawMessage(defaultTransformerFeatures)
 		})
 		mockRsourcesService.EXPECT().IncrementStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), rsources.Stats{Out: 10}).Times(1)
@@ -276,7 +276,7 @@ func TestProcessorManager(t *testing.T) {
 		)
 
 		mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
-		mockTransformer.EXPECT().Setup(config.Default, logger.Default, stats.Default).Times(1).Do(func() {
+		mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Do(func(*config.Config, logger.Logger, stats.Stats) {
 			processor.Handle.transformerFeatures = json.RawMessage(defaultTransformerFeatures)
 		})
 		mockRsourcesService.EXPECT().IncrementStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), rsources.Stats{Out: 10}).Times(1)

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rudderlabs/rudder-go-kit/stats"
-
 	transformationdebugger "github.com/rudderlabs/rudder-server/services/debugger/transformation"
 
 	destinationdebugger "github.com/rudderlabs/rudder-server/services/debugger/destination"
@@ -236,9 +234,7 @@ func TestProcessorManager(t *testing.T) {
 			},
 		)
 		mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
-		mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Do(func(*config.Config, logger.Logger, stats.Stats) {
-			processor.Handle.transformerFeatures = json.RawMessage(defaultTransformerFeatures)
-		})
+		processor.Handle.transformerFeatures = json.RawMessage(defaultTransformerFeatures)
 		mockRsourcesService.EXPECT().IncrementStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), rsources.Stats{Out: 10}).Times(1)
 		processor.BackendConfig = mockBackendConfig
 		processor.Handle.transformer = mockTransformer
@@ -276,9 +272,7 @@ func TestProcessorManager(t *testing.T) {
 		)
 
 		mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
-		mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Do(func(*config.Config, logger.Logger, stats.Stats) {
-			processor.Handle.transformerFeatures = json.RawMessage(defaultTransformerFeatures)
-		})
+		processor.Handle.transformerFeatures = json.RawMessage(defaultTransformerFeatures)
 		mockRsourcesService.EXPECT().IncrementStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), rsources.Stats{Out: 10}).Times(1)
 
 		require.NoError(t, processor.Start())

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2136,7 +2136,6 @@ func (proc *Handle) transformSrcDest(
 	}
 	// REPORTING - END
 
-	url := integrations.GetDestinationURL(destType)
 	var response transformer.ResponseT
 	var eventsToTransform []transformer.TransformerEventT
 	// Send to custom transformer only if the destination has a transformer enabled
@@ -2147,7 +2146,7 @@ func (proc *Handle) transformSrcDest(
 
 		trace.WithRegion(ctx, "UserTransform", func() {
 			startedAt := time.Now()
-			response = proc.transformer.Transform(ctx, eventList, integrations.GetUserTransformURL(), proc.config.userTransformBatchSize, transformer.UserTransformerStage)
+			response = proc.transformer.UserTransform(ctx, eventList, proc.config.userTransformBatchSize)
 			d := time.Since(startedAt)
 			userTransformationStat.transformTime.SendTiming(d)
 
@@ -2278,7 +2277,7 @@ func (proc *Handle) transformSrcDest(
 			trace.Logf(ctx, "Dest Transform", "input size %d", len(eventsToTransform))
 			proc.logger.Debug("Dest Transform input size", len(eventsToTransform))
 			s := time.Now()
-			response = proc.transformer.Transform(ctx, eventsToTransform, url, proc.config.transformBatchSize, transformer.DestTransformerStage)
+			response = proc.transformer.Transform(ctx, eventsToTransform, proc.config.transformBatchSize)
 
 			destTransformationStat := proc.newDestinationTransformationStat(sourceID, workspaceID, transformAt, destination)
 			destTransformationStat.transformTime.Since(s)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -444,7 +444,6 @@ func (proc *Handle) Setup(
 		}
 	}))
 
-	proc.transformer.Setup(config.Default, proc.logger, proc.statsFactory)
 	proc.crashRecover()
 }
 
@@ -805,7 +804,7 @@ func getTimestampFromEvent(event types.SingularEventT, field string) time.Time {
 	return timestamp
 }
 
-func enhanceWithTimeFields(event *transformer.TransformerEventT, singularEventMap types.SingularEventT, receivedAt time.Time) {
+func enhanceWithTimeFields(event *transformer.TransformerEvent, singularEventMap types.SingularEventT, receivedAt time.Time) {
 	// set timestamp skew based on timestamp fields from SDKs
 	originalTimestamp := getTimestampFromEvent(singularEventMap, "originalTimestamp")
 	sentAt := getTimestampFromEvent(singularEventMap, "sentAt")
@@ -826,8 +825,8 @@ func enhanceWithTimeFields(event *transformer.TransformerEventT, singularEventMa
 	event.Message["timestamp"] = timestamp.Format(misc.RFC3339Milli)
 }
 
-func makeCommonMetadataFromSingularEvent(singularEvent types.SingularEventT, batchEvent *jobsdb.JobT, receivedAt time.Time, source *backendconfig.SourceT) *transformer.MetadataT {
-	commonMetadata := transformer.MetadataT{}
+func makeCommonMetadataFromSingularEvent(singularEvent types.SingularEventT, batchEvent *jobsdb.JobT, receivedAt time.Time, source *backendconfig.SourceT) *transformer.Metadata {
+	commonMetadata := transformer.Metadata{}
 	commonMetadata.SourceID = gjson.GetBytes(batchEvent.Parameters, "source_id").Str
 	commonMetadata.WorkspaceID = source.WorkspaceID
 	commonMetadata.Namespace = config.GetKubeNamespace()
@@ -854,8 +853,8 @@ func makeCommonMetadataFromSingularEvent(singularEvent types.SingularEventT, bat
 }
 
 // add metadata to each singularEvent which will be returned by transformer in response
-func enhanceWithMetadata(commonMetadata *transformer.MetadataT, event *transformer.TransformerEventT, destination *backendconfig.DestinationT) {
-	metadata := transformer.MetadataT{}
+func enhanceWithMetadata(commonMetadata *transformer.Metadata, event *transformer.TransformerEvent, destination *backendconfig.DestinationT) {
+	metadata := transformer.Metadata{}
 	metadata.SourceType = commonMetadata.SourceType
 	metadata.SourceCategory = commonMetadata.SourceCategory
 	metadata.SourceID = commonMetadata.SourceID
@@ -942,13 +941,13 @@ func (proc *Handle) recordEventDeliveryStatus(jobsByDestID map[string][]*jobsdb.
 	}
 }
 
-func (proc *Handle) getDestTransformerEvents(response transformer.ResponseT, commonMetaData *transformer.MetadataT, eventsByMessageID map[string]types.SingularEventWithReceivedAt, destination *backendconfig.DestinationT, stage string, trackingPlanEnabled, userTransformationEnabled bool) ([]transformer.TransformerEventT, []*types.PUReportedMetric, map[string]int64, map[string]MetricMetadata) {
+func (proc *Handle) getDestTransformerEvents(response transformer.Response, commonMetaData *transformer.Metadata, eventsByMessageID map[string]types.SingularEventWithReceivedAt, destination *backendconfig.DestinationT, stage string, trackingPlanEnabled, userTransformationEnabled bool) ([]transformer.TransformerEvent, []*types.PUReportedMetric, map[string]int64, map[string]MetricMetadata) {
 	successMetrics := make([]*types.PUReportedMetric, 0)
 	connectionDetailsMap := make(map[string]*types.ConnectionDetails)
 	statusDetailsMap := make(map[string]map[string]*types.StatusDetail)
 	successCountMap := make(map[string]int64)
 	successCountMetadataMap := make(map[string]MetricMetadata)
-	var eventsToTransform []transformer.TransformerEventT
+	var eventsToTransform []transformer.TransformerEvent
 	for i := range response.Events {
 		// Update metrics maps
 		userTransformedEvent := &response.Events[i]
@@ -992,7 +991,7 @@ func (proc *Handle) getDestTransformerEvents(response transformer.ResponseT, com
 		eventMetadata.SourceDefinitionID = userTransformedEvent.Metadata.SourceDefinitionID
 		eventMetadata.DestinationDefinitionID = userTransformedEvent.Metadata.DestinationDefinitionID
 		eventMetadata.SourceCategory = userTransformedEvent.Metadata.SourceCategory
-		updatedEvent := transformer.TransformerEventT{
+		updatedEvent := transformer.TransformerEvent{
 			Message:     userTransformedEvent.Output,
 			Metadata:    *eventMetadata,
 			Destination: *destination,
@@ -1049,7 +1048,7 @@ func (proc *Handle) updateMetricMaps(
 	countMap map[string]int64,
 	connectionDetailsMap map[string]*types.ConnectionDetails,
 	statusDetailsMap map[string]map[string]*types.StatusDetail,
-	event *transformer.TransformerResponseT,
+	event *transformer.TransformerResponse,
 	status, stage string,
 	payload func() json.RawMessage,
 ) {
@@ -1164,7 +1163,7 @@ func (proc *Handle) updateMetricMaps(
 	}
 }
 
-func (proc *Handle) getFailedEventJobs(response transformer.ResponseT, commonMetaData *transformer.MetadataT, eventsByMessageID map[string]types.SingularEventWithReceivedAt, stage string, transformationEnabled, trackingPlanEnabled bool) ([]*jobsdb.JobT, []*types.PUReportedMetric, map[string]int64) {
+func (proc *Handle) getFailedEventJobs(response transformer.Response, commonMetaData *transformer.Metadata, eventsByMessageID map[string]types.SingularEventWithReceivedAt, stage string, transformationEnabled, trackingPlanEnabled bool) ([]*jobsdb.JobT, []*types.PUReportedMetric, map[string]int64) {
 	failedMetrics := make([]*types.PUReportedMetric, 0)
 	connectionDetailsMap := make(map[string]*types.ConnectionDetails)
 	statusDetailsMap := make(map[string]map[string]*types.StatusDetail)
@@ -1376,8 +1375,8 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 	proc.stats.statNumRequests.Count(len(jobList))
 
 	var statusList []*jobsdb.JobStatusT
-	groupedEvents := make(map[string][]transformer.TransformerEventT)
-	groupedEventsByWriteKey := make(map[WriteKeyT][]transformer.TransformerEventT)
+	groupedEvents := make(map[string][]transformer.TransformerEvent)
+	groupedEventsByWriteKey := make(map[WriteKeyT][]transformer.TransformerEvent)
 	eventsByMessageID := make(map[string]types.SingularEventWithReceivedAt)
 	var procErrorJobs []*jobsdb.JobT
 	eventSchemaJobs := make([]*jobsdb.JobT, 0)
@@ -1491,7 +1490,7 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 
 			// REPORTING - GATEWAY metrics - START
 			// dummy event for metrics purposes only
-			event := &transformer.TransformerResponseT{}
+			event := &transformer.TransformerResponse{}
 			if proc.isReportingEnabled() {
 				event.Metadata = *commonMetadataFromSingularEvent
 				proc.updateMetricMaps(
@@ -1519,9 +1518,9 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 			}
 
 			if _, ok := groupedEventsByWriteKey[WriteKeyT(writeKey)]; !ok {
-				groupedEventsByWriteKey[WriteKeyT(writeKey)] = make([]transformer.TransformerEventT, 0)
+				groupedEventsByWriteKey[WriteKeyT(writeKey)] = make([]transformer.TransformerEvent, 0)
 			}
-			shallowEventCopy := transformer.TransformerEventT{}
+			shallowEventCopy := transformer.TransformerEvent{}
 			shallowEventCopy.Message = singularEvent
 			shallowEventCopy.Message["request_ip"] = requestIP
 			enhanceWithTimeFields(&shallowEventCopy, singularEvent, receivedAt)
@@ -1660,7 +1659,7 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 				// Adding a singular event multiple times if there are multiple destinations of same type
 				for idx := range enabledDestinationsList {
 					destination := &enabledDestinationsList[idx]
-					shallowEventCopy := transformer.TransformerEventT{}
+					shallowEventCopy := transformer.TransformerEvent{}
 					shallowEventCopy.Message = singularEvent
 					shallowEventCopy.Destination = *destination
 					shallowEventCopy.Libraries = workspaceLibraries
@@ -1683,7 +1682,7 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 					// We have at-least one event so marking it good
 					_, ok := groupedEvents[srcAndDestKey]
 					if !ok {
-						groupedEvents[srcAndDestKey] = make([]transformer.TransformerEventT, 0)
+						groupedEvents[srcAndDestKey] = make([]transformer.TransformerEvent, 0)
 					}
 					groupedEvents[srcAndDestKey] = append(groupedEvents[srcAndDestKey],
 						shallowEventCopy)
@@ -1724,7 +1723,7 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 }
 
 type transformationMessage struct {
-	groupedEvents map[string][]transformer.TransformerEventT
+	groupedEvents map[string][]transformer.TransformerEvent
 
 	trackingPlanEnabledMap       map[SourceIDT]bool
 	eventsByMessageID            map[string]types.SingularEventWithReceivedAt
@@ -2058,7 +2057,7 @@ type transformSrcDestOutput struct {
 func (proc *Handle) transformSrcDest(
 	ctx context.Context,
 	// main inputs
-	srcAndDestKey string, eventList []transformer.TransformerEventT,
+	srcAndDestKey string, eventList []transformer.TransformerEvent,
 
 	// helpers
 	trackingPlanEnabledMap map[SourceIDT]bool,
@@ -2070,7 +2069,7 @@ func (proc *Handle) transformSrcDest(
 	sourceID, destID := getSourceAndDestIDsFromKey(srcAndDestKey)
 	destination := &eventList[0].Destination
 	workspaceID := eventList[0].Metadata.WorkspaceID
-	commonMetaData := &transformer.MetadataT{
+	commonMetaData := &transformer.Metadata{
 		SourceID:             sourceID,
 		SourceType:           eventList[0].Metadata.SourceType,
 		SourceCategory:       eventList[0].Metadata.SourceCategory,
@@ -2136,8 +2135,8 @@ func (proc *Handle) transformSrcDest(
 	}
 	// REPORTING - END
 
-	var response transformer.ResponseT
-	var eventsToTransform []transformer.TransformerEventT
+	var response transformer.Response
+	var eventsToTransform []transformer.TransformerEvent
 	// Send to custom transformer only if the destination has a transformer enabled
 	if transformationEnabled {
 		userTransformationStat := proc.newUserTransformationStat(sourceID, workspaceID, destination)
@@ -2433,9 +2432,9 @@ func (proc *Handle) saveFailedJobs(failedJobs []*jobsdb.JobT) {
 	}
 }
 
-func ConvertToFilteredTransformerResponse(events []transformer.TransformerEventT, filter bool) transformer.ResponseT {
-	var responses []transformer.TransformerResponseT
-	var failedEvents []transformer.TransformerResponseT
+func ConvertToFilteredTransformerResponse(events []transformer.TransformerEvent, filter bool) transformer.Response {
+	var responses []transformer.TransformerResponse
+	var failedEvents []transformer.TransformerResponse
 
 	type cacheValue struct {
 		values []string
@@ -2445,7 +2444,7 @@ func ConvertToFilteredTransformerResponse(events []transformer.TransformerEventT
 	supportedMessageEventsCache := make(map[string]*cacheValue)
 
 	// filter unsupported message types
-	var resp transformer.TransformerResponseT
+	var resp transformer.TransformerResponse
 	var errMessage string
 	for i := range events {
 		event := &events[i]
@@ -2480,7 +2479,7 @@ func ConvertToFilteredTransformerResponse(events []transformer.TransformerEventT
 				if !typOk {
 					// add to FailedEvents
 					errMessage = "Invalid message event. Type assertion failed"
-					resp = transformer.TransformerResponseT{Output: event.Message, StatusCode: 400, Metadata: event.Metadata, Error: errMessage}
+					resp = transformer.TransformerResponse{Output: event.Message, StatusCode: 400, Metadata: event.Metadata, Error: errMessage}
 					failedEvents = append(failedEvents, resp)
 					continue
 				}
@@ -2491,11 +2490,11 @@ func ConvertToFilteredTransformerResponse(events []transformer.TransformerEventT
 
 		}
 		// allow event
-		resp = transformer.TransformerResponseT{Output: event.Message, StatusCode: 200, Metadata: event.Metadata}
+		resp = transformer.TransformerResponse{Output: event.Message, StatusCode: 200, Metadata: event.Metadata}
 		responses = append(responses, resp)
 	}
 
-	return transformer.ResponseT{Events: responses, FailedEvents: failedEvents}
+	return transformer.Response{Events: responses, FailedEvents: failedEvents}
 }
 
 func (proc *Handle) getJobs(partition string) jobsdb.JobsResult {
@@ -2688,7 +2687,7 @@ func (proc *Handle) updateRudderSourcesStats(ctx context.Context, tx jobsdb.Stor
 	return err
 }
 
-func filterConfig(eventCopy *transformer.TransformerEventT) {
+func filterConfig(eventCopy *transformer.TransformerEvent) {
 	if configsToFilterI, ok := eventCopy.Destination.DestinationDefinition.Config["configFilters"]; ok {
 		if configsToFilter, ok := configsToFilterI.([]interface{}); ok {
 			omitKeys := lo.FilterMap(configsToFilter, func(configKey interface{}, _ int) (string, bool) {

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -554,7 +554,6 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 				},
 			}
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
-			mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			c.mockEventSchemasDB.EXPECT().
 				WithStoreSafeTx(
@@ -621,7 +620,6 @@ var _ = Describe("Processor", Ordered, func() {
 	Context("Initialization", func() {
 		It("should initialize (no jobs to recover)", func() {
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
-			mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			processor := prepareHandle(NewHandle(mockTransformer))
 
@@ -636,7 +634,6 @@ var _ = Describe("Processor", Ordered, func() {
 
 		It("should recover after crash", func() {
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
-			mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			processor := prepareHandle(NewHandle(mockTransformer))
 
@@ -657,7 +654,6 @@ var _ = Describe("Processor", Ordered, func() {
 
 		It("should only send proper stats, if not pending jobs are returned", func() {
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
-			mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			processor := prepareHandle(NewHandle(mockTransformer))
 
@@ -802,7 +798,6 @@ var _ = Describe("Processor", Ordered, func() {
 				},
 			}
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
-			mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			processor := prepareHandle(NewHandle(mockTransformer))
 			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(
@@ -995,7 +990,6 @@ var _ = Describe("Processor", Ordered, func() {
 			}
 
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
-			mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			processor := prepareHandle(NewHandle(mockTransformer))
 
@@ -1016,19 +1010,19 @@ var _ = Describe("Processor", Ordered, func() {
 
 			// We expect one call to user transform for destination B
 			callUserTransform := mockTransformer.EXPECT().UserTransform(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).After(callUnprocessed).
-				DoAndReturn(func(ctx context.Context, clientEvents []transformer.TransformerEventT, batchSize int) transformer.ResponseT {
+				DoAndReturn(func(ctx context.Context, clientEvents []transformer.TransformerEvent, batchSize int) transformer.Response {
 					defer GinkgoRecover()
 
-					outputEvents := make([]transformer.TransformerResponseT, 0)
+					outputEvents := make([]transformer.TransformerResponse, 0)
 
 					for _, event := range clientEvents {
 						event.Message["user-transform"] = "value"
-						outputEvents = append(outputEvents, transformer.TransformerResponseT{
+						outputEvents = append(outputEvents, transformer.TransformerResponse{
 							Output: event.Message,
 						})
 					}
 
-					return transformer.ResponseT{
+					return transformer.Response{
 						Events: outputEvents,
 					}
 				})
@@ -1146,7 +1140,6 @@ var _ = Describe("Processor", Ordered, func() {
 			}
 
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
-			mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), gomock.Any()).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1)
 			c.MockDedup.EXPECT().Set(gomock.Any()).Return(true, int64(0)).After(callUnprocessed).Times(3)
@@ -1222,16 +1215,16 @@ var _ = Describe("Processor", Ordered, func() {
 				},
 			}
 
-			transformerResponses := []transformer.TransformerResponseT{
+			transformerResponses := []transformer.TransformerResponse{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-1",
 					},
 					StatusCode: 400,
 					Error:      "error-1",
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					StatusCode: 400,
@@ -1270,7 +1263,6 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
-			mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			processor := prepareHandle(NewHandle(mockTransformer))
 
@@ -1282,8 +1274,8 @@ var _ = Describe("Processor", Ordered, func() {
 			}).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1)
 			// Test transformer failure
 			mockTransformer.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
-				Return(transformer.ResponseT{
-					Events:       []transformer.TransformerResponseT{},
+				Return(transformer.Response{
+					Events:       []transformer.TransformerResponse{},
 					FailedEvents: transformerResponses,
 				})
 
@@ -1358,9 +1350,9 @@ var _ = Describe("Processor", Ordered, func() {
 				},
 			}
 
-			transformerResponses := []transformer.TransformerResponseT{
+			transformerResponses := []transformer.TransformerResponse{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageIDs: []string{"message-1", "message-2"},
 					},
 					StatusCode: 400,
@@ -1405,7 +1397,6 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
-			mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			processor := prepareHandle(NewHandle(mockTransformer))
 
@@ -1418,8 +1409,8 @@ var _ = Describe("Processor", Ordered, func() {
 
 			// Test transformer failure
 			mockTransformer.EXPECT().UserTransform(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
-				Return(transformer.ResponseT{
-					Events:       []transformer.TransformerResponseT{},
+				Return(transformer.Response{
+					Events:       []transformer.TransformerResponse{},
 					FailedEvents: transformerResponses,
 				})
 
@@ -1489,7 +1480,6 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
-			mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			processor := prepareHandle(NewHandle(mockTransformer))
 
@@ -1527,7 +1517,6 @@ var _ = Describe("Processor", Ordered, func() {
 	Context("MainLoop Tests", func() {
 		It("Should not handle jobs when transformer features are not set", func() {
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
-			mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			processor := prepareHandle(NewHandle(mockTransformer))
 
@@ -1571,7 +1560,6 @@ var _ = Describe("Processor", Ordered, func() {
 	Context("ProcessorLoop Tests", func() {
 		It("Should not handle jobs when transformer features are not set", func() {
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
-			mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			processor := prepareHandle(NewHandle(mockTransformer))
 
@@ -1630,7 +1618,6 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
-			mockTransformer.EXPECT().Setup(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			processor := prepareHandle(NewHandle(mockTransformer))
 
@@ -1658,9 +1645,9 @@ var _ = Describe("Static Function Tests", func() {
 
 	Context("TransformerFormatResponse Tests", func() {
 		It("Should match ConvertToTransformerResponse without filtering", func() {
-			events := []transformer.TransformerEventT{
+			events := []transformer.TransformerEvent{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-1",
 					},
 					Message: map[string]interface{}{
@@ -1668,7 +1655,7 @@ var _ = Describe("Static Function Tests", func() {
 					},
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					Message: map[string]interface{}{
@@ -1676,14 +1663,14 @@ var _ = Describe("Static Function Tests", func() {
 					},
 				},
 			}
-			expectedResponses := transformer.ResponseT{
-				Events: []transformer.TransformerResponseT{
+			expectedResponses := transformer.Response{
+				Events: []transformer.TransformerResponse{
 					{
 						Output: map[string]interface{}{
 							"some-key-1": "some-value-1",
 						},
 						StatusCode: 200,
-						Metadata: transformer.MetadataT{
+						Metadata: transformer.Metadata{
 							MessageID: "message-1",
 						},
 					},
@@ -1692,7 +1679,7 @@ var _ = Describe("Static Function Tests", func() {
 							"some-key-2": "some-value-2",
 						},
 						StatusCode: 200,
-						Metadata: transformer.MetadataT{
+						Metadata: transformer.Metadata{
 							MessageID: "message-2",
 						},
 					},
@@ -1803,8 +1790,8 @@ var _ = Describe("Static Function Tests", func() {
 			proc.reportingEnabled = true
 			proc.reporting = &mockReportingTypes.MockReporting{}
 
-			inputEvent := &transformer.TransformerResponseT{
-				Metadata: transformer.MetadataT{
+			inputEvent := &transformer.TransformerResponse{
+				Metadata: transformer.Metadata{
 					SourceID:         "source-id-1",
 					DestinationID:    "destination-id-1",
 					TransformationID: "transformation-id-1",
@@ -1891,9 +1878,9 @@ var _ = Describe("Static Function Tests", func() {
 				},
 			}
 
-			events := []transformer.TransformerEventT{
+			events := []transformer.TransformerEvent{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-1",
 					},
 					Message: map[string]interface{}{
@@ -1903,7 +1890,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					Message: map[string]interface{}{
@@ -1913,7 +1900,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					Message: map[string]interface{}{
@@ -1923,15 +1910,15 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 			}
-			expectedResponse := transformer.ResponseT{
-				Events: []transformer.TransformerResponseT{
+			expectedResponse := transformer.Response{
+				Events: []transformer.TransformerResponse{
 					{
 						Output:     events[0].Message,
 						StatusCode: 200,
 						Metadata:   events[0].Metadata,
 					},
 				},
-				FailedEvents: []transformer.TransformerResponseT{
+				FailedEvents: []transformer.TransformerResponse{
 					{
 						Output:     events[2].Message,
 						StatusCode: 400,
@@ -1958,9 +1945,9 @@ var _ = Describe("Static Function Tests", func() {
 				},
 			}
 
-			events := []transformer.TransformerEventT{
+			events := []transformer.TransformerEvent{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-1",
 					},
 					Message: map[string]interface{}{
@@ -1970,7 +1957,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					Message: map[string]interface{}{
@@ -1980,7 +1967,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					Message: map[string]interface{}{
@@ -1990,15 +1977,15 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 			}
-			expectedResponse := transformer.ResponseT{
-				Events: []transformer.TransformerResponseT{
+			expectedResponse := transformer.Response{
+				Events: []transformer.TransformerResponse{
 					{
 						Output:     events[1].Message,
 						StatusCode: 200,
 						Metadata:   events[1].Metadata,
 					},
 				},
-				FailedEvents: []transformer.TransformerResponseT{
+				FailedEvents: []transformer.TransformerResponse{
 					{
 						Output:     events[2].Message,
 						StatusCode: 400,
@@ -2018,9 +2005,9 @@ var _ = Describe("Static Function Tests", func() {
 				},
 			}
 
-			events := []transformer.TransformerEventT{
+			events := []transformer.TransformerEvent{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-1",
 					},
 					Message: map[string]interface{}{
@@ -2030,7 +2017,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					Message: map[string]interface{}{
@@ -2040,7 +2027,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					Message: map[string]interface{}{
@@ -2050,8 +2037,8 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 			}
-			expectedResponse := transformer.ResponseT{
-				Events: []transformer.TransformerResponseT{
+			expectedResponse := transformer.Response{
+				Events: []transformer.TransformerResponse{
 					{
 						Output:     events[0].Message,
 						StatusCode: 200,
@@ -2082,9 +2069,9 @@ var _ = Describe("Static Function Tests", func() {
 				},
 			}
 
-			events := []transformer.TransformerEventT{
+			events := []transformer.TransformerEvent{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-1",
 					},
 					Message: map[string]interface{}{
@@ -2094,7 +2081,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					Message: map[string]interface{}{
@@ -2104,7 +2091,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					Message: map[string]interface{}{
@@ -2114,8 +2101,8 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 			}
-			expectedResponse := transformer.ResponseT{
-				Events: []transformer.TransformerResponseT{
+			expectedResponse := transformer.Response{
+				Events: []transformer.TransformerResponse{
 					{
 						Output:     events[0].Message,
 						StatusCode: 200,
@@ -2150,9 +2137,9 @@ var _ = Describe("Static Function Tests", func() {
 				DestinationDefinition: backendconfig.DestinationDefinitionT{},
 			}
 
-			events := []transformer.TransformerEventT{
+			events := []transformer.TransformerEvent{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-1",
 					},
 					Message: map[string]interface{}{
@@ -2162,7 +2149,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					Message: map[string]interface{}{
@@ -2172,7 +2159,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					Message: map[string]interface{}{
@@ -2182,15 +2169,15 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 			}
-			expectedResponse := transformer.ResponseT{
-				Events: []transformer.TransformerResponseT{
+			expectedResponse := transformer.Response{
+				Events: []transformer.TransformerResponse{
 					{
 						Output:     events[1].Message,
 						StatusCode: 200,
 						Metadata:   events[1].Metadata,
 					},
 				},
-				FailedEvents: []transformer.TransformerResponseT{
+				FailedEvents: []transformer.TransformerResponse{
 					{
 						Output:     events[2].Message,
 						StatusCode: 400,
@@ -2217,9 +2204,9 @@ var _ = Describe("Static Function Tests", func() {
 				},
 			}
 
-			events := []transformer.TransformerEventT{
+			events := []transformer.TransformerEvent{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-1",
 					},
 					Message: map[string]interface{}{
@@ -2229,7 +2216,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					Message: map[string]interface{}{
@@ -2239,7 +2226,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID: "message-2",
 					},
 					Message: map[string]interface{}{
@@ -2249,8 +2236,8 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 			}
-			expectedResponse := transformer.ResponseT{
-				Events: []transformer.TransformerResponseT{
+			expectedResponse := transformer.Response{
+				Events: []transformer.TransformerResponse{
 					{
 						Output:     events[0].Message,
 						StatusCode: 200,
@@ -2307,9 +2294,9 @@ var _ = Describe("Static Function Tests", func() {
 				},
 			}
 
-			events := []transformer.TransformerEventT{
+			events := []transformer.TransformerEvent{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-1",
 						SourceDefinitionType: "web",
 					},
@@ -2320,7 +2307,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-2",
 						SourceDefinitionType: "web",
 					},
@@ -2331,7 +2318,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-2",
 						SourceDefinitionType: "web",
 					},
@@ -2342,8 +2329,8 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 			}
-			expectedResponse := transformer.ResponseT{
-				Events: []transformer.TransformerResponseT{
+			expectedResponse := transformer.Response{
+				Events: []transformer.TransformerResponse{
 					{
 						Output:     events[0].Message,
 						StatusCode: 200,
@@ -2395,9 +2382,9 @@ var _ = Describe("Static Function Tests", func() {
 				},
 			}
 
-			events := []transformer.TransformerEventT{
+			events := []transformer.TransformerEvent{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-1",
 						SourceDefinitionType: "web",
 					},
@@ -2408,7 +2395,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-2",
 						SourceDefinitionType: "web",
 					},
@@ -2419,7 +2406,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-2",
 						SourceDefinitionType: "web",
 					},
@@ -2430,7 +2417,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 			}
-			expectedResponse := transformer.ResponseT{
+			expectedResponse := transformer.Response{
 				Events:       nil,
 				FailedEvents: nil,
 			}
@@ -2472,9 +2459,9 @@ var _ = Describe("Static Function Tests", func() {
 				},
 			}
 
-			events := []transformer.TransformerEventT{
+			events := []transformer.TransformerEvent{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-1",
 						SourceDefinitionType: "web",
 					},
@@ -2485,7 +2472,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-2",
 						SourceDefinitionType: "web",
 					},
@@ -2496,7 +2483,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-2",
 						SourceDefinitionType: "web",
 					},
@@ -2507,8 +2494,8 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 			}
-			expectedResponse := transformer.ResponseT{
-				Events: []transformer.TransformerResponseT{
+			expectedResponse := transformer.Response{
+				Events: []transformer.TransformerResponse{
 					{
 						Output:     events[0].Message,
 						StatusCode: 200,
@@ -2555,9 +2542,9 @@ var _ = Describe("Static Function Tests", func() {
 				},
 			}
 
-			events := []transformer.TransformerEventT{
+			events := []transformer.TransformerEvent{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-1",
 						SourceDefinitionType: "web",
 					},
@@ -2568,7 +2555,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-2",
 						SourceDefinitionType: "web",
 					},
@@ -2579,7 +2566,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-2",
 						SourceDefinitionType: "web",
 					},
@@ -2590,8 +2577,8 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 			}
-			expectedResponse := transformer.ResponseT{
-				Events: []transformer.TransformerResponseT{
+			expectedResponse := transformer.Response{
+				Events: []transformer.TransformerResponse{
 					{
 						Output:     events[0].Message,
 						StatusCode: 200,
@@ -2641,9 +2628,9 @@ var _ = Describe("Static Function Tests", func() {
 				},
 			}
 
-			events := []transformer.TransformerEventT{
+			events := []transformer.TransformerEvent{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-1",
 						SourceDefinitionType: "web",
 					},
@@ -2654,7 +2641,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-2",
 						SourceDefinitionType: "web",
 					},
@@ -2665,7 +2652,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-2",
 						SourceDefinitionType: "web",
 					},
@@ -2676,8 +2663,8 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 			}
-			expectedResponse := transformer.ResponseT{
-				Events: []transformer.TransformerResponseT{
+			expectedResponse := transformer.Response{
+				Events: []transformer.TransformerResponse{
 					{
 						Output:     events[0].Message,
 						StatusCode: 200,
@@ -2730,9 +2717,9 @@ var _ = Describe("Static Function Tests", func() {
 				},
 			}
 
-			events := []transformer.TransformerEventT{
+			events := []transformer.TransformerEvent{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-1",
 						SourceDefinitionType: "",
 					},
@@ -2743,7 +2730,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-2",
 						SourceDefinitionType: "",
 					},
@@ -2754,7 +2741,7 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MessageID:            "message-2",
 						SourceDefinitionType: "",
 					},
@@ -2765,8 +2752,8 @@ var _ = Describe("Static Function Tests", func() {
 					Destination: destinationConfig,
 				},
 			}
-			expectedResponse := transformer.ResponseT{
-				Events: []transformer.TransformerResponseT{
+			expectedResponse := transformer.Response{
+				Events: []transformer.TransformerResponse{
 					{
 						Output:     events[0].Message,
 						StatusCode: 200,
@@ -2887,14 +2874,14 @@ func assertDestinationTransform(
 	expectations transformExpectation,
 ) func(
 	ctx context.Context,
-	clientEvents []transformer.TransformerEventT,
+	clientEvents []transformer.TransformerEvent,
 	batchSize int,
-) transformer.ResponseT {
+) transformer.Response {
 	return func(
 		ctx context.Context,
-		clientEvents []transformer.TransformerEventT,
+		clientEvents []transformer.TransformerEvent,
 		batchSize int,
-	) transformer.ResponseT {
+	) transformer.Response {
 		defer GinkgoRecover()
 
 		fmt.Println("clientEvents:", len(clientEvents))
@@ -2971,14 +2958,14 @@ func assertDestinationTransform(
 
 		Expect(strings.Join(messageIDs, ",")).To(Equal(expectations.messageIds))
 
-		return transformer.ResponseT{
-			Events: []transformer.TransformerResponseT{
+		return transformer.Response{
+			Events: []transformer.TransformerResponse{
 				{
 					Output: map[string]interface{}{
 						"int-value":    0,
 						"string-value": fmt.Sprintf("value-%s", destinationID),
 					},
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						SourceID:      "source-from-transformer",      // transformer should replay source id
 						DestinationID: "destination-from-transformer", // transformer should replay destination id
 					},
@@ -2988,7 +2975,7 @@ func assertDestinationTransform(
 						"int-value":    1,
 						"string-value": fmt.Sprintf("value-%s", destinationID),
 					},
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						SourceID:      "source-from-transformer",      // transformer should replay source id
 						DestinationID: "destination-from-transformer", // transformer should replay destination id
 					},
@@ -3183,7 +3170,7 @@ var _ = Describe("TestConfigFilter", func() {
 				Enabled:            true,
 				IsProcessorEnabled: true,
 			}
-			expectedEvent := transformer.TransformerEventT{
+			expectedEvent := transformer.TransformerEvent{
 				Message: types.SingularEventT{
 					"MessageID": "messageId-1",
 				},
@@ -3202,7 +3189,7 @@ var _ = Describe("TestConfigFilter", func() {
 					IsProcessorEnabled: true,
 				},
 			}
-			event := transformer.TransformerEventT{
+			event := transformer.TransformerEvent{
 				Message: types.SingularEventT{
 					"MessageID": "messageId-1",
 				},
@@ -3234,7 +3221,7 @@ var _ = Describe("TestConfigFilter", func() {
 			Expect(json.Unmarshal([]byte(intgConfigStr), &intgConfig)).To(BeNil())
 			Expect(json.Unmarshal([]byte(destDefStr), &destDef)).To(BeNil())
 			intgConfig.DestinationDefinition = destDef
-			expectedEvent := transformer.TransformerEventT{
+			expectedEvent := transformer.TransformerEvent{
 				Message: types.SingularEventT{
 					"MessageID": "messageId-1",
 				},
@@ -3253,7 +3240,7 @@ var _ = Describe("TestConfigFilter", func() {
 					IsProcessorEnabled: true,
 				},
 			}
-			event := transformer.TransformerEventT{
+			event := transformer.TransformerEvent{
 				Message: types.SingularEventT{
 					"MessageID": "messageId-1",
 				},
@@ -3280,7 +3267,7 @@ var _ = Describe("TestConfigFilter", func() {
 				Enabled:            true,
 				IsProcessorEnabled: true,
 			}
-			expectedEvent := transformer.TransformerEventT{
+			expectedEvent := transformer.TransformerEvent{
 				Message: types.SingularEventT{
 					"MessageID": "messageId-1",
 				},
@@ -3301,7 +3288,7 @@ var _ = Describe("TestConfigFilter", func() {
 					IsProcessorEnabled: true,
 				},
 			}
-			event := transformer.TransformerEventT{
+			event := transformer.TransformerEvent{
 				Message: types.SingularEventT{
 					"MessageID": "messageId-1",
 				},

--- a/processor/trackingplan.go
+++ b/processor/trackingplan.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"context"
 	"strconv"
 	"time"
 
@@ -78,7 +79,7 @@ func (proc *Handle) validateEvents(groupedEventsByWriteKey map[WriteKeyT][]trans
 		}
 
 		validationStart := time.Now()
-		response := proc.transformer.Validate(eventList, integrations.GetTrackingPlanValidationURL(), proc.config.userTransformBatchSize)
+		response := proc.transformer.Transform(context.TODO(), eventList, integrations.GetTrackingPlanValidationURL(), proc.config.userTransformBatchSize, transformer.TrackingPlanValidationStage)
 		validationStat.tpValidationTime.Since(validationStart)
 
 		// If transformerInput does not match with transformerOutput then we do not consider transformerOutput

--- a/processor/trackingplan.go
+++ b/processor/trackingplan.go
@@ -8,7 +8,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/jobsdb"
-	"github.com/rudderlabs/rudder-server/processor/integrations"
 	"github.com/rudderlabs/rudder-server/processor/transformer"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/types"
@@ -79,7 +78,7 @@ func (proc *Handle) validateEvents(groupedEventsByWriteKey map[WriteKeyT][]trans
 		}
 
 		validationStart := time.Now()
-		response := proc.transformer.Transform(context.TODO(), eventList, integrations.GetTrackingPlanValidationURL(), proc.config.userTransformBatchSize, transformer.TrackingPlanValidationStage)
+		response := proc.transformer.Validate(context.TODO(), eventList, proc.config.userTransformBatchSize)
 		validationStat.tpValidationTime.Since(validationStart)
 
 		// If transformerInput does not match with transformerOutput then we do not consider transformerOutput

--- a/processor/trackingplan.go
+++ b/processor/trackingplan.go
@@ -22,7 +22,7 @@ type TrackingPlanStatT struct {
 
 // reportViolations It is going add violationErrors in context depending upon certain criteria:
 // 1. sourceSchemaConfig in Metadata.MergedTpConfig should be true
-func reportViolations(validateEvent *transformer.TransformerResponseT, trackingPlanId string, trackingPlanVersion int) {
+func reportViolations(validateEvent *transformer.TransformerResponse, trackingPlanId string, trackingPlanVersion int) {
 	if validateEvent.Metadata.MergedTpConfig["propagateValidationErrors"] == "false" {
 		return
 	}
@@ -40,7 +40,7 @@ func reportViolations(validateEvent *transformer.TransformerResponseT, trackingP
 // enhanceWithViolation It enhances extra information of ValidationErrors in context for:
 // 1. response.Events
 // 1. response.FailedEvents
-func enhanceWithViolation(response transformer.ResponseT, trackingPlanId string, trackingPlanVersion int) {
+func enhanceWithViolation(response transformer.Response, trackingPlanId string, trackingPlanVersion int) {
 	for i := range response.Events {
 		validatedEvent := &response.Events[i]
 		reportViolations(validatedEvent, trackingPlanId, trackingPlanVersion)
@@ -53,11 +53,11 @@ func enhanceWithViolation(response transformer.ResponseT, trackingPlanId string,
 }
 
 // validateEvents If the TrackingPlanId exist for a particular write key then we are going to Validate from the transformer.
-// The ResponseT will contain both the Events and FailedEvents
+// The Response will contain both the Events and FailedEvents
 // 1. eventsToTransform gets added to validatedEventsByWriteKey
 // 2. failedJobs gets added to validatedErrorJobs
-func (proc *Handle) validateEvents(groupedEventsByWriteKey map[WriteKeyT][]transformer.TransformerEventT, eventsByMessageID map[string]types.SingularEventWithReceivedAt) (map[WriteKeyT][]transformer.TransformerEventT, []*types.PUReportedMetric, []*jobsdb.JobT, map[SourceIDT]bool) {
-	validatedEventsByWriteKey := make(map[WriteKeyT][]transformer.TransformerEventT)
+func (proc *Handle) validateEvents(groupedEventsByWriteKey map[WriteKeyT][]transformer.TransformerEvent, eventsByMessageID map[string]types.SingularEventWithReceivedAt) (map[WriteKeyT][]transformer.TransformerEvent, []*types.PUReportedMetric, []*jobsdb.JobT, map[SourceIDT]bool) {
+	validatedEventsByWriteKey := make(map[WriteKeyT][]transformer.TransformerEvent)
 	validatedReportMetrics := make([]*types.PUReportedMetric, 0)
 	validatedErrorJobs := make([]*jobsdb.JobT, 0)
 	trackingPlanEnabledMap := make(map[SourceIDT]bool)
@@ -72,7 +72,7 @@ func (proc *Handle) validateEvents(groupedEventsByWriteKey map[WriteKeyT][]trans
 		isTpExists := eventList[0].Metadata.TrackingPlanId != ""
 		if !isTpExists {
 			// pass on the jobs for transformation(User, Dest)
-			validatedEventsByWriteKey[writeKey] = make([]transformer.TransformerEventT, 0)
+			validatedEventsByWriteKey[writeKey] = make([]transformer.TransformerEvent, 0)
 			validatedEventsByWriteKey[writeKey] = append(validatedEventsByWriteKey[writeKey], eventList...)
 			continue
 		}
@@ -85,7 +85,7 @@ func (proc *Handle) validateEvents(groupedEventsByWriteKey map[WriteKeyT][]trans
 		// This is a safety check we are adding so that if something unexpected comes from transformer
 		// We are ignoring it.
 		if (len(response.Events) + len(response.FailedEvents)) != len(eventList) {
-			validatedEventsByWriteKey[writeKey] = make([]transformer.TransformerEventT, 0)
+			validatedEventsByWriteKey[writeKey] = make([]transformer.TransformerEvent, 0)
 			validatedEventsByWriteKey[writeKey] = append(validatedEventsByWriteKey[writeKey], eventList...)
 			continue
 		}
@@ -122,16 +122,16 @@ func (proc *Handle) validateEvents(groupedEventsByWriteKey map[WriteKeyT][]trans
 		if len(eventsToTransform) == 0 {
 			continue
 		}
-		validatedEventsByWriteKey[writeKey] = make([]transformer.TransformerEventT, 0)
+		validatedEventsByWriteKey[writeKey] = make([]transformer.TransformerEvent, 0)
 		validatedEventsByWriteKey[writeKey] = append(validatedEventsByWriteKey[writeKey], eventsToTransform...)
 	}
 	return validatedEventsByWriteKey, validatedReportMetrics, validatedErrorJobs, trackingPlanEnabledMap
 }
 
-// makeCommonMetadataFromTransformerEvent Creates a new MetadataT instance
-func makeCommonMetadataFromTransformerEvent(transformerEvent *transformer.TransformerEventT) *transformer.MetadataT {
+// makeCommonMetadataFromTransformerEvent Creates a new Metadata instance
+func makeCommonMetadataFromTransformerEvent(transformerEvent *transformer.TransformerEvent) *transformer.Metadata {
 	metadata := transformerEvent.Metadata
-	commonMetaData := transformer.MetadataT{
+	commonMetaData := transformer.Metadata{
 		SourceID:        metadata.SourceID,
 		SourceType:      metadata.SourceType,
 		SourceCategory:  metadata.SourceCategory,
@@ -145,7 +145,7 @@ func makeCommonMetadataFromTransformerEvent(transformerEvent *transformer.Transf
 }
 
 // newValidationStat Creates a new TrackingPlanStatT instance
-func (proc *Handle) newValidationStat(metadata *transformer.MetadataT) *TrackingPlanStatT {
+func (proc *Handle) newValidationStat(metadata *transformer.Metadata) *TrackingPlanStatT {
 	tags := map[string]string{
 		"destination":         metadata.DestinationID,
 		"destType":            metadata.DestinationType,

--- a/processor/trackingplan_test.go
+++ b/processor/trackingplan_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestReportViolations(t *testing.T) {
-	eventsFromTransformerResponse := func(response *transformer.ResponseT) (events []transformer.TransformerResponseT) {
+	eventsFromTransformerResponse := func(response *transformer.Response) (events []transformer.TransformerResponse) {
 		events = append(events, response.Events...)
 		events = append(events, response.FailedEvents...)
 		return
@@ -21,10 +21,10 @@ func TestReportViolations(t *testing.T) {
 			trackingPlanVersion int
 		)
 
-		response := transformer.ResponseT{
-			Events: []transformer.TransformerResponseT{
+		response := transformer.Response{
+			Events: []transformer.TransformerResponse{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MergedTpConfig: map[string]interface{}{
 							"propagateValidationErrors": "false",
 						},
@@ -34,9 +34,9 @@ func TestReportViolations(t *testing.T) {
 					},
 				},
 			},
-			FailedEvents: []transformer.TransformerResponseT{
+			FailedEvents: []transformer.TransformerResponse{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MergedTpConfig: map[string]interface{}{
 							"propagateValidationErrors": "false",
 						},
@@ -59,10 +59,10 @@ func TestReportViolations(t *testing.T) {
 	})
 
 	t.Run("Propagate validation errors", func(t *testing.T) {
-		response := transformer.ResponseT{
-			Events: []transformer.TransformerResponseT{
+		response := transformer.Response{
+			Events: []transformer.TransformerResponse{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MergedTpConfig: map[string]interface{}{
 							"propagateValidationErrors": "true",
 						},
@@ -82,9 +82,9 @@ func TestReportViolations(t *testing.T) {
 					},
 				},
 			},
-			FailedEvents: []transformer.TransformerResponseT{
+			FailedEvents: []transformer.TransformerResponse{
 				{
-					Metadata: transformer.MetadataT{
+					Metadata: transformer.Metadata{
 						MergedTpConfig: map[string]interface{}{
 							"propagateValidationErrors": "true",
 						},

--- a/processor/trackingplan_test.go
+++ b/processor/trackingplan_test.go
@@ -70,7 +70,7 @@ func TestReportViolations(t *testing.T) {
 					Output: map[string]interface{}{
 						"context": map[string]interface{}{},
 					},
-					ValidationErrors: []transformer.ValidationErrorT{
+					ValidationErrors: []transformer.ValidationError{
 						{
 							Type: "Datatype-Mismatch",
 							Meta: map[string]string{
@@ -92,7 +92,7 @@ func TestReportViolations(t *testing.T) {
 					Output: map[string]interface{}{
 						"context": map[string]interface{}{},
 					},
-					ValidationErrors: []transformer.ValidationErrorT{
+					ValidationErrors: []transformer.ValidationError{
 						{
 							Type: "Datatype-Mismatch",
 							Meta: map[string]string{

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -43,16 +43,7 @@ const (
 	TransformerRequestTimeout = 919
 )
 
-var (
-	json                    = jsoniter.ConfigCompatibleWithStandardLibrary
-	warehouseDestinationMap map[string]struct{}
-)
-
-func init() {
-	warehouseDestinationMap = lo.SliceToMap(warehouseutils.WarehouseDestinations, func(destination string) (string, struct{}) {
-		return destination, struct{}{}
-	})
-}
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 type Metadata struct {
 	SourceID            string                            `json:"sourceId"`
@@ -502,7 +493,7 @@ func (trans *handle) doPost(ctx context.Context, rawJSON []byte, url, stage stri
 func (trans *handle) destTransformURL(destType string) string {
 	destinationEndPoint := fmt.Sprintf("%s/v0/destinations/%s", trans.config.destTransformationURL, strings.ToLower(destType))
 
-	if _, ok := warehouseDestinationMap[destType]; ok {
+	if _, ok := warehouseutils.WarehouseDestinationMap[destType]; ok {
 		whSchemaVersionQueryParam := fmt.Sprintf("whSchemaVersion=%s&whIDResolve=%v", trans.conf.GetString("Warehouse.schemaVersion", "v1"), warehouseutils.IDResolutionEnabled())
 		if destType == warehouseutils.RS {
 			return destinationEndPoint + "?" + whSchemaVersionQueryParam

--- a/processor/transformer/transformer_test.go
+++ b/processor/transformer/transformer_test.go
@@ -1,209 +1,459 @@
-package transformer_test
+package transformer
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/gateway/response"
+
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-server/gateway/response"
-	"github.com/rudderlabs/rudder-server/processor/transformer"
 )
 
 type fakeTransformer struct {
-	requests [][]transformer.TransformerEventT
+	requests [][]TransformerEventT
+	t        testing.TB
 }
 
 func (t *fakeTransformer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	var reqBody []transformer.TransformerEventT
-	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
-		panic(err)
-	}
+	var reqBody []TransformerEventT
+	require.NoError(t.t, json.NewDecoder(r.Body).Decode(&reqBody))
 
 	t.requests = append(t.requests, reqBody)
-	resps := make([]transformer.TransformerResponseT, len(reqBody))
+
+	responses := make([]TransformerResponseT, len(reqBody))
+
 	for i := range reqBody {
 		statusCode := int(reqBody[i].Message["forceStatusCode"].(float64))
 		delete(reqBody[i].Message, "forceStatusCode")
 		reqBody[i].Message["echo-key-1"] = reqBody[i].Message["src-key-1"]
 
-		resps[i] = transformer.TransformerResponseT{
+		responses[i] = TransformerResponseT{
 			Output:     reqBody[i].Message,
 			Metadata:   reqBody[i].Metadata,
 			StatusCode: statusCode,
 			Error:      "",
 		}
 		if statusCode >= 400 {
-			resps[i].Error = "error"
+			responses[i].Error = "error"
 		}
 	}
+
 	w.Header().Set("apiVersion", "2")
-	if err := json.NewEncoder(w).Encode(resps); err != nil {
-		panic(err)
-	}
-}
 
-func Test_Transformer(t *testing.T) {
-	config.Reset()
-	logger.Reset()
-	transformer.Init()
-
-	ft := &fakeTransformer{}
-
-	srv := httptest.NewServer(ft)
-	defer srv.Close()
-
-	tr := transformer.NewTransformer()
-	tr.Client = srv.Client()
-
-	tr.Setup()
-
-	tc := []struct {
-		batchSize   int
-		eventsCount int
-		failEvery   int
-	}{
-		{batchSize: 10, eventsCount: 100},
-		{batchSize: 10, eventsCount: 9},
-		{batchSize: 10, eventsCount: 91},
-		{batchSize: 10, eventsCount: 99},
-		{batchSize: 10, eventsCount: 1},
-		{batchSize: 10, eventsCount: 80, failEvery: 4},
-		{batchSize: 10, eventsCount: 80, failEvery: 1},
-	}
-
-	for _, tt := range tc {
-		batchSize := tt.batchSize
-		eventsCount := tt.eventsCount
-		failEvery := tt.failEvery
-
-		events := make([]transformer.TransformerEventT, eventsCount)
-		expectedResponse := transformer.ResponseT{}
-
-		for i := range events {
-			msgID := fmt.Sprintf("messageID-%d", i)
-			statusCode := 200
-
-			if failEvery != 0 && i%failEvery == 0 {
-				statusCode = 400
-			}
-
-			events[i] = transformer.TransformerEventT{
-				Metadata: transformer.MetadataT{
-					MessageID: msgID,
-				},
-				Message: map[string]interface{}{
-					"src-key-1":       msgID,
-					"forceStatusCode": statusCode,
-				},
-			}
-
-			tresp := transformer.TransformerResponseT{
-				Metadata: transformer.MetadataT{
-					MessageID: msgID,
-				},
-				StatusCode: statusCode,
-				Output: map[string]interface{}{
-					"src-key-1":  msgID,
-					"echo-key-1": msgID,
-				},
-			}
-
-			if statusCode < 400 {
-				expectedResponse.Events = append(expectedResponse.Events, tresp)
-			} else {
-				tresp.Error = "error"
-				expectedResponse.FailedEvents = append(expectedResponse.FailedEvents, tresp)
-			}
-
-		}
-
-		rsp := tr.Transform(context.TODO(), events, srv.URL, batchSize)
-		require.Equal(t, expectedResponse, rsp)
-	}
-}
-
-func Test_EndlessLoopIf809(t *testing.T) {
-	transformer.Init()
-
-	ft := &endlessLoopTransformer{
-		maxRetryCount: 3,
-		t:             t,
-	}
-
-	srv := httptest.NewServer(ft)
-	defer srv.Close()
-
-	tr := transformer.NewTransformer()
-	tr.Client = srv.Client()
-
-	tr.Setup()
-
-	msgID := "messageID-0"
-	events := make([]transformer.TransformerEventT, 1)
-	events[0] = transformer.TransformerEventT{
-		Metadata: transformer.MetadataT{
-			MessageID: msgID,
-		},
-		Message: map[string]interface{}{
-			"src-key-1": msgID,
-		},
-	}
-
-	rsp := tr.Transform(context.TODO(), events, srv.URL, 10)
-	require.Equal(
-		t,
-		transformer.ResponseT{
-			Events: []transformer.TransformerResponseT{
-				{
-					Metadata: transformer.MetadataT{
-						MessageID: msgID,
-					},
-					StatusCode: 200,
-					Output: map[string]interface{}{
-						"src-key-1": msgID,
-					},
-				},
-			},
-		},
-		rsp,
-	)
-	require.Equal(t, ft.retryCount, ft.maxRetryCount)
+	require.NoError(t.t, json.NewEncoder(w).Encode(responses))
 }
 
 type endlessLoopTransformer struct {
 	retryCount    int
 	maxRetryCount int
-	t             *testing.T
+
+	apiVersion int
+
+	statusCode  int
+	statusError string
+
+	t testing.TB
 }
 
 func (elt *endlessLoopTransformer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	var reqBody []transformer.TransformerEventT
+	elt.retryCount++
+
+	var reqBody []TransformerEventT
 	require.NoError(elt.t, json.NewDecoder(r.Body).Decode(&reqBody))
 
-	resps := make([]transformer.TransformerResponseT, len(reqBody))
-	var statusCode int
+	responses := make([]TransformerResponseT, len(reqBody))
+
 	if elt.retryCount < elt.maxRetryCount {
-		elt.retryCount++
-		http.Error(w, response.MakeResponse("control plane not reachable"), 809)
+		http.Error(w, response.MakeResponse(elt.statusError), elt.statusCode)
 		return
-	} else {
-		for i := range reqBody {
-			statusCode = 200
-			resps[i] = transformer.TransformerResponseT{
-				Output:     reqBody[i].Message,
-				Metadata:   reqBody[i].Metadata,
-				StatusCode: statusCode,
-				Error:      "",
-			}
+	}
+
+	for i := range reqBody {
+		responses[i] = TransformerResponseT{
+			Output:     reqBody[i].Message,
+			Metadata:   reqBody[i].Metadata,
+			StatusCode: http.StatusOK,
+			Error:      "",
 		}
 	}
-	w.Header().Set("apiVersion", "2")
-	require.NoError(elt.t, json.NewEncoder(w).Encode(resps))
+
+	w.Header().Set("apiVersion", strconv.Itoa(elt.apiVersion))
+
+	require.NoError(elt.t, json.NewEncoder(w).Encode(responses))
+}
+
+func TestTransformer(t *testing.T) {
+	Init()
+
+	t.Run("success", func(t *testing.T) {
+		ft := &fakeTransformer{
+			t: t,
+		}
+
+		srv := httptest.NewServer(ft)
+		defer srv.Close()
+
+		tr := NewTransformer()
+		tr.Client = srv.Client()
+
+		tr.Setup(config.Default, logger.NOP, stats.Default)
+
+		tc := []struct {
+			batchSize   int
+			eventsCount int
+			failEvery   int
+		}{
+			{batchSize: 10, eventsCount: 100},
+			{batchSize: 10, eventsCount: 9},
+			{batchSize: 10, eventsCount: 91},
+			{batchSize: 10, eventsCount: 99},
+			{batchSize: 10, eventsCount: 1},
+			{batchSize: 10, eventsCount: 80, failEvery: 4},
+			{batchSize: 10, eventsCount: 80, failEvery: 1},
+		}
+
+		for _, tt := range tc {
+			batchSize := tt.batchSize
+			eventsCount := tt.eventsCount
+			failEvery := tt.failEvery
+
+			events := make([]TransformerEventT, eventsCount)
+			expectedResponse := ResponseT{}
+
+			for i := range events {
+				msgID := fmt.Sprintf("messageID-%d", i)
+				statusCode := http.StatusOK
+
+				if failEvery != 0 && i%failEvery == 0 {
+					statusCode = http.StatusBadRequest
+				}
+
+				events[i] = TransformerEventT{
+					Metadata: MetadataT{
+						MessageID: msgID,
+					},
+					Message: map[string]interface{}{
+						"src-key-1":       msgID,
+						"forceStatusCode": statusCode,
+					},
+				}
+
+				tResp := TransformerResponseT{
+					Metadata: MetadataT{
+						MessageID: msgID,
+					},
+					StatusCode: statusCode,
+					Output: map[string]interface{}{
+						"src-key-1":  msgID,
+						"echo-key-1": msgID,
+					},
+				}
+
+				if statusCode < http.StatusBadRequest {
+					expectedResponse.Events = append(expectedResponse.Events, tResp)
+				} else {
+					tResp.Error = "error"
+					expectedResponse.FailedEvents = append(expectedResponse.FailedEvents, tResp)
+				}
+			}
+
+			rsp := tr.Transform(context.TODO(), events, srv.URL, batchSize, "test-stage")
+			require.Equal(t, expectedResponse, rsp)
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		msgID := "messageID-0"
+		events := make([]TransformerEventT, 1)
+		events[0] = TransformerEventT{
+			Metadata: MetadataT{
+				MessageID: msgID,
+			},
+			Message: map[string]interface{}{
+				"src-key-1": msgID,
+			},
+		}
+
+		testCases := []struct {
+			name             string
+			retries          int
+			expectedRetries  int
+			expectPanic      bool
+			stage            string
+			expectedResponse []TransformerResponseT
+			failOnTimeout    bool
+		}{
+			{
+				name:          "user transformation timeout",
+				retries:       3,
+				stage:         UserTransformerStage,
+				expectPanic:   true,
+				failOnTimeout: false,
+			},
+			{
+				name:        "user transformation timeout with fail on timeout",
+				retries:     3,
+				stage:       UserTransformerStage,
+				expectPanic: false,
+				expectedResponse: []TransformerResponseT{
+					{
+						Metadata: MetadataT{
+							MessageID: msgID,
+						},
+						StatusCode: TransformerRequestTimeout,
+						Output: map[string]interface{}{
+							"src-key-1": msgID,
+						},
+					},
+				},
+				failOnTimeout: true,
+			},
+			{
+				name:          "destination transformation timeout",
+				retries:       3,
+				stage:         DestTransformerStage,
+				expectPanic:   true,
+				failOnTimeout: false,
+			},
+			{
+				name:          "destination transformation timeout with fail on timeout",
+				retries:       3,
+				stage:         DestTransformerStage,
+				expectPanic:   true,
+				failOnTimeout: true,
+			},
+		}
+
+		for _, tc := range testCases {
+			tc := tc
+
+			t.Run(tc.name, func(t *testing.T) {
+				ch := make(chan struct{})
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					<-ch
+				}))
+				defer srv.Close()
+
+				c := config.New()
+				c.Set("Processor.maxRetry", tc.retries)
+				c.Set("Processor.Transformer.failOnTimeout", tc.failOnTimeout)
+
+				tr := NewTransformer()
+				tr.Client = srv.Client()
+				tr.Client.Timeout = 1 * time.Millisecond
+				tr.Setup(c, logger.NOP, stats.Default)
+
+				if tc.expectPanic {
+					require.Panics(t, func() {
+						_ = tr.request(context.TODO(), srv.URL, tc.stage, events)
+					})
+					close(ch)
+					return
+				}
+
+				u, err := url.Parse(srv.URL)
+				require.NoError(t, err)
+
+				rsp := tr.request(context.TODO(), srv.URL, tc.stage, events)
+				require.Len(t, rsp, 1)
+				require.Equal(t, rsp[0].StatusCode, TransformerRequestTimeout)
+				require.Equal(t, rsp[0].Metadata, MetadataT{
+					MessageID: msgID,
+				})
+				require.Equal(t, rsp[0].Error, errors.New(`transformer request timed out: Post "http://127.0.0.1:`+u.Port()+`": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`).Error())
+				close(ch)
+			})
+		}
+	})
+
+	t.Run("endless in case of control plane down", func(t *testing.T) {
+		msgID := "messageID-0"
+		events := make([]TransformerEventT, 1)
+		events[0] = TransformerEventT{
+			Metadata: MetadataT{
+				MessageID: msgID,
+			},
+			Message: map[string]interface{}{
+				"src-key-1": msgID,
+			},
+		}
+
+		elt := &endlessLoopTransformer{
+			maxRetryCount: 3,
+			statusCode:    StatusCPDown,
+			statusError:   "control plane not reachable",
+			apiVersion:    2,
+			t:             t,
+		}
+
+		srv := httptest.NewServer(elt)
+		defer srv.Close()
+
+		c := config.New()
+		c.Set("Processor.maxRetry", 1)
+
+		tr := NewTransformer()
+		tr.Client = srv.Client()
+		tr.Setup(c, logger.NOP, stats.Default)
+
+		rsp := tr.request(context.TODO(), srv.URL, "test-stage", events)
+		require.Equal(t, rsp, []TransformerResponseT{
+			{
+				Metadata: MetadataT{
+					MessageID: msgID,
+				},
+				StatusCode: http.StatusOK,
+				Output: map[string]interface{}{
+					"src-key-1": msgID,
+				},
+			},
+		})
+		require.Equal(t, elt.retryCount, 3)
+	})
+
+	t.Run("retries", func(t *testing.T) {
+		msgID := "messageID-0"
+		events := make([]TransformerEventT, 1)
+		events[0] = TransformerEventT{
+			Metadata: MetadataT{
+				MessageID: msgID,
+			},
+			Message: map[string]interface{}{
+				"src-key-1": msgID,
+			},
+			Destination: backendconfig.DestinationT{
+				Transformations: []backendconfig.TransformationT{
+					{
+						ID:        "test-transformation",
+						VersionID: "test-version",
+					},
+				},
+			},
+		}
+
+		testCases := []struct {
+			name             string
+			retries          int
+			maxRetryCount    int
+			statusCode       int
+			apiVersion       int
+			statusError      string
+			expectedRetries  int
+			expectPanic      bool
+			expectedResponse []TransformerResponseT
+			failOnError      bool
+		}{
+			{
+				name:            "too many requests",
+				retries:         3,
+				maxRetryCount:   10,
+				apiVersion:      2,
+				statusCode:      http.StatusTooManyRequests,
+				statusError:     "too many requests",
+				expectedRetries: 4,
+				expectPanic:     true,
+				failOnError:     false,
+			},
+			{
+				name:            "too many requests with fail on error",
+				retries:         3,
+				maxRetryCount:   10,
+				apiVersion:      2,
+				statusCode:      http.StatusTooManyRequests,
+				statusError:     "too many requests",
+				expectedRetries: 4,
+				expectPanic:     false,
+				expectedResponse: []TransformerResponseT{
+					{
+						Metadata: MetadataT{
+							MessageID: msgID,
+						},
+						StatusCode: TransformerRequestFailure,
+						Error:      "transformer request failed: transformer returned status code: 429",
+					},
+				},
+				failOnError: true,
+			},
+			{
+				name:            "transient control plane error",
+				retries:         30,
+				maxRetryCount:   3,
+				apiVersion:      2,
+				statusCode:      StatusCPDown,
+				statusError:     "control plane not reachable",
+				expectedRetries: 3,
+				expectPanic:     false,
+				expectedResponse: []TransformerResponseT{
+					{
+						Metadata: MetadataT{
+							MessageID: msgID,
+						},
+						StatusCode: http.StatusOK,
+						Output: map[string]interface{}{
+							"src-key-1": msgID,
+						},
+					},
+				},
+				failOnError: false,
+			},
+			{
+				name:            "incompatible api version",
+				retries:         30,
+				maxRetryCount:   0,
+				apiVersion:      1,
+				expectedRetries: 1,
+				expectPanic:     true,
+			},
+		}
+
+		for _, tc := range testCases {
+			tc := tc
+
+			t.Run(tc.name, func(t *testing.T) {
+				elt := &endlessLoopTransformer{
+					maxRetryCount: tc.maxRetryCount,
+					statusCode:    tc.statusCode,
+					statusError:   tc.statusError,
+					apiVersion:    tc.apiVersion,
+					t:             t,
+				}
+
+				srv := httptest.NewServer(elt)
+				defer srv.Close()
+
+				c := config.New()
+				c.Set("Processor.maxRetry", tc.retries)
+				c.Set("Processor.Transformer.failOnError", tc.failOnError)
+
+				tr := NewTransformer()
+				tr.Client = srv.Client()
+				tr.Setup(c, logger.NOP, stats.Default)
+
+				if tc.expectPanic {
+					require.Panics(t, func() {
+						_ = tr.request(context.TODO(), srv.URL, "test-stage", events)
+					})
+					require.Equal(t, elt.retryCount, tc.expectedRetries)
+					return
+				}
+
+				rsp := tr.request(context.TODO(), srv.URL, "test-stage", events)
+				require.Equal(t, tc.expectedResponse, rsp)
+				require.Equal(t, tc.expectedRetries, elt.retryCount)
+			})
+		}
+	})
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -30,7 +30,6 @@ import (
 	"github.com/rudderlabs/rudder-server/gateway/webhook"
 	"github.com/rudderlabs/rudder-server/info"
 	"github.com/rudderlabs/rudder-server/jobsdb"
-	"github.com/rudderlabs/rudder-server/processor/integrations"
 	"github.com/rudderlabs/rudder-server/processor/stash"
 	"github.com/rudderlabs/rudder-server/processor/transformer"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager"
@@ -358,7 +357,6 @@ func runAllInit() {
 	customdestinationmanager.Init()
 	routertransformer.Init()
 	gateway.Init()
-	integrations.Init()
 	alert.Init()
 	oauth.Init()
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -346,7 +346,6 @@ func runAllInit() {
 	warehouse.Init6()
 	warehousearchiver.Init()
 	validations.Init()
-	transformer.Init()
 	webhook.Init()
 	asyncdestinationmanager.Init()
 	batchrouterutils.Init()

--- a/services/debugger/transformation/transformationStatusUploader.go
+++ b/services/debugger/transformation/transformationStatusUploader.go
@@ -24,9 +24,9 @@ type TransformationStatusT struct {
 	SourceID              string
 	DestID                string
 	Destination           *backendconfig.DestinationT
-	UserTransformedEvents []transformer.TransformerEventT
+	UserTransformedEvents []transformer.TransformerEvent
 	EventsByMessageID     map[string]types.SingularEventWithReceivedAt
-	FailedEvents          []transformer.TransformerResponseT
+	FailedEvents          []transformer.TransformerResponse
 	UniqueMessageIds      map[string]struct{}
 }
 
@@ -236,13 +236,13 @@ func (ts *TransformationStatusT) Limit(
 		append(
 			lo.Map(
 				ts.UserTransformedEvents,
-				func(event transformer.TransformerEventT, _ int) string {
+				func(event transformer.TransformerEvent, _ int) string {
 					return event.Metadata.MessageID
 				},
 			),
 			lo.Map(
 				ts.FailedEvents,
-				func(event transformer.TransformerResponseT, _ int) string {
+				func(event transformer.TransformerResponse, _ int) string {
 					return event.Metadata.MessageID
 				},
 			)...,

--- a/services/debugger/transformation/transformationStatusUploader_test.go
+++ b/services/debugger/transformation/transformationStatusUploader_test.go
@@ -323,13 +323,13 @@ var _ = Describe("eventDeliveryStatusUploader", func() {
 func TestLimit(t *testing.T) {
 	var (
 		singularEvent1 = types.SingularEventT{"payload": "event-1"}
-		metadata1      = transformer.MetadataT{MessageID: "message-id-1"}
+		metadata1      = transformer.Metadata{MessageID: "message-id-1"}
 		singularEvent2 = types.SingularEventT{"payload": "event-2"}
-		metadata2      = transformer.MetadataT{MessageID: "message-id-2"}
+		metadata2      = transformer.Metadata{MessageID: "message-id-2"}
 		singularEvent3 = types.SingularEventT{"payload": "event-3"}
-		metadata3      = transformer.MetadataT{MessageID: "message-id-3"}
+		metadata3      = transformer.Metadata{MessageID: "message-id-3"}
 		singularEvent4 = types.SingularEventT{"payload": "event-4"}
-		metadata4      = transformer.MetadataT{MessageID: "message-id-4"}
+		metadata4      = transformer.Metadata{MessageID: "message-id-4"}
 		now            = time.Now()
 		limit          = 1
 	)
@@ -338,7 +338,7 @@ func TestLimit(t *testing.T) {
 			Destination: &sampleBackendConfig.Sources[1].Destinations[1],
 			DestID:      sampleBackendConfig.Sources[1].Destinations[1].ID,
 			SourceID:    sampleBackendConfig.Sources[1].ID,
-			UserTransformedEvents: []transformer.TransformerEventT{
+			UserTransformedEvents: []transformer.TransformerEvent{
 				{
 					Message:  singularEvent1,
 					Metadata: metadata1,
@@ -366,7 +366,7 @@ func TestLimit(t *testing.T) {
 					ReceivedAt:    now,
 				},
 			},
-			FailedEvents: []transformer.TransformerResponseT{
+			FailedEvents: []transformer.TransformerResponse{
 				{
 					Output:   singularEvent1,
 					Metadata: metadata3,
@@ -400,7 +400,7 @@ func TestLimit(t *testing.T) {
 		)
 		require.Equal(
 			t,
-			[]transformer.TransformerEventT{
+			[]transformer.TransformerEvent{
 				{
 					Message:  singularEvent1,
 					Metadata: metadata1,
@@ -410,7 +410,7 @@ func TestLimit(t *testing.T) {
 		)
 		require.Equal(
 			t,
-			[]transformer.TransformerResponseT{
+			[]transformer.TransformerResponse{
 				{
 					Output:   singularEvent1,
 					Metadata: metadata3,

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/samber/lo"
+
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
@@ -141,6 +143,10 @@ var (
 	IdentityEnabledWarehouses = []string{SNOWFLAKE, BQ}
 	S3PathStyleRegex          = regexp.MustCompile(`https?://s3([.-](?P<region>[^.]+))?.amazonaws\.com/(?P<bucket>[^/]+)/(?P<keyname>.*)`)
 	S3VirtualHostedRegex      = regexp.MustCompile(`https?://(?P<bucket>[^/]+).s3([.-](?P<region>[^.]+))?.amazonaws\.com/(?P<keyname>.*)`)
+
+	WarehouseDestinationMap = lo.SliceToMap(WarehouseDestinations, func(destination string) (string, struct{}) {
+		return destination, struct{}{}
+	})
 )
 
 var WHDestNameMap = map[string]string{


### PR DESCRIPTION
# Description

- Add support for handling panics in case of user transformations for timeouts.
- Small refactoring around removing globals.

## Notion Ticket

https://www.notion.so/rudderstacks/Hosted-abort-jobs-timed-out-during-UT-c21526789be046b3bec857bd239b8ae3?pvs=4

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
