### PR TITLE
chore(jobsdb): tuning and improvements

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -2664,6 +2664,7 @@ func (jd *HandleT) refreshDSList(ctx context.Context) error {
 	if previousLastDS.Index == nextLastDS.Index {
 		return nil
 	}
+	defer stats.Default.NewTaggedStat("refresh_ds_loop_lock", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix}).RecordDuration()()
 	err = jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
 		return jd.doRefreshDSRangeList(l)
 	})

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -647,7 +647,6 @@ var (
 	backupRowsBatchSize                          int64
 	backupMaxTotalPayloadSize                    int64
 	pkgLogger                                    logger.Logger
-	jobStatusCountMigrationCheck                 bool // TODO: Remove this in next release
 )
 
 // Loads db config and migration related config from config file
@@ -667,7 +666,7 @@ func loadConfig() {
 	refreshDSListLoopSleepDuration: How often is the loop (which refreshes DSList) run
 	maxTableSizeInMB: Maximum Table size in MB
 	*/
-	config.RegisterFloat64ConfigVariable(0.8, &jobDoneMigrateThres, true, "JobsDB.jobDoneMigrateThres")
+	config.RegisterFloat64ConfigVariable(0.7, &jobDoneMigrateThres, true, "JobsDB.jobDoneMigrateThres")
 	config.RegisterFloat64ConfigVariable(3, &jobStatusMigrateThres, true, "JobsDB.jobStatusMigrateThres")
 	config.RegisterFloat64ConfigVariable(0.2, &jobMinRowsMigrateThres, true, "JobsDB.jobMinRowsMigrateThres")
 	config.RegisterIntConfigVariable(100000, &maxDSSize, true, 1, "JobsDB.maxDSSize")
@@ -680,11 +679,10 @@ func loadConfig() {
 	config.RegisterInt64ConfigVariable(64*bytesize.MB, &backupMaxTotalPayloadSize, true, 1, "JobsDB.maxBackupTotalPayloadSize")
 	config.RegisterDurationConfigVariable(30, &migrateDSLoopSleepDuration, true, time.Second, []string{"JobsDB.migrateDSLoopSleepDuration", "JobsDB.migrateDSLoopSleepDurationInS"}...)
 	config.RegisterDurationConfigVariable(5, &addNewDSLoopSleepDuration, true, time.Second, []string{"JobsDB.addNewDSLoopSleepDuration", "JobsDB.addNewDSLoopSleepDurationInS"}...)
-	config.RegisterDurationConfigVariable(5, &refreshDSListLoopSleepDuration, true, time.Second, []string{"JobsDB.refreshDSListLoopSleepDuration", "JobsDB.refreshDSListLoopSleepDurationInS"}...)
+	config.RegisterDurationConfigVariable(10, &refreshDSListLoopSleepDuration, true, time.Second, []string{"JobsDB.refreshDSListLoopSleepDuration", "JobsDB.refreshDSListLoopSleepDurationInS"}...)
 	config.RegisterDurationConfigVariable(5, &backupCheckSleepDuration, true, time.Second, []string{"JobsDB.backupCheckSleepDuration", "JobsDB.backupCheckSleepDurationIns"}...)
-	config.RegisterDurationConfigVariable(60, &cacheExpiration, true, time.Minute, []string{"JobsDB.cacheExpiration"}...)
+	config.RegisterDurationConfigVariable(120, &cacheExpiration, true, time.Minute, []string{"JobsDB.cacheExpiration"}...)
 	config.RegisterDurationConfigVariable(24, &jobCleanupFrequency, true, time.Hour, []string{"JobsDB.jobCleanupFrequency"}...)
-	config.RegisterBoolConfigVariable(false, &jobStatusCountMigrationCheck, true, "JobsDB.jobStatusCountMigrationCheck")
 }
 
 func Init2() {

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -529,7 +529,7 @@ func (jd *HandleT) checkIfMigrateDS(ds dataSetT) (
 		&statTags{CustomValFilters: []string{jd.tablePrefix}},
 	).RecordDuration()()
 
-	var delCount, totalCount, statusCount int
+	var delCount, totalCount int
 	sqlStatement := fmt.Sprintf(`SELECT COUNT(*) from %q`, ds.JobTable)
 	if err = jd.dbHandle.QueryRow(sqlStatement).Scan(&totalCount); err != nil {
 		return false, false, 0, fmt.Errorf("error getting count of jobs in %s: %w", ds.JobTable, err)
@@ -578,7 +578,7 @@ func (jd *HandleT) checkIfMigrateDS(ds dataSetT) (
 		return float64(totalCount) < smallThreshold
 	}
 
-	if float64(delCount)/float64(totalCount) > jobDoneMigrateThres || (float64(statusCount)/float64(totalCount) > jobStatusMigrateThres) {
+	if float64(delCount)/float64(totalCount) > jobDoneMigrateThres {
 		return true, isSmall(), recordsLeft, nil
 	}
 

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -88,7 +88,7 @@ func (rt *Handle) Setup(
 	config.RegisterDurationConfigVariable(300, &rt.reloadableConfig.maxRetryBackoff, true, time.Second, []string{"Router.maxRetryBackoff", "Router.maxRetryBackoffInS"}...)
 	config.RegisterStringConfigVariable("", &rt.reloadableConfig.toAbortDestinationIDs, true, "Router.toAbortDestinationIDs")
 	config.RegisterDurationConfigVariable(2, &rt.reloadableConfig.pickupFlushInterval, true, time.Second, "Router.pickupFlushInterval")
-	config.RegisterDurationConfigVariable(1000, &rt.reloadableConfig.failingJobsPenaltySleep, true, time.Millisecond, []string{"Router.failingJobsPenaltySleep"}...)
+	config.RegisterDurationConfigVariable(2000, &rt.reloadableConfig.failingJobsPenaltySleep, true, time.Millisecond, []string{"Router.failingJobsPenaltySleep"}...)
 	config.RegisterFloat64ConfigVariable(0.6, &rt.reloadableConfig.failingJobsPenaltyThreshold, true, []string{"Router.failingJobsPenaltyThreshold"}...)
 
 	config.RegisterDurationConfigVariable(60, &rt.diagnosisTickerTime, false, time.Second, []string{"Diagnostics.routerTimePeriod", "Diagnostics.routerTimePeriodInS"}...)


### PR DESCRIPTION
# Description

- Change default values
  - `JobsDB.jobDoneMigrateThres: 0.7` tables with 70% of jobs completed will be eligible for migration
  - `JobsDB.refreshDSListLoopSleepDuration: 10s` refresh loop will run less often
  - `JobsDB.cacheExpiration: 120m` no-jobs cache will expire after 2 hours
- New `migration_loop_lock` metric: Count the time that jobsdb operations will be blocked due to a migration/dsList lock
- New `refresh_ds_loop_lock` metric: Count the time that jobsdb operations will be blocked due to a dsList lock
- Remove `jobStatusCountMigrationCheck`: this was disabled by default and we planned to remove it anyway
- Don't care about the number of job statuses while deciding whether a table is small during migrations (small tables will be migrated as long as there are two of them, i.e. compacted)
- Increase `Router.failingJobsPenaltySleep` to `2sec`

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=b9db81b7c6324d81b4746f65dc6b484a&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
