### PR TITLE
fix: warehouse stringmap configs are lower case w.r.t viper

### DIFF
--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -144,7 +144,7 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 	if publishBatchSize == 0 {
 		publishBatchSize = defaultPublishBatchSize
 	}
-	if size, ok := lf.publishBatchSizePerWorkspace[job.Warehouse.WorkspaceID]; ok {
+	if size, ok := lf.publishBatchSizePerWorkspace[strings.ToLower(job.Warehouse.WorkspaceID)]; ok {
 		publishBatchSize = size
 	}
 

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -904,7 +904,7 @@ func (job *UploadJob) loadAllTablesExcept(skipLoadForTables []string, loadFilesT
 	}
 
 	configKey := fmt.Sprintf("Warehouse.%s.maxParallelLoadsWorkspaceIDs", warehouseutils.WHDestNameMap[job.upload.DestinationType])
-	if k, ok := config.GetStringMap(configKey, nil)[job.warehouse.WorkspaceID]; ok {
+	if k, ok := config.GetStringMap(configKey, nil)[strings.ToLower(job.warehouse.WorkspaceID)]; ok {
 		if load, ok := k.(float64); ok {
 			parallelLoads = int(load)
 		}


### PR DESCRIPTION
# Description

- Since viper internally stores its keys in lowercase, we need to compare checking with lowercase for StringMap

## Notion Ticket

 https://www.notion.so/rudderstacks/warehouse-config-string-map-comparision-in-lower-case-941eae92d77946fc9f41be8d17e5f685?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
