### PR TITLE
fix: cleanup for warehouse integration tests

### DIFF
--- a/warehouse/integrations/bigquery/bigquery_test.go
+++ b/warehouse/integrations/bigquery/bigquery_test.go
@@ -137,9 +137,16 @@ func TestIntegration(t *testing.T) {
 
 		t.Cleanup(func() {
 			for _, dataset := range []string{namespace, sourcesNamespace} {
-				require.NoError(t, testhelper.WithConstantRetries(func() error {
-					return db.Dataset(dataset).DeleteWithContents(ctx)
-				}))
+				require.Eventually(t, func() bool {
+					if err := db.Dataset(dataset).DeleteWithContents(ctx); err != nil {
+						t.Logf("error deleting dataset: %v", err)
+						return false
+					}
+					return true
+				},
+					time.Minute,
+					time.Second,
+				)
 			}
 		})
 
@@ -353,9 +360,16 @@ func TestIntegration(t *testing.T) {
 
 	t.Run("Validations", func(t *testing.T) {
 		t.Cleanup(func() {
-			require.NoError(t, testhelper.WithConstantRetries(func() error {
-				return db.Dataset(namespace).DeleteWithContents(ctx)
-			}))
+			require.Eventually(t, func() bool {
+				if err := db.Dataset(namespace).DeleteWithContents(ctx); err != nil {
+					t.Logf("error deleting dataset: %v", err)
+					return false
+				}
+				return true
+			},
+				time.Minute,
+				time.Second,
+			)
 		})
 
 		dest := backendconfig.DestinationT{

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -142,25 +142,25 @@ func TestIntegration(t *testing.T) {
 	serviceHealthEndpoint := fmt.Sprintf("http://localhost:%d/health", httpPort)
 	health.WaitUntilReady(ctx, t, serviceHealthEndpoint, time.Minute, time.Second, "serviceHealthEndpoint")
 
+	port, err := strconv.Atoi(deltaLakeCredentials.Port)
+	require.NoError(t, err)
+
+	connector, err := dbsql.NewConnector(
+		dbsql.WithServerHostname(deltaLakeCredentials.Host),
+		dbsql.WithPort(port),
+		dbsql.WithHTTPPath(deltaLakeCredentials.Path),
+		dbsql.WithAccessToken(deltaLakeCredentials.Token),
+		dbsql.WithSessionParams(map[string]string{
+			"ansi_mode": "false",
+		}),
+	)
+	require.NoError(t, err)
+
+	db := sql.OpenDB(connector)
+	require.NoError(t, db.Ping())
+
 	t.Run("Event flow", func(t *testing.T) {
 		jobsDB := testhelper.JobsDB(t, jobsDBPort)
-
-		port, err := strconv.Atoi(deltaLakeCredentials.Port)
-		require.NoError(t, err)
-
-		connector, err := dbsql.NewConnector(
-			dbsql.WithServerHostname(deltaLakeCredentials.Host),
-			dbsql.WithPort(port),
-			dbsql.WithHTTPPath(deltaLakeCredentials.Path),
-			dbsql.WithAccessToken(deltaLakeCredentials.Token),
-			dbsql.WithSessionParams(map[string]string{
-				"ansi_mode": "false",
-			}),
-		)
-		require.NoError(t, err)
-
-		db := sql.OpenDB(connector)
-		require.NoError(t, db.Ping())
 
 		t.Cleanup(func() {
 			require.NoError(t, testhelper.WithConstantRetries(func() error {
@@ -290,6 +290,13 @@ func TestIntegration(t *testing.T) {
 	})
 
 	t.Run("Validation", func(t *testing.T) {
+		t.Cleanup(func() {
+			require.NoError(t, testhelper.WithConstantRetries(func() error {
+				_, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %[1]s CASCADE;`, namespace))
+				return err
+			}))
+		})
+
 		dest := backendconfig.DestinationT{
 			ID: destinationID,
 			Config: map[string]interface{}{

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -163,10 +163,16 @@ func TestIntegration(t *testing.T) {
 		jobsDB := testhelper.JobsDB(t, jobsDBPort)
 
 		t.Cleanup(func() {
-			require.NoError(t, testhelper.WithConstantRetries(func() error {
-				_, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %[1]s CASCADE;`, namespace))
-				return err
-			}))
+			require.Eventually(t, func() bool {
+				if _, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %[1]s CASCADE;`, namespace)); err != nil {
+					t.Logf("error deleting schema: %v", err)
+					return false
+				}
+				return true
+			},
+				time.Minute,
+				time.Second,
+			)
 		})
 
 		testCases := []struct {
@@ -291,10 +297,16 @@ func TestIntegration(t *testing.T) {
 
 	t.Run("Validation", func(t *testing.T) {
 		t.Cleanup(func() {
-			require.NoError(t, testhelper.WithConstantRetries(func() error {
-				_, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %[1]s CASCADE;`, namespace))
-				return err
-			}))
+			require.Eventually(t, func() bool {
+				if _, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %[1]s CASCADE;`, namespace)); err != nil {
+					t.Logf("error deleting schema: %v", err)
+					return false
+				}
+				return true
+			},
+				time.Minute,
+				time.Second,
+			)
 		})
 
 		dest := backendconfig.DestinationT{

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -223,10 +223,16 @@ func TestIntegration(t *testing.T) {
 				t.Parallel()
 
 				t.Cleanup(func() {
-					require.NoError(t, testhelper.WithConstantRetries(func() error {
-						_, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %q CASCADE;`, tc.schema))
-						return err
-					}))
+					require.Eventually(t, func() bool {
+						if _, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %q CASCADE;`, tc.schema)); err != nil {
+							t.Logf("error deleting schema: %v", err)
+							return false
+						}
+						return true
+					},
+						time.Minute,
+						time.Second,
+					)
 				})
 
 				sqlClient := &client.Client{
@@ -298,10 +304,18 @@ func TestIntegration(t *testing.T) {
 	})
 
 	t.Run("Validation", func(t *testing.T) {
-		require.NoError(t, testhelper.WithConstantRetries(func() error {
-			_, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %q CASCADE;`, namespace))
-			return err
-		}))
+		t.Cleanup(func() {
+			require.Eventually(t, func() bool {
+				if _, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %q CASCADE;`, namespace)); err != nil {
+					t.Logf("error deleting schema: %v", err)
+					return false
+				}
+				return true
+			},
+				time.Minute,
+				time.Second,
+			)
+		})
 
 		dest := backendconfig.DestinationT{
 			ID: destinationID,

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -162,6 +162,18 @@ func TestIntegration(t *testing.T) {
 	serviceHealthEndpoint := fmt.Sprintf("http://localhost:%d/health", httpPort)
 	health.WaitUntilReady(ctx, t, serviceHealthEndpoint, time.Minute, time.Second, "serviceHealthEndpoint")
 
+	dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
+		rsTestCredentials.UserName,
+		rsTestCredentials.Password,
+		rsTestCredentials.Host,
+		rsTestCredentials.Port,
+		rsTestCredentials.DbName,
+	)
+
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	require.NoError(t, db.Ping())
+
 	t.Run("Event flow", func(t *testing.T) {
 		jobsDB := testhelper.JobsDB(t, jobsDBPort)
 
@@ -209,18 +221,6 @@ func TestIntegration(t *testing.T) {
 
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
-
-				dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
-					rsTestCredentials.UserName,
-					rsTestCredentials.Password,
-					rsTestCredentials.Host,
-					rsTestCredentials.Port,
-					rsTestCredentials.DbName,
-				)
-
-				db, err := sql.Open("postgres", dsn)
-				require.NoError(t, err)
-				require.NoError(t, db.Ping())
 
 				t.Cleanup(func() {
 					require.NoError(t, testhelper.WithConstantRetries(func() error {
@@ -298,6 +298,11 @@ func TestIntegration(t *testing.T) {
 	})
 
 	t.Run("Validation", func(t *testing.T) {
+		require.NoError(t, testhelper.WithConstantRetries(func() error {
+			_, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %q CASCADE;`, namespace))
+			return err
+		}))
+
 		dest := backendconfig.DestinationT{
 			ID: destinationID,
 			Config: map[string]interface{}{

--- a/warehouse/integrations/snowflake/snowflake_test.go
+++ b/warehouse/integrations/snowflake/snowflake_test.go
@@ -396,6 +396,27 @@ func TestIntegration(t *testing.T) {
 	})
 
 	t.Run("Validation", func(t *testing.T) {
+		dsn, err := snowflakedb.DSN(&snowflakedb.Config{
+			Account:   credentials.Account,
+			User:      credentials.User,
+			Role:      credentials.Role,
+			Password:  credentials.Password,
+			Database:  credentials.Database,
+			Warehouse: credentials.Warehouse,
+		})
+		require.NoError(t, err)
+
+		db, err := sql.Open("snowflake", dsn)
+		require.NoError(t, err)
+		require.NoError(t, db.Ping())
+
+		t.Cleanup(func() {
+			require.NoError(t, testhelper.WithConstantRetries(func() error {
+				_, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %q CASCADE;`, namespace))
+				return err
+			}))
+		})
+
 		dest := backendconfig.DestinationT{
 			ID: destinationID,
 			Config: map[string]interface{}{

--- a/warehouse/integrations/snowflake/snowflake_test.go
+++ b/warehouse/integrations/snowflake/snowflake_test.go
@@ -318,10 +318,16 @@ func TestIntegration(t *testing.T) {
 				require.NoError(t, db.Ping())
 
 				t.Cleanup(func() {
-					require.NoError(t, testhelper.WithConstantRetries(func() error {
-						_, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %q CASCADE;`, tc.schema))
-						return err
-					}))
+					require.Eventually(t, func() bool {
+						if _, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %q CASCADE;`, tc.schema)); err != nil {
+							t.Logf("error deleting schema: %v", err)
+							return false
+						}
+						return true
+					},
+						time.Minute,
+						time.Second,
+					)
 				})
 
 				sqlClient := &client.Client{
@@ -411,10 +417,16 @@ func TestIntegration(t *testing.T) {
 		require.NoError(t, db.Ping())
 
 		t.Cleanup(func() {
-			require.NoError(t, testhelper.WithConstantRetries(func() error {
-				_, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %q CASCADE;`, namespace))
-				return err
-			}))
+			require.Eventually(t, func() bool {
+				if _, err := db.Exec(fmt.Sprintf(`DROP SCHEMA %q CASCADE;`, namespace)); err != nil {
+					t.Logf("error deleting schema: %v", err)
+					return false
+				}
+				return true
+			},
+				time.Minute,
+				time.Second,
+			)
 		})
 
 		dest := backendconfig.DestinationT{


### PR DESCRIPTION
# Description

Since validation tests are also running which creates the schema but not drops it. Added cleanup during validations.

## Notion Ticket

https://www.notion.so/rudderstacks/Cleanup-integration-tests-fa75cc8c7d9e4ce887988a107d1f684f?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
