### PR TITLE
chore: add max connections to warehouse and pgnotifier

### DIFF
--- a/services/pgnotifier/pgnotifier.go
+++ b/services/pgnotifier/pgnotifier.go
@@ -128,6 +128,7 @@ func New(workspaceIdentifier, fallbackConnectionInfo string) (notifier PGNotifie
 	if err != nil {
 		return
 	}
+	dbHandle.SetMaxOpenConns(config.GetInt("PgNotifier.maxOpenConnections", 20))
 
 	// setup metrics
 	pgNotifierModuleTag := whUtils.Tag{Name: "module", Value: "pgnotifier"}

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -1617,6 +1617,7 @@ func setupDB(ctx context.Context, connInfo string) error {
 	if err != nil {
 		return err
 	}
+	dbHandle.SetMaxOpenConns(config.GetInt("Warehouse.maxOpenConnections", 20))
 
 	isDBCompatible, err := validators.IsPostgresCompatible(ctx, dbHandle)
 	if err != nil {


### PR DESCRIPTION
# Description

- Setting maxOpenConnections for Warehouse and PgNotifier db handle.

## Notion Ticket

https://www.notion.so/rudderstacks/Max-open-connection-for-warehouse-and-postgres-91e4987ff26b41f6a7aa337fa3cb8f80?pvs=4

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
