### PR TITLE
chore(jobsdb): increase maintenance operation timeouts and make them hot-reloadable

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -536,9 +536,9 @@ func (jd *HandleT) registerBackUpSettings() {
 	config.RegisterBoolConfigVariable(false, &jd.BackupSettings.FailedOnly, false, fmt.Sprintf("JobsDB.backup.%v.failedOnly", jd.tablePrefix))
 	config.RegisterStringConfigVariable(jd.tablePrefix, &pathPrefix, false, fmt.Sprintf("JobsDB.backup.%v.pathPrefix", jd.tablePrefix))
 	config.RegisterDurationConfigVariable(10, &jd.maxBackupRetryTime, false, time.Minute, "JobsDB.backup.maxRetry")
-	config.RegisterDurationConfigVariable(1, &jd.refreshDSTimeout, false, time.Minute, "JobsDB.refreshDS.timeout")
+	config.RegisterDurationConfigVariable(10, &jd.refreshDSTimeout, true, time.Minute, "JobsDB.refreshDS.timeout")
 	config.RegisterDurationConfigVariable(720, &jd.JobMaxAge, false, time.Hour, "JobsDB.jobMaxAge")
-	config.RegisterDurationConfigVariable(2, &jd.migrateDSTimeout, false, time.Minute, "JobsDB.migrateDS.timeout")
+	config.RegisterDurationConfigVariable(10, &jd.migrateDSTimeout, true, time.Minute, "JobsDB.migrateDS.timeout")
 
 	jd.BackupSettings.PathPrefix = strings.TrimSpace(pathPrefix)
 }


### PR DESCRIPTION
# Description

In scenarios where the database is being throttled, database query delays can cause jobsdb's maintenance operations to take much longer. 
Usually, a maintenance operation times out when it doesn't manage to acquire a write lock in time. But this operation will keep retrying periodically and will be timing out continuously, causing the system to come to a standstill (a waiting write lock causes any other read lock requests to block too).
Therefore increasing timeouts to more sensible values (`10m`) and making them hot-reloadable as well

## Notion Ticket

[Link](https://www.notion.so/rudderstacks/Pipelines-Sprint-68c1c213e9b840b3a9b3826e3631e39a?p=122ab1effd184bdb881d02c069c2235b&pm=s)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
