### PR TITLE
chore: add logs for debugging unmarshalling issues

### DIFF
--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -282,18 +282,19 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	transformerResponse := integrations.TransResponseT{
 		Message: "[TransformerProxy]:: Default Message TransResponseT",
 	}
-	respData = []byte(gjson.GetBytes(respData, "output").Raw)
-	integrations.CollectDestErrorStats(respData)
-	err := jsonfast.Unmarshal(respData, &transformerResponse)
+	respOutputData := []byte(gjson.GetBytes(respData, "output").Raw)
+	integrations.CollectDestErrorStats(respOutputData)
+	err := jsonfast.Unmarshal(respOutputData, &transformerResponse)
 	// unmarshal failure
 	if err != nil {
 		errStr := string(respData) + " [TransformerProxy Unmarshaling]::" + err.Error()
-		trans.logger.Errorf(errStr)
+		trans.logger.Errorf("Error: %s, destType: %s, destID: %s",
+			errStr, proxyReqParams.DestName, proxyReqParams.ResponseData.Metadata.DestinationID)
 		respCode = http.StatusInternalServerError
 		return respCode, errStr, "text/plain; charset=utf-8"
 	}
 
-	return respCode, string(respData), "application/json"
+	return respCode, string(respOutputData), "application/json"
 }
 
 func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration) {

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -349,7 +349,9 @@ func (trans *handle) doProxyRequest(ctx context.Context, proxyReqParams *ProxyRe
 	httpReqStTime := time.Now()
 	resp, err := trans.proxyClient.Do(req)
 	reqRoundTripTime := time.Since(httpReqStTime)
-	trans.logger.Infof("[TransformerProxy] Response Headers: %v", resp.Header)
+	if resp != nil {
+		trans.logger.Infof("[TransformerProxy] Response Headers: %#v", resp.Header)
+	}
 	// This stat will be useful in understanding the round trip time taken for the http req
 	// between server and transformer
 	stats.Default.NewTaggedStat("transformer_proxy.req_round_trip_time", stats.TimerType, stats.Tags{

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -349,9 +349,6 @@ func (trans *handle) doProxyRequest(ctx context.Context, proxyReqParams *ProxyRe
 	httpReqStTime := time.Now()
 	resp, err := trans.proxyClient.Do(req)
 	reqRoundTripTime := time.Since(httpReqStTime)
-	if resp != nil {
-		trans.logger.Infof("[TransformerProxy] Response Headers: %#v", resp.Header)
-	}
 	// This stat will be useful in understanding the round trip time taken for the http req
 	// between server and transformer
 	stats.Default.NewTaggedStat("transformer_proxy.req_round_trip_time", stats.TimerType, stats.Tags{

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -288,7 +288,7 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	// unmarshal failure
 	if err != nil {
 		errStr := string(respData) + " [TransformerProxy Unmarshaling]::" + err.Error()
-		trans.logger.Errorf("Error: %s, destType: %s, destID: %s",
+		trans.logger.Errorf("ErrorStatusCode: %d, Error: %s, destType: %s, destID: %s", respCode,
 			errStr, proxyReqParams.DestName, proxyReqParams.ResponseData.Metadata.DestinationID)
 		respCode = http.StatusInternalServerError
 		return respCode, errStr, "text/plain; charset=utf-8"
@@ -349,6 +349,7 @@ func (trans *handle) doProxyRequest(ctx context.Context, proxyReqParams *ProxyRe
 	httpReqStTime := time.Now()
 	resp, err := trans.proxyClient.Do(req)
 	reqRoundTripTime := time.Since(httpReqStTime)
+	trans.logger.Infof("[TransformerProxy] Response Headers: %v", resp.Header)
 	// This stat will be useful in understanding the round trip time taken for the http req
 	// between server and transformer
 	stats.Default.NewTaggedStat("transformer_proxy.req_round_trip_time", stats.TimerType, stats.Tags{

--- a/router/worker.go
+++ b/router/worker.go
@@ -426,7 +426,7 @@ func (w *worker) processDestinationJobs() {
 					if err != nil {
 						errorAt = routerutils.ERROR_AT_TF
 						respStatusCode, respBody = types.RouterUnMarshalErrorCode, fmt.Errorf("transformer response unmarshal error: %w", err).Error()
-						w.logger.Errorf("transformer response unmarshal error: %v, destType: %s, destID: %s, jobID: %d", err, w.rt.destType, destinationID, destinationJob.JobMetadataArray[0].JobID)
+						w.logger.Errorf("transformer response unmarshal error: %v, destType: %s, destID: %s", err, w.rt.destType, destinationID)
 					} else {
 						for _, val := range result {
 							err := integrations.ValidatePostInfo(val)

--- a/router/worker.go
+++ b/router/worker.go
@@ -426,6 +426,7 @@ func (w *worker) processDestinationJobs() {
 					if err != nil {
 						errorAt = routerutils.ERROR_AT_TF
 						respStatusCode, respBody = types.RouterUnMarshalErrorCode, fmt.Errorf("transformer response unmarshal error: %w", err).Error()
+						w.logger.Errorf("transformer response unmarshal error: %v, destType: %s, destID: %s, jobID: %d", err, w.rt.destType, destinationID, destinationJob.JobMetadataArray[0].JobID)
 					} else {
 						for _, val := range result {
 							err := integrations.ValidatePostInfo(val)


### PR DESCRIPTION
# Description

This is for debugging: 
1. https://app.squadcast.com/incident/64aa22a772ca03089f7b6ebc
2. Error: 2023-07-09T07:22:41.681Z	ERROR	router.transformer	transformer/transformer.go:291	 [TransformerProxy Unmarshaling]::readObjectStart: expect { or n, but found , error found in #0 byte of ...||..., bigger context ...||...

## Notion Ticket

< Replace with Notion Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
