### PR TITLE
chore: retry on 408 response events

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -119,7 +119,7 @@ func Init() {
 }
 
 func isJobTerminated(status int) bool {
-	if status == http.StatusTooManyRequests {
+	if status == http.StatusTooManyRequests || status == http.StatusRequestTimeout {
 		return false
 	}
 	return status >= http.StatusOK && status < http.StatusInternalServerError

--- a/router/batchrouter/util.go
+++ b/router/batchrouter/util.go
@@ -3,6 +3,7 @@ package batchrouter
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -18,10 +19,10 @@ import (
 )
 
 func isJobTerminated(status int) bool {
-	if status == 429 {
+	if status == http.StatusTooManyRequests || status == http.StatusRequestTimeout {
 		return false
 	}
-	return status >= 200 && status < 500
+	return status >= http.StatusOK && status < http.StatusInternalServerError
 }
 
 func IsObjectStorageDestination(destType string) bool {

--- a/router/misc.go
+++ b/router/misc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/http"
 	"time"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
@@ -18,10 +19,10 @@ func isSuccessStatus(status int) bool {
 }
 
 func isJobTerminated(status int) bool {
-	if status == 429 {
+	if status == http.StatusTooManyRequests || status == http.StatusRequestTimeout {
 		return false
 	}
-	return status >= 200 && status < 500
+	return status >= http.StatusOK && status < http.StatusInternalServerError
 }
 
 func nextAttemptAfter(attempt int, minRetryBackoff, maxRetryBackoff time.Duration) time.Duration {


### PR DESCRIPTION
# Description
Retry events when traefik gives 408 as a response to server.

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/Retry-408-transformer-65ab447caf224d00b227b65fff1d1959?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
