### PR TITLE
test: add max connections to warehouse and pgnotifier

### DIFF
--- a/services/pgnotifier/pgnotifier.go
+++ b/services/pgnotifier/pgnotifier.go
@@ -128,6 +128,7 @@ func New(workspaceIdentifier, fallbackConnectionInfo string) (notifier PGNotifie
 	if err != nil {
 		return
 	}
+	dbHandle.SetMaxOpenConns(config.GetInt("PgNotifier.maxOpenConnections", 20))
 
 	// setup metrics
 	pgNotifierModuleTag := whUtils.Tag{Name: "module", Value: "pgnotifier"}

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -1625,6 +1625,7 @@ func setupDB(ctx context.Context, connInfo string) error {
 	if err != nil {
 		return err
 	}
+	dbHandle.SetMaxOpenConns(config.GetInt("Warehouse.maxOpenConnections", 20))
 
 	isDBCompatible, err := validators.IsPostgresCompatible(ctx, dbHandle)
 	if err != nil {


### PR DESCRIPTION
# Description

- Adding a limit to the dbHandle and the pgNotifier dbHandle. Need to be deployed in warehouse slaves to check the effect.

## Notion Ticket

https://www.notion.so/rudderstacks/Warehouse-investigation-on-stuck-syncs-982136d5712247d681b919b690bee5be?pvs=4

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
