### PR TITLE
chore: fix negative pending event count

### DIFF
--- a/processor/manager.go
+++ b/processor/manager.go
@@ -58,13 +58,10 @@ func (proc *LifecycleManager) Start() error {
 	var wg sync.WaitGroup
 	proc.waitGroup = &wg
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if err := proc.Handle.Start(currentCtx); err != nil {
-			proc.Handle.logger.Errorf("Error starting processor: %v", err)
-		}
-	}()
+	if err := proc.Handle.Start(currentCtx); err != nil {
+		proc.Handle.logger.Errorf("Error starting processor: %v", err)
+		return err
+	}
 	return nil
 }
 

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -59,7 +59,7 @@ func (proc *LifecycleManager) Start() error {
 	var wg sync.WaitGroup
 	proc.waitGroup = &wg
 	metric.Instance.Reset()
-	if err := proc.Handle.countPendingEvents(); err != nil {
+	if err := proc.Handle.countPendingEvents(currentCtx); err != nil {
 		return err
 	}
 	wg.Add(1)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2811,7 +2811,7 @@ func (proc *Handle) IncreasePendingEvents(tablePrefix string, stats map[string]m
 	}
 }
 
-func (proc *Handle) countPendingEvents() error {
+func (proc *Handle) countPendingEvents(ctx context.Context) error {
 	dbs := map[string]jobsdb.JobsDB{"rt": proc.routerDB, "brt": proc.batchRouterDB}
 	var jobdDBQueryRequestTimeout time.Duration
 	var jobdDBMaxRetries int
@@ -2819,7 +2819,7 @@ func (proc *Handle) countPendingEvents() error {
 	config.RegisterIntConfigVariable(2, &jobdDBMaxRetries, true, 1, []string{"JobsDB." + "Processor." + "MaxRetries", "JobsDB." + "MaxRetries"}...)
 
 	for tablePrefix, db := range dbs {
-		pileUpStatMap, err := misc.QueryWithRetriesAndNotify(context.Background(),
+		pileUpStatMap, err := misc.QueryWithRetriesAndNotify(ctx,
 			jobdDBQueryRequestTimeout,
 			jobdDBMaxRetries,
 			func(ctx context.Context) (map[string]map[string]int, error) {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -452,10 +452,6 @@ func (proc *Handle) Setup(
 
 // Start starts this processor's main loops.
 func (proc *Handle) Start(ctx context.Context) error {
-	metric.Instance.Reset()
-	if err := proc.countPendingEvents(); err != nil {
-		return fmt.Errorf("counting pending events: %w", err)
-	}
 	g, ctx := errgroup.WithContext(ctx)
 	var err error
 	proc.logger.Infof("Starting processor in isolation mode: %s", proc.config.isolationMode)


### PR DESCRIPTION
# Description
The call to populate pending events should be a blocking call and should be completed before any of the components start
Since the removal of multi-tenant stats the population of pending events is done at `processor.Start` which is a non blocking call and the `router`,`batch router` components might start before the backfilling of in-memory stats.

Now the backfilling code is made blocking and will be executed before the processor starts

## Notion Ticket

[ Notion Link ](https://www.notion.so/rudderstacks/negative-pending-event-count-bug-1d57bd99cb874b5b96e6a691820f4a1e?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
