### PR TITLE
chore: add custom buckets to gateway.user_suppression_age

### DIFF
--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -4,4 +4,7 @@ var customBuckets = map[string][]float64{
 	"gateway.response_time": {
 		0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60,
 	},
+	"gateway.user_suppression_age": {
+		86400, 2592000, 5184000, 7776000, // 1 day, 1 month, 2 months, 3 months
+	},
 }


### PR DESCRIPTION
# Description

Add custom buckets i.e. 1 day, 1 month, 2 months, 3 months for gateway.user_suppression_age metric

## Notion Ticket

https://www.notion.so/rudderstacks/Add-custom-buckets-i-e-1-day-1-month-2-months-3-months-for-gateway-user_suppression_age-metric-6fc3093d32834f6a9ee3576964f81a81

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
