### PR TITLE
chore: add custom buckets to gateway.user_suppression_age

### DIFF
--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -4,4 +4,7 @@ var customBuckets = map[string][]float64{
 	"gateway.response_time": {
 		0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60,
 	},
+	"gateway.user_suppression_age": {
+		86400, 432000, 864000, 2592000, 5184000, 7776000, 15552000, 31104000, // 1 day, 5 days, 10 days, 30 days, 60 days, 90 days, 180 days, 360 days
+	},
 }


### PR DESCRIPTION
# Description

Add custom buckets i.e. 1 day, 5 days, 10 days, 30 days, 60 days, 90 days, 180 days, 360 days for gateway.user_suppression_age metric

## Notion Ticket

https://www.notion.so/rudderstacks/Add-custom-buckets-1-day-5-days-10-days-30-days-60-days-90-days-180-days-360-days-for-gateway-6fc3093d32834f6a9ee3576964f81a81

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
