### PR TITLE
fix: ignore workspace if no backup config is found

### DIFF
--- a/processor/stash/stash_test.go
+++ b/processor/stash/stash_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/google/uuid"
+	"github.com/google/uuid"
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -180,7 +180,7 @@ func TestStoreErrorsToObjectStorage(t *testing.T) {
 
 	errJobs = st.storeErrorsToObjectStorage(jobsToFail)
 	require.Equal(t, 1, len(errJobs))
-	require.Equal(t, errJobs[0].errorOutput.Error.Error(), "no storage settings found for workspace: defaultWorkspaceID-5")
+	require.Equal(t, errJobs[0].errorOutput.Error, fileuploader.NoStorageForWorkspaceError)
 }
 
 func countJobsByWorkspace(jobs []*jobsdb.JobT) map[string]int {

--- a/services/fileuploader/fileuploader.go
+++ b/services/fileuploader/fileuploader.go
@@ -16,7 +16,7 @@ type StorageSettings struct {
 	Preferences backendconfig.StoragePreferences
 }
 
-var noStorageForWorkspaceErrorString string = "no storage settings found for workspace: %s"
+var NoStorageForWorkspaceError = fmt.Errorf("no storage settings found for workspace")
 
 // Provider is an interface that provides file managers and storage preferences for a given workspace.
 type Provider interface {
@@ -67,7 +67,7 @@ func (p *provider) getStorageSettings(workspaceID string) (StorageSettings, erro
 	defer p.mu.RUnlock()
 	settings, ok := p.storageSettings[workspaceID]
 	if !ok {
-		return StorageSettings{}, fmt.Errorf(noStorageForWorkspaceErrorString, workspaceID)
+		return StorageSettings{}, NoStorageForWorkspaceError
 	}
 	return settings, nil
 }

--- a/services/fileuploader/fileuploader_test.go
+++ b/services/fileuploader/fileuploader_test.go
@@ -2,7 +2,6 @@ package fileuploader
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 
@@ -125,7 +124,7 @@ func TestFileUploaderUpdatingWithConfigBackend(t *testing.T) {
 	Expect(fm3.Prefix()).To(Equal("defaultPrefixWithStorageTTL"))
 
 	fm0, err := fileUploaderProvider.GetFileManager("testWorkspaceId-0")
-	Expect(err).To(Equal(fmt.Errorf(noStorageForWorkspaceErrorString, "testWorkspaceId-0")))
+	Expect(err).To(Equal(NoStorageForWorkspaceError))
 	Expect(fm0).To(BeNil())
 
 	storageSettings.Wait()
@@ -137,7 +136,7 @@ func TestFileUploaderUpdatingWithConfigBackend(t *testing.T) {
 	))
 
 	preferences, err = fileUploaderProvider.GetStoragePreferences("testWorkspaceId-0")
-	Expect(err).To(Equal(fmt.Errorf(noStorageForWorkspaceErrorString, "testWorkspaceId-0")))
+	Expect(err).To(Equal(NoStorageForWorkspaceError))
 	Expect(preferences).To(BeEquivalentTo(backendconfig.StoragePreferences{}))
 
 	preferences, err = fileUploaderProvider.GetStoragePreferences("testWorkspaceId-2")
@@ -251,6 +250,7 @@ func TestOverride(t *testing.T) {
 			"d": "5",
 		},
 	}
+
 	bucket = overrideWithSettings(config, settings, "wrk-1")
 	Expect(bucket.Config).To(Equal(map[string]interface{}{
 		"a":          "1",


### PR DESCRIPTION
# Description

Ignore error resulting from a workspace's backup config not being found.
This is done so the backup is not stalled in such case.

## Notion Ticket

[linear cfd link](https://linear.app/rudderstack/issue/RUD-412/subteams03sekbfx0dserver-on-call-lot-of-pre-drop-gw-tables-on)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
