### PR TITLE
fix: send last error response for aborted jobs to reporting

### DIFF
--- a/router/router_test.go
+++ b/router/router_test.go
@@ -616,9 +616,9 @@ var _ = Describe("router", func() {
 					},
 					Parameters: []byte(fmt.Sprintf(`{
 						"source_id": "1fMCVYZboDlYlauh4GFsEo2JU77",
-						"destination_id": "%s", 
-						"message_id": "2f548e6d-60f6-44af-a1f4-62b3272445c3", 
-						"received_at": "%s", 
+						"destination_id": "%s",
+						"message_id": "2f548e6d-60f6-44af-a1f4-62b3272445c3",
+						"received_at": "%s",
 						"transform_at": "processor"
 					}`, gaDestinationID, firstAttemptedAt.Add(-time.Minute).Format(misc.RFC3339Milli))),
 					WorkspaceId: workspaceID,
@@ -660,8 +660,7 @@ var _ = Describe("router", func() {
 			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
 				Do(func(ctx context.Context, tx jobsdb.UpdateSafeTx, drainList []*jobsdb.JobStatusT, _, _ interface{}) {
 					Expect(drainList).To(HaveLen(1))
-					assertJobStatus(jobs[0], drainList[0], jobsdb.Aborted.State, strconv.Itoa(routerUtils.DRAIN_ERROR_CODE), `{"reason": "retry limit reached"}`, jobs[0].LastJobStatus.AttemptNum)
-					routerAborted = true
+					assertJobStatus(jobs[0], drainList[0], jobsdb.Aborted.State, strconv.Itoa(routerUtils.DRAIN_ERROR_CODE), fmt.Sprintf(`{"reason": %s}`, fmt.Sprintf(`{"firstAttemptedAt": %q}`, firstAttemptedAt.Format(misc.RFC3339Milli))), jobs[0].LastJobStatus.AttemptNum)
 				})
 
 			<-router.backendConfigInitialized
@@ -1572,7 +1571,7 @@ func assertJobStatus(job *jobsdb.JobT, status *jobsdb.JobStatusT, expectedState,
 	if attemptNum >= 1 {
 		Expect(gjson.GetBytes(status.ErrorResponse, "content-type").String()).To(Equal(gjson.Get(errorResponse, "content-type").String()))
 		Expect(gjson.GetBytes(status.ErrorResponse, "response").String()).To(Equal(gjson.Get(errorResponse, "response").String()))
-		Expect(gjson.GetBytes(status.ErrorResponse, "reason").String()).To(Equal(gjson.Get(errorResponse, "reason").String()))
+		Expect(gjson.Get(string(status.ErrorResponse), "reason").String()).To(Equal(gjson.Get(errorResponse, "reason").String()))
 	}
 	Expect(status.ExecTime).To(BeTemporally("~", time.Now(), 10*time.Second))
 	Expect(status.RetryTime).To(BeTemporally(">=", status.ExecTime, 10*time.Second))

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -661,6 +661,7 @@ var _ = Describe("router", func() {
 				Do(func(ctx context.Context, tx jobsdb.UpdateSafeTx, drainList []*jobsdb.JobStatusT, _, _ interface{}) {
 					Expect(drainList).To(HaveLen(1))
 					assertJobStatus(jobs[0], drainList[0], jobsdb.Aborted.State, strconv.Itoa(routerUtils.DRAIN_ERROR_CODE), fmt.Sprintf(`{"reason": %s}`, fmt.Sprintf(`{"firstAttemptedAt": %q}`, firstAttemptedAt.Format(misc.RFC3339Milli))), jobs[0].LastJobStatus.AttemptNum)
+					routerAborted = true
 				})
 
 			<-router.backendConfigInitialized

--- a/router/worker.go
+++ b/router/worker.go
@@ -89,14 +89,13 @@ func (w *worker) workLoop() {
 				panic(fmt.Errorf("unmarshalling of job parameters failed for job %d (%s): %w", job.JobID, string(job.Parameters), err))
 			}
 			w.rt.destinationsMapMu.RLock()
-			var abortTag string
 			abort, abortReason := routerutils.ToBeDrained(job, parameters.DestinationID, w.rt.reloadableConfig.toAbortDestinationIDs, w.rt.destinationsMap)
-			abortTag = abortReason
+			abortTag := abortReason
 			w.rt.destinationsMapMu.RUnlock()
 			if !abort {
 				abort = w.retryLimitReached(&job.LastJobStatus)
 				abortReason = string(job.LastJobStatus.ErrorResponse)
-				abortTag = "retry_limit_reached"
+				abortTag = "retry limit reached"
 			}
 			if abort {
 				status := jobsdb.JobStatusT{


### PR DESCRIPTION
# Description

This PR sends the last error response to reporting and in the job status table for the jobs which get aborted due the exhausting their retries

## Linear Ticket

[ Linear Link ](https://linear.app/rudderstack/issue/PIPE-78/propagate-error-response-for-aborted-jobs-to-reporting)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
