### PR TITLE
chore: increase transformer request timeouts

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -204,7 +204,7 @@ func NewTransformer(conf *config.Config, log logger.Logger, stat stats.Stats, op
 	trans.config.maxHTTPConnections = conf.GetInt("Processor.maxHTTPConnections", 100)
 	trans.config.maxHTTPIdleConnections = conf.GetInt("Processor.maxHTTPIdleConnections", 5)
 	trans.config.disableKeepAlives = conf.GetBool("Transformer.Client.disableKeepAlives", true)
-	trans.config.timeoutDuration = conf.GetDuration("HttpClient.procTransformer.timeout", 30, time.Second)
+	trans.config.timeoutDuration = conf.GetDuration("HttpClient.procTransformer.timeout", 600, time.Second)
 
 	trans.config.destTransformationURL = conf.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
 	trans.config.userTransformationURL = conf.GetString("USER_TRANSFORM_URL", trans.config.destTransformationURL)

--- a/router/handle.go
+++ b/router/handle.go
@@ -60,7 +60,7 @@ type Handle struct {
 	destType                string
 	guaranteeUserEventOrder bool
 	netClientTimeout        time.Duration
-	backendProxyTimeout     time.Duration
+	transformerTimeout      time.Duration
 	enableBatching          bool
 	noOfWorkers             int
 	barrierConcurrencyLimit int

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -95,7 +95,7 @@ func (rt *Handle) Setup(
 
 	netClientTimeoutKeys := []string{"Router." + rt.destType + "." + "httpTimeout", "Router." + rt.destType + "." + "httpTimeoutInS", "Router." + "httpTimeout", "Router." + "httpTimeoutInS"}
 	config.RegisterDurationConfigVariable(10, &rt.netClientTimeout, false, time.Second, netClientTimeoutKeys...)
-	config.RegisterDurationConfigVariable(30, &rt.backendProxyTimeout, false, time.Second, "HttpClient.backendProxy.timeout")
+	config.RegisterDurationConfigVariable(600, &rt.transformerTimeout, false, time.Second, "HttpClient.backendProxy.timeout", "HttpClient.routerTransformer.timeout")
 	rt.crashRecover()
 	rt.responseQ = make(chan workerJobStatus, rt.reloadableConfig.jobQueryBatchSize)
 	if rt.netHandle == nil {
@@ -135,7 +135,7 @@ func (rt *Handle) Setup(
 	rt.throttlingErrorStat = stats.Default.NewTaggedStat("router_throttling_error", stats.CountType, statTags)
 	rt.throttledStat = stats.Default.NewTaggedStat("router_throttled", stats.CountType, statTags)
 
-	rt.transformer = transformer.NewTransformer(rt.netClientTimeout, rt.backendProxyTimeout)
+	rt.transformer = transformer.NewTransformer(rt.netClientTimeout, rt.transformerTimeout)
 
 	rt.oauth = oauth.NewOAuthErrorHandler(backendConfig)
 

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -80,9 +80,9 @@ type Transformer interface {
 }
 
 // NewTransformer creates a new transformer
-func NewTransformer(netClientTimeout, backendProxyTimeout time.Duration) Transformer {
+func NewTransformer(destinationTimeout, transformTimeout time.Duration) Transformer {
 	handle := &handle{}
-	handle.setup(netClientTimeout, backendProxyTimeout)
+	handle.setup(destinationTimeout, transformTimeout)
 	return handle
 }
 

--- a/router/worker.go
+++ b/router/worker.go
@@ -915,7 +915,7 @@ func (w *worker) accept(wj workerJob) {
 func (w *worker) trackStuckDelivery() chan struct{} {
 	var d time.Duration
 	if w.rt.reloadableConfig.transformerProxy {
-		d = (w.rt.backendProxyTimeout + w.rt.netClientTimeout) * 2
+		d = (w.rt.transformerTimeout + w.rt.netClientTimeout) * 2
 	} else {
 		d = w.rt.netClientTimeout * 2
 	}


### PR DESCRIPTION
# Description

There are multiple occasions where we currently need a much higher timeout than `30s` during transformation requests, e.g. when using large event batches and transformer needs to perform some external request(s). This has also caused a number of issues already, forcing us to manually increase this timeout. Therefore increasing the default timeout to 10 minutes, instead of 30 seconds.

## Linear Ticket

[Link](https://linear.app/rudderstack/issue/PIPE-96/increase-default-transformer-timeout-in-rudder-server)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
