### PR TITLE
chore: logfield with structured logging

### DIFF
--- a/warehouse/archive/archiver.go
+++ b/warehouse/archive/archiver.go
@@ -65,7 +65,7 @@ type uploadRecord struct {
 type Archiver struct {
 	DB          *sql.DB
 	Stats       stats.Stats
-	Logger      *lf.Logger
+	Logger      lf.Logger
 	FileManager filemanager.Factory
 	Multitenant *multitenant.Manager
 }

--- a/warehouse/logfield/logfield.go
+++ b/warehouse/logfield/logfield.go
@@ -1,6 +1,8 @@
 package logfield
 
 import (
+	"sync"
+
 	"github.com/rudderlabs/rudder-go-kit/logger"
 )
 
@@ -59,32 +61,46 @@ var (
 	}
 )
 
-func NewLogger(component string, l logger.Logger) *Logger {
-	return &Logger{component: component, logger: l}
+func NewLogger(component string, l logger.Logger) Logger {
+	return Logger{component: component, logger: l}
 }
 
 type Logger struct {
 	component string
 	logger    logger.Logger
+	once      sync.Once
+}
+
+func (l *Logger) init() {
+	l.once.Do(func() {
+		if l.logger == nil {
+			l.logger = logger.NOP
+		}
+	})
 }
 
 func (l *Logger) Infow(msg string, kvs ...KeyValue) {
+	l.init()
 	l.logger.Infow(msg, l.keyAndValues(kvs)...)
 }
 
 func (l *Logger) Debugw(msg string, kvs ...KeyValue) {
+	l.init()
 	l.logger.Debugw(msg, l.keyAndValues(kvs)...)
 }
 
 func (l *Logger) Errorw(msg string, kvs ...KeyValue) {
+	l.init()
 	l.logger.Errorw(msg, l.keyAndValues(kvs)...)
 }
 
 func (l *Logger) Warnw(msg string, kvs ...KeyValue) {
+	l.init()
 	l.logger.Warnw(msg, l.keyAndValues(kvs)...)
 }
 
 func (l *Logger) Fatalw(msg string, kvs ...KeyValue) {
+	l.init()
 	l.logger.Fatalw(msg, l.keyAndValues(kvs)...)
 }
 


### PR DESCRIPTION
# Description

Experimenting with structured logging in the warehouse.

Rationale:
* by allowing only `KeyValue` parameters with unexported attributes, we enforce the usage of the desired pattern
* we eliminate the risk of passing an odd number of key/values
* the type `Generic` can be removed altogether, forcing to add a new `Field` whenever required. alternatively it can be kept and then used later on to search for `Generic` usage to see if new fields can be created (e.g. used more than once)
* by using functions instead of constants we are able to do some conversions (see `logfield.Error`, now we can pass both a `string` or an `error` without having to do `err.Error()` each time)
* by having a `logfield.Logger` we can enforce the pattern and make sure a `component` is always specified

This relates to a discussion we had in [this other PR](https://github.com/rudderlabs/rudder-server/pull/3726#issuecomment-1672724607).

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-129/warehouse-structured-logging) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
