### PR TITLE
chore: remove Init and exported struct variables from Archiver

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -47,7 +47,6 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/types/deployment"
 	"github.com/rudderlabs/rudder-server/warehouse"
-	warehousearchiver "github.com/rudderlabs/rudder-server/warehouse/archive"
 	"github.com/rudderlabs/rudder-server/warehouse/encoding"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 	"github.com/rudderlabs/rudder-server/warehouse/validations"
@@ -340,7 +339,6 @@ func runAllInit() {
 	warehouse.Init()
 	warehouse.Init4()
 	warehouse.Init6()
-	warehousearchiver.Init()
 	validations.Init()
 	webhook.Init()
 	asyncdestinationmanager.Init()

--- a/warehouse/archive/archiver_test.go
+++ b/warehouse/archive/archiver_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/config"
+
 	"github.com/golang/mock/gomock"
 	"github.com/minio/minio-go"
 	"github.com/stretchr/testify/require"
@@ -114,12 +116,12 @@ func TestArchiver(t *testing.T) {
 
 			ctrl := gomock.NewController(t)
 			mockStats := mock_stats.NewMockStats(ctrl)
+			mockStats.EXPECT().NewStat(gomock.Any(), gomock.Any()).Times(1)
+
 			mockMeasurement := mock_stats.NewMockMeasurement(ctrl)
 
 			if tc.archived {
-				mockStats.EXPECT().NewTaggedStat(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Times(4).Return(mockMeasurement)
+				mockStats.EXPECT().NewTaggedStat(gomock.Any(), gomock.Any(), gomock.Any()).Times(4).Return(mockMeasurement)
 				mockMeasurement.EXPECT().Increment().Times(4)
 			}
 
@@ -145,15 +147,16 @@ func TestArchiver(t *testing.T) {
 			`, tc.workspaceID, now)
 			require.NoError(t, err)
 
-			archiver := archive.Archiver{
-				DB:          pgResource.DB,
-				Stats:       mockStats,
-				Logger:      logger.NOP,
-				FileManager: filemanager.New,
-				Multitenant: &multitenant.Manager{
+			archiver := archive.New(
+				config.Default,
+				logger.NOP,
+				mockStats,
+				pgResource.DB,
+				filemanager.New,
+				&multitenant.Manager{
 					DegradedWorkspaceIDs: tc.degradedWorkspaceIDs,
 				},
-			}
+			)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/warehouse/archive/cron.go
+++ b/warehouse/archive/cron.go
@@ -9,13 +9,13 @@ func CronArchiver(ctx context.Context, a *Archiver) {
 	for {
 		select {
 		case <-ctx.Done():
-			a.Logger.Infof("context is cancelled, stopped running archiving")
+			a.log.Infof("context is cancelled, stopped running archiving")
 			return
-		case <-time.After(archiverTickerTime):
-			if archiveUploadRelatedRecords {
+		case <-time.After(a.config.archiverTickerTime):
+			if a.config.archiveUploadRelatedRecords {
 				err := a.Do(ctx)
 				if err != nil {
-					a.Logger.Errorf(`Error archiving uploads: %v`, err)
+					a.log.Errorf(`Error archiving uploads: %v`, err)
 				}
 			}
 		}

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -887,15 +887,15 @@ func Start(ctx context.Context, app app.App) error {
 			return monitorDestRouters(gCtx)
 		}))
 
-		archiver := &archive.Archiver{
-			DB:          dbHandle,
-			Stats:       stats.Default,
-			Logger:      pkgLogger.Child("archiver"),
-			FileManager: filemanager.New,
-			Multitenant: tenantManager,
-		}
 		g.Go(misc.WithBugsnagForWarehouse(func() error {
-			archive.CronArchiver(gCtx, archiver)
+			archive.CronArchiver(gCtx, archive.New(
+				config.Default,
+				pkgLogger,
+				stats.Default,
+				dbHandle,
+				filemanager.New,
+				tenantManager,
+			))
 			return nil
 		}))
 


### PR DESCRIPTION
# Description

- Remove `archive.Init()`
- Expose `archive.New(...)` to initialize.
- Remove Globals.

## Linear Ticket

- https://linear.app/rudderstack/issue/PIPE-117/warehouse-init-cleanup

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
