### PR TITLE
fix: illegal job sequence during barrier enter in router pickup

### DIFF
--- a/router/handle.go
+++ b/router/handle.go
@@ -532,6 +532,7 @@ func (rt *Handle) findWorkerSlot(workers []*worker, job *jobsdb.JobT, blockedOrd
 	}
 	rt.logger.Debugf("EventOrder: job %d of orderKey %s is blocked (previousFailedJobID: %s)", job.JobID, orderKey, previousFailedJobIDStr)
 	slot.Release()
+	blockedOrderKeys[orderKey] = struct{}{}
 	return nil, types.ErrBarrierExists
 	//#EndJobOrder
 }


### PR DESCRIPTION
# Description

During router's pickup iteration, while trying to find an available worker slot, if the barrier forbids the job to enter, this job needs to be added to the `blockedOrderKeys`, so that no other job for the same ordering key can be picked up in this iteration.

Even though the barrier is synced only once before the router iterator's loop begins, the barrier's two limiters (concurrency & drain) are updated in realtime and can at any time fill or empty causing barrier#Enter's response to vary.

## Linear Ticket

[Link](https://linear.app/rudderstack/issue/PIPE-133/bug-causing-illegal-job-sequence-during-barrier-enter-in-router-pickup)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
