### PR TITLE
chore: option to pass *config.Config to jobsdb

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -99,7 +99,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 	reporting := a.app.Features().Reporting.Setup(backendconfig.DefaultBackendConfig)
 
 	g.Go(func() error {
-		reporting.AddClient(ctx, types.Config{ConnInfo: misc.GetConnectionString()})
+		reporting.AddClient(ctx, types.Config{ConnInfo: misc.GetConnectionString(config)})
 		return nil
 	})
 

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -113,7 +113,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 	reporting := a.app.Features().Reporting.Setup(backendconfig.DefaultBackendConfig)
 
 	g.Go(misc.WithBugsnag(func() error {
-		reporting.AddClient(ctx, types.Config{ConnInfo: misc.GetConnectionString()})
+		reporting.AddClient(ctx, types.Config{ConnInfo: misc.GetConnectionString(nil)})
 		return nil
 	}))
 

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -113,7 +113,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 	reporting := a.app.Features().Reporting.Setup(backendconfig.DefaultBackendConfig)
 
 	g.Go(misc.WithBugsnag(func() error {
-		reporting.AddClient(ctx, types.Config{ConnInfo: misc.GetConnectionString(nil)})
+		reporting.AddClient(ctx, types.Config{ConnInfo: misc.GetConnectionString(config.Default)})
 		return nil
 	}))
 

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -58,7 +58,7 @@ func rudderCoreWorkSpaceTableSetup() error {
 func NewRsourcesService(deploymentType deployment.Type) (rsources.JobService, error) {
 	var rsourcesConfig rsources.JobServiceConfig
 	rsourcesConfig.MaxPoolSize = config.GetInt("Rsources.PoolSize", 5)
-	rsourcesConfig.LocalConn = misc.GetConnectionString(nil)
+	rsourcesConfig.LocalConn = misc.GetConnectionString(config.Default)
 	rsourcesConfig.LocalHostname = config.GetString("DB.host", "localhost")
 	rsourcesConfig.SharedConn = config.GetString("SharedDB.dsn", "")
 	rsourcesConfig.SkipFailedRecordsCollection = !config.GetBool("Router.failedKeysEnabled", true)

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -58,7 +58,7 @@ func rudderCoreWorkSpaceTableSetup() error {
 func NewRsourcesService(deploymentType deployment.Type) (rsources.JobService, error) {
 	var rsourcesConfig rsources.JobServiceConfig
 	rsourcesConfig.MaxPoolSize = config.GetInt("Rsources.PoolSize", 5)
-	rsourcesConfig.LocalConn = misc.GetConnectionString()
+	rsourcesConfig.LocalConn = misc.GetConnectionString(nil)
 	rsourcesConfig.LocalHostname = config.GetString("DB.host", "localhost")
 	rsourcesConfig.SharedConn = config.GetString("SharedDB.dsn", "")
 	rsourcesConfig.SkipFailedRecordsCollection = !config.GetBool("Router.failedKeysEnabled", true)

--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -163,7 +163,6 @@ func initJobsDB() {
 	logger.Reset()
 	stash.Init()
 	admin.Init()
-	jobsdb.Init()
 	Init()
 }
 

--- a/archiver/archiver_isolation_test.go
+++ b/archiver/archiver_isolation_test.go
@@ -312,7 +312,6 @@ func insertJobs(
 	configMap map[string]backendconfig.ConfigT,
 	numJobsPerSource int,
 ) (map[string][]*jobsdb.JobT, int) {
-	t.Log(misc.GetConnectionString())
 	gwJobsDB := jobsdb.NewForWrite("gw")
 	require.NoError(t, gwJobsDB.Start(), "it should be able to start the jobsdb")
 	defer gwJobsDB.Stop()

--- a/archiver/archiver_isolation_test.go
+++ b/archiver/archiver_isolation_test.go
@@ -312,7 +312,6 @@ func insertJobs(
 	configMap map[string]backendconfig.ConfigT,
 	numJobsPerSource int,
 ) (map[string][]*jobsdb.JobT, int) {
-	jobsdb.Init()
 	t.Log(misc.GetConnectionString())
 	gwJobsDB := jobsdb.NewForWrite("gw")
 	require.NoError(t, gwJobsDB.Start(), "it should be able to start the jobsdb")

--- a/archiver/archiver_test.go
+++ b/archiver/archiver_test.go
@@ -71,7 +71,6 @@ func TestJobsArchival(t *testing.T) {
 		t.Setenv("JOBS_DB_USER", postgresResource.User)
 		t.Setenv("JOBS_DB_PASSWORD", postgresResource.Password)
 	}
-	jobsdb.Init()
 	misc.Init()
 	jd := &jobsdb.Handle{
 		TriggerAddNewDS: func() <-chan time.Time {

--- a/archiver/archiver_test.go
+++ b/archiver/archiver_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/misc"
 
 	"github.com/rudderlabs/rudder-server/services/fileuploader"
-	"github.com/rudderlabs/rudder-server/testhelper"
 	"github.com/rudderlabs/rudder-server/testhelper/destination"
 )
 
@@ -45,9 +44,8 @@ func TestJobsArchival(t *testing.T) {
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err, "Failed to create docker pool")
-	cleanup := &testhelper.Cleanup{}
 
-	postgresResource, err := resource.SetupPostgres(pool, cleanup)
+	postgresResource, err := resource.SetupPostgres(pool, t)
 	require.NoError(t, err, "failed to setup postgres resource")
 	c := config.New()
 	c.Set("MINIO_SSL", "false")
@@ -63,7 +61,7 @@ func TestJobsArchival(t *testing.T) {
 
 	minioResource = make([]*destination.MINIOResource, uniqueWorkspaces)
 	for i := 0; i < uniqueWorkspaces; i++ {
-		minioResource[i], err = destination.SetupMINIO(pool, cleanup)
+		minioResource[i], err = destination.SetupMINIO(pool, t)
 		require.NoError(t, err, "failed to setup minio resource")
 	}
 
@@ -184,7 +182,7 @@ func TestJobsArchival(t *testing.T) {
 			require.NoError(t, err)
 			dJobs, err := readGzipJobFile(downloadFile.Name())
 			require.NoError(t, err)
-			cleanup.Cleanup(func() {
+			t.Cleanup(func() {
 				_ = os.Remove(downloadFile.Name())
 			})
 			downloadedJobs = append(downloadedJobs, dJobs...)
@@ -194,7 +192,6 @@ func TestJobsArchival(t *testing.T) {
 	archiver.Stop()
 	jd.Stop()
 	jd.Close()
-	cleanup.Run()
 }
 
 func readGzipJobFile(filename string) ([]*jobsdb.JobT, error) {

--- a/archiver/archiver_test.go
+++ b/archiver/archiver_test.go
@@ -48,7 +48,6 @@ func TestJobsArchival(t *testing.T) {
 	postgresResource, err := resource.SetupPostgres(pool, t)
 	require.NoError(t, err, "failed to setup postgres resource")
 	c := config.New()
-	c.Set("MINIO_SSL", "false")
 	c.Set("DB.name", postgresResource.Database)
 	c.Set("DB.host", postgresResource.Host)
 	c.Set("DB.port", postgresResource.Port)
@@ -174,7 +173,7 @@ func TestJobsArchival(t *testing.T) {
 		require.Equal(t, sourcesPerWorkspace[i], len(files))
 
 		for j, file := range files {
-			downloadFile, err := os.CreateTemp("", fmt.Sprintf("backedupfile%d%d", i, j))
+			downloadFile, err := os.CreateTemp(t.TempDir(), fmt.Sprintf("backedupfile%d%d", i, j))
 			require.NoError(t, err)
 			err = fm.Download(context.Background(), downloadFile, file)
 			require.NoError(t, err, file)
@@ -182,9 +181,6 @@ func TestJobsArchival(t *testing.T) {
 			require.NoError(t, err)
 			dJobs, err := readGzipJobFile(downloadFile.Name())
 			require.NoError(t, err)
-			t.Cleanup(func() {
-				_ = os.Remove(downloadFile.Name())
-			})
 			downloadedJobs = append(downloadedJobs, dJobs...)
 		}
 	}

--- a/backend-config/internal/cache/cache.go
+++ b/backend-config/internal/cache/cache.go
@@ -132,7 +132,7 @@ func (db *cacheStore) Get(ctx context.Context) ([]byte, error) {
 
 // setupDBConn sets up the database connection, creates the config table if it doesn't exist
 func setupDBConn() (*sql.DB, error) {
-	psqlInfo := misc.GetConnectionString()
+	psqlInfo := misc.GetConnectionString(nil)
 	db, err := sql.Open("postgres", psqlInfo)
 	if err != nil {
 		pkgLogger.Errorf("failed to open db: %v", err)

--- a/backend-config/internal/cache/cache.go
+++ b/backend-config/internal/cache/cache.go
@@ -132,7 +132,7 @@ func (db *cacheStore) Get(ctx context.Context) ([]byte, error) {
 
 // setupDBConn sets up the database connection, creates the config table if it doesn't exist
 func setupDBConn() (*sql.DB, error) {
-	psqlInfo := misc.GetConnectionString(nil)
+	psqlInfo := misc.GetConnectionString(config.Default)
 	db, err := sql.Open("postgres", psqlInfo)
 	if err != nil {
 		pkgLogger.Errorf("failed to open db: %v", err)

--- a/event-schema/event_schema.go
+++ b/event-schema/event_schema.go
@@ -890,7 +890,7 @@ func (manager *EventSchemaManagerT) reloadSchemaVersion(offloadedVersion *Offloa
 
 // TODO: Move this into some DB manager
 func createDBConnection() *sql.DB {
-	psqlInfo := misc.GetConnectionString(nil)
+	psqlInfo := misc.GetConnectionString(config.Default)
 	var err error
 	dbHandle, err := sql.Open("postgres", psqlInfo)
 	if err != nil {

--- a/event-schema/event_schema.go
+++ b/event-schema/event_schema.go
@@ -890,7 +890,7 @@ func (manager *EventSchemaManagerT) reloadSchemaVersion(offloadedVersion *Offloa
 
 // TODO: Move this into some DB manager
 func createDBConnection() *sql.DB {
-	psqlInfo := misc.GetConnectionString()
+	psqlInfo := misc.GetConnectionString(nil)
 	var err error
 	dbHandle, err := sql.Open("postgres", psqlInfo)
 	if err != nil {

--- a/event-schema/event_schema_test.go
+++ b/event-schema/event_schema_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
 	"github.com/rudderlabs/rudder-server/admin"
-	"github.com/rudderlabs/rudder-server/jobsdb"
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 	"github.com/rudderlabs/rudder-server/testhelper"
 )
@@ -74,7 +73,6 @@ func jobsDBInit(es envSetter, pgResource *resource.PostgresResource) {
 	es.Setenv("JOBS_DB_PORT", pgResource.Port)
 
 	admin.Init()
-	jobsdb.Init()
 }
 
 var _ = Describe("Event Schemas", Ordered, func() {

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -149,9 +149,9 @@ func (jd *Handle) startCleanupLoop(ctx context.Context) {
 			case <-jd.TriggerJobCleanUp():
 				func() {
 					for {
-						if err := jd.doCleanup(ctx, jd.configGetter.GetInt("jobsdb.cleanupBatchSize", 100)); err != nil && ctx.Err() == nil {
+						if err := jd.doCleanup(ctx, jd.config.GetInt("jobsdb.cleanupBatchSize", 100)); err != nil && ctx.Err() == nil {
 							jd.logger.Errorf("error while cleaning up old jobs: %w", err)
-							if err := misc.SleepCtx(ctx, jd.configGetter.GetDuration("jobsdb.cleanupRetryInterval", 10, time.Second)); err != nil {
+							if err := misc.SleepCtx(ctx, jd.config.GetDuration("jobsdb.cleanupRetryInterval", 10, time.Second)); err != nil {
 								return
 							}
 							continue
@@ -181,7 +181,7 @@ func (jd *Handle) doCleanup(ctx context.Context, batchSize int) error {
 			jobs := lo.Filter(
 				jobsResult.Jobs,
 				func(job *JobT, _ int) bool {
-					return job.CreatedAt.Before(time.Now().Add(-jd.config.jobMaxAge()))
+					return job.CreatedAt.Before(time.Now().Add(-jd.conf.jobMaxAge()))
 				},
 			)
 			if len(jobs) > 0 {
@@ -224,7 +224,7 @@ func (jd *Handle) doCleanup(ctx context.Context, batchSize int) error {
 			fmt.Sprintf(
 				deleteStmt,
 				jd.tablePrefix,
-				jd.configGetter.GetInt("JobsDB.archivalTimeInDays", 10),
+				jd.config.GetInt("JobsDB.archivalTimeInDays", 10),
 			),
 		).Scan(&journalEntryCount); err != nil {
 			return err

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -181,7 +181,7 @@ func (jd *Handle) doCleanup(ctx context.Context, batchSize int) error {
 			jobs := lo.Filter(
 				jobsResult.Jobs,
 				func(job *JobT, _ int) bool {
-					return job.CreatedAt.Before(time.Now().Add(-jd.JobMaxAge()))
+					return job.CreatedAt.Before(time.Now().Add(-jd.config.jobMaxAge()))
 				},
 			)
 			if len(jobs) > 0 {

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
@@ -150,9 +149,9 @@ func (jd *Handle) startCleanupLoop(ctx context.Context) {
 			case <-jd.TriggerJobCleanUp():
 				func() {
 					for {
-						if err := jd.doCleanup(ctx, config.GetInt("jobsdb.cleanupBatchSize", 100)); err != nil && ctx.Err() == nil {
+						if err := jd.doCleanup(ctx, jd.configGetter.GetInt("jobsdb.cleanupBatchSize", 100)); err != nil && ctx.Err() == nil {
 							jd.logger.Errorf("error while cleaning up old jobs: %w", err)
-							if err := misc.SleepCtx(ctx, config.GetDuration("jobsdb.cleanupRetryInterval", 10, time.Second)); err != nil {
+							if err := misc.SleepCtx(ctx, jd.configGetter.GetDuration("jobsdb.cleanupRetryInterval", 10, time.Second)); err != nil {
 								return
 							}
 							continue
@@ -225,7 +224,7 @@ func (jd *Handle) doCleanup(ctx context.Context, batchSize int) error {
 			fmt.Sprintf(
 				deleteStmt,
 				jd.tablePrefix,
-				config.GetInt("JobsDB.archivalTimeInDays", 10),
+				jd.configGetter.GetInt("JobsDB.archivalTimeInDays", 10),
 			),
 		).Scan(&journalEntryCount); err != nil {
 			return err

--- a/jobsdb/backup.go
+++ b/jobsdb/backup.go
@@ -181,7 +181,7 @@ func (jd *Handle) failedOnlyBackup(ctx context.Context, backupDSRange *dataSetRa
 		if err != nil {
 			return "", err
 		}
-		pathPrefix = strings.TrimPrefix(tableName, preDropTablePrefix)
+		pathPrefix := strings.TrimPrefix(tableName, preDropTablePrefix)
 		return fmt.Sprintf(`%v%v_%v.%v.gz`, tmpDirPath+backupPathDirName, pathPrefix, Aborted.State, workspaceID), nil
 	}
 
@@ -233,7 +233,7 @@ func (jd *Handle) backupJobsTable(ctx context.Context, backupDSRange *dataSetRan
 		if err != nil {
 			return "", err
 		}
-		pathPrefix = strings.TrimPrefix(tableName, preDropTablePrefix)
+		pathPrefix := strings.TrimPrefix(tableName, preDropTablePrefix)
 		return fmt.Sprintf(`%v%v.%v.%v.%v.%v.%v.gz`,
 			tmpDirPath+backupPathDirName,
 			pathPrefix,
@@ -295,7 +295,7 @@ func (jd *Handle) backupStatusTable(ctx context.Context, backupDSRange *dataSetR
 		if err != nil {
 			return "", err
 		}
-		pathPrefix = strings.TrimPrefix(tableName, preDropTablePrefix)
+		pathPrefix := strings.TrimPrefix(tableName, preDropTablePrefix)
 		return fmt.Sprintf(`%v%v.%v.gz`, tmpDirPath+backupPathDirName, pathPrefix, workspaceID), nil
 	}
 

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -69,7 +69,7 @@ func TestJobsDB(t *testing.T) {
 		TriggerAddNewDS: func() <-chan time.Time {
 			return triggerAddNewDS
 		},
-		configGetter: c,
+		config: c,
 	}
 	err := jobDB.Setup(ReadWrite, false, strings.ToLower(rand.String(5)), []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 	require.NoError(t, err)
@@ -229,7 +229,7 @@ func TestJobsDB(t *testing.T) {
 			TriggerAddNewDS: func() <-chan time.Time {
 				return triggerAddNewDS
 			},
-			configGetter: c,
+			config: c,
 		}
 
 		err := jobDB.Setup(ReadWrite, true, strings.ToLower(rand.String(5)), []prebackup.Handler{}, fileuploader.NewDefaultProvider())
@@ -315,7 +315,7 @@ func TestJobsDB(t *testing.T) {
 			TriggerAddNewDS: func() <-chan time.Time {
 				return triggerAddNewDS
 			},
-			configGetter: c,
+			config: c,
 		}
 
 		err := jobDB.Setup(ReadWrite, true, strings.ToLower(rand.String(5)), []prebackup.Handler{}, fileuploader.NewDefaultProvider())
@@ -355,7 +355,7 @@ func TestJobsDB(t *testing.T) {
 			TriggerAddNewDS: func() <-chan time.Time {
 				return triggerAddNewDS
 			},
-			configGetter: c,
+			config: c,
 		}
 		err := jobDB.Setup(ReadWrite, false, strings.ToLower(rand.String(5)), []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 		require.NoError(t, err)
@@ -385,7 +385,7 @@ func TestJobsDB(t *testing.T) {
 
 		c.Set("jobsdb.maxDSSize", 1)
 		jobDB := Handle{
-			configGetter: c,
+			config: c,
 			TriggerAddNewDS: func() <-chan time.Time {
 				return triggerAddNewDS
 			},
@@ -416,7 +416,7 @@ func TestJobsDB(t *testing.T) {
 
 		c.Set("jobsdb.maxDSSize", 4)
 		jobDB := Handle{
-			configGetter: c,
+			config: c,
 			TriggerAddNewDS: func() <-chan time.Time {
 				return triggerAddNewDS
 			},
@@ -460,7 +460,7 @@ func TestJobsDB(t *testing.T) {
 			TriggerAddNewDS: func() <-chan time.Time {
 				return triggerAddNewDS
 			},
-			configGetter: c,
+			config: c,
 		}
 
 		tablePrefix := strings.ToLower(rand.String(5))
@@ -493,7 +493,7 @@ func TestJobsDB(t *testing.T) {
 			TriggerMigrateDS: func() <-chan time.Time {
 				return triggerMigrateDS
 			},
-			configGetter: c,
+			config: c,
 		}
 
 		tablePrefix := strings.ToLower(rand.String(5))
@@ -579,7 +579,7 @@ func TestJobsDB(t *testing.T) {
 			TriggerMigrateDS: func() <-chan time.Time {
 				return triggerMigrateDS
 			},
-			configGetter: c,
+			config: c,
 		}
 		prefix := strings.ToLower(rand.String(5))
 		c.Set("JobsDB.jobDoneMigrateThreshold", 0.7)
@@ -701,7 +701,7 @@ func TestJobsDB(t *testing.T) {
 			TriggerMigrateDS: func() <-chan time.Time {
 				return triggerMigrateDS
 			},
-			configGetter: c,
+			config: c,
 		}
 		tablePrefix := strings.ToLower(rand.String(5))
 		c.Set(fmt.Sprintf("JobsDB.%s.maxDSRetention", tablePrefix), "1s")
@@ -808,7 +808,7 @@ func TestMultiTenantLegacyGetAllJobs(t *testing.T) {
 	c := config.New()
 	c.Set("jobsdb.maxDSSize", 10)
 	jobDB := Handle{
-		configGetter: c,
+		config: c,
 		TriggerAddNewDS: func() <-chan time.Time {
 			return triggerAddNewDS
 		},
@@ -893,7 +893,7 @@ func TestStoreAndUpdateStatusExceedingAnalyzeThreshold(t *testing.T) {
 	c.Set("jobsdb.maxDSSize", 10)
 
 	jobDB := Handle{
-		configGetter: c,
+		config: c,
 	}
 	customVal := "MOCKDS"
 	err := jobDB.Setup(ReadWrite, false, strings.ToLower(rand.String(5)), []prebackup.Handler{}, fileuploader.NewDefaultProvider())
@@ -977,8 +977,8 @@ func TestCreateDS(t *testing.T) {
 			c := config.New()
 			c.Set("jobsdb.maxDSSize", 1)
 			jobDB := Handle{
-				dbHandle:     postgresql.DB,
-				configGetter: c,
+				dbHandle: postgresql.DB,
+				config:   c,
 				TriggerAddNewDS: func() <-chan time.Time {
 					return triggerAddNewDS
 				},
@@ -1029,7 +1029,7 @@ func TestJobsDB_IncompatiblePayload(t *testing.T) {
 	c := config.New()
 	c.Set("jobsdb.maxDSSize", 10)
 	jobDB := Handle{
-		configGetter: c,
+		config: c,
 		TriggerAddNewDS: func() <-chan time.Time {
 			return triggerAddNewDS
 		},
@@ -1236,7 +1236,7 @@ func BenchmarkLifecycle(b *testing.B) {
 	triggerAddNewDS := make(chan time.Time)
 
 	jobDB := &Handle{
-		configGetter: c,
+		config: c,
 		TriggerAddNewDS: func() <-chan time.Time {
 			return triggerAddNewDS
 		},

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -772,7 +772,6 @@ func (jd *Handle) init() {
 
 	if !jd.enableReaderQueue || !jd.enableWriterQueue {
 		jd.dbHandle.SetMaxOpenConns(jd.maxOpenConnections)
-		return
 	} else {
 		maxOpenConnections := 2 // buffer
 		maxOpenConnections += jd.maxReaders + jd.maxWriters

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -685,6 +685,12 @@ func WithConfig(c *config.Config) OptsFunc {
 	}
 }
 
+func WithLogger(l logger.Logger) OptsFunc {
+	return func(jd *HandleT) {
+		jd.logger = l
+	}
+}
+
 func WithSkipMaintenanceErr(ignore bool) OptsFunc {
 	return func(jd *Handle) {
 		jd.skipMaintenanceError = ignore

--- a/jobsdb/jobsdb_renameDs_test.go
+++ b/jobsdb/jobsdb_renameDs_test.go
@@ -21,7 +21,7 @@ func Test_mustRenameDS(t *testing.T) {
 		tablePrefix: prefix,
 		dbHandle:    dbHandle,
 	}
-	jobsdb.backupConfig.preBackupHandlers = []prebackup.Handler{
+	jobsdb.conf.backup.preBackupHandlers = []prebackup.Handler{
 		prebackup.DropSourceIds(func() []string { return []string{"one", "two"} }),
 	}
 	var (
@@ -67,7 +67,7 @@ func Test_mustRenameDS_drops_table_if_left_empty(t *testing.T) {
 		tablePrefix: prefix,
 		dbHandle:    dbHandle,
 	}
-	jobsdb.backupConfig.preBackupHandlers = []prebackup.Handler{
+	jobsdb.conf.backup.preBackupHandlers = []prebackup.Handler{
 		prebackup.DropSourceIds(func() []string { return []string{"one", "two"} }),
 	}
 	var (

--- a/jobsdb/jobsdb_renameDs_test.go
+++ b/jobsdb/jobsdb_renameDs_test.go
@@ -20,9 +20,9 @@ func Test_mustRenameDS(t *testing.T) {
 	jobsdb := &Handle{
 		tablePrefix: prefix,
 		dbHandle:    dbHandle,
-		preBackupHandlers: []prebackup.Handler{
-			prebackup.DropSourceIds(func() []string { return []string{"one", "two"} }),
-		},
+	}
+	jobsdb.backupConfig.preBackupHandlers = []prebackup.Handler{
+		prebackup.DropSourceIds(func() []string { return []string{"one", "two"} }),
 	}
 	var (
 		jobsTable      = prefix + "_jobs"
@@ -66,9 +66,9 @@ func Test_mustRenameDS_drops_table_if_left_empty(t *testing.T) {
 	jobsdb := &Handle{
 		tablePrefix: prefix,
 		dbHandle:    dbHandle,
-		preBackupHandlers: []prebackup.Handler{
-			prebackup.DropSourceIds(func() []string { return []string{"one", "two"} }),
-		},
+	}
+	jobsdb.backupConfig.preBackupHandlers = []prebackup.Handler{
+		prebackup.DropSourceIds(func() []string { return []string{"one", "two"} }),
 	}
 	var (
 		jobsTable      = prefix + "_jobs"

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -410,7 +410,7 @@ func TestJobsDBTimeout(t *testing.T) {
 
 	c.Set("JobsDB.maxDSSize", 10)
 	jobDB := Handle{
-		configGetter: c,
+		config: c,
 	}
 
 	customVal := "MOCKDS"
@@ -497,7 +497,7 @@ func TestThreadSafeAddNewDSLoop(t *testing.T) {
 		TriggerAddNewDS: func() <-chan time.Time {
 			return triggerAddNewDS1
 		},
-		configGetter: c,
+		config: c,
 	}
 	prefix := strings.ToLower(rsRand.String(5))
 	err := jobsDB1.Setup(ReadWrite, false, prefix, []prebackup.Handler{}, fileuploader.NewDefaultProvider())
@@ -511,7 +511,7 @@ func TestThreadSafeAddNewDSLoop(t *testing.T) {
 		TriggerAddNewDS: func() <-chan time.Time {
 			return triggerAddNewDS2
 		},
-		configGetter: c,
+		config: c,
 	}
 	err = jobsDB2.Setup(ReadWrite, false, prefix, []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 	require.NoError(t, err)
@@ -596,7 +596,7 @@ func TestThreadSafeJobStorage(t *testing.T) {
 			TriggerAddNewDS: func() <-chan time.Time {
 				return triggerAddNewDS
 			},
-			configGetter: c,
+			config: c,
 		}
 		err := jobsDB.Setup(ReadWrite, true, strings.ToLower(rsRand.String(5)), []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 		require.NoError(t, err)
@@ -660,7 +660,7 @@ func TestThreadSafeJobStorage(t *testing.T) {
 			TriggerAddNewDS: func() <-chan time.Time {
 				return triggerAddNewDS1
 			},
-			configGetter: c,
+			config: c,
 		}
 		clearAllDS := true
 		prefix := strings.ToLower(rsRand.String(5))
@@ -679,7 +679,7 @@ func TestThreadSafeJobStorage(t *testing.T) {
 			TriggerRefreshDS: func() <-chan time.Time {
 				return triggerRefreshDS
 			},
-			configGetter: c,
+			config: c,
 		}
 		err = jobsDB2.Setup(ReadWrite, !clearAllDS, prefix, []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 		require.NoError(t, err)
@@ -695,7 +695,7 @@ func TestThreadSafeJobStorage(t *testing.T) {
 			TriggerRefreshDS: func() <-chan time.Time {
 				return triggerRefreshDS
 			},
-			configGetter: c,
+			config: c,
 		}
 		err = jobsDB3.Setup(ReadWrite, !clearAllDS, prefix, []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 		require.NoError(t, err)
@@ -790,7 +790,7 @@ func TestCacheScenarios(t *testing.T) {
 				"cache",
 			)
 		}
-		dbWithOneLimit.config.MaxDSSize = &maxDSSize
+		dbWithOneLimit.conf.MaxDSSize = &maxDSSize
 		dbWithOneLimit.TriggerAddNewDS = func() <-chan time.Time {
 			return triggerAddNewDS
 		}
@@ -1328,7 +1328,7 @@ func TestGetActiveWorkspaces(t *testing.T) {
 		TriggerAddNewDS: func() <-chan time.Time {
 			return triggerAddNewDS
 		},
-		configGetter: c,
+		config: c,
 	}
 	err := jobsDB.Setup(ReadWrite, true, strings.ToLower(rsRand.String(5)), []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 	require.NoError(t, err)
@@ -1440,7 +1440,7 @@ func TestGetDistinctParameterValues(t *testing.T) {
 		TriggerAddNewDS: func() <-chan time.Time {
 			return triggerAddNewDS
 		},
-		configGetter: c,
+		config: c,
 	}
 	err := jobsDB.Setup(ReadWrite, true, strings.ToLower(rsRand.String(5)), []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 	require.NoError(t, err)

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -37,7 +37,6 @@ import (
 
 var _ = Describe("Calculate newDSIdx for internal migrations", Ordered, func() {
 	BeforeAll(func() {
-		pkgLogger = logger.NOP
 	})
 
 	DescribeTable("newDSIdx tests",
@@ -150,7 +149,6 @@ var _ = Describe("Calculate newDSIdx for internal migrations", Ordered, func() {
 
 var _ = Describe("jobsdb", Ordered, func() {
 	BeforeAll(func() {
-		pkgLogger = logger.NOP
 	})
 
 	Context("getDSList", func() {
@@ -1582,5 +1580,4 @@ func initJobsDB() {
 	logger.Reset()
 	admin.Init()
 	misc.Init()
-	Init()
 }

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -406,10 +406,11 @@ func TestRefreshDSList(t *testing.T) {
 func TestJobsDBTimeout(t *testing.T) {
 	_ = startPostgres(t)
 	defaultWorkspaceID := "workspaceId"
+	c := config.New()
 
-	maxDSSize := 10
+	c.Set("JobsDB.maxDSSize", 10)
 	jobDB := Handle{
-		MaxDSSize: &maxDSSize,
+		configGetter: c,
 	}
 
 	customVal := "MOCKDS"
@@ -488,14 +489,15 @@ func TestJobsDBTimeout(t *testing.T) {
 
 func TestThreadSafeAddNewDSLoop(t *testing.T) {
 	_ = startPostgres(t)
-	maxDSSize := 1
+	c := config.New()
+	c.Set("JobsDB.maxDSSize", 1)
 	triggerAddNewDS1 := make(chan time.Time)
 	// jobsDB-1 setup
 	jobsDB1 := &Handle{
 		TriggerAddNewDS: func() <-chan time.Time {
 			return triggerAddNewDS1
 		},
-		MaxDSSize: &maxDSSize,
+		configGetter: c,
 	}
 	prefix := strings.ToLower(rsRand.String(5))
 	err := jobsDB1.Setup(ReadWrite, false, prefix, []prebackup.Handler{}, fileuploader.NewDefaultProvider())
@@ -509,7 +511,7 @@ func TestThreadSafeAddNewDSLoop(t *testing.T) {
 		TriggerAddNewDS: func() <-chan time.Time {
 			return triggerAddNewDS2
 		},
-		MaxDSSize: &maxDSSize,
+		configGetter: c,
 	}
 	err = jobsDB2.Setup(ReadWrite, false, prefix, []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 	require.NoError(t, err)
@@ -587,13 +589,14 @@ func TestThreadSafeJobStorage(t *testing.T) {
 	_ = startPostgres(t)
 
 	t.Run("verify that `pgErrorCodeTableReadonly` exception is triggered, if we try to insert in any DS other than latest.", func(t *testing.T) {
-		maxDSSize := 1
 		triggerAddNewDS := make(chan time.Time)
+		c := config.New()
+		c.Set("JobsDB.maxDSSize", 1)
 		jobsDB := &Handle{
 			TriggerAddNewDS: func() <-chan time.Time {
 				return triggerAddNewDS
 			},
-			MaxDSSize: &maxDSSize,
+			configGetter: c,
 		}
 		err := jobsDB.Setup(ReadWrite, true, strings.ToLower(rsRand.String(5)), []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 		require.NoError(t, err)
@@ -646,7 +649,8 @@ func TestThreadSafeJobStorage(t *testing.T) {
 
 	t.Run(`verify that even if jobsDB instance is unaware of new DS addition by other jobsDB instance.
 	 And, it tries to Store() in postgres, then the exception thrown is handled properly & DS cache is refreshed`, func(t *testing.T) {
-		maxDSSize := 1
+		c := config.New()
+		c.Set("JobsDB.maxDSSize", 1)
 
 		triggerRefreshDS := make(chan time.Time)
 		triggerAddNewDS1 := make(chan time.Time)
@@ -656,7 +660,7 @@ func TestThreadSafeJobStorage(t *testing.T) {
 			TriggerAddNewDS: func() <-chan time.Time {
 				return triggerAddNewDS1
 			},
-			MaxDSSize: &maxDSSize,
+			configGetter: c,
 		}
 		clearAllDS := true
 		prefix := strings.ToLower(rsRand.String(5))
@@ -675,7 +679,7 @@ func TestThreadSafeJobStorage(t *testing.T) {
 			TriggerRefreshDS: func() <-chan time.Time {
 				return triggerRefreshDS
 			},
-			MaxDSSize: &maxDSSize,
+			configGetter: c,
 		}
 		err = jobsDB2.Setup(ReadWrite, !clearAllDS, prefix, []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 		require.NoError(t, err)
@@ -691,7 +695,7 @@ func TestThreadSafeJobStorage(t *testing.T) {
 			TriggerRefreshDS: func() <-chan time.Time {
 				return triggerRefreshDS
 			},
-			MaxDSSize: &maxDSSize,
+			configGetter: c,
 		}
 		err = jobsDB3.Setup(ReadWrite, !clearAllDS, prefix, []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 		require.NoError(t, err)
@@ -786,7 +790,7 @@ func TestCacheScenarios(t *testing.T) {
 				"cache",
 			)
 		}
-		dbWithOneLimit.MaxDSSize = &maxDSSize
+		dbWithOneLimit.config.MaxDSSize = &maxDSSize
 		dbWithOneLimit.TriggerAddNewDS = func() <-chan time.Time {
 			return triggerAddNewDS
 		}
@@ -1317,13 +1321,14 @@ func TestConstructParameterJSONQuery(t *testing.T) {
 
 func TestGetActiveWorkspaces(t *testing.T) {
 	_ = startPostgres(t)
-	maxDSSize := 1
+	c := config.New()
+	c.Set("JobsDB.maxDSSize", 1)
 	triggerAddNewDS := make(chan time.Time)
 	jobsDB := &Handle{
 		TriggerAddNewDS: func() <-chan time.Time {
 			return triggerAddNewDS
 		},
-		MaxDSSize: &maxDSSize,
+		configGetter: c,
 	}
 	err := jobsDB.Setup(ReadWrite, true, strings.ToLower(rsRand.String(5)), []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 	require.NoError(t, err)
@@ -1428,13 +1433,14 @@ func TestGetActiveWorkspaces(t *testing.T) {
 
 func TestGetDistinctParameterValues(t *testing.T) {
 	_ = startPostgres(t)
-	maxDSSize := 1
+	c := config.New()
+	c.Set("JobsDB.maxDSSize", 1)
 	triggerAddNewDS := make(chan time.Time)
 	jobsDB := &Handle{
 		TriggerAddNewDS: func() <-chan time.Time {
 			return triggerAddNewDS
 		},
-		MaxDSSize: &maxDSSize,
+		configGetter: c,
 	}
 	err := jobsDB.Setup(ReadWrite, true, strings.ToLower(rsRand.String(5)), []prebackup.Handler{}, fileuploader.NewDefaultProvider())
 	require.NoError(t, err)

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -39,7 +39,7 @@ func (jd *Handle) migrateDSLoop(ctx context.Context) {
 		migrate := func() error {
 			start := time.Now()
 			jd.logger.Debugw("Start", "operation", "migrateDSLoop")
-			timeoutCtx, cancel := context.WithTimeout(ctx, jd.migrationConfig.migrateDSTimeout)
+			timeoutCtx, cancel := context.WithTimeout(ctx, jd.conf.migration.migrateDSTimeout)
 			defer cancel()
 			err := jd.doMigrateDS(timeoutCtx)
 			stats.Default.NewTaggedStat("migration_loop", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix, "error": strconv.FormatBool(err != nil)}).Since(start)
@@ -49,7 +49,7 @@ func (jd *Handle) migrateDSLoop(ctx context.Context) {
 			return nil
 		}
 		if err := migrate(); err != nil && ctx.Err() == nil {
-			if !jd.config.skipMaintenanceError {
+			if !jd.conf.skipMaintenanceError {
 				panic(err)
 			}
 			jd.logger.Errorw("Failed to migrate ds", "error", err)
@@ -219,7 +219,7 @@ func (jd *Handle) getVacuumFullCandidates(ctx context.Context, dsList []dataSetT
 
 	toVacuumFull := []string{}
 	for _, ds := range dsList {
-		if tableSizes[ds.JobStatusTable] > jd.migrationConfig.vacuumFullStatusTableThreshold() {
+		if tableSizes[ds.JobStatusTable] > jd.conf.migration.vacuumFullStatusTableThreshold() {
 			toVacuumFull = append(toVacuumFull, ds.JobStatusTable)
 		}
 	}
@@ -267,12 +267,12 @@ func (jd *Handle) getCleanUpCandidates(ctx context.Context, dsList []dataSetT) (
 			statuses := estimates[ds.JobStatusTable]
 			jobs := estimates[ds.JobTable]
 			if jobs == 0 { // using max ds size if we have no stats for the number of jobs
-				jobs = float64(*jd.config.MaxDSSize)
+				jobs = float64(*jd.conf.MaxDSSize)
 			}
-			return statuses/jobs > jd.migrationConfig.jobStatusMigrateThres()
+			return statuses/jobs > jd.conf.migration.jobStatusMigrateThres()
 		})
 
-	return lo.Slice(datasets, 0, jd.migrationConfig.maxMigrateDSProbe), nil
+	return lo.Slice(datasets, 0, jd.conf.migration.maxMigrateDSProbe), nil
 }
 
 // based on an estimate cleans up the status tables
@@ -349,7 +349,7 @@ func (jd *Handle) cleanStatusTable(ctx context.Context, tx *Tx, table string, ca
 		return false, err
 	}
 
-	if numJobStatusDeleted > jd.migrationConfig.vacuumAnalyzeStatusTableThreshold() && canBeVacuumed {
+	if numJobStatusDeleted > jd.conf.migration.vacuumAnalyzeStatusTableThreshold() && canBeVacuumed {
 		vacuum = true
 	} else {
 		_, err = tx.ExecContext(ctx, fmt.Sprintf(`ANALYZE %q`, table))
@@ -365,7 +365,7 @@ func (jd *Handle) getMigrationList(dsList []dataSetT) (migrateFrom []dataSetT, p
 	var (
 		liveDSCount, migrateDSProbeCount int
 		// we don't want `maxDSSize` value to change, during dsList loop
-		maxDSSize = *jd.config.MaxDSSize
+		maxDSSize = *jd.conf.MaxDSSize
 		waiting   *smallDS
 	)
 
@@ -381,7 +381,7 @@ func (jd *Handle) getMigrationList(dsList []dataSetT) (migrateFrom []dataSetT, p
 			idxCheck = idx == len(dsList)-1
 		}
 
-		if liveDSCount >= jd.migrationConfig.maxMigrateOnce || pendingJobsCount >= maxDSSize || idxCheck {
+		if liveDSCount >= jd.conf.migration.maxMigrateOnce || pendingJobsCount >= maxDSSize || idxCheck {
 			break
 		}
 
@@ -412,7 +412,7 @@ func (jd *Handle) getMigrationList(dsList []dataSetT) (migrateFrom []dataSetT, p
 			}
 		} else {
 			waiting = nil // if there was a small DS waiting, we should remove it since its next dataset is not eligible for migration
-			if liveDSCount > 0 || migrateDSProbeCount > jd.migrationConfig.maxMigrateDSProbe {
+			if liveDSCount > 0 || migrateDSProbeCount > jd.conf.migration.maxMigrateDSProbe {
 				// DS is not eligible for migration. But there are data sets on the left eligible to migrate, so break.
 				break
 			}
@@ -546,26 +546,26 @@ func (jd *Handle) checkIfMigrateDS(ds dataSetT) (
 
 	recordsLeft = totalCount - delCount
 
-	if jd.config.minDSRetentionPeriod > 0 {
+	if jd.conf.minDSRetentionPeriod > 0 {
 		var maxCreatedAt time.Time
 		sqlStatement = fmt.Sprintf(`SELECT MAX(created_at) from %q`, ds.JobTable)
 		if err = jd.dbHandle.QueryRow(sqlStatement).Scan(&maxCreatedAt); err != nil {
 			return false, false, 0, fmt.Errorf("error getting max created_at from %s: %w", ds.JobTable, err)
 		}
 
-		if time.Since(maxCreatedAt) < jd.config.minDSRetentionPeriod {
+		if time.Since(maxCreatedAt) < jd.conf.minDSRetentionPeriod {
 			return false, false, recordsLeft, nil
 		}
 	}
 
-	if jd.config.maxDSRetentionPeriod > 0 {
+	if jd.conf.maxDSRetentionPeriod > 0 {
 		var terminalJobsExist bool
 		sqlStatement = fmt.Sprintf(`SELECT EXISTS (
 									SELECT id
 										FROM %q
 										WHERE job_state = ANY($1) and exec_time < $2)`,
 			ds.JobStatusTable)
-		if err = jd.dbHandle.QueryRow(sqlStatement, pq.Array(validTerminalStates), time.Now().Add(-1*jd.config.maxDSRetentionPeriod)).Scan(&terminalJobsExist); err != nil {
+		if err = jd.dbHandle.QueryRow(sqlStatement, pq.Array(validTerminalStates), time.Now().Add(-1*jd.conf.maxDSRetentionPeriod)).Scan(&terminalJobsExist); err != nil {
 			return false, false, 0, fmt.Errorf("checking terminalJobsExist %s: %w", ds.JobStatusTable, err)
 		}
 		if terminalJobsExist {
@@ -573,12 +573,12 @@ func (jd *Handle) checkIfMigrateDS(ds dataSetT) (
 		}
 	}
 
-	smallThreshold := jd.migrationConfig.jobMinRowsMigrateThres() * float64(*jd.config.MaxDSSize)
+	smallThreshold := jd.conf.migration.jobMinRowsMigrateThres() * float64(*jd.conf.MaxDSSize)
 	isSmall := func() bool {
 		return float64(totalCount) < smallThreshold
 	}
 
-	if float64(delCount)/float64(totalCount) > jd.migrationConfig.jobDoneMigrateThres() {
+	if float64(delCount)/float64(totalCount) > jd.conf.migration.jobDoneMigrateThres() {
 		return true, isSmall(), recordsLeft, nil
 	}
 

--- a/jobsdb/migration_test.go
+++ b/jobsdb/migration_test.go
@@ -33,7 +33,7 @@ func TestMigration(t *testing.T) {
 			TriggerMigrateDS: func() <-chan time.Time {
 				return triggerMigrateDS
 			},
-			configGetter: c,
+			config: c,
 		}
 		tablePrefix := strings.ToLower(rand.String(5))
 		err := jobDB.Setup(
@@ -46,7 +46,7 @@ func TestMigration(t *testing.T) {
 		require.NoError(t, err)
 		defer jobDB.TearDown()
 
-		jobDB.config.maxDSRetentionPeriod = time.Millisecond
+		jobDB.conf.maxDSRetentionPeriod = time.Millisecond
 
 		customVal := rand.String(5)
 		jobs := genJobs(defaultWorkspaceID, customVal, 30, 1)
@@ -220,7 +220,7 @@ func TestMigration(t *testing.T) {
 			TriggerMigrateDS: func() <-chan time.Time {
 				return triggerMigrateDS
 			},
-			configGetter: c,
+			config: c,
 		}
 		tablePrefix := strings.ToLower(rand.String(5))
 		require.NoError(t, jobDB.Setup(
@@ -232,7 +232,7 @@ func TestMigration(t *testing.T) {
 		))
 		defer jobDB.TearDown()
 
-		jobDB.config.maxDSRetentionPeriod = time.Millisecond
+		jobDB.conf.maxDSRetentionPeriod = time.Millisecond
 
 		// 3 datasets with 10 jobs each, 1 dataset with 0 jobs
 		for i := 0; i < 3; i++ {

--- a/jobsdb/queued_db_request.go
+++ b/jobsdb/queued_db_request.go
@@ -15,11 +15,11 @@ func executeDbRequest[T any](jd *Handle, c *dbRequest[T]) T {
 	var queueCap chan struct{}
 	switch c.reqType {
 	case readReqType:
-		queueEnabled = jd.enableReaderQueue
-		queueCap = jd.readCapacity
+		queueEnabled = jd.config.enableReaderQueue
+		queueCap = jd.config.readCapacity
 	case writeReqType:
-		queueEnabled = jd.enableWriterQueue
-		queueCap = jd.writeCapacity
+		queueEnabled = jd.config.enableWriterQueue
+		queueCap = jd.config.writeCapacity
 	case undefinedReqType:
 		fallthrough
 	default:

--- a/jobsdb/queued_db_request.go
+++ b/jobsdb/queued_db_request.go
@@ -15,11 +15,11 @@ func executeDbRequest[T any](jd *Handle, c *dbRequest[T]) T {
 	var queueCap chan struct{}
 	switch c.reqType {
 	case readReqType:
-		queueEnabled = jd.config.enableReaderQueue
-		queueCap = jd.config.readCapacity
+		queueEnabled = jd.conf.enableReaderQueue
+		queueCap = jd.conf.readCapacity
 	case writeReqType:
-		queueEnabled = jd.config.enableWriterQueue
-		queueCap = jd.config.writeCapacity
+		queueEnabled = jd.conf.enableWriterQueue
+		queueCap = jd.conf.writeCapacity
 	case undefinedReqType:
 		fallthrough
 	default:

--- a/jobsdb/queued_db_request_test.go
+++ b/jobsdb/queued_db_request_test.go
@@ -22,10 +22,9 @@ func Test_executeDbRequest_read_direct(t *testing.T) {
 }
 
 func Test_executeDbRequest_read_channel(t *testing.T) {
-	h := Handle{
-		enableReaderQueue: true,
-		readCapacity:      make(chan struct{}, 1),
-	}
+	h := Handle{}
+	h.config.enableReaderQueue = true
+	h.config.readCapacity = make(chan struct{}, 1)
 	res := executeDbRequest(&h, &dbRequest[string]{
 		reqType: readReqType,
 		name:    "test",
@@ -50,10 +49,9 @@ func Test_executeDbRequest_write_direct(t *testing.T) {
 }
 
 func Test_executeDbRequest_write_channel(t *testing.T) {
-	h := Handle{
-		enableWriterQueue: true,
-		writeCapacity:     make(chan struct{}, 1),
-	}
+	h := Handle{}
+	h.config.enableWriterQueue = true
+	h.config.writeCapacity = make(chan struct{}, 1)
 	res := executeDbRequest(&h, &dbRequest[string]{
 		reqType: writeReqType,
 		name:    "test",

--- a/jobsdb/queued_db_request_test.go
+++ b/jobsdb/queued_db_request_test.go
@@ -23,8 +23,8 @@ func Test_executeDbRequest_read_direct(t *testing.T) {
 
 func Test_executeDbRequest_read_channel(t *testing.T) {
 	h := Handle{}
-	h.config.enableReaderQueue = true
-	h.config.readCapacity = make(chan struct{}, 1)
+	h.conf.enableReaderQueue = true
+	h.conf.readCapacity = make(chan struct{}, 1)
 	res := executeDbRequest(&h, &dbRequest[string]{
 		reqType: readReqType,
 		name:    "test",
@@ -50,8 +50,8 @@ func Test_executeDbRequest_write_direct(t *testing.T) {
 
 func Test_executeDbRequest_write_channel(t *testing.T) {
 	h := Handle{}
-	h.config.enableWriterQueue = true
-	h.config.writeCapacity = make(chan struct{}, 1)
+	h.conf.enableWriterQueue = true
+	h.conf.writeCapacity = make(chan struct{}, 1)
 	res := executeDbRequest(&h, &dbRequest[string]{
 		reqType: writeReqType,
 		name:    "test",

--- a/jobsdb/setup.go
+++ b/jobsdb/setup.go
@@ -22,7 +22,7 @@ func (jd *Handle) setupDatabaseTables(templateData map[string]interface{}) {
 	m := &migrator.Migrator{
 		Handle:                     jd.dbHandle,
 		MigrationsTable:            jd.SchemaMigrationTable(),
-		ShouldForceSetLowerVersion: jd.configGetter.GetBool("SQLMigrator.forceSetLowerVersion", true),
+		ShouldForceSetLowerVersion: jd.config.GetBool("SQLMigrator.forceSetLowerVersion", true),
 	}
 	// execute any necessary migrations
 	if err := m.MigrateFromTemplates("jobsdb", templateData); err != nil {

--- a/jobsdb/setup.go
+++ b/jobsdb/setup.go
@@ -3,7 +3,6 @@ package jobsdb
 import (
 	"fmt"
 
-	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-server/jobsdb/internal/lock"
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 )
@@ -23,7 +22,7 @@ func (jd *Handle) setupDatabaseTables(templateData map[string]interface{}) {
 	m := &migrator.Migrator{
 		Handle:                     jd.dbHandle,
 		MigrationsTable:            jd.SchemaMigrationTable(),
-		ShouldForceSetLowerVersion: config.GetBool("SQLMigrator.forceSetLowerVersion", true),
+		ShouldForceSetLowerVersion: jd.configGetter.GetBool("SQLMigrator.forceSetLowerVersion", true),
 	}
 	// execute any necessary migrations
 	if err := m.MigrateFromTemplates("jobsdb", templateData); err != nil {

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -254,6 +254,20 @@ func (mr *MockJobsDBMockRecorder) Identifier() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identifier", reflect.TypeOf((*MockJobsDB)(nil).Identifier))
 }
 
+// IsMasterBackupEnabled mocks base method.
+func (m *MockJobsDB) IsMasterBackupEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsMasterBackupEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsMasterBackupEnabled indicates an expected call of IsMasterBackupEnabled.
+func (mr *MockJobsDBMockRecorder) IsMasterBackupEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMasterBackupEnabled", reflect.TypeOf((*MockJobsDB)(nil).IsMasterBackupEnabled))
+}
+
 // JournalDeleteEntry mocks base method.
 func (m *MockJobsDB) JournalDeleteEntry(arg0 int64) {
 	m.ctrl.T.Helper()

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -158,8 +158,8 @@ func TestProcessorManager(t *testing.T) {
 		"gw",
 		jobsdb.WithConfig(c),
 	)
-	defer tempDB.TearDown()
 	require.NoError(t, tempDB.Start())
+	defer tempDB.TearDown()
 
 	customVal := "GW"
 	unprocessedListEmpty, err := tempDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParams{

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -126,7 +126,6 @@ func initJobsDB() {
 	logger.Reset()
 	stash.Init()
 	admin.Init()
-	jobsdb.Init()
 }
 
 func genJobs(customVal string, jobCount, eventsPerJob int) []*jobsdb.JobT {

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -120,8 +120,8 @@ func sendQueryRetryStats(attempt int) {
 	stats.Default.NewTaggedStat("jobsdb_query_timeout", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt), "module": "stash"}).Count(1)
 }
 
-func backupEnabled() bool {
-	return errorStashEnabled && jobsdb.IsMasterBackupEnabled()
+func backupEnabled(jd jobsdb.JobsDB) bool {
+	return errorStashEnabled && jd.IsMasterBackupEnabled()
 }
 
 func (st *HandleT) runErrWorkers(ctx context.Context) {
@@ -339,7 +339,7 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 				continue
 			}
 
-			canUpload := backupEnabled()
+			canUpload := backupEnabled(st.errorDB)
 
 			jobState := jobsdb.Executing.State
 

--- a/router/batchrouter/batchrouter_isolation_test.go
+++ b/router/batchrouter/batchrouter_isolation_test.go
@@ -472,7 +472,6 @@ func (brtIsolationMethods) newMockWarehouse() *httptest.Server {
 
 // seedBrtDB seeds the batch router database with jobs based on the provided spec
 func (m brtIsolationMethods) seedBrtDB(t testing.TB, spec *BrtIsolationScenarioSpec) {
-	jobsdb.Init()
 	brtJobsDB := jobsdb.NewForWrite("batch_rt")
 	require.NoError(t, brtJobsDB.Start(), "it should be able to start the jobsdb")
 	defer brtJobsDB.Stop()

--- a/router/batchrouter/batchrouter_isolation_test.go
+++ b/router/batchrouter/batchrouter_isolation_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"compress/gzip"
 	"context"
-	"database/sql"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -241,6 +240,7 @@ func BatchrouterIsolationScenario(t testing.TB, spec *BrtIsolationScenarioSpec) 
 	config.Set("DB.user", postgresContainer.User)
 	config.Set("DB.name", postgresContainer.Database)
 	config.Set("DB.password", postgresContainer.Password)
+	config.Set("DB.host", postgresContainer.Host)
 
 	config.Set("Warehouse.mode", "off")
 	config.Set("DestinationDebugger.disableEventDeliveryStatusUploads", true)
@@ -259,7 +259,7 @@ func BatchrouterIsolationScenario(t testing.TB, spec *BrtIsolationScenarioSpec) 
 	config.Set("RUDDER_TMPDIR", os.TempDir())
 
 	t.Logf("Seeding batch_rt jobsdb with jobs")
-	m.seedBrtDB(t, spec, postgresContainer.DB)
+	m.seedBrtDB(t, spec)
 
 	t.Logf("Starting rudder server")
 	svcDone := make(chan struct{})
@@ -472,8 +472,8 @@ func (brtIsolationMethods) newMockWarehouse() *httptest.Server {
 }
 
 // seedBrtDB seeds the batch router database with jobs based on the provided spec
-func (m brtIsolationMethods) seedBrtDB(t testing.TB, spec *BrtIsolationScenarioSpec, dbHandle *sql.DB) {
-	brtJobsDB := jobsdb.NewForWrite("batch_rt", jobsdb.WithDBHandle(dbHandle))
+func (m brtIsolationMethods) seedBrtDB(t testing.TB, spec *BrtIsolationScenarioSpec) {
+	brtJobsDB := jobsdb.NewForWrite("batch_rt")
 	require.NoError(t, brtJobsDB.Start(), "it should be able to start the jobsdb")
 	defer brtJobsDB.Stop()
 	for _, batch := range m.generateJobs(spec.jobs, 100) {

--- a/router/manager/manager_test.go
+++ b/router/manager/manager_test.go
@@ -162,7 +162,6 @@ func initRouter() {
 	logger.Reset()
 	stash.Init()
 	admin.Init()
-	jobsdb.Init()
 }
 
 func TestRouterManager(t *testing.T) {

--- a/router/router_isolation_test.go
+++ b/router/router_isolation_test.go
@@ -359,7 +359,6 @@ func (rtIsolationMethods) newMockConfigBackend(t testing.TB, path string) *httpt
 
 // seedRtDB seeds the router database with jobs based on the provided spec
 func (m rtIsolationMethods) seedRtDB(t testing.TB, spec *RtIsolationScenarioSpec, url string) {
-	jobsdb.Init()
 	rtJobsDB := jobsdb.NewForWrite("rt")
 	require.NoError(t, rtJobsDB.Start(), "it should be able to start the jobsdb")
 	defer rtJobsDB.Stop()

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -28,7 +28,6 @@ import (
 	eventschema "github.com/rudderlabs/rudder-server/event-schema"
 	"github.com/rudderlabs/rudder-server/gateway/webhook"
 	"github.com/rudderlabs/rudder-server/info"
-	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/processor/stash"
 	"github.com/rudderlabs/rudder-server/processor/transformer"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager"
@@ -330,7 +329,6 @@ func runAllInit() {
 	backendconfig.Init()
 	warehouseutils.Init()
 	pgnotifier.Init()
-	jobsdb.Init()
 	warehouse.Init4()
 	validations.Init()
 	webhook.Init()

--- a/schema-forwarder/internal/forwarder/abortingforwarder_test.go
+++ b/schema-forwarder/internal/forwarder/abortingforwarder_test.go
@@ -21,7 +21,6 @@ func Test_AbortingForwarder(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 
-	jobsdb.Init()
 	postgres, err := resource.SetupPostgres(pool, t)
 	require.NoError(t, err)
 	t.Setenv("JOBS_DB_PORT", postgres.Port)

--- a/schema-forwarder/internal/forwarder/baseforwarder_test.go
+++ b/schema-forwarder/internal/forwarder/baseforwarder_test.go
@@ -22,7 +22,6 @@ func Test_BaseForwarder(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 
-	jobsdb.Init()
 	postgres, err := resource.SetupPostgres(pool, t)
 	require.NoError(t, err)
 	t.Setenv("JOBS_DB_PORT", postgres.Port)
@@ -74,7 +73,6 @@ func TestBaseForwarder_MarkJobStautses(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 
-	jobsdb.Init()
 	postgres, err := resource.SetupPostgres(pool, t)
 	require.NoError(t, err)
 	t.Setenv("JOBS_DB_PORT", postgres.Port)

--- a/schema-forwarder/internal/forwarder/jobsforwarder_test.go
+++ b/schema-forwarder/internal/forwarder/jobsforwarder_test.go
@@ -33,7 +33,6 @@ func Test_JobsForwarder(t *testing.T) {
 	conf.Set("SchemaForwarder.loopSleepTime", time.Millisecond)
 	mockBackendConfig := mocksBackendConfig.NewMockBackendConfig(gomock.NewController(t))
 
-	jobsdb.Init()
 	postgres, err := resource.SetupPostgres(pool, t)
 	require.NoError(t, err)
 	t.Setenv("JOBS_DB_PORT", postgres.Port)

--- a/services/validators/envValidator.go
+++ b/services/validators/envValidator.go
@@ -124,7 +124,7 @@ func getWorkspaceFromDB(dbHandle *sql.DB) (string, error) {
 }
 
 func createDBConnection() (*sql.DB, error) {
-	psqlInfo := misc.GetConnectionString(nil)
+	psqlInfo := misc.GetConnectionString(config.Default)
 	var err error
 	dbHandle, err := sql.Open("postgres", psqlInfo)
 	if err != nil {
@@ -274,7 +274,7 @@ func CheckAndValidateWorkspaceToken() error {
 	pkgLogger.Warn("Previous workspace token is not same as the current workspace token. Parking current jobsdb aside and creating a new one")
 
 	dbName := config.GetString("DB.name", "ubuntu")
-	misc.ReplaceDB(dbName, dbName+"_"+strconv.FormatInt(time.Now().Unix(), 10)+"_"+workspaceTokenHashInDB, nil)
+	misc.ReplaceDB(dbName, dbName+"_"+strconv.FormatInt(time.Now().Unix(), 10)+"_"+workspaceTokenHashInDB, config.Default)
 
 	dbHandle, err = createDBConnection()
 	if err != nil {

--- a/services/validators/envValidator.go
+++ b/services/validators/envValidator.go
@@ -124,7 +124,7 @@ func getWorkspaceFromDB(dbHandle *sql.DB) (string, error) {
 }
 
 func createDBConnection() (*sql.DB, error) {
-	psqlInfo := misc.GetConnectionString()
+	psqlInfo := misc.GetConnectionString(nil)
 	var err error
 	dbHandle, err := sql.Open("postgres", psqlInfo)
 	if err != nil {
@@ -274,7 +274,7 @@ func CheckAndValidateWorkspaceToken() error {
 	pkgLogger.Warn("Previous workspace token is not same as the current workspace token. Parking current jobsdb aside and creating a new one")
 
 	dbName := config.GetString("DB.name", "ubuntu")
-	misc.ReplaceDB(dbName, dbName+"_"+strconv.FormatInt(time.Now().Unix(), 10)+"_"+workspaceTokenHashInDB)
+	misc.ReplaceDB(dbName, dbName+"_"+strconv.FormatInt(time.Now().Unix(), 10)+"_"+workspaceTokenHashInDB, nil)
 
 	dbHandle, err = createDBConnection()
 	if err != nil {

--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -11,13 +11,16 @@ import (
 )
 
 // GetConnectionString Returns Jobs DB connection configuration
-func GetConnectionString() string {
-	host := config.GetString("DB.host", "localhost")
-	user := config.GetString("DB.user", "ubuntu")
-	dbname := config.GetString("DB.name", "ubuntu")
-	port := config.GetInt("DB.port", 5432)
-	password := config.GetString("DB.password", "ubuntu") // Reading secrets from
-	sslmode := config.GetString("DB.sslMode", "disable")
+func GetConnectionString(c *config.Config) string {
+	if c == nil {
+		c = config.Default
+	}
+	host := c.GetString("DB.host", "localhost")
+	user := c.GetString("DB.user", "ubuntu")
+	dbname := c.GetString("DB.name", "ubuntu")
+	port := c.GetInt("DB.port", 5432)
+	password := c.GetString("DB.password", "ubuntu") // Reading secrets from
+	sslmode := c.GetString("DB.sslMode", "disable")
 	// Application Name can be any string of less than NAMEDATALEN characters (64 characters in a standard PostgreSQL build).
 	// There is no need to truncate the string on our own though since PostgreSQL auto-truncates this identifier and issues a relevant notice if necessary.
 	appName := DefaultString("rudder-server").OnError(os.Hostname())
@@ -30,12 +33,15 @@ func GetConnectionString() string {
 ReplaceDB : Rename the OLD DB and create a new one.
 Since we are not journaling, this should be idemponent
 */
-func ReplaceDB(dbName, targetName string) {
-	host := config.GetString("DB.host", "localhost")
-	user := config.GetString("DB.user", "ubuntu")
-	port := config.GetInt("DB.port", 5432)
-	password := config.GetString("DB.password", "ubuntu") // Reading secrets from
-	sslmode := config.GetString("DB.sslMode", "disable")
+func ReplaceDB(dbName, targetName string, c *config.Config) {
+	if c == nil {
+		c = config.Default
+	}
+	host := c.GetString("DB.host", "localhost")
+	user := c.GetString("DB.user", "ubuntu")
+	port := c.GetInt("DB.port", 5432)
+	password := c.GetString("DB.password", "ubuntu") // Reading secrets from
+	sslmode := c.GetString("DB.sslMode", "disable")
 	connInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=postgres sslmode=%s",
 		host, port, user, password, sslmode)
 	db, err := sql.Open("postgres", connInfo)

--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -12,9 +12,6 @@ import (
 
 // GetConnectionString Returns Jobs DB connection configuration
 func GetConnectionString(c *config.Config) string {
-	if c == nil {
-		c = config.Default
-	}
 	host := c.GetString("DB.host", "localhost")
 	user := c.GetString("DB.user", "ubuntu")
 	dbname := c.GetString("DB.name", "ubuntu")
@@ -34,9 +31,6 @@ ReplaceDB : Rename the OLD DB and create a new one.
 Since we are not journaling, this should be idemponent
 */
 func ReplaceDB(dbName, targetName string, c *config.Config) {
-	if c == nil {
-		c = config.Default
-	}
 	host := c.GetString("DB.host", "localhost")
 	user := c.GetString("DB.user", "ubuntu")
 	port := c.GetInt("DB.port", 5432)

--- a/warehouse/router_test.go
+++ b/warehouse/router_test.go
@@ -906,12 +906,6 @@ func TestRouter(t *testing.T) {
 				pgResource, err := resource.SetupPostgres(pool, t)
 				require.NoError(t, err)
 
-				config.Set("DB.host", pgResource.Host)
-				config.Set("DB.port", pgResource.Port)
-				config.Set("DB.user", pgResource.User)
-				config.Set("DB.password", pgResource.Password)
-				config.Set("DB.name", pgResource.Database)
-
 				t.Log("db:", pgResource.DBDsn)
 
 				err = (&migrator.Migrator{

--- a/warehouse/router_test.go
+++ b/warehouse/router_test.go
@@ -906,6 +906,12 @@ func TestRouter(t *testing.T) {
 				pgResource, err := resource.SetupPostgres(pool, t)
 				require.NoError(t, err)
 
+				config.Set("DB.host", pgResource.Host)
+				config.Set("DB.port", pgResource.Port)
+				config.Set("DB.user", pgResource.User)
+				config.Set("DB.password", pgResource.Password)
+				config.Set("DB.name", pgResource.Database)
+
 				t.Log("db:", pgResource.DBDsn)
 
 				err = (&migrator.Migrator{

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -615,7 +615,7 @@ func CheckPGHealth(ctx context.Context, db *sql.DB) bool {
 
 func getConnectionString() string {
 	if !CheckForWarehouseEnvVars() {
-		return misc.GetConnectionString(nil)
+		return misc.GetConnectionString(config.Default)
 	}
 	return fmt.Sprintf("host=%s port=%d user=%s "+
 		"password=%s dbname=%s sslmode=%s application_name=%s",
@@ -809,7 +809,7 @@ func Start(ctx context.Context, app app.App) error {
 	// A different DB for warehouse is used when:
 	// 1. MultiTenant (uses RDS)
 	// 2. rudderstack-postgresql-warehouse pod in Hosted and Enterprise
-	if (isStandAlone() && isMaster()) || (misc.GetConnectionString(nil) != psqlInfo) {
+	if (isStandAlone() && isMaster()) || (misc.GetConnectionString(config.Default) != psqlInfo) {
 		reporting := application.Features().Reporting.Setup(backendconfig.DefaultBackendConfig)
 
 		g.Go(misc.WithBugsnagForWarehouse(func() error {

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -615,7 +615,7 @@ func CheckPGHealth(ctx context.Context, db *sql.DB) bool {
 
 func getConnectionString() string {
 	if !CheckForWarehouseEnvVars() {
-		return misc.GetConnectionString()
+		return misc.GetConnectionString(nil)
 	}
 	return fmt.Sprintf("host=%s port=%d user=%s "+
 		"password=%s dbname=%s sslmode=%s application_name=%s",
@@ -809,7 +809,7 @@ func Start(ctx context.Context, app app.App) error {
 	// A different DB for warehouse is used when:
 	// 1. MultiTenant (uses RDS)
 	// 2. rudderstack-postgresql-warehouse pod in Hosted and Enterprise
-	if (isStandAlone() && isMaster()) || (misc.GetConnectionString() != psqlInfo) {
+	if (isStandAlone() && isMaster()) || (misc.GetConnectionString(nil) != psqlInfo) {
 		reporting := application.Features().Reporting.Setup(backendconfig.DefaultBackendConfig)
 
 		g.Go(misc.WithBugsnagForWarehouse(func() error {


### PR DESCRIPTION
# Description

Option(`Optfunc`) to have jobsdb-handle-specific config, which falls back to `config.Default` if not passed.
This can help avoid configuration mixups between tests, each jobsdb handle can have specific config to itself, and also to test actual runtime behaviour by changing config values instead of setting `jobsdb.Handle`'s internal fields.

Also moved and grouped jobsdb config fields around to help with readability. eg.: it wasn't entirely clear(to me at first glance) how the number of `maxOpenConnections` were being set in case of a `write`/`read`/`readWrite` jobsdb.

Additionally:
`misc.GetConnectionString` now takes in `*config.Config` as a parameter, using it to fetch db connection details.

## Linear Ticket

[jobsdb handle specific config](https://linear.app/rudderstack/issue/PIPE-166/jobsdb-handle-specific-config)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
