### PR TITLE
chore: deltalake error message length

### DIFF
--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -463,13 +463,13 @@ func (d *Deltalake) CreateTable(ctx context.Context, tableName string, columns m
 
 	_, err := d.DB.ExecContext(ctx, query)
 	if err != nil {
-		return fmt.Errorf("creating table: %w", d.trimErrorMessage(err))
+		return fmt.Errorf("creating table: %w", d.TrimErrorMessage(err))
 	}
 
 	return nil
 }
 
-func (d *Deltalake) trimErrorMessage(baseError error) error {
+func (d *Deltalake) TrimErrorMessage(baseError error) error {
 	errorString := baseError.Error()
 
 	if len(errorString) <= d.config.maxErrorLength {

--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -141,6 +141,7 @@ type Deltalake struct {
 		maxRetries             int
 		retryMinWait           time.Duration
 		retryMaxWait           time.Duration
+		maxErrorLength         int
 	}
 }
 
@@ -156,6 +157,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats) *Deltalake {
 	dl.config.maxRetries = conf.GetInt("Warehouse.deltalake.maxRetries", 10)
 	dl.config.retryMinWait = conf.GetDuration("Warehouse.deltalake.retryMinWait", 1, time.Second)
 	dl.config.retryMaxWait = conf.GetDuration("Warehouse.deltalake.retryMaxWait", 300, time.Second)
+	dl.config.maxErrorLength = conf.GetInt("Warehouse.deltalake.maxErrorLength", 64*1024) // 64 KB
 
 	return dl
 }
@@ -461,10 +463,19 @@ func (d *Deltalake) CreateTable(ctx context.Context, tableName string, columns m
 
 	_, err := d.DB.ExecContext(ctx, query)
 	if err != nil {
-		return fmt.Errorf("creating table: %w", err)
+		return fmt.Errorf("creating table: %w", d.trimErrorMessage(err))
 	}
 
 	return nil
+}
+
+func (d *Deltalake) trimErrorMessage(baseError error) error {
+	errorString := baseError.Error()
+
+	if len(errorString) <= d.config.maxErrorLength {
+		return baseError
+	}
+	return errors.New(errorString[:d.config.maxErrorLength])
 }
 
 // columnsWithDataTypes returns the columns with their data types.

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -8,8 +8,14 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-server/warehouse/integrations/deltalake"
 
 	"github.com/rudderlabs/compose-test/compose"
 
@@ -375,6 +381,44 @@ func TestIntegration(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestDeltalake_TrimErrorMessage(t *testing.T) {
+	tempError := errors.New("temp error")
+
+	testCases := []struct {
+		name          string
+		inputError    error
+		expectedError error
+	}{
+		{
+			name:          "error message is above max length",
+			inputError:    errors.New(strings.Repeat(tempError.Error(), 100)),
+			expectedError: errors.New(strings.Repeat(tempError.Error(), 25)),
+		},
+		{
+			name:          "error message is below max length",
+			inputError:    errors.New(strings.Repeat(tempError.Error(), 25)),
+			expectedError: errors.New(strings.Repeat(tempError.Error(), 25)),
+		},
+		{
+			name:          "error message is equal to max length",
+			inputError:    errors.New(strings.Repeat(tempError.Error(), 10)),
+			expectedError: errors.New(strings.Repeat(tempError.Error(), 10)),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			c := config.New()
+			c.Set("Warehouse.deltalake.maxErrorLength", len(tempError.Error())*25)
+
+			d := deltalake.New(c, logger.NOP, stats.Default)
+			require.Equal(t, d.TrimErrorMessage(tc.inputError), tc.expectedError)
+		})
+	}
 }
 
 func mergeEventsMap() testhelper.EventsCountMap {


### PR DESCRIPTION
# Description

- While creating an external table, we are getting an error since there is already some data present specifying some other schema, and in the error messages, it's dumping the entire other schema which is coming to be very huge. It's reaching around 20MB.
- For delta lake, trim error if it exceeds 64KB

## Linear Ticket

- https://linear.app/rudderstack/issue/PIPE-164/deltalake-error-length

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
