### PR TITLE
fix: extend sql middleware for mssql, azure_synapse and clickhouse

### DIFF
--- a/warehouse/integrations/manager/manager.go
+++ b/warehouse/integrations/manager/manager.go
@@ -73,9 +73,9 @@ func New(destType string, conf *config.Config, logger logger.Logger, stats stats
 	case warehouseutils.CLICKHOUSE:
 		return clickhouse.New(conf, logger, stats), nil
 	case warehouseutils.MSSQL:
-		return mssql.New(conf, logger), nil
+		return mssql.New(conf, logger, stats), nil
 	case warehouseutils.AzureSynapse:
-		return azuresynapse.New(conf, logger), nil
+		return azuresynapse.New(conf, logger, stats), nil
 	case warehouseutils.S3Datalake, warehouseutils.GCSDatalake, warehouseutils.AzureDatalake:
 		return datalake.New(logger), nil
 	case warehouseutils.DELTALAKE:
@@ -98,9 +98,9 @@ func NewWarehouseOperations(destType string, conf *config.Config, logger logger.
 	case warehouseutils.CLICKHOUSE:
 		return clickhouse.New(conf, logger, stats), nil
 	case warehouseutils.MSSQL:
-		return mssql.New(conf, logger), nil
+		return mssql.New(conf, logger, stats), nil
 	case warehouseutils.AzureSynapse:
-		return azuresynapse.New(conf, logger), nil
+		return azuresynapse.New(conf, logger, stats), nil
 	case warehouseutils.S3Datalake, warehouseutils.GCSDatalake, warehouseutils.AzureDatalake:
 		return datalake.New(logger), nil
 	case warehouseutils.DELTALAKE:


### PR DESCRIPTION
# Description

- Extend SQL middleware to MSSQL, AZURE SYNAPSE, CLICKHOUSE

## Linear Ticket

- https://linear.app/rudderstack/issue/PIPE-174/extend-sql-middleware-to-remaining-destinations

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
