### PR TITLE
chore: router_response_counts stat now shows if it's a retry attempt

### DIFF
--- a/router/worker.go
+++ b/router/worker.go
@@ -820,6 +820,7 @@ func (w *worker) sendRouterResponseCountStat(status *jobsdb.JobStatusT, destinat
 		"alert": strconv.FormatBool(alert),
 		// To specify at which point failure happened
 		"errorAt": errorAt,
+		"retry":   fmt.Sprint(status.AttemptNum > 1),
 	})
 	routerResponseStat.Count(1)
 }

--- a/router/worker.go
+++ b/router/worker.go
@@ -820,7 +820,7 @@ func (w *worker) sendRouterResponseCountStat(status *jobsdb.JobStatusT, destinat
 		"alert": strconv.FormatBool(alert),
 		// To specify at which point failure happened
 		"errorAt": errorAt,
-		"retry":   fmt.Sprint(status.AttemptNum > 1),
+		"retry":   strconv.FormatBool(status.AttemptNum > 1),
 	})
 	routerResponseStat.Count(1)
 }


### PR DESCRIPTION
# Description

`router_response_counts` stat now tell if an attempt is a retry(true/false).
Checks if `attemptNum > 1`.

## Linear Ticket

[adding retry flag to `router_response_counts`](https://linear.app/rudderstack/issue/PIPE-193/adding-retry=bool-labeltag-to-router-delivery-stats)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
