### PR TITLE
fix: don't query db if archival is disabled, set parameters in jobStatus

### DIFF
--- a/archiver/archiver_test.go
+++ b/archiver/archiver_test.go
@@ -294,12 +294,11 @@ func TestNoQueriesIfDisabled(t *testing.T) {
 
 	require.NoError(t, arc.Start())
 	defer arc.Stop()
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	require.True(t, atomic.LoadInt32(&queryCount) == 0)
 
 	c.Set("archival.Enabled", true)
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	require.True(t, atomic.LoadInt32(&queryCount) > 0)
 	// queries should've happened(only getDistinct) -> since empty list is returned
-
 }

--- a/archiver/options.go
+++ b/archiver/options.go
@@ -12,6 +12,7 @@ type configGetter interface {
 	GetInt64(key string, defaultValue int64) (value int64)
 	GetString(key, defaultValue string) (value string)
 	GetDuration(key string, defaultValueInTimescaleUnits int64, timeScale time.Duration) time.Duration
+	GetBool(key string, defaultValue bool) (value bool)
 }
 
 type Option func(*archiver)

--- a/archiver/worker.go
+++ b/archiver/worker.go
@@ -238,6 +238,7 @@ func (w *worker) markStatus(
 						JobID:         job.JobID,
 						JobState:      state,
 						ErrorResponse: response,
+						Parameters:    []byte(`{}`),
 						AttemptNum:    job.LastJobStatus.AttemptNum + 1,
 						ExecTime:      time.Now(),
 						RetryTime:     time.Now(),

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -597,7 +597,7 @@ func (proc *Handle) loadConfig() {
 	config.RegisterIntConfigVariable(defaultMaxEventsToProcess, &proc.config.maxEventsToProcess, true, 1, "Processor.maxLoopProcessEvents")
 	// EventSchemas2 feature.
 	config.RegisterBoolConfigVariable(false, &proc.config.eventSchemaV2Enabled, false, "EventSchemas2.enabled")
-	config.RegisterBoolConfigVariable(true, &proc.config.archivalEnabled, true, "Archival.enabled")
+	config.RegisterBoolConfigVariable(true, &proc.config.archivalEnabled, true, "archival.Enabled")
 	config.RegisterBoolConfigVariable(false, &proc.config.eventSchemaV2AllSources, false, "EventSchemas2.enableAllSources")
 	proc.config.batchDestinations = misc.BatchDestinations()
 	config.RegisterIntConfigVariable(5, &proc.config.transformTimesPQLength, false, 1, "Processor.transformTimesPQLength")


### PR DESCRIPTION
# Description

Stop querying archival jobsdb if archival is disabled, and sets parameters in the archival job status.

## Linear Ticket

[release-1.13 fixes](https://linear.app/rudderstack/issue/PIPE-203/release-1130-fixes)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
