### PR TITLE
chore: use single query for getting jobs

### DIFF
--- a/processor/processor_isolation_test.go
+++ b/processor/processor_isolation_test.go
@@ -227,6 +227,7 @@ func ProcIsolationScenario(t testing.TB, spec *ProcIsolationScenarioSpec) (overa
 	config.Set("JobsDB.backup.enabled", false)
 	config.Set("JobsDB.migrateDSLoopSleepDuration", "60m")
 	config.Set("Router.toAbortDestinationIDs", destinationID)
+	config.Set("archival.Enabled", false)
 
 	config.Set("Processor.isolationMode", string(spec.isolationMode))
 

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2070,8 +2070,7 @@ var _ = Describe("Processor", Ordered, func() {
 
 			c.mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
 			c.mockReadProcErrorsDB.EXPECT().FailExecuting().Times(1)
-			c.mockReadProcErrorsDB.EXPECT().GetFailed(gomock.Any(), gomock.Any()).AnyTimes()
-			c.mockReadProcErrorsDB.EXPECT().GetUnprocessed(gomock.Any(), gomock.Any()).AnyTimes()
+			c.mockReadProcErrorsDB.EXPECT().GetJobs(gomock.Any(), []string{jobsdb.Failed.State, jobsdb.Unprocessed.State}, gomock.Any()).AnyTimes()
 			c.mockRouterJobsDB.EXPECT().GetPileUpCounts(gomock.Any()).AnyTimes()
 			c.mockBatchRouterJobsDB.EXPECT().GetPileUpCounts(gomock.Any()).AnyTimes()
 
@@ -2126,8 +2125,7 @@ var _ = Describe("Processor", Ordered, func() {
 			processor.config.readLoopSleep = time.Millisecond
 
 			c.mockReadProcErrorsDB.EXPECT().FailExecuting()
-			c.mockReadProcErrorsDB.EXPECT().GetFailed(gomock.Any(), gomock.Any()).Return(jobsdb.JobsResult{}, nil).AnyTimes()
-			c.mockReadProcErrorsDB.EXPECT().GetUnprocessed(gomock.Any(), gomock.Any()).Return(jobsdb.JobsResult{}, nil).AnyTimes()
+			c.mockReadProcErrorsDB.EXPECT().GetJobs(gomock.Any(), []string{jobsdb.Failed.State, jobsdb.Unprocessed.State}, gomock.Any()).AnyTimes()
 			c.mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).Times(1)
 			c.mockRouterJobsDB.EXPECT().GetPileUpCounts(gomock.Any()).AnyTimes()
 			c.mockBatchRouterJobsDB.EXPECT().GetPileUpCounts(gomock.Any()).AnyTimes()

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -191,30 +191,44 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 	}
 	brt.isolationStrategy.AugmentQueryParams(partition, &queryParams)
 	var limitsReached bool
-	toRetry, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
-		return brt.jobsDB.GetFailed(ctx, queryParams)
-	}, brt.sendQueryRetryStats)
-	if err != nil {
-		brt.logger.Errorf("BRT: %s: Error while reading from DB: %v", brt.destType, err)
-		panic(err)
-	}
-	jobs = toRetry.Jobs
-	limitsReached = toRetry.LimitsReached
-	if !limitsReached {
-		queryParams.JobsLimit -= len(toRetry.Jobs)
-		if queryParams.PayloadSizeLimit > 0 {
-			queryParams.PayloadSizeLimit -= toRetry.PayloadSize
-		}
-		unprocessed, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
-			return brt.jobsDB.GetUnprocessed(ctx, queryParams)
+
+	if config.GetBool("JobsDB.useSingleGetJobsQuery", true) { // TODO: remove condition after successful rollout of sinle query
+		toProcess, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+			return brt.jobsDB.GetJobs(ctx, []string{jobsdb.Failed.State, jobsdb.Unprocessed.State}, queryParams)
 		}, brt.sendQueryRetryStats)
 		if err != nil {
 			brt.logger.Errorf("BRT: %s: Error while reading from DB: %v", brt.destType, err)
 			panic(err)
 		}
-		jobs = append(jobs, unprocessed.Jobs...)
-		limitsReached = unprocessed.LimitsReached
+		jobs = toProcess.Jobs
+		limitsReached = toProcess.LimitsReached
+	} else {
+		toRetry, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+			return brt.jobsDB.GetFailed(ctx, queryParams)
+		}, brt.sendQueryRetryStats)
+		if err != nil {
+			brt.logger.Errorf("BRT: %s: Error while reading from DB: %v", brt.destType, err)
+			panic(err)
+		}
+		jobs = toRetry.Jobs
+		limitsReached = toRetry.LimitsReached
+		if !limitsReached {
+			queryParams.JobsLimit -= len(toRetry.Jobs)
+			if queryParams.PayloadSizeLimit > 0 {
+				queryParams.PayloadSizeLimit -= toRetry.PayloadSize
+			}
+			unprocessed, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+				return brt.jobsDB.GetUnprocessed(ctx, queryParams)
+			}, brt.sendQueryRetryStats)
+			if err != nil {
+				brt.logger.Errorf("BRT: %s: Error while reading from DB: %v", brt.destType, err)
+				panic(err)
+			}
+			jobs = append(jobs, unprocessed.Jobs...)
+			limitsReached = unprocessed.LimitsReached
+		}
 	}
+
 	brtQueryStat.Since(queryStart)
 	sort.Slice(jobs, func(i, j int) bool {
 		return jobs[i].JobID < jobs[j].JobID

--- a/router/handle.go
+++ b/router/handle.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tidwall/gjson"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
@@ -151,11 +152,16 @@ func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worke
 	var firstJob *jobsdb.JobT
 	var lastJob *jobsdb.JobT
 
+	orderGroupKeyFn := func(job *jobsdb.JobT) string { return job.LastJobStatus.JobState }
+	if config.GetBool("JobsDB.useSingleGetJobsQuery", true) { // TODO: remove condition and option after successful rollout of sinle query
+		orderGroupKeyFn = func(job *jobsdb.JobT) string { return "same" }
+	}
 	iterator := jobiterator.New(
 		rt.getQueryParams(partition, rt.reloadableConfig.jobQueryBatchSize),
 		rt.getJobsFn(ctx),
 		jobiterator.WithDiscardedPercentageTolerance(rt.reloadableConfig.jobIteratorDiscardedPercentageTolerance),
 		jobiterator.WithMaxQueries(rt.reloadableConfig.jobIteratorMaxQueries),
+		jobiterator.WithOrderGroupKeyFn(orderGroupKeyFn),
 	)
 
 	if !iterator.HasNext() {

--- a/router/internal/jobiterator/jobiterator.go
+++ b/router/internal/jobiterator/jobiterator.go
@@ -26,6 +26,13 @@ func WithDiscardedPercentageTolerance(discardedPercentageTolerance int) Iterator
 	}
 }
 
+// WithOrderGroupKeyFn sets the orderGroupKeyFn
+func WithOrderGroupKeyFn(orderGroupKeyFn func(*jobsdb.JobT) string) IteratorOptFn {
+	return func(ji *Iterator) {
+		ji.orderGroupKeyFn = orderGroupKeyFn
+	}
+}
+
 // Iterator is a job iterator with support for fetching more than the original set of jobs requested,
 // in case some of these jobs get discarded, according to the configured discarded percentage tolerance.
 type Iterator struct {


### PR DESCRIPTION
# Description

Router iterator, batchrouter & stash can now perform a single SQL query for retrieving jobs instead of multiple.
The above behaviour is toggleable through a feature flag, `JobsDB.useSingleGetJobsQuery`. If the flag is disabled, rudder-server falls back to its previous behaviour.

## Querying

- For unprocessed jobs we are using a left join with the status table
- For all other job states we are using an inner join with the latest status view
- When the query needs to query both types of states we are using a left join with the latest status view

## Caching

- The no jobs cache is checked for all requested job states separately. e.g. if you ask for failed and unprocessed and an entry exists in the cache for failed, the final query will only contain predicates for unprocessed jobs.
- The no jobs cache is updated for separate job states as well, e.g.
  - If no jobs are returned by the query, entries will be added in the cache for all states
  - If only unprocessed jobs are returned for a request issued about both failed and unprocessed, an entry will be added in the no jobs cache for failed state.

## Linear Ticket

[PIPE-219](https://linear.app/rudderstack/issue/PIPE-219/support-performing-a-single-get-jobs-query-toggleable-behind-a-feature)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
