### PR TITLE
fix: remove table name for load file

### DIFF
--- a/warehouse/slave_worker_job.go
+++ b/warehouse/slave_worker_job.go
@@ -409,7 +409,7 @@ func (jr *jobRun) writer(tableName string) (encoding.LoadFileWriter, error) {
 		return writer, nil
 	}
 
-	outputFilePath := jr.loadFilePath(tableName)
+	outputFilePath := jr.loadFilePath()
 
 	writer, err := jr.encodingFactory.NewLoadFileWriter(jr.job.LoadFileType, outputFilePath, jr.job.UploadSchema[tableName], jr.job.DestinationType)
 	if err != nil {
@@ -422,10 +422,9 @@ func (jr *jobRun) writer(tableName string) (encoding.LoadFileWriter, error) {
 	return writer, nil
 }
 
-func (jr *jobRun) loadFilePath(tableName string) string {
-	return fmt.Sprintf("%s%s.%s.%s.%s",
-		strings.TrimSuffix(jr.stagingFilePath, "json.gz"),
-		tableName,
+func (jr *jobRun) loadFilePath() string {
+	return fmt.Sprintf("%s.%s.%s.%s",
+		strings.TrimSuffix(jr.stagingFilePath, ".json.gz"),
 		jr.job.SourceID,
 		misc.FastUUID().String(),
 		warehouseutils.GetLoadFileFormat(jr.job.LoadFileType),


### PR DESCRIPTION
# Description

- Removing table name from load file since table name comes long it exceeds the limit set for filename. 
- `open /data/rudderstack/rudder-warehouse-json-uploads-tmp/_0/SNOWFLAKE_2GPPTuv601yRk511IYD3iXmJsOV/rudder-warehouse-staging-logs/2GP84ugylpnO6KxBCGsUQfbZVhG/2023-09-06/1693979056.2GP84ugylpnO6KxBCGsUQfbZVhG.f969f653-3700-4e19-9219-6e05f6eb8a99.APP_TRACK_WHEN_USER_CLICKS_ONE_OF_THE_SHARE_METHOD_TO_SHARE_THE_APP_SHOP_PRODUCT_TO_AN_EXTERNAL_SITE_PLATFORM_RS.2GP84ugylpnO6KxBCGsUQfbZVhG.13543b71-4e7e-49bc-9fe2-39acc2184e22.csv.gz: file name too long`

## Linear Ticket

- https://linear.app/rudderstack/issue/PIPE-228/load-file-path-too-long

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
