### PR TITLE
fix: error while cleaning up old jobs: sql: no rows in result set

### DIFF
--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -1244,6 +1244,9 @@ func TestMaxAgeCleanup(t *testing.T) {
 	require.NoError(t, err)
 	defer jobsDB.TearDown()
 
+	// run cleanup once with an empty db
+	require.NoError(t, jobsDB.doCleanup(context.Background(), 200))
+
 	// store some jobs
 	require.NoError(
 		t,
@@ -1279,6 +1282,7 @@ func TestMaxAgeCleanup(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	require.NoError(t, jobsDB.doCleanup(context.Background(), 200))
 	triggerJobCleanup <- time.Now()
 	triggerJobCleanup <- time.Now()
 


### PR DESCRIPTION
# Description

Ignoring `sql. ErrNoRows` while deleting journal entries

## Linear Ticket

[PIPE-238](https://linear.app/rudderstack/issue/PIPE-238/error-while-cleaning-up-old-jobs-sql-no-rows-in-result-set)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
