### PR TITLE
chore: add rsources stats for dropped events at processor

### DIFF
--- a/processor/events_response.go
+++ b/processor/events_response.go
@@ -1,0 +1,75 @@
+package processor
+
+import (
+	"time"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/processor/transformer"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+	"github.com/samber/lo"
+)
+
+func (proc *Handle) getDroppedJobs(response transformer.Response, eventsToTransform []transformer.TransformerEvent) []*jobsdb.JobT {
+	// each messageID is one event when sending to the transformer
+	inputMessageIDs := lo.Map(eventsToTransform, func(e transformer.TransformerEvent, _ int) string {
+		return e.Metadata.MessageID
+	})
+
+	// in transformer response, multiple messageIDs could be batched together
+	successFullMessageIDs := make([]string, 0)
+	lo.ForEach(response.Events, func(e transformer.TransformerResponse, _ int) {
+		if len(e.Metadata.MessageIDs) > 0 {
+			successFullMessageIDs = append(successFullMessageIDs, e.Metadata.MessageIDs...)
+		} else {
+			successFullMessageIDs = append(successFullMessageIDs, e.Metadata.MessageID)
+		}
+	})
+	// for failed as well
+	failedMessageIDs := make([]string, 0)
+	lo.ForEach(response.FailedEvents, func(e transformer.TransformerResponse, _ int) {
+		if len(e.Metadata.MessageIDs) > 0 {
+			failedMessageIDs = append(failedMessageIDs, e.Metadata.MessageIDs...)
+		} else {
+			failedMessageIDs = append(failedMessageIDs, e.Metadata.MessageID)
+		}
+	})
+	// the remainder of the messageIDs are those that are dropped
+	// we get jobs for those dropped messageIDs - for rsources_stats_collector
+	droppedMessageIDs, _ := lo.Difference(inputMessageIDs, append(successFullMessageIDs, failedMessageIDs...))
+	droppedMessageIDKeys := lo.SliceToMap(droppedMessageIDs, func(m string) (string, struct{}) { return m, struct{}{} })
+	droppedJobs := make([]*jobsdb.JobT, 0)
+	for _, e := range eventsToTransform {
+		if _, ok := droppedMessageIDKeys[e.Metadata.MessageID]; ok {
+			var params = struct {
+				SourceJobRunID  string      `json:"source_job_run_id"`
+				SourceTaskRunID string      `json:"source_task_run_id"`
+				SourceID        string      `json:"source_id"`
+				DestinationID   string      `json:"destination_id"`
+				RecordID        interface{} `json:"record_id"`
+			}{
+				SourceJobRunID:  e.Metadata.SourceJobRunID,
+				SourceTaskRunID: e.Metadata.SourceTaskRunID,
+				SourceID:        e.Metadata.SourceID,
+				DestinationID:   e.Metadata.DestinationID,
+				RecordID:        e.Metadata.RecordID,
+			}
+			marshalledParams, err := jsonfast.Marshal(params)
+			if err != nil {
+				proc.logger.Errorf("[Processor] Failed to marshal parameters. Parameters: %v", params)
+				marshalledParams = []byte(`{"error": "Processor failed to marshal params"}`)
+			}
+
+			droppedJobs = append(droppedJobs, &jobsdb.JobT{
+				UUID:         misc.FastUUID(),
+				EventPayload: []byte(`{}`),
+				Parameters:   marshalledParams,
+				CreatedAt:    time.Now(),
+				ExpireAt:     time.Now(),
+				CustomVal:    e.Metadata.DestinationType,
+				UserID:       e.Metadata.RudderID,
+				WorkspaceId:  e.Metadata.WorkspaceID,
+			})
+		}
+	}
+	return droppedJobs
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2243,7 +2243,7 @@ func (proc *Handle) transformSrcDest(
 			var successCountMetadataMap map[string]MetricMetadata
 			eventsToTransform, successMetrics, successCountMap, successCountMetadataMap = proc.getDestTransformerEvents(response, commonMetaData, eventsByMessageID, destination, transformer.UserTransformerStage, trackingPlanEnabled, transformationEnabled)
 			failedJobs, failedMetrics, failedCountMap := proc.getFailedEventJobs(response, commonMetaData, eventsByMessageID, transformer.UserTransformerStage, transformationEnabled, trackingPlanEnabled)
-			droppedJobs = append(droppedJobs, proc.getDroppedJobs(response, eventList)...)
+			droppedJobs = append(droppedJobs, append(proc.getDroppedJobs(response, eventList), failedJobs...)...)
 			if _, ok := procErrorJobsByDestID[destID]; !ok {
 				procErrorJobsByDestID[destID] = make([]*jobsdb.JobT, 0)
 			}
@@ -2311,7 +2311,7 @@ func (proc *Handle) transformSrcDest(
 	var successCountMetadataMap map[string]MetricMetadata
 	eventsToTransform, successMetrics, successCountMap, successCountMetadataMap = proc.getDestTransformerEvents(response, commonMetaData, eventsByMessageID, destination, transformer.EventFilterStage, trackingPlanEnabled, transformationEnabled)
 	failedJobs, failedMetrics, failedCountMap := proc.getFailedEventJobs(response, commonMetaData, eventsByMessageID, transformer.EventFilterStage, transformationEnabled, trackingPlanEnabled)
-	droppedJobs = append(droppedJobs, proc.getDroppedJobs(response, eventList)...)
+	droppedJobs = append(droppedJobs, append(proc.getDroppedJobs(response, eventsToTransform), failedJobs...)...)
 	proc.logger.Debug("Supported messages filtering output size", len(eventsToTransform))
 
 	// REPORTING - START
@@ -2381,7 +2381,7 @@ func (proc *Handle) transformSrcDest(
 			destTransformationStat.numEvents.Count(len(eventsToTransform))
 			destTransformationStat.numOutputSuccessEvents.Count(len(response.Events))
 			destTransformationStat.numOutputFailedEvents.Count(len(failedJobs))
-			droppedJobs = append(droppedJobs, proc.getDroppedJobs(response, eventList)...)
+			droppedJobs = append(droppedJobs, append(proc.getDroppedJobs(response, eventsToTransform), failedJobs...)...)
 
 			if _, ok := procErrorJobsByDestID[destID]; !ok {
 				procErrorJobsByDestID[destID] = make([]*jobsdb.JobT, 0)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2232,7 +2232,8 @@ func (proc *Handle) transformSrcDest(
 			var successCountMetadataMap map[string]MetricMetadata
 			eventsToTransform, successMetrics, successCountMap, successCountMetadataMap = proc.getDestTransformerEvents(response, commonMetaData, eventsByMessageID, destination, transformer.UserTransformerStage, trackingPlanEnabled, transformationEnabled)
 			failedJobs, failedMetrics, failedCountMap := proc.getFailedEventJobs(response, commonMetaData, eventsByMessageID, transformer.UserTransformerStage, transformationEnabled, trackingPlanEnabled)
-			proc.saveFailedJobs(failedJobs)
+			droppedJobs := proc.getDroppedJobs(response, eventList)
+			proc.saveFailedJobs(append(failedJobs, droppedJobs...))
 			if _, ok := procErrorJobsByDestID[destID]; !ok {
 				procErrorJobsByDestID[destID] = make([]*jobsdb.JobT, 0)
 			}
@@ -2300,7 +2301,8 @@ func (proc *Handle) transformSrcDest(
 	var successCountMetadataMap map[string]MetricMetadata
 	eventsToTransform, successMetrics, successCountMap, successCountMetadataMap = proc.getDestTransformerEvents(response, commonMetaData, eventsByMessageID, destination, transformer.EventFilterStage, trackingPlanEnabled, transformationEnabled)
 	failedJobs, failedMetrics, failedCountMap := proc.getFailedEventJobs(response, commonMetaData, eventsByMessageID, transformer.EventFilterStage, transformationEnabled, trackingPlanEnabled)
-	proc.saveFailedJobs(failedJobs)
+	droppedJobs := proc.getDroppedJobs(response, eventsToTransform)
+	proc.saveFailedJobs(append(failedJobs, droppedJobs...))
 	proc.logger.Debug("Supported messages filtering output size", len(eventsToTransform))
 
 	// REPORTING - START
@@ -2370,8 +2372,8 @@ func (proc *Handle) transformSrcDest(
 			destTransformationStat.numEvents.Count(len(eventsToTransform))
 			destTransformationStat.numOutputSuccessEvents.Count(len(response.Events))
 			destTransformationStat.numOutputFailedEvents.Count(len(failedJobs))
-
-			proc.saveFailedJobs(failedJobs)
+			droppedJobs := proc.getDroppedJobs(response, eventsToTransform)
+			proc.saveFailedJobs(append(failedJobs, droppedJobs...))
 
 			if _, ok := procErrorJobsByDestID[destID]; !ok {
 				procErrorJobsByDestID[destID] = make([]*jobsdb.JobT, 0)

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -1322,7 +1322,7 @@ var _ = Describe("Processor", Ordered, func() {
 					}
 				})
 
-			c.MockRsourcesService.EXPECT().IncrementStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+			c.MockRsourcesService.EXPECT().IncrementStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(nil) // one for newly stored jobs and one for dropped jobs
 			c.mockArchivalDB.EXPECT().
 				WithStoreSafeTx(
 					gomock.Any(),
@@ -1796,11 +1796,6 @@ var _ = Describe("Processor", Ordered, func() {
 				StoreInTx(gomock.Any(), gomock.Any(), gomock.Any()).
 				AnyTimes()
 
-			// will be used to save failed events to failed keys table
-			c.mockWriteProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(tx *jobsdb.Tx) error) {
-				_ = f(&jobsdb.Tx{})
-			}).Times(1)
-
 			// One Store call is expected for all events
 			c.mockWriteProcErrorsDB.EXPECT().Store(gomock.Any(), gomock.Any()).Times(1).
 				Do(func(ctx context.Context, jobs []*jobsdb.JobT) {
@@ -1938,10 +1933,6 @@ var _ = Describe("Processor", Ordered, func() {
 					// job should be marked as successful regardless of transformer response
 					assertJobStatus(unprocessedJobsList[0], statuses[0], jobsdb.Succeeded.State)
 				})
-
-			c.mockWriteProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(tx *jobsdb.Tx) error) {
-				_ = f(&jobsdb.Tx{})
-			}).Return(nil).Times(1)
 
 			// One Store call is expected for all events
 			c.mockWriteProcErrorsDB.EXPECT().Store(gomock.Any(), gomock.Any()).Times(1).

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -79,6 +79,13 @@ type Metadata struct {
 	SourceDefinitionType    string   `json:"-"`
 }
 
+func (m Metadata) GetMessagesIDs() []string {
+	if len(m.MessageIDs) > 0 {
+		return m.MessageIDs
+	}
+	return []string{m.MessageID}
+}
+
 type TransformerEvent struct {
 	Message     types.SingularEventT       `json:"message"`
 	Metadata    Metadata                   `json:"metadata"`

--- a/services/debugger/transformation/transformationStatusUploader.go
+++ b/services/debugger/transformation/transformationStatusUploader.go
@@ -370,8 +370,9 @@ func (h *Handle) processRecordTransformationStatus(tStatus *TransformationStatus
 	}
 
 	for _, failedEvent := range tStatus.FailedEvents {
-		if len(failedEvent.Metadata.MessageIDs) > 0 {
-			for _, msgID := range failedEvent.Metadata.MessageIDs {
+		messageIDs := failedEvent.Metadata.GetMessagesIDs()
+		for _, msgID := range messageIDs {
+			if msgID != "" {
 				reportedMessageIDs[msgID] = struct{}{}
 				singularEventWithReceivedAt := tStatus.EventsByMessageID[msgID]
 				eventBefore := getEventBeforeTransform(singularEventWithReceivedAt.SingularEvent, singularEventWithReceivedAt.ReceivedAt)
@@ -390,24 +391,6 @@ func (h *Handle) processRecordTransformationStatus(tStatus *TransformationStatus
 					IsError:          true,
 				})
 			}
-		} else if failedEvent.Metadata.MessageID != "" {
-			reportedMessageIDs[failedEvent.Metadata.MessageID] = struct{}{}
-			singularEventWithReceivedAt := tStatus.EventsByMessageID[failedEvent.Metadata.MessageID]
-			eventBefore := getEventBeforeTransform(singularEventWithReceivedAt.SingularEvent, singularEventWithReceivedAt.ReceivedAt)
-			eventAfter := &EventsAfterTransform{
-				Error:      failedEvent.Error,
-				ReceivedAt: time.Now().Format(misc.RFC3339Milli),
-				StatusCode: failedEvent.StatusCode,
-			}
-
-			h.RecordTransformationStatus(&TransformStatusT{
-				TransformationID: tID,
-				SourceID:         tStatus.SourceID,
-				DestinationID:    tStatus.DestID,
-				EventBefore:      eventBefore,
-				EventsAfter:      eventAfter,
-				IsError:          true,
-			})
 		}
 	}
 


### PR DESCRIPTION
# Description

- All events failed during the processor's pipeline (failed, filtered) are treated as dropped with respect to rudder-sources stats.
- For dropped events we are not capturing failed records

## Linear Ticket

[Ensure drop events are marked as failed in source [job-status endpoint]](https://linear.app/rudderstack/issue/PIPE-177/ensure-drop-events-are-marked-as-failed-in-source-[job-status)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
