### PR TITLE
chore: support generic rules to have routers drain events

### DIFF
--- a/integration_test/reporting_dropped_events/reporting_dropped_events_test.go
+++ b/integration_test/reporting_dropped_events/reporting_dropped_events_test.go
@@ -503,7 +503,7 @@ func TestReportingDroppedEvents(t *testing.T) {
 			gwPort, err := kithelper.GetFreePort()
 			require.NoError(t, err)
 			wg.Go(func() error {
-				config.Set("BatchRouter.toAbortDestinationIDs", "destination-1")
+				config.Set("Router.toAbortDestinationIDs", "destination-1")
 				err := runRudderServer(ctx, gwPort, postgresContainer, bcserver.URL, trServer.URL, t.TempDir())
 				if err != nil {
 					t.Logf("rudder-server exited with error: %v", err)

--- a/integration_test/reporting_error_index/reporting_error_index_test.go
+++ b/integration_test/reporting_error_index/reporting_error_index_test.go
@@ -531,7 +531,7 @@ func TestReportingErrorIndex(t *testing.T) {
 
 			wg, ctx := errgroup.WithContext(ctx)
 			wg.Go(func() error {
-				config.Set("BatchRouter.toAbortDestinationIDs", "destination-1")
+				config.Set("Router.toAbortDestinationIDs", "destination-1")
 
 				err := runRudderServer(ctx, gwPort, postgresContainer, minioResource, bcServer.URL, trServer.URL, t.TempDir())
 				if err != nil {

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -103,14 +103,28 @@ func WithFeaturesRetryMaxAttempts(maxAttempts int) func(l *LifecycleManager) {
 }
 
 // New creates a new Processor instance
-func New(ctx context.Context, clearDb *bool, gwDb, rtDb, brtDb, errDbForRead, errDBForWrite, esDB, arcDB *jobsdb.Handle,
-	reporting types.Reporting, transientSources transientsource.Service, fileuploader fileuploader.Provider,
-	rsourcesService rsources.JobService, destDebugger destinationdebugger.DestinationDebugger, transDebugger transformationdebugger.TransformationDebugger,
+func New(
+	ctx context.Context,
+	clearDb *bool,
+	gwDb, rtDb, brtDb, errDbForRead, errDBForWrite, esDB, arcDB *jobsdb.Handle,
+	reporting types.Reporting,
+	transientSources transientsource.Service,
+	fileuploader fileuploader.Provider,
+	rsourcesService rsources.JobService,
+	destDebugger destinationdebugger.DestinationDebugger,
+	transDebugger transformationdebugger.TransformationDebugger,
 	enrichers []enricher.PipelineEnricher,
 	opts ...Opts,
 ) *LifecycleManager {
 	proc := &LifecycleManager{
-		Handle:           NewHandle(transformer.NewTransformer(config.Default, logger.NewLogger().Child("processor"), stats.Default)),
+		Handle: NewHandle(
+			config.Default,
+			transformer.NewTransformer(
+				config.Default,
+				logger.NewLogger().Child("processor"),
+				stats.Default,
+			),
+		),
 		mainCtx:          ctx,
 		gatewayDB:        gwDb,
 		routerDB:         rtDb,

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1591,10 +1591,11 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 			}
 			// check if jobRunId is cancelled
 			if len(proc.drainConfig.jobRunIDs.Load()) > 0 {
-				if slices.Contains(
-					proc.drainConfig.jobRunIDs.Load(),
-					commonMetadataFromSingularEvent.SourceJobRunID,
-				) {
+				if commonMetadataFromSingularEvent.SourceJobRunID != "" &&
+					slices.Contains(
+						proc.drainConfig.jobRunIDs.Load(),
+						commonMetadataFromSingularEvent.SourceJobRunID,
+					) {
 					proc.logger.Debugf(
 						"cancelled jobRunID: %s",
 						commonMetadataFromSingularEvent.SourceJobRunID,

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1590,18 +1590,16 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 				continue
 			}
 			// check if jobRunId is cancelled
-			if len(proc.drainConfig.jobRunIDs.Load()) > 0 {
-				if commonMetadataFromSingularEvent.SourceJobRunID != "" &&
-					slices.Contains(
-						proc.drainConfig.jobRunIDs.Load(),
-						commonMetadataFromSingularEvent.SourceJobRunID,
-					) {
-					proc.logger.Debugf(
-						"cancelled jobRunID: %s",
-						commonMetadataFromSingularEvent.SourceJobRunID,
-					)
-					continue
-				}
+			if commonMetadataFromSingularEvent.SourceJobRunID != "" &&
+				slices.Contains(
+					proc.drainConfig.jobRunIDs.Load(),
+					commonMetadataFromSingularEvent.SourceJobRunID,
+				) {
+				proc.logger.Debugf(
+					"cancelled jobRunID: %s",
+					commonMetadataFromSingularEvent.SourceJobRunID,
+				)
+				continue
 			}
 
 			if _, ok := groupedEventsBySourceId[SourceIDT(sourceId)]; !ok {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -143,8 +143,6 @@ type Handle struct {
 		eventSchemaV2Enabled      bool
 		archivalEnabled           misc.ValueLoader[bool]
 		eventAuditEnabled         map[string]bool
-
-		toAbortJobRunIDs misc.ValueLoader[string]
 	}
 
 	adaptiveLimit func(int64) int64

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2101,6 +2101,7 @@ var _ = Describe("Processor", Ordered, func() {
 				})
 
 			c.MockRsourcesService.EXPECT().IncrementStats(gomock.Any(), gomock.Any(), "job_run_id_1", gomock.Any(), rsources.Stats{Out: 1}).Times(1)
+			c.MockRsourcesService.EXPECT().IncrementStats(gomock.Any(), gomock.Any(), "job_run_id_1", gomock.Any(), rsources.Stats{In: 1, Failed: 1}).Times(1)
 
 			c.mockArchivalDB.EXPECT().WithStoreSafeTx(gomock.Any(), gomock.Any()).AnyTimes().Do(func(ctx context.Context, f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())
@@ -2113,8 +2114,10 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockWriteProcErrorsDB.EXPECT().WithTx(gomock.Any()).Return(nil).Times(0)
 
 			// One Store call is expected for all events
-			c.mockWriteProcErrorsDB.EXPECT().Store(gomock.Any(), gomock.Any()).Times(0).
-				Do(func(ctx context.Context, jobs []*jobsdb.JobT) {})
+			c.mockWriteProcErrorsDB.EXPECT().Store(gomock.Any(), gomock.Any()).Times(1).
+				Do(func(ctx context.Context, jobs []*jobsdb.JobT) {
+					Expect(jobs).To(HaveLen(1))
+				})
 
 			config.Set("RSources.toAbortJobRunIDs", "job_run_id_1")
 			defer config.Reset()
@@ -2412,7 +2415,7 @@ var _ = Describe("Static Function Tests", func() {
 					},
 				},
 			}
-			response := ConvertToFilteredTransformerResponse(events, false)
+			response := ConvertToFilteredTransformerResponse(events, false, func(event transformer.TransformerEvent) (bool, string) { return false, "" })
 			Expect(response.Events[0].StatusCode).To(Equal(expectedResponses.Events[0].StatusCode))
 			Expect(response.Events[0].Metadata.MessageID).To(Equal(expectedResponses.Events[0].Metadata.MessageID))
 			Expect(response.Events[0].Output["some-key-1"]).To(Equal(expectedResponses.Events[0].Output["some-key-1"]))
@@ -2664,7 +2667,7 @@ var _ = Describe("Static Function Tests", func() {
 					},
 				},
 			}
-			response := ConvertToFilteredTransformerResponse(events, true)
+			response := ConvertToFilteredTransformerResponse(events, true, func(event transformer.TransformerEvent) (bool, string) { return false, "" })
 			Expect(response).To(Equal(expectedResponse))
 		})
 
@@ -2737,7 +2740,7 @@ var _ = Describe("Static Function Tests", func() {
 					},
 				},
 			}
-			response := ConvertToFilteredTransformerResponse(events, true)
+			response := ConvertToFilteredTransformerResponse(events, true, func(event transformer.TransformerEvent) (bool, string) { return false, "" })
 			Expect(response).To(Equal(expectedResponse))
 		})
 
@@ -2800,7 +2803,7 @@ var _ = Describe("Static Function Tests", func() {
 				},
 				FailedEvents: nil,
 			}
-			response := ConvertToFilteredTransformerResponse(events, true)
+			response := ConvertToFilteredTransformerResponse(events, true, func(event transformer.TransformerEvent) (bool, string) { return false, "" })
 			Expect(response).To(Equal(expectedResponse))
 		})
 		It("Should allow all events when supportedMessageTypes is not an array", func() {
@@ -2864,7 +2867,7 @@ var _ = Describe("Static Function Tests", func() {
 				},
 				FailedEvents: nil,
 			}
-			response := ConvertToFilteredTransformerResponse(events, true)
+			response := ConvertToFilteredTransformerResponse(events, true, func(event transformer.TransformerEvent) (bool, string) { return false, "" })
 			Expect(response).To(Equal(expectedResponse))
 		})
 
@@ -2935,7 +2938,7 @@ var _ = Describe("Static Function Tests", func() {
 					},
 				},
 			}
-			response := ConvertToFilteredTransformerResponse(events, true)
+			response := ConvertToFilteredTransformerResponse(events, true, func(event transformer.TransformerEvent) (bool, string) { return false, "" })
 			Expect(response).To(Equal(expectedResponse))
 		})
 
@@ -3005,7 +3008,7 @@ var _ = Describe("Static Function Tests", func() {
 				},
 				FailedEvents: nil,
 			}
-			response := ConvertToFilteredTransformerResponse(events, true)
+			response := ConvertToFilteredTransformerResponse(events, true, func(event transformer.TransformerEvent) (bool, string) { return false, "" })
 			Expect(response).To(Equal(expectedResponse))
 		})
 
@@ -3101,7 +3104,7 @@ var _ = Describe("Static Function Tests", func() {
 					},
 				},
 			}
-			response := ConvertToFilteredTransformerResponse(events, true)
+			response := ConvertToFilteredTransformerResponse(events, true, func(event transformer.TransformerEvent) (bool, string) { return false, "" })
 			Expect(response).To(Equal(expectedResponse))
 		})
 
@@ -3197,7 +3200,7 @@ var _ = Describe("Static Function Tests", func() {
 					},
 				},
 			}
-			response := ConvertToFilteredTransformerResponse(events, true)
+			response := ConvertToFilteredTransformerResponse(events, true, func(event transformer.TransformerEvent) (bool, string) { return false, "" })
 			Expect(response).To(Equal(expectedResponse))
 		})
 
@@ -3292,7 +3295,7 @@ var _ = Describe("Static Function Tests", func() {
 					},
 				},
 			}
-			response := ConvertToFilteredTransformerResponse(events, true)
+			response := ConvertToFilteredTransformerResponse(events, true, func(event transformer.TransformerEvent) (bool, string) { return false, "" })
 			Expect(response).To(Equal(expectedResponse))
 		})
 
@@ -3382,7 +3385,7 @@ var _ = Describe("Static Function Tests", func() {
 					},
 				},
 			}
-			response := ConvertToFilteredTransformerResponse(events, true)
+			response := ConvertToFilteredTransformerResponse(events, true, func(event transformer.TransformerEvent) (bool, string) { return false, "" })
 			Expect(response).To(Equal(expectedResponse))
 		})
 
@@ -3475,7 +3478,7 @@ var _ = Describe("Static Function Tests", func() {
 					},
 				},
 			}
-			response := ConvertToFilteredTransformerResponse(events, true)
+			response := ConvertToFilteredTransformerResponse(events, true, func(event transformer.TransformerEvent) (bool, string) { return false, "" })
 			Expect(response).To(Equal(expectedResponse))
 		})
 
@@ -3571,7 +3574,7 @@ var _ = Describe("Static Function Tests", func() {
 					},
 				},
 			}
-			response := ConvertToFilteredTransformerResponse(events, true)
+			response := ConvertToFilteredTransformerResponse(events, true, func(event transformer.TransformerEvent) (bool, string) { return false, "" })
 			Expect(response).To(Equal(expectedResponse))
 		})
 	})

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2110,9 +2110,7 @@ var _ = Describe("Processor", Ordered, func() {
 				StoreInTx(gomock.Any(), gomock.Any(), gomock.Any()).
 				Times(0)
 
-			c.mockWriteProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(tx *jobsdb.Tx) error) {
-				_ = f(&jobsdb.Tx{})
-			}).Return(nil).Times(0)
+			c.mockWriteProcErrorsDB.EXPECT().WithTx(gomock.Any()).Return(nil).Times(0)
 
 			// One Store call is expected for all events
 			c.mockWriteProcErrorsDB.EXPECT().Store(gomock.Any(), gomock.Any()).Times(0).

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -3557,7 +3557,6 @@ var _ = Describe("Static Function Tests", func() {
 			}
 			response := ConvertToFilteredTransformerResponse(events, true)
 			Expect(response).To(Equal(expectedResponse))
-
 		})
 	})
 })

--- a/router/batchrouter/batchrouterBenchmark_test.go
+++ b/router/batchrouter/batchrouterBenchmark_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
+	routerutils "github.com/rudderlabs/rudder-server/router/utils"
 )
 
 func Benchmark_GetStorageDateFormat(b *testing.B) {
@@ -47,7 +48,7 @@ func Benchmark_JSONUnmarshal(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var jobs []*jobsdb.JobT
 		for i := 0; i < 100; i++ {
-			params := JobParameters{
+			params := routerutils.JobParameters{
 				EventName:  "test",
 				EventType:  "track",
 				MessageID:  uuid.New().String(),
@@ -64,7 +65,7 @@ func Benchmark_JSONUnmarshal(b *testing.B) {
 
 		g := errgroup.Group{}
 		g.Go(func() error {
-			params := JobParameters{
+			params := routerutils.JobParameters{
 				EventName: "test",
 				EventType: "track",
 				MessageID: uuid.New().String(),
@@ -84,7 +85,7 @@ func Benchmark_JSONUnmarshal(b *testing.B) {
 		})
 		g.Go(func() error {
 			for i := range jobs {
-				var params JobParameters
+				var params routerutils.JobParameters
 				_ = json.Unmarshal(jobs[i].Parameters, &params)
 			}
 

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -162,7 +162,17 @@ var _ = Describe("BatchRouter", func() {
 
 			c.mockBatchRouterJobsDB.EXPECT().GetJournalEntries(gomock.Any()).Times(1).Return(emptyJournalEntries)
 
-			batchrouter.Setup(s3DestinationDefinition.Name, c.mockBackendConfig, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, nil, transientsource.NewEmptyService(), rsources.NewNoOpService(), destinationdebugger.NewNoOpService())
+			batchrouter.Setup(
+				s3DestinationDefinition.Name,
+				c.mockBackendConfig,
+				c.mockBatchRouterJobsDB,
+				c.mockProcErrorsDB,
+				nil,
+				transientsource.NewEmptyService(),
+				rsources.NewNoOpService(),
+				destinationdebugger.NewNoOpService(),
+				config.Default,
+			)
 		})
 	})
 
@@ -175,7 +185,17 @@ var _ = Describe("BatchRouter", func() {
 
 		It("should send failed, unprocessed jobs to s3 destination", func() {
 			batchrouter := &Handle{}
-			batchrouter.Setup(s3DestinationDefinition.Name, c.mockBackendConfig, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, nil, transientsource.NewEmptyService(), rsources.NewNoOpService(), destinationdebugger.NewNoOpService())
+			batchrouter.Setup(
+				s3DestinationDefinition.Name,
+				c.mockBackendConfig,
+				c.mockBatchRouterJobsDB,
+				c.mockProcErrorsDB,
+				nil,
+				transientsource.NewEmptyService(),
+				rsources.NewNoOpService(),
+				destinationdebugger.NewNoOpService(),
+				config.Default,
+			)
 
 			batchrouter.fileManagerFactory = c.mockFileManagerFactory
 

--- a/router/batchrouter/factory.go
+++ b/router/batchrouter/factory.go
@@ -1,6 +1,7 @@
 package batchrouter
 
 import (
+	"github.com/rudderlabs/rudder-go-kit/config"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	destinationdebugger "github.com/rudderlabs/rudder-server/services/debugger/destination"
@@ -34,6 +35,7 @@ func (f *Factory) New(destType string) *Handle {
 		f.TransientSources,
 		f.RsourcesService,
 		f.Debugger,
+		config.Default,
 	)
 	return r
 }

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -83,6 +83,7 @@ type Handle struct {
 	mainLoopFreq                 misc.ValueLoader[time.Duration]
 	disableEgress                bool
 	toAbortDestinationIDs        misc.ValueLoader[string]
+	toAbortJobRunIDs             misc.ValueLoader[string]
 	warehouseServiceMaxRetryTime misc.ValueLoader[time.Duration]
 	transformerURL               string
 	datePrefixOverride           misc.ValueLoader[string]

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -32,7 +32,7 @@ import (
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/isolation"
 	"github.com/rudderlabs/rudder-server/router/rterror"
-	router_utils "github.com/rudderlabs/rudder-server/router/utils"
+	routerutils "github.com/rudderlabs/rudder-server/router/utils"
 	destinationdebugger "github.com/rudderlabs/rudder-server/services/debugger/destination"
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 	"github.com/rudderlabs/rudder-server/services/rmetrics"
@@ -82,12 +82,12 @@ type Handle struct {
 	uploadFreq                   misc.ValueLoader[time.Duration]
 	mainLoopFreq                 misc.ValueLoader[time.Duration]
 	disableEgress                bool
-	toAbortDestinationIDs        misc.ValueLoader[string]
-	toAbortJobRunIDs             misc.ValueLoader[string]
 	warehouseServiceMaxRetryTime misc.ValueLoader[time.Duration]
 	transformerURL               string
 	datePrefixOverride           misc.ValueLoader[string]
 	customDatePrefix             misc.ValueLoader[string]
+
+	drainer routerutils.Drainer
 
 	// state
 
@@ -99,9 +99,9 @@ type Handle struct {
 	backendConfigInitializedOnce sync.Once
 	backendConfigInitialized     chan bool
 
-	configSubscriberMu       sync.RWMutex                                    // protects the following fields
-	destinationsMap          map[string]*router_utils.DestinationWithSources // destinationID -> destination
-	connectionWHNamespaceMap map[string]string                               // connectionIdentifier -> warehouseConnectionIdentifier(+namepsace)
+	configSubscriberMu       sync.RWMutex                                   // protects the following fields
+	destinationsMap          map[string]*routerutils.DestinationWithSources // destinationID -> destination
+	connectionWHNamespaceMap map[string]string                              // connectionIdentifier -> warehouseConnectionIdentifier(+namepsace)
 	uploadIntervalMap        map[string]time.Duration
 
 	encounteredMergeRuleMapMu sync.Mutex
@@ -479,7 +479,7 @@ func (brt *Handle) pingWarehouse(batchJobs *BatchedJobs, output UploadResult) (e
 			}
 		}
 	}
-	var sampleParameters router_utils.JobParameters
+	var sampleParameters routerutils.JobParameters
 	err = json.Unmarshal(batchJobs.Jobs[0].Parameters, &sampleParameters)
 	if err != nil {
 		brt.logger.Error("Unmarshal of job parameters failed in postToWarehouse function. ", string(batchJobs.Jobs[0].Parameters))
@@ -593,7 +593,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 			errorResp = []byte(errorRespString)
 		}
 
-		var parameters router_utils.JobParameters
+		var parameters routerutils.JobParameters
 		err = json.Unmarshal(job.Parameters, &parameters)
 		if err != nil {
 			brt.logger.Error("Unmarshal of job parameters failed. ", string(job.Parameters))
@@ -610,7 +610,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 				abortedEvents = append(abortedEvents, job)
 				failedMessage = &types.FailedMessage{MessageID: parameters.MessageID, ReceivedAt: parameters.ParseReceivedAtTime()}
 				jobState = jobsdb.Aborted.State
-				errorCode = router_utils.DRAIN_ERROR_CODE
+				errorCode = routerutils.DRAIN_ERROR_CODE
 			}
 			if notifyWarehouseErr && isWarehouse {
 				// change job state to abort state after warehouse service is continuously failing more than warehouseServiceMaxRetryTimeinHr time
@@ -621,7 +621,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 					abortedEvents = append(abortedEvents, job)
 					failedMessage = &types.FailedMessage{MessageID: parameters.MessageID, ReceivedAt: parameters.ParseReceivedAtTime()}
 					jobState = jobsdb.Aborted.State
-					errorCode = router_utils.DRAIN_ERROR_CODE
+					errorCode = routerutils.DRAIN_ERROR_CODE
 				}
 				brt.warehouseServiceFailedTimeMu.RUnlock()
 			}

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -478,7 +478,7 @@ func (brt *Handle) pingWarehouse(batchJobs *BatchedJobs, output UploadResult) (e
 			}
 		}
 	}
-	var sampleParameters JobParameters
+	var sampleParameters router_utils.JobParameters
 	err = json.Unmarshal(batchJobs.Jobs[0].Parameters, &sampleParameters)
 	if err != nil {
 		brt.logger.Error("Unmarshal of job parameters failed in postToWarehouse function. ", string(batchJobs.Jobs[0].Parameters))
@@ -592,7 +592,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 			errorResp = []byte(errorRespString)
 		}
 
-		var parameters JobParameters
+		var parameters router_utils.JobParameters
 		err = json.Unmarshal(job.Parameters, &parameters)
 		if err != nil {
 			brt.logger.Error("Unmarshal of job parameters failed. ", string(job.Parameters))

--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -509,7 +509,7 @@ func (brt *Handle) getReportMetrics(statusList []*jobsdb.JobStatusT, parametersM
 	statusDetailsMap := make(map[string]*utilTypes.StatusDetail)
 	routerWorkspaceJobStatusCount := make(map[string]int)
 	for _, status := range statusList {
-		var parameters JobParameters
+		var parameters routerutils.JobParameters
 		err := json.Unmarshal(parametersMap[status.JobID], &parameters)
 		if err != nil {
 			brt.logger.Error("Unmarshal of job parameters failed. ", string(parametersMap[status.JobID]))

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -97,15 +97,11 @@ func (brt *Handle) Setup(
 	brt.setupReloadableVars()
 	brt.drainer = routerutils.NewDrainer(
 		conf,
-		func(destinationID string) (bool, string) {
+		func(destinationID string) (*routerutils.DestinationWithSources, bool) {
 			brt.configSubscriberMu.RLock()
 			defer brt.configSubscriberMu.RUnlock()
-			if dest, destFound := brt.destinationsMap[destinationID]; !destFound {
-				return true, routerutils.DestNotFoundInConfig
-			} else if !dest.Destination.Enabled {
-				return true, routerutils.DestDisabled
-			}
-			return false, ""
+			dest, destFound := brt.destinationsMap[destinationID]
+			return dest, destFound
 		})
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -200,6 +200,7 @@ func (brt *Handle) setupReloadableVars() {
 	brt.uploadFreq = config.GetReloadableDurationVar(30, time.Second, "BatchRouter.uploadFreqInS", "BatchRouter.uploadFreq")
 	brt.mainLoopFreq = config.GetReloadableDurationVar(30, time.Second, "BatchRouter.mainLoopFreq")
 	brt.toAbortDestinationIDs = config.GetReloadableStringVar("", "BatchRouter.toAbortDestinationIDs")
+	brt.toAbortJobRunIDs = config.GetReloadableStringVar("", "RSources.toAbortJobRunIDs")
 	brt.warehouseServiceMaxRetryTime = config.GetReloadableDurationVar(3, time.Hour, "BatchRouter.warehouseServiceMaxRetryTime", "BatchRouter.warehouseServiceMaxRetryTimeinHr")
 	brt.datePrefixOverride = config.GetReloadableStringVar("", "BatchRouter.datePrefixOverride")
 	brt.customDatePrefix = config.GetReloadableStringVar("", "BatchRouter.customDatePrefix")

--- a/router/batchrouter/types.go
+++ b/router/batchrouter/types.go
@@ -6,34 +6,11 @@ import (
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	router_utils "github.com/rudderlabs/rudder-server/router/utils"
-	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
 type Connection struct {
 	Source      backendconfig.SourceT
 	Destination backendconfig.DestinationT
-}
-
-type JobParameters struct {
-	SourceID                string `json:"source_id"`
-	DestinationID           string `json:"destination_id"`
-	ReceivedAt              string `json:"received_at"`
-	TransformAt             string `json:"transform_at"`
-	SourceTaskRunID         string `json:"source_task_run_id"`
-	SourceJobID             string `json:"source_job_id"`
-	SourceJobRunID          string `json:"source_job_run_id"`
-	SourceDefinitionID      string `json:"source_definition_id"`
-	DestinationDefinitionID string `json:"destination_definition_id"`
-	SourceCategory          string `json:"source_category"`
-	EventName               string `json:"event_name"`
-	EventType               string `json:"event_type"`
-	MessageID               string `json:"message_id"`
-}
-
-// ParseReceivedAtTime parses the [ReceivedAt] field and returns the parsed time or a zero value time if parsing fails
-func (jp *JobParameters) ParseReceivedAtTime() time.Time {
-	receivedAt, _ := time.Parse(misc.RFC3339Milli, jp.ReceivedAt)
-	return receivedAt
 }
 
 type DestinationJobs struct {

--- a/router/batchrouter/types_test.go
+++ b/router/batchrouter/types_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/rudderlabs/rudder-server/router/batchrouter"
+	routerutils "github.com/rudderlabs/rudder-server/router/utils"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
@@ -14,19 +14,19 @@ func TestJobParameters(t *testing.T) {
 	t.Run("ParseReceivedAtTime", func(t *testing.T) {
 		refTime := time.Now().UTC().Truncate(time.Millisecond)
 		t.Run("invalid string", func(t *testing.T) {
-			jp := batchrouter.JobParameters{
+			jp := routerutils.JobParameters{
 				ReceivedAt: refTime.Format(misc.RFC3339Milli),
 			}
 			require.Equal(t, refTime, jp.ParseReceivedAtTime())
 		})
 
 		t.Run("empty string", func(t *testing.T) {
-			var jp batchrouter.JobParameters
+			var jp routerutils.JobParameters
 			require.True(t, jp.ParseReceivedAtTime().IsZero(), "an empty ReceivedAt should return a zero value time")
 		})
 
 		t.Run("invalid string", func(t *testing.T) {
-			jp := batchrouter.JobParameters{
+			jp := routerutils.JobParameters{
 				ReceivedAt: "invalid",
 			}
 			require.True(t, jp.ParseReceivedAtTime().IsZero(), "an invalid ReceivedAt should return a zero value time")

--- a/router/batchrouter/worker.go
+++ b/router/batchrouter/worker.go
@@ -76,7 +76,15 @@ func (w *worker) processJobAsync(jobsWg *sync.WaitGroup, destinationJobs *Destin
 		for _, job := range destinationJobs.jobs {
 			var params router_utils.JobParameters
 			_ = json.Unmarshal(job.Parameters, &params)
-			if drain, reason := router_utils.ToBeDrained(job, params, router_utils.AbortConfigs{ToAbortDestinationIDs: brt.toAbortDestinationIDs.Load()}, destinationsMap); drain {
+			if drain, reason := router_utils.ToBeDrained(
+				job,
+				params,
+				router_utils.AbortConfigs{
+					DestinationIDs: brt.toAbortDestinationIDs.Load(),
+					JobRunIDs:      brt.toAbortJobRunIDs.Load(),
+				},
+				destinationsMap,
+			); drain {
 				status := jobsdb.JobStatusT{
 					JobID:         job.JobID,
 					AttemptNum:    job.LastJobStatus.AttemptNum + 1,

--- a/router/handle.go
+++ b/router/handle.go
@@ -283,7 +283,7 @@ func (rt *Handle) commitStatusList(workerJobStatuses *[]workerJobStatus) {
 	var statusList []*jobsdb.JobStatusT
 	var routerAbortedJobs []*jobsdb.JobT
 	for _, workerJobStatus := range *workerJobStatuses {
-		var parameters JobParameters
+		var parameters routerutils.JobParameters
 		err := json.Unmarshal(workerJobStatus.job.Parameters, &parameters)
 		if err != nil {
 			rt.logger.Error("Unmarshal of job parameters failed. ", string(workerJobStatus.job.Parameters))
@@ -474,7 +474,7 @@ func (rt *Handle) findWorkerSlot(workers []*worker, job *jobsdb.JobT, blockedOrd
 		return nil, types.ErrContextCancelled
 	}
 
-	var parameters JobParameters
+	var parameters routerutils.JobParameters
 	if err := json.Unmarshal(job.Parameters, &parameters); err != nil {
 		rt.logger.Errorf(`[%v Router] :: Unmarshalling parameters failed with the error %v . Returning nil worker`, err)
 		return nil, types.ErrParamsUnmarshal
@@ -545,7 +545,7 @@ func (*Handle) shouldBackoff(job *jobsdb.JobT) bool {
 	return job.LastJobStatus.JobState == jobsdb.Failed.State && job.LastJobStatus.AttemptNum > 0 && time.Until(job.LastJobStatus.RetryTime) > 0
 }
 
-func (rt *Handle) shouldThrottle(job *jobsdb.JobT, parameters JobParameters) (limited bool) {
+func (rt *Handle) shouldThrottle(job *jobsdb.JobT, parameters routerutils.JobParameters) (limited bool) {
 	if rt.throttlerFactory == nil {
 		// throttlerFactory could be nil when throttling is disabled or misconfigured.
 		// in case of misconfiguration, logging errors are emitted.

--- a/router/handle.go
+++ b/router/handle.go
@@ -113,6 +113,8 @@ type Handle struct {
 			process   *partition.Stats
 		}
 	}
+
+	drainer routerutils.Drainer
 }
 
 // activePartitions returns the list of active partitions, depending on the active isolation strategy

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -58,6 +58,7 @@ func (rt *Handle) Setup(
 	rt.errorDB = errorDB
 	rt.destType = destType
 
+	rt.drainer = routerutils.NewDrainer(config)
 	rt.reloadableConfig = &reloadableConfig{}
 	rt.setupReloadableVars()
 	rt.crashRecover()
@@ -265,8 +266,6 @@ func (rt *Handle) setupReloadableVars() {
 	rt.reloadableConfig.maxStatusUpdateWait = config.GetReloadableDurationVar(5, time.Second, "Router.maxStatusUpdateWait", "Router.maxStatusUpdateWaitInS")
 	rt.reloadableConfig.minRetryBackoff = config.GetReloadableDurationVar(10, time.Second, "Router.minRetryBackoff", "Router.minRetryBackoffInS")
 	rt.reloadableConfig.maxRetryBackoff = config.GetReloadableDurationVar(300, time.Second, "Router.maxRetryBackoff", "Router.maxRetryBackoffInS")
-	rt.reloadableConfig.toAbortDestinationIDs = config.GetReloadableStringVar("", "Router.toAbortDestinationIDs")
-	rt.reloadableConfig.toAbortJobRunIDs = config.GetReloadableStringVar("", "RSources.toAbortJobRunIDs")
 	rt.reloadableConfig.pickupFlushInterval = config.GetReloadableDurationVar(2, time.Second, "Router.pickupFlushInterval")
 	rt.reloadableConfig.failingJobsPenaltySleep = config.GetReloadableDurationVar(2000, time.Millisecond, "Router.failingJobsPenaltySleep")
 	rt.reloadableConfig.failingJobsPenaltyThreshold = config.GetReloadableFloat64Var(0.6, "Router.failingJobsPenaltyThreshold")

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -266,6 +266,7 @@ func (rt *Handle) setupReloadableVars() {
 	rt.reloadableConfig.minRetryBackoff = config.GetReloadableDurationVar(10, time.Second, "Router.minRetryBackoff", "Router.minRetryBackoffInS")
 	rt.reloadableConfig.maxRetryBackoff = config.GetReloadableDurationVar(300, time.Second, "Router.maxRetryBackoff", "Router.maxRetryBackoffInS")
 	rt.reloadableConfig.toAbortDestinationIDs = config.GetReloadableStringVar("", "Router.toAbortDestinationIDs")
+	rt.reloadableConfig.toAbortJobRunIDs = config.GetReloadableStringVar("", "RSources.toAbortJobRunIDs")
 	rt.reloadableConfig.pickupFlushInterval = config.GetReloadableDurationVar(2, time.Second, "Router.pickupFlushInterval")
 	rt.reloadableConfig.failingJobsPenaltySleep = config.GetReloadableDurationVar(2000, time.Millisecond, "Router.failingJobsPenaltySleep")
 	rt.reloadableConfig.failingJobsPenaltyThreshold = config.GetReloadableFloat64Var(0.6, "Router.failingJobsPenaltyThreshold")

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -60,15 +60,11 @@ func (rt *Handle) Setup(
 
 	rt.drainer = routerutils.NewDrainer(
 		config,
-		func(destinationID string) (bool, string) {
+		func(destinationID string) (*routerutils.DestinationWithSources, bool) {
 			rt.destinationsMapMu.RLock()
 			defer rt.destinationsMapMu.RUnlock()
-			if dest, ok := rt.destinationsMap[destinationID]; !ok {
-				return true, routerutils.DestNotFoundInConfig
-			} else if !dest.Destination.Enabled {
-				return true, routerutils.DestDisabled
-			}
-			return false, ""
+			dest, destFound := rt.destinationsMap[destinationID]
+			return dest, destFound
 		})
 	rt.reloadableConfig = &reloadableConfig{}
 	rt.setupReloadableVars()

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -603,7 +603,7 @@ var _ = Describe("router", func() {
 		})
 
 		It("aborts jobs that bear a abort configured jobRunId", func() {
-			config.Set("RSources.toAbortJobRunIDs", "someJobRunId")
+			conf.Set("RSources.toAbortJobRunIDs", "someJobRunId")
 			router := &Handle{
 				Reporting: &reporting.NOOP{},
 			}

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -602,6 +602,85 @@ var _ = Describe("router", func() {
 			Eventually(func() bool { return routerAborted && procErrorStored }, 5*time.Second, 100*time.Millisecond).Should(Equal(true))
 		})
 
+		It("aborts jobs that bear a abort configured jobRunId", func() {
+			config.Set("RSources.toAbortJobRunIDs", "someJobRunId")
+			router := &Handle{
+				Reporting: &reporting.NOOP{},
+			}
+			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
+
+			router.Setup(gaDestinationDefinition, logger.NOP, conf, c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, transientsource.NewEmptyService(), rsources.NewNoOpService(), destinationdebugger.NewNoOpService())
+			mockNetHandle := mocksRouter.NewMockNetHandle(c.mockCtrl)
+			router.netHandle = mockNetHandle
+
+			gaPayload := `{"body": {"XML": {}, "FORM": {}, "JSON": {}}, "type": "REST", "files": {}, "method": "POST", "params": {"t": "event", "v": "1", "an": "RudderAndroidClient", "av": "1.0", "ds": "android-sdk", "ea": "Demo Track", "ec": "Demo Category", "el": "Demo Label", "ni": 0, "qt": 59268380964, "ul": "en-US", "cid": "anon_id", "tid": "UA-185645846-1", "uip": "[::1]", "aiid": "com.rudderlabs.android.sdk"}, "userId": "anon_id", "headers": {}, "version": "1", "endpoint": "https://www.google-analytics.com/collect"}`
+			parameters := fmt.Sprintf(`{"source_job_run_id": "someJobRunId", "source_id": "1fMCVYZboDlYlauh4GFsEo2JU77", "destination_id": "%s", "message_id": "2f548e6d-60f6-44af-a1f4-62b3272445c3", "received_at": "2021-06-28T10:04:48.527+05:30", "transform_at": "processor"}`, gaDestinationID) // skipcq: GO-R4002
+
+			unprocessedJobsList := []*jobsdb.JobT{
+				{
+					UUID:         uuid.New(),
+					UserID:       "u1",
+					JobID:        2010,
+					CreatedAt:    time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
+					ExpireAt:     time.Date(2020, 0o4, 28, 13, 26, 0o0, 0o0, time.UTC),
+					CustomVal:    customVal["GA"],
+					EventPayload: []byte(gaPayload),
+					LastJobStatus: jobsdb.JobStatusT{
+						AttemptNum: 0,
+					},
+					Parameters:  []byte(parameters),
+					WorkspaceId: workspaceID,
+				},
+			}
+
+			payloadLimit := router.reloadableConfig.payloadLimit
+			c.mockRouterJobsDB.EXPECT().GetToProcess(gomock.Any(), jobsdb.GetQueryParams{
+				CustomValFilters: []string{customVal["GA"]},
+				ParameterFilters: []jobsdb.ParameterFilterT{{Name: "destination_id", Value: gaDestinationID}},
+				PayloadSizeLimit: payloadLimit.Load(),
+				JobsLimit:        10000,
+			}, nil).Times(1).Return(&jobsdb.MoreJobsResult{JobsResult: jobsdb.JobsResult{Jobs: unprocessedJobsList}}, nil)
+
+			var routerAborted bool
+			var procErrorStored bool
+
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1)
+
+			c.mockProcErrorsDB.EXPECT().Store(gomock.Any(), gomock.Any()).Times(1).
+				Do(func(ctx context.Context, jobList []*jobsdb.JobT) {
+					job := jobList[0]
+					var parameters map[string]interface{}
+					err := json.Unmarshal(job.Parameters, &parameters)
+					if err != nil {
+						panic(err)
+					}
+
+					Expect(job.JobID).To(Equal(unprocessedJobsList[0].JobID))
+					Expect(job.CustomVal).To(Equal(unprocessedJobsList[0].CustomVal))
+					Expect(job.UserID).To(Equal(unprocessedJobsList[0].UserID))
+					procErrorStored = true
+				})
+
+			c.mockRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
+				_ = f(jobsdb.EmptyUpdateSafeTx())
+			}).Return(nil).Times(1)
+
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+				Do(func(ctx context.Context, tx jobsdb.UpdateSafeTx, drainList []*jobsdb.JobStatusT, _, _ interface{}) {
+					Expect(drainList).To(HaveLen(1))
+					assertJobStatus(unprocessedJobsList[0], drainList[0], jobsdb.Aborted.State, "410", `{"reason": "job expired"}`, 0)
+					routerAborted = true
+				})
+
+			<-router.backendConfigInitialized
+			worker := newPartitionWorker(context.Background(), router, gaDestinationID)
+			defer worker.Stop()
+			Expect(worker.Work()).To(BeTrue())
+			Expect(worker.pickupCount).To(Equal(len(unprocessedJobsList)))
+			Eventually(func() bool { return routerAborted && procErrorStored }, 5*time.Second, 100*time.Millisecond).Should(Equal(true))
+
+		})
+
 		It("aborts events that have reached max retries", func() {
 			config.Set("Router.jobRetention", "24h")
 			mockNetHandle := mocksRouter.NewMockNetHandle(c.mockCtrl)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1084,7 +1084,7 @@ var _ = Describe("router", func() {
 						statuses[0],
 						jobsdb.Aborted.State,
 						routerutils.DRAIN_ERROR_CODE,
-						`{"reason": "`+routerutils.DestNotFoundInConfig+`"}`,
+						`{"reason": "`+routerutils.DrainReasonDestNotFound+`"}`,
 						3,
 					)
 				}).Return(nil)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -678,7 +678,6 @@ var _ = Describe("router", func() {
 			Expect(worker.Work()).To(BeTrue())
 			Expect(worker.pickupCount).To(Equal(len(unprocessedJobsList)))
 			Eventually(func() bool { return routerAborted && procErrorStored }, 5*time.Second, 100*time.Millisecond).Should(Equal(true))
-
 		})
 
 		It("aborts events that have reached max retries", func() {

--- a/router/types.go
+++ b/router/types.go
@@ -79,7 +79,4 @@ type reloadableConfig struct {
 	transformerProxy                        misc.ValueLoader[bool]
 	skipRtAbortAlertForTransformation       misc.ValueLoader[bool] // represents if event delivery(via transformerProxy) should be alerted via router-aborted-count alert def
 	skipRtAbortAlertForDelivery             misc.ValueLoader[bool] // represents if transformation(router or batch) should be alerted via router-aborted-count alert def
-
-	toAbortDestinationIDs misc.ValueLoader[string]
-	toAbortJobRunIDs      misc.ValueLoader[string]
 }

--- a/router/types.go
+++ b/router/types.go
@@ -11,30 +11,6 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
-// JobParameters struct holds source id and destination id of a job
-type JobParameters struct {
-	SourceID                string      `json:"source_id"`
-	DestinationID           string      `json:"destination_id"`
-	ReceivedAt              string      `json:"received_at"`
-	TransformAt             string      `json:"transform_at"`
-	SourceTaskRunID         string      `json:"source_task_run_id"`
-	SourceJobID             string      `json:"source_job_id"`
-	SourceJobRunID          string      `json:"source_job_run_id"`
-	SourceDefinitionID      string      `json:"source_definition_id"`
-	DestinationDefinitionID string      `json:"destination_definition_id"`
-	SourceCategory          string      `json:"source_category"`
-	RecordID                interface{} `json:"record_id"`
-	MessageID               string      `json:"message_id"`
-	WorkspaceID             string      `json:"workspaceId"`
-	RudderAccountID         string      `json:"rudderAccountId"`
-}
-
-// ParseReceivedAtTime parses the [ReceivedAt] field and returns the parsed time or a zero value time if parsing fails
-func (jp *JobParameters) ParseReceivedAtTime() time.Time {
-	receivedAt, _ := time.Parse(misc.RFC3339Milli, jp.ReceivedAt)
-	return receivedAt
-}
-
 type workerJobStatus struct {
 	userID string
 	worker *worker

--- a/router/types.go
+++ b/router/types.go
@@ -62,7 +62,6 @@ type reloadableConfig struct {
 	jobsBatchTimeout                        misc.ValueLoader[time.Duration]
 	failingJobsPenaltyThreshold             misc.ValueLoader[float64]
 	failingJobsPenaltySleep                 misc.ValueLoader[time.Duration]
-	toAbortDestinationIDs                   misc.ValueLoader[string]
 	noOfJobsToBatchInAWorker                misc.ValueLoader[int]
 	jobsDBCommandTimeout                    misc.ValueLoader[time.Duration]
 	jobdDBMaxRetries                        misc.ValueLoader[int]
@@ -80,4 +79,7 @@ type reloadableConfig struct {
 	transformerProxy                        misc.ValueLoader[bool]
 	skipRtAbortAlertForTransformation       misc.ValueLoader[bool] // represents if event delivery(via transformerProxy) should be alerted via router-aborted-count alert def
 	skipRtAbortAlertForDelivery             misc.ValueLoader[bool] // represents if transformation(router or batch) should be alerted via router-aborted-count alert def
+
+	toAbortDestinationIDs misc.ValueLoader[string]
+	toAbortJobRunIDs      misc.ValueLoader[string]
 }

--- a/router/types_test.go
+++ b/router/types_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/rudderlabs/rudder-server/router"
+	routerutils "github.com/rudderlabs/rudder-server/router/utils"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
@@ -14,19 +14,19 @@ func TestJobParameters(t *testing.T) {
 	t.Run("ParseReceivedAtTime", func(t *testing.T) {
 		refTime := time.Now().UTC().Truncate(time.Millisecond)
 		t.Run("valid string", func(t *testing.T) {
-			jp := router.JobParameters{
+			jp := routerutils.JobParameters{
 				ReceivedAt: refTime.Format(misc.RFC3339Milli),
 			}
 			require.Equal(t, refTime, jp.ParseReceivedAtTime())
 		})
 
 		t.Run("empty string", func(t *testing.T) {
-			var jp router.JobParameters
+			var jp routerutils.JobParameters
 			require.True(t, jp.ParseReceivedAtTime().IsZero(), "an empty ReceivedAt should return a zero value time")
 		})
 
 		t.Run("invalid string", func(t *testing.T) {
-			jp := router.JobParameters{
+			jp := routerutils.JobParameters{
 				ReceivedAt: "invalid",
 			}
 			require.True(t, jp.ParseReceivedAtTime().IsZero(), "an invalid ReceivedAt should return a zero value time")

--- a/router/utils/utils.go
+++ b/router/utils/utils.go
@@ -144,7 +144,8 @@ func (d *drainer) Drain(
 	}
 
 	if len(d.jobRunIDs.Load()) > 0 {
-		if slices.Contains(d.jobRunIDs.Load(), jobParams.SourceJobRunID) {
+		if jobParams.SourceJobRunID != "" &&
+			slices.Contains(d.jobRunIDs.Load(), jobParams.SourceJobRunID) {
 			return true, "cancelled jobRunID"
 		}
 	}

--- a/router/utils/utils.go
+++ b/router/utils/utils.go
@@ -29,6 +29,7 @@ const (
 	DrainReasonDestDisabled      = "destination is disabled"
 	DrainReasonDestAbort         = "destination configured to abort"
 	DrainReasonJobRunIDCancelled = "cancelled jobRunID"
+	DrainReasonJobExpired        = "job expired"
 )
 
 type DestinationWithSources struct {
@@ -140,7 +141,7 @@ func (d *drainer) Drain(
 	_ = json.Unmarshal(job.Parameters, &jobParams)
 	destID := jobParams.DestinationID
 	if time.Since(createdAt) > getRetentionTimeForDestination(destID) {
-		return true, "job expired"
+		return true, DrainReasonJobExpired
 	}
 
 	if destination, ok := d.destinationResolver(destID); !ok {

--- a/router/worker.go
+++ b/router/worker.go
@@ -89,13 +89,9 @@ func (w *worker) workLoop() {
 				panic(fmt.Errorf("unmarshalling of job parameters failed for job %d (%s): %w", job.JobID, string(job.Parameters), err))
 			}
 			w.rt.destinationsMapMu.RLock()
-			abort, abortReason := routerutils.ToBeDrained(
+			abort, abortReason := w.rt.drainer.Drain(
 				job,
 				parameters,
-				routerutils.AbortConfigs{
-					DestinationIDs: w.rt.reloadableConfig.toAbortDestinationIDs.Load(),
-					JobRunIDs:      w.rt.reloadableConfig.toAbortJobRunIDs.Load(),
-				},
 				w.rt.destinationsMap,
 			)
 			abortTag := abortReason

--- a/router/worker.go
+++ b/router/worker.go
@@ -89,7 +89,15 @@ func (w *worker) workLoop() {
 				panic(fmt.Errorf("unmarshalling of job parameters failed for job %d (%s): %w", job.JobID, string(job.Parameters), err))
 			}
 			w.rt.destinationsMapMu.RLock()
-			abort, abortReason := routerutils.ToBeDrained(job, parameters, routerutils.AbortConfigs{ToAbortDestinationIDs: w.rt.reloadableConfig.toAbortDestinationIDs.Load()}, w.rt.destinationsMap)
+			abort, abortReason := routerutils.ToBeDrained(
+				job,
+				parameters,
+				routerutils.AbortConfigs{
+					DestinationIDs: w.rt.reloadableConfig.toAbortDestinationIDs.Load(),
+					JobRunIDs:      w.rt.reloadableConfig.toAbortJobRunIDs.Load(),
+				},
+				w.rt.destinationsMap,
+			)
 			abortTag := abortReason
 			w.rt.destinationsMapMu.RUnlock()
 			if !abort {

--- a/router/worker.go
+++ b/router/worker.go
@@ -84,12 +84,12 @@ func (w *worker) workLoop() {
 			job := message.job
 			userID := job.UserID
 
-			var parameters JobParameters
+			var parameters routerutils.JobParameters
 			if err := json.Unmarshal(job.Parameters, &parameters); err != nil {
 				panic(fmt.Errorf("unmarshalling of job parameters failed for job %d (%s): %w", job.JobID, string(job.Parameters), err))
 			}
 			w.rt.destinationsMapMu.RLock()
-			abort, abortReason := routerutils.ToBeDrained(job, parameters.DestinationID, w.rt.reloadableConfig.toAbortDestinationIDs.Load(), w.rt.destinationsMap)
+			abort, abortReason := routerutils.ToBeDrained(job, parameters, routerutils.AbortConfigs{ToAbortDestinationIDs: w.rt.reloadableConfig.toAbortDestinationIDs.Load()}, w.rt.destinationsMap)
 			abortTag := abortReason
 			w.rt.destinationsMapMu.RUnlock()
 			if !abort {

--- a/router/worker.go
+++ b/router/worker.go
@@ -90,7 +90,6 @@ func (w *worker) workLoop() {
 			}
 			abort, abortReason := w.rt.drainer.Drain(
 				job,
-				parameters,
 			)
 			abortTag := abortReason
 			if !abort {

--- a/utils/types/types.go
+++ b/utils/types/types.go
@@ -13,6 +13,7 @@ import (
 const (
 	FilterEventCode   = 298
 	SuppressEventCode = 299
+	DrainEventCode    = 410
 )
 
 // SingularEventT single event structrue


### PR DESCRIPTION
# Description

The topic of draining events from a sync gave birth to this.
This is a way to pass generic rules by which (batch)router and processor(only `jobRunID` now) can drain events. How this is set to config is another story.

Routers, BatchRouters now have a `drainer` which provides the method:
`Drain(job *jobsdb.JobT) (bool, string)` to check if their jobs can be drained. Support for draining via configurable destinationIDs(`"Router.toAbortDestinationIDs"`) and jobRunID(`"RSources.toAbortJobRunIDs"`) present now. Adding more drain configurations should be straightforward -> just need to add logic in `type drainer` and `(d *drainer) Drain(...)`.

Processor has a simpler approach, a new config field is added to accommodate configurations to drain by, `jobRunId` for now. Also injecting `*config.Config` into processor now. Plan is to proliferate it's use instead of `config.Default` in processor package(story for another PR).

## Linear Ticket

[drain events for a cancelled sync](https://linear.app/rudderstack/issue/PIPE-122/drain-events-for-disabled-syncs)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
