### PR TITLE
fix: send reportedAt in milliseconds for error reporting

### DIFF
--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -558,7 +558,7 @@ func (edRep *ErrorDetailReporter) aggregate(reports []*types.EDReportsDB) []*typ
 			},
 			PU: firstReport.PU,
 			ReportMetadata: types.ReportMetadata{
-				ReportedAt: firstReport.ReportedAt,
+				ReportedAt: firstReport.ReportedAt * 60 * 1000,
 			},
 		}
 		var errs []types.EDErrorDetails


### PR DESCRIPTION
# Description

We used to send `reportedAt` in minutes to reporting service which is causing problems.
With this PR, we would be sending `reportedAt` in milliseconds to reporting service

## Linear Ticket

https://linear.app/rudderstack/issue/INT-608/send-reportedat-in-milliseconds

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
