### PR TITLE
chore: go-kit v0.15.9

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -53,8 +53,9 @@ type embeddedApp struct {
 	}
 }
 
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func (a *embeddedApp) loadConfiguration() {
-	config.RegisterBoolConfigVariable(types.DefaultReplayEnabled, &a.config.enableReplay, false, "Replay.enabled")
+	a.config.enableReplay = config.GetBoolVar(types.DefaultReplayEnabled, "Replay.enabled")
 	config.RegisterIntConfigVariable(0, &a.config.processorDSLimit, true, 1, "Processor.jobsDB.dsLimit", "JobsDB.dsLimit")
 	config.RegisterIntConfigVariable(0, &a.config.gatewayDSLimit, true, 1, "Gateway.jobsDB.dsLimit", "JobsDB.dsLimit")
 	config.RegisterIntConfigVariable(0, &a.config.routerDSLimit, true, 1, "Router.jobsDB.dsLimit", "JobsDB.dsLimit")

--- a/app/apphandlers/gatewayAppHandler.go
+++ b/app/apphandlers/gatewayAppHandler.go
@@ -34,6 +34,7 @@ type gatewayApp struct {
 	}
 }
 
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func (a *gatewayApp) loadConfiguration() {
 	config.RegisterIntConfigVariable(0, &a.config.gatewayDSLimit, true, 1, "Gateway.jobsDB.dsLimit", "JobsDB.dsLimit")
 }

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -64,13 +64,14 @@ type processorApp struct {
 	}
 }
 
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func (a *processorApp) loadConfiguration() {
-	config.RegisterDurationConfigVariable(0, &a.config.http.ReadTimeout, false, time.Second, []string{"ReadTimeout", "ReadTimeOutInSec"}...)
-	config.RegisterDurationConfigVariable(0, &a.config.http.ReadHeaderTimeout, false, time.Second, []string{"ReadHeaderTimeout", "ReadHeaderTimeoutInSec"}...)
-	config.RegisterDurationConfigVariable(10, &a.config.http.WriteTimeout, false, time.Second, []string{"WriteTimeout", "WriteTimeOutInSec"}...)
-	config.RegisterDurationConfigVariable(720, &a.config.http.IdleTimeout, false, time.Second, []string{"IdleTimeout", "IdleTimeoutInSec"}...)
-	config.RegisterIntConfigVariable(8086, &a.config.http.webPort, false, 1, "Processor.webPort")
-	config.RegisterIntConfigVariable(524288, &a.config.http.MaxHeaderBytes, false, 1, "MaxHeaderBytes")
+	a.config.http.ReadTimeout = config.GetDurationVar(0, time.Second, []string{"ReadTimeout", "ReadTimeOutInSec"}...)
+	a.config.http.ReadHeaderTimeout = config.GetDurationVar(0, time.Second, []string{"ReadHeaderTimeout", "ReadHeaderTimeoutInSec"}...)
+	a.config.http.WriteTimeout = config.GetDurationVar(10, time.Second, []string{"WriteTimeout", "WriteTimeOutInSec"}...)
+	a.config.http.IdleTimeout = config.GetDurationVar(720, time.Second, []string{"IdleTimeout", "IdleTimeoutInSec"}...)
+	a.config.http.webPort = config.GetIntVar(8086, 1, "Processor.webPort")
+	a.config.http.MaxHeaderBytes = config.GetIntVar(524288, 1, "MaxHeaderBytes")
 	config.RegisterIntConfigVariable(0, &a.config.processorDSLimit, true, 1, "Processor.jobsDB.dsLimit", "JobsDB.dsLimit")
 	config.RegisterIntConfigVariable(0, &a.config.gatewayDSLimit, true, 1, "Gateway.jobsDB.dsLimit", "JobsDB.dsLimit")
 	config.RegisterIntConfigVariable(0, &a.config.routerDSLimit, true, 1, "Router.jobsDB.dsLimit", "JobsDB.dsLimit")

--- a/app/cluster/state/etcd.go
+++ b/app/cluster/state/etcd.go
@@ -76,10 +76,10 @@ func EnvETCDConfig() *ETCDConfig {
 	var ackTimeout time.Duration
 
 	envConfigOnce.Do(func() {
-		config.RegisterDurationConfigVariable(15, &ackTimeout, false, time.Second, "etcd.ackTimeout")
-		config.RegisterDurationConfigVariable(30, &keepaliveTime, false, time.Second, "etcd.keepaliveTime")
-		config.RegisterDurationConfigVariable(10, &keepaliveTimeout, false, time.Second, "etcd.keepaliveTimeout")
-		config.RegisterDurationConfigVariable(20, &dialTimeout, false, time.Second, "etcd.dialTimeout")
+		ackTimeout = config.GetDurationVar(15, time.Second, "etcd.ackTimeout")
+		keepaliveTime = config.GetDurationVar(30, time.Second, "etcd.keepaliveTime")
+		keepaliveTimeout = config.GetDurationVar(10, time.Second, "etcd.keepaliveTimeout")
+		dialTimeout = config.GetDurationVar(20, time.Second, "etcd.dialTimeout")
 	})
 
 	return &ETCDConfig{

--- a/backend-config/backend-config.go
+++ b/backend-config/backend-config.go
@@ -92,17 +92,18 @@ type backendConfigImpl struct {
 	cache             cache.Cache
 }
 
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func loadConfig() {
 	configBackendURL = config.GetString("CONFIG_BACKEND_URL", "https://api.rudderstack.com")
 	cpRouterURL = config.GetString("CP_ROUTER_URL", "https://cp-router.rudderlabs.com")
-	config.RegisterDurationConfigVariable(5, &pollInterval, true, time.Second, []string{"BackendConfig.pollInterval", "BackendConfig.pollIntervalInS"}...)
-	config.RegisterDurationConfigVariable(300, &regulationsPollInterval, true, time.Second, []string{"BackendConfig.regulationsPollInterval", "BackendConfig.regulationsPollIntervalInS"}...)
-	config.RegisterStringConfigVariable("/etc/rudderstack/workspaceConfig.json", &configJSONPath, false, "BackendConfig.configJSONPath")
-	config.RegisterBoolConfigVariable(false, &configFromFile, false, "BackendConfig.configFromFile")
+	config.RegisterDurationConfigVariable(5, &pollInterval, true, time.Second, "BackendConfig.pollInterval", "BackendConfig.pollIntervalInS")
+	config.RegisterDurationConfigVariable(300, &regulationsPollInterval, true, time.Second, "BackendConfig.regulationsPollInterval", "BackendConfig.regulationsPollIntervalInS")
 	config.RegisterIntConfigVariable(1000, &maxRegulationsPerRequest, true, 1, "BackendConfig.maxRegulationsPerRequest")
-	config.RegisterBoolConfigVariable(true, &configEnvReplacementEnabled, false, "BackendConfig.envReplacementEnabled")
-	config.RegisterBoolConfigVariable(false, &incrementalConfigUpdates, false, "BackendConfig.incrementalConfigUpdates")
-	config.RegisterBoolConfigVariable(true, &dbCacheEnabled, false, "BackendConfig.dbCacheEnabled")
+	configJSONPath = config.GetStringVar("/etc/rudderstack/workspaceConfig.json", "BackendConfig.configJSONPath")
+	configFromFile = config.GetBoolVar(false, "BackendConfig.configFromFile")
+	configEnvReplacementEnabled = config.GetBoolVar(true, "BackendConfig.envReplacementEnabled")
+	incrementalConfigUpdates = config.GetBoolVar(false, "BackendConfig.incrementalConfigUpdates")
+	dbCacheEnabled = config.GetBoolVar(true, "BackendConfig.dbCacheEnabled")
 }
 
 func Init() {

--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -64,41 +64,31 @@ func (gw *Handle) Setup(
 	gw.rsourcesService = rsourcesService
 	gw.sourcehandle = sourcehandle
 
-	config.RegisterDurationConfigVariable(30, &gw.conf.httpTimeout, false, time.Second, "Gateway.httpTimeout")
+	gw.conf.httpTimeout = config.GetDurationVar(30, time.Second, "Gateway.httpTimeout")
 	// Port where GW is running
-	config.RegisterIntConfigVariable(8080, &gw.conf.webPort, false, 1, "Gateway.webPort")
+	gw.conf.webPort = config.GetIntVar(8080, 1, "Gateway.webPort")
 	// Number of incoming requests that are batched before handing off to write workers
-	config.RegisterIntConfigVariable(128, &gw.conf.maxUserWebRequestBatchSize, false, 1, "Gateway.maxUserRequestBatchSize")
+	gw.conf.maxUserWebRequestBatchSize = config.GetIntVar(128, 1, "Gateway.maxUserRequestBatchSize")
 	// Number of userWorkerBatchRequest that are batched before initiating write
-	config.RegisterIntConfigVariable(128, &gw.conf.maxDBBatchSize, false, 1, "Gateway.maxDBBatchSize")
-	// Timeout after which batch is formed anyway with whatever requests
-	// are available
-	config.RegisterDurationConfigVariable(15, &gw.conf.userWebRequestBatchTimeout, true, time.Millisecond, []string{"Gateway.userWebRequestBatchTimeout", "Gateway.userWebRequestBatchTimeoutInMS"}...)
-	config.RegisterDurationConfigVariable(5, &gw.conf.dbBatchWriteTimeout, true, time.Millisecond, []string{"Gateway.dbBatchWriteTimeout", "Gateway.dbBatchWriteTimeoutInMS"}...)
+	gw.conf.maxDBBatchSize = config.GetIntVar(128, 1, "Gateway.maxDBBatchSize")
 	// Multiple workers are used to batch user web requests
-	config.RegisterIntConfigVariable(64, &gw.conf.maxUserWebRequestWorkerProcess, false, 1, "Gateway.maxUserWebRequestWorkerProcess")
+	gw.conf.maxUserWebRequestWorkerProcess = config.GetIntVar(64, 1, "Gateway.maxUserWebRequestWorkerProcess")
 	// Multiple DB writers are used to write data to DB
-	config.RegisterIntConfigVariable(256, &gw.conf.maxDBWriterProcess, false, 1, "Gateway.maxDBWriterProcess")
-	// Maximum request size to gateway
-	config.RegisterIntConfigVariable(4000, &gw.conf.maxReqSize, true, 1024, "Gateway.maxReqSizeInKB")
-	// Enable rate limit on incoming events. false by default
-	config.RegisterBoolConfigVariable(false, &gw.conf.enableRateLimit, true, "Gateway.enableRateLimit")
+	gw.conf.maxDBWriterProcess = config.GetIntVar(256, 1, "Gateway.maxDBWriterProcess")
+	gw.setupReloadableVars(config)
 	// Enable suppress user feature. false by default
-	config.RegisterBoolConfigVariable(true, &gw.conf.enableSuppressUserFeature, false, "Gateway.enableSuppressUserFeature")
+	gw.conf.enableSuppressUserFeature = config.GetBoolVar(true, "Gateway.enableSuppressUserFeature")
 	// EventSchemas feature. false by default
-	config.RegisterBoolConfigVariable(false, &gw.conf.enableEventSchemasFeature, false, "EventSchemas.enableEventSchemasFeature")
+	gw.conf.enableEventSchemasFeature = config.GetBoolVar(false, "EventSchemas.enableEventSchemasFeature")
 	// Time period for diagnosis ticker
-	config.RegisterDurationConfigVariable(60, &gw.conf.diagnosisTickerTime, false, time.Second, []string{"Diagnostics.gatewayTimePeriod", "Diagnostics.gatewayTimePeriodInS"}...)
-	// Enables accepting requests without user id and anonymous id. This is added to prevent client 4xx retries.
-	config.RegisterBoolConfigVariable(false, &gw.conf.allowReqsWithoutUserIDAndAnonymousID, true, "Gateway.allowReqsWithoutUserIDAndAnonymousID")
-	config.RegisterBoolConfigVariable(true, &gw.conf.gwAllowPartialWriteWithErrors, true, "Gateway.allowPartialWriteWithErrors")
-	config.RegisterDurationConfigVariable(0, &gw.conf.ReadTimeout, false, time.Second, []string{"ReadTimeout", "ReadTimeOutInSec"}...)
-	config.RegisterDurationConfigVariable(0, &gw.conf.ReadHeaderTimeout, false, time.Second, []string{"ReadHeaderTimeout", "ReadHeaderTimeoutInSec"}...)
-	config.RegisterDurationConfigVariable(10, &gw.conf.WriteTimeout, false, time.Second, []string{"WriteTimeout", "WriteTimeOutInSec"}...)
-	config.RegisterDurationConfigVariable(720, &gw.conf.IdleTimeout, false, time.Second, []string{"IdleTimeout", "IdleTimeoutInSec"}...)
-	config.RegisterIntConfigVariable(524288, &gw.conf.maxHeaderBytes, false, 1, "MaxHeaderBytes")
+	gw.conf.diagnosisTickerTime = config.GetDurationVar(60, time.Second, "Diagnostics.gatewayTimePeriod", "Diagnostics.gatewayTimePeriodInS")
+	gw.conf.ReadTimeout = config.GetDurationVar(0, time.Second, "ReadTimeout", "ReadTimeOutInSec")
+	gw.conf.ReadHeaderTimeout = config.GetDurationVar(0, time.Second, "ReadHeaderTimeout", "ReadHeaderTimeoutInSec")
+	gw.conf.WriteTimeout = config.GetDurationVar(10, time.Second, "WriteTimeout", "WriteTimeOutInSec")
+	gw.conf.IdleTimeout = config.GetDurationVar(720, time.Second, "IdleTimeout", "IdleTimeoutInSec")
+	gw.conf.maxHeaderBytes = config.GetIntVar(524288, 1, "MaxHeaderBytes")
 	// if set to '0', it means disabled.
-	config.RegisterIntConfigVariable(50000, &gw.conf.maxConcurrentRequests, false, 1, "Gateway.maxConcurrentRequests")
+	gw.conf.maxConcurrentRequests = config.GetIntVar(50000, 1, "Gateway.maxConcurrentRequests")
 
 	// Registering stats
 	gw.batchSizeStat = gw.stats.NewStat("gateway.batch_size", stats.HistogramType)
@@ -163,6 +153,20 @@ func (gw *Handle) Setup(
 		return nil
 	}))
 	return nil
+}
+
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
+func (gw *Handle) setupReloadableVars(config *config.Config) {
+	// Timeout after which batch is formed anyway with whatever requests are available
+	config.RegisterDurationConfigVariable(15, &gw.conf.userWebRequestBatchTimeout, true, time.Millisecond, "Gateway.userWebRequestBatchTimeout", "Gateway.userWebRequestBatchTimeoutInMS")
+	config.RegisterDurationConfigVariable(5, &gw.conf.dbBatchWriteTimeout, true, time.Millisecond, "Gateway.dbBatchWriteTimeout", "Gateway.dbBatchWriteTimeoutInMS")
+	// Enables accepting requests without user id and anonymous id. This is added to prevent client 4xx retries.
+	config.RegisterBoolConfigVariable(false, &gw.conf.allowReqsWithoutUserIDAndAnonymousID, true, "Gateway.allowReqsWithoutUserIDAndAnonymousID")
+	config.RegisterBoolConfigVariable(true, &gw.conf.gwAllowPartialWriteWithErrors, true, "Gateway.allowPartialWriteWithErrors")
+	// Maximum request size to gateway
+	config.RegisterIntConfigVariable(4000, &gw.conf.maxReqSize, true, 1024, "Gateway.maxReqSizeInKB")
+	// Enable rate limit on incoming events. false by default
+	config.RegisterBoolConfigVariable(false, &gw.conf.enableRateLimit, true, "Gateway.enableRateLimit")
 }
 
 // initUserWebRequestWorkers initiates `maxUserWebRequestWorkerProcess` number of `webRequestWorkers` that listen on their `webRequestQ` for new WebRequests.

--- a/gateway/webhook/configuration.go
+++ b/gateway/webhook/configuration.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 )
 
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func loadConfig() {
 	sourceTransformerURL = strings.TrimSuffix(config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090"), "/") + "/v0/sources"
 	// Number of incoming webhooks that are batched before calling source transformer

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/rs/cors v1.9.0
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/rudderlabs/compose-test v0.1.3
-	github.com/rudderlabs/rudder-go-kit v0.15.8
+	github.com/rudderlabs/rudder-go-kit v0.15.9
 	github.com/rudderlabs/sql-tunnels v0.1.4
 	github.com/samber/lo v1.38.1
 	github.com/segmentio/kafka-go v0.4.42

--- a/go.sum
+++ b/go.sum
@@ -1774,8 +1774,8 @@ github.com/rudderlabs/compose-test v0.1.3 h1:uyep6jDCIF737sfv4zIaMsKRQKX95IDz5Xb
 github.com/rudderlabs/compose-test v0.1.3/go.mod h1:tuvS1eQdSfwOYv1qwyVAcpdJxPLQXJgy5xGDd/9XmMg=
 github.com/rudderlabs/parquet-go v0.0.2 h1:ZXRdZdimB0PdJtmxeSSxfI0fDQ3kZjwzBxRi6Ut1J8k=
 github.com/rudderlabs/parquet-go v0.0.2/go.mod h1:g6guum7o8uhj/uNhunnt7bw5Vabu/goI5i21/3fnxWQ=
-github.com/rudderlabs/rudder-go-kit v0.15.8 h1:EpTHGpvqTjx9XotO67g3lTIaWzzVYBMGWvuimxtZUY0=
-github.com/rudderlabs/rudder-go-kit v0.15.8/go.mod h1:W7b3rft7Kt8TvNd4gguw5ZB9Hu4M1k60EGLv91+N2zM=
+github.com/rudderlabs/rudder-go-kit v0.15.9 h1:i1dUUL1JLAOOn+2RgVq0K6UnTn6X4OZMTiZPZZBKmTQ=
+github.com/rudderlabs/rudder-go-kit v0.15.9/go.mod h1:W7b3rft7Kt8TvNd4gguw5ZB9Hu4M1k60EGLv91+N2zM=
 github.com/rudderlabs/sql-tunnels v0.1.4 h1:snnkUItx3nRCPGSouibkYzBpOcEiWhCVjRY95A0eMuk=
 github.com/rudderlabs/sql-tunnels v0.1.4/go.mod h1:C6O0M6C3V+pdVwjy3UvyPd+d5SeRvbBQfApm+67qNnI=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -855,6 +855,7 @@ func (jd *Handle) workersAndAuxSetup() {
 	jd.statDropDSPeriod = stats.Default.NewTaggedStat("jobsdb.drop_ds_period", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix})
 }
 
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func (jd *Handle) loadConfig() {
 	// maxTableSizeInMB: Maximum Table size in MB
 	jd.config.RegisterInt64ConfigVariable(300, &jd.conf.maxTableSize, true, 1000000, "JobsDB.maxTableSizeInMB")

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -232,11 +232,11 @@ func (jd *Handle) getCleanUpCandidates(ctx context.Context, dsList []dataSetT) (
 	var rows *sql.Rows
 	rows, err := jd.dbHandle.QueryContext(
 		ctx,
-		`SELECT reltuples AS estimate, relname 
-		FROM pg_class 
+		`SELECT reltuples AS estimate, relname
+		FROM pg_class
 		where relname = ANY(
-			SELECT tablename 
-				FROM pg_catalog.pg_tables 
+			SELECT tablename
+				FROM pg_catalog.pg_tables
 				WHERE schemaname NOT IN ('pg_catalog','information_schema')
 				AND tablename like $1
 		)`,
@@ -432,13 +432,13 @@ func (jd *Handle) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dat
 		`with last_status as (select * from "v_last_%[1]s"),
 		inserted_jobs as
 		(
-			insert into %[3]q (job_id,   workspace_id,   uuid,   user_id,   custom_val,   parameters,   event_payload,   event_count,   created_at,   expire_at) 
+			insert into %[3]q (job_id,   workspace_id,   uuid,   user_id,   custom_val,   parameters,   event_payload,   event_count,   created_at,   expire_at)
 			           (select j.job_id, j.workspace_id, j.uuid, j.user_id, j.custom_val, j.parameters, j.event_payload, j.event_count, j.created_at, j.expire_at from %[2]q j left join last_status js on js.job_id = j.job_id
 				where js.job_id is null or js.job_state = ANY('{%[5]s}') order by j.job_id) returning job_id
 		),
-		insertedStatuses as 
+		insertedStatuses as
 		(
-			insert into %[4]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters) 
+			insert into %[4]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters)
 			           (select job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters from last_status where job_state = ANY('{%[5]s}'))
 		)
 		select count(*) from inserted_jobs;`,

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -331,10 +331,8 @@ func (proc *Handle) Setup(
 	proc.reporting = reporting
 	proc.destDebugger = destDebugger
 	proc.transDebugger = transDebugger
-	config.RegisterBoolConfigVariable(types.DefaultReportingEnabled, &proc.reportingEnabled, false, "Reporting.enabled")
-	config.RegisterDurationConfigVariable(600, &proc.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB.Processor.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
-	config.RegisterDurationConfigVariable(600, &proc.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.Processor.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
-	config.RegisterIntConfigVariable(2, &proc.jobdDBMaxRetries, true, 1, []string{"JobsDB.Processor.MaxRetries", "JobsDB.MaxRetries"}...)
+	proc.reportingEnabled = config.GetBoolVar(types.DefaultReportingEnabled, "Reporting.enabled")
+	proc.setupReloadableVars()
 	proc.logger = logger.NewLogger().Child("processor")
 	proc.backendConfig = backendConfig
 
@@ -449,6 +447,13 @@ func (proc *Handle) Setup(
 	}))
 
 	proc.crashRecover()
+}
+
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
+func (proc *Handle) setupReloadableVars() {
+	config.RegisterDurationConfigVariable(600, &proc.jobdDBQueryRequestTimeout, true, time.Second, "JobsDB.Processor.QueryRequestTimeout", "JobsDB.QueryRequestTimeout")
+	config.RegisterDurationConfigVariable(600, &proc.jobsDBCommandTimeout, true, time.Second, "JobsDB.Processor.CommandRequestTimeout", "JobsDB.CommandRequestTimeout")
+	config.RegisterIntConfigVariable(2, &proc.jobdDBMaxRetries, true, 1, "JobsDB.Processor.MaxRetries", "JobsDB.MaxRetries")
 }
 
 // Start starts this processor's main loops.
@@ -577,36 +582,40 @@ func (proc *Handle) loadConfig() {
 		defaultPayloadLimit = 20 * bytesize.MB
 	}
 
-	config.RegisterInt64ConfigVariable(defaultPayloadLimit, &proc.payloadLimit, true, 1, "Processor.payloadLimit")
-	config.RegisterBoolConfigVariable(true, &proc.config.enablePipelining, false, "Processor.enablePipelining")
-	config.RegisterIntConfigVariable(0, &proc.config.pipelineBufferedItems, false, 1, "Processor.pipelineBufferedItems")
-	config.RegisterIntConfigVariable(defaultSubJobSize, &proc.config.subJobSize, false, 1, "Processor.subJobSize")
-	config.RegisterDurationConfigVariable(10000, &proc.config.maxLoopSleep, true, time.Millisecond, []string{"Processor.maxLoopSleep", "Processor.maxLoopSleepInMS"}...)
-	config.RegisterDurationConfigVariable(5, &proc.config.storeTimeout, true, time.Minute, "Processor.storeTimeout")
+	proc.config.enablePipelining = config.GetBoolVar(true, "Processor.enablePipelining")
+	proc.config.pipelineBufferedItems = config.GetIntVar(0, 1, "Processor.pipelineBufferedItems")
+	proc.config.subJobSize = config.GetIntVar(defaultSubJobSize, 1, "Processor.subJobSize")
+	// Enable dedup of incoming events by default
+	proc.config.enableDedup = config.GetBoolVar(false, "Dedup.enableDedup")
+	// EventSchemas feature. false by default
+	proc.config.enableEventSchemasFeature = config.GetBoolVar(false, "EventSchemas.enableEventSchemasFeature")
+	proc.config.eventSchemaV2Enabled = config.GetBoolVar(false, "EventSchemas2.enabled")
+	proc.config.eventSchemaV2AllSources = config.GetBoolVar(false, "EventSchemas2.enableAllSources")
+	proc.config.batchDestinations = misc.BatchDestinations()
+	proc.config.transformTimesPQLength = config.GetIntVar(5, 1, "Processor.transformTimesPQLength")
+	proc.config.transformerURL = config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
+	proc.config.pollInterval = config.GetDurationVar(5, time.Second, "Processor.pollInterval", "Processor.pollIntervalInS")
+	// GWCustomVal is used as a key in the jobsDB customval column
+	proc.config.GWCustomVal = config.GetStringVar("GW", "Gateway.CustomVal")
 
+	proc.loadReloadableConfig(defaultPayloadLimit, defaultMaxEventsToProcess)
+}
+
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
+func (proc *Handle) loadReloadableConfig(defaultPayloadLimit int64, defaultMaxEventsToProcess int) {
+	config.RegisterInt64ConfigVariable(defaultPayloadLimit, &proc.payloadLimit, true, 1, "Processor.payloadLimit")
+	config.RegisterDurationConfigVariable(10000, &proc.config.maxLoopSleep, true, time.Millisecond, "Processor.maxLoopSleep", "Processor.maxLoopSleepInMS")
+	config.RegisterDurationConfigVariable(5, &proc.config.storeTimeout, true, time.Minute, "Processor.storeTimeout")
 	config.RegisterDurationConfigVariable(1000, &proc.config.pingerSleep, true, time.Millisecond, "Processor.pingerSleep")
 	config.RegisterDurationConfigVariable(1000, &proc.config.readLoopSleep, true, time.Millisecond, "Processor.readLoopSleep")
 	config.RegisterIntConfigVariable(100, &proc.config.transformBatchSize, true, 1, "Processor.transformBatchSize")
 	config.RegisterIntConfigVariable(200, &proc.config.userTransformBatchSize, true, 1, "Processor.userTransformBatchSize")
-	// Enable dedup of incoming events by default
-	config.RegisterBoolConfigVariable(false, &proc.config.enableDedup, false, "Dedup.enableDedup")
 	config.RegisterBoolConfigVariable(true, &proc.config.enableEventCount, true, "Processor.enableEventCount")
-	// EventSchemas feature. false by default
-	config.RegisterBoolConfigVariable(false, &proc.config.enableEventSchemasFeature, false, "EventSchemas.enableEventSchemasFeature")
 	config.RegisterBoolConfigVariable(false, &proc.config.enableEventSchemasAPIOnly, true, "EventSchemas.enableEventSchemasAPIOnly")
 	config.RegisterIntConfigVariable(defaultMaxEventsToProcess, &proc.config.maxEventsToProcess, true, 1, "Processor.maxLoopProcessEvents")
-	// EventSchemas2 feature.
-	config.RegisterBoolConfigVariable(false, &proc.config.eventSchemaV2Enabled, false, "EventSchemas2.enabled")
 	config.RegisterBoolConfigVariable(true, &proc.config.archivalEnabled, true, "archival.Enabled")
-	config.RegisterBoolConfigVariable(false, &proc.config.eventSchemaV2AllSources, false, "EventSchemas2.enableAllSources")
-	proc.config.batchDestinations = misc.BatchDestinations()
-	config.RegisterIntConfigVariable(5, &proc.config.transformTimesPQLength, false, 1, "Processor.transformTimesPQLength")
 	// Capture event name as a tag in event level stats
 	config.RegisterBoolConfigVariable(false, &proc.config.captureEventNameStats, true, "Processor.Stats.captureEventName")
-	proc.config.transformerURL = config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
-	config.RegisterDurationConfigVariable(5, &proc.config.pollInterval, false, time.Second, []string{"Processor.pollInterval", "Processor.pollIntervalInS"}...)
-	// GWCustomVal is used as a key in the jobsDB customval column
-	config.RegisterStringConfigVariable("GW", &proc.config.GWCustomVal, false, "Gateway.CustomVal")
 }
 
 // syncTransformerFeatureJson polls the transformer feature json endpoint,
@@ -2855,8 +2864,10 @@ func (proc *Handle) countPendingEvents(ctx context.Context) error {
 	dbs := map[string]jobsdb.JobsDB{"rt": proc.routerDB, "batch_rt": proc.batchRouterDB}
 	var jobdDBQueryRequestTimeout time.Duration
 	var jobdDBMaxRetries int
-	config.RegisterDurationConfigVariable(600, &jobdDBQueryRequestTimeout, false, time.Second, []string{"JobsDB.GetPileUpCounts.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
-	config.RegisterIntConfigVariable(2, &jobdDBMaxRetries, true, 1, []string{"JobsDB." + "Processor." + "MaxRetries", "JobsDB." + "MaxRetries"}...)
+	jobdDBQueryRequestTimeout = config.GetDurationVar(600, time.Second, "JobsDB.GetPileUpCounts.QueryRequestTimeout", "JobsDB.QueryRequestTimeout")
+
+	// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
+	config.RegisterIntConfigVariable(2, &jobdDBMaxRetries, true, 1, "JobsDB.Processor.MaxRetries", "JobsDB.MaxRetries")
 
 	for tablePrefix, db := range dbs {
 		pileUpStatMap, err := misc.QueryWithRetriesAndNotify(ctx,

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -37,6 +37,7 @@ func Init() {
 	pkgLogger = logger.NewLogger().Child("processor").Child("stash")
 }
 
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func loadConfig() {
 	config.RegisterBoolConfigVariable(true, &errorStashEnabled, true, "Processor.errorStashEnabled")
 	config.RegisterIntConfigVariable(1000, &errDBReadBatchSize, true, 1, "Processor.errDBReadBatchSize")
@@ -84,10 +85,15 @@ func (st *HandleT) Setup(
 	st.transientSource = transientSource
 	st.fileuploader = fileuploader
 	st.adaptiveLimit = adaptiveLimitFunc
+	st.setupReloadableVars()
+	st.crashRecover()
+}
+
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
+func (st *HandleT) setupReloadableVars() {
 	config.RegisterIntConfigVariable(2, &st.jobdDBMaxRetries, true, 1, []string{"JobsDB.Processor.MaxRetries", "JobsDB.MaxRetries"}...)
 	config.RegisterDurationConfigVariable(600, &st.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB.Processor.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
 	config.RegisterDurationConfigVariable(600, &st.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.Processor.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
-	st.crashRecover()
 }
 
 func (st *HandleT) crashRecover() {

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -205,13 +205,9 @@ func NewTransformer(conf *config.Config, log logger.Logger, stat stats.Stats, op
 	trans.config.maxHTTPIdleConnections = conf.GetInt("Processor.maxHTTPIdleConnections", 5)
 	trans.config.disableKeepAlives = conf.GetBool("Transformer.Client.disableKeepAlives", true)
 	trans.config.timeoutDuration = conf.GetDuration("HttpClient.procTransformer.timeout", 600, time.Second)
-
 	trans.config.destTransformationURL = conf.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
 	trans.config.userTransformationURL = conf.GetString("USER_TRANSFORM_URL", trans.config.destTransformationURL)
-
-	conf.RegisterIntConfigVariable(30, &trans.config.maxRetry, true, 1, "Processor.maxRetry")
-	conf.RegisterBoolConfigVariable(false, &trans.config.failOnUserTransformTimeout, true, "Processor.Transformer.failOnUserTransformTimeout")
-	conf.RegisterBoolConfigVariable(false, &trans.config.failOnError, true, "Processor.Transformer.failOnError")
+	trans.setupReloadableVars()
 
 	trans.guardConcurrency = make(chan struct{}, trans.config.maxConcurrency)
 
@@ -232,6 +228,13 @@ func NewTransformer(conf *config.Config, log logger.Logger, stat stats.Stats, op
 	}
 
 	return &trans
+}
+
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
+func (trans *handle) setupReloadableVars() {
+	trans.conf.RegisterIntConfigVariable(30, &trans.config.maxRetry, true, 1, "Processor.maxRetry")
+	trans.conf.RegisterBoolConfigVariable(false, &trans.config.failOnUserTransformTimeout, true, "Processor.Transformer.failOnUserTransformTimeout")
+	trans.conf.RegisterBoolConfigVariable(false, &trans.config.failOnError, true, "Processor.Transformer.failOnError")
 }
 
 // Transform function is used to invoke destination transformer API

--- a/router/batchrouter/asyncdestinationmanager/manager.go
+++ b/router/batchrouter/asyncdestinationmanager/manager.go
@@ -2,11 +2,9 @@ package asyncdestinationmanager
 
 import (
 	"errors"
-	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
-	"github.com/rudderlabs/rudder-go-kit/config"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	bingads "github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/bing-ads"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
@@ -15,16 +13,6 @@ import (
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
-
-var HTTPTimeout time.Duration
-
-func loadConfig() {
-	config.RegisterDurationConfigVariable(600, &HTTPTimeout, true, time.Second, "AsyncDestination.HTTPTimeout")
-}
-
-func Init() {
-	loadConfig()
-}
 
 func GetMarshalledData(payload string, jobID int64) string {
 	var job common.AsyncJob

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -87,27 +87,12 @@ func (brt *Handle) Setup(
 	}); err != nil {
 		panic(fmt.Errorf("resolving isolation strategy for mode %q: %w", isolationMode, err))
 	}
-	config.RegisterIntConfigVariable(10000, &brt.maxEventsInABatch, false, 1, []string{"BatchRouter." + brt.destType + "." + "maxEventsInABatch", "BatchRouter.maxEventsInABatch"}...)
-	config.RegisterIntConfigVariable(10000, &brt.maxPayloadSizeInBytes, false, 1, []string{"BatchRouter." + brt.destType + "." + "maxPayloadSizeInBytes", "BatchRouter.maxPayloadSizeInBytes"}...)
-	config.RegisterIntConfigVariable(128, &brt.maxFailedCountForJob, true, 1, []string{"BatchRouter." + brt.destType + "." + "maxFailedCountForJob", "BatchRouter." + "maxFailedCountForJob"}...)
-	config.RegisterDurationConfigVariable(30, &brt.asyncUploadTimeout, true, time.Minute, []string{"BatchRouter." + brt.destType + "." + "asyncUploadTimeout", "BatchRouter." + "asyncUploadTimeout"}...)
-	config.RegisterDurationConfigVariable(180, &brt.retryTimeWindow, true, time.Minute, []string{"BatchRouter." + brt.destType + "." + "retryTimeWindow", "BatchRouter." + brt.destType + "." + "retryTimeWindowInMins", "BatchRouter." + "retryTimeWindow", "BatchRouter." + "retryTimeWindowInMins"}...)
-	config.RegisterBoolConfigVariable(types.DefaultReportingEnabled, &brt.reportingEnabled, false, "Reporting.enabled")
-	config.RegisterIntConfigVariable(100000, &brt.jobQueryBatchSize, true, 1, []string{"BatchRouter." + brt.destType + "." + "jobQueryBatchSize", "BatchRouter.jobQueryBatchSize"}...)
-	config.RegisterDurationConfigVariable(10, &brt.pollStatusLoopSleep, true, time.Second, []string{"BatchRouter." + brt.destType + "." + "pollStatusLoopSleep", "BatchRouter.pollStatusLoopSleep"}...)
-	config.RegisterInt64ConfigVariable(1*bytesize.GB, &brt.payloadLimit, true, 1, []string{"BatchRouter." + brt.destType + "." + "PayloadLimit", "BatchRouter.PayloadLimit"}...)
-	config.RegisterDurationConfigVariable(600, &brt.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.BatchRouter.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
-	config.RegisterDurationConfigVariable(600, &brt.jobdDBQueryRequestTimeout, true, time.Second, []string{"JobsDB.BatchRouter.QueryRequestTimeout", "JobsDB.QueryRequestTimeout"}...)
-	config.RegisterIntConfigVariable(2, &brt.jobdDBMaxRetries, true, 1, []string{"JobsDB.BatchRouter.MaxRetries", "JobsDB.MaxRetries"}...)
-	config.RegisterDurationConfigVariable(2, &brt.minIdleSleep, true, time.Second, []string{"BatchRouter.minIdleSleep"}...)
-	config.RegisterDurationConfigVariable(30, &brt.uploadFreq, true, time.Second, []string{"BatchRouter.uploadFreqInS", "BatchRouter.uploadFreq"}...)
-	config.RegisterBoolConfigVariable(false, &brt.forceHonorUploadFrequency, true, "BatchRouter.forceHonorUploadFrequency")
-	config.RegisterBoolConfigVariable(false, &brt.disableEgress, false, "disableEgress")
-	config.RegisterStringConfigVariable("", &brt.toAbortDestinationIDs, true, "BatchRouter.toAbortDestinationIDs")
-	config.RegisterDurationConfigVariable(3, &brt.warehouseServiceMaxRetryTime, true, time.Hour, []string{"BatchRouter.warehouseServiceMaxRetryTime", "BatchRouter.warehouseServiceMaxRetryTimeinHr"}...)
+	brt.maxEventsInABatch = config.GetIntVar(10000, 1, "BatchRouter."+brt.destType+"."+"maxEventsInABatch", "BatchRouter.maxEventsInABatch")
+	brt.maxPayloadSizeInBytes = config.GetIntVar(10000, 1, "BatchRouter."+brt.destType+"."+"maxPayloadSizeInBytes", "BatchRouter.maxPayloadSizeInBytes")
+	brt.reportingEnabled = config.GetBoolVar(types.DefaultReportingEnabled, "Reporting.enabled")
+	brt.disableEgress = config.GetBoolVar(false, "disableEgress")
 	brt.transformerURL = config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
-	config.RegisterStringConfigVariable("", &brt.datePrefixOverride, true, "BatchRouter.datePrefixOverride")
-	config.RegisterStringConfigVariable("", &brt.customDatePrefix, true, "BatchRouter.customDatePrefix")
+	brt.setupReloadableVars()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	brt.backgroundGroup, brt.backgroundCtx = errgroup.WithContext(ctx)
@@ -123,8 +108,7 @@ func (brt *Handle) Setup(
 	brt.uploadIntervalMap = map[string]time.Duration{}
 	brt.lastExecTimes = map[string]time.Time{}
 	brt.dateFormatProvider = &storageDateFormatProvider{dateFormatsCache: make(map[string]string)}
-	var diagnosisTickerTime time.Duration
-	config.RegisterDurationConfigVariable(600, &diagnosisTickerTime, false, time.Second, []string{"Diagnostics.batchRouterTimePeriod", "Diagnostics.batchRouterTimePeriodInS"}...)
+	diagnosisTickerTime := config.GetDurationVar(600, time.Second, "Diagnostics.batchRouterTimePeriod", "Diagnostics.batchRouterTimePeriodInS")
 	brt.diagnosisTicker = time.NewTicker(diagnosisTickerTime)
 	brt.uploadedRawDataJobsCache = make(map[string]map[string]bool)
 
@@ -204,6 +188,26 @@ func (brt *Handle) Setup(
 		brt.backendConfigSubscriber()
 		return nil
 	}))
+}
+
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
+func (brt *Handle) setupReloadableVars() {
+	config.RegisterIntConfigVariable(128, &brt.maxFailedCountForJob, true, 1, "BatchRouter."+brt.destType+".maxFailedCountForJob", "BatchRouter.maxFailedCountForJob")
+	config.RegisterDurationConfigVariable(30, &brt.asyncUploadTimeout, true, time.Minute, "BatchRouter."+brt.destType+".asyncUploadTimeout", "BatchRouter.asyncUploadTimeout")
+	config.RegisterDurationConfigVariable(180, &brt.retryTimeWindow, true, time.Minute, "BatchRouter."+brt.destType+".retryTimeWindow", "BatchRouter."+brt.destType+".retryTimeWindowInMins", "BatchRouter.retryTimeWindow", "BatchRouter.retryTimeWindowInMins")
+	config.RegisterIntConfigVariable(100000, &brt.jobQueryBatchSize, true, 1, "BatchRouter."+brt.destType+".jobQueryBatchSize", "BatchRouter.jobQueryBatchSize")
+	config.RegisterDurationConfigVariable(10, &brt.pollStatusLoopSleep, true, time.Second, "BatchRouter."+brt.destType+".pollStatusLoopSleep", "BatchRouter.pollStatusLoopSleep")
+	config.RegisterInt64ConfigVariable(1*bytesize.GB, &brt.payloadLimit, true, 1, "BatchRouter."+brt.destType+".PayloadLimit", "BatchRouter.PayloadLimit")
+	config.RegisterDurationConfigVariable(600, &brt.jobsDBCommandTimeout, true, time.Second, "JobsDB.BatchRouter.CommandRequestTimeout", "JobsDB.CommandRequestTimeout")
+	config.RegisterDurationConfigVariable(600, &brt.jobdDBQueryRequestTimeout, true, time.Second, "JobsDB.BatchRouter.QueryRequestTimeout", "JobsDB.QueryRequestTimeout")
+	config.RegisterIntConfigVariable(2, &brt.jobdDBMaxRetries, true, 1, "JobsDB.BatchRouter.MaxRetries", "JobsDB.MaxRetries")
+	config.RegisterDurationConfigVariable(2, &brt.minIdleSleep, true, time.Second, "BatchRouter.minIdleSleep")
+	config.RegisterDurationConfigVariable(30, &brt.uploadFreq, true, time.Second, "BatchRouter.uploadFreqInS", "BatchRouter.uploadFreq")
+	config.RegisterBoolConfigVariable(false, &brt.forceHonorUploadFrequency, true, "BatchRouter.forceHonorUploadFrequency")
+	config.RegisterStringConfigVariable("", &brt.toAbortDestinationIDs, true, "BatchRouter.toAbortDestinationIDs")
+	config.RegisterDurationConfigVariable(3, &brt.warehouseServiceMaxRetryTime, true, time.Hour, "BatchRouter.warehouseServiceMaxRetryTime", "BatchRouter.warehouseServiceMaxRetryTimeinHr")
+	config.RegisterStringConfigVariable("", &brt.datePrefixOverride, true, "BatchRouter.datePrefixOverride")
+	config.RegisterStringConfigVariable("", &brt.customDatePrefix, true, "BatchRouter.customDatePrefix")
 }
 
 func (brt *Handle) startAsyncDestinationManager() {
@@ -329,8 +333,8 @@ func (brt *Handle) crashRecover() {
 				continue
 			}
 
-			jsonFile.Close()
-			defer os.Remove(jsonPath)
+			_ = jsonFile.Close()
+			defer func() { _ = os.Remove(jsonPath) }()
 			rawf, err := os.Open(jsonPath)
 			if err != nil {
 				panic(err)

--- a/router/customdestinationmanager/customdestinationmanager.go
+++ b/router/customdestinationmanager/customdestinationmanager.go
@@ -76,10 +76,13 @@ func Init() {
 }
 
 func loadConfig() {
-	ObjectStreamDestinations = []string{"KINESIS", "KAFKA", "AZURE_EVENT_HUB", "FIREHOSE", "EVENTBRIDGE", "GOOGLEPUBSUB", "CONFLUENT_CLOUD", "PERSONALIZE", "GOOGLESHEETS", "BQSTREAM", "LAMBDA"}
+	ObjectStreamDestinations = []string{
+		"KINESIS", "KAFKA", "AZURE_EVENT_HUB", "FIREHOSE", "EVENTBRIDGE", "GOOGLEPUBSUB", "CONFLUENT_CLOUD",
+		"PERSONALIZE", "GOOGLESHEETS", "BQSTREAM", "LAMBDA",
+	}
 	KVStoreDestinations = []string{"REDIS"}
 	Destinations = append(ObjectStreamDestinations, KVStoreDestinations...)
-	config.RegisterBoolConfigVariable(false, &disableEgress, false, "disableEgress")
+	disableEgress = config.GetBoolVar(false, "disableEgress")
 }
 
 // newClient delegates the call to the appropriate manager

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -6,10 +6,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
+
 	"github.com/samber/lo"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
@@ -65,37 +66,7 @@ func (rt *Handle) Setup(
 	rt.destType = destType
 
 	rt.reloadableConfig = &reloadableConfig{}
-	config.RegisterDurationConfigVariable(90, &rt.reloadableConfig.jobsDBCommandTimeout, true, time.Second, []string{"JobsDB.Router.CommandRequestTimeout", "JobsDB.CommandRequestTimeout"}...)
-	config.RegisterIntConfigVariable(2, &rt.reloadableConfig.jobdDBMaxRetries, true, 1, []string{"JobsDB." + "Router." + "MaxRetries", "JobsDB." + "MaxRetries"}...)
-	config.RegisterIntConfigVariable(20, &rt.reloadableConfig.noOfJobsToBatchInAWorker, true, 1, []string{"Router." + rt.destType + "." + "noOfJobsToBatchInAWorker", "Router." + "noOfJobsToBatchInAWorker"}...)
-	config.RegisterIntConfigVariable(3, &rt.reloadableConfig.maxFailedCountForJob, true, 1, []string{"Router." + rt.destType + "." + "maxFailedCountForJob", "Router." + "maxFailedCountForJob"}...)
-	config.RegisterInt64ConfigVariable(100*bytesize.MB, &rt.reloadableConfig.payloadLimit, true, 1, []string{"Router." + rt.destType + "." + "PayloadLimit", "Router." + "PayloadLimit"}...)
-	config.RegisterDurationConfigVariable(3600, &rt.reloadableConfig.routerTimeout, true, time.Second, []string{"Router." + rt.destType + "." + "routerTimeout", "Router." + "routerTimeout"}...)
-	config.RegisterDurationConfigVariable(180, &rt.reloadableConfig.retryTimeWindow, true, time.Minute, []string{"Router." + rt.destType + "." + "retryTimeWindow", "Router." + rt.destType + "." + "retryTimeWindowInMins", "Router." + "retryTimeWindow", "Router." + "retryTimeWindowInMins"}...)
-	config.RegisterIntConfigVariable(10, &rt.reloadableConfig.maxDSQuerySize, true, 1, []string{"Router." + rt.destType + "." + "maxDSQuery", "Router." + "maxDSQuery"}...)
-	config.RegisterIntConfigVariable(50, &rt.reloadableConfig.jobIteratorMaxQueries, true, 1, "Router.jobIterator.maxQueries")
-	config.RegisterIntConfigVariable(10, &rt.reloadableConfig.jobIteratorDiscardedPercentageTolerance, true, 1, "Router.jobIterator.discardedPercentageTolerance")
-	config.RegisterBoolConfigVariable(false, &rt.reloadableConfig.savePayloadOnError, true, []string{"Router." + rt.destType + "." + "savePayloadOnError", "Router." + "savePayloadOnError"}...)
-	config.RegisterBoolConfigVariable(false, &rt.reloadableConfig.transformerProxy, true, []string{"Router." + rt.destType + "." + "transformerProxy", "Router." + "transformerProxy"}...)
-	config.RegisterBoolConfigVariable(false, &rt.reloadableConfig.skipRtAbortAlertForTransformation, true, []string{"Router." + rt.destType + "." + "skipRtAbortAlertForTf", "Router.skipRtAbortAlertForTf"}...)
-	config.RegisterBoolConfigVariable(false, &rt.reloadableConfig.skipRtAbortAlertForDelivery, true, []string{"Router." + rt.destType + "." + "skipRtAbortAlertForDelivery", "Router.skipRtAbortAlertForDelivery"}...)
-	config.RegisterIntConfigVariable(10000, &rt.reloadableConfig.jobQueryBatchSize, true, 1, "Router.jobQueryBatchSize")
-	config.RegisterIntConfigVariable(1000, &rt.reloadableConfig.updateStatusBatchSize, true, 1, "Router.updateStatusBatchSize")
-	config.RegisterDurationConfigVariable(1000, &rt.reloadableConfig.readSleep, true, time.Millisecond, []string{"Router.readSleep", "Router.readSleepInMS"}...)
-	config.RegisterDurationConfigVariable(5, &rt.reloadableConfig.jobsBatchTimeout, true, time.Second, []string{"Router.jobsBatchTimeout", "Router.jobsBatchTimeoutInSec"}...)
-	config.RegisterDurationConfigVariable(5, &rt.reloadableConfig.maxStatusUpdateWait, true, time.Second, []string{"Router.maxStatusUpdateWait", "Router.maxStatusUpdateWaitInS"}...)
-	config.RegisterDurationConfigVariable(10, &rt.reloadableConfig.minRetryBackoff, true, time.Second, []string{"Router.minRetryBackoff", "Router.minRetryBackoffInS"}...)
-	config.RegisterDurationConfigVariable(300, &rt.reloadableConfig.maxRetryBackoff, true, time.Second, []string{"Router.maxRetryBackoff", "Router.maxRetryBackoffInS"}...)
-	config.RegisterStringConfigVariable("", &rt.reloadableConfig.toAbortDestinationIDs, true, "Router.toAbortDestinationIDs")
-	config.RegisterDurationConfigVariable(2, &rt.reloadableConfig.pickupFlushInterval, true, time.Second, "Router.pickupFlushInterval")
-	config.RegisterDurationConfigVariable(2000, &rt.reloadableConfig.failingJobsPenaltySleep, true, time.Millisecond, []string{"Router.failingJobsPenaltySleep"}...)
-	config.RegisterFloat64ConfigVariable(0.6, &rt.reloadableConfig.failingJobsPenaltyThreshold, true, []string{"Router.failingJobsPenaltyThreshold"}...)
-
-	config.RegisterDurationConfigVariable(60, &rt.diagnosisTickerTime, false, time.Second, []string{"Diagnostics.routerTimePeriod", "Diagnostics.routerTimePeriodInS"}...)
-
-	netClientTimeoutKeys := []string{"Router." + rt.destType + "." + "httpTimeout", "Router." + rt.destType + "." + "httpTimeoutInS", "Router." + "httpTimeout", "Router." + "httpTimeoutInS"}
-	config.RegisterDurationConfigVariable(10, &rt.netClientTimeout, false, time.Second, netClientTimeoutKeys...)
-	config.RegisterDurationConfigVariable(600, &rt.transformerTimeout, false, time.Second, "HttpClient.backendProxy.timeout", "HttpClient.routerTransformer.timeout")
+	rt.setupReloadableVars()
 	rt.crashRecover()
 	rt.responseQ = make(chan workerJobStatus, rt.reloadableConfig.jobQueryBatchSize)
 	if rt.netHandle == nil {
@@ -120,7 +91,7 @@ func (rt *Handle) Setup(
 	rt.noOfWorkers = getRouterConfigInt("noOfWorkers", destType, 64)
 	rt.workerInputBufferSize = getRouterConfigInt("noOfJobsPerChannel", destType, 1000)
 
-	config.RegisterBoolConfigVariable(false, &rt.enableBatching, false, "Router."+rt.destType+"."+"enableBatching")
+	rt.enableBatching = config.GetBoolVar(false, "Router."+rt.destType+".enableBatching")
 
 	rt.drainConcurrencyLimit = getRouterConfigInt("drainedConcurrencyLimit", destType, 1)
 	rt.barrierConcurrencyLimit = getRouterConfigInt("barrierConcurrencyLimit", destType, 100)
@@ -274,6 +245,41 @@ func (rt *Handle) Setup(
 	rruntime.Go(func() {
 		rt.backendConfigSubscriber()
 	})
+}
+
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
+func (rt *Handle) setupReloadableVars() {
+	config.RegisterDurationConfigVariable(90, &rt.reloadableConfig.jobsDBCommandTimeout, true, time.Second, "JobsDB.Router.CommandRequestTimeout", "JobsDB.CommandRequestTimeout")
+	config.RegisterIntConfigVariable(2, &rt.reloadableConfig.jobdDBMaxRetries, true, 1, "JobsDB.Router.MaxRetries", "JobsDB.MaxRetries")
+	config.RegisterIntConfigVariable(20, &rt.reloadableConfig.noOfJobsToBatchInAWorker, true, 1, "Router."+rt.destType+".noOfJobsToBatchInAWorker", "Router.noOfJobsToBatchInAWorker")
+	config.RegisterIntConfigVariable(3, &rt.reloadableConfig.maxFailedCountForJob, true, 1, "Router."+rt.destType+".maxFailedCountForJob", "Router.maxFailedCountForJob")
+	config.RegisterInt64ConfigVariable(100*bytesize.MB, &rt.reloadableConfig.payloadLimit, true, 1, "Router."+rt.destType+".PayloadLimit", "Router.PayloadLimit")
+	config.RegisterDurationConfigVariable(3600, &rt.reloadableConfig.routerTimeout, true, time.Second, "Router."+rt.destType+".routerTimeout", "Router.routerTimeout")
+	config.RegisterDurationConfigVariable(180, &rt.reloadableConfig.retryTimeWindow, true, time.Minute, "Router."+rt.destType+".retryTimeWindow", "Router."+rt.destType+".retryTimeWindowInMins", "Router.retryTimeWindow", "Router.retryTimeWindowInMins")
+	config.RegisterIntConfigVariable(10, &rt.reloadableConfig.maxDSQuerySize, true, 1, "Router."+rt.destType+".maxDSQuery", "Router.maxDSQuery")
+	config.RegisterIntConfigVariable(50, &rt.reloadableConfig.jobIteratorMaxQueries, true, 1, "Router.jobIterator.maxQueries")
+	config.RegisterIntConfigVariable(10, &rt.reloadableConfig.jobIteratorDiscardedPercentageTolerance, true, 1, "Router.jobIterator.discardedPercentageTolerance")
+	config.RegisterBoolConfigVariable(false, &rt.reloadableConfig.savePayloadOnError, true, "Router."+rt.destType+".savePayloadOnError", "Router.savePayloadOnError")
+	config.RegisterBoolConfigVariable(false, &rt.reloadableConfig.transformerProxy, true, "Router."+rt.destType+".transformerProxy", "Router.transformerProxy")
+	config.RegisterBoolConfigVariable(false, &rt.reloadableConfig.skipRtAbortAlertForTransformation, true, "Router."+rt.destType+".skipRtAbortAlertForTf", "Router.skipRtAbortAlertForTf")
+	config.RegisterBoolConfigVariable(false, &rt.reloadableConfig.skipRtAbortAlertForDelivery, true, "Router."+rt.destType+".skipRtAbortAlertForDelivery", "Router.skipRtAbortAlertForDelivery")
+	config.RegisterIntConfigVariable(10000, &rt.reloadableConfig.jobQueryBatchSize, true, 1, "Router.jobQueryBatchSize")
+	config.RegisterIntConfigVariable(1000, &rt.reloadableConfig.updateStatusBatchSize, true, 1, "Router.updateStatusBatchSize")
+	config.RegisterDurationConfigVariable(1000, &rt.reloadableConfig.readSleep, true, time.Millisecond, "Router.readSleep", "Router.readSleepInMS")
+	config.RegisterDurationConfigVariable(5, &rt.reloadableConfig.jobsBatchTimeout, true, time.Second, "Router.jobsBatchTimeout", "Router.jobsBatchTimeoutInSec")
+	config.RegisterDurationConfigVariable(5, &rt.reloadableConfig.maxStatusUpdateWait, true, time.Second, "Router.maxStatusUpdateWait", "Router.maxStatusUpdateWaitInS")
+	config.RegisterDurationConfigVariable(10, &rt.reloadableConfig.minRetryBackoff, true, time.Second, "Router.minRetryBackoff", "Router.minRetryBackoffInS")
+	config.RegisterDurationConfigVariable(300, &rt.reloadableConfig.maxRetryBackoff, true, time.Second, "Router.maxRetryBackoff", "Router.maxRetryBackoffInS")
+	config.RegisterStringConfigVariable("", &rt.reloadableConfig.toAbortDestinationIDs, true, "Router.toAbortDestinationIDs")
+	config.RegisterDurationConfigVariable(2, &rt.reloadableConfig.pickupFlushInterval, true, time.Second, "Router.pickupFlushInterval")
+	config.RegisterDurationConfigVariable(2000, &rt.reloadableConfig.failingJobsPenaltySleep, true, time.Millisecond, "Router.failingJobsPenaltySleep")
+	config.RegisterFloat64ConfigVariable(0.6, &rt.reloadableConfig.failingJobsPenaltyThreshold, true, "Router.failingJobsPenaltyThreshold")
+	config.RegisterDurationConfigVariable(60, &rt.diagnosisTickerTime, false, time.Second, "Diagnostics.routerTimePeriod", "Diagnostics.routerTimePeriodInS")
+	config.RegisterDurationConfigVariable(10, &rt.netClientTimeout, false, time.Second,
+		"Router."+rt.destType+".httpTimeout",
+		"Router."+rt.destType+".httpTimeoutInS",
+		"Router.httpTimeout", "Router.httpTimeoutInS")
+	config.RegisterDurationConfigVariable(600, &rt.transformerTimeout, false, time.Second, "HttpClient.backendProxy.timeout", "HttpClient.routerTransformer.timeout")
 }
 
 func (rt *Handle) Start() {

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -93,9 +93,10 @@ var (
 	pkgLogger         logger.Logger
 )
 
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func loadConfig() {
 	config.RegisterIntConfigVariable(30, &maxRetry, true, 1, "Processor.maxRetry")
-	config.RegisterDurationConfigVariable(100, &retrySleep, true, time.Millisecond, []string{"Processor.retrySleep", "Processor.retrySleepInMS"}...)
+	config.RegisterDurationConfigVariable(100, &retrySleep, true, time.Millisecond, "Processor.retrySleep", "Processor.retrySleepInMS")
 	config.RegisterBoolConfigVariable(true, &disableKeepAlives, false, "Transformer.Client.disableKeepAlives")
 }
 

--- a/router/utils/utils.go
+++ b/router/utils/utils.go
@@ -50,6 +50,7 @@ func Init() {
 	loadConfig()
 }
 
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func loadConfig() {
 	config.RegisterDurationConfigVariable(720, &JobRetention, true, time.Hour, "Router.jobRetention")
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -30,7 +30,6 @@ import (
 	"github.com/rudderlabs/rudder-server/info"
 	"github.com/rudderlabs/rudder-server/processor/stash"
 	"github.com/rudderlabs/rudder-server/processor/transformer"
-	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager"
 	"github.com/rudderlabs/rudder-server/router/customdestinationmanager"
 	routertransformer "github.com/rudderlabs/rudder-server/router/transformer"
 	batchrouterutils "github.com/rudderlabs/rudder-server/router/utils"
@@ -332,7 +331,6 @@ func runAllInit() {
 	warehouse.Init4()
 	validations.Init()
 	webhook.Init()
-	asyncdestinationmanager.Init()
 	batchrouterutils.Init()
 	eventschema.Init()
 	eventschema.Init2()

--- a/schema-forwarder/internal/forwarder/jobsforwarder.go
+++ b/schema-forwarder/internal/forwarder/jobsforwarder.go
@@ -53,12 +53,17 @@ func NewJobsForwarder(terminalErrFn func(error), schemaDB jobsdb.JobsDB, client 
 	forwarder.pulsarClient = client
 
 	forwarder.topic = config.GetString("SchemaForwarder.pulsarTopic", "event-schema")
-	config.RegisterDurationConfigVariable(10, &forwarder.initialRetryInterval, true, time.Second, "SchemaForwarder.initialRetryInterval")
-	config.RegisterDurationConfigVariable(60, &forwarder.maxRetryInterval, true, time.Second, "SchemaForwarder.maxRetryInterval")
-	config.RegisterDurationConfigVariable(60, &forwarder.maxRetryElapsedTime, true, time.Minute, "SchemaForwarder.maxRetryElapsedTime")
-	config.RegisterInt64ConfigVariable(10*bytesize.KB, &forwarder.maxSampleSize, true, 1, "SchemaForwarder.maxSampleSize")
+	forwarder.setupReloadableVars()
 
 	return &forwarder
+}
+
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
+func (jf *JobsForwarder) setupReloadableVars() {
+	config.RegisterDurationConfigVariable(10, &jf.initialRetryInterval, true, time.Second, "SchemaForwarder.initialRetryInterval")
+	config.RegisterDurationConfigVariable(60, &jf.maxRetryInterval, true, time.Second, "SchemaForwarder.maxRetryInterval")
+	config.RegisterDurationConfigVariable(60, &jf.maxRetryElapsedTime, true, time.Minute, "SchemaForwarder.maxRetryElapsedTime")
+	config.RegisterInt64ConfigVariable(10*bytesize.KB, &jf.maxSampleSize, true, 1, "SchemaForwarder.maxSampleSize")
 }
 
 // Start starts the forwarder which will start forwarding jobs from database to the appropriate pulsar topics

--- a/services/db/normalModeHandler.go
+++ b/services/db/normalModeHandler.go
@@ -15,13 +15,12 @@ func (handler *NormalModeHandler) RecordAppStart(currTime int64) {
 }
 
 func (handler *NormalModeHandler) HasThresholdReached() bool {
-	config.RegisterIntConfigVariable(5, &maxCrashes, false, 1, "recovery.normal.crashThreshold")
-	config.RegisterIntConfigVariable(300, &duration, false, 1, "recovery.normal.durationInS")
+	maxCrashes = config.GetIntVar(5, 1, "recovery.normal.crashThreshold")
+	duration = config.GetIntVar(300, 1, "recovery.normal.durationInS")
 	return CheckOccurrences(handler.recoveryData.StartTimes, maxCrashes, duration)
 }
 
-func (*NormalModeHandler) Handle() {
-}
+func (*NormalModeHandler) Handle() {}
 
 type NormalModeHandler struct {
 	recoveryData *RecoveryDataT

--- a/services/db/recovery.go
+++ b/services/db/recovery.go
@@ -42,7 +42,7 @@ type RecoveryDataT struct {
 var pkgLogger logger.Logger
 
 func Init() {
-	config.RegisterStringConfigVariable("/tmp/recovery_data.json", &storagePath, false, "recovery.storagePath")
+	storagePath = config.GetStringVar("/tmp/recovery_data.json", "recovery.storagePath")
 	pkgLogger = logger.NewLogger().Child("db").Child("recovery")
 }
 

--- a/services/debugger/cache/internal/badger/badger.go
+++ b/services/debugger/cache/internal/badger/badger.go
@@ -22,19 +22,20 @@ import (
 loadCacheConfig sets the properties of the cache after reading it from the config file.
 This gives a feature of hot readability as well.
 */
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func (e *Cache[E]) loadCacheConfig() {
 	config.RegisterDurationConfigVariable(5, &e.ttl, true, time.Minute, "LiveEvent.cache."+e.origin+".clearFreq", "LiveEvent.cache.ttl")
 	config.RegisterIntConfigVariable(100, &e.limiter, true, 1, "LiveEvent.cache."+e.origin+".limiter", "LiveEvent.cache.limiter")
-	config.RegisterDurationConfigVariable(1, &e.ticker, false, time.Minute, "LiveEvent.cache."+e.origin+".GCTime", "LiveEvent.cache.GCTime")
-	config.RegisterDurationConfigVariable(15, &e.queryTimeout, false, time.Second, "LiveEvent.cache."+e.origin+".queryTimeout", "LiveEvent.cache.queryTimeout")
-	config.RegisterFloat64ConfigVariable(0.5, &e.gcDiscardRatio, false, "LiveEvent.cache."+e.origin+".gcDiscardRatio", "LiveEvent.cache.gcDiscardRatio")
-	config.RegisterIntConfigVariable(5, &e.numMemtables, false, 1, "LiveEvent.cache."+e.origin+".NumMemtables", "LiveEvent.cache.NumMemtables")
-	config.RegisterIntConfigVariable(5, &e.numLevelZeroTables, false, 1, "LiveEvent.cache."+e.origin+".NumLevelZeroTables", "LiveEvent.cache.NumLevelZeroTables")
-	config.RegisterIntConfigVariable(15, &e.numLevelZeroTablesStall, false, 1, "LiveEvent.cache."+e.origin+".NumLevelZeroTablesStall", "LiveEvent.cache.NumLevelZeroTablesStall")
+	e.ticker = config.GetDurationVar(1, time.Minute, "LiveEvent.cache."+e.origin+".GCTime", "LiveEvent.cache.GCTime")
+	e.queryTimeout = config.GetDurationVar(15, time.Second, "LiveEvent.cache."+e.origin+".queryTimeout", "LiveEvent.cache.queryTimeout")
+	e.gcDiscardRatio = config.GetFloat64Var(0.5, "LiveEvent.cache."+e.origin+".gcDiscardRatio", "LiveEvent.cache.gcDiscardRatio")
+	e.numMemtables = config.GetIntVar(5, 1, "LiveEvent.cache."+e.origin+".NumMemtables", "LiveEvent.cache.NumMemtables")
+	e.numLevelZeroTables = config.GetIntVar(5, 1, "LiveEvent.cache."+e.origin+".NumLevelZeroTables", "LiveEvent.cache.NumLevelZeroTables")
+	e.numLevelZeroTablesStall = config.GetIntVar(15, 1, "LiveEvent.cache."+e.origin+".NumLevelZeroTablesStall", "LiveEvent.cache.NumLevelZeroTablesStall")
 	// Using the maximum value threshold: (1 << 20) == 1048576 (1MB)
-	config.RegisterInt64ConfigVariable(1<<20, &e.valueThreshold, false, 1, "LiveEvent.cache."+e.origin+".ValueThreshold", "LiveEvent.cache.ValueThreshold")
-	config.RegisterBoolConfigVariable(false, &e.syncWrites, false, "LiveEvent.cache."+e.origin+".SyncWrites", "LiveEvent.cache.SyncWrites")
-	config.RegisterBoolConfigVariable(true, &e.cleanupOnStartup, false, "LiveEvent.cache."+e.origin+".CleanupOnStartup", "LiveEvent.cache.CleanupOnStartup")
+	e.valueThreshold = config.GetInt64Var(1<<20, 1, "LiveEvent.cache."+e.origin+".ValueThreshold", "LiveEvent.cache.ValueThreshold")
+	e.syncWrites = config.GetBoolVar(false, "LiveEvent.cache."+e.origin+".SyncWrites", "LiveEvent.cache.SyncWrites")
+	e.cleanupOnStartup = config.GetBoolVar(true, "LiveEvent.cache."+e.origin+".CleanupOnStartup", "LiveEvent.cache.CleanupOnStartup")
 }
 
 /*

--- a/services/debugger/cache/internal/memory/memory.go
+++ b/services/debugger/cache/internal/memory/memory.go
@@ -17,6 +17,7 @@ type cacheItem[E any] struct {
 loadCacheConfig sets the properties of the cache after reading it from the config file.
 This gives a feature of hot readability as well.
 */
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func (c *Cache[E]) loadCacheConfig() {
 	if c.size == 0 {
 		config.RegisterIntConfigVariable(3, &c.size, true, 1, "LiveEvent.cache.size")

--- a/services/debugger/source/eventUploader_test.go
+++ b/services/debugger/source/eventUploader_test.go
@@ -1,4 +1,4 @@
-package sourcedebugger_test
+package sourcedebugger
 
 import (
 	"context"
@@ -7,16 +7,13 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
-
 	"github.com/tidwall/gjson"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/backend-config"
-	sourcedebugger "github.com/rudderlabs/rudder-server/services/debugger/source"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 )
@@ -37,7 +34,7 @@ type eventUploaderContext struct {
 	mockBackendConfig *mocksBackendConfig.MockBackendConfig
 }
 
-// Initiaze mocks and common expectations
+// Initialize mocks and common expectations
 func (c *eventUploaderContext) Setup() {
 	c.mockCtrl = gomock.NewController(GinkgoT())
 	c.mockBackendConfig = mocksBackendConfig.NewMockBackendConfig(c.mockCtrl)
@@ -59,7 +56,7 @@ var _ = Describe("eventUploader", func() {
 	var (
 		c              *eventUploaderContext
 		recordingEvent string
-		h              sourcedebugger.SourceDebugger
+		h              SourceDebugger
 	)
 
 	BeforeEach(func() {
@@ -88,7 +85,7 @@ var _ = Describe("eventUploader", func() {
 			config.Reset()
 			config.Set("RUDDER_TMPDIR", path.Join(GinkgoT().TempDir(), rand.String(10)))
 			config.Set("LiveEvent.cache.GCTime", "1s")
-			h, err = sourcedebugger.NewHandle(c.mockBackendConfig, sourcedebugger.WithDisableEventUploads(false))
+			h, err = NewHandle(c.mockBackendConfig)
 			Expect(err).To(BeNil())
 		})
 
@@ -98,8 +95,9 @@ var _ = Describe("eventUploader", func() {
 
 		It("returns false if disableEventUploads is true", func() {
 			h.Stop()
-			h, err := sourcedebugger.NewHandle(c.mockBackendConfig, sourcedebugger.WithDisableEventUploads(true))
+			h, err := NewHandle(c.mockBackendConfig)
 			Expect(err).To(BeNil())
+			h.(*Handle).disableEventUploads = config.GetReloadableBoolVar(true, rand.UniqueString(10))
 			Expect(h.RecordEvent(sampleWriteKey, []byte(recordingEvent))).To(BeFalse())
 		})
 
@@ -110,10 +108,10 @@ var _ = Describe("eventUploader", func() {
 		It("transforms payload properly", func() {
 			recordingEvent0 := `{"receivedAt":"2021-08-03T17:26:","writeKey":"1vWezJfHKkbUHexNepDsGcSVWae","requestIP":"[::1]",  "batch": [{"anonymousId":"anon_id","channel":"android-sdk","context":{"app":{"build":"1","name":"RudderAndroidClient","namespace":"com.rudderlabs.android.sdk","version":"1.0"},"device":{"id":"49e4bdd1c280bc00","manufacturer":"Google","model":"Android SDK built for x86","name":"generic_x86"},"library":{"name":"com.rudderstack.android.sdk.core"},"locale":"en-US","network":{"carrier":"Android"},"screen":{"density":420,"height":1794,"width":1080},"traits":{"anonymousId":"49e4bdd1c280bc00"},"user_agent":"Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.075)"},"event":{"name": "Demo Track"},"integrations":{"All":true},"messageId":"7a355fdd-0325-4778-9905-b43f586acdd4","originalTimestamp":"2019-08-12T05:08:30.909Z","properties":{"category":"Demo Category","floatVal":4.501,"label":"Demo Label","testArray":[{"id":"elem1","value":"e1"},{"id":"elem2","value":"e2"}],"testMap":{"t1":"a","t2":4},"value":5},"rudderId":"90ca6da0-292e-4e79-9880-f8009e0ae4a3","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}]}`
 			recordingEvent = `{"receivedAt":"2021-08-03T17:26:00.279+05:30","writeKey":"1vWezJfHKkbUHexNepDsGcSVWae","requestIP":"[::1]",  "batch": [{"anonymousId":"anon_id","channel":"android-sdk","context":{"app":{"build":"1","name":"RudderAndroidClient","namespace":"com.rudderlabs.android.sdk","version":"1.0"},"device":{"id":"49e4bdd1c280bc00","manufacturer":"Google","model":"Android SDK built for x86","name":"generic_x86"},"library":{"name":"com.rudderstack.android.sdk.core"},"locale":"en-US","network":{"carrier":"Android"},"screen":{"density":420,"height":1794,"width":1080},"traits":{"anonymousId":"49e4bdd1c280bc00"},"user_agent":"Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.075)"},"event":"Demo Track","integrations":{"All":true},"messageId":"7a355fdd-0325-4778-9905-b43f586acdd4","originalTimestamp":"2019-08-12T05:08:30.909Z","properties":{"category":"Demo Category","floatVal":4.501,"label":"Demo Label","testArray":[{"id":"elem1","value":"e1"},{"id":"elem2","value":"e2"}],"testMap":{"t1":"a","t2":4},"value":5},"rudderId":"90ca6da0-292e-4e79-9880-f8009e0ae4a3","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}]}`
-			eventUploader := sourcedebugger.NewEventUploader(logger.NOP)
-			var payload []*sourcedebugger.GatewayEventBatchT
-			payload = append(payload, &sourcedebugger.GatewayEventBatchT{WriteKey: WriteKeyEnabled, EventBatch: []byte(recordingEvent0)})
-			payload = append(payload, &sourcedebugger.GatewayEventBatchT{WriteKey: WriteKeyEnabled, EventBatch: []byte(recordingEvent)})
+			eventUploader := NewEventUploader(logger.NOP)
+			var payload []*GatewayEventBatchT
+			payload = append(payload, &GatewayEventBatchT{WriteKey: WriteKeyEnabled, EventBatch: []byte(recordingEvent0)})
+			payload = append(payload, &GatewayEventBatchT{WriteKey: WriteKeyEnabled, EventBatch: []byte(recordingEvent)})
 			rawJson, err := eventUploader.Transform(payload)
 			Expect(err).To(BeNil())
 			Expect(gjson.GetBytes(rawJson, `1vWezJfHKkbUHexNepDsGcSVWae.0.eventName`).String()).To(Equal("{\"name\":\"Demo Track\"}"))
@@ -123,9 +121,9 @@ var _ = Describe("eventUploader", func() {
 
 		It("ignores improperly built payload", func() {
 			recordingEvent0 := `{"receivedAt":"2021-08-03T17:26:","writeKey":"1vWezJfHKkbUHexNepDsGcSVWae","requestIP":"[::1]",  "batch": [{"anonymousId":"anon_id","channel":"android-sdk","context":{"app":{"build":"1","name":"RudderAndroidClient","namespace":"com.rudderlabs.android.sdk","version":"1.0"},"device":{"id":"49e4bdd1c280bc00","manufacturer":"Google","model":"Android SDK built for x86","name":"generic_x86"},"library":{"name":"com.rudderstack.android.sdk.core"},"locale":"en-US","network":{"carrier":"Android"},"screen":{"density":420,"height":1794,"width":1080},"traits":{"anonymousId":"49e4bdd1c280bc00"},"user_agent":"Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.075)"},"event":{"name": "Demo Track"},"integrations":{"All":true},"messageId":"7a355fdd-0325-4778-9905-b43f586acdd4","originalTimestamp":"2019-08-12T05:08:30.909Z","properties":{"category":"Demo Category","floatVal":4.501,"label":"Demo Label","testArray":[{"id":"elem1","value":"e1"},{"id":"elem2","value":"e2"}],"testMap":{"t1":"a","t2":4},"value":5},"rudderId":"90ca6da0-292e-4e79-9880-f8009e0ae4a3","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}`
-			eventUploader := sourcedebugger.NewEventUploader(logger.NOP)
-			var payload []*sourcedebugger.GatewayEventBatchT
-			payload = append(payload, &sourcedebugger.GatewayEventBatchT{WriteKey: WriteKeyEnabled, EventBatch: []byte(recordingEvent0)})
+			eventUploader := NewEventUploader(logger.NOP)
+			var payload []*GatewayEventBatchT
+			payload = append(payload, &GatewayEventBatchT{WriteKey: WriteKeyEnabled, EventBatch: []byte(recordingEvent0)})
 			rawJson, err := eventUploader.Transform(payload)
 			Expect(err).To(BeNil())
 			Expect(string(rawJson)).To(Equal(`{"version":"v2"}`))
@@ -145,7 +143,7 @@ var _ = Describe("eventUploader", func() {
 			config.Set("SourceDebugger.cacheType", 0)
 			config.Set("RUDDER_TMPDIR", path.Join(GinkgoT().TempDir(), rand.String(10)))
 			config.Set("LiveEvent.cache.GCTime", "1s")
-			h, err = sourcedebugger.NewHandle(c.mockBackendConfig, sourcedebugger.WithDisableEventUploads(false))
+			h, err = NewHandle(c.mockBackendConfig)
 			Expect(err).To(BeNil())
 		})
 
@@ -155,8 +153,9 @@ var _ = Describe("eventUploader", func() {
 
 		It("returns false if disableEventUploads is true", func() {
 			h.Stop()
-			h, err := sourcedebugger.NewHandle(c.mockBackendConfig, sourcedebugger.WithDisableEventUploads(true))
+			h, err := NewHandle(c.mockBackendConfig)
 			Expect(err).To(BeNil())
+			h.(*Handle).disableEventUploads = config.GetReloadableBoolVar(true, rand.UniqueString(10))
 			Expect(h.RecordEvent(sampleWriteKey, []byte(recordingEvent))).To(BeFalse())
 		})
 
@@ -167,10 +166,10 @@ var _ = Describe("eventUploader", func() {
 		It("transforms payload properly", func() {
 			recordingEvent0 := `{"receivedAt":"2021-08-03T17:26:","writeKey":"1vWezJfHKkbUHexNepDsGcSVWae","requestIP":"[::1]",  "batch": [{"anonymousId":"anon_id","channel":"android-sdk","context":{"app":{"build":"1","name":"RudderAndroidClient","namespace":"com.rudderlabs.android.sdk","version":"1.0"},"device":{"id":"49e4bdd1c280bc00","manufacturer":"Google","model":"Android SDK built for x86","name":"generic_x86"},"library":{"name":"com.rudderstack.android.sdk.core"},"locale":"en-US","network":{"carrier":"Android"},"screen":{"density":420,"height":1794,"width":1080},"traits":{"anonymousId":"49e4bdd1c280bc00"},"user_agent":"Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.075)"},"event":{"name": "Demo Track"},"integrations":{"All":true},"messageId":"7a355fdd-0325-4778-9905-b43f586acdd4","originalTimestamp":"2019-08-12T05:08:30.909Z","properties":{"category":"Demo Category","floatVal":4.501,"label":"Demo Label","testArray":[{"id":"elem1","value":"e1"},{"id":"elem2","value":"e2"}],"testMap":{"t1":"a","t2":4},"value":5},"rudderId":"90ca6da0-292e-4e79-9880-f8009e0ae4a3","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}]}`
 			recordingEvent = `{"receivedAt":"2021-08-03T17:26:00.279+05:30","writeKey":"1vWezJfHKkbUHexNepDsGcSVWae","requestIP":"[::1]",  "batch": [{"anonymousId":"anon_id","channel":"android-sdk","context":{"app":{"build":"1","name":"RudderAndroidClient","namespace":"com.rudderlabs.android.sdk","version":"1.0"},"device":{"id":"49e4bdd1c280bc00","manufacturer":"Google","model":"Android SDK built for x86","name":"generic_x86"},"library":{"name":"com.rudderstack.android.sdk.core"},"locale":"en-US","network":{"carrier":"Android"},"screen":{"density":420,"height":1794,"width":1080},"traits":{"anonymousId":"49e4bdd1c280bc00"},"user_agent":"Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.075)"},"event":"Demo Track","integrations":{"All":true},"messageId":"7a355fdd-0325-4778-9905-b43f586acdd4","originalTimestamp":"2019-08-12T05:08:30.909Z","properties":{"category":"Demo Category","floatVal":4.501,"label":"Demo Label","testArray":[{"id":"elem1","value":"e1"},{"id":"elem2","value":"e2"}],"testMap":{"t1":"a","t2":4},"value":5},"rudderId":"90ca6da0-292e-4e79-9880-f8009e0ae4a3","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}]}`
-			eventUploader := sourcedebugger.NewEventUploader(logger.NOP)
-			var payload []*sourcedebugger.GatewayEventBatchT
-			payload = append(payload, &sourcedebugger.GatewayEventBatchT{WriteKey: WriteKeyEnabled, EventBatch: []byte(recordingEvent0)})
-			payload = append(payload, &sourcedebugger.GatewayEventBatchT{WriteKey: WriteKeyEnabled, EventBatch: []byte(recordingEvent)})
+			eventUploader := NewEventUploader(logger.NOP)
+			var payload []*GatewayEventBatchT
+			payload = append(payload, &GatewayEventBatchT{WriteKey: WriteKeyEnabled, EventBatch: []byte(recordingEvent0)})
+			payload = append(payload, &GatewayEventBatchT{WriteKey: WriteKeyEnabled, EventBatch: []byte(recordingEvent)})
 			rawJson, err := eventUploader.Transform(payload)
 			Expect(err).To(BeNil())
 			Expect(gjson.GetBytes(rawJson, `1vWezJfHKkbUHexNepDsGcSVWae.0.eventName`).String()).To(Equal("{\"name\":\"Demo Track\"}"))
@@ -180,9 +179,9 @@ var _ = Describe("eventUploader", func() {
 
 		It("ignores improperly built payload", func() {
 			recordingEvent0 := `{"receivedAt":"2021-08-03T17:26:","writeKey":"1vWezJfHKkbUHexNepDsGcSVWae","requestIP":"[::1]",  "batch": [{"anonymousId":"anon_id","channel":"android-sdk","context":{"app":{"build":"1","name":"RudderAndroidClient","namespace":"com.rudderlabs.android.sdk","version":"1.0"},"device":{"id":"49e4bdd1c280bc00","manufacturer":"Google","model":"Android SDK built for x86","name":"generic_x86"},"library":{"name":"com.rudderstack.android.sdk.core"},"locale":"en-US","network":{"carrier":"Android"},"screen":{"density":420,"height":1794,"width":1080},"traits":{"anonymousId":"49e4bdd1c280bc00"},"user_agent":"Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.075)"},"event":{"name": "Demo Track"},"integrations":{"All":true},"messageId":"7a355fdd-0325-4778-9905-b43f586acdd4","originalTimestamp":"2019-08-12T05:08:30.909Z","properties":{"category":"Demo Category","floatVal":4.501,"label":"Demo Label","testArray":[{"id":"elem1","value":"e1"},{"id":"elem2","value":"e2"}],"testMap":{"t1":"a","t2":4},"value":5},"rudderId":"90ca6da0-292e-4e79-9880-f8009e0ae4a3","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}`
-			eventUploader := sourcedebugger.NewEventUploader(logger.NOP)
-			var payload []*sourcedebugger.GatewayEventBatchT
-			payload = append(payload, &sourcedebugger.GatewayEventBatchT{WriteKey: WriteKeyEnabled, EventBatch: []byte(recordingEvent0)})
+			eventUploader := NewEventUploader(logger.NOP)
+			var payload []*GatewayEventBatchT
+			payload = append(payload, &GatewayEventBatchT{WriteKey: WriteKeyEnabled, EventBatch: []byte(recordingEvent0)})
 			rawJson, err := eventUploader.Transform(payload)
 			Expect(err).To(BeNil())
 			Expect(string(rawJson)).To(Equal(`{"version":"v2"}`))

--- a/services/debugger/transformation/transformationStatusUploader.go
+++ b/services/debugger/transformation/transformationStatusUploader.go
@@ -65,15 +65,13 @@ type UploadT struct {
 	Payload []*TransformStatusT `json:"payload"`
 }
 
-type Opt func(*Handle)
-
 var jsonfast = jsoniter.ConfigCompatibleWithStandardLibrary
 
 type Handle struct {
 	configBackendURL               string
 	started                        bool
-	disableTransformationUploads   bool
-	limitEventsInMemory            int
+	disableTransformationUploads   *config.Reloadable[bool]
+	limitEventsInMemory            *config.Reloadable[int]
 	uploader                       debugger.Uploader[*TransformStatusT]
 	log                            logger.Logger
 	transformationCacheMap         cache.Cache[TransformationStatusT]
@@ -85,12 +83,6 @@ type Handle struct {
 	done                           chan struct{}
 }
 
-func WithDisableTransformationStatusUploads(disableTransformationStatusUploads bool) func(h *Handle) {
-	return func(h *Handle) {
-		h.disableTransformationUploads = disableTransformationStatusUploads
-	}
-}
-
 type TransformationDebugger interface {
 	IsUploadEnabled(id string) bool
 	RecordTransformationStatus(transformStatus *TransformStatusT)
@@ -98,18 +90,25 @@ type TransformationDebugger interface {
 	Stop()
 }
 
-func NewHandle(backendConfig backendconfig.BackendConfig, opts ...Opt) (TransformationDebugger, error) {
+func NewHandle(backendConfig backendconfig.BackendConfig) (TransformationDebugger, error) {
 	h := &Handle{
 		configBackendURL: config.GetString("CONFIG_BACKEND_URL", "https://api.rudderstack.com"),
 		log:              logger.NewLogger().Child("debugger").Child("transformation"),
+		disableTransformationUploads: config.GetReloadableBoolVar(
+			false, "TransformationDebugger.disableTransformationStatusUploads",
+		),
+		limitEventsInMemory: config.GetReloadableIntVar(1, 1, "TransformationDebugger.limitEventsInMemory"),
 	}
-	var err error
-	config.RegisterBoolConfigVariable(false, &h.disableTransformationUploads, true, "TransformationDebugger.disableTransformationStatusUploads")
-	config.RegisterIntConfigVariable(1, &h.limitEventsInMemory, true, 1, "TransformationDebugger.limitEventsInMemory")
-	url := fmt.Sprintf("%s/dataplane/eventTransformStatus", h.configBackendURL)
-	transformationStatusUploader := &TransformationStatusUploader{}
 
-	cacheType := cache.CacheType(config.GetInt("TransformationDebugger.cacheType", int(cache.MemoryCacheType)))
+	var (
+		err                          error
+		url                          = fmt.Sprintf("%s/dataplane/eventTransformStatus", h.configBackendURL)
+		transformationStatusUploader = &TransformationStatusUploader{}
+		cacheType                    = cache.CacheType(config.GetInt(
+			"TransformationDebugger.cacheType", int(cache.MemoryCacheType),
+		))
+	)
+
 	h.transformationCacheMap, err = cache.New[TransformationStatusT](cacheType, "transformation", h.log)
 	if err != nil {
 		return nil, err
@@ -118,9 +117,6 @@ func NewHandle(backendConfig backendconfig.BackendConfig, opts ...Opt) (Transfor
 	h.uploader = debugger.New[*TransformStatusT](url, transformationStatusUploader)
 	h.uploader.Start()
 
-	for _, opt := range opts {
-		opt(h)
-	}
 	h.start(backendConfig)
 	return h, nil
 }
@@ -168,7 +164,7 @@ func (h *Handle) Stop() {
 // which will be processed by handleEvents.
 func (h *Handle) RecordTransformationStatus(transformStatus *TransformStatusT) {
 	// if disableTransformationUploads is true, return;
-	if !h.started || h.disableTransformationUploads {
+	if !h.started || h.disableTransformationUploads.Load() {
 		return
 	}
 	<-h.initialized
@@ -268,7 +264,7 @@ func (h *Handle) UploadTransformationStatus(tStatus *TransformationStatusT) bool
 	}()
 
 	// if disableTransformationUploads is true, return;
-	if h.disableTransformationUploads {
+	if h.disableTransformationUploads.Load() {
 		return false
 	}
 	<-h.initialized
@@ -279,7 +275,7 @@ func (h *Handle) UploadTransformationStatus(tStatus *TransformationStatusT) bool
 		} else {
 			err := h.transformationCacheMap.Update(
 				transformation.ID,
-				*(tStatus.Limit(h.limitEventsInMemory+1, transformation)),
+				*(tStatus.Limit(h.limitEventsInMemory.Load()+1, transformation)),
 			)
 			if err != nil {
 				h.log.Errorf("Error while updating transformation cache: %v", err)

--- a/services/debugger/transformation/transformationStatusUploader_test.go
+++ b/services/debugger/transformation/transformationStatusUploader_test.go
@@ -1,4 +1,4 @@
-package transformationdebugger_test
+package transformationdebugger
 
 import (
 	"context"
@@ -6,22 +6,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
-	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
-	"github.com/rudderlabs/rudder-server/processor/transformer"
-
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/backend-config"
-	transformationdebugger "github.com/rudderlabs/rudder-server/services/debugger/transformation"
+	"github.com/rudderlabs/rudder-server/processor/transformer"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
@@ -188,30 +184,30 @@ var _ = Describe("eventDeliveryStatusUploader", func() {
 
 	var (
 		c              *eventDeliveryStatusUploaderContext
-		h              transformationdebugger.TransformationDebugger
-		deliveryStatus transformationdebugger.TransformStatusT
+		h              TransformationDebugger
+		deliveryStatus TransformStatusT
 	)
 
 	BeforeEach(func() {
 		c = &eventDeliveryStatusUploaderContext{}
 		c.Setup()
-		deliveryStatus = transformationdebugger.TransformStatusT{
+		deliveryStatus = TransformStatusT{
 			DestinationID:    DestinationIDEnabledB,
 			SourceID:         SourceIDEnabled,
 			IsError:          false,
 			TransformationID: "enabled-id",
-			EventBefore: &transformationdebugger.EventBeforeTransform{
+			EventBefore: &EventBeforeTransform{
 				ReceivedAt: time.Now().String(),
 				EventName:  "event-name",
 				EventType:  "event-type",
 				Payload:    types.SingularEventT{},
 			},
-			EventsAfter: &transformationdebugger.EventsAfterTransform{
+			EventsAfter: &EventsAfterTransform{
 				ReceivedAt: time.Now().String(),
 				IsDropped:  false,
 				Error:      "",
 				StatusCode: 200,
-				EventPayloads: []*transformationdebugger.EventPayloadAfterTransform{
+				EventPayloads: []*EventPayloadAfterTransform{
 					{
 						EventName: "event-name",
 						EventType: "event-type",
@@ -231,7 +227,7 @@ var _ = Describe("eventDeliveryStatusUploader", func() {
 			var err error
 			config.Reset()
 			config.Set("RUDDER_TMPDIR", path.Join(GinkgoT().TempDir(), rand.String(10)))
-			h, err = transformationdebugger.NewHandle(c.mockBackendConfig, transformationdebugger.WithDisableTransformationStatusUploads(false))
+			h, err = NewHandle(c.mockBackendConfig)
 			Expect(err).To(BeNil())
 		})
 
@@ -241,15 +237,16 @@ var _ = Describe("eventDeliveryStatusUploader", func() {
 
 		It("returns false if disableEventDeliveryStatusUploads is true", func() {
 			h.Stop()
-			h, err := transformationdebugger.NewHandle(c.mockBackendConfig, transformationdebugger.WithDisableTransformationStatusUploads(true))
+			h, err := NewHandle(c.mockBackendConfig)
 			Expect(err).To(BeNil())
-			Expect(h.UploadTransformationStatus(&transformationdebugger.TransformationStatusT{})).To(BeFalse())
+			h.(*Handle).disableTransformationUploads = config.GetReloadableBoolVar(true, rand.UniqueString(10))
+			Expect(h.UploadTransformationStatus(&TransformationStatusT{})).To(BeFalse())
 		})
 
 		It("records events", func() {
 			eventuallyFunc := func() bool {
 				return h.UploadTransformationStatus(
-					&transformationdebugger.TransformationStatusT{
+					&TransformationStatusT{
 						Destination: &sampleBackendConfig.Sources[1].Destinations[1],
 						DestID:      sampleBackendConfig.Sources[1].Destinations[1].ID,
 						SourceID:    sampleBackendConfig.Sources[1].ID,
@@ -260,8 +257,8 @@ var _ = Describe("eventDeliveryStatusUploader", func() {
 		})
 
 		It("transforms payload properly", func() {
-			var edsUploader transformationdebugger.TransformationStatusUploader
-			var payload []*transformationdebugger.TransformStatusT
+			var edsUploader TransformationStatusUploader
+			var payload []*TransformStatusT
 			payload = append(payload, &deliveryStatus)
 			rawJSON, err := edsUploader.Transform(payload)
 			Expect(err).To(BeNil())
@@ -278,7 +275,7 @@ var _ = Describe("eventDeliveryStatusUploader", func() {
 			config.Reset()
 			config.Set("RUDDER_TMPDIR", path.Join(GinkgoT().TempDir(), rand.String(10)))
 			config.Set("TransformationDebugger.cacheType", 0)
-			h, err = transformationdebugger.NewHandle(c.mockBackendConfig, transformationdebugger.WithDisableTransformationStatusUploads(false))
+			h, err = NewHandle(c.mockBackendConfig)
 			Expect(err).To(BeNil())
 		})
 
@@ -288,15 +285,16 @@ var _ = Describe("eventDeliveryStatusUploader", func() {
 
 		It("returns false if disableEventDeliveryStatusUploads is true", func() {
 			h.Stop()
-			h, err := transformationdebugger.NewHandle(c.mockBackendConfig, transformationdebugger.WithDisableTransformationStatusUploads(true))
+			h, err := NewHandle(c.mockBackendConfig)
 			Expect(err).To(BeNil())
-			Expect(h.UploadTransformationStatus(&transformationdebugger.TransformationStatusT{})).To(BeFalse())
+			h.(*Handle).disableTransformationUploads = config.GetReloadableBoolVar(true, rand.UniqueString(10))
+			Expect(h.UploadTransformationStatus(&TransformationStatusT{})).To(BeFalse())
 		})
 
 		It("records events", func() {
 			eventuallyFunc := func() bool {
 				return h.UploadTransformationStatus(
-					&transformationdebugger.TransformationStatusT{
+					&TransformationStatusT{
 						Destination: &sampleBackendConfig.Sources[1].Destinations[1],
 						DestID:      sampleBackendConfig.Sources[1].Destinations[1].ID,
 						SourceID:    sampleBackendConfig.Sources[1].ID,
@@ -307,8 +305,8 @@ var _ = Describe("eventDeliveryStatusUploader", func() {
 		})
 
 		It("transforms payload properly", func() {
-			var edsUploader transformationdebugger.TransformationStatusUploader
-			var payload []*transformationdebugger.TransformStatusT
+			var edsUploader TransformationStatusUploader
+			var payload []*TransformStatusT
 			payload = append(payload, &deliveryStatus)
 			rawJSON, err := edsUploader.Transform(payload)
 			Expect(err).To(BeNil())
@@ -334,7 +332,7 @@ func TestLimit(t *testing.T) {
 		limit          = 1
 	)
 	t.Run("should limit the received transformation status", func(t *testing.T) {
-		tStatus := &transformationdebugger.TransformationStatusT{
+		tStatus := &TransformationStatusT{
 			Destination: &sampleBackendConfig.Sources[1].Destinations[1],
 			DestID:      sampleBackendConfig.Sources[1].Destinations[1].ID,
 			SourceID:    sampleBackendConfig.Sources[1].ID,

--- a/services/debugger/uploader.go
+++ b/services/debugger/uploader.go
@@ -55,6 +55,7 @@ func init() {
 	pkgLogger = logger.NewLogger().Child("debugger")
 }
 
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func (uploader *uploaderImpl[E]) Setup() {
 	// Number of events that are batched before sending events to control plane
 	config.RegisterIntConfigVariable(32, &uploader.maxBatchSize, true, 1, "Debugger.maxBatchSize")

--- a/services/dedup/dedup.go
+++ b/services/dedup/dedup.go
@@ -32,7 +32,9 @@ func DefaultPath() string {
 // New creates a new deduplication service. The service needs to be closed after use.
 func New(path string) Dedup {
 	var dedupWindow time.Duration
-	config.RegisterDurationConfigVariable(3600, &dedupWindow, true, time.Second, []string{"Dedup.dedupWindow", "Dedup.dedupWindowInS"}...)
+	// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
+	config.RegisterDurationConfigVariable(3600, &dedupWindow, true, time.Second, "Dedup.dedupWindow", "Dedup.dedupWindowInS")
+
 	log := logger.NewLogger().Child("dedup")
 	defer func() {
 		// TODO : Remove this after badgerdb v2 is completely removed

--- a/services/diagnostics/diagnostics.go
+++ b/services/diagnostics/diagnostics.go
@@ -72,17 +72,17 @@ func Init() {
 }
 
 func loadConfig() {
-	config.RegisterBoolConfigVariable(true, &EnableDiagnostics, false, "Diagnostics.enableDiagnostics")
-	config.RegisterStringConfigVariable("https://rudderstack-dataplane.rudderstack.com", &endpoint, false, "Diagnostics.endpoint")
-	config.RegisterStringConfigVariable("1aWPBIROQvFYW9FHxgc03nUsLza", &writekey, false, "Diagnostics.writekey")
-	config.RegisterBoolConfigVariable(true, &EnableServerStartMetric, false, "Diagnostics.enableServerStartMetric")
-	config.RegisterBoolConfigVariable(true, &EnableConfigIdentifyMetric, false, "Diagnostics.enableConfigIdentifyMetric")
-	config.RegisterBoolConfigVariable(true, &EnableServerStartedMetric, false, "Diagnostics.enableServerStartedMetric")
-	config.RegisterBoolConfigVariable(true, &EnableConfigProcessedMetric, false, "Diagnostics.enableConfigProcessedMetric")
-	config.RegisterBoolConfigVariable(true, &EnableGatewayMetric, false, "Diagnostics.enableGatewayMetric")
-	config.RegisterBoolConfigVariable(true, &EnableRouterMetric, false, "Diagnostics.enableRouterMetric")
-	config.RegisterBoolConfigVariable(true, &EnableBatchRouterMetric, false, "Diagnostics.enableBatchRouterMetric")
-	config.RegisterBoolConfigVariable(true, &EnableDestinationFailuresMetric, false, "Diagnostics.enableDestinationFailuresMetric")
+	EnableDiagnostics = config.GetBoolVar(true, "Diagnostics.enableDiagnostics")
+	endpoint = config.GetStringVar("https://rudderstack-dataplane.rudderstack.com", "Diagnostics.endpoint")
+	writekey = config.GetStringVar("1aWPBIROQvFYW9FHxgc03nUsLza", "Diagnostics.writekey")
+	EnableServerStartMetric = config.GetBoolVar(true, "Diagnostics.enableServerStartMetric")
+	EnableConfigIdentifyMetric = config.GetBoolVar(true, "Diagnostics.enableConfigIdentifyMetric")
+	EnableServerStartedMetric = config.GetBoolVar(true, "Diagnostics.enableServerStartedMetric")
+	EnableConfigProcessedMetric = config.GetBoolVar(true, "Diagnostics.enableConfigProcessedMetric")
+	EnableGatewayMetric = config.GetBoolVar(true, "Diagnostics.enableGatewayMetric")
+	EnableRouterMetric = config.GetBoolVar(true, "Diagnostics.enableRouterMetric")
+	EnableBatchRouterMetric = config.GetBoolVar(true, "Diagnostics.enableBatchRouterMetric")
+	EnableDestinationFailuresMetric = config.GetBoolVar(true, "Diagnostics.enableDestinationFailuresMetric")
 	Diagnostics = newDiagnostics()
 }
 

--- a/services/pgnotifier/pgnotifier.go
+++ b/services/pgnotifier/pgnotifier.go
@@ -26,8 +26,8 @@ var (
 	queueName          string
 	maxAttempt         int
 	trackBatchInterval time.Duration
-	maxPollSleep       time.Duration
-	jobOrphanTimeout   time.Duration
+	maxPollSleep       *config.Reloadable[time.Duration]
+	jobOrphanTimeout   *config.Reloadable[time.Duration]
 	pkgLogger          logger.Logger
 )
 
@@ -108,10 +108,10 @@ func loadPGNotifierConfig() {
 	pgNotifierDBPort = config.GetInt("PGNOTIFIER_DB_PORT", 5432)
 	pgNotifierDBPassword = config.GetString("PGNOTIFIER_DB_PASSWORD", "ubuntu") // Reading secrets from
 	pgNotifierDBSSLMode = config.GetString("PGNOTIFIER_DB_SSL_MODE", "disable")
-	config.RegisterIntConfigVariable(3, &maxAttempt, false, 1, "PgNotifier.maxAttempt")
+	maxAttempt = config.GetIntVar(3, 1, "PgNotifier.maxAttempt")
 	trackBatchInterval = time.Duration(config.GetInt("PgNotifier.trackBatchIntervalInS", 2)) * time.Second
-	config.RegisterDurationConfigVariable(5000, &maxPollSleep, true, time.Millisecond, "PgNotifier.maxPollSleep")
-	config.RegisterDurationConfigVariable(120, &jobOrphanTimeout, true, time.Second, "PgNotifier.jobOrphanTimeout")
+	maxPollSleep = config.GetReloadableDurationVar(5000, time.Millisecond, "PgNotifier.maxPollSleep")
+	jobOrphanTimeout = config.GetReloadableDurationVar(120, time.Second, "PgNotifier.jobOrphanTimeout")
 }
 
 // New Given default connection info return pg notifier object from it
@@ -613,8 +613,8 @@ func (notifier *PGNotifier) Subscribe(ctx context.Context, workerId string, jobs
 				pollSleep = time.Duration(0)
 			} else {
 				pollSleep = 2*pollSleep + time.Duration(rand.Intn(100))*time.Millisecond
-				if pollSleep > maxPollSleep {
-					pollSleep = maxPollSleep
+				if pollSleep > maxPollSleep.Load() {
+					pollSleep = maxPollSleep.Load()
 				}
 			}
 			select {
@@ -678,7 +678,7 @@ func (notifier *PGNotifier) RunMaintenanceWorker(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-time.After(jobOrphanTimeout / 5):
+		case <-time.After(jobOrphanTimeout.Load() / 5):
 		}
 	}
 	for {
@@ -705,7 +705,7 @@ func (notifier *PGNotifier) RunMaintenanceWorker(ctx context.Context) error {
 			GetCurrentSQLTimestamp(),
 			WaitingState,
 			ExecutingState,
-			int(jobOrphanTimeout/time.Second),
+			int(jobOrphanTimeout.Load()/time.Second),
 		)
 		pkgLogger.Debugf("PgNotifier: re-triggering zombie jobs: %v", stmt)
 		rows, err := notifier.db.Query(stmt)
@@ -732,7 +732,7 @@ func (notifier *PGNotifier) RunMaintenanceWorker(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-time.After(jobOrphanTimeout / 5):
+		case <-time.After(jobOrphanTimeout.Load() / 5):
 		}
 	}
 }

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -199,7 +199,7 @@ var (
 	kafkaBatchSize                       = defaultBatchSize
 	kafkaBatchingEnabled                 bool
 	kafkaCompression                     client.Compression
-	allowReqsWithoutUserIDAndAnonymousID bool
+	allowReqsWithoutUserIDAndAnonymousID *config.Reloadable[bool]
 
 	kafkaStats managerStats
 	pkgLogger  logger
@@ -223,27 +223,16 @@ func Init() {
 		}
 	}
 
-	config.RegisterDurationConfigVariable(
-		10, &kafkaDialTimeout, false, time.Second,
-		[]string{"Router.kafkaDialTimeout", "Router.kafkaDialTimeoutInSec"}...,
+	kafkaDialTimeout = config.GetDurationVar(10, time.Second, "Router.kafkaDialTimeout", "Router.kafkaDialTimeoutInSec")
+	kafkaReadTimeout = config.GetDurationVar(2, time.Second, "Router.kafkaReadTimeout", "Router.kafkaReadTimeoutInSec")
+	kafkaWriteTimeout = config.GetDurationVar(2, time.Second, "Router.kafkaWriteTimeout", "Router.kafkaWriteTimeoutInSec")
+	kafkaBatchTimeout = config.GetDurationVar(
+		int64(defaultBatchTimeout)/int64(time.Second), time.Second,
+		"Router.kafkaBatchTimeout", "Router.kafkaBatchTimeoutInSec",
 	)
-	config.RegisterDurationConfigVariable(
-		2, &kafkaReadTimeout, false, time.Second,
-		[]string{"Router.kafkaReadTimeout", "Router.kafkaReadTimeoutInSec"}...,
-	)
-	config.RegisterDurationConfigVariable(
-		2, &kafkaWriteTimeout, false, time.Second,
-		[]string{"Router.kafkaWriteTimeout", "Router.kafkaWriteTimeoutInSec"}...,
-	)
-	config.RegisterDurationConfigVariable(
-		int64(defaultBatchTimeout)/int64(time.Second), &kafkaBatchTimeout, false, time.Second,
-		[]string{"Router.kafkaBatchTimeout", "Router.kafkaBatchTimeoutInSec"}...,
-	)
-	config.RegisterIntConfigVariable(defaultBatchSize, &kafkaBatchSize, false, 1, "Router.kafkaBatchSize")
-	config.RegisterBoolConfigVariable(false, &kafkaBatchingEnabled, false, "Router.KAFKA.enableBatching")
-	config.RegisterBoolConfigVariable(
-		false, &allowReqsWithoutUserIDAndAnonymousID, true, "Gateway.allowReqsWithoutUserIDAndAnonymousID",
-	)
+	kafkaBatchSize = config.GetIntVar(defaultBatchSize, 1, "Router.kafkaBatchSize")
+	kafkaBatchingEnabled = config.GetBoolVar(false, "Router.KAFKA.enableBatching")
+	allowReqsWithoutUserIDAndAnonymousID = config.GetReloadableBoolVar(false, "Gateway.allowReqsWithoutUserIDAndAnonymousID")
 
 	pkgLogger = rslogger.NewLogger().Child("streammanager").Child("kafka")
 
@@ -581,7 +570,7 @@ func prepareBatchOfMessages(batch []map[string]interface{}, timestamp time.Time,
 			continue
 		}
 		userID, ok := data["userId"].(string)
-		if !ok && !allowReqsWithoutUserIDAndAnonymousID {
+		if !ok && !allowReqsWithoutUserIDAndAnonymousID.Load() {
 			kafkaStats.missingUserID.Increment()
 			pkgLogger.Errorf("batch from topic %s is missing the userId attribute", topic)
 			continue

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+
 	"github.com/linkedin/goavro/v2"
 	"github.com/ory/dockertest/v3"
 	"github.com/segmentio/kafka-go"
@@ -513,6 +515,7 @@ func TestPrepareBatchOfMessages(t *testing.T) {
 		missingMessage:   mockSkippedDueToMessage,
 		prepareBatchTime: mockPrepareBatchTime,
 	}
+	allowReqsWithoutUserIDAndAnonymousID = config.GetReloadableBoolVar(false, rand.UniqueString(10))
 
 	t.Run("nil", func(t *testing.T) {
 		mockPrepareBatchTime.EXPECT().SendTiming(sinceDuration).Times(1)
@@ -573,7 +576,7 @@ func TestPrepareBatchOfMessages(t *testing.T) {
 		mockPrepareBatchTime.EXPECT().SendTiming(sinceDuration).Times(1)
 
 		now := time.Now()
-		allowReqsWithoutUserIDAndAnonymousID = true
+		allowReqsWithoutUserIDAndAnonymousID = config.GetReloadableBoolVar(true, rand.UniqueString(10))
 		data := []map[string]interface{}{
 			{"not-interesting": "some value", "topic": "some-topic"},
 			{"message": "msg01", "topic": "some-topic"},

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -98,7 +98,7 @@ func init() {
 
 func Init() {
 	pkgLogger = logger.NewLogger().Child("utils").Child("misc")
-	config.RegisterStringConfigVariable("/tmp/error_store.json", &errorStorePath, false, "recovery.errorStorePath")
+	errorStorePath = config.GetStringVar("/tmp/error_store.json", "recovery.errorStorePath")
 	reservedFolderPaths = GetReservedFolderPaths()
 }
 

--- a/warehouse/archive/archiver.go
+++ b/warehouse/archive/archiver.go
@@ -56,10 +56,10 @@ type Archiver struct {
 	tenantManager *multitenant.Manager
 
 	config struct {
-		archiveUploadRelatedRecords bool
-		uploadsArchivalTimeInDays   int
-		archiverTickerTime          time.Duration
-		backupRowsBatchSize         int
+		archiveUploadRelatedRecords *config.Reloadable[bool]
+		uploadsArchivalTimeInDays   *config.Reloadable[int]
+		archiverTickerTime          *config.Reloadable[time.Duration]
+		backupRowsBatchSize         *config.Reloadable[int]
 	}
 
 	archiveFailedStat stats.Measurement
@@ -82,10 +82,10 @@ func New(
 		tenantManager: tenantManager,
 	}
 
-	conf.RegisterBoolConfigVariable(true, &a.config.archiveUploadRelatedRecords, true, "Warehouse.archiveUploadRelatedRecords")
-	conf.RegisterIntConfigVariable(5, &a.config.uploadsArchivalTimeInDays, true, 1, "Warehouse.uploadsArchivalTimeInDays")
-	conf.RegisterIntConfigVariable(100, &a.config.backupRowsBatchSize, true, 1, "Warehouse.Archiver.backupRowsBatchSize")
-	conf.RegisterDurationConfigVariable(360, &a.config.archiverTickerTime, true, time.Minute, []string{"Warehouse.archiverTickerTime", "Warehouse.archiverTickerTimeInMin"}...) // default 6 hours
+	a.config.archiveUploadRelatedRecords = config.GetReloadableBoolVar(true, "Warehouse.archiveUploadRelatedRecords")
+	a.config.uploadsArchivalTimeInDays = config.GetReloadableIntVar(5, 1, "Warehouse.uploadsArchivalTimeInDays")
+	a.config.backupRowsBatchSize = config.GetReloadableIntVar(100, 1, "Warehouse.Archiver.backupRowsBatchSize")
+	a.config.archiverTickerTime = config.GetReloadableDurationVar(360, time.Minute, "Warehouse.archiverTickerTime", "Warehouse.archiverTickerTimeInMin") // default 6 hours
 
 	a.archiveFailedStat = a.stats.NewStat("warehouse.archiver.archiveFailed", stats.CountType)
 
@@ -149,7 +149,7 @@ func (a *Archiver) backupRecords(ctx context.Context, args backupRecordsArgs) (b
 	)
 	tableJSONArchiver := tablearchiver.TableJSONArchiver{
 		DbHandle:      a.db,
-		Pagination:    a.config.backupRowsBatchSize,
+		Pagination:    a.config.backupRowsBatchSize.Load(),
 		QueryTemplate: tmpl,
 		OutputPath:    path,
 		FileManager:   fManager,
@@ -220,7 +220,7 @@ func (a *Archiver) Do(ctx context.Context) error {
 	skipWorkspaceIDs = append(skipWorkspaceIDs, a.tenantManager.DegradedWorkspaces()...)
 
 	rows, err := a.db.QueryContext(ctx, sqlStatement,
-		fmt.Sprintf("%d DAY", a.config.uploadsArchivalTimeInDays),
+		fmt.Sprintf("%d DAY", a.config.uploadsArchivalTimeInDays.Load()),
 		model.ExportedData,
 		pq.Array(skipWorkspaceIDs),
 	)

--- a/warehouse/archive/cron.go
+++ b/warehouse/archive/cron.go
@@ -11,8 +11,8 @@ func CronArchiver(ctx context.Context, a *Archiver) {
 		case <-ctx.Done():
 			a.log.Infof("context is cancelled, stopped running archiving")
 			return
-		case <-time.After(a.config.archiverTickerTime):
-			if a.config.archiveUploadRelatedRecords {
+		case <-time.After(a.config.archiverTickerTime.Load()):
+			if a.config.archiveUploadRelatedRecords.Load() {
 				err := a.Do(ctx)
 				if err != nil {
 					a.log.Errorf(`Error archiving uploads: %v`, err)

--- a/warehouse/constraint.go
+++ b/warehouse/constraint.go
@@ -64,6 +64,8 @@ func newConstraintsManager(conf *config.Config) *constraintsManager {
 			},
 		},
 	}
+
+	// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 	conf.RegisterBoolConfigVariable(true, &cm.enableConstraintsViolations, true, "Warehouse.enableConstraintsViolations")
 
 	return cm

--- a/warehouse/router.go
+++ b/warehouse/router.go
@@ -168,18 +168,13 @@ func newRouter(
 
 	whName := warehouseutils.WHDestNameMap[destType]
 
-	r.conf.RegisterIntConfigVariable(8, &r.config.noOfWorkers, true, 1, fmt.Sprintf(`Warehouse.%v.noOfWorkers`, whName), "Warehouse.noOfWorkers")
-	r.conf.RegisterIntConfigVariable(1, &r.config.maxConcurrentUploadJobs, false, 1, fmt.Sprintf(`Warehouse.%v.maxConcurrentUploadJobs`, whName))
-	r.conf.RegisterIntConfigVariable(8, &r.config.maxParallelJobCreation, true, 1, "Warehouse.maxParallelJobCreation")
-	r.conf.RegisterDurationConfigVariable(5, &r.config.waitForWorkerSleep, false, time.Second, []string{"Warehouse.waitForWorkerSleep", "Warehouse.waitForWorkerSleepInS"}...)
-	r.conf.RegisterDurationConfigVariable(5, &r.config.uploadAllocatorSleep, false, time.Second, []string{"Warehouse.uploadAllocatorSleep", "Warehouse.uploadAllocatorSleepInS"}...)
-	r.conf.RegisterDurationConfigVariable(5, &r.config.mainLoopSleep, true, time.Second, []string{"Warehouse.mainLoopSleep", "Warehouse.mainLoopSleepInS"}...)
-	r.conf.RegisterIntConfigVariable(960, &r.config.stagingFilesBatchSize, true, 1, "Warehouse.stagingFilesBatchSize")
-	r.conf.RegisterDurationConfigVariable(30, &r.config.uploadStatusTrackFrequency, false, time.Minute, []string{"Warehouse.uploadStatusTrackFrequency", "Warehouse.uploadStatusTrackFrequencyInMin"}...)
-	r.conf.RegisterBoolConfigVariable(false, &r.config.allowMultipleSourcesForJobsPickup, false, fmt.Sprintf(`Warehouse.%v.allowMultipleSourcesForJobsPickup`, whName))
-	r.conf.RegisterBoolConfigVariable(false, &r.config.enableJitterForSyncs, true, "Warehouse.enableJitterForSyncs")
-	r.conf.RegisterBoolConfigVariable(false, &r.config.warehouseSyncFreqIgnore, true, "Warehouse.warehouseSyncFreqIgnore")
-	r.conf.RegisterBoolConfigVariable(false, &r.config.shouldPopulateHistoricIdentities, false, "Warehouse.populateHistoricIdentities")
+	r.config.maxConcurrentUploadJobs = config.GetIntVar(1, 1, fmt.Sprintf(`Warehouse.%v.maxConcurrentUploadJobs`, whName))
+	r.config.waitForWorkerSleep = config.GetDurationVar(5, time.Second, "Warehouse.waitForWorkerSleep", "Warehouse.waitForWorkerSleepInS")
+	r.config.uploadAllocatorSleep = config.GetDurationVar(5, time.Second, "Warehouse.uploadAllocatorSleep", "Warehouse.uploadAllocatorSleepInS")
+	r.config.uploadStatusTrackFrequency = config.GetDurationVar(30, time.Minute, "Warehouse.uploadStatusTrackFrequency", "Warehouse.uploadStatusTrackFrequencyInMin")
+	r.config.allowMultipleSourcesForJobsPickup = config.GetBoolVar(false, fmt.Sprintf(`Warehouse.%v.allowMultipleSourcesForJobsPickup`, whName))
+	r.config.shouldPopulateHistoricIdentities = config.GetBoolVar(false, "Warehouse.populateHistoricIdentities")
+	r.setupReloadableVars(whName)
 
 	r.stats.processingPendingJobsStat = r.statsFactory.NewTaggedStat("wh_processing_pending_jobs", stats.GaugeType, stats.Tags{
 		"destType": r.destType,
@@ -224,6 +219,16 @@ func newRouter(
 	}))
 
 	return r, nil
+}
+
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
+func (r *router) setupReloadableVars(whName string) {
+	r.conf.RegisterIntConfigVariable(8, &r.config.noOfWorkers, true, 1, fmt.Sprintf(`Warehouse.%v.noOfWorkers`, whName), "Warehouse.noOfWorkers")
+	r.conf.RegisterIntConfigVariable(8, &r.config.maxParallelJobCreation, true, 1, "Warehouse.maxParallelJobCreation")
+	r.conf.RegisterDurationConfigVariable(5, &r.config.mainLoopSleep, true, time.Second, "Warehouse.mainLoopSleep", "Warehouse.mainLoopSleepInS")
+	r.conf.RegisterIntConfigVariable(960, &r.config.stagingFilesBatchSize, true, 1, "Warehouse.stagingFilesBatchSize")
+	r.conf.RegisterBoolConfigVariable(false, &r.config.enableJitterForSyncs, true, "Warehouse.enableJitterForSyncs")
+	r.conf.RegisterBoolConfigVariable(false, &r.config.warehouseSyncFreqIgnore, true, "Warehouse.warehouseSyncFreqIgnore")
 }
 
 // Backend Config subscriber subscribes to backend-config and gets all the configurations that includes all sources, destinations and their latest values.

--- a/warehouse/slave.go
+++ b/warehouse/slave.go
@@ -54,6 +54,7 @@ func newSlave(
 	s.constraintsManager = constraintsManager
 	s.encodingFactory = encodingFactory
 
+	// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 	conf.RegisterIntConfigVariable(4, &s.config.noOfSlaveWorkerRoutines, true, 1, "Warehouse.noOfSlaveWorkerRoutines")
 
 	return s

--- a/warehouse/slave_worker.go
+++ b/warehouse/slave_worker.go
@@ -86,6 +86,7 @@ func newSlaveWorker(
 	s.encodingFactory = encodingFactory
 	s.workerIdx = workerIdx
 
+	// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 	conf.RegisterIntConfigVariable(10240, &s.config.maxStagingFileReadBufferCapacityInK, true, 1, "Warehouse.maxStagingFileReadBufferCapacityInK")
 
 	tags := stats.Tags{

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -195,8 +195,9 @@ func Init() {
 	pkgLogger = logger.NewLogger().Child("warehouse").Child("utils")
 }
 
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func loadConfig() {
-	config.RegisterBoolConfigVariable(false, &enableIDResolution, false, "Warehouse.enableIDResolution")
+	enableIDResolution = config.GetBoolVar(false, "Warehouse.enableIDResolution")
 	config.RegisterInt64ConfigVariable(3600, &AWSCredsExpiryInS, true, 1, "Warehouse.awsCredsExpiryInS")
 }
 

--- a/warehouse/warehouse.go
+++ b/warehouse/warehouse.go
@@ -83,6 +83,7 @@ func Init4() {
 	pkgLogger = logger.NewLogger().Child("warehouse")
 }
 
+// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func loadConfig() {
 	// Port where WH is running
 	config.RegisterInt64ConfigVariable(1800, &uploadFreqInS, true, 1, "Warehouse.uploadFreqInS")
@@ -94,8 +95,8 @@ func loadConfig() {
 	password = config.GetString("WAREHOUSE_JOBS_DB_PASSWORD", "ubuntu") // Reading secrets from
 	sslMode = config.GetString("WAREHOUSE_JOBS_DB_SSL_MODE", "disable")
 	triggerUploadsMap = map[string]bool{}
-	config.RegisterBoolConfigVariable(true, &ShouldForceSetLowerVersion, false, "SQLMigrator.forceSetLowerVersion")
-	config.RegisterDurationConfigVariable(5, &dbHandleTimeout, true, time.Minute, []string{"Warehouse.dbHandleTimeout", "Warehouse.dbHanndleTimeoutInMin"}...)
+	ShouldForceSetLowerVersion = config.GetBoolVar(true, "SQLMigrator.forceSetLowerVersion")
+	config.RegisterDurationConfigVariable(5, &dbHandleTimeout, true, time.Minute, "Warehouse.dbHandleTimeout", "Warehouse.dbHanndleTimeoutInMin")
 
 	appName = misc.DefaultString("rudder-server").OnError(os.Hostname())
 }


### PR DESCRIPTION
# Description

Pulling kit with the new config Reloadable API.

The idea is to suppress the linter to incrementally migrate towards the new API. While making the changes I took the liberty to migrate a few packages.

Follow up task (it has 2 sub-issues, 1 for server, 1 for warehouse):
* https://linear.app/rudderstack/issue/PIPE-263/sa1019-config-register-reloadable-functions-are-deprecated

## Sidenote

In some tests reloadable variables are changed manually. For now I fixed them by doing:

```go
disableEventUploads = config.GetReloadableBoolVar(true, rand.UniqueString(10))
```

The ideal way of doing it would be to have proper constructors that take a `*config.Config` as a parameter. Unfortunately that requires refactoring the code to make it work that way. As a temporary hack I used the above trick.

If you disagree I can revert, suppress the linter and then we can take the time to properly refactor the affected packages. In those cases I felt it was overkill so I went ahead with that approach.

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-257/update-rudderserver-to-suppressremove-deprecated-config-calls) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
