### PR TITLE
chore(batchrouter): honour upload frequency when limitsReached if destination is failing

### DIFF
--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -114,6 +114,9 @@ type Handle struct {
 	lastExecTimesMu sync.RWMutex
 	lastExecTimes   map[string]time.Time
 
+	failingDestinationsMu sync.RWMutex
+	failingDestinations   map[string]bool
+
 	batchRequestsMetricMu sync.RWMutex
 	batchRequestsMetric   []batchRequestMetric
 
@@ -243,7 +246,8 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 		if batchDest, ok := destinationsMap[destID]; ok {
 			var processJobs bool
 			brt.lastExecTimesMu.Lock()
-			if limitsReached { // if limits are reached, process all jobs regardless of their upload frequency
+			brt.failingDestinationsMu.RLock()
+			if limitsReached && !brt.failingDestinations[destID] { // if limits are reached and the destination is not failing, process all jobs regardless of their upload frequency
 				processJobs = true
 			} else { // honour upload frequency
 				lastExecTime := brt.lastExecTimes[destID]
@@ -252,6 +256,7 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 					brt.lastExecTimes[destID] = time.Now()
 				}
 			}
+			brt.failingDestinationsMu.RUnlock()
 			brt.lastExecTimesMu.Unlock()
 			if processJobs {
 				workerJobs = append(workerJobs, &DestinationJobs{destWithSources: *batchDest, jobs: destJobs})
@@ -572,6 +577,9 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 		batchReqMetric.batchRequestSuccess = 1
 	}
 	brt.trackRequestMetrics(batchReqMetric)
+	brt.failingDestinationsMu.Lock()
+	brt.failingDestinations[batchJobs.Connection.Destination.ID] = batchReqMetric.batchRequestFailed > 0
+	brt.failingDestinationsMu.Unlock()
 	var statusList []*jobsdb.JobStatusT
 
 	if isWarehouse && notifyWarehouseErr {

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -68,26 +68,24 @@ type Handle struct {
 
 	maxEventsInABatch            int
 	maxPayloadSizeInBytes        int
-	maxFailedCountForJob         int
-	asyncUploadTimeout           time.Duration
-	retryTimeWindow              time.Duration
+	maxFailedCountForJob         *config.Reloadable[int]
+	asyncUploadTimeout           *config.Reloadable[time.Duration]
+	retryTimeWindow              *config.Reloadable[time.Duration]
 	reportingEnabled             bool
-	jobQueryBatchSize            int
-	pollStatusLoopSleep          time.Duration
-	payloadLimit                 int64
-	jobsDBCommandTimeout         time.Duration
-	jobdDBQueryRequestTimeout    time.Duration
-	jobdDBMaxRetries             int
-	minIdleSleep                 time.Duration
-	uploadFreq                   time.Duration
-	forceHonorUploadFrequency    bool
-	readPerDestination           bool
+	jobQueryBatchSize            *config.Reloadable[int]
+	pollStatusLoopSleep          *config.Reloadable[time.Duration]
+	payloadLimit                 *config.Reloadable[int64]
+	jobsDBCommandTimeout         *config.Reloadable[time.Duration]
+	jobdDBQueryRequestTimeout    *config.Reloadable[time.Duration]
+	jobdDBMaxRetries             *config.Reloadable[int]
+	minIdleSleep                 *config.Reloadable[time.Duration]
+	uploadFreq                   *config.Reloadable[time.Duration]
 	disableEgress                bool
-	toAbortDestinationIDs        string
-	warehouseServiceMaxRetryTime time.Duration
+	toAbortDestinationIDs        *config.Reloadable[string]
+	warehouseServiceMaxRetryTime *config.Reloadable[time.Duration]
 	transformerURL               string
-	datePrefixOverride           string
-	customDatePrefix             string
+	datePrefixOverride           *config.Reloadable[string]
+	customDatePrefix             *config.Reloadable[string]
 
 	// state
 
@@ -148,7 +146,7 @@ func (brt *Handle) mainLoop(ctx context.Context) {
 			for _, partition := range brt.activePartitions(ctx) {
 				pool.PingWorker(partition)
 			}
-			mainLoopSleep = brt.uploadFreq
+			mainLoopSleep = brt.uploadFreq.Load()
 		}
 	}
 }
@@ -186,14 +184,14 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 	queryStart := time.Now()
 	queryParams := jobsdb.GetQueryParams{
 		CustomValFilters: []string{brt.destType},
-		JobsLimit:        limit,
-		PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit),
+		JobsLimit:        limit.Load(),
+		PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit.Load()),
 	}
 	brt.isolationStrategy.AugmentQueryParams(partition, &queryParams)
 	var limitsReached bool
 
 	if config.GetBool("JobsDB.useSingleGetJobsQuery", true) { // TODO: remove condition after successful rollout of sinle query
-		toProcess, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+		toProcess, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) (jobsdb.JobsResult, error) {
 			return brt.jobsDB.GetJobs(ctx, []string{jobsdb.Failed.State, jobsdb.Unprocessed.State}, queryParams)
 		}, brt.sendQueryRetryStats)
 		if err != nil {
@@ -203,7 +201,7 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 		jobs = toProcess.Jobs
 		limitsReached = toProcess.LimitsReached
 	} else {
-		toRetry, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+		toRetry, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) (jobsdb.JobsResult, error) {
 			return brt.jobsDB.GetFailed(ctx, queryParams)
 		}, brt.sendQueryRetryStats)
 		if err != nil {
@@ -217,7 +215,7 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 			if queryParams.PayloadSizeLimit > 0 {
 				queryParams.PayloadSizeLimit -= toRetry.PayloadSize
 			}
-			unprocessed, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+			unprocessed, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) (jobsdb.JobsResult, error) {
 				return brt.jobsDB.GetUnprocessed(ctx, queryParams)
 			}, brt.sendQueryRetryStats)
 			if err != nil {
@@ -245,11 +243,11 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 		if batchDest, ok := destinationsMap[destID]; ok {
 			var processJobs bool
 			brt.lastExecTimesMu.Lock()
-			if limitsReached && !brt.forceHonorUploadFrequency { // if limits are reached, process all jobs regardless of their upload frequency
+			if limitsReached { // if limits are reached, process all jobs regardless of their upload frequency
 				processJobs = true
 			} else { // honour upload frequency
 				lastExecTime := brt.lastExecTimes[destID]
-				if lastExecTime.IsZero() || time.Since(lastExecTime) >= brt.uploadFreq {
+				if lastExecTime.IsZero() || time.Since(lastExecTime) >= brt.uploadFreq.Load() {
 					processJobs = true
 					brt.lastExecTimes[destID] = time.Now()
 				}
@@ -406,8 +404,8 @@ func (brt *Handle) upload(provider string, batchJobs *BatchedJobs, isWarehouse b
 	}
 
 	var datePrefixLayout string
-	if brt.datePrefixOverride != "" {
-		datePrefixLayout = brt.datePrefixOverride
+	if brt.datePrefixOverride.Load() != "" {
+		datePrefixLayout = brt.datePrefixOverride.Load()
 	} else {
 		dateFormat, _ := brt.dateFormatProvider.GetFormat(brt.logger, uploader, batchJobs.Connection, folderName)
 		datePrefixLayout = dateFormat
@@ -420,7 +418,7 @@ func (brt *Handle) upload(provider string, batchJobs *BatchedJobs, isWarehouse b
 	default:
 		datePrefixLayout = time.Now().Format("2006-01-02")
 	}
-	keyPrefixes := []string{folderName, batchJobs.Connection.Source.ID, brt.customDatePrefix + datePrefixLayout}
+	keyPrefixes := []string{folderName, batchJobs.Connection.Source.ID, brt.customDatePrefix.Load() + datePrefixLayout}
 
 	_, fileName := filepath.Split(gzipFilePath)
 	var (
@@ -622,8 +620,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 		timeElapsed := time.Since(firstAttemptedAt)
 		switch jobState {
 		case jobsdb.Failed.State:
-			if !notifyWarehouseErr && timeElapsed > brt.retryTimeWindow && job.LastJobStatus.AttemptNum >= brt.
-				maxFailedCountForJob {
+			if !notifyWarehouseErr && timeElapsed > brt.retryTimeWindow.Load() && job.LastJobStatus.AttemptNum >= brt.maxFailedCountForJob.Load() {
 				job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "stage", "batch_router")
 				job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "reason", errOccurred.Error())
 				abortedEvents = append(abortedEvents, job)
@@ -632,7 +629,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 			if notifyWarehouseErr && isWarehouse {
 				// change job state to abort state after warehouse service is continuously failing more than warehouseServiceMaxRetryTimeinHr time
 				brt.warehouseServiceFailedTimeMu.RLock()
-				if time.Since(brt.warehouseServiceFailedTime) > brt.warehouseServiceMaxRetryTime {
+				if time.Since(brt.warehouseServiceFailedTime) > brt.warehouseServiceMaxRetryTime.Load() {
 					job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "stage", "batch_router")
 					job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "reason", errOccurred.Error())
 					abortedEvents = append(abortedEvents, job)
@@ -722,7 +719,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 
 	// Store the aborted jobs to errorDB
 	if abortedEvents != nil {
-		err := misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) error {
+		err := misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
 			return brt.errorDB.Store(ctx, abortedEvents)
 		}, brt.sendRetryStoreStats)
 		if err != nil {
@@ -759,7 +756,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 	// REPORTING - END
 
 	// Mark the status of the jobs
-	err = misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) error {
+	err = misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
 		return brt.jobsDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
 			err = brt.jobsDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{brt.destType}, parameterFilters)
 			if err != nil {
@@ -791,17 +788,17 @@ func (brt *Handle) uploadInterval(destinationConfig map[string]interface{}) time
 	uploadInterval, ok := destinationConfig["uploadInterval"]
 	if !ok {
 		brt.logger.Debugf("BRT: uploadInterval not found in destination config, falling back to default: %s", brt.asyncUploadTimeout)
-		return brt.asyncUploadTimeout
+		return brt.asyncUploadTimeout.Load()
 	}
 	dur, ok := uploadInterval.(string)
 	if !ok {
 		brt.logger.Warnf("BRT: not found string type uploadInterval, falling back to default: %s", brt.asyncUploadTimeout)
-		return brt.asyncUploadTimeout
+		return brt.asyncUploadTimeout.Load()
 	}
 	parsedTime, err := strconv.ParseInt(dur, 10, 64)
 	if err != nil {
 		brt.logger.Warnf("BRT: Couldn't parseint uploadInterval, falling back to default: %s", brt.asyncUploadTimeout)
-		return brt.asyncUploadTimeout
+		return brt.asyncUploadTimeout.Load()
 	}
 	return time.Duration(parsedTime * int64(time.Minute))
 }
@@ -812,10 +809,10 @@ func (brt *Handle) skipFetchingJobs(partition string) bool {
 		queryParams := jobsdb.GetQueryParams{
 			CustomValFilters: []string{brt.destType},
 			JobsLimit:        1,
-			PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit),
+			PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit.Load()),
 		}
 		brt.isolationStrategy.AugmentQueryParams(partition, &queryParams)
-		importingList, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+		importingList, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) (jobsdb.JobsResult, error) {
 			return brt.jobsDB.GetImporting(ctx, queryParams)
 		}, brt.sendQueryRetryStats)
 		if err != nil {

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -107,6 +107,7 @@ func (brt *Handle) Setup(
 	brt.encounteredMergeRuleMap = map[string]map[string]bool{}
 	brt.uploadIntervalMap = map[string]time.Duration{}
 	brt.lastExecTimes = map[string]time.Time{}
+	brt.failingDestinations = map[string]bool{}
 	brt.dateFormatProvider = &storageDateFormatProvider{dateFormatsCache: make(map[string]string)}
 	diagnosisTickerTime := config.GetDurationVar(600, time.Second, "Diagnostics.batchRouterTimePeriod", "Diagnostics.batchRouterTimePeriodInS")
 	brt.diagnosisTicker = time.NewTicker(diagnosisTickerTime)

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -192,22 +192,21 @@ func (brt *Handle) Setup(
 
 // nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func (brt *Handle) setupReloadableVars() {
-	config.RegisterIntConfigVariable(128, &brt.maxFailedCountForJob, true, 1, "BatchRouter."+brt.destType+".maxFailedCountForJob", "BatchRouter.maxFailedCountForJob")
-	config.RegisterDurationConfigVariable(30, &brt.asyncUploadTimeout, true, time.Minute, "BatchRouter."+brt.destType+".asyncUploadTimeout", "BatchRouter.asyncUploadTimeout")
-	config.RegisterDurationConfigVariable(180, &brt.retryTimeWindow, true, time.Minute, "BatchRouter."+brt.destType+".retryTimeWindow", "BatchRouter."+brt.destType+".retryTimeWindowInMins", "BatchRouter.retryTimeWindow", "BatchRouter.retryTimeWindowInMins")
-	config.RegisterIntConfigVariable(100000, &brt.jobQueryBatchSize, true, 1, "BatchRouter."+brt.destType+".jobQueryBatchSize", "BatchRouter.jobQueryBatchSize")
-	config.RegisterDurationConfigVariable(10, &brt.pollStatusLoopSleep, true, time.Second, "BatchRouter."+brt.destType+".pollStatusLoopSleep", "BatchRouter.pollStatusLoopSleep")
-	config.RegisterInt64ConfigVariable(1*bytesize.GB, &brt.payloadLimit, true, 1, "BatchRouter."+brt.destType+".PayloadLimit", "BatchRouter.PayloadLimit")
-	config.RegisterDurationConfigVariable(600, &brt.jobsDBCommandTimeout, true, time.Second, "JobsDB.BatchRouter.CommandRequestTimeout", "JobsDB.CommandRequestTimeout")
-	config.RegisterDurationConfigVariable(600, &brt.jobdDBQueryRequestTimeout, true, time.Second, "JobsDB.BatchRouter.QueryRequestTimeout", "JobsDB.QueryRequestTimeout")
-	config.RegisterIntConfigVariable(2, &brt.jobdDBMaxRetries, true, 1, "JobsDB.BatchRouter.MaxRetries", "JobsDB.MaxRetries")
-	config.RegisterDurationConfigVariable(2, &brt.minIdleSleep, true, time.Second, "BatchRouter.minIdleSleep")
-	config.RegisterDurationConfigVariable(30, &brt.uploadFreq, true, time.Second, "BatchRouter.uploadFreqInS", "BatchRouter.uploadFreq")
-	config.RegisterBoolConfigVariable(false, &brt.forceHonorUploadFrequency, true, "BatchRouter.forceHonorUploadFrequency")
-	config.RegisterStringConfigVariable("", &brt.toAbortDestinationIDs, true, "BatchRouter.toAbortDestinationIDs")
-	config.RegisterDurationConfigVariable(3, &brt.warehouseServiceMaxRetryTime, true, time.Hour, "BatchRouter.warehouseServiceMaxRetryTime", "BatchRouter.warehouseServiceMaxRetryTimeinHr")
-	config.RegisterStringConfigVariable("", &brt.datePrefixOverride, true, "BatchRouter.datePrefixOverride")
-	config.RegisterStringConfigVariable("", &brt.customDatePrefix, true, "BatchRouter.customDatePrefix")
+	brt.maxFailedCountForJob = config.GetReloadableIntVar(128, 1, "BatchRouter."+brt.destType+".maxFailedCountForJob", "BatchRouter.maxFailedCountForJob")
+	brt.asyncUploadTimeout = config.GetReloadableDurationVar(30, time.Minute, "BatchRouter."+brt.destType+".asyncUploadTimeout", "BatchRouter.asyncUploadTimeout")
+	brt.retryTimeWindow = config.GetReloadableDurationVar(180, time.Minute, "BatchRouter."+brt.destType+".retryTimeWindow", "BatchRouter."+brt.destType+".retryTimeWindowInMins", "BatchRouter.retryTimeWindow", "BatchRouter.retryTimeWindowInMins")
+	brt.jobQueryBatchSize = config.GetReloadableIntVar(100000, 1, "BatchRouter."+brt.destType+".jobQueryBatchSize", "BatchRouter.jobQueryBatchSize")
+	brt.pollStatusLoopSleep = config.GetReloadableDurationVar(10, time.Second, "BatchRouter."+brt.destType+".pollStatusLoopSleep", "BatchRouter.pollStatusLoopSleep")
+	brt.payloadLimit = config.GetReloadableInt64Var(1*bytesize.GB, 1, "BatchRouter."+brt.destType+".PayloadLimit", "BatchRouter.PayloadLimit")
+	brt.jobsDBCommandTimeout = config.GetReloadableDurationVar(600, time.Second, "JobsDB.BatchRouter.CommandRequestTimeout", "JobsDB.CommandRequestTimeout")
+	brt.jobdDBQueryRequestTimeout = config.GetReloadableDurationVar(600, time.Second, "JobsDB.BatchRouter.QueryRequestTimeout", "JobsDB.QueryRequestTimeout")
+	brt.jobdDBMaxRetries = config.GetReloadableIntVar(2, 1, "JobsDB.BatchRouter.MaxRetries", "JobsDB.MaxRetries")
+	brt.minIdleSleep = config.GetReloadableDurationVar(2, time.Second, "BatchRouter.minIdleSleep")
+	brt.uploadFreq = config.GetReloadableDurationVar(30, time.Second, "BatchRouter.uploadFreqInS", "BatchRouter.uploadFreq")
+	brt.toAbortDestinationIDs = config.GetReloadableStringVar("", "BatchRouter.toAbortDestinationIDs")
+	brt.warehouseServiceMaxRetryTime = config.GetReloadableDurationVar(3, time.Hour, "BatchRouter.warehouseServiceMaxRetryTime", "BatchRouter.warehouseServiceMaxRetryTimeinHr")
+	brt.datePrefixOverride = config.GetReloadableStringVar("", "BatchRouter.datePrefixOverride")
+	brt.customDatePrefix = config.GetReloadableStringVar("", "BatchRouter.customDatePrefix")
 }
 
 func (brt *Handle) startAsyncDestinationManager() {


### PR DESCRIPTION
# Description

When a destination is failing there is no point in keep retrying jobs continuously even if there are a lot of jobs in the queue (`limitsReached` in jobsdb query).

Other changes:

- Use the new reloadable config api
- Remove `forceHonorUploadFrequency` since we are not using it

## Linear Ticket

< Replace with Linear Link >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
