### PR TITLE
chore: use new reloadable config api in router and batchrouter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/rs/cors v1.9.0
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/rudderlabs/compose-test v0.1.3
-	github.com/rudderlabs/rudder-go-kit v0.15.9
+	github.com/rudderlabs/rudder-go-kit v0.15.11-0.20230915092401-72266ee5b529
 	github.com/rudderlabs/sql-tunnels v0.1.4
 	github.com/samber/lo v1.38.1
 	github.com/segmentio/kafka-go v0.4.42

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/rs/cors v1.9.0
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/rudderlabs/compose-test v0.1.3
-	github.com/rudderlabs/rudder-go-kit v0.15.11-0.20230915092401-72266ee5b529
+	github.com/rudderlabs/rudder-go-kit v0.15.11
 	github.com/rudderlabs/sql-tunnels v0.1.4
 	github.com/samber/lo v1.38.1
 	github.com/segmentio/kafka-go v0.4.42

--- a/go.sum
+++ b/go.sum
@@ -1774,8 +1774,8 @@ github.com/rudderlabs/compose-test v0.1.3 h1:uyep6jDCIF737sfv4zIaMsKRQKX95IDz5Xb
 github.com/rudderlabs/compose-test v0.1.3/go.mod h1:tuvS1eQdSfwOYv1qwyVAcpdJxPLQXJgy5xGDd/9XmMg=
 github.com/rudderlabs/parquet-go v0.0.2 h1:ZXRdZdimB0PdJtmxeSSxfI0fDQ3kZjwzBxRi6Ut1J8k=
 github.com/rudderlabs/parquet-go v0.0.2/go.mod h1:g6guum7o8uhj/uNhunnt7bw5Vabu/goI5i21/3fnxWQ=
-github.com/rudderlabs/rudder-go-kit v0.15.9 h1:i1dUUL1JLAOOn+2RgVq0K6UnTn6X4OZMTiZPZZBKmTQ=
-github.com/rudderlabs/rudder-go-kit v0.15.9/go.mod h1:W7b3rft7Kt8TvNd4gguw5ZB9Hu4M1k60EGLv91+N2zM=
+github.com/rudderlabs/rudder-go-kit v0.15.11-0.20230915092401-72266ee5b529 h1:XXcs8XyAE1i/Afo4X4bVw0YqU5VrLhk0Y1UZwSi9CGA=
+github.com/rudderlabs/rudder-go-kit v0.15.11-0.20230915092401-72266ee5b529/go.mod h1:W7b3rft7Kt8TvNd4gguw5ZB9Hu4M1k60EGLv91+N2zM=
 github.com/rudderlabs/sql-tunnels v0.1.4 h1:snnkUItx3nRCPGSouibkYzBpOcEiWhCVjRY95A0eMuk=
 github.com/rudderlabs/sql-tunnels v0.1.4/go.mod h1:C6O0M6C3V+pdVwjy3UvyPd+d5SeRvbBQfApm+67qNnI=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=

--- a/go.sum
+++ b/go.sum
@@ -1774,8 +1774,8 @@ github.com/rudderlabs/compose-test v0.1.3 h1:uyep6jDCIF737sfv4zIaMsKRQKX95IDz5Xb
 github.com/rudderlabs/compose-test v0.1.3/go.mod h1:tuvS1eQdSfwOYv1qwyVAcpdJxPLQXJgy5xGDd/9XmMg=
 github.com/rudderlabs/parquet-go v0.0.2 h1:ZXRdZdimB0PdJtmxeSSxfI0fDQ3kZjwzBxRi6Ut1J8k=
 github.com/rudderlabs/parquet-go v0.0.2/go.mod h1:g6guum7o8uhj/uNhunnt7bw5Vabu/goI5i21/3fnxWQ=
-github.com/rudderlabs/rudder-go-kit v0.15.11-0.20230915092401-72266ee5b529 h1:XXcs8XyAE1i/Afo4X4bVw0YqU5VrLhk0Y1UZwSi9CGA=
-github.com/rudderlabs/rudder-go-kit v0.15.11-0.20230915092401-72266ee5b529/go.mod h1:W7b3rft7Kt8TvNd4gguw5ZB9Hu4M1k60EGLv91+N2zM=
+github.com/rudderlabs/rudder-go-kit v0.15.11 h1:pvZMQWgCVeUmCJVWIkJ2hIiDEjVDYg0Tx5VTJ6X4feM=
+github.com/rudderlabs/rudder-go-kit v0.15.11/go.mod h1:W7b3rft7Kt8TvNd4gguw5ZB9Hu4M1k60EGLv91+N2zM=
 github.com/rudderlabs/sql-tunnels v0.1.4 h1:snnkUItx3nRCPGSouibkYzBpOcEiWhCVjRY95A0eMuk=
 github.com/rudderlabs/sql-tunnels v0.1.4/go.mod h1:C6O0M6C3V+pdVwjy3UvyPd+d5SeRvbBQfApm+67qNnI=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/backend-config"
 	mocksJobsDB "github.com/rudderlabs/rudder-server/mocks/jobsdb"
-	router_utils "github.com/rudderlabs/rudder-server/router/utils"
 	"github.com/rudderlabs/rudder-server/services/rsources"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -147,7 +146,6 @@ var _ = Describe("BatchRouter", func() {
 
 	BeforeEach(func() {
 		config.Reset()
-		router_utils.JobRetention = time.Duration(175200) * time.Hour // 20 Years(20*365*24)
 		c = &testContext{}
 		c.Setup()
 	})

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/filemanager/mock_filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
 	"github.com/rudderlabs/rudder-server/admin"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
@@ -146,6 +147,7 @@ var _ = Describe("BatchRouter", func() {
 
 	BeforeEach(func() {
 		config.Reset()
+		config.Set("Router.jobRetention", "175200h") // 20 Years(20*365*24)
 		c = &testContext{}
 		c.Setup()
 	})
@@ -176,7 +178,6 @@ var _ = Describe("BatchRouter", func() {
 			batchrouter := &Handle{}
 			batchrouter.Setup(s3DestinationDefinition.Name, c.mockBackendConfig, c.mockBatchRouterJobsDB, c.mockProcErrorsDB, nil, transientsource.NewEmptyService(), rsources.NewNoOpService(), destinationdebugger.NewNoOpService())
 
-			batchrouter.readPerDestination = false
 			batchrouter.fileManagerFactory = c.mockFileManagerFactory
 
 			c.mockFileManager.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(filemanager.UploadedFile{Location: "local", ObjectName: "file"}, nil)
@@ -234,7 +235,7 @@ var _ = Describe("BatchRouter", func() {
 
 			payloadLimit := batchrouter.payloadLimit
 			var getJobsListCalled bool
-			c.mockBatchRouterJobsDB.EXPECT().GetJobs(gomock.Any(), []string{jobsdb.Failed.State, jobsdb.Unprocessed.State}, jobsdb.GetQueryParams{CustomValFilters: []string{CustomVal["S3"]}, JobsLimit: c.jobQueryBatchSize, PayloadSizeLimit: payloadLimit}).DoAndReturn(func(ctx context.Context, states []string, params jobsdb.GetQueryParams) (jobsdb.JobsResult, error) {
+			c.mockBatchRouterJobsDB.EXPECT().GetJobs(gomock.Any(), []string{jobsdb.Failed.State, jobsdb.Unprocessed.State}, jobsdb.GetQueryParams{CustomValFilters: []string{CustomVal["S3"]}, JobsLimit: c.jobQueryBatchSize, PayloadSizeLimit: payloadLimit.Load()}).DoAndReturn(func(ctx context.Context, states []string, params jobsdb.GetQueryParams) (jobsdb.JobsResult, error) {
 				var res jobsdb.JobsResult
 				if !getJobsListCalled {
 					getJobsListCalled = true
@@ -265,8 +266,8 @@ var _ = Describe("BatchRouter", func() {
 			c.mockBatchRouterJobsDB.EXPECT().JournalDeleteEntry(gomock.Any()).Times(1)
 
 			<-batchrouter.backendConfigInitialized
-			batchrouter.minIdleSleep = time.Microsecond
-			batchrouter.uploadFreq = time.Microsecond
+			batchrouter.minIdleSleep = config.GetReloadableDurationVar(1, time.Microsecond, rand.UniqueString(10))
+			batchrouter.uploadFreq = config.GetReloadableDurationVar(1, time.Microsecond, rand.UniqueString(10))
 			ctx, cancel := context.WithCancel(context.Background())
 			var wg sync.WaitGroup
 			wg.Add(1)

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -175,7 +175,6 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 	destinationsMap := brt.destinationsMap
 	brt.configSubscriberMu.RUnlock()
 	var jobs []*jobsdb.JobT
-	limit := brt.jobQueryBatchSize
 
 	var firstJob *jobsdb.JobT
 	var lastJob *jobsdb.JobT
@@ -184,7 +183,7 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 	queryStart := time.Now()
 	queryParams := jobsdb.GetQueryParams{
 		CustomValFilters: []string{brt.destType},
-		JobsLimit:        limit.Load(),
+		JobsLimit:        brt.jobQueryBatchSize.Load(),
 		PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit.Load()),
 	}
 	brt.isolationStrategy.AugmentQueryParams(partition, &queryParams)

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -68,26 +68,24 @@ type Handle struct {
 
 	maxEventsInABatch            int
 	maxPayloadSizeInBytes        int
-	maxFailedCountForJob         int
-	asyncUploadTimeout           time.Duration
-	retryTimeWindow              time.Duration
+	maxFailedCountForJob         *config.Reloadable[int]
+	asyncUploadTimeout           *config.Reloadable[time.Duration]
+	retryTimeWindow              *config.Reloadable[time.Duration]
 	reportingEnabled             bool
-	jobQueryBatchSize            int
-	pollStatusLoopSleep          time.Duration
-	payloadLimit                 int64
-	jobsDBCommandTimeout         time.Duration
-	jobdDBQueryRequestTimeout    time.Duration
-	jobdDBMaxRetries             int
-	minIdleSleep                 time.Duration
-	uploadFreq                   time.Duration
-	forceHonorUploadFrequency    bool
-	readPerDestination           bool
+	jobQueryBatchSize            *config.Reloadable[int]
+	pollStatusLoopSleep          *config.Reloadable[time.Duration]
+	payloadLimit                 *config.Reloadable[int64]
+	jobsDBCommandTimeout         *config.Reloadable[time.Duration]
+	jobdDBQueryRequestTimeout    *config.Reloadable[time.Duration]
+	jobdDBMaxRetries             *config.Reloadable[int]
+	minIdleSleep                 *config.Reloadable[time.Duration]
+	uploadFreq                   *config.Reloadable[time.Duration]
 	disableEgress                bool
-	toAbortDestinationIDs        string
-	warehouseServiceMaxRetryTime time.Duration
+	toAbortDestinationIDs        *config.Reloadable[string]
+	warehouseServiceMaxRetryTime *config.Reloadable[time.Duration]
 	transformerURL               string
-	datePrefixOverride           string
-	customDatePrefix             string
+	datePrefixOverride           *config.Reloadable[string]
+	customDatePrefix             *config.Reloadable[string]
 
 	// state
 
@@ -148,7 +146,7 @@ func (brt *Handle) mainLoop(ctx context.Context) {
 			for _, partition := range brt.activePartitions(ctx) {
 				pool.PingWorker(partition)
 			}
-			mainLoopSleep = brt.uploadFreq
+			mainLoopSleep = brt.uploadFreq.Load()
 		}
 	}
 }
@@ -186,14 +184,14 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 	queryStart := time.Now()
 	queryParams := jobsdb.GetQueryParams{
 		CustomValFilters: []string{brt.destType},
-		JobsLimit:        limit,
-		PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit),
+		JobsLimit:        limit.Load(),
+		PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit.Load()),
 	}
 	brt.isolationStrategy.AugmentQueryParams(partition, &queryParams)
 	var limitsReached bool
 
 	if config.GetBool("JobsDB.useSingleGetJobsQuery", true) { // TODO: remove condition after successful rollout of sinle query
-		toProcess, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+		toProcess, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) (jobsdb.JobsResult, error) {
 			return brt.jobsDB.GetJobs(ctx, []string{jobsdb.Failed.State, jobsdb.Unprocessed.State}, queryParams)
 		}, brt.sendQueryRetryStats)
 		if err != nil {
@@ -203,7 +201,7 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 		jobs = toProcess.Jobs
 		limitsReached = toProcess.LimitsReached
 	} else {
-		toRetry, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+		toRetry, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) (jobsdb.JobsResult, error) {
 			return brt.jobsDB.GetFailed(ctx, queryParams)
 		}, brt.sendQueryRetryStats)
 		if err != nil {
@@ -217,7 +215,7 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 			if queryParams.PayloadSizeLimit > 0 {
 				queryParams.PayloadSizeLimit -= toRetry.PayloadSize
 			}
-			unprocessed, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+			unprocessed, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) (jobsdb.JobsResult, error) {
 				return brt.jobsDB.GetUnprocessed(ctx, queryParams)
 			}, brt.sendQueryRetryStats)
 			if err != nil {
@@ -245,11 +243,11 @@ func (brt *Handle) getWorkerJobs(partition string) (workerJobs []*DestinationJob
 		if batchDest, ok := destinationsMap[destID]; ok {
 			var processJobs bool
 			brt.lastExecTimesMu.Lock()
-			if limitsReached && !brt.forceHonorUploadFrequency { // if limits are reached, process all jobs regardless of their upload frequency
+			if limitsReached { // if limits are reached, process all jobs regardless of their upload frequency
 				processJobs = true
 			} else { // honour upload frequency
 				lastExecTime := brt.lastExecTimes[destID]
-				if lastExecTime.IsZero() || time.Since(lastExecTime) >= brt.uploadFreq {
+				if lastExecTime.IsZero() || time.Since(lastExecTime) >= brt.uploadFreq.Load() {
 					processJobs = true
 					brt.lastExecTimes[destID] = time.Now()
 				}
@@ -406,8 +404,8 @@ func (brt *Handle) upload(provider string, batchJobs *BatchedJobs, isWarehouse b
 	}
 
 	var datePrefixLayout string
-	if brt.datePrefixOverride != "" {
-		datePrefixLayout = brt.datePrefixOverride
+	if brt.datePrefixOverride.Load() != "" {
+		datePrefixLayout = brt.datePrefixOverride.Load()
 	} else {
 		dateFormat, _ := brt.dateFormatProvider.GetFormat(brt.logger, uploader, batchJobs.Connection, folderName)
 		datePrefixLayout = dateFormat
@@ -420,7 +418,7 @@ func (brt *Handle) upload(provider string, batchJobs *BatchedJobs, isWarehouse b
 	default:
 		datePrefixLayout = time.Now().Format("2006-01-02")
 	}
-	keyPrefixes := []string{folderName, batchJobs.Connection.Source.ID, brt.customDatePrefix + datePrefixLayout}
+	keyPrefixes := []string{folderName, batchJobs.Connection.Source.ID, brt.customDatePrefix.Load() + datePrefixLayout}
 
 	_, fileName := filepath.Split(gzipFilePath)
 	var (
@@ -622,8 +620,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 		timeElapsed := time.Since(firstAttemptedAt)
 		switch jobState {
 		case jobsdb.Failed.State:
-			if !notifyWarehouseErr && timeElapsed > brt.retryTimeWindow && job.LastJobStatus.AttemptNum >= brt.
-				maxFailedCountForJob {
+			if !notifyWarehouseErr && timeElapsed > brt.retryTimeWindow.Load() && job.LastJobStatus.AttemptNum >= brt.maxFailedCountForJob.Load() {
 				job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "stage", "batch_router")
 				job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "reason", errOccurred.Error())
 				abortedEvents = append(abortedEvents, job)
@@ -632,7 +629,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 			if notifyWarehouseErr && isWarehouse {
 				// change job state to abort state after warehouse service is continuously failing more than warehouseServiceMaxRetryTimeinHr time
 				brt.warehouseServiceFailedTimeMu.RLock()
-				if time.Since(brt.warehouseServiceFailedTime) > brt.warehouseServiceMaxRetryTime {
+				if time.Since(brt.warehouseServiceFailedTime) > brt.warehouseServiceMaxRetryTime.Load() {
 					job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "stage", "batch_router")
 					job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "reason", errOccurred.Error())
 					abortedEvents = append(abortedEvents, job)
@@ -722,7 +719,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 
 	// Store the aborted jobs to errorDB
 	if abortedEvents != nil {
-		err := misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) error {
+		err := misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
 			return brt.errorDB.Store(ctx, abortedEvents)
 		}, brt.sendRetryStoreStats)
 		if err != nil {
@@ -759,7 +756,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 	// REPORTING - END
 
 	// Mark the status of the jobs
-	err = misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) error {
+	err = misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
 		return brt.jobsDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
 			err = brt.jobsDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{brt.destType}, parameterFilters)
 			if err != nil {
@@ -791,17 +788,17 @@ func (brt *Handle) uploadInterval(destinationConfig map[string]interface{}) time
 	uploadInterval, ok := destinationConfig["uploadInterval"]
 	if !ok {
 		brt.logger.Debugf("BRT: uploadInterval not found in destination config, falling back to default: %s", brt.asyncUploadTimeout)
-		return brt.asyncUploadTimeout
+		return brt.asyncUploadTimeout.Load()
 	}
 	dur, ok := uploadInterval.(string)
 	if !ok {
 		brt.logger.Warnf("BRT: not found string type uploadInterval, falling back to default: %s", brt.asyncUploadTimeout)
-		return brt.asyncUploadTimeout
+		return brt.asyncUploadTimeout.Load()
 	}
 	parsedTime, err := strconv.ParseInt(dur, 10, 64)
 	if err != nil {
 		brt.logger.Warnf("BRT: Couldn't parseint uploadInterval, falling back to default: %s", brt.asyncUploadTimeout)
-		return brt.asyncUploadTimeout
+		return brt.asyncUploadTimeout.Load()
 	}
 	return time.Duration(parsedTime * int64(time.Minute))
 }
@@ -812,10 +809,10 @@ func (brt *Handle) skipFetchingJobs(partition string) bool {
 		queryParams := jobsdb.GetQueryParams{
 			CustomValFilters: []string{brt.destType},
 			JobsLimit:        1,
-			PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit),
+			PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit.Load()),
 		}
 		brt.isolationStrategy.AugmentQueryParams(partition, &queryParams)
-		importingList, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout, brt.jobdDBMaxRetries, func(ctx context.Context) (jobsdb.JobsResult, error) {
+		importingList, err := misc.QueryWithRetriesAndNotify(context.Background(), brt.jobdDBQueryRequestTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) (jobsdb.JobsResult, error) {
 			return brt.jobsDB.GetImporting(ctx, queryParams)
 		}, brt.sendQueryRetryStats)
 		if err != nil {

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -192,22 +192,21 @@ func (brt *Handle) Setup(
 
 // nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func (brt *Handle) setupReloadableVars() {
-	config.RegisterIntConfigVariable(128, &brt.maxFailedCountForJob, true, 1, "BatchRouter."+brt.destType+".maxFailedCountForJob", "BatchRouter.maxFailedCountForJob")
-	config.RegisterDurationConfigVariable(30, &brt.asyncUploadTimeout, true, time.Minute, "BatchRouter."+brt.destType+".asyncUploadTimeout", "BatchRouter.asyncUploadTimeout")
-	config.RegisterDurationConfigVariable(180, &brt.retryTimeWindow, true, time.Minute, "BatchRouter."+brt.destType+".retryTimeWindow", "BatchRouter."+brt.destType+".retryTimeWindowInMins", "BatchRouter.retryTimeWindow", "BatchRouter.retryTimeWindowInMins")
-	config.RegisterIntConfigVariable(100000, &brt.jobQueryBatchSize, true, 1, "BatchRouter."+brt.destType+".jobQueryBatchSize", "BatchRouter.jobQueryBatchSize")
-	config.RegisterDurationConfigVariable(10, &brt.pollStatusLoopSleep, true, time.Second, "BatchRouter."+brt.destType+".pollStatusLoopSleep", "BatchRouter.pollStatusLoopSleep")
-	config.RegisterInt64ConfigVariable(1*bytesize.GB, &brt.payloadLimit, true, 1, "BatchRouter."+brt.destType+".PayloadLimit", "BatchRouter.PayloadLimit")
-	config.RegisterDurationConfigVariable(600, &brt.jobsDBCommandTimeout, true, time.Second, "JobsDB.BatchRouter.CommandRequestTimeout", "JobsDB.CommandRequestTimeout")
-	config.RegisterDurationConfigVariable(600, &brt.jobdDBQueryRequestTimeout, true, time.Second, "JobsDB.BatchRouter.QueryRequestTimeout", "JobsDB.QueryRequestTimeout")
-	config.RegisterIntConfigVariable(2, &brt.jobdDBMaxRetries, true, 1, "JobsDB.BatchRouter.MaxRetries", "JobsDB.MaxRetries")
-	config.RegisterDurationConfigVariable(2, &brt.minIdleSleep, true, time.Second, "BatchRouter.minIdleSleep")
-	config.RegisterDurationConfigVariable(30, &brt.uploadFreq, true, time.Second, "BatchRouter.uploadFreqInS", "BatchRouter.uploadFreq")
-	config.RegisterBoolConfigVariable(false, &brt.forceHonorUploadFrequency, true, "BatchRouter.forceHonorUploadFrequency")
-	config.RegisterStringConfigVariable("", &brt.toAbortDestinationIDs, true, "BatchRouter.toAbortDestinationIDs")
-	config.RegisterDurationConfigVariable(3, &brt.warehouseServiceMaxRetryTime, true, time.Hour, "BatchRouter.warehouseServiceMaxRetryTime", "BatchRouter.warehouseServiceMaxRetryTimeinHr")
-	config.RegisterStringConfigVariable("", &brt.datePrefixOverride, true, "BatchRouter.datePrefixOverride")
-	config.RegisterStringConfigVariable("", &brt.customDatePrefix, true, "BatchRouter.customDatePrefix")
+	brt.maxFailedCountForJob = config.GetReloadableIntVar(128, 1, "BatchRouter."+brt.destType+".maxFailedCountForJob", "BatchRouter.maxFailedCountForJob")
+	brt.asyncUploadTimeout = config.GetReloadableDurationVar(30, time.Minute, "BatchRouter."+brt.destType+".asyncUploadTimeout", "BatchRouter.asyncUploadTimeout")
+	brt.retryTimeWindow = config.GetReloadableDurationVar(180, time.Minute, "BatchRouter."+brt.destType+".retryTimeWindow", "BatchRouter."+brt.destType+".retryTimeWindowInMins", "BatchRouter.retryTimeWindow", "BatchRouter.retryTimeWindowInMins")
+	brt.jobQueryBatchSize = config.GetReloadableIntVar(100000, 1, "BatchRouter."+brt.destType+".jobQueryBatchSize", "BatchRouter.jobQueryBatchSize")
+	brt.pollStatusLoopSleep = config.GetReloadableDurationVar(10, time.Second, "BatchRouter."+brt.destType+".pollStatusLoopSleep", "BatchRouter.pollStatusLoopSleep")
+	brt.payloadLimit = config.GetReloadableInt64Var(1*bytesize.GB, 1, "BatchRouter."+brt.destType+".PayloadLimit", "BatchRouter.PayloadLimit")
+	brt.jobsDBCommandTimeout = config.GetReloadableDurationVar(600, time.Second, "JobsDB.BatchRouter.CommandRequestTimeout", "JobsDB.CommandRequestTimeout")
+	brt.jobdDBQueryRequestTimeout = config.GetReloadableDurationVar(600, time.Second, "JobsDB.BatchRouter.QueryRequestTimeout", "JobsDB.QueryRequestTimeout")
+	brt.jobdDBMaxRetries = config.GetReloadableIntVar(2, 1, "JobsDB.BatchRouter.MaxRetries", "JobsDB.MaxRetries")
+	brt.minIdleSleep = config.GetReloadableDurationVar(2, time.Second, "BatchRouter.minIdleSleep")
+	brt.uploadFreq = config.GetReloadableDurationVar(30, time.Second, "BatchRouter.uploadFreqInS", "BatchRouter.uploadFreq")
+	brt.toAbortDestinationIDs = config.GetReloadableStringVar("", "BatchRouter.toAbortDestinationIDs")
+	brt.warehouseServiceMaxRetryTime = config.GetReloadableDurationVar(3, time.Hour, "BatchRouter.warehouseServiceMaxRetryTime", "BatchRouter.warehouseServiceMaxRetryTimeinHr")
+	brt.datePrefixOverride = config.GetReloadableStringVar("", "BatchRouter.datePrefixOverride")
+	brt.customDatePrefix = config.GetReloadableStringVar("", "BatchRouter.customDatePrefix")
 }
 
 func (brt *Handle) startAsyncDestinationManager() {

--- a/router/eventorder_test.go
+++ b/router/eventorder_test.go
@@ -258,7 +258,7 @@ func TestEventOrderGuarantee(t *testing.T) {
 					t.Logf("%d/%d done (%d drained)", done, total, drained)
 				}
 				return done == total
-			}, 360*time.Second, 2*time.Second, "webhook should receive all events and process them till the end")
+			}, 120*time.Second, 2*time.Second, "webhook should receive all events and process them till the end")
 
 			require.False(t, t.Failed(), "webhook shouldn't have failed")
 

--- a/router/handle.go
+++ b/router/handle.go
@@ -157,10 +157,10 @@ func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worke
 		orderGroupKeyFn = func(job *jobsdb.JobT) string { return "same" }
 	}
 	iterator := jobiterator.New(
-		rt.getQueryParams(partition, rt.reloadableConfig.jobQueryBatchSize),
+		rt.getQueryParams(partition, rt.reloadableConfig.jobQueryBatchSize.Load()),
 		rt.getJobsFn(ctx),
-		jobiterator.WithDiscardedPercentageTolerance(rt.reloadableConfig.jobIteratorDiscardedPercentageTolerance),
-		jobiterator.WithMaxQueries(rt.reloadableConfig.jobIteratorMaxQueries),
+		jobiterator.WithDiscardedPercentageTolerance(rt.reloadableConfig.jobIteratorDiscardedPercentageTolerance.Load()),
+		jobiterator.WithMaxQueries(rt.reloadableConfig.jobIteratorMaxQueries.Load()),
 		jobiterator.WithOrderGroupKeyFn(orderGroupKeyFn),
 	)
 
@@ -168,7 +168,7 @@ func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worke
 		rt.pipelineDelayStats(partition, nil, nil)
 		rt.logger.Debugf("RT: DB Read Complete. No RT Jobs to process for destination: %s", rt.destType)
 		limiterEnd() // exit the limiter before sleeping
-		_ = misc.SleepCtx(ctx, rt.reloadableConfig.readSleep)
+		_ = misc.SleepCtx(ctx, rt.reloadableConfig.readSleep.Load())
 		return 0, false
 	}
 
@@ -183,12 +183,12 @@ func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worke
 
 	flushTime := time.Now()
 	shouldFlush := func() bool {
-		return len(statusList) > 0 && time.Since(flushTime) > rt.reloadableConfig.pickupFlushInterval
+		return len(statusList) > 0 && time.Since(flushTime) > rt.reloadableConfig.pickupFlushInterval.Load()
 	}
 	flush := func() {
 		flushTime = time.Now()
 		// Mark the jobs as executing
-		err := misc.RetryWithNotify(context.Background(), rt.reloadableConfig.jobsDBCommandTimeout, rt.reloadableConfig.jobdDBMaxRetries, func(ctx context.Context) error {
+		err := misc.RetryWithNotify(context.Background(), rt.reloadableConfig.jobsDBCommandTimeout.Load(), rt.reloadableConfig.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
 			return rt.jobsDB.UpdateJobStatus(ctx, statusList, []string{rt.destType}, nil)
 		}, rt.sendRetryUpdateStats)
 		if err != nil {
@@ -256,9 +256,9 @@ func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worke
 	discardedRatio := float64(iteratorStats.DiscardedJobs) / float64(iteratorStats.TotalJobs)
 	// If the discarded ratio is greater than the penalty threshold,
 	// sleep for a while to avoid having a loop running continuously without producing events
-	if limitsReached && discardedRatio > rt.reloadableConfig.failingJobsPenaltyThreshold {
+	if limitsReached && discardedRatio > rt.reloadableConfig.failingJobsPenaltyThreshold.Load() {
 		limiterEnd() // exit the limiter before sleeping
-		_ = misc.SleepCtx(ctx, rt.reloadableConfig.failingJobsPenaltySleep)
+		_ = misc.SleepCtx(ctx, rt.reloadableConfig.failingJobsPenaltySleep.Load())
 	}
 
 	return
@@ -389,7 +389,7 @@ func (rt *Handle) commitStatusList(workerJobStatuses *[]workerJobStatus) {
 		})
 		// Store the aborted jobs to errorDB
 		if routerAbortedJobs != nil {
-			err := misc.RetryWithNotify(context.Background(), rt.reloadableConfig.jobsDBCommandTimeout, rt.reloadableConfig.jobdDBMaxRetries, func(ctx context.Context) error {
+			err := misc.RetryWithNotify(context.Background(), rt.reloadableConfig.jobsDBCommandTimeout.Load(), rt.reloadableConfig.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
 				return rt.errorDB.Store(ctx, routerAbortedJobs)
 			}, rt.sendRetryStoreStats)
 			if err != nil {
@@ -397,7 +397,7 @@ func (rt *Handle) commitStatusList(workerJobStatuses *[]workerJobStatus) {
 			}
 		}
 		// Update the status
-		err := misc.RetryWithNotify(context.Background(), rt.reloadableConfig.jobsDBCommandTimeout, rt.reloadableConfig.jobdDBMaxRetries, func(ctx context.Context) error {
+		err := misc.RetryWithNotify(context.Background(), rt.reloadableConfig.jobsDBCommandTimeout.Load(), rt.reloadableConfig.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
 			return rt.jobsDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
 				err := rt.jobsDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{rt.destType}, nil)
 				if err != nil {
@@ -447,7 +447,7 @@ func (rt *Handle) commitStatusList(workerJobStatuses *[]workerJobStatus) {
 
 func (rt *Handle) getJobsFn(parentContext context.Context) func(context.Context, jobsdb.GetQueryParams, jobsdb.MoreToken) (*jobsdb.MoreJobsResult, error) {
 	return func(ctx context.Context, params jobsdb.GetQueryParams, resumeFrom jobsdb.MoreToken) (*jobsdb.MoreJobsResult, error) {
-		jobs, err := misc.QueryWithRetriesAndNotify(parentContext, rt.reloadableConfig.jobsDBCommandTimeout, rt.reloadableConfig.jobdDBMaxRetries, func(ctx context.Context) (*jobsdb.MoreJobsResult, error) {
+		jobs, err := misc.QueryWithRetriesAndNotify(parentContext, rt.reloadableConfig.jobsDBCommandTimeout.Load(), rt.reloadableConfig.jobdDBMaxRetries.Load(), func(ctx context.Context) (*jobsdb.MoreJobsResult, error) {
 			return rt.jobsDB.GetToProcess(
 				ctx,
 				params,
@@ -464,7 +464,7 @@ func (rt *Handle) getJobsFn(parentContext context.Context) func(context.Context,
 func (rt *Handle) getQueryParams(partition string, pickUpCount int) jobsdb.GetQueryParams {
 	params := jobsdb.GetQueryParams{
 		CustomValFilters: []string{rt.destType},
-		PayloadSizeLimit: rt.adaptiveLimit(rt.reloadableConfig.payloadLimit),
+		PayloadSizeLimit: rt.adaptiveLimit(rt.reloadableConfig.payloadLimit.Load()),
 		JobsLimit:        pickUpCount,
 	}
 	rt.isolationStrategy.AugmentQueryParams(partition, &params)

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -68,7 +68,7 @@ func (rt *Handle) Setup(
 	rt.reloadableConfig = &reloadableConfig{}
 	rt.setupReloadableVars()
 	rt.crashRecover()
-	rt.responseQ = make(chan workerJobStatus, rt.reloadableConfig.jobQueryBatchSize)
+	rt.responseQ = make(chan workerJobStatus, rt.reloadableConfig.jobQueryBatchSize.Load())
 	if rt.netHandle == nil {
 		netHandle := &netHandle{disableEgress: config.GetBool("disableEgress", false)}
 		netHandle.logger = rt.logger.Child("network")
@@ -247,39 +247,38 @@ func (rt *Handle) Setup(
 	})
 }
 
-// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func (rt *Handle) setupReloadableVars() {
-	config.RegisterDurationConfigVariable(90, &rt.reloadableConfig.jobsDBCommandTimeout, true, time.Second, "JobsDB.Router.CommandRequestTimeout", "JobsDB.CommandRequestTimeout")
-	config.RegisterIntConfigVariable(2, &rt.reloadableConfig.jobdDBMaxRetries, true, 1, "JobsDB.Router.MaxRetries", "JobsDB.MaxRetries")
-	config.RegisterIntConfigVariable(20, &rt.reloadableConfig.noOfJobsToBatchInAWorker, true, 1, "Router."+rt.destType+".noOfJobsToBatchInAWorker", "Router.noOfJobsToBatchInAWorker")
-	config.RegisterIntConfigVariable(3, &rt.reloadableConfig.maxFailedCountForJob, true, 1, "Router."+rt.destType+".maxFailedCountForJob", "Router.maxFailedCountForJob")
-	config.RegisterInt64ConfigVariable(100*bytesize.MB, &rt.reloadableConfig.payloadLimit, true, 1, "Router."+rt.destType+".PayloadLimit", "Router.PayloadLimit")
-	config.RegisterDurationConfigVariable(3600, &rt.reloadableConfig.routerTimeout, true, time.Second, "Router."+rt.destType+".routerTimeout", "Router.routerTimeout")
-	config.RegisterDurationConfigVariable(180, &rt.reloadableConfig.retryTimeWindow, true, time.Minute, "Router."+rt.destType+".retryTimeWindow", "Router."+rt.destType+".retryTimeWindowInMins", "Router.retryTimeWindow", "Router.retryTimeWindowInMins")
-	config.RegisterIntConfigVariable(10, &rt.reloadableConfig.maxDSQuerySize, true, 1, "Router."+rt.destType+".maxDSQuery", "Router.maxDSQuery")
-	config.RegisterIntConfigVariable(50, &rt.reloadableConfig.jobIteratorMaxQueries, true, 1, "Router.jobIterator.maxQueries")
-	config.RegisterIntConfigVariable(10, &rt.reloadableConfig.jobIteratorDiscardedPercentageTolerance, true, 1, "Router.jobIterator.discardedPercentageTolerance")
-	config.RegisterBoolConfigVariable(false, &rt.reloadableConfig.savePayloadOnError, true, "Router."+rt.destType+".savePayloadOnError", "Router.savePayloadOnError")
-	config.RegisterBoolConfigVariable(false, &rt.reloadableConfig.transformerProxy, true, "Router."+rt.destType+".transformerProxy", "Router.transformerProxy")
-	config.RegisterBoolConfigVariable(false, &rt.reloadableConfig.skipRtAbortAlertForTransformation, true, "Router."+rt.destType+".skipRtAbortAlertForTf", "Router.skipRtAbortAlertForTf")
-	config.RegisterBoolConfigVariable(false, &rt.reloadableConfig.skipRtAbortAlertForDelivery, true, "Router."+rt.destType+".skipRtAbortAlertForDelivery", "Router.skipRtAbortAlertForDelivery")
-	config.RegisterIntConfigVariable(10000, &rt.reloadableConfig.jobQueryBatchSize, true, 1, "Router.jobQueryBatchSize")
-	config.RegisterIntConfigVariable(1000, &rt.reloadableConfig.updateStatusBatchSize, true, 1, "Router.updateStatusBatchSize")
-	config.RegisterDurationConfigVariable(1000, &rt.reloadableConfig.readSleep, true, time.Millisecond, "Router.readSleep", "Router.readSleepInMS")
-	config.RegisterDurationConfigVariable(5, &rt.reloadableConfig.jobsBatchTimeout, true, time.Second, "Router.jobsBatchTimeout", "Router.jobsBatchTimeoutInSec")
-	config.RegisterDurationConfigVariable(5, &rt.reloadableConfig.maxStatusUpdateWait, true, time.Second, "Router.maxStatusUpdateWait", "Router.maxStatusUpdateWaitInS")
-	config.RegisterDurationConfigVariable(10, &rt.reloadableConfig.minRetryBackoff, true, time.Second, "Router.minRetryBackoff", "Router.minRetryBackoffInS")
-	config.RegisterDurationConfigVariable(300, &rt.reloadableConfig.maxRetryBackoff, true, time.Second, "Router.maxRetryBackoff", "Router.maxRetryBackoffInS")
-	config.RegisterStringConfigVariable("", &rt.reloadableConfig.toAbortDestinationIDs, true, "Router.toAbortDestinationIDs")
-	config.RegisterDurationConfigVariable(2, &rt.reloadableConfig.pickupFlushInterval, true, time.Second, "Router.pickupFlushInterval")
-	config.RegisterDurationConfigVariable(2000, &rt.reloadableConfig.failingJobsPenaltySleep, true, time.Millisecond, "Router.failingJobsPenaltySleep")
-	config.RegisterFloat64ConfigVariable(0.6, &rt.reloadableConfig.failingJobsPenaltyThreshold, true, "Router.failingJobsPenaltyThreshold")
-	config.RegisterDurationConfigVariable(60, &rt.diagnosisTickerTime, false, time.Second, "Diagnostics.routerTimePeriod", "Diagnostics.routerTimePeriodInS")
-	config.RegisterDurationConfigVariable(10, &rt.netClientTimeout, false, time.Second,
+	rt.reloadableConfig.jobsDBCommandTimeout = config.GetReloadableDurationVar(90, time.Second, "JobsDB.Router.CommandRequestTimeout", "JobsDB.CommandRequestTimeout")
+	rt.reloadableConfig.jobdDBMaxRetries = config.GetReloadableIntVar(2, 1, "JobsDB.Router.MaxRetries", "JobsDB.MaxRetries")
+	rt.reloadableConfig.noOfJobsToBatchInAWorker = config.GetReloadableIntVar(20, 1, "Router."+rt.destType+".noOfJobsToBatchInAWorker", "Router.noOfJobsToBatchInAWorker")
+	rt.reloadableConfig.maxFailedCountForJob = config.GetReloadableIntVar(3, 1, "Router."+rt.destType+".maxFailedCountForJob", "Router.maxFailedCountForJob")
+	rt.reloadableConfig.payloadLimit = config.GetReloadableInt64Var(100*bytesize.MB, 1, "Router."+rt.destType+".PayloadLimit", "Router.PayloadLimit")
+	rt.reloadableConfig.routerTimeout = config.GetReloadableDurationVar(3600, time.Second, "Router."+rt.destType+".routerTimeout", "Router.routerTimeout")
+	rt.reloadableConfig.retryTimeWindow = config.GetReloadableDurationVar(180, time.Minute, "Router."+rt.destType+".retryTimeWindow", "Router."+rt.destType+".retryTimeWindowInMins", "Router.retryTimeWindow", "Router.retryTimeWindowInMins")
+	rt.reloadableConfig.maxDSQuerySize = config.GetReloadableIntVar(10, 1, "Router."+rt.destType+".maxDSQuery", "Router.maxDSQuery")
+	rt.reloadableConfig.jobIteratorMaxQueries = config.GetReloadableIntVar(50, 1, "Router.jobIterator.maxQueries")
+	rt.reloadableConfig.jobIteratorDiscardedPercentageTolerance = config.GetReloadableIntVar(10, 1, "Router.jobIterator.discardedPercentageTolerance")
+	rt.reloadableConfig.savePayloadOnError = config.GetReloadableBoolVar(false, "Router."+rt.destType+".savePayloadOnError", "Router.savePayloadOnError")
+	rt.reloadableConfig.transformerProxy = config.GetReloadableBoolVar(false, "Router."+rt.destType+".transformerProxy", "Router.transformerProxy")
+	rt.reloadableConfig.skipRtAbortAlertForTransformation = config.GetReloadableBoolVar(false, "Router."+rt.destType+".skipRtAbortAlertForTf", "Router.skipRtAbortAlertForTf")
+	rt.reloadableConfig.skipRtAbortAlertForDelivery = config.GetReloadableBoolVar(false, "Router."+rt.destType+".skipRtAbortAlertForDelivery", "Router.skipRtAbortAlertForDelivery")
+	rt.reloadableConfig.jobQueryBatchSize = config.GetReloadableIntVar(10000, 1, "Router.jobQueryBatchSize")
+	rt.reloadableConfig.updateStatusBatchSize = config.GetReloadableIntVar(1000, 1, "Router.updateStatusBatchSize")
+	rt.reloadableConfig.readSleep = config.GetReloadableDurationVar(1000, time.Millisecond, "Router.readSleep", "Router.readSleepInMS")
+	rt.reloadableConfig.jobsBatchTimeout = config.GetReloadableDurationVar(5, time.Second, "Router.jobsBatchTimeout", "Router.jobsBatchTimeoutInSec")
+	rt.reloadableConfig.maxStatusUpdateWait = config.GetReloadableDurationVar(5, time.Second, "Router.maxStatusUpdateWait", "Router.maxStatusUpdateWaitInS")
+	rt.reloadableConfig.minRetryBackoff = config.GetReloadableDurationVar(10, time.Second, "Router.minRetryBackoff", "Router.minRetryBackoffInS")
+	rt.reloadableConfig.maxRetryBackoff = config.GetReloadableDurationVar(300, time.Second, "Router.maxRetryBackoff", "Router.maxRetryBackoffInS")
+	rt.reloadableConfig.toAbortDestinationIDs = config.GetReloadableStringVar("", "Router.toAbortDestinationIDs")
+	rt.reloadableConfig.pickupFlushInterval = config.GetReloadableDurationVar(2, time.Second, "Router.pickupFlushInterval")
+	rt.reloadableConfig.failingJobsPenaltySleep = config.GetReloadableDurationVar(2000, time.Millisecond, "Router.failingJobsPenaltySleep")
+	rt.reloadableConfig.failingJobsPenaltyThreshold = config.GetReloadableFloat64Var(0.6, "Router.failingJobsPenaltyThreshold")
+	rt.diagnosisTickerTime = config.GetDurationVar(60, time.Second, "Diagnostics.routerTimePeriod", "Diagnostics.routerTimePeriodInS")
+	rt.netClientTimeout = config.GetDurationVar(10, time.Second,
 		"Router."+rt.destType+".httpTimeout",
 		"Router."+rt.destType+".httpTimeoutInS",
 		"Router.httpTimeout", "Router.httpTimeoutInS")
-	config.RegisterDurationConfigVariable(600, &rt.transformerTimeout, false, time.Second, "HttpClient.backendProxy.timeout", "HttpClient.routerTransformer.timeout")
+	rt.transformerTimeout = config.GetDurationVar(600, time.Second, "HttpClient.backendProxy.timeout", "HttpClient.routerTransformer.timeout")
 }
 
 func (rt *Handle) Start() {
@@ -317,7 +316,7 @@ func (rt *Handle) Start() {
 				for _, partition := range rt.activePartitions(ctx) {
 					pool.PingWorker(partition)
 				}
-				mainLoopSleep = rt.reloadableConfig.readSleep
+				mainLoopSleep = rt.reloadableConfig.readSleep.Load()
 			}
 		}
 	}))
@@ -345,8 +344,8 @@ func (rt *Handle) statusInsertLoop() {
 	for {
 		jobResponseBuffer, numJobResponses, _, isResponseQOpen := lo.BufferWithTimeout(
 			rt.responseQ,
-			rt.reloadableConfig.updateStatusBatchSize,
-			rt.reloadableConfig.maxStatusUpdateWait,
+			rt.reloadableConfig.updateStatusBatchSize.Load(),
+			rt.reloadableConfig.maxStatusUpdateWait.Load(),
 		)
 		if numJobResponses > 0 {
 			start := time.Now()

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -321,11 +321,14 @@ var _ = Describe("router", func() {
 
 	BeforeEach(func() {
 		conf = config.New()
+		config.Reset()
+		config.Set("Router.jobRetention", "175200h") // 20 Years(20*365*24)
 		c = &testContext{}
 		c.Setup()
 	})
 
 	AfterEach(func() {
+		config.Reset()
 		c.Finish()
 	})
 
@@ -427,7 +430,14 @@ var _ = Describe("router", func() {
 			defer worker.Stop()
 			Expect(worker.Work()).To(BeTrue())
 			Expect(worker.pickupCount).To(Equal(2))
-			<-done
+			Eventually(func() bool {
+				select {
+				case <-done:
+					return true
+				default:
+					return false
+				}
+			}, 20*time.Second, 100*time.Millisecond).Should(Equal(true))
 		})
 
 		It("should abort unprocessed jobs to ga destination because of bad payload", func() {
@@ -506,10 +516,18 @@ var _ = Describe("router", func() {
 			defer worker.Stop()
 			Expect(worker.Work()).To(BeTrue())
 			Expect(worker.pickupCount).To(Equal(1))
-			<-done
+			Eventually(func() bool {
+				select {
+				case <-done:
+					return true
+				default:
+					return false
+				}
+			}, 20*time.Second, 100*time.Millisecond).Should(Equal(true))
 		})
 
 		It("aborts events that are older than a configurable duration", func() {
+			config.Set("Router.jobRetention", "24h")
 			router := &Handle{
 				Reporting: &reporting.NOOP{},
 			}
@@ -587,6 +605,7 @@ var _ = Describe("router", func() {
 		})
 
 		It("aborts events that have reached max retries", func() {
+			config.Set("Router.jobRetention", "24h")
 			mockNetHandle := mocksRouter.NewMockNetHandle(c.mockCtrl)
 			c.mockBackendConfig.EXPECT().AccessToken().AnyTimes()
 
@@ -794,7 +813,14 @@ var _ = Describe("router", func() {
 			defer worker.Stop()
 			Expect(worker.Work()).To(BeTrue())
 			Expect(worker.pickupCount).To(Equal(5))
-			<-done
+			Eventually(func() bool {
+				select {
+				case <-done:
+					return true
+				default:
+					return false
+				}
+			}, 20*time.Second, 100*time.Millisecond).Should(Equal(true))
 		})
 
 		It("fails jobs if destination is not found in config", func() {
@@ -879,7 +905,14 @@ var _ = Describe("router", func() {
 			defer worker.Stop()
 			Expect(worker.Work()).To(BeTrue())
 			Expect(worker.pickupCount).To(Equal(1))
-			<-done
+			Eventually(func() bool {
+				select {
+				case <-done:
+					return true
+				default:
+					return false
+				}
+			}, 20*time.Second, 100*time.Millisecond).Should(Equal(true))
 		})
 	})
 
@@ -1023,7 +1056,14 @@ var _ = Describe("router", func() {
 			defer worker.Stop()
 			Expect(worker.Work()).To(BeTrue())
 			Expect(worker.pickupCount).To(Equal(3))
-			<-done
+			Eventually(func() bool {
+				select {
+				case <-done:
+					return true
+				default:
+					return false
+				}
+			}, 20*time.Second, 100*time.Millisecond).Should(Equal(true))
 		})
 
 		It("aborts jobs if batching fails for few of the jobs", func() {
@@ -1172,7 +1212,14 @@ var _ = Describe("router", func() {
 			defer worker.Stop()
 			Expect(worker.Work()).To(BeTrue())
 			Expect(worker.pickupCount).To(Equal(3))
-			<-done
+			Eventually(func() bool {
+				select {
+				case <-done:
+					return true
+				default:
+					return false
+				}
+			}, 20*time.Second, 100*time.Millisecond).Should(Equal(true))
 		})
 	})
 
@@ -1207,7 +1254,7 @@ var _ = Describe("router", func() {
 			router.Setup(gaDestinationDefinition, logger.NOP, conf, c.mockBackendConfig, c.mockRouterJobsDB, c.mockProcErrorsDB, transientsource.NewEmptyService(), rsources.NewNoOpService(), destinationdebugger.NewNoOpService())
 			router.transformer = mockTransformer
 			router.noOfWorkers = 1
-			router.reloadableConfig.noOfJobsToBatchInAWorker = config.GetReloadableIntVar(3, 1, rand.UniqueString(10))
+			router.reloadableConfig.noOfJobsToBatchInAWorker = config.GetReloadableIntVar(5, 1, rand.UniqueString(10))
 			router.reloadableConfig.routerTimeout = config.GetReloadableDurationVar(math.MaxInt64, time.Nanosecond, rand.UniqueString(10))
 
 			gaPayload := `{"body": {"XML": {}, "FORM": {}, "JSON": {}}, "type": "REST", "files": {}, "method": "POST", "params": {"t": "event", "v": "1", "an": "RudderAndroidClient", "av": "1.0", "ds": "android-sdk", "ea": "Demo Track", "ec": "Demo Category", "el": "Demo Label", "ni": 0, "qt": 59268380964, "ul": "en-US", "cid": "anon_id", "tid": "UA-185645846-1", "uip": "[::1]", "aiid": "com.rudderlabs.android.sdk"}, "userId": "anon_id", "headers": {}, "version": "1", "endpoint": "https://www.google-analytics.com/collect"}`
@@ -1396,7 +1443,14 @@ var _ = Describe("router", func() {
 			defer worker.Stop()
 			Expect(worker.Work()).To(BeTrue())
 			Expect(worker.pickupCount).To(Equal(5))
-			<-done
+			Eventually(func() bool {
+				select {
+				case <-done:
+					return true
+				default:
+					return false
+				}
+			}, 20*time.Second, 100*time.Millisecond).Should(Equal(true))
 		})
 
 		/*
@@ -1553,7 +1607,14 @@ var _ = Describe("router", func() {
 			defer worker.Stop()
 			Expect(worker.Work()).To(BeTrue())
 			Expect(worker.pickupCount).To(Equal(3))
-			<-done
+			Eventually(func() bool {
+				select {
+				case <-done:
+					return true
+				default:
+					return false
+				}
+			}, 20*time.Second, 100*time.Millisecond).Should(Equal(true))
 		})
 	})
 })

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -86,24 +86,7 @@ func NewTransformer(destinationTimeout, transformTimeout time.Duration) Transfor
 	return handle
 }
 
-var (
-	maxRetry          int
-	disableKeepAlives bool
-	retrySleep        time.Duration
-	pkgLogger         logger.Logger
-)
-
-// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
-func loadConfig() {
-	config.RegisterIntConfigVariable(30, &maxRetry, true, 1, "Processor.maxRetry")
-	config.RegisterDurationConfigVariable(100, &retrySleep, true, time.Millisecond, "Processor.retrySleep", "Processor.retrySleepInMS")
-	config.RegisterBoolConfigVariable(true, &disableKeepAlives, false, "Transformer.Client.disableKeepAlives")
-}
-
-func Init() {
-	loadConfig()
-	pkgLogger = logger.NewLogger().Child("router").Child("transformer")
-}
+var loggerOverride logger.Logger
 
 // Transform transforms router jobs to destination jobs
 func (trans *handle) Transform(transformType string, transformMessage *types.TransformMessageT) []types.DestinationJobT {
@@ -149,11 +132,11 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 			trans.transformRequestTimerStat.SendTiming(time.Since(s))
 			reqFailed = true
 			trans.logger.Errorf("JS HTTP connection error: URL: %v Error: %+v", url, err)
-			if retryCount > maxRetry {
+			if retryCount > config.GetInt("Processor.maxRetry", 30) {
 				panic(fmt.Errorf("JS HTTP connection error: URL: %v Error: %+v", url, err))
 			}
 			retryCount++
-			time.Sleep(retrySleep)
+			time.Sleep(config.GetDurationVar(100, time.Millisecond, "Processor.retrySleep", "Processor.retrySleepInMS"))
 			// Refresh the connection
 			continue
 		}
@@ -299,8 +282,13 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 }
 
 func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration) {
-	trans.logger = pkgLogger
-	trans.tr = &http.Transport{DisableKeepAlives: disableKeepAlives}
+	if loggerOverride == nil {
+		trans.logger = logger.NewLogger().Child("router").Child("transformer")
+	} else {
+		trans.logger = loggerOverride
+	}
+
+	trans.tr = &http.Transport{DisableKeepAlives: config.GetBool("Transformer.Client.disableKeepAlives", true)}
 	// The timeout between server and transformer
 	// Basically this timeout is more for communication between transformer and server
 	trans.transformTimeout = transformTimeout

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -349,7 +349,7 @@ func mockProxyHandler(timeout time.Duration, code int, response string) *chi.Mux
 func TestTransformNoValidationErrors(t *testing.T) {
 	initMocks(t)
 	config.Reset()
-	pkgLogger = logger.NOP
+	loggerOverride = logger.NOP
 	expectedTransformerResponse := []types.DestinationJobT{
 		{JobMetadataArray: []types.JobMetadataT{{JobID: 1}}, StatusCode: http.StatusOK},
 		{JobMetadataArray: []types.JobMetadataT{{JobID: 2}}, StatusCode: http.StatusOK},
@@ -381,7 +381,7 @@ func TestTransformNoValidationErrors(t *testing.T) {
 func TestTransformValidationUnmarshallingError(t *testing.T) {
 	initMocks(t)
 	config.Reset()
-	pkgLogger = logger.NOP
+	loggerOverride = logger.NOP
 	expectedErrorTxt := "Transformer returned invalid response: invalid json for input:"
 	expectedTransformerResponse := []types.DestinationJobT{
 		{JobMetadataArray: []types.JobMetadataT{{JobID: 1}}, StatusCode: http.StatusInternalServerError, Error: expectedErrorTxt},
@@ -413,7 +413,7 @@ func TestTransformValidationUnmarshallingError(t *testing.T) {
 func TestTransformValidationInOutMismatchError(t *testing.T) {
 	initMocks(t)
 	config.Reset()
-	pkgLogger = logger.NOP
+	loggerOverride = logger.NOP
 	expectedErrorTxt := "Transformer returned invalid output size: 4 for input size: 3"
 	expectedTransformerResponse := []types.DestinationJobT{
 		{JobMetadataArray: []types.JobMetadataT{{JobID: 1}}, StatusCode: http.StatusInternalServerError, Error: expectedErrorTxt},
@@ -453,7 +453,7 @@ func TestTransformValidationInOutMismatchError(t *testing.T) {
 func TestTransformValidationJobIDMismatchError(t *testing.T) {
 	initMocks(t)
 	config.Reset()
-	pkgLogger = logger.NOP
+	loggerOverride = logger.NOP
 	expectedErrorTxt := "Transformer returned invalid jobIDs: [4]"
 	expectedTransformerResponse := []types.DestinationJobT{
 		{JobMetadataArray: []types.JobMetadataT{{JobID: 1}}, StatusCode: http.StatusInternalServerError, Error: expectedErrorTxt},
@@ -544,7 +544,7 @@ func initMocks(t *testing.T) {
 	mockRudderStats.EXPECT().SendTiming(gomock.Any()).AnyTimes()
 	mockRudderStats.EXPECT().Increment().AnyTimes()
 
-	pkgLogger = logger.NOP
+	loggerOverride = logger.NOP
 }
 
 func normalizeErrors(transformerResponse []types.DestinationJobT, prefix string) {

--- a/router/types.go
+++ b/router/types.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/router/types"
 )
@@ -70,29 +71,29 @@ type JobResponse struct {
 }
 
 type reloadableConfig struct {
-	jobQueryBatchSize                       int
-	updateStatusBatchSize                   int
-	readSleep                               time.Duration
-	maxStatusUpdateWait                     time.Duration
-	minRetryBackoff                         time.Duration
-	maxRetryBackoff                         time.Duration
-	jobsBatchTimeout                        time.Duration
-	failingJobsPenaltyThreshold             float64
-	failingJobsPenaltySleep                 time.Duration
-	toAbortDestinationIDs                   string
-	noOfJobsToBatchInAWorker                int
-	jobsDBCommandTimeout                    time.Duration
-	jobdDBMaxRetries                        int
-	maxFailedCountForJob                    int
-	payloadLimit                            int64
-	routerTimeout                           time.Duration
-	retryTimeWindow                         time.Duration
-	pickupFlushInterval                     time.Duration
-	maxDSQuerySize                          int
-	jobIteratorMaxQueries                   int
-	jobIteratorDiscardedPercentageTolerance int
-	savePayloadOnError                      bool
-	transformerProxy                        bool
-	skipRtAbortAlertForTransformation       bool // represents if event delivery(via transformerProxy) should be alerted via router-aborted-count alert def
-	skipRtAbortAlertForDelivery             bool // represents if transformation(router or batch) should be alerted via router-aborted-count alert def
+	jobQueryBatchSize                       *config.Reloadable[int]
+	updateStatusBatchSize                   *config.Reloadable[int]
+	readSleep                               *config.Reloadable[time.Duration]
+	maxStatusUpdateWait                     *config.Reloadable[time.Duration]
+	minRetryBackoff                         *config.Reloadable[time.Duration]
+	maxRetryBackoff                         *config.Reloadable[time.Duration]
+	jobsBatchTimeout                        *config.Reloadable[time.Duration]
+	failingJobsPenaltyThreshold             *config.Reloadable[float64]
+	failingJobsPenaltySleep                 *config.Reloadable[time.Duration]
+	toAbortDestinationIDs                   *config.Reloadable[string]
+	noOfJobsToBatchInAWorker                *config.Reloadable[int]
+	jobsDBCommandTimeout                    *config.Reloadable[time.Duration]
+	jobdDBMaxRetries                        *config.Reloadable[int]
+	maxFailedCountForJob                    *config.Reloadable[int]
+	payloadLimit                            *config.Reloadable[int64]
+	routerTimeout                           *config.Reloadable[time.Duration]
+	retryTimeWindow                         *config.Reloadable[time.Duration]
+	pickupFlushInterval                     *config.Reloadable[time.Duration]
+	maxDSQuerySize                          *config.Reloadable[int]
+	jobIteratorMaxQueries                   *config.Reloadable[int]
+	jobIteratorDiscardedPercentageTolerance *config.Reloadable[int]
+	savePayloadOnError                      *config.Reloadable[bool]
+	transformerProxy                        *config.Reloadable[bool]
+	skipRtAbortAlertForTransformation       *config.Reloadable[bool] // represents if event delivery(via transformerProxy) should be alerted via router-aborted-count alert def
+	skipRtAbortAlertForDelivery             *config.Reloadable[bool] // represents if transformation(router or batch) should be alerted via router-aborted-count alert def
 }

--- a/router/utils/utils.go
+++ b/router/utils/utils.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	JobRetention time.Duration
-	EmptyPayload = []byte(`{}`)
+	DefaultJobRetention *config.Reloadable[time.Duration]
+	EmptyPayload        = []byte(`{}`)
 )
 
 const (
@@ -46,21 +46,8 @@ type SendPostResponse struct {
 	ResponseBody        []byte
 }
 
-func Init() {
-	loadConfig()
-}
-
-// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
-func loadConfig() {
-	config.RegisterDurationConfigVariable(720, &JobRetention, true, time.Hour, "Router.jobRetention")
-}
-
 func getRetentionTimeForDestination(destID string) time.Duration {
-	if config.IsSet("Router." + destID + ".jobRetention") {
-		return config.GetDuration("Router."+destID+".jobRetention", 720, time.Hour)
-	}
-
-	return JobRetention
+	return config.GetDurationVar(720, time.Hour, "Router."+destID+".jobRetention", "Router.jobRetention")
 }
 
 func ToBeDrained(job *jobsdb.JobT, destID, toAbortDestinationIDs string, destinationsMap map[string]*DestinationWithSources) (bool, string) {

--- a/router/utils/utils.go
+++ b/router/utils/utils.go
@@ -14,10 +14,7 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
-var (
-	DefaultJobRetention *config.Reloadable[time.Duration]
-	EmptyPayload        = []byte(`{}`)
-)
+var EmptyPayload = []byte(`{}`)
 
 const (
 	DRAIN_ERROR_CODE int = 410

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -31,8 +31,6 @@ import (
 	"github.com/rudderlabs/rudder-server/processor/stash"
 	"github.com/rudderlabs/rudder-server/processor/transformer"
 	"github.com/rudderlabs/rudder-server/router/customdestinationmanager"
-	routertransformer "github.com/rudderlabs/rudder-server/router/transformer"
-	batchrouterutils "github.com/rudderlabs/rudder-server/router/utils"
 	"github.com/rudderlabs/rudder-server/rruntime"
 	"github.com/rudderlabs/rudder-server/services/alert"
 	"github.com/rudderlabs/rudder-server/services/controlplane"
@@ -331,13 +329,11 @@ func runAllInit() {
 	warehouse.Init4()
 	validations.Init()
 	webhook.Init()
-	batchrouterutils.Init()
 	eventschema.Init()
 	eventschema.Init2()
 	stash.Init()
 	kafka.Init()
 	customdestinationmanager.Init()
-	routertransformer.Init()
 	alert.Init()
 	oauth.Init()
 }


### PR DESCRIPTION
# Description

- Use new reloadable config api in router and batchrouter
- Drop support for `forceHonorUploadFrequency` since it was never used
- Minor improvements on router tests, when mock calls are missing

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
