### PR TITLE
chore: check list permissions for replay

### DIFF
--- a/warehouse/grpc.go
+++ b/warehouse/grpc.go
@@ -708,6 +708,12 @@ func (g *GRPC) validateObjectStorage(ctx context.Context, request validateObject
 		return fmt.Errorf("unable to create file manager: \n%s", err.Error())
 	}
 
+	it := filemanager.IterateFilesWithPrefix(ctx, fileManager.Prefix(), "", 1, fileManager)
+	_ = it.Next()
+	if err = it.Err(); err != nil {
+		return invalidDestinationCredErr{Base: err, Operation: "list"}
+	}
+
 	tempFilePath, err := validations.CreateTempLoadFile(&backendconfig.DestinationT{
 		DestinationDefinition: backendconfig.DestinationDefinitionT{
 			Name: request.Type,
@@ -757,7 +763,6 @@ func (g *GRPC) validateObjectStorage(ctx context.Context, request validateObject
 	if err = f.Close(); err != nil {
 		return fmt.Errorf("unable to close file: \n%w", err)
 	}
-
 	return nil
 }
 

--- a/warehouse/grpc_test.go
+++ b/warehouse/grpc_test.go
@@ -989,7 +989,45 @@ func TestGRPC(t *testing.T) {
 					})
 					require.NoError(t, err)
 					require.NotEmpty(t, res)
-					require.Equal(t, "Invalid destination creds, failed for operation: upload with err: \nEndpoint:  does not follow ip address or domain name standards.", res.GetError())
+					require.Equal(t, "Invalid destination creds, failed for operation: list with err: \nEndpoint:  does not follow ip address or domain name standards.", res.GetError())
+					require.False(t, res.GetIsValid())
+				})
+				t.Run("list permissions missing", func(t *testing.T) {
+					res, err := grpcClient.ValidateObjectStorageDestination(ctx, &proto.ValidateObjectStorageRequest{
+						Type: whutils.MINIO,
+						Config: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"region": {
+									Kind: &structpb.Value_StringValue{
+										StringValue: minioResource.SiteRegion,
+									},
+								},
+								"bucketName": {
+									Kind: &structpb.Value_StringValue{
+										StringValue: minioResource.BucketName,
+									},
+								},
+								"secretAccessKey": {
+									Kind: &structpb.Value_StringValue{
+										StringValue: "wrongSecretKey",
+									},
+								},
+								"accessKeyID": {
+									Kind: &structpb.Value_StringValue{
+										StringValue: "wrongAccessKey",
+									},
+								},
+								"endPoint": {
+									Kind: &structpb.Value_StringValue{
+										StringValue: minioResource.Endpoint,
+									},
+								},
+							},
+						},
+					})
+					require.NoError(t, err)
+					require.NotEmpty(t, res)
+					require.Equal(t, "Invalid destination creds, failed for operation: list with err: \nThe Access Key Id you provided does not exist in our records.", res.GetError())
 					require.False(t, res.GetIsValid())
 				})
 				t.Run("checkMapForValidKey", func(t *testing.T) {


### PR DESCRIPTION
# Description
In this PR,
Add a check for list permission. This permission is required for doing a replay.

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-94/verify-replay-will-work-when-custom-object-storage-is-defined

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
