### PR TITLE
chore: minor processor cleanup

### DIFF
--- a/archiver/archiver_test.go
+++ b/archiver/archiver_test.go
@@ -33,8 +33,8 @@ import (
 
 func TestJobsArchival(t *testing.T) {
 	var (
-		prefix        = trand.String(10)
-		minioResource []*resource.MinioResource
+		prefixByWorkspace = map[int]string{0: trand.String(10), 1: trand.String(10), 2: trand.String(10)}
+		minioResource     []*resource.MinioResource
 
 		// test data - contains jobs from 3 workspaces(1 - 1 source, 2 & 3 - 2 sources each)
 		seedJobsFileName    = "testdata/MultiWorkspaceBackupJobs.json.gz"
@@ -77,7 +77,7 @@ func TestJobsArchival(t *testing.T) {
 				Type: "MINIO",
 				Config: map[string]interface{}{
 					"bucketName":      minioResource[0].BucketName,
-					"prefix":          prefix,
+					"prefix":          prefixByWorkspace[0],
 					"endPoint":        minioResource[0].Endpoint,
 					"accessKeyID":     minioResource[0].AccessKeyID,
 					"secretAccessKey": minioResource[0].AccessKeySecret,
@@ -95,7 +95,7 @@ func TestJobsArchival(t *testing.T) {
 				Type: "MINIO",
 				Config: map[string]interface{}{
 					"bucketName":      minioResource[1].BucketName,
-					"prefix":          prefix,
+					"prefix":          prefixByWorkspace[1],
 					"endPoint":        minioResource[1].Endpoint,
 					"accessKeyID":     minioResource[1].AccessKeyID,
 					"secretAccessKey": minioResource[1].AccessKeySecret,
@@ -113,7 +113,7 @@ func TestJobsArchival(t *testing.T) {
 				Type: "MINIO",
 				Config: map[string]interface{}{
 					"bucketName":      minioResource[2].BucketName,
-					"prefix":          prefix,
+					"prefix":          prefixByWorkspace[2],
 					"endPoint":        minioResource[2].Endpoint,
 					"accessKeyID":     minioResource[2].AccessKeyID,
 					"secretAccessKey": minioResource[2].AccessKeySecret,
@@ -169,7 +169,7 @@ func TestJobsArchival(t *testing.T) {
 		workspace := "defaultWorkspaceID-" + strconv.Itoa(i+1)
 		fm, err := fileUploaderProvider.GetFileManager(workspace)
 		require.NoError(t, err)
-		fileIter := fm.ListFilesWithPrefix(context.Background(), "", prefix, 20)
+		fileIter := fm.ListFilesWithPrefix(context.Background(), "", prefixByWorkspace[i], 20)
 		files, err := getAllFileNames(fileIter)
 		require.NoError(t, err)
 		require.Equal(t, sourcesPerWorkspace[i], len(files),

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -978,7 +978,7 @@ func (proc *Handle) recordEventDeliveryStatus(jobsByDestID map[string][]*jobsdb.
 	}
 }
 
-func (proc *Handle) getDestTransformerEvents(response transformer.Response, commonMetaData *transformer.Metadata, eventsByMessageID map[string]types.SingularEventWithReceivedAt, destination *backendconfig.DestinationT, stage string, trackingPlanEnabled, userTransformationEnabled bool) ([]transformer.TransformerEvent, []*types.PUReportedMetric, map[string]int64, map[string]MetricMetadata) {
+func (proc *Handle) getDestTransformerEvents(response transformer.Response, commonMetaData *transformer.Metadata, eventsByMessageID map[string]types.SingularEventWithReceivedAt, destination *backendconfig.DestinationT, inPU, pu string) ([]transformer.TransformerEvent, []*types.PUReportedMetric, map[string]int64, map[string]MetricMetadata) {
 	successMetrics := make([]*types.PUReportedMetric, 0)
 	connectionDetailsMap := make(map[string]*types.ConnectionDetails)
 	statusDetailsMap := make(map[string]map[string]*types.StatusDetail)
@@ -996,22 +996,21 @@ func (proc *Handle) getDestTransformerEvents(response transformer.Response, comm
 		)
 
 		for _, message := range messages {
-			proc.updateMetricMaps(successCountMetadataMap, successCountMap, connectionDetailsMap, statusDetailsMap, userTransformedEvent, jobsdb.Succeeded.State, stage,
-				func() json.RawMessage {
-					if stage != transformer.TrackingPlanValidationStage {
-						return []byte(`{}`)
-					}
-					if proc.transientSources.Apply(commonMetaData.SourceID) {
-						return []byte(`{}`)
-					}
+			proc.updateMetricMaps(successCountMetadataMap, successCountMap, connectionDetailsMap, statusDetailsMap, userTransformedEvent, jobsdb.Succeeded.State, pu, func() json.RawMessage {
+				if pu != types.TRACKINGPLAN_VALIDATOR {
+					return []byte(`{}`)
+				}
+				if proc.transientSources.Apply(commonMetaData.SourceID) {
+					return []byte(`{}`)
+				}
 
-					sampleEvent, err := jsonfast.Marshal(message)
-					if err != nil {
-						proc.logger.Errorf(`[Processor: getDestTransformerEvents] Failed to unmarshal first element in transformed events: %v`, err)
-						sampleEvent = []byte(`{}`)
-					}
-					return sampleEvent
-				},
+				sampleEvent, err := jsonfast.Marshal(message)
+				if err != nil {
+					proc.logger.Errorf(`[Processor: getDestTransformerEvents] Failed to unmarshal first element in transformed events: %v`, err)
+					sampleEvent = []byte(`{}`)
+				}
+				return sampleEvent
+			},
 				nil)
 		}
 
@@ -1041,30 +1040,6 @@ func (proc *Handle) getDestTransformerEvents(response transformer.Response, comm
 	// REPORTING - START
 	if proc.isReportingEnabled() {
 		types.AssertSameKeys(connectionDetailsMap, statusDetailsMap)
-
-		var inPU, pu string
-		if stage == transformer.UserTransformerStage {
-			if trackingPlanEnabled {
-				inPU = types.TRACKINGPLAN_VALIDATOR
-			} else {
-				inPU = types.DESTINATION_FILTER
-			}
-			pu = types.USER_TRANSFORMER
-		} else if stage == transformer.TrackingPlanValidationStage {
-			inPU = types.DESTINATION_FILTER
-			pu = types.TRACKINGPLAN_VALIDATOR
-		} else if stage == transformer.EventFilterStage {
-			if userTransformationEnabled {
-				inPU = types.USER_TRANSFORMER
-			} else {
-				if trackingPlanEnabled {
-					inPU = types.TRACKINGPLAN_VALIDATOR
-				} else {
-					inPU = types.DESTINATION_FILTER
-				}
-			}
-			pu = types.EVENT_FILTER
-		}
 
 		for k, cd := range connectionDetailsMap {
 			for _, sd := range statusDetailsMap[k] {
@@ -1162,7 +1137,7 @@ func (proc *Handle) updateMetricMaps(
 	// create status details for each validation error
 	// single event can have multiple validation errors of same type
 	veCount := len(event.ValidationErrors)
-	if stage == transformer.TrackingPlanValidationStage && status == jobsdb.Succeeded.State {
+	if stage == types.TRACKINGPLAN_VALIDATOR && status == jobsdb.Succeeded.State {
 		if veCount > 0 {
 			status = types.SUCCEEDED_WITH_VIOLATIONS
 		} else {
@@ -1204,19 +1179,19 @@ func (proc *Handle) updateMetricMaps(
 	sd.ViolationCount += int64(veCount)
 }
 
-func (proc *Handle) getNonSuccessfulMetrics(response transformer.Response, commonMetaData *transformer.Metadata, eventsByMessageID map[string]types.SingularEventWithReceivedAt, stage string, transformationEnabled, trackingPlanEnabled bool) *NonSuccessfulTransformationMetrics {
+func (proc *Handle) getNonSuccessfulMetrics(response transformer.Response, commonMetaData *transformer.Metadata, eventsByMessageID map[string]types.SingularEventWithReceivedAt, inPU, pu string) *NonSuccessfulTransformationMetrics {
 	m := &NonSuccessfulTransformationMetrics{}
 
 	grouped := lo.GroupBy(response.FailedEvents, func(event transformer.TransformerResponse) bool { return event.StatusCode == types.FilterEventCode })
 	filtered, failed := grouped[true], grouped[false]
 
-	m.filteredJobs, m.filteredMetrics, m.filteredCountMap = proc.getTransformationMetrics(filtered, jobsdb.Filtered.State, commonMetaData, eventsByMessageID, stage, transformationEnabled, trackingPlanEnabled)
-	m.failedJobs, m.failedMetrics, m.failedCountMap = proc.getTransformationMetrics(failed, jobsdb.Aborted.State, commonMetaData, eventsByMessageID, stage, transformationEnabled, trackingPlanEnabled)
+	m.filteredJobs, m.filteredMetrics, m.filteredCountMap = proc.getTransformationMetrics(filtered, jobsdb.Filtered.State, commonMetaData, eventsByMessageID, inPU, pu)
+	m.failedJobs, m.failedMetrics, m.failedCountMap = proc.getTransformationMetrics(failed, jobsdb.Aborted.State, commonMetaData, eventsByMessageID, inPU, pu)
 
 	return m
 }
 
-func (proc *Handle) getTransformationMetrics(transformerResponses []transformer.TransformerResponse, state string, commonMetaData *transformer.Metadata, eventsByMessageID map[string]types.SingularEventWithReceivedAt, stage string, transformationEnabled, trackingPlanEnabled bool) ([]*jobsdb.JobT, []*types.PUReportedMetric, map[string]int64) {
+func (proc *Handle) getTransformationMetrics(transformerResponses []transformer.TransformerResponse, state string, commonMetaData *transformer.Metadata, eventsByMessageID map[string]types.SingularEventWithReceivedAt, inPU, pu string) ([]*jobsdb.JobT, []*types.PUReportedMetric, map[string]int64) {
 	metrics := make([]*types.PUReportedMetric, 0)
 	connectionDetailsMap := make(map[string]*types.ConnectionDetails)
 	statusDetailsMap := make(map[string]map[string]*types.StatusDetail)
@@ -1237,7 +1212,7 @@ func (proc *Handle) getTransformationMetrics(transformerResponses []transformer.
 		}
 
 		for _, message := range messages {
-			proc.updateMetricMaps(nil, countMap, connectionDetailsMap, statusDetailsMap, failedEvent, state, stage, func() json.RawMessage {
+			proc.updateMetricMaps(nil, countMap, connectionDetailsMap, statusDetailsMap, failedEvent, state, pu, func() json.RawMessage {
 				if proc.transientSources.Apply(commonMetaData.SourceID) {
 					return []byte(`{}`)
 				}
@@ -1263,7 +1238,7 @@ func (proc *Handle) getTransformationMetrics(transformerResponses []transformer.
 			"source_job_run_id":  failedEvent.Metadata.SourceJobRunID,
 			"error":              failedEvent.Error,
 			"status_code":        failedEvent.StatusCode,
-			"stage":              stage,
+			"stage":              pu,
 			"record_id":          failedEvent.Metadata.RecordID,
 			"source_task_run_id": failedEvent.Metadata.SourceTaskRunID,
 		}
@@ -1291,7 +1266,7 @@ func (proc *Handle) getTransformationMetrics(transformerResponses []transformer.
 		procErrorStat := stats.Default.NewTaggedStat("proc_error_counts", stats.CountType, stats.Tags{
 			"destName":   commonMetaData.DestinationType,
 			"statusCode": strconv.Itoa(failedEvent.StatusCode),
-			"stage":      stage,
+			"stage":      pu,
 		})
 
 		procErrorStat.Increment()
@@ -1300,33 +1275,6 @@ func (proc *Handle) getTransformationMetrics(transformerResponses []transformer.
 	// REPORTING - START
 	if proc.isReportingEnabled() {
 		types.AssertSameKeys(connectionDetailsMap, statusDetailsMap)
-
-		var inPU, pu string
-		if stage == transformer.EventFilterStage {
-			if transformationEnabled {
-				inPU = types.USER_TRANSFORMER
-			} else {
-				if trackingPlanEnabled {
-					inPU = types.TRACKINGPLAN_VALIDATOR
-				} else {
-					inPU = types.DESTINATION_FILTER
-				}
-			}
-			pu = types.EVENT_FILTER
-		} else if stage == transformer.DestTransformerStage {
-			inPU = types.EVENT_FILTER
-			pu = types.DEST_TRANSFORMER
-		} else if stage == transformer.UserTransformerStage {
-			if trackingPlanEnabled {
-				inPU = types.TRACKINGPLAN_VALIDATOR
-			} else {
-				inPU = types.DESTINATION_FILTER
-			}
-			pu = types.USER_TRANSFORMER
-		} else if stage == transformer.TrackingPlanValidationStage {
-			inPU = types.DESTINATION_FILTER
-			pu = types.TRACKINGPLAN_VALIDATOR
-		}
 		for k, cd := range connectionDetailsMap {
 			for _, sd := range statusDetailsMap[k] {
 				m := &types.PUReportedMetric{
@@ -2290,6 +2238,12 @@ func (proc *Handle) transformSrcDest(
 
 	var response transformer.Response
 	var eventsToTransform []transformer.TransformerEvent
+	var inPU string
+	if trackingPlanEnabled {
+		inPU = types.TRACKINGPLAN_VALIDATOR
+	} else {
+		inPU = types.DESTINATION_FILTER
+	}
 	// Send to custom transformer only if the destination has a transformer enabled
 	if transformationEnabled {
 		userTransformationStat := proc.newUserTransformationStat(sourceID, workspaceID, destination)
@@ -2305,8 +2259,8 @@ func (proc *Handle) transformSrcDest(
 			var successMetrics []*types.PUReportedMetric
 			var successCountMap map[string]int64
 			var successCountMetadataMap map[string]MetricMetadata
-			eventsToTransform, successMetrics, successCountMap, successCountMetadataMap = proc.getDestTransformerEvents(response, commonMetaData, eventsByMessageID, destination, transformer.UserTransformerStage, trackingPlanEnabled, transformationEnabled)
-			nonSuccessMetrics := proc.getNonSuccessfulMetrics(response, commonMetaData, eventsByMessageID, transformer.UserTransformerStage, transformationEnabled, trackingPlanEnabled)
+			eventsToTransform, successMetrics, successCountMap, successCountMetadataMap = proc.getDestTransformerEvents(response, commonMetaData, eventsByMessageID, destination, inPU, types.USER_TRANSFORMER)
+			nonSuccessMetrics := proc.getNonSuccessfulMetrics(response, commonMetaData, eventsByMessageID, inPU, types.USER_TRANSFORMER)
 			droppedJobs = append(droppedJobs, append(proc.getDroppedJobs(response, eventList), append(nonSuccessMetrics.failedJobs, nonSuccessMetrics.filteredJobs...)...)...)
 			if _, ok := procErrorJobsByDestID[destID]; !ok {
 				procErrorJobsByDestID[destID] = make([]*jobsdb.JobT, 0)
@@ -2341,6 +2295,7 @@ func (proc *Handle) transformSrcDest(
 				inCountMetadataMap = successCountMetadataMap
 			}
 			// REPORTING - END
+			inPU = types.USER_TRANSFORMER // for the next step in the pipeline
 		})
 	} else {
 		proc.logger.Debug("No custom transformation")
@@ -2377,28 +2332,17 @@ func (proc *Handle) transformSrcDest(
 	var successMetrics []*types.PUReportedMetric
 	var successCountMap map[string]int64
 	var successCountMetadataMap map[string]MetricMetadata
-	nonSuccessMetrics := proc.getNonSuccessfulMetrics(response, commonMetaData, eventsByMessageID, transformer.EventFilterStage, transformationEnabled, trackingPlanEnabled)
+	nonSuccessMetrics := proc.getNonSuccessfulMetrics(response, commonMetaData, eventsByMessageID, inPU, types.EVENT_FILTER)
 	droppedJobs = append(droppedJobs, append(proc.getDroppedJobs(response, eventsToTransform), append(nonSuccessMetrics.failedJobs, nonSuccessMetrics.filteredJobs...)...)...)
 	if _, ok := procErrorJobsByDestID[destID]; !ok {
 		procErrorJobsByDestID[destID] = make([]*jobsdb.JobT, 0)
 	}
 	procErrorJobsByDestID[destID] = append(procErrorJobsByDestID[destID], nonSuccessMetrics.failedJobs...)
-	eventsToTransform, successMetrics, successCountMap, successCountMetadataMap = proc.getDestTransformerEvents(response, commonMetaData, eventsByMessageID, destination, transformer.EventFilterStage, trackingPlanEnabled, transformationEnabled)
+	eventsToTransform, successMetrics, successCountMap, successCountMetadataMap = proc.getDestTransformerEvents(response, commonMetaData, eventsByMessageID, destination, inPU, types.EVENT_FILTER)
 	proc.logger.Debug("Supported messages filtering output size", len(eventsToTransform))
 
 	// REPORTING - START
 	if proc.isReportingEnabled() {
-		var inPU string
-		if transformationEnabled {
-			inPU = types.USER_TRANSFORMER
-		} else {
-			if trackingPlanEnabled {
-				inPU = types.TRACKINGPLAN_VALIDATOR
-			} else {
-				inPU = types.DESTINATION_FILTER
-			}
-		}
-
 		diffMetrics := getDiffMetrics(inPU, types.EVENT_FILTER, inCountMetadataMap, inCountMap, successCountMap, nonSuccessMetrics.failedCountMap, nonSuccessMetrics.filteredCountMap)
 		reportMetrics = append(reportMetrics, successMetrics...)
 		reportMetrics = append(reportMetrics, nonSuccessMetrics.failedMetrics...)
@@ -2451,7 +2395,7 @@ func (proc *Handle) transformSrcDest(
 
 			nonSuccessMetrics := proc.getNonSuccessfulMetrics(
 				response, commonMetaData, eventsByMessageID,
-				transformer.DestTransformerStage, transformationEnabled, trackingPlanEnabled,
+				types.EVENT_FILTER, types.DEST_TRANSFORMER,
 			)
 			destTransformationStat.numEvents.Count(len(eventsToTransform))
 			destTransformationStat.numOutputSuccessEvents.Count(len(response.Events))

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2262,14 +2262,13 @@ var _ = Describe("Processor", Ordered, func() {
 				types.DEST_TRANSFORMER,
 			)
 
-			key := fmt.Sprintf(
-				"%s!<<#>>!%s!<<#>>!%s!<<#>>!%s!<<#>>!%s",
+			key := strings.Join([]string{
 				commonMetadata.SourceID,
 				commonMetadata.DestinationID,
 				commonMetadata.SourceJobRunID,
 				commonMetadata.EventName,
 				commonMetadata.EventType,
-			)
+			},  "!<<#>>!")
 
 			Expect(len(m.failedJobs)).To(Equal(2))
 			Expect(len(m.failedMetrics)).To(Equal(2))

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2268,7 +2268,7 @@ var _ = Describe("Processor", Ordered, func() {
 				commonMetadata.SourceJobRunID,
 				commonMetadata.EventName,
 				commonMetadata.EventType,
-			},  "!<<#>>!")
+			}, "!<<#>>!")
 
 			Expect(len(m.failedJobs)).To(Equal(2))
 			Expect(len(m.failedMetrics)).To(Equal(2))

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2258,11 +2258,18 @@ var _ = Describe("Processor", Ordered, func() {
 			m := processor.getNonSuccessfulMetrics(transformerResponse,
 				&commonMetadata,
 				eventsByMessageID,
-				transformer.DestTransformerStage,
-				false,
-				false)
+				types.DEST_TRANSFORMER,
+				types.EVENT_FILTER,
+			)
 
-			key := fmt.Sprintf("%s!<<#>>!%s!<<#>>!%s!<<#>>!%s!<<#>>!%s", commonMetadata.SourceID, commonMetadata.DestinationID, commonMetadata.SourceJobRunID, commonMetadata.EventName, commonMetadata.EventType)
+			key := fmt.Sprintf(
+				"%s!<<#>>!%s!<<#>>!%s!<<#>>!%s!<<#>>!%s",
+				commonMetadata.SourceID,
+				commonMetadata.DestinationID,
+				commonMetadata.SourceJobRunID,
+				commonMetadata.EventName,
+				commonMetadata.EventType,
+			)
 
 			Expect(len(m.failedJobs)).To(Equal(2))
 			Expect(len(m.failedMetrics)).To(Equal(2))

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2258,8 +2258,8 @@ var _ = Describe("Processor", Ordered, func() {
 			m := processor.getNonSuccessfulMetrics(transformerResponse,
 				&commonMetadata,
 				eventsByMessageID,
-				types.DEST_TRANSFORMER,
 				types.EVENT_FILTER,
+				types.DEST_TRANSFORMER,
 			)
 
 			key := fmt.Sprintf(

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2490,7 +2490,7 @@ var _ = Describe("Static Function Tests", func() {
 			countMap := make(map[string]int64)
 			countMetadataMap := make(map[string]MetricMetadata)
 			// update metric maps
-			proc.updateMetricMaps(countMetadataMap, countMap, connectionDetailsMap, statusDetailsMap, inputEvent, jobsdb.Succeeded.State, transformer.TrackingPlanValidationStage, func() json.RawMessage { return []byte(`{}`) }, nil)
+			proc.updateMetricMaps(countMetadataMap, countMap, connectionDetailsMap, statusDetailsMap, inputEvent, jobsdb.Succeeded.State, types.TRACKINGPLAN_VALIDATOR, func() json.RawMessage { return []byte(`{}`) }, nil)
 
 			Expect(len(countMetadataMap)).To(Equal(1))
 			Expect(len(countMap)).To(Equal(1))

--- a/processor/trackingplan.go
+++ b/processor/trackingplan.go
@@ -113,8 +113,8 @@ func (proc *Handle) validateEvents(groupedEventsBySourceId map[SourceIDT][]trans
 		trackingPlanEnabledMap[SourceIDT(sourceID)] = true
 
 		var successMetrics []*types.PUReportedMetric
-		eventsToTransform, successMetrics, _, _ := proc.getDestTransformerEvents(response, commonMetaData, eventsByMessageID, destination, transformer.TrackingPlanValidationStage, true, false) // Note: Sending false for usertransformation enabled is safe because this stage is before user transformation.
-		nonSuccessMetrics := proc.getNonSuccessfulMetrics(response, commonMetaData, eventsByMessageID, transformer.TrackingPlanValidationStage, false, true)
+		eventsToTransform, successMetrics, _, _ := proc.getDestTransformerEvents(response, commonMetaData, eventsByMessageID, destination, types.DESTINATION_FILTER, types.TRACKINGPLAN_VALIDATOR) // Note: Sending false for usertransformation enabled is safe because this stage is before user transformation.
+		nonSuccessMetrics := proc.getNonSuccessfulMetrics(response, commonMetaData, eventsByMessageID, types.DESTINATION_FILTER, types.TRACKINGPLAN_VALIDATOR)
 
 		validationStat.numValidationSuccessEvents.Count(len(eventsToTransform))
 		validationStat.numValidationFailedEvents.Count(len(nonSuccessMetrics.failedJobs))

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -32,10 +32,9 @@ import (
 )
 
 const (
-	UserTransformerStage        = "user_transformer"
-	EventFilterStage            = "event_filter"
-	DestTransformerStage        = "dest_transformer"
-	TrackingPlanValidationStage = "trackingPlan_validation"
+	userTransformerStage        = "user_transformer"
+	destTransformerStage        = "dest_transformer"
+	trackingPlanValidationStage = "trackingPlan_validation"
 )
 
 const (
@@ -247,17 +246,17 @@ func (trans *handle) Transform(ctx context.Context, clientEvents []TransformerEv
 	}
 	destType := clientEvents[0].Destination.DestinationDefinition.Name
 	transformURL := trans.destTransformURL(destType)
-	return trans.transform(ctx, clientEvents, transformURL, batchSize, DestTransformerStage)
+	return trans.transform(ctx, clientEvents, transformURL, batchSize, destTransformerStage)
 }
 
 // UserTransform function is used to invoke user transformer API
 func (trans *handle) UserTransform(ctx context.Context, clientEvents []TransformerEvent, batchSize int) Response {
-	return trans.transform(ctx, clientEvents, trans.userTransformURL(), batchSize, UserTransformerStage)
+	return trans.transform(ctx, clientEvents, trans.userTransformURL(), batchSize, userTransformerStage)
 }
 
 // Validate function is used to invoke tracking plan validation API
 func (trans *handle) Validate(ctx context.Context, clientEvents []TransformerEvent, batchSize int) Response {
-	return trans.transform(ctx, clientEvents, trans.trackingPlanValidationURL(), batchSize, TrackingPlanValidationStage)
+	return trans.transform(ctx, clientEvents, trans.trackingPlanValidationURL(), batchSize, trackingPlanValidationStage)
 }
 
 func (trans *handle) transform(
@@ -496,7 +495,7 @@ func (trans *handle) doPost(ctx context.Context, rawJSON []byte, url, stage stri
 		},
 	)
 	if err != nil {
-		if trans.config.failOnUserTransformTimeout.Load() && stage == UserTransformerStage && os.IsTimeout(err) {
+		if trans.config.failOnUserTransformTimeout.Load() && stage == userTransformerStage && os.IsTimeout(err) {
 			return []byte(fmt.Sprintf("transformer request timed out: %s", err)), TransformerRequestTimeout
 		} else if trans.config.failOnError.Load() {
 			return []byte(fmt.Sprintf("transformer request failed: %s", err)), TransformerRequestFailure

--- a/processor/transformer/transformer_test.go
+++ b/processor/transformer/transformer_test.go
@@ -247,14 +247,14 @@ func TestTransformer(t *testing.T) {
 			{
 				name:                       "user transformation timeout",
 				retries:                    3,
-				stage:                      UserTransformerStage,
+				stage:                      userTransformerStage,
 				expectPanic:                true,
 				failOnUserTransformTimeout: false,
 			},
 			{
 				name:        "user transformation timeout with fail on timeout",
 				retries:     3,
-				stage:       UserTransformerStage,
+				stage:       userTransformerStage,
 				expectPanic: false,
 				expectedResponse: []TransformerResponse{
 					{
@@ -272,14 +272,14 @@ func TestTransformer(t *testing.T) {
 			{
 				name:                       "destination transformation timeout",
 				retries:                    3,
-				stage:                      DestTransformerStage,
+				stage:                      destTransformerStage,
 				expectPanic:                true,
 				failOnUserTransformTimeout: false,
 			},
 			{
 				name:                       "destination transformation timeout with fail on timeout",
 				retries:                    3,
-				stage:                      DestTransformerStage,
+				stage:                      destTransformerStage,
 				expectPanic:                true,
 				failOnUserTransformTimeout: true,
 			},

--- a/router/types/types_test.go
+++ b/router/types/types_test.go
@@ -28,9 +28,9 @@ func TestDehydrateAndHydrate(t *testing.T) {
 	}
 
 	destJobs := types.DestinationJobs{
-		{JobMetadataArray: []types.JobMetadataT{{JobID: 1}}},
-		{JobMetadataArray: []types.JobMetadataT{{JobID: 2}}},
-		{JobMetadataArray: []types.JobMetadataT{{JobID: 3}}},
+		types.DestinationJobT{JobMetadataArray: []types.JobMetadataT{{JobID: 1}}},
+		types.DestinationJobT{JobMetadataArray: []types.JobMetadataT{{JobID: 2}}},
+		types.DestinationJobT{JobMetadataArray: []types.JobMetadataT{{JobID: 3}}},
 	}
 	destJobs.Hydrate(jobs)
 


### PR DESCRIPTION
# Description

Cleaned up some processor code.
Specifically the usage of 2 flags(`trackingPlanEnabled` and `userTransformationEnabled`) to decide the `PU` and `inPU` at various stages during the computation of metrics.
Also using stage literals from one package(`utils/types`) instead of two earlier(`processor/transformer` and `utils/types`).

## Linear Ticket

< Replace with Linear Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
