### PR TITLE
feat: new event type - record

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -16,6 +16,7 @@ const (
 	delimiter                 = "<<>>"
 	eventStreamSourceCategory = "eventStream"
 	extractEvent              = "extract"
+	rETLEvent                 = "record"
 	customVal                 = "GW"
 )
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -58,6 +58,8 @@ const (
 	SourceIDEnabled           = "enabled-source"
 	ReplaySourceID            = "replay-source"
 	ReplayWriteKey            = "replay-source"
+	RETLSourceID              = "retl-source"
+	RETLWriteKey              = "retl-source"
 	SourceIDDisabled          = "disabled-source"
 	TestRemoteAddressWithPort = "test.com:80"
 	TestRemoteAddress         = "test.com"
@@ -67,6 +69,7 @@ const (
 	WorkspaceID      = "workspace"
 	sourceType1      = "sourceType1"
 	sourceType2      = "webhook"
+	RETLSourceType   = "retl"
 	sdkLibrary       = "sdkLibrary"
 	sdkVersion       = "v1.2.3"
 )
@@ -121,6 +124,17 @@ var sampleBackendConfig = backendconfig.ConfigT{
 			OriginalID: ReplaySourceID,
 			SourceDefinition: backendconfig.SourceDefinitionT{
 				Name: SourceIDEnabled,
+			},
+			WorkspaceID: WorkspaceID,
+		},
+		{
+			ID:         RETLSourceID,
+			WriteKey:   RETLWriteKey,
+			Enabled:    true,
+			OriginalID: RETLSourceID,
+			SourceDefinition: backendconfig.SourceDefinitionT{
+				Name:     SourceIDEnabled,
+				Category: RETLSourceType,
 			},
 			WorkspaceID: WorkspaceID,
 		},
@@ -462,7 +476,7 @@ var _ = Describe("Gateway", func() {
 				}
 				Expect(err).To(BeNil())
 				req.Header.Set("Content-Type", "application/json")
-				if ep == "/internal/v1/replay" {
+				if ep == "/internal/v1/replay" || ep == "/internal/v1/retl" {
 					req.Header.Set("X-Rudder-Source-Id", ReplaySourceID)
 				} else {
 					req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(WriteKeyEnabled+":")))
@@ -713,6 +727,121 @@ var _ = Describe("Gateway", func() {
 				},
 				1*time.Second,
 			).Should(BeTrue())
+		})
+
+		It("should accept valid (with and without userId and anonymousId) retl request and store to jobsdb", func() {
+			handler := gateway.webRetlHandler()
+
+			payloads := [2][]byte{
+				[]byte(`{"batch": [{"data": "valid-json", "type": "record", "userId": "dummyId"}]}`),
+				[]byte(`{"batch": [{"data": "valid-json", "type": "record"}]}`),
+			}
+			c.mockJobsDB.EXPECT().WithStoreSafeTx(
+				gomock.Any(),
+				gomock.Any()).AnyTimes().Do(func(
+				ctx context.Context,
+				f func(tx jobsdb.StoreSafeTx) error,
+			) {
+				_ = f(jobsdb.EmptyStoreSafeTx())
+			}).Return(nil)
+			c.mockJobsDB.
+				EXPECT().StoreEachBatchRetryInTx(
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).AnyTimes()
+
+			// With userId
+			expectHandlerResponse(
+				handler,
+				authorizedRETLRequest(
+					RETLSourceID,
+					bytes.NewBuffer(payloads[0])),
+				http.StatusOK,
+				"OK",
+				"retl",
+			)
+
+			Eventually(
+				func() bool {
+					stat := statsStore.Get(
+						"gateway.write_key_successful_events",
+						map[string]string{
+							"source":      "_source",
+							"sourceID":    RETLSourceID,
+							"workspaceId": WorkspaceID,
+							"writeKey":    RETLWriteKey,
+							"reqType":     "retl",
+							"sourceType":  "retl",
+							"sdkVersion":  "",
+						},
+					)
+					return stat != nil && stat.LastValue() == float64(1)
+				},
+				1*time.Second,
+			).Should(BeTrue())
+
+			// Without userId
+			expectHandlerResponse(
+				handler,
+				authorizedRETLRequest(
+					RETLSourceID,
+					bytes.NewBuffer(payloads[1])),
+				http.StatusOK,
+				"OK",
+				"retl",
+			)
+
+			Eventually(
+				func() bool {
+					stat := statsStore.Get(
+						"gateway.write_key_successful_events",
+						map[string]string{
+							"source":      "_source",
+							"sourceID":    RETLSourceID,
+							"workspaceId": WorkspaceID,
+							"writeKey":    RETLWriteKey,
+							"reqType":     "retl",
+							"sourceType":  "retl",
+							"sdkVersion":  "",
+						},
+					)
+					return stat != nil && stat.LastValue() == float64(1)
+				},
+				1*time.Second,
+			).Should(BeTrue())
+		})
+
+		It("should accept requests with both userId and anonymousId absent in case of extract events", func() {
+			extractHandlers := map[string]http.HandlerFunc{
+				"batch":   gateway.webBatchHandler(),
+				"import":  gateway.webImportHandler(),
+				"extract": gateway.webExtractHandler(),
+			}
+			c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any(), gomock.Any()).AnyTimes().Do(func(ctx context.Context, f func(tx jobsdb.StoreSafeTx) error) {
+				_ = f(jobsdb.EmptyStoreSafeTx())
+			}).Return(nil)
+			c.mockJobsDB.EXPECT().StoreEachBatchRetryInTx(gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
+
+			for handlerType, handler := range extractHandlers {
+				var body string
+				switch handlerType {
+				case "extract":
+					body = `{"data": "valid-json", "type": "extract"}`
+				default:
+					body = `{"batch": [{"data": "valid-json", "type": "extract"}]}`
+				}
+				expectHandlerResponse(
+					handler,
+					authorizedRequest(
+						WriteKeyEnabled,
+						bytes.NewBufferString(body),
+					),
+					http.StatusOK,
+					"OK",
+					handlerType,
+				)
+			}
 		})
 	})
 
@@ -1089,38 +1218,6 @@ var _ = Describe("Gateway", func() {
 			}
 		})
 
-		It("should allow requests with both userId and anonymousId absent in case of extract events", func() {
-			extractHandlers := map[string]http.HandlerFunc{
-				"batch":   gateway.webBatchHandler(),
-				"import":  gateway.webImportHandler(),
-				"extract": gateway.webExtractHandler(),
-			}
-			c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any(), gomock.Any()).AnyTimes().Do(func(ctx context.Context, f func(tx jobsdb.StoreSafeTx) error) {
-				_ = f(jobsdb.EmptyStoreSafeTx())
-			}).Return(nil)
-			c.mockJobsDB.EXPECT().StoreEachBatchRetryInTx(gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
-
-			for handlerType, handler := range extractHandlers {
-				var body string
-				switch handlerType {
-				case "extract":
-					body = `{"data": "valid-json", "type": "extract"}`
-				default:
-					body = `{"batch": [{"data": "valid-json", "type": "extract"}]}`
-				}
-				expectHandlerResponse(
-					handler,
-					authorizedRequest(
-						WriteKeyEnabled,
-						bytes.NewBufferString(body),
-					),
-					http.StatusOK,
-					"OK",
-					handlerType,
-				)
-			}
-		})
-
 		It("should reject requests without request body", func() {
 			for handlerType, handler := range allHandlers(gateway) {
 				expectHandlerResponse(handler, authorizedRequest(WriteKeyEnabled, nil), http.StatusBadRequest, response.RequestBodyNil+"\n", handlerType)
@@ -1426,6 +1523,18 @@ var _ = Describe("Gateway", func() {
 			_, err := gateway.getJobDataFromRequest(req)
 			Expect(err).To(BeNil())
 		})
+
+		It("allows retl events even if userID and anonID are not present in the request payload", func() {
+			req := &webRequestT{
+				reqType:        "retl",
+				authContext:    rCtxEnabled,
+				done:           make(chan<- string),
+				userIDHeader:   userIDHeader,
+				requestPayload: []byte(`{"batch": [{"type": "record"}]}`),
+			}
+			_, err := gateway.getJobDataFromRequest(req)
+			Expect(err).To(BeNil())
+		})
 	})
 
 	Context("SaveWebhookFailures", func() {
@@ -1527,6 +1636,15 @@ func authorizedReplayRequest(sourceID string, body io.Reader) *http.Request {
 	return req
 }
 
+func authorizedRETLRequest(sourceID string, body io.Reader) *http.Request {
+	req := unauthorizedRequest(body)
+	req.Header.Set("X-Rudder-Source-Id", sourceID)
+	// set anonymousId header to ensure everything goes into same batch
+	req.Header.Set("AnonymousId", "094985f8-b4eb-43c3-bc8a-e8b75aae9c7c")
+	req.RemoteAddr = TestRemoteAddressWithPort
+	return req
+}
+
 func expectHandlerResponse(handler http.HandlerFunc, req *http.Request, responseStatus int, responseBody, reqType string) {
 	var body string
 	Eventually(func() int {
@@ -1575,6 +1693,7 @@ func endpointsToVerify() ([]string, []string, []string) {
 		"/v1/webhook",
 		"/beacon/v1/batch",
 		"/internal/v1/extract",
+		"/internal/v1/retl",
 		"/internal/v1/replay",
 		"/internal/v1/audiencelist",
 		"/v1/warehouse/pending-events",

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -289,7 +289,7 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 	}
 
 	gw.requestSizeStat.Observe(float64(len(body)))
-	if req.reqType != "batch" && req.reqType != "replay" {
+	if req.reqType != "batch" && req.reqType != "replay" && req.reqType != "retl" {
 		body, err = sjson.SetBytes(body, "type", req.reqType)
 		if err != nil {
 			err = errors.New(response.NotRudderEvent)
@@ -483,8 +483,8 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 }
 
 func (gw *Handle) isNonIdentifiable(anonIDFromReq, userIDFromReq, eventType string) bool {
-	if eventType == extractEvent {
-		// extract event is allowed without user id and anonymous id
+	if eventType == extractEvent || eventType == rETLEvent {
+		// extract or rETL event is allowed without user id and anonymous id
 		return false
 	}
 	if anonIDFromReq == "" && userIDFromReq == "" {

--- a/gateway/handle_http_replay.go
+++ b/gateway/handle_http_replay.go
@@ -2,7 +2,7 @@ package gateway
 
 import "net/http"
 
-// webImportHandler can handle import requests
+// webReplayHandler can handle replay requests
 func (gw *Handle) webReplayHandler() http.HandlerFunc {
 	return gw.callType("replay", gw.replaySourceIDAuth(gw.webHandler()))
 }

--- a/gateway/handle_http_retl.go
+++ b/gateway/handle_http_retl.go
@@ -1,0 +1,8 @@
+package gateway
+
+import "net/http"
+
+// webRetlHandler - handler for retl requests
+func (gw *Handle) webRetlHandler() http.HandlerFunc {
+	return gw.callType("retl", gw.sourceIDAuth(gw.webHandler()))
+}

--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -369,6 +369,7 @@ func (gw *Handle) StartWebHandler(ctx context.Context) error {
 	)
 	srvMux.Route("/internal", func(r chi.Router) {
 		r.Post("/v1/extract", gw.webExtractHandler())
+		r.Post("/v1/retl", gw.webRetlHandler())
 		r.Get("/v1/warehouse/fetch-tables", gw.whProxy.ServeHTTP)
 		r.Post("/v1/audiencelist", gw.webAudienceListHandler())
 		r.Post("/v1/replay", gw.webReplayHandler())


### PR DESCRIPTION
# Description

New event type "record". (To be used to sync rETL records.)

## Linear Ticket

https://linear.app/rudderstack/issue/INT-650/handling-new-event-type-processing-in-pipeline

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
