### PR TITLE
fix: detected illegal job sequence during barrier enter/wait

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1916,6 +1916,7 @@ func (sm *storeMessage) merge(subJob *storeMessage) {
 	for id, job := range subJob.procErrorJobsByDestID {
 		sm.procErrorJobsByDestID[id] = append(sm.procErrorJobsByDestID[id], job...)
 	}
+	sm.routerDestIDs = append(sm.routerDestIDs, subJob.routerDestIDs...)
 
 	sm.reportMetrics = append(sm.reportMetrics, subJob.reportMetrics...)
 	for dupStatKey, count := range subJob.sourceDupStats {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1998,6 +1998,14 @@ func (proc *Handle) Store(partition string, in *storeMessage) {
 					proc.storePlocker.Lock(destID)
 					defer proc.storePlocker.Unlock(destID)
 				}
+			} else {
+				proc.logger.Warnw("empty storeMessage.routerDestIDs",
+					"expected",
+					lo.Uniq(
+						lo.Map(destJobs, func(j *jobsdb.JobT, _ int) string {
+							return gjson.GetBytes(j.Parameters, "destination_id").String()
+						}),
+					))
 			}
 			err := misc.RetryWithNotify(
 				context.Background(),


### PR DESCRIPTION
# Description

`storeMessage#merge` will be called when processor has picked up a number of jobs (`maxLoopProcessEvents: 10K`) that is greater than the configured sub-job size (`subJobSize: 2K`). Processor will split the picked up batch in more than one sub-jobs, it will process all sub-jobs using pipelining and will finally merge them before storing the output to the database.

Whenever more than one source is connected to a destination, this absence of the appropriate `routerDestIDs` in the merged store message can cause processor to write batches of jobs for the same destination in parallel. This, in turn, can cause router to pickup jobs out-of-order due to `jobID` races.

If processor picks jobs less than the configured sub-job size, then the original `storeMessage` will be used, which will include the appropriate `routerDestIDs`, thus jobs will be processed in-order.

One small mistake... thousands of brain cells damaged!

## Linear Ticket

[PIPE-291](https://linear.app/rudderstack/issue/PIPE-291/detected-illegal-job-sequence-during-barrier-enterwait)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
