### PR TITLE
fix: sample duplicate messagesids for snowflake

### DIFF
--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -412,10 +412,6 @@ func (sf *Snowflake) loadTable(ctx context.Context, tableName string, tableSchem
 	} else if len(duplicates) > 0 {
 		uploadID, _ := whutils.UploadIDFromCtx(ctx)
 
-		sort.Slice(duplicates, func(i, j int) bool {
-			return duplicates[i].receivedAt.Before(duplicates[j].receivedAt)
-		})
-
 		formattedDuplicateMessages := lo.Map(duplicates, func(item duplicateMessage, index int) string {
 			return item.String()
 		})
@@ -544,6 +540,7 @@ func (sf *Snowflake) sampleDuplicateMessages(
 				FROM
 			  		`+stagingTable+`
 		  	)
+        ORDER BY RECEIVED_AT DESC
 		LIMIT
 		  ?;
 `,

--- a/warehouse/integrations/snowflake/snowflake_test.go
+++ b/warehouse/integrations/snowflake/snowflake_test.go
@@ -180,6 +180,13 @@ func TestIntegration(t *testing.T) {
 		t.Setenv("RSERVER_WAREHOUSE_WEB_PORT", strconv.Itoa(httpPort))
 		t.Setenv("RSERVER_BACKEND_CONFIG_CONFIG_JSONPATH", workspaceConfigPath)
 		t.Setenv("RSERVER_WAREHOUSE_SNOWFLAKE_SLOW_QUERY_THRESHOLD", "0s")
+		t.Setenv("RSERVER_WAREHOUSE_SNOWFLAKE_DEBUG_DUPLICATE_WORKSPACE_IDS", workspaceID)
+		t.Setenv("RSERVER_WAREHOUSE_SNOWFLAKE_DEBUG_DUPLICATE_TABLES", strings.Join(
+			[]string{
+				"identifies", "users", "tracks", "product_track", "pages", "screens", "aliases", "groups",
+			},
+			" ",
+		))
 
 		ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
# Description

- Since duplicates need to be found before a merge query is completed, moving it before deduplication for Snowflake.

## Linear Ticket

- https://linear.app/rudderstack/issue/PIPE-266/investigate-duplicates-for-mattermost

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
