### PR TITLE
chore: don't create custom destination clients for disabled destination

### DIFF
--- a/router/customdestinationmanager/customdestinationmanager.go
+++ b/router/customdestinationmanager/customdestinationmanager.go
@@ -337,7 +337,7 @@ func (customManager *CustomManagerT) backendConfigSubscriber() {
 		for _, wConfig := range config {
 			for _, source := range wConfig.Sources {
 				for _, destination := range source.Destinations {
-					if destination.DestinationDefinition.Name == customManager.destType {
+					if destination.DestinationDefinition.Name == customManager.destType && destination.Enabled {
 						err := customManager.onNewDestination(destination)
 						if err != nil {
 							pkgLogger.Errorf(


### PR DESCRIPTION
# Description

There is no point in trying to create clients for custom destinations which are disabled. Even if there are jobs for such destinations in the database, router will drain them before reaching to the point of needing to use the client.

## Linear Ticket

[PIPE-295](https://linear.app/rudderstack/issue/PIPE-295/dont-create-custom-destination-clients-for-disabled-destination)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
