### PR TITLE
chore(batchrouter): decouple upload frequency from main loop frequency

### DIFF
--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -267,6 +267,7 @@ var _ = Describe("BatchRouter", func() {
 			<-batchrouter.backendConfigInitialized
 			batchrouter.minIdleSleep = misc.SingleValueLoader(time.Microsecond)
 			batchrouter.uploadFreq = misc.SingleValueLoader(time.Microsecond)
+			batchrouter.mainLoopFreq = misc.SingleValueLoader(time.Microsecond)
 			ctx, cancel := context.WithCancel(context.Background())
 			var wg sync.WaitGroup
 			wg.Add(1)

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -80,6 +80,7 @@ type Handle struct {
 	jobdDBMaxRetries             misc.ValueLoader[int]
 	minIdleSleep                 misc.ValueLoader[time.Duration]
 	uploadFreq                   misc.ValueLoader[time.Duration]
+	mainLoopFreq                 misc.ValueLoader[time.Duration]
 	disableEgress                bool
 	toAbortDestinationIDs        misc.ValueLoader[string]
 	warehouseServiceMaxRetryTime misc.ValueLoader[time.Duration]
@@ -149,7 +150,7 @@ func (brt *Handle) mainLoop(ctx context.Context) {
 			for _, partition := range brt.activePartitions(ctx) {
 				pool.PingWorker(partition)
 			}
-			mainLoopSleep = brt.uploadFreq.Load()
+			mainLoopSleep = brt.mainLoopFreq.Load()
 		}
 	}
 }

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -203,6 +203,7 @@ func (brt *Handle) setupReloadableVars() {
 	brt.jobdDBMaxRetries = config.GetReloadableIntVar(2, 1, "JobsDB.BatchRouter.MaxRetries", "JobsDB.MaxRetries")
 	brt.minIdleSleep = config.GetReloadableDurationVar(2, time.Second, "BatchRouter.minIdleSleep")
 	brt.uploadFreq = config.GetReloadableDurationVar(30, time.Second, "BatchRouter.uploadFreqInS", "BatchRouter.uploadFreq")
+	brt.mainLoopFreq = config.GetReloadableDurationVar(30, time.Second, "BatchRouter.mainLoopFreq")
 	brt.toAbortDestinationIDs = config.GetReloadableStringVar("", "BatchRouter.toAbortDestinationIDs")
 	brt.warehouseServiceMaxRetryTime = config.GetReloadableDurationVar(3, time.Hour, "BatchRouter.warehouseServiceMaxRetryTime", "BatchRouter.warehouseServiceMaxRetryTimeinHr")
 	brt.datePrefixOverride = config.GetReloadableStringVar("", "BatchRouter.datePrefixOverride")


### PR DESCRIPTION
# Description

- `uploadFreq` dictates how often load files will be created under normal conditions
-  `mainLoopFreq` dictates the max frequency at which load files will be created when there is a large backlog in jobsdb (`limitsReached: true`)

## Linear Ticket

[PIPE-299](https://linear.app/rudderstack/issue/PIPE-299/decouple-upload-frequency-from-main-loop-frequency-in-batchrouter)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
