### PR TITLE
exp: use subject cache for jobsdb

### DIFF
--- a/archiver/archiver_test.go
+++ b/archiver/archiver_test.go
@@ -268,7 +268,7 @@ func (jd jdWrapper) GetUnprocessed(
 func (jd jdWrapper) UpdateJobStatus(
 	ctx context.Context,
 	statusList []*jobsdb.JobStatusT,
-	customValFilters []string,
+	customVal string,
 	parameterFilters []jobsdb.ParameterFilterT,
 ) error {
 	atomic.AddInt32(jd.queries, 1)

--- a/archiver/worker.go
+++ b/archiver/worker.go
@@ -248,7 +248,7 @@ func (w *worker) markStatus(
 						RetryTime:     time.Now(),
 					}
 				}),
-				nil,
+				"",
 				nil,
 			)
 		},

--- a/enterprise/replay/replay.go
+++ b/enterprise/replay/replay.go
@@ -40,8 +40,8 @@ func (handle *Handler) generatorLoop(ctx context.Context) {
 	}
 	for {
 		queryParams := jobsdb.GetQueryParams{
-			CustomValFilters: []string{"replay"},
-			JobsLimit:        handle.dbReadSize,
+			CustomVal: "replay",
+			JobsLimit: handle.dbReadSize,
 		}
 		jobsResult, err := handle.db.GetJobs(context.TODO(), []string{jobsdb.Unprocessed.State, jobsdb.Failed.State}, queryParams)
 		if err != nil {
@@ -58,8 +58,8 @@ func (handle *Handler) generatorLoop(ctx context.Context) {
 					context.TODO(),
 					[]string{jobsdb.Executing.State},
 					jobsdb.GetQueryParams{
-						CustomValFilters: []string{"replay"},
-						JobsLimit:        handle.dbReadSize,
+						CustomVal: "replay",
+						JobsLimit: handle.dbReadSize,
 					},
 				)
 				if err != nil {
@@ -111,7 +111,7 @@ func (handle *Handler) generatorLoop(ctx context.Context) {
 		}
 
 		// Mark the jobs as executing
-		err = handle.db.UpdateJobStatus(ctx, statusList, []string{"replay"}, nil)
+		err = handle.db.UpdateJobStatus(ctx, statusList, "replay", nil)
 		if err != nil {
 			panic(err)
 		}

--- a/enterprise/replay/sourceWorker.go
+++ b/enterprise/replay/sourceWorker.go
@@ -53,7 +53,7 @@ func (worker *SourceWorkerT) workerProcess(ctx context.Context) {
 			Parameters:    []byte(`{}`), // check
 			JobParameters: job.Parameters,
 		}
-		err := worker.replayHandler.db.UpdateJobStatus(ctx, []*jobsdb.JobStatusT{&status}, []string{"replay"}, nil)
+		err := worker.replayHandler.db.UpdateJobStatus(ctx, []*jobsdb.JobStatusT{&status}, "replay", nil)
 		if err != nil {
 			panic(err)
 		}

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -1,0 +1,71 @@
+package tokens
+
+import "strings"
+
+const (
+	fwc   = '>'
+	btsep = '.'
+	pwc   = '*'
+)
+
+// SubjectIsSubsetMatch checks if the subject is a subset of the test
+func SubjectIsSubsetMatch(subject, test string) bool {
+	tsa := [32]string{}
+	tts := tokenizeSubjectIntoSlice(tsa[:0], subject)
+	return isSubsetMatch(tts, test)
+}
+
+func isSubsetMatch(tokens []string, test string) bool {
+	tsa := [32]string{}
+	tts := tokenizeSubjectIntoSlice(tsa[:0], test)
+	return isSubsetMatchTokenized(tokens, tts)
+}
+
+func tokenizeSubjectIntoSlice(tts []string, subject string) []string {
+	start := 0
+	for i := 0; i < len(subject); i++ {
+		if subject[i] == btsep {
+			tts = append(tts, subject[start:i])
+			start = i + 1
+		}
+	}
+	tts = append(tts, subject[start:])
+	return tts
+}
+
+func isSubsetMatchTokenized(tokens, test []string) bool {
+	// Walk the target tokens
+	for i, t2 := range test {
+		if i >= len(tokens) {
+			return false
+		}
+		l := len(t2)
+		if l == 0 {
+			return false
+		}
+		if t2[0] == fwc && l == 1 {
+			return true
+		}
+		t1 := tokens[i]
+
+		l = len(t1)
+		if l == 0 || t1[0] == fwc && l == 1 {
+			return false
+		}
+
+		if t1[0] == pwc && len(t1) == 1 {
+			m := t2[0] == pwc && len(t2) == 1
+			if !m {
+				return false
+			}
+			if i >= len(test) {
+				return true
+			}
+			continue
+		}
+		if t2[0] != pwc && strings.Compare(t1, t2) != 0 {
+			return false
+		}
+	}
+	return len(tokens) == len(test)
+}

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -1,0 +1,30 @@
+package tokens
+
+import "testing"
+
+func TestIsSubsetMatch(t *testing.T) {
+	for _, test := range []struct {
+		subject string
+		test    string
+		result  bool
+	}{
+		{"foo.bar", "foo.bar", true},
+		{"foo.*", ">", true},
+		{"foo.*", "*.*", true},
+		{"foo.*", "foo.*", true},
+		{"foo.*", "foo.bar", false},
+		{"foo.>", ">", true},
+		{"foo.>", "*.>", true},
+		{"foo.>", "foo.>", true},
+		{"foo.>", "foo.bar", false},
+		{"foo..bar", "foo.*", false}, // Bad subject, we return false
+		{"foo.*", "foo..bar", false}, // Bad subject, we return false
+	} {
+		t.Run("", func(t *testing.T) {
+			if res := SubjectIsSubsetMatch(test.subject, test.test); res != test.result {
+				t.Fatalf("Subject %q subset match of %q, should be %v, got %v",
+					test.test, test.subject, test.result, res)
+			}
+		})
+	}
+}

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -53,7 +53,7 @@ func (jd *Handle) deleteJobStatus() {
 				return err
 			}
 			tx.Tx().AddSuccessListener(func() {
-				jd.noResultsCache.InvalidateDataset(ds.Index)
+				jd.noJobsCache.ClearDS(ds.Index)
 			})
 		}
 
@@ -114,7 +114,7 @@ func (jd *Handle) failExecuting() {
 				return err
 			}
 			tx.Tx().AddSuccessListener(func() {
-				jd.noResultsCache.InvalidateDataset(ds.Index)
+				// jd.noResultsCache.InvalidateDataset(ds.Index)
 			})
 		}
 		return nil
@@ -209,7 +209,7 @@ func (jd *Handle) doCleanup(ctx context.Context, batchSize int) error {
 	}
 
 	if len(statusList) > 0 {
-		if err := jd.UpdateJobStatus(ctx, statusList, nil, nil); err != nil {
+		if err := jd.UpdateJobStatus(ctx, statusList, "", nil); err != nil {
 			return err
 		}
 		jd.logger.Infof("cleaned up %d old jobs", len(statusList))

--- a/jobsdb/internal/subjectCache/subjectCache.go
+++ b/jobsdb/internal/subjectCache/subjectCache.go
@@ -184,7 +184,7 @@ func (c *cacheMap) ClearDS(dsIndex string) {
 		if !ok {
 			panic(fmt.Sprintf("invalid key type: %v", k))
 		}
-		if strings.HasPrefix(key, dsIndex) {
+		if strings.HasPrefix(key, dsIndex+".") {
 			c.Delete(k)
 		}
 		return true

--- a/jobsdb/internal/subjectCache/subjectCache.go
+++ b/jobsdb/internal/subjectCache/subjectCache.go
@@ -1,0 +1,192 @@
+package subjectcache
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/internal/tokens"
+)
+
+// map[string]time.Time
+//
+// key: wildcard subject of format:
+//
+// dsIndex.WorkspaceID.CustomVal.SourceID.DestinationID.State
+type cacheMap struct {
+	sync.Map
+}
+
+type Cache interface {
+	// call before querying jobsdb to check if the query is necessary
+	Check(key string) bool
+
+	// call with a subject literal after writing to jobsdb
+	Remove(key string)
+
+	// call before querying jobsdb to set a placeholder value in the cache
+	SetPreRead(key string)
+
+	// call after querying jobsdb(no jobs found) to commit the PreRead key to the cache
+	CommitPreRead(key string)
+
+	// call after querying jobsdb(jobs found) to remove the PreRead key from the cache
+	RemovePreRead(key string)
+
+	// String returns a string representation of the cache
+	String() string
+
+	// ClearDS clears the cache for a given dsIndex
+	ClearDS(dsIndex string)
+}
+
+// New returns a new subjectCache
+//
+// Subject pattern used: dsIndex.WorkspaceID.CustomVal.SourceID.DestinationID.State
+//
+// each write must do *cache.Remove(subject literal) - no wildcards allowed
+//
+// reads may use wildcards as per query params
+//
+// existence of a superset of read subject implies existence of read subject
+//
+// do not query jobsdb in that case
+//
+// works because reads look for existence of a subject whose subset key may belong to
+//
+// and writes remove the key and any other subject whose subset key may belong to
+func New() Cache {
+	c := &cacheMap{}
+	return c
+}
+
+// check if key belongs to the subset of any subject in the cache
+func (c *cacheMap) Check(key string) bool {
+	var subjectExists bool
+	c.Range(func(k, _ any) bool {
+		keySub, ok := k.(string)
+		if !ok {
+			panic(fmt.Sprintf("invalid key type: %v", k))
+		}
+		if tokens.SubjectIsSubsetMatch(key, keySub) {
+			subjectExists = true
+			return false
+		}
+		return true
+	})
+	return subjectExists
+}
+
+// removes the key and any other subject whose subset key may belong to
+func (c *cacheMap) Remove(key string) {
+	if key == "" {
+		panic("invalid key - key empty: " + key)
+	}
+	// cannot contain wildCard
+	if strings.Contains(key, "*") {
+		panic("invalid key - wildcard: " + key)
+	}
+	// cannot have an empty token
+	if strings.Contains(key, "..") {
+		panic("invalid key - empty token: " + key)
+	}
+	// cannot have empty dsIndex
+	if strings.HasPrefix(key, ".") {
+		panic("invalid key - empty dsIndex: " + key)
+	}
+	// cannot have empty state
+	if strings.HasSuffix(key, ".") {
+		panic("invalid key - empty state: " + key)
+	}
+	c.Range(func(k, _ any) bool {
+		keySub, ok := k.(string)
+		if !ok {
+			panic(fmt.Sprintf("invalid key type: %v", k))
+		}
+		if tokens.SubjectIsSubsetMatch(key, keySub) {
+			c.Delete(k)
+		}
+		return true
+	})
+}
+
+// sets a placeholder value in the cache
+//
+// depending on the result of the query, the value may be overwritten or deleted
+//
+// overwritten(CompareAndSwap) in case no jobs are found
+//
+// deleted in case jobs are found
+func (c *cacheMap) SetPreRead(key string) {
+	c.Store(key, time.Time{})
+}
+
+// CommitPreRead commits the PreRead key to the cache
+//
+// # Done when the query is complete, and no jobs are found
+//
+// if the key is not found, it is a no-op
+func (c *cacheMap) CommitPreRead(key string) {
+	_ = c.CompareAndSwap(key, time.Time{}, time.Now())
+}
+
+// RemovePreRead removes the PreRead key from the cache
+//
+// # Done when the query is complete, and jobs are found
+//
+// if the key is not found, it is a no-op
+func (c *cacheMap) RemovePreRead(key string) {
+	c.Delete(key)
+}
+
+// func (c *cacheMap) cleanupLoop() {
+// 	go func() {
+// 		for {
+// 			time.Sleep(15 * time.Minute)
+// 			c.Range(func(k any, val any) bool {
+// 				t, ok := val.(time.Time)
+// 				if !ok {
+// 					panic("invalid value type")
+// 				}
+// 				if t.Add(GetDurationVar(
+// 					120, time.Minute, []string{"JobsDB.cacheExpiration"}...,
+// 				)).Before(time.Now()) {
+// 					c.Delete(k)
+// 				}
+// 				return true
+// 			})
+// 		}
+// 		ticker := time.NewTicker(5 * time.Minute)
+// 		for range ticker.C {
+// 			c.cleanup()
+// 		}
+// 	}()
+// }
+
+func (c *cacheMap) String() string {
+	var s strings.Builder
+	c.Range(func(k, _ any) bool {
+		key, ok := k.(string)
+		if !ok {
+			panic(fmt.Sprintf("invalid key type: %v", k))
+		}
+		s.WriteString(key)
+		s.WriteString("\n")
+		return true
+	})
+	return s.String()
+}
+
+func (c *cacheMap) ClearDS(dsIndex string) {
+	c.Range(func(k, _ any) bool {
+		key, ok := k.(string)
+		if !ok {
+			panic(fmt.Sprintf("invalid key type: %v", k))
+		}
+		if strings.HasPrefix(key, dsIndex) {
+			c.Delete(k)
+		}
+		return true
+	})
+}

--- a/jobsdb/internal/subjectCache/subjectCache_test.go
+++ b/jobsdb/internal/subjectCache/subjectCache_test.go
@@ -68,9 +68,9 @@ func Test_subjectCache(t *testing.T) {
 
 	t.Run("a write during read(jobs found) removes the preRead subject", func(t *testing.T) {
 		c := subjectcache.New()
-		c.SetPreRead("foo.*")             // getJobs will call SetPreRead
-		c.Remove("foo.bar")               // write will call Remove
-		c.RemovePreRead("foo.*")          // getJobs will call RemovePreRead(jobs found)
-		require.True(t, c.Check("foo.*")) // next iteration of getJobs
+		c.SetPreRead("foo.*")              // getJobs will call SetPreRead
+		c.Remove("foo.bar")                // write will call Remove
+		c.RemovePreRead("foo.*")           // getJobs will call RemovePreRead(jobs found)
+		require.False(t, c.Check("foo.*")) // next iteration of getJobs
 	})
 }

--- a/jobsdb/internal/subjectCache/subjectCache_test.go
+++ b/jobsdb/internal/subjectCache/subjectCache_test.go
@@ -1,0 +1,76 @@
+package subjectcache_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	subjectcache "github.com/rudderlabs/rudder-server/jobsdb/internal/subjectCache"
+)
+
+func Test_subjectCache(t *testing.T) {
+	t.Run("check for non-existent subject", func(t *testing.T) {
+		c := subjectcache.New()
+		require.False(t, c.Check("foo.bar"))
+	})
+
+	t.Run("check for existing subject", func(t *testing.T) {
+		c := subjectcache.New()
+		c.SetPreRead("foo.bar")
+		require.True(t, c.Check("foo.bar"))
+	})
+
+	t.Run("check for existing subject with wildcard", func(t *testing.T) {
+		c := subjectcache.New()
+		c.SetPreRead("foo.bar")
+		require.False(t, c.Check("foo.*"))
+	})
+
+	t.Run("check for key is wildcard subject exists", func(t *testing.T) {
+		c := subjectcache.New()
+		c.SetPreRead("foo.*")
+		require.True(t, c.Check("foo.bar"))
+	})
+
+	t.Run("Remove only allows subject literals, no wildcards - panics", func(t *testing.T) {
+		c := subjectcache.New()
+		require.Panics(t, func() {
+			c.Remove("foo.*")
+		})
+		require.Panics(t, func() {
+			c.Remove("foo.")
+		})
+		require.Panics(t, func() {
+			c.Remove(".foo")
+		})
+		require.Panics(t, func() {
+			c.Remove("")
+		})
+		require.Panics(t, func() {
+			c.Remove("foo..bar")
+		})
+	})
+
+	t.Run("should remove a literal subject", func(t *testing.T) {
+		c := subjectcache.New()
+		// c.SetPreRead("foo.bar")
+		c.Remove("foo.bar")
+		require.False(t, c.Check("foo.bar"))
+	})
+
+	t.Run("a write during read(no jobs) removes the preRead subject", func(t *testing.T) {
+		c := subjectcache.New()
+		c.SetPreRead("foo.*")              // getJobs will call SetPreRead
+		c.Remove("foo.bar")                // write will call Remove
+		c.CommitPreRead("foo.*")           // getJobs will call CommitPreRead(no jobs found)
+		require.False(t, c.Check("foo.*")) // next iteration of getJobs
+	})
+
+	t.Run("a write during read(jobs found) removes the preRead subject", func(t *testing.T) {
+		c := subjectcache.New()
+		c.SetPreRead("foo.*")             // getJobs will call SetPreRead
+		c.Remove("foo.bar")               // write will call Remove
+		c.RemovePreRead("foo.*")          // getJobs will call RemovePreRead(jobs found)
+		require.True(t, c.Check("foo.*")) // next iteration of getJobs
+	})
+}

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -447,7 +447,7 @@ func TestJobsDBTimeout(t *testing.T) {
 
 		jobs, err := misc.QueryWithRetries(context.Background(), 10*time.Millisecond, expectedRetries, func(ctx context.Context) (JobsResult, error) {
 			jobs, err := jobDB.GetUnprocessed(ctx, GetQueryParams{
-				CustomValFilters: []string{customVal},
+				CustomVal:        customVal,
 				JobsLimit:        1,
 				ParameterFilters: []ParameterFilterT{},
 			})
@@ -807,7 +807,7 @@ func TestCacheScenarios(t *testing.T) {
 		err = dbWithOneLimit.Store(context.Background(), generateJobs(2, ""))
 		require.NoError(t, err)
 
-		res, err := dbWithOneLimit.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100})
+		res, err := dbWithOneLimit.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(res.Jobs))
 
@@ -822,7 +822,7 @@ func TestCacheScenarios(t *testing.T) {
 
 		require.NoError(t, dbWithOneLimit.Store(context.Background(), generateJobs(3, "")))
 
-		res, err = dbWithOneLimit.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100})
+		res, err = dbWithOneLimit.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, JobsLimit: 100})
 		require.NoError(t, err)
 		fmt.Println("res jobs:", len(res.Jobs))
 		return res.Jobs
@@ -850,19 +850,19 @@ func TestCacheScenarios(t *testing.T) {
 		require.NoError(t, gwDBForProcessor.Start())
 		defer gwDBForProcessor.TearDown()
 
-		res, err := gwDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100})
+		res, err := gwDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(res.Jobs), "gwDB should report 0 unprocessed jobs")
-		res, err = gwDBForProcessor.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100})
+		res, err = gwDBForProcessor.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(res.Jobs), "gwDBForProcessor should report 0 unprocessed jobs")
 
 		require.NoError(t, gwDB.Store(context.Background(), generateJobs(2, "")))
 
-		res, err = gwDBForProcessor.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100})
+		res, err = gwDBForProcessor.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(res.Jobs), "gwDBForProcessor should report 2 unprocessed jobs since we added 2 jobs through gwDB")
-		res, err = gwDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100})
+		res, err = gwDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(res.Jobs), "gwDB should report 2 unprocessed jobs since we added 2 jobs through gwDB")
 	})
@@ -874,26 +874,26 @@ func TestCacheScenarios(t *testing.T) {
 
 		destinationID := "destinationID"
 
-		res, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100})
+		res, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(res.Jobs), "jobsDB should report 0 unprocessed jobs when not using parameter filters")
-		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(res.Jobs), "jobsDB should report 0 unprocessed jobs when using destination_id in parameter filters")
 
 		require.NoError(t, jobsDB.Store(context.Background(), generateJobs(2, "")))
-		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100})
+		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(res.Jobs), "jobsDB should report 2 unprocessed jobs when not using parameter filters, after we added 2 jobs")
-		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(res.Jobs), "jobsDB should report 0 unprocessed jobs when using destination_id in parameter filters, after we added 2 jobs but for another destination_id")
 
 		require.NoError(t, jobsDB.Store(context.Background(), generateJobs(2, destinationID)))
-		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100})
+		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 4, len(res.Jobs), "jobsDB should report 4 unprocessed jobs when not using parameter filters, after we added 2 more jobs")
-		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(res.Jobs), "jobsDB should report 2 unprocessed jobs when using destination_id in parameter filters, after we added 2 jobs for this destination_id")
 	})
@@ -905,12 +905,12 @@ func TestCacheScenarios(t *testing.T) {
 
 		destinationID := "destinationID"
 
-		res, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}, {Name: "source_id", Value: "sourceID"}}, JobsLimit: 100})
+		res, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}, {Name: "source_id", Value: "sourceID"}}, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(res.Jobs), "jobsDB should report 0 unprocessed jobs when using both destination_id and source_id as filters")
 
 		require.NoError(t, jobsDB.Store(context.Background(), generateJobs(2, destinationID)))
-		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}, {Name: "source_id", Value: "sourceID"}}, JobsLimit: 100})
+		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}, {Name: "source_id", Value: "sourceID"}}, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(res.Jobs), "jobsDB should report 2 unprocessed jobs when using both destination_id and source_id as filters, after we added 2 jobs")
 	})
@@ -927,12 +927,12 @@ func TestCacheScenarios(t *testing.T) {
 
 		destinationID := "destinationID"
 
-		res, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+		res, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(res.Jobs), "jobsDB should report 0 unprocessed jobs when using destination_id as filter")
 
 		require.NoError(t, jobsDB.Store(context.Background(), generateJobs(2, destinationID)))
-		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+		res, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(res.Jobs), "jobsDB should report 2 unprocessed jobs when using destination_id as filter, after we added 2 jobs")
 	})
@@ -962,9 +962,9 @@ func TestCacheScenarios(t *testing.T) {
 		res, err := jobDB.GetUnprocessed(
 			context.Background(),
 			GetQueryParams{
-				CustomValFilters: []string{customVal},
-				WorkspaceID:      workspaceID,
-				JobsLimit:        100,
+				CustomVal:   customVal,
+				WorkspaceID: workspaceID,
+				JobsLimit:   100,
 			},
 		)
 		require.NoError(t, err)
@@ -978,7 +978,7 @@ func TestCacheScenarios(t *testing.T) {
 		res, err = jobDB.GetUnprocessed(
 			context.Background(),
 			GetQueryParams{
-				CustomValFilters: []string{customVal},
+				CustomVal:        customVal,
 				ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: "someDestinationID"}},
 				JobsLimit:        100,
 			},
@@ -1040,15 +1040,15 @@ func TestAfterJobIDQueryParam(t *testing.T) {
 		require.NoError(t, jobsDB.Start())
 		defer jobsDB.TearDown()
 		require.NoError(t, jobsDB.Store(context.Background(), generateJobs(2, destinationID)))
-		unprocessed, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+		unprocessed, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(unprocessed.Jobs))
 
-		unprocessed1, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100, afterJobID: &unprocessed.Jobs[0].JobID})
+		unprocessed1, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, JobsLimit: 100, afterJobID: &unprocessed.Jobs[0].JobID})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(unprocessed1.Jobs))
 
-		unprocessed2, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100, afterJobID: &unprocessed.Jobs[1].JobID})
+		unprocessed2, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, JobsLimit: 100, afterJobID: &unprocessed.Jobs[1].JobID})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(unprocessed2.Jobs))
 	})
@@ -1061,7 +1061,7 @@ func TestAfterJobIDQueryParam(t *testing.T) {
 		require.NoError(t, jobsDB.Start())
 		defer jobsDB.TearDown()
 		require.NoError(t, jobsDB.Store(context.Background(), generateJobs(2, destinationID)))
-		unprocessed, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+		unprocessed, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(unprocessed.Jobs))
 
@@ -1079,13 +1079,13 @@ func TestAfterJobIDQueryParam(t *testing.T) {
 				WorkspaceId:   defaultWorkspaceID,
 			})
 		}
-		require.NoError(t, jobsDB.UpdateJobStatus(context.Background(), statuses, []string{customVal}, []ParameterFilterT{}))
+		require.NoError(t, jobsDB.UpdateJobStatus(context.Background(), statuses, customVal, []ParameterFilterT{}))
 
-		processed1, err := jobsDB.GetFailed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100, afterJobID: &unprocessed.Jobs[0].JobID})
+		processed1, err := jobsDB.GetFailed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100, afterJobID: &unprocessed.Jobs[0].JobID})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(processed1.Jobs))
 
-		processed2, err := jobsDB.GetFailed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100, afterJobID: &unprocessed.Jobs[1].JobID})
+		processed2, err := jobsDB.GetFailed(context.Background(), GetQueryParams{CustomVal: customVal, JobsLimit: 100, afterJobID: &unprocessed.Jobs[1].JobID})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(processed2.Jobs))
 	})
@@ -1116,7 +1116,7 @@ func TestDeleteExecuting(t *testing.T) {
 	require.NoError(t, jobsDB.Start())
 	defer jobsDB.TearDown()
 	require.NoError(t, jobsDB.Store(context.Background(), generateJobs(2, destinationID)))
-	unprocessed, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+	unprocessed, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 	require.NoError(t, err)
 	require.Equal(t, 2, len(unprocessed.Jobs))
 	var statuses []*JobStatusT
@@ -1133,14 +1133,14 @@ func TestDeleteExecuting(t *testing.T) {
 			WorkspaceId:   defaultWorkspaceID,
 		})
 	}
-	require.NoError(t, jobsDB.UpdateJobStatus(context.Background(), statuses, []string{customVal}, []ParameterFilterT{}))
-	unprocessed, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+	require.NoError(t, jobsDB.UpdateJobStatus(context.Background(), statuses, customVal, []ParameterFilterT{}))
+	unprocessed, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(unprocessed.Jobs))
 
 	jobsDB.DeleteExecuting()
 
-	unprocessed, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+	unprocessed, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 	require.NoError(t, err)
 	require.Equal(t, 2, len(unprocessed.Jobs))
 }
@@ -1170,7 +1170,7 @@ func TestFailExecuting(t *testing.T) {
 	require.NoError(t, jobsDB.Start())
 	defer jobsDB.TearDown()
 	require.NoError(t, jobsDB.Store(context.Background(), generateJobs(2, destinationID)))
-	unprocessed, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+	unprocessed, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 	require.NoError(t, err)
 	require.Equal(t, 2, len(unprocessed.Jobs))
 
@@ -1188,19 +1188,19 @@ func TestFailExecuting(t *testing.T) {
 			WorkspaceId:   defaultWorkspaceID,
 		})
 	}
-	require.NoError(t, jobsDB.UpdateJobStatus(context.Background(), statuses, []string{customVal}, []ParameterFilterT{}))
+	require.NoError(t, jobsDB.UpdateJobStatus(context.Background(), statuses, customVal, []ParameterFilterT{}))
 
-	unprocessed, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+	unprocessed, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(unprocessed.Jobs))
 
 	jobsDB.FailExecuting()
 
-	unprocessed, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+	unprocessed, err = jobsDB.GetUnprocessed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(unprocessed.Jobs))
 
-	failed, err := jobsDB.GetFailed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
+	failed, err := jobsDB.GetFailed(context.Background(), GetQueryParams{CustomVal: customVal, ParameterFilters: []ParameterFilterT{{Name: "destination_id", Value: destinationID}}, JobsLimit: 100})
 	require.NoError(t, err)
 	require.Equal(t, 2, len(failed.Jobs))
 }
@@ -1262,7 +1262,7 @@ func TestMaxAgeCleanup(t *testing.T) {
 	unprocessed, err := jobsDB.GetUnprocessed(
 		context.Background(),
 		GetQueryParams{
-			CustomValFilters: []string{customVal},
+			CustomVal: customVal,
 			ParameterFilters: []ParameterFilterT{
 				{Name: "destination_id", Value: destinationID},
 			},
@@ -1292,7 +1292,7 @@ func TestMaxAgeCleanup(t *testing.T) {
 	abortedJobs, err := jobsDB.GetAborted(
 		context.Background(),
 		GetQueryParams{
-			CustomValFilters: []string{customVal},
+			CustomVal: customVal,
 			ParameterFilters: []ParameterFilterT{
 				{Name: "destination_id", Value: destinationID},
 			},
@@ -1305,7 +1305,7 @@ func TestMaxAgeCleanup(t *testing.T) {
 	unprocessed, err = jobsDB.GetUnprocessed(
 		context.Background(),
 		GetQueryParams{
-			CustomValFilters: []string{customVal},
+			CustomVal: customVal,
 			ParameterFilters: []ParameterFilterT{
 				{Name: "destination_id", Value: destinationID},
 			},
@@ -1322,8 +1322,11 @@ func TestMaxAgeCleanup(t *testing.T) {
 }
 
 func TestConstructParameterJSONQuery(t *testing.T) {
-	q := constructParameterJSONQuery("alias", []ParameterFilterT{{Name: "name", Value: "value"}})
-	require.Equal(t, `(alias.parameters->>'name'='value')`, q)
+	q := constructParameterJSONQuery("alias", []ParameterFilterT{
+		{Name: "name", Value: "value"},
+		{Name: "name2", Value: "value2"},
+	})
+	require.Equal(t, `(alias.parameters->>'name'='value' AND alias.parameters->>'name2'='value2')`, q)
 }
 
 func TestGetActiveWorkspaces(t *testing.T) {
@@ -1430,7 +1433,7 @@ func TestGetActiveWorkspaces(t *testing.T) {
 			WorkspaceId: "ws-3",
 		}
 	})
-	require.NoError(t, jobsDB.UpdateJobStatus(context.Background(), statuses, []string{}, []ParameterFilterT{}))
+	require.NoError(t, jobsDB.UpdateJobStatus(context.Background(), statuses, "", []ParameterFilterT{}))
 
 	activeWorkspaces, err = jobsDB.GetActiveWorkspaces(context.Background(), "")
 	require.NoError(t, err)
@@ -1525,7 +1528,7 @@ func TestGetDistinctParameterValues(t *testing.T) {
 			WorkspaceId: "workspace",
 		}
 	})
-	require.NoError(t, jobsDB.UpdateJobStatus(context.Background(), statuses, []string{}, []ParameterFilterT{}))
+	require.NoError(t, jobsDB.UpdateJobStatus(context.Background(), statuses, "", []ParameterFilterT{}))
 
 	parameterValues, err = jobsDB.GetDistinctParameterValues(context.Background(), "param")
 	require.NoError(t, err)

--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -131,7 +131,7 @@ func constructParameterJSONQuery(alias string, parameterFilters []ParameterFilte
 		return fmt.Sprintf(`%s.parameters->>'%s'='%s'`, alias, parameter.Name, parameter.Value)
 	})
 
-	return "(" + strings.Join(conditions, " OR ") + ")"
+	return "(" + strings.Join(conditions, " AND ") + ")"
 }
 
 // statTags is a struct to hold tags for stats

--- a/jobsdb/migration_test.go
+++ b/jobsdb/migration_test.go
@@ -58,7 +58,7 @@ func TestMigration(t *testing.T) {
 			jobDB.UpdateJobStatus(
 				context.Background(),
 				genJobStatuses(jobs[:9], "executing"),
-				[]string{customVal},
+				customVal,
 				[]ParameterFilterT{},
 			),
 		)
@@ -67,7 +67,7 @@ func TestMigration(t *testing.T) {
 			jobDB.UpdateJobStatus(
 				context.Background(),
 				genJobStatuses(jobs[:9], "succeeded"),
-				[]string{customVal},
+				customVal,
 				[]ParameterFilterT{},
 			),
 		)
@@ -77,7 +77,7 @@ func TestMigration(t *testing.T) {
 			jobDB.UpdateJobStatus(
 				context.Background(),
 				genJobStatuses(jobs[9:10], "executing"),
-				[]string{customVal},
+				customVal,
 				[]ParameterFilterT{},
 			),
 			`status update failed in 1st DS`,
@@ -87,7 +87,7 @@ func TestMigration(t *testing.T) {
 			jobDB.UpdateJobStatus(
 				context.Background(),
 				genJobStatuses(jobs[9:10], "failed"),
-				[]string{customVal},
+				customVal,
 				[]ParameterFilterT{},
 			),
 			`status update failed in 1st DS`,
@@ -115,7 +115,7 @@ func TestMigration(t *testing.T) {
 				jobDB.UpdateJobStatus(
 					context.Background(),
 					genJobStatuses(jobs[20:30], "executing"),
-					[]string{customVal},
+					customVal,
 					[]ParameterFilterT{},
 				),
 				`status update failed in 3rd DS`,
@@ -125,7 +125,7 @@ func TestMigration(t *testing.T) {
 				jobDB.UpdateJobStatus(
 					context.Background(),
 					genJobStatuses(jobs[20:30], "failed"),
-					[]string{customVal},
+					customVal,
 					[]ParameterFilterT{},
 				),
 				`status update failed in 3rd DS`,
@@ -248,7 +248,7 @@ func TestMigration(t *testing.T) {
 			jobs = append(jobs, &JobT{JobID: int64(i + 1)})
 		}
 		for i := 0; i < 5; i++ {
-			require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(jobs, "failed"), []string{"test"}, []ParameterFilterT{}))
+			require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(jobs, "failed"), "test", []ParameterFilterT{}))
 		}
 		var count int
 		require.NoError(t, jobDB.dbHandle.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %[1]s_job_status_1 `, tablePrefix)).Scan(&count))
@@ -260,7 +260,7 @@ func TestMigration(t *testing.T) {
 			jobs = append(jobs, &JobT{JobID: int64(i + 11)})
 		}
 		for i := 0; i < 10; i++ {
-			require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(jobs, "failed"), []string{"test"}, []ParameterFilterT{}))
+			require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(jobs, "failed"), "test", []ParameterFilterT{}))
 		}
 		require.NoError(t, jobDB.dbHandle.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %[1]s_job_status_2 `, tablePrefix)).Scan(&count))
 		require.EqualValues(t, 10*10, count)
@@ -326,7 +326,7 @@ func TestMigration(t *testing.T) {
 			jobs = append(jobs, &JobT{JobID: int64(i + 1)})
 		}
 		for i := 0; i < 4; i++ {
-			require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(jobs, "failed"), []string{"test"}, []ParameterFilterT{}))
+			require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(jobs, "failed"), "test", []ParameterFilterT{}))
 		}
 
 		updatedTableSizes := getTableSizes(jobDB.getDSList())

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -381,7 +381,7 @@ func (mr *MockJobsDBMockRecorder) StoreInTx(arg0, arg1, arg2 interface{}) *gomoc
 }
 
 // UpdateJobStatus mocks base method.
-func (m *MockJobsDB) UpdateJobStatus(arg0 context.Context, arg1 []*jobsdb.JobStatusT, arg2 []string, arg3 []jobsdb.ParameterFilterT) error {
+func (m *MockJobsDB) UpdateJobStatus(arg0 context.Context, arg1 []*jobsdb.JobStatusT, arg2 string, arg3 []jobsdb.ParameterFilterT) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateJobStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -395,7 +395,7 @@ func (mr *MockJobsDBMockRecorder) UpdateJobStatus(arg0, arg1, arg2, arg3 interfa
 }
 
 // UpdateJobStatusInTx mocks base method.
-func (m *MockJobsDB) UpdateJobStatusInTx(arg0 context.Context, arg1 jobsdb.UpdateSafeTx, arg2 []*jobsdb.JobStatusT, arg3 []string, arg4 []jobsdb.ParameterFilterT) error {
+func (m *MockJobsDB) UpdateJobStatusInTx(arg0 context.Context, arg1 jobsdb.UpdateSafeTx, arg2 []*jobsdb.JobStatusT, arg3 string, arg4 []jobsdb.ParameterFilterT) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateJobStatusInTx", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -161,7 +161,7 @@ func TestProcessorManager(t *testing.T) {
 
 	customVal := "GW"
 	unprocessedListEmpty, err := tempDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParams{
-		CustomValFilters: []string{customVal},
+		CustomVal:        customVal,
 		JobsLimit:        1,
 		ParameterFilters: []jobsdb.ParameterFilterT{},
 	})
@@ -253,7 +253,7 @@ func TestProcessorManager(t *testing.T) {
 		defer processor.Stop()
 		Eventually(func() int {
 			res, err := tempDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParams{
-				CustomValFilters: []string{customVal},
+				CustomVal:        customVal,
 				JobsLimit:        20,
 				ParameterFilters: []jobsdb.ParameterFilterT{},
 			})
@@ -292,14 +292,14 @@ func TestProcessorManager(t *testing.T) {
 		err = tempDB.Store(context.Background(), genJobs(customVal, jobCountPerDS, eventsPerJob))
 		require.NoError(t, err)
 		unprocessedListEmpty, err = tempDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParams{
-			CustomValFilters: []string{customVal},
+			CustomVal:        customVal,
 			JobsLimit:        20,
 			ParameterFilters: []jobsdb.ParameterFilterT{},
 		})
 		require.NoError(t, err, "failed to get unprocessed jobs")
 		Eventually(func() int {
 			res, err := tempDB.GetUnprocessed(context.Background(), jobsdb.GetQueryParams{
-				CustomValFilters: []string{customVal},
+				CustomVal:        customVal,
 				JobsLimit:        20,
 				ParameterFilters: []jobsdb.ParameterFilterT{},
 			})

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2067,7 +2067,7 @@ func (proc *Handle) Store(partition string, in *storeMessage) {
 	txnStart := time.Now()
 	err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout.Load(), proc.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
 		return proc.gatewayDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
-			err := proc.gatewayDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{proc.config.GWCustomVal}, nil)
+			err := proc.gatewayDB.UpdateJobStatusInTx(ctx, tx, statusList, proc.config.GWCustomVal, nil)
 			if err != nil {
 				return fmt.Errorf("updating gateway jobs statuses: %w", err)
 			}
@@ -2599,7 +2599,7 @@ func (proc *Handle) getJobs(partition string) jobsdb.JobsResult {
 		eventCount = 0
 	}
 	queryParams := jobsdb.GetQueryParams{
-		CustomValFilters: []string{proc.config.GWCustomVal},
+		CustomVal:        proc.config.GWCustomVal,
 		JobsLimit:        proc.config.maxEventsToProcess.Load(),
 		EventsLimit:      eventCount,
 		PayloadSizeLimit: proc.adaptiveLimit(proc.payloadLimit.Load()),
@@ -2685,7 +2685,7 @@ func (proc *Handle) markExecuting(jobs []*jobsdb.JobT) error {
 	}
 	// Mark the jobs as executing
 	err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout.Load(), proc.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
-		return proc.gatewayDB.UpdateJobStatus(ctx, statusList, []string{proc.config.GWCustomVal}, nil)
+		return proc.gatewayDB.UpdateJobStatus(ctx, statusList, proc.config.GWCustomVal, nil)
 	}, proc.sendRetryUpdateStats)
 	if err != nil {
 		return fmt.Errorf("marking jobs as executing: %w", err)

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -1129,7 +1129,7 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(
 				gomock.Any(),
 				jobsdb.GetQueryParams{
-					CustomValFilters: gatewayCustomVal,
+					CustomVal:        gatewayCustomVal[0],
 					JobsLimit:        processor.config.maxEventsToProcess.Load(),
 					EventsLimit:      processor.config.maxEventsToProcess.Load(),
 					PayloadSizeLimit: processor.payloadLimit.Load(),
@@ -1272,7 +1272,7 @@ var _ = Describe("Processor", Ordered, func() {
 			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(
 				gomock.Any(),
 				jobsdb.GetQueryParams{
-					CustomValFilters: gatewayCustomVal,
+					CustomVal:        gatewayCustomVal[0],
 					JobsLimit:        processor.config.maxEventsToProcess.Load(),
 					EventsLimit:      processor.config.maxEventsToProcess.Load(),
 					PayloadSizeLimit: processor.payloadLimit.Load(),
@@ -1341,7 +1341,7 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
-			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(unprocessedJobsList)), gatewayCustomVal, nil).Times(1).After(callStoreRouter).
+			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(unprocessedJobsList)), gatewayCustomVal[0], nil).Times(1).After(callStoreRouter).
 				Do(func(ctx context.Context, txn jobsdb.UpdateSafeTx, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					// jobs should be sorted by jobid, so order of statuses is different from order of jobs
 					for i := range unprocessedJobsList {
@@ -1479,7 +1479,7 @@ var _ = Describe("Processor", Ordered, func() {
 			processor := prepareHandle(NewHandle(mockTransformer))
 
 			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), jobsdb.GetQueryParams{
-				CustomValFilters: gatewayCustomVal,
+				CustomVal:        gatewayCustomVal[0],
 				JobsLimit:        processor.config.maxEventsToProcess.Load(),
 				EventsLimit:      processor.config.maxEventsToProcess.Load(),
 				PayloadSizeLimit: processor.payloadLimit.Load(),
@@ -1548,7 +1548,7 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
-			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(unprocessedJobsList)), gatewayCustomVal, nil).Times(1).After(callStoreBatchRouter).
+			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(unprocessedJobsList)), gatewayCustomVal[0], nil).Times(1).After(callStoreBatchRouter).
 				Do(func(ctx context.Context, txn jobsdb.UpdateSafeTx, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					for i := range unprocessedJobsList {
 						assertJobStatus(unprocessedJobsList[i], statuses[i], jobsdb.Succeeded.State)
@@ -1656,7 +1656,7 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
-			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(unprocessedJobsList)), gatewayCustomVal, nil).Times(1).After(callStoreRouter)
+			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(unprocessedJobsList)), gatewayCustomVal[0], nil).Times(1).After(callStoreRouter)
 			processor := prepareHandle(NewHandle(mockTransformer))
 
 			Setup(processor, c, true, false)
@@ -1767,7 +1767,7 @@ var _ = Describe("Processor", Ordered, func() {
 			processor := prepareHandle(NewHandle(mockTransformer))
 
 			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), jobsdb.GetQueryParams{
-				CustomValFilters: gatewayCustomVal,
+				CustomVal:        gatewayCustomVal[0],
 				JobsLimit:        processor.config.maxEventsToProcess.Load(),
 				EventsLimit:      processor.config.maxEventsToProcess.Load(),
 				PayloadSizeLimit: processor.payloadLimit.Load(),
@@ -1782,7 +1782,7 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
-			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(unprocessedJobsList)), gatewayCustomVal, nil).Times(1).
+			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(unprocessedJobsList)), gatewayCustomVal[0], nil).Times(1).
 				Do(func(ctx context.Context, txn jobsdb.UpdateSafeTx, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					// job should be marked as successful regardless of transformer response
 					assertJobStatus(unprocessedJobsList[0], statuses[0], jobsdb.Succeeded.State)
@@ -1904,7 +1904,7 @@ var _ = Describe("Processor", Ordered, func() {
 			processor := prepareHandle(NewHandle(mockTransformer))
 
 			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), jobsdb.GetQueryParams{
-				CustomValFilters: gatewayCustomVal,
+				CustomVal:        gatewayCustomVal[0],
 				JobsLimit:        processor.config.maxEventsToProcess.Load(),
 				EventsLimit:      processor.config.maxEventsToProcess.Load(),
 				PayloadSizeLimit: processor.payloadLimit.Load(),
@@ -1928,7 +1928,7 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
-			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(toRetryJobsList)+len(unprocessedJobsList)), gatewayCustomVal, nil).Times(1).
+			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(toRetryJobsList)+len(unprocessedJobsList)), gatewayCustomVal[0], nil).Times(1).
 				Do(func(ctx context.Context, txn jobsdb.UpdateSafeTx, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					// job should be marked as successful regardless of transformer response
 					assertJobStatus(unprocessedJobsList[0], statuses[0], jobsdb.Succeeded.State)
@@ -1991,7 +1991,7 @@ var _ = Describe("Processor", Ordered, func() {
 			processor := prepareHandle(NewHandle(mockTransformer))
 
 			c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), jobsdb.GetQueryParams{
-				CustomValFilters: gatewayCustomVal,
+				CustomVal:        gatewayCustomVal[0],
 				JobsLimit:        processor.config.maxEventsToProcess.Load(),
 				EventsLimit:      processor.config.maxEventsToProcess.Load(),
 				PayloadSizeLimit: processor.payloadLimit.Load(),
@@ -2003,7 +2003,7 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockGatewayJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
-			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(toRetryJobsList)+len(unprocessedJobsList)), gatewayCustomVal, nil).Times(1).
+			c.mockGatewayJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Len(len(toRetryJobsList)+len(unprocessedJobsList)), gatewayCustomVal[0], nil).Times(1).
 				Do(func(ctx context.Context, txn jobsdb.UpdateSafeTx, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					// job should be marked as successful regardless of transformer response
 					assertJobStatus(unprocessedJobsList[0], statuses[0], jobsdb.Succeeded.State)

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -284,7 +284,7 @@ func (st *HandleT) setErrJobStatus(jobs []*jobsdb.JobT, output StoreErrorOutputT
 		statusList = append(statusList, &status)
 	}
 	err := misc.RetryWithNotify(context.Background(), st.config.jobsDBCommandTimeout.Load(), st.config.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
-		return st.errorDB.UpdateJobStatus(ctx, statusList, nil, nil)
+		return st.errorDB.UpdateJobStatus(ctx, statusList, "", nil)
 	}, st.sendRetryUpdateStats)
 	if err != nil {
 		st.logger.Errorf("Error occurred while updating proc error jobs statuses. Panicking. Err: %v", err)
@@ -306,7 +306,7 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 			var limitReached bool
 			// NOTE: sending custom val filters array of size 1 to take advantage of cache in jobsdb.
 			queryParams := jobsdb.GetQueryParams{
-				CustomValFilters:              []string{""},
+				CustomVal:                     "",
 				IgnoreCustomValFiltersInQuery: true,
 				JobsLimit:                     st.config.errDBReadBatchSize.Load(),
 				PayloadSizeLimit:              st.adaptiveLimit(st.config.payloadLimit.Load()),
@@ -411,7 +411,7 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 				statusList = append(statusList, &status)
 			}
 			err := misc.RetryWithNotify(context.Background(), st.config.jobsDBCommandTimeout.Load(), st.config.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
-				return st.errorDB.UpdateJobStatus(ctx, statusList, nil, nil)
+				return st.errorDB.UpdateJobStatus(ctx, statusList, "", nil)
 			}, st.sendRetryUpdateStats)
 			if err != nil {
 				if ctx.Err() != nil { // we are shutting down

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -234,7 +234,7 @@ var _ = Describe("BatchRouter", func() {
 
 			payloadLimit := batchrouter.payloadLimit
 			var getJobsListCalled bool
-			c.mockBatchRouterJobsDB.EXPECT().GetJobs(gomock.Any(), []string{jobsdb.Failed.State, jobsdb.Unprocessed.State}, jobsdb.GetQueryParams{CustomValFilters: []string{CustomVal["S3"]}, JobsLimit: c.jobQueryBatchSize, PayloadSizeLimit: payloadLimit.Load()}).DoAndReturn(func(ctx context.Context, states []string, params jobsdb.GetQueryParams) (jobsdb.JobsResult, error) {
+			c.mockBatchRouterJobsDB.EXPECT().GetJobs(gomock.Any(), []string{jobsdb.Failed.State, jobsdb.Unprocessed.State}, jobsdb.GetQueryParams{CustomVal: CustomVal["S3"], JobsLimit: c.jobQueryBatchSize, PayloadSizeLimit: payloadLimit.Load()}).DoAndReturn(func(ctx context.Context, states []string, params jobsdb.GetQueryParams) (jobsdb.JobsResult, error) {
 				var res jobsdb.JobsResult
 				if !getJobsListCalled {
 					getJobsListCalled = true

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -245,7 +245,7 @@ var _ = Describe("BatchRouter", func() {
 				return res, nil
 			}).AnyTimes()
 
-			c.mockBatchRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{CustomVal["S3"]}, gomock.Any()).Times(1).
+			c.mockBatchRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), CustomVal["S3"], gomock.Any()).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Executing.State, `{}`, 2)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Executing.State, `{}`, 1)
@@ -256,7 +256,7 @@ var _ = Describe("BatchRouter", func() {
 			c.mockBatchRouterJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil)
-			c.mockBatchRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{CustomVal["S3"]}, gomock.Any()).Times(1).
+			c.mockBatchRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), CustomVal["S3"], gomock.Any()).Times(1).
 				Do(func(ctx context.Context, _ interface{}, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Succeeded.State, `{"firstAttemptedAt": "2021-06-28T15:57:30.742+05:30", "success": "OK"}`, 2)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Succeeded.State, `{"firstAttemptedAt": "2021-06-28T15:57:30.742+05:30, "success": "OK""}`, 1)

--- a/router/batchrouter/worker.go
+++ b/router/batchrouter/worker.go
@@ -137,7 +137,7 @@ func (w *worker) processJobAsync(jobsWg *sync.WaitGroup, destinationJobs *Destin
 
 			err = misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
 				return brt.jobsDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
-					err := brt.jobsDB.UpdateJobStatusInTx(ctx, tx, drainList, []string{brt.destType}, parameterFilters)
+					err := brt.jobsDB.UpdateJobStatusInTx(ctx, tx, drainList, brt.destType, parameterFilters)
 					if err != nil {
 						return fmt.Errorf("marking %s job statuses as aborted: %w", brt.destType, err)
 					}
@@ -167,7 +167,7 @@ func (w *worker) processJobAsync(jobsWg *sync.WaitGroup, destinationJobs *Destin
 		}
 		// Mark the jobs as executing
 		err := misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
-			return brt.jobsDB.UpdateJobStatus(ctx, statusList, []string{brt.destType}, parameterFilters)
+			return brt.jobsDB.UpdateJobStatus(ctx, statusList, brt.destType, parameterFilters)
 		}, brt.sendRetryUpdateStats)
 		if err != nil {
 			panic(fmt.Errorf("storing %s jobs into ErrorDB: %w", brt.destType, err))

--- a/router/eventorder_debugger_test.go
+++ b/router/eventorder_debugger_test.go
@@ -51,16 +51,16 @@ func TestEventOrderDebugInfo(t *testing.T) {
 		JobState:      jobsdb.Executing.State,
 		ErrorResponse: []byte("{}"),
 		Parameters:    []byte(`{}`),
-		JobParameters: []byte(`{"destination_id", "destination1"}`),
-	}}, nil, nil))
+		JobParameters: []byte(`{"destination_id": "destination1"}`),
+	}}, "", nil))
 	require.NoError(t, jdb.UpdateJobStatus(context.Background(), []*jobsdb.JobStatusT{{
 		WorkspaceId:   "workspace1",
 		JobID:         job.JobID,
 		JobState:      jobsdb.Succeeded.State,
 		ErrorResponse: []byte("{}"),
 		Parameters:    []byte(`{}`),
-		JobParameters: []byte(`{"destination_id", "destination1"}`),
-	}}, nil, nil))
+		JobParameters: []byte(`{"destination_id": "destination1"}`),
+	}}, "", nil))
 
 	rt := &Handle{
 		jobsDB: jdb,

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -398,7 +398,7 @@ var _ = Describe("router", func() {
 			payloadLimit := router.reloadableConfig.payloadLimit
 			callGetAllJobs := c.mockRouterJobsDB.EXPECT().GetToProcess(gomock.Any(),
 				jobsdb.GetQueryParams{
-					CustomValFilters: []string{customVal["GA"]},
+					CustomVal:        customVal["GA"],
 					ParameterFilters: []jobsdb.ParameterFilterT{{Name: "destination_id", Value: gaDestinationID}},
 					PayloadSizeLimit: payloadLimit.Load(),
 					JobsLimit:        10000,
@@ -472,7 +472,7 @@ var _ = Describe("router", func() {
 
 			payloadLimit := router.reloadableConfig.payloadLimit
 			callGetAllJobs := c.mockRouterJobsDB.EXPECT().GetToProcess(gomock.Any(), jobsdb.GetQueryParams{
-				CustomValFilters: []string{customVal["GA"]},
+				CustomVal:        customVal["GA"],
 				ParameterFilters: []jobsdb.ParameterFilterT{{Name: "destination_id", Value: gaDestinationID}},
 				PayloadSizeLimit: payloadLimit.Load(),
 				JobsLimit:        10000,
@@ -558,7 +558,7 @@ var _ = Describe("router", func() {
 
 			payloadLimit := router.reloadableConfig.payloadLimit
 			c.mockRouterJobsDB.EXPECT().GetToProcess(gomock.Any(), jobsdb.GetQueryParams{
-				CustomValFilters: []string{customVal["GA"]},
+				CustomVal:        customVal["GA"],
 				ParameterFilters: []jobsdb.ParameterFilterT{{Name: "destination_id", Value: gaDestinationID}},
 				PayloadSizeLimit: payloadLimit.Load(),
 				JobsLimit:        10000,
@@ -643,7 +643,7 @@ var _ = Describe("router", func() {
 
 			payloadLimit := router.reloadableConfig.payloadLimit
 			c.mockRouterJobsDB.EXPECT().GetToProcess(gomock.Any(), jobsdb.GetQueryParams{
-				CustomValFilters: []string{customVal["GA"]},
+				CustomVal:        customVal["GA"],
 				ParameterFilters: []jobsdb.ParameterFilterT{{Name: "destination_id", Value: gaDestinationID}},
 				PayloadSizeLimit: payloadLimit.Load(),
 				JobsLimit:        10000,
@@ -652,7 +652,7 @@ var _ = Describe("router", func() {
 			var routerAborted bool
 			var procErrorStored bool
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1)
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1)
 
 			c.mockProcErrorsDB.EXPECT().Store(gomock.Any(), gomock.Any()).Times(1).
 				Do(func(ctx context.Context, jobList []*jobsdb.JobT) {
@@ -785,7 +785,7 @@ var _ = Describe("router", func() {
 			payloadLimit := router.reloadableConfig.payloadLimit
 			callAllJobs := c.mockRouterJobsDB.EXPECT().GetToProcess(gomock.Any(),
 				jobsdb.GetQueryParams{
-					CustomValFilters: []string{customVal["GA"]},
+					CustomVal:        customVal["GA"],
 					ParameterFilters: []jobsdb.ParameterFilterT{{Name: "destination_id", Value: gaDestinationID}},
 					PayloadSizeLimit: payloadLimit.Load(),
 					JobsLimit:        10000,
@@ -860,7 +860,7 @@ var _ = Describe("router", func() {
 			callAllJobs := c.mockRouterJobsDB.EXPECT().GetToProcess(
 				gomock.Any(),
 				jobsdb.GetQueryParams{
-					CustomValFilters: []string{customVal["GA"]},
+					CustomVal:        customVal["GA"],
 					ParameterFilters: []jobsdb.ParameterFilterT{{Name: "destination_id", Value: gaDestinationID}},
 					PayloadSizeLimit: payloadLimit.Load(),
 					JobsLimit:        10000,
@@ -991,7 +991,7 @@ var _ = Describe("router", func() {
 
 			payloadLimit := router.reloadableConfig.payloadLimit
 			callAllJobs := c.mockRouterJobsDB.EXPECT().GetToProcess(gomock.Any(), jobsdb.GetQueryParams{
-				CustomValFilters: []string{customVal["GA"]},
+				CustomVal:        customVal["GA"],
 				ParameterFilters: []jobsdb.ParameterFilterT{{Name: "destination_id", Value: gaDestinationID}},
 				PayloadSizeLimit: payloadLimit.Load(),
 				JobsLimit:        10000,
@@ -1134,7 +1134,7 @@ var _ = Describe("router", func() {
 			payloadLimit := router.reloadableConfig.payloadLimit
 			callAllJobs := c.mockRouterJobsDB.EXPECT().GetToProcess(gomock.Any(),
 				jobsdb.GetQueryParams{
-					CustomValFilters: []string{customVal["GA"]},
+					CustomVal:        customVal["GA"],
 					ParameterFilters: []jobsdb.ParameterFilterT{{Name: "destination_id", Value: gaDestinationID}},
 					PayloadSizeLimit: payloadLimit.Load(),
 					JobsLimit:        10000,
@@ -1336,7 +1336,7 @@ var _ = Describe("router", func() {
 			payloadLimit := router.reloadableConfig.payloadLimit
 			callAllJobs := c.mockRouterJobsDB.EXPECT().GetToProcess(gomock.Any(),
 				jobsdb.GetQueryParams{
-					CustomValFilters: []string{customVal["GA"]},
+					CustomVal:        customVal["GA"],
 					ParameterFilters: []jobsdb.ParameterFilterT{{Name: "destination_id", Value: gaDestinationID}},
 					PayloadSizeLimit: payloadLimit.Load(),
 					JobsLimit:        10000,
@@ -1530,7 +1530,7 @@ var _ = Describe("router", func() {
 			payloadLimit := router.reloadableConfig.payloadLimit
 			callAllJobs := c.mockRouterJobsDB.EXPECT().GetToProcess(gomock.Any(),
 				jobsdb.GetQueryParams{
-					CustomValFilters: []string{customVal["GA"]},
+					CustomVal:        customVal["GA"],
 					ParameterFilters: []jobsdb.ParameterFilterT{{Name: "destination_id", Value: gaDestinationID}},
 					PayloadSizeLimit: payloadLimit.Load(),
 					JobsLimit:        10000,

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -404,7 +404,7 @@ var _ = Describe("router", func() {
 					JobsLimit:        10000,
 				}, nil).Times(1).Return(&jobsdb.MoreJobsResult{JobsResult: jobsdb.JobsResult{Jobs: allJobs}}, nil)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 1)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Executing.State, "", `{}`, 0)
@@ -418,7 +418,7 @@ var _ = Describe("router", func() {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, _ interface{}, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Succeeded.State, "200", `{"content-type":"","response": "","firstAttemptedAt":"2021-06-28T15:57:30.742+05:30"}`, 2)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Succeeded.State, "200", `{"content-type":"","response": "","firstAttemptedAt":"2021-06-28T15:57:30.742+05:30"}`, 1)
@@ -478,7 +478,7 @@ var _ = Describe("router", func() {
 				JobsLimit:        10000,
 			}, nil).Times(1).Return(&jobsdb.MoreJobsResult{JobsResult: jobsdb.JobsResult{Jobs: unprocessedJobsList}}, nil)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(unprocessedJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 0)
 				}).After(callGetAllJobs)
@@ -505,7 +505,7 @@ var _ = Describe("router", func() {
 				close(done)
 			}).Return(nil)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, _ interface{}, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(unprocessedJobsList[0], statuses[0], jobsdb.Aborted.State, "400", `{"content-type":"","response":"","firstAttemptedAt":"2021-06-28T15:57:30.742+05:30"}`, 1)
 				})
@@ -567,7 +567,7 @@ var _ = Describe("router", func() {
 			var routerAborted bool
 			var procErrorStored bool
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1)
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1)
 
 			c.mockProcErrorsDB.EXPECT().Store(gomock.Any(), gomock.Any()).Times(1).
 				Do(func(ctx context.Context, jobList []*jobsdb.JobT) {
@@ -588,7 +588,7 @@ var _ = Describe("router", func() {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, tx jobsdb.UpdateSafeTx, drainList []*jobsdb.JobStatusT, _, _ interface{}) {
 					Expect(drainList).To(HaveLen(1))
 					assertJobStatus(unprocessedJobsList[0], drainList[0], jobsdb.Aborted.State, "410", `{"reason": "job expired"}`, 0)
@@ -673,7 +673,7 @@ var _ = Describe("router", func() {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 			}).Return(nil).Times(1)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, tx jobsdb.UpdateSafeTx, drainList []*jobsdb.JobStatusT, _, _ interface{}) {
 					Expect(drainList).To(HaveLen(1))
 					assertJobStatus(jobs[0], drainList[0], jobsdb.Aborted.State, strconv.Itoa(routerUtils.DRAIN_ERROR_CODE), fmt.Sprintf(`{"reason": %s}`, fmt.Sprintf(`{"firstAttemptedAt": %q}`, firstAttemptedAt.Format(misc.RFC3339Milli))), jobs[0].LastJobStatus.AttemptNum)
@@ -791,7 +791,7 @@ var _ = Describe("router", func() {
 					JobsLimit:        10000,
 				}, nil).Times(1).Return(&jobsdb.MoreJobsResult{JobsResult: jobsdb.JobsResult{Jobs: allJobs}}, nil)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 1)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Executing.State, "", `{}`, 0)
@@ -805,7 +805,7 @@ var _ = Describe("router", func() {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1)
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1)
 
 			<-router.backendConfigInitialized
 			worker := newPartitionWorker(context.Background(), router, gaDestinationID)
@@ -869,7 +869,7 @@ var _ = Describe("router", func() {
 				Times(1).
 				Return(&jobsdb.MoreJobsResult{JobsResult: jobsdb.JobsResult{Jobs: unprocessedJobsList}}, nil)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(unprocessedJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 3)
 				}).Return(nil).After(callAllJobs)
@@ -887,7 +887,7 @@ var _ = Describe("router", func() {
 					}).Return(nil)
 
 			c.mockRouterJobsDB.EXPECT().
-				UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).
+				UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), customVal["GA"], nil).
 				Times(1).
 				Do(func(ctx context.Context, _ jobsdb.UpdateSafeTx, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(
@@ -997,7 +997,7 @@ var _ = Describe("router", func() {
 				JobsLimit:        10000,
 			}, nil).Times(1).Return(&jobsdb.MoreJobsResult{JobsResult: jobsdb.JobsResult{Jobs: jobsList}}, nil)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 1)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Executing.State, "", `{}`, 0)
@@ -1043,7 +1043,7 @@ var _ = Describe("router", func() {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, _ interface{}, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertTransformJobStatuses(toRetryJobsList[0], statuses[0], jobsdb.Succeeded.State, "200", 1)
 					assertTransformJobStatuses(unprocessedJobsList[0], statuses[1], jobsdb.Succeeded.State, "200", 1)
@@ -1141,7 +1141,7 @@ var _ = Describe("router", func() {
 				}, nil).Return(&jobsdb.MoreJobsResult{JobsResult: jobsdb.JobsResult{Jobs: toRetryJobsList}}, nil).Times(
 				1).Return(&jobsdb.MoreJobsResult{JobsResult: jobsdb.JobsResult{Jobs: allJobs}}, nil)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 1)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Executing.State, "", `{}`, 0)
@@ -1199,7 +1199,7 @@ var _ = Describe("router", func() {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, _ interface{}, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertTransformJobStatuses(toRetryJobsList[0], statuses[0], jobsdb.Failed.State, "500", 2)
 					assertTransformJobStatuses(unprocessedJobsList[0], statuses[1], jobsdb.Waiting.State, "", 0)
@@ -1342,7 +1342,7 @@ var _ = Describe("router", func() {
 					JobsLimit:        10000,
 				}, nil).Times(1).Return(&jobsdb.MoreJobsResult{JobsResult: jobsdb.JobsResult{Jobs: allJobs}}, nil)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 1)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Executing.State, "", `{}`, 0)
@@ -1435,7 +1435,7 @@ var _ = Describe("router", func() {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1)
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1)
 
 			<-router.backendConfigInitialized
 			worker := newPartitionWorker(context.Background(), router, gaDestinationID)
@@ -1536,7 +1536,7 @@ var _ = Describe("router", func() {
 					JobsLimit:        10000,
 				}, nil).Times(1).Return(&jobsdb.MoreJobsResult{JobsResult: jobsdb.JobsResult{Jobs: allJobs}}, nil)
 
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1).
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatus(gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1).
 				Do(func(ctx context.Context, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Executing.State, "", `{}`, 1)
 					assertJobStatus(unprocessedJobsList[0], statuses[1], jobsdb.Executing.State, "", `{}`, 0)
@@ -1599,7 +1599,7 @@ var _ = Describe("router", func() {
 				_ = f(jobsdb.EmptyUpdateSafeTx())
 				close(done)
 			}).Return(nil)
-			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), []string{customVal["GA"]}, nil).Times(1)
+			c.mockRouterJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), customVal["GA"], nil).Times(1)
 
 			<-router.backendConfigInitialized
 			worker := newPartitionWorker(context.Background(), router, gaDestinationID)

--- a/schema-forwarder/internal/forwarder/baseforwarder.go
+++ b/schema-forwarder/internal/forwarder/baseforwarder.go
@@ -67,7 +67,7 @@ func (bf *BaseForwarder) GetJobs(ctx context.Context) ([]*jobsdb.JobT, bool, err
 func (bf *BaseForwarder) MarkJobStatuses(ctx context.Context, statusList []*jobsdb.JobStatusT) error {
 	err := misc.RetryWithNotify(ctx, bf.conf.jobsDBQueryRequestTimeout, bf.conf.jobsDBMaxRetries, func(ctx context.Context) error {
 		return bf.jobsDB.WithUpdateSafeTx(ctx, func(txn jobsdb.UpdateSafeTx) error {
-			return bf.jobsDB.UpdateJobStatusInTx(ctx, txn, statusList, nil, nil)
+			return bf.jobsDB.UpdateJobStatusInTx(ctx, txn, statusList, "", nil)
 		})
 	}, bf.sendQueryRetryStats)
 	return err


### PR DESCRIPTION
# Description

subject cache for jobsdb.

Motivation: to reduce the amount of adaptations to jobsdb's cache every time the query pattern changes. And also something that has lesser cognitive load. imo this would simplify(at least cache adaptations - simply add the required tokens) if we were to add more query filters, ex.: both source and destination IDs, `jobRunID`, `user_id` etc.

Idea is that each time a consumer of jobsdb queries for jobs -> it's with a subset of all the query parameters possible. We use this subset and wildcards to create subjects. Any write to jobsdb(store/status update) if contains enough information would then be a subset of the subject used during read. The subject is of the format - `dsIndex.WorkspaceID.customVal.SourceID.DestID.State`
For example:
1. read query subject: `1.*.GA.*.*.Unprocessed`
    a write that is a subset of above subject would be: `1.WS-1.GA.SRC-1.DST-1.Unprocessed`(a store job call)

2. read query subject: `3.*.GA.*.dest1.Failed`
    a write that is a subset of above subject would be: `3.WS-1.GA.SRC-99.dest1.Failed` (a job status update call)

Writes when updating the cache can only pass subject literals(no wildcards).

Introduces package `tokens` in `/internal`(credits: nats-server). This is the package that tells us if one subject is a subset of another.

TODO: implement a ttl for the cache.

Other changes:
1. changed `jobsdb.GetQueryParams.CustomVal` from `[]string` to `string`. Because never saw a query by multiple `customVal`s. With more isolation, this is much less likelier.
2. changed `OR` clause to `AND` in parameters -> query string.
3. changed `jobsbd.updatestatus` signature to accept `customVal string` instead of `customValFilters []string` - because again - haven't seen multiple `customVal`s being passed anyway.
4. no cache business at all for the lastDS in a read jobsdb.

We'd have to enforce that any writes that go into jobsdb(store/status update) must have enough information to form a subject literal(no wildcard allowed in writes)
E.g.: populating `jobsdb.JobStatusT.JobParameters` with it's job's `job.Parameters`, set `status.WorkspaceId = job.WorkspaceId`. And making sure update status calls are grouped by one `customVal`.

## Linear Ticket

< Replace with Linear Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search functionality now available with a new search bar for improved navigation and user experience.
- **Enhancements**
  - Streamlined job status update process with simplified filtering.
- **Bug Fixes**
  - Corrected syntax errors in job status update parameters.
- **Refactor**
  - Consolidated custom value filters into a single field for more efficient querying.
- **Performance Improvements**
  - Optimized job status update logic for faster processing.
- **Documentation**
  - Updated documentation to reflect changes in job status update methods and query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->