### PR TITLE
fix: router transformer client fails with error connect: cannot assign requested address

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -201,8 +201,8 @@ func NewTransformer(conf *config.Config, log logger.Logger, stat stats.Stats, op
 	trans.cpDownGauge = stat.NewStat("processor.control_plane_down", stats.GaugeType)
 
 	trans.config.maxConcurrency = conf.GetInt("Processor.maxConcurrency", 200)
-	trans.config.maxHTTPConnections = conf.GetInt("Processor.maxHTTPConnections", 100)
-	trans.config.maxHTTPIdleConnections = conf.GetInt("Processor.maxHTTPIdleConnections", 5)
+	trans.config.maxHTTPConnections = conf.GetInt("Transformer.Client.maxHTTPConnections", 100)
+	trans.config.maxHTTPIdleConnections = conf.GetInt("Transformer.Client.maxHTTPIdleConnections", 10)
 	trans.config.disableKeepAlives = conf.GetBool("Transformer.Client.disableKeepAlives", true)
 	trans.config.timeoutDuration = conf.GetDuration("HttpClient.procTransformer.timeout", 600, time.Second)
 
@@ -221,7 +221,7 @@ func NewTransformer(conf *config.Config, log logger.Logger, stat stats.Stats, op
 				DisableKeepAlives:   trans.config.disableKeepAlives,
 				MaxConnsPerHost:     trans.config.maxHTTPConnections,
 				MaxIdleConnsPerHost: trans.config.maxHTTPIdleConnections,
-				IdleConnTimeout:     time.Minute,
+				IdleConnTimeout:     30 * time.Second,
 			},
 			Timeout: trans.config.timeoutDuration,
 		}

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -87,16 +87,14 @@ func NewTransformer(destinationTimeout, transformTimeout time.Duration) Transfor
 }
 
 var (
-	maxRetry          int
-	disableKeepAlives bool
-	retrySleep        time.Duration
-	pkgLogger         logger.Logger
+	maxRetry   int
+	retrySleep time.Duration
+	pkgLogger  logger.Logger
 )
 
 func loadConfig() {
 	config.RegisterIntConfigVariable(30, &maxRetry, true, 1, "Processor.maxRetry")
 	config.RegisterDurationConfigVariable(100, &retrySleep, true, time.Millisecond, []string{"Processor.retrySleep", "Processor.retrySleepInMS"}...)
-	config.RegisterBoolConfigVariable(true, &disableKeepAlives, false, "Transformer.Client.disableKeepAlives")
 }
 
 func Init() {
@@ -299,7 +297,12 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 
 func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration) {
 	trans.logger = pkgLogger
-	trans.tr = &http.Transport{DisableKeepAlives: disableKeepAlives}
+	trans.tr = &http.Transport{
+		DisableKeepAlives:   config.GetBool("Transformer.Client.disableKeepAlives", true),
+		MaxConnsPerHost:     config.GetInt("Transformer.Client.maxHTTPConnections", 100),
+		MaxIdleConnsPerHost: config.GetInt("Transformer.Client.maxHTTPIdleConnections", 10),
+		IdleConnTimeout:     30 * time.Second,
+	}
 	// The timeout between server and transformer
 	// Basically this timeout is more for communication between transformer and server
 	trans.transformTimeout = transformTimeout


### PR DESCRIPTION
# Description

Using common http transport setting for both processor and router transformers

## Linear Ticket

< Replace with Linear Link >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
