### PR TITLE
fix: router transformer client fails with error connect: cannot assign requested address

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -201,8 +201,8 @@ func NewTransformer(conf *config.Config, log logger.Logger, stat stats.Stats, op
 	trans.cpDownGauge = stat.NewStat("processor.control_plane_down", stats.GaugeType)
 
 	trans.config.maxConcurrency = conf.GetInt("Processor.maxConcurrency", 200)
-	trans.config.maxHTTPConnections = conf.GetInt("Processor.maxHTTPConnections", 100)
-	trans.config.maxHTTPIdleConnections = conf.GetInt("Processor.maxHTTPIdleConnections", 5)
+	trans.config.maxHTTPConnections = conf.GetInt("Transformer.Client.maxHTTPConnections", 100)
+	trans.config.maxHTTPIdleConnections = conf.GetInt("Transformer.Client.maxHTTPIdleConnections", 10)
 	trans.config.disableKeepAlives = conf.GetBool("Transformer.Client.disableKeepAlives", true)
 	trans.config.timeoutDuration = conf.GetDuration("HttpClient.procTransformer.timeout", 600, time.Second)
 	trans.config.destTransformationURL = conf.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
@@ -220,7 +220,7 @@ func NewTransformer(conf *config.Config, log logger.Logger, stat stats.Stats, op
 				DisableKeepAlives:   trans.config.disableKeepAlives,
 				MaxConnsPerHost:     trans.config.maxHTTPConnections,
 				MaxIdleConnsPerHost: trans.config.maxHTTPIdleConnections,
-				IdleConnTimeout:     time.Minute,
+				IdleConnTimeout:     30 * time.Second,
 			},
 			Timeout: trans.config.timeoutDuration,
 		}

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -288,7 +288,12 @@ func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration) {
 		trans.logger = loggerOverride
 	}
 
-	trans.tr = &http.Transport{DisableKeepAlives: config.GetBool("Transformer.Client.disableKeepAlives", true)}
+	trans.tr = &http.Transport{
+		DisableKeepAlives:   config.GetBool("Transformer.Client.disableKeepAlives", true),
+		MaxConnsPerHost:     config.GetInt("Transformer.Client.maxHTTPConnections", 100),
+		MaxIdleConnsPerHost: config.GetInt("Transformer.Client.maxHTTPIdleConnections", 10),
+		IdleConnTimeout:     30 * time.Second,
+	}
 	// The timeout between server and transformer
 	// Basically this timeout is more for communication between transformer and server
 	trans.transformTimeout = transformTimeout


### PR DESCRIPTION
# Description

Problem caused by exhausted sockets on the container, due to having too many connections in `TIME_WAIT` state. 
Related to golang/go#16012

- Using common http transport setting for both processor and router transformer clients
- Change `IdleConnTimeout: 30 * time.Second`
- Change default `MaxIdleConnsPerHost: 10`

## Linear Ticket

[PIPE-330](https://linear.app/rudderstack/issue/PIPE-330/router-transformer-client-fails-with-error-connect-cannot-assign)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
