### PR TITLE
chore: warehouse schema race and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 test-warehouse-integration:
 	$(eval TEST_PATTERN = 'TestIntegration')
 	$(eval TEST_CMD = SLOW=1 go test)
-	$(eval TEST_OPTIONS = -v -p 8 -timeout 30m -count 1 -run $(TEST_PATTERN) -coverprofile=profile.out -covermode=atomic -coverpkg=./...)
+	$(eval TEST_OPTIONS = -v -p 8 -timeout 30m -count 1 -race -run $(TEST_PATTERN) -coverprofile=profile.out -covermode=atomic -coverpkg=./...)
 	$(TEST_CMD) $(TEST_OPTIONS) $(package) && touch $(TESTFILE) || true
 
 test-warehouse: test-warehouse-integration test-teardown

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -892,7 +892,7 @@ func (ch *Clickhouse) AddColumns(ctx context.Context, tableName string, columnsI
 }
 
 func (ch *Clickhouse) CreateSchema(ctx context.Context) error {
-	if len(ch.Uploader.GetSchemaInWarehouse()) > 0 {
+	if !ch.Uploader.IsWarehouseSchemaEmpty() {
 		return nil
 	}
 

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -770,7 +770,7 @@ func (ch *Clickhouse) schemaExists(ctx context.Context, schemaName string) (exis
 	sqlStatement := "SELECT count(*) FROM system.databases WHERE name = ?"
 	err = ch.DB.QueryRowContext(ctx, sqlStatement, schemaName).Scan(&count)
 	// ignore err if no results for query
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		err = nil
 	}
 	exists = count > 0
@@ -977,7 +977,8 @@ func (ch *Clickhouse) FetchSchema(ctx context.Context) (model.Schema, model.Sche
 		return schema, unrecognizedSchema, nil
 	}
 	if err != nil {
-		if clickhouseErr, ok := err.(*clickhouse.Exception); ok && clickhouseErr.Code == 81 {
+		var clickhouseErr *clickhouse.Exception
+		if errors.As(err, &clickhouseErr) && clickhouseErr.Code == 81 {
 			return schema, unrecognizedSchema, nil
 		}
 		return nil, nil, fmt.Errorf("fetching schema: %w", err)

--- a/warehouse/integrations/clickhouse/clickhouse_test.go
+++ b/warehouse/integrations/clickhouse/clickhouse_test.go
@@ -1208,7 +1208,7 @@ func newMockUploader(
 	u.EXPECT().GetTableSchemaInUpload(gomock.Any()).Return(tableSchema).AnyTimes()
 	u.EXPECT().GetLoadFilesMetadata(gomock.Any(), gomock.Any()).Return(metadata).AnyTimes()
 	u.EXPECT().UseRudderStorage().Return(false).AnyTimes()
-	u.EXPECT().GetSchemaInWarehouse().Return(nil).AnyTimes()
+	u.EXPECT().IsWarehouseSchemaEmpty().Return(true).AnyTimes()
 
 	return u
 }

--- a/warehouse/internal/mocks/utils/mock_uploader.go
+++ b/warehouse/internal/mocks/utils/mock_uploader.go
@@ -138,20 +138,6 @@ func (mr *MockUploaderMockRecorder) GetSampleLoadFileLocation(arg0, arg1 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSampleLoadFileLocation", reflect.TypeOf((*MockUploader)(nil).GetSampleLoadFileLocation), arg0, arg1)
 }
 
-// GetSchemaInWarehouse mocks base method.
-func (m *MockUploader) GetSchemaInWarehouse() model.Schema {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSchemaInWarehouse")
-	ret0, _ := ret[0].(model.Schema)
-	return ret0
-}
-
-// GetSchemaInWarehouse indicates an expected call of GetSchemaInWarehouse.
-func (mr *MockUploaderMockRecorder) GetSchemaInWarehouse() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchemaInWarehouse", reflect.TypeOf((*MockUploader)(nil).GetSchemaInWarehouse))
-}
-
 // GetSingleLoadFile mocks base method.
 func (m *MockUploader) GetSingleLoadFile(arg0 context.Context, arg1 string) (warehouseutils.LoadFile, error) {
 	m.ctrl.T.Helper()
@@ -193,6 +179,20 @@ func (m *MockUploader) GetTableSchemaInWarehouse(arg0 string) model.TableSchema 
 func (mr *MockUploaderMockRecorder) GetTableSchemaInWarehouse(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTableSchemaInWarehouse", reflect.TypeOf((*MockUploader)(nil).GetTableSchemaInWarehouse), arg0)
+}
+
+// IsWarehouseSchemaEmpty mocks base method.
+func (m *MockUploader) IsWarehouseSchemaEmpty() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsWarehouseSchemaEmpty")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsWarehouseSchemaEmpty indicates an expected call of IsWarehouseSchemaEmpty.
+func (mr *MockUploaderMockRecorder) IsWarehouseSchemaEmpty() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWarehouseSchemaEmpty", reflect.TypeOf((*MockUploader)(nil).IsWarehouseSchemaEmpty))
 }
 
 // ShouldOnDedupUseNewRecord mocks base method.

--- a/warehouse/jobs/jobs.go
+++ b/warehouse/jobs/jobs.go
@@ -11,9 +11,7 @@ import (
 
 type WhAsyncJob struct{}
 
-func (*WhAsyncJob) GetSchemaInWarehouse() model.Schema {
-	return model.Schema{}
-}
+func (*WhAsyncJob) IsWarehouseSchemaEmpty() bool { return true }
 
 func (*WhAsyncJob) GetLocalSchema(context.Context) (model.Schema, error) {
 	return model.Schema{}, nil

--- a/warehouse/router_identities.go
+++ b/warehouse/router_identities.go
@@ -436,7 +436,7 @@ func (r *router) populateHistoricIdentities(ctx context.Context, warehouse model
 		))
 		err = whManager.Setup(ctx, job.warehouse, job)
 		if err != nil {
-			job.setUploadError(err, model.Aborted)
+			_, _ = job.setUploadError(err, model.Aborted)
 			return
 		}
 		defer whManager.Cleanup(ctx)
@@ -444,19 +444,19 @@ func (r *router) populateHistoricIdentities(ctx context.Context, warehouse model
 		err = job.schemaHandle.FetchSchemaFromWarehouse(ctx, whManager)
 		if err != nil {
 			r.logger.Errorf(`[WH]: Failed fetching schema from warehouse: %v`, err)
-			job.setUploadError(err, model.Aborted)
+			_, _ = job.setUploadError(err, model.Aborted)
 			return
 		}
 
-		job.setUploadStatus(UploadStatusOpts{Status: getInProgressState(model.ExportedData)})
+		_ = job.setUploadStatus(UploadStatusOpts{Status: getInProgressState(model.ExportedData)})
 		loadErrors, err := job.loadIdentityTables(true)
 		if err != nil {
 			r.logger.Errorf(`[WH]: Identity table upload errors: %v`, err)
 		}
 		if len(loadErrors) > 0 {
-			job.setUploadError(misc.ConcatErrors(loadErrors), model.Aborted)
+			_, _ = job.setUploadError(misc.ConcatErrors(loadErrors), model.Aborted)
 			return
 		}
-		job.setUploadStatus(UploadStatusOpts{Status: model.ExportedData})
+		_ = job.setUploadStatus(UploadStatusOpts{Status: model.ExportedData})
 	})
 }

--- a/warehouse/router_identities.go
+++ b/warehouse/router_identities.go
@@ -440,7 +440,7 @@ func (r *router) populateHistoricIdentities(ctx context.Context, warehouse model
 		}
 		defer whManager.Cleanup(ctx)
 
-		err = job.schemaHandle.fetchSchemaFromWarehouse(ctx, whManager)
+		err = job.schemaHandle.FetchSchemaFromWarehouse(ctx, whManager)
 		if err != nil {
 			r.logger.Errorf(`[WH]: Failed fetching schema from warehouse: %v`, err)
 			job.setUploadError(err, model.Aborted)

--- a/warehouse/router_identities.go
+++ b/warehouse/router_identities.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -123,7 +124,7 @@ func (r *router) getPendingPopulateIdentitiesLoad(warehouse model.Warehouse) (up
 		&upload.LoadFileEndID,
 		&upload.Error,
 	)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return
 	}
 	if err != nil {

--- a/warehouse/schema/schema.go
+++ b/warehouse/schema/schema.go
@@ -402,10 +402,6 @@ func (sh *Schema) TableSchemaDiff(tableName string, tableSchema model.TableSchem
 	return diff
 }
 
-func (sh *Schema) GetSchemaInWarehouse() model.Schema {
-	return sh.schemaInWarehouse
-}
-
 func (sh *Schema) GetTableSchemaInWarehouse(tableName string) model.TableSchema {
 	return sh.schemaInWarehouse[tableName]
 }

--- a/warehouse/schema/schema.go
+++ b/warehouse/schema/schema.go
@@ -51,7 +51,7 @@ type Schema struct {
 	enableIDResolution               bool
 }
 
-func NewSchema(
+func New(
 	db *sqlquerywrapper.DB,
 	warehouse model.Warehouse,
 	conf *config.Config,

--- a/warehouse/schema/schema.go
+++ b/warehouse/schema/schema.go
@@ -154,8 +154,8 @@ func (sh *Schema) SyncRemoteSchema(ctx context.Context, fetchSchemaRepo fetchSch
 	}
 
 	sh.schemaInWarehouseMu.RLock()
-	schemaChanged := sh.hasSchemaChanged(localSchema)
 	defer sh.schemaInWarehouseMu.RUnlock()
+	schemaChanged := sh.hasSchemaChanged(localSchema)
 	if schemaChanged {
 		err := sh.updateLocalSchema(ctx, uploadID, sh.schemaInWarehouse)
 		if err != nil {

--- a/warehouse/schema/schema_test.go
+++ b/warehouse/schema/schema_test.go
@@ -1,4 +1,4 @@
-package warehouse
+package schema
 
 import (
 	"context"
@@ -17,265 +17,6 @@ import (
 
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
-
-func TestHandleSchemaChange(t *testing.T) {
-	inputs := []struct {
-		name             string
-		existingDatatype string
-		currentDataType  string
-		value            any
-
-		newColumnVal any
-		convError    error
-	}{
-		{
-			name:             "should send int values if existing datatype is int, new datatype is float",
-			existingDatatype: "int",
-			currentDataType:  "float",
-			value:            1.501,
-			newColumnVal:     1,
-		},
-		{
-			name:             "should send float values if existing datatype is float, new datatype is int",
-			existingDatatype: "float",
-			currentDataType:  "int",
-			value:            1,
-			newColumnVal:     1.0,
-		},
-		{
-			name:             "should send string values if existing datatype is string, new datatype is boolean",
-			existingDatatype: "string",
-			currentDataType:  "boolean",
-			value:            false,
-			newColumnVal:     "false",
-		},
-		{
-			name:             "should send string values if existing datatype is string, new datatype is int",
-			existingDatatype: "string",
-			currentDataType:  "int",
-			value:            1,
-			newColumnVal:     "1",
-		},
-		{
-			name:             "should send string values if existing datatype is string, new datatype is float",
-			existingDatatype: "string",
-			currentDataType:  "float",
-			value:            1.501,
-			newColumnVal:     "1.501",
-		},
-		{
-			name:             "should send string values if existing datatype is string, new datatype is datetime",
-			existingDatatype: "string",
-			currentDataType:  "datetime",
-			value:            "2022-05-05T00:00:00.000Z",
-			newColumnVal:     "2022-05-05T00:00:00.000Z",
-		},
-		{
-			name:             "should send string values if existing datatype is string, new datatype is string",
-			existingDatatype: "string",
-			currentDataType:  "json",
-			value:            `{"json":true}`,
-			newColumnVal:     `{"json":true}`,
-		},
-		{
-			name:             "should send json string values if existing datatype is json, new datatype is boolean",
-			existingDatatype: "json",
-			currentDataType:  "boolean",
-			value:            false,
-			newColumnVal:     "false",
-		},
-		{
-			name:             "should send json string values if existing datatype is jso, new datatype is int",
-			existingDatatype: "json",
-			currentDataType:  "int",
-			value:            1,
-			newColumnVal:     "1",
-		},
-		{
-			name:             "should send json string values if existing datatype is json, new datatype is float",
-			existingDatatype: "json",
-			currentDataType:  "float",
-			value:            1.501,
-			newColumnVal:     "1.501",
-		},
-		{
-			name:             "should send json string values if existing datatype is json, new datatype is json",
-			existingDatatype: "json",
-			currentDataType:  "datetime",
-			value:            "2022-05-05T00:00:00.000Z",
-			newColumnVal:     `"2022-05-05T00:00:00.000Z"`,
-		},
-		{
-			name:             "should send json string values if existing datatype is json, new datatype is string",
-			existingDatatype: "json",
-			currentDataType:  "string",
-			value:            "string value",
-			newColumnVal:     `"string value"`,
-		},
-		{
-			name:             "should send json string values if existing datatype is json, new datatype is array",
-			existingDatatype: "json",
-			currentDataType:  "array",
-			value:            []any{false, 1, "string value"},
-			newColumnVal:     []any{false, 1, "string value"},
-		},
-		{
-			name:             "existing datatype is boolean, new datatype is int",
-			existingDatatype: "boolean",
-			currentDataType:  "int",
-			value:            1,
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is boolean, new datatype is float",
-			existingDatatype: "boolean",
-			currentDataType:  "float",
-			value:            1.501,
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is boolean, new datatype is string",
-			existingDatatype: "boolean",
-			currentDataType:  "string",
-			value:            "string value",
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is boolean, new datatype is datetime",
-			existingDatatype: "boolean",
-			currentDataType:  "datetime",
-			value:            "2022-05-05T00:00:00.000Z",
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is boolean, new datatype is json",
-			existingDatatype: "boolean",
-			currentDataType:  "json",
-			value:            `{"json":true}`,
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is int, new datatype is boolean",
-			existingDatatype: "int",
-			currentDataType:  "boolean",
-			value:            false,
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is int, new datatype is string",
-			existingDatatype: "int",
-			currentDataType:  "string",
-			value:            "string value",
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is int, new datatype is datetime",
-			existingDatatype: "int",
-			currentDataType:  "datetime",
-			value:            "2022-05-05T00:00:00.000Z",
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is int, new datatype is json",
-			existingDatatype: "int",
-			currentDataType:  "json",
-			value:            `{"json":true}`,
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is int, new datatype is float",
-			existingDatatype: "int",
-			currentDataType:  "float",
-			value:            1,
-			convError:        errIncompatibleSchemaConversion,
-		},
-		{
-			name:             "existing datatype is float, new datatype is boolean",
-			existingDatatype: "float",
-			currentDataType:  "boolean",
-			value:            false,
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is float, new datatype is int",
-			existingDatatype: "float",
-			currentDataType:  "int",
-			value:            1.0,
-			convError:        errIncompatibleSchemaConversion,
-		},
-		{
-			name:             "existing datatype is float, new datatype is string",
-			existingDatatype: "float",
-			currentDataType:  "string",
-			value:            "string value",
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is float, new datatype is datetime",
-			existingDatatype: "float",
-			currentDataType:  "datetime",
-			value:            "2022-05-05T00:00:00.000Z",
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is float, new datatype is json",
-			existingDatatype: "float",
-			currentDataType:  "json",
-			value:            `{"json":true}`,
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is datetime, new datatype is boolean",
-			existingDatatype: "datetime",
-			currentDataType:  "boolean",
-			value:            false,
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is datetime, new datatype is string",
-			existingDatatype: "datetime",
-			currentDataType:  "string",
-			value:            "string value",
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is datetime, new datatype is int",
-			existingDatatype: "datetime",
-			currentDataType:  "int",
-			value:            1,
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is datetime, new datatype is float",
-			existingDatatype: "datetime",
-			currentDataType:  "float",
-			value:            1.501,
-			convError:        errSchemaConversionNotSupported,
-		},
-		{
-			name:             "existing datatype is datetime, new datatype is json",
-			existingDatatype: "datetime",
-			currentDataType:  "json",
-			value:            `{"json":true}`,
-			convError:        errSchemaConversionNotSupported,
-		},
-	}
-	for _, ip := range inputs {
-		tc := ip
-
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			newColumnVal, convError := handleSchemaChange(
-				model.SchemaType(tc.existingDatatype),
-				model.SchemaType(tc.currentDataType),
-				tc.value,
-			)
-			require.Equal(t, newColumnVal, tc.newColumnVal)
-			require.ErrorIs(t, convError, tc.convError)
-		})
-	}
-}
 
 type mockSchemaRepo struct {
 	err       error
@@ -401,7 +142,7 @@ func TestSchema_GetUpdateLocalSchema(t *testing.T) {
 
 			ctx := context.Background()
 
-			err := sch.updateLocalSchema(ctx, uploadID, tc.mockSchema.Schema)
+			err := sch.UpdateLocalSchema(ctx, uploadID, tc.mockSchema.Schema)
 			if tc.wantError == nil {
 				require.NoError(t, err)
 			} else {
@@ -420,8 +161,6 @@ func TestSchema_GetUpdateLocalSchema(t *testing.T) {
 }
 
 func TestSchema_FetchSchemaFromWarehouse(t *testing.T) {
-	Init4()
-
 	testCases := []struct {
 		name           string
 		mockSchema     model.Schema
@@ -571,7 +310,7 @@ func TestSchema_FetchSchemaFromWarehouse(t *testing.T) {
 
 			ctx := context.Background()
 
-			err := sh.fetchSchemaFromWarehouse(ctx, &fechSchemaRepo)
+			err := sh.FetchSchemaFromWarehouse(ctx, &fechSchemaRepo)
 			if tc.wantError != nil {
 				require.EqualError(t, err, tc.wantError.Error())
 			} else {
@@ -1891,7 +1630,7 @@ func TestSchema_PrepareUploadSchema(t *testing.T) {
 				stagingFilesSchemaPaginationSize: 2,
 			}
 
-			uploadSchema, err := sh.prepareUploadSchema(ctx, stagingFiles)
+			uploadSchema, err := sh.PrepareUploadSchema(ctx, stagingFiles)
 			if tc.wantError != nil {
 				require.EqualError(t, err, tc.wantError.Error())
 			} else {

--- a/warehouse/schema/schema_test.go
+++ b/warehouse/schema/schema_test.go
@@ -78,7 +78,7 @@ func TestSchema_GetUpdateLocalSchema(t *testing.T) {
 			name:          "no schema in db",
 			mockSchema:    model.WHSchema{},
 			mockSchemaErr: nil,
-			wantSchema:    model.Schema{},
+			wantSchema:    nil,
 			wantError:     nil,
 		},
 		{
@@ -149,7 +149,6 @@ func TestSchema_GetUpdateLocalSchema(t *testing.T) {
 				require.ErrorContains(t, err, tc.wantError.Error())
 			}
 
-			err = sch.fetchSchemaFromLocal(ctx)
 			require.Equal(t, tc.wantSchema, sch.localSchema)
 			if tc.wantError == nil {
 				require.NoError(t, err)
@@ -596,10 +595,9 @@ func TestSchema_HasLocalSchemaChanged(t *testing.T) {
 					Type: warehouseutils.SNOWFLAKE,
 				},
 				skipDeepEqualSchemas: tc.skipDeepEquals,
-				localSchema:          tc.localSchema,
 				schemaInWarehouse:    tc.schemaInWarehouse,
 			}
-			require.Equal(t, tc.expected, sch.hasSchemaChanged())
+			require.Equal(t, tc.expected, sch.hasSchemaChanged(tc.localSchema))
 		})
 	}
 }

--- a/warehouse/schema/schema_test.go
+++ b/warehouse/schema/schema_test.go
@@ -604,7 +604,7 @@ func TestSchema_HasLocalSchemaChanged(t *testing.T) {
 	}
 }
 
-func TestSchema_PrepareUploadSchema(t *testing.T) {
+func TestSchema_ConsolidateStagingFilesUsingLocalSchema(t *testing.T) {
 	warehouseutils.Init()
 
 	const (
@@ -638,7 +638,7 @@ func TestSchema_PrepareUploadSchema(t *testing.T) {
 			warehouseType: warehouseutils.RS,
 			mockSchemas:   []model.Schema{},
 			mockErr:       errors.New("test error"),
-			wantError:     errors.New("consolidating staging files schema: getting staging files schema: test error"),
+			wantError:     errors.New("getting staging files schema: test error"),
 		},
 
 		{
@@ -1630,7 +1630,7 @@ func TestSchema_PrepareUploadSchema(t *testing.T) {
 				stagingFilesSchemaPaginationSize: 2,
 			}
 
-			uploadSchema, err := sh.PrepareUploadSchema(ctx, stagingFiles)
+			uploadSchema, err := sh.ConsolidateStagingFilesUsingLocalSchema(ctx, stagingFiles)
 			if tc.wantError != nil {
 				require.EqualError(t, err, tc.wantError.Error())
 			} else {

--- a/warehouse/slave_worker.go
+++ b/warehouse/slave_worker.go
@@ -25,6 +25,11 @@ import (
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
+var (
+	errIncompatibleSchemaConversion = errors.New("incompatible schema conversion")
+	errSchemaConversionNotSupported = errors.New("schema conversion not supported")
+)
+
 type uploadProcessingResult struct {
 	result uploadResult
 	err    error
@@ -518,4 +523,48 @@ func (sw *slaveWorker) destinationFromSlaveConnectionMap(destinationId, sourceId
 	}
 
 	return conn, nil
+}
+
+// handleSchemaChange checks if the existing column type is compatible with the new column type
+func handleSchemaChange(existingDataType, currentDataType model.SchemaType, value any) (any, error) {
+	var (
+		newColumnVal any
+		err          error
+	)
+
+	if existingDataType == model.StringDataType || existingDataType == model.TextDataType {
+		// only stringify if the previous type is non-string/text/json
+		if currentDataType != model.StringDataType && currentDataType != model.TextDataType && currentDataType != model.JSONDataType {
+			newColumnVal = fmt.Sprintf("%v", value)
+		} else {
+			newColumnVal = value
+		}
+	} else if (currentDataType == model.IntDataType || currentDataType == model.BigIntDataType) && existingDataType == model.FloatDataType {
+		intVal, ok := value.(int)
+		if !ok {
+			err = errIncompatibleSchemaConversion
+		} else {
+			newColumnVal = float64(intVal)
+		}
+	} else if currentDataType == model.FloatDataType && (existingDataType == model.IntDataType || existingDataType == model.BigIntDataType) {
+		floatVal, ok := value.(float64)
+		if !ok {
+			err = errIncompatibleSchemaConversion
+		} else {
+			newColumnVal = int(floatVal)
+		}
+	} else if existingDataType == model.JSONDataType {
+		var interfaceSliceSample []any
+		if currentDataType == model.IntDataType || currentDataType == model.FloatDataType || currentDataType == model.BooleanDataType {
+			newColumnVal = fmt.Sprintf("%v", value)
+		} else if reflect.TypeOf(value) == reflect.TypeOf(interfaceSliceSample) {
+			newColumnVal = value
+		} else {
+			newColumnVal = fmt.Sprintf(`"%v"`, value)
+		}
+	} else {
+		err = errSchemaConversionNotSupported
+	}
+
+	return newColumnVal, err
 }

--- a/warehouse/slave_worker_test.go
+++ b/warehouse/slave_worker_test.go
@@ -712,3 +712,262 @@ func TestSlaveWorker(t *testing.T) {
 		})
 	})
 }
+
+func TestHandleSchemaChange(t *testing.T) {
+	inputs := []struct {
+		name             string
+		existingDatatype string
+		currentDataType  string
+		value            any
+
+		newColumnVal any
+		convError    error
+	}{
+		{
+			name:             "should send int values if existing datatype is int, new datatype is float",
+			existingDatatype: "int",
+			currentDataType:  "float",
+			value:            1.501,
+			newColumnVal:     1,
+		},
+		{
+			name:             "should send float values if existing datatype is float, new datatype is int",
+			existingDatatype: "float",
+			currentDataType:  "int",
+			value:            1,
+			newColumnVal:     1.0,
+		},
+		{
+			name:             "should send string values if existing datatype is string, new datatype is boolean",
+			existingDatatype: "string",
+			currentDataType:  "boolean",
+			value:            false,
+			newColumnVal:     "false",
+		},
+		{
+			name:             "should send string values if existing datatype is string, new datatype is int",
+			existingDatatype: "string",
+			currentDataType:  "int",
+			value:            1,
+			newColumnVal:     "1",
+		},
+		{
+			name:             "should send string values if existing datatype is string, new datatype is float",
+			existingDatatype: "string",
+			currentDataType:  "float",
+			value:            1.501,
+			newColumnVal:     "1.501",
+		},
+		{
+			name:             "should send string values if existing datatype is string, new datatype is datetime",
+			existingDatatype: "string",
+			currentDataType:  "datetime",
+			value:            "2022-05-05T00:00:00.000Z",
+			newColumnVal:     "2022-05-05T00:00:00.000Z",
+		},
+		{
+			name:             "should send string values if existing datatype is string, new datatype is string",
+			existingDatatype: "string",
+			currentDataType:  "json",
+			value:            `{"json":true}`,
+			newColumnVal:     `{"json":true}`,
+		},
+		{
+			name:             "should send json string values if existing datatype is json, new datatype is boolean",
+			existingDatatype: "json",
+			currentDataType:  "boolean",
+			value:            false,
+			newColumnVal:     "false",
+		},
+		{
+			name:             "should send json string values if existing datatype is jso, new datatype is int",
+			existingDatatype: "json",
+			currentDataType:  "int",
+			value:            1,
+			newColumnVal:     "1",
+		},
+		{
+			name:             "should send json string values if existing datatype is json, new datatype is float",
+			existingDatatype: "json",
+			currentDataType:  "float",
+			value:            1.501,
+			newColumnVal:     "1.501",
+		},
+		{
+			name:             "should send json string values if existing datatype is json, new datatype is json",
+			existingDatatype: "json",
+			currentDataType:  "datetime",
+			value:            "2022-05-05T00:00:00.000Z",
+			newColumnVal:     `"2022-05-05T00:00:00.000Z"`,
+		},
+		{
+			name:             "should send json string values if existing datatype is json, new datatype is string",
+			existingDatatype: "json",
+			currentDataType:  "string",
+			value:            "string value",
+			newColumnVal:     `"string value"`,
+		},
+		{
+			name:             "should send json string values if existing datatype is json, new datatype is array",
+			existingDatatype: "json",
+			currentDataType:  "array",
+			value:            []any{false, 1, "string value"},
+			newColumnVal:     []any{false, 1, "string value"},
+		},
+		{
+			name:             "existing datatype is boolean, new datatype is int",
+			existingDatatype: "boolean",
+			currentDataType:  "int",
+			value:            1,
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is boolean, new datatype is float",
+			existingDatatype: "boolean",
+			currentDataType:  "float",
+			value:            1.501,
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is boolean, new datatype is string",
+			existingDatatype: "boolean",
+			currentDataType:  "string",
+			value:            "string value",
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is boolean, new datatype is datetime",
+			existingDatatype: "boolean",
+			currentDataType:  "datetime",
+			value:            "2022-05-05T00:00:00.000Z",
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is boolean, new datatype is json",
+			existingDatatype: "boolean",
+			currentDataType:  "json",
+			value:            `{"json":true}`,
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is int, new datatype is boolean",
+			existingDatatype: "int",
+			currentDataType:  "boolean",
+			value:            false,
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is int, new datatype is string",
+			existingDatatype: "int",
+			currentDataType:  "string",
+			value:            "string value",
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is int, new datatype is datetime",
+			existingDatatype: "int",
+			currentDataType:  "datetime",
+			value:            "2022-05-05T00:00:00.000Z",
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is int, new datatype is json",
+			existingDatatype: "int",
+			currentDataType:  "json",
+			value:            `{"json":true}`,
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is int, new datatype is float",
+			existingDatatype: "int",
+			currentDataType:  "float",
+			value:            1,
+			convError:        errIncompatibleSchemaConversion,
+		},
+		{
+			name:             "existing datatype is float, new datatype is boolean",
+			existingDatatype: "float",
+			currentDataType:  "boolean",
+			value:            false,
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is float, new datatype is int",
+			existingDatatype: "float",
+			currentDataType:  "int",
+			value:            1.0,
+			convError:        errIncompatibleSchemaConversion,
+		},
+		{
+			name:             "existing datatype is float, new datatype is string",
+			existingDatatype: "float",
+			currentDataType:  "string",
+			value:            "string value",
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is float, new datatype is datetime",
+			existingDatatype: "float",
+			currentDataType:  "datetime",
+			value:            "2022-05-05T00:00:00.000Z",
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is float, new datatype is json",
+			existingDatatype: "float",
+			currentDataType:  "json",
+			value:            `{"json":true}`,
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is datetime, new datatype is boolean",
+			existingDatatype: "datetime",
+			currentDataType:  "boolean",
+			value:            false,
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is datetime, new datatype is string",
+			existingDatatype: "datetime",
+			currentDataType:  "string",
+			value:            "string value",
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is datetime, new datatype is int",
+			existingDatatype: "datetime",
+			currentDataType:  "int",
+			value:            1,
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is datetime, new datatype is float",
+			existingDatatype: "datetime",
+			currentDataType:  "float",
+			value:            1.501,
+			convError:        errSchemaConversionNotSupported,
+		},
+		{
+			name:             "existing datatype is datetime, new datatype is json",
+			existingDatatype: "datetime",
+			currentDataType:  "json",
+			value:            `{"json":true}`,
+			convError:        errSchemaConversionNotSupported,
+		},
+	}
+	for _, ip := range inputs {
+		tc := ip
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			newColumnVal, convError := handleSchemaChange(
+				model.SchemaType(tc.existingDatatype),
+				model.SchemaType(tc.currentDataType),
+				tc.value,
+			)
+			require.Equal(t, newColumnVal, tc.newColumnVal)
+			require.ErrorIs(t, convError, tc.convError)
+		})
+	}
+}

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -1802,11 +1802,11 @@ func (job *UploadJob) getLoadFilesTableMap() (loadFilesMap map[tableNameT]bool, 
 		job.upload.LoadFileEndID,
 	}
 	rows, err := job.dbHandle.QueryContext(job.ctx, sqlStatement, sqlStatementArgs...)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		err = nil
 		return
 	}
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		err = fmt.Errorf("error occurred while executing distinct table name query for jobId: %d, sourceId: %s, destinationId: %s, err: %w", job.upload.ID, job.warehouse.Source.ID, job.warehouse.Destination.ID, err)
 		return
 	}

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -309,7 +309,7 @@ func (job *UploadJob) trackLongRunningUpload() chan struct{} {
 }
 
 func (job *UploadJob) generateUploadSchema() error {
-	uploadSchema, err := job.schemaHandle.PrepareUploadSchema(job.ctx, job.stagingFiles)
+	uploadSchema, err := job.schemaHandle.ConsolidateStagingFilesUsingLocalSchema(job.ctx, job.stagingFiles)
 	if err != nil {
 		return fmt.Errorf("consolidate staging files schema using warehouse schema: %w", err)
 	}
@@ -1938,7 +1938,6 @@ func (job *UploadJob) IsWarehouseSchemaEmpty() bool {
 	return job.schemaHandle.IsWarehouseSchemaEmpty()
 }
 
-// GetTableSchemaInWarehouse TODO check usage of this function
 func (job *UploadJob) GetTableSchemaInWarehouse(tableName string) model.TableSchema {
 	return job.schemaHandle.GetTableSchemaInWarehouse(tableName)
 }
@@ -2081,12 +2080,10 @@ func initializeStateMachine() {
 	abortState.nextState = nil
 }
 
-// GetLocalSchema TODO check usage of this function
 func (job *UploadJob) GetLocalSchema(ctx context.Context) (model.Schema, error) {
 	return job.schemaHandle.GetLocalSchema(ctx)
 }
 
-// UpdateLocalSchema TODO check usage of this function
 func (job *UploadJob) UpdateLocalSchema(ctx context.Context, schema model.Schema) error {
 	return job.schemaHandle.UpdateLocalSchema(ctx, job.upload.ID, schema)
 }

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -194,7 +194,7 @@ func (f *UploadJobFactory) NewUploadJob(ctx context.Context, dto *model.UploadJo
 		logger:               f.logger,
 		statsFactory:         f.statsFactory,
 		tableUploadsRepo:     repo.NewTableUploads(f.dbHandle),
-		schemaHandle: schema.NewSchema(
+		schemaHandle: schema.New(
 			f.dbHandle,
 			dto.Warehouse,
 			config.Default,

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -1934,12 +1934,8 @@ func (job *UploadJob) GetSampleLoadFileLocation(ctx context.Context, tableName s
 	return locations[0].Location, nil
 }
 
-// GetSchemaInWarehouse TODO check usage of this function
-func (job *UploadJob) GetSchemaInWarehouse() (schema model.Schema) {
-	if job.schemaHandle == nil {
-		return
-	}
-	return job.schemaHandle.GetSchemaInWarehouse()
+func (job *UploadJob) IsWarehouseSchemaEmpty() bool {
+	return job.schemaHandle.IsWarehouseSchemaEmpty()
 }
 
 // GetTableSchemaInWarehouse TODO check usage of this function

--- a/warehouse/upload_test.go
+++ b/warehouse/upload_test.go
@@ -86,8 +86,8 @@ func TestColumnCountStat(t *testing.T) {
 
 	var (
 		workspaceID     = "test-workspaceID"
-		destinationID   = "test-desinationID"
-		destinationName = "test-desinationName"
+		destinationID   = "test-destinationID"
+		destinationName = "test-destinationName"
 		sourceID        = "test-sourceID"
 		sourceName      = "test-sourceName"
 		tableName       = "test-table"

--- a/warehouse/upload_test.go
+++ b/warehouse/upload_test.go
@@ -8,23 +8,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rudderlabs/rudder-go-kit/stats"
-
 	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/services/alerta"
 	sqlmiddleware "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/redshift"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
-
-	"github.com/rudderlabs/rudder-go-kit/logger"
-	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"github.com/rudderlabs/rudder-server/warehouse/schema"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
@@ -152,16 +149,13 @@ func TestColumnCountStat(t *testing.T) {
 					},
 				},
 				statsFactory: store,
-				schemaHandle: &Schema{
-					schemaInWarehouse: model.Schema{
-						tableName: model.TableSchema{
-							"test-column-1": "string",
-							"test-column-2": "string",
-							"test-column-3": "string",
-						},
-					},
-				},
+				schemaHandle: &schema.Schema{}, // TODO use constructor
 			}
+			j.schemaHandle.UpdateWarehouseTableSchema(tableName, model.TableSchema{
+				"test-column-1": "string",
+				"test-column-2": "string",
+				"test-column-3": "string",
+			})
 
 			tags := j.buildTags()
 			tags["tableName"] = tableName
@@ -172,7 +166,7 @@ func TestColumnCountStat(t *testing.T) {
 			m2 := store.Get("warehouse_load_table_column_limit", tags)
 
 			if tc.statExpected {
-				require.EqualValues(t, m1.LastValue(), len(j.schemaHandle.schemaInWarehouse[tableName]))
+				require.EqualValues(t, m1.LastValue(), j.schemaHandle.GetColumnsCountInWarehouseSchema(tableName))
 				require.EqualValues(t, m2.LastValue(), tc.columnCountLimit)
 			} else {
 				require.Nil(t, m1)

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -233,7 +233,7 @@ type KeyValue struct {
 
 //go:generate mockgen -destination=../internal/mocks/utils/mock_uploader.go -package mock_uploader github.com/rudderlabs/rudder-server/warehouse/utils Uploader
 type Uploader interface {
-	GetSchemaInWarehouse() model.Schema
+	IsWarehouseSchemaEmpty() bool
 	GetLocalSchema(ctx context.Context) (model.Schema, error)
 	UpdateLocalSchema(ctx context.Context, schema model.Schema) error
 	GetTableSchemaInWarehouse(tableName string) model.TableSchema

--- a/warehouse/validations/validate.go
+++ b/warehouse/validations/validate.go
@@ -552,7 +552,7 @@ type dummyUploader struct {
 	dest *backendconfig.DestinationT
 }
 
-func (*dummyUploader) GetSchemaInWarehouse() model.Schema                    { return nil }
+func (*dummyUploader) IsWarehouseSchemaEmpty() bool                          { return true }
 func (*dummyUploader) GetLocalSchema(context.Context) (model.Schema, error)  { return nil, nil }
 func (*dummyUploader) UpdateLocalSchema(context.Context, model.Schema) error { return nil }
 func (*dummyUploader) ShouldOnDedupUseNewRecord() bool                       { return false }


### PR DESCRIPTION
# Description

Sub issue for the Warehouse integration tests with `-race`.

The plan is to incrementally reintroduce the changes in smaller PRs to better test the changes in isolation. This is the last PR that is going to reintroduce the changes we reverted [here](https://github.com/rudderlabs/rudder-server/pull/3825).

In this Pull Request we are moving the `Schema` into its own package and we're making it safe for concurrent use.
The Warehouse Integration tests are going to be covered by `-race` but **not the unit ones**. For those we are going to tackle the issues we found in other PRs.

In order to enable the `-race` in the unit test we have to change the `test-run` recipe in the `Makefile` as such:

```
test-run: ## Run all unit tests
ifeq ($(filter 1,$(debug) $(RUNNER_DEBUG)),)
	$(eval TEST_CMD = SLOW=0 gotestsum --format pkgname-and-test-fails --)
	$(eval TEST_OPTIONS = -p=1 -v -failfast -shuffle=on -coverprofile=profile.out -covermode=atomic -coverpkg=./... -vet=all --timeout=15m)
else
	$(eval TEST_CMD = SLOW=0 go test)
	$(eval TEST_OPTIONS = -p=1 -v -failfast -shuffle=on -coverprofile=profile.out -covermode=atomic -coverpkg=./... -vet=all --timeout=15m)
endif
ifdef package
    ifeq ($(findstring warehouse,$(package)),warehouse)
	    $(TEST_CMD) $(TEST_OPTIONS) -race $(package) && touch $(TESTFILE) || true
    else
	    $(TEST_CMD) $(TEST_OPTIONS) $(package) && touch $(TESTFILE) || true
    endif
else ifdef exclude
	$(eval FILES = `go list ./... | egrep -iv '$(exclude)'`)
	$(TEST_CMD) -count=1 $(TEST_OPTIONS) $(FILES) && touch $(TESTFILE) || true
else
	$(TEST_CMD) -count=1 $(TEST_OPTIONS) ./... && touch $(TESTFILE) || true
endif
```

### It is recommended to review this PR commit by commit to simplify the review.

Panos' [E2E Tests run](https://github.com/rudderlabs/e2e/actions/runs/6276197143).

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-331/warehouseschema-race-and-cleanup) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
