### PR TITLE
chore: use the new reloadable config api in reporting

### DIFF
--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -71,7 +71,7 @@ type ErrorDetailReporter struct {
 	sleepInterval             misc.ValueLoader[time.Duration]
 	mainLoopSleepInterval     misc.ValueLoader[time.Duration]
 	maxConcurrentRequests     misc.ValueLoader[int]
-	maxOpenConnections        misc.ValueLoader[int]
+	maxOpenConnections        int
 	workspaceIDForSourceIDMap map[string]string
 	destinationIDMap          map[string]destDetail
 	srcWspMutex               sync.RWMutex
@@ -99,7 +99,7 @@ func NewEdReporterFromEnvConfig() *ErrorDetailReporter {
 	mainLoopSleepInterval := config.GetReloadableDurationVar(5, time.Second, "Reporting.mainLoopSleepInterval")
 	sleepInterval := config.GetReloadableDurationVar(30, time.Second, "Reporting.sleepInterval")
 	maxConcurrentRequests := config.GetReloadableIntVar(32, 1, "Reporting.maxConcurrentRequests")
-	maxOpenConnections := config.GetReloadableIntVar(16, 1, "Reporting.errorReporting.maxOpenConnections")
+	maxOpenConnections := config.GetIntVar(16, 1, "Reporting.errorReporting.maxOpenConnections")
 
 	log := logger.NewLogger().Child("enterprise").Child("error-detail-reporting")
 	extractor := NewErrorDetailExtractor(log)
@@ -278,7 +278,7 @@ func (edRep *ErrorDetailReporter) migrate(c types.Config) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	dbHandle.SetMaxOpenConns(edRep.maxOpenConnections.Load())
+	dbHandle.SetMaxOpenConns(edRep.maxOpenConnections)
 
 	m := &migrator.Migrator{
 		Handle:          dbHandle,

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -68,10 +68,10 @@ type ErrorDetailReporter struct {
 	workspaceID               string
 	instanceID                string
 	region                    string
-	sleepInterval             time.Duration
-	mainLoopSleepInterval     time.Duration
-	maxConcurrentRequests     int
-	maxOpenConnections        int
+	sleepInterval             misc.ValueLoader[time.Duration]
+	mainLoopSleepInterval     misc.ValueLoader[time.Duration]
+	maxConcurrentRequests     misc.ValueLoader[int]
+	maxOpenConnections        misc.ValueLoader[int]
 	workspaceIDForSourceIDMap map[string]string
 	destinationIDMap          map[string]destDetail
 	srcWspMutex               sync.RWMutex
@@ -91,18 +91,15 @@ type errorDetails struct {
 }
 
 func NewEdReporterFromEnvConfig() *ErrorDetailReporter {
-	var sleepInterval, mainLoopSleepInterval time.Duration
-	var maxConcurrentRequests int
-	var maxOpenConnections int
 	tr := &http.Transport{}
 	reportingServiceURL := config.GetString("REPORTING_URL", "https://reporting.dev.rudderlabs.com")
 	reportingServiceURL = strings.TrimSuffix(reportingServiceURL, "/")
 
 	netClient := &http.Client{Transport: tr, Timeout: config.GetDuration("HttpClient.reporting.timeout", 60, time.Second)}
-	config.RegisterDurationConfigVariable(5, &mainLoopSleepInterval, true, time.Second, "Reporting.mainLoopSleepInterval")
-	config.RegisterDurationConfigVariable(30, &sleepInterval, true, time.Second, "Reporting.sleepInterval")
-	config.RegisterIntConfigVariable(32, &maxConcurrentRequests, true, 1, "Reporting.maxConcurrentRequests")
-	config.RegisterIntConfigVariable(16, &maxOpenConnections, false, 1, []string{"Reporting.errorReporting.maxOpenConnections"}...)
+	mainLoopSleepInterval := config.GetReloadableDurationVar(5, time.Second, "Reporting.mainLoopSleepInterval")
+	sleepInterval := config.GetReloadableDurationVar(30, time.Second, "Reporting.sleepInterval")
+	maxConcurrentRequests := config.GetReloadableIntVar(32, 1, "Reporting.maxConcurrentRequests")
+	maxOpenConnections := config.GetReloadableIntVar(16, 1, "Reporting.errorReporting.maxOpenConnections")
 
 	log := logger.NewLogger().Child("enterprise").Child("error-detail-reporting")
 	extractor := NewErrorDetailExtractor(log)
@@ -281,7 +278,7 @@ func (edRep *ErrorDetailReporter) migrate(c types.Config) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	dbHandle.SetMaxOpenConns(edRep.maxOpenConnections)
+	dbHandle.SetMaxOpenConns(edRep.maxOpenConnections.Load())
 
 	m := &migrator.Migrator{
 		Handle:          dbHandle,
@@ -359,7 +356,7 @@ func (edRep *ErrorDetailReporter) mainLoop(ctx context.Context, clientName strin
 			edRep.log.Infof("stopping mainLoop for client %s : %s", clientName, ctx.Err())
 			return
 		}
-		requestChan := make(chan struct{}, maxConcurrentRequests)
+		requestChan := make(chan struct{}, edRep.maxConcurrentRequests.Load())
 		loopStart := time.Now()
 		currentMs := time.Now().UTC().Unix() / 60
 
@@ -373,7 +370,7 @@ func (edRep *ErrorDetailReporter) mainLoop(ctx context.Context, clientName strin
 			case <-ctx.Done():
 				edRep.log.Infof("stopping mainLoop for client %s : %s", clientName, ctx.Err())
 				return
-			case <-time.After(edRep.sleepInterval):
+			case <-time.After(edRep.sleepInterval.Load()):
 			}
 			continue
 		}
@@ -423,7 +420,7 @@ func (edRep *ErrorDetailReporter) mainLoop(ctx context.Context, clientName strin
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(edRep.mainLoopSleepInterval):
+		case <-time.After(edRep.mainLoopSleepInterval.Load()):
 		}
 	}
 }

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -32,8 +32,6 @@ import (
 
 const ReportsTable = "reports"
 
-var maxConcurrentRequests int
-
 const (
 	StatReportingMainLoopTime              = "reporting_client_main_loop_time"
 	StatReportingGetReportsTime            = "reporting_client_get_reports_time"
@@ -46,7 +44,7 @@ const (
 	StatReportingGetReportsQueryTime       = "reporting_client_get_reports_query_time"
 )
 
-type HandleT struct {
+type Handle struct {
 	init                                 chan struct{}
 	onceInit                             sync.Once
 	clients                              map[string]*types.Client
@@ -60,37 +58,36 @@ type HandleT struct {
 	piiReportingSettings                 map[string]bool
 	whActionsOnly                        bool
 	region                               string
-	sleepInterval                        time.Duration
-	mainLoopSleepInterval                time.Duration
+	sleepInterval                        misc.ValueLoader[time.Duration]
+	mainLoopSleepInterval                misc.ValueLoader[time.Duration]
 	dbQueryTimeout                       *config.Reloadable[time.Duration]
 	sourcesWithEventNameTrackingDisabled []string
-	maxOpenConnections                   int
+	maxOpenConnections                   misc.ValueLoader[int]
+	maxConcurrentRequests                misc.ValueLoader[int]
 
 	getMinReportedAtQueryTime stats.Measurement
 	getReportsQueryTime       stats.Measurement
 	requestLatency            stats.Measurement
 }
 
-func NewFromEnvConfig(log logger.Logger) *HandleT {
-	var sleepInterval, mainLoopSleepInterval time.Duration
-	var maxOpenConnections int
+func NewFromEnvConfig(log logger.Logger) *Handle {
 	var dbQueryTimeout *config.Reloadable[time.Duration]
 
 	reportingServiceURL := config.GetString("REPORTING_URL", "https://reporting.rudderstack.com/")
 	reportingServiceURL = strings.TrimSuffix(reportingServiceURL, "/")
 	sourcesWithEventNameTrackingDisabled := config.GetStringSlice("Reporting.sourcesWithEventNameTrackingDisabled", []string{})
 
-	config.RegisterDurationConfigVariable(5, &mainLoopSleepInterval, true, time.Second, "Reporting.mainLoopSleepInterval")
-	config.RegisterDurationConfigVariable(30, &sleepInterval, true, time.Second, "Reporting.sleepInterval")
-	config.RegisterIntConfigVariable(32, &maxConcurrentRequests, true, 1, "Reporting.maxConcurrentRequests")
-	config.RegisterIntConfigVariable(32, &maxOpenConnections, true, 1, "Reporting.maxOpenConnections")
+	mainLoopSleepInterval := config.GetReloadableDurationVar(5, time.Second, "Reporting.mainLoopSleepInterval")
+	sleepInterval := config.GetReloadableDurationVar(30, time.Second, "Reporting.sleepInterval")
+	maxConcurrentRequests := config.GetReloadableIntVar(32, 1, "Reporting.maxConcurrentRequests")
+	maxOpenConnections := config.GetReloadableIntVar(32, 1, "Reporting.maxOpenConnections")
 	dbQueryTimeout = config.GetReloadableDurationVar(60, time.Second, "Reporting.dbQueryTimeout")
 	// only send reports for wh actions sources if whActionsOnly is configured
 	whActionsOnly := config.GetBool("REPORTING_WH_ACTIONS_ONLY", false)
 	if whActionsOnly {
 		log.Info("REPORTING_WH_ACTIONS_ONLY enabled.only sending reports relevant to wh actions.")
 	}
-	return &HandleT{
+	return &Handle{
 		init:                                 make(chan struct{}),
 		log:                                  log,
 		clients:                              make(map[string]*types.Client),
@@ -105,11 +102,12 @@ func NewFromEnvConfig(log logger.Logger) *HandleT {
 		region:                               config.GetString("region", ""),
 		sourcesWithEventNameTrackingDisabled: sourcesWithEventNameTrackingDisabled,
 		maxOpenConnections:                   maxOpenConnections,
+		maxConcurrentRequests:                maxConcurrentRequests,
 		dbQueryTimeout:                       dbQueryTimeout,
 	}
 }
 
-func (r *HandleT) setup(beConfigHandle backendconfig.BackendConfig) {
+func (r *Handle) setup(beConfigHandle backendconfig.BackendConfig) {
 	r.log.Info("[[ Reporting ]] Setting up reporting handler")
 
 	ch := beConfigHandle.Subscribe(context.TODO(), backendconfig.TopicBackendConfig)
@@ -143,12 +141,12 @@ func (r *HandleT) setup(beConfigHandle backendconfig.BackendConfig) {
 	})
 }
 
-func (r *HandleT) getWorkspaceID(sourceID string) string {
+func (r *Handle) getWorkspaceID(sourceID string) string {
 	<-r.init
 	return r.workspaceIDForSourceIDMap[sourceID]
 }
 
-func (r *HandleT) AddClient(ctx context.Context, c types.Config) {
+func (r *Handle) AddClient(ctx context.Context, c types.Config) {
 	if c.ClientName == "" {
 		c.ClientName = types.CoreReportingClient
 	}
@@ -163,7 +161,7 @@ func (r *HandleT) AddClient(ctx context.Context, c types.Config) {
 	if err != nil {
 		panic(err)
 	}
-	dbHandle.SetMaxOpenConns(r.maxOpenConnections)
+	dbHandle.SetMaxOpenConns(r.maxOpenConnections.Load())
 
 	m := &migrator.Migrator{
 		Handle:                     dbHandle,
@@ -182,7 +180,7 @@ func (r *HandleT) AddClient(ctx context.Context, c types.Config) {
 	r.mainLoop(ctx, c.ClientName)
 }
 
-func (r *HandleT) WaitForSetup(ctx context.Context, clientName string) error {
+func (r *Handle) WaitForSetup(ctx context.Context, clientName string) error {
 	for {
 		if r.GetClient(clientName) != nil {
 			break
@@ -195,7 +193,7 @@ func (r *HandleT) WaitForSetup(ctx context.Context, clientName string) error {
 	return nil
 }
 
-func (r *HandleT) GetClient(clientName string) *types.Client {
+func (r *Handle) GetClient(clientName string) *types.Client {
 	r.clientsMapLock.RLock()
 	defer r.clientsMapLock.RUnlock()
 
@@ -206,7 +204,7 @@ func (r *HandleT) GetClient(clientName string) *types.Client {
 	return nil
 }
 
-func (r *HandleT) getDBHandle(clientName string) (*sql.DB, error) {
+func (r *Handle) getDBHandle(clientName string) (*sql.DB, error) {
 	client := r.GetClient(clientName)
 	if client != nil {
 		return client.DbHandle, nil
@@ -215,7 +213,7 @@ func (r *HandleT) getDBHandle(clientName string) (*sql.DB, error) {
 	return nil, fmt.Errorf("DBHandle not found for client name: %s", clientName)
 }
 
-func (r *HandleT) getReports(currentMs int64, clientName string) (reports []*types.ReportByStatus, reportedAt int64, err error) {
+func (r *Handle) getReports(currentMs int64, clientName string) (reports []*types.ReportByStatus, reportedAt int64, err error) {
 	sqlStatement := fmt.Sprintf(`SELECT reported_at FROM %s WHERE reported_at < %d ORDER BY reported_at ASC LIMIT 1`, ReportsTable, currentMs)
 	var queryMin sql.NullInt64
 	dbHandle, err := r.getDBHandle(clientName)
@@ -286,7 +284,7 @@ func (r *HandleT) getReports(currentMs int64, clientName string) (reports []*typ
 	return metricReports, queryMin.Int64, err
 }
 
-func (*HandleT) getAggregatedReports(reports []*types.ReportByStatus) []*types.Metric {
+func (*Handle) getAggregatedReports(reports []*types.ReportByStatus) []*types.Metric {
 	metricsByGroup := map[string]*types.Metric{}
 
 	reportIdentifier := func(report *types.ReportByStatus) string {
@@ -374,7 +372,7 @@ func (*HandleT) getAggregatedReports(reports []*types.ReportByStatus) []*types.M
 	return values
 }
 
-func (r *HandleT) mainLoop(ctx context.Context, clientName string) {
+func (r *Handle) mainLoop(ctx context.Context, clientName string) {
 	tr := &http.Transport{}
 	netClient := &http.Client{Transport: tr, Timeout: config.GetDuration("HttpClient.reporting.timeout", 60, time.Second)}
 	tags := r.getTags(clientName)
@@ -403,10 +401,9 @@ func (r *HandleT) mainLoop(ctx context.Context, clientName string) {
 		for {
 			lag := time.Since(lastReportedAtTime.Load())
 			reportingLag.Gauge(lag.Seconds())
-
 			select {
 			case <-ctx.Done():
-				break
+				return
 			case <-time.After(2 * time.Minute):
 			}
 		}
@@ -417,7 +414,7 @@ func (r *HandleT) mainLoop(ctx context.Context, clientName string) {
 			r.log.Infof("stopping mainLoop for client %s : %s", clientName, ctx.Err())
 			return
 		}
-		requestChan := make(chan struct{}, maxConcurrentRequests)
+		requestChan := make(chan struct{}, r.maxConcurrentRequests.Load())
 		loopStart := time.Now()
 		currentMs := time.Now().UTC().Unix() / 60
 
@@ -433,7 +430,7 @@ func (r *HandleT) mainLoop(ctx context.Context, clientName string) {
 			case <-ctx.Done():
 				r.log.Infof("stopping mainLoop for client %s : %s", clientName, ctx.Err())
 				return
-			case <-time.After(r.sleepInterval):
+			case <-time.After(r.sleepInterval.Load()):
 			}
 			continue
 		}
@@ -480,12 +477,12 @@ func (r *HandleT) mainLoop(ctx context.Context, clientName string) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(r.mainLoopSleepInterval):
+		case <-time.After(r.mainLoopSleepInterval.Load()):
 		}
 	}
 }
 
-func (r *HandleT) sendMetric(ctx context.Context, netClient *http.Client, clientName string, metric *types.Metric) error {
+func (r *Handle) sendMetric(ctx context.Context, netClient *http.Client, clientName string, metric *types.Metric) error {
 	payload, err := json.Marshal(metric)
 	if err != nil {
 		panic(err)
@@ -570,12 +567,12 @@ func transformMetricForPII(metric types.PUReportedMetric, piiColumns []string) t
 	return metric
 }
 
-func (r *HandleT) IsPIIReportingDisabled(workspaceID string) bool {
+func (r *Handle) IsPIIReportingDisabled(workspaceID string) bool {
 	<-r.init
 	return r.piiReportingSettings[workspaceID]
 }
 
-func (r *HandleT) Report(metrics []*types.PUReportedMetric, txn *sql.Tx) {
+func (r *Handle) Report(metrics []*types.PUReportedMetric, txn *sql.Tx) {
 	if len(metrics) == 0 {
 		return
 	}
@@ -657,7 +654,7 @@ func (r *HandleT) Report(metrics []*types.PUReportedMetric, txn *sql.Tx) {
 	}
 }
 
-func (r *HandleT) getTags(clientName string) stats.Tags {
+func (r *Handle) getTags(clientName string) stats.Tags {
 	return stats.Tags{
 		"workspaceId": r.workspaceID,
 		"instanceId":  r.instanceID,

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -62,7 +62,7 @@ type Handle struct {
 	mainLoopSleepInterval                misc.ValueLoader[time.Duration]
 	dbQueryTimeout                       *config.Reloadable[time.Duration]
 	sourcesWithEventNameTrackingDisabled []string
-	maxOpenConnections                   misc.ValueLoader[int]
+	maxOpenConnections                   int
 	maxConcurrentRequests                misc.ValueLoader[int]
 
 	getMinReportedAtQueryTime stats.Measurement
@@ -80,7 +80,7 @@ func NewFromEnvConfig(log logger.Logger) *Handle {
 	mainLoopSleepInterval := config.GetReloadableDurationVar(5, time.Second, "Reporting.mainLoopSleepInterval")
 	sleepInterval := config.GetReloadableDurationVar(30, time.Second, "Reporting.sleepInterval")
 	maxConcurrentRequests := config.GetReloadableIntVar(32, 1, "Reporting.maxConcurrentRequests")
-	maxOpenConnections := config.GetReloadableIntVar(32, 1, "Reporting.maxOpenConnections")
+	maxOpenConnections := config.GetIntVar(32, 1, "Reporting.maxOpenConnections")
 	dbQueryTimeout = config.GetReloadableDurationVar(60, time.Second, "Reporting.dbQueryTimeout")
 	// only send reports for wh actions sources if whActionsOnly is configured
 	whActionsOnly := config.GetBool("REPORTING_WH_ACTIONS_ONLY", false)
@@ -161,7 +161,7 @@ func (r *Handle) AddClient(ctx context.Context, c types.Config) {
 	if err != nil {
 		panic(err)
 	}
-	dbHandle.SetMaxOpenConns(r.maxOpenConnections.Load())
+	dbHandle.SetMaxOpenConns(r.maxOpenConnections)
 
 	m := &migrator.Migrator{
 		Handle:                     dbHandle,


### PR DESCRIPTION
# Description

Only Event schemas v1 is now left using the old config api, which shall be removed altogether in the next release

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
