### PR TITLE
fix: replay request fails with 400 - request neither has anonymousId nor userId

### DIFF
--- a/backend-config/replay_types.go
+++ b/backend-config/replay_types.go
@@ -37,6 +37,7 @@ func (config *ConfigT) ApplyReplaySources() {
 			}
 			newDestination := *d
 			newDestination.ID = id
+			newDestination.IsProcessorEnabled = true // processor is always enabled for replay destinations
 			return &newDestination
 		}), []*DestinationT{nil})
 

--- a/backend-config/replay_types_test.go
+++ b/backend-config/replay_types_test.go
@@ -20,7 +20,12 @@ func TestApplyReplayConfig(t *testing.T) {
 					},
 					Destinations: []DestinationT{
 						{
-							ID: "d-1",
+							ID:                 "d-1",
+							IsProcessorEnabled: true,
+						},
+						{
+							ID:                 "d-2",
+							IsProcessorEnabled: false,
 						},
 					},
 				},
@@ -56,6 +61,7 @@ func TestApplyReplayConfig(t *testing.T) {
 		require.Equal(t, map[string]interface{}{}, c.Sources[1].Config)
 		require.Len(t, c.Sources[1].Destinations, 1)
 		require.Equal(t, "er-d-1", c.Sources[1].Destinations[0].ID)
+		require.True(t, c.Sources[1].Destinations[0].IsProcessorEnabled)
 	})
 
 	t.Run("Invalid Replay Config", func(t *testing.T) {

--- a/backend-config/replay_types_test.go
+++ b/backend-config/replay_types_test.go
@@ -21,11 +21,12 @@ func TestApplyReplayConfig(t *testing.T) {
 					Destinations: []DestinationT{
 						{
 							ID:                 "d-1",
-							IsProcessorEnabled: true,
+							RevisionID:         "rev-1",
+							IsProcessorEnabled: false,
 						},
 						{
-							ID:                 "d-2",
-							IsProcessorEnabled: false,
+							ID:         "d-2",
+							RevisionID: "rev-2",
 						},
 					},
 				},
@@ -61,7 +62,8 @@ func TestApplyReplayConfig(t *testing.T) {
 		require.Equal(t, map[string]interface{}{}, c.Sources[1].Config)
 		require.Len(t, c.Sources[1].Destinations, 1)
 		require.Equal(t, "er-d-1", c.Sources[1].Destinations[0].ID)
-		require.True(t, c.Sources[1].Destinations[0].IsProcessorEnabled)
+		require.Equal(t, true, c.Sources[1].Destinations[0].IsProcessorEnabled)
+		require.Equal(t, "rev-1", c.Sources[1].Destinations[0].RevisionID)
 	})
 
 	t.Run("Invalid Replay Config", func(t *testing.T) {

--- a/backend-config/types.go
+++ b/backend-config/types.go
@@ -104,7 +104,8 @@ type ConfigT struct {
 
 func (c *ConfigT) SourcesMap() map[string]*SourceT {
 	sourcesMap := make(map[string]*SourceT)
-	for _, source := range c.Sources {
+	for i := range c.Sources {
+		source := c.Sources[i]
 		sourcesMap[source.ID] = &source
 	}
 	return sourcesMap
@@ -112,8 +113,10 @@ func (c *ConfigT) SourcesMap() map[string]*SourceT {
 
 func (c *ConfigT) DestinationsMap() map[string]*DestinationT {
 	destinationsMap := make(map[string]*DestinationT)
-	for _, source := range c.Sources {
-		for _, destination := range source.Destinations {
+	for i := range c.Sources {
+		source := c.Sources[i]
+		for j := range source.Destinations {
+			destination := source.Destinations[j]
 			destinationsMap[destination.ID] = &destination
 		}
 	}

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -283,7 +283,7 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 	}
 
 	gw.requestSizeStat.Observe(float64(len(body)))
-	if req.reqType != "batch" {
+	if req.reqType != "batch" && req.reqType != "replay" {
 		body, err = sjson.SetBytes(body, "type", req.reqType)
 		if err != nil {
 			err = errors.New(response.NotRudderEvent)


### PR DESCRIPTION
# Description

- Treating `replay` request types equally to `batch` request types in terms of expected payload
- Fixing a loopvar issue
- Setting `IsProcessorEnabled` always true for replay destinations

## Linear Ticket

[PIPE-351](https://linear.app/rudderstack/issue/PIPE-351/replay-request-fails-with-400-request-neither-has-anonymousid-nor)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
