### PR TITLE
refactor: reporting feature

### DIFF
--- a/app/features.go
+++ b/app/features.go
@@ -32,8 +32,7 @@ Reporting Feature
 
 // ReportingFeature handles reporting statuses / errors to reporting service
 type ReportingFeature interface {
-	Setup(backendConfig backendconfig.BackendConfig) types.Reporting
-	GetReportingInstance() types.Reporting
+	Setup(cxt context.Context, backendConfig backendconfig.BackendConfig) types.Reporting
 }
 
 /*********************************

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -58,25 +58,28 @@ type destDetail struct {
 }
 
 type ErrorDetailReporter struct {
-	onceInit                  sync.Once
-	init                      chan struct{}
-	reportingServiceURL       string
-	Table                     string
-	clients                   map[string]*types.Client
-	log                       logger.Logger
-	namespace                 string
+	ctx                 context.Context
+	onceInit            sync.Once
+	init                chan struct{}
+	reportingServiceURL string
+	clients             map[string]*types.Client
+	log                 logger.Logger
+	namespace           string
+
+	instanceID            string
+	region                string
+	sleepInterval         misc.ValueLoader[time.Duration]
+	mainLoopSleepInterval misc.ValueLoader[time.Duration]
+	maxConcurrentRequests misc.ValueLoader[int]
+	maxOpenConnections    int
+
+	httpClient     *http.Client
+	clientsMapLock sync.RWMutex
+
+	backendConfigMu           sync.RWMutex // protects the following
 	workspaceID               string
-	instanceID                string
-	region                    string
-	sleepInterval             misc.ValueLoader[time.Duration]
-	mainLoopSleepInterval     misc.ValueLoader[time.Duration]
-	maxConcurrentRequests     misc.ValueLoader[int]
-	maxOpenConnections        int
 	workspaceIDForSourceIDMap map[string]string
 	destinationIDMap          map[string]destDetail
-	srcWspMutex               sync.RWMutex
-	httpClient                *http.Client
-	clientsMapLock            sync.RWMutex
 
 	errorDetailExtractor *ExtractorHandle
 
@@ -90,7 +93,7 @@ type errorDetails struct {
 	ErrorMessage string
 }
 
-func NewEdReporterFromEnvConfig() *ErrorDetailReporter {
+func NewErrorDetailReporter(ctx context.Context) *ErrorDetailReporter {
 	tr := &http.Transport{}
 	reportingServiceURL := config.GetString("REPORTING_URL", "https://reporting.dev.rudderlabs.com")
 	reportingServiceURL = strings.TrimSuffix(reportingServiceURL, "/")
@@ -105,8 +108,8 @@ func NewEdReporterFromEnvConfig() *ErrorDetailReporter {
 	extractor := NewErrorDetailExtractor(log)
 
 	return &ErrorDetailReporter{
+		ctx:                   ctx,
 		reportingServiceURL:   reportingServiceURL,
-		Table:                 ErrorDetailReportsTable,
 		log:                   log,
 		sleepInterval:         sleepInterval,
 		mainLoopSleepInterval: mainLoopSleepInterval,
@@ -126,40 +129,15 @@ func NewEdReporterFromEnvConfig() *ErrorDetailReporter {
 	}
 }
 
-func (edRep *ErrorDetailReporter) AddClient(ctx context.Context, c types.Config) {
-	if c.ClientName == "" {
-		c.ClientName = types.CoreReportingClient
-	}
-
-	edRep.clientsMapLock.RLock()
-	if _, ok := edRep.clients[c.ClientName]; ok {
+func (edr *ErrorDetailReporter) backendConfigSubscriber(beConfigHandle backendconfig.BackendConfig) {
+	edr.log.Info("[Error Detail Reporting] Setting up reporting handler")
+	defer edr.onceInit.Do(func() {
+		close(edr.init)
+	})
+	if edr.ctx.Err() != nil {
 		return
 	}
-	edRep.clientsMapLock.RUnlock()
-	dbHandle, err := edRep.migrate(c)
-	if err != nil {
-		panic(fmt.Errorf("failed during migration: %v", err))
-	}
-	edRep.clientsMapLock.Lock()
-	edRep.clients[c.ClientName] = &types.Client{Config: c, DbHandle: dbHandle}
-	edRep.clientsMapLock.Unlock()
-	// start main-loop
-	edRep.mainLoop(ctx, c.ClientName)
-}
-
-func (edRep *ErrorDetailReporter) GetClient(clientName string) *types.Client {
-	edRep.clientsMapLock.RLock()
-	defer edRep.clientsMapLock.RUnlock()
-	if c, ok := edRep.clients[clientName]; ok {
-		return c
-	}
-	return nil
-}
-
-func (edRep *ErrorDetailReporter) setup(beConfigHandle backendconfig.BackendConfig) {
-	edRep.log.Info("[Error Detail Reporting] Setting up reporting handler")
-
-	ch := beConfigHandle.Subscribe(context.TODO(), backendconfig.TopicBackendConfig)
+	ch := beConfigHandle.Subscribe(edr.ctx, backendconfig.TopicBackendConfig)
 
 	for c := range ch {
 		conf := c.Data.(map[string]backendconfig.ConfigT)
@@ -186,49 +164,71 @@ func (edRep *ErrorDetailReporter) setup(beConfigHandle backendconfig.BackendConf
 		if len(conf) > 1 {
 			newWorkspaceID = ""
 		}
-		edRep.srcWspMutex.Lock()
-		edRep.workspaceID = newWorkspaceID
-		edRep.workspaceIDForSourceIDMap = newWorkspaceIDForSourceIDMap
-		edRep.destinationIDMap = newDestinationIDMap
-		edRep.srcWspMutex.Unlock()
-		// r.piiReportingSettings = newPIIReportingSettings
-		edRep.onceInit.Do(func() {
-			close(edRep.init)
+		edr.backendConfigMu.Lock()
+		edr.workspaceID = newWorkspaceID
+		edr.workspaceIDForSourceIDMap = newWorkspaceIDForSourceIDMap
+		edr.destinationIDMap = newDestinationIDMap
+		edr.backendConfigMu.Unlock()
+		edr.onceInit.Do(func() {
+			close(edr.init)
 		})
 	}
-
-	edRep.onceInit.Do(func() {
-		close(edRep.init)
-	})
 }
 
-func (edRep *ErrorDetailReporter) Report(metrics []*types.PUReportedMetric, txn *sql.Tx) {
-	edRep.log.Debug("[ErrorDetailReport] Report method called\n")
+func (edr *ErrorDetailReporter) DatabaseSyncer(c types.SyncerConfig) types.ReportingSyncer {
+	if c.Label == "" {
+		c.Label = types.CoreReportingLabel
+	}
+
+	edr.clientsMapLock.Lock()
+	defer edr.clientsMapLock.Unlock()
+	if _, ok := edr.clients[c.ConnInfo]; ok {
+		return func() {} // returning a no-op syncer since another go routine has already started syncing
+	}
+	dbHandle, err := edr.migrate(c)
+	if err != nil {
+		panic(fmt.Errorf("failed during migration: %v", err))
+	}
+	edr.clients[c.ConnInfo] = &types.Client{SyncerConfig: c, DbHandle: dbHandle}
+
+	return func() {
+		edr.mainLoop(edr.ctx, c)
+	}
+}
+
+func (edr *ErrorDetailReporter) GetClient(clientKey string) *types.Client {
+	edr.clientsMapLock.RLock()
+	defer edr.clientsMapLock.RUnlock()
+	return edr.clients[clientKey]
+}
+
+func (edr *ErrorDetailReporter) Report(metrics []*types.PUReportedMetric, txn *sql.Tx) {
+	edr.log.Debug("[ErrorDetailReport] Report method called\n")
 	if len(metrics) == 0 {
 		return
 	}
 
-	stmt, err := txn.Prepare(pq.CopyIn(edRep.Table, ErrorDetailReportsColumns...))
+	stmt, err := txn.Prepare(pq.CopyIn(ErrorDetailReportsTable, ErrorDetailReportsColumns...))
 	if err != nil {
 		_ = txn.Rollback()
-		edRep.log.Errorf("Failed during statement preparation: %v", err)
+		edr.log.Errorf("Failed during statement preparation: %v", err)
 		return
 	}
 	defer func() { _ = stmt.Close() }()
 
 	reportedAt := time.Now().UTC().Unix() / 60
 	for _, metric := range metrics {
-		workspaceID := edRep.getWorkspaceID(metric.ConnectionDetails.SourceID)
+		workspaceID := edr.getWorkspaceID(metric.ConnectionDetails.SourceID)
 		metric := *metric
-		destinationDetail := edRep.getDestDetail(metric.ConnectionDetails.DestinationID)
-		edRep.log.Debugf("For DestId: %v -> DestDetail: %v", metric.ConnectionDetails.DestinationID, destinationDetail)
+		destinationDetail := edr.getDestDetail(metric.ConnectionDetails.DestinationID)
+		edr.log.Debugf("For DestId: %v -> DestDetail: %v", metric.ConnectionDetails.DestinationID, destinationDetail)
 
 		// extract error-message & error-code
-		errDets := edRep.extractErrorDetails(metric.StatusDetail.SampleResponse)
+		errDets := edr.extractErrorDetails(metric.StatusDetail.SampleResponse)
 		_, err = stmt.Exec(
 			workspaceID,
-			edRep.namespace,
-			edRep.instanceID,
+			edr.namespace,
+			edr.instanceID,
 			metric.ConnectionDetails.SourceDefinitionId,
 			metric.ConnectionDetails.SourceID,
 			destinationDetail.DestinationDefinitionID,
@@ -243,29 +243,16 @@ func (edRep *ErrorDetailReporter) Report(metrics []*types.PUReportedMetric, txn 
 			errDets.ErrorMessage,
 		)
 		if err != nil {
-			edRep.log.Errorf("Failed during statement execution(each metric): %v", err)
+			edr.log.Errorf("Failed during statement execution(each metric): %v", err)
 			return
 		}
 	}
 
 	_, err = stmt.Exec()
 	if err != nil {
-		edRep.log.Errorf("Failed during statement preparation: %v", err)
+		edr.log.Errorf("Failed during statement preparation: %v", err)
 		return
 	}
-}
-
-func (edRep *ErrorDetailReporter) WaitForSetup(ctx context.Context, clientName string) error {
-	for {
-		if edRep.GetClient(clientName) != nil {
-			break
-		}
-		if err := misc.SleepCtx(ctx, time.Second); err != nil {
-			return fmt.Errorf("wait for setup: %w", ctx.Err())
-		}
-	}
-
-	return nil
 }
 
 func (*ErrorDetailReporter) IsPIIReportingDisabled(_ string) bool {
@@ -273,12 +260,12 @@ func (*ErrorDetailReporter) IsPIIReportingDisabled(_ string) bool {
 	return false
 }
 
-func (edRep *ErrorDetailReporter) migrate(c types.Config) (*sql.DB, error) {
+func (edr *ErrorDetailReporter) migrate(c types.SyncerConfig) (*sql.DB, error) {
 	dbHandle, err := sql.Open("postgres", c.ConnInfo)
 	if err != nil {
 		return nil, err
 	}
-	dbHandle.SetMaxOpenConns(edRep.maxOpenConnections)
+	dbHandle.SetMaxOpenConns(edr.maxOpenConnections)
 
 	m := &migrator.Migrator{
 		Handle:          dbHandle,
@@ -293,46 +280,46 @@ func (edRep *ErrorDetailReporter) migrate(c types.Config) (*sql.DB, error) {
 	return dbHandle, nil
 }
 
-func (edRep *ErrorDetailReporter) getWorkspaceID(sourceID string) string {
-	edRep.srcWspMutex.RLock()
-	defer func() { edRep.srcWspMutex.RUnlock() }()
-	return edRep.workspaceIDForSourceIDMap[sourceID]
+func (edr *ErrorDetailReporter) getWorkspaceID(sourceID string) string {
+	edr.backendConfigMu.RLock()
+	defer edr.backendConfigMu.RUnlock()
+	return edr.workspaceIDForSourceIDMap[sourceID]
 }
 
-func (edRep *ErrorDetailReporter) getDestDetail(destID string) destDetail {
-	edRep.srcWspMutex.RLock()
-	defer func() { edRep.srcWspMutex.RUnlock() }()
-	return edRep.destinationIDMap[destID]
+func (edr *ErrorDetailReporter) getDestDetail(destID string) destDetail {
+	edr.backendConfigMu.RLock()
+	defer edr.backendConfigMu.RUnlock()
+	return edr.destinationIDMap[destID]
 }
 
-func (edRep *ErrorDetailReporter) extractErrorDetails(sampleResponse string) errorDetails {
-	errMsg := edRep.errorDetailExtractor.GetErrorMessage(sampleResponse)
-	cleanedErrMsg := edRep.errorDetailExtractor.CleanUpErrorMessage(errMsg)
+func (edr *ErrorDetailReporter) extractErrorDetails(sampleResponse string) errorDetails {
+	errMsg := edr.errorDetailExtractor.GetErrorMessage(sampleResponse)
+	cleanedErrMsg := edr.errorDetailExtractor.CleanUpErrorMessage(errMsg)
 	return errorDetails{
 		ErrorMessage: cleanedErrMsg,
 	}
 }
 
-func (edRep *ErrorDetailReporter) getDBHandle(clientName string) (*sql.DB, error) {
-	client := edRep.GetClient(clientName)
+func (edr *ErrorDetailReporter) getDBHandle(clientKey string) (*sql.DB, error) {
+	client := edr.GetClient(clientKey)
 	if client != nil {
 		return client.DbHandle, nil
 	}
-
-	return nil, fmt.Errorf("DBHandle not found for client name: %s", clientName)
+	return nil, fmt.Errorf("DBHandle not found for client name: %s", clientKey)
 }
 
-func (edRep *ErrorDetailReporter) getTags(clientName string) stats.Tags {
+func (edr *ErrorDetailReporter) getTags(clientName string) stats.Tags {
 	return stats.Tags{
-		"workspaceID": edRep.workspaceID,
+		"workspaceID": edr.workspaceID,
 		"clientName":  clientName,
-		"instanceId":  edRep.instanceID,
+		"instanceId":  edr.instanceID,
 	}
 }
 
 // Sending metrics to Reporting service --- STARTS
-func (edRep *ErrorDetailReporter) mainLoop(ctx context.Context, clientName string) {
-	tags := edRep.getTags(clientName)
+func (edr *ErrorDetailReporter) mainLoop(ctx context.Context, c types.SyncerConfig) {
+	<-edr.init
+	tags := edr.getTags(c.Label)
 
 	mainLoopTimer := stats.Default.NewTaggedStat("error_detail_reports_main_loop_time", stats.TimerType, tags)
 	getReportsTimer := stats.Default.NewTaggedStat("error_detail_reports_get_reports_time", stats.TimerType, tags)
@@ -342,9 +329,9 @@ func (edRep *ErrorDetailReporter) mainLoop(ctx context.Context, clientName strin
 
 	errorDetailReportsDeleteQueryTimer := stats.Default.NewTaggedStat("error_detail_reports_delete_query_time", stats.TimerType, tags)
 
-	edRep.minReportedAtQueryTime = stats.Default.NewTaggedStat("error_detail_reports_min_reported_at_query_time", stats.TimerType, tags)
-	edRep.errorDetailReportsQueryTime = stats.Default.NewTaggedStat("error_detail_reports_query_time", stats.TimerType, tags)
-	edRep.edReportingRequestLatency = stats.Default.NewTaggedStat("error_detail_reporting_request_latency", stats.TimerType, tags)
+	edr.minReportedAtQueryTime = stats.Default.NewTaggedStat("error_detail_reports_min_reported_at_query_time", stats.TimerType, tags)
+	edr.errorDetailReportsQueryTime = stats.Default.NewTaggedStat("error_detail_reports_query_time", stats.TimerType, tags)
+	edr.edReportingRequestLatency = stats.Default.NewTaggedStat("error_detail_reporting_request_latency", stats.TimerType, tags)
 
 	// In infinite loop
 	// Get Reports
@@ -353,30 +340,30 @@ func (edRep *ErrorDetailReporter) mainLoop(ctx context.Context, clientName strin
 	// Delete in a separate go-routine
 	for {
 		if ctx.Err() != nil {
-			edRep.log.Infof("stopping mainLoop for client %s : %s", clientName, ctx.Err())
+			edr.log.Infof("stopping mainLoop for client %s : %s", c.Label, ctx.Err())
 			return
 		}
-		requestChan := make(chan struct{}, edRep.maxConcurrentRequests.Load())
+		requestChan := make(chan struct{}, edr.maxConcurrentRequests.Load())
 		loopStart := time.Now()
 		currentMs := time.Now().UTC().Unix() / 60
 
 		getReportsStart := time.Now()
-		reports, reportedAt := edRep.getReports(ctx, currentMs, clientName)
+		reports, reportedAt := edr.getReports(ctx, currentMs, c.ConnInfo)
 		getReportsTimer.Since(getReportsStart)
 		getReportsSize.Observe(float64(len(reports)))
 
 		if len(reports) == 0 {
 			select {
 			case <-ctx.Done():
-				edRep.log.Infof("stopping mainLoop for client %s : %s", clientName, ctx.Err())
+				edr.log.Infof("stopping mainLoop for client %s : %s", c.Label, ctx.Err())
 				return
-			case <-time.After(edRep.sleepInterval.Load()):
+			case <-time.After(edr.sleepInterval.Load()):
 			}
 			continue
 		}
 
 		aggregationStart := time.Now()
-		metrics := edRep.aggregate(reports)
+		metrics := edr.aggregate(reports)
 		aggregateTimer.Since(aggregationStart)
 		getAggregatedReportsSize.Observe(float64(len(metrics)))
 
@@ -389,9 +376,9 @@ func (edRep *ErrorDetailReporter) mainLoop(ctx context.Context, clientName strin
 				break
 			}
 			errGroup.Go(func() error {
-				err := edRep.sendMetric(errCtx, clientName, metricToSend)
+				err := edr.sendMetric(errCtx, c.Label, metricToSend)
 				if err != nil {
-					edRep.log.Error("Error while sending to Reporting service:", err)
+					edr.log.Error("Error while sending to Reporting service:", err)
 				}
 				<-requestChan
 				return err
@@ -401,9 +388,9 @@ func (edRep *ErrorDetailReporter) mainLoop(ctx context.Context, clientName strin
 		err := errGroup.Wait()
 		if err == nil {
 			// sqlStatement := fmt.Sprintf(`DELETE FROM %s WHERE reported_at = %d`, ErrorDetailReportsTable, reportedAt)
-			dbHandle, err := edRep.getDBHandle(clientName)
+			dbHandle, err := edr.getDBHandle(c.ConnInfo)
 			if err != nil {
-				edRep.log.Errorf("error reports deletion getDbhandle failed: %v", err)
+				edr.log.Errorf("error reports deletion getDbhandle failed: %v", err)
 				continue
 			}
 			deleteReportsStart := time.Now()
@@ -411,7 +398,7 @@ func (edRep *ErrorDetailReporter) mainLoop(ctx context.Context, clientName strin
 			delRows, err = dbHandle.Query(`DELETE FROM `+ErrorDetailReportsTable+` WHERE reported_at = $1`, reportedAt)
 			errorDetailReportsDeleteQueryTimer.Since(deleteReportsStart)
 			if err != nil {
-				edRep.log.Errorf(`[ Error Detail Reporting ]: Error deleting local reports from %s: %v`, ErrorDetailReportsTable, err)
+				edr.log.Errorf(`[ Error Detail Reporting ]: Error deleting local reports from %s: %v`, ErrorDetailReportsTable, err)
 			}
 			delRows.Close()
 		}
@@ -420,26 +407,26 @@ func (edRep *ErrorDetailReporter) mainLoop(ctx context.Context, clientName strin
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(edRep.mainLoopSleepInterval.Load()):
+		case <-time.After(edr.mainLoopSleepInterval.Load()):
 		}
 	}
 }
 
-func (edRep *ErrorDetailReporter) getReports(ctx context.Context, currentMs int64, clientName string) ([]*types.EDReportsDB, int64) {
+func (edr *ErrorDetailReporter) getReports(ctx context.Context, currentMs int64, clientKey string) ([]*types.EDReportsDB, int64) {
 	var queryMin sql.NullInt64
-	dbHandle, err := edRep.getDBHandle(clientName)
+	dbHandle, err := edr.getDBHandle(clientKey)
 	if err != nil {
-		edRep.log.Errorf("Failed while getting DbHandle: %v", err)
+		edr.log.Errorf("Failed while getting DbHandle: %v", err)
 		return []*types.EDReportsDB{}, queryMin.Int64
 	}
 
 	queryStart := time.Now()
 	err = dbHandle.QueryRowContext(ctx, "SELECT reported_at FROM "+ErrorDetailReportsTable+" WHERE reported_at < $1 ORDER BY reported_at ASC LIMIT 1", currentMs).Scan(&queryMin)
 	if err != nil && err != sql.ErrNoRows {
-		edRep.log.Errorf("Failed while getting reported_at: %v", err)
+		edr.log.Errorf("Failed while getting reported_at: %v", err)
 		return []*types.EDReportsDB{}, queryMin.Int64
 	}
-	edRep.minReportedAtQueryTime.Since(queryStart)
+	edr.minReportedAtQueryTime.Since(queryStart)
 	if !queryMin.Valid {
 		return nil, 0
 	}
@@ -464,10 +451,10 @@ func (edRep *ErrorDetailReporter) getReports(ctx context.Context, currentMs int6
 	queryStart = time.Now()
 	rows, err = dbHandle.Query(`SELECT `+edSelColumns+` FROM `+ErrorDetailReportsTable+` WHERE reported_at = $1`, queryMin.Int64)
 	if err != nil {
-		edRep.log.Errorf("Failed while getting reports(reported_at=%v): %v", queryMin.Int64, err)
+		edr.log.Errorf("Failed while getting reports(reported_at=%v): %v", queryMin.Int64, err)
 		return []*types.EDReportsDB{}, queryMin.Int64
 	}
-	edRep.errorDetailReportsQueryTime.Since(queryStart)
+	edr.errorDetailReportsQueryTime.Since(queryStart)
 	defer func() { _ = rows.Close() }()
 	var metrics []*types.EDReportsDB
 	for rows.Next() {
@@ -510,7 +497,7 @@ func (edRep *ErrorDetailReporter) getReports(ctx context.Context, currentMs int6
 			&dbEdMetric.EDConnectionDetails.DestType,
 		)
 		if err != nil {
-			edRep.log.Errorf("Failed while scanning rows(reported_at=%v): %v", queryMin.Int64, err)
+			edr.log.Errorf("Failed while scanning rows(reported_at=%v): %v", queryMin.Int64, err)
 			return []*types.EDReportsDB{}, queryMin.Int64
 		}
 		metrics = append(metrics, dbEdMetric)
@@ -518,7 +505,7 @@ func (edRep *ErrorDetailReporter) getReports(ctx context.Context, currentMs int6
 	return metrics, queryMin.Int64
 }
 
-func (edRep *ErrorDetailReporter) aggregate(reports []*types.EDReportsDB) []*types.EDMetric {
+func (edr *ErrorDetailReporter) aggregate(reports []*types.EDReportsDB) []*types.EDMetric {
 	groupedReports := lo.GroupBy(reports, func(report *types.EDReportsDB) string {
 		keys := []string{
 			report.WorkspaceID,
@@ -533,14 +520,14 @@ func (edRep *ErrorDetailReporter) aggregate(reports []*types.EDReportsDB) []*typ
 		}
 		return strings.Join(keys, groupKeyDelimitter)
 	})
-	var edReportingMetrics []*types.EDMetric
+	var edrortingMetrics []*types.EDMetric
 	groupKeys := lo.Keys(groupedReports)
 	sort.Strings(groupKeys)
 
 	for _, key := range groupKeys {
 		reports := groupedReports[key]
 		firstReport := reports[0]
-		edRepSchema := types.EDMetric{
+		edrSchema := types.EDMetric{
 			EDInstanceDetails: types.EDInstanceDetails{
 				WorkspaceID: firstReport.WorkspaceID,
 				Namespace:   firstReport.Namespace,
@@ -587,62 +574,62 @@ func (edRep *ErrorDetailReporter) aggregate(reports []*types.EDReportsDB) []*typ
 				Count:        reportsCountMap[rep],
 			})
 		}
-		edRepSchema.Errors = errs
-		edReportingMetrics = append(edReportingMetrics, &edRepSchema)
+		edrSchema.Errors = errs
+		edrortingMetrics = append(edrortingMetrics, &edrSchema)
 	}
-	return edReportingMetrics
+	return edrortingMetrics
 }
 
-func (edRep *ErrorDetailReporter) sendMetric(ctx context.Context, clientName string, metric *types.EDMetric) error {
+func (edr *ErrorDetailReporter) sendMetric(ctx context.Context, label string, metric *types.EDMetric) error {
 	payload, err := json.Marshal(metric)
 	if err != nil {
 		return fmt.Errorf("marshal failure: %w", err)
 	}
 	operation := func() error {
-		uri := fmt.Sprintf("%s/recordErrors", edRep.reportingServiceURL)
+		uri := fmt.Sprintf("%s/recordErrors", edr.reportingServiceURL)
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, uri, bytes.NewBuffer(payload))
 		if err != nil {
 			return err
 		}
-		if edRep.region != "" {
+		if edr.region != "" {
 			q := req.URL.Query()
-			q.Add("region", edRep.region)
+			q.Add("region", edr.region)
 			req.URL.RawQuery = q.Encode()
 		}
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 		httpRequestStart := time.Now()
-		resp, err := edRep.httpClient.Do(req)
+		resp, err := edr.httpClient.Do(req)
 		if err != nil {
-			edRep.log.Errorf("Sending request failed: %v", err)
+			edr.log.Errorf("Sending request failed: %v", err)
 			return err
 		}
 
-		edRep.edReportingRequestLatency.Since(httpRequestStart)
-		httpStatTags := edRep.getTags(clientName)
+		edr.edReportingRequestLatency.Since(httpRequestStart)
+		httpStatTags := edr.getTags(label)
 		httpStatTags["status"] = strconv.Itoa(resp.StatusCode)
 		stats.Default.NewTaggedStat("error_detail_reporting_http_request", stats.CountType, httpStatTags).Increment()
 
 		defer func() { httputil.CloseResponse(resp) }()
 		respBody, err := io.ReadAll(resp.Body)
-		edRep.log.Debugf("[ErrorDetailReporting]Response from ReportingAPI: %v\n", string(respBody))
+		edr.log.Debugf("[ErrorDetailReporting]Response from ReportingAPI: %v\n", string(respBody))
 		if err != nil {
-			edRep.log.Errorf("Reading response failed: %w", err)
+			edr.log.Errorf("Reading response failed: %w", err)
 			return err
 		}
 
 		if !isMetricPosted(resp.StatusCode) {
 			err = fmt.Errorf(`received response: statusCode: %d error: %v`, resp.StatusCode, string(respBody))
-			edRep.log.Error(err.Error())
+			edr.log.Error(err.Error())
 		}
 		return err
 	}
 
 	b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
 	err = backoff.RetryNotify(operation, b, func(err error, t time.Duration) {
-		edRep.log.Errorf(`[ Error Detail Reporting ]: Error reporting to service: %v`, err)
+		edr.log.Errorf(`[ Error Detail Reporting ]: Error reporting to service: %v`, err)
 	})
 	if err != nil {
-		edRep.log.Errorf(`[ Error Detail Reporting ]: Error making request to reporting service: %v`, err)
+		edr.log.Errorf(`[ Error Detail Reporting ]: Error making request to reporting service: %v`, err)
 	}
 	return err
 }

--- a/enterprise/reporting/noop.go
+++ b/enterprise/reporting/noop.go
@@ -1,7 +1,6 @@
 package reporting
 
 import (
-	"context"
 	"database/sql"
 
 	"github.com/rudderlabs/rudder-server/utils/types"
@@ -13,17 +12,6 @@ type NOOP struct{}
 func (*NOOP) Report(_ []*types.PUReportedMetric, _ *sql.Tx) {
 }
 
-func (*NOOP) WaitForSetup(_ context.Context, _ string) error {
-	return nil
-}
-
-func (*NOOP) AddClient(_ context.Context, _ types.Config) {
-}
-
-func (*NOOP) GetClient(_ string) *types.Client {
-	return nil
-}
-
-func (*NOOP) IsPIIReportingDisabled(_ string) bool {
-	return false
+func (*NOOP) DatabaseSyncer(c types.SyncerConfig) types.ReportingSyncer {
+	return func() {}
 }

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -44,18 +44,17 @@ const (
 	StatReportingGetReportsQueryTime       = "reporting_client_get_reports_query_time"
 )
 
-type Handle struct {
-	init                                 chan struct{}
-	onceInit                             sync.Once
-	clients                              map[string]*types.Client
-	clientsMapLock                       sync.RWMutex
-	log                                  logger.Logger
-	reportingServiceURL                  string
-	namespace                            string
-	workspaceID                          string
+type DefaultReporter struct {
+	ctx                 context.Context
+	init                chan struct{}
+	onceInit            sync.Once
+	clients             map[string]*types.Client
+	clientsMapLock      sync.RWMutex
+	log                 logger.Logger
+	reportingServiceURL string
+	namespace           string
+
 	instanceID                           string
-	workspaceIDForSourceIDMap            map[string]string
-	piiReportingSettings                 map[string]bool
 	whActionsOnly                        bool
 	region                               string
 	sleepInterval                        misc.ValueLoader[time.Duration]
@@ -65,12 +64,17 @@ type Handle struct {
 	maxOpenConnections                   int
 	maxConcurrentRequests                misc.ValueLoader[int]
 
+	backendConfigMu           sync.RWMutex // protects the following
+	workspaceID               string
+	workspaceIDForSourceIDMap map[string]string
+	piiReportingSettings      map[string]bool
+
 	getMinReportedAtQueryTime stats.Measurement
 	getReportsQueryTime       stats.Measurement
 	requestLatency            stats.Measurement
 }
 
-func NewFromEnvConfig(log logger.Logger) *Handle {
+func NewDefaultReporter(ctx context.Context, log logger.Logger) *DefaultReporter {
 	var dbQueryTimeout *config.Reloadable[time.Duration]
 
 	reportingServiceURL := config.GetString("REPORTING_URL", "https://reporting.rudderstack.com/")
@@ -87,7 +91,8 @@ func NewFromEnvConfig(log logger.Logger) *Handle {
 	if whActionsOnly {
 		log.Info("REPORTING_WH_ACTIONS_ONLY enabled.only sending reports relevant to wh actions.")
 	}
-	return &Handle{
+	return &DefaultReporter{
+		ctx:                                  ctx,
 		init:                                 make(chan struct{}),
 		log:                                  log,
 		clients:                              make(map[string]*types.Client),
@@ -107,10 +112,16 @@ func NewFromEnvConfig(log logger.Logger) *Handle {
 	}
 }
 
-func (r *Handle) setup(beConfigHandle backendconfig.BackendConfig) {
+func (r *DefaultReporter) backendConfigSubscriber(beConfigHandle backendconfig.BackendConfig) {
 	r.log.Info("[[ Reporting ]] Setting up reporting handler")
+	defer r.onceInit.Do(func() {
+		close(r.init)
+	})
 
-	ch := beConfigHandle.Subscribe(context.TODO(), backendconfig.TopicBackendConfig)
+	if r.ctx.Err() != nil {
+		return
+	}
+	ch := beConfigHandle.Subscribe(r.ctx, backendconfig.TopicBackendConfig)
 
 	for c := range ch {
 		conf := c.Data.(map[string]backendconfig.ConfigT)
@@ -128,34 +139,36 @@ func (r *Handle) setup(beConfigHandle backendconfig.BackendConfig) {
 		if len(conf) > 1 {
 			newWorkspaceID = ""
 		}
+
+		r.backendConfigMu.Lock()
 		r.workspaceID = newWorkspaceID
 		r.workspaceIDForSourceIDMap = newWorkspaceIDForSourceIDMap
 		r.piiReportingSettings = newPIIReportingSettings
+		r.backendConfigMu.Unlock()
+
 		r.onceInit.Do(func() {
 			close(r.init)
 		})
 	}
-
-	r.onceInit.Do(func() {
-		close(r.init)
-	})
 }
 
-func (r *Handle) getWorkspaceID(sourceID string) string {
+func (r *DefaultReporter) getWorkspaceID(sourceID string) string {
 	<-r.init
+	r.backendConfigMu.RLock()
+	defer r.backendConfigMu.RUnlock()
 	return r.workspaceIDForSourceIDMap[sourceID]
 }
 
-func (r *Handle) AddClient(ctx context.Context, c types.Config) {
-	if c.ClientName == "" {
-		c.ClientName = types.CoreReportingClient
+func (r *DefaultReporter) DatabaseSyncer(c types.SyncerConfig) types.ReportingSyncer {
+	if c.Label == "" {
+		c.Label = types.CoreReportingLabel
 	}
 
-	r.clientsMapLock.RLock()
-	if _, ok := r.clients[c.ClientName]; ok {
-		return
+	r.clientsMapLock.Lock()
+	defer r.clientsMapLock.Unlock()
+	if _, ok := r.clients[c.ConnInfo]; ok {
+		return func() {} // returning a no-op syncer since another go routine has already started syncing
 	}
-	r.clientsMapLock.RUnlock()
 
 	dbHandle, err := sql.Open("postgres", c.ConnInfo)
 	if err != nil {
@@ -172,51 +185,32 @@ func (r *Handle) AddClient(ctx context.Context, c types.Config) {
 	if err != nil {
 		panic(fmt.Errorf("could not run reports migrations: %w", err))
 	}
+	r.clients[c.ConnInfo] = &types.Client{SyncerConfig: c, DbHandle: dbHandle}
 
-	r.clientsMapLock.Lock()
-	r.clients[c.ClientName] = &types.Client{Config: c, DbHandle: dbHandle}
-	r.clientsMapLock.Unlock()
-
-	r.mainLoop(ctx, c.ClientName)
-}
-
-func (r *Handle) WaitForSetup(ctx context.Context, clientName string) error {
-	for {
-		if r.GetClient(clientName) != nil {
-			break
-		}
-		if err := misc.SleepCtx(ctx, time.Second); err != nil {
-			return fmt.Errorf("wait for setup: %w", ctx.Err())
-		}
+	return func() {
+		r.mainLoop(r.ctx, c)
 	}
-
-	return nil
 }
 
-func (r *Handle) GetClient(clientName string) *types.Client {
+func (r *DefaultReporter) GetClient(clientKey string) *types.Client {
 	r.clientsMapLock.RLock()
 	defer r.clientsMapLock.RUnlock()
-
-	if c, ok := r.clients[clientName]; ok {
-		return c
-	}
-
-	return nil
+	return r.clients[clientKey]
 }
 
-func (r *Handle) getDBHandle(clientName string) (*sql.DB, error) {
-	client := r.GetClient(clientName)
+func (r *DefaultReporter) getDBHandle(clientKey string) (*sql.DB, error) {
+	client := r.GetClient(clientKey)
 	if client != nil {
 		return client.DbHandle, nil
 	}
 
-	return nil, fmt.Errorf("DBHandle not found for client name: %s", clientName)
+	return nil, fmt.Errorf("DBHandle not found for client name: %s", clientKey)
 }
 
-func (r *Handle) getReports(currentMs int64, clientName string) (reports []*types.ReportByStatus, reportedAt int64, err error) {
+func (r *DefaultReporter) getReports(currentMs int64, clientKey string) (reports []*types.ReportByStatus, reportedAt int64, err error) {
 	sqlStatement := fmt.Sprintf(`SELECT reported_at FROM %s WHERE reported_at < %d ORDER BY reported_at ASC LIMIT 1`, ReportsTable, currentMs)
 	var queryMin sql.NullInt64
-	dbHandle, err := r.getDBHandle(clientName)
+	dbHandle, err := r.getDBHandle(clientKey)
 	if err != nil {
 		panic(err)
 	}
@@ -284,7 +278,7 @@ func (r *Handle) getReports(currentMs int64, clientName string) (reports []*type
 	return metricReports, queryMin.Int64, err
 }
 
-func (*Handle) getAggregatedReports(reports []*types.ReportByStatus) []*types.Metric {
+func (*DefaultReporter) getAggregatedReports(reports []*types.ReportByStatus) []*types.Metric {
 	metricsByGroup := map[string]*types.Metric{}
 
 	reportIdentifier := func(report *types.ReportByStatus) string {
@@ -372,10 +366,11 @@ func (*Handle) getAggregatedReports(reports []*types.ReportByStatus) []*types.Me
 	return values
 }
 
-func (r *Handle) mainLoop(ctx context.Context, clientName string) {
+func (r *DefaultReporter) mainLoop(ctx context.Context, c types.SyncerConfig) {
+	<-r.init
 	tr := &http.Transport{}
 	netClient := &http.Client{Transport: tr, Timeout: config.GetDuration("HttpClient.reporting.timeout", 60, time.Second)}
-	tags := r.getTags(clientName)
+	tags := r.getTags(c.Label)
 	mainLoopTimer := stats.Default.NewTaggedStat(StatReportingMainLoopTime, stats.TimerType, tags)
 	getReportsTimer := stats.Default.NewTaggedStat(StatReportingGetReportsTime, stats.TimerType, tags)
 	getReportsCount := stats.Default.NewTaggedStat(StatReportingGetReportsCount, stats.HistogramType, tags)
@@ -386,7 +381,7 @@ func (r *Handle) mainLoop(ctx context.Context, clientName string) {
 	r.getReportsQueryTime = stats.Default.NewTaggedStat(StatReportingGetReportsQueryTime, stats.TimerType, tags)
 	r.requestLatency = stats.Default.NewTaggedStat(StatReportingHttpReqLatency, stats.TimerType, tags)
 	reportingLag := stats.Default.NewTaggedStat(
-		"reporting_metrics_lag_seconds", stats.GaugeType, stats.Tags{"client": clientName},
+		"reporting_metrics_lag_seconds", stats.GaugeType, stats.Tags{"client": c.Label},
 	)
 
 	var lastReportedAtTime atomic.Time
@@ -411,7 +406,7 @@ func (r *Handle) mainLoop(ctx context.Context, clientName string) {
 
 	for {
 		if ctx.Err() != nil {
-			r.log.Infof("stopping mainLoop for client %s : %s", clientName, ctx.Err())
+			r.log.Infof("stopping mainLoop for client %s : %s", c.Label, ctx.Err())
 			return
 		}
 		requestChan := make(chan struct{}, r.maxConcurrentRequests.Load())
@@ -419,7 +414,7 @@ func (r *Handle) mainLoop(ctx context.Context, clientName string) {
 		currentMs := time.Now().UTC().Unix() / 60
 
 		getReportsStart := time.Now()
-		reports, reportedAt, err := r.getReports(currentMs, clientName)
+		reports, reportedAt, err := r.getReports(currentMs, c.ConnInfo)
 		getReportsTimer.Since(getReportsStart)
 		getReportsCount.Observe(float64(len(reports)))
 		if len(reports) == 0 {
@@ -428,7 +423,7 @@ func (r *Handle) mainLoop(ctx context.Context, clientName string) {
 			}
 			select {
 			case <-ctx.Done():
-				r.log.Infof("stopping mainLoop for client %s : %s", clientName, ctx.Err())
+				r.log.Infof("stopping mainLoop for client %s : %s", c.Label, ctx.Err())
 				return
 			case <-time.After(r.sleepInterval.Load()):
 			}
@@ -455,7 +450,7 @@ func (r *Handle) mainLoop(ctx context.Context, clientName string) {
 				break
 			}
 			errGroup.Go(func() error {
-				err := r.sendMetric(errCtx, netClient, clientName, metricToSend)
+				err := r.sendMetric(errCtx, netClient, c.Label, metricToSend)
 				<-requestChan
 				return err
 			})
@@ -463,7 +458,7 @@ func (r *Handle) mainLoop(ctx context.Context, clientName string) {
 
 		err = errGroup.Wait()
 		if err == nil {
-			dbHandle, err := r.getDBHandle(clientName)
+			dbHandle, err := r.getDBHandle(c.ConnInfo)
 			if err != nil {
 				panic(err)
 			}
@@ -482,7 +477,7 @@ func (r *Handle) mainLoop(ctx context.Context, clientName string) {
 	}
 }
 
-func (r *Handle) sendMetric(ctx context.Context, netClient *http.Client, clientName string, metric *types.Metric) error {
+func (r *DefaultReporter) sendMetric(ctx context.Context, netClient *http.Client, label string, metric *types.Metric) error {
 	payload, err := json.Marshal(metric)
 	if err != nil {
 		panic(err)
@@ -507,7 +502,7 @@ func (r *Handle) sendMetric(ctx context.Context, netClient *http.Client, clientN
 		}
 
 		r.requestLatency.Since(httpRequestStart)
-		httpStatTags := r.getTags(clientName)
+		httpStatTags := r.getTags(label)
 		httpStatTags["status"] = strconv.Itoa(resp.StatusCode)
 		stats.Default.NewTaggedStat(StatReportingHttpReq, stats.CountType, httpStatTags).Count(1)
 
@@ -567,12 +562,14 @@ func transformMetricForPII(metric types.PUReportedMetric, piiColumns []string) t
 	return metric
 }
 
-func (r *Handle) IsPIIReportingDisabled(workspaceID string) bool {
+func (r *DefaultReporter) IsPIIReportingDisabled(workspaceID string) bool {
 	<-r.init
+	r.backendConfigMu.RLock()
+	defer r.backendConfigMu.RUnlock()
 	return r.piiReportingSettings[workspaceID]
 }
 
-func (r *Handle) Report(metrics []*types.PUReportedMetric, txn *sql.Tx) {
+func (r *DefaultReporter) Report(metrics []*types.PUReportedMetric, txn *sql.Tx) {
 	if len(metrics) == 0 {
 		return
 	}
@@ -654,7 +651,7 @@ func (r *Handle) Report(metrics []*types.PUReportedMetric, txn *sql.Tx) {
 	}
 }
 
-func (r *Handle) getTags(clientName string) stats.Tags {
+func (r *DefaultReporter) getTags(clientName string) stats.Tags {
 	return stats.Tags{
 		"workspaceId": r.workspaceID,
 		"instanceId":  r.instanceID,

--- a/enterprise/reporting/reporting_test.go
+++ b/enterprise/reporting/reporting_test.go
@@ -204,7 +204,7 @@ var _ = Describe("Reporting", func() {
 			},
 		}
 
-		reportHandle := NewFromEnvConfig(logger.NOP)
+		reportHandle := NewDefaultReporter(context.Background(), logger.NOP)
 
 		aggregatedMetrics := reportHandle.getAggregatedReports(inputReports)
 		Expect(aggregatedMetrics).To(Equal(expectedResponse))
@@ -248,11 +248,11 @@ func TestReportingBasedOnConfigBackend(t *testing.T) {
 		return configCh
 	})
 
-	reporting := NewFromEnvConfig(logger.NOP)
+	reporting := NewDefaultReporter(context.Background(), logger.NOP)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		reporting.setup(config)
+		reporting.backendConfigSubscriber(config)
 		wg.Done()
 	}()
 
@@ -584,7 +584,7 @@ func TestAggregationLogic(t *testing.T) {
 			},
 		},
 	}
-	ed := NewEdReporterFromEnvConfig()
+	ed := NewErrorDetailReporter(context.Background())
 	reportingMetrics := ed.aggregate(dbErrs)
 
 	reportResults := []*types.EDMetric{

--- a/enterprise/reporting/setup_test.go
+++ b/enterprise/reporting/setup_test.go
@@ -83,7 +83,7 @@ func TestSetupForNoop(t *testing.T) {
 				}
 			}
 			med := NewReportingMediator(context.Background(), logger.NOP, f.EnterpriseToken, &backendconfig.NOOP{})
-			require.Len(t, med.delegates, tc.expectedDelegates)
+			require.Len(t, med.reporters, tc.expectedDelegates)
 		})
 
 	}

--- a/mocks/utils/types/mock_types.go
+++ b/mocks/utils/types/mock_types.go
@@ -5,7 +5,6 @@
 package mock_types
 
 import (
-	context "context"
 	sql "database/sql"
 	reflect "reflect"
 
@@ -74,16 +73,18 @@ func (m *MockReporting) EXPECT() *MockReportingMockRecorder {
 	return m.recorder
 }
 
-// AddClient mocks base method.
-func (m *MockReporting) AddClient(arg0 context.Context, arg1 types.Config) {
+// DatabaseSyncer mocks base method.
+func (m *MockReporting) DatabaseSyncer(arg0 types.SyncerConfig) types.ReportingSyncer {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddClient", arg0, arg1)
+	ret := m.ctrl.Call(m, "DatabaseSyncer", arg0)
+	ret0, _ := ret[0].(types.ReportingSyncer)
+	return ret0
 }
 
-// AddClient indicates an expected call of AddClient.
-func (mr *MockReportingMockRecorder) AddClient(arg0, arg1 interface{}) *gomock.Call {
+// DatabaseSyncer indicates an expected call of DatabaseSyncer.
+func (mr *MockReportingMockRecorder) DatabaseSyncer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddClient", reflect.TypeOf((*MockReporting)(nil).AddClient), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseSyncer", reflect.TypeOf((*MockReporting)(nil).DatabaseSyncer), arg0)
 }
 
 // Report mocks base method.
@@ -96,18 +97,4 @@ func (m *MockReporting) Report(arg0 []*types.PUReportedMetric, arg1 *sql.Tx) {
 func (mr *MockReportingMockRecorder) Report(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockReporting)(nil).Report), arg0, arg1)
-}
-
-// WaitForSetup mocks base method.
-func (m *MockReporting) WaitForSetup(arg0 context.Context, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForSetup", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// WaitForSetup indicates an expected call of WaitForSetup.
-func (mr *MockReportingMockRecorder) WaitForSetup(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForSetup", reflect.TypeOf((*MockReporting)(nil).WaitForSetup), arg0, arg1)
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -493,12 +493,6 @@ func (proc *Handle) Start(ctx context.Context) error {
 		proc.logger.Info("Starting pinger loop")
 		proc.backendConfig.WaitForConfig(ctx)
 		proc.logger.Info("Backend config received")
-		// waiting for reporting client setup
-		if proc.reporting != nil && proc.reportingEnabled {
-			if err := proc.reporting.WaitForSetup(ctx, types.CoreReportingClient); err != nil {
-				return err
-			}
-		}
 
 		// waiting for init group
 		proc.logger.Info("Waiting for async init group")

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2119,7 +2119,6 @@ var _ = Describe("Processor", Ordered, func() {
 				transformationdebugger.NewNoOpService(),
 			)
 			defer processor.Shutdown()
-			c.MockReportingI.EXPECT().WaitForSetup(gomock.Any(), gomock.Any()).Times(1)
 
 			processor.config.readLoopSleep = misc.SingleValueLoader(time.Millisecond)
 

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -145,12 +145,6 @@ func (brt *Handle) Setup(
 
 	brt.logger.Infof("BRT: Batch Router started: %s", destType)
 
-	// waiting for reporting client setup
-	if brt.reporting != nil && brt.reportingEnabled {
-		// error is ignored as context.TODO() is passed, err is not expected.
-		_ = brt.reporting.WaitForSetup(context.TODO(), types.CoreReportingClient)
-	}
-
 	brt.crashRecover()
 
 	// periodically publish a zero counter for ensuring that stuck processing pipeline alert

--- a/router/factory.go
+++ b/router/factory.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"context"
 	"database/sql"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
@@ -49,6 +48,5 @@ func (f *Factory) New(destination *backendconfig.DestinationT) *Handle {
 }
 
 type reporter interface {
-	WaitForSetup(ctx context.Context, clientName string) error
 	Report(metrics []*utilTypes.PUReportedMetric, txn *sql.Tx)
 }

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -29,7 +29,6 @@ import (
 	"github.com/rudderlabs/rudder-server/services/rsources"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/misc"
-	utilTypes "github.com/rudderlabs/rudder-server/utils/types"
 	"github.com/rudderlabs/rudder-server/utils/workerpool"
 )
 
@@ -54,12 +53,6 @@ func (rt *Handle) Setup(
 
 	rt.transientSources = transientSources
 	rt.rsourcesService = rsourcesService
-
-	// waiting for reporting client setup
-	err := rt.Reporting.WaitForSetup(context.TODO(), utilTypes.CoreReportingClient)
-	if err != nil {
-		return
-	}
 
 	rt.jobsDB = jobsDB
 	rt.errorDB = errorDB
@@ -114,6 +107,7 @@ func (rt *Handle) Setup(
 	rt.backendConfigInitialized = make(chan bool)
 
 	isolationMode := isolationMode(destType, config)
+	var err error
 	if rt.isolationStrategy, err = isolation.GetStrategy(isolationMode, rt.destType, func(destinationID string) bool {
 		rt.destinationsMapMu.RLock()
 		defer rt.destinationsMapMu.RUnlock()

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -356,8 +356,7 @@ func setupStatsTable(ctx context.Context, db *sql.DB, defaultDbName string, log 
 
 func (sh *sourcesHandler) setupLogicalReplication(ctx context.Context) error {
 	publicationQuery := `CREATE PUBLICATION "rsources_stats_pub" FOR TABLE rsources_stats`
-	_, err := sh.localDB.ExecContext(ctx, publicationQuery)
-	if err != nil {
+	if _, err := sh.localDB.ExecContext(ctx, publicationQuery); err != nil {
 		pqError, ok := err.(*pq.Error)
 		if !ok || pqError.Code != pq.ErrorCode("42710") { // duplicate
 			return fmt.Errorf("failed to create publication on local database: %w", err)
@@ -365,8 +364,7 @@ func (sh *sourcesHandler) setupLogicalReplication(ctx context.Context) error {
 	}
 
 	alterPublicationQuery := `ALTER PUBLICATION "rsources_stats_pub" ADD TABLE rsources_failed_keys`
-	_, err = sh.localDB.ExecContext(ctx, alterPublicationQuery)
-	if err != nil {
+	if _, err := sh.localDB.ExecContext(ctx, alterPublicationQuery); err != nil {
 		pqError, ok := err.(*pq.Error)
 		if !ok || pqError.Code != pq.ErrorCode("42710") { // duplicate
 			return fmt.Errorf("failed to alter publication on local database to add failed_keys table: %w", err)
@@ -381,8 +379,7 @@ func (sh *sourcesHandler) setupLogicalReplication(ctx context.Context) error {
 		subscriptionConn = sh.config.LocalConn
 	}
 	subscriptionQuery := fmt.Sprintf(`CREATE SUBSCRIPTION "%s" CONNECTION '%s' PUBLICATION "rsources_stats_pub"`, subscriptionName, subscriptionConn) // skipcq: GO-R4002
-	_, err = sh.sharedDB.ExecContext(ctx, subscriptionQuery)
-	if err != nil {
+	if _, err := sh.sharedDB.ExecContext(ctx, subscriptionQuery); err != nil {
 		pqError, ok := err.(*pq.Error)
 		if !ok || pqError.Code != pq.ErrorCode("42710") { // duplicate
 			return fmt.Errorf("failed to create subscription on shared database: %w", err)
@@ -390,8 +387,7 @@ func (sh *sourcesHandler) setupLogicalReplication(ctx context.Context) error {
 	}
 
 	refreshSubscriptionQuery := fmt.Sprintf(`ALTER SUBSCRIPTION %s REFRESH PUBLICATION`, subscriptionName)
-	_, err = sh.sharedDB.ExecContext(ctx, refreshSubscriptionQuery)
-	if err != nil {
+	if _, err := sh.sharedDB.ExecContext(ctx, refreshSubscriptionQuery); err != nil {
 		return fmt.Errorf("failed to refresh subscription on shared database: %w", err)
 	}
 

--- a/utils/types/reporting_types.go
+++ b/utils/types/reporting_types.go
@@ -42,7 +42,7 @@ var (
 	SUCCEEDED_WITH_VIOLATIONS    = "succeeded_with_violations"
 )
 
-type Client struct {
+type SyncSource struct {
 	SyncerConfig
 	DbHandle *sql.DB
 }

--- a/utils/types/reporting_types.go
+++ b/utils/types/reporting_types.go
@@ -3,16 +3,17 @@ package types
 import (
 	"database/sql"
 	"encoding/json"
+	"time"
 )
 
-type Config struct {
-	ClientName string
-	ConnInfo   string
+type SyncerConfig struct {
+	ConnInfo string
+	Label    string
 }
 
 const (
-	CoreReportingClient      = "core"
-	WarehouseReportingClient = "warehouse"
+	CoreReportingLabel      = "core"
+	WarehouseReportingLabel = "warehouse"
 
 	SupportedTransformerApiVersion = 2
 
@@ -42,20 +43,26 @@ var (
 )
 
 type Client struct {
-	Config
+	SyncerConfig
 	DbHandle *sql.DB
 }
 
 type StatusDetail struct {
-	Status         string          `json:"state"`
-	Count          int64           `json:"count"`
-	StatusCode     int             `json:"statusCode"`
-	SampleResponse string          `json:"sampleResponse"`
-	SampleEvent    json.RawMessage `json:"sampleEvent"`
-	EventName      string          `json:"eventName"`
-	EventType      string          `json:"eventType"`
-	ErrorType      string          `json:"errorType"`
-	ViolationCount int64           `json:"violationCount"`
+	Status         string           `json:"state"`
+	Count          int64            `json:"count"`
+	StatusCode     int              `json:"statusCode"`
+	SampleResponse string           `json:"sampleResponse"`
+	SampleEvent    json.RawMessage  `json:"sampleEvent"`
+	EventName      string           `json:"eventName"`
+	EventType      string           `json:"eventType"`
+	ErrorType      string           `json:"errorType"`
+	ViolationCount int64            `json:"violationCount"`
+	FailedMessages []*FailedMessage `json:"failedMessages"`
+}
+
+type FailedMessage struct {
+	MessageID  string    `json:"messageId"`
+	ReceivedAt time.Time `json:"receivedAt"`
 }
 
 type ReportByStatus struct {

--- a/utils/types/types.go
+++ b/utils/types/types.go
@@ -3,7 +3,6 @@
 package types
 
 import (
-	"context"
 	"database/sql"
 	"net/http"
 	"time"
@@ -56,10 +55,14 @@ type ConfigEnvI interface {
 
 // Reporting is interface to report metrics
 type Reporting interface {
-	WaitForSetup(ctx context.Context, clientName string) error
+	// Report reports metrics to reporting service
 	Report(metrics []*PUReportedMetric, txn *sql.Tx)
-	AddClient(ctx context.Context, c Config)
+
+	// DatabaseSyncer creates reporting tables in the database and returns a function to periodically sync the data
+	DatabaseSyncer(c SyncerConfig) ReportingSyncer
 }
+
+type ReportingSyncer func()
 
 // ConfigT simple map config structure
 type ConfigT map[string]interface{}

--- a/warehouse/router.go
+++ b/warehouse/router.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/rudderlabs/rudder-server/warehouse/encoding"
 
-	"github.com/rudderlabs/rudder-server/app"
-
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
 
 	"golang.org/x/exp/slices"
@@ -34,6 +32,7 @@ import (
 	"github.com/rudderlabs/rudder-server/rruntime"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
+	"github.com/rudderlabs/rudder-server/utils/types"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/loadfiles"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
@@ -121,7 +120,7 @@ type router struct {
 
 func newRouter(
 	ctx context.Context,
-	app app.App,
+	reporting types.Reporting,
 	destType string,
 	conf *config.Config,
 	logger logger.Logger,
@@ -163,7 +162,7 @@ func newRouter(
 	r.inProgressMap = make(map[workerIdentifierMapKey][]jobID)
 
 	r.uploadJobFactory = UploadJobFactory{
-		app:                  app,
+		reporting:            reporting,
 		conf:                 r.conf,
 		logger:               r.logger,
 		statsFactory:         r.statsFactory,

--- a/warehouse/router_test.go
+++ b/warehouse/router_test.go
@@ -21,9 +21,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
-	"github.com/rudderlabs/rudder-server/app"
 	"github.com/rudderlabs/rudder-server/enterprise/reporting"
-	mocksApp "github.com/rudderlabs/rudder-server/mocks/app"
 	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/backend-config"
 	"github.com/rudderlabs/rudder-server/services/controlplane"
 	"github.com/rudderlabs/rudder-server/services/controlplane/identity"
@@ -46,15 +44,6 @@ import (
 func TestRouter(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
-
-	report := &reporting.Factory{}
-	report.Setup(&backendconfig.NOOP{})
-
-	mockCtrl := gomock.NewController(t)
-	mockApp := mocksApp.NewMockApp(mockCtrl)
-	mockApp.EXPECT().Features().Return(&app.Features{
-		Reporting: report,
-	}).AnyTimes()
 
 	sourceID := "test-source-id"
 	destinationID := "test-destination-id"
@@ -124,7 +113,7 @@ func TestRouter(t *testing.T) {
 
 		r, err := newRouter(
 			ctx,
-			mockApp,
+			&reporting.NOOP{},
 			destinationType,
 			config.Default,
 			logger.NOP,
@@ -594,7 +583,7 @@ func TestRouter(t *testing.T) {
 		r.tenantManager = multitenant.New(config.Default, mocksBackendConfig.NewMockBackendConfig(ctrl))
 		r.warehouses = []model.Warehouse{warehouse}
 		r.uploadJobFactory = UploadJobFactory{
-			app:          mockApp,
+			reporting:    &reporting.NOOP{},
 			conf:         config.Default,
 			logger:       logger.NOP,
 			statsFactory: r.statsFactory,
@@ -731,7 +720,7 @@ func TestRouter(t *testing.T) {
 		r.bcManager = newBackendConfigManager(r.conf, r.db, r.tenantManager, r.logger)
 		r.warehouses = []model.Warehouse{warehouse}
 		r.uploadJobFactory = UploadJobFactory{
-			app:          mockApp,
+			reporting:    &reporting.NOOP{},
 			conf:         config.Default,
 			logger:       logger.NOP,
 			statsFactory: r.statsFactory,
@@ -880,7 +869,7 @@ func TestRouter(t *testing.T) {
 			r.bcManager = newBackendConfigManager(r.conf, r.db, r.tenantManager, r.logger)
 			r.warehouses = []model.Warehouse{warehouse}
 			r.uploadJobFactory = UploadJobFactory{
-				app:          mockApp,
+				reporting:    &reporting.NOOP{},
 				conf:         config.Default,
 				logger:       logger.NOP,
 				statsFactory: r.statsFactory,

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -15,7 +15,6 @@ import (
 	"github.com/rudderlabs/rudder-server/warehouse/encoding"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-server/app"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/samber/lo"
@@ -34,7 +33,6 @@ import (
 	schemarepository "github.com/rudderlabs/rudder-server/warehouse/integrations/datalake/schema-repository"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
-	sqlmiddleware "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/loadfiles"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/repo"
@@ -70,7 +68,7 @@ type uploadState struct {
 type tableNameT string
 
 type UploadJobFactory struct {
-	app                  app.App
+	reporting            types.Reporting
 	db                   *sqlquerywrapper.DB
 	destinationValidator validations.DestinationValidator
 	loadFile             *loadfiles.LoadFileGenerator
@@ -82,9 +80,9 @@ type UploadJobFactory struct {
 }
 
 type UploadJob struct {
-	app                  app.App
 	ctx                  context.Context
-	db                   *sqlmiddleware.DB
+	db                   *sqlquerywrapper.DB
+	reporting            types.Reporting
 	destinationValidator validations.DestinationValidator
 	loadfile             *loadfiles.LoadFileGenerator
 	tableUploadsRepo     *repo.TableUploads
@@ -182,7 +180,7 @@ func (f *UploadJobFactory) NewUploadJob(ctx context.Context, dto *model.UploadJo
 
 	uj := &UploadJob{
 		ctx:                  ujCtx,
-		app:                  f.app,
+		reporting:            f.reporting,
 		db:                   f.db,
 		loadfile:             f.loadFile,
 		recovery:             f.recovery,
@@ -1484,7 +1482,7 @@ func (job *UploadJob) setUploadStatus(statusOpts UploadStatusOpts) (err error) {
 			return
 		}
 		if job.config.reportingEnabled {
-			job.app.Features().Reporting.GetReportingInstance().Report(
+			job.reporting.Report(
 				[]*types.PUReportedMetric{&statusOpts.ReportingMetric},
 				txn.GetTx(),
 			)
@@ -1515,7 +1513,7 @@ func (job *UploadJob) setLoadFileIDs(startLoadFileID, endLoadFileID int64) error
 
 type UploadColumnsOpts struct {
 	Fields []UploadColumn
-	Txn    *sqlmiddleware.Tx
+	Txn    *sqlquerywrapper.Tx
 }
 
 // SetUploadColumns sets any column values passed as args in UploadColumn format for WarehouseUploadsTable
@@ -1730,7 +1728,7 @@ func (job *UploadJob) setUploadError(statusError error, state string) (string, e
 		})
 	}
 	if job.config.reportingEnabled {
-		job.app.Features().Reporting.GetReportingInstance().Report(reportingMetrics, txn.GetTx())
+		job.reporting.Report(reportingMetrics, txn.GetTx())
 	}
 	err = txn.Commit()
 

--- a/warehouse/warehouse_test.go
+++ b/warehouse/warehouse_test.go
@@ -61,7 +61,7 @@ func TestApp(t *testing.T) {
 	require.NoError(t, err)
 
 	report := &reporting.Factory{}
-	report.Setup(&bcConfig.NOOP{})
+	report.Setup(context.Background(), &bcConfig.NOOP{})
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
# Description

Preparatory work for being able to collect additional error metadata fields for the purpose of replaying errors.

- Introduce a new struct for including error message details in reported data (`types.FailedMessage`). This is required for capturing error index metadata through reporting interfaces.
- Honouring context in goroutines started by the reporting feature. 
- Support new reporting implementations easily by using a variable-sized list of delegates inside reporting mediator.
- Remove `WaitForSetup`, since reporting tables are now being migrated synchronously when the program starts.
- Introduced `types.ReportingSyncer` to decouple database initialisation from syncer's main loop.
- Simplify warehouse's reporting setup conditions: 
  - Only standalone slaves don't setup reporting
  - Database syncers are only initialised and run once for each separate database (we are now using `connInfo` as a key instead of the `clientName`).
  - Injecting `Reporting` interface to `UploadJob` instead of `App` to avoid having to expose `ReportingFeature#GetReportingInstance`.
- Addressing races with concurrent map access.

## Linear Ticket

[PIPE-352](https://linear.app/rudderstack/issue/PIPE-352/refactor-reporting-service)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
