### PR TITLE
fix: event schema versions without a sample event

### DIFF
--- a/proto/event-schema/types.helper.go
+++ b/proto/event-schema/types.helper.go
@@ -60,8 +60,7 @@ func (sm *EventSchemaMessage) Merge(other *EventSchemaMessage) {
 	if len(other.Sample) < len(sm.Sample) { // keep the smallest sample
 		sm.Sample = other.Sample
 	}
-	sm.Sample = other.Sample
-	if other.ObservedAt.AsTime().After(sm.ObservedAt.AsTime()) { // keep the laters observed time
+	if other.ObservedAt.AsTime().After(sm.ObservedAt.AsTime()) { // keep the latest observed time
 		sm.ObservedAt = other.ObservedAt
 	}
 }

--- a/schema-forwarder/internal/forwarder/jobsforwarder.go
+++ b/schema-forwarder/internal/forwarder/jobsforwarder.go
@@ -95,7 +95,7 @@ func (jf *JobsForwarder) Start() error {
 					if ctx.Err() != nil { // we are shutting down
 						return nil //nolint:nilerr
 					}
-					jf.terminalErrFn(err) // we are signaling to shutdown the app
+					jf.terminalErrFn(err) // we are signaling to shut down the app
 					return err
 				}
 				var mu sync.Mutex // protects statuses and toRetry
@@ -123,7 +123,7 @@ func (jf *JobsForwarder) Start() error {
 				for _, messageBatch := range messageBatches {
 					if !bytes.Equal(messageBatch.Message.Sample, []byte("{}")) && // if the sample is not an empty json object (redacted) and
 						(len(messageBatch.Message.Sample) > int(jf.maxSampleSize.Load()) || // sample is too big or
-							!jf.sampler.Sample(messageBatch.Message.Key.String())) { // sample should be skipped
+							!jf.sampler.Sample(messageBatch.Message.Key.String()+messageBatch.Message.Hash)) { // sample should be skipped
 						messageBatch.Message.Sample = nil // by setting to sample to nil we are instructing the schema worker to keep the previous sample
 					}
 				}


### PR DESCRIPTION
# Description

Sampling events at EventSchemaVersion level to populate more samples in the `schema_version` table

## Linear Ticket

[ Linear Link ](https://linear.app/rudderstack/issue/PIPE-343/fix-empty-sample-event-bug-in-schema-version-table)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
