### PR TITLE
feat: report failed messages in processor, router and batchrouter

### DIFF
--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -192,7 +192,9 @@ func (edr *ErrorDetailReporter) DatabaseSyncer(c types.SyncerConfig) types.Repor
 	edr.syncers[c.ConnInfo] = &types.SyncSource{SyncerConfig: c, DbHandle: dbHandle}
 
 	return func() {
-		edr.mainLoop(edr.ctx, c)
+		if config.GetBool("Reporting.errorReporting.syncer.enabled", true) {
+			edr.mainLoop(edr.ctx, c)
+		}
 	}
 }
 

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -191,10 +191,12 @@ func (edr *ErrorDetailReporter) DatabaseSyncer(c types.SyncerConfig) types.Repor
 	}
 	edr.syncers[c.ConnInfo] = &types.SyncSource{SyncerConfig: c, DbHandle: dbHandle}
 
+	if !config.GetBool("Reporting.errorReporting.syncer.enabled", true) {
+		return func() {}
+	}
+
 	return func() {
-		if config.GetBool("Reporting.errorReporting.syncer.enabled", true) {
-			edr.mainLoop(edr.ctx, c)
-		}
+		edr.mainLoop(edr.ctx, c)
 	}
 }
 

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -187,10 +187,11 @@ func (r *DefaultReporter) DatabaseSyncer(c types.SyncerConfig) types.ReportingSy
 	}
 	r.syncers[c.ConnInfo] = &types.SyncSource{SyncerConfig: c, DbHandle: dbHandle}
 
+	if !config.GetBool("Reporting.syncer.enabled", true) {
+		return func() {}
+	}
 	return func() {
-		if config.GetBool("Reporting.syncer.enabled", true) {
-			r.mainLoop(r.ctx, c)
-		}
+		r.mainLoop(r.ctx, c)
 	}
 }
 

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -188,7 +188,9 @@ func (r *DefaultReporter) DatabaseSyncer(c types.SyncerConfig) types.ReportingSy
 	r.syncers[c.ConnInfo] = &types.SyncSource{SyncerConfig: c, DbHandle: dbHandle}
 
 	return func() {
-		r.mainLoop(r.ctx, c)
+		if config.GetBool("Reporting.syncer.enabled", true) {
+			r.mainLoop(r.ctx, c)
+		}
 	}
 }
 

--- a/integration_test/reporting_dropped_events/reporting_dropped_events_test.go
+++ b/integration_test/reporting_dropped_events/reporting_dropped_events_test.go
@@ -1,0 +1,634 @@
+package reportingfailedmessages_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
+	"github.com/rudderlabs/rudder-go-kit/sqlutil"
+	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+	"github.com/rudderlabs/rudder-server/processor/transformer"
+	"github.com/rudderlabs/rudder-server/runner"
+	"github.com/rudderlabs/rudder-server/testhelper/backendconfigtest"
+	"github.com/rudderlabs/rudder-server/testhelper/health"
+	"github.com/rudderlabs/rudder-server/testhelper/transformertest"
+)
+
+func TestReportingDroppedEvents(t *testing.T) {
+	// FIXME: destination filter should drop events using a [filtered] status instead of a [diff] status with negative count
+	t.Run("Events dropped in destination filter stage", func(t *testing.T) {
+		config.Reset()
+		defer config.Reset()
+
+		bcserver := backendconfigtest.NewBuilder().
+			WithWorkspaceConfig(
+				backendconfigtest.NewConfigBuilder().
+					WithSource(
+						backendconfigtest.NewSourceBuilder().
+							WithID("source-1").
+							WithWriteKey("writekey-1").
+							Build()).
+					Build()).
+			Build()
+		defer bcserver.Close()
+
+		trServer := transformertest.NewBuilder().Build()
+		defer trServer.Close()
+
+		pool, err := dockertest.NewPool("")
+		require.NoError(t, err)
+		postgresContainer, err := resource.SetupPostgres(pool, t)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		wg, ctx := errgroup.WithContext(ctx)
+		gwPort, err := kithelper.GetFreePort()
+		require.NoError(t, err)
+		wg.Go(func() error {
+			err := runRudderServer(ctx, gwPort, postgresContainer, bcserver.URL, trServer.URL, t.TempDir())
+			if err != nil {
+				t.Logf("rudder-server exited with error: %v", err)
+			}
+			return err
+		})
+		url := fmt.Sprintf("http://localhost:%d", gwPort)
+		health.WaitUntilReady(ctx, t, url+"/health", 60*time.Second, 10*time.Millisecond, t.Name())
+		err = sendEvents(10, "identify", "writekey-1", url)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			var jobsCount int
+			require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('gw',1) WHERE job_state = 'succeeded'").Scan(&jobsCount))
+			t.Logf("gw processedJobCount: %d", jobsCount)
+			return jobsCount == 10
+		}, 20*time.Second, 1*time.Second, "all gw events should be successfully processed")
+
+		require.Eventually(t, func() bool {
+			var droppedCount sql.NullInt64
+			require.NoError(t, postgresContainer.DB.QueryRow("SELECT sum(count) FROM reports WHERE source_id = 'source-1' and destination_id = '' AND pu = 'destination_filter' and status = 'diff' and error_type = ''").Scan(&droppedCount))
+			t.Logf("destination_filter diff count: %d", droppedCount.Int64)
+			logRows(t, postgresContainer.DB, "SELECT * FROM reports")
+			return droppedCount.Int64 == -10
+		}, 10*time.Second, 1*time.Second, "all events should be dropped in destination_filter stage")
+
+		cancel()
+		_ = wg.Wait()
+	})
+
+	t.Run("Events dropped in tracking plan validation stage", func(t *testing.T) {
+		config.Reset()
+		defer config.Reset()
+
+		bcserver := backendconfigtest.NewBuilder().
+			WithWorkspaceConfig(
+				backendconfigtest.NewConfigBuilder().
+					WithSource(
+						backendconfigtest.NewSourceBuilder().
+							WithID("source-1").
+							WithWriteKey("writekey-1").
+							WithTrackingPlan("trackingplan-1", 1).
+							WithConnection(
+								backendconfigtest.NewDestinationBuilder("WEBHOOK").
+									WithID("destination-1").
+									Build()).
+							Build()).
+					Build()).
+			Build()
+		defer bcserver.Close()
+
+		trServer := transformertest.NewBuilder().
+			WithTrackingPlanHandler(
+				transformertest.ViolationErrorTransformerHandler(
+					http.StatusBadRequest,
+					"tracking plan validation failed",
+					[]transformer.ValidationError{{Type: "Datatype-Mismatch", Message: "must be number"}},
+				),
+			).
+			Build()
+		defer trServer.Close()
+
+		pool, err := dockertest.NewPool("")
+		require.NoError(t, err)
+		postgresContainer, err := resource.SetupPostgres(pool, t)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		wg, ctx := errgroup.WithContext(ctx)
+		gwPort, err := kithelper.GetFreePort()
+		require.NoError(t, err)
+		wg.Go(func() error {
+			err := runRudderServer(ctx, gwPort, postgresContainer, bcserver.URL, trServer.URL, t.TempDir())
+			if err != nil {
+				t.Logf("rudder-server exited with error: %v", err)
+			}
+			return err
+		})
+		url := fmt.Sprintf("http://localhost:%d", gwPort)
+		health.WaitUntilReady(ctx, t, url+"/health", 60*time.Second, 10*time.Millisecond, t.Name())
+		err = sendEvents(10, "identify", "writekey-1", url)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			var jobsCount int
+			require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('gw',1) WHERE job_state = 'succeeded'").Scan(&jobsCount))
+			t.Logf("gw processedJobCount: %d", jobsCount)
+			return jobsCount == 10
+		}, 20*time.Second, 1*time.Second, "all gw events should be successfully processed")
+
+		require.Eventually(t, func() bool {
+			var droppedCount sql.NullInt64
+			require.NoError(t, postgresContainer.DB.QueryRow("SELECT sum(count) FROM reports WHERE source_id = 'source-1' and destination_id = '' AND pu = 'tracking_plan_validator' and status = 'aborted' and error_type = ''").Scan(&droppedCount))
+			t.Logf("tracking_plan_validator aborted count: %d", droppedCount.Int64)
+			logRows(t, postgresContainer.DB, "SELECT * FROM reports")
+			return droppedCount.Int64 == 10
+		}, 10*time.Second, 1*time.Second, "all events should be aborted in tracking_plan_validator stage")
+
+		cancel()
+		_ = wg.Wait()
+	})
+
+	// TODO: revisit user transformation [diff] metrics?
+	t.Run("Events dropped in user transformation stage", func(t *testing.T) {
+		t.Run("user transformer function returns an null event", func(t *testing.T) {
+			config.Reset()
+			defer config.Reset()
+
+			bcserver := backendconfigtest.NewBuilder().
+				WithWorkspaceConfig(
+					backendconfigtest.NewConfigBuilder().
+						WithSource(
+							backendconfigtest.NewSourceBuilder().
+								WithID("source-1").
+								WithWriteKey("writekey-1").
+								WithConnection(
+									backendconfigtest.NewDestinationBuilder("WEBHOOK").
+										WithID("destination-1").
+										WithUserTransformation("transformation-1", "version-1").
+										Build()).
+								Build()).
+						Build()).
+				Build()
+			defer bcserver.Close()
+
+			trServer := transformertest.NewBuilder().
+				WithUserTransformHandler(transformertest.EmptyTransformerHandler).
+				Build()
+			defer trServer.Close()
+
+			pool, err := dockertest.NewPool("")
+			require.NoError(t, err)
+			postgresContainer, err := resource.SetupPostgres(pool, t)
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			wg, ctx := errgroup.WithContext(ctx)
+			gwPort, err := kithelper.GetFreePort()
+			require.NoError(t, err)
+			wg.Go(func() error {
+				err := runRudderServer(ctx, gwPort, postgresContainer, bcserver.URL, trServer.URL, t.TempDir())
+				if err != nil {
+					t.Logf("rudder-server exited with error: %v", err)
+				}
+				return err
+			})
+			url := fmt.Sprintf("http://localhost:%d", gwPort)
+			health.WaitUntilReady(ctx, t, url+"/health", 60*time.Second, 10*time.Millisecond, t.Name())
+			err = sendEvents(10, "identify", "writekey-1", url)
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				var jobsCount int
+				require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('gw',1) WHERE job_state = 'succeeded'").Scan(&jobsCount))
+				t.Logf("gw processedJobCount: %d", jobsCount)
+				return jobsCount == 10
+			}, 20*time.Second, 1*time.Second, "all gw events should be successfully processed")
+
+			require.Eventually(t, func() bool {
+				var droppedCount sql.NullInt64
+				require.NoError(t, postgresContainer.DB.QueryRow("SELECT sum(count) FROM reports WHERE source_id = 'source-1' and destination_id = 'destination-1' AND pu = 'user_transformer' and status = 'diff' and error_type = ''").Scan(&droppedCount))
+				t.Logf("user_transformer aborted/diff count: %d", droppedCount.Int64)
+				logRows(t, postgresContainer.DB, "SELECT * FROM reports")
+				return droppedCount.Int64 == -10
+			}, 10*time.Second, 1*time.Second, "all events should be aborted in user_transformer stage")
+
+			cancel()
+			_ = wg.Wait()
+		})
+	})
+
+	t.Run("Events dropped in event filtering stage", func(t *testing.T) {
+		t.Run("unsupported message type", func(t *testing.T) {
+			config.Reset()
+			defer config.Reset()
+
+			bcserver := backendconfigtest.NewBuilder().
+				WithWorkspaceConfig(
+					backendconfigtest.NewConfigBuilder().
+						WithSource(
+							backendconfigtest.NewSourceBuilder().
+								WithID("source-1").
+								WithWriteKey("writekey-1").
+								WithConnection(
+									backendconfigtest.NewDestinationBuilder("WEBHOOK").
+										WithID("destination-1").
+										WithDefinitionConfigOption("supportedMessageTypes", []string{"track"}).
+										Build()).
+								Build()).
+						Build()).
+				Build()
+			defer bcserver.Close()
+
+			trServer := transformertest.NewBuilder().
+				WithUserTransformHandler(transformertest.EmptyTransformerHandler).
+				Build()
+			defer trServer.Close()
+
+			pool, err := dockertest.NewPool("")
+			require.NoError(t, err)
+			postgresContainer, err := resource.SetupPostgres(pool, t)
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			wg, ctx := errgroup.WithContext(ctx)
+			gwPort, err := kithelper.GetFreePort()
+			require.NoError(t, err)
+			wg.Go(func() error {
+				err := runRudderServer(ctx, gwPort, postgresContainer, bcserver.URL, trServer.URL, t.TempDir())
+				if err != nil {
+					t.Logf("rudder-server exited with error: %v", err)
+				}
+				return err
+			})
+			url := fmt.Sprintf("http://localhost:%d", gwPort)
+			health.WaitUntilReady(ctx, t, url+"/health", 60*time.Second, 10*time.Millisecond, t.Name())
+			err = sendEvents(10, "identify", "writekey-1", url)
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				var jobsCount int
+				require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('gw',1) WHERE job_state = 'succeeded'").Scan(&jobsCount))
+				t.Logf("gw processedJobCount: %d", jobsCount)
+				return jobsCount == 10
+			}, 20*time.Second, 1*time.Second, "all gw events should be successfully processed")
+
+			require.Eventually(t, func() bool {
+				var droppedCount sql.NullInt64
+				require.NoError(t, postgresContainer.DB.QueryRow("SELECT sum(count) FROM reports WHERE source_id = 'source-1' and destination_id = 'destination-1' AND pu = 'event_filter' and status = 'filtered' and error_type = ''").Scan(&droppedCount))
+				t.Logf("event_filter filtered count: %d", droppedCount.Int64)
+				logRows(t, postgresContainer.DB, "SELECT * FROM reports")
+				return droppedCount.Int64 == 10
+			}, 10*time.Second, 1*time.Second, "all events should be filtered in event_filter stage")
+
+			cancel()
+			_ = wg.Wait()
+		})
+	})
+
+	t.Run("Events dropped in destination transformation stage", func(t *testing.T) {
+		config.Reset()
+		defer config.Reset()
+
+		bcserver := backendconfigtest.NewBuilder().
+			WithWorkspaceConfig(
+				backendconfigtest.NewConfigBuilder().
+					WithSource(
+						backendconfigtest.NewSourceBuilder().
+							WithID("source-1").
+							WithWriteKey("writekey-1").
+							WithConnection(
+								backendconfigtest.NewDestinationBuilder("WEBHOOK").
+									WithID("destination-1").
+									Build()).
+							Build()).
+					Build()).
+			Build()
+		defer bcserver.Close()
+
+		trServer := transformertest.NewBuilder().
+			WithDestTransformHandler(
+				"WEBHOOK",
+				transformertest.ErrorTransformerHandler(http.StatusBadRequest, "dest transformation failed"),
+			).
+			Build()
+		defer trServer.Close()
+
+		pool, err := dockertest.NewPool("")
+		require.NoError(t, err)
+		postgresContainer, err := resource.SetupPostgres(pool, t)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		wg, ctx := errgroup.WithContext(ctx)
+		gwPort, err := kithelper.GetFreePort()
+		require.NoError(t, err)
+		wg.Go(func() error {
+			err := runRudderServer(ctx, gwPort, postgresContainer, bcserver.URL, trServer.URL, t.TempDir())
+			if err != nil {
+				t.Logf("rudder-server exited with error: %v", err)
+			}
+			return err
+		})
+		url := fmt.Sprintf("http://localhost:%d", gwPort)
+		health.WaitUntilReady(ctx, t, url+"/health", 60*time.Second, 10*time.Millisecond, t.Name())
+		err = sendEvents(10, "identify", "writekey-1", url)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			var jobsCount int
+			require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('gw',1) WHERE job_state = 'succeeded'").Scan(&jobsCount))
+			t.Logf("gw processedJobCount: %d", jobsCount)
+			return jobsCount == 10
+		}, 20*time.Second, 1*time.Second, "all gw events should be successfully processed")
+
+		require.Eventually(t, func() bool {
+			var droppedCount sql.NullInt64
+			require.NoError(t, postgresContainer.DB.QueryRow("SELECT sum(count) FROM reports WHERE source_id = 'source-1' and destination_id = 'destination-1' AND pu = 'dest_transformer' and status = 'aborted' and error_type = ''").Scan(&droppedCount))
+			t.Logf("tracking_plan_validator aborted count: %d", droppedCount.Int64)
+			logRows(t, postgresContainer.DB, "SELECT * FROM reports")
+			return droppedCount.Int64 == 10
+		}, 10*time.Second, 1*time.Second, "all events should be aborted in dest_transformer stage")
+
+		cancel()
+		_ = wg.Wait()
+	})
+
+	t.Run("Events dropped in router delivery stage", func(t *testing.T) {
+		t.Run("rejected by destination itself", func(t *testing.T) {
+			config.Reset()
+			defer config.Reset()
+
+			bcserver := backendconfigtest.NewBuilder().
+				WithWorkspaceConfig(
+					backendconfigtest.NewConfigBuilder().
+						WithSource(
+							backendconfigtest.NewSourceBuilder().
+								WithID("source-1").
+								WithWriteKey("writekey-1").
+								WithConnection(
+									backendconfigtest.NewDestinationBuilder("WEBHOOK").
+										WithID("destination-1").
+										Build()).
+								Build()).
+						Build()).
+				Build()
+			defer bcserver.Close()
+
+			webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "aborted", http.StatusBadRequest)
+			}))
+			defer webhook.Close()
+
+			trServer := transformertest.NewBuilder().
+				WithDestTransformHandler(
+					"WEBHOOK",
+					transformertest.RESTJSONDestTransformerHandler(http.MethodPost, webhook.URL),
+				).
+				Build()
+			defer trServer.Close()
+
+			pool, err := dockertest.NewPool("")
+			require.NoError(t, err)
+			postgresContainer, err := resource.SetupPostgres(pool, t)
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			wg, ctx := errgroup.WithContext(ctx)
+			gwPort, err := kithelper.GetFreePort()
+			require.NoError(t, err)
+			wg.Go(func() error {
+				err := runRudderServer(ctx, gwPort, postgresContainer, bcserver.URL, trServer.URL, t.TempDir())
+				if err != nil {
+					t.Logf("rudder-server exited with error: %v", err)
+				}
+				return err
+			})
+			url := fmt.Sprintf("http://localhost:%d", gwPort)
+			health.WaitUntilReady(ctx, t, url+"/health", 60*time.Second, 10*time.Millisecond, t.Name())
+			err = sendEvents(10, "identify", "writekey-1", url)
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				var jobsCount int
+				require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('gw',1) WHERE job_state = 'succeeded'").Scan(&jobsCount))
+				t.Logf("gw processedJobCount: %d", jobsCount)
+				return jobsCount == 10
+			}, 20*time.Second, 1*time.Second, "all gw events should be successfully processed")
+
+			require.Eventually(t, func() bool {
+				var jobsCount int
+				require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('rt',1) WHERE job_state = 'aborted'").Scan(&jobsCount))
+				t.Logf("rt abortedJobCount: %d", jobsCount)
+				return jobsCount == 10
+			}, 20*time.Second, 1*time.Second, "all events should be aborted in router")
+
+			require.Eventually(t, func() bool {
+				var droppedCount sql.NullInt64
+				require.NoError(t, postgresContainer.DB.QueryRow("SELECT sum(count) FROM reports WHERE source_id = 'source-1' and destination_id = 'destination-1' AND pu = 'router' and status = 'aborted' and error_type = ''").Scan(&droppedCount))
+				t.Logf("router aborted count: %d", droppedCount.Int64)
+				logRows(t, postgresContainer.DB, "SELECT * FROM reports")
+				return droppedCount.Int64 == 10
+			}, 10*time.Second, 1*time.Second, "all events should be aborted in router stage")
+
+			cancel()
+			_ = wg.Wait()
+		})
+	})
+
+	t.Run("Events dropped in batch router delivery stage", func(t *testing.T) {
+		t.Run("destination id included in BatchRouter.toAbortDestinationIDs", func(t *testing.T) {
+			config.Reset()
+			defer config.Reset()
+
+			bcserver := backendconfigtest.NewBuilder().
+				WithWorkspaceConfig(
+					backendconfigtest.NewConfigBuilder().
+						WithSource(
+							backendconfigtest.NewSourceBuilder().
+								WithID("source-1").
+								WithWriteKey("writekey-1").
+								WithConnection(
+									backendconfigtest.NewDestinationBuilder("S3").
+										WithID("destination-1").
+										Build()).
+								Build()).
+						Build()).
+				Build()
+			defer bcserver.Close()
+
+			webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "aborted", http.StatusBadRequest)
+			}))
+			defer webhook.Close()
+
+			trServer := transformertest.NewBuilder().
+				WithDestTransformHandler(
+					"S3",
+					transformertest.MirroringTransformerHandler,
+				).
+				Build()
+			defer trServer.Close()
+
+			pool, err := dockertest.NewPool("")
+			require.NoError(t, err)
+			postgresContainer, err := resource.SetupPostgres(pool, t)
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			wg, ctx := errgroup.WithContext(ctx)
+			gwPort, err := kithelper.GetFreePort()
+			require.NoError(t, err)
+			wg.Go(func() error {
+				config.Set("BatchRouter.toAbortDestinationIDs", "destination-1")
+				err := runRudderServer(ctx, gwPort, postgresContainer, bcserver.URL, trServer.URL, t.TempDir())
+				if err != nil {
+					t.Logf("rudder-server exited with error: %v", err)
+				}
+				return err
+			})
+			url := fmt.Sprintf("http://localhost:%d", gwPort)
+			health.WaitUntilReady(ctx, t, url+"/health", 60*time.Second, 10*time.Millisecond, t.Name())
+			err = sendEvents(10, "identify", "writekey-1", url)
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				var jobsCount int
+				require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('gw',1) WHERE job_state = 'succeeded'").Scan(&jobsCount))
+				t.Logf("gw processedJobCount: %d", jobsCount)
+				return jobsCount == 10
+			}, 20*time.Second, 1*time.Second, "all gw events should be successfully processed")
+
+			require.Eventually(t, func() bool {
+				var jobsCount int
+				require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('batch_rt',1) WHERE job_state = 'aborted'").Scan(&jobsCount))
+				t.Logf("batch_rt abortedJobCount: %d", jobsCount)
+				return jobsCount == 10
+			}, 20*time.Second, 1*time.Second, "all events should be aborted in batch router")
+
+			require.Eventually(t, func() bool {
+				var droppedCount sql.NullInt64
+				require.NoError(t, postgresContainer.DB.QueryRow("SELECT sum(count) FROM reports WHERE source_id = 'source-1' and destination_id = 'destination-1' AND pu = 'batch_router' and status = 'aborted' and error_type = ''").Scan(&droppedCount))
+				t.Logf("batch router aborted count: %d", droppedCount.Int64)
+				logRows(t, postgresContainer.DB, "SELECT * FROM reports")
+				return droppedCount.Int64 == 10
+			}, 10*time.Second, 1*time.Second, "all events should be aborted in batch_router stage")
+
+			cancel()
+			_ = wg.Wait()
+		})
+	})
+}
+
+func runRudderServer(ctx context.Context, port int, postgresContainer *resource.PostgresResource, cbURL, transformerURL, tmpDir string) (err error) {
+	config.Set("CONFIG_BACKEND_URL", cbURL)
+	config.Set("WORKSPACE_TOKEN", "token")
+	config.Set("DB.port", postgresContainer.Port)
+	config.Set("DB.user", postgresContainer.User)
+	config.Set("DB.name", postgresContainer.Database)
+	config.Set("DB.password", postgresContainer.Password)
+	config.Set("DEST_TRANSFORM_URL", transformerURL)
+
+	config.Set("Warehouse.mode", "off")
+	config.Set("DestinationDebugger.disableEventDeliveryStatusUploads", true)
+	config.Set("SourceDebugger.disableEventUploads", true)
+	config.Set("TransformationDebugger.disableTransformationStatusUploads", true)
+	config.Set("JobsDB.backup.enabled", false)
+	config.Set("JobsDB.migrateDSLoopSleepDuration", "60m")
+	config.Set("archival.Enabled", false)
+	config.Set("Reporting.syncer.enabled", false)
+	config.Set("BatchRouter.mainLoopFreq", "1s")
+	config.Set("BatchRouter.uploadFreq", "1s")
+	config.Set("Gateway.webPort", strconv.Itoa(port))
+	config.Set("RUDDER_TMPDIR", os.TempDir())
+	config.Set("recovery.storagePath", path.Join(tmpDir, "/recovery_data.json"))
+	config.Set("recovery.enabled", false)
+	config.Set("Profiler.Enabled", false)
+	config.Set("Gateway.enableSuppressUserFeature", false)
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panicked: %v", r)
+		}
+	}()
+	r := runner.New(runner.ReleaseInfo{EnterpriseToken: "TOKEN"})
+	c := r.Run(ctx, []string{"proc-isolation-test-rudder-server"})
+	if c != 0 {
+		err = fmt.Errorf("rudder-server exited with a non-0 exit code: %d", c)
+	}
+	return
+}
+
+func sendEvents(num int, eventType, writeKey, url string) error { // nolint:unparam
+	for i := 0; i < num; i++ {
+		payload := []byte(fmt.Sprintf(`{"batch": [{
+			"userId": %[1]q,
+			"type": %[2]q,
+			"context":
+			{
+				"traits":
+				{
+					"trait1": "new-val"
+				},
+				"ip": "14.5.67.21",
+				"library":
+				{
+					"name": "http"
+				}
+			},
+			"timestamp": "2020-02-02T00:23:09.544Z"
+			}]}`,
+			rand.String(10),
+			eventType))
+		req, err := http.NewRequest("POST", url+"/v1/batch", bytes.NewReader(payload))
+		if err != nil {
+			return err
+		}
+		req.SetBasicAuth(writeKey, "password")
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("failed to send event to rudder server, status code: %d: %s", resp.StatusCode, string(b))
+		}
+		func() { kithttputil.CloseResponse(resp) }()
+	}
+
+	return nil
+}
+
+func logRows(t *testing.T, db *sql.DB, query string) { // nolint:unparam
+	rows, err := db.Query(query) // nolint:rowserrcheck
+	defer func() { _ = rows.Close() }()
+	if err != nil {
+		var b strings.Builder
+		_ = sqlutil.PrintRowsToTable(rows, &b)
+		t.Log(b.String())
+	}
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -988,21 +988,23 @@ func (proc *Handle) getDestTransformerEvents(response transformer.Response, comm
 		)
 
 		for _, message := range messages {
-			proc.updateMetricMaps(successCountMetadataMap, successCountMap, connectionDetailsMap, statusDetailsMap, userTransformedEvent, jobsdb.Succeeded.State, stage, func() json.RawMessage {
-				if stage != transformer.TrackingPlanValidationStage {
-					return []byte(`{}`)
-				}
-				if proc.transientSources.Apply(commonMetaData.SourceID) {
-					return []byte(`{}`)
-				}
+			proc.updateMetricMaps(successCountMetadataMap, successCountMap, connectionDetailsMap, statusDetailsMap, userTransformedEvent, jobsdb.Succeeded.State, stage,
+				func() json.RawMessage {
+					if stage != transformer.TrackingPlanValidationStage {
+						return []byte(`{}`)
+					}
+					if proc.transientSources.Apply(commonMetaData.SourceID) {
+						return []byte(`{}`)
+					}
 
-				sampleEvent, err := jsonfast.Marshal(message)
-				if err != nil {
-					proc.logger.Errorf(`[Processor: getDestTransformerEvents] Failed to unmarshal first element in transformed events: %v`, err)
-					sampleEvent = []byte(`{}`)
-				}
-				return sampleEvent
-			})
+					sampleEvent, err := jsonfast.Marshal(message)
+					if err != nil {
+						proc.logger.Errorf(`[Processor: getDestTransformerEvents] Failed to unmarshal first element in transformed events: %v`, err)
+						sampleEvent = []byte(`{}`)
+					}
+					return sampleEvent
+				},
+				nil)
 		}
 
 		eventMetadata := commonMetaData
@@ -1080,116 +1082,118 @@ func (proc *Handle) updateMetricMaps(
 	event *transformer.TransformerResponse,
 	status, stage string,
 	payload func() json.RawMessage,
+	eventsByMessageID map[string]types.SingularEventWithReceivedAt,
 ) {
-	if proc.isReportingEnabled() {
-		var eventName string
-		var eventType string
-		eventName = event.Metadata.EventName
-		eventType = event.Metadata.EventType
+	if !proc.isReportingEnabled() {
+		return
+	}
+	incrementCount := int64(len(event.Metadata.GetMessagesIDs()))
+	eventName := event.Metadata.EventName
+	eventType := event.Metadata.EventType
+	countKey := strings.Join([]string{
+		event.Metadata.SourceID,
+		event.Metadata.DestinationID,
+		event.Metadata.SourceJobRunID,
+		eventName,
+		eventType,
+	}, MetricKeyDelimiter)
 
-		countKey := strings.Join([]string{
-			event.Metadata.SourceID,
-			event.Metadata.DestinationID,
-			event.Metadata.SourceJobRunID,
-			eventName,
-			eventType,
-		}, MetricKeyDelimiter)
+	countMap[countKey] = countMap[countKey] + 1
 
-		if _, ok := countMap[countKey]; !ok {
-			countMap[countKey] = 0
-		}
-		countMap[countKey] = countMap[countKey] + 1
-
-		if countMetadataMap != nil {
-			if _, ok := countMetadataMap[countKey]; !ok {
-				countMetadataMap[countKey] = MetricMetadata{
-					sourceID:                event.Metadata.SourceID,
-					destinationID:           event.Metadata.DestinationID,
-					sourceTaskRunID:         event.Metadata.SourceTaskRunID,
-					sourceJobID:             event.Metadata.SourceJobID,
-					sourceJobRunID:          event.Metadata.SourceJobRunID,
-					sourceDefinitionID:      event.Metadata.SourceDefinitionID,
-					destinationDefinitionID: event.Metadata.DestinationDefinitionID,
-					sourceCategory:          event.Metadata.SourceCategory,
-					transformationID:        event.Metadata.TransformationID,
-					transformationVersionID: event.Metadata.TransformationVersionID,
-					trackingPlanID:          event.Metadata.TrackingPlanId,
-					trackingPlanVersion:     event.Metadata.TrackingPlanVersion,
-				}
+	if countMetadataMap != nil {
+		if _, ok := countMetadataMap[countKey]; !ok {
+			countMetadataMap[countKey] = MetricMetadata{
+				sourceID:                event.Metadata.SourceID,
+				destinationID:           event.Metadata.DestinationID,
+				sourceTaskRunID:         event.Metadata.SourceTaskRunID,
+				sourceJobID:             event.Metadata.SourceJobID,
+				sourceJobRunID:          event.Metadata.SourceJobRunID,
+				sourceDefinitionID:      event.Metadata.SourceDefinitionID,
+				destinationDefinitionID: event.Metadata.DestinationDefinitionID,
+				sourceCategory:          event.Metadata.SourceCategory,
+				transformationID:        event.Metadata.TransformationID,
+				transformationVersionID: event.Metadata.TransformationVersionID,
+				trackingPlanID:          event.Metadata.TrackingPlanId,
+				trackingPlanVersion:     event.Metadata.TrackingPlanVersion,
 			}
 		}
+	}
 
-		key := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%d:%s:%d:%s:%s",
+	key := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%d:%s:%d:%s:%s",
+		event.Metadata.SourceID,
+		event.Metadata.DestinationID,
+		event.Metadata.SourceJobRunID,
+		event.Metadata.TransformationID,
+		event.Metadata.TransformationVersionID,
+		event.Metadata.TrackingPlanId,
+		event.Metadata.TrackingPlanVersion,
+		status, event.StatusCode,
+		eventName, eventType,
+	)
+
+	if _, ok := connectionDetailsMap[key]; !ok {
+		connectionDetailsMap[key] = types.CreateConnectionDetail(
 			event.Metadata.SourceID,
 			event.Metadata.DestinationID,
+			event.Metadata.SourceTaskRunID,
+			event.Metadata.SourceJobID,
 			event.Metadata.SourceJobRunID,
+			event.Metadata.SourceDefinitionID,
+			event.Metadata.DestinationDefinitionID,
+			event.Metadata.SourceCategory,
 			event.Metadata.TransformationID,
 			event.Metadata.TransformationVersionID,
 			event.Metadata.TrackingPlanId,
 			event.Metadata.TrackingPlanVersion,
-			status, event.StatusCode,
-			eventName, eventType,
 		)
+	}
 
-		_, ok := connectionDetailsMap[key]
-		if !ok {
-			cd := types.CreateConnectionDetail(
-				event.Metadata.SourceID,
-				event.Metadata.DestinationID,
-				event.Metadata.SourceTaskRunID,
-				event.Metadata.SourceJobID,
-				event.Metadata.SourceJobRunID,
-				event.Metadata.SourceDefinitionID,
-				event.Metadata.DestinationDefinitionID,
-				event.Metadata.SourceCategory,
-				event.Metadata.TransformationID,
-				event.Metadata.TransformationVersionID,
-				event.Metadata.TrackingPlanId,
-				event.Metadata.TrackingPlanVersion,
-			)
-			connectionDetailsMap[key] = cd
+	if _, ok := statusDetailsMap[key]; !ok {
+		statusDetailsMap[key] = make(map[string]*types.StatusDetail)
+	}
+	// create status details for each validation error
+	// single event can have multiple validation errors of same type
+	veCount := len(event.ValidationErrors)
+	if stage == transformer.TrackingPlanValidationStage && status == jobsdb.Succeeded.State {
+		if veCount > 0 {
+			status = types.SUCCEEDED_WITH_VIOLATIONS
+		} else {
+			status = types.SUCCEEDED_WITHOUT_VIOLATIONS
 		}
+	}
+	sdkeySet := map[string]struct{}{}
+	for _, ve := range event.ValidationErrors {
+		sdkey := fmt.Sprintf("%s:%d:%s:%s:%s", status, event.StatusCode, eventName, eventType, ve.Type)
+		sdkeySet[sdkey] = struct{}{}
 
-		if _, ok := statusDetailsMap[key]; !ok {
-			statusDetailsMap[key] = make(map[string]*types.StatusDetail)
-		}
-		// create status details for each validation error
-		// single event can have multiple validation errors of same type
-		veCount := len(event.ValidationErrors)
-		if stage == transformer.TrackingPlanValidationStage && status == jobsdb.Succeeded.State {
-			if veCount > 0 {
-				status = types.SUCCEEDED_WITH_VIOLATIONS
-			} else {
-				status = types.SUCCEEDED_WITHOUT_VIOLATIONS
-			}
-		}
-		sdkeySet := map[string]struct{}{}
-		for _, ve := range event.ValidationErrors {
-			sdkey := fmt.Sprintf("%s:%d:%s:%s:%s",
-				status, event.StatusCode, eventName, eventType, ve.Type)
-			sdkeySet[sdkey] = struct{}{}
-
-			sd, ok := statusDetailsMap[key][sdkey]
-			if !ok {
-				sd = types.CreateStatusDetail(status, 0, 0, event.StatusCode, event.Error, payload(), eventName, eventType, ve.Type)
-				statusDetailsMap[key][sdkey] = sd
-			}
-			sd.ViolationCount++
-		}
-		for k := range sdkeySet {
-			statusDetailsMap[key][k].Count++
-		}
-
-		// create status details for a whole event
-		sdkey := fmt.Sprintf("%s:%d:%s:%s:%s", status, event.StatusCode, eventName, eventType, "")
 		sd, ok := statusDetailsMap[key][sdkey]
 		if !ok {
-			sd = types.CreateStatusDetail(status, 0, 0, event.StatusCode, event.Error, payload(), eventName, eventType, "")
+			sd = types.CreateStatusDetail(status, 0, 0, event.StatusCode, event.Error, payload(), eventName, eventType, ve.Type)
 			statusDetailsMap[key][sdkey] = sd
 		}
-		sd.Count++
-		sd.ViolationCount += int64(veCount)
+		sd.ViolationCount += incrementCount
 	}
+	for k := range sdkeySet {
+		statusDetailsMap[key][k].Count += incrementCount
+	}
+
+	// create status details for a whole event
+	sdkey := fmt.Sprintf("%s:%d:%s:%s:%s", status, event.StatusCode, eventName, eventType, "")
+	sd, ok := statusDetailsMap[key][sdkey]
+	if !ok {
+		sd = types.CreateStatusDetail(status, 0, 0, event.StatusCode, event.Error, payload(), eventName, eventType, "")
+		statusDetailsMap[key][sdkey] = sd
+	}
+
+	sd.Count += incrementCount
+	if status == jobsdb.Aborted.State {
+		messageIDs := lo.Uniq(event.Metadata.GetMessagesIDs()) // this is called defensive programming... :(
+		for _, messageID := range messageIDs {
+			receivedAt := eventsByMessageID[messageID].ReceivedAt
+			sd.FailedMessages = append(sd.FailedMessages, &types.FailedMessage{MessageID: messageID, ReceivedAt: receivedAt})
+		}
+	}
+	sd.ViolationCount += int64(veCount)
 }
 
 func (proc *Handle) getNonSuccessfulMetrics(response transformer.Response, commonMetaData *transformer.Metadata, eventsByMessageID map[string]types.SingularEventWithReceivedAt, stage string, transformationEnabled, trackingPlanEnabled bool) *NonSuccessfulTransformationMetrics {
@@ -1235,7 +1239,8 @@ func (proc *Handle) getTransformationMetrics(transformerResponses []transformer.
 					sampleEvent = []byte(`{}`)
 				}
 				return sampleEvent
-			})
+			},
+				eventsByMessageID)
 		}
 
 		proc.logger.Debugf(
@@ -1254,8 +1259,7 @@ func (proc *Handle) getTransformationMetrics(transformerResponses []transformer.
 			"record_id":          failedEvent.Metadata.RecordID,
 			"source_task_run_id": failedEvent.Metadata.SourceTaskRunID,
 		}
-		eventContext, castOk := failedEvent.Output["context"].(map[string]interface{})
-		if castOk {
+		if eventContext, castOk := failedEvent.Output["context"].(map[string]interface{}); castOk {
 			params["violationErrors"] = eventContext["violationErrors"]
 		}
 		marshalledParams, err := jsonfast.Marshal(params)
@@ -1586,6 +1590,7 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 						}
 						return []byte("{}")
 					},
+					nil,
 				)
 			}
 			// REPORTING - GATEWAY metrics - END
@@ -1618,7 +1623,7 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 			groupedEventsBySourceId[SourceIDT(sourceId)] = append(groupedEventsBySourceId[SourceIDT(sourceId)], shallowEventCopy)
 
 			if proc.isReportingEnabled() {
-				proc.updateMetricMaps(inCountMetadataMap, outCountMap, connectionDetailsMap, destFilterStatusDetailMap, event, jobsdb.Succeeded.State, types.DESTINATION_FILTER, func() json.RawMessage { return []byte(`{}`) })
+				proc.updateMetricMaps(inCountMetadataMap, outCountMap, connectionDetailsMap, destFilterStatusDetailMap, event, jobsdb.Succeeded.State, types.DESTINATION_FILTER, func() json.RawMessage { return []byte(`{}`) }, nil)
 			}
 		}
 
@@ -2446,7 +2451,7 @@ func (proc *Handle) transformSrcDest(
 				successCountMap := make(map[string]int64)
 				for i := range response.Events {
 					// Update metrics maps
-					proc.updateMetricMaps(nil, successCountMap, connectionDetailsMap, statusDetailsMap, &response.Events[i], jobsdb.Succeeded.State, types.DEST_TRANSFORMER, func() json.RawMessage { return []byte(`{}`) })
+					proc.updateMetricMaps(nil, successCountMap, connectionDetailsMap, statusDetailsMap, &response.Events[i], jobsdb.Succeeded.State, types.DEST_TRANSFORMER, func() json.RawMessage { return []byte(`{}`) }, nil)
 				}
 				types.AssertSameKeys(connectionDetailsMap, statusDetailsMap)
 

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2486,7 +2486,7 @@ var _ = Describe("Static Function Tests", func() {
 			countMap := make(map[string]int64)
 			countMetadataMap := make(map[string]MetricMetadata)
 			// update metric maps
-			proc.updateMetricMaps(countMetadataMap, countMap, connectionDetailsMap, statusDetailsMap, inputEvent, jobsdb.Succeeded.State, transformer.TrackingPlanValidationStage, func() json.RawMessage { return []byte(`{}`) })
+			proc.updateMetricMaps(countMetadataMap, countMap, connectionDetailsMap, statusDetailsMap, inputEvent, jobsdb.Succeeded.State, transformer.TrackingPlanValidationStage, func() json.RawMessage { return []byte(`{}`) }, nil)
 
 			Expect(len(countMetadataMap)).To(Equal(1))
 			Expect(len(countMap)).To(Equal(1))

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -530,7 +530,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 				time.Now().Format("01-02-2006"))
 			batchJobState = jobsdb.Succeeded.State
 			errorResp = []byte(fmt.Sprintf(`{"success":"%s"}`, errOccurred.Error())) // skipcq: GO-R4002
-		case errors.Is(errOccurred, rterror.InvalidServiceProvider):
+		case errors.Is(errOccurred, filemanager.ErrInvalidServiceProvider):
 			brt.logger.Warnf("BRT: Destination %s : %s for destination ID : %v at %v",
 				batchJobs.Connection.Destination.DestinationDefinition.DisplayName, errOccurred.Error(),
 				batchJobs.Connection.Destination.ID, time.Now().Format("01-02-2006"))
@@ -599,13 +599,15 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 		}
 
 		timeElapsed := time.Since(firstAttemptedAt)
-		errorCode := ""
+		var failedMessage *types.FailedMessage
+		var errorCode string
 		switch jobState {
 		case jobsdb.Failed.State:
 			if !notifyWarehouseErr && timeElapsed > brt.retryTimeWindow.Load() && job.LastJobStatus.AttemptNum >= brt.maxFailedCountForJob.Load() {
 				job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "stage", "batch_router")
 				job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "reason", errOccurred.Error())
 				abortedEvents = append(abortedEvents, job)
+				failedMessage = &types.FailedMessage{MessageID: parameters.MessageID, ReceivedAt: parameters.ParseReceivedAtTime()}
 				jobState = jobsdb.Aborted.State
 				errorCode = router_utils.DRAIN_ERROR_CODE
 			}
@@ -616,6 +618,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 					job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "stage", "batch_router")
 					job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "reason", errOccurred.Error())
 					abortedEvents = append(abortedEvents, job)
+					failedMessage = &types.FailedMessage{MessageID: parameters.MessageID, ReceivedAt: parameters.ParseReceivedAtTime()}
 					jobState = jobsdb.Aborted.State
 					errorCode = router_utils.DRAIN_ERROR_CODE
 				}
@@ -624,6 +627,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 		case jobsdb.Aborted.State:
 			job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "stage", "batch_router")
 			job.Parameters = misc.UpdateJSONWithNewKeyVal(job.Parameters, "reason", errOccurred.Error())
+			failedMessage = &types.FailedMessage{MessageID: parameters.MessageID, ReceivedAt: parameters.ParseReceivedAtTime()}
 			abortedEvents = append(abortedEvents, job)
 		}
 		attemptNum := job.LastJobStatus.AttemptNum + 1
@@ -671,6 +675,9 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 					batchRouterWorkspaceJobStatusCount[workspaceID] += 1
 				}
 				sd.Count++
+				if failedMessage != nil {
+					sd.FailedMessages = append(sd.FailedMessages, failedMessage)
+				}
 			}
 		}
 		// REPORTING - END

--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -77,18 +77,13 @@ func enhanceErrorResponseWithFirstAttemptedAtt(msg stdjson.RawMessage, errorResp
 }
 
 func getFirstAttemptAtFromErrorResponse(msg stdjson.RawMessage) time.Time {
-	var err error
-	var firstAttemptedAt time.Time
-	firstAttemptedAtString := gjson.GetBytes(msg, "firstAttemptedAt").Str
-	if firstAttemptedAtString != "" {
-		firstAttemptedAt, err = time.Parse(misc.RFC3339Milli, firstAttemptedAtString)
-		if err != nil {
-			firstAttemptedAt = time.Now()
+	res := time.Now()
+	if firstAttemptedAtString := gjson.GetBytes(msg, "firstAttemptedAt").Str; firstAttemptedAtString != "" {
+		if firstAttemptedAt, err := time.Parse(misc.RFC3339Milli, firstAttemptedAtString); err == nil {
+			res = firstAttemptedAt
 		}
-	} else {
-		firstAttemptedAt = time.Now()
 	}
-	return firstAttemptedAt
+	return res
 }
 
 func (brt *Handle) prepareJobStatusList(importingList []*jobsdb.JobT, defaultStatus jobsdb.JobStatusT) ([]*jobsdb.JobStatusT, []*jobsdb.JobT) {
@@ -549,6 +544,7 @@ func (brt *Handle) getReportMetrics(statusList []*jobsdb.JobStatusT, parametersM
 			routerWorkspaceJobStatusCount[workspaceID]++
 			sd.Count++
 		case jobsdb.Aborted.State:
+			sd.FailedMessages = append(sd.FailedMessages, &utilTypes.FailedMessage{MessageID: parameters.MessageID, ReceivedAt: parameters.ParseReceivedAtTime()})
 			routerWorkspaceJobStatusCount[workspaceID]++
 			sd.Count++
 		}

--- a/router/batchrouter/handle_observability.go
+++ b/router/batchrouter/handle_observability.go
@@ -189,8 +189,7 @@ func (brt *Handle) recordUploadStats(destination Connection, output UploadResult
 	})
 	eventDeliveryStat.Count(output.TotalEvents)
 
-	receivedTime, err := time.Parse(misc.RFC3339Milli, output.FirstEventAt)
-	if err == nil {
+	if receivedTime, err := time.Parse(misc.RFC3339Milli, output.FirstEventAt); err == nil {
 		eventDeliveryTimeStat := stats.Default.NewTaggedStat("event_delivery_time", stats.TimerType, map[string]string{
 			"module":      "batch_router",
 			"destType":    brt.destType,

--- a/router/batchrouter/types.go
+++ b/router/batchrouter/types.go
@@ -6,6 +6,7 @@ import (
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	router_utils "github.com/rudderlabs/rudder-server/router/utils"
+	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
 type Connection struct {
@@ -27,6 +28,12 @@ type JobParameters struct {
 	EventName               string `json:"event_name"`
 	EventType               string `json:"event_type"`
 	MessageID               string `json:"message_id"`
+}
+
+// ParseReceivedAtTime parses the [ReceivedAt] field and returns the parsed time or a zero value time if parsing fails
+func (jp *JobParameters) ParseReceivedAtTime() time.Time {
+	receivedAt, _ := time.Parse(misc.RFC3339Milli, jp.ReceivedAt)
+	return receivedAt
 }
 
 type DestinationJobs struct {

--- a/router/batchrouter/types_test.go
+++ b/router/batchrouter/types_test.go
@@ -1,0 +1,35 @@
+package batchrouter_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/router/batchrouter"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+)
+
+func TestJobParameters(t *testing.T) {
+	t.Run("ParseReceivedAtTime", func(t *testing.T) {
+		refTime := time.Now().UTC().Truncate(time.Millisecond)
+		t.Run("invalid string", func(t *testing.T) {
+			jp := batchrouter.JobParameters{
+				ReceivedAt: refTime.Format(misc.RFC3339Milli),
+			}
+			require.Equal(t, refTime, jp.ParseReceivedAtTime())
+		})
+
+		t.Run("empty string", func(t *testing.T) {
+			var jp batchrouter.JobParameters
+			require.True(t, jp.ParseReceivedAtTime().IsZero(), "an empty ReceivedAt should return a zero value time")
+		})
+
+		t.Run("invalid string", func(t *testing.T) {
+			jp := batchrouter.JobParameters{
+				ReceivedAt: "invalid",
+			}
+			require.True(t, jp.ParseReceivedAtTime().IsZero(), "an invalid ReceivedAt should return a zero value time")
+		})
+	})
+}

--- a/router/handle.go
+++ b/router/handle.go
@@ -327,6 +327,7 @@ func (rt *Handle) commitStatusList(workerJobStatuses *[]workerJobStatus) {
 		case jobsdb.Aborted.State:
 			routerWorkspaceJobStatusCount[workspaceID]++
 			sd.Count++
+			sd.FailedMessages = append(sd.FailedMessages, &utilTypes.FailedMessage{MessageID: parameters.MessageID, ReceivedAt: parameters.ParseReceivedAtTime()})
 			routerAbortedJobs = append(routerAbortedJobs, workerJobStatus.job)
 			completedJobsList = append(completedJobsList, workerJobStatus.job)
 		}

--- a/router/rterror/error.go
+++ b/router/rterror/error.go
@@ -4,7 +4,4 @@ import (
 	"errors"
 )
 
-var (
-	DisabledEgress         = errors.New("200: outgoing disabled")
-	InvalidServiceProvider = errors.New("service provider not supported")
-)
+var DisabledEgress = errors.New("200: outgoing disabled")

--- a/router/types.go
+++ b/router/types.go
@@ -29,6 +29,12 @@ type JobParameters struct {
 	RudderAccountID         string      `json:"rudderAccountId"`
 }
 
+// ParseReceivedAtTime parses the [ReceivedAt] field and returns the parsed time or a zero value time if parsing fails
+func (jp *JobParameters) ParseReceivedAtTime() time.Time {
+	receivedAt, _ := time.Parse(misc.RFC3339Milli, jp.ReceivedAt)
+	return receivedAt
+}
+
 type workerJobStatus struct {
 	userID string
 	worker *worker

--- a/router/types_test.go
+++ b/router/types_test.go
@@ -1,0 +1,35 @@
+package router_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/router"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+)
+
+func TestJobParameters(t *testing.T) {
+	t.Run("ParseReceivedAtTime", func(t *testing.T) {
+		refTime := time.Now().UTC().Truncate(time.Millisecond)
+		t.Run("invalid string", func(t *testing.T) {
+			jp := router.JobParameters{
+				ReceivedAt: refTime.Format(misc.RFC3339Milli),
+			}
+			require.Equal(t, refTime, jp.ParseReceivedAtTime())
+		})
+
+		t.Run("empty string", func(t *testing.T) {
+			var jp router.JobParameters
+			require.True(t, jp.ParseReceivedAtTime().IsZero(), "an empty ReceivedAt should return a zero value time")
+		})
+
+		t.Run("invalid string", func(t *testing.T) {
+			jp := router.JobParameters{
+				ReceivedAt: "invalid",
+			}
+			require.True(t, jp.ParseReceivedAtTime().IsZero(), "an invalid ReceivedAt should return a zero value time")
+		})
+	})
+}

--- a/router/types_test.go
+++ b/router/types_test.go
@@ -13,7 +13,7 @@ import (
 func TestJobParameters(t *testing.T) {
 	t.Run("ParseReceivedAtTime", func(t *testing.T) {
 		refTime := time.Now().UTC().Truncate(time.Millisecond)
-		t.Run("invalid string", func(t *testing.T) {
+		t.Run("valid string", func(t *testing.T) {
 			jp := router.JobParameters{
 				ReceivedAt: refTime.Format(misc.RFC3339Milli),
 			}

--- a/router/worker.go
+++ b/router/worker.go
@@ -762,8 +762,7 @@ func (w *worker) postStatusOnResponseQ(respStatusCode int, payload json.RawMessa
 	// Enhancing status.ErrorResponse with firstAttemptedAt
 	firstAttemptedAtTime := time.Now()
 	if destinationJobMetadata.FirstAttemptedAt != "" {
-		t, err := time.Parse(misc.RFC3339Milli, destinationJobMetadata.FirstAttemptedAt)
-		if err == nil {
+		if t, err := time.Parse(misc.RFC3339Milli, destinationJobMetadata.FirstAttemptedAt); err == nil {
 			firstAttemptedAtTime = t
 		}
 	}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -298,7 +298,7 @@ func (r *Runner) Run(ctx context.Context, args []string) int {
 	case <-shutdownDone:
 		r.application.Stop()
 		r.logger.Infof(
-			"Graceful terminal after %s, with %d go-routines",
+			"Graceful termination after %s, with %d go-routines",
 			time.Since(ctxDoneTime),
 			runtime.NumGoroutine(),
 		)

--- a/schema-forwarder/internal/forwarder/abortingforwarder.go
+++ b/schema-forwarder/internal/forwarder/abortingforwarder.go
@@ -70,7 +70,7 @@ func (nf *AbortingForwarder) Start() error {
 					nf.terminalErrFn(err) // we are signaling to shutdown the app
 					return err
 				}
-				time.Sleep(nf.GetSleepTime(limitReached))
+				_ = misc.SleepCtx(ctx, nf.GetSleepTime(limitReached))
 			}
 		}
 	}))

--- a/testhelper/backendconfigtest/config_builder.go
+++ b/testhelper/backendconfigtest/config_builder.go
@@ -1,0 +1,30 @@
+package backendconfigtest
+
+import (
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+)
+
+// NewConfigBuilder returns a new ConfigBuilder
+func NewConfigBuilder() *ConfigBuilder {
+	var b ConfigBuilder
+	b.v = &backendconfig.ConfigT{
+		EnableMetrics: false,
+		WorkspaceID:   rand.UniqueString(10),
+		UpdatedAt:     time.Now(),
+	}
+	return &b
+}
+
+// ConfigBuilder is a builder for a backend config
+type ConfigBuilder struct {
+	valueBuilder[backendconfig.ConfigT]
+}
+
+// WithSource adds a source to the config
+func (b *ConfigBuilder) WithSource(source backendconfig.SourceT) *ConfigBuilder {
+	b.v.Sources = append(b.v.Sources, source)
+	return b
+}

--- a/testhelper/backendconfigtest/destination_builder.go
+++ b/testhelper/backendconfigtest/destination_builder.go
@@ -49,7 +49,7 @@ func (b *DestinationBuilder) WithUserTransformation(id, version string) *Destina
 	return b
 }
 
-// WithDestinationTransformation adds a config option to the destination definition
+// WithDefinitionConfigOption adds a config option to the destination definition
 func (b *DestinationBuilder) WithDefinitionConfigOption(key string, value any) *DestinationBuilder {
 	b.v.DestinationDefinition.Config[key] = value
 	return b

--- a/testhelper/backendconfigtest/destination_builder.go
+++ b/testhelper/backendconfigtest/destination_builder.go
@@ -1,0 +1,56 @@
+package backendconfigtest
+
+import (
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+)
+
+// NewDestinationBuilder returns a new DestinationBuilder
+func NewDestinationBuilder(destType string) *DestinationBuilder {
+	var b DestinationBuilder
+	b.v = &backendconfig.DestinationT{
+		ID:                 rand.UniqueString(10),
+		Name:               rand.String(5),
+		Enabled:            true,
+		IsProcessorEnabled: true,
+		Config:             map[string]any{},
+		DestinationDefinition: backendconfig.DestinationDefinitionT{
+			ID:     rand.UniqueString(10),
+			Name:   destType,
+			Config: map[string]any{},
+		},
+	}
+	return &b
+}
+
+// DestinationBuilder is a builder for a destination
+type DestinationBuilder struct {
+	valueBuilder[backendconfig.DestinationT]
+}
+
+// WithID sets the ID of the destination
+func (b *DestinationBuilder) WithID(id string) *DestinationBuilder {
+	b.v.ID = id
+	return b
+}
+
+// WithConfigOption sets a config option for the destination
+func (b *DestinationBuilder) WithConfigOption(key string, value any) *DestinationBuilder {
+	b.v.Config[key] = value
+	return b
+}
+
+// WithUserTransformation adds a user transformation to the destination
+func (b *DestinationBuilder) WithUserTransformation(id, version string) *DestinationBuilder {
+	b.v.Transformations = append(b.v.Transformations, backendconfig.TransformationT{
+		ID:        id,
+		VersionID: version,
+	})
+	return b
+}
+
+// WithDestinationTransformation adds a config option to the destination definition
+func (b *DestinationBuilder) WithDefinitionConfigOption(key string, value any) *DestinationBuilder {
+	b.v.DestinationDefinition.Config[key] = value
+	return b
+}

--- a/testhelper/backendconfigtest/server_builder.go
+++ b/testhelper/backendconfigtest/server_builder.go
@@ -1,0 +1,63 @@
+package backendconfigtest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/samber/lo"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+)
+
+// NewBuilder returns a new ServerBuilder
+func NewBuilder() *ServerBuilder {
+	return &ServerBuilder{
+		settingsHandler: func(_ http.ResponseWriter, _ *http.Request) {},
+	}
+}
+
+// ServerBuilder is a builder for a test server that returns backend configs
+type ServerBuilder struct {
+	namespace       string
+	configs         map[string]backendconfig.ConfigT
+	settingsHandler http.HandlerFunc
+}
+
+// WithNamespace sets the namespace for the server along with the configs for that namespace
+func (b *ServerBuilder) WithNamespace(namespace string, configs ...backendconfig.ConfigT) *ServerBuilder {
+	b.namespace = namespace
+	b.configs = map[string]backendconfig.ConfigT{}
+	for i := range configs {
+		config := configs[i]
+		b.configs[config.WorkspaceID] = config
+	}
+	return b
+}
+
+// WithWorkspaceConfig sets the workspace config for the server
+func (b *ServerBuilder) WithWorkspaceConfig(config backendconfig.ConfigT) *ServerBuilder {
+	b.configs = map[string]backendconfig.ConfigT{
+		config.WorkspaceID: config,
+	}
+	return b
+}
+
+// Build builds the test server
+func (b *ServerBuilder) Build() *httptest.Server {
+	mux := http.NewServeMux()
+	if b.namespace != "" {
+		mux.HandleFunc(fmt.Sprintf("/data-plane/v1/namespaces/%s/config", b.namespace), func(w http.ResponseWriter, r *http.Request) {
+			response, _ := json.Marshal(b.configs)
+			_, _ = w.Write(response)
+		})
+	} else {
+		mux.HandleFunc("/workspaceConfig", func(w http.ResponseWriter, r *http.Request) {
+			response, _ := json.Marshal(lo.Values(b.configs)[0])
+			_, _ = w.Write(response)
+		})
+	}
+
+	return httptest.NewServer(mux)
+}

--- a/testhelper/backendconfigtest/source_builder.go
+++ b/testhelper/backendconfigtest/source_builder.go
@@ -1,0 +1,68 @@
+package backendconfigtest
+
+import (
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+)
+
+// NewSourceBuilder returns a new SourceBuilder
+func NewSourceBuilder() *SourceBuilder {
+	var b SourceBuilder
+
+	b.v = &backendconfig.SourceT{
+		ID:       rand.UniqueString(10),
+		Name:     rand.String(5),
+		Enabled:  true,
+		WriteKey: rand.UniqueString(10),
+		Config:   map[string]any{},
+		SourceDefinition: backendconfig.SourceDefinitionT{
+			ID:       rand.UniqueString(10),
+			Name:     rand.String(5),
+			Category: "eventStream",
+			Type:     "type",
+		},
+	}
+	return &b
+}
+
+// SourceBuilder is a builder for a source
+type SourceBuilder struct {
+	valueBuilder[backendconfig.SourceT]
+}
+
+// WithID sets the ID of the source
+func (b *SourceBuilder) WithID(id string) *SourceBuilder {
+	b.v.ID = id
+	return b
+}
+
+// WithWriteKey sets the write key of the source
+func (b *SourceBuilder) WithWriteKey(writeKey string) *SourceBuilder {
+	b.v.WriteKey = writeKey
+	return b
+}
+
+// WithConfigOption sets a config option for the source
+func (b *SourceBuilder) WithConfigOption(key string, value any) *SourceBuilder {
+	b.v.Config[key] = value
+	return b
+}
+
+// WithConnection adds a destination to the source
+func (b *SourceBuilder) WithConnection(destination backendconfig.DestinationT) *SourceBuilder {
+	b.v.Destinations = append(b.v.Destinations, destination)
+	return b
+}
+
+// Disabled disables the source
+func (b *SourceBuilder) Disabled() *SourceBuilder {
+	b.v.Enabled = false
+	return b
+}
+
+// WithTrackingPlan adds a tracking plan to the source
+func (b *SourceBuilder) WithTrackingPlan(id string, version int) *SourceBuilder {
+	b.v.DgSourceTrackingPlanConfig.TrackingPlan.Id = id
+	b.v.DgSourceTrackingPlanConfig.TrackingPlan.Version = version
+	return b
+}

--- a/testhelper/backendconfigtest/value_builder.go
+++ b/testhelper/backendconfigtest/value_builder.go
@@ -1,0 +1,10 @@
+package backendconfigtest
+
+type valueBuilder[V any] struct {
+	v *V
+}
+
+// Build builds the value
+func (b *valueBuilder[V]) Build() V {
+	return *b.v
+}

--- a/testhelper/transformertest/builder.go
+++ b/testhelper/transformertest/builder.go
@@ -1,0 +1,132 @@
+package transformertest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/tidwall/sjson"
+
+	"github.com/rudderlabs/rudder-server/processor/transformer"
+)
+
+// NewBuilder returns a new test transformer Builder
+func NewBuilder() *Builder {
+	b := &Builder{
+		routerTransforms:      map[string]struct{}{},
+		destTransformHandlers: map[string]http.HandlerFunc{},
+	}
+	return b
+}
+
+// Builder is a builder for a test transformer server
+type Builder struct {
+	routerTransforms      map[string]struct{}
+	userTransformHandler  http.HandlerFunc
+	destTransformHandlers map[string]http.HandlerFunc
+	trackingPlanHandler   http.HandlerFunc
+}
+
+// WithUserTransformHandlerFunc sets the user transformation http handler function for the server
+func (b *Builder) WithUserTransformHandlerFunc(h http.HandlerFunc) *Builder {
+	b.userTransformHandler = apiVersionMiddleware(h)
+	return b
+}
+
+// WithUserTransformHandler sets the user transformation handler for the server
+func (b *Builder) WithUserTransformHandler(h TransformerHandler) *Builder {
+	return b.WithUserTransformHandlerFunc(transformerFunc(h))
+}
+
+// WithDesTransformHandlerFunc sets a destination specific transformation http handler function for the server
+func (b *Builder) WithDesTransformHandlerFunc(destType string, h http.HandlerFunc) *Builder {
+	b.destTransformHandlers[destType] = apiVersionMiddleware(h)
+	return b
+}
+
+// WithDestTransformHandler sets a destination specific transformation handler for the server
+func (b *Builder) WithDestTransformHandler(destType string, h TransformerHandler) *Builder {
+	return b.WithDesTransformHandlerFunc(destType, transformerFunc(h))
+}
+
+// WithTrackingPlanHandlerFunc sets the tracking plan validation http handler function for the server
+func (b *Builder) WithTrackingPlanHandlerFunc(h http.HandlerFunc) *Builder {
+	b.trackingPlanHandler = apiVersionMiddleware(h)
+	return b
+}
+
+// WithTrackingPlanHandler sets the tracking plan validation handler for the server
+func (b *Builder) WithTrackingPlanHandler(h TransformerHandler) *Builder {
+	return b.WithTrackingPlanHandlerFunc(transformerFunc(h))
+}
+
+// WithRouterTransform enables router transformation for a specific destination type
+func (b *Builder) WithRouterTransform(destType string) *Builder {
+	b.routerTransforms[destType] = struct{}{}
+	return b
+}
+
+// Build builds the test tranformer server
+func (b *Builder) Build() *httptest.Server {
+	// user/custom transformation
+	if b.userTransformHandler == nil {
+		b.userTransformHandler = apiVersionMiddleware(transformerFunc(MirroringTransformerHandler))
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/customTransform", b.userTransformHandler)
+
+	// tracking plan validtion
+	if b.trackingPlanHandler == nil {
+		b.trackingPlanHandler = apiVersionMiddleware(transformerFunc(MirroringTransformerHandler))
+	}
+	mux.HandleFunc("/v0/validate", b.trackingPlanHandler)
+
+	// destination transformation
+	if _, ok := b.destTransformHandlers["*"]; !ok {
+		b.destTransformHandlers["*"] = apiVersionMiddleware(transformerFunc(MirroringTransformerHandler))
+	}
+	for k := range b.destTransformHandlers {
+		destHandler := b.destTransformHandlers[k]
+		switch k {
+		case "*":
+			mux.HandleFunc("/v0/destinations/", destHandler)
+		default:
+			mux.HandleFunc("/v0/destinations/"+strings.ToLower(k), destHandler)
+		}
+	}
+
+	// features
+	features := []byte(`{"routerTransform": {}}`)
+	for destType := range b.routerTransforms {
+		features, _ = sjson.SetBytes(features, "routerTransform."+destType, true)
+	}
+	mux.HandleFunc("/features", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(features)
+	})
+	return httptest.NewServer(mux)
+}
+
+func transformerFunc(h TransformerHandler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(500)
+			return
+		}
+		var request []transformer.TransformerEvent
+		if err := json.Unmarshal(data, &request); err != nil {
+			w.WriteHeader(400)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(h(request))
+	}
+}
+
+func apiVersionMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("apiVersion", "2")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/testhelper/transformertest/handler_funcs.go
+++ b/testhelper/transformertest/handler_funcs.go
@@ -1,0 +1,94 @@
+package transformertest
+
+import (
+	"encoding/json"
+
+	"github.com/rudderlabs/rudder-server/processor/integrations"
+	"github.com/rudderlabs/rudder-server/processor/transformer"
+)
+
+// TransformerHandler is a function that takes a transformer request and returns a response
+type TransformerHandler func(request []transformer.TransformerEvent) []transformer.TransformerResponse
+
+// MirroringTransformerHandler mirrors the request payload in the response
+var MirroringTransformerHandler TransformerHandler = func(request []transformer.TransformerEvent) (response []transformer.TransformerResponse) {
+	for i := range request {
+		req := request[i]
+		response = append(response, transformer.TransformerResponse{
+			Metadata:   req.Metadata,
+			Output:     req.Message,
+			StatusCode: 200,
+		})
+	}
+	return
+}
+
+// ErrorTransformerHandler mirrors the request payload in the response but uses an error status code
+func ErrorTransformerHandler(code int, err string) TransformerHandler {
+	return func(request []transformer.TransformerEvent) (response []transformer.TransformerResponse) {
+		for i := range request {
+			req := request[i]
+			response = append(response, transformer.TransformerResponse{
+				Metadata:   req.Metadata,
+				Output:     req.Message,
+				StatusCode: code,
+				Error:      err,
+			})
+		}
+		return
+	}
+}
+
+// ValidationErrorTransformerHandler mirrors the request payload in the response but uses an error status code along with the provided validation errors
+func ViolationErrorTransformerHandler(code int, err string, validationErrors []transformer.ValidationError) TransformerHandler {
+	return func(request []transformer.TransformerEvent) (response []transformer.TransformerResponse) {
+		for i := range request {
+			req := request[i]
+			response = append(response, transformer.TransformerResponse{
+				Metadata:         req.Metadata,
+				Output:           req.Message,
+				StatusCode:       code,
+				Error:            err,
+				ValidationErrors: validationErrors,
+			})
+		}
+		return
+	}
+}
+
+// EmptyTransformerHandler returns an empty response
+var EmptyTransformerHandler TransformerHandler = func(request []transformer.TransformerEvent) []transformer.TransformerResponse {
+	return []transformer.TransformerResponse{}
+}
+
+// DestTransformerHandler returns an empty response
+func DestTransformerHandler(f func(event transformer.TransformerEvent) integrations.PostParametersT) func(request []transformer.TransformerEvent) []transformer.TransformerResponse {
+	return func(request []transformer.TransformerEvent) (res []transformer.TransformerResponse) {
+		for _, req := range request {
+			postParameters := f(req)
+			jsonString, _ := json.Marshal(postParameters)
+			var output map[string]interface{}
+			_ = json.Unmarshal(jsonString, &output)
+			res = append(res, transformer.TransformerResponse{
+				Metadata:   req.Metadata,
+				Output:     output,
+				StatusCode: 200,
+			})
+		}
+		return
+	}
+}
+
+// RESTJSONDestTransformerHandler transforms the request payload into a REST JSON destination request using the original message as the payload
+func RESTJSONDestTransformerHandler(method, url string) func(request []transformer.TransformerEvent) []transformer.TransformerResponse {
+	return DestTransformerHandler(func(event transformer.TransformerEvent) integrations.PostParametersT {
+		return integrations.PostParametersT{
+			Type:          "REST",
+			URL:           url,
+			RequestMethod: method,
+			Body: map[string]interface{}{
+				"JSON": event.Message,
+			},
+		}
+	})
+}

--- a/testhelper/transformertest/handler_funcs.go
+++ b/testhelper/transformertest/handler_funcs.go
@@ -39,7 +39,7 @@ func ErrorTransformerHandler(code int, err string) TransformerHandler {
 	}
 }
 
-// ValidationErrorTransformerHandler mirrors the request payload in the response but uses an error status code along with the provided validation errors
+// ViolationErrorTransformerHandler mirrors the request payload in the response but uses an error status code along with the provided validation errors
 func ViolationErrorTransformerHandler(code int, err string, validationErrors []transformer.ValidationError) TransformerHandler {
 	return func(request []transformer.TransformerEvent) (response []transformer.TransformerResponse) {
 		for i := range request {


### PR DESCRIPTION
# Description

1. Filling FailedMessages in reporting stats for aborted job scenarios (processor/router/batchrouter).
2. Fixing a reporting bug where we were counting less when a batch user transformation failed.
3. Fixing a reporting bug where we were not reporting drained jobs in batch router.
4. Introducing `backendconfigtest` package which provides a fluent builder for workspace config, useful for preparing test scenario fixtures.
5. Introducing `transformertest` package which provides a fluent builder for transformer service to easily simulate different transformer behaviours in tests.
6. Added `reporting_dropped_events_test` integration test to verify reporting behaviour in scenarios where events are being aborted/filtered in the pipeline.
7. The same testing framework shall be used to verify reporting of failed messages for replay purposes after the new reporter is ready.

## Linear Ticket

[PIPE-315](https://linear.app/rudderstack/issue/PIPE-315/collect-additional-reporting-fields-messageid-received-at-in-processor)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
