### PR TITLE
fix: test ssh

### DIFF
--- a/services/streammanager/kafka/client/client_test.go
+++ b/services/streammanager/kafka/client/client_test.go
@@ -784,8 +784,15 @@ func TestSSH(t *testing.T) {
 	}, defaultTestTimeout, time.Second)
 
 	// Check that the topic has been created with the right number of partitions
-	topics, err := tc.ListTopics(ctx)
-	require.NoError(t, err)
+	var topics []testutil.TopicPartition
+	require.Eventually(t, func() bool {
+		topics, err = tc.ListTopics(ctx)
+		success := err == nil && len(topics) > 0
+		if !success {
+			t.Logf("List topics failure %+v: %v", topics, err)
+		}
+		return success
+	}, defaultTestTimeout, time.Second)
 	require.Equal(t, []testutil.TopicPartition{{Topic: t.Name(), Partition: 0}}, topics)
 
 	// Check producer


### PR DESCRIPTION
# Description

First attempt to address flakyness of the `TestSSH` test as seen [here](https://github.com/rudderlabs/rudder-server/actions/runs/6315301663/job/17147543264).

I'm proposing to use the same approach we're using in another test [here](https://github.com/rudderlabs/rudder-server/blob/v1.14.2/services/streammanager/kafka/client/client_test.go#L97).

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-365/testssh-flakyness) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
