### PR TITLE
chore: use new reloadable config api for warehouse

### DIFF
--- a/warehouse/constraint.go
+++ b/warehouse/constraint.go
@@ -28,7 +28,7 @@ type indexConstraint struct {
 
 type constraintsManager struct {
 	constraintsMap              map[string][]constraints
-	enableConstraintsViolations bool
+	enableConstraintsViolations misc.ValueLoader[bool]
 }
 
 func newConstraintsManager(conf *config.Config) *constraintsManager {
@@ -64,9 +64,7 @@ func newConstraintsManager(conf *config.Config) *constraintsManager {
 			},
 		},
 	}
-
-	// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
-	conf.RegisterBoolConfigVariable(true, &cm.enableConstraintsViolations, true, "Warehouse.enableConstraintsViolations")
+	cm.enableConstraintsViolations = conf.GetReloadableBoolVar(true, "Warehouse.enableConstraintsViolations")
 
 	return cm
 }
@@ -74,7 +72,7 @@ func newConstraintsManager(conf *config.Config) *constraintsManager {
 func (cm *constraintsManager) violatedConstraints(destinationType string, brEvent *BatchRouterEvent, columnName string) (cv *constraintsViolation) {
 	cv = &constraintsViolation{}
 
-	if !cm.enableConstraintsViolations {
+	if !cm.enableConstraintsViolations.Load() {
 		return
 	}
 

--- a/warehouse/router_scheduling.go
+++ b/warehouse/router_scheduling.go
@@ -39,7 +39,7 @@ func (r *router) canCreateUpload(ctx context.Context, warehouse model.Warehouse)
 		return true, nil
 	}
 
-	if r.config.warehouseSyncFreqIgnore {
+	if r.config.warehouseSyncFreqIgnore.Load() {
 		if r.uploadFrequencyExceeded(warehouse, "") {
 			return true, nil
 		}

--- a/warehouse/router_scheduling_test.go
+++ b/warehouse/router_scheduling_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/utils/misc"
+
 	"github.com/ory/dockertest/v3"
 
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
@@ -205,7 +207,8 @@ func TestRouter_CanCreateUpload(t *testing.T) {
 				}
 
 				r := router{}
-				r.config.warehouseSyncFreqIgnore = true
+				r.config.uploadFreqInS = misc.SingleValueLoader(int64(1800))
+				r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
 				r.triggerStore = &sync.Map{}
 
 				canCreate, err := r.canCreateUpload(context.Background(), w)
@@ -224,8 +227,8 @@ func TestRouter_CanCreateUpload(t *testing.T) {
 				r.now = func() time.Time {
 					return now
 				}
-				r.config.uploadFreqInS = 1800
-				r.config.warehouseSyncFreqIgnore = true
+				r.config.uploadFreqInS = misc.SingleValueLoader(int64(1800))
+				r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
 				r.createJobMarkerMap = make(map[string]time.Time)
 				r.triggerStore = &sync.Map{}
 
@@ -247,8 +250,8 @@ func TestRouter_CanCreateUpload(t *testing.T) {
 				r.now = func() time.Time {
 					return now
 				}
-				r.config.uploadFreqInS = 1800
-				r.config.warehouseSyncFreqIgnore = true
+				r.config.uploadFreqInS = misc.SingleValueLoader(int64(1800))
+				r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
 				r.createJobMarkerMap = make(map[string]time.Time)
 				r.triggerStore = &sync.Map{}
 
@@ -275,6 +278,7 @@ func TestRouter_CanCreateUpload(t *testing.T) {
 
 			r := router{}
 			r.triggerStore = &sync.Map{}
+			r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(false)
 			r.now = func() time.Time {
 				return time.Date(2009, time.November, 10, 5, 30, 0, 0, time.UTC)
 			}
@@ -298,7 +302,8 @@ func TestRouter_CanCreateUpload(t *testing.T) {
 			r.now = func() time.Time {
 				return now
 			}
-			r.config.uploadFreqInS = 1800
+			r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(false)
+			r.config.uploadFreqInS = misc.SingleValueLoader(int64(1800))
 			r.createJobMarkerMap = make(map[string]time.Time)
 			r.triggerStore = &sync.Map{}
 
@@ -323,7 +328,8 @@ func TestRouter_CanCreateUpload(t *testing.T) {
 			r.now = func() time.Time {
 				return now
 			}
-			r.config.uploadFreqInS = 1800
+			r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(false)
+			r.config.uploadFreqInS = misc.SingleValueLoader(int64(1800))
 			r.triggerStore = &sync.Map{}
 			r.createJobMarkerMap = make(map[string]time.Time)
 
@@ -413,6 +419,7 @@ func TestRouter_CanCreateUpload(t *testing.T) {
 
 					r := router{}
 					r.triggerStore = &sync.Map{}
+					r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(false)
 					r.createJobMarkerMap = make(map[string]time.Time)
 					r.uploadRepo = repoUpload
 					r.now = func() time.Time {

--- a/warehouse/router_test.go
+++ b/warehouse/router_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/utils/misc"
+
 	"github.com/rudderlabs/rudder-server/services/notifier"
 
 	"github.com/samber/lo"
@@ -194,9 +196,10 @@ func TestRouter(t *testing.T) {
 		r.stagingRepo = repoStaging
 		r.statsFactory = memstats.New()
 		r.conf = config.Default
-		r.config.stagingFilesBatchSize = 100
-		r.config.warehouseSyncFreqIgnore = true
-		r.config.enableJitterForSyncs = true
+		r.config.uploadFreqInS = misc.SingleValueLoader(int64(1800))
+		r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
+		r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
+		r.config.enableJitterForSyncs = misc.SingleValueLoader(true)
 		r.destType = destinationType
 		r.logger = logger.NOP
 		r.triggerStore = &sync.Map{}
@@ -349,9 +352,9 @@ func TestRouter(t *testing.T) {
 		r.stagingRepo = repoStaging
 		r.statsFactory = memstats.New()
 		r.conf = config.Default
-		r.config.stagingFilesBatchSize = 100
-		r.config.warehouseSyncFreqIgnore = true
-		r.config.enableJitterForSyncs = true
+		r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
+		r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
+		r.config.enableJitterForSyncs = misc.SingleValueLoader(true)
 		r.destType = destinationType
 		r.inProgressMap = make(map[workerIdentifierMapKey][]jobID)
 		r.triggerStore = &sync.Map{}
@@ -482,11 +485,13 @@ func TestRouter(t *testing.T) {
 		r.uploadRepo = repoUpload
 		r.stagingRepo = repoStaging
 		r.conf = config.Default
-		r.config.stagingFilesBatchSize = 100
-		r.config.warehouseSyncFreqIgnore = true
-		r.config.enableJitterForSyncs = true
-		r.config.mainLoopSleep = time.Millisecond * 100
-		r.config.maxParallelJobCreation = 100
+		r.config.uploadFreqInS = misc.SingleValueLoader(int64(1800))
+		r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
+		r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
+		r.config.enableJitterForSyncs = misc.SingleValueLoader(true)
+		r.config.enableJitterForSyncs = misc.SingleValueLoader(true)
+		r.config.mainLoopSleep = misc.SingleValueLoader(time.Millisecond * 100)
+		r.config.maxParallelJobCreation = misc.SingleValueLoader(100)
 		r.destType = destinationType
 		r.logger = logger.NOP
 		r.now = func() time.Time {
@@ -587,8 +592,8 @@ func TestRouter(t *testing.T) {
 		r.statsFactory = memstats.New()
 		r.conf = config.Default
 		r.config.allowMultipleSourcesForJobsPickup = true
-		r.config.stagingFilesBatchSize = 100
-		r.config.warehouseSyncFreqIgnore = true
+		r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
+		r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
 		r.destType = destinationType
 		r.logger = logger.NOP
 		r.tenantManager = multitenant.New(config.Default, mocksBackendConfig.NewMockBackendConfig(ctrl))
@@ -720,9 +725,9 @@ func TestRouter(t *testing.T) {
 		r.statsFactory = memstats.New()
 		r.conf = config.Default
 		r.config.allowMultipleSourcesForJobsPickup = true
-		r.config.stagingFilesBatchSize = 100
-		r.config.warehouseSyncFreqIgnore = true
-		r.config.noOfWorkers = 10
+		r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
+		r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
+		r.config.noOfWorkers = misc.SingleValueLoader(10)
 		r.config.waitForWorkerSleep = time.Millisecond * 100
 		r.config.uploadAllocatorSleep = time.Millisecond * 100
 		r.destType = warehouseutils.RS
@@ -869,9 +874,9 @@ func TestRouter(t *testing.T) {
 			r.statsFactory = memstats.New()
 			r.conf = config.Default
 			r.config.allowMultipleSourcesForJobsPickup = true
-			r.config.stagingFilesBatchSize = 100
-			r.config.warehouseSyncFreqIgnore = true
-			r.config.noOfWorkers = 0
+			r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
+			r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
+			r.config.noOfWorkers = misc.SingleValueLoader(0)
 			r.config.waitForWorkerSleep = time.Second * 5
 			r.config.uploadAllocatorSleep = time.Millisecond * 100
 			r.destType = warehouseutils.RS
@@ -957,11 +962,12 @@ func TestRouter(t *testing.T) {
 			r.uploadRepo = repoUpload
 			r.stagingRepo = repoStaging
 			r.conf = config.Default
-			r.config.stagingFilesBatchSize = 100
-			r.config.warehouseSyncFreqIgnore = true
-			r.config.enableJitterForSyncs = true
-			r.config.mainLoopSleep = time.Second * 5
-			r.config.maxParallelJobCreation = 100
+
+			r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
+			r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
+			r.config.enableJitterForSyncs = misc.SingleValueLoader(true)
+			r.config.mainLoopSleep = misc.SingleValueLoader(time.Second * 5)
+			r.config.maxParallelJobCreation = misc.SingleValueLoader(100)
 			r.destType = destinationType
 			r.logger = logger.NOP
 			r.now = func() time.Time {

--- a/warehouse/slave_test.go
+++ b/warehouse/slave_test.go
@@ -87,7 +87,7 @@ func TestSlave(t *testing.T) {
 		subscribeCh: subscriberCh,
 	}
 
-	workers := 4
+	workers := misc.SingleValueLoader(4)
 	workerJobs := 25
 
 	tenantManager := multitenant.New(

--- a/warehouse/slave_worker_job.go
+++ b/warehouse/slave_worker_job.go
@@ -135,11 +135,7 @@ func newJobRun(job payload, conf *config.Config, log logger.Logger, stat stats.S
 		encodingFactory: encodingFactory,
 	}
 
-	if conf.IsSet("Warehouse.slaveUploadTimeout") {
-		jr.config.slaveUploadTimeout = conf.GetDuration("Warehouse.slaveUploadTimeout", 10, time.Minute)
-	} else {
-		jr.config.slaveUploadTimeout = conf.GetDuration("Warehouse.slaveUploadTimeoutInMin", 10, time.Minute)
-	}
+	jr.config.slaveUploadTimeout = conf.GetDurationVar(10, time.Minute, "Warehouse.slaveUploadTimeout", "Warehouse.slaveUploadTimeoutInMin")
 	jr.config.numLoadFileUploadWorkers = conf.GetInt("Warehouse.numLoadFileUploadWorkers", 8)
 	jr.config.loadObjectFolder = conf.GetString("WAREHOUSE_BUCKET_LOAD_OBJECTS_FOLDER_NAME", "rudder-warehouse-load-objects")
 

--- a/warehouse/upload.go
+++ b/warehouse/upload.go
@@ -225,32 +225,11 @@ func (f *UploadJobFactory) NewUploadJob(ctx context.Context, dto *model.UploadJo
 	uj.config.disableGenerateTableLoadCountMetricsWorkspaceIDs = f.conf.GetStringSlice("Warehouse.disableGenerateTableLoadCountMetricsWorkspaceIDs", nil)
 	uj.config.columnsBatchSize = f.conf.GetInt(fmt.Sprintf("Warehouse.%s.columnsBatchSize", whutils.WHDestNameMap[uj.upload.DestinationType]), 100)
 	uj.config.maxParallelLoadsWorkspaceIDs = f.conf.GetStringMap(fmt.Sprintf("Warehouse.%s.maxParallelLoadsWorkspaceIDs", whutils.WHDestNameMap[uj.upload.DestinationType]), nil)
-
-	if f.conf.IsSet("Warehouse.tableCountQueryTimeout") {
-		uj.config.tableCountQueryTimeout = f.conf.GetDuration("Warehouse.tableCountQueryTimeout", 30, time.Second)
-	} else {
-		uj.config.tableCountQueryTimeout = f.conf.GetDuration("Warehouse.tableCountQueryTimeoutInS", 30, time.Second)
-	}
-	if f.conf.IsSet("Warehouse.longRunningUploadStatThreshold") {
-		uj.config.longRunningUploadStatThresholdInMin = f.conf.GetDuration("Warehouse.longRunningUploadStatThreshold", 120, time.Minute)
-	} else {
-		uj.config.longRunningUploadStatThresholdInMin = f.conf.GetDuration("Warehouse.longRunningUploadStatThresholdInMin", 120, time.Minute)
-	}
-	if f.conf.IsSet("Warehouse.minUploadBackoff") {
-		uj.config.minUploadBackoff = f.conf.GetDuration("Warehouse.minUploadBackoff", 60, time.Second)
-	} else {
-		uj.config.minUploadBackoff = f.conf.GetDuration("Warehouse.minUploadBackoffInS", 60, time.Second)
-	}
-	if f.conf.IsSet("Warehouse.maxUploadBackoff") {
-		uj.config.maxUploadBackoff = f.conf.GetDuration("Warehouse.maxUploadBackoff", 1800, time.Second)
-	} else {
-		uj.config.maxUploadBackoff = f.conf.GetDuration("Warehouse.maxUploadBackoffInS", 1800, time.Second)
-	}
-	if f.conf.IsSet("Warehouse.retryTimeWindow") {
-		uj.config.retryTimeWindow = f.conf.GetDuration("Warehouse.retryTimeWindow", 180, time.Minute)
-	} else {
-		uj.config.retryTimeWindow = f.conf.GetDuration("Warehouse.retryTimeWindowInMins", 180, time.Minute)
-	}
+	uj.config.tableCountQueryTimeout = f.conf.GetDurationVar(30, time.Second, "Warehouse.tableCountQueryTimeout", "Warehouse.tableCountQueryTimeoutInS")
+	uj.config.longRunningUploadStatThresholdInMin = f.conf.GetDurationVar(120, time.Minute, "Warehouse.longRunningUploadStatThreshold", "Warehouse.longRunningUploadStatThresholdInMin")
+	uj.config.minUploadBackoff = f.conf.GetDurationVar(60, time.Second, "Warehouse.minUploadBackoff", "Warehouse.minUploadBackoffInS")
+	uj.config.maxUploadBackoff = f.conf.GetDurationVar(1800, time.Second, "Warehouse.maxUploadBackoff", "Warehouse.maxUploadBackoffInS")
+	uj.config.retryTimeWindow = f.conf.GetDurationVar(180, time.Minute, "Warehouse.retryTimeWindow", "Warehouse.retryTimeWindowInMins")
 
 	uj.stats.uploadTime = uj.timerStat("upload_time")
 	uj.stats.userTablesLoadTime = uj.timerStat("user_tables_load_time")

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -133,7 +133,7 @@ const (
 var (
 	pkgLogger          logger.Logger
 	enableIDResolution bool
-	AWSCredsExpiryInS  int64
+	awsCredsExpiryInS  misc.ValueLoader[int64]
 
 	TimeWindowDestinations    = []string{S3Datalake, GCSDatalake, AzureDatalake}
 	WarehouseDestinations     = []string{RS, BQ, SNOWFLAKE, POSTGRES, CLICKHOUSE, MSSQL, AzureSynapse, S3Datalake, GCSDatalake, AzureDatalake, DELTALAKE}
@@ -194,10 +194,9 @@ func Init() {
 	pkgLogger = logger.NewLogger().Child("warehouse").Child("utils")
 }
 
-// nolint:staticcheck // SA1019: config Register reloadable functions are deprecated
 func loadConfig() {
 	enableIDResolution = config.GetBoolVar(false, "Warehouse.enableIDResolution")
-	config.RegisterInt64ConfigVariable(3600, &AWSCredsExpiryInS, true, 1, "Warehouse.awsCredsExpiryInS")
+	awsCredsExpiryInS = config.GetReloadableInt64Var(3600, 1, "Warehouse.awsCredsExpiryInS")
 }
 
 type DeleteByMetaData struct {
@@ -726,7 +725,8 @@ func GetTemporaryS3Cred(destination *backendconfig.DestinationT) (string, string
 	// Create an STS client from just a session.
 	svc := sts.New(awsSession)
 
-	sessionTokenOutput, err := svc.GetSessionToken(&sts.GetSessionTokenInput{DurationSeconds: &AWSCredsExpiryInS})
+	expiryInSec := awsCredsExpiryInS.Load()
+	sessionTokenOutput, err := svc.GetSessionToken(&sts.GetSessionTokenInput{DurationSeconds: &expiryInSec})
 	if err != nil {
 		return "", "", "", err
 	}


### PR DESCRIPTION
# Description

- Use the new reloadable config API

## Linear Ticket

- https://linear.app/rudderstack/issue/PIPE-265/sa1019-update-configregister-api-in-warehouse

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
