### PR TITLE
fix: invalid JobsDB.backup.pathPrefix configuration

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -945,7 +945,7 @@ func (jd *Handle) loadConfig() {
 	jd.conf.backup.backupCheckSleepDuration = jd.config.GetReloadableDurationVar(
 		5, time.Second, []string{"JobsDB.backupCheckSleepDuration", "JobsDB.backupCheckSleepDurationIns"}...,
 	)
-	jd.conf.backup.PathPrefix = jd.config.GetString(
+	jd.conf.backup.PathPrefix = jd.config.GetStringVar(
 		jd.tablePrefix, fmt.Sprintf("JobsDB.backup.%v.pathPrefix", jd.tablePrefix),
 	)
 


### PR DESCRIPTION
# Description

For `JobsDB.backup.pathPrefix` we were using the default value as a configuration key and vice versa.

## Linear Ticket

[linear](https://linear.app/rudderstack/issue/PIPE-371/fix-jobsdb-pathprefix-config)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
