### PR TITLE
fix: use dedup on new records for deltalake

### DIFF
--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -899,6 +899,9 @@ func (d *Deltalake) partitionQuery(ctx context.Context, tableName string) (strin
 	if !d.config.enablePartitionPruning {
 		return "", nil
 	}
+	if d.Uploader.ShouldOnDedupUseNewRecord() {
+		return "", nil
+	}
 
 	query := fmt.Sprintf(`SHOW PARTITIONS %s.%s;`, d.Namespace, tableName)
 	rows, err := d.DB.QueryContext(ctx, query)


### PR DESCRIPTION
# Description

- Use dedup on new records for deltalake

## Linear Ticket

- https://linear.app/rudderstack/issue/PIPE-373/investigate-duplicates-for-acorns-prod

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
