### PR TITLE
chore: omit failedMessages from reporting json object

### DIFF
--- a/utils/types/reporting_types.go
+++ b/utils/types/reporting_types.go
@@ -57,7 +57,7 @@ type StatusDetail struct {
 	EventType      string           `json:"eventType"`
 	ErrorType      string           `json:"errorType"`
 	ViolationCount int64            `json:"violationCount"`
-	FailedMessages []*FailedMessage `json:"failedMessages"`
+	FailedMessages []*FailedMessage `json:"-"`
 }
 
 type FailedMessage struct {


### PR DESCRIPTION
# Description

Reporting http api doesn't expect a `failedMessages` field in the payload.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
