### PR TITLE
chore: enable user deletion for supported destinations

### DIFF
--- a/regulation-worker/internal/delete/api/api.go
+++ b/regulation-worker/internal/delete/api/api.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	pkgLogger             = logger.NewLogger().Child("api")
-	supportedDestinations = []string{"BRAZE", "AM", "INTERCOM", "CLEVERTAP", "AF", "MP", "GA", "ITERABLE"}
+	supportedDestinations = []string{"BRAZE", "AM", "INTERCOM", "CLEVERTAP", "AF", "MP", "GA", "ITERABLE", "ENGAGE", "CUSTIFY", "SENDGRID"}
 )
 
 type APIManager struct {

--- a/regulation-worker/internal/delete/api/api.go
+++ b/regulation-worker/internal/delete/api/api.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	pkgLogger             = logger.NewLogger().Child("api")
-	supportedDestinations = []string{"BRAZE", "AM", "INTERCOM", "CLEVERTAP", "AF", "MP", "GA"}
+	supportedDestinations = []string{"BRAZE", "AM", "INTERCOM", "CLEVERTAP", "AF", "MP", "GA", "ITERABLE"}
 )
 
 type APIManager struct {


### PR DESCRIPTION
# Description
- This pr enables user deletion for iterable destination
- user deletion changes for transformer is already released, adding destination name to  `supportedDestinations` list is pending, which is what this pr addresses

## Linear Ticket
https://linear.app/rudderstack/issue/INT-607/iterable-destination-user-delete-support

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
