### PR TITLE
chore: empty batch payload

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1216,6 +1216,19 @@ var _ = Describe("Gateway", func() {
 				}
 			}
 		})
+
+		It("should return empty batch payload error", func() {
+			expectHandlerResponse(
+				gateway.webBatchHandler(),
+				authorizedRequest(
+					WriteKeyEnabled,
+					bytes.NewBufferString(`{"batch":[]}`),
+				),
+				http.StatusBadRequest,
+				"Empty batch payload\n",
+				"batch",
+			)
+		})
 	})
 
 	Context("Robots", func() {

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -184,10 +184,10 @@ func (gw *Handle) userWebRequestWorkerProcess(userWebRequestWorker *userWebReque
 			sourceStats[sourceTag].RequestEventsBot(jobData.botEvents)
 			if err != nil {
 				switch {
-				case err == errRequestDropped:
+				case errors.Is(err, errRequestDropped):
 					req.done <- response.TooManyRequests
 					sourceStats[sourceTag].RequestDropped()
-				case err == errRequestSuppressed:
+				case errors.Is(err, errRequestSuppressed):
 					req.done <- "" // no error
 					sourceStats[sourceTag].RequestSuppressed()
 				default:

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -210,8 +210,8 @@ func (gw *Handle) userWebRequestWorkerProcess(userWebRequestWorker *userWebReque
 					)
 				}
 			} else {
-				req.done <- response.InvalidJSON
-				sourceStats[sourceTag].RequestFailed(response.InvalidJSON)
+				req.done <- response.EmptyBatchPayload
+				sourceStats[sourceTag].RequestFailed(response.EmptyBatchPayload)
 			}
 		}
 

--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -26,6 +26,8 @@ const (
 	InvalidWriteKey = "Invalid Write Key"
 	// InvalidJSON - Invalid JSON
 	InvalidJSON = "Invalid JSON"
+	// EmptyBatchPayload - Empty batch payload
+	EmptyBatchPayload = "Empty batch payload"
 	// InvalidWebhookSource - Source does not accept webhook events
 	InvalidWebhookSource = "Source does not accept webhook events"
 	// SourceTransformerResponseErrorReadFailed - Failed to read error from source transformer response

--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -81,6 +81,7 @@ var statusMap = map[string]status{
 	InvalidWriteKey:         {message: InvalidWriteKey, code: http.StatusUnauthorized},
 	SourceDisabled:          {message: SourceDisabled, code: http.StatusNotFound},
 	InvalidJSON:             {message: InvalidJSON, code: http.StatusBadRequest},
+	EmptyBatchPayload:       {message: EmptyBatchPayload, code: http.StatusBadRequest},
 	NoSourceIdInHeader:      {message: NoSourceIdInHeader, code: http.StatusUnauthorized},
 	InvalidSourceID:         {message: InvalidSourceID, code: http.StatusUnauthorized},
 	InvalidReplaySource:     {message: InvalidReplaySource, code: http.StatusUnauthorized},


### PR DESCRIPTION
# Description

### Improve response message when JSON payload is empty (gateway)

Current behaviour:

If a request contains an empty array as value of the batch property in JSON we respond with Invalid JSON

Desired behaviour

If a request contains an empty array as value of the batch property in JSON we should respond with Empty Batch Payload

## Sidenotes

I could not find other places where `InvalidJSON` is being misused.

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-250/improve-response-message-when-json-payload-is-empty-gateway) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
