### PR TITLE
chore: use common PAT instead of rudder-server-bot

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -13,7 +13,7 @@ jobs:
         id: extract_branch
       - uses: google-github-actions/release-please-action@v3
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.PAT }}
           pull-request-title-pattern: "chore: prerelease ${version}"
           release-type: go
           package-name: rudder-server


### PR DESCRIPTION
# Description

`secrets.GH_PAT` is using rudder-server-bot Personal Access Token. We want to remove the `rudder-server-bot` account and instead use `secrets.PAT`, already used in other Github actions

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-388/remove-rudder-server-bot-account-from-github

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
