### PR TITLE
fix: set local schema when syncing from remote

### DIFF
--- a/warehouse/schema/schema_test.go
+++ b/warehouse/schema/schema_test.go
@@ -18,35 +18,32 @@ import (
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
+func schemaKey(sourceID, destinationID, namespace string) string {
+	return fmt.Sprintf("%s_%s_%s", sourceID, destinationID, namespace)
+}
+
 type mockSchemaRepo struct {
 	err       error
 	schemaMap map[string]model.WHSchema
 }
 
-func (m *mockSchemaRepo) GetForNamespace(_ context.Context, sourceID, destID, namespace string) (model.WHSchema, error) {
-	key := fmt.Sprintf("%s_%s_%s", sourceID, destID, namespace)
+func (m *mockSchemaRepo) GetForNamespace(_ context.Context, sourceID, destinationID, namespace string) (model.WHSchema, error) {
+	if m.err != nil {
+		return model.WHSchema{}, m.err
+	}
 
-	return m.schemaMap[key], m.err
+	key := schemaKey(sourceID, destinationID, namespace)
+	return m.schemaMap[key], nil
 }
 
 func (m *mockSchemaRepo) Insert(_ context.Context, schema *model.WHSchema) (int64, error) {
-	if schema == nil {
+	if m.err != nil {
 		return 0, m.err
 	}
-	key := fmt.Sprintf("%s_%s_%s", schema.SourceID, schema.DestinationID, schema.Namespace)
 
+	key := schemaKey(schema.SourceID, schema.DestinationID, schema.Namespace)
 	m.schemaMap[key] = *schema
-	return int64(len(m.schemaMap)), m.err
-}
-
-type mockFetchSchemaFromWarehouse struct {
-	schemaInWarehouse             model.Schema
-	unrecognizedSchemaInWarehouse model.Schema
-	err                           error
-}
-
-func (m *mockFetchSchemaFromWarehouse) FetchSchema(context.Context) (model.Schema, model.Schema, error) {
-	return m.schemaInWarehouse, m.unrecognizedSchemaInWarehouse, m.err
+	return 0, nil
 }
 
 type mockStagingFileRepo struct {
@@ -55,17 +52,45 @@ type mockStagingFileRepo struct {
 }
 
 func (m *mockStagingFileRepo) GetSchemasByIDs(context.Context, []int64) ([]model.Schema, error) {
-	return m.schemas, m.err
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.schemas, nil
 }
 
-func TestSchema_GetUpdateLocalSchema(t *testing.T) {
-	const (
-		sourceID      = "test_source"
-		destID        = "test_dest"
-		namespace     = "test_namespace"
-		warehouseType = warehouseutils.RS
-		uploadID      = 1
-	)
+type mockFetchSchemaRepo struct {
+	schemaInWarehouse             model.Schema
+	unrecognizedSchemaInWarehouse model.Schema
+	err                           error
+}
+
+func (m *mockFetchSchemaRepo) FetchSchema(context.Context) (model.Schema, model.Schema, error) {
+	if m.err != nil {
+		return nil, nil, m.err
+	}
+
+	return m.schemaInWarehouse, m.unrecognizedSchemaInWarehouse, nil
+}
+
+func TestSchema_UpdateLocalSchema(t *testing.T) {
+	sourceID := "test_source_id"
+	destinationID := "test_destination_id"
+	namespace := "test_namespace"
+	warehouseType := warehouseutils.RS
+	uploadID := int64(1)
+	tableName := "test_table"
+
+	schemaInWarehouse := model.Schema{
+		tableName: model.TableSchema{
+			"warehouse_test_int":       "int",
+			"warehouse_test_str":       "string",
+			"warehouse_test_bool":      "boolean",
+			"warehouse_test_float":     "float",
+			"warehouse_test_timestamp": "timestamp",
+			"warehouse_test_date":      "date",
+			"warehouse_test_datetime":  "datetime",
+		},
+	}
 
 	testCases := []struct {
 		name          string
@@ -92,7 +117,7 @@ func TestSchema_GetUpdateLocalSchema(t *testing.T) {
 			name: "schema in db",
 			mockSchema: model.WHSchema{
 				Schema: model.Schema{
-					"table1": model.TableSchema{
+					tableName: model.TableSchema{
 						"column1": "string",
 						"column2": "int",
 						"column3": "float",
@@ -103,7 +128,7 @@ func TestSchema_GetUpdateLocalSchema(t *testing.T) {
 			},
 			mockSchemaErr: nil,
 			wantSchema: model.Schema{
-				"table1": model.TableSchema{
+				tableName: model.TableSchema{
 					"column1": "string",
 					"column2": "int",
 					"column3": "float",
@@ -121,45 +146,73 @@ func TestSchema_GetUpdateLocalSchema(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			mockSchemaRepo := &mockSchemaRepo{
+			mockRepo := &mockSchemaRepo{
 				err:       tc.mockSchemaErr,
 				schemaMap: map[string]model.WHSchema{},
 			}
 
-			sch := Schema{
+			s := Schema{
 				warehouse: model.Warehouse{
 					Source: backendconfig.SourceT{
 						ID: sourceID,
 					},
 					Destination: backendconfig.DestinationT{
-						ID: destID,
+						ID: destinationID,
 					},
 					Namespace: namespace,
 					Type:      warehouseType,
 				},
-				schemaRepo: mockSchemaRepo,
+				schemaRepo:        mockRepo,
+				schemaInWarehouse: schemaInWarehouse,
 			}
 
 			ctx := context.Background()
 
-			err := sch.UpdateLocalSchema(ctx, uploadID, tc.mockSchema.Schema)
+			err := s.UpdateLocalSchema(ctx, uploadID, tc.mockSchema.Schema)
 			if tc.wantError == nil {
 				require.NoError(t, err)
+				require.Equal(t, tc.wantSchema, s.localSchema)
+				require.Equal(t, tc.wantSchema, mockRepo.schemaMap[schemaKey(sourceID, destinationID, namespace)].Schema)
 			} else {
-				require.ErrorContains(t, err, tc.wantError.Error())
+				require.Error(t, err, fmt.Sprintf("got error %v, want error %v", err, tc.wantError))
+				require.Empty(t, s.localSchema)
+				require.Empty(t, mockRepo.schemaMap[schemaKey(sourceID, destinationID, namespace)].Schema)
 			}
 
-			require.Equal(t, tc.wantSchema, sch.localSchema)
+			err = s.UpdateLocalSchemaWithWarehouse(ctx, uploadID)
 			if tc.wantError == nil {
 				require.NoError(t, err)
+				require.Equal(t, schemaInWarehouse, s.localSchema)
+				require.Equal(t, schemaInWarehouse, mockRepo.schemaMap[schemaKey(sourceID, destinationID, namespace)].Schema)
 			} else {
-				require.ErrorContains(t, err, tc.wantError.Error())
+				require.Error(t, err, fmt.Sprintf("got error %v, want error %v", err, tc.wantError))
+				require.Empty(t, s.localSchema)
+				require.Empty(t, mockRepo.schemaMap[schemaKey(sourceID, destinationID, namespace)].Schema)
 			}
 		})
 	}
 }
 
 func TestSchema_FetchSchemaFromWarehouse(t *testing.T) {
+	sourceID := "test_source_id"
+	destinationID := "test_destination_id"
+	namespace := "test_namespace"
+	destType := warehouseutils.RS
+	workspaceID := "test-workspace-id"
+	tableName := "test-table"
+	column := "test_date"
+	unknownColumn := "test_unknown_column"
+	updatedTable := "updated_test_table"
+	updatedSchema := model.TableSchema{
+		"updated_test_int":       "int",
+		"updated_test_str":       "string",
+		"updated_test_bool":      "boolean",
+		"updated_test_float":     "float",
+		"updated_test_timestamp": "timestamp",
+		"updated_test_date":      "date",
+		"updated_test_datetime":  "datetime",
+	}
+
 	testCases := []struct {
 		name           string
 		mockSchema     model.Schema
@@ -181,7 +234,7 @@ func TestSchema_FetchSchemaFromWarehouse(t *testing.T) {
 		{
 			name: "no deprecated columns",
 			mockSchema: model.Schema{
-				"test-table": model.TableSchema{
+				tableName: model.TableSchema{
 					"test_int":       "int",
 					"test_str":       "string",
 					"test_bool":      "boolean",
@@ -192,7 +245,7 @@ func TestSchema_FetchSchemaFromWarehouse(t *testing.T) {
 				},
 			},
 			expectedSchema: model.Schema{
-				"test-table": model.TableSchema{
+				tableName: model.TableSchema{
 					"test_int":       "int",
 					"test_str":       "string",
 					"test_bool":      "boolean",
@@ -206,7 +259,7 @@ func TestSchema_FetchSchemaFromWarehouse(t *testing.T) {
 		{
 			name: "invalid deprecated column format",
 			mockSchema: model.Schema{
-				"test-table": model.TableSchema{
+				tableName: model.TableSchema{
 					"test_int":                 "int",
 					"test_str":                 "string",
 					"test_bool":                "boolean",
@@ -220,7 +273,7 @@ func TestSchema_FetchSchemaFromWarehouse(t *testing.T) {
 				},
 			},
 			expectedSchema: model.Schema{
-				"test-table": model.TableSchema{
+				tableName: model.TableSchema{
 					"test_int":                 "int",
 					"test_str":                 "string",
 					"test_bool":                "boolean",
@@ -237,7 +290,7 @@ func TestSchema_FetchSchemaFromWarehouse(t *testing.T) {
 		{
 			name: "valid deprecated column format",
 			mockSchema: model.Schema{
-				"test-table": model.TableSchema{
+				tableName: model.TableSchema{
 					"test_int":                 "int",
 					"test_str":                 "string",
 					"test_bool":                "boolean",
@@ -254,7 +307,7 @@ func TestSchema_FetchSchemaFromWarehouse(t *testing.T) {
 				},
 			},
 			expectedSchema: model.Schema{
-				"test-table": model.TableSchema{
+				tableName: model.TableSchema{
 					"test_int":                 "int",
 					"test_str":                 "string",
 					"test_bool":                "boolean",
@@ -270,33 +323,25 @@ func TestSchema_FetchSchemaFromWarehouse(t *testing.T) {
 		},
 	}
 
-	const (
-		sourceID    = "test-source-id"
-		destID      = "test-dest-id"
-		destType    = "RS"
-		workspaceID = "test-workspace-id"
-		namespace   = "test-namespace"
-	)
-
 	for _, tc := range testCases {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			fechSchemaRepo := mockFetchSchemaFromWarehouse{
+			mockRepo := mockFetchSchemaRepo{
 				schemaInWarehouse:             tc.mockSchema,
 				unrecognizedSchemaInWarehouse: tc.mockSchema,
 				err:                           tc.mockErr,
 			}
 
-			sh := &Schema{
+			s := &Schema{
 				warehouse: model.Warehouse{
 					Source: backendconfig.SourceT{
 						ID: sourceID,
 					},
 					Destination: backendconfig.DestinationT{
-						ID: destID,
+						ID: destinationID,
 						DestinationDefinition: backendconfig.DestinationDefinitionT{
 							Name: destType,
 						},
@@ -309,19 +354,37 @@ func TestSchema_FetchSchemaFromWarehouse(t *testing.T) {
 
 			ctx := context.Background()
 
-			err := sh.FetchSchemaFromWarehouse(ctx, &fechSchemaRepo)
-			if tc.wantError != nil {
-				require.EqualError(t, err, tc.wantError.Error())
-			} else {
+			require.Empty(t, s.GetTableSchemaInWarehouse(tableName))
+			require.True(t, s.IsWarehouseSchemaEmpty())
+
+			err := s.FetchSchemaFromWarehouse(ctx, &mockRepo)
+			if tc.wantError == nil {
 				require.NoError(t, err)
+			} else {
+				require.Error(t, err, fmt.Sprintf("got error %v, want error %v", err, tc.wantError))
 			}
-			require.Equal(t, tc.expectedSchema, sh.schemaInWarehouse)
-			require.Equal(t, tc.expectedSchema, sh.unrecognizedSchemaInWarehouse)
+			require.Equal(t, tc.expectedSchema, s.schemaInWarehouse)
+			require.Equal(t, tc.expectedSchema, s.unrecognizedSchemaInWarehouse)
+			require.Equal(t, tc.expectedSchema[tableName], s.GetTableSchemaInWarehouse(tableName))
+			require.Equal(t, len(tc.expectedSchema[tableName]), s.GetColumnsCountInWarehouseSchema(tableName))
+			if len(tc.expectedSchema) == 0 {
+				require.True(t, s.IsWarehouseSchemaEmpty())
+				require.False(t, s.IsColumnInUnrecognizedSchema(tableName, column))
+				require.False(t, s.IsColumnInUnrecognizedSchema(tableName, unknownColumn))
+			} else {
+				require.False(t, s.IsWarehouseSchemaEmpty())
+				require.True(t, s.IsColumnInUnrecognizedSchema(tableName, column))
+				require.False(t, s.IsColumnInUnrecognizedSchema(tableName, unknownColumn))
+			}
+
+			s.UpdateWarehouseTableSchema(updatedTable, updatedSchema)
+			require.Equal(t, updatedSchema, s.GetTableSchemaInWarehouse(updatedTable))
+			require.False(t, s.IsWarehouseSchemaEmpty())
 		})
 	}
 }
 
-func TestSchema_GetUploadSchemaDiff(t *testing.T) {
+func TestSchema_TableSchemaDiff(t *testing.T) {
 	testCases := []struct {
 		name              string
 		tableName         string
@@ -437,10 +500,10 @@ func TestSchema_GetUploadSchemaDiff(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			sch := Schema{
+			s := Schema{
 				schemaInWarehouse: tc.currentSchema,
 			}
-			diff := sch.TableSchemaDiff(tc.tableName, tc.uploadTableSchema)
+			diff := s.TableSchemaDiff(tc.tableName, tc.uploadTableSchema)
 			require.EqualValues(t, diff, tc.expected)
 		})
 	}
@@ -590,28 +653,24 @@ func TestSchema_HasLocalSchemaChanged(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			sch := &Schema{
+			s := &Schema{
 				warehouse: model.Warehouse{
 					Type: warehouseutils.SNOWFLAKE,
 				},
 				skipDeepEqualSchemas: tc.skipDeepEquals,
 				schemaInWarehouse:    tc.schemaInWarehouse,
 			}
-			require.Equal(t, tc.expected, sch.hasSchemaChanged(tc.localSchema))
+			require.Equal(t, tc.expected, s.hasSchemaChanged(tc.localSchema))
 		})
 	}
 }
 
 func TestSchema_ConsolidateStagingFilesUsingLocalSchema(t *testing.T) {
-	warehouseutils.Init()
-
-	const (
-		sourceID    = "test-source-id"
-		destID      = "test-dest-id"
-		destType    = "BQ"
-		workspaceID = "test-workspace-id"
-		namespace   = "test-namespace"
-	)
+	sourceID := "test_source_id"
+	destinationID := "test_destination_id"
+	namespace := "test_namespace"
+	destType := warehouseutils.RS
+	workspaceID := "test-workspace-id"
 
 	stagingFiles := lo.RepeatBy(100, func(index int) *model.StagingFile {
 		return &model.StagingFile{
@@ -1603,13 +1662,18 @@ func TestSchema_ConsolidateStagingFilesUsingLocalSchema(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			sh := &Schema{
+			mockRepo := &mockStagingFileRepo{
+				schemas: tc.mockSchemas,
+				err:     tc.mockErr,
+			}
+
+			s := &Schema{
 				warehouse: model.Warehouse{
 					Source: backendconfig.SourceT{
 						ID: sourceID,
 					},
 					Destination: backendconfig.DestinationT{
-						ID: destID,
+						ID: destinationID,
 						DestinationDefinition: backendconfig.DestinationDefinitionT{
 							Name: destType,
 						},
@@ -1618,23 +1682,219 @@ func TestSchema_ConsolidateStagingFilesUsingLocalSchema(t *testing.T) {
 					Namespace:   namespace,
 					Type:        tc.warehouseType,
 				},
-				log: logger.NOP,
-				stagingFileRepo: &mockStagingFileRepo{
-					schemas: tc.mockSchemas,
-					err:     tc.mockErr,
-				},
+				log:                              logger.NOP,
+				stagingFileRepo:                  mockRepo,
 				enableIDResolution:               tc.idResolutionEnabled,
 				localSchema:                      tc.warehouseSchema,
 				stagingFilesSchemaPaginationSize: 2,
 			}
 
-			uploadSchema, err := sh.ConsolidateStagingFilesUsingLocalSchema(ctx, stagingFiles)
-			if tc.wantError != nil {
-				require.EqualError(t, err, tc.wantError.Error())
-			} else {
+			uploadSchema, err := s.ConsolidateStagingFilesUsingLocalSchema(ctx, stagingFiles)
+			if tc.wantError == nil {
 				require.NoError(t, err)
+			} else {
+				require.Error(t, err, fmt.Sprintf("got error %v, want error %v", err, tc.wantError))
 			}
 			require.Equal(t, tc.expectedSchema, uploadSchema)
 		})
 	}
+}
+
+func TestSchema_SyncRemoteSchema(t *testing.T) {
+	sourceID := "test_source_id"
+	destinationID := "test_destination_id"
+	namespace := "test_namespace"
+	destType := warehouseutils.RS
+	workspaceID := "test-workspace-id"
+	uploadID := int64(1)
+	tableName := "test_table_name"
+
+	t.Run("should return error if unable to fetch local schema", func(t *testing.T) {
+		s := &Schema{
+			warehouse: model.Warehouse{
+				Source: backendconfig.SourceT{
+					ID: sourceID,
+				},
+				Destination: backendconfig.DestinationT{
+					ID: destinationID,
+					DestinationDefinition: backendconfig.DestinationDefinitionT{
+						Name: destType,
+					},
+				},
+				WorkspaceID: workspaceID,
+				Namespace:   namespace,
+				Type:        destType,
+			},
+			schemaRepo: &mockSchemaRepo{
+				err:       errors.New("test error"),
+				schemaMap: map[string]model.WHSchema{},
+			},
+			log: logger.NOP,
+		}
+
+		ctx := context.Background()
+
+		schemaChanged, err := s.SyncRemoteSchema(ctx, &mockFetchSchemaRepo{}, uploadID)
+		require.Error(t, err, "got error %v, want error %v", err, "fetching schema from local: test error")
+		require.False(t, schemaChanged)
+	})
+	t.Run("should return error if unable to fetch remote schema", func(t *testing.T) {
+		s := &Schema{
+			warehouse: model.Warehouse{
+				Source: backendconfig.SourceT{
+					ID: sourceID,
+				},
+				Destination: backendconfig.DestinationT{
+					ID: destinationID,
+					DestinationDefinition: backendconfig.DestinationDefinitionT{
+						Name: destType,
+					},
+				},
+				WorkspaceID: workspaceID,
+				Namespace:   namespace,
+				Type:        destType,
+			},
+			schemaRepo: &mockSchemaRepo{
+				err:       nil,
+				schemaMap: map[string]model.WHSchema{},
+			},
+			log: logger.NOP,
+		}
+
+		mockFetchSchemaRepo := &mockFetchSchemaRepo{
+			err: errors.New("test error"),
+		}
+
+		ctx := context.Background()
+
+		schemaChanged, err := s.SyncRemoteSchema(ctx, mockFetchSchemaRepo, uploadID)
+		require.Error(t, err, "got error %v, want error %v", err, "fetching schema from warehouse: test error")
+		require.False(t, schemaChanged)
+	})
+	t.Run("schema changed", func(t *testing.T) {
+		testSchema := model.Schema{
+			tableName: model.TableSchema{
+				"test_int":       "int",
+				"test_str":       "string",
+				"test_bool":      "boolean",
+				"test_float":     "float",
+				"test_timestamp": "timestamp",
+				"test_date":      "date",
+				"test_datetime":  "datetime",
+			},
+		}
+		schemaInWarehouse := model.Schema{
+			tableName: model.TableSchema{
+				"warehouse_test_int":       "int",
+				"warehouse_test_str":       "string",
+				"warehouse_test_bool":      "boolean",
+				"warehouse_test_float":     "float",
+				"warehouse_test_timestamp": "timestamp",
+				"warehouse_test_date":      "date",
+				"warehouse_test_datetime":  "datetime",
+			},
+		}
+
+		key := schemaKey(sourceID, destinationID, namespace)
+		mockSchemaRepo := &mockSchemaRepo{
+			err: nil,
+			schemaMap: map[string]model.WHSchema{
+				key: {
+					Schema: testSchema,
+				},
+			},
+		}
+
+		s := &Schema{
+			warehouse: model.Warehouse{
+				Source: backendconfig.SourceT{
+					ID: sourceID,
+				},
+				Destination: backendconfig.DestinationT{
+					ID: destinationID,
+					DestinationDefinition: backendconfig.DestinationDefinitionT{
+						Name: destType,
+					},
+				},
+				WorkspaceID: workspaceID,
+				Namespace:   namespace,
+				Type:        destType,
+			},
+			schemaRepo: mockSchemaRepo,
+			log:        logger.NOP,
+		}
+
+		mockFetchSchemaRepo := &mockFetchSchemaRepo{
+			err:                           nil,
+			schemaInWarehouse:             schemaInWarehouse,
+			unrecognizedSchemaInWarehouse: schemaInWarehouse,
+		}
+
+		ctx := context.Background()
+
+		schemaChanged, err := s.SyncRemoteSchema(ctx, mockFetchSchemaRepo, uploadID)
+		require.NoError(t, err)
+		require.True(t, schemaChanged)
+		require.Equal(t, schemaInWarehouse, s.localSchema)
+		require.Equal(t, schemaInWarehouse, mockSchemaRepo.schemaMap[schemaKey(sourceID, destinationID, namespace)].Schema)
+		require.Equal(t, schemaInWarehouse, s.schemaInWarehouse)
+		require.Equal(t, schemaInWarehouse, s.unrecognizedSchemaInWarehouse)
+	})
+	t.Run("schema not changed", func(t *testing.T) {
+		testSchema := model.Schema{
+			tableName: model.TableSchema{
+				"test_int":       "int",
+				"test_str":       "string",
+				"test_bool":      "boolean",
+				"test_float":     "float",
+				"test_timestamp": "timestamp",
+				"test_date":      "date",
+				"test_datetime":  "datetime",
+			},
+		}
+
+		key := schemaKey(sourceID, destinationID, namespace)
+		mockSchemaRepo := &mockSchemaRepo{
+			err: nil,
+			schemaMap: map[string]model.WHSchema{
+				key: {
+					Schema: testSchema,
+				},
+			},
+		}
+
+		s := &Schema{
+			warehouse: model.Warehouse{
+				Source: backendconfig.SourceT{
+					ID: sourceID,
+				},
+				Destination: backendconfig.DestinationT{
+					ID: destinationID,
+					DestinationDefinition: backendconfig.DestinationDefinitionT{
+						Name: destType,
+					},
+				},
+				WorkspaceID: workspaceID,
+				Namespace:   namespace,
+				Type:        destType,
+			},
+			schemaRepo: mockSchemaRepo,
+			log:        logger.NOP,
+		}
+
+		mockFetchSchemaRepo := &mockFetchSchemaRepo{
+			err:                           nil,
+			schemaInWarehouse:             testSchema,
+			unrecognizedSchemaInWarehouse: testSchema,
+		}
+
+		ctx := context.Background()
+
+		schemaChanged, err := s.SyncRemoteSchema(ctx, mockFetchSchemaRepo, uploadID)
+		require.NoError(t, err)
+		require.False(t, schemaChanged)
+		require.Equal(t, testSchema, s.localSchema)
+		require.Equal(t, testSchema, s.schemaInWarehouse)
+		require.Equal(t, testSchema, s.unrecognizedSchemaInWarehouse)
+	})
 }


### PR DESCRIPTION
# Description

- When syncing from remote, we need to set the local schema as well.

## Linear Ticket

- https://linear.app/rudderstack/issue/PIPE-392/sync-remote-schema-fix

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
