### PR TITLE
feat: introduce pagination in failed-keys endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	github.com/rudderlabs/sql-tunnels v0.1.5
 	github.com/samber/lo v1.38.1
 	github.com/segmentio/kafka-go v0.4.42
+	github.com/segmentio/ksuid v1.0.4
 	github.com/snowflakedb/gosnowflake v1.6.24
 	github.com/sony/gobreaker v0.5.0
 	github.com/spaolacci/murmur3 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1856,6 +1856,8 @@ github.com/segmentio/backo-go v1.0.1 h1:68RQccglxZeyURy93ASB/2kc9QudzgIDexJ927N+
 github.com/segmentio/backo-go v1.0.1/go.mod h1:9/Rh6yILuLysoQnZ2oNooD2g7aBnvM7r/fNVxRNWfBc=
 github.com/segmentio/kafka-go v0.4.42 h1:qffhBZCz4WcWyNuHEclHjIMLs2slp6mZO8px+5W5tfU=
 github.com/segmentio/kafka-go v0.4.42/go.mod h1:d0g15xPMqoUookug0OU75DhGZxXwCFxSLeJ4uphwJzg=
+github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
+github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/shirou/gopsutil/v3 v3.23.9 h1:ZI5bWVeu2ep4/DIxB4U9okeYJ7zp/QLTO4auRb/ty/E=
 github.com/shirou/gopsutil/v3 v3.23.9/go.mod h1:x/NWSb71eMcjFIO0vhyGW5nZ7oSIgVjrCnADckb85GA=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=

--- a/processor/transformer/transformer_test.go
+++ b/processor/transformer/transformer_test.go
@@ -771,7 +771,7 @@ func TestLongRunningTransformation(t *testing.T) {
 		mockLogger := mock_logger.NewMockLogger(ctrl)
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		trackLongRunningTransformation(ctx, "stage", time.Microsecond, mockLogger)
+		trackLongRunningTransformation(ctx, "stage", time.Hour, mockLogger)
 	})
 
 	t.Run("log stmt", func(t *testing.T) {

--- a/services/rsources/failed_records_pagination_test.go
+++ b/services/rsources/failed_records_pagination_test.go
@@ -1,0 +1,89 @@
+package rsources
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
+)
+
+func TestFailedRecordsPerformanceTest(t *testing.T) {
+	var noPaginationDur time.Duration
+	var paginationDur time.Duration
+
+	total := 100_000
+	pageSize := 10_000
+	t.Run("100k records no pagination", func(t *testing.T) {
+		noPaginationDur = RunFailedRecordsPerformanceTest(t, total, 0)
+		t.Logf("100k records no pagination took %s", noPaginationDur)
+	})
+	t.Run("100k records with 10k pagination", func(t *testing.T) {
+		paginationDur = RunFailedRecordsPerformanceTest(t, total, pageSize)
+		t.Logf("100k records with 10k pagination took %s", paginationDur)
+	})
+
+	t.Run("pagination vs no pagination comparison", func(t *testing.T) {
+		pages := total / pageSize
+		if noPaginationDur > 0 && int(paginationDur/noPaginationDur) > pages {
+			t.Errorf("Pagination time (%s) is more than %dx slower than no pagination time (%s)", paginationDur, pages, noPaginationDur)
+		}
+	})
+}
+
+func BenchmarkFailedRecordsPerformanceTest(b *testing.B) {
+	b.Run("10Mil records no pagination", func(b *testing.B) {
+		d := RunFailedRecordsPerformanceTest(b, 10_000_000, 0)
+		b.ReportMetric(float64(d.Milliseconds()), "duration_millis")
+	})
+	b.Run("10Mil records with 100k pagination", func(b *testing.B) {
+		d := RunFailedRecordsPerformanceTest(b, 10_000_000, 100_000)
+		b.ReportMetric(float64(d.Milliseconds()), "duration_millis")
+	})
+}
+
+func RunFailedRecordsPerformanceTest(t testing.TB, recordCount, pageSize int) time.Duration {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	postgresContainer, err := resource.SetupPostgres(pool, t)
+	require.NoError(t, err)
+
+	service, err := NewJobService(JobServiceConfig{
+		LocalHostname: postgresContainer.Host,
+		MaxPoolSize:   1,
+		LocalConn:     postgresContainer.DBDsn,
+		Log:           logger.NOP,
+	})
+	require.NoError(t, err)
+
+	// seed the database with records
+
+	// Create 20k different job run ids with 10 records each
+	_, err = postgresContainer.DB.Exec(`INSERT INTO rsources_failed_keys_v2 (id, job_run_id, task_run_id, source_id, destination_id) SELECT id::text, id::text, '1', '1', '1' FROM generate_series(1, 20000) as id`)
+	require.NoError(t, err)
+	_, err = postgresContainer.DB.Exec(`INSERT INTO rsources_failed_keys_v2_records (id, record_id) SELECT k.id, to_json('"'||s.id||'"') from rsources_failed_keys_v2 k CROSS JOIN (SELECT id::text FROM generate_series(1, 10) as id) s`)
+	require.NoError(t, err)
+	// job run id 1 should have [recordCount] records
+	_, err = postgresContainer.DB.Exec(fmt.Sprintf(`INSERT INTO rsources_failed_keys_v2_records (id, record_id) SELECT k.id, to_json('"'||s.id||'"') from rsources_failed_keys_v2 k CROSS JOIN (SELECT id::text FROM generate_series(11, %d) as id) s WHERE k.job_run_id = '1'`, recordCount))
+	require.NoError(t, err)
+
+	start := time.Now()
+	paging := PagingInfo{
+		Size: pageSize,
+	}
+	var total int
+	for total < recordCount {
+		r, err := service.GetFailedRecords(context.Background(), "1", JobFilter{}, paging)
+		require.NoError(t, err)
+		require.Len(t, r.Tasks, 1)
+		require.Len(t, r.Tasks[0].Sources, 1)
+		require.Len(t, r.Tasks[0].Sources[0].Destinations, 1)
+		total += len(r.Tasks[0].Sources[0].Destinations[0].Records)
+	}
+	return time.Since(start)
+}

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -22,6 +22,9 @@ const defaultRetentionPeriodInHours = 3 * 24
 // ErrOperationNotSupported sentinel error indicating an unsupported operation
 var ErrOperationNotSupported = errors.New("rsources: operation not supported")
 
+// ErrInvalidPaginationToken sentinel error indicating an invalid pagination token
+var ErrInvalidPaginationToken = errors.New("rsources: invalid pagination token")
+
 // In postgres, the replication slot name can contain lower-case letters, underscore characters, and numbers.
 var replSlotDisallowedChars *regexp.Regexp = regexp.MustCompile(`[^a-z0-9_]`)
 
@@ -177,6 +180,8 @@ func (sh *sourcesHandler) GetFailedRecords(ctx context.Context, jobRunId string,
 			filters = filters + fmt.Sprintf(` AND r.id >= $%[1]d AND r.record_id > $%[2]d`, len(params)+1, len(params)+2)
 			params = append(params, nextPageToken.ID, nextPageToken.RecordID)
 			limit = fmt.Sprintf(`LIMIT %d`, paging.Size)
+		} else {
+			return JobFailedRecords{ID: jobRunId}, ErrInvalidPaginationToken
 		}
 	}
 	sqlStatement := fmt.Sprintf(

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/lib/pq"
+	"github.com/segmentio/ksuid"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -33,7 +34,7 @@ type sourcesHandler struct {
 }
 
 func (sh *sourcesHandler) GetStatus(ctx context.Context, jobRunId string, filter JobFilter) (JobStatus, error) {
-	filters, filterParams := sqlFilters(jobRunId, filter)
+	filters, filterParams := sqlFilters(jobRunId, filter, "")
 
 	sqlStatement := fmt.Sprintf(
 		`SELECT 
@@ -103,51 +104,57 @@ func (*sourcesHandler) IncrementStats(ctx context.Context, tx *sql.Tx, jobRunId 
 	return err
 }
 
-func (sh *sourcesHandler) AddFailedRecords(ctx context.Context, tx *sql.Tx, jobRunId string, key JobTargetKey, records []json.RawMessage) (err error) {
+func (sh *sourcesHandler) AddFailedRecords(ctx context.Context, tx *sql.Tx, jobRunId string, key JobTargetKey, records []json.RawMessage) error {
 	if sh.config.SkipFailedRecordsCollection {
-		return
+		return nil
 	}
-	stmt, err := tx.Prepare(`insert into "rsources_failed_keys" (
-		job_run_id,
-		task_run_id,
-		source_id,
-		destination_id,
-		record_id
-	) values ($1, $2, $3, $4, $5)`)
+
+	row := tx.QueryRow(`WITH new_key AS (
+		INSERT INTO rsources_failed_keys_v2 (id, job_run_id, task_run_id, source_id, destination_id)
+		VALUES ($1, $2, $3, $4, $5) 
+		ON CONFLICT (job_run_id, task_run_id, source_id, destination_id, db_name) DO NOTHING
+		RETURNING id
+	) SELECT COALESCE(
+		(SELECT id FROM new_key),
+		(SELECT id FROM rsources_failed_keys_v2 WHERE job_run_id = $2 AND task_run_id = $3 AND source_id = $4 AND destination_id = $5)
+	)`, ksuid.New().String(), jobRunId, key.TaskRunID, key.SourceID, key.DestinationID)
+	var id string
+	if err := row.Scan(&id); err != nil {
+		return fmt.Errorf("scanning rsources_failed_keys_v2 id: %w", err)
+	}
+
+	stmt, err := tx.Prepare(`INSERT INTO rsources_failed_keys_v2_records (id, record_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = stmt.Close() }()
 
 	for i := range records {
-		_, err = stmt.ExecContext(
+		if _, err = stmt.ExecContext(
 			ctx,
-			jobRunId,
-			key.TaskRunID,
-			key.SourceID,
-			key.DestinationID,
-			records[i])
-		if err != nil {
-			return err
+			id,
+			records[i]); err != nil {
+			return fmt.Errorf("inserting into rsources_failed_keys_v2_records: %w", err)
 		}
 	}
-
-	return
+	return nil
 }
 
 func (sh *sourcesHandler) GetFailedRecords(ctx context.Context, jobRunId string, filter JobFilter) (JobFailedRecords, error) {
 	if sh.config.SkipFailedRecordsCollection {
 		return JobFailedRecords{ID: jobRunId}, ErrOperationNotSupported
 	}
-	filters, filterParams := sqlFilters(jobRunId, filter)
+	filters, filterParams := sqlFilters(jobRunId, filter, "k")
 
 	sqlStatement := fmt.Sprintf(
 		`SELECT
-			task_run_id,
-			source_id,
-			destination_id,
-			record_id  FROM "rsources_failed_keys" %s
-			ORDER BY task_run_id, source_id, destination_id ASC`,
+			k.task_run_id,
+			k.source_id,
+			k.destination_id,
+			r.record_id 
+		FROM "rsources_failed_keys_v2" k 
+		JOIN "rsources_failed_keys_v2_records" r ON r.id = k.id %s 
+		ORDER BY r.id, r.record_id ASC`,
 		filters)
 
 	failedRecordsMap := map[JobTargetKey]FailedRecords{}
@@ -158,7 +165,7 @@ func (sh *sourcesHandler) GetFailedRecords(ctx context.Context, jobRunId string,
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var key JobTargetKey
-		var record json.RawMessage
+		var record string
 		err := rows.Scan(
 			&key.TaskRunID,
 			&key.SourceID,
@@ -168,7 +175,7 @@ func (sh *sourcesHandler) GetFailedRecords(ctx context.Context, jobRunId string,
 		if err != nil {
 			return JobFailedRecords{ID: jobRunId}, err
 		}
-		failedRecordsMap[key] = append(failedRecordsMap[key], record)
+		failedRecordsMap[key] = append(failedRecordsMap[key], json.RawMessage(record))
 	}
 	if err := rows.Err(); err != nil {
 		return JobFailedRecords{ID: jobRunId}, err
@@ -194,18 +201,19 @@ func (sh *sourcesHandler) Delete(ctx context.Context, jobRunId string, filter Jo
 		return err
 	}
 
-	filters, filterParams := sqlFilters(jobRunId, filter)
+	filters, filterParams := sqlFilters(jobRunId, filter, "")
 
-	sqlStatement := fmt.Sprintf(`delete from "rsources_stats" %s`, filters)
-	_, err = tx.ExecContext(ctx, sqlStatement, filterParams...)
-	if err != nil {
+	if _, err = tx.ExecContext(ctx, fmt.Sprintf(`delete from "rsources_stats" %s`, filters), filterParams...); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
 
-	sqlStatement = fmt.Sprintf(`delete from "rsources_failed_keys" %s`, filters)
-	_, err = tx.ExecContext(ctx, sqlStatement, filterParams...)
-	if err != nil {
+	if _, err = tx.ExecContext(ctx, fmt.Sprintf(`delete from "rsources_failed_keys_v2_records" where id in (select id from "rsources_failed_keys_v2" %s) `, filters), filterParams...); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	if _, err = tx.ExecContext(ctx, fmt.Sprintf(`delete from "rsources_failed_keys_v2" %s`, filters), filterParams...); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
@@ -236,20 +244,28 @@ func (sh *sourcesHandler) doCleanupTables(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
 	before := time.Now().Add(-config.GetDuration("Rsources.retention", defaultRetentionPeriodInHours, time.Hour))
-	sqlStatement := `delete from "%[1]s" where job_run_id in (
+	if _, err := tx.ExecContext(ctx, `delete from "rsources_stats" where job_run_id in (
 		select lastUpdateToJobRunId.job_run_id from 
-			(select job_run_id, max(ts) as mts from "%[1]s" group by job_run_id) lastUpdateToJobRunId
+			(select job_run_id, max(ts) as mts from "rsources_stats" group by job_run_id) lastUpdateToJobRunId
 		where lastUpdateToJobRunId.mts <= $1
-	)`
-	_, err = tx.ExecContext(ctx, fmt.Sprintf(sqlStatement, "rsources_stats"), before)
-	if err != nil {
+	)`, before); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
-	_, err = tx.ExecContext(ctx, fmt.Sprintf(sqlStatement, "rsources_failed_keys"), before)
-	if err != nil {
+	if _, err := tx.ExecContext(ctx, `WITH to_delete AS (
+		SELECT id FROM "rsources_failed_keys_v2" WHERE job_run_id IN (
+			SELECT lastUpdateToJobRunId.job_run_id FROM (
+				SELECT k.job_run_id, max(r.ts) as mts from "rsources_failed_keys_v2" k
+				JOIN "rsources_failed_keys_v2_records" r on r.id = k.id
+				GROUP BY k.job_run_id
+			) lastUpdateToJobRunId WHERE lastUpdateToJobRunId.mts <= $1
+		)    
+	),
+	deleted AS (
+		DELETE FROM "rsources_failed_keys_v2_records" WHERE id IN (SELECT id FROM to_delete) RETURNING id
+	)
+	DELETE FROM "rsources_failed_keys_v2" WHERE id IN (SELECT id FROM to_delete) RETURNING id`, before); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
@@ -273,6 +289,9 @@ func (sh *sourcesHandler) init() error {
 	sh.log.Debugf("setting up rsources tables in %s", sh.config.LocalHostname)
 	if err := setupTables(ctx, sh.localDB, sh.config.LocalHostname, sh.log); err != nil {
 		return err
+	}
+	if err := migrateFailedKeysTable(ctx, sh.localDB); err != nil {
+		return fmt.Errorf("failed to migrate rsources_failed_keys table: %w", err)
 	}
 	sh.log.Debugf("rsources tables setup successfully in %s", sh.config.LocalHostname)
 	if sh.sharedDB != nil {
@@ -301,7 +320,101 @@ func setupTables(ctx context.Context, db *sql.DB, defaultDbName string, log logg
 	return nil
 }
 
-func setupFailedKeysTable(ctx context.Context, db *sql.DB, defaultDbName string, log logger.Logger) error {
+// TODO: Remove this after a few releases
+func migrateFailedKeysTable(ctx context.Context, db *sql.DB) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to start transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(100020001)`); err != nil {
+		return fmt.Errorf("error while acquiring advisory lock for failed keys migration: %w", err)
+	}
+	var previousTableExists bool
+	row := tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT FROM pg_tables WHERE schemaname NOT IN ('pg_catalog','information_schema') AND  tablename  = 'rsources_failed_keys')`)
+	if err := row.Scan(&previousTableExists); err != nil {
+		return err
+	}
+	if previousTableExists {
+		if _, err := tx.ExecContext(ctx, `create or replace function ksuid() returns text as $$
+		declare
+			v_time timestamp with time zone := null;
+			v_seconds numeric(50) := null;
+			v_numeric numeric(50) := null;
+			v_epoch numeric(50) = 1400000000; -- 2014-05-13T16:53:20Z
+			v_base62 text := '';
+			v_alphabet char array[62] := array[
+				'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+				'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+				'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 
+				'U', 'V', 'W', 'X', 'Y', 'Z', 
+				'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 
+				'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
+				'u', 'v', 'w', 'x', 'y', 'z'];
+			i integer := 0;
+		begin
+		
+			-- Get the current time
+			v_time := clock_timestamp();
+		
+			-- Extract epoch seconds
+			v_seconds := EXTRACT(EPOCH FROM v_time) - v_epoch;
+		
+			-- Generate a KSUID in a numeric variable
+			v_numeric := v_seconds * pow(2::numeric(50), 128) -- 32 bits for seconds and 128 bits for randomness
+				+ ((random()::numeric(70,20) * pow(2::numeric(70,20), 48))::numeric(50) * pow(2::numeric(50), 80)::numeric(50))
+				+ ((random()::numeric(70,20) * pow(2::numeric(70,20), 40))::numeric(50) * pow(2::numeric(50), 40)::numeric(50))
+				+  (random()::numeric(70,20) * pow(2::numeric(70,20), 40))::numeric(50);
+		
+			-- Encode it to base-62
+			while v_numeric <> 0 loop
+				v_base62 := v_base62 || v_alphabet[mod(v_numeric, 62) + 1];
+				v_numeric := div(v_numeric, 62);
+			end loop;
+			v_base62 := reverse(v_base62);
+			v_base62 := lpad(v_base62, 27, '0');
+		
+			return v_base62;
+			
+		end $$ language plpgsql;`); err != nil {
+			return fmt.Errorf("failed to create ksuid function: %w", err)
+		}
+
+		if _, err := tx.ExecContext(ctx, `WITH new_keys AS (
+			INSERT INTO "rsources_failed_keys_v2" 
+			(id, job_run_id, task_run_id, source_id, destination_id, db_name)
+			SELECT ksuid(), t.* FROM (
+				SELECT DISTINCT job_run_id, task_run_id, source_id, destination_id, db_name from "rsources_failed_keys"
+			) t
+			RETURNING *
+		)
+		INSERT INTO "rsources_failed_keys_v2_records" (id, record_id, ts)
+		 SELECT n.id, o.record_id::text, min(o.ts) FROM new_keys n
+			JOIN rsources_failed_keys o 
+				on o.db_name = n.db_name 
+				and o.destination_id = n.destination_id 
+				and o.source_id = n.source_id 
+				and o.task_run_id = n.task_run_id 
+				and o.job_run_id = n.job_run_id 
+			group by n.id, o.record_id
+		`); err != nil {
+			return fmt.Errorf("failed to migrate rsources_failed_keys table: %w", err)
+		}
+
+		if _, err := tx.ExecContext(ctx, `DROP TABLE IF EXISTS "rsources_failed_keys" CASCADE`); err != nil {
+			return fmt.Errorf("failed to drop old rsources_failed_keys table: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `drop function if exists ksuid()`); err != nil {
+			return fmt.Errorf("failed to drop ksuid function: %w", err)
+		}
+		return tx.Commit()
+	}
+
+	return nil
+}
+
+// TODO: Remove this after a few releases
+func setupFailedKeysTableV0(ctx context.Context, db *sql.DB, defaultDbName string, log logger.Logger) error {
 	sqlStatement := fmt.Sprintf(`create table "rsources_failed_keys" (	
 		id BIGSERIAL,
 		db_name text not null default '%s',
@@ -323,6 +436,39 @@ func setupFailedKeysTable(ctx context.Context, db *sql.DB, defaultDbName string,
 	}
 	if _, err := db.ExecContext(ctx, `create index if not exists rsources_failed_keys_job_run_id_idx on "rsources_failed_keys" (job_run_id)`); err != nil {
 		return err
+	}
+	return nil
+}
+
+func setupFailedKeysTable(ctx context.Context, db *sql.DB, defaultDbName string, log logger.Logger) error {
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(`create table "rsources_failed_keys_v2" (	
+		id VARCHAR(27) COLLATE "C",
+		db_name text not null default '%s',
+		job_run_id text not null,
+		task_run_id text not null,
+		source_id text not null,
+		destination_id text not null,		
+		primary key (id),
+		unique (job_run_id, task_run_id, source_id, destination_id, db_name)
+	)`, defaultDbName)); err != nil {
+		if pqError, ok := err.(*pq.Error); ok && pqError.Code == "42P07" {
+			log.Debugf("table rsources_failed_keys_v2 already exists in %s", defaultDbName)
+		} else {
+			return err
+		}
+	}
+
+	if _, err := db.ExecContext(ctx, `create table "rsources_failed_keys_v2_records" (	
+		id VARCHAR(27) COLLATE "C",
+		record_id text not null,
+    	ts timestamp not null default NOW(),
+		primary key (id, record_id)
+	)`); err != nil {
+		if pqError, ok := err.(*pq.Error); ok && pqError.Code == "42P07" {
+			log.Debugf("table rsources_failed_keys_v2_records already exists in %s", defaultDbName)
+		} else {
+			return err
+		}
 	}
 	return nil
 }
@@ -355,19 +501,24 @@ func setupStatsTable(ctx context.Context, db *sql.DB, defaultDbName string, log 
 }
 
 func (sh *sourcesHandler) setupLogicalReplication(ctx context.Context) error {
-	publicationQuery := `CREATE PUBLICATION "rsources_stats_pub" FOR TABLE rsources_stats`
-	if _, err := sh.localDB.ExecContext(ctx, publicationQuery); err != nil {
+	if _, err := sh.localDB.ExecContext(ctx, `CREATE PUBLICATION "rsources_stats_pub" FOR TABLE rsources_stats`); err != nil {
 		pqError, ok := err.(*pq.Error)
 		if !ok || pqError.Code != pq.ErrorCode("42710") { // duplicate
 			return fmt.Errorf("failed to create publication on local database: %w", err)
 		}
 	}
 
-	alterPublicationQuery := `ALTER PUBLICATION "rsources_stats_pub" ADD TABLE rsources_failed_keys`
-	if _, err := sh.localDB.ExecContext(ctx, alterPublicationQuery); err != nil {
+	if _, err := sh.localDB.ExecContext(ctx, `ALTER PUBLICATION "rsources_stats_pub" ADD TABLE rsources_failed_keys_v2`); err != nil {
 		pqError, ok := err.(*pq.Error)
 		if !ok || pqError.Code != pq.ErrorCode("42710") { // duplicate
-			return fmt.Errorf("failed to alter publication on local database to add failed_keys table: %w", err)
+			return fmt.Errorf("failed to alter publication on local database to add rsources_failed_keys_v2 table: %w", err)
+		}
+	}
+
+	if _, err := sh.localDB.ExecContext(ctx, `ALTER PUBLICATION "rsources_stats_pub" ADD TABLE rsources_failed_keys_v2_records`); err != nil {
+		pqError, ok := err.(*pq.Error)
+		if !ok || pqError.Code != pq.ErrorCode("42710") { // duplicate
+			return fmt.Errorf("failed to alter publication on local database to add rsources_failed_keys_v2_records table: %w", err)
 		}
 	}
 
@@ -385,27 +536,37 @@ func (sh *sourcesHandler) setupLogicalReplication(ctx context.Context) error {
 			return fmt.Errorf("failed to create subscription on shared database: %w", err)
 		}
 	}
-
-	refreshSubscriptionQuery := fmt.Sprintf(`ALTER SUBSCRIPTION %s REFRESH PUBLICATION`, subscriptionName)
-	if _, err := sh.sharedDB.ExecContext(ctx, refreshSubscriptionQuery); err != nil {
+	if _, err := sh.sharedDB.ExecContext(ctx, fmt.Sprintf(`ALTER SUBSCRIPTION %s REFRESH PUBLICATION`, subscriptionName)); err != nil {
 		return fmt.Errorf("failed to refresh subscription on shared database: %w", err)
+	}
+
+	// TODO: Remove this after a few releases
+	if _, err := sh.sharedDB.ExecContext(ctx, `DROP TABLE IF EXISTS "rsources_failed_keys" CASCADE`); err != nil {
+		pqError, ok := err.(*pq.Error)
+		if !ok || pqError.Code != pq.ErrorCode("22023") { // table synchronization in progress
+			return fmt.Errorf("failed to drop old rsources_failed_keys table on shared database: %w", err)
+		}
 	}
 
 	return nil
 }
 
-func sqlFilters(jobRunId string, filter JobFilter) (fragment string, params []interface{}) {
+func sqlFilters(jobRunId string, filter JobFilter, alias string) (fragment string, params []interface{}) {
 	var filterParams []interface{}
-	filters := `WHERE job_run_id = $1`
+	var prefix string
+	if alias != "" {
+		prefix = alias + "."
+	}
+	filters := fmt.Sprintf(`WHERE %sjob_run_id = $1`, prefix)
 	filterParams = append(filterParams, jobRunId)
 
 	if len(filter.TaskRunID) > 0 {
-		filters += fmt.Sprintf(` AND task_run_id  = ANY ($%d)`, len(filterParams)+1)
+		filters += fmt.Sprintf(` AND %stask_run_id  = ANY ($%d)`, prefix, len(filterParams)+1)
 		filterParams = append(filterParams, pq.Array(filter.TaskRunID))
 	}
 
 	if len(filter.SourceID) > 0 {
-		filters += fmt.Sprintf(` AND source_id = ANY ($%d)`, len(filterParams)+1)
+		filters += fmt.Sprintf(` AND %ssource_id = ANY ($%d)`, prefix, len(filterParams)+1)
 		filterParams = append(filterParams, pq.Array(filter.SourceID))
 	}
 	return filters, filterParams

--- a/services/rsources/http/http.go
+++ b/services/rsources/http/http.go
@@ -116,7 +116,7 @@ func (h *handler) failedRecords(w http.ResponseWriter, r *http.Request) {
 	)
 	if err != nil {
 		httpStatus := http.StatusInternalServerError
-		if errors.Is(err, rsources.ErrOperationNotSupported) {
+		if errors.Is(err, rsources.ErrOperationNotSupported) || errors.Is(err, rsources.ErrInvalidPaginationToken) {
 			httpStatus = http.StatusBadRequest
 		}
 		http.Error(w, err.Error(), httpStatus)

--- a/services/rsources/http/http_integration_test.go
+++ b/services/rsources/http/http_integration_test.go
@@ -1,0 +1,130 @@
+package http_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
+	"github.com/rudderlabs/rudder-server/services/rsources"
+	rsources_http "github.com/rudderlabs/rudder-server/services/rsources/http"
+)
+
+func TestGetFailedRecordsIntegration(t *testing.T) {
+	prepare := func() (handler http.Handler, service rsources.JobService, db *sql.DB) {
+		pool, err := dockertest.NewPool("")
+		require.NoError(t, err)
+		postgresContainer, err := resource.SetupPostgres(pool, t)
+		require.NoError(t, err)
+
+		config := rsources.JobServiceConfig{
+			LocalHostname: postgresContainer.Host,
+			MaxPoolSize:   1,
+			LocalConn:     postgresContainer.DBDsn,
+			Log:           logger.NOP,
+		}
+		service, err = rsources.NewJobService(config)
+		require.NoError(t, err)
+		handler = rsources_http.NewHandler(service, logger.NOP)
+		db = postgresContainer.DB
+		return
+	}
+
+	addFailedRecords := func(t *testing.T, service rsources.JobService, db *sql.DB, records []json.RawMessage) {
+		tx, err := db.Begin()
+		require.NoError(t, err)
+		err = service.AddFailedRecords(context.Background(), tx,
+			"jobRunID",
+			rsources.JobTargetKey{
+				TaskRunID:     "taskRunID",
+				SourceID:      "sourceID",
+				DestinationID: "destinationID",
+			},
+			records,
+		)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit())
+	}
+
+	getFailedRecords := func(t *testing.T, handler http.Handler, pageSize int, pageToken string) *rsources.JobFailedRecords {
+		params := url.Values{}
+		if pageSize > 0 {
+			params.Set("pageSize", strconv.Itoa(pageSize))
+			if pageToken != "" {
+				params.Set("pageToken", pageToken)
+			}
+		}
+		reqURL, err := url.Parse("http://localhost/jobRunID/failed-records")
+		require.NoError(t, err)
+		reqURL.RawQuery = params.Encode()
+		req, err := http.NewRequest("GET", reqURL.String(), nil)
+		require.NoError(t, err)
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		var failedRecords rsources.JobFailedRecords
+		err = json.Unmarshal(body, &failedRecords)
+		require.NoError(t, err)
+		return &failedRecords
+	}
+
+	t.Run("without pagination", func(t *testing.T) {
+		handler, service, db := prepare()
+		addFailedRecords(t, service, db, []json.RawMessage{
+			[]byte(`"id-1"`),
+			[]byte(`"id-2"`),
+			[]byte(`"id-3"`),
+			[]byte(`"id-4"`),
+		})
+		pageSize := 0
+		pageToken := ""
+		failedRecords := getFailedRecords(t, handler, pageSize, pageToken)
+		require.NotNil(t, failedRecords)
+		require.Len(t, failedRecords.Tasks, 1)
+		require.Len(t, failedRecords.Tasks[0].Sources, 1)
+		require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations, 1)
+		require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations[0].Records, 4)
+		require.Nil(t, failedRecords.Paging, "no paging information should be present")
+	})
+
+	t.Run("with pagination", func(t *testing.T) {
+		handler, service, db := prepare()
+		addFailedRecords(t, service, db, []json.RawMessage{
+			[]byte(`"id-1"`),
+			[]byte(`"id-2"`),
+			[]byte(`"id-3"`),
+			[]byte(`"id-4"`),
+		})
+		pageSize := 2
+		pageToken := ""
+		for i := 0; i < 2; i++ { // 2 pages are retrieved with 2 records each and where paging is present
+			failedRecords := getFailedRecords(t, handler, pageSize, pageToken)
+			require.NotNil(t, failedRecords)
+			require.Len(t, failedRecords.Tasks, 1)
+			require.Len(t, failedRecords.Tasks[0].Sources, 1)
+			require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations, 1)
+			require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations[0].Records, pageSize)
+			require.NotNil(t, failedRecords.Paging, "paging information should be present")
+			require.Equal(t, pageSize, failedRecords.Paging.Size)
+			pageToken = failedRecords.Paging.NextPageToken
+		}
+
+		// 3 page is retrieved with 0 records and where paging is not present
+		failedRecords := getFailedRecords(t, handler, pageSize, pageToken)
+		require.NotNil(t, failedRecords)
+		require.Len(t, failedRecords.Tasks, 0)
+		require.Nil(t, failedRecords.Paging, "no paging information should be present")
+	})
+}

--- a/services/rsources/http/http_test.go
+++ b/services/rsources/http/http_test.go
@@ -244,6 +244,7 @@ func TestGetStatus(t *testing.T) {
 }
 
 func TestGetFailedRecords(t *testing.T) {
+	var noPaging rsources.PagingInfo
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	service := rsources.NewMockJobService(mockCtrl)
@@ -320,7 +321,7 @@ func TestGetFailedRecords(t *testing.T) {
 			t.Log("endpoint tested:", tt.endpoint)
 
 			filterArg := getArgumentFilter(tt.filter)
-			service.EXPECT().GetFailedRecords(gomock.Any(), tt.jobID, filterArg).Return(tt.failedRecords, tt.failedRecordsError).Times(1)
+			service.EXPECT().GetFailedRecords(gomock.Any(), tt.jobID, filterArg, noPaging).Return(tt.failedRecords, tt.failedRecordsError).Times(1)
 
 			basicUrl := fmt.Sprintf("http://localhost:8080%s", tt.endpoint)
 			url := withFilter(basicUrl, tt.filter)
@@ -345,7 +346,7 @@ func TestFailedRecordsDisabled(t *testing.T) {
 	service := rsources.NewMockJobService(mockCtrl)
 	handler := rsources_http.NewHandler(service, mock_logger.NewMockLogger(mockCtrl))
 
-	service.EXPECT().GetFailedRecords(gomock.Any(), gomock.Any(), gomock.Any()).Return(rsources.JobFailedRecords{}, rsources.ErrOperationNotSupported).Times(1)
+	service.EXPECT().GetFailedRecords(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(rsources.JobFailedRecords{}, rsources.ErrOperationNotSupported).Times(1)
 
 	url := fmt.Sprintf("http://localhost:8080%s", prepURL("/{job_run_id}/failed-records", "123"))
 	req, err := http.NewRequest("GET", url, http.NoBody)

--- a/services/rsources/http/http_test.go
+++ b/services/rsources/http/http_test.go
@@ -315,6 +315,20 @@ func TestGetFailedRecords(t *testing.T) {
 			failedRecordsError: errors.New("failed to get failed records"),
 			respBody:           failedRecordsRespBody,
 		},
+		{
+			name:                 "get failed records with invalid pagination token",
+			jobID:                "123",
+			endpoint:             prepURL("/{job_run_id}/failed-records", "123"),
+			method:               "GET",
+			expectedResponseCode: http.StatusBadRequest,
+			filter: map[string][]string{
+				"task_run_id": {"t1", "t2"},
+				"source_id":   {"s1"},
+			},
+			failedRecords:      rsources.JobFailedRecords{ID: "123"},
+			failedRecordsError: rsources.ErrInvalidPaginationToken,
+			respBody:           rsources.ErrInvalidPaginationToken.Error() + "\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/services/rsources/mock_rsources.go
+++ b/services/rsources/mock_rsources.go
@@ -116,18 +116,18 @@ func (mr *MockJobServiceMockRecorder) Delete(ctx, jobRunId, filter interface{}) 
 }
 
 // GetFailedRecords mocks base method.
-func (m *MockJobService) GetFailedRecords(ctx context.Context, jobRunId string, filter JobFilter) (JobFailedRecords, error) {
+func (m *MockJobService) GetFailedRecords(ctx context.Context, jobRunId string, filter JobFilter, paging PagingInfo) (JobFailedRecords, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFailedRecords", ctx, jobRunId, filter)
+	ret := m.ctrl.Call(m, "GetFailedRecords", ctx, jobRunId, filter, paging)
 	ret0, _ := ret[0].(JobFailedRecords)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFailedRecords indicates an expected call of GetFailedRecords.
-func (mr *MockJobServiceMockRecorder) GetFailedRecords(ctx, jobRunId, filter interface{}) *gomock.Call {
+func (mr *MockJobServiceMockRecorder) GetFailedRecords(ctx, jobRunId, filter, paging interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFailedRecords", reflect.TypeOf((*MockJobService)(nil).GetFailedRecords), ctx, jobRunId, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFailedRecords", reflect.TypeOf((*MockJobService)(nil).GetFailedRecords), ctx, jobRunId, filter, paging)
 }
 
 // GetStatus mocks base method.

--- a/services/rsources/stats_collector.go
+++ b/services/rsources/stats_collector.go
@@ -210,6 +210,10 @@ func (r *statsCollector) Publish(ctx context.Context, tx *sql.Tx) error {
 	for i := range failedRecordsKeys {
 		k := failedRecordsKeys[i]
 		v := r.failedRecordsIndex[k]
+		// sort the records as well to avoid deadlocks
+		sort.Slice(v, func(i, j int) bool {
+			return string(v[i]) < string(v[j])
+		})
 		err := r.jobService.AddFailedRecords(ctx, tx, k.jobRunId, k.JobTargetKey, v)
 		if err != nil {
 			return err


### PR DESCRIPTION
# Description

## feat: introduce pagination in failed-keys endpoint

Adding support for pagination in failed-keys endpoint in a backwards compatible manner:
- If the request contains a `pageSize` query parameter then pagination will be enabled, otherwise the full resultset will be returned in the response.
- If pagination is requested, then the next page's token will be included in the `paging` field of the response's payload. To retrieve the next page, the client needs to include this token in the `pageToken `query parameter of it's next http request.
- Pagination stops when no more results are returned in the response. When this happens, the `paging` field is omitted from the response's payload as well.

_**Performance**_
Added a test and a benchmark to verify the performance characteristics of the new paging API compared to the previous one. The paging API is more memory efficient but slower, e.g. splitting 10Mil records in 10 pages is 3x slower than returning the full resultset at once. 

Thus, an adequately large page size needs to be used in production environments: **It is advised to use a page size between 100K - 1Mil records**.


## chore: use a normalised data model for storing failed keys

- using a normalised data model for greater disk storage efficiency when there is a large number of failed keys
- deduplicating failed keys for the same job, task, source & destination
- using `ksuid` for `id` column and `text` instead of `jsonb` for `record_id` column in the new data model so that future introduction of pagination becomes a straightforward task & highly performant
- removing previous table `rsources_failed_keys`. In case of a rollback, the previous server version will recreate this table. Data migration after rollback needs to happen manually, using the following statement (a hotfix including this statement could be prepared if needed):
```sql
INSERT INTO rsources_failed_keys (
	job_run_id, 
	task_run_id, 
	source_id, 
	destination_id, 
	record_id, 
	ts
)
SELECT 
	k.job_run_id, 
	k.task_run_id, 
	k.source_id, 
	k.destination_id, 
	to_jsonb(r.record_id), 
	r.ts 
FROM rsources_failed_keys_v2 k 
JOIN rsources_failed_keys_v2_records r on r.id = k.id;
```

**_Trivia_**

One could argue that by introducing normalisation and deduplication here, we might also affect performance by introducing lock contention at the database level, since competing threads will be trying to insert data with the same primary key. Thankfully, that's not the case, we only collect failed keys in router & batchrouter and these two components never update job statuses concurrently for a given destination id. But even if concurrent updates was the case, recording failed keys is an exceptional flow for the system, i.e. it shouldn't matter much. 

## Linear Ticket

Resolves PIPE-396
Resolves PIPE-336

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

BEGIN_COMMIT_OVERRIDE
feat: introduce pagination in failed-keys endpoint (#3967)
chore: use a normalised data model for storing failed keys (#3961)
END_COMMIT_OVERRIDE