### PR TITLE
feat: introduce pagination in failed-keys endpoint

### DIFF
--- a/services/rsources/failed_records_pagination_test.go
+++ b/services/rsources/failed_records_pagination_test.go
@@ -1,0 +1,89 @@
+package rsources
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
+)
+
+func TestFailedRecordsPerformanceTest(t *testing.T) {
+	var noPaginationDur time.Duration
+	var paginationDur time.Duration
+
+	total := 100_000
+	pageSize := 10_000
+	t.Run("100k records no pagination", func(t *testing.T) {
+		noPaginationDur = RunFailedRecordsPerformanceTest(t, total, 0)
+		t.Logf("100k records no pagination took %s", noPaginationDur)
+	})
+	t.Run("100k records with 10k pagination", func(t *testing.T) {
+		paginationDur = RunFailedRecordsPerformanceTest(t, total, pageSize)
+		t.Logf("100k records with 10k pagination took %s", paginationDur)
+	})
+
+	t.Run("pagination vs no pagination comparison", func(t *testing.T) {
+		pages := total / pageSize
+		if noPaginationDur > 0 && int(paginationDur/noPaginationDur) > pages {
+			t.Errorf("Pagination time (%s) is more than %dx slower than no pagination time (%s)", paginationDur, pages, noPaginationDur)
+		}
+	})
+}
+
+func BenchmarkFailedRecordsPerformanceTest(b *testing.B) {
+	b.Run("10Mil records no pagination", func(b *testing.B) {
+		d := RunFailedRecordsPerformanceTest(b, 10_000_000, 0)
+		b.ReportMetric(float64(d.Milliseconds()), "duration_millis")
+	})
+	b.Run("10Mil records with 100k pagination", func(b *testing.B) {
+		d := RunFailedRecordsPerformanceTest(b, 10_000_000, 100_000)
+		b.ReportMetric(float64(d.Milliseconds()), "duration_millis")
+	})
+}
+
+func RunFailedRecordsPerformanceTest(t testing.TB, recordCount, pageSize int) time.Duration {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	postgresContainer, err := resource.SetupPostgres(pool, t)
+	require.NoError(t, err)
+
+	service, err := NewJobService(JobServiceConfig{
+		LocalHostname: postgresContainer.Host,
+		MaxPoolSize:   1,
+		LocalConn:     postgresContainer.DBDsn,
+		Log:           logger.NOP,
+	})
+	require.NoError(t, err)
+
+	// seed the database with records
+
+	// Create 20k different job run ids with 10 records each
+	_, err = postgresContainer.DB.Exec(`INSERT INTO rsources_failed_keys_v2 (id, job_run_id, task_run_id, source_id, destination_id) SELECT id::text, id::text, '1', '1', '1' FROM generate_series(1, 20000) as id`)
+	require.NoError(t, err)
+	_, err = postgresContainer.DB.Exec(`INSERT INTO rsources_failed_keys_v2_records (id, record_id) SELECT k.id, to_json('"'||s.id||'"') from rsources_failed_keys_v2 k CROSS JOIN (SELECT id::text FROM generate_series(1, 10) as id) s`)
+	require.NoError(t, err)
+	// job run id 1 should have [recordCount] records
+	_, err = postgresContainer.DB.Exec(fmt.Sprintf(`INSERT INTO rsources_failed_keys_v2_records (id, record_id) SELECT k.id, to_json('"'||s.id||'"') from rsources_failed_keys_v2 k CROSS JOIN (SELECT id::text FROM generate_series(11, %d) as id) s WHERE k.job_run_id = '1'`, recordCount))
+	require.NoError(t, err)
+
+	start := time.Now()
+	paging := PagingInfo{
+		Size: pageSize,
+	}
+	var total int
+	for total < recordCount {
+		r, err := service.GetFailedRecords(context.Background(), "1", JobFilter{}, paging)
+		require.NoError(t, err)
+		require.Len(t, r.Tasks, 1)
+		require.Len(t, r.Tasks[0].Sources, 1)
+		require.Len(t, r.Tasks[0].Sources[0].Destinations, 1)
+		total += len(r.Tasks[0].Sources[0].Destinations[0].Records)
+	}
+	return time.Since(start)
+}

--- a/services/rsources/http/http_integration_test.go
+++ b/services/rsources/http/http_integration_test.go
@@ -1,0 +1,130 @@
+package http_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
+	"github.com/rudderlabs/rudder-server/services/rsources"
+	rsources_http "github.com/rudderlabs/rudder-server/services/rsources/http"
+)
+
+func TestGetFailedRecordsIntegration(t *testing.T) {
+	prepare := func() (handler http.Handler, service rsources.JobService, db *sql.DB) {
+		pool, err := dockertest.NewPool("")
+		require.NoError(t, err)
+		postgresContainer, err := resource.SetupPostgres(pool, t)
+		require.NoError(t, err)
+
+		config := rsources.JobServiceConfig{
+			LocalHostname: postgresContainer.Host,
+			MaxPoolSize:   1,
+			LocalConn:     postgresContainer.DBDsn,
+			Log:           logger.NOP,
+		}
+		service, err = rsources.NewJobService(config)
+		require.NoError(t, err)
+		handler = rsources_http.NewHandler(service, logger.NOP)
+		db = postgresContainer.DB
+		return
+	}
+
+	addFailedRecords := func(t *testing.T, service rsources.JobService, db *sql.DB, records []json.RawMessage) {
+		tx, err := db.Begin()
+		require.NoError(t, err)
+		err = service.AddFailedRecords(context.Background(), tx,
+			"jobRunID",
+			rsources.JobTargetKey{
+				TaskRunID:     "taskRunID",
+				SourceID:      "sourceID",
+				DestinationID: "destinationID",
+			},
+			records,
+		)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit())
+	}
+
+	getFailedRecords := func(t *testing.T, handler http.Handler, pageSize int, pageToken string) *rsources.JobFailedRecords {
+		params := url.Values{}
+		if pageSize > 0 {
+			params.Set("pageSize", strconv.Itoa(pageSize))
+			if pageToken != "" {
+				params.Set("pageToken", pageToken)
+			}
+		}
+		reqURL, err := url.Parse("http://localhost/jobRunID/failed-records")
+		require.NoError(t, err)
+		reqURL.RawQuery = params.Encode()
+		req, err := http.NewRequest("GET", reqURL.String(), nil)
+		require.NoError(t, err)
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		var failedRecords rsources.JobFailedRecords
+		err = json.Unmarshal(body, &failedRecords)
+		require.NoError(t, err)
+		return &failedRecords
+	}
+
+	t.Run("without pagination", func(t *testing.T) {
+		handler, service, db := prepare()
+		addFailedRecords(t, service, db, []json.RawMessage{
+			[]byte(`"id-1"`),
+			[]byte(`"id-2"`),
+			[]byte(`"id-3"`),
+			[]byte(`"id-4"`),
+		})
+		pageSize := 0
+		pageToken := ""
+		failedRecords := getFailedRecords(t, handler, pageSize, pageToken)
+		require.NotNil(t, failedRecords)
+		require.Len(t, failedRecords.Tasks, 1)
+		require.Len(t, failedRecords.Tasks[0].Sources, 1)
+		require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations, 1)
+		require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations[0].Records, 4)
+		require.Nil(t, failedRecords.Paging, "no paging information should be present")
+	})
+
+	t.Run("with pagination", func(t *testing.T) {
+		handler, service, db := prepare()
+		addFailedRecords(t, service, db, []json.RawMessage{
+			[]byte(`"id-1"`),
+			[]byte(`"id-2"`),
+			[]byte(`"id-3"`),
+			[]byte(`"id-4"`),
+		})
+		pageSize := 2
+		pageToken := ""
+		for i := 0; i < 2; i++ { // 2 pages are retrieved with 2 records each and where paging is present
+			failedRecords := getFailedRecords(t, handler, pageSize, pageToken)
+			require.NotNil(t, failedRecords)
+			require.Len(t, failedRecords.Tasks, 1)
+			require.Len(t, failedRecords.Tasks[0].Sources, 1)
+			require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations, 1)
+			require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations[0].Records, pageSize)
+			require.NotNil(t, failedRecords.Paging, "paging information should be present")
+			require.Equal(t, pageSize, failedRecords.Paging.Size)
+			pageToken = failedRecords.Paging.NextPageToken
+		}
+
+		// 3 page is retrieved with 0 records and where paging is not present
+		failedRecords := getFailedRecords(t, handler, pageSize, pageToken)
+		require.NotNil(t, failedRecords)
+		require.Len(t, failedRecords.Tasks, 0)
+		require.Nil(t, failedRecords.Paging, "no paging information should be present")
+	})
+}

--- a/services/rsources/http/http_test.go
+++ b/services/rsources/http/http_test.go
@@ -244,6 +244,7 @@ func TestGetStatus(t *testing.T) {
 }
 
 func TestGetFailedRecords(t *testing.T) {
+	var noPaging rsources.PagingInfo
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	service := rsources.NewMockJobService(mockCtrl)
@@ -320,7 +321,7 @@ func TestGetFailedRecords(t *testing.T) {
 			t.Log("endpoint tested:", tt.endpoint)
 
 			filterArg := getArgumentFilter(tt.filter)
-			service.EXPECT().GetFailedRecords(gomock.Any(), tt.jobID, filterArg).Return(tt.failedRecords, tt.failedRecordsError).Times(1)
+			service.EXPECT().GetFailedRecords(gomock.Any(), tt.jobID, filterArg, noPaging).Return(tt.failedRecords, tt.failedRecordsError).Times(1)
 
 			basicUrl := fmt.Sprintf("http://localhost:8080%s", tt.endpoint)
 			url := withFilter(basicUrl, tt.filter)
@@ -345,7 +346,7 @@ func TestFailedRecordsDisabled(t *testing.T) {
 	service := rsources.NewMockJobService(mockCtrl)
 	handler := rsources_http.NewHandler(service, mock_logger.NewMockLogger(mockCtrl))
 
-	service.EXPECT().GetFailedRecords(gomock.Any(), gomock.Any(), gomock.Any()).Return(rsources.JobFailedRecords{}, rsources.ErrOperationNotSupported).Times(1)
+	service.EXPECT().GetFailedRecords(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(rsources.JobFailedRecords{}, rsources.ErrOperationNotSupported).Times(1)
 
 	url := fmt.Sprintf("http://localhost:8080%s", prepURL("/{job_run_id}/failed-records", "123"))
 	req, err := http.NewRequest("GET", url, http.NoBody)

--- a/services/rsources/mock_rsources.go
+++ b/services/rsources/mock_rsources.go
@@ -116,18 +116,18 @@ func (mr *MockJobServiceMockRecorder) Delete(ctx, jobRunId, filter interface{}) 
 }
 
 // GetFailedRecords mocks base method.
-func (m *MockJobService) GetFailedRecords(ctx context.Context, jobRunId string, filter JobFilter) (JobFailedRecords, error) {
+func (m *MockJobService) GetFailedRecords(ctx context.Context, jobRunId string, filter JobFilter, paging PagingInfo) (JobFailedRecords, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFailedRecords", ctx, jobRunId, filter)
+	ret := m.ctrl.Call(m, "GetFailedRecords", ctx, jobRunId, filter, paging)
 	ret0, _ := ret[0].(JobFailedRecords)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFailedRecords indicates an expected call of GetFailedRecords.
-func (mr *MockJobServiceMockRecorder) GetFailedRecords(ctx, jobRunId, filter interface{}) *gomock.Call {
+func (mr *MockJobServiceMockRecorder) GetFailedRecords(ctx, jobRunId, filter, paging interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFailedRecords", reflect.TypeOf((*MockJobService)(nil).GetFailedRecords), ctx, jobRunId, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFailedRecords", reflect.TypeOf((*MockJobService)(nil).GetFailedRecords), ctx, jobRunId, filter, paging)
 }
 
 // GetStatus mocks base method.


### PR DESCRIPTION
# Description

Adding support for pagination in failed-keys endpoint in a backwards compatible manner:
- If the request contains a `pageSize` query parameter then pagination will be enabled, otherwise the full resultset will be returned in the response.
- If pagination is requested, then the next page's token will be included in the `paging` field of the response's payload. To retrieve the next page, the client needs to include this token in the `pageToken `query parameter of it's next http request.
- Pagination stops when no more results are returned in the response. When this happens, the `paging` field is omitted from the response's payload as well.

## Performance
Added a test and a benchmark to verify the performance characteristics of the new paging API compared to the previous one. The paging API is more memory efficient but slower, e.g. splitting 10Mil records in 10 pages is 3x slower than returning the full resultset at once. 

Thus, an adequately large page size needs to be used in production environments: **It is advised to use a page size between 100K - 1Mil records**.


## Linear Ticket

Resolves PIPE-336

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
