### PR TITLE
fix: create schema before even fetching for deltalake

### DIFF
--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -318,6 +318,12 @@ func (d *Deltalake) dropTable(ctx context.Context, table string) error {
 
 // FetchSchema fetches the schema from the warehouse
 func (d *Deltalake) FetchSchema(ctx context.Context) (model.Schema, model.Schema, error) {
+	// Since error handling is not so good with the Databricks driver we need to verify the exact string in the error.
+	// Therefore, creating the schema every time before we fetch it. Also, creating the schema is idempotent.
+	if err := d.CreateSchema(ctx); err != nil {
+		return nil, nil, fmt.Errorf("creating schema: %w", err)
+	}
+
 	schema := make(model.Schema)
 	unrecognizedSchema := make(model.Schema)
 	tableNames, err := d.fetchTables(ctx, nonRudderStagingTableRegex)


### PR DESCRIPTION
# Description

- Since error handling is not so good with the Databricks driver we need to verify the exact string in the error.
- Therefore, creating the schema every time before we fetch it. Also, creating the schema is idempotent.

## Linear Ticket

- https://linear.app/rudderstack/issue/PIPE-413/databricks-fetch-schema-error-handling

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
