### PR TITLE
chore: add workspaceID to router discarded stats

### DIFF
--- a/router/types/types.go
+++ b/router/types/types.go
@@ -131,7 +131,7 @@ var (
 	// ErrContextCancelled is returned when the context is cancelled
 	ErrContextCancelled = errors.New("context cancelled")
 	// ErrParamsUnmarshal is returned when it is not possible to unmarshal the job parameters
-	ErrParamsUnmarshal = errors.New("unmarhall params")
+	ErrParamsUnmarshal = errors.New("unmarshal params")
 	// ErrJobOrderBlocked is returned when the job is blocked by another job discarded by the router in the same loop
 	ErrJobOrderBlocked = errors.New("blocked")
 	// ErrWorkerNoSlot is returned when the worker doesn't have an available slot


### PR DESCRIPTION
# Description
fixes PIPE-420 : Add workspaceID to router discarded stats 

## Linear Ticket

[ Linear Link ](https://linear.app/rudderstack/issue/PIPE-420/add-workspaceid-to-router-discarded-stats)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
