### PR TITLE
fix: add error log for reporting metrics

### DIFF
--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -369,7 +369,7 @@ func (r *DefaultReporter) mainLoop(ctx context.Context, c types.SyncerConfig) {
 			if err == nil {
 				lastReportedAtTime.Store(loopStart)
 			} else {
-				r.log.Errorf("error getting reports: %v", err)
+				r.log.Errorw("getting reports", "error", err)
 			}
 			select {
 			case <-ctx.Done():

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -368,6 +368,8 @@ func (r *DefaultReporter) mainLoop(ctx context.Context, c types.SyncerConfig) {
 		if len(reports) == 0 {
 			if err == nil {
 				lastReportedAtTime.Store(loopStart)
+			} else {
+				fmt.Println(err)
 			}
 			select {
 			case <-ctx.Done():

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -369,7 +369,7 @@ func (r *DefaultReporter) mainLoop(ctx context.Context, c types.SyncerConfig) {
 			if err == nil {
 				lastReportedAtTime.Store(loopStart)
 			} else {
-				r.log.Errorf("error getting reports: %s", err.Error())
+				r.log.Errorf("error getting reports: %v", err)
 			}
 			select {
 			case <-ctx.Done():

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -369,7 +369,7 @@ func (r *DefaultReporter) mainLoop(ctx context.Context, c types.SyncerConfig) {
 			if err == nil {
 				lastReportedAtTime.Store(loopStart)
 			} else {
-				fmt.Println(err)
+				r.log.Errorf("error getting reports: %s", err.Error())
 			}
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
# Description

Logging error caused by getting reports.

## Linear Ticket

Resolving OBS-159
https://linear.app/rudderstack/issue/OBS-159/log-errors-in-rudder-server-for-reporting-metrics

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
