### PR TITLE
chore: flaky error index report test

### DIFF
--- a/enterprise/reporting/error_index_reporting_test.go
+++ b/enterprise/reporting/error_index_reporting_test.go
@@ -266,12 +266,7 @@ func TestErrorIndexReporter(t *testing.T) {
 				err = eir.Report(tc.reports, nil)
 				require.NoError(t, err)
 
-				errIndexDB := jobsdb.NewForRead(errorIndex, jobsdb.WithConfig(c))
-				err = errIndexDB.Start()
-				require.NoError(t, err)
-				defer errIndexDB.TearDown()
-
-				jr, err := errIndexDB.GetUnprocessed(ctx, jobsdb.GetQueryParams{
+				jr, err := eir.errIndexDB.GetUnprocessed(ctx, jobsdb.GetQueryParams{
 					JobsLimit: 100,
 				})
 				require.NoError(t, err)


### PR DESCRIPTION
# Description

- Since we can't have 2 jobsDB for reading, using existing `eir.errIndexDB`

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
