### PR TITLE
chore: error index cleanup should not depend on syncers

### DIFF
--- a/enterprise/reporting/error_index_reporting.go
+++ b/enterprise/reporting/error_index_reporting.go
@@ -141,13 +141,9 @@ func (eir *ErrorIndexReporter) Report(metrics []*types.PUReportedMetric, _ *sql.
 	return nil
 }
 
-// DatabaseSyncer returns a syncer that syncs the errorIndex jobsDB. Once the context is done, it stops the errorIndex jobsDB
+// DatabaseSyncer no op for error index reporting
 func (eir *ErrorIndexReporter) DatabaseSyncer(
 	types.SyncerConfig,
 ) types.ReportingSyncer {
-	return func() {
-		<-eir.ctx.Done()
-
-		eir.errIndexDB.Stop()
-	}
+	return func() {}
 }

--- a/enterprise/reporting/mediator.go
+++ b/enterprise/reporting/mediator.go
@@ -51,6 +51,16 @@ func NewReportingMediator(ctx context.Context, log logger.Logger, enterpriseToke
 	if config.GetBool("Reporting.errorIndexReporting.enabled", false) {
 		errorIndexReporter := NewErrorIndexReporter(rm.ctx, config.Default, rm.log, configSubscriber)
 		rm.reporters = append(rm.reporters, errorIndexReporter)
+
+		rm.g.Go(func() error {
+			// Once the context is done, it stops the errorIndex jobsDB
+			<-rm.ctx.Done()
+
+			rm.log.Infof("Stopping error index reporting")
+
+			errorIndexReporter.errIndexDB.Stop()
+			return nil
+		})
 	}
 
 	return rm

--- a/enterprise/reporting/setup_test.go
+++ b/enterprise/reporting/setup_test.go
@@ -10,11 +10,10 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/rudderlabs/rudder-go-kit/config"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
-	"github.com/rudderlabs/rudder-server/utils/types"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
 )
@@ -123,17 +122,13 @@ func TestSetupForDelegates(t *testing.T) {
 				}
 			}
 			ctx, cancel := context.WithCancel(context.Background())
+
 			med := NewReportingMediator(ctx, logger.NOP, f.EnterpriseToken, &backendconfig.NOOP{})
 			require.Len(t, med.reporters, tc.expectedDelegates)
-			// TODO: error index reporting jobsdb should start with the syncer
-			// so that we shouldn't need to start the database syncer here and end it just for cleanup
-			cancel()
-			syncer := med.DatabaseSyncer(types.SyncerConfig{
-				Label:    "test",
-				ConnInfo: postgresContainer.DBDsn,
-			})
-			syncer()
-		})
 
+			cancel()
+
+			_ = med.g.Wait()
+		})
 	}
 }


### PR DESCRIPTION
# Description

- For error index reporter, we shouldn't need to start the database syncer.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
