### PR TITLE
chore: error index reporter improvements

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -93,6 +93,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 	a.log.Infof("Configured deployment type: %q", deploymentType)
 
 	reporting := a.app.Features().Reporting.Setup(ctx, backendconfig.DefaultBackendConfig)
+	defer reporting.Stop()
 	syncer := reporting.DatabaseSyncer(types.SyncerConfig{ConnInfo: misc.GetConnectionString(config)})
 	g.Go(func() error {
 		syncer()

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -107,6 +107,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 	a.log.Infof("Configured deployment type: %q", deploymentType)
 
 	reporting := a.app.Features().Reporting.Setup(ctx, backendconfig.DefaultBackendConfig)
+	defer reporting.Stop()
 	syncer := reporting.DatabaseSyncer(types.SyncerConfig{ConnInfo: misc.GetConnectionString(config.Default)})
 	g.Go(misc.WithBugsnag(func() error {
 		syncer()

--- a/enterprise/reporting/error_index_reporting.go
+++ b/enterprise/reporting/error_index_reporting.go
@@ -2,12 +2,15 @@ package reporting
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
@@ -30,25 +33,32 @@ type payload struct {
 type ErrorIndexReporter struct {
 	ctx              context.Context
 	log              logger.Logger
+	conf             *config.Config
 	configSubscriber *configSubscriber
-	errIndexDB       jobsdb.JobsDB
 	now              func() time.Time
+	dbsMu            sync.RWMutex
+	dbs              map[string]*handleWithSqlDB
+}
+
+type handleWithSqlDB struct {
+	*jobsdb.Handle
+	sqlDB *sql.DB
 }
 
 func NewErrorIndexReporter(
 	ctx context.Context,
 	log logger.Logger,
 	configSubscriber *configSubscriber,
-	errIndexDB jobsdb.JobsDB,
+	conf *config.Config,
 ) *ErrorIndexReporter {
 	eir := &ErrorIndexReporter{
 		ctx:              ctx,
 		log:              log,
+		conf:             conf,
 		configSubscriber: configSubscriber,
 		now:              time.Now,
+		dbs:              map[string]*handleWithSqlDB{},
 	}
-
-	eir.errIndexDB = errIndexDB
 	return eir
 }
 
@@ -107,9 +117,12 @@ func (eir *ErrorIndexReporter) Report(metrics []*types.PUReportedMetric, tx *Tx)
 	if len(jobs) == 0 {
 		return nil
 	}
-
-	if err := eir.errIndexDB.WithStoreSafeTxFromTx(eir.ctx, tx, func(tx jobsdb.StoreSafeTx) error {
-		return eir.errIndexDB.StoreInTx(eir.ctx, tx, jobs)
+	db, err := eir.resolveJobsDB(tx)
+	if err != nil {
+		return fmt.Errorf("failed to resolve jobsdb: %w", err)
+	}
+	if err := db.WithStoreSafeTxFromTx(eir.ctx, tx, func(tx jobsdb.StoreSafeTx) error {
+		return db.StoreInTx(eir.ctx, tx, jobs)
 	}); err != nil {
 		return fmt.Errorf("failed to store jobs: %v", err)
 	}
@@ -117,11 +130,72 @@ func (eir *ErrorIndexReporter) Report(metrics []*types.PUReportedMetric, tx *Tx)
 	return nil
 }
 
-func (eir *ErrorIndexReporter) DatabaseSyncer(types.SyncerConfig) types.ReportingSyncer {
+func (eir *ErrorIndexReporter) DatabaseSyncer(c types.SyncerConfig) types.ReportingSyncer {
+	eir.dbsMu.Lock()
+	defer eir.dbsMu.Unlock()
+	if _, ok := eir.dbs[c.ConnInfo]; !ok {
+		dbHandle, err := sql.Open("postgres", c.ConnInfo)
+		if err != nil {
+			panic(fmt.Errorf("failed to open error index db: %w", err))
+		}
+		errIndexDB := jobsdb.NewForReadWrite(
+			"err_idx",
+			jobsdb.WithDBHandle(dbHandle),
+			jobsdb.WithDSLimit(eir.conf.GetReloadableIntVar(0, 1, "Reporting.errorIndexReporting.dsLimit")),
+			jobsdb.WithConfig(eir.conf),
+			jobsdb.WithSkipMaintenanceErr(eir.conf.GetBool("Reporting.errorIndexReporting.skipMaintenanceError", false)),
+			jobsdb.WithJobMaxAge(
+				func() time.Duration {
+					return eir.conf.GetDurationVar(24, time.Hour, "Reporting.errorIndexReporting.jobRetention")
+				},
+			),
+		)
+		if err := errIndexDB.Start(); err != nil {
+			panic(fmt.Errorf("failed to start error index db: %w", err))
+		}
+		eir.dbs[c.ConnInfo] = &handleWithSqlDB{
+			Handle: errIndexDB,
+			sqlDB:  dbHandle,
+		}
+	}
 	return func() {
 	}
 }
 
-func (edr *ErrorIndexReporter) Stop() {
-	// No op
+func (eir *ErrorIndexReporter) Stop() {
+	eir.dbsMu.RLock()
+	defer eir.dbsMu.RUnlock()
+	for _, db := range eir.dbs {
+		db.Handle.Stop()
+	}
+}
+
+// resolveJobsDB returns the jobsdb that matches the current transaction (using system information functions)
+// https://www.postgresql.org/docs/11/functions-info.html
+func (eir *ErrorIndexReporter) resolveJobsDB(tx *Tx) (jobsdb.JobsDB, error) {
+	eir.dbsMu.RLock()
+	defer eir.dbsMu.RUnlock()
+
+	if len(eir.dbs) == 1 { // optimisation, if there is only one jobsdb, return this. If it is the wrong one, it will fail anyway
+		for i := range eir.dbs {
+			return eir.dbs[i].Handle, nil
+		}
+	}
+
+	dbIdentityQuery := `select inet_server_addr()::text || ':' || inet_server_port()::text || ':' || current_user || ':' || current_database() || ':' || current_schema || ':' || pg_postmaster_start_time()::text || ':' || version()`
+	var txDatabaseIdentity string
+	if err := tx.QueryRow(dbIdentityQuery).Scan(&txDatabaseIdentity); err != nil {
+		return nil, fmt.Errorf("failed to get current tx's db identity: %w", err)
+	}
+
+	for key := range eir.dbs {
+		var databaseIdentity string
+		if err := eir.dbs[key].sqlDB.QueryRow(dbIdentityQuery).Scan(&databaseIdentity); err != nil {
+			return nil, fmt.Errorf("failed to get db identity for %q: %w", key, err)
+		}
+		if databaseIdentity == txDatabaseIdentity {
+			return eir.dbs[key].Handle, nil
+		}
+	}
+	return nil, fmt.Errorf("no jobsdb found matching the current transaction")
 }

--- a/enterprise/reporting/error_index_reporting.go
+++ b/enterprise/reporting/error_index_reporting.go
@@ -117,10 +117,11 @@ func (eir *ErrorIndexReporter) Report(metrics []*types.PUReportedMetric, tx *Tx)
 	return nil
 }
 
-// DatabaseSyncer returns a syncer that syncs the errorIndex jobsDB. Once the context is done, it stops the errorIndex jobsDB
-func (eir *ErrorIndexReporter) DatabaseSyncer(
-	types.SyncerConfig,
-) types.ReportingSyncer {
+func (eir *ErrorIndexReporter) DatabaseSyncer(types.SyncerConfig) types.ReportingSyncer {
 	return func() {
 	}
+}
+
+func (edr *ErrorIndexReporter) Stop() {
+	// No op
 }

--- a/enterprise/reporting/error_index_reporting.go
+++ b/enterprise/reporting/error_index_reporting.go
@@ -124,7 +124,7 @@ func (eir *ErrorIndexReporter) Report(metrics []*types.PUReportedMetric, tx *Tx)
 	if err := db.WithStoreSafeTxFromTx(eir.ctx, tx, func(tx jobsdb.StoreSafeTx) error {
 		return db.StoreInTx(eir.ctx, tx, jobs)
 	}); err != nil {
-		return fmt.Errorf("failed to store jobs: %v", err)
+		return fmt.Errorf("failed to store jobs: %w", err)
 	}
 
 	return nil

--- a/enterprise/reporting/error_index_reporting_test.go
+++ b/enterprise/reporting/error_index_reporting_test.go
@@ -244,25 +244,17 @@ func TestErrorIndexReporter(t *testing.T) {
 				require.NoError(t, err)
 
 				c := config.New()
-				c.Set("DB.port", postgresContainer.Port)
-				c.Set("DB.user", postgresContainer.User)
-				c.Set("DB.name", postgresContainer.Database)
-				c.Set("DB.password", postgresContainer.Password)
-
 				ctx, cancel := context.WithCancel(ctx)
-
 				cs := newConfigSubscriber(logger.NOP)
-
 				subscribeDone := make(chan struct{})
 				go func() {
 					defer close(subscribeDone)
 					cs.Subscribe(ctx, mockBackendConfig)
 				}()
 
-				errIndexDB := jobsdb.NewForReadWrite("err_idx", jobsdb.WithConfig(c))
-				require.NoError(t, errIndexDB.Start())
-				defer errIndexDB.TearDown()
-				eir := NewErrorIndexReporter(ctx, logger.NOP, cs, errIndexDB)
+				eir := NewErrorIndexReporter(ctx, logger.NOP, cs, c)
+				_ = eir.DatabaseSyncer(types.SyncerConfig{ConnInfo: postgresContainer.DBDsn})
+				defer eir.Stop()
 
 				eir.now = failedAt
 				sqltx, err := postgresContainer.DB.Begin()
@@ -271,7 +263,9 @@ func TestErrorIndexReporter(t *testing.T) {
 				err = eir.Report(tc.reports, tx)
 				require.NoError(t, err)
 				require.NoError(t, tx.Commit())
-				jr, err := eir.errIndexDB.GetUnprocessed(ctx, jobsdb.GetQueryParams{
+				db, err := eir.resolveJobsDB(tx)
+				require.NoError(t, err)
+				jr, err := db.GetUnprocessed(ctx, jobsdb.GetQueryParams{
 					JobsLimit: 100,
 				})
 				require.NoError(t, err)
@@ -304,31 +298,23 @@ func TestErrorIndexReporter(t *testing.T) {
 			})
 		}
 	})
-	t.Run("Graceful shutdown", func(t *testing.T) {
+	t.Run("graceful shutdown", func(t *testing.T) {
 		postgresContainer, err := resource.SetupPostgres(pool, t)
 		require.NoError(t, err)
 
 		c := config.New()
-		c.Set("DB.port", postgresContainer.Port)
-		c.Set("DB.user", postgresContainer.User)
-		c.Set("DB.name", postgresContainer.Database)
-		c.Set("DB.password", postgresContainer.Password)
-
 		ctx, cancel := context.WithCancel(ctx)
-
 		cs := newConfigSubscriber(logger.NOP)
-
 		subscribeDone := make(chan struct{})
 		go func() {
 			defer close(subscribeDone)
-
 			cs.Subscribe(ctx, mockBackendConfig)
 		}()
 
-		errIndexDB := jobsdb.NewForReadWrite("err_idx", jobsdb.WithConfig(c))
-		require.NoError(t, errIndexDB.Start())
-		defer errIndexDB.TearDown()
-		eir := NewErrorIndexReporter(ctx, logger.NOP, cs, errIndexDB)
+		eir := NewErrorIndexReporter(ctx, logger.NOP, cs, c)
+		defer eir.Stop()
+		syncer := eir.DatabaseSyncer(types.SyncerConfig{ConnInfo: postgresContainer.DBDsn})
+
 		sqltx, err := postgresContainer.DB.Begin()
 		require.NoError(t, err)
 		tx := &Tx{Tx: sqltx}
@@ -339,14 +325,164 @@ func TestErrorIndexReporter(t *testing.T) {
 		syncerDone := make(chan struct{})
 		go func() {
 			defer close(syncerDone)
-
-			syncer := eir.DatabaseSyncer(types.SyncerConfig{})
 			syncer()
 		}()
 
 		cancel()
-
 		<-subscribeDone
 		<-syncerDone
+	})
+
+	t.Run("using 1 syncer", func(t *testing.T) {
+		t.Run("wrong transaction", func(t *testing.T) {
+			pg1, err := resource.SetupPostgres(pool, t)
+			require.NoError(t, err)
+			pg2, err := resource.SetupPostgres(pool, t)
+			require.NoError(t, err)
+
+			c := config.New()
+			ctx, cancel := context.WithCancel(ctx)
+			cs := newConfigSubscriber(logger.NOP)
+			subscribeDone := make(chan struct{})
+			go func() {
+				defer close(subscribeDone)
+				cs.Subscribe(ctx, mockBackendConfig)
+			}()
+
+			eir := NewErrorIndexReporter(ctx, logger.NOP, cs, c)
+			defer eir.Stop()
+			_ = eir.DatabaseSyncer(types.SyncerConfig{ConnInfo: pg1.DBDsn})
+
+			sqltx, err := pg2.DB.Begin()
+			require.NoError(t, err)
+			tx := &Tx{Tx: sqltx}
+			err = eir.Report([]*types.PUReportedMetric{
+				{
+					ConnectionDetails: types.ConnectionDetails{
+						SourceID:         sourceID,
+						DestinationID:    destinationID,
+						TransformationID: transformationID,
+						TrackingPlanID:   trackingPlanID,
+					},
+					PUDetails: types.PUDetails{
+						PU: reportedBy,
+					},
+					StatusDetail: &types.StatusDetail{
+						EventName: eventName,
+						EventType: eventType,
+						FailedMessages: []*types.FailedMessage{
+							{
+								MessageID:  messageID + "1",
+								ReceivedAt: receivedAt.Add(1 * time.Hour),
+							},
+							{
+								MessageID:  messageID + "2",
+								ReceivedAt: receivedAt.Add(2 * time.Hour),
+							},
+						},
+					},
+				},
+			}, tx)
+			require.Error(t, err)
+			require.Error(t, tx.Commit())
+
+			cancel()
+			<-subscribeDone
+		})
+	})
+
+	t.Run("using 2 syncers", func(t *testing.T) {
+		pg1, err := resource.SetupPostgres(pool, t)
+		require.NoError(t, err)
+		pg2, err := resource.SetupPostgres(pool, t)
+		require.NoError(t, err)
+		pg3, err := resource.SetupPostgres(pool, t)
+		require.NoError(t, err)
+
+		c := config.New()
+		ctx, cancel := context.WithCancel(ctx)
+		cs := newConfigSubscriber(logger.NOP)
+		subscribeDone := make(chan struct{})
+		go func() {
+			defer close(subscribeDone)
+			cs.Subscribe(ctx, mockBackendConfig)
+		}()
+
+		eir := NewErrorIndexReporter(ctx, logger.NOP, cs, c)
+		defer eir.Stop()
+		_ = eir.DatabaseSyncer(types.SyncerConfig{ConnInfo: pg1.DBDsn})
+		_ = eir.DatabaseSyncer(types.SyncerConfig{ConnInfo: pg2.DBDsn})
+
+		t.Run("correct transaction", func(t *testing.T) {
+			sqltx, err := pg1.DB.Begin()
+			require.NoError(t, err)
+			tx := &Tx{Tx: sqltx}
+			err = eir.Report([]*types.PUReportedMetric{
+				{
+					ConnectionDetails: types.ConnectionDetails{
+						SourceID:         sourceID,
+						DestinationID:    destinationID,
+						TransformationID: transformationID,
+						TrackingPlanID:   trackingPlanID,
+					},
+					PUDetails: types.PUDetails{
+						PU: reportedBy,
+					},
+					StatusDetail: &types.StatusDetail{
+						EventName: eventName,
+						EventType: eventType,
+						FailedMessages: []*types.FailedMessage{
+							{
+								MessageID:  messageID + "1",
+								ReceivedAt: receivedAt.Add(1 * time.Hour),
+							},
+							{
+								MessageID:  messageID + "2",
+								ReceivedAt: receivedAt.Add(2 * time.Hour),
+							},
+						},
+					},
+				},
+			}, tx)
+			require.NoError(t, err)
+			require.NoError(t, tx.Commit())
+		})
+		t.Run("wrong transaction", func(t *testing.T) {
+			sqltx, err := pg3.DB.Begin()
+			require.NoError(t, err)
+			tx := &Tx{Tx: sqltx}
+			err = eir.Report([]*types.PUReportedMetric{
+				{
+					ConnectionDetails: types.ConnectionDetails{
+						SourceID:         sourceID,
+						DestinationID:    destinationID,
+						TransformationID: transformationID,
+						TrackingPlanID:   trackingPlanID,
+					},
+					PUDetails: types.PUDetails{
+						PU: reportedBy,
+					},
+					StatusDetail: &types.StatusDetail{
+						EventName: eventName,
+						EventType: eventType,
+						FailedMessages: []*types.FailedMessage{
+							{
+								MessageID:  messageID + "1",
+								ReceivedAt: receivedAt.Add(1 * time.Hour),
+							},
+							{
+								MessageID:  messageID + "2",
+								ReceivedAt: receivedAt.Add(2 * time.Hour),
+							},
+						},
+					},
+				},
+			}, tx)
+			require.Error(t, err)
+			require.NoError(t, tx.Commit())
+		})
+
+		cancel()
+		<-subscribeDone
 	})
 }

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -25,6 +25,7 @@ import (
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 	"github.com/rudderlabs/rudder-server/utils/httputil"
 	"github.com/rudderlabs/rudder-server/utils/misc"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
@@ -149,7 +150,7 @@ func (edr *ErrorDetailReporter) GetSyncer(syncerKey string) *types.SyncSource {
 	return edr.syncers[syncerKey]
 }
 
-func (edr *ErrorDetailReporter) Report(metrics []*types.PUReportedMetric, txn *sql.Tx) error {
+func (edr *ErrorDetailReporter) Report(metrics []*types.PUReportedMetric, txn *Tx) error {
 	edr.log.Debug("[ErrorDetailReport] Report method called\n")
 	if len(metrics) == 0 {
 		return nil

--- a/enterprise/reporting/mediator.go
+++ b/enterprise/reporting/mediator.go
@@ -2,13 +2,13 @@ package reporting
 
 import (
 	"context"
-	"database/sql"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
@@ -56,7 +56,7 @@ func NewReportingMediator(ctx context.Context, log logger.Logger, enterpriseToke
 	return rm
 }
 
-func (rm *Mediator) Report(metrics []*types.PUReportedMetric, txn *sql.Tx) error {
+func (rm *Mediator) Report(metrics []*types.PUReportedMetric, txn *Tx) error {
 	for _, reporter := range rm.reporters {
 		if err := reporter.Report(metrics, txn); err != nil {
 			return err

--- a/enterprise/reporting/mediator.go
+++ b/enterprise/reporting/mediator.go
@@ -2,15 +2,12 @@ package reporting
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
-	"github.com/rudderlabs/rudder-server/jobsdb"
 	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
@@ -34,8 +31,6 @@ func NewReportingMediator(ctx context.Context, log logger.Logger, enterpriseToke
 		ctx:    ctx,
 		cancel: cancel,
 	}
-	rm.ctx, rm.cancel = context.WithCancel(ctx)
-	rm.g, rm.ctx = errgroup.WithContext(rm.ctx)
 
 	reportingEnabled := config.GetBool("Reporting.enabled", types.DefaultReportingEnabled)
 	if enterpriseToken == "" || !reportingEnabled {
@@ -60,29 +55,8 @@ func NewReportingMediator(ctx context.Context, log logger.Logger, enterpriseToke
 
 	// error index reporting implementation
 	if config.GetBool("Reporting.errorIndexReporting.enabled", false) {
-		conf := config.Default
-		errIndexDB := jobsdb.NewForReadWrite(
-			"err_idx",
-			jobsdb.WithDSLimit(conf.GetReloadableIntVar(0, 1, "Reporting.errorIndexReporting.dsLimit")),
-			jobsdb.WithConfig(conf),
-			jobsdb.WithSkipMaintenanceErr(conf.GetBool("Reporting.errorIndexReporting.skipMaintenanceError", false)),
-			jobsdb.WithJobMaxAge(
-				func() time.Duration {
-					return conf.GetDurationVar(24, time.Hour, "Reporting.errorIndexReporting.jobRetention")
-				},
-			),
-		)
-		if err := errIndexDB.Start(); err != nil {
-			panic(fmt.Sprintf("failed to start error index db: %v", err))
-		}
-		errorIndexReporter := NewErrorIndexReporter(rm.ctx, rm.log, configSubscriber, errIndexDB)
+		errorIndexReporter := NewErrorIndexReporter(rm.ctx, rm.log, configSubscriber, config.Default)
 		rm.reporters = append(rm.reporters, errorIndexReporter)
-		rm.g.Go(func() error {
-			// Once the context is done, it stops the errorIndex jobsDB
-			<-rm.ctx.Done()
-			errIndexDB.Stop()
-			return nil
-		})
 	}
 
 	return rm
@@ -120,4 +94,7 @@ func (rm *Mediator) DatabaseSyncer(c types.SyncerConfig) types.ReportingSyncer {
 func (rm *Mediator) Stop() {
 	rm.cancel()
 	_ = rm.g.Wait()
+	for _, reporter := range rm.reporters {
+		reporter.Stop()
+	}
 }

--- a/enterprise/reporting/noop.go
+++ b/enterprise/reporting/noop.go
@@ -15,3 +15,5 @@ func (*NOOP) Report(_ []*types.PUReportedMetric, _ *Tx) error {
 func (*NOOP) DatabaseSyncer(c types.SyncerConfig) types.ReportingSyncer {
 	return func() {}
 }
+
+func (*NOOP) Stop() {}

--- a/enterprise/reporting/noop.go
+++ b/enterprise/reporting/noop.go
@@ -1,15 +1,14 @@
 package reporting
 
 import (
-	"database/sql"
-
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
 // NOOP reporting implementation that does nothing
 type NOOP struct{}
 
-func (*NOOP) Report(_ []*types.PUReportedMetric, _ *sql.Tx) error {
+func (*NOOP) Report(_ []*types.PUReportedMetric, _ *Tx) error {
 	return nil
 }
 

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -26,6 +26,7 @@ import (
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 	"github.com/rudderlabs/rudder-server/utils/httputil"
 	"github.com/rudderlabs/rudder-server/utils/misc"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
@@ -512,7 +513,7 @@ func transformMetricForPII(metric types.PUReportedMetric, piiColumns []string) t
 	return metric
 }
 
-func (r *DefaultReporter) Report(metrics []*types.PUReportedMetric, txn *sql.Tx) error {
+func (r *DefaultReporter) Report(metrics []*types.PUReportedMetric, txn *Tx) error {
 	if len(metrics) == 0 {
 		return nil
 	}

--- a/enterprise/reporting/setup_test.go
+++ b/enterprise/reporting/setup_test.go
@@ -121,12 +121,8 @@ func TestSetupForDelegates(t *testing.T) {
 					EnterpriseToken: "dummy-token",
 				}
 			}
-			ctx, cancel := context.WithCancel(context.Background())
-			med := NewReportingMediator(ctx, logger.NOP, f.EnterpriseToken, &backendconfig.NOOP{})
-			defer func() {
-				cancel()
-				_ = med.g.Wait()
-			}()
+			med := NewReportingMediator(context.Background(), logger.NOP, f.EnterpriseToken, &backendconfig.NOOP{})
+			defer med.Stop()
 			require.Len(t, med.reporters, tc.expectedDelegates)
 		})
 

--- a/enterprise/reporting/setup_test.go
+++ b/enterprise/reporting/setup_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
-	"github.com/rudderlabs/rudder-server/utils/types"
 
 	"github.com/stretchr/testify/require"
 
@@ -124,15 +123,11 @@ func TestSetupForDelegates(t *testing.T) {
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			med := NewReportingMediator(ctx, logger.NOP, f.EnterpriseToken, &backendconfig.NOOP{})
+			defer func() {
+				cancel()
+				_ = med.g.Wait()
+			}()
 			require.Len(t, med.reporters, tc.expectedDelegates)
-			// TODO: error index reporting jobsdb should start with the syncer
-			// so that we shouldn't need to start the database syncer here and end it just for cleanup
-			cancel()
-			syncer := med.DatabaseSyncer(types.SyncerConfig{
-				Label:    "test",
-				ConnInfo: postgresContainer.DBDsn,
-			})
-			syncer()
 		})
 
 	}

--- a/enterprise/reporting/setup_test.go
+++ b/enterprise/reporting/setup_test.go
@@ -122,7 +122,6 @@ func TestSetupForDelegates(t *testing.T) {
 				}
 			}
 			med := NewReportingMediator(context.Background(), logger.NOP, f.EnterpriseToken, &backendconfig.NOOP{})
-			defer med.Stop()
 			require.Len(t, med.reporters, tc.expectedDelegates)
 		})
 

--- a/jobsdb/backup.go
+++ b/jobsdb/backup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/services/fileuploader"
 	"github.com/rudderlabs/rudder-server/utils/misc"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 )
 
 func (jd *Handle) isBackupEnabled() bool {

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
 	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
 	fileuploader "github.com/rudderlabs/rudder-server/services/fileuploader"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 )
 
 const (

--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rudderlabs/rudder-server/services/fileuploader"
 	"github.com/rudderlabs/rudder-server/testhelper"
 	"github.com/rudderlabs/rudder-server/testhelper/destination"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 )
 
 func TestBackupTable(t *testing.T) {

--- a/jobsdb/jobsdb_renameDs_test.go
+++ b/jobsdb/jobsdb_renameDs_test.go
@@ -10,6 +10,7 @@ import (
 
 	rsRand "github.com/rudderlabs/rudder-go-kit/testhelper/rand"
 	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 )
 
 func Test_mustRenameDS(t *testing.T) {

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/rudderlabs/rudder-server/jobsdb/prebackup"
 	fileuploader "github.com/rudderlabs/rudder-server/services/fileuploader"
 	"github.com/rudderlabs/rudder-server/utils/misc"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 )
 
 var _ = Describe("Calculate newDSIdx for internal migrations", Ordered, func() {

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rudderlabs/rudder-server/jobsdb/internal/dsindex"
 	"github.com/rudderlabs/rudder-server/jobsdb/internal/lock"
 	"github.com/rudderlabs/rudder-server/utils/misc"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 )
 
 // startMigrateDSLoop migrates jobs from src dataset (srcDS) to destination dataset (dest_ds)

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -12,6 +12,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	uuid "github.com/google/uuid"
 	jobsdb "github.com/rudderlabs/rudder-server/jobsdb"
+	tx "github.com/rudderlabs/rudder-server/utils/tx"
 )
 
 // MockJobsDB is a mock of JobsDB interface.
@@ -422,8 +423,22 @@ func (mr *MockJobsDBMockRecorder) WithStoreSafeTx(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithStoreSafeTx", reflect.TypeOf((*MockJobsDB)(nil).WithStoreSafeTx), arg0, arg1)
 }
 
+// WithStoreSafeTxFromTx mocks base method.
+func (m *MockJobsDB) WithStoreSafeTxFromTx(arg0 context.Context, arg1 *tx.Tx, arg2 func(jobsdb.StoreSafeTx) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WithStoreSafeTxFromTx", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WithStoreSafeTxFromTx indicates an expected call of WithStoreSafeTxFromTx.
+func (mr *MockJobsDBMockRecorder) WithStoreSafeTxFromTx(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithStoreSafeTxFromTx", reflect.TypeOf((*MockJobsDB)(nil).WithStoreSafeTxFromTx), arg0, arg1, arg2)
+}
+
 // WithTx mocks base method.
-func (m *MockJobsDB) WithTx(arg0 func(*jobsdb.Tx) error) error {
+func (m *MockJobsDB) WithTx(arg0 func(*tx.Tx) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithTx", arg0)
 	ret0, _ := ret[0].(error)

--- a/mocks/utils/types/mock_types.go
+++ b/mocks/utils/types/mock_types.go
@@ -100,3 +100,15 @@ func (mr *MockReportingMockRecorder) Report(arg0, arg1 interface{}) *gomock.Call
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockReporting)(nil).Report), arg0, arg1)
 }
+
+// Stop mocks base method.
+func (m *MockReporting) Stop() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Stop")
+}
+
+// Stop indicates an expected call of Stop.
+func (mr *MockReportingMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockReporting)(nil).Stop))
+}

--- a/mocks/utils/types/mock_types.go
+++ b/mocks/utils/types/mock_types.go
@@ -5,11 +5,11 @@
 package mock_types
 
 import (
-	sql "database/sql"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 	model "github.com/rudderlabs/rudder-server/enterprise/suppress-user/model"
+	tx "github.com/rudderlabs/rudder-server/utils/tx"
 	types "github.com/rudderlabs/rudder-server/utils/types"
 )
 
@@ -88,7 +88,7 @@ func (mr *MockReportingMockRecorder) DatabaseSyncer(arg0 interface{}) *gomock.Ca
 }
 
 // Report mocks base method.
-func (m *MockReporting) Report(arg0 []*types.PUReportedMetric, arg1 *sql.Tx) error {
+func (m *MockReporting) Report(arg0 []*types.PUReportedMetric, arg1 *tx.Tx) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Report", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -47,6 +47,7 @@ import (
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/httputil"
 	"github.com/rudderlabs/rudder-server/utils/misc"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 	"github.com/rudderlabs/rudder-server/utils/types"
 	"github.com/rudderlabs/rudder-server/utils/workerpool"
 )
@@ -2131,7 +2132,7 @@ func (proc *Handle) Store(partition string, in *storeMessage) {
 			}
 
 			if proc.isReportingEnabled() {
-				if err = proc.reporting.Report(in.reportMetrics, tx.SqlTx()); err != nil {
+				if err = proc.reporting.Report(in.reportMetrics, tx.Tx()); err != nil {
 					return fmt.Errorf("reporting metrics: %w", err)
 				}
 			}
@@ -2573,7 +2574,7 @@ func (proc *Handle) transformSrcDest(
 	}
 }
 
-func (proc *Handle) saveDroppedJobs(droppedJobs []*jobsdb.JobT, tx *jobsdb.Tx) error {
+func (proc *Handle) saveDroppedJobs(droppedJobs []*jobsdb.JobT, tx *Tx) error {
 	if len(droppedJobs) > 0 {
 		for i := range droppedJobs { // each dropped job should have a unique jobID in the scope of the batch
 			droppedJobs[i].JobID = int64(i)

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 	testutils "github.com/rudderlabs/rudder-server/utils/tests"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
@@ -2024,8 +2025,8 @@ var _ = Describe("Processor", Ordered, func() {
 				StoreInTx(gomock.Any(), gomock.Any(), gomock.Any()).
 				AnyTimes()
 
-			c.mockWriteProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(tx *jobsdb.Tx) error) {
-				_ = f(&jobsdb.Tx{})
+			c.mockWriteProcErrorsDB.EXPECT().WithTx(gomock.Any()).Do(func(f func(tx *Tx) error) {
+				_ = f(&Tx{})
 			}).Return(nil).Times(0)
 
 			// One Store call is expected for all events

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -762,7 +762,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 			}
 
 			if brt.reporting != nil && brt.reportingEnabled {
-				if err = brt.reporting.Report(reportMetrics, tx.SqlTx()); err != nil {
+				if err = brt.reporting.Report(reportMetrics, tx.Tx()); err != nil {
 					return fmt.Errorf("reporting metrics: %w", err)
 				}
 			}

--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -58,7 +58,7 @@ func (brt *Handle) updateJobStatuses(ctx context.Context, destinationID string, 
 			}
 
 			if brt.reporting != nil && brt.reportingEnabled {
-				if err = brt.reporting.Report(reportMetrics, tx.SqlTx()); err != nil {
+				if err = brt.reporting.Report(reportMetrics, tx.Tx()); err != nil {
 					return fmt.Errorf("reporting metrics: %w", err)
 				}
 			}
@@ -688,7 +688,7 @@ func (brt *Handle) setMultipleJobStatus(asyncOutput common.AsyncUploadOutput, at
 			}
 
 			if brt.reporting != nil && brt.reportingEnabled {
-				if err = brt.reporting.Report(reportMetrics, tx.SqlTx()); err != nil {
+				if err = brt.reporting.Report(reportMetrics, tx.Tx()); err != nil {
 					return fmt.Errorf("reporting metrics: %w", err)
 				}
 			}

--- a/router/batchrouter/worker.go
+++ b/router/batchrouter/worker.go
@@ -142,7 +142,7 @@ func (w *worker) processJobAsync(jobsWg *sync.WaitGroup, destinationJobs *Destin
 						return fmt.Errorf("marking %s job statuses as aborted: %w", brt.destType, err)
 					}
 					if brt.reporting != nil && brt.reportingEnabled {
-						if err = brt.reporting.Report(reportMetrics, tx.SqlTx()); err != nil {
+						if err = brt.reporting.Report(reportMetrics, tx.Tx()); err != nil {
 							return fmt.Errorf("reporting metrics: %w", err)
 						}
 					}

--- a/router/factory.go
+++ b/router/factory.go
@@ -1,8 +1,6 @@
 package router
 
 import (
-	"database/sql"
-
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
@@ -11,6 +9,7 @@ import (
 	destinationdebugger "github.com/rudderlabs/rudder-server/services/debugger/destination"
 	"github.com/rudderlabs/rudder-server/services/rsources"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 	utilTypes "github.com/rudderlabs/rudder-server/utils/types"
 )
 
@@ -48,5 +47,5 @@ func (f *Factory) New(destination *backendconfig.DestinationT) *Handle {
 }
 
 type reporter interface {
-	Report(metrics []*utilTypes.PUReportedMetric, txn *sql.Tx) error
+	Report(metrics []*utilTypes.PUReportedMetric, txn *Tx) error
 }

--- a/router/handle.go
+++ b/router/handle.go
@@ -405,7 +405,7 @@ func (rt *Handle) commitStatusList(workerJobStatuses *[]workerJobStatus) {
 				if err != nil {
 					return err
 				}
-				if err = rt.Reporting.Report(reportMetrics, tx.SqlTx()); err != nil {
+				if err = rt.Reporting.Report(reportMetrics, tx.Tx()); err != nil {
 					return fmt.Errorf("reporting metrics: %w", err)
 				}
 				return nil

--- a/router/handle_observability.go
+++ b/router/handle_observability.go
@@ -14,6 +14,7 @@ import (
 	routerutils "github.com/rudderlabs/rudder-server/router/utils"
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 	"github.com/rudderlabs/rudder-server/services/rsources"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 )
 
 func (rt *Handle) trackRequestMetrics(reqMetric requestMetric) {
@@ -175,7 +176,7 @@ func (rt *Handle) eventOrderDebugInfo(orderKey string) (res string) {
 		}
 	}()
 	userID, destinationID := parseJobOrderKey(orderKey)
-	if err := rt.jobsDB.WithTx(func(tx *jobsdb.Tx) error {
+	if err := rt.jobsDB.WithTx(func(tx *Tx) error {
 		rows, err := tx.Query(`SELECT * FROM joborderlog($1, $2, 10) LIMIT 100`, destinationID, userID)
 		if err != nil {
 			return err

--- a/utils/tx/tx.go
+++ b/utils/tx/tx.go
@@ -1,0 +1,26 @@
+package tx
+
+import "database/sql"
+
+// Tx is a wrapper around sql.Tx that supports registering and executing
+// post-commit actions, a.k.a. success listeners.
+type Tx struct {
+	*sql.Tx
+	successListeners []func()
+}
+
+// AddSuccessListener registers a listener to be executed after the transaction has been committed successfully.
+func (tx *Tx) AddSuccessListener(listener func()) {
+	tx.successListeners = append(tx.successListeners, listener)
+}
+
+// Commit commits the transaction and executes all listeners.
+func (tx *Tx) Commit() error {
+	err := tx.Tx.Commit()
+	if err == nil {
+		for _, successListener := range tx.successListeners {
+			successListener()
+		}
+	}
+	return err
+}

--- a/utils/types/types.go
+++ b/utils/types/types.go
@@ -3,11 +3,11 @@
 package types
 
 import (
-	"database/sql"
 	"net/http"
 	"time"
 
 	"github.com/rudderlabs/rudder-server/enterprise/suppress-user/model"
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 )
 
 const (
@@ -61,7 +61,7 @@ type ConfigEnvI interface {
 // Reporting is interface to report metrics
 type Reporting interface {
 	// Report reports metrics to reporting service
-	Report(metrics []*PUReportedMetric, txn *sql.Tx) error
+	Report(metrics []*PUReportedMetric, tx *Tx) error
 
 	// DatabaseSyncer creates reporting tables in the database and returns a function to periodically sync the data
 	DatabaseSyncer(c SyncerConfig) ReportingSyncer

--- a/utils/types/types.go
+++ b/utils/types/types.go
@@ -65,6 +65,9 @@ type Reporting interface {
 
 	// DatabaseSyncer creates reporting tables in the database and returns a function to periodically sync the data
 	DatabaseSyncer(c SyncerConfig) ReportingSyncer
+
+	// Stop the reporting service
+	Stop()
 }
 
 type ReportingSyncer func()

--- a/warehouse/app.go
+++ b/warehouse/app.go
@@ -341,6 +341,7 @@ func (a *App) Run(ctx context.Context) error {
 
 	if !mode.IsStandAloneSlave(a.config.mode) {
 		a.reporting = a.app.Features().Reporting.Setup(gCtx, a.bcConfig)
+		defer a.reporting.Stop()
 		syncer := a.reporting.DatabaseSyncer(types.SyncerConfig{ConnInfo: a.connectionString(), Label: types.WarehouseReportingLabel})
 		g.Go(misc.WithBugsnagForWarehouse(func() error {
 			syncer()

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -1411,7 +1411,7 @@ func (job *UploadJob) setUploadStatus(statusOpts UploadStatusOpts) (err error) {
 		if job.config.reportingEnabled {
 			err = job.reporting.Report(
 				[]*types.PUReportedMetric{&statusOpts.ReportingMetric},
-				txn.GetTx(),
+				txn.Tx,
 			)
 			if err != nil {
 				return
@@ -1665,7 +1665,7 @@ func (job *UploadJob) setUploadError(statusError error, state string) (string, e
 		})
 	}
 	if job.config.reportingEnabled {
-		if err = job.reporting.Report(reportingMetrics, txn.GetTx()); err != nil {
+		if err = job.reporting.Report(reportingMetrics, txn.Tx); err != nil {
 			return "", fmt.Errorf("reporting metrics: %w", err)
 		}
 	}


### PR DESCRIPTION
# Description

- Respect transaction while reporting in error index reporter.
- Support declaring transaction listeners in reporters.
- Support declaratively stopping the reporting service.
- Support different jobsdbs for different syncers in error index reporter.

## Linear Ticket

Resolves PIPE-430

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
