### PR TITLE
fix: corrupted rsources stats captured by processor for dropped jobs

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2566,10 +2566,13 @@ func (proc *Handle) transformSrcDest(
 	}
 }
 
-func (proc *Handle) saveDroppedJobs(failedJobs []*jobsdb.JobT, tx *jobsdb.Tx) error {
-	if len(failedJobs) > 0 {
+func (proc *Handle) saveDroppedJobs(droppedJobs []*jobsdb.JobT, tx *jobsdb.Tx) error {
+	if len(droppedJobs) > 0 {
+		for i := range droppedJobs { // each dropped job should have a unique jobID in the scope of the batch
+			droppedJobs[i].JobID = int64(i)
+		}
 		rsourcesStats := rsources.NewDroppedJobsCollector(proc.rsourcesService)
-		rsourcesStats.JobsDropped(failedJobs)
+		rsourcesStats.JobsDropped(droppedJobs)
 		return rsourcesStats.Publish(context.TODO(), tx.Tx)
 	}
 	return nil


### PR DESCRIPTION
# Description

Using a unique job id instead of a zero (0) value for every dropped job so that stats are captured correctly.

## Problem
By using the same (0) job id, `in_count` was being incremented for all different stat key combinations (job_run_id, task_run_id, source_id & destination_id), but `failed_count` was being erroneously incremented always for the first stat key, due to a corrupted [jobIdsToStatKeyIndex](https://github.com/rudderlabs/rudder-server/blob/49b376fc8b8f4eb1cb20c4fd949f4bfa869845d6/services/rsources/stats_collector.go#L151-L152).

## Linear Ticket

Resolves PIPE-433

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
