### PR TITLE
fix: invalid memory address or nil pointer dereference in googlecloudfunction

### DIFF
--- a/services/streammanager/googlecloudfunction/googlecloudfunction.go
+++ b/services/streammanager/googlecloudfunction/googlecloudfunction.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/services/streammanager/common"
+	"github.com/rudderlabs/rudder-server/utils/httputil"
 )
 
 type Config struct {
@@ -140,8 +141,9 @@ func (producer *GoogleCloudFunctionProducer) Produce(jsonData json.RawMessage, _
 	}
 
 	var responseBody []byte
-	defer resp.Body.Close()
+
 	if err == nil {
+		defer func() { httputil.CloseResponse(resp) }()
 		responseBody, err = io.ReadAll(resp.Body)
 	}
 	if err != nil {

--- a/utils/httputil/client.go
+++ b/utils/httputil/client.go
@@ -37,6 +37,6 @@ func CloseResponse(resp *http.Response) {
 	if resp != nil && resp.Body != nil {
 		const maxBodySlurpSize = 2 << 10 // 2KB
 		_, _ = io.CopyN(io.Discard, resp.Body, maxBodySlurpSize)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 }


### PR DESCRIPTION
# Description

Using `httputil.CloseResponse` for safely closing the response's body

## Linear Ticket

Fixes PIPE-439
Fixes PIPE-438

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
