### PR TITLE
feat: new transformer service to fetch and serve transformer features

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -31,6 +31,7 @@ import (
 	sourcedebugger "github.com/rudderlabs/rudder-server/services/debugger/source"
 	transformationdebugger "github.com/rudderlabs/rudder-server/services/debugger/transformation"
 	"github.com/rudderlabs/rudder-server/services/fileuploader"
+	"github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/payload"
@@ -129,6 +130,12 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 	if err != nil {
 		return err
 	}
+
+	transformerFeaturesService := transformer.NewFeaturesService(ctx, transformer.FeaturesServiceConfig{
+		PollInterval:             config.GetDuration("Transformer.pollInterval", 1, time.Second),
+		TransformerURL:           config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090"),
+		FeaturesRetryMaxAttempts: 10,
+	})
 
 	// This separate gateway db is created just to be used with gateway because in case of degraded mode,
 	// the earlier created gwDb (which was created to be used mainly with processor) will not be running, and it
@@ -257,6 +264,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 		transientSources,
 		fileUploaderProvider,
 		rsourcesService,
+		transformerFeaturesService,
 		destinationHandle,
 		transformationhandle,
 		enrichers,
@@ -319,7 +327,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 		ctx,
 		config, logger.NewLogger().Child("gateway"), stats.Default,
 		a.app, backendconfig.DefaultBackendConfig, gatewayDB, errDBForWrite,
-		rateLimiter, a.versionHandler, rsourcesService, sourceHandle,
+		rateLimiter, a.versionHandler, rsourcesService, transformerFeaturesService, sourceHandle,
 	)
 	if err != nil {
 		return fmt.Errorf("could not setup gateway: %w", err)

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -33,6 +33,7 @@ import (
 	destinationdebugger "github.com/rudderlabs/rudder-server/services/debugger/destination"
 	transformationdebugger "github.com/rudderlabs/rudder-server/services/debugger/transformation"
 	"github.com/rudderlabs/rudder-server/services/fileuploader"
+	"github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/payload"
@@ -136,6 +137,12 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 	if err != nil {
 		return err
 	}
+
+	transformerFeaturesService := transformer.NewFeaturesService(ctx, transformer.FeaturesServiceConfig{
+		PollInterval:             config.GetDuration("Transformer.pollInterval", 1, time.Second),
+		TransformerURL:           config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090"),
+		FeaturesRetryMaxAttempts: 10,
+	})
 
 	gwDBForProcessor := jobsdb.NewForRead(
 		"gw",
@@ -247,6 +254,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 		transientSources,
 		fileUploaderProvider,
 		rsourcesService,
+		transformerFeaturesService,
 		destinationHandle,
 		transformationhandle,
 		enrichers,

--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -38,6 +38,7 @@ import (
 	transformationdebugger "github.com/rudderlabs/rudder-server/services/debugger/transformation"
 	"github.com/rudderlabs/rudder-server/services/fileuploader"
 	"github.com/rudderlabs/rudder-server/services/rsources"
+	"github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 	"github.com/rudderlabs/rudder-server/utils/types/servermode"
@@ -208,10 +209,10 @@ func TestDynamicClusterManager(t *testing.T) {
 		transientsource.NewEmptyService(),
 		fileuploader.NewDefaultProvider(),
 		rsources.NewNoOpService(),
+		transformer.NewNoOpService(),
 		destinationdebugger.NewNoOpService(),
 		transformationdebugger.NewNoOpService(),
 		[]enricher.PipelineEnricher{},
-		processor.WithFeaturesRetryMaxAttempts(0),
 	)
 	processor.BackendConfig = mockBackendConfig
 	processor.Transformer = mockTransformer

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -45,6 +45,7 @@ import (
 	mocksTypes "github.com/rudderlabs/rudder-server/mocks/utils/types"
 	sourcedebugger "github.com/rudderlabs/rudder-server/services/debugger/source"
 	"github.com/rudderlabs/rudder-server/services/rsources"
+	"github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 	testutils "github.com/rudderlabs/rudder-server/utils/tests"
@@ -266,7 +267,7 @@ var _ = Describe("Gateway Enterprise", func() {
 	Context("Suppress users", func() {
 		BeforeEach(func() {
 			gateway = &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService())
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService())
 			Expect(err).To(BeNil())
 			statsStore = memstats.New()
 			gateway.stats = statsStore
@@ -402,7 +403,7 @@ var _ = Describe("Gateway", func() {
 	Context("Initialization", func() {
 		It("should wait for backend config", func() {
 			gateway := &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService())
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService())
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 			err = gateway.Shutdown()
@@ -435,7 +436,7 @@ var _ = Describe("Gateway", func() {
 			GinkgoT().Setenv("RSERVER_GATEWAY_WEB_PORT", strconv.Itoa(serverPort))
 
 			gateway = &Handle{}
-			err = gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService())
+			err = gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService())
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 			gateway.irh = mockRequestHandler{}
@@ -526,7 +527,7 @@ var _ = Describe("Gateway", func() {
 
 		BeforeEach(func() {
 			gateway = &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService())
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService())
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 			statsStore = memstats.New()
@@ -854,7 +855,7 @@ var _ = Describe("Gateway", func() {
 		BeforeEach(func() {
 			gateway = &Handle{}
 
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, c.mockRateLimiter, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService())
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, c.mockRateLimiter, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService())
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 
@@ -959,7 +960,7 @@ var _ = Describe("Gateway", func() {
 		BeforeEach(func() {
 			gateway = &Handle{}
 			conf.Set("Gateway.enableRateLimit", true)
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, c.mockRateLimiter, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService())
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, c.mockRateLimiter, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService())
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 
@@ -1051,7 +1052,7 @@ var _ = Describe("Gateway", func() {
 
 		BeforeEach(func() {
 			gateway = &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService())
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService())
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 
@@ -1334,7 +1335,7 @@ var _ = Describe("Gateway", func() {
 
 		BeforeEach(func() {
 			gateway = &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService())
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService())
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 		})
@@ -1360,7 +1361,7 @@ var _ = Describe("Gateway", func() {
 		)
 		BeforeEach(func() {
 			gateway = &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService())
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService())
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 		})
@@ -1541,7 +1542,7 @@ var _ = Describe("Gateway", func() {
 		var gateway *Handle
 		BeforeEach(func() {
 			gateway = &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService())
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.Default, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService())
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 		})

--- a/gateway/handle_http_auth.go
+++ b/gateway/handle_http_auth.go
@@ -172,6 +172,7 @@ func sourceToRequestContext(s backendconfig.SourceT) *gwtypes.AuthRequestContext
 		SourceCategory: s.SourceDefinition.Category,
 		SourceDefName:  s.SourceDefinition.Name,
 		ReplaySource:   s.IsReplaySource(),
+		Source:         s,
 	}
 	if arctx.SourceCategory == "" {
 		arctx.SourceCategory = eventStreamSourceCategory

--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -33,6 +33,7 @@ import (
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 	"github.com/rudderlabs/rudder-server/services/rsources"
 	rsources_http "github.com/rudderlabs/rudder-server/services/rsources/http"
+	"github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
@@ -50,7 +51,7 @@ func (gw *Handle) Setup(
 	config *config.Config, logger logger.Logger, stat stats.Stats,
 	application app.App, backendConfig backendconfig.BackendConfig, jobsDB, errDB jobsdb.JobsDB,
 	rateLimiter throttler.Throttler, versionHandler func(w http.ResponseWriter, r *http.Request),
-	rsourcesService rsources.JobService, sourcehandle sourcedebugger.SourceDebugger,
+	rsourcesService rsources.JobService, transformerFeaturesService transformer.FeaturesService, sourcehandle sourcedebugger.SourceDebugger,
 ) error {
 	gw.config = config
 	gw.logger = logger
@@ -118,7 +119,7 @@ func (gw *Handle) Setup(
 	gw.batchUserWorkerBatchRequestQ = make(chan *batchUserWorkerBatchRequestT, gw.conf.maxDBWriterProcess)
 	gw.irh = &ImportRequestHandler{Handle: gw}
 	gw.rrh = &RegularRequestHandler{Handle: gw}
-	gw.webhook = webhook.Setup(gw, gw.stats)
+	gw.webhook = webhook.Setup(gw, transformerFeaturesService, gw.stats)
 	whURL, err := url.ParseRequestURI(misc.GetWarehouseURL())
 	if err != nil {
 		return fmt.Errorf("invalid warehouse URL %s: %w", whURL, err)

--- a/gateway/internal/types/types.go
+++ b/gateway/internal/types/types.go
@@ -1,6 +1,9 @@
 package types
 
-import "github.com/rudderlabs/rudder-server/utils/misc"
+import (
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+)
 
 type ContextKey string
 
@@ -23,6 +26,7 @@ type AuthRequestContext struct {
 	ReplaySource    bool
 	SourceJobRunID  string
 	SourceTaskRunID string
+	Source          backendconfig.SourceT
 }
 
 func (arctx *AuthRequestContext) SourceTag() string {

--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -58,6 +58,8 @@ const (
 	ContextDeadlineExceeded = "context deadline exceeded"
 	// GatewayTimeout - Gateway timeout
 	GatewayTimeout = "Gateway timeout"
+	// ServiceUnavailable - Service unavailable
+	ServiceUnavailable = "Service unavailable"
 	// NoSourceIdInHeader - Failed to read source id from header
 	NoSourceIdInHeader = "Failed to read source id from header"
 	// InvalidSourceID - Invalid source id
@@ -100,6 +102,8 @@ var statusMap = map[string]status{
 	ErrorInParseMultiform:                          {message: ErrorInParseMultiform, code: http.StatusBadRequest},
 	NotRudderEvent:                                 {message: NotRudderEvent, code: http.StatusBadRequest},
 	ContextDeadlineExceeded:                        {message: GatewayTimeout, code: http.StatusGatewayTimeout},
+	GatewayTimeout:                                 {message: GatewayTimeout, code: http.StatusGatewayTimeout},
+	ServiceUnavailable:                             {message: ServiceUnavailable, code: http.StatusServiceUnavailable},
 }
 
 // status holds the gateway response status message and code

--- a/gateway/webhook/webhookTransformer_test.go
+++ b/gateway/webhook/webhookTransformer_test.go
@@ -1,0 +1,65 @@
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	gwtypes "github.com/rudderlabs/rudder-server/gateway/internal/types"
+	"github.com/rudderlabs/rudder-server/services/transformer"
+)
+
+func TestV0Adapter(t *testing.T) {
+	v0Adapter := newSourceTransformAdapter(transformer.V0)
+
+	t.Run("should return the right url", func(t *testing.T) {
+		testSrcType := "testSrcType"
+		url, err := v0Adapter.getTransformerURL(testSrcType)
+		require.Nil(t, err)
+		require.True(t, strings.HasSuffix(url, fmt.Sprintf("/%s/sources/%s", transformer.V0, testSrcType)))
+	})
+
+	t.Run("should return the body as is", func(t *testing.T) {
+		testBody := []byte("testBody")
+		retBody, err := v0Adapter.getTransformerEvent(nil, testBody)
+		require.Equal(t, testBody, retBody)
+		require.Nil(t, err)
+	})
+}
+
+func TestV1Adapter(t *testing.T) {
+	t.Run("should return the right url", func(t *testing.T) {
+		v1Adapter := newSourceTransformAdapter(transformer.V1)
+		testSrcType := "testSrcType"
+		url, err := v1Adapter.getTransformerURL(testSrcType)
+		require.Nil(t, err)
+		require.True(t, strings.HasSuffix(url, fmt.Sprintf("/%s/sources/%s", transformer.V1, testSrcType)))
+	})
+
+	t.Run("should return the body in v1 format", func(t *testing.T) {
+		testSrcId := "testSrcId"
+		testBody := []byte(`{"a": "testBody"}`)
+
+		mockSrc := backendconfig.SourceT{
+			ID:           testSrcId,
+			Destinations: []backendconfig.DestinationT{{ID: "testDestId"}},
+		}
+
+		v1Adapter := newSourceTransformAdapter(transformer.V1)
+
+		retBody, err := v1Adapter.getTransformerEvent(&gwtypes.AuthRequestContext{Source: mockSrc}, testBody)
+		require.Nil(t, err)
+
+		v1TransformerEvent := V1TransformerEvent{
+			Event:  testBody,
+			Source: backendconfig.SourceT{ID: mockSrc.ID},
+		}
+		expectedBody, err := json.Marshal(v1TransformerEvent)
+		require.Nil(t, err)
+		require.Equal(t, expectedBody, retBody)
+	})
+}

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -16,32 +16,34 @@ import (
 	transformationdebugger "github.com/rudderlabs/rudder-server/services/debugger/transformation"
 	"github.com/rudderlabs/rudder-server/services/fileuploader"
 	"github.com/rudderlabs/rudder-server/services/rsources"
+	transformerFeaturesService "github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
 type LifecycleManager struct {
-	Handle           *Handle
-	mainCtx          context.Context
-	currentCancel    context.CancelFunc
-	waitGroup        interface{ Wait() }
-	gatewayDB        *jobsdb.Handle
-	routerDB         *jobsdb.Handle
-	batchRouterDB    *jobsdb.Handle
-	readErrDB        *jobsdb.Handle
-	writeErrDB       *jobsdb.Handle
-	esDB             *jobsdb.Handle
-	arcDB            *jobsdb.Handle
-	clearDB          *bool
-	ReportingI       types.Reporting // need not initialize again
-	BackendConfig    backendconfig.BackendConfig
-	Transformer      transformer.Transformer
-	transientSources transientsource.Service
-	fileuploader     fileuploader.Provider
-	rsourcesService  rsources.JobService
-	destDebugger     destinationdebugger.DestinationDebugger
-	transDebugger    transformationdebugger.TransformationDebugger
-	enrichers        []enricher.PipelineEnricher
+	Handle                     *Handle
+	mainCtx                    context.Context
+	currentCancel              context.CancelFunc
+	waitGroup                  interface{ Wait() }
+	gatewayDB                  *jobsdb.Handle
+	routerDB                   *jobsdb.Handle
+	batchRouterDB              *jobsdb.Handle
+	readErrDB                  *jobsdb.Handle
+	writeErrDB                 *jobsdb.Handle
+	esDB                       *jobsdb.Handle
+	arcDB                      *jobsdb.Handle
+	clearDB                    *bool
+	ReportingI                 types.Reporting // need not initialize again
+	BackendConfig              backendconfig.BackendConfig
+	Transformer                transformer.Transformer
+	transientSources           transientsource.Service
+	fileuploader               fileuploader.Provider
+	rsourcesService            rsources.JobService
+	transformerFeaturesService transformerFeaturesService.FeaturesService
+	destDebugger               destinationdebugger.DestinationDebugger
+	transDebugger              transformationdebugger.TransformationDebugger
+	enrichers                  []enricher.PipelineEnricher
 }
 
 // Start starts a processor, this is not a blocking call.
@@ -65,6 +67,7 @@ func (proc *LifecycleManager) Start() error {
 		proc.transientSources,
 		proc.fileuploader,
 		proc.rsourcesService,
+		proc.transformerFeaturesService,
 		proc.destDebugger,
 		proc.transDebugger,
 		proc.enrichers,
@@ -96,12 +99,6 @@ func (proc *LifecycleManager) Stop() {
 	proc.Handle.Shutdown()
 }
 
-func WithFeaturesRetryMaxAttempts(maxAttempts int) func(l *LifecycleManager) {
-	return func(l *LifecycleManager) {
-		l.Handle.config.featuresRetryMaxAttempts = maxAttempts
-	}
-}
-
 // New creates a new Processor instance
 func New(
 	ctx context.Context,
@@ -111,6 +108,7 @@ func New(
 	transientSources transientsource.Service,
 	fileuploader fileuploader.Provider,
 	rsourcesService rsources.JobService,
+	transformerFeaturesService transformerFeaturesService.FeaturesService,
 	destDebugger destinationdebugger.DestinationDebugger,
 	transDebugger transformationdebugger.TransformationDebugger,
 	enrichers []enricher.PipelineEnricher,
@@ -125,23 +123,24 @@ func New(
 				stats.Default,
 			),
 		),
-		mainCtx:          ctx,
-		gatewayDB:        gwDb,
-		routerDB:         rtDb,
-		batchRouterDB:    brtDb,
-		readErrDB:        errDbForRead,
-		writeErrDB:       errDBForWrite,
-		esDB:             esDB,
-		arcDB:            arcDB,
-		clearDB:          clearDb,
-		BackendConfig:    backendconfig.DefaultBackendConfig,
-		ReportingI:       reporting,
-		transientSources: transientSources,
-		fileuploader:     fileuploader,
-		rsourcesService:  rsourcesService,
-		destDebugger:     destDebugger,
-		transDebugger:    transDebugger,
-		enrichers:        enrichers,
+		mainCtx:                    ctx,
+		gatewayDB:                  gwDb,
+		routerDB:                   rtDb,
+		batchRouterDB:              brtDb,
+		readErrDB:                  errDbForRead,
+		writeErrDB:                 errDBForWrite,
+		esDB:                       esDB,
+		arcDB:                      arcDB,
+		clearDB:                    clearDb,
+		BackendConfig:              backendconfig.DefaultBackendConfig,
+		ReportingI:                 reporting,
+		transientSources:           transientSources,
+		fileuploader:               fileuploader,
+		rsourcesService:            rsourcesService,
+		transformerFeaturesService: transformerFeaturesService,
+		destDebugger:               destDebugger,
+		transDebugger:              transDebugger,
+		enrichers:                  enrichers,
 	}
 	for _, opt := range opts {
 		opt(proc)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,13 +1,10 @@
 package processor
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"runtime/trace"
 	"slices"
 	"strconv"
@@ -45,8 +42,8 @@ import (
 	"github.com/rudderlabs/rudder-server/services/fileuploader"
 	"github.com/rudderlabs/rudder-server/services/rmetrics"
 	"github.com/rudderlabs/rudder-server/services/rsources"
+	transformerFeaturesService "github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
-	"github.com/rudderlabs/rudder-server/utils/httputil"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 	"github.com/rudderlabs/rudder-server/utils/types"
@@ -75,36 +72,35 @@ type Handle struct {
 	transformer   transformer.Transformer
 	lastJobID     int64
 
-	gatewayDB     jobsdb.JobsDB
-	routerDB      jobsdb.JobsDB
-	batchRouterDB jobsdb.JobsDB
-	readErrorDB   jobsdb.JobsDB
-	writeErrorDB  jobsdb.JobsDB
-	eventSchemaDB jobsdb.JobsDB
-	archivalDB    jobsdb.JobsDB
-
-	logger                    logger.Logger
-	eventSchemaHandler        types.EventSchemasI
-	enrichers                 []enricher.PipelineEnricher
-	dedup                     dedup.Dedup
-	reporting                 types.Reporting
-	reportingEnabled          bool
-	backgroundWait            func() error
-	backgroundCancel          context.CancelFunc
-	transformerFeatures       json.RawMessage
-	statsFactory              stats.Stats
-	stats                     processorStats
-	payloadLimit              misc.ValueLoader[int64]
-	jobsDBCommandTimeout      misc.ValueLoader[time.Duration]
-	jobdDBQueryRequestTimeout misc.ValueLoader[time.Duration]
-	jobdDBMaxRetries          misc.ValueLoader[int]
-	transientSources          transientsource.Service
-	fileuploader              fileuploader.Provider
-	rsourcesService           rsources.JobService
-	destDebugger              destinationdebugger.DestinationDebugger
-	transDebugger             transformationdebugger.TransformationDebugger
-	isolationStrategy         isolation.Strategy
-	limiter                   struct {
+	gatewayDB                  jobsdb.JobsDB
+	routerDB                   jobsdb.JobsDB
+	batchRouterDB              jobsdb.JobsDB
+	readErrorDB                jobsdb.JobsDB
+	writeErrorDB               jobsdb.JobsDB
+	eventSchemaDB              jobsdb.JobsDB
+	archivalDB                 jobsdb.JobsDB
+	logger                     logger.Logger
+	eventSchemaHandler         types.EventSchemasI
+	enrichers                  []enricher.PipelineEnricher
+	dedup                      dedup.Dedup
+	reporting                  types.Reporting
+	reportingEnabled           bool
+	backgroundWait             func() error
+	backgroundCancel           context.CancelFunc
+	statsFactory               stats.Stats
+	stats                      processorStats
+	payloadLimit               misc.ValueLoader[int64]
+	jobsDBCommandTimeout       misc.ValueLoader[time.Duration]
+	jobdDBQueryRequestTimeout  misc.ValueLoader[time.Duration]
+	jobdDBMaxRetries           misc.ValueLoader[int]
+	transientSources           transientsource.Service
+	fileuploader               fileuploader.Provider
+	rsourcesService            rsources.JobService
+	transformerFeaturesService transformerFeaturesService.FeaturesService
+	destDebugger               destinationdebugger.DestinationDebugger
+	transDebugger              transformationdebugger.TransformationDebugger
+	isolationStrategy          isolation.Strategy
+	limiter                    struct {
 		read       kitsync.Limiter
 		preprocess kitsync.Limiter
 		transform  kitsync.Limiter
@@ -113,7 +109,6 @@ type Handle struct {
 	config struct {
 		isolationMode                isolation.Mode
 		mainLoopTimeout              time.Duration
-		featuresRetryMaxAttempts     int
 		enablePipelining             bool
 		pipelineBufferedItems        int
 		subJobSize                   int
@@ -193,13 +188,6 @@ type processorStats struct {
 	transformationsThroughput     stats.Measurement
 	DBWriteThroughput             stats.Measurement
 }
-
-var defaultTransformerFeatures = `{
-	"routerTransform": {
-	  "MARKETO": true,
-	  "HS": true
-	}
-  }`
 
 type DestStatT struct {
 	numEvents               stats.Measurement
@@ -365,6 +353,7 @@ func (proc *Handle) Setup(
 	transientSources transientsource.Service,
 	fileuploader fileuploader.Provider,
 	rsourcesService rsources.JobService,
+	transformerFeaturesService transformerFeaturesService.FeaturesService,
 	destDebugger destinationdebugger.DestinationDebugger,
 	transDebugger transformationdebugger.TransformationDebugger,
 	enrichers []enricher.PipelineEnricher,
@@ -392,6 +381,8 @@ func (proc *Handle) Setup(
 	proc.fileuploader = fileuploader
 	proc.rsourcesService = rsourcesService
 	proc.enrichers = enrichers
+
+	proc.transformerFeaturesService = transformerFeaturesService
 
 	if proc.adaptiveLimit == nil {
 		proc.adaptiveLimit = func(limit int64) int64 { return limit }
@@ -467,14 +458,9 @@ func (proc *Handle) Setup(
 	proc.backgroundWait = g.Wait
 	proc.backgroundCancel = cancel
 
-	proc.config.asyncInit = misc.NewAsyncInit(2)
+	proc.config.asyncInit = misc.NewAsyncInit(1)
 	g.Go(misc.WithBugsnag(func() error {
 		proc.backendConfigSubscriber(ctx)
-		return nil
-	}))
-
-	g.Go(misc.WithBugsnag(func() error {
-		proc.syncTransformerFeatureJson(ctx)
 		return nil
 	}))
 
@@ -550,6 +536,16 @@ func (proc *Handle) Start(ctx context.Context) error {
 		}
 		proc.logger.Info("Async init group done")
 
+		// waiting for init group
+		proc.logger.Info("Waiting for transformer features")
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-proc.transformerFeaturesService.Wait():
+			// proceed
+		}
+		proc.logger.Info("Transformer features received")
+
 		h := &workerHandleAdapter{proc}
 		pool := workerpool.New(ctx, func(partition string) workerpool.Worker { return newProcessorWorker(partition, h) }, proc.logger)
 		defer pool.Shutdown()
@@ -603,7 +599,6 @@ func (proc *Handle) Shutdown() {
 
 func (proc *Handle) loadConfig() {
 	proc.config.mainLoopTimeout = 200 * time.Millisecond
-	proc.config.featuresRetryMaxAttempts = 10
 
 	defaultSubJobSize := 2000
 	defaultMaxEventsToProcess := 10000
@@ -653,79 +648,6 @@ func (proc *Handle) loadReloadableConfig(defaultPayloadLimit int64, defaultMaxEv
 	proc.config.archivalEnabled = config.GetReloadableBoolVar(true, "archival.Enabled")
 	// Capture event name as a tag in event level stats
 	proc.config.captureEventNameStats = config.GetReloadableBoolVar(false, "Processor.Stats.captureEventName")
-}
-
-// syncTransformerFeatureJson polls the transformer feature json endpoint,
-//
-//	updates the transformer feature map.
-//
-// It will set isUnLocked to true if it successfully fetches the transformer feature json at least once.
-func (proc *Handle) syncTransformerFeatureJson(ctx context.Context) {
-	var initDone bool
-	proc.logger.Infof("Fetching transformer features from %s", proc.config.transformerURL)
-	for {
-		for i := 0; i < proc.config.featuresRetryMaxAttempts; i++ {
-
-			if ctx.Err() != nil {
-				return
-			}
-
-			retry := proc.makeFeaturesFetchCall()
-			if retry {
-				proc.logger.Infof("Fetched transformer features from %s (retry: %v)", proc.config.transformerURL, retry)
-			}
-			if retry {
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(200 * time.Millisecond):
-					continue
-				}
-			}
-			break
-		}
-
-		if proc.transformerFeatures != nil && !initDone {
-			initDone = true
-			proc.config.asyncInit.Done()
-		}
-
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(proc.config.pollInterval):
-		}
-	}
-}
-
-func (proc *Handle) makeFeaturesFetchCall() bool {
-	url := proc.config.transformerURL + "/features"
-	req, err := http.NewRequest("GET", url, bytes.NewReader([]byte{}))
-	if err != nil {
-		proc.logger.Error("error creating request - %s", err)
-		return true
-	}
-	tr := &http.Transport{}
-	client := &http.Client{Transport: tr, Timeout: config.GetDuration("HttpClient.processor.timeout", 30, time.Second)}
-	res, err := client.Do(req)
-	if err != nil {
-		proc.logger.Error("error sending request - %s", err)
-		return true
-	}
-
-	defer func() { httputil.CloseResponse(res) }()
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return true
-	}
-
-	if res.StatusCode == 200 {
-		proc.transformerFeatures = body
-	} else if res.StatusCode == 404 {
-		proc.transformerFeatures = json.RawMessage(defaultTransformerFeatures)
-	}
-
-	return false
 }
 
 func (proc *Handle) backendConfigSubscriber(ctx context.Context) {
@@ -2309,7 +2231,7 @@ func (proc *Handle) transformSrcDest(
 	if transformAtOverrideFound {
 		transformAt = config.GetString("Processor."+destination.DestinationDefinition.Name+".transformAt", "processor")
 	}
-	transformAtFromFeaturesFile := gjson.Get(string(proc.transformerFeatures), fmt.Sprintf("routerTransform.%s", destination.DestinationDefinition.Name)).String()
+	transformAtFromFeaturesFile := proc.transformerFeaturesService.RouterTransform(destination.DestinationDefinition.Name)
 
 	// Filtering events based on the supported message types - START
 	s := time.Now()
@@ -2383,7 +2305,7 @@ func (proc *Handle) transformSrcDest(
 	// a. transformAt is processor
 	// OR
 	// b. transformAt is router and transformer doesn't support router transform
-	if transformAt == "processor" || (transformAt == "router" && transformAtFromFeaturesFile == "") {
+	if transformAt == "processor" || (transformAt == "router" && !transformAtFromFeaturesFile) {
 		trace.WithRegion(ctx, "Dest Transform", func() {
 			trace.Logf(ctx, "Dest Transform", "input size %d", len(eventsToTransform))
 			proc.logger.Debug("Dest Transform input size", len(eventsToTransform))

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -39,6 +39,7 @@ import (
 	transformationdebugger "github.com/rudderlabs/rudder-server/services/debugger/transformation"
 	"github.com/rudderlabs/rudder-server/services/fileuploader"
 	"github.com/rudderlabs/rudder-server/services/rsources"
+	transformerFeaturesService "github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
@@ -1160,6 +1161,7 @@ var _ = Describe("Processor", Ordered, func() {
 				transientsource.NewEmptyService(),
 				fileuploader.NewDefaultProvider(),
 				c.MockRsourcesService,
+				transformerFeaturesService.NewNoOpService(),
 				destinationdebugger.NewNoOpService(),
 				transformationdebugger.NewNoOpService(),
 				[]enricher.PipelineEnricher{},
@@ -1189,6 +1191,7 @@ var _ = Describe("Processor", Ordered, func() {
 				transientsource.NewEmptyService(),
 				fileuploader.NewDefaultProvider(),
 				c.MockRsourcesService,
+				transformerFeaturesService.NewNoOpService(),
 				destinationdebugger.NewNoOpService(),
 				transformationdebugger.NewNoOpService(),
 				[]enricher.PipelineEnricher{},
@@ -1223,6 +1226,7 @@ var _ = Describe("Processor", Ordered, func() {
 				transientsource.NewEmptyService(),
 				fileuploader.NewDefaultProvider(),
 				c.MockRsourcesService,
+				transformerFeaturesService.NewNoOpService(),
 				destinationdebugger.NewNoOpService(),
 				transformationdebugger.NewNoOpService(),
 				[]enricher.PipelineEnricher{},
@@ -2272,7 +2276,6 @@ var _ = Describe("Processor", Ordered, func() {
 
 			// crash recover returns empty list
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
-			processor.config.featuresRetryMaxAttempts = 0
 			processor.Setup(
 				c.mockBackendConfig,
 				c.mockGatewayJobsDB,
@@ -2286,6 +2289,7 @@ var _ = Describe("Processor", Ordered, func() {
 				transientsource.NewEmptyService(),
 				fileuploader.NewDefaultProvider(),
 				c.MockRsourcesService,
+				getMockTransformerService(),
 				destinationdebugger.NewNoOpService(),
 				transformationdebugger.NewNoOpService(),
 				[]enricher.PipelineEnricher{},
@@ -2312,7 +2316,7 @@ var _ = Describe("Processor", Ordered, func() {
 
 			Consistently(func() bool {
 				select {
-				case <-processor.config.asyncInit.Wait():
+				case <-processor.transformerFeaturesService.Wait():
 					return true
 				default:
 					return false
@@ -2330,7 +2334,6 @@ var _ = Describe("Processor", Ordered, func() {
 
 			// crash recover returns empty list
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
-			processor.config.featuresRetryMaxAttempts = 0
 			processor.Setup(
 				c.mockBackendConfig,
 				c.mockGatewayJobsDB,
@@ -2344,6 +2347,7 @@ var _ = Describe("Processor", Ordered, func() {
 				transientsource.NewEmptyService(),
 				fileuploader.NewDefaultProvider(),
 				c.MockRsourcesService,
+				transformerFeaturesService.NewNoOpService(),
 				destinationdebugger.NewNoOpService(),
 				transformationdebugger.NewNoOpService(),
 				[]enricher.PipelineEnricher{},
@@ -4010,6 +4014,7 @@ func Setup(processor *Handle, c *testContext, enableDedup, enableReporting bool)
 		transientsource.NewStaticService([]string{SourceIDTransient}),
 		fileuploader.NewDefaultProvider(),
 		c.MockRsourcesService,
+		transformerFeaturesService.NewNoOpService(),
 		destinationdebugger.NewNoOpService(),
 		transformationdebugger.NewNoOpService(),
 		[]enricher.PipelineEnricher{},
@@ -4365,4 +4370,22 @@ func TestStoreMessageMerge(t *testing.T) {
 	require.EqualValues(t, merged.sourceDupStats[dupStatKey{sourceID: "1"}], 3)
 	require.Len(t, merged.dedupKeys, 2, "dedup keys should have 2 elements")
 	require.Equal(t, merged.totalEvents, 2, "total events should be 2")
+}
+
+func getMockTransformerService() transformerFeaturesService.FeaturesService {
+	return &mockTransformerService{}
+}
+
+type mockTransformerService struct{}
+
+func (*mockTransformerService) SourceTransformerVersion() string {
+	return "random-version"
+}
+
+func (*mockTransformerService) Wait() chan struct{} {
+	return make(chan struct{})
+}
+
+func (*mockTransformerService) RouterTransform(destType string) bool {
+	return false
 }

--- a/services/transformer/features.go
+++ b/services/transformer/features.go
@@ -1,0 +1,67 @@
+package transformer
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-server/rruntime"
+)
+
+const (
+	V0 = "v0"
+	V1 = "v1"
+)
+
+type FeaturesServiceConfig struct {
+	PollInterval             time.Duration
+	TransformerURL           string
+	FeaturesRetryMaxAttempts int
+}
+
+type FeaturesService interface {
+	SourceTransformerVersion() string
+	RouterTransform(destType string) bool
+	Wait() chan struct{}
+}
+
+var defaultTransformerFeatures = `{
+	"routerTransform": {
+	  "MARKETO": true,
+	  "HS": true
+	}
+  }`
+
+func NewFeaturesService(ctx context.Context, config FeaturesServiceConfig) FeaturesService {
+	handler := &featuresService{
+		features: json.RawMessage(defaultTransformerFeatures),
+		logger:   logger.NewLogger().Child("transformer-features"),
+		waitChan: make(chan struct{}),
+		config:   config,
+	}
+
+	rruntime.Go(func() { handler.syncTransformerFeatureJson(ctx) })
+
+	return handler
+}
+
+func NewNoOpService() FeaturesService {
+	return &noopService{}
+}
+
+type noopService struct{}
+
+func (*noopService) SourceTransformerVersion() string {
+	return V0
+}
+
+func (*noopService) Wait() chan struct{} {
+	dummyChan := make(chan struct{})
+	close(dummyChan)
+	return dummyChan
+}
+
+func (*noopService) RouterTransform(_ string) bool {
+	return false
+}

--- a/services/transformer/features_impl.go
+++ b/services/transformer/features_impl.go
@@ -1,0 +1,107 @@
+package transformer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-server/utils/httputil"
+)
+
+type featuresService struct {
+	logger   logger.Logger
+	waitChan chan struct{}
+	config   FeaturesServiceConfig
+	features json.RawMessage
+}
+
+func (t *featuresService) SourceTransformerVersion() string {
+	if gjson.GetBytes(t.features, "supportSourceTransformV1").Bool() {
+		return V1
+	}
+
+	return V0
+}
+
+func (t *featuresService) RouterTransform(destType string) bool {
+	return gjson.GetBytes(t.features, "routerTransform."+destType).Bool()
+}
+
+func (t *featuresService) Wait() chan struct{} {
+	return t.waitChan
+}
+
+func (t *featuresService) syncTransformerFeatureJson(ctx context.Context) {
+	var initDone bool
+	t.logger.Infof("Fetching transformer features from %s", t.config.TransformerURL)
+	for {
+		var downloaded bool
+		for i := 0; i < t.config.FeaturesRetryMaxAttempts; i++ {
+
+			if ctx.Err() != nil {
+				return
+			}
+
+			retry := t.makeFeaturesFetchCall()
+			if retry {
+				t.logger.Infof("Fetched transformer features from %s (retry: %v)", t.config.TransformerURL, retry)
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(200 * time.Millisecond):
+					continue
+				}
+			}
+			downloaded = true
+			break
+		}
+
+		if downloaded && !initDone {
+			initDone = true
+			close(t.waitChan)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(t.config.PollInterval):
+		}
+	}
+}
+
+func (t *featuresService) makeFeaturesFetchCall() bool {
+	url := t.config.TransformerURL + "/features"
+	req, err := http.NewRequest("GET", url, bytes.NewReader([]byte{}))
+	if err != nil {
+		t.logger.Error("error creating request - ", err)
+		return true
+	}
+	tr := &http.Transport{}
+	client := &http.Client{Transport: tr, Timeout: config.GetDuration("HttpClient.processor.timeout", 30, time.Second)}
+	res, err := client.Do(req)
+	if err != nil {
+		t.logger.Error("error sending request - ", err)
+		return true
+	}
+
+	defer func() { httputil.CloseResponse(res) }()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return true
+	}
+
+	if res.StatusCode == 200 {
+		t.features = body
+	} else if res.StatusCode == 404 {
+		t.features = json.RawMessage(defaultTransformerFeatures)
+	}
+
+	return false
+}

--- a/services/transformer/features_impl_test.go
+++ b/services/transformer/features_impl_test.go
@@ -1,0 +1,117 @@
+package transformer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+)
+
+var _ = Describe("Transformer features", func() {
+	Context("Transformer features service", func() {
+		It("handler should wait till features are not fetched", func() {
+			handler := &featuresService{
+				logger:   logger.NewLogger(),
+				waitChan: make(chan struct{}),
+				config: FeaturesServiceConfig{
+					PollInterval:             time.Duration(1),
+					FeaturesRetryMaxAttempts: 1,
+				},
+			}
+
+			Consistently(func() bool {
+				select {
+				case <-handler.Wait():
+					return true
+				default:
+					return false
+				}
+			}, 2*time.Second, 10*time.Millisecond).Should(BeFalse())
+		})
+
+		It("before features are fetched, SourceTransformerVersion should return v0", func() {
+			handler := &featuresService{
+				features: json.RawMessage(defaultTransformerFeatures),
+				logger:   logger.NewLogger(),
+				waitChan: make(chan struct{}),
+				config: FeaturesServiceConfig{
+					PollInterval:             time.Duration(1),
+					FeaturesRetryMaxAttempts: 1,
+				},
+			}
+
+			Expect(handler.SourceTransformerVersion()).To(Equal(V0))
+		})
+
+		It("before features are fetched, defaultTransformerFeatures must be served", func() {
+			handler := &featuresService{
+				features: json.RawMessage(defaultTransformerFeatures),
+				logger:   logger.NewLogger(),
+				waitChan: make(chan struct{}),
+				config: FeaturesServiceConfig{
+					PollInterval:             time.Duration(1),
+					FeaturesRetryMaxAttempts: 1,
+				},
+			}
+
+			Expect(handler.RouterTransform("MARKETO")).To(BeTrue())
+			Expect(handler.RouterTransform("HS")).To(BeTrue())
+			Expect(handler.RouterTransform("ACTIVE_CAMPAIGN")).To(BeFalse())
+			Expect(handler.RouterTransform("ALGOLIA")).To(BeFalse())
+		})
+
+		It("if transformer returns 404, features should be same as defaultTransformerFeatures", func() {
+			transformerServer := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.Error(w, "not found error", http.StatusNotFound)
+				}))
+
+			handler := NewFeaturesService(context.TODO(), FeaturesServiceConfig{
+				PollInterval:             time.Duration(1),
+				TransformerURL:           transformerServer.URL,
+				FeaturesRetryMaxAttempts: 1,
+			})
+
+			<-handler.Wait()
+
+			Expect(handler.RouterTransform("MARKETO")).To(BeTrue())
+			Expect(handler.RouterTransform("HS")).To(BeTrue())
+			Expect(handler.RouterTransform("ACTIVE_CAMPAIGN")).To(BeFalse())
+			Expect(handler.RouterTransform("ALGOLIA")).To(BeFalse())
+		})
+
+		It("Get should return features fetched from transformer", func() {
+			mockTransformerResp := `{
+				"routerTransform": {
+				  "a": true,
+				  "b": true
+				},
+				"supportSourceTransformV1": true
+			  }`
+			transformerServer := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					_, _ = w.Write([]byte(mockTransformerResp))
+				}))
+
+			handler := NewFeaturesService(context.TODO(), FeaturesServiceConfig{
+				PollInterval:             time.Duration(1),
+				TransformerURL:           transformerServer.URL,
+				FeaturesRetryMaxAttempts: 1,
+			})
+
+			<-handler.Wait()
+
+			Expect(handler.RouterTransform("MARKETO")).To(BeFalse())
+			Expect(handler.RouterTransform("HS")).To(BeFalse())
+			Expect(handler.RouterTransform("a")).To(BeTrue())
+			Expect(handler.RouterTransform("b")).To(BeTrue())
+			Expect(handler.SourceTransformerVersion()).To(Equal(V1))
+		})
+	})
+})

--- a/services/transformer/features_suite_test.go
+++ b/services/transformer/features_suite_test.go
@@ -1,0 +1,13 @@
+package transformer
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTransformerFeatures(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Transformer features Suite")
+}


### PR DESCRIPTION
# Description
Resolves INT-543 and INT-768
**What do we want to achieve?**
      We want to send fetch the `sourceConfig` and send it to transformer for sources as well as we do for destinations.

**How we are planning to do that ?**
      We are introducing new endpoint `{transformUrl}/v1/sourceType` which would accept the data in the format 
       `{event: ingested event, source: sourceObject}`.
       
**How We are Maintaining Backward Compatibility ?**
      If some how transformer is old and **does not** support v1 endpoint then it could break. To control this we are 
       globalising the `/feature` endpoint from we already use in `processor.go` to check for router destinations.
       In feature json response we are checking for a boolean value to check if transformer support `v1` endpoint.
       Also for this `/feature` endpoint we made a new transformer service which is fetching the /feature frequently to be updated about is transformer supports source-V1-Endpoint or not.
       
Notion Research : https://www.notion.so/rudderstacks/Add-new-support-features-json-from-transformer-11deb41d5fe44470822e4b3a9873cd32?pvs=4

## Linear Ticket

https://linear.app/rudderstack/issue/INT-768/servertransformer-features-endpoint-extended-support
https://linear.app/rudderstack/issue/INT-543/send-sourceconfig-from-server-to-transformer

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
