### PR TITLE
feat: introducing chi middleware for warehouse

### DIFF
--- a/warehouse/api/http.go
+++ b/warehouse/api/http.go
@@ -25,6 +25,7 @@ import (
 	ierrors "github.com/rudderlabs/rudder-server/warehouse/internal/errors"
 	lf "github.com/rudderlabs/rudder-server/warehouse/logfield"
 
+	"github.com/rudderlabs/rudder-go-kit/chiware"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -127,6 +128,9 @@ func NewApi(
 
 func (a *Api) Start(ctx context.Context) error {
 	srvMux := chi.NewRouter()
+	srvMux.Use(
+		chiware.StatMiddleware(ctx, srvMux, a.statsFactory, "warehouse"),
+	)
 
 	if mode.IsStandAlone(a.mode) {
 		srvMux.Get("/health", a.healthHandler)


### PR DESCRIPTION
# Description

- Using chi.middleWare to introduce HTTP API response times for the warehouse. This will help us provide better observability around the HTTP requests.

## Linear Ticket

- https://linear.app/rudderstack/issue/PIPE-444/chi-middleware-for-warehouse

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
