### PR TITLE
chore: flaky validations test

### DIFF
--- a/warehouse/validations/validate_test.go
+++ b/warehouse/validations/validate_test.go
@@ -46,8 +46,6 @@ func TestValidator(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Object Storage", func(t *testing.T) {
-		t.Parallel()
-
 		t.Run("Non Datalakes", func(t *testing.T) {
 			v, err := validations.NewValidator(ctx, model.VerifyingObjectStorage, &backendconfig.DestinationT{
 				DestinationDefinition: backendconfig.DestinationDefinitionT{
@@ -94,8 +92,6 @@ func TestValidator(t *testing.T) {
 	})
 
 	t.Run("Connections", func(t *testing.T) {
-		t.Parallel()
-
 		testCases := []struct {
 			name      string
 			config    map[string]interface{}
@@ -153,8 +149,6 @@ func TestValidator(t *testing.T) {
 	})
 
 	t.Run("Create Schema", func(t *testing.T) {
-		t.Parallel()
-
 		var (
 			namespace           = "cs_test_namespace"
 			password            = "cs_test_password"
@@ -227,8 +221,6 @@ func TestValidator(t *testing.T) {
 	})
 
 	t.Run("Create And Alter Table", func(t *testing.T) {
-		t.Parallel()
-
 		var (
 			namespace                    = "cat_test_namespace"
 			password                     = "cat_test_password"
@@ -335,8 +327,6 @@ func TestValidator(t *testing.T) {
 	})
 
 	t.Run("Fetch schema", func(t *testing.T) {
-		t.Parallel()
-
 		namespace := "fs_test_namespace"
 
 		_, err = pgResource.DB.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", namespace))
@@ -369,8 +359,6 @@ func TestValidator(t *testing.T) {
 	})
 
 	t.Run("Load table", func(t *testing.T) {
-		t.Parallel()
-
 		var (
 			namespace                    = "lt_test_namespace"
 			password                     = "lt_test_password"

--- a/warehouse/validations/validations_test.go
+++ b/warehouse/validations/validations_test.go
@@ -39,8 +39,6 @@ func TestValidate(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("invalid path", func(t *testing.T) {
-		t.Parallel()
-
 		_, err := validations.Validate(ctx, &model.ValidationRequest{
 			Path: "invalid",
 		})
@@ -48,8 +46,6 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("steps", func(t *testing.T) {
-		t.Parallel()
-
 		res, err := validations.Validate(ctx, &model.ValidationRequest{
 			Path: "steps",
 			Destination: &backendconfig.DestinationT{
@@ -64,11 +60,7 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("validate", func(t *testing.T) {
-		t.Parallel()
-
 		t.Run("invalid step", func(t *testing.T) {
-			t.Parallel()
-
 			res, err := validations.Validate(ctx, &model.ValidationRequest{
 				Path: "validate",
 				Step: "invalid",
@@ -84,8 +76,6 @@ func TestValidate(t *testing.T) {
 		})
 
 		t.Run("step not found", func(t *testing.T) {
-			t.Parallel()
-
 			res, err := validations.Validate(ctx, &model.ValidationRequest{
 				Path: "validate",
 				Step: "1000",
@@ -101,8 +91,6 @@ func TestValidate(t *testing.T) {
 		})
 
 		t.Run("invalid destination", func(t *testing.T) {
-			t.Parallel()
-
 			res, err := validations.Validate(ctx, &model.ValidationRequest{
 				Path: "validate",
 				Step: "2",
@@ -118,8 +106,6 @@ func TestValidate(t *testing.T) {
 		})
 
 		t.Run("step error", func(t *testing.T) {
-			t.Parallel()
-
 			res, err := validations.Validate(ctx, &model.ValidationRequest{
 				Path: "validate",
 				Destination: &backendconfig.DestinationT{
@@ -134,8 +120,6 @@ func TestValidate(t *testing.T) {
 		})
 
 		t.Run("invalid destination", func(t *testing.T) {
-			t.Parallel()
-
 			res, err := validations.Validate(ctx, &model.ValidationRequest{
 				Path: "validate",
 				Step: "2",
@@ -151,8 +135,6 @@ func TestValidate(t *testing.T) {
 		})
 
 		t.Run("empty step", func(t *testing.T) {
-			t.Parallel()
-
 			namespace := "es_test_namespace"
 
 			res, err := validations.Validate(ctx, &model.ValidationRequest{
@@ -184,8 +166,6 @@ func TestValidate(t *testing.T) {
 		})
 
 		t.Run("steps in order", func(t *testing.T) {
-			t.Parallel()
-
 			namespace := "sio_test_namespace"
 
 			testCases := []struct {


### PR DESCRIPTION
# Description

- Even now, a few times tests are failing with i/o timeout, since we are running all of the tests in parallel. Removing parallel for now so that it can be more stable.
```
https://github.com/rudderlabs/rudder-server/actions/runs/6666283593/job/18117517599?pr=4026
=== FAIL: warehouse/validations TestValidator/Fetch_schema (25.01s)
    validate_test.go:368: 
        	Error Trace:	/home/runner/work/rudder-server/rudder-server/warehouse/validations/validate_test.go:368
        	Error:      	Received unexpected error:
        	            	fetch schema: fetching schema: read tcp [::1]:33190->[::1]:32872: i/o timeout
        	Test:       	TestValidator/Fetch_schema
    --- FAIL: TestValidator/Fetch_schema (25.01s)
```
- Although, if we feel that test times become a burden, we can explore other options in the future. Alteast we will stable tetsts.
```
package=./warehouse/validations/... make test
go install github.com/golang/mock/mockgen@v1.6.0
go install mvdan.cc/gofumpt@latest
go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1
go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
go install gotest.tools/gotestsum@v1.10.0
go install golang.org/x/tools/cmd/goimports@latest
SLOW=0 gotestsum --format pkgname-and-test-fails -- -p=1 -v -failfast -shuffle=on -coverprofile=profile.out -covermode=atomic -coverpkg=./... -vet=all --timeout=15m ./warehouse/validations/... && touch _testok || true
✓  warehouse/validations (11.453s) (coverage: 9.7% of statements in ./...)
```

## Linear Ticket

- Resolves PIPE-453

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
