### PR TITLE
chore: upgrade golangci-lint

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,5 +60,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54.2
+          version: v1.55.0
           args: -v

--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,11 @@ install-tools:
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
 	go install gotest.tools/gotestsum@v1.10.0
 	go install golang.org/x/tools/cmd/goimports@latest
+	bash ./scripts/install-golangci-lint.sh v1.55.0
 
 .PHONY: lint
 lint: fmt ## Run linters on all go files
-	docker run --rm -v $(shell pwd):/app:ro -w /app golangci/golangci-lint:v1.54.2 bash -e -c \
-		'golangci-lint run -v --timeout 5m'
+	golangci-lint run -v --timeout 5m
 
 .PHONY: fmt
 fmt: install-tools ## Formats all go files

--- a/scripts/install-golangci-lint.sh
+++ b/scripts/install-golangci-lint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+VERSION=$1
+[ -z "${VERSION}" ] && VERSION="v1.55.0"
+GOPATH=$(go env GOPATH)
+[ -f "${GOPATH}/bin/golangci-lint-${VERSION}" ] && echo "golangci-lint ${VERSION} is already installed" || \
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/${VERSION}/install.sh | sh -s -- -b ${GOPATH}/bin ${VERSION} && \
+cp ${GOPATH}/bin/golangci-lint ${GOPATH}/bin/golangci-lint-${VERSION}


### PR DESCRIPTION
# Description

Upgrading golangci lint to the latest version and using a local golangci-lint binary instead of the docker image for lightning-fast lints!

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
