### PR TITLE
chore: replace golang.org/x/exp/slices to slices

### DIFF
--- a/.github/tools/matrixchecker/main.go
+++ b/.github/tools/matrixchecker/main.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 
-	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v2"
 )
 

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -8,17 +8,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/lib/pq"
 	"github.com/samber/lo"
-	"go.uber.org/atomic"
-	"golang.org/x/exp/slices"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -17,7 +18,6 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"

--- a/jobsdb/internal/cache/cache.go
+++ b/jobsdb/internal/cache/cache.go
@@ -2,12 +2,12 @@ package cache
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -28,6 +28,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -35,7 +36,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/samber/lo"

--- a/processor/eventfilter/eventfilter.go
+++ b/processor/eventfilter/eventfilter.go
@@ -1,9 +1,8 @@
 package eventfilter
 
 import (
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -9,12 +9,12 @@ import (
 	"io"
 	"net/http"
 	"runtime/trace"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	jsoniter "github.com/json-iterator/go"

--- a/processor/transformer/transformer_test.go
+++ b/processor/transformer/transformer_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -16,8 +17,6 @@ import (
 	"github.com/golang/mock/gomock"
 
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/types"

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -20,7 +21,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"

--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -8,12 +8,12 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager"

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -8,14 +8,15 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
-	"golang.org/x/exp/slices"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"

--- a/router/batchrouter/util.go
+++ b/router/batchrouter/util.go
@@ -3,11 +3,10 @@ package batchrouter
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"

--- a/router/batchrouter/worker.go
+++ b/router/batchrouter/worker.go
@@ -3,13 +3,13 @@ package batchrouter
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"

--- a/router/customdestinationmanager/customdestinationmanager.go
+++ b/router/customdestinationmanager/customdestinationmanager.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/sony/gobreaker"
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"

--- a/router/internal/partition/stats.go
+++ b/router/internal/partition/stats.go
@@ -2,11 +2,11 @@ package partition
 
 import (
 	"math"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/stats/metric"
 )

--- a/router/manager/manager.go
+++ b/router/manager/manager.go
@@ -3,8 +3,8 @@ package manager
 import (
 	"context"
 	"fmt"
+	"slices"
 
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"

--- a/router/utils/utils.go
+++ b/router/utils/utils.go
@@ -1,10 +1,9 @@
 package utils
 
 import (
+	"slices"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/tidwall/sjson"
 

--- a/router/worker.go
+++ b/router/worker.go
@@ -5,12 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"

--- a/schema-forwarder/internal/forwarder/jobsforwarder.go
+++ b/schema-forwarder/internal/forwarder/jobsforwarder.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	pulsarType "github.com/apache/pulsar-client-go/pulsar"

--- a/services/debugger/source/eventUploader.go
+++ b/services/debugger/source/eventUploader.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"

--- a/warehouse/api/grpc.go
+++ b/warehouse/api/grpc.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"slices"
 	"sync"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 
 	"github.com/samber/lo"
 
-	"golang.org/x/exp/slices"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/warehouse/app.go
+++ b/warehouse/app.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 	"time"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
 
 	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/config"

--- a/warehouse/integrations/azure-synapse/azure-synapse.go
+++ b/warehouse/integrations/azure-synapse/azure-synapse.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -24,8 +25,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	sqlmw "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
 	"github.com/rudderlabs/rudder-server/warehouse/logfield"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-server/warehouse/internal/service/loadfiles/downloader"
 

--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/samber/lo"
 
 	"cloud.google.com/go/bigquery"
-	"golang.org/x/exp/slices"
 	bqService "google.golang.org/api/bigquery/v2"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"

--- a/warehouse/integrations/bigquery/bigquery_test.go
+++ b/warehouse/integrations/bigquery/bigquery_test.go
@@ -5,12 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/golang/mock/gomock"
 

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -28,8 +29,6 @@ import (
 	"github.com/rudderlabs/rudder-server/warehouse/internal/service/loadfiles/downloader"
 
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/cenkalti/backoff/v4"
 

--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -14,7 +15,6 @@ import (
 
 	dbsql "github.com/databricks/databricks-sql-go"
 	dbsqllog "github.com/databricks/databricks-sql-go/logger"
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -7,12 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"

--- a/warehouse/integrations/postgres/load.go
+++ b/warehouse/integrations/postgres/load.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/types"
@@ -19,7 +20,6 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/misc"
 
 	"github.com/lib/pq"
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"

--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -17,8 +18,6 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/types"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/lib/pq"
 	"github.com/tidwall/gjson"

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -7,12 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/golang/mock/gomock"
 

--- a/warehouse/integrations/snowflake/snowflake_test.go
+++ b/warehouse/integrations/snowflake/snowflake_test.go
@@ -7,12 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/samber/lo"
 

--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -3,6 +3,7 @@ package loadfiles
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 
 	"github.com/samber/lo"
 
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	jsoniter "github.com/json-iterator/go"

--- a/warehouse/internal/loadfiles/mock_loadfile_repo_test.go
+++ b/warehouse/internal/loadfiles/mock_loadfile_repo_test.go
@@ -2,8 +2,7 @@ package loadfiles_test
 
 import (
 	"context"
-
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 )

--- a/warehouse/internal/repo/schema_test.go
+++ b/warehouse/internal/repo/schema_test.go
@@ -3,10 +3,9 @@ package repo_test
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 

--- a/warehouse/internal/service/recovery.go
+++ b/warehouse/internal/service/recovery.go
@@ -3,11 +3,10 @@ package service
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
-
-	"golang.org/x/exp/slices"
 
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )

--- a/warehouse/router/router.go
+++ b/warehouse/router/router.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"slices"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -19,8 +20,6 @@ import (
 	"github.com/rudderlabs/rudder-server/warehouse/encoding"
 
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-server/services/controlplane"
 	"github.com/rudderlabs/rudder-server/warehouse/multitenant"

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -6,13 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/samber/lo"

--- a/warehouse/router/upload_stats.go
+++ b/warehouse/router/upload_stats.go
@@ -2,10 +2,9 @@ package router
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/stats"

--- a/warehouse/schema/schema.go
+++ b/warehouse/schema/schema.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"slices"
 	"sync"
 
 	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"

--- a/warehouse/slave/worker_job.go
+++ b/warehouse/slave/worker_job.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -19,7 +20,6 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 
 	"go.uber.org/atomic"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/config"

--- a/warehouse/slave/worker_job_test.go
+++ b/warehouse/slave/worker_job_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -19,7 +20,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"


### PR DESCRIPTION
# Description
clean up golang.org/x/exp/slices to slices
Fixes PIPE-457

## Linear Ticket

[ Linear Link ](https://linear.app/rudderstack/issue/PIPE-457/replace-golangorgxexpslices-to-slices)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
