### PR TITLE
refactor: minor scheduler cleanup

### DIFF
--- a/warehouse/admin/admin.go
+++ b/warehouse/admin/admin.go
@@ -32,7 +32,7 @@ type ConfigurationTestOutput struct {
 
 type Admin struct {
 	csf    connectionSourcesFetcher
-	suas   startUploadAlwaysSetter
+	cuas   createUploadAlwaysSetter
 	logger logger.Logger
 }
 
@@ -40,25 +40,25 @@ type connectionSourcesFetcher interface {
 	ConnectionSourcesMap(destID string) (map[string]model.Warehouse, bool)
 }
 
-type startUploadAlwaysSetter interface {
+type createUploadAlwaysSetter interface {
 	Store(bool)
 }
 
 func New(
 	csf connectionSourcesFetcher,
-	suas startUploadAlwaysSetter,
+	cuas createUploadAlwaysSetter,
 	logger logger.Logger,
 ) *Admin {
 	return &Admin{
 		csf:    csf,
-		suas:   suas,
+		cuas:   cuas,
 		logger: logger.Child("admin"),
 	}
 }
 
 // TriggerUpload sets uploads to start without delay
 func (a *Admin) TriggerUpload(off bool, reply *string) error {
-	a.suas.Store(!off)
+	a.cuas.Store(!off)
 	if off {
 		*reply = "Turned off explicit warehouse upload triggers.\nWarehouse uploads will continue to be done as per schedule in control plane."
 	} else {

--- a/warehouse/router/router_test.go
+++ b/warehouse/router/router_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -97,6 +98,7 @@ func TestRouter(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 
+		startUploadAlwaysLoader := &atomic.Bool{}
 		triggerStore := &sync.Map{}
 		tenantManager := multitenant.New(config.Default, mocksBackendConfig.NewMockBackendConfig(ctrl))
 
@@ -129,6 +131,7 @@ func TestRouter(t *testing.T) {
 			backendConfigManager,
 			ef,
 			triggerStore,
+			startUploadAlwaysLoader,
 		)
 		require.NoError(t, err)
 

--- a/warehouse/router/scheduling.go
+++ b/warehouse/router/scheduling.go
@@ -4,33 +4,23 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
-	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
-// TODO: Move this to router struct instead of exposing it as globals.
-var (
-	scheduledTimesCache     map[string][]int
-	scheduledTimesCacheLock sync.RWMutex
-
-	StartUploadAlways atomic.Bool
-)
-
-func init() {
-	scheduledTimesCache = map[string][]int{}
+type createUploadAlwaysLoader interface {
+	Load() bool
 }
 
 // canCreateUpload indicates if an upload can be started now for the warehouse based on its configured schedule
 func (r *Router) canCreateUpload(ctx context.Context, warehouse model.Warehouse) (bool, error) {
 	// can be set from rudder-cli to force uploads always
-	if StartUploadAlways.Load() {
+	if r.createUploadAlwaysLoader.Load() {
 		return true, nil
 	}
 
@@ -47,15 +37,15 @@ func (r *Router) canCreateUpload(ctx context.Context, warehouse model.Warehouse)
 	}
 
 	// gets exclude window start time and end time
-	excludeWindow := warehouseutils.GetConfigValueAsMap(warehouseutils.ExcludeWindow, warehouse.Destination.Config)
-	excludeWindowStartTime, excludeWindowEndTime := excludeWindowStartEndTimes(excludeWindow)
+	excludeWindow := whutils.GetConfigValueAsMap(whutils.ExcludeWindow, warehouse.Destination.Config)
+	excludeWindowStartTime, excludeWindowEndTime := r.excludeWindowStartEndTimes(excludeWindow)
 
 	if checkCurrentTimeExistsInExcludeWindow(r.now().UTC(), excludeWindowStartTime, excludeWindowEndTime) {
 		return false, fmt.Errorf("exclude window: current time exists in exclude window")
 	}
 
-	syncFrequency := warehouseutils.GetConfigValue(warehouseutils.SyncFrequency, warehouse)
-	syncStartAt := warehouseutils.GetConfigValue(warehouseutils.SyncStartAt, warehouse)
+	syncFrequency := whutils.GetConfigValue(whutils.SyncFrequency, warehouse)
+	syncStartAt := whutils.GetConfigValue(whutils.SyncStartAt, warehouse)
 	if syncFrequency == "" || syncStartAt == "" {
 		if r.uploadFrequencyExceeded(warehouse, syncFrequency) {
 			return true, nil
@@ -63,7 +53,7 @@ func (r *Router) canCreateUpload(ctx context.Context, warehouse model.Warehouse)
 		return false, fmt.Errorf("upload frequency exceeded")
 	}
 
-	prevScheduledTime := prevScheduledTime(syncFrequency, syncStartAt, r.now())
+	prevScheduledTime := r.prevScheduledTime(syncFrequency, syncStartAt, r.now())
 	lastUploadCreatedAt, err := r.uploadRepo.LastCreatedAt(ctx, warehouse.Source.ID, warehouse.Destination.ID)
 	if err != nil {
 		return false, err
@@ -77,17 +67,15 @@ func (r *Router) canCreateUpload(ctx context.Context, warehouse model.Warehouse)
 	return false, fmt.Errorf("before scheduled time")
 }
 
-func excludeWindowStartEndTimes(excludeWindow map[string]interface{}) (string, string) {
+func (r *Router) excludeWindowStartEndTimes(excludeWindow map[string]interface{}) (string, string) {
 	var startTime, endTime string
 
-	if st, ok := excludeWindow[warehouseutils.ExcludeWindowStartTime].(string); ok {
+	if st, ok := excludeWindow[whutils.ExcludeWindowStartTime].(string); ok {
 		startTime = st
 	}
-
-	if et, ok := excludeWindow[warehouseutils.ExcludeWindowEndTime].(string); ok {
+	if et, ok := excludeWindow[whutils.ExcludeWindowEndTime].(string); ok {
 		endTime = et
 	}
-
 	return startTime, endTime
 }
 
@@ -96,34 +84,31 @@ func checkCurrentTimeExistsInExcludeWindow(currentTime time.Time, windowStartTim
 		return false
 	}
 
-	startTimeMins := timeutil.MinsOfDay(windowStartTime)
-	endTimeMins := timeutil.MinsOfDay(windowEndTime)
+	startTimeInMin := timeutil.MinsOfDay(windowStartTime)
+	endTimeInMin := timeutil.MinsOfDay(windowEndTime)
 
 	currentTimeMins := timeutil.GetElapsedMinsInThisDay(currentTime)
 
 	// startTime, currentTime, endTime: 05:09, 06:19, 09:07 - > window between this day 05:09 and 09:07
-	if startTimeMins < currentTimeMins && currentTimeMins < endTimeMins {
+	if startTimeInMin < currentTimeMins && currentTimeMins < endTimeInMin {
 		return true
 	}
-
 	// startTime, currentTime, endTime: 22:09, 06:19, 09:07 -> window between this day 22:09 and tomorrow 09:07
-	if startTimeMins > currentTimeMins && currentTimeMins < endTimeMins && startTimeMins > endTimeMins {
+	if startTimeInMin > currentTimeMins && currentTimeMins < endTimeInMin && startTimeInMin > endTimeInMin {
 		return true
 	}
-
 	// startTime, currentTime, endTime: 22:09, 23:19, 09:07 -> window between this day 22:09 and tomorrow 09:07
-	if startTimeMins < currentTimeMins && currentTimeMins > endTimeMins && startTimeMins > endTimeMins {
+	if startTimeInMin < currentTimeMins && currentTimeMins > endTimeInMin && startTimeInMin > endTimeInMin {
 		return true
 	}
-
 	return false
 }
 
 // prevScheduledTime returns the closest previous scheduled time
 // e.g. Syncing every 3hrs starting at 13:00 (scheduled times: 13:00, 16:00, 19:00, 22:00, 01:00, 04:00, 07:00, 10:00)
 // prev scheduled time for current time (e.g. 18:00 -> 16:00 same day, 00:30 -> 22:00 prev day)
-func prevScheduledTime(syncFrequency, syncStartAt string, currTime time.Time) time.Time {
-	allStartTimes := scheduledTimes(syncFrequency, syncStartAt)
+func (r *Router) prevScheduledTime(syncFrequency, syncStartAt string, currTime time.Time) time.Time {
+	allStartTimes := r.scheduledTimes(syncFrequency, syncStartAt)
 
 	loc, _ := time.LoadLocation("UTC")
 	now := currTime.In(loc)
@@ -154,10 +139,10 @@ func prevScheduledTime(syncFrequency, syncStartAt string, currTime time.Time) ti
 
 // scheduledTimes returns all possible start times (minutes from start of day) as per schedule
 // e.g. Syncing every 3hrs starting at 13:00 (scheduled times: 13:00, 16:00, 19:00, 22:00, 01:00, 04:00, 07:00, 10:00)
-func scheduledTimes(syncFrequency, syncStartAt string) []int {
-	scheduledTimesCacheLock.RLock()
-	cachedTimes, ok := scheduledTimesCache[fmt.Sprintf(`%s-%s`, syncFrequency, syncStartAt)]
-	scheduledTimesCacheLock.RUnlock()
+func (r *Router) scheduledTimes(syncFrequency, syncStartAt string) []int {
+	r.scheduledTimesCacheLock.RLock()
+	cachedTimes, ok := r.scheduledTimesCache[fmt.Sprintf(`%s-%s`, syncFrequency, syncStartAt)]
+	r.scheduledTimesCacheLock.RUnlock()
 
 	if ok {
 		return cachedTimes
@@ -191,9 +176,9 @@ func scheduledTimes(syncFrequency, syncStartAt string) []int {
 
 	times = append(lo.Reverse(prependTimes), times...)
 
-	scheduledTimesCacheLock.Lock()
-	scheduledTimesCache[fmt.Sprintf(`%s-%s`, syncFrequency, syncStartAt)] = times
-	scheduledTimesCacheLock.Unlock()
+	r.scheduledTimesCacheLock.Lock()
+	r.scheduledTimesCache[fmt.Sprintf(`%s-%s`, syncFrequency, syncStartAt)] = times
+	r.scheduledTimesCacheLock.Unlock()
 
 	return times
 }

--- a/warehouse/router/scheduling_test.go
+++ b/warehouse/router/scheduling_test.go
@@ -91,7 +91,8 @@ func TestRouter_CanCreateUpload(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				require.Equal(t, tc.expectedPrevScheduledTime, prevScheduledTime(tc.syncFrequency, tc.syncStartAt, tc.currTime))
+				r := Router{}
+				require.Equal(t, tc.expectedPrevScheduledTime, r.prevScheduledTime(tc.syncFrequency, tc.syncStartAt, tc.currTime))
 			})
 		}
 	})
@@ -119,7 +120,8 @@ func TestRouter_CanCreateUpload(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				start, end := excludeWindowStartEndTimes(tc.excludeWindow)
+				r := Router{}
+				start, end := r.excludeWindowStartEndTimes(tc.excludeWindow)
 				require.Equal(t, tc.expectedStart, start)
 				require.Equal(t, tc.expectedEnd, end)
 			})

--- a/warehouse/router/tracker.go
+++ b/warehouse/router/tracker.go
@@ -91,7 +91,7 @@ func (r *Router) Track(
 	}
 
 	excludeWindow := warehouseutils.GetConfigValueAsMap(warehouseutils.ExcludeWindow, warehouse.Destination.Config)
-	excludeWindowStartTime, excludeWindowEndTime := excludeWindowStartEndTimes(excludeWindow)
+	excludeWindowStartTime, excludeWindowEndTime := r.excludeWindowStartEndTimes(excludeWindow)
 	if checkCurrentTimeExistsInExcludeWindow(now(), excludeWindowStartTime, excludeWindowEndTime) {
 		return nil
 	}


### PR DESCRIPTION
# Description

- Avoid using globals (`scheduledTimesCache`, `StartUploadAlways`)

## Linear Ticket

- Resolves PIPE-458

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.