### PR TITLE
chore: avoid using global conf during tests

### DIFF
--- a/warehouse/api/grpc_test.go
+++ b/warehouse/api/grpc_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 
 	"github.com/rudderlabs/rudder-server/warehouse/bcm"
 
@@ -148,8 +148,8 @@ func TestGRPC(t *testing.T) {
 
 		triggerStore := &sync.Map{}
 		tenantManager := multitenant.New(c, mockBackendConfig)
-		bcManager := bcm.New(c, db, tenantManager, logger.NOP, stats.Default)
-		grpcServer, err := NewGRPCServer(c, logger.NOP, stats.Default, db, tenantManager, bcManager, triggerStore)
+		bcManager := bcm.New(c, db, tenantManager, logger.NOP, memstats.New())
+		grpcServer, err := NewGRPCServer(c, logger.NOP, memstats.New(), db, tenantManager, bcManager, triggerStore)
 		require.NoError(t, err)
 
 		tcpPort, err := kithelper.GetFreePort()
@@ -160,7 +160,7 @@ func TestGRPC(t *testing.T) {
 		listener, err := net.Listen("tcp", tcpAddress)
 		require.NoError(t, err)
 
-		server := grpc.NewServer(grpc.Creds(insecure.NewCredentials()), grpc.UnaryInterceptor(statsInterceptor(stats.Default)))
+		server := grpc.NewServer(grpc.Creds(insecure.NewCredentials()), grpc.UnaryInterceptor(statsInterceptor(memstats.New())))
 		proto.RegisterWarehouseServer(server, grpcServer)
 
 		g, gCtx := errgroup.WithContext(ctx)

--- a/warehouse/api/http_test.go
+++ b/warehouse/api/http_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	"github.com/rudderlabs/rudder-server/warehouse/internal/mode"
 
 	"github.com/rudderlabs/rudder-server/warehouse/bcm"
@@ -37,7 +39,6 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/backend-config"
@@ -177,13 +178,13 @@ func TestHTTPApi(t *testing.T) {
 
 	tenantManager := multitenant.New(c, mockBackendConfig)
 
-	bcManager := bcm.New(config.Default, db, tenantManager, logger.NOP, stats.Default)
+	bcManager := bcm.New(config.New(), db, tenantManager, logger.NOP, memstats.New())
 
 	triggerStore := &sync.Map{}
 
 	ctx, stopTest := context.WithCancel(context.Background())
 
-	n := notifier.New(config.Default, logger.NOP, stats.Default, workspaceIdentifier)
+	n := notifier.New(config.New(), logger.NOP, memstats.New(), workspaceIdentifier)
 	err = n.Setup(ctx, pgResource.DBDsn)
 	require.NoError(t, err)
 
@@ -192,7 +193,7 @@ func TestHTTPApi(t *testing.T) {
 		db,
 		n,
 	)
-	jobs.WithConfig(sourcesManager, config.Default)
+	jobs.WithConfig(sourcesManager, config.New())
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.Go(func() error {
@@ -411,7 +412,7 @@ func TestHTTPApi(t *testing.T) {
 				c := config.New()
 				c.Set("Warehouse.runningMode", tc.runningMode)
 
-				a := NewApi(tc.mode, c, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+				a := NewApi(tc.mode, c, logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 				a.healthHandler(resp, req)
 
 				var healthBody map[string]string
@@ -429,7 +430,7 @@ func TestHTTPApi(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/v1/warehouse/pending-events", bytes.NewReader([]byte(`"Invalid payload"`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.pendingEventsHandler(resp, req)
 			require.Equal(t, http.StatusBadRequest, resp.Code)
 
@@ -447,7 +448,7 @@ func TestHTTPApi(t *testing.T) {
 			`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.pendingEventsHandler(resp, req)
 			require.Equal(t, http.StatusBadRequest, resp.Code)
 
@@ -465,7 +466,7 @@ func TestHTTPApi(t *testing.T) {
 			`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.pendingEventsHandler(resp, req)
 			require.Equal(t, http.StatusBadRequest, resp.Code)
 
@@ -483,7 +484,7 @@ func TestHTTPApi(t *testing.T) {
 			`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.pendingEventsHandler(resp, req)
 			require.Equal(t, http.StatusServiceUnavailable, resp.Code)
 
@@ -501,7 +502,7 @@ func TestHTTPApi(t *testing.T) {
 			`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.pendingEventsHandler(resp, req)
 			require.Equal(t, http.StatusOK, resp.Code)
 
@@ -527,7 +528,7 @@ func TestHTTPApi(t *testing.T) {
 			`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.pendingEventsHandler(resp, req)
 			require.Equal(t, http.StatusOK, resp.Code)
 
@@ -557,7 +558,7 @@ func TestHTTPApi(t *testing.T) {
 			`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.pendingEventsHandler(resp, req)
 			require.Equal(t, http.StatusOK, resp.Code)
 
@@ -579,7 +580,7 @@ func TestHTTPApi(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/internal/v1/warehouse/fetch-tables", bytes.NewReader([]byte(`"Invalid payload"`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.fetchTablesHandler(resp, req)
 			require.Equal(t, http.StatusBadRequest, resp.Code)
 
@@ -596,7 +597,7 @@ func TestHTTPApi(t *testing.T) {
 			`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.fetchTablesHandler(resp, req)
 			require.Equal(t, http.StatusInternalServerError, resp.Code)
 
@@ -618,7 +619,7 @@ func TestHTTPApi(t *testing.T) {
 			`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.fetchTablesHandler(resp, req)
 			require.Equal(t, http.StatusOK, resp.Code)
 
@@ -641,7 +642,7 @@ func TestHTTPApi(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/v1/warehouse/trigger-upload", bytes.NewReader([]byte(`"Invalid payload"`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.triggerUploadHandler(resp, req)
 			require.Equal(t, http.StatusBadRequest, resp.Code)
 
@@ -659,7 +660,7 @@ func TestHTTPApi(t *testing.T) {
 			`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.triggerUploadHandler(resp, req)
 			require.Equal(t, http.StatusBadRequest, resp.Code)
 
@@ -677,7 +678,7 @@ func TestHTTPApi(t *testing.T) {
 			`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.triggerUploadHandler(resp, req)
 
 			require.Equal(t, http.StatusServiceUnavailable, resp.Code)
@@ -695,7 +696,7 @@ func TestHTTPApi(t *testing.T) {
 			`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.triggerUploadHandler(resp, req)
 
 			require.Equal(t, http.StatusBadRequest, resp.Code)
@@ -713,7 +714,7 @@ func TestHTTPApi(t *testing.T) {
 			`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.triggerUploadHandler(resp, req)
 
 			require.Equal(t, http.StatusOK, resp.Code)
@@ -735,7 +736,7 @@ func TestHTTPApi(t *testing.T) {
 			`)))
 			resp := httptest.NewRecorder()
 
-			a := NewApi(config.MasterMode, config.Default, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, config.New(), logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 			a.triggerUploadHandler(resp, req)
 
 			require.Equal(t, http.StatusOK, resp.Code)
@@ -759,7 +760,7 @@ func TestHTTPApi(t *testing.T) {
 
 			srvCtx, stopServer := context.WithCancel(ctx)
 
-			a := NewApi(config.MasterMode, c, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, c, logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 
 			serverSetupCh := make(chan struct{})
 			go func() {
@@ -957,7 +958,7 @@ func TestHTTPApi(t *testing.T) {
 
 			srvCtx, stopServer := context.WithCancel(ctx)
 
-			a := NewApi(config.MasterMode, c, logger.NOP, stats.Default, mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
+			a := NewApi(config.MasterMode, c, logger.NOP, memstats.New(), mockBackendConfig, db, n, tenantManager, bcManager, sourcesManager, triggerStore)
 
 			serverSetupCh := make(chan struct{})
 			go func() {

--- a/warehouse/app_test.go
+++ b/warehouse/app_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	"github.com/rudderlabs/rudder-server/warehouse/internal/mode"
 
 	"github.com/ory/dockertest/v3"
@@ -30,7 +32,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
@@ -131,7 +132,7 @@ func TestApp(t *testing.T) {
 					c.Set("Warehouse.runningMode", subTC.runningMode)
 					c.Set("Warehouse.webPort", webPort)
 
-					a := New(mockApp, c, logger.NOP, stats.Default, &bcConfig.NOOP{}, filemanager.New)
+					a := New(mockApp, c, logger.NOP, memstats.New(), &bcConfig.NOOP{}, filemanager.New)
 					err = a.Setup(ctx)
 					require.NoError(t, err)
 
@@ -210,7 +211,7 @@ func TestApp(t *testing.T) {
 			return ch
 		}).AnyTimes()
 
-		a := New(mockApp, c, logger.NOP, stats.Default, mockBackendConfig, filemanager.New)
+		a := New(mockApp, c, logger.NOP, memstats.New(), mockBackendConfig, filemanager.New)
 		err = a.Setup(ctx)
 		require.NoError(t, err)
 
@@ -278,7 +279,7 @@ func TestApp(t *testing.T) {
 		c.Set("WAREHOUSE_JOBS_DB_PASSWORD", pgResource.Password)
 		c.Set("WAREHOUSE_JOBS_DB_DB_NAME", pgResource.Database)
 
-		a := New(mockApp, c, logger.NOP, stats.Default, &bcConfig.NOOP{}, filemanager.New)
+		a := New(mockApp, c, logger.NOP, memstats.New(), &bcConfig.NOOP{}, filemanager.New)
 		err = a.Setup(context.Background())
 		require.EqualError(t, err, "setting up database: warehouse Service needs postgres version >= 10. Exiting")
 	})
@@ -290,7 +291,7 @@ func TestApp(t *testing.T) {
 		c.Set("WAREHOUSE_JOBS_DB_PASSWORD", "ubuntu")
 		c.Set("WAREHOUSE_JOBS_DB_DB_NAME", "ubuntu")
 
-		a := New(mockApp, c, logger.NOP, stats.Default, &bcConfig.NOOP{}, filemanager.New)
+		a := New(mockApp, c, logger.NOP, memstats.New(), &bcConfig.NOOP{}, filemanager.New)
 		err = a.Setup(context.Background())
 		require.ErrorContains(t, err, "setting up database: could not check compatibility:")
 	})
@@ -305,7 +306,7 @@ func TestApp(t *testing.T) {
 		c.Set("DB.password", pgResource.Password)
 		c.Set("DB.name", pgResource.Database)
 
-		a := New(mockApp, c, logger.NOP, stats.Default, &bcConfig.NOOP{}, filemanager.New)
+		a := New(mockApp, c, logger.NOP, memstats.New(), &bcConfig.NOOP{}, filemanager.New)
 		err = a.Setup(context.Background())
 		require.NoError(t, err)
 	})
@@ -386,7 +387,7 @@ func TestApp(t *testing.T) {
 			return ch
 		}).AnyTimes()
 
-		a := New(mockApp, c, logger.NOP, stats.Default, mockBackendConfig, filemanager.New)
+		a := New(mockApp, c, logger.NOP, memstats.New(), mockBackendConfig, filemanager.New)
 		require.NoError(t, a.Setup(ctx))
 		require.NoError(t, a.monitorDestRouters(ctx))
 	})
@@ -417,7 +418,7 @@ func TestApp(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			a := New(mockApp, c, logger.NOP, stats.Default, &bcConfig.NOOP{}, filemanager.New)
+			a := New(mockApp, c, logger.NOP, memstats.New(), &bcConfig.NOOP{}, filemanager.New)
 			err = a.Setup(ctx)
 			require.NoError(t, err)
 
@@ -475,7 +476,7 @@ func TestApp(t *testing.T) {
 			mockLogger.EXPECT().Info(gomock.Any()).AnyTimes()
 			mockLogger.EXPECT().Infof(gomock.Any()).AnyTimes()
 
-			a := New(mockApp, c, mockLogger, stats.Default, &bcConfig.NOOP{}, filemanager.New)
+			a := New(mockApp, c, mockLogger, memstats.New(), &bcConfig.NOOP{}, filemanager.New)
 			err = a.Setup(ctx)
 			require.NoError(t, err)
 

--- a/warehouse/archive/archiver_test.go
+++ b/warehouse/archive/archiver_test.go
@@ -159,7 +159,7 @@ func TestArchiver(t *testing.T) {
 			db := sqlmw.New(pgResource.DB)
 
 			archiver := archive.New(
-				config.Default,
+				config.New(),
 				logger.NOP,
 				mockStats,
 				db,

--- a/warehouse/bcm/backend_config_test.go
+++ b/warehouse/bcm/backend_config_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 
 	"github.com/rudderlabs/rudder-server/warehouse/multitenant"
 
@@ -112,10 +112,10 @@ func TestBackendConfigManager(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	tenantManager := multitenant.New(config.Default, mockBackendConfig)
+	tenantManager := multitenant.New(config.New(), mockBackendConfig)
 
 	t.Run("Subscriptions", func(t *testing.T) {
-		bcm := New(c, db, tenantManager, logger.NOP, stats.Default)
+		bcm := New(c, db, tenantManager, logger.NOP, memstats.New())
 
 		require.False(t, bcm.IsInitialized())
 		require.Equal(t, bcm.Connections(), map[string]map[string]model.Warehouse{})
@@ -191,7 +191,7 @@ func TestBackendConfigManager(t *testing.T) {
 	})
 
 	t.Run("Tunnelling", func(t *testing.T) {
-		bcm := New(c, db, tenantManager, logger.NOP, stats.Default)
+		bcm := New(c, db, tenantManager, logger.NOP, memstats.New())
 
 		testCases := []struct {
 			name     string
@@ -261,7 +261,7 @@ func TestBackendConfigManager(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		numSubscribers := 1000
-		bcm := New(c, db, tenantManager, logger.NOP, stats.Default)
+		bcm := New(c, db, tenantManager, logger.NOP, memstats.New())
 		subscriptionsChs := make([]<-chan []model.Warehouse, numSubscribers)
 
 		for i := 0; i < numSubscribers; i++ {
@@ -459,11 +459,11 @@ func TestBackendConfigManager_Namespace(t *testing.T) {
 			require.NoError(t, err)
 
 			tenantManager := multitenant.New(
-				config.Default,
+				config.New(),
 				backendconfig.DefaultBackendConfig,
 			)
 
-			bcm := New(c, db, tenantManager, logger.NOP, stats.Default)
+			bcm := New(c, db, tenantManager, logger.NOP, memstats.New())
 
 			namespace := bcm.namespace(context.Background(), tc.source, tc.destination)
 			require.Equal(t, tc.expectedNamespace, namespace)

--- a/warehouse/encoding/encoding_test.go
+++ b/warehouse/encoding/encoding_test.go
@@ -58,7 +58,7 @@ func TestReaderLoader(t *testing.T) {
 		)
 		t.Log("Parquet", outputFilePath)
 
-		ef := encoding.NewFactory(config.Default)
+		ef := encoding.NewFactory(config.New())
 
 		writer, err := ef.NewLoadFileWriter(loadFileType, outputFilePath, schema, destinationType)
 		require.NoError(t, err)
@@ -205,7 +205,7 @@ func TestReaderLoader(t *testing.T) {
 			lines           = 100
 		)
 
-		ef := encoding.NewFactory(config.Default)
+		ef := encoding.NewFactory(config.New())
 
 		writer, err := ef.NewLoadFileWriter(loadFileType, outputFilePath, nil, destinationType)
 		require.NoError(t, err)
@@ -267,7 +267,7 @@ func TestReaderLoader(t *testing.T) {
 			lines           = 100
 		)
 
-		ef := encoding.NewFactory(config.Default)
+		ef := encoding.NewFactory(config.New())
 
 		writer, err := ef.NewLoadFileWriter(loadFileType, outputFilePath, nil, destinationType)
 		require.NoError(t, err)
@@ -320,7 +320,7 @@ func TestReaderLoader(t *testing.T) {
 	})
 
 	t.Run("Empty files", func(t *testing.T) {
-		ef := encoding.NewFactory(config.Default)
+		ef := encoding.NewFactory(config.New())
 
 		t.Run("csv", func(t *testing.T) {
 			destinationType := warehouseutils.RS

--- a/warehouse/integrations/azure-synapse/azure_synapse_test.go
+++ b/warehouse/integrations/azure-synapse/azure_synapse_test.go
@@ -10,12 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	"github.com/golang/mock/gomock"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 	azuresynapse "github.com/rudderlabs/rudder-server/warehouse/integrations/azure-synapse"
 	mockuploader "github.com/rudderlabs/rudder-server/warehouse/internal/mocks/utils"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
@@ -346,7 +347,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			az := azuresynapse.New(config.Default, logger.NOP, stats.Default)
+			az := azuresynapse.New(config.New(), logger.NOP, memstats.New())
 			err := az.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -362,7 +363,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			az := azuresynapse.New(config.Default, logger.NOP, stats.Default)
+			az := azuresynapse.New(config.New(), logger.NOP, memstats.New())
 			err := az.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -382,7 +383,7 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-				az := azuresynapse.New(config.Default, logger.NOP, stats.Default)
+				az := azuresynapse.New(config.New(), logger.NOP, memstats.New())
 				err := az.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -429,7 +430,7 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-				az := azuresynapse.New(config.Default, logger.NOP, stats.Default)
+				az := azuresynapse.New(config.New(), logger.NOP, memstats.New())
 				err := az.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -474,7 +475,7 @@ func TestIntegration(t *testing.T) {
 			}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			az := azuresynapse.New(config.Default, logger.NOP, stats.Default)
+			az := azuresynapse.New(config.New(), logger.NOP, memstats.New())
 			err := az.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -496,7 +497,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			az := azuresynapse.New(config.Default, logger.NOP, stats.Default)
+			az := azuresynapse.New(config.New(), logger.NOP, memstats.New())
 			err := az.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -518,7 +519,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			az := azuresynapse.New(config.Default, logger.NOP, stats.Default)
+			az := azuresynapse.New(config.New(), logger.NOP, memstats.New())
 			err := az.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -562,7 +563,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, warehouseutils.DiscardsSchema, warehouseutils.DiscardsSchema)
 
-			az := azuresynapse.New(config.Default, logger.NOP, stats.Default)
+			az := azuresynapse.New(config.New(), logger.NOP, memstats.New())
 			err := az.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -677,7 +678,7 @@ func TestAzureSynapse_ProcessColumnValue(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			az := azuresynapse.New(config.Default, logger.NOP, stats.Default)
+			az := azuresynapse.New(config.New(), logger.NOP, memstats.New())
 
 			value, err := az.ProcessColumnValue(tc.data, tc.dataType)
 			if tc.wantError {

--- a/warehouse/integrations/bigquery/bigquery_test.go
+++ b/warehouse/integrations/bigquery/bigquery_test.go
@@ -488,7 +488,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			bq := whbigquery.New(config.Default, logger.NOP)
+			bq := whbigquery.New(config.New(), logger.NOP)
 			err := bq.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -504,7 +504,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			bq := whbigquery.New(config.Default, logger.NOP)
+			bq := whbigquery.New(config.New(), logger.NOP)
 			err := bq.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -617,7 +617,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			bq := whbigquery.New(config.Default, logger.NOP)
+			bq := whbigquery.New(config.New(), logger.NOP)
 			err := bq.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -670,7 +670,7 @@ func TestIntegration(t *testing.T) {
 			}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			bq := whbigquery.New(config.Default, logger.NOP)
+			bq := whbigquery.New(config.New(), logger.NOP)
 			err := bq.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -692,7 +692,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			bq := whbigquery.New(config.Default, logger.NOP)
+			bq := whbigquery.New(config.New(), logger.NOP)
 			err := bq.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -714,7 +714,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			bq := whbigquery.New(config.Default, logger.NOP)
+			bq := whbigquery.New(config.New(), logger.NOP)
 			err := bq.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -736,7 +736,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, warehouseutils.DiscardsSchema, warehouseutils.DiscardsSchema)
 
-			bq := whbigquery.New(config.Default, logger.NOP)
+			bq := whbigquery.New(config.New(), logger.NOP)
 			err := bq.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -897,7 +897,7 @@ func TestIntegration(t *testing.T) {
 		}
 
 		t.Run("tables doesn't exists", func(t *testing.T) {
-			bq := whbigquery.New(config.Default, logger.NOP)
+			bq := whbigquery.New(config.New(), logger.NOP)
 			err := bq.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -906,7 +906,7 @@ func TestIntegration(t *testing.T) {
 			require.True(t, isEmpty)
 		})
 		t.Run("tables empty", func(t *testing.T) {
-			bq := whbigquery.New(config.Default, logger.NOP)
+			bq := whbigquery.New(config.New(), logger.NOP)
 			err := bq.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -932,7 +932,7 @@ func TestIntegration(t *testing.T) {
 			require.True(t, isEmpty)
 		})
 		t.Run("tables not empty", func(t *testing.T) {
-			bq := whbigquery.New(config.Default, logger.NOP)
+			bq := whbigquery.New(config.New(), logger.NOP)
 			err := bq.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 

--- a/warehouse/integrations/clickhouse/clickhouse_test.go
+++ b/warehouse/integrations/clickhouse/clickhouse_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
@@ -20,7 +22,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/runner"
@@ -342,7 +343,7 @@ func TestClickhouse_UseS3CopyEngineForLoading(t *testing.T) {
 			c := config.New()
 			c.Set("Warehouse.clickhouse.s3EngineEnabledWorkspaceIDs", S3EngineEnabledWorkspaceIDs)
 
-			ch := clickhouse.New(c, logger.NOP, stats.Default)
+			ch := clickhouse.New(c, logger.NOP, memstats.New())
 			ch.Warehouse = model.Warehouse{
 				WorkspaceID: tc.workspaceID,
 			}
@@ -423,7 +424,7 @@ func TestClickhouse_LoadTableRoundTrip(t *testing.T) {
 			c.Set("Warehouse.clickhouse.s3EngineEnabledWorkspaceIDs", tc.S3EngineEnabledWorkspaceIDs)
 			c.Set("Warehouse.clickhouse.disableNullable", tc.disableNullable)
 
-			ch := clickhouse.New(c, logger.NOP, stats.Default)
+			ch := clickhouse.New(c, logger.NOP, memstats.New())
 
 			warehouse := model.Warehouse{
 				Namespace:   fmt.Sprintf("test_namespace_%d", i),
@@ -669,7 +670,7 @@ func TestClickhouse_TestConnection(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			ch := clickhouse.New(config.Default, logger.NOP, stats.Default)
+			ch := clickhouse.New(config.New(), logger.NOP, memstats.New())
 
 			host := "localhost"
 			if tc.host != "" {
@@ -768,7 +769,7 @@ func TestClickhouse_LoadTestTable(t *testing.T) {
 		i := i
 
 		t.Run(tc.name, func(t *testing.T) {
-			ch := clickhouse.New(config.Default, logger.NOP, stats.Default)
+			ch := clickhouse.New(config.New(), logger.NOP, memstats.New())
 
 			warehouse := model.Warehouse{
 				Namespace:   namespace,
@@ -840,7 +841,7 @@ func TestClickhouse_FetchSchema(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Success", func(t *testing.T) {
-		ch := clickhouse.New(config.Default, logger.NOP, stats.Default)
+		ch := clickhouse.New(config.New(), logger.NOP, memstats.New())
 
 		warehouse := model.Warehouse{
 			Namespace:   fmt.Sprintf("%s_success", namespace),
@@ -885,7 +886,7 @@ func TestClickhouse_FetchSchema(t *testing.T) {
 	})
 
 	t.Run("Invalid host", func(t *testing.T) {
-		ch := clickhouse.New(config.Default, logger.NOP, stats.Default)
+		ch := clickhouse.New(config.New(), logger.NOP, memstats.New())
 
 		warehouse := model.Warehouse{
 			Namespace:   fmt.Sprintf("%s_invalid_host", namespace),
@@ -911,7 +912,7 @@ func TestClickhouse_FetchSchema(t *testing.T) {
 	})
 
 	t.Run("Invalid database", func(t *testing.T) {
-		ch := clickhouse.New(config.Default, logger.NOP, stats.Default)
+		ch := clickhouse.New(config.New(), logger.NOP, memstats.New())
 
 		warehouse := model.Warehouse{
 			Namespace:   fmt.Sprintf("%s_invalid_database", namespace),
@@ -937,7 +938,7 @@ func TestClickhouse_FetchSchema(t *testing.T) {
 	})
 
 	t.Run("Empty schema", func(t *testing.T) {
-		ch := clickhouse.New(config.Default, logger.NOP, stats.Default)
+		ch := clickhouse.New(config.New(), logger.NOP, memstats.New())
 
 		warehouse := model.Warehouse{
 			Namespace:   fmt.Sprintf("%s_empty_schema", namespace),
@@ -966,7 +967,7 @@ func TestClickhouse_FetchSchema(t *testing.T) {
 	})
 
 	t.Run("Unrecognized schema", func(t *testing.T) {
-		ch := clickhouse.New(config.Default, logger.NOP, stats.Default)
+		ch := clickhouse.New(config.New(), logger.NOP, memstats.New())
 
 		warehouse := model.Warehouse{
 			Namespace:   fmt.Sprintf("%s_unrecognized_schema", namespace),

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 
@@ -24,7 +26,6 @@ import (
 	"github.com/rudderlabs/compose-test/testcompose"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/runner"
@@ -474,7 +475,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv, false, false, "2022-12-15T06:53:49.640Z")
 
-			d := deltalake.New(config.Default, logger.NOP, stats.Default)
+			d := deltalake.New(config.New(), logger.NOP, memstats.New())
 			err := d.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -490,7 +491,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv, false, false, "2022-12-15T06:53:49.640Z")
 
-			d := deltalake.New(config.Default, logger.NOP, stats.Default)
+			d := deltalake.New(config.New(), logger.NOP, memstats.New())
 			err := d.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -510,7 +511,7 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv, false, false, "2022-12-15T06:53:49.640Z")
 
-				d := deltalake.New(config.Default, logger.NOP, stats.Default)
+				d := deltalake.New(config.New(), logger.NOP, memstats.New())
 				err := d.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -557,7 +558,7 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv, false, true, "2022-12-15T06:53:49.640Z")
 
-				d := deltalake.New(config.Default, logger.NOP, stats.Default)
+				d := deltalake.New(config.New(), logger.NOP, memstats.New())
 				err := d.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -599,7 +600,7 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv, false, false, "2022-11-15T06:53:49.640Z")
 
-				d := deltalake.New(config.Default, logger.NOP, stats.Default)
+				d := deltalake.New(config.New(), logger.NOP, memstats.New())
 				err := d.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -647,7 +648,7 @@ func TestIntegration(t *testing.T) {
 			c := config.New()
 			c.Set("Warehouse.deltalake.loadTableStrategy", "APPEND")
 
-			d := deltalake.New(c, logger.NOP, stats.Default)
+			d := deltalake.New(c, logger.NOP, memstats.New())
 			err := d.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -696,7 +697,7 @@ func TestIntegration(t *testing.T) {
 			}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv, false, false, "2022-12-15T06:53:49.640Z")
 
-			d := deltalake.New(config.Default, logger.NOP, stats.Default)
+			d := deltalake.New(config.New(), logger.NOP, memstats.New())
 			err := d.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -718,7 +719,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv, false, false, "2022-12-15T06:53:49.640Z")
 
-			d := deltalake.New(config.Default, logger.NOP, stats.Default)
+			d := deltalake.New(config.New(), logger.NOP, memstats.New())
 			err := d.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -762,7 +763,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv, false, false, "2022-12-15T06:53:49.640Z")
 
-			d := deltalake.New(config.Default, logger.NOP, stats.Default)
+			d := deltalake.New(config.New(), logger.NOP, memstats.New())
 			err := d.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -806,7 +807,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, warehouseutils.DiscardsSchema, warehouseutils.DiscardsSchema, warehouseutils.LoadFileTypeCsv, false, false, "2022-12-15T06:53:49.640Z")
 
-			d := deltalake.New(config.Default, logger.NOP, stats.Default)
+			d := deltalake.New(config.New(), logger.NOP, memstats.New())
 			err := d.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -848,7 +849,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeParquet, false, false, "2022-12-15T06:53:49.640Z")
 
-			d := deltalake.New(config.Default, logger.NOP, stats.Default)
+			d := deltalake.New(config.New(), logger.NOP, memstats.New())
 			err := d.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -893,7 +894,7 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv, false, false, "2022-12-15T06:53:49.640Z")
 
-				d := deltalake.New(config.Default, logger.NOP, stats.Default)
+				d := deltalake.New(config.New(), logger.NOP, memstats.New())
 				err := d.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -955,7 +956,7 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv, false, false, "2022-12-15T06:53:49.640Z")
 
-				d := deltalake.New(config.Default, logger.NOP, stats.Default)
+				d := deltalake.New(config.New(), logger.NOP, memstats.New())
 				err := d.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -1045,7 +1046,7 @@ func TestDeltalake_TrimErrorMessage(t *testing.T) {
 			c := config.New()
 			c.Set("Warehouse.deltalake.maxErrorLength", len(tempError.Error())*25)
 
-			d := deltalake.New(c, logger.NOP, stats.Default)
+			d := deltalake.New(c, logger.NOP, memstats.New())
 			require.Equal(t, d.TrimErrorMessage(tc.inputError), tc.expectedError)
 		})
 	}
@@ -1094,7 +1095,7 @@ func TestDeltalake_ShouldAppend(t *testing.T) {
 			c := config.New()
 			c.Set("Warehouse.deltalake.loadTableStrategy", tc.loadTableStrategy)
 
-			d := deltalake.New(c, logger.NOP, stats.Default)
+			d := deltalake.New(c, logger.NOP, memstats.New())
 
 			mockCtrl := gomock.NewController(t)
 			uploader := mockuploader.NewMockUploader(mockCtrl)

--- a/warehouse/integrations/mssql/mssql_test.go
+++ b/warehouse/integrations/mssql/mssql_test.go
@@ -10,12 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	"github.com/golang/mock/gomock"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/mssql"
 	mockuploader "github.com/rudderlabs/rudder-server/warehouse/internal/mocks/utils"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
@@ -385,7 +386,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			ms := mssql.New(config.Default, logger.NOP, stats.Default)
+			ms := mssql.New(config.New(), logger.NOP, memstats.New())
 			err := ms.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -401,7 +402,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			ms := mssql.New(config.Default, logger.NOP, stats.Default)
+			ms := mssql.New(config.New(), logger.NOP, memstats.New())
 			err := ms.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -421,7 +422,7 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-				ms := mssql.New(config.Default, logger.NOP, stats.Default)
+				ms := mssql.New(config.New(), logger.NOP, memstats.New())
 				err := ms.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -468,7 +469,7 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-				ms := mssql.New(config.Default, logger.NOP, stats.Default)
+				ms := mssql.New(config.New(), logger.NOP, memstats.New())
 				err := ms.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -513,7 +514,7 @@ func TestIntegration(t *testing.T) {
 			}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			ms := mssql.New(config.Default, logger.NOP, stats.Default)
+			ms := mssql.New(config.New(), logger.NOP, memstats.New())
 			err := ms.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -535,7 +536,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			ms := mssql.New(config.Default, logger.NOP, stats.Default)
+			ms := mssql.New(config.New(), logger.NOP, memstats.New())
 			err := ms.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -557,7 +558,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			ms := mssql.New(config.Default, logger.NOP, stats.Default)
+			ms := mssql.New(config.New(), logger.NOP, memstats.New())
 			err := ms.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -601,7 +602,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, warehouseutils.DiscardsSchema, warehouseutils.DiscardsSchema)
 
-			ms := mssql.New(config.Default, logger.NOP, stats.Default)
+			ms := mssql.New(config.New(), logger.NOP, memstats.New())
 			err := ms.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -716,7 +717,7 @@ func TestMSSQL_ProcessColumnValue(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ms := mssql.New(config.Default, logger.NOP, stats.Default)
+			ms := mssql.New(config.New(), logger.NOP, memstats.New())
 
 			value, err := ms.ProcessColumnValue(tc.data, tc.dataType)
 			if tc.wantError {

--- a/warehouse/integrations/postgres/postgres_test.go
+++ b/warehouse/integrations/postgres/postgres_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/tunnelling"
 
 	"github.com/golang/mock/gomock"
@@ -17,7 +19,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/postgres"
 	mockuploader "github.com/rudderlabs/rudder-server/warehouse/internal/mocks/utils"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
@@ -550,7 +551,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := mockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			pg := postgres.New(config.Default, logger.NOP, stats.Default)
+			pg := postgres.New(config.New(), logger.NOP, memstats.New())
 			err := pg.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -566,7 +567,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := mockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			pg := postgres.New(config.Default, logger.NOP, stats.Default)
+			pg := postgres.New(config.New(), logger.NOP, memstats.New())
 			err := pg.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -589,7 +590,7 @@ func TestIntegration(t *testing.T) {
 				c := config.New()
 				c.Set("Warehouse.postgres.EnableSQLStatementExecutionPlanWorkspaceIDs", workspaceID)
 
-				pg := postgres.New(c, logger.NOP, stats.Default)
+				pg := postgres.New(c, logger.NOP, memstats.New())
 				err := pg.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -639,7 +640,7 @@ func TestIntegration(t *testing.T) {
 				c := config.New()
 				c.Set("Warehouse.postgres.EnableSQLStatementExecutionPlanWorkspaceIDs", workspaceID)
 
-				pg := postgres.New(config.Default, logger.NOP, stats.Default)
+				pg := postgres.New(config.New(), logger.NOP, memstats.New())
 				err := pg.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -687,7 +688,7 @@ func TestIntegration(t *testing.T) {
 			c := config.New()
 			c.Set("Warehouse.postgres.skipDedupDestinationIDs", destinationID)
 
-			pg := postgres.New(c, logger.NOP, stats.Default)
+			pg := postgres.New(c, logger.NOP, memstats.New())
 			err := pg.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -736,7 +737,7 @@ func TestIntegration(t *testing.T) {
 			}}
 			mockUploader := mockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			pg := postgres.New(config.Default, logger.NOP, stats.Default)
+			pg := postgres.New(config.New(), logger.NOP, memstats.New())
 			err := pg.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -758,7 +759,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := mockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			pg := postgres.New(config.Default, logger.NOP, stats.Default)
+			pg := postgres.New(config.New(), logger.NOP, memstats.New())
 			err := pg.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -780,7 +781,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := mockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			pg := postgres.New(config.Default, logger.NOP, stats.Default)
+			pg := postgres.New(config.New(), logger.NOP, memstats.New())
 			err := pg.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -802,7 +803,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := mockUploader(t, loadFiles, tableName, warehouseutils.DiscardsSchema, warehouseutils.DiscardsSchema)
 
-			pg := postgres.New(config.Default, logger.NOP, stats.Default)
+			pg := postgres.New(config.New(), logger.NOP, memstats.New())
 			err := pg.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -13,16 +13,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	"github.com/golang/mock/gomock"
 
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	mockuploader "github.com/rudderlabs/rudder-server/warehouse/internal/mocks/utils"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 
-	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
-
 	"github.com/rudderlabs/compose-test/compose"
+	"github.com/rudderlabs/rudder-go-kit/logger"
 
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/redshift"
 
@@ -447,7 +447,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv)
 
-			rs := redshift.New(config.Default, logger.NOP, stats.Default)
+			rs := redshift.New(config.New(), logger.NOP, memstats.New())
 			err := rs.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -463,7 +463,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv)
 
-			rs := redshift.New(config.Default, logger.NOP, stats.Default)
+			rs := redshift.New(config.New(), logger.NOP, memstats.New())
 			err := rs.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -483,7 +483,7 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv)
 
-				d := redshift.New(config.Default, logger.NOP, stats.Default)
+				d := redshift.New(config.New(), logger.NOP, memstats.New())
 				err := d.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -530,7 +530,7 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv)
 
-				d := redshift.New(config.Default, logger.NOP, stats.Default)
+				d := redshift.New(config.New(), logger.NOP, memstats.New())
 				err := d.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -576,7 +576,7 @@ func TestIntegration(t *testing.T) {
 				c.Set("Warehouse.redshift.dedupWindow", true)
 				c.Set("Warehouse.redshift.dedupWindowInHours", 0)
 
-				d := redshift.New(c, logger.NOP, stats.Default)
+				d := redshift.New(c, logger.NOP, memstats.New())
 				err := d.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
@@ -624,7 +624,7 @@ func TestIntegration(t *testing.T) {
 			c := config.New()
 			c.Set("Warehouse.redshift.skipDedupDestinationIDs", []string{destinationID})
 
-			rs := redshift.New(c, logger.NOP, stats.Default)
+			rs := redshift.New(c, logger.NOP, memstats.New())
 			err := rs.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -673,7 +673,7 @@ func TestIntegration(t *testing.T) {
 			}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv)
 
-			rs := redshift.New(config.Default, logger.NOP, stats.Default)
+			rs := redshift.New(config.New(), logger.NOP, memstats.New())
 			err := rs.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -695,7 +695,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv)
 
-			rs := redshift.New(config.Default, logger.NOP, stats.Default)
+			rs := redshift.New(config.New(), logger.NOP, memstats.New())
 			err := rs.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -717,7 +717,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv)
 
-			rs := redshift.New(config.Default, logger.NOP, stats.Default)
+			rs := redshift.New(config.New(), logger.NOP, memstats.New())
 			err := rs.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -739,7 +739,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, warehouseutils.DiscardsSchema, warehouseutils.DiscardsSchema, warehouseutils.LoadFileTypeCsv)
 
-			rs := redshift.New(config.Default, logger.NOP, stats.Default)
+			rs := redshift.New(config.New(), logger.NOP, memstats.New())
 			err := rs.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -787,7 +787,7 @@ func TestIntegration(t *testing.T) {
 			}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInUpload, warehouseutils.LoadFileTypeParquet)
 
-			rs := redshift.New(config.Default, logger.NOP, stats.Default)
+			rs := redshift.New(config.New(), logger.NOP, memstats.New())
 			err = rs.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
@@ -896,7 +896,7 @@ func TestRedshift_AlterColumn(t *testing.T) {
 
 			t.Log("db:", pgResource.DBDsn)
 
-			rs := redshift.New(config.Default, logger.NOP, stats.Default)
+			rs := redshift.New(config.New(), logger.NOP, memstats.New())
 
 			rs.DB = sqlmiddleware.New(pgResource.DB)
 			rs.Namespace = testNamespace

--- a/warehouse/integrations/snowflake/snowflake_test.go
+++ b/warehouse/integrations/snowflake/snowflake_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
@@ -26,7 +28,6 @@ import (
 	"github.com/rudderlabs/compose-test/testcompose"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/runner"
@@ -627,7 +628,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []whutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, false, false)
 
-			sf, err := snowflake.New(config.Default, logger.NOP, stats.Default)
+			sf, err := snowflake.New(config.New(), logger.NOP, memstats.New())
 			require.NoError(t, err)
 			err = sf.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
@@ -644,7 +645,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []whutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, false, false)
 
-			sf, err := snowflake.New(config.Default, logger.NOP, stats.Default)
+			sf, err := snowflake.New(config.New(), logger.NOP, memstats.New())
 			require.NoError(t, err)
 			err = sf.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
@@ -673,7 +674,7 @@ func TestIntegration(t *testing.T) {
 					tableName,
 				)})
 
-				sf, err := snowflake.New(c, logger.NOP, stats.Default)
+				sf, err := snowflake.New(c, logger.NOP, memstats.New())
 				require.NoError(t, err)
 				err = sf.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
@@ -721,7 +722,7 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []whutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, false, true)
 
-				sf, err := snowflake.New(config.Default, logger.NOP, stats.Default)
+				sf, err := snowflake.New(config.New(), logger.NOP, memstats.New())
 				require.NoError(t, err)
 				err = sf.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
@@ -771,7 +772,7 @@ func TestIntegration(t *testing.T) {
 				c := config.New()
 				c.Set("Warehouse.snowflake.loadTableStrategy", "APPEND")
 
-				sf, err := snowflake.New(c, logger.NOP, stats.Default)
+				sf, err := snowflake.New(c, logger.NOP, memstats.New())
 				require.NoError(t, err)
 				err = sf.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
@@ -828,7 +829,7 @@ func TestIntegration(t *testing.T) {
 			}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, false, false)
 
-			sf, err := snowflake.New(config.Default, logger.NOP, stats.Default)
+			sf, err := snowflake.New(config.New(), logger.NOP, memstats.New())
 			require.NoError(t, err)
 			err = sf.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
@@ -851,7 +852,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []whutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, false, false)
 
-			sf, err := snowflake.New(config.Default, logger.NOP, stats.Default)
+			sf, err := snowflake.New(config.New(), logger.NOP, memstats.New())
 			require.NoError(t, err)
 			err = sf.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
@@ -896,7 +897,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []whutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, false, false)
 
-			sf, err := snowflake.New(config.Default, logger.NOP, stats.Default)
+			sf, err := snowflake.New(config.New(), logger.NOP, memstats.New())
 			require.NoError(t, err)
 			err = sf.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
@@ -923,7 +924,7 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []whutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, discardsSchema, discardsSchema, false, false)
 
-			sf, err := snowflake.New(config.Default, logger.NOP, stats.Default)
+			sf, err := snowflake.New(config.New(), logger.NOP, memstats.New())
 			require.NoError(t, err)
 			err = sf.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
@@ -1004,7 +1005,7 @@ func TestSnowflake_ShouldAppend(t *testing.T) {
 			c := config.New()
 			c.Set("Warehouse.snowflake.loadTableStrategy", tc.loadTableStrategy)
 
-			sf, err := snowflake.New(c, logger.NOP, stats.Default)
+			sf, err := snowflake.New(c, logger.NOP, memstats.New())
 			require.NoError(t, err)
 
 			mockCtrl := gomock.NewController(t)

--- a/warehouse/internal/api/http_test.go
+++ b/warehouse/internal/api/http_test.go
@@ -13,13 +13,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rudderlabs/rudder-go-kit/config"
-	backendConfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-go-kit/config"
+
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/api"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 	"github.com/rudderlabs/rudder-server/warehouse/multitenant"
@@ -172,12 +173,12 @@ func TestAPI_Process(t *testing.T) {
 			c := config.New()
 			c.Set("Warehouse.degradedWorkspaceIDs", tc.degradedWorkspaceIDs)
 
-			m := multitenant.New(c, backendConfig.DefaultBackendConfig)
+			m := multitenant.New(c, backendconfig.DefaultBackendConfig)
 
 			wAPI := api.WarehouseAPI{
 				Repo:        r,
 				Logger:      logger.NOP,
-				Stats:       stats.Default, // TODO: use a NOP stats
+				Stats:       memstats.New(), // TODO: use a NOP stats
 				Multitenant: m,
 			}
 

--- a/warehouse/jobs/http_test.go
+++ b/warehouse/jobs/http_test.go
@@ -13,8 +13,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	"github.com/rudderlabs/rudder-go-kit/config"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/services/notifier"
 
 	"github.com/ory/dockertest/v3"
@@ -61,7 +62,7 @@ func TestAsyncJobHandlers(t *testing.T) {
 
 	ctx := context.Background()
 
-	n := notifier.New(config.Default, logger.NOP, stats.Default, workspaceIdentifier)
+	n := notifier.New(config.New(), logger.NOP, memstats.New(), workspaceIdentifier)
 	err = n.Setup(ctx, pgResource.DBDsn)
 	require.NoError(t, err)
 

--- a/warehouse/multitenant/manager_test.go
+++ b/warehouse/multitenant/manager_test.go
@@ -150,7 +150,7 @@ func TestSourceToWorkspace(t *testing.T) {
 		backendConfig[workspace] = entry
 	}
 
-	m := multitenant.New(config.Default, &mockBackendConfig{
+	m := multitenant.New(config.New(), &mockBackendConfig{
 		config: backendConfig,
 	})
 
@@ -177,7 +177,7 @@ func TestSourceToWorkspace(t *testing.T) {
 	require.NoError(t, g.Wait())
 
 	t.Run("context canceled", func(t *testing.T) {
-		m := multitenant.New(config.Default, &mockBackendConfig{
+		m := multitenant.New(config.New(), &mockBackendConfig{
 			config: backendConfig,
 		})
 		ctx, cancel := context.WithCancel(context.Background())

--- a/warehouse/router/errors_test.go
+++ b/warehouse/router/errors_test.go
@@ -4,14 +4,14 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	"github.com/rudderlabs/rudder-server/warehouse/router"
 
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
-
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 
 	"github.com/stretchr/testify/require"
@@ -179,7 +179,7 @@ func TestErrorHandler_MatchUploadJobErrorType(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				m, err := manager.New(tc.destType, config.Default, logger.NOP, stats.Default)
+				m, err := manager.New(tc.destType, config.New(), logger.NOP, memstats.New())
 				require.NoError(t, err)
 
 				er := &router.ErrorHandler{Mapper: m}
@@ -191,7 +191,7 @@ func TestErrorHandler_MatchUploadJobErrorType(t *testing.T) {
 	})
 
 	t.Run("UnKnown errors", func(t *testing.T) {
-		m, err := manager.New(warehouseutils.RS, config.Default, logger.NOP, stats.Default)
+		m, err := manager.New(warehouseutils.RS, config.New(), logger.NOP, memstats.New())
 		require.NoError(t, err)
 
 		er := &router.ErrorHandler{Mapper: m}
@@ -206,7 +206,7 @@ func TestErrorHandler_MatchUploadJobErrorType(t *testing.T) {
 	})
 
 	t.Run("Nil error: ", func(t *testing.T) {
-		m, err := manager.New(warehouseutils.RS, config.Default, logger.NOP, stats.Default)
+		m, err := manager.New(warehouseutils.RS, config.New(), logger.NOP, memstats.New())
 		require.NoError(t, err)
 
 		er := &router.ErrorHandler{Mapper: m}

--- a/warehouse/router/router_test.go
+++ b/warehouse/router/router_test.go
@@ -92,7 +92,7 @@ func TestRouter(t *testing.T) {
 
 		ctx := context.Background()
 
-		n := notifier.New(config.Default, logger.NOP, stats.Default, workspaceIdentifier)
+		n := notifier.New(config.New(), logger.NOP, memstats.New(), workspaceIdentifier)
 		err = n.Setup(ctx, pgResource.DBDsn)
 		require.NoError(t, err)
 
@@ -100,7 +100,7 @@ func TestRouter(t *testing.T) {
 
 		createUploadAlways := &atomic.Bool{}
 		triggerStore := &sync.Map{}
-		tenantManager := multitenant.New(config.Default, mocksBackendConfig.NewMockBackendConfig(ctrl))
+		tenantManager := multitenant.New(config.New(), mocksBackendConfig.NewMockBackendConfig(ctrl))
 
 		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -110,20 +110,20 @@ func TestRouter(t *testing.T) {
 		cp := controlplane.NewClient(s.URL, &identity.Namespace{},
 			controlplane.WithHTTPClient(s.Client()),
 		)
-		backendConfigManager := bcm.New(config.Default, db, tenantManager, logger.NOP, stats.Default)
+		backendConfigManager := bcm.New(config.New(), db, tenantManager, logger.NOP, memstats.New())
 
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
-		ef := encoding.NewFactory(config.Default)
+		ef := encoding.NewFactory(config.New())
 
 		r, err := New(
 			ctx,
 			&reporting.NOOP{},
 			destinationType,
-			config.Default,
+			config.New(),
 			logger.NOP,
-			stats.Default,
+			memstats.New(),
 			db,
 			n,
 			tenantManager,
@@ -189,7 +189,7 @@ func TestRouter(t *testing.T) {
 		r.uploadRepo = repoUpload
 		r.stagingRepo = repoStaging
 		r.statsFactory = memstats.New()
-		r.conf = config.Default
+		r.conf = config.New()
 		r.config.uploadFreqInS = misc.SingleValueLoader(int64(1800))
 		r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
 		r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
@@ -347,7 +347,7 @@ func TestRouter(t *testing.T) {
 		r.uploadRepo = repoUpload
 		r.stagingRepo = repoStaging
 		r.statsFactory = memstats.New()
-		r.conf = config.Default
+		r.conf = config.New()
 		r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
 		r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
 		r.config.enableJitterForSyncs = misc.SingleValueLoader(true)
@@ -482,7 +482,7 @@ func TestRouter(t *testing.T) {
 		r.statsFactory = statsStore
 		r.uploadRepo = repoUpload
 		r.stagingRepo = repoStaging
-		r.conf = config.Default
+		r.conf = config.New()
 		r.config.uploadFreqInS = misc.SingleValueLoader(int64(1800))
 		r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
 		r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
@@ -590,17 +590,17 @@ func TestRouter(t *testing.T) {
 		r.uploadRepo = repoUpload
 		r.stagingRepo = repoStaging
 		r.statsFactory = memstats.New()
-		r.conf = config.Default
+		r.conf = config.New()
 		r.config.allowMultipleSourcesForJobsPickup = true
 		r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
 		r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
 		r.destType = destinationType
 		r.logger = logger.NOP
-		r.tenantManager = multitenant.New(config.Default, mocksBackendConfig.NewMockBackendConfig(ctrl))
+		r.tenantManager = multitenant.New(config.New(), mocksBackendConfig.NewMockBackendConfig(ctrl))
 		r.warehouses = []model.Warehouse{warehouse}
 		r.uploadJobFactory = UploadJobFactory{
 			reporting:    &reporting.NOOP{},
-			conf:         config.Default,
+			conf:         config.New(),
 			logger:       logger.NOP,
 			statsFactory: r.statsFactory,
 			db:           r.db,
@@ -725,7 +725,7 @@ func TestRouter(t *testing.T) {
 		r.uploadRepo = repoUpload
 		r.stagingRepo = repoStaging
 		r.statsFactory = memstats.New()
-		r.conf = config.Default
+		r.conf = config.New()
 		r.config.allowMultipleSourcesForJobsPickup = true
 		r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
 		r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
@@ -734,12 +734,12 @@ func TestRouter(t *testing.T) {
 		r.config.uploadAllocatorSleep = time.Millisecond * 100
 		r.destType = warehouseutils.RS
 		r.logger = logger.NOP
-		r.tenantManager = multitenant.New(config.Default, mocksBackendConfig.NewMockBackendConfig(ctrl))
-		r.bcManager = bcm.New(r.conf, r.db, r.tenantManager, r.logger, stats.Default)
+		r.tenantManager = multitenant.New(config.New(), mocksBackendConfig.NewMockBackendConfig(ctrl))
+		r.bcManager = bcm.New(r.conf, r.db, r.tenantManager, r.logger, memstats.New())
 		r.warehouses = []model.Warehouse{warehouse}
 		r.uploadJobFactory = UploadJobFactory{
 			reporting:    &reporting.NOOP{},
-			conf:         config.Default,
+			conf:         config.New(),
 			logger:       logger.NOP,
 			statsFactory: r.statsFactory,
 			db:           r.db,
@@ -876,7 +876,7 @@ func TestRouter(t *testing.T) {
 			r.uploadRepo = repoUpload
 			r.stagingRepo = repoStaging
 			r.statsFactory = memstats.New()
-			r.conf = config.Default
+			r.conf = config.New()
 			r.config.allowMultipleSourcesForJobsPickup = true
 			r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
 			r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
@@ -885,12 +885,12 @@ func TestRouter(t *testing.T) {
 			r.config.uploadAllocatorSleep = time.Millisecond * 100
 			r.destType = warehouseutils.RS
 			r.logger = logger.NOP
-			r.tenantManager = multitenant.New(config.Default, mocksBackendConfig.NewMockBackendConfig(ctrl))
-			r.bcManager = bcm.New(r.conf, r.db, r.tenantManager, r.logger, stats.Default)
+			r.tenantManager = multitenant.New(config.New(), mocksBackendConfig.NewMockBackendConfig(ctrl))
+			r.bcManager = bcm.New(r.conf, r.db, r.tenantManager, r.logger, memstats.New())
 			r.warehouses = []model.Warehouse{warehouse}
 			r.uploadJobFactory = UploadJobFactory{
 				reporting:    &reporting.NOOP{},
-				conf:         config.Default,
+				conf:         config.New(),
 				logger:       logger.NOP,
 				statsFactory: r.statsFactory,
 				db:           r.db,
@@ -967,7 +967,7 @@ func TestRouter(t *testing.T) {
 			r.statsFactory = statsStore
 			r.uploadRepo = repoUpload
 			r.stagingRepo = repoStaging
-			r.conf = config.Default
+			r.conf = config.New()
 
 			r.config.stagingFilesBatchSize = misc.SingleValueLoader(100)
 			r.config.warehouseSyncFreqIgnore = misc.SingleValueLoader(true)
@@ -1195,12 +1195,12 @@ func TestRouter(t *testing.T) {
 		r.uploadRepo = repoUpload
 		r.stagingRepo = repoStaging
 		r.statsFactory = memstats.New()
-		r.conf = config.Default
+		r.conf = config.New()
 		r.logger = logger.NOP
 		r.destType = warehouseutils.RS
 		r.config.maxConcurrentUploadJobs = 1
-		r.tenantManager = multitenant.New(config.Default, mockBackendConfig)
-		r.bcManager = bcm.New(r.conf, r.db, r.tenantManager, r.logger, stats.Default)
+		r.tenantManager = multitenant.New(config.New(), mockBackendConfig)
+		r.bcManager = bcm.New(r.conf, r.db, r.tenantManager, r.logger, memstats.New())
 		r.createJobMarkerMap = make(map[string]time.Time)
 		r.triggerStore = &sync.Map{}
 		r.createUploadAlways = &atomic.Bool{}

--- a/warehouse/router/tracker_test.go
+++ b/warehouse/router/tracker_test.go
@@ -270,7 +270,7 @@ func TestRouter_CronTracker(t *testing.T) {
 			statsFactory: memstats.New(),
 			db:           sqlquerywrapper.New(pgResource.DB),
 			logger:       logger.NOP,
-			conf:         config.Default,
+			conf:         config.New(),
 		}
 		r.warehouses = append(r.warehouses, warehouse)
 

--- a/warehouse/router/upload_stats_test.go
+++ b/warehouse/router/upload_stats_test.go
@@ -7,7 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/repo"
 
@@ -41,7 +42,7 @@ func TestUploadJob_Stats(t *testing.T) {
 		mockMeasurement.EXPECT().Count(1).Times(1)
 
 		ujf := &UploadJobFactory{
-			conf:         config.Default,
+			conf:         config.New(),
 			logger:       logger.NOP,
 			statsFactory: mockStats,
 			db:           sqlmiddleware.New(db),
@@ -71,7 +72,7 @@ func TestUploadJob_Stats(t *testing.T) {
 		mockMeasurement.EXPECT().Count(4).Times(2)
 
 		ujf := &UploadJobFactory{
-			conf:         config.Default,
+			conf:         config.New(),
 			logger:       logger.NOP,
 			statsFactory: mockStats,
 			db:           sqlmiddleware.New(db),
@@ -102,7 +103,7 @@ func TestUploadJob_Stats(t *testing.T) {
 		mockMeasurement.EXPECT().Since(gomock.Any()).Times(1)
 
 		ujf := &UploadJobFactory{
-			conf:         config.Default,
+			conf:         config.New(),
 			logger:       logger.NOP,
 			statsFactory: mockStats,
 			db:           sqlmiddleware.New(db),
@@ -131,7 +132,7 @@ func TestUploadJob_Stats(t *testing.T) {
 		mockMeasurement.EXPECT().SendTiming(gomock.Any()).Times(1)
 
 		ujf := &UploadJobFactory{
-			conf:         config.Default,
+			conf:         config.New(),
 			logger:       logger.NOP,
 			statsFactory: mockStats,
 			db:           sqlmiddleware.New(db),
@@ -165,9 +166,9 @@ func TestUploadJob_MatchRows(t *testing.T) {
 
 	t.Run("Total rows in load files", func(t *testing.T) {
 		ujf := &UploadJobFactory{
-			conf:         config.Default,
+			conf:         config.New(),
 			logger:       logger.NOP,
-			statsFactory: stats.Default,
+			statsFactory: memstats.New(),
 			db:           sqlmiddleware.New(db),
 		}
 		job := ujf.NewUploadJob(context.Background(), &model.UploadJob{
@@ -205,9 +206,9 @@ func TestUploadJob_MatchRows(t *testing.T) {
 
 	t.Run("Total rows in staging files", func(t *testing.T) {
 		ujf := &UploadJobFactory{
-			conf:         config.Default,
+			conf:         config.New(),
 			logger:       logger.NOP,
-			statsFactory: stats.Default,
+			statsFactory: memstats.New(),
 			db:           sqlmiddleware.New(db),
 		}
 		job := ujf.NewUploadJob(context.Background(), &model.UploadJob{
@@ -246,9 +247,9 @@ func TestUploadJob_MatchRows(t *testing.T) {
 
 	t.Run("Get uploads timings", func(t *testing.T) {
 		ujf := &UploadJobFactory{
-			conf:         config.Default,
+			conf:         config.New(),
 			logger:       logger.NOP,
-			statsFactory: stats.Default,
+			statsFactory: memstats.New(),
 			db:           sqlmiddleware.New(db),
 		}
 		job := ujf.NewUploadJob(context.Background(), &model.UploadJob{
@@ -333,7 +334,7 @@ func TestUploadJob_MatchRows(t *testing.T) {
 				mockMeasurement.EXPECT().Gauge(gomock.Any()).Times(tc.statsCount)
 
 				ujf := &UploadJobFactory{
-					conf:         config.Default,
+					conf:         config.New(),
 					logger:       logger.NOP,
 					statsFactory: mockStats,
 					db:           sqlmiddleware.New(db),

--- a/warehouse/router/upload_test.go
+++ b/warehouse/router/upload_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
@@ -241,14 +240,14 @@ func TestUploadJobT_UpdateTableSchema(t *testing.T) {
 
 					t.Log("db:", pgResource.DBDsn)
 
-					rs := redshift.New(config.Default, logger.NOP, stats.Default)
+					rs := redshift.New(config.New(), logger.NOP, memstats.New())
 					rs.DB = sqlmiddleware.New(pgResource.DB)
 					rs.Namespace = testNamespace
 
 					ujf := &UploadJobFactory{
-						conf:         config.Default,
+						conf:         config.New(),
 						logger:       logger.NOP,
-						statsFactory: stats.Default,
+						statsFactory: memstats.New(),
 						db:           sqlmiddleware.New(pgResource.DB),
 					}
 
@@ -317,14 +316,14 @@ func TestUploadJobT_UpdateTableSchema(t *testing.T) {
 
 			t.Log("db:", pgResource.DBDsn)
 
-			rs := redshift.New(config.Default, logger.NOP, stats.Default)
+			rs := redshift.New(config.New(), logger.NOP, memstats.New())
 			rs.DB = sqlmiddleware.New(pgResource.DB)
 			rs.Namespace = testNamespace
 
 			ujf := &UploadJobFactory{
-				conf:         config.Default,
+				conf:         config.New(),
 				logger:       logger.NOP,
-				statsFactory: stats.Default,
+				statsFactory: memstats.New(),
 				db:           sqlmiddleware.New(pgResource.DB),
 			}
 

--- a/warehouse/slave/slave_test.go
+++ b/warehouse/slave/slave_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
 
 	"github.com/rudderlabs/rudder-server/warehouse/bcm"
@@ -29,7 +31,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 )
@@ -95,18 +96,18 @@ func TestSlave(t *testing.T) {
 	workerJobs := 25
 
 	tenantManager := multitenant.New(
-		config.Default,
+		config.New(),
 		backendconfig.DefaultBackendConfig,
 	)
 
 	slave := New(
-		config.Default,
+		config.New(),
 		logger.NOP,
-		stats.Default,
+		memstats.New(),
 		slaveNotifier,
-		bcm.New(config.Default, nil, tenantManager, logger.NOP, stats.Default),
-		constraints.New(config.Default),
-		encoding.NewFactory(config.Default),
+		bcm.New(config.New(), nil, tenantManager, logger.NOP, memstats.New()),
+		constraints.New(config.New()),
+		encoding.NewFactory(config.New()),
 	)
 	slave.config.noOfSlaveWorkerRoutines = workers
 

--- a/warehouse/slave/worker_job_test.go
+++ b/warehouse/slave/worker_job_test.go
@@ -198,7 +198,7 @@ func TestSlaveJob(t *testing.T) {
 				StagingFileLocation: uf.ObjectName,
 			}
 
-			jr := newJobRun(p, config.Default, logger.NOP, stats.Default, encoding.NewFactory(config.Default))
+			jr := newJobRun(p, config.New(), logger.NOP, memstats.New(), encoding.NewFactory(config.New()))
 
 			defer jr.cleanup()
 
@@ -226,7 +226,7 @@ func TestSlaveJob(t *testing.T) {
 
 			statsStore := memstats.New()
 
-			jr := newJobRun(p, config.Default, logger.NOP, statsStore, encoding.NewFactory(config.Default))
+			jr := newJobRun(p, config.New(), logger.NOP, statsStore, encoding.NewFactory(config.New()))
 
 			defer jr.cleanup()
 
@@ -263,7 +263,7 @@ func TestSlaveJob(t *testing.T) {
 
 			statsStore := memstats.New()
 
-			jr := newJobRun(p, config.Default, logger.NOP, statsStore, encoding.NewFactory(config.Default))
+			jr := newJobRun(p, config.New(), logger.NOP, statsStore, encoding.NewFactory(config.New()))
 
 			defer jr.cleanup()
 
@@ -296,7 +296,7 @@ func TestSlaveJob(t *testing.T) {
 				StagingDestinationRevisionID: uuid.New().String(),
 			}
 
-			jr := newJobRun(p, config.Default, logger.NOP, stats.Default, encoding.NewFactory(config.Default))
+			jr := newJobRun(p, config.New(), logger.NOP, memstats.New(), encoding.NewFactory(config.New()))
 
 			defer jr.cleanup()
 
@@ -323,7 +323,7 @@ func TestSlaveJob(t *testing.T) {
 			DestinationType: destType,
 		}
 
-		jr := newJobRun(p, config.Default, logger.NOP, stats.Default, encoding.NewFactory(config.Default))
+		jr := newJobRun(p, config.New(), logger.NOP, memstats.New(), encoding.NewFactory(config.New()))
 
 		defer jr.cleanup()
 
@@ -364,7 +364,7 @@ func TestSlaveJob(t *testing.T) {
 
 		now := time.Date(2020, 4, 27, 20, 0, 0, 0, time.UTC)
 
-		jr := newJobRun(p, config.Default, logger.NOP, stats.Default, encoding.NewFactory(config.Default))
+		jr := newJobRun(p, config.New(), logger.NOP, memstats.New(), encoding.NewFactory(config.New()))
 		jr.uuidTS = now
 		jr.now = func() time.Time {
 			return now
@@ -515,7 +515,7 @@ func TestSlaveJob(t *testing.T) {
 				c.Set("Warehouse.slaveUploadTimeout", "5m")
 				c.Set("WAREHOUSE_BUCKET_LOAD_OBJECTS_FOLDER_NAME", loadObjectFolder)
 
-				jr := newJobRun(job, c, logger.NOP, store, encoding.NewFactory(config.Default))
+				jr := newJobRun(job, c, logger.NOP, store, encoding.NewFactory(config.New()))
 				jr.since = func(t time.Time) time.Duration {
 					return time.Second
 				}

--- a/warehouse/slave/worker_test.go
+++ b/warehouse/slave/worker_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
 	"github.com/rudderlabs/rudder-server/warehouse/bcm"
 	"github.com/rudderlabs/rudder-server/warehouse/constraints"
 
@@ -25,7 +27,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/backend-config"
@@ -77,7 +78,7 @@ func TestSlaveWorker(t *testing.T) {
 		jobLocation := uploadFile(t, ctx, destConf, "testdata/staging.json.gz")
 
 		schemaMap := stagingSchema(t)
-		ef := encoding.NewFactory(config.Default)
+		ef := encoding.NewFactory(config.New())
 
 		t.Run("success", func(t *testing.T) {
 			subscribeCh := make(chan *notifier.ClaimJobResponse)
@@ -87,15 +88,15 @@ func TestSlaveWorker(t *testing.T) {
 				subscribeCh: subscribeCh,
 			}
 
-			tenantManager := multitenant.New(config.Default, backendconfig.DefaultBackendConfig)
+			tenantManager := multitenant.New(config.New(), backendconfig.DefaultBackendConfig)
 
 			slaveWorker := newWorker(
-				config.Default,
+				config.New(),
 				logger.NOP,
-				stats.Default,
+				memstats.New(),
 				slaveNotifier,
-				bcm.New(config.Default, nil, tenantManager, logger.NOP, stats.Default),
-				constraints.New(config.Default),
+				bcm.New(config.New(), nil, tenantManager, logger.NOP, memstats.New()),
+				constraints.New(config.New()),
 				ef,
 				workerIdx,
 			)
@@ -189,15 +190,15 @@ func TestSlaveWorker(t *testing.T) {
 				subscribeCh: subscribeCh,
 			}
 
-			tenantManager := multitenant.New(config.Default, backendconfig.DefaultBackendConfig)
+			tenantManager := multitenant.New(config.New(), backendconfig.DefaultBackendConfig)
 
 			slaveWorker := newWorker(
-				config.Default,
+				config.New(),
 				logger.NOP,
-				stats.Default,
+				memstats.New(),
 				slaveNotifier,
-				bcm.New(config.Default, nil, tenantManager, logger.NOP, stats.Default),
-				constraints.New(config.Default),
+				bcm.New(config.New(), nil, tenantManager, logger.NOP, memstats.New()),
+				constraints.New(config.New()),
 				ef,
 				workerIdx,
 			)
@@ -318,15 +319,15 @@ func TestSlaveWorker(t *testing.T) {
 			c := config.New()
 			c.Set("Warehouse.s3_datalake.columnCountLimit", 10)
 
-			tenantManager := multitenant.New(config.Default, backendconfig.DefaultBackendConfig)
+			tenantManager := multitenant.New(config.New(), backendconfig.DefaultBackendConfig)
 
 			slaveWorker := newWorker(
 				c,
 				logger.NOP,
-				stats.Default,
+				memstats.New(),
 				slaveNotifier,
-				bcm.New(config.Default, nil, tenantManager, logger.NOP, stats.Default),
-				constraints.New(config.Default),
+				bcm.New(config.New(), nil, tenantManager, logger.NOP, memstats.New()),
+				constraints.New(config.New()),
 				ef,
 				workerIdx,
 			)
@@ -387,15 +388,15 @@ func TestSlaveWorker(t *testing.T) {
 				subscribeCh: subscribeCh,
 			}
 
-			tenantManager := multitenant.New(config.Default, backendconfig.DefaultBackendConfig)
+			tenantManager := multitenant.New(config.New(), backendconfig.DefaultBackendConfig)
 
 			slaveWorker := newWorker(
-				config.Default,
+				config.New(),
 				logger.NOP,
-				stats.Default,
+				memstats.New(),
 				slaveNotifier,
-				bcm.New(config.Default, nil, tenantManager, logger.NOP, stats.Default),
-				constraints.New(config.Default),
+				bcm.New(config.New(), nil, tenantManager, logger.NOP, memstats.New()),
+				constraints.New(config.New()),
 				ef,
 				workerIdx,
 			)
@@ -540,9 +541,9 @@ func TestSlaveWorker(t *testing.T) {
 			return ch
 		}).AnyTimes()
 
-		tenantManager := multitenant.New(config.Default, mockBackendConfig)
-		bcm := bcm.New(config.Default, nil, tenantManager, logger.NOP, stats.Default)
-		ef := encoding.NewFactory(config.Default)
+		tenantManager := multitenant.New(config.New(), mockBackendConfig)
+		bcm := bcm.New(config.New(), nil, tenantManager, logger.NOP, memstats.New())
+		ef := encoding.NewFactory(config.New())
 
 		setupCh := make(chan struct{})
 		go func() {
@@ -568,10 +569,10 @@ func TestSlaveWorker(t *testing.T) {
 			slaveWorker := newWorker(
 				c,
 				logger.NOP,
-				stats.Default,
+				memstats.New(),
 				slaveNotifier,
 				bcm,
-				constraints.New(config.Default),
+				constraints.New(config.New()),
 				ef,
 				workerIdx,
 			)
@@ -634,10 +635,10 @@ func TestSlaveWorker(t *testing.T) {
 			slaveWorker := newWorker(
 				c,
 				logger.NOP,
-				stats.Default,
+				memstats.New(),
 				slaveNotifier,
 				bcm,
-				constraints.New(config.Default),
+				constraints.New(config.New()),
 				ef,
 				workerIdx,
 			)


### PR DESCRIPTION
# Description

- Avoid using global configuration in tests like (`config.Default`, `stats.Default`) to have better isolation.
- More about it in [here](https://github.com/rudderlabs/rudder-server/pull/4030#discussion_r1376313312).

## Linear Ticket

- Resolves PIPE-464

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
