### PR TITLE
fix: don't send error in stats

### DIFF
--- a/warehouse/router/router.go
+++ b/warehouse/router/router.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/warehouse/logfield"
+
 	"github.com/rudderlabs/rudder-server/warehouse/bcm"
 
 	"github.com/lib/pq"
@@ -594,10 +596,9 @@ func (r *Router) createJobs(ctx context.Context, warehouse model.Warehouse) (err
 			"workspaceId":   warehouse.WorkspaceID,
 			"destinationID": warehouse.Destination.ID,
 			"destType":      warehouse.Destination.DestinationDefinition.Name,
-			"reason":        err.Error(),
 		}).Count(1)
 
-		r.logger.Debugf("[WH]: Skipping upload loop since %s upload freq not exceeded: %v", warehouse.Identifier, err)
+		r.logger.Debugw("Skipping upload loop since upload freq not exceeded", logfield.Error, err.Error())
 
 		return nil
 	}


### PR DESCRIPTION
# Description

- Don't send errors in the stats as it can increase the cardinality.

## Linear Ticket

- Resolves PIPE-465

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
