### PR TITLE
fix: error index filtering for timestamp fields use int64

### DIFF
--- a/enterprise/reporting/error_index/types.go
+++ b/enterprise/reporting/error_index/types.go
@@ -34,8 +34,8 @@ type payload struct {
 	FailedStage      string `json:"failedStage" parquet:"name=failed_stage, type=BYTE_ARRAY, convertedtype=UTF8, encoding=RLE_DICTIONARY"`
 	EventType        string `json:"eventType" parquet:"name=event_type, type=BYTE_ARRAY, convertedtype=UTF8, encoding=RLE_DICTIONARY"`
 	EventName        string `json:"eventName" parquet:"name=event_name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=RLE_DICTIONARY"`
-	ReceivedAt       int64  `json:"receivedAt" parquet:"name=received_at, type=INT64, convertedtype=TIMESTAMP_MICROS, encoding=DELTA_BINARY_PACKED"` // In Microseconds
-	FailedAt         int64  `json:"failedAt" parquet:"name=failed_at, type=INT64, convertedtype=TIMESTAMP_MICROS, encoding=DELTA_BINARY_PACKED"`     // In Microseconds
+	ReceivedAt       int64  `json:"receivedAt" parquet:"name=received_at, type=INT64, encoding=DELTA_BINARY_PACKED"` // In Microseconds
+	FailedAt         int64  `json:"failedAt" parquet:"name=failed_at, type=INT64, encoding=DELTA_BINARY_PACKED"`     // In Microseconds
 }
 
 func (p *payload) SetReceivedAt(t time.Time) {


### PR DESCRIPTION
# Description

- Don't use the logical timestamps to store the `time.TIme` fields. Store it as INT64 itself.

## Linear Ticket

- Resolves PIPE-467

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
