### PR TITLE
feat(router): disable event order for users with event volume above threshold

### DIFF
--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -3,6 +3,7 @@ package router
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	customDestinationManager "github.com/rudderlabs/rudder-server/router/customdestinationmanager"
+	"github.com/rudderlabs/rudder-server/router/internal/eventorder"
 	"github.com/rudderlabs/rudder-server/router/internal/partition"
 	"github.com/rudderlabs/rudder-server/router/isolation"
 	"github.com/rudderlabs/rudder-server/router/transformer"
@@ -94,8 +96,10 @@ func (rt *Handle) Setup(
 
 	rt.enableBatching = config.GetBoolVar(false, "Router."+rt.destType+".enableBatching")
 
-	rt.drainConcurrencyLimit = getRouterConfigInt("drainedConcurrencyLimit", destType, 1)
-	rt.barrierConcurrencyLimit = getRouterConfigInt("barrierConcurrencyLimit", destType, 100)
+	rt.drainConcurrencyLimit = config.GetReloadableIntVar(1, 1, "Router."+destType+".eventOrderDrainedConcurrencyLimit", "Router.eventOrderDrainedConcurrencyLimit")
+	rt.eventOrderKeyThreshold = config.GetReloadableIntVar(200, 1, "Router."+destType+".eventOrderKeyThreshold", "Router.eventOrderKeyThreshold")
+	rt.eventOrderDisabledStateDuration = config.GetReloadableDurationVar(20, time.Minute, "Router."+destType+".eventOrderDisabledStateDuration", "Router.eventOrderDisabledStateDuration")
+	rt.eventOrderHalfEnabledStateDuration = config.GetReloadableDurationVar(10, time.Minute, "Router."+destType+".eventOrderHalfEnabledStateDuration", "Router.eventOrderHalfEnabledStateDuration")
 
 	statTags := stats.Tags{"destType": rt.destType}
 	rt.batchInputCountStat = stats.Default.NewTaggedStat("router_batch_num_input_jobs", stats.CountType, statTags)
@@ -124,6 +128,18 @@ func (rt *Handle) Setup(
 	}); err != nil {
 		panic(fmt.Errorf("resolving isolation strategy for mode %q: %w", isolationMode, err))
 	}
+
+	rt.barrier = eventorder.NewBarrier(eventorder.WithMetadata(map[string]string{
+		"destType":         rt.destType,
+		"batching":         strconv.FormatBool(rt.enableBatching),
+		"transformerProxy": strconv.FormatBool(rt.reloadableConfig.transformerProxy.Load()),
+	}),
+		eventorder.WithEventOrderKeyThreshold(rt.eventOrderKeyThreshold),
+		eventorder.WithDisabledStateDuration(rt.eventOrderDisabledStateDuration),
+		eventorder.WithHalfEnabledStateDuration(rt.eventOrderHalfEnabledStateDuration),
+		eventorder.WithDrainConcurrencyLimit(rt.drainConcurrencyLimit),
+		eventorder.WithDebugInfoProvider(rt.eventOrderDebugInfo),
+	)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	g, ctx := errgroup.WithContext(ctx)

--- a/router/internal/eventorder/eventorder_simulation_test.go
+++ b/router/internal/eventorder/eventorder_simulation_test.go
@@ -36,7 +36,7 @@ func TestSimulateBarrier(t *testing.T) {
 	defer cancel()
 
 	var logger log = t
-	barrier := eventorder.NewBarrier(eventorder.WithConcurrencyLimit(1))
+	barrier := eventorder.NewBarrier()
 	generator := &generatorLoop{ctx: ctx, barrier: barrier, batchSize: batchSize, pending: jobs, out: workerQueue, logger: logger}
 	worker := &workerProcess{ctx: ctx, barrier: barrier, in: workerQueue, out: statusQueue, logger: logger}
 	commit := &commitStatusLoop{ctx: ctx, barrier: barrier, in: statusQueue, putBack: generator.putBack, logger: logger}

--- a/router/partition_worker.go
+++ b/router/partition_worker.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
-	"github.com/rudderlabs/rudder-server/router/internal/eventorder"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
@@ -26,19 +25,11 @@ func newPartitionWorker(ctx context.Context, rt *Handle, partition string) *part
 	pw.workers = make([]*worker, rt.noOfWorkers)
 	for i := 0; i < rt.noOfWorkers; i++ {
 		worker := &worker{
-			logger:    pw.logger.Child("w-" + strconv.Itoa(i)),
-			partition: partition,
-			id:        i,
-			input:     make(chan workerJob, rt.workerInputBufferSize),
-			barrier: eventorder.NewBarrier(eventorder.WithMetadata(map[string]string{
-				"destType":         rt.destType,
-				"batching":         strconv.FormatBool(rt.enableBatching),
-				"transformerProxy": strconv.FormatBool(rt.reloadableConfig.transformerProxy.Load()),
-			}),
-				eventorder.WithConcurrencyLimit(rt.barrierConcurrencyLimit),
-				eventorder.WithDrainConcurrencyLimit(rt.drainConcurrencyLimit),
-				eventorder.WithDebugInfoProvider(rt.eventOrderDebugInfo),
-			),
+			logger:                    pw.logger.Child("w-" + strconv.Itoa(i)),
+			partition:                 partition,
+			id:                        i,
+			input:                     make(chan workerJob, rt.workerInputBufferSize),
+			barrier:                   rt.barrier,
 			rt:                        rt,
 			deliveryTimeStat:          stats.Default.NewTaggedStat("router_delivery_time", stats.TimerType, stats.Tags{"destType": rt.destType}),
 			batchTimeStat:             stats.Default.NewTaggedStat("router_batch_time", stats.TimerType, stats.Tags{"destType": rt.destType}),

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -208,17 +208,18 @@ func TestBackoff(t *testing.T) {
 				RetryTime:  time.Now().Add(-1 * time.Hour),
 			},
 		}
-
+		barrier := eventorder.NewBarrier()
 		r := &Handle{
 			logger:                logger.NOP,
 			backgroundCtx:         context.Background(),
 			noOfWorkers:           1,
 			workerInputBufferSize: 3,
+			barrier:               barrier,
 		}
 		workers := []*worker{{
 			logger:  logger.NOP,
 			input:   make(chan workerJob, 3),
-			barrier: eventorder.NewBarrier(),
+			barrier: barrier,
 		}}
 		t.Run("eventorder disabled", func(t *testing.T) {
 			r.guaranteeUserEventOrder = false


### PR DESCRIPTION
# Description

Replacing concurrency limiter introduced in #3243 with a different strategy which can be summarised as below:
- Whenever the concurrency limit is reached, event ordering (i.e. the barrier) will be disabled for this specific ordering key and router will start distributing events for that key evenly across its workers.
- A disabled barrier will transition to the half-enabled state after a configurable period (default: 20m).
- While in the half-enabled state, event ordering will be re-enabled, however the barrier will not panic if an illegal job sequence is detected. Why? Because multiple workers will be processing events for some time in parallel, so out-of-order delivery will be possible. 
- The barrier will finally transition to the enabled state after a configurable period (default: 10m) and as long as the concurrency limit isn't reached during that period. In the enabled state the barrier will panic if an illegal job sequence is detected.

**_Bonus:_** we are now using reloadable barrier configuration options.


## Design proposal document
https://www.notion.so/Design-Proposal-Bypassing-event-ordering-for-spammy-userIDs-5bf84d4fc2bd4aeb9f817f2aced4b8a0

## Linear Ticket

Resolves PIPE-148

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
