### PR TITLE
fix: minio heathcheck

### DIFF
--- a/warehouse/integrations/testdata/docker-compose.minio.yml
+++ b/warehouse/integrations/testdata/docker-compose.minio.yml
@@ -11,6 +11,6 @@ services:
       - MINIO_SITE_REGION=us-east-1
     command: server /data
     healthcheck:
-      test: curl --fail http://localhost:9000/minio/health/live || exit 1
+      test: timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
       interval: 1s
       retries: 25


### PR DESCRIPTION
# Description

- curl no longer available in container image, can no longer healthcheck. See more in [here](https://github.com/minio/minio/issues/18371).

## Linear Ticket

- Resolves PIPE-476

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
