### PR TITLE
chore: set gw rate limits at event level

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -884,10 +884,11 @@ var _ = Describe("Gateway", func() {
 		})
 
 		It("should reject messages if rate limit is reached for workspace", func() {
+			conf.Set("Gateway.allowReqsWithoutUserIDAndAnonymousID", true)
 			c.mockRateLimiter.EXPECT().CheckLimitReached(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 			expectHandlerResponse(
 				gateway.webAliasHandler(),
-				authorizedRequest(WriteKeyEnabled, bytes.NewBufferString("{}")),
+				authorizedRequest(WriteKeyEnabled, bytes.NewBufferString(`{"data": "valid-json"}`)),
 				http.StatusTooManyRequests,
 				response.TooManyRequests+"\n",
 				"alias",

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -844,7 +844,7 @@ var _ = Describe("Gateway", func() {
 		})
 
 		It("should store messages successfully if rate limit is not reached for workspace", func() {
-			c.mockRateLimiter.EXPECT().CheckLimitReached(gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
+			c.mockRateLimiter.EXPECT().CheckLimitReached(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 			c.mockJobsDB.EXPECT().WithStoreSafeTx(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx context.Context, f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())
 			}).Return(nil)
@@ -884,7 +884,7 @@ var _ = Describe("Gateway", func() {
 		})
 
 		It("should reject messages if rate limit is reached for workspace", func() {
-			c.mockRateLimiter.EXPECT().CheckLimitReached(gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+			c.mockRateLimiter.EXPECT().CheckLimitReached(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 			expectHandlerResponse(
 				gateway.webAliasHandler(),
 				authorizedRequest(WriteKeyEnabled, bytes.NewBufferString("{}")),

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -267,6 +267,9 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 		userIDHeader = req.userIDHeader
 		ipAddr       = req.ipAddr
 		body         = req.requestPayload
+
+		// values retrieved from first event in batch
+		sourcesJobRunID, sourcesTaskRunID = req.authContext.SourceJobRunID, req.authContext.SourceTaskRunID
 	)
 
 	fillMessageID := func(event map[string]interface{}) {
@@ -295,18 +298,6 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 	eventsBatch := gjson.GetBytes(body, "batch").Array()
 	jobData.numEvents = len(eventsBatch)
 
-	if gw.conf.enableRateLimit.Load() {
-		// In case of "batch" requests, if rate-limiter returns true for LimitReached, just drop the event batch and continue.
-		ok, errCheck := gw.rateLimiter.CheckLimitReached(context.TODO(), workspaceId, int64(len(eventsBatch)))
-		if errCheck != nil {
-			gw.stats.NewTaggedStat("gateway.rate_limiter_error", stats.CountType, stats.Tags{"workspaceId": workspaceId}).Increment()
-			gw.logger.Errorf("Rate limiter error: %v Allowing the request", errCheck)
-		}
-		if ok {
-			return jobData, errRequestDropped
-		}
-	}
-
 	type jobObject struct {
 		userID string
 		events []map[string]interface{}
@@ -317,8 +308,6 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 		out []jobObject
 
 		marshalledParams []byte
-		// values retrieved from first event in batch
-		sourcesJobRunID, sourcesTaskRunID = req.authContext.SourceJobRunID, req.authContext.SourceTaskRunID
 
 		// facts about the batch populated as we iterate over events
 		containsAudienceList, suppressed bool
@@ -406,6 +395,18 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 			userID: userID,
 			events: []map[string]interface{}{toSet},
 		})
+	}
+
+	if gw.conf.enableRateLimit.Load() && sourcesJobRunID == "" && sourcesTaskRunID == "" {
+		// In case of "batch" requests, if rate-limiter returns true for LimitReached, just drop the event batch and continue.
+		ok, errCheck := gw.rateLimiter.CheckLimitReached(context.TODO(), workspaceId, int64(len(eventsBatch)))
+		if errCheck != nil {
+			gw.stats.NewTaggedStat("gateway.rate_limiter_error", stats.CountType, stats.Tags{"workspaceId": workspaceId}).Increment()
+			gw.logger.Errorf("Rate limiter error: %v Allowing the request", errCheck)
+		}
+		if ok {
+			return jobData, errRequestDropped
+		}
 	}
 
 	if len(out) == 0 && suppressed {

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -297,7 +297,7 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 
 	if gw.conf.enableRateLimit.Load() {
 		// In case of "batch" requests, if rate-limiter returns true for LimitReached, just drop the event batch and continue.
-		ok, errCheck := gw.rateLimiter.CheckLimitReached(context.TODO(), workspaceId)
+		ok, errCheck := gw.rateLimiter.CheckLimitReached(context.TODO(), workspaceId, int64(len(eventsBatch)))
 		if errCheck != nil {
 			gw.stats.NewTaggedStat("gateway.rate_limiter_error", stats.CountType, stats.Tags{"workspaceId": workspaceId}).Increment()
 			gw.logger.Errorf("Rate limiter error: %v Allowing the request", errCheck)

--- a/gateway/throttler/throttler_test.go
+++ b/gateway/throttler/throttler_test.go
@@ -34,14 +34,14 @@ func TestGateway_Throttler(t *testing.T) {
 	}
 
 	for i := 0; i < eventLimit; i++ {
-		_, err := testThrottler.checkLimitReached(context.TODO(), workspaceId)
+		_, err := testThrottler.checkLimitReached(context.TODO(), workspaceId, 1)
 		require.NoError(t, err)
 	}
 
 	startTime := time.Now()
 	var passed int
 	for i := 0; i < 2*eventLimit; i++ {
-		allowed, err := testThrottler.checkLimitReached(context.TODO(), workspaceId)
+		allowed, err := testThrottler.checkLimitReached(context.TODO(), workspaceId, 1)
 		require.NoError(t, err)
 		if allowed {
 			passed++
@@ -69,14 +69,14 @@ func TestGateway_Factory(t *testing.T) {
 	require.NotNil(t, rateLimiter)
 
 	for i := 0; i < eventLimit; i++ {
-		_, err := rateLimiter.CheckLimitReached(context.TODO(), workspaceId)
+		_, err := rateLimiter.CheckLimitReached(context.TODO(), workspaceId, 1)
 		require.NoError(t, err)
 	}
 
 	startTime := time.Now()
 	var passed int
 	for i := 0; i < 2*eventLimit; i++ {
-		allowed, err := rateLimiter.CheckLimitReached(context.TODO(), workspaceId)
+		allowed, err := rateLimiter.CheckLimitReached(context.TODO(), workspaceId, 1)
 		require.NoError(t, err)
 		if allowed {
 			passed++

--- a/mocks/gateway/throttler.go
+++ b/mocks/gateway/throttler.go
@@ -35,16 +35,16 @@ func (m *MockThrottler) EXPECT() *MockThrottlerMockRecorder {
 }
 
 // CheckLimitReached mocks base method.
-func (m *MockThrottler) CheckLimitReached(arg0 context.Context, arg1 string) (bool, error) {
+func (m *MockThrottler) CheckLimitReached(arg0 context.Context, arg1 string, arg2 int64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckLimitReached", arg0, arg1)
+	ret := m.ctrl.Call(m, "CheckLimitReached", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CheckLimitReached indicates an expected call of CheckLimitReached.
-func (mr *MockThrottlerMockRecorder) CheckLimitReached(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockThrottlerMockRecorder) CheckLimitReached(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckLimitReached", reflect.TypeOf((*MockThrottler)(nil).CheckLimitReached), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckLimitReached", reflect.TypeOf((*MockThrottler)(nil).CheckLimitReached), arg0, arg1, arg2)
 }


### PR DESCRIPTION
# Description

Tweaking the existing GW Rate Limiter to throttle based on the incoming events rather than requests

## Linear Ticket

Fixes PIPE-475

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
