### PR TITLE
feat: new sources endpoints

### DIFF
--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -365,11 +365,11 @@ func (gw *Handle) StartWebHandler(ctx context.Context) error {
 	)
 	failedKeysHandler := rsources_http.FailedKeysHandler(
 		gw.rsourcesService,
-		gw.logger.Child("rsources-failed-keys"),
+		gw.logger.Child("rsources_failed_keys"),
 	)
 	jobStatusHandler := rsources_http.JobStatusHandler(
 		gw.rsourcesService,
-		gw.logger.Child("rsources-job-status"),
+		gw.logger.Child("rsources_job_status"),
 	)
 	srvMux.Use(
 		chiware.StatMiddleware(ctx, stats.Default, component),
@@ -387,8 +387,6 @@ func (gw *Handle) StartWebHandler(ctx context.Context) error {
 		r.Mount("/v2/job-status", withContentType("application/json; charset=utf-8", jobStatusHandler.ServeHTTP))
 	})
 	srvMux.Mount("/v1/job-status", withContentType("application/json; charset=utf-8", rsourcesHandler.ServeHTTP))
-	srvMux.Mount("/v2/failed-keys", withContentType("application/json; charset=utf-8", failedKeysHandler.ServeHTTP))
-	srvMux.Mount("/v2/job-status", withContentType("application/json; charset=utf-8", jobStatusHandler.ServeHTTP))
 
 	srvMux.Route("/v1", func(r chi.Router) {
 		r.Post("/alias", gw.webAliasHandler())

--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -359,9 +359,18 @@ func (gw *Handle) StartWebHandler(ctx context.Context) error {
 	component := "gateway"
 	srvMux := chi.NewRouter()
 	// rudder-sources new APIs
-	rsourcesHandler := rsources_http.NewHandler(
+	rsourcesHandler := rsources_http.NewV1Handler(
 		gw.rsourcesService,
-		gw.logger.Child("rsources"))
+		gw.logger.Child("rsources"),
+	)
+	failedKeysHandler := rsources_http.FailedKeysHandler(
+		gw.rsourcesService,
+		gw.logger.Child("rsources-failed-keys"),
+	)
+	jobStatusHandler := rsources_http.JobStatusHandler(
+		gw.rsourcesService,
+		gw.logger.Child("rsources-job-status"),
+	)
 	srvMux.Use(
 		chiware.StatMiddleware(ctx, stats.Default, component),
 		middleware.LimitConcurrentRequests(gw.conf.maxConcurrentRequests),
@@ -374,8 +383,12 @@ func (gw *Handle) StartWebHandler(ctx context.Context) error {
 		r.Post("/v1/audiencelist", gw.webAudienceListHandler())
 		r.Post("/v1/replay", gw.webReplayHandler())
 		r.Mount("/v1/job-status", withContentType("application/json; charset=utf-8", rsourcesHandler.ServeHTTP))
+		r.Mount("/v2/failed-keys", withContentType("application/json; charset=utf-8", failedKeysHandler.ServeHTTP))
+		r.Mount("/v2/job-status", withContentType("application/json; charset=utf-8", jobStatusHandler.ServeHTTP))
 	})
 	srvMux.Mount("/v1/job-status", withContentType("application/json; charset=utf-8", rsourcesHandler.ServeHTTP))
+	srvMux.Mount("/v2/failed-keys", withContentType("application/json; charset=utf-8", failedKeysHandler.ServeHTTP))
+	srvMux.Mount("/v2/job-status", withContentType("application/json; charset=utf-8", jobStatusHandler.ServeHTTP))
 
 	srvMux.Route("/v1", func(r chi.Router) {
 		r.Post("/alias", gw.webAliasHandler())

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -307,11 +307,7 @@ func (sh *sourcesHandler) DeleteJobStatus(ctx context.Context, jobRunId string, 
 	}
 	filters, filterParams := sqlFilters(jobRunId, filter)
 	sqlStatement := fmt.Sprintf(`delete from "rsources_stats" %s`, filters)
-	res, err := sh.localDB.ExecContext(ctx, sqlStatement, filterParams...)
-	if err != nil {
-		return err
-	}
-	if _, err := res.RowsAffected(); err != nil {
+	if _, err := sh.localDB.ExecContext(ctx, sqlStatement, filterParams...); err != nil {
 		return err
 	}
 	return nil

--- a/services/rsources/handlerv2_test.go
+++ b/services/rsources/handlerv2_test.go
@@ -1,0 +1,175 @@
+package rsources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/ory/dockertest/v3"
+
+	testlog "github.com/rudderlabs/rudder-server/testhelper/log"
+)
+
+var _ = Describe("Using sources handler", func() {
+	var noPaging PagingInfo
+	Context("single-tenant setup with a single local datasource", Ordered, func() {
+		var (
+			pool     *dockertest.Pool
+			resource postgresResource
+			sh       JobService
+		)
+		stats := Stats{
+			In:     10,
+			Out:    4,
+			Failed: 6,
+		}
+		BeforeAll(func() {
+			var err error
+			pool, err = dockertest.NewPool("")
+			Expect(err).NotTo(HaveOccurred())
+			resource = newDBResource(pool, "", "postgres")
+			config := JobServiceConfig{
+				LocalHostname: "postgres",
+				MaxPoolSize:   1,
+				LocalConn:     resource.externalDSN,
+				Log:           testlog.GinkgoLogger,
+			}
+			sh = createService(config)
+		})
+
+		AfterAll(func() {
+			purgeResources(pool, resource.resource)
+		})
+
+		It("should be able to delete failed keys", func() {
+			jobRunId := newJobRunId()
+			increment(resource.db, jobRunId, defaultJobTargetKey, stats, sh, nil)
+			addFailedRecords(resource.db, jobRunId, defaultJobTargetKey, sh, []json.RawMessage{
+				[]byte(`{"record-1": "id-1"}`),
+				[]byte(`{"record-2": "id-2"}`),
+			})
+			err := sh.DeleteFailedRecords(context.Background(), jobRunId, JobFilter{})
+			Expect(err).NotTo(HaveOccurred(), "it should be able to delete failed keys for the jobrunid")
+			jobFilters := JobFilter{
+				SourceID:  []string{"source_id"},
+				TaskRunID: []string{"task_run_id"},
+			}
+			status, err := sh.GetStatus(context.Background(), jobRunId, jobFilters)
+			Expect(err).To(BeNil())
+			Expect(status).To(Equal(JobStatus{
+				ID: jobRunId,
+				TasksStatus: []TaskStatus{
+					{
+						ID: "task_run_id",
+						SourcesStatus: []SourceStatus{
+							{
+								ID:        "source_id",
+								Completed: true,
+								Stats:     Stats{In: 0, Out: 0, Failed: 0},
+								DestinationsStatus: []DestinationStatus{
+									{
+										ID:        "destination_id",
+										Completed: true,
+										Stats:     Stats{In: 10, Out: 4, Failed: 6},
+									},
+								},
+							},
+						},
+					},
+				},
+			}))
+			failedRecords, err := sh.GetFailedRecords(context.Background(), jobRunId, jobFilters, noPaging)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(failedRecords).To(Equal(JobFailedRecords{ID: jobRunId}))
+		})
+
+		It("should be able to delete stats only", func() {
+			otherJobTargetKey := defaultJobTargetKey
+			otherJobTargetKey.SourceID = "other_source_id"
+			jobRunId := newJobRunId()
+			increment(resource.db, jobRunId, defaultJobTargetKey, stats, sh, nil)
+			increment(resource.db, jobRunId, otherJobTargetKey, stats, sh, nil)
+
+			addFailedRecords(resource.db, jobRunId, defaultJobTargetKey, sh, []json.RawMessage{
+				[]byte(`{"record-1": "id-1"}`),
+				[]byte(`{"record-2": "id-2"}`),
+			})
+			addFailedRecords(resource.db, jobRunId, otherJobTargetKey, sh, []json.RawMessage{
+				[]byte(`{"record-1": "id-1"}`),
+				[]byte(`{"record-2": "id-2"}`),
+			})
+			err := sh.DeleteJobStatus(context.Background(), jobRunId, JobFilter{SourceID: []string{"other_source_id"}})
+			Expect(err).NotTo(HaveOccurred(), "it should be able to delete stats for the jobrunid")
+
+			jobFilters := JobFilter{
+				SourceID:  []string{"other_source_id"},
+				TaskRunID: []string{"task_run_id"},
+			}
+			status, err := sh.GetStatus(context.Background(), jobRunId, jobFilters)
+			Expect(err).To(HaveOccurred())
+			Expect(status).To(Equal(JobStatus{}))
+			Expect(errors.Is(err, ErrStatusNotFound)).To(BeTrue(), "it should return a StatusNotFoundError")
+			failedRecords, err := sh.GetFailedRecords(context.Background(), jobRunId, jobFilters, noPaging)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(failedRecords).To(Equal(
+				JobFailedRecords{
+					ID: jobRunId,
+					Tasks: []TaskFailedRecords{
+						{
+							ID: "task_run_id",
+							Sources: []SourceFailedRecords{
+								{
+									ID: "other_source_id",
+									Destinations: []DestinationFailedRecords{
+										{
+											ID: "destination_id",
+											Records: []json.RawMessage{
+												[]byte(`{"record-1": "id-1"}`),
+												[]byte(`{"record-2": "id-2"}`),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			))
+
+			jobFilters.SourceID = []string{defaultJobTargetKey.SourceID}
+			_, err = sh.GetStatus(context.Background(), jobRunId, jobFilters)
+			Expect(err).ToNot(HaveOccurred())
+			failedRecords, err = sh.GetFailedRecords(context.Background(), jobRunId, jobFilters, noPaging)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(failedRecords).ToNot(Equal(JobFailedRecords{ID: jobRunId}))
+		})
+
+		It("shouldn't be able to delete stats for an incomplete source", func() {
+			jobRunId := newJobRunId()
+			stats := Stats{
+				In:     10,
+				Out:    4,
+				Failed: 5,
+			}
+			increment(resource.db, jobRunId, defaultJobTargetKey, stats, sh, nil)
+
+			err := sh.DeleteJobStatus(context.Background(), jobRunId, JobFilter{SourceID: []string{defaultJobTargetKey.SourceID}})
+			Expect(err).To(Equal(ErrSourceNotCompleted), "it shouldn't be able to delete stats for an incomplete source")
+		})
+
+		It("shouldn't be able to delete stats for an invalid job", func() {
+			jobRunId := newJobRunId()
+			stats := Stats{
+				In:     10,
+				Out:    4,
+				Failed: 5,
+			}
+			increment(resource.db, jobRunId, defaultJobTargetKey, stats, sh, nil)
+
+			err := sh.DeleteJobStatus(context.Background(), "invalidJobRunId", JobFilter{SourceID: []string{defaultJobTargetKey.SourceID}})
+			Expect(err).To(Equal(ErrStatusNotFound), "it shouldn't be able to delete stats for an invalid jobrunid")
+		})
+	})
+})

--- a/services/rsources/http/http.go
+++ b/services/rsources/http/http.go
@@ -43,7 +43,6 @@ func FailedKeysHandler(service rsources.JobService, logger logger.Logger) http.H
 	}
 	srvMux := chi.NewRouter()
 	srvMux.Delete("/{job_run_id}", h.deleteFailedRecords)
-	srvMux.Get("/{job_run_id}", h.failedRecords)
 	return srvMux
 }
 

--- a/services/rsources/http/http_integration_test.go
+++ b/services/rsources/http/http_integration_test.go
@@ -355,6 +355,5 @@ func TestDeleteEndpoints(t *testing.T) {
 			require.Len(t, failedRecords.Tasks, 0)
 			require.Nil(t, failedRecords.Paging, "no paging information should be present")
 		})
-
 	})
 }

--- a/services/rsources/http/http_integration_test.go
+++ b/services/rsources/http/http_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -23,15 +24,18 @@ import (
 func prepare(
 	t *testing.T,
 	handlerType func(service rsources.JobService, logger logger.Logger) http.Handler,
+	postgresContainer *resource.PostgresResource,
 ) (
 	handler http.Handler,
 	service rsources.JobService,
-	db *sql.DB,
+	dbResource *resource.PostgresResource,
 ) {
-	pool, err := dockertest.NewPool("")
-	require.NoError(t, err)
-	postgresContainer, err := resource.SetupPostgres(pool, t)
-	require.NoError(t, err)
+	if postgresContainer == nil {
+		pool, err := dockertest.NewPool("")
+		require.NoError(t, err)
+		postgresContainer, err = resource.SetupPostgres(pool, t)
+		require.NoError(t, err)
+	}
 
 	config := rsources.JobServiceConfig{
 		LocalHostname: postgresContainer.Host,
@@ -39,10 +43,10 @@ func prepare(
 		LocalConn:     postgresContainer.DBDsn,
 		Log:           logger.NOP,
 	}
-	service, err = rsources.NewJobService(config)
+	service, err := rsources.NewJobService(config)
 	require.NoError(t, err)
 	handler = handlerType(service, logger.NOP)
-	db = postgresContainer.DB
+	dbResource = postgresContainer
 	return
 }
 
@@ -73,6 +77,7 @@ func getFailedRecords(
 	pageSize int,
 	pageToken,
 	endpoint string,
+	failedKeysResponseCode int,
 ) *rsources.JobFailedRecords {
 	params := url.Values{}
 	if pageSize > 0 {
@@ -88,19 +93,20 @@ func getFailedRecords(
 	require.NoError(t, err)
 	resp := httptest.NewRecorder()
 	handler.ServeHTTP(resp, req)
-	require.Equal(t, http.StatusOK, resp.Code)
+	require.Equal(t, failedKeysResponseCode, resp.Code)
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
+	fmt.Println(`!!!!!!!!!!!!!`)
+	fmt.Println(string(body))
 	var failedRecords rsources.JobFailedRecords
-	err = json.Unmarshal(body, &failedRecords)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(body, &failedRecords))
 	return &failedRecords
 }
 
 func TestGetFailedRecordsIntegration(t *testing.T) {
 	t.Run("without pagination", func(t *testing.T) {
-		handler, service, db := prepare(t, rsources_http.NewV1Handler)
-		addFailedRecords(t, service, db, []json.RawMessage{
+		handler, service, dbResource := prepare(t, rsources_http.NewV1Handler, nil)
+		addFailedRecords(t, service, dbResource.DB, []json.RawMessage{
 			[]byte(`"id-1"`),
 			[]byte(`"id-2"`),
 			[]byte(`"id-3"`),
@@ -114,6 +120,7 @@ func TestGetFailedRecordsIntegration(t *testing.T) {
 			pageSize,
 			pageToken,
 			"jobRunID/failed-records",
+			http.StatusOK,
 		)
 		require.NotNil(t, failedRecords)
 		require.Len(t, failedRecords.Tasks, 1)
@@ -124,8 +131,8 @@ func TestGetFailedRecordsIntegration(t *testing.T) {
 	})
 
 	t.Run("with pagination", func(t *testing.T) {
-		handler, service, db := prepare(t, rsources_http.NewV1Handler)
-		addFailedRecords(t, service, db, []json.RawMessage{
+		handler, service, dbResource := prepare(t, rsources_http.NewV1Handler, nil)
+		addFailedRecords(t, service, dbResource.DB, []json.RawMessage{
 			[]byte(`"id-1"`),
 			[]byte(`"id-2"`),
 			[]byte(`"id-3"`),
@@ -140,6 +147,7 @@ func TestGetFailedRecordsIntegration(t *testing.T) {
 				pageSize,
 				pageToken,
 				"jobRunID/failed-records",
+				http.StatusOK,
 			)
 			require.NotNil(t, failedRecords)
 			require.Len(t, failedRecords.Tasks, 1)
@@ -158,57 +166,8 @@ func TestGetFailedRecordsIntegration(t *testing.T) {
 			pageSize,
 			pageToken,
 			"jobRunID/failed-records",
+			http.StatusOK,
 		)
-		require.NotNil(t, failedRecords)
-		require.Len(t, failedRecords.Tasks, 0)
-		require.Nil(t, failedRecords.Paging, "no paging information should be present")
-	})
-}
-
-func TestFailedRecordsV2(t *testing.T) {
-	t.Run("without pagination", func(t *testing.T) {
-		handler, service, db := prepare(t, rsources_http.FailedKeysHandler)
-		addFailedRecords(t, service, db, []json.RawMessage{
-			[]byte(`"id-1"`),
-			[]byte(`"id-2"`),
-			[]byte(`"id-3"`),
-			[]byte(`"id-4"`),
-		})
-		pageSize := 0
-		pageToken := ""
-		failedRecords := getFailedRecords(t, handler, pageSize, pageToken, "jobRunID")
-		require.NotNil(t, failedRecords)
-		require.Len(t, failedRecords.Tasks, 1)
-		require.Len(t, failedRecords.Tasks[0].Sources, 1)
-		require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations, 1)
-		require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations[0].Records, 4)
-		require.Nil(t, failedRecords.Paging, "no paging information should be present")
-	})
-
-	t.Run("with pagination", func(t *testing.T) {
-		handler, service, db := prepare(t, rsources_http.FailedKeysHandler)
-		addFailedRecords(t, service, db, []json.RawMessage{
-			[]byte(`"id-1"`),
-			[]byte(`"id-2"`),
-			[]byte(`"id-3"`),
-			[]byte(`"id-4"`),
-		})
-		pageSize := 2
-		pageToken := ""
-		for i := 0; i < 2; i++ { // 2 pages are retrieved with 2 records each and where paging is present
-			failedRecords := getFailedRecords(t, handler, pageSize, pageToken, "jobRunID")
-			require.NotNil(t, failedRecords)
-			require.Len(t, failedRecords.Tasks, 1)
-			require.Len(t, failedRecords.Tasks[0].Sources, 1)
-			require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations, 1)
-			require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations[0].Records, pageSize)
-			require.NotNil(t, failedRecords.Paging, "paging information should be present")
-			require.Equal(t, pageSize, failedRecords.Paging.Size)
-			pageToken = failedRecords.Paging.NextPageToken
-		}
-
-		// 3 page is retrieved with 0 records and where paging is not present
-		failedRecords := getFailedRecords(t, handler, pageSize, pageToken, "jobRunID")
 		require.NotNil(t, failedRecords)
 		require.Len(t, failedRecords.Tasks, 0)
 		require.Nil(t, failedRecords.Paging, "no paging information should be present")
@@ -217,15 +176,16 @@ func TestFailedRecordsV2(t *testing.T) {
 
 func TestDeleteEndpoints(t *testing.T) {
 	t.Run("v2 delete endpoints delete only failed-keys", func(t *testing.T) {
-		fkHandler, service, db := prepare(t, rsources_http.FailedKeysHandler)
-		addFailedRecords(t, service, db, []json.RawMessage{
+		fkHandler, service, dbResource := prepare(t, rsources_http.FailedKeysHandler, nil)
+		v1Handler, _, _ := prepare(t, rsources_http.NewV1Handler, dbResource)
+		addFailedRecords(t, service, dbResource.DB, []json.RawMessage{
 			[]byte(`"id-1"`),
 			[]byte(`"id-2"`),
 			[]byte(`"id-3"`),
 			[]byte(`"id-4"`),
 		})
 		jsHandler := rsources_http.JobStatusHandler(service, logger.NOP)
-		tx, err := db.Begin()
+		tx, err := dbResource.DB.Begin()
 		require.NoError(t, err)
 		require.NoError(
 			t,
@@ -246,21 +206,15 @@ func TestDeleteEndpoints(t *testing.T) {
 			),
 		)
 		require.NoError(t, tx.Commit())
-		t.Run("should retrieve failed keys from v2 endpoint", func(t *testing.T) {
-			failedRecords := getFailedRecords(t, fkHandler, 10, "", "jobRunID")
-			require.NotNil(t, failedRecords)
-			require.Len(t, failedRecords.Tasks, 1)
-			require.Nil(t, failedRecords.Paging, "no paging information should be present")
-		})
 		t.Run("calling v2 failed-keys delete should only delete failed keys", func(t *testing.T) {
 			req, err := http.NewRequest("DELETE", "http://localhost/jobRunID", nil)
 			require.NoError(t, err)
 			resp := httptest.NewRecorder()
 			fkHandler.ServeHTTP(resp, req)
 			require.Equal(t, http.StatusNoContent, resp.Code)
-			failedRecords := getFailedRecords(t, fkHandler, 10, "", "jobRunID")
+			failedRecords := getFailedRecords(t, v1Handler, 10, "", "jobRunID", http.StatusOK)
 			require.NotNil(t, failedRecords)
-			require.Len(t, failedRecords.Tasks, 0)
+			require.Len(t, failedRecords.Tasks, 1)
 			require.Nil(t, failedRecords.Paging, "no paging information should be present")
 
 			req, err = http.NewRequest("GET", "http://localhost/jobRunID", nil)
@@ -283,15 +237,15 @@ func TestDeleteEndpoints(t *testing.T) {
 	})
 
 	t.Run("v2 delete endpoints delete only job-status", func(t *testing.T) {
-		fkHandler, service, db := prepare(t, rsources_http.FailedKeysHandler)
-		addFailedRecords(t, service, db, []json.RawMessage{
+		v1Handler, service, dbResource := prepare(t, rsources_http.NewV1Handler, nil)
+		jsHandler := rsources_http.JobStatusHandler(service, logger.NOP)
+		addFailedRecords(t, service, dbResource.DB, []json.RawMessage{
 			[]byte(`"id-1"`),
 			[]byte(`"id-2"`),
 			[]byte(`"id-3"`),
 			[]byte(`"id-4"`),
 		})
-		jsHandler := rsources_http.JobStatusHandler(service, logger.NOP)
-		tx, err := db.Begin()
+		tx, err := dbResource.DB.Begin()
 		require.NoError(t, err)
 		require.NoError(
 			t,
@@ -307,7 +261,7 @@ func TestDeleteEndpoints(t *testing.T) {
 				rsources.Stats{
 					In:     15,
 					Out:    6,
-					Failed: 4,
+					Failed: 9,
 				},
 			),
 		)
@@ -329,15 +283,13 @@ func TestDeleteEndpoints(t *testing.T) {
 			require.Len(t, jobStatus.TasksStatus[0].SourcesStatus[0].DestinationsStatus, 1)
 			require.Equal(t, uint(15), jobStatus.TasksStatus[0].SourcesStatus[0].DestinationsStatus[0].Stats.In)
 			require.Equal(t, uint(6), jobStatus.TasksStatus[0].SourcesStatus[0].DestinationsStatus[0].Stats.Out)
-			require.Equal(t, uint(4), jobStatus.TasksStatus[0].SourcesStatus[0].DestinationsStatus[0].Stats.Failed)
+			require.Equal(t, uint(9), jobStatus.TasksStatus[0].SourcesStatus[0].DestinationsStatus[0].Stats.Failed)
 
 			req, err = http.NewRequest("DELETE", "http://localhost/jobRunID", nil)
 			require.NoError(t, err)
 			resp = httptest.NewRecorder()
 			jsHandler.ServeHTTP(resp, req)
 			require.Equal(t, http.StatusNoContent, resp.Code)
-			failedRecords := getFailedRecords(t, fkHandler, 10, "", "jobRunID")
-			require.NotNil(t, failedRecords)
 
 			req, err = http.NewRequest("GET", "http://localhost/jobRunID", nil)
 			require.NoError(t, err)
@@ -345,15 +297,13 @@ func TestDeleteEndpoints(t *testing.T) {
 			jsHandler.ServeHTTP(resp, req)
 			require.Equal(t, http.StatusNotFound, resp.Code)
 
-			req, err = http.NewRequest("DELETE", "http://localhost/jobRunID", nil)
-			require.NoError(t, err)
-			resp = httptest.NewRecorder()
-			fkHandler.ServeHTTP(resp, req)
-			require.Equal(t, http.StatusNoContent, resp.Code)
-			failedRecords = getFailedRecords(t, fkHandler, 10, "", "jobRunID")
+			failedRecords := getFailedRecords(t, v1Handler, 10, "", "jobRunID/failed-records", http.StatusOK)
 			require.NotNil(t, failedRecords)
-			require.Len(t, failedRecords.Tasks, 0)
+			require.Len(t, failedRecords.Tasks, 1)
 			require.Nil(t, failedRecords.Paging, "no paging information should be present")
+			require.Len(t, failedRecords.Tasks[0].Sources, 1)
+			require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations, 1)
+			require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations[0].Records, 4)
 		})
 	})
 }

--- a/services/rsources/http/http_integration_test.go
+++ b/services/rsources/http/http_integration_test.go
@@ -20,68 +20,86 @@ import (
 	rsources_http "github.com/rudderlabs/rudder-server/services/rsources/http"
 )
 
+func prepare(
+	t *testing.T,
+	handlerType func(service rsources.JobService, logger logger.Logger) http.Handler,
+) (
+	handler http.Handler,
+	service rsources.JobService,
+	db *sql.DB,
+) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	postgresContainer, err := resource.SetupPostgres(pool, t)
+	require.NoError(t, err)
+
+	config := rsources.JobServiceConfig{
+		LocalHostname: postgresContainer.Host,
+		MaxPoolSize:   1,
+		LocalConn:     postgresContainer.DBDsn,
+		Log:           logger.NOP,
+	}
+	service, err = rsources.NewJobService(config)
+	require.NoError(t, err)
+	handler = handlerType(service, logger.NOP)
+	db = postgresContainer.DB
+	return
+}
+
+func addFailedRecords(
+	t *testing.T,
+	service rsources.JobService,
+	db *sql.DB,
+	records []json.RawMessage,
+) {
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	err = service.AddFailedRecords(context.Background(), tx,
+		"jobRunID",
+		rsources.JobTargetKey{
+			TaskRunID:     "taskRunID",
+			SourceID:      "sourceID",
+			DestinationID: "destinationID",
+		},
+		records,
+	)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+}
+
+func getFailedRecords(
+	t *testing.T,
+	handler http.Handler,
+	pageSize int,
+	pageToken,
+	endpoint string,
+) *rsources.JobFailedRecords {
+	params := url.Values{}
+	if pageSize > 0 {
+		params.Set("pageSize", strconv.Itoa(pageSize))
+		if pageToken != "" {
+			params.Set("pageToken", pageToken)
+		}
+	}
+	reqURL, err := url.Parse("http://localhost/" + endpoint)
+	require.NoError(t, err)
+	reqURL.RawQuery = params.Encode()
+	req, err := http.NewRequest("GET", reqURL.String(), nil)
+	require.NoError(t, err)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var failedRecords rsources.JobFailedRecords
+	err = json.Unmarshal(body, &failedRecords)
+	require.NoError(t, err)
+	return &failedRecords
+}
+
 func TestGetFailedRecordsIntegration(t *testing.T) {
-	prepare := func() (handler http.Handler, service rsources.JobService, db *sql.DB) {
-		pool, err := dockertest.NewPool("")
-		require.NoError(t, err)
-		postgresContainer, err := resource.SetupPostgres(pool, t)
-		require.NoError(t, err)
-
-		config := rsources.JobServiceConfig{
-			LocalHostname: postgresContainer.Host,
-			MaxPoolSize:   1,
-			LocalConn:     postgresContainer.DBDsn,
-			Log:           logger.NOP,
-		}
-		service, err = rsources.NewJobService(config)
-		require.NoError(t, err)
-		handler = rsources_http.NewHandler(service, logger.NOP)
-		db = postgresContainer.DB
-		return
-	}
-
-	addFailedRecords := func(t *testing.T, service rsources.JobService, db *sql.DB, records []json.RawMessage) {
-		tx, err := db.Begin()
-		require.NoError(t, err)
-		err = service.AddFailedRecords(context.Background(), tx,
-			"jobRunID",
-			rsources.JobTargetKey{
-				TaskRunID:     "taskRunID",
-				SourceID:      "sourceID",
-				DestinationID: "destinationID",
-			},
-			records,
-		)
-		require.NoError(t, err)
-		require.NoError(t, tx.Commit())
-	}
-
-	getFailedRecords := func(t *testing.T, handler http.Handler, pageSize int, pageToken string) *rsources.JobFailedRecords {
-		params := url.Values{}
-		if pageSize > 0 {
-			params.Set("pageSize", strconv.Itoa(pageSize))
-			if pageToken != "" {
-				params.Set("pageToken", pageToken)
-			}
-		}
-		reqURL, err := url.Parse("http://localhost/jobRunID/failed-records")
-		require.NoError(t, err)
-		reqURL.RawQuery = params.Encode()
-		req, err := http.NewRequest("GET", reqURL.String(), nil)
-		require.NoError(t, err)
-		resp := httptest.NewRecorder()
-		handler.ServeHTTP(resp, req)
-		require.Equal(t, http.StatusOK, resp.Code)
-		body, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		var failedRecords rsources.JobFailedRecords
-		err = json.Unmarshal(body, &failedRecords)
-		require.NoError(t, err)
-		return &failedRecords
-	}
-
 	t.Run("without pagination", func(t *testing.T) {
-		handler, service, db := prepare()
+		handler, service, db := prepare(t, rsources_http.NewV1Handler)
 		addFailedRecords(t, service, db, []json.RawMessage{
 			[]byte(`"id-1"`),
 			[]byte(`"id-2"`),
@@ -90,7 +108,13 @@ func TestGetFailedRecordsIntegration(t *testing.T) {
 		})
 		pageSize := 0
 		pageToken := ""
-		failedRecords := getFailedRecords(t, handler, pageSize, pageToken)
+		failedRecords := getFailedRecords(
+			t,
+			handler,
+			pageSize,
+			pageToken,
+			"jobRunID/failed-records",
+		)
 		require.NotNil(t, failedRecords)
 		require.Len(t, failedRecords.Tasks, 1)
 		require.Len(t, failedRecords.Tasks[0].Sources, 1)
@@ -100,7 +124,7 @@ func TestGetFailedRecordsIntegration(t *testing.T) {
 	})
 
 	t.Run("with pagination", func(t *testing.T) {
-		handler, service, db := prepare()
+		handler, service, db := prepare(t, rsources_http.NewV1Handler)
 		addFailedRecords(t, service, db, []json.RawMessage{
 			[]byte(`"id-1"`),
 			[]byte(`"id-2"`),
@@ -110,7 +134,13 @@ func TestGetFailedRecordsIntegration(t *testing.T) {
 		pageSize := 2
 		pageToken := ""
 		for i := 0; i < 2; i++ { // 2 pages are retrieved with 2 records each and where paging is present
-			failedRecords := getFailedRecords(t, handler, pageSize, pageToken)
+			failedRecords := getFailedRecords(
+				t,
+				handler,
+				pageSize,
+				pageToken,
+				"jobRunID/failed-records",
+			)
 			require.NotNil(t, failedRecords)
 			require.Len(t, failedRecords.Tasks, 1)
 			require.Len(t, failedRecords.Tasks[0].Sources, 1)
@@ -122,9 +152,209 @@ func TestGetFailedRecordsIntegration(t *testing.T) {
 		}
 
 		// 3 page is retrieved with 0 records and where paging is not present
-		failedRecords := getFailedRecords(t, handler, pageSize, pageToken)
+		failedRecords := getFailedRecords(
+			t,
+			handler,
+			pageSize,
+			pageToken,
+			"jobRunID/failed-records",
+		)
 		require.NotNil(t, failedRecords)
 		require.Len(t, failedRecords.Tasks, 0)
 		require.Nil(t, failedRecords.Paging, "no paging information should be present")
+	})
+}
+
+func TestFailedRecordsV2(t *testing.T) {
+	t.Run("without pagination", func(t *testing.T) {
+		handler, service, db := prepare(t, rsources_http.FailedKeysHandler)
+		addFailedRecords(t, service, db, []json.RawMessage{
+			[]byte(`"id-1"`),
+			[]byte(`"id-2"`),
+			[]byte(`"id-3"`),
+			[]byte(`"id-4"`),
+		})
+		pageSize := 0
+		pageToken := ""
+		failedRecords := getFailedRecords(t, handler, pageSize, pageToken, "jobRunID")
+		require.NotNil(t, failedRecords)
+		require.Len(t, failedRecords.Tasks, 1)
+		require.Len(t, failedRecords.Tasks[0].Sources, 1)
+		require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations, 1)
+		require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations[0].Records, 4)
+		require.Nil(t, failedRecords.Paging, "no paging information should be present")
+	})
+
+	t.Run("with pagination", func(t *testing.T) {
+		handler, service, db := prepare(t, rsources_http.FailedKeysHandler)
+		addFailedRecords(t, service, db, []json.RawMessage{
+			[]byte(`"id-1"`),
+			[]byte(`"id-2"`),
+			[]byte(`"id-3"`),
+			[]byte(`"id-4"`),
+		})
+		pageSize := 2
+		pageToken := ""
+		for i := 0; i < 2; i++ { // 2 pages are retrieved with 2 records each and where paging is present
+			failedRecords := getFailedRecords(t, handler, pageSize, pageToken, "jobRunID")
+			require.NotNil(t, failedRecords)
+			require.Len(t, failedRecords.Tasks, 1)
+			require.Len(t, failedRecords.Tasks[0].Sources, 1)
+			require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations, 1)
+			require.Len(t, failedRecords.Tasks[0].Sources[0].Destinations[0].Records, pageSize)
+			require.NotNil(t, failedRecords.Paging, "paging information should be present")
+			require.Equal(t, pageSize, failedRecords.Paging.Size)
+			pageToken = failedRecords.Paging.NextPageToken
+		}
+
+		// 3 page is retrieved with 0 records and where paging is not present
+		failedRecords := getFailedRecords(t, handler, pageSize, pageToken, "jobRunID")
+		require.NotNil(t, failedRecords)
+		require.Len(t, failedRecords.Tasks, 0)
+		require.Nil(t, failedRecords.Paging, "no paging information should be present")
+	})
+}
+
+func TestDeleteEndpoints(t *testing.T) {
+	t.Run("v2 delete endpoints delete only failed-keys", func(t *testing.T) {
+		fkHandler, service, db := prepare(t, rsources_http.FailedKeysHandler)
+		addFailedRecords(t, service, db, []json.RawMessage{
+			[]byte(`"id-1"`),
+			[]byte(`"id-2"`),
+			[]byte(`"id-3"`),
+			[]byte(`"id-4"`),
+		})
+		jsHandler := rsources_http.JobStatusHandler(service, logger.NOP)
+		tx, err := db.Begin()
+		require.NoError(t, err)
+		require.NoError(
+			t,
+			service.IncrementStats(
+				context.Background(),
+				tx,
+				"jobRunID",
+				rsources.JobTargetKey{
+					TaskRunID:     "taskRunID",
+					SourceID:      "sourceID",
+					DestinationID: "destinationID",
+				},
+				rsources.Stats{
+					In:     15,
+					Out:    6,
+					Failed: 4,
+				},
+			),
+		)
+		require.NoError(t, tx.Commit())
+		t.Run("should retrieve failed keys from v2 endpoint", func(t *testing.T) {
+			failedRecords := getFailedRecords(t, fkHandler, 10, "", "jobRunID")
+			require.NotNil(t, failedRecords)
+			require.Len(t, failedRecords.Tasks, 1)
+			require.Nil(t, failedRecords.Paging, "no paging information should be present")
+		})
+		t.Run("calling v2 failed-keys delete should only delete failed keys", func(t *testing.T) {
+			req, err := http.NewRequest("DELETE", "http://localhost/jobRunID", nil)
+			require.NoError(t, err)
+			resp := httptest.NewRecorder()
+			fkHandler.ServeHTTP(resp, req)
+			require.Equal(t, http.StatusNoContent, resp.Code)
+			failedRecords := getFailedRecords(t, fkHandler, 10, "", "jobRunID")
+			require.NotNil(t, failedRecords)
+			require.Len(t, failedRecords.Tasks, 0)
+			require.Nil(t, failedRecords.Paging, "no paging information should be present")
+
+			req, err = http.NewRequest("GET", "http://localhost/jobRunID", nil)
+			require.NoError(t, err)
+			resp = httptest.NewRecorder()
+			jsHandler.ServeHTTP(resp, req)
+			require.Equal(t, http.StatusOK, resp.Code)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			var jobStatus rsources.JobStatus
+			err = json.Unmarshal(body, &jobStatus)
+			require.NoError(t, err)
+			require.Len(t, jobStatus.TasksStatus, 1)
+			require.Len(t, jobStatus.TasksStatus[0].SourcesStatus, 1)
+			require.Len(t, jobStatus.TasksStatus[0].SourcesStatus[0].DestinationsStatus, 1)
+			require.Equal(t, uint(15), jobStatus.TasksStatus[0].SourcesStatus[0].DestinationsStatus[0].Stats.In)
+			require.Equal(t, uint(6), jobStatus.TasksStatus[0].SourcesStatus[0].DestinationsStatus[0].Stats.Out)
+			require.Equal(t, uint(4), jobStatus.TasksStatus[0].SourcesStatus[0].DestinationsStatus[0].Stats.Failed)
+		})
+	})
+
+	t.Run("v2 delete endpoints delete only job-status", func(t *testing.T) {
+		fkHandler, service, db := prepare(t, rsources_http.FailedKeysHandler)
+		addFailedRecords(t, service, db, []json.RawMessage{
+			[]byte(`"id-1"`),
+			[]byte(`"id-2"`),
+			[]byte(`"id-3"`),
+			[]byte(`"id-4"`),
+		})
+		jsHandler := rsources_http.JobStatusHandler(service, logger.NOP)
+		tx, err := db.Begin()
+		require.NoError(t, err)
+		require.NoError(
+			t,
+			service.IncrementStats(
+				context.Background(),
+				tx,
+				"jobRunID",
+				rsources.JobTargetKey{
+					TaskRunID:     "taskRunID",
+					SourceID:      "sourceID",
+					DestinationID: "destinationID",
+				},
+				rsources.Stats{
+					In:     15,
+					Out:    6,
+					Failed: 4,
+				},
+			),
+		)
+		require.NoError(t, tx.Commit())
+
+		t.Run("calling v2 job-status delete should only delete job-status", func(t *testing.T) {
+			req, err := http.NewRequest("GET", "http://localhost/jobRunID", nil)
+			require.NoError(t, err)
+			resp := httptest.NewRecorder()
+			jsHandler.ServeHTTP(resp, req)
+			require.Equal(t, http.StatusOK, resp.Code)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			var jobStatus rsources.JobStatus
+			err = json.Unmarshal(body, &jobStatus)
+			require.NoError(t, err)
+			require.Len(t, jobStatus.TasksStatus, 1)
+			require.Len(t, jobStatus.TasksStatus[0].SourcesStatus, 1)
+			require.Len(t, jobStatus.TasksStatus[0].SourcesStatus[0].DestinationsStatus, 1)
+			require.Equal(t, uint(15), jobStatus.TasksStatus[0].SourcesStatus[0].DestinationsStatus[0].Stats.In)
+			require.Equal(t, uint(6), jobStatus.TasksStatus[0].SourcesStatus[0].DestinationsStatus[0].Stats.Out)
+			require.Equal(t, uint(4), jobStatus.TasksStatus[0].SourcesStatus[0].DestinationsStatus[0].Stats.Failed)
+
+			req, err = http.NewRequest("DELETE", "http://localhost/jobRunID", nil)
+			require.NoError(t, err)
+			resp = httptest.NewRecorder()
+			jsHandler.ServeHTTP(resp, req)
+			require.Equal(t, http.StatusNoContent, resp.Code)
+			failedRecords := getFailedRecords(t, fkHandler, 10, "", "jobRunID")
+			require.NotNil(t, failedRecords)
+
+			req, err = http.NewRequest("GET", "http://localhost/jobRunID", nil)
+			require.NoError(t, err)
+			resp = httptest.NewRecorder()
+			jsHandler.ServeHTTP(resp, req)
+			require.Equal(t, http.StatusNotFound, resp.Code)
+
+			req, err = http.NewRequest("DELETE", "http://localhost/jobRunID", nil)
+			require.NoError(t, err)
+			resp = httptest.NewRecorder()
+			fkHandler.ServeHTTP(resp, req)
+			require.Equal(t, http.StatusNoContent, resp.Code)
+			failedRecords = getFailedRecords(t, fkHandler, 10, "", "jobRunID")
+			require.NotNil(t, failedRecords)
+			require.Len(t, failedRecords.Tasks, 0)
+			require.Nil(t, failedRecords.Paging, "no paging information should be present")
+		})
+
 	})
 }

--- a/services/rsources/http/http_test.go
+++ b/services/rsources/http/http_test.go
@@ -23,7 +23,7 @@ func TestDelete(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	service := rsources.NewMockJobService(mockCtrl)
-	handler := rsources_http.NewHandler(service, mock_logger.NewMockLogger(mockCtrl))
+	handler := rsources_http.NewV1Handler(service, mock_logger.NewMockLogger(mockCtrl))
 
 	tests := []struct {
 		name                 string
@@ -109,7 +109,7 @@ func TestGetStatus(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	service := rsources.NewMockJobService(mockCtrl)
-	handler := rsources_http.NewHandler(service, mock_logger.NewMockLogger(mockCtrl))
+	handler := rsources_http.NewV1Handler(service, mock_logger.NewMockLogger(mockCtrl))
 
 	tests := []struct {
 		name                 string
@@ -248,7 +248,7 @@ func TestGetFailedRecords(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	service := rsources.NewMockJobService(mockCtrl)
-	handler := rsources_http.NewHandler(service, mock_logger.NewMockLogger(mockCtrl))
+	handler := rsources_http.NewV1Handler(service, mock_logger.NewMockLogger(mockCtrl))
 
 	tests := []struct {
 		name                 string
@@ -358,7 +358,7 @@ func TestFailedRecordsDisabled(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	service := rsources.NewMockJobService(mockCtrl)
-	handler := rsources_http.NewHandler(service, mock_logger.NewMockLogger(mockCtrl))
+	handler := rsources_http.NewV1Handler(service, mock_logger.NewMockLogger(mockCtrl))
 
 	service.EXPECT().GetFailedRecords(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(rsources.JobFailedRecords{}, rsources.ErrOperationNotSupported).Times(1)
 

--- a/services/rsources/http/httpv2_test.go
+++ b/services/rsources/http/httpv2_test.go
@@ -1,0 +1,104 @@
+package http_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gomock "github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	mock_logger "github.com/rudderlabs/rudder-server/mocks/utils/logger"
+	"github.com/rudderlabs/rudder-server/services/rsources"
+	rsources_http "github.com/rudderlabs/rudder-server/services/rsources/http"
+)
+
+func TestFailedKeysHandler(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	service := rsources.NewMockJobService(mockCtrl)
+	handler := rsources_http.FailedKeysHandler(
+		service,
+		mock_logger.NewMockLogger(mockCtrl),
+	)
+	tests := []struct {
+		name                 string
+		jobRunId             string
+		jobFilter            rsources.JobFilter
+		endpoint             string
+		method               string
+		expectedResponseCode int
+		serviceReturnError   error
+	}{
+		{
+			name:                 "basic test",
+			jobRunId:             "123",
+			jobFilter:            rsources.JobFilter{},
+			endpoint:             prepURL("/{job_run_id}", "123"),
+			method:               http.MethodDelete,
+			expectedResponseCode: http.StatusNoContent,
+		},
+		{
+			name:                 "service returns error test",
+			jobRunId:             "123",
+			jobFilter:            rsources.JobFilter{},
+			endpoint:             prepURL("/{job_run_id}", "123"),
+			method:               http.MethodDelete,
+			expectedResponseCode: http.StatusInternalServerError,
+			serviceReturnError:   fmt.Errorf("something when wrong"),
+		},
+		{
+			name:                 "job run id doesn't exist",
+			jobRunId:             "invalid",
+			jobFilter:            rsources.JobFilter{},
+			endpoint:             prepURL("/{job_run_id}", "invalid"),
+			method:               http.MethodDelete,
+			expectedResponseCode: http.StatusNoContent,
+		},
+		{
+			name:                 "job's source is incomplete",
+			jobRunId:             "123",
+			jobFilter:            rsources.JobFilter{},
+			endpoint:             prepURL("/{job_run_id}", "123"),
+			method:               http.MethodDelete,
+			expectedResponseCode: http.StatusNoContent,
+		},
+	}
+	toQueryParams := func(jobFilter rsources.JobFilter) string {
+		var params []string
+		for _, v := range jobFilter.TaskRunID {
+			params = append(params, fmt.Sprintf("task_run_id=%s", v))
+		}
+		for _, v := range jobFilter.SourceID {
+			params = append(params, fmt.Sprintf("source_id=%s", v))
+		}
+		if len(params) == 0 {
+			return ""
+		}
+		return "?" + strings.Join(params, "&")
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queryParams := toQueryParams(tt.jobFilter)
+			t.Log("endpoint tested:", tt.endpoint+queryParams)
+			service.EXPECT().DeleteFailedRecords(gomock.Any(), tt.jobRunId, tt.jobFilter).Return(tt.serviceReturnError).Times(1)
+
+			url := fmt.Sprintf("http://localhost:8080%s%s", tt.endpoint, queryParams)
+			req, err := http.NewRequest(tt.method, url, http.NoBody)
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			resp := httptest.NewRecorder()
+
+			handler.ServeHTTP(resp, req)
+			_, err = io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expectedResponseCode, resp.Code, "required error different than expected")
+		})
+	}
+}
+
+func TestJobStatusHandler(t *testing.T) {}

--- a/services/rsources/mock_rsources.go
+++ b/services/rsources/mock_rsources.go
@@ -115,6 +115,34 @@ func (mr *MockJobServiceMockRecorder) Delete(ctx, jobRunId, filter interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockJobService)(nil).Delete), ctx, jobRunId, filter)
 }
 
+// DeleteFailedRecords mocks base method.
+func (m *MockJobService) DeleteFailedRecords(ctx context.Context, jobRunId string, filter JobFilter) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteFailedRecords", ctx, jobRunId, filter)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteFailedRecords indicates an expected call of DeleteFailedRecords.
+func (mr *MockJobServiceMockRecorder) DeleteFailedRecords(ctx, jobRunId, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFailedRecords", reflect.TypeOf((*MockJobService)(nil).DeleteFailedRecords), ctx, jobRunId, filter)
+}
+
+// DeleteJobStatus mocks base method.
+func (m *MockJobService) DeleteJobStatus(ctx context.Context, jobRunId string, filter JobFilter) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteJobStatus", ctx, jobRunId, filter)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteJobStatus indicates an expected call of DeleteJobStatus.
+func (mr *MockJobServiceMockRecorder) DeleteJobStatus(ctx, jobRunId, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJobStatus", reflect.TypeOf((*MockJobService)(nil).DeleteJobStatus), ctx, jobRunId, filter)
+}
+
 // GetFailedRecords mocks base method.
 func (m *MockJobService) GetFailedRecords(ctx context.Context, jobRunId string, filter JobFilter, paging PagingInfo) (JobFailedRecords, error) {
 	m.ctrl.T.Helper()

--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -132,6 +132,9 @@ var ErrStatusNotFound = errors.New("Status not found")
 // ErrSourceNotCompleted sentinel error indicating that a source is not completed
 var ErrSourceNotCompleted = errors.New("Source not completed")
 
+// ErrFailedRecordsNotFound sentinel error indicating that failed records cannot be found
+var ErrFailedRecordsNotFound = errors.New("Failed records not found")
+
 // StatsIncrementer increments stats
 type StatsIncrementer interface {
 	// IncrementStats increments the existing statistic counters
@@ -155,6 +158,12 @@ type JobService interface {
 
 	// Delete deletes all relevant information for a given jobRunId
 	Delete(ctx context.Context, jobRunId string, filter JobFilter) error
+
+	// DeleteJobStatus deletes the status for a given jobRunId
+	DeleteJobStatus(ctx context.Context, jobRunId string, filter JobFilter) error
+
+	// DeleteFailedRecords deletes all failed records for a given jobRunId
+	DeleteFailedRecords(ctx context.Context, jobRunId string, filter JobFilter) error
 
 	// GetStatus gets the current status of a job
 	GetStatus(ctx context.Context, jobRunId string, filter JobFilter) (JobStatus, error)
@@ -215,6 +224,14 @@ func NewNoOpService() JobService {
 type noopService struct{}
 
 func (*noopService) Delete(_ context.Context, _ string, _ JobFilter) error {
+	return nil
+}
+
+func (*noopService) DeleteJobStatus(_ context.Context, _ string, _ JobFilter) error {
+	return nil
+}
+
+func (*noopService) DeleteFailedRecords(_ context.Context, _ string, _ JobFilter) error {
 	return nil
 }
 


### PR DESCRIPTION
# Description

v2 endpoints for sources use. Basic premise is to separate the delete endpoint which used to delete all the available info for passed query filters.
Now there's two different endpoints to delete job stats and failed keys separately.

`/v2/failed-keys` - lets the user fetch or delete failed keys
`/v2/job-status` - lets the user fetch or delete job status(stats)

The existing endpoint has been left for now to be deprecated soon.
`/v1/job-status` - lets the user fetch job stats, failed keys, and delete all relevant information for a particular `jobRunId`.

## Linear Ticket

[delete endpoints](https://linear.app/rudderstack/issue/PIPE-401/deletefailedkeys-deletestats)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
