### PR TITLE
fix: sorting key for error indexing during parquet

### DIFF
--- a/enterprise/reporting/error_index/worker.go
+++ b/enterprise/reporting/error_index/worker.go
@@ -263,7 +263,7 @@ func (w *worker) encodeToParquet(wr io.Writer, payloads []payload) error {
 	pw.CompressionType = parquet.CompressionCodec_SNAPPY
 
 	sort.Slice(payloads, func(i, j int) bool {
-		return payloads[i].FailedAt > payloads[j].FailedAt
+		return payloads[i].SortingKey() < payloads[j].SortingKey()
 	})
 
 	for _, payload := range payloads {


### PR DESCRIPTION
# Description

- Use sorting key for storing data in parquet. 

## Linear Ticket

- Resolves PIPE-493

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
