### PR TITLE
fix: invalid input syntax for type json for table esch_job_status

### DIFF
--- a/schema-forwarder/internal/forwarder/jobsforwarder.go
+++ b/schema-forwarder/internal/forwarder/jobsforwarder.go
@@ -156,6 +156,7 @@ func (jf *JobsForwarder) Start() error {
 											JobState:      jobsdb.Succeeded.State,
 											ExecTime:      time.Now(),
 											Parameters:    []byte(`{}`),
+											ErrorResponse: []byte(`{}`),
 											JobParameters: job.Parameters,
 										})
 									}


### PR DESCRIPTION
# Description
Using an empty payload for ErrorResponse when recording a successful jobs status for `esch` jobs.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
