### PR TITLE
chore: use latest dependencies for tests

### DIFF
--- a/warehouse/integrations/datalake/testdata/docker-compose.spark.yml
+++ b/warehouse/integrations/datalake/testdata/docker-compose.spark.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   spark-master:
-    image: bitnami/spark:3.2.4
+    image: bitnami/spark:latest
     environment:
       - SPARK_MODE=master
       - SPARK_RPC_AUTHENTICATION_ENABLED=no
@@ -31,7 +31,7 @@ services:
           memory: 1G
 
   spark-worker:
-    image: bitnami/spark:3.2.4
+    image: bitnami/spark:latest
     environment:
       - SPARK_MODE=worker
       - SPARK_MASTER_URL=spark://spark-master:7077

--- a/warehouse/integrations/datalake/testdata/docker-compose.trino.yml
+++ b/warehouse/integrations/datalake/testdata/docker-compose.trino.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   trino:
-    image: trinodb/trino:362
+    image: trinodb/trino:latest
     ports:
       - "8080"
     volumes:

--- a/warehouse/integrations/datalake/testdata/etc/catalog/minio.properties
+++ b/warehouse/integrations/datalake/testdata/etc/catalog/minio.properties
@@ -1,10 +1,9 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hive-metastore:9083
 hive.s3.path-style-access=true
 hive.s3.endpoint=http://minio:9000
 hive.s3.aws-access-key=MYACCESSKEY
 hive.s3.aws-secret-key=MYSECRETKEY
 hive.non-managed-table-writes-enabled=true
-hive.s3select-pushdown.enabled=true
 hive.storage-format=ORC
 hive.metastore-timeout=60s

--- a/warehouse/integrations/datalake/testdata/etc/jvm.config
+++ b/warehouse/integrations/datalake/testdata/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/warehouse/integrations/postgres/testdata/docker-compose.postgres.yml
+++ b/warehouse/integrations/postgres/testdata/docker-compose.postgres.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   postgres:
-    image: postgres:15-alpine
+    image: postgres:latest
     environment:
       - POSTGRES_DB=rudderdb
       - POSTGRES_PASSWORD=rudder-password

--- a/warehouse/integrations/postgres/testdata/docker-compose.ssh-server.yml
+++ b/warehouse/integrations/postgres/testdata/docker-compose.ssh-server.yml
@@ -22,7 +22,7 @@ services:
     depends_on:
       - db-private-postgres
   db-private-postgres:
-    image: postgres:14.1-alpine
+    image: postgres:latest
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres

--- a/warehouse/integrations/testdata/docker-compose.jobsdb.yml
+++ b/warehouse/integrations/testdata/docker-compose.jobsdb.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   jobsDb:
-    image: postgres:15-alpine
+    image: postgres:latest
     environment:
       - POSTGRES_DB=jobsdb
       - POSTGRES_PASSWORD=password

--- a/warehouse/integrations/tunnelling/testdata/docker-compose.yml
+++ b/warehouse/integrations/tunnelling/testdata/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - postgres
 
   postgres:
-    image: postgres:15-alpine
+    image: postgres:latest
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres


### PR DESCRIPTION
# Description

- Upgrade docker dependencies to the latest version for tests. This will help us detect breaking changes early. We need not worry about rate limits since we are pulling images from our internally deployed Rudder Hub Proxy. More about it is [here](https://rudderlabs.slack.com/archives/C02B31USATA/p1696859664448059).
- Feedback in [here](https://github.com/rudderlabs/rudder-server/pull/4058#discussion_r1384659395).
- **The only concern here is the backward compatibility since we will be using older version [server(PostgreSQL 11.21, PostgreSQL 12.9) and warehouse (PostgreSQL 12.9, PostgreSQL 11.6)] in Production, as compared to [Postgres latest (PostgreSQL 16)] in tests. We were already using 15 now, so I guess we should be OK**

## Linear Ticket

- Resolves PIPE-506

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
