### PR TITLE
fix: preferAppend defaults to false if not defined

### DIFF
--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -867,7 +867,7 @@ func (bq *BigQuery) connect(ctx context.Context, cred BQCredentials) (*bigquery.
 // * the server config says we allow merging
 // * the user opted in to merging
 func (bq *BigQuery) shouldMerge() bool {
-	return bq.config.allowMerge && bq.warehouse.GetBoolDestinationConfig(model.EnableMergeSetting)
+	return bq.config.allowMerge && !bq.warehouse.GetPreferAppendSetting()
 }
 
 func (bq *BigQuery) CrashRecover(ctx context.Context) {

--- a/warehouse/integrations/bigquery/bigquery_test.go
+++ b/warehouse/integrations/bigquery/bigquery_test.go
@@ -78,7 +78,7 @@ func TestIntegration(t *testing.T) {
 
 	escapedCredentialsTrimmedStr := strings.Trim(string(escapedCredentials), `"`)
 
-	bootstrapSvc := func(t *testing.T, enableMerge bool) *bigquery.Client {
+	bootstrapSvc := func(t *testing.T, preferAppend bool) *bigquery.Client {
 		templateConfigurations := map[string]any{
 			"workspaceID":          workspaceID,
 			"sourceID":             sourceID,
@@ -93,7 +93,7 @@ func TestIntegration(t *testing.T) {
 			"bucketName":           bqTestCredentials.BucketName,
 			"credentials":          escapedCredentialsTrimmedStr,
 			"sourcesNamespace":     sourcesNamespace,
-			"enableMerge":          enableMerge,
+			"preferAppend":         preferAppend,
 		}
 		workspaceConfigPath := workspaceConfig.CreateTempFile(t, "testdata/template.json", templateConfigurations)
 
@@ -151,7 +151,7 @@ func TestIntegration(t *testing.T) {
 			asyncJob                            bool
 			skipModifiedEvents                  bool
 			prerequisite                        func(context.Context, testing.TB, *bigquery.Client)
-			enableMerge                         bool
+			preferAppend                        bool
 			customPartitionsEnabledWorkspaceIDs string
 			stagingFilePrefix                   string
 		}{
@@ -169,7 +169,7 @@ func TestIntegration(t *testing.T) {
 				loadFilesEventsMap:            loadFilesEventsMap(),
 				tableUploadsEventsMap:         tableUploadsEventsMap(),
 				warehouseEventsMap:            mergeEventsMap(),
-				enableMerge:                   true,
+				preferAppend:                  false,
 				prerequisite: func(ctx context.Context, t testing.TB, db *bigquery.Client) {
 					t.Helper()
 					_ = db.Dataset(namespace).DeleteWithContents(ctx)
@@ -193,7 +193,7 @@ func TestIntegration(t *testing.T) {
 				tableUploadsEventsMap: whth.SourcesTableUploadsEventsMap(),
 				warehouseEventsMap:    whth.SourcesWarehouseEventsMap(),
 				asyncJob:              true,
-				enableMerge:           false,
+				preferAppend:          true,
 				prerequisite: func(ctx context.Context, t testing.TB, db *bigquery.Client) {
 					t.Helper()
 					_ = db.Dataset(namespace).DeleteWithContents(ctx)
@@ -215,7 +215,7 @@ func TestIntegration(t *testing.T) {
 				tableUploadsEventsMap:         tableUploadsEventsMap(),
 				warehouseEventsMap:            appendEventsMap(),
 				skipModifiedEvents:            true,
-				enableMerge:                   false,
+				preferAppend:                  true,
 				prerequisite: func(ctx context.Context, t testing.TB, db *bigquery.Client) {
 					t.Helper()
 					_ = db.Dataset(namespace).DeleteWithContents(ctx)
@@ -237,7 +237,7 @@ func TestIntegration(t *testing.T) {
 				tableUploadsEventsMap:               tableUploadsEventsMap(),
 				warehouseEventsMap:                  appendEventsMap(),
 				skipModifiedEvents:                  true,
-				enableMerge:                         false,
+				preferAppend:                        true,
 				customPartitionsEnabledWorkspaceIDs: workspaceID,
 				prerequisite: func(ctx context.Context, t testing.TB, db *bigquery.Client) {
 					t.Helper()
@@ -274,7 +274,7 @@ func TestIntegration(t *testing.T) {
 					"RSERVER_WAREHOUSE_BIGQUERY_CUSTOM_PARTITIONS_ENABLED_WORKSPACE_IDS",
 					tc.customPartitionsEnabledWorkspaceIDs,
 				)
-				db := bootstrapSvc(t, tc.enableMerge)
+				db := bootstrapSvc(t, tc.preferAppend)
 
 				t.Cleanup(func() {
 					for _, dataset := range []string{tc.schema} {
@@ -542,12 +542,9 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
-			dedupWarehouse := th.Clone(t, warehouse)
-			dedupWarehouse.Destination.Config[string(model.EnableMergeSetting)] = true
-
 			c := config.New()
 			bq := whbigquery.New(c, logger.NOP)
-			err := bq.Setup(ctx, dedupWarehouse, mockUploader)
+			err := bq.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
 
 			err = bq.CreateSchema(ctx)
@@ -590,9 +587,12 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
+			appendWarehouse := th.Clone(t, warehouse)
+			appendWarehouse.Destination.Config[string(model.PreferAppendSetting)] = true
+
 			c := config.New()
 			bq := whbigquery.New(c, logger.NOP)
-			err := bq.Setup(ctx, warehouse, mockUploader)
+			err := bq.Setup(ctx, appendWarehouse, mockUploader)
 			require.NoError(t, err)
 
 			err = bq.CreateSchema(ctx)
@@ -638,8 +638,11 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
 
+			appendWarehouse := th.Clone(t, warehouse)
+			appendWarehouse.Destination.Config[string(model.PreferAppendSetting)] = true
+
 			bq := whbigquery.New(config.New(), logger.NOP)
-			err := bq.Setup(ctx, warehouse, mockUploader)
+			err := bq.Setup(ctx, appendWarehouse, mockUploader)
 			require.NoError(t, err)
 
 			err = bq.CreateSchema(ctx)

--- a/warehouse/integrations/bigquery/testdata/template.json
+++ b/warehouse/integrations/bigquery/testdata/template.json
@@ -32,7 +32,7 @@
             "prefix": "",
             "namespace": "{{.namespace}}",
             "syncFrequency": "30",
-            "enableMerge": {{.enableMerge}}
+            "preferAppend": {{.preferAppend}}
           },
           "liveEventsConfig": {},
           "secretConfig": {},
@@ -161,7 +161,7 @@
             "prefix": "",
             "namespace": "{{.sourcesNamespace}}",
             "syncFrequency": "30",
-            "enableMerge": {{.enableMerge}}
+            "preferAppend": {{.preferAppend}}
           },
           "liveEventsConfig": {},
           "secretConfig": {},

--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -1387,5 +1387,5 @@ func (*Deltalake) DeleteBy(context.Context, []string, warehouseutils.DeleteByPar
 // * the user opted in to merging and we allow merging
 func (d *Deltalake) ShouldMerge() bool {
 	return !d.Uploader.CanAppend() ||
-		(d.config.allowMerge && d.Warehouse.GetBoolDestinationConfig(model.EnableMergeSetting))
+		(d.config.allowMerge && !d.Warehouse.GetPreferAppendSetting())
 }

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -117,7 +117,7 @@ func TestIntegration(t *testing.T) {
 	db := sql.OpenDB(connector)
 	require.NoError(t, db.Ping())
 
-	bootstrapSvc := func(t *testing.T, enableMerge bool) {
+	bootstrapSvc := func(t *testing.T, preferAppend bool) {
 		templateConfigurations := map[string]any{
 			"workspaceID":   workspaceID,
 			"sourceID":      sourceID,
@@ -131,7 +131,7 @@ func TestIntegration(t *testing.T) {
 			"containerName": deltaLakeCredentials.ContainerName,
 			"accountName":   deltaLakeCredentials.AccountName,
 			"accountKey":    deltaLakeCredentials.AccountKey,
-			"enableMerge":   enableMerge,
+			"preferAppend":  preferAppend,
 		}
 		workspaceConfigPath := workspaceConfig.CreateTempFile(t, "testdata/template.json", templateConfigurations)
 
@@ -186,7 +186,7 @@ func TestIntegration(t *testing.T) {
 			destinationID       string
 			messageID           string
 			warehouseEventsMap  whth.EventsCountMap
-			enableMerge         bool
+			preferAppend        bool
 			useParquetLoadFiles bool
 			stagingFilePrefix   string
 			jobRunID            string
@@ -198,7 +198,7 @@ func TestIntegration(t *testing.T) {
 				sourceID:            sourceID,
 				destinationID:       destinationID,
 				warehouseEventsMap:  mergeEventsMap(),
-				enableMerge:         true,
+				preferAppend:        false,
 				useParquetLoadFiles: false,
 				stagingFilePrefix:   "testdata/upload-job-merge-mode",
 				jobRunID:            misc.FastUUID().String(),
@@ -210,7 +210,7 @@ func TestIntegration(t *testing.T) {
 				sourceID:            sourceID,
 				destinationID:       destinationID,
 				warehouseEventsMap:  appendEventsMap(),
-				enableMerge:         false,
+				preferAppend:        true,
 				useParquetLoadFiles: false,
 				stagingFilePrefix:   "testdata/upload-job-append-mode",
 				// an empty jobRunID means that the source is not an ETL one
@@ -224,7 +224,7 @@ func TestIntegration(t *testing.T) {
 				sourceID:            sourceID,
 				destinationID:       destinationID,
 				warehouseEventsMap:  mergeEventsMap(),
-				enableMerge:         true,
+				preferAppend:        false,
 				useParquetLoadFiles: true,
 				stagingFilePrefix:   "testdata/upload-job-parquet",
 				jobRunID:            misc.FastUUID().String(),
@@ -234,7 +234,7 @@ func TestIntegration(t *testing.T) {
 		for _, tc := range testCases {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
-				bootstrapSvc(t, tc.enableMerge)
+				bootstrapSvc(t, tc.preferAppend)
 				t.Setenv("RSERVER_WAREHOUSE_DELTALAKE_USE_PARQUET_LOAD_FILES", strconv.FormatBool(tc.useParquetLoadFiles))
 
 				sqlClient := &warehouseclient.Client{
@@ -563,11 +563,8 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv, true, true, "2022-12-15T06:53:49.640Z")
 
-				mergeWarehouse := th.Clone(t, warehouse)
-				mergeWarehouse.Destination.Config[string(model.EnableMergeSetting)] = true
-
 				d := deltalake.New(config.New(), logger.NOP, memstats.New())
-				err := d.Setup(ctx, mergeWarehouse, mockUploader)
+				err := d.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
 				err = d.CreateSchema(ctx)
@@ -613,11 +610,11 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv, false, false, "2022-11-15T06:53:49.640Z")
 
-				mergeWarehouse := th.Clone(t, warehouse)
-				mergeWarehouse.Destination.Config[string(model.EnableMergeSetting)] = true
+				appendWarehouse := th.Clone(t, warehouse)
+				appendWarehouse.Destination.Config[string(model.PreferAppendSetting)] = true
 
 				d := deltalake.New(config.New(), logger.NOP, memstats.New())
-				err := d.Setup(ctx, mergeWarehouse, mockUploader)
+				err := d.Setup(ctx, appendWarehouse, mockUploader)
 				require.NoError(t, err)
 
 				err = d.CreateSchema(ctx)
@@ -664,8 +661,11 @@ func TestIntegration(t *testing.T) {
 			loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 			mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv, true, false, "2022-12-15T06:53:49.640Z")
 
+			appendWarehouse := th.Clone(t, warehouse)
+			appendWarehouse.Destination.Config[string(model.PreferAppendSetting)] = true
+
 			d := deltalake.New(config.New(), logger.NOP, memstats.New())
-			err := d.Setup(ctx, warehouse, mockUploader)
+			err := d.Setup(ctx, appendWarehouse, mockUploader)
 			require.NoError(t, err)
 
 			err = d.CreateSchema(ctx)
@@ -1057,35 +1057,35 @@ func TestDeltalake_TrimErrorMessage(t *testing.T) {
 func TestDeltalake_ShouldMerge(t *testing.T) {
 	testCases := []struct {
 		name                  string
-		enableMerge           bool
+		preferAppend          bool
 		uploaderCanAppend     bool
 		uploaderExpectedCalls int
 		expected              bool
 	}{
 		{
-			name:                  "uploader says we can append and merge is not enabled",
-			enableMerge:           false,
+			name:                  "uploader says we can append and user prefers to append",
+			preferAppend:          true,
 			uploaderCanAppend:     true,
 			uploaderExpectedCalls: 1,
 			expected:              false,
 		},
 		{
-			name:                  "uploader says we can append and merge is enabled",
-			enableMerge:           true,
+			name:                  "uploader says we can append and users prefers not to append",
+			preferAppend:          false,
 			uploaderCanAppend:     true,
 			uploaderExpectedCalls: 1,
 			expected:              true,
 		},
 		{
-			name:                  "uploader says we cannot append so enableMerge false is ignored",
-			enableMerge:           false,
+			name:                  "uploader says we cannot append and user prefers to append",
+			preferAppend:          true,
 			uploaderCanAppend:     false,
 			uploaderExpectedCalls: 1,
 			expected:              true,
 		},
 		{
-			name:                  "uploader says we cannot append so enableMerge true is ignored",
-			enableMerge:           true,
+			name:                  "uploader says we cannot append and users prefers not to append",
+			preferAppend:          false,
 			uploaderCanAppend:     false,
 			uploaderExpectedCalls: 1,
 			expected:              true,
@@ -1098,7 +1098,7 @@ func TestDeltalake_ShouldMerge(t *testing.T) {
 			d.Warehouse = model.Warehouse{
 				Destination: backendconfig.DestinationT{
 					Config: map[string]any{
-						string(model.EnableMergeSetting): tc.enableMerge,
+						string(model.PreferAppendSetting): tc.preferAppend,
 					},
 				},
 			}

--- a/warehouse/integrations/deltalake/testdata/template.json
+++ b/warehouse/integrations/deltalake/testdata/template.json
@@ -39,7 +39,7 @@
             "syncFrequency": "30",
             "eventDelivery": false,
             "eventDeliveryTS": 1648195480174,
-            "enableMerge": {{.enableMerge}}
+            "preferAppend": {{.preferAppend}}
           },
           "liveEventsConfig": {
             "eventDelivery": false,

--- a/warehouse/integrations/postgres/load.go
+++ b/warehouse/integrations/postgres/load.go
@@ -556,6 +556,6 @@ func (pg *Postgres) loadUsersTable(
 func (pg *Postgres) shouldMerge() bool {
 	return !pg.Uploader.CanAppend() ||
 		(pg.config.allowMerge &&
-			pg.Warehouse.GetBoolDestinationConfig(model.EnableMergeSetting) &&
+			!pg.Warehouse.GetPreferAppendSetting() &&
 			!slices.Contains(pg.config.skipDedupDestinationIDs, pg.Warehouse.Destination.ID))
 }

--- a/warehouse/integrations/postgres/postgres_test.go
+++ b/warehouse/integrations/postgres/postgres_test.go
@@ -571,9 +571,8 @@ func TestIntegration(t *testing.T) {
 			require.Nil(t, loadTableStat)
 		})
 		t.Run("merge", func(t *testing.T) {
-			tableName := "merge_test_table"
-
 			t.Run("without dedup", func(t *testing.T) {
+				tableName := "merge_without_dedup_test_table"
 				uploadOutput := whth.UploadLoadFile(t, fm, "../testdata/load.csv.gz", tableName)
 
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
@@ -582,11 +581,62 @@ func TestIntegration(t *testing.T) {
 				c := config.New()
 				c.Set("Warehouse.postgres.EnableSQLStatementExecutionPlanWorkspaceIDs", workspaceID)
 
-				mergeWarehouse := th.Clone(t, warehouse)
-				mergeWarehouse.Destination.Config[string(model.EnableMergeSetting)] = true
+				appendWarehouse := th.Clone(t, warehouse)
+				appendWarehouse.Destination.Config[string(model.PreferAppendSetting)] = true
 
 				pg := postgres.New(c, logger.NOP, memstats.New())
-				err := pg.Setup(ctx, mergeWarehouse, mockUploader)
+				err := pg.Setup(ctx, appendWarehouse, mockUploader)
+				require.NoError(t, err)
+
+				err = pg.CreateSchema(ctx)
+				require.NoError(t, err)
+
+				err = pg.CreateTable(ctx, tableName, schemaInWarehouse)
+				require.NoError(t, err)
+
+				loadTableStat, err := pg.LoadTable(ctx, tableName)
+				require.NoError(t, err)
+				require.Equal(t, loadTableStat.RowsInserted, int64(14))
+				require.Equal(t, loadTableStat.RowsUpdated, int64(0))
+
+				loadTableStat, err = pg.LoadTable(ctx, tableName)
+				require.NoError(t, err)
+				require.Equal(t, loadTableStat.RowsInserted, int64(14))
+				require.Equal(t, loadTableStat.RowsUpdated, int64(0))
+
+				records := whth.RetrieveRecordsFromWarehouse(t, pg.DB.DB,
+					fmt.Sprintf(`
+					SELECT
+					  id,
+					  received_at,
+					  test_bool,
+					  test_datetime,
+					  test_float,
+					  test_int,
+					  test_string
+					FROM
+					  %q.%q
+					ORDER BY
+					  id;
+					`,
+						namespace,
+						tableName,
+					),
+				)
+				require.Equal(t, records, whth.AppendTestRecords())
+			})
+			t.Run("with dedup", func(t *testing.T) {
+				tableName := "merge_with_dedup_test_table"
+				uploadOutput := whth.UploadLoadFile(t, fm, "../testdata/dedup.csv.gz", tableName)
+
+				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
+				mockUploader := mockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
+
+				c := config.New()
+				c.Set("Warehouse.postgres.EnableSQLStatementExecutionPlanWorkspaceIDs", workspaceID)
+
+				pg := postgres.New(config.New(), logger.NOP, memstats.New())
+				err := pg.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
 				err = pg.CreateSchema(ctx)
@@ -624,54 +674,6 @@ func TestIntegration(t *testing.T) {
 						tableName,
 					),
 				)
-				require.Equal(t, records, whth.SampleTestRecords())
-			})
-			t.Run("with dedup", func(t *testing.T) {
-				uploadOutput := whth.UploadLoadFile(t, fm, "../testdata/dedup.csv.gz", tableName)
-
-				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
-				mockUploader := mockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse)
-
-				c := config.New()
-				c.Set("Warehouse.postgres.EnableSQLStatementExecutionPlanWorkspaceIDs", workspaceID)
-
-				mergeWarehouse := th.Clone(t, warehouse)
-				mergeWarehouse.Destination.Config[string(model.EnableMergeSetting)] = true
-
-				pg := postgres.New(config.New(), logger.NOP, memstats.New())
-				err := pg.Setup(ctx, mergeWarehouse, mockUploader)
-				require.NoError(t, err)
-
-				err = pg.CreateSchema(ctx)
-				require.NoError(t, err)
-
-				err = pg.CreateTable(ctx, tableName, schemaInWarehouse)
-				require.NoError(t, err)
-
-				loadTableStat, err := pg.LoadTable(ctx, tableName)
-				require.NoError(t, err)
-				require.Equal(t, loadTableStat.RowsInserted, int64(0))
-				require.Equal(t, loadTableStat.RowsUpdated, int64(14))
-
-				records := whth.RetrieveRecordsFromWarehouse(t, pg.DB.DB,
-					fmt.Sprintf(`
-					SELECT
-					  id,
-					  received_at,
-					  test_bool,
-					  test_datetime,
-					  test_float,
-					  test_int,
-					  test_string
-					FROM
-					  %q.%q
-					ORDER BY
-					  id;
-					`,
-						namespace,
-						tableName,
-					),
-				)
 				require.Equal(t, records, whth.DedupTestRecords())
 			})
 		})
@@ -686,8 +688,11 @@ func TestIntegration(t *testing.T) {
 			c := config.New()
 			c.Set("Warehouse.postgres.skipDedupDestinationIDs", destinationID)
 
+			appendWarehouse := th.Clone(t, warehouse)
+			appendWarehouse.Destination.Config[string(model.PreferAppendSetting)] = true
+
 			pg := postgres.New(c, logger.NOP, memstats.New())
-			err := pg.Setup(ctx, warehouse, mockUploader)
+			err := pg.Setup(ctx, appendWarehouse, mockUploader)
 			require.NoError(t, err)
 
 			err = pg.CreateSchema(ctx)

--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -1329,7 +1329,7 @@ func (rs *Redshift) SetConnectionTimeout(timeout time.Duration) {
 func (rs *Redshift) shouldMerge() bool {
 	return !rs.Uploader.CanAppend() ||
 		(rs.config.allowMerge &&
-			rs.Warehouse.GetBoolDestinationConfig(model.EnableMergeSetting) &&
+			!rs.Warehouse.GetPreferAppendSetting() &&
 			!slices.Contains(rs.config.skipDedupDestinationIDs, rs.Warehouse.Destination.ID))
 }
 

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	th "github.com/rudderlabs/rudder-server/testhelper"
+
 	"github.com/golang/mock/gomock"
 	"github.com/lib/pq"
 	"github.com/ory/dockertest/v3"
@@ -28,7 +30,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/runner"
-	th "github.com/rudderlabs/rudder-server/testhelper"
 	"github.com/rudderlabs/rudder-server/testhelper/health"
 	"github.com/rudderlabs/rudder-server/testhelper/workspaceConfig"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -470,8 +471,11 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv)
 
+				appendWarehouse := th.Clone(t, warehouse)
+				appendWarehouse.Destination.Config[string(model.PreferAppendSetting)] = true
+
 				d := redshift.New(config.New(), logger.NOP, memstats.New())
-				err := d.Setup(ctx, warehouse, mockUploader)
+				err := d.Setup(ctx, appendWarehouse, mockUploader)
 				require.NoError(t, err)
 
 				err = d.CreateSchema(ctx)
@@ -515,11 +519,8 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv)
 
-				mergeWarehouse := th.Clone(t, warehouse)
-				mergeWarehouse.Destination.Config[string(model.EnableMergeSetting)] = true
-
 				d := redshift.New(config.New(), logger.NOP, memstats.New())
-				err := d.Setup(ctx, mergeWarehouse, mockUploader)
+				err := d.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
 				err = d.CreateSchema(ctx)
@@ -563,15 +564,12 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv)
 
-				mergeWarehouse := th.Clone(t, warehouse)
-				mergeWarehouse.Destination.Config[string(model.EnableMergeSetting)] = true
-
 				c := config.New()
 				c.Set("Warehouse.redshift.dedupWindow", true)
 				c.Set("Warehouse.redshift.dedupWindowInHours", 999999)
 
 				d := redshift.New(c, logger.NOP, memstats.New())
-				err := d.Setup(ctx, mergeWarehouse, mockUploader)
+				err := d.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
 				err = d.CreateSchema(ctx)
@@ -615,15 +613,12 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []warehouseutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, warehouseutils.LoadFileTypeCsv)
 
-				mergeWarehouse := th.Clone(t, warehouse)
-				mergeWarehouse.Destination.Config[string(model.EnableMergeSetting)] = true
-
 				c := config.New()
 				c.Set("Warehouse.redshift.dedupWindow", true)
 				c.Set("Warehouse.redshift.dedupWindowInHours", 0)
 
 				d := redshift.New(c, logger.NOP, memstats.New())
-				err := d.Setup(ctx, mergeWarehouse, mockUploader)
+				err := d.Setup(ctx, warehouse, mockUploader)
 				require.NoError(t, err)
 
 				err = d.CreateSchema(ctx)
@@ -672,8 +667,11 @@ func TestIntegration(t *testing.T) {
 			c := config.New()
 			c.Set("Warehouse.redshift.skipDedupDestinationIDs", []string{destinationID})
 
+			appendWarehouse := th.Clone(t, warehouse)
+			appendWarehouse.Destination.Config[string(model.PreferAppendSetting)] = true
+
 			rs := redshift.New(c, logger.NOP, memstats.New())
-			err := rs.Setup(ctx, warehouse, mockUploader)
+			err := rs.Setup(ctx, appendWarehouse, mockUploader)
 			require.NoError(t, err)
 
 			err = rs.CreateSchema(ctx)

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -829,7 +829,7 @@ func (sf *Snowflake) LoadIdentityMappingsTable(ctx context.Context) error {
 // * the user opted-in
 func (sf *Snowflake) ShouldMerge() bool {
 	return !sf.Uploader.CanAppend() ||
-		(sf.config.allowMerge && sf.Warehouse.GetBoolDestinationConfig(model.EnableMergeSetting))
+		(sf.config.allowMerge && !sf.Warehouse.GetPreferAppendSetting())
 }
 
 func (sf *Snowflake) LoadUserTables(ctx context.Context) map[string]error {

--- a/warehouse/integrations/snowflake/snowflake_test.go
+++ b/warehouse/integrations/snowflake/snowflake_test.go
@@ -27,6 +27,7 @@ import (
 	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/runner"
+	th "github.com/rudderlabs/rudder-server/testhelper"
 	"github.com/rudderlabs/rudder-server/testhelper/health"
 	"github.com/rudderlabs/rudder-server/testhelper/workspaceConfig"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -130,7 +131,7 @@ func TestIntegration(t *testing.T) {
 	rbacCredentials, err := getSnowflakeTestCredentials(testRBACKey)
 	require.NoError(t, err)
 
-	bootstrapSvc := func(t testing.TB, enableMerge bool) {
+	bootstrapSvc := func(t testing.TB, preferAppend bool) {
 		templateConfigurations := map[string]any{
 			"workspaceID":                workspaceID,
 			"sourceID":                   sourceID,
@@ -168,7 +169,7 @@ func TestIntegration(t *testing.T) {
 			"rbacBucketName":             rbacCredentials.BucketName,
 			"rbacAccessKeyID":            rbacCredentials.AccessKeyID,
 			"rbacAccessKey":              rbacCredentials.AccessKey,
-			"enableMerge":                enableMerge,
+			"preferAppend":               preferAppend,
 		}
 		workspaceConfigPath := workspaceConfig.CreateTempFile(t, "testdata/template.json", templateConfigurations)
 
@@ -227,7 +228,7 @@ func TestIntegration(t *testing.T) {
 			asyncJob                      bool
 			stagingFilePrefix             string
 			emptyJobRunID                 bool
-			enableMerge                   bool
+			preferAppend                  bool
 			customUserID                  string
 		}{
 			{
@@ -248,7 +249,7 @@ func TestIntegration(t *testing.T) {
 					"wh_staging_files": 34, // 32 + 2 (merge events because of ID resolution)
 				},
 				stagingFilePrefix: "testdata/upload-job",
-				enableMerge:       true,
+				preferAppend:      false,
 			},
 			{
 				name:     "Upload Job with Role",
@@ -268,7 +269,7 @@ func TestIntegration(t *testing.T) {
 					"wh_staging_files": 34, // 32 + 2 (merge events because of ID resolution)
 				},
 				stagingFilePrefix: "testdata/upload-job-with-role",
-				enableMerge:       true,
+				preferAppend:      false,
 			},
 			{
 				name:     "Upload Job with Case Sensitive Database",
@@ -288,10 +289,10 @@ func TestIntegration(t *testing.T) {
 					"wh_staging_files": 34, // 32 + 2 (merge events because of ID resolution)
 				},
 				stagingFilePrefix: "testdata/upload-job-case-sensitive",
-				enableMerge:       true,
+				preferAppend:      false,
 			},
 			{
-				name:          "Async Job with Sources",
+				name:          "Source Job with Sources",
 				writeKey:      sourcesWriteKey,
 				schema:        sourcesNamespace,
 				tables:        []string{"tracks", "google_sheet"},
@@ -310,7 +311,7 @@ func TestIntegration(t *testing.T) {
 				warehouseEventsMap:    testhelper.SourcesWarehouseEventsMap(),
 				asyncJob:              true,
 				stagingFilePrefix:     "testdata/sources-job",
-				enableMerge:           true,
+				preferAppend:          false,
 			},
 			{
 				name:                          "Upload Job in append mode",
@@ -331,7 +332,7 @@ func TestIntegration(t *testing.T) {
 				// an empty jobRunID means that the source is not an ETL one
 				// see Uploader.CanAppend()
 				emptyJobRunID: true,
-				enableMerge:   false,
+				preferAppend:  true,
 				customUserID:  testhelper.GetUserId("append_test"),
 			},
 		}
@@ -339,7 +340,7 @@ func TestIntegration(t *testing.T) {
 		for _, tc := range testcase {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
-				bootstrapSvc(t, tc.enableMerge)
+				bootstrapSvc(t, tc.preferAppend)
 
 				urlConfig := sfdb.Config{
 					Account:   tc.cred.Account,
@@ -501,7 +502,7 @@ func TestIntegration(t *testing.T) {
 				"syncFrequency":      "30",
 				"enableSSE":          false,
 				"useRudderStorage":   false,
-				"enableMerge":        true,
+				"preferAppend":       false,
 			},
 			DestinationDefinition: backendconfig.DestinationDefinitionT{
 				ID:          "1XjvXnzw34UMAz1YOuKqL1kwzh6",
@@ -662,9 +663,12 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []whutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, true, false)
 
+				appendWarehouse := th.Clone(t, warehouse)
+				appendWarehouse.Destination.Config[string(model.PreferAppendSetting)] = true
+
 				sf, err := snowflake.New(config.New(), logger.NOP, memstats.New())
 				require.NoError(t, err)
-				err = sf.Setup(ctx, warehouse, mockUploader)
+				err = sf.Setup(ctx, appendWarehouse, mockUploader)
 				require.NoError(t, err)
 
 				err = sf.CreateSchema(ctx)
@@ -756,9 +760,12 @@ func TestIntegration(t *testing.T) {
 				loadFiles := []whutils.LoadFile{{Location: uploadOutput.Location}}
 				mockUploader := newMockUploader(t, loadFiles, tableName, schemaInUpload, schemaInWarehouse, true, false)
 
+				appendWarehouse := th.Clone(t, warehouse)
+				appendWarehouse.Destination.Config[string(model.PreferAppendSetting)] = true
+
 				sf, err := snowflake.New(config.New(), logger.NOP, memstats.New())
 				require.NoError(t, err)
-				err = sf.Setup(ctx, warehouse, mockUploader)
+				err = sf.Setup(ctx, appendWarehouse, mockUploader)
 				require.NoError(t, err)
 
 				err = sf.CreateSchema(ctx)
@@ -949,35 +956,35 @@ func TestIntegration(t *testing.T) {
 func TestSnowflake_ShouldMerge(t *testing.T) {
 	testCases := []struct {
 		name                  string
-		enableMerge           bool
+		preferAppend          bool
 		uploaderCanAppend     bool
 		uploaderExpectedCalls int
 		expected              bool
 	}{
 		{
-			name:                  "uploader says we can append and merge is not enabled",
-			enableMerge:           false,
+			name:                  "uploader says we can append and user prefers append",
+			preferAppend:          true,
 			uploaderCanAppend:     true,
 			uploaderExpectedCalls: 1,
 			expected:              false,
 		},
 		{
-			name:                  "uploader says we cannot append and merge is not enabled",
-			enableMerge:           false,
+			name:                  "uploader says we cannot append and user prefers append",
+			preferAppend:          true,
 			uploaderCanAppend:     false,
 			uploaderExpectedCalls: 1,
 			expected:              true,
 		},
 		{
-			name:                  "uploader says we can append and merge is enabled",
-			enableMerge:           true,
+			name:                  "uploader says we can append and user prefers not to append",
+			preferAppend:          false,
 			uploaderCanAppend:     true,
 			uploaderExpectedCalls: 1,
 			expected:              true,
 		},
 		{
-			name:                  "uploader says we cannot append and we are in merge mode",
-			enableMerge:           true,
+			name:                  "uploader says we cannot append and user prefers not to append",
+			preferAppend:          false,
 			uploaderCanAppend:     false,
 			uploaderExpectedCalls: 1,
 			expected:              true,
@@ -992,7 +999,7 @@ func TestSnowflake_ShouldMerge(t *testing.T) {
 			sf.Warehouse = model.Warehouse{
 				Destination: backendconfig.DestinationT{
 					Config: map[string]any{
-						string(model.EnableMergeSetting): tc.enableMerge,
+						string(model.PreferAppendSetting): tc.preferAppend,
 					},
 				},
 			}

--- a/warehouse/integrations/snowflake/testdata/template.json
+++ b/warehouse/integrations/snowflake/testdata/template.json
@@ -40,7 +40,7 @@
             "syncFrequency": "30",
             "enableSSE": false,
             "useRudderStorage": false,
-            "enableMerge": {{.enableMerge}}
+            "preferAppend": {{.preferAppend}}
           },
           "liveEventsConfig": {},
           "secretConfig": {},
@@ -165,7 +165,7 @@
             "syncFrequency": "30",
             "enableSSE": false,
             "useRudderStorage": false,
-            "enableMerge": {{.enableMerge}}
+            "preferAppend": {{.preferAppend}}
           },
           "liveEventsConfig": {},
           "secretConfig": {},
@@ -291,7 +291,7 @@
             "syncFrequency": "30",
             "enableSSE": false,
             "useRudderStorage": false,
-            "enableMerge": {{.enableMerge}}
+            "preferAppend": {{.preferAppend}}
           },
           "liveEventsConfig": {},
           "secretConfig": {},
@@ -442,7 +442,7 @@
             "syncFrequency": "30",
             "enableSSE": false,
             "useRudderStorage": false,
-            "enableMerge": {{.enableMerge}}
+            "preferAppend": {{.preferAppend}}
           },
           "liveEventsConfig": {},
           "secretConfig": {},

--- a/warehouse/integrations/testdata/docker-compose.minio.yml
+++ b/warehouse/integrations/testdata/docker-compose.minio.yml
@@ -11,6 +11,6 @@ services:
       - MINIO_SITE_REGION=us-east-1
     command: server /data
     healthcheck:
-      test: curl --fail http://localhost:9000/minio/health/live || exit 1
+      test: timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
       interval: 1s
       retries: 25

--- a/warehouse/internal/model/warehouse.go
+++ b/warehouse/internal/model/warehouse.go
@@ -9,7 +9,7 @@ type destConfSetting string
 func (s destConfSetting) string() string { return string(s) }
 
 const (
-	EnableMergeSetting      destConfSetting = "enableMerge"
+	PreferAppendSetting     destConfSetting = "preferAppend"
 	UseRudderStorageSetting destConfSetting = "useRudderStorage"
 )
 
@@ -30,4 +30,13 @@ func (w *Warehouse) GetBoolDestinationConfig(key DestinationConfigSetting) bool 
 		}
 	}
 	return false
+}
+
+func (w *Warehouse) GetPreferAppendSetting() bool {
+	destConfig := w.Destination.Config
+	value, ok := destConfig[PreferAppendSetting.string()].(bool)
+	if !ok {
+		return false // default value for backwards compatibility
+	}
+	return value
 }

--- a/warehouse/internal/model/warehouse.go
+++ b/warehouse/internal/model/warehouse.go
@@ -34,9 +34,7 @@ func (w *Warehouse) GetBoolDestinationConfig(key DestinationConfigSetting) bool 
 
 func (w *Warehouse) GetPreferAppendSetting() bool {
 	destConfig := w.Destination.Config
-	value, ok := destConfig[PreferAppendSetting.string()].(bool)
-	if !ok {
-		return false // default value for backwards compatibility
-	}
+	// defaulting to false if not defined for backwards compatibility with previous behaviour
+	value, _ := destConfig[PreferAppendSetting.string()].(bool)
 	return value
 }


### PR DESCRIPTION
# Description

Follow up to [this PR](https://github.com/rudderlabs/rudder-server/pull/3965) where we changed the default behaviour for Warehouse destinations so that users would have to opt-in if they want to merge (aka remove duplicates).

Given that the UI changes for enabling the merge are not live we're setting `enableMerge` by default to `true` if it's not set. This maintains backwards compatibility and allows us to decouple the data plane deployment from the control plane one.

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-497/default-enablemerge-to-true-if-neither-true-of-false-are-present) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
