### PR TITLE
chore: increasing retries for health check for trino

### DIFF
--- a/warehouse/integrations/datalake/testdata/docker-compose.trino.yml
+++ b/warehouse/integrations/datalake/testdata/docker-compose.trino.yml
@@ -13,6 +13,12 @@ services:
         limits:
           cpus: '1'
           memory: 1G
+    healthcheck:
+      test: [ "CMD-SHELL", "/usr/lib/trino/bin/health-check" ]
+      interval: 10s
+      timeout: 5s
+      start_period: 10s
+      retries: 25
 
   hive-metastore:
     image: rudderstack/hive-metastore:latest


### PR DESCRIPTION
# Description

- Configuring health check for Trino (Datalake tests). It got failed couple of times, container was not healthy. 
  ```
   https://github.com/rudderlabs/rudder-server/actions/runs/6802468397/job/18511513258
   https://github.com/rudderlabs/rudder-server/actions/runs/6808051074/job/18511879650
          
   container test_cpzetxvyawuwqvhyqfgm-trino-1 is unhealthy
   err: exit status 1
   --- FAIL: TestIntegration (107.12s)
  ```

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
