### PR TITLE
chore: remove panic and continue with old config on incremental update failure

### DIFF
--- a/backend-config/backend-config.go
+++ b/backend-config/backend-config.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -177,6 +178,9 @@ func (bc *backendConfigImpl) configUpdate(ctx context.Context) {
 	if err != nil {
 		statConfigBackendError.Increment()
 		pkgLogger.Warnf("Error fetching config from backend: %v", err)
+		if errors.Is(err, ErrIncrementalUpdateFailed) {
+			stats.Default.NewStat("config_backend.ErrIncrementalUpdateFailed", stats.CountType).Increment()
+		}
 
 		bc.initializedLock.RLock()
 		if bc.initialized {


### PR DESCRIPTION
# Description

incremental update failure causes a panic. Removing that panic.

## Linear Ticket

[Slack thread for context](https://rudderlabs.slack.com/archives/C01HTT66UMB/p1699502654415459)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
