### PR TITLE
fix: redshift users dedup and bq default when undefined

### DIFF
--- a/warehouse/internal/model/warehouse.go
+++ b/warehouse/internal/model/warehouse.go
@@ -37,10 +37,7 @@ func (w *Warehouse) GetPreferAppendSetting() bool {
 	// defaulting to false if not defined for backwards compatibility with previous behaviour
 	value, ok := destConfig[PreferAppendSetting.string()].(bool)
 	if !ok {
-		if w.Type == "BQ" {
-			return true // defaulting to true for BQ
-		}
-		return false
+		return w.Type == "BQ" // defaulting to true for BQ, false for other destination types
 	}
 	return value
 }

--- a/warehouse/internal/model/warehouse.go
+++ b/warehouse/internal/model/warehouse.go
@@ -35,6 +35,12 @@ func (w *Warehouse) GetBoolDestinationConfig(key DestinationConfigSetting) bool 
 func (w *Warehouse) GetPreferAppendSetting() bool {
 	destConfig := w.Destination.Config
 	// defaulting to false if not defined for backwards compatibility with previous behaviour
-	value, _ := destConfig[PreferAppendSetting.string()].(bool)
+	value, ok := destConfig[PreferAppendSetting.string()].(bool)
+	if !ok {
+		if w.Type == "BQ" {
+			return true // defaulting to true for BQ
+		}
+		return false
+	}
 	return value
 }


### PR DESCRIPTION
# Description

* always merge user tables on redshift
* if UI setting is undefined default to true for bigquery

### TODOs
* add test scenarios

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-519/fix-redshift-users-dedup-on-warehouse-plus-review-defaults-when-ui-not) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
