### PR TITLE
chore: add a dial timeout of 10 seconds in etcd client during tests

### DIFF
--- a/testhelper/etcd/etcd.go
+++ b/testhelper/etcd/etcd.go
@@ -3,6 +3,7 @@ package etcd
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/ory/dockertest/v3"
 	etcd "go.etcd.io/etcd/client/v3"
@@ -53,6 +54,7 @@ func Setup(pool *dockertest.Pool, cln cleaner) (*Resource, error) {
 			DialOptions: []grpc.DialOption{
 				grpc.WithBlock(), // block until the underlying connection is up
 			},
+			DialTimeout: 10 * time.Second,
 		})
 		return err
 	})


### PR DESCRIPTION
# Description

Adding a timeout so that the client creation doesn't block forever in case of a problem

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
