### PR TITLE
fix: warehouse archiver integration tests

### DIFF
--- a/integration_test/warehouse/integration_test.go
+++ b/integration_test/warehouse/integration_test.go
@@ -1090,15 +1090,6 @@ func TestUploads(t *testing.T) {
 				},
 			},
 		}))
-		requireStagingFileEventsCount(t, ctx, db, events, []lo.Tuple2[string, interface{}]{
-			{A: "source_id", B: sourceID},
-			{A: "destination_id", B: destinationID},
-			{A: "status", B: succeeded},
-		}...)
-		requireLoadFileEventsCount(t, ctx, db, events, []lo.Tuple2[string, interface{}]{
-			{A: "source_id", B: sourceID},
-			{A: "destination_id", B: destinationID},
-		}...)
 		requireTableUploadEventsCount(t, ctx, db, events, []lo.Tuple2[string, interface{}]{
 			{A: "status", B: exportedData},
 			{A: "wh_uploads.source_id", B: sourceID},


### PR DESCRIPTION
# Description

- Entries for staging files and load files are archived during the test. Verifying their count may introduce a race condition due to the archiving process.
- We can skip verification for staging files and load files as we are already validating the successful upload count.

## Linear Ticket

- Resolves PIPE-535

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
