### PR TITLE
chore: include github-actions and docker updates (PIPE-539)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/" # Location of package manifests
+    directory: "/" 
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/" 
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/" 
     schedule:
       interval: "daily"


### PR DESCRIPTION
# Description

Configure dependabot to check for updates github-actions and dockerfiles

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-539/extend-dependabot-responsibilites

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
