### PR TITLE
chore: include all aborted jobs in failed records

### DIFF
--- a/router/batchrouter/handle_observability.go
+++ b/router/batchrouter/handle_observability.go
@@ -5,15 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/samber/lo"
-
 	"github.com/rudderlabs/rudder-server/warehouse/router"
 
 	"github.com/tidwall/sjson"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/jobsdb"
-	routerutils "github.com/rudderlabs/rudder-server/router/utils"
 	destinationdebugger "github.com/rudderlabs/rudder-server/services/debugger/destination"
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 	"github.com/rudderlabs/rudder-server/services/rsources"
@@ -224,14 +221,7 @@ func (brt *Handle) updateRudderSourcesStats(
 	rsourcesStats := rsources.NewStatsCollector(brt.rsourcesService)
 	rsourcesStats.BeginProcessing(jobs)
 	rsourcesStats.CollectStats(jobStatuses)
-	rsourcesStats.CollectFailedRecords(
-		lo.Filter(
-			jobStatuses,
-			func(status *jobsdb.JobStatusT, _ int) bool {
-				return status.ErrorCode == routerutils.DRAIN_ERROR_CODE
-			},
-		),
-	)
+	rsourcesStats.CollectFailedRecords(jobStatuses)
 	err := rsourcesStats.Publish(ctx, tx.SqlTx())
 	if err != nil {
 		return fmt.Errorf("publishing rsources stats: %w", err)

--- a/router/handle_observability.go
+++ b/router/handle_observability.go
@@ -6,12 +6,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/samber/lo"
-
 	"github.com/rudderlabs/rudder-go-kit/sqlutil"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/jobsdb"
-	routerutils "github.com/rudderlabs/rudder-server/router/utils"
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 	"github.com/rudderlabs/rudder-server/services/rsources"
 	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
@@ -97,14 +94,7 @@ func (rt *Handle) updateRudderSourcesStats(
 	rsourcesStats := rsources.NewStatsCollector(rt.rsourcesService)
 	rsourcesStats.BeginProcessing(jobs)
 	rsourcesStats.CollectStats(jobStatuses)
-	rsourcesStats.CollectFailedRecords(
-		lo.Filter(
-			jobStatuses,
-			func(status *jobsdb.JobStatusT, _ int) bool {
-				return status.ErrorCode == routerutils.DRAIN_ERROR_CODE
-			},
-		),
-	)
+	rsourcesStats.CollectFailedRecords(jobStatuses)
 	err := rsourcesStats.Publish(ctx, tx.SqlTx())
 	if err != nil {
 		rt.logger.Errorf("publishing rsources stats: %w", err)


### PR DESCRIPTION
# Description

Including all router/batchrouter aborted jobs in failed records instead of just drained ones

## Linear Ticket

Partially resolves PIPE-485 see also #4116

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
