### PR TITLE
fix: gateway responds with http status 500 and body pq: invalid byte sequence for encoding UTF8: 0x00

### DIFF
--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -324,8 +324,8 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 			return
 		}
 
-		anonIDFromReq := strings.TrimSpace(misc.GetStringifiedData(toSet["anonymousId"]))
-		userIDFromReq := strings.TrimSpace(misc.GetStringifiedData(toSet["userId"]))
+		anonIDFromReq := strings.TrimSpace(misc.SanitizeUnicode(misc.GetStringifiedData(toSet["anonymousId"])))
+		userIDFromReq := strings.TrimSpace(misc.SanitizeUnicode(misc.GetStringifiedData(toSet["userId"])))
 		eventTypeFromReq, _ := misc.MapLookup(
 			toSet,
 			"type",


### PR DESCRIPTION
# Description

Sanitizing user id fields while reading them from the message before storing user_id in database 

## Linear Ticket

fixes PIPE-549

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
