### PR TITLE
fix: update submodule repo links to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "rudder-transformer"]
 	path = rudder-transformer
-	url = git@github.com:rudderlabs/rudder-transformer.git
+	url = https://rudderlabs/rudder-transformer.git


### PR DESCRIPTION
Github does not allow public cloning via ssh link but only https links. Update the rudder-transformer submodule repo link to https so people can setup rudder-server on local without Git identity.

# Description

< Replace with adequate description for this PR as per [Pull Request document](https://www.notion.so/rudderstacks/Pull-Requests-40a4c6bd7a5e4387ba9029bab297c9e3) >

## Linear Ticket

< Replace with Linear Link >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
