### PR TITLE
chore: improve rsources service table setup procedure

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,7 +76,7 @@ jobs:
           username: rudderlabs
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Warehouse Service Integration [ ${{ matrix.destination }} ]
-        run: make test-warehouse package=./${{ matrix.package }}/...
+        run: make test-warehouse package=${{ matrix.package }}
         env:
           BIGQUERY_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.BIGQUERY_INTEGRATION_TEST_CREDENTIALS }}
           DATABRICKS_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.DATABRICKS_INTEGRATION_TEST_CREDENTIALS }}
@@ -123,8 +123,13 @@ jobs:
           - regulation-worker
           - router
           - services
+          - services/rsources
           - suppression-backup-service
           - warehouse
+        include:
+          - package: services
+            exclude: services/rsources
+          
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
@@ -143,7 +148,7 @@ jobs:
           TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_CONNECTION_STRING: ${{ secrets.TEST_KAFKA_AZURE_EVENT_HUBS_CLOUD_CONNECTION_STRING }}
           TEST_S3_DATALAKE_CREDENTIALS: ${{ secrets.TEST_S3_DATALAKE_CREDENTIALS }}
           BIGQUERY_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.BIGQUERY_INTEGRATION_TEST_CREDENTIALS }}
-        run: make test package=./${{ matrix.package }}/...
+        run: make test exclude="${{ matrix.exclude }}" package=${{ matrix.package }}
       - name: Sanitize name for Artifact
         run: |
           name=$(echo -n "${{ matrix.package }}" | sed -e 's/[ \t:\/\\"<>|*?]/-/g' -e 's/--*/-/g')

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,12 @@ else
 	$(eval TEST_OPTIONS = -p=1 -v -failfast -shuffle=on -coverprofile=profile.out -covermode=atomic -coverpkg=./... -vet=all --timeout=15m)
 endif
 ifdef package
-	$(TEST_CMD) $(TEST_OPTIONS) $(package) && touch $(TESTFILE) || true
+ifdef exclude
+	$(eval FILES = `go list ./$(package)/... | egrep -iv '$(exclude)'`)
+	$(TEST_CMD) -count=1 $(TEST_OPTIONS) $(FILES) && touch $(TESTFILE) || true
+else
+	$(TEST_CMD) $(TEST_OPTIONS) ./$(package)/... && touch $(TESTFILE) || true
+endif
 else ifdef exclude
 	$(eval FILES = `go list ./... | egrep -iv '$(exclude)'`)
 	$(TEST_CMD) -count=1 $(TEST_OPTIONS) $(FILES) && touch $(TESTFILE) || true
@@ -32,7 +37,7 @@ test-warehouse-integration:
 	$(eval TEST_PATTERN = 'TestIntegration')
 	$(eval TEST_CMD = SLOW=1 go test)
 	$(eval TEST_OPTIONS = -v -p 8 -timeout 30m -count 1 -run $(TEST_PATTERN) -coverprofile=profile.out -covermode=atomic -coverpkg=./...)
-	$(TEST_CMD) $(TEST_OPTIONS) $(package) && touch $(TESTFILE) || true
+	$(TEST_CMD) $(TEST_OPTIONS) ./$(package)/... && touch $(TESTFILE) || true
 
 test-warehouse: test-warehouse-integration test-teardown
 

--- a/services/rsources/handler_test.go
+++ b/services/rsources/handler_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Using sources handler", func() {
 			Out:    4,
 			Failed: 6,
 		}
-		BeforeAll(func() {
+		BeforeEach(func() {
 			var err error
 			pool, err = dockertest.NewPool("")
 			Expect(err).NotTo(HaveOccurred())
@@ -65,7 +65,7 @@ var _ = Describe("Using sources handler", func() {
 			sh = createService(config)
 		})
 
-		AfterAll(func() {
+		AfterEach(func() {
 			purgeResources(pool, resource.resource)
 		})
 
@@ -655,7 +655,7 @@ var _ = Describe("Using sources handler", func() {
 			serviceA, serviceB JobService
 		)
 
-		BeforeAll(func() {
+		BeforeEach(func() {
 			var err error
 			pool, err = dockertest.NewPool("")
 			Expect(err).NotTo(HaveOccurred())
@@ -700,7 +700,7 @@ var _ = Describe("Using sources handler", func() {
 			serviceB = createService(configB)
 		})
 
-		AfterAll(func() {
+		AfterEach(func() {
 			purgeResources(pool, pgA.resource, pgB.resource, pgC.resource)
 			if network != nil {
 				_ = pool.Client.RemoveNetwork(network.ID)
@@ -888,7 +888,7 @@ var _ = Describe("Using sources handler", func() {
 			serviceA JobService
 		)
 
-		BeforeAll(func() {
+		BeforeEach(func() {
 			var err error
 			pool, err = dockertest.NewPool("")
 			Expect(err).NotTo(HaveOccurred())
@@ -918,7 +918,7 @@ var _ = Describe("Using sources handler", func() {
 			serviceA = createService(configA)
 		})
 
-		AfterAll(func() {
+		AfterEach(func() {
 			purgeResources(pool, pgA.resource, pgB.resource)
 			if network != nil {
 				_ = pool.Client.RemoveNetwork(network.ID)

--- a/services/rsources/handler_v1_test.go
+++ b/services/rsources/handler_v1_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Using sources handler v1", func() {
 			Out:    4,
 			Failed: 6,
 		}
-		BeforeAll(func() {
+		BeforeEach(func() {
 			var err error
 			pool, err = dockertest.NewPool("")
 			Expect(err).NotTo(HaveOccurred())
@@ -45,7 +45,7 @@ var _ = Describe("Using sources handler v1", func() {
 			sh = createService(config)
 		})
 
-		AfterAll(func() {
+		AfterEach(func() {
 			purgeResources(pool, resource.resource)
 		})
 
@@ -337,7 +337,7 @@ var _ = Describe("Using sources handler v1", func() {
 			serviceA, serviceB JobService
 		)
 
-		BeforeAll(func() {
+		BeforeEach(func() {
 			var err error
 			pool, err = dockertest.NewPool("")
 			Expect(err).NotTo(HaveOccurred())
@@ -382,7 +382,7 @@ var _ = Describe("Using sources handler v1", func() {
 			serviceB = createService(configB)
 		})
 
-		AfterAll(func() {
+		AfterEach(func() {
 			purgeResources(pool, pgA.resource, pgB.resource, pgC.resource)
 			if network != nil {
 				_ = pool.Client.RemoveNetwork(network.ID)

--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -199,6 +199,9 @@ func NewJobService(config JobServiceConfig) (JobService, error) {
 	if config.Log == nil {
 		config.Log = logger.NewLogger().Child("rsources")
 	}
+	if config.MaxPoolSize <= 2 {
+		config.MaxPoolSize = 2 // minimum 2 connections in the pool for proper startup
+	}
 	var (
 		localDB, sharedDB *sql.DB
 		err               error


### PR DESCRIPTION
# Description

- Using an advisory lock during rsources table setup to avoid race conditions between pods.
- Addressing rsources tests' flakiness while running in github actions:
  - isolating `services/rsources` tests on a separate runner
  - using BeforeEach/AfterEach instead of BeforeAll/AfterAll

## Linear Ticket

resolves PIPE-488
resolves PIPE-561

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD Pipeline Enhancements**
  - Improved CI/CD pipeline to conditionally configure test runs and artifact naming for the "services" package.

- **Testing Infrastructure**
  - Updated Makefile to refine test execution based on package inclusion or exclusion.
  - Enhanced test suites for better resource management and isolation during setup and teardown.

- **Service Reliability**
  - Implemented advisory lock mechanism to ensure safe initialization of resources.
  - Adjusted `JobService` configuration to enforce a minimum connection pool size for stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->