### PR TITLE
chore: trim down error responses stored in job status to a maximum of 10KB

### DIFF
--- a/router/worker.go
+++ b/router/worker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
@@ -629,8 +630,9 @@ func (w *worker) processDestinationJobs() {
 			jobOrderKeyToJobIDMap[orderKey] = destinationJobMetadata.JobID
 		}
 
+		trimmedResponse := string(lo.Slice([]byte(routerJobResponse.respBody), 0, int(10*bytesize.KB)))
 		status.AttemptNum++
-		status.ErrorResponse = routerutils.EnhanceJSON(routerutils.EmptyPayload, "response", routerJobResponse.respBody)
+		status.ErrorResponse = routerutils.EnhanceJSON(routerutils.EmptyPayload, "response", trimmedResponse)
 		status.ErrorCode = strconv.Itoa(respStatusCode)
 
 		if isJobTerminated(respStatusCode) {


### PR DESCRIPTION
# Description

Avoiding storing huge error responses in job status tables causing infinite full vaccums

## Linear Ticket

resolves PIPE-562

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
