### PR TITLE
fix: snowflake pass timestamp in prepared statement

### DIFF
--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -326,7 +326,7 @@ func (sf *Snowflake) DeleteBy(ctx context.Context, tableNames []string, params w
 		log.Debugw("Deleting rows in table in snowflake", lf.Query, sqlStatement)
 
 		if sf.config.enableDeleteByJobs {
-			_, err := sf.DB.ExecContext(ctx,
+			_, err := sf.DB.ExecContext(ctx, sqlStatement,
 				params.JobRunId,
 				params.TaskRunId,
 				params.SourceId,

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -319,7 +319,7 @@ func (sf *Snowflake) DeleteBy(ctx context.Context, tableNames []string, params w
 				context_sources_job_run_id <> $1 AND
 				context_sources_task_run_id <> $2 AND
 				context_source_id = $3 AND
-				received_at < $4;`,
+				received_at < TO_TIMESTAMP($4,'MM-DD-YYYY HH:MI:SS');`,
 			sf.Namespace,
 			tb,
 		)

--- a/warehouse/integrations/testhelper/verify.go
+++ b/warehouse/integrations/testhelper/verify.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"github.com/rudderlabs/rudder-server/warehouse/source"
 
 	"github.com/stretchr/testify/require"
 
@@ -254,7 +255,7 @@ func verifySourceJob(t testing.TB, tc *TestConfig) {
 		tc.JobRunID,
 		tc.TaskRunID,
 		tc.DestinationID,
-		time.Now().UTC().Format("2006-01-02 15:04:05"),
+		time.Now().UTC().Format(source.CustomTimeLayout),
 		tc.WorkspaceID,
 	)
 

--- a/warehouse/slave/worker.go
+++ b/warehouse/slave/worker.go
@@ -490,7 +490,7 @@ func (w *worker) runSourceJob(ctx context.Context, sourceJob source.NotifierRequ
 			SourceId:  sourceJob.SourceID,
 			TaskRunId: metadata.TaskRunId,
 			JobRunId:  metadata.JobRunId,
-			StartTime: metadata.StartTime.Time,
+			StartTime: metadata.StartTime,
 		})
 	default:
 		err = errors.New("invalid sourceJob type")

--- a/warehouse/slave/worker.go
+++ b/warehouse/slave/worker.go
@@ -490,7 +490,7 @@ func (w *worker) runSourceJob(ctx context.Context, sourceJob source.NotifierRequ
 			SourceId:  sourceJob.SourceID,
 			TaskRunId: metadata.TaskRunId,
 			JobRunId:  metadata.JobRunId,
-			StartTime: metadata.StartTime,
+			StartTime: metadata.StartTime.Time,
 		})
 	default:
 		err = errors.New("invalid sourceJob type")

--- a/warehouse/source/source.go
+++ b/warehouse/source/source.go
@@ -99,7 +99,7 @@ func (m *Manager) InsertJobs(ctx context.Context, payload insertJobRequest) ([]i
 	metadataJson, err := json.Marshal(metadata{
 		JobRunID:  payload.JobRunID,
 		TaskRunID: payload.TaskRunID,
-		StartTime: payload.StartTime,
+		StartTime: payload.StartTime.Time,
 		JobType:   string(notifier.JobTypeAsync),
 	})
 	if err != nil {

--- a/warehouse/source/source.go
+++ b/warehouse/source/source.go
@@ -91,10 +91,10 @@ func (m *Manager) InsertJobs(ctx context.Context, payload insertJobRequest) ([]i
 	})
 
 	type metadata struct {
-		JobRunID  string `json:"job_run_id"`
-		TaskRunID string `json:"task_run_id"`
-		JobType   string `json:"jobtype"`
-		StartTime string `json:"start_time"`
+		JobRunID  string    `json:"job_run_id"`
+		TaskRunID string    `json:"task_run_id"`
+		JobType   string    `json:"jobtype"`
+		StartTime time.Time `json:"start_time"`
 	}
 	metadataJson, err := json.Marshal(metadata{
 		JobRunID:  payload.JobRunID,

--- a/warehouse/source/types.go
+++ b/warehouse/source/types.go
@@ -31,7 +31,7 @@ type CustomTime struct {
 	time.Time
 }
 
-const ctLayout = "01-02-2006 15:04:05"
+const CustomTimeLayout = "01-02-2006 15:04:05"
 
 func (ct *CustomTime) UnmarshalJSON(b []byte) (err error) {
 	s := strings.Trim(string(b), "\"")
@@ -39,7 +39,7 @@ func (ct *CustomTime) UnmarshalJSON(b []byte) (err error) {
 		ct.Time = time.Time{}
 		return
 	}
-	ct.Time, err = time.Parse(ctLayout, s)
+	ct.Time, err = time.Parse(CustomTimeLayout, s)
 	return
 }
 
@@ -47,7 +47,7 @@ func (ct *CustomTime) MarshalJSON() ([]byte, error) {
 	if ct.Time.IsZero() {
 		return []byte("null"), nil
 	}
-	return []byte(fmt.Sprintf("\"%s\"", ct.Time.Format(ctLayout))), nil
+	return []byte(fmt.Sprintf("\"%s\"", ct.Time.Format(CustomTimeLayout))), nil
 }
 
 type insertJobResponse struct {

--- a/warehouse/source/types.go
+++ b/warehouse/source/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"time"
 
 	"github.com/rudderlabs/rudder-server/services/notifier"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
@@ -15,13 +16,13 @@ var (
 )
 
 type insertJobRequest struct {
-	SourceID      string `json:"source_id"`
-	DestinationID string `json:"destination_id"`
-	StartTime     string `json:"start_time"`
-	JobRunID      string `json:"job_run_id"`
-	TaskRunID     string `json:"task_run_id"`
-	JobType       string `json:"async_job_type"`
-	WorkspaceID   string `json:"workspace_id"`
+	SourceID      string    `json:"source_id"`
+	DestinationID string    `json:"destination_id"`
+	StartTime     time.Time `json:"start_time"`
+	JobRunID      string    `json:"job_run_id"`
+	TaskRunID     string    `json:"task_run_id"`
+	JobType       string    `json:"async_job_type"`
+	WorkspaceID   string    `json:"workspace_id"`
 }
 
 type insertJobResponse struct {

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -199,9 +199,32 @@ func loadConfig() {
 }
 
 type DeleteByMetaData struct {
-	JobRunId  string    `json:"job_run_id"`
-	TaskRunId string    `json:"task_run_id"`
-	StartTime time.Time `json:"start_time"`
+	JobRunId  string     `json:"job_run_id"`
+	TaskRunId string     `json:"task_run_id"`
+	StartTime CustomTime `json:"start_time"`
+}
+
+type CustomTime struct {
+	time.Time
+}
+
+const ctLayout = "01-02-2006 15:04:05"
+
+func (ct *CustomTime) UnmarshalJSON(b []byte) (err error) {
+	s := strings.Trim(string(b), "\"")
+	if s == "null" {
+		ct.Time = time.Time{}
+		return
+	}
+	ct.Time, err = time.Parse(ctLayout, s)
+	return
+}
+
+func (ct *CustomTime) MarshalJSON() ([]byte, error) {
+	if ct.Time.IsZero() {
+		return []byte("null"), nil
+	}
+	return []byte(fmt.Sprintf("\"%s\"", ct.Time.Format(ctLayout))), nil
 }
 
 type DeleteByParams struct {

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -199,16 +199,16 @@ func loadConfig() {
 }
 
 type DeleteByMetaData struct {
-	JobRunId  string `json:"job_run_id"`
-	TaskRunId string `json:"task_run_id"`
-	StartTime string `json:"start_time"`
+	JobRunId  string    `json:"job_run_id"`
+	TaskRunId string    `json:"task_run_id"`
+	StartTime time.Time `json:"start_time"`
 }
 
 type DeleteByParams struct {
 	SourceId  string
 	JobRunId  string
 	TaskRunId string
-	StartTime string
+	StartTime time.Time
 }
 
 type ColumnInfo struct {

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -199,32 +199,9 @@ func loadConfig() {
 }
 
 type DeleteByMetaData struct {
-	JobRunId  string     `json:"job_run_id"`
-	TaskRunId string     `json:"task_run_id"`
-	StartTime CustomTime `json:"start_time"`
-}
-
-type CustomTime struct {
-	time.Time
-}
-
-const ctLayout = "01-02-2006 15:04:05"
-
-func (ct *CustomTime) UnmarshalJSON(b []byte) (err error) {
-	s := strings.Trim(string(b), "\"")
-	if s == "null" {
-		ct.Time = time.Time{}
-		return
-	}
-	ct.Time, err = time.Parse(ctLayout, s)
-	return
-}
-
-func (ct *CustomTime) MarshalJSON() ([]byte, error) {
-	if ct.Time.IsZero() {
-		return []byte("null"), nil
-	}
-	return []byte(fmt.Sprintf("\"%s\"", ct.Time.Format(ctLayout))), nil
+	JobRunId  string    `json:"job_run_id"`
+	TaskRunId string    `json:"task_run_id"`
+	StartTime time.Time `json:"start_time"`
 }
 
 type DeleteByParams struct {


### PR DESCRIPTION
# Description

< Replace with adequate description for this PR as per [Pull Request document](https://www.notion.so/rudderstacks/Pull-Requests-40a4c6bd7a5e4387ba9029bab297c9e3) >

## Linear Ticket

< Replace with Linear Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the `DeleteBy` method to use parameterized queries for improved security and maintainability.
  - Introduced a `CustomTime` type to standardize time-related operations across the system.

- **Refactor**
  - Updated various structures to use `time.Time` and `CustomTime` instead of string representations for time fields, ensuring better type safety and consistency.

- **Bug Fixes**
  - Adjusted the `runSourceJob` function to correctly populate the `StartTime` field with a time object.

- **Documentation**
  - No visible changes to end-user documentation in this release.

Please note that these changes are part of ongoing improvements to enhance the system's reliability and performance. Users may experience more accurate and consistent handling of time-related data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->