### PR TITLE
chore: improve fatal log during panic capture

### DIFF
--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -924,7 +924,15 @@ func BugsnagNotify(ctx context.Context, team string) func() {
 					},
 				})
 				RecordAppError(fmt.Errorf("%v", r))
-				pkgLogger.Fatal(r)
+				pkgLogger.Fatalw("Panic detected. Application will crash.",
+					"stack", string(debug.Stack()),
+					"panic", r,
+					"team", team,
+					"goRoutines", runtime.NumGoroutine(),
+					"version", bugsnag.Config.AppVersion,
+					"releaseStage", bugsnag.Config.ReleaseStage,
+				)
+				logger.Sync()
 				panic(r)
 			})
 		}


### PR DESCRIPTION
# Description

Ensuring Fatal log during panic capture contains equivalent information to panic. This will allow us to start using alerts based on logs instead of bugsnag for getting notified.

## Linear Ticket

resolves PIPE-549 https://linear.app/rudderstack/issue/PIPE-594/improve-log-during-panic-capture

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
