### PR TITLE
feat: introduce random sleep before clickhouse loads

### DIFF
--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -503,8 +503,10 @@ func (ch *Clickhouse) typecastDataFromType(data, dataType string) interface{} {
 
 // loadTable loads table to clickhouse from the load files
 func (ch *Clickhouse) loadTable(ctx context.Context, tableName string, tableSchemaInUpload model.TableSchema) (err error) {
-	if err = misc.SleepCtx(ctx, ch.config.randomLoadDelay(ch.Warehouse.WorkspaceID)); err != nil {
-		return
+	if delay := ch.config.randomLoadDelay(ch.Warehouse.WorkspaceID); delay > 0 {
+		if err = misc.SleepCtx(ctx, delay); err != nil {
+			return
+		}
 	}
 	if ch.UseS3CopyEngineForLoading() {
 		return ch.loadByCopyCommand(ctx, tableName, tableSchemaInUpload)

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/url"
 	"os"
 	"path"
@@ -160,6 +161,7 @@ type Clickhouse struct {
 		numWorkersDownloadLoadFiles int
 		s3EngineEnabledWorkspaceIDs []string
 		slowQueryThreshold          time.Duration
+		randomLoadDelay             func(string) time.Duration
 	}
 }
 
@@ -234,6 +236,15 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats) *Clickhouse {
 	ch.config.numWorkersDownloadLoadFiles = conf.GetInt("Warehouse.clickhouse.numWorkersDownloadLoadFiles", 8)
 	ch.config.s3EngineEnabledWorkspaceIDs = conf.GetStringSlice("Warehouse.clickhouse.s3EngineEnabledWorkspaceIDs", nil)
 	ch.config.slowQueryThreshold = conf.GetDuration("Warehouse.clickhouse.slowQueryThreshold", 5, time.Minute)
+	ch.config.randomLoadDelay = func(destinationID string) time.Duration {
+		maxDelay := conf.GetDurationVar(
+			5,
+			time.Second,
+			fmt.Sprintf("Warehouse.clickhouse.%s.maxLoadDelay", destinationID),
+			"Warehouse.clickhouse.maxLoadDelay",
+		)
+		return time.Duration(float64(maxDelay) * (1 - rand.Float64()))
+	}
 
 	return ch
 }
@@ -491,6 +502,9 @@ func (ch *Clickhouse) typecastDataFromType(data, dataType string) interface{} {
 
 // loadTable loads table to clickhouse from the load files
 func (ch *Clickhouse) loadTable(ctx context.Context, tableName string, tableSchemaInUpload model.TableSchema) (err error) {
+	if misc.SleepCtx(ctx, ch.config.randomLoadDelay(ch.Warehouse.Destination.ID)) != nil {
+		return nil
+	}
 	if ch.UseS3CopyEngineForLoading() {
 		return ch.loadByCopyCommand(ctx, tableName, tableSchemaInUpload)
 	}

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -236,6 +236,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats) *Clickhouse {
 	ch.config.numWorkersDownloadLoadFiles = conf.GetInt("Warehouse.clickhouse.numWorkersDownloadLoadFiles", 8)
 	ch.config.s3EngineEnabledWorkspaceIDs = conf.GetStringSlice("Warehouse.clickhouse.s3EngineEnabledWorkspaceIDs", nil)
 	ch.config.slowQueryThreshold = conf.GetDuration("Warehouse.clickhouse.slowQueryThreshold", 5, time.Minute)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	ch.config.randomLoadDelay = func(destinationID string) time.Duration {
 		maxDelay := conf.GetDurationVar(
 			5,
@@ -243,7 +244,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats) *Clickhouse {
 			fmt.Sprintf("Warehouse.clickhouse.%s.maxLoadDelay", destinationID),
 			"Warehouse.clickhouse.maxLoadDelay",
 		)
-		return time.Duration(float64(maxDelay) * (1 - rand.Float64()))
+		return time.Duration(float64(maxDelay) * (1 - r.Float64()))
 	}
 
 	return ch

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -239,7 +239,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats) *Clickhouse {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	ch.config.randomLoadDelay = func(destinationID string) time.Duration {
 		maxDelay := conf.GetDurationVar(
-			5,
+			0,
 			time.Second,
 			fmt.Sprintf("Warehouse.clickhouse.%s.maxLoadDelay", destinationID),
 			"Warehouse.clickhouse.maxLoadDelay",
@@ -503,8 +503,8 @@ func (ch *Clickhouse) typecastDataFromType(data, dataType string) interface{} {
 
 // loadTable loads table to clickhouse from the load files
 func (ch *Clickhouse) loadTable(ctx context.Context, tableName string, tableSchemaInUpload model.TableSchema) (err error) {
-	if misc.SleepCtx(ctx, ch.config.randomLoadDelay(ch.Warehouse.Destination.ID)) != nil {
-		return nil
+	if err = misc.SleepCtx(ctx, ch.config.randomLoadDelay(ch.Warehouse.Destination.ID)); err != nil {
+		return
 	}
 	if ch.UseS3CopyEngineForLoading() {
 		return ch.loadByCopyCommand(ctx, tableName, tableSchemaInUpload)


### PR DESCRIPTION
# Description

Customers facing issues due to continuous inserts on clickhouse. This introduces a `misc.SleepCtx` before every load anywhere between (0, maxDelay] with maxDelay defaulting to 5s.

## Linear Ticket

[Fix Clickhouse "too many parts" errors while inserting data](https://linear.app/rudderstack/issue/PIPE-529/fix-clickhouse-too-many-parts-errors-while-inserting-data)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented a feature to introduce a random delay in data loading processes to optimize performance under varying system loads.

- **Refactor**
  - Enhanced the data loading mechanism with a new configuration option for managing operation timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->