### PR TITLE
chore(deps): revert google-github-actions/release-please-action from 4 to 3

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -11,7 +11,7 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
-      - uses: google-github-actions/release-please-action@v4
+      - uses: google-github-actions/release-please-action@v3
         with:
           token: ${{ secrets.PAT }}
           pull-request-title-pattern: "chore: prerelease ${version}"

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -11,7 +11,7 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
-      - uses: google-github-actions/release-please-action@v4
+      - uses: google-github-actions/release-please-action@v3
         with:
           token: ${{ secrets.PAT }}
           pull-request-title-pattern: "chore: release ${version}"


### PR DESCRIPTION
Reverts rudderlabs/rudder-server#4184

I tried to adapt to the breaking changes, but I wasn't successful https://github.com/rudderlabs/rudder-server/pull/4204/files

The usage of manifest files breaks our prerelease strategy completely.  requesting revert until we find a better solution.
