### PR TITLE
chore: tune shared db connection pooling

### DIFF
--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -59,7 +59,8 @@ func rudderCoreWorkSpaceTableSetup() error {
 // NewRsourcesService produces a rsources.JobService through environment configuration (env variables & config file)
 func NewRsourcesService(deploymentType deployment.Type) (rsources.JobService, error) {
 	var rsourcesConfig rsources.JobServiceConfig
-	rsourcesConfig.MaxPoolSize = config.GetInt("Rsources.PoolSize", 5)
+	rsourcesConfig.MaxPoolSize = config.GetInt("Rsources.MaxPoolSize", 3)
+	rsourcesConfig.MinPoolSize = config.GetInt("Rsources.MinPoolSize", 1)
 	rsourcesConfig.LocalConn = misc.GetConnectionString(config.Default)
 	rsourcesConfig.LocalHostname = config.GetString("DB.host", "localhost")
 	rsourcesConfig.SharedConn = config.GetString("SharedDB.dsn", "")

--- a/internal/drain-config/drainConfig.go
+++ b/internal/drain-config/drainConfig.go
@@ -192,5 +192,7 @@ func setupDBConn(conf *config.Config) (*sql.DB, error) {
 	if err := db.Ping(); err != nil {
 		return nil, fmt.Errorf("db ping: %v", err)
 	}
+	db.SetMaxIdleConns(conf.GetInt("drainConfig.maxIdleConns", 1))
+	db.SetMaxOpenConns(conf.GetInt("drainConfig.maxOpenConns", 2))
 	return db, nil
 }

--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -153,6 +153,7 @@ type JobServiceConfig struct {
 	LocalHostname               string
 	LocalConn                   string
 	MaxPoolSize                 int
+	MinPoolSize                 int
 	SharedConn                  string
 	SubscriptionTargetConn      string
 	SkipFailedRecordsCollection bool
@@ -202,6 +203,9 @@ func NewJobService(config JobServiceConfig) (JobService, error) {
 	if config.MaxPoolSize <= 2 {
 		config.MaxPoolSize = 2 // minimum 2 connections in the pool for proper startup
 	}
+	if config.MinPoolSize <= 0 {
+		config.MinPoolSize = 1
+	}
 	var (
 		localDB, sharedDB *sql.DB
 		err               error
@@ -219,6 +223,7 @@ func NewJobService(config JobServiceConfig) (JobService, error) {
 			return nil, fmt.Errorf("failed to create shared postgresql connection pool: %w", err)
 		}
 		sharedDB.SetMaxOpenConns(config.MaxPoolSize)
+		sharedDB.SetMaxIdleConns(config.MinPoolSize)
 	}
 	handler := &sourcesHandler{
 		log:      config.Log,


### PR DESCRIPTION
# Description

Trying to minimise each rudder-server's footprint on the overall number of shared postgres's connections

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
