### PR TITLE
fix: gateway stat tags when source is disabled

### DIFF
--- a/gateway/handle_http_auth.go
+++ b/gateway/handle_http_auth.go
@@ -227,10 +227,12 @@ func (gw *Handle) handleFailureStats(errorMessage, reqType string, arctx *gwtype
 			}
 		case response.SourceDisabled:
 			stat = gwstats.SourceStat{
-				SourceID: arctx.SourceID,
-				WriteKey: arctx.WriteKey,
-				ReqType:  reqType,
-				Source:   arctx.SourceTag(),
+				SourceID:    arctx.SourceID,
+				WriteKey:    arctx.WriteKey,
+				ReqType:     reqType,
+				Source:      arctx.SourceTag(),
+				WorkspaceID: arctx.WorkspaceID,
+				SourceType:  arctx.SourceCategory,
 			}
 		}
 		stat.RequestFailed(response.GetStatus(errorMessage))


### PR DESCRIPTION
# Description

Seeing empty `workspaceID` in gateway stats when source is disabled. This fixes that. Added a couple tests to verify that.

## Linear Ticket

[slack thread](https://rudderlabs.slack.com/archives/C01HTT66UMB/p1701714466251759)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
