### PR TITLE
fix(processor): duplicate rsources out stats can be recorded in case of a retry due to an operation timeout

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2193,6 +2193,7 @@ func (proc *Handle) Store(partition string, in *storeMessage) {
 	writeJobsTime := time.Since(beforeStoreStatus)
 
 	txnStart := time.Now()
+	in.rsourcesStats.CollectStats(statusList)
 	err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout.Load(), proc.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
 		return proc.gatewayDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
 			err := proc.gatewayDB.UpdateJobStatusInTx(ctx, tx, statusList, []string{proc.config.GWCustomVal}, nil)
@@ -2200,13 +2201,7 @@ func (proc *Handle) Store(partition string, in *storeMessage) {
 				return fmt.Errorf("updating gateway jobs statuses: %w", err)
 			}
 
-			// rsources stats
-			in.rsourcesStats.CollectStats(statusList)
-			err = in.rsourcesStats.Publish(ctx, tx.SqlTx())
-			if err != nil {
-				return fmt.Errorf("publishing rsources stats: %w", err)
-			}
-			err = proc.saveDroppedJobs(in.droppedJobs, tx.Tx())
+			err = proc.saveDroppedJobs(ctx, in.droppedJobs, tx.Tx())
 			if err != nil {
 				return fmt.Errorf("saving dropped jobs: %w", err)
 			}
@@ -2215,6 +2210,11 @@ func (proc *Handle) Store(partition string, in *storeMessage) {
 				if err = proc.reporting.Report(in.reportMetrics, tx.Tx()); err != nil {
 					return fmt.Errorf("reporting metrics: %w", err)
 				}
+			}
+
+			err = in.rsourcesStats.Publish(ctx, tx.SqlTx())
+			if err != nil {
+				return fmt.Errorf("publishing rsources stats: %w", err)
 			}
 
 			return nil
@@ -2668,7 +2668,7 @@ func (proc *Handle) transformSrcDest(
 	}
 }
 
-func (proc *Handle) saveDroppedJobs(droppedJobs []*jobsdb.JobT, tx *Tx) error {
+func (proc *Handle) saveDroppedJobs(ctx context.Context, droppedJobs []*jobsdb.JobT, tx *Tx) error {
 	if len(droppedJobs) > 0 {
 		for i := range droppedJobs { // each dropped job should have a unique jobID in the scope of the batch
 			droppedJobs[i].JobID = int64(i)
@@ -2678,7 +2678,7 @@ func (proc *Handle) saveDroppedJobs(droppedJobs []*jobsdb.JobT, tx *Tx) error {
 			rsources.IgnoreDestinationID(),
 		)
 		rsourcesStats.JobsDropped(droppedJobs)
-		return rsourcesStats.Publish(context.TODO(), tx.Tx)
+		return rsourcesStats.Publish(ctx, tx.Tx)
 	}
 	return nil
 }

--- a/services/rsources/stats_collector.go
+++ b/services/rsources/stats_collector.go
@@ -229,14 +229,6 @@ func (r *statsCollector) Publish(ctx context.Context, tx *sql.Tx) error {
 		}
 	}
 
-	// reset state so that the collector can be
-	// reused for another stats collecting cycle
-	r.processing = false
-	r.jobIdsToStatKeyIndex = map[int64]statKey{}
-	r.statsIndex = map[statKey]*Stats{}
-	r.jobIdsToRecordIdIndex = map[int64]json.RawMessage{}
-	r.failedRecordsIndex = map[statKey][]FailedRecord{}
-
 	return nil
 }
 


### PR DESCRIPTION
# Description

1. Calling `rsourcesStats.CollectStats` only once so that no duplicates can be captured.
2. Avoiding to reset state in `rsourcesStats.Publish` so that the method can be repeated for another transaction (we are not reusing stat collectors anyway).
3. Performing `rsourcesStats.Publish` as the last step of the transaction.
4. Honouring context while storing dropped jobs' stats.

## Linear Ticket

fixes PIPE-616

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
