### PR TITLE
chore: include the component in application_name of postgres connection

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -96,7 +96,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 
 	reporting := a.app.Features().Reporting.Setup(ctx, backendconfig.DefaultBackendConfig)
 	defer reporting.Stop()
-	syncer := reporting.DatabaseSyncer(types.SyncerConfig{ConnInfo: misc.GetConnectionString(config, "embedded-app-db-syncer")})
+	syncer := reporting.DatabaseSyncer(types.SyncerConfig{ConnInfo: misc.GetConnectionString(config, "reporting")})
 	g.Go(func() error {
 		syncer()
 		return nil

--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -96,7 +96,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 
 	reporting := a.app.Features().Reporting.Setup(ctx, backendconfig.DefaultBackendConfig)
 	defer reporting.Stop()
-	syncer := reporting.DatabaseSyncer(types.SyncerConfig{ConnInfo: misc.GetConnectionString(config)})
+	syncer := reporting.DatabaseSyncer(types.SyncerConfig{ConnInfo: misc.GetConnectionString(config, "embedded-app-db-syncer")})
 	g.Go(func() error {
 		syncer()
 		return nil

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -108,7 +108,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 
 	reporting := a.app.Features().Reporting.Setup(ctx, backendconfig.DefaultBackendConfig)
 	defer reporting.Stop()
-	syncer := reporting.DatabaseSyncer(types.SyncerConfig{ConnInfo: misc.GetConnectionString(config.Default, "processor-app-db-syncer")})
+	syncer := reporting.DatabaseSyncer(types.SyncerConfig{ConnInfo: misc.GetConnectionString(config.Default, "reporting")})
 	g.Go(misc.WithBugsnag(func() error {
 		syncer()
 		return nil

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -108,7 +108,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 
 	reporting := a.app.Features().Reporting.Setup(ctx, backendconfig.DefaultBackendConfig)
 	defer reporting.Stop()
-	syncer := reporting.DatabaseSyncer(types.SyncerConfig{ConnInfo: misc.GetConnectionString(config.Default)})
+	syncer := reporting.DatabaseSyncer(types.SyncerConfig{ConnInfo: misc.GetConnectionString(config.Default, "processor-app-db-syncer")})
 	g.Go(misc.WithBugsnag(func() error {
 		syncer()
 		return nil

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -61,7 +61,7 @@ func NewRsourcesService(deploymentType deployment.Type) (rsources.JobService, er
 	var rsourcesConfig rsources.JobServiceConfig
 	rsourcesConfig.MaxPoolSize = config.GetInt("Rsources.MaxPoolSize", 3)
 	rsourcesConfig.MinPoolSize = config.GetInt("Rsources.MinPoolSize", 1)
-	rsourcesConfig.LocalConn = misc.GetConnectionString(config.Default)
+	rsourcesConfig.LocalConn = misc.GetConnectionString(config.Default, "rsources-service")
 	rsourcesConfig.LocalHostname = config.GetString("DB.host", "localhost")
 	rsourcesConfig.SharedConn = config.GetString("SharedDB.dsn", "")
 	rsourcesConfig.SkipFailedRecordsCollection = !config.GetBool("Router.failedKeysEnabled", true)

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -61,7 +61,7 @@ func NewRsourcesService(deploymentType deployment.Type) (rsources.JobService, er
 	var rsourcesConfig rsources.JobServiceConfig
 	rsourcesConfig.MaxPoolSize = config.GetInt("Rsources.MaxPoolSize", 3)
 	rsourcesConfig.MinPoolSize = config.GetInt("Rsources.MinPoolSize", 1)
-	rsourcesConfig.LocalConn = misc.GetConnectionString(config.Default, "rsources-service")
+	rsourcesConfig.LocalConn = misc.GetConnectionString(config.Default, "rsources")
 	rsourcesConfig.LocalHostname = config.GetString("DB.host", "localhost")
 	rsourcesConfig.SharedConn = config.GetString("SharedDB.dsn", "")
 	rsourcesConfig.SkipFailedRecordsCollection = !config.GetBool("Router.failedKeysEnabled", true)

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -66,7 +66,7 @@ func NewRsourcesService(deploymentType deployment.Type) (rsources.JobService, er
 	sharedDBConnUrl := config.GetString("SharedDB.dsn", "")
 	if len(sharedDBConnUrl) != 0 {
 		var err error
-		sharedDBConnUrl, err = misc.SetApplicationNameInDBConnectionURL(sharedDBConnUrl, "rsources")
+		sharedDBConnUrl, err = misc.SetAppNameInDBConnURL(sharedDBConnUrl, "rsources")
 		if err != nil {
 			return nil, fmt.Errorf("failed to set application name in dns: %w", err)
 		}

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -63,7 +63,15 @@ func NewRsourcesService(deploymentType deployment.Type) (rsources.JobService, er
 	rsourcesConfig.MinPoolSize = config.GetInt("Rsources.MinPoolSize", 1)
 	rsourcesConfig.LocalConn = misc.GetConnectionString(config.Default, "rsources")
 	rsourcesConfig.LocalHostname = config.GetString("DB.host", "localhost")
-	rsourcesConfig.SharedConn = config.GetString("SharedDB.dsn", "")
+	sharedDBConnUrl := config.GetString("SharedDB.dsn", "")
+	if len(sharedDBConnUrl) != 0 {
+		var err error
+		sharedDBConnUrl, err = misc.SetApplicationNameInDBConnectionURL(sharedDBConnUrl, "rsources")
+		if err != nil {
+			return nil, fmt.Errorf("failed to set application name in dns: %w", err)
+		}
+	}
+	rsourcesConfig.SharedConn = sharedDBConnUrl
 	rsourcesConfig.SkipFailedRecordsCollection = !config.GetBool("Router.failedKeysEnabled", true)
 
 	if deploymentType == deployment.MultiTenantType {

--- a/backend-config/internal/cache/cache.go
+++ b/backend-config/internal/cache/cache.go
@@ -132,7 +132,7 @@ func (db *cacheStore) Get(ctx context.Context) ([]byte, error) {
 
 // setupDBConn sets up the database connection, creates the config table if it doesn't exist
 func setupDBConn() (*sql.DB, error) {
-	psqlInfo := misc.GetConnectionString(config.Default)
+	psqlInfo := misc.GetConnectionString(config.Default, "backend-config-cache")
 	db, err := sql.Open("postgres", psqlInfo)
 	if err != nil {
 		pkgLogger.Errorf("failed to open db: %v", err)

--- a/backend-config/internal/cache/cache.go
+++ b/backend-config/internal/cache/cache.go
@@ -132,7 +132,7 @@ func (db *cacheStore) Get(ctx context.Context) ([]byte, error) {
 
 // setupDBConn sets up the database connection, creates the config table if it doesn't exist
 func setupDBConn() (*sql.DB, error) {
-	psqlInfo := misc.GetConnectionString(config.Default, "backend-config-cache")
+	psqlInfo := misc.GetConnectionString(config.Default, "backend-config")
 	db, err := sql.Open("postgres", psqlInfo)
 	if err != nil {
 		pkgLogger.Errorf("failed to open db: %v", err)

--- a/internal/drain-config/drainConfig.go
+++ b/internal/drain-config/drainConfig.go
@@ -181,7 +181,7 @@ func migrate(db *sql.DB) error {
 
 // setupDBConn sets up the database connection
 func setupDBConn(conf *config.Config) (*sql.DB, error) {
-	psqlInfo := misc.GetConnectionString(conf)
+	psqlInfo := misc.GetConnectionString(conf, "drain-config")
 	if conf.IsSet("SharedDB.dsn") {
 		psqlInfo = conf.GetString("SharedDB.dsn", "")
 	}

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -739,7 +739,7 @@ func (jd *Handle) init() {
 	// Initialize dbHandle if not already set
 	if jd.dbHandle == nil {
 		var err error
-		psqlInfo := misc.GetConnectionString(jd.config)
+		psqlInfo := misc.GetConnectionString(jd.config, "jobsdb")
 		jd.dbHandle, err = sql.Open("postgres", psqlInfo)
 		jd.assertError(err)
 	}

--- a/services/notifier/notifier.go
+++ b/services/notifier/notifier.go
@@ -243,13 +243,14 @@ func (n *Notifier) checkForNotifierEnvVars() bool {
 }
 
 func (n *Notifier) connectionString() string {
-	return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+	return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s application_name=%s",
 		n.config.host,
 		n.config.port,
 		n.config.user,
 		n.config.password,
 		n.config.database,
 		n.config.sslMode,
+		"notifier",
 	)
 }
 

--- a/services/validators/envValidator.go
+++ b/services/validators/envValidator.go
@@ -150,7 +150,7 @@ func killDanglingDBConnections(db *sql.DB) error {
 	rows, err := db.Query(`SELECT PID, QUERY_START, COALESCE(WAIT_EVENT_TYPE,''), COALESCE(WAIT_EVENT, ''), COALESCE(STATE, ''), QUERY, PG_TERMINATE_BACKEND(PID)
 							FROM PG_STAT_ACTIVITY
 							WHERE PID <> PG_BACKEND_PID()
-							AND APPLICATION_NAME = CURRENT_SETTING('APPLICATION_NAME')
+							AND APPLICATION_NAME LIKE ('%' || CURRENT_SETTING('APPLICATION_NAME'))
 							AND APPLICATION_NAME <> ''`)
 	if err != nil {
 		return fmt.Errorf("querying pg_stat_activity table for terminating dangling connections: %w", err)

--- a/services/validators/envValidator.go
+++ b/services/validators/envValidator.go
@@ -124,7 +124,7 @@ func getWorkspaceFromDB(dbHandle *sql.DB) (string, error) {
 }
 
 func createDBConnection() (*sql.DB, error) {
-	psqlInfo := misc.GetConnectionString(config.Default)
+	psqlInfo := misc.GetConnectionString(config.Default, "env-validator")
 	var err error
 	dbHandle, err := sql.Open("postgres", psqlInfo)
 	if err != nil {

--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -30,9 +30,9 @@ func GetConnectionString(c *config.Config, componentName string) string {
 		host, port, user, password, dbname, sslmode, appName)
 }
 
-// SetApplicationNameInDBDNS sets application name in db connection url
+// SetAppNameInDBConnURL sets application name in db connection url
 // if application name is already present in dns it will get override by the appName
-func SetApplicationNameInDBConnectionURL(connectionUrl, appName string) (string, error) {
+func SetAppNameInDBConnURL(connectionUrl, appName string) (string, error) {
 	connUrl, err := url.Parse(connectionUrl)
 	if err != nil {
 		return "", err

--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GetConnectionString Returns Jobs DB connection configuration
-func GetConnectionString(c *config.Config) string {
+func GetConnectionString(c *config.Config, componentName string) string {
 	host := c.GetString("DB.host", "localhost")
 	user := c.GetString("DB.user", "ubuntu")
 	dbname := c.GetString("DB.name", "ubuntu")
@@ -21,6 +21,9 @@ func GetConnectionString(c *config.Config) string {
 	// Application Name can be any string of less than NAMEDATALEN characters (64 characters in a standard PostgreSQL build).
 	// There is no need to truncate the string on our own though since PostgreSQL auto-truncates this identifier and issues a relevant notice if necessary.
 	appName := DefaultString("rudder-server").OnError(os.Hostname())
+	if len(componentName) > 0 {
+		appName = fmt.Sprintf("%s-%s", componentName, appName)
+	}
 	return fmt.Sprintf("host=%s port=%d user=%s "+
 		"password=%s dbname=%s sslmode=%s application_name=%s",
 		host, port, user, password, dbname, sslmode, appName)

--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -3,6 +3,7 @@ package misc
 import (
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/lib/pq"
@@ -27,6 +28,19 @@ func GetConnectionString(c *config.Config, componentName string) string {
 	return fmt.Sprintf("host=%s port=%d user=%s "+
 		"password=%s dbname=%s sslmode=%s application_name=%s",
 		host, port, user, password, dbname, sslmode, appName)
+}
+
+// SetApplicationNameInDBDNS sets application name in db connection url
+// if application name is already present in dns it will get override by the appName
+func SetApplicationNameInDBConnectionURL(connectionUrl, appName string) (string, error) {
+	connUrl, err := url.Parse(connectionUrl)
+	if err != nil {
+		return "", err
+	}
+	queryParams := connUrl.Query()
+	queryParams.Set("application_name", appName)
+	connUrl.RawQuery = queryParams.Encode()
+	return connUrl.String(), nil
 }
 
 /*

--- a/utils/misc/dbutils_test.go
+++ b/utils/misc/dbutils_test.go
@@ -1,11 +1,12 @@
 package misc_test
 
 import (
-	"github.com/rudderlabs/rudder-server/utils/misc"
 	"testing"
+
+	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
-func TestSetApplicationNameInDBConnection(t *testing.T) {
+func TestSetApplicationNameInDBConnectionURL(t *testing.T) {
 	type args struct {
 		dns     string
 		appName string

--- a/utils/misc/dbutils_test.go
+++ b/utils/misc/dbutils_test.go
@@ -1,0 +1,59 @@
+package misc_test
+
+import (
+	"github.com/rudderlabs/rudder-server/utils/misc"
+	"testing"
+)
+
+func TestSetApplicationNameInDBConnection(t *testing.T) {
+	type args struct {
+		dns     string
+		appName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "invalid dns url",
+			args: args{
+				dns:     "abc@example.com:5432",
+				appName: "rsources",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "add app name in dns url",
+			args: args{
+				dns:     "postgresql://rudder:password@prousmtusmt-rs-shared-postgresql:5432/jobsdb?sslmode=disable",
+				appName: "rsources",
+			},
+			want:    "postgresql://rudder:password@prousmtusmt-rs-shared-postgresql:5432/jobsdb?application_name=rsources&sslmode=disable",
+			wantErr: false,
+		},
+		{
+			name: "update app name in dns url",
+			args: args{
+				dns:     "postgresql://rudder:password@prousmtusmt-rs-shared-postgresql:5432/jobsdb?application_name=random&sslmode=disable",
+				appName: "rsources",
+			},
+			want:    "postgresql://rudder:password@prousmtusmt-rs-shared-postgresql:5432/jobsdb?application_name=rsources&sslmode=disable",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := misc.SetApplicationNameInDBConnectionURL(tt.args.dns, tt.args.appName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetApplicationNameInDBConnectionURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SetApplicationNameInDBConnectionURL() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/utils/misc/dbutils_test.go
+++ b/utils/misc/dbutils_test.go
@@ -47,13 +47,13 @@ func TestSetApplicationNameInDBConnectionURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := misc.SetApplicationNameInDBConnectionURL(tt.args.dns, tt.args.appName)
+			got, err := misc.SetAppNameInDBConnURL(tt.args.dns, tt.args.appName)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("SetApplicationNameInDBConnectionURL() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("SetAppNameInDBConnURL() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("SetApplicationNameInDBConnectionURL() got = %v, want %v", got, tt.want)
+				t.Errorf("SetAppNameInDBConnURL() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/warehouse/app.go
+++ b/warehouse/app.go
@@ -254,9 +254,10 @@ func (a *App) setupDatabase(ctx context.Context) error {
 
 func (a *App) connectionString() string {
 	if !a.checkForWarehouseEnvVars() {
-		return misc.GetConnectionString(a.conf)
+		return misc.GetConnectionString(a.conf, "warehouse")
 	}
 
+	appName := fmt.Sprintf("warehouse-%s", a.appName)
 	return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s application_name=%s",
 		a.config.host,
 		a.config.port,
@@ -264,7 +265,7 @@ func (a *App) connectionString() string {
 		a.config.password,
 		a.config.database,
 		a.config.sslMode,
-		a.appName,
+		appName,
 	)
 }
 


### PR DESCRIPTION
# Description

We want to manage and identify PostgreSQL connections based on the components that establish them. PostgreSQL provides the application_name parameter, which we can use to tag connections with the name of the component. This can be helpful for monitoring and managing connections.

Usecase:
1. To see how many connections are used by a specific component, we can query the `pg_stat_activity`
2. To identify slow queries by a specific component, we can use the `pg_stat_statements` extension along with `application_name`
3. kill all connections from a specific component
4. To monitor resource usage (e.g., CPU, memory) by a specific component, we can use the `pg_stat_activity` along with other system views.

## Linear Ticket

pipe-605

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
