### PR TITLE
feat: add destinationID to rETL endpoint

### DIFF
--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -264,7 +264,7 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 	var (
 		arctx         = req.authContext
 		sourceID      = arctx.SourceID
-		destinationId = arctx.DestinationId
+		destinationID = arctx.DestinationID
 		// Should be function of body
 		workspaceId  = arctx.WorkspaceID
 		userIDHeader = req.userIDHeader
@@ -434,8 +434,8 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 		"source_task_run_id": sourcesTaskRunID,
 		"traceparent":        traceParent,
 	}
-	if len(destinationId) != 0 {
-		params["destination_id"] = destinationId
+	if len(destinationID) != 0 {
+		params["destination_id"] = destinationID
 	}
 	marshalledParams, err = json.Marshal(params)
 	if err != nil {

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -262,8 +262,9 @@ func (gw *Handle) userWebRequestWorkerProcess(userWebRequestWorker *userWebReque
 // - user in the payload is not allowed to send events (suppressed)
 func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, err error) {
 	var (
-		arctx    = req.authContext
-		sourceID = arctx.SourceID
+		arctx         = req.authContext
+		sourceID      = arctx.SourceID
+		destinationId = arctx.DestinationId
 		// Should be function of body
 		workspaceId  = arctx.WorkspaceID
 		userIDHeader = req.userIDHeader
@@ -432,6 +433,9 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 		"source_job_run_id":  sourcesJobRunID,
 		"source_task_run_id": sourcesTaskRunID,
 		"traceparent":        traceParent,
+	}
+	if len(destinationId) != 0 {
+		params["destination_id"] = destinationId
 	}
 	marshalledParams, err = json.Marshal(params)
 	if err != nil {

--- a/gateway/handle_http_auth_test.go
+++ b/gateway/handle_http_auth_test.go
@@ -2,12 +2,13 @@ package gateway
 
 import (
 	"context"
-	"github.com/rudderlabs/rudder-go-kit/config"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
 
 	"github.com/stretchr/testify/require"
 

--- a/gateway/handle_http_auth_test.go
+++ b/gateway/handle_http_auth_test.go
@@ -465,7 +465,7 @@ func TestAuth(t *testing.T) {
 			w := httptest.NewRecorder()
 			gw.authDestIDForSource(delegate).ServeHTTP(w, r)
 
-			require.Equal(t, http.StatusUnauthorized, w.Code, "authentication should succeed")
+			require.Equal(t, http.StatusBadRequest, w.Code, "authentication should succeed")
 			body, err := io.ReadAll(w.Body)
 			require.NoError(t, err, "reading response body should succeed")
 			require.Equal(t, "Failed to read destination id from header\n", string(body))
@@ -490,7 +490,7 @@ func TestAuth(t *testing.T) {
 			w := httptest.NewRecorder()
 			gw.authDestIDForSource(delegate).ServeHTTP(w, r)
 
-			require.Equal(t, http.StatusUnauthorized, w.Code, "authentication should fail")
+			require.Equal(t, http.StatusBadRequest, w.Code, "authentication should fail")
 			body, err := io.ReadAll(w.Body)
 			require.NoError(t, err, "reading response body should succeed")
 			require.Equal(t, "Invalid destination id\n", string(body))

--- a/gateway/handle_http_auth_test.go
+++ b/gateway/handle_http_auth_test.go
@@ -408,7 +408,7 @@ func TestAuth(t *testing.T) {
 		})
 	})
 
-	t.Run("authenticateDestinationIDForSource", func(t *testing.T) {
+	t.Run("authDestIDForSource", func(t *testing.T) {
 		t.Run("successful auth with destination header", func(t *testing.T) {
 			sourceID := "123"
 			destinationID := "456"
@@ -426,7 +426,7 @@ func TestAuth(t *testing.T) {
 				},
 			})
 			w := httptest.NewRecorder()
-			gw.authenticateDestinationIDForSource(delegate).ServeHTTP(w, r)
+			gw.authDestIDForSource(delegate).ServeHTTP(w, r)
 
 			require.Equal(t, http.StatusOK, w.Code, "authentication should succeed")
 			body, err := io.ReadAll(w.Body)
@@ -444,7 +444,7 @@ func TestAuth(t *testing.T) {
 			gw.config = config.Default
 			r := newRequestWithSourceIDAndDestID(sourceID, "", &gwtypes.AuthRequestContext{})
 			w := httptest.NewRecorder()
-			gw.authenticateDestinationIDForSource(delegate).ServeHTTP(w, r)
+			gw.authDestIDForSource(delegate).ServeHTTP(w, r)
 
 			require.Equal(t, http.StatusOK, w.Code, "authentication should succeed")
 			body, err := io.ReadAll(w.Body)
@@ -460,10 +460,10 @@ func TestAuth(t *testing.T) {
 				},
 			})
 			gw.config = config.Default
-			gw.config.Set("Gateway.isDestinationIdMandatoryInRequestHeader", true)
+			gw.config.Set("Gateway.requireDestinationIdHeader", true)
 			r := newRequestWithSourceIDAndDestID(sourceID, "", &gwtypes.AuthRequestContext{})
 			w := httptest.NewRecorder()
-			gw.authenticateDestinationIDForSource(delegate).ServeHTTP(w, r)
+			gw.authDestIDForSource(delegate).ServeHTTP(w, r)
 
 			require.Equal(t, http.StatusUnauthorized, w.Code, "authentication should succeed")
 			body, err := io.ReadAll(w.Body)
@@ -488,7 +488,7 @@ func TestAuth(t *testing.T) {
 				},
 			})
 			w := httptest.NewRecorder()
-			gw.authenticateDestinationIDForSource(delegate).ServeHTTP(w, r)
+			gw.authDestIDForSource(delegate).ServeHTTP(w, r)
 
 			require.Equal(t, http.StatusUnauthorized, w.Code, "authentication should fail")
 			body, err := io.ReadAll(w.Body)
@@ -513,7 +513,7 @@ func TestAuth(t *testing.T) {
 				},
 			})
 			w := httptest.NewRecorder()
-			gw.authenticateDestinationIDForSource(delegate).ServeHTTP(w, r)
+			gw.authDestIDForSource(delegate).ServeHTTP(w, r)
 
 			require.Equal(t, http.StatusNotFound, w.Code, "authentication should fail")
 			body, err := io.ReadAll(w.Body)

--- a/gateway/handle_http_auth_test.go
+++ b/gateway/handle_http_auth_test.go
@@ -52,13 +52,13 @@ func TestAuth(t *testing.T) {
 		return r
 	}
 
-	newRequestWithSourceIdAndDestId := func(sourceId, destinationId string, reqCtx *gwtypes.AuthRequestContext) *http.Request {
+	newRequestWithSourceIDAndDestID := func(sourceID, destinationID string, reqCtx *gwtypes.AuthRequestContext) *http.Request {
 		r := httptest.NewRequest("GET", "/", nil)
-		if len(sourceId) != 0 {
-			r.Header.Add("X-Rudder-Source-Id", sourceId)
+		if len(sourceID) != 0 {
+			r.Header.Add("X-Rudder-Source-Id", sourceID)
 		}
-		if len(destinationId) != 0 {
-			r.Header.Add("X-Rudder-Destination-Id", destinationId)
+		if len(destinationID) != 0 {
+			r.Header.Add("X-Rudder-Destination-Id", destinationID)
 		}
 		r = r.WithContext(context.WithValue(r.Context(), gwtypes.CtxParamCallType, "dummy"))
 		r = r.WithContext(context.WithValue(r.Context(), gwtypes.CtxParamAuthRequestContext, reqCtx))
@@ -408,7 +408,7 @@ func TestAuth(t *testing.T) {
 		})
 	})
 
-	t.Run("authenticateDestinationIdForSource", func(t *testing.T) {
+	t.Run("authenticateDestinationIDForSource", func(t *testing.T) {
 		t.Run("successful auth with destination header", func(t *testing.T) {
 			sourceID := "123"
 			destinationID := "456"
@@ -420,13 +420,13 @@ func TestAuth(t *testing.T) {
 					}},
 				},
 			})
-			r := newRequestWithSourceIdAndDestId(sourceID, destinationID, &gwtypes.AuthRequestContext{
+			r := newRequestWithSourceIDAndDestID(sourceID, destinationID, &gwtypes.AuthRequestContext{
 				Source: backendconfig.SourceT{
 					Destinations: []backendconfig.DestinationT{{ID: destinationID, Enabled: true}},
 				},
 			})
 			w := httptest.NewRecorder()
-			gw.authenticateDestinationIdForSource(delegate).ServeHTTP(w, r)
+			gw.authenticateDestinationIDForSource(delegate).ServeHTTP(w, r)
 
 			require.Equal(t, http.StatusOK, w.Code, "authentication should succeed")
 			body, err := io.ReadAll(w.Body)
@@ -442,9 +442,9 @@ func TestAuth(t *testing.T) {
 				},
 			})
 			gw.config = config.Default
-			r := newRequestWithSourceIdAndDestId(sourceID, "", &gwtypes.AuthRequestContext{})
+			r := newRequestWithSourceIDAndDestID(sourceID, "", &gwtypes.AuthRequestContext{})
 			w := httptest.NewRecorder()
-			gw.authenticateDestinationIdForSource(delegate).ServeHTTP(w, r)
+			gw.authenticateDestinationIDForSource(delegate).ServeHTTP(w, r)
 
 			require.Equal(t, http.StatusOK, w.Code, "authentication should succeed")
 			body, err := io.ReadAll(w.Body)
@@ -461,9 +461,9 @@ func TestAuth(t *testing.T) {
 			})
 			gw.config = config.Default
 			gw.config.Set("Gateway.isDestinationIdMandatoryInRequestHeader", true)
-			r := newRequestWithSourceIdAndDestId(sourceID, "", &gwtypes.AuthRequestContext{})
+			r := newRequestWithSourceIDAndDestID(sourceID, "", &gwtypes.AuthRequestContext{})
 			w := httptest.NewRecorder()
-			gw.authenticateDestinationIdForSource(delegate).ServeHTTP(w, r)
+			gw.authenticateDestinationIDForSource(delegate).ServeHTTP(w, r)
 
 			require.Equal(t, http.StatusUnauthorized, w.Code, "authentication should succeed")
 			body, err := io.ReadAll(w.Body)
@@ -482,13 +482,13 @@ func TestAuth(t *testing.T) {
 					}},
 				},
 			})
-			r := newRequestWithSourceIdAndDestId(sourceID, destinationID, &gwtypes.AuthRequestContext{
+			r := newRequestWithSourceIDAndDestID(sourceID, destinationID, &gwtypes.AuthRequestContext{
 				Source: backendconfig.SourceT{
 					Destinations: []backendconfig.DestinationT{{ID: "invalid-dest-id"}},
 				},
 			})
 			w := httptest.NewRecorder()
-			gw.authenticateDestinationIdForSource(delegate).ServeHTTP(w, r)
+			gw.authenticateDestinationIDForSource(delegate).ServeHTTP(w, r)
 
 			require.Equal(t, http.StatusUnauthorized, w.Code, "authentication should fail")
 			body, err := io.ReadAll(w.Body)
@@ -507,13 +507,13 @@ func TestAuth(t *testing.T) {
 					}},
 				},
 			})
-			r := newRequestWithSourceIdAndDestId(sourceID, destinationID, &gwtypes.AuthRequestContext{
+			r := newRequestWithSourceIDAndDestID(sourceID, destinationID, &gwtypes.AuthRequestContext{
 				Source: backendconfig.SourceT{
 					Destinations: []backendconfig.DestinationT{{ID: destinationID, Enabled: false}},
 				},
 			})
 			w := httptest.NewRecorder()
-			gw.authenticateDestinationIdForSource(delegate).ServeHTTP(w, r)
+			gw.authenticateDestinationIDForSource(delegate).ServeHTTP(w, r)
 
 			require.Equal(t, http.StatusNotFound, w.Code, "authentication should fail")
 			body, err := io.ReadAll(w.Body)

--- a/gateway/handle_http_retl.go
+++ b/gateway/handle_http_retl.go
@@ -4,5 +4,5 @@ import "net/http"
 
 // webRetlHandler - handler for retl requests
 func (gw *Handle) webRetlHandler() http.HandlerFunc {
-	return gw.callType("retl", gw.sourceIDAuth(gw.authenticateDestinationIDForSource(gw.webHandler())))
+	return gw.callType("retl", gw.sourceDestIDAuth(gw.webHandler()))
 }

--- a/gateway/handle_http_retl.go
+++ b/gateway/handle_http_retl.go
@@ -4,5 +4,5 @@ import "net/http"
 
 // webRetlHandler - handler for retl requests
 func (gw *Handle) webRetlHandler() http.HandlerFunc {
-	return gw.callType("retl", gw.sourceIDAuth(gw.authenticateDestinationIdForSource(gw.webHandler())))
+	return gw.callType("retl", gw.sourceIDAuth(gw.authenticateDestinationIDForSource(gw.webHandler())))
 }

--- a/gateway/handle_http_retl.go
+++ b/gateway/handle_http_retl.go
@@ -4,5 +4,5 @@ import "net/http"
 
 // webRetlHandler - handler for retl requests
 func (gw *Handle) webRetlHandler() http.HandlerFunc {
-	return gw.callType("retl", gw.sourceIDAuth(gw.webHandler()))
+	return gw.callType("retl", gw.sourceIDAuth(gw.authenticateDestinationIdForSource(gw.webHandler())))
 }

--- a/gateway/internal/context/context.go
+++ b/gateway/internal/context/context.go
@@ -1,0 +1,19 @@
+package context
+
+import (
+	"context"
+
+	gwtypes "github.com/rudderlabs/rudder-server/gateway/internal/types"
+)
+
+// GetRequestTypeFromCtx : get request type from context
+func GetRequestTypeFromCtx(ctx context.Context) (string, bool) {
+	reqType, ok := ctx.Value(gwtypes.CtxParamCallType).(string)
+	return reqType, ok
+}
+
+// GetAuthRequestFromCtx : get auth request from context
+func GetAuthRequestFromCtx(ctx context.Context) (*gwtypes.AuthRequestContext, bool) {
+	authReqCtx, ok := ctx.Value(gwtypes.CtxParamAuthRequestContext).(*gwtypes.AuthRequestContext)
+	return authReqCtx, ok
+}

--- a/gateway/internal/types/types.go
+++ b/gateway/internal/types/types.go
@@ -27,6 +27,8 @@ type AuthRequestContext struct {
 	SourceJobRunID  string
 	SourceTaskRunID string
 	Source          backendconfig.SourceT
+	// DestinationId is optional param, destination id will be present for rETL Request
+	DestinationId string
 }
 
 func (arctx *AuthRequestContext) SourceTag() string {

--- a/gateway/internal/types/types.go
+++ b/gateway/internal/types/types.go
@@ -27,8 +27,8 @@ type AuthRequestContext struct {
 	SourceJobRunID  string
 	SourceTaskRunID string
 	Source          backendconfig.SourceT
-	// DestinationId is optional param, destination id will be present for rETL Request
-	DestinationId string
+	// DestinationID is optional param, destination id will be present for rETL Request
+	DestinationID string
 }
 
 func (arctx *AuthRequestContext) SourceTag() string {

--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -94,8 +94,8 @@ var statusMap = map[string]status{
 	InvalidSourceID:         {message: InvalidSourceID, code: http.StatusUnauthorized},
 	InvalidReplaySource:     {message: InvalidReplaySource, code: http.StatusUnauthorized},
 	DestinationDisabled:     {message: DestinationDisabled, code: http.StatusNotFound},
-	InvalidDestinationID:    {message: InvalidDestinationID, code: http.StatusUnauthorized},
-	NoDestinationIDInHeader: {message: NoDestinationIDInHeader, code: http.StatusUnauthorized},
+	InvalidDestinationID:    {message: InvalidDestinationID, code: http.StatusBadRequest},
+	NoDestinationIDInHeader: {message: NoDestinationIDInHeader, code: http.StatusBadRequest},
 
 	// webhook specific status
 	InvalidWebhookSource:                           {message: InvalidWebhookSource, code: http.StatusNotFound},

--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -66,6 +66,10 @@ const (
 	InvalidSourceID = "Invalid source id"
 	// InvalidReplaySource - Invalid replay source
 	InvalidReplaySource = "Invalid replay source"
+	// InvalidDestinationID - Invalid destination id
+	InvalidDestinationID = "Invalid destination id"
+	// DestinationDisabled - Destination is disabled
+	DestinationDisabled = "Destination is disabled"
 
 	transPixelResponse = "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x21\xF9\x04" +
 		"\x01\x00\x00\x00\x00\x2C\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3B"
@@ -87,6 +91,8 @@ var statusMap = map[string]status{
 	NoSourceIdInHeader:      {message: NoSourceIdInHeader, code: http.StatusUnauthorized},
 	InvalidSourceID:         {message: InvalidSourceID, code: http.StatusUnauthorized},
 	InvalidReplaySource:     {message: InvalidReplaySource, code: http.StatusUnauthorized},
+	DestinationDisabled:     {message: DestinationDisabled, code: http.StatusNotFound},
+	InvalidDestinationID:    {message: InvalidDestinationID, code: http.StatusUnauthorized},
 
 	// webhook specific status
 	InvalidWebhookSource:                           {message: InvalidWebhookSource, code: http.StatusNotFound},

--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -70,8 +70,8 @@ const (
 	InvalidDestinationID = "Invalid destination id"
 	// DestinationDisabled - Destination is disabled
 	DestinationDisabled = "Destination is disabled"
-	// NoDestinationIdInHeader - Failed to read destination id from header
-	NoDestinationIdInHeader = "Failed to read destination id from header"
+	// NoDestinationIDInHeader - Failed to read destination id from header
+	NoDestinationIDInHeader = "Failed to read destination id from header"
 
 	transPixelResponse = "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x21\xF9\x04" +
 		"\x01\x00\x00\x00\x00\x2C\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3B"
@@ -95,7 +95,7 @@ var statusMap = map[string]status{
 	InvalidReplaySource:     {message: InvalidReplaySource, code: http.StatusUnauthorized},
 	DestinationDisabled:     {message: DestinationDisabled, code: http.StatusNotFound},
 	InvalidDestinationID:    {message: InvalidDestinationID, code: http.StatusUnauthorized},
-	NoDestinationIdInHeader: {message: NoDestinationIdInHeader, code: http.StatusUnauthorized},
+	NoDestinationIDInHeader: {message: NoDestinationIDInHeader, code: http.StatusUnauthorized},
 
 	// webhook specific status
 	InvalidWebhookSource:                           {message: InvalidWebhookSource, code: http.StatusNotFound},

--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -70,6 +70,8 @@ const (
 	InvalidDestinationID = "Invalid destination id"
 	// DestinationDisabled - Destination is disabled
 	DestinationDisabled = "Destination is disabled"
+	// NoDestinationIdInHeader - Failed to read destination id from header
+	NoDestinationIdInHeader = "Failed to read destination id from header"
 
 	transPixelResponse = "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x21\xF9\x04" +
 		"\x01\x00\x00\x00\x00\x2C\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3B"
@@ -93,6 +95,7 @@ var statusMap = map[string]status{
 	InvalidReplaySource:     {message: InvalidReplaySource, code: http.StatusUnauthorized},
 	DestinationDisabled:     {message: DestinationDisabled, code: http.StatusNotFound},
 	InvalidDestinationID:    {message: InvalidDestinationID, code: http.StatusUnauthorized},
+	NoDestinationIdInHeader: {message: NoDestinationIdInHeader, code: http.StatusUnauthorized},
 
 	// webhook specific status
 	InvalidWebhookSource:                           {message: InvalidWebhookSource, code: http.StatusNotFound},


### PR DESCRIPTION
# Description

Adding Destination ID to rETL endpoint to provide a way for rETL to send an event from a source to a destination. If there are multiple sources rETL will call `/retl` endpoint multiple times to deliver to multiple destinations. 

- Destination ID will be stored in parameters column along with source ID

## Linear Ticket

Pipe-619

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
