### PR TITLE
fix: adapt connection timeout for sql for redshift

### DIFF
--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -956,6 +956,7 @@ func (rs *Redshift) connect(ctx context.Context) (*sqlmiddleware.DB, error) {
 			logfield.Schema, rs.Namespace,
 		),
 		sqlmiddleware.WithSlowQueryThreshold(rs.config.slowQueryThreshold),
+		sqlmiddleware.WithQueryTimeout(rs.connectTimeout),
 		sqlmiddleware.WithSecretsRegex(map[string]string{
 			"ACCESS_KEY_ID '[^']*'":     "ACCESS_KEY_ID '***'",
 			"SECRET_ACCESS_KEY '[^']*'": "SECRET_ACCESS_KEY '***'",


### PR DESCRIPTION
# Description

- Added connection timeout for middleware for Redshift.
- Stuck stacktrace.
  ```
  goroutine 299619831 [IO wait, 3151 minutes]:
  internal/poll.runtime_pollWait(0x7fce0052e5a0, 0x72)
	  /usr/local/go/src/runtime/netpoll.go:343 +0x85
  internal/poll.(*pollDesc).wait(0xc03779b200?, 0xc03b95a000?, 0x0)
	  /usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
  internal/poll.(*pollDesc).waitRead(...)
	  /usr/local/go/src/internal/poll/fd_poll_runtime.go:89
  internal/poll.(*FD).Read(0xc03779b200, {0xc03b95a000, 0x2000, 0x2000})
	  /usr/local/go/src/internal/poll/fd_unix.go:164 +0x27a
  net.(*netFD).Read(0xc03779b200, {0xc03b95a000?, 0x6c8dd488321103b6?, 0x653e59eb27991262?})
	  /usr/local/go/src/net/fd_posix.go:55 +0x25
  net.(*conn).Read(0xc087082ce0, {0xc03b95a000?, 0x523fe6d9683bf05f?, 0xc0e11a3fe70c5767?})
	  /usr/local/go/src/net/net.go:179 +0x45
  crypto/tls.(*atLeastReader).Read(0xc0cd451350, {0xc03b95a000?, 0xc0cd451350?, 0x0?})
	  /usr/local/go/src/crypto/tls/conn.go:805 +0x3b
  bytes.(*Buffer).ReadFrom(0xc021c33428, {0x3e02940, 0xc0cd451350})
	  /usr/local/go/src/bytes/buffer.go:211 +0x98
  crypto/tls.(*Conn).readFromUntil(0xc021c33180, {0x3e02b00?, 0xc087082ce0}, 0xc000e3a930?)
	  /usr/local/go/src/crypto/tls/conn.go:827 +0xde
  crypto/tls.(*Conn).readRecordOrCCS(0xc021c33180, 0x0)
	  /usr/local/go/src/crypto/tls/conn.go:625 +0x250
  crypto/tls.(*Conn).readRecord(...)
	  /usr/local/go/src/crypto/tls/conn.go:587
  crypto/tls.(*Conn).Read(0xc021c33180, {0xc03a504000, 0x1000, 0x0?})
	  /usr/local/go/src/crypto/tls/conn.go:1369 +0x158
  bufio.(*Reader).Read(0xc0a385ff20, {0xc00c9a4f20, 0x5, 0x6eca77?})
	  /usr/local/go/src/bufio/bufio.go:244 +0x197
  io.ReadAtLeast({0x3e00880, 0xc0a385ff20}, {0xc00c9a4f20, 0x5, 0x200}, 0x5)
	  /usr/local/go/src/io/io.go:335 +0x90
  io.ReadFull(...)
	  /usr/local/go/src/io/io.go:354
  github.com/lib/pq.(*conn).recvMessage(0xc00c9a4f00, 0xc01b6a6ea0)
	  /go/pkg/mod/github.com/lib/pq@v1.10.9/conn.go:1018 +0xc5
  github.com/lib/pq.(*conn).recv1Buf(0xc00c9a4f00, 0x3e32600?)
	  /go/pkg/mod/github.com/lib/pq@v1.10.9/conn.go:1073 +0x28
  github.com/lib/pq.(*conn).recv1(...)
	  /go/pkg/mod/github.com/lib/pq@v1.10.9/conn.go:1100
  github.com/lib/pq.(*conn).simpleExec(0xc00c9a4f00, {0xc00f310000?, 0x3e18?})
	  /go/pkg/mod/github.com/lib/pq@v1.10.9/conn.go:676 +0x1e5
  github.com/lib/pq.(*conn).Exec(0xc00c9a4f00, {0xc00f310000, 0x3e18}, {0x5c1e500, 0x0, 0x0})
	  /go/pkg/mod/github.com/lib/pq@v1.10.9/conn.go:935 +0x225
  github.com/lib/pq.(*conn).ExecContext(0x4577ca?, {0x3e32958, 0xc072da1f50}, {0xc00f310000, 0x3e18}, {0x5c1e500, 0x0, 0xc000e3b0c0?})
	  /go/pkg/mod/github.com/lib/pq@v1.10.9/conn_go18.go:46 +0x15c
  database/sql.ctxDriverExec({0x3e32958?, 0xc072da1f50?}, {0x7fce069ae0f8?, 0xc00c9a4f00?}, {0x0?, 0x0?}, {0xc00f310000?, 0xc000e3b130?}, {0x5c1e500, 0x0, ...})
	  /usr/local/go/src/database/sql/ctxutil.go:31 +0xd7
  database/sql.(*DB).execDC.func2()
	  /usr/local/go/src/database/sql/sql.go:1675 +0x165
  database/sql.withLock({0x3e15420, 0xc039fa5e60}, 0xc000e3b318)
	  /usr/local/go/src/database/sql/sql.go:3502 +0x82
  database/sql.(*DB).execDC(0x10c2d42?, {0x3e32958, 0xc072da1f50}, 0xc039fa5e60, 0x0?, {0xc00f310000, 0x3e18}, {0x0, 0x0, 0x0})
	  /usr/local/go/src/database/sql/sql.go:1670 +0x251
  database/sql.(*Tx).ExecContext(0xc017c01f00, {0x3e32958, 0xc072da1f50}, {0xc00f310000, 0x3e18}, {0x0, 0x0, 0x0})
	  /usr/local/go/src/database/sql/sql.go:2478 +0xad
  github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper.(*Tx).ExecContext(0xc0cd451338, {0x3e32958, 0xc072da1f50}, {0xc00f310000, 0x3e18}, {0x0, 0x0, 0x0})
	  /rudder-server/warehouse/integrations/middleware/sqlquerywrapper/sql.go:299 +0x113
  github.com/rudderlabs/rudder-server/warehouse/integrations/redshift.(*Redshift).loadUserTables(0xc0391d2000, {0x3e32958, 0xc072da1f50})
	  /rudder-server/warehouse/integrations/redshift/redshift.go:849 +0xf0a
  github.com/rudderlabs/rudder-server/warehouse/integrations/redshift.(*Redshift).LoadUserTables(0x30e7d20?, {0x3e32958?, 0xc072da1f50?})
	  /rudder-server/warehouse/integrations/redshift/redshift.go:1358 +0x1d
  github.com/rudderlabs/rudder-server/warehouse/router.(*UploadJob).loadUserTables(0xc000f36000, 0xc0a1563680?)
	  /rudder-server/warehouse/router/state_export_data.go:280 +0x975
  github.com/rudderlabs/rudder-server/warehouse/router.(*UploadJob).exportUserTables(0xc000f36000, 0x7fce036d2f98?)
	  /rudder-server/warehouse/router/state_export_data.go:190 +0xb0
  github.com/rudderlabs/rudder-server/warehouse/router.(*UploadJob).exportData.func1()
	  /rudder-server/warehouse/router/state_export_data.go:64 +0x19a
  github.com/rudderlabs/rudder-server/rruntime.GoForWarehouse.func1()
	  /rudder-server/rruntime/goroutine-factory.go:36 +0x90
  created by github.com/rudderlabs/rudder-server/rruntime.GoForWarehouse in goroutine 4593
	  /rudder-server/rruntime/goroutine-factory.go:33 +0x4f
  ```
- Resolves PIPE-639

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
