### PR TITLE
chore: enabling gateway to ingest events even when sharedDB is down

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -127,7 +127,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 
 	fileUploaderProvider := fileuploader.NewProvider(ctx, backendconfig.DefaultBackendConfig)
 
-	rsourcesService, err := NewRsourcesService(deploymentType)
+	rsourcesService, err := NewRsourcesService(deploymentType, true)
 	if err != nil {
 		return err
 	}

--- a/app/apphandlers/gatewayAppHandler.go
+++ b/app/apphandlers/gatewayAppHandler.go
@@ -132,13 +132,10 @@ func (a *gatewayApp) StartRudderCore(ctx context.Context, options *app.Options) 
 	})
 	drainConfigManager, err := drain_config.NewDrainConfigManager(config, a.log.Child("drain-config"))
 	if err != nil {
-		a.log.Errorw("drain config manager setup fail", "error", err)
+		a.log.Errorw("drain config manager setup failed while starting gateway", "error", err)
 	}
 
-	drainConfigHttpHandler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "unable to start drain config http handler", http.StatusInternalServerError)
-	}))
-
+	drainConfigHttpHandler := drain_config.ErrorResponder("unable to start drain config http handler")
 	if drainConfigManager != nil {
 		defer drainConfigManager.Stop()
 		drainConfigHttpHandler = drainConfigManager.DrainConfigHttpHandler()

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -134,7 +134,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 
 	fileUploaderProvider := fileuploader.NewProvider(ctx, backendconfig.DefaultBackendConfig)
 
-	rsourcesService, err := NewRsourcesService(deploymentType)
+	rsourcesService, err := NewRsourcesService(deploymentType, true)
 	if err != nil {
 		return err
 	}

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -57,7 +57,7 @@ func rudderCoreWorkSpaceTableSetup() error {
 }
 
 // NewRsourcesService produces a rsources.JobService through environment configuration (env variables & config file)
-func NewRsourcesService(deploymentType deployment.Type) (rsources.JobService, error) {
+func NewRsourcesService(deploymentType deployment.Type, shouldSetupSharedDB bool) (rsources.JobService, error) {
 	var rsourcesConfig rsources.JobServiceConfig
 	rsourcesConfig.MaxPoolSize = config.GetInt("Rsources.MaxPoolSize", 3)
 	rsourcesConfig.MinPoolSize = config.GetInt("Rsources.MinPoolSize", 1)
@@ -81,6 +81,8 @@ func NewRsourcesService(deploymentType deployment.Type) (rsources.JobService, er
 			return nil, fmt.Errorf("deployment type %s requires SharedDB.dsn to be provided", deploymentType)
 		}
 	}
+
+	rsourcesConfig.ShouldSetupSharedDB = shouldSetupSharedDB
 
 	return rsources.NewJobService(rsourcesConfig)
 }

--- a/internal/drain-config/drainConfig.go
+++ b/internal/drain-config/drainConfig.go
@@ -39,6 +39,9 @@ type drainConfigManager struct {
 	wg   sync.WaitGroup
 }
 
+// NewDrainConfigManager returns a drainConfigManager
+// If migration fails while setting up drain config, drainConfigManager object will be returned along with error
+// Consumers must handle errors and non-nil drainConfigManager object according to their use case.
 func NewDrainConfigManager(conf *config.Config, log logger.Logger) (*drainConfigManager, error) {
 	db, err := setupDBConn(conf)
 	if err != nil {

--- a/internal/drain-config/drainConfig.go
+++ b/internal/drain-config/drainConfig.go
@@ -45,9 +45,8 @@ func NewDrainConfigManager(conf *config.Config, log logger.Logger) (*drainConfig
 		log.Errorw("db setup", "error", err)
 		return nil, fmt.Errorf("db setup: %v", err)
 	}
-	if err := migrate(db); err != nil {
+	if err = migrate(db); err != nil {
 		log.Errorw("db migrations", "error", err)
-		return nil, fmt.Errorf("db migrations: %v", err)
 	}
 	return &drainConfigManager{
 		log:  log,
@@ -55,7 +54,7 @@ func NewDrainConfigManager(conf *config.Config, log logger.Logger) (*drainConfig
 		db:   db,
 
 		done: &atomic.Bool{},
-	}, nil
+	}, err
 }
 
 func (d *drainConfigManager) CleanupRoutine(ctx context.Context) error {
@@ -188,9 +187,6 @@ func setupDBConn(conf *config.Config) (*sql.DB, error) {
 	db, err := sql.Open("postgres", psqlInfo)
 	if err != nil {
 		return nil, fmt.Errorf("db open: %v", err)
-	}
-	if err := db.Ping(); err != nil {
-		return nil, fmt.Errorf("db ping: %v", err)
 	}
 	db.SetMaxIdleConns(conf.GetInt("drainConfig.maxIdleConns", 1))
 	db.SetMaxOpenConns(conf.GetInt("drainConfig.maxOpenConns", 2))

--- a/internal/drain-config/http.go
+++ b/internal/drain-config/http.go
@@ -41,3 +41,9 @@ func (dcm *drainConfigManager) insert(ctx context.Context, key, value string) er
 	}
 	return nil
 }
+
+func ErrorResponder(errMsg string) http.Handler {
+	return http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, errMsg, http.StatusInternalServerError)
+	}))
+}

--- a/services/rsources/failed_records_pagination_test.go
+++ b/services/rsources/failed_records_pagination_test.go
@@ -43,10 +43,11 @@ func TestFailedRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	service, err := NewJobService(JobServiceConfig{
-		LocalHostname: postgresContainer.Host,
-		MaxPoolSize:   1,
-		LocalConn:     postgresContainer.DBDsn,
-		Log:           logger.NOP,
+		LocalHostname:       postgresContainer.Host,
+		MaxPoolSize:         1,
+		LocalConn:           postgresContainer.DBDsn,
+		Log:                 logger.NOP,
+		ShouldSetupSharedDB: true,
 	})
 	require.NoError(t, err)
 	// Create 2 different job run ids with 10 records each
@@ -85,10 +86,11 @@ func RunFailedRecordsPerformanceTest(t testing.TB, recordCount, pageSize int) ti
 	require.NoError(t, err)
 
 	service, err := NewJobService(JobServiceConfig{
-		LocalHostname: postgresContainer.Host,
-		MaxPoolSize:   1,
-		LocalConn:     postgresContainer.DBDsn,
-		Log:           logger.NOP,
+		LocalHostname:       postgresContainer.Host,
+		MaxPoolSize:         1,
+		LocalConn:           postgresContainer.DBDsn,
+		Log:                 logger.NOP,
+		ShouldSetupSharedDB: true,
 	})
 	require.NoError(t, err)
 

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -487,7 +487,7 @@ func (sh *sourcesHandler) init() error {
 		return err
 	}
 
-	if sh.sharedDB != nil && sh.config.ShouldSetupSharedDB {
+	if sh.config.ShouldSetupSharedDB && sh.sharedDB != nil {
 		if err := withAdvisoryLock(ctx, sh.sharedDB, lockID, func(_ *sql.Tx) error {
 			sh.log.Debugf("setting up rsources tables for shared db %s", sh.config.SharedConn)
 			if err := setupTables(ctx, sh.sharedDB, "shared", sh.log); err != nil {

--- a/services/rsources/handler_test.go
+++ b/services/rsources/handler_test.go
@@ -58,10 +58,11 @@ var _ = Describe("Using sources handler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			resource = newDBResource(pool, "", "postgres")
 			config := JobServiceConfig{
-				LocalHostname: "postgres",
-				MaxPoolSize:   1,
-				LocalConn:     resource.externalDSN,
-				Log:           testlog.GinkgoLogger,
+				LocalHostname:       "postgres",
+				MaxPoolSize:         1,
+				LocalConn:           resource.externalDSN,
+				Log:                 testlog.GinkgoLogger,
+				ShouldSetupSharedDB: true,
 			}
 			sh = createService(config)
 		})
@@ -762,6 +763,7 @@ var _ = Describe("Using sources handler", func() {
 				SharedConn:             pgC.externalDSN,
 				SubscriptionTargetConn: pgA.internalDSN,
 				Log:                    testlog.GinkgoLogger,
+				ShouldSetupSharedDB:    true,
 			}
 
 			configB = JobServiceConfig{
@@ -771,6 +773,7 @@ var _ = Describe("Using sources handler", func() {
 				SharedConn:             pgC.externalDSN,
 				SubscriptionTargetConn: pgB.internalDSN,
 				Log:                    testlog.GinkgoLogger,
+				ShouldSetupSharedDB:    true,
 			}
 
 			// Start 2 JobServices
@@ -937,6 +940,7 @@ var _ = Describe("Using sources handler", func() {
 				SharedConn:             pgC.externalDSN,
 				SubscriptionTargetConn: pgD.internalDSN,
 				Log:                    testlog.GinkgoLogger,
+				ShouldSetupSharedDB:    true,
 			}
 			_, err := NewJobService(badConfig)
 			Expect(err).To(HaveOccurred(), "it shouldn't able to create the service")
@@ -953,6 +957,7 @@ var _ = Describe("Using sources handler", func() {
 				SharedConn:             pgC.externalDSN,
 				SubscriptionTargetConn: pgD.externalDSN,
 				Log:                    testlog.GinkgoLogger,
+				ShouldSetupSharedDB:    true,
 			}
 			_, err := NewJobService(badConfig)
 			Expect(err).To(HaveOccurred(), "it shouldn't able to create the service")
@@ -994,6 +999,7 @@ var _ = Describe("Using sources handler", func() {
 				SharedConn:             pgB.externalDSN,
 				SubscriptionTargetConn: pgA.internalDSN,
 				Log:                    testlog.GinkgoLogger,
+				ShouldSetupSharedDB:    true,
 			}
 			serviceA = createService(configA)
 		})
@@ -1070,6 +1076,7 @@ var _ = Describe("Using sources handler", func() {
 				SharedConn:             pgC.externalDSN,
 				SubscriptionTargetConn: pgA.internalDSN,
 				Log:                    log,
+				ShouldSetupSharedDB:    true,
 			}
 
 			configB := JobServiceConfig{
@@ -1079,6 +1086,7 @@ var _ = Describe("Using sources handler", func() {
 				SharedConn:             pgC.externalDSN,
 				SubscriptionTargetConn: pgB.internalDSN,
 				Log:                    log,
+				ShouldSetupSharedDB:    true,
 			}
 
 			// Setting up previous environment before adding failedkeys table to the publication
@@ -1306,6 +1314,7 @@ var _ = Describe("Using sources handler", func() {
 				SharedConn:             pgC.externalDSN,
 				SubscriptionTargetConn: pgA.internalDSN,
 				Log:                    log,
+				ShouldSetupSharedDB:    true,
 			}
 
 			configB := JobServiceConfig{
@@ -1315,6 +1324,7 @@ var _ = Describe("Using sources handler", func() {
 				SharedConn:             pgC.externalDSN,
 				SubscriptionTargetConn: pgB.internalDSN,
 				Log:                    log,
+				ShouldSetupSharedDB:    true,
 			}
 
 			// Setting up previous environment before adding failedkeys table to the publication

--- a/services/rsources/handler_v1_test.go
+++ b/services/rsources/handler_v1_test.go
@@ -37,10 +37,11 @@ var _ = Describe("Using sources handler v1", func() {
 			Expect(err).NotTo(HaveOccurred())
 			resource = newDBResource(pool, "", "postgres")
 			config := JobServiceConfig{
-				LocalHostname: "postgres",
-				MaxPoolSize:   1,
-				LocalConn:     resource.externalDSN,
-				Log:           testlog.GinkgoLogger,
+				LocalHostname:       "postgres",
+				MaxPoolSize:         1,
+				LocalConn:           resource.externalDSN,
+				Log:                 testlog.GinkgoLogger,
+				ShouldSetupSharedDB: true,
 			}
 			sh = createService(config)
 		})
@@ -364,6 +365,7 @@ var _ = Describe("Using sources handler v1", func() {
 				SharedConn:             pgC.externalDSN,
 				SubscriptionTargetConn: pgA.internalDSN,
 				Log:                    testlog.GinkgoLogger,
+				ShouldSetupSharedDB:    true,
 			}
 
 			configB = JobServiceConfig{
@@ -373,6 +375,7 @@ var _ = Describe("Using sources handler v1", func() {
 				SharedConn:             pgC.externalDSN,
 				SubscriptionTargetConn: pgB.internalDSN,
 				Log:                    testlog.GinkgoLogger,
+				ShouldSetupSharedDB:    true,
 			}
 
 			// Start 2 JobServices

--- a/services/rsources/http/http_integration_test.go
+++ b/services/rsources/http/http_integration_test.go
@@ -34,10 +34,11 @@ func prepare(
 	require.NoError(t, err)
 
 	config := rsources.JobServiceConfig{
-		LocalHostname: postgresContainer.Host,
-		MaxPoolSize:   1,
-		LocalConn:     postgresContainer.DBDsn,
-		Log:           logger.NOP,
+		LocalHostname:       postgresContainer.Host,
+		MaxPoolSize:         1,
+		LocalConn:           postgresContainer.DBDsn,
+		Log:                 logger.NOP,
+		ShouldSetupSharedDB: true,
 	}
 	service, err = rsources.NewJobService(config)
 	require.NoError(t, err)

--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -203,6 +203,7 @@ type JobServiceConfig struct {
 	SubscriptionTargetConn      string
 	SkipFailedRecordsCollection bool
 	Log                         logger.Logger
+	ShouldSetupSharedDB         bool
 }
 
 // JobService manages information about jobs created by rudder-sources


### PR DESCRIPTION
# Description
Gateway was not able to start web server, If sharedDB is down for some reason. Following steps in startup are blocking web server to start.
1. RSources service was not able to start as it was not able to connect with sharedDB and setup db tables and replication.
2. DrainConfigManager was not able start and run migrations for the drain config db tables present in shared DB.

Solution: 
When a new gateway instance is coming up, 
1. while setting up RSources service we will not setup sharedDB tables and replication.
2. while setting up DrainConfigManager we will not halt gateway setup on failure of migration for drain config tables.

We will raise an alert for the failure logs. AI for the alert will be to restart gateway instance.

## Linear Ticket
https://linear.app/rudderstack/issue/PIPE-484/gateway-should-accept-data-even-if-it-is-not-able-to-connect-with

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
