### PR TITLE
fix: bigquery job statistics for rate limit

### DIFF
--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -466,6 +466,11 @@ func (bq *BigQuery) jobStatistics(
 	)
 	bqJob, err := bqJobGetCall.Context(ctx).Location(job.Location()).Fields("statistics").Do()
 	if err != nil {
+		// In case of rate limit error, return empty statistics
+		var e *googleapi.Error
+		if errors.As(err, &e) && e.Code == 429 {
+			return &bqService.JobStatistics{}, nil
+		}
 		return nil, fmt.Errorf("getting job: %w", err)
 	}
 	return bqJob.Statistics, nil


### PR DESCRIPTION
# Description

- While getting job statistics for BigQuery, it's getting rate limited for gelato (PRO). 
  ```
  load table: append job statistics: getting job: googleapi: Error 429: Quota exceeded for quota metric 'Requests' and limit 'Requests per day' of service 'bigquery.googleapis.com'
  ```
- We can ignore the errors as these statistics are just for tracking alerts and we don't want to retry the syncs due to the following error.

## Linear Ticket

- Resolves PIPE-653

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
