### PR TITLE
feat: new internal api for workspace status

### DIFF
--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -91,6 +91,7 @@ type Handle struct {
 	configSubscriberLock sync.RWMutex
 	writeKeysSourceMap   map[string]backendconfig.SourceT
 	sourceIDSourceMap    map[string]backendconfig.SourceT
+	workspaceIDMap       map[string]struct{}
 
 	conf struct { // configuration parameters
 		httpTimeout                                                                       time.Duration


### PR DESCRIPTION
# Description

- New GET endpoint for `internal/v1/workspace/{workspaceID}/status` to check the status for a workspace whether it is serving or not.
- More about it in [here](https://linear.app/rudderstack/issue/PIPE-627/research-zero-downtime-cross-tier-migration) and [here](https://www.notion.so/rudderstacks/Zero-Downtime-Cross-tier-migration-1e8b7a214d2544528c699c684331ca94?pvs=4).

## Linear Ticket

- Resolves PIPE-652

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
