### PR TITLE
chore: custom buckets for gw request size

### DIFF
--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -1,14 +1,18 @@
 package runner
 
+import "github.com/rudderlabs/rudder-go-kit/bytesize"
+
 var customBuckets = map[string][]float64{
 	"gateway.request_size": {
-		10,       // 10 bytes
-		100,      // 100 bytes
-		1000,     // 1kb
-		10000,    // 10kb
-		100000,   // 100kb
-		1000000,  // 1mb
-		10000000, // 10mb
+		float64(10 * bytesize.B),
+		float64(100 * bytesize.B),
+		float64(1 * bytesize.KB),
+		float64(10 * bytesize.KB),
+		float64(100 * bytesize.KB),
+		float64(1 * bytesize.MB),
+		float64(3 * bytesize.MB),
+		float64(5 * bytesize.MB),
+		float64(10 * bytesize.MB),
 	},
 	"gateway.response_time": {
 		0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60,

--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -1,6 +1,15 @@
 package runner
 
 var customBuckets = map[string][]float64{
+	"gateway.request_size": {
+		10,       // 10 bytes
+		100,      // 100 bytes
+		1000,     // 1kb
+		10000,    // 10kb
+		100000,   // 100kb
+		1000000,  // 1mb
+		10000000, // 10mb
+	},
 	"gateway.response_time": {
 		0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60,
 	},


### PR DESCRIPTION
# Description

Adding custom buckets for GW request size for better cost analysis (HA ingestion project).

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-659/histogram-buckets-for-gw-request-size) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
