### PR TITLE
feat: toggle event ordering for workspace/destination

### DIFF
--- a/router/eventorder_debugger_test.go
+++ b/router/eventorder_debugger_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
 	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/router/internal/eventorder"
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 )
 
@@ -71,7 +72,7 @@ func TestEventOrderDebugInfo(t *testing.T) {
 	_, err = pgContainer.DB.Exec("UPDATE rt_jobs_1 SET created_at = $1", refTime)
 	require.NoError(t, err)
 
-	debugInfo := rt.eventOrderDebugInfo("user1:destination1")
+	debugInfo := rt.eventOrderDebugInfo(eventorder.BarrierKey{UserID: "user1", DestinationID: "destination1"})
 	require.Equal(t,
 		` |    t_name| job_id|                    created_at| status_id| job_state| attempt|                     exec_time| error_code| parameters| error_response|
  |       ---|    ---|                           ---|       ---|       ---|     ---|                           ---|        ---|        ---|            ---|

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -3,6 +3,7 @@ package router
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -136,6 +137,12 @@ func (rt *Handle) Setup(
 		panic(fmt.Errorf("resolving isolation strategy for mode %q: %w", isolationMode, err))
 	}
 
+	rt.eventOrderingDisabledForWorkspace = func(workspaceID string) bool {
+		return slices.Contains(config.GetStringSlice("Router.orderingDisabledWorkspaceIDs", nil), workspaceID)
+	}
+	rt.eventOrderingDisabledForDestination = func(destinationID string) bool {
+		return slices.Contains(config.GetStringSlice("Router.orderingDisabledDestinationIDs", nil), destinationID)
+	}
 	rt.barrier = eventorder.NewBarrier(eventorder.WithMetadata(map[string]string{
 		"destType":         rt.destType,
 		"batching":         strconv.FormatBool(rt.enableBatching),
@@ -146,6 +153,9 @@ func (rt *Handle) Setup(
 		eventorder.WithHalfEnabledStateDuration(rt.eventOrderHalfEnabledStateDuration),
 		eventorder.WithDrainConcurrencyLimit(rt.drainConcurrencyLimit),
 		eventorder.WithDebugInfoProvider(rt.eventOrderDebugInfo),
+		eventorder.WithOrderingDisabledCheckForBarrierKey(func(key eventorder.BarrierKey) bool {
+			return rt.eventOrderingDisabledForWorkspace(key.WorkspaceID) || rt.eventOrderingDisabledForDestination(key.DestinationID)
+		}),
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/router/handle_observability.go
+++ b/router/handle_observability.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/sqlutil"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/router/internal/eventorder"
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 	"github.com/rudderlabs/rudder-server/services/rsources"
 	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
@@ -137,13 +138,13 @@ func (rt *Handle) pipelineDelayStats(partition string, first, last *jobsdb.JobT)
 
 // eventOrderDebugInfo provides some debug information for the given orderKey in case of a panic.
 // Top 100 job statuses for the given orderKey are returned.
-func (rt *Handle) eventOrderDebugInfo(orderKey string) (res string) {
+func (rt *Handle) eventOrderDebugInfo(orderKey eventorder.BarrierKey) (res string) {
 	defer func() {
 		if r := recover(); r != nil {
 			res = fmt.Sprintf("panic in EventOrderDebugInfo: %v", r)
 		}
 	}()
-	userID, destinationID := parseJobOrderKey(orderKey)
+	userID, destinationID := orderKey.UserID, orderKey.DestinationID
 	if err := rt.jobsDB.WithTx(func(tx *Tx) error {
 		rows, err := tx.Query(`SELECT * FROM joborderlog($1, $2, 10) LIMIT 100`, destinationID, userID)
 		if err != nil {

--- a/router/misc.go
+++ b/router/misc.go
@@ -58,10 +58,6 @@ func getWorkerPartition(key eventorder.BarrierKey, noOfWorkers int) int {
 	return misc.GetHash(key.String()) % noOfWorkers
 }
 
-func jobOrderKey(userID, destinationID string) string {
-	return userID + ":" + destinationID
-}
-
 func isolationMode(destType string, config *config.Config) isolation.Mode {
 	defaultIsolationMode := isolation.ModeDestination
 	if config.IsSet("WORKSPACE_NAMESPACE") {

--- a/router/misc.go
+++ b/router/misc.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	"github.com/rudderlabs/rudder-server/processor/integrations"
+	"github.com/rudderlabs/rudder-server/router/internal/eventorder"
 	"github.com/rudderlabs/rudder-server/router/isolation"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
@@ -54,17 +54,12 @@ func getIterableStruct(payload []byte, transformAt string) ([]integrations.PostP
 	return responseArray, err
 }
 
-func getWorkerPartition(key string, noOfWorkers int) int {
-	return misc.GetHash(key) % noOfWorkers
+func getWorkerPartition(key eventorder.BarrierKey, noOfWorkers int) int {
+	return misc.GetHash(key.String()) % noOfWorkers
 }
 
 func jobOrderKey(userID, destinationID string) string {
 	return userID + ":" + destinationID
-}
-
-func parseJobOrderKey(key string) (string, string) {
-	colonIndex := strings.LastIndex(key, ":")
-	return key[:colonIndex], key[colonIndex+1:]
 }
 
 func isolationMode(destType string, config *config.Config) isolation.Mode {

--- a/router/worker.go
+++ b/router/worker.go
@@ -424,7 +424,7 @@ func (w *worker) processDestinationJobs() {
 		u2e3 will send
 	*/
 
-	failedJobOrderKeys := make(map[string]struct{})
+	failedJobOrderKeys := make(map[eventorder.BarrierKey]struct{})
 	var routerJobResponses []*JobResponse
 
 	sort.Slice(w.destinationJobs, func(i, j int) bool {
@@ -625,7 +625,7 @@ func (w *worker) processDestinationJobs() {
 	})
 
 	// Struct to hold unique users in the batch (worker.destinationJobs)
-	jobOrderKeyToJobIDMap := make(map[string]int64)
+	jobOrderKeyToJobIDMap := make(map[eventorder.BarrierKey]int64)
 
 	for _, routerJobResponse := range routerJobResponses {
 		destinationJobMetadata := routerJobResponse.destinationJobMetadata
@@ -645,7 +645,11 @@ func (w *worker) processDestinationJobs() {
 		routerJobResponse.status = &status
 
 		if !isJobTerminated(respStatusCode) {
-			orderKey := jobOrderKey(destinationJobMetadata.UserID, destinationJobMetadata.DestinationID)
+			orderKey := eventorder.BarrierKey{
+				UserID:        destinationJobMetadata.UserID,
+				DestinationID: destinationJobMetadata.DestinationID,
+				WorkspaceID:   destinationJobMetadata.WorkspaceID,
+			}
 			if prevFailedJobID, ok := jobOrderKeyToJobIDMap[orderKey]; ok {
 				// This means more than two jobs of the same user are in the batch & the batch job is failed
 				// Only one job is marked failed and the rest are marked waiting
@@ -802,7 +806,7 @@ func (w *worker) hydrateRespStatusCodes(destinationJob types.DestinationJobT, re
 	}
 }
 
-func (w *worker) updateFailedJobOrderKeys(failedJobOrderKeys map[string]struct{}, destinationJob *types.DestinationJobT, respStatusCodes map[int64]int) {
+func (w *worker) updateFailedJobOrderKeys(failedJobOrderKeys map[eventorder.BarrierKey]struct{}, destinationJob *types.DestinationJobT, respStatusCodes map[int64]int) {
 	for _, metadata := range destinationJob.JobMetadataArray {
 		if !isJobTerminated(respStatusCodes[metadata.JobID]) {
 			orderKey := eventorder.BarrierKey{
@@ -811,7 +815,7 @@ func (w *worker) updateFailedJobOrderKeys(failedJobOrderKeys map[string]struct{}
 				WorkspaceID:   metadata.WorkspaceID,
 			}
 			if w.rt.guaranteeUserEventOrder && !w.barrier.Disabled(orderKey) { // if barrier is disabled, we shouldn't need to track the failed job
-				failedJobOrderKeys[jobOrderKey(metadata.UserID, metadata.DestinationID)] = struct{}{}
+				failedJobOrderKeys[orderKey] = struct{}{}
 			}
 		}
 	}
@@ -879,7 +883,7 @@ func (w *worker) prepareResponsesForJobs(destinationJob *types.DestinationJobT, 
 	return respStatusCodes, respBodys
 }
 
-func (w *worker) canSendJobToDestination(failedJobOrderKeys map[string]struct{}, destinationJob *types.DestinationJobT) bool {
+func (w *worker) canSendJobToDestination(failedJobOrderKeys map[eventorder.BarrierKey]struct{}, destinationJob *types.DestinationJobT) bool {
 	if !w.rt.guaranteeUserEventOrder {
 		// if guaranteeUserEventOrder is false, letting the next jobs pass
 		return true
@@ -888,7 +892,11 @@ func (w *worker) canSendJobToDestination(failedJobOrderKeys map[string]struct{},
 	// If the destinationJob has come through router transform / batch transform,
 	// drop the request if it is of a failed user, else send
 	for i := range destinationJob.JobMetadataArray {
-		orderKey := jobOrderKey(destinationJob.JobMetadataArray[i].UserID, destinationJob.JobMetadataArray[i].DestinationID)
+		orderKey := eventorder.BarrierKey{
+			UserID:        destinationJob.JobMetadataArray[i].UserID,
+			DestinationID: destinationJob.JobMetadataArray[i].DestinationID,
+			WorkspaceID:   destinationJob.JobMetadataArray[i].WorkspaceID,
+		}
 		if _, ok := failedJobOrderKeys[orderKey]; ok {
 			return false
 		}


### PR DESCRIPTION
# Description

Provides config to toggle event ordering at a workspace/destination level.(`"Router.orderingDisabledWorkspaceIDs"`, `"Router.orderingDisabledDestinationIDs"`)

On setting required workspace/destinationID, the barrier for that `BarrierKey` is disabled. Turns back to processing events in  order once the config has been reset and after passing of `eventOrderDisabledStateDuration` and `eventOrderHalfEnabledStateDuration` duration.

Introduces `BarrierKey` which is just a composite:
```
type BarrierKey struct {
	DestinationID, UserID, WorkspaceID string
}
```
so the barrier methods now take this instead of the string(`<destID>:<userID>`) earlier


## Linear Ticket

[linear](https://linear.app/rudderstack/issue/PIPE-28/disable-event-ordering-at-a-workspace-level-destination-id-level)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
