### PR TITLE
chore: improve error logging

### DIFF
--- a/services/rsources/handler_test.go
+++ b/services/rsources/handler_test.go
@@ -918,7 +918,7 @@ var _ = Describe("Using sources handler", func() {
 					return false
 				}
 				return true
-			}, "30s", "100ms").Should(BeTrue(), "Failed Records from both services should be the same", mustMarshal(failedKeysA), mustMarshal(failedKeysB), mustMarshal(expected), err)
+			}, "30s", "100ms").Should(BeTrue(), "Failed Records from both services should be the same", string(mustMarshal(failedKeysA)), string(mustMarshal(failedKeysB)), string(mustMarshal(expected)), err)
 		})
 
 		It("should be able to create the same services again and not affect publications and subscriptions", func() {
@@ -1203,7 +1203,7 @@ var _ = Describe("Using sources handler", func() {
 					return false
 				}
 				return true
-			}, "30s", "100ms").Should(BeTrue(), "Failed Records from both services should be the same", mustMarshal(failedKeysA), mustMarshal(failedKeysB), mustMarshal(expected), err)
+			}, "30s", "100ms").Should(BeTrue(), "Failed Records from both services should be the same", string(mustMarshal(failedKeysA)), string(mustMarshal(failedKeysB)), string(mustMarshal(expected)), err)
 
 			jobRunId := newJobRunId()
 			addFailedRecords(pgA.db, jobRunId, defaultJobTargetKey, serviceA, []FailedRecord{
@@ -1270,7 +1270,7 @@ var _ = Describe("Using sources handler", func() {
 					return false
 				}
 				return true
-			}, "30s", "100ms").Should(BeTrue(), "Failed Records from both services should be the same", mustMarshal(failedKeysA), mustMarshal(failedKeysB), mustMarshal(expected), err)
+			}, "30s", "100ms").Should(BeTrue(), "Failed Records from both services should be the same", string(mustMarshal(failedKeysA)), string(mustMarshal(failedKeysB)), string(mustMarshal(expected)), err)
 		})
 
 		It("should be able to add a code column to rsources_failed_keys_v2_records table seamlessly, without affecting logical replication", func() {
@@ -1417,7 +1417,7 @@ var _ = Describe("Using sources handler", func() {
 					return false
 				}
 				return true
-			}, "30s", "100ms").Should(BeTrue(), "Failed Records from both services should be the same", mustMarshal(failedKeysA), mustMarshal(failedKeysB), mustMarshal(expected), err)
+			}, "30s", "100ms").Should(BeTrue(), "Failed Records from both services should be the same", string(mustMarshal(failedKeysA)), string(mustMarshal(failedKeysB)), string(mustMarshal(expected)), err)
 
 			jobRunId := newJobRunId()
 			addFailedRecords(pgA.db, jobRunId, defaultJobTargetKey, serviceA, []FailedRecord{
@@ -1484,7 +1484,7 @@ var _ = Describe("Using sources handler", func() {
 					return false
 				}
 				return true
-			}, "30s", "100ms").Should(BeTrue(), "Failed Records from both services should be the same", mustMarshal(failedKeysA), mustMarshal(failedKeysB), mustMarshal(expected), err)
+			}, "30s", "100ms").Should(BeTrue(), "Failed Records from both services should be the same", string(mustMarshal(failedKeysA)), string(mustMarshal(failedKeysB)), string(mustMarshal(expected)), err)
 		})
 	})
 })

--- a/services/rsources/handler_v1_test.go
+++ b/services/rsources/handler_v1_test.go
@@ -457,7 +457,7 @@ var _ = Describe("Using sources handler v1", func() {
 					return false
 				}
 				return true
-			}, "30s", "100ms").Should(BeTrue(), "Failed Records from both services should be the same", mustMarshal(failedKeysA), mustMarshal(failedKeysB), mustMarshal(expected), err)
+			}, "30s", "100ms").Should(BeTrue(), "Failed Records from both services should be the same", string(mustMarshal(failedKeysA)), string(mustMarshal(failedKeysB)), string(mustMarshal(expected)), err)
 		})
 	})
 })


### PR DESCRIPTION
# Description

- Currently, we are logging as a byte sequence. [GA link.](https://github.com/rudderlabs/rudder-server/actions/runs/7338777343/job/19981825989)
```
  Failed Records from both services should be the same%!(EXTRA []uint8=[123 34 105 100 34 58 34 34 44 34 116 97 115 107 115 34 58 110 117 108 108 125], []uint8=[123 34 105 100 34 58 34 34 44 34 116 97 115 107 115 34 58 110 117 108 108 125], []uint8=[123 34 105 100 34 58 34 56 101 51 53 98 55 56 53 98 55 48 56 52 56 49 99 56 100 100 53 97 101 50 101 99 53 52 98 54 101 53 99 34 44 34 116 97 115 107 115 34 58 91 123 34 105 100 34 58 34 116 97 115 107 95 114 117 110 95 105 100 34 44 34 115 111 117 114 99 101 115 34 58 91 123 34 105 100 34 58 34 115 111 117 114 99 101 95 105 100 34 44 34 114 101 99 111 114 100 115 34 58 110 117 108 108 44 34 100 101 115 116 105 110 97 116 105 111 110 115 34 58 91 123 34 105 100 34 58 34 100 101 115 116 105 110 97 116 105 111 110 95 105 100 34 44 34 114 101 99 111 114 100 115 34 58 91 123 34 105 100 34 58 34 49 34 125 44 123 34 105 100 34 58 34 50 34 125 44 123 34 105 100 34 58 34 50 34 125 44 123 34 105 100 34 58 34 51 34 125 93 125 93 125 93 125 93 125], <nil>)
```
- Log as string instead of byte sequence for better debuggability.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
