### PR TITLE
chore: error index file path collision

### DIFF
--- a/enterprise/reporting/error_index/worker.go
+++ b/enterprise/reporting/error_index/worker.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 
 	"github.com/samber/lo"
@@ -191,6 +193,7 @@ func (w *worker) uploadJobs(ctx context.Context, jobs []*jobsdb.JobT) ([]*jobsdb
 		if err != nil {
 			return nil, fmt.Errorf("uploading aggregated payloads: %w", err)
 		}
+		w.log.Debugn("successfully uploaded aggregated payloads", logger.NewStringField("location", uploadFile.Location))
 
 		statusList = append(statusList, lo.Map(jobWithPayloads, func(item jobWithPayload, index int) *jobsdb.JobStatusT {
 			return &jobsdb.JobStatusT{
@@ -225,7 +228,7 @@ func (w *worker) uploadPayloads(ctx context.Context, payloads []payload) (*filem
 	minFailedAt := payloads[0].FailedAtTime()
 	maxFailedAt := payloads[len(payloads)-1].FailedAtTime()
 
-	filePath := path.Join(dir, fmt.Sprintf("%d_%d_%s.parquet", minFailedAt.Unix(), maxFailedAt.Unix(), w.config.instanceID))
+	filePath := path.Join(dir, fmt.Sprintf("%d_%d_%s_%s.parquet", minFailedAt.Unix(), maxFailedAt.Unix(), w.config.instanceID, uuid.NewString()))
 
 	f, err := os.Create(filePath)
 	if err != nil {


### PR DESCRIPTION
# Description

- Identified and addressed an issue with over 10k records (around 2M) for a specific **sourceID** and **failedAt** during PWCC debugging.
- Introduced a **uuid** to the error-index file path, maintaining backward compatibility with the existing format.
- Successfully executed e2e tests [here](https://github.com/rudderlabs/e2e/actions/runs/7475473131/job/20343689226).

## Linear Ticket

- Resolves PIPE-682

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
