### PR TITLE
fix: ignore destinationID in gateway rsources.statCollector

### DIFF
--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -331,7 +331,7 @@ func (gw *Handle) dbWriterWorkerProcess() {
 			}
 
 			// rsources stats
-			rsourcesStats := rsources.NewStatsCollector(gw.rsourcesService)
+			rsourcesStats := rsources.NewStatsCollector(gw.rsourcesService, rsources.IgnoreDestinationID())
 			rsourcesStats.JobsStoredWithErrors(lo.Flatten(jobBatches), errorMessagesMap)
 			return rsourcesStats.Publish(ctx, tx.SqlTx())
 		})

--- a/router/batchrouter/batchrouter_isolation_test.go
+++ b/router/batchrouter/batchrouter_isolation_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ory/dockertest/v3"
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -195,7 +196,7 @@ func BatchrouterIsolationScenario(t testing.TB, spec *BrtIsolationScenarioSpec) 
 	containersGroup, _ := errgroup.WithContext(ctx)
 	containersGroup.Go(func() (err error) {
 		t.Logf("Starting postgres container")
-		postgresContainer, err = resource.SetupPostgres(pool, t, postgres.WithOptions("max_connections=1000"))
+		postgresContainer, err = resource.SetupPostgres(pool, t, postgres.WithOptions("max_connections=1000"), postgres.WithShmSize(256*bytesize.MB))
 		return err
 	})
 	containersGroup.Go(func() (err error) {

--- a/router/batchrouter/batchrouter_isolation_test.go
+++ b/router/batchrouter/batchrouter_isolation_test.go
@@ -16,11 +16,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ory/dockertest/v3"
-	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"

--- a/router/eventorder_debugger_test.go
+++ b/router/eventorder_debugger_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 )
@@ -17,7 +19,7 @@ import (
 func TestEventOrderDebugInfo(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
-	postgres, err := resource.SetupPostgres(pool, t)
+	postgres, err := resource.SetupPostgres(pool, t, postgres.WithShmSize(256*bytesize.MB))
 	require.NoError(t, err)
 
 	m := &migrator.Migrator{

--- a/router/eventorder_test.go
+++ b/router/eventorder_test.go
@@ -20,9 +20,11 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
 	"github.com/rudderlabs/rudder-server/router/utils"
 	"github.com/rudderlabs/rudder-server/runner"
 	"github.com/rudderlabs/rudder-server/testhelper/health"
@@ -94,7 +96,7 @@ func TestEventOrderGuarantee(t *testing.T) {
 			require.NoError(t, err)
 			containersGroup, _ := errgroup.WithContext(ctx)
 			containersGroup.Go(func() (err error) {
-				postgresContainer, err = resource.SetupPostgres(pool, t)
+				postgresContainer, err = resource.SetupPostgres(pool, t, postgres.WithShmSize(256*bytesize.MB))
 				return err
 			})
 			containersGroup.Go(func() (err error) {

--- a/router/router_isolation_test.go
+++ b/router/router_isolation_test.go
@@ -176,7 +176,7 @@ func RouterIsolationScenario(t testing.TB, spec *RtIsolationScenarioSpec) (overa
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err, "it should be able to create a new docker pool")
 	t.Logf("Starting postgres container")
-	postgresContainer, err := resource.SetupPostgres(pool, t, postgres.WithOptions("max_connections=1000"))
+	postgresContainer, err := resource.SetupPostgres(pool, t, postgres.WithOptions("max_connections=1000"), postgres.WithShmSize(256*bytesize.MB))
 	require.NoError(t, err, "it should be able to start postgres container without an error")
 	transformerContainer, err := destination.SetupTransformer(pool, t)
 	require.NoError(t, err)

--- a/router/router_throttling_test.go
+++ b/router/router_throttling_test.go
@@ -22,9 +22,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
 	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
 	trand "github.com/rudderlabs/rudder-go-kit/testhelper/rand"
 	"github.com/rudderlabs/rudder-server/runner"
 	"github.com/rudderlabs/rudder-server/testhelper"
@@ -86,7 +88,7 @@ func Test_RouterThrottling(t *testing.T) {
 		transformerContainer *destination.TransformerResource
 	)
 	group.Go(func() (err error) {
-		postgresContainer, err = resource.SetupPostgres(pool, t)
+		postgresContainer, err = resource.SetupPostgres(pool, t, postgres.WithShmSize(256*bytesize.MB))
 		return
 	})
 	group.Go(func() (err error) {

--- a/services/rsources/stats_collector.go
+++ b/services/rsources/stats_collector.go
@@ -55,8 +55,8 @@ type FailedJobsStatsCollector interface {
 }
 
 // NewStatsCollector creates a new stats collector
-func NewStatsCollector(jobservice JobService) StatsCollector {
-	return &statsCollector{
+func NewStatsCollector(jobservice JobService, opts ...OptFunc) StatsCollector {
+	sc := &statsCollector{
 		jobService:            jobservice,
 		jobIdsToStatKeyIndex:  map[int64]statKey{},
 		jobIdsToRecordIdIndex: map[int64]json.RawMessage{},
@@ -64,6 +64,10 @@ func NewStatsCollector(jobservice JobService) StatsCollector {
 		failedRecordsIndex:    map[statKey][]FailedRecord{},
 		parametersParser:      defaultParametersParser,
 	}
+	for _, opt := range opts {
+		opt(sc)
+	}
+	return sc
 }
 
 // NewDroppedJobsCollector creates a new stats collector for publishing failed job stats and records


### PR DESCRIPTION
# Description

Ignore destinationID in gateway's rsources stats collector.

## Linear Ticket

[slack thread](https://rudderlabs.slack.com/archives/C02B0A38QQG/p1704894410348019)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
