### PR TITLE
chore: remove namespace tag from error_detail_reporting_failures metric

### DIFF
--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -182,7 +182,6 @@ func (edr *ErrorDetailReporter) Report(ctx context.Context, metrics []*types.PUR
 		errDets := edr.extractErrorDetails(metric.StatusDetail.SampleResponse)
 
 		stats.Default.NewTaggedStat("error_detail_reporting_failures", stats.CountType, stats.Tags{
-			"namespace":     edr.namespace,
 			"errorCode":     errDets.ErrorCode,
 			"workspaceId":   workspaceID,
 			"destType":      destinationDetail.destType,


### PR DESCRIPTION
# Description
Removed namespace tag from error_detail_reporting_failures as it is not supported

## Linear Ticket
https://rudderlabs.slack.com/archives/C01HTT66UMB/p1704960958577379

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
