### PR TITLE
chore: backend config calls metric

### DIFF
--- a/backend-config/backend_config_test.go
+++ b/backend-config/backend_config_test.go
@@ -129,8 +129,6 @@ func TestBadResponse(t *testing.T) {
 
 	for name, conf := range configs {
 		t.Run(name, func(t *testing.T) {
-			t.Setenv("WORKSPACE_TOKEN", "foobar")
-
 			ctx := context.Background()
 			pkgLogger = logger.NOP
 			atomic.StoreInt32(&calls, 0)

--- a/backend-config/backend_config_test.go
+++ b/backend-config/backend_config_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	adminpkg "github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/backend-config/internal/cache"
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
@@ -116,15 +117,20 @@ func TestBadResponse(t *testing.T) {
 			namespace:        "some-namespace",
 			client:           http.DefaultClient,
 			logger:           logger.NOP,
+			httpCallsStat:    stats.NOP.NewStat("backend_config_http_calls", stats.CountType),
 		},
 		"single-workspace": &singleWorkspaceConfig{
 			configBackendURL: parsedURL,
+			logger:           logger.NOP,
+			httpCallsStat:    stats.NOP.NewStat("backend_config_http_calls", stats.CountType),
 		},
 	}
 	disableCache()
 
 	for name, conf := range configs {
 		t.Run(name, func(t *testing.T) {
+			t.Setenv("WORKSPACE_TOKEN", "foobar")
+
 			ctx := context.Background()
 			pkgLogger = logger.NOP
 			atomic.StoreInt32(&calls, 0)

--- a/backend-config/namespace_config.go
+++ b/backend-config/namespace_config.go
@@ -15,6 +15,8 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 	"github.com/rudderlabs/rudder-server/services/controlplane/identity"
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
@@ -41,6 +43,8 @@ type namespaceConfig struct {
 	incrementalConfigUpdates bool
 	lastUpdatedAt            time.Time
 	workspacesConfig         map[string]ConfigT
+
+	httpCallsStat stats.Counter
 }
 
 func (nc *namespaceConfig) SetUp() (err error) {
@@ -71,25 +75,27 @@ func (nc *namespaceConfig) SetUp() (err error) {
 			Timeout: nc.config.GetDuration("HttpClient.backendConfig.timeout", 30, time.Second),
 		}
 	}
-	if nc.logger == nil {
-		nc.logger = logger.NewLogger().Child("backend-config")
-	}
 	nc.workspacesConfig = make(map[string]ConfigT)
-	nc.logger.Infof("Setup config for namespace %s complete", nc.namespace)
+	nc.httpCallsStat = stats.Default.NewStat("backend_config_http_calls", stats.CountType)
+
+	if nc.logger == nil {
+		nc.logger = logger.NewLogger().Child("backend-config").Withn(obskit.Namespace(nc.namespace))
+	}
+	nc.logger.Infon("Setup backend config complete")
 
 	return nil
 }
 
 // Get returns sources from the workspace
 func (nc *namespaceConfig) Get(ctx context.Context) (map[string]ConfigT, error) {
-	config, err := nc.getFromAPI(ctx)
+	conf, err := nc.getFromAPI(ctx)
 	if errors.Is(err, ErrIncrementalUpdateFailed) {
 		// reset state here
 		// this triggers a full update
 		nc.lastUpdatedAt = time.Time{}
 		return nc.getFromAPI(ctx)
 	}
-	return config, err
+	return conf, err
 }
 
 // getFromApi gets the workspace config from api
@@ -115,18 +121,21 @@ func (nc *namespaceConfig) getFromAPI(ctx context.Context) (map[string]ConfigT, 
 	}
 
 	operation := func() (fetchError error) {
-		nc.logger.Debugf("Fetching config from %s", urlString)
+		defer nc.httpCallsStat.Increment()
+		nc.logger.Debugn("Fetching backend config", logger.NewStringField("url", urlString))
 		respBody, fetchError = nc.makeHTTPRequest(req)
 		return fetchError
 	}
 
 	backoffWithMaxRetry := backoff.WithContext(backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 3), ctx)
 	err = backoff.RetryNotify(operation, backoffWithMaxRetry, func(err error, t time.Duration) {
-		nc.logger.Warnf("Failed to fetch config from API with error: %v, retrying after %v", err, t)
+		nc.logger.Warnn("Failed to fetch backend config from API",
+			obskit.Error(err), logger.NewDurationField("retryAfter", t),
+		)
 	})
 	if err != nil {
 		if ctx.Err() == nil {
-			nc.logger.Errorf("Error sending request to the server: %v", err)
+			nc.logger.Errorn("Error sending request to the server", obskit.Error(err))
 		}
 		return configOnError, err
 	}
@@ -138,7 +147,7 @@ func (nc *namespaceConfig) getFromAPI(ctx context.Context) (map[string]ConfigT, 
 	var requestData map[string]*ConfigT
 	err = jsonfast.Unmarshal(respBody, &requestData)
 	if err != nil {
-		nc.logger.Errorf("Error while parsing request: %v", err)
+		nc.logger.Errorn("Error while parsing request", obskit.Error(err))
 		return configOnError, err
 	}
 
@@ -147,10 +156,10 @@ func (nc *namespaceConfig) getFromAPI(ctx context.Context) (map[string]ConfigT, 
 		if workspace == nil { // this workspace was not updated, populate it with the previous config
 			previousConfig, ok := nc.workspacesConfig[workspaceID]
 			if !ok {
-				nc.logger.Errorw(
+				nc.logger.Errorn(
 					"workspace was not updated but was not present in previous config",
-					"workspaceID", workspaceID,
-					"req", req,
+					obskit.WorkspaceID(workspaceID),
+					logger.NewField("req", req),
 				)
 				return configOnError, ErrIncrementalUpdateFailed
 			}

--- a/backend-config/single_workspace.go
+++ b/backend-config/single_workspace.go
@@ -36,6 +36,12 @@ type singleWorkspaceConfig struct {
 }
 
 func (wc *singleWorkspaceConfig) SetUp() error {
+	wc.httpCallsStat = stats.Default.NewStat("backend_config_http_calls", stats.CountType)
+
+	if wc.logger == nil {
+		wc.logger = logger.NewLogger().Child("backend-config").Withn(obskit.WorkspaceID(wc.workspaceID))
+	}
+
 	if configFromFile {
 		if wc.configJSONPath == "" {
 			return fmt.Errorf("valid configJSONPath is required when configFromFile is set to true")
@@ -49,11 +55,6 @@ func (wc *singleWorkspaceConfig) SetUp() error {
 		return fmt.Errorf("single workspace: empty workspace config token")
 	}
 
-	wc.httpCallsStat = stats.Default.NewStat("backend_config_http_calls", stats.CountType)
-
-	if wc.logger == nil {
-		wc.logger = logger.NewLogger().Child("backend-config").Withn(obskit.WorkspaceID(wc.workspaceID))
-	}
 	wc.logger.Infon("Setup backend config complete")
 
 	return nil

--- a/backend-config/single_workspace_test.go
+++ b/backend-config/single_workspace_test.go
@@ -41,6 +41,7 @@ func TestSingleWorkspaceGetFromAPI(t *testing.T) {
 			token:            token,
 			configBackendURL: parsedSrvURL,
 		}
+		require.NoError(t, wc.SetUp())
 		conf, err := wc.getFromAPI(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, map[string]ConfigT{sampleWorkspaceID: sampleBackendConfig}, conf)
@@ -60,6 +61,7 @@ func TestSingleWorkspaceGetFromAPI(t *testing.T) {
 			token:            "testToken",
 			configBackendURL: configBackendURL,
 		}
+		require.NoError(t, wc.SetUp())
 		conf, err := wc.getFromAPI(context.Background())
 		require.ErrorContains(t, err, "unsupported protocol scheme")
 		require.Equal(t, map[string]ConfigT{}, conf)
@@ -70,6 +72,7 @@ func TestSingleWorkspaceGetFromAPI(t *testing.T) {
 			token:            "testToken",
 			configBackendURL: nil,
 		}
+		require.NoError(t, wc.SetUp())
 		conf, err := wc.getFromAPI(context.Background())
 		require.ErrorContains(t, err, "config backend url is nil")
 		require.Equal(t, map[string]ConfigT{}, conf)
@@ -84,6 +87,7 @@ func TestSingleWorkspaceGetFromFile(t *testing.T) {
 			token:          "testToken",
 			configJSONPath: "invalid-path",
 		}
+		require.NoError(t, wc.SetUp())
 		conf, err := wc.getFromFile()
 		require.Error(t, err)
 		require.Equal(t, map[string]ConfigT{}, conf)
@@ -99,6 +103,7 @@ func TestSingleWorkspaceGetFromFile(t *testing.T) {
 			token:          "testToken",
 			configJSONPath: tmpFile.Name(),
 		}
+		require.NoError(t, wc.SetUp())
 		conf, err := wc.getFromFile()
 		require.Error(t, err)
 		require.Equal(t, map[string]ConfigT{}, conf)
@@ -144,6 +149,7 @@ func TestSingleWorkspaceGetFromFile(t *testing.T) {
 			token:          "testToken",
 			configJSONPath: tmpFile.Name(),
 		}
+		require.NoError(t, wc.SetUp())
 		conf, err := wc.getFromFile()
 		require.NoError(t, err)
 		require.Equal(t, map[string]ConfigT{sampleWorkspaceID: sampleBackendConfig}, conf)

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/rudderlabs/compose-test v0.1.3
 	github.com/rudderlabs/rudder-go-kit v0.19.0
+	github.com/rudderlabs/rudder-observability-kit v0.0.3
 	github.com/rudderlabs/sql-tunnels v0.1.6
 	github.com/samber/lo v1.38.1
 	github.com/segmentio/kafka-go v0.4.44

--- a/go.sum
+++ b/go.sum
@@ -962,6 +962,8 @@ github.com/rudderlabs/parquet-go v0.0.2 h1:ZXRdZdimB0PdJtmxeSSxfI0fDQ3kZjwzBxRi6
 github.com/rudderlabs/parquet-go v0.0.2/go.mod h1:g6guum7o8uhj/uNhunnt7bw5Vabu/goI5i21/3fnxWQ=
 github.com/rudderlabs/rudder-go-kit v0.19.0 h1:Q4LzoS/mGHjb4Q8Yws5UAvs92hBfPwgTLw8aVOEsrLY=
 github.com/rudderlabs/rudder-go-kit v0.19.0/go.mod h1:UawoeYHo1KnKan4hmSbj/HW3w/U51mXSyknuTaDrhmE=
+github.com/rudderlabs/rudder-observability-kit v0.0.3 h1:vZtuZRkGX+6rjaeKtxxFE2YYP6QlmAcVcgecTOjvz+Q=
+github.com/rudderlabs/rudder-observability-kit v0.0.3/go.mod h1:6UjAh3H6rkE0fFLh7z8ZGQEQbKtUkRfhWOf/OUhfqW8=
 github.com/rudderlabs/sql-tunnels v0.1.6 h1:v2KA2cq8ZV5LXRJQpqigq1Q4V64oDL+XlfckW/0K2/4=
 github.com/rudderlabs/sql-tunnels v0.1.6/go.mod h1:Jew/XwojzFTK4KTDj/wvChI7iZCgAKYyKjFK1nnHlNM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=


### PR DESCRIPTION
# Description

Adding metric to record the number of calls to the BackendConfig HTTP API.

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-695/backend-config-calls-metric) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
