### PR TITLE
chore: fix flaky test for tables for connections from wh schemas as ordering for tables can be different

### DIFF
--- a/warehouse/internal/repo/schema_test.go
+++ b/warehouse/internal/repo/schema_test.go
@@ -121,14 +121,11 @@ func TestWHSchemasRepo(t *testing.T) {
 		connection := warehouseutils.SourceIDDestinationID{SourceID: sourceID, DestinationID: destinationID}
 		expectedTableNames, err := r.GetTablesForConnection(ctx, []warehouseutils.SourceIDDestinationID{connection})
 		require.NoError(t, err)
-		require.ElementsMatch(t, expectedTableNames, []warehouseutils.FetchTableInfo{
-			{
-				SourceID:      sourceID,
-				DestinationID: destinationID,
-				Namespace:     namespace,
-				Tables:        []string{"table_name_1", "table_name_2"},
-			},
-		})
+		require.Len(t, expectedTableNames, 1)
+		require.Equal(t, sourceID, expectedTableNames[0].SourceID)
+		require.Equal(t, destinationID, expectedTableNames[0].DestinationID)
+		require.Equal(t, namespace, expectedTableNames[0].Namespace)
+		require.ElementsMatch(t, []string{"table_name_1", "table_name_2"}, expectedTableNames[0].Tables)
 
 		t.Log("cancelled context")
 		_, err = r.GetTablesForConnection(cancelledCtx, []warehouseutils.SourceIDDestinationID{connection})
@@ -160,11 +157,10 @@ func TestWHSchemasRepo(t *testing.T) {
 		require.NoError(t, err)
 		expectedTableNames, err = r.GetTablesForConnection(ctx, []warehouseutils.SourceIDDestinationID{connection})
 		require.NoError(t, err)
-		require.ElementsMatch(t, expectedTableNames, []warehouseutils.FetchTableInfo{{
-			SourceID:      sourceID,
-			DestinationID: destinationID,
-			Namespace:     latestNamespace,
-			Tables:        []string{"table_name_1", "table_name_2"},
-		}}, "the new schema should not have changed the returned tables since we already had a schema for the same source id and destination id pair")
+		require.Len(t, expectedTableNames, 1)
+		require.Equal(t, sourceID, expectedTableNames[0].SourceID)
+		require.Equal(t, destinationID, expectedTableNames[0].DestinationID)
+		require.Equal(t, latestNamespace, expectedTableNames[0].Namespace)
+		require.ElementsMatch(t, []string{"table_name_1", "table_name_2"}, expectedTableNames[0].Tables)
 	})
 }


### PR DESCRIPTION
# Description

- Recognized potential variations in the ordering of the tables field in GetTablesForConnection.
- Comparing individual fields now.
- Refer to the [GitHub Actions run](https://github.com/rudderlabs/rudder-server/actions/runs/7498425504/job/20413517963) for details on the unsuccessful validation.
  ```
  === Failed
  === FAIL: warehouse/internal/repo TestWHSchemasRepo/GetTablesForConnection (0.00s)
      schema_test.go:120: existing
      schema_test.go:124: 
        	  Error Trace:	/home/runner/work/rudder-server/rudder-server/warehouse/internal/repo/schema_test.go:124
        	  Error:      	elements differ
        	            	  
        	            	  extra elements in list A:
        	            	  ([]interface {}) (len=1) {
        	            	   (warehouseutils.FetchTableInfo) {
        	            	    SourceID: (string) (len=9) "source_id",
        	            	    DestinationID: (string) (len=14) "destination_id",
        	            	    Namespace: (string) (len=9) "namespace",
        	            	    Tables: ([]string) (len=2) {
        	            	     (string) (len=12) "table_name_2",
        	            	     (string) (len=12) "table_name_1"
        	            	    }
        	            	   }
        	            	  }
        	            	  
        	            	  
        	            	  extra elements in list B:
        	            	  ([]interface {}) (len=1) {
        	            	   (warehouseutils.FetchTableInfo) {
        	            	    SourceID: (string) (len=9) "source_id",
        	            	    DestinationID: (string) (len=14) "destination_id",
        	            	    Namespace: (string) (len=9) "namespace",
        	            	    Tables: ([]string) (len=2) {
        	            	     (string) (len=12) "table_name_1",
        	            	     (string) (len=12) "table_name_2"
        	            	    }
        	            	   }
        	            	  }
        	            	  
        	            	  
        	            	  listA:
        	            	  ([]warehouseutils.FetchTableInfo) (len=1) {
        	            	   (warehouseutils.FetchTableInfo) {
        	            	    SourceID: (string) (len=9) "source_id",
        	            	    DestinationID: (string) (len=14) "destination_id",
        	            	    Namespace: (string) (len=9) "namespace",
        	            	    Tables: ([]string) (len=2) {
        	            	     (string) (len=12) "table_name_2",
        	            	     (string) (len=12) "table_name_1"
        	            	    }
        	            	   }
        	            	  }
        	            	  
        	            	  
        	            	  listB:
        	            	  ([]warehouseutils.FetchTableInfo) (len=1) {
        	            	   (warehouseutils.FetchTableInfo) {
        	            	    SourceID: (string) (len=9) "source_id",
        	            	    DestinationID: (string) (len=14) "destination_id",
        	            	    Namespace: (string) (len=9) "namespace",
        	            	    Tables: ([]string) (len=2) {
        	            	     (string) (len=12) "table_name_1",
        	            	     (string) (len=12) "table_name_2"
        	            	    }
        	            	   }
        	            	  }
        	  Test:       	TestWHSchemasRepo/GetTablesForConnection
      --- FAIL: TestWHSchemasRepo/GetTablesForConnection (0.00s)
  ```


## Linear Ticket

- Resolves PIPE-696

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
