### PR TITLE
chore: improve error logs during jobsdb backup table test

### DIFF
--- a/jobsdb/jobsdb_backup_test.go
+++ b/jobsdb/jobsdb_backup_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/lo"
+
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 	"github.com/ory/dockertest/v3"
@@ -121,7 +123,9 @@ func TestBackupTable(t *testing.T) {
 		file, err = fm.ListFilesWithPrefix(context.Background(), "", prefix, 5).Next()
 
 		if len(file) != 3 {
-			t.Log("file list: ", file, " err: ", err)
+			t.Logf("file list: %+v err: %v", lo.Map(file, func(item *filemanager.FileInfo, _ int) string {
+				return item.Key
+			}), err)
 			fm, _ = filemanager.New(&filemanager.Settings{
 				Logger:   logger.NOP,
 				Provider: "MINIO",
@@ -317,14 +321,18 @@ func TestMultipleWorkspacesBackupTable(t *testing.T) {
 			file, err = fm.ListFilesWithPrefix(context.Background(), "", prefix, 10).Next()
 
 			if len(file) != 3 {
-				t.Log("file list: ", file, " err: ", err, "len: ", len(file))
+				t.Logf("file list: %+v err: %v", lo.Map(file, func(item *filemanager.FileInfo, _ int) string {
+					return item.Key
+				}), err)
 				fm, err = fileuploaderProvider.GetFileManager(workspace)
 				require.NoError(t, err)
 				return false
 			}
 			return true
 		}, 30*time.Second, 1*time.Second, fmt.Errorf("less than 3 backup files found in backup store for workspace:%s. Error: %w ", workspace, err))
-		t.Log("file list: ", file, " err: ", err)
+		t.Logf("file list: %+v err: %v", lo.Map(file, func(item *filemanager.FileInfo, _ int) string {
+			return item.Key
+		}), err)
 
 		var jobStatusBackupFilename, jobsBackupFilename, abortedJobsBackupFilename string
 		for j := 0; j < len(file); j++ {


### PR DESCRIPTION
# Description

- Log files instead of a pointer which will help debug the failed test.
  ```
      jobsdb_backup_test.go:320: file list:  [0xc0008caea0 0xc0008caed0 0xc0008caf00 0xc0008caf30 0xc0008caf60 0xc0008caf90]  err:  <nil> len:  6
      jobsdb_backup_test.go:320: file list:  [0xc0008cb1a0 0xc0008cb1d0 0xc0008cb230 0xc0008cb260 0xc0008cb290 0xc0008cb2c0]  err:  <nil> len:  6
  ```
- Refer to the [GitHub Actions run](https://github.com/rudderlabs/rudder-server/actions/runs/7490156481/job/20388357432) for details on the unsuccessful validation.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
