### PR TITLE
fix: nil load statistics for bigquery

### DIFF
--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -439,8 +439,9 @@ func (bq *BigQuery) loadTableByAppend(
 
 	log.Infow("completed loading")
 
-	tableStats := &types.LoadTableStats{
-		RowsInserted: statistics.Load.OutputRows,
+	tableStats := &types.LoadTableStats{}
+	if statistics.Load != nil {
+		tableStats.RowsInserted = statistics.Load.OutputRows
 	}
 	response := &loadTableResponse{
 		partitionDate: partitionDate,
@@ -448,6 +449,8 @@ func (bq *BigQuery) loadTableByAppend(
 	return tableStats, response, nil
 }
 
+// jobStatistics returns statistics for a job
+// In case of rate limit error, it returns empty statistics
 func (bq *BigQuery) jobStatistics(
 	ctx context.Context,
 	job *bigquery.Job,


### PR DESCRIPTION
# Description

- In case of rate limit errors, we are sending empty statistics and then trying to access a Load field which will be nil.

## Linear Ticket

- Resolves PIPE-704

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
