### PR TITLE
exp: use a job pool in gateway

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -395,6 +395,21 @@ type JobT struct {
 	WorkspaceId   string          `json:"WorkspaceId"`
 }
 
+func (job *JobT) Reset() {
+	job.UUID = uuid.UUID{}
+	job.JobID = 0
+	job.UserID = ""
+	job.CreatedAt = time.Time{}
+	job.ExpireAt = time.Time{}
+	job.CustomVal = ""
+	job.EventCount = 0
+	job.EventPayload = nil
+	job.PayloadSize = 0
+	job.LastJobStatus = JobStatusT{}
+	job.Parameters = nil
+	job.WorkspaceId = ""
+}
+
 func (job *JobT) String() string {
 	return fmt.Sprintf("JobID=%v, UserID=%v, CreatedAt=%v, ExpireAt=%v, CustomVal=%v, Parameters=%v, EventPayload=%v EventCount=%d", job.JobID, job.UserID, job.CreatedAt, job.ExpireAt, job.CustomVal, string(job.Parameters), string(job.EventPayload), job.EventCount)
 }


### PR DESCRIPTION
# Description

exp: using a `jobsb.JobT` `sync.Pool` in gateway.

## Linear Ticket

< Replace with Linear Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced job pooling and counting for improved handling of user web requests.
	- Added a new method to reset job data to initial state for better resource management.

- **Refactor**
	- Enhanced synchronization within the gateway handling process to ensure thread safety and data integrity.

- **Chores**
	- Updated logging to include job object statistics for better monitoring and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->