### PR TITLE
feat: internal batch endpoint

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -34,6 +34,7 @@ var (
 var (
 	errRequestDropped    = errors.New("request dropped")
 	errRequestSuppressed = errors.New("request suppressed")
+	errEventSuppressed   = errors.New("event suppressed")
 )
 
 //go:embed openapi/index.html

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -477,9 +477,10 @@ var _ = Describe("Gateway", func() {
 				}
 				Expect(err).To(BeNil())
 				req.Header.Set("Content-Type", "application/json")
-				if ep == "/internal/v1/replay" || ep == "/internal/v1/retl" || ep == "/internal/v1/batch" {
+				switch ep {
+				case "/internal/v1/replay", "/internal/v1/retl", "/internal/v1/batch":
 					req.Header.Set("X-Rudder-Source-Id", ReplaySourceID)
-				} else {
+				default:
 					req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(WriteKeyEnabled+":")))
 				}
 				resp, err := client.Do(req)

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -477,7 +477,7 @@ var _ = Describe("Gateway", func() {
 				}
 				Expect(err).To(BeNil())
 				req.Header.Set("Content-Type", "application/json")
-				if ep == "/internal/v1/replay" || ep == "/internal/v1/retl" {
+				if ep == "/internal/v1/replay" || ep == "/internal/v1/retl" || ep == "/internal/v1/batch" {
 					req.Header.Set("X-Rudder-Source-Id", ReplaySourceID)
 				} else {
 					req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(WriteKeyEnabled+":")))
@@ -1708,6 +1708,7 @@ func endpointsToVerify() ([]string, []string, []string) {
 		"/v1/warehouse/pending-events",
 		"/v1/warehouse/trigger-upload",
 		"/v1/warehouse/jobs",
+		"/internal/v1/batch",
 	}
 
 	deleteEndpoints := []string{

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -630,14 +630,6 @@ func (gw *Handle) internalBatchHandlerFunc() http.HandlerFunc {
 
 		// TODO: add tracing
 		gw.logger.LogRequest(r)
-		defer func() {
-			defer gw.logger.Infon("response",
-				logger.NewStringField("ip", misc.GetIPFromReq(r)),
-				logger.NewStringField("path", r.URL.Path),
-				logger.NewIntField("status", int64(status)),
-				logger.NewStringField("body", responseBody),
-			)
-		}()
 		body, err = gw.getPayload(arctx, r, reqType)
 		if err != nil {
 			goto requestError
@@ -670,6 +662,12 @@ func (gw *Handle) internalBatchHandlerFunc() http.HandlerFunc {
 			stats.CountType,
 			gw.newSourceStatTagsWithReason(arctx, reqType, ""),
 		).Increment()
+		gw.logger.Debugn("response",
+			logger.NewStringField("ip", misc.GetIPFromReq(r)),
+			logger.NewStringField("path", r.URL.Path),
+			logger.NewIntField("status", int64(status)),
+			logger.NewStringField("body", responseBody),
+		)
 		_, _ = w.Write([]byte(responseBody))
 		return
 
@@ -682,6 +680,12 @@ func (gw *Handle) internalBatchHandlerFunc() http.HandlerFunc {
 			stats.CountType,
 			gw.newSourceStatTagsWithReason(arctx, reqType, errorMessage),
 		).Increment()
+		gw.logger.Infon("response",
+			logger.NewStringField("ip", misc.GetIPFromReq(r)),
+			logger.NewStringField("path", r.URL.Path),
+			logger.NewIntField("status", int64(status)),
+			logger.NewStringField("body", responseBody),
+		)
 		http.Error(w, responseBody, status)
 	}
 }

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -779,7 +779,7 @@ func (gw *Handle) writeToJobsDB() http.HandlerFunc {
 				}
 				singularEventBatch := SingularEventBatch{
 					Batch:      userEvent.events,
-					RequestIP:  ipAddr,
+					RequestIP:  ipAddr, // TODO: processor gets IPAddr from inside each event
 					WriteKey:   arctx.WriteKey,
 					ReceivedAt: receivedAt,
 				}
@@ -801,7 +801,7 @@ func (gw *Handle) writeToJobsDB() http.HandlerFunc {
 			})
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), gw.conf.WriteTimeout)
+		ctx, cancel := context.WithTimeout(ctx, gw.conf.WriteTimeout)
 		err = gw.jobsDB.WithStoreSafeTx(ctx, func(tx jobsdb.StoreSafeTx) error {
 			err := gw.jobsDB.StoreInTx(ctx, tx, jobs)
 			if err != nil {

--- a/gateway/handle_http.go
+++ b/gateway/handle_http.go
@@ -27,7 +27,7 @@ func (gw *Handle) webBatchHandler() http.HandlerFunc {
 }
 
 func (gw *Handle) internalBatchHandler() http.HandlerFunc {
-	return gw.callType("internalBatch", gw.sourceIDAuth(gw.writeToJobsDB()))
+	return gw.callType("internalBatch", gw.sourceIDAuth(gw.internalBatchHandlerFunc()))
 }
 
 // webIdentifyHandler - handler for identify requests

--- a/gateway/handle_http.go
+++ b/gateway/handle_http.go
@@ -26,6 +26,10 @@ func (gw *Handle) webBatchHandler() http.HandlerFunc {
 	return gw.callType("batch", gw.writeKeyAuth(gw.webHandler()))
 }
 
+func (gw *Handle) internalBatchHandler() http.HandlerFunc {
+	return gw.callType("internalBatch", gw.sourceIDAuth(gw.writeToJobsDB()))
+}
+
 // webIdentifyHandler - handler for identify requests
 func (gw *Handle) webIdentifyHandler() http.HandlerFunc {
 	return gw.callType("identify", gw.writeKeyAuth(gw.webHandler()))

--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -385,6 +385,7 @@ func (gw *Handle) StartWebHandler(ctx context.Context) error {
 		r.Get("/v1/warehouse/fetch-tables", gw.whProxy.ServeHTTP)
 		r.Post("/v1/audiencelist", gw.webAudienceListHandler())
 		r.Post("/v1/replay", gw.webReplayHandler())
+		r.Post("/v1/batch", gw.internalBatchHandler())
 
 		// TODO: delete this handler once we are ready to remove support for the v1 api
 		r.Mount("/v1/job-status", withContentType("application/json; charset=utf-8", rsourcesHandlerV1.ServeHTTP))

--- a/gateway/handle_observability.go
+++ b/gateway/handle_observability.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	gwstats "github.com/rudderlabs/rudder-server/gateway/internal/stats"
 	gwtypes "github.com/rudderlabs/rudder-server/gateway/internal/types"
 )
@@ -15,4 +16,19 @@ func (gw *Handle) NewSourceStat(arctx *gwtypes.AuthRequestContext, reqType strin
 		WorkspaceID: arctx.WorkspaceID,
 		SourceType:  arctx.SourceCategory,
 	}
+}
+
+func (gw *Handle) newSourceStatTagsWithReason(arctx *gwtypes.AuthRequestContext, reqType, reason string) stats.Tags {
+	tags := stats.Tags{
+		"source":       arctx.SourceTag(),
+		"source_id":    arctx.SourceID,
+		"write_key":    arctx.WriteKey,
+		"req_type":     reqType,
+		"workspace_id": arctx.WorkspaceID,
+		"source_type":  arctx.SourceCategory,
+	}
+	if reason != "" {
+		tags["reason"] = reason
+	}
+	return tags
 }

--- a/gateway/integration_test.go
+++ b/gateway/integration_test.go
@@ -41,7 +41,6 @@ func TestGatewayIntegration(t *testing.T) {
 }
 
 func testGatewayByAppType(t *testing.T, appType string) {
-	// t.SkipNow()
 	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
 	defer cancel()
@@ -252,8 +251,8 @@ func testGatewayByAppType(t *testing.T, appType string) {
 			t.Cleanup(cleanupGwJobs)
 
 			require.Eventuallyf(t, func() bool {
-				return len(webhook.Requests()) == 2
-			}, 60*time.Second, 100*time.Millisecond, "Webhook should have received a request on %d", httpPort)
+				return webhook.RequestsCount() == 2
+			}, 60*time.Second, 100*time.Millisecond, "Webhook should have received %d requests on %d", webhook.RequestsCount(), httpPort)
 		})
 
 		// Trigger degraded mode, the Gateway should still work

--- a/gateway/integration_test.go
+++ b/gateway/integration_test.go
@@ -83,7 +83,7 @@ func testGatewayByAppType(t *testing.T, appType string) {
 		"webhookUrl":  webhook.Server.URL,
 	})
 	require.NoError(t, err)
-	var sourceID = "xxxyyyzzEaEurW247ad9WYZLUyk" // sourceID from the workspace config template
+	sourceID := "xxxyyyzzEaEurW247ad9WYZLUyk" // sourceID from the workspace config template
 
 	beConfigRouter := chi.NewMux()
 	if testing.Verbose() {

--- a/gateway/openapi.yaml
+++ b/gateway/openapi.yaml
@@ -641,6 +641,37 @@ paths:
               example: "Too many requests"
       security:
         - sourceIDAuth: []
+  /internal/v1/batch:
+    post:
+      tags:
+        - Internal API
+      summary: Batch
+      description: Handles internal batch requests.
+      operationId: InternalBatch
+      responses:
+        '200':
+          description: StatusOK
+          content:
+            text/plain; charset=utf-8:
+              schema:
+                type: string
+              example: "OK"
+        '400':
+          description: StatusBadRequest
+          content:
+            text/plain; charset=utf-8:
+              schema:
+                type: string
+              example: "Invalid request"
+        '401':
+          description: StatusUnauthorized
+          content:
+            text/plain; charset=utf-8:
+              schema:
+                type: string
+              example: "Invalid Authorization Header"
+      security:
+        - sourceIDAuth: []
 servers:
   - url: /v1
 components:

--- a/gateway/openapi/index.html
+++ b/gateway/openapi/index.html
@@ -1173,6 +1173,9 @@ ul.nav-tabs {
                     <li data-group="InternalAPI" data-name="extract" class="">
                       <a href="#api-InternalAPI-extract">extract</a>
                     </li>
+                    <li data-group="InternalAPI" data-name="internalBatch" class="">
+                      <a href="#api-InternalAPI-internalBatch">internalBatch</a>
+                    </li>
                     <li data-group="InternalAPI" data-name="replay" class="">
                       <a href="#api-InternalAPI-replay">replay</a>
                     </li>
@@ -7579,6 +7582,471 @@ pub fn main() {
                                     </script>
                                   </div>
                                   <input id='responses-InternalAPI-extract-429-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-InternalAPI-internalBatch">
+                      <article id="api-InternalAPI-internalBatch-0" data-group="User" data-name="internalBatch" data-version="0">
+                        <div class="pull-left">
+                          <h1>internalBatch</h1>
+                          <p>Batch</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Handles internal batch requests.</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/internal/v1/batch</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-InternalAPI-internalBatch-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-InternalAPI-internalBatch-0-java">Java</a></li>
+                          <li class=""><a href="#examples-InternalAPI-internalBatch-0-dart">Dart</a></li>
+                          <li class=""><a href="#examples-InternalAPI-internalBatch-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-InternalAPI-internalBatch-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-InternalAPI-internalBatch-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-InternalAPI-internalBatch-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-InternalAPI-internalBatch-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-InternalAPI-internalBatch-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-InternalAPI-internalBatch-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-InternalAPI-internalBatch-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-InternalAPI-internalBatch-0-python">Python</a></li>
+                          <li class=""><a href="#examples-InternalAPI-internalBatch-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-InternalAPI-internalBatch-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X POST \
+ -H "Authorization: Basic [[basicHash]]" \
+ -H "Accept: text/plain; charset=utf-8" \
+ "/v1/internal/v1/batch"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-InternalAPI-internalBatch-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.InternalAPIApi;
+
+import java.io.File;
+import java.util.*;
+
+public class InternalAPIApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        // Configure HTTP basic authorization: sourceIDAuth
+        HttpBasicAuth sourceIDAuth = (HttpBasicAuth) defaultClient.getAuthentication("sourceIDAuth");
+        sourceIDAuth.setUsername("YOUR USERNAME");
+        sourceIDAuth.setPassword("YOUR PASSWORD");
+
+        // Create an instance of the API class
+        InternalAPIApi apiInstance = new InternalAPIApi();
+
+        try {
+            'String' result = apiInstance.internalBatch();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling InternalAPIApi#internalBatch");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-InternalAPI-internalBatch-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+
+try {
+    final result = await api_instance.internalBatch();
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->internalBatch: $e\n');
+}
+
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-InternalAPI-internalBatch-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.InternalAPIApi;
+
+public class InternalAPIApiExample {
+    public static void main(String[] args) {
+        InternalAPIApi apiInstance = new InternalAPIApi();
+
+        try {
+            'String' result = apiInstance.internalBatch();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling InternalAPIApi#internalBatch");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-InternalAPI-internalBatch-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-InternalAPI-internalBatch-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+// Configure HTTP basic authorization (authentication scheme: sourceIDAuth)
+[apiConfig setUsername:@"YOUR_USERNAME"];
+[apiConfig setPassword:@"YOUR_PASSWORD"];
+
+// Create an instance of the API class
+InternalAPIApi *apiInstance = [[InternalAPIApi alloc] init];
+
+// Batch
+[apiInstance internalBatchWithCompletionHandler: 
+              ^('String' output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-InternalAPI-internalBatch-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var RudderStackHttpApi = require('rudder_stack_http_api');
+var defaultClient = RudderStackHttpApi.ApiClient.instance;
+
+// Configure HTTP basic authorization: sourceIDAuth
+var sourceIDAuth = defaultClient.authentications['sourceIDAuth'];
+sourceIDAuth.username = 'YOUR USERNAME';
+sourceIDAuth.password = 'YOUR PASSWORD';
+
+// Create an instance of the API class
+var api = new RudderStackHttpApi.InternalAPIApi()
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.internalBatch(callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-InternalAPI-internalBatch-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-InternalAPI-internalBatch-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class internalBatchExample
+    {
+        public void main()
+        {
+            // Configure HTTP basic authorization: sourceIDAuth
+            Configuration.Default.Username = "YOUR_USERNAME";
+            Configuration.Default.Password = "YOUR_PASSWORD";
+
+            // Create an instance of the API class
+            var apiInstance = new InternalAPIApi();
+
+            try {
+                // Batch
+                'String' result = apiInstance.internalBatch();
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling InternalAPIApi.internalBatch: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-InternalAPI-internalBatch-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+// Configure HTTP basic authorization: sourceIDAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setUsername('YOUR_USERNAME');
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setPassword('YOUR_PASSWORD');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\InternalAPIApi();
+
+try {
+    $result = $api_instance->internalBatch();
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling InternalAPIApi->internalBatch: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-InternalAPI-internalBatch-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::InternalAPIApi;
+# Configure HTTP basic authorization: sourceIDAuth
+$WWW::OPenAPIClient::Configuration::username = 'YOUR_USERNAME';
+$WWW::OPenAPIClient::Configuration::password = 'YOUR_PASSWORD';
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::InternalAPIApi->new();
+
+eval {
+    my $result = $api_instance->internalBatch();
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling InternalAPIApi->internalBatch: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-InternalAPI-internalBatch-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+# Configure HTTP basic authorization: sourceIDAuth
+openapi_client.configuration.username = 'YOUR_USERNAME'
+openapi_client.configuration.password = 'YOUR_PASSWORD'
+
+# Create an instance of the API class
+api_instance = openapi_client.InternalAPIApi()
+
+try:
+    # Batch
+    api_response = api_instance.internal_batch()
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling InternalAPIApi->internalBatch: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-InternalAPI-internalBatch-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate InternalAPIApi;
+
+pub fn main() {
+
+    let mut context = InternalAPIApi::Context::default();
+    let result = client.internalBatch(&context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-InternalAPI-internalBatch-title-200"></h3>
+                            <p id="examples-InternalAPI-internalBatch-description-200" class="marked"></p>
+                            <script>
+                              var responseInternalAPI200_description = `StatusOK`;
+                              var responseInternalAPI200_description_break = responseInternalAPI200_description.indexOf('\n');
+                              if (responseInternalAPI200_description_break == -1) {
+                                $("#examples-InternalAPI-internalBatch-title-200").text("Status: 200 - " + responseInternalAPI200_description);
+                              } else {
+                                $("#examples-InternalAPI-internalBatch-title-200").text("Status: 200 - " + responseInternalAPI200_description.substring(0, responseInternalAPI200_description_break));
+                                $("#examples-InternalAPI-internalBatch-description-200").html(responseInternalAPI200_description.substring(responseInternalAPI200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-InternalAPI-internalBatch-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-InternalAPI-internalBatch-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-InternalAPI-internalBatch-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-InternalAPI-internalBatch-200-schema">
+                                  <div id="responses-InternalAPI-internalBatch-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = ;
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                          Object.keys(schema.properties).forEach( (item) => {
+                                            if (schema.properties[item].$ref != null) {
+                                              schema.properties[item] = defsParser.$refs.get(schema.properties[item].$ref);
+                                            }
+                                          });
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-InternalAPI-internalBatch-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-InternalAPI-internalBatch-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-InternalAPI-internalBatch-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-InternalAPI-internalBatch-title-400"></h3>
+                            <p id="examples-InternalAPI-internalBatch-description-400" class="marked"></p>
+                            <script>
+                              var responseInternalAPI400_description = `StatusBadRequest`;
+                              var responseInternalAPI400_description_break = responseInternalAPI400_description.indexOf('\n');
+                              if (responseInternalAPI400_description_break == -1) {
+                                $("#examples-InternalAPI-internalBatch-title-400").text("Status: 400 - " + responseInternalAPI400_description);
+                              } else {
+                                $("#examples-InternalAPI-internalBatch-title-400").text("Status: 400 - " + responseInternalAPI400_description.substring(0, responseInternalAPI400_description_break));
+                                $("#examples-InternalAPI-internalBatch-description-400").html(responseInternalAPI400_description.substring(responseInternalAPI400_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-InternalAPI-internalBatch-400" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-InternalAPI-internalBatch-400-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-InternalAPI-internalBatch-400-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-InternalAPI-internalBatch-400-schema">
+                                  <div id="responses-InternalAPI-internalBatch-schema-400" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = ;
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                          Object.keys(schema.properties).forEach( (item) => {
+                                            if (schema.properties[item].$ref != null) {
+                                              schema.properties[item] = defsParser.$refs.get(schema.properties[item].$ref);
+                                            }
+                                          });
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-InternalAPI-internalBatch-400-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-InternalAPI-internalBatch-schema-400');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-InternalAPI-internalBatch-400-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-InternalAPI-internalBatch-title-401"></h3>
+                            <p id="examples-InternalAPI-internalBatch-description-401" class="marked"></p>
+                            <script>
+                              var responseInternalAPI401_description = `StatusUnauthorized`;
+                              var responseInternalAPI401_description_break = responseInternalAPI401_description.indexOf('\n');
+                              if (responseInternalAPI401_description_break == -1) {
+                                $("#examples-InternalAPI-internalBatch-title-401").text("Status: 401 - " + responseInternalAPI401_description);
+                              } else {
+                                $("#examples-InternalAPI-internalBatch-title-401").text("Status: 401 - " + responseInternalAPI401_description.substring(0, responseInternalAPI401_description_break));
+                                $("#examples-InternalAPI-internalBatch-description-401").html(responseInternalAPI401_description.substring(responseInternalAPI401_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-InternalAPI-internalBatch-401" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-InternalAPI-internalBatch-401-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-InternalAPI-internalBatch-401-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-InternalAPI-internalBatch-401-schema">
+                                  <div id="responses-InternalAPI-internalBatch-schema-401" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = ;
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                          Object.keys(schema.properties).forEach( (item) => {
+                                            if (schema.properties[item].$ref != null) {
+                                              schema.properties[item] = defsParser.$refs.get(schema.properties[item].$ref);
+                                            }
+                                          });
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-InternalAPI-internalBatch-401-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-InternalAPI-internalBatch-schema-401');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-InternalAPI-internalBatch-401-schema-data' type='hidden' value=''></input>
                                 </div>
                             </div>
                         </article>


### PR DESCRIPTION
# Description

internal batch endpoint: no buffering, not a lot of validations -> just write to jobsdb.

## Linear Ticket

[resolves PIPE-765](https://linear.app/rudderstack/issue/PIPE-765/[rudder-server]-create-a-gw-internal-endpoint-to-bypass-validations)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
