### PR TITLE
exp: readonly backendconfig cache in gateway

### DIFF
--- a/backend-config/configUnmarshalBenchmark_test.go
+++ b/backend-config/configUnmarshalBenchmark_test.go
@@ -1,0 +1,74 @@
+package backendconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func BenchmarkConfigMapUnmarshal(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var requestData map[string]*ConfigT
+		_ = jsonfast.Unmarshal(dummyConfig, &requestData)
+	}
+}
+
+var dummyConfig []byte = []byte(`{"2P5AYZF3ZRFPohzQP0pjQqUew7j": null,"2P5q8KF55r50AIDWlqzLZPJ8PZ8": null,"2P5xquzeyzbpVhjwDP7yyJen0cp": null,"2P68utZBYWwXM6AKfiBGhf5Ahrp": null,"2c2stEGnBd4TBy3DVB0UBzo4Ir6": {
+	"sources": [],
+	"libraries": [],
+	"settings": {
+		"dataRetention": {
+			"disableReportingPii": false,
+			"useSelfStorage": false,
+			"retentionPeriod": "default",
+			"storagePreferences": {
+				"procErrors": false,
+				"gatewayDumps": false
+			}
+		},
+		"eventAuditEnabled": false
+	},
+	"whtProjects": [],
+	"updatedAt": "2024-02-07T15:53:41.076Z",
+	"destinationTransformations": [],
+	"eventReplays": {},
+	"connections": {}
+}}`)
+
+var nullBytes = []byte("null")
+
+type NullConfigT struct {
+	Config ConfigT
+	Valid  bool
+}
+
+func (s *NullConfigT) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, nullBytes) {
+		s.Valid = false
+		return nil
+	}
+
+	if err := json.Unmarshal(data, &s.Config); err != nil {
+		return fmt.Errorf("null: couldn't unmarshal JSON: %w", err)
+	}
+
+	s.Valid = true
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler.
+// It will encode null if this String is null.
+func (s NullConfigT) MarshalJSON() ([]byte, error) {
+	if !s.Valid {
+		return []byte("null"), nil
+	}
+	return json.Marshal(s.Config)
+}
+
+func BenchmarkNullConfigMapUnmarshal(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var requestData map[string]NullConfigT
+		_ = jsonfast.Unmarshal(dummyConfig, &requestData)
+	}
+}

--- a/backend-config/noop.go
+++ b/backend-config/noop.go
@@ -39,7 +39,7 @@ func (*NOOP) Subscribe(ctx context.Context, _ Topic) pubsub.DataChannel {
 	return ch
 }
 
-func (*NOOP) StartWithIDs(_ context.Context, _ string) {}
+func (*NOOP) StartWithIDs(_ context.Context, _ string, _ ...OptFunc) {}
 
 func (*NOOP) Stop() {
 }

--- a/mocks/backend-config/mock_backendconfig.go
+++ b/mocks/backend-config/mock_backendconfig.go
@@ -95,15 +95,20 @@ func (mr *MockBackendConfigMockRecorder) SetUp() *gomock.Call {
 }
 
 // StartWithIDs mocks base method.
-func (m *MockBackendConfig) StartWithIDs(arg0 context.Context, arg1 string) {
+func (m *MockBackendConfig) StartWithIDs(arg0 context.Context, arg1 string, arg2 ...backendconfig.OptFunc) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartWithIDs", arg0, arg1)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "StartWithIDs", varargs...)
 }
 
 // StartWithIDs indicates an expected call of StartWithIDs.
-func (mr *MockBackendConfigMockRecorder) StartWithIDs(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBackendConfigMockRecorder) StartWithIDs(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithIDs", reflect.TypeOf((*MockBackendConfig)(nil).StartWithIDs), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithIDs", reflect.TypeOf((*MockBackendConfig)(nil).StartWithIDs), varargs...)
 }
 
 // Stop mocks base method.

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -181,7 +181,11 @@ func (r *Runner) Run(ctx context.Context, args []string) int {
 		r.logger.Errorf("Unable to setup backend config: %s", err)
 		return 1
 	}
-	backendconfig.DefaultBackendConfig.StartWithIDs(ctx, "")
+	backendconfig.DefaultBackendConfig.StartWithIDs(
+		ctx,
+		"",
+		backendconfig.WithReadOnlyCache(r.appType == app.GATEWAY),
+	)
 
 	// Prepare databases in sequential order, so that failure in one doesn't affect others (leaving dirty schema migration state)
 	if r.canStartServer() {

--- a/warehouse/multitenant/manager_test.go
+++ b/warehouse/multitenant/manager_test.go
@@ -21,12 +21,12 @@ type mockBackendConfig struct {
 	config map[string]backendconfig.ConfigT
 }
 
-func (*mockBackendConfig) WaitForConfig(_ context.Context)          {}
-func (*mockBackendConfig) Stop()                                    {}
-func (*mockBackendConfig) StartWithIDs(_ context.Context, _ string) {}
-func (*mockBackendConfig) SetUp() error                             { return nil }
-func (*mockBackendConfig) AccessToken() string                      { return "" }
-func (*mockBackendConfig) Identity() identity.Identifier            { return nil }
+func (*mockBackendConfig) WaitForConfig(_ context.Context)                                      {}
+func (*mockBackendConfig) Stop()                                                                {}
+func (*mockBackendConfig) StartWithIDs(_ context.Context, _ string, _ ...backendconfig.OptFunc) {}
+func (*mockBackendConfig) SetUp() error                                                         { return nil }
+func (*mockBackendConfig) AccessToken() string                                                  { return "" }
+func (*mockBackendConfig) Identity() identity.Identifier                                        { return nil }
 
 func (m *mockBackendConfig) Get(context.Context) (map[string]backendconfig.ConfigT, error) {
 	return m.config, nil


### PR DESCRIPTION
# Description

`gateway` only reads from `backendConfigCache`. `processor` can set the it.

## Linear Ticket

< Replace with Linear Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
