### PR TITLE
fix: handling invalid client id error for bingads audience

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/bing-ads/util.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/util.go
@@ -111,6 +111,7 @@ func (b *BingAdsBulkUploader) populateZipFile(actionFile *ActionFileInfo, audien
 		actionFile.EventCount += 1
 		for _, uploadData := range data.Message.List {
 			clientIdI := newClientID(data.Metadata.JobID, uploadData.HashedEmail)
+			fmt.Println("######## clientIdI ###########", clientIdI)
 			clientIdStr := clientIdI.ToString()
 			err := actionFile.CSVWriter.Write([]string{"Customer List Item", "", "", audienceId, clientIdStr, "", "", "", "", "", "", "Email", uploadData.HashedEmail})
 			if err != nil {
@@ -312,14 +313,14 @@ func (b *BingAdsBulkUploader) readPollResults(filePath string) ([][]string, erro
 			}
 		}
 		// remove the file after the response has been written
-		removeErr := os.Remove(filePath)
-		if removeErr != nil {
-			b.logger.Errorf("Error removing the CSV file: %w", removeErr)
-			if err == nil {
-				err = removeErr
-			}
+		// removeErr := os.Remove(filePath)
+		// if removeErr != nil {
+		// 	b.logger.Errorf("Error removing the CSV file: %w", removeErr)
+		// 	if err == nil {
+		// 		err = removeErr
+		// 	}
 
-		}
+		// }
 	}()
 	// Create a new CSV reader
 	reader := csv.NewReader(file)
@@ -336,6 +337,7 @@ func (b *BingAdsBulkUploader) readPollResults(filePath string) ([][]string, erro
 // converting the string clientID to ClientID struct
 
 func newClientIDFromString(clientID string) (*ClientID, error) {
+	fmt.Println("######## clientID ###########", clientID)
 	clientIDParts := strings.Split(clientID, clientIDSeparator)
 	if len(clientIDParts) != 2 {
 		return nil, fmt.Errorf("invalid client id: %s", clientID)
@@ -401,6 +403,7 @@ func processPollStatusData(records [][]string) (map[int64]map[string]struct{}, e
 		rowname := record[typeIndex]
 		if typeIndex < len(record) && strings.Contains(rowname, "Error") {
 			if clientIDIndex >= 0 && clientIDIndex < len(record) {
+				fmt.Println("######## record[clientIDIndex] ###########", record[clientIDIndex])
 				// expecting the client ID is present as jobId<<>>clientId
 				clientId, err := newClientIDFromString(record[clientIDIndex])
 				if err != nil {

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/util.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/util.go
@@ -312,14 +312,14 @@ func (b *BingAdsBulkUploader) readPollResults(filePath string) ([][]string, erro
 			}
 		}
 		// remove the file after the response has been written
-		// removeErr := os.Remove(filePath)
-		// if removeErr != nil {
-		// 	b.logger.Errorf("Error removing the CSV file: %w", removeErr)
-		// 	if err == nil {
-		// 		err = removeErr
-		// 	}
+		removeErr := os.Remove(filePath)
+		if removeErr != nil {
+			b.logger.Errorf("Error removing the CSV file: %w", removeErr)
+			if err == nil {
+				err = removeErr
+			}
 
-		// }
+		}
 	}()
 	// Create a new CSV reader
 	reader := csv.NewReader(file)

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/util.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/util.go
@@ -111,7 +111,6 @@ func (b *BingAdsBulkUploader) populateZipFile(actionFile *ActionFileInfo, audien
 		actionFile.EventCount += 1
 		for _, uploadData := range data.Message.List {
 			clientIdI := newClientID(data.Metadata.JobID, uploadData.HashedEmail)
-			fmt.Println("######## clientIdI ###########", clientIdI)
 			clientIdStr := clientIdI.ToString()
 			err := actionFile.CSVWriter.Write([]string{"Customer List Item", "", "", audienceId, clientIdStr, "", "", "", "", "", "", "Email", uploadData.HashedEmail})
 			if err != nil {
@@ -343,7 +342,6 @@ func newClientIDFromString(clientID string, id string) (*ClientID, error) {
 			HashedEmail: "",
 		}, nil
 	}
-	fmt.Println("######## clientID ###########", clientID)
 	clientIDParts := strings.Split(clientID, clientIDSeparator)
 	if len(clientIDParts) != 2 {
 		return nil, fmt.Errorf("invalid client id: %s", clientID)


### PR DESCRIPTION
# Description

we are encountering issue with bingAds bulk API returning client ID as empty string. 
We are handling this by checking the status file row name and eventually aborting all the events in importing state


## Linear Ticket

Resolves INT-1682

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
