### PR TITLE
chore: processor transformer uses parent ctx to create new request

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -463,7 +463,7 @@ func (trans *handle) doPost(ctx context.Context, rawJSON []byte, url, stage stri
 
 			trace.WithRegion(ctx, "request/post", func() {
 				var req *http.Request
-				req, reqErr = http.NewRequest("POST", url, bytes.NewBuffer(rawJSON))
+				req, reqErr = http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(rawJSON))
 				if reqErr != nil {
 					return
 				}
@@ -492,7 +492,12 @@ func (trans *handle) doPost(ctx context.Context, rawJSON []byte, url, stage stri
 		backoff.WithMaxRetries(backoff.NewExponentialBackOff(), uint64(trans.config.maxRetry.Load())),
 		func(err error, t time.Duration) {
 			retryCount++
-			trans.logger.Warnf("JS HTTP connection error: URL: %v Error: %+v after %v tries", url, err, retryCount)
+			trans.logger.Warnn(
+				"JS HTTP connection error",
+				logger.NewStringField("URL", url),
+				logger.NewErrorField(err),
+				logger.NewIntField("attempts", int64(retryCount)),
+			)
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
# Description

use parent context in transformer to create new request.

## Linear Ticket

[link to relevant line](https://github.com/rudderlabs/rudder-server/blob/3f879308aa17f56a77c0e3d116ee0d371e00c716/processor/transformer/transformer.go#L466)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
