### PR TITLE
chore: some non-exhaustive processor drop count stats

### DIFF
--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/admin"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/internal/enricher"
@@ -3271,7 +3272,16 @@ var _ = Describe("Static Function Tests", func() {
 
 	Context("getDiffMetrics Tests", func() {
 		It("Should match diffMetrics response for Empty Inputs", func() {
-			response := getDiffMetrics("some-string-1", "some-string-2", map[string]MetricMetadata{}, map[string]int64{}, map[string]int64{}, map[string]int64{}, map[string]int64{})
+			response := getDiffMetrics(
+				"some-string-1",
+				"some-string-2",
+				map[string]MetricMetadata{},
+				map[string]int64{},
+				map[string]int64{},
+				map[string]int64{},
+				map[string]int64{},
+				stats.NOP,
+			)
 			Expect(len(response)).To(Equal(0))
 		})
 
@@ -3357,7 +3367,16 @@ var _ = Describe("Static Function Tests", func() {
 				},
 			}
 
-			response := getDiffMetrics("some-string-1", "some-string-2", inCountMetadataMap, inCountMap, successCountMap, failedCountMap, filteredCountMap)
+			response := getDiffMetrics(
+				"some-string-1",
+				"some-string-2",
+				inCountMetadataMap,
+				inCountMap,
+				successCountMap,
+				failedCountMap,
+				filteredCountMap,
+				stats.NOP,
+			)
 			assertReportMetric(expectedResponse, response)
 		})
 	})


### PR DESCRIPTION
# Description

adding some non-exhaustive drop count stats in processor.

## Linear Ticket

[motivation is to help find out where events are dropped(if they are) in cases like this(in a not so tiring manner)](https://rudderlabs.slack.com/archives/C02AALVFHJN/p1709405639968449)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
