### PR TITLE
feat: add support to build arm64 image

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -280,7 +280,16 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Create multi-arch manifest for Docker OSS
         run: |
-          docker buildx imagetools create -t ${{ needs.docker-oss-meta.outputs.tags }} ${{ needs.docker-oss-meta.outputs.arm64_tags }} ${{ needs.docker-oss-meta.outputs.amd64_tags }}
+          while read -r tag; do
+            echo "$tag"
+
+            arm_tag=$(echo "${{ needs.docker-oss-meta.outputs.arm64_tags }}" | grep "$tag")
+
+            amd_tag=$(echo "${{ needs.docker-oss-meta.outputs.amd64_tags }}" | grep "$tag")
+
+            docker buildx imagetools create -t $tag $arm_tag $amd_tag
+
+          done <<< "${{ needs.docker-oss-meta.outputs.tags }}"
   create-manifest-docker-ent:
     runs-on: ubuntu-latest
     needs: [ docker-ent, docker-ent-meta ]
@@ -294,7 +303,16 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Create multi-arch manifest for Docker ENT
         run: |
-          docker buildx imagetools create -t ${{ needs.docker-ent-meta.outputs.tags }} ${{ needs.docker-ent-meta.outputs.arm64_tags }} ${{ needs.docker-ent-meta.outputs.amd64_tags }}
+          while read -r tag; do
+            echo "$tag"
+
+            arm_tag=$(echo "${{ needs.docker-ent-meta.outputs.arm64_tags }}" | grep "$tag")
+
+            amd_tag=$(echo "${{ needs.docker-ent-meta.outputs.amd64_tags }}" | grep "$tag")
+
+            docker buildx imagetools create -t $tag $arm_tag $amd_tag
+
+          done <<< "${{ needs.docker-ent-meta.outputs.tags }}"
   create-manifest-docker-sbsvc:
     runs-on: ubuntu-latest
     needs: [ docker-suppression-backup-service, docker-sbsvc-meta ]
@@ -308,4 +326,13 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Create multi-arch manifest for Docker Suppression Backup Service
         run: |
-          docker buildx imagetools create -t ${{ needs.docker-sbsvc-meta.outputs.tags }} ${{ needs.docker-sbsvc-meta.outputs.arm64_tags }} ${{ needs.docker-sbsvc-meta.outputs.amd64_tags }}
+          while read -r tag; do
+            echo "$tag"
+
+            arm_tag=$(echo "${{ needs.docker-sbsvc-meta.outputs.arm64_tags }}" | grep "$tag")
+
+            amd_tag=$(echo "${{ needs.docker-sbsvc-meta.outputs.amd64_tags }}" | grep "$tag")
+
+            docker buildx imagetools create -t $tag $arm_tag $amd_tag
+
+          done <<< "${{ needs.docker-sbsvc-meta.outputs.tags }}"

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -53,19 +53,17 @@ jobs:
             COMMIT_HASH=${{ github.sha }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
   docker-oss-arm64:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, ARM64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: rudderlabs
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -137,12 +135,10 @@ jobs:
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
             ENTERPRISE_TOKEN=${{ secrets.ENTERPRISE_TOKEN }}
   docker-ent-arm64:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, ARM64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Docker meta
@@ -220,12 +216,10 @@ jobs:
             COMMIT_HASH=${{ github.sha }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
   docker-suppression-backup-service-arm64:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, ARM64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Docker meta

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -19,7 +19,7 @@ env:
     type=ref,event=branch
     type=raw,value=1-alpine,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
     type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
-    type=raw,value=${{ github.head_ref }}
+    type=raw,value=${{ github.head_ref }},enable=${{ github.event_name == 'pull_request' }}
     type=semver,pattern={{version}}
     type=semver,pattern={{major}}.{{minor}}
     type=semver,pattern={{major}}
@@ -29,7 +29,7 @@ env:
   docker_ent_tags: |
     type=ref,event=branch
     type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-    type=raw,value=${{ github.head_ref }}
+    type=raw,value=${{ github.head_ref }},enable=${{ github.event_name == 'pull_request' }}
     type=semver,pattern={{version}}
     type=semver,pattern={{major}}.{{minor}}
     type=semver,pattern={{major}}
@@ -39,7 +39,7 @@ env:
   docker_sbsvc_tags: |
     type=ref,event=branch
     type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-    type=raw,value=${{ github.head_ref }}
+    type=raw,value=${{ github.head_ref }},enable=${{ github.event_name == 'pull_request' }}
     type=semver,pattern={{version}}
     type=semver,pattern={{major}}.{{minor}}
     type=semver,pattern={{major}}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -52,6 +52,48 @@ jobs:
             VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
             COMMIT_HASH=${{ github.sha }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+  docker-oss-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: rudderlabs
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            name=rudderlabs/develop-rudder-server
+            name=rudderlabs/rudder-server,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=1-alpine,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=${{ github.head_ref }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-arm64
+            COMMIT_HASH=${{ github.sha }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
   docker-ent:
     runs-on: ubuntu-latest
     steps:
@@ -94,6 +136,48 @@ jobs:
             COMMIT_HASH=${{ github.sha }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
             ENTERPRISE_TOKEN=${{ secrets.ENTERPRISE_TOKEN }}
+  docker-ent-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            name=rudderstack/develop-rudder-server-enterprise
+            name=rudderstack/rudder-server-enterprise,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=${{ github.head_ref }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: rudderlabs
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-arm64
+            COMMIT_HASH=${{ github.sha }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            ENTERPRISE_TOKEN=${{ secrets.ENTERPRISE_TOKEN }}
   docker-suppression-backup-service:
     runs-on: ubuntu-latest
     steps:
@@ -133,5 +217,47 @@ jobs:
           build-args: |
             BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            COMMIT_HASH=${{ github.sha }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+  docker-suppression-backup-service-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            name=rudderstack/develop-suppression-backup-service
+            name=rudderstack/suppression-backup-service,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=${{ github.head_ref }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: rudderlabs
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm64
+          file: ./suppression-backup-service/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-arm64
             COMMIT_HASH=${{ github.sha }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   docker-oss:
     runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
     steps:
       -
         name: Checkout
@@ -54,6 +56,8 @@ jobs:
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
   docker-oss-arm64:
     runs-on: [self-hosted, Linux, ARM64]
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -94,6 +98,8 @@ jobs:
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
   docker-ent:
     runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
     steps:
       -
         name: Checkout
@@ -134,7 +140,23 @@ jobs:
             COMMIT_HASH=${{ github.sha }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
             ENTERPRISE_TOKEN=${{ secrets.ENTERPRISE_TOKEN }}
+      - name: Build and push amd64
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-amd64
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-amd64
+            COMMIT_HASH=${{ github.sha }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            ENTERPRISE_TOKEN=${{ secrets.ENTERPRISE_TOKEN }}
   docker-ent-arm64:
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}-arm64
     runs-on: [self-hosted, Linux, ARM64]
     steps:
       - name: Checkout
@@ -176,6 +198,8 @@ jobs:
             ENTERPRISE_TOKEN=${{ secrets.ENTERPRISE_TOKEN }}
   docker-suppression-backup-service:
     runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
     steps:
       -
         name: Checkout
@@ -217,6 +241,8 @@ jobs:
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
   docker-suppression-backup-service-arm64:
     runs-on: [self-hosted, Linux, ARM64]
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -255,3 +281,17 @@ jobs:
             VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-arm64
             COMMIT_HASH=${{ github.sha }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+  create-manifest:
+    runs-on: ubuntu-latest
+    needs: [ docker-ent-arm64, docker-ent ]
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: rudderlabs
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create multi-arch manifest for enterprise
+        run: |
+          docker buildx imagetools create -t ${{ needs.docker-ent.outputs.tags }} ${{ needs.docker-ent-arm64.outputs.tags }} ${{ needs.docker-ent.outputs.tags }}-amd64

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2,181 +2,178 @@ name: builds
 
 on:
   release:
-    types: [created]
+    types: [ created ]
   push:
     branches:
       - master
       - main
   pull_request:
 
+env:
+  arch_amd64: amd64
+  arch_arm64: arm64
+  docker_oss_images: |
+    name=rudderlabs/develop-rudder-server
+    name=rudderlabs/rudder-server,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
+  docker_oss_tags: |
+    type=ref,event=branch
+    type=raw,value=1-alpine,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+    type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+    type=raw,value=${{ github.head_ref }}
+    type=semver,pattern={{version}}
+    type=semver,pattern={{major}}.{{minor}}
+    type=semver,pattern={{major}}
+  docker_ent_images: |
+    name=rudderstack/develop-rudder-server-enterprise
+    name=rudderstack/rudder-server-enterprise,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
+  docker_ent_tags: |
+    type=ref,event=branch
+    type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+    type=raw,value=${{ github.head_ref }}
+    type=semver,pattern={{version}}
+    type=semver,pattern={{major}}.{{minor}}
+    type=semver,pattern={{major}}
+  docker_sbsvc_images: |
+    name=rudderstack/develop-suppression-backup-service
+    name=rudderstack/suppression-backup-service,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
+  docker_sbsvc_tags: |
+    type=ref,event=branch
+    type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+    type=raw,value=${{ github.head_ref }}
+    type=semver,pattern={{version}}
+    type=semver,pattern={{major}}.{{minor}}
+    type=semver,pattern={{major}}
+
 jobs:
+  docker-oss-meta:
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.meta.outputs.labels }}
+      build-date: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+      version: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+      revision: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+      tags: ${{ steps.meta.outputs.tags }}
+      arm64_tags: ${{ steps.arm64_meta.outputs.tags }}
+      arm64_labels: ${{ steps.arm64_meta.outputs.labels }}
+      amd64_tags: ${{ steps.amd64_meta.outputs.tags }}
+      amd64_labels: ${{ steps.amd64_meta.outputs.labels }}
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.docker_oss_images}}
+          tags: ${{env.docker_oss_tags}}
+      - name: Docker arm64 meta
+        id: arm64_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.docker_oss_images}}
+          tags: ${{env.docker_oss_tags}}
+          flavor: |
+            suffix=-${{env.arch_arm64}},onlatest=true
+      - name: Docker amd64 meta
+        id: amd64_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.docker_oss_images}}
+          tags: ${{env.docker_oss_tags}}
+          flavor: |
+            suffix=-${{env.arch_amd64}},onlatest=true
   docker-oss:
-    runs-on: ubuntu-latest
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            name=rudderlabs/develop-rudder-server
-            name=rudderlabs/rudder-server,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
-          tags: |
-            type=ref,event=branch
-            type=raw,value=1-alpine,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
-            type=raw,value=${{ github.head_ref }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: rudderlabs
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          # platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
-            COMMIT_HASH=${{ github.sha }}
-            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
-  docker-oss-arm64:
-    runs-on: [self-hosted, Linux, ARM64]
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
+    needs:
+      - docker-oss-meta
+    strategy:
+      matrix:
+        build-config:
+          - os: [ self-hosted, Linux, ARM64 ]
+            tags: ${{needs.docker-oss-meta.outputs.arm64_tags}}
+            labels: ${{needs.docker-oss-meta.outputs.arm64_labels}}
+            platform: linux/arm64
+          - os: ubuntu-latest
+            tags: ${{needs.docker-oss-meta.outputs.amd64_tags}}
+            labels: ${{needs.docker-oss-meta.outputs.amd64_labels}}
+            platform: linux/amd64
+    runs-on: ${{matrix.build-config.os}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: rudderlabs
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            name=rudderlabs/develop-rudder-server
-            name=rudderlabs/rudder-server,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
-          tags: |
-            type=ref,event=branch
-            type=raw,value=1-alpine,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
-            type=raw,value=${{ github.head_ref }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/arm64
+          platforms: ${{ matrix.build-config.platform }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}-arm64
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ matrix.build-config.tags }}
+          labels: ${{ matrix.build-config.labels }}
           build-args: |
-            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-arm64
+            BUILD_DATE=${{ needs.docker-oss-meta.outputs.build-date }}
+            VERSION=${{ needs.docker-oss-meta.outputs.version }}
             COMMIT_HASH=${{ github.sha }}
-            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            REVISION=${{ needs.docker-oss-meta.outputs.revision }}
+
+  docker-ent-meta:
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.meta.outputs.labels }}
+      build-date: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+      version: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+      revision: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+      tags: ${{ steps.meta.outputs.tags }}
+      arm64_tags: ${{ steps.arm64_meta.outputs.tags }}
+      arm64_labels: ${{ steps.arm64_meta.outputs.labels }}
+      amd64_tags: ${{ steps.amd64_meta.outputs.tags }}
+      amd64_labels: ${{ steps.amd64_meta.outputs.labels }}
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.docker_ent_images}}
+          tags: ${{env.docker_ent_tags}}
+      - name: Docker arm64 meta
+        id: arm64_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.docker_ent_images}}
+          tags: ${{env.docker_ent_tags}}
+          flavor: |
+            suffix=-${{env.arch_arm64}},onlatest=true
+      - name: Docker amd64 meta
+        id: amd64_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.docker_ent_images}}
+          tags: ${{env.docker_ent_tags}}
+          flavor: |
+            suffix=-${{env.arch_amd64}},onlatest=true
   docker-ent:
-    runs-on: ubuntu-latest
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            name=rudderstack/develop-rudder-server-enterprise
-            name=rudderstack/rudder-server-enterprise,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
-          tags: |
-            type=ref,event=branch
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-            type=raw,value=${{ github.head_ref }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: rudderlabs
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          # platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
-            COMMIT_HASH=${{ github.sha }}
-            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
-            ENTERPRISE_TOKEN=${{ secrets.ENTERPRISE_TOKEN }}
-      - name: Build and push amd64
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}-amd64
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-amd64
-            COMMIT_HASH=${{ github.sha }}
-            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
-            ENTERPRISE_TOKEN=${{ secrets.ENTERPRISE_TOKEN }}
-  docker-ent-arm64:
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}-arm64
-    runs-on: [self-hosted, Linux, ARM64]
+    needs:
+      - docker-ent-meta
+    strategy:
+      matrix:
+        build-config:
+          - os: [ self-hosted, Linux, ARM64 ]
+            tags: ${{needs.docker-ent-meta.outputs.arm64_tags}}
+            labels: ${{needs.docker-ent-meta.outputs.arm64_labels}}
+            platform: linux/arm64
+          - os: ubuntu-latest
+            tags: ${{needs.docker-ent-meta.outputs.amd64_tags}}
+            labels: ${{needs.docker-ent-meta.outputs.amd64_labels}}
+            platforms: linux/amd64
+    runs-on: ${{matrix.build-config.os}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            name=rudderstack/develop-rudder-server-enterprise
-            name=rudderstack/rudder-server-enterprise,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
-          tags: |
-            type=ref,event=branch
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-            type=raw,value=${{ github.head_ref }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+        uses: docker/setup-buildx-action@v3.0.0
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -186,82 +183,71 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/arm64
+          platforms: ${{ matrix.build-config.platform }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}-arm64
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ matrix.build-config.tags }}
+          labels: ${{ matrix.build-config.labels }}
           build-args: |
-            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-arm64
+            BUILD_DATE=${{ needs.docker-ent-meta.outputs.build-date }}
+            VERSION=${{ needs.docker-ent-meta.outputs.version }}
             COMMIT_HASH=${{ github.sha }}
-            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            REVISION=${{ needs.docker-ent-meta.outputs.revision }}
             ENTERPRISE_TOKEN=${{ secrets.ENTERPRISE_TOKEN }}
+  docker-sbsvc-meta:
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.meta.outputs.labels }}
+      build-date: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+      version: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+      revision: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+      tags: ${{ steps.meta.outputs.tags }}
+      arm64_tags: ${{ steps.arm64_meta.outputs.tags }}
+      arm64_labels: ${{ steps.arm64_meta.outputs.labels }}
+      amd64_tags: ${{ steps.amd64_meta.outputs.tags }}
+      amd64_labels: ${{ steps.amd64_meta.outputs.labels }}
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.docker_sbsvc_images}}
+          tags: ${{env.docker_sbsvc_tags}}
+      - name: Docker arm64 meta
+        id: arm64_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.docker_sbsvc_images}}
+          tags: ${{env.docker_sbsvc_tags}}
+          flavor: |
+            suffix=-${{env.arch_arm64}},onlatest=true
+      - name: Docker amd64 meta
+        id: amd64_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.docker_sbsvc_images}}
+          tags: ${{env.docker_sbsvc_tags}}
+          flavor: |
+            suffix=-${{env.arch_amd64}},onlatest=true
   docker-suppression-backup-service:
-    runs-on: ubuntu-latest
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            name=rudderstack/develop-suppression-backup-service
-            name=rudderstack/suppression-backup-service,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
-          tags: |
-            type=ref,event=branch
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-            type=raw,value=${{ github.head_ref }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: rudderlabs
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./suppression-backup-service/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
-            COMMIT_HASH=${{ github.sha }}
-            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
-  docker-suppression-backup-service-arm64:
-    runs-on: [self-hosted, Linux, ARM64]
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
+    needs:
+      - docker-sbsvc-meta
+    strategy:
+      matrix:
+        build-config:
+          - os: [ self-hosted, Linux, ARM64 ]
+            tags: ${{needs.docker-sbsvc-meta.outputs.arm64_tags}}
+            labels: ${{needs.docker-sbsvc-meta.outputs.arm64_labels}}
+            platform: linux/arm64
+          - os: ubuntu-latest
+            tags: ${{needs.docker-sbsvc-meta.outputs.amd64_tags}}
+            labels: ${{needs.docker-sbsvc-meta.outputs.amd64_labels}}
+            platform: linux/amd64
+    runs-on: ${{matrix.build-config.os}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            name=rudderstack/develop-suppression-backup-service
-            name=rudderstack/suppression-backup-service,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.event_name == 'release' }}
-          tags: |
-            type=ref,event=branch
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-            type=raw,value=${{ github.head_ref }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+        uses: docker/setup-buildx-action@v3.0.0
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -271,19 +257,19 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/arm64
+          platforms: ${{ matrix.build-config.platform }}
           file: ./suppression-backup-service/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}-arm64
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ matrix.build-config.tags }}
+          labels: ${{ matrix.build-config.labels }}
           build-args: |
-            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}-arm64
+            BUILD_DATE=${{ needs.docker-sbsvc-meta.outputs.build-date }}
+            VERSION=${{ needs.docker-sbsvc-meta.outputs.version }}
             COMMIT_HASH=${{ github.sha }}
-            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
-  create-manifest:
+            REVISION=${{ needs.docker-sbsvc-meta.outputs.revision }}
+  create-manifest-docker-oss:
     runs-on: ubuntu-latest
-    needs: [ docker-ent-arm64, docker-ent ]
+    needs: [ docker-oss, docker-oss-meta ]
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.0.0
@@ -292,6 +278,34 @@ jobs:
         with:
           username: rudderlabs
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Create multi-arch manifest for enterprise
+      - name: Create multi-arch manifest for Docker OSS
         run: |
-          docker buildx imagetools create -t ${{ needs.docker-ent.outputs.tags }} ${{ needs.docker-ent-arm64.outputs.tags }} ${{ needs.docker-ent.outputs.tags }}-amd64
+          docker buildx imagetools create -t ${{ needs.docker-oss-meta.outputs.tags }} ${{ needs.docker-oss-meta.outputs.arm64_tags }} ${{ needs.docker-oss-meta.outputs.amd64_tags }}
+  create-manifest-docker-ent:
+    runs-on: ubuntu-latest
+    needs: [ docker-ent, docker-ent-meta ]
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: rudderlabs
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create multi-arch manifest for Docker ENT
+        run: |
+          docker buildx imagetools create -t ${{ needs.docker-ent-meta.outputs.tags }} ${{ needs.docker-ent-meta.outputs.arm64_tags }} ${{ needs.docker-ent-meta.outputs.amd64_tags }}
+  create-manifest-docker-sbsvc:
+    runs-on: ubuntu-latest
+    needs: [ docker-suppression-backup-service, docker-sbsvc-meta ]
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: rudderlabs
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create multi-arch manifest for Docker Suppression Backup Service
+        run: |
+          docker buildx imagetools create -t ${{ needs.docker-sbsvc-meta.outputs.tags }} ${{ needs.docker-sbsvc-meta.outputs.arm64_tags }} ${{ needs.docker-sbsvc-meta.outputs.amd64_tags }}


### PR DESCRIPTION
# Description

Adding support to build arm64 image in GA. 

We will create both arm64 as well as amd64 docker image for rudder-server. A manifest will be created that will add both the builds to a common tag so that based on the arch of host machine correct build will be picked-up

Successful Build: https://github.com/rudderlabs/rudder-server/actions/runs/8537621984/job/23388772427

<img width="1215" alt="image" src="https://github.com/rudderlabs/rudder-server/assets/26831213/fbdc3800-4aaa-4673-a714-4e6b676c35aa">

<img width="1215" alt="image" src="https://github.com/rudderlabs/rudder-server/assets/26831213/3f17d56a-c9fe-4817-9d0c-39328b2426d6">

<img width="1215" alt="image" src="https://github.com/rudderlabs/rudder-server/assets/26831213/ad096377-50b9-4606-8c9b-5d9a046f1e0f">

<img width="1215" alt="image" src="https://github.com/rudderlabs/rudder-server/assets/26831213/24e2209e-d521-48c0-a0a1-e036bedb11ab">

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-889/arm-build-for-rudder-server

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
