### PR TITLE
fix: destType issue in eloqua stats

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/eloqua/manager.go
+++ b/router/batchrouter/asyncdestinationmanager/eloqua/manager.go
@@ -23,7 +23,7 @@ func NewManager(destination *backendconfig.DestinationT) (*EloquaBulkUploader, e
 		return nil, fmt.Errorf("error in unmarshalling destination config: %v", err)
 	}
 	authorization := destConfig.CompanyName + "\\" + destConfig.UserName + ":" + destConfig.Password
-	destName := destination.DestinationDefinition.Name + ":" + destination.Name
+	destName := destination.DestinationDefinition.Name
 	encodedAuthorizationString := "Basic " + base64.StdEncoding.EncodeToString([]byte(authorization))
 	eloquaData := HttpRequestData{
 		Authorization: encodedAuthorizationString,


### PR DESCRIPTION
# Description

We are updating the destType name in the stats of Eloqua destination to send only the destination definition name, not the destination name set by the customer.
## Linear Ticket

Resolves INT-1671

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
