### PR TITLE
fix: too many connections in router transform

### DIFF
--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -152,17 +152,27 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 		if err != nil {
 			trans.transformRequestTimerStat.SendTiming(time.Since(s))
 			reqFailed = true
-			trans.logger.Errorf("JS HTTP connection error: URL: %v Error: %+v", url, err)
+			trans.logger.Errorn(
+				"JS HTTP connection error",
+				logger.NewErrorField(err),
+				logger.NewStringField("URL", url),
+			)
 			if retryCount > config.GetInt("Processor.maxRetry", 30) {
 				panic(fmt.Errorf("JS HTTP connection error: URL: %v Error: %+v", url, err))
 			}
 			retryCount++
 			time.Sleep(config.GetDurationVar(100, time.Millisecond, "Processor.retrySleep", "Processor.retrySleepInMS"))
 			// Refresh the connection
+			httputil.CloseResponse(resp)
 			continue
 		}
+
 		if reqFailed {
-			trans.logger.Errorf("Failed request succeeded after %v retries, URL: %v", retryCount, url)
+			trans.logger.Errorn(
+				"Failed request succeeded",
+				logger.NewStringField("URL", url),
+				logger.NewIntField("RetryCount", int64(retryCount)),
+			)
 		}
 
 		trans.transformRequestTimerStat.SendTiming(time.Since(s))


### PR DESCRIPTION
# Description

On failures in router transform, there's 30 retries - each retry reading the body but not closing it.
1. Closing the body in case of failures before retrying again.
2. Updated some log statements to use `Errorn` instead of `Error`

## Linear Ticket

[resolves PIPE-846](https://linear.app/rudderstack/issue/PIPE-846/hostedmtedmt-v0-rs-1-is-opening-too-many-connections-to-transformer)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
