### PR TITLE
chore: version handler cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN go mod download
 COPY . .
 
 RUN BUILD_DATE=$(date "+%F,%T") \
-    LDFLAGS="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT_HASH} -X main.buildDate=$BUILD_DATE -X main.builtBy=${REVISION} -X main.builtBy=${REVISION} -X main.enterpriseToken=${ENTERPRISE_TOKEN} " \
+    LDFLAGS="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT_HASH} -X main.buildDate=$BUILD_DATE -X main.builtBy=${REVISION} -X main.enterpriseToken=${ENTERPRISE_TOKEN} " \
     make build
 
 RUN go build -o devtool ./cmd/devtool/

--- a/main.go
+++ b/main.go
@@ -12,12 +12,13 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/mem"
+
 	"github.com/rudderlabs/rudder-server/runner"
 )
 
 var (
-	version                                                                  = "Not an official release. Get the latest release from the github repo."
-	major, minor, commit, buildDate, builtBy, gitURL, patch, enterpriseToken string
+	version                                     = "Not an official release. Get the latest release from the github repo."
+	commit, buildDate, builtBy, enterpriseToken string
 )
 
 func main() {
@@ -29,13 +30,9 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	r := runner.New(runner.ReleaseInfo{
 		Version:         version,
-		Major:           major,
-		Minor:           minor,
-		Patch:           patch,
 		Commit:          commit,
 		BuildDate:       buildDate,
 		BuiltBy:         builtBy,
-		GitURL:          gitURL,
 		EnterpriseToken: config.GetString("ENTERPRISE_TOKEN", enterpriseToken),
 	})
 	exitCode := r.Run(ctx, os.Args)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/profiler"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	svcMetric "github.com/rudderlabs/rudder-go-kit/stats/metric"
+
 	"github.com/rudderlabs/rudder-server/admin"
 	"github.com/rudderlabs/rudder-server/app"
 	"github.com/rudderlabs/rudder-server/app/apphandlers"
@@ -59,13 +60,9 @@ var (
 // ReleaseInfo holds the release information
 type ReleaseInfo struct {
 	Version         string
-	Major           string
-	Minor           string
-	Patch           string
 	Commit          string
 	BuildDate       string
 	BuiltBy         string
-	GitURL          string
 	EnterpriseToken string
 }
 
@@ -165,13 +162,9 @@ func (r *Runner) Run(ctx context.Context, args []string) int {
 		stats.GaugeType,
 		stats.Tags{
 			"version":            r.releaseInfo.Version,
-			"major":              r.releaseInfo.Major,
-			"minor":              r.releaseInfo.Minor,
-			"patch":              r.releaseInfo.Patch,
 			"commit":             r.releaseInfo.Commit,
 			"buildDate":          r.releaseInfo.BuildDate,
 			"builtBy":            r.releaseInfo.BuiltBy,
-			"gitUrl":             r.releaseInfo.GitURL,
 			"TransformerVersion": transformer.GetVersion(),
 		}).Gauge(1)
 
@@ -327,13 +320,9 @@ func runAllInit() {
 func (r *Runner) versionInfo() map[string]interface{} {
 	return map[string]interface{}{
 		"Version":            r.releaseInfo.Version,
-		"Major":              r.releaseInfo.Major,
-		"Minor":              r.releaseInfo.Minor,
-		"Patch":              r.releaseInfo.Patch,
 		"Commit":             r.releaseInfo.Commit,
 		"BuildDate":          r.releaseInfo.BuildDate,
 		"BuiltBy":            r.releaseInfo.BuiltBy,
-		"GitUrl":             r.releaseInfo.GitURL,
 		"TransformerVersion": transformer.GetVersion(),
 		"Features":           info.ServerComponent.Features,
 	}


### PR DESCRIPTION
# Description

- Cleanup for version info handler since these fields are not being set.

## Linear Ticket

- Resolves PIPE-834

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
