### PR TITLE
fix: filter success events before sending it to error reporting table

### DIFF
--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -173,9 +173,9 @@ func (edr *ErrorDetailReporter) Report(ctx context.Context, metrics []*types.PUR
 
 	reportedAt := time.Now().UTC().Unix() / 60
 	for _, metric := range metrics {
-		if (metric.StatusDetail.StatusCode < http.StatusBadRequest && !lo.Contains([]int{types.FilterEventCode, types.SuppressEventCode}, metric.StatusDetail.StatusCode)) {
-            continue
-        }
+		if metric.StatusDetail.StatusCode < http.StatusBadRequest && !lo.Contains([]int{types.FilterEventCode, types.SuppressEventCode}, metric.StatusDetail.StatusCode) {
+			continue
+		}
 
 		workspaceID := edr.configSubscriber.WorkspaceIDFromSource(metric.ConnectionDetails.SourceID)
 		metric := *metric

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -158,6 +158,15 @@ func (edr *ErrorDetailReporter) GetSyncer(syncerKey string) *types.SyncSource {
 	return edr.syncers[syncerKey]
 }
 
+func shouldReport(metric *types.PUReportedMetric) bool {
+	switch {
+	case metric.StatusDetail.StatusCode >= http.StatusBadRequest, metric.StatusDetail.StatusCode == types.FilterEventCode, metric.StatusDetail.StatusCode == types.SuppressEventCode:
+		return true
+	default:
+		return false
+	}
+}
+
 func (edr *ErrorDetailReporter) Report(ctx context.Context, metrics []*types.PUReportedMetric, txn *Tx) error {
 	edr.log.Debug("[ErrorDetailReport] Report method called\n")
 	if len(metrics) == 0 {
@@ -173,7 +182,7 @@ func (edr *ErrorDetailReporter) Report(ctx context.Context, metrics []*types.PUR
 
 	reportedAt := time.Now().UTC().Unix() / 60
 	for _, metric := range metrics {
-		if metric.StatusDetail.StatusCode < http.StatusBadRequest && !lo.Contains([]int{types.FilterEventCode, types.SuppressEventCode}, metric.StatusDetail.StatusCode) {
+		if !shouldReport(metric) {
 			continue
 		}
 

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -173,42 +173,44 @@ func (edr *ErrorDetailReporter) Report(ctx context.Context, metrics []*types.PUR
 
 	reportedAt := time.Now().UTC().Unix() / 60
 	for _, metric := range metrics {
-		workspaceID := edr.configSubscriber.WorkspaceIDFromSource(metric.ConnectionDetails.SourceID)
-		metric := *metric
-		destinationDetail := edr.configSubscriber.GetDestDetail(metric.ConnectionDetails.DestinationID)
-		edr.log.Debugf("For DestId: %v -> DestDetail: %v", metric.ConnectionDetails.DestinationID, destinationDetail)
+		if metric.StatusDetail.StatusCode >= http.StatusBadRequest || lo.Contains([]int{types.FilterEventCode, types.SuppressEventCode}, metric.StatusDetail.StatusCode) {
+			workspaceID := edr.configSubscriber.WorkspaceIDFromSource(metric.ConnectionDetails.SourceID)
+			metric := *metric
+			destinationDetail := edr.configSubscriber.GetDestDetail(metric.ConnectionDetails.DestinationID)
+			edr.log.Debugf("For DestId: %v -> DestDetail: %v", metric.ConnectionDetails.DestinationID, destinationDetail)
 
-		// extract error-message & error-code
-		errDets := edr.extractErrorDetails(metric.StatusDetail.SampleResponse)
+			// extract error-message & error-code
+			errDets := edr.extractErrorDetails(metric.StatusDetail.SampleResponse)
 
-		stats.Default.NewTaggedStat("error_detail_reporting_failures", stats.CountType, stats.Tags{
-			"errorCode":     errDets.ErrorCode,
-			"workspaceId":   workspaceID,
-			"destType":      destinationDetail.destType,
-			"sourceId":      metric.ConnectionDetails.SourceID,
-			"destinationId": metric.ConnectionDetails.DestinationID,
-		}).Count(int(metric.StatusDetail.Count))
+			stats.Default.NewTaggedStat("error_detail_reporting_failures", stats.CountType, stats.Tags{
+				"errorCode":     errDets.ErrorCode,
+				"workspaceId":   workspaceID,
+				"destType":      destinationDetail.destType,
+				"sourceId":      metric.ConnectionDetails.SourceID,
+				"destinationId": metric.ConnectionDetails.DestinationID,
+			}).Count(int(metric.StatusDetail.Count))
 
-		_, err = stmt.Exec(
-			workspaceID,
-			edr.namespace,
-			edr.instanceID,
-			metric.ConnectionDetails.SourceDefinitionId,
-			metric.ConnectionDetails.SourceID,
-			destinationDetail.destinationDefinitionID,
-			metric.ConnectionDetails.DestinationID,
-			destinationDetail.destType,
-			metric.PUDetails.PU,
-			reportedAt,
-			metric.StatusDetail.Count,
-			metric.StatusDetail.StatusCode,
-			metric.StatusDetail.EventType,
-			errDets.ErrorCode,
-			errDets.ErrorMessage,
-		)
-		if err != nil {
-			edr.log.Errorf("Failed during statement execution(each metric): %v", err)
-			return fmt.Errorf("executing statement: %v", err)
+			_, err = stmt.Exec(
+				workspaceID,
+				edr.namespace,
+				edr.instanceID,
+				metric.ConnectionDetails.SourceDefinitionId,
+				metric.ConnectionDetails.SourceID,
+				destinationDetail.destinationDefinitionID,
+				metric.ConnectionDetails.DestinationID,
+				destinationDetail.destType,
+				metric.PUDetails.PU,
+				reportedAt,
+				metric.StatusDetail.Count,
+				metric.StatusDetail.StatusCode,
+				metric.StatusDetail.EventType,
+				errDets.ErrorCode,
+				errDets.ErrorMessage,
+			)
+			if err != nil {
+				edr.log.Errorf("Failed during statement execution(each metric): %v", err)
+				return fmt.Errorf("executing statement: %v", err)
+			}
 		}
 	}
 

--- a/enterprise/reporting/error_reporting_test.go
+++ b/enterprise/reporting/error_reporting_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	
+
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
@@ -28,7 +28,7 @@ func TestShouldReport(t *testing.T) {
 	}
 	Expect(shouldReport(metric2)).To(BeTrue())
 
-	// Test case 3: Supress event case
+	// Test case 3: Suppress event case
 	metric3 := &types.PUReportedMetric{
 		StatusDetail: &types.StatusDetail{
 			StatusCode: types.SuppressEventCode,

--- a/enterprise/reporting/error_reporting_test.go
+++ b/enterprise/reporting/error_reporting_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 

--- a/enterprise/reporting/error_reporting_test.go
+++ b/enterprise/reporting/error_reporting_test.go
@@ -1,0 +1,45 @@
+package reporting
+
+import (
+    "net/http"
+    "testing"
+
+    . "github.com/onsi/gomega"
+    "github.com/rudderlabs/rudder-server/utils/types" 
+)
+
+func TestShouldReport(t *testing.T) {
+    RegisterTestingT(t)
+
+    // Test case 1: Event failure case
+    metric1 := &types.PUReportedMetric{
+        StatusDetail: &types.StatusDetail{
+            StatusCode: http.StatusBadRequest,
+        },
+    }
+    Expect(shouldReport(metric1)).To(BeTrue())
+
+    // Test case 2: Filter event case
+    metric2 := &types.PUReportedMetric{
+        StatusDetail: &types.StatusDetail{
+            StatusCode: types.FilterEventCode,
+        },
+    }
+    Expect(shouldReport(metric2)).To(BeTrue())
+
+    // Test case 3: Supress event case
+    metric3 := &types.PUReportedMetric{
+        StatusDetail: &types.StatusDetail{
+            StatusCode: types.SuppressEventCode,
+        },
+    }
+    Expect(shouldReport(metric3)).To(BeTrue())
+
+    // Test case 4: Success cases
+    metric4 := &types.PUReportedMetric{
+        StatusDetail: &types.StatusDetail{
+            StatusCode: http.StatusOK,
+        },
+    }
+    Expect(shouldReport(metric4)).To(BeFalse())
+}

--- a/enterprise/reporting/error_reporting_test.go
+++ b/enterprise/reporting/error_reporting_test.go
@@ -1,45 +1,45 @@
 package reporting
 
 import (
-    "net/http"
-    "testing"
+	"net/http"
+	"testing"
 
-    . "github.com/onsi/gomega"
-    "github.com/rudderlabs/rudder-server/utils/types" 
+	. "github.com/onsi/gomega"
+	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
 func TestShouldReport(t *testing.T) {
-    RegisterTestingT(t)
+	RegisterTestingT(t)
 
-    // Test case 1: Event failure case
-    metric1 := &types.PUReportedMetric{
-        StatusDetail: &types.StatusDetail{
-            StatusCode: http.StatusBadRequest,
-        },
-    }
-    Expect(shouldReport(metric1)).To(BeTrue())
+	// Test case 1: Event failure case
+	metric1 := &types.PUReportedMetric{
+		StatusDetail: &types.StatusDetail{
+			StatusCode: http.StatusBadRequest,
+		},
+	}
+	Expect(shouldReport(metric1)).To(BeTrue())
 
-    // Test case 2: Filter event case
-    metric2 := &types.PUReportedMetric{
-        StatusDetail: &types.StatusDetail{
-            StatusCode: types.FilterEventCode,
-        },
-    }
-    Expect(shouldReport(metric2)).To(BeTrue())
+	// Test case 2: Filter event case
+	metric2 := &types.PUReportedMetric{
+		StatusDetail: &types.StatusDetail{
+			StatusCode: types.FilterEventCode,
+		},
+	}
+	Expect(shouldReport(metric2)).To(BeTrue())
 
-    // Test case 3: Supress event case
-    metric3 := &types.PUReportedMetric{
-        StatusDetail: &types.StatusDetail{
-            StatusCode: types.SuppressEventCode,
-        },
-    }
-    Expect(shouldReport(metric3)).To(BeTrue())
+	// Test case 3: Supress event case
+	metric3 := &types.PUReportedMetric{
+		StatusDetail: &types.StatusDetail{
+			StatusCode: types.SuppressEventCode,
+		},
+	}
+	Expect(shouldReport(metric3)).To(BeTrue())
 
-    // Test case 4: Success cases
-    metric4 := &types.PUReportedMetric{
-        StatusDetail: &types.StatusDetail{
-            StatusCode: http.StatusOK,
-        },
-    }
-    Expect(shouldReport(metric4)).To(BeFalse())
+	// Test case 4: Success cases
+	metric4 := &types.PUReportedMetric{
+		StatusDetail: &types.StatusDetail{
+			StatusCode: http.StatusOK,
+		},
+	}
+	Expect(shouldReport(metric4)).To(BeFalse())
 }


### PR DESCRIPTION
# Description
- In this pr we are filtering successful events before sending it to errors table in reporting DB


## Security

- [ ✅] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
