### PR TITLE
fix: robust dangling table deletion during recovery

### DIFF
--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -992,9 +992,11 @@ func (rs *Redshift) dropDanglingStagingTables(ctx context.Context) error {
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("iterating for dangling staging tables: %w", err)
 	}
-	rs.logger.Infof("WH: RS: Dropping dangling staging tables: %+v  %+v\n", len(stagingTableNames), stagingTableNames)
+	rs.logger.Infon("Dropping dangling staging tables",
+		logger.NewStringField("stagingTableNames", strings.Join(stagingTableNames, ",")),
+	)
 	for _, stagingTableName := range stagingTableNames {
-		_, err := rs.DB.ExecContext(ctx, fmt.Sprintf(`DROP TABLE "%[1]s"."%[2]s"`, rs.Namespace, stagingTableName))
+		_, err := rs.DB.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS "%[1]s"."%[2]s"`, rs.Namespace, stagingTableName))
 		if err != nil {
 			return fmt.Errorf("dropping dangling staging table %q.%q: %w", rs.Namespace, stagingTableName, err)
 		}

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -1001,12 +1001,11 @@ func TestIntegration(t *testing.T) {
 		})
 
 		t.Run("crashRecover", func(t *testing.T) {
-
 			ctx := context.Background()
 			tableName := "crash_recovery_test_table"
 			stgTableName := warehouseutils.StagingTableName(warehouseutils.RS, tableName, 64)
 			mockUploader := newMockUploader(t, nil, tableName, schemaInUpload, schemaInUpload, warehouseutils.LoadFileTypeParquet)
-		
+
 			rs := redshift.New(config.New(), logger.NOP, stats.NOP)
 			err := rs.Setup(ctx, warehouse, mockUploader)
 			require.NoError(t, err)
@@ -1021,7 +1020,7 @@ func TestIntegration(t *testing.T) {
 				t.Helper()
 				var count int
 				err = rs.DB.DB.QueryRow(`
-					SELECT count()
+					SELECT count(*)
 					FROM information_schema.tables
 					WHERE table_schema = $1 AND table_name = $2;
 						`,
@@ -1039,9 +1038,7 @@ func TestIntegration(t *testing.T) {
 
 			require.False(t, tableExists(t))
 		})
-
 	})
-
 }
 
 func TestCheckAndIgnoreColumnAlreadyExistError(t *testing.T) {


### PR DESCRIPTION
# Description

Recently we had three incidents where redshift crash recovery kept on failing. We select tables matching a prefix and then attempt to delete them. Due to race, the table has already been deleted by another process. Although we have concurrency controls to prevent multiple recoveries from taking place for the same destination, but another destination configured in the same namespace could likely cause this. 

Thus, introducing `IF EXIST` to ensure that deletes failures won't cause sync to fail.

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-926/robust-dangling-tables-deletion

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
