### PR TITLE
chore: remove rudder id from internal batch endpoint

### DIFF
--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	"github.com/rudderlabs/rudder-server/app"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/gateway/internal/bot"
@@ -753,8 +754,6 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(
 			continue
 		}
 
-		rudderID, _ := misc.GetMD5UUID(userIDFromReq + ":" + anonIDFromReq)
-		toSet["rudderId"] = rudderID
 		userID := buildUserID("", anonIDFromReq, userIDFromReq)
 		receivedAt, _ := toSet["receivedAt"].(string)
 		if receivedAt == "" {


### PR DESCRIPTION
# Description

-  Remove rudder id from internal batch endpoint, as it is being set by the ingestion svc.
- Corresponding ingestion svc changes: https://github.com/rudderlabs/rudder-ingestion-svc/pull/41

## Linear Ticket

- Resolves PIPE-920

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
