### PR TITLE
fix: health check for ssh server

### DIFF
--- a/integration_test/warehouse/testdata/docker-compose.ssh-server.yml
+++ b/integration_test/warehouse/testdata/docker-compose.ssh-server.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   ssh-server:
-    image: lscr.io/linuxserver/openssh-server:latest
+    image: lscr.io/linuxserver/openssh-server:9.3_p2-r1-ls145
     environment:
       - PUBLIC_KEY_FILE=/test_key.pub
       - USER_NAME=rudderstack #optional

--- a/warehouse/integrations/postgres/testdata/docker-compose.ssh-server.yml
+++ b/warehouse/integrations/postgres/testdata/docker-compose.ssh-server.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   ssh-server:
-    image: lscr.io/linuxserver/openssh-server:latest
+    image: lscr.io/linuxserver/openssh-server:9.3_p2-r1-ls145
     environment:
       - PUBLIC_KEY_FILE=/test_key.pub
       - USER_NAME=rudderstack #optional

--- a/warehouse/integrations/tunnelling/testdata/docker-compose.yml
+++ b/warehouse/integrations/tunnelling/testdata/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   openssh-server:
-    image: lscr.io/linuxserver/openssh-server:latest
+    image: lscr.io/linuxserver/openssh-server:9.3_p2-r1-ls145
     environment:
       - PUBLIC_KEY_FILE=/test_key.pub
       - SUDO_ACCESS=false


### PR DESCRIPTION
# Description

- There seem to be some changes made in the latest docker image which was published 4 days back. I tried with an older image [9.3_p2-r1-ls145](https://hub.docker.com/layers/linuxserver/openssh-server/9.3_p2-r1-ls145/images/sha256-518b05c43d45a515f5e78b3f822f25884afd2ddfa396ff430e6fb1ed7dd8ad02?context=explore) and it's working there.

## Linear Ticket

- Resolves PIPE-966

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
