### PR TITLE
chore: configure histogram buckets and add sourceId label on event_delivery_time metric

### DIFF
--- a/router/batchrouter/handle_observability.go
+++ b/router/batchrouter/handle_observability.go
@@ -192,7 +192,7 @@ func (brt *Handle) recordUploadStats(destination Connection, output UploadResult
 			"destType":    brt.destType,
 			"destination": destinationTag,
 			"workspaceId": destination.Source.WorkspaceID,
-			"sourceId":      destination.Source.ID,
+			"sourceId":    destination.Source.ID,
 		})
 		eventDeliveryTimeStat.SendTiming(time.Since(receivedTime))
 	}

--- a/router/batchrouter/handle_observability.go
+++ b/router/batchrouter/handle_observability.go
@@ -188,11 +188,12 @@ func (brt *Handle) recordUploadStats(destination Connection, output UploadResult
 
 	if receivedTime, err := time.Parse(misc.RFC3339Milli, output.FirstEventAt); err == nil {
 		eventDeliveryTimeStat := stats.Default.NewTaggedStat("event_delivery_time", stats.TimerType, map[string]string{
-			"module":      "batch_router",
-			"destType":    brt.destType,
-			"destination": destinationTag,
-			"workspaceId": destination.Source.WorkspaceID,
-			"sourceId":    destination.Source.ID,
+			"module":        "batch_router",
+			"destType":      brt.destType,
+			"destination":   destinationTag,
+			"workspaceId":   destination.Source.WorkspaceID,
+			"sourceId":      destination.Source.ID,
+			"destinationId": destination.Destination.ID,
 		})
 		eventDeliveryTimeStat.SendTiming(time.Since(receivedTime))
 	}

--- a/router/batchrouter/handle_observability.go
+++ b/router/batchrouter/handle_observability.go
@@ -192,6 +192,7 @@ func (brt *Handle) recordUploadStats(destination Connection, output UploadResult
 			"destType":    brt.destType,
 			"destination": destinationTag,
 			"workspaceId": destination.Source.WorkspaceID,
+			"sourceId":      destination.Source.ID,
 		})
 		eventDeliveryTimeStat.SendTiming(time.Since(receivedTime))
 	}

--- a/router/worker.go
+++ b/router/worker.go
@@ -1083,6 +1083,7 @@ func (w *worker) sendEventDeliveryStat(destinationJobMetadata *types.JobMetadata
 						"destID":      destination.ID,
 						"destination": destinationTag,
 						"workspaceId": status.WorkspaceId,
+						"sourceId":    destinationJobMetadata.SourceID,
 					})
 
 				eventsDeliveryTimeStat.SendTiming(time.Since(receivedTime))

--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -21,3 +21,10 @@ var customBuckets = map[string][]float64{
 		86400, 432000, 864000, 2592000, 5184000, 7776000, 15552000, 31104000, // 1 day, 5 days, 10 days, 30 days, 60 days, 90 days, 180 days, 360 days
 	},
 }
+
+var customBucketsServer = map[string][]float64{
+	"event_delivery_time": {
+		0.5, 1, 2.5, 5, 10, 30, 60, 300 /* 5 minutes */, 600 /* 10 minutes */, 1800, /* 30 minutes */
+		3600 /* 1 hour */, 10800 /* 3 hours */, 21600 /* 6 hours */, 86400, /* 1 day */
+	},
+}

--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -20,4 +20,8 @@ var customBuckets = map[string][]float64{
 	"gateway.user_suppression_age": {
 		86400, 432000, 864000, 2592000, 5184000, 7776000, 15552000, 31104000, // 1 day, 5 days, 10 days, 30 days, 60 days, 90 days, 180 days, 360 days
 	},
+	"event_delivery_time": {
+		0.5, 1, 2.5, 5, 10, 30, 60, 300 /* 5 minutes */, 600 /* 10 minutes */, 1800, /* 30 minutes */
+		3600 /* 1 hour */, 10800 /* 3 hours */, 21600 /* 6 hours */, 86400, /* 1 day */
+	},
 }

--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -20,8 +20,4 @@ var customBuckets = map[string][]float64{
 	"gateway.user_suppression_age": {
 		86400, 432000, 864000, 2592000, 5184000, 7776000, 15552000, 31104000, // 1 day, 5 days, 10 days, 30 days, 60 days, 90 days, 180 days, 360 days
 	},
-	"event_delivery_time": {
-		0.5, 1, 2.5, 5, 10, 30, 60, 300 /* 5 minutes */, 600 /* 10 minutes */, 1800, /* 30 minutes */
-		3600 /* 1 hour */, 10800 /* 3 hours */, 21600 /* 6 hours */, 86400, /* 1 day */
-	},
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -113,9 +113,8 @@ func (r *Runner) Run(ctx context.Context, args []string) int {
 		statsOptions = append(statsOptions, stats.WithDefaultHistogramBuckets(defaultWarehouseHistogramBuckets))
 	} else {
 		statsOptions = append(statsOptions, stats.WithDefaultHistogramBuckets(defaultHistogramBuckets))
-		customBuckets["event_delivery_time"] = []float64{
-			0.5, 1, 2.5, 5, 10, 30, 60, 300 /* 5 minutes */, 600 /* 10 minutes */, 1800, /* 30 minutes */
-			3600 /* 1 hour */, 10800 /* 3 hours */, 21600 /* 6 hours */, 86400, /* 1 day */
+		for histogramName, buckets := range customBucketsServer {
+			statsOptions = append(statsOptions, stats.WithHistogramBuckets(histogramName, buckets))
 		}
 	}
 	for histogramName, buckets := range customBuckets {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -113,6 +113,10 @@ func (r *Runner) Run(ctx context.Context, args []string) int {
 		statsOptions = append(statsOptions, stats.WithDefaultHistogramBuckets(defaultWarehouseHistogramBuckets))
 	} else {
 		statsOptions = append(statsOptions, stats.WithDefaultHistogramBuckets(defaultHistogramBuckets))
+		customBuckets["event_delivery_time"] = []float64{
+			0.5, 1, 2.5, 5, 10, 30, 60, 300 /* 5 minutes */, 600 /* 10 minutes */, 1800, /* 30 minutes */
+			3600 /* 1 hour */, 10800 /* 3 hours */, 21600 /* 6 hours */, 86400, /* 1 day */
+		}
 	}
 	for histogramName, buckets := range customBuckets {
 		statsOptions = append(statsOptions, stats.WithHistogramBuckets(histogramName, buckets))


### PR DESCRIPTION
# Description
- As part of the [delays project](https://www.notion.so/rudderstacks/End-to-End-Delays-in-Pipeline-362b6fe1e3b148c68aa538670d2a60da), we are planning to show end-to-end delay in pipeline to customers on webapp. As part of this PR we are making 2 changes
  - Tweak the histogram buckets on `event_delivery_time` metric
  - Add `sourceId` label on `event_delivery_time` metric
  
- On destination page, we are planning to show end-to-end delay for a selected connection or delay across all sources connected to a destination

## Linear Ticket

- https://linear.app/rudderstack/issue/OBS-428/tweak-buckets-on-histogram-metric-event-delivery-time-bucket

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

completes OBS-428
