### PR TITLE
chore: group minor, patch dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,32 @@ updates:
     directory: "/" 
     schedule:
       interval: "daily"
+    groups:
+      go-deps:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/" 
     schedule:
       interval: "daily"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "docker"
     directory: "/" 
     schedule:
       interval: "daily"
+    groups:
+      docker-deps:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
# Description

Group minor, patch updates in go package, docker and github actions.
Any major upgrade can be dealt with separately.

## Linear Ticket

[context](https://rudderlabs.slack.com/archives/C01HTT66UMB/p1712768198567829)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
