### PR TITLE
fix: actions cancelling on push to master

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -9,7 +9,7 @@ on:
       - main
   pull_request:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 env:
   arch_amd64: amd64

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ on:
       - "release/*"
   pull_request:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 jobs:
   integration:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,7 +8,7 @@ on:
       - main
   pull_request:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 jobs:
   generate:


### PR DESCRIPTION
# Description

Our earlier change was cancelling actions in progress.
[That change](https://github.com/rudderlabs/rudder-server/pull/4573) was unwittingly cancelling runs on push to master as well. 
IMO, it's nice to have this suite run for every commit to master without cancelling.
<img width="1061" alt="image" src="https://github.com/rudderlabs/rudder-server/assets/82795818/9f68c516-2368-4c09-948e-73f26e4fd531">

On push to master `github.head_ref` would be empty, so one way to group the workflows would be by falling back on commit hash - `github.sha`.

Alternatively, we could separate workflow files for `push`, `pull-request` for simplicity and not have concurrency groups in `push` workflow.


## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
