### PR TITLE
feat: add transform function to async destination manager

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/bing-ads/bulk_uploader.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/bulk_uploader.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 	router_utils "github.com/rudderlabs/rudder-server/router/utils"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -27,6 +28,10 @@ func NewBingAdsBulkUploader(destName string, service bingads.BulkServiceI, clien
 		fileSizeLimit: common.GetBatchRouterConfigInt64("MaxUploadLimit", destName, 100*bytesize.MB),
 		eventsLimit:   common.GetBatchRouterConfigInt64("MaxEventsLimit", destName, 4000000),
 	}
+}
+
+func (b *BingAdsBulkUploader) Transform(job *jobsdb.JobT) (string, error) {
+	return common.GetMarshalledData(job), nil
 }
 
 /*

--- a/router/batchrouter/asyncdestinationmanager/common/manager.go
+++ b/router/batchrouter/asyncdestinationmanager/common/manager.go
@@ -1,10 +1,17 @@
 package common
 
 import (
+	"errors"
 	"fmt"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
 )
 
 type InvalidManager struct{}
+
+func (f *InvalidManager) Transform(job *jobsdb.JobT) (string, error) {
+	return "", errors.New("invalid job")
+}
 
 func (f *InvalidManager) Upload(asyncDestStruct *AsyncDestinationStruct) AsyncUploadOutput {
 	abortedJobIDs := append(asyncDestStruct.ImportingJobIDs, asyncDestStruct.FailedJobIDs...)

--- a/router/batchrouter/asyncdestinationmanager/eloqua/bulk_uploader.go
+++ b/router/batchrouter/asyncdestinationmanager/eloqua/bulk_uploader.go
@@ -10,6 +10,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 )
 
@@ -21,6 +22,10 @@ func (b *EloquaBulkUploader) createAsyncUploadErrorOutput(errorString string, er
 		FailedCount:   len(asyncDestStruct.FailedJobIDs) + len(asyncDestStruct.ImportingJobIDs),
 		DestinationID: destinationId,
 	}
+}
+
+func (b *EloquaBulkUploader) Transform(job *jobsdb.JobT) (string, error) {
+	return common.GetMarshalledData(job), nil
 }
 
 func (b *EloquaBulkUploader) Upload(asyncDestStruct *common.AsyncDestinationStruct) common.AsyncUploadOutput {

--- a/router/batchrouter/asyncdestinationmanager/manager.go
+++ b/router/batchrouter/asyncdestinationmanager/manager.go
@@ -14,21 +14,6 @@ import (
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
-func GetMarshalledData(payload string, jobID int64) string {
-	var job common.AsyncJob
-	err := json.Unmarshal([]byte(payload), &job.Message)
-	if err != nil {
-		panic("Unmarshalling Transformer Response Failed")
-	}
-	job.Metadata = make(map[string]interface{})
-	job.Metadata["job_id"] = jobID
-	responsePayload, err := json.Marshal(job)
-	if err != nil {
-		panic("Marshalling Response Payload Failed")
-	}
-	return string(responsePayload)
-}
-
 func NewManager(destination *backendconfig.DestinationT, backendConfig backendconfig.BackendConfig) (common.AsyncDestinationManager, error) {
 	switch destination.DestinationDefinition.Name {
 	case "BINGADS_AUDIENCE":

--- a/router/batchrouter/asyncdestinationmanager/marketo-bulk-upload/marketobulkupload.go
+++ b/router/batchrouter/asyncdestinationmanager/marketo-bulk-upload/marketobulkupload.go
@@ -227,6 +227,10 @@ func extractJobStats(keyMap map[string]interface{}, importingJobIDs []int64, sta
 	return succesfulJobIDs, failedJobIDsTrans
 }
 
+func (b *MarketoBulkUploader) Transform(job *jobsdb.JobT) (string, error) {
+	return common.GetMarshalledData(job), nil
+}
+
 func (b *MarketoBulkUploader) Upload(asyncDestStruct *common.AsyncDestinationStruct) common.AsyncUploadOutput {
 	destination := asyncDestStruct.Destination
 	destinationID := destination.ID


### PR DESCRIPTION
# Description
add transform function to async destination manager to support custom transformation logic before creating file for async destinations


## Linear Ticket

https://linear.app/rudderstack/issue/INT-1922/rudder-server-changes-in-async-destination-to-deliver-events
Resolves INT-1922

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
