### PR TITLE
feat: append only tables for redshift

### DIFF
--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/runner"
 	th "github.com/rudderlabs/rudder-server/testhelper"
@@ -1039,6 +1040,113 @@ func TestIntegration(t *testing.T) {
 			require.False(t, tableExists(t))
 		})
 	})
+}
+
+func TestRedshift_ShouldMerge(t *testing.T) {
+	testCases := []struct {
+		name              string
+		preferAppend      bool
+		tableName         string
+		appendOnlyTables  []string
+		uploaderCanAppend bool
+		expected          bool
+	}{
+		{
+			name:              "uploader says we can append and user prefers append",
+			preferAppend:      true,
+			uploaderCanAppend: true,
+			tableName:         "tracks",
+			expected:          false,
+		},
+		{
+			name:              "uploader says we cannot append and user prefers append",
+			preferAppend:      true,
+			uploaderCanAppend: false,
+			tableName:         "tracks",
+			expected:          true,
+		},
+		{
+			name:              "uploader says we can append and user prefers not to append",
+			preferAppend:      false,
+			uploaderCanAppend: true,
+			tableName:         "tracks",
+			expected:          true,
+		},
+		{
+			name:              "uploader says we cannot append and user prefers not to append",
+			preferAppend:      false,
+			uploaderCanAppend: false,
+			tableName:         "tracks",
+			expected:          true,
+		},
+		{
+			name:              "uploader says we can append, in merge mode, but table is in append only",
+			preferAppend:      false,
+			uploaderCanAppend: true,
+			tableName:         "tracks",
+			appendOnlyTables:  []string{"tracks"},
+			expected:          false,
+		},
+		{
+			name:              "uploader says we can append, in append mode, but table is in append only",
+			preferAppend:      true,
+			uploaderCanAppend: true,
+			tableName:         "tracks",
+			appendOnlyTables:  []string{"tracks"},
+			expected:          false,
+		},
+		{
+			name:              "uploader says we can append, in append mode, but table is not in append only",
+			preferAppend:      true,
+			uploaderCanAppend: true,
+			tableName:         "page_views",
+			appendOnlyTables:  []string{"tracks"},
+			expected:          false,
+		},
+		{
+			name:              "uploader says we cannot append, in merge mode, but table is in append only",
+			preferAppend:      false,
+			uploaderCanAppend: false,
+			tableName:         "tracks",
+			appendOnlyTables:  []string{"tracks"},
+			expected:          false,
+		},
+		{
+			name:              "uploader says we can append, in merge mode, but table is not in append only",
+			preferAppend:      false,
+			uploaderCanAppend: true,
+			tableName:         "page_views",
+			appendOnlyTables:  []string{"tracks"},
+			expected:          true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			destID := "test_destination_id"
+
+			c := config.New()
+			c.Set("Warehouse.redshift.appendOnlyTables."+destID, tc.appendOnlyTables)
+
+			rs := redshift.New(c, logger.NOP, stats.NOP)
+
+			rs.Warehouse = model.Warehouse{
+				Destination: backendconfig.DestinationT{
+					ID: destID,
+					Config: map[string]any{
+						model.PreferAppendSetting.String(): tc.preferAppend,
+					},
+				},
+			}
+
+			mockCtrl := gomock.NewController(t)
+			uploader := mockuploader.NewMockUploader(mockCtrl)
+			uploader.EXPECT().CanAppend().AnyTimes().Return(tc.uploaderCanAppend)
+
+			rs.Uploader = uploader
+			require.Equal(t, rs.ShouldMerge(tc.tableName), tc.expected)
+		})
+	}
 }
 
 func TestCheckAndIgnoreColumnAlreadyExistError(t *testing.T) {

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/client"
 	sqlmw "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"


### PR DESCRIPTION
# Description

- Introducing append-only table for redshift at the table level same as we have for [Snowflake](https://github.com/rudderlabs/rudder-server/blob/c7398deb820ad4a1f0f51d3d150f36cd5426b80c/warehouse/integrations/snowflake/snowflake.go#L192) but at a granularity for `destinationID`.
- For setting this, we would need something like:
  ```
  serverConfigOverride:
    Warehouse:
      redshift:
        appendOnlyTables:
          destinationID:
            - tracks
            - identifies
  ```

## Linear Ticket

- Resolves PIPE-1021, PIPE-1020

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
