### PR TITLE
fix: correctly quote connection on subscription creation

### DIFF
--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -726,7 +726,7 @@ func (sh *sourcesHandler) setupLogicalReplication(ctx context.Context) error {
 	if subscriptionConn == "" {
 		subscriptionConn = sh.config.LocalConn
 	}
-	subscriptionQuery := fmt.Sprintf(`CREATE SUBSCRIPTION "%s" CONNECTION '%s' PUBLICATION "rsources_stats_pub"`, subscriptionName, subscriptionConn) // skipcq: GO-R4002
+	subscriptionQuery := fmt.Sprintf(`CREATE SUBSCRIPTION "%s" CONNECTION %s PUBLICATION "rsources_stats_pub"`, subscriptionName, pq.QuoteLiteral(subscriptionConn)) // skipcq: GO-R4002
 	if _, err := sh.sharedDB.ExecContext(ctx, subscriptionQuery); err != nil {
 		pqError, ok := err.(*pq.Error)
 		if !ok || pqError.Code != pq.ErrorCode("42710") { // duplicate

--- a/services/rsources/handler_test.go
+++ b/services/rsources/handler_test.go
@@ -1585,7 +1585,7 @@ func newDBResource(pool *dockertest.Pool, networkId, hostname string, params ...
 	internalDSN := fmt.Sprintf("postgres://%[1]s:%[2]s@%[3]s:5432/%[4]s?sslmode=disable", username, password, hostname, database)
 	var (
 		db  *sql.DB
-		dsn = fmt.Sprintf("host=localhost port=%[1]s user=%[2]s password=%[3]s dbname=%[4]s sslmode=disable", port, username, password, database)
+		dsn = fmt.Sprintf("host=localhost port=%[1]s user=%[2]s password=%[3]s dbname=%[4]s sslmode=disable options='-c idle_in_transaction_session_timeout=300000' ", port, username, password, database)
 	)
 	// exponential backoff-retry, because the application in the container might not be ready to accept connections yet
 	if err := pool.Retry(func() (err error) {


### PR DESCRIPTION
# Description


### Issue 
The issue triggered by this change https://github.com/rudderlabs/rudder-server/pull/4598, when deployed to free users.

The underlaying cause was that we didn't properly escaping the connection info string passed to the query. The new connection query contained `'`, causing the parsing to break and the following error to happen:

```
{"level":"ERROR","ts":"2024-04-23T12:27:22.674Z","logger":"runner","caller":"runner/runner.go:274","msg":"Terminal error: rudder core: logical replication in \"hostedmtedmt-v0-rs-postgresql-3.hostedmtedmt-v0-rs-postgresql-headless\": failed to create subscription on shared database: pq: syntax error at or near \"-\""}
```

### Fix 
Using [pq.QuoteLiteral](https://pkg.go.dev/github.com/lib/pq#QuoteLiteral) to properly escape the connection string. 
Updated the test to contain the `options='-c idle_in_transaction_session_timeout=300000'`

### TODOs

* Refactor the test to use rudder-go-kit resource
* Use the misc.GetConnectionString instead of hardcoding `options='-c idle_in_transaction_session_timeout=300000` in tests
* Integration test with sharedDB

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1031/fix-correctly-quote-connection-on-subscription-creation

fixes PIPE-1031 

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
