### PR TITLE
chore: add error logs for oauthv2 errors

### DIFF
--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -1259,8 +1259,8 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 			},
 			RespBodys:       map[int64]string{},
 			RespContentType: "text/plain; charset=utf-8",
-			// Originally Response Body will look like this "Post \"http://<TF_SERVER>/v1/destinations/salesforce_oauth/proxy\": getting auth error category: LB cannot send to transformer"
-			ProxyRequestResponseBody: `getting auth error category: LB cannot send to transformer`,
+			// Originally Response Body will look like this "Post \"http://<TF_SERVER>/v1/destinations/salesforce_oauth/proxy\": getting auth error category post roundTrip: LB cannot send to transformer"
+			ProxyRequestResponseBody: `getting auth error category post roundTrip: LB cannot send to transformer`,
 			ProxyRequestStatusCode:   500,
 			RespStatusCodes:          map[int64]int{},
 		},

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -1208,8 +1208,8 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 			},
 			RespBodys:       map[int64]string{},
 			RespContentType: "text/plain; charset=utf-8",
-			// Originally Response Body will look like this "Post \"http://<TF_SERVER>/v1/destinations/salesforce_oauth/proxy\": getting auth error category: LB cannot send to transformer"
-			ProxyRequestResponseBody: `getting auth error category: LB cannot send to transformer`,
+			// Originally Response Body will look like this "Post \"http://<TF_SERVER>/v1/destinations/salesforce_oauth/proxy\": getting auth error category post roundTrip: LB cannot send to transformer"
+			ProxyRequestResponseBody: `getting auth error category post roundTrip: LB cannot send to transformer`,
 			ProxyRequestStatusCode:   500,
 			RespStatusCodes:          map[int64]int{},
 		},

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -1152,7 +1152,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 			},
 			RespBodys:                map[int64]string{},
 			RespContentType:          "text/plain; charset=utf-8",
-			ProxyRequestResponseBody: `reading response body post RoundTrip: unexpected EOF`, // not full error message
+			ProxyRequestResponseBody: `reading response body post roundTrip: unexpected EOF`, // not full error message
 			ProxyRequestStatusCode:   500,
 			RespStatusCodes:          map[int64]int{},
 		},

--- a/services/oauth/v2/http/transport.go
+++ b/services/oauth/v2/http/transport.go
@@ -94,7 +94,7 @@ func (t *OAuthTransport) preRoundTrip(rts *roundTripState) *http.Response {
 	}
 	body, err := io.ReadAll(rts.req.Body)
 	if err != nil {
-		t.log.Errorn("reading request body",
+		t.log.Errorn("reading request body pre roundTrip",
 			obskit.DestinationID(rts.destination.ID),
 			obskit.WorkspaceID(rts.destination.WorkspaceID),
 			obskit.DestinationType(rts.destination.DefinitionName),
@@ -106,8 +106,11 @@ func (t *OAuthTransport) preRoundTrip(rts *roundTripState) *http.Response {
 		rts.req = rts.req.WithContext(cntx.CtxWithSecret(rts.req.Context(), authResponse.Account.Secret))
 		err = t.Augmenter.Augment(rts.req, body, authResponse.Account.Secret)
 		if err != nil {
-			t.log.Debugn("augmenting the secret",
-				logger.NewErrorField(err))
+			t.log.Errorn(fmt.Sprintf("augmenting the secret pre roundTrip: %s", err.Error()),
+				obskit.DestinationID(rts.destination.ID),
+				obskit.WorkspaceID(rts.destination.WorkspaceID),
+				obskit.DestinationType(rts.destination.DefinitionName),
+				logger.NewStringField("flow", string(t.flow)))
 			return httpResponseCreator(http.StatusInternalServerError, []byte(fmt.Errorf("augmenting the secret pre roundTrip: %w", err).Error()))
 		}
 		return nil
@@ -127,7 +130,12 @@ func (t *OAuthTransport) preRoundTrip(rts *roundTripState) *http.Response {
 func (t *OAuthTransport) postRoundTrip(rts *roundTripState) (*http.Response, error) {
 	respData, err := io.ReadAll(rts.res.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading response body post RoundTrip: %w", err)
+		t.log.Errorn(fmt.Sprintf("reading response body post roundTrip: %s", err.Error()),
+			obskit.DestinationID(rts.destination.ID),
+			obskit.WorkspaceID(rts.destination.WorkspaceID),
+			obskit.DestinationType(rts.destination.DefinitionName),
+			logger.NewStringField("flow", string(t.flow)))
+		return nil, fmt.Errorf("reading response body post roundTrip: %w", err)
 	}
 	interceptorResp := oauth.OAuthInterceptorResponse{}
 	// internal function
@@ -142,14 +150,24 @@ func (t *OAuthTransport) postRoundTrip(rts *roundTripState) (*http.Response, err
 	}
 	authErrorCategory, err := t.getAuthErrorCategory(respData)
 	if err != nil {
-		return nil, fmt.Errorf("getting auth error category: %s", string(respData))
+		t.log.Errorn(fmt.Sprintf("getting auth error category post roundTrip: %s", string(respData)),
+			obskit.DestinationID(rts.destination.ID),
+			obskit.WorkspaceID(rts.destination.WorkspaceID),
+			obskit.DestinationType(rts.destination.DefinitionName),
+			logger.NewStringField("flow", string(t.flow)))
+		return nil, fmt.Errorf("getting auth error category post roundTrip: %s", string(respData))
 	}
 	if authErrorCategory == common.CategoryRefreshToken {
 		// since same token that was used to make the http call needs to be refreshed, we need the current token information
 		var oldSecret json.RawMessage
 		oldSecret, ok := cntx.SecretFromCtx(rts.req.Context())
 		if !ok {
-			return nil, fmt.Errorf("getting secret from context")
+			t.log.Errorn("getting secret from context post roundTrip",
+				obskit.DestinationID(rts.destination.ID),
+				obskit.WorkspaceID(rts.destination.WorkspaceID),
+				obskit.DestinationType(rts.destination.DefinitionName),
+				logger.NewStringField("flow", string(t.flow)))
+			return nil, fmt.Errorf("getting secret from context post roundTrip")
 		}
 		rts.refreshTokenParams.Secret = oldSecret
 		rts.refreshTokenParams.Destination = rts.destination
@@ -212,9 +230,11 @@ func (t *OAuthTransport) fireTimerStats(statName string, tags stats.Tags, startT
 func (t *OAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	destination, ok := cntx.DestInfoFromCtx(req.Context())
 	if !ok {
-		return httpResponseCreator(http.StatusInternalServerError, []byte("the consent data is not of destinationInfo type")), nil
+		t.log.Errorn("request context data is not of destinationInfo type", logger.NewStringField("flow", string(t.flow)))
+		return httpResponseCreator(http.StatusInternalServerError, []byte("request context data is not of destinationInfo type")), nil
 	}
 	if destination == nil {
+		t.log.Errorn("no destination found in context of the request", logger.NewStringField("flow", string(t.flow)))
 		return httpResponseCreator(http.StatusInternalServerError, []byte("no destination found in context of the request")), nil
 	}
 


### PR DESCRIPTION
# Description

We want to add logs for errors in oauthv2 implementation. These errors are platform and not user actionable.

## Linear Ticket

Resolves INT-2041

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
