### PR TITLE
chore: ensure health endpoint backwards compatibility

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -165,7 +165,7 @@ func getHealthVal(jobsDB jobsdb.JobsDB) (bool, string) {
 
 	appTypeStr := strings.ToUpper(config.GetString("APP_TYPE", EMBEDDED))
 	return healthy, fmt.Sprintf(
-		`{"appType":"%s","server":"UP","db":"%s","acceptingEvents":"TRUE","routingEvents":"TRUE","mode":"%s",`+
+		`{"appType":"%s","server":"UP","db":"%s","acceptingEvents":"TRUE","routingEvents":"%s","mode":"NORMAL",`+
 			`"backendConfigMode":"%s","lastSync":"%s","lastRegulationSync":"%s"}`,
 		appTypeStr, dbService, enabledRouter,
 		backendConfigMode, backendconfig.LastSync, backendconfig.LastRegulationSync,

--- a/app/app.go
+++ b/app/app.go
@@ -165,7 +165,7 @@ func getHealthVal(jobsDB jobsdb.JobsDB) (bool, string) {
 
 	appTypeStr := strings.ToUpper(config.GetString("APP_TYPE", EMBEDDED))
 	return healthy, fmt.Sprintf(
-		`{"appType":"%s","server":"UP","db":"%s","acceptingEvents":"TRUE","mode":"%s",`+
+		`{"appType":"%s","server":"UP","db":"%s","acceptingEvents":"TRUE","routingEvents":"TRUE","mode":"%s",`+
 			`"backendConfigMode":"%s","lastSync":"%s","lastRegulationSync":"%s"}`,
 		appTypeStr, dbService, enabledRouter,
 		backendConfigMode, backendconfig.LastSync, backendconfig.LastRegulationSync,


### PR DESCRIPTION
# Description

This PR introduced a breaking change for the health endpoint https://github.com/rudderlabs/rudder-server/pull/4584/files#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R168

Thus hard-coding the routingEvents to always true, since we remove recovery on rudder-server.

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1033/health-endpoint-backwards-compatibility

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
