### PR TITLE
chore: use uuid for archival files to avoid conflicts

### DIFF
--- a/archiver/worker.go
+++ b/archiver/worker.go
@@ -8,6 +8,8 @@ import (
 	"path"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 
@@ -153,7 +155,7 @@ func (w *worker) uploadJobs(ctx context.Context, jobs []*jobsdb.JobT) (string, e
 		lo.Must(misc.CreateTMPDIR()),
 		"rudder-backups",
 		w.sourceID,
-		fmt.Sprintf("%d_%d_%s.json.gz", firstJobCreatedAt.Unix(), lastJobCreatedAt.Unix(), workspaceID),
+		fmt.Sprintf("%d_%d_%s_%s.json.gz", firstJobCreatedAt.Unix(), lastJobCreatedAt.Unix(), workspaceID, uuid.NewString()),
 	)
 
 	for _, job := range jobs {


### PR DESCRIPTION
# Description

Adding a uuid suffix for archival files to avoid conflicts while uploading same files

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1059/use-uuid-for-archival-files-to-avoid-conflicts

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
