### PR TITLE
chore: cleanup *jobsdb.Handle.checkIfFullDSInTx(...)

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1190,21 +1190,21 @@ func (jd *Handle) doRefreshDSRangeList(l lock.LockToken) error {
 	return nil
 }
 
-func (jd *Handle) getTableRowCount(jobTable string) int {
+func (jd *Handle) getTableRowCount(tx *Tx, jobTable string) int {
 	var count int
 
 	sqlStatement := fmt.Sprintf(`SELECT COUNT(*) from %q`, jobTable)
-	row := jd.dbHandle.QueryRow(sqlStatement)
+	row := tx.QueryRow(sqlStatement)
 	err := row.Scan(&count)
 	jd.assertError(err)
 	return count
 }
 
-func (jd *Handle) getTableSize(jobTable string) int64 {
+func (jd *Handle) getTableSize(tx *Tx, jobTable string) int64 {
 	var tableSize int64
 
 	sqlStatement := fmt.Sprintf(`SELECT PG_TOTAL_RELATION_SIZE('%s')`, jobTable)
-	row := jd.dbHandle.QueryRow(sqlStatement)
+	row := tx.QueryRow(sqlStatement)
 	err := row.Scan(&tableSize)
 	jd.assertError(err)
 	return tableSize
@@ -1213,26 +1213,29 @@ func (jd *Handle) getTableSize(jobTable string) int64 {
 func (jd *Handle) checkIfFullDSInTx(tx *Tx, ds dataSetT) (bool, error) {
 	if jd.conf.maxDSRetentionPeriod.Load() > 0 {
 		var minJobCreatedAt sql.NullTime
-		sqlStatement := fmt.Sprintf(`SELECT MIN(created_at) FROM %q`, ds.JobTable)
+		sqlStatement := fmt.Sprintf(`SELECT created_at FROM %q ORDER BY job_id ASC LIMIT 1`, ds.JobTable)
 		row := tx.QueryRow(sqlStatement)
 		err := row.Scan(&minJobCreatedAt)
-		if err != nil && err != sql.ErrNoRows {
-			return false, err
+		if err != nil {
+			if !errors.Is(err, sql.ErrNoRows) {
+				return false, err
+			}
+			return false, nil
 		}
-		if err == nil && minJobCreatedAt.Valid && time.Since(minJobCreatedAt.Time) > jd.conf.maxDSRetentionPeriod.Load() {
+		if minJobCreatedAt.Valid && time.Since(minJobCreatedAt.Time) > jd.conf.maxDSRetentionPeriod.Load() {
 			return true, nil
 		}
 	}
 
-	tableSize := jd.getTableSize(ds.JobTable)
+	tableSize := jd.getTableSize(tx, ds.JobTable)
+	totalCount := jd.getTableRowCount(tx, ds.JobTable)
 	if tableSize > jd.conf.maxTableSize.Load() {
-		jd.logger.Infof("[JobsDB] %s is full in size. Count: %v, Size: %v", ds.JobTable, jd.getTableRowCount(ds.JobTable), tableSize)
+		jd.logger.Infof("[JobsDB] %s is full in size. Count: %v, Size: %v", ds.JobTable, totalCount, tableSize)
 		return true, nil
 	}
 
-	totalCount := jd.getTableRowCount(ds.JobTable)
 	if totalCount > jd.conf.MaxDSSize.Load() {
-		jd.logger.Infof("[JobsDB] %s is full by rows. Count: %v, Size: %v", ds.JobTable, totalCount, jd.getTableSize(ds.JobTable))
+		jd.logger.Infof("[JobsDB] %s is full by rows. Count: %v, Size: %v", ds.JobTable, totalCount, tableSize)
 		return true, nil
 	}
 

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1216,11 +1216,10 @@ func (jd *Handle) checkIfFullDSInTx(tx *Tx, ds dataSetT) (bool, error) {
 		sqlStatement := fmt.Sprintf(`SELECT created_at FROM %q ORDER BY job_id ASC LIMIT 1`, ds.JobTable)
 		row := tx.QueryRow(sqlStatement)
 		err := row.Scan(&minJobCreatedAt)
-		if err != nil {
-			if !errors.Is(err, sql.ErrNoRows) {
-				return false, err
-			}
+		if errors.Is(err, sql.ErrNoRows) {
 			return false, nil
+		} else if err != nil {
+			return false, err
 		}
 		if minJobCreatedAt.Valid && time.Since(minJobCreatedAt.Time) > jd.conf.maxDSRetentionPeriod.Load() {
 			return true, nil


### PR DESCRIPTION
# Description

Minor cleanup in jobsdb's `checkIfFullDSInTx` method.
1. Using a better query imo to get min `created_at`
2. Use the transaction to fetch required info(because why use another conn)
3. return early if `sql.ErrNoRows`
4. query only once for row count and table size

## Benefits of changing the query:

##### explain analyze select created_at from gw_jobs_132478 order by job_id asc limit 1;
```
Limit  (cost=0.29..0.56 rows=1 width=16) (actual time=0.013..0.013 rows=1 loops=1)
  ->  Index Scan using gw_jobs_132478_pkey on gw_jobs_132478  (cost=0.29..26637.24 rows=100258 width=16) (actual time=0.012..0.012 rows=1 loops=1)
Planning Time: 0.048 ms
Execution Time: 0.022 ms
```

##### explain analyze select min(created_at) from gw_jobs_132478;
```
Aggregate  (cost=25277.23..25277.24 rows=1 width=8) (actual time=56.690..56.691 rows=1 loops=1)
  ->  Seq Scan on gw_jobs_132478  (cost=0.00..25026.58 rows=100258 width=8) (actual time=0.022..48.656 rows=100265 loops=1)
Planning Time: 0.062 ms
Execution Time: 56.706 ms
```
Above analyze result from `wyze-postgres-0` on `2024-05-03 1230IST`.

## Linear Ticket

misc: [Resolves PIPE-1072](https://linear.app/rudderstack/issue/PIPE-1072/misc)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
