### PR TITLE
fix: response handling for proxy v1 when oauthv2 is enabled

### DIFF
--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-server/processor/integrations"
+	"github.com/rudderlabs/rudder-server/services/oauth/v2/common"
 )
 
 type transformerProxyAdapter interface {
@@ -164,6 +165,9 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 
 	for _, resp := range transformerResponse.Response {
 		routerJobResponseCodes[resp.Metadata.JobID] = resp.StatusCode
+		if transformerResponse.AuthErrorCategory == common.CategoryRefreshToken {
+			routerJobResponseCodes[resp.Metadata.JobID] = respCode
+		}
 		routerJobResponseBodys[resp.Metadata.JobID] = resp.Error
 		routerJobDontBatchDirectives[resp.Metadata.JobID] = resp.Metadata.DontBatch
 	}

--- a/router/worker.go
+++ b/router/worker.go
@@ -799,9 +799,6 @@ func (w *worker) proxyRequest(ctx context.Context, destinationJob types.Destinat
 
 		proxyRequestResponse.RespStatusCodes, proxyRequestResponse.RespBodys = w.prepareResponsesForJobs(&destinationJob, respStatusCode, respBodyTemp)
 		proxyRequestResponse.RespContentType = contentType
-	} else if oauthV2Enabled {
-		proxyRequestResponse.RespStatusCodes, proxyRequestResponse.RespBodys = w.prepareResponsesForJobs(&destinationJob, proxyRequestResponse.ProxyRequestStatusCode, proxyRequestResponse.ProxyRequestResponseBody)
-		proxyRequestResponse.RespContentType = http.DetectContentType([]byte(proxyRequestResponse.ProxyRequestResponseBody))
 	}
 	return proxyRequestResponse
 }


### PR DESCRIPTION
# Description

< Replace with adequate description for this PR as per [Pull Request document](https://www.notion.so/rudderstacks/Pull-Requests-40a4c6bd7a5e4387ba9029bab297c9e3) >

## Linear Ticket

< Replace with Linear Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
