### PR TITLE
bug: ack cumulative on pulsar

### DIFF
--- a/cmd/ack/ack_test.go
+++ b/cmd/ack/ack_test.go
@@ -28,7 +28,7 @@ func TestCumulativeAck(t *testing.T) {
 
 	log := logger.NOP
 	if testing.Verbose() {
-		// Uncomment the next 2 lines to enable DEBUG logging
+		// Uncomment the next 3 lines to enable DEBUG logging
 		// factory := logger.NewFactory(config.New())
 		// require.NoError(t, factory.SetLogLevel("", "DEBUG"))
 		// log = factory.NewLogger()

--- a/cmd/ack/ack_test.go
+++ b/cmd/ack/ack_test.go
@@ -1,0 +1,165 @@
+package ack
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/apache/pulsar-client-go/pulsar"
+	pulsarlog "github.com/apache/pulsar-client-go/pulsar/log"
+	"github.com/apache/pulsar-client-go/pulsaradmin"
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
+	"github.com/ory/dockertest/v3"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	pulsardocker "github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/pulsar"
+)
+
+func TestCumulativeAck(t *testing.T) {
+	// Set up Pulsar Standalone Docker container
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	pulsarStandalone, err := pulsardocker.Setup(pool, t, pulsardocker.WithTag("3.2.2"))
+	require.NoError(t, err)
+
+	log := logger.NOP
+	if testing.Verbose() {
+		// Uncomment the next 2 lines to enable DEBUG logging
+		// factory := logger.NewFactory(config.New())
+		// require.NoError(t, factory.SetLogLevel("", "DEBUG"))
+		// log = factory.NewLogger()
+	}
+
+	pulsarClient, err := pulsar.NewClient(pulsar.ClientOptions{
+		URL:                     pulsarStandalone.URL,
+		MaxConnectionsPerBroker: 10,
+		Logger:                  &pulsarLogAdapter{Logger: log},
+	})
+	require.NoError(t, err)
+
+	// Setting up consumer
+	var (
+		topic            = "persistent://public/default/my-topic"
+		subscriptionName = "my-subscription-name"
+	)
+	consumer, err := pulsarClient.Subscribe(pulsar.ConsumerOptions{
+		Topic:                       topic,
+		SubscriptionName:            subscriptionName,
+		Type:                        pulsar.KeyShared,
+		SubscriptionInitialPosition: pulsar.SubscriptionPositionEarliest,
+		ReceiverQueueSize:           1000,
+		AckWithResponse:             true,
+	})
+	require.NoError(t, err)
+
+	// Setting up producer
+	producer, err := pulsarClient.CreateProducer(pulsar.ProducerOptions{
+		Topic: topic,
+	})
+	require.NoError(t, err)
+
+	var (
+		producerDone              = make(chan struct{})
+		producerCtx, stopProducer = context.WithCancel(context.Background())
+	)
+	defer func() {
+		stopProducer()
+		<-producerDone
+	}()
+	go func() {
+		defer close(producerDone)
+		t.Log("Starting producer...")
+		for {
+			select {
+			case <-producerCtx.Done():
+				return
+			default:
+				_, err := producer.Send(producerCtx, &pulsar.ProducerMessage{
+					Key:     "my-key",
+					Payload: []byte("hello"),
+				})
+				if err != nil {
+					if errors.Is(err, context.Canceled) {
+						t.Logf("Producer stopped: %v", err)
+						return
+					}
+					require.NoError(t, err)
+				}
+			}
+		}
+	}()
+
+	// Set up pulsar admin client to check for unacked messages
+	pulsarAdmin, err := pulsaradmin.NewClient(&pulsaradmin.Config{
+		WebServiceURL: pulsarStandalone.AdminURL,
+	})
+	require.NoError(t, err)
+	topicName, err := utils.GetTopicName(topic)
+	require.NoError(t, err)
+
+	// Set up a ticker to check the unacked messages every 10 seconds
+	ticker := time.NewTicker(10 * time.Second)
+
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				stats, err := pulsarAdmin.Topics().GetStats(*topicName)
+				require.NoError(t, err)
+
+				unackedMessages := stats.Subscriptions[subscriptionName].UnAckedMessages
+				t.Logf("UnAcked messages: %d", unackedMessages)
+			}
+		}
+	}()
+
+	// Start consuming
+	t.Log("Starting consumer...")
+	for {
+		batchBuffer, numMessages, bufferTime, ok := lo.BufferWithTimeout(consumer.Chan(), 1000, time.Second)
+		if !ok {
+			t.Log("Pulsar consumer channel closed")
+			return
+		}
+
+		t.Logf("BufferWithTimeout: %d messages, %v buffer time", numMessages, bufferTime)
+
+		if numMessages == 0 {
+			continue
+		}
+
+		lastMsg := batchBuffer[len(batchBuffer)-1]
+		t.Logf("We received %d messages. Acking last ID : %q", len(batchBuffer), lastMsg.ID())
+
+		err = consumer.AckIDCumulative(lastMsg.ID())
+		require.NoError(t, err)
+	}
+}
+
+type pulsarLogAdapter struct {
+	logger.Logger
+}
+
+func (pl *pulsarLogAdapter) SubLogger(fields pulsarlog.Fields) pulsarlog.Logger {
+	logFields := make([]logger.Field, 0, len(fields))
+	for k, v := range fields {
+		logFields = append(logFields, logger.NewField(k, v))
+	}
+	return &pulsarLogAdapter{pl.Logger.Withn(logFields...)}
+}
+
+func (pl *pulsarLogAdapter) WithFields(fields pulsarlog.Fields) pulsarlog.Entry {
+	return pl.SubLogger(fields)
+}
+
+func (pl *pulsarLogAdapter) WithField(name string, value interface{}) pulsarlog.Entry {
+	return &pulsarLogAdapter{pl.Logger.Withn(logger.NewField(name, value))}
+}
+
+func (pl *pulsarLogAdapter) WithError(err error) pulsarlog.Entry {
+	return pl.WithField("error", err)
+}

--- a/cmd/ack/ack_test.go
+++ b/cmd/ack/ack_test.go
@@ -135,6 +135,13 @@ func TestCumulativeAck(t *testing.T) {
 		lastMsg := batchBuffer[len(batchBuffer)-1]
 		t.Logf("We received %d messages. Acking last ID : %q", len(batchBuffer), lastMsg.ID())
 
+		for _, msg := range batchBuffer {
+			if msg.PublishTime().After(lastMsg.PublishTime()) {
+				t.Logf("Detected a newer message: %q", msg.ID())
+				lastMsg = msg
+			}
+		}
+
 		err = consumer.AckIDCumulative(lastMsg.ID())
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
# Description

Reproducing `AckCumulative` bug on Pulsar.

To run the test, pull the project, get into the `./cmd/ack` folder and run:

```
go test -v -count 1 -race .
```

### Example output

```
    ack_test.go:115: UnAcked messages: 43147
    ack_test.go:129: BufferWithTimeout: 729 messages, 1.000012224s buffer time
    ack_test.go:136: We received 729 messages. Acking last ID : "9:43188:0"
    ack_test.go:129: BufferWithTimeout: 730 messages, 1.000129154s buffer time
    ack_test.go:136: We received 730 messages. Acking last ID : "9:43918:0"
    ack_test.go:129: BufferWithTimeout: 722 messages, 1.00025047s buffer time
    ack_test.go:136: We received 722 messages. Acking last ID : "9:44640:0"
    ack_test.go:129: BufferWithTimeout: 731 messages, 1.000929136s buffer time
    ack_test.go:136: We received 731 messages. Acking last ID : "9:45371:0"
    ack_test.go:129: BufferWithTimeout: 734 messages, 1.000103214s buffer time
    ack_test.go:136: We received 734 messages. Acking last ID : "9:46105:0"
    ack_test.go:129: BufferWithTimeout: 729 messages, 1.000098143s buffer time
    ack_test.go:136: We received 729 messages. Acking last ID : "9:46834:0"
    ack_test.go:129: BufferWithTimeout: 741 messages, 1.000961664s buffer time
    ack_test.go:136: We received 741 messages. Acking last ID : "9:47575:0"
    ack_test.go:129: BufferWithTimeout: 718 messages, 1.00008832s buffer time
    ack_test.go:136: We received 718 messages. Acking last ID : "9:48293:0"
    ack_test.go:129: BufferWithTimeout: 729 messages, 1.000120943s buffer time
    ack_test.go:136: We received 729 messages. Acking last ID : "9:49022:0"
    ack_test.go:129: BufferWithTimeout: 734 messages, 1.000074187s buffer time
    ack_test.go:136: We received 734 messages. Acking last ID : "9:49756:0"
    ack_test.go:115: UnAcked messages: 50000
    ack_test.go:129: BufferWithTimeout: 243 messages, 1.000232772s buffer time
    ack_test.go:136: We received 243 messages. Acking last ID : "9:49999:0"
    ack_test.go:129: BufferWithTimeout: 0 messages, 1.000011879s buffer time
    ack_test.go:129: BufferWithTimeout: 0 messages, 1.000341405s buffer time
    ack_test.go:129: BufferWithTimeout: 0 messages, 1.000678685s buffer time
    ack_test.go:129: BufferWithTimeout: 0 messages, 1.000678189s buffer time
    ack_test.go:129: BufferWithTimeout: 0 messages, 1.000395633s buffer time
    ack_test.go:129: BufferWithTimeout: 0 messages, 1.000030104s buffer time
    ack_test.go:129: BufferWithTimeout: 0 messages, 1.000178602s buffer time
    ack_test.go:129: BufferWithTimeout: 0 messages, 1.0007541s buffer time
    ack_test.go:129: BufferWithTimeout: 0 messages, 1.000225721s buffer time
    ack_test.go:115: UnAcked messages: 50000
    ack_test.go:129: BufferWithTimeout: 0 messages, 1.000822534s buffer time
```

As you can see, after reaching 50k unacked messages, the consumer stops receiving messages despite the fact that we've been acking the messages after receving each batch with `AckIDCumulative`.

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-1082/bug-ack-cumulative-on-pulsar) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
