### PR TITLE
chore: disable event name tracking for retl connections

### DIFF
--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -613,7 +613,7 @@ func (r *DefaultReporter) Report(ctx context.Context, metrics []*types.PUReporte
 		workspaceID := r.configSubscriber.WorkspaceIDFromSource(metric.ConnectionDetails.SourceID)
 		metric := *metric
 
-		if slices.Contains(r.sourcesWithEventNameTrackingDisabled, metric.ConnectionDetails.SourceID) {
+		if metric.ConnectionDetails.SourceCategory == "warehouse" || slices.Contains(r.sourcesWithEventNameTrackingDisabled, metric.ConnectionDetails.SourceID) {
 			metric.StatusDetail.EventName = metric.StatusDetail.EventType
 		}
 


### PR DESCRIPTION
# Description

Disabling event name tracking for all RETL connections, because many customer uses UUIDs for event names, creates a high level of cardinality.

## Linear Ticket

https://linear.app/rudderstack/issue/OBS-470/disable-event-name-tracking-for-retl-connections

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
