### PR TITLE
chore: reducing metrics cardinality

### DIFF
--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -195,7 +195,7 @@ func (ch *Clickhouse) newClickHouseStat(tableName string) *clickHouseStat {
 		"destType":    ch.Warehouse.Type,
 		"source":      ch.Warehouse.Source.ID,
 		"identifier":  ch.Warehouse.Identifier,
-		"tableName":   tableName,
+		"tableName":   warehouseutils.TableNameForStats(tableName),
 	}
 
 	numRowsLoadFile := ch.stats.NewTaggedStat("warehouse.clickhouse.numRowsLoadFile", stats.CountType, tags)

--- a/warehouse/router/upload_stats.go
+++ b/warehouse/router/upload_stats.go
@@ -2,10 +2,9 @@ package router
 
 import (
 	"fmt"
-	"slices"
-	"strings"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
@@ -108,12 +107,7 @@ func (job *UploadJob) generateUploadAbortedMetrics() {
 }
 
 func (job *UploadJob) recordTableLoad(tableName string, numEvents int64) {
-	capturedTableName := strings.ToLower(tableName)
-	rudderAPISupportedEventTypes := []string{"tracks", "identifies", "pages", "screens", "aliases", "groups"}
-	if !slices.Contains(rudderAPISupportedEventTypes, capturedTableName) {
-		// making all other tableName as other, to reduce cardinality
-		capturedTableName = "others"
-	}
+	capturedTableName := warehouseutils.TableNameForStats(tableName)
 
 	job.counterStat(`event_delivery`, warehouseutils.Tag{
 		Name:  "tableName",

--- a/warehouse/router/upload_test.go
+++ b/warehouse/router/upload_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/services/alerta"
 	sqlmiddleware "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
@@ -157,7 +158,7 @@ func TestColumnCountStat(t *testing.T) {
 			})
 
 			tags := j.buildTags()
-			tags["tableName"] = tableName
+			tags["tableName"] = warehouseutils.TableNameForStats(tableName)
 
 			j.columnCountStat(tableName)
 

--- a/warehouse/utils/stats.go
+++ b/warehouse/utils/stats.go
@@ -7,6 +7,7 @@ import (
 var statsSupportedTableNames = map[string]struct{}{
 	"tracks":     {},
 	"identifies": {},
+	"users":      {},
 	"pages":      {},
 	"screens":    {},
 	"aliases":    {},

--- a/warehouse/utils/stats.go
+++ b/warehouse/utils/stats.go
@@ -1,0 +1,22 @@
+package warehouseutils
+
+import (
+	"strings"
+)
+
+var statsSupportedTableNames = map[string]struct{}{
+	"tracks":     {},
+	"identifies": {},
+	"pages":      {},
+	"screens":    {},
+	"aliases":    {},
+	"groups":     {},
+}
+
+func TableNameForStats(tableName string) string {
+	capturedTableName := strings.ToLower(tableName)
+	if _, ok := statsSupportedTableNames[capturedTableName]; !ok {
+		capturedTableName = "others" // making all other tableName as other, to reduce cardinality
+	}
+	return capturedTableName
+}

--- a/warehouse/utils/stats_test.go
+++ b/warehouse/utils/stats_test.go
@@ -1,0 +1,32 @@
+package warehouseutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableNameForStats(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"Should return the input string 'tracks'", "tracks", "tracks"},
+		{"Should return the input string 'identifies'", "identifies", "identifies"},
+		{"Should return the input string 'users'", "users", "users"},
+		{"Should return the input string 'pages'", "pages", "pages"},
+		{"Should return the input string 'screens'", "screens", "screens"},
+		{"Should return the input string 'aliases'", "aliases", "aliases"},
+		{"Should return the input string 'groups'", "groups", "groups"},
+		{"Should return 'others' for unsupported table names", "random", "others"},
+		{"Should return 'others' for an empty input string", "", "others"},
+		{"Should handle case sensitivity", "Tracks", "tracks"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, TableNameForStats(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
# Description

- Restricting tableName in warehouse stats to be from one of these []string{"tracks", "identifies", "pages", "screens", "aliases", "groups", "users"}, otherwise use others.

## Linear Ticket

- Resolves PIPE-1067

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
