### PR TITLE
fix: error handling in marketo bulk upload

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/marketo-bulk-upload/marketobulkupload.go
+++ b/router/batchrouter/asyncdestinationmanager/marketo-bulk-upload/marketobulkupload.go
@@ -80,6 +80,7 @@ func (b *MarketoBulkUploader) Poll(pollInput common.AsyncPoll) common.PollStatus
 		return common.PollStatusResponse{
 			StatusCode: transformerConnectionStatus,
 			HasFailed:  true,
+			Error:      string(bodyBytes),
 		}
 	}
 	var asyncResponse common.PollStatusResponse

--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -258,7 +258,7 @@ func (brt *Handle) updatePollStatusToDB(
 		brt.asyncAbortedJobCount.Count(len(statusList))
 	} else {
 		var abortedJobsList []*jobsdb.JobT
-		statusList, abortedJobsList, jobIDConnectionDetailsMap = brt.prepareJobStatusList(importingList, jobsdb.JobStatusT{JobState: jobsdb.Failed.State, ErrorResponse: misc.UpdateJSONWithNewKeyVal(routerutils.EmptyPayload, "error", pollResp.Error)}, sourceID, destinationID)
+		statusList, abortedJobsList, jobIDConnectionDetailsMap = brt.prepareJobStatusList(importingList, jobsdb.JobStatusT{JobState: jobsdb.Failed.State, ErrorCode: strconv.Itoa(pollResp.StatusCode), ErrorResponse: misc.UpdateJSONWithNewKeyVal(routerutils.EmptyPayload, "error", pollResp.Error)}, sourceID, destinationID)
 		if err := brt.updateJobStatuses(ctx, destinationID, importingList, abortedJobsList, statusList); err != nil {
 			brt.logger.Errorf("[Batch Router] Failed to update job status for Dest Type %v with error %v", brt.destType, err)
 			return statusList, err


### PR DESCRIPTION
# Description

Potentially we are missing setting a proper statusCode when failure occurred at traeffik level while connecting to transformer

## Linear Ticket


## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
