### PR TITLE
chore: avoid sending warehouseID in stats

### DIFF
--- a/warehouse/bcm/backend_config.go
+++ b/warehouse/bcm/backend_config.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-server/utils/misc"
 
 	"github.com/rudderlabs/rudder-server/warehouse/multitenant"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	cpclient "github.com/rudderlabs/rudder-server/warehouse/client/controlplane"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
@@ -348,6 +350,7 @@ func (bcm *BackendConfigManager) persistSSLFileErrorStat(
 		"module":        "warehouse",
 		"destType":      destType,
 		"warehouseID":   misc.GetTagName(destID, sourceName, destName, misc.TailTruncateStr(sourceID, 6)),
+		"sourceID":      sourceID,
 		"destinationID": destID,
 		"errTag":        errTag,
 	}

--- a/warehouse/bcm/backend_config.go
+++ b/warehouse/bcm/backend_config.go
@@ -350,7 +350,7 @@ func (bcm *BackendConfigManager) persistSSLFileErrorStat(
 		"module":        "warehouse",
 		"destType":      destType,
 		"warehouseID":   misc.GetTagName(destID, sourceName, destName, misc.TailTruncateStr(sourceID, 6)),
-		"sourceID":      sourceID,
+		"sourceId":      sourceID,
 		"destinationID": destID,
 		"errTag":        errTag,
 	}

--- a/warehouse/internal/api/http.go
+++ b/warehouse/internal/api/http.go
@@ -147,11 +147,11 @@ func (api *WarehouseAPI) processHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	api.Stats.NewTaggedStat("rows_staged", stats.CountType, stats.Tags{
-		"workspaceId": stagingFile.WorkspaceID,
-		"module":      "warehouse",
-		"destType":    payload.BatchDestination.Destination.DestinationDefinition.Name,
-		"sourceID":    payload.BatchDestination.Source.ID,
-		"destID":      payload.BatchDestination.Destination.ID,
+		"workspaceId":   stagingFile.WorkspaceID,
+		"module":        "warehouse",
+		"destType":      payload.BatchDestination.Destination.DestinationDefinition.Name,
+		"sourceId":      payload.BatchDestination.Source.ID,
+		"destinationId": payload.BatchDestination.Destination.ID,
 		"warehouseID": misc.GetTagName(
 			payload.BatchDestination.Destination.ID,
 			payload.BatchDestination.Source.Name,

--- a/warehouse/internal/api/http.go
+++ b/warehouse/internal/api/http.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
@@ -149,6 +150,8 @@ func (api *WarehouseAPI) processHandler(w http.ResponseWriter, r *http.Request) 
 		"workspaceId": stagingFile.WorkspaceID,
 		"module":      "warehouse",
 		"destType":    payload.BatchDestination.Destination.DestinationDefinition.Name,
+		"sourceID":    payload.BatchDestination.Source.ID,
+		"destID":      payload.BatchDestination.Destination.ID,
 		"warehouseID": misc.GetTagName(
 			payload.BatchDestination.Destination.ID,
 			payload.BatchDestination.Source.Name,

--- a/warehouse/router/tracker.go
+++ b/warehouse/router/tracker.go
@@ -81,11 +81,11 @@ func (r *Router) Track(
 	}
 
 	trackUploadMissingStat := r.statsFactory.NewTaggedStat("warehouse_track_upload_missing", stats.GaugeType, stats.Tags{
-		"workspaceId": warehouse.WorkspaceID,
-		"module":      moduleName,
-		"destType":    r.destType,
-		"sourceID":    source.ID,
-		"destID":      destination.ID,
+		"workspaceId":   warehouse.WorkspaceID,
+		"module":        moduleName,
+		"destType":      r.destType,
+		"sourceId":      source.ID,
+		"destinationId": destination.ID,
 		"warehouseID": misc.GetTagName(
 			destination.ID,
 			source.Name,

--- a/warehouse/router/tracker.go
+++ b/warehouse/router/tracker.go
@@ -84,6 +84,8 @@ func (r *Router) Track(
 		"workspaceId": warehouse.WorkspaceID,
 		"module":      moduleName,
 		"destType":    r.destType,
+		"sourceID":    source.ID,
+		"destID":      destination.ID,
 		"warehouseID": misc.GetTagName(
 			destination.ID,
 			source.Name,

--- a/warehouse/router/tracker_test.go
+++ b/warehouse/router/tracker_test.go
@@ -172,11 +172,11 @@ func TestRouter_Track(t *testing.T) {
 			require.NoError(t, err)
 
 			m := statsStore.Get("warehouse_track_upload_missing", stats.Tags{
-				"module":      moduleName,
-				"workspaceId": warehouse.WorkspaceID,
-				"destType":    handle.destType,
-				"sourceID":    warehouse.Source.ID,
-				"destID":      warehouse.Destination.ID,
+				"module":        moduleName,
+				"workspaceId":   warehouse.WorkspaceID,
+				"destType":      handle.destType,
+				"sourceId":      warehouse.Source.ID,
+				"destinationId": warehouse.Destination.ID,
 				"warehouseID": misc.GetTagName(
 					warehouse.Destination.ID,
 					warehouse.Source.Name,

--- a/warehouse/router/tracker_test.go
+++ b/warehouse/router/tracker_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -174,6 +175,8 @@ func TestRouter_Track(t *testing.T) {
 				"module":      moduleName,
 				"workspaceId": warehouse.WorkspaceID,
 				"destType":    handle.destType,
+				"sourceID":    warehouse.Source.ID,
+				"destID":      warehouse.Destination.ID,
 				"warehouseID": misc.GetTagName(
 					warehouse.Destination.ID,
 					warehouse.Source.Name,


### PR DESCRIPTION
# Description

- **Avoid sending warehouseID in stats** since we already have sourceID and destinationID we don't need warehouseID which is essentially a combination of `(sourceName, destinationName, sourceID, destiantionID)`.
- For new tags following the standards we have in [observability-kit](https://github.com/rudderlabs/rudder-observability-kit/blob/main/go/labels/common.go#L11).
- **Current Plan Overview**:
  - **Ensuring Availability of Stable Identifiers**: In all statistics where `warehouseID` is utilized, `sourceID` and `destID` are ensured to be available. For any instances where these identifiers are absent, they are added.
  - **Transitioning from `warehouseID`**: Once the new tags (`sourceID` and `destID`) are consistently populated, the next step involves removing `warehouseID` from the metrics dashboard and alerts. Instead, `sourceID` and `destID` will be used for contextual information if necessary. ([PIPE-1089](https://linear.app/rudderstack/issue/PIPE-1089/correct-metrics-dashboard-and-alerts-for-warehouseid))
  - **Application Code Update**: Following the successful correction of metrics dashboards and alerts, the final step entails removing references to `warehouseID` from the application code. ([PIPE-1090](https://linear.app/rudderstack/issue/PIPE-1090/remove-warehouseid-from-application-code))

This improved version provides clearer explanations and organizes the plan's steps for better readability and understanding.
## Linear Ticket

- Resolves PIPE-1088

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
