### PR TITLE
chore: use jsoniter in warehouse slave

### DIFF
--- a/warehouse/slave/slave_test.go
+++ b/warehouse/slave/slave_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"compress/gzip"
 	"context"
-	"encoding/json"
 	"os"
 	"testing"
 

--- a/warehouse/slave/worker.go
+++ b/warehouse/slave/worker.go
@@ -34,7 +34,7 @@ import (
 var (
 	errIncompatibleSchemaConversion = errors.New("incompatible schema conversion")
 	errSchemaConversionNotSupported = errors.New("schema conversion not supported")
-	json                            = jsoniter.ConfigCompatibleWithStandardLibrary
+	json                            = jsoniter.ConfigFastest
 )
 
 type uploadProcessingResult struct {

--- a/warehouse/slave/worker.go
+++ b/warehouse/slave/worker.go
@@ -3,13 +3,14 @@ package slave
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"reflect"
 	"strconv"
 	"time"
+
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/rudderlabs/rudder-server/warehouse/bcm"
 	"github.com/rudderlabs/rudder-server/warehouse/constraints"
@@ -33,6 +34,7 @@ import (
 var (
 	errIncompatibleSchemaConversion = errors.New("incompatible schema conversion")
 	errSchemaConversionNotSupported = errors.New("schema conversion not supported")
+	json                            = jsoniter.ConfigCompatibleWithStandardLibrary
 )
 
 type uploadProcessingResult struct {

--- a/warehouse/slave/worker_test.go
+++ b/warehouse/slave/worker_test.go
@@ -4,7 +4,6 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/csv"
-	"encoding/json"
 	"errors"
 	"os"
 	"testing"


### PR DESCRIPTION
# Description
warehouse-slave is spending a lot of cpu time in marshalling JSON, but we don't use jsoniter to marshall or unmarshall.

<img width="1458" alt="image" src="https://github.com/rudderlabs/rudder-server/assets/26831213/3554f1a7-7aa6-462a-967e-6dab1267d67a">

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1104/warehouse-slave-is-spending-a-lot-of-cpu-time-in-marshaling-json-but

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
