### PR TITLE
chore: use jsoniter.ConfigCompatibleWithStandardLibrary

### DIFF
--- a/warehouse/slave/worker.go
+++ b/warehouse/slave/worker.go
@@ -34,7 +34,7 @@ import (
 var (
 	errIncompatibleSchemaConversion = errors.New("incompatible schema conversion")
 	errSchemaConversionNotSupported = errors.New("schema conversion not supported")
-	json                            = jsoniter.ConfigFastest
+	json                            = jsoniter.ConfigCompatibleWithStandardLibrary
 )
 
 type uploadProcessingResult struct {


### PR DESCRIPTION
# Description

replacing jsoniter.ConfigFast with jsoniter.ConfigCompatibleWithStandardLibrary as we are loosing precision in case of json.ConfigFast

ref: https://jsoniter.com/migrate-from-go-std.html#:~:text=6%20digits%20precision%20(lossy)

## Linear Ticket

pipe-1104

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
