### PR TITLE
chore: use json-iterator in backend config cache

### DIFF
--- a/backend-config/internal/cache/cache.go
+++ b/backend-config/internal/cache/cache.go
@@ -7,8 +7,9 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"database/sql"
-	"encoding/json"
 	"fmt"
+
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -17,7 +18,10 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 )
 
-var pkgLogger = logger.NewLogger().Child("backend-config-cache")
+var (
+	pkgLogger = logger.NewLogger().Child("backend-config-cache")
+	json      = jsoniter.ConfigCompatibleWithStandardLibrary
+)
 
 type Cache interface {
 	Get(ctx context.Context) ([]byte, error)


### PR DESCRIPTION
# Description

use json-iterator in backend config cache as its consuming 3.2% cpu time for multitenent customers
 
<img width="1694" alt="image" src="https://github.com/rudderlabs/rudder-server/assets/26831213/df62d82e-1aa3-4002-b7e4-253644e9b666">


## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1119/use-json-iterator-in-backend-config-cache

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
