### PR TITLE
chore: separate dataset index creation

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1272,15 +1272,6 @@ func (jd *Handle) addNewDSInTx(tx *Tx, l lock.LockToken, dsList []dataSetT, ds d
 	return nil
 }
 
-func (jd *Handle) addDSInTx(tx *Tx, ds dataSetT) error {
-	defer jd.getTimerStat(
-		"add_new_ds",
-		&statTags{CustomValFilters: []string{jd.tablePrefix}},
-	).RecordDuration()()
-	jd.logger.Infof("Creating DS %+v", ds)
-	return jd.createDSInTx(tx, ds)
-}
-
 func (jd *Handle) computeNewIdxForAppend(l lock.LockToken) string {
 	dList, err := jd.doRefreshDSList(l)
 	jd.assertError(err)
@@ -1325,7 +1316,22 @@ func (jd *Handle) createDSInTx(tx *Tx, newDS dataSetT) error {
 	}
 
 	// Create the jobs and job_status tables
-	if _, err = tx.ExecContext(ctx, fmt.Sprintf(`CREATE TABLE %q (
+	if err = jd.createDSTablesInTx(ctx, tx, newDS); err != nil {
+		return err
+	}
+	if err = jd.createDSIndicesInTx(ctx, tx, newDS); err != nil {
+		return err
+	}
+
+	err = jd.journalMarkDoneInTx(tx, opID)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (jd *Handle) createDSTablesInTx(ctx context.Context, tx *Tx, newDS dataSetT) error {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE TABLE %q (
 		job_id BIGSERIAL PRIMARY KEY,
 		workspace_id TEXT NOT NULL DEFAULT '',
 		uuid UUID NOT NULL,
@@ -1338,21 +1344,9 @@ func (jd *Handle) createDSInTx(tx *Tx, newDS dataSetT) error {
 		expire_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW());`, newDS.JobTable)); err != nil {
 		return err
 	}
-	if _, err = tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_ws" ON %[1]q (workspace_id)`, newDS.JobTable)); err != nil {
-		return err
-	}
-	if _, err = tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_cv" ON %[1]q (custom_val)`, newDS.JobTable)); err != nil {
-		return err
-	}
-	for _, param := range cacheParameterFilters {
-		if _, err = tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_%[2]s" ON %[1]q USING BTREE ((parameters->>'%[2]s'))`, newDS.JobTable, param)); err != nil {
-			return err
-		}
-	}
-
-	if _, err = tx.ExecContext(ctx, fmt.Sprintf(`CREATE TABLE %q (
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE TABLE %q (
 		id BIGSERIAL,
-		job_id BIGINT REFERENCES %q(job_id),
+		job_id BIGINT,
 		job_state VARCHAR(64),
 		attempt SMALLINT,
 		exec_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
@@ -1360,17 +1354,40 @@ func (jd *Handle) createDSInTx(tx *Tx, newDS dataSetT) error {
 		error_code VARCHAR(32),
 		error_response JSONB DEFAULT '{}'::JSONB,
 		parameters JSONB DEFAULT '{}'::JSONB,
-		PRIMARY KEY (job_id, job_state, id));`, newDS.JobStatusTable, newDS.JobTable)); err != nil {
+		PRIMARY KEY (job_id, job_state, id));`, newDS.JobStatusTable)); err != nil {
 		return err
 	}
-	if _, err = tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_jid_id" ON %[1]q(job_id asc,id desc)`, newDS.JobStatusTable)); err != nil {
+	return nil
+}
+
+func (jd *Handle) createDSIndicesInTx(ctx context.Context, tx *Tx, newDS dataSetT) error {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_ws" ON %[1]q (workspace_id)`, newDS.JobTable)); err != nil {
 		return err
 	}
-	if _, err = tx.ExecContext(ctx, fmt.Sprintf(`CREATE VIEW "v_last_%[1]s" AS SELECT DISTINCT ON (job_id) * FROM %[1]q ORDER BY job_id ASC, id DESC`, newDS.JobStatusTable)); err != nil {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_cv" ON %[1]q (custom_val)`, newDS.JobTable)); err != nil {
 		return err
 	}
-	err = jd.journalMarkDoneInTx(tx, opID)
-	if err != nil {
+	for _, param := range cacheParameterFilters {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_%[2]s" ON %[1]q USING BTREE ((parameters->>'%[2]s'))`, newDS.JobTable, param)); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.ExecContext(
+		ctx,
+		fmt.Sprintf(
+			`ALTER TABLE %[1]q
+			ADD CONSTRAINT "fk_%[1]s_job_id"
+			FOREIGN KEY (job_id)
+			REFERENCES %[2]q (job_id)`,
+			newDS.JobStatusTable,
+			newDS.JobTable,
+		)); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_jid_id" ON %[1]q(job_id asc,id desc)`, newDS.JobStatusTable)); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE VIEW "v_last_%[1]s" AS SELECT DISTINCT ON (job_id) * FROM %[1]q ORDER BY job_id ASC, id DESC`, newDS.JobStatusTable)); err != nil {
 		return err
 	}
 	return nil

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -365,7 +365,7 @@ func TestRefreshDSList(t *testing.T) {
 
 	require.Equal(t, 1, len(jobsDB.getDSList()), "jobsDB should start with a ds list size of 1")
 	require.NoError(t, jobsDB.WithTx(func(tx *Tx) error {
-		return jobsDB.addDSInTx(tx, newDataSet(prefix, "2"))
+		return jobsDB.createDSInTx(tx, newDataSet(prefix, "2"))
 	}))
 	require.Equal(t, 1, len(jobsDB.getDSList()), "addDS should not refresh the ds list")
 	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -124,9 +124,8 @@ func (jd *Handle) doMigrateDS(ctx context.Context) error {
 					return fmt.Errorf("failed to mark journal start: %w", err)
 				}
 
-				err = jd.addDSInTx(tx, destination)
-				if err != nil {
-					return fmt.Errorf("failed to add dataset: %w", err)
+				if err = jd.createDSTablesInTx(ctx, tx, destination); err != nil {
+					return fmt.Errorf("failed to create dataset tables: %w", err)
 				}
 
 				totalJobsMigrated := 0
@@ -138,6 +137,9 @@ func (jd *Handle) doMigrateDS(ctx context.Context) error {
 						return fmt.Errorf("failed to migrate jobs: %w", err)
 					}
 					totalJobsMigrated += noJobsMigrated
+				}
+				if err = jd.createDSIndicesInTx(ctx, tx, destination); err != nil {
+					return fmt.Errorf("create %v indices: %w", destination, err)
 				}
 				if err = jd.journalMarkDoneInTx(tx, opID); err != nil {
 					return fmt.Errorf("failed to mark journal done: %w", err)


### PR DESCRIPTION
# Description

Separate out index creation for jobsdb datasets. Motivation stemmed from wanting to create indices after jobs are copied during migration([src](https://www.postgresql.org/docs/current/populate.html#POPULATE-RM-INDEXES)). Includes foreign key constraint.

Removed `addDS` journal entry during migration. Which imo is fine considering the `migrateDS` entry contains info about the created dataset.

## Linear Ticket

[Resolves PIPE-1072](https://linear.app/rudderstack/issue/PIPE-1072/misc)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
