### PR TITLE
chore: get processor namespace, instanceID during setup

### DIFF
--- a/processor/processorBenchmark_test.go
+++ b/processor/processorBenchmark_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 func Benchmark_makeCommonMetadataFromSingularEvent(b *testing.B) {
+	proc := &Handle{}
 	for i := 0; i < b.N; i++ {
-		_ = makeCommonMetadataFromSingularEvent(
+		_ = proc.makeCommonMetadataFromSingularEvent(
 			dummySingularEvent, &dummyBatchEvent, time.Now(), &backendconfig.SourceT{
 				WorkspaceID: "test",
 				SourceDefinition: backendconfig.SourceDefinitionT{


### PR DESCRIPTION
# Description

Instead of `config.Get...`ing the same thing(kube namespace, instanceID) for every event, we may fetch it once and use that information for all.

## Linear Ticket

[Resolves PIPE-1072](https://linear.app/rudderstack/issue/PIPE-1072/misc)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
