### PR TITLE
fix: invalid byte sequence UTF-8

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -531,6 +531,7 @@ var dbInvalidJsonErrors = map[string]struct{}{
 	"22P05": {},
 	"22025": {},
 	"22019": {},
+	"22021": {}, // invalid byte sequence for encoding "UTF8"
 }
 
 // Some helper functions


### PR DESCRIPTION
# Description

Adding error to handle invalid byte UTF-8 sequences for jobsdb.

## Linear Ticket

< Linear Link >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
