### PR TITLE
fix: archival to archive everything whenever it is running

### DIFF
--- a/warehouse/archive/archiver_test.go
+++ b/warehouse/archive/archiver_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats/mock_stats"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/minio"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
+
 	backendConfig "github.com/rudderlabs/rudder-server/backend-config"
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 	"github.com/rudderlabs/rudder-server/warehouse/archive"
@@ -113,6 +114,7 @@ func TestArchiver(t *testing.T) {
 			t.Setenv("MINIO_SSL", "false")
 			t.Setenv("RUDDER_TMPDIR", t.TempDir())
 			t.Setenv("RSERVER_WAREHOUSE_UPLOADS_ARCHIVAL_TIME_IN_DAYS", "0")
+			t.Setenv("RSERVER_WAREHOUSE_ARCHIVER_MAX_LIMIT", "1")
 
 			ctrl := gomock.NewController(t)
 			mockStats := mock_stats.NewMockStats(ctrl)


### PR DESCRIPTION
# Description

- Since the current archival runs every 6 Hrs and archives 10K (limit) uploads which are older then 5 days.
- This is causing an issue if we are generating more than 10K uploads in 6Hrs which will create a Backlog and it will keep accumulating.
- We face an issue with our MT system where we have accumulated 1.1M uploads. More about it in [here](https://rudderlabs.slack.com/archives/C01JF5MGUAG/p1717045801751619?thread_ts=1717040388.986919&cid=C01JF5MGUAG).

## Linear Ticket

- Resolves [PIPE-1140](https://linear.app/rudderstack/issue/PIPE-1140/warehouse-archiver-fix)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
