### PR TITLE
fix: populate singular batch with writeKey in internal handler

### DIFF
--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -674,6 +674,10 @@ func (gw *Handle) internalBatchHandlerFunc() http.HandlerFunc {
 			// Sending events to config backend
 			for _, job := range jobs {
 				writeKey := gjson.GetBytes(job.EventPayload, "writeKey").String()
+				if writeKey == "" {
+					gw.logger.Errorn("writeKey not found in event payload")
+					continue
+				}
 				gw.sourcehandle.RecordEvent(writeKey, job.EventPayload)
 			}
 		}

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -673,14 +673,7 @@ func (gw *Handle) internalBatchHandlerFunc() http.HandlerFunc {
 
 			// Sending events to config backend
 			for _, job := range jobs {
-				sourceID := gjson.GetBytes(job.Parameters, "source_id").String()
-				writeKey, ok := gw.getWriteKeyFromSourceID(sourceID)
-				if !ok {
-					gw.logger.Warnn("unable to get writeKey for job",
-						logger.NewStringField("uuid", job.UUID.String()),
-						obskit.SourceID(sourceID))
-					continue
-				}
+				writeKey := gjson.GetBytes(job.EventPayload, "writeKey").String()
 				gw.sourcehandle.RecordEvent(writeKey, job.EventPayload)
 			}
 		}
@@ -742,6 +735,7 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 		Batch      []json.RawMessage `json:"batch"`
 		ReceivedAt string            `json:"receivedAt"`
 		RequestIP  string            `json:"requestIP"`
+		WriteKey   string            `json:"writeKey"` // only needed for live-events
 	}
 
 	var (
@@ -793,6 +787,14 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 			DestinationID:   msg.Properties.DestinationID,
 		}
 
+		writeKey, ok := gw.getWriteKeyFromSourceID(msg.Properties.SourceID)
+		if !ok {
+			// only live-events will not work if writeKey is not found
+			gw.logger.Errorn("unable to get writeKey for job",
+				logger.NewStringField("messageId", msg.Properties.MessageID),
+				obskit.SourceID(msg.Properties.SourceID))
+		}
+
 		marshalledParams, err := json.Marshal(jobsDBParams)
 		if err != nil {
 			gw.logger.Errorn("[Gateway] Failed to marshal parameters map",
@@ -808,6 +810,7 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 			Batch:      []json.RawMessage{msg.Payload},
 			ReceivedAt: msg.Properties.ReceivedAt.Format(misc.RFC3339Milli),
 			RequestIP:  msg.Properties.RequestIP,
+			WriteKey:   writeKey,
 		}
 
 		payload, err := json.Marshal(eventBatch)


### PR DESCRIPTION
# Description

Events coming for HA ingestion did not appear in live-events viewer, due to `writeKey` missing from the payload.


Note: this PR doesn't contain test, as it would require significant changes in our tests suite. I wanted to keep scope small since it is hotfix. I have create a [task](https://linear.app/rudderstack/issue/PIPE-1148/improve-gateway-tests-for-internalv1batch) for them.

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1147/fix-ha-ingestion-live-events

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
