### PR TITLE
fix: webhook sources name needs to be lower cased

### DIFF
--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -262,7 +262,7 @@ func (webhook *HandleT) batchRequests(sourceDef string, requestQ chan *webhookT)
 	}
 }
 
-func prepareRequestBody(req *http.Request, includeQueryParams bool, sourceType string, sourceListForParsingParams []string) ([]byte, error) {
+func prepareRequestBody(req *http.Request, sourceType string, sourceListForParsingParams []string) ([]byte, error) {
 	defer func() {
 		_ = req.Body.Close()
 	}()
@@ -276,7 +276,7 @@ func prepareRequestBody(req *http.Request, includeQueryParams bool, sourceType s
 		body = []byte("{}") // If body is empty, set it to an empty JSON object
 	}
 
-	if includeQueryParams && slices.Contains(sourceListForParsingParams, strings.ToLower(sourceType)) {
+	if slices.Contains(sourceListForParsingParams, strings.ToLower(sourceType)) {
 		queryParams := req.URL.Query()
 		paramsBytes, err := json.Marshal(queryParams)
 		if err != nil {
@@ -319,7 +319,7 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 		var payloadArr [][]byte
 		var webRequests []*webhookT
 		for _, req := range breq.batchRequest {
-			body, err := prepareRequestBody(req.request, slices.Contains(bt.webhook.config.sourceListForParsingParams, breq.sourceType), breq.sourceType, bt.webhook.config.sourceListForParsingParams)
+			body, err := prepareRequestBody(req.request, breq.sourceType, bt.webhook.config.sourceListForParsingParams)
 			if err != nil {
 				req.done <- transformerResponse{Err: response.GetStatus(err.Error())}
 				continue

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -450,7 +450,7 @@ func TestPrepareRequestBody(t *testing.T) {
 	testCases := []struct {
 		name               string
 		req                *http.Request
-		secondParam        string
+		sourceType        string
 		includeQueryParams bool
 		wantError          bool
 		expectedResponse   []byte

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -450,7 +450,7 @@ func TestPrepareRequestBody(t *testing.T) {
 	testCases := []struct {
 		name               string
 		req                *http.Request
-		sourceType        string
+		sourceType         string
 		includeQueryParams bool
 		wantError          bool
 		expectedResponse   []byte
@@ -458,57 +458,57 @@ func TestPrepareRequestBody(t *testing.T) {
 		{
 			name:             "Empty request body with no query parameters for webhook",
 			req:              createRequest(http.MethodPost, "http://example.com", nil, nil),
-			secondParam:      "webhook",
+			sourceType:       "webhook",
 			expectedResponse: []byte("{}"),
 		},
 		{
 			name:             "Empty request body with query parameters for webhook",
 			req:              createRequest(http.MethodPost, "http://example.com", nil, map[string]string{"key": "value"}),
-			secondParam:      "webhook",
+			sourceType:       "webhook",
 			expectedResponse: []byte("{}"),
 		},
 		{
 			name:             "Some payload with no query parameters for webhook",
 			req:              createRequest(http.MethodPost, "http://example.com", strings.NewReader(`{"key":"value"}`), nil),
-			secondParam:      "webhook",
+			sourceType:       "webhook",
 			expectedResponse: []byte(`{"key":"value"}`),
 		},
 		{
 			name:             "Empty request body with query parameters for shopify",
 			req:              createRequest(http.MethodPost, "http://example.com", nil, map[string]string{"key": "value"}),
-			secondParam:      "shopify",
+			sourceType:       "shopify",
 			expectedResponse: []byte(`{"query_parameters":{"key":["value"]}}`),
 		},
 		{
 			name:             "Error reading request body for Shopify",
 			req:              createRequest(http.MethodPost, "http://example.com", iotest.ErrReader(errors.New("some error")), nil),
-			secondParam:      "Shopify",
+			sourceType:       "Shopify",
 			wantError:        true,
 			expectedResponse: nil,
 		},
 		{
 			name:             "Some payload with no query parameters for shopify",
 			req:              createRequest(http.MethodPost, "http://example.com", strings.NewReader(`{"key":"value"}`), nil),
-			secondParam:      "shopify",
+			sourceType:       "shopify",
 			expectedResponse: []byte(`{"key":"value","query_parameters":{}}`),
 		},
 		{
 			name:             "Some payload with query parameters for Adjust",
 			req:              createRequest(http.MethodPost, "http://example.com", strings.NewReader(`{"key1":"value1"}`), map[string]string{"key2": "value2"}),
-			secondParam:      "Adjust",
+			sourceType:       "Adjust",
 			expectedResponse: []byte(`{"key1":"value1","query_parameters":{"key2":["value2"]}}`),
 		},
 		{
 			name:             "No payload with query parameters for Adjust",
 			req:              createRequest(http.MethodPost, "http://example.com", nil, map[string]string{"key2": "value2"}),
-			secondParam:      "adjust",
+			sourceType:       "adjust",
 			expectedResponse: []byte(`{"query_parameters":{"key2":["value2"]}}`),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := prepareRequestBody(tc.req, tc.secondParam, []string{"adjust", "shopify"})
+			result, err := prepareRequestBody(tc.req, tc.sourceType, []string{"adjust", "shopify"})
 			if tc.wantError {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
# Description

The sources names need to be lower cased in order to stay consistent with sourceListForParsingParams, which is getting lower cased in https://github.com/rudderlabs/rudder-server/blob/2ac517df928248bda5465396b9963b1642d9dab4/gateway/webhook/setup.go#L57

## Linear Ticket

https://linear.app/rudderstack/issue/RUD-1741/hey-team-a-customer-reached-out-regarding-potential-lack-of-events

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
