### PR TITLE
chore: defining bucket boundaries

### DIFF
--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -1,30 +1,100 @@
 package runner
 
-import "github.com/rudderlabs/rudder-go-kit/bytesize"
+import (
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
+)
 
-var customBuckets = map[string][]float64{
-	"gateway.request_size": {
-		float64(10 * bytesize.B),
-		float64(100 * bytesize.B),
-		float64(1 * bytesize.KB),
-		float64(10 * bytesize.KB),
-		float64(100 * bytesize.KB),
-		float64(1 * bytesize.MB),
-		float64(3 * bytesize.MB),
-		float64(5 * bytesize.MB),
-		float64(10 * bytesize.MB),
-	},
-	"gateway.response_time": {
-		0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60,
-	},
-	"gateway.user_suppression_age": {
-		86400, 432000, 864000, 2592000, 5184000, 7776000, 15552000, 31104000, // 1 day, 5 days, 10 days, 30 days, 60 days, 90 days, 180 days, 360 days
-	},
-}
+var (
+	defaultHistogramBuckets = []float64{
+		0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60, 300, 600, // 2ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s, 30s, 1m
+	}
+	defaultWarehouseHistogramBuckets = []float64{
+		0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60, 300, 600, // 0.1s, 0.25s, 0.5s, 1s, 2.5s, 5s, 10s, 1m, 5m, 10m
+	}
 
-var customBucketsServer = map[string][]float64{
-	"event_delivery_time": {
-		0.5, 1, 2.5, 5, 10, 30, 60, 300 /* 5 minutes */, 600 /* 10 minutes */, 1800, /* 30 minutes */
-		3600 /* 1 hour */, 10800 /* 3 hours */, 21600 /* 6 hours */, 86400, /* 1 day */
-	},
-}
+	customBucketsServer = map[string][]float64{
+		"event_delivery_time": {
+			0.5, 1, 2.5, 5, 10, 30, 60, 300, 600, 1800, 3600, 7200, 10800, 21600, 32400, 86400, // 0.5 seconds, 1 second, 2.5 seconds, 5 seconds, 10 seconds, 30 seconds, 1 minute, 5 minutes, 10 minutes, 30 minutes, 1 hour, 2 hours, 3 hours, 6 hours, 9 hours, 24 hours
+		},
+	}
+	customBucketsWarehouse = map[string][]float64{
+		"event_delivery_time": {
+			60, 300, 600, 1800, 3600, 5400, 12600, 23400, 45000, 88200, // 1 minute, 5 minutes, 10 minutes, 30 minutes, 1 hour, 1.5 hours, 3.5 hours, 6.5 hours, 12.5 hours, 24.5 hours
+		},
+	}
+
+	customBuckets = map[string][]float64{
+		"exporting_data": {
+			0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60, 300, 600, 1800, 3600, 7200, 10800, 21600, 32400, 86400, // 0.1 seconds, 0.25 seconds, 0.5 seconds, 1 second, 2.5 seconds, 5 seconds, 10 seconds, 30 seconds, 1 minute, 5 minutes, 10 minutes, 30 minutes, 1 hour, 2 hours, 3 hours, 6 hours, 9 hours, 24 hours
+		},
+
+		"error_detail_reports_size": {
+			1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+		},
+		"error_detail_reports_aggregated_size": {
+			1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+		},
+		"reporting_client_get_reports_count": {
+			1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+		},
+		"reporting_client_get_aggregated_reports_count": {
+			1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+		},
+		"csv_file_size": {
+			float64(10 * bytesize.B), float64(100 * bytesize.B),
+			float64(1 * bytesize.KB), float64(10 * bytesize.KB), float64(100 * bytesize.KB),
+			float64(1 * bytesize.MB), float64(3 * bytesize.MB), float64(5 * bytesize.MB), float64(10 * bytesize.MB),
+			float64(1 * bytesize.GB),
+		},
+		"payload_size": {
+			float64(10 * bytesize.B), float64(100 * bytesize.B),
+			float64(1 * bytesize.KB), float64(10 * bytesize.KB), float64(100 * bytesize.KB),
+			float64(1 * bytesize.MB), float64(3 * bytesize.MB), float64(5 * bytesize.MB), float64(10 * bytesize.MB),
+			float64(1 * bytesize.GB),
+		},
+		"backend_config_http_response_size": {
+			float64(10 * bytesize.B), float64(100 * bytesize.B),
+			float64(1 * bytesize.KB), float64(10 * bytesize.KB), float64(100 * bytesize.KB),
+			float64(1 * bytesize.MB), float64(5 * bytesize.MB), float64(10 * bytesize.MB), float64(100 * bytesize.MB),
+			float64(1 * bytesize.GB), float64(10 * bytesize.GB),
+		},
+		"gateway.batch_size": {
+			1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+		},
+		"router.kafka.batch_size": {
+			1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+		},
+		"gateway.request_size": {
+			float64(10 * bytesize.B), float64(100 * bytesize.B),
+			float64(1 * bytesize.KB), float64(10 * bytesize.KB), float64(100 * bytesize.KB),
+			float64(1 * bytesize.MB), float64(3 * bytesize.MB), float64(5 * bytesize.MB), float64(10 * bytesize.MB),
+		},
+		"gateway.user_suppression_age": {
+			86400, 432000, 864000, 2592000, 5184000, 7776000, 15552000, 31104000, // 1 day, 5 days, 10 days, 30 days, 60 days, 90 days, 180 days, 360 days
+		},
+		"processor.transformer_request_batch_count": {
+			1, 5, 10, 25, 50, 100, 250, 500, 1000,
+		},
+		"processor_db_write_events": {
+			1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+		},
+		"processor_db_write_payload_bytes": {
+			float64(10 * bytesize.B), float64(100 * bytesize.B),
+			float64(1 * bytesize.KB), float64(10 * bytesize.KB), float64(100 * bytesize.KB),
+			float64(1 * bytesize.MB), float64(5 * bytesize.MB), float64(10 * bytesize.MB), float64(100 * bytesize.MB),
+			float64(1 * bytesize.GB),
+		},
+		"processor_db_read_events": {
+			1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+		},
+		"processor_db_read_payload_bytes": {
+			float64(10 * bytesize.B), float64(100 * bytesize.B),
+			float64(1 * bytesize.KB), float64(10 * bytesize.KB), float64(100 * bytesize.KB),
+			float64(1 * bytesize.MB), float64(5 * bytesize.MB), float64(10 * bytesize.MB), float64(100 * bytesize.MB),
+			float64(1 * bytesize.GB),
+		},
+		"processor_db_read_requests": {
+			1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+		},
+	}
+)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -43,18 +43,6 @@ import (
 	"github.com/rudderlabs/rudder-server/warehouse/validations"
 )
 
-var (
-	defaultHistogramBuckets = []float64{
-		0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60,
-		300 /* 5 mins */, 600 /* 10 mins */, 1800, /* 30 mins */
-	}
-	defaultWarehouseHistogramBuckets = []float64{
-		0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60,
-		300 /* 5 mins */, 600 /* 10 mins */, 1800 /* 30 mins */, 10800 /* 3 hours */, 36000, /* 10 hours */
-		86400 /* 1 day */, 259200 /* 3 days */, 604800 /* 7 days */, 1209600, /* 2 weeks */
-	}
-)
-
 // ReleaseInfo holds the release information
 type ReleaseInfo struct {
 	Version         string
@@ -122,6 +110,9 @@ func (r *Runner) Run(ctx context.Context, args []string) int {
 	}
 	if r.canStartWarehouse() {
 		statsOptions = append(statsOptions, stats.WithDefaultHistogramBuckets(defaultWarehouseHistogramBuckets))
+		for histogramName, buckets := range customBucketsWarehouse {
+			statsOptions = append(statsOptions, stats.WithHistogramBuckets(histogramName, buckets))
+		}
 	} else {
 		statsOptions = append(statsOptions, stats.WithDefaultHistogramBuckets(defaultHistogramBuckets))
 		for histogramName, buckets := range customBucketsServer {


### PR DESCRIPTION
# Description

- Defining explicit bucket boundaries for `HistogramType` and `TimerType`. 
- I have used [this](https://rudderstack.grafana.net/d/fdnjidambq58gd/bucket-for-timers-and-histograms?orgId=1&var-datasource=d49563b6-5b4a-4760-b314-26ce914827b0&var-metric=jobsdb_get_jobs_total_time_bucket&from=now-24h&to=now) dashboard for deciding the bucket sizes and [this](https://rudderstack.grafana.net/d/cardinality-management/cardinality-management-1-overview?orgId=1&refresh=15m&var-cardinality=grafanacloud-cardinality-management&var-datasource=d49563b6-5b4a-4760-b314-26ce914827b0) for deciding what metrics to target at an initial level.

## Linear Ticket

- Resolves PIPE-1079
- Resolves PIPE-1080

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated histogram bucket configurations for various metrics to provide more precise data analysis.
  - Removed global variables for default histogram buckets and implemented dynamic assignment based on conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->