### PR TITLE
fix: trino test

### DIFF
--- a/warehouse/integrations/datalake/testdata/etc/jvm.config
+++ b/warehouse/integrations/datalake/testdata/etc/jvm.config
@@ -9,3 +9,5 @@
 -XX:ReservedCodeCacheSize=256M
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
+-XX:+UnlockDiagnosticVMOptions
+-XX:G1NumCollectionsKeepPinned=10000000


### PR DESCRIPTION
# Description

- Using previous version (trinodb/trino:448) for trino test. 
- Else it requires some [additional JVM config changes](https://github.com/rudderlabs/rudder-server/actions/runs/9347809213/job/25725576454?pr=4747) as per the recent release for `trinodb/trino:449`.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
