### PR TITLE
fix: trino jvm config

### DIFF
--- a/warehouse/integrations/datalake/testdata/etc/jvm.config
+++ b/warehouse/integrations/datalake/testdata/etc/jvm.config
@@ -9,3 +9,5 @@
 -XX:ReservedCodeCacheSize=256M
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
+-XX:+UnlockDiagnosticVMOptions
+-XX:G1NumCollectionsKeepPinned=10000000


### PR DESCRIPTION
## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
