### PR TITLE
chore: upgrade go version in release-1.26.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 # syntax=docker/dockerfile:1
-ARG GO_VERSION=1.22.3
+ARG GO_VERSION=1.22.4
 ARG ALPINE_VERSION=3.20
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 ARG VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudderlabs/rudder-server
 
-go 1.22.3
+go 1.22.4
 
 // Addressing snyk vulnerabilities in indirect dependencies
 // When upgrading a dependency, please make sure that


### PR DESCRIPTION
# Description

Similar to https://github.com/rudderlabs/rudder-server/pull/4758
Upgrade go version to address security issues on CI

## Linear Ticket

resolves PIPE-1166


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
