### PR TITLE
chore: sync release v1.26.3 to main branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.26.3](https://github.com/rudderlabs/rudder-server/compare/v1.26.2...v1.26.3) (2024-06-06)
+
+
+### Bug Fixes
+
+* jobsdb handle: unicode low surrogate must follow a high surrogate ([#4762](https://github.com/rudderlabs/rudder-server/issues/4762)) ([4155fa2](https://github.com/rudderlabs/rudder-server/commit/4155fa2bec7142579264973740a8e26d2b2385e0))
+
 ## [1.26.2](https://github.com/rudderlabs/rudder-server/compare/v1.26.1...v1.26.2) (2024-05-31)
 
 


### PR DESCRIPTION
Description
Syncing patch release v1.26.3 to main branch

↓↓ Please review and edit commit overrides before merging ↓↓

BEGIN_COMMIT_OVERRIDE
fix: jobsdb handle: unicode low surrogate must follow a high surrogate (https://github.com/rudderlabs/rudder-server/pull/4762)
END_COMMIT_OVERRIDE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with handling jobsdb where a unicode low surrogate must follow a high surrogate.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->