### PR TITLE
feat: snowflake key pair

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/viney-shih/go-lock v1.1.2
 	github.com/xitongsys/parquet-go v1.5.1
 	github.com/xitongsys/parquet-go-source v0.0.0-20240122235623-d6294584ab18
+	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d
 	go.etcd.io/etcd/api/v3 v3.5.14
 	go.etcd.io/etcd/client/v3 v3.5.14
 	go.uber.org/atomic v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -1256,6 +1256,8 @@ github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGC
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c h1:3lbZUMbMiGUW/LMkfsEABsc5zNT9+b1CvsJx47JzJ8g=
 github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63MEE3IF9l2/ebyx59GyGgPi+tICQdmM=
+github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d h1:splanxYIlg+5LfHAM6xpdFEAYOk8iySO56hMFq6uLyA=
+github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/warehouse/integrations/bigquery/bigquery_test.go
+++ b/warehouse/integrations/bigquery/bigquery_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/runner"
 	"github.com/rudderlabs/rudder-server/testhelper/health"
@@ -42,7 +43,7 @@ func TestIntegration(t *testing.T) {
 	if os.Getenv("SLOW") != "1" {
 		t.Skip("Skipping tests. Add 'SLOW=1' env var to run test.")
 	}
-	if !bqHelper.IsBQTestCredentialsAvailable() {
+	if _, exists := os.LookupEnv(bqHelper.TestKey); !exists {
 		t.Skipf("Skipping %s as %s is not set", t.Name(), bqHelper.TestKey)
 	}
 

--- a/warehouse/integrations/bigquery/middleware/middleware_test.go
+++ b/warehouse/integrations/bigquery/middleware/middleware_test.go
@@ -2,6 +2,7 @@ package middleware_test
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -11,13 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-go-kit/logger/mock_logger"
+
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/bigquery"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/bigquery/middleware"
 	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 )
 
 func TestQueryWrapper(t *testing.T) {
-	if !bqHelper.IsBQTestCredentialsAvailable() {
+	if _, exists := os.LookupEnv(bqHelper.TestKey); !exists {
 		t.Skipf("Skipping %s as %s is not set", t.Name(), bqHelper.TestKey)
 	}
 

--- a/warehouse/integrations/bigquery/testhelper/setup.go
+++ b/warehouse/integrations/bigquery/testhelper/setup.go
@@ -41,11 +41,6 @@ func GetBQTestCredentials() (*TestCredentials, error) {
 	return &credentials, nil
 }
 
-func IsBQTestCredentialsAvailable() bool {
-	_, err := GetBQTestCredentials()
-	return err == nil
-}
-
 // RetrieveRecordsFromWarehouse retrieves records from the warehouse based on the given query.
 // It returns a slice of slices, where each inner slice represents a record's values.
 func RetrieveRecordsFromWarehouse(

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/runner"
 	th "github.com/rudderlabs/rudder-server/testhelper"
@@ -66,16 +67,11 @@ func deltaLakeTestCredentials() (*testCredentials, error) {
 	return &credentials, nil
 }
 
-func testCredentialsAvailable() bool {
-	_, err := deltaLakeTestCredentials()
-	return err == nil
-}
-
 func TestIntegration(t *testing.T) {
 	if os.Getenv("SLOW") != "1" {
 		t.Skip("Skipping tests. Add 'SLOW=1' env var to run test.")
 	}
-	if !testCredentialsAvailable() {
+	if _, exists := os.LookupEnv(testKey); !exists {
 		t.Skipf("Skipping %s as %s is not set", t.Name(), testKey)
 	}
 

--- a/warehouse/integrations/manager/manager.go
+++ b/warehouse/integrations/manager/manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/client"
 	azuresynapse "github.com/rudderlabs/rudder-server/warehouse/integrations/azure-synapse"
@@ -65,7 +66,7 @@ func New(destType string, conf *config.Config, logger logger.Logger, stats stats
 	case warehouseutils.BQ:
 		return bigquery.New(conf, logger), nil
 	case warehouseutils.SNOWFLAKE:
-		return snowflake.New(conf, logger, stats)
+		return snowflake.New(conf, logger, stats), nil
 	case warehouseutils.POSTGRES:
 		return postgres.New(conf, logger, stats), nil
 	case warehouseutils.CLICKHOUSE:
@@ -90,7 +91,7 @@ func NewWarehouseOperations(destType string, conf *config.Config, logger logger.
 	case warehouseutils.BQ:
 		return bigquery.New(conf, logger), nil
 	case warehouseutils.SNOWFLAKE:
-		return snowflake.New(conf, logger, stats)
+		return snowflake.New(conf, logger, stats), nil
 	case warehouseutils.POSTGRES:
 		return postgres.New(conf, logger, stats), nil
 	case warehouseutils.CLICKHOUSE:

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -70,16 +70,11 @@ func rsTestCredentials() (*testCredentials, error) {
 	return &credentials, nil
 }
 
-func testCredentialsAvailable() bool {
-	_, err := rsTestCredentials()
-	return err == nil
-}
-
 func TestIntegration(t *testing.T) {
 	if os.Getenv("SLOW") != "1" {
 		t.Skip("Skipping tests. Add 'SLOW=1' env var to run test.")
 	}
-	if !testCredentialsAvailable() {
+	if _, exists := os.LookupEnv(testKey); !exists {
 		t.Skipf("Skipping %s as %s is not set", t.Name(), testKey)
 	}
 

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -3,8 +3,10 @@ package snowflake
 import (
 	"bytes"
 	"context"
+	"crypto/rsa"
 	"database/sql"
 	"encoding/csv"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"regexp"
@@ -16,6 +18,7 @@ import (
 
 	"github.com/samber/lo"
 	snowflake "github.com/snowflakedb/gosnowflake"
+	"github.com/youmark/pkcs8"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -37,14 +40,17 @@ const (
 
 // String constants for snowflake destination config
 const (
-	storageIntegration = "storageIntegration"
-	account            = "account"
-	warehouse          = "warehouse"
-	database           = "database"
-	user               = "user"
-	role               = "role"
-	password           = "password"
-	application        = "Rudderstack_Warehouse"
+	storageIntegration   = "storageIntegration"
+	account              = "account"
+	warehouse            = "warehouse"
+	database             = "database"
+	user                 = "user"
+	role                 = "role"
+	password             = "password"
+	useKeyPairAuth       = "useKeyPairAuth"
+	privateKey           = "privateKey"
+	privateKeyPassphrase = "privateKeyPassphrase"
+	application          = "Rudderstack_Warehouse"
 )
 
 var primaryKeyMap = map[string]string{
@@ -127,14 +133,17 @@ var errorsMappings = []model.JobError{
 }
 
 type credentials struct {
-	account    string
-	warehouse  string
-	database   string
-	user       string
-	role       string
-	password   string
-	schemaName string
-	timeout    time.Duration
+	account              string
+	warehouse            string
+	database             string
+	user                 string
+	role                 string
+	password             string
+	schemaName           string
+	useKeyPairAuth       bool
+	privateKey           string
+	privateKeyPassphrase string
+	timeout              time.Duration
 }
 
 type tableLoadResp struct {
@@ -179,11 +188,11 @@ type Snowflake struct {
 	}
 }
 
-func New(conf *config.Config, log logger.Logger, stat stats.Stats) (*Snowflake, error) {
-	sf := &Snowflake{}
-
-	sf.logger = log.Child("integrations").Child("snowflake")
-	sf.stats = stat
+func New(conf *config.Config, log logger.Logger, stat stats.Stats) *Snowflake {
+	sf := &Snowflake{
+		logger: log.Child("integrations").Child("snowflake"),
+		stats:  stat,
+	}
 
 	sf.config.allowMerge = conf.GetBool("Warehouse.snowflake.allowMerge", true)
 	sf.config.enableDeleteByJobs = conf.GetBool("Warehouse.snowflake.enableDeleteByJobs", false)
@@ -199,7 +208,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats) (*Snowflake, 
 		return strings.ToUpper(item)
 	})
 
-	return sf, nil
+	return sf
 }
 
 func ColumnsWithDataTypes(columns model.TableSchema, prefix string) string {
@@ -1058,15 +1067,25 @@ func (sf *Snowflake) connect(ctx context.Context, opts optionalCreds) (*sqlmw.DB
 		Account:     cred.account,
 		User:        cred.user,
 		Role:        cred.role,
-		Password:    cred.password,
 		Database:    cred.database,
 		Schema:      cred.schemaName,
 		Warehouse:   cred.warehouse,
 		Application: application,
 	}
-
 	if cred.timeout > 0 {
 		urlConfig.LoginTimeout = cred.timeout
+	}
+	if cred.useKeyPairAuth {
+		rsaPrivateKey, err := ParsePrivateKey(cred.privateKey, cred.privateKeyPassphrase)
+		if err != nil {
+			return nil, fmt.Errorf("parsing private key: %w", err)
+		}
+
+		urlConfig.PrivateKey = rsaPrivateKey
+		urlConfig.Authenticator = snowflake.AuthTypeJwt
+	} else {
+		urlConfig.Password = cred.password
+		urlConfig.Authenticator = snowflake.AuthTypeSnowflake
 	}
 
 	var err error
@@ -1106,6 +1125,24 @@ func (sf *Snowflake) connect(ctx context.Context, opts optionalCreds) (*sqlmw.DB
 		}),
 	)
 	return middleware, nil
+}
+
+func ParsePrivateKey(privateKey, passPhrase string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(whutils.FormatPemContent(privateKey)))
+	if block == nil {
+		return nil, errors.New("decoding private key failed")
+	}
+
+	var opts [][]byte
+	if len(passPhrase) > 0 {
+		opts = append(opts, []byte(passPhrase))
+	}
+
+	rsaPrivateKey, err := pkcs8.ParsePKCS8PrivateKeyRSA(block.Bytes, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("parsing private key: %w", err)
+	}
+	return rsaPrivateKey, nil
 }
 
 func (sf *Snowflake) CreateSchema(ctx context.Context) (err error) {
@@ -1336,14 +1373,17 @@ func (sf *Snowflake) IsEmpty(ctx context.Context, warehouse model.Warehouse) (em
 
 func (sf *Snowflake) getConnectionCredentials(opts optionalCreds) credentials {
 	return credentials{
-		account:    whutils.GetConfigValue(account, sf.Warehouse),
-		warehouse:  whutils.GetConfigValue(warehouse, sf.Warehouse),
-		database:   whutils.GetConfigValue(database, sf.Warehouse),
-		user:       whutils.GetConfigValue(user, sf.Warehouse),
-		role:       whutils.GetConfigValue(role, sf.Warehouse),
-		password:   whutils.GetConfigValue(password, sf.Warehouse),
-		schemaName: opts.schemaName,
-		timeout:    sf.connectTimeout,
+		account:              whutils.GetConfigValue(account, sf.Warehouse),
+		warehouse:            whutils.GetConfigValue(warehouse, sf.Warehouse),
+		database:             whutils.GetConfigValue(database, sf.Warehouse),
+		user:                 whutils.GetConfigValue(user, sf.Warehouse),
+		role:                 whutils.GetConfigValue(role, sf.Warehouse),
+		password:             whutils.GetConfigValue(password, sf.Warehouse),
+		useKeyPairAuth:       whutils.ReadAsBool(useKeyPairAuth, sf.Warehouse.Destination.Config),
+		privateKey:           whutils.GetConfigValue(privateKey, sf.Warehouse),
+		privateKeyPassphrase: whutils.GetConfigValue(privateKeyPassphrase, sf.Warehouse),
+		schemaName:           opts.schemaName,
+		timeout:              sf.connectTimeout,
 	}
 }
 

--- a/warehouse/integrations/snowflake/testdata/template.json
+++ b/warehouse/integrations/snowflake/testdata/template.json
@@ -262,6 +262,259 @@
         "eventUpload": false,
         "eventUploadTS": 1646073666353
       },
+      "id": "{{.keypairEncryptedSourceID}}",
+      "name": "snowflake-integration",
+      "writeKey": "{{.keypairEncryptedWriteKey}}",
+      "enabled": true,
+      "sourceDefinitionId": "1dCzCUAtpWDzNxgGUYzq9sZdZZB",
+      "createdBy": "24p1CMAkx18KwNbFDXlR7sUhqaa",
+      "workspaceId": "{{.workspaceID}}",
+      "deleted": false,
+      "createdAt": "2022-02-08T09:30:27.073Z",
+      "updatedAt": "2022-02-28T18:41:06.362Z",
+      "destinations": [
+        {
+          "config": {
+        {{.preferAppend}}
+        "account": "{{.account}}",
+        "database": "{{.database}}",
+        "warehouse": "{{.warehouse}}",
+        "user": "{{.keypairEncryptedUser}}",
+        "cloudProvider": "AWS",
+        "bucketName": "{{.bucketName}}",
+        "storageIntegration": "",
+        "accessKeyID": "{{.accessKeyID}}",
+        "accessKey": "{{.accessKey}}",
+        "namespace": "{{.keypairEncryptedNamespace}}",
+        "prefix": "snowflake-prefix",
+        "syncFrequency": "30",
+        "enableSSE": false,
+        "useKeyPairAuth": true,
+        "privateKey": "{{.keypairEncryptedPrivateKey}}",
+        "privateKeyPassphrase": "{{.keypairEncryptedPassphrase}}",
+        "useRudderStorage": false
+        },
+        "liveEventsConfig": {},
+        "secretConfig": {},
+        "id": "{{.keypairEncryptedDestinationID}}",
+        "name": "snowflake-demo",
+        "enabled": true,
+        "workspaceId": "{{.workspaceID}}",
+        "deleted": false,
+        "createdAt": "2022-02-08T23:19:58.278Z",
+        "updatedAt": "2022-05-17T08:18:33.587Z",
+        "revisionId": "{{.keypairEncryptedDestinationID}}",
+        "transformations": [],
+        "destinationDefinition": {
+          "config": {
+            "destConfig": {
+              "defaultConfig": [
+                "account",
+                "database",
+                "warehouse",
+                "user",
+                "password",
+                "cloudProvider",
+                "bucketName",
+                "containerName",
+                "storageIntegration",
+                "accessKeyID",
+                "accessKey",
+                "accountName",
+                "accountKey",
+                "credentials",
+                "namespace",
+                "prefix",
+                "syncFrequency",
+                "syncStartAt",
+                "enableSSE",
+                "excludeWindow",
+                "useRudderStorage"
+              ]
+            },
+            "secretKeys": [
+              "password",
+              "accessKeyID",
+              "accessKey"
+            ],
+            "excludeKeys": [],
+            "includeKeys": [],
+            "transformAt": "processor",
+            "transformAtV1": "processor",
+            "supportedSourceTypes": [
+              "android",
+              "ios",
+              "web",
+              "unity",
+              "amp",
+              "cloud",
+              "reactnative",
+              "cloudSource",
+              "flutter",
+              "cordova"
+            ],
+            "saveDestinationResponse": true
+          },
+          "responseRules": null,
+          "options": null,
+          "id": "1XjvXnzw34UMAz1YOuKqL1kwzh6",
+          "name": "SNOWFLAKE",
+          "displayName": "Snowflake",
+          "category": "warehouse",
+          "createdAt": "2020-02-13T05:39:20.184Z",
+          "updatedAt": "2022-02-08T06:46:45.432Z"
+        },
+        "isConnectionEnabled": true,
+        "isProcessorEnabled": true
+        }
+      ],
+      "sourceDefinition": {
+        "options": null,
+        "id": "1dCzCUAtpWDzNxgGUYzq9sZdZZB",
+        "name": "HTTP",
+        "displayName": "HTTP",
+        "category": "",
+        "createdAt": "2020-06-12T06:35:35.962Z",
+        "updatedAt": "2020-06-12T06:35:35.962Z"
+      },
+      "dgSourceTrackingPlanConfig": null
+    },
+    {
+      "config": {
+        "isSampleSource": true,
+        "eventUpload": false,
+        "eventUploadTS": 1646073666353
+      },
+      "liveEventsConfig": {
+        "eventUpload": false,
+        "eventUploadTS": 1646073666353
+      },
+      "id": "{{.keypairUnencryptedSourceID}}",
+      "name": "snowflake-integration",
+      "writeKey": "{{.keypairUnencryptedWriteKey}}",
+      "enabled": true,
+      "sourceDefinitionId": "1dCzCUAtpWDzNxgGUYzq9sZdZZB",
+      "createdBy": "24p1CMAkx18KwNbFDXlR7sUhqaa",
+      "workspaceId": "{{.workspaceID}}",
+      "deleted": false,
+      "createdAt": "2022-02-08T09:30:27.073Z",
+      "updatedAt": "2022-02-28T18:41:06.362Z",
+      "destinations": [
+        {
+          "config": {
+        {{.preferAppend}}
+        "account": "{{.account}}",
+        "database": "{{.database}}",
+        "warehouse": "{{.warehouse}}",
+        "user": "{{.keypairUnencryptedUser}}",
+        "cloudProvider": "AWS",
+        "bucketName": "{{.bucketName}}",
+        "storageIntegration": "",
+        "accessKeyID": "{{.accessKeyID}}",
+        "accessKey": "{{.accessKey}}",
+        "namespace": "{{.keypairUnencryptedNamespace}}",
+        "prefix": "snowflake-prefix",
+        "syncFrequency": "30",
+        "enableSSE": false,
+        "useKeyPairAuth": true,
+        "privateKey": "{{.keypairUnencryptedPrivateKey}}",
+        "useRudderStorage": false
+        },
+        "liveEventsConfig": {},
+        "secretConfig": {},
+        "id": "{{.keypairUnencryptedDestinationID}}",
+        "name": "snowflake-demo",
+        "enabled": true,
+        "workspaceId": "{{.workspaceID}}",
+        "deleted": false,
+        "createdAt": "2022-02-08T23:19:58.278Z",
+        "updatedAt": "2022-05-17T08:18:33.587Z",
+        "revisionId": "{{.keypairUnencryptedDestinationID}}",
+        "transformations": [],
+        "destinationDefinition": {
+          "config": {
+            "destConfig": {
+              "defaultConfig": [
+                "account",
+                "database",
+                "warehouse",
+                "user",
+                "password",
+                "cloudProvider",
+                "bucketName",
+                "containerName",
+                "storageIntegration",
+                "accessKeyID",
+                "accessKey",
+                "accountName",
+                "accountKey",
+                "credentials",
+                "namespace",
+                "prefix",
+                "syncFrequency",
+                "syncStartAt",
+                "enableSSE",
+                "excludeWindow",
+                "useRudderStorage"
+              ]
+            },
+            "secretKeys": [
+              "password",
+              "accessKeyID",
+              "accessKey"
+            ],
+            "excludeKeys": [],
+            "includeKeys": [],
+            "transformAt": "processor",
+            "transformAtV1": "processor",
+            "supportedSourceTypes": [
+              "android",
+              "ios",
+              "web",
+              "unity",
+              "amp",
+              "cloud",
+              "reactnative",
+              "cloudSource",
+              "flutter",
+              "cordova"
+            ],
+            "saveDestinationResponse": true
+          },
+          "responseRules": null,
+          "options": null,
+          "id": "1XjvXnzw34UMAz1YOuKqL1kwzh6",
+          "name": "SNOWFLAKE",
+          "displayName": "Snowflake",
+          "category": "warehouse",
+          "createdAt": "2020-02-13T05:39:20.184Z",
+          "updatedAt": "2022-02-08T06:46:45.432Z"
+        },
+        "isConnectionEnabled": true,
+        "isProcessorEnabled": true
+        }
+      ],
+      "sourceDefinition": {
+        "options": null,
+        "id": "1dCzCUAtpWDzNxgGUYzq9sZdZZB",
+        "name": "HTTP",
+        "displayName": "HTTP",
+        "category": "",
+        "createdAt": "2020-06-12T06:35:35.962Z",
+        "updatedAt": "2020-06-12T06:35:35.962Z"
+      },
+      "dgSourceTrackingPlanConfig": null
+    },
+    {
+      "config": {
+        "isSampleSource": true,
+        "eventUpload": false,
+        "eventUploadTS": 1646073666353
+      },
+      "liveEventsConfig": {
+        "eventUpload": false,
+        "eventUploadTS": 1646073666353
+      },
       "id": "{{.rbacSourceID}}",
       "name": "snowflake-rbac-integration",
       "writeKey": "{{.rbacWriteKey}}",

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -755,16 +755,23 @@ func WHCounterStat(name string, warehouse *model.Warehouse, extraTags ...Tag) st
 	return stats.Default.NewTaggedStat(name, stats.CountType, tags)
 }
 
-func formatSSLFile(content string) (formattedContent string) {
-	formattedContent = strings.ReplaceAll(content, "\n", "")
-	// Add new line at the end of -----BEGIN CERTIFICATE-----
+// FormatPemContent formats the content of certificates and keys by adding necessary newlines around specific markers.
+func FormatPemContent(content string) string {
+	// Remove all existing newline characters
+	formattedContent := strings.ReplaceAll(content, "\n", "")
+
+	// Add a newline after specific BEGIN markers
 	formattedContent = strings.Replace(formattedContent, "-----BEGIN CERTIFICATE-----", "-----BEGIN CERTIFICATE-----\n", 1)
-	// Add new line at the end of -----BEGIN RSA PRIVATE KEY-----
 	formattedContent = strings.Replace(formattedContent, "-----BEGIN RSA PRIVATE KEY-----", "-----BEGIN RSA PRIVATE KEY-----\n", 1)
-	// Add new line at the start and end of -----END CERTIFICATE-----
+	formattedContent = strings.Replace(formattedContent, "-----BEGIN ENCRYPTED PRIVATE KEY-----", "-----BEGIN ENCRYPTED PRIVATE KEY-----\n", 1)
+	formattedContent = strings.Replace(formattedContent, "-----BEGIN PRIVATE KEY-----", "-----BEGIN PRIVATE KEY-----\n", 1)
+
+	// Add a newline before and after specific END markers
 	formattedContent = strings.Replace(formattedContent, "-----END CERTIFICATE-----", "\n-----END CERTIFICATE-----\n", 1)
-	// Add new line at the start and end of -----END RSA PRIVATE KEY-----
 	formattedContent = strings.Replace(formattedContent, "-----END RSA PRIVATE KEY-----", "\n-----END RSA PRIVATE KEY-----\n", 1)
+	formattedContent = strings.Replace(formattedContent, "-----END ENCRYPTED PRIVATE KEY-----", "\n-----END ENCRYPTED PRIVATE KEY-----\n", 1)
+	formattedContent = strings.Replace(formattedContent, "-----END PRIVATE KEY-----", "\n-----END PRIVATE KEY-----\n", 1)
+
 	return formattedContent
 }
 
@@ -802,9 +809,9 @@ func WriteSSLKeys(destination backendconfig.DestinationT) WriteSSLKeyError {
 	if clientKeyConfig == nil || clientCertConfig == nil || serverCAConfig == nil {
 		return WriteSSLKeyError{fmt.Sprintf("Error extracting ssl information; invalid config passed for destination %s", destination.ID), "certs_nil_value"}
 	}
-	clientKey := formatSSLFile(clientKeyConfig.(string))
-	clientCert := formatSSLFile(clientCertConfig.(string))
-	serverCert := formatSSLFile(serverCAConfig.(string))
+	clientKey := FormatPemContent(clientKeyConfig.(string))
+	clientCert := FormatPemContent(clientCertConfig.(string))
+	serverCert := FormatPemContent(serverCAConfig.(string))
 	sslDirPath := fmt.Sprintf("%s/dest-ssls/%s", directoryName, destination.ID)
 	if err = os.MkdirAll(sslDirPath, 0o700); err != nil {
 		return WriteSSLKeyError{fmt.Sprintf("Error creating SSL root directory for destination %s %v", destination.ID, err), "dest_ssl_create_err"}


### PR DESCRIPTION
# Description

- Add support for [Key-pair authentication](https://docs.snowflake.com/en/user-guide/key-pair-auth) for Snowflake.
- More about it in [here](https://www.notion.so/rudderstacks/Key-Pair-13cadfa4e44e480fa58b5c6865bfe43f?pvs=4).

## Linear Ticket

- Resolves PIPE-1175

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated integration tests to use environment variables for checking test credentials availability.
  - Refactored Snowflake integration to support key pair authentication.

- **New Features**
  - Added support for key pair authentication in Snowflake integration.
  - Enhanced Snowflake integration configuration with new parameters for key pair authentication.

- **Chores**
  - Updated dependencies to include `github.com/youmark/pkcs8`.

- **Tests**
  - Expanded test cases to cover key pair encrypted and unencrypted scenarios in Snowflake integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->