### PR TITLE
chore: detect tracker not running

### DIFF
--- a/warehouse/router/tracker.go
+++ b/warehouse/router/tracker.go
@@ -23,7 +23,14 @@ import (
 // CronTracker Track the status of the staging file whether it has reached the terminal state or not for every warehouse
 // we pick the staging file which is oldest within the range NOW() - 2 * syncFrequency and NOW() - 3 * syncFrequency
 func (r *Router) CronTracker(ctx context.Context) error {
+	tick := r.statsFactory.NewTaggedStat("warehouse_cron_tracker_tick", stats.CountType, stats.Tags{
+		"module":   moduleName,
+		"destType": r.destType,
+	})
 	for {
+
+		tick.Count(1)
+
 		r.configSubscriberLock.RLock()
 		warehouses := append([]model.Warehouse{}, r.warehouses...)
 		r.configSubscriberLock.RUnlock()


### PR DESCRIPTION
# Description

Introduce `warehouse_cron_tracker_tick` metric, always incrementing. If cronTrack loop stop running, the metric will remain stable.

We can setup an alert on `increase(warehouse_cron_tracker_tick[5m]) = 0`

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1183/detect-stuck-cron-tracker

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
