### PR TITLE
chore: remove version from docker compose files

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   integration:
     name: Integration
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     strategy:
       matrix:
         FEATURES: [ oss ,enterprise ]
@@ -42,7 +42,7 @@ jobs:
           RSERVER_ENABLE_MULTITENANCY: false
   warehouse-integration:
     name: Warehouse Integration
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     strategy:
       fail-fast: false
       matrix:
@@ -99,7 +99,7 @@ jobs:
           path: coverage.txt
   unit:
     name: Unit
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     steps:
       - name: Disable IPv6 (temporary fix)
         run: |
@@ -119,7 +119,7 @@ jobs:
           path: coverage.txt
   package-unit:
     name: Package Unit
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     strategy:
       fail-fast: false
       matrix:
@@ -177,7 +177,7 @@ jobs:
           path: coverage.txt
   coverage:
     name: Coverage
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-24.04'
     needs:
       - warehouse-integration
       - unit
@@ -203,7 +203,7 @@ jobs:
   all-green:
     name: All
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - integration
       - warehouse-integration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   db:
     image: postgres:15-alpine
@@ -21,9 +19,9 @@ services:
       - build/docker.env
     environment:
       - JOBS_DB_HOST=db
-  #   Uncomment the following lines to mount workspaceConfig file
-  #   volumes:
-  #     - <absolute_path_to_workspace_config>:/etc/rudderstack/workspaceConfig.json
+    # Uncomment the following lines to mount workspaceConfig file
+    # volumes:
+    #   - <absolute_path_to_workspace_config>:/etc/rudderstack/workspaceConfig.json
   transformer:
     image: "rudderstack/rudder-transformer:latest"
     ports:

--- a/integration_test/warehouse/testdata/docker-compose.ssh-server.yml
+++ b/integration_test/warehouse/testdata/docker-compose.ssh-server.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   ssh-server:
     image: lscr.io/linuxserver/openssh-server:9.3_p2-r1-ls145

--- a/rudder-docker.yml
+++ b/rudder-docker.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   db:
     image: postgres:15-alpine

--- a/warehouse/integrations/azure-synapse/testdata/docker-compose.yml
+++ b/warehouse/integrations/azure-synapse/testdata/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   azure_synapse:
     image: rudderstack/azure-sql-edge:1.0.6

--- a/warehouse/integrations/clickhouse/testdata/docker-compose.clickhouse-cluster.yml
+++ b/warehouse/integrations/clickhouse/testdata/docker-compose.clickhouse-cluster.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   zookeeper:
     image: zookeeper:3.5
@@ -8,7 +6,7 @@ services:
       interval: 1s
       retries: 25
   clickhouse01:
-    image: yandex/clickhouse-server:21-alpine
+    image: clickhouse/clickhouse-server:24-alpine
     ports:
       - "9000"
     volumes:
@@ -20,7 +18,7 @@ services:
       interval: 1s
       retries: 25
   clickhouse02:
-    image: yandex/clickhouse-server:21-alpine
+    image: clickhouse/clickhouse-server:24-alpine
     ports:
       - "9000"
     volumes:
@@ -32,7 +30,7 @@ services:
       interval: 1s
       retries: 25
   clickhouse03:
-    image: yandex/clickhouse-server:21-alpine
+    image: clickhouse/clickhouse-server:24-alpine
     ports:
       - "9000"
     volumes:
@@ -44,7 +42,7 @@ services:
       interval: 1s
       retries: 25
   clickhouse04:
-    image: yandex/clickhouse-server:21-alpine
+    image: clickhouse/clickhouse-server:24-alpine
     ports:
       - "9000"
     volumes:

--- a/warehouse/integrations/clickhouse/testdata/docker-compose.clickhouse.yml
+++ b/warehouse/integrations/clickhouse/testdata/docker-compose.clickhouse.yml
@@ -1,8 +1,6 @@
-version: "3.9"
-
 services:
   clickhouse:
-    image: yandex/clickhouse-server:21-alpine
+    image: clickhouse/clickhouse-server:24-alpine
     environment:
       - CLICKHOUSE_DB=rudderdb
       - CLICKHOUSE_PASSWORD=rudder-password

--- a/warehouse/integrations/datalake/testdata/docker-compose.spark.yml
+++ b/warehouse/integrations/datalake/testdata/docker-compose.spark.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   spark-master:
     image: bitnami/spark:latest

--- a/warehouse/integrations/datalake/testdata/docker-compose.trino.yml
+++ b/warehouse/integrations/datalake/testdata/docker-compose.trino.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   trino:
     image: trinodb/trino:latest

--- a/warehouse/integrations/datalake/testdata/docker-compose.yml
+++ b/warehouse/integrations/datalake/testdata/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3.9"
-
 services:
   azure:
-    image: mcr.microsoft.com/azure-storage/azurite:latest
+    image: mcr.microsoft.com/azure-storage/azurite:3.29.0
     ports:
       - "10000"
     environment:

--- a/warehouse/integrations/mssql/testdata/docker-compose.yml
+++ b/warehouse/integrations/mssql/testdata/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   mssql:
     image: rudderstack/azure-sql-edge:1.0.6

--- a/warehouse/integrations/postgres/testdata/docker-compose.postgres.yml
+++ b/warehouse/integrations/postgres/testdata/docker-compose.postgres.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   postgres:
     image: postgres:latest

--- a/warehouse/integrations/postgres/testdata/docker-compose.ssh-server.yml
+++ b/warehouse/integrations/postgres/testdata/docker-compose.ssh-server.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   ssh-server:
     image: lscr.io/linuxserver/openssh-server:9.3_p2-r1-ls145

--- a/warehouse/integrations/testdata/docker-compose.jobsdb.yml
+++ b/warehouse/integrations/testdata/docker-compose.jobsdb.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   jobsDb:
     image: postgres:latest

--- a/warehouse/integrations/testdata/docker-compose.minio.yml
+++ b/warehouse/integrations/testdata/docker-compose.minio.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   minio:
     image: minio/minio:latest

--- a/warehouse/integrations/tunnelling/testdata/docker-compose.yml
+++ b/warehouse/integrations/tunnelling/testdata/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   openssh-server:
     image: lscr.io/linuxserver/openssh-server:9.3_p2-r1-ls145


### PR DESCRIPTION
# Description

Tests started failing and it seems like docker no longer needs version in `docker-compose `files as mentioned [here](https://github.com/mailcow/mailcow-dockerized/issues/5797). This PR removes the version from the files 


## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
