### PR TITLE
chore: fix warehouse integration tests

### DIFF
--- a/warehouse/integrations/clickhouse/testdata/docker-compose.clickhouse-cluster.yml
+++ b/warehouse/integrations/clickhouse/testdata/docker-compose.clickhouse-cluster.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - zookeeper
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
+      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:8123/ping || exit 1
       interval: 1s
       retries: 25
   clickhouse02:
@@ -28,7 +28,7 @@ services:
     depends_on:
       - zookeeper
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
+      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:8123/ping || exit 1
       interval: 1s
       retries: 25
   clickhouse03:
@@ -40,7 +40,7 @@ services:
     depends_on:
       - zookeeper
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
+      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:8123/ping || exit 1
       interval: 1s
       retries: 25
   clickhouse04:
@@ -52,6 +52,6 @@ services:
     depends_on:
       - zookeeper
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
+      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:8123/ping || exit 1
       interval: 1s
       retries: 25

--- a/warehouse/integrations/clickhouse/testdata/docker-compose.clickhouse.yml
+++ b/warehouse/integrations/clickhouse/testdata/docker-compose.clickhouse.yml
@@ -10,6 +10,6 @@ services:
     ports:
       - "9000"
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
+      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:8123/ping || exit 1
       interval: 1s
       retries: 25

--- a/warehouse/integrations/datalake/testdata/docker-compose.yml
+++ b/warehouse/integrations/datalake/testdata/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - AZURITE_ACCOUNTS=MYACCESSKEY:TVlTRUNSRVRLRVk=
       - DefaultEndpointsProtocol=http
     healthcheck:
-      test: nc -z localhost 10000 || exit 1
+      test: nc -z 0.0.0.0 10000 || exit 1
       interval: 1s
       retries: 25
 


### PR DESCRIPTION
# Description
Clickhouse and datalake tests were failing, as the container was unheathy. The issue was with docker versions 26.1.x. Event though we had disabled ipv6 on the host machine localhost requests were resolved to `[::]:8123` in container which is ipv6 address. When I switched from `localhost` to `0.0.0.0` everything worked.

```
runner@fv-az532-110:~/work/rudder-server/rudder-server$ docker exec -it test_qzldqgzazleffkelfbjz-clickhouse04-1 wget --no-verbose --tries=1 --spider http://localhost:8123/ping                                                                     
Connecting to localhost:8123 ([::1]:8123)
wget: can't connect to remote host: Connection refused

runner@fv-az532-110:~/work/rudder-server/rudder-server$ docker exec -it test_qzldqgzazleffkelfbjz-clickhouse04-1 wget --no-verbose --tries=1 --spider http://0.0.0.0:8123/ping                                                                       
Connecting to 0.0.0.0:8123 (0.0.0.0:8123)
remote file exists
runner@fv-az532-110:~/work/rudder-server/rudder-server$ 
```

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1191/fix-warehouse-test-case-failures

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
