### PR TITLE
chore: fix workspace id in tags

### DIFF
--- a/services/rmetrics/pending-events.go
+++ b/services/rmetrics/pending-events.go
@@ -50,8 +50,8 @@ func (r pendingEventsMeasurement) GetName() string {
 
 func (r pendingEventsMeasurement) GetTags() map[string]string {
 	return map[string]string{
-		"workspaceId": r.workspace,
-		"destType":    r.destType,
+		"workspace_id": r.workspace,
+		"destType":     r.destType,
 	}
 }
 


### PR DESCRIPTION
# Description

`workspaceId` in tag is getting replaced by workspaceID defined in customer object. For enterprise customers its fine but for multitenant customers workspaceID is set as namespace of the deployment.

So renaming the tag to `workspace_id`

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
