### PR TITLE
chore: enable sending request headers to source webhook

### DIFF
--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -47,7 +47,7 @@ const (
 	// NonIdentifiableRequest - Request neither has anonymousId nor userId
 	NonIdentifiableRequest = "Request neither has anonymousId nor userId"
 	// ErrorInMarshal - Error while marshalling
-	ErrorInMarshal = "Error while marshalling"
+	ErrorInMarshal              = "Error while marshalling"
 	ErrorInMarshallingReqHeader = "error while marshalling request headers"
 	// ErrorInParseForm - Error during parsing form
 	ErrorInParseForm = "Error during parsing form"

--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -48,6 +48,7 @@ const (
 	NonIdentifiableRequest = "Request neither has anonymousId nor userId"
 	// ErrorInMarshal - Error while marshalling
 	ErrorInMarshal = "Error while marshalling"
+	ErrorInMarshallingReqHeader = "error while marshalling request headers"
 	// ErrorInParseForm - Error during parsing form
 	ErrorInParseForm = "Error during parsing form"
 	// ErrorInParseMultiform - Error during parsing multiform

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -301,7 +301,7 @@ func prepareRequestBody(req *http.Request, sourceType string, sourceListForParsi
 		if err != nil {
 			return nil, fmt.Errorf("setting headers into source transform req body:%w", err)
 		}
-		body, err = sjson.SetRawBytes(body, "httpRequest.method", []byte(req.Method))
+		body, err = sjson.SetBytes(body, "httpRequest.method", []byte(req.Method))
 		if err != nil {
 			return nil, fmt.Errorf("setting method into source transform req body:%w", err)
 		}

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -448,18 +448,17 @@ func TestPrepareRequestBody(t *testing.T) {
 	}
 
 	type reqWithHeadersInput struct {
-		method string
-		target string
-		body io.Reader
-		params map[string]string
+		method  string
+		target  string
+		body    io.Reader
+		params  map[string]string
 		headers map[string]string
 	}
 
-
 	createReqWithHeaders := func(input reqWithHeadersInput) *http.Request {
 		r := httptest.NewRequest(input.method, input.target, input.body)
-		for k,v := range input.headers {
-			r.Header.Add(k,v)
+		for k, v := range input.headers {
+			r.Header.Add(k, v)
 		}
 		q := r.URL.Query()
 		for k, v := range input.params {
@@ -527,11 +526,11 @@ func TestPrepareRequestBody(t *testing.T) {
 			expectedResponse: []byte(`{"query_parameters":{"key2":["value2"]},"httpRequest":{"headers":{},"method":"POST"}}`),
 		},
 		{
-			name:             "No payload with query parameters & headers for Adjust",
-			req:              createReqWithHeaders(reqWithHeadersInput{
+			name: "No payload with query parameters & headers for Adjust",
+			req: createReqWithHeaders(reqWithHeadersInput{
 				method: http.MethodPost,
 				target: "http://example.com",
-				body: nil,
+				body:   nil,
 				params: map[string]string{"key2": "value2"},
 				headers: map[string]string{
 					"X-Some-Value-1": "1",


### PR DESCRIPTION
# Description

Enable sending request headers & request method information to source webhook

## Linear Ticket

Resolves INT-2193

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
