### PR TITLE
fix: memory leak for clickhouse during loading

### DIFF
--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -727,6 +727,7 @@ func (ch *Clickhouse) loadTablesFromFilesNamesWithRetry(ctx context.Context, tab
 				ch.logger.Debugf("%s Starting Prepared statement exec", ch.GetLogIdentifier(tableName))
 				_, err = stmt.ExecContext(stmtCtx, recordInterface...)
 				ch.logger.Debugf("%s Completed Prepared statement exec", ch.GetLogIdentifier(tableName))
+				stmtCancel()
 			}, func() {
 				ch.logger.Debugf("%s Cancelling and closing statement", ch.GetLogIdentifier(tableName))
 				stmtCancel()


### PR DESCRIPTION
# Description

- We are not closing the context causing the memory leak to happen for `clickhouse` during `ExecContext`.

## Linear Ticket

- Resolves PIPE-1211

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
