### PR TITLE
chore: sync release v1.28.1 to main branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.28.1](https://github.com/rudderlabs/rudder-server/compare/v1.28.0...v1.28.1) (2024-06-21)
+
+
+### Bug Fixes
+
+* memory leak for clickhouse during loading ([#4829](https://github.com/rudderlabs/rudder-server/issues/4829)) ([7772638](https://github.com/rudderlabs/rudder-server/commit/77726383c8c218af0f9a3de68d19ede7cab8506e))
+
 ## [1.28.0](https://github.com/rudderlabs/rudder-server/compare/v1.27.0...v1.28.0) (2024-06-19)
 
 

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -727,6 +727,7 @@ func (ch *Clickhouse) loadTablesFromFilesNamesWithRetry(ctx context.Context, tab
 				ch.logger.Debugf("%s Starting Prepared statement exec", ch.GetLogIdentifier(tableName))
 				_, err = stmt.ExecContext(stmtCtx, recordInterface...)
 				ch.logger.Debugf("%s Completed Prepared statement exec", ch.GetLogIdentifier(tableName))
+				stmtCancel()
 			}, func() {
 				ch.logger.Debugf("%s Cancelling and closing statement", ch.GetLogIdentifier(tableName))
 				stmtCancel()


### PR DESCRIPTION
# Description

Syncing patch release v1.28.1 to main branch

**↓↓ Please review and edit commit overrides before merging ↓↓**

BEGIN_COMMIT_OVERRIDE
fix: memory leak for clickhouse during loading (#4829)
END_COMMIT_OVERRIDE