### PR TITLE
fix: use safeguard to panic if not stop on time

### DIFF
--- a/warehouse/integrations/postgres/load.go
+++ b/warehouse/integrations/postgres/load.go
@@ -11,8 +11,10 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/types"
+	"github.com/rudderlabs/rudder-server/warehouse/safeguard"
 
 	sqlmiddleware "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
@@ -32,6 +34,9 @@ type loadUsersTableResponse struct {
 
 func (pg *Postgres) LoadTable(ctx context.Context, tableName string) (*types.LoadTableStats, error) {
 	var loadTableStats *types.LoadTableStats
+	cancel := safeguard.MustStop(ctx, 5*time.Minute)
+	defer cancel()
+
 	err := pg.DB.WithTx(ctx, func(tx *sqlmiddleware.Tx) error {
 		var err error
 		loadTableStats, _, err = pg.loadTable(

--- a/warehouse/safeguard/stop.go
+++ b/warehouse/safeguard/stop.go
@@ -1,0 +1,50 @@
+package safeguard
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+var defaultGuard = &Guard{}
+
+type Guard struct {
+	Go   func(func())
+	once sync.Once
+}
+
+func (g *Guard) MustStop(ctx context.Context, timeout time.Duration) func() {
+	g.once.Do(func() {
+		if g.Go == nil {
+			g.Go = func(fn func()) {
+				go fn()
+			}
+		}
+	})
+
+	inCtx, cancel := context.WithCancel(context.Background())
+
+	g.Go(func() {
+		select {
+		case <-inCtx.Done():
+			return
+		case <-ctx.Done():
+		}
+
+		timer := time.NewTimer(timeout)
+		select {
+		case <-timer.C:
+			panic("timeout waiting for method stop")
+		case <-inCtx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+		}
+	})
+
+	return cancel
+}
+
+func MustStop(ctx context.Context, timeout time.Duration) func() {
+	return defaultGuard.MustStop(ctx, timeout)
+}

--- a/warehouse/safeguard/stop_test.go
+++ b/warehouse/safeguard/stop_test.go
@@ -1,0 +1,52 @@
+package safeguard_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-server/warehouse/safeguard"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMustStop(t *testing.T) {
+	t.Run("no panic: if context not canceled", func(t *testing.T) {
+		stop := safeguard.MustStop(context.Background(), 1*time.Millisecond)
+		<-time.After(3 * time.Millisecond)
+		stop()
+	})
+
+	t.Run("no panic: if within timeout", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		stop := safeguard.MustStop(ctx, 2*time.Millisecond)
+		stop()
+	})
+
+	t.Run("panic: timeout before stop called", func(t *testing.T) {
+		t.Helper()
+		wg := sync.WaitGroup{}
+
+		Go := func(fn func()) {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				require.Panics(t, fn)
+			}()
+		}
+
+		g := &safeguard.Guard{
+			Go: Go,
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_ = g.MustStop(ctx, 1*time.Millisecond)
+
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
# Description

## Motivation
It has been observe in production that during shutdown postgres can get stuck on rollback, ignoring ctx cancelation:

```
github.com/lib/pq.(*conn).Rollback(0x4025540908)
	/go/pkg/mod/github.com/lib/pq@v1.10.9/conn.go:646 +0xc8
database/sql.(*Tx).rollback.func1()
	/usr/local/go/src/database/sql/sql.go:2335 +0x34
database/sql.withLock({0x3c84c08, 0x408783a090}, 0x40a6da58b0)
	/usr/local/go/src/database/sql/sql.go:3530 +0x7c
database/sql.(*Tx).rollback(0x4045941380, 0x0)
	/usr/local/go/src/database/sql/sql.go:2334 +0xf0
database/sql.(*Tx).Rollback(...)
	/usr/local/go/src/database/sql/sql.go:2349
github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper.(*Tx).Rollback(0x4053255050)
	/rudder-server/warehouse/integrations/middleware/sqlquerywrapper/sql.go:347 +0x64
github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper.(*DB).WithTx(...)
	/rudder-server/warehouse/integrations/middleware/sqlquerywrapper/sql.go:212 +0x104
github.com/rudderlabs/rudder-server/warehouse/integrations/postgres.(*Postgres).LoadTable(...)
```
 
## Proposed work-around

`safeguard.MustStop` ensures that when ctx is canceled the function must return within the specified time. Otherwise it will panic.

Notes:
* We should fix the core issue, which would probably require us moving to pgx.
* I tried to be as precise as possible with introducing this workaround. Potential this technique can be used in other places, but I believe we should trust that ctx cancellation works rather than safe guarding around it.


## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1231/safeguard-ctx-cancellation

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
