### PR TITLE
chore: update default mtu config

### DIFF
--- a/enterprise/trackedusers/users_reporter.go
+++ b/enterprise/trackedusers/users_reporter.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rudderlabs/rudder-server/utils/timeutil"
+
 	"github.com/rudderlabs/rudder-go-kit/stats"
 
 	"github.com/rudderlabs/rudder-server/jobsdb"
@@ -70,7 +72,7 @@ func NewUniqueUsersReporter(log logger.Logger, conf *config.Config, stats stats.
 		instanceID: config.GetString("INSTANCE_ID", "1"),
 		stats:      stats,
 		now: func() time.Time {
-			return time.Now().UTC()
+			return timeutil.Now()
 		},
 	}, nil
 }

--- a/enterprise/trackedusers/users_reporter.go
+++ b/enterprise/trackedusers/users_reporter.go
@@ -62,7 +62,7 @@ func NewUniqueUsersReporter(log logger.Logger, conf *config.Config, stats stats.
 	return &UniqueUsersReporter{
 		log: log,
 		hllSettings: &hll.Settings{
-			Log2m:             conf.GetInt("TrackedUsers.precision", 14),
+			Log2m:             conf.GetInt("TrackedUsers.precision", 16),
 			Regwidth:          conf.GetInt("TrackedUsers.registerWidth", 5),
 			ExplicitThreshold: hll.AutoExplicitThreshold,
 			SparseEnabled:     true,
@@ -70,7 +70,7 @@ func NewUniqueUsersReporter(log logger.Logger, conf *config.Config, stats stats.
 		instanceID: config.GetString("INSTANCE_ID", "1"),
 		stats:      stats,
 		now: func() time.Time {
-			return time.Now()
+			return time.Now().UTC()
 		},
 	}, nil
 }

--- a/enterprise/trackedusers/users_reporter_test.go
+++ b/enterprise/trackedusers/users_reporter_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	hllSettings          = hll.Settings{Log2m: 14, Regwidth: 5, ExplicitThreshold: hll.AutoExplicitThreshold, SparseEnabled: true}
+	hllSettings          = hll.Settings{Log2m: 16, Regwidth: 5, ExplicitThreshold: hll.AutoExplicitThreshold, SparseEnabled: true}
 	sampleWorkspaceID    = "workspaceID"
 	sampleWorkspaceID2   = "workspaceID2"
 	sampleSourceID       = "sourceID"


### PR DESCRIPTION
# Description

- Update default value for MTU precision to 16
- Set timezone for reported_at in UTC as flusher is expecting time in UTC timezone. currently we are storing timezone in the DB so it should not an issue. 

## Linear Ticket

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
