### PR TITLE
chore: add mock reporting server in mtu integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -135,6 +135,7 @@ jobs:
           - integration_test/warehouse
           - integration_test/tracing
           - integration_test/backendconfigunavailability
+          - integration_test/trackedusersreporting
           - processor
           - regulation-worker
           - router


### PR DESCRIPTION
# Description
Add mock reporting server in MTU integration tests where currently we are reading from DB and validating. We need to add a mock reporting server to record the requests and aggregate HLLs and see if correct data is showing up.

## Linear Ticket
https://linear.app/rudderstack/issue/PIPE-1300/add-mock-reporting-server-in-mtu-integration-tests

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
