### PR TITLE
feat: drop trigger for populating warehouse schema versions

### DIFF
--- a/sql/migrations/warehouse/000025_drop_trigger_schema_versions.sql.up.sql
+++ b/sql/migrations/warehouse/000025_drop_trigger_schema_versions.sql.up.sql
@@ -1,0 +1,2 @@
+
+DROP TRIGGER IF EXISTS warehouse_schema_history_trigger ON wh_schemas;


### PR DESCRIPTION
# Description

Stop populating `wh_schema_version` table.


## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1318/stop-populating-schema-versions

Resolves PIPE-1318

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
