### PR TITLE
chore: upgrade go v1.22.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # syntax=docker/dockerfile:1
 
 # GO_VERSION is updated automatically to match go.mod, see Makefile
-ARG GO_VERSION=1.22.4
+ARG GO_VERSION=1.22.5
 ARG ALPINE_VERSION=3.20
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 ARG VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudderlabs/rudder-server
 
-go 1.22.4
+go 1.22.5
 
 // Addressing snyk vulnerabilities in indirect dependencies
 // When upgrading a dependency, please make sure that

--- a/suppression-backup-service/Dockerfile
+++ b/suppression-backup-service/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # GO_VERSION is updated automatically to match go.mod, see Makefile
-ARG GO_VERSION=1.22.4
+ARG GO_VERSION=1.22.5
 ARG ALPINE_VERSION=3.20
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 RUN mkdir /app


### PR DESCRIPTION
# Description

Addressing:
```
Vulnerability #1: GO-2024-2963
    Denial of service due to improper 100-continue handling in net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2963
  Standard library
    Found in: net/http@go1.22.4
    Fixed in: net/http@go1.22.5
    Example traces found:
      #1: services/streammanager/googlecloudfunction/googlecloudfunction.go:169:42: googlecloudfunction.GoogleCloudFunctionProducer.Close calls http.Client.CloseIdleConnections
      #2: utils/misc/misc.go:346:24: misc.MakeHTTPRequestWithTimeout calls http.Client.Do
      #3: integration_test/retl_test/sut.go:348:28: retl_test.SUT.JobStatus calls http.Client.Get
      #4: services/alert/pagerduty.go:35:26: alert.PagerDuty.Alert calls http.Client.Post
      #5: services/streammanager/googlecloudfunction/googlecloudfunction.go:86:17: googlecloudfunction.GoogleCloudFunctionClientImpl.GetToken calls oauth2.reuseTokenSource.Token, which eventually calls http.Client.PostForm
      #6: testhelper/health/checker.go:27:25: health.WaitUntilReady calls http.Get
      #7: testhelper/webhook/recorder.go:56:18: webhook.Recorder.Close calls httptest.Server.Close, which calls http.Transport.CloseIdleConnections
      #8: services/oauth/v2/http/transport.go:261:31: http.OAuthTransport.RoundTrip calls http.Transport.RoundTrip

Your code is affected by 1 vulnerability from the Go standard library.
```
## Linear Ticket

Resolves PIPE-1313

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
