### PR TITLE
chore: automate server release on hosted with prerelease

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -12,6 +12,7 @@ jobs:
         run: echo "branch=$(echo "${GITHUB_REF#refs/heads/}")" >> $GITHUB_OUTPUT
         id: extract_branch
       - uses: google-github-actions/release-please-action@v3
+        id: release_action
         with:
           token: ${{ secrets.PAT }}
           pull-request-title-pattern: "chore: prerelease ${version}"
@@ -58,6 +59,8 @@ jobs:
         id: extract_version
       - name: Trigger dispatch event
         uses: peter-evans/repository-dispatch@v3
+        # release please run 2 times, first for creating the PR and second for creating the release
+        if: ${{ steps.release_action.outputs.releases_created == 'true' }}
         with:
           token: "${{ secrets.PAT }}"
           repository: rudderlabs/rudder-devops

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=$(echo "${GITHUB_REF#refs/heads/}")" >> $GITHUB_OUTPUT
         id: extract_branch
       - uses: google-github-actions/release-please-action@v3
         with:
@@ -53,9 +53,9 @@ jobs:
           prerelease: true
           release-as: ${{ steps.extract_branch.outputs.branch }}
       - name: Extract prerelease version
-        id: extract_version
         shell: bash
         run: echo "version=$(echo "${{ steps.extract_branch.outputs.branch }}" | cut -d'/' -f2)" >> $GITHUB_OUTPUT
+        id: extract_version
       - name: Trigger dispatch event
         uses: peter-evans/repository-dispatch@v3
         with:
@@ -64,7 +64,5 @@ jobs:
           event-type: release-server-hosted
           client-payload: |
             {
-                "version": "${{ steps.extract_version.outputs.version }}",
-              },
-              "value-paths": []
+                "version": "${{ steps.extract_version.outputs.version }}"
             }

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -52,3 +52,19 @@ jobs:
             ]'
           prerelease: true
           release-as: ${{ steps.extract_branch.outputs.branch }}
+      - name: Extract prerelease version
+        id: extract_version
+        shell: bash
+        run: echo "version=$(echo "${{ steps.extract_branch.outputs.branch }}" | cut -d'/' -f2)" >> $GITHUB_OUTPUT
+      - name: Trigger dispatch event
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: "${{ secrets.PAT }}"
+          repository: rudderlabs/rudder-devops
+          event-type: release-server-hosted
+          client-payload: |
+            {
+                "version": "${{ steps.extract_version.outputs.version }}",
+              },
+              "value-paths": []
+            }


### PR DESCRIPTION
# Description

automate server release on hosted whenever we push to a pre-release branch

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1327/trigger-release-workflow-from-pre-release

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
