### PR TITLE
fix: introduce config for get requests in webhook sources

### DIFF
--- a/gateway/webhook/setup.go
+++ b/gateway/webhook/setup.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 
@@ -55,6 +56,14 @@ func Setup(gwHandle Gateway, transformerFeaturesService transformer.FeaturesServ
 	maxTransformerProcess := config.GetIntVar(64, 1, "Gateway.webhook.maxTransformerProcess")
 	// Parse all query params from sources mentioned in this list
 	webhook.config.sourceListForParsingParams = config.GetStringSliceVar([]string{"Shopify", "adjust"}, "Gateway.webhook.sourceListForParsingParams")
+
+	webhook.config.forwardGetRequestForSrcMap = lo.SliceToMap(
+		config.GetStringSliceVar([]string{"adjust"}, "Gateway.webhook.forwardGetRequestForSrcs"),
+		func(item string) (string, struct{}) {
+			return item, struct{}{}
+		},
+	)
+
 	// lowercasing the strings in sourceListForParsingParams
 	for i, s := range webhook.config.sourceListForParsingParams {
 		webhook.config.sourceListForParsingParams[i] = strings.ToLower(s)

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -69,6 +69,7 @@ type HandleT struct {
 		webhookBatchTimeout        config.ValueLoader[time.Duration]
 		maxWebhookBatchSize        config.ValueLoader[int]
 		sourceListForParsingParams []string
+		forwardGetRequestForSrcMap map[string]struct{}
 	}
 }
 
@@ -104,6 +105,11 @@ func (webhook *HandleT) failRequest(w http.ResponseWriter, r *http.Request, reas
 	http.Error(w, reason, statusCode)
 }
 
+func (wb *HandleT) IsGetAndNotAllow(reqMethod, sourceDefName string) bool {
+	_, ok := wb.config.forwardGetRequestForSrcMap[sourceDefName]
+	return reqMethod == http.MethodGet && !ok
+}
+
 func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 	reqType := r.Context().Value(gwtypes.CtxParamCallType).(string)
 	arctx := r.Context().Value(gwtypes.CtxParamAuthRequestContext).(*gwtypes.AuthRequestContext)
@@ -114,7 +120,7 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 	var postFrom url.Values
 	var multipartForm *multipart.Form
 
-	if r.Method == "GET" {
+	if webhook.IsGetAndNotAllow(r.Method, sourceDefName) {
 		return
 	}
 	contentType := r.Header.Get("Content-Type")

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -518,3 +518,96 @@ func TestPrepareRequestBody(t *testing.T) {
 		})
 	}
 }
+
+func TestAllowGetReqForWebhookSrc(t *testing.T) {
+	initWebhook()
+	ctrl := gomock.NewController(t)
+	mockGW := mockWebhook.NewMockGateway(ctrl)
+	transformerServer := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() { _ = r.Body.Close() }()
+			body, _ := io.ReadAll(r.Body)
+			var requests []interface{}
+			_ = json.Unmarshal(body, &requests)
+			var responses []transformerResponse
+			for i := 0; i < len(requests); i++ {
+				responses = append(responses, transformerResponse{
+					OutputToSource: outputToWebhook,
+					StatusCode:     http.StatusOK,
+				})
+			}
+			respBody, _ := json.Marshal(responses)
+			_, _ = w.Write(respBody)
+		}))
+	wbh := Setup(mockGW, transformer.NewNoOpService(), stats.Default, func(bt *batchWebhookTransformerT) {
+		bt.sourceTransformAdapter = getMockSourceTransformAdapterFunc(transformerServer.URL)
+	})
+	type testCase struct {
+		description string
+		input       struct {
+			srcMap map[string]struct{}
+			method string
+			srcDef string
+		}
+		output bool
+	}
+
+	cases := []testCase{
+		{
+			description: "should allow get request for adjust",
+			input: struct {
+				srcMap map[string]struct{}
+				method string
+				srcDef string
+			}{
+				method: http.MethodGet,
+				srcMap: map[string]struct{}{
+					"adjust": {},
+				},
+				srcDef: "adjust",
+			},
+			output: false,
+		},
+		{
+			description: "should allow post request for adjust",
+			input: struct {
+				srcMap map[string]struct{}
+				method string
+				srcDef string
+			}{
+				method: http.MethodPost,
+				srcMap: map[string]struct{}{
+					"adjust": {},
+				},
+				srcDef: "adjust",
+			},
+			output: false,
+		},
+		{
+			description: "should not allow get request for shopify",
+			input: struct {
+				srcMap map[string]struct{}
+				method string
+				srcDef string
+			}{
+				srcMap: map[string]struct{}{
+					"adjust":     {},
+					"customerio": {},
+				},
+				method: http.MethodGet,
+				srcDef: "Shopify",
+			},
+			output: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			if len(tc.input.srcDef) != 0 {
+				wbh.config.forwardGetRequestForSrcMap = tc.input.srcMap
+			}
+			isGetAndNotAllow := wbh.IsGetAndNotAllow(tc.input.method, tc.input.srcDef)
+			require.Equal(t, tc.output, isGetAndNotAllow)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Introduce configuration to allow GET requests in webhook sources. Currently we have added adjust source by default as one of the sources which sends source event via GET calls to rudderstack webhook

## Linear Ticket

Resolves INT-2460

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
