### PR TITLE
fix: syncs dashboard

### DIFF
--- a/warehouse/internal/repo/table_upload.go
+++ b/warehouse/internal/repo/table_upload.go
@@ -381,7 +381,7 @@ func (tu *TableUploads) SyncsInfo(ctx context.Context, uploadID int64) ([]model.
 	}
 
 	tableUploadInfos := lo.Map(tableUploads, func(item model.TableUpload, index int) model.TableUploadInfo {
-		return model.TableUploadInfo{
+		tuf := model.TableUploadInfo{
 			ID:         item.ID,
 			UploadID:   item.UploadID,
 			Name:       item.TableName,
@@ -389,8 +389,11 @@ func (tu *TableUploads) SyncsInfo(ctx context.Context, uploadID int64) ([]model.
 			Error:      item.Error,
 			LastExecAt: item.LastExecTime,
 			Count:      item.TotalEvents,
-			Duration:   int64(item.UpdatedAt.Sub(item.LastExecTime) / time.Second),
 		}
+		if !item.LastExecTime.IsZero() {
+			tuf.Duration = int64(item.UpdatedAt.Sub(item.LastExecTime) / time.Second)
+		}
+		return tuf
 	})
 	return tableUploadInfos, nil
 }

--- a/warehouse/internal/repo/table_upload_test.go
+++ b/warehouse/internal/repo/table_upload_test.go
@@ -111,6 +111,21 @@ func TestTableUploadRepo(t *testing.T) {
 			}
 		})
 
+		t.Run("last exec time is nil", func(t *testing.T) {
+			uploadID := int64(2)
+
+			err := r.Insert(ctx, uploadID, tables)
+			require.NoError(t, err)
+
+			syncsInfos, err := r.SyncsInfo(ctx, uploadID)
+			require.NoError(t, err)
+			require.Len(t, syncsInfos, len(tables))
+			for i := range syncsInfos {
+				require.Zero(t, syncsInfos[i].LastExecAt)
+				require.Zero(t, syncsInfos[i].Duration)
+			}
+		})
+
 		t.Run("invalid sync id", func(t *testing.T) {
 			syncsInfos, err := r.SyncsInfo(ctx, int64(-1))
 			require.NoError(t, err)

--- a/warehouse/internal/repo/upload_test.go
+++ b/warehouse/internal/repo/upload_test.go
@@ -1563,7 +1563,7 @@ func TestUploads_SyncsInfo(t *testing.T) {
 			require.Equal(t, uploadInfo.Error, "{}")
 			require.Zero(t, uploadInfo.LastExecAt)
 			require.Equal(t, uploadInfo.NextRetryTime.UTC(), now.UTC())
-			require.Equal(t, uploadInfo.Duration, now.Sub(time.Time{})/time.Second)
+			require.Zero(t, uploadInfo.Duration)
 			require.Zero(t, uploadInfo.Attempt)
 			require.False(t, uploadInfo.IsArchivedUpload)
 		}
@@ -1590,7 +1590,7 @@ func TestUploads_SyncsInfo(t *testing.T) {
 			require.Equal(t, uploadInfo.Error, "{}")
 			require.Zero(t, uploadInfo.LastExecAt)
 			require.Zero(t, uploadInfo.NextRetryTime)
-			require.Equal(t, uploadInfo.Duration, now.Sub(time.Time{})/time.Second)
+			require.Zero(t, uploadInfo.Duration)
 			require.Zero(t, uploadInfo.Attempt)
 			require.True(t, uploadInfo.IsArchivedUpload)
 		}


### PR DESCRIPTION
# Description

- Fixes in syncs dashboard
  - souceID filter is not working as expected.
  - In case of `lastExecAt` is set as NULL, it behaving in an unexpected way.

## Linear Ticket

- Resolves PIPE-1232
- Resolves PIPE-1344

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.