### PR TITLE
chore: enforce max limit for webhook

### DIFF
--- a/gateway/webhook/setup.go
+++ b/gateway/webhook/setup.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	gwstats "github.com/rudderlabs/rudder-server/gateway/internal/stats"
 	gwtypes "github.com/rudderlabs/rudder-server/gateway/internal/types"
 	"github.com/rudderlabs/rudder-server/gateway/webhook/model"
@@ -56,6 +57,8 @@ func Setup(gwHandle Gateway, transformerFeaturesService transformer.FeaturesServ
 	maxTransformerProcess := config.GetIntVar(64, 1, "Gateway.webhook.maxTransformerProcess")
 	// Parse all query params from sources mentioned in this list
 	webhook.config.sourceListForParsingParams = config.GetStringSliceVar([]string{"Shopify", "adjust"}, "Gateway.webhook.sourceListForParsingParams")
+	// Maximum request size to gateway
+	webhook.config.maxReqSize = config.GetReloadableIntVar(4000, 1024, "Gateway.maxReqSizeInKB")
 
 	webhook.config.forwardGetRequestForSrcMap = lo.SliceToMap(
 		config.GetStringSliceVar([]string{"adjust"}, "Gateway.webhook.forwardGetRequestForSrcs"),


### PR DESCRIPTION
# Description

- Max limit enforcement on the incoming webhook request. 
- Currently, we are enforcing the source transformation responses we get from the transformer if there is some Output present. 
- We might overwhelm the transformers if we don't enforce the incoming webhook request.

## Linear Ticket

- Resolves PIPE-1382

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.