### PR TITLE
chore: adapting obskit for warehouse

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/marketo-bulk-upload/marketobulkupload.go
+++ b/router/batchrouter/asyncdestinationmanager/marketo-bulk-upload/marketobulkupload.go
@@ -99,7 +99,7 @@ func (b *MarketoBulkUploader) Poll(pollInput common.AsyncPoll) common.PollStatus
 		b.logger.Errorw("[Batch Router] Failed to fetch status for",
 			obskit.DestinationType("MARKETO_BULK_UPLOAD"),
 			"body", string(bodyBytes[:512]),
-			"errpr", asyncResponse.Error,
+			"error", asyncResponse.Error,
 		)
 		return common.PollStatusResponse{
 			StatusCode: 500,

--- a/router/batchrouter/asyncdestinationmanager/marketo-bulk-upload/marketobulkupload.go
+++ b/router/batchrouter/asyncdestinationmanager/marketo-bulk-upload/marketobulkupload.go
@@ -12,15 +12,16 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
 	"github.com/tidwall/gjson"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 	"github.com/rudderlabs/rudder-server/utils/misc"
-	lf "github.com/rudderlabs/rudder-server/warehouse/logfield"
 )
 
 type MarketoBulkUploader struct {
@@ -96,9 +97,9 @@ func (b *MarketoBulkUploader) Poll(pollInput common.AsyncPoll) common.PollStatus
 
 	if asyncResponse.Error != "" {
 		b.logger.Errorw("[Batch Router] Failed to fetch status for",
-			lf.DestinationType, "MARKETO_BULK_UPLOAD",
+			obskit.DestinationType("MARKETO_BULK_UPLOAD"),
 			"body", string(bodyBytes[:512]),
-			lf.Error, asyncResponse.Error,
+			"errpr", asyncResponse.Error,
 		)
 		return common.PollStatusResponse{
 			StatusCode: 500,
@@ -173,9 +174,9 @@ func (b *MarketoBulkUploader) GetUploadStats(UploadStatsInput common.GetUploadSt
 
 	if failedJobsResponse.Error != "" {
 		b.logger.Errorw("[Batch Router] Failed to fetch status for",
-			lf.DestinationType, "MARKETO_BULK_UPLOAD",
+			obskit.DestinationType("MARKETO_BULK_UPLOAD"),
 			"body", string(failedBodyBytes),
-			lf.Error, failedJobsResponse.Error,
+			"error", failedJobsResponse.Error,
 		)
 		return common.GetUploadStatsResponse{
 			StatusCode: 500,

--- a/warehouse/api/grpc.go
+++ b/warehouse/api/grpc.go
@@ -543,7 +543,7 @@ func (g *GRPC) CountWHUploadsToRetry(ctx context.Context, req *proto.RetryWHUplo
 		obskit.SourceID(req.SourceId),
 		obskit.DestinationID(req.DestinationId),
 		obskit.DestinationType(req.DestinationType),
-		logger.NewField(lf.IntervalInHours, req.IntervalInHours),
+		logger.NewIntField(lf.IntervalInHours, req.IntervalInHours),
 	)
 
 	if req.SourceId == "" && req.DestinationId == "" && req.WorkspaceId == "" {

--- a/warehouse/api/grpc.go
+++ b/warehouse/api/grpc.go
@@ -186,9 +186,9 @@ func (*GRPC) GetHealth(context.Context, *emptypb.Empty) (*wrapperspb.BoolValue, 
 func (g *GRPC) GetWHUploads(ctx context.Context, request *proto.WHUploadsRequest) (*proto.WHUploadsResponse, error) {
 	g.logger.Infow(
 		"Getting warehouse uploads",
-		lf.WorkspaceID, request.WorkspaceId,
-		lf.SourceID, request.SourceId,
-		lf.DestinationID, request.DestinationId,
+		obskit.WorkspaceID(request.WorkspaceId),
+		obskit.SourceID(request.SourceId),
+		obskit.DestinationID(request.DestinationId),
 	)
 
 	limit, offset := request.Limit, request.Offset
@@ -278,8 +278,8 @@ func (g *GRPC) GetWHUploads(ctx context.Context, request *proto.WHUploadsRequest
 
 func (g *GRPC) GetWHUpload(ctx context.Context, request *proto.WHUploadRequest) (*proto.WHUploadResponse, error) {
 	g.logger.Infow("Getting warehouse upload",
-		lf.WorkspaceID, request.WorkspaceId,
-		lf.UploadJobID, request.UploadId,
+		obskit.WorkspaceID(request.WorkspaceId),
+		obskit.UploadID(request.UploadId),
 	)
 
 	if request.UploadId < 1 {
@@ -362,9 +362,9 @@ func (g *GRPC) GetWHUpload(ctx context.Context, request *proto.WHUploadRequest) 
 
 func (g *GRPC) TriggerWHUploads(ctx context.Context, request *proto.WHUploadsRequest) (*proto.TriggerWhUploadsResponse, error) {
 	g.logger.Infow("Triggering warehouse uploads",
-		lf.WorkspaceID, request.WorkspaceId,
-		lf.SourceID, request.SourceId,
-		lf.DestinationID, request.DestinationId,
+		obskit.WorkspaceID(request.WorkspaceId),
+		obskit.SourceID(request.SourceId),
+		obskit.DestinationID(request.DestinationId),
 	)
 
 	if request.DestinationId == "" {
@@ -435,8 +435,8 @@ func (g *GRPC) TriggerWHUploads(ctx context.Context, request *proto.WHUploadsReq
 
 func (g *GRPC) TriggerWHUpload(ctx context.Context, request *proto.WHUploadRequest) (*proto.TriggerWhUploadsResponse, error) {
 	g.logger.Infow("Triggering warehouse upload",
-		lf.WorkspaceID, request.WorkspaceId,
-		lf.UploadJobID, request.UploadId,
+		obskit.WorkspaceID(request.WorkspaceId),
+		obskit.UploadID(request.UploadId),
 	)
 
 	sourceIDs := g.bcManager.SourceIDsByWorkspace()[request.WorkspaceId]
@@ -485,11 +485,11 @@ func (g *GRPC) TriggerWHUpload(ctx context.Context, request *proto.WHUploadReque
 
 func (g *GRPC) RetryWHUploads(ctx context.Context, req *proto.RetryWHUploadsRequest) (response *proto.RetryWHUploadsResponse, err error) {
 	g.logger.Infow("Retrying warehouse syncs",
-		lf.WorkspaceID, req.WorkspaceId,
-		lf.SourceID, req.SourceId,
-		lf.DestinationID, req.DestinationId,
-		lf.DestinationType, req.DestinationType,
-		lf.IntervalInHours, req.IntervalInHours,
+		obskit.WorkspaceID(req.WorkspaceId),
+		obskit.SourceID(req.SourceId),
+		obskit.DestinationID(req.DestinationId),
+		obskit.DestinationType(req.DestinationType),
+		logger.NewIntField(lf.IntervalInHours, req.IntervalInHours),
 	)
 
 	if req.SourceId == "" && req.DestinationId == "" && req.WorkspaceId == "" {
@@ -539,11 +539,11 @@ func (g *GRPC) RetryWHUploads(ctx context.Context, req *proto.RetryWHUploadsRequ
 
 func (g *GRPC) CountWHUploadsToRetry(ctx context.Context, req *proto.RetryWHUploadsRequest) (response *proto.RetryWHUploadsResponse, err error) {
 	g.logger.Infow("Count syncs to retry",
-		lf.WorkspaceID, req.WorkspaceId,
-		lf.SourceID, req.SourceId,
-		lf.DestinationID, req.DestinationId,
-		lf.DestinationType, req.DestinationType,
-		lf.IntervalInHours, req.IntervalInHours,
+		obskit.WorkspaceID(req.WorkspaceId),
+		obskit.SourceID(req.SourceId),
+		obskit.DestinationID(req.DestinationId),
+		obskit.DestinationType(req.DestinationType),
+		logger.NewField(lf.IntervalInHours, req.IntervalInHours),
 	)
 
 	if req.SourceId == "" && req.DestinationId == "" && req.WorkspaceId == "" {
@@ -835,10 +835,10 @@ func (g *GRPC) RetrieveFailedBatches(
 	req *proto.RetrieveFailedBatchesRequest,
 ) (*proto.RetrieveFailedBatchesResponse, error) {
 	log := g.logger.With(
-		lf.WorkspaceID, req.GetWorkspaceID(),
-		lf.DestinationID, req.GetDestinationID(),
-		lf.StartTime, req.GetStart(),
-		lf.EndTime, req.GetEnd(),
+		obskit.WorkspaceID(req.GetWorkspaceID()),
+		obskit.DestinationID(req.GetDestinationID()),
+		logger.NewStringField(lf.StartTime, req.GetStart()),
+		logger.NewStringField(lf.EndTime, req.GetEnd()),
 	)
 	log.Infow("Retrieving failed batches")
 
@@ -880,7 +880,7 @@ func (g *GRPC) RetrieveFailedBatches(
 		End:           endTime,
 	})
 	if err != nil {
-		log.Warnw("unable to get failed batches", lf.Error, err.Error())
+		log.Warnw("unable to get failed batches", obskit.Error(err))
 
 		return &proto.RetrieveFailedBatchesResponse{},
 			status.Error(codes.Code(code.Code_INTERNAL), "unable to get failed batches")
@@ -906,13 +906,13 @@ func (g *GRPC) RetryFailedBatches(
 	req *proto.RetryFailedBatchesRequest,
 ) (*proto.RetryFailedBatchesResponse, error) {
 	log := g.logger.With(
-		lf.WorkspaceID, req.GetWorkspaceID(),
-		lf.DestinationID, req.GetDestinationID(),
-		lf.StartTime, req.GetStart(),
-		lf.EndTime, req.GetEnd(),
-		lf.ErrorCategory, req.GetErrorCategory(),
-		lf.SourceID, req.GetSourceID(),
-		lf.Status, req.GetStatus(),
+		obskit.WorkspaceID(req.GetWorkspaceID()),
+		obskit.DestinationID(req.GetDestinationID()),
+		logger.NewStringField(lf.StartTime, req.GetStart()),
+		logger.NewStringField(lf.EndTime, req.GetEnd()),
+		logger.NewStringField(lf.ErrorCategory, req.GetErrorCategory()),
+		obskit.SourceID(req.GetSourceID()),
+		logger.NewStringField(lf.Status, req.GetStatus()),
 	)
 	log.Infow("Retrying failed batches")
 
@@ -961,7 +961,7 @@ func (g *GRPC) RetryFailedBatches(
 		Status:        req.GetStatus(),
 	})
 	if err != nil {
-		log.Warnw("unable to retry failed batches", lf.Error, err.Error())
+		log.Warnw("unable to retry failed batches", obskit.Error(err))
 
 		return &proto.RetryFailedBatchesResponse{},
 			status.Error(codes.Code(code.Code_INTERNAL), "unable to retry failed batches")
@@ -997,7 +997,7 @@ func (g *GRPC) GetFirstAbortedUploadInContinuousAbortsByDestination(
 	g.logger.Infon(
 		"Getting first aborted uploads in a series of continuous aborts",
 		obskit.WorkspaceID(request.WorkspaceId),
-		logger.NewStringField("startTime", request.Start),
+		logger.NewStringField(lf.StartTime, request.Start),
 	)
 
 	var startTime time.Time

--- a/warehouse/api/http.go
+++ b/warehouse/api/http.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	"github.com/rudderlabs/rudder-server/warehouse/internal/mode"
 
 	"github.com/rudderlabs/rudder-server/services/notifier"
@@ -30,6 +32,7 @@ import (
 	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	sqlmw "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
@@ -246,7 +249,7 @@ func (a *Api) pendingEventsHandler(w http.ResponseWriter, r *http.Request) {
 
 	var payload pendingEventsRequest
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		a.logger.Warnw("invalid JSON in request body for pending events", lf.Error, err.Error())
+		a.logger.Warnw("invalid JSON in request body for pending events", obskit.Error(err))
 		http.Error(w, ierrors.ErrInvalidJSONRequestBody.Error(), http.StatusBadRequest)
 		return
 	}
@@ -254,8 +257,8 @@ func (a *Api) pendingEventsHandler(w http.ResponseWriter, r *http.Request) {
 	sourceID, taskRunID := payload.SourceID, payload.TaskRunID
 	if sourceID == "" || taskRunID == "" {
 		a.logger.Warnw("empty source or task run id for pending events",
-			lf.SourceID, payload.SourceID,
-			lf.TaskRunID, payload.TaskRunID,
+			obskit.SourceID(payload.SourceID),
+			logger.NewStringField(lf.TaskRunID, payload.TaskRunID),
 		)
 		http.Error(w, "empty source or task run id", http.StatusBadRequest)
 		return
@@ -263,13 +266,15 @@ func (a *Api) pendingEventsHandler(w http.ResponseWriter, r *http.Request) {
 
 	workspaceID, err := a.tenantManager.SourceToWorkspace(r.Context(), sourceID)
 	if err != nil {
-		a.logger.Warnw("workspace from source not found for pending events", lf.SourceID, payload.SourceID)
+		a.logger.Warnw("workspace from source not found for pending events",
+			obskit.SourceID(payload.SourceID),
+		)
 		http.Error(w, ierrors.ErrWorkspaceFromSourceNotFound.Error(), http.StatusBadRequest)
 		return
 	}
 
 	if a.tenantManager.DegradedWorkspace(workspaceID) {
-		a.logger.Infow("workspace is degraded for pending events", lf.WorkspaceID, workspaceID)
+		a.logger.Infow("workspace is degraded for pending events", obskit.WorkspaceID(workspaceID))
 		http.Error(w, ierrors.ErrWorkspaceDegraded.Error(), http.StatusServiceUnavailable)
 		return
 	}
@@ -280,7 +285,7 @@ func (a *Api) pendingEventsHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, ierrors.ErrRequestCancelled.Error(), http.StatusBadRequest)
 			return
 		}
-		a.logger.Errorw("counting pending staging files", lf.Error, err.Error())
+		a.logger.Errorw("counting pending staging files", obskit.Error(err))
 		http.Error(w, "can't get pending staging files count", http.StatusInternalServerError)
 		return
 	}
@@ -297,7 +302,7 @@ func (a *Api) pendingEventsHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, ierrors.ErrRequestCancelled.Error(), http.StatusBadRequest)
 			return
 		}
-		a.logger.Errorw("counting pending uploads", lf.Error, err.Error())
+		a.logger.Errorw("counting pending uploads", obskit.Error(err))
 		http.Error(w, "can't get pending uploads count", http.StatusInternalServerError)
 		return
 	}
@@ -313,7 +318,7 @@ func (a *Api) pendingEventsHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, ierrors.ErrRequestCancelled.Error(), http.StatusBadRequest)
 			return
 		}
-		a.logger.Errorw("counting aborted uploads", lf.Error, err.Error())
+		a.logger.Errorw("counting aborted uploads", obskit.Error(err))
 		http.Error(w, "can't get aborted uploads count", http.StatusInternalServerError)
 		return
 	}
@@ -323,15 +328,15 @@ func (a *Api) pendingEventsHandler(w http.ResponseWriter, r *http.Request) {
 
 	if pendingEventsAvailable && triggerPendingUpload {
 		a.logger.Infow("triggering upload for all destinations connected to source",
-			lf.WorkspaceID, workspaceID,
-			lf.SourceID, payload.SourceID,
+			obskit.WorkspaceID(workspaceID),
+			obskit.SourceID(payload.SourceID),
 		)
 
 		wh := a.bcManager.WarehousesBySourceID(sourceID)
 		if len(wh) == 0 {
 			a.logger.Warnw("no warehouse found for pending events",
-				lf.WorkspaceID, workspaceID,
-				lf.SourceID, payload.SourceID,
+				obskit.WorkspaceID(workspaceID),
+				obskit.SourceID(payload.SourceID),
 			)
 			http.Error(w, ierrors.ErrNoWarehouseFound.Error(), http.StatusBadRequest)
 			return
@@ -349,7 +354,7 @@ func (a *Api) pendingEventsHandler(w http.ResponseWriter, r *http.Request) {
 		AbortedEvents:            abortedUploadCount > 0,
 	})
 	if err != nil {
-		a.logger.Errorw("marshalling response for pending events", lf.Error, err.Error())
+		a.logger.Errorw("marshalling response for pending events", obskit.Error(err))
 		http.Error(w, ierrors.ErrMarshallResponse.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -362,20 +367,22 @@ func (a *Api) triggerUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	var payload triggerUploadRequest
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		a.logger.Warnw("invalid JSON in request body for triggering upload", lf.Error, err.Error())
+		a.logger.Warnw("invalid JSON in request body for triggering upload", obskit.Error(err))
 		http.Error(w, ierrors.ErrInvalidJSONRequestBody.Error(), http.StatusBadRequest)
 		return
 	}
 
 	workspaceID, err := a.tenantManager.SourceToWorkspace(r.Context(), payload.SourceID)
 	if err != nil {
-		a.logger.Warnw("workspace from source not found for triggering upload", lf.SourceID, payload.SourceID)
+		a.logger.Warnw("workspace from source not found for triggering upload",
+			obskit.SourceID(payload.SourceID),
+		)
 		http.Error(w, ierrors.ErrWorkspaceFromSourceNotFound.Error(), http.StatusBadRequest)
 		return
 	}
 
 	if a.tenantManager.DegradedWorkspace(workspaceID) {
-		a.logger.Infow("workspace is degraded for triggering upload", lf.WorkspaceID, workspaceID)
+		a.logger.Infow("workspace is degraded for triggering upload", obskit.WorkspaceID(workspaceID))
 		http.Error(w, ierrors.ErrWorkspaceDegraded.Error(), http.StatusServiceUnavailable)
 		return
 	}
@@ -388,9 +395,9 @@ func (a *Api) triggerUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(wh) == 0 {
 		a.logger.Warnw("no warehouse found for triggering upload",
-			lf.WorkspaceID, workspaceID,
-			lf.SourceID, payload.SourceID,
-			lf.DestinationID, payload.DestinationID,
+			obskit.WorkspaceID(workspaceID),
+			obskit.SourceID(payload.SourceID),
+			obskit.DestinationID(payload.DestinationID),
 		)
 		http.Error(w, ierrors.ErrNoWarehouseFound.Error(), http.StatusBadRequest)
 		return
@@ -408,7 +415,7 @@ func (a *Api) fetchTablesHandler(w http.ResponseWriter, r *http.Request) {
 
 	var payload fetchTablesRequest
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		a.logger.Warnw("invalid JSON in request body for fetching tables", lf.Error, err.Error())
+		a.logger.Warnw("invalid JSON in request body for fetching tables", obskit.Error(err))
 		http.Error(w, ierrors.ErrInvalidJSONRequestBody.Error(), http.StatusBadRequest)
 		return
 	}
@@ -419,7 +426,7 @@ func (a *Api) fetchTablesHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, ierrors.ErrRequestCancelled.Error(), http.StatusBadRequest)
 			return
 		}
-		a.logger.Errorw("fetching tables", lf.Error, err.Error())
+		a.logger.Errorw("fetching tables", obskit.Error(err))
 		http.Error(w, "can't fetch tables", http.StatusInternalServerError)
 		return
 	}
@@ -428,7 +435,7 @@ func (a *Api) fetchTablesHandler(w http.ResponseWriter, r *http.Request) {
 		ConnectionsTables: tables,
 	})
 	if err != nil {
-		a.logger.Errorw("marshalling response for fetching tables", lf.Error, err.Error())
+		a.logger.Errorw("marshalling response for fetching tables", obskit.Error(err))
 		http.Error(w, ierrors.ErrMarshallResponse.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/warehouse/bcm/backend_config.go
+++ b/warehouse/bcm/backend_config.go
@@ -8,12 +8,11 @@ import (
 	"sync"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
 	"github.com/rudderlabs/rudder-server/utils/misc"
 
 	"github.com/rudderlabs/rudder-server/warehouse/multitenant"
-
-	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 
 	"github.com/samber/lo"
 
@@ -243,11 +242,11 @@ func (bcm *BackendConfigManager) namespace(ctx context.Context, source backendco
 	namespace, err := bcm.schema.GetNamespace(ctx, source.ID, destination.ID)
 	if err != nil {
 		bcm.logger.Errorw("getting namespace",
-			logfield.SourceID, source.ID,
-			logfield.DestinationID, destination.ID,
-			logfield.DestinationType, destination.DestinationDefinition.Name,
-			logfield.WorkspaceID, destination.WorkspaceID,
-			logfield.Error, err.Error(),
+			obskit.SourceID(source.ID),
+			obskit.DestinationID(destination.ID),
+			obskit.DestinationType(destination.DestinationDefinition.Name),
+			obskit.WorkspaceID(destination.WorkspaceID),
+			obskit.Error(err),
 		)
 		return ""
 	}

--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -17,6 +17,8 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	"github.com/rudderlabs/rudder-go-kit/stats"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
@@ -145,12 +147,12 @@ func (bq *BigQuery) getMiddleware() *middleware.Client {
 		bq.db,
 		middleware.WithLogger(bq.logger),
 		middleware.WithKeyAndValues(
-			logfield.SourceID, bq.warehouse.Source.ID,
-			logfield.SourceType, bq.warehouse.Source.SourceDefinition.Name,
-			logfield.DestinationID, bq.warehouse.Destination.ID,
-			logfield.DestinationType, bq.warehouse.Destination.DestinationDefinition.Name,
-			logfield.WorkspaceID, bq.warehouse.WorkspaceID,
-			logfield.Schema, bq.namespace,
+			obskit.SourceID(bq.warehouse.Source.ID),
+			obskit.SourceType(bq.warehouse.Source.SourceDefinition.Name),
+			obskit.DestinationID(bq.warehouse.Destination.ID),
+			obskit.DestinationType(bq.warehouse.Destination.DestinationDefinition.Name),
+			obskit.WorkspaceID(bq.warehouse.WorkspaceID),
+			obskit.Namespace(bq.namespace),
 		),
 		middleware.WithSlowQueryThreshold(bq.config.slowQueryThreshold),
 	)
@@ -344,14 +346,14 @@ func (bq *BigQuery) loadTable(ctx context.Context, tableName string) (
 	*types.LoadTableStats, *loadTableResponse, error,
 ) {
 	log := bq.logger.With(
-		logfield.SourceID, bq.warehouse.Source.ID,
-		logfield.SourceType, bq.warehouse.Source.SourceDefinition.Name,
-		logfield.DestinationID, bq.warehouse.Destination.ID,
-		logfield.DestinationType, bq.warehouse.Destination.DestinationDefinition.Name,
-		logfield.WorkspaceID, bq.warehouse.WorkspaceID,
-		logfield.Namespace, bq.namespace,
-		logfield.TableName, tableName,
-		logfield.ShouldMerge, false, // we don't support merging in BigQuery due to its cost limitations
+		obskit.SourceID(bq.warehouse.Source.ID),
+		obskit.SourceType(bq.warehouse.Source.SourceDefinition.Name),
+		obskit.DestinationID(bq.warehouse.Destination.ID),
+		obskit.DestinationType(bq.warehouse.Destination.DestinationDefinition.Name),
+		obskit.WorkspaceID(bq.warehouse.WorkspaceID),
+		obskit.Namespace(bq.namespace),
+		logger.NewStringField(logfield.TableName, tableName),
+		logger.NewBoolField(logfield.ShouldMerge, false), // we don't support merging in BigQuery due to its cost limitations
 	)
 	log.Infow("started loading")
 

--- a/warehouse/integrations/bigquery/middleware/middleware.go
+++ b/warehouse/integrations/bigquery/middleware/middleware.go
@@ -6,6 +6,8 @@ import (
 
 	"cloud.google.com/go/bigquery"
 
+	"github.com/rudderlabs/rudder-go-kit/logger"
+
 	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 )
 
@@ -82,8 +84,8 @@ func (client *Client) logQuery(query *bigquery.Query, elapsed time.Duration) {
 	queryStatement := query.QueryConfig.Q
 
 	keysAndValues := []any{
-		logfield.Query, queryStatement,
-		logfield.QueryExecutionTime, elapsed,
+		logger.NewStringField(logfield.Query, queryStatement),
+		logger.NewDurationField(logfield.QueryExecutionTime, elapsed),
 	}
 	keysAndValues = append(keysAndValues, client.keysAndValues...)
 

--- a/warehouse/integrations/bigquery/middleware/middleware_test.go
+++ b/warehouse/integrations/bigquery/middleware/middleware_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/logger"
+
 	bqHelper "github.com/rudderlabs/rudder-server/warehouse/integrations/bigquery/testhelper"
 
 	"github.com/stretchr/testify/require"
@@ -81,8 +83,8 @@ func TestQueryWrapper(t *testing.T) {
 			query := db.Query(queryStatement)
 
 			kvs := []any{
-				logfield.Query, queryStatement,
-				logfield.QueryExecutionTime, tc.executionTimeInSec,
+				logger.NewStringField(logfield.Query, queryStatement),
+				logger.NewDurationField(logfield.QueryExecutionTime, tc.executionTimeInSec),
 			}
 			kvs = append(kvs, keysAndValues...)
 

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -26,6 +26,8 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
 
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
@@ -37,7 +39,6 @@ import (
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/types"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/service/loadfiles/downloader"
-	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
@@ -336,12 +337,12 @@ func registerTLSConfig(key, certificate string) error {
 
 func (ch *Clickhouse) defaultLogFields() []any {
 	return []any{
-		logfield.SourceID, ch.Warehouse.Source.ID,
-		logfield.SourceType, ch.Warehouse.Source.SourceDefinition.Name,
-		logfield.DestinationID, ch.Warehouse.Destination.ID,
-		logfield.DestinationType, ch.Warehouse.Destination.DestinationDefinition.Name,
-		logfield.WorkspaceID, ch.Warehouse.WorkspaceID,
-		logfield.Namespace, ch.Namespace,
+		obskit.SourceID(ch.Warehouse.Source.ID),
+		obskit.SourceType(ch.Warehouse.Source.SourceDefinition.Name),
+		obskit.DestinationID(ch.Warehouse.Destination.ID),
+		obskit.DestinationType(ch.Warehouse.Destination.DestinationDefinition.Name),
+		obskit.WorkspaceID(ch.Warehouse.WorkspaceID),
+		obskit.Namespace(ch.Namespace),
 	}
 }
 

--- a/warehouse/integrations/middleware/sqlquerywrapper/sql_test.go
+++ b/warehouse/integrations/middleware/sqlquerywrapper/sql_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
+
 	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 )
 
@@ -78,8 +79,8 @@ func TestQueryWrapper(t *testing.T) {
 			query := "SELECT 1;"
 
 			kvs := []any{
-				logfield.Query, query,
-				logfield.QueryExecutionTime, tc.executionTime,
+				rslogger.NewStringField(logfield.Query, query),
+				rslogger.NewDurationField(logfield.QueryExecutionTime, tc.executionTime),
 			}
 			kvs = append(kvs, keysAndValues...)
 
@@ -137,12 +138,12 @@ func TestQueryWrapper(t *testing.T) {
 				user := fmt.Sprintf("test_user_%d", uuid.New().ID())
 
 				createKvs := []any{
-					logfield.Query, fmt.Sprintf("CREATE USER %s;", user),
-					logfield.QueryExecutionTime, tc.executionTime,
+					rslogger.NewStringField(logfield.Query, fmt.Sprintf("CREATE USER %s;", user)),
+					rslogger.NewDurationField(logfield.QueryExecutionTime, tc.executionTime),
 				}
 				alterKvs := []any{
-					logfield.Query, fmt.Sprintf("ALTER USER %s WITH PASSWORD '***';", user),
-					logfield.QueryExecutionTime, tc.executionTime,
+					rslogger.NewStringField(logfield.Query, fmt.Sprintf("ALTER USER %s WITH PASSWORD '***';", user)),
+					rslogger.NewDurationField(logfield.QueryExecutionTime, tc.executionTime),
 				}
 
 				createKvs = append(createKvs, keysAndValues...)
@@ -190,12 +191,12 @@ func TestQueryWrapper(t *testing.T) {
 						user := fmt.Sprintf("test_user_%d", uuid.New().ID())
 
 						createKvs := []any{
-							logfield.Query, fmt.Sprintf("CREATE USER %s;", user),
-							logfield.QueryExecutionTime, tc.executionTime,
+							rslogger.NewStringField(logfield.Query, fmt.Sprintf("CREATE USER %s;", user)),
+							rslogger.NewDurationField(logfield.QueryExecutionTime, tc.executionTime),
 						}
 						alterKvs := []any{
-							logfield.Query, fmt.Sprintf("ALTER USER %s WITH PASSWORD '***';", user),
-							logfield.QueryExecutionTime, tc.executionTime,
+							rslogger.NewStringField(logfield.Query, fmt.Sprintf("ALTER USER %s WITH PASSWORD '***';", user)),
+							rslogger.NewDurationField(logfield.QueryExecutionTime, tc.executionTime),
 						}
 
 						createKvs = append(createKvs, keysAndValues...)
@@ -244,8 +245,8 @@ func TestQueryWrapper(t *testing.T) {
 			query := "SELECT 1;"
 
 			kvs := []any{
-				logfield.Query, query,
-				logfield.QueryExecutionTime, tc.executionTime,
+				rslogger.NewStringField(logfield.Query, query),
+				rslogger.NewDurationField(logfield.QueryExecutionTime, tc.executionTime),
 			}
 			kvs = append(kvs, keysAndValues...)
 

--- a/warehouse/integrations/postgres/load.go
+++ b/warehouse/integrations/postgres/load.go
@@ -13,6 +13,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/types"
 	"github.com/rudderlabs/rudder-server/warehouse/safeguard"
 
@@ -61,14 +64,14 @@ func (pg *Postgres) loadTable(
 	tableSchemaInUpload model.TableSchema,
 ) (*types.LoadTableStats, string, error) {
 	log := pg.logger.With(
-		logfield.SourceID, pg.Warehouse.Source.ID,
-		logfield.SourceType, pg.Warehouse.Source.SourceDefinition.Name,
-		logfield.DestinationID, pg.Warehouse.Destination.ID,
-		logfield.DestinationType, pg.Warehouse.Destination.DestinationDefinition.Name,
-		logfield.WorkspaceID, pg.Warehouse.WorkspaceID,
-		logfield.Namespace, pg.Namespace,
-		logfield.TableName, tableName,
-		logfield.ShouldMerge, pg.shouldMerge(tableName),
+		obskit.SourceID(pg.Warehouse.Source.ID),
+		obskit.SourceType(pg.Warehouse.Source.SourceDefinition.Name),
+		obskit.DestinationID(pg.Warehouse.Destination.ID),
+		obskit.DestinationType(pg.Warehouse.Destination.DestinationDefinition.Name),
+		obskit.WorkspaceID(pg.Warehouse.WorkspaceID),
+		obskit.Namespace(pg.Namespace),
+		logger.NewStringField(logfield.TableName, tableName),
+		logger.NewBoolField(logfield.ShouldMerge, pg.shouldMerge(tableName)),
 	)
 	log.Infow("started loading")
 	defer log.Infow("completed loading")
@@ -308,12 +311,12 @@ func (pg *Postgres) insertIntoLoadTable(
 
 func (pg *Postgres) LoadUserTables(ctx context.Context) map[string]error {
 	pg.logger.Infow("started loading for identifies and users tables",
-		logfield.SourceID, pg.Warehouse.Source.ID,
-		logfield.SourceType, pg.Warehouse.Source.SourceDefinition.Name,
-		logfield.DestinationID, pg.Warehouse.Destination.ID,
-		logfield.DestinationType, pg.Warehouse.Destination.DestinationDefinition.Name,
-		logfield.WorkspaceID, pg.Warehouse.WorkspaceID,
-		logfield.Namespace, pg.Namespace,
+		obskit.SourceID(pg.Warehouse.Source.ID),
+		obskit.SourceType(pg.Warehouse.Source.SourceDefinition.Name),
+		obskit.DestinationID(pg.Warehouse.Destination.ID),
+		obskit.DestinationType(pg.Warehouse.Destination.DestinationDefinition.Name),
+		obskit.WorkspaceID(pg.Warehouse.WorkspaceID),
+		obskit.Namespace(pg.Namespace),
 	)
 
 	identifiesSchemaInUpload := pg.Uploader.GetTableSchemaInUpload(warehouseutils.IdentifiesTable)
@@ -347,12 +350,12 @@ func (pg *Postgres) LoadUserTables(ctx context.Context) map[string]error {
 	}
 
 	pg.logger.Infow("completed loading for users and identities table",
-		logfield.SourceID, pg.Warehouse.Source.ID,
-		logfield.SourceType, pg.Warehouse.Source.SourceDefinition.Name,
-		logfield.DestinationID, pg.Warehouse.Destination.ID,
-		logfield.DestinationType, pg.Warehouse.Destination.DestinationDefinition.Name,
-		logfield.WorkspaceID, pg.Warehouse.WorkspaceID,
-		logfield.Namespace, pg.Namespace,
+		obskit.SourceID(pg.Warehouse.Source.ID),
+		obskit.SourceType(pg.Warehouse.Source.SourceDefinition.Name),
+		obskit.DestinationID(pg.Warehouse.Destination.ID),
+		obskit.DestinationType(pg.Warehouse.Destination.DestinationDefinition.Name),
+		obskit.WorkspaceID(pg.Warehouse.WorkspaceID),
+		obskit.Namespace(pg.Namespace),
 	)
 
 	return map[string]error{
@@ -441,15 +444,15 @@ func (pg *Postgres) loadUsersTable(
 	)
 
 	pg.logger.Infow("creating union staging users table",
-		logfield.SourceID, pg.Warehouse.Source.ID,
-		logfield.SourceType, pg.Warehouse.Source.SourceDefinition.Name,
-		logfield.DestinationID, pg.Warehouse.Destination.ID,
-		logfield.DestinationType, pg.Warehouse.Destination.DestinationDefinition.Name,
-		logfield.WorkspaceID, pg.Warehouse.WorkspaceID,
-		logfield.TableName, warehouseutils.UsersTable,
-		logfield.StagingTableName, unionStagingTableName,
-		logfield.Namespace, pg.Namespace,
-		logfield.Query, query,
+		obskit.SourceID(pg.Warehouse.Source.ID),
+		obskit.SourceType(pg.Warehouse.Source.SourceDefinition.Name),
+		obskit.DestinationID(pg.Warehouse.Destination.ID),
+		obskit.DestinationType(pg.Warehouse.Destination.DestinationDefinition.Name),
+		obskit.WorkspaceID(pg.Warehouse.WorkspaceID),
+		logger.NewStringField(logfield.TableName, warehouseutils.UsersTable),
+		logger.NewStringField(logfield.StagingTableName, unionStagingTableName),
+		obskit.Namespace(pg.Namespace),
+		logger.NewStringField(logfield.Query, query),
 	)
 	if _, err = tx.ExecContext(ctx, query); err != nil {
 		return loadUsersTableResponse{
@@ -462,14 +465,14 @@ func (pg *Postgres) loadUsersTable(
 		unionStagingTableName,
 	)
 	pg.logger.Debugw("creating index on union staging users table",
-		logfield.SourceID, pg.Warehouse.Source.ID,
-		logfield.SourceType, pg.Warehouse.Source.SourceDefinition.Name,
-		logfield.DestinationID, pg.Warehouse.Destination.ID,
-		logfield.DestinationType, pg.Warehouse.Destination.DestinationDefinition.Name,
-		logfield.WorkspaceID, pg.Warehouse.WorkspaceID,
-		logfield.TableName, warehouseutils.UsersTable,
-		logfield.StagingTableName, usersStagingTableName,
-		logfield.Query, query,
+		obskit.SourceID(pg.Warehouse.Source.ID),
+		obskit.SourceType(pg.Warehouse.Source.SourceDefinition.Name),
+		obskit.DestinationID(pg.Warehouse.Destination.ID),
+		obskit.DestinationType(pg.Warehouse.Destination.DestinationDefinition.Name),
+		obskit.WorkspaceID(pg.Warehouse.WorkspaceID),
+		logger.NewStringField(logfield.TableName, warehouseutils.UsersTable),
+		logger.NewStringField(logfield.StagingTableName, usersStagingTableName),
+		logger.NewStringField(logfield.Query, query),
 	)
 	if _, err = tx.ExecContext(ctx, query); err != nil {
 		return loadUsersTableResponse{
@@ -497,14 +500,14 @@ func (pg *Postgres) loadUsersTable(
 	)
 
 	pg.logger.Debugw("creating temporary users table",
-		logfield.SourceID, pg.Warehouse.Source.ID,
-		logfield.SourceType, pg.Warehouse.Source.SourceDefinition.Name,
-		logfield.DestinationID, pg.Warehouse.Destination.ID,
-		logfield.DestinationType, pg.Warehouse.Destination.DestinationDefinition.Name,
-		logfield.WorkspaceID, pg.Warehouse.WorkspaceID,
-		logfield.TableName, warehouseutils.UsersTable,
-		logfield.StagingTableName, usersStagingTableName,
-		logfield.Query, query,
+		obskit.SourceID(pg.Warehouse.Source.ID),
+		obskit.SourceType(pg.Warehouse.Source.SourceDefinition.Name),
+		obskit.DestinationID(pg.Warehouse.Destination.ID),
+		obskit.DestinationType(pg.Warehouse.Destination.DestinationDefinition.Name),
+		obskit.WorkspaceID(pg.Warehouse.WorkspaceID),
+		logger.NewStringField(logfield.TableName, warehouseutils.UsersTable),
+		logger.NewStringField(logfield.StagingTableName, usersStagingTableName),
+		logger.NewStringField(logfield.Query, query),
 	)
 	if _, err = tx.ExecContext(ctx, query); err != nil {
 		return loadUsersTableResponse{
@@ -525,15 +528,15 @@ func (pg *Postgres) loadUsersTable(
 	)
 
 	pg.logger.Infow("deduplication for users table",
-		logfield.SourceID, pg.Warehouse.Source.ID,
-		logfield.SourceType, pg.Warehouse.Source.SourceDefinition.Name,
-		logfield.DestinationID, pg.Warehouse.Destination.ID,
-		logfield.DestinationType, pg.Warehouse.Destination.DestinationDefinition.Name,
-		logfield.WorkspaceID, pg.Warehouse.WorkspaceID,
-		logfield.TableName, warehouseutils.UsersTable,
-		logfield.StagingTableName, usersStagingTableName,
-		logfield.Namespace, pg.Namespace,
-		logfield.Query, query,
+		obskit.SourceID(pg.Warehouse.Source.ID),
+		obskit.SourceType(pg.Warehouse.Source.SourceDefinition.Name),
+		obskit.DestinationID(pg.Warehouse.Destination.ID),
+		obskit.DestinationType(pg.Warehouse.Destination.DestinationDefinition.Name),
+		obskit.WorkspaceID(pg.Warehouse.WorkspaceID),
+		logger.NewStringField(logfield.TableName, warehouseutils.UsersTable),
+		logger.NewStringField(logfield.StagingTableName, usersStagingTableName),
+		obskit.Namespace(pg.Namespace),
+		logger.NewStringField(logfield.Query, query),
 	)
 	if _, err = tx.ExecContext(ctx, query); err != nil {
 		return loadUsersTableResponse{
@@ -555,15 +558,15 @@ func (pg *Postgres) loadUsersTable(
 		strings.Join(append([]string{"id"}, userColNames...), ","),
 	)
 	pg.logger.Infow("inserting records to users table",
-		logfield.SourceID, pg.Warehouse.Source.ID,
-		logfield.SourceType, pg.Warehouse.Source.SourceDefinition.Name,
-		logfield.DestinationID, pg.Warehouse.Destination.ID,
-		logfield.DestinationType, pg.Warehouse.Destination.DestinationDefinition.Name,
-		logfield.WorkspaceID, pg.Warehouse.WorkspaceID,
-		logfield.TableName, warehouseutils.UsersTable,
-		logfield.StagingTableName, usersStagingTableName,
-		logfield.Namespace, pg.Namespace,
-		logfield.Query, query,
+		obskit.SourceID(pg.Warehouse.Source.ID),
+		obskit.SourceType(pg.Warehouse.Source.SourceDefinition.Name),
+		obskit.DestinationID(pg.Warehouse.Destination.ID),
+		obskit.DestinationType(pg.Warehouse.Destination.DestinationDefinition.Name),
+		obskit.WorkspaceID(pg.Warehouse.WorkspaceID),
+		logger.NewStringField(logfield.TableName, warehouseutils.UsersTable),
+		logger.NewStringField(logfield.StagingTableName, usersStagingTableName),
+		obskit.Namespace(pg.Namespace),
+		logger.NewStringField(logfield.Query, query),
 	)
 	if _, err = tx.ExecContext(ctx, query); err != nil {
 		return loadUsersTableResponse{

--- a/warehouse/integrations/postgres/postgres.go
+++ b/warehouse/integrations/postgres/postgres.go
@@ -10,15 +10,15 @@ import (
 	"strings"
 	"time"
 
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/tunnelling"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
 
 	sqlmiddleware "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
-	"github.com/rudderlabs/rudder-server/warehouse/internal/service/loadfiles/downloader"
-	"github.com/rudderlabs/rudder-server/warehouse/logfield"
-
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/service/loadfiles/downloader"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -183,12 +183,12 @@ func (pg *Postgres) getNewMiddleWare(db *sql.DB) *sqlmiddleware.DB {
 		sqlmiddleware.WithStats(pg.stats),
 		sqlmiddleware.WithLogger(pg.logger),
 		sqlmiddleware.WithKeyAndValues(
-			logfield.SourceID, pg.Warehouse.Source.ID,
-			logfield.SourceType, pg.Warehouse.Source.SourceDefinition.Name,
-			logfield.DestinationID, pg.Warehouse.Destination.ID,
-			logfield.DestinationType, pg.Warehouse.Destination.DestinationDefinition.Name,
-			logfield.WorkspaceID, pg.Warehouse.WorkspaceID,
-			logfield.Schema, pg.Namespace,
+			obskit.SourceID(pg.Warehouse.Source.ID),
+			obskit.SourceType(pg.Warehouse.Source.SourceDefinition.Name),
+			obskit.DestinationID(pg.Warehouse.Destination.ID),
+			obskit.DestinationType(pg.Warehouse.Destination.DestinationDefinition.Name),
+			obskit.WorkspaceID(pg.Warehouse.WorkspaceID),
+			obskit.Namespace(pg.Namespace),
 		),
 		sqlmiddleware.WithSlowQueryThreshold(pg.config.slowQueryThreshold),
 		sqlmiddleware.WithQueryTimeout(pg.connectTimeout),

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -410,7 +410,10 @@ func (sf *Snowflake) loadTable(
 		formattedDuplicateMessages := lo.Map(duplicates, func(item duplicateMessage, index int) string {
 			return item.String()
 		})
-		log.Infow("sample duplicate rows", obskit.UploadID(uploadID), logger.NewField(lf.SampleDuplicateMessages, formattedDuplicateMessages))
+		log.Infow("sample duplicate rows",
+			obskit.UploadID(uploadID),
+			logger.NewField(lf.SampleDuplicateMessages, formattedDuplicateMessages),
+		)
 	}
 
 	log.Infow("merge data into load table")

--- a/warehouse/logfield/logfield.go
+++ b/warehouse/logfield/logfield.go
@@ -1,20 +1,11 @@
 package logfield
 
 const (
-	UploadJobID                = "uploadJobID"
 	UploadStatus               = "uploadStatus"
 	UseRudderStorage           = "useRudderStorage"
 	TaskRunID                  = "taskRunID"
-	SourceID                   = "sourceID"
-	SourceType                 = "sourceType"
-	DestinationID              = "destinationID"
-	DestinationType            = "destinationType"
 	DestinationRevisionID      = "destinationRevisionID"
 	DestinationValidationsStep = "step"
-	WorkspaceID                = "workspaceID"
-	Namespace                  = "namespace"
-	Schema                     = "schema"
-	Error                      = "error"
 	Status                     = "status"
 	ErrorCategory              = "errorCategory"
 	TableName                  = "tableName"

--- a/warehouse/router/identities.go
+++ b/warehouse/router/identities.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"sync"
 
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
-
-	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 
@@ -414,12 +414,12 @@ func (r *Router) populateHistoricIdentities(ctx context.Context, warehouse model
 		tableUploadsCreated, tableUploadsErr := job.tableUploadsRepo.ExistsForUploadID(ctx, job.upload.ID)
 		if tableUploadsErr != nil {
 			r.logger.Warnw("table uploads exists",
-				logfield.UploadJobID, job.upload.ID,
-				logfield.SourceID, job.upload.SourceID,
-				logfield.DestinationID, job.upload.DestinationID,
-				logfield.DestinationType, job.upload.DestinationType,
-				logfield.WorkspaceID, job.upload.WorkspaceID,
-				logfield.Error, tableUploadsErr.Error(),
+				obskit.UploadID(job.upload.ID),
+				obskit.SourceID(job.upload.SourceID),
+				obskit.DestinationID(job.upload.DestinationID),
+				obskit.DestinationType(job.upload.DestinationType),
+				obskit.WorkspaceID(job.upload.WorkspaceID),
+				obskit.Error(tableUploadsErr),
 			)
 			return
 		}

--- a/warehouse/router/router.go
+++ b/warehouse/router/router.go
@@ -14,6 +14,8 @@ import (
 	"github.com/lib/pq"
 	"golang.org/x/sync/errgroup"
 
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
@@ -34,7 +36,6 @@ import (
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/repo"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/service"
-	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 	"github.com/rudderlabs/rudder-server/warehouse/multitenant"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 	"github.com/rudderlabs/rudder-server/warehouse/validations"
@@ -543,7 +544,7 @@ func (r *Router) createJobs(ctx context.Context, warehouse model.Warehouse) (err
 			"destType":      warehouse.Destination.DestinationDefinition.Name,
 		}).Count(1)
 
-		r.logger.Debugw("Skipping upload loop since upload freq not exceeded", logfield.Error, err.Error())
+		r.logger.Debugw("Skipping upload loop since upload freq not exceeded", obskit.Error(err))
 
 		return nil
 	}

--- a/warehouse/router/state_export_data.go
+++ b/warehouse/router/state_export_data.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/rudderlabs/rudder-go-kit/logger"
+
 	"github.com/rudderlabs/rudder-go-kit/stats"
 
 	"github.com/rudderlabs/rudder-server/services/alerta"
@@ -327,7 +329,7 @@ func (job *UploadJob) UpdateTableSchema(tName string, tableSchemaDiff whutils.Ta
 func (job *UploadJob) alterColumnsToWarehouse(ctx context.Context, tName string, columnsMap model.TableSchema) error {
 	if job.config.disableAlter {
 		job.logger.Debugw("skipping alter columns to warehouse",
-			logfield.TableName, tName,
+			logger.NewStringField(logfield.TableName, tName),
 			"columns", columnsMap,
 		)
 		return nil
@@ -721,7 +723,7 @@ func (job *UploadJob) loadTable(tName string) (bool, error) {
 		return alteredSchema, fmt.Errorf("update schema: %w", err)
 	}
 
-	job.logger.Infow("starting load for table", logfield.TableName, tName)
+	job.logger.Infow("starting load for table", logger.NewStringField(logfield.TableName, tName))
 
 	status := model.TableUploadExecuting
 	lastExecTime := job.now()

--- a/warehouse/router/state_generate_load_files.go
+++ b/warehouse/router/state_generate_load_files.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/rudderlabs/rudder-server/warehouse/logfield"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
 	"github.com/rudderlabs/rudder-server/warehouse/internal/repo"
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
@@ -74,7 +74,7 @@ func (job *UploadJob) getTotalRowsInLoadFiles(ctx context.Context) int64 {
 		whutils.ToProviderCase(job.warehouse.Type, whutils.DiscardsTable),
 	})
 	if err != nil {
-		job.logger.Errorw(`Getting total rows in load files`, logfield.Error, err)
+		job.logger.Errorw(`Getting total rows in load files`, obskit.Error(err))
 		return 0
 	}
 	return exportedEvents

--- a/warehouse/router/upload_stats.go
+++ b/warehouse/router/upload_stats.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
 	"github.com/rudderlabs/rudder-server/utils/misc"
-	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
@@ -55,7 +55,7 @@ func (job *UploadJob) generateUploadSuccessMetrics() {
 		[]string{},
 	)
 	if err != nil {
-		job.logger.Warnw("sum of total exported events for upload", logfield.Error, err.Error())
+		job.logger.Warnw("sum of total exported events for upload", obskit.Error(err))
 		return
 	}
 
@@ -64,7 +64,7 @@ func (job *UploadJob) generateUploadSuccessMetrics() {
 		job.upload,
 	)
 	if err != nil {
-		job.logger.Warnw("total events for upload", logfield.Error, err.Error())
+		job.logger.Warnw("total events for upload", obskit.Error(err))
 		return
 	}
 
@@ -85,7 +85,7 @@ func (job *UploadJob) generateUploadAbortedMetrics() {
 		[]string{},
 	)
 	if err != nil {
-		job.logger.Warnw("sum of total exported events for upload", logfield.Error, err.Error())
+		job.logger.Warnw("sum of total exported events for upload", obskit.Error(err))
 		return
 	}
 
@@ -94,7 +94,7 @@ func (job *UploadJob) generateUploadAbortedMetrics() {
 		job.upload,
 	)
 	if err != nil {
-		job.logger.Warnw("total events for upload", logfield.Error, err.Error())
+		job.logger.Warnw("total events for upload", obskit.Error(err))
 		return
 	}
 

--- a/warehouse/schema/schema.go
+++ b/warehouse/schema/schema.go
@@ -10,8 +10,11 @@ import (
 
 	"github.com/samber/lo"
 
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/repo"
@@ -347,13 +350,13 @@ func (sh *Schema) removeDeprecatedColumns(schema model.Schema) {
 		for columnName := range columnMap {
 			if deprecatedColumnsRegex.MatchString(columnName) {
 				sh.log.Debugw("skipping deprecated column",
-					logfield.SourceID, sh.warehouse.Source.ID,
-					logfield.DestinationID, sh.warehouse.Destination.ID,
-					logfield.DestinationType, sh.warehouse.Destination.DestinationDefinition.Name,
-					logfield.WorkspaceID, sh.warehouse.WorkspaceID,
-					logfield.Namespace, sh.warehouse.Namespace,
-					logfield.TableName, tableName,
-					logfield.ColumnName, columnName,
+					obskit.SourceID(sh.warehouse.Source.ID),
+					obskit.DestinationID(sh.warehouse.Destination.ID),
+					obskit.DestinationType(sh.warehouse.Destination.DestinationDefinition.Name),
+					obskit.WorkspaceID(sh.warehouse.WorkspaceID),
+					obskit.Namespace(sh.warehouse.Namespace),
+					logger.NewStringField(logfield.TableName, tableName),
+					logger.NewStringField(logfield.ColumnName, columnName),
 				)
 				delete(schema[tableName], columnName)
 			}

--- a/warehouse/source/http.go
+++ b/warehouse/source/http.go
@@ -8,10 +8,11 @@ import (
 	"net/http"
 	"regexp"
 
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 
 	ierrors "github.com/rudderlabs/rudder-server/warehouse/internal/errors"
-	lf "github.com/rudderlabs/rudder-server/warehouse/logfield"
 )
 
 // emptyRegex matches empty strings
@@ -23,13 +24,13 @@ func (m *Manager) InsertJobHandler(w http.ResponseWriter, r *http.Request) {
 
 	var payload insertJobRequest
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		m.logger.Warnw("invalid JSON in request body for inserting source jobs", lf.Error, err.Error())
+		m.logger.Warnw("invalid JSON in request body for inserting source jobs", obskit.Error(err))
 		http.Error(w, ierrors.ErrInvalidJSONRequestBody.Error(), http.StatusBadRequest)
 		return
 	}
 
 	if err := validatePayload(&payload); err != nil {
-		m.logger.Warnw("invalid payload for inserting source job", lf.Error, err.Error())
+		m.logger.Warnw("invalid payload for inserting source job", obskit.Error(err))
 		http.Error(w, fmt.Sprintf("invalid payload: %s", err.Error()), http.StatusBadRequest)
 		return
 	}
@@ -40,7 +41,7 @@ func (m *Manager) InsertJobHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, ierrors.ErrRequestCancelled.Error(), http.StatusBadRequest)
 			return
 		}
-		m.logger.Errorw("inserting source jobs", lf.Error, err.Error())
+		m.logger.Errorw("inserting source jobs", obskit.Error(err))
 		http.Error(w, "can't insert source jobs", http.StatusInternalServerError)
 		return
 	}
@@ -50,7 +51,7 @@ func (m *Manager) InsertJobHandler(w http.ResponseWriter, r *http.Request) {
 		Err:    nil,
 	})
 	if err != nil {
-		m.logger.Errorw("marshalling response for inserting source job", lf.Error, err.Error())
+		m.logger.Errorw("marshalling response for inserting source job", obskit.Error(err))
 		http.Error(w, ierrors.ErrMarshallResponse.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -71,7 +72,7 @@ func (m *Manager) StatusJobHandler(w http.ResponseWriter, r *http.Request) {
 		WorkspaceID:   queryParams.Get("workspace_id"),
 	}
 	if err := validatePayload(&payload); err != nil {
-		m.logger.Warnw("invalid payload for source job status", lf.Error, err.Error())
+		m.logger.Warnw("invalid payload for source job status", obskit.Error(err))
 		http.Error(w, fmt.Sprintf("invalid request: %s", err.Error()), http.StatusBadRequest)
 		return
 	}
@@ -86,7 +87,7 @@ func (m *Manager) StatusJobHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, model.ErrSourcesJobNotFound.Error(), http.StatusNotFound)
 			return
 		}
-		m.logger.Warnw("unable to get source job status", lf.Error, err.Error())
+		m.logger.Warnw("unable to get source job status", obskit.Error(err))
 		http.Error(w, fmt.Sprintf("can't get source job status: %s", err.Error()), http.StatusBadRequest)
 		return
 	}
@@ -106,7 +107,7 @@ func (m *Manager) StatusJobHandler(w http.ResponseWriter, r *http.Request) {
 
 	resBody, err := json.Marshal(statusResponse)
 	if err != nil {
-		m.logger.Errorw("marshalling response for source job status", lf.Error, err.Error())
+		m.logger.Errorw("marshalling response for source job status", obskit.Error(err))
 		http.Error(w, ierrors.ErrMarshallResponse.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/warehouse/validations/validate.go
+++ b/warehouse/validations/validate.go
@@ -12,7 +12,10 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
+	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/encoding"
@@ -83,11 +86,11 @@ func validateDestination(ctx context.Context, dest *backendconfig.DestinationT, 
 	)
 
 	pkgLogger.Infow("validate destination configuration",
-		logfield.DestinationID, destID,
-		logfield.DestinationType, destType,
-		logfield.DestinationRevisionID, dest.RevisionID,
-		logfield.WorkspaceID, dest.WorkspaceID,
-		logfield.DestinationValidationsStep, stepToValidate,
+		obskit.DestinationID(destID),
+		obskit.DestinationType(destType),
+		logger.NewStringField(logfield.DestinationRevisionID, dest.RevisionID),
+		obskit.WorkspaceID(dest.WorkspaceID),
+		logger.NewStringField(logfield.DestinationValidationsStep, stepToValidate),
 	)
 
 	// check if req has specified a step in query params
@@ -126,12 +129,12 @@ func validateDestination(ctx context.Context, dest *backendconfig.DestinationT, 
 			step.Error = err.Error()
 
 			pkgLogger.Warnw("creating validator",
-				logfield.DestinationID, destID,
-				logfield.DestinationType, destType,
-				logfield.DestinationRevisionID, dest.RevisionID,
-				logfield.WorkspaceID, dest.WorkspaceID,
-				logfield.DestinationValidationsStep, step.Name,
-				logfield.Error, step.Error,
+				obskit.DestinationID(destID),
+				obskit.DestinationType(destType),
+				logger.NewStringField(logfield.DestinationRevisionID, dest.RevisionID),
+				obskit.WorkspaceID(dest.WorkspaceID),
+				logger.NewStringField(logfield.DestinationValidationsStep, step.Name),
+				obskit.Error(err),
 			)
 			break
 		}
@@ -146,12 +149,12 @@ func validateDestination(ctx context.Context, dest *backendconfig.DestinationT, 
 		// if any of steps fails, the whole validation fails
 		if !step.Success {
 			pkgLogger.Warnw("not able to validate destination configuration",
-				logfield.DestinationID, destID,
-				logfield.DestinationType, destType,
-				logfield.DestinationRevisionID, dest.RevisionID,
-				logfield.WorkspaceID, dest.WorkspaceID,
-				logfield.DestinationValidationsStep, step.Name,
-				logfield.Error, step.Error,
+				obskit.DestinationID(destID),
+				obskit.DestinationType(destType),
+				logger.NewStringField(logfield.DestinationRevisionID, dest.RevisionID),
+				obskit.WorkspaceID(dest.WorkspaceID),
+				logger.NewStringField(logfield.DestinationValidationsStep, step.Name),
+				"error", step.Error,
 			)
 			break
 		}


### PR DESCRIPTION
# Description

- Adapting `obskit` for the warehouse package to standardise log fields and remove those duplicates from `logfield` package.
- I removed the dependency of the `logfield` from `marketobulkupload.go`.
- Also using logger.New* so that we can move to [Non-Sugared Structured format](https://rudderlabs.slack.com/archives/C02LNLLAABC/p1708346761796859) easily in future.

## Linear Ticket

- Resolves PIPE-1383

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
