### PR TITLE
feat: users table loading from user load files

### DIFF
--- a/warehouse/integrations/bigquery/credentials_test.go
+++ b/warehouse/integrations/bigquery/credentials_test.go
@@ -1,0 +1,36 @@
+package bigquery
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	mockuploader "github.com/rudderlabs/rudder-server/warehouse/internal/mocks/utils"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+)
+
+func TestUnsupportedCredentials(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	uploader := mockuploader.NewMockUploader(ctrl)
+
+	bq := New(config.New(), logger.NOP)
+	bq.warehouse = model.Warehouse{
+		Destination: backendconfig.DestinationT{
+			Config: map[string]interface{}{
+				"credentials": "{\"installed\":{\"client_id\":\"1234.apps.googleusercontent.com\",\"project_id\":\"project_id\",\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"token_uri\":\"https://oauth2.googleapis.com/token\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\",\"client_secret\":\"client_secret\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"http://localhost\"]}}",
+			},
+		},
+	}
+	bq.uploader = uploader
+	bq.projectID = "projectId"
+
+	_, err := bq.connect(context.Background())
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "client_credentials.json file is not supported")
+}

--- a/warehouse/integrations/bigquery/middleware/middleware_test.go
+++ b/warehouse/integrations/bigquery/middleware/middleware_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/bigquery"
+	"google.golang.org/api/option"
+
 	bqHelper "github.com/rudderlabs/rudder-server/warehouse/integrations/bigquery/testhelper"
 
 	"github.com/stretchr/testify/require"
@@ -13,7 +16,6 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/logger/mock_logger"
 
-	"github.com/rudderlabs/rudder-server/warehouse/integrations/bigquery"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/bigquery/middleware"
 	"github.com/rudderlabs/rudder-server/warehouse/logfield"
 )
@@ -28,10 +30,11 @@ func TestQueryWrapper(t *testing.T) {
 
 	ctx := context.Background()
 
-	db, err := bigquery.Connect(ctx, &bigquery.BQCredentials{
-		ProjectID:   bqTestCredentials.ProjectID,
-		Credentials: bqTestCredentials.Credentials,
-	})
+	db, err := bigquery.NewClient(
+		ctx,
+		bqTestCredentials.ProjectID,
+		option.WithCredentialsJSON([]byte(bqTestCredentials.Credentials)),
+	)
 	require.NoError(t, err)
 
 	testCases := []struct {

--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -143,15 +143,15 @@ var dataTypesMapToRudder = map[string]string{
 }
 
 var primaryKeyMap = map[string]string{
-	"users":                      "id",
-	"identifies":                 "id",
-	warehouseutils.DiscardsTable: "row_id",
+	warehouseutils.UsersTable:      "id",
+	warehouseutils.IdentifiesTable: "id",
+	warehouseutils.DiscardsTable:   "row_id",
 }
 
 var partitionKeyMap = map[string]string{
-	"users":                      "id",
-	"identifies":                 "id",
-	warehouseutils.DiscardsTable: "row_id, column_name, table_name",
+	warehouseutils.UsersTable:      "id",
+	warehouseutils.IdentifiesTable: "id",
+	warehouseutils.DiscardsTable:   "row_id, column_name, table_name",
 }
 
 type Redshift struct {

--- a/warehouse/integrations/testhelper/setup.go
+++ b/warehouse/integrations/testhelper/setup.go
@@ -240,6 +240,7 @@ func EnhanceWithDefaultEnvs(t testing.TB) {
 	t.Setenv("RSERVER_WAREHOUSE_ENABLE_JITTER_FOR_SYNCS", "false")
 	t.Setenv("RSERVER_WAREHOUSE_ENABLE_IDRESOLUTION", "true")
 	t.Setenv("RSERVER_BACKEND_CONFIG_CONFIG_FROM_FILE", "true")
+	t.Setenv("RSERVER_ADMIN_SERVER_ENABLED", "false")
 	t.Setenv("RUDDER_ADMIN_PASSWORD", "password")
 	t.Setenv("RUDDER_GRACEFUL_SHUTDOWN_TIMEOUT_EXIT", "false")
 	t.Setenv("RSERVER_LOGGER_CONSOLE_JSON_FORMAT", "true")

--- a/warehouse/logfield/logfield.go
+++ b/warehouse/logfield/logfield.go
@@ -36,4 +36,5 @@ const (
 	IntervalInHours            = "intervalInHours"
 	StartTime                  = "startTime"
 	EndTime                    = "endTime"
+	ProjectID                  = "projectID"
 )


### PR DESCRIPTION
# Description

- Decoupling or loading of users table from identifies table:
  - Currently, we are querying the `identifies` table for staging data.
  - So, instead of this, we can use `users` load files to populate that data.
- Injecting middleware while creating the client itself instead of using the `getMiddleware` function which is prone to race conditions.

## Linear Ticket

- Resolves PIPE-1347
- Resolves PIPE-1421

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
