### PR TITLE
exp: users table loading using time unit column

### DIFF
--- a/warehouse/integrations/bigquery/bigquery_test.go
+++ b/warehouse/integrations/bigquery/bigquery_test.go
@@ -154,52 +154,52 @@ func TestIntegration(t *testing.T) {
 			customPartitionsEnabledWorkspaceIDs string
 			stagingFilePrefix                   string
 		}{
+			//{
+			//	name:          "Source Job",
+			//	writeKey:      sourcesWriteKey,
+			//	sourceID:      sourcesSourceID,
+			//	destinationID: sourcesDestinationID,
+			//	schema:        sourcesNamespace,
+			//	tables:        []string{"tracks", "google_sheet"},
+			//	stagingFilesEventsMap: whth.EventsCountMap{
+			//		"wh_staging_files": 9, // 8 + 1 (merge events because of ID resolution)
+			//	},
+			//	stagingFilesModifiedEventsMap: whth.EventsCountMap{
+			//		"wh_staging_files": 8, // 8 (de-duped by encounteredMergeRuleMap)
+			//	},
+			//	loadFilesEventsMap:    whth.SourcesLoadFilesEventsMap(),
+			//	tableUploadsEventsMap: whth.SourcesTableUploadsEventsMap(),
+			//	warehouseEventsMap:    whth.SourcesWarehouseEventsMap(),
+			//	sourceJob:             true,
+			//	prerequisite: func(ctx context.Context, t testing.TB, db *bigquery.Client) {
+			//		t.Helper()
+			//		_ = db.Dataset(namespace).DeleteWithContents(ctx)
+			//	},
+			//	stagingFilePrefix: "testdata/sources-job",
+			//},
+			//{
+			//	name:   "Append mode",
+			//	schema: namespace,
+			//	tables: []string{
+			//		"identifies", "users", "tracks", "product_track", "pages", "screens", "aliases", "groups",
+			//	},
+			//	writeKey:                      writeKey,
+			//	sourceID:                      sourceID,
+			//	destinationID:                 destinationID,
+			//	stagingFilesEventsMap:         stagingFilesEventsMap(),
+			//	stagingFilesModifiedEventsMap: stagingFilesEventsMap(),
+			//	loadFilesEventsMap:            loadFilesEventsMap(),
+			//	tableUploadsEventsMap:         tableUploadsEventsMap(),
+			//	warehouseEventsMap:            appendEventsMap(),
+			//	skipModifiedEvents:            true,
+			//	prerequisite: func(ctx context.Context, t testing.TB, db *bigquery.Client) {
+			//		t.Helper()
+			//		_ = db.Dataset(namespace).DeleteWithContents(ctx)
+			//	},
+			//	stagingFilePrefix: "testdata/upload-job-append-mode",
+			//},
 			{
-				name:          "Source Job",
-				writeKey:      sourcesWriteKey,
-				sourceID:      sourcesSourceID,
-				destinationID: sourcesDestinationID,
-				schema:        sourcesNamespace,
-				tables:        []string{"tracks", "google_sheet"},
-				stagingFilesEventsMap: whth.EventsCountMap{
-					"wh_staging_files": 9, // 8 + 1 (merge events because of ID resolution)
-				},
-				stagingFilesModifiedEventsMap: whth.EventsCountMap{
-					"wh_staging_files": 8, // 8 (de-duped by encounteredMergeRuleMap)
-				},
-				loadFilesEventsMap:    whth.SourcesLoadFilesEventsMap(),
-				tableUploadsEventsMap: whth.SourcesTableUploadsEventsMap(),
-				warehouseEventsMap:    whth.SourcesWarehouseEventsMap(),
-				sourceJob:             true,
-				prerequisite: func(ctx context.Context, t testing.TB, db *bigquery.Client) {
-					t.Helper()
-					_ = db.Dataset(namespace).DeleteWithContents(ctx)
-				},
-				stagingFilePrefix: "testdata/sources-job",
-			},
-			{
-				name:   "Append mode",
-				schema: namespace,
-				tables: []string{
-					"identifies", "users", "tracks", "product_track", "pages", "screens", "aliases", "groups",
-				},
-				writeKey:                      writeKey,
-				sourceID:                      sourceID,
-				destinationID:                 destinationID,
-				stagingFilesEventsMap:         stagingFilesEventsMap(),
-				stagingFilesModifiedEventsMap: stagingFilesEventsMap(),
-				loadFilesEventsMap:            loadFilesEventsMap(),
-				tableUploadsEventsMap:         tableUploadsEventsMap(),
-				warehouseEventsMap:            appendEventsMap(),
-				skipModifiedEvents:            true,
-				prerequisite: func(ctx context.Context, t testing.TB, db *bigquery.Client) {
-					t.Helper()
-					_ = db.Dataset(namespace).DeleteWithContents(ctx)
-				},
-				stagingFilePrefix: "testdata/upload-job-append-mode",
-			},
-			{
-				name:   "Append mode with custom partition",
+				name:   "Append mode with custom partition [timestamp(DAY)]",
 				schema: namespace,
 				tables: []string{
 					"identifies", "users", "tracks", "product_track", "pages", "screens", "aliases", "groups",
@@ -224,7 +224,7 @@ func TestIntegration(t *testing.T) {
 					})
 					require.NoError(t, err)
 
-					err = db.Dataset(namespace).Table("tracks").Create(
+					err = db.Dataset(namespace).Table("users").Create(
 						context.Background(),
 						&bigquery.TableMetadata{
 							Schema: []*bigquery.FieldSchema{{
@@ -233,6 +233,7 @@ func TestIntegration(t *testing.T) {
 							}},
 							TimePartitioning: &bigquery.TimePartitioning{
 								Field: "timestamp",
+								Type:  bigquery.DayPartitioningType,
 							},
 						},
 					)

--- a/warehouse/integrations/testhelper/setup.go
+++ b/warehouse/integrations/testhelper/setup.go
@@ -240,6 +240,7 @@ func EnhanceWithDefaultEnvs(t testing.TB) {
 	t.Setenv("RSERVER_WAREHOUSE_ENABLE_JITTER_FOR_SYNCS", "false")
 	t.Setenv("RSERVER_WAREHOUSE_ENABLE_IDRESOLUTION", "true")
 	t.Setenv("RSERVER_BACKEND_CONFIG_CONFIG_FROM_FILE", "true")
+	t.Setenv("RSERVER_ADMIN_SERVER_ENABLED", "false")
 	t.Setenv("RUDDER_ADMIN_PASSWORD", "password")
 	t.Setenv("RUDDER_GRACEFUL_SHUTDOWN_TIMEOUT_EXIT", "false")
 	t.Setenv("RSERVER_LOGGER_CONSOLE_JSON_FORMAT", "true")


### PR DESCRIPTION
# Description

- Experimentation: Using proper pruning filter based on the time unit column provided.

## Linear Ticket

- Resolves PIPE-1347

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
