### PR TITLE
chore: store anonymous ids in userID hll to optimise storage

### DIFF
--- a/enterprise/trackedusers/users_reporter.go
+++ b/enterprise/trackedusers/users_reporter.go
@@ -137,11 +137,11 @@ func (u *UniqueUsersReporter) GenerateReportsFromJobs(jobs []*jobsdb.JobT, sourc
 			workspaceSourceUserIdTypeMap[job.WorkspaceId][sourceID] = u.recordIdentifier(workspaceSourceUserIdTypeMap[job.WorkspaceId][sourceID], userID, idTypeUserID)
 		}
 
-		if anonymousID != "" {
-			workspaceSourceUserIdTypeMap[job.WorkspaceId][sourceID] = u.recordIdentifier(workspaceSourceUserIdTypeMap[job.WorkspaceId][sourceID], anonymousID, idTypeAnonymousID)
+		if anonymousID != "" && userID != anonymousID {
+			workspaceSourceUserIdTypeMap[job.WorkspaceId][sourceID] = u.recordIdentifier(workspaceSourceUserIdTypeMap[job.WorkspaceId][sourceID], anonymousID, idTypeUserID)
 		}
 
-		if userID != "" && anonymousID != "" {
+		if userID != "" && anonymousID != "" && userID != anonymousID {
 			combinedUserIDAnonymousID := combineUserIDAnonymousID(userID, anonymousID)
 			workspaceSourceUserIdTypeMap[job.WorkspaceId][sourceID] = u.recordIdentifier(workspaceSourceUserIdTypeMap[job.WorkspaceId][sourceID], combinedUserIDAnonymousID, idTypeIdentifiedAnonymousID)
 		}

--- a/enterprise/trackedusers/users_reporter_test.go
+++ b/enterprise/trackedusers/users_reporter_test.go
@@ -63,7 +63,7 @@ var (
 			userIDHll.AddRaw(murmur3.Sum64WithSeed([]byte(uuid.NewString()), murmurSeed))
 		}
 		for i := 0; i < noOfAnnID; i++ {
-			annIDHll.AddRaw(murmur3.Sum64WithSeed([]byte(uuid.NewString()), murmurSeed))
+			userIDHll.AddRaw(murmur3.Sum64WithSeed([]byte(uuid.NewString()), murmurSeed))
 		}
 		for i := 0; i < noOfIdentifiedAnnID; i++ {
 			identifiedAnnIDHll.AddRaw(murmur3.Sum64WithSeed([]byte(uuid.NewString()), murmurSeed))
@@ -115,17 +115,13 @@ func TestUniqueUsersReporter(t *testing.T) {
 						UserIDHll: func() *hll.Hll {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
+							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user_id"), murmurSeed))
+							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id_1"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user_id_1"), murmurSeed))
 							return &resHll
 						}(),
-						AnonymousIDHll: func() *hll.Hll {
-							resHll, err := hll.NewHll(hllSettings)
-							require.NoError(t, err)
-							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id"), murmurSeed))
-							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id_1"), murmurSeed))
-							return &resHll
-						}(),
+						AnonymousIDHll: nil,
 						IdentifiedAnonymousIDHll: func() *hll.Hll {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
@@ -158,16 +154,12 @@ func TestUniqueUsersReporter(t *testing.T) {
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user_id"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user_id_1"), murmurSeed))
-							return &resHll
-						}(),
-						AnonymousIDHll: func() *hll.Hll {
-							resHll, err := hll.NewHll(hllSettings)
-							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("ann"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id_1"), murmurSeed))
 							return &resHll
 						}(),
+						AnonymousIDHll: nil,
 						IdentifiedAnonymousIDHll: func() *hll.Hll {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
@@ -187,14 +179,10 @@ func TestUniqueUsersReporter(t *testing.T) {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user"), murmurSeed))
-							return &resHll
-						}(),
-						AnonymousIDHll: func() *hll.Hll {
-							resHll, err := hll.NewHll(hllSettings)
-							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("ann"), murmurSeed))
 							return &resHll
 						}(),
+						AnonymousIDHll: nil,
 						IdentifiedAnonymousIDHll: func() *hll.Hll {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
@@ -226,16 +214,12 @@ func TestUniqueUsersReporter(t *testing.T) {
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user_id"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user_id_1"), murmurSeed))
-							return &resHll
-						}(),
-						AnonymousIDHll: func() *hll.Hll {
-							resHll, err := hll.NewHll(hllSettings)
-							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("ann"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id_1"), murmurSeed))
 							return &resHll
 						}(),
+						AnonymousIDHll: nil,
 						IdentifiedAnonymousIDHll: func() *hll.Hll {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
@@ -256,14 +240,10 @@ func TestUniqueUsersReporter(t *testing.T) {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user"), murmurSeed))
-							return &resHll
-						}(),
-						AnonymousIDHll: func() *hll.Hll {
-							resHll, err := hll.NewHll(hllSettings)
-							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("ann"), murmurSeed))
 							return &resHll
 						}(),
+						AnonymousIDHll: nil,
 						IdentifiedAnonymousIDHll: func() *hll.Hll {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
@@ -295,16 +275,12 @@ func TestUniqueUsersReporter(t *testing.T) {
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user_id"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user_id_1"), murmurSeed))
-							return &resHll
-						}(),
-						AnonymousIDHll: func() *hll.Hll {
-							resHll, err := hll.NewHll(hllSettings)
-							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("ann"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id_1"), murmurSeed))
 							return &resHll
 						}(),
+						AnonymousIDHll: nil,
 						IdentifiedAnonymousIDHll: func() *hll.Hll {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
@@ -324,14 +300,10 @@ func TestUniqueUsersReporter(t *testing.T) {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user"), murmurSeed))
-							return &resHll
-						}(),
-						AnonymousIDHll: func() *hll.Hll {
-							resHll, err := hll.NewHll(hllSettings)
-							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("ann"), murmurSeed))
 							return &resHll
 						}(),
+						AnonymousIDHll: nil,
 						IdentifiedAnonymousIDHll: func() *hll.Hll {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
@@ -359,26 +331,59 @@ func TestUniqueUsersReporter(t *testing.T) {
 							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user_id"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user"), murmurSeed))
-							return &resHll
-						}(),
-						AnonymousIDHll: func() *hll.Hll {
-							resHll, err := hll.NewHll(hllSettings)
-							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id"), murmurSeed))
 							return &resHll
 						}(),
+						AnonymousIDHll:           nil,
 						IdentifiedAnonymousIDHll: nil,
 					},
 					{
 						WorkspaceID: sampleWorkspaceID2,
 						SourceID:    sampleSourceID,
-						UserIDHll:   nil,
-						AnonymousIDHll: func() *hll.Hll {
+						UserIDHll: func() *hll.Hll {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("ann"), murmurSeed))
 							return &resHll
 						}(),
+						AnonymousIDHll:           nil,
+						IdentifiedAnonymousIDHll: nil,
+					},
+				},
+			},
+			{
+				name: "happy case - same user and anonymous id",
+				jobs: []*jobsdb.JobT{
+					prepareJob(sampleSourceID, "anon_id", "anon_id", sampleWorkspaceID),
+					prepareJob(sampleSourceID, "user_id", "user_id", sampleWorkspaceID),
+					prepareJob(sampleSourceID, "user", "", sampleWorkspaceID),
+					prepareJob(sampleSourceID, "ann", "ann", sampleWorkspaceID2),
+				},
+				trackedUsers: []*UsersReport{
+					{
+						WorkspaceID: sampleWorkspaceID,
+						SourceID:    sampleSourceID,
+						UserIDHll: func() *hll.Hll {
+							resHll, err := hll.NewHll(hllSettings)
+							require.NoError(t, err)
+							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user_id"), murmurSeed))
+							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user"), murmurSeed))
+							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id"), murmurSeed))
+							return &resHll
+						}(),
+						AnonymousIDHll:           nil,
+						IdentifiedAnonymousIDHll: nil,
+					},
+					{
+						WorkspaceID: sampleWorkspaceID2,
+						SourceID:    sampleSourceID,
+						UserIDHll: func() *hll.Hll {
+							resHll, err := hll.NewHll(hllSettings)
+							require.NoError(t, err)
+							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("ann"), murmurSeed))
+							return &resHll
+						}(),
+						AnonymousIDHll:           nil,
 						IdentifiedAnonymousIDHll: nil,
 					},
 				},
@@ -407,16 +412,12 @@ func TestUniqueUsersReporter(t *testing.T) {
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user_id"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user_id_1"), murmurSeed))
-							return &resHll
-						}(),
-						AnonymousIDHll: func() *hll.Hll {
-							resHll, err := hll.NewHll(hllSettings)
-							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("ann"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id"), murmurSeed))
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("anon_id_1"), murmurSeed))
 							return &resHll
 						}(),
+						AnonymousIDHll: nil,
 						IdentifiedAnonymousIDHll: func() *hll.Hll {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
@@ -436,14 +437,10 @@ func TestUniqueUsersReporter(t *testing.T) {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("user"), murmurSeed))
-							return &resHll
-						}(),
-						AnonymousIDHll: func() *hll.Hll {
-							resHll, err := hll.NewHll(hllSettings)
-							require.NoError(t, err)
 							resHll.AddRaw(murmur3.Sum64WithSeed([]byte("ann"), murmurSeed))
 							return &resHll
 						}(),
+						AnonymousIDHll: nil,
 						IdentifiedAnonymousIDHll: func() *hll.Hll {
 							resHll, err := hll.NewHll(hllSettings)
 							require.NoError(t, err)

--- a/integration_test/trackedusersreporting/tracked_users_reporting_test.go
+++ b/integration_test/trackedusersreporting/tracked_users_reporting_test.go
@@ -234,6 +234,9 @@ func TestTrackedUsersReporting(t *testing.T) {
 		{anonymousID: "anon-2"},
 	}, "identify", writeKey, url)
 	require.NoError(t, err)
+	err = sendAliasEvent("user-1", "user-2", writeKey, url)
+	require.NoError(t, err)
+	eventsCount++
 
 	require.Eventuallyf(t, func() bool {
 		return tc.webhook.RequestsCount() == eventsCount
@@ -244,9 +247,9 @@ func TestTrackedUsersReporting(t *testing.T) {
 	}, 1*time.Minute, 5*time.Second, "data not reported to reporting service")
 
 	cardinalityMap := tc.reportingServer.getCardinalityFromReportingServer()
-	require.Equal(t, 2, cardinalityMap[workspaceID][sourceID].userIDCount)
-	require.Equal(t, 2, cardinalityMap[workspaceID][sourceID].anonIDCount)
-	require.Equal(t, 2, cardinalityMap[workspaceID][sourceID].identifiedUsersCount)
+	require.Equal(t, 4, cardinalityMap[workspaceID][sourceID].userIDCount)
+	require.Equal(t, 0, cardinalityMap[workspaceID][sourceID].anonIDCount)
+	require.Equal(t, 3, cardinalityMap[workspaceID][sourceID].identifiedUsersCount)
 	cancel()
 	require.NoError(t, wg.Wait())
 }
@@ -369,6 +372,53 @@ func runRudderServer(
 		err = fmt.Errorf("rudder-server exited with a non-0 exit code: %d", c)
 	}
 	return
+}
+
+// nolint: bodyclose
+func sendAliasEvent(userID, previousID, writeKey,
+	url string,
+) error {
+	payload := []byte(fmt.Sprintf(`
+			{
+			  "batch": [
+				{
+				  "userId": %[1]q,
+				  "type": "alias",
+				  "previousId": %[2]q,
+				  "anonymousId": %[1]q,
+				  "context": {
+					"traits": {
+					  "trait1": "new-val"
+					},
+					"ip": "14.5.67.21",
+					"library": {
+					  "name": "http"
+					}
+				  },
+				  "timestamp": "2020-02-02T00:23:09.544Z"
+				}
+			  ]
+			}`,
+		userID,
+		previousID,
+	))
+	req, err := http.NewRequest(http.MethodPost, url+"/v1/batch", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(writeKey, "password")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to send event to rudder server, status code: %d: %s", resp.StatusCode, string(b))
+	}
+	kithttputil.CloseResponse(resp)
+	return nil
 }
 
 // nolint: bodyclose


### PR DESCRIPTION
# Description

 store anonymous ids in userID hll to optimise storage and memory

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1384/add-anonymous-ids-in-userid-column

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
