### PR TITLE
chore: update destination id label to be consistent with other modules

### DIFF
--- a/router/batchrouter/handle_observability.go
+++ b/router/batchrouter/handle_observability.go
@@ -193,7 +193,7 @@ func (brt *Handle) recordUploadStats(destination Connection, output UploadResult
 			"destination":    destinationTag,
 			"workspaceId":    destination.Source.WorkspaceID,
 			"sourceId":       destination.Source.ID,
-			"destinationId":  destination.Destination.ID,
+			"destID":         destination.Destination.ID,
 			"sourceCategory": destination.Source.SourceDefinition.Category,
 		})
 		eventDeliveryTimeStat.SendTiming(time.Since(receivedTime))


### PR DESCRIPTION
# Description

We use different destination label keys for `event_delivery_time` metric for different modules, for router and warehouse we are using `destID` and for batch_router we are using `destinationId`. 
Changing destination id label for batch_router module to be consistent with other modules.

## Linear Ticket

Resolves OBS-586
https://linear.app/rudderstack/issue/OBS-586/update-labels-in-event-delivery-time-metric

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
