### PR TITLE
chore: add sourceCategory label in event_delivery_time metric

### DIFF
--- a/warehouse/router/upload_stats.go
+++ b/warehouse/router/upload_stats.go
@@ -130,6 +130,7 @@ func (job *UploadJob) recordTableLoad(tableName string, numEvents int64) {
 		job.timerStat("event_delivery_time",
 			warehouseutils.Tag{Name: "tableName", Value: capturedTableName},
 			warehouseutils.Tag{Name: "syncFrequency", Value: syncFrequency},
+			warehouseutils.Tag{Name: "sourceCategory", Value: job.warehouse.Source.SourceDefinition.Category},
 		).Since(firstEventAt)
 	}
 }


### PR DESCRIPTION
# Description

Adding sourceCategory label in event_delivery_time metric.

## Linear Ticket

https://linear.app/rudderstack/issue/OBS-600/add-sourcecategory-label-for-warehouse-latency-metric

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
