### PR TITLE
fix: terminate loop after long-running transformation is detected

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -552,6 +552,7 @@ func trackLongRunningTransformation(ctx context.Context, stage string, timeout t
 			log.Errorw("Long running transformation detected",
 				"stage", stage,
 				"duration", time.Since(start).String())
+			return // ensure the loop terminates after logging
 		}
 	}
 }


### PR DESCRIPTION
# Description
terminate loop after long-running transformation is detected

## Linear Ticket

-

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
