### PR TITLE
chore: rename identified_anon_id_hll, user_id_hll column

### DIFF
--- a/enterprise/reporting/flusher/aggregator/types.go
+++ b/enterprise/reporting/flusher/aggregator/types.go
@@ -14,7 +14,6 @@ type TrackedUsersReport struct {
 	SourceID                    string    `json:"sourceId"`
 	InstanceID                  string    `json:"instanceId"`
 	UserIDHLL                   *hll.Hll  `json:"-"`
-	AnonymousIDHLL              *hll.Hll  `json:"-"`
 	IdentifiedAnonymousIDHLL    *hll.Hll  `json:"-"`
 	UserIDHLLHex                string    `json:"userIdHLL"`
 	AnonymousIDHLLHex           string    `json:"anonymousIdHLL"`
@@ -23,7 +22,6 @@ type TrackedUsersReport struct {
 
 func (t *TrackedUsersReport) MarshalJSON() ([]byte, error) {
 	t.UserIDHLLHex = hex.EncodeToString(t.UserIDHLL.ToBytes())
-	t.AnonymousIDHLLHex = hex.EncodeToString(t.AnonymousIDHLL.ToBytes())
 	t.IdentifiedAnonymousIDHLLHex = hex.EncodeToString(t.IdentifiedAnonymousIDHLL.ToBytes())
 
 	type Alias TrackedUsersReport

--- a/sql/migrations/tracked_users/000002_rename_column.up.sql
+++ b/sql/migrations/tracked_users/000002_rename_column.up.sql
@@ -1,0 +1,9 @@
+alter table tracked_users_reports
+    rename column userid_hll to tracked_identifiers_hll;
+
+alter table tracked_users_reports
+    rename column identified_anonymousid_hll to merged_identifiers_hll;
+
+-- we are dropping this column because it is not used from the last 2 releases, so it should be safe to drop it
+alter table tracked_users_reports
+    drop column anonymousid_hll;


### PR DESCRIPTION
# Description

- Rename columns for better instrumentation
- remove unused columns

ref: https://github.com/rudderlabs/rudder-server/pull/4988#discussion_r1713639422

## Linear Ticket

pipe-1462

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
