### PR TITLE
fix: take tacking plan id from dgsourceTPconfig

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1832,19 +1832,12 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 				&backendconfig.DestinationT{},
 			)
 
-			trackingPlanID := source.DgSourceTrackingPlanConfig.TrackingPlan.Id
 			trackingPlanVersion := source.DgSourceTrackingPlanConfig.TrackingPlan.Version
-			rudderTyperTPID := misc.MapLookup(singularEvent, "context", "ruddertyper", "trackingPlanId")
 			rudderTyperTPVersion := misc.MapLookup(singularEvent, "context", "ruddertyper", "trackingPlanVersion")
-			if rudderTyperTPID != nil && rudderTyperTPVersion != nil {
-				if id, ok := rudderTyperTPID.(string); ok && id != "" {
-					trackingPlanID = id
-				}
-				if version, ok := rudderTyperTPVersion.(float64); ok && version > 0 {
-					trackingPlanVersion = int(version)
-				}
+			if version, ok := rudderTyperTPVersion.(float64); ok && version > 0 && rudderTyperTPVersion != nil {
+				trackingPlanVersion = int(version)
 			}
-			shallowEventCopy.Metadata.TrackingPlanId = trackingPlanID
+			shallowEventCopy.Metadata.TrackingPlanId = source.DgSourceTrackingPlanConfig.TrackingPlan.Id
 			shallowEventCopy.Metadata.TrackingPlanVersion = trackingPlanVersion
 			shallowEventCopy.Metadata.SourceTpConfig = source.DgSourceTrackingPlanConfig.Config
 			shallowEventCopy.Metadata.MergedTpConfig = source.DgSourceTrackingPlanConfig.GetMergedConfig(commonMetadataFromSingularEvent.EventType)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1834,8 +1834,10 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 
 			trackingPlanVersion := source.DgSourceTrackingPlanConfig.TrackingPlan.Version
 			rudderTyperTPVersion := misc.MapLookup(singularEvent, "context", "ruddertyper", "trackingPlanVersion")
-			if version, ok := rudderTyperTPVersion.(float64); ok && version > 0 && rudderTyperTPVersion != nil {
-				trackingPlanVersion = int(version)
+			if rudderTyperTPVersion != nil {
+				if version, ok := rudderTyperTPVersion.(float64); ok && version > 0 {
+					trackingPlanVersion = int(version)
+				}
 			}
 			shallowEventCopy.Metadata.TrackingPlanId = source.DgSourceTrackingPlanConfig.TrackingPlan.Id
 			shallowEventCopy.Metadata.TrackingPlanVersion = trackingPlanVersion

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1832,17 +1832,16 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 				&backendconfig.DestinationT{},
 			)
 
+			trackingPlanID := source.DgSourceTrackingPlanConfig.TrackingPlan.Id
 			trackingPlanVersion := source.DgSourceTrackingPlanConfig.TrackingPlan.Version
 			rudderTyperTPID := misc.MapLookup(singularEvent, "context", "ruddertyper", "trackingPlanId")
 			rudderTyperTPVersion := misc.MapLookup(singularEvent, "context", "ruddertyper", "trackingPlanVersion")
-			if rudderTyperTPID != nil && rudderTyperTPID == source.DgSourceTrackingPlanConfig.TrackingPlan.Id {
-				if rudderTyperTPVersion != nil {
-					if version, ok := rudderTyperTPVersion.(float64); ok && version > 0 {
-						trackingPlanVersion = int(version)
-					}
+			if rudderTyperTPID != nil && rudderTyperTPVersion != nil && rudderTyperTPID == trackingPlanID {
+				if version, ok := rudderTyperTPVersion.(float64); ok && version > 0 {
+					trackingPlanVersion = int(version)
 				}
 			}
-			shallowEventCopy.Metadata.TrackingPlanId = source.DgSourceTrackingPlanConfig.TrackingPlan.Id
+			shallowEventCopy.Metadata.TrackingPlanId = trackingPlanID
 			shallowEventCopy.Metadata.TrackingPlanVersion = trackingPlanVersion
 			shallowEventCopy.Metadata.SourceTpConfig = source.DgSourceTrackingPlanConfig.Config
 			shallowEventCopy.Metadata.MergedTpConfig = source.DgSourceTrackingPlanConfig.GetMergedConfig(commonMetadataFromSingularEvent.EventType)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1833,10 +1833,13 @@ func (proc *Handle) processJobsForDest(partition string, subJobs subJob) *transf
 			)
 
 			trackingPlanVersion := source.DgSourceTrackingPlanConfig.TrackingPlan.Version
+			rudderTyperTPID := misc.MapLookup(singularEvent, "context", "ruddertyper", "trackingPlanId")
 			rudderTyperTPVersion := misc.MapLookup(singularEvent, "context", "ruddertyper", "trackingPlanVersion")
-			if rudderTyperTPVersion != nil {
-				if version, ok := rudderTyperTPVersion.(float64); ok && version > 0 {
-					trackingPlanVersion = int(version)
+			if rudderTyperTPID != nil && rudderTyperTPID == source.DgSourceTrackingPlanConfig.TrackingPlan.Id {
+				if rudderTyperTPVersion != nil {
+					if version, ok := rudderTyperTPVersion.(float64); ok && version > 0 {
+						trackingPlanVersion = int(version)
+					}
 				}
 			}
 			shallowEventCopy.Metadata.TrackingPlanId = source.DgSourceTrackingPlanConfig.TrackingPlan.Id

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -984,6 +984,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 					},
 				},
 			)
+			Expect(err).To(BeNil())
 
 			Expect(c.MockObserver.calls).To(HaveLen(1))
 			for _, v := range c.MockObserver.calls {

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -946,7 +946,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 	})
 
 	Context("RudderTyper", func() {
-		It("Tracking Plan Id and Version from DgSourceTrackingPlanConfig", func() {
+		It("Tracking plan id and version from DgSourceTrackingPlanConfig", func() {
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			mockTransformer.EXPECT().Validate(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(transformer.Response{})
 
@@ -1017,11 +1017,11 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 			for _, v := range c.MockObserver.calls {
 				for _, e := range v.events {
 					Expect(e.Metadata.TrackingPlanId).To(BeEquivalentTo("tracking-plan-id"))
-					Expect(e.Metadata.TrackingPlanVersion).To(BeEquivalentTo(100))
+					Expect(e.Metadata.TrackingPlanVersion).To(BeEquivalentTo(100)) // from DgSourceTrackingPlanConfig
 				}
 			}
 		})
-		It("Tracking plan Version override from context.ruddertyper", func() {
+		It("Tracking plan version override from context.ruddertyper", func() {
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			mockTransformer.EXPECT().Validate(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(transformer.Response{})
 
@@ -1073,6 +1073,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 										  "sentAt": %[3]q,
 										  "context": {
 											"ruddertyper": {
+                                              "trackingPlanId": "tracking-plan-id",
 											  "trackingPlanVersion": 123
 											}
 										  }
@@ -1097,7 +1098,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 			for _, v := range c.MockObserver.calls {
 				for _, e := range v.events {
 					Expect(e.Metadata.TrackingPlanId).To(BeEquivalentTo("tracking-plan-id"))
-					Expect(e.Metadata.TrackingPlanVersion).To(BeEquivalentTo(123))
+					Expect(e.Metadata.TrackingPlanVersion).To(BeEquivalentTo(123)) // Overridden happens when tracking plan id is same in context.ruddertyper and DgSourceTrackingPlanConfig
 				}
 			}
 		})

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -912,7 +912,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 	})
 
 	Context("RudderTyper", func() {
-		It("TrackingPlanId and TrackingPlanVersion", func() {
+		It("TrackingPlanVersion", func() {
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			mockTransformer.EXPECT().Validate(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(transformer.Response{})
 
@@ -988,7 +988,6 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 			Expect(c.MockObserver.calls).To(HaveLen(1))
 			for _, v := range c.MockObserver.calls {
 				for _, e := range v.events {
-					Expect(e.Metadata.TrackingPlanId).To(BeEquivalentTo("tracking-plan-id"))
 					Expect(e.Metadata.TrackingPlanVersion).To(BeEquivalentTo(123))
 				}
 			}


### PR DESCRIPTION
# Description

take tacking plan id from dgsourceTPconfig instead of context.ruddertyper config

## Linear Ticket

[DAT-1551](https://linear.app/rudderstack/issue/DAT-1551/typer-rudder-server-take-tacking-plan-id-from-dgsourcetpconfig-instead)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
