### PR TITLE
chore: update webhook test cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/rudderlabs/rudder-go-kit v0.38.0
 	github.com/rudderlabs/rudder-observability-kit v0.0.3
 	github.com/rudderlabs/rudder-schemas v0.5.1
-	github.com/rudderlabs/rudder-transformer/go v0.0.0-20240812044419-23196ec42acf
+	github.com/rudderlabs/rudder-transformer/go v0.0.0-20240903092449-3f2a5a664d32
 	github.com/rudderlabs/sql-tunnels v0.1.7
 	github.com/rudderlabs/sqlconnect-go v1.9.0
 	github.com/samber/lo v1.47.0

--- a/go.sum
+++ b/go.sum
@@ -1140,8 +1140,8 @@ github.com/rudderlabs/rudder-observability-kit v0.0.3 h1:vZtuZRkGX+6rjaeKtxxFE2Y
 github.com/rudderlabs/rudder-observability-kit v0.0.3/go.mod h1:6UjAh3H6rkE0fFLh7z8ZGQEQbKtUkRfhWOf/OUhfqW8=
 github.com/rudderlabs/rudder-schemas v0.5.1 h1:g4I5wp2yA6ZWQZ1MjSNn4zby3XctG/TOgbYUW3dS4z4=
 github.com/rudderlabs/rudder-schemas v0.5.1/go.mod h1:JoDTB9nCDXwRz+G+aYwP3Fj42HLssKARxsFFm+qqgb4=
-github.com/rudderlabs/rudder-transformer/go v0.0.0-20240812044419-23196ec42acf h1:nsU2tKjPV/sbmOoIk39ncFT8D5HBDVppmrCWO0v9HsU=
-github.com/rudderlabs/rudder-transformer/go v0.0.0-20240812044419-23196ec42acf/go.mod h1:3NGitPz4pYRRZ6Xt09S+8hb0tHK/9pZcKJ3OgOTaSmE=
+github.com/rudderlabs/rudder-transformer/go v0.0.0-20240903092449-3f2a5a664d32 h1:hsvbOvwfA8wr9GjNBWuh3lZnpqMgIzLU7HNESB87wSg=
+github.com/rudderlabs/rudder-transformer/go v0.0.0-20240903092449-3f2a5a664d32/go.mod h1:3NGitPz4pYRRZ6Xt09S+8hb0tHK/9pZcKJ3OgOTaSmE=
 github.com/rudderlabs/sql-tunnels v0.1.7 h1:wDCRl6zY4M5gfWazf7XkSTGQS3yjBzUiUgEMBIfHNDA=
 github.com/rudderlabs/sql-tunnels v0.1.7/go.mod h1:5f7+YL49JHYgteP4rAgqKnr4K2OadB0oIpUS+Tt3sPM=
 github.com/rudderlabs/sqlconnect-go v1.9.0 h1:icLgqvVQ15Vh+oP7epA0b0yK6sIzxRVwPlRzOoDNVRA=


### PR DESCRIPTION
# Description


Update rudder-transformer module to get latest test-cases.


## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1484/update-webhook-test-cases-in-rudder-server

Resolves PIPE-1484

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
