### PR TITLE
fix: revert support for webhook headers

### DIFF
--- a/gateway/webhook/integration_test.go
+++ b/gateway/webhook/integration_test.go
@@ -295,7 +295,7 @@ func TestIntegrationWebhook(t *testing.T) {
 				})
 				return err == nil && len(r.Jobs) == len(tc.Output.ErrQueue)
 			}, time.Second, time.Millisecond*10)
-			
+
 			require.NoError(t, err)
 			assert.Len(t, r.Jobs, len(tc.Output.ErrQueue))
 			for i, p := range tc.Output.ErrQueue {

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -269,17 +269,6 @@ func (webhook *HandleT) batchRequests(sourceDef string, requestQ chan *webhookT)
 	}
 }
 
-func getXHeaders(req *http.Request) map[string]string {
-	xHeaders := make(map[string]string)
-	for key, values := range req.Header {
-		lowerCaseKey := strings.ToLower(key)
-		if !strings.HasPrefix(lowerCaseKey, "x-forwarded-") && strings.HasPrefix(lowerCaseKey, "x-") {
-			xHeaders[key] = strings.Join(values, ",")
-		}
-	}
-	return xHeaders
-}
-
 func prepareRequestBody(req *http.Request, sourceType string, sourceListForParsingParams []string) ([]byte, error) {
 	defer func() {
 		_ = req.Body.Close()
@@ -301,15 +290,6 @@ func prepareRequestBody(req *http.Request, sourceType string, sourceListForParsi
 		if err != nil {
 			return nil, errors.New(response.InvalidJSON)
 		}
-	}
-
-	xHeaders := getXHeaders(req)
-	if len(xHeaders) > 0 {
-		body, err = sjson.SetBytes(body, "headers", xHeaders)
-		if err != nil {
-			return nil, errors.New(response.InvalidJSON)
-		}
-
 	}
 
 	return body, nil

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -550,12 +550,6 @@ func TestPrepareRequestBody(t *testing.T) {
 			expectedResponse: `{"key":"value","query_parameters":{}}`,
 		},
 		{
-			name:             "Some payload with headers for shopify",
-			req:              createRequest(requestOpts{method: http.MethodPost, target: "http://example.com", body: strings.NewReader(`{"key":"value"}`), headers: map[string]string{"X-Key": "header-value"}}),
-			sourceType:       "shopify",
-			expectedResponse: `{"key":"value","query_parameters":{},"headers":{"X-Key":"header-value"}}`,
-		},
-		{
 			name:             "Some payload with query parameters for Adjust",
 			req:              createRequest(requestOpts{method: http.MethodPost, target: "http://example.com", body: strings.NewReader(`{"key1":"value1"}`), params: map[string]string{"key2": "value2"}}),
 			sourceType:       "Adjust",

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/rudderlabs/rudder-go-kit v0.38.0
 	github.com/rudderlabs/rudder-observability-kit v0.0.3
 	github.com/rudderlabs/rudder-schemas v0.5.1
-	github.com/rudderlabs/rudder-transformer/go v0.0.0-20240812044419-23196ec42acf
+	github.com/rudderlabs/rudder-transformer/go v0.0.0-20240906042448-f7783d8fb300
 	github.com/rudderlabs/sql-tunnels v0.1.7
 	github.com/rudderlabs/sqlconnect-go v1.9.0
 	github.com/samber/lo v1.47.0

--- a/go.sum
+++ b/go.sum
@@ -1136,6 +1136,8 @@ github.com/rudderlabs/rudder-schemas v0.5.1 h1:g4I5wp2yA6ZWQZ1MjSNn4zby3XctG/TOg
 github.com/rudderlabs/rudder-schemas v0.5.1/go.mod h1:JoDTB9nCDXwRz+G+aYwP3Fj42HLssKARxsFFm+qqgb4=
 github.com/rudderlabs/rudder-transformer/go v0.0.0-20240812044419-23196ec42acf h1:nsU2tKjPV/sbmOoIk39ncFT8D5HBDVppmrCWO0v9HsU=
 github.com/rudderlabs/rudder-transformer/go v0.0.0-20240812044419-23196ec42acf/go.mod h1:3NGitPz4pYRRZ6Xt09S+8hb0tHK/9pZcKJ3OgOTaSmE=
+github.com/rudderlabs/rudder-transformer/go v0.0.0-20240906042448-f7783d8fb300 h1:SmOLUqSCCcYs8QXYdZlHXCSCw77xhQ6qjNBsSA3bDKI=
+github.com/rudderlabs/rudder-transformer/go v0.0.0-20240906042448-f7783d8fb300/go.mod h1:3NGitPz4pYRRZ6Xt09S+8hb0tHK/9pZcKJ3OgOTaSmE=
 github.com/rudderlabs/sql-tunnels v0.1.7 h1:wDCRl6zY4M5gfWazf7XkSTGQS3yjBzUiUgEMBIfHNDA=
 github.com/rudderlabs/sql-tunnels v0.1.7/go.mod h1:5f7+YL49JHYgteP4rAgqKnr4K2OadB0oIpUS+Tt3sPM=
 github.com/rudderlabs/sqlconnect-go v1.9.0 h1:icLgqvVQ15Vh+oP7epA0b0yK6sIzxRVwPlRzOoDNVRA=

--- a/go.sum
+++ b/go.sum
@@ -1134,8 +1134,6 @@ github.com/rudderlabs/rudder-observability-kit v0.0.3 h1:vZtuZRkGX+6rjaeKtxxFE2Y
 github.com/rudderlabs/rudder-observability-kit v0.0.3/go.mod h1:6UjAh3H6rkE0fFLh7z8ZGQEQbKtUkRfhWOf/OUhfqW8=
 github.com/rudderlabs/rudder-schemas v0.5.1 h1:g4I5wp2yA6ZWQZ1MjSNn4zby3XctG/TOgbYUW3dS4z4=
 github.com/rudderlabs/rudder-schemas v0.5.1/go.mod h1:JoDTB9nCDXwRz+G+aYwP3Fj42HLssKARxsFFm+qqgb4=
-github.com/rudderlabs/rudder-transformer/go v0.0.0-20240812044419-23196ec42acf h1:nsU2tKjPV/sbmOoIk39ncFT8D5HBDVppmrCWO0v9HsU=
-github.com/rudderlabs/rudder-transformer/go v0.0.0-20240812044419-23196ec42acf/go.mod h1:3NGitPz4pYRRZ6Xt09S+8hb0tHK/9pZcKJ3OgOTaSmE=
 github.com/rudderlabs/rudder-transformer/go v0.0.0-20240906042448-f7783d8fb300 h1:SmOLUqSCCcYs8QXYdZlHXCSCw77xhQ6qjNBsSA3bDKI=
 github.com/rudderlabs/rudder-transformer/go v0.0.0-20240906042448-f7783d8fb300/go.mod h1:3NGitPz4pYRRZ6Xt09S+8hb0tHK/9pZcKJ3OgOTaSmE=
 github.com/rudderlabs/sql-tunnels v0.1.7 h1:wDCRl6zY4M5gfWazf7XkSTGQS3yjBzUiUgEMBIfHNDA=


### PR DESCRIPTION
# Description
The webhook headers feature was added in release 1.33 but it is causing issues for SendGrid webhooks as they are sending the request body as a JSON array so we are reverting the change and we will revisit the logic later


## Linear Ticket
https://linear.app/rudderstack/issue/INT-2504/webhook-source-deckers-has-requested-the-ability-to-forward-the-x-dash


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
