### PR TITLE
chore: close dedup without waiting for 5 minutes

### DIFF
--- a/services/dedup/badger/badger.go
+++ b/services/dedup/badger/badger.go
@@ -144,6 +144,11 @@ func (d *BadgerDB) gcLoop() {
 		case <-time.After(5 * time.Minute):
 		}
 	again:
+		select {
+		case <-d.close:
+			return
+		default:
+		}
 		// One call would only result in removal of at max one log file.
 		// As an optimization, you could also immediately re-run it whenever it returns nil error
 		// (this is why `goto again` is used).


### PR DESCRIPTION
# Description

Dedup gcloop has a 5 minute wait. Close the loop asap on `(*BadgerDB).Close()`.

## Linear Ticket

< Replace with Linear Link ( [create](https://linear.new?title=Awesome-pr-without-linear-ticket) or [search](https://linear.app/rudderstack/search) linear ticket) or  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
