### PR TITLE
fix: prevent badgerdb hang when closing without prior operations

### DIFF
--- a/services/dedup/badger/badger.go
+++ b/services/dedup/badger/badger.go
@@ -129,8 +129,6 @@ func (d *BadgerDB) init() error {
 	var err error
 
 	d.once.Do(func() {
-		d.wg = sync.WaitGroup{}
-
 		d.badgerDB, err = badger.Open(d.opts)
 		if err != nil {
 			return

--- a/services/dedup/badger/badger.go
+++ b/services/dedup/badger/badger.go
@@ -114,6 +114,7 @@ func (d *BadgerDB) Set(kvs []types.KeyValue) error {
 }
 
 func (d *BadgerDB) Close() {
+	d.init()
 	close(d.close)
 	<-d.gcDone
 	_ = d.badgerDB.Close()

--- a/services/dedup/badger/badger.go
+++ b/services/dedup/badger/badger.go
@@ -1,6 +1,7 @@
 package badger
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"sync"
@@ -23,11 +24,12 @@ type BadgerDB struct {
 	logger   loggerForBadger
 	badgerDB *badger.DB
 	window   config.ValueLoader[time.Duration]
-	close    chan struct{}
-	gcDone   chan struct{}
 	path     string
 	opts     badger.Options
 	once     sync.Once
+	wg       sync.WaitGroup
+	bgCtx    context.Context
+	cancel   context.CancelFunc
 }
 
 // DefaultPath returns the default path for the deduplication service's badger DB
@@ -57,14 +59,16 @@ func NewBadgerDB(conf *config.Config, stats stats.Stats, path string) *Dedup {
 		WithSyncWrites(conf.GetBool("BadgerDB.syncWrites", false)).
 		WithDetectConflicts(conf.GetBool("BadgerDB.detectConflicts", false))
 
+	bgCtx, cancel := context.WithCancel(context.Background())
 	db := &BadgerDB{
 		stats:  stats,
 		logger: loggerForBadger{log},
 		path:   path,
-		gcDone: make(chan struct{}),
-		close:  make(chan struct{}),
 		window: dedupWindow,
 		opts:   badgerOpts,
+		wg:     sync.WaitGroup{},
+		bgCtx:  bgCtx,
+		cancel: cancel,
 	}
 	return &Dedup{
 		badgerDB: db,
@@ -114,23 +118,27 @@ func (d *BadgerDB) Set(kvs []types.KeyValue) error {
 }
 
 func (d *BadgerDB) Close() {
-	d.init()
-	close(d.close)
-	<-d.gcDone
-	_ = d.badgerDB.Close()
+	d.cancel()
+	d.wg.Wait()
+	if d.badgerDB != nil {
+		_ = d.badgerDB.Close()
+	}
 }
 
 func (d *BadgerDB) init() error {
 	var err error
 
 	d.once.Do(func() {
+		d.wg = sync.WaitGroup{}
+
 		d.badgerDB, err = badger.Open(d.opts)
 		if err != nil {
 			return
 		}
+		d.wg.Add(1)
 		rruntime.Go(func() {
+			defer d.wg.Done()
 			d.gcLoop()
-			close(d.gcDone)
 		})
 	})
 	return err
@@ -139,12 +147,15 @@ func (d *BadgerDB) init() error {
 func (d *BadgerDB) gcLoop() {
 	for {
 		select {
-		case <-d.close:
+		case <-d.bgCtx.Done():
 			_ = d.badgerDB.RunValueLogGC(0.5)
 			return
 		case <-time.After(5 * time.Minute):
 		}
 	again:
+		if d.bgCtx.Err() != nil {
+			return
+		}
 		// One call would only result in removal of at max one log file.
 		// As an optimization, you could also immediately re-run it whenever it returns nil error
 		// (this is why `goto again` is used).

--- a/services/dedup/badger/badger_test.go
+++ b/services/dedup/badger/badger_test.go
@@ -46,3 +46,11 @@ func Test_Badger(t *testing.T) {
 		require.False(t, found)
 	})
 }
+
+func TestBadgerClose(t *testing.T) {
+	badger := NewBadgerDB(config.New(), stats.NOP, t.TempDir())
+	require.NotNil(t, badger)
+
+	t.Log("close badger without any other operation")
+	badger.Close()
+}


### PR DESCRIPTION
# Description

## Issue

When transitioning a newly created rudder-server instance that has received no traffic from normal to degraded mode, the process hangs. Causing migration to stuck as well, until instance is restarted, upon restart no transition is required, as rudder-server starts on degrade mode.


Taking a goroutine dump:
```
goroutine 786 [chan receive, 3 minutes]:
github.com/rudderlabs/rudder-server/services/dedup/badger.(*BadgerDB).Close(...)
	/rudder-server/services/dedup/badger/badger.go:118
github.com/rudderlabs/rudder-server/services/dedup/badger.(*Dedup).Close(0x0?)
	/rudder-server/services/dedup/badger/badger.go:230 +0x38
github.com/rudderlabs/rudder-server/processor.(*Handle).Shutdown(0x4001b08008)
	/rudder-server/processor/processor.go:766 +0x50
github.com/rudderlabs/rudder-server/processor.(*LifecycleManager).Stop(0x4000f348c0)
```
You can see that badger.Close hangs, preventing the shutdown to be completed.


I was able to replicate this locally, using the following test:

```go
func TestBadgerClose(t *testing.T) {
	badger := NewBadgerDB(config.New(), stats.NOP, t.TempDir())
	require.NotNil(t, badger)

	t.Log("close badger without any other operation")
	badger.Close()
}
```

### Root-cause

Close was waiting for `d.gcDone` to close, but this will never happen, because `init` was never called.

## Solution

Naive approach is to ensure init is called at the start of close method.  However, this is counter intuitive, and also handling error for init would be needed. Also, in case init error, gc loop go routine won't be call as well.

A safer approach is to introduce a waitgroup, that tracks for any pending background go routines, and won't block if non have been started.

Also, `bgCtx` is introduced as a more conventional wait to pass termination.   
 

## Linear Ticket


https://linear.app/rudderstack/issue/PIPE-1420/rudder-server-did-not-transition-to-degraded-mode

resolves PIPE-1420

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
