### PR TITLE
fix: datalake spark flaky test

### DIFF
--- a/warehouse/integrations/datalake/testdata/docker-compose.spark.yml
+++ b/warehouse/integrations/datalake/testdata/docker-compose.spark.yml
@@ -24,6 +24,8 @@ services:
     ports:
       - "8080"
       - "7077"
+    depends_on:
+      - hive-metastore
     deploy:
       resources:
         limits:


### PR DESCRIPTION
# Description

- Getting some flakiness around the Spark tests where the `hive-metastore` server is not up. I added a dependency for the spark-master to have the `hive-metastore` server up first.
- https://github.com/rudderlabs/rudder-server/actions/runs/10775819984/job/29883355740
  ```
      datalake_test.go:717: compose library exec: docker exec: output: Setting default log level to "WARN".
          To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
          24/09/09 15:42:19 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
          24/09/09 15:42:23 WARN metastore: Failed to connect to the MetaStore Server...
          24/09/09 15:42:24 WARN metastore: Failed to connect to the MetaStore Server...
          24/09/09 15:42:25 WARN metastore: Failed to connect to the MetaStore Server...
  ```

## Linear Ticket

- Resolves PIPE-1508

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
