### PR TITLE
chore: passing dependency for asyncdestinationmanager

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/bing-ads/audience/bingads_test.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/audience/bingads_test.go
@@ -13,6 +13,8 @@ import (
 
 	"go.uber.org/mock/gomock"
 
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -21,6 +23,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	mocks_oauth "github.com/rudderlabs/rudder-server/mocks/services/oauth"
@@ -68,7 +71,7 @@ var _ = Describe("Bing ads Audience", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 			bingAdsService.EXPECT().GetBulkUploadUrl().Return(&bingads_sdk.GetBulkUploadUrlResponse{
 				UploadUrl: "http://localhost/upload1",
 				RequestId: misc.FastUUID().URN(),
@@ -135,7 +138,7 @@ var _ = Describe("Bing ads Audience", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 			bingAdsService.EXPECT().GetBulkUploadUrl().Return(nil, fmt.Errorf("Error in getting bulk upload url"))
 			bingAdsService.EXPECT().GetBulkUploadUrl().Return(nil, fmt.Errorf("Error in getting bulk upload url"))
 
@@ -188,7 +191,7 @@ var _ = Describe("Bing ads Audience", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			ClientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &ClientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &ClientI)
 			bingAdsService.EXPECT().GetBulkUploadUrl().Return(nil, fmt.Errorf("unable to get bulk upload url, check your credentials"))
 
 			bingAdsService.EXPECT().GetBulkUploadUrl().Return(nil, fmt.Errorf("unable to get bulk upload url, check your credentials"))
@@ -242,7 +245,7 @@ var _ = Describe("Bing ads Audience", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 			bingAdsService.EXPECT().GetBulkUploadUrl().Return(&bingads_sdk.GetBulkUploadUrlResponse{
 				UploadUrl: "http://localhost/upload1",
 				RequestId: misc.FastUUID().URN(),
@@ -307,7 +310,7 @@ var _ = Describe("Bing ads Audience", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			bingAdsService.EXPECT().GetBulkUploadStatus("dummyRequestId123").Return(&bingads_sdk.GetBulkUploadStatusResponse{
 				PercentComplete: int64(100),
@@ -330,7 +333,7 @@ var _ = Describe("Bing ads Audience", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			bingAdsService.EXPECT().GetBulkUploadStatus("dummyRequestId123").Return(nil, fmt.Errorf("failed to get bulk upload status:"))
 			pollInput := common.AsyncPoll{
@@ -349,7 +352,7 @@ var _ = Describe("Bing ads Audience", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			bingAdsService.EXPECT().GetBulkUploadStatus("dummyRequestId123").Return(&bingads_sdk.GetBulkUploadStatusResponse{
 				PercentComplete: int64(100),
@@ -378,7 +381,7 @@ var _ = Describe("Bing ads Audience", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			bingAdsService.EXPECT().GetBulkUploadStatus("dummyRequestId123").Return(&bingads_sdk.GetBulkUploadStatusResponse{
 				PercentComplete: int64(0),
@@ -405,7 +408,7 @@ var _ = Describe("Bing ads Audience", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			bingAdsService.EXPECT().GetBulkUploadStatus("dummyRequestId123").Return(&bingads_sdk.GetBulkUploadStatusResponse{
 				PercentComplete: int64(0),
@@ -432,7 +435,7 @@ var _ = Describe("Bing ads Audience", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			bingAdsService.EXPECT().GetBulkUploadStatus("dummyRequestId456").Return(&bingads_sdk.GetBulkUploadStatusResponse{
 				PercentComplete: int64(100),
@@ -478,7 +481,7 @@ var _ = Describe("Bing ads Audience", func() {
 			client := ts.Client()
 			modifiedURL := ts.URL // Use the test server URL
 			clientI := Client{client: client, URL: modifiedURL}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			UploadStatsInput := common.GetUploadStatsInput{
 				FailedJobURLs: modifiedURL,
@@ -528,7 +531,7 @@ var _ = Describe("Bing ads Audience", func() {
 			client := ts.Client()
 			modifiedURL := ts.URL // Use the test server URL
 			clientI := Client{client: client, URL: modifiedURL}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			UploadStatsInput := common.GetUploadStatsInput{
 				FailedJobURLs: modifiedURL,
@@ -582,7 +585,7 @@ var _ = Describe("Bing ads Audience", func() {
 				},
 			})
 
-			bingAdsUploader, err := newManagerInternal(&destination, oauthService, nil)
+			bingAdsUploader, err := newManagerInternal(logger.NOP, stats.NOP, &destination, oauthService, nil)
 			Expect(err).To(BeNil())
 			Expect(bingAdsUploader).ToNot(BeNil())
 		})
@@ -592,7 +595,7 @@ var _ = Describe("Bing ads Audience", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 			bingAdsService.EXPECT().GetBulkUploadUrl().Return(&bingads_sdk.GetBulkUploadUrlResponse{
 				UploadUrl: "http://localhost/upload",
 				RequestId: misc.FastUUID().URN(),

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/audience/manager.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/audience/manager.go
@@ -10,13 +10,14 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/bing-ads/common"
 	"github.com/rudderlabs/rudder-server/services/oauth"
 	oauthv2 "github.com/rudderlabs/rudder-server/services/oauth/v2"
 )
 
-func newManagerInternal(destination *backendconfig.DestinationT, oauthClient oauth.Authorizer, oauthClientV2 oauthv2.Authorizer) (*BingAdsBulkUploader, error) {
+func newManagerInternal(logger logger.Logger, statsFactory stats.Stats, destination *backendconfig.DestinationT, oauthClient oauth.Authorizer, oauthClientV2 oauthv2.Authorizer) (*BingAdsBulkUploader, error) {
 	destConfig := DestinationConfig{}
 	jsonConfig, err := stdjson.Marshal(destination.Config)
 	if err != nil {
@@ -49,16 +50,22 @@ func newManagerInternal(destination *backendconfig.DestinationT, oauthClient oau
 	session := bingads.NewSession(sessionConfig)
 
 	clientNew := Client{}
-	bingUploader := NewBingAdsBulkUploader(destination.DestinationDefinition.Name, bingads.NewBulkService(session), &clientNew)
+	bingUploader := NewBingAdsBulkUploader(logger, statsFactory, destination.DestinationDefinition.Name, bingads.NewBulkService(session), &clientNew)
 	return bingUploader, nil
 }
 
-func NewManager(destination *backendconfig.DestinationT, backendConfig backendconfig.BackendConfig) (*BingAdsBulkUploader, error) {
+func NewManager(
+	conf *config.Config,
+	logger logger.Logger,
+	statsFactory stats.Stats,
+	destination *backendconfig.DestinationT,
+	backendConfig backendconfig.BackendConfig,
+) (*BingAdsBulkUploader, error) {
 	oauthClient := oauth.NewOAuthErrorHandler(backendConfig)
 	oauthClientV2 := oauthv2.NewOAuthHandler(backendConfig,
-		oauthv2.WithLogger(logger.NewLogger().Child("BatchRouter")),
-		oauthv2.WithCPConnectorTimeout(config.GetDuration("HttpClient.oauth.timeout", 30, time.Second)),
-		oauthv2.WithStats(stats.Default),
+		oauthv2.WithLogger(logger),
+		oauthv2.WithCPConnectorTimeout(conf.GetDuration("HttpClient.oauth.timeout", 30, time.Second)),
+		oauthv2.WithStats(statsFactory),
 	)
-	return newManagerInternal(destination, oauthClient, oauthClientV2)
+	return newManagerInternal(logger, statsFactory, destination, oauthClient, oauthClientV2)
 }

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/audience/types.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/audience/types.go
@@ -6,8 +6,9 @@ import (
 	"net/http"
 	"os"
 
-	bingads "github.com/rudderlabs/bing-ads-go-sdk/bingads"
+	"github.com/rudderlabs/bing-ads-go-sdk/bingads"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 )
 
 type Client struct {
@@ -18,6 +19,7 @@ type BingAdsBulkUploader struct {
 	destName      string
 	service       bingads.BulkServiceI
 	logger        logger.Logger
+	statsFactory  stats.Stats
 	client        Client
 	fileSizeLimit int64
 	eventsLimit   int64

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/audience/util.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/audience/util.go
@@ -18,6 +18,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
@@ -161,7 +162,7 @@ func (b *BingAdsBulkUploader) createZipFile(filePath, audienceId string) ([]*Act
 			return nil, err
 		}
 
-		payloadSizeStat := stats.Default.NewTaggedStat("payload_size", stats.HistogramType,
+		payloadSizeStat := b.statsFactory.NewTaggedStat("payload_size", stats.HistogramType,
 			map[string]string{
 				"module":   "batch_router",
 				"destType": b.destName,

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bingads_test.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bingads_test.go
@@ -14,6 +14,8 @@ import (
 
 	"go.uber.org/mock/gomock"
 
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -22,6 +24,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	mocks_oauth "github.com/rudderlabs/rudder-server/mocks/services/oauth"
@@ -71,7 +74,7 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 				URL:    "http://localhost/upload1",
 				client: &http.Client{},
 			}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 			bingAdsService.EXPECT().GetBulkUploadUrl().Return(&bingads_sdk.GetBulkUploadUrlResponse{
 				UploadUrl: "http://localhost/upload1",
 				RequestId: misc.FastUUID().URN(),
@@ -136,7 +139,7 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 			errorMsg := "Error in getting bulk upload url"
 			bingAdsService.EXPECT().GetBulkUploadUrl().Return(nil, errors.New(errorMsg))
 			bingAdsService.EXPECT().GetBulkUploadUrl().Return(nil, errors.New(errorMsg))
@@ -179,7 +182,7 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			ClientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &ClientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &ClientI)
 			errMsg := "unable to get bulk upload url, check your credentials"
 			bingAdsService.EXPECT().GetBulkUploadUrl().Return(nil, errors.New(errMsg))
 
@@ -225,7 +228,7 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 			bingAdsService.EXPECT().GetBulkUploadUrl().Return(&bingads_sdk.GetBulkUploadUrlResponse{
 				UploadUrl: "http://localhost/upload1",
 				RequestId: misc.FastUUID().URN(),
@@ -283,7 +286,7 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			bingAdsService.EXPECT().GetBulkUploadStatus("dummyRequestId123").Return(&bingads_sdk.GetBulkUploadStatusResponse{
 				PercentComplete: int64(100),
@@ -306,7 +309,7 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			bingAdsService.EXPECT().GetBulkUploadStatus("dummyRequestId123").Return(nil, fmt.Errorf("failed to get bulk upload status:"))
 			pollInput := common.AsyncPoll{
@@ -325,7 +328,7 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			bingAdsService.EXPECT().GetBulkUploadStatus("dummyRequestId123").Return(&bingads_sdk.GetBulkUploadStatusResponse{
 				PercentComplete: int64(100),
@@ -354,7 +357,7 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			bingAdsService.EXPECT().GetBulkUploadStatus("dummyRequestId123").Return(&bingads_sdk.GetBulkUploadStatusResponse{
 				PercentComplete: int64(0),
@@ -381,7 +384,7 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			bingAdsService.EXPECT().GetBulkUploadStatus("dummyRequestId123").Return(&bingads_sdk.GetBulkUploadStatusResponse{
 				PercentComplete: int64(0),
@@ -408,7 +411,7 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			bingAdsService := mock_bulkservice.NewMockBulkServiceI(ctrl)
 			clientI := Client{}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			bingAdsService.EXPECT().GetBulkUploadStatus("dummyRequestId456").Return(&bingads_sdk.GetBulkUploadStatusResponse{
 				PercentComplete: int64(100),
@@ -454,7 +457,7 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			client := ts.Client()
 			modifiedURL := ts.URL // Use the test server URL
 			clientI := Client{client: client, URL: modifiedURL}
-			bulkUploader := NewBingAdsBulkUploader("BING_ADS", bingAdsService, &clientI)
+			bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", bingAdsService, &clientI)
 
 			UploadStatsInput := common.GetUploadStatsInput{
 				FailedJobURLs: modifiedURL,
@@ -522,7 +525,7 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 				},
 			})
 
-			bingAdsUploader, err := newManagerInternal(&destination, oauthService, nil)
+			bingAdsUploader, err := newManagerInternal(logger.NOP, stats.NOP, &destination, oauthService, nil)
 			Expect(err).To(BeNil())
 			Expect(bingAdsUploader).ToNot(BeNil())
 		})

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bulk_uploader.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bulk_uploader.go
@@ -14,15 +14,17 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 )
 
-func NewBingAdsBulkUploader(destName string, service bingads.BulkServiceI, client *Client) *BingAdsBulkUploader {
+func NewBingAdsBulkUploader(logger logger.Logger, statsFactory stats.Stats, destName string, service bingads.BulkServiceI, client *Client) *BingAdsBulkUploader {
 	return &BingAdsBulkUploader{
 		destName:      destName,
 		service:       service,
-		logger:        logger.NewLogger().Child("batchRouter").Child("AsyncDestinationManager").Child("BingAds").Child("BingAdsBulkUploader"),
+		logger:        logger.Child("BingAds").Child("BingAdsBulkUploader"),
+		statsFactory:  statsFactory,
 		client:        *client,
 		fileSizeLimit: common.GetBatchRouterConfigInt64("MaxUploadLimit", destName, 100*bytesize.MB),
 		eventsLimit:   common.GetBatchRouterConfigInt64("MaxEventsLimit", destName, 1000),
@@ -115,7 +117,7 @@ func (b *BingAdsBulkUploader) Upload(asyncDestStruct *common.AsyncDestinationStr
 			DestinationID: destination.ID,
 		}
 	}
-	uploadRetryableStat := stats.Default.NewTaggedStat("events_over_prescribed_limit", stats.CountType, map[string]string{
+	uploadRetryableStat := b.statsFactory.NewTaggedStat("events_over_prescribed_limit", stats.CountType, map[string]string{
 		"module":   "batch_router",
 		"destType": b.destName,
 	})
@@ -133,7 +135,7 @@ func (b *BingAdsBulkUploader) Upload(asyncDestStruct *common.AsyncDestinationStr
 			continue
 		}
 
-		uploadTimeStat := stats.Default.NewTaggedStat("async_upload_time", stats.TimerType, map[string]string{
+		uploadTimeStat := b.statsFactory.NewTaggedStat("async_upload_time", stats.TimerType, map[string]string{
 			"module":   "batch_router",
 			"destType": b.destName,
 		})
@@ -284,13 +286,13 @@ func (b *BingAdsBulkUploader) getUploadStatsOfSingleImport(filePath string) (com
 		},
 	}
 
-	eventsAbortedStat := stats.Default.NewTaggedStat("failed_job_count", stats.CountType, map[string]string{
+	eventsAbortedStat := b.statsFactory.NewTaggedStat("failed_job_count", stats.CountType, map[string]string{
 		"module":   "batch_router",
 		"destType": b.destName,
 	})
 	eventsAbortedStat.Count(len(eventStatsResponse.Metadata.FailedKeys))
 
-	eventsSuccessStat := stats.Default.NewTaggedStat("success_job_count", stats.CountType, map[string]string{
+	eventsSuccessStat := b.statsFactory.NewTaggedStat("success_job_count", stats.CountType, map[string]string{
 		"module":   "batch_router",
 		"destType": b.destName,
 	})

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/manager.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/manager.go
@@ -10,13 +10,15 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/bing-ads/common"
+	asynccommon "github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 	"github.com/rudderlabs/rudder-server/services/oauth"
 	oauthv2 "github.com/rudderlabs/rudder-server/services/oauth/v2"
 )
 
-func newManagerInternal(destination *backendconfig.DestinationT, oauthClient oauth.Authorizer, oauthClientV2 oauthv2.Authorizer) (*BingAdsBulkUploader, error) {
+func newManagerInternal(logger logger.Logger, statsFactory stats.Stats, destination *backendconfig.DestinationT, oauthClient oauth.Authorizer, oauthClientV2 oauthv2.Authorizer) (*BingAdsBulkUploader, error) {
 	destConfig := DestinationConfig{}
 	jsonConfig, err := stdjson.Marshal(destination.Config)
 	if err != nil {
@@ -49,16 +51,16 @@ func newManagerInternal(destination *backendconfig.DestinationT, oauthClient oau
 	session := bingads.NewSession(sessionConfig)
 
 	clientNew := Client{}
-	bingUploader := NewBingAdsBulkUploader(destination.DestinationDefinition.Name, bingads.NewBulkService(session), &clientNew)
+	bingUploader := NewBingAdsBulkUploader(logger, statsFactory, destination.DestinationDefinition.Name, bingads.NewBulkService(session), &clientNew)
 	return bingUploader, nil
 }
 
-func NewManager(destination *backendconfig.DestinationT, backendConfig backendconfig.BackendConfig) (*BingAdsBulkUploader, error) {
+func NewManager(conf *config.Config, logger logger.Logger, statsFactory stats.Stats, destination *backendconfig.DestinationT, backendConfig backendconfig.BackendConfig) (asynccommon.AsyncDestinationManager, error) {
 	oauthClient := oauth.NewOAuthErrorHandler(backendConfig)
 	oauthClientV2 := oauthv2.NewOAuthHandler(backendConfig,
-		oauthv2.WithLogger(logger.NewLogger().Child("BatchRouter")),
-		oauthv2.WithCPConnectorTimeout(config.GetDuration("HttpClient.oauth.timeout", 30, time.Second)),
-		oauthv2.WithStats(stats.Default),
+		oauthv2.WithLogger(logger),
+		oauthv2.WithCPConnectorTimeout(conf.GetDuration("HttpClient.oauth.timeout", 30, time.Second)),
+		oauthv2.WithStats(statsFactory),
 	)
-	return newManagerInternal(destination, oauthClient, oauthClientV2)
+	return newManagerInternal(logger, statsFactory, destination, oauthClient, oauthClientV2)
 }

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/types.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/types.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 
-	bingads "github.com/rudderlabs/bing-ads-go-sdk/bingads"
+	"github.com/rudderlabs/bing-ads-go-sdk/bingads"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 )
 
 type Client struct {
@@ -17,6 +18,7 @@ type BingAdsBulkUploader struct {
 	destName      string
 	service       bingads.BulkServiceI
 	logger        logger.Logger
+	statsFactory  stats.Stats
 	client        Client
 	fileSizeLimit int64
 	eventsLimit   int64

--- a/router/batchrouter/asyncdestinationmanager/eloqua/eloqua_test.go
+++ b/router/batchrouter/asyncdestinationmanager/eloqua/eloqua_test.go
@@ -9,6 +9,8 @@ import (
 
 	"go.uber.org/mock/gomock"
 
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	. "github.com/onsi/ginkgo/v2"
 
 	. "github.com/onsi/gomega"
@@ -16,6 +18,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	mock_bulkservice "github.com/rudderlabs/rudder-server/mocks/router/eloqua"
@@ -72,7 +75,7 @@ var _ = Describe("Eloqua test", func() {
 			initEloqua()
 			ctrl := gomock.NewController(GinkgoT())
 			eloquaService := mock_bulkservice.NewMockEloquaService(ctrl)
-			bulkUploader := eloqua.NewEloquaBulkUploader("Eloqua", "", "", eloquaService)
+			bulkUploader := eloqua.NewEloquaBulkUploader(logger.NOP, stats.NOP, "Eloqua", "", "", eloquaService)
 			asyncDestination := common.AsyncDestinationStruct{
 				ImportingJobIDs: []int64{1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1023},
 				FailedJobIDs:    []int64{},
@@ -95,7 +98,7 @@ var _ = Describe("Eloqua test", func() {
 			initEloqua()
 			ctrl := gomock.NewController(GinkgoT())
 			eloquaService := mock_bulkservice.NewMockEloquaService(ctrl)
-			bulkUploader := eloqua.NewEloquaBulkUploader("Eloqua", "", "", eloquaService)
+			bulkUploader := eloqua.NewEloquaBulkUploader(logger.NOP, stats.NOP, "Eloqua", "", "", eloquaService)
 			asyncDestination := common.AsyncDestinationStruct{
 				ImportingJobIDs: []int64{1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1023},
 				FailedJobIDs:    []int64{},
@@ -121,7 +124,7 @@ var _ = Describe("Eloqua test", func() {
 			initEloqua()
 			ctrl := gomock.NewController(GinkgoT())
 			eloquaService := mock_bulkservice.NewMockEloquaService(ctrl)
-			bulkUploader := eloqua.NewEloquaBulkUploader("Eloqua", "", "", eloquaService)
+			bulkUploader := eloqua.NewEloquaBulkUploader(logger.NOP, stats.NOP, "Eloqua", "", "", eloquaService)
 			asyncDestination := common.AsyncDestinationStruct{
 				ImportingJobIDs: []int64{1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1023},
 				FailedJobIDs:    []int64{},
@@ -164,7 +167,7 @@ var _ = Describe("Eloqua test", func() {
 			initEloqua()
 			ctrl := gomock.NewController(GinkgoT())
 			eloquaService := mock_bulkservice.NewMockEloquaService(ctrl)
-			bulkUploader := eloqua.NewEloquaBulkUploader("Eloqua", "", "", eloquaService)
+			bulkUploader := eloqua.NewEloquaBulkUploader(logger.NOP, stats.NOP, "Eloqua", "", "", eloquaService)
 			asyncDestination := common.AsyncDestinationStruct{
 				ImportingJobIDs: []int64{1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1023},
 				FailedJobIDs:    []int64{},
@@ -211,7 +214,7 @@ var _ = Describe("Eloqua test", func() {
 			initEloqua()
 			ctrl := gomock.NewController(GinkgoT())
 			eloquaService := mock_bulkservice.NewMockEloquaService(ctrl)
-			bulkUploader := eloqua.NewEloquaBulkUploader("Eloqua", "", "", eloquaService)
+			bulkUploader := eloqua.NewEloquaBulkUploader(logger.NOP, stats.NOP, "Eloqua", "", "", eloquaService)
 			asyncDestination := common.AsyncDestinationStruct{
 				ImportingJobIDs: []int64{1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1023},
 				FailedJobIDs:    []int64{},
@@ -258,7 +261,7 @@ var _ = Describe("Eloqua test", func() {
 			initEloqua()
 			ctrl := gomock.NewController(GinkgoT())
 			eloquaService := mock_bulkservice.NewMockEloquaService(ctrl)
-			bulkUploader := eloqua.NewEloquaBulkUploader("Eloqua", "", "", eloquaService)
+			bulkUploader := eloqua.NewEloquaBulkUploader(logger.NOP, stats.NOP, "Eloqua", "", "", eloquaService)
 			asyncDestination := common.AsyncDestinationStruct{
 				ImportingJobIDs: []int64{1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1023},
 				FailedJobIDs:    []int64{},
@@ -321,7 +324,7 @@ var _ = Describe("Eloqua test", func() {
 		It("TestEloquaFailedToGetSyncStatus", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			eloquaService := mock_bulkservice.NewMockEloquaService(ctrl)
-			bulkUploader := eloqua.NewEloquaBulkUploader("Eloqua", "", "", eloquaService)
+			bulkUploader := eloqua.NewEloquaBulkUploader(logger.NOP, stats.NOP, "Eloqua", "", "", eloquaService)
 			pollInput := common.AsyncPoll{
 				ImportId: "/syncs/384:/contacts/imports/384",
 			}
@@ -339,7 +342,7 @@ var _ = Describe("Eloqua test", func() {
 		It("TestEloquaReceivedSuccess", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			eloquaService := mock_bulkservice.NewMockEloquaService(ctrl)
-			bulkUploader := eloqua.NewEloquaBulkUploader("Eloqua", "", "", eloquaService)
+			bulkUploader := eloqua.NewEloquaBulkUploader(logger.NOP, stats.NOP, "Eloqua", "", "", eloquaService)
 			pollInput := common.AsyncPoll{
 				ImportId: "/syncs/384:/contacts/imports/384",
 			}
@@ -358,7 +361,7 @@ var _ = Describe("Eloqua test", func() {
 		It("TestEloquaReceivedPending", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			eloquaService := mock_bulkservice.NewMockEloquaService(ctrl)
-			bulkUploader := eloqua.NewEloquaBulkUploader("Eloqua", "", "", eloquaService)
+			bulkUploader := eloqua.NewEloquaBulkUploader(logger.NOP, stats.NOP, "Eloqua", "", "", eloquaService)
 			pollInput := common.AsyncPoll{
 				ImportId: "/syncs/384:/contacts/imports/384",
 			}
@@ -383,7 +386,7 @@ var _ = Describe("Eloqua test", func() {
 		It("TestEloquaErrorOccurredWhileUploading", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			eloquaService := mock_bulkservice.NewMockEloquaService(ctrl)
-			bulkUploader := eloqua.NewEloquaBulkUploader("Eloqua", "", "", eloquaService)
+			bulkUploader := eloqua.NewEloquaBulkUploader(logger.NOP, stats.NOP, "Eloqua", "", "", eloquaService)
 
 			pollInput := common.GetUploadStatsInput{
 				FailedJobURLs: "/syncs/384",
@@ -415,7 +418,7 @@ var _ = Describe("Eloqua test", func() {
 		It("TestEloquaFailedToFetchRejectedData", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			eloquaService := mock_bulkservice.NewMockEloquaService(ctrl)
-			bulkUploader := eloqua.NewEloquaBulkUploader("Eloqua", "", "", eloquaService)
+			bulkUploader := eloqua.NewEloquaBulkUploader(logger.NOP, stats.NOP, "Eloqua", "", "", eloquaService)
 
 			pollInput := common.GetUploadStatsInput{
 				WarningJobURLs: "/syncs/384",
@@ -432,7 +435,7 @@ var _ = Describe("Eloqua test", func() {
 		It("TestEloquaSucceedToFetchRejectedData", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			eloquaService := mock_bulkservice.NewMockEloquaService(ctrl)
-			bulkUploader := eloqua.NewEloquaBulkUploader("Eloqua", "", "", eloquaService)
+			bulkUploader := eloqua.NewEloquaBulkUploader(logger.NOP, stats.NOP, "Eloqua", "", "", eloquaService)
 			pollInput := common.GetUploadStatsInput{
 				WarningJobURLs: "/syncs/384",
 				ImportingList:  jobs,

--- a/router/batchrouter/asyncdestinationmanager/eloqua/types.go
+++ b/router/batchrouter/asyncdestinationmanager/eloqua/types.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 )
 
 type EloquaService interface {
@@ -23,6 +24,7 @@ type EloquaService interface {
 type EloquaBulkUploader struct {
 	destName          string
 	logger            logger.Logger
+	statsFactory      stats.Stats
 	authorization     string
 	baseEndpoint      string
 	fileSizeLimit     int64

--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload_test.go
@@ -7,6 +7,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+
 	"go.uber.org/mock/gomock"
 
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
@@ -30,7 +34,7 @@ var destination = &backendconfig.DestinationT{
 }
 
 func TestNewManagerSuccess(t *testing.T) {
-	manager, err := klaviyobulkupload.NewManager(destination)
+	manager, err := klaviyobulkupload.NewManager(logger.NOP, stats.NOP, destination)
 	assert.NoError(t, err)
 	assert.NotNil(t, manager)
 	assert.Equal(t, "KLAVIYO_BULK_UPLOAD", destination.Name)

--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/types.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/types.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 )
 
@@ -33,6 +35,7 @@ type KlaviyoBulkUploader struct {
 	destName             string
 	destinationConfig    map[string]interface{}
 	logger               logger.Logger
+	statsFactory         stats.Stats
 	Client               *http.Client
 	jobIdToIdentifierMap map[string]int64
 }

--- a/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/lyticsBulkUpload.go
+++ b/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/lyticsBulkUpload.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 )
@@ -74,7 +75,7 @@ func (u *LyticsBulkUploader) Upload(asyncDestStruct *common.AsyncDestinationStru
 	filePath := asyncDestStruct.FileName
 	destConfig, err := jsoniter.Marshal(destination.Config)
 	if err != nil {
-		eventsAbortedStat := stats.Default.NewTaggedStat("failed_job_count", stats.CountType, map[string]string{
+		eventsAbortedStat := u.statsFactory.NewTaggedStat("failed_job_count", stats.CountType, map[string]string{
 			"module":   "batch_router",
 			"destType": u.destName,
 		})
@@ -108,14 +109,14 @@ func (u *LyticsBulkUploader) Upload(asyncDestStruct *common.AsyncDestinationStru
 			DestinationID: destination.ID,
 		}
 	}
-	uploadRetryableStat := stats.Default.NewTaggedStat("events_over_prescribed_limit", stats.CountType, map[string]string{
+	uploadRetryableStat := u.statsFactory.NewTaggedStat("events_over_prescribed_limit", stats.CountType, map[string]string{
 		"module":   "batch_router",
 		"destType": u.destName,
 	})
 
 	uploadRetryableStat.Count(len(actionFiles.FailedJobIDs))
 
-	uploadTimeStat := stats.Default.NewTaggedStat("async_upload_time", stats.TimerType, map[string]string{
+	uploadTimeStat := u.statsFactory.NewTaggedStat("async_upload_time", stats.TimerType, map[string]string{
 		"module":   "batch_router",
 		"destType": u.destName,
 	})

--- a/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/lytics_test.go
+++ b/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/lytics_test.go
@@ -8,12 +8,15 @@ import (
 
 	"go.uber.org/mock/gomock"
 
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 
 	mocks "github.com/rudderlabs/rudder-server/mocks/router/lytics_bulk_upload"
@@ -67,7 +70,7 @@ var _ = Describe("LYTICS_BULK_UPLOAD test", func() {
 			LyticsServiceImpl := lyticsBulkUpload.LyticsServiceImpl{
 				BulkApi: "https://bulk.lytics.io/collect/bulk/test?timestamp_field=timestamp",
 			}
-			bulkUploader := common.SimpleAsyncDestinationManager{UploaderAndTransformer: lyticsBulkUpload.NewLyticsBulkUploader("LYTICS_BULK_UPLOAD", destination.Config["lyticsApiKey"].(string), LyticsServiceImpl.BulkApi, lyticsService)}
+			bulkUploader := common.SimpleAsyncDestinationManager{UploaderAndTransformer: lyticsBulkUpload.NewLyticsBulkUploader(logger.NOP, stats.NOP, "LYTICS_BULK_UPLOAD", destination.Config["lyticsApiKey"].(string), LyticsServiceImpl.BulkApi, lyticsService)}
 			asyncDestination := common.AsyncDestinationStruct{
 				ImportingJobIDs: []int64{1, 2, 3, 4},
 				FailedJobIDs:    []int64{},
@@ -102,12 +105,7 @@ var _ = Describe("LYTICS_BULK_UPLOAD test", func() {
 
 			// Set up the SimpleAsyncDestinationManager with the LyticsBulkUploader
 			bulkUploader := common.SimpleAsyncDestinationManager{
-				UploaderAndTransformer: lyticsBulkUpload.NewLyticsBulkUploader(
-					"LYTICS_BULK_UPLOAD",
-					destination.Config["lyticsApiKey"].(string),
-					LyticsServiceImpl.BulkApi,
-					lyticsService,
-				),
+				UploaderAndTransformer: lyticsBulkUpload.NewLyticsBulkUploader(logger.NOP, stats.NOP, "LYTICS_BULK_UPLOAD", destination.Config["lyticsApiKey"].(string), LyticsServiceImpl.BulkApi, lyticsService),
 			}
 
 			// Set up the AsyncDestinationStruct with test data
@@ -163,12 +161,7 @@ var _ = Describe("LYTICS_BULK_UPLOAD test", func() {
 
 			// Set up the SimpleAsyncDestinationManager with the LyticsBulkUploader
 			bulkUploader := common.SimpleAsyncDestinationManager{
-				UploaderAndTransformer: lyticsBulkUpload.NewLyticsBulkUploader(
-					"LYTICS_BULK_UPLOAD",
-					destination.Config["lyticsApiKey"].(string),
-					LyticsServiceImpl.BulkApi,
-					lyticsService,
-				),
+				UploaderAndTransformer: lyticsBulkUpload.NewLyticsBulkUploader(logger.NOP, stats.NOP, "LYTICS_BULK_UPLOAD", destination.Config["lyticsApiKey"].(string), LyticsServiceImpl.BulkApi, lyticsService),
 			}
 
 			// Set up the AsyncDestinationStruct with test data

--- a/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/types.go
+++ b/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/types.go
@@ -10,13 +10,17 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-go-kit/logger"
+
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 )
 
 type LyticsBulkUploader struct {
 	destName      string
 	logger        logger.Logger
+	statsFactory  stats.Stats
 	authorization string
 	baseEndpoint  string
 	fileSizeLimit int64

--- a/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/utils.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
@@ -156,7 +157,7 @@ func (u *LyticsBulkUploader) createCSVFile(existingFilePath string, streamTraits
 		}
 
 		// Calculate the payload size and observe it
-		payloadSizeStat := stats.Default.NewTaggedStat("payload_size", stats.HistogramType,
+		payloadSizeStat := u.statsFactory.NewTaggedStat("payload_size", stats.HistogramType,
 			map[string]string{
 				"module":   "batch_router",
 				"destType": u.destName,

--- a/router/batchrouter/asyncdestinationmanager/manager.go
+++ b/router/batchrouter/asyncdestinationmanager/manager.go
@@ -3,52 +3,68 @@ package asyncdestinationmanager
 import (
 	"errors"
 
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	bingads_audience "github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/bing-ads/audience"
 	bingads_offline_conversions "github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/eloqua"
-	klaviyobulkupload "github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/klaviyobulkupload"
+	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/klaviyobulkupload"
 	lyticsBulkUpload "github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload"
 	marketobulkupload "github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/marketo-bulk-upload"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/sftp"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/yandexmetrica"
 )
 
-func newRegularManager(destination *backendconfig.DestinationT, backendConfig backendconfig.BackendConfig) (common.AsyncDestinationManager, error) {
+func newRegularManager(
+	conf *config.Config,
+	logger logger.Logger,
+	statsFactory stats.Stats,
+	destination *backendconfig.DestinationT,
+	backendConfig backendconfig.BackendConfig,
+) (common.AsyncDestinationManager, error) {
 	switch destination.DestinationDefinition.Name {
 	case "BINGADS_AUDIENCE":
-		return bingads_audience.NewManager(destination, backendConfig)
+		return bingads_audience.NewManager(conf, logger, statsFactory, destination, backendConfig)
 	case "BINGADS_OFFLINE_CONVERSIONS":
-		return bingads_offline_conversions.NewManager(destination, backendConfig)
+		return bingads_offline_conversions.NewManager(conf, logger, statsFactory, destination, backendConfig)
 	case "MARKETO_BULK_UPLOAD":
-		return marketobulkupload.NewManager(destination)
+		return marketobulkupload.NewManager(conf, logger, statsFactory, destination)
 	case "ELOQUA":
-		return eloqua.NewManager(destination)
+		return eloqua.NewManager(logger, statsFactory, destination)
 	case "YANDEX_METRICA_OFFLINE_EVENTS":
-		return yandexmetrica.NewManager(destination, backendConfig)
+		return yandexmetrica.NewManager(logger, statsFactory, destination, backendConfig)
 	case "KLAVIYO_BULK_UPLOAD":
-		return klaviyobulkupload.NewManager(destination)
+		return klaviyobulkupload.NewManager(logger, statsFactory, destination)
 	case "LYTICS_BULK_UPLOAD":
-		return lyticsBulkUpload.NewManager(destination)
+		return lyticsBulkUpload.NewManager(logger, statsFactory, destination)
 	}
 	return nil, errors.New("invalid destination type")
 }
 
-func newSFTPManager(destination *backendconfig.DestinationT) (common.AsyncDestinationManager, error) {
+func newSFTPManager(logger logger.Logger, statsFactory stats.Stats, destination *backendconfig.DestinationT) (common.AsyncDestinationManager, error) {
 	switch destination.DestinationDefinition.Name {
 	case "SFTP":
-		return sftp.NewManager(destination)
+		return sftp.NewManager(logger, statsFactory, destination)
 	}
 	return nil, errors.New("invalid destination type")
 }
 
-func NewManager(destination *backendconfig.DestinationT, backendConfig backendconfig.BackendConfig) (common.AsyncDestinationManager, error) {
+func NewManager(
+	conf *config.Config,
+	logger logger.Logger,
+	statsFactory stats.Stats,
+	destination *backendconfig.DestinationT,
+	backendConfig backendconfig.BackendConfig,
+) (common.AsyncDestinationManager, error) {
 	switch {
 	case common.IsAsyncRegularDestination(destination.DestinationDefinition.Name):
-		return newRegularManager(destination, backendConfig)
+		return newRegularManager(conf, logger, statsFactory, destination, backendConfig)
 	case common.IsSFTPDestination(destination.DestinationDefinition.Name):
-		return newSFTPManager(destination)
+		return newSFTPManager(logger, statsFactory, destination)
 	}
 	return nil, errors.New("invalid destination type")
 }

--- a/router/batchrouter/asyncdestinationmanager/sftp/sftp_test.go
+++ b/router/batchrouter/asyncdestinationmanager/sftp/sftp_test.go
@@ -12,9 +12,12 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/sftp/mock_sftp"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -133,7 +136,7 @@ var _ = Describe("SFTP test", func() {
 			initSFTP()
 			ctrl := gomock.NewController(GinkgoT())
 			fileManager := mock_sftp.NewMockFileManager(ctrl)
-			defaultManager := newDefaultManager(fileManager)
+			defaultManager := newDefaultManager(logger.NOP, stats.NOP, fileManager)
 			manager := common.SimpleAsyncDestinationManager{UploaderAndTransformer: defaultManager}
 			asyncDestination := common.AsyncDestinationStruct{
 				ImportingJobIDs: []int64{1014, 1015, 1016, 1017},
@@ -155,7 +158,7 @@ var _ = Describe("SFTP test", func() {
 			initSFTP()
 			ctrl := gomock.NewController(GinkgoT())
 			fileManager := mock_sftp.NewMockFileManager(ctrl)
-			defaultManager := newDefaultManager(fileManager)
+			defaultManager := newDefaultManager(logger.NOP, stats.NOP, fileManager)
 			fileManager.EXPECT().Upload(gomock.Any(), gomock.Any()).Return(fmt.Errorf("root directory does not exists"))
 			manager := common.SimpleAsyncDestinationManager{UploaderAndTransformer: defaultManager}
 			asyncDestination := common.AsyncDestinationStruct{
@@ -178,7 +181,7 @@ var _ = Describe("SFTP test", func() {
 			initSFTP()
 			ctrl := gomock.NewController(GinkgoT())
 			fileManager := mock_sftp.NewMockFileManager(ctrl)
-			defaultManager := newDefaultManager(fileManager)
+			defaultManager := newDefaultManager(logger.NOP, stats.NOP, fileManager)
 			now := time.Now()
 			filePath := fmt.Sprintf("/tmp/testDir1/destination_id_1_someJobRunId_1/file_%d_%02d_%02d_%d_1.csv", now.Year(), now.Month(), now.Day(), now.Unix())
 			fileManager.EXPECT().Upload(gomock.Any(), filePath).Return(nil)

--- a/router/batchrouter/asyncdestinationmanager/sftp/types.go
+++ b/router/batchrouter/asyncdestinationmanager/sftp/types.go
@@ -3,12 +3,14 @@ package sftp
 import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/sftp"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 )
 
 // defaultManager is the default manager for SFTP
 type defaultManager struct {
-	FileManager    sftp.FileManager
 	logger         logger.Logger
+	statsFactory   stats.Stats
+	FileManager    sftp.FileManager
 	filePathPrefix string
 }
 

--- a/router/batchrouter/asyncdestinationmanager/yandexmetrica/yandexmetrica_test.go
+++ b/router/batchrouter/asyncdestinationmanager/yandexmetrica/yandexmetrica_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	mockoauthv2 "github.com/rudderlabs/rudder-server/mocks/services/oauthV2"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
@@ -49,7 +50,7 @@ var (
 var _ = Describe("Antisymmetric", func() {
 	Describe("NewManager function test", func() {
 		It("should return yandexmetrica manager", func() {
-			yandexmetrica, err := yandexmetrica.NewManager(destination, backendconfig.DefaultBackendConfig)
+			yandexmetrica, err := yandexmetrica.NewManager(logger.NOP, stats.NOP, destination, backendconfig.DefaultBackendConfig)
 			Expect(err).To(BeNil())
 			Expect(yandexmetrica).NotTo(BeNil())
 		})
@@ -73,8 +74,8 @@ var _ = Describe("Antisymmetric", func() {
 			oauthHandler := oauthv2.NewOAuthHandler(mockTokenProvider,
 				oauthv2.WithCache(oauthv2.NewCache()),
 				oauthv2.WithLocker(kitsync.NewPartitionRWLocker()),
-				oauthv2.WithStats(stats.Default),
-				oauthv2.WithLogger(logger.NewLogger().Child("MockOAuthHandler")),
+				oauthv2.WithStats(stats.NOP),
+				oauthv2.WithLogger(logger.NOP),
 				oauthv2.WithCpConnector(mockCpConnector),
 			)
 			optionalArgs := httpClient.HttpClientOptionalArgs{
@@ -83,7 +84,7 @@ var _ = Describe("Antisymmetric", func() {
 				OAuthHandler: oauthHandler,
 			}
 			httpClient := httpClient.NewOAuthHttpClient(&http.Client{}, oauthv2common.RudderFlowDelivery, &cache, backendconfig.DefaultBackendConfig, augmenter.GetAuthErrorCategoryForYandex, &optionalArgs)
-			yandexmetrica, _ := yandexmetrica.NewManager(destination, backendconfig.DefaultBackendConfig)
+			yandexmetrica, _ := yandexmetrica.NewManager(logger.NOP, stats.NOP, destination, backendconfig.DefaultBackendConfig)
 			yandexmetrica.Client = httpClient
 			asyncDestination := common.AsyncDestinationStruct{
 				ImportingJobIDs: []int64{1, 2, 3, 4},
@@ -115,8 +116,8 @@ var _ = Describe("Antisymmetric", func() {
 			oauthHandler := oauthv2.NewOAuthHandler(mockTokenProvider,
 				oauthv2.WithCache(oauthv2.NewCache()),
 				oauthv2.WithLocker(kitsync.NewPartitionRWLocker()),
-				oauthv2.WithStats(stats.Default),
-				oauthv2.WithLogger(logger.NewLogger().Child("MockOAuthHandler")),
+				oauthv2.WithStats(stats.NOP),
+				oauthv2.WithLogger(logger.NOP),
 				oauthv2.WithCpConnector(mockCpConnector),
 			)
 			optionalArgs := httpClient.HttpClientOptionalArgs{
@@ -125,7 +126,7 @@ var _ = Describe("Antisymmetric", func() {
 				OAuthHandler: oauthHandler,
 			}
 			httpClient := httpClient.NewOAuthHttpClient(&http.Client{}, oauthv2common.RudderFlowDelivery, &cache, backendconfig.DefaultBackendConfig, augmenter.GetAuthErrorCategoryForYandex, &optionalArgs)
-			yandexmetrica, _ := yandexmetrica.NewManager(destination, backendconfig.DefaultBackendConfig)
+			yandexmetrica, _ := yandexmetrica.NewManager(logger.NOP, stats.NOP, destination, backendconfig.DefaultBackendConfig)
 			yandexmetrica.Client = httpClient
 			asyncDestination := common.AsyncDestinationStruct{
 				ImportingJobIDs: []int64{1, 2, 3, 4},

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager"
@@ -261,7 +262,7 @@ func (brt *Handle) Shutdown() {
 
 func (brt *Handle) initAsyncDestinationStruct(destination *backendconfig.DestinationT) {
 	_, ok := brt.asyncDestinationStruct[destination.ID]
-	manager, err := asyncdestinationmanager.NewManager(destination, brt.backendConfig)
+	manager, err := asyncdestinationmanager.NewManager(brt.conf, brt.logger.Child("asyncdestinationmanager"), stats.Default, destination, brt.backendConfig)
 	if err != nil {
 		brt.logger.Errorf("BRT: Error initializing async destination struct for %s destination: %v", destination.Name, err)
 		destInitFailStat := stats.Default.NewTaggedStat("destination_initialization_fail", stats.CountType, map[string]string{


### PR DESCRIPTION
# Description

- Passing dependency for config, logger and stats instead of global default for `asyncdestinationmanager` package.
- It's a preliminary PR for the changes I am making around `snowpipe streaming` in `asyncdestinationmanager`.

## Linear Ticket

- Resolves PIPE-1511

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
