### PR TITLE
fix: replace counter with gauge cron tracker alert

### DIFF
--- a/warehouse/router/tracker.go
+++ b/warehouse/router/tracker.go
@@ -23,13 +23,13 @@ import (
 // CronTracker Track the status of the staging file whether it has reached the terminal state or not for every warehouse
 // we pick the staging file which is oldest within the range NOW() - 2 * syncFrequency and NOW() - 3 * syncFrequency
 func (r *Router) CronTracker(ctx context.Context) error {
-	tick := r.statsFactory.NewTaggedStat("warehouse_cron_tracker_tick", stats.CountType, stats.Tags{
+	cronTrackerExecTimestamp := r.statsFactory.NewTaggedStat("warehouse_cron_tracker_timestamp_seconds", stats.GaugeType, stats.Tags{
 		"module":   moduleName,
 		"destType": r.destType,
 	})
 	for {
 
-		tick.Count(1)
+		cronTrackerExecTimestamp.Gauge(time.Now().Unix())
 
 		r.configSubscriberLock.RLock()
 		warehouses := append([]model.Warehouse{}, r.warehouses...)

--- a/warehouse/router/tracker_test.go
+++ b/warehouse/router/tracker_test.go
@@ -215,16 +215,17 @@ func TestRouter_CronTracker(t *testing.T) {
 
 		mockLogger.EXPECT().Infon("context is cancelled, stopped running tracking").Times(1)
 
+		executionTime := time.Now().Unix()
 		err = r.CronTracker(ctx)
 		require.NoError(t, err)
 
-		m := statsStore.GetByName("warehouse_cron_tracker_tick")
+		m := statsStore.GetByName("warehouse_cron_tracker_timestamp_seconds")
 		require.Equal(t, len(m), 1)
-		require.Equal(t, m[0].Name, "warehouse_cron_tracker_tick")
+		require.Equal(t, m[0].Name, "warehouse_cron_tracker_timestamp_seconds")
 		require.Equal(t, m[0].Tags, stats.Tags{
 			"module":   moduleName,
 			"destType": warehouseutils.POSTGRES,
 		})
-		require.GreaterOrEqual(t, m[0].Value, 1.0)
+		require.GreaterOrEqual(t, m[0].Value, float64(executionTime))
 	})
 }


### PR DESCRIPTION
# Description

counter resetting on restarts was causing [false alerts](https://www.notion.so/rudderstacks/warehouse-cron-tracker-stuck-cfb91cfa9f45431ca9ed8f22415129d9). As the operation being tracked (cron tracker execution) doesn't happen often, using epoch gauge metric will help. 

## Linear Ticket
part of PIPE-1514

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
