### PR TITLE
chore: make scylla hosts as slice

### DIFF
--- a/services/dedup/scylla/scylla.go
+++ b/services/dedup/scylla/scylla.go
@@ -113,7 +113,7 @@ func (d *ScyllaDB) Commit(keys []string) error {
 }
 
 func New(conf *config.Config, stats stats.Stats) (*ScyllaDB, error) {
-	cluster := gocql.NewCluster(conf.GetString("Scylla.Hosts", "localhost:9042"))
+	cluster := gocql.NewCluster(conf.GetReloadableStringSliceVar([]string{"localhost:9042"}, "Scylla.Hosts").Load()...)
 	cluster.Consistency = gocql.Quorum
 	cluster.RetryPolicy = &gocql.ExponentialBackoffRetryPolicy{
 		NumRetries: conf.GetInt("Scylla.NumRetries", 3),


### PR DESCRIPTION
# Description

Add support to pass `Scylla.Hosts` as a slice

## Linear Ticket

Fixes PIPE-1536

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
