### PR TITLE
exp: migration eligiblity check upgrades

### DIFF
--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -560,6 +560,7 @@ func TestJobsDB(t *testing.T) {
 		require.NoError(t, err, "GetUnprocessed failed")
 		require.EqualValues(t, 19, len(jobsResult.Jobs))
 	})
+
 	t.Run("should migrate small datasets that have been migrated at least once (except right most one)", func(t *testing.T) {
 		customVal := "MOCKDS"
 		triggerAddNewDS := make(chan time.Time)

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -748,10 +748,10 @@ func (jd *Handle) init() {
 		jd.assertError(err)
 	}
 
+	maxOpenConnections := 2
 	if !jd.conf.enableReaderQueue || !jd.conf.enableWriterQueue {
-		jd.dbHandle.SetMaxOpenConns(jd.conf.maxOpenConnections)
+		maxOpenConnections = jd.conf.maxOpenConnections
 	} else {
-		maxOpenConnections := 2 // buffer
 		maxOpenConnections += jd.conf.maxReaders + jd.conf.maxWriters
 		switch jd.ownerType {
 		case Read:
@@ -761,12 +761,12 @@ func (jd *Handle) init() {
 		case ReadWrite:
 			maxOpenConnections += 3 // migrate, addNewDS, archive
 		}
-		if maxOpenConnections < jd.conf.maxOpenConnections {
-			jd.dbHandle.SetMaxOpenConns(maxOpenConnections)
-		} else {
-			jd.dbHandle.SetMaxOpenConns(jd.conf.maxOpenConnections)
+		if maxOpenConnections >= jd.conf.maxOpenConnections {
+			maxOpenConnections = jd.conf.maxOpenConnections
 		}
 	}
+	jd.dbHandle.SetMaxOpenConns(maxOpenConnections)
+	jd.dbHandle.SetMaxIdleConns(maxOpenConnections)
 
 	jd.assertError(jd.dbHandle.Ping())
 

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -526,59 +526,45 @@ func (jd *Handle) checkIfMigrateDS(ds dataSetT) (
 	).RecordDuration()()
 
 	var delCount, totalCount int
-	sqlStatement := fmt.Sprintf(`SELECT COUNT(*) from %q`, ds.JobTable)
-	if err = jd.dbHandle.QueryRow(sqlStatement).Scan(&totalCount); err != nil {
-		return false, false, 0, fmt.Errorf("error getting count of jobs in %s: %w", ds.JobTable, err)
-	}
+	var terminalJobsExist bool
+	var maxCreatedAt time.Time
 
-	// Jobs which have either succeeded or expired
-	sqlStatement = fmt.Sprintf(`SELECT COUNT(*)
-                                      from %q
-                                      WHERE job_state IN ('%s')`,
-		ds.JobStatusTable, strings.Join(validTerminalStates, "', '"))
-	if err = jd.dbHandle.QueryRow(sqlStatement).Scan(&delCount); err != nil {
-		return false, false, 0, fmt.Errorf("error getting count of jobs in %s: %w", ds.JobStatusTable, err)
+	query := fmt.Sprintf(
+		`with combinedResult as (
+			select
+			(select count(*) from %[1]q) as totalJobCount,
+			(select count(*) from %[2]q where job_state = ANY($1)) as terminalJobCount,
+			(select created_at from %[1]q order by job_id desc limit 1) as maxCreatedAt,
+			(select exists (select id from %[2]q where job_state = ANY($1) and exec_time < $2)) as retentionExpired
+		)
+		select totalJobCount, terminalJobCount, maxCreatedAt, retentionExpired from combinedResult`,
+		ds.JobTable, ds.JobStatusTable)
+
+	if err := jd.dbHandle.QueryRow(
+		query,
+		pq.Array(validTerminalStates),
+		time.Now().Add(-1*jd.conf.maxDSRetentionPeriod.Load()),
+	).Scan(&totalCount, &delCount, &maxCreatedAt, &terminalJobsExist); err != nil {
+		return false, false, 0, fmt.Errorf("error running check query in %s: %w", ds.JobStatusTable, err)
 	}
 
 	recordsLeft = totalCount - delCount
 
-	if jd.conf.minDSRetentionPeriod.Load() > 0 {
-		var maxCreatedAt time.Time
-		sqlStatement = fmt.Sprintf(`SELECT created_at FROM %q ORDER BY job_id DESC LIMIT 1`, ds.JobTable)
-		if err = jd.dbHandle.QueryRow(sqlStatement).Scan(&maxCreatedAt); err != nil {
-			return false, false, 0, fmt.Errorf("error getting max created_at from %s: %w", ds.JobTable, err)
-		}
-
-		if time.Since(maxCreatedAt) < jd.conf.minDSRetentionPeriod.Load() {
-			return false, false, recordsLeft, nil
-		}
+	if jd.conf.minDSRetentionPeriod.Load() > 0 && time.Since(maxCreatedAt) < jd.conf.minDSRetentionPeriod.Load() {
+		return false, false, recordsLeft, nil
 	}
 
-	if jd.conf.maxDSRetentionPeriod.Load() > 0 {
-		var terminalJobsExist bool
-		sqlStatement = fmt.Sprintf(`SELECT EXISTS (
-									SELECT id
-										FROM %q
-										WHERE job_state = ANY($1) and exec_time < $2)`,
-			ds.JobStatusTable)
-		if err = jd.dbHandle.QueryRow(sqlStatement, pq.Array(validTerminalStates), time.Now().Add(-1*jd.conf.maxDSRetentionPeriod.Load())).Scan(&terminalJobsExist); err != nil {
-			return false, false, 0, fmt.Errorf("checking terminalJobsExist %s: %w", ds.JobStatusTable, err)
-		}
-		if terminalJobsExist {
-			return true, false, recordsLeft, nil
-		}
+	if jd.conf.maxDSRetentionPeriod.Load() > 0 && terminalJobsExist {
+		return true, false, recordsLeft, nil
 	}
 
-	smallThreshold := jd.conf.migration.jobMinRowsMigrateThres() * float64(jd.conf.MaxDSSize.Load())
-	isSmall := func() bool {
-		return float64(totalCount) < smallThreshold
-	}
+	isSmall := float64(totalCount) < jd.conf.migration.jobMinRowsMigrateThres()*float64(jd.conf.MaxDSSize.Load())
 
 	if float64(delCount)/float64(totalCount) > jd.conf.migration.jobDoneMigrateThres() {
-		return true, isSmall(), recordsLeft, nil
+		return true, isSmall, recordsLeft, nil
 	}
 
-	if isSmall() {
+	if isSmall {
 		return true, true, recordsLeft, nil
 	}
 

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -532,7 +532,7 @@ func (jd *Handle) checkIfMigrateDS(ds dataSetT) (
 	}
 
 	// Jobs which have either succeeded or expired
-	sqlStatement = fmt.Sprintf(`SELECT COUNT(DISTINCT(job_id))
+	sqlStatement = fmt.Sprintf(`SELECT COUNT(*)
                                       from %q
                                       WHERE job_state IN ('%s')`,
 		ds.JobStatusTable, strings.Join(validTerminalStates, "', '"))
@@ -544,7 +544,7 @@ func (jd *Handle) checkIfMigrateDS(ds dataSetT) (
 
 	if jd.conf.minDSRetentionPeriod.Load() > 0 {
 		var maxCreatedAt time.Time
-		sqlStatement = fmt.Sprintf(`SELECT MAX(created_at) from %q`, ds.JobTable)
+		sqlStatement = fmt.Sprintf(`SELECT created_at FROM %q ORDER BY job_id DESC LIMIT 1`, ds.JobTable)
 		if err = jd.dbHandle.QueryRow(sqlStatement).Scan(&maxCreatedAt); err != nil {
 			return false, false, 0, fmt.Errorf("error getting max created_at from %s: %w", ds.JobTable, err)
 		}

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -383,8 +383,14 @@ func (jd *Handle) getMigrationList(ctx context.Context, dsList []dataSetT) (migr
 	case Read:
 		// if jobsdb owner is read, exempting the last two datasets from migration.
 		// This is done to avoid dsList conflicts between reader and writer
+		if len(dsList) <= 2 {
+			return
+		}
 		dsListOfInterest = dsList[:len(dsList)-2]
 	default:
+		if len(dsList) <= 1 {
+			return
+		}
 		dsListOfInterest = dsList[:len(dsList)-1]
 	}
 	if maxMigrateDSProbe < len(dsListOfInterest) {


### PR DESCRIPTION
# Description

Check dataset eligibility for migration for all at once, instead of querying for each dataset one at a time.
This would allow us in future to more effectively pack jobs in the future when multiple batches of datasets can be migrated in one loop.


commit-wise:
1. using a simpler query
2. combine multiple simple queries into one
3. combine(`union all`) said query for all datasets at once

## Linear Ticket



## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
