### PR TITLE
chore: no full vacuum for various reports tables

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -88,6 +88,14 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 	}
 	a.log.Infof("Configured deployment type: %q", deploymentType)
 
+	trackedUsersReporter, err := a.app.Features().TrackedUsers.Setup(config)
+	if err != nil {
+		return fmt.Errorf("could not setup tracked users: %w", err)
+	}
+	err = trackedUsersReporter.MigrateDatabase(misc.GetConnectionString(config, "tracked_users"), config)
+	if err != nil {
+		return fmt.Errorf("could not run tracked users database migration: %w", err)
+	}
 	reporting := a.app.Features().Reporting.Setup(ctx, backendconfig.DefaultBackendConfig)
 	defer reporting.Stop()
 	syncer := reporting.DatabaseSyncer(types.SyncerConfig{ConnInfo: misc.GetConnectionString(config, "reporting")})
@@ -233,15 +241,6 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 			_ = enricher.Close()
 		}
 	}()
-
-	trackedUsersReporter, err := a.app.Features().TrackedUsers.Setup(config)
-	if err != nil {
-		return fmt.Errorf("could not setup tracked users: %w", err)
-	}
-	err = trackedUsersReporter.MigrateDatabase(misc.GetConnectionString(config, "tracked_users"), config)
-	if err != nil {
-		return fmt.Errorf("could not run tracked users database migration: %w", err)
-	}
 
 	proc := processor.New(
 		ctx,

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -460,7 +460,7 @@ func (edr *ErrorDetailReporter) vacuum(ctx context.Context, dbHandle *sql.DB, c 
 	if sizeEstimate > edr.config.GetInt64("Reporting.errorReporting.vacuumThresholdBytes", 5*bytesize.GB) {
 		vacuumStart := time.Now()
 		vacuumDuration := edr.stats.NewTaggedStat(StatReportingVacuumDuration, stats.TimerType, tags)
-		vaccumStatement := fmt.Sprintf("vacuum full analyze %s", pq.QuoteIdentifier(ErrorDetailReportsTable))
+		vaccumStatement := fmt.Sprintf("vacuum analyze %s", pq.QuoteIdentifier(ErrorDetailReportsTable))
 		if _, err := dbHandle.ExecContext(ctx, vaccumStatement); err != nil {
 			edr.log.Errorn(
 				fmt.Sprintf(`Error vacuuming %s table`, ErrorDetailReportsTable),

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -160,10 +160,7 @@ func (edr *ErrorDetailReporter) DatabaseSyncer(c types.SyncerConfig) types.Repor
 		context.Background(),
 		fmt.Sprintf("vacuum full analyze %s", pq.QuoteIdentifier(ErrorDetailReportsTable)),
 	); err != nil {
-		edr.log.Errorn(
-			fmt.Sprintf(`Error full vacuuming %s table`, ErrorDetailReportsTable),
-			logger.NewErrorField(err),
-		)
+		edr.log.Errorn("error full vacuuming", logger.NewStringField("table", ErrorDetailReportsTable), obskit.Error(err))
 		panic(err)
 	}
 
@@ -447,10 +444,7 @@ func (edr *ErrorDetailReporter) mainLoop(ctx context.Context, c types.SyncerConf
 						ctx,
 						fmt.Sprintf("vacuum analyze %s", pq.QuoteIdentifier(ErrorDetailReportsTable)),
 					); err != nil {
-						edr.log.Errorn(
-							fmt.Sprintf(`Error vacuuming %s table`, ErrorDetailReportsTable),
-							logger.NewErrorField(err),
-						)
+						edr.log.Errorn("error vacuuming", logger.NewStringField("table", ErrorDetailReportsTable), obskit.Error(err))
 					} else {
 						deletedRows = 0
 					}

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -464,7 +464,7 @@ func (edr *ErrorDetailReporter) mainLoop(ctx context.Context, c types.SyncerConf
 						deletedRows = 0
 						lastVacuum = time.Now()
 					}
-				} else {
+				} else if time.Since(lastVacuum) >= vacuumInterval.Load() {
 					var sizeEstimate int64
 					if err := dbHandle.QueryRowContext(
 						ctx,
@@ -475,7 +475,7 @@ func (edr *ErrorDetailReporter) mainLoop(ctx context.Context, c types.SyncerConf
 							logger.NewErrorField(err),
 						)
 					}
-					if sizeEstimate >= vacuumThresholdBytes.Load() && time.Since(lastVacuum) >= vacuumInterval.Load() {
+					if sizeEstimate >= vacuumThresholdBytes.Load() {
 						if err := edr.vacuum(ctx, dbHandle, tags); err == nil {
 							deletedRows = 0
 							lastVacuum = time.Now()

--- a/enterprise/reporting/flusher/flusher.go
+++ b/enterprise/reporting/flusher/flusher.go
@@ -109,10 +109,7 @@ func NewFlusher(db *sql.DB, log logger.Logger, stats stats.Stats, conf *config.C
 	if _, err := db.Exec(
 		fmt.Sprintf("vacuum full analyze %s", pq.QuoteIdentifier(table)),
 	); err != nil {
-		log.Errorn(
-			fmt.Sprintf(`Error full vacuuming %s table`, table),
-			logger.NewErrorField(err),
-		)
+		log.Errorn("error full vacuuming", logger.NewStringField("table", table), obskit.Error(err))
 		return nil, fmt.Errorf("error full vacuuming %s table %w", table, err)
 	}
 	return &f, nil

--- a/enterprise/reporting/flusher/flusher.go
+++ b/enterprise/reporting/flusher/flusher.go
@@ -326,7 +326,7 @@ func (f *Flusher) vacuum(ctx context.Context) error {
 	}
 	if sizeEstimate > f.vacuumThresholdBytes.Load() {
 		vacuumStart := time.Now()
-		if _, err := f.db.ExecContext(ctx, fmt.Sprintf("vacuum full analyze %s", pq.QuoteIdentifier(f.table))); err != nil {
+		if _, err := f.db.ExecContext(ctx, fmt.Sprintf("vacuum analyze %s", pq.QuoteIdentifier(f.table))); err != nil {
 			return fmt.Errorf("error vacuuming table %w", err)
 		}
 		f.vacuumReportsTimer.Since(vacuumStart)

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -472,7 +472,7 @@ func (r *DefaultReporter) mainLoop(ctx context.Context, c types.SyncerConfig) {
 						deletedRows = 0
 						lastVacuum = time.Now()
 					}
-				} else {
+				} else if time.Since(lastVacuum) > vacuumInterval.Load() {
 					var sizeEstimate int64
 					if err := dbHandle.QueryRowContext(
 						ctx,
@@ -483,7 +483,7 @@ func (r *DefaultReporter) mainLoop(ctx context.Context, c types.SyncerConfig) {
 							logger.NewErrorField(err),
 						)
 					}
-					if sizeEstimate >= vacuumThresholdBytes.Load() && time.Since(lastVacuum) > vacuumInterval.Load() {
+					if sizeEstimate >= vacuumThresholdBytes.Load() {
 						if err := r.vacuum(ctx, dbHandle, tags); err == nil {
 							deletedRows = 0
 							lastVacuum = time.Now()

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -463,7 +463,7 @@ func (r *DefaultReporter) mainLoop(ctx context.Context, c types.SyncerConfig) {
 					)
 				}
 				if sizeEstimate > config.GetInt64("Reporting.vacuumThresholdBytes", 5*bytesize.GB) {
-					if _, err := dbHandle.ExecContext(ctx, `vacuum full analyze reports;`); err != nil {
+					if _, err := dbHandle.ExecContext(ctx, `vacuum analyze reports;`); err != nil {
 						r.log.Errorn(
 							`[ Reporting ]: Error vacuuming reports table`,
 							logger.NewErrorField(err),


### PR DESCRIPTION
# Description

1. Using `vacuum` instead of `vacuum full` for various reports tables. This only takes lenient locking and doesn't disrupt other reads/writes to the tables. And while it doesn't free up disk space, it makes the space available for newer tuples added to the table.
2. Full vacuum on startup
3. vacuum threshold based on number of deleted rows.

Having done all this, the table size might still grow, but not at the rate when there was no vacuum at all. Each server startup would help free up disk space.

## Linear Ticket

[Resolves PIPE-1517](https://linear.app/rudderstack/issue/PIPE-1549/remove-full-vacuum)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
