### PR TITLE
chore: set maxIdleConns for jobsdb handles and emit (*sql.DB).Stats

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -43,6 +43,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
+	"github.com/rudderlabs/rudder-go-kit/stats/metric"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-server/jobsdb/internal/cache"
@@ -743,30 +744,31 @@ func (jd *Handle) init() {
 	// Initialize dbHandle if not already set
 	if jd.dbHandle == nil {
 		var err error
-		psqlInfo := misc.GetConnectionString(jd.config, "jobsdb")
+		psqlInfo := misc.GetConnectionString(jd.config, "jobsdb_"+jd.tablePrefix)
 		jd.dbHandle, err = sql.Open("postgres", psqlInfo)
 		jd.assertError(err)
 	}
 
+	var maxConns int
 	if !jd.conf.enableReaderQueue || !jd.conf.enableWriterQueue {
-		jd.dbHandle.SetMaxOpenConns(jd.conf.maxOpenConnections)
+		maxConns = jd.conf.maxOpenConnections
 	} else {
-		maxOpenConnections := 2 // buffer
-		maxOpenConnections += jd.conf.maxReaders + jd.conf.maxWriters
+		maxConns = 2 // buffer
+		maxConns += jd.conf.maxReaders + jd.conf.maxWriters
 		switch jd.ownerType {
 		case Read:
-			maxOpenConnections += 2 // migrate, refreshDsList
+			maxConns += 2 // migrate, refreshDsList
 		case Write:
-			maxOpenConnections += 1 // addNewDS
+			maxConns += 1 // addNewDS
 		case ReadWrite:
-			maxOpenConnections += 3 // migrate, addNewDS, archive
+			maxConns += 3 // migrate, addNewDS, archive
 		}
-		if maxOpenConnections < jd.conf.maxOpenConnections {
-			jd.dbHandle.SetMaxOpenConns(maxOpenConnections)
-		} else {
-			jd.dbHandle.SetMaxOpenConns(jd.conf.maxOpenConnections)
+		if maxConns >= jd.conf.maxOpenConnections {
+			maxConns = jd.conf.maxOpenConnections
 		}
 	}
+	jd.dbHandle.SetMaxOpenConns(maxConns)
+	jd.dbHandle.SetMaxIdleConns(maxConns)
 
 	jd.assertError(jd.dbHandle.Ping())
 
@@ -969,7 +971,44 @@ func (jd *Handle) Start() error {
 	if !jd.skipSetupDBSetup {
 		jd.setUpForOwnerType(ctx, jd.ownerType)
 	}
+	g.Go(crash.Wrapper(func() error {
+		for {
+			select {
+			case <-time.After(jd.config.GetDuration("JobsDB.ConnStatsFrequency", 15, time.Second)):
+			case <-ctx.Done():
+				return nil
+			}
+			stats := jd.dbHandle.Stats()
+			metric.Instance.GetRegistry(metric.PublishedMetrics).MustGetGauge(
+				dbConnStats{name: "jobsdb_max_open_conns", tablePrefix: jd.tablePrefix},
+			).Set(float64(stats.MaxOpenConnections))
+			metric.Instance.GetRegistry(metric.PublishedMetrics).MustGetGauge(
+				dbConnStats{name: "jobsdb_idle_conns", tablePrefix: jd.tablePrefix},
+			).Set(float64(stats.Idle))
+			metric.Instance.GetRegistry(metric.PublishedMetrics).MustGetGauge(
+				dbConnStats{name: "jobsdb_in_use_conns", tablePrefix: jd.tablePrefix},
+			).Set(float64(stats.InUse))
+			metric.Instance.GetRegistry(metric.PublishedMetrics).MustGetGauge(
+				dbConnStats{name: "jobsdb_max_idle_closed", tablePrefix: jd.tablePrefix},
+			).Set(float64(stats.MaxIdleClosed))
+			metric.Instance.GetRegistry(metric.PublishedMetrics).MustGetGauge(
+				dbConnStats{name: "jobsdb_wait_conn_duration", tablePrefix: jd.tablePrefix},
+			).Set(stats.WaitDuration.Seconds())
+		}
+	}))
 	return nil
+}
+
+type dbConnStats struct {
+	name, tablePrefix string
+}
+
+func (dbs dbConnStats) GetName() string {
+	return dbs.name
+}
+
+func (dbs dbConnStats) GetTags() map[string]string {
+	return map[string]string{"tablePrefix": dbs.tablePrefix}
 }
 
 func (jd *Handle) setUpForOwnerType(ctx context.Context, ownerType OwnerType) {


### PR DESCRIPTION
# Description

1. Set `maxIdleConns` for all the jobsdb handles. 
The current default is only 2 max idle conns per pool which causes a lot of turnaround and consistent new connections. Setting it to the same as max open connections.
2. Emit periodic `(*sql.DB).Stats()`. that gauge the total closed(due to `maxIdleConns`) every 15 seconds(configurable).
3. Add tablePrefix to the jobsdb connection pool's `application_name`.

## Linear Ticket



## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
