### PR TITLE
chore: trim eventNames sent to reporting if length exceeds 50 characters

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -249,5 +249,3 @@ PgNotifier:
   retriggerCount: 500
   trackBatchInterval: 2s
   maxAttempt: 3
-Reporting:
-  eventNameMaxLength: 0

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -607,7 +607,6 @@ func (r *DefaultReporter) Report(ctx context.Context, metrics []*types.PUReporte
 	}
 	defer func() { _ = stmt.Close() }()
 
-	eventNameMaxLength := config.GetInt("Reporting.eventNameMaxLength", 0)
 	reportedAt := time.Now().UTC().Unix() / 60
 	for _, metric := range metrics {
 		workspaceID := r.configSubscriber.WorkspaceIDFromSource(metric.ConnectionDetails.SourceID)
@@ -621,8 +620,9 @@ func (r *DefaultReporter) Report(ctx context.Context, metrics []*types.PUReporte
 			metric = transformMetricForPII(metric, getPIIColumnsToExclude())
 		}
 
-		if eventNameMaxLength > 0 && len(metric.StatusDetail.EventName) > eventNameMaxLength {
-			metric.StatusDetail.EventName = types.MaxLengthExceeded
+		eventName := metric.StatusDetail.EventName
+		if len(eventName) > 50 {
+			metric.StatusDetail.EventName = fmt.Sprintf("%s...%s", eventName[:40], eventName[len(eventName)-10:])
 		}
 
 		_, err = stmt.Exec(

--- a/utils/types/reporting_types.go
+++ b/utils/types/reporting_types.go
@@ -21,8 +21,6 @@ const (
 	DefaultReplayEnabled    = false
 )
 
-const MaxLengthExceeded = ":max-length-exceeded:"
-
 const (
 	DiffStatus = "diff"
 


### PR DESCRIPTION
# Description

Trimming eventName being sent to reporting if length exceeds 50 characters

## Linear Ticket

Completes OBS-670

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
