### PR TITLE
chore: optimise config backend revisionId calls

### DIFF
--- a/services/notifier/repo.go
+++ b/services/notifier/repo.go
@@ -6,9 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
-	"time"
 
 	"github.com/lib/pq"
 

--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -374,7 +374,6 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 func (lf *LoadFileGenerator) destinationRevisionIDMap(ctx context.Context, job *model.UploadJob) (revisionIDMap map[string]backendconfig.DestinationT, err error) {
 	revisionIDMap = make(map[string]backendconfig.DestinationT)
 
-	lf.Logger.Infof("[WH]: Getting destination history for %s", job.Warehouse.Destination.RevisionID)
 	revisionIDMap[job.Warehouse.Destination.RevisionID] = job.Warehouse.Destination
 	revisionIds := lo.Uniq(
 		lo.Map(

--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -163,13 +163,14 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 
 	job.LoadFileGenStartTime = timeutil.Now()
 
+	startTime := time.Now()
 	// Getting distinct destination revision ID from staging files metadata
 	destinationRevisionIDMap, err := lf.destinationRevisionIDMap(ctx, job)
 	if err != nil {
 		return 0, 0, fmt.Errorf("populating destination revision ID: %w", err)
 	}
+	lf.Logger.Infof("[WH]: Populated destination revision ID for %s", time.Since(startTime))
 
-	startTime := time.Now()
 	// Delete previous load files for the staging files
 	stagingFileIDs := repo.StagingFileIDs(toProcessStagingFiles)
 	if err := lf.LoadRepo.DeleteByStagingFiles(ctx, stagingFileIDs); err != nil {
@@ -381,7 +382,7 @@ func (lf *LoadFileGenerator) destinationRevisionIDMap(ctx context.Context, job *
 			revisionIDMap[revisionID] = job.Warehouse.Destination
 			continue
 		}
-
+		lf.Logger.Infof("[WH]: Fetching destination history for revision ID %s", revisionID)
 		destination, err := lf.ControlPlaneClient.DestinationHistory(ctx, revisionID)
 		if err != nil {
 			return nil, err

--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -175,7 +175,7 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 	if err := lf.LoadRepo.DeleteByStagingFiles(ctx, stagingFileIDs); err != nil {
 		return 0, 0, fmt.Errorf("deleting previous load files: %w", err)
 	}
-	lf.Logger.Infof("[WH]: Deleted previous load files for staging files %v for %v", time.Since(startTime), destID)
+	lf.Logger.Infof("[WH]: Deleted previous load files for staging files %v for %s", time.Since(startTime), destID)
 
 	// Set staging file status to executing
 	if err := lf.StageRepo.SetStatuses(
@@ -186,7 +186,7 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 		return 0, 0, fmt.Errorf("set staging file status to executing: %w", err)
 	}
 
-	lf.Logger.Infof("[WH]: Set staging file status to executing for staging files %v for %v", time.Since(startTime), destID)
+	lf.Logger.Infof("[WH]: Set staging file status to executing for staging files %v for %s", time.Since(startTime), destID)
 	defer func() {
 		// ensure that if there is an error, we set the staging file status to failed
 		if err != nil {
@@ -241,7 +241,7 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 			messages = append(messages, payloadJSON)
 		}
 
-		lf.Logger.Infof("[WH]: Publishing %d staging files in %v for %v", len(messages), time.Since(startTime), destID)
+		lf.Logger.Infof("[WH]: Publishing %d staging files in %v for %s", len(messages), time.Since(startTime), destID)
 		uploadSchemaJSON, err := json.Marshal(struct {
 			UploadSchema model.Schema
 		}{

--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -169,11 +169,13 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 		return 0, 0, fmt.Errorf("populating destination revision ID: %w", err)
 	}
 
+	startTime := time.Now()
 	// Delete previous load files for the staging files
 	stagingFileIDs := repo.StagingFileIDs(toProcessStagingFiles)
 	if err := lf.LoadRepo.DeleteByStagingFiles(ctx, stagingFileIDs); err != nil {
 		return 0, 0, fmt.Errorf("deleting previous load files: %w", err)
 	}
+	lf.Logger.Infof("[WH]: Deleted previous load files for staging files %v for %v", time.Since(startTime), destID)
 
 	// Set staging file status to executing
 	if err := lf.StageRepo.SetStatuses(
@@ -184,6 +186,7 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 		return 0, 0, fmt.Errorf("set staging file status to executing: %w", err)
 	}
 
+	lf.Logger.Infof("[WH]: Set staging file status to executing for staging files %v for %v", time.Since(startTime), destID)
 	defer func() {
 		// ensure that if there is an error, we set the staging file status to failed
 		if err != nil {
@@ -238,6 +241,7 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 			messages = append(messages, payloadJSON)
 		}
 
+		lf.Logger.Infof("[WH]: Publishing %d staging files in %v for %v", len(messages), time.Since(startTime), destID)
 		uploadSchemaJSON, err := json.Marshal(struct {
 			UploadSchema model.Schema
 		}{

--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -374,6 +374,7 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 func (lf *LoadFileGenerator) destinationRevisionIDMap(ctx context.Context, job *model.UploadJob) (revisionIDMap map[string]backendconfig.DestinationT, err error) {
 	revisionIDMap = make(map[string]backendconfig.DestinationT)
 
+	revisionIDMap[job.Warehouse.Destination.RevisionID] = job.Warehouse.Destination
 	revisionIds := lo.Uniq(
 		lo.Map(
 			lo.Filter(job.StagingFiles, func(file *model.StagingFile, _ int) bool {

--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -374,6 +374,7 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 func (lf *LoadFileGenerator) destinationRevisionIDMap(ctx context.Context, job *model.UploadJob) (revisionIDMap map[string]backendconfig.DestinationT, err error) {
 	revisionIDMap = make(map[string]backendconfig.DestinationT)
 
+	lf.Logger.Infof("[WH]: Getting destination history for %s", job.Warehouse.Destination.RevisionID)
 	revisionIDMap[job.Warehouse.Destination.RevisionID] = job.Warehouse.Destination
 	revisionIds := lo.Uniq(
 		lo.Map(


### PR DESCRIPTION
# Description

PrizePicks CFD

- Reduce the number of config backend API calls being made for a single revisionId
- `VACUUM FULL` notifier table if the size exceeds 5GB

## Linear Ticket

Fixes PIPE-1583

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
