### PR TITLE
fix: wrong filtering while killing dangling connections

### DIFF
--- a/services/validators/envValidator.go
+++ b/services/validators/envValidator.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 func createDBConnection() (*sql.DB, error) {
-	psqlInfo := misc.GetConnectionString(config.Default, "env-validator")
+	psqlInfo := misc.GetConnectionString(config.Default, "")
 	var err error
 	dbHandle, err := sql.Open("postgres", psqlInfo)
 	if err != nil {


### PR DESCRIPTION
# Description

No component name for env validator so that `kill-dangling-queries` query filters correctly.

Earlier query was for `kill where APPLICATION_NAME LIKE '%env-validator-<rudder-server-host-name>`.

Now it becomes `kill where APPLICATION_NAME LIKE '%-<rudder-server-host-name>`. This kills all connections/transactions from previous host.

## Linear Ticket

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
