### PR TITLE
fix: change retl check to source category

### DIFF
--- a/router/worker.go
+++ b/router/worker.go
@@ -193,7 +193,7 @@ func (w *worker) workLoop() {
 				DestinationID: parameters.DestinationID,
 			}]
 			w.rt.destinationsMapMu.RUnlock()
-			if !destOK || (parameters.SourceJobRunID != "" && !connOK) {
+			if !destOK || (parameters.SourceCategory == "warehouse" && !connOK) {
 				continue
 			}
 			destination := batchDestination.Destination


### PR DESCRIPTION
# Description

Replace the check for validating an rETL event from comparing sourceJobRunId(which can also appear in a replay) to sourceCategory

## Linear Ticket

Fixes PIPE-1606

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
