### PR TITLE
chore: trim eventNames sent to reporting if length exceeds 50 characters

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -249,5 +249,3 @@ PgNotifier:
   retriggerCount: 500
   trackBatchInterval: 2s
   maxAttempt: 3
-Reporting:
-  eventNameMaxLength: 0

--- a/utils/types/reporting_types.go
+++ b/utils/types/reporting_types.go
@@ -21,8 +21,6 @@ const (
 	DefaultReplayEnabled    = false
 )
 
-const MaxLengthExceeded = ":max-length-exceeded:"
-
 const (
 	DiffStatus = "diff"
 


### PR DESCRIPTION
# Description
Trimming eventName being sent to reporting if length exceeds 50 characters

Tested with `你好世界😊 Привет мир 🌍 ¡Hola, mundo! こんにちは世界 안녕하세요 세계 नमस्ते दुनिया مرحبا بالعالم 😊🌎`

## Linear Ticket

Completes OBS-670

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
