### PR TITLE
chore: use stage's input payload for processor reports' sample events

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2627,6 +2627,15 @@ func (proc *Handle) transformSrcDest(
 
 			proc.transDebugger.UploadTransformationStatus(&transformationdebugger.TransformationStatusT{SourceID: sourceID, DestID: destID, Destination: destination, UserTransformedEvents: eventsToTransform, EventsByMessageID: eventsByMessageID, FailedEvents: response.FailedEvents, UniqueMessageIds: uniqueMessageIdsBySrcDestKey[srcAndDestKey]})
 
+			// update eventsByMessageID payload with output payload
+			for _, event := range eventsToTransform {
+				receviedAt := eventsByMessageID[event.Metadata.MessageID].ReceivedAt
+				eventsByMessageID[event.Metadata.MessageID] = types.SingularEventWithReceivedAt{
+					SingularEvent: event.Message,
+					ReceivedAt:    receviedAt,
+				}
+			}
+
 			// REPORTING - START
 			if proc.isReportingEnabled() {
 				diffMetrics := getDiffMetrics(

--- a/processor/trackingplan.go
+++ b/processor/trackingplan.go
@@ -138,6 +138,16 @@ func (proc *Handle) validateEvents(groupedEventsBySourceId map[SourceIDT][]trans
 		}
 		validatedEventsBySourceId[sourceId] = make([]transformer.TransformerEvent, 0)
 		validatedEventsBySourceId[sourceId] = append(validatedEventsBySourceId[sourceId], eventsToTransform...)
+		for _, event := range eventsToTransform {
+			messageIDs := event.Metadata.GetMessagesIDs()
+			for _, messageID := range messageIDs {
+				receivedAt := eventsByMessageID[messageID].ReceivedAt
+				eventsByMessageID[messageID] = types.SingularEventWithReceivedAt{
+					SingularEvent: event.Message,
+					ReceivedAt:    receivedAt,
+				}
+			}
+		}
 	}
 	return validatedEventsBySourceId, validatedReportMetrics, validatedErrorJobs, trackingPlanEnabledMap
 }


### PR DESCRIPTION
# Description


Use a stage's input payload as reports' sample events in processor.

## Linear Ticket


## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
