### PR TITLE
fix: set hosted secret as auth instead of workspace token

### DIFF
--- a/services/debugger/destination/eventDeliveryStatusUploader.go
+++ b/services/debugger/destination/eventDeliveryStatusUploader.go
@@ -61,7 +61,7 @@ func NewHandle(backendConfig backendconfig.BackendConfig) (DestinationDebugger, 
 	var err error
 	url := fmt.Sprintf("%s/dataplane/v2/eventDeliveryStatus", h.configBackendURL)
 	eventUploader := NewEventDeliveryStatusUploader(h.log)
-	h.uploader = debugger.New[*DeliveryStatusT](url, eventUploader)
+	h.uploader = debugger.New[*DeliveryStatusT](url, backendConfig.Identity(), eventUploader)
 	h.uploader.Start()
 
 	cacheType := cache.CacheType(config.GetInt("DestinationDebugger.cacheType", int(cache.MemoryCacheType)))

--- a/services/debugger/destination/eventDeliveryStatusUploader_test.go
+++ b/services/debugger/destination/eventDeliveryStatusUploader_test.go
@@ -16,6 +16,7 @@ import (
 	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/backend-config"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
+	testutils "github.com/rudderlabs/rudder-server/utils/tests"
 )
 
 const (
@@ -169,6 +170,7 @@ type eventDeliveryStatusUploaderContext struct {
 func (c *eventDeliveryStatusUploaderContext) Setup() {
 	c.mockCtrl = gomock.NewController(GinkgoT())
 	c.mockBackendConfig = mocksBackendConfig.NewMockBackendConfig(c.mockCtrl)
+	c.mockBackendConfig.EXPECT().Identity().AnyTimes().Return(&testutils.BasicAuthMock{})
 }
 
 func initEventDeliveryStatusUploader() {

--- a/services/debugger/source/eventUploader.go
+++ b/services/debugger/source/eventUploader.go
@@ -67,7 +67,7 @@ func NewHandle(backendConfig backendconfig.BackendConfig) (SourceDebugger, error
 	h.disableEventUploads = config.GetReloadableBoolVar(false, "SourceDebugger.disableEventUploads")
 	url := fmt.Sprintf("%s/dataplane/v2/eventUploads", h.configBackendURL)
 	eventUploader := NewEventUploader(h.log)
-	h.uploader = debugger.New[*GatewayEventBatchT](url, eventUploader)
+	h.uploader = debugger.New[*GatewayEventBatchT](url, backendConfig.Identity(), eventUploader)
 	h.uploader.Start()
 
 	cacheType := cache.CacheType(config.GetInt("SourceDebugger.cacheType", int(cache.MemoryCacheType)))

--- a/services/debugger/source/eventUploader_test.go
+++ b/services/debugger/source/eventUploader_test.go
@@ -16,6 +16,7 @@ import (
 	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/backend-config"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
+	testutils "github.com/rudderlabs/rudder-server/utils/tests"
 )
 
 const (
@@ -38,6 +39,7 @@ type eventUploaderContext struct {
 func (c *eventUploaderContext) Setup() {
 	c.mockCtrl = gomock.NewController(GinkgoT())
 	c.mockBackendConfig = mocksBackendConfig.NewMockBackendConfig(c.mockCtrl)
+	c.mockBackendConfig.EXPECT().Identity().AnyTimes().Return(&testutils.BasicAuthMock{})
 }
 
 func (c *eventUploaderContext) Finish() {

--- a/services/debugger/transformation/transformationStatusUploader.go
+++ b/services/debugger/transformation/transformationStatusUploader.go
@@ -115,7 +115,7 @@ func NewHandle(backendConfig backendconfig.BackendConfig) (TransformationDebugge
 		return nil, err
 	}
 
-	h.uploader = debugger.New[*TransformStatusT](url, transformationStatusUploader)
+	h.uploader = debugger.New[*TransformStatusT](url, backendConfig.Identity(), transformationStatusUploader)
 	h.uploader.Start()
 
 	h.start(backendConfig)

--- a/services/debugger/transformation/transformationStatusUploader_test.go
+++ b/services/debugger/transformation/transformationStatusUploader_test.go
@@ -20,6 +20,7 @@ import (
 	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/backend-config"
 	"github.com/rudderlabs/rudder-server/processor/transformer"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
+	testutils "github.com/rudderlabs/rudder-server/utils/tests"
 	"github.com/rudderlabs/rudder-server/utils/types"
 )
 
@@ -165,6 +166,7 @@ type eventDeliveryStatusUploaderContext struct {
 func (c *eventDeliveryStatusUploaderContext) Setup() {
 	c.mockCtrl = gomock.NewController(GinkgoT())
 	c.mockBackendConfig = mocksBackendConfig.NewMockBackendConfig(c.mockCtrl)
+	c.mockBackendConfig.EXPECT().Identity().AnyTimes().Return(&testutils.BasicAuthMock{})
 	c.mockBackendConfig.EXPECT().Subscribe(gomock.Any(), backendconfig.TopicProcessConfig).
 		DoAndReturn(func(ctx context.Context, topic backendconfig.Topic) pubsub.DataChannel {
 			// on Subscribe, emulate a backend configuration event

--- a/services/debugger/uploader_test.go
+++ b/services/debugger/uploader_test.go
@@ -69,6 +69,7 @@ var _ = Describe("Uploader", func() {
 			mockHTTPClient = mocksSysUtils.NewMockHTTPClientI(c.mockCtrl)
 			mockHTTP = mocksSysUtils.NewMockHttpI(c.mockCtrl)
 			mockTransformer = mocksDebugger.NewMockTransformerAny(c.mockCtrl)
+			config.Set("HOSTED_SERVICE_SECRET", "testAuth")
 			uploader = New[any]("http://test", mockTransformer)
 			uploader.Start()
 		})
@@ -99,8 +100,7 @@ var _ = Describe("Uploader", func() {
 
 			mockHTTPClient.EXPECT().Do(gomock.Any()).Do(func(req *http.Request) {
 				// asserting http request
-				req.Method = "POST"
-				req.URL.Host = "test"
+				assertRequest(req)
 			}).Return(&http.Response{
 				StatusCode: 200,
 				Body:       r,
@@ -129,8 +129,7 @@ var _ = Describe("Uploader", func() {
 
 			mockHTTPClient.EXPECT().Do(gomock.Any()).Do(func(req *http.Request) {
 				// asserting http request
-				req.Method = "POST"
-				req.URL.Host = "test"
+				assertRequest(req)
 			}).Return(&http.Response{
 				StatusCode: 400,
 				Body:       r,
@@ -199,8 +198,7 @@ var _ = Describe("Uploader", func() {
 
 			mockHTTPClient.EXPECT().Do(gomock.Any()).Do(func(req *http.Request) {
 				// asserting http request
-				req.Method = "POST"
-				req.URL.Host = "test"
+				assertRequest(req)
 
 				wg.Done()
 			}).Return(&http.Response{
@@ -236,8 +234,7 @@ var _ = Describe("Uploader", func() {
 
 			mockHTTPClient.EXPECT().Do(gomock.Any()).Do(func(req *http.Request) {
 				// asserting http request
-				req.Method = "POST"
-				req.URL.Host = "test"
+				assertRequest(req)
 			}).Return(&http.Response{
 				StatusCode: 200,
 				Body:       r,
@@ -283,8 +280,7 @@ var _ = Describe("Uploader", func() {
 
 			mockHTTPClient.EXPECT().Do(gomock.Any()).Do(func(req *http.Request) {
 				// asserting http request
-				req.Method = "POST"
-				req.URL.Host = "test"
+				assertRequest(req)
 				wg.Done()
 			}).Return(&http.Response{
 				StatusCode: 200,
@@ -298,3 +294,12 @@ var _ = Describe("Uploader", func() {
 		})
 	})
 })
+
+func assertRequest(req *http.Request) {
+	username, password, ok := req.BasicAuth()
+	Expect(ok).To(BeTrue())
+	Expect(username).To(Equal("testAuth"))
+	Expect(password).To(Equal(""))
+	Expect(req.Method).To(Equal("POST"))
+	Expect(req.URL.Host).To(Equal("test"))
+}

--- a/services/debugger/uploader_test.go
+++ b/services/debugger/uploader_test.go
@@ -19,6 +19,7 @@ import (
 
 	mocksDebugger "github.com/rudderlabs/rudder-server/mocks/services/debugger"
 	mocksSysUtils "github.com/rudderlabs/rudder-server/mocks/utils/sysUtils"
+	"github.com/rudderlabs/rudder-server/utils/types/deployment"
 )
 
 type uploaderContext struct {
@@ -69,13 +70,27 @@ var _ = Describe("Uploader", func() {
 			mockHTTPClient = mocksSysUtils.NewMockHTTPClientI(c.mockCtrl)
 			mockHTTP = mocksSysUtils.NewMockHttpI(c.mockCtrl)
 			mockTransformer = mocksDebugger.NewMockTransformerAny(c.mockCtrl)
-			config.Set("HOSTED_SERVICE_SECRET", "testAuth")
+			config.Set("WORKSPACE_TOKEN", "testToken")
+			config.Set("HOSTED_SERVICE_SECRET", "testSecret")
+			config.Set("DEPLOYMENT_TYPE", string(deployment.MultiTenantType))
 			uploader = New[any]("http://test", mockTransformer)
 			uploader.Start()
 		})
 
 		AfterEach(func() {
 			uploader.Stop()
+		})
+
+		It("should get basic auth username based on deployment type", func() {
+			// MultiTenantType
+			username, err := getAuthUsername()
+			Expect(err).To(BeNil())
+			assertUsername(username)
+			// DedicatedType
+			config.Set("DEPLOYMENT_TYPE", string(deployment.DedicatedType))
+			username, err = getAuthUsername()
+			Expect(err).To(BeNil())
+			assertUsername(username)
 		})
 
 		It("should successfully send the live events request", func() {
@@ -199,7 +214,6 @@ var _ = Describe("Uploader", func() {
 			mockHTTPClient.EXPECT().Do(gomock.Any()).Do(func(req *http.Request) {
 				// asserting http request
 				assertRequest(req)
-
 				wg.Done()
 			}).Return(&http.Response{
 				StatusCode: 200,
@@ -295,10 +309,18 @@ var _ = Describe("Uploader", func() {
 	})
 })
 
+func assertUsername(username string) {
+	if config.MustGetString("DEPLOYMENT_TYPE") != string(deployment.DedicatedType) {
+		Expect(username).To(Equal("testSecret"))
+	} else {
+		Expect(username).To(Equal("testToken"))
+	}
+}
+
 func assertRequest(req *http.Request) {
 	username, password, ok := req.BasicAuth()
 	Expect(ok).To(BeTrue())
-	Expect(username).To(Equal("testAuth"))
+	assertUsername(username)
 	Expect(password).To(Equal(""))
 	Expect(req.Method).To(Equal("POST"))
 	Expect(req.URL.Host).To(Equal("test"))


### PR DESCRIPTION
# Description

Set hosted secret as auth instead of workspace token. We can also validate with hosted secret. More info [here](https://github.com/rudderlabs/rudder-config-backend/blob/f83d9f7e7651ee536d7117f373fa6f8b3b956aa5/src/controllers/dataPlane.controller.ts#L40-L53)

## Linear Ticket

Fixes PIPE-1571

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
