### PR TITLE
fix: clickhouse temporary files deletion happening twice

### DIFF
--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -30,7 +30,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 
-	"github.com/rudderlabs/rudder-server/rruntime"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/client"
 	sqlmw "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
@@ -679,9 +678,6 @@ func (ch *Clickhouse) loadTablesFromFilesNamesWithRetry(ctx context.Context, tab
 		var gzipReader *gzip.Reader
 		gzipReader, err = gzip.NewReader(gzipFile)
 		if err != nil {
-			rruntime.GoForWarehouse(func() {
-				misc.RemoveFilePaths(objectFileName)
-			})
 			_ = gzipFile.Close()
 			err = fmt.Errorf("%s Error reading file using gzip.NewReader for file:%s while loading to table with error:%v", ch.GetLogIdentifier(tableName), gzipFile.Name(), err.Error())
 			onError(err)


### PR DESCRIPTION
# Description

- Since we are already calling `misc.RemoveFilePaths` around `LoadFileDownloader.Download`, we don't need to call it again.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
