### PR TITLE
chore: cleanup old jobs(beyond maxAge) at startup

### DIFF
--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/samber/lo"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
 )
 
 /*

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -766,6 +766,8 @@ func (jd *Handle) init() {
 	}
 
 	jd.loadConfig()
+	jd.conf.writeCapacity = make(chan struct{}, jd.conf.maxWriters)
+	jd.conf.readCapacity = make(chan struct{}, jd.conf.maxReaders)
 
 	// Initialize dbHandle if not already set
 	if jd.dbHandle != nil {
@@ -994,9 +996,6 @@ func (jd *Handle) Start() error {
 		return nil
 	}
 	defer func() { jd.lifecycle.started = true }()
-
-	jd.conf.writeCapacity = make(chan struct{}, jd.conf.maxWriters)
-	jd.conf.readCapacity = make(chan struct{}, jd.conf.maxReaders)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	g, ctx := errgroup.WithContext(ctx)

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -1236,7 +1236,7 @@ func TestMaxAgeCleanup(t *testing.T) {
 	))
 
 	// run cleanup once with an empty db
-	require.NoError(t, jobsDB.doCleanup(context.Background(), 200))
+	require.NoError(t, jobsDB.doCleanup(context.Background()))
 
 	// store some jobs
 	require.NoError(
@@ -1475,6 +1475,7 @@ func TestGetDistinctParameterValues(t *testing.T) {
 	jobs := generateJobs("param-1", 2)
 	err = jobsDB.Store(context.Background(), jobs)
 	require.NoError(t, err)
+	t.Log("stored jobs")
 
 	parameterValues, err := jobsDB.GetDistinctParameterValues(context.Background(), "param")
 	require.NoError(t, err)
@@ -1495,6 +1496,7 @@ func TestGetDistinctParameterValues(t *testing.T) {
 	jobs = generateJobs("param-2", 2)
 	err = jobsDB.Store(context.Background(), jobs)
 	require.NoError(t, err)
+	t.Log("stored jobs again")
 
 	parameterValues, err = jobsDB.GetDistinctParameterValues(context.Background(), "param")
 	require.NoError(t, err)
@@ -1513,6 +1515,7 @@ func TestGetDistinctParameterValues(t *testing.T) {
 	jobs = generateJobs("param-3", 2)
 	err = jobsDB.Store(context.Background(), jobs)
 	require.NoError(t, err)
+	t.Log("and stored jobs again")
 
 	res, err := jobsDB.GetUnprocessed(context.Background(), GetQueryParams{ParameterFilters: []ParameterFilterT{{Name: "param", Value: "param-3"}}, JobsLimit: 10})
 	require.NoError(t, err)


### PR DESCRIPTION
# Description

Remove the cleanup loop from jobsdb, because it's not "air-tight"(Doesn't enforce a proper abort for a job).
Also it isn't triggered in many production instances because it triggers once every 24 hours
and more often than not - servers restart within that duration anyway.

So considering these two facts, it's prudent to perform cleanup once at startup and not worry about it later on.
We should also take a look at consumers and have them perform some operation in the off chance that a server were to live for longer durations(days) and jobs are no longer of interest to them.

## Linear Ticket

[Resolves PIPE-1619](https://linear.app/rudderstack/issue/PIPE-1619/clean-up-invalid-jobs)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
