### PR TITLE
chore: jobsdb flaky test

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1076,15 +1076,12 @@ func (jd *Handle) readerWriterSetup(ctx context.Context, l lock.LockToken) {
 // Stop should be called once only after Start.
 // Only Start and Close can be called after Stop.
 func (jd *Handle) Stop() {
-	jd.logger.Infon("stopping jobsdb")
 	jd.lifecycle.mu.Lock()
 	defer jd.lifecycle.mu.Unlock()
 	if jd.lifecycle.started {
 		defer func() { jd.lifecycle.started = false }()
 		jd.backgroundCancel()
-		jd.logger.Infon("cancelled background context")
 		_ = jd.backgroundGroup.Wait()
-		jd.logger.Infon("stopped background goroutines")
 	}
 }
 
@@ -1092,9 +1089,7 @@ func (jd *Handle) Stop() {
 //
 //	waits until they finish and closes the database.
 func (jd *Handle) TearDown() {
-	jd.logger.Infon("teardown started")
 	jd.Stop()
-	jd.logger.Infon("closing db connection")
 	jd.Close()
 }
 
@@ -1105,13 +1100,10 @@ func (jd *Handle) TearDown() {
 //	Noop if the connection pool is shared with the handle.
 func (jd *Handle) Close() {
 	if !jd.sharedConnectionPool {
-		jd.logger.Info("not shared pool, so closing dbHandle")
 		if err := jd.dbHandle.Close(); err != nil {
 			jd.logger.Errorw("error closing db connection", "error", err)
 		}
-		return
 	}
-	jd.logger.Info("shared pool, not closing dbHandle")
 }
 
 /*
@@ -2364,11 +2356,9 @@ func (jd *Handle) addNewDSLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			jd.logger.Infon("addNewDSLoop exiting")
 			return
 		case <-jd.TriggerAddNewDS():
 		}
-		jd.logger.Infon("addNewDSLoop step triggered")
 		var dsListLock lock.LockToken
 		var releaseDsListLock chan<- lock.LockToken
 		addNewDS := func() error {

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1076,12 +1076,15 @@ func (jd *Handle) readerWriterSetup(ctx context.Context, l lock.LockToken) {
 // Stop should be called once only after Start.
 // Only Start and Close can be called after Stop.
 func (jd *Handle) Stop() {
+	jd.logger.Infon("stopping jobsdb")
 	jd.lifecycle.mu.Lock()
 	defer jd.lifecycle.mu.Unlock()
 	if jd.lifecycle.started {
 		defer func() { jd.lifecycle.started = false }()
 		jd.backgroundCancel()
+		jd.logger.Infon("cancelled background context")
 		_ = jd.backgroundGroup.Wait()
+		jd.logger.Infon("stopped background goroutines")
 	}
 }
 
@@ -1089,7 +1092,9 @@ func (jd *Handle) Stop() {
 //
 //	waits until they finish and closes the database.
 func (jd *Handle) TearDown() {
+	jd.logger.Infon("teardown started")
 	jd.Stop()
+	jd.logger.Infon("closing db connection")
 	jd.Close()
 }
 
@@ -1100,10 +1105,13 @@ func (jd *Handle) TearDown() {
 //	Noop if the connection pool is shared with the handle.
 func (jd *Handle) Close() {
 	if !jd.sharedConnectionPool {
+		jd.logger.Info("not shared pool, so closing dbHandle")
 		if err := jd.dbHandle.Close(); err != nil {
 			jd.logger.Errorw("error closing db connection", "error", err)
 		}
+		return
 	}
+	jd.logger.Info("shared pool, not closing dbHandle")
 }
 
 /*
@@ -2356,9 +2364,11 @@ func (jd *Handle) addNewDSLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			jd.logger.Infon("addNewDSLoop exiting")
 			return
 		case <-jd.TriggerAddNewDS():
 		}
+		jd.logger.Infon("addNewDSLoop step triggered")
 		var dsListLock lock.LockToken
 		var releaseDsListLock chan<- lock.LockToken
 		addNewDS := func() error {

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -1281,6 +1281,7 @@ func TestMaxAgeCleanup(t *testing.T) {
 		false,
 		tablePrefix,
 	))
+	defer jobsDB.TearDown()
 
 	abortedJobs, err := jobsDB.GetAborted(
 		context.Background(),


### PR DESCRIPTION
# Description

Missed teardown in one of the tests. That was causing jobsdb test suite to fail. This fixes that.

## Linear Ticket

[Resolves PIPE-1619](https://linear.app/rudderstack/issue/PIPE-1619/clean-up-invalid-jobs)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
