### PR TITLE
fix: discard badger transactions

### DIFF
--- a/services/dedup/badger/badger.go
+++ b/services/dedup/badger/badger.go
@@ -101,7 +101,10 @@ func (d *BadgerDB) Get(key string) (int64, bool, error) {
 
 func (d *BadgerDB) Set(kvs []types.KeyValue) error {
 	defer d.stats.NewTaggedStat("dedup_commit_duration_seconds", stats.TimerType, stats.Tags{"mode": "badger"}).RecordDuration()()
+	return d.set(kvs)
+}
 
+func (d *BadgerDB) set(kvs []types.KeyValue) error {
 	txn := d.badgerDB.NewTransaction(true)
 	defer txn.Discard()
 	for i := range kvs {
@@ -114,7 +117,7 @@ func (d *BadgerDB) Set(kvs []types.KeyValue) error {
 				return err
 			}
 			txn.Discard()
-			return d.Set(kvs[i:])
+			return d.set(kvs[i:])
 		} else if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Description

According to badger documentation:

`func (db *badger.DB) NewTransaction(update bool) *badger.Txn`
```
NewTransaction creates a new transaction.
Badger supports concurrent execution of transactions,
providing serializable snapshot isolation, avoiding write skews.
Badger achieves this by tracking the keys read and at Commit time,
ensuring that these read keys weren't concurrently modified by another transaction.

For read-only transactions, set update to false.
In this mode, we don't track the rows read for any changes.
Thus, any long running iterations done in this mode wouldn't pay this overhead.

Running transactions concurrently is OK.
However, a transaction itself isn't thread safe, and should only be run serially.
It doesn't matter if a transaction is created by one goroutine and passed down to other,
as long as the Txn APIs are called serially.

When you create a new transaction, it is absolutely essential to call Discard().
This should be done irrespective of what the update param is set to.
Commit API internally runs Discard, but running it twice wouldn't cause any issues.

txn := db.NewTransaction(false)
defer txn.Discard()
// Call various APIs.
```

and

`func (txn *badger.Txn) Discard()`
```
Discard discards a created transaction.
This method is very important and must be called.
Commit method calls this internally, however, calling this multiple times doesn't cause any issues.
So, this can safely be called via a defer right when transaction is created.

NOTE: If any operations are run on a discarded transaction, ErrDiscardedTxn is returned.
```

## Linear Ticket

< Replace with Linear Link ( [create](https://linear.new?title=Awesome-pr-without-linear-ticket) or [search](https://linear.app/rudderstack/search) linear ticket) or  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
