### PR TITLE
feat: drain jobs of 'Null' dest type

### DIFF
--- a/router/utils/utils.go
+++ b/router/utils/utils.go
@@ -139,6 +139,9 @@ type drainer struct {
 func (d *drainer) Drain(
 	job *jobsdb.JobT,
 ) (bool, string) {
+	if job.CustomVal == "Null" {
+		return true, DrainReasonDestDisabled
+	}
 	createdAt := job.CreatedAt
 	var jobParams JobParameters
 	_ = json.Unmarshal(job.Parameters, &jobParams)


### PR DESCRIPTION
# Description

Drain jobs of `Null` destType. destType introduced for convenience. Allows events to enjoy all features upto user transformation(including). Router transformations are obviously not allowed for these events.

## Linear Ticket



## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
