### PR TITLE
fix: common db pool config wasn't reloadable

### DIFF
--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -80,7 +80,14 @@ func NewDatabaseConnectionPool(
 	db.SetConnMaxLifetime(maxConnLifetime)
 
 	rruntime.Go(func() {
-		ticker := time.NewTicker(5 * time.Second)
+		ticker := time.NewTicker(
+			conf.GetDurationVar(
+				5,
+				time.Second,
+				"db."+componentName+".pool.configUpdateInterval",
+				"db.pool.configUpdateInterval",
+			),
+		)
 		defer ticker.Stop()
 		for {
 			select {

--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -79,9 +79,9 @@ func NewDatabaseConnectionPool(
 	maxConnLifetime := maxConnLifetimeVar.Load()
 	db.SetConnMaxLifetime(maxConnLifetime)
 
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
 	rruntime.Go(func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():

--- a/utils/misc/dbutils_test.go
+++ b/utils/misc/dbutils_test.go
@@ -146,6 +146,7 @@ func TestCommonPool(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	conf.Set("db.test.pool.configUpdateInterval", 10*time.Millisecond)
 	db, err := misc.NewDatabaseConnectionPool(ctx, conf, stats.NOP, "test")
 	require.NoError(t, err)
 	require.NoError(t, db.Ping())
@@ -153,7 +154,6 @@ func TestCommonPool(t *testing.T) {
 	require.Equal(t, 40, db.Stats().MaxOpenConnections)
 
 	conf.Set("db.test.pool.maxOpenConnections", 5)
-	time.Sleep(10 * time.Second)
+	time.Sleep(100 * time.Millisecond)
 	require.Equal(t, 5, db.Stats().MaxOpenConnections)
-	t.Log()
 }

--- a/utils/misc/dbutils_test.go
+++ b/utils/misc/dbutils_test.go
@@ -1,6 +1,7 @@
 package misc_test
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
@@ -127,4 +129,31 @@ func TestIdleTxTimeout(t *testing.T) {
 
 		require.NoError(t, tx.Commit())
 	})
+}
+
+func TestCommonPool(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	postgresContainer, err := postgres.Setup(pool, t)
+	require.NoError(t, err)
+
+	conf := config.New()
+	conf.Set("DB.host", postgresContainer.Host)
+	conf.Set("DB.user", postgresContainer.User)
+	conf.Set("DB.name", postgresContainer.Database)
+	conf.Set("DB.port", postgresContainer.Port)
+	conf.Set("DB.password", postgresContainer.Password)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db, err := misc.NewDatabaseConnectionPool(ctx, conf, stats.NOP, "test")
+	require.NoError(t, err)
+	require.NoError(t, db.Ping())
+	defer db.Close()
+	require.Equal(t, 40, db.Stats().MaxOpenConnections)
+
+	conf.Set("db.test.pool.maxOpenConnections", 5)
+	time.Sleep(10 * time.Second)
+	require.Equal(t, 5, db.Stats().MaxOpenConnections)
+	t.Log()
 }


### PR DESCRIPTION
# Description

Due to early ticker stop, the common db pool config couldn't hot-reload.

## Linear Ticket

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
