### PR TITLE
feat: adds client side load balancing support for transformer requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -288,6 +288,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/rs/zerolog v1.33.0 // indirect
+	github.com/rudderlabs/cslb v0.0.0-20241022023330-a4acff3d7b42
 	github.com/rudderlabs/goqu/v10 v10.3.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1164,6 +1164,8 @@ github.com/rudderlabs/bing-ads-go-sdk v0.2.3 h1:jR85Ep6X6SkiesaI7Q7WJHs/65SgByZb
 github.com/rudderlabs/bing-ads-go-sdk v0.2.3/go.mod h1:38Yig/202ni4GcloXhaTeH1LqUyFPEx6iljnFa+IDQI=
 github.com/rudderlabs/compose-test v0.1.3 h1:uyep6jDCIF737sfv4zIaMsKRQKX95IDz5Xbxor+x0kU=
 github.com/rudderlabs/compose-test v0.1.3/go.mod h1:tuvS1eQdSfwOYv1qwyVAcpdJxPLQXJgy5xGDd/9XmMg=
+github.com/rudderlabs/cslb v0.0.0-20241022023330-a4acff3d7b42 h1:GaVIxHlLdetHjwv4unLCtoRCriT4+kE4m+exC+6VyKc=
+github.com/rudderlabs/cslb v0.0.0-20241022023330-a4acff3d7b42/go.mod h1:1dVMz4io4JnPCXNF7xmsTukgwGN6tiA6lyNFNhgdHn8=
 github.com/rudderlabs/goqu/v10 v10.3.1 h1:rnfX+b4EwBWQ2UQfIGeEW299JBBkK5biEbnf7Kq4/Gg=
 github.com/rudderlabs/goqu/v10 v10.3.1/go.mod h1:LH2vI5gGHBxEQuESqFyk5ZA2anGINc8o25hbidDWOYw=
 github.com/rudderlabs/parquet-go v0.0.2 h1:ZXRdZdimB0PdJtmxeSSxfI0fDQ3kZjwzBxRi6Ut1J8k=

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 
+	"github.com/rudderlabs/cslb"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
@@ -493,6 +494,11 @@ func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration, c
 		MaxIdleConnsPerHost: config.GetInt("Transformer.Client.maxHTTPIdleConnections", 10),
 		IdleConnTimeout:     30 * time.Second,
 	}
+	if config.GetBool("Transformer.Client.cslbEnabled", false) {
+		cslb.Setup()
+		cslb.Enable(trans.tr)
+	}
+
 	// The timeout between server and transformer
 	// Basically this timeout is more for communication between transformer and server
 	trans.transformTimeout = transformTimeout

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -495,6 +495,10 @@ func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration, c
 		IdleConnTimeout:     30 * time.Second,
 	}
 	if config.GetBool("Transformer.Client.cslbEnabled", false) {
+		// Reduce the TTL to 10 seconds from the default 5 minutes to account for frequent evictions of the transformer
+		os.Setenv("cslb_srv_ttl", fmt.Sprintf("%v", 10*time.Second))
+		// Disable the health checks in CSLB in lieu of health checks performed by k8s readiness probes
+		os.Setenv("cslb_options", "H")
 		cslb.Setup()
 		cslb.Enable(trans.tr)
 	}


### PR DESCRIPTION
# Description
We noticed uneven load distribution to upstream transformation services due to long lived connections along with lack of native load balancing in k8s. So, we will try to move to client side load balancing using the forked library https://github.com/rudderlabs/cslb. 

## Linear Ticket
resolves PIPE-1642
https://linear.app/rudderstack/issue/PIPE-1642/client-side-load-balancing-for-server-transformer-communication

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
