### PR TITLE
chore: preTransformation is it's own concurrnet step

### DIFF
--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -1020,13 +1020,6 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 				},
 			)
 
-			Expect(c.MockObserver.calls).To(HaveLen(1))
-			for _, v := range c.MockObserver.calls {
-				for _, e := range v.events {
-					Expect(e.Metadata.TrackingPlanId).To(BeEquivalentTo("tracking-plan-id"))
-					Expect(e.Metadata.TrackingPlanVersion).To(BeEquivalentTo(100)) // from DgSourceTrackingPlanConfig
-				}
-			}
 		})
 		It("Tracking plan version override from context.ruddertyper", func() {
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
@@ -1100,14 +1093,6 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 					},
 				},
 			)
-
-			Expect(c.MockObserver.calls).To(HaveLen(1))
-			for _, v := range c.MockObserver.calls {
-				for _, e := range v.events {
-					Expect(e.Metadata.TrackingPlanId).To(BeEquivalentTo("tracking-plan-id"))
-					Expect(e.Metadata.TrackingPlanVersion).To(BeEquivalentTo(123)) // Overridden happens when tracking plan id is same in context.ruddertyper and DgSourceTrackingPlanConfig
-				}
-			}
 		})
 	})
 })
@@ -1305,8 +1290,6 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 					subJobs: unprocessedJobsList,
 				},
 			)
-
-			Expect(c.MockObserver.calls).To(HaveLen(1))
 		})
 
 		It("should process events and write to event schemas DB with enableParallelScan", func() {
@@ -1476,8 +1459,6 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 					subJobs: unprocessedJobsList,
 				},
 			)
-
-			Expect(c.MockObserver.calls).To(HaveLen(1))
 		})
 	})
 })
@@ -1661,8 +1642,6 @@ var _ = Describe("Processor with ArchivalV2 enabled", Ordered, func() {
 					subJobs: unprocessedJobsList,
 				},
 			)
-
-			Expect(c.MockObserver.calls).To(HaveLen(1))
 		})
 
 		It("should process events and write to archival DB with parallelScan", func() {
@@ -1818,8 +1797,6 @@ var _ = Describe("Processor with ArchivalV2 enabled", Ordered, func() {
 					subJobs: unprocessedJobsList,
 				},
 			)
-
-			Expect(c.MockObserver.calls).To(HaveLen(1))
 		})
 
 		It("should skip writing events belonging to transient sources in archival DB", func() {
@@ -1969,8 +1946,6 @@ var _ = Describe("Processor with ArchivalV2 enabled", Ordered, func() {
 					subJobs: unprocessedJobsList,
 				},
 			)
-
-			Expect(c.MockObserver.calls).To(HaveLen(1))
 		})
 	})
 })

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -971,7 +971,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
 
-			_, _ = processor.processJobsForDest(
+			_ = processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: []*jobsdb.JobT{
@@ -1046,7 +1046,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
 
-			_, _ = processor.processJobsForDest(
+			_ = processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: []*jobsdb.JobT{
@@ -1299,7 +1299,7 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 			defer cancel()
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
-			_, _ = processor.processJobsForDest(
+			_ = processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: unprocessedJobsList,
@@ -1470,7 +1470,7 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 			defer cancel()
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
-			_, _ = processor.processJobsForDest(
+			_ = processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: unprocessedJobsList,
@@ -1655,7 +1655,7 @@ var _ = Describe("Processor with ArchivalV2 enabled", Ordered, func() {
 			defer cancel()
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
-			_, _ = processor.processJobsForDest(
+			_ = processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: unprocessedJobsList,
@@ -1812,7 +1812,7 @@ var _ = Describe("Processor with ArchivalV2 enabled", Ordered, func() {
 			defer cancel()
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
-			_, _ = processor.processJobsForDest(
+			_ = processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: unprocessedJobsList,
@@ -1963,7 +1963,7 @@ var _ = Describe("Processor with ArchivalV2 enabled", Ordered, func() {
 			defer cancel()
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
-			_, _ = processor.processJobsForDest(
+			_ = processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: unprocessedJobsList,
@@ -3343,7 +3343,6 @@ var _ = Describe("Processor", Ordered, func() {
 						"2001-01-02T02:23:45.000Z",
 						[]mockEventData{
 							messages["message-some-id-2"],
-							messages["message-some-id-1"],
 						},
 						createMessagePayloadWithSameMessageId,
 					),
@@ -3375,7 +3374,6 @@ var _ = Describe("Processor", Ordered, func() {
 			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), gomock.Any()).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1)
 			c.MockDedup.EXPECT().GetBatch(gomock.Any()).Return(map[dedupTypes.KeyValue]bool{
 				{Key: "message-some-id", Value: 230, JobID: 1010, WorkspaceID: ""}: true,
-				{Key: "message-some-id", Value: 246, JobID: 1010, WorkspaceID: ""}: true,
 				{Key: "message-some-id", Value: 246, JobID: 2010, WorkspaceID: ""}: true,
 			}, nil, nil).After(callUnprocessed).AnyTimes()
 			c.MockDedup.EXPECT().Commit(gomock.Any()).Times(1)
@@ -3386,7 +3384,7 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockRouterJobsDB.EXPECT().WithStoreSafeTx(gomock.Any(), gomock.Any()).Do(func(ctx context.Context, f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())
 			}).Return(nil).Times(1)
-			callStoreRouter := c.mockRouterJobsDB.EXPECT().StoreInTx(gomock.Any(), gomock.Any(), gomock.Len(3)).Times(1)
+			callStoreRouter := c.mockRouterJobsDB.EXPECT().StoreInTx(gomock.Any(), gomock.Any(), gomock.Len(2)).Times(1)
 
 			c.mockArchivalDB.EXPECT().WithStoreSafeTx(gomock.Any(), gomock.Any()).AnyTimes().Do(func(ctx context.Context, f func(tx jobsdb.StoreSafeTx) error) {
 				_ = f(jobsdb.EmptyStoreSafeTx())

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -971,7 +971,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
 
-			_ = processor.processJobsForDest(
+			_ = processor.generateTransformationMessage(processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: []*jobsdb.JobT{
@@ -1018,7 +1018,15 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 						},
 					},
 				},
-			)
+			))
+
+			Expect(c.MockObserver.calls).To(HaveLen(1))
+			for _, v := range c.MockObserver.calls {
+				for _, e := range v.events {
+					Expect(e.Metadata.TrackingPlanId).To(BeEquivalentTo("tracking-plan-id"))
+					Expect(e.Metadata.TrackingPlanVersion).To(BeEquivalentTo(100)) // from DgSourceTrackingPlanConfig
+				}
+			}
 
 		})
 		It("Tracking plan version override from context.ruddertyper", func() {
@@ -1039,7 +1047,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
 
-			_ = processor.processJobsForDest(
+			_ = processor.generateTransformationMessage(processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: []*jobsdb.JobT{
@@ -1092,7 +1100,15 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 						},
 					},
 				},
-			)
+			))
+
+			Expect(c.MockObserver.calls).To(HaveLen(1))
+			for _, v := range c.MockObserver.calls {
+				for _, e := range v.events {
+					Expect(e.Metadata.TrackingPlanId).To(BeEquivalentTo("tracking-plan-id"))
+					Expect(e.Metadata.TrackingPlanVersion).To(BeEquivalentTo(123)) // Overridden happens when tracking plan id is same in context.ruddertyper and DgSourceTrackingPlanConfig
+				}
+			}
 		})
 	})
 })
@@ -1284,12 +1300,14 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 			defer cancel()
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
-			_ = processor.processJobsForDest(
+			_ = processor.generateTransformationMessage(processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: unprocessedJobsList,
 				},
-			)
+			))
+
+			Expect(c.MockObserver.calls).To(HaveLen(1))
 		})
 
 		It("should process events and write to event schemas DB with enableParallelScan", func() {
@@ -1453,12 +1471,14 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 			defer cancel()
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
-			_ = processor.processJobsForDest(
+			_ = processor.generateTransformationMessage(processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: unprocessedJobsList,
 				},
-			)
+			))
+
+			Expect(c.MockObserver.calls).To(HaveLen(1))
 		})
 	})
 })
@@ -1636,12 +1656,14 @@ var _ = Describe("Processor with ArchivalV2 enabled", Ordered, func() {
 			defer cancel()
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
-			_ = processor.processJobsForDest(
+			_ = processor.generateTransformationMessage(processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: unprocessedJobsList,
 				},
-			)
+			))
+
+			Expect(c.MockObserver.calls).To(HaveLen(1))
 		})
 
 		It("should process events and write to archival DB with parallelScan", func() {
@@ -1791,12 +1813,14 @@ var _ = Describe("Processor with ArchivalV2 enabled", Ordered, func() {
 			defer cancel()
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
-			_ = processor.processJobsForDest(
+			_ = processor.generateTransformationMessage(processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: unprocessedJobsList,
 				},
-			)
+			))
+
+			Expect(c.MockObserver.calls).To(HaveLen(1))
 		})
 
 		It("should skip writing events belonging to transient sources in archival DB", func() {
@@ -1940,12 +1964,14 @@ var _ = Describe("Processor with ArchivalV2 enabled", Ordered, func() {
 			defer cancel()
 			Expect(processor.config.asyncInit.WaitContext(ctx)).To(BeNil())
 			GinkgoT().Log("Processor setup and init done")
-			_ = processor.processJobsForDest(
+			_ = processor.generateTransformationMessage(processor.processJobsForDest(
 				"",
 				subJob{
 					subJobs: unprocessedJobsList,
 				},
-			)
+			))
+
+			Expect(c.MockObserver.calls).To(HaveLen(1))
 		})
 	})
 })

--- a/processor/worker.go
+++ b/processor/worker.go
@@ -46,7 +46,7 @@ type worker struct {
 	}
 	channel struct { // worker channels
 		preprocess   chan subJob                    // preprocess channel is used to send jobs to preprocess asynchronously when pipelining is enabled
-		preTransform chan *preTransformationMessage // pre-transform step - deduplication, validation, store to arc, esch
+		preTransform chan *preTransformationMessage // pre-transform step - validation, store to arc, esch
 		transform    chan *transformationMessage    // transform channel is used to send jobs to transform asynchronously when pipelining is enabled
 		store        chan *storeMessage             // store channel is used to send jobs to store asynchronously when pipelining is enabled
 	}

--- a/processor/worker_handle.go
+++ b/processor/worker_handle.go
@@ -23,8 +23,9 @@ type workerHandle interface {
 	getJobs(partition string) jobsdb.JobsResult
 	markExecuting(partition string, jobs []*jobsdb.JobT) error
 	jobSplitter(jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []subJob
-	processJobsForDest(partition string, subJobs subJob) (*transformationMessage, error)
-	processJobsForDestV2(partition string, subJobs subJob) (*transformationMessage, error)
+	processJobsForDest(partition string, subJobs subJob) *preTransformationMessage
+	processJobsForDestV2(partition string, subJobs subJob) *preTransformationMessage
+	generateTransformationMessage(*preTransformationMessage) *transformationMessage
 	transformations(partition string, in *transformationMessage) *storeMessage
 	Store(partition string, in *storeMessage)
 }


### PR DESCRIPTION
# Description

separate `preTransform` into its own concurrent step.
Allows us to separate out initial preprocessing(dedup, destination filtering) and following steps(store to arc, esch; validation; multiplexing).


## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
