### PR TITLE
fix: address flaky marketo test

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/marketo-bulk-upload/utils_test.go
+++ b/router/batchrouter/asyncdestinationmanager/marketo-bulk-upload/utils_test.go
@@ -380,9 +380,9 @@ func TestCreateCSVFile(t *testing.T) {
 				// Check header
 				if scanner.Scan() {
 					headerLine := scanner.Text()
-					expectedHeader := strings.Join(tt.wantHeaders, ",")
-					if headerLine != expectedHeader {
-						t.Errorf("createCSVFile() header = %v, want %v", headerLine, expectedHeader)
+					generatedHeaders := strings.Join(gotHeaders, ",")
+					if headerLine != generatedHeaders {
+						t.Errorf("createCSVFile() header from file and generated = %v, want %v", headerLine, generatedHeaders)
 					}
 				}
 


### PR DESCRIPTION
# Description

This PR address the flaky marketo utils unit tests, where headers are compared which are written in csv and output from the function.



## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
