### PR TITLE
feat: optional oauth support

### DIFF
--- a/services/oauth/oauth.go
+++ b/services/oauth/oauth.go
@@ -32,6 +32,7 @@ type (
 
 const (
 	OAuth           AuthType = "OAuth"
+	OptionalOAuth   AuthType = "optionalAuth"
 	InvalidAuthType AuthType = "InvalidAuthType"
 
 	RudderFlow_Delivery RudderFlow = "delivery"

--- a/services/oauth/oauth.go
+++ b/services/oauth/oauth.go
@@ -32,7 +32,7 @@ type (
 
 const (
 	OAuth           AuthType = "OAuth"
-	OptionalOAuth   AuthType = "optionalAuth"
+	OptionalOAuth   AuthType = "optionalOAuth"
 	InvalidAuthType AuthType = "InvalidAuthType"
 
 	RudderFlow_Delivery RudderFlow = "delivery"

--- a/services/oauth/v2/destination_info.go
+++ b/services/oauth/v2/destination_info.go
@@ -19,7 +19,7 @@ type DestinationInfo struct {
 	Config           map[string]interface{}
 }
 
-func (d *DestinationInfo) isOptionalOAuth(flow common.RudderFlow) bool {
+func (d *DestinationInfo) IsOptionalOAuth(flow common.RudderFlow) bool {
 	authTypeValue, _ := misc.NestedMapLookup(d.DefinitionConfig, "auth", "type")
 	if authTypeValue == nil {
 		return false
@@ -49,7 +49,7 @@ func (d *DestinationInfo) isOAuth(flow common.RudderFlow) (bool, error) {
 		// we should throw error here, as we expect authValue to be a string if present
 		return false, fmt.Errorf("auth type is not a string: %v", authValue)
 	}
-	isScopeSupported, err := d.IsOAuthSupportedForFlow(string(flow))
+	isScopeSupported, err := d.isOAuthSupportedForFlow(string(flow))
 	if err != nil {
 		return false, err
 	}
@@ -61,11 +61,11 @@ func (d *DestinationInfo) IsOAuthDestination(flow common.RudderFlow) (bool, erro
 	if err != nil {
 		return false, err
 	}
-	isOptionalOAuth := d.isOptionalOAuth(flow)
+	isOptionalOAuth := d.IsOptionalOAuth(flow)
 	return isOAuth || isOptionalOAuth, nil
 }
 
-func (d *DestinationInfo) IsOAuthSupportedForFlow(flow string) (bool, error) {
+func (d *DestinationInfo) isOAuthSupportedForFlow(flow string) (bool, error) {
 	rudderScopesValue, _ := misc.NestedMapLookup(d.DefinitionConfig, "auth", "rudderScopes")
 	if rudderScopesValue == nil {
 		// valid use-case for non-OAuth destinations

--- a/services/oauth/v2/destination_info.go
+++ b/services/oauth/v2/destination_info.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/samber/lo"
 
@@ -18,7 +19,26 @@ type DestinationInfo struct {
 	Config           map[string]interface{}
 }
 
-func (d *DestinationInfo) IsOAuthDestination(flow common.RudderFlow) (bool, error) {
+func (d *DestinationInfo) isOptionalOAuth(flow common.RudderFlow) bool {
+	authTypeValue, _ := misc.NestedMapLookup(d.DefinitionConfig, "auth", "type")
+	if authTypeValue == nil {
+		return false
+	}
+	authType, ok := authTypeValue.(string)
+	if !ok {
+		return false
+	}
+	accountID, err := d.GetAccountID(flow)
+	if err != nil {
+		return false
+	}
+	if strings.TrimSpace(accountID) == "" {
+		return false
+	}
+	return authType == string(oauth.OptionalOAuth)
+}
+
+func (d *DestinationInfo) isOAuth(flow common.RudderFlow) (bool, error) {
 	authValue, _ := misc.NestedMapLookup(d.DefinitionConfig, "auth", "type")
 	if authValue == nil {
 		// valid use-case for non-OAuth destinations
@@ -34,6 +54,15 @@ func (d *DestinationInfo) IsOAuthDestination(flow common.RudderFlow) (bool, erro
 		return false, err
 	}
 	return authType == string(oauth.OAuth) && isScopeSupported, nil
+}
+
+func (d *DestinationInfo) IsOAuthDestination(flow common.RudderFlow) (bool, error) {
+	isOAuth, err := d.isOAuth(flow)
+	if err != nil {
+		return false, err
+	}
+	isOptionalOAuth := d.isOptionalOAuth(flow)
+	return isOAuth || isOptionalOAuth, nil
 }
 
 func (d *DestinationInfo) IsOAuthSupportedForFlow(flow string) (bool, error) {
@@ -66,22 +95,17 @@ Example:
 `GetAccountID(common.RudderFlowDelivery)` --> To be used when we make use of OAuth during normal event delivery
 */
 func (d *DestinationInfo) GetAccountID(flow common.RudderFlow) (string, error) {
-	oauthDest, err := d.IsOAuthDestination(flow)
-	if err != nil {
-		return "", fmt.Errorf("failed to check if destination is oauth destination: %v", err)
-	}
-
 	idKey := common.DeliveryAccountIDKey
 	if flow == common.RudderFlowDelete {
 		idKey = common.DeleteAccountIDKey
 	}
 	rudderAccountIdInterface, found := d.Config[idKey]
-	if !oauthDest || !found || idKey == "" {
+	if !found || idKey == "" {
 		return "", fmt.Errorf("destination is not an oauth destination or accountId not found")
 	}
 	rudderAccountId, ok := rudderAccountIdInterface.(string)
 	if !ok {
-		return "", fmt.Errorf("rudderAccountId is not a string")
+		return "", fmt.Errorf("%s is not a string", idKey)
 	}
 	return rudderAccountId, nil
 }

--- a/services/oauth/v2/destination_info_test.go
+++ b/services/oauth/v2/destination_info_test.go
@@ -115,7 +115,7 @@ var isOAuthDestTestCases = []destInfoTestCase{
 		flow:        common.RudderFlowDelivery,
 		inputDefConfig: map[string]interface{}{
 			"auth": map[string]interface{}{
-				"type": "optionalAuth",
+				"type": "optionalOAuth",
 			},
 		},
 		Config: map[string]interface{}{
@@ -130,7 +130,7 @@ var isOAuthDestTestCases = []destInfoTestCase{
 		flow:        common.RudderFlowDelivery,
 		inputDefConfig: map[string]interface{}{
 			"auth": map[string]interface{}{
-				"type": "optionalAuth",
+				"type": "optionalOAuth",
 			},
 		},
 		Config: map[string]interface{}{},

--- a/services/oauth/v2/destination_info_test.go
+++ b/services/oauth/v2/destination_info_test.go
@@ -19,6 +19,7 @@ type destInfoTestCase struct {
 	description    string
 	flow           common.RudderFlow
 	inputDefConfig map[string]interface{}
+	Config         map[string]interface{}
 	expected       isOAuthResult
 }
 
@@ -109,6 +110,34 @@ var isOAuthDestTestCases = []destInfoTestCase{
 			isOAuth: false,
 		},
 	},
+	{
+		description: "should return 'true' for optionalOAuth destination when flow is delivery and rudderAccountId is present",
+		flow:        common.RudderFlowDelivery,
+		inputDefConfig: map[string]interface{}{
+			"auth": map[string]interface{}{
+				"type": "optionalAuth",
+			},
+		},
+		Config: map[string]interface{}{
+			"rudderAccountId": "123",
+		},
+		expected: isOAuthResult{
+			isOAuth: true,
+		},
+	},
+	{
+		description: "should return 'false' for optionalOAuth destination when flow is delivery and rudderAccountId is empty",
+		flow:        common.RudderFlowDelivery,
+		inputDefConfig: map[string]interface{}{
+			"auth": map[string]interface{}{
+				"type": "optionalAuth",
+			},
+		},
+		Config: map[string]interface{}{},
+		expected: isOAuthResult{
+			isOAuth: false,
+		},
+	},
 }
 
 var _ = Describe("DestinationInfo tests", func() {
@@ -119,6 +148,9 @@ var _ = Describe("DestinationInfo tests", func() {
 					DefinitionName: "dest_def_name",
 				}
 				d.DefinitionConfig = tc.inputDefConfig
+				if len(tc.Config) > 0 {
+					d.Config = tc.Config
+				}
 				isOAuth, err := d.IsOAuthDestination(tc.flow)
 
 				Expect(isOAuth).To(Equal(tc.expected.isOAuth))

--- a/services/oauth/v2/destination_info_test.go
+++ b/services/oauth/v2/destination_info_test.go
@@ -138,6 +138,20 @@ var isOAuthDestTestCases = []destInfoTestCase{
 			isOAuth: false,
 		},
 	},
+	{
+		description: "should return 'false' when auth.type is not a string",
+		flow:        common.RudderFlowDelivery,
+		inputDefConfig: map[string]interface{}{
+			"auth": map[string]interface{}{
+				"type": 2,
+			},
+		},
+		Config: map[string]interface{}{},
+		expected: isOAuthResult{
+			isOAuth: false,
+			err:     fmt.Errorf("auth type is not a string: 2"),
+		},
+	},
 }
 
 var _ = Describe("DestinationInfo tests", func() {
@@ -161,5 +175,51 @@ var _ = Describe("DestinationInfo tests", func() {
 				}
 			})
 		}
+	})
+
+	Describe("GetAccountID tests", func() {
+		It("should return accountID for a valid OAuth destination for delivery flow", func() {
+			d := &v2.DestinationInfo{
+				DefinitionName: "dest_def_name",
+				Config: map[string]interface{}{
+					"rudderAccountId": "123",
+				},
+			}
+			accountID, err := d.GetAccountID(common.RudderFlowDelivery)
+			Expect(accountID).To(Equal("123"))
+			Expect(err).To(BeNil())
+		})
+
+		It("should return error when auth.type is not a string for delivery flow", func() {
+			d := &v2.DestinationInfo{
+				DefinitionName: "dest_def_name",
+			}
+			accountID, err := d.GetAccountID(common.RudderFlowDelivery)
+			Expect(accountID).To(Equal(""))
+			Expect(err).To(MatchError("destination is not an oauth destination or accountId not found"))
+		})
+
+		It("should return error when accountID is not a string for delivery flow", func() {
+			d := &v2.DestinationInfo{
+				DefinitionName: "dest_def_name",
+				Config: map[string]interface{}{
+					"rudderAccountId": 123,
+				},
+			}
+			accountID, err := d.GetAccountID(common.RudderFlowDelivery)
+			Expect(accountID).To(Equal(""))
+			Expect(err).To(MatchError("rudderAccountId is not a string"))
+		})
+		It("should return error when accountID is not found for delete flow", func() {
+			d := &v2.DestinationInfo{
+				DefinitionName: "dest_def_name",
+				Config: map[string]interface{}{
+					"rudderDeleteAccountId": 123,
+				},
+			}
+			accountID, err := d.GetAccountID(common.RudderFlowDelete)
+			Expect(accountID).To(Equal(""))
+			Expect(err).To(MatchError("rudderDeleteAccountId is not a string"))
+		})
 	})
 })

--- a/services/oauth/v2/destination_info_test.go
+++ b/services/oauth/v2/destination_info_test.go
@@ -222,4 +222,32 @@ var _ = Describe("DestinationInfo tests", func() {
 			Expect(err).To(MatchError("rudderDeleteAccountId is not a string"))
 		})
 	})
+
+	Describe("IsOptionalOAuth tests", func() {
+		It("should return true when auth.type is optionalOAuth & rudderAccountId is present", func() {
+			d := &v2.DestinationInfo{
+				DefinitionConfig: map[string]interface{}{
+					"auth": map[string]interface{}{"type": "optionalOAuth"},
+				},
+				Config: map[string]interface{}{
+					"rudderAccountId": "123",
+				},
+			}
+			Expect(d.IsOptionalOAuth(common.RudderFlowDelivery)).To(BeTrue())
+		})
+
+		It("should return false when auth.type is not optionalOAuth", func() {
+			d := &v2.DestinationInfo{
+				DefinitionConfig: map[string]interface{}{"auth": map[string]interface{}{"type": "OAuth"}},
+			}
+			Expect(d.IsOptionalOAuth(common.RudderFlowDelivery)).To(BeFalse())
+		})
+
+		It("should return false when auth.type is not a string", func() {
+			d := &v2.DestinationInfo{
+				DefinitionConfig: map[string]interface{}{"auth": map[string]interface{}{"type": 2}},
+			}
+			Expect(d.IsOptionalOAuth(common.RudderFlowDelivery)).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
# Description

Currently we would be attach OAuth framework specific things when we identify(`auth.type`) from the destination definition config to be `OAuth`, which would mean user would be restricted to go ahead with only `OAuth` not anything else.

In the past there have been use-cases where a destination would need to support multiple authentication mechanisms. We would need to provide multiple authentication mechanisms in the UI
In order to fulfil this, we have added `auth.type` as `optionalAuth` in the destination definition config. We are using this to identify if a destination optionally selected `OAuth` & also confirm if account id information is available in destination.config for attaching OAuth framework specific things


## Linear Ticket

Resolves INT-2832

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
