### PR TITLE
fix: silent ignore of 4xx errors from reporting

### DIFF
--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -583,11 +583,7 @@ func (r *DefaultReporter) sendMetric(ctx context.Context, netClient *http.Client
 }
 
 func isMetricPosted(status int) bool {
-	if status == 429 {
-		return false
-	}
-
-	return status >= 200 && status < 500
+	return status >= 200 && status < 300
 }
 
 func getPIIColumnsToExclude() []string {


### PR DESCRIPTION
# Description

We are currently ignoring 4XX errors from reporting service (for example due to payload too large or invalid sourceDefinitionId value). This result in reports being silently dropped without generating any alert. 

By treating 4XX as failure, we ensure that reports are retired, allowing us to detect and receive alerts for high 4XX rates or report backlogs.

## Linear Ticket

https://linear.app/rudderstack/issue/OBS-711/fix-silent-ignore-of-400-errors-in-reporting-service

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
