### PR TITLE
chore: remove unused columns from scylla

### DIFF
--- a/mocks/services/dedup/mock_dedup.go
+++ b/mocks/services/dedup/mock_dedup.go
@@ -66,13 +66,12 @@ func (mr *MockDedupMockRecorder) Commit(arg0 any) *gomock.Call {
 }
 
 // Get mocks base method.
-func (m *MockDedup) Get(arg0 types.KeyValue) (bool, int64, error) {
+func (m *MockDedup) Get(arg0 types.KeyValue) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(int64)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
@@ -82,13 +81,12 @@ func (mr *MockDedupMockRecorder) Get(arg0 any) *gomock.Call {
 }
 
 // GetBatch mocks base method.
-func (m *MockDedup) GetBatch(arg0 []types.KeyValue) (map[types.KeyValue]bool, map[types.KeyValue]int64, error) {
+func (m *MockDedup) GetBatch(arg0 []types.KeyValue) (map[types.KeyValue]bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBatch", arg0)
 	ret0, _ := ret[0].(map[types.KeyValue]bool)
-	ret1, _ := ret[1].(map[types.KeyValue]int64)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetBatch indicates an expected call of GetBatch.

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -3262,7 +3262,7 @@ var _ = Describe("Processor", Ordered, func() {
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 
 			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), gomock.Any()).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1)
-			c.MockDedup.EXPECT().Get(gomock.Any()).Return(true, int64(0), nil).After(callUnprocessed).AnyTimes()
+			c.MockDedup.EXPECT().Get(gomock.Any()).Return(true, nil).After(callUnprocessed).AnyTimes()
 			c.MockDedup.EXPECT().Commit(gomock.Any()).Times(1)
 
 			// We expect one transform call to destination A, after callUnprocessed.
@@ -3374,10 +3374,9 @@ var _ = Describe("Processor", Ordered, func() {
 
 			callUnprocessed := c.mockGatewayJobsDB.EXPECT().GetUnprocessed(gomock.Any(), gomock.Any()).Return(jobsdb.JobsResult{Jobs: unprocessedJobsList}, nil).Times(1)
 			c.MockDedup.EXPECT().GetBatch(gomock.Any()).Return(map[dedupTypes.KeyValue]bool{
-				{Key: "message-some-id", Value: 230, JobID: 1010, WorkspaceID: ""}: true,
-				{Key: "message-some-id", Value: 246, JobID: 1010, WorkspaceID: ""}: true,
-				{Key: "message-some-id", Value: 246, JobID: 2010, WorkspaceID: ""}: true,
-			}, nil, nil).After(callUnprocessed).AnyTimes()
+				{Key: "message-some-id", JobID: 1010, WorkspaceID: ""}: true,
+				{Key: "message-some-id", JobID: 2010, WorkspaceID: ""}: true,
+			}, nil).After(callUnprocessed).AnyTimes()
 			c.MockDedup.EXPECT().Commit(gomock.Any()).Times(1)
 
 			// We expect one transform call to destination A, after callUnprocessed.

--- a/services/dedup/badger/badger_test.go
+++ b/services/dedup/badger/badger_test.go
@@ -24,34 +24,34 @@ func Test_Badger(t *testing.T) {
 	require.NotNil(t, badger)
 	defer badger.Close()
 	t.Run("Same messageID should be deduped from badger", func(t *testing.T) {
-		key1 := types.KeyValue{Key: "a", Value: 1, WorkspaceID: "test"}
-		key2 := types.KeyValue{Key: "a", Value: 1, WorkspaceID: "test"}
-		notAvailable, _, err := badger.Get(key1)
+		key1 := types.KeyValue{Key: "a", WorkspaceID: "test"}
+		key2 := types.KeyValue{Key: "a", WorkspaceID: "test"}
+		notAvailable, err := badger.Get(key1)
 		require.NoError(t, err)
 		require.True(t, notAvailable)
 		err = badger.Commit([]string{key1.Key})
 		require.NoError(t, err)
-		notAvailable, _, err = badger.Get(key2)
+		notAvailable, err = badger.Get(key2)
 		require.NoError(t, err)
 		require.False(t, notAvailable)
 	})
 	t.Run("Same messageID should be deduped from cache", func(t *testing.T) {
-		key1 := types.KeyValue{Key: "b", Value: 1, WorkspaceID: "test"}
-		key2 := types.KeyValue{Key: "b", Value: 1, WorkspaceID: "test"}
-		found, _, err := badger.Get(key1)
+		key1 := types.KeyValue{Key: "b", WorkspaceID: "test"}
+		key2 := types.KeyValue{Key: "b", WorkspaceID: "test"}
+		found, err := badger.Get(key1)
 		require.NoError(t, err)
 		require.True(t, found)
-		found, _, err = badger.Get(key2)
+		found, err = badger.Get(key2)
 		require.NoError(t, err)
 		require.False(t, found)
 	})
 	t.Run("different messageID should not be deduped for batch", func(t *testing.T) {
 		keys := []types.KeyValue{
-			{Key: "c", Value: 1, WorkspaceID: "test"},
-			{Key: "d", Value: 1, WorkspaceID: "test"},
-			{Key: "e", Value: 1, WorkspaceID: "test"},
+			{Key: "c", WorkspaceID: "test"},
+			{Key: "d", WorkspaceID: "test"},
+			{Key: "e", WorkspaceID: "test"},
 		}
-		found, _, err := badger.GetBatch(keys)
+		found, err := badger.GetBatch(keys)
 		require.NoError(t, err)
 		require.Len(t, found, 3)
 		for _, key := range keys {
@@ -60,16 +60,16 @@ func Test_Badger(t *testing.T) {
 	})
 	t.Run("same messageID should be deduped for batch", func(t *testing.T) {
 		keys := []types.KeyValue{
-			{Key: "f", Value: 1, WorkspaceID: "test", JobID: 3},
-			{Key: "f", Value: 1, WorkspaceID: "test", JobID: 4},
-			{Key: "g", Value: 1, WorkspaceID: "test", JobID: 5},
+			{Key: "f", WorkspaceID: "test", JobID: 3},
+			{Key: "f", WorkspaceID: "test", JobID: 4},
+			{Key: "g", WorkspaceID: "test", JobID: 5},
 		}
 		expected := map[types.KeyValue]bool{
 			keys[0]: true,
 			keys[1]: false,
 			keys[2]: true,
 		}
-		found, _, err := badger.GetBatch(keys)
+		found, err := badger.GetBatch(keys)
 		require.NoError(t, err)
 		require.Len(t, found, 3)
 		for _, key := range keys {

--- a/services/dedup/dedup.go
+++ b/services/dedup/dedup.go
@@ -49,10 +49,10 @@ func New(conf *config.Config, stats stats.Stats) (Dedup, error) {
 // Dedup is the interface for deduplication service
 type Dedup interface {
 	// Get returns [true] if it was the first time the key was encountered, otherwise it returns [false] along with the previous value
-	Get(kv types.KeyValue) (bool, int64, error)
+	Get(kv types.KeyValue) (bool, error)
 
 	// GetBatch
-	GetBatch(kvs []types.KeyValue) (map[types.KeyValue]bool, map[types.KeyValue]int64, error)
+	GetBatch(kvs []types.KeyValue) (map[types.KeyValue]bool, error)
 
 	// Commit commits a list of previously set keys to the DB
 	Commit(keys []string) error

--- a/services/dedup/dedup_test.go
+++ b/services/dedup/dedup_test.go
@@ -67,33 +67,31 @@ func Test_Dedup(t *testing.T) {
 			defer d.Close()
 
 			t.Run("if message id is not present in cache and badger db", func(t *testing.T) {
-				found, _, err := d.Get(types.KeyValue{Key: "a", Value: 1, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
+				found, err := d.Get(types.KeyValue{Key: "a", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
 				require.NoError(t, err)
 				require.Equal(t, true, found)
 
 				// Checking it again should give us the previous value from the cache
-				found, value, err := d.Get(types.KeyValue{Key: "a", Value: 2, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
+				found, err = d.Get(types.KeyValue{Key: "a", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
 				require.Nil(t, err)
 				require.Equal(t, false, found)
-				require.Equal(t, int64(1), value)
 			})
 
 			t.Run("if message is committed, previous value should always return", func(t *testing.T) {
-				found, _, err := d.Get(types.KeyValue{Key: "b", Value: 1, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
+				found, err := d.Get(types.KeyValue{Key: "b", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
 				require.Nil(t, err)
 				require.Equal(t, true, found)
 
 				err = d.Commit([]string{"a"})
 				require.NoError(t, err)
 
-				found, value, err := d.Get(types.KeyValue{Key: "b", Value: 2, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
+				found, err = d.Get(types.KeyValue{Key: "b", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
 				require.Nil(t, err)
 				require.Equal(t, false, found)
-				require.Equal(t, int64(1), value)
 			})
 
 			t.Run("committing a messageid not present in cache", func(t *testing.T) {
-				found, _, err := d.Get(types.KeyValue{Key: "c", Value: 1, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
+				found, err := d.Get(types.KeyValue{Key: "c", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
 				require.Nil(t, err)
 				require.Equal(t, true, found)
 
@@ -103,11 +101,11 @@ func Test_Dedup(t *testing.T) {
 
 			t.Run("test GetBatch with unique keys", func(t *testing.T) {
 				kvs := []types.KeyValue{
-					{Key: "e", Value: 1, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"},
-					{Key: "f", Value: 1, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"},
-					{Key: "g", Value: 1, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"},
+					{Key: "e", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"},
+					{Key: "f", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"},
+					{Key: "g", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"},
 				}
-				found, _, err := d.GetBatch(kvs)
+				found, err := d.GetBatch(kvs)
 				require.Nil(t, err)
 				require.Len(t, found, 3)
 				for _, kv := range kvs {
@@ -119,16 +117,16 @@ func Test_Dedup(t *testing.T) {
 
 			t.Run("test GetBatch with non-unique keys", func(t *testing.T) {
 				kvs := []types.KeyValue{
-					{Key: "g", Value: 1, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh", JobID: 3},
-					{Key: "h", Value: 1, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh", JobID: 4},
-					{Key: "h", Value: 1, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh", JobID: 5},
+					{Key: "g", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh", JobID: 3},
+					{Key: "h", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh", JobID: 4},
+					{Key: "h", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh", JobID: 5},
 				}
 				expected := map[types.KeyValue]bool{
 					kvs[0]: false,
 					kvs[1]: true,
 					kvs[2]: false,
 				}
-				found, _, err := d.GetBatch(kvs)
+				found, err := d.GetBatch(kvs)
 				require.Nil(t, err)
 				require.Len(t, found, 3)
 				for _, kv := range kvs {
@@ -156,19 +154,19 @@ func Test_Dedup_Window(t *testing.T) {
 	require.Nil(t, err)
 	defer d.Close()
 
-	found, _, err := d.Get(types.KeyValue{Key: "to be deleted", Value: 1, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
+	found, err := d.Get(types.KeyValue{Key: "to be deleted", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
 	require.Nil(t, err)
 	require.Equal(t, true, found)
 
 	err = d.Commit([]string{"to be deleted"})
 	require.NoError(t, err)
 
-	found, _, err = d.Get(types.KeyValue{Key: "to be deleted", Value: 2, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
+	found, err = d.Get(types.KeyValue{Key: "to be deleted", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
 	require.Nil(t, err)
 	require.Equal(t, false, found)
 
 	require.Eventually(t, func() bool {
-		found, _, err = d.Get(types.KeyValue{Key: "to be deleted", Value: 3, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
+		found, err = d.Get(types.KeyValue{Key: "to be deleted", WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
 		require.Nil(t, err)
 		return found
 	}, 2*time.Second, 100*time.Millisecond)
@@ -180,7 +178,7 @@ func Test_Dedup_ErrTxnTooBig(t *testing.T) {
 	misc.Init()
 
 	dbPath := os.TempDir() + "/dedup_test_errtxntoobig"
-	defer os.RemoveAll(dbPath)
+	defer func() { _ = os.RemoveAll(dbPath) }()
 	conf := config.New()
 	t.Setenv("RUDDER_TMPDIR", dbPath)
 	d, err := dedup.New(conf, stats.Default)
@@ -192,7 +190,7 @@ func Test_Dedup_ErrTxnTooBig(t *testing.T) {
 	for i := 0; i < size; i++ {
 		key := uuid.New().String()
 		messages[i] = key
-		_, _, _ = d.Get(types.KeyValue{Key: key, Value: int64(i + 1), WorkspaceID: "test"})
+		_, _ = d.Get(types.KeyValue{Key: key, WorkspaceID: "test"})
 	}
 	err = d.Commit(messages)
 	require.NoError(t, err)
@@ -221,13 +219,12 @@ func Benchmark_Dedup(b *testing.B) {
 			key := uuid.New().String()
 			msgIDs[i%batchSize] = types.KeyValue{
 				Key:         key,
-				Value:       int64(i + 1),
 				WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh",
 			}
 			keys = append(keys, key)
 			if i%batchSize == batchSize-1 || i == b.N-1 {
 				for _, msgID := range msgIDs[:i%batchSize] {
-					_, _, _ = d.Get(msgID)
+					_, _ = d.Get(msgID)
 				}
 				err := d.Commit(keys)
 				require.NoError(b, err)
@@ -295,7 +292,7 @@ func Benchmark_DedupModes(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				key := uuid.New().String()
-				_, _, err = d.Get(types.KeyValue{Key: key, Value: int64(i + 1), WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
+				_, err = d.Get(types.KeyValue{Key: key, WorkspaceID: "2DAZvjf8PEMrAkbVm6smqEJnh"})
 				require.NoError(b, err)
 				err = d.Commit([]string{key})
 				require.NoError(b, err)

--- a/services/dedup/mirrorBadger/mirrorBadger.go
+++ b/services/dedup/mirrorBadger/mirrorBadger.go
@@ -32,19 +32,19 @@ func (mb *MirrorBadger) Close() {
 	mb.badger.Close()
 }
 
-func (mb *MirrorBadger) GetBatch(kvs []types.KeyValue) (map[types.KeyValue]bool, map[types.KeyValue]int64, error) {
+func (mb *MirrorBadger) GetBatch(kvs []types.KeyValue) (map[types.KeyValue]bool, error) {
 	defer mb.stat.NewTaggedStat("dedup_get_batch_duration_seconds", stats.TimerType, stats.Tags{"mode": "mirror_badger"}).RecordDuration()()
-	_, _, err := mb.scylla.GetBatch(kvs)
+	_, err := mb.scylla.GetBatch(kvs)
 	if err != nil {
 		mb.stat.NewTaggedStat("dedup_mirror_badger_get_batch_error", stats.CountType, stats.Tags{}).Increment()
 	}
 	return mb.badger.GetBatch(kvs)
 }
 
-func (mb *MirrorBadger) Get(kv types.KeyValue) (bool, int64, error) {
+func (mb *MirrorBadger) Get(kv types.KeyValue) (bool, error) {
 	defer mb.stat.NewTaggedStat("dedup_get_duration_seconds", stats.TimerType, stats.Tags{"mode": "mirror_badger"}).RecordDuration()()
 
-	_, _, err := mb.scylla.Get(kv)
+	_, err := mb.scylla.Get(kv)
 	if err != nil {
 		mb.stat.NewTaggedStat("dedup_mirror_badger_get_error", stats.CountType, stats.Tags{}).Increment()
 	}

--- a/services/dedup/mirrorBadger/mirrorBadger_test.go
+++ b/services/dedup/mirrorBadger/mirrorBadger_test.go
@@ -41,40 +41,40 @@ func Test_MirrorBadger(t *testing.T) {
 	require.NotNil(t, mirrorBadger)
 	defer mirrorBadger.Close()
 	t.Run("Same messageID should be deduped from badger", func(t *testing.T) {
-		key1 := types.KeyValue{Key: "a", Value: 1, WorkspaceID: "test"}
-		key2 := types.KeyValue{Key: "a", Value: 1, WorkspaceID: "test"}
-		found, _, err := mirrorBadger.Get(key1)
+		key1 := types.KeyValue{Key: "a", WorkspaceID: "test"}
+		key2 := types.KeyValue{Key: "a", WorkspaceID: "test"}
+		found, err := mirrorBadger.Get(key1)
 		require.Nil(t, err)
 		require.True(t, found)
 		err = mirrorBadger.Commit([]string{key1.Key})
 		require.NoError(t, err)
-		found, _, err = mirrorBadger.Get(key2)
+		found, err = mirrorBadger.Get(key2)
 		require.Nil(t, err)
 		require.False(t, found)
-		found, _, err = mirrorBadger.scylla.Get(key1)
+		found, err = mirrorBadger.scylla.Get(key1)
 		require.Nil(t, err)
 		require.False(t, found)
-		found, _, err = mirrorBadger.badger.Get(key1)
+		found, err = mirrorBadger.badger.Get(key1)
 		require.Nil(t, err)
 		require.False(t, found)
 	})
 	t.Run("Same messageID should be deduped from cache", func(t *testing.T) {
-		key1 := types.KeyValue{Key: "b", Value: 1, WorkspaceID: "test"}
-		key2 := types.KeyValue{Key: "b", Value: 1, WorkspaceID: "test"}
-		found, _, err := mirrorBadger.Get(key1)
+		key1 := types.KeyValue{Key: "b", WorkspaceID: "test"}
+		key2 := types.KeyValue{Key: "b", WorkspaceID: "test"}
+		found, err := mirrorBadger.Get(key1)
 		require.Nil(t, err)
 		require.True(t, found)
-		found, _, err = mirrorBadger.Get(key2)
+		found, err = mirrorBadger.Get(key2)
 		require.Nil(t, err)
 		require.False(t, found)
 	})
 	t.Run("different messageID should not be deduped for batch", func(t *testing.T) {
 		keys := []types.KeyValue{
-			{Key: "c", Value: 1, WorkspaceID: "test"},
-			{Key: "d", Value: 1, WorkspaceID: "test"},
-			{Key: "e", Value: 1, WorkspaceID: "test"},
+			{Key: "c", WorkspaceID: "test"},
+			{Key: "d", WorkspaceID: "test"},
+			{Key: "e", WorkspaceID: "test"},
 		}
-		found, _, err := mirrorBadger.GetBatch(keys)
+		found, err := mirrorBadger.GetBatch(keys)
 		require.NoError(t, err)
 		require.Len(t, found, 3)
 		for _, key := range keys {
@@ -83,16 +83,16 @@ func Test_MirrorBadger(t *testing.T) {
 	})
 	t.Run("same messageID should be deduped for batch", func(t *testing.T) {
 		keys := []types.KeyValue{
-			{Key: "f", Value: 1, WorkspaceID: "test", JobID: 3},
-			{Key: "f", Value: 1, WorkspaceID: "test", JobID: 4},
-			{Key: "g", Value: 1, WorkspaceID: "test", JobID: 5},
+			{Key: "f", WorkspaceID: "test", JobID: 3},
+			{Key: "f", WorkspaceID: "test", JobID: 4},
+			{Key: "g", WorkspaceID: "test", JobID: 5},
 		}
 		expected := map[types.KeyValue]bool{
 			keys[0]: true,
 			keys[1]: false,
 			keys[2]: true,
 		}
-		found, _, err := mirrorBadger.GetBatch(keys)
+		found, err := mirrorBadger.GetBatch(keys)
 		require.NoError(t, err)
 		require.Len(t, found, 3)
 		for _, key := range keys {

--- a/services/dedup/mirrorScylla/mirrorScylla.go
+++ b/services/dedup/mirrorScylla/mirrorScylla.go
@@ -32,19 +32,19 @@ func (ms *MirrorScylla) Close() {
 	ms.badger.Close()
 }
 
-func (ms *MirrorScylla) GetBatch(kvs []types.KeyValue) (map[types.KeyValue]bool, map[types.KeyValue]int64, error) {
+func (ms *MirrorScylla) GetBatch(kvs []types.KeyValue) (map[types.KeyValue]bool, error) {
 	defer ms.stat.NewTaggedStat("dedup_get_batch_duration_seconds", stats.TimerType, stats.Tags{"mode": "mirror_scylla"}).RecordDuration()()
-	_, _, err := ms.badger.GetBatch(kvs)
+	_, err := ms.badger.GetBatch(kvs)
 	if err != nil {
 		ms.stat.NewTaggedStat("dedup_mirror_scylla_get_batch_error", stats.CountType, stats.Tags{}).Increment()
 	}
 	return ms.scylla.GetBatch(kvs)
 }
 
-func (ms *MirrorScylla) Get(kv types.KeyValue) (bool, int64, error) {
+func (ms *MirrorScylla) Get(kv types.KeyValue) (bool, error) {
 	defer ms.stat.NewTaggedStat("dedup_get_duration_seconds", stats.TimerType, stats.Tags{"mode": "mirror_scylla"}).RecordDuration()()
 
-	_, _, err := ms.badger.Get(kv)
+	_, err := ms.badger.Get(kv)
 	if err != nil {
 		ms.stat.NewTaggedStat("dedup_mirror_scylla_get_error", stats.CountType, stats.Tags{}).Increment()
 	}

--- a/services/dedup/mirrorScylla/mirrorScylla_test.go
+++ b/services/dedup/mirrorScylla/mirrorScylla_test.go
@@ -41,54 +41,54 @@ func Test_MirrorBadger(t *testing.T) {
 	require.NotNil(t, mirrorScylla)
 	defer mirrorScylla.Close()
 	t.Run("Same messageID should not be deduped for different workspace", func(t *testing.T) {
-		key1 := types.KeyValue{Key: "a", Value: 1, WorkspaceID: "test1"}
-		key2 := types.KeyValue{Key: "a", Value: 1, WorkspaceID: "test2"}
-		found, _, err := mirrorScylla.Get(key1)
+		key1 := types.KeyValue{Key: "a", WorkspaceID: "test1"}
+		key2 := types.KeyValue{Key: "a", WorkspaceID: "test2"}
+		found, err := mirrorScylla.Get(key1)
 		require.Nil(t, err)
 		require.True(t, found)
 		err = mirrorScylla.Commit([]string{key1.Key})
 		require.NoError(t, err)
-		found, _, err = mirrorScylla.Get(key2)
+		found, err = mirrorScylla.Get(key2)
 		require.Nil(t, err)
 		require.True(t, found)
 		err = mirrorScylla.Commit([]string{key2.Key})
 		require.NoError(t, err)
 	})
 	t.Run("Same messageID should be deduped for same workspace", func(t *testing.T) {
-		key1 := types.KeyValue{Key: "a", Value: 1, WorkspaceID: "test"}
-		key2 := types.KeyValue{Key: "a", Value: 1, WorkspaceID: "test"}
-		found, _, err := mirrorScylla.Get(key1)
+		key1 := types.KeyValue{Key: "a", WorkspaceID: "test"}
+		key2 := types.KeyValue{Key: "a", WorkspaceID: "test"}
+		found, err := mirrorScylla.Get(key1)
 		require.Nil(t, err)
 		require.True(t, found)
 		err = mirrorScylla.Commit([]string{key1.Key})
 		require.NoError(t, err)
-		found, _, err = mirrorScylla.Get(key2)
+		found, err = mirrorScylla.Get(key2)
 		require.Nil(t, err)
 		require.False(t, found)
-		found, _, err = mirrorScylla.scylla.Get(key1)
+		found, err = mirrorScylla.scylla.Get(key1)
 		require.Nil(t, err)
 		require.False(t, found)
-		found, _, err = mirrorScylla.badger.Get(key1)
+		found, err = mirrorScylla.badger.Get(key1)
 		require.Nil(t, err)
 		require.False(t, found)
 	})
 	t.Run("Same messageID should be deduped for same workspace from cache", func(t *testing.T) {
-		key1 := types.KeyValue{Key: "b", Value: 1, WorkspaceID: "test"}
-		key2 := types.KeyValue{Key: "b", Value: 1, WorkspaceID: "test"}
-		found, _, err := mirrorScylla.Get(key1)
+		key1 := types.KeyValue{Key: "b", WorkspaceID: "test"}
+		key2 := types.KeyValue{Key: "b", WorkspaceID: "test"}
+		found, err := mirrorScylla.Get(key1)
 		require.Nil(t, err)
 		require.True(t, found)
-		found, _, err = mirrorScylla.Get(key2)
+		found, err = mirrorScylla.Get(key2)
 		require.Nil(t, err)
 		require.False(t, found)
 	})
 	t.Run("different messageID should not be deduped for batch", func(t *testing.T) {
 		keys := []types.KeyValue{
-			{Key: "c", Value: 1, WorkspaceID: "test"},
-			{Key: "d", Value: 1, WorkspaceID: "test"},
-			{Key: "e", Value: 1, WorkspaceID: "test"},
+			{Key: "c", WorkspaceID: "test"},
+			{Key: "d", WorkspaceID: "test"},
+			{Key: "e", WorkspaceID: "test"},
 		}
-		found, _, err := mirrorScylla.GetBatch(keys)
+		found, err := mirrorScylla.GetBatch(keys)
 		require.NoError(t, err)
 		require.Len(t, found, 3)
 		for _, key := range keys {
@@ -97,16 +97,16 @@ func Test_MirrorBadger(t *testing.T) {
 	})
 	t.Run("same messageID should be deduped for batch", func(t *testing.T) {
 		keys := []types.KeyValue{
-			{Key: "f", Value: 1, WorkspaceID: "test", JobID: 3},
-			{Key: "f", Value: 1, WorkspaceID: "test", JobID: 4},
-			{Key: "g", Value: 1, WorkspaceID: "test", JobID: 5},
+			{Key: "f", WorkspaceID: "test", JobID: 3},
+			{Key: "f", WorkspaceID: "test", JobID: 4},
+			{Key: "g", WorkspaceID: "test", JobID: 5},
 		}
 		expected := map[types.KeyValue]bool{
 			keys[0]: true,
 			keys[1]: false,
 			keys[2]: true,
 		}
-		found, _, err := mirrorScylla.GetBatch(keys)
+		found, err := mirrorScylla.GetBatch(keys)
 		require.NoError(t, err)
 		require.Len(t, found, 3)
 		for _, key := range keys {

--- a/services/dedup/scylla/scylla_test.go
+++ b/services/dedup/scylla/scylla_test.go
@@ -32,53 +32,53 @@ func Test_Scylla(t *testing.T) {
 	require.NotNil(t, scylla)
 	defer scylla.Close()
 	t.Run("Same messageID should not be deduped for different workspace", func(t *testing.T) {
-		key1 := types.KeyValue{Key: "a", Value: 1, WorkspaceID: "test1"}
-		key2 := types.KeyValue{Key: "a", Value: 1, WorkspaceID: "test2"}
-		found, _, err := scylla.Get(key1)
+		key1 := types.KeyValue{Key: "a", WorkspaceID: "test1"}
+		key2 := types.KeyValue{Key: "a", WorkspaceID: "test2"}
+		found, err := scylla.Get(key1)
 		require.Nil(t, err)
 		require.True(t, found)
 		err = scylla.Commit([]string{key1.Key})
 		require.NoError(t, err)
-		found, _, err = scylla.Get(key2)
+		found, err = scylla.Get(key2)
 		require.Nil(t, err)
 		require.True(t, found)
 		err = scylla.Commit([]string{key2.Key})
 		require.NoError(t, err)
 	})
 	t.Run("Same messageID should be deduped for same workspace", func(t *testing.T) {
-		key1 := types.KeyValue{Key: "a", Value: 1, WorkspaceID: "test"}
-		key2 := types.KeyValue{Key: "a", Value: 1, WorkspaceID: "test"}
-		found, _, err := scylla.Get(key1)
+		key1 := types.KeyValue{Key: "a", WorkspaceID: "test"}
+		key2 := types.KeyValue{Key: "a", WorkspaceID: "test"}
+		found, err := scylla.Get(key1)
 		require.NoError(t, err)
 		require.True(t, found)
 		err = scylla.Commit([]string{key1.Key})
 		require.NoError(t, err)
-		found, _, err = scylla.Get(key2)
+		found, err = scylla.Get(key2)
 		require.NoError(t, err)
 		require.False(t, found)
 	})
 	t.Run("Same messageID should be deduped for same workspace from cache", func(t *testing.T) {
-		key1 := types.KeyValue{Key: "b", Value: 1, WorkspaceID: "test"}
-		key2 := types.KeyValue{Key: "b", Value: 1, WorkspaceID: "test"}
-		found, _, err := scylla.Get(key1)
+		key1 := types.KeyValue{Key: "b", WorkspaceID: "test"}
+		key2 := types.KeyValue{Key: "b", WorkspaceID: "test"}
+		found, err := scylla.Get(key1)
 		require.NoError(t, err)
 		require.True(t, found)
-		found, _, err = scylla.Get(key2)
+		found, err = scylla.Get(key2)
 		require.NoError(t, err)
 		require.False(t, found)
 	})
 	t.Run("Same messageID should be deduped for same workspace from cache for Batch call", func(t *testing.T) {
 		keys := []types.KeyValue{
-			{Key: "c", Value: 1, WorkspaceID: "test", JobID: 1},
-			{Key: "c", Value: 1, WorkspaceID: "test", JobID: 2},
-			{Key: "d", Value: 1, WorkspaceID: "test", JobID: 3},
+			{Key: "c", WorkspaceID: "test", JobID: 1},
+			{Key: "c", WorkspaceID: "test", JobID: 2},
+			{Key: "d", WorkspaceID: "test", JobID: 3},
 		}
 		expected := map[types.KeyValue]bool{
 			keys[0]: true,
 			keys[1]: false,
 			keys[2]: true,
 		}
-		found, _, err := scylla.GetBatch(keys)
+		found, err := scylla.GetBatch(keys)
 		require.NoError(t, err)
 		require.Len(t, found, 3)
 		for _, key := range keys {
@@ -89,11 +89,11 @@ func Test_Scylla(t *testing.T) {
 	})
 	t.Run("Different messageID should not be deduped for same workspace", func(t *testing.T) {
 		keys := []types.KeyValue{
-			{Key: "e", Value: 1, WorkspaceID: "test", JobID: 1},
-			{Key: "f", Value: 1, WorkspaceID: "test", JobID: 2},
-			{Key: "g", Value: 1, WorkspaceID: "test", JobID: 3},
+			{Key: "e", WorkspaceID: "test", JobID: 1},
+			{Key: "f", WorkspaceID: "test", JobID: 2},
+			{Key: "g", WorkspaceID: "test", JobID: 3},
 		}
-		found, _, err := scylla.GetBatch(keys)
+		found, err := scylla.GetBatch(keys)
 		require.NoError(t, err)
 		require.Len(t, found, 3)
 		for _, key := range keys {
@@ -102,9 +102,9 @@ func Test_Scylla(t *testing.T) {
 	})
 	t.Run("Same messageID should not be deduped for different workspace", func(t *testing.T) {
 		keys := []types.KeyValue{
-			{Key: "h", Value: 1, WorkspaceID: "test1", JobID: 1},
+			{Key: "h", WorkspaceID: "test1", JobID: 1},
 		}
-		found, _, err := scylla.GetBatch(keys)
+		found, err := scylla.GetBatch(keys)
 		require.NoError(t, err)
 		require.Len(t, found, 1)
 		for _, key := range keys {
@@ -113,9 +113,9 @@ func Test_Scylla(t *testing.T) {
 		err = scylla.Commit([]string{"h"})
 		require.NoError(t, err)
 		keys = []types.KeyValue{
-			{Key: "h", Value: 1, WorkspaceID: "test2", JobID: 1},
+			{Key: "h", WorkspaceID: "test2", JobID: 1},
 		}
-		found, _, err = scylla.GetBatch(keys)
+		found, err = scylla.GetBatch(keys)
 		require.NoError(t, err)
 		require.Len(t, found, 1)
 		for _, key := range keys {
@@ -147,7 +147,7 @@ func Benchmark_ScyllaGet(b *testing.B) {
 			for j := 0; j < 100; j++ {
 				key := uuid.New().String()
 				keys = append(keys, key)
-				_, _, err = scylla.Get(types.KeyValue{Key: key, Value: 1, WorkspaceID: "test", JobID: int64(i*100 + j)})
+				_, err = scylla.Get(types.KeyValue{Key: key, WorkspaceID: "test", JobID: int64(i*100 + j)})
 				require.NoError(b, err)
 			}
 			err = scylla.Commit(keys)
@@ -160,10 +160,10 @@ func Benchmark_ScyllaGet(b *testing.B) {
 			var commitKeys []string
 			for j := 0; j < 100; j++ {
 				key := uuid.New().String()
-				keys = append(keys, types.KeyValue{Key: key, Value: 1, WorkspaceID: "test", JobID: int64(i*100 + j)})
+				keys = append(keys, types.KeyValue{Key: key, WorkspaceID: "test", JobID: int64(i*100 + j)})
 				commitKeys = append(commitKeys, key)
 			}
-			_, _, err = scylla.GetBatch(keys)
+			_, err = scylla.GetBatch(keys)
 			require.NoError(b, err)
 			err = scylla.Commit(commitKeys)
 			require.NoError(b, err)

--- a/services/dedup/types/types.go
+++ b/services/dedup/types/types.go
@@ -2,7 +2,6 @@ package types
 
 type KeyValue struct {
 	Key         string
-	Value       int64
 	WorkspaceID string
 	JobID       int64
 }


### PR DESCRIPTION
# Description

This PR aims to 
- Get rid of the fields timestamp and size field in scylla table
- Change the contract to remove the size field from dedup interface
- Minor fixes in processor

## Linear Ticket

Fixes PIPE-1700

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
