### PR TITLE
fix: too many concurrent timer firings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # syntax=docker/dockerfile:1
 
 # GO_VERSION is updated automatically to match go.mod, see Makefile
-ARG GO_VERSION=1.23.2
+ARG GO_VERSION=1.23.3
 ARG ALPINE_VERSION=3.20
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 ARG VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudderlabs/rudder-server
 
-go 1.23.2
+go 1.23.3
 
 // Addressing snyk vulnerabilities in indirect dependencies
 // When upgrading a dependency, please make sure that

--- a/suppression-backup-service/Dockerfile
+++ b/suppression-backup-service/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # GO_VERSION is updated automatically to match go.mod, see Makefile
-ARG GO_VERSION=1.23.2
+ARG GO_VERSION=1.23.3
 ARG ALPINE_VERSION=3.20
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 RUN mkdir /app


### PR DESCRIPTION
# Description

Upgrade to Go1.23.3, to address fatal crash observe in production.

https://github.com/golang/go/issues/69882

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1723/fix-fatal-error-too-many-concurrent-timer-firings

resolves PIPE-1723

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
