### PR TITLE
feat: send one sample event / response per label set to reporting

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -249,3 +249,7 @@ PgNotifier:
   retriggerCount: 500
   trackBatchInterval: 2s
   maxAttempt: 3
+Reporting:
+  eventSamplingEnabled: true
+  eventSamplingDurationInMinutes: 60
+  eventSamplingCardinality: 100000000 # 100M

--- a/enterprise/reporting/event_sampler.go
+++ b/enterprise/reporting/event_sampler.go
@@ -1,0 +1,52 @@
+package reporting
+
+import (
+	"sync"
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/cachettl"
+	"github.com/rudderlabs/rudder-go-kit/config"
+)
+
+type EventSampler[K comparable] struct {
+	cache  *cachettl.Cache[K, bool]
+	mu     sync.Mutex
+	ttl    config.ValueLoader[time.Duration]
+	limit  config.ValueLoader[int]
+	length int
+}
+
+func NewEventSampler[K comparable](ttl config.ValueLoader[time.Duration], limit config.ValueLoader[int]) *EventSampler[K] {
+	c := cachettl.New[K, bool](cachettl.WithNoRefreshTTL)
+
+	es := &EventSampler[K]{
+		cache:  c,
+		ttl:    ttl,
+		limit:  limit,
+		length: 0,
+	}
+
+	es.cache.OnEvicted(func(key K, value bool) {
+		es.length--
+	})
+
+	return es
+}
+
+func (es *EventSampler[K]) Get(key K) (ok bool) {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	value := es.cache.Get(key)
+	return value
+}
+
+func (es *EventSampler[K]) Put(key K) {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	if es.length >= es.limit.Load() {
+		return
+	}
+
+	es.cache.Put(key, true, es.ttl.Load())
+	es.length++
+}

--- a/enterprise/reporting/event_sampler_test.go
+++ b/enterprise/reporting/event_sampler_test.go
@@ -1,0 +1,59 @@
+package reporting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPutAndGet(t *testing.T) {
+	conf := config.New()
+	ttl := conf.GetReloadableDurationVar(1, time.Second, "Reporting.eventSamplingDurationInMinutes")
+	limit := conf.GetReloadableIntVar(3, 1, "Reporting.eventSamplingCardinality")
+
+	es := NewEventSampler[string](ttl, limit)
+
+	es.Put("key1")
+	es.Put("key2")
+	es.Put("key3")
+
+	assert.True(t, es.Get("key1"), "Expected key1 to be present")
+	assert.True(t, es.Get("key2"), "Expected key2 to be present")
+	assert.True(t, es.Get("key3"), "Expected key3 to be present")
+
+	es.Put("key4")
+	assert.False(t, es.Get("key4"), "Expected key4 not to be added as limit is reached")
+}
+
+func TestLimitEnforcement(t *testing.T) {
+	conf := config.New()
+	ttl := conf.GetReloadableDurationVar(1, time.Second, "Reporting.eventSamplingDurationInMinutes")
+	limit := conf.GetReloadableIntVar(2, 1, "Reporting.eventSamplingCardinality")
+
+	es := NewEventSampler[string](ttl, limit)
+
+	es.Put("key1")
+	es.Put("key2")
+	es.Put("key3")
+
+	assert.Equal(t, 2, es.length, "Expected length to be 2 due to limit")
+	assert.True(t, es.Get("key1"), "Expected key1 to be present")
+	assert.True(t, es.Get("key2"), "Expected key2 to be present")
+	assert.False(t, es.Get("key3"), "Expected key3 not to be present as limit was reached")
+}
+
+func TestEvictionOnTTLExpiry(t *testing.T) {
+	conf := config.New()
+	ttl := conf.GetReloadableDurationVar(500, time.Millisecond, "Reporting.eventSamplingDurationInMinutes")
+	limit := conf.GetReloadableIntVar(3, 1, "Reporting.eventSamplingCardinality")
+
+	es := NewEventSampler[string](ttl, limit)
+
+	es.Put("key1")
+	time.Sleep(600 * time.Millisecond)
+
+	assert.False(t, es.Get("key1"), "Expected key1 to be evicted after TTL expiry")
+	assert.Equal(t, 0, es.length, "Expected length to be 0 after TTL expiry eviction")
+}

--- a/enterprise/reporting/label_set.go
+++ b/enterprise/reporting/label_set.go
@@ -1,0 +1,69 @@
+package reporting
+
+import (
+	"encoding/hex"
+	"strconv"
+
+	"github.com/rudderlabs/rudder-server/utils/types"
+	"github.com/spaolacci/murmur3"
+)
+
+type LabelSet struct {
+	WorkspaceID string
+	// Namespace               string
+	// InstanceID              string
+	SourceDefinitionID      string
+	SourceCategory          string
+	SourceID                string
+	DestinationDefinitionID string
+	DestinationID           string
+	SourceTaskRunID         string
+	SourceJobID             string
+	SourceJobRunID          string
+	TransformationID        string
+	TransformationVersionID string
+	TrackingPlanID          string
+	TrackingPlanVersion     int
+	InPU                    string
+	PU                      string
+	Status                  string
+	TerminalState           bool
+	InitialState            bool
+	StatusCode              int
+	EventName               string
+	EventType               string
+	ErrorType               string
+}
+
+func NewLabelSet(metric types.PUReportedMetric) LabelSet {
+	return LabelSet{
+		WorkspaceID:             metric.ConnectionDetails.SourceID,
+		SourceDefinitionID:      metric.ConnectionDetails.SourceDefinitionId,
+		SourceCategory:          metric.ConnectionDetails.SourceCategory,
+		SourceID:                metric.ConnectionDetails.SourceID,
+		DestinationDefinitionID: metric.ConnectionDetails.DestinationDefinitionId,
+		DestinationID:           metric.ConnectionDetails.DestinationID,
+		SourceTaskRunID:         metric.ConnectionDetails.SourceTaskRunID,
+		SourceJobID:             metric.ConnectionDetails.SourceJobID,
+		SourceJobRunID:          metric.ConnectionDetails.SourceJobRunID,
+		TransformationID:        metric.ConnectionDetails.TransformationID,
+		TransformationVersionID: metric.ConnectionDetails.TransformationVersionID,
+		TrackingPlanID:          metric.ConnectionDetails.TrackingPlanID,
+		TrackingPlanVersion:     metric.ConnectionDetails.TrackingPlanVersion,
+		InPU:                    metric.PUDetails.InPU,
+		PU:                      metric.PUDetails.PU,
+		Status:                  metric.StatusDetail.Status,
+		TerminalState:           metric.PUDetails.TerminalPU,
+		InitialState:            metric.PUDetails.InitialPU,
+		StatusCode:              metric.StatusDetail.StatusCode,
+		EventName:               metric.StatusDetail.EventName,
+		EventType:               metric.StatusDetail.EventType,
+		ErrorType:               metric.StatusDetail.ErrorType,
+	}
+}
+
+func (labelSet LabelSet) generateHash() string {
+	data := labelSet.WorkspaceID + labelSet.SourceDefinitionID + labelSet.SourceCategory + labelSet.SourceID + labelSet.DestinationDefinitionID + labelSet.DestinationID + labelSet.SourceTaskRunID + labelSet.SourceJobID + labelSet.SourceJobRunID + labelSet.TransformationID + labelSet.TransformationVersionID + labelSet.TrackingPlanID + strconv.Itoa(labelSet.TrackingPlanVersion) + labelSet.InPU + labelSet.PU + labelSet.Status + strconv.FormatBool(labelSet.TerminalState) + strconv.FormatBool(labelSet.InitialState) + strconv.Itoa(labelSet.StatusCode) + labelSet.EventName + labelSet.EventType + labelSet.ErrorType
+	hash := murmur3.Sum64([]byte(data))
+	return hex.EncodeToString([]byte(strconv.FormatUint(hash, 16)))
+}

--- a/enterprise/reporting/label_set_test.go
+++ b/enterprise/reporting/label_set_test.go
@@ -1,0 +1,76 @@
+package reporting
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-server/utils/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func createMetricObject(eventName string) types.PUReportedMetric {
+	return types.PUReportedMetric{
+		ConnectionDetails: types.ConnectionDetails{
+			SourceID:      "some-source-id",
+			DestinationID: "some-destination-id",
+		},
+		PUDetails: types.PUDetails{
+			InPU: "some-in-pu",
+			PU:   "some-pu",
+		},
+		StatusDetail: &types.StatusDetail{
+			Status:         "some-status",
+			Count:          3,
+			StatusCode:     0,
+			SampleResponse: `{"some-sample-response-key": "some-sample-response-value"}`,
+			SampleEvent:    []byte(`{"some-sample-event-key": "some-sample-event-value"}`),
+			EventName:      eventName,
+			EventType:      "some-event-type",
+		},
+	}
+}
+
+func TestNewLabelSet(t *testing.T) {
+	t.Run("should create the correct LabelSet from types.PUReportedMetric", func(t *testing.T) {
+		inputMetric := createMetricObject("some-event-name")
+		labelSet := NewLabelSet(inputMetric)
+
+		assert.Equal(t, "some-source-id", labelSet.SourceID)
+		assert.Equal(t, "some-event-name", labelSet.EventName) // Default value
+	})
+
+	t.Run("should create the correct LabelSet with custom EventName", func(t *testing.T) {
+		inputMetric := createMetricObject("custom-event-name")
+		labelSet := NewLabelSet(inputMetric)
+
+		assert.Equal(t, "some-source-id", labelSet.SourceID)
+		assert.Equal(t, "custom-event-name", labelSet.EventName) // Custom event name
+	})
+}
+
+func TestGenerateHash(t *testing.T) {
+	t.Run("same hash for same LabelSet", func(t *testing.T) {
+		inputMetric1 := createMetricObject("some-event-name")
+		labelSet1 := NewLabelSet(inputMetric1)
+
+		inputMetric2 := createMetricObject("some-event-name")
+		labelSet2 := NewLabelSet(inputMetric2)
+
+		hash1 := labelSet1.generateHash()
+		hash2 := labelSet2.generateHash()
+
+		assert.Equal(t, hash1, hash2)
+	})
+
+	t.Run("different hash for different LabelSet", func(t *testing.T) {
+		inputMetric1 := createMetricObject("some-event-name-1")
+		labelSet1 := NewLabelSet(inputMetric1)
+
+		inputMetric2 := createMetricObject("some-event-name-2")
+		labelSet2 := NewLabelSet(inputMetric2)
+
+		hash1 := labelSet1.generateHash()
+		hash2 := labelSet2.generateHash()
+
+		assert.NotEqual(t, hash1, hash2)
+	})
+}

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -625,10 +625,8 @@ func transformMetricForPII(metric types.PUReportedMetric, piiColumns []string) t
 
 func (r *DefaultReporter) transformMetricWithEventSampling(metric types.PUReportedMetric) types.PUReportedMetric {
 	isValidSampleEvent := metric.StatusDetail.SampleEvent != nil && string(metric.StatusDetail.SampleEvent) != "{}"
-	isValidSampleResponse := metric.StatusDetail.SampleResponse != ""
-	// TODO: Check if this is needed and if the validation is correct
 
-	if isValidSampleEvent && isValidSampleResponse {
+	if isValidSampleEvent {
 		hash := NewLabelSet(metric).generateHash()
 
 		if r.eventSampler.Get(hash) {


### PR DESCRIPTION
# Description
Send one sample event or response per LabelSet to reporting within the configured duration.
- Generate a hash for each report and store it in memory.
- If the hash is already present in the cache, do not resend the sample event or response. If the hash is not present, send the sample event/response.
- The hash stored in the cache expires after the configured TTL.
- Limit the number of keys stored in the cache. If the limit is exceeded, the hash will not be stored.

## Linear Ticket


## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
