### PR TITLE
fix: bq partitioning for additional columns

### DIFF
--- a/warehouse/integrations/bigquery/partition.go
+++ b/warehouse/integrations/bigquery/partition.go
@@ -17,9 +17,12 @@ var (
 )
 
 var supportedPartitionColumnMap = map[string]struct{}{
-	"_PARTITIONTIME": {},
-	"loaded_at":      {},
-	"received_at":    {},
+	"_PARTITIONTIME":     {},
+	"loaded_at":          {},
+	"received_at":        {},
+	"sent_at":            {},
+	"timestamp":          {},
+	"original_timestamp": {},
 }
 
 var supportedPartitionTypeMap = map[string]bigquery.TimePartitioningType{

--- a/warehouse/integrations/bigquery/partition_test.go
+++ b/warehouse/integrations/bigquery/partition_test.go
@@ -182,7 +182,28 @@ func TestBigQuery_AvoidPartitionDecorator(t *testing.T) {
 			avoidPartitionDecorator: true,
 		},
 		{
-			name: "ingenstion partition",
+			name: "sent_at partition",
+			destConfig: map[string]interface{}{
+				"partitionColumn": "sent_at",
+			},
+			avoidPartitionDecorator: true,
+		},
+		{
+			name: "timestamp partition",
+			destConfig: map[string]interface{}{
+				"partitionColumn": "timestamp",
+			},
+			avoidPartitionDecorator: true,
+		},
+		{
+			name: "original_timestamp partition",
+			destConfig: map[string]interface{}{
+				"partitionColumn": "received_at",
+			},
+			avoidPartitionDecorator: true,
+		},
+		{
+			name: "ingestion partition",
 			destConfig: map[string]interface{}{
 				"partitionColumn": "_PARTITIONTIME",
 			},


### PR DESCRIPTION
# Description

- BQ partitioning is used for additional columns like `sent_at`, `timestamp`, and `original_timestamp`.

## Linear Ticket

- Resolves PIPE-1731

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
