### PR TITLE
fix: exclude window feature for single-digit minute values (#5266)

### DIFF
--- a/utils/timeutil/timeutil.go
+++ b/utils/timeutil/timeutil.go
@@ -36,5 +36,5 @@ func Now() time.Time {
 func GetElapsedMinsInThisDay(currentTime time.Time) int {
 	hour := currentTime.Hour()
 	minute := currentTime.Minute()
-	return MinsOfDay(fmt.Sprintf("%d:%d", hour, minute))
+	return MinsOfDay(fmt.Sprintf("%02d:%02d", hour, minute))
 }

--- a/warehouse/router/scheduling_test.go
+++ b/warehouse/router/scheduling_test.go
@@ -144,6 +144,12 @@ func TestRouter_CanCreateUpload(t *testing.T) {
 				expectedValue: true,
 			},
 			{
+				currentTime:   time.Date(2009, time.November, 10, 5, 0o5, 0, 0, time.UTC),
+				windowStart:   "05:00",
+				windowEnd:     "06:00",
+				expectedValue: true,
+			},
+			{
 				currentTime:   time.Date(2009, time.November, 10, 5, 30, 0, 0, time.UTC),
 				windowStart:   "22:00",
 				windowEnd:     "06:00",


### PR DESCRIPTION
# Description

Fix exclude window handling for single-digit minute values

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
