### PR TITLE
fix: json marshal l errors when parsing poll response from klaviyo

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/apiService.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/apiService.go
@@ -59,6 +59,10 @@ func (k *KlaviyoAPIServiceImpl) UploadProfiles(profiles Payload) (*UploadResp, e
 	if len(uploadResp.Errors) > 0 {
 		return &uploadResp, fmt.Errorf("upload failed with errors: %+v", uploadResp.Errors)
 	}
+	if uploadResp.Data.Id == "" {
+		k.logger.Error("[klaviyo bulk upload] upload failed with empty importId", string(uploadBodyBytes))
+		return &uploadResp, fmt.Errorf("upload failed with empty importId")
+	}
 	uploadTimeStat := k.statsFactory.NewTaggedStat("async_upload_time", stats.TimerType, k.statLabels)
 	uploadTimeStat.Since(startTime)
 
@@ -66,6 +70,9 @@ func (k *KlaviyoAPIServiceImpl) UploadProfiles(profiles Payload) (*UploadResp, e
 }
 
 func (k *KlaviyoAPIServiceImpl) GetUploadStatus(importId string) (*PollResp, error) {
+	if importId == "" {
+		return nil, fmt.Errorf("importId is empty")
+	}
 	pollUrl := KlaviyoAPIURL + importId
 	req, err := http.NewRequest("GET", pollUrl, nil)
 	if err != nil {

--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
@@ -106,7 +106,9 @@ func (kbu *KlaviyoBulkUploader) Poll(pollInput common.AsyncPoll) common.PollStat
 	importStatuses := make(map[string]string)
 	failedImports := make([]string, 0)
 	for _, importId := range importIds {
-		importStatuses[importId] = "queued"
+		if importId != "" {
+			importStatuses[importId] = "queued"
+		}
 	}
 
 	for {
@@ -304,7 +306,7 @@ func (kbu *KlaviyoBulkUploader) Upload(asyncDestStruct *common.AsyncDestinationS
 		uploadResp, err := kbu.KlaviyoAPIService.UploadProfiles(combinedPayload)
 		if err != nil {
 			failedJobs = append(failedJobs, importingJobIDs[idx])
-			kbu.Logger.Error("Error while uploading profiles", err, uploadResp.Errors)
+			kbu.Logger.Error("Error while uploading profiles", err, uploadResp.Errors, destinationID)
 			continue
 		}
 


### PR DESCRIPTION
# Description
There is a bug in the Klaviyo implementation where, at times, we receive an empty import ID from the upload. However, when we poll with an empty import ID, we encounter parsing errors because Klaviyo returns a list response when the import ID is empty.

## Linear Ticket

https://linear.app/rudderstack/issue/INT-2820/klaviyo-bulk-upload-at-times-they-are-running-into-errors
Resolves INT-2820

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
