### PR TITLE
fix: disable vacuum at startup for reporting

### DIFF
--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -161,9 +161,11 @@ func (r *DefaultReporter) DatabaseSyncer(c types.SyncerConfig) types.ReportingSy
 	if !config.GetBool("Reporting.syncer.enabled", true) {
 		return func() {}
 	}
-	if _, err := dbHandle.ExecContext(context.Background(), `vacuum full analyze reports;`); err != nil {
-		r.log.Errorn(`[ Reporting ]: Error full vacuuming reports table`, logger.NewErrorField(err))
-		panic(err)
+	if config.GetBool("Reporting.syncer.vacuumAtStartup", false) {
+		if _, err := dbHandle.ExecContext(context.Background(), `vacuum full analyze reports;`); err != nil {
+			r.log.Errorn(`[ Reporting ]: Error full vacuuming reports table`, logger.NewErrorField(err))
+			panic(err)
+		}
 	}
 	return func() {
 		r.g.Go(func() error {


### PR DESCRIPTION
# Description

- Added flag for conditionally running vacuuming for reporting and error reporting at startup.

## Linear Ticket

Ref PIPE-1748

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
