### PR TITLE
refactor: error reporting to drive category from stats

### DIFF
--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -236,7 +236,7 @@ func (edr *ErrorDetailReporter) Report(ctx context.Context, metrics []*types.PUR
 		edr.log.Debugn("DestinationId & DestDetail details", obskit.DestinationID(metric.ConnectionDetails.DestinationID), logger.NewField("destinationDetail", destinationDetail))
 
 		// extract error-message & error-code
-		errDets := edr.extractErrorDetails(metric.StatusDetail.SampleResponse)
+		errDets := edr.extractErrorDetails(metric.StatusDetail.SampleResponse, metric.StatusDetail.StatTags)
 
 		edr.stats.NewTaggedStat("error_detail_reporting_failures", stats.CountType, stats.Tags{
 			"errorCode":     errDets.ErrorCode,
@@ -250,7 +250,7 @@ func (edr *ErrorDetailReporter) Report(ctx context.Context, metrics []*types.PUR
 			workspaceID,
 			edr.namespace,
 			edr.instanceID,
-			metric.ConnectionDetails.SourceDefinitionId,
+			metric.ConnectionDetails.SourceDefinitionID,
 			metric.ConnectionDetails.SourceID,
 			destinationDetail.destinationDefinitionID,
 			metric.ConnectionDetails.DestinationID,
@@ -309,10 +309,10 @@ func (edr *ErrorDetailReporter) migrate(c types.SyncerConfig) (*sql.DB, error) {
 	return dbHandle, nil
 }
 
-func (edr *ErrorDetailReporter) extractErrorDetails(sampleResponse string) errorDetails {
+func (edr *ErrorDetailReporter) extractErrorDetails(sampleResponse string, statTags map[string]string) errorDetails {
 	errMsg := edr.errorDetailExtractor.GetErrorMessage(sampleResponse)
 	cleanedErrMsg := edr.errorDetailExtractor.CleanUpErrorMessage(errMsg)
-	errorCode := edr.errorDetailExtractor.GetErrorCode(cleanedErrMsg)
+	errorCode := edr.errorDetailExtractor.GetErrorCode(cleanedErrMsg, statTags)
 	return errorDetails{
 		ErrorMessage: cleanedErrMsg,
 		ErrorCode:    errorCode,

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -230,10 +230,10 @@ func (r *DefaultReporter) getReports(currentMs int64, syncerKey string) (reports
 		metricReport := types.ReportByStatus{StatusDetail: &types.StatusDetail{}}
 		err = rows.Scan(
 			&metricReport.InstanceDetails.WorkspaceID, &metricReport.InstanceDetails.Namespace, &metricReport.InstanceDetails.InstanceID,
-			&metricReport.ConnectionDetails.SourceDefinitionId,
+			&metricReport.ConnectionDetails.SourceDefinitionID,
 			&metricReport.ConnectionDetails.SourceCategory,
 			&metricReport.ConnectionDetails.SourceID,
-			&metricReport.ConnectionDetails.DestinationDefinitionId,
+			&metricReport.ConnectionDetails.DestinationDefinitionID,
 			&metricReport.ConnectionDetails.DestinationID,
 			&metricReport.ConnectionDetails.SourceTaskRunID,
 			&metricReport.ConnectionDetails.SourceJobID,
@@ -299,10 +299,10 @@ func (*DefaultReporter) getAggregatedReports(reports []*types.ReportByStatus) []
 					InstanceID:  report.InstanceID,
 				},
 				ConnectionDetails: types.ConnectionDetails{
-					SourceDefinitionId:      report.SourceDefinitionId,
+					SourceDefinitionID:      report.SourceDefinitionID,
 					SourceCategory:          report.SourceCategory,
 					SourceID:                report.SourceID,
-					DestinationDefinitionId: report.DestinationDefinitionId,
+					DestinationDefinitionID: report.DestinationDefinitionID,
 					DestinationID:           report.DestinationID,
 					SourceTaskRunID:         report.SourceTaskRunID,
 					SourceJobID:             report.SourceJobID,
@@ -665,10 +665,10 @@ func (r *DefaultReporter) Report(ctx context.Context, metrics []*types.PUReporte
 
 		_, err = stmt.Exec(
 			workspaceID, r.namespace, r.instanceID,
-			metric.ConnectionDetails.SourceDefinitionId,
+			metric.ConnectionDetails.SourceDefinitionID,
 			metric.ConnectionDetails.SourceCategory,
 			metric.ConnectionDetails.SourceID,
-			metric.ConnectionDetails.DestinationDefinitionId,
+			metric.ConnectionDetails.DestinationDefinitionID,
 			metric.ConnectionDetails.DestinationID,
 			metric.ConnectionDetails.SourceTaskRunID,
 			metric.ConnectionDetails.SourceJobID,

--- a/enterprise/reporting/reporting_test.go
+++ b/enterprise/reporting/reporting_test.go
@@ -404,6 +404,7 @@ func TestExtractErrorDetails(t *testing.T) {
 		caseDescription string
 		inputErrMsg     string
 		output          depTcOutput
+		statTags        map[string]string
 	}
 	testCases := []depTc{
 		{
@@ -422,12 +423,24 @@ func TestExtractErrorDetails(t *testing.T) {
 				errorCode: "deprecation",
 			},
 		},
+		{
+			caseDescription: "should use statTags to compute errorCode",
+			statTags: map[string]string{
+				"errorCategory": "dataValidation",
+				"errorType":     "configuration",
+			},
+			inputErrMsg: "Some error",
+			output: depTcOutput{
+				errorMsg:  "Some error",
+				errorCode: "dataValidation:configuration",
+			},
+		},
 	}
 
 	edr := NewErrorDetailReporter(context.Background(), &configSubscriber{}, stats.NOP, config.Default)
 	for _, tc := range testCases {
 		t.Run(tc.caseDescription, func(t *testing.T) {
-			errorDetails := edr.extractErrorDetails(tc.inputErrMsg)
+			errorDetails := edr.extractErrorDetails(tc.inputErrMsg, tc.statTags)
 
 			require.Equal(t, tc.output.errorMsg, errorDetails.ErrorMessage)
 			require.Equal(t, tc.output.errorCode, errorDetails.ErrorCode)

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -1023,7 +1023,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 			Expect(c.MockObserver.calls).To(HaveLen(1))
 			for _, v := range c.MockObserver.calls {
 				for _, e := range v.events {
-					Expect(e.Metadata.TrackingPlanId).To(BeEquivalentTo("tracking-plan-id"))
+					Expect(e.Metadata.TrackingPlanID).To(BeEquivalentTo("tracking-plan-id"))
 					Expect(e.Metadata.TrackingPlanVersion).To(BeEquivalentTo(100)) // from DgSourceTrackingPlanConfig
 				}
 			}
@@ -1104,7 +1104,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 			Expect(c.MockObserver.calls).To(HaveLen(1))
 			for _, v := range c.MockObserver.calls {
 				for _, e := range v.events {
-					Expect(e.Metadata.TrackingPlanId).To(BeEquivalentTo("tracking-plan-id"))
+					Expect(e.Metadata.TrackingPlanID).To(BeEquivalentTo("tracking-plan-id"))
 					Expect(e.Metadata.TrackingPlanVersion).To(BeEquivalentTo(123)) // Overridden happens when tracking plan id is same in context.ruddertyper and DgSourceTrackingPlanConfig
 				}
 			}
@@ -5151,7 +5151,7 @@ var _ = Describe("Static Function Tests", func() {
 					SourceID:         "source-id-1",
 					DestinationID:    "destination-id-1",
 					TransformationID: "transformation-id-1",
-					TrackingPlanId:   "tracking-plan-id-1",
+					TrackingPlanID:   "tracking-plan-id-1",
 					EventName:        "event-name-1",
 					EventType:        "event-type-1",
 				},
@@ -5183,7 +5183,7 @@ var _ = Describe("Static Function Tests", func() {
 				sourceCategory:          inputEvent.Metadata.SourceCategory,
 				transformationID:        inputEvent.Metadata.TransformationID,
 				transformationVersionID: inputEvent.Metadata.TransformationVersionID,
-				trackingPlanID:          inputEvent.Metadata.TrackingPlanId,
+				trackingPlanID:          inputEvent.Metadata.TrackingPlanID,
 				trackingPlanVersion:     inputEvent.Metadata.TrackingPlanVersion,
 			}
 			expectedConnectionDetails := &types.ConnectionDetails{
@@ -5192,12 +5192,12 @@ var _ = Describe("Static Function Tests", func() {
 				SourceJobRunID:          inputEvent.Metadata.SourceJobRunID,
 				SourceJobID:             inputEvent.Metadata.SourceJobID,
 				SourceTaskRunID:         inputEvent.Metadata.SourceTaskRunID,
-				SourceDefinitionId:      inputEvent.Metadata.SourceDefinitionID,
-				DestinationDefinitionId: inputEvent.Metadata.DestinationDefinitionID,
+				SourceDefinitionID:      inputEvent.Metadata.SourceDefinitionID,
+				DestinationDefinitionID: inputEvent.Metadata.DestinationDefinitionID,
 				SourceCategory:          inputEvent.Metadata.SourceCategory,
 				TransformationID:        inputEvent.Metadata.TransformationID,
 				TransformationVersionID: inputEvent.Metadata.TransformationVersionID,
-				TrackingPlanID:          inputEvent.Metadata.TrackingPlanId,
+				TrackingPlanID:          inputEvent.Metadata.TrackingPlanID,
 				TrackingPlanVersion:     inputEvent.Metadata.TrackingPlanVersion,
 			}
 			connectionDetailsMap := make(map[string]*types.ConnectionDetails)

--- a/processor/trackingplan.go
+++ b/processor/trackingplan.go
@@ -81,7 +81,7 @@ func (proc *Handle) validateEvents(groupedEventsBySourceId map[SourceIDT][]trans
 		proc.logger.Debug("Validation input size", len(eventList))
 
 		// Checking if the tracking plan exists
-		isTpExists := eventList[0].Metadata.TrackingPlanId != ""
+		isTpExists := eventList[0].Metadata.TrackingPlanID != ""
 		if !isTpExists {
 			// pass on the jobs for transformation(User, Dest)
 			validatedEventsBySourceId[sourceId] = make([]transformer.TransformerEvent, 0)
@@ -102,7 +102,7 @@ func (proc *Handle) validateEvents(groupedEventsBySourceId map[SourceIDT][]trans
 			continue
 		}
 
-		enhanceWithViolation(response, eventList[0].Metadata.TrackingPlanId, eventList[0].Metadata.TrackingPlanVersion)
+		enhanceWithViolation(response, eventList[0].Metadata.TrackingPlanID, eventList[0].Metadata.TrackingPlanVersion)
 
 		transformerEvent := eventList[0]
 		destination := &transformerEvent.Destination
@@ -166,7 +166,7 @@ func (proc *Handle) newValidationStat(metadata *transformer.Metadata) *TrackingP
 		"destType":            metadata.DestinationType,
 		"source":              metadata.SourceID,
 		"workspaceId":         metadata.WorkspaceID,
-		"trackingPlanId":      metadata.TrackingPlanId,
+		"trackingPlanId":      metadata.TrackingPlanID,
 		"trackingPlanVersion": strconv.Itoa(metadata.TrackingPlanVersion),
 	}
 

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -53,7 +53,7 @@ type Metadata struct {
 	InstanceID          string                            `json:"instanceId"`
 	SourceType          string                            `json:"sourceType"`
 	SourceCategory      string                            `json:"sourceCategory"`
-	TrackingPlanId      string                            `json:"trackingPlanId"`
+	TrackingPlanID      string                            `json:"trackingPlanId"`
 	TrackingPlanVersion int                               `json:"trackingPlanVersion"`
 	SourceTpConfig      map[string]map[string]interface{} `json:"sourceTpConfig"`
 	MergedTpConfig      map[string]interface{}            `json:"mergedTpConfig"`
@@ -118,6 +118,7 @@ type TransformerResponse struct {
 	StatusCode       int                    `json:"statusCode"`
 	Error            string                 `json:"error"`
 	ValidationErrors []ValidationError      `json:"validationErrors"`
+	StatTags         map[string]string      `json:"statTags"`
 }
 
 type ValidationError struct {

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -689,7 +689,16 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 			workspaceID := job.WorkspaceId
 			key := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s", parameters.SourceID, parameters.DestinationID, parameters.SourceJobRunID, jobState, strconv.Itoa(errorCode), parameters.EventName, parameters.EventType)
 			if _, ok := connectionDetailsMap[key]; !ok {
-				cd = types.CreateConnectionDetail(parameters.SourceID, parameters.DestinationID, parameters.SourceTaskRunID, parameters.SourceJobID, parameters.SourceJobRunID, parameters.SourceDefinitionID, parameters.DestinationDefinitionID, parameters.SourceCategory, "", "", "", 0)
+				cd = &types.ConnectionDetails{
+					SourceID:                parameters.SourceID,
+					DestinationID:           parameters.DestinationID,
+					SourceTaskRunID:         parameters.SourceTaskRunID,
+					SourceJobID:             parameters.SourceJobID,
+					SourceJobRunID:          parameters.SourceJobRunID,
+					SourceDefinitionID:      parameters.SourceDefinitionID,
+					DestinationDefinitionID: parameters.DestinationDefinitionID,
+					SourceCategory:          parameters.SourceCategory,
+				}
 				connectionDetailsMap[key] = cd
 				transformedAtMap[key] = parameters.TransformAt
 			}
@@ -699,7 +708,14 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 				if brt.transientSources.Apply(parameters.SourceID) {
 					sampleEvent = []byte(`{}`)
 				}
-				sd = types.CreateStatusDetail(jobState, 0, 0, errorCode, string(errorResp), sampleEvent, parameters.EventName, parameters.EventType, "")
+				sd = &types.StatusDetail{
+					Status:         jobState,
+					StatusCode:     errorCode,
+					SampleResponse: string(errorResp),
+					SampleEvent:    sampleEvent,
+					EventName:      parameters.EventName,
+					EventType:      parameters.EventType,
+				}
 				statusDetailsMap[key] = sd
 			}
 			if status.JobState == jobsdb.Failed.State && status.AttemptNum == 1 {

--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -556,7 +556,16 @@ func (brt *Handle) getReportMetrics(statusList []*jobsdb.JobStatusT, parametersM
 		key := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s", parameters.SourceID, parameters.DestinationID, parameters.SourceJobRunID, status.JobState, status.ErrorCode, eventName, eventType)
 		_, ok := connectionDetailsMap[key]
 		if !ok {
-			cd := utilTypes.CreateConnectionDetail(parameters.SourceID, parameters.DestinationID, parameters.SourceTaskRunID, parameters.SourceJobID, parameters.SourceJobRunID, parameters.SourceDefinitionID, parameters.DestinationDefinitionID, parameters.SourceCategory, "", "", "", 0)
+			cd := &utilTypes.ConnectionDetails{
+				SourceID:                parameters.SourceID,
+				DestinationID:           parameters.DestinationID,
+				SourceTaskRunID:         parameters.SourceTaskRunID,
+				SourceJobID:             parameters.SourceJobID,
+				SourceJobRunID:          parameters.SourceJobRunID,
+				SourceDefinitionID:      parameters.SourceDefinitionID,
+				DestinationDefinitionID: parameters.DestinationDefinitionID,
+				SourceCategory:          parameters.SourceCategory,
+			}
 			connectionDetailsMap[key] = cd
 			transformedAtMap[key] = parameters.TransformAt
 		}
@@ -567,7 +576,14 @@ func (brt *Handle) getReportMetrics(statusList []*jobsdb.JobStatusT, parametersM
 				errorCode = 0
 			}
 			sampleEvent := routerutils.EmptyPayload
-			sd = utilTypes.CreateStatusDetail(status.JobState, 0, 0, errorCode, string(status.ErrorResponse), sampleEvent, eventName, eventType, "")
+			sd = &utilTypes.StatusDetail{
+				Status:         status.JobState,
+				StatusCode:     errorCode,
+				SampleResponse: string(status.ErrorResponse),
+				SampleEvent:    sampleEvent,
+				EventName:      eventName,
+				EventType:      eventType,
+			}
 			statusDetailsMap[key] = sd
 		}
 

--- a/router/handle.go
+++ b/router/handle.go
@@ -353,7 +353,16 @@ func (rt *Handle) commitStatusList(workerJobStatuses *[]workerJobStatus) {
 		key := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s", parameters.SourceID, parameters.DestinationID, parameters.SourceJobRunID, workerJobStatus.status.JobState, workerJobStatus.status.ErrorCode, eventName, eventType)
 		_, ok := connectionDetailsMap[key]
 		if !ok {
-			cd := utilTypes.CreateConnectionDetail(parameters.SourceID, parameters.DestinationID, parameters.SourceTaskRunID, parameters.SourceJobID, parameters.SourceJobRunID, parameters.SourceDefinitionID, parameters.DestinationDefinitionID, parameters.SourceCategory, "", "", "", 0)
+			cd := &utilTypes.ConnectionDetails{
+				SourceID:                parameters.SourceID,
+				DestinationID:           parameters.DestinationID,
+				SourceTaskRunID:         parameters.SourceTaskRunID,
+				SourceJobID:             parameters.SourceJobID,
+				SourceJobRunID:          parameters.SourceJobRunID,
+				SourceDefinitionID:      parameters.SourceDefinitionID,
+				DestinationDefinitionID: parameters.DestinationDefinitionID,
+				SourceCategory:          parameters.SourceCategory,
+			}
 			connectionDetailsMap[key] = cd
 			transformedAtMap[key] = parameters.TransformAt
 		}
@@ -363,7 +372,15 @@ func (rt *Handle) commitStatusList(workerJobStatuses *[]workerJobStatus) {
 			if rt.transientSources.Apply(parameters.SourceID) {
 				sampleEvent = routerutils.EmptyPayload
 			}
-			sd = utilTypes.CreateStatusDetail(workerJobStatus.status.JobState, 0, 0, errorCode, string(workerJobStatus.status.ErrorResponse), sampleEvent, eventName, eventType, "")
+			sd = &utilTypes.StatusDetail{
+				Status:         workerJobStatus.status.JobState,
+				StatusCode:     errorCode,
+				SampleResponse: string(workerJobStatus.status.ErrorResponse),
+				SampleEvent:    sampleEvent,
+				EventName:      eventName,
+				EventType:      eventType,
+				StatTags:       workerJobStatus.statTags,
+			}
 			statusDetailsMap[key] = sd
 		}
 

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -248,8 +248,9 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 			integrations.CollectIntgTransformErrorStats(respData)
 			err = jsonfast.Unmarshal(respData, &destinationJobs)
 		} else if transformType == ROUTER_TRANSFORM {
-			integrations.CollectIntgTransformErrorStats([]byte(gjson.GetBytes(respData, "output").Raw))
-			err = jsonfast.Unmarshal([]byte(gjson.GetBytes(respData, "output").Raw), &destinationJobs)
+			rawResp := []byte(gjson.GetBytes(respData, "output").Raw)
+			integrations.CollectIntgTransformErrorStats(rawResp)
+			err = jsonfast.Unmarshal(rawResp, &destinationJobs)
 		}
 
 		// Validate the response received from the transformer

--- a/router/types.go
+++ b/router/types.go
@@ -13,11 +13,12 @@ import (
 )
 
 type workerJobStatus struct {
-	userID  string
-	worker  *worker
-	job     *jobsdb.JobT
-	status  *jobsdb.JobStatusT
-	payload json.RawMessage
+	userID   string
+	worker   *worker
+	job      *jobsdb.JobT
+	status   *jobsdb.JobStatusT
+	payload  json.RawMessage
+	statTags map[string]string
 }
 
 type HandleDestOAuthRespParams struct {

--- a/router/types/types.go
+++ b/router/types/types.go
@@ -54,6 +54,7 @@ type DestinationJobT struct {
 	StatusCode        int                        `json:"statusCode"`
 	Error             string                     `json:"error"`
 	AuthErrorCategory string                     `json:"authErrorCategory"`
+	StatTags          map[string]string          `json:"statTags"`
 }
 
 func (dj *DestinationJobT) MinJobID() int64 {

--- a/utils/types/reporting_types.go
+++ b/utils/types/reporting_types.go
@@ -48,16 +48,17 @@ type SyncSource struct {
 }
 
 type StatusDetail struct {
-	Status         string           `json:"state"`
-	Count          int64            `json:"count"`
-	StatusCode     int              `json:"statusCode"`
-	SampleResponse string           `json:"sampleResponse"`
-	SampleEvent    json.RawMessage  `json:"sampleEvent"`
-	EventName      string           `json:"eventName"`
-	EventType      string           `json:"eventType"`
-	ErrorType      string           `json:"errorType"`
-	ViolationCount int64            `json:"violationCount"`
-	FailedMessages []*FailedMessage `json:"-"`
+	Status         string            `json:"state"`
+	Count          int64             `json:"count"`
+	StatusCode     int               `json:"statusCode"`
+	SampleResponse string            `json:"sampleResponse"`
+	SampleEvent    json.RawMessage   `json:"sampleEvent"`
+	EventName      string            `json:"eventName"`
+	EventType      string            `json:"eventType"`
+	ErrorType      string            `json:"errorType"`
+	ViolationCount int64             `json:"violationCount"`
+	StatTags       map[string]string `json:"statTags"`
+	FailedMessages []*FailedMessage  `json:"-"`
 }
 
 type FailedMessage struct {
@@ -157,8 +158,8 @@ type ConnectionDetails struct {
 	SourceTaskRunID         string `json:"sourceTaskRunId"`
 	SourceJobID             string `json:"sourceJobId"`
 	SourceJobRunID          string `json:"sourceJobRunId"`
-	SourceDefinitionId      string `json:"sourceDefinitionId"`
-	DestinationDefinitionId string `string:"destinationDefinitionId"`
+	SourceDefinitionID      string `json:"sourceDefinitionId"`
+	DestinationDefinitionID string `string:"destinationDefinitionId"`
 	SourceCategory          string `json:"sourceCategory"`
 	TransformationID        string `json:"transformationId"`
 	TransformationVersionID string `json:"transformationVersionId"`
@@ -176,37 +177,6 @@ type PUReportedMetric struct {
 	ConnectionDetails
 	PUDetails
 	StatusDetail *StatusDetail
-}
-
-func CreateConnectionDetail(sid, did, strid, sjid, sjrid, sdid, ddid, sc, trid, trvid, tpid string, tpv int) *ConnectionDetails {
-	return &ConnectionDetails{
-		SourceID:                sid,
-		DestinationID:           did,
-		SourceTaskRunID:         strid,
-		SourceJobID:             sjid,
-		SourceJobRunID:          sjrid,
-		SourceDefinitionId:      sdid,
-		DestinationDefinitionId: ddid,
-		SourceCategory:          sc,
-		TransformationID:        trid,
-		TransformationVersionID: trvid,
-		TrackingPlanID:          tpid,
-		TrackingPlanVersion:     tpv,
-	}
-}
-
-func CreateStatusDetail(status string, count, violationCount int64, code int, resp string, event json.RawMessage, eventName, eventType, errorType string) *StatusDetail {
-	return &StatusDetail{
-		Status:         status,
-		Count:          count,
-		ViolationCount: violationCount,
-		StatusCode:     code,
-		SampleResponse: resp,
-		SampleEvent:    event,
-		EventName:      eventName,
-		EventType:      eventType,
-		ErrorType:      errorType,
-	}
 }
 
 func CreatePUDetails(inPU, pu string, terminalPU, initialPU bool) *PUDetails {


### PR DESCRIPTION
# Description

Propagate statTags from transformer response to reporting.
Address sonar issues of too many function params and reduced code complexity

## Linear Ticket

https://linear.app/rudderstack/issue/INT-2973/[chore]-propagate-error-category-from-stattags-of-transformer
Resolves INT-2973

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
