### PR TITLE
chore: drop upload id from wh_schema

### DIFF
--- a/sql/migrations/warehouse/000026_drop_wh_upload_id_column.up.sql
+++ b/sql/migrations/warehouse/000026_drop_wh_upload_id_column.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE wh_schemas ALTER COLUMN wh_upload_id DROP NOT NULL;
+

--- a/warehouse/api/http_test.go
+++ b/warehouse/api/http_test.go
@@ -295,7 +295,6 @@ func TestHTTPApi(t *testing.T) {
 
 	schemaRepo := repo.NewWHSchemas(db)
 	_, err = schemaRepo.Insert(ctx, &model.WHSchema{
-		UploadID:        1,
 		SourceID:        sourceID,
 		Namespace:       namespace,
 		DestinationID:   destinationID,

--- a/warehouse/bcm/testdata/sql/namespace_test.sql
+++ b/warehouse/bcm/testdata/sql/namespace_test.sql
@@ -1,6 +1,6 @@
 BEGIN;
-INSERT INTO wh_schemas(id,wh_upload_id, source_id, namespace, destination_id, destination_type,
+INSERT INTO wh_schemas(id, source_id, namespace, destination_id, destination_type,
                         schema, error, created_at, updated_at)
-VALUES (1,1, 'test-sourceID', 'test-namespace', 'test-destinationID', 'POSTGRES','{}', NULL,
+VALUES (1, 'test-sourceID', 'test-namespace', 'test-destinationID', 'POSTGRES','{}', NULL,
         '2022-12-06 15:23:37.100685', '2022-12-06 15:23:37.100685');
 COMMIT;

--- a/warehouse/internal/model/schema.go
+++ b/warehouse/internal/model/schema.go
@@ -22,7 +22,6 @@ const (
 
 type WHSchema struct {
 	ID              int64
-	UploadID        int64
 	SourceID        string
 	Namespace       string
 	DestinationID   string

--- a/warehouse/internal/repo/schema.go
+++ b/warehouse/internal/repo/schema.go
@@ -17,7 +17,6 @@ const whSchemaTableName = warehouseutils.WarehouseSchemasTable
 
 const whSchemaTableColumns = `
 	id,
-   	wh_upload_id,
    	source_id,
 	namespace,
    	destination_id,
@@ -53,20 +52,19 @@ func (sh *WHSchema) Insert(ctx context.Context, whSchema *model.WHSchema) (int64
 
 	err = sh.db.QueryRowContext(ctx, `
 		INSERT INTO `+whSchemaTableName+` (
-		  wh_upload_id, source_id, namespace, destination_id,
+          source_id, namespace, destination_id,
 		  destination_type, schema, created_at,
 		  updated_at
 		)
 		VALUES
-		  ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT (
+		  ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (
 			source_id, destination_id, namespace
 		  ) DO
 		UPDATE
 		SET
-		  schema = $6,
+		  schema = $5,
 		  updated_at = $7 RETURNING id;
 `,
-		whSchema.UploadID,
 		whSchema.SourceID,
 		whSchema.Namespace,
 		whSchema.DestinationID,
@@ -125,7 +123,6 @@ func parseWHSchemas(rows *sqlmiddleware.Rows) ([]*model.WHSchema, error) {
 		)
 		err := rows.Scan(
 			&whSchema.ID,
-			&whSchema.UploadID,
 			&whSchema.SourceID,
 			&whSchema.Namespace,
 			&whSchema.DestinationID,

--- a/warehouse/internal/repo/schema_test.go
+++ b/warehouse/internal/repo/schema_test.go
@@ -57,7 +57,6 @@ func TestWHSchemasRepo(t *testing.T) {
 			},
 		}
 		schema = model.WHSchema{
-			UploadID:        1,
 			SourceID:        sourceID,
 			Namespace:       namespace,
 			DestinationID:   destinationID,
@@ -144,7 +143,6 @@ func TestWHSchemasRepo(t *testing.T) {
 		t.Log("multiple")
 		latestNamespace := "latest_namespace"
 		schemaLatest := model.WHSchema{
-			UploadID:        2,
 			SourceID:        sourceID,
 			Namespace:       latestNamespace,
 			DestinationID:   destinationID,

--- a/warehouse/router/state_export_data.go
+++ b/warehouse/router/state_export_data.go
@@ -282,7 +282,7 @@ func (job *UploadJob) loadUserTables(loadFilesTableMap map[tableNameT]bool) ([]e
 
 	if alteredIdentitySchema || alteredUserSchema {
 		job.logger.Infof("loadUserTables: schema changed - updating local schema for %s", job.warehouse.Identifier)
-		_ = job.schemaHandle.UpdateLocalSchemaWithWarehouse(job.ctx, job.upload.ID)
+		_ = job.schemaHandle.UpdateLocalSchemaWithWarehouse(job.ctx)
 	}
 	return job.processLoadTableResponse(errorMap)
 }
@@ -555,7 +555,7 @@ func (job *UploadJob) loadIdentityTables(populateHistoricIdentities bool) (loadE
 
 	if alteredSchema {
 		job.logger.Infof("loadIdentityTables: schema changed - updating local schema for %s", job.warehouse.Identifier)
-		_ = job.schemaHandle.UpdateLocalSchemaWithWarehouse(job.ctx, job.upload.ID) // TODO check error
+		_ = job.schemaHandle.UpdateLocalSchemaWithWarehouse(job.ctx) // TODO check error
 	}
 
 	return job.processLoadTableResponse(errorMap)
@@ -698,7 +698,7 @@ func (job *UploadJob) loadAllTablesExcept(skipLoadForTables []string, loadFilesT
 
 	if alteredSchemaInAtLeastOneTable.Load() {
 		job.logger.Infof("loadAllTablesExcept: schema changed - updating local schema for %s", job.warehouse.Identifier)
-		_ = job.schemaHandle.UpdateLocalSchemaWithWarehouse(job.ctx, job.upload.ID) // TODO check error
+		_ = job.schemaHandle.UpdateLocalSchemaWithWarehouse(job.ctx) // TODO check error
 	}
 
 	return loadErrors

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -904,5 +904,5 @@ func (job *UploadJob) GetLocalSchema(ctx context.Context) (model.Schema, error) 
 }
 
 func (job *UploadJob) UpdateLocalSchema(ctx context.Context, schema model.Schema) error {
-	return job.schemaHandle.UpdateLocalSchema(ctx, job.upload.ID, schema)
+	return job.schemaHandle.UpdateLocalSchema(ctx, schema)
 }

--- a/warehouse/schema/schema_test.go
+++ b/warehouse/schema/schema_test.go
@@ -78,7 +78,6 @@ func TestSchema_UpdateLocalSchema(t *testing.T) {
 	destinationID := "test_destination_id"
 	namespace := "test_namespace"
 	warehouseType := warehouseutils.RS
-	uploadID := int64(1)
 	tableName := "test_table"
 
 	schemaInWarehouse := model.Schema{
@@ -181,7 +180,7 @@ func TestSchema_UpdateLocalSchema(t *testing.T) {
 
 			ctx := context.Background()
 
-			err = s.UpdateLocalSchema(ctx, uploadID, tc.mockSchema.Schema)
+			err = s.UpdateLocalSchema(ctx, tc.mockSchema.Schema)
 			if tc.wantError == nil {
 				require.NoError(t, err)
 				require.Equal(t, tc.wantSchema, s.localSchema)
@@ -195,7 +194,7 @@ func TestSchema_UpdateLocalSchema(t *testing.T) {
 			require.NoError(t, err)
 			require.EqualValues(t, float64(len(marshalledSchema)), statsStore.Get("warehouse_schema_size", tags).LastValue())
 
-			err = s.UpdateLocalSchemaWithWarehouse(ctx, uploadID)
+			err = s.UpdateLocalSchemaWithWarehouse(ctx)
 			if tc.wantError == nil {
 				require.NoError(t, err)
 				require.Equal(t, schemaInWarehouse, s.localSchema)


### PR DESCRIPTION
# Description
Removes unused wh_upload_id from wh_schema table

## Linear Ticket

Fixes WAR-102

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
