### PR TITLE
fix: parse received_at from job parameters instead of payload

### DIFF
--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -864,7 +864,7 @@ func (brt *Handle) splitBatchJobsOnTimeWindow(batchJobs BatchedJobs) map[time.Ti
 	// split batchJobs based on timeWindow
 	for _, job := range batchJobs.Jobs {
 		// ignore error as receivedAt will always be in the expected format
-		receivedAtStr := gjson.Get(string(job.EventPayload), "metadata.receivedAt").String()
+		receivedAtStr := gjson.Get(string(job.Parameters), "received_at").String()
 		receivedAt, err := time.Parse(time.RFC3339, receivedAtStr)
 		if err != nil {
 			brt.logger.Errorf("Invalid value '%s' for receivedAt : %v ", receivedAtStr, err)

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -865,7 +865,7 @@ func (brt *Handle) splitBatchJobsOnTimeWindow(batchJobs BatchedJobs) map[time.Ti
 	for _, job := range batchJobs.Jobs {
 		// ignore error as receivedAt will always be in the expected format
 		receivedAtStr := gjson.Get(string(job.Parameters), "received_at").String()
-		receivedAt, err := time.Parse(time.RFC3339, receivedAtStr)
+		receivedAt, err := time.Parse(misc.RFC3339Milli, receivedAtStr)
 		if err != nil {
 			brt.logger.Errorf("Invalid value '%s' for receivedAt : %v ", receivedAtStr, err)
 			panic(err)


### PR DESCRIPTION
# Description

Parse received_at for a batch router job from parameters instead of job payload.
Using `misc.RFC3339Milli` since that's used everywhere.

## Linear Ticket

[Pertinent slack thread](https://rudderlabs.slack.com/archives/C02HCFVJVAR/p1733319913789669)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
