### PR TITLE
chore: cleanup staging repo to use upload_id for queries

### DIFF
--- a/warehouse/router/router.go
+++ b/warehouse/router/router.go
@@ -441,7 +441,7 @@ func (r *Router) uploadsToProcess(ctx context.Context, availableWorkers int, ski
 			continue
 		}
 
-		stagingFilesList, err := r.stagingRepo.GetForUpload(ctx, upload)
+		stagingFilesList, err := r.stagingRepo.GetForUploadID(ctx, upload.ID)
 		if err != nil {
 			return nil, err
 		}

--- a/warehouse/router/state_generate_load_files.go
+++ b/warehouse/router/state_generate_load_files.go
@@ -57,7 +57,7 @@ func (job *UploadJob) setLoadFileIDs(startLoadFileID, endLoadFileID int64) error
 }
 
 func (job *UploadJob) matchRowsInStagingAndLoadFiles(ctx context.Context) error {
-	rowsInStagingFiles, err := job.stagingFileRepo.TotalEventsForUpload(ctx, job.upload)
+	rowsInStagingFiles, err := job.stagingFileRepo.TotalEventsForUploadID(ctx, job.upload.ID)
 	if err != nil {
 		return fmt.Errorf("total rows: %w", err)
 	}

--- a/warehouse/router/testdata/sql/upload_test.sql
+++ b/warehouse/router/testdata/sql/upload_test.sql
@@ -44,38 +44,38 @@ INSERT INTO wh_staging_files (
   id, location, schema, source_id, destination_id,
   status, total_events, first_event_at,
   last_event_at, created_at, updated_at,
-  metadata
+  metadata,upload_id
 )
 VALUES
   (
     1, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     '{}', 'test-sourceID', 'test-destinationID',
     'succeeded', 1, NOW(), NOW(), NOW(),
-    NOW(), '{}'
+    NOW(), '{}',1
   ),
   (
     2, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     '{}', 'test-sourceID', 'test-destinationID',
     'succeeded', 1, NOW(), NOW(), NOW(),
-    NOW(), '{}'
+    NOW(), '{}',1
   ),
   (
     3, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     '{}', 'test-sourceID', 'test-destinationID',
     'succeeded', 1, NOW(), NOW(), NOW(),
-    NOW(), '{}'
+    NOW(), '{}',1
   ),
   (
     4, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     '{}', 'test-sourceID', 'test-destinationID',
     'succeeded', 1, NOW(), NOW(), NOW(),
-    NOW(), '{}'
+    NOW(), '{}',1
   ),
   (
     5, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     '{}', 'test-sourceID', 'test-destinationID',
     'succeeded', 1, NOW(), NOW(), NOW(),
-    NOW(), '{}'
+    NOW(), '{}',1
   );
 INSERT INTO wh_load_files (
   id, staging_file_id, location, source_id,

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -383,7 +383,7 @@ func (job *UploadJob) run() (err error) {
 		uploadStatusOpts := UploadStatusOpts{Status: newStatus}
 		if newStatus == model.ExportedData {
 
-			rowCount, _ := job.stagingFileRepo.TotalEventsForUpload(job.ctx, job.upload)
+			rowCount, _ := job.stagingFileRepo.TotalEventsForUploadID(job.ctx, job.upload.ID)
 
 			reportingMetric := types.PUReportedMetric{
 				ConnectionDetails: types.ConnectionDetails{
@@ -662,7 +662,7 @@ func (job *UploadJob) setUploadError(statusError error, state string) (string, e
 		return "", fmt.Errorf("changing upload columns: %w", err)
 	}
 
-	inputCount, _ := job.stagingFileRepo.TotalEventsForUpload(job.ctx, upload)
+	inputCount, _ := job.stagingFileRepo.TotalEventsForUploadID(job.ctx, upload.ID)
 	outputCount, _ := job.tableUploadsRepo.TotalExportedEvents(job.ctx, job.upload.ID, []string{
 		whutils.ToProviderCase(job.warehouse.Type, whutils.DiscardsTable),
 	})

--- a/warehouse/router/upload_stats.go
+++ b/warehouse/router/upload_stats.go
@@ -60,9 +60,9 @@ func (job *UploadJob) generateUploadSuccessMetrics() {
 		return
 	}
 
-	numStagedEvents, err = job.stagingFileRepo.TotalEventsForUpload(
+	numStagedEvents, err = job.stagingFileRepo.TotalEventsForUploadID(
 		job.ctx,
-		job.upload,
+		job.upload.ID,
 	)
 	if err != nil {
 		job.logger.Warnw("total events for upload", logfield.Error, err.Error())
@@ -101,9 +101,9 @@ func (job *UploadJob) generateUploadAbortedMetrics() {
 		return
 	}
 
-	numStagedEvents, err = job.stagingFileRepo.TotalEventsForUpload(
+	numStagedEvents, err = job.stagingFileRepo.TotalEventsForUploadID(
 		job.ctx,
-		job.upload,
+		job.upload.ID,
 	)
 	if err != nil {
 		job.logger.Warnw("total events for upload", logfield.Error, err.Error())

--- a/warehouse/router/upload_stats_test.go
+++ b/warehouse/router/upload_stats_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/mock_stats"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 	sqlmiddleware "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
@@ -243,7 +244,7 @@ func TestUploadJob_MatchRows(t *testing.T) {
 			},
 		}, nil)
 
-		count, err := repo.NewStagingFiles(sqlmiddleware.New(db)).TotalEventsForUpload(context.Background(), job.upload)
+		count, err := repo.NewStagingFiles(sqlmiddleware.New(db)).TotalEventsForUploadID(context.Background(), job.upload.ID)
 		require.NoError(t, err)
 		require.EqualValues(t, 5, count)
 	})


### PR DESCRIPTION
# Description

Since `wh_staging_files` has a `upload_id,` we can use that to find associated staging files. We don't need additional filters for `source_id` and `destination_id`.

## Linear Ticket

- Resolves WAR-103

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
