### PR TITLE
fix: struct tag for connection details reporting type

### DIFF
--- a/utils/types/reporting_types.go
+++ b/utils/types/reporting_types.go
@@ -159,7 +159,7 @@ type ConnectionDetails struct {
 	SourceJobID             string `json:"sourceJobId"`
 	SourceJobRunID          string `json:"sourceJobRunId"`
 	SourceDefinitionID      string `json:"sourceDefinitionId"`
-	DestinationDefinitionID string `string:"destinationDefinitionId"`
+	DestinationDefinitionID string `json:"DestinationDefinitionId"`
 	SourceCategory          string `json:"sourceCategory"`
 	TransformationID        string `json:"transformationId"`
 	TransformationVersionID string `json:"transformationVersionId"`


### PR DESCRIPTION
# Description

The struct tag was wrong earlier, and I renamed the field. Then, it broke the reporting API contract, so I am fixing the struct tag.

## Linear Ticket

https://linear.app/rudderstack/issue/INT-2973/[chore]-propagate-error-category-from-stattags-of-transformer
Resolves INT-2973

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
