### PR TITLE
fix: bulk add columns

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/apiadapter.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/apiadapter.go
@@ -43,13 +43,14 @@ func (a *apiAdapter) defaultTags(apiName string) stats.Tags {
 }
 
 func (a *apiAdapter) CreateChannel(ctx context.Context, req *model.CreateChannelRequest) (*model.ChannelResponse, error) {
-	a.logger.Infon("Creating channel",
+	log := a.logger.Withn(
 		logger.NewStringField("rudderIdentifier", req.RudderIdentifier),
 		logger.NewStringField("partition", req.Partition),
 		logger.NewStringField("database", req.TableConfig.Database),
 		logger.NewStringField("namespace", req.TableConfig.Schema),
 		logger.NewStringField("table", req.TableConfig.Table),
 	)
+	log.Infon("Creating channel")
 
 	tags := a.defaultTags(createChannelAPI)
 	defer a.recordDuration(tags)()
@@ -59,6 +60,16 @@ func (a *apiAdapter) CreateChannel(ctx context.Context, req *model.CreateChannel
 		tags["success"] = "false"
 		return nil, err
 	}
+	a.logger.Infon("Create channel response",
+		logger.NewBoolField("success", resp.Success),
+		logger.NewStringField("channelID", resp.ChannelID),
+		logger.NewStringField("channelName", resp.ChannelName),
+		logger.NewBoolField("valid", resp.Valid),
+		logger.NewBoolField("deleted", resp.Deleted),
+		logger.NewStringField("error", resp.Error),
+		logger.NewStringField("code", resp.Code),
+		logger.NewStringField("message", resp.SnowflakeAPIMessage),
+	)
 	tags["success"] = strconv.FormatBool(resp.Success)
 	tags["code"] = resp.Code
 	return resp, nil

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/channel.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/channel.go
@@ -65,10 +65,8 @@ func (m *Manager) addColumns(ctx context.Context, namespace, tableName string, c
 	defer func() {
 		snowflakeManager.Cleanup(ctx)
 	}()
-	for _, column := range columns {
-		if err = snowflakeManager.AddColumns(ctx, tableName, []whutils.ColumnInfo{column}); err != nil {
-			return fmt.Errorf("adding column: %w", err)
-		}
+	if err = snowflakeManager.AddColumns(ctx, tableName, columns); err != nil {
+		return fmt.Errorf("adding column: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

- Since we are now handling errors during Polling (earlier we used to mark it as aborted instead of marking it as failed), We can call `AddColumns` with all the necessary columns. 
  - In case some columns already exist (maybe another instead added them), we will get an error and will mark these jobs as a failure. They will be picked up again.

## Linear Ticket

- Resolves WAR-115

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
