### PR TITLE
fix: reports aggregation query to select sample_event and sample_response correctly

### DIFF
--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -248,11 +248,11 @@ func (r *DefaultReporter) getReports(currentMs, aggregationIntervalMin int64, sy
     SELECT 
         %s, MAX(reported_at),
         COALESCE(
-            (ARRAY_AGG(sample_response ORDER BY id DESC) FILTER (WHERE sample_event != '{}'::jsonb))[1], 
+            (ARRAY_AGG(sample_response ORDER BY id DESC) FILTER (WHERE (sample_event != '{}'::jsonb AND sample_event IS NOT NULL) OR (sample_response IS NOT NULL AND sample_response != '')))[1],
             ''
         ) AS sample_response,
         COALESCE(
-            (ARRAY_AGG(sample_event ORDER BY id DESC) FILTER (WHERE sample_event != '{}'::jsonb))[1], 
+            (ARRAY_AGG(sample_event ORDER BY id DESC) FILTER (WHERE (sample_event != '{}'::jsonb AND sample_event IS NOT NULL) OR (sample_response IS NOT NULL AND sample_response != '')))[1],
             '{}'::jsonb
         ) AS sample_event,
         SUM(count),


### PR DESCRIPTION
# Description

For warehouse module sample event will always be empty, we need to update the FILTER on ARRAY_AGG in reporting reports aggregation query to select samples response even if sample event is empty. 

## Linear Ticket

Resolves OBS-732
[OBS-732: Fix reports aggregation query on rudder-server to handle empty sample event](https://linear.app/rudderstack/issue/OBS-732/fix-reports-aggregation-query-on-rudder-server-to-handle-empty-sample)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
