### PR TITLE
feat: implement backoff for snowpipe streaming authorization errors

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -406,10 +406,10 @@ func (m *Manager) abortJobs(asyncDest *common.AsyncDestinationStruct, abortReaso
 func (m *Manager) failedJobs(asyncDest *common.AsyncDestinationStruct, failedReason string) common.AsyncUploadOutput {
 	m.stats.jobs.failed.Count(len(asyncDest.ImportingJobIDs))
 	return common.AsyncUploadOutput{
-		ImportingJobIDs: asyncDest.ImportingJobIDs,
-		ImportingCount:  len(asyncDest.ImportingJobIDs),
-		FailedReason:    failedReason,
-		DestinationID:   asyncDest.Destination.ID,
+		FailedJobIDs:  asyncDest.ImportingJobIDs,
+		FailedCount:   len(asyncDest.ImportingJobIDs),
+		FailedReason:  failedReason,
+		DestinationID: asyncDest.Destination.ID,
 	}
 }
 

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -353,11 +353,11 @@ func TestSnowpipeStreaming(t *testing.T) {
 		}
 		managerCreatorCallCount := 0
 		sm.managerCreator = func(_ context.Context, _ whutils.ModelWarehouse, _ *config.Config, _ logger.Logger, _ stats.Stats) (manager.Manager, error) {
-			sm := snowflake.New(config.New(), logger.NOP, stats.NOP)
+			sf := snowflake.New(config.New(), logger.NOP, stats.NOP)
 			managerCreatorCallCount++
-			mockManager := newMockManager(sm)
-			mockManager.createSchemaErr = fmt.Errorf("failed to create schema")
-			return mockManager, nil
+			mm := newMockManager(sf)
+			mm.createSchemaErr = fmt.Errorf("failed to create schema")
+			return mm, nil
 		}
 		sm.config.backoff.initialInterval = config.SingleValueLoader(time.Second * 10)
 		asyncDestStruct := &common.AsyncDestinationStruct{
@@ -390,9 +390,9 @@ func TestSnowpipeStreaming(t *testing.T) {
 		require.True(t, sm.isInBackoff())
 
 		sm.managerCreator = func(_ context.Context, _ whutils.ModelWarehouse, _ *config.Config, _ logger.Logger, _ stats.Stats) (manager.Manager, error) {
-			sm := snowflake.New(config.New(), logger.NOP, stats.NOP)
+			sf := snowflake.New(config.New(), logger.NOP, stats.NOP)
 			managerCreatorCallCount++
-			return newMockManager(sm), nil
+			return newMockManager(sf), nil
 		}
 		sm.now = func() time.Time {
 			return timeutil.Now().Add(time.Second * 50)
@@ -415,10 +415,10 @@ func TestSnowpipeStreaming(t *testing.T) {
 			},
 		}
 		sm.managerCreator = func(_ context.Context, _ whutils.ModelWarehouse, _ *config.Config, _ logger.Logger, _ stats.Stats) (manager.Manager, error) {
-			sm := snowflake.New(config.New(), logger.NOP, stats.NOP)
-			mockManager := newMockManager(sm)
-			mockManager.createSchemaErr = fmt.Errorf("failed to create schema")
-			return mockManager, nil
+			sf := snowflake.New(config.New(), logger.NOP, stats.NOP)
+			mm := newMockManager(sf)
+			mm.createSchemaErr = fmt.Errorf("failed to create schema")
+			return mm, nil
 		}
 		output := sm.Upload(&common.AsyncDestinationStruct{
 			ImportingJobIDs: []int64{1},

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/testdata/successful_user_records.txt
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/testdata/successful_user_records.txt
@@ -1,0 +1,2 @@
+{"message":{"metadata":{"table":"USERS","columns":{"ID":"int","NAME":"string","AGE":"int","RECEIVED_AT":"datetime"}},"data":{"ID":1,"NAME":"Alice","AGE":30,"RECEIVED_AT":"2023-05-12T04:36:50.199Z"}},"metadata":{"job_id":1001}}
+{"message":{"metadata":{"table":"USERS","columns":{"ID":"int","NAME":"string","AGE":"int","RECEIVED_AT":"datetime"}},"data":{"ID":1,"NAME":"Alice","AGE":30,"RECEIVED_AT":"2023-05-12T04:36:50.199Z"}},"metadata":{"job_id":1003}}

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
@@ -172,7 +172,7 @@ func newAuthzBackoff(initialInterval time.Duration, clock backoff.Clock) *authzB
 			backoff.WithClockProvider(clock),
 			backoff.WithRandomizationFactor(0),
 			backoff.WithMaxElapsedTime(0),
-			backoff.WithMaxInterval(0),
+			backoff.WithMaxInterval(time.Hour),
 		},
 	}
 }

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats"
 
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/model"
+	"github.com/rudderlabs/rudder-server/utils/timeutil"
 
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
@@ -169,7 +170,7 @@ func newAuthzBackoff(initialBackoffDuration time.Duration) *authzBackoff {
 }
 
 func (abe *authzBackoff) set() {
-	abe.lastestErrorTime = time.Now()
+	abe.lastestErrorTime = timeutil.Now()
 	if abe.backoffDuration == 0 {
 		abe.backoffDuration = abe.initialBackoffDuration
 	} else {

--- a/warehouse/integrations/manager/manager.go
+++ b/warehouse/integrations/manager/manager.go
@@ -26,9 +26,6 @@ import (
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
-// Creating an alias since "model.TableSchema" is defined in an internal module
-type ModelTableSchema = model.TableSchema
-
 type Manager interface {
 	Setup(ctx context.Context, warehouse model.Warehouse, uploader warehouseutils.Uploader) error
 	FetchSchema(ctx context.Context) (model.Schema, error)

--- a/warehouse/integrations/manager/manager.go
+++ b/warehouse/integrations/manager/manager.go
@@ -26,6 +26,9 @@ import (
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
+// Creating an alias since "model.TableSchema" is defined in an internal module
+type ModelTableSchema = model.TableSchema
+
 type Manager interface {
 	Setup(ctx context.Context, warehouse model.Warehouse, uploader warehouseutils.Uploader) error
 	FetchSchema(ctx context.Context) (model.Schema, error)


### PR DESCRIPTION
# Description

This PR introduces a backoff mechanism when creating channels in the Snowpipe streaming destination. If an authorization error is encountered at the schema, table, or column level, the backoff ensures that we avoid repeatedly attempting to connect to Snowflake unnecessarily.

- Added a new struct `backoff` in manager to store backoff related state
- Refactoring: Added `managerCreator` as a field in the manager for making the code testable.
- Until now, any error encountered while creating the channel for the discards table resulted in the job being marked as aborted. In this PR, the behavior has been updated to mark the job as failed, allowing it to be retried.
- Backoff is applied whenever an authorization error is encountered.
- Backoff is being cleared whenver channels for all the tables are being created without any authz error

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
