### PR TITLE
fix: add missing statuscode for poll call, update error string

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
@@ -14,10 +14,10 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
-	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 )
 
 const (

--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
@@ -17,6 +17,7 @@ import (
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 )
 
 const (
@@ -118,11 +119,12 @@ func (kbu *KlaviyoBulkUploader) Poll(pollInput common.AsyncPoll) common.PollStat
 				allComplete = false
 				pollresp, err := kbu.KlaviyoAPIService.GetUploadStatus(importId)
 				if err != nil {
+					kbu.Logger.Errorn("Error during fetching Klaviyo Bulk Upload status", obskit.Error(err))
 					return common.PollStatusResponse{
-						StatusCode: 400,
+						StatusCode: 500,
 						Complete:   true,
 						HasFailed:  true,
-						Error:      `Error during fetching upload status `+ err.Error(),
+						Error:      `Error during fetching upload status ` + err.Error(),
 					}
 				}
 

--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
@@ -119,9 +119,10 @@ func (kbu *KlaviyoBulkUploader) Poll(pollInput common.AsyncPoll) common.PollStat
 				pollresp, err := kbu.KlaviyoAPIService.GetUploadStatus(importId)
 				if err != nil {
 					return common.PollStatusResponse{
-						Complete:  true,
-						HasFailed: true,
-						Error:     err.Error(),
+						StatusCode: 400,
+						Complete:   true,
+						HasFailed:  true,
+						Error:      `Error during fetching upload status `+ err.Error(),
 					}
 				}
 

--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload_test.go
@@ -315,7 +315,7 @@ func TestPoll(t *testing.T) {
 		assert.Equal(t, true, jobStatus.HasFailed)
 		assert.Equal(t, false, jobStatus.HasWarning)
 		assert.Empty(t, jobStatus.WarningJobParameters)
-		assert.Equal(t, "The import job failed", jobStatus.Error)
+		assert.Equal(t, "Error during fetching upload status The import job failed", jobStatus.Error)
 	})
 }
 

--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -271,7 +271,7 @@ func (brt *Handle) updatePollStatusToDB(
 			}
 		}
 	} else if pollResp.StatusCode == http.StatusBadRequest {
-		statusList, _, jobIDConnectionDetailsMap = brt.prepareJobStatusList(importingList, jobsdb.JobStatusT{JobState: jobsdb.Aborted.State, ErrorResponse: misc.UpdateJSONWithNewKeyVal(routerutils.EmptyPayload, "error", "poll failed with status code 400")}, sourceID, destinationID)
+		statusList, _, jobIDConnectionDetailsMap = brt.prepareJobStatusList(importingList, jobsdb.JobStatusT{JobState: jobsdb.Aborted.State, ErrorResponse: misc.UpdateJSONWithNewKeyVal(routerutils.EmptyPayload, "error", pollResp.Error)}, sourceID, destinationID)
 		if err := brt.updateJobStatuses(ctx, destinationID, importingList, importingList, statusList); err != nil {
 			brt.logger.Errorf("[Batch Router] Failed to update job status for Dest Type %v with error %v", brt.destType, err)
 			return statusList, err

--- a/router/batchrouter/handle_async_test.go
+++ b/router/batchrouter/handle_async_test.go
@@ -244,7 +244,7 @@ func TestAsyncDestinationManager(t *testing.T) {
 			require.Equal(t, int64(1), statuses[0].JobID)
 			require.Equal(t, jobsdb.Aborted.State, statuses[0].JobState)
 			require.Empty(t, statuses[0].ErrorCode)
-			require.Equal(t, "poll failed with status code 400", gjson.GetBytes(statuses[0].ErrorResponse, "error").String())
+			require.Equal(t, "", gjson.GetBytes(statuses[0].ErrorResponse, "error").String())
 			require.JSONEq(t, `{}`, string(statuses[0].Parameters))
 			require.JSONEq(t, `{"importId": "importID", "source_id": "sourceID", "destination_id": "destinationID"}`, string(statuses[0].JobParameters))
 			cancel()


### PR DESCRIPTION
# Description

Polling errors were not being set with a proper status code in Klaviyo Bulk Upload. This is rectified here

## Linear Ticket

Resolves INT-3076

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
