### PR TITLE
feat: implement background syncing for warehouse schema

### DIFF
--- a/warehouse/integrations/bigquery/bigquery_test.go
+++ b/warehouse/integrations/bigquery/bigquery_test.go
@@ -607,6 +607,7 @@ func TestIntegration(t *testing.T) {
 				t.Setenv("RSERVER_WAREHOUSE_BIGQUERY_ENABLE_DELETE_BY_JOBS", "true")
 				t.Setenv("RSERVER_WAREHOUSE_BIGQUERY_MAX_PARALLEL_LOADS", "8")
 				t.Setenv("RSERVER_WAREHOUSE_BIGQUERY_SLOW_QUERY_THRESHOLD", "0s")
+				t.Setenv("RSERVER_WAREHOUSE_SYNC_SCHEMA_FREQUENCY", "10s")
 
 				whth.BootstrapSvc(t, workspaceConfig, httpPort, jobsDBPort)
 

--- a/warehouse/router/router.go
+++ b/warehouse/router/router.go
@@ -721,7 +721,7 @@ func (r *Router) loadReloadableConfig(whName string) {
 	r.config.cronTrackerRetries = r.conf.GetReloadableInt64Var(5, 1, "Warehouse.cronTrackerRetries")
 	r.config.uploadBufferTimeInMin = r.conf.GetReloadableDurationVar(180, time.Minute, "Warehouse.uploadBufferTimeInMin")
 	r.config.syncSchemaFrequency = r.conf.GetDurationVar(12, time.Hour, "Warehouse.syncSchemaFrequency")
-    r.config.enableSyncSchema = r.conf.GetBoolVar(false, "Warehouse.enableSyncSchema")
+    r.config.enableSyncSchema = r.conf.GetBoolVar(true, "Warehouse.enableSyncSchema")
 }
 
 func (r *Router) loadStats() {

--- a/warehouse/router/router.go
+++ b/warehouse/router/router.go
@@ -721,7 +721,7 @@ func (r *Router) loadReloadableConfig(whName string) {
 	r.config.cronTrackerRetries = r.conf.GetReloadableInt64Var(5, 1, "Warehouse.cronTrackerRetries")
 	r.config.uploadBufferTimeInMin = r.conf.GetReloadableDurationVar(180, time.Minute, "Warehouse.uploadBufferTimeInMin")
 	r.config.syncSchemaFrequency = r.conf.GetDurationVar(12, time.Hour, "Warehouse.syncSchemaFrequency")
-    r.config.enableSyncSchema = r.conf.GetBoolVar(true, "Warehouse.enableSyncSchema")
+	r.config.enableSyncSchema = r.conf.GetBoolVar(true, "Warehouse.enableSyncSchema")
 }
 
 func (r *Router) loadStats() {

--- a/warehouse/router/sync.go
+++ b/warehouse/router/sync.go
@@ -2,12 +2,12 @@ package router
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/repo"
 	"github.com/rudderlabs/rudder-server/warehouse/schema"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
@@ -18,20 +18,22 @@ func (r *Router) sync(ctx context.Context) error {
 		warehouses := append([]model.Warehouse{}, r.warehouses...)
 		r.configSubscriberLock.RUnlock()
 		execTime := time.Now()
-		whManager, err := manager.New(r.destType, r.conf, r.logger, r.statsFactory)
-		if err != nil {
-			return fmt.Errorf("failed to create warehouse manager: %w", err)
-		}
 		for _, warehouse := range warehouses {
-			err := whManager.Setup(ctx, warehouse, warehouseutils.NewNoOpUploader())
+			whManager, err := manager.New(r.destType, r.conf, r.logger, r.statsFactory)
+			if err != nil {
+				r.logger.Errorn("create warehouse manager: %w", obskit.Error(err))
+				continue
+			}
+			err = whManager.Setup(ctx, warehouse, warehouseutils.NewNoOpUploader())
 			if err != nil {
 				r.logger.Errorn("failed to setup WH Manager", obskit.Error(err))
 				continue
 			}
-			if err := schema.SyncSchema(ctx, whManager, warehouse, r.db, r.logger.Child("syncer")); err != nil {
+			if err := schema.FetchAndSaveSchema(ctx, whManager, warehouse, repo.NewWHSchemas(r.db), r.logger.Child("syncer")); err != nil {
 				r.logger.Errorn("failed to sync schema", obskit.Error(err))
 				continue
 			}
+			whManager.Cleanup(ctx)
 		}
 		nextExecTime := execTime.Add(r.config.syncSchemaFrequency)
 		select {

--- a/warehouse/router/sync.go
+++ b/warehouse/router/sync.go
@@ -1,0 +1,44 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"github.com/rudderlabs/rudder-server/warehouse/schema"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+func (r *Router) sync(ctx context.Context) error {
+	for {
+		r.configSubscriberLock.RLock()
+		warehouses := append([]model.Warehouse{}, r.warehouses...)
+		r.configSubscriberLock.RUnlock()
+		execTime := time.Now()
+		whManager, err := manager.New(r.destType, r.conf, r.logger, r.statsFactory)
+		if err != nil {
+			return fmt.Errorf("failed to create warehouse manager: %w", err)
+		}
+		for _, warehouse := range warehouses {
+			err := whManager.Setup(ctx, warehouse, warehouseutils.NewNoOpUploader())
+			if err != nil {
+				r.logger.Errorn("failed to setup WH Manager", obskit.Error(err))
+				continue
+			}
+			if err := schema.SyncSchema(ctx, whManager, warehouse, r.db, r.logger.Child("syncer")); err != nil {
+				r.logger.Errorn("failed to sync schema", obskit.Error(err))
+				continue
+			}
+		}
+		nextExecTime := execTime.Add(r.config.syncSchemaFrequency)
+		select {
+		case <-ctx.Done():
+			r.logger.Infon("context is cancelled, stopped running schema syncer")
+			return nil
+		case <-time.After(time.Until(nextExecTime)):
+		}
+	}
+}

--- a/warehouse/router/sync_test.go
+++ b/warehouse/router/sync_test.go
@@ -1,0 +1,154 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	miniogo "github.com/minio/minio-go/v7"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/minio"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
+	sqlmiddleware "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"github.com/rudderlabs/rudder-server/warehouse/schema"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+func TestSync_SyncRemoteSchemaIntegration(t *testing.T) {
+	destinationType := warehouseutils.POSTGRES
+	bucket := "some-bucket"
+	sourceID := "test-source-id"
+	destinationID := "test-destination-id"
+	workspaceID := "test-workspace-id"
+	provider := "MINIO"
+	sslMode := "disable"
+	testNamespace := "test_namespace"
+	testTable := "test_table"
+
+	ctx := context.Background()
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pgResource, err := postgres.Setup(pool, t)
+	require.NoError(t, err)
+	minioResource, err := minio.Setup(pool, t)
+	require.NoError(t, err)
+
+	err = minioResource.Client.MakeBucket(ctx, bucket, miniogo.MakeBucketOptions{
+		Region: "us-east-1",
+	})
+	require.NoError(t, err)
+	t.Log("db:", pgResource.DBDsn)
+	conf := config.New()
+	err = (&migrator.Migrator{
+		Handle:          pgResource.DB,
+		MigrationsTable: "wh_schema_migrations",
+	}).Migrate("warehouse")
+	require.NoError(t, err)
+
+	db := sqlmiddleware.New(pgResource.DB)
+
+	warehouse := model.Warehouse{
+		WorkspaceID: workspaceID,
+		Source: backendconfig.SourceT{
+			ID: sourceID,
+		},
+		Destination: backendconfig.DestinationT{
+			ID: destinationID,
+			DestinationDefinition: backendconfig.DestinationDefinitionT{
+				Name: destinationType,
+			},
+			Config: map[string]interface{}{
+				"host":            pgResource.Host,
+				"port":            pgResource.Port,
+				"database":        pgResource.Database,
+				"user":            pgResource.User,
+				"password":        pgResource.Password,
+				"sslMode":         sslMode,
+				"bucketProvider":  provider,
+				"bucketName":      minioResource.BucketName,
+				"accessKeyID":     minioResource.AccessKeyID,
+				"secretAccessKey": minioResource.AccessKeySecret,
+				"endPoint":        minioResource.Endpoint,
+			},
+		},
+		Namespace:  "test_namespace",
+		Identifier: "RS:test-source-id:test-destination-id-create-jobs",
+	}
+	r := Router{
+		logger:       logger.NOP,
+		conf:         conf,
+		db:           db,
+		warehouses:   []model.Warehouse{warehouse},
+		destType:     warehouseutils.POSTGRES,
+		statsFactory: stats.NOP,
+	}
+	r.config.syncSchemaFrequency = 1 * time.Hour
+
+	setupCh := make(chan struct{})
+	syncCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	go func() {
+		defer close(setupCh)
+		err = r.sync(syncCtx)
+		require.NoError(t, err)
+	}()
+
+	t.Run("fetching schema from postgres", func(t *testing.T) {
+		schemaSql := fmt.Sprintf("CREATE SCHEMA %q;", testNamespace)
+		_, err = pgResource.DB.Exec(schemaSql)
+		require.NoError(t, err)
+
+		tableSql := fmt.Sprintf(`CREATE TABLE %q.%q (
+		job_id BIGSERIAL PRIMARY KEY,
+		workspace_id TEXT NOT NULL DEFAULT '',
+		uuid UUID NOT NULL,
+		user_id TEXT NOT NULL,
+		parameters JSONB NOT NULL,
+		custom_val VARCHAR(64) NOT NULL,
+		event_payload JSONB NOT NULL,
+		event_count INTEGER NOT NULL DEFAULT 1,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+		expire_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW());`, testNamespace, testTable)
+		_, err = pgResource.DB.Exec(tableSql)
+		require.NoError(t, err)
+
+		<-setupCh
+		r.conf.Set("Warehouse.enableSyncSchema", true)
+		sh, err := schema.New(
+			context.Background(),
+			r.db,
+			warehouse,
+			r.conf,
+			r.logger.Child("syncer"),
+			r.statsFactory,
+		)
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			schema, err := sh.GetLocalSchema(ctx)
+			require.NoError(t, err)
+			return reflect.DeepEqual(schema, model.Schema{
+				"test_table": model.TableSchema{
+					"created_at":    "datetime",
+					"event_count":   "int",
+					"event_payload": "json",
+					"expire_at":     "datetime",
+					"job_id":        "int",
+					"parameters":    "json",
+					"user_id":       "string",
+					"workspace_id":  "string",
+				},
+			})
+		}, 3*time.Second, 100*time.Millisecond)
+		cancel()
+	})
+}

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -148,7 +148,7 @@ func (f *UploadJobFactory) NewUploadJob(ctx context.Context, dto *model.UploadJo
 		logfield.UseRudderStorage, dto.Upload.UseRudderStorage,
 	)
 
-	schemaHandle, err := schema.New(
+	schemaHandle := schema.New(
 		ctx,
 		f.db,
 		dto.Warehouse,
@@ -156,10 +156,6 @@ func (f *UploadJobFactory) NewUploadJob(ctx context.Context, dto *model.UploadJo
 		f.logger.Child("warehouse"),
 		f.statsFactory,
 	)
-	if err != nil {
-		log.Errorw("failed to create schema handler", logfield.Error, err)
-		return nil
-	}
 
 	uj := &UploadJob{
 		ctx:                  ujCtx,

--- a/warehouse/schema/schema.go
+++ b/warehouse/schema/schema.go
@@ -101,7 +101,7 @@ func New(
 		stagingFilesSchemaPaginationSize: conf.GetInt("Warehouse.stagingFilesSchemaPaginationSize", 100),
 		enableIDResolution:               conf.GetBool("Warehouse.enableIDResolution", false),
 	}
-	if conf.GetBoolVar(false, "Warehouse.enableSyncSchema") {
+	if conf.GetBoolVar(true, "Warehouse.enableSyncSchema") {
 		schemaHandler, err := newSchemaV2(ctx, schemaV1, warehouse, log)
 		if err != nil {
 			return nil, fmt.Errorf("creating schema handler: %w", err)

--- a/warehouse/schema/schema_test.go
+++ b/warehouse/schema/schema_test.go
@@ -154,7 +154,7 @@ func TestSchema_UpdateLocalSchema(t *testing.T) {
 			statsStore, err := memstats.New()
 			require.NoError(t, err)
 
-			s := Schema{
+			s := schema{
 				warehouse: model.Warehouse{
 					WorkspaceID: workspaceID,
 					Source: backendconfig.SourceT{
@@ -352,7 +352,7 @@ func TestSchema_FetchSchemaFromWarehouse(t *testing.T) {
 				err:                           tc.mockErr,
 			}
 
-			s := &Schema{
+			s := &schema{
 				warehouse: model.Warehouse{
 					Source: backendconfig.SourceT{
 						ID: sourceID,
@@ -511,7 +511,7 @@ func TestSchema_TableSchemaDiff(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			s := Schema{
+			s := schema{
 				schemaInWarehouse: tc.currentSchema,
 			}
 			diff := s.TableSchemaDiff(tc.tableName, tc.uploadTableSchema)
@@ -592,7 +592,7 @@ func TestSchema_HasLocalSchemaChanged(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			s := &Schema{
+			s := &schema{
 				warehouse: model.Warehouse{
 					Type: warehouseutils.SNOWFLAKE,
 				},
@@ -1625,7 +1625,7 @@ func TestSchema_ConsolidateStagingFilesUsingLocalSchema(t *testing.T) {
 				err:     tc.mockErr,
 			}
 
-			s := &Schema{
+			s := &schema{
 				warehouse: model.Warehouse{
 					Source: backendconfig.SourceT{
 						ID: sourceID,
@@ -1668,7 +1668,7 @@ func TestSchema_SyncRemoteSchema(t *testing.T) {
 	tableName := "test_table_name"
 
 	t.Run("should return error if unable to fetch local schema", func(t *testing.T) {
-		s := &Schema{
+		s := &schema{
 			warehouse: model.Warehouse{
 				Source: backendconfig.SourceT{
 					ID: sourceID,
@@ -1697,7 +1697,7 @@ func TestSchema_SyncRemoteSchema(t *testing.T) {
 		require.False(t, schemaChanged)
 	})
 	t.Run("should return error if unable to fetch remote schema", func(t *testing.T) {
-		s := &Schema{
+		s := &schema{
 			warehouse: model.Warehouse{
 				Source: backendconfig.SourceT{
 					ID: sourceID,
@@ -1766,7 +1766,7 @@ func TestSchema_SyncRemoteSchema(t *testing.T) {
 			},
 		}
 
-		s := &Schema{
+		s := &schema{
 			warehouse: model.Warehouse{
 				Source: backendconfig.SourceT{
 					ID: sourceID,
@@ -1835,7 +1835,7 @@ func TestSchema_SyncRemoteSchema(t *testing.T) {
 			},
 		}
 
-		s := &Schema{
+		s := &schema{
 			warehouse: model.Warehouse{
 				Source: backendconfig.SourceT{
 					ID: sourceID,

--- a/warehouse/schema/schema_v2.go
+++ b/warehouse/schema/schema_v2.go
@@ -1,0 +1,143 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/samber/lo"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/repo"
+	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+type schemaV2 struct {
+	stats struct {
+		schemaSize stats.Histogram
+	}
+	cachedSchema model.Schema
+	warehouse    model.Warehouse
+	v1           *schema
+	log          logger.Logger
+	schemaMu     sync.RWMutex
+}
+
+func SyncSchema(ctx context.Context, fetchSchemaRepo fetchSchemaRepo, warehouse model.Warehouse, db *sqlquerywrapper.DB, log logger.Logger) error {
+	warehouseSchema, err := fetchSchemaRepo.FetchSchema(ctx)
+	if err != nil {
+		return fmt.Errorf("fetching schema: %w", err)
+	}
+	removeDeprecatedColumns(warehouseSchema, warehouse, log)
+	schemaRepo := repo.NewWHSchemas(db)
+	return writeSchema(ctx, schemaRepo, warehouse, warehouseSchema)
+}
+
+func newSchemaV2(ctx context.Context, v1 *schema, warehouse model.Warehouse, log logger.Logger) (*schemaV2, error) {
+	v2 := &schemaV2{
+		v1:        v1,
+		warehouse: warehouse,
+		log:       log,
+	}
+	var err error
+	v2.cachedSchema, err = v1.GetLocalSchema(ctx)
+	return v2, err
+}
+
+func (sh *schemaV2) SyncRemoteSchema(ctx context.Context, fetchSchemaRepo fetchSchemaRepo, uploadID int64) (bool, error) {
+	// no-op since syncing of local schema with warehouse schema is being done in the background
+	return false, nil
+}
+
+func (sh *schemaV2) IsWarehouseSchemaEmpty() bool {
+	sh.schemaMu.RLock()
+	defer sh.schemaMu.RUnlock()
+	return len(sh.cachedSchema) == 0
+}
+
+func (sh *schemaV2) GetTableSchemaInWarehouse(tableName string) model.TableSchema {
+	sh.schemaMu.RLock()
+	defer sh.schemaMu.RUnlock()
+	return sh.cachedSchema[tableName]
+}
+
+func (sh *schemaV2) GetLocalSchema(ctx context.Context) (model.Schema, error) {
+	return sh.cachedSchema, nil
+}
+
+func (sh *schemaV2) UpdateLocalSchema(ctx context.Context, updatedSchema model.Schema) error {
+	updatedSchemaInBytes, err := json.Marshal(updatedSchema)
+	if err != nil {
+		return fmt.Errorf("marshaling schema: %w", err)
+	}
+	sh.stats.schemaSize.Observe(float64(len(updatedSchemaInBytes)))
+	sh.schemaMu.Lock()
+	defer sh.schemaMu.Unlock()
+	err = writeSchema(ctx, sh.v1.schemaRepo, sh.warehouse, updatedSchema)
+	if err != nil {
+		return fmt.Errorf("updating local schema: %w", err)
+	}
+	sh.cachedSchema = updatedSchema
+	return nil
+}
+
+func (sh *schemaV2) UpdateWarehouseTableSchema(tableName string, tableSchema model.TableSchema) {
+	// no-op since there is no warehouse schema to update
+}
+
+func (sh *schemaV2) GetColumnsCountInWarehouseSchema(tableName string) int {
+	sh.schemaMu.RLock()
+	defer sh.schemaMu.RUnlock()
+	return len(sh.cachedSchema[tableName])
+}
+
+func (sh *schemaV2) ConsolidateStagingFilesUsingLocalSchema(ctx context.Context, stagingFiles []*model.StagingFile) (model.Schema, error) {
+	consolidatedSchema := model.Schema{}
+	batches := lo.Chunk(stagingFiles, sh.v1.stagingFilesSchemaPaginationSize)
+	for _, batch := range batches {
+		schemas, err := sh.v1.stagingFileRepo.GetSchemasByIDs(ctx, repo.StagingFileIDs(batch))
+		if err != nil {
+			return nil, fmt.Errorf("getting staging files schema: %v", err)
+		}
+
+		consolidatedSchema = consolidateStagingSchemas(consolidatedSchema, schemas)
+	}
+	sh.schemaMu.RLock()
+	consolidatedSchema = consolidateWarehouseSchema(consolidatedSchema, sh.cachedSchema)
+	consolidatedSchema = overrideUsersWithIdentifiesSchema(consolidatedSchema, sh.warehouse.Type, sh.cachedSchema)
+	sh.schemaMu.RUnlock()
+	consolidatedSchema = enhanceDiscardsSchema(consolidatedSchema, sh.warehouse.Type)
+	consolidatedSchema = enhanceSchemaWithIDResolution(consolidatedSchema, sh.v1.isIDResolutionEnabled(), sh.warehouse.Type)
+
+	return consolidatedSchema, nil
+}
+
+func (sh *schemaV2) UpdateLocalSchemaWithWarehouse(ctx context.Context) error {
+	// no-op
+	return nil
+}
+
+func (sh *schemaV2) TableSchemaDiff(tableName string, tableSchema model.TableSchema) whutils.TableSchemaDiff {
+	sh.schemaMu.RLock()
+	defer sh.schemaMu.RUnlock()
+	return tableSchemaDiff(tableName, sh.cachedSchema, tableSchema)
+}
+
+func (sh *schemaV2) FetchSchemaFromWarehouse(ctx context.Context, repo fetchSchemaRepo) error {
+	// no-op since local schema and warehouse schema are supposed to be in sync
+	return nil
+}
+
+func writeSchema(ctx context.Context, schemaRepo schemaRepo, warehouse model.Warehouse, updatedSchema model.Schema) error {
+	_, err := schemaRepo.Insert(ctx, &model.WHSchema{
+		SourceID:        warehouse.Source.ID,
+		Namespace:       warehouse.Namespace,
+		DestinationID:   warehouse.Destination.ID,
+		DestinationType: warehouse.Type,
+		Schema:          updatedSchema,
+	})
+	return err
+}

--- a/warehouse/schema/schema_v2_test.go
+++ b/warehouse/schema/schema_v2_test.go
@@ -1,0 +1,108 @@
+package schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+)
+
+type mFetchSchemaRepo struct{}
+
+var schema1 = model.Schema{
+	"identifies": model.TableSchema{
+		"id":      "string",
+		"user_id": "int",
+	},
+}
+
+var warehouse = model.Warehouse{
+	WorkspaceID: "workspaceID",
+	Source: backendconfig.SourceT{
+		ID: "sourceID",
+	},
+	Destination: backendconfig.DestinationT{
+		ID: "destinationID",
+	},
+	Namespace: "namespace",
+	Type:      "warehouseType",
+}
+
+func (m *mFetchSchemaRepo) FetchSchema(ctx context.Context) (model.Schema, error) {
+	return schema1, nil
+}
+
+type mSchemaRepo struct {
+	schemaMap map[string]model.WHSchema
+}
+
+func (m *mSchemaRepo) Insert(ctx context.Context, whSchema *model.WHSchema) (int64, error) {
+	if m.schemaMap == nil {
+		m.schemaMap = make(map[string]model.WHSchema)
+	}
+	m.schemaMap[whSchema.Namespace] = *whSchema
+	return 0, nil
+}
+
+func (m *mSchemaRepo) GetForNamespace(ctx context.Context, sourceID, destinationID, namespace string) (model.WHSchema, error) {
+	return m.schemaMap[namespace], nil
+}
+
+func TestFetchAndSaveSchema(t *testing.T) {
+	schemaRepo := &mSchemaRepo{}
+	v1 := &schema{
+		schemaRepo: schemaRepo,
+	}
+	ctx := context.Background()
+	v2 := newSchemaV2(ctx, v1, warehouse, nil, stats.NOP.NewStat("schema_size", "size of the schema"))
+	isEmpty := v2.IsWarehouseSchemaEmpty()
+	require.True(t, isEmpty)
+
+	fetchSchemaRepo := &mFetchSchemaRepo{}
+
+	err := FetchAndSaveSchema(ctx, fetchSchemaRepo, warehouse, schemaRepo, nil)
+	require.NoError(t, err)
+
+	schema, err := v2.GetLocalSchema(ctx)
+	require.NoError(t, err)
+	require.Equal(t, model.Schema{}, schema)
+
+	hasSchemaChanged, err := v2.SyncRemoteSchema(ctx, fetchSchemaRepo, 0)
+	require.NoError(t, err)
+	require.False(t, hasSchemaChanged)
+
+	schema, err = v2.GetLocalSchema(ctx)
+	require.NoError(t, err)
+	require.Equal(t, schema1, schema)
+}
+
+func TestUpdateLocalSchema(t *testing.T) {
+	schemaRepo := &mSchemaRepo{}
+	v1 := &schema{
+		schemaRepo: schemaRepo,
+	}
+	ctx := context.Background()
+	v2 := newSchemaV2(ctx, v1, warehouse, nil, stats.NOP.NewStat("schema_size", "size of the schema"))
+
+	schema, err := v2.GetLocalSchema(ctx)
+	require.NoError(t, err)
+	require.Equal(t, model.Schema{}, schema)
+
+	schema2 := model.Schema{
+		"users": model.TableSchema{
+			"anonymous_id": "string",
+			"received_at":  "datetime",
+		},
+	}
+
+	err = v2.UpdateLocalSchema(ctx, schema2)
+	require.NoError(t, err)
+
+	schema, err = v2.GetLocalSchema(ctx)
+	require.NoError(t, err)
+	require.Equal(t, schema2, schema)
+}


### PR DESCRIPTION
# Description

Related to #5347 

Refactoring
- Replaced the use of the `Schema` struct with the `SchemaHandler` interface, ensuring clients depend on an interface rather than the actual implementation.

New features
- Introduced a new implementation of `SchemaHandler`, `schemaV2`, where the schema in the database is the source of truth.
- Added a schema syncer that runs on a configurable schedule (copied from #5347).

Implementation Notes
- Retained existing method names to minimize the risk of regression and limit the scope of the PR. These can be updated once the `schema` implementation is deprecated.
- Controlled the choice between `schema` and `schemaV2` using an env.

## Linear Ticket

< Replace with Linear Link ( [create](https://linear.new?title=Awesome-pr-without-linear-ticket) or [search](https://linear.app/rudderstack/search) linear ticket) or  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
