### PR TITLE
feat: add validation library to be compatible with ingestion svc [PIPE-1834]

### DIFF
--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -637,7 +637,8 @@ func (gw *Handle) addToWebRequestQ(_ *http.ResponseWriter, req *http.Request, do
 }
 
 func (gw *Handle) internalBatchHandlerFunc() http.HandlerFunc {
-	// IMPORTANT: only use validation instead of encoding/json in this function or any functions called from this function to be compatible with ingestion service
+	// IMPORTANT: only use the "validation" package for all kinds of validation here to avoid
+	// any differences with the ingestion service.
 	return func(w http.ResponseWriter, r *http.Request) {
 		var (
 			ctx           = r.Context()

--- a/gateway/validation/validation.go
+++ b/gateway/validation/validation.go
@@ -18,7 +18,6 @@ func SanitizeJSON(input []byte) ([]byte, error) {
 	if len(v) == 0 {
 		v = []byte(`{}`)
 	}
-
 	var a stdjson.RawMessage
 	err := json.Unmarshal(v, &a)
 	if err != nil {
@@ -28,7 +27,6 @@ func SanitizeJSON(input []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return v, nil
 }
 

--- a/gateway/validation/validation.go
+++ b/gateway/validation/validation.go
@@ -3,16 +3,15 @@ package validation
 import (
 	"bytes"
 	stdjson "encoding/json"
-	"io"
 
 	jsoniter "github.com/json-iterator/go"
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
-// sanitizeJSON makes a json payload safe for writing into postgres.
+// SanitizeJSON makes a json payload safe for writing into postgres.
 // 1. Removes any \u0000 string from the payload
-// 2. unmashals and marshals the payload to remove any extra keys
+// 2. unmarshals and marshals the payload to remove any extra keys
 func SanitizeJSON(input []byte) ([]byte, error) {
 	v := bytes.ReplaceAll(input, []byte(`\u0000`), []byte(""))
 	if len(v) == 0 {
@@ -36,16 +35,4 @@ func Marshal(v interface{}) ([]byte, error) {
 
 func Unmarshal(data []byte, v interface{}) error {
 	return json.Unmarshal(data, v)
-}
-
-func Valid(data []byte) bool {
-	return json.Valid(data)
-}
-
-func NewDecoder(reader io.Reader) *jsoniter.Decoder {
-	return json.NewDecoder(reader)
-}
-
-func NewEncoder(writer io.Writer) *jsoniter.Encoder {
-	return json.NewEncoder(writer)
 }

--- a/gateway/validation/validation.go
+++ b/gateway/validation/validation.go
@@ -1,0 +1,53 @@
+package validation
+
+import (
+	"bytes"
+	stdjson "encoding/json"
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+// sanitizeJSON makes a json payload safe for writing into postgres.
+// 1. Removes any \u0000 string from the payload
+// 2. unmashals and marshals the payload to remove any extra keys
+func SanitizeJSON(input []byte) ([]byte, error) {
+	v := bytes.ReplaceAll(input, []byte(`\u0000`), []byte(""))
+	if len(v) == 0 {
+		v = []byte(`{}`)
+	}
+
+	var a stdjson.RawMessage
+	err := json.Unmarshal(v, &a)
+	if err != nil {
+		return nil, err
+	}
+	v, err = json.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+func Marshal(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+func Unmarshal(data []byte, v interface{}) error {
+	return json.Unmarshal(data, v)
+}
+
+func Valid(data []byte) bool {
+	return json.Valid(data)
+}
+
+func NewDecoder(reader io.Reader) *jsoniter.Decoder {
+	return json.NewDecoder(reader)
+}
+
+func NewEncoder(writer io.Writer) *jsoniter.Encoder {
+	return json.NewEncoder(writer)
+}

--- a/gateway/validation/validation_test.go
+++ b/gateway/validation/validation_test.go
@@ -1,0 +1,70 @@
+package validation
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobsDB_SanitizeJSON(t *testing.T) {
+	ch := func(n int) string {
+		return strings.Repeat("�", n)
+	}
+	toValidUTF8Tests := []struct {
+		in  string
+		out string
+		err error
+	}{
+		{`\u0000`, "", nil},
+		{`\u0000☺\u0000b☺`, "☺b☺", nil},
+		// NOTE: we are not handling the following:
+		// {"\u0000", ""},
+		// {"\u0000☺\u0000b☺", "☺b☺"},
+
+		{"", "", nil},
+		{"abc", "abc", nil},
+		{"\uFDDD", "\uFDDD", nil},
+		{"a\xffb", "a" + ch(1) + "b", nil},
+		{"a\xffb\uFFFD", "a" + ch(1) + "b\uFFFD", nil},
+		{"a☺\xffb☺\xC0\xAFc☺\xff", "a☺" + ch(1) + "b☺" + ch(2) + "c☺" + ch(1), nil},
+		{"\xC0\xAF", ch(2), nil},
+		{"\xE0\x80\xAF", ch(3), nil},
+		{"\xed\xa0\x80", ch(3), nil},
+		{"\xed\xbf\xbf", ch(3), nil},
+		{"\xF0\x80\x80\xaf", ch(4), nil},
+		{"\xF8\x80\x80\x80\xAF", ch(5), nil},
+		{"\xFC\x80\x80\x80\x80\xAF", ch(6), nil},
+
+		// {"\ud800", ""},
+		{`\ud800`, ch(1), nil},
+		{`\uDEAD`, ch(1), nil},
+
+		{`\uD83D\ub000`, string([]byte{239, 191, 189, 235, 128, 128}), nil},
+		{`\uD83D\ude04`, "😄", nil},
+
+		{`\u4e2d\u6587`, "中文", nil},
+		{`\ud83d\udc4a`, "\xf0\x9f\x91\x8a", nil},
+
+		{`\U0001f64f`, ch(1), errors.New(`readEscapedChar: invalid escape char after`)},
+		{`\uD83D\u00`, ch(1), errors.New(`readU4: expects 0~9 or a~f, but found`)},
+	}
+
+	eventPayload := []byte(`{"batch": [{"anonymousId":"anon_id","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}]}`)
+	for _, tt := range toValidUTF8Tests {
+		sanitizedPayload, err := SanitizeJSON(bytes.Replace(eventPayload, []byte("track"), []byte(tt.in), 1))
+		if tt.err != nil {
+			require.Error(t, err, "should error")
+			require.Contains(t, err.Error(), tt.err.Error(), "should contain error")
+			continue
+		}
+
+		require.NoError(t, err)
+		require.JSONEq(t,
+			string(bytes.Replace(eventPayload, []byte("track"), []byte(tt.out), 1)),
+			string(sanitizedPayload),
+		)
+	}
+}


### PR DESCRIPTION
# Description

add validation library to be compatible with ingestion svc

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1834/gateway-validation-library

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
