### PR TITLE
feat: remove unnecessary fields from UT payload

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -101,10 +101,10 @@ type TransformerEvent struct {
 	Credentials []Credential               `json:"credentials"`
 }
 
-// Dehydrate removes the connection and credentials from the event
+// GetVersionsOnly removes the connection and credentials from the event
 // along with pruning the destination to only include the transformation versionID
 // before sending it to the transformer thereby reducing the payload size
-func (e *TransformerEvent) Dehydrate() *TransformerEvent {
+func (e *TransformerEvent) GetVersionsOnly() *TransformerEvent {
 	tmCopy := *e
 	transformations := make([]backendconfig.TransformationT, 0, len(e.Destination.Transformations))
 	for _, t := range e.Destination.Transformations {
@@ -290,7 +290,7 @@ func (trans *handle) Transform(ctx context.Context, clientEvents []TransformerEv
 func (trans *handle) UserTransform(ctx context.Context, clientEvents []TransformerEvent, batchSize int) Response {
 	var dehydratedClientEvents []TransformerEvent
 	for _, clientEvent := range clientEvents {
-		dehydratedClientEvent := clientEvent.Dehydrate()
+		dehydratedClientEvent := clientEvent.GetVersionsOnly()
 		dehydratedClientEvents = append(dehydratedClientEvents, *dehydratedClientEvent)
 	}
 

--- a/processor/transformer/transformer_test.go
+++ b/processor/transformer/transformer_test.go
@@ -13,25 +13,22 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/mock/gomock"
-
-	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
-	"github.com/rudderlabs/rudder-server/testhelper/backendconfigtest"
-	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
-
-	"github.com/rudderlabs/rudder-server/utils/types"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/rudderlabs/rudder-go-kit/logger/mock_logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
-	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
-
-	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
-	"github.com/rudderlabs/rudder-server/gateway/response"
+	"go.uber.org/mock/gomock"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/logger/mock_logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/gateway/response"
+	"github.com/rudderlabs/rudder-server/testhelper/backendconfigtest"
+	"github.com/rudderlabs/rudder-server/utils/types"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
 type fakeTransformer struct {
@@ -888,4 +885,130 @@ func TestLongRunningTransformation(t *testing.T) {
 		}
 		cancel()
 	})
+}
+
+func TestTransformerEvent_Dehydrate(t *testing.T) {
+	testCases := []struct {
+		name     string
+		event    *TransformerEvent
+		expected *TransformerEvent
+	}{
+		{
+			name: "remove connections",
+			event: &TransformerEvent{
+				Metadata: Metadata{},
+				Message:  map[string]interface{}{},
+				Connection: backendconfig.Connection{
+					SourceID:      "source-id",
+					DestinationID: "destination-id",
+				},
+				Destination: backendconfig.DestinationT{
+					Transformations: make([]backendconfig.TransformationT, 0),
+				},
+			},
+			expected: &TransformerEvent{
+				Metadata:   Metadata{},
+				Message:    map[string]interface{}{},
+				Connection: backendconfig.Connection{},
+				Destination: backendconfig.DestinationT{
+					Transformations: make([]backendconfig.TransformationT, 0),
+				},
+			},
+		},
+		{
+			name: "remove everything except transformations in destination",
+			event: &TransformerEvent{
+				Metadata: Metadata{},
+				Message:  map[string]interface{}{},
+				Connection: backendconfig.Connection{
+					SourceID:      "source-id",
+					DestinationID: "destination-id",
+				},
+				Destination: backendconfig.DestinationT{
+					ID:              "destination-id",
+					Transformations: make([]backendconfig.TransformationT, 0),
+					Name:            "destination-name",
+					Config: map[string]interface{}{
+						"key": "value",
+						"key2": map[string]interface{}{
+							"key": "value",
+						},
+						"key3": []interface{}{"value"},
+					},
+					DestinationDefinition: backendconfig.DestinationDefinitionT{
+						Name:          "destination-definition-name",
+						Config:        map[string]interface{}{},
+						ResponseRules: map[string]interface{}{},
+					},
+				},
+			},
+			expected: &TransformerEvent{
+				Metadata:   Metadata{},
+				Message:    map[string]interface{}{},
+				Connection: backendconfig.Connection{},
+				Destination: backendconfig.DestinationT{
+					Transformations: make([]backendconfig.TransformationT, 0),
+				},
+			},
+		},
+		{
+			name: "remove everything except transformations in destination with multiple transformer versions",
+			event: &TransformerEvent{
+				Metadata: Metadata{},
+				Message:  map[string]interface{}{},
+				Connection: backendconfig.Connection{
+					SourceID:      "source-id",
+					DestinationID: "destination-id",
+				},
+				Destination: backendconfig.DestinationT{
+					ID: "destination-id",
+					Transformations: []backendconfig.TransformationT{
+						{
+							ID:        "transformation-id",
+							VersionID: "version-id",
+							Config:    map[string]interface{}{},
+						},
+						{
+							ID:        "transformation-id-2",
+							VersionID: "version-id-2",
+							Config:    map[string]interface{}{},
+						},
+					},
+					Name: "destination-name",
+					Config: map[string]interface{}{
+						"key": "value",
+						"key2": map[string]interface{}{
+							"key": "value",
+						},
+						"key3": []interface{}{"value"},
+					},
+					DestinationDefinition: backendconfig.DestinationDefinitionT{
+						Name:          "destination-definition-name",
+						Config:        map[string]interface{}{},
+						ResponseRules: map[string]interface{}{},
+					},
+				},
+			},
+			expected: &TransformerEvent{
+				Metadata:   Metadata{},
+				Message:    map[string]interface{}{},
+				Connection: backendconfig.Connection{},
+				Destination: backendconfig.DestinationT{
+					Transformations: []backendconfig.TransformationT{
+						{
+							VersionID: "version-id",
+						},
+						{
+							VersionID: "version-id-2",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.event.Dehydrate())
+		})
+	}
 }

--- a/processor/transformer/transformer_test.go
+++ b/processor/transformer/transformer_test.go
@@ -1008,7 +1008,7 @@ func TestTransformerEvent_Dehydrate(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.event.Dehydrate())
+			assert.Equal(t, tc.expected, tc.event.GetVersionsOnly())
 		})
 	}
 }


### PR DESCRIPTION
# Description

This pull request aims to enhance the efficiency of the User Transformation (UT) payload by eliminating unnecessary fields, thereby improving performance by reducing payload size.

Changes Introduced:
Field Removal: Unused or redundant fields have been identified and removed from the UT payload structure.

<img width="1495" alt="Screenshot 2025-01-13 at 5 21 06 PM" src="https://github.com/user-attachments/assets/dee45e3d-4636-4594-a15b-990dabc70ed1" />

In the image shown above the blue line represent the latency for a User Transformation with master and the yellow line represent the latency with the changes made in this PR. This change leads to 10-15% reduction in latency

## Linear Ticket

Fixes PIPE-1845

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
