### PR TITLE
fix: databricks external location

### DIFF
--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -517,7 +517,7 @@ func (d *Deltalake) tableLocationQuery(tableName string) string {
 	enableExternalLocation := d.Warehouse.GetBoolDestinationConfig(model.EnableExternalLocationSetting)
 	externalLocation := d.Warehouse.GetStringDestinationConfig(d.conf, model.ExternalLocationSetting)
 
-	if enableExternalLocation || externalLocation == "" {
+	if !enableExternalLocation || externalLocation == "" {
 		return ""
 	}
 


### PR DESCRIPTION
# Description

- There seems to be a bug that got introduced in [this](https://github.com/rudderlabs/rudder-server/pull/5001) PR. 

```GO
func (d *Deltalake) tableLocationQuery(tableName string) string {
	enableExternalLocation := warehouseutils.GetConfigValueBoolString(configKeyEnableExternalLocation, d.Warehouse)
	externalLocation := warehouseutils.GetConfigValue(configKeyExternalLocation, d.Warehouse)

	if enableExternalLocation != "true" || externalLocation == "" {
		return ""
	}

	return fmt.Sprintf("LOCATION '%s/%s/%s'", externalLocation, d.Namespace, tableName)
}
```
Got converted to 
```GO
func (d *Deltalake) tableLocationQuery(tableName string) string {
	enableExternalLocation := d.Warehouse.GetBoolDestinationConfig(model.EnableExternalLocationSetting)
	externalLocation := d.Warehouse.GetStringDestinationConfig(d.conf, model.ExternalLocationSetting)

	if enableExternalLocation || externalLocation == "" {
		return ""
	}

	return fmt.Sprintf("LOCATION '%s/%s/%s'", externalLocation, d.Namespace, tableName)
}
```


## Linear Ticket

- Resolves WAR-172

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
