### PR TITLE
chore: transformer 404 error logs

### DIFF
--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -480,7 +480,6 @@ func (trans *handle) request(ctx context.Context, url, stage string, data []Tran
 	switch statusCode {
 	case http.StatusOK,
 		http.StatusBadRequest,
-		http.StatusNotFound,
 		http.StatusRequestEntityTooLarge:
 	default:
 		trans.logger.Errorf("Transformer returned status code: %v", statusCode)

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -502,6 +502,9 @@ func (trans *handle) request(ctx context.Context, url, stage string, data []Tran
 			panic(err)
 		}
 	default:
+		if statusCode == http.StatusNotFound {
+			statusCode = http.StatusInternalServerError
+		}
 		for i := range data {
 			transformEvent := &data[i]
 			resp := TransformerResponse{StatusCode: statusCode, Error: string(respData), Metadata: transformEvent.Metadata}

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -502,9 +502,6 @@ func (trans *handle) request(ctx context.Context, url, stage string, data []Tran
 			panic(err)
 		}
 	default:
-		if statusCode == http.StatusNotFound {
-			statusCode = http.StatusInternalServerError
-		}
 		for i := range data {
 			transformEvent := &data[i]
 			resp := TransformerResponse{StatusCode: statusCode, Error: string(respData), Metadata: transformEvent.Metadata}

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -583,7 +583,7 @@ func (trans *handle) doProxyRequest(ctx context.Context, proxyUrl string, proxyR
 	} else if resp.StatusCode == http.StatusNotFound {
 		// Actually Router wouldn't send any destination to proxy unless it already exists
 		// But if accidentally such a request is sent, failing instead of aborting
-		notFoundErr := fmt.Errorf(`post "%s" not found`, req.URL)
+		notFoundErr := fmt.Errorf(`Transformer returned status code: %v | post "%s" not found`, http.StatusNotFound, req.URL)
 		trans.logger.Errorf(`[TransformerProxy] (Dest-%[1]v) Client.Do Failure for %[1]v, with %[2]v`, destName, notFoundErr)
 		return httpProxyResponse{
 			respData:   []byte{},

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -583,7 +583,7 @@ func (trans *handle) doProxyRequest(ctx context.Context, proxyUrl string, proxyR
 	} else if resp.StatusCode == http.StatusNotFound {
 		// Actually Router wouldn't send any destination to proxy unless it already exists
 		// But if accidentally such a request is sent, failing instead of aborting
-		notFoundErr := fmt.Errorf(`Transformer returned status code: %v | post "%s" not found`, http.StatusNotFound, req.URL)
+		notFoundErr := fmt.Errorf(`post "%s" not found`, req.URL)
 		trans.logger.Errorf(`[TransformerProxy] (Dest-%[1]v) Client.Do Failure for %[1]v, with %[2]v`, destName, notFoundErr)
 		return httpProxyResponse{
 			respData:   []byte{},


### PR DESCRIPTION
# Description

This commit aims to allow logging of 404 errors in the processor while communicating with transformer to trigger log based alerts (loki)

Transformer can respond with 404 errors if the destination is not available in the transformer image but the config-backend has the destination.
This can only happend when some outdated transformer image is used in the deployment. In order to catch such errors and immediately alert (throw loki-log based triggers) the team to make a fix, we aim to log 404 errors and add alerts for those errors.
The below ticket is attached with corresponding alert PR in devops as well.

## Linear Ticket

Resolves INT-3031
https://linear.app/rudderstack/issue/INT-3031/revisit-transformer-and-rudder-server-api-contracts-and-throw-alerts

## Security

- [X] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
