### PR TITLE
fix: report modification in reporting during event sampling

### DIFF
--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -266,8 +266,10 @@ func (edr *ErrorDetailReporter) Report(ctx context.Context, metrics []*types.PUR
 			"destinationId": metric.ConnectionDetails.DestinationID,
 		}).Count(int(metric.StatusDetail.Count))
 
+		var sampleEvent json.RawMessage
+		var sampleResponse string
 		if edr.eventSamplingEnabled.Load() {
-			metric, err = transformMetricWithEventSampling(metric, reportedAt, edr.eventSampler, int64(edr.eventSamplingDuration.Load().Minutes()))
+			sampleEvent, sampleResponse, err = getSampleWithEventSampling(metric, reportedAt, edr.eventSampler, int64(edr.eventSamplingDuration.Load().Minutes()))
 			if err != nil {
 				return err
 			}
@@ -289,8 +291,8 @@ func (edr *ErrorDetailReporter) Report(ctx context.Context, metrics []*types.PUR
 			metric.StatusDetail.EventType,
 			metric.StatusDetail.ErrorDetails.Code,
 			metric.StatusDetail.ErrorDetails.Message,
-			metric.StatusDetail.SampleResponse,
-			string(metric.StatusDetail.SampleEvent),
+			sampleResponse,
+			string(sampleEvent),
 			metric.StatusDetail.EventName,
 		)
 		if err != nil {

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -266,13 +266,9 @@ func (edr *ErrorDetailReporter) Report(ctx context.Context, metrics []*types.PUR
 			"destinationId": metric.ConnectionDetails.DestinationID,
 		}).Count(int(metric.StatusDetail.Count))
 
-		var sampleEvent json.RawMessage
-		var sampleResponse string
-		if edr.eventSamplingEnabled.Load() {
-			sampleEvent, sampleResponse, err = getSampleWithEventSampling(metric, reportedAt, edr.eventSampler, int64(edr.eventSamplingDuration.Load().Minutes()))
-			if err != nil {
-				return err
-			}
+		sampleEvent, sampleResponse, err := getSampleWithEventSampling(metric, reportedAt, edr.eventSampler, edr.eventSamplingEnabled.Load(), int64(edr.eventSamplingDuration.Load().Minutes()))
+		if err != nil {
+			return err
 		}
 
 		_, err = stmt.Exec(

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -685,8 +685,10 @@ func (r *DefaultReporter) Report(ctx context.Context, metrics []*types.PUReporte
 			metric = transformMetricForPII(metric, getPIIColumnsToExclude())
 		}
 
+		var sampleEvent json.RawMessage
+		var sampleResponse string
 		if r.eventSamplingEnabled.Load() {
-			metric, err = transformMetricWithEventSampling(metric, reportedAt, r.eventSampler, int64(r.eventSamplingDuration.Load().Minutes()))
+			sampleEvent, sampleResponse, err = getSampleWithEventSampling(metric, reportedAt, r.eventSampler, int64(r.eventSamplingDuration.Load().Minutes()))
 			if err != nil {
 				return err
 			}
@@ -717,7 +719,7 @@ func (r *DefaultReporter) Report(ctx context.Context, metrics []*types.PUReporte
 			metric.StatusDetail.Count, metric.StatusDetail.ViolationCount,
 			metric.PUDetails.TerminalPU, metric.PUDetails.InitialPU,
 			metric.StatusDetail.StatusCode,
-			metric.StatusDetail.SampleResponse, string(metric.StatusDetail.SampleEvent),
+			sampleResponse, string(sampleEvent),
 			metric.StatusDetail.EventName, metric.StatusDetail.EventType,
 			metric.StatusDetail.ErrorType,
 		)

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -685,13 +685,9 @@ func (r *DefaultReporter) Report(ctx context.Context, metrics []*types.PUReporte
 			metric = transformMetricForPII(metric, getPIIColumnsToExclude())
 		}
 
-		var sampleEvent json.RawMessage
-		var sampleResponse string
-		if r.eventSamplingEnabled.Load() {
-			sampleEvent, sampleResponse, err = getSampleWithEventSampling(metric, reportedAt, r.eventSampler, int64(r.eventSamplingDuration.Load().Minutes()))
-			if err != nil {
-				return err
-			}
+		sampleEvent, sampleResponse, err := getSampleWithEventSampling(metric, reportedAt, r.eventSampler, r.eventSamplingEnabled.Load(), int64(r.eventSamplingDuration.Load().Minutes()))
+		if err != nil {
+			return err
 		}
 
 		runeEventName := []rune(metric.StatusDetail.EventName)

--- a/enterprise/reporting/util_test.go
+++ b/enterprise/reporting/util_test.go
@@ -234,7 +234,7 @@ func TestGetSampleWithEventSamplingWithNilEventSampler(t *testing.T) {
 			SampleResponse: inputSampleResponse,
 		},
 	}
-	outputSampleEvent, outputSampleResponse, err := getSampleWithEventSampling(metric, 1234567890, nil, 60)
+	outputSampleEvent, outputSampleResponse, err := getSampleWithEventSampling(metric, 1234567890, nil, false, 60)
 	require.NoError(t, err)
 	require.Equal(t, inputSampleEvent, outputSampleEvent)
 	require.Equal(t, inputSampleResponse, outputSampleResponse)
@@ -392,7 +392,7 @@ func TestGetSampleWithEventSampling(t *testing.T) {
 				mockEventSampler.EXPECT().Put(gomock.Any()).Return(tt.putError)
 			}
 
-			sampleEvent, sampleResponse, err := getSampleWithEventSampling(tt.metric, 1234567890, mockEventSampler, 60)
+			sampleEvent, sampleResponse, err := getSampleWithEventSampling(tt.metric, 1234567890, mockEventSampler, true, 60)
 			if tt.getError != nil || tt.putError != nil {
 				require.Error(t, err)
 			} else {

--- a/enterprise/reporting/util_test.go
+++ b/enterprise/reporting/util_test.go
@@ -1,6 +1,7 @@
 package reporting
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -224,19 +225,19 @@ func TestGetAggregationBucket(t *testing.T) {
 	})
 }
 
-func TestTransformMetricWithEventSamplingWithNilEventSampler(t *testing.T) {
-	sampleEvent := []byte(`{"event": "1"}`)
-	sampleResponse := "response"
+func TestGetSampleWithEventSamplingWithNilEventSampler(t *testing.T) {
+	inputSampleEvent := json.RawMessage(`{"event": "1"}`)
+	inputSampleResponse := "response"
 	metric := types.PUReportedMetric{
 		StatusDetail: &types.StatusDetail{
-			SampleEvent:    sampleEvent,
-			SampleResponse: sampleResponse,
+			SampleEvent:    inputSampleEvent,
+			SampleResponse: inputSampleResponse,
 		},
 	}
-	transformedMetric, err := transformMetricWithEventSampling(metric, 1234567890, nil, 60)
+	outputSampleEvent, outputSampleResponse, err := getSampleWithEventSampling(metric, 1234567890, nil, 60)
 	require.NoError(t, err)
-	require.Equal(t, sampleEvent, []byte(transformedMetric.StatusDetail.SampleEvent))
-	require.Equal(t, sampleResponse, transformedMetric.StatusDetail.SampleResponse)
+	require.Equal(t, inputSampleEvent, outputSampleEvent)
+	require.Equal(t, inputSampleResponse, outputSampleResponse)
 }
 
 func TestFloorFactor(t *testing.T) {
@@ -267,10 +268,10 @@ func TestFloorFactor(t *testing.T) {
 	}
 }
 
-func TestTransformMetricWithEventSampling(t *testing.T) {
-	sampleEvent := []byte(`{"event": "2"}`)
+func TestGetSampleWithEventSampling(t *testing.T) {
+	sampleEvent := json.RawMessage(`{"event": "2"}`)
 	sampleResponse := "sample response"
-	emptySampleEvent := []byte(`{}`)
+	emptySampleEvent := json.RawMessage(`{}`)
 	emptySampleResponse := ""
 
 	tests := []struct {
@@ -391,14 +392,14 @@ func TestTransformMetricWithEventSampling(t *testing.T) {
 				mockEventSampler.EXPECT().Put(gomock.Any()).Return(tt.putError)
 			}
 
-			gotMetric, err := transformMetricWithEventSampling(tt.metric, 1234567890, mockEventSampler, 60)
+			sampleEvent, sampleResponse, err := getSampleWithEventSampling(tt.metric, 1234567890, mockEventSampler, 60)
 			if tt.getError != nil || tt.putError != nil {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 			}
-			require.Equal(t, tt.wantMetric.StatusDetail.SampleEvent, gotMetric.StatusDetail.SampleEvent)
-			require.Equal(t, tt.wantMetric.StatusDetail.SampleResponse, gotMetric.StatusDetail.SampleResponse)
+			require.Equal(t, tt.wantMetric.StatusDetail.SampleEvent, sampleEvent)
+			require.Equal(t, tt.wantMetric.StatusDetail.SampleResponse, sampleResponse)
 		})
 	}
 }

--- a/enterprise/reporting/utils.go
+++ b/enterprise/reporting/utils.go
@@ -45,32 +45,35 @@ func getAggregationBucketMinute(timeMs, intervalMs int64) (int64, int64) {
 	return bucketStart, bucketEnd
 }
 
-func transformMetricWithEventSampling(metric types.PUReportedMetric, reportedAt int64, eventSampler event_sampler.EventSampler, eventSamplingDuration int64) (types.PUReportedMetric, error) {
+func getSampleWithEventSampling(metric types.PUReportedMetric, reportedAt int64, eventSampler event_sampler.EventSampler, eventSamplingDuration int64) (sampleEvent json.RawMessage, sampleResponse string, err error) {
+	sampleEvent = metric.StatusDetail.SampleEvent
+	sampleResponse = metric.StatusDetail.SampleResponse
+
 	if eventSampler == nil {
-		return metric, nil
+		return sampleEvent, sampleResponse, nil
 	}
 
-	isValidSample := (metric.StatusDetail.SampleEvent != nil && string(metric.StatusDetail.SampleEvent) != "{}") || metric.StatusDetail.SampleResponse != ""
+	isValidSample := (sampleEvent != nil && string(sampleEvent) != "{}") || sampleResponse != ""
 
 	if isValidSample {
 		sampleEventBucket, _ := getAggregationBucketMinute(reportedAt, eventSamplingDuration)
 		hash := NewLabelSet(metric, sampleEventBucket).generateHash()
-		found, err := eventSampler.Get(hash)
+
+		var found bool
+		found, err = eventSampler.Get(hash)
 		if err != nil {
-			return metric, err
+			return sampleEvent, sampleResponse, err
 		}
 
 		if found {
-			metric.StatusDetail.SampleEvent = json.RawMessage(`{}`)
-			metric.StatusDetail.SampleResponse = ""
+			sampleEvent = json.RawMessage(`{}`)
+			sampleResponse = ""
 		} else {
-			err := eventSampler.Put(hash)
-			if err != nil {
-				return metric, err
-			}
+			err = eventSampler.Put(hash)
 		}
 	}
-	return metric, nil
+
+	return sampleEvent, sampleResponse, err
 }
 
 func transformMetricForPII(metric types.PUReportedMetric, piiColumns []string) types.PUReportedMetric {

--- a/enterprise/reporting/utils.go
+++ b/enterprise/reporting/utils.go
@@ -45,11 +45,11 @@ func getAggregationBucketMinute(timeMs, intervalMs int64) (int64, int64) {
 	return bucketStart, bucketEnd
 }
 
-func getSampleWithEventSampling(metric types.PUReportedMetric, reportedAt int64, eventSampler event_sampler.EventSampler, eventSamplingDuration int64) (sampleEvent json.RawMessage, sampleResponse string, err error) {
+func getSampleWithEventSampling(metric types.PUReportedMetric, reportedAt int64, eventSampler event_sampler.EventSampler, eventSamplingEnabled bool, eventSamplingDuration int64) (sampleEvent json.RawMessage, sampleResponse string, err error) {
 	sampleEvent = metric.StatusDetail.SampleEvent
 	sampleResponse = metric.StatusDetail.SampleResponse
 
-	if eventSampler == nil {
+	if !eventSamplingEnabled || eventSampler == nil {
 		return sampleEvent, sampleResponse, nil
 	}
 


### PR DESCRIPTION
# Description
In Reporting Report function, we are modifying the metric object by removing sample event and sample response when  event sampling is enabled. This same metrics is used by error reporting since metric is being passed as pointer. 

Because of this, error reporting will not get all samples. So, we should transform the metric in any reporter.

## Linear Ticket

Completes OBS-763

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
