### PR TITLE
chore: configurable transformer http client in processor, router

### DIFF
--- a/internal/transformer-client/client.go
+++ b/internal/transformer-client/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bufbuild/httplb/health"
 	"github.com/bufbuild/httplb/picker"
 	"github.com/bufbuild/httplb/resolver"
+
 	"github.com/rudderlabs/rudder-server/utils/sysUtils"
 )
 
@@ -129,7 +130,7 @@ func (t *HTTPLBTransport) NewRoundTripper(scheme, target string, config httplb.T
 	return httplb.RoundTripperResult{RoundTripper: t.Transport, Close: t.CloseIdleConnections}
 }
 
-func getChecker(checkerType string, url string) health.Checker {
+func getChecker(checkerType, url string) health.Checker {
 	switch checkerType {
 	case "nop":
 		return health.NopChecker

--- a/internal/transformer-client/client.go
+++ b/internal/transformer-client/client.go
@@ -2,6 +2,8 @@ package transformerclient
 
 import (
 	"context"
+	"github.com/bufbuild/httplb/resolver"
+	"net"
 	"net/http"
 	"time"
 
@@ -91,8 +93,9 @@ func NewClient(config *ClientConfig) Client {
 			httplb.WithHealthChecks(getChecker(checkerType, config.CheckURL)),
 			httplb.WithIdleConnectionTimeout(transport.IdleConnTimeout),
 			httplb.WithRequestTimeout(client.Timeout),
-			httplb.WithRoundTripperMaxLifetime(clientTTL),
-			httplb.WithIdleTransportTimeout(2*clientTTL),
+			httplb.WithRoundTripperMaxLifetime(transport.IdleConnTimeout),
+			httplb.WithIdleTransportTimeout(2*transport.IdleConnTimeout),
+			httplb.WithResolver(resolver.NewDNSResolver(net.DefaultResolver, resolver.PreferIPv4, clientTTL)),
 		)
 	default:
 		return client

--- a/internal/transformer-client/client.go
+++ b/internal/transformer-client/client.go
@@ -2,7 +2,6 @@ package transformerclient
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"time"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/bufbuild/httplb/conn"
 	"github.com/bufbuild/httplb/health"
 	"github.com/bufbuild/httplb/picker"
-	httplbResolver "github.com/bufbuild/httplb/resolver"
 
 	"github.com/rudderlabs/rudder-server/utils/sysUtils"
 )
@@ -32,9 +30,6 @@ type ClientConfig struct {
 
 	CheckerType string // nop, polling
 	CheckURL    string
-
-	ResolverType     string //	minConns, default
-	ResolverMinConns int    //	64
 }
 
 type Client interface {
@@ -90,14 +85,6 @@ func NewClient(config *ClientConfig) Client {
 		if config.CheckURL == "" {
 			checkerType = "nop"
 		}
-		res := defaultReasolver(clientTTL)
-		if config.ResolverType == "minConns" {
-			minConns := 64
-			if config.ResolverMinConns != 0 {
-				minConns = config.ResolverMinConns
-			}
-			res = minConnsResolver(clientTTL, minConns)
-		}
 		return httplb.NewClient(
 			httplb.WithRootContext(context.TODO()),
 			httplb.WithPicker(getPicker(config.PickerType)),
@@ -106,7 +93,6 @@ func NewClient(config *ClientConfig) Client {
 			httplb.WithRequestTimeout(client.Timeout),
 			httplb.WithRoundTripperMaxLifetime(clientTTL),
 			httplb.WithIdleTransportTimeout(2*clientTTL),
-			httplb.WithResolver(res),
 		)
 	default:
 		return client
@@ -150,12 +136,4 @@ func getChecker(checkerType, url string) health.Checker {
 	default:
 		return health.NopChecker
 	}
-}
-
-func minConnsResolver(ttl time.Duration, minConns int) httplbResolver.Resolver {
-	return httplbResolver.MinConnections(defaultReasolver(ttl), minConns)
-}
-
-func defaultReasolver(ttl time.Duration) httplbResolver.Resolver {
-	return httplbResolver.NewDNSResolver(net.DefaultResolver, httplbResolver.PreferIPv4, ttl)
 }

--- a/internal/transformer-client/client.go
+++ b/internal/transformer-client/client.go
@@ -2,7 +2,6 @@ package transformerclient
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"time"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/bufbuild/httplb/conn"
 	"github.com/bufbuild/httplb/health"
 	"github.com/bufbuild/httplb/picker"
-	"github.com/bufbuild/httplb/resolver"
 
 	"github.com/rudderlabs/rudder-server/utils/sysUtils"
 )
@@ -91,13 +89,6 @@ func NewClient(config *ClientConfig) Client {
 			httplb.WithRootContext(context.TODO()),
 			httplb.WithPicker(getPicker(config.PickerType)),
 			httplb.WithHealthChecks(getChecker(checkerType, config.CheckURL)),
-			httplb.WithResolver(
-				resolver.NewDNSResolver(
-					net.DefaultResolver,
-					resolver.PreferIPv6,
-					clientTTL,
-				),
-			),
 			httplb.WithIdleConnectionTimeout(transport.IdleConnTimeout),
 			httplb.WithRequestTimeout(client.Timeout),
 			httplb.WithRoundTripperMaxLifetime(clientTTL),

--- a/internal/transformer-client/client.go
+++ b/internal/transformer-client/client.go
@@ -1,0 +1,144 @@
+package transformerclient
+
+import (
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/bufbuild/httplb"
+	"github.com/bufbuild/httplb/conn"
+	"github.com/bufbuild/httplb/health"
+	"github.com/bufbuild/httplb/picker"
+	"github.com/bufbuild/httplb/resolver"
+	"github.com/rudderlabs/rudder-server/utils/sysUtils"
+)
+
+type ClientConfig struct {
+	TransportConfig struct {
+		DisableKeepAlives   bool          //	true
+		MaxConnsPerHost     int           //	100
+		MaxIdleConnsPerHost int           //	10
+		IdleConnTimeout     time.Duration //	30*time.Second
+	}
+
+	ClientTimeout time.Duration //	600*time.Second
+	ClientTTL     time.Duration //	120*time.Second
+
+	ClientType string // stdlib(default), recycled, httplb
+
+	PickerType string // power_of_two(default), round_robin, least_loaded_random, least_loaded_round_robin, random
+
+	CheckerType string // nop, polling
+	CheckURL    string
+}
+
+type Client interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+func NewClient(config *ClientConfig) Client {
+	transport := &http.Transport{
+		DisableKeepAlives:   true,
+		MaxConnsPerHost:     100,
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout:     30 * time.Second,
+	}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   600 * time.Second,
+	}
+	if config == nil {
+		return client
+	}
+
+	if !config.TransportConfig.DisableKeepAlives {
+		transport.DisableKeepAlives = false
+	}
+	if config.TransportConfig.MaxConnsPerHost != 0 {
+		transport.MaxConnsPerHost = config.TransportConfig.MaxConnsPerHost
+	}
+	if config.TransportConfig.MaxIdleConnsPerHost != 0 {
+		transport.MaxIdleConnsPerHost = config.TransportConfig.MaxIdleConnsPerHost
+	}
+	if config.TransportConfig.IdleConnTimeout != 0 {
+		transport.IdleConnTimeout = config.TransportConfig.IdleConnTimeout
+	}
+
+	if config.ClientTimeout != 0 {
+		client.Timeout = config.ClientTimeout
+	}
+
+	clientTTL := 120 * time.Second
+	if config.ClientTTL != 0 {
+		clientTTL = config.ClientTTL
+	}
+
+	switch config.ClientType {
+	case "stdlib":
+		return client
+	case "recycled":
+		return sysUtils.NewRecycledHTTPClient(func() *http.Client {
+			return client
+		}, clientTTL)
+	case "httplb":
+		checkerType := config.CheckerType
+		if config.CheckURL == "" {
+			checkerType = "nop"
+		}
+		return httplb.NewClient(
+			httplb.WithPicker(getPicker(config.PickerType)),
+			httplb.WithTransport("http", &HTTPLBTransport{
+				Transport: transport,
+			}),
+			httplb.WithHealthChecks(getChecker(checkerType, config.CheckURL)),
+			httplb.WithResolver(
+				resolver.NewDNSResolver(
+					net.DefaultResolver,
+					resolver.PreferIPv6,
+					clientTTL,
+				),
+			),
+		)
+	default:
+		return client
+	}
+}
+
+func getPicker(pickerType string) func(prev picker.Picker, allConns conn.Conns) picker.Picker {
+	switch pickerType {
+	case "power_of_two":
+		return picker.NewPowerOfTwo
+	case "round_robin":
+		return picker.NewRoundRobin
+	case "least_loaded_random":
+		return picker.NewLeastLoadedRandom
+	case "least_loaded_round_robin":
+		return picker.NewLeastLoadedRoundRobin
+	case "random":
+		return picker.NewRandom
+	default:
+		return picker.NewPowerOfTwo
+	}
+}
+
+type HTTPLBTransport struct {
+	*http.Transport
+}
+
+func (t *HTTPLBTransport) NewRoundTripper(scheme, target string, config httplb.TransportConfig) httplb.RoundTripperResult {
+	return httplb.RoundTripperResult{RoundTripper: t.Transport, Close: t.CloseIdleConnections}
+}
+
+func getChecker(checkerType string, url string) health.Checker {
+	switch checkerType {
+	case "nop":
+		return health.NopChecker
+	case "polling":
+		return health.NewPollingChecker(
+			health.PollingCheckerConfig{},
+			health.NewSimpleProber(url),
+		)
+	default:
+		return health.NopChecker
+	}
+}

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -241,8 +241,8 @@ func NewTransformer(conf *config.Config, log logger.Logger, stat stats.Stats, op
 		PickerType:    conf.GetString("Transformer.Client.httplb.pickerType", "power_of_two"),
 		CheckerType:   conf.GetString("Transformer.Client.httplb.checkerType", "nop"),
 
-		// for now no health checks - can be implemented when there are different clients for UT, DT, TPV
-		// CheckURL: trans.config.userTransformationURL,
+		//for now no health checks - can be implemented when there are different clients for UT, DT, TPV
+		CheckURL: trans.config.userTransformationURL,
 	}
 	transformerClientConfig.TransportConfig.DisableKeepAlives = trans.config.disableKeepAlives
 	transformerClientConfig.TransportConfig.MaxConnsPerHost = trans.config.maxHTTPConnections
@@ -508,7 +508,6 @@ func (trans *handle) doPost(ctx context.Context, rawJSON []byte, url, stage stri
 				req.Header.Set("X-Feature-Filter-Code", "?1")
 
 				resp, reqErr = trans.httpClient.Do(req)
-
 			})
 			trans.stat.NewTaggedStat("processor.transformer_request_time", stats.TimerType, tags).SendTiming(time.Since(requestStartTime))
 			if reqErr != nil {

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -522,9 +522,9 @@ func (trans *handle) doPost(ctx context.Context, rawJSON []byte, url, stage stri
 				newTags["instanceWorker"] = instanceWorker
 				trans.stat.NewTaggedStat("processor_transformer_instance_event_count", stats.CountType, newTags).Count(numEvents)
 				dur := time.Since(requestStartTime).Milliseconds()
-				headerTime, err := strconv.Atoi(headerResponseTime)
+				headerTime, err := strconv.ParseFloat(strings.TrimSuffix(headerResponseTime, "ms"), 64)
 				if err == nil {
-					diff := dur - int64(headerTime)
+					diff := float64(dur) - headerTime
 					trans.stat.NewTaggedStat("processor_tranform_duration_diff_time", stats.TimerType, newTags).SendTiming(time.Duration(diff) * time.Millisecond)
 				}
 			}

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -243,8 +243,6 @@ func NewTransformer(conf *config.Config, log logger.Logger, stat stats.Stats, op
 
 		// for now no health checks - can be implemented when there are different clients for UT, DT, TPV
 		// CheckURL: trans.config.userTransformationURL,
-		ResolverType:     conf.GetString("Transformer.Client.httplb.resolverType", ""),
-		ResolverMinConns: conf.GetInt("Transformer.Client.httplb.minConns", 64),
 	}
 	transformerClientConfig.TransportConfig.DisableKeepAlives = trans.config.disableKeepAlives
 	transformerClientConfig.TransportConfig.MaxConnsPerHost = trans.config.maxHTTPConnections

--- a/processor/transformer/transformer.go
+++ b/processor/transformer/transformer.go
@@ -243,6 +243,8 @@ func NewTransformer(conf *config.Config, log logger.Logger, stat stats.Stats, op
 
 		// for now no health checks - can be implemented when there are different clients for UT, DT, TPV
 		// CheckURL: trans.config.userTransformationURL,
+		ResolverType:     conf.GetString("Transformer.Client.httplb.resolverType", ""),
+		ResolverMinConns: conf.GetInt("Transformer.Client.httplb.minConns", 64),
 	}
 	transformerClientConfig.TransportConfig.DisableKeepAlives = trans.config.disableKeepAlives
 	transformerClientConfig.TransportConfig.MaxConnsPerHost = trans.config.maxHTTPConnections

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -26,6 +26,7 @@ import (
 	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	transformerclient "github.com/rudderlabs/rudder-server/internal/transformer-client"
 	"github.com/rudderlabs/rudder-server/processor/integrations"
 	"github.com/rudderlabs/rudder-server/router/types"
 	oauthv2 "github.com/rudderlabs/rudder-server/services/oauth/v2"
@@ -50,7 +51,7 @@ const (
 type handle struct {
 	tr *http.Transport
 	// http client for router transformation request
-	client *http.Client
+	client sysUtils.HTTPClientI
 	// Mockable http.client for transformer proxy request
 	proxyClient sysUtils.HTTPClientI
 	// http client timeout for transformer proxy request
@@ -501,7 +502,21 @@ func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration, c
 	// Basically this timeout we will configure when we make final call to destination to send event
 	trans.destinationTimeout = destinationTimeout
 	// This client is used for Router Transformation
-	trans.client = &http.Client{Transport: trans.tr, Timeout: trans.transformTimeout}
+	transformerClientConfig := &transformerclient.ClientConfig{
+		ClientTimeout: trans.transformTimeout,
+		ClientTTL:     config.GetDuration("Transformer.Client.ttl", 120, time.Second),
+		ClientType:    config.GetString("Transformer.Client.type", "stdlib"),
+		PickerType:    config.GetString("Transformer.Client.httplb.pickerType", "power_of_two"),
+		CheckerType:   config.GetString("Transformer.Client.httplb.checkerType", "nop"),
+
+		// for now no health checks - can be implemented when there are different clients for UT, DT, TPV
+		// CheckURL: trans.config.userTransformationURL,
+	}
+	transformerClientConfig.TransportConfig.DisableKeepAlives = config.GetBool("Transformer.Client.disableKeepAlives", true)
+	transformerClientConfig.TransportConfig.MaxConnsPerHost = config.GetInt("Transformer.Client.maxHTTPConnections", 100)
+	transformerClientConfig.TransportConfig.MaxIdleConnsPerHost = config.GetInt("Transformer.Client.maxHTTPIdleConnections", 10)
+	transformerClientConfig.TransportConfig.IdleConnTimeout = 30 * time.Second
+	trans.client = transformerclient.NewClient(transformerClientConfig)
 	optionalArgs := &oauthv2httpclient.HttpClientOptionalArgs{
 		Locker:             locker,
 		Augmenter:          extensions.RouterBodyAugmenter,
@@ -517,7 +532,8 @@ func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration, c
 		Logger:             logger.NewLogger().Child("TransformerProxyHttpClient"),
 	}
 	// This client is used for Transformer Proxy(delivered from transformer to destination)
-	trans.proxyClient = &http.Client{Transport: trans.tr, Timeout: trans.destinationTimeout + trans.transformTimeout}
+	transformerClientConfig.ClientTimeout = trans.destinationTimeout + trans.transformTimeout
+	trans.proxyClient = transformerclient.NewClient(transformerClientConfig)
 	// This client is used for Transformer Proxy(delivered from transformer to destination) using oauthV2
 	trans.proxyClientOAuthV2 = oauthv2httpclient.NewOAuthHttpClient(&http.Client{Transport: trans.tr, Timeout: trans.destinationTimeout + trans.transformTimeout}, common.RudderFlowDelivery, cache, backendConfig, GetAuthErrorCategoryFromTransformProxyResponse, proxyClientOptionalArgs)
 	trans.transformRequestTimerStat = stats.Default.NewStat("router.transformer_request_time", stats.TimerType)


### PR DESCRIPTION
# Description

Configurable http Client(`Doer`) in processor, rt transformers. Doesn't include `oauth` clients in rt transform at this point.

## Linear Ticket

On top of #5451 

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
