### PR TITLE
fix: event sampling order so that error reporter can extract data

### DIFF
--- a/enterprise/reporting/mediator.go
+++ b/enterprise/reporting/mediator.go
@@ -57,15 +57,15 @@ func NewReportingMediator(ctx context.Context, conf *config.Config, log logger.L
 		return nil
 	})
 
-	// default reporting implementation
-	defaultReporter := NewDefaultReporter(rm.ctx, conf, rm.log, configSubscriber, rm.stats)
-	rm.reporters = append(rm.reporters, defaultReporter)
-
 	// error reporting implementation
 	if config.GetBool("Reporting.errorReporting.enabled", false) {
 		errorReporter := NewErrorDetailReporter(rm.ctx, configSubscriber, rm.stats, config.Default)
 		rm.reporters = append(rm.reporters, errorReporter)
 	}
+
+	// default reporting implementation
+	defaultReporter := NewDefaultReporter(rm.ctx, conf, rm.log, configSubscriber, rm.stats)
+	rm.reporters = append(rm.reporters, defaultReporter)
 
 	// error index reporting implementation
 	if config.GetBool("Reporting.errorIndexReporting.enabled", false) {


### PR DESCRIPTION
# Description
Handle error reporting first and then metrics so that we can extract error details  before it is going to get sampled by metrics reporter

## Linear Ticket

https://linear.app/rudderstack/issue/OBS-763/fix-report-modification-in-reporting-during-event-sampling-rudder
Resolves OBS-763

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
