### PR TITLE
fix: deltalake syncs failing for columns with unhandled data type

### DIFF
--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -531,7 +531,7 @@ func (d *Deltalake) AddColumns(ctx context.Context, tableName string, columnsInf
 	if err != nil {
 		return fmt.Errorf("fetch table attributes: %w", err)
 	}
-	columnsInfo = lo.Filter(columnsInfo, func(columnInfo warehouseutils.ColumnInfo, _ int) bool {
+	columnsToAddInfo := lo.Filter(columnsInfo, func(columnInfo warehouseutils.ColumnInfo, _ int) bool {
 		_, ok := tableSchema[columnInfo.Name]
 		return !ok
 	})
@@ -546,7 +546,7 @@ func (d *Deltalake) AddColumns(ctx context.Context, tableName string, columnsInf
 		tableName,
 	))
 
-	for _, columnInfo := range columnsInfo {
+	for _, columnInfo := range columnsToAddInfo {
 		queryBuilder.WriteString(fmt.Sprintf(` %s %s,`, columnInfo.Name, dataTypesMap[columnInfo.Type]))
 	}
 

--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/samber/lo"
+
 	"github.com/rudderlabs/sqlconnect-go/sqlconnect"
 	sqlconnectconfig "github.com/rudderlabs/sqlconnect-go/sqlconnect/config"
 
@@ -35,8 +37,7 @@ const (
 )
 
 const (
-	schemaNotFound       = "[SCHEMA_NOT_FOUND]"
-	columnsAlreadyExists = "already exists in root"
+	schemaNotFound = "[SCHEMA_NOT_FOUND]"
 )
 
 const (
@@ -530,13 +531,10 @@ func (d *Deltalake) AddColumns(ctx context.Context, tableName string, columnsInf
 	if err != nil {
 		return fmt.Errorf("fetch table attributes: %w", err)
 	}
-	var updatedColumnsInfo []warehouseutils.ColumnInfo
-	for _, columnInfo := range columnsInfo {
+	columnsInfo = lo.Filter(columnsInfo, func(columnInfo warehouseutils.ColumnInfo, _ int) bool {
 		_, ok := tableSchema[columnInfo.Name]
-		if !ok {
-			updatedColumnsInfo = append(updatedColumnsInfo, columnInfo)
-		}
-	}
+		return !ok
+	})
 
 	var queryBuilder strings.Builder
 
@@ -548,7 +546,7 @@ func (d *Deltalake) AddColumns(ctx context.Context, tableName string, columnsInf
 		tableName,
 	))
 
-	for _, columnInfo := range updatedColumnsInfo {
+	for _, columnInfo := range columnsInfo {
 		queryBuilder.WriteString(fmt.Sprintf(` %s %s,`, columnInfo.Name, dataTypesMap[columnInfo.Type]))
 	}
 
@@ -556,25 +554,6 @@ func (d *Deltalake) AddColumns(ctx context.Context, tableName string, columnsInf
 	query += ");"
 
 	_, err = d.DB.ExecContext(ctx, query)
-
-	// Handle error in case of single column
-	if len(updatedColumnsInfo) == 1 {
-		if err != nil && strings.Contains(err.Error(), columnsAlreadyExists) {
-			d.logger.Infow("column already exists",
-				logfield.SourceID, d.Warehouse.Source.ID,
-				logfield.SourceType, d.Warehouse.Source.SourceDefinition.Name,
-				logfield.DestinationID, d.Warehouse.Destination.ID,
-				logfield.DestinationType, d.Warehouse.Destination.DestinationDefinition.Name,
-				logfield.WorkspaceID, d.Warehouse.WorkspaceID,
-				logfield.Namespace, d.Namespace,
-				logfield.TableName, tableName,
-				logfield.ColumnName, updatedColumnsInfo[0].Name,
-				logfield.Error, err.Error(),
-			)
-			return nil
-		}
-	}
-
 	if err != nil {
 		return fmt.Errorf("adding columns: %w", err)
 	}

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -1319,6 +1319,75 @@ func TestIntegration(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("Add columns to table", func(t *testing.T) {
+		tableName := "test_add_existing_columns"
+		namespace := whth.RandSchema(destType)
+
+		loadFiles := []whutils.LoadFile{{Location: "dummy_location"}}
+		mockUploader := newMockUploader(t, loadFiles, tableName, nil, nil, whutils.LoadFileTypeCsv, false, false)
+		ctx := context.Background()
+
+		d := deltalake.New(config.New(), logger.NOP, stats.NOP)
+		warehouse := model.Warehouse{
+			Destination: backendconfig.DestinationT{
+				ID: "test_destination_id",
+				DestinationDefinition: backendconfig.DestinationDefinitionT{
+					Name: destType,
+				},
+				Config: map[string]any{
+					"host":           credentials.Host,
+					"port":           credentials.Port,
+					"path":           credentials.Path,
+					"token":          credentials.Token,
+					"namespace":      namespace,
+					"bucketProvider": whutils.AzureBlob,
+					"containerName":  credentials.ContainerName,
+					"accountName":    credentials.AccountName,
+					"accountKey":     credentials.AccountKey,
+				},
+			},
+			Namespace: namespace,
+		}
+		err := d.Setup(ctx, warehouse, mockUploader)
+		require.NoError(t, err)
+
+		err = d.CreateSchema(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			dropSchema(t, d.DB.DB, d.Namespace)
+		})
+		columns := map[string]string{
+			"col1": "int",
+			"col2": "string",
+		}
+
+		err = d.CreateTable(ctx, tableName, columns)
+		require.NoError(t, err)
+
+		columnsToAdd := []whutils.ColumnInfo{
+			{
+				Name: "col1",
+				Type: "int",
+			},
+			{
+				Name: "col3",
+				Type: "int",
+			},
+		}
+
+		err = d.AddColumns(ctx, tableName, columnsToAdd)
+		require.NoError(t, err)
+
+		schema, err := d.FetchSchema(ctx)
+		require.NoError(t, err)
+		require.Contains(t, schema, tableName)
+		require.Equal(t, model.TableSchema(map[string]string{
+			"col1": "int",
+			"col2": "string",
+			"col3": "int",
+		}), schema[tableName])
+	})
 }
 
 func tableMetadata(t *testing.T, db *sql.DB, namespace, tableName string) map[string]string {

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -1382,11 +1382,11 @@ func TestIntegration(t *testing.T) {
 		schema, err := d.FetchSchema(ctx)
 		require.NoError(t, err)
 		require.Contains(t, schema, tableName)
-		require.Equal(t, model.TableSchema(map[string]string{
+		require.Equal(t, model.TableSchema{
 			"col1": "int",
 			"col2": "string",
 			"col3": "int",
-		}), schema[tableName])
+		}, schema[tableName])
 	})
 }
 


### PR DESCRIPTION
# Description

**Issue**

Deltalake syncs were failing when processing events containing a field of type `DECIMAL(38,0)`, which was not handled by the warehouse code.
- For unhandled data types, the column is skipped in the local table schema. So when a mismatch was detected between the local table schema and event schema, warehouse attempted to add the missing columns in the table. The column addition failed because the column already existed.
- This is a regression introduced from changes in #5322 
- This issue doesn't affect other warehouses since their `AddColumns` method handles already existing columns.

**Fix**

To resolve this, we now retrieve all existing columns of the table before adding new ones. Columns that are already present are skipped, preventing the failure.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
