### PR TITLE
chore: migration to drop unused wh_schema_versions table

### DIFF
--- a/sql/migrations/warehouse/000027_drop_wh_schema_versions_table.up.sql
+++ b/sql/migrations/warehouse/000027_drop_wh_schema_versions_table.up.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS wh_schema_versions;


### PR DESCRIPTION
# Description

This PR adds a migration to get rid of `wh_schema_versions` table which is not being used anymore

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
