### PR TITLE
feat: implement snowpipe destination config validation

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -233,7 +233,7 @@ func (m *Manager) Upload(asyncDest *common.AsyncDestinationStruct) common.AsyncU
 					isBackoffSet = true
 					m.setBackOff(err)
 					response := m.validator.Validate(ctx, asyncDest.Destination)
-					if !response.Success {
+					if !response.Success && failedReason == nil {
 						failedReason = fmt.Errorf("failed to validate snowpipe credentials: %s", response.Error)
 					}
 				}
@@ -244,9 +244,10 @@ func (m *Manager) Upload(asyncDest *common.AsyncDestinationStruct) common.AsyncU
 				logger.NewStringField("table", info.tableName),
 				obskit.Error(err),
 			)
-			if failedReason == "" {
-				failedReason = err.Error()
+			if failedReason == nil {
+				failedReason = err
 			}
+
 			failedJobIDs = append(failedJobIDs, info.jobIDs...)
 			continue
 		}

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/snowflake"
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+	"github.com/rudderlabs/rudder-server/warehouse/validations"
 )
 
 type mockAPI struct {
@@ -68,6 +69,22 @@ func (m *mockManager) CreateTable(context.Context, string, whutils.ModelTableSch
 	return nil
 }
 
+type mockValidator struct {
+	err error
+}
+
+func (m *mockValidator) Validate(_ context.Context, _ *backendconfig.DestinationT) *validations.DestinationValidationResponse {
+	if m.err != nil {
+		return &validations.DestinationValidationResponse{
+			Success: false,
+			Error:   m.err.Error(),
+		}
+	}
+	return &validations.DestinationValidationResponse{
+		Success: true,
+	}
+}
+
 var (
 	usersChannelResponse = &model.ChannelResponse{
 		ChannelID: "test-users-channel",
@@ -104,6 +121,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 		},
 		Config: make(map[string]interface{}),
 	}
+	validations.Init()
 
 	t.Run("Upload with invalid file path", func(t *testing.T) {
 		statsStore, err := memstats.New()
@@ -405,34 +423,103 @@ func TestSnowpipeStreaming(t *testing.T) {
 		require.False(t, sm.isInBackoff())
 	})
 
-	t.Run("Upload with discards table authorization error should mark the job as failed", func(t *testing.T) {
-		statsStore, err := memstats.New()
-		require.NoError(t, err)
-
-		sm := New(config.New(), logger.NOP, statsStore, destination)
-		sm.api = &mockAPI{
-			createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
-				"RUDDER_DISCARDS": func() (*model.ChannelResponse, error) {
-					return &model.ChannelResponse{Code: internalapi.ErrSchemaDoesNotExistOrNotAuthorized}, nil
-				},
+	t.Run("destination config validation", func(t *testing.T) {
+		testCases := []struct {
+			name                 string
+			validationError      error
+			expectedFailedReason string
+		}{
+			{
+				name:                 "should return validation error",
+				validationError:      fmt.Errorf("missing permissions to do xyz"),
+				expectedFailedReason: "missing permissions to do xyz",
+			},
+			{
+				name:                 "should not return any error",
+				validationError:      nil,
+				expectedFailedReason: "",
 			},
 		}
-		sm.managerCreator = func(_ context.Context, _ whutils.ModelWarehouse, _ *config.Config, _ logger.Logger, _ stats.Stats) (manager.Manager, error) {
-			sf := snowflake.New(config.New(), logger.NOP, stats.NOP)
-			mm := newMockManager(sf)
-			mm.createSchemaErr = fmt.Errorf("failed to create schema")
-			return mm, nil
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				sm := New(config.New(), logger.NOP, stats.NOP, destination)
+				sm.channelCache.Store("RUDDER_DISCARDS", rudderDiscardsChannelResponse)
+				sm.api = &mockAPI{
+					createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
+						"USERS": func() (*model.ChannelResponse, error) {
+							return &model.ChannelResponse{Code: internalapi.ErrSchemaDoesNotExistOrNotAuthorized}, nil
+						},
+					},
+				}
+				sm.managerCreator = func(_ context.Context, _ whutils.ModelWarehouse, _ *config.Config, _ logger.Logger, _ stats.Stats) (manager.Manager, error) {
+					sf := snowflake.New(config.New(), logger.NOP, stats.NOP)
+					mm := newMockManager(sf)
+					mm.createSchemaErr = fmt.Errorf("failed to create schema")
+					return mm, nil
+				}
+				sm.validator = &mockValidator{err: tc.validationError}
+				asyncDestStruct := &common.AsyncDestinationStruct{
+					Destination: destination,
+					FileName:    "testdata/successful_user_records.txt",
+				}
+				output := sm.Upload(asyncDestStruct)
+				require.Equal(t, 2, output.FailedCount)
+				require.Equal(t, 0, output.AbortCount)
+				if tc.expectedFailedReason != "" {
+					require.Contains(t, output.FailedReason, tc.expectedFailedReason)
+				} else {
+					require.Empty(t, output.FailedReason)
+				}
+			})
 		}
-		output := sm.Upload(&common.AsyncDestinationStruct{
-			ImportingJobIDs: []int64{1},
-			Destination:     destination,
-			FileName:        "testdata/successful_user_records.txt",
-		})
-		require.Equal(t, 1, output.FailedCount)
-		require.Equal(t, 0, output.AbortCount)
-		require.NotEmpty(t, output.FailedReason)
-		require.Empty(t, output.AbortReason)
-		require.Equal(t, true, sm.isInBackoff())
+	})
+
+	t.Run("Upload with discards table authorization error should mark the job as failed", func(t *testing.T) {
+		testCases := []struct {
+			name                 string
+			validationError      error
+			expectedFailedReason string
+		}{
+			{
+				name:                 "authorization error",
+				validationError:      fmt.Errorf("authorization error"),
+				expectedFailedReason: "failed to validate snowpipe credentials: authorization error",
+			},
+			{
+				name:                 "other error",
+				validationError:      nil,
+				expectedFailedReason: "failed to create schema",
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				sm := New(config.New(), logger.NOP, stats.NOP, destination)
+				sm.api = &mockAPI{
+					createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
+						"RUDDER_DISCARDS": func() (*model.ChannelResponse, error) {
+							return &model.ChannelResponse{Code: internalapi.ErrSchemaDoesNotExistOrNotAuthorized}, nil
+						},
+					},
+				}
+				sm.managerCreator = func(_ context.Context, _ whutils.ModelWarehouse, _ *config.Config, _ logger.Logger, _ stats.Stats) (manager.Manager, error) {
+					sf := snowflake.New(config.New(), logger.NOP, stats.NOP)
+					mm := newMockManager(sf)
+					mm.createSchemaErr = fmt.Errorf("failed to create schema")
+					return mm, nil
+				}
+				sm.validator = &mockValidator{err: tc.validationError}
+				output := sm.Upload(&common.AsyncDestinationStruct{
+					ImportingJobIDs: []int64{1},
+					Destination:     destination,
+					FileName:        "testdata/successful_user_records.txt",
+				})
+				require.Equal(t, 1, output.FailedCount)
+				require.Equal(t, 0, output.AbortCount)
+				require.Contains(t, output.FailedReason, tc.expectedFailedReason)
+				require.Empty(t, output.AbortReason)
+				require.Equal(t, true, sm.isInBackoff())
+			})
+		}
 	})
 
 	t.Run("Upload insert error for all events", func(t *testing.T) {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -437,7 +437,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			{
 				name:                 "should not return any error",
 				validationError:      nil,
-				expectedFailedReason: "",
+				expectedFailedReason: "failed to create schema",
 			},
 		}
 		for _, tc := range testCases {
@@ -465,11 +465,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 				output := sm.Upload(asyncDestStruct)
 				require.Equal(t, 2, output.FailedCount)
 				require.Equal(t, 0, output.AbortCount)
-				if tc.expectedFailedReason != "" {
-					require.Contains(t, output.FailedReason, tc.expectedFailedReason)
-				} else {
-					require.Empty(t, output.FailedReason)
-				}
+				require.Contains(t, output.FailedReason, tc.expectedFailedReason)
 			})
 		}
 	})

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
@@ -17,6 +17,7 @@ import (
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/manager"
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+	"github.com/rudderlabs/rudder-server/warehouse/validations"
 )
 
 type (
@@ -31,6 +32,7 @@ type (
 		api                 api
 		channelCache        sync.Map
 		polledImportInfoMap map[string]*importInfo
+		validator           validations.DestinationValidator
 
 		config struct {
 			client struct {

--- a/warehouse/internal/model/validation.go
+++ b/warehouse/internal/model/validation.go
@@ -32,9 +32,3 @@ type Step struct {
 type StepsResponse struct {
 	Steps []*Step `json:"steps"`
 }
-
-type DestinationValidationResponse struct {
-	Success bool    `json:"success"`
-	Error   string  `json:"error"`
-	Steps   []*Step `json:"steps"`
-}

--- a/warehouse/validations/steps.go
+++ b/warehouse/validations/steps.go
@@ -20,7 +20,6 @@ func StepsToValidate(dest *backendconfig.DestinationT) *model.StepsResponse {
 	destType := dest.DestinationDefinition.Name
 
 	if destType == warehouseutils.SnowpipeStreaming {
-		dest.Config["useKeyPairAuth"] = true // Since we are currently only supporting key pair auth
 		return &model.StepsResponse{
 			Steps: []*model.Step{
 				{ID: 1, Name: model.VerifyingConnections},

--- a/warehouse/validations/steps.go
+++ b/warehouse/validations/steps.go
@@ -19,11 +19,12 @@ func StepsToValidate(dest *backendconfig.DestinationT) *model.StepsResponse {
 		destType = dest.DestinationDefinition.Name
 		steps    []*model.Step
 	)
-
-	steps = []*model.Step{{
-		ID:   len(steps) + 1,
-		Name: model.VerifyingObjectStorage,
-	}}
+	if destType != warehouseutils.SnowpipeStreaming {
+		steps = []*model.Step{{
+			ID:   len(steps) + 1,
+			Name: model.VerifyingObjectStorage,
+		}}
+	}
 
 	switch destType {
 	case warehouseutils.GCSDatalake, warehouseutils.AzureDatalake:
@@ -65,11 +66,13 @@ func StepsToValidate(dest *backendconfig.DestinationT) *model.StepsResponse {
 				ID:   len(steps) + 4,
 				Name: model.VerifyingFetchSchema,
 			},
-			&model.Step{
-				ID:   len(steps) + 5,
-				Name: model.VerifyingLoadTable,
-			},
 		)
+		if destType != warehouseutils.SnowpipeStreaming {
+			steps = append(steps, &model.Step{
+				ID:   len(steps) + 1,
+				Name: model.VerifyingLoadTable,
+			})
+		}
 	}
 	return &model.StepsResponse{
 		Steps: steps,

--- a/warehouse/validations/steps.go
+++ b/warehouse/validations/steps.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/samber/lo"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	schemarepository "github.com/rudderlabs/rudder-server/warehouse/integrations/datalake/schema-repository"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
@@ -15,66 +17,50 @@ func validateStepFunc(_ context.Context, destination *backendconfig.DestinationT
 }
 
 func StepsToValidate(dest *backendconfig.DestinationT) *model.StepsResponse {
-	var (
-		destType = dest.DestinationDefinition.Name
-		steps    []*model.Step
-	)
-	if destType != warehouseutils.SnowpipeStreaming {
-		steps = []*model.Step{{
-			ID:   len(steps) + 1,
-			Name: model.VerifyingObjectStorage,
-		}}
+	destType := dest.DestinationDefinition.Name
+
+	if destType == warehouseutils.SnowpipeStreaming {
+		dest.Config["useKeyPairAuth"] = true // Since we are currently only supporting key pair auth
+		return &model.StepsResponse{
+			Steps: []*model.Step{
+				{ID: 1, Name: model.VerifyingConnections},
+				{ID: 2, Name: model.VerifyingCreateSchema},
+				{ID: 3, Name: model.VerifyingCreateAndAlterTable},
+				{ID: 4, Name: model.VerifyingFetchSchema},
+			},
+		}
+	}
+
+	steps := []*model.Step{
+		{ID: 1, Name: model.VerifyingObjectStorage},
+	}
+
+	appendSteps := func(newSteps ...string) {
+		for _, step := range newSteps {
+			steps = append(steps, &model.Step{ID: len(steps) + 1, Name: step})
+		}
 	}
 
 	switch destType {
 	case warehouseutils.GCSDatalake, warehouseutils.AzureDatalake:
+		// No additional steps
 	case warehouseutils.S3Datalake:
-		wh := createDummyWarehouse(dest)
-		if canUseGlue := schemarepository.UseGlue(&wh); !canUseGlue {
-			break
+		if schemarepository.UseGlue(lo.ToPtr(createDummyWarehouse(dest))) {
+			appendSteps(
+				model.VerifyingCreateSchema,
+				model.VerifyingCreateAndAlterTable,
+				model.VerifyingFetchSchema,
+			)
 		}
-
-		steps = append(steps,
-			&model.Step{
-				ID:   len(steps) + 1,
-				Name: model.VerifyingCreateSchema,
-			},
-			&model.Step{
-				ID:   len(steps) + 2,
-				Name: model.VerifyingCreateAndAlterTable,
-			},
-			&model.Step{
-				ID:   len(steps) + 3,
-				Name: model.VerifyingFetchSchema,
-			},
-		)
 	default:
-		steps = append(steps,
-			&model.Step{
-				ID:   len(steps) + 1,
-				Name: model.VerifyingConnections,
-			},
-			&model.Step{
-				ID:   len(steps) + 2,
-				Name: model.VerifyingCreateSchema,
-			},
-			&model.Step{
-				ID:   len(steps) + 3,
-				Name: model.VerifyingCreateAndAlterTable,
-			},
-			&model.Step{
-				ID:   len(steps) + 4,
-				Name: model.VerifyingFetchSchema,
-			},
+		appendSteps(
+			model.VerifyingConnections,
+			model.VerifyingCreateSchema,
+			model.VerifyingCreateAndAlterTable,
+			model.VerifyingFetchSchema,
+			model.VerifyingLoadTable,
 		)
-		if destType != warehouseutils.SnowpipeStreaming {
-			steps = append(steps, &model.Step{
-				ID:   len(steps) + 1,
-				Name: model.VerifyingLoadTable,
-			})
-		}
 	}
-	return &model.StepsResponse{
-		Steps: steps,
-	}
+
+	return &model.StepsResponse{Steps: steps}
 }

--- a/warehouse/validations/steps_test.go
+++ b/warehouse/validations/steps_test.go
@@ -83,6 +83,20 @@ func TestValidationSteps(t *testing.T) {
 				model.VerifyingLoadTable,
 			},
 		},
+		{
+			name: "Snowpipe",
+			dest: backendconfig.DestinationT{
+				DestinationDefinition: backendconfig.DestinationDefinitionT{
+					Name: warehouseutils.SnowpipeStreaming,
+				},
+			},
+			steps: []string{
+				model.VerifyingConnections,
+				model.VerifyingCreateSchema,
+				model.VerifyingCreateAndAlterTable,
+				model.VerifyingFetchSchema,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/warehouse/validations/steps_test.go
+++ b/warehouse/validations/steps_test.go
@@ -89,7 +89,6 @@ func TestValidationSteps(t *testing.T) {
 				DestinationDefinition: backendconfig.DestinationDefinitionT{
 					Name: warehouseutils.SnowpipeStreaming,
 				},
-				Config: make(map[string]interface{}),
 			},
 			steps: []string{
 				model.VerifyingConnections,

--- a/warehouse/validations/steps_test.go
+++ b/warehouse/validations/steps_test.go
@@ -89,6 +89,7 @@ func TestValidationSteps(t *testing.T) {
 				DestinationDefinition: backendconfig.DestinationDefinitionT{
 					Name: warehouseutils.SnowpipeStreaming,
 				},
+				Config: make(map[string]interface{}),
 			},
 			steps: []string{
 				model.VerifyingConnections,

--- a/warehouse/validations/validate.go
+++ b/warehouse/validations/validate.go
@@ -23,6 +23,12 @@ import (
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
+type DestinationValidationResponse struct {
+	Success bool          `json:"success"`
+	Error   string        `json:"error"`
+	Steps   []*model.Step `json:"steps"`
+}
+
 type Validator interface {
 	Validate(ctx context.Context) error
 }
@@ -57,7 +63,7 @@ type loadTable struct {
 }
 
 type DestinationValidator interface {
-	Validate(ctx context.Context, dest *backendconfig.DestinationT) *model.DestinationValidationResponse
+	Validate(ctx context.Context, dest *backendconfig.DestinationT) *DestinationValidationResponse
 }
 
 type destinationValidationImpl struct{}
@@ -66,7 +72,7 @@ func NewDestinationValidator() DestinationValidator {
 	return &destinationValidationImpl{}
 }
 
-func (*destinationValidationImpl) Validate(ctx context.Context, dest *backendconfig.DestinationT) *model.DestinationValidationResponse {
+func (*destinationValidationImpl) Validate(ctx context.Context, dest *backendconfig.DestinationT) *DestinationValidationResponse {
 	return validateDestination(ctx, dest, "")
 }
 
@@ -74,7 +80,7 @@ func validateDestinationFunc(ctx context.Context, dest *backendconfig.Destinatio
 	return json.Marshal(validateDestination(ctx, dest, stepToValidate))
 }
 
-func validateDestination(ctx context.Context, dest *backendconfig.DestinationT, stepToValidate string) *model.DestinationValidationResponse {
+func validateDestination(ctx context.Context, dest *backendconfig.DestinationT, stepToValidate string) *DestinationValidationResponse {
 	var (
 		destID          = dest.ID
 		destType        = dest.DestinationDefinition.Name
@@ -95,7 +101,7 @@ func validateDestination(ctx context.Context, dest *backendconfig.DestinationT, 
 	if stepToValidate != "" {
 		stepI, err := strconv.Atoi(stepToValidate)
 		if err != nil {
-			return &model.DestinationValidationResponse{
+			return &DestinationValidationResponse{
 				Error: fmt.Sprintf("Invalid step: %s", stepToValidate),
 			}
 		}
@@ -110,7 +116,7 @@ func validateDestination(ctx context.Context, dest *backendconfig.DestinationT, 
 		}
 
 		if vs == nil {
-			return &model.DestinationValidationResponse{
+			return &DestinationValidationResponse{
 				Error: fmt.Sprintf("Invalid step: %s", stepToValidate),
 			}
 		}
@@ -158,7 +164,7 @@ func validateDestination(ctx context.Context, dest *backendconfig.DestinationT, 
 		}
 	}
 
-	res := &model.DestinationValidationResponse{
+	res := &DestinationValidationResponse{
 		Steps:   stepsToValidate,
 		Success: err == nil,
 	}


### PR DESCRIPTION
# Description

[Context](https://linear.app/rudderstack/issue/WAR-240/short-term-solution-for-validation-errors-in-sync-errors-for-snowpipe#comment-150d9d94)

Implementation
- Made changes in `StepsToValidate` method to return relevant steps for Snowpipe destination
- Moved `DestinationValidationResponse` struct from `internal/model` package to `validations` package so that it can be accessed in `snowpipestreaming` package
- Added a `validator` field in snowpipe's `Manager` struct which is responsible for validating the destination config
- Made changes in `Upload` function to call the validator whenever there is an authorization error. And if the response is not successful, the error is being returned.

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
