### PR TITLE
chore: fix gateway metrics

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1756,15 +1756,9 @@ var _ = Describe("Gateway", func() {
 			return []byte(fmt.Sprintf(`[%s,%s]`, internalBatchPayload(), internalBatchPayload()))
 		}
 
+		var statStore *memstats.Store
 		// a second after receivedAt
 		now, err := time.Parse(time.RFC3339Nano, "2024-01-01T01:01:02.000000001Z")
-		Expect(err).To(BeNil())
-
-		statStore, err := memstats.New(
-			memstats.WithNow(func() time.Time {
-				return now
-			}),
-		)
 		Expect(err).To(BeNil())
 
 		BeforeEach(func() {
@@ -1788,6 +1782,13 @@ var _ = Describe("Gateway", func() {
 			Expect(err).To(BeNil())
 			internalBatchEndpoint = fmt.Sprintf("http://localhost:%d/internal/v1/batch", serverPort)
 			GinkgoT().Setenv("RSERVER_GATEWAY_WEB_PORT", strconv.Itoa(serverPort))
+
+			statStore, err = memstats.New(
+				memstats.WithNow(func() time.Time {
+					return now
+				}),
+			)
+			Expect(err).To(BeNil())
 
 			gateway = &Handle{}
 			srcDebugger = mocksrcdebugger.NewMockSourceDebugger(c.mockCtrl)
@@ -1872,12 +1873,12 @@ var _ = Describe("Gateway", func() {
 				{
 					Name: "gateway.write_key_requests",
 					Tags: map[string]string{
-						"workspaceId": WorkspaceID,
-						"sourceID":    SourceIDEnabled,
+						"workspaceId": "",
+						"sourceID":    "",
 						"sourceType":  "",
 						"sdkVersion":  "",
 						"source":      "",
-						"writeKey":    WriteKeyEnabled,
+						"writeKey":    "",
 						"reqType":     "internalBatch",
 					},
 					Value: 1,
@@ -1888,10 +1889,10 @@ var _ = Describe("Gateway", func() {
 					Name: "gateway.write_key_successful_requests",
 					Tags: map[string]string{
 						"source":      "",
-						"writeKey":    WriteKeyEnabled,
+						"writeKey":    "",
 						"reqType":     "internalBatch",
-						"workspaceId": WorkspaceID,
-						"sourceID":    SourceIDEnabled,
+						"workspaceId": "",
+						"sourceID":    "",
 						"sourceType":  "",
 						"sdkVersion":  "",
 					},
@@ -1903,10 +1904,10 @@ var _ = Describe("Gateway", func() {
 					Name: "gateway.write_key_failed_requests",
 					Tags: map[string]string{
 						"source":      "",
-						"writeKey":    WriteKeyEnabled,
+						"writeKey":    "",
 						"reqType":     "internalBatch",
-						"workspaceId": WorkspaceID,
-						"sourceID":    SourceIDEnabled,
+						"workspaceId": "",
+						"sourceID":    "",
 						"sourceType":  "",
 						"sdkVersion":  "",
 					},
@@ -2007,10 +2008,10 @@ var _ = Describe("Gateway", func() {
 			Expect(err).To(BeNil())
 			Expect(http.StatusOK, resp.StatusCode)
 			successfulReqStat := statStore.Get("gateway.write_key_successful_requests", map[string]string{
-				"writeKey":    WriteKeyEnabled,
+				"writeKey":    "",
 				"reqType":     "internalBatch",
-				"workspaceId": WorkspaceID,
-				"sourceID":    SourceIDEnabled,
+				"workspaceId": "",
+				"sourceID":    "",
 				"sourceType":  "",
 				"sdkVersion":  "",
 				"source":      "",
@@ -2029,16 +2030,16 @@ var _ = Describe("Gateway", func() {
 			Expect(err).To(BeNil())
 			Expect(http.StatusOK, resp.StatusCode)
 			successfulReqStat := statStore.Get("gateway.write_key_successful_requests", map[string]string{
-				"writeKey":    WriteKeyEnabled,
+				"writeKey":    "",
 				"reqType":     "internalBatch",
-				"workspaceId": WorkspaceID,
-				"sourceID":    SourceIDEnabled,
+				"workspaceId": "",
+				"sourceID":    "",
 				"sourceType":  "",
 				"sdkVersion":  "",
 				"source":      "",
 			})
 			Expect(successfulReqStat).To(Not(BeNil()))
-			Expect(successfulReqStat.LastValue()).To(Equal(float64(3)))
+			Expect(successfulReqStat.LastValue()).To(Equal(float64(1)))
 			successfulEventStat := statStore.Get("gateway.write_key_successful_events", map[string]string{
 				"writeKey":    WriteKeyEnabled,
 				"reqType":     "internalBatch",
@@ -2049,7 +2050,7 @@ var _ = Describe("Gateway", func() {
 				"source":      "",
 			})
 			Expect(successfulEventStat).To(Not(BeNil()))
-			Expect(successfulEventStat.LastValue()).To(Equal(float64(3)))
+			Expect(successfulEventStat.LastValue()).To(Equal(float64(2)))
 			eventsStat := statStore.Get("gateway.write_key_events", map[string]string{
 				"writeKey":    WriteKeyEnabled,
 				"reqType":     "internalBatch",
@@ -2060,7 +2061,7 @@ var _ = Describe("Gateway", func() {
 				"source":      "",
 			})
 			Expect(eventsStat).To(Not(BeNil()))
-			Expect(eventsStat.Values()).To(Equal([]float64{1, 2, 3}))
+			Expect(eventsStat.Values()).To(Equal([]float64{1, 2}))
 		})
 
 		It("request failed db error", func() {
@@ -2072,10 +2073,10 @@ var _ = Describe("Gateway", func() {
 			Expect(err).To(BeNil())
 			Expect(http.StatusInternalServerError, resp.StatusCode)
 			failedReqStat := statStore.Get("gateway.write_key_failed_requests", map[string]string{
-				"writeKey":    WriteKeyEnabled,
+				"writeKey":    "",
 				"reqType":     "internalBatch",
-				"workspaceId": WorkspaceID,
-				"sourceID":    SourceIDEnabled,
+				"workspaceId": "",
+				"sourceID":    "",
 				"sourceType":  "",
 				"sdkVersion":  "",
 				"source":      "",
@@ -2105,7 +2106,7 @@ var _ = Describe("Gateway", func() {
 				"source":      "",
 			})
 			Expect(eventsStat).To(Not(BeNil()))
-			Expect(eventsStat.Values()).To(Equal([]float64{1, 2, 3, 4}))
+			Expect(eventsStat.Values()).To(Equal([]float64{1}))
 		})
 	})
 

--- a/gateway/internal/stats/stats.go
+++ b/gateway/internal/stats/stats.go
@@ -110,11 +110,13 @@ func (ss *SourceStat) Report(s stats.Stats) {
 	if ss.reason != "" {
 		failedTags["reason"] = ss.reason
 	}
-	s.NewTaggedStat("gateway.write_key_requests", stats.CountType, tags).Count(ss.requests.total)
-	s.NewTaggedStat("gateway.write_key_successful_requests", stats.CountType, tags).Count(ss.requests.succeeded)
-	s.NewTaggedStat("gateway.write_key_failed_requests", stats.CountType, failedTags).Count(ss.requests.failed)
-	s.NewTaggedStat("gateway.write_key_dropped_requests", stats.CountType, tags).Count(ss.requests.dropped)
-	s.NewTaggedStat("gateway.write_key_suppressed_requests", stats.CountType, tags).Count(ss.requests.suppressed)
+	if ss.requests.total > 0 {
+		s.NewTaggedStat("gateway.write_key_requests", stats.CountType, tags).Count(ss.requests.total)
+		s.NewTaggedStat("gateway.write_key_successful_requests", stats.CountType, tags).Count(ss.requests.succeeded)
+		s.NewTaggedStat("gateway.write_key_failed_requests", stats.CountType, failedTags).Count(ss.requests.failed)
+		s.NewTaggedStat("gateway.write_key_dropped_requests", stats.CountType, tags).Count(ss.requests.dropped)
+		s.NewTaggedStat("gateway.write_key_suppressed_requests", stats.CountType, tags).Count(ss.requests.suppressed)
+	}
 	if ss.events.total > 0 {
 		s.NewTaggedStat("gateway.write_key_events", stats.CountType, tags).Count(ss.events.total)
 		s.NewTaggedStat("gateway.write_key_successful_events", stats.CountType, tags).Count(ss.events.succeeded)

--- a/gateway/internal/stats/stats.go
+++ b/gateway/internal/stats/stats.go
@@ -77,6 +77,19 @@ func (ss *SourceStat) RequestEventsFailed(num int, reason string) {
 	ss.reason = reason
 }
 
+// EventsSuccess increments the events total & succeeded counters by num
+func (ss *SourceStat) EventsSuccess(num int) {
+	ss.events.succeeded += num
+	ss.events.total += num
+}
+
+// EventsFailed increments the events total & failed counters by num
+func (ss *SourceStat) EventsFailed(num int, reason string) {
+	ss.events.failed += num
+	ss.events.total += num
+	ss.reason = reason
+}
+
 func (ss *SourceStat) RequestEventsBot(num int) {
 	ss.events.bot += num
 }


### PR DESCRIPTION
# Description

We iterate on the jobs and for each job we increase the events by 1 like this:
```
for _, jws := range jobsWithStats {
	jws.stat.RequestEventsSucceeded(1)
```
The problem is that, whenever you call RequestEventsSucceeded it is also increasing the requests:
```
func (ss *SourceStat) RequestEventsSucceeded(num int) {
	ss.events.succeeded += num
	ss.events.total += num
	ss.requests.total++
	ss.requests.succeeded++
}
```
So we should increment events and requests separately. there are some tags like sourceID which are required for events but do not makes sense for internalBatch request. So introducing new methods `EventsSuccess` `EventsFailed` to increment events and requests separately.

## Linear Ticket

-

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
