### PR TITLE
fix: databricks columns to add becomes empty after filtering

### DIFF
--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -535,6 +535,9 @@ func (d *Deltalake) AddColumns(ctx context.Context, tableName string, columnsInf
 		_, ok := tableSchema[columnInfo.Name]
 		return !ok
 	})
+	if len(columnsToAddInfo) == 0 {
+		return nil
+	}
 
 	var queryBuilder strings.Builder
 

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -1376,8 +1376,8 @@ func TestIntegration(t *testing.T) {
 			},
 		}
 
-		err = d.AddColumns(ctx, tableName, columnsToAdd)
-		require.NoError(t, err)
+		require.NoError(t, d.AddColumns(ctx, tableName, columnsToAdd))
+		require.NoError(t, d.AddColumns(ctx, tableName, columnsToAdd))
 
 		schema, err := d.FetchSchema(ctx)
 		require.NoError(t, err)


### PR DESCRIPTION
# Description

- Databricks columns to add become empty after filtering.

## Linear Ticket

- Resolves WAR-268

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
