### PR TITLE
fix: snowpipe backoff missing for validation error

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/channel.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/channel.go
@@ -138,7 +138,7 @@ func (m *Manager) createChannel(
 		}
 		m.channelCache.Store(tableName, resp)
 		return resp, nil
-	case internalapi.ErrValidationError:
+	case internalapi.ErrValidationError, internalapi.ErrAuthenticationFailed, internalapi.ErrRoleDoesNotExistOrNotAuthorized, internalapi.ErrDatabaseDoesNotExistOrNotAuthorized:
 		return nil, fmt.Errorf("%w, %w", errAuthz, err)
 	default:
 		return nil, fmt.Errorf("creating channel with code %s, message: %s and error: %s", resp.Code, resp.SnowflakeAPIMessage, resp.Error)

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/channel.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/channel.go
@@ -138,6 +138,8 @@ func (m *Manager) createChannel(
 		}
 		m.channelCache.Store(tableName, resp)
 		return resp, nil
+	case internalapi.ErrValidationError:
+		return nil, fmt.Errorf("%w, %w", errAuthz, err)
 	default:
 		return nil, fmt.Errorf("creating channel with code %s, message: %s and error: %s", resp.Code, resp.SnowflakeAPIMessage, resp.Error)
 	}


### PR DESCRIPTION
# Description

If a Snowpipe destination is created with an invalid private key, the Snowpipe client returns an `ERR_VALIDATION_ERROR` code. Previously, this was handled in the default case, preventing it from being classified as an `Authz` error. As a result, neither backoff nor config validation occurred in the Upload function.

This PR fixes the issue by correctly identifying and returning this error as `Authz`.

- Added `ErrAuthenticationFailed` for invalid user name and `ErrRoleDoesNotExistOrNotAuthorized` for invalid role

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
