### PR TITLE
feat: introduce transformer metrics for cost attribution

### DIFF
--- a/processor/transformer/transformer_test.go
+++ b/processor/transformer/transformer_test.go
@@ -287,6 +287,21 @@ func TestTransformer(t *testing.T) {
 								"dest_id":   destinationConfig.ID,
 								"src_id":    metadata.SourceID,
 							}, m.Tags)
+
+							metricsToCheck := []string{
+								"transformer_client_request_total_bytes",
+								"transformer_client_response_total_bytes",
+								"transformer_client_request_total_events",
+								"transformer_client_response_total_events",
+								"transformer_client_total_durations_seconds",
+							}
+
+							expectedTags := labels.ToStatsTag()
+							for _, metricName := range metricsToCheck {
+								measurements := statsStore.GetByName(metricName)
+								require.NotEmpty(t, measurements, "metric %s should not be empty", metricName)
+								require.Equal(t, expectedTags, measurements[0].Tags, "metric %s tags mismatch", metricName)
+							}
 						}
 					}
 				}

--- a/processor/transformer/transformer_test.go
+++ b/processor/transformer/transformer_test.go
@@ -254,7 +254,6 @@ func TestTransformer(t *testing.T) {
 
 					labels := transformerMetricLabels{
 						Endpoint:         getEndpointFromURL(srv.URL),
-						Service:          destServiceName,
 						Stage:            "test-stage",
 						SourceID:         metadata.SourceID,
 						SourceType:       metadata.SourceType,
@@ -272,7 +271,6 @@ func TestTransformer(t *testing.T) {
 						for _, m := range metrics {
 							require.Equal(t, stats.Tags{
 								"endpoint":         getEndpointFromURL(srv.URL),
-								"service":          destServiceName,
 								"stage":            "test-stage",
 								"sourceId":         metadata.SourceID,
 								"sourceType":       metadata.SourceType,
@@ -404,7 +402,6 @@ func TestTransformer(t *testing.T) {
 							require.Panics(t, func() {
 								_ = tr.request(context.TODO(), srv.URL, transformerMetricLabels{
 									Endpoint: getEndpointFromURL(srv.URL),
-									Service:  destServiceName,
 									Stage:    tc.stage,
 								}, events)
 							})
@@ -417,7 +414,6 @@ func TestTransformer(t *testing.T) {
 
 						rsp := tr.request(context.TODO(), srv.URL, transformerMetricLabels{
 							Endpoint: getEndpointFromURL(srv.URL),
-							Service:  destServiceName,
 							Stage:    tc.stage,
 						}, events)
 						require.Len(t, rsp, 1)
@@ -474,7 +470,6 @@ func TestTransformer(t *testing.T) {
 
 				rsp := tr.request(context.TODO(), srv.URL, transformerMetricLabels{
 					Endpoint: getEndpointFromURL(srv.URL),
-					Service:  destServiceName,
 					Stage:    "test-stage",
 				}, events)
 				require.Equal(t, rsp, []TransformerResponse{
@@ -612,7 +607,6 @@ func TestTransformer(t *testing.T) {
 							require.Panics(t, func() {
 								_ = tr.request(context.TODO(), srv.URL, transformerMetricLabels{
 									Endpoint: getEndpointFromURL(srv.URL),
-									Service:  destServiceName,
 									Stage:    "test-stage",
 								}, events)
 							})
@@ -622,7 +616,6 @@ func TestTransformer(t *testing.T) {
 
 						rsp := tr.request(context.TODO(), srv.URL, transformerMetricLabels{
 							Endpoint: getEndpointFromURL(srv.URL),
-							Service:  destServiceName,
 							Stage:    "test-stage",
 						}, events)
 						require.Equal(t, tc.expectedResponse, rsp)
@@ -721,7 +714,6 @@ func TestTransformer(t *testing.T) {
 							require.Panics(t, func() {
 								_ = tr.request(context.TODO(), srv.URL, transformerMetricLabels{
 									Endpoint: getEndpointFromURL(srv.URL),
-									Service:  destServiceName,
 									Stage:    "test-stage",
 								}, events)
 							})
@@ -730,7 +722,6 @@ func TestTransformer(t *testing.T) {
 
 						rsp := tr.request(context.TODO(), srv.URL, transformerMetricLabels{
 							Endpoint: getEndpointFromURL(srv.URL),
-							Service:  destServiceName,
 							Stage:    "test-stage",
 						}, events)
 						require.Equal(t, tc.expectedResponse, rsp)


### PR DESCRIPTION
Added the following metrics:

```
transformer_client_request_total_bytes
transformer_client_response_total_bytes
transformer_client_request_total_events
transformer_client_response_total_events
transformer_client_total_durations_seconds
```

Adding `workspaceId` and `endpoint` as labels, to all metrics collected in transformer, we already track dest/source id so they won't increase cardinality.

Created `transformerMetricLabels` to pass around all the labels

Note: This PR covers processor, will create a similar PR for gateway/ingestion-svc and router


https://linear.app/rudderstack/issue/PRI-163/introduce-transformer-client-metrics-in-rudder-server-for-cost

resolves PRI-163

