### PR TITLE
fix: unmarshaller json configuration not respected

### DIFF
--- a/jsonrs/json.go
+++ b/jsonrs/json.go
@@ -19,20 +19,27 @@ const (
 
 var Default = New(config.Default)
 
-// JSON is the interface that wraps the basic JSON operations.
-type JSON interface {
+type Marshaller interface {
 	// Marshal returns the JSON encoding of v.
 	Marshal(v any) ([]byte, error)
 	// MarshalToString returns the JSON encoding of v as a string.
 	MarshalToString(v any) (string, error)
 	// MarshalIndent returns the JSON encoding of v with indentation.
 	MarshalIndent(v any, prefix, indent string) ([]byte, error)
+	// NewEncoder returns a new json encoder that writes to w.
+	NewEncoder(w io.Writer) Encoder
+}
+type Unmarshaller interface {
 	// Unmarshal parses the JSON-encoded data and stores the result in the value pointed to by v.
 	Unmarshal(data []byte, v any) error
 	// NewDecoder returns a new json decoder that reads from r.
 	NewDecoder(r io.Reader) Decoder
-	// NewEncoder returns a new json encoder that writes to w.
-	NewEncoder(w io.Writer) Encoder
+}
+
+// JSON is the interface that wraps the basic JSON operations.
+type JSON interface {
+	Marshaller
+	Unmarshaller
 }
 
 // Decoder is the interface that wraps the basic JSON decoder operations.
@@ -61,8 +68,8 @@ func New(conf *config.Config) JSON {
 			SonnetLib:   &sonnetJSON{},
 			JsoniterLib: &jsoniterJSON{},
 		},
-		marshaller:   marshaller,
-		unmarshaller: unmarshaller,
+		marshallerFn:   marshaller,
+		unmarshallerFn: unmarshaller,
 	}
 }
 

--- a/jsonrs/switcher.go
+++ b/jsonrs/switcher.go
@@ -4,37 +4,44 @@ import "io"
 
 // switcher is a JSON implementation that switches between different JSON implementations, based on the configuration.
 type switcher struct {
-	marshaller   func() string
-	unmarshaller func() string
-	impls        map[string]JSON
+	marshallerFn   func() string
+	unmarshallerFn func() string
+	impls          map[string]JSON
 }
 
 func (s *switcher) Marshal(v any) ([]byte, error) {
-	return s.impl().Marshal(v)
+	return s.marshaller().Marshal(v)
 }
 
 func (s *switcher) MarshalIndent(v any, prefix, indent string) ([]byte, error) {
-	return s.impl().MarshalIndent(v, prefix, indent)
+	return s.marshaller().MarshalIndent(v, prefix, indent)
 }
 
 func (s *switcher) Unmarshal(data []byte, v any) error {
-	return s.impl().Unmarshal(data, v)
+	return s.unmarshaller().Unmarshal(data, v)
 }
 
 func (s *switcher) MarshalToString(v any) (string, error) {
-	return s.impl().MarshalToString(v)
+	return s.marshaller().MarshalToString(v)
 }
 
 func (s *switcher) NewDecoder(r io.Reader) Decoder {
-	return s.impl().NewDecoder(r)
+	return s.unmarshaller().NewDecoder(r)
 }
 
 func (s *switcher) NewEncoder(w io.Writer) Encoder {
-	return s.impl().NewEncoder(w)
+	return s.marshaller().NewEncoder(w)
 }
 
-func (s *switcher) impl() JSON {
-	if impl, ok := s.impls[s.marshaller()]; ok {
+func (s *switcher) marshaller() Marshaller {
+	if impl, ok := s.impls[s.marshallerFn()]; ok {
+		return impl
+	}
+	return s.impls[DefaultLib]
+}
+
+func (s *switcher) unmarshaller() Unmarshaller {
+	if impl, ok := s.impls[s.unmarshallerFn()]; ok {
 		return impl
 	}
 	return s.impls[DefaultLib]

--- a/jsonrs/switcher_test.go
+++ b/jsonrs/switcher_test.go
@@ -1,6 +1,7 @@
 package jsonrs
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,8 +12,8 @@ func TestSwitcher(t *testing.T) {
 	unmarshaller := StdLib
 
 	switcher := &switcher{
-		marshaller:   func() string { return marshaller },
-		unmarshaller: func() string { return unmarshaller },
+		marshallerFn:   func() string { return marshaller },
+		unmarshallerFn: func() string { return unmarshaller },
 		impls: map[string]JSON{
 			StdLib:      &stdJSON{},
 			JsoniterLib: &jsoniterJSON{},
@@ -45,4 +46,61 @@ func TestSwitcher(t *testing.T) {
 		err = switcher.Unmarshal([]byte(`"text"`), &text)
 		require.NoError(t, err)
 	})
+
+	t.Run("proper marshaller and unmarshaller", func(t *testing.T) {
+		oneJSON := &mockJSON{}
+		twoJSON := &mockJSON{}
+		switcher.impls["one"] = oneJSON
+		switcher.impls["two"] = twoJSON
+		marshaller = "one"
+		unmarshaller = "two"
+
+		_, _ = switcher.Marshal("")
+		require.Equal(t, 1, oneJSON.called)
+		_, _ = switcher.MarshalIndent("", "", "")
+		require.Equal(t, 2, oneJSON.called)
+		_, _ = switcher.MarshalToString("")
+		require.Equal(t, 3, oneJSON.called)
+		_ = switcher.NewEncoder(nil)
+		require.Equal(t, 4, oneJSON.called)
+
+		_ = switcher.Unmarshal([]byte(`""`), nil)
+		require.Equal(t, 1, twoJSON.called)
+		_ = switcher.NewDecoder(nil)
+		require.Equal(t, 2, twoJSON.called)
+	})
+}
+
+type mockJSON struct {
+	called int
+}
+
+func (m *mockJSON) Marshal(v any) ([]byte, error) {
+	m.called++
+	return nil, nil
+}
+
+func (m *mockJSON) MarshalIndent(v any, prefix, indent string) ([]byte, error) {
+	m.called++
+	return nil, nil
+}
+
+func (m *mockJSON) Unmarshal(data []byte, v any) error {
+	m.called++
+	return nil
+}
+
+func (m *mockJSON) MarshalToString(v any) (string, error) {
+	m.called++
+	return "", nil
+}
+
+func (m *mockJSON) NewDecoder(r io.Reader) Decoder {
+	m.called++
+	return nil
+}
+
+func (m *mockJSON) NewEncoder(w io.Writer) Encoder {
+	m.called++
+	return nil
 }


### PR DESCRIPTION
# Description

The `Json.Library.Unmarshaller` configuration option was not respected and the unmarshaller was actually using `Json.Library.Marshaller` configuration option instead. This regression was introduced after refactoring, post benchmarking.
Added a scenario to verify correct behaviour

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
