### PR TITLE
fix: refreshing of datalake expired schemas causing inifinite loop

### DIFF
--- a/warehouse/integrations/datalake/datalake_test.go
+++ b/warehouse/integrations/datalake/datalake_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/xitongsys/parquet-go/reader"
 	"github.com/xitongsys/parquet-go/types"
 
+	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 
 	"google.golang.org/api/option"
@@ -83,15 +84,15 @@ func TestIntegration(t *testing.T) {
 		jobsDB := whth.JobsDB(t, jobsDBPort)
 
 		testCases := []struct {
-			name           string
-			tables         []string
-			destType       string
-			conf           map[string]interface{}
-			schemaTTL      int
-			prerequisite   func(t testing.TB, ctx context.Context)
-			configOverride map[string]any
-			verifySchema   func(*testing.T, filemanager.FileManager, string)
-			verifyRecords  func(*testing.T, filemanager.FileManager, string, string, string)
+			name               string
+			tables             []string
+			destType           string
+			conf               map[string]interface{}
+			schemaTTLInMinutes int
+			prerequisite       func(t testing.TB, ctx context.Context)
+			configOverride     map[string]any
+			verifySchema       func(*testing.T, filemanager.FileManager, string)
+			verifyRecords      func(*testing.T, filemanager.FileManager, string, string, string)
 		}{
 			{
 				name:     "S3Datalake",
@@ -109,7 +110,7 @@ func TestIntegration(t *testing.T) {
 					"prefix":           "some-prefix",
 					"syncFrequency":    "30",
 				},
-				schemaTTL: 0,
+				schemaTTLInMinutes: 0,
 				prerequisite: func(t testing.TB, ctx context.Context) {
 					t.Helper()
 					createMinioBucket(t, ctx, s3EndPoint, s3AccessKeyID, s3AccessKey, s3BucketName, s3Region)
@@ -176,10 +177,10 @@ func TestIntegration(t *testing.T) {
 				},
 			},
 			{
-				name:      "GCSDatalake",
-				tables:    []string{"identifies", "users", "tracks", "product_track", "pages", "screens", "aliases"},
-				destType:  whutils.GCSDatalake,
-				schemaTTL: 100,
+				name:               "GCSDatalake",
+				tables:             []string{"identifies", "users", "tracks", "product_track", "pages", "screens", "aliases"},
+				destType:           whutils.GCSDatalake,
+				schemaTTLInMinutes: 100,
 				conf: map[string]interface{}{
 					"bucketName":    gcsBucketName,
 					"prefix":        "",
@@ -250,10 +251,10 @@ func TestIntegration(t *testing.T) {
 				},
 			},
 			{
-				name:      "AzureDatalake",
-				tables:    []string{"identifies", "users", "tracks", "product_track", "pages", "screens", "aliases", "groups"},
-				destType:  whutils.AzureDatalake,
-				schemaTTL: 100,
+				name:               "AzureDatalake",
+				tables:             []string{"identifies", "users", "tracks", "product_track", "pages", "screens", "aliases", "groups"},
+				destType:           whutils.AzureDatalake,
+				schemaTTLInMinutes: 100,
 				conf: map[string]interface{}{
 					"containerName":  azContainerName,
 					"prefix":         "",
@@ -360,7 +361,7 @@ func TestIntegration(t *testing.T) {
 
 				t.Setenv("STORAGE_EMULATOR_HOST", fmt.Sprintf("localhost:%d", c.Port("gcs", 4443)))
 				t.Setenv("RSERVER_WORKLOAD_IDENTITY_TYPE", "GKE")
-				t.Setenv("RSERVER_WAREHOUSE_SCHEMA_TTL_IN_MINUTES", strconv.Itoa(tc.schemaTTL))
+				t.Setenv(config.ConfigKeyToEnv(config.DefaultEnvPrefix, "Warehouse.schemaTTLInMinutes"), strconv.Itoa(tc.schemaTTLInMinutes))
 
 				whth.BootstrapSvc(t, workspaceConfig, httpPort, jobsDBPort)
 

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -72,6 +72,7 @@ type UploadJob struct {
 	uploadsRepo          *repo.Uploads
 	stagingFileRepo      *repo.StagingFiles
 	loadFilesRepo        *repo.LoadFiles
+	whSchemaRepo         *repo.WHSchema
 	whManager            manager.Manager
 	schemaHandle         schema.Handler
 	conf                 *config.Config
@@ -165,6 +166,7 @@ func (f *UploadJobFactory) NewUploadJob(ctx context.Context, dto *model.UploadJo
 		uploadsRepo:          repo.NewUploads(f.db),
 		stagingFileRepo:      repo.NewStagingFiles(f.db),
 		loadFilesRepo:        repo.NewLoadFiles(f.db),
+		whSchemaRepo:         repo.NewWHSchemas(f.db),
 		schemaHandle: schema.New(
 			f.db,
 			dto.Warehouse,
@@ -942,8 +944,7 @@ func (job *UploadJob) DTO() *model.UploadJob {
 }
 
 func (job *UploadJob) GetLocalSchema(ctx context.Context) (model.Schema, error) {
-	schemaRepo := repo.NewWHSchemas(job.db)
-	whSchema, err := schemaRepo.GetForNamespace(
+	whSchema, err := job.whSchemaRepo.GetForNamespace(
 		ctx,
 		job.warehouse.Source.ID,
 		job.warehouse.Destination.ID,

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -942,7 +942,20 @@ func (job *UploadJob) DTO() *model.UploadJob {
 }
 
 func (job *UploadJob) GetLocalSchema(ctx context.Context) (model.Schema, error) {
-	return job.schemaHandle.GetLocalSchema(ctx)
+	schemaRepo := repo.NewWHSchemas(job.db)
+	whSchema, err := schemaRepo.GetForNamespace(
+		ctx,
+		job.warehouse.Source.ID,
+		job.warehouse.Destination.ID,
+		job.warehouse.Namespace,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("getting schema for namespace: %w", err)
+	}
+	if whSchema.Schema == nil {
+		return model.Schema{}, nil
+	}
+	return whSchema.Schema, nil
 }
 
 func (job *UploadJob) UpdateLocalSchema(ctx context.Context, schema model.Schema) error {

--- a/warehouse/schema/schema.go
+++ b/warehouse/schema/schema.go
@@ -99,7 +99,7 @@ func New(
 		"destinationId": warehouse.Destination.ID,
 	})
 	if conf.GetBoolVar(true, "Warehouse.enableSchemaTTL") {
-		ttlInMinutes := conf.GetDurationVar(720, time.Minute, "Warehouse.schemaTtlInMinutes")
+		ttlInMinutes := conf.GetDurationVar(720, time.Minute, "Warehouse.schemaTTLInMinutes")
 		return newSchemaV2(s, warehouse, logger.Child("schema_v2"), ttlInMinutes, fetchSchemaRepo)
 	}
 	return s

--- a/warehouse/schema/schema.go
+++ b/warehouse/schema/schema.go
@@ -48,7 +48,6 @@ type Handler interface {
 	SyncRemoteSchema(ctx context.Context, fetchSchemaRepo fetchSchemaRepo, uploadID int64) (bool, error)
 	IsWarehouseSchemaEmpty(ctx context.Context) bool
 	GetTableSchemaInWarehouse(ctx context.Context, tableName string) model.TableSchema
-	GetLocalSchema(ctx context.Context) (model.Schema, error)
 	UpdateLocalSchema(ctx context.Context, updatedSchema model.Schema) error
 	UpdateWarehouseTableSchema(ctx context.Context, tableName string, tableSchema model.TableSchema) error
 	GetColumnsCountInWarehouseSchema(ctx context.Context, tableName string) (int, error)
@@ -100,7 +99,7 @@ func New(
 		"destinationId": warehouse.Destination.ID,
 	})
 	if conf.GetBoolVar(true, "Warehouse.enableSchemaTTL") {
-		ttlInMinutes := conf.GetDurationVar(720, time.Minute, "Warehouse.schemaTTLInMinutes")
+		ttlInMinutes := conf.GetDurationVar(720, time.Minute, "Warehouse.schemaTtlInMinutes")
 		return newSchemaV2(s, warehouse, logger.Child("schema_v2"), ttlInMinutes, fetchSchemaRepo)
 	}
 	return s
@@ -311,7 +310,7 @@ func (sh *schema) updateLocalSchema(ctx context.Context, updatedSchema model.Sch
 // 4. Updates local schema with warehouse schema if it has changed
 // 5. Returns true if schema has changed
 func (sh *schema) SyncRemoteSchema(ctx context.Context, fetchSchemaRepo fetchSchemaRepo, uploadID int64) (bool, error) {
-	localSchema, err := sh.GetLocalSchema(ctx)
+	localSchema, err := sh.getLocalSchema(ctx)
 	if err != nil {
 		return false, fmt.Errorf("fetching schema from local: %w", err)
 	}
@@ -339,7 +338,7 @@ func (sh *schema) SyncRemoteSchema(ctx context.Context, fetchSchemaRepo fetchSch
 }
 
 // GetLocalSchema returns the local schema from wh_schemas table
-func (sh *schema) GetLocalSchema(ctx context.Context) (model.Schema, error) {
+func (sh *schema) getLocalSchema(ctx context.Context) (model.Schema, error) {
 	whSchema, err := sh.schemaRepo.GetForNamespace(
 		ctx,
 		sh.warehouse.Source.ID,

--- a/warehouse/schema/schema_v2.go
+++ b/warehouse/schema/schema_v2.go
@@ -75,10 +75,6 @@ func (sh *schemaV2) GetTableSchemaInWarehouse(ctx context.Context, tableName str
 	return schema[tableName]
 }
 
-func (sh *schemaV2) GetLocalSchema(ctx context.Context) (model.Schema, error) {
-	return sh.getSchema(ctx)
-}
-
 func (sh *schemaV2) UpdateLocalSchema(ctx context.Context, updatedSchema model.Schema) error {
 	updatedSchemaInBytes, err := jsonrs.Marshal(updatedSchema)
 	if err != nil {

--- a/warehouse/schema/schema_v2_test.go
+++ b/warehouse/schema/schema_v2_test.go
@@ -58,14 +58,14 @@ func TestSchemaV2(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("SyncRemoteSchema", func(t *testing.T) {
-		schema, err := v2.GetLocalSchema(ctx)
+		schema, err := v2.getSchema(ctx)
 		require.NoError(t, err)
 		require.Equal(t, model.Schema{}, schema)
 		require.True(t, v2.IsWarehouseSchemaEmpty(ctx))
 
 		_, err = v2.SyncRemoteSchema(ctx, nil, 0)
 		require.NoError(t, err)
-		schema, err = v2.GetLocalSchema(ctx)
+		schema, err = v2.getSchema(ctx)
 		require.NoError(t, err)
 		require.Equal(t, model.Schema{
 			"table1": {


### PR DESCRIPTION
# Description

**BUG**: In the `getSchema` method of `schemaV2` if the schema is found to be expired, it calls the `FetchSchema` method of the corresponding warehouse. In case of datalake, it calls `GetLocalSchema` of the uploader which calls the `GetLocalSchema` of schema. This created an inifinte loop as `GetLocalSchema` again calls `getSchema`

**FIX**: Moved the logic of fetching schema from DB from `schema` to `uploader` and removed it from the `Handle` interface

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
