### PR TITLE
chore: skip previously failed tables

### DIFF
--- a/warehouse/router/state_export_data.go
+++ b/warehouse/router/state_export_data.go
@@ -157,7 +157,9 @@ func (job *UploadJob) TablesToSkip() (map[string]model.PendingTableUpload, map[s
 	)
 
 	for _, pendingTableUpload := range job.pendingTableUploads {
-		if pendingTableUpload.UploadID < job.upload.ID && pendingTableUpload.Status == model.TableUploadExportingFailed {
+		if !job.config.skipPreviouslyFailedTables &&
+			pendingTableUpload.UploadID < job.upload.ID &&
+			pendingTableUpload.Status == model.TableUploadExportingFailed {
 			previouslyFailedTableMap[pendingTableUpload.TableName] = pendingTableUpload
 		}
 		if pendingTableUpload.UploadID == job.upload.ID && pendingTableUpload.Status == model.TableUploadExported { // Current upload and table upload succeeded

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -102,6 +102,7 @@ type UploadJob struct {
 		maxParallelLoadsWorkspaceIDs        map[string]interface{}
 		columnsBatchSize                    int
 		longRunningUploadStatThresholdInMin time.Duration
+		skipPreviouslyFailedTables          bool
 	}
 
 	errorHandler    ErrorHandler
@@ -202,6 +203,7 @@ func (f *UploadJobFactory) NewUploadJob(ctx context.Context, dto *model.UploadJo
 	uj.config.minUploadBackoff = f.conf.GetDurationVar(60, time.Second, "Warehouse.minUploadBackoff", "Warehouse.minUploadBackoffInS")
 	uj.config.maxUploadBackoff = f.conf.GetDurationVar(1800, time.Second, "Warehouse.maxUploadBackoff", "Warehouse.maxUploadBackoffInS")
 	uj.config.retryTimeWindow = f.conf.GetDurationVar(180, time.Minute, "Warehouse.retryTimeWindow", "Warehouse.retryTimeWindowInMins")
+	uj.config.skipPreviouslyFailedTables = f.conf.GetBool("Warehouse.skipPreviouslyFailedTables", false)
 
 	uj.stats.uploadTime = uj.timerStat("upload_time")
 	uj.stats.userTablesLoadTime = uj.timerStat("user_tables_load_time")

--- a/warehouse/router/upload_test.go
+++ b/warehouse/router/upload_test.go
@@ -533,48 +533,43 @@ func TestUploadJobT_TablesToSkip(t *testing.T) {
 	})
 
 	t.Run("skip tables", func(t *testing.T) {
-		const (
-			namespace = "namespace"
-			destID    = "destID"
-		)
-
 		pendingTables := []model.PendingTableUpload{
 			{
 				UploadID:      1,
-				DestinationID: destID,
-				Namespace:     namespace,
+				DestinationID: "destID",
+				Namespace:     "namespace",
 				Status:        model.TableUploadExportingFailed,
 				TableName:     "previously_failed_table_1",
 				Error:         "some error",
 			},
 			{
 				UploadID:      1,
-				DestinationID: destID,
-				Namespace:     namespace,
+				DestinationID: "destID",
+				Namespace:     "namespace",
 				Status:        model.TableUploadUpdatingSchemaFailed,
 				TableName:     "previously_failed_table_2",
 				Error:         "",
 			},
 			{
 				UploadID:      1,
-				DestinationID: destID,
-				Namespace:     namespace,
+				DestinationID: "destID",
+				Namespace:     "namespace",
 				Status:        model.TableUploadExported,
 				TableName:     "previously_succeeded_table_1",
 				Error:         "",
 			},
 			{
 				UploadID:      5,
-				DestinationID: destID,
-				Namespace:     namespace,
+				DestinationID: "destID",
+				Namespace:     "namespace",
 				Status:        model.TableUploadExportingFailed,
 				TableName:     "current_failed_table_1",
 				Error:         "some error",
 			},
 			{
 				UploadID:      5,
-				DestinationID: destID,
-				Namespace:     namespace,
+				DestinationID: "destID",
+				Namespace:     "namespace",
 				Status:        model.TableUploadExported,
 				TableName:     "current_succeeded_table_1",
 				Error:         "",
@@ -582,27 +577,20 @@ func TestUploadJobT_TablesToSkip(t *testing.T) {
 		}
 
 		testCases := []struct {
-			name                              string
-			skipPreviouslyFailedTables        bool
-			expectedPreviouslyFailedTables    map[string]model.PendingTableUpload
-			expectedCurrentJobSucceededTables map[string]model.PendingTableUpload
+			name                           string
+			skipPreviouslyFailedTables     bool
+			expectedPreviouslyFailedTables map[string]model.PendingTableUpload
 		}{
 			{
 				name:                           "skip previously failed tables",
 				skipPreviouslyFailedTables:     true,
 				expectedPreviouslyFailedTables: map[string]model.PendingTableUpload{},
-				expectedCurrentJobSucceededTables: map[string]model.PendingTableUpload{
-					"current_succeeded_table_1": pendingTables[4],
-				},
 			},
 			{
 				name:                       "do not skip previously failed tables",
 				skipPreviouslyFailedTables: false,
 				expectedPreviouslyFailedTables: map[string]model.PendingTableUpload{
 					"previously_failed_table_1": pendingTables[0],
-				},
-				expectedCurrentJobSucceededTables: map[string]model.PendingTableUpload{
-					"current_succeeded_table_1": pendingTables[4],
 				},
 			},
 		}
@@ -621,8 +609,10 @@ func TestUploadJobT_TablesToSkip(t *testing.T) {
 
 				previouslyFailedTables, currentJobSucceededTables, err := job.TablesToSkip()
 				require.NoError(t, err)
-				require.Equal(t, previouslyFailedTables, tc.expectedPreviouslyFailedTables)
-				require.Equal(t, currentJobSucceededTables, tc.expectedCurrentJobSucceededTables)
+				require.Equal(t, tc.expectedPreviouslyFailedTables, previouslyFailedTables)
+				require.Equal(t, map[string]model.PendingTableUpload{
+					"current_succeeded_table_1": pendingTables[4],
+				}, currentJobSucceededTables)
 			})
 		}
 	})


### PR DESCRIPTION
# Description

- Skipping previously failed tables when retrying for failed syncs, we can set the failed syncs priority as lower so that it will not affect the real-time syncs. Failed syncs will get processed at a lower priority.
- Using this config, we will not skip the tables which failed for previous syncs. If we don't do it then the current sync will fail till the retry policy and will eventually get marked as aborted.
- In most retry cases, we usually go with the default priority as 100, which means the failed syncs will be processed first and then the real-time ones. But if the number of re-triggered syncs are too many it will take time and affect the real-time syncs.

## Linear Ticket

- Resolves WAR-329.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
