### PR TITLE
feat: increase shm size for postgres in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - build/docker.env
     ports:
       - "6432:5432"
+    shm_size: 128mb
   backend:
     build:
       context: ./

--- a/rudder-docker.yml
+++ b/rudder-docker.yml
@@ -9,6 +9,7 @@ services:
       - POSTGRES_DB=jobsdb
     ports:
       - "6432:5432"
+    shm_size: 128mb
   backend:
     depends_on:
       - db


### PR DESCRIPTION
# Description

[Self-hosted Docker version](https://www.rudderstack.com/docs/get-started/rudderstack-open-source/data-plane-setup/docker/) of RudderStack sometimes may crash with the following stack trace:

```
rudderstack-backend-1  | 2025-02-03T10:17:00.400Z	ERROR	processor	processor/processor.go:3518	Failed to get unprocessed jobs from DB. Error: pq: could not resize shared memory segment "/PostgreSQL.1265551680" to 8388608 bytes: No space left on device
rudderstack-backend-1  | 2025-02-03T10:17:00.400Z	ERROR	runner.panic	crash/logger.go:33	Panic detected. Application will crash.	{"stack": "goroutine 1119 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:26 +0x5e\ngithub.com/rudderlabs/rudder-server/utils/crash.(*panicLogger).Notify.func1.1()\n\t/rudder-server/utils/crash/logger.go:34 +0x58\nsync.(*Once).doSlow(0x43bb25?, 0xc001409880?)\n\t/usr/local/go/src/sync/once.go:76 +0xb4\nsync.(*Once).Do(...)\n\t/usr/local/go/src/sync/once.go:67\ngithub.com/rudderlabs/rudder-server/utils/crash.(*panicLogger).Notify.func1()\n\t/rudder-server/utils/crash/logger.go:32 +0x9c\npanic({0x41c7000?, 0xc00237e6c0?})\n\t/usr/local/go/src/runtime/panic.go:785 +0x132\ngithub.com/rudderlabs/rudder-server/processor.(*Handle).getJobs(0xc000c90008, {0xc00522a6c0, 0x1b})\n\t/rudder-server/processor/processor.go:3519 +0x9ca\ngithub.com/rudderlabs/rudder-server/processor.(*worker).Work(0xc003655300)\n\t/rudder-server/processor/worker.go:141 +0xc9\ngithub.com/rudderlabs/rudder-server/utils/workerpool.(*internalWorker).start.func1()\n\t/rudder-server/utils/workerpool/internal_worker.go:64 +0x2a7\ngithub.com/rudderlabs/rudder-server/rruntime.Go.func1()\n\t/rudder-server/rruntime/goroutine-factory.go:23 +0x57\ncreated by github.com/rudderlabs/rudder-server/rruntime.Go in goroutine 929\n\t/rudder-server/rruntime/goroutine-factory.go:21 +0x4f\n", "panic": "pq: could not resize shared memory segment \"/PostgreSQL.1265551680\" to 8388608 bytes: No space left on device", "team": "Core", "goRoutines": 834, "version": "1.41.0", "releaseStage": "development", "appType": "rudder-server-EMBEDDED"}
rudderstack-backend-1  | 2025-02-03T10:17:00.400Z	ERROR	runner.panic	crash/logger.go:33	goroutine 1119 [running]:
rudderstack-backend-1  | github.com/rudderlabs/rudder-go-kit/logger.(*logger).Fataln(0xc000aa8ea0, {0x48ddf45, 0x27}, {0xc0000e2008, 0x7, 0xc00182e300?})
rudderstack-backend-1  | 	/go/pkg/mod/github.com/rudderlabs/rudder-go-kit@v0.46.1/logger/logger.go:381 +0x314
rudderstack-backend-1  | github.com/rudderlabs/rudder-server/utils/crash.(*panicLogger).Notify.func1.1()
rudderstack-backend-1  | 	/rudder-server/utils/crash/logger.go:33 +0x604
rudderstack-backend-1  | sync.(*Once).doSlow(0x43bb25?, 0xc001409880?)
rudderstack-backend-1  | 	/usr/local/go/src/sync/once.go:76 +0xb4
rudderstack-backend-1  | sync.(*Once).Do(...)
rudderstack-backend-1  | 	/usr/local/go/src/sync/once.go:67
rudderstack-backend-1  | github.com/rudderlabs/rudder-server/utils/crash.(*panicLogger).Notify.func1()
rudderstack-backend-1  | 	/rudder-server/utils/crash/logger.go:32 +0x9c
rudderstack-backend-1  | panic({0x41c7000?, 0xc00237e6c0?})
rudderstack-backend-1  | 	/usr/local/go/src/runtime/panic.go:785 +0x132
rudderstack-backend-1  | github.com/rudderlabs/rudder-server/processor.(*Handle).getJobs(0xc000c90008, {0xc00522a6c0, 0x1b})
rudderstack-backend-1  | 	/rudder-server/processor/processor.go:3519 +0x9ca
rudderstack-backend-1  | github.com/rudderlabs/rudder-server/processor.(*worker).Work(0xc003655300)
rudderstack-backend-1  | 	/rudder-server/processor/worker.go:141 +0xc9
rudderstack-backend-1  | github.com/rudderlabs/rudder-server/utils/workerpool.(*internalWorker).start.func1()
rudderstack-backend-1  | 	/rudder-server/utils/workerpool/internal_worker.go:64 +0x2a7
rudderstack-backend-1  | github.com/rudderlabs/rudder-server/rruntime.Go.func1()
rudderstack-backend-1  | 	/rudder-server/rruntime/goroutine-factory.go:23 +0x57
rudderstack-backend-1  | created by github.com/rudderlabs/rudder-server/rruntime.Go in goroutine 929
rudderstack-backend-1  | 	/rudder-server/rruntime/goroutine-factory.go:21 +0x4f
rudderstack-backend-1  | 	{"stack": "goroutine 1119 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:26 +0x5e\ngithub.com/rudderlabs/rudder-server/utils/crash.(*panicLogger).Notify.func1.1()\n\t/rudder-server/utils/crash/logger.go:34 +0x58\nsync.(*Once).doSlow(0x43bb25?, 0xc001409880?)\n\t/usr/local/go/src/sync/once.go:76 +0xb4\nsync.(*Once).Do(...)\n\t/usr/local/go/src/sync/once.go:67\ngithub.com/rudderlabs/rudder-server/utils/crash.(*panicLogger).Notify.func1()\n\t/rudder-server/utils/crash/logger.go:32 +0x9c\npanic({0x41c7000?, 0xc00237e6c0?})\n\t/usr/local/go/src/runtime/panic.go:785 +0x132\ngithub.com/rudderlabs/rudder-server/processor.(*Handle).getJobs(0xc000c90008, {0xc00522a6c0, 0x1b})\n\t/rudder-server/processor/processor.go:3519 +0x9ca\ngithub.com/rudderlabs/rudder-server/processor.(*worker).Work(0xc003655300)\n\t/rudder-server/processor/worker.go:141 +0xc9\ngithub.com/rudderlabs/rudder-server/utils/workerpool.(*internalWorker).start.func1()\n\t/rudder-server/utils/workerpool/internal_worker.go:64 +0x2a7\ngithub.com/rudderlabs/rudder-server/rruntime.Go.func1()\n\t/rudder-server/rruntime/goroutine-factory.go:23 +0x57\ncreated by github.com/rudderlabs/rudder-server/rruntime.Go in goroutine 929\n\t/rudder-server/rruntime/goroutine-factory.go:21 +0x4f\n", "panic": "pq: could not resize shared memory segment \"/PostgreSQL.1265551680\" to 8388608 bytes: No space left on device", "team": "Core", "goRoutines": 834, "version": "1.41.0", "releaseStage": "development", "appType": "rudder-server-EMBEDDED"}
rudderstack-backend-1  | panic: pq: could not resize shared memory segment "/PostgreSQL.1265551680" to 8388608 bytes: No space left on device [recovered]
rudderstack-backend-1  | 	panic: pq: could not resize shared memory segment "/PostgreSQL.1265551680" to 8388608 bytes: No space left on device
rudderstack-backend-1  | 
rudderstack-backend-1  | goroutine 1119 [running]:
rudderstack-backend-1  | github.com/rudderlabs/rudder-server/utils/crash.(*panicLogger).Notify.func1()
rudderstack-backend-1  | 	/rudder-server/utils/crash/logger.go:43 +0x85
rudderstack-backend-1  | panic({0x41c7000?, 0xc00237e6c0?})
rudderstack-backend-1  | 	/usr/local/go/src/runtime/panic.go:785 +0x132
rudderstack-backend-1  | github.com/rudderlabs/rudder-server/processor.(*Handle).getJobs(0xc000c90008, {0xc00522a6c0, 0x1b})
rudderstack-backend-1  | 	/rudder-server/processor/processor.go:3519 +0x9ca
rudderstack-backend-1  | github.com/rudderlabs/rudder-server/processor.(*worker).Work(0xc003655300)
rudderstack-backend-1  | 	/rudder-server/processor/worker.go:141 +0xc9
rudderstack-backend-1  | github.com/rudderlabs/rudder-server/utils/workerpool.(*internalWorker).start.func1()
rudderstack-backend-1  | 	/rudder-server/utils/workerpool/internal_worker.go:64 +0x2a7
rudderstack-backend-1  | github.com/rudderlabs/rudder-server/rruntime.Go.func1()
rudderstack-backend-1  | 	/rudder-server/rruntime/goroutine-factory.go:23 +0x57
rudderstack-backend-1  | created by github.com/rudderlabs/rudder-server/rruntime.Go in goroutine 929
rudderstack-backend-1  | 	/rudder-server/rruntime/goroutine-factory.go:21 +0x4f
rudderstack-backend-1 exited with code 0
```

The problem is in `pq: could not resize shared memory segment. No space left on device`. It occurs when there is no space left in `/dev/shm` which is used for shared memory.

[By default](https://docs.docker.com/engine/containers/run/) Docker sets it to 64 MB using `--shm-size`, which is quite low for modern systems or high load environments. For example [official Postgres Docker image](https://hub.docker.com/_/postgres) sets `shm_size` to 128 MB. 

This PR increases `/dev/shm` size of Postgres container for production Docker Compose config (`rudder-docker.yml`) from 64 MB to 128 MB. Setting it explicitly also highlights an ability to increase it, which may be the case for some users who expect high load. All uses who will set up their self-hosted version using [this](https://www.rudderstack.com/docs/get-started/rudderstack-open-source/data-plane-setup/docker/) documentation will use explicitly set `shm_size`.

This PR also increases default `shm_size` of `docker-compose.yml` to match the production config. Though I didn't touch test configurations: `warehouse/integrations/postgres/testdata/docker-compose.postgres.yml`, `warehouse/integrations/postgres/testdata/docker-compose.replication.yml`, `warehouse/integrations/testdata/docker-compose.jobsdb.yml`. Tell me if they also should be tweaked. 

## Linear Ticket

There is no Linear Ticket, but here is related GitHub discussion - https://github.com/rudderlabs/rudder-server/discussions/5468

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
