### PR TITLE
fix: error handling for async destinations

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/common/manager.go
+++ b/router/batchrouter/asyncdestinationmanager/common/manager.go
@@ -7,7 +7,9 @@ import (
 	"github.com/rudderlabs/rudder-server/jobsdb"
 )
 
-type InvalidManager struct{}
+type InvalidManager struct {
+	Error error
+}
 
 func (*InvalidManager) Transform(job *jobsdb.JobT) (string, error) {
 	return "", errors.New("invalid job")

--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -524,6 +524,17 @@ func (brt *Handle) sendJobsToStorage(batchJobs BatchedJobs) {
 			continue
 		}
 
+		if invalidManager, ok := brt.asyncDestinationStruct[destinationID].Manager.(*asynccommon.InvalidManager); ok {
+			failedAsyncJobs := BatchedJobs{
+				Jobs:       []*jobsdb.JobT{job},
+				Connection: batchJobs.Connection,
+				TimeWindow: batchJobs.TimeWindow,
+				JobState:   jobsdb.Aborted.State,
+			}
+			brt.updateJobStatus(&failedAsyncJobs, false, invalidManager.Error, false)
+			continue
+		}
+
 		fileData, err := brt.asyncDestinationStruct[destinationID].Manager.Transform(job)
 		if err != nil {
 			failedAsyncJobs := BatchedJobs{

--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -476,6 +476,16 @@ func (brt *Handle) sendJobsToStorage(batchJobs BatchedJobs) {
 
 	_, ok := brt.asyncDestinationStruct[destinationID]
 	if ok {
+		if invalidManager, ok := brt.asyncDestinationStruct[destinationID].Manager.(*asynccommon.InvalidManager); ok {
+			failedAsyncJobs := BatchedJobs{
+				Jobs:       batchJobs.Jobs,
+				Connection: batchJobs.Connection,
+				TimeWindow: batchJobs.TimeWindow,
+				JobState:   jobsdb.Aborted.State,
+			}
+			brt.updateJobStatus(&failedAsyncJobs, false, invalidManager.Error, false)
+			return
+		}
 		brt.asyncDestinationStruct[destinationID].UploadMutex.Lock()
 		defer brt.asyncDestinationStruct[destinationID].UploadMutex.Unlock()
 		if brt.asyncDestinationStruct[destinationID].CanUpload {
@@ -521,17 +531,6 @@ func (brt *Handle) sendJobsToStorage(batchJobs BatchedJobs) {
 		if !IsAsyncDestinationLimitNotReached(brt, destinationID) {
 			overFlow = true
 			overFlownJobs = append(overFlownJobs, job)
-			continue
-		}
-
-		if invalidManager, ok := brt.asyncDestinationStruct[destinationID].Manager.(*asynccommon.InvalidManager); ok {
-			failedAsyncJobs := BatchedJobs{
-				Jobs:       []*jobsdb.JobT{job},
-				Connection: batchJobs.Connection,
-				TimeWindow: batchJobs.TimeWindow,
-				JobState:   jobsdb.Aborted.State,
-			}
-			brt.updateJobStatus(&failedAsyncJobs, false, invalidManager.Error, false)
 			continue
 		}
 

--- a/router/batchrouter/handle_async_test.go
+++ b/router/batchrouter/handle_async_test.go
@@ -53,9 +53,12 @@ func (m mockAsyncDestinationManager) GetUploadStats(common.GetUploadStatsInput) 
 func defaultHandle(destType string) *Handle {
 	batchRouter := &Handle{}
 	batchRouter.destType = destType
+	batchRouter.maxPayloadSizeInBytes = 10000
+	batchRouter.maxEventsInABatch = 100
 	batchRouter.destinationsMap = make(map[string]*routerutils.DestinationWithSources)
 	batchRouter.uploadIntervalMap = make(map[string]time.Duration)
 	batchRouter.asyncDestinationStruct = make(map[string]*common.AsyncDestinationStruct)
+	batchRouter.failingDestinations = make(map[string]bool)
 	batchRouter.setupReloadableVars()
 	batchRouter.logger = logger.NOP
 	batchRouter.conf = config.Default
@@ -728,5 +731,76 @@ func TestAsyncDestinationManager(t *testing.T) {
 		}()
 		<-done
 		require.EqualValues(t, 1, statsStore.Get("async_failed_job_count", stats.Tags{}).LastValue())
+	})
+
+	t.Run("SendJobsToStorage", func(t *testing.T) {
+		t.Run("Invalid Destination", func(t *testing.T) {
+			destType := "SOME_INVALID_DESTINATION_TYPE"
+			destination := backendconfig.DestinationT{
+				ID:   "destinationID",
+				Name: destType,
+				DestinationDefinition: backendconfig.DestinationDefinitionT{
+					Name: destType,
+				},
+			}
+			sources := []backendconfig.SourceT{
+				{
+					ID: "sourceID",
+					Destinations: []backendconfig.DestinationT{
+						destination,
+					},
+				},
+			}
+
+			batchRouter := defaultHandle(destType)
+			mockCtrl := gomock.NewController(t)
+			mockJobsDB := mocksJobsDB.NewMockJobsDB(mockCtrl)
+			mockErrJobsDB := mocksJobsDB.NewMockJobsDB(mockCtrl)
+			batchRouter.jobsDB = mockJobsDB
+			batchRouter.errorDB = mockErrJobsDB
+			batchRouter.destinationsMap = make(map[string]*routerutils.DestinationWithSources)
+			for _, source := range sources {
+				for _, destination := range source.Destinations {
+					batchRouter.destinationsMap[destination.ID] = &routerutils.DestinationWithSources{
+						Destination: destination,
+						Sources:     []backendconfig.SourceT{source},
+					}
+				}
+			}
+
+			job := &jobsdb.JobT{
+				JobID:        1,
+				EventPayload: []byte(`{"key": "value"}`),
+			}
+			abortedJob := &jobsdb.JobT{
+				JobID:        job.JobID,
+				EventPayload: job.EventPayload,
+				Parameters:   []byte(`{"stage":"batch_router","reason":"SOME_INVALID_DESTINATION_TYPE initialization failed with error: invalid destination type"}`),
+			}
+			batchRouter.initAsyncDestinationStruct(&destination)
+			mockJobsDB.EXPECT().WithUpdateSafeTx(gomock.Any(), gomock.Any()).Times(1).
+				Do(func(ctx context.Context, f func(tx jobsdb.UpdateSafeTx) error) {
+					_ = f(jobsdb.EmptyUpdateSafeTx())
+				}).Return(nil)
+			mockJobsDB.EXPECT().UpdateJobStatusInTx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
+				Do(func(ctx context.Context, _ interface{}, statuses []*jobsdb.JobStatusT, customValFilters []string, _ interface{}) {
+					require.Equal(t, []string{destType}, customValFilters)
+					require.Len(t, statuses, 1)
+					require.Equal(t, job.JobID, statuses[0].JobID)
+					require.Equal(t, jobsdb.Aborted.State, statuses[0].JobState)
+					require.Equal(t, "SOME_INVALID_DESTINATION_TYPE initialization failed with error: invalid destination type", gjson.GetBytes(statuses[0].ErrorResponse, "Error").String())
+				}).Return(nil)
+			mockErrJobsDB.EXPECT().Store(gomock.Any(), []*jobsdb.JobT{abortedJob}).Return(nil).AnyTimes()
+
+			batchRouter.sendJobsToStorage(BatchedJobs{
+				Jobs: []*jobsdb.JobT{
+					job,
+				},
+				Connection: &Connection{
+					Source:      sources[0],
+					Destination: destination,
+				},
+			})
+		})
 	})
 }

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -272,7 +272,9 @@ func (brt *Handle) initAsyncDestinationStruct(destination *backendconfig.Destina
 			"destType": destination.DestinationDefinition.Name,
 		})
 		destInitFailStat.Count(1)
-		manager = &asynccommon.InvalidManager{}
+		manager = &asynccommon.InvalidManager{
+			Error: fmt.Errorf("%s initialization failed with error: %v", destination.Name, err),
+		}
 	}
 	if !ok {
 		brt.asyncDestinationStruct[destination.ID] = &asynccommon.AsyncDestinationStruct{}


### PR DESCRIPTION
# Description

Async destinations are not providing clear errors when destination initialization is failing so customers are getting confused.

## Linear Ticket

https://linear.app/rudderstack/issue/INT-3323/investigate-object-storage-configuration-errors-in-snowflake-to-eloqua
Resolves INT-3323/

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
