### PR TITLE
chore: mssql and azure synapse cleanup and enable integration tests

### DIFF
--- a/warehouse/integrations/azure-synapse/azure-synapse.go
+++ b/warehouse/integrations/azure-synapse/azure-synapse.go
@@ -78,13 +78,13 @@ var azureSynapseDataTypesMapToRudder = map[string]string{
 }
 
 type AzureSynapse struct {
-	DB                 *sqlmw.DB
-	Namespace          string
-	ObjectStorage      string
-	Warehouse          model.Warehouse
-	Uploader           warehouseutils.Uploader
+	db                 *sqlmw.DB
+	namespace          string
+	objectStorage      string
+	warehouse          model.Warehouse
+	uploader           warehouseutils.Uploader
 	connectTimeout     time.Duration
-	LoadFileDownLoader downloader.Downloader
+	loadFileDownLoader downloader.Downloader
 
 	stats  stats.Stats
 	conf   *config.Config
@@ -169,12 +169,12 @@ func (as *AzureSynapse) connect() (*sqlmw.DB, error) {
 		sqlmw.WithStats(as.stats),
 		sqlmw.WithLogger(as.logger),
 		sqlmw.WithKeyAndValues([]any{
-			logfield.SourceID, as.Warehouse.Source.ID,
-			logfield.SourceType, as.Warehouse.Source.SourceDefinition.Name,
-			logfield.DestinationID, as.Warehouse.Destination.ID,
-			logfield.DestinationType, as.Warehouse.Destination.DestinationDefinition.Name,
-			logfield.WorkspaceID, as.Warehouse.WorkspaceID,
-			logfield.Namespace, as.Namespace,
+			logfield.SourceID, as.warehouse.Source.ID,
+			logfield.SourceType, as.warehouse.Source.SourceDefinition.Name,
+			logfield.DestinationID, as.warehouse.Destination.ID,
+			logfield.DestinationType, as.warehouse.Destination.DestinationDefinition.Name,
+			logfield.WorkspaceID, as.warehouse.WorkspaceID,
+			logfield.Namespace, as.namespace,
 		}),
 		sqlmw.WithQueryTimeout(as.connectTimeout),
 		sqlmw.WithSlowQueryThreshold(as.config.slowQueryThreshold),
@@ -184,12 +184,12 @@ func (as *AzureSynapse) connect() (*sqlmw.DB, error) {
 
 func (as *AzureSynapse) connectionCredentials() *credentials {
 	return &credentials{
-		host:     as.Warehouse.GetStringDestinationConfig(as.conf, model.HostSetting),
-		dbName:   as.Warehouse.GetStringDestinationConfig(as.conf, model.DatabaseSetting),
-		user:     as.Warehouse.GetStringDestinationConfig(as.conf, model.UserSetting),
-		password: as.Warehouse.GetStringDestinationConfig(as.conf, model.PasswordSetting),
-		port:     as.Warehouse.GetStringDestinationConfig(as.conf, model.PortSetting),
-		sslMode:  as.Warehouse.GetStringDestinationConfig(as.conf, model.SSLModeSetting),
+		host:     as.warehouse.GetStringDestinationConfig(as.conf, model.HostSetting),
+		dbName:   as.warehouse.GetStringDestinationConfig(as.conf, model.DatabaseSetting),
+		user:     as.warehouse.GetStringDestinationConfig(as.conf, model.UserSetting),
+		password: as.warehouse.GetStringDestinationConfig(as.conf, model.PasswordSetting),
+		port:     as.warehouse.GetStringDestinationConfig(as.conf, model.PortSetting),
+		sslMode:  as.warehouse.GetStringDestinationConfig(as.conf, model.SSLModeSetting),
 		timeout:  as.connectTimeout,
 	}
 }
@@ -212,17 +212,17 @@ func (as *AzureSynapse) loadTable(
 	skipTempTableDelete bool,
 ) (*types.LoadTableStats, string, error) {
 	log := as.logger.With(
-		logfield.SourceID, as.Warehouse.Source.ID,
-		logfield.SourceType, as.Warehouse.Source.SourceDefinition.Name,
-		logfield.DestinationID, as.Warehouse.Destination.ID,
-		logfield.DestinationType, as.Warehouse.Destination.DestinationDefinition.Name,
-		logfield.WorkspaceID, as.Warehouse.WorkspaceID,
-		logfield.Namespace, as.Namespace,
+		logfield.SourceID, as.warehouse.Source.ID,
+		logfield.SourceType, as.warehouse.Source.SourceDefinition.Name,
+		logfield.DestinationID, as.warehouse.Destination.ID,
+		logfield.DestinationType, as.warehouse.Destination.DestinationDefinition.Name,
+		logfield.WorkspaceID, as.warehouse.WorkspaceID,
+		logfield.Namespace, as.namespace,
 		logfield.TableName, tableName,
 	)
 	log.Infow("started loading")
 
-	fileNames, err := as.LoadFileDownLoader.Download(ctx, tableName)
+	fileNames, err := as.loadFileDownLoader.Download(ctx, tableName)
 	if err != nil {
 		return nil, "", fmt.Errorf("downloading load files: %w", err)
 	}
@@ -250,11 +250,11 @@ func (as *AzureSynapse) loadTable(
 		  TOP 0 * INTO %[1]s.%[2]s
 		FROM
 		  %[1]s.%[3]s;`,
-		as.Namespace,
+		as.namespace,
 		stagingTableName,
 		tableName,
 	)
-	if _, err = as.DB.ExecContext(ctx, createStagingTableStmt); err != nil {
+	if _, err = as.db.ExecContext(ctx, createStagingTableStmt); err != nil {
 		return nil, "", fmt.Errorf("creating temporary table: %w", err)
 	}
 
@@ -264,7 +264,7 @@ func (as *AzureSynapse) loadTable(
 		}()
 	}
 
-	txn, err := as.DB.BeginTx(ctx, &sql.TxOptions{})
+	txn, err := as.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
 		return nil, "", fmt.Errorf("begin transaction: %w", err)
 	}
@@ -278,7 +278,7 @@ func (as *AzureSynapse) loadTable(
 		tableSchemaInUpload,
 	)
 	previousColumnKeys := warehouseutils.SortColumnKeysFromColumnMap(
-		as.Uploader.GetTableSchemaInWarehouse(
+		as.uploader.GetTableSchemaInWarehouse(
 			tableName,
 		),
 	)
@@ -287,7 +287,7 @@ func (as *AzureSynapse) loadTable(
 	})
 
 	log.Debugw("creating prepared stmt for loading data")
-	copyInStmt := mssql.CopyIn(as.Namespace+"."+stagingTableName, mssql.BulkOptions{CheckConstraints: false},
+	copyInStmt := mssql.CopyIn(as.namespace+"."+stagingTableName, mssql.BulkOptions{CheckConstraints: false},
 		append(sortedColumnKeys, extraColumns...)...,
 	)
 	stmt, err := txn.PrepareContext(ctx, copyInStmt)
@@ -490,7 +490,7 @@ func (as *AzureSynapse) deleteFromLoadTable(
 	var additionalJoinClause string
 	if tableName == warehouseutils.DiscardsTable {
 		additionalJoinClause = fmt.Sprintf(`AND _source.%[3]s = %[1]q.%[2]q.%[3]q AND _source.%[4]s = %[1]q.%[2]q.%[4]q`,
-			as.Namespace,
+			as.namespace,
 			tableName,
 			"table_name",
 			"column_name",
@@ -506,7 +506,7 @@ func (as *AzureSynapse) deleteFromLoadTable(
 		  (
 			_source.%[4]s = %[1]q.%[2]q.%[4]q %[5]s
 		  );`,
-		as.Namespace,
+		as.namespace,
 		tableName,
 		stagingTableName,
 		primaryKey,
@@ -554,7 +554,7 @@ func (as *AzureSynapse) insertIntoLoadTable(
 		  ) AS _
 		WHERE
 		  _rudder_staging_row_number = 1;`,
-		as.Namespace,
+		as.namespace,
 		tableName,
 		quotedColumnNames,
 		stagingTableName,
@@ -591,13 +591,13 @@ func hasDiacritics(str string) bool {
 func (as *AzureSynapse) loadUserTables(ctx context.Context) (errorMap map[string]error) {
 	errorMap = map[string]error{warehouseutils.IdentifiesTable: nil}
 	as.logger.Infof("AZ: Starting load for identifies and users tables\n")
-	_, identifyStagingTable, err := as.loadTable(ctx, warehouseutils.IdentifiesTable, as.Uploader.GetTableSchemaInUpload(warehouseutils.IdentifiesTable), true)
+	_, identifyStagingTable, err := as.loadTable(ctx, warehouseutils.IdentifiesTable, as.uploader.GetTableSchemaInUpload(warehouseutils.IdentifiesTable), true)
 	if err != nil {
 		errorMap[warehouseutils.IdentifiesTable] = err
 		return
 	}
 
-	if len(as.Uploader.GetTableSchemaInUpload(warehouseutils.UsersTable)) == 0 {
+	if len(as.uploader.GetTableSchemaInUpload(warehouseutils.UsersTable)) == 0 {
 		return
 	}
 	errorMap[warehouseutils.UsersTable] = nil
@@ -608,7 +608,7 @@ func (as *AzureSynapse) loadUserTables(ctx context.Context) (errorMap map[string
 	defer as.dropStagingTable(ctx, unionStagingTableName)
 	defer as.dropStagingTable(ctx, identifyStagingTable)
 
-	userColMap := as.Uploader.GetTableSchemaInWarehouse(warehouseutils.UsersTable)
+	userColMap := as.uploader.GetTableSchemaInWarehouse(warehouseutils.UsersTable)
 	var userColNames, firstValProps []string
 	for colName := range userColMap {
 		if colName == "id" {
@@ -622,7 +622,7 @@ func (as *AzureSynapse) loadUserTables(ctx context.Context) (errorMap map[string
 							  and %[1]q is not null
 							order by received_at desc
 							)
-						  end as %[1]q`, colName, as.Namespace+"."+unionStagingTableName)
+						  end as %[1]q`, colName, as.namespace+"."+unionStagingTableName)
 		// IGNORE NULLS only supported in Azure SQL edge, in which case the query can be shortened to below
 		// https://docs.microsoft.com/en-us/sql/t-sql/functions/first-value-transact-sql?view=sql-server-ver15
 		// caseSubQuery := fmt.Sprintf(`FIRST_VALUE(%[1]s) IGNORE NULLS OVER (PARTITION BY id ORDER BY received_at DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "%[1]s"`, colName)
@@ -637,10 +637,10 @@ func (as *AzureSynapse) loadUserTables(ctx context.Context) (errorMap map[string
 												(
 													SELECT user_id, %[4]s FROM %[3]s  WHERE user_id IS NOT NULL
 												)) a
-											`, as.Namespace, as.Namespace+"."+warehouseutils.UsersTable, as.Namespace+"."+identifyStagingTable, strings.Join(userColNames, ","), as.Namespace+"."+unionStagingTableName)
+											`, as.namespace, as.namespace+"."+warehouseutils.UsersTable, as.namespace+"."+identifyStagingTable, strings.Join(userColNames, ","), as.namespace+"."+unionStagingTableName)
 
 	as.logger.Debugf("AZ: Creating staging table for union of users table with identify staging table: %s\n", sqlStatement)
-	_, err = as.DB.ExecContext(ctx, sqlStatement)
+	_, err = as.db.ExecContext(ctx, sqlStatement)
 	if err != nil {
 		errorMap[warehouseutils.UsersTable] = err
 		return
@@ -653,13 +653,13 @@ func (as *AzureSynapse) loadUserTables(ctx context.Context) (errorMap map[string
 											FROM %[3]s as x
 										) as xyz
 									) a`,
-		as.Namespace+"."+stagingTableName,
+		as.namespace+"."+stagingTableName,
 		strings.Join(firstValProps, ","),
-		as.Namespace+"."+unionStagingTableName,
+		as.namespace+"."+unionStagingTableName,
 	)
 
 	as.logger.Debugf("AZ: Creating staging table for users: %s\n", sqlStatement)
-	_, err = as.DB.ExecContext(ctx, sqlStatement)
+	_, err = as.db.ExecContext(ctx, sqlStatement)
 	if err != nil {
 		as.logger.Errorf("AZ: Error Creating staging table for users: %s\n", sqlStatement)
 		errorMap[warehouseutils.UsersTable] = err
@@ -667,14 +667,14 @@ func (as *AzureSynapse) loadUserTables(ctx context.Context) (errorMap map[string
 	}
 
 	// BEGIN TRANSACTION
-	tx, err := as.DB.BeginTx(ctx, &sql.TxOptions{})
+	tx, err := as.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
 		errorMap[warehouseutils.UsersTable] = err
 		return
 	}
 
 	primaryKey := "id"
-	sqlStatement = fmt.Sprintf(`DELETE FROM %[1]s."%[2]s" FROM %[3]s _source where (_source.%[4]s = %[1]s.%[2]s.%[4]s)`, as.Namespace, warehouseutils.UsersTable, as.Namespace+"."+stagingTableName, primaryKey)
+	sqlStatement = fmt.Sprintf(`DELETE FROM %[1]s."%[2]s" FROM %[3]s _source where (_source.%[4]s = %[1]s.%[2]s.%[4]s)`, as.namespace, warehouseutils.UsersTable, as.namespace+"."+stagingTableName, primaryKey)
 	as.logger.Infof("AZ: Dedup records for table:%s using staging table: %s\n", warehouseutils.UsersTable, sqlStatement)
 	_, err = tx.ExecContext(ctx, sqlStatement)
 	if err != nil {
@@ -684,7 +684,7 @@ func (as *AzureSynapse) loadUserTables(ctx context.Context) (errorMap map[string
 		return
 	}
 
-	sqlStatement = fmt.Sprintf(`INSERT INTO "%[1]s"."%[2]s" (%[4]s) SELECT %[4]s FROM  %[3]s`, as.Namespace, warehouseutils.UsersTable, as.Namespace+"."+stagingTableName, strings.Join(append([]string{"id"}, userColNames...), ","))
+	sqlStatement = fmt.Sprintf(`INSERT INTO "%[1]s"."%[2]s" (%[4]s) SELECT %[4]s FROM  %[3]s`, as.namespace, warehouseutils.UsersTable, as.namespace+"."+stagingTableName, strings.Join(append([]string{"id"}, userColNames...), ","))
 	as.logger.Infof("AZ: Inserting records for table:%s using staging table: %s\n", warehouseutils.UsersTable, sqlStatement)
 	_, err = tx.ExecContext(ctx, sqlStatement)
 	if err != nil {
@@ -710,9 +710,9 @@ func (*AzureSynapse) DeleteBy(context.Context, []string, warehouseutils.DeleteBy
 
 func (as *AzureSynapse) CreateSchema(ctx context.Context) (err error) {
 	sqlStatement := fmt.Sprintf(`IF NOT EXISTS ( SELECT  * FROM  sys.schemas WHERE   name = N'%s' )
-    EXEC('CREATE SCHEMA [%s]');`, as.Namespace, as.Namespace)
-	as.logger.Infof("SYNAPSE: Creating schema name in synapse for AZ:%s : %v", as.Warehouse.Destination.ID, sqlStatement)
-	_, err = as.DB.ExecContext(ctx, sqlStatement)
+    EXEC('CREATE SCHEMA [%s]');`, as.namespace, as.namespace)
+	as.logger.Infof("SYNAPSE: Creating schema name in synapse for AZ:%s : %v", as.warehouse.Destination.ID, sqlStatement)
+	_, err = as.db.ExecContext(ctx, sqlStatement)
 	if errors.Is(err, io.EOF) {
 		return nil
 	}
@@ -721,9 +721,9 @@ func (as *AzureSynapse) CreateSchema(ctx context.Context) (err error) {
 
 func (as *AzureSynapse) dropStagingTable(ctx context.Context, stagingTableName string) {
 	as.logger.Infof("AZ: dropping table %+v\n", stagingTableName)
-	_, err := as.DB.ExecContext(ctx, fmt.Sprintf(`IF OBJECT_ID ('%[1]s','U') IS NOT NULL DROP TABLE %[1]s;`, as.Namespace+"."+stagingTableName))
+	_, err := as.db.ExecContext(ctx, fmt.Sprintf(`IF OBJECT_ID ('%[1]s','U') IS NOT NULL DROP TABLE %[1]s;`, as.namespace+"."+stagingTableName))
 	if err != nil {
-		as.logger.Errorf("AZ:  Error dropping staging table %s in synapse: %v", as.Namespace+"."+stagingTableName, err)
+		as.logger.Errorf("AZ:  Error dropping staging table %s in synapse: %v", as.namespace+"."+stagingTableName, err)
 	}
 }
 
@@ -731,21 +731,21 @@ func (as *AzureSynapse) createTable(ctx context.Context, name string, columns mo
 	sqlStatement := fmt.Sprintf(`IF  NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'%[1]s') AND type = N'U')
 	CREATE TABLE %[1]s ( %v )`, name, columnsWithDataTypes(columns, ""))
 
-	as.logger.Infof("AZ: Creating table in synapse for AZ:%s : %v", as.Warehouse.Destination.ID, sqlStatement)
-	_, err = as.DB.ExecContext(ctx, sqlStatement)
+	as.logger.Infof("AZ: Creating table in synapse for AZ:%s : %v", as.warehouse.Destination.ID, sqlStatement)
+	_, err = as.db.ExecContext(ctx, sqlStatement)
 	return
 }
 
 func (as *AzureSynapse) CreateTable(ctx context.Context, tableName string, columnMap model.TableSchema) (err error) {
 	// Search paths doesn't exist unlike Postgres, default is dbo. Hence, use namespace wherever possible
-	err = as.createTable(ctx, as.Namespace+"."+tableName, columnMap)
+	err = as.createTable(ctx, as.namespace+"."+tableName, columnMap)
 	return err
 }
 
 func (as *AzureSynapse) DropTable(ctx context.Context, tableName string) (err error) {
 	sqlStatement := `DROP TABLE "%[1]s"."%[2]s"`
-	as.logger.Infof("AZ: Dropping table in synapse for AZ:%s : %v", as.Warehouse.Destination.ID, sqlStatement)
-	_, err = as.DB.ExecContext(ctx, fmt.Sprintf(sqlStatement, as.Namespace, tableName))
+	as.logger.Infof("AZ: Dropping table in synapse for AZ:%s : %v", as.warehouse.Destination.ID, sqlStatement)
+	_, err = as.db.ExecContext(ctx, fmt.Sprintf(sqlStatement, as.namespace, tableName))
 	return
 }
 
@@ -766,7 +766,7 @@ func (as *AzureSynapse) AddColumns(ctx context.Context, tableName string, column
 				OBJECT_ID = OBJECT_ID(N'%[1]s.%[2]s')
 				AND name = '%[3]s'
 			)`,
-			as.Namespace,
+			as.namespace,
 			tableName,
 			columnsInfo[0].Name,
 		))
@@ -776,7 +776,7 @@ func (as *AzureSynapse) AddColumns(ctx context.Context, tableName string, column
 		ALTER TABLE
 		  %s.%s
 		ADD`,
-		as.Namespace,
+		as.namespace,
 		tableName,
 	))
 
@@ -787,8 +787,8 @@ func (as *AzureSynapse) AddColumns(ctx context.Context, tableName string, column
 	query = strings.TrimSuffix(queryBuilder.String(), ",")
 	query += ";"
 
-	as.logger.Infof("AZ: Adding columns for destinationID: %s, tableName: %s with query: %v", as.Warehouse.Destination.ID, tableName, query)
-	_, err = as.DB.ExecContext(ctx, query)
+	as.logger.Infof("AZ: Adding columns for destinationID: %s, tableName: %s with query: %v", as.warehouse.Destination.ID, tableName, query)
+	_, err = as.db.ExecContext(ctx, query)
 	return
 }
 
@@ -797,7 +797,7 @@ func (*AzureSynapse) AlterColumn(_ context.Context, _, _, _ string) (model.Alter
 }
 
 func (as *AzureSynapse) TestConnection(ctx context.Context, _ model.Warehouse) error {
-	err := as.DB.PingContext(ctx)
+	err := as.db.PingContext(ctx)
 	if errors.Is(err, context.DeadlineExceeded) {
 		return fmt.Errorf("connection timeout: %w", err)
 	}
@@ -809,13 +809,13 @@ func (as *AzureSynapse) TestConnection(ctx context.Context, _ model.Warehouse) e
 }
 
 func (as *AzureSynapse) Setup(_ context.Context, warehouse model.Warehouse, uploader warehouseutils.Uploader) (err error) {
-	as.Warehouse = warehouse
-	as.Namespace = warehouse.Namespace
-	as.Uploader = uploader
-	as.ObjectStorage = warehouseutils.ObjectStorageType(warehouseutils.AzureSynapse, warehouse.Destination.Config, as.Uploader.UseRudderStorage())
-	as.LoadFileDownLoader = downloader.NewDownloader(&warehouse, uploader, as.config.numWorkersDownloadLoadFiles)
+	as.warehouse = warehouse
+	as.namespace = warehouse.Namespace
+	as.uploader = uploader
+	as.objectStorage = warehouseutils.ObjectStorageType(warehouseutils.AzureSynapse, warehouse.Destination.Config, as.uploader.UseRudderStorage())
+	as.loadFileDownLoader = downloader.NewDownloader(&warehouse, uploader, as.config.numWorkersDownloadLoadFiles)
 
-	if as.DB, err = as.connect(); err != nil {
+	if as.db, err = as.connect(); err != nil {
 		return fmt.Errorf("connecting to azure synapse: %w", err)
 	}
 	return err
@@ -831,10 +831,10 @@ func (as *AzureSynapse) dropDanglingStagingTables(ctx context.Context) error {
 		  table_schema = '%s'
 		  AND table_name like '%s';
 	`,
-		as.Namespace,
+		as.namespace,
 		fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider)),
 	)
-	rows, err := as.DB.QueryContext(ctx, sqlStatement)
+	rows, err := as.db.QueryContext(ctx, sqlStatement)
 	if err != nil {
 		return fmt.Errorf("querying for dangling staging tables: %w", err)
 	}
@@ -854,9 +854,9 @@ func (as *AzureSynapse) dropDanglingStagingTables(ctx context.Context) error {
 	}
 	as.logger.Infof("WH: SYNAPSE: Dropping dangling staging tables: %+v  %+v\n", len(stagingTableNames), stagingTableNames)
 	for _, stagingTableName := range stagingTableNames {
-		_, err := as.DB.ExecContext(ctx, fmt.Sprintf(`DROP TABLE "%[1]s"."%[2]s"`, as.Namespace, stagingTableName))
+		_, err := as.db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE "%[1]s"."%[2]s"`, as.namespace, stagingTableName))
 		if err != nil {
-			return fmt.Errorf("dropping dangling staging table %q.%q: %w", as.Namespace, stagingTableName, err)
+			return fmt.Errorf("dropping dangling staging table %q.%q: %w", as.namespace, stagingTableName, err)
 		}
 	}
 	return nil
@@ -877,10 +877,10 @@ func (as *AzureSynapse) FetchSchema(ctx context.Context) (model.Schema, error) {
 			table_schema = @schema
 			and table_name not like @prefix
 `
-	rows, err := as.DB.QueryContext(
+	rows, err := as.db.QueryContext(
 		ctx,
 		sqlStatement,
-		sql.Named("schema", as.Namespace),
+		sql.Named("schema", as.namespace),
 		sql.Named("prefix", fmt.Sprintf("%s%%", warehouseutils.StagingTablePrefix(provider))),
 	)
 	if errors.Is(err, io.EOF) {
@@ -904,7 +904,7 @@ func (as *AzureSynapse) FetchSchema(ctx context.Context) (model.Schema, error) {
 		if datatype, ok := azureSynapseDataTypesMapToRudder[columnType]; ok {
 			schema[tableName][columnName] = datatype
 		} else {
-			warehouseutils.WHCounterStat(as.stats, warehouseutils.RudderMissingDatatype, &as.Warehouse, warehouseutils.Tag{Name: "datatype", Value: columnType}).Count(1)
+			warehouseutils.WHCounterStat(as.stats, warehouseutils.RudderMissingDatatype, &as.warehouse, warehouseutils.Tag{Name: "datatype", Value: columnType}).Count(1)
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -922,31 +922,31 @@ func (as *AzureSynapse) LoadTable(ctx context.Context, tableName string) (*types
 	loadTableStat, _, err := as.loadTable(
 		ctx,
 		tableName,
-		as.Uploader.GetTableSchemaInUpload(tableName),
+		as.uploader.GetTableSchemaInUpload(tableName),
 		false,
 	)
 	return loadTableStat, err
 }
 
 func (as *AzureSynapse) Cleanup(ctx context.Context) {
-	if as.DB != nil {
+	if as.db != nil {
 		// extra check aside dropStagingTable(table)
 		err := as.dropDanglingStagingTables(ctx)
 		if err != nil {
 			as.logger.Warnw("Error dropping dangling staging tables",
-				logfield.DestinationID, as.Warehouse.Destination.ID,
-				logfield.DestinationType, as.Warehouse.Destination.DestinationDefinition.Name,
-				logfield.SourceID, as.Warehouse.Source.ID,
-				logfield.SourceType, as.Warehouse.Source.SourceDefinition.Name,
-				logfield.DestinationID, as.Warehouse.Destination.ID,
-				logfield.DestinationType, as.Warehouse.Destination.DestinationDefinition.Name,
-				logfield.WorkspaceID, as.Warehouse.WorkspaceID,
-				logfield.Namespace, as.Warehouse.Namespace,
+				logfield.DestinationID, as.warehouse.Destination.ID,
+				logfield.DestinationType, as.warehouse.Destination.DestinationDefinition.Name,
+				logfield.SourceID, as.warehouse.Source.ID,
+				logfield.SourceType, as.warehouse.Source.SourceDefinition.Name,
+				logfield.DestinationID, as.warehouse.Destination.ID,
+				logfield.DestinationType, as.warehouse.Destination.DestinationDefinition.Name,
+				logfield.WorkspaceID, as.warehouse.WorkspaceID,
+				logfield.Namespace, as.warehouse.Namespace,
 
 				logfield.Error, err,
 			)
 		}
-		_ = as.DB.Close()
+		_ = as.db.Close()
 	}
 }
 
@@ -963,8 +963,8 @@ func (*AzureSynapse) DownloadIdentityRules(context.Context, *misc.GZipWriter) (e
 }
 
 func (as *AzureSynapse) Connect(_ context.Context, warehouse model.Warehouse) (client.Client, error) {
-	as.Warehouse = warehouse
-	as.Namespace = warehouse.Namespace
+	as.warehouse = warehouse
+	as.namespace = warehouse.Namespace
 
 	db, err := as.connect()
 	if err != nil {
@@ -976,12 +976,12 @@ func (as *AzureSynapse) Connect(_ context.Context, warehouse model.Warehouse) (c
 
 func (as *AzureSynapse) LoadTestTable(ctx context.Context, _, tableName string, payloadMap map[string]interface{}, _ string) (err error) {
 	sqlStatement := fmt.Sprintf(`INSERT INTO %q.%q (%v) VALUES (%s)`,
-		as.Namespace,
+		as.namespace,
 		tableName,
 		fmt.Sprintf(`%q, %q`, "id", "val"),
 		fmt.Sprintf(`'%d', '%s'`, payloadMap["id"], payloadMap["val"]),
 	)
-	_, err = as.DB.ExecContext(ctx, sqlStatement)
+	_, err = as.db.ExecContext(ctx, sqlStatement)
 	return
 }
 

--- a/warehouse/integrations/azure-synapse/azure_synapse_test.go
+++ b/warehouse/integrations/azure-synapse/azure_synapse_test.go
@@ -39,7 +39,6 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
-	t.Skip("skipping for 1.34.1 release")
 	if os.Getenv("SLOW") != "1" {
 		t.Skip("Skipping tests. Add 'SLOW=1' env var to run test.")
 	}
@@ -172,15 +171,9 @@ func TestIntegration(t *testing.T) {
 
 				whth.BootstrapSvc(t, workspaceConfig, httpPort, jobsDBPort)
 
-				dsn := fmt.Sprintf("sqlserver://%s:%s@%s:%d?TrustServerCertificate=true&database=%s&encrypt=disable",
+				db := pingAzureSynapse(t, context.Background(), fmt.Sprintf("sqlserver://%s:%s@%s:%d?TrustServerCertificate=true&database=%s&encrypt=disable",
 					user, password, host, azureSynapsePort, database,
-				)
-				db, err := sql.Open("sqlserver", dsn)
-				require.NoError(t, err)
-				require.NoError(t, db.Ping())
-				t.Cleanup(func() {
-					_ = db.Close()
-				})
+				))
 
 				sqlClient := &client.Client{
 					SQL:  db,
@@ -252,6 +245,10 @@ func TestIntegration(t *testing.T) {
 
 		azureSynapsePort := c.Port("azure_synapse", 1433)
 		minioEndpoint := fmt.Sprintf("localhost:%d", c.Port("minio", 9000))
+
+		_ = pingAzureSynapse(t, context.Background(), fmt.Sprintf("sqlserver://%s:%s@%s:%d?TrustServerCertificate=true&database=%s&encrypt=disable",
+			user, password, host, azureSynapsePort, database,
+		))
 
 		namespace := whth.RandSchema(destType)
 
@@ -369,6 +366,10 @@ func TestIntegration(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		db := pingAzureSynapse(t, ctx, fmt.Sprintf("sqlserver://%s:%s@%s:%d?TrustServerCertificate=true&database=%s&encrypt=disable",
+			user, password, host, azureSynapsePort, database,
+		))
+
 		t.Run("schema does not exists", func(t *testing.T) {
 			tableName := "schema_not_exists_test_table"
 
@@ -433,7 +434,7 @@ func TestIntegration(t *testing.T) {
 				require.Equal(t, loadTableStat.RowsInserted, int64(0))
 				require.Equal(t, loadTableStat.RowsUpdated, int64(14))
 
-				records := whth.RetrieveRecordsFromWarehouse(t, az.DB.DB,
+				records := whth.RetrieveRecordsFromWarehouse(t, db,
 					fmt.Sprintf(`
 						SELECT
 						  id,
@@ -475,7 +476,7 @@ func TestIntegration(t *testing.T) {
 				require.Equal(t, loadTableStat.RowsInserted, int64(0))
 				require.Equal(t, loadTableStat.RowsUpdated, int64(14))
 
-				records := whth.RetrieveRecordsFromWarehouse(t, az.DB.DB,
+				records := whth.RetrieveRecordsFromWarehouse(t, db,
 					fmt.Sprintf(`
 						SELECT
 						  id,
@@ -564,7 +565,7 @@ func TestIntegration(t *testing.T) {
 			require.Equal(t, loadTableStat.RowsInserted, int64(14))
 			require.Equal(t, loadTableStat.RowsUpdated, int64(0))
 
-			records := whth.RetrieveRecordsFromWarehouse(t, az.DB.DB,
+			records := whth.RetrieveRecordsFromWarehouse(t, db,
 				fmt.Sprintf(`
 					SELECT
 					  id,
@@ -608,7 +609,7 @@ func TestIntegration(t *testing.T) {
 			require.Equal(t, loadTableStat.RowsInserted, int64(6))
 			require.Equal(t, loadTableStat.RowsUpdated, int64(0))
 
-			records := whth.RetrieveRecordsFromWarehouse(t, az.DB.DB,
+			records := whth.RetrieveRecordsFromWarehouse(t, db,
 				fmt.Sprintf(`
 					SELECT
 					  column_name,
@@ -739,4 +740,25 @@ func newMockUploader(
 	mockUploader.EXPECT().GetTableSchemaInWarehouse(tableName).Return(schemaInWarehouse).AnyTimes()
 
 	return mockUploader
+}
+
+func pingAzureSynapse(t testing.TB, ctx context.Context, dsn string) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlserver", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	require.Eventually(t, func() bool {
+		if err := db.PingContext(ctx); err != nil {
+			t.Log("Ping failed:", err)
+			return false
+		}
+		return true
+	}, time.Minute, time.Second)
+
+	return db
 }

--- a/warehouse/integrations/azure-synapse/azure_synapse_test.go
+++ b/warehouse/integrations/azure-synapse/azure_synapse_test.go
@@ -749,7 +749,7 @@ func pingAzureSynapse(t testing.TB, ctx context.Context, dsn string) *sql.DB {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	require.Eventually(t, func() bool {

--- a/warehouse/integrations/azure-synapse/testdata/docker-compose.yml
+++ b/warehouse/integrations/azure-synapse/testdata/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   azure_synapse:
-    image: rudderstack/azure-sql-edge:1.0.6
+    image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=reallyStrongPwd123

--- a/warehouse/integrations/mssql/mssql.go
+++ b/warehouse/integrations/mssql/mssql.go
@@ -82,13 +82,13 @@ var mssqlDataTypesMapToRudder = map[string]string{
 }
 
 type MSSQL struct {
-	DB                 *sqlmw.DB
-	Namespace          string
-	ObjectStorage      string
-	Warehouse          model.Warehouse
-	Uploader           warehouseutils.Uploader
+	db                 *sqlmw.DB
+	namespace          string
+	objectStorage      string
+	warehouse          model.Warehouse
+	uploader           warehouseutils.Uploader
 	connectTimeout     time.Duration
-	LoadFileDownLoader downloader.Downloader
+	loadFileDownLoader downloader.Downloader
 
 	conf   *config.Config
 	stats  stats.Stats
@@ -181,12 +181,12 @@ func (ms *MSSQL) connect() (*sqlmw.DB, error) {
 		sqlmw.WithStats(ms.stats),
 		sqlmw.WithLogger(ms.logger),
 		sqlmw.WithKeyAndValues([]any{
-			logfield.SourceID, ms.Warehouse.Source.ID,
-			logfield.SourceType, ms.Warehouse.Source.SourceDefinition.Name,
-			logfield.DestinationID, ms.Warehouse.Destination.ID,
-			logfield.DestinationType, ms.Warehouse.Destination.DestinationDefinition.Name,
-			logfield.WorkspaceID, ms.Warehouse.WorkspaceID,
-			logfield.Namespace, ms.Namespace,
+			logfield.SourceID, ms.warehouse.Source.ID,
+			logfield.SourceType, ms.warehouse.Source.SourceDefinition.Name,
+			logfield.DestinationID, ms.warehouse.Destination.ID,
+			logfield.DestinationType, ms.warehouse.Destination.DestinationDefinition.Name,
+			logfield.WorkspaceID, ms.warehouse.WorkspaceID,
+			logfield.Namespace, ms.namespace,
 		}),
 		sqlmw.WithQueryTimeout(ms.connectTimeout),
 		sqlmw.WithSlowQueryThreshold(ms.config.slowQueryThreshold),
@@ -196,12 +196,12 @@ func (ms *MSSQL) connect() (*sqlmw.DB, error) {
 
 func (ms *MSSQL) connectionCredentials() *credentials {
 	return &credentials{
-		host:     ms.Warehouse.GetStringDestinationConfig(ms.conf, model.HostSetting),
-		database: ms.Warehouse.GetStringDestinationConfig(ms.conf, model.DatabaseSetting),
-		user:     ms.Warehouse.GetStringDestinationConfig(ms.conf, model.UserSetting),
-		password: ms.Warehouse.GetStringDestinationConfig(ms.conf, model.PasswordSetting),
-		port:     ms.Warehouse.GetStringDestinationConfig(ms.conf, model.PortSetting),
-		sslMode:  ms.Warehouse.GetStringDestinationConfig(ms.conf, model.SSLModeSetting),
+		host:     ms.warehouse.GetStringDestinationConfig(ms.conf, model.HostSetting),
+		database: ms.warehouse.GetStringDestinationConfig(ms.conf, model.DatabaseSetting),
+		user:     ms.warehouse.GetStringDestinationConfig(ms.conf, model.UserSetting),
+		password: ms.warehouse.GetStringDestinationConfig(ms.conf, model.PasswordSetting),
+		port:     ms.warehouse.GetStringDestinationConfig(ms.conf, model.PortSetting),
+		sslMode:  ms.warehouse.GetStringDestinationConfig(ms.conf, model.SSLModeSetting),
 		timeout:  ms.connectTimeout,
 	}
 }
@@ -225,15 +225,15 @@ func (ms *MSSQL) DeleteBy(ctx context.Context, tableNames []string, params wareh
 		context_sources_task_run_id <> @taskrunid AND
 		context_source_id = @sourceid AND
 		received_at < @starttime`,
-			ms.Namespace,
+			ms.namespace,
 			tb,
 		)
 
-		ms.logger.Debugf("MSSQL: Deleting rows in table in mysql for MSSQL:%s ", ms.Warehouse.Destination.ID)
+		ms.logger.Debugf("MSSQL: Deleting rows in table in mysql for MSSQL:%s ", ms.warehouse.Destination.ID)
 		ms.logger.Infof("MSSQL: Executing the statement %v", sqlStatement)
 
 		if ms.config.enableDeleteByJobs {
-			_, err = ms.DB.ExecContext(ctx, sqlStatement,
+			_, err = ms.db.ExecContext(ctx, sqlStatement,
 				sql.Named("jobrunid", params.JobRunId),
 				sql.Named("taskrunid", params.TaskRunId),
 				sql.Named("sourceid", params.SourceId),
@@ -256,17 +256,17 @@ func (ms *MSSQL) loadTable(
 	skipTempTableDelete bool,
 ) (*types.LoadTableStats, string, error) {
 	log := ms.logger.With(
-		logfield.SourceID, ms.Warehouse.Source.ID,
-		logfield.SourceType, ms.Warehouse.Source.SourceDefinition.Name,
-		logfield.DestinationID, ms.Warehouse.Destination.ID,
-		logfield.DestinationType, ms.Warehouse.Destination.DestinationDefinition.Name,
-		logfield.WorkspaceID, ms.Warehouse.WorkspaceID,
-		logfield.Namespace, ms.Namespace,
+		logfield.SourceID, ms.warehouse.Source.ID,
+		logfield.SourceType, ms.warehouse.Source.SourceDefinition.Name,
+		logfield.DestinationID, ms.warehouse.Destination.ID,
+		logfield.DestinationType, ms.warehouse.Destination.DestinationDefinition.Name,
+		logfield.WorkspaceID, ms.warehouse.WorkspaceID,
+		logfield.Namespace, ms.namespace,
 		logfield.TableName, tableName,
 	)
 	log.Infow("started loading")
 
-	fileNames, err := ms.LoadFileDownLoader.Download(ctx, tableName)
+	fileNames, err := ms.loadFileDownLoader.Download(ctx, tableName)
 	if err != nil {
 		return nil, "", fmt.Errorf("downloading load files: %w", err)
 	}
@@ -294,11 +294,11 @@ func (ms *MSSQL) loadTable(
 		  TOP 0 * INTO %[1]s.%[2]s
 		FROM
 		  %[1]s.%[3]s;`,
-		ms.Namespace,
+		ms.namespace,
 		stagingTableName,
 		tableName,
 	)
-	if _, err = ms.DB.ExecContext(ctx, createStagingTableStmt); err != nil {
+	if _, err = ms.db.ExecContext(ctx, createStagingTableStmt); err != nil {
 		return nil, "", fmt.Errorf("creating temporary table: %w", err)
 	}
 
@@ -308,7 +308,7 @@ func (ms *MSSQL) loadTable(
 		}()
 	}
 
-	txn, err := ms.DB.BeginTx(ctx, &sql.TxOptions{})
+	txn, err := ms.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
 		return nil, "", fmt.Errorf("begin transaction: %w", err)
 	}
@@ -323,7 +323,7 @@ func (ms *MSSQL) loadTable(
 	)
 
 	log.Debugw("creating prepared stmt for loading data")
-	copyInStmt := mssql.CopyIn(ms.Namespace+"."+stagingTableName, mssql.BulkOptions{CheckConstraints: false},
+	copyInStmt := mssql.CopyIn(ms.namespace+"."+stagingTableName, mssql.BulkOptions{CheckConstraints: false},
 		sortedColumnKeys...,
 	)
 	stmt, err := txn.PrepareContext(ctx, copyInStmt)
@@ -510,7 +510,7 @@ func (ms *MSSQL) deleteFromLoadTable(
 	var additionalDeleteStmtClause string
 	if tableName == warehouseutils.DiscardsTable {
 		additionalDeleteStmtClause = fmt.Sprintf(`AND _source.%[3]s = %[1]q.%[2]q.%[3]q AND _source.%[4]s = %[1]q.%[2]q.%[4]q`,
-			ms.Namespace,
+			ms.namespace,
 			tableName,
 			"table_name",
 			"column_name",
@@ -526,7 +526,7 @@ func (ms *MSSQL) deleteFromLoadTable(
 		  (
 			_source.%[4]s = %[1]q.%[2]q.%[4]q %[5]s
 		  );`,
-		ms.Namespace,
+		ms.namespace,
 		tableName,
 		stagingTableName,
 		primaryKey,
@@ -574,7 +574,7 @@ func (ms *MSSQL) insertIntoLoadTable(
 		  ) AS _
 		WHERE
 		  _rudder_staging_row_number = 1;`,
-		ms.Namespace,
+		ms.namespace,
 		tableName,
 		quotedColumnNames,
 		stagingTableName,
@@ -611,13 +611,13 @@ func hasDiacritics(str string) bool {
 func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error) {
 	errorMap = map[string]error{warehouseutils.IdentifiesTable: nil}
 	ms.logger.Infof("MSSQL: Starting load for identifies and users tables\n")
-	_, identifyStagingTable, err := ms.loadTable(ctx, warehouseutils.IdentifiesTable, ms.Uploader.GetTableSchemaInUpload(warehouseutils.IdentifiesTable), true)
+	_, identifyStagingTable, err := ms.loadTable(ctx, warehouseutils.IdentifiesTable, ms.uploader.GetTableSchemaInUpload(warehouseutils.IdentifiesTable), true)
 	if err != nil {
 		errorMap[warehouseutils.IdentifiesTable] = err
 		return
 	}
 
-	if len(ms.Uploader.GetTableSchemaInUpload(warehouseutils.UsersTable)) == 0 {
+	if len(ms.uploader.GetTableSchemaInUpload(warehouseutils.UsersTable)) == 0 {
 		return
 	}
 	errorMap[warehouseutils.UsersTable] = nil
@@ -628,7 +628,7 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 	defer ms.dropStagingTable(ctx, unionStagingTableName)
 	defer ms.dropStagingTable(ctx, identifyStagingTable)
 
-	userColMap := ms.Uploader.GetTableSchemaInWarehouse(warehouseutils.UsersTable)
+	userColMap := ms.uploader.GetTableSchemaInWarehouse(warehouseutils.UsersTable)
 	var userColNames, firstValProps []string
 	for colName := range userColMap {
 		if colName == "id" {
@@ -643,7 +643,7 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 							  order by received_at desc
 						  	OFFSET 0 ROWS
 							FETCH NEXT 1 ROWS ONLY)
-						  end as "%[1]s"`, colName, ms.Namespace+"."+unionStagingTableName)
+						  end as "%[1]s"`, colName, ms.namespace+"."+unionStagingTableName)
 
 		// IGNORE NULLS only supported in Azure SQL edge, in which case the query can be shortened to below
 		// https://docs.microsoft.com/en-us/sql/t-sql/functions/first-value-transact-sql?view=sql-server-ver15
@@ -659,10 +659,10 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 												(
 													SELECT user_id, %[4]s FROM %[3]s  WHERE user_id IS NOT NULL
 												)) a
-											`, ms.Namespace, ms.Namespace+"."+warehouseutils.UsersTable, ms.Namespace+"."+identifyStagingTable, strings.Join(userColNames, ","), ms.Namespace+"."+unionStagingTableName)
+											`, ms.namespace, ms.namespace+"."+warehouseutils.UsersTable, ms.namespace+"."+identifyStagingTable, strings.Join(userColNames, ","), ms.namespace+"."+unionStagingTableName)
 
 	ms.logger.Debugf("MSSQL: Creating staging table for union of users table with identify staging table: %s\n", sqlStatement)
-	_, err = ms.DB.ExecContext(ctx, sqlStatement)
+	_, err = ms.db.ExecContext(ctx, sqlStatement)
 	if err != nil {
 		errorMap[warehouseutils.UsersTable] = err
 		return
@@ -675,13 +675,13 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 											FROM %[3]s as x
 										) as xyz
 									) a`,
-		ms.Namespace+"."+stagingTableName,
+		ms.namespace+"."+stagingTableName,
 		strings.Join(firstValProps, ","),
-		ms.Namespace+"."+unionStagingTableName,
+		ms.namespace+"."+unionStagingTableName,
 	)
 
 	ms.logger.Debugf("MSSQL: Creating staging table for users: %s\n", sqlStatement)
-	_, err = ms.DB.ExecContext(ctx, sqlStatement)
+	_, err = ms.db.ExecContext(ctx, sqlStatement)
 	if err != nil {
 		ms.logger.Errorf("MSSQL: Error Creating staging table for users: %s\n", sqlStatement)
 		errorMap[warehouseutils.UsersTable] = err
@@ -689,14 +689,14 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 	}
 
 	// BEGIN TRANSACTION
-	tx, err := ms.DB.BeginTx(ctx, &sql.TxOptions{})
+	tx, err := ms.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
 		errorMap[warehouseutils.UsersTable] = err
 		return
 	}
 
 	primaryKey := "id"
-	sqlStatement = fmt.Sprintf(`DELETE FROM %[1]s."%[2]s" FROM %[3]s _source where (_source.%[4]s = %[1]s.%[2]s.%[4]s)`, ms.Namespace, warehouseutils.UsersTable, ms.Namespace+"."+stagingTableName, primaryKey)
+	sqlStatement = fmt.Sprintf(`DELETE FROM %[1]s."%[2]s" FROM %[3]s _source where (_source.%[4]s = %[1]s.%[2]s.%[4]s)`, ms.namespace, warehouseutils.UsersTable, ms.namespace+"."+stagingTableName, primaryKey)
 	ms.logger.Infof("MSSQL: Dedup records for table:%s using staging table: %s\n", warehouseutils.UsersTable, sqlStatement)
 	_, err = tx.ExecContext(ctx, sqlStatement)
 	if err != nil {
@@ -706,7 +706,7 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 		return
 	}
 
-	sqlStatement = fmt.Sprintf(`INSERT INTO "%[1]s"."%[2]s" (%[4]s) SELECT %[4]s FROM  %[3]s`, ms.Namespace, warehouseutils.UsersTable, ms.Namespace+"."+stagingTableName, strings.Join(append([]string{"id"}, userColNames...), ","))
+	sqlStatement = fmt.Sprintf(`INSERT INTO "%[1]s"."%[2]s" (%[4]s) SELECT %[4]s FROM  %[3]s`, ms.namespace, warehouseutils.UsersTable, ms.namespace+"."+stagingTableName, strings.Join(append([]string{"id"}, userColNames...), ","))
 	ms.logger.Infof("MSSQL: Inserting records for table:%s using staging table: %s\n", warehouseutils.UsersTable, sqlStatement)
 	_, err = tx.ExecContext(ctx, sqlStatement)
 	if err != nil {
@@ -728,9 +728,9 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 
 func (ms *MSSQL) CreateSchema(ctx context.Context) (err error) {
 	sqlStatement := fmt.Sprintf(`IF NOT EXISTS ( SELECT  * FROM  sys.schemas WHERE   name = N'%s' )
-    EXEC('CREATE SCHEMA [%s]');`, ms.Namespace, ms.Namespace)
-	ms.logger.Infof("MSSQL: Creating schema name in mssql for MSSQL:%s : %v", ms.Warehouse.Destination.ID, sqlStatement)
-	_, err = ms.DB.ExecContext(ctx, sqlStatement)
+    EXEC('CREATE SCHEMA [%s]');`, ms.namespace, ms.namespace)
+	ms.logger.Infof("MSSQL: Creating schema name in mssql for MSSQL:%s : %v", ms.warehouse.Destination.ID, sqlStatement)
+	_, err = ms.db.ExecContext(ctx, sqlStatement)
 	if errors.Is(err, io.EOF) {
 		return nil
 	}
@@ -739,9 +739,9 @@ func (ms *MSSQL) CreateSchema(ctx context.Context) (err error) {
 
 func (ms *MSSQL) dropStagingTable(ctx context.Context, stagingTableName string) {
 	ms.logger.Infof("MSSQL: dropping table %+v\n", stagingTableName)
-	_, err := ms.DB.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, ms.Namespace+"."+stagingTableName))
+	_, err := ms.db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, ms.namespace+"."+stagingTableName))
 	if err != nil {
-		ms.logger.Errorf("MSSQL:  Error dropping staging table %s in mssql: %v", ms.Namespace+"."+stagingTableName, err)
+		ms.logger.Errorf("MSSQL:  Error dropping staging table %s in mssql: %v", ms.namespace+"."+stagingTableName, err)
 	}
 }
 
@@ -749,21 +749,21 @@ func (ms *MSSQL) createTable(ctx context.Context, name string, columns model.Tab
 	sqlStatement := fmt.Sprintf(`IF  NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'%[1]s') AND type = N'U')
 	CREATE TABLE %[1]s ( %v )`, name, ColumnsWithDataTypes(columns, ""))
 
-	ms.logger.Infof("MSSQL: Creating table in mssql for MSSQL:%s : %v", ms.Warehouse.Destination.ID, sqlStatement)
-	_, err = ms.DB.ExecContext(ctx, sqlStatement)
+	ms.logger.Infof("MSSQL: Creating table in mssql for MSSQL:%s : %v", ms.warehouse.Destination.ID, sqlStatement)
+	_, err = ms.db.ExecContext(ctx, sqlStatement)
 	return
 }
 
 func (ms *MSSQL) CreateTable(ctx context.Context, tableName string, columnMap model.TableSchema) (err error) {
 	// Search paths doesn't exist unlike Postgres, default is dbo. Hence, use namespace wherever possible
-	err = ms.createTable(ctx, ms.Namespace+"."+tableName, columnMap)
+	err = ms.createTable(ctx, ms.namespace+"."+tableName, columnMap)
 	return err
 }
 
 func (ms *MSSQL) DropTable(ctx context.Context, tableName string) (err error) {
 	sqlStatement := `DROP TABLE "%[1]s"."%[2]s"`
-	ms.logger.Infof("AZ: Dropping table in synapse for AZ:%s : %v", ms.Warehouse.Destination.ID, sqlStatement)
-	_, err = ms.DB.ExecContext(ctx, fmt.Sprintf(sqlStatement, ms.Namespace, tableName))
+	ms.logger.Infof("AZ: Dropping table in synapse for AZ:%s : %v", ms.warehouse.Destination.ID, sqlStatement)
+	_, err = ms.db.ExecContext(ctx, fmt.Sprintf(sqlStatement, ms.namespace, tableName))
 	return
 }
 
@@ -784,7 +784,7 @@ func (ms *MSSQL) AddColumns(ctx context.Context, tableName string, columnsInfo [
 				OBJECT_ID = OBJECT_ID(N'%[1]s.%[2]s')
 				AND name = '%[3]s'
 			)`,
-			ms.Namespace,
+			ms.namespace,
 			tableName,
 			columnsInfo[0].Name,
 		))
@@ -794,7 +794,7 @@ func (ms *MSSQL) AddColumns(ctx context.Context, tableName string, columnsInfo [
 		ALTER TABLE
 		  %s.%s
 		ADD`,
-		ms.Namespace,
+		ms.namespace,
 		tableName,
 	))
 
@@ -805,8 +805,8 @@ func (ms *MSSQL) AddColumns(ctx context.Context, tableName string, columnsInfo [
 	query = strings.TrimSuffix(queryBuilder.String(), ",")
 	query += ";"
 
-	ms.logger.Infof("MSSQL: Adding columns for destinationID: %s, tableName: %s with query: %v", ms.Warehouse.Destination.ID, tableName, query)
-	_, err = ms.DB.ExecContext(ctx, query)
+	ms.logger.Infof("MSSQL: Adding columns for destinationID: %s, tableName: %s with query: %v", ms.warehouse.Destination.ID, tableName, query)
+	_, err = ms.db.ExecContext(ctx, query)
 	return
 }
 
@@ -815,7 +815,7 @@ func (*MSSQL) AlterColumn(context.Context, string, string, string) (model.AlterT
 }
 
 func (ms *MSSQL) TestConnection(ctx context.Context, _ model.Warehouse) error {
-	err := ms.DB.PingContext(ctx)
+	err := ms.db.PingContext(ctx)
 	if errors.Is(err, context.DeadlineExceeded) {
 		return fmt.Errorf("connection timeout: %w", err)
 	}
@@ -827,13 +827,13 @@ func (ms *MSSQL) TestConnection(ctx context.Context, _ model.Warehouse) error {
 }
 
 func (ms *MSSQL) Setup(_ context.Context, warehouse model.Warehouse, uploader warehouseutils.Uploader) (err error) {
-	ms.Warehouse = warehouse
-	ms.Namespace = warehouse.Namespace
-	ms.Uploader = uploader
-	ms.ObjectStorage = warehouseutils.ObjectStorageType(warehouseutils.MSSQL, warehouse.Destination.Config, ms.Uploader.UseRudderStorage())
-	ms.LoadFileDownLoader = downloader.NewDownloader(&warehouse, uploader, ms.config.numWorkersDownloadLoadFiles)
+	ms.warehouse = warehouse
+	ms.namespace = warehouse.Namespace
+	ms.uploader = uploader
+	ms.objectStorage = warehouseutils.ObjectStorageType(warehouseutils.MSSQL, warehouse.Destination.Config, ms.uploader.UseRudderStorage())
+	ms.loadFileDownLoader = downloader.NewDownloader(&warehouse, uploader, ms.config.numWorkersDownloadLoadFiles)
 
-	if ms.DB, err = ms.connect(); err != nil {
+	if ms.db, err = ms.connect(); err != nil {
 		return fmt.Errorf("connecting to mssql: %w", err)
 	}
 	return err
@@ -849,10 +849,10 @@ func (ms *MSSQL) dropDanglingStagingTables(ctx context.Context) error {
 		  table_schema = '%s'
 		  AND table_name like '%s';
 	`,
-		ms.Namespace,
+		ms.namespace,
 		fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider)),
 	)
-	rows, err := ms.DB.QueryContext(ctx, sqlStatement)
+	rows, err := ms.db.QueryContext(ctx, sqlStatement)
 	if err != nil {
 		return fmt.Errorf("querying for dangling staging tables: %w", err)
 	}
@@ -872,9 +872,9 @@ func (ms *MSSQL) dropDanglingStagingTables(ctx context.Context) error {
 	}
 	ms.logger.Infof("WH: MSSQL: Dropping dangling staging tables: %+v  %+v\n", len(stagingTableNames), stagingTableNames)
 	for _, stagingTableName := range stagingTableNames {
-		_, err := ms.DB.ExecContext(ctx, fmt.Sprintf(`DROP TABLE "%[1]s"."%[2]s"`, ms.Namespace, stagingTableName))
+		_, err := ms.db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE "%[1]s"."%[2]s"`, ms.namespace, stagingTableName))
 		if err != nil {
-			return fmt.Errorf("dropping dangling staging tables %q.%q : %w", ms.Namespace, stagingTableName, err)
+			return fmt.Errorf("dropping dangling staging tables %q.%q : %w", ms.namespace, stagingTableName, err)
 		}
 	}
 	return nil
@@ -894,8 +894,8 @@ func (ms *MSSQL) FetchSchema(ctx context.Context) (model.Schema, error) {
 		WHERE
 			table_schema = @schema
 			and table_name not like @prefix`
-	rows, err := ms.DB.QueryContext(ctx, sqlStatement,
-		sql.Named("schema", ms.Namespace),
+	rows, err := ms.db.QueryContext(ctx, sqlStatement,
+		sql.Named("schema", ms.namespace),
 		sql.Named("prefix", fmt.Sprintf("%s%%", warehouseutils.StagingTablePrefix(provider))),
 	)
 	if errors.Is(err, io.EOF) {
@@ -919,7 +919,7 @@ func (ms *MSSQL) FetchSchema(ctx context.Context) (model.Schema, error) {
 		if datatype, ok := mssqlDataTypesMapToRudder[columnType]; ok {
 			schema[tableName][columnName] = datatype
 		} else {
-			warehouseutils.WHCounterStat(ms.stats, warehouseutils.RudderMissingDatatype, &ms.Warehouse, warehouseutils.Tag{Name: "datatype", Value: columnType}).Count(1)
+			warehouseutils.WHCounterStat(ms.stats, warehouseutils.RudderMissingDatatype, &ms.warehouse, warehouseutils.Tag{Name: "datatype", Value: columnType}).Count(1)
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -937,32 +937,32 @@ func (ms *MSSQL) LoadTable(ctx context.Context, tableName string) (*types.LoadTa
 	loadTableStat, _, err := ms.loadTable(
 		ctx,
 		tableName,
-		ms.Uploader.GetTableSchemaInUpload(tableName),
+		ms.uploader.GetTableSchemaInUpload(tableName),
 		false,
 	)
 	return loadTableStat, err
 }
 
 func (ms *MSSQL) Cleanup(ctx context.Context) {
-	if ms.DB != nil {
+	if ms.db != nil {
 		// extra check aside dropStagingTable(table)
 		err := ms.dropDanglingStagingTables(ctx)
 		if err != nil {
 			ms.logger.Warnw("Error dropping dangling staging tables",
-				logfield.DestinationID, ms.Warehouse.Destination.ID,
-				logfield.DestinationType, ms.Warehouse.Destination.DestinationDefinition.Name,
-				logfield.SourceID, ms.Warehouse.Source.ID,
-				logfield.SourceType, ms.Warehouse.Source.SourceDefinition.Name,
-				logfield.DestinationID, ms.Warehouse.Destination.ID,
-				logfield.DestinationType, ms.Warehouse.Destination.DestinationDefinition.Name,
-				logfield.WorkspaceID, ms.Warehouse.WorkspaceID,
-				logfield.Namespace, ms.Warehouse.Namespace,
+				logfield.DestinationID, ms.warehouse.Destination.ID,
+				logfield.DestinationType, ms.warehouse.Destination.DestinationDefinition.Name,
+				logfield.SourceID, ms.warehouse.Source.ID,
+				logfield.SourceType, ms.warehouse.Source.SourceDefinition.Name,
+				logfield.DestinationID, ms.warehouse.Destination.ID,
+				logfield.DestinationType, ms.warehouse.Destination.DestinationDefinition.Name,
+				logfield.WorkspaceID, ms.warehouse.WorkspaceID,
+				logfield.Namespace, ms.warehouse.Namespace,
 
 				logfield.Error, err,
 			)
 		}
 
-		_ = ms.DB.Close()
+		_ = ms.db.Close()
 	}
 }
 
@@ -979,12 +979,12 @@ func (*MSSQL) DownloadIdentityRules(context.Context, *misc.GZipWriter) (err erro
 }
 
 func (ms *MSSQL) Connect(_ context.Context, warehouse model.Warehouse) (client.Client, error) {
-	ms.Warehouse = warehouse
-	ms.Namespace = warehouse.Namespace
-	ms.ObjectStorage = warehouseutils.ObjectStorageType(
+	ms.warehouse = warehouse
+	ms.namespace = warehouse.Namespace
+	ms.objectStorage = warehouseutils.ObjectStorageType(
 		warehouseutils.MSSQL,
 		warehouse.Destination.Config,
-		misc.IsConfiguredToUseRudderObjectStorage(ms.Warehouse.Destination.Config),
+		misc.IsConfiguredToUseRudderObjectStorage(ms.warehouse.Destination.Config),
 	)
 
 	db, err := ms.connect()
@@ -997,12 +997,12 @@ func (ms *MSSQL) Connect(_ context.Context, warehouse model.Warehouse) (client.C
 
 func (ms *MSSQL) LoadTestTable(ctx context.Context, _, tableName string, payloadMap map[string]interface{}, _ string) (err error) {
 	sqlStatement := fmt.Sprintf(`INSERT INTO %q.%q (%v) VALUES (%s)`,
-		ms.Namespace,
+		ms.namespace,
 		tableName,
 		fmt.Sprintf(`%q, %q`, "id", "val"),
 		fmt.Sprintf(`'%d', '%s'`, payloadMap["id"], payloadMap["val"]),
 	)
-	_, err = ms.DB.ExecContext(ctx, sqlStatement)
+	_, err = ms.db.ExecContext(ctx, sqlStatement)
 	return
 }
 

--- a/warehouse/integrations/mssql/mssql_test.go
+++ b/warehouse/integrations/mssql/mssql_test.go
@@ -787,7 +787,7 @@ func pingMSSQL(t testing.TB, ctx context.Context, dsn string) *sql.DB {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	require.Eventually(t, func() bool {

--- a/warehouse/integrations/mssql/mssql_test.go
+++ b/warehouse/integrations/mssql/mssql_test.go
@@ -40,7 +40,6 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
-	t.Skip("skipping for 1.34.1 release")
 	if os.Getenv("SLOW") != "1" {
 		t.Skip("Skipping tests. Add 'SLOW=1' env var to run test.")
 	}
@@ -405,6 +404,14 @@ func TestIntegration(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		dsn := fmt.Sprintf("sqlserver://%s:%s@%s:%d?TrustServerCertificate=true&database=%s&encrypt=disable",
+			user, password, host, mssqlPort, database,
+		)
+		db, err := sql.Open("sqlserver", dsn)
+		require.NoError(t, err)
+		require.NoError(t, db.Ping())
+		t.Cleanup(func() { _ = db.Close() })
+
 		t.Run("schema does not exists", func(t *testing.T) {
 			tableName := "schema_not_exists_test_table"
 
@@ -469,7 +476,7 @@ func TestIntegration(t *testing.T) {
 				require.Equal(t, loadTableStat.RowsInserted, int64(0))
 				require.Equal(t, loadTableStat.RowsUpdated, int64(14))
 
-				records := whth.RetrieveRecordsFromWarehouse(t, ms.DB.DB,
+				records := whth.RetrieveRecordsFromWarehouse(t, db,
 					fmt.Sprintf(`
 						SELECT
 						  id,
@@ -511,7 +518,7 @@ func TestIntegration(t *testing.T) {
 				require.Equal(t, loadTableStat.RowsInserted, int64(0))
 				require.Equal(t, loadTableStat.RowsUpdated, int64(14))
 
-				records := whth.RetrieveRecordsFromWarehouse(t, ms.DB.DB,
+				records := whth.RetrieveRecordsFromWarehouse(t, db,
 					fmt.Sprintf(`
 						SELECT
 						  id,
@@ -600,7 +607,7 @@ func TestIntegration(t *testing.T) {
 			require.Equal(t, loadTableStat.RowsInserted, int64(14))
 			require.Equal(t, loadTableStat.RowsUpdated, int64(0))
 
-			records := whth.RetrieveRecordsFromWarehouse(t, ms.DB.DB,
+			records := whth.RetrieveRecordsFromWarehouse(t, db,
 				fmt.Sprintf(`
 					SELECT
 					  id,
@@ -644,7 +651,7 @@ func TestIntegration(t *testing.T) {
 			require.Equal(t, loadTableStat.RowsInserted, int64(6))
 			require.Equal(t, loadTableStat.RowsUpdated, int64(0))
 
-			records := whth.RetrieveRecordsFromWarehouse(t, ms.DB.DB,
+			records := whth.RetrieveRecordsFromWarehouse(t, db,
 				fmt.Sprintf(`
 					SELECT
 					  column_name,

--- a/warehouse/integrations/mssql/testdata/docker-compose.yml
+++ b/warehouse/integrations/mssql/testdata/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mssql:
-    image: rudderstack/azure-sql-edge:1.0.6
+    image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=reallyStrongPwd123


### PR DESCRIPTION
# Description

- Enable integration tests for **MSSQL** and **Azure Synapse**. This was [disabled](https://github.com/rudderlabs/rudder-server/pull/5123/commits/5a310c62f714ceb07211bbcf814da4851e153ca9) a couple of months back because we had an issue with the existing [microsoft/azure-sql-edge](https://hub.docker.com/r/microsoft/azure-sql-edge) image. Also, Microsoft is planning to [retire](https://learn.microsoft.com/en-us/lifecycle/products/azure-sql-edge) this image around Sep 30, 2025.
  - Using [mcr.microsoft.com/mssql/server:2022-latest](https://hub.docker.com/r/microsoft/mssql-server) instead.
- A small clean up around making fields unexported for `AzureSynapse` and `MSSQL` struct.

## Linear Ticket

- Resolves WAR-365

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
