### PR TITLE
chore: add pattern based matching for version deprecation errors

### DIFF
--- a/enterprise/reporting/error_reporting_test.go
+++ b/enterprise/reporting/error_reporting_test.go
@@ -299,6 +299,14 @@ func TestExtractErrorDetails(t *testing.T) {
 				errorCode: "dataValidation:configuration",
 			},
 		},
+		{
+			caseDescription: "should use complex patterns to match version deprecation",
+			inputErrMsg:     "version v1 not active",
+			output: depTcOutput{
+				errorMsg:  "version not active",
+				errorCode: "deprecation",
+			},
+		},
 	}
 
 	edr := NewErrorDetailReporter(context.Background(), &configSubscriber{}, stats.NOP, config.Default)


### PR DESCRIPTION
# Description

The current keys count method is missing cases like `version 2402 is not active`, so now added pattern-based matching for more robust detection of version errors 

## Linear Ticket

[INT-3339: LinkedIn ads version deprecation](https://linear.app/rudderstack/issue/INT-3339/linkedin-ads-version-deprecation)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
