### PR TITLE
feat: add support for Snowflake Iceberg tables

### DIFF
--- a/warehouse/integrations/snowflake/datatype_mapper.go
+++ b/warehouse/integrations/snowflake/datatype_mapper.go
@@ -1,15 +1,5 @@
 package snowflake
 
-var dataTypesMap = map[string]string{
-	"boolean":  "boolean",
-	"int":      "number",
-	"bigint":   "number",
-	"float":    "double precision",
-	"string":   "varchar",
-	"datetime": "timestamp_tz",
-	"json":     "variant",
-}
-
 var dataTypesMapToRudder = map[string]string{
 	"NUMBER":           "int",
 	"DECIMAL":          "int",

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -147,6 +147,7 @@ type Snowflake struct {
 	conf           *config.Config
 	logger         logger.Logger
 	stats          stats.Stats
+	tableManager   tableManager
 
 	config struct {
 		allowMerge         bool
@@ -185,14 +186,6 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats) *Snowflake {
 	return sf
 }
 
-func ColumnsWithDataTypes(columns model.TableSchema, prefix string) string {
-	var arr []string
-	for name, dataType := range columns {
-		arr = append(arr, fmt.Sprintf(`"%s%s" %s`, prefix, name, dataTypesMap[dataType]))
-	}
-	return strings.Join(arr, ",")
-}
-
 // schemaIdentifier returns [DATABASE_NAME].[NAMESPACE] format to access the schema directly.
 func (sf *Snowflake) schemaIdentifier() string {
 	return fmt.Sprintf(`%q`,
@@ -202,10 +195,9 @@ func (sf *Snowflake) schemaIdentifier() string {
 
 func (sf *Snowflake) createTable(ctx context.Context, tableName string, columns model.TableSchema) (err error) {
 	schemaIdentifier := sf.schemaIdentifier()
-	sqlStatement := fmt.Sprintf(
-		`CREATE TABLE IF NOT EXISTS %s.%q ( %v )`,
-		schemaIdentifier, tableName, ColumnsWithDataTypes(columns, ""),
-	)
+
+	sqlStatement := sf.tableManager.createTableQuery(schemaIdentifier, tableName, columns)
+
 	sf.logger.Infow("Creating table in snowflake",
 		lf.DestinationID, sf.Warehouse.Destination.ID,
 		lf.Query, sqlStatement,
@@ -334,23 +326,21 @@ func (sf *Snowflake) loadTable(
 		lf.ShouldMerge, sf.ShouldMerge(tableName),
 	)
 	log.Infow("started loading")
-
-	if db, err = sf.connect(ctx, optionalCreds{schemaName: sf.Namespace}); err != nil {
+	schemaIdentifier := sf.schemaIdentifier()
+	if db, err = sf.connect(ctx, optionalCreds{schemaName: schemaIdentifier}); err != nil {
 		return nil, nil, fmt.Errorf("connect: %w", err)
 	}
 
 	if !skipClosingDBSession {
 		defer func() { _ = db.Close() }()
 	}
-
-	schemaIdentifier := sf.schemaIdentifier()
 	stagingTableName := whutils.StagingTableName(
 		provider,
 		tableName,
 		tableNameLimit,
 	)
 
-	strKeys := sf.getSortedColumnsFromTableSchema(tableSchemaInUpload)
+	strKeys := getSortedColumnsFromTableSchema(tableSchemaInUpload)
 	sortedColumnNames := sf.joinColumnsWithFormatting(strKeys, "%q")
 
 	// Truncating the columns by default to avoid size limitation errors
@@ -504,12 +494,6 @@ func (sf *Snowflake) mergeIntoLoadTable(
 		RowsInserted: rowsInserted,
 		RowsUpdated:  rowsUpdated,
 	}, nil
-}
-
-func (sf *Snowflake) getSortedColumnsFromTableSchema(tableSchemaInUpload model.TableSchema) []string {
-	strKeys := whutils.GetColumnsFromTableSchema(tableSchemaInUpload)
-	sort.Strings(strKeys)
-	return strKeys
 }
 
 func (sf *Snowflake) joinColumnsWithFormatting(columns []string, format string) string {
@@ -888,7 +872,7 @@ func (sf *Snowflake) LoadUserTables(ctx context.Context) map[string]error {
 			}
 		}
 
-		strKeys := sf.getSortedColumnsFromTableSchema(identifiesSchema)
+		strKeys := getSortedColumnsFromTableSchema(identifiesSchema)
 		sortedColumnNames := sf.joinColumnsWithFormatting(strKeys, "%q")
 
 		_, err = sf.copyInto(ctx, resp.db, schemaIdentifier, identifiesTable, sortedColumnNames, tmpIdentifiesStagingTable)
@@ -1152,25 +1136,11 @@ func (sf *Snowflake) DropTable(ctx context.Context, tableName string) (err error
 }
 
 func (sf *Snowflake) AddColumns(ctx context.Context, tableName string, columnsInfo []whutils.ColumnInfo) (err error) {
-	var (
-		query            string
-		queryBuilder     strings.Builder
-		schemaIdentifier = sf.schemaIdentifier()
-	)
-
-	queryBuilder.WriteString(fmt.Sprintf(`
-		ALTER TABLE
-		  %s.%q
-		ADD COLUMN`,
-		schemaIdentifier,
-		tableName,
-	))
-
-	for _, columnInfo := range columnsInfo {
-		queryBuilder.WriteString(fmt.Sprintf(` %q %s,`, columnInfo.Name, dataTypesMap[columnInfo.Type]))
+	schemaIdentifier := sf.schemaIdentifier()
+	query, err := sf.tableManager.addColumnsQuery(schemaIdentifier, tableName, columnsInfo)
+	if err != nil {
+		return fmt.Errorf("adding columns: %w", err)
 	}
-
-	query = strings.TrimSuffix(queryBuilder.String(), ",") + ";"
 
 	log := sf.logger.With(
 		lf.Schema, schemaIdentifier,
@@ -1345,6 +1315,7 @@ func (sf *Snowflake) Setup(ctx context.Context, warehouse model.Warehouse, uploa
 	sf.CloudProvider = whutils.SnowflakeCloudProvider(warehouse.Destination.Config)
 	sf.Uploader = uploader
 	sf.ObjectStorage = whutils.ObjectStorageType(whutils.SNOWFLAKE, warehouse.Destination.Config, sf.Uploader.UseRudderStorage())
+	sf.tableManager = newTableManager(sf.conf, warehouse)
 
 	sf.DB, err = sf.connect(ctx, optionalCreds{})
 	return err
@@ -1469,4 +1440,10 @@ func (sf *Snowflake) SetConnectionTimeout(timeout time.Duration) {
 
 func (*Snowflake) ErrorMappings() []model.JobError {
 	return errorsMappings
+}
+
+func getSortedColumnsFromTableSchema(tableSchemaInUpload model.TableSchema) []string {
+	strKeys := whutils.GetColumnsFromTableSchema(tableSchemaInUpload)
+	sort.Strings(strKeys)
+	return strKeys
 }

--- a/warehouse/integrations/snowflake/table_manager.go
+++ b/warehouse/integrations/snowflake/table_manager.go
@@ -1,0 +1,128 @@
+package snowflake
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+type tableManager interface {
+	createTableQuery(schemaIdentifier, tableName string, columns model.TableSchema) string
+	addColumnsQuery(schemaIdentifier, tableName string, columnsInfo []whutils.ColumnInfo) (string, error)
+}
+
+func newTableManager(config *config.Config, warehouse model.Warehouse) tableManager {
+	if warehouse.GetBoolDestinationConfig(model.EnableIcebergSetting) {
+		externalVolume := warehouse.GetStringDestinationConfig(config, model.ExternalVolumeSetting)
+		return newIcebergTableManager(externalVolume)
+	}
+	return newStandardTableManager()
+}
+
+// for standard Snowflake tables
+type standardTableManager struct {
+	dataTypesMap map[string]string
+}
+
+func newStandardTableManager() tableManager {
+	return &standardTableManager{
+		dataTypesMap: map[string]string{
+			"boolean":  "boolean",
+			"int":      "number",
+			"bigint":   "number",
+			"float":    "double precision",
+			"string":   "varchar",
+			"datetime": "timestamp_tz",
+			"json":     "variant",
+		},
+	}
+}
+
+func (m *standardTableManager) createTableQuery(schemaIdentifier, tableName string, columns model.TableSchema) string {
+	return fmt.Sprintf(
+		`CREATE TABLE IF NOT EXISTS %s.%q ( %v )`,
+		schemaIdentifier, tableName, columnsWithDataTypes(columns, "", m.dataTypesMap),
+	)
+}
+
+func (m *standardTableManager) addColumnsQuery(schemaIdentifier, tableName string, columnsInfo []whutils.ColumnInfo) (string, error) {
+	var queryBuilder strings.Builder
+	queryBuilder.WriteString(fmt.Sprintf(`
+		ALTER TABLE
+		  %s.%q
+		ADD COLUMN`,
+		schemaIdentifier,
+		tableName,
+	))
+
+	for _, columnInfo := range columnsInfo {
+		dataType := m.dataTypesMap[columnInfo.Type]
+		queryBuilder.WriteString(fmt.Sprintf(` %q %s,`, columnInfo.Name, dataType))
+	}
+	return strings.TrimSuffix(queryBuilder.String(), ",") + ";", nil
+}
+
+// for snowflake managed Iceberg tables
+type icebergTableManager struct {
+	dataTypesMap   map[string]string
+	externalVolume string
+}
+
+func newIcebergTableManager(externalVolume string) tableManager {
+	return &icebergTableManager{
+		dataTypesMap: map[string]string{
+			"boolean":  "boolean",
+			"int":      "number(10,0)",
+			"bigint":   "number(19,0)",
+			"float":    "double precision",
+			"string":   "varchar",
+			"datetime": "timestamp_ltz(6)",
+			"json":     "varchar",
+		},
+		externalVolume: externalVolume,
+	}
+}
+
+func (m *icebergTableManager) createTableQuery(schemaIdentifier, tableName string, columns model.TableSchema) string {
+	baseLocation := fmt.Sprintf("%s/%s", schemaIdentifier, tableName)
+	return fmt.Sprintf(
+		`CREATE OR REPLACE ICEBERG TABLE %s.%q ( %v )
+		CATALOG = 'SNOWFLAKE'
+		EXTERNAL_VOLUME = '%s'
+		BASE_LOCATION = '%s'`,
+		schemaIdentifier, tableName, columnsWithDataTypes(columns, "", m.dataTypesMap),
+		m.externalVolume,
+		baseLocation,
+	)
+}
+
+func (m *icebergTableManager) addColumnsQuery(schemaIdentifier, tableName string, columnsInfo []whutils.ColumnInfo) (string, error) {
+	var queryBuilder strings.Builder
+	queryBuilder.WriteString(fmt.Sprintf(`
+		ALTER ICEBERG TABLE
+		  %s.%q
+		ADD COLUMN`,
+		schemaIdentifier,
+		tableName,
+	))
+	for _, columnInfo := range columnsInfo {
+		dataType, ok := m.dataTypesMap[columnInfo.Type]
+		if !ok {
+			return "", fmt.Errorf("invalid data type: %s", columnInfo.Type)
+		}
+		queryBuilder.WriteString(fmt.Sprintf(` %q %s,`, columnInfo.Name, dataType))
+	}
+	return strings.TrimSuffix(queryBuilder.String(), ",") + ";", nil
+}
+
+func columnsWithDataTypes(columns model.TableSchema, prefix string, dataTypesMap map[string]string) string {
+	var arr []string
+	sortedColumns := getSortedColumnsFromTableSchema(columns)
+	for _, name := range sortedColumns {
+		arr = append(arr, fmt.Sprintf(`"%s%s" %s`, prefix, name, dataTypesMap[columns[name]]))
+	}
+	return strings.Join(arr, ",")
+}

--- a/warehouse/integrations/snowflake/table_manager_test.go
+++ b/warehouse/integrations/snowflake/table_manager_test.go
@@ -1,0 +1,130 @@
+package snowflake
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+
+	"github.com/stretchr/testify/require"
+
+	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+func TestTableManager(t *testing.T) {
+	columns := model.TableSchema{
+		"col1": "boolean",
+		"col2": "int",
+		"col3": "bigint",
+		"col4": "float",
+		"col5": "string",
+		"col6": "datetime",
+		"col7": "json",
+	}
+	standardWarehouse := model.Warehouse{
+		Destination: backendconfig.DestinationT{
+			Config: map[string]interface{}{
+				"enableIceberg": false,
+			},
+		},
+	}
+	icebergWarehouse := model.Warehouse{
+		Destination: backendconfig.DestinationT{
+			Config: map[string]interface{}{
+				"enableIceberg":  true,
+				"externalVolume": "myvolume",
+			},
+		},
+	}
+
+	t.Run("TestCreateTableQuery", func(t *testing.T) {
+		tests := []struct {
+			name                     string
+			warehouse                model.Warehouse
+			columns                  model.TableSchema
+			expectedCreateTableQuery string
+		}{
+			{
+				name:                     "standard table",
+				warehouse:                standardWarehouse,
+				columns:                  columns,
+				expectedCreateTableQuery: "CREATE TABLE IF NOT EXISTS myschema.\"mytable\" ( \"col1\" boolean,\"col2\" number,\"col3\" number,\"col4\" double precision,\"col5\" varchar,\"col6\" timestamp_tz,\"col7\" variant )",
+			},
+			{
+				name:      "iceberg table",
+				warehouse: icebergWarehouse,
+				columns:   columns,
+				expectedCreateTableQuery: `CREATE OR REPLACE ICEBERG TABLE myschema."mytable" ( "col1" boolean,"col2" number(10,0),"col3" number(19,0),"col4" double precision,"col5" varchar,"col6" timestamp_ltz(6),"col7" varchar )
+		CATALOG = 'SNOWFLAKE'
+		EXTERNAL_VOLUME = 'myvolume'
+		BASE_LOCATION = 'myschema/mytable'`,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				manager := newTableManager(config.New(), tt.warehouse)
+				result := manager.createTableQuery("myschema", "mytable", tt.columns)
+				require.Equal(t, tt.expectedCreateTableQuery, result)
+			})
+		}
+	})
+
+	t.Run("TestAddColumnsQuery", func(t *testing.T) {
+		tests := []struct {
+			name                    string
+			warehouse               model.Warehouse
+			additionalColumns       []whutils.ColumnInfo
+			expectedAddColumnsQuery string
+			expectedError           string
+		}{
+			{
+				name:      "standard table manager",
+				warehouse: standardWarehouse,
+				additionalColumns: []whutils.ColumnInfo{
+					{Name: "new_col1", Type: "string"},
+					{Name: "new_col2", Type: "int"},
+				},
+				expectedAddColumnsQuery: `
+		ALTER TABLE
+		  myschema."mytable"
+		ADD COLUMN "new_col1" varchar, "new_col2" number;`,
+			},
+			{
+				name:      "iceberg table",
+				warehouse: icebergWarehouse,
+				additionalColumns: []whutils.ColumnInfo{
+					{Name: "new_col1", Type: "string"},
+					{Name: "new_col2", Type: "int"},
+				},
+				expectedAddColumnsQuery: `
+		ALTER ICEBERG TABLE
+		  myschema."mytable"
+		ADD COLUMN "new_col1" varchar, "new_col2" number(10,0);`,
+			},
+			{
+				name:      "iceberg table - invalid data type",
+				warehouse: icebergWarehouse,
+				additionalColumns: []whutils.ColumnInfo{
+					{Name: "col1", Type: "hello"},
+				},
+				expectedError: "invalid data type: hello",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				manager := newTableManager(config.New(), tt.warehouse)
+				result, err := manager.addColumnsQuery("myschema", "mytable", tt.additionalColumns)
+
+				if tt.expectedError != "" {
+					require.EqualError(t, err, tt.expectedError)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tt.expectedAddColumnsQuery, result)
+				}
+			})
+		}
+	})
+}

--- a/warehouse/internal/model/settings.go
+++ b/warehouse/internal/model/settings.go
@@ -59,6 +59,8 @@ var (
 	ExcludeWindowSetting             DestinationConfigSetting = destConfSetting("excludeWindow")
 	PartitionColumnSetting           DestinationConfigSetting = destConfSetting("partitionColumn")
 	PartitionTypeSetting             DestinationConfigSetting = destConfSetting("partitionType")
+	EnableIcebergSetting             DestinationConfigSetting = destConfSetting("enableIceberg")
+	ExternalVolumeSetting            DestinationConfigSetting = destConfSetting("externalVolume")
 	CleanupObjectStorageFilesSetting DestinationConfigSetting = destConfSetting("cleanupObjectStorageFiles")
 	UseOauthSetting                  DestinationConfigSetting = destConfSetting("useOauth")
 	OauthClientIDSetting             DestinationConfigSetting = destConfSetting("oauthClientID")


### PR DESCRIPTION
# Description

This PR enhances the Snowflake implementation of the `Manager` interface by adding support for Iceberg tables.

Implementation Details:
- Introduced two new destination settings for Iceberg: `enableIceberg` and `externalVolume`.
- Created a `tableManager` interface to encapsulate table-specific behavior. This interface has two implementations: standard (existing) and Iceberg.
- Moved `dataTypesMap` and the corresponding Iceberg type handling behind this interface.
- `tableManager` is being initialized in the `Setup` method.
- Refactored `getSortedColumnsFromTableSchema` into a standalone function, making it reusable for `tableManager` instead of being a Snowflake-specific method.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
