### PR TITLE
refactor: add columns in snowflake using IF NOT EXISTS

### DIFF
--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -1161,7 +1161,7 @@ func (sf *Snowflake) AddColumns(ctx context.Context, tableName string, columnsIn
 	queryBuilder.WriteString(fmt.Sprintf(`
 		ALTER TABLE
 		  %s.%q
-		ADD COLUMN`,
+		ADD COLUMN IF NOT EXISTS`,
 		schemaIdentifier,
 		tableName,
 	))
@@ -1179,19 +1179,6 @@ func (sf *Snowflake) AddColumns(ctx context.Context, tableName string, columnsIn
 	)
 	log.Infow("Adding columns", lf.Query, query)
 	_, err = sf.DB.ExecContext(ctx, query)
-
-	// Handle error in case of single column
-	if len(columnsInfo) == 1 {
-		if err != nil {
-			if checkAndIgnoreAlreadyExistError(err) {
-				log.Infow("Column already exists",
-					lf.ColumnName, columnsInfo[0].Name,
-					lf.Error, err.Error(),
-				)
-				err = nil
-			}
-		}
-	}
 	return
 }
 


### PR DESCRIPTION
# Description

Currently, when adding columns in Snowflake, we use `ADD COLUMN`, which results in an error if the column already exists. For single-column additions, we catch this error.

This PR updates the query to use `IF NOT EXISTS`, preventing Snowflake from throwing an error for existing columns and removing the need for error handling. However, the query will still fail when adding multiple columns if any column beyond the first already exists in the table.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
