### PR TITLE
chore(jobsdb): finer granularity metrics when querying jobs

### DIFF
--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -140,6 +140,7 @@ type statTags struct {
 	ParameterFilters []ParameterFilterT
 	StateFilters     []string
 	WorkspaceID      string
+	MoreToken        bool
 }
 
 func (jd *Handle) getTimerStat(stat string, tags *statTags) stats.Measurement {
@@ -172,6 +173,9 @@ func (tags *statTags) getStatsTags(tablePrefix string) stats.Tags {
 
 		for _, paramTag := range tags.ParameterFilters {
 			statTagsMap[paramTag.Name] = paramTag.Value
+		}
+		if tags.MoreToken {
+			statTagsMap["moreToken"] = "true"
 		}
 	}
 


### PR DESCRIPTION
# Description

We need finer granularity of jobsdb metrics when querying jobs, which can help us troubleshoot issues easier and gain some more insight about the system's behaviour:

- Adding parameter filters and moreToken as tags in existing metrics so that we can know what gets queried by each and every pipeline
- Adding a new metric for counting the times we query for jobs but get nothing back so that we can tell with confidence whether the pipeline is active or not

## Linear Ticket

resolves PIPE-1953

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
