### PR TITLE
fix(jobsdb): cache not getting updating after 10 consecutive uncommitted transactions

### DIFF
--- a/jobsdb/internal/cache/cache.go
+++ b/jobsdb/internal/cache/cache.go
@@ -3,24 +3,43 @@ package cache
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/samber/lo"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
 )
 
 const (
 	wildcard = "*"
 )
 
-// NewNoResultsCache creates a new, properly initialised NoResultsCache.
-func NewNoResultsCache[T ParameterFilter](supportedParams []string, ttlFn func() time.Duration) *NoResultsCache[T] {
-	return &NoResultsCache[T]{
-		ttl:             ttlFn,
-		supportedParams: supportedParams,
-		cacheTree:       make(cacheTree),
+type Option[T ParameterFilter] func(*NoResultsCache[T])
+
+// WithWarnOnBranchInvalidation is a config option that enables logging of branch invalidations.
+func WithWarnOnBranchInvalidation[T ParameterFilter](enabled config.ValueLoader[bool], logger logger.Logger) Option[T] {
+	return func(c *NoResultsCache[T]) {
+		c.warnOnBranchInvalidation = enabled
+		c.logger = logger
 	}
+}
+
+// NewNoResultsCache creates a new, properly initialised NoResultsCache.
+func NewNoResultsCache[T ParameterFilter](supportedParams []string, ttlFn func() time.Duration, opts ...Option[T]) *NoResultsCache[T] {
+	c := &NoResultsCache[T]{
+		ttl:                      ttlFn,
+		supportedParams:          supportedParams,
+		cacheTree:                make(cacheTree),
+		warnOnBranchInvalidation: config.SingleValueLoader(false),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 type ParameterFilter interface {
@@ -29,8 +48,10 @@ type ParameterFilter interface {
 }
 
 type NoResultsCache[T ParameterFilter] struct {
-	ttl             func() time.Duration // returns the time to live for a cache entry
-	supportedParams []string             // a list of parameters that are supported by the cache
+	ttl                      func() time.Duration // returns the time to live for a cache entry
+	supportedParams          []string             // a list of parameters that are supported by the cache
+	warnOnBranchInvalidation config.ValueLoader[bool]
+	logger                   logger.Logger
 
 	cacheTreeMu sync.RWMutex // protects the cacheTree
 	cacheTree   cacheTree    // a hierarchical tree of cache entries
@@ -77,6 +98,15 @@ func (c *NoResultsCache[T]) Invalidate(dataset, workspace string, customVals, st
 	workspaces, states, customVals, params := c.filtersToInvalidationKeys(workspace, states, customVals, parameters)
 
 	if len(workspaces) == 0 { // if no workspace is provided, invalidate all by deleting the workspace's parent node
+		if c.warnOnBranchInvalidation.Load() && !(len(customVals) == 0 && len(states) == 0 && len(parameters) == 0) {
+			c.logger.Warnn("Invalidating entire dataset",
+				logger.NewStringField("dataset", dataset),
+				logger.NewStringField("workspace", workspace),
+				logger.NewStringField("customVals", strings.Join(customVals, ",")),
+				logger.NewStringField("states", strings.Join(states, ",")),
+				logger.NewStringField("parameters", strings.Join(lo.Map(parameters, func(pf T, _ int) string { return pf.GetName() + ":" + pf.GetValue() }), ",")),
+			)
+		}
 		delete(c.cacheTree, dataset)
 		return
 	}
@@ -85,6 +115,15 @@ func (c *NoResultsCache[T]) Invalidate(dataset, workspace string, customVals, st
 	}
 	for _, workspace := range workspaces {
 		if len(customVals) == 0 { // if no custom value is provided, invalidate all by deleting the customVal's parent node
+			if c.warnOnBranchInvalidation.Load() {
+				c.logger.Warnn("Invalidating entire workspace branch",
+					logger.NewStringField("dataset", dataset),
+					logger.NewStringField("workspace", workspace),
+					logger.NewStringField("customVals", strings.Join(customVals, ",")),
+					logger.NewStringField("states", strings.Join(states, ",")),
+					logger.NewStringField("parameters", strings.Join(lo.Map(parameters, func(pf T, _ int) string { return pf.GetName() + ":" + pf.GetValue() }), ",")),
+				)
+			}
 			delete(c.cacheTree[dataset], workspace)
 			continue
 		}
@@ -93,6 +132,15 @@ func (c *NoResultsCache[T]) Invalidate(dataset, workspace string, customVals, st
 		}
 		for _, customVal := range customVals {
 			if len(states) == 0 { // if no state is provided, invalidate all by deleting the state's parent node
+				if c.warnOnBranchInvalidation.Load() {
+					c.logger.Warnn("Invalidating entire customVal branch",
+						logger.NewStringField("dataset", dataset),
+						logger.NewStringField("workspace", workspace),
+						logger.NewStringField("customVal", customVal),
+						logger.NewStringField("states", strings.Join(states, ",")),
+						logger.NewStringField("parameters", strings.Join(lo.Map(parameters, func(pf T, _ int) string { return pf.GetName() + ":" + pf.GetValue() }), ",")),
+					)
+				}
 				delete(c.cacheTree[dataset][workspace], customVal)
 				continue
 			}
@@ -101,6 +149,15 @@ func (c *NoResultsCache[T]) Invalidate(dataset, workspace string, customVals, st
 			}
 			for _, state := range states {
 				if len(params) == 0 { // if no parameter is provided, invalidate all by deleting the param's parent node
+					if c.warnOnBranchInvalidation.Load() {
+						c.logger.Warnn("Invalidating entire state branch",
+							logger.NewStringField("dataset", dataset),
+							logger.NewStringField("workspace", workspace),
+							logger.NewStringField("customVal", customVal),
+							logger.NewStringField("state", state),
+							logger.NewStringField("parameters", strings.Join(lo.Map(parameters, func(pf T, _ int) string { return pf.GetName() + ":" + pf.GetValue() }), ",")),
+						)
+					}
 					delete(c.cacheTree[dataset][workspace][customVal], state)
 					continue
 				}
@@ -108,6 +165,15 @@ func (c *NoResultsCache[T]) Invalidate(dataset, workspace string, customVals, st
 					continue
 				}
 				for _, param := range params {
+					if c.warnOnBranchInvalidation.Load() {
+						c.logger.Warnn("Invalidating leaf",
+							logger.NewStringField("dataset", dataset),
+							logger.NewStringField("workspace", workspace),
+							logger.NewStringField("customVal", customVal),
+							logger.NewStringField("state", state),
+							logger.NewStringField("parameter", param),
+						)
+					}
 					delete(c.cacheTree[dataset][workspace][customVal][state], param)
 				}
 			}
@@ -174,9 +240,10 @@ type NoResultTx[T ParameterFilter] struct {
 }
 
 // Commit sets the necessary cache entries for the relevant dataset, workspace, states, customVals and parameters filters.
-func (tx *NoResultTx[T]) Commit() {
+// It returns [true] if the cache was successfully updated for all cache entries, [false] otherwise.
+func (tx *NoResultTx[T]) Commit() bool {
 	if tx.c.skipCache(tx.states, tx.parameters) {
-		return
+		return false
 	}
 	workspace, states, customVals, params := filtersToCacheKeys(tx.workspace, tx.states, tx.customVals, tx.parameters)
 
@@ -184,27 +251,33 @@ func (tx *NoResultTx[T]) Commit() {
 	defer tx.c.cacheTreeMu.Unlock()
 
 	if _, ok := tx.c.cacheTree[tx.dataset]; !ok {
-		return
+		return false
 	}
 	if _, ok := tx.c.cacheTree[tx.dataset][workspace]; !ok {
-		return
+		return false
 	}
+	var missed bool
 	for _, customVal := range customVals {
 		if _, ok := tx.c.cacheTree[tx.dataset][workspace][customVal]; !ok {
+			missed = true
 			continue
 		}
 		for _, state := range states {
 			if _, ok := tx.c.cacheTree[tx.dataset][workspace][customVal][state]; !ok {
+				missed = true
 				continue
 			}
 			for _, param := range params {
 				e := tx.c.cacheTree[tx.dataset][workspace][customVal][state][param]
 				if e.SetNoJobs(tx.id) {
 					tx.c.cacheTree[tx.dataset][workspace][customVal][state][param] = e
+				} else {
+					missed = true
 				}
 			}
 		}
 	}
+	return !missed
 }
 
 // skipCache returns true if the cache should be skipped for the provided states and parameters.
@@ -295,7 +368,7 @@ type cacheEntry struct {
 func (ce *cacheEntry) AddToken(token string) {
 	ce.tokens = append(ce.tokens, token)
 	if len(ce.tokens) > 10 {
-		ce.tokens = lo.Slice(ce.tokens, 0, 10)
+		ce.tokens = lo.Slice(ce.tokens, len(ce.tokens)-10, len(ce.tokens))
 	}
 }
 

--- a/jobsdb/internal/cache/cache_internal_test.go
+++ b/jobsdb/internal/cache/cache_internal_test.go
@@ -27,4 +27,25 @@ func TestCacheEntry(t *testing.T) {
 		require.Len(t, e.tokens, 0)
 		require.False(t, e.SetNoJobs(token), "it shouldn't be able to set no jobs twice with the same token")
 	})
+
+	t.Run("Tokens limit reached", func(t *testing.T) {
+		e := cacheEntry{}
+		for i := 0; i < 14; i++ { // add 14 tokens
+			e.AddToken(fmt.Sprintf("token-%d", i))
+		}
+
+		// Should not be able to set no jobs for the first 4 tokens
+		require.False(t, e.SetNoJobs("token-0"))
+		require.False(t, e.SetNoJobs("token-1"))
+		require.False(t, e.SetNoJobs("token-2"))
+		require.False(t, e.SetNoJobs("token-3"))
+
+		// Should be able to set no jobs for the last 4 tokens
+		require.True(t, e.SetNoJobs("token-13"))
+		e.AddToken("token-14")
+		require.True(t, e.SetNoJobs("token-4"), "after setting no jobs, token gets removed from the list freeing up space")
+		require.True(t, e.SetNoJobs("token-12"))
+		require.True(t, e.SetNoJobs("token-11"))
+		require.True(t, e.SetNoJobs("token-10"))
+	})
 }

--- a/jobsdb/internal/cache/cache_test.go
+++ b/jobsdb/internal/cache/cache_test.go
@@ -42,7 +42,7 @@ func TestNoResultsCache(t *testing.T) {
 			require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}), "it should return false if noresult is not set")
 		})
 
-		c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit()
+		require.True(t, c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}).Commit())
 		require.True(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}), "it should return true if no result is set for valid token")
 
 		t.Run("expiration", func(t *testing.T) {
@@ -65,7 +65,7 @@ func TestNoResultsCache(t *testing.T) {
 			c := cache.NewNoResultsCache[paramFilter](supportedParamFilters, func() time.Duration { return time.Hour })
 			tx := c.StartNoResultTx(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
 			c.Invalidate(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}})
-			tx.Commit()
+			require.False(t, tx.Commit())
 			require.False(t, c.Get(dataset, workspace, []string{customVal}, []string{state}, []paramFilter{{name: "param1", value: "value1"}}), "it should return false if invalidation is called before SetNoResult")
 		})
 

--- a/processor/processor_isolation_test.go
+++ b/processor/processor_isolation_test.go
@@ -181,7 +181,7 @@ func ProcIsolationScenario(t testing.TB, spec *ProcIsolationScenarioSpec) (overa
 	defer jsonrs.Reset()
 	defer logger.Reset()
 	defer config.Reset()
-	config.Set("LOG_LEVEL", "ERROR")
+	config.Set("LOG_LEVEL", "WARN")
 	config.Set("Json.Library.Marshaller", spec.marshallerLib)
 	config.Set("Json.Library.Unmarshaller", spec.unmarshallerLib)
 	logger.Reset()

--- a/router/router_isolation_test.go
+++ b/router/router_isolation_test.go
@@ -169,7 +169,7 @@ func RouterIsolationScenario(t testing.TB, spec *RtIsolationScenarioSpec) (overa
 	config.Reset()
 	defer logger.Reset()
 	defer config.Reset()
-	config.Set("LOG_LEVEL", "ERROR")
+	config.Set("LOG_LEVEL", "WARN")
 	logger.Reset()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -387,8 +387,9 @@ func (rtIsolationMethods) generateJobs(jobs []*rtIsolationJobSpec, url string, b
 			Parameters: []byte(fmt.Sprintf(`{
 				"source_id": %[1]q,
 				"destination_id": %[1]q,
-				"receivedAt": %[2]q
-			}`, job.workspaceID, time.Now().Format(misc.RFC3339Milli))),
+				"receivedAt": %[2]q,
+				"workspaceId": %[3]q
+			}`, job.workspaceID, time.Now().Format(misc.RFC3339Milli), job.workspaceID)),
 			CustomVal:    "WEBHOOK",
 			EventPayload: payload,
 			CreatedAt:    time.Now(),


### PR DESCRIPTION
# Description

![Untitled Diagram drawio](https://github.com/user-attachments/assets/ff5504f1-3859-41da-9f55-ff6e41b762f0)

- Inside jobsdb, `noResultsCache` uses its own concept of transactions for properly handling concurrent reads/writes and avoiding caching stale results.
- A `noResultsCache` transaction begins before a query against a dataset happens and this transaction gets committed if the query doesn't return any results. 
- Each transaction has an id and when the transaction begins, it marks all cache entries that it plans to mark as having no jobs by adding its id in the entries' list of **pending ids**.
- During commit, the entry will be updated as having no jobs, as long as the entry's list of pending ids still contains the transaction id, i.e. no write operation happened in the meantime which invalidated the entry.
- Each entry has a **bounded limit of 10** for the number of pending transaction ids that it can hold.
- If the entry's list is full with ids (transaction ids which didn't ever commit) the code's documentation claims that it keeps only the latest 10 ids, i.e. removes older ones. **However, in practice, the code was retaining the 10 earliest ones, discarding newer ids**.

Effectively, if a pipeline managed to retrieve jobs in a dataset for 10 consecutive times, the dataset's cache entries for this pipeline cannot be updated again as having no jobs, causing the cache for this dataset to be disabled for this pipeline unless something else manages to invalidate the cache entries!

## Additional changes
- Adding some logging in `NoResultsCache` for capturing whenever a whole branch of the cache is getting invalidated unexpectedly.
- Adding a metric counter for capturing pipelines that fail to commit all their cache entries when there are no results

## Linear Ticket

resolves PIPE-1954
resolves PIPE-1956

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
