### PR TITLE
chore(jobsdb): leaf invalidations should be logged at debug level

### DIFF
--- a/jobsdb/internal/cache/cache.go
+++ b/jobsdb/internal/cache/cache.go
@@ -165,8 +165,8 @@ func (c *NoResultsCache[T]) Invalidate(dataset, workspace string, customVals, st
 					continue
 				}
 				for _, param := range params {
-					if c.warnOnBranchInvalidation.Load() {
-						c.logger.Warnn("Invalidating leaf",
+					if c.warnOnBranchInvalidation.Load() { // if logging is enabled, log the invalidation of the leaf node at debug level, since this is the most granular level
+						c.logger.Debugn("Invalidating leaf",
 							logger.NewStringField("dataset", dataset),
 							logger.NewStringField("workspace", workspace),
 							logger.NewStringField("customVal", customVal),


### PR DESCRIPTION
# Description

We shouldn't be logging a warning when leaf nodes get invalidated

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
