### PR TITLE
chore(jobsdb): improve checkValidJobState performance

### DIFF
--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -104,13 +104,11 @@ func getAllTableNames(dbHandle sqlDbOrTx) ([]string, error) {
 
 // checkValidJobState Function to check validity of states
 func checkValidJobState(jd assertInterface, stateFilters []string) {
-	jobStateMap := make(map[string]jobStateT)
-	for _, js := range jobStates {
-		jobStateMap[js.State] = js
-	}
+	jobStateMap := lo.SliceToMap(jobStates, func(js jobStateT) (string, struct{}) { return js.State, struct{}{} })
 	for _, st := range stateFilters {
-		_, ok := jobStateMap[st]
-		jd.assert(ok, fmt.Sprintf("state %s is not found in jobStates: %v", st, jobStates))
+		if _, ok := jobStateMap[st]; !ok {
+			jd.assert(false, fmt.Sprintf("state %s is not found in jobStates: %v", st, jobStates))
+		}
 	}
 }
 


### PR DESCRIPTION
# Description

Avoiding unnecessary evaluation of `fmt.Sprintf` which is slow

![image](https://github.com/user-attachments/assets/9f865feb-75d0-4730-88a5-4d1ad5af61b0)

```go
func BenchmarkCheckValidJobState(b *testing.B) {

	jobStates := lo.Map(jobStates, func(s jobStateT, _ int) string { return s.State })
	var a dummyAssert
	b.Run("v1", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			checkValidJobStatev1(a, jobStates)
		}
	})

	b.Run("v2", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			checkValidJobStatev2(a, jobStates)
		}
	})

}
```
```sh
goos: darwin
goarch: arm64
pkg: github.com/rudderlabs/rudder-server/jobsdb
cpu: Apple M1 Pro
BenchmarkCheckValidJobState2
BenchmarkCheckValidJobState2/v1
BenchmarkCheckValidJobState2/v1-10 	   90434	     13019 ns/op	    6613 B/op	     190 allocs/op
BenchmarkCheckValidJobState2/v2
BenchmarkCheckValidJobState2/v2-10 	 3285302	       371.2 ns/op	     336 B/op	       2 allocs/op
```
## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
