### PR TITLE
chore: cpu performance improvements

### DIFF
--- a/enterprise/suppress-user/internal/badgerdb/badgerdb.go
+++ b/enterprise/suppress-user/internal/badgerdb/badgerdb.go
@@ -344,7 +344,7 @@ func (l blogger) Warningf(fmt string, args ...interface{}) {
 }
 
 func keyPrefix(workspaceID, userID string) string {
-	return fmt.Sprintf("%s:%s:", workspaceID, userID)
+	return workspaceID + ":" + userID + ":"
 }
 
 func getMetadataFromBadgerItem(item *badger.Item) (*model.Metadata, error) {

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1810,7 +1810,7 @@ func (jd *Handle) invalidateCacheForJobs(ds dataSetT, jobList []*JobT) {
 
 		for _, key := range cacheParameterFilters {
 			val := gjson.GetBytes(job.Parameters, key).String()
-			params = append(params, fmt.Sprintf("%s:%s", key, val))
+			params = append(params, key+":"+val)
 			parameterFilters = append(parameterFilters, ParameterFilterT{Name: key, Value: val})
 		}
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1273,17 +1273,15 @@ func (proc *Handle) updateMetricMaps(
 		}
 	}
 
-	key := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%d:%s:%d:%s:%s",
-		event.Metadata.SourceID,
-		event.Metadata.DestinationID,
-		event.Metadata.SourceJobRunID,
-		event.Metadata.TransformationID,
-		event.Metadata.TransformationVersionID,
-		event.Metadata.TrackingPlanID,
-		event.Metadata.TrackingPlanVersion,
-		status, event.StatusCode,
-		eventName, eventType,
-	)
+	key := event.Metadata.SourceID + ":" +
+		event.Metadata.DestinationID + ":" +
+		event.Metadata.SourceJobRunID + ":" +
+		event.Metadata.TransformationID + ":" +
+		event.Metadata.TransformationVersionID + ":" +
+		event.Metadata.TrackingPlanID + ":" +
+		strconv.Itoa(event.Metadata.TrackingPlanVersion) + ":" +
+		status + ":" + strconv.Itoa(event.StatusCode) + ":" +
+		eventName + ":" + eventType
 
 	if _, ok := connectionDetailsMap[key]; !ok {
 		connectionDetailsMap[key] = &reportingtypes.ConnectionDetails{
@@ -1317,7 +1315,7 @@ func (proc *Handle) updateMetricMaps(
 	}
 	sdkeySet := map[string]struct{}{}
 	for _, ve := range event.ValidationErrors {
-		sdkey := fmt.Sprintf("%s:%d:%s:%s:%s", status, event.StatusCode, eventName, eventType, ve.Type)
+		sdkey := status + ":" + strconv.Itoa(event.StatusCode) + ":" + eventName + ":" + eventType + ":" + ve.Type
 		sdkeySet[sdkey] = struct{}{}
 
 		sd, ok := statusDetailsMap[key][sdkey]
@@ -1341,7 +1339,7 @@ func (proc *Handle) updateMetricMaps(
 	}
 
 	// create status details for a whole event
-	sdkey := fmt.Sprintf("%s:%d:%s:%s:%s", status, event.StatusCode, eventName, eventType, "")
+	sdkey := status + ":" + strconv.Itoa(event.StatusCode) + ":" + eventName + ":" + eventType + ":"
 	sd, ok := statusDetailsMap[key][sdkey]
 	if !ok {
 		sd = &reportingtypes.StatusDetail{

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -691,7 +691,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 			errorCode := getBRTErrorCode(jobState)
 			var cd *types.ConnectionDetails
 			workspaceID := job.WorkspaceId
-			key := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s", parameters.SourceID, parameters.DestinationID, parameters.SourceJobRunID, jobState, strconv.Itoa(errorCode), parameters.EventName, parameters.EventType)
+			key := parameters.SourceID + ":" + parameters.DestinationID + ":" + parameters.SourceJobRunID + ":" + jobState + ":" + strconv.Itoa(errorCode) + ":" + parameters.EventName + ":" + parameters.EventType
 			if _, ok := connectionDetailsMap[key]; !ok {
 				cd = &types.ConnectionDetails{
 					SourceID:                parameters.SourceID,

--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -620,7 +620,7 @@ func (brt *Handle) getReportMetrics(params getReportMetricsParams) []*utilTypes.
 		workspaceID := status.WorkspaceId
 		eventName := parameters.EventName
 		eventType := parameters.EventType
-		key := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s", parameters.SourceID, parameters.DestinationID, parameters.SourceJobRunID, status.JobState, status.ErrorCode, eventName, eventType)
+		key := parameters.SourceID + ":" + parameters.DestinationID + ":" + parameters.SourceJobRunID + ":" + status.JobState + ":" + status.ErrorCode + ":" + eventName + ":" + eventType
 		_, ok := connectionDetailsMap[key]
 		if !ok {
 			cd := &utilTypes.ConnectionDetails{

--- a/router/config.go
+++ b/router/config.go
@@ -5,19 +5,9 @@ import (
 )
 
 func getRouterConfigBool(key, destType string, defaultValue bool) bool {
-	destOverrideFound := config.IsSet("Router." + destType + "." + key)
-	if destOverrideFound {
-		return config.GetBool("Router."+destType+"."+key, defaultValue)
-	} else {
-		return config.GetBool("Router."+key, defaultValue)
-	}
+	return config.GetBoolVar(defaultValue, "Router."+destType+"."+key, "Router."+key)
 }
 
 func getRouterConfigInt(key, destType string, defaultValue int) int {
-	destOverrideFound := config.IsSet("Router." + destType + "." + key)
-	if destOverrideFound {
-		return config.GetInt("Router."+destType+"."+key, defaultValue)
-	} else {
-		return config.GetInt("Router."+key, defaultValue)
-	}
+	return config.GetIntVar(defaultValue, 1, "Router."+destType+"."+key, "Router."+key)
 }

--- a/router/handle.go
+++ b/router/handle.go
@@ -75,6 +75,7 @@ type Handle struct {
 	drainConcurrencyLimit              config.ValueLoader[int]
 	workerInputBufferSize              int
 	saveDestinationResponse            bool
+	saveDestinationResponseOverride    config.ValueLoader[bool]
 	reportJobsdbPayload                config.ValueLoader[bool]
 
 	diagnosisTickerTime time.Duration
@@ -350,7 +351,7 @@ func (rt *Handle) commitStatusList(workerJobStatuses *[]workerJobStatus) {
 			SourceID:      parameters.SourceID,
 			DestinationID: parameters.DestinationID,
 		}
-		key := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s", parameters.SourceID, parameters.DestinationID, parameters.SourceJobRunID, workerJobStatus.status.JobState, workerJobStatus.status.ErrorCode, eventName, eventType)
+		key := parameters.SourceID + ":" + parameters.DestinationID + ":" + parameters.SourceJobRunID + ":" + workerJobStatus.status.JobState + ":" + workerJobStatus.status.ErrorCode + ":" + eventName + ":" + eventType
 		_, ok := connectionDetailsMap[key]
 		if !ok {
 			cd := &utilTypes.ConnectionDetails{

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -109,6 +109,7 @@ func (rt *Handle) Setup(
 	rt.eventOrderDisabledStateDuration = config.GetReloadableDurationVar(20, time.Minute, "Router."+destType+".eventOrderDisabledStateDuration", "Router.eventOrderDisabledStateDuration")
 	rt.eventOrderHalfEnabledStateDuration = config.GetReloadableDurationVar(10, time.Minute, "Router."+destType+".eventOrderHalfEnabledStateDuration", "Router.eventOrderHalfEnabledStateDuration")
 	rt.reportJobsdbPayload = config.GetReloadableBoolVar(true, "Router."+destType+".reportJobsdbPayload", "Router.reportJobsdbPayload")
+	rt.saveDestinationResponseOverride = config.GetReloadableBoolVar(false, "Router."+destType+".saveDestinationResponseOverride", "Router.saveDestinationResponseOverride")
 
 	statTags := stats.Tags{"destType": rt.destType}
 	rt.tracer = stats.Default.NewTracer("router")

--- a/router/internal/eventorder/eventorder.go
+++ b/router/internal/eventorder/eventorder.go
@@ -114,7 +114,7 @@ type BarrierKey struct {
 }
 
 func (bk *BarrierKey) String() string {
-	return fmt.Sprintf("%s:%s:%s", bk.WorkspaceID, bk.DestinationID, bk.UserID)
+	return bk.WorkspaceID + ":" + bk.DestinationID + ":" + bk.UserID
 }
 
 // Enter the barrier for this key and jobID. If there is not already a barrier for this key

--- a/router/network.go
+++ b/router/network.go
@@ -254,8 +254,9 @@ func (network *netHandle) Setup(destID string, netClientTimeout time.Duration) {
 	// https://groups.google.com/forum/#!topic/golang-nuts/JmpHoAd76aU
 	// Solved in go1.8 https://github.com/golang/go/issues/26013
 	misc.Copy(&defaultTransportCopy, defaultTransportPointer)
-	network.logger.Info("forceHTTP1: ", getRouterConfigBool("forceHTTP1", destID, false))
-	if getRouterConfigBool("forceHTTP1", destID, false) {
+	forceHTTP1 := getRouterConfigBool("forceHTTP1", destID, false)
+	network.logger.Info("forceHTTP1: ", forceHTTP1)
+	if forceHTTP1 {
 		network.logger.Info("Forcing HTTP1 connection for ", destID)
 		defaultTransportCopy.ForceAttemptHTTP2 = false
 		var tlsClientConfig tls.Config

--- a/router/worker.go
+++ b/router/worker.go
@@ -870,7 +870,7 @@ func (w *worker) prepareRouterJobResponses(destinationJob types.DestinationJobT,
 	// We can override via env saveDestinationResponseOverride
 
 	for k, respStatusCode := range respStatusCodes {
-		if isSuccessStatus(respStatusCode) && !getRouterConfigBool("saveDestinationResponseOverride", w.rt.destType, false) && !w.rt.saveDestinationResponse {
+		if isSuccessStatus(respStatusCode) && !w.rt.saveDestinationResponseOverride.Load() && !w.rt.saveDestinationResponse {
 			respBodys[k] = ""
 		}
 	}

--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -28,7 +28,7 @@ type JobTargetKey struct {
 }
 
 func (k JobTargetKey) String() string {
-	return fmt.Sprintf("%s:%s:%s", k.TaskRunID, k.SourceID, k.DestinationID)
+	return k.TaskRunID + ":" + k.SourceID + ":" + k.DestinationID
 }
 
 type Stats struct {

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -567,7 +567,7 @@ func IdentityMappingsUniqueMappingConstraintName(warehouse model.Warehouse) stri
 }
 
 func GetWarehouseIdentifier(destType, sourceID, destinationID string) string {
-	return fmt.Sprintf("%s:%s:%s", destType, sourceID, destinationID)
+	return destType + ":" + sourceID + ":" + destinationID
 }
 
 func DoubleQuoteAndJoinByComma(elems []string) string {


### PR DESCRIPTION
# Description

- using plain string concatenation instead of formatted strings for critical paths
- caching and using reloadable configuration variables instead of asking for the same variable again and again in critical paths

```sh
goos: darwin
goarch: arm64
pkg: github.com/rudderlabs/rudder-server/processor
cpu: Apple M1 Pro
BenchmarkSprintfvsConcat
BenchmarkSprintfvsConcat/Sprintf
BenchmarkSprintfvsConcat/Sprintf-10         	 2810226	       430.2 ns/op	     288 B/op	      10 allocs/op
BenchmarkSprintfvsConcat/Concat
BenchmarkSprintfvsConcat/Concat-10          	 9418416	       124.6 ns/op	     147 B/op	       2 allocs/op
```

## 1. Sprintf issue in processor's updateMetricMaps
<img width="845" alt="Screenshot 2025-03-12 at 11 11 17 AM" src="https://github.com/user-attachments/assets/1aaa3f52-e3e9-4cdf-8ca9-167f6dd1d336" />

## 2. Router's prepareRouterJobResponses spending too much time for resolving configuration
<img width="845" alt="Screenshot 2025-03-12 at 11 29 13 AM" src="https://github.com/user-attachments/assets/5bc0ec26-3b46-4b7c-b177-9596b3dc05e2" />

## 3. Router & Batchrouter spending too much time on draining logic inside getRetentionTimeForDestination
<img width="845" alt="Screenshot 2025-03-12 at 11 42 33 AM" src="https://github.com/user-attachments/assets/e42abdbb-592b-44ff-ad02-966e12cec6d4" />


```go
func BenchmarkSprintfvsConcat(b *testing.B) {
	SourceID := "source_id"
	DestinationID := "destination_id"
	SourceJobRunID := "source_job_run_id"
	TransformationID := "transformation_id"
	TransformationVersionID := "transformation_version_id"
	TrackingPlanID := "tracking_plan_id"
	TrackingPlanVersion := 1
	status := "status"
	StatusCode := 200
	eventName := "event_name"
	eventType := "event_type"

	sprintf := func() string {
		return fmt.Sprintf("%s:%s:%s:%s:%s:%s:%d:%s:%d:%s:%s",
			SourceID,
			DestinationID,
			SourceJobRunID,
			TransformationID,
			TransformationVersionID,
			TrackingPlanID,
			TrackingPlanVersion,
			status,
			StatusCode,
			eventName,
			eventType,
		)
	}

	concat := func() string {
		return SourceID + ":" +
			DestinationID + ":" +
			SourceJobRunID + ":" +
			TransformationID + ":" +
			TransformationVersionID + ":" +
			TrackingPlanID + ":" +
			strconv.Itoa(TrackingPlanVersion) + ":" +
			status + ":" +
			strconv.Itoa(StatusCode) + ":" +
			eventName + ":" +
			eventType
	}

	b.Run("Sprintf", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			sprintf()
		}
	})

	b.Run("Concat", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			concat()
		}
	})
}
```

## Linear Ticket

resolves PIPE-1964

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
