### PR TITLE
chore(router): finding worker slots efficiently

### DIFF
--- a/router/handle.go
+++ b/router/handle.go
@@ -245,7 +245,8 @@ func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worke
 			firstJob = job
 		}
 		lastJob = job
-		workerJobSlot, err := rt.findWorkerSlot(ctx, workers, job, blockedOrderKeys)
+		destinationID := gjson.GetBytes(job.Parameters, "destination_id").String()
+		workerJobSlot, err := rt.findWorkerSlot(ctx, workers, job, destinationID, blockedOrderKeys)
 		if err == nil {
 			traceParent := gjson.GetBytes(job.Parameters, "traceparent").String()
 			if traceParent != "" {
@@ -254,7 +255,7 @@ func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worke
 					_, span := rt.tracer.Start(ctx, "rt.pickup", stats.SpanKindConsumer, stats.SpanWithTags(stats.Tags{
 						"workspaceId":   job.WorkspaceId,
 						"sourceId":      gjson.GetBytes(job.Parameters, "source_id").String(),
-						"destinationId": gjson.GetBytes(job.Parameters, "destination_id").String(),
+						"destinationId": destinationID,
 						"destType":      rt.destType,
 					}))
 					traces[traceParent] = span
@@ -555,31 +556,24 @@ type workerJobSlot struct {
 	drainReason string
 }
 
-func (rt *Handle) findWorkerSlot(ctx context.Context, workers []*worker, job *jobsdb.JobT, blockedOrderKeys map[eventorder.BarrierKey]struct{}) (*workerJobSlot, error) {
+func (rt *Handle) findWorkerSlot(ctx context.Context, workers []*worker, job *jobsdb.JobT, destinationID string, blockedOrderKeys map[eventorder.BarrierKey]struct{}) (*workerJobSlot, error) {
 	if rt.backgroundCtx.Err() != nil {
 		return nil, types.ErrContextCancelled
 	}
-
-	var parameters routerutils.JobParameters
-	if err := jsonrs.Unmarshal(job.Parameters, &parameters); err != nil {
-		rt.logger.Errorf(`[%v Router] :: Unmarshalling parameters failed with the error %v . Returning nil worker`, err)
-		return nil, types.ErrParamsUnmarshal
-	}
-
 	orderKey := eventorder.BarrierKey{
 		UserID:        job.UserID,
-		DestinationID: parameters.DestinationID,
+		DestinationID: destinationID,
 		WorkspaceID:   job.WorkspaceId,
 	}
 
 	eventOrderingDisabled := !rt.guaranteeUserEventOrder
 	if (rt.guaranteeUserEventOrder && rt.barrier.Disabled(orderKey)) ||
 		(rt.eventOrderingDisabledForWorkspace(job.WorkspaceId) ||
-			rt.eventOrderingDisabledForDestination(parameters.DestinationID)) {
+			rt.eventOrderingDisabledForDestination(destinationID)) {
 		eventOrderingDisabled = true
 		stats.Default.NewTaggedStat("router_eventorder_key_disabled", stats.CountType, stats.Tags{
 			"destType":      rt.destType,
-			"destinationId": parameters.DestinationID,
+			"destinationId": destinationID,
 			"workspaceID":   job.WorkspaceId,
 		}).Increment()
 	}
@@ -600,7 +594,7 @@ func (rt *Handle) findWorkerSlot(ctx context.Context, workers []*worker, job *jo
 			slot.Release()
 			return nil, types.ErrJobBackoff
 		}
-		if rt.shouldThrottle(ctx, job, parameters) {
+		if rt.shouldThrottle(ctx, job, destinationID) {
 			slot.Release()
 			return nil, types.ErrDestinationThrottled
 		}
@@ -638,7 +632,7 @@ func (rt *Handle) findWorkerSlot(ctx context.Context, workers []*worker, job *jo
 		return nil, types.ErrBarrierExists
 	}
 	rt.logger.Debugf("EventOrder: job %d of orderKey %s is allowed to be processed", job.JobID, orderKey)
-	if !abortedJob && rt.shouldThrottle(ctx, job, parameters) {
+	if !abortedJob && rt.shouldThrottle(ctx, job, destinationID) {
 		blockedOrderKeys[orderKey] = struct{}{}
 		worker.barrier.Leave(orderKey, job.JobID)
 		slot.Release()
@@ -694,20 +688,20 @@ func (*Handle) shouldBackoff(job *jobsdb.JobT) bool {
 	return job.LastJobStatus.JobState == jobsdb.Failed.State && job.LastJobStatus.AttemptNum > 0 && time.Until(job.LastJobStatus.RetryTime) > 0
 }
 
-func (rt *Handle) shouldThrottle(ctx context.Context, job *jobsdb.JobT, parameters routerutils.JobParameters) (limited bool) {
+func (rt *Handle) shouldThrottle(ctx context.Context, job *jobsdb.JobT, destinationID string) (limited bool) {
 	if rt.throttlerFactory == nil {
 		// throttlerFactory could be nil when throttling is disabled or misconfigured.
 		// in case of misconfiguration, logging errors are emitted.
 		rt.logger.Debugf(`[%v Router] :: ThrottlerFactory is nil. Not throttling destination with ID %s`,
-			rt.destType, parameters.DestinationID,
+			rt.destType, destinationID,
 		)
 		return false
 	}
 
-	throttler := rt.throttlerFactory.Get(rt.destType, parameters.DestinationID)
+	throttler := rt.throttlerFactory.Get(rt.destType, destinationID)
 	throttlingCost := rt.getThrottlingCost(job)
 
-	limited, err := throttler.CheckLimitReached(ctx, parameters.DestinationID, throttlingCost)
+	limited, err := throttler.CheckLimitReached(ctx, destinationID, throttlingCost)
 	if err != nil {
 		// we can't throttle, let's hit the destination, worst case we get a 429
 		rt.throttlingErrorStat.Count(1)

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -142,11 +142,13 @@ func (rt *Handle) Setup(
 		panic(fmt.Errorf("resolving isolation strategy for mode %q: %w", isolationMode, err))
 	}
 
+	orderingDisabledWorkspaceIDs := config.GetReloadableStringSliceVar(nil, "Router.orderingDisabledWorkspaceIDs")
 	rt.eventOrderingDisabledForWorkspace = func(workspaceID string) bool {
-		return slices.Contains(config.GetStringSlice("Router.orderingDisabledWorkspaceIDs", nil), workspaceID)
+		return slices.Contains(orderingDisabledWorkspaceIDs.Load(), workspaceID)
 	}
+	orderingDisabledDestinationIDs := config.GetReloadableStringSliceVar(nil, "Router.orderingDisabledDestinationIDs")
 	rt.eventOrderingDisabledForDestination = func(destinationID string) bool {
-		return slices.Contains(config.GetStringSlice("Router.orderingDisabledDestinationIDs", nil), destinationID)
+		return slices.Contains(orderingDisabledDestinationIDs.Load(), destinationID)
 	}
 	rt.barrier = eventorder.NewBarrier(eventorder.WithMetadata(map[string]string{
 		"destType":         rt.destType,

--- a/router/types/types.go
+++ b/router/types/types.go
@@ -143,8 +143,6 @@ func (e *EventTypeThrottlingCost) Cost(eventType string) (cost int64) {
 var (
 	// ErrContextCancelled is returned when the context is cancelled
 	ErrContextCancelled = errors.New("context cancelled")
-	// ErrParamsUnmarshal is returned when it is not possible to unmarshal the job parameters
-	ErrParamsUnmarshal = errors.New("unmarshal params")
 	// ErrJobOrderBlocked is returned when the job is blocked by another job discarded by the router in the same loop
 	ErrJobOrderBlocked = errors.New("blocked")
 	// ErrWorkerNoSlot is returned when the worker doesn't have an available slot


### PR DESCRIPTION
# Description

`findWorkerSlot` cpu breakdown:
- 14% unmarshalling parameters for getting destination id
- 12% resolving `Router.orderingDisabledWorkspaceIDs` configuration option
- 12% resolving `Router.orderingDisabledDestinationIDs` configuration option
- 53% calling `drainOrRetryLimitReached` (addressing this in #5591 )
- 9% other

We are eliminating the time for the first 3 bullets by:
1. reading destination id only once and skipping unmarshalling
2. using cached reloadable configuration variables

<img width="1474" alt="Screenshot 2025-03-12 at 1 51 15 PM" src="https://github.com/user-attachments/assets/9b6b0c60-baa6-4295-a164-300ecd0c735f" />

## Linear Ticket

resolves PIPE-1966

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
