### PR TITLE
fix: warehouse transformations for empty array and map

### DIFF
--- a/warehouse/transformer/internal/utils/utils.go
+++ b/warehouse/transformer/internal/utils/utils.go
@@ -155,6 +155,10 @@ func IsBlank(value interface{}) bool {
 		return v == ""
 	case fmt.Stringer:
 		return v.String() == ""
+	case map[string]any:
+		return len(v) == 0
+	case []any:
+		return len(v) == 0
 	default:
 		return false
 	}

--- a/warehouse/transformer/internal/utils/utils_test.go
+++ b/warehouse/transformer/internal/utils/utils_test.go
@@ -132,10 +132,10 @@ func TestIsBlank(t *testing.T) {
 		{"FloatNonZero", 123.45, false},                             // non-zero float
 		{"BoolFalse", false, false},                                 // boolean false
 		{"BoolTrue", true, false},                                   // boolean true
-		{"EmptySlice", []int{}, false},                              // empty slice
-		{"NonEmptySlice", []int{1, 2, 3}, false},                    // non-empty slice
-		{"EmptyMap", map[string]int{}, false},                       // empty map
-		{"NonEmptyMap", map[string]int{"key": 1}, false},            // non-empty map
+		{"EmptySlice", []any{}, true},                               // empty slice
+		{"NonEmptySlice", []any{1, 2, 3}, false},                    // non-empty slice
+		{"EmptyMap", map[string]any{}, true},                        // empty map
+		{"NonEmptyMap", map[string]any{"key": 1}, false},            // non-empty map
 		{"EmptyStruct", struct{}{}, false},                          // empty struct
 		{"StructWithField", struct{ Field string }{"value"}, false}, // non-empty struct
 		{"StructWithMethod", Person{Name: "Alice", Age: 30}, false}, // struct with String method

--- a/warehouse/transformer/transformer_test.go
+++ b/warehouse/transformer/transformer_test.go
@@ -557,6 +557,26 @@ func TestTransformer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:         "Empty array and object",
+			eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4", "empty_array":[],"empty_object":{},"nil":null}}`,
+			metadata:     getTrackMetadata("POSTGRES", "webhook"),
+			destination:  getDestination("POSTGRES", map[string]any{}),
+			expectedResponse: types.Response{
+				Events: []types.TransformerResponse{
+					{
+						Output:     trackDefaultOutput(),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+					{
+						Output:     trackEventDefaultOutput(),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

- Handle warehouse transformations for empty array and map. These should not be included in the response.
- This is what we see in the debug logs files.
```
  types.TransformerResponse{
  	Output: map[string]any{
  		"data": map[string]any{
- 			"companies_data":        []any{},
- 			"notes_data":                               []any{},
- 			"opted_out_subscription_types_data":        []any{},
- 			"social_profiles_data": []any{},
- 			"tags_data":            []any{},
  		},
  		"metadata": map[string]any{
  			"columns": map[string]any{
- 				"companies_data":        string("string"),
- 				"notes_data":                               string("string"),
- 				"opted_out_subscription_types_data":        string("string"),
- 				"social_profiles_data": string("string"),
- 				"tags_data":            string("string"),
  			},
  			"receivedAt": string("2025-03-14T03:55:48.631Z"),
  			"table":      string("rudder_contacts"),
  		},
  		"userId": string(""),
  	},
  }
```

## Linear Ticket

- Resolves WAR-404.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
