### PR TITLE
fix: sonnet panic while unmarshalling float64 types

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,6 +83,6 @@ linters-settings:
             desc: 'use "slices" instead'
           - pkg: "github.com/json-iterator/go"
             desc: 'use "jsonrs" instead'
-          - pkg: "github.com/sugawarayuuta/sonnet"
+          - pkg: "github.com/rudderlabs/sonnet"
             desc: 'use "jsonrs" instead'
 

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/rudderlabs/rudder-observability-kit v0.0.4
 	github.com/rudderlabs/rudder-schemas v0.5.4
 	github.com/rudderlabs/rudder-transformer/go v0.0.0-20240910055720-f77d2ab4125a
+	github.com/rudderlabs/sonnet v1.0.2
 	github.com/rudderlabs/sql-tunnels v0.1.7
 	github.com/rudderlabs/sqlconnect-go v1.18.0
 	github.com/samber/lo v1.49.1
@@ -94,7 +95,6 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/spf13/cast v1.7.1
 	github.com/stretchr/testify v1.10.0
-	github.com/sugawarayuuta/sonnet v0.0.0-20231004000330-239c7b6e4ce8
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/trinodb/trino-go-client v0.322.0
@@ -118,16 +118,6 @@ require (
 )
 
 require (
-	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
-	github.com/apache/arrow-go/v18 v18.1.0 // indirect
-	github.com/dgraph-io/ristretto/v2 v2.1.0 // indirect
-	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
-	github.com/minio/crc64nvme v1.0.1 // indirect
-	github.com/spf13/viper v1.19.0 // indirect
-	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-)
-
-require (
 	cel.dev/expr v0.19.2 // indirect
 	cloud.google.com/go v0.119.0 // indirect
 	cloud.google.com/go/auth v0.15.0 // indirect
@@ -145,6 +135,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
+	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
 	github.com/DataDog/zstd v1.5.6 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.51.0 // indirect
@@ -154,6 +145,7 @@ require (
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/actgardner/gogen-avro/v10 v10.2.1 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
+	github.com/apache/arrow-go/v18 v18.1.0 // indirect
 	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect
 	github.com/apache/arrow/go/v12 v12.0.1 // indirect
 	github.com/apache/arrow/go/v15 v15.0.2 // indirect
@@ -194,6 +186,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgraph-io/ristretto/v2 v2.1.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dnephin/pflag v1.0.7 // indirect
 	github.com/docker/cli v27.2.1+incompatible // indirect
@@ -202,6 +195,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dvsekhvalnov/jose2go v1.7.0 // indirect
+	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/fatih/color v1.18.0 // indirect
@@ -265,6 +259,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
+	github.com/minio/crc64nvme v1.0.1 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
@@ -302,6 +297,7 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/spf13/viper v1.19.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/throttled/throttled/v2 v2.13.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
@@ -322,6 +318,7 @@ require (
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.19 // indirect
 	go.opencensus.io v0.24.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.34.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.59.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1187,6 +1187,8 @@ github.com/rudderlabs/rudder-schemas v0.5.4 h1:QzI6vIC38W0jGJu6E0vdwh4IAtSKx8ziq
 github.com/rudderlabs/rudder-schemas v0.5.4/go.mod h1:oypQtew1d2jBGJdFMT4zf1XOvXgGEcNPtRFy6vRDAv8=
 github.com/rudderlabs/rudder-transformer/go v0.0.0-20240910055720-f77d2ab4125a h1:OZcvpApxEYNkB9UNXrKDUBufQ24Lsr2Cs0pw70tzXBw=
 github.com/rudderlabs/rudder-transformer/go v0.0.0-20240910055720-f77d2ab4125a/go.mod h1:3NGitPz4pYRRZ6Xt09S+8hb0tHK/9pZcKJ3OgOTaSmE=
+github.com/rudderlabs/sonnet v1.0.2 h1:nPfmDKD9gUwT571Dwtcsx0VIglSchvyNjuRLju4Xs3s=
+github.com/rudderlabs/sonnet v1.0.2/go.mod h1:tjQmKEGAo/xwmhw9AwLkazP5b5m8VpUvWNzPSx4ve0g=
 github.com/rudderlabs/sql-tunnels v0.1.7 h1:wDCRl6zY4M5gfWazf7XkSTGQS3yjBzUiUgEMBIfHNDA=
 github.com/rudderlabs/sql-tunnels v0.1.7/go.mod h1:5f7+YL49JHYgteP4rAgqKnr4K2OadB0oIpUS+Tt3sPM=
 github.com/rudderlabs/sqlconnect-go v1.18.0 h1:6+xHWBlxvC8tZosII2/m35x3RSyLZiDA31S45eHtp78=
@@ -1283,8 +1285,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/sugawarayuuta/sonnet v0.0.0-20231004000330-239c7b6e4ce8 h1:u+kxnRXxx+0O5SiefP3oTt4jeeIx+rYf1jkdW2qd2Ss=
-github.com/sugawarayuuta/sonnet v0.0.0-20231004000330-239c7b6e4ce8/go.mod h1:6M53rd6DvbzoLbFnL3bjCsDSkCYh4i2yqW04hxr1/5o=
 github.com/testcontainers/testcontainers-go v0.33.0 h1:zJS9PfXYT5O0ZFXM2xxXfk4J5UMw/kRiISng037Gxdw=
 github.com/testcontainers/testcontainers-go v0.33.0/go.mod h1:W80YpTa8D5C3Yy16icheD01UTDu+LmXIA2Keo+jWtT8=
 github.com/testcontainers/testcontainers-go/modules/compose v0.33.0 h1:PyrUOF+zG+xrS3p+FesyVxMI+9U+7pwhZhyFozH3jKY=

--- a/jsonrs/json.go
+++ b/jsonrs/json.go
@@ -9,7 +9,7 @@ import (
 const (
 	// StdLib is the JSON implementation of package/json.
 	StdLib = "std"
-	// SonnetLib is the JSON implementation of github.com/sugawarayuuta/sonnet.
+	// SonnetLib is the JSON implementation of github.com/rudderlabs/sonnet.
 	SonnetLib = "sonnet"
 	// JsoniterLib is the JSON implementation of github.com/json-iterator/go.
 	JsoniterLib = "jsoniter"

--- a/jsonrs/json_fuzz_test.go
+++ b/jsonrs/json_fuzz_test.go
@@ -1,0 +1,152 @@
+package jsonrs_test
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	trand "github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+	"github.com/rudderlabs/rudder-server/jsonrs"
+)
+
+func FuzzSonnet(f *testing.F) {
+	fuzzScenario(jsonrs.SonnetLib, f)
+}
+
+func FuzzJsoniter(f *testing.F) {
+	fuzzScenario(jsonrs.JsoniterLib, f)
+}
+
+type Scenario struct {
+	StringValue string
+	UintValue   uint64
+	IntValue    int64
+	FloatValue  float64
+	BoolValue   bool
+}
+
+func fuzzScenario(name string, f *testing.F) {
+	j := jsonrs.NewWithLibrary(name)
+
+	seed := []Scenario{
+		{}, // zero values
+		{StringValue: "hello", UintValue: 1, IntValue: 1, FloatValue: 0.1, BoolValue: true},
+		{StringValue: "foo", UintValue: math.MaxUint64, IntValue: math.MaxInt64, FloatValue: math.MaxFloat64},
+		{StringValue: "bar", UintValue: math.MaxUint32, IntValue: math.MaxInt32, FloatValue: float64(math.MaxFloat32)},
+		{StringValue: `{"key": "string containing json"}`, UintValue: math.MaxUint16, IntValue: math.MaxInt16, FloatValue: float64(math.SmallestNonzeroFloat64)},
+		{StringValue: "!@#$%^", UintValue: math.MaxUint8, IntValue: math.MaxInt8, FloatValue: float64(math.SmallestNonzeroFloat64)},
+		{StringValue: trand.String(10000), FloatValue: 3.4028235e+38},
+		{FloatValue: -26413875975788446000},
+		{FloatValue: 1.1e3},
+		{FloatValue: 1.1e-2},
+	}
+
+	for _, s := range seed {
+		f.Add(s.FloatValue, s.IntValue, s.UintValue, s.StringValue, s.BoolValue)
+	}
+
+	f.Fuzz(func(t *testing.T, float64Value float64, int64Value int64, uint64Value uint64, stringValue string, boolValue bool) {
+		if math.IsInf(float64Value, 0) || math.IsNaN(float64Value) {
+			float64Value = 0
+		}
+		verify(t, name, j, float64Value)          // float64
+		verifyAsFloat32(t, name, j, float64Value) // float64 as float32
+		verify(t, name, j, float32(float64Value)) // float32
+		verify(t, name, j, any(float64Value))     // float64 as any
+
+		verify(t, name, j, int64Value)        // int64
+		verify(t, name, j, int32(int64Value)) // int32
+		verify(t, name, j, int16(int64Value)) // int16
+		verify(t, name, j, int8(int64Value))  // int8
+		verify(t, name, j, int(int64Value))   // int
+		verify(t, name, j, any(int64Value))   // int64 as any
+
+		verify(t, name, j, uint64Value)         // uint64
+		verify(t, name, j, uint32(uint64Value)) // uint32
+		verify(t, name, j, uint16(uint64Value)) // uint16
+		verify(t, name, j, uint8(uint64Value))  // uint8
+		verify(t, name, j, uint(uint64Value))   // uint
+		verify(t, name, j, any(uint64Value))    // uint64 as any
+
+		verify(t, name, j, stringValue)      // string
+		verify(t, name, j, any(stringValue)) // string as any
+
+		verify(t, name, j, boolValue)      // bool
+		verify(t, name, j, any(boolValue)) // bool as any
+
+		s := Scenario{
+			StringValue: stringValue,
+			UintValue:   uint64Value,
+			IntValue:    int64Value,
+			FloatValue:  float64Value,
+			BoolValue:   boolValue,
+		}
+		verify(t, name, j, s) // struct
+		verify(t, name, j, any(s))
+
+		m := map[string]any{
+			"stringValue": stringValue,
+			"uint":        uint64Value,
+			"int":         int64Value,
+			"float":       float64Value,
+			"bool":        boolValue,
+			"struct":      s,
+		}
+
+		verify(t, name, j, m) // map[string]any
+
+		verify(t, name, j, any(m)) // map[string]any as any
+
+		verify(t, name, j, []any{m, m})      // slice
+		verify(t, name, j, any([]any{m, m})) // slice as any
+	})
+}
+
+func verify[T any](t *testing.T, libName string, j jsonrs.JSON, value T) {
+	std := jsonrs.NewWithLibrary(jsonrs.StdLib)
+	valueType := reflect.TypeOf(value)
+
+	jsonValue, err := std.Marshal(value)
+	if err != nil {
+		_, jerr := j.Marshal(value)
+		require.Errorf(t, jerr, "%s shouldn't be able to marshal %s that std lib cannot marshal: %v, err: %v", valueType, value, err)
+		return
+	}
+	require.NoErrorf(t, std.Unmarshal(jsonValue, &value), "std json library should be able to unmarshal %q to %s", string(jsonValue), valueType)
+
+	// Marshal with library
+	libJsonValue, err := j.Marshal(value)
+	require.NoErrorf(t, err, "%s should be able to marshal %s: %v", libName, valueType, value)
+	require.JSONEqf(t, string(jsonValue), string(libJsonValue), "unexpected marshal result for %v", value)
+
+	// Unmarshal with library
+	var libValue T
+	err = j.Unmarshal(jsonValue, &libValue)
+	require.NoErrorf(t, err, "%s should be able to unmarshal %q to %s (std unmarshalled to: %v)", libName, string(jsonValue), valueType, value)
+
+	require.EqualValues(t, value, libValue, "unexpected unmarshal result for %v", value)
+}
+
+func verifyAsFloat32(t *testing.T, libName string, j jsonrs.JSON, value float64) {
+	if math.IsInf(value, 0) || math.IsNaN(value) {
+		return
+	}
+	std := jsonrs.NewWithLibrary(jsonrs.StdLib)
+	jsonValue, err := std.Marshal(value)
+
+	var f32Std float32
+	err1 := std.Unmarshal(jsonValue, &f32Std)
+	var f32Lib float32
+	err2 := j.Unmarshal(jsonValue, &f32Lib)
+
+	if err1 != nil {
+		require.Errorf(t, err2, "%s shouldn't be able to unmarshal %f that std lib cannot unmarshal: %v, err: %v", libName, value, err1)
+		return
+	} else {
+		require.NoErrorf(t, err2, "%s should be able to unmarshal %q to float32: %v", libName, jsonValue, err2)
+	}
+
+	require.NoError(t, err)
+}

--- a/jsonrs/sonnet.go
+++ b/jsonrs/sonnet.go
@@ -4,10 +4,11 @@ import (
 	"io"
 
 	jsoniter "github.com/json-iterator/go"
-	"github.com/sugawarayuuta/sonnet"
+
+	"github.com/rudderlabs/sonnet"
 )
 
-// sonnetJSON is the JSON implementation of github.com/sugawarayuuta/sonnet.
+// sonnetJSON is the JSON implementation of github.com/rudderlabs/sonnet.
 type sonnetJSON struct{}
 
 func (j *sonnetJSON) Marshal(v any) ([]byte, error) {


### PR DESCRIPTION
# Description

Issue raised against upstream repository: https://github.com/sugawarayuuta/sonnet/issues/14 

Until issues in upstream are resolved, we'll be using our own fork

Summary of issues:

- fast path for unmarshalling floats was unreliable, i.e. it could either panic or parse wrong float ([fix](https://github.com/rudderlabs/sonnet/commit/7713358c8f1700f017c9e68882df2ec380c303fa))
- issue in marshalling float32 numbers at the boundaries ([fix](https://github.com/rudderlabs/sonnet/commit/c6531aaf3eb5b9fab5e71909ef12720471f7093a))


Adding fuzzing scenarios for all json types, covering both libraries that we are using (`sonnet` & `jsoniter`) and verifying them against the reference `std` json library.

## Linear Ticket

resolves PIPE-1972

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
