### PR TITLE
chore: badger configuration tuning

### DIFF
--- a/enterprise/reporting/event_sampler/badger_event_sampler.go
+++ b/enterprise/reporting/event_sampler/badger_event_sampler.go
@@ -62,7 +62,7 @@ func NewBadgerEventSampler(
 		WithLogger(badgerLogger{log}).
 		WithCompression(options.None).
 		WithIndexCacheSize(conf.GetInt64Var(10*bytesize.MB, 1, "BadgerDB.EventSampler.indexCacheSize", "BadgerDB.indexCacheSize")).
-		WithValueLogFileSize(conf.GetInt64Var(16*bytesize.MB, 1, "BadgerDB.EventSampler.valueLogFileSize", "BadgerDB.valueLogFileSize")).
+		WithValueLogFileSize(conf.GetInt64Var(1*bytesize.MB, 1, "BadgerDB.EventSampler.valueLogFileSize", "BadgerDB.valueLogFileSize")).
 		WithBlockSize(conf.GetIntVar(int(4*bytesize.KB), 1, "BadgerDB.EventSampler.blockSize", "BadgerDB.blockSize")).
 		WithMemTableSize(conf.GetInt64Var(1*bytesize.MB, 1, "BadgerDB.EventSampler.memTableSize", "BadgerDB.memTableSize")).
 		WithNumMemtables(conf.GetIntVar(5, 1, "BadgerDB.EventSampler.numMemtable", "BadgerDB.numMemtable")).

--- a/enterprise/reporting/event_sampler/badger_event_sampler.go
+++ b/enterprise/reporting/event_sampler/badger_event_sampler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dgraph-io/badger/v4"
 	"github.com/dgraph-io/badger/v4/options"
 
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
@@ -59,16 +60,22 @@ func NewBadgerEventSampler(
 	opts := badger.DefaultOptions(dbPath).
 		WithLogger(badgerLogger{log}).
 		WithCompression(options.None).
-		WithIndexCacheSize(16 << 20). // 16mb
-		WithNumGoroutines(1).
-		WithBlockCacheSize(0).
-		WithNumVersionsToKeep(1).
-		WithNumMemtables(conf.GetInt("Reporting.eventSampling.badgerDB.numMemtable", 5)).
-		WithValueThreshold(conf.GetInt64("Reporting.eventSampling.badgerDB.valueThreshold", 1048576)).
-		WithNumLevelZeroTables(conf.GetInt("Reporting.eventSampling.badgerDB.numLevelZeroTables", 5)).
-		WithNumLevelZeroTablesStall(conf.GetInt("Reporting.eventSampling.badgerDB.numLevelZeroTablesStall", 15)).
-		WithSyncWrites(conf.GetBool("Reporting.eventSampling.badgerDB.syncWrites", false)).
-		WithDetectConflicts(conf.GetBool("Reporting.eventSampling.badgerDB.detectConflicts", false))
+		WithIndexCacheSize(conf.GetInt64Var(10*bytesize.MB, 1, "BadgerDB.EventSampler.indexCacheSize", "BadgerDB.indexCacheSize")).
+		WithValueLogFileSize(conf.GetInt64Var(16*bytesize.MB, 1, "BadgerDB.EventSampler.valueLogFileSize", "BadgerDB.valueLogFileSize")).
+		WithBlockSize(conf.GetIntVar(int(4*bytesize.KB), 1, "BadgerDB.EventSampler.blockSize", "BadgerDB.blockSize")).
+		WithMemTableSize(conf.GetInt64Var(1*bytesize.MB, 1, "BadgerDB.EventSampler.memTableSize", "BadgerDB.memTableSize")).
+		WithNumMemtables(conf.GetIntVar(5, 1, "BadgerDB.EventSampler.numMemtable", "BadgerDB.numMemtable")).
+		WithNumLevelZeroTables(conf.GetIntVar(5, 1, "BadgerDB.EventSampler.numLevelZeroTables", "BadgerDB.numLevelZeroTables")).
+		WithNumLevelZeroTablesStall(conf.GetIntVar(10, 1, "BadgerDB.EventSampler.numLevelZeroTablesStall", "BadgerDB.numLevelZeroTablesStall")).
+		WithBaseTableSize(conf.GetInt64Var(200*bytesize.KB, 1, "BadgerDB.EventSampler.baseTableSize", "BadgerDB.baseTableSize")).
+		WithBaseLevelSize(conf.GetInt64Var(1*bytesize.MB, 1, "BadgerDB.EventSampler.baseLevelSize", "BadgerDB.baseLevelSize")).
+		WithLevelSizeMultiplier(conf.GetIntVar(10, 1, "BadgerDB.EventSampler.levelSizeMultiplier", "BadgerDB.levelSizeMultiplier")).
+		WithMaxLevels(conf.GetIntVar(7, 1, "BadgerDB.EventSampler.maxLevels", "BadgerDB.maxLevels")).
+		WithNumCompactors(conf.GetIntVar(4, 1, "BadgerDB.EventSampler.numCompactors", "BadgerDB.numCompactors")).
+		WithValueThreshold(conf.GetInt64Var(10*bytesize.B, 1, "BadgerDB.EventSampler.valueThreshold", "BadgerDB.valueThreshold")).
+		WithSyncWrites(conf.GetBoolVar(false, "BadgerDB.EventSampler.syncWrites", "BadgerDB.syncWrites")).
+		WithBlockCacheSize(conf.GetInt64Var(0, 1, "BadgerDB.EventSampler.blockCacheSize", "BadgerDB.blockCacheSize")).
+		WithDetectConflicts(conf.GetBoolVar(false, "BadgerDB.EventSampler.detectConflicts", "BadgerDB.detectConflicts"))
 
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -135,7 +142,7 @@ func (es *BadgerEventSampler) Put(key string) error {
 	es.sc.RecordPut()
 
 	return es.db.Update(func(txn *badger.Txn) error {
-		entry := badger.NewEntry([]byte(key), []byte{1}).WithTTL(es.ttl.Load())
+		entry := badger.NewEntry([]byte(key), nil).WithTTL(es.ttl.Load())
 		return txn.SetEntry(entry)
 	})
 }

--- a/enterprise/reporting/event_sampler/event_sampler_test.go
+++ b/enterprise/reporting/event_sampler/event_sampler_test.go
@@ -2,6 +2,8 @@ package event_sampler
 
 import (
 	"context"
+	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -109,7 +111,7 @@ func TestBadgerDirCleanup(t *testing.T) {
 	require.True(t, found)
 	badger.Close()
 
-	// start badger again with same config
+	// start badger again
 	badger, err = NewEventSampler(context.Background(),
 		config.SingleValueLoader(time.Hour),
 		config.SingleValueLoader(string(BadgerTypeEventSampler)),
@@ -124,7 +126,9 @@ func TestBadgerDirCleanup(t *testing.T) {
 	require.True(t, found, "since directory was not cleaned up the previous key should be found")
 	badger.Close()
 
-	// start badger again with different config
+	// corrupt KEYREGISTRY file
+	require.NoError(t, os.WriteFile(path.Join(dbPath, "module-badger", "KEYREGISTRY"), []byte("corrupted"), 0o644))
+	// start badger again
 	conf.Set("BadgerDB.memTableSize", 2*bytesize.MB)
 	badger, err = NewEventSampler(context.Background(),
 		config.SingleValueLoader(time.Hour),

--- a/enterprise/reporting/event_sampler/event_sampler_test.go
+++ b/enterprise/reporting/event_sampler/event_sampler_test.go
@@ -142,6 +142,24 @@ func TestBadgerDirCleanup(t *testing.T) {
 	found, err = badger.Get("a")
 	require.NoError(t, err)
 	require.False(t, found, "since directory was cleaned up the previous key should not be found")
+	err = badger.Put("a")
+	require.NoError(t, err)
+	badger.Close()
+
+	// cleanup on startup
+	conf.Set("BadgerDB.cleanupOnStartup", true)
+	badger, err = NewEventSampler(context.Background(),
+		config.SingleValueLoader(time.Hour),
+		config.SingleValueLoader(string(BadgerTypeEventSampler)),
+		config.SingleValueLoader(100),
+		"module",
+		conf,
+		logger.NOP,
+		stats.NOP)
+	require.NoError(t, err)
+	found, err = badger.Get("a")
+	require.NoError(t, err)
+	require.False(t, found, "since directory was cleaned up the previous key should not be found")
 	badger.Close()
 }
 

--- a/services/dedup/badger/badger.go
+++ b/services/dedup/badger/badger.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"sync"
 	"time"
 
@@ -138,41 +137,22 @@ func (d *BadgerDB) Close() {
 
 func (d *BadgerDB) init() error {
 	var err error
-
 	d.once.Do(func() {
-		// cleanup the badger db directory if the badger version file value changes
-		{
-			badgerVersionFileValue := fmt.Sprintf("%d-%d-%d", d.opts.MemTableSize, d.opts.BlockSize, d.opts.BaseTableSize)
-			badgerVersionFilePath := path.Join(d.path, ".rudder-version")
-			createDirWithVersionFile := func() error {
-				if err = os.MkdirAll(d.opts.Dir, 0o755); err != nil {
-					return fmt.Errorf("creating badger db directory: %w", err)
-				}
-				if err = os.WriteFile(badgerVersionFilePath, []byte(badgerVersionFileValue), 0o644); err != nil {
-					return fmt.Errorf("writing badger version file: %w", err)
-				}
-				return nil
-			}
-			// create the directory if it doesn't exist
-			if _, err = os.Stat(d.opts.Dir); errors.Is(err, os.ErrNotExist) {
-				if err = createDirWithVersionFile(); err != nil {
-					return
-				}
-			}
-			// check if the version file exists
-			if previous, _ := os.ReadFile(badgerVersionFilePath); string(previous) != badgerVersionFileValue {
-				if err = os.RemoveAll(d.opts.Dir); err != nil {
-					err = fmt.Errorf("removing badger db directory: %w", err)
-					return
-				}
-				if err = createDirWithVersionFile(); err != nil {
-					return
-				}
-			}
-		}
 		d.badgerDB, err = badger.Open(d.opts)
 		if err != nil {
-			return
+			// corrupted or incompatible db, clean up the directory and retry
+			d.logger.Errorn("Error while opening dedup badger db, cleaning up the directory",
+				logger.NewErrorField(err),
+			)
+			if err = os.RemoveAll(d.opts.Dir); err != nil {
+				err = fmt.Errorf("removing badger db directory: %w", err)
+				return
+			}
+			d.badgerDB, err = badger.Open(d.opts)
+			if err != nil {
+				err = fmt.Errorf("opening badger db: %w", err)
+				return
+			}
 		}
 		d.wg.Add(1)
 		rruntime.Go(func() {

--- a/services/dedup/badger/badger.go
+++ b/services/dedup/badger/badger.go
@@ -59,7 +59,7 @@ func NewBadgerDB(conf *config.Config, stat stats.Stats, path string) *Dedup {
 		DefaultOptions(path).
 		WithCompression(options.None).
 		WithIndexCacheSize(conf.GetInt64Var(16*bytesize.MB, 1, "BadgerDB.Dedup.indexCacheSize", "BadgerDB.indexCacheSize")).
-		WithValueLogFileSize(conf.GetInt64Var(16*bytesize.MB, 1, "BadgerDB.Dedup.valueLogFileSize", "BadgerDB.valueLogFileSize")).
+		WithValueLogFileSize(conf.GetInt64Var(1*bytesize.MB, 1, "BadgerDB.Dedup.valueLogFileSize", "BadgerDB.valueLogFileSize")).
 		WithBlockSize(conf.GetIntVar(int(4*bytesize.KB), 1, "BadgerDB.Dedup.blockSize", "BadgerDB.blockSize")).
 		WithMemTableSize(conf.GetInt64Var(20*bytesize.MB, 1, "BadgerDB.Dedup.memTableSize", "BadgerDB.memTableSize")).
 		WithNumMemtables(conf.GetIntVar(5, 1, "BadgerDB.Dedup.numMemtable", "BadgerDB.numMemtable")).

--- a/services/dedup/badger/badger_test.go
+++ b/services/dedup/badger/badger_test.go
@@ -113,6 +113,16 @@ func TestBadgerDirCleanup(t *testing.T) {
 	err = badger.Commit([]string{"a"})
 	require.NoError(t, err)
 	badger.Close()
+
+	// cleanup on startup
+	conf.Set("BadgerDB.cleanupOnStartup", true)
+	badger = NewBadgerDB(conf, stats.NOP, DefaultPath())
+	allowed, err = badger.Allowed(types.BatchKey{Key: "a"})
+	require.NoError(t, err)
+	require.True(t, allowed[types.BatchKey{Key: "a"}], "since the directory was cleaned up, the key should not be present")
+	err = badger.Commit([]string{"a"})
+	require.NoError(t, err)
+	badger.Close()
 }
 
 func TestBadgerClose(t *testing.T) {


### PR DESCRIPTION
# Description

- All badger db configuration options are now externally configurable
- Event Sampler
  - Using `nil` values
  - Using lower memory (5x1MB+10MB vs 5x64MB+16MB)
  - Using smaller memory mapped base tables (200KB instead of 2MB)
  - Using smaller level size (1MB vs 10MB)
  - Using smaller memory mapped valuefiles since we are not using them (1MB vs 1GB)
- Dedup
  - Using `nil` values
  - Using lower memory (5x20MB+16MB vs 5x64MB+16MB)
  - Using smaller memory mapped base tables (1MB instead of 2MB)
  - Using smaller level size (5MB vs 10MB)
  - Using smaller memory mapped valuefiles since we are not using them (1MB vs 1GB)

For both databases, if during startup we fail to open the database using the previous data, we are logging a warning, clearing the directory and starting badgerdb again.

## Linear Ticket

resolves OBS-805

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
