### PR TITLE
chore: clean up of version specific logic for sources

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -359,7 +359,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, options *app.Options)
 	streamMsgValidator := stream.NewMessageValidator()
 	gw := gateway.Handle{}
 	err = gw.Setup(ctx, config, logger.NewLogger().Child("gateway"), statsFactory, a.app, backendconfig.DefaultBackendConfig,
-		gatewayDB, errDBForWrite, rateLimiter, a.versionHandler, rsourcesService, transformerFeaturesService, sourceHandle,
+		gatewayDB, errDBForWrite, rateLimiter, a.versionHandler, rsourcesService, sourceHandle,
 		streamMsgValidator, gateway.WithInternalHttpHandlers(
 			map[string]http.Handler{
 				"/drain": drainConfigManager.DrainConfigHttpHandler(),

--- a/app/apphandlers/gatewayAppHandler.go
+++ b/app/apphandlers/gatewayAppHandler.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/rudderlabs/rudder-schemas/go/stream"
 
@@ -23,7 +22,6 @@ import (
 	drain_config "github.com/rudderlabs/rudder-server/internal/drain-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	sourcedebugger "github.com/rudderlabs/rudder-server/services/debugger/source"
-	"github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/types/deployment"
 )
@@ -132,11 +130,11 @@ func (a *gatewayApp) StartRudderCore(ctx context.Context, options *app.Options) 
 	if err != nil {
 		return err
 	}
-	transformerFeaturesService := transformer.NewFeaturesService(ctx, config, transformer.FeaturesServiceOptions{
-		PollInterval:             config.GetDuration("Transformer.pollInterval", 10, time.Second),
-		TransformerURL:           config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090"),
-		FeaturesRetryMaxAttempts: 10,
-	})
+	// _ = transformer.NewFeaturesService(ctx, config, transformer.FeaturesServiceOptions{
+	// 	PollInterval:             config.GetDuration("Transformer.pollInterval", 10, time.Second),
+	// 	TransformerURL:           config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090"),
+	// 	FeaturesRetryMaxAttempts: 10,
+	// })
 	drainConfigManager, err := drain_config.NewDrainConfigManager(config, a.log.Child("drain-config"), statsFactory)
 	if err != nil {
 		a.log.Errorw("drain config manager setup failed while starting gateway", "error", err)
@@ -149,7 +147,7 @@ func (a *gatewayApp) StartRudderCore(ctx context.Context, options *app.Options) 
 	}
 	streamMsgValidator := stream.NewMessageValidator()
 	err = gw.Setup(ctx, config, logger.NewLogger().Child("gateway"), statsFactory, a.app, backendconfig.DefaultBackendConfig,
-		gatewayDB, errDB, rateLimiter, a.versionHandler, rsourcesService, transformerFeaturesService, sourceHandle,
+		gatewayDB, errDB, rateLimiter, a.versionHandler, rsourcesService, sourceHandle,
 		streamMsgValidator, gateway.WithInternalHttpHandlers(
 			map[string]http.Handler{
 				"/drain": drainConfigHttpHandler,

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -54,7 +54,6 @@ import (
 	sourcedebugger "github.com/rudderlabs/rudder-server/services/debugger/source"
 	mocksrcdebugger "github.com/rudderlabs/rudder-server/services/debugger/source/mocks"
 	"github.com/rudderlabs/rudder-server/services/rsources"
-	"github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
 	testutils "github.com/rudderlabs/rudder-server/utils/tests"
@@ -282,7 +281,7 @@ var _ = Describe("Gateway Enterprise", func() {
 			Expect(err).To(BeNil())
 
 			gateway = &Handle{}
-			err = gateway.Setup(context.Background(), conf, logger.NOP, statsStore, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
+			err = gateway.Setup(context.Background(), conf, logger.NOP, statsStore, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
 			Expect(err).To(BeNil())
 
 			waitForBackendConfigInit(gateway)
@@ -417,7 +416,7 @@ var _ = Describe("Gateway", func() {
 		It("should wait for backend config", func() {
 			c.initializeAppFeatures()
 			gateway := &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.NOP, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.NOP, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 			err = gateway.Shutdown()
@@ -450,7 +449,7 @@ var _ = Describe("Gateway", func() {
 			GinkgoT().Setenv("RSERVER_GATEWAY_WEB_PORT", strconv.Itoa(serverPort))
 
 			gateway = &Handle{}
-			err = gateway.Setup(context.Background(), conf, logger.NOP, stats.NOP, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
+			err = gateway.Setup(context.Background(), conf, logger.NOP, stats.NOP, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 			gateway.irh = mockRequestHandler{}
@@ -545,7 +544,7 @@ var _ = Describe("Gateway", func() {
 			Expect(err).To(BeNil())
 
 			gateway = &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, statsStore, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
+			err := gateway.Setup(context.Background(), conf, logger.NOP, statsStore, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 		})
@@ -881,7 +880,7 @@ var _ = Describe("Gateway", func() {
 
 			gateway = &Handle{}
 
-			err := gateway.Setup(context.Background(), conf, logger.NOP, statsStore, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, c.mockRateLimiter, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
+			err := gateway.Setup(context.Background(), conf, logger.NOP, statsStore, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, c.mockRateLimiter, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 		})
@@ -988,7 +987,7 @@ var _ = Describe("Gateway", func() {
 
 			gateway = &Handle{}
 			conf.Set("Gateway.enableRateLimit", true)
-			err := gateway.Setup(context.Background(), conf, logger.NOP, statsStore, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, c.mockRateLimiter, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
+			err := gateway.Setup(context.Background(), conf, logger.NOP, statsStore, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, c.mockRateLimiter, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 		})
@@ -1082,7 +1081,7 @@ var _ = Describe("Gateway", func() {
 			Expect(err).To(BeNil())
 
 			gateway = &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, statsStore, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
+			err := gateway.Setup(context.Background(), conf, logger.NOP, statsStore, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 		})
@@ -1378,7 +1377,7 @@ var _ = Describe("Gateway", func() {
 		BeforeEach(func() {
 			c.initializeAppFeatures()
 			gateway = &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.NOP, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.NOP, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 		})
@@ -1405,7 +1404,7 @@ var _ = Describe("Gateway", func() {
 		BeforeEach(func() {
 			c.initializeAppFeatures()
 			gateway = &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.NOP, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.NOP, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 		})
@@ -1634,7 +1633,7 @@ var _ = Describe("Gateway", func() {
 		BeforeEach(func() {
 			c.initializeAppFeatures()
 			gateway = &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.NOP, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.NOP, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 		})
@@ -1793,7 +1792,7 @@ var _ = Describe("Gateway", func() {
 
 			gateway = &Handle{}
 			srcDebugger = mocksrcdebugger.NewMockSourceDebugger(c.mockCtrl)
-			err = gateway.Setup(context.Background(), conf, logger.NOP, statStore, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), srcDebugger, nil)
+			err = gateway.Setup(context.Background(), conf, logger.NOP, statStore, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), srcDebugger, nil)
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 			c.mockBackendConfig.EXPECT().WaitForConfig(gomock.Any()).AnyTimes()
@@ -2116,7 +2115,7 @@ var _ = Describe("Gateway", func() {
 		BeforeEach(func() {
 			c.initializeAppFeatures()
 			gateway = &Handle{}
-			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.NOP, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
+			err := gateway.Setup(context.Background(), conf, logger.NOP, stats.NOP, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockErrJobsDB, nil, c.mockVersionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
 			Expect(err).To(BeNil())
 			waitForBackendConfigInit(gateway)
 		})

--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -35,7 +35,6 @@ import (
 	"github.com/rudderlabs/rudder-server/services/diagnostics"
 	"github.com/rudderlabs/rudder-server/services/rsources"
 	rsources_http "github.com/rudderlabs/rudder-server/services/rsources/http"
-	"github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/utils/crash"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
@@ -55,7 +54,7 @@ func (gw *Handle) Setup(
 	config *config.Config, logger logger.Logger, stat stats.Stats,
 	application app.App, backendConfig backendconfig.BackendConfig, jobsDB, errDB jobsdb.JobsDB,
 	rateLimiter throttler.Throttler, versionHandler func(w http.ResponseWriter, r *http.Request),
-	rsourcesService rsources.JobService, transformerFeaturesService transformer.FeaturesService,
+	rsourcesService rsources.JobService,
 	sourcehandle sourcedebugger.SourceDebugger, streamMsgValidator func(message *stream.Message) error,
 	opts ...OptFunc,
 ) error {
@@ -123,7 +122,7 @@ func (gw *Handle) Setup(
 	gw.batchUserWorkerBatchRequestQ = make(chan *batchUserWorkerBatchRequestT, gw.conf.maxDBWriterProcess)
 	gw.irh = &ImportRequestHandler{Handle: gw}
 	gw.rrh = &RegularRequestHandler{Handle: gw}
-	gw.webhook = webhook.Setup(gw, transformerFeaturesService, gw.stats)
+	gw.webhook = webhook.Setup(gw, gw.stats)
 	whURL, err := url.ParseRequestURI(misc.GetWarehouseURL())
 	if err != nil {
 		return fmt.Errorf("invalid warehouse URL %s: %w", whURL, err)

--- a/gateway/webhook/integration_test.go
+++ b/gateway/webhook/integration_test.go
@@ -179,7 +179,7 @@ func TestIntegrationWebhook(t *testing.T) {
 		application,
 		backendconfigtest.NewStaticLibrary(bcs),
 		gatewayDB, errDB,
-		rateLimiter, versionHandler, rsources.NewNoOpService(), transformerFeaturesService, sourcedebugger.NewNoOpService(),
+		rateLimiter, versionHandler, rsources.NewNoOpService(), sourcedebugger.NewNoOpService(),
 		streamMsgValidator,
 		gateway.WithNow(func() time.Time {
 			return testSetup.Context.Now

--- a/gateway/webhook/webhookTransformer_test.go
+++ b/gateway/webhook/webhookTransformer_test.go
@@ -10,65 +10,16 @@ import (
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	gwtypes "github.com/rudderlabs/rudder-server/gateway/internal/types"
 	"github.com/rudderlabs/rudder-server/jsonrs"
-	"github.com/rudderlabs/rudder-server/services/transformer"
 )
-
-func TestV1Adapter(t *testing.T) {
-	t.Run("should return the right url", func(t *testing.T) {
-		v1Adapter := newSourceTransformAdapter(transformer.V1)
-		testSrcType := "testSrcType"
-		testSrcTypeLower := "testsrctype"
-
-		url, err := v1Adapter.getTransformerURL(testSrcType)
-		require.Nil(t, err)
-		require.True(t, strings.HasSuffix(url, fmt.Sprintf("/%s/sources/%s", transformer.V1, testSrcTypeLower)))
-	})
-
-	t.Run("should return the right adapter version", func(t *testing.T) {
-		v1Adapter := newSourceTransformAdapter(transformer.V1)
-		adapterVersion := v1Adapter.getAdapterVersion()
-		require.Equal(t, adapterVersion, transformer.V1)
-	})
-
-	t.Run("should return the body in v1 format", func(t *testing.T) {
-		testSrcId := "testSrcId"
-		testBody := []byte(`{"a": "testBody"}`)
-
-		mockSrc := backendconfig.SourceT{
-			ID:           testSrcId,
-			Destinations: []backendconfig.DestinationT{{ID: "testDestId"}},
-		}
-
-		v1Adapter := newSourceTransformAdapter(transformer.V1)
-
-		retBody, err := v1Adapter.getTransformerEvent(&gwtypes.AuthRequestContext{Source: mockSrc}, testBody)
-		require.Nil(t, err)
-
-		v1TransformerEvent := V1TransformerEvent{
-			EventRequest: testBody,
-			Source:       backendconfig.SourceT{ID: mockSrc.ID},
-		}
-		expectedBody, err := jsonrs.Marshal(v1TransformerEvent)
-		require.Nil(t, err)
-		require.JSONEq(t, string(expectedBody), string(retBody))
-	})
-}
 
 func TestV2Adapter(t *testing.T) {
 	t.Run("should return the right url", func(t *testing.T) {
-		v2Adapter := newSourceTransformAdapter(transformer.V2)
 		testSrcType := "testSrcType"
 		testSrcTypeLower := "testsrctype"
 
-		url, err := v2Adapter.getTransformerURL(testSrcType)
+		url, err := getTransformerURL(testSrcType)
 		require.Nil(t, err)
-		require.True(t, strings.HasSuffix(url, fmt.Sprintf("/%s/sources/%s", transformer.V2, testSrcTypeLower)))
-	})
-
-	t.Run("should return the right adapter version", func(t *testing.T) {
-		v1Adapter := newSourceTransformAdapter(transformer.V2)
-		adapterVersion := v1Adapter.getAdapterVersion()
-		require.Equal(t, adapterVersion, transformer.V2)
+		require.True(t, strings.HasSuffix(url, fmt.Sprintf("/v2/sources/%s", testSrcTypeLower)))
 	})
 
 	t.Run("should return the body in v2 format", func(t *testing.T) {
@@ -80,16 +31,14 @@ func TestV2Adapter(t *testing.T) {
 			Destinations: []backendconfig.DestinationT{{ID: "testDestId"}},
 		}
 
-		v2Adapter := newSourceTransformAdapter(transformer.V2)
-
-		retBody, err := v2Adapter.getTransformerEvent(&gwtypes.AuthRequestContext{Source: mockSrc}, testBody)
+		retBody, err := getTransformerEvent(&gwtypes.AuthRequestContext{Source: mockSrc}, testBody)
 		require.Nil(t, err)
 
-		v2TransformerEvent := V2TransformerEvent{
+		transformerEvent := TransformerEvent{
 			EventRequest: testBody,
 			Source:       backendconfig.SourceT{ID: mockSrc.ID},
 		}
-		expectedBody, err := jsonrs.Marshal(v2TransformerEvent)
+		expectedBody, err := jsonrs.Marshal(transformerEvent)
 		require.Nil(t, err)
 		require.JSONEq(t, string(expectedBody), string(retBody))
 	})

--- a/mocks/services/transformer/mock_features.go
+++ b/mocks/services/transformer/mock_features.go
@@ -67,20 +67,6 @@ func (mr *MockFeaturesServiceMockRecorder) RouterTransform(destType any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouterTransform", reflect.TypeOf((*MockFeaturesService)(nil).RouterTransform), destType)
 }
 
-// SourceTransformerVersion mocks base method.
-func (m *MockFeaturesService) SourceTransformerVersion() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SourceTransformerVersion")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// SourceTransformerVersion indicates an expected call of SourceTransformerVersion.
-func (mr *MockFeaturesServiceMockRecorder) SourceTransformerVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SourceTransformerVersion", reflect.TypeOf((*MockFeaturesService)(nil).SourceTransformerVersion))
-}
-
 // TransformerProxyVersion mocks base method.
 func (m *MockFeaturesService) TransformerProxyVersion() string {
 	m.ctrl.T.Helper()

--- a/services/transformer/features.go
+++ b/services/transformer/features.go
@@ -16,7 +16,6 @@ import (
 const (
 	V0 = "v0"
 	V1 = "v1"
-	V2 = "v2"
 )
 
 type FeaturesServiceOptions struct {
@@ -27,7 +26,6 @@ type FeaturesServiceOptions struct {
 
 type FeaturesService interface {
 	Regulations() []string
-	SourceTransformerVersion() string
 	RouterTransform(destType string) bool
 	TransformerProxyVersion() string
 	Wait() chan struct{}
@@ -38,9 +36,7 @@ var defaultTransformerFeatures = `{
 	  "MARKETO": true,
 	  "HS": true
 	},
-	"regulations": ["AM"],
-	"supportSourceTransformV1": true,
-	"upgradedToSourceTransformV2": false,
+	"regulations": ["AM"]
   }`
 
 func NewFeaturesService(ctx context.Context, config *config.Config, featConfig FeaturesServiceOptions) FeaturesService {
@@ -73,11 +69,6 @@ type noopService struct{}
 
 func (*noopService) Regulations() []string {
 	return []string{}
-}
-
-func (*noopService) SourceTransformerVersion() string {
-	// v0 is deprecated and upgrading to v2
-	return V2
 }
 
 func (*noopService) TransformerProxyVersion() string {

--- a/services/transformer/features_impl.go
+++ b/services/transformer/features_impl.go
@@ -23,20 +23,6 @@ type featuresService struct {
 	client   *http.Client
 }
 
-func (t *featuresService) SourceTransformerVersion() string {
-	// If transformer is upgraded to V2, enable V2 spec communication
-	if gjson.GetBytes(t.features, "upgradedToSourceTransformV2").Bool() {
-		return V2
-	}
-
-	// V0 Deprecation: This function will verify if `supportSourceTransformV1` is available and enabled
-	// if `supportSourceTransformV1` is not enabled, transformer is not compatible and server will panic with appropriate message.
-	if gjson.GetBytes(t.features, "supportSourceTransformV1").Bool() {
-		return V1
-	}
-	panic("Webhook source v0 version has been deprecated. This is a breaking change. Upgrade transformer version to greater than 1.50.0 for v1")
-}
-
 func (t *featuresService) TransformerProxyVersion() string {
 	if gjson.GetBytes(t.features, "supportTransformerProxyV1").Bool() {
 		return V1
@@ -122,9 +108,6 @@ func (t *featuresService) makeFeaturesFetchCall() bool {
 
 	if res.StatusCode == 200 {
 		t.features = body
-
-		//  we are calling this to see if the transformer version is deprecated. if so, we panic.
-		t.SourceTransformerVersion()
 	} else if res.StatusCode == 404 {
 		t.features = json.RawMessage(defaultTransformerFeatures)
 	}

--- a/services/transformer/features_impl_test.go
+++ b/services/transformer/features_impl_test.go
@@ -37,20 +37,6 @@ var _ = Describe("Transformer features", func() {
 			}, 2*time.Second, 10*time.Millisecond).Should(BeFalse())
 		})
 
-		It("before features are fetched, SourceTransformerVersion should return v1(default) because v0 is deprecated", func() {
-			handler := &featuresService{
-				features: json.RawMessage(defaultTransformerFeatures),
-				logger:   logger.NewLogger(),
-				waitChan: make(chan struct{}),
-				options: FeaturesServiceOptions{
-					PollInterval:             time.Duration(1),
-					FeaturesRetryMaxAttempts: 1,
-				},
-			}
-
-			Expect(handler.SourceTransformerVersion()).To(Equal(V1))
-		})
-
 		It("before features are fetched, TransformerProxyVersion should return v0", func() {
 			handler := &featuresService{
 				features: json.RawMessage(defaultTransformerFeatures),
@@ -81,7 +67,6 @@ var _ = Describe("Transformer features", func() {
 			Expect(handler.RouterTransform("ACTIVE_CAMPAIGN")).To(BeFalse())
 			Expect(handler.RouterTransform("ALGOLIA")).To(BeFalse())
 			Expect(handler.Regulations()).To(Equal([]string{"AM"}))
-			Expect(handler.SourceTransformerVersion()).To(Equal(V1))
 		})
 
 		It("if transformer returns 404, features should be same as defaultTransformerFeatures", func() {
@@ -104,61 +89,6 @@ var _ = Describe("Transformer features", func() {
 			Expect(handler.RouterTransform("ALGOLIA")).To(BeFalse())
 		})
 
-		It("If source transform is not v1, it should panic as v0 is deprecated", func() {
-			defer func() {
-				if r := recover(); r == nil {
-					Fail("The function `SourceTransformerVersion()` is supposed to panic. It did not.")
-				} else {
-					if err, ok := r.(error); ok {
-						Expect(err.Error()).To(Equal("Webhook source v0 version has been deprecated. This is a breaking change. Upgrade transformer version to greater than 1.50.0 for v1"))
-					} else {
-						Expect(r).To(Equal("Webhook source v0 version has been deprecated. This is a breaking change. Upgrade transformer version to greater than 1.50.0 for v1"))
-					}
-				}
-			}()
-
-			mockTransformerResp := `{
-				"routerTransform": {
-				  "a": true,
-				  "b": true
-				},
-				"regulations": ["AM"],
-				"supportSourceTransformV1": false,
-				"supportTransformerProxyV1": true
-			  }`
-			transformerServer := httptest.NewServer(
-				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					_, _ = w.Write([]byte(mockTransformerResp))
-				}))
-
-			featConfig := FeaturesServiceOptions{
-				PollInterval:             time.Duration(1),
-				TransformerURL:           transformerServer.URL,
-				FeaturesRetryMaxAttempts: 1,
-			}
-
-			handler := &featuresService{
-				features: json.RawMessage(defaultTransformerFeatures),
-				logger:   logger.NewLogger().Child("transformer-features"),
-				waitChan: make(chan struct{}),
-				options:  featConfig,
-				client: &http.Client{
-					Transport: &http.Transport{
-						DisableKeepAlives:   config.Default.GetBool("Transformer.Client.disableKeepAlives", true),
-						MaxConnsPerHost:     config.Default.GetInt("Transformer.Client.maxHTTPConnections", 100),
-						MaxIdleConnsPerHost: config.Default.GetInt("Transformer.Client.maxHTTPIdleConnections", 10),
-						IdleConnTimeout:     config.Default.GetDuration("Transformer.Client.maxIdleConnDuration", 30, time.Second),
-					},
-					Timeout: config.Default.GetDuration("HttpClient.processor.timeout", 30, time.Second),
-				},
-			}
-			handler.syncTransformerFeatureJson(context.TODO())
-
-			<-handler.Wait()
-
-			handler.SourceTransformerVersion()
-		})
-
 		It("Get should return features fetched from transformer", func() {
 			mockTransformerResp := `{
 				"routerTransform": {
@@ -166,7 +96,6 @@ var _ = Describe("Transformer features", func() {
 				  "b": true
 				},
 				"regulations": ["AM"],
-				"supportSourceTransformV1": true,
 				"supportTransformerProxyV1": true
 			  }`
 			transformerServer := httptest.NewServer(
@@ -186,7 +115,6 @@ var _ = Describe("Transformer features", func() {
 			Expect(handler.RouterTransform("HS")).To(BeFalse())
 			Expect(handler.RouterTransform("a")).To(BeTrue())
 			Expect(handler.RouterTransform("b")).To(BeTrue())
-			Expect(handler.SourceTransformerVersion()).To(Equal(V1)) // V1 is default (V0 is deprecated)
 			Expect(handler.TransformerProxyVersion()).To(Equal(V1))
 			Expect(handler.Regulations()).To(Equal([]string{"AM"}))
 		})


### PR DESCRIPTION
# Description

As part of webhook refactor to v2 spec project, we are cleaning up all the version specific logic (towards the end of the project) as there is no need for it now.
All communication between gateway (webhook) and transformer are done in v2 spec. There is no dependency on transformer's /features endpoint at least for version interpretation.

## Linear Ticket
Resolves INT-2757
https://linear.app/rudderstack/issue/INT-2757/stage-3-or-clean-up-or-no-more-adapters-to-convert-v2-v1-spec

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
