### PR TITLE
fix: increased archival table count alert firing after starting using dslimit

### DIFF
--- a/app/apphandlers/gatewayAppHandler.go
+++ b/app/apphandlers/gatewayAppHandler.go
@@ -34,13 +34,9 @@ type gatewayApp struct {
 	app            app.App
 	versionHandler func(w http.ResponseWriter, r *http.Request)
 	log            logger.Logger
-	config         struct {
-		gatewayDSLimit config.ValueLoader[int]
-	}
 }
 
 func (a *gatewayApp) Setup() error {
-	a.config.gatewayDSLimit = config.GetReloadableIntVar(0, 1, "Gateway.jobsDB.dsLimit", "JobsDB.dsLimit")
 	if err := rudderCoreDBValidator(); err != nil {
 		return err
 	}
@@ -82,7 +78,6 @@ func (a *gatewayApp) StartRudderCore(ctx context.Context, options *app.Options) 
 	gatewayDB := jobsdb.NewForWrite(
 		"gw",
 		jobsdb.WithClearDB(options.ClearDB),
-		jobsdb.WithDSLimit(a.config.gatewayDSLimit),
 		jobsdb.WithSkipMaintenanceErr(config.GetBool("Gateway.jobsDB.skipMaintenanceError", true)),
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(dbPool),

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -49,11 +49,13 @@ type processorApp struct {
 	versionHandler func(w http.ResponseWriter, r *http.Request)
 	log            logger.Logger
 	config         struct {
-		processorDSLimit   config.ValueLoader[int]
-		routerDSLimit      config.ValueLoader[int]
-		batchRouterDSLimit config.ValueLoader[int]
-		gatewayDSLimit     config.ValueLoader[int]
-		http               struct {
+		procErrorDSLimit config.ValueLoader[int]
+		eschDSLimit      config.ValueLoader[int]
+		arcDSLimit       config.ValueLoader[int]
+		rtDSLimit        config.ValueLoader[int]
+		batchrtDSLimit   config.ValueLoader[int]
+		gwDSLimit        config.ValueLoader[int]
+		http             struct {
 			ReadTimeout       time.Duration
 			ReadHeaderTimeout time.Duration
 			WriteTimeout      time.Duration
@@ -71,10 +73,12 @@ func (a *processorApp) Setup() error {
 	a.config.http.IdleTimeout = config.GetDurationVar(720, time.Second, []string{"IdleTimeout", "IdleTimeoutInSec"}...)
 	a.config.http.webPort = config.GetIntVar(8086, 1, "Processor.webPort")
 	a.config.http.MaxHeaderBytes = config.GetIntVar(524288, 1, "MaxHeaderBytes")
-	a.config.processorDSLimit = config.GetReloadableIntVar(0, 1, "Processor.jobsDB.dsLimit", "JobsDB.dsLimit")
-	a.config.gatewayDSLimit = config.GetReloadableIntVar(0, 1, "Gateway.jobsDB.dsLimit", "JobsDB.dsLimit")
-	a.config.routerDSLimit = config.GetReloadableIntVar(0, 1, "Router.jobsDB.dsLimit", "JobsDB.dsLimit")
-	a.config.batchRouterDSLimit = config.GetReloadableIntVar(0, 1, "BatchRouter.jobsDB.dsLimit", "JobsDB.dsLimit")
+	a.config.gwDSLimit = config.GetReloadableIntVar(0, 1, "JobsDB.gw.dsLimit", "Gateway.jobsDB.dsLimit", "JobsDB.dsLimit")
+	a.config.rtDSLimit = config.GetReloadableIntVar(0, 1, "JobsDB.rt.dsLimit", "Router.jobsDB.dsLimit", "JobsDB.dsLimit")
+	a.config.batchrtDSLimit = config.GetReloadableIntVar(0, 1, "JobsDB.batch_rt.dsLimit", "BatchRouter.jobsDB.dsLimit", "JobsDB.dsLimit")
+	a.config.procErrorDSLimit = config.GetReloadableIntVar(0, 1, "JobsDB.proc_error.dsLimit", "Processor.jobsDB.dsLimit", "JobsDB.dsLimit")
+	a.config.eschDSLimit = config.GetReloadableIntVar(0, 1, "JobsDB.esch.dsLimit", "Processor.jobsDB.dsLimit", "JobsDB.dsLimit")
+	a.config.arcDSLimit = config.GetReloadableIntVar(0, 1, "JobsDB.arc.dsLimit", "Processor.jobsDB.dsLimit", "JobsDB.dsLimit")
 	if err := rudderCoreDBValidator(); err != nil {
 		return err
 	}
@@ -159,7 +163,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 	gwDBForProcessor := jobsdb.NewForRead(
 		"gw",
 		jobsdb.WithClearDB(options.ClearDB),
-		jobsdb.WithDSLimit(a.config.gatewayDSLimit),
+		jobsdb.WithDSLimit(a.config.gwDSLimit),
 		jobsdb.WithSkipMaintenanceErr(config.GetBool("Gateway.jobsDB.skipMaintenanceError", true)),
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(dbPool),
@@ -168,7 +172,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 	routerDB := jobsdb.NewForReadWrite(
 		"rt",
 		jobsdb.WithClearDB(options.ClearDB),
-		jobsdb.WithDSLimit(a.config.routerDSLimit),
+		jobsdb.WithDSLimit(a.config.rtDSLimit),
 		jobsdb.WithSkipMaintenanceErr(config.GetBool("Router.jobsDB.skipMaintenanceError", false)),
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(dbPool),
@@ -177,7 +181,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 	batchRouterDB := jobsdb.NewForReadWrite(
 		"batch_rt",
 		jobsdb.WithClearDB(options.ClearDB),
-		jobsdb.WithDSLimit(a.config.batchRouterDSLimit),
+		jobsdb.WithDSLimit(a.config.batchrtDSLimit),
 		jobsdb.WithSkipMaintenanceErr(config.GetBool("BatchRouter.jobsDB.skipMaintenanceError", false)),
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(dbPool),
@@ -186,7 +190,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 	errDBForRead := jobsdb.NewForRead(
 		"proc_error",
 		jobsdb.WithClearDB(options.ClearDB),
-		jobsdb.WithDSLimit(a.config.processorDSLimit),
+		jobsdb.WithDSLimit(a.config.procErrorDSLimit),
 		jobsdb.WithSkipMaintenanceErr(config.GetBool("Processor.jobsDB.skipMaintenanceError", false)),
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(dbPool),
@@ -207,7 +211,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 	schemaDB := jobsdb.NewForReadWrite(
 		"esch",
 		jobsdb.WithClearDB(options.ClearDB),
-		jobsdb.WithDSLimit(a.config.processorDSLimit),
+		jobsdb.WithDSLimit(a.config.eschDSLimit),
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(dbPool),
 	)
@@ -216,7 +220,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 	archivalDB := jobsdb.NewForReadWrite(
 		"arc",
 		jobsdb.WithClearDB(options.ClearDB),
-		jobsdb.WithDSLimit(a.config.processorDSLimit),
+		jobsdb.WithDSLimit(a.config.arcDSLimit),
 		jobsdb.WithSkipMaintenanceErr(config.GetBool("Processor.jobsDB.skipMaintenanceError", false)),
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithJobMaxAge(

--- a/archiver/archiver.go
+++ b/archiver/archiver.go
@@ -39,6 +39,7 @@ type archiver struct {
 		minWorkerSleep   time.Duration
 		uploadFrequency  time.Duration
 		enabled          func() bool
+		customVal        string
 	}
 }
 
@@ -57,11 +58,7 @@ func New(
 
 		archiveFrom: "gw",
 		archiveTrigger: func() <-chan time.Time {
-			return time.After(c.GetDuration(
-				"archival.ArchiveSleepDuration",
-				30,
-				time.Second,
-			))
+			return time.After(c.GetDuration("archival.ArchiveSleepDuration", 30, time.Second))
 		},
 		adaptivePayloadLimitFunc: func(i int64) int64 { return i },
 	}
@@ -87,6 +84,7 @@ func New(
 	a.config.instanceID = c.GetString("INSTANCE_ID", "1")
 	a.config.minWorkerSleep = c.GetDuration("archival.MinWorkerSleep", 1, time.Minute)
 	a.config.uploadFrequency = c.GetDuration("archival.UploadFrequency", 5, time.Minute)
+	a.config.customVal = c.GetString("Gateway.CustomVal", "GW")
 
 	for _, opt := range opts {
 		opt(a)
@@ -151,6 +149,7 @@ func (a *archiver) Start() error {
 
 				queryParams := &jobsdb.GetQueryParams{
 					ParameterFilters: []jobsdb.ParameterFilterT{{Name: "source_id", Value: sourceID}},
+					CustomValFilters: []string{a.config.customVal},
 				}
 				w.queryParams = *queryParams
 

--- a/archiver/archiver_test.go
+++ b/archiver/archiver_test.go
@@ -54,6 +54,7 @@ func TestJobsArchival(t *testing.T) {
 	c.Set("DB.port", postgresResource.Port)
 	c.Set("DB.user", postgresResource.User)
 	c.Set("DB.password", postgresResource.Password)
+	c.Set("Gateway.CustomVal", "MOCKDS")
 	misc.Init()
 
 	jd := jobsdb.NewForReadWrite("archiver", jobsdb.WithClearDB(false), jobsdb.WithConfig(c), jobsdb.WithStats(stats.NOP))

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -887,7 +887,7 @@ func (jd *Handle) workersAndAuxSetup() {
 
 	var defaultLogCacheBranchInvalidation bool
 	switch jd.tablePrefix {
-	case "gw", "rt", "batch_rt":
+	case "gw", "rt", "batch_rt", "arc":
 		defaultLogCacheBranchInvalidation = true
 	}
 	jd.noResultsCache = cache.NewNoResultsCache(


### PR DESCRIPTION
# Description

Archival jobsdb cache was keep getting invalidated, due to usage of incomplete job status (missing `workspaceID` & `jobParameters`) and query conditions (missing `customVal` filter). As such, a low dsLimit was causing the archiver worker to keep querying the same tables again and again, leading to table pileup.

Additional items:
- Using separate configuration options for each jobsdb's dsLimit
- Giving precedence to more sensible configuration option names, `JobsDB.<tableprefix>.dsLimit`
- Logging a warning whenever a full branch of arc jobsdb's cache is being invalidated

**Note:** for archival we should use a `dsLimit` closer to the value we are using for `batch_rt` (12), since we are picking 100K jobs on every loop.

## Linear Ticket

resolves PIPE-1988

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
