### PR TITLE
chore: post v2 webhook cleanup

### DIFF
--- a/gateway/webhook/integration_test.go
+++ b/gateway/webhook/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -50,17 +49,6 @@ import (
 	"github.com/rudderlabs/rudder-transformer/go/webhook/testcases"
 )
 
-var webhookVersion string
-
-func init() {
-	flag.StringVar(&webhookVersion, "webhookversion", "v1", "webhook version: v1 or v2 (v0 is deprecated)")
-}
-
-func TestMain(m *testing.M) {
-	flag.Parse()
-	os.Exit(m.Run())
-}
-
 func TestIntegrationWebhook(t *testing.T) {
 	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
@@ -84,11 +72,7 @@ func TestIntegrationWebhook(t *testing.T) {
 	})
 
 	g.Go(func() (err error) {
-		if webhookVersion == "v2" {
-			transformerContainer, err = transformertest.Setup(pool, t, transformertest.WithEnv("UPGRADED_TO_SOURCE_TRANSFORM_V2=true"))
-		} else {
-			transformerContainer, err = transformertest.Setup(pool, t)
-		}
+		transformerContainer, err = transformertest.Setup(pool, t, transformertest.WithEnv("UPGRADED_TO_SOURCE_TRANSFORM_V2=true"))
 		if err != nil {
 			return fmt.Errorf("starting transformer: %w", err)
 		}
@@ -326,47 +310,33 @@ func TestIntegrationWebhook(t *testing.T) {
 			for i, p := range tc.Output.ErrQueue {
 				var errPayload []byte
 				// expected error payload stored in errDB is dependant on the webhook transformation version
-				if webhookVersion == "v1" {
-					errPayload, err = jsonrs.Marshal(struct {
-						Event  json.RawMessage       `json:"event"`
-						Source backendconfig.SourceT `json:"source"`
-					}{
-						Source: sConfig,
-						Event:  bytes.ReplaceAll(p, []byte(`{{.WriteKey}}`), []byte(sConfig.WriteKey)),
-					})
-				} else {
-					var requestPayload *requesttojson.RequestJSON
-					var requestPayloadBytes []byte
 
-					// set defaults assigned by go http client
-					req.Body = io.NopCloser(bytes.NewReader(p))
-					req.Method = "POST"
-					req.Proto = "HTTP/1.1"
-					req.Header.Set("Accept-Encoding", "gzip")
-					req.Header.Set("Content-Length", strconv.Itoa(len(p)))
-					req.Header.Set("User-Agent", "Go-http-client/1.1")
+				var requestPayload *requesttojson.RequestJSON
+				var requestPayloadBytes []byte
 
-					requestPayload, err = requesttojson.RequestToJSON(req, "{}")
-					requestPayloadBytes, err = jsonrs.Marshal(requestPayload)
+				// set defaults assigned by go http client
+				req.Body = io.NopCloser(bytes.NewReader(p))
+				req.Method = "POST"
+				req.Proto = "HTTP/1.1"
+				req.Header.Set("Accept-Encoding", "gzip")
+				req.Header.Set("Content-Length", strconv.Itoa(len(p)))
+				req.Header.Set("User-Agent", "Go-http-client/1.1")
 
-					errPayload, err = jsonrs.Marshal(struct {
-						Request json.RawMessage       `json:"request"`
-						Source  backendconfig.SourceT `json:"source"`
-					}{
-						Source: sConfig,
-						// Event:  bytes.ReplaceAll(p, []byte(`{{.WriteKey}}`), []byte(sConfig.WriteKey)),
-						Request: requestPayloadBytes,
-					})
-				}
+				requestPayload, err = requesttojson.RequestToJSON(req, "{}")
+				requestPayloadBytes, err = jsonrs.Marshal(requestPayload)
+
+				errPayload, err = jsonrs.Marshal(struct {
+					Request json.RawMessage       `json:"request"`
+					Source  backendconfig.SourceT `json:"source"`
+				}{
+					Source: sConfig,
+					// Event:  bytes.ReplaceAll(p, []byte(`{{.WriteKey}}`), []byte(sConfig.WriteKey)),
+					Request: requestPayloadBytes,
+				})
+
 				require.NoError(t, err)
 				errPayload, err = sjson.SetBytes(errPayload, "source.Destinations", nil)
 				require.NoError(t, err)
-
-				errPayloadWriteKey := gjson.GetBytes(p, "query_parameters.writeKey").Value()
-				if errPayloadWriteKey != nil && webhookVersion == "v1" {
-					r.Jobs[i].EventPayload, err = sjson.SetBytes(r.Jobs[i].EventPayload, "event.query_parameters.writeKey", errPayloadWriteKey)
-					require.NoError(t, err)
-				}
 
 				assert.JSONEq(t, string(errPayload), string(r.Jobs[i].EventPayload))
 			}

--- a/gateway/webhook/setup.go
+++ b/gateway/webhook/setup.go
@@ -95,7 +95,7 @@ func Setup(gwHandle Gateway, transformerFeaturesService transformer.FeaturesServ
 					case <-ctx.Done():
 						return nil, ctx.Err()
 					case <-transformerFeaturesService.Wait():
-						return newSourceTransformAdapter(transformerFeaturesService.SourceTransformerVersion()), nil
+						return &adapter{}, nil
 					}
 				},
 			}

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -27,7 +27,6 @@ import (
 	"github.com/rudderlabs/rudder-server/gateway/response"
 	"github.com/rudderlabs/rudder-server/gateway/webhook/model"
 	"github.com/rudderlabs/rudder-server/jsonrs"
-	"github.com/rudderlabs/rudder-server/services/transformer"
 )
 
 type webhookT struct {
@@ -310,13 +309,8 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 		var webRequests []*webhookT
 		for _, req := range breq.batchRequest {
 			var payload []byte
-			var eventRequest []byte
 
-			if sourceTransformAdapter.getAdapterVersion() == transformer.V1 {
-				eventRequest, err = prepareTransformerEventRequestV1(req.request, breq.sourceType, bt.webhook.config.sourceListForParsingParams)
-			} else {
-				eventRequest, err = prepareTransformerEventRequestV2(req.request)
-			}
+			eventRequest, err := prepareTransformerRequestBody(req.request)
 
 			if err == nil && !json.Valid(eventRequest) {
 				err = errors.New(response.InvalidJSON)

--- a/gateway/webhook/webhookTransformer.go
+++ b/gateway/webhook/webhookTransformer.go
@@ -8,11 +8,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"slices"
 	"strings"
 	"time"
-
-	"github.com/tidwall/sjson"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/requesttojson"
@@ -20,7 +17,6 @@ import (
 	gwtypes "github.com/rudderlabs/rudder-server/gateway/internal/types"
 	"github.com/rudderlabs/rudder-server/gateway/response"
 	"github.com/rudderlabs/rudder-server/jsonrs"
-	"github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/utils/httputil"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
@@ -28,60 +24,19 @@ import (
 type sourceTransformAdapter interface {
 	getTransformerEvent(authCtx *gwtypes.AuthRequestContext, eventRequest []byte) ([]byte, error)
 	getTransformerURL(sourceType string) (string, error)
-	getAdapterVersion() string
 }
 
-// ----- v1 adapter ---------
+type adapter struct{}
 
-type v1Adapter struct{}
-
-type V1TransformerEvent struct {
-	EventRequest json.RawMessage       `json:"event"`
-	Source       backendconfig.SourceT `json:"source"`
-}
-
-func (v1 *v1Adapter) getTransformerEvent(authCtx *gwtypes.AuthRequestContext, eventRequest []byte) ([]byte, error) {
-	source := authCtx.Source
-
-	v1TransformerEvent := V1TransformerEvent{
-		EventRequest: eventRequest,
-		Source: backendconfig.SourceT{
-			ID:               source.ID,
-			OriginalID:       source.OriginalID,
-			Name:             source.Name,
-			SourceDefinition: source.SourceDefinition,
-			Config:           source.Config,
-			Enabled:          source.Enabled,
-			WorkspaceID:      source.WorkspaceID,
-			WriteKey:         source.WriteKey,
-			Transient:        source.Transient,
-		},
-	}
-
-	return jsonrs.Marshal(v1TransformerEvent)
-}
-
-func (v1 *v1Adapter) getTransformerURL(sourceType string) (string, error) {
-	return getTransformerURL(transformer.V1, sourceType)
-}
-
-func (v1 *v1Adapter) getAdapterVersion() string {
-	return transformer.V1
-}
-
-// ----- v2 adapter -----
-
-type v2Adapter struct{}
-
-type V2TransformerEvent struct {
+type TransformerEvent struct {
 	EventRequest json.RawMessage       `json:"request"`
 	Source       backendconfig.SourceT `json:"source"`
 }
 
-func (v2 *v2Adapter) getTransformerEvent(authCtx *gwtypes.AuthRequestContext, eventRequest []byte) ([]byte, error) {
+func (adp *adapter) getTransformerEvent(authCtx *gwtypes.AuthRequestContext, eventRequest []byte) ([]byte, error) {
 	source := authCtx.Source
 
-	v2TransformerEvent := V2TransformerEvent{
+	transformerEvent := TransformerEvent{
 		EventRequest: eventRequest,
 		Source: backendconfig.SourceT{
 			ID:               source.ID,
@@ -96,59 +51,15 @@ func (v2 *v2Adapter) getTransformerEvent(authCtx *gwtypes.AuthRequestContext, ev
 		},
 	}
 
-	return jsonrs.Marshal(v2TransformerEvent)
+	return jsonrs.Marshal(transformerEvent)
 }
 
-func (v2 *v2Adapter) getTransformerURL(sourceType string) (string, error) {
-	return getTransformerURL(transformer.V2, sourceType)
-}
-
-func (v2 *v2Adapter) getAdapterVersion() string {
-	return transformer.V2
-}
-
-// ------------------------------
-
-func newSourceTransformAdapter(version string) sourceTransformAdapter {
-	// V0 Deprecation: this function returns v1 adapter by default, thereby deprecating v0
-	if version == transformer.V2 {
-		return &v2Adapter{}
-	}
-	return &v1Adapter{}
-}
-
-// --- utilities -----
-
-func getTransformerURL(version, sourceType string) (string, error) {
+func (adp *adapter) getTransformerURL(sourceType string) (string, error) {
 	baseURL := config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
-	return url.JoinPath(baseURL, version, "sources", strings.ToLower(sourceType))
+	return url.JoinPath(baseURL, "v2", "sources", strings.ToLower(sourceType))
 }
 
-func prepareTransformerEventRequestV1(req *http.Request, sourceType string, sourceListForParsingParams []string) ([]byte, error) {
-	defer func() {
-		if req.Body != nil {
-			_ = req.Body.Close()
-		}
-	}()
-
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, errors.New(response.RequestBodyReadFailed)
-	}
-
-	if len(body) == 0 {
-		body = []byte("{}") // If body is empty, set it to an empty JSON object
-	}
-
-	if slices.Contains(sourceListForParsingParams, strings.ToLower(sourceType)) {
-		queryParams := req.URL.Query()
-		return sjson.SetBytes(body, "query_parameters", queryParams)
-	}
-
-	return body, nil
-}
-
-func prepareTransformerEventRequestV2(req *http.Request) ([]byte, error) {
+func prepareTransformerRequestBody(req *http.Request) ([]byte, error) {
 	requestJson, err := requesttojson.RequestToJSON(req, "{}")
 	if err != nil {
 		return nil, err

--- a/gateway/webhook/webhookTransformer_test.go
+++ b/gateway/webhook/webhookTransformer_test.go
@@ -10,65 +10,17 @@ import (
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	gwtypes "github.com/rudderlabs/rudder-server/gateway/internal/types"
 	"github.com/rudderlabs/rudder-server/jsonrs"
-	"github.com/rudderlabs/rudder-server/services/transformer"
 )
 
-func TestV1Adapter(t *testing.T) {
+func TestAdapter(t *testing.T) {
 	t.Run("should return the right url", func(t *testing.T) {
-		v1Adapter := newSourceTransformAdapter(transformer.V1)
+		adp := &adapter{}
 		testSrcType := "testSrcType"
 		testSrcTypeLower := "testsrctype"
 
-		url, err := v1Adapter.getTransformerURL(testSrcType)
+		url, err := adp.getTransformerURL(testSrcType)
 		require.Nil(t, err)
-		require.True(t, strings.HasSuffix(url, fmt.Sprintf("/%s/sources/%s", transformer.V1, testSrcTypeLower)))
-	})
-
-	t.Run("should return the right adapter version", func(t *testing.T) {
-		v1Adapter := newSourceTransformAdapter(transformer.V1)
-		adapterVersion := v1Adapter.getAdapterVersion()
-		require.Equal(t, adapterVersion, transformer.V1)
-	})
-
-	t.Run("should return the body in v1 format", func(t *testing.T) {
-		testSrcId := "testSrcId"
-		testBody := []byte(`{"a": "testBody"}`)
-
-		mockSrc := backendconfig.SourceT{
-			ID:           testSrcId,
-			Destinations: []backendconfig.DestinationT{{ID: "testDestId"}},
-		}
-
-		v1Adapter := newSourceTransformAdapter(transformer.V1)
-
-		retBody, err := v1Adapter.getTransformerEvent(&gwtypes.AuthRequestContext{Source: mockSrc}, testBody)
-		require.Nil(t, err)
-
-		v1TransformerEvent := V1TransformerEvent{
-			EventRequest: testBody,
-			Source:       backendconfig.SourceT{ID: mockSrc.ID},
-		}
-		expectedBody, err := jsonrs.Marshal(v1TransformerEvent)
-		require.Nil(t, err)
-		require.JSONEq(t, string(expectedBody), string(retBody))
-	})
-}
-
-func TestV2Adapter(t *testing.T) {
-	t.Run("should return the right url", func(t *testing.T) {
-		v2Adapter := newSourceTransformAdapter(transformer.V2)
-		testSrcType := "testSrcType"
-		testSrcTypeLower := "testsrctype"
-
-		url, err := v2Adapter.getTransformerURL(testSrcType)
-		require.Nil(t, err)
-		require.True(t, strings.HasSuffix(url, fmt.Sprintf("/%s/sources/%s", transformer.V2, testSrcTypeLower)))
-	})
-
-	t.Run("should return the right adapter version", func(t *testing.T) {
-		v1Adapter := newSourceTransformAdapter(transformer.V2)
-		adapterVersion := v1Adapter.getAdapterVersion()
-		require.Equal(t, adapterVersion, transformer.V2)
+		require.True(t, strings.HasSuffix(url, fmt.Sprintf("/v2/sources/%s", testSrcTypeLower)))
 	})
 
 	t.Run("should return the body in v2 format", func(t *testing.T) {
@@ -80,16 +32,16 @@ func TestV2Adapter(t *testing.T) {
 			Destinations: []backendconfig.DestinationT{{ID: "testDestId"}},
 		}
 
-		v2Adapter := newSourceTransformAdapter(transformer.V2)
+		v2Adapter := &adapter{}
 
 		retBody, err := v2Adapter.getTransformerEvent(&gwtypes.AuthRequestContext{Source: mockSrc}, testBody)
 		require.Nil(t, err)
 
-		v2TransformerEvent := V2TransformerEvent{
+		transformerEvent := TransformerEvent{
 			EventRequest: testBody,
 			Source:       backendconfig.SourceT{ID: mockSrc.ID},
 		}
-		expectedBody, err := jsonrs.Marshal(v2TransformerEvent)
+		expectedBody, err := jsonrs.Marshal(transformerEvent)
 		require.Nil(t, err)
 		require.JSONEq(t, string(expectedBody), string(retBody))
 	})

--- a/mocks/services/transformer/mock_features.go
+++ b/mocks/services/transformer/mock_features.go
@@ -67,20 +67,6 @@ func (mr *MockFeaturesServiceMockRecorder) RouterTransform(destType any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouterTransform", reflect.TypeOf((*MockFeaturesService)(nil).RouterTransform), destType)
 }
 
-// SourceTransformerVersion mocks base method.
-func (m *MockFeaturesService) SourceTransformerVersion() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SourceTransformerVersion")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// SourceTransformerVersion indicates an expected call of SourceTransformerVersion.
-func (mr *MockFeaturesServiceMockRecorder) SourceTransformerVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SourceTransformerVersion", reflect.TypeOf((*MockFeaturesService)(nil).SourceTransformerVersion))
-}
-
 // TransformerProxyVersion mocks base method.
 func (m *MockFeaturesService) TransformerProxyVersion() string {
 	m.ctrl.T.Helper()

--- a/services/transformer/features.go
+++ b/services/transformer/features.go
@@ -16,7 +16,6 @@ import (
 const (
 	V0 = "v0"
 	V1 = "v1"
-	V2 = "v2"
 )
 
 type FeaturesServiceOptions struct {
@@ -27,7 +26,6 @@ type FeaturesServiceOptions struct {
 
 type FeaturesService interface {
 	Regulations() []string
-	SourceTransformerVersion() string
 	RouterTransform(destType string) bool
 	TransformerProxyVersion() string
 	Wait() chan struct{}
@@ -38,9 +36,7 @@ var defaultTransformerFeatures = `{
 	  "MARKETO": true,
 	  "HS": true
 	},
-	"regulations": ["AM"],
-	"supportSourceTransformV1": true,
-	"upgradedToSourceTransformV2": false,
+	"regulations": ["AM"]
   }`
 
 func NewFeaturesService(ctx context.Context, config *config.Config, featConfig FeaturesServiceOptions) FeaturesService {
@@ -73,11 +69,6 @@ type noopService struct{}
 
 func (*noopService) Regulations() []string {
 	return []string{}
-}
-
-func (*noopService) SourceTransformerVersion() string {
-	// v0 is deprecated and upgrading to v2
-	return V2
 }
 
 func (*noopService) TransformerProxyVersion() string {

--- a/services/transformer/features_impl.go
+++ b/services/transformer/features_impl.go
@@ -23,20 +23,6 @@ type featuresService struct {
 	client   *http.Client
 }
 
-func (t *featuresService) SourceTransformerVersion() string {
-	// If transformer is upgraded to V2, enable V2 spec communication
-	if gjson.GetBytes(t.features, "upgradedToSourceTransformV2").Bool() {
-		return V2
-	}
-
-	// V0 Deprecation: This function will verify if `supportSourceTransformV1` is available and enabled
-	// if `supportSourceTransformV1` is not enabled, transformer is not compatible and server will panic with appropriate message.
-	if gjson.GetBytes(t.features, "supportSourceTransformV1").Bool() {
-		return V1
-	}
-	panic("Webhook source v0 version has been deprecated. This is a breaking change. Upgrade transformer version to greater than 1.50.0 for v1")
-}
-
 func (t *featuresService) TransformerProxyVersion() string {
 	if gjson.GetBytes(t.features, "supportTransformerProxyV1").Bool() {
 		return V1
@@ -122,9 +108,6 @@ func (t *featuresService) makeFeaturesFetchCall() bool {
 
 	if res.StatusCode == 200 {
 		t.features = body
-
-		//  we are calling this to see if the transformer version is deprecated. if so, we panic.
-		t.SourceTransformerVersion()
 	} else if res.StatusCode == 404 {
 		t.features = json.RawMessage(defaultTransformerFeatures)
 	}

--- a/services/transformer/features_impl_test.go
+++ b/services/transformer/features_impl_test.go
@@ -37,20 +37,6 @@ var _ = Describe("Transformer features", func() {
 			}, 2*time.Second, 10*time.Millisecond).Should(BeFalse())
 		})
 
-		It("before features are fetched, SourceTransformerVersion should return v1(default) because v0 is deprecated", func() {
-			handler := &featuresService{
-				features: json.RawMessage(defaultTransformerFeatures),
-				logger:   logger.NewLogger(),
-				waitChan: make(chan struct{}),
-				options: FeaturesServiceOptions{
-					PollInterval:             time.Duration(1),
-					FeaturesRetryMaxAttempts: 1,
-				},
-			}
-
-			Expect(handler.SourceTransformerVersion()).To(Equal(V1))
-		})
-
 		It("before features are fetched, TransformerProxyVersion should return v0", func() {
 			handler := &featuresService{
 				features: json.RawMessage(defaultTransformerFeatures),
@@ -81,7 +67,6 @@ var _ = Describe("Transformer features", func() {
 			Expect(handler.RouterTransform("ACTIVE_CAMPAIGN")).To(BeFalse())
 			Expect(handler.RouterTransform("ALGOLIA")).To(BeFalse())
 			Expect(handler.Regulations()).To(Equal([]string{"AM"}))
-			Expect(handler.SourceTransformerVersion()).To(Equal(V1))
 		})
 
 		It("if transformer returns 404, features should be same as defaultTransformerFeatures", func() {
@@ -104,61 +89,6 @@ var _ = Describe("Transformer features", func() {
 			Expect(handler.RouterTransform("ALGOLIA")).To(BeFalse())
 		})
 
-		It("If source transform is not v1, it should panic as v0 is deprecated", func() {
-			defer func() {
-				if r := recover(); r == nil {
-					Fail("The function `SourceTransformerVersion()` is supposed to panic. It did not.")
-				} else {
-					if err, ok := r.(error); ok {
-						Expect(err.Error()).To(Equal("Webhook source v0 version has been deprecated. This is a breaking change. Upgrade transformer version to greater than 1.50.0 for v1"))
-					} else {
-						Expect(r).To(Equal("Webhook source v0 version has been deprecated. This is a breaking change. Upgrade transformer version to greater than 1.50.0 for v1"))
-					}
-				}
-			}()
-
-			mockTransformerResp := `{
-				"routerTransform": {
-				  "a": true,
-				  "b": true
-				},
-				"regulations": ["AM"],
-				"supportSourceTransformV1": false,
-				"supportTransformerProxyV1": true
-			  }`
-			transformerServer := httptest.NewServer(
-				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					_, _ = w.Write([]byte(mockTransformerResp))
-				}))
-
-			featConfig := FeaturesServiceOptions{
-				PollInterval:             time.Duration(1),
-				TransformerURL:           transformerServer.URL,
-				FeaturesRetryMaxAttempts: 1,
-			}
-
-			handler := &featuresService{
-				features: json.RawMessage(defaultTransformerFeatures),
-				logger:   logger.NewLogger().Child("transformer-features"),
-				waitChan: make(chan struct{}),
-				options:  featConfig,
-				client: &http.Client{
-					Transport: &http.Transport{
-						DisableKeepAlives:   config.Default.GetBool("Transformer.Client.disableKeepAlives", true),
-						MaxConnsPerHost:     config.Default.GetInt("Transformer.Client.maxHTTPConnections", 100),
-						MaxIdleConnsPerHost: config.Default.GetInt("Transformer.Client.maxHTTPIdleConnections", 10),
-						IdleConnTimeout:     config.Default.GetDuration("Transformer.Client.maxIdleConnDuration", 30, time.Second),
-					},
-					Timeout: config.Default.GetDuration("HttpClient.processor.timeout", 30, time.Second),
-				},
-			}
-			handler.syncTransformerFeatureJson(context.TODO())
-
-			<-handler.Wait()
-
-			handler.SourceTransformerVersion()
-		})
-
 		It("Get should return features fetched from transformer", func() {
 			mockTransformerResp := `{
 				"routerTransform": {
@@ -166,7 +96,6 @@ var _ = Describe("Transformer features", func() {
 				  "b": true
 				},
 				"regulations": ["AM"],
-				"supportSourceTransformV1": true,
 				"supportTransformerProxyV1": true
 			  }`
 			transformerServer := httptest.NewServer(
@@ -186,7 +115,6 @@ var _ = Describe("Transformer features", func() {
 			Expect(handler.RouterTransform("HS")).To(BeFalse())
 			Expect(handler.RouterTransform("a")).To(BeTrue())
 			Expect(handler.RouterTransform("b")).To(BeTrue())
-			Expect(handler.SourceTransformerVersion()).To(Equal(V1)) // V1 is default (V0 is deprecated)
 			Expect(handler.TransformerProxyVersion()).To(Equal(V1))
 			Expect(handler.Regulations()).To(Equal([]string{"AM"}))
 		})


### PR DESCRIPTION
# Description

As part of webhook refactor to v2 spec project, we are cleaning up all the version specific logic (towards the end of the project) as there is no need for it now.
All communication between gateway (webhook) and transformer are done in v2 spec. There is no dependency on transformer's /features endpoint at least for version interpretation.

## Linear Ticket
Resolves INT-2757
https://linear.app/rudderstack/issue/INT-2757/stage-3-or-clean-up-or-no-more-adapters-to-convert-v2-v1-spec

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
