### PR TITLE
fix: warehouse transformations for data_warehouse json paths

### DIFF
--- a/warehouse/transformer/events.go
+++ b/warehouse/transformer/events.go
@@ -397,7 +397,9 @@ func (t *Transformer) usersResponse(tec *transformEventContext, commonData map[s
 }
 
 func shouldSkipUsersTable(tec *transformEventContext) bool {
-	return tec.event.Metadata.DestinationType == whutils.SnowpipeStreaming || tec.destOpts.skipUsersTable || tec.intrOpts.skipUsersTable
+	return tec.event.Metadata.DestinationType == whutils.SnowpipeStreaming ||
+		tec.destOpts.skipUsersTable ||
+		tec.intrOpts.skipUsersTable
 }
 
 func (t *Transformer) pageEvents(tec *transformEventContext) ([]map[string]any, error) {

--- a/warehouse/transformer/events_test.go
+++ b/warehouse/transformer/events_test.go
@@ -626,7 +626,7 @@ func TestEvents(t *testing.T) {
 			"userId": "",
 		}
 	}
-	trackMergedefaultOutput := func() testhelper.OutputBuilder {
+	trackMergeDefaultOutput := func() testhelper.OutputBuilder {
 		return testhelper.OutputBuilder{
 			"data": map[string]any{
 				"merge_property_1_type":  "anonymous_id",
@@ -1844,6 +1844,166 @@ func TestEvents(t *testing.T) {
 			},
 		},
 		{
+			name:         "track (POSTGRES) jsonPaths (legacy destOpts for properties)",
+			eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"location": {"city":"Palo Alto","state":"California","country":"USA","coordinates":{"latitude":37.4419,"longitude":-122.143,"geo":{"altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}},"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+			metadata:     getTrackMetadata("POSTGRES", "webhook"),
+			destination: getDestination("POSTGRES", map[string]any{
+				"jsonPaths": "location",
+			}),
+			expectedResponse: types.Response{
+				Events: []types.TransformerResponse{
+					{
+						Output:     trackDefaultOutput(),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+					{
+						Output: trackEventDefaultOutput().
+							SetDataField("location", "{\"city\":\"Palo Alto\",\"coordinates\":{\"geo\":{\"accuracy\":5,\"altitude\":30.5,\"details\":{\"accuracyUnits\":\"meters\",\"altitudeUnits\":\"meters\"}},\"latitude\":37.4419,\"longitude\":-122.143},\"country\":\"USA\",\"state\":\"California\"}").
+							SetColumnField("location", "json"),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+				},
+			},
+		},
+		{
+			name:         "track (POSTGRES) jsonPaths (legacy destOpts for user properties)",
+			eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"location": {"city":"Palo Alto","state":"California","country":"USA","coordinates":{"latitude":37.4419,"longitude":-122.143,"geo":{"altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}}, "rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+			metadata:     getTrackMetadata("POSTGRES", "webhook"),
+			destination: getDestination("POSTGRES", map[string]any{
+				"jsonPaths": "location",
+			}),
+			expectedResponse: types.Response{
+				Events: []types.TransformerResponse{
+					{
+						Output:     trackDefaultOutput(),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+					{
+						Output: trackEventDefaultOutput().
+							SetDataField("location", "{\"city\":\"Palo Alto\",\"coordinates\":{\"geo\":{\"accuracy\":5,\"altitude\":30.5,\"details\":{\"accuracyUnits\":\"meters\",\"altitudeUnits\":\"meters\"}},\"latitude\":37.4419,\"longitude\":-122.143},\"country\":\"USA\",\"state\":\"California\"}").
+							SetColumnField("location", "json"),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+				},
+			},
+		},
+		{
+			name:         "track (POSTGRES) jsonPaths (destOpts)",
+			eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311", "location": {"city":"Palo Alto","state":"California","country":"USA","coordinates":{"latitude":37.4419,"longitude":-122.143,"geo":{"altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}}},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+			metadata:     getTrackMetadata("POSTGRES", "webhook"),
+			destination: getDestination("POSTGRES", map[string]any{
+				"jsonPaths": "track.properties.location",
+			}),
+			expectedResponse: types.Response{
+				Events: []types.TransformerResponse{
+					{
+						Output:     trackDefaultOutput(),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+					{
+						Output: trackEventDefaultOutput().
+							SetDataField("location", "{\"city\":\"Palo Alto\",\"coordinates\":{\"geo\":{\"accuracy\":5,\"altitude\":30.5,\"details\":{\"accuracyUnits\":\"meters\",\"altitudeUnits\":\"meters\"}},\"latitude\":37.4419,\"longitude\":-122.143},\"country\":\"USA\",\"state\":\"California\"}").
+							SetColumnField("location", "json"),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+				},
+			},
+		},
+		{
+			name:         "track (POSTGRES) jsonPaths (intrOpts)",
+			eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311", "location": {"city":"Palo Alto","state":"California","country":"USA","coordinates":{"latitude":37.4419,"longitude":-122.143,"geo":{"altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}}},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"},"integrations":{"POSTGRES":{"options":{"jsonPaths":["track.properties.location"]}}}}`,
+			metadata:     getTrackMetadata("POSTGRES", "webhook"),
+			destination:  getDestination("POSTGRES", map[string]any{}),
+			expectedResponse: types.Response{
+				Events: []types.TransformerResponse{
+					{
+						Output:     trackDefaultOutput(),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+					{
+						Output: trackEventDefaultOutput().
+							SetDataField("location", "{\"city\":\"Palo Alto\",\"coordinates\":{\"geo\":{\"accuracy\":5,\"altitude\":30.5,\"details\":{\"accuracyUnits\":\"meters\",\"altitudeUnits\":\"meters\"}},\"latitude\":37.4419,\"longitude\":-122.143},\"country\":\"USA\",\"state\":\"California\"}").
+							SetColumnField("location", "json"),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+				},
+			},
+		},
+		{
+			name:         "track (POSTGRES) jsonPaths (DATA_WAREHOUSE)",
+			eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311", "location": {"city":"Palo Alto","state":"California","country":"USA","coordinates":{"latitude":37.4419,"longitude":-122.143,"geo":{"altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}}},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"},"integrations":{"DATA_WAREHOUSE":{"options":{"jsonPaths":["track.properties.location"]}}}}`,
+			metadata:     getTrackMetadata("POSTGRES", "webhook"),
+			destination:  getDestination("POSTGRES", map[string]any{}),
+			expectedResponse: types.Response{
+				Events: []types.TransformerResponse{
+					{
+						Output:     trackDefaultOutput(),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+					{
+						Output: trackEventDefaultOutput().
+							SetDataField("location", "{\"city\":\"Palo Alto\",\"coordinates\":{\"geo\":{\"accuracy\":5,\"altitude\":30.5,\"details\":{\"accuracyUnits\":\"meters\",\"altitudeUnits\":\"meters\"}},\"latitude\":37.4419,\"longitude\":-122.143},\"country\":\"USA\",\"state\":\"California\"}").
+							SetColumnField("location", "json"),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+				},
+			},
+		},
+		{
+			name:         "track (POSTGRES) jsonPaths (intrOpts with higher path)",
+			eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311", "location": {"city":"Palo Alto","state":"California","country":"USA","coordinates":{"latitude":37.4419,"longitude":-122.143,"geo":{"altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}}},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"},"integrations":{"DATA_WAREHOUSE":{"options":{"jsonPaths":["track.properties.location"]}},"POSTGRES":{"options":{"jsonPaths":["track.properties.location.coordinates"]}}}}`,
+			metadata:     getTrackMetadata("POSTGRES", "webhook"),
+			destination:  getDestination("POSTGRES", map[string]any{}),
+			expectedResponse: types.Response{
+				Events: []types.TransformerResponse{
+					{
+						Output:     trackDefaultOutput(),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+					{
+						Output: trackEventDefaultOutput().
+							SetDataField("location", "{\"city\":\"Palo Alto\",\"coordinates\":{\"geo\":{\"accuracy\":5,\"altitude\":30.5,\"details\":{\"accuracyUnits\":\"meters\",\"altitudeUnits\":\"meters\"}},\"latitude\":37.4419,\"longitude\":-122.143},\"country\":\"USA\",\"state\":\"California\"}").
+							SetColumnField("location", "json"),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+				},
+			},
+		},
+		{
+			name:         "track (POSTGRES) jsonPaths (DATA_WAREHOUSE with higher path)",
+			eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311", "location": {"city":"Palo Alto","state":"California","country":"USA","coordinates":{"latitude":37.4419,"longitude":-122.143,"geo":{"altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}}},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"},"integrations":{"DATA_WAREHOUSE":{"options":{"jsonPaths":["track.properties.location.coordinates"]}},"POSTGRES":{"options":{"jsonPaths":["track.properties.location"]}}}}`,
+			metadata:     getTrackMetadata("POSTGRES", "webhook"),
+			destination:  getDestination("POSTGRES", map[string]any{}),
+			expectedResponse: types.Response{
+				Events: []types.TransformerResponse{
+					{
+						Output:     trackDefaultOutput(),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+					{
+						Output: trackEventDefaultOutput().
+							SetDataField("location", "{\"city\":\"Palo Alto\",\"coordinates\":{\"geo\":{\"accuracy\":5,\"altitude\":30.5,\"details\":{\"accuracyUnits\":\"meters\",\"altitudeUnits\":\"meters\"}},\"latitude\":37.4419,\"longitude\":-122.143},\"country\":\"USA\",\"state\":\"California\"}").
+							SetColumnField("location", "json"),
+						Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+						StatusCode: http.StatusOK,
+					},
+				},
+			},
+		},
+		{
 			name: "track (BQ) merge event",
 			configOverride: map[string]any{
 				"Warehouse.enableIDResolution": true,
@@ -1868,7 +2028,7 @@ func TestEvents(t *testing.T) {
 						StatusCode: http.StatusOK,
 					},
 					{
-						Output:     trackMergedefaultOutput(),
+						Output:     trackMergeDefaultOutput(),
 						Metadata:   getTrackMetadata("BQ", "webhook"),
 						StatusCode: http.StatusOK,
 					},

--- a/warehouse/transformer/logger.go
+++ b/warehouse/transformer/logger.go
@@ -33,7 +33,7 @@ func (t *Transformer) CompareAndLog(
 		return
 	}
 
-	t.stats.comparisionTime.RecordDuration()()
+	t.stats.comparisonTime.RecordDuration()()
 
 	differingEvents, sampleDiff := t.differingEvents(events, pResponse, wResponse, eventsByMessageID)
 	if len(differingEvents) == 0 {

--- a/warehouse/transformer/options.go
+++ b/warehouse/transformer/options.go
@@ -46,11 +46,14 @@ func mergeDataWarehouseIntrOpts(destType string, message map[string]any, opts in
 
 	setOption(srcMap, "jsonPaths", &jsonPaths)
 	if len(jsonPaths) > 0 && utils.IsJSONPathSupportedAsPartOfConfig(destType) {
-		for _, jp := range jsonPaths {
-			if jpStr, ok := jp.(string); ok {
-				opts.jsonPaths = append(opts.jsonPaths, jpStr)
+		mergedJSONPaths := make([]string, 0, len(jsonPaths)+len(opts.jsonPaths))
+		for _, jsonPath := range jsonPaths {
+			if jsonPathStr, ok := jsonPath.(string); ok {
+				mergedJSONPaths = append(mergedJSONPaths, jsonPathStr)
 			}
 		}
+		mergedJSONPaths = append(mergedJSONPaths, opts.jsonPaths...)
+		opts.jsonPaths = mergedJSONPaths
 	}
 	return opts
 }

--- a/warehouse/transformer/options_test.go
+++ b/warehouse/transformer/options_test.go
@@ -136,7 +136,7 @@ func TestIntegrationOptions(t *testing.T) {
 		require.False(t, opts.useBlendoCasing)
 		require.True(t, opts.skipTracksTable)
 		require.False(t, opts.skipUsersTable)
-		require.Equal(t, []string{"path1", "path2", "path3", "path4", "path5"}, opts.jsonPaths)
+		require.Equal(t, []string{"path4", "path5", "path1", "path2", "path3"}, opts.jsonPaths)
 	})
 }
 

--- a/warehouse/transformer/transformer.go
+++ b/warehouse/transformer/transformer.go
@@ -37,7 +37,7 @@ func New(conf *config.Config, logger logger.Logger, statsFactory stats.Stats) *T
 
 	t.stats.matchedEvents = t.statsFactory.NewStat("warehouse_dest_transform_matched_events", stats.HistogramType)
 	t.stats.mismatchedEvents = t.statsFactory.NewStat("warehouse_dest_transform_mismatched_events", stats.HistogramType)
-	t.stats.comparisionTime = t.statsFactory.NewStat("warehouse_dest_transform_comparison_time", stats.TimerType)
+	t.stats.comparisonTime = t.statsFactory.NewStat("warehouse_dest_transform_comparison_time", stats.TimerType)
 
 	t.config.enableIDResolution = conf.GetReloadableBoolVar(false, "Warehouse.enableIDResolution")
 	t.config.populateSrcDestInfoInContext = conf.GetReloadableBoolVar(true, "WH_POPULATE_SRC_DEST_INFO_IN_CONTEXT")

--- a/warehouse/transformer/types.go
+++ b/warehouse/transformer/types.go
@@ -19,7 +19,7 @@ type (
 		statsFactory stats.Stats
 
 		stats struct {
-			comparisionTime  stats.Timer
+			comparisonTime   stats.Timer
 			matchedEvents    stats.Histogram
 			mismatchedEvents stats.Histogram
 		}


### PR DESCRIPTION
# Description

- Ordering for **JSON Paths** for `DATA_WAREHOUSE` should be first w.r.t the corresponding integration.
- https://github.com/rudderlabs/rudder-transformer/blob/3c20393a0e4e3ec98d316820d187310bfec1faea/src/warehouse/util.js#L155

## Linear Ticket

- Resolves WAR-446

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
