### PR TITLE
chore: use rss for calculating used memory in adaptive payload limiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/rudderlabs/bing-ads-go-sdk v0.2.3
 	github.com/rudderlabs/compose-test v0.1.3
-	github.com/rudderlabs/rudder-go-kit v0.47.1
+	github.com/rudderlabs/rudder-go-kit v0.48.0
 	github.com/rudderlabs/rudder-observability-kit v0.0.4
 	github.com/rudderlabs/rudder-schemas v0.5.4
 	github.com/rudderlabs/rudder-transformer/go v0.0.0-20240910055720-f77d2ab4125a

--- a/go.sum
+++ b/go.sum
@@ -1173,8 +1173,8 @@ github.com/rudderlabs/goqu/v10 v10.3.1 h1:rnfX+b4EwBWQ2UQfIGeEW299JBBkK5biEbnf7K
 github.com/rudderlabs/goqu/v10 v10.3.1/go.mod h1:LH2vI5gGHBxEQuESqFyk5ZA2anGINc8o25hbidDWOYw=
 github.com/rudderlabs/parquet-go v0.0.2 h1:ZXRdZdimB0PdJtmxeSSxfI0fDQ3kZjwzBxRi6Ut1J8k=
 github.com/rudderlabs/parquet-go v0.0.2/go.mod h1:g6guum7o8uhj/uNhunnt7bw5Vabu/goI5i21/3fnxWQ=
-github.com/rudderlabs/rudder-go-kit v0.47.1 h1:MsYvLhBLCSjeqDV5NIqceI3IxWqSxC+bCtXeGDoCC2I=
-github.com/rudderlabs/rudder-go-kit v0.47.1/go.mod h1:jaVLZnoFq+AX7x3mCPdgL5VnWaRD1giabnTNre/KyNo=
+github.com/rudderlabs/rudder-go-kit v0.48.0 h1:/iQLAgKyIRSr/dLfnTPOzbKDDiLQ2VtWBx2zJtNyGxI=
+github.com/rudderlabs/rudder-go-kit v0.48.0/go.mod h1:jaVLZnoFq+AX7x3mCPdgL5VnWaRD1giabnTNre/KyNo=
 github.com/rudderlabs/rudder-observability-kit v0.0.4 h1:h9nLoWqiv/nqGOu1dhuVFAHNRkyodR6R3v36bqmavRs=
 github.com/rudderlabs/rudder-observability-kit v0.0.4/go.mod h1:YTsvJmpvh8OLk7c4C+wXiV8NRdcrrdLa8UvIdLoXTho=
 github.com/rudderlabs/rudder-schemas v0.5.4 h1:QzI6vIC38W0jGJu6E0vdwh4IAtSKx8ziqff+JL0xmIE=

--- a/utils/payload/limiter_setup.go
+++ b/utils/payload/limiter_setup.go
@@ -18,10 +18,14 @@ type AdaptiveLimiterFunc func(int64) int64
 func SetupAdaptiveLimiter(ctx context.Context, g *errgroup.Group) AdaptiveLimiterFunc {
 	var freeMem FreeMemory
 	if config.GetBool("AdaptivePayloadLimiter.enabled", true) {
+		useRSS := config.GetReloadableBoolVar(true, "AdaptivePayloadLimiter.useRSS")
 		freeMem = func() (float64, error) {
 			s, err := mem.Get()
 			if err != nil {
 				return 0, err
+			}
+			if useRSS.Load() {
+				return s.AvailableIgnoreCachePercent(), nil
 			}
 			return s.AvailablePercent, nil
 		}


### PR DESCRIPTION
# Description

rss memory excludes active page cache memory, which can be reclaimable in our case, since badger db makes heavy use of mmap.

## Linear Ticket

resolves PIPE-1989

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
