### PR TITLE
fix: warehouse transformations for tracking plans

### DIFF
--- a/warehouse/transformer/datatype.go
+++ b/warehouse/transformer/datatype.go
@@ -3,7 +3,10 @@ package transformer
 import (
 	"reflect"
 
+	"github.com/samber/lo"
+
 	"github.com/rudderlabs/rudder-server/jsonrs"
+	"github.com/rudderlabs/rudder-server/processor/types"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 	"github.com/rudderlabs/rudder-server/warehouse/transformer/internal/utils"
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
@@ -90,6 +93,48 @@ func overrideForRedshift(val any, isJSONKey bool) string {
 func convertValIfDateTime(val any, colType string) any {
 	if colType == model.DateTimeDataType {
 		return utils.ToTimestamp(val)
+	}
+	return val
+}
+
+func convertToFloat64IfInteger(val any) any {
+	switch v := val.(type) {
+	case int:
+		return float64(v)
+	case int8:
+		return float64(v)
+	case int16:
+		return float64(v)
+	case int32:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case uint:
+		return float64(v)
+	case uint8:
+		return float64(v)
+	case uint16:
+		return float64(v)
+	case uint32:
+		return float64(v)
+	case uint64:
+		return float64(v)
+	}
+	return val
+}
+
+func convertToSliceIfViolationErrors(val any) any {
+	if validationErrors, ok := val.([]types.ValidationError); ok {
+		result := make([]any, len(validationErrors))
+		for i, e := range validationErrors {
+			result[i] = map[string]any{
+				"type":     e.Type,
+				"message":  e.Message,
+				"meta":     lo.MapValues(e.Meta, func(value, _ string) any { return value }),
+				"property": e.Property,
+			}
+		}
+		return result
 	}
 	return val
 }

--- a/warehouse/transformer/internal/utils/utils.go
+++ b/warehouse/transformer/internal/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/araddon/dateparse"
 	"github.com/samber/lo"
 
+	"github.com/rudderlabs/rudder-server/processor/types"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
@@ -158,6 +159,8 @@ func IsBlank(value interface{}) bool {
 	case map[string]any:
 		return len(v) == 0
 	case []any:
+		return len(v) == 0
+	case []types.ValidationError:
 		return len(v) == 0
 	default:
 		return false

--- a/warehouse/transformer/internal/utils/utils_test.go
+++ b/warehouse/transformer/internal/utils/utils_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-server/processor/types"
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
@@ -123,22 +124,24 @@ func TestIsBlank(t *testing.T) {
 		input    interface{}
 		expected bool
 	}{
-		{"NilValue", nil, true},                                     // nil
-		{"EmptyString", "", true},                                   // empty string
-		{"NonEmptyString", "Hello", false},                          // non-empty string
-		{"IntZero", 0, false},                                       // integer zero
-		{"IntNonZero", 123, false},                                  // non-zero integer
-		{"FloatZero", 0.0, false},                                   // float zero
-		{"FloatNonZero", 123.45, false},                             // non-zero float
-		{"BoolFalse", false, false},                                 // boolean false
-		{"BoolTrue", true, false},                                   // boolean true
-		{"EmptySlice", []any{}, true},                               // empty slice
-		{"NonEmptySlice", []any{1, 2, 3}, false},                    // non-empty slice
-		{"EmptyMap", map[string]any{}, true},                        // empty map
-		{"NonEmptyMap", map[string]any{"key": 1}, false},            // non-empty map
-		{"EmptyStruct", struct{}{}, false},                          // empty struct
-		{"StructWithField", struct{ Field string }{"value"}, false}, // non-empty struct
-		{"StructWithMethod", Person{Name: "Alice", Age: 30}, false}, // struct with String method
+		{"NilValue", nil, true},
+		{"EmptyString", "", true},
+		{"NonEmptyString", "Hello", false},
+		{"IntZero", 0, false},
+		{"IntNonZero", 123, false},
+		{"FloatZero", 0.0, false},
+		{"FloatNonZero", 123.45, false},
+		{"BoolFalse", false, false},
+		{"BoolTrue", true, false},
+		{"EmptySlice", []any{}, true},
+		{"NonEmptySlice", []any{1, 2, 3}, false},
+		{"EmptyMap", map[string]any{}, true},
+		{"NonEmptyMap", map[string]any{"key": 1}, false},
+		{"EmptyStruct", struct{}{}, false},
+		{"StructWithField", struct{ Field string }{"value"}, false},
+		{"StructWithMethod", Person{Name: "Alice", Age: 30}, false},
+		{"EmptyValidationError", []types.ValidationError{}, true},
+		{"NonEmptyValidationError", []types.ValidationError{{Type: "something"}}, false},
 	}
 
 	for _, tc := range testCases {

--- a/warehouse/transformer/set.go
+++ b/warehouse/transformer/set.go
@@ -85,9 +85,16 @@ func addDataAndMetadata(tec *transformEventContext, key string, val any, isJSONK
 	}
 
 	dataType := dataTypeFor(tec.event.Metadata.DestinationType, key, val, isJSONKey)
-
-	data[safeKey] = convertValIfDateTime(val, dataType)
 	metadata[safeKey] = dataType
+
+	switch safeKey {
+	case "context_tracking_plan_version", "CONTEXT_TRACKING_PLAN_VERSION":
+		data[safeKey] = convertToFloat64IfInteger(val)
+	case "context_violation_errors", "CONTEXT_VIOLATION_ERRORS":
+		data[safeKey] = convertToSliceIfViolationErrors(val)
+	default:
+		data[safeKey] = convertValIfDateTime(val, dataType)
+	}
 	return nil
 }
 

--- a/warehouse/transformer/transformer.go
+++ b/warehouse/transformer/transformer.go
@@ -29,6 +29,14 @@ const (
 	redshiftStringLimit = 512
 )
 
+// Compile-time check to ensure ValidationError struct remains unchanged.
+var _ = struct {
+	Type     string
+	Message  string
+	Meta     map[string]string
+	Property string
+}(types.ValidationError{})
+
 func New(conf *config.Config, logger logger.Logger, statsFactory stats.Stats) *Transformer {
 	t := &Transformer{
 		logger:         logger.Child("warehouse-transformer"),


### PR DESCRIPTION
# Description

The [Tracking Plan properties](https://github.com/rudderlabs/rudder-server/blob/master/processor/trackingplan.go#L28-L51) in the Go code differ in type from the response received from `rudder-transformer`, causing a type mismatch:
- **`context_tracking_plan_version`**:  
  - Unmarshalling response from `rudder-transformer` treats all numbers as `json.Number` (essentially `float64`).  
  - Go code sets it as `int`.
- **`context_violation_errors`**:  
  - Unmarshalling response from `rudder-transformer` returns it as `[]any`.  
  - Go code sets it as `[]types.ValidationError`.
- This results in a type mismatch, though the actual data remains correct.

 ```GO
  - 			"context_tracking_plan_version": int(8),
  + 			"context_tracking_plan_version": float64(8),
  - 			"context_violation_errors": []types.ValidationError{
  - 				{
  - 					Type:     "Required-Missing",
  - 					Message:  "must have required property 'name'",
  - 					Meta:     map[string]string{"instancePath": "/traits", "schemaPath": "#/properties/traits/required"},
  - 					Property: "name",
  - 				},
  - 				{
  - 					Type:    "Datatype-Mismatch",
  - 					Message: "must be string",
  - 					Meta: map[string]string{
  - 						"instancePath": "/traits/email",
  - 						"schemaPath":   "#/properties/traits/properties/e"...,
  - 					},
  - 				},
  - 			},
  + 			"context_violation_errors": []any{
  + 				map[string]any{
  + 					"message": string("must have required property 'name'"),
  + 					"meta": map[string]any{
  + 						"instancePath": string("/traits"),
  + 						"schemaPath":   string("#/properties/traits/required"),
  + 					},
  + 					"property": string("name"),
  + 					"type":     string("Required-Missing"),
  + 				},
  + 				map[string]any{
  + 					"message": string("must be string"),
  + 					"meta": map[string]any{
  + 						"instancePath": string("/traits/email"),
  + 						"schemaPath":   string("#/properties/traits/properties/e"...),
  + 					},
  + 					"property": string(""),
  + 					"type":     string("Datatype-Mismatch"),
  + 				},
  + 			},
  ```


## Linear Ticket

- Resolves WAR-424

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
