### PR TITLE
feat: support compacted destination transformation payloads

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,6 +34,7 @@ jobs:
         run: go test -v ./integration_test/docker_test/docker_test.go -count 1
         env:
           ENTERPRISE_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
+          RSERVER_TRANSFORMER_FORCE_COMPACTION_ENABLED: true
 
       - name: oss
         if: matrix.FEATURES == 'oss'
@@ -125,6 +126,7 @@ jobs:
         run: FORCE_RUN_INTEGRATION_TESTS=true make test exclude="/rudder-server/(jobsdb|integration_test|processor|regulation-worker|router|services|suppression-backup-service|warehouse)"
         env:
           RSERVER_PROCESSOR_ENABLE_CONCURRENT_STORE: "true"
+          RSERVER_TRANSFORMER_FORCE_COMPACTION_ENABLED: "true"
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
@@ -193,6 +195,7 @@ jobs:
           SNOWPIPE_STREAMING_KEYPAIR_ENCRYPTED_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.SNOWPIPE_STREAMING_KEYPAIR_ENCRYPTED_INTEGRATION_TEST_CREDENTIALS }}
           SNOWFLAKE_PRIVILEGE_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.SNOWFLAKE_PRIVILEGE_INTEGRATION_TEST_CREDENTIALS }}
           RSERVER_PROCESSOR_ENABLE_CONCURRENT_STORE: "true"
+          RSERVER_TRANSFORMER_FORCE_COMPACTION_ENABLED: "true"
         run: FORCE_RUN_INTEGRATION_TESTS=true make test exclude="${{ matrix.exclude }}" package=${{ matrix.package }}
       - name: Sanitize name for Artifact
         run: |

--- a/integration_test/snowpipestreaming/testdata/docker-compose.rudder-transformer.yml
+++ b/integration_test/snowpipestreaming/testdata/docker-compose.rudder-transformer.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   transformer:
-    image: "rudderstack/develop-rudder-transformer:fix.snowpipe-streaming-users"
+    image: "rudderstack/rudder-transformer:latest"
     ports:
       - "9090:9090"
     healthcheck:

--- a/mocks/services/transformer/mock_features.go
+++ b/mocks/services/transformer/mock_features.go
@@ -81,6 +81,20 @@ func (mr *MockFeaturesServiceMockRecorder) SourceTransformerVersion() *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SourceTransformerVersion", reflect.TypeOf((*MockFeaturesService)(nil).SourceTransformerVersion))
 }
 
+// SupportDestTransformCompactedPayloadV1 mocks base method.
+func (m *MockFeaturesService) SupportDestTransformCompactedPayloadV1() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SupportDestTransformCompactedPayloadV1")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SupportDestTransformCompactedPayloadV1 indicates an expected call of SupportDestTransformCompactedPayloadV1.
+func (mr *MockFeaturesServiceMockRecorder) SupportDestTransformCompactedPayloadV1() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportDestTransformCompactedPayloadV1", reflect.TypeOf((*MockFeaturesService)(nil).SupportDestTransformCompactedPayloadV1))
+}
+
 // TransformerProxyVersion mocks base method.
 func (m *MockFeaturesService) TransformerProxyVersion() string {
 	m.ctrl.T.Helper()

--- a/processor/internal/transformer/destination_transformer/destination_transformer.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer.go
@@ -407,10 +407,7 @@ func (c *Client) Transform(ctx context.Context, clientEvents []types.Transformer
 }
 
 func (d *Client) compactRequestPayloads() bool {
-	if d.config.compactionSupported && d.config.compactionEnabled.Load() {
-		return true
-	}
-	return d.config.forceCompactionEnabled
+	return (d.config.compactionSupported && d.config.compactionEnabled.Load()) || d.config.forceCompactionEnabled
 }
 
 func (d *Client) getRequestPayload(data []types.TransformerEvent, compactRequestPayloads bool) ([]byte, error) {

--- a/processor/internal/transformer/destination_transformer/destination_transformer.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer.go
@@ -11,7 +11,9 @@ import (
 	"sync"
 	"time"
 
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jsonrs"
+	transformerfs "github.com/rudderlabs/rudder-server/services/transformer"
 
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
@@ -41,6 +43,22 @@ func WithClient(client transformerclient.Client) Opt {
 	}
 }
 
+// WithFeatureService is used to set the feature service for the transformer client.
+// It is used to check if the destination transformer supports compacted payloads.
+// If this option is omitted, the transformer client will not be able to use compacted payloads.
+func WithFeatureService(featureService transformerfs.FeaturesService) Opt {
+	return func(s *Client) {
+		if featureService == nil {
+			return
+		}
+		go func() {
+			// Wait for the feature service to be ready
+			<-featureService.Wait()
+			s.config.compactionSupported = featureService.SupportDestTransformCompactedPayloadV1()
+		}()
+	}
+}
+
 func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) *Client {
 	handle := &Client{}
 	handle.conf = conf
@@ -66,6 +84,9 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) 
 	handle.loggedEventsMu = sync.Mutex{}
 	handle.loggedFileName = generateLogFileName()
 
+	handle.config.forceCompactionEnabled = conf.GetBoolVar(false, "Processor.DestinationTransformer.forceCompactionEnabled", "Transformer.forceCompactionEnabled")
+	handle.config.compactionEnabled = conf.GetReloadableBoolVar(false, "Processor.DestinationTransformer.compactionEnabled", "Transformer.compactionEnabled")
+
 	for _, opt := range opts {
 		opt(handle)
 	}
@@ -84,6 +105,10 @@ type Client struct {
 		batchSize               config.ValueLoader[int]
 
 		maxLoggedEvents config.ValueLoader[int]
+
+		forceCompactionEnabled bool // option to force usage of compaction for testing
+		compactionEnabled      config.ValueLoader[bool]
+		compactionSupported    bool
 	}
 	guardConcurrency chan struct{}
 	conf             *config.Config
@@ -193,27 +218,21 @@ func (d *Client) transform(ctx context.Context, clientEvents []types.Transformer
 
 func (d *Client) sendBatch(ctx context.Context, url string, labels types.TransformerMetricLabels, data []types.TransformerEvent) ([]types.TransformerResponse, error) {
 	d.stat.NewTaggedStat("transformer_client_request_total_events", stats.CountType, labels.ToStatsTag()).Count(len(data))
+	if len(data) == 0 {
+		return nil, nil
+	}
+	compactRequestPayloads := d.compactRequestPayloads() // consistent state for the entire request
 	// Call remote transformation
-	var (
-		rawJSON []byte
-		err     error
-	)
-
-	rawJSON, err = jsonrs.Marshal(data)
+	rawJSON, err := d.getRequestPayload(data, compactRequestPayloads)
 	if err != nil {
 		panic(err)
 	}
 
-	if len(data) == 0 {
-		return nil, nil
+	var extraHeaders map[string]string
+	if compactRequestPayloads {
+		extraHeaders = map[string]string{"X-Content-Format": "json+compactedv1"}
 	}
-
-	var (
-		respData   []byte
-		statusCode int
-	)
-
-	respData, statusCode, err = d.doPost(ctx, rawJSON, url, labels)
+	respData, statusCode, err := d.doPost(ctx, rawJSON, url, labels, extraHeaders)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +269,7 @@ func (d *Client) sendBatch(ctx context.Context, url string, labels types.Transfo
 	return transformerResponses, nil
 }
 
-func (d *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels types.TransformerMetricLabels) ([]byte, int, error) {
+func (d *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels types.TransformerMetricLabels, extraHeaders map[string]string) ([]byte, int, error) {
 	var (
 		retryCount int
 		resp       *http.Response
@@ -275,6 +294,9 @@ func (d *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 			req.Header.Set("X-Feature-Gzip-Support", "?1")
 			// Header to let transformer know that the client understands event filter code
 			req.Header.Set("X-Feature-Filter-Code", "?1")
+			for k, v := range extraHeaders {
+				req.Header.Set(k, v)
+			}
 
 			resp, reqErr = d.client.Do(req)
 			defer func() { httputil.CloseResponse(resp) }()
@@ -382,4 +404,34 @@ func (c *Client) Transform(ctx context.Context, clientEvents []types.Transformer
 		return legacyTransformerResponse
 	}
 	return impl(ctx, clientEvents)
+}
+
+func (d *Client) compactRequestPayloads() bool {
+	if d.config.compactionSupported && d.config.compactionEnabled.Load() {
+		return true
+	}
+	return d.config.forceCompactionEnabled
+}
+
+func (d *Client) getRequestPayload(data []types.TransformerEvent, compactRequestPayloads bool) ([]byte, error) {
+	if compactRequestPayloads {
+		ctr := types.CompactedTransformRequest{
+			Input:        make([]types.CompactedTransformerEvent, 0, len(data)),
+			Connections:  make(map[string]backendconfig.Connection),
+			Destinations: make(map[string]backendconfig.DestinationT),
+		}
+		for i := range data {
+			ctr.Input = append(ctr.Input, types.CompactedTransformerEvent{
+				Message:     data[i].Message,
+				Metadata:    data[i].Metadata,
+				Libraries:   data[i].Libraries,
+				Credentials: data[i].Credentials,
+			})
+			ctr.Destinations[data[i].Metadata.DestinationID] = data[i].Destination
+			ctr.Connections[data[i].Metadata.SourceID+":"+data[i].Metadata.DestinationID] = data[i].Connection
+		}
+		return jsonrs.Marshal(&ctr)
+
+	}
+	return jsonrs.Marshal(data)
 }

--- a/processor/internal/transformer/destination_transformer/destination_transformer.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer.go
@@ -427,8 +427,13 @@ func (d *Client) getRequestPayload(data []types.TransformerEvent, compactRequest
 				Libraries:   data[i].Libraries,
 				Credentials: data[i].Credentials,
 			})
-			ctr.Destinations[data[i].Metadata.DestinationID] = data[i].Destination
-			ctr.Connections[data[i].Metadata.SourceID+":"+data[i].Metadata.DestinationID] = data[i].Connection
+			if _, ok := ctr.Destinations[data[i].Metadata.DestinationID]; !ok {
+				ctr.Destinations[data[i].Metadata.DestinationID] = data[i].Destination
+			}
+			connectionKey := data[i].Metadata.SourceID + ":" + data[i].Metadata.DestinationID
+			if _, ok := ctr.Connections[connectionKey]; !ok {
+				ctr.Connections[connectionKey] = data[i].Connection
+			}
 		}
 		return jsonrs.Marshal(&ctr)
 

--- a/processor/internal/transformer/destination_transformer/destination_transformer_test.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer_test.go
@@ -41,7 +41,13 @@ type fakeTransformer struct {
 
 func (t *fakeTransformer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var reqBody []types.TransformerEvent
-	require.NoError(t.t, jsonrs.NewDecoder(r.Body).Decode(&reqBody))
+	if r.Header.Get("X-Content-Format") == "json+compactedv1" {
+		var ctr types.CompactedTransformRequest
+		require.NoError(t.t, jsonrs.NewDecoder(r.Body).Decode(&ctr))
+		reqBody = ctr.ToTransformerEvents()
+	} else {
+		require.NoError(t.t, jsonrs.NewDecoder(r.Body).Decode(&reqBody))
+	}
 
 	t.requests = append(t.requests, reqBody)
 
@@ -84,7 +90,13 @@ func (elt *endlessLoopTransformer) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	elt.retryCount++
 
 	var reqBody []types.TransformerEvent
-	require.NoError(elt.t, jsonrs.NewDecoder(r.Body).Decode(&reqBody))
+	if r.Header.Get("X-Content-Format") == "json+compactedv1" {
+		var ctr types.CompactedTransformRequest
+		require.NoError(elt.t, jsonrs.NewDecoder(r.Body).Decode(&ctr))
+		reqBody = ctr.ToTransformerEvents()
+	} else {
+		require.NoError(elt.t, jsonrs.NewDecoder(r.Body).Decode(&reqBody))
+	}
 
 	responses := make([]types.TransformerResponse, len(reqBody))
 
@@ -123,7 +135,13 @@ func (et *endpointTransformer) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	var reqBody []types.TransformerEvent
-	require.NoError(et.t, jsonrs.NewDecoder(r.Body).Decode(&reqBody))
+	if r.Header.Get("X-Content-Format") == "json+compactedv1" {
+		var ctr types.CompactedTransformRequest
+		require.NoError(et.t, jsonrs.NewDecoder(r.Body).Decode(&ctr))
+		reqBody = ctr.ToTransformerEvents()
+	} else {
+		require.NoError(et.t, jsonrs.NewDecoder(r.Body).Decode(&reqBody))
+	}
 
 	responses := make([]types.TransformerResponse, len(reqBody))
 

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -731,11 +731,11 @@ func TestLongRunningTransformation(t *testing.T) {
 	})
 }
 
-func TestTransformerEvent_GetVersionsOnly(t *testing.T) {
+func TestTransformerEvent_ToUserTransformerEvent(t *testing.T) {
 	testCases := []struct {
 		name     string
 		event    *types.TransformerEvent
-		expected *types.TransformerEvent
+		expected *types.UserTransformerEvent
 	}{
 		{
 			name: "remove connections",
@@ -750,13 +750,9 @@ func TestTransformerEvent_GetVersionsOnly(t *testing.T) {
 					Transformations: make([]backendconfig.TransformationT, 0),
 				},
 			},
-			expected: &types.TransformerEvent{
-				Metadata:   types.Metadata{},
-				Message:    map[string]interface{}{},
-				Connection: backendconfig.Connection{},
-				Destination: backendconfig.DestinationT{
-					Transformations: make([]backendconfig.TransformationT, 0),
-				},
+			expected: &types.UserTransformerEvent{
+				Metadata: types.Metadata{},
+				Message:  map[string]interface{}{},
 			},
 		},
 		{
@@ -786,13 +782,9 @@ func TestTransformerEvent_GetVersionsOnly(t *testing.T) {
 					},
 				},
 			},
-			expected: &types.TransformerEvent{
-				Metadata:   types.Metadata{},
-				Message:    map[string]interface{}{},
-				Connection: backendconfig.Connection{},
-				Destination: backendconfig.DestinationT{
-					Transformations: make([]backendconfig.TransformationT, 0),
-				},
+			expected: &types.UserTransformerEvent{
+				Metadata: types.Metadata{},
+				Message:  map[string]interface{}{},
 			},
 		},
 		{
@@ -833,12 +825,13 @@ func TestTransformerEvent_GetVersionsOnly(t *testing.T) {
 					},
 				},
 			},
-			expected: &types.TransformerEvent{
-				Metadata:   types.Metadata{},
-				Message:    map[string]interface{}{},
-				Connection: backendconfig.Connection{},
-				Destination: backendconfig.DestinationT{
-					Transformations: []backendconfig.TransformationT{
+			expected: &types.UserTransformerEvent{
+				Metadata: types.Metadata{},
+				Message:  map[string]interface{}{},
+				Destination: struct {
+					Transformations []struct{ VersionID string }
+				}{
+					Transformations: []struct{ VersionID string }{
 						{
 							VersionID: "version-id",
 						},
@@ -852,7 +845,7 @@ func TestTransformerEvent_GetVersionsOnly(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.event.GetVersionsOnly())
+			assert.Equal(t, tc.expected, tc.event.ToUserTransformerEvent())
 		})
 	}
 }

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -42,7 +42,13 @@ type fakeTransformer struct {
 
 func (t *fakeTransformer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var reqBody []types.TransformerEvent
-	require.NoError(t.t, jsonrs.NewDecoder(r.Body).Decode(&reqBody))
+	if r.Header.Get("X-Content-Format") == "json+compactedv1" {
+		var ctr types.CompactedTransformRequest
+		require.NoError(t.t, jsonrs.NewDecoder(r.Body).Decode(&ctr))
+		reqBody = ctr.ToTransformerEvents()
+	} else {
+		require.NoError(t.t, jsonrs.NewDecoder(r.Body).Decode(&reqBody))
+	}
 
 	t.requests = append(t.requests, reqBody)
 

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -136,6 +136,7 @@ func New(
 				config.Default,
 				logger.NewLogger().Child("processor"),
 				stats.Default,
+				transformer.WithFeatureService(transformerFeaturesService),
 			),
 		),
 		mainCtx:                    ctx,

--- a/processor/processor_isolation_test.go
+++ b/processor/processor_isolation_test.go
@@ -151,7 +151,7 @@ func NewProcIsolationScenarioSpec(isolationMode isolation.Mode, workspaces, even
 	s.pipelinesPerPartition = pipelinesPerPartition
 
 	var idx int
-	for u := 0; u < workspaces; u++ {
+	for u := range workspaces {
 		workspaceID := "workspace-" + strconv.Itoa(u)
 		s.workspaces = append(s.workspaces, workspaceID)
 		for i := 0; i < eventsPerWorkspace; i++ {

--- a/processor/types/types.go
+++ b/processor/types/types.go
@@ -43,22 +43,61 @@ type TransformerEvent struct {
 	Credentials []Credential               `json:"credentials"`
 }
 
-// GetVersionsOnly removes the connection and credentials from the event
-// along with pruning the destination to only include the transformation versionID
+// UserTransformerEvent is the event sent to the user transformer, which is similar to a
+// [TransformerEvent] but without the connection and with a simplified destination structure
+type UserTransformerEvent struct {
+	Message     SingularEventT `json:"message"`
+	Metadata    Metadata       `json:"metadata"`
+	Destination struct {
+		Transformations []struct {
+			VersionID string
+		}
+	} `json:"destination"`
+	Libraries   []backendconfig.LibraryT `json:"libraries,omitempty"`
+	Credentials []Credential             `json:"credentials,omitempty"`
+}
+
+// CompactedTransformerEvent is similar to a [TransformerEvent] but without the connection and destination fields
+type CompactedTransformerEvent struct {
+	Message     SingularEventT           `json:"message"`
+	Metadata    Metadata                 `json:"metadata"`
+	Libraries   []backendconfig.LibraryT `json:"libraries,omitempty"`
+	Credentials []Credential             `json:"credentials,omitempty"`
+}
+
+// CompactedTransformRequest is the request structure for a compacted transformer request payload.
+// It contains a list of [CompactedTransformerEvent]s and two lookup maps,
+// one for destinations and one for connections.
+//
+// The destinations and connections are used to look up the actual destination and connection
+// objects based on their IDs, which are included in the [CompactedTransformerEvent]s.
+//
+// This allows for a more compact representation of the request payload, as the full destination
+// and connection objects do not need to be included in each event.
+type CompactedTransformRequest struct {
+	Input        []CompactedTransformerEvent           `json:"input"`
+	Destinations map[string]backendconfig.DestinationT `json:"destinations"`
+	Connections  map[string]backendconfig.Connection   `json:"connections"`
+}
+
+// ToUserTransformerEvent removes the connection from the event
+// along with pruning the destination to only include the transformation ID and VersionID
 // before sending it to the transformer thereby reducing the payload size
-func (e *TransformerEvent) GetVersionsOnly() *TransformerEvent {
-	tmCopy := *e
-	transformations := make([]backendconfig.TransformationT, 0, len(e.Destination.Transformations))
+func (e *TransformerEvent) ToUserTransformerEvent() *UserTransformerEvent {
+	ute := &UserTransformerEvent{
+		Message:     e.Message,
+		Metadata:    e.Metadata,
+		Libraries:   e.Libraries,
+		Credentials: e.Credentials,
+	}
 	for _, t := range e.Destination.Transformations {
-		transformations = append(transformations, backendconfig.TransformationT{
+		ute.Destination.Transformations = append(ute.Destination.Transformations, struct {
+			VersionID string
+		}{
 			VersionID: t.VersionID,
 		})
 	}
-	tmCopy.Destination = backendconfig.DestinationT{
-		Transformations: transformations,
-	}
-	tmCopy.Connection = backendconfig.Connection{}
-	return &tmCopy
+	return ute
 }
 
 type Credential struct {
@@ -73,35 +112,35 @@ type Metadata struct {
 	SourceName          string                            `json:"sourceName"`
 	OriginalSourceID    string                            `json:"originalSourceId"`
 	WorkspaceID         string                            `json:"workspaceId"`
-	Namespace           string                            `json:"namespace"`
-	InstanceID          string                            `json:"instanceId"`
+	Namespace           string                            `json:"namespace,omitempty"`
+	InstanceID          string                            `json:"instanceId,omitempty"`
 	SourceType          string                            `json:"sourceType"`
 	SourceCategory      string                            `json:"sourceCategory"`
-	TrackingPlanID      string                            `json:"trackingPlanId"`
-	TrackingPlanVersion int                               `json:"trackingPlanVersion"`
-	SourceTpConfig      map[string]map[string]interface{} `json:"sourceTpConfig"`
-	MergedTpConfig      map[string]interface{}            `json:"mergedTpConfig"`
+	TrackingPlanID      string                            `json:"trackingPlanId,omitempty"`
+	TrackingPlanVersion int                               `json:"trackingPlanVersion,omitempty"`
+	SourceTpConfig      map[string]map[string]interface{} `json:"sourceTpConfig,omitempty"`
+	MergedTpConfig      map[string]interface{}            `json:"mergedTpConfig,omitempty"`
 	DestinationID       string                            `json:"destinationId"`
 	JobID               int64                             `json:"jobId"`
-	SourceJobID         string                            `json:"sourceJobId"`
-	SourceJobRunID      string                            `json:"sourceJobRunId"`
-	SourceTaskRunID     string                            `json:"sourceTaskRunId"`
-	RecordID            interface{}                       `json:"recordId"`
+	SourceJobID         string                            `json:"sourceJobId,omitempty"`
+	SourceJobRunID      string                            `json:"sourceJobRunId,omitempty"`
+	SourceTaskRunID     string                            `json:"sourceTaskRunId,omitempty"`
+	RecordID            interface{}                       `json:"recordId,omitempty"`
 	DestinationType     string                            `json:"destinationType"`
 	DestinationName     string                            `json:"destinationName"`
 	MessageID           string                            `json:"messageId"`
-	OAuthAccessToken    string                            `json:"oauthAccessToken"`
-	TraceParent         string                            `json:"traceparent"`
+	OAuthAccessToken    string                            `json:"oauthAccessToken,omitempty"`
+	TraceParent         string                            `json:"traceparent,omitempty"`
 	// set by user_transformer to indicate transformed event is part of group indicated by messageIDs
-	MessageIDs              []string `json:"messageIds"`
-	RudderID                string   `json:"rudderId"`
-	ReceivedAt              string   `json:"receivedAt"`
-	EventName               string   `json:"eventName"`
-	EventType               string   `json:"eventType"`
-	SourceDefinitionID      string   `json:"sourceDefinitionId"`
-	DestinationDefinitionID string   `json:"destinationDefinitionId"`
-	TransformationID        string   `json:"transformationId"`
-	TransformationVersionID string   `json:"transformationVersionId"`
+	MessageIDs              []string `json:"messageIds,omitempty"`
+	RudderID                string   `json:"rudderId,omitempty"`
+	ReceivedAt              string   `json:"receivedAt,omitempty"`
+	EventName               string   `json:"eventName,omitempty"`
+	EventType               string   `json:"eventType,omitempty"`
+	SourceDefinitionID      string   `json:"sourceDefinitionId,omitempty"`
+	DestinationDefinitionID string   `json:"destinationDefinitionId,omitempty"`
+	TransformationID        string   `json:"transformationId,omitempty"`
+	TransformationVersionID string   `json:"transformationVersionId,omitempty"`
 	SourceDefinitionType    string   `json:"-"`
 }
 

--- a/processor/types/types.go
+++ b/processor/types/types.go
@@ -80,6 +80,21 @@ type CompactedTransformRequest struct {
 	Connections  map[string]backendconfig.Connection   `json:"connections"`
 }
 
+func (ctr *CompactedTransformRequest) ToTransformerEvents() []TransformerEvent {
+	events := make([]TransformerEvent, len(ctr.Input))
+	for i, input := range ctr.Input {
+		events[i] = TransformerEvent{
+			Message:     input.Message,
+			Metadata:    input.Metadata,
+			Destination: ctr.Destinations[input.Metadata.DestinationID],
+			Connection:  ctr.Connections[input.Metadata.SourceID+":"+input.Metadata.DestinationID],
+			Libraries:   input.Libraries,
+			Credentials: input.Credentials,
+		}
+	}
+	return events
+}
+
 // ToUserTransformerEvent removes the connection from the event
 // along with pruning the destination to only include the transformation ID and VersionID
 // before sending it to the transformer thereby reducing the payload size

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -128,6 +128,7 @@ func (rt *Handle) Setup(
 	rt.transformer = transformer.NewTransformer(rt.netClientTimeout, rt.transformerTimeout,
 		backendConfig, rt.reloadableConfig.oauthV2Enabled,
 		rt.reloadableConfig.oauthV2ExpirationTimeDiff,
+		rt.transformerFeaturesService,
 	)
 	rt.isOAuthDestination = oauth.IsOAuthDestination(destinationDefinition.Config)
 	rt.oauth = oauth.NewOAuthErrorHandler(backendConfig)

--- a/router/testdata/rtIsolationTestTemplate.json.tpl
+++ b/router/testdata/rtIsolationTestTemplate.json.tpl
@@ -27,6 +27,7 @@
                         "transformations": [],
                         "destinationDefinition": {
                             "config": {
+                                "cdkV2Enabled": true,
                                 "destConfig": {
                                     "defaultConfig": [
                                         "webhookUrl",

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -782,16 +782,12 @@ func getEndpointFromURL(urlStr string) string {
 }
 
 func (trans *handle) compactRequestPayloads() bool {
-	if trans.compactionSupported && trans.compactionEnabled.Load() {
-		return true
-	}
-	return trans.forceCompactionEnabled
+	return (trans.compactionSupported && trans.compactionEnabled.Load()) || trans.forceCompactionEnabled
 }
 
 func (trans *handle) getRequestPayload(data *types.TransformMessageT, compactRequestPayloads bool) ([]byte, error) {
 	if compactRequestPayloads {
-		compacted := data.Compacted()
-		return jsonrs.Marshal(compacted)
+		return jsonrs.Marshal(data.Compacted())
 	}
 	return jsonrs.Marshal(&data)
 }

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -34,6 +34,7 @@ import (
 	cntx "github.com/rudderlabs/rudder-server/services/oauth/v2/context"
 	"github.com/rudderlabs/rudder-server/services/oauth/v2/extensions"
 	oauthv2httpclient "github.com/rudderlabs/rudder-server/services/oauth/v2/http"
+	transformerfs "github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/utils/httputil"
 	"github.com/rudderlabs/rudder-server/utils/sysUtils"
 	utilTypes "github.com/rudderlabs/rudder-server/utils/types"
@@ -69,6 +70,10 @@ type handle struct {
 	oAuthV2EnabledLoader config.ValueLoader[bool]
 	// expirationTimeDiff holds the configured time difference for token expiration.
 	expirationTimeDiff config.ValueLoader[time.Duration]
+
+	forceCompactionEnabled bool // option to force usage of compaction for testing
+	compactionEnabled      config.ValueLoader[bool]
+	compactionSupported    bool
 }
 
 type ProxyRequestMetadata struct {
@@ -113,15 +118,22 @@ type Transformer interface {
 	ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequestParams) ProxyRequestResponse
 }
 
-// NewTransformer creates a new transformer
-func NewTransformer(destinationTimeout, transformTimeout time.Duration, backendConfig backendconfig.BackendConfig, oauthV2Enabled config.ValueLoader[bool], expirationTimeDiff config.ValueLoader[time.Duration]) Transformer {
+// NewTransformer creates a new transformer.
+// If a nil [featuresService] is provided, the transformer will not use message compaction, even though transformation service might support it.
+func NewTransformer(
+	destinationTimeout, transformTimeout time.Duration,
+	backendConfig backendconfig.BackendConfig,
+	oauthV2Enabled config.ValueLoader[bool],
+	expirationTimeDiff config.ValueLoader[time.Duration],
+	featuresService transformerfs.FeaturesService,
+) Transformer {
 	cache := oauthv2.NewCache()
 	oauthLock := sync.NewPartitionRWLocker()
 	handle := &handle{
 		oAuthV2EnabledLoader: oauthV2Enabled,
 		expirationTimeDiff:   expirationTimeDiff,
 	}
-	handle.setup(destinationTimeout, transformTimeout, &cache, oauthLock, backendConfig)
+	handle.setup(destinationTimeout, transformTimeout, &cache, oauthLock, backendConfig, featuresService)
 	return handle
 }
 
@@ -159,9 +171,9 @@ func (t transformerMetricLabels) ToStatsTag() stats.Tags {
 func (trans *handle) Transform(transformType string, transformMessage *types.TransformMessageT) []types.DestinationJobT {
 	var destinationJobs types.DestinationJobs
 	transformMessageCopy, preservedData := transformMessage.Dehydrate()
+	compactRequestPayloads := trans.compactRequestPayloads() // consistent state for the entire request
 
-	// Call remote transformation
-	rawJSON, err := jsonrs.Marshal(&transformMessageCopy)
+	rawJSON, err := trans.getRequestPayload(transformMessageCopy, compactRequestPayloads)
 	if err != nil {
 		trans.logger.Errorf("problematic input for marshalling: %#v", transformMessage)
 		panic(err)
@@ -207,6 +219,9 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 		}
 
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		if compactRequestPayloads {
+			req.Header.Set("X-Content-Format", "json+compactedv1")
+		}
 		req.Header.Set("X-Feature-Gzip-Support", "?1")
 		// Header to let transformer know that the client understands event filter code
 		req.Header.Set("X-Feature-Filter-Code", "?1")
@@ -550,7 +565,7 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	}
 }
 
-func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration, cache *oauthv2.Cache, locker *sync.PartitionRWLocker, backendConfig backendconfig.BackendConfig) {
+func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration, cache *oauthv2.Cache, locker *sync.PartitionRWLocker, backendConfig backendconfig.BackendConfig, featuresService transformerfs.FeaturesService) {
 	if loggerOverride == nil {
 		trans.logger = logger.NewLogger().Child("router").Child("transformer")
 	} else {
@@ -591,6 +606,14 @@ func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration, c
 	trans.proxyClientOAuthV2 = oauthv2httpclient.NewOAuthHttpClient(&http.Client{Transport: trans.tr, Timeout: trans.destinationTimeout + trans.transformTimeout}, common.RudderFlowDelivery, cache, backendConfig, GetAuthErrorCategoryFromTransformProxyResponse, proxyClientOptionalArgs)
 	trans.stats = stats.Default
 	trans.transformRequestTimerStat = stats.Default.NewStat("router.transformer_request_time", stats.TimerType)
+	trans.forceCompactionEnabled = config.GetBoolVar(false, "Router.DestinationTransformer.forceCompactionEnabled", "Transformer.forceCompactionEnabled")
+	trans.compactionEnabled = config.GetReloadableBoolVar(false, "Router.DestinationTransformer.compactionEnabled", "Transformer.compactionEnabled")
+	if featuresService != nil {
+		go func() {
+			<-featuresService.Wait()
+			trans.compactionSupported = featuresService.SupportDestTransformCompactedPayloadV1()
+		}()
+	}
 }
 
 func (trans *handle) transformerClientConfig() *transformerclient.ClientConfig {
@@ -756,4 +779,19 @@ func getEndpointFromURL(urlStr string) string {
 		return parsedURL.Host
 	}
 	return ""
+}
+
+func (trans *handle) compactRequestPayloads() bool {
+	if trans.compactionSupported && trans.compactionEnabled.Load() {
+		return true
+	}
+	return trans.forceCompactionEnabled
+}
+
+func (trans *handle) getRequestPayload(data *types.TransformMessageT, compactRequestPayloads bool) ([]byte, error) {
+	if compactRequestPayloads {
+		compacted := data.Compacted()
+		return jsonrs.Marshal(compacted)
+	}
+	return jsonrs.Marshal(&data)
 }

--- a/router/types/types.go
+++ b/router/types/types.go
@@ -103,6 +103,35 @@ type TransformMessageT struct {
 	DestType string       `json:"destType"`
 }
 
+func (tm *TransformMessageT) Compacted() *CompactedTransformMessageT {
+	res := CompactedTransformMessageT{
+		Data: make([]struct {
+			Message     json.RawMessage `json:"message"`
+			JobMetadata JobMetadataT    `json:"metadata"`
+		}, len(tm.Data)),
+		DestType:     tm.DestType,
+		Destinations: make(map[string]backendconfig.DestinationT),
+		Connections:  make(map[string]backendconfig.Connection),
+	}
+	for i := range tm.Data {
+		res.Data[i].Message = tm.Data[i].Message
+		res.Data[i].JobMetadata = tm.Data[i].JobMetadata
+		res.Destinations[tm.Data[i].JobMetadata.DestinationID] = tm.Data[i].Destination
+		res.Connections[tm.Data[i].JobMetadata.SourceID+":"+tm.Data[i].JobMetadata.DestinationID] = tm.Data[i].Connection
+	}
+	return &res
+}
+
+type CompactedTransformMessageT struct {
+	Data []struct {
+		Message     json.RawMessage `json:"message"`
+		JobMetadata JobMetadataT    `json:"metadata"`
+	} `json:"input"`
+	DestType     string                                `json:"destType"`
+	Destinations map[string]backendconfig.DestinationT `json:"destinations"`
+	Connections  map[string]backendconfig.Connection   `json:"connections"`
+}
+
 // Dehydrate JobT information from RouterJobT.JobMetadata returning the dehydrated message along with the jobs
 func (tm *TransformMessageT) Dehydrate() (*TransformMessageT, map[int64]lo.Tuple2[*jobsdb.JobT, routerutils.JobParameters]) {
 	jobs := make(map[int64]lo.Tuple2[*jobsdb.JobT, routerutils.JobParameters])

--- a/router/types/types.go
+++ b/router/types/types.go
@@ -116,8 +116,13 @@ func (tm *TransformMessageT) Compacted() *CompactedTransformMessageT {
 	for i := range tm.Data {
 		res.Data[i].Message = tm.Data[i].Message
 		res.Data[i].JobMetadata = tm.Data[i].JobMetadata
-		res.Destinations[tm.Data[i].JobMetadata.DestinationID] = tm.Data[i].Destination
-		res.Connections[tm.Data[i].JobMetadata.SourceID+":"+tm.Data[i].JobMetadata.DestinationID] = tm.Data[i].Connection
+		if _, ok := res.Destinations[tm.Data[i].JobMetadata.DestinationID]; !ok {
+			res.Destinations[tm.Data[i].JobMetadata.DestinationID] = tm.Data[i].Destination
+		}
+		connectionKey := tm.Data[i].JobMetadata.SourceID + ":" + tm.Data[i].JobMetadata.DestinationID
+		if _, ok := res.Connections[connectionKey]; !ok {
+			res.Connections[connectionKey] = tm.Data[i].Connection
+		}
 	}
 	return &res
 }

--- a/router/types/types_test.go
+++ b/router/types/types_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/router/types"
 )
@@ -35,5 +36,42 @@ func TestDehydrateAndHydrate(t *testing.T) {
 
 	for i := range destJobs {
 		require.NotNil(t, destJobs[i].JobMetadataArray[0].JobT, "JobT should not be nil")
+	}
+}
+
+func TestCompactedTransformMessage(t *testing.T) {
+	msg := types.TransformMessageT{
+		Data: []types.RouterJobT{
+			{
+				Message:     []byte(`{"key": "msg1"}`),
+				Destination: backendconfig.DestinationT{ID: "d1"},
+				Connection:  backendconfig.Connection{SourceID: "s1", DestinationID: "d1"},
+				JobMetadata: types.JobMetadataT{DestinationID: "d1", SourceID: "s1"},
+			},
+			{
+				Message:     []byte(`{"key": "msg2"}`),
+				Destination: backendconfig.DestinationT{ID: "d2"},
+				Connection:  backendconfig.Connection{SourceID: "s1", DestinationID: "d2"},
+				JobMetadata: types.JobMetadataT{DestinationID: "d2", SourceID: "s1"},
+			},
+			{
+				Message:     []byte(`{"key": "msg3"}`),
+				Destination: backendconfig.DestinationT{ID: "d2"},
+				Connection:  backendconfig.Connection{SourceID: "s2", DestinationID: "d2"},
+				JobMetadata: types.JobMetadataT{DestinationID: "d2", SourceID: "s2"},
+			},
+		},
+	}
+
+	compactedMsg := msg.Compacted()
+	require.Len(t, compactedMsg.Connections, 3)
+	require.Len(t, compactedMsg.Destinations, 2)
+	require.Len(t, compactedMsg.Data, 3)
+	for i := range msg.Data {
+		require.Equal(t, msg.Data[i].Message, compactedMsg.Data[i].Message)
+		require.Equal(t, msg.Data[i].JobMetadata, compactedMsg.Data[i].JobMetadata)
+		require.Equal(t, msg.Data[i].Destination.ID, compactedMsg.Destinations[msg.Data[i].JobMetadata.DestinationID].ID)
+		require.Equal(t, msg.Data[i].Connection.SourceID, compactedMsg.Connections[msg.Data[i].JobMetadata.SourceID+":"+msg.Data[i].JobMetadata.DestinationID].SourceID)
+		require.Equal(t, msg.Data[i].Connection.DestinationID, compactedMsg.Connections[msg.Data[i].JobMetadata.SourceID+":"+msg.Data[i].JobMetadata.DestinationID].DestinationID)
 	}
 }

--- a/services/transformer/features.go
+++ b/services/transformer/features.go
@@ -30,6 +30,7 @@ type FeaturesService interface {
 	SourceTransformerVersion() string
 	RouterTransform(destType string) bool
 	TransformerProxyVersion() string
+	SupportDestTransformCompactedPayloadV1() bool
 	Wait() chan struct{}
 }
 
@@ -91,5 +92,9 @@ func (*noopService) Wait() chan struct{} {
 }
 
 func (*noopService) RouterTransform(_ string) bool {
+	return false
+}
+
+func (*noopService) SupportDestTransformCompactedPayloadV1() bool {
 	return false
 }

--- a/services/transformer/features_impl.go
+++ b/services/transformer/features_impl.go
@@ -59,6 +59,11 @@ func (t *featuresService) Regulations() []string {
 	return []string{}
 }
 
+// SupportDestTransformCompactedPayloadV1 checks if the transformer supports compacted payload for destination transformation
+func (t *featuresService) SupportDestTransformCompactedPayloadV1() bool {
+	return gjson.GetBytes(t.features, "supportDestTransformCompactedPayloadV1").Bool()
+}
+
 func (t *featuresService) Wait() chan struct{} {
 	return t.waitChan
 }

--- a/testhelper/transformertest/handler_funcs.go
+++ b/testhelper/transformertest/handler_funcs.go
@@ -38,6 +38,7 @@ var MirroringRouterTransformerHandler RouterTransformerHandler = func(request ty
 			Message:          req.Message,
 			JobMetadataArray: []types.JobMetadataT{req.JobMetadata},
 			Destination:      req.Destination,
+			Connection:       req.Connection,
 			StatusCode:       http.StatusOK,
 		}
 	}


### PR DESCRIPTION
# Description

Related to https://github.com/rudderlabs/rudder-transformer/pull/4220

From now on, as long as transformer service supports it and the relevant feature flag is enabled, rudder-server is going to send compacted transformation request payloads by making use of lookup tables instead of repeating the same destination and connection information in every event.

The feature can be enabled through the following configuration options
```yaml
Transformer:
  compactionEnabled: true # enables compaction in both processor and router as long as the remote transformer service supports it
  forceCompactionEnabled: true # enables compaction in both processor and router regardless if the remote transformer service supports it or not
Router:
  DestinationTransformer:
    compactionEnabled: true # enables compaction in router as long as the remote transformer service supports it
    forceCompactionEnabled: true # enables compaction in router regardless if the remote transformer service supports it or not
Processor:
  DestinationTransformer:
    compactionEnabled: true # enables it in processor as long as the remote transformer service supports it
    forceCompactionEnabled: true # enables compaction in processor regardless if the remote transformer service supports it or not

```

All three transformer endpoints are being tested for proper handling of compacted payloads through integration tests:
- `POST /:version/destinations/:destination` in `processor_isolation_test.go` using a `WEBHOOK` destination
- `POST /routerTransform` in `router_isolation_test.go` using a `WEBHOOK` destination
- `POST /batch` in `kafka_batching_test.go` using a `KAFKA` destination

We are making use of `RSERVER_TRANSFORMER_FORCE_COMPACTION_ENABLED` flag in our tests for ensuring that the `rudder-transformer` container we are using is indeed able to understand compacted payloads. 

_**Note:** tests are expected to fail until the required feature gets released in rudder-transformer._ (update: all ✅ now)

## Additional items
- Trimming down user transformation payloads by stripping out empty metadata fields and zero destination and connection structs


## Linear Ticket

Resolves PIPE-1992

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
