### PR TITLE
refactor: remove explicit schema synchronization in upload job

### DIFF
--- a/warehouse/integrations/bigquery/bigquery_test.go
+++ b/warehouse/integrations/bigquery/bigquery_test.go
@@ -628,6 +628,7 @@ func TestIntegration(t *testing.T) {
 				t.Setenv("RSERVER_WAREHOUSE_BIGQUERY_ENABLE_DELETE_BY_JOBS", "true")
 				t.Setenv("RSERVER_WAREHOUSE_BIGQUERY_MAX_PARALLEL_LOADS", "8")
 				t.Setenv("RSERVER_WAREHOUSE_BIGQUERY_SLOW_QUERY_THRESHOLD", "0s")
+				t.Setenv("RSERVER_WAREHOUSE_SCHEMA_TTLIN_MINUTES", "0s")
 
 				whth.BootstrapSvc(t, workspaceConfig, httpPort, jobsDBPort)
 

--- a/warehouse/router/identities.go
+++ b/warehouse/router/identities.go
@@ -440,14 +440,6 @@ func (r *Router) populateHistoricIdentities(ctx context.Context, warehouse model
 			return
 		}
 		defer whManager.Cleanup(ctx)
-
-		err = job.schemaHandle.FetchSchemaFromWarehouse(ctx, whManager)
-		if err != nil {
-			r.logger.Errorf(`[WH]: Failed fetching schema from warehouse: %v`, err)
-			_, _ = job.setUploadError(err, model.Aborted)
-			return
-		}
-
 		_ = job.setUploadStatus(UploadStatusOpts{Status: inProgressState(model.ExportedData)})
 		loadErrors, err := job.loadIdentityTables(true)
 		if err != nil {

--- a/warehouse/router/state_create_schema.go
+++ b/warehouse/router/state_create_schema.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (job *UploadJob) createRemoteSchema(whManager manager.Manager) error {
-	if job.schemaHandle.IsWarehouseSchemaEmpty(job.ctx) {
+	if job.schemaHandle.IsSchemaEmpty(job.ctx) {
 		if err := whManager.CreateSchema(job.ctx); err != nil {
 			return fmt.Errorf("creating schema: %w", err)
 		}

--- a/warehouse/router/state_generate_load_files.go
+++ b/warehouse/router/state_generate_load_files.go
@@ -11,9 +11,8 @@ import (
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
-func (job *UploadJob) generateLoadFiles(hasSchemaChanged bool) error {
-	generateAll := hasSchemaChanged ||
-		slices.Contains(warehousesToAlwaysRegenerateAllLoadFilesOnResume, job.warehouse.Type) ||
+func (job *UploadJob) generateLoadFiles() error {
+	generateAll := slices.Contains(warehousesToAlwaysRegenerateAllLoadFilesOnResume, job.warehouse.Type) ||
 		job.config.alwaysRegenerateAllLoadFiles
 
 	var startLoadFileID, endLoadFileID int64

--- a/warehouse/router/state_generate_upload_schema.go
+++ b/warehouse/router/state_generate_upload_schema.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (job *UploadJob) generateUploadSchema() error {
-	uploadSchema, err := job.schemaHandle.ConsolidateStagingFilesUsingLocalSchema(job.ctx, job.stagingFiles)
+	uploadSchema, err := job.schemaHandle.ConsolidateStagingFilesSchema(job.ctx, job.stagingFiles)
 	if err != nil {
 		return fmt.Errorf("consolidate staging files schema using warehouse schema: %w", err)
 	}

--- a/warehouse/router/upload_test.go
+++ b/warehouse/router/upload_test.go
@@ -171,7 +171,7 @@ func TestColumnCountStat(t *testing.T) {
 					},
 				},
 			}, whManager)
-			err = j.schemaHandle.UpdateWarehouseTableSchema(ctx, tableName, model.TableSchema{
+			err = j.schemaHandle.UpdateTableSchema(ctx, tableName, model.TableSchema{
 				"test-column-1": "string",
 				"test-column-2": "string",
 				"test-column-3": "string",
@@ -187,7 +187,7 @@ func TestColumnCountStat(t *testing.T) {
 			m2 := statsStore.Get("warehouse_load_table_column_limit", tags)
 
 			if tc.statExpected {
-				columnsCount, err := j.schemaHandle.GetColumnsCountInWarehouseSchema(ctx, tableName)
+				columnsCount, err := j.schemaHandle.GetColumnsCount(ctx, tableName)
 				require.NoError(t, err)
 				require.EqualValues(t, m1.LastValue(), columnsCount)
 				require.EqualValues(t, m2.LastValue(), tc.columnCountLimit)

--- a/warehouse/schema/schema.go
+++ b/warehouse/schema/schema.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	"github.com/rudderlabs/rudder-server/jsonrs"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
@@ -45,27 +46,21 @@ type fetchSchemaRepo interface {
 }
 
 type Handler interface {
-	// Synchronizes the schema with the schema from the warehouse
-	SyncRemoteSchema(ctx context.Context, fetchSchemaRepo fetchSchemaRepo, uploadID int64) (bool, error)
 	// Check if schema exists for the namespace
-	IsWarehouseSchemaEmpty(ctx context.Context) bool
+	IsSchemaEmpty(ctx context.Context) bool
 	// Retrieves the schema for a specific table
-	GetTableSchemaInWarehouse(ctx context.Context, tableName string) model.TableSchema
+	GetTableSchema(ctx context.Context, tableName string) model.TableSchema
 	// Updates the schema with the provided schema definition
-	UpdateLocalSchema(ctx context.Context, updatedSchema model.Schema) error
+	UpdateSchema(ctx context.Context, updatedSchema model.Schema) error
 	// Updates the schema for a specific table
-	UpdateWarehouseTableSchema(ctx context.Context, tableName string, tableSchema model.TableSchema) error
+	UpdateTableSchema(ctx context.Context, tableName string, tableSchema model.TableSchema) error
 	// Returns the number of columns present in the schema for a given table
-	GetColumnsCountInWarehouseSchema(ctx context.Context, tableName string) (int, error)
+	GetColumnsCount(ctx context.Context, tableName string) (int, error)
 	// Merges schemas from staging files with the schema to produce a consolidated schema.
-	ConsolidateStagingFilesUsingLocalSchema(ctx context.Context, stagingFiles []*model.StagingFile) (model.Schema, error)
-	// TODO: Remove this method as it's no longer needed.
-	UpdateLocalSchemaWithWarehouse(ctx context.Context) error
+	ConsolidateStagingFilesSchema(ctx context.Context, stagingFiles []*model.StagingFile) (model.Schema, error)
 	// Computes the difference between the existing schema of a table and a newly provided schema.
 	// Returns details of added and modified columns
 	TableSchemaDiff(ctx context.Context, tableName string, tableSchema model.TableSchema) (whutils.TableSchemaDiff, error)
-	// Synchronizes the schema with the schema from the warehouse
-	FetchSchemaFromWarehouse(ctx context.Context, repo fetchSchemaRepo) error
 }
 
 type schema struct {
@@ -116,11 +111,7 @@ func New(
 	return schema
 }
 
-func (sh *schema) SyncRemoteSchema(ctx context.Context, _ fetchSchemaRepo, uploadID int64) (bool, error) {
-	return false, sh.FetchSchemaFromWarehouse(ctx, sh.fetchSchemaRepo)
-}
-
-func (sh *schema) IsWarehouseSchemaEmpty(ctx context.Context) bool {
+func (sh *schema) IsSchemaEmpty(ctx context.Context) bool {
 	schema, err := sh.getSchema(ctx)
 	if err != nil {
 		sh.log.Warnn("error getting schema", obskit.Error(err))
@@ -129,7 +120,7 @@ func (sh *schema) IsWarehouseSchemaEmpty(ctx context.Context) bool {
 	return len(schema) == 0
 }
 
-func (sh *schema) GetTableSchemaInWarehouse(ctx context.Context, tableName string) model.TableSchema {
+func (sh *schema) GetTableSchema(ctx context.Context, tableName string) model.TableSchema {
 	schema, err := sh.getSchema(ctx)
 	if err != nil {
 		sh.log.Warnn("error getting schema", obskit.Error(err))
@@ -138,7 +129,7 @@ func (sh *schema) GetTableSchemaInWarehouse(ctx context.Context, tableName strin
 	return schema[tableName]
 }
 
-func (sh *schema) UpdateLocalSchema(ctx context.Context, updatedSchema model.Schema) error {
+func (sh *schema) UpdateSchema(ctx context.Context, updatedSchema model.Schema) error {
 	updatedSchemaInBytes, err := jsonrs.Marshal(updatedSchema)
 	if err != nil {
 		return fmt.Errorf("marshaling schema: %w", err)
@@ -147,7 +138,7 @@ func (sh *schema) UpdateLocalSchema(ctx context.Context, updatedSchema model.Sch
 	return sh.saveSchema(ctx, updatedSchema)
 }
 
-func (sh *schema) UpdateWarehouseTableSchema(ctx context.Context, tableName string, tableSchema model.TableSchema) error {
+func (sh *schema) UpdateTableSchema(ctx context.Context, tableName string, tableSchema model.TableSchema) error {
 	schema, err := sh.getSchema(ctx)
 	if err != nil {
 		return fmt.Errorf("getting schema: %w", err)
@@ -164,7 +155,7 @@ func (sh *schema) UpdateWarehouseTableSchema(ctx context.Context, tableName stri
 	return nil
 }
 
-func (sh *schema) GetColumnsCountInWarehouseSchema(ctx context.Context, tableName string) (int, error) {
+func (sh *schema) GetColumnsCount(ctx context.Context, tableName string) (int, error) {
 	schema, err := sh.getSchema(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("getting schema: %w", err)
@@ -172,7 +163,7 @@ func (sh *schema) GetColumnsCountInWarehouseSchema(ctx context.Context, tableNam
 	return len(schema[tableName]), nil
 }
 
-func (sh *schema) ConsolidateStagingFilesUsingLocalSchema(ctx context.Context, stagingFiles []*model.StagingFile) (model.Schema, error) {
+func (sh *schema) ConsolidateStagingFilesSchema(ctx context.Context, stagingFiles []*model.StagingFile) (model.Schema, error) {
 	consolidatedSchema := model.Schema{}
 	batches := lo.Chunk(stagingFiles, sh.stagingFilesSchemaPaginationSize)
 	for _, batch := range batches {
@@ -199,22 +190,12 @@ func (sh *schema) isIDResolutionEnabled() bool {
 	return sh.enableIDResolution && slices.Contains(whutils.IdentityEnabledWarehouses, sh.warehouse.Type)
 }
 
-func (sh *schema) UpdateLocalSchemaWithWarehouse(ctx context.Context) error {
-	// no-op
-	return nil
-}
-
 func (sh *schema) TableSchemaDiff(ctx context.Context, tableName string, tableSchema model.TableSchema) (whutils.TableSchemaDiff, error) {
 	schema, err := sh.getSchema(ctx)
 	if err != nil {
 		return whutils.TableSchemaDiff{}, fmt.Errorf("getting schema: %w", err)
 	}
 	return tableSchemaDiff(tableName, schema, tableSchema), nil
-}
-
-func (sh *schema) FetchSchemaFromWarehouse(ctx context.Context, _ fetchSchemaRepo) error {
-	_, err := sh.fetchSchemaFromWarehouse(ctx)
-	return err
 }
 
 func (sh *schema) fetchSchemaFromWarehouse(ctx context.Context) (model.Schema, error) {

--- a/warehouse/schema/schema_test.go
+++ b/warehouse/schema/schema_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
@@ -85,7 +86,7 @@ func (m *mockStagingFileRepo) GetSchemasByIDs(context.Context, []int64) ([]model
 var ttl = 10 * time.Minute
 
 func newSchema(warehouse model.Warehouse, schemaRepo schemaRepo) *schema {
-	return &schema{
+	sch := &schema{
 		warehouse:                        warehouse,
 		log:                              logger.NOP,
 		ttlInMinutes:                     ttl,
@@ -94,6 +95,8 @@ func newSchema(warehouse model.Warehouse, schemaRepo schemaRepo) *schema {
 		now:                              timeutil.Now,
 		stagingFilesSchemaPaginationSize: 2,
 	}
+	sch.stats.schemaSize = stats.NOP.NewStat("warehouse_schema_size", stats.HistogramType)
+	return sch
 }
 
 func TestSchema(t *testing.T) {
@@ -111,27 +114,46 @@ func TestSchema(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	t.Run("SyncRemoteSchema", func(t *testing.T) {
-		schema, err := sch.getSchema(ctx)
-		require.NoError(t, err)
-		require.Equal(t, model.Schema{}, schema)
-		require.True(t, sch.IsWarehouseSchemaEmpty(ctx))
-
-		_, err = sch.SyncRemoteSchema(ctx, nil, 0)
-		require.NoError(t, err)
-		schema, err = sch.getSchema(ctx)
-		require.NoError(t, err)
-		require.Equal(t, model.Schema{
+	t.Run("Test IsSchemaEmpty", func(t *testing.T) {
+		sch := newSchema(warehouse, &mockSchemaRepo{
+			schemaMap: make(map[string]model.WHSchema),
+		})
+		require.True(t, sch.IsSchemaEmpty(ctx))
+		err := sch.UpdateSchema(ctx, model.Schema{
 			"table1": {
 				"column1": "string",
 				"column2": "int",
 			},
 			"table2": {
 				"column11": "string",
-				"column12": "int",
-				"column13": "int",
 			},
-		}, schema)
+		})
+		require.NoError(t, err)
+		require.False(t, sch.IsSchemaEmpty(ctx))
+	})
+
+	t.Run("Test GetTableSchema", func(t *testing.T) {
+		sch := newSchema(warehouse, &mockSchemaRepo{
+			schemaMap: map[string]model.WHSchema{
+				"source_id_dest_id_namespace": {
+					Schema: model.Schema{
+						"table1": {
+							"column1": "string",
+							"column2": "int",
+						},
+						"table2": {
+							"column11": "string",
+						},
+					},
+					ExpiresAt: timeutil.Now().Add(10 * time.Minute),
+				},
+			},
+		})
+		tableSchema := sch.GetTableSchema(ctx, "table1")
+		require.Equal(t, model.TableSchema{
+			"column1": "string",
+			"column2": "int",
+		}, tableSchema)
 	})
 
 	t.Run("Test ttl", func(t *testing.T) {
@@ -151,25 +173,20 @@ func TestSchema(t *testing.T) {
 				},
 			},
 		})
-		count, err := sch.GetColumnsCountInWarehouseSchema(ctx, "table2")
+		count, err := sch.GetColumnsCount(ctx, "table2")
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
-		_, err = sch.SyncRemoteSchema(ctx, nil, 0)
-		require.NoError(t, err)
-		count, err = sch.GetColumnsCountInWarehouseSchema(ctx, "table2")
-		require.NoError(t, err)
-		require.Equal(t, 3, count)
 
 		sch.now = func() time.Time {
 			return timeutil.Now().Add(ttl * 2)
 		}
-		count, err = sch.GetColumnsCountInWarehouseSchema(ctx, "table2")
+		count, err = sch.GetColumnsCount(ctx, "table2")
 		require.NoError(t, err)
-		require.Equal(t, 4, count)
+		require.Equal(t, 3, count)
 	})
 
 	t.Run("TableSchemaDiff", func(t *testing.T) {
-		err := sch.UpdateWarehouseTableSchema(ctx, "table2", model.TableSchema{
+		err := sch.UpdateTableSchema(ctx, "table2", model.TableSchema{
 			"column11": "string",
 			"column12": "int",
 			"column13": "int",
@@ -192,7 +209,7 @@ func TestSchema(t *testing.T) {
 		}, diff)
 	})
 
-	t.Run("ConsolidateStagingFilesUsingLocalSchema", func(t *testing.T) {
+	t.Run("ConsolidateStagingFilesSchema", func(t *testing.T) {
 		sourceID := "test_source_id"
 		destinationID := "test_destination_id"
 		namespace := "test_namespace"
@@ -1238,7 +1255,7 @@ func TestSchema(t *testing.T) {
 				sch.now = func() time.Time {
 					return time.Time{}
 				}
-				uploadSchema, err := sch.ConsolidateStagingFilesUsingLocalSchema(ctx, stagingFiles)
+				uploadSchema, err := sch.ConsolidateStagingFilesSchema(ctx, stagingFiles)
 				if tc.wantError == nil {
 					require.NoError(t, err)
 				} else {

--- a/warehouse/schema/schema_test.go
+++ b/warehouse/schema/schema_test.go
@@ -114,7 +114,7 @@ func TestSchema(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	t.Run("Test IsSchemaEmpty", func(t *testing.T) {
+	t.Run("IsSchemaEmpty", func(t *testing.T) {
 		sch := newSchema(warehouse, &mockSchemaRepo{
 			schemaMap: make(map[string]model.WHSchema),
 		})
@@ -132,7 +132,7 @@ func TestSchema(t *testing.T) {
 		require.False(t, sch.IsSchemaEmpty(ctx))
 	})
 
-	t.Run("Test GetTableSchema", func(t *testing.T) {
+	t.Run("GetTableSchema", func(t *testing.T) {
 		sch := newSchema(warehouse, &mockSchemaRepo{
 			schemaMap: map[string]model.WHSchema{
 				"source_id_dest_id_namespace": {
@@ -156,7 +156,7 @@ func TestSchema(t *testing.T) {
 		}, tableSchema)
 	})
 
-	t.Run("Test ttl", func(t *testing.T) {
+	t.Run("ttl", func(t *testing.T) {
 		sch := newSchema(warehouse, &mockSchemaRepo{
 			schemaMap: map[string]model.WHSchema{
 				"source_id_dest_id_namespace": {


### PR DESCRIPTION
# Description

**Updated the Handler interface in schema:**
- Removed `SyncRemoteSchema` and `FetchSchemaFromWarehouse` since schema sync is now driven by TTL instead of the caller.
- Removed the no-op `UpdateLocalSchemaWithWarehouse` method.
- Renamed methods to eliminate "local" and "warehouse" from their names.

**Other updates:**
- Updated `updateSchema` and `loadTable` to remove the first argument, as it is no longer used.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
