### PR TITLE
chore: avoid using reflections for warehouse transformations

### DIFF
--- a/warehouse/transformer/datatype_test.go
+++ b/warehouse/transformer/datatype_test.go
@@ -1,18 +1,25 @@
 package transformer
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-server/processor/types"
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
 func TestDataType(t *testing.T) {
-	sliceOfIntegers := make([]int, 600)
-	for i := 0; i < 512; i++ {
-		sliceOfIntegers[i] = i
+	anySlice, validationErrorSlice := make([]any, 600), make([]types.ValidationError, 600)
+	anyMap := make(map[string]any)
+	for i := 0; i < 600; i++ {
+		anySlice[i] = i
+		validationErrorSlice[i] = types.ValidationError{
+			Type: "type",
+		}
+		anyMap[strconv.Itoa(i)] = i
 	}
 
 	testCases := []struct {
@@ -45,10 +52,12 @@ func TestDataType(t *testing.T) {
 		{"Redshift violationErrors", whutils.RS, violationErrors, `{"key": "value"}`, false, "string"},
 
 		// Redshift with text and string types
-		{"Redshift Text Type (Array)", whutils.RS, "someKey", [600]int{1, 2, 3}, false, "text"},
-		{"Redshift Text Type (Slice)", whutils.RS, "someKey", sliceOfIntegers, false, "text"},
-		{"Redshift Text Type (Array)", whutils.RS, "someKey", [3]int{1, 2, 3}, false, "string"},
-		{"Redshift Text Type (Slice)", whutils.RS, "someKey", []int{1, 2, 3}, false, "string"},
+		{"Redshift Text Type (Any Slice)", whutils.RS, "someKey", anySlice, false, "text"},
+		{"Redshift String Type (Any Slice)", whutils.RS, "someKey", []any{1, 2, 3}, false, "string"},
+		{"Redshift Text Type (Validation Error Slice)", whutils.RS, "someKey", validationErrorSlice, false, "text"},
+		{"Redshift String Type (Validation Error Slice)", whutils.RS, "someKey", []types.ValidationError{{Type: "type"}, {Type: "type"}, {Type: "type"}}, false, "string"},
+		{"Redshift Text Type (Any Map)", whutils.RS, "someKey", anyMap, false, "text"},
+		{"Redshift String Type (Any Map)", whutils.RS, "someKey", map[string]any{"1": 1, "2": 2, "3": 3}, false, "string"},
 		{"Redshift Text Type", whutils.RS, "someKey", strings.Repeat("a", 600), false, "text"},
 		{"Redshift String Type (nil)", whutils.RS, "someKey", nil, false, "string"},
 		{"Redshift String Type (shortValue)", whutils.RS, "someKey", "shortValue", false, "string"},
@@ -73,45 +82,47 @@ func TestDataType(t *testing.T) {
 // BenchmarkDataType/string
 // BenchmarkDataType/string-12      	24060914	        51.80 ns/op
 // BenchmarkDataType/text
-// BenchmarkDataType/text-12        	 4626680	       281.2 ns/op
+// BenchmarkDataType/text-12        	 4835743	       246.4 ns/op
 // BenchmarkDataType/json
-// BenchmarkDataType/json-12        	23007733	        58.03 ns/op
+// BenchmarkDataType/json-12        	22701242	        53.24 ns/op
 // BenchmarkDataType/datetime
 // BenchmarkDataType/datetime-12    	 1463211	       814.5 ns/op
 func BenchmarkDataType(b *testing.B) {
+	key := "someKey"
+
 	b.Run("int", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			dataTypeFor(whutils.POSTGRES, "someKey", 42, false)
+			dataTypeFor(whutils.POSTGRES, key, 42, false)
 		}
 	})
 	b.Run("float", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			dataTypeFor(whutils.POSTGRES, "someKey", 42.5, false)
+			dataTypeFor(whutils.POSTGRES, key, 42.5, false)
 		}
 	})
 	b.Run("bool", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			dataTypeFor(whutils.POSTGRES, "someKey", true, false)
+			dataTypeFor(whutils.POSTGRES, key, true, false)
 		}
 	})
 	b.Run("string", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			dataTypeFor(whutils.POSTGRES, "someKey", "shortValue", false)
+			dataTypeFor(whutils.POSTGRES, key, "shortValue", false)
 		}
 	})
 	b.Run("text", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			dataTypeFor(whutils.RS, "someKey", strings.Repeat("a", 600), false)
+			dataTypeFor(whutils.RS, key, strings.Repeat("a", 600), false)
 		}
 	})
 	b.Run("json", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			dataTypeFor(whutils.RS, "someKey", `{"key": "value"}`, true)
+			dataTypeFor(whutils.RS, key, `{"key": "value"}`, true)
 		}
 	})
 	b.Run("datetime", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			dataTypeFor(whutils.POSTGRES, "someKey", "2022-10-05T14:48:00.000Z", false)
+			dataTypeFor(whutils.POSTGRES, key, "2022-10-05T14:48:00.000Z", false)
 		}
 	})
 }

--- a/warehouse/transformer/internal/utils/utils_test.go
+++ b/warehouse/transformer/internal/utils/utils_test.go
@@ -104,8 +104,8 @@ func TestToString(t *testing.T) {
 		{123.45, "123.45"},                       // float
 		{true, "true"},                           // bool true
 		{false, "false"},                         // bool false
-		{[]int{1, 2, 3}, "[1 2 3]"},              // slice
-		{map[string]int{"key": 1}, "map[key:1]"}, // map
+		{[]any{1, 2, 3}, "[1 2 3]"},              // slice
+		{map[string]any{"key": 1}, "map[key:1]"}, // map
 		{struct{}{}, "{}"},                       // empty struct
 		{struct{ Field string }{"value"}, "{value}"},                     // struct with field
 		{Person{Name: "Alice", Age: 30}, "Person(Name: Alice, Age: 30)"}, // struct with String method

--- a/warehouse/transformer/transformer_benchmark_test.go
+++ b/warehouse/transformer/transformer_benchmark_test.go
@@ -35,7 +35,7 @@ func Benchmark_Transformer(b *testing.B) {
 		require.NoError(t, err)
 
 		batchSize := 1000
-		events := lo.Times(batchSize, func(index int) types.TransformerEvent {
+		events := lo.Times(batchSize, func(int) types.TransformerEvent {
 			return types.TransformerEvent{
 				Message:     singularEvent,
 				Metadata:    metadata,

--- a/warehouse/transformer/transformer_test.go
+++ b/warehouse/transformer/transformer_test.go
@@ -558,8 +558,8 @@ func TestTransformer(t *testing.T) {
 			},
 		},
 		{
-			name:         "Empty array and object",
-			eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4", "empty_array":[],"empty_object":{},"nil":null}}`,
+			name:         "Empty slice and object",
+			eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4", "empty_slice":[],"empty_object":{},"nil":null}}`,
 			metadata:     getTrackMetadata("POSTGRES", "webhook"),
 			destination:  getDestination("POSTGRES", map[string]any{}),
 			expectedResponse: types.Response{


### PR DESCRIPTION
# Description

- Avoid using refections instead use type inferring for warehouse transformations.

## Linear Ticket

- Resolves WAR-454

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
