### PR TITLE
fix(router): applying excessive read pressure to the database when jobs are being throttled

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2471,7 +2471,7 @@ func (proc *Handle) storeStage(partition string, in *storeMessage) {
 	}
 
 	if proc.limiter.store != nil {
-		defer proc.limiter.store.BeginWithPriority("", proc.getLimiterPriority(partition))()
+		defer proc.limiter.store.BeginWithPriority(partition, proc.getLimiterPriority(partition))()
 		defer proc.stats.statStoreStageCount(partition).Count(len(in.statusList))
 	}
 

--- a/router/handle.go
+++ b/router/handle.go
@@ -293,6 +293,7 @@ func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worke
 			iterator.Discard(job)
 			discardedCount++
 			if rt.stopIteration(err) {
+				iterator.Stop()
 				iterationInterrupted = true
 				break
 			}


### PR DESCRIPTION
# Description
Router picks up 10K jobs during each loop. Whenever any job gets discarded due to throttling, even if it is the first one, router stops the iteration immediately and the next loop kicks in after <1sec, which will pick up again 10K jobs.

With all destinations being throttled at 1K/sec by default, router ends up querying 10K+ jobs/sec while it can only produce max 1K/sec. This excessive number of jobs that are being retrieved from the database, cause high read iops and affects all other database operations.

To alleviate this issue, whenever a job is discarded due to throttling in a router's pipeline, this pipeline will mark all pending jobs as discarded, effectively making the loop eligible for sleeping for `failingJobsPenaltySleep` seconds , relieving some of the read pressure from the database.


**Note:** we are additionally adjusting the default throttling limit to 3K/sec and the default router job pickup size to 3K.

## Linear Ticket

resolves PIPE-1996

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
