### PR TITLE
feat(processor): concurrent store steps

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -123,6 +123,8 @@ jobs:
       - run: go mod download # Not required, used to segregate module download vs test times
       - name: tests
         run: FORCE_RUN_INTEGRATION_TESTS=true make test exclude="/rudder-server/(jobsdb|integration_test|processor|regulation-worker|router|services|suppression-backup-service|warehouse)"
+        env:
+          RSERVER_PROCESSOR_ENABLE_CONCURRENT_STORE: "true"
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
@@ -190,6 +192,7 @@ jobs:
           SNOWPIPE_STREAMING_KEYPAIR_UNENCRYPTED_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.SNOWPIPE_STREAMING_KEYPAIR_UNENCRYPTED_INTEGRATION_TEST_CREDENTIALS }}
           SNOWPIPE_STREAMING_KEYPAIR_ENCRYPTED_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.SNOWPIPE_STREAMING_KEYPAIR_ENCRYPTED_INTEGRATION_TEST_CREDENTIALS }}
           SNOWFLAKE_PRIVILEGE_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.SNOWFLAKE_PRIVILEGE_INTEGRATION_TEST_CREDENTIALS }}
+          RSERVER_PROCESSOR_ENABLE_CONCURRENT_STORE: "true"
         run: FORCE_RUN_INTEGRATION_TESTS=true make test exclude="${{ matrix.exclude }}" package=${{ matrix.package }}
       - name: Sanitize name for Artifact
         run: |

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -957,6 +957,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 			processor := NewHandle(config.Default, mockTransformerClients)
 			processor.isolationStrategy = isolationStrategy
 			processor.config.archivalEnabled = config.SingleValueLoader(false)
+			processor.config.enableConcurrentStore = config.SingleValueLoader(false)
 			Setup(processor, c, false, false)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -1033,6 +1034,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 			processor := NewHandle(config.Default, mockTransformerClients)
 			processor.isolationStrategy = isolationStrategy
 			processor.config.archivalEnabled = config.SingleValueLoader(false)
+			processor.config.enableConcurrentStore = config.SingleValueLoader(false)
 			Setup(processor, c, false, false)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -1120,6 +1122,7 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 		isolationStrategy, err := isolation.GetStrategy(isolation.ModeNone)
 		Expect(err).To(BeNil())
 		proc.isolationStrategy = isolationStrategy
+		proc.config.enableConcurrentStore = config.SingleValueLoader(false)
 		return proc
 	}
 
@@ -1318,6 +1321,7 @@ var _ = Describe("Processor with ArchivalV2 enabled", Ordered, func() {
 	prepareHandle := func(proc *Handle) *Handle {
 		proc.archivalDB = c.mockArchivalDB
 		proc.config.archivalEnabled = config.SingleValueLoader(true)
+		proc.config.enableConcurrentStore = config.SingleValueLoader(false)
 		isolationStrategy, err := isolation.GetStrategy(isolation.ModeNone)
 		Expect(err).To(BeNil())
 		proc.isolationStrategy = isolationStrategy
@@ -1657,6 +1661,7 @@ var _ = Describe("Processor with trackedUsers feature enabled", Ordered, func() 
 		isolationStrategy, err := isolation.GetStrategy(isolation.ModeNone)
 		Expect(err).To(BeNil())
 		proc.isolationStrategy = isolationStrategy
+		proc.config.enableConcurrentStore = config.SingleValueLoader(false)
 		return proc
 	}
 	BeforeEach(func() {
@@ -1976,6 +1981,7 @@ var _ = Describe("Processor", Ordered, func() {
 		isolationStrategy, err := isolation.GetStrategy(isolation.ModeNone)
 		Expect(err).To(BeNil())
 		proc.isolationStrategy = isolationStrategy
+		proc.config.enableConcurrentStore = config.SingleValueLoader(false)
 		return proc
 	}
 	BeforeEach(func() {


### PR DESCRIPTION
# Description

During processor's **store** stage, the following operations are happening in sequence:
1. store jobs in batch router jobsdb
2. store jobs in router jobsdb
3. store jobs in proc errors jobsdb
4. update job statuses in gateway and report stats

Providing a new configuration option so that (1) (2) (3) & (4) can happen concurrently. Transaction of (4) will only commit as long as (1) (2) and (3) have completed successfully to guarantee our current at-least-once delivery semantics.

## Linear Ticket

resolves PIPE-2020

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
