### PR TITLE
fix: kafka message batching applies to Confluent Cloud and Azure Event Hub

### DIFF
--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -441,7 +441,8 @@ func NewProducerForAzureEventHubs(destination *backendconfig.DestinationT, o com
 	if err != nil {
 		return nil, err
 	}
-	return &ProducerManager{p: p, timeout: o.Timeout,
+	return &ProducerManager{
+		p: p, timeout: o.Timeout,
 		enableBatching: config.GetBoolVar(false, "Router.AZURE_EVENT_HUB.enableBatching"),
 	}, nil
 }
@@ -492,7 +493,8 @@ func NewProducerForConfluentCloud(destination *backendconfig.DestinationT, o com
 	if err != nil {
 		return nil, err
 	}
-	return &ProducerManager{p: p, timeout: o.Timeout,
+	return &ProducerManager{
+		p: p, timeout: o.Timeout,
 		enableBatching: config.GetBoolVar(false, "Router.CONFLUENT_CLOUD.enableBatching"),
 	}, nil
 }

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -151,6 +151,7 @@ type ProducerManager struct {
 	timeout           time.Duration
 	embedAvroSchemaID bool
 	codecs            map[string]*goavro.Codec
+	enableBatching    bool
 }
 
 func (p *ProducerManager) getTimeout() time.Duration {
@@ -391,6 +392,7 @@ func NewProducer(destination *backendconfig.DestinationT, o common.Opts) (*Produ
 		timeout:           o.Timeout,
 		embedAvroSchemaID: embedAvroSchemaID,
 		codecs:            codecs,
+		enableBatching:    kafkaBatchingEnabled,
 	}, nil
 }
 
@@ -439,7 +441,9 @@ func NewProducerForAzureEventHubs(destination *backendconfig.DestinationT, o com
 	if err != nil {
 		return nil, err
 	}
-	return &ProducerManager{p: p, timeout: o.Timeout}, nil
+	return &ProducerManager{p: p, timeout: o.Timeout,
+		enableBatching: config.GetBoolVar(false, "Router.AZURE_EVENT_HUB.enableBatching"),
+	}, nil
 }
 
 // NewProducerForConfluentCloud creates a producer for Confluent cloud based on destination config
@@ -488,7 +492,9 @@ func NewProducerForConfluentCloud(destination *backendconfig.DestinationT, o com
 	if err != nil {
 		return nil, err
 	}
-	return &ProducerManager{p: p, timeout: o.Timeout}, nil
+	return &ProducerManager{p: p, timeout: o.Timeout,
+		enableBatching: config.GetBoolVar(false, "Router.CONFLUENT_CLOUD.enableBatching"),
+	}, nil
 }
 
 func prepareMessage(topic, key string, message []byte, timestamp time.Time) client.Message {
@@ -674,7 +680,7 @@ func (p *ProducerManager) Produce(jsonData json.RawMessage, destConfig interface
 
 	ctx, cancel := context.WithTimeout(context.TODO(), p.getTimeout())
 	defer cancel()
-	if kafkaBatchingEnabled {
+	if p.enableBatching {
 		return sendBatchedMessage(ctx, jsonData, p, conf.Topic)
 	}
 


### PR DESCRIPTION
# Description

Kafka stream manager is used for `Azure Event Hub` and `Confluent Cloud` destinations. The problem is message batching directive(configured for Kafka) is applied across all three as well which can be a problem if batched messages cannot be accepted further down the pipeline. The same compression directive still applies to all three.

## Linear Ticket

Resolves PIPE-1982
[Remove kafka batching on transformer and use client batching with a new config flag](https://linear.app/rudderstack/issue/PIPE-1982/remove-kafka-batching-on-transformer-and-use-client-batching-with-a)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
