### PR TITLE
feat: query load files using upload_id instead of staging_file_id

### DIFF
--- a/warehouse/api/grpc.go
+++ b/warehouse/api/grpc.go
@@ -109,7 +109,7 @@ func NewGRPCServer(
 		bcManager:          bcManager,
 		stagingRepo:        repo.NewStagingFiles(db),
 		uploadRepo:         repo.NewUploads(db),
-		tableUploadsRepo:   repo.NewTableUploads(db),
+		tableUploadsRepo:   repo.NewTableUploads(db, conf),
 		schemaRepo:         repo.NewWHSchemas(db),
 		triggerStore:       triggerStore,
 		fileManagerFactory: filemanager.New,

--- a/warehouse/api/grpc_test.go
+++ b/warehouse/api/grpc_test.go
@@ -238,7 +238,7 @@ func TestGRPC(t *testing.T) {
 			repoStaging := repo.NewStagingFiles(db, repo.WithNow(func() time.Time {
 				return now
 			}))
-			repoTableUploads := repo.NewTableUploads(db, repo.WithNow(func() time.Time {
+			repoTableUploads := repo.NewTableUploads(db, c, repo.WithNow(func() time.Time {
 				return now
 			}))
 
@@ -1242,7 +1242,7 @@ func TestGRPC(t *testing.T) {
 				repoStaging := repo.NewStagingFiles(db, repo.WithNow(func() time.Time {
 					return now
 				}))
-				repoTableUpload := repo.NewTableUploads(db, repo.WithNow(func() time.Time {
+				repoTableUpload := repo.NewTableUploads(db, c, repo.WithNow(func() time.Time {
 					return now
 				}))
 

--- a/warehouse/api/http_test.go
+++ b/warehouse/api/http_test.go
@@ -214,7 +214,7 @@ func TestHTTPApi(t *testing.T) {
 	uploadsRepo := repo.NewUploads(db, repo.WithNow(func() time.Time {
 		return now
 	}))
-	tableUploadsRepo := repo.NewTableUploads(db, repo.WithNow(func() time.Time {
+	tableUploadsRepo := repo.NewTableUploads(db, c, repo.WithNow(func() time.Time {
 		return now
 	}))
 

--- a/warehouse/archive/testdata/dump.sql
+++ b/warehouse/archive/testdata/dump.sql
@@ -64,32 +64,32 @@ VALUES
     NOW(), '{}', 4
   );
 INSERT INTO wh_load_files (
-  id, staging_file_id, location, source_id,
+  id, staging_file_id, upload_id, location, source_id,
   destination_id, destination_type,
   table_name, total_events, created_at,
   metadata
 )
 VALUES
   (
-    1, 1, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
+    1, 1, NULL, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     'test-sourceID', 'test-destinationID',
     'POSTGRES', 'test-table', 1, NOW(),
     '{}'
   ),
   (
-    2, 2, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
+    2, 2, 2, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     'test-sourceID', 'test-destinationID',
     'POSTGRES', 'test-table', 1, NOW(),
     '{}'
   ),
   (
-    3, 3, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
+    3, NULL, 3,'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     'test-sourceID', 'test-destinationID',
     'POSTGRES', 'test-table', 1, NOW(),
     '{}'
   ),
   (
-    4, 4, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
+    4, NULL, 4,'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     'test-sourceID', 'test-destinationID',
     'POSTGRES', 'test-table', 1, NOW(),
     '{}'

--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -45,8 +45,8 @@ type StageFileRepo interface {
 
 type LoadFileRepo interface {
 	Insert(ctx context.Context, loadFiles []model.LoadFile) error
-	DeleteByStagingFiles(ctx context.Context, stagingFileIDs []int64) error
-	GetByStagingFiles(ctx context.Context, stagingFileIDs []int64) ([]model.LoadFile, error)
+	Delete(ctx context.Context, uploadID int64, stagingFileIDs []int64) error
+	Get(ctx context.Context, uploadID int64, stagingFileIDs []int64) ([]model.LoadFile, error)
 }
 
 type ControlPlaneClient interface {
@@ -166,7 +166,7 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 
 	// Delete previous load files for the staging files
 	stagingFileIDs := repo.StagingFileIDs(toProcessStagingFiles)
-	if err := lf.LoadRepo.DeleteByStagingFiles(ctx, stagingFileIDs); err != nil {
+	if err := lf.LoadRepo.Delete(ctx, job.Upload.ID, stagingFileIDs); err != nil {
 		return 0, 0, fmt.Errorf("deleting previous load files: %w", err)
 	}
 
@@ -335,7 +335,7 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 		return 0, 0, err
 	}
 
-	loadFiles, err := lf.LoadRepo.GetByStagingFiles(ctx, stagingFileIDs)
+	loadFiles, err := lf.LoadRepo.Get(ctx, job.Upload.ID, stagingFileIDs)
 	if err != nil {
 		return 0, 0, fmt.Errorf("getting load files: %w", err)
 	}

--- a/warehouse/internal/loadfiles/loadfiles_test.go
+++ b/warehouse/internal/loadfiles/loadfiles_test.go
@@ -102,7 +102,7 @@ func TestCreateLoadFiles(t *testing.T) {
 	require.Len(t, stageRepo.store, len(stagingFiles))
 
 	for _, stagingFile := range stagingFiles {
-		loadFiles, err := loadRepo.GetByStagingFiles(ctx, []int64{stagingFile.ID})
+		loadFiles, err := loadRepo.Get(ctx, job.Upload.ID, []int64{stagingFile.ID})
 		require.Equal(t, 2, len(loadFiles))
 		require.NoError(t, err)
 
@@ -330,7 +330,7 @@ func TestCreateLoadFiles_DestinationHistory(t *testing.T) {
 	require.Equal(t, int64(1), startID)
 	require.Equal(t, int64(2), endID)
 
-	loadFiles, err := loadRepo.GetByStagingFiles(ctx, []int64{stagingFile.ID})
+	loadFiles, err := loadRepo.Get(ctx, job.Upload.ID, []int64{stagingFile.ID})
 	require.Equal(t, 2, len(loadFiles))
 	require.NoError(t, err)
 

--- a/warehouse/internal/loadfiles/mock_loadfile_repo_test.go
+++ b/warehouse/internal/loadfiles/mock_loadfile_repo_test.go
@@ -23,7 +23,7 @@ func (m *mockLoadFilesRepo) Insert(_ context.Context, loadFiles []model.LoadFile
 	return nil
 }
 
-func (m *mockLoadFilesRepo) DeleteByStagingFiles(_ context.Context, stagingFileIDs []int64) error {
+func (m *mockLoadFilesRepo) Delete(_ context.Context, uploadID int64, stagingFileIDs []int64) error {
 	store := make([]model.LoadFile, 0)
 	for _, loadFile := range m.store {
 		if !slices.Contains(stagingFileIDs, loadFile.StagingFileID) {
@@ -35,7 +35,7 @@ func (m *mockLoadFilesRepo) DeleteByStagingFiles(_ context.Context, stagingFileI
 	return nil
 }
 
-func (m *mockLoadFilesRepo) GetByStagingFiles(_ context.Context, stagingFileIDs []int64) ([]model.LoadFile, error) {
+func (m *mockLoadFilesRepo) Get(_ context.Context, uploadID int64, stagingFileIDs []int64) ([]model.LoadFile, error) {
 	var loadFiles []model.LoadFile
 	for _, loadFile := range m.store {
 		if slices.Contains(stagingFileIDs, loadFile.StagingFileID) {

--- a/warehouse/internal/repo/upload_test.go
+++ b/warehouse/internal/repo/upload_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-server/jsonrs"
 	sqlmiddleware "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
@@ -873,7 +874,7 @@ func TestUploads_PendingTableUploads(t *testing.T) {
 		ctx             = context.Background()
 		db              = setupDB(t)
 		repoUpload      = repo.NewUploads(db)
-		repoTableUpload = repo.NewTableUploads(db)
+		repoTableUpload = repo.NewTableUploads(db, config.New())
 		repoStaging     = repo.NewStagingFiles(db)
 	)
 
@@ -1733,7 +1734,7 @@ func TestUploads_FailedBatchOperations(t *testing.T) {
 		repoStaging := repo.NewStagingFiles(db, repo.WithNow(func() time.Time {
 			return now
 		}))
-		repoTableUpload := repo.NewTableUploads(db, repo.WithNow(func() time.Time {
+		repoTableUpload := repo.NewTableUploads(db, config.New(), repo.WithNow(func() time.Time {
 			return now
 		}))
 

--- a/warehouse/router/router.go
+++ b/warehouse/router/router.go
@@ -170,7 +170,7 @@ func New(
 			Logger:             r.logger.Child("loadfile"),
 			Notifier:           r.notifier,
 			StageRepo:          r.stagingRepo,
-			LoadRepo:           repo.NewLoadFiles(db),
+			LoadRepo:           repo.NewLoadFiles(db, r.conf),
 			ControlPlaneClient: controlPlaneClient,
 		},
 		encodingFactory: encodingFactory,

--- a/warehouse/router/state_generate_load_files.go
+++ b/warehouse/router/state_generate_load_files.go
@@ -69,7 +69,7 @@ func (job *UploadJob) matchRowsInStagingAndLoadFiles(ctx context.Context) error 
 }
 
 func (job *UploadJob) getTotalRowsInLoadFiles(ctx context.Context) int64 {
-	exportedEvents, err := job.loadFilesRepo.TotalExportedEvents(ctx, job.stagingFileIDs, []string{
+	exportedEvents, err := job.loadFilesRepo.TotalExportedEvents(ctx, job.upload.ID, job.stagingFileIDs, []string{
 		whutils.ToProviderCase(job.warehouse.Type, whutils.DiscardsTable),
 	})
 	if err != nil {

--- a/warehouse/source/http_test.go
+++ b/warehouse/source/http_test.go
@@ -127,7 +127,7 @@ func TestManager_InsertJobHandler(t *testing.T) {
 	uploadsRepo := repo.NewUploads(db, repo.WithNow(func() time.Time {
 		return now
 	}))
-	tableUploadsRepo := repo.NewTableUploads(db, repo.WithNow(func() time.Time {
+	tableUploadsRepo := repo.NewTableUploads(db, config.New(), repo.WithNow(func() time.Time {
 		return now
 	}))
 	stagingRepo := repo.NewStagingFiles(db, repo.WithNow(func() time.Time {

--- a/warehouse/source/source.go
+++ b/warehouse/source/source.go
@@ -45,7 +45,7 @@ type Manager struct {
 func New(conf *config.Config, log logger.Logger, db *sqlmw.DB, publisher publisher) *Manager {
 	m := &Manager{
 		logger:           log.Child("source"),
-		tableUploadsRepo: repo.NewTableUploads(db),
+		tableUploadsRepo: repo.NewTableUploads(db, conf),
 		sourceRepo:       repo.NewSource(db),
 		publisher:        publisher,
 	}


### PR DESCRIPTION
# Description

https://linear.app/rudderstack/issue/WAR-464/modify-load-files-lookup-query-to-start-using-upload-id

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
