### PR TITLE
fix: warehouse transformations valid timestamp formats and log file path

### DIFF
--- a/warehouse/transformer/internal/utils/utils.go
+++ b/warehouse/transformer/internal/utils/utils.go
@@ -14,6 +14,11 @@ import (
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
+const (
+	DateTimeISO8601  = "2006-01-02T15:04:05"
+	DateTimeMillisTZ = "2006-01-02 15:04:05.000-0700"
+)
+
 var (
 	rudderCreatedTables                      = sliceToMap([]string{"tracks", "pages", "screens", "aliases", "groups", "accounts"})
 	rudderIsolatedTables                     = sliceToMap([]string{"users", "identifies"})
@@ -41,6 +46,8 @@ var (
 		time.RFC3339,
 		misc.RFC3339Milli,
 		time.DateTime,
+		DateTimeISO8601,
+		DateTimeMillisTZ,
 		time.DateOnly,
 		time.RFC3339Nano,
 	}

--- a/warehouse/transformer/internal/utils/utils_test.go
+++ b/warehouse/transformer/internal/utils/utils_test.go
@@ -75,6 +75,8 @@ func TestValidTimestamp(t *testing.T) {
 		{name: "Positive year and time input", timestamp: "+2023-06-14T05:23:59.244Z", expected: false},
 		{name: "Negative year and time input", timestamp: "-2023-06-14T05:23:59.244Z", expected: false},
 		{name: "Malicious string input should return false", timestamp: "%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216Windows%u2216win%u002ein", expected: false},
+		{name: "Date time ISO 8601", timestamp: "2025-04-02T01:09:03", expected: true},
+		{name: "Date time Millis timezone", timestamp: "2025-04-02 01:09:03.000+0530", expected: true},
 	}
 
 	for _, tc := range testCases {
@@ -85,11 +87,11 @@ func TestValidTimestamp(t *testing.T) {
 }
 
 // BenchmarkValidTimestamp/ValidTimestamp_Valid
-// BenchmarkValidTimestamp/ValidTimestamp_Valid-12         				34838106	 	31.71 ns/op
+// BenchmarkValidTimestamp/ValidTimestamp_Valid-12         				36466681		32.00 ns/op
 // BenchmarkValidTimestamp/ValidTimestamp_Invalid
-// BenchmarkValidTimestamp/ValidTimestamp_Invalid-12       	 			2619600	       	430.6 ns/op
+// BenchmarkValidTimestamp/ValidTimestamp_Invalid-12       	 			2823615	       	423.4 ns/op
 // BenchmarkValidTimestamp/ValidTimestamp_Invalid_Big_String
-// BenchmarkValidTimestamp/ValidTimestamp_Invalid_Big_String-12        	7234989	       	178.7 ns/op
+// BenchmarkValidTimestamp/ValidTimestamp_Invalid_Big_String-12     	7731496	       	154.8 ns/op
 func BenchmarkValidTimestamp(b *testing.B) {
 	b.Run("ValidTimestamp_Valid", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {

--- a/warehouse/transformer/logger.go
+++ b/warehouse/transformer/logger.go
@@ -2,6 +2,7 @@ package transformer
 
 import (
 	"fmt"
+	"path/filepath"
 	"slices"
 
 	"github.com/google/go-cmp/cmp"
@@ -102,5 +103,7 @@ func (t *Transformer) write(data []string) error {
 }
 
 func generateLogFileName() string {
-	return fmt.Sprintf("warehouse_transformations_debug_%s.log.gz", uuid.NewString())
+	fileName := fmt.Sprintf("warehouse_transformations_debug_%s.log.gz", uuid.NewString())
+	tmpDirPath, _ := misc.CreateTMPDIR()
+	return filepath.Join(tmpDirPath, fileName)
 }


### PR DESCRIPTION
# Description

- Added additional format ("2006-01-02T15:04:05") for timestamp detection.

```
  types.TransformerResponse{
  	Output: map[string]any{
  		"data": map[string]any{
  			... // 45 identical entries
- 			"published_date": string("2025-04-02T01:09:03"),
+ 			"published_date": string("2025-04-02T01:09:03.000Z"),
  			"received_at":    string("2025-04-08T09:12:48.456Z"),
  			... // 7 identical entries
  		},
  		"metadata": map[string]any{
  			"columns": map[string]any{
  				... // 45 identical entries
- 				"published_date": string("string"),
+ 				"published_date": string("datetime"),
  				... // 8 identical entries
  			},
  		},
  		"userId": string(""),
  	},
  	StatusCode: 200,
  	... // 3 identical fields
  }
```

## Linear Ticket

- Resolves WAR-494

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
