### PR TITLE
chore(router): make net client timeout reloadable

### DIFF
--- a/router/handle.go
+++ b/router/handle.go
@@ -66,7 +66,7 @@ type Handle struct {
 	reloadableConfig                   *reloadableConfig
 	destType                           string
 	guaranteeUserEventOrder            bool
-	netClientTimeout                   time.Duration
+	netClientTimeout                   config.ValueLoader[time.Duration]
 	transformerTimeout                 time.Duration
 	enableBatching                     bool
 	noOfWorkers                        int

--- a/router/worker.go
+++ b/router/worker.go
@@ -553,7 +553,7 @@ func (w *worker) processDestinationJobs() {
 									respBodyArrs = append(respBodyArrs, respBodyTemps)
 								}
 							} else {
-								sendCtx, cancel := context.WithTimeout(ctx, w.rt.netClientTimeout)
+								sendCtx, cancel := context.WithTimeout(ctx, w.rt.netClientTimeout.Load())
 								rdlTime := time.Now()
 								resp := w.rt.netHandle.SendPost(sendCtx, val)
 								cancel()
@@ -1192,9 +1192,9 @@ func (w *worker) accept(wj workerJob) {
 func (w *worker) trackStuckDelivery() chan struct{} {
 	var d time.Duration
 	if w.rt.reloadableConfig.transformerProxy.Load() {
-		d = (w.rt.transformerTimeout + w.rt.netClientTimeout) * 2
+		d = (w.rt.transformerTimeout + w.rt.netClientTimeout.Load()) * 2
 	} else {
-		d = w.rt.netClientTimeout * 2
+		d = w.rt.netClientTimeout.Load() * 2
 	}
 
 	ch := make(chan struct{}, 1)


### PR DESCRIPTION


# Description
This commit implements the reloadable netClientTimeout parameter in the router package. The implementation allows the HTTP client timeout to be updated at runtime without requiring a server restart, improving operational flexibility.


## Linear Ticket

https://linear.app/rudderstack/issue/INT-3508/make-router-netclienttimeout-hot-reloadable
Resolves INT-3508

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
