### PR TITLE
fix: warehouse transformations ordering while processing properties

### DIFF
--- a/warehouse/transformer/set.go
+++ b/warehouse/transformer/set.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/samber/lo"
+
 	"github.com/rudderlabs/rudder-server/jsonrs"
 	"github.com/rudderlabs/rudder-server/warehouse/transformer/internal/rules"
 	"github.com/rudderlabs/rudder-server/warehouse/transformer/internal/stringlikeobject"
@@ -28,7 +30,8 @@ func setDataAndMetadataFromInput(
 	if shouldHandleStringLikeObject(inputMap, pi) {
 		return handleStringLikeObject(tec, inputMap, data, metadata, pi)
 	}
-	for key, val := range inputMap {
+	for _, key := range tec.sorter(lo.Keys(inputMap)) {
+		val := inputMap[key]
 		if utils.IsBlank(val) {
 			continue
 		}
@@ -158,7 +161,8 @@ func setDataAndMetadataFromRules(
 	data map[string]any, metadata map[string]string,
 	rules map[string]rules.Rules,
 ) error {
-	for colKey, rule := range rules {
+	for _, colKey := range tec.sorter(lo.Keys(rules)) {
+		rule := rules[colKey]
 		columnName, err := safeColumnNameCached(tec, colKey)
 		if err != nil {
 			return fmt.Errorf("safe column name: %w", err)

--- a/warehouse/transformer/transformer.go
+++ b/warehouse/transformer/transformer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -44,6 +45,10 @@ func New(conf *config.Config, logger logger.Logger, statsFactory stats.Stats) *T
 		now:            timeutil.Now,
 		uuidGenerator:  uuid.NewString,
 		loggedFileName: generateLogFileName(),
+		sorter: func(x []string) []string {
+			sort.Strings(x)
+			return x
+		},
 	}
 
 	t.stats.matchedEvents = t.statsFactory.NewStat("warehouse_dest_transform_matched_events", stats.HistogramType)
@@ -203,6 +208,7 @@ func (t *Transformer) handleEvent(event *types.TransformerEvent, cache *cache) (
 		destOpts:      &destOpts,
 		jsonPathsInfo: &jsonPathsInfo,
 		cache:         cache,
+		sorter:        t.sorter,
 	}
 
 	switch eventType {

--- a/warehouse/transformer/types.go
+++ b/warehouse/transformer/types.go
@@ -15,6 +15,7 @@ type (
 	Transformer struct {
 		now           func() time.Time
 		uuidGenerator func() string
+		sorter        func([]string) []string
 
 		logger       logger.Logger
 		statsFactory stats.Stats
@@ -70,6 +71,7 @@ type (
 		destOpts      *destOptions
 		jsonPathsInfo *jsonPathInfo
 		cache         *cache
+		sorter        func([]string) []string
 	}
 
 	intrOptions struct {


### PR DESCRIPTION
# Description

- Events are stored as map[string]any in-memory while processing. Upon sending the request to the rudder-transformer, we do JSON marshalling, which [keeps the keys sorted](https://github.com/golang/go/blob/master/src/encoding/json/encode.go#L151-L152). While doing [Object.keys(columnMapping)](https://github.com/rudderlabs/rudder-transformer/blob/develop/src/warehouse/index.js#L146C3-L146C29) during processing in rudder-transformer it follows that same sorted order.
- Now in GO, we do range over a map [does not guarantee ordering](https://go.dev/blog/maps#iteration-order). So sorting the keys while processing the properties in GO code as well.
```
    types.TransformerResponse{
  	  Output: map[string]any{
  		  "data": map[string]any{
  			  ... // 40 identical entries
  - 			"context_traits_user_id": string("18794"),
  + 			"context_traits_user_id": float64(18794),
  			  ... // 8 identical entries
  		  },
  		  "metadata": map[string]any{
  			  "columns": map[string]any{
  				  ... // 40 identical entries
  - 				"context_traits_user_id": string("string"),
  + 				"context_traits_user_id": string("int"),
  				  ... // 10 identical entries
  			  },
  		  },
  	  },
  	  ... // 3 identical fields
    }
```
- Corresponding Sample event:
```JSON
{
  "message": {
    "channel": "mobile",
    "context": {
      "traits": {
        "user_id": 18794,
        "userId": "18794"
      }
    },
    "event": "identify",
    "integrations": {
      "All": true
    },
    "originalTimestamp": "2025-04-08T09:07:48.887Z",
    "receivedAt": "2025-04-08T09:07:55.813Z",
    "sentAt": "2025-04-08T09:07:54.963Z",
    "timestamp": "2025-04-08T09:07:49.737Z",
    "type": "identify",
    "userId": "18794"
  }
}
```



## Linear Ticket

- Resolves WAR-497

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
