### PR TITLE
fix: jobsdb payload limit used compressed column sizes instead of actual payload length

### DIFF
--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
@@ -1534,6 +1535,66 @@ func TestGetDistinctParameterValues(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, parameterValues, 3)
 	require.ElementsMatch(t, []string{"param-1", "param-2", "param-3"}, parameterValues)
+}
+
+func TestPayloadSizeColumnQueries(t *testing.T) {
+	pgContainer := startPostgres(t)
+	customVal := "CUSTOMVAL"
+	workspaceID := "workspaceID"
+	generateJobs := func(numOfJob int, destinationID string) []*JobT {
+		js := make([]*JobT, numOfJob)
+		for i := 0; i < numOfJob; i++ {
+			js[i] = &JobT{
+				Parameters: []byte(fmt.Sprintf(
+					`{"batch_id":1,"source_id":"sourceID","destination_id":%q}`,
+					destinationID,
+				)),
+				EventPayload: []byte(`{"keykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykey": "valuevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevaluevalue"}`),
+				UserID:       "a-292e-4e79-9880-f8009e0ae4a3",
+				UUID:         uuid.New(),
+				CustomVal:    customVal,
+				EventCount:   1,
+				WorkspaceId:  workspaceID,
+			}
+		}
+		return js
+	}
+
+	destinationID := strings.ToLower(rsRand.String(5))
+	jobsDB := &Handle{dbHandle: pgContainer.DB}
+	tablePrefix := strings.ToLower(rsRand.String(5))
+	t.Setenv("RSERVER_JOBS_DB_PAYLOAD_COLUMN_TYPE", "text")
+	require.NoError(t, jobsDB.Setup(
+		ReadWrite,
+		true,
+		tablePrefix,
+	))
+
+	// run cleanup once with an empty db
+	require.NoError(t, jobsDB.doCleanup(context.Background()))
+
+	// store some jobs
+	require.NoError(
+		t,
+		jobsDB.Store(
+			context.Background(),
+			generateJobs(5000, destinationID),
+		),
+	)
+
+	unprocessed, err := jobsDB.GetUnprocessed(
+		context.Background(),
+		GetQueryParams{
+			CustomValFilters: []string{customVal},
+			ParameterFilters: []ParameterFilterT{
+				{Name: "destination_id", Value: destinationID},
+			},
+			JobsLimit:        1000,
+			PayloadSizeLimit: 16 * bytesize.KB,
+		})
+	require.NoError(t, err)
+	require.Equal(t, 5, len(unprocessed.Jobs))
+	jobsDB.TearDown()
 }
 
 type testingT interface {

--- a/schema-forwarder/internal/transformer/transformer_test.go
+++ b/schema-forwarder/internal/transformer/transformer_test.go
@@ -179,7 +179,6 @@ func generateTestJob(t *testing.T, time time.Time) *jobsdb.JobT {
 		ExpireAt:      time,
 		CustomVal:     "event-schema",
 		EventCount:    1,
-		PayloadSize:   100,
 		LastJobStatus: jobsdb.JobStatusT{},
 		WorkspaceId:   testdata.SampleWorkspaceID,
 		Parameters:    []byte(`{"source_id": "enabled-source"}`),


### PR DESCRIPTION
# Description

Job queries aggregated over `pg_column_size(event_payload)` to limit the result when a size limit is passed. This could lead to loading more jobs into memory than can be handled safely because it's the compressed size of the column(when compressed). Using the `octet_length(event_payload)` instead to find the actual byte size of the event payload column.

## Linear Ticket

[Resolves PIPE-2009](https://linear.app/rudderstack/issue/PIPE-2009/fix-payload-limiting-by-adding-actual-column-size-in-jobsdb)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
