### PR TITLE
fix: warehouse transformations concurrent writes

### DIFF
--- a/warehouse/transformer/events.go
+++ b/warehouse/transformer/events.go
@@ -36,7 +36,7 @@ func (t *Transformer) trackCommonProps(tec *transformEventContext) (map[string]a
 	commonData := make(map[string]any)
 	commonMetadata := make(map[string]string)
 
-	if err := setDataAndMetadataFromInput(tec, tec.event.Message["context"], commonData, commonMetadata, &prefixInfo{
+	if err := setDataAndMetadataFromInput(tec, t.eventContext(tec), commonData, commonMetadata, &prefixInfo{
 		completePrefix: "track_context_",
 		completeLevel:  2,
 		prefix:         "context_",
@@ -83,7 +83,7 @@ func (t *Transformer) tracksResponse(tec *transformEventContext, commonData map[
 	if err := setDataAndMetadataFromRules(tec, data, metadata, rules.TrackTableRules); err != nil {
 		return nil, fmt.Errorf("tracks response: setting data and column types from rules: %w", err)
 	}
-	if err := storeRudderEvent(tec, data, metadata); err != nil {
+	if err := t.storeRudderEvent(tec, data, metadata); err != nil {
 		return nil, fmt.Errorf("tracks response: storing rudder event: %w", err)
 	}
 
@@ -167,7 +167,7 @@ func (t *Transformer) extractEvents(tec *transformEventContext) ([]map[string]an
 	data := make(map[string]any)
 	metadata := make(map[string]string)
 
-	if err := setDataAndMetadataFromInput(tec, tec.event.Message["context"], data, metadata, &prefixInfo{
+	if err := setDataAndMetadataFromInput(tec, t.eventContext(tec), data, metadata, &prefixInfo{
 		completePrefix: "extract_context_",
 		completeLevel:  2,
 		prefix:         "context_",
@@ -279,7 +279,7 @@ func (t *Transformer) identifyCommonProps(tec *transformEventContext) (map[strin
 	}); err != nil {
 		return nil, nil, fmt.Errorf("identify common props: setting data and column types from message: %w", err)
 	}
-	if err := setDataAndMetadataFromInput(tec, tec.event.Message["context"], commonData, commonMetadata, &prefixInfo{
+	if err := setDataAndMetadataFromInput(tec, t.eventContext(tec), commonData, commonMetadata, &prefixInfo{
 		completePrefix: "identify_context_",
 		completeLevel:  2,
 		prefix:         "context_",
@@ -310,7 +310,7 @@ func (t *Transformer) identifiesResponse(tec *transformEventContext, commonData 
 	if err := setDataAndMetadataFromRules(tec, data, metadata, rules.DefaultRules); err != nil {
 		return nil, fmt.Errorf("identifies response: setting data and column types from rules: %w", err)
 	}
-	if err := storeRudderEvent(tec, data, metadata); err != nil {
+	if err := t.storeRudderEvent(tec, data, metadata); err != nil {
 		return nil, fmt.Errorf("identifies response: storing rudder event: %w", err)
 	}
 
@@ -412,7 +412,7 @@ func (t *Transformer) pageEvents(tec *transformEventContext) ([]map[string]any, 
 	}); err != nil {
 		return nil, fmt.Errorf("page: setting data and column types from input: %w", err)
 	}
-	if err := setDataAndMetadataFromInput(tec, tec.event.Message["context"], data, metadata, &prefixInfo{
+	if err := setDataAndMetadataFromInput(tec, t.eventContext(tec), data, metadata, &prefixInfo{
 		completePrefix: "page_context_",
 		completeLevel:  2,
 		prefix:         "context_",
@@ -426,7 +426,7 @@ func (t *Transformer) pageEvents(tec *transformEventContext) ([]map[string]any, 
 		return nil, fmt.Errorf("page: setting data and column types from rules: %w", err)
 	}
 
-	if err := storeRudderEvent(tec, data, metadata); err != nil {
+	if err := t.storeRudderEvent(tec, data, metadata); err != nil {
 		return nil, fmt.Errorf("page: storing rudder event: %w", err)
 	}
 
@@ -466,7 +466,7 @@ func (t *Transformer) screenEvents(tec *transformEventContext) ([]map[string]any
 	}); err != nil {
 		return nil, fmt.Errorf("screen: setting data and column types from input: %w", err)
 	}
-	if err := setDataAndMetadataFromInput(tec, tec.event.Message["context"], data, metadata, &prefixInfo{
+	if err := setDataAndMetadataFromInput(tec, t.eventContext(tec), data, metadata, &prefixInfo{
 		completePrefix: "screen_context_",
 		completeLevel:  2,
 		prefix:         "context_",
@@ -480,7 +480,7 @@ func (t *Transformer) screenEvents(tec *transformEventContext) ([]map[string]any
 		return nil, fmt.Errorf("screen: setting data and column types from rules: %w", err)
 	}
 
-	if err := storeRudderEvent(tec, data, metadata); err != nil {
+	if err := t.storeRudderEvent(tec, data, metadata); err != nil {
 		return nil, fmt.Errorf("screen: storing rudder event: %w", err)
 	}
 
@@ -520,7 +520,7 @@ func (t *Transformer) groupEvents(tec *transformEventContext) ([]map[string]any,
 	}); err != nil {
 		return nil, fmt.Errorf("group: setting data and column types from input: %w", err)
 	}
-	if err := setDataAndMetadataFromInput(tec, tec.event.Message["context"], data, metadata, &prefixInfo{
+	if err := setDataAndMetadataFromInput(tec, t.eventContext(tec), data, metadata, &prefixInfo{
 		completePrefix: "group_context_",
 		completeLevel:  2,
 		prefix:         "context_",
@@ -534,7 +534,7 @@ func (t *Transformer) groupEvents(tec *transformEventContext) ([]map[string]any,
 		return nil, fmt.Errorf("group: setting data and column types from rules: %w", err)
 	}
 
-	if err := storeRudderEvent(tec, data, metadata); err != nil {
+	if err := t.storeRudderEvent(tec, data, metadata); err != nil {
 		return nil, fmt.Errorf("group: storing rudder event: %w", err)
 	}
 
@@ -574,7 +574,7 @@ func (t *Transformer) aliasEvents(tec *transformEventContext) ([]map[string]any,
 	}); err != nil {
 		return nil, fmt.Errorf("alias: setting data and column types from input: %w", err)
 	}
-	if err := setDataAndMetadataFromInput(tec, tec.event.Message["context"], data, metadata, &prefixInfo{
+	if err := setDataAndMetadataFromInput(tec, t.eventContext(tec), data, metadata, &prefixInfo{
 		completePrefix: "alias_context_",
 		completeLevel:  2,
 		prefix:         "context_",
@@ -588,7 +588,7 @@ func (t *Transformer) aliasEvents(tec *transformEventContext) ([]map[string]any,
 		return nil, fmt.Errorf("alias: setting data and column types from rules: %w", err)
 	}
 
-	if err := storeRudderEvent(tec, data, metadata); err != nil {
+	if err := t.storeRudderEvent(tec, data, metadata); err != nil {
 		return nil, fmt.Errorf("alias: storing rudder event: %w", err)
 	}
 

--- a/warehouse/transformer/internal/rules/rules.go
+++ b/warehouse/transformer/internal/rules/rules.go
@@ -16,12 +16,12 @@ type Rules func(event *types.TransformerEvent) (any, error)
 
 var (
 	DefaultRules = map[string]Rules{
-		"id":                 staticRule("messageId"),
+		"id":                 messageIDFromMetadata(),
 		"anonymous_id":       staticRule("anonymousId"),
 		"user_id":            staticRule("userId"),
 		"sent_at":            staticRule("sentAt"),
 		"timestamp":          staticRule("timestamp"),
-		"received_at":        staticRule("receivedAt"),
+		"received_at":        receivedAtFromMetadata(),
 		"original_timestamp": staticRule("originalTimestamp"),
 		"channel":            staticRule("channel"),
 		"context_ip": func(event *types.TransformerEvent) (any, error) {
@@ -101,7 +101,7 @@ var (
 		"id": func(event *types.TransformerEvent) (any, error) {
 			return extractRecordID(&event.Metadata)
 		},
-		"received_at": staticRule("receivedAt"),
+		"received_at": receivedAtFromMetadata(),
 		"event":       staticRule("event"),
 	}
 )
@@ -109,6 +109,18 @@ var (
 func staticRule(key string) Rules {
 	return func(event *types.TransformerEvent) (any, error) {
 		return misc.MapLookup(event.Message, strings.Split(key, ".")...), nil
+	}
+}
+
+func messageIDFromMetadata() Rules {
+	return func(event *types.TransformerEvent) (any, error) {
+		return event.Metadata.MessageID, nil
+	}
+}
+
+func receivedAtFromMetadata() Rules {
+	return func(event *types.TransformerEvent) (any, error) {
+		return event.Metadata.ReceivedAt, nil
 	}
 }
 

--- a/warehouse/transformer/internal/rules/rules.go
+++ b/warehouse/transformer/internal/rules/rules.go
@@ -16,12 +16,12 @@ type Rules func(event *types.TransformerEvent) (any, error)
 
 var (
 	DefaultRules = map[string]Rules{
-		"id":                 messageIDFromMetadata(),
+		"id":                 messageIDFromMetadata(), // Use metadata, since we are not modifying Message
 		"anonymous_id":       staticRule("anonymousId"),
 		"user_id":            staticRule("userId"),
 		"sent_at":            staticRule("sentAt"),
 		"timestamp":          staticRule("timestamp"),
-		"received_at":        receivedAtFromMetadata(),
+		"received_at":        receivedAtFromMetadata(), // Use metadata, since we are not modifying Message
 		"original_timestamp": staticRule("originalTimestamp"),
 		"channel":            staticRule("channel"),
 		"context_ip": func(event *types.TransformerEvent) (any, error) {
@@ -101,7 +101,7 @@ var (
 		"id": func(event *types.TransformerEvent) (any, error) {
 			return extractRecordID(&event.Metadata)
 		},
-		"received_at": receivedAtFromMetadata(),
+		"received_at": receivedAtFromMetadata(), // Use metadata, since we are not modifying Message
 		"event":       staticRule("event"),
 	}
 )

--- a/warehouse/transformer/transformer_benchmark_test.go
+++ b/warehouse/transformer/transformer_benchmark_test.go
@@ -10,19 +10,18 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-server/jsonrs"
 	"github.com/rudderlabs/rudder-server/processor/types"
 )
 
 /*
-Benchmark_Transformer/Identify_(POSTGRES)_-_1000_events
-Benchmark_Transformer/Identify_(POSTGRES)_-_1000_events-12         	       9	 112701398 ns/op
-
-Benchmark_Transformer/Identify_(POSTGRES)_-_1000_events
-Benchmark_Transformer/Identify_(POSTGRES)_-_1000_events-12         	      28	  37071064 ns/op
+Benchmark_Transformer
+Benchmark_Transformer/Identify_(POSTGRES)_-_10000_events
+Benchmark_Transformer/Identify_(POSTGRES)_-_10000_events-12         	      12	  85358024 ns/op
 */
 func Benchmark_Transformer(b *testing.B) {
-	b.Run("Identify (POSTGRES) - 1000 events", func(t *testing.B) {
+	b.Run("Identify (POSTGRES) - 10000 events", func(t *testing.B) {
 		b.StopTimer()
 		eventPayload := `{"type":"identify","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","request_ip":"5.6.7.8","traits":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`
 		metadata := getMetadata("identify", "POSTGRES")
@@ -34,7 +33,7 @@ func Benchmark_Transformer(b *testing.B) {
 		err := jsonrs.Unmarshal([]byte(eventPayload), &singularEvent)
 		require.NoError(t, err)
 
-		batchSize := 1000
+		batchSize := 10000
 		events := lo.Times(batchSize, func(int) types.TransformerEvent {
 			return types.TransformerEvent{
 				Message:     singularEvent,


### PR DESCRIPTION
# Description

- In processor, [multiplexing happens](https://github.com/rudderlabs/rudder-server/blob/69f1baff51e05c561f0b3122a020e315c62c37bc/processor/processor.go#L2159) when source is connected to multiple destinations. These shallow events point to the same singular event, a map. Modifying and reading this singular event gives `fatal error: concurrent map read and map write` error.
- Also, avoid making modifications to singular events.

## Linear Ticket

- Resolves WAR-488.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
