### PR TITLE
chore: add destination type in metrics

### DIFF
--- a/regulation-worker/internal/delete/api/api.go
+++ b/regulation-worker/internal/delete/api/api.go
@@ -132,15 +132,24 @@ func (m *APIManager) deleteWithRetry(ctx context.Context, job model.Job, destina
 		"regulation_worker_cleaning_time",
 		stats.TimerType,
 		stats.Tags{
-			"destinationId": job.DestinationID,
-			"workspaceId":   job.WorkspaceID,
-			"jobType":       "api",
+			"destinationId":   job.DestinationID,
+			"workspaceId":     job.WorkspaceID,
+			"destinationType": destination.Name,
+			"jobType":         "api",
 		}).RecordDuration()()
 
 	resp, err := m.Client.Do(req)
 	if err != nil {
 		if os.IsTimeout(err) {
-			stats.Default.NewStat("regulation_worker_delete_api_timeout", stats.CountType).Count(1)
+			stats.Default.NewTaggedStat(
+				"regulation_worker_delete_api_timeout",
+				stats.CountType,
+				stats.Tags{
+					"destinationId":   job.DestinationID,
+					"workspaceId":     job.WorkspaceID,
+					"destinationType": destination.Name,
+					"jobType":         "api",
+				}).Count(1)
 		}
 		return model.JobStatus{Status: model.JobStatusFailed, Error: err}
 	}


### PR DESCRIPTION
# Description

It is difficult to triage the issue from timeout-alerts without clearly knowing the type of destination the regulation worker is facing issues with. This PR is to add that.

## Linear Ticket

Resolves INT-3436
https://linear.app/rudderstack/issue/INT-3436/research-regulation-worker-alerts

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
