### PR TITLE
feat: support for creating upload v2 notifier jobs

### DIFF
--- a/services/notifier/notifier.go
+++ b/services/notifier/notifier.go
@@ -35,8 +35,9 @@ const (
 type JobType string
 
 const (
-	JobTypeUpload JobType = "upload"
-	JobTypeAsync  JobType = "async_job"
+	JobTypeUpload   JobType = "upload"
+	JobTypeUploadV2 JobType = "upload_v2"
+	JobTypeAsync    JobType = "async_job"
 )
 
 type JobStatus string

--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -213,7 +213,7 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 	if !lf.AllowUploadV2JobCreation(job) {
 		err = lf.createUploadJobs(ctx, job, toProcessStagingFiles, publishBatchSize, uniqueLoadGenID)
 		if err != nil {
-			return 0, 0, err
+			return 0, 0, fmt.Errorf("creating upload jobs: %w", err)
 		}
 		return lf.getLoadFileIDs(ctx, job, stagingFileIDs, uniqueLoadGenID)
 	}
@@ -343,7 +343,7 @@ func (lf *LoadFileGenerator) publishJobs(
 		Priority:     job.Upload.Priority,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error publishing to notifier: %w", err)
+		return nil, fmt.Errorf("publishing to notifier: %w", err)
 	}
 	return ch, nil
 }

--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -68,8 +68,12 @@ type LoadFileGenerator struct {
 }
 
 type WorkerJobResponse struct {
-	StagingFileID int64            `json:"StagingFileID"`
-	Output        []LoadFileUpload `json:"Output"`
+	StagingFileID int64            `json:"staging_file_id"`
+	Output        []LoadFileUpload `json:"output"`
+}
+
+type WorkerJobResponseV2 struct {
+	Output []LoadFileUpload `json:"output"`
 }
 
 type LoadFileUpload struct {
@@ -82,28 +86,43 @@ type LoadFileUpload struct {
 	UseRudderStorage      bool
 }
 
+// baseWorkerJobRequest contains common fields for both v1 and v2 job requests
+type baseWorkerJobRequest struct {
+	BatchID                      string                 `json:"batch_id"`
+	UploadID                     int64                  `json:"upload_id"`
+	WorkspaceID                  string                 `json:"workspace_id"`
+	SourceID                     string                 `json:"source_id"`
+	SourceName                   string                 `json:"source_name"`
+	DestinationID                string                 `json:"destination_id"`
+	DestinationName              string                 `json:"destination_name"`
+	DestinationType              string                 `json:"destination_type"`
+	DestinationNamespace         string                 `json:"destination_namespace"`
+	DestinationRevisionID        string                 `json:"destination_revision_id"`
+	StagingDestinationRevisionID string                 `json:"staging_destination_revision_id"`
+	DestinationConfig            map[string]interface{} `json:"destination_config"`
+	StagingDestinationConfig     interface{}            `json:"staging_destination_config"`
+	UseRudderStorage             bool                   `json:"use_rudder_storage"`
+	StagingUseRudderStorage      bool                   `json:"staging_use_rudder_storage"`
+	UniqueLoadGenID              string                 `json:"unique_load_gen_id"`
+	RudderStoragePrefix          string                 `json:"rudder_storage_prefix"`
+	LoadFilePrefix               string                 `json:"load_file_prefix"` // prefix for the load file name
+	LoadFileType                 string                 `json:"load_file_type"`
+}
+
 type WorkerJobRequest struct {
-	BatchID                      string
-	UploadID                     int64
-	StagingFileID                int64
-	StagingFileLocation          string
-	WorkspaceID                  string
-	SourceID                     string
-	SourceName                   string
-	DestinationID                string
-	DestinationName              string
-	DestinationType              string
-	DestinationNamespace         string
-	DestinationRevisionID        string
-	StagingDestinationRevisionID string
-	DestinationConfig            map[string]interface{}
-	StagingDestinationConfig     interface{}
-	UseRudderStorage             bool
-	StagingUseRudderStorage      bool
-	UniqueLoadGenID              string
-	RudderStoragePrefix          string
-	LoadFilePrefix               string // prefix for the load file name
-	LoadFileType                 string
+	baseWorkerJobRequest
+	StagingFileID       int64  `json:"staging_file_id"`
+	StagingFileLocation string `json:"staging_file_location"`
+}
+
+type StagingFileInfo struct {
+	ID       int64  `json:"id"`
+	Location string `json:"location"`
+}
+
+type WorkerJobRequestV2 struct {
+	baseWorkerJobRequest
+	StagingFiles []StagingFileInfo `json:"staging_files"`
 }
 
 func WithConfig(ld *LoadFileGenerator, config *config.Config) {
@@ -140,9 +159,14 @@ func (lf *LoadFileGenerator) ForceCreateLoadFiles(ctx context.Context, job *mode
 	return lf.createFromStaging(ctx, job, job.StagingFiles)
 }
 
+func (lf *LoadFileGenerator) AllowUploadV2JobCreation(job *model.UploadJob) bool {
+	return lf.Conf.GetBool(fmt.Sprintf("Warehouse.%s.enableV2NotifierJob", job.Upload.DestinationType), false) || lf.Conf.GetBool("Warehouse.enableV2NotifierJob", false)
+}
+
 func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.UploadJob, toProcessStagingFiles []*model.StagingFile) (int64, int64, error) {
 	destID := job.Upload.DestinationID
 	destType := job.Upload.DestinationType
+	var err error
 
 	publishBatchSize := lf.publishBatchSize
 	if publishBatchSize == 0 {
@@ -158,12 +182,6 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 
 	job.LoadFileGenStartTime = timeutil.Now()
 
-	// Getting distinct destination revision ID from staging files metadata
-	destinationRevisionIDMap, err := lf.destinationRevisionIDMap(ctx, job)
-	if err != nil {
-		return 0, 0, fmt.Errorf("populating destination revision ID: %w", err)
-	}
-
 	// Delete previous load files for the staging files
 	stagingFileIDs := repo.StagingFileIDs(toProcessStagingFiles)
 	if err := lf.LoadRepo.Delete(ctx, job.Upload.ID, stagingFileIDs); err != nil {
@@ -171,7 +189,7 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 	}
 
 	// Set staging file status to executing
-	if err := lf.StageRepo.SetStatuses(
+	if err = lf.StageRepo.SetStatuses(
 		ctx,
 		stagingFileIDs,
 		warehouseutils.StagingFileExecutingState,
@@ -192,155 +210,52 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 		}
 	}()
 
-	var g errgroup.Group
-
-	var sampleError error
-	for _, chunk := range lo.Chunk(toProcessStagingFiles, publishBatchSize) {
-		// td : add prefix to payload for s3 dest
-		var messages []stdjson.RawMessage
-		for _, stagingFile := range chunk {
-			payload := WorkerJobRequest{
-				UploadID:                     job.Upload.ID,
-				StagingFileID:                stagingFile.ID,
-				StagingFileLocation:          stagingFile.Location,
-				LoadFileType:                 job.Upload.LoadFileType,
-				SourceID:                     job.Warehouse.Source.ID,
-				SourceName:                   job.Warehouse.Source.Name,
-				DestinationID:                destID,
-				DestinationName:              job.Warehouse.Destination.Name,
-				DestinationType:              destType,
-				DestinationNamespace:         job.Warehouse.Namespace,
-				DestinationConfig:            job.Warehouse.Destination.Config,
-				WorkspaceID:                  job.Warehouse.Destination.WorkspaceID,
-				UniqueLoadGenID:              uniqueLoadGenID,
-				RudderStoragePrefix:          misc.GetRudderObjectStoragePrefix(),
-				UseRudderStorage:             job.Upload.UseRudderStorage,
-				StagingUseRudderStorage:      stagingFile.UseRudderStorage,
-				DestinationRevisionID:        job.Warehouse.Destination.RevisionID,
-				StagingDestinationRevisionID: stagingFile.DestinationRevisionID,
-			}
-			if revisionConfig, ok := destinationRevisionIDMap[stagingFile.DestinationRevisionID]; ok {
-				payload.StagingDestinationConfig = revisionConfig.Config
-			}
-			if slices.Contains(warehouseutils.TimeWindowDestinations, job.Warehouse.Type) {
-				payload.LoadFilePrefix = lf.GetLoadFilePrefix(stagingFile.TimeWindow, job.Warehouse)
-			}
-
-			payloadJSON, err := jsonrs.Marshal(payload)
-			if err != nil {
-				return 0, 0, fmt.Errorf("error marshalling payload: %w", err)
-			}
-			messages = append(messages, payloadJSON)
-		}
-
-		uploadSchemaJSON, err := jsonrs.Marshal(struct {
-			UploadSchema model.Schema
-		}{
-			UploadSchema: job.Upload.UploadSchema,
-		})
+	if !lf.AllowUploadV2JobCreation(job) {
+		err = lf.createUploadJobs(ctx, job, toProcessStagingFiles, publishBatchSize, uniqueLoadGenID)
 		if err != nil {
-			return 0, 0, fmt.Errorf("error marshalling upload schema: %w", err)
+			return 0, 0, err
 		}
+		return lf.getLoadFileIDs(ctx, job, stagingFileIDs, uniqueLoadGenID)
+	}
 
-		lf.Logger.Infof("[WH]: Publishing %d staging files for %s:%s to notifier", len(messages), destType, destID)
-
-		ch, err := lf.Notifier.Publish(ctx, &notifier.PublishRequest{
-			Payloads:     messages,
-			JobType:      notifier.JobTypeUpload,
-			UploadSchema: uploadSchemaJSON,
-			Priority:     job.Upload.Priority,
-		})
-		if err != nil {
-			return 0, 0, fmt.Errorf("error publishing to notifier: %w", err)
+	v1Files := make([]*model.StagingFile, 0)
+	v2Files := make([]*model.StagingFile, 0)
+	for _, file := range toProcessStagingFiles {
+		if len(file.BytesPerTable) > 0 {
+			v2Files = append(v2Files, file)
+		} else {
+			v1Files = append(v1Files, file)
 		}
-		// set messages to nil to release mem allocated
-		messages = nil
-		startId := chunk[0].ID
-		endId := chunk[len(chunk)-1].ID
+	}
+
+	// Process both groups in parallel. This might violate the publishBatchSize constraint
+	// but that should be fine since we don't expect too many such instances where the batch will have both v1 and v2 files
+	// Usually a batch will have only v1 or v2 files
+	g, gCtx := errgroup.WithContext(ctx)
+	if len(v1Files) > 0 {
 		g.Go(func() error {
-			responses, ok := <-ch
-			if !ok {
-				return fmt.Errorf("receiving notifier channel closed")
-			}
-
-			lf.Logger.Infon("Received responses for staging files from notifier",
-				logger.NewIntField("startId", startId),
-				logger.NewIntField("endID", endId),
-				obskit.DestinationID(destID),
-				obskit.DestinationType(destType),
-			)
-			if responses.Err != nil {
-				return fmt.Errorf("receiving responses from notifier: %w", responses.Err)
-			}
-
-			var loadFiles []model.LoadFile
-			var successfulStagingFileIDs []int64
-			for _, resp := range responses.Jobs {
-				// Error handling during generating_load_files step:
-				// 1. any error returned by notifier is set on corresponding staging_file
-				// 2. any error effecting a batch/all the staging files like saving load file records to wh db
-				//    is returned as error to caller of the func to set error on all staging files and the whole generating_load_files step
-				var jobResponse WorkerJobResponse
-				if err := jsonrs.Unmarshal(resp.Payload, &jobResponse); err != nil {
-					return fmt.Errorf("unmarshalling response from notifier: %w", err)
-				}
-
-				if resp.Status == notifier.Aborted && resp.Error != nil {
-					lf.Logger.Errorf("[WH]: Error in generating load files: %v", resp.Error)
-					sampleError = errors.New(resp.Error.Error())
-					err = lf.StageRepo.SetErrorStatus(ctx, jobResponse.StagingFileID, sampleError)
-					if err != nil {
-						return fmt.Errorf("set staging file error status: %w", err)
-					}
-					continue
-				}
-				if len(jobResponse.Output) == 0 {
-					lf.Logger.Errorf("[WH]: No LoadFiles returned by worker")
-					continue
-				}
-				for _, output := range jobResponse.Output {
-					loadFiles = append(loadFiles, model.LoadFile{
-						TableName:             output.TableName,
-						Location:              output.Location,
-						TotalRows:             output.TotalRows,
-						ContentLength:         output.ContentLength,
-						StagingFileID:         output.StagingFileID,
-						DestinationRevisionID: output.DestinationRevisionID,
-						UseRudderStorage:      output.UseRudderStorage,
-						SourceID:              job.Upload.SourceID,
-						DestinationID:         job.Upload.DestinationID,
-						DestinationType:       job.Upload.DestinationType,
-						UploadID:              &job.Upload.ID,
-					})
-				}
-
-				successfulStagingFileIDs = append(successfulStagingFileIDs, jobResponse.StagingFileID)
-			}
-
-			if len(loadFiles) == 0 {
-				return nil
-			}
-
-			if err = lf.LoadRepo.Insert(ctx, loadFiles); err != nil {
-				return fmt.Errorf("inserting load files: %w", err)
-			}
-			if err = lf.StageRepo.SetStatuses(ctx, successfulStagingFileIDs, warehouseutils.StagingFileSucceededState); err != nil {
-				return fmt.Errorf("setting staging file status to succeeded: %w", err)
-			}
-			return nil
+			return lf.createUploadJobs(gCtx, job, v1Files, publishBatchSize, uniqueLoadGenID)
+		})
+	}
+	if len(v2Files) > 0 {
+		g.Go(func() error {
+			return lf.createUploadV2Jobs(gCtx, job, v2Files, publishBatchSize, uniqueLoadGenID)
 		})
 	}
 
-	if err := g.Wait(); err != nil {
+	if err = g.Wait(); err != nil {
 		return 0, 0, err
 	}
+	return lf.getLoadFileIDs(ctx, job, stagingFileIDs, uniqueLoadGenID)
+}
 
+func (lf *LoadFileGenerator) getLoadFileIDs(ctx context.Context, job *model.UploadJob, stagingFileIDs []int64, uniqueLoadGenID string) (int64, int64, error) {
 	loadFiles, err := lf.LoadRepo.Get(ctx, job.Upload.ID, stagingFileIDs)
 	if err != nil {
 		return 0, 0, fmt.Errorf("getting load files: %w", err)
 	}
 	if len(loadFiles) == 0 {
-		return 0, 0, fmt.Errorf(`no load files generated. Sample error: %v`, sampleError)
+		return 0, 0, fmt.Errorf("no load files generated")
 	}
 
 	if !slices.IsSortedFunc(loadFiles, func(a, b model.LoadFile) int {
@@ -360,6 +275,228 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 	}
 
 	return loadFiles[0].ID, loadFiles[len(loadFiles)-1].ID, nil
+}
+
+func (lf *LoadFileGenerator) prepareBaseJobRequest(job *model.UploadJob, uniqueLoadGenID string, stagingFile *model.StagingFile) baseWorkerJobRequest {
+	destID := job.Upload.DestinationID
+	destType := job.Upload.DestinationType
+	return baseWorkerJobRequest{
+		UploadID:                     job.Upload.ID,
+		LoadFileType:                 job.Upload.LoadFileType,
+		SourceID:                     job.Warehouse.Source.ID,
+		SourceName:                   job.Warehouse.Source.Name,
+		DestinationID:                destID,
+		DestinationName:              job.Warehouse.Destination.Name,
+		DestinationType:              destType,
+		DestinationNamespace:         job.Warehouse.Namespace,
+		DestinationConfig:            job.Warehouse.Destination.Config,
+		WorkspaceID:                  job.Warehouse.Destination.WorkspaceID,
+		UniqueLoadGenID:              uniqueLoadGenID,
+		RudderStoragePrefix:          misc.GetRudderObjectStoragePrefix(),
+		UseRudderStorage:             job.Upload.UseRudderStorage,
+		StagingUseRudderStorage:      stagingFile.UseRudderStorage,
+		DestinationRevisionID:        job.Warehouse.Destination.RevisionID,
+		StagingDestinationRevisionID: stagingFile.DestinationRevisionID,
+	}
+}
+
+func (lf *LoadFileGenerator) publishJobs(
+	ctx context.Context,
+	job *model.UploadJob,
+	uniqueLoadGenID string,
+	chunk []*model.StagingFile,
+	destinationRevisionIDMap map[string]backendconfig.DestinationT,
+	jobType notifier.JobType,
+	rawPayloadGenerator func(baseReq baseWorkerJobRequest, stagingFile *model.StagingFile) (stdjson.RawMessage, error),
+) (<-chan *notifier.PublishResponse, error) {
+	destID := job.Upload.DestinationID
+	destType := job.Upload.DestinationType
+	var messages []stdjson.RawMessage
+	for _, stagingFile := range chunk {
+		baseReq := lf.prepareBaseJobRequest(job, uniqueLoadGenID, stagingFile)
+		if revisionConfig, ok := destinationRevisionIDMap[stagingFile.DestinationRevisionID]; ok {
+			baseReq.StagingDestinationConfig = revisionConfig.Config
+		}
+		if slices.Contains(warehouseutils.TimeWindowDestinations, job.Warehouse.Type) {
+			baseReq.LoadFilePrefix = lf.GetLoadFilePrefix(stagingFile.TimeWindow, job.Warehouse)
+		}
+		rawPayload, err := rawPayloadGenerator(baseReq, stagingFile)
+		if err != nil {
+			return nil, fmt.Errorf("error generating raw payload: %w", err)
+		}
+		messages = append(messages, rawPayload)
+	}
+
+	uploadSchemaJSON, err := jsonrs.Marshal(struct {
+		UploadSchema model.Schema `json:"upload_schema"`
+	}{
+		UploadSchema: job.Upload.UploadSchema,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling upload schema: %w", err)
+	}
+	lf.Logger.Infof("[WH]: Publishing %d staging files for %s:%s to notifier", len(messages), destType, destID)
+	ch, err := lf.Notifier.Publish(ctx, &notifier.PublishRequest{
+		Payloads:     messages,
+		JobType:      jobType,
+		UploadSchema: uploadSchemaJSON,
+		Priority:     job.Upload.Priority,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error publishing to notifier: %w", err)
+	}
+	return ch, nil
+}
+
+func (lf *LoadFileGenerator) processNotifierResponse(ctx context.Context, ch <-chan *notifier.PublishResponse, job *model.UploadJob, chunk []*model.StagingFile) error {
+	responses, ok := <-ch
+	if !ok {
+		return fmt.Errorf("receiving notifier channel closed")
+	}
+
+	logNotifierResponse(lf.Logger, job, chunk)
+	if responses.Err != nil {
+		return fmt.Errorf("receiving responses from notifier: %w", responses.Err)
+	}
+
+	var loadFiles []model.LoadFile
+	var successfulStagingFileIDs []int64
+	for _, resp := range responses.Jobs {
+		// Error handling during generating_load_files step:
+		// 1. any error returned by notifier is set on corresponding staging_file
+		// 2. any error effecting a batch/all the staging files like saving load file records to wh db
+		//    is returned as error to caller of the func to set error on all staging files and the whole generating_load_files step
+		var jobResponse WorkerJobResponse
+		if err := jsonrs.Unmarshal(resp.Payload, &jobResponse); err != nil {
+			return fmt.Errorf("unmarshalling response from notifier: %w", err)
+		}
+
+		if resp.Status == notifier.Aborted && resp.Error != nil {
+			lf.Logger.Errorf("[WH]: Error in generating load files: %v", resp.Error)
+			sampleError := errors.New(resp.Error.Error())
+			err := lf.StageRepo.SetErrorStatus(ctx, jobResponse.StagingFileID, sampleError)
+			if err != nil {
+				return fmt.Errorf("set staging file error status: %w", err)
+			}
+			continue
+		}
+		if len(jobResponse.Output) == 0 {
+			lf.Logger.Errorf("[WH]: No LoadFiles returned by worker")
+			continue
+		}
+		for _, output := range jobResponse.Output {
+			loadFile := toLoadFile(output, job)
+			loadFile.StagingFileID = jobResponse.StagingFileID
+			loadFiles = append(loadFiles, loadFile)
+		}
+
+		successfulStagingFileIDs = append(successfulStagingFileIDs, jobResponse.StagingFileID)
+	}
+
+	if len(loadFiles) == 0 {
+		return nil
+	}
+
+	if err := lf.LoadRepo.Insert(ctx, loadFiles); err != nil {
+		return fmt.Errorf("inserting load files: %w", err)
+	}
+	if err := lf.StageRepo.SetStatuses(ctx, successfulStagingFileIDs, warehouseutils.StagingFileSucceededState); err != nil {
+		return fmt.Errorf("setting staging file status to succeeded: %w", err)
+	}
+	return nil
+}
+
+// Unlike upload type job, for v2 we are not setting the status of staging files
+func (lf *LoadFileGenerator) processNotifierResponseV2(ctx context.Context, ch <-chan *notifier.PublishResponse, job *model.UploadJob, chunk []*model.StagingFile) error {
+	responses, ok := <-ch
+	if !ok {
+		return fmt.Errorf("receiving notifier channel closed")
+	}
+	logNotifierResponse(lf.Logger, job, chunk)
+	if responses.Err != nil {
+		return fmt.Errorf("receiving responses from notifier: %w", responses.Err)
+	}
+
+	var loadFiles []model.LoadFile
+	for _, resp := range responses.Jobs {
+		var response WorkerJobResponseV2
+		if err := jsonrs.Unmarshal(resp.Payload, &response); err != nil {
+			return fmt.Errorf("unmarshalling response from notifier: %w", err)
+		}
+
+		if resp.Status == notifier.Aborted && resp.Error != nil {
+			lf.Logger.Errorf("[WH]: Error in generating load files: %v", resp.Error)
+			continue
+		}
+		if len(response.Output) == 0 {
+			lf.Logger.Errorf("[WH]: No LoadFiles returned by worker")
+			continue
+		}
+		for _, output := range response.Output {
+			loadFiles = append(loadFiles, toLoadFile(output, job))
+		}
+	}
+	if len(loadFiles) == 0 {
+		return nil
+	}
+	if err := lf.LoadRepo.Insert(ctx, loadFiles); err != nil {
+		return fmt.Errorf("inserting load files: %w", err)
+	}
+	return nil
+}
+
+func (lf *LoadFileGenerator) createUploadJobs(ctx context.Context, job *model.UploadJob, stagingFiles []*model.StagingFile, publishBatchSize int, uniqueLoadGenID string) error {
+	destinationRevisionIDMap, err := lf.destinationRevisionIDMap(ctx, job)
+	if err != nil {
+		return fmt.Errorf("populating destination revision ID: %w", err)
+	}
+	g, gCtx := errgroup.WithContext(ctx)
+	for _, chunk := range lo.Chunk(stagingFiles, publishBatchSize) {
+		ch, err := lf.publishJobs(ctx, job, uniqueLoadGenID, chunk, destinationRevisionIDMap, notifier.JobTypeUpload, func(baseReq baseWorkerJobRequest, stagingFile *model.StagingFile) (stdjson.RawMessage, error) {
+			return jsonrs.Marshal(WorkerJobRequest{
+				baseWorkerJobRequest: baseReq,
+				StagingFileID:        stagingFile.ID,
+				StagingFileLocation:  stagingFile.Location,
+			})
+		})
+		if err != nil {
+			return fmt.Errorf("error publishing jobs: %w", err)
+		}
+		_chunk := chunk
+		g.Go(func() error {
+			return lf.processNotifierResponse(gCtx, ch, job, _chunk)
+		})
+	}
+	return g.Wait()
+}
+
+func (lf *LoadFileGenerator) createUploadV2Jobs(ctx context.Context, job *model.UploadJob, stagingFiles []*model.StagingFile, publishBatchSize int, uniqueLoadGenID string) error {
+	destinationRevisionIDMap, err := lf.destinationRevisionIDMap(ctx, job)
+	if err != nil {
+		return fmt.Errorf("populating destination revision ID: %w", err)
+	}
+	g, gCtx := errgroup.WithContext(ctx)
+	for _, chunk := range lo.Chunk(stagingFiles, publishBatchSize) {
+		// FIXME
+		// 1. Batch multiple files in a single job
+		// 2. Ensure that the correct time window is used for computing the load file prefix
+		ch, err := lf.publishJobs(ctx, job, uniqueLoadGenID, chunk, destinationRevisionIDMap, notifier.JobTypeUploadV2, func(baseReq baseWorkerJobRequest, stagingFile *model.StagingFile) (stdjson.RawMessage, error) {
+			return jsonrs.Marshal(WorkerJobRequestV2{
+				baseWorkerJobRequest: baseReq,
+				StagingFiles: []StagingFileInfo{
+					{ID: stagingFile.ID, Location: stagingFile.Location},
+				},
+			})
+		})
+		if err != nil {
+			return fmt.Errorf("error publishing jobs: %w", err)
+		}
+		_chunk := chunk
+		g.Go(func() error {
+			return lf.processNotifierResponseV2(gCtx, ch, job, _chunk)
+		})
+	}
+	return g.Wait()
 }
 
 func (lf *LoadFileGenerator) destinationRevisionIDMap(ctx context.Context, job *model.UploadJob) (map[string]backendconfig.DestinationT, error) {
@@ -406,4 +543,32 @@ func (lf *LoadFileGenerator) GetLoadFilePrefix(timeWindow time.Time, warehouse m
 		}
 	}
 	return timeWindow.Format(warehouseutils.DatalakeTimeWindowFormat)
+}
+
+func logNotifierResponse(lfLogger logger.Logger, job *model.UploadJob, chunk []*model.StagingFile) {
+	destID := job.Upload.DestinationID
+	destType := job.Upload.DestinationType
+	startId := chunk[0].ID
+	endId := chunk[len(chunk)-1].ID
+	lfLogger.Infon("Received responses for staging files from notifier",
+		logger.NewIntField("startId", startId),
+		logger.NewIntField("endID", endId),
+		obskit.DestinationID(destID),
+		obskit.DestinationType(destType),
+	)
+}
+
+func toLoadFile(output LoadFileUpload, job *model.UploadJob) model.LoadFile {
+	return model.LoadFile{
+		TableName:             output.TableName,
+		Location:              output.Location,
+		TotalRows:             output.TotalRows,
+		ContentLength:         output.ContentLength,
+		DestinationRevisionID: output.DestinationRevisionID,
+		UseRudderStorage:      output.UseRudderStorage,
+		SourceID:              job.Upload.SourceID,
+		DestinationID:         job.Upload.DestinationID,
+		DestinationType:       job.Upload.DestinationType,
+		UploadID:              &job.Upload.ID,
+	}
 }

--- a/warehouse/internal/loadfiles/loadfiles_test.go
+++ b/warehouse/internal/loadfiles/loadfiles_test.go
@@ -361,7 +361,7 @@ func TestCreateLoadFiles_DestinationHistory(t *testing.T) {
 		stagingFile.DestinationRevisionID = "invalid_revision_id"
 
 		startID, endID, err := lf.CreateLoadFiles(ctx, &job)
-		require.EqualError(t, err, "populating destination revision ID: revision \"invalid_revision_id\" not found")
+		require.ErrorContains(t, err, "populating destination revision ID: revision \"invalid_revision_id\" not found")
 		require.Zero(t, startID)
 		require.Zero(t, endID)
 	})

--- a/warehouse/internal/loadfiles/mock_notifier_test.go
+++ b/warehouse/internal/loadfiles/mock_notifier_test.go
@@ -16,11 +16,19 @@ import (
 type mockNotifier struct {
 	t *testing.T
 
-	requests []loadfiles.WorkerJobRequest
-	tables   []string
+	requests   []loadfiles.WorkerJobRequest
+	requestsV2 []loadfiles.WorkerJobRequestV2
+	tables     []string
 }
 
 func (n *mockNotifier) Publish(_ context.Context, payload *notifier.PublishRequest) (<-chan *notifier.PublishResponse, error) {
+	if payload.JobType == notifier.JobTypeUploadV2 {
+		return n.publishV2(payload)
+	}
+	return n.publish(payload)
+}
+
+func (n *mockNotifier) publish(payload *notifier.PublishRequest) (<-chan *notifier.PublishResponse, error) {
 	var responses notifier.PublishResponse
 	for _, p := range payload.Payloads {
 		var req loadfiles.WorkerJobRequest
@@ -57,6 +65,56 @@ func (n *mockNotifier) Publish(_ context.Context, payload *notifier.PublishReque
 		status := notifier.Succeeded
 		if req.StagingFileLocation == "" {
 			errString = "staging file location is empty"
+			status = notifier.Aborted
+		}
+
+		responses.Jobs = append(responses.Jobs, notifier.Job{
+			Payload: out,
+			Error:   errors.New(errString),
+			Status:  status,
+		})
+	}
+
+	ch := make(chan *notifier.PublishResponse, 1)
+	ch <- &responses
+	return ch, nil
+}
+
+func (n *mockNotifier) publishV2(payload *notifier.PublishRequest) (<-chan *notifier.PublishResponse, error) {
+	var responses notifier.PublishResponse
+	for _, p := range payload.Payloads {
+		var req loadfiles.WorkerJobRequestV2
+		err := jsonrs.Unmarshal(p, &req)
+		require.NoError(n.t, err)
+
+		var loadFileUploads []loadfiles.LoadFileUpload
+		for _, tableName := range n.tables {
+			destinationRevisionID := req.DestinationRevisionID
+
+			n.requestsV2 = append(n.requestsV2, req)
+
+			loadFileUploads = append(loadFileUploads, loadfiles.LoadFileUpload{
+				TableName:             tableName,
+				Location:              req.UniqueLoadGenID + "/" + tableName,
+				TotalRows:             10,
+				ContentLength:         1000,
+				DestinationRevisionID: destinationRevisionID,
+				UseRudderStorage:      req.UseRudderStorage,
+			})
+		}
+		jobResponse := loadfiles.WorkerJobResponseV2{
+			Output: loadFileUploads,
+		}
+		out, err := jsonrs.Marshal(jobResponse)
+
+		errString := ""
+		if err != nil {
+			errString = err.Error()
+		}
+
+		status := notifier.Succeeded
+		if req.StagingFiles[0].Location == "abort" {
+			errString = "staging file location is abort"
 			status = notifier.Aborted
 		}
 

--- a/warehouse/slave/worker_job.go
+++ b/warehouse/slave/worker_job.go
@@ -34,29 +34,29 @@ import (
 )
 
 type payload struct {
-	BatchID                      string
-	UploadID                     int64
-	StagingFileID                int64
-	StagingFileLocation          string
-	UploadSchema                 model.Schema
-	WorkspaceID                  string
-	SourceID                     string
-	SourceName                   string
-	DestinationID                string
-	DestinationName              string
-	DestinationType              string
-	DestinationNamespace         string
-	DestinationRevisionID        string
-	StagingDestinationRevisionID string
-	DestinationConfig            map[string]interface{}
-	StagingDestinationConfig     interface{}
-	UseRudderStorage             bool
-	StagingUseRudderStorage      bool
-	UniqueLoadGenID              string
-	RudderStoragePrefix          string
-	Output                       []uploadResult
-	LoadFilePrefix               string // prefix for the load file name
-	LoadFileType                 string
+	BatchID                      string                 `json:"batch_id"`
+	UploadID                     int64                  `json:"upload_id"`
+	StagingFileID                int64                  `json:"staging_file_id"`
+	StagingFileLocation          string                 `json:"staging_file_location"`
+	UploadSchema                 model.Schema           `json:"upload_schema"`
+	WorkspaceID                  string                 `json:"workspace_id"`
+	SourceID                     string                 `json:"source_id"`
+	SourceName                   string                 `json:"source_name"`
+	DestinationID                string                 `json:"destination_id"`
+	DestinationName              string                 `json:"destination_name"`
+	DestinationType              string                 `json:"destination_type"`
+	DestinationNamespace         string                 `json:"destination_namespace"`
+	DestinationRevisionID        string                 `json:"destination_revision_id"`
+	StagingDestinationRevisionID string                 `json:"staging_destination_revision_id"`
+	DestinationConfig            map[string]interface{} `json:"destination_config"`
+	StagingDestinationConfig     interface{}            `json:"staging_destination_config"`
+	UseRudderStorage             bool                   `json:"use_rudder_storage"`
+	StagingUseRudderStorage      bool                   `json:"staging_use_rudder_storage"`
+	UniqueLoadGenID              string                 `json:"unique_load_gen_id"`
+	RudderStoragePrefix          string                 `json:"rudder_storage_prefix"`
+	Output                       []uploadResult         `json:"output"`
+	LoadFilePrefix               string                 `json:"load_file_prefix"`
+	LoadFileType                 string                 `json:"load_file_type"`
 }
 
 func (p *payload) discardsTable() string {


### PR DESCRIPTION
# Description

This PR introduces support for creation of upload_v2 notifier jobs required for batching of staging files

**Key Changes:**
- Files are grouped into v1 and v2 based on the presence of BytesPerTable and a feature flag.
- Extracted common logic for v1 and v2 paths into separate methods
- For now, v2 notifier jobs include only one staging file per job, similar to v1. This is temporary — batching logic will be implemented in the next PR.
- We will no longer track the processing status (success/failure) of staging files in v2.
- v2 jobs will always force creation of load files (see state_generate_load_files.go).

## Linear Ticket

https://linear.app/rudderstack/issue/WAR-461/enable-creation-of-upload-v2-notifier-jobs

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
