### PR TITLE
chore: granular configuration for adaptive rate limiting

### DIFF
--- a/router/throttler/adaptivethrottlercounter/algorithm.go
+++ b/router/throttler/adaptivethrottlercounter/algorithm.go
@@ -16,27 +16,29 @@ type Adaptive struct {
 	wg                   *sync.WaitGroup
 }
 
-func New(config *config.Config, window config.ValueLoader[time.Duration]) *Adaptive {
+func New(destination string, config *config.Config, window config.ValueLoader[time.Duration]) *Adaptive {
 	lf := &limitFactor{value: 1}
 
-	increaseWindowMultiplier := config.GetReloadableIntVar(2, 1, "Router.throttler.adaptive.increaseWindowMultiplier")
+	increaseWindowMultiplier := config.GetReloadableIntVar(2, 1, "Router.throttler.adaptive."+destination+".increaseWindowMultiplier", "Router.throttler.adaptive.increaseWindowMultiplier")
 	increaseCounterWindow := func() time.Duration { return window.Load() * time.Duration(increaseWindowMultiplier.Load()) }
-	increasePercentage := config.GetReloadableInt64Var(10, 1, "Router.throttler.adaptive.increasePercentage")
+	increasePercentage := config.GetReloadableInt64Var(10, 1, "Router.throttler.adaptive."+destination+".increasePercentage", "Router.throttler.adaptive.increasePercentage")
+
 	ilc := &increaseLimitCounter{
 		limitFactor:        lf,
 		window:             increaseCounterWindow,
 		increasePercentage: increasePercentage,
 	}
 
-	decreaseWaitWindowMultiplier := config.GetReloadableIntVar(1, 1, "Router.throttler.adaptive.decreaseWaitWindowMultiplier")
+	decreaseWaitWindowMultiplier := config.GetReloadableIntVar(1, 1, "Router.throttler.adaptive."+destination+".decreaseWaitWindowMultiplier", "Router.throttler.adaptive.decreaseWaitWindowMultiplier")
 	decreaseWaitWindow := func() time.Duration { return window.Load() * time.Duration(decreaseWaitWindowMultiplier.Load()) }
-	decreasePercentage := config.GetReloadableInt64Var(30, 1, "Router.throttler.adaptive.decreasePercentage")
+	decreasePercentage := config.GetReloadableInt64Var(30, 1, "Router.throttler.adaptive."+destination+".decreasePercentage", "Router.throttler.adaptive.decreasePercentage")
+	throttleTolerancePercentage := config.GetReloadableInt64Var(10, 1, "Router.throttler.adaptive."+destination+".throttleTolerancePercentage", "Router.throttler.adaptive.throttleTolerancePercentage")
 	dlc := &decreaseLimitCounter{
 		limitFactor:                 lf,
 		window:                      func() time.Duration { return window.Load() },
 		waitWindow:                  decreaseWaitWindow,
 		decreasePercentage:          decreasePercentage,
-		throttleTolerancePercentage: func() int64 { return min(increasePercentage.Load(), decreasePercentage.Load()) },
+		throttleTolerancePercentage: func() int64 { return throttleTolerancePercentage.Load() },
 	}
 
 	var wg sync.WaitGroup

--- a/router/throttler/adaptivethrottlercounter/algorithm_test.go
+++ b/router/throttler/adaptivethrottlercounter/algorithm_test.go
@@ -15,7 +15,7 @@ const float64EqualityThreshold = 1e-9
 
 func TestAdaptiveRateLimit(t *testing.T) {
 	cfg := config.New()
-	al := New(cfg, config.SingleValueLoader(500*time.Millisecond))
+	al := New("dest", cfg, config.SingleValueLoader(500*time.Millisecond))
 	defer al.Shutdown()
 	t.Run("when there is a 429s in the last decrease limit counter window", func(t *testing.T) {
 		al.ResponseCodeReceived(429)
@@ -51,7 +51,7 @@ func TestAdaptiveRateLimit(t *testing.T) {
 	t.Run("should delay for few windows before decreasing again", func(t *testing.T) {
 		cfg := config.New()
 		cfg.Set("Router.throttler.adaptive.decreaseRateDelay", 2)
-		al := New(cfg, config.SingleValueLoader(500*time.Millisecond))
+		al := New("dest", cfg, config.SingleValueLoader(500*time.Millisecond))
 		defer al.Shutdown()
 		al.ResponseCodeReceived(429)
 		require.Eventually(t, func() bool {

--- a/router/throttler/algorithm.go
+++ b/router/throttler/algorithm.go
@@ -17,10 +17,10 @@ type adaptiveAlgorithm interface {
 	LimitFactor() float64
 }
 
-func newAdaptiveAlgorithm(config *config.Config, window config.ValueLoader[time.Duration]) adaptiveAlgorithm {
+func newAdaptiveAlgorithm(destination string, config *config.Config, window config.ValueLoader[time.Duration]) adaptiveAlgorithm {
 	name := config.GetString("Router.throttler.adaptive.algorithm", "")
 	switch name {
 	default:
-		return adaptivethrottlercounter.New(config, window)
+		return adaptivethrottlercounter.New(destination, config, window)
 	}
 }

--- a/router/throttler/factory.go
+++ b/router/throttler/factory.go
@@ -80,7 +80,7 @@ func (f *factory) Get(destName, destID string) Throttler {
 		}
 		at = &adaptiveThrottler{
 			limiter:                f.adaptiveLimiter,
-			algorithm:              newAdaptiveAlgorithm(f.config, adaptiveConf.window),
+			algorithm:              newAdaptiveAlgorithm(destName, f.config, adaptiveConf.window),
 			config:                 adaptiveConf,
 			limitFactorMeasurement: limitFactorMeasurement,
 		}


### PR DESCRIPTION
# Description

- Support granular configuration in adaptive rate limiter, different for each destination.
- Decouple `throttleTolerancePercentage` from `increasePercentage` and `decreasePercentage`


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
