### PR TITLE
chore: use transformer compaction by default

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,7 +34,6 @@ jobs:
         run: go test -v ./integration_test/docker_test/docker_test.go -count 1
         env:
           ENTERPRISE_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
-          RSERVER_TRANSFORMER_FORCE_COMPACTION_ENABLED: true
 
       - name: oss
         if: matrix.FEATURES == 'oss'
@@ -126,7 +125,6 @@ jobs:
         run: FORCE_RUN_INTEGRATION_TESTS=true make test exclude="/rudder-server/(jobsdb|integration_test|processor|regulation-worker|router|services|suppression-backup-service|warehouse)"
         env:
           RSERVER_PROCESSOR_ENABLE_CONCURRENT_STORE: "true"
-          RSERVER_TRANSFORMER_FORCE_COMPACTION_ENABLED: "true"
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
@@ -195,7 +193,6 @@ jobs:
           SNOWPIPE_STREAMING_KEYPAIR_ENCRYPTED_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.SNOWPIPE_STREAMING_KEYPAIR_ENCRYPTED_INTEGRATION_TEST_CREDENTIALS }}
           SNOWFLAKE_PRIVILEGE_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.SNOWFLAKE_PRIVILEGE_INTEGRATION_TEST_CREDENTIALS }}
           RSERVER_PROCESSOR_ENABLE_CONCURRENT_STORE: "true"
-          RSERVER_TRANSFORMER_FORCE_COMPACTION_ENABLED: "true"
         run: FORCE_RUN_INTEGRATION_TESTS=true make test exclude="${{ matrix.exclude }}" package=${{ matrix.package }}
       - name: Sanitize name for Artifact
         run: |

--- a/processor/internal/transformer/destination_transformer/destination_transformer.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer.go
@@ -84,8 +84,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) 
 	handle.loggedEventsMu = sync.Mutex{}
 	handle.loggedFileName = generateLogFileName()
 
-	handle.config.forceCompactionEnabled = conf.GetBoolVar(false, "Processor.DestinationTransformer.forceCompactionEnabled", "Transformer.forceCompactionEnabled")
-	handle.config.compactionEnabled = conf.GetReloadableBoolVar(false, "Processor.DestinationTransformer.compactionEnabled", "Transformer.compactionEnabled")
+	handle.config.compactionEnabled = conf.GetReloadableBoolVar(true, "Processor.DestinationTransformer.compactionEnabled", "Transformer.compactionEnabled")
 
 	for _, opt := range opts {
 		opt(handle)
@@ -106,9 +105,8 @@ type Client struct {
 
 		maxLoggedEvents config.ValueLoader[int]
 
-		forceCompactionEnabled bool // option to force usage of compaction for testing
-		compactionEnabled      config.ValueLoader[bool]
-		compactionSupported    bool
+		compactionEnabled   config.ValueLoader[bool]
+		compactionSupported bool
 	}
 	guardConcurrency chan struct{}
 	conf             *config.Config
@@ -407,7 +405,7 @@ func (c *Client) Transform(ctx context.Context, clientEvents []types.Transformer
 }
 
 func (d *Client) compactRequestPayloads() bool {
-	return (d.config.compactionSupported && d.config.compactionEnabled.Load()) || d.config.forceCompactionEnabled
+	return (d.config.compactionSupported && d.config.compactionEnabled.Load())
 }
 
 func (d *Client) getRequestPayload(data []types.TransformerEvent, compactRequestPayloads bool) ([]byte, error) {

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -71,9 +71,8 @@ type handle struct {
 	// expirationTimeDiff holds the configured time difference for token expiration.
 	expirationTimeDiff config.ValueLoader[time.Duration]
 
-	forceCompactionEnabled bool // option to force usage of compaction for testing
-	compactionEnabled      config.ValueLoader[bool]
-	compactionSupported    bool
+	compactionEnabled   config.ValueLoader[bool]
+	compactionSupported bool
 }
 
 type ProxyRequestMetadata struct {
@@ -601,8 +600,7 @@ func (trans *handle) setup(destinationTimeout, transformTimeout time.Duration, c
 	trans.proxyClientOAuthV2 = oauthv2httpclient.NewOAuthHttpClient(&http.Client{Transport: trans.tr, Timeout: trans.destinationTimeout + trans.transformTimeout}, common.RudderFlowDelivery, cache, backendConfig, GetAuthErrorCategoryFromTransformProxyResponse, proxyClientOptionalArgs)
 	trans.stats = stats.Default
 	trans.transformRequestTimerStat = stats.Default.NewStat("router.transformer_request_time", stats.TimerType)
-	trans.forceCompactionEnabled = config.GetBoolVar(false, "Router.DestinationTransformer.forceCompactionEnabled", "Transformer.forceCompactionEnabled")
-	trans.compactionEnabled = config.GetReloadableBoolVar(false, "Router.DestinationTransformer.compactionEnabled", "Transformer.compactionEnabled")
+	trans.compactionEnabled = config.GetReloadableBoolVar(true, "Router.DestinationTransformer.compactionEnabled", "Transformer.compactionEnabled")
 	if featuresService != nil {
 		go func() {
 			<-featuresService.Wait()
@@ -773,7 +771,7 @@ func getEndpointFromURL(urlStr string) string {
 }
 
 func (trans *handle) compactRequestPayloads() bool {
-	return (trans.compactionSupported && trans.compactionEnabled.Load()) || trans.forceCompactionEnabled
+	return (trans.compactionSupported && trans.compactionEnabled.Load())
 }
 
 func (trans *handle) getRequestPayload(data *types.TransformMessageT, compactRequestPayloads bool) ([]byte, error) {

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -2066,47 +2066,25 @@ func TestTransformerMetrics(t *testing.T) {
 func TestTransformerCompactionFlags(t *testing.T) {
 	t.Run("compaction not supported and not enabled", func(t *testing.T) {
 		h := &handle{
-			compactionEnabled:      config.SingleValueLoader(false),
-			compactionSupported:    false,
-			forceCompactionEnabled: false,
+			compactionEnabled:   config.SingleValueLoader(false),
+			compactionSupported: false,
 		}
 
 		require.False(t, h.compactRequestPayloads())
-	})
-
-	t.Run("compaction not supported and not enabled but forced", func(t *testing.T) {
-		h := &handle{
-			compactionEnabled:      config.SingleValueLoader(false),
-			compactionSupported:    false,
-			forceCompactionEnabled: true,
-		}
-
-		require.True(t, h.compactRequestPayloads())
 	})
 
 	t.Run("compaction supported but not enabled", func(t *testing.T) {
 		h := &handle{
-			compactionEnabled:      config.SingleValueLoader(false),
-			compactionSupported:    true,
-			forceCompactionEnabled: false,
+			compactionEnabled:   config.SingleValueLoader(false),
+			compactionSupported: true,
 		}
 		require.False(t, h.compactRequestPayloads())
 	})
 
-	t.Run("compaction supported, not enabled but forced", func(t *testing.T) {
-		h := &handle{
-			compactionEnabled:      config.SingleValueLoader(false),
-			compactionSupported:    true,
-			forceCompactionEnabled: true,
-		}
-		require.True(t, h.compactRequestPayloads())
-	})
-
 	t.Run("compaction supported and enabled", func(t *testing.T) {
 		h := &handle{
-			compactionEnabled:      config.SingleValueLoader(true),
-			compactionSupported:    true,
-			forceCompactionEnabled: false,
+			compactionEnabled:   config.SingleValueLoader(true),
+			compactionSupported: true,
 		}
 		require.True(t, h.compactRequestPayloads())
 	})


### PR DESCRIPTION
# Description

transformer compaction will now be enabled by default, as long as transformer service supports it

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
