### PR TITLE
fix: use copy to load table in case append mode

### DIFF
--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -461,7 +461,7 @@ func (rs *Redshift) loadTable(
 	strKeys := warehouseutils.GetColumnsFromTableSchema(tableSchemaInUpload)
 	sort.Strings(strKeys)
 
-	// Users table still needs to be deduped by partition key. 
+	// Users table still needs to be deduped by partition key.
 	// In case of users table, staging table should be created, so that users table can be deduped by partition key
 	if !shouldMerge && tableName != warehouseutils.UsersTable {
 		err := rs.copyIntoLoadTable(ctx, rs.DB, tableName, tableName, strKeys)

--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -461,7 +461,9 @@ func (rs *Redshift) loadTable(
 	strKeys := warehouseutils.GetColumnsFromTableSchema(tableSchemaInUpload)
 	sort.Strings(strKeys)
 
-	if !shouldMerge {
+	// Users table still needs to be deduped by partition key. 
+	// In case of users table, staging table should be created, so that users table can be deduped by partition key
+	if !shouldMerge && tableName != warehouseutils.UsersTable {
 		err := rs.copyIntoLoadTable(ctx, rs.DB, tableName, tableName, strKeys)
 		if err != nil {
 			return nil, "", fmt.Errorf("copy into load table: %w", err)

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -937,13 +937,11 @@ func TestIntegration(t *testing.T) {
 
 				loadTableStat, err := d.LoadTable(ctx, tableName)
 				require.NoError(t, err)
-				require.Equal(t, loadTableStat.RowsInserted, int64(14))
-				require.Equal(t, loadTableStat.RowsUpdated, int64(0))
+				require.Empty(t, loadTableStat)
 
 				loadTableStat, err = d.LoadTable(ctx, tableName)
 				require.NoError(t, err)
-				require.Equal(t, loadTableStat.RowsInserted, int64(14))
-				require.Equal(t, loadTableStat.RowsUpdated, int64(0))
+				require.Empty(t, loadTableStat)
 
 				records := whth.RetrieveRecordsFromWarehouse(
 					t,
@@ -1156,13 +1154,11 @@ func TestIntegration(t *testing.T) {
 
 			loadTableStat, err := rs.LoadTable(ctx, tableName)
 			require.NoError(t, err)
-			require.Equal(t, loadTableStat.RowsInserted, int64(14))
-			require.Equal(t, loadTableStat.RowsUpdated, int64(0))
+			require.Empty(t, loadTableStat)
 
 			loadTableStat, err = rs.LoadTable(ctx, tableName)
 			require.NoError(t, err)
-			require.Equal(t, loadTableStat.RowsInserted, int64(14))
-			require.Equal(t, loadTableStat.RowsUpdated, int64(0))
+			require.Empty(t, loadTableStat)
 
 			records := whth.RetrieveRecordsFromWarehouse(
 				t,


### PR DESCRIPTION
# Description
- `tx.Commit` for redshift getting stuck in some cases when loading data into table. In case of append mode, we can directly load file instead of doing it in transaction
- Since we are now skipping creating staging table if append mode is preferred. In case of `loadUserTables`, it relies on indentifies staging table because `users` table will be deduped/merged even when append mode is preferred.  So, creating a staging table for `identifies` is now handled by `loadUserTables`

## Linear Ticket
Part of WAR-517, WAR-515

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
