### PR TITLE
chore: use reloadable limiters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # syntax=docker/dockerfile:1
 
 # GO_VERSION is updated automatically to match go.mod, see Makefile
-ARG GO_VERSION=1.24.1
+ARG GO_VERSION=1.24.2
 ARG ALPINE_VERSION=3.20
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 ARG VERSION

--- a/archiver/options.go
+++ b/archiver/options.go
@@ -6,15 +6,6 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/payload"
 )
 
-type configGetter interface {
-	IsSet(key string) bool
-	GetInt(key string, defaultValue int) (value int)
-	GetInt64(key string, defaultValue int64) (value int64)
-	GetString(key, defaultValue string) (value string)
-	GetDuration(key string, defaultValueInTimescaleUnits int64, timeScale time.Duration) time.Duration
-	GetBool(key string, defaultValue bool) (value bool)
-}
-
 type Option func(*archiver)
 
 func WithAdaptiveLimit(limiter payload.AdaptiveLimiterFunc) Option {

--- a/enterprise/reporting/error_index/error_index_reporting.go
+++ b/enterprise/reporting/error_index/error_index_reporting.go
@@ -79,19 +79,19 @@ func NewErrorIndexReporter(ctx context.Context, log logger.Logger, configSubscri
 	eir.concurrency = conf.GetReloadableIntVar(10, 1, "Reporting.errorIndexReporting.concurrency")
 
 	eir.limiterGroup = sync.WaitGroup{}
-	eir.limiter.fetch = kitsync.NewLimiter(
+	eir.limiter.fetch = kitsync.NewReloadableLimiter(
 		eir.ctx, &eir.limiterGroup, "erridx_fetch",
-		eir.concurrency.Load(),
+		eir.concurrency,
 		eir.statsFactory,
 	)
-	eir.limiter.upload = kitsync.NewLimiter(
+	eir.limiter.upload = kitsync.NewReloadableLimiter(
 		eir.ctx, &eir.limiterGroup, "erridx_upload",
-		eir.concurrency.Load(),
+		eir.concurrency,
 		eir.statsFactory,
 	)
-	eir.limiter.update = kitsync.NewLimiter(
+	eir.limiter.update = kitsync.NewReloadableLimiter(
 		eir.ctx, &eir.limiterGroup, "erridx_update",
-		eir.concurrency.Load(),
+		eir.concurrency,
 		eir.statsFactory,
 	)
 	g.Go(func() error {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudderlabs/rudder-server
 
-go 1.24.1
+go 1.24.2
 
 // Addressing snyk vulnerabilities in indirect dependencies
 // When upgrading a dependency, please make sure that
@@ -78,7 +78,7 @@ require (
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/rudderlabs/bing-ads-go-sdk v0.2.3
 	github.com/rudderlabs/compose-test v0.1.3
-	github.com/rudderlabs/rudder-go-kit v0.48.2
+	github.com/rudderlabs/rudder-go-kit v0.49.0
 	github.com/rudderlabs/rudder-observability-kit v0.0.4
 	github.com/rudderlabs/rudder-schemas v0.5.5
 	github.com/rudderlabs/rudder-transformer/go v0.0.0-20240910055720-f77d2ab4125a
@@ -116,8 +116,6 @@ require (
 	google.golang.org/protobuf v1.36.6
 )
 
-require github.com/moby/sys/capability v0.4.0 // indirect
-
 require (
 	cel.dev/expr v0.19.2 // indirect
 	cloud.google.com/go v0.120.0 // indirect
@@ -137,7 +135,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
-	github.com/DataDog/zstd v1.5.6 // indirect
+	github.com/DataDog/zstd v1.5.7 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.51.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0 // indirect
@@ -200,7 +198,7 @@ require (
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.7 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
@@ -278,7 +276,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus/client_golang v1.21.1 // indirect
+	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/ClickHouse/clickhouse-go/v2 v2.25.0 h1:rKscwqgQHzWBTZySZDcHKxgs0Ad+xF
 github.com/ClickHouse/clickhouse-go/v2 v2.25.0/go.mod h1:iDTViXk2Fgvf1jn2dbJd1ys+fBkdD1UMRnXlwmhijhQ=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
-github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
-github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=
+github.com/DataDog/zstd v1.5.7/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/GoogleCloudPlatform/cloudsql-proxy v1.29.0/go.mod h1:spvB9eLJH9dutlbPSRmHvSXXHOwGRyeXh1jVdquA2G8=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0 h1:3c8yed4lgqTt+oTQ+JNMDo+F4xprBf+O/il4ZC0nRLw=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0/go.mod h1:obipzmGjfSjam60XLwGfqUkJsfiheAl+TUjG+4yzyPM=
@@ -528,8 +528,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
-github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fsouza/fake-gcs-server v1.52.2 h1:j6ne83nqHrlX5EEor7WWVIKdBsztGtwJ1J2mL+k+iio=
 github.com/fsouza/fake-gcs-server v1.52.2/go.mod h1:47HKyIkz6oLTes1R8vEaHLwXfzYsGfmDUk1ViHHAUsA=
 github.com/fvbommel/sortorder v1.0.2 h1:mV4o8B2hKboCdkJm+a7uX/SIpZob4JzUpc5GGnM45eo=
@@ -1129,8 +1129,8 @@ github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
-github.com/prometheus/client_golang v1.21.1 h1:DOvXXTqVzvkIewV/CDPFdejpMCGeMcbGCQ8YOmu+Ibk=
-github.com/prometheus/client_golang v1.21.1/go.mod h1:U9NM32ykUErtVBxdvD3zfi+EuFkkaBvMb09mIfe0Zgg=
+github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/Y92Vm0Zc6Q=
+github.com/prometheus/client_golang v1.22.0/go.mod h1:R7ljNsLXhuQXYZYtw6GAE9AZg8Y7vEW5scdCXrWRXC0=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
@@ -1173,8 +1173,8 @@ github.com/rudderlabs/goqu/v10 v10.3.1 h1:rnfX+b4EwBWQ2UQfIGeEW299JBBkK5biEbnf7K
 github.com/rudderlabs/goqu/v10 v10.3.1/go.mod h1:LH2vI5gGHBxEQuESqFyk5ZA2anGINc8o25hbidDWOYw=
 github.com/rudderlabs/parquet-go v0.0.2 h1:ZXRdZdimB0PdJtmxeSSxfI0fDQ3kZjwzBxRi6Ut1J8k=
 github.com/rudderlabs/parquet-go v0.0.2/go.mod h1:g6guum7o8uhj/uNhunnt7bw5Vabu/goI5i21/3fnxWQ=
-github.com/rudderlabs/rudder-go-kit v0.48.2 h1:9MmUBAEnqJD/ZefMzdQ6wcD/v6baaGAymuMHWCgJHfE=
-github.com/rudderlabs/rudder-go-kit v0.48.2/go.mod h1:cqqP6MGm6Jwdd+8QjIBgC7pOeTMwnutjfW4m+F76olI=
+github.com/rudderlabs/rudder-go-kit v0.49.0 h1:TtO/CYpV20A00VoNjEeHTYJDt3w6KOMtWBdRKqxJg0k=
+github.com/rudderlabs/rudder-go-kit v0.49.0/go.mod h1:lLPM+p5eeXqzXb01A+1CH54I0OTCVAtXlIFadyWz5DI=
 github.com/rudderlabs/rudder-observability-kit v0.0.4 h1:h9nLoWqiv/nqGOu1dhuVFAHNRkyodR6R3v36bqmavRs=
 github.com/rudderlabs/rudder-observability-kit v0.0.4/go.mod h1:YTsvJmpvh8OLk7c4C+wXiV8NRdcrrdLa8UvIdLoXTho=
 github.com/rudderlabs/rudder-schemas v0.5.5 h1:aIXxyn/PbEMMZBXGbNDTmf/gDDUoSHcF7DJYmHwiIUc=

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -596,28 +596,28 @@ func (proc *Handle) Start(ctx context.Context) error {
 	// limiters
 	s := proc.statsFactory
 	var limiterGroup sync.WaitGroup
-	proc.limiter.read = kitsync.NewLimiter(ctx, &limiterGroup, "proc_read",
-		config.GetInt("Processor.Limiter.read.limit", 50),
+	proc.limiter.read = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "proc_read",
+		config.GetReloadableIntVar(50, 1, "Processor.Limiter.read.limit"),
 		s,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Processor.Limiter.read.dynamicPeriod", 1, time.Second)))
-	proc.limiter.preprocess = kitsync.NewLimiter(ctx, &limiterGroup, "proc_preprocess",
-		config.GetInt("Processor.Limiter.preprocess.limit", 50),
+	proc.limiter.preprocess = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "proc_preprocess",
+		config.GetReloadableIntVar(50, 1, "Processor.Limiter.preprocess.limit"),
 		s,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Processor.Limiter.preprocess.dynamicPeriod", 1, time.Second)))
-	proc.limiter.pretransform = kitsync.NewLimiter(ctx, &limiterGroup, "proc_pretransform",
-		config.GetInt("Processor.Limiter.pretransform.limit", 50),
+	proc.limiter.pretransform = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "proc_pretransform",
+		config.GetReloadableIntVar(50, 1, "Processor.Limiter.pretransform.limit"),
 		s,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Processor.Limiter.pretransform.dynamicPeriod", 1, time.Second)))
-	proc.limiter.utransform = kitsync.NewLimiter(ctx, &limiterGroup, "proc_utransform",
-		config.GetInt("Processor.Limiter.utransform.limit", 50),
+	proc.limiter.utransform = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "proc_utransform",
+		config.GetReloadableIntVar(50, 1, "Processor.Limiter.utransform.limit"),
 		s,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Processor.Limiter.utransform.dynamicPeriod", 1, time.Second)))
-	proc.limiter.dtransform = kitsync.NewLimiter(ctx, &limiterGroup, "proc_dtransform",
-		config.GetInt("Processor.Limiter.dtransform.limit", 50),
+	proc.limiter.dtransform = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "proc_dtransform",
+		config.GetReloadableIntVar(50, 1, "Processor.Limiter.dtransform.limit"),
 		s,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Processor.Limiter.dtransform.dynamicPeriod", 1, time.Second)))
-	proc.limiter.store = kitsync.NewLimiter(ctx, &limiterGroup, "proc_store",
-		config.GetInt("Processor.Limiter.store.limit", 50),
+	proc.limiter.store = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "proc_store",
+		config.GetReloadableIntVar(50, 1, "Processor.Limiter.store.limit"),
 		s,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Processor.Limiter.store.dynamicPeriod", 1, time.Second)))
 	g.Go(func() error {

--- a/router/batchrouter/batchrouterBenchmark_test.go
+++ b/router/batchrouter/batchrouterBenchmark_test.go
@@ -2,6 +2,7 @@ package batchrouter
 
 import (
 	"context"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -109,7 +110,11 @@ func (mockFileManager) Upload(context.Context, *os.File, ...string) (filemanager
 	return filemanager.UploadedFile{}, nil
 }
 
-func (mockFileManager) Download(context.Context, *os.File, string) error {
+func (mockFileManager) UploadReader(context.Context, string, io.Reader) (filemanager.UploadedFile, error) {
+	return filemanager.UploadedFile{}, nil
+}
+
+func (mockFileManager) Download(context.Context, io.WriterAt, string) error {
 	return nil
 }
 

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -132,8 +132,8 @@ func (brt *Handle) Setup(
 
 	var limiterGroup sync.WaitGroup
 	limiterStatsPeriod := config.GetDuration("BatchRouter.Limiter.statsPeriod", 15, time.Second)
-	brt.limiter.read = kitsync.NewLimiter(ctx, &limiterGroup, "brt_read",
-		getBatchRouterConfigInt("Limiter.read.limit", brt.destType, 20),
+	brt.limiter.read = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "brt_read",
+		getReloadableBatchRouterConfigInt("Limiter.read.limit", brt.destType, 20),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("BatchRouter.Limiter.read.dynamicPeriod", 1, time.Second)),
 		kitsync.WithLimiterTags(map[string]string{"destType": brt.destType}),
@@ -141,8 +141,8 @@ func (brt *Handle) Setup(
 			return time.After(limiterStatsPeriod)
 		}),
 	)
-	brt.limiter.process = kitsync.NewLimiter(ctx, &limiterGroup, "brt_process",
-		getBatchRouterConfigInt("Limiter.process.limit", brt.destType, 20),
+	brt.limiter.process = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "brt_process",
+		getReloadableBatchRouterConfigInt("Limiter.process.limit", brt.destType, 20),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("BatchRouter.Limiter.process.dynamicPeriod", 1, time.Second)),
 		kitsync.WithLimiterTags(map[string]string{"destType": brt.destType}),
@@ -150,8 +150,8 @@ func (brt *Handle) Setup(
 			return time.After(limiterStatsPeriod)
 		}),
 	)
-	brt.limiter.upload = kitsync.NewLimiter(ctx, &limiterGroup, "brt_upload",
-		getBatchRouterConfigInt("Limiter.upload.limit", brt.destType, 50),
+	brt.limiter.upload = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "brt_upload",
+		getReloadableBatchRouterConfigInt("Limiter.upload.limit", brt.destType, 50),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("BatchRouter.Limiter.upload.dynamicPeriod", 1, time.Second)),
 		kitsync.WithLimiterTags(map[string]string{"destType": brt.destType}),

--- a/router/batchrouter/util.go
+++ b/router/batchrouter/util.go
@@ -67,12 +67,8 @@ func getBRTErrorCode(state string) int {
 	return 500
 }
 
-func getBatchRouterConfigInt(key, destType string, defaultValue int) int {
-	destOverrideFound := config.IsSet("BatchRouter." + destType + "." + key)
-	if destOverrideFound {
-		return config.GetInt("BatchRouter."+destType+"."+key, defaultValue)
-	}
-	return config.GetInt("BatchRouter."+key, defaultValue)
+func getReloadableBatchRouterConfigInt(key, destType string, defaultValue int) config.ValueLoader[int] {
+	return config.GetReloadableIntVar(defaultValue, 1, "BatchRouter."+destType+"."+key, "BatchRouter."+key)
 }
 
 type storageDateFormatProvider struct {

--- a/router/config.go
+++ b/router/config.go
@@ -11,3 +11,16 @@ func getRouterConfigBool(key, destType string, defaultValue bool) bool {
 func getRouterConfigInt(key, destType string, defaultValue int) int {
 	return config.GetIntVar(defaultValue, 1, "Router."+destType+"."+key, "Router."+key)
 }
+
+func getHierarchicalRouterConfigInt(destType string, defaultValue int, keys ...string) int {
+	orderedKeys := make([]string, 0, len(keys)*2)
+	for i := range keys {
+		orderedKeys = append(orderedKeys, "Router."+destType+"."+keys[i])
+		orderedKeys = append(orderedKeys, "Router."+keys[i])
+	}
+	return config.GetIntVar(defaultValue, 1, orderedKeys...)
+}
+
+func getReloadableRouterConfigInt(key, destType string, defaultValue int) config.ValueLoader[int] {
+	return config.GetReloadableIntVar(defaultValue, 1, "Router."+destType+"."+key, "Router."+key)
+}

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -180,8 +180,8 @@ func (rt *Handle) Setup(
 
 	var limiterGroup sync.WaitGroup
 	limiterStatsPeriod := config.GetDuration("Router.Limiter.statsPeriod", 15, time.Second)
-	rt.limiter.pickup = kitsync.NewLimiter(ctx, &limiterGroup, "rt_pickup",
-		getRouterConfigInt("Limiter.pickup.limit", rt.destType, 100),
+	rt.limiter.pickup = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "rt_pickup",
+		getReloadableRouterConfigInt("Limiter.pickup.limit", rt.destType, 100),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Router.Limiter.pickup.dynamicPeriod", 1, time.Second)),
 		kitsync.WithLimiterTags(map[string]string{"destType": rt.destType}),
@@ -191,8 +191,8 @@ func (rt *Handle) Setup(
 	)
 	rt.limiter.stats.pickup = partition.NewStats()
 
-	rt.limiter.transform = kitsync.NewLimiter(ctx, &limiterGroup, "rt_transform",
-		getRouterConfigInt("Limiter.transform.limit", rt.destType, 200),
+	rt.limiter.transform = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "rt_transform",
+		getReloadableRouterConfigInt("Limiter.transform.limit", rt.destType, 200),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Router.Limiter.transform.dynamicPeriod", 1, time.Second)),
 		kitsync.WithLimiterTags(map[string]string{"destType": rt.destType}),
@@ -202,8 +202,8 @@ func (rt *Handle) Setup(
 	)
 	rt.limiter.stats.transform = partition.NewStats()
 
-	rt.limiter.batch = kitsync.NewLimiter(ctx, &limiterGroup, "rt_batch",
-		getRouterConfigInt("Limiter.batch.limit", rt.destType, 200),
+	rt.limiter.batch = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "rt_batch",
+		getReloadableRouterConfigInt("Limiter.batch.limit", rt.destType, 200),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Router.Limiter.batch.dynamicPeriod", 1, time.Second)),
 		kitsync.WithLimiterTags(map[string]string{"destType": rt.destType}),
@@ -213,8 +213,8 @@ func (rt *Handle) Setup(
 	)
 	rt.limiter.stats.batch = partition.NewStats()
 
-	rt.limiter.process = kitsync.NewLimiter(ctx, &limiterGroup, "rt_process",
-		getRouterConfigInt("Limiter.process.limit", rt.destType, 200),
+	rt.limiter.process = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "rt_process",
+		getReloadableRouterConfigInt("Limiter.process.limit", rt.destType, 1024),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("Router.Limiter.process.dynamicPeriod", 1, time.Second)),
 		kitsync.WithLimiterTags(map[string]string{"destType": rt.destType}),

--- a/suppression-backup-service/Dockerfile
+++ b/suppression-backup-service/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # GO_VERSION is updated automatically to match go.mod, see Makefile
-ARG GO_VERSION=1.24.1
+ARG GO_VERSION=1.24.2
 ARG ALPINE_VERSION=3.20
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 RUN mkdir /app


### PR DESCRIPTION
# Description

- Using reloadable limiters so that we can adjust limits at runtime
- Tuning some router configuration
  - process limiter increased from 200 to 1024
  - http client's max idle connections following the number of workers by default

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
