### PR TITLE
chore: change jobsdb payload column type default to text

### DIFF
--- a/jobsdb/bench/bench_test.go
+++ b/jobsdb/bench/bench_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	statsmetric "github.com/rudderlabs/rudder-go-kit/stats/metric"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
-	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/jobsdb/bench"
 )
 
@@ -53,7 +52,6 @@ func TestBench(t *testing.T) {
 		c.Set("JobsDB.maxWriters", 4)           // default: 3
 		c.Set("JobsDB.enableReaderQueue", true) //	default: true
 		c.Set("JobsDB.maxReaders", 8)           // default: 6
-		c.Set("JobsDB.payloadColumnType", string(jobsdb.TEXT))
 		c.Set("JobsDB.enableToastOptimizations", true)
 		c.Set("JobsDB.Compression.enabled", true)
 		c.Set("JobsDB.Compression.algorithm", "lz4")
@@ -126,7 +124,6 @@ func TestBench(t *testing.T) {
 		c.Set("JobsDB.maxWriters", 4)           // default: 3
 		c.Set("JobsDB.enableReaderQueue", true) //	default: true
 		c.Set("JobsDB.maxReaders", 8)           // default: 6
-		c.Set("JobsDB.payloadColumnType", string(jobsdb.TEXT))
 		c.Set("JobsDB.enableToastOptimizations", false)
 		c.Set("JobsDB.refreshDSListLoopSleepDuration", 1*time.Second)
 

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -1154,8 +1154,8 @@ func TestJobsdbSanitizeJSON(t *testing.T) {
 		t.Run(tCase.payloadColumnType, func(t *testing.T) {
 			_ = startPostgres(t)
 			conf := config.New()
-			conf.Set("JobsDB.payloadColumnType", tCase.payloadColumnType)
 			jobDB := Handle{config: conf}
+			jobDB.conf.payloadColumnType = payloadColumnType(tCase.payloadColumnType)
 			err := jobDB.Setup(ReadWrite, true, tCase.payloadColumnType+"_"+strings.ToLower(rand.String(5)))
 			require.NoError(t, err, tCase.payloadColumnType)
 			eventPayload := []byte(`{"batch":[{"anonymousId":"anon_id","sentAt":"2019-08-12T05:08:30.909Z","type":"track"}]}`)

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -775,7 +775,7 @@ func (jd *Handle) init() {
 	}
 
 	if string(jd.conf.payloadColumnType) == "" {
-		jd.conf.payloadColumnType = payloadColumnType(jd.config.GetStringVar(string(TEXT), jd.configKeys("payloadColumnType")...))
+		jd.conf.payloadColumnType = TEXT
 	}
 
 	if jd.stats == nil {

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -775,7 +775,7 @@ func (jd *Handle) init() {
 	}
 
 	if string(jd.conf.payloadColumnType) == "" {
-		jd.conf.payloadColumnType = payloadColumnType(jd.config.GetStringVar(string(JSONB), jd.configKeys("payloadColumnType")...))
+		jd.conf.payloadColumnType = payloadColumnType(jd.config.GetStringVar(string(TEXT), jd.configKeys("payloadColumnType")...))
 	}
 
 	if jd.stats == nil {


### PR DESCRIPTION
# Description

Change jobsdb column type default to text. This change ensures - when not configured new datasets created have a `text` event_payload column. Left the config and related handling for now so that it can phased out at a later point so it leaves some time for jobsdb to compact and cleanup older jsonb column containing datasets.

## Linear Ticket

[Resolves PIPE-2043](https://linear.app/rudderstack/issue/PIPE-2043/jobsdb-update-default-payload-column-type-to-text)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
