### PR TITLE
fix: warehouse jobs skip processing destinations

### DIFF
--- a/warehouse/router/router_test.go
+++ b/warehouse/router/router_test.go
@@ -583,6 +583,7 @@ func TestRouter(t *testing.T) {
 		r.statsFactory = stats.NOP
 		r.conf = config.New()
 		r.config.allowMultipleSourcesForJobsPickup = true
+		r.config.skipDestinationIDs = config.SingleValueLoader([]string{})
 		r.config.stagingFilesBatchSize = config.SingleValueLoader(100)
 		r.config.warehouseSyncFreqIgnore = config.SingleValueLoader(true)
 		r.destType = destinationType
@@ -718,6 +719,7 @@ func TestRouter(t *testing.T) {
 		r.statsFactory = stats.NOP
 		r.conf = config.New()
 		r.config.allowMultipleSourcesForJobsPickup = true
+		r.config.skipDestinationIDs = config.SingleValueLoader([]string{})
 		r.config.stagingFilesBatchSize = config.SingleValueLoader(100)
 		r.config.warehouseSyncFreqIgnore = config.SingleValueLoader(true)
 		r.config.noOfWorkers = config.SingleValueLoader(10)
@@ -869,6 +871,7 @@ func TestRouter(t *testing.T) {
 			r.statsFactory = stats.NOP
 			r.conf = config.New()
 			r.config.allowMultipleSourcesForJobsPickup = true
+			r.config.skipDestinationIDs = config.SingleValueLoader([]string{})
 			r.config.stagingFilesBatchSize = config.SingleValueLoader(100)
 			r.config.warehouseSyncFreqIgnore = config.SingleValueLoader(true)
 			r.config.noOfWorkers = config.SingleValueLoader(0)


### PR DESCRIPTION
# Description

- Additional filters will be added to skip destinations during the pickup of sync jobs. Later, this can be exposed in the UI for customers to pause syncs during scenarios like migrations.
- Corresoponding Slack Thread: https://rudderlabs.slack.com/archives/C02AALVFHJN/p1744730044640719 

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
