### PR TITLE
chore: trim down tracking plan validation payload

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -190,7 +190,6 @@ Processor:
   maxLoopProcessEvents: 10000
   transformBatchSize: 100
   userTransformBatchSize: 200
-  maxConcurrency: 200
   maxHTTPConnections: 100
   maxHTTPIdleConnections: 50
   maxRetry: 30

--- a/processor/internal/transformer/destination_transformer/destination_transformer_test.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer_test.go
@@ -193,7 +193,6 @@ func TestDestinationTransformer(t *testing.T) {
 					statsStore, err := memstats.New()
 					require.NoError(t, err)
 
-					conf.Set("Processor.maxConcurrency", 200)
 					conf.Set("Processor.Transformer.failOnUserTransformTimeout", true)
 					conf.Set("Processor.Transformer.failOnError", true)
 					conf.Set("Processor.Transformer.maxRetryBackoffInterval", 1*time.Second)

--- a/processor/internal/transformer/trackingplan_validation/trackingplan_validation.go
+++ b/processor/internal/transformer/trackingplan_validation/trackingplan_validation.go
@@ -44,8 +44,6 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) 
 	handle.stat = stat
 	handle.client = transformerclient.NewClient(transformerutils.TransformerClientConfig(conf, "TrackingPlanValidation"))
 	handle.config.destTransformationURL = handle.conf.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
-	handle.config.maxConcurrency = conf.GetInt("Processor.maxConcurrency", 200)
-	handle.guardConcurrency = make(chan struct{}, handle.config.maxConcurrency)
 	handle.config.maxRetry = conf.GetReloadableIntVar(30, 1, "Processor.TrackingPlanValidation.maxRetry", "Processor.maxRetry")
 	handle.config.timeoutDuration = conf.GetDuration("HttpClient.procTransformer.timeout", 600, time.Second)
 	handle.config.failOnError = conf.GetReloadableBoolVar(false, "Processor.TrackingPlanValidation.failOnError", "Processor.Transformer.failOnError")
@@ -64,16 +62,14 @@ type Client struct {
 		destTransformationURL   string
 		maxRetry                config.ValueLoader[int]
 		failOnError             config.ValueLoader[bool]
-		maxConcurrency          int
 		maxRetryBackoffInterval config.ValueLoader[time.Duration]
 		timeoutDuration         time.Duration
 		batchSize               config.ValueLoader[int]
 	}
-	conf             *config.Config
-	log              logger.Logger
-	stat             stats.Stats
-	guardConcurrency chan struct{}
-	client           transformerclient.Client
+	conf   *config.Config
+	log    logger.Logger
+	stat   stats.Stats
+	client transformerclient.Client
 }
 
 func (t *Client) Validate(ctx context.Context, clientEvents []types.TransformerEvent) types.Response {
@@ -119,10 +115,8 @@ func (t *Client) Validate(ctx context.Context, clientEvents []types.TransformerE
 	lo.ForEach(
 		batches,
 		func(batch []types.TransformerEvent, i int) {
-			t.guardConcurrency <- struct{}{}
 			go func() {
 				transformResponse[i] = t.sendBatch(ctx, t.trackingPlanValidationURL(), labels, batch)
-				<-t.guardConcurrency
 				wg.Done()
 			}()
 		},
@@ -154,9 +148,11 @@ func (t *Client) Validate(ctx context.Context, clientEvents []types.TransformerE
 	}
 }
 
-func (t *Client) sendBatch(ctx context.Context, url string, labels types.TransformerMetricLabels, data []types.TransformerEvent) []types.TransformerResponse {
-	t.stat.NewTaggedStat("transformer_client_request_total_events", stats.CountType, labels.ToStatsTag()).Count(len(data))
-	// Call remote transformation
+func (t *Client) sendBatch(ctx context.Context, url string, labels types.TransformerMetricLabels, clientEvents []types.TransformerEvent) []types.TransformerResponse {
+	t.stat.NewTaggedStat("transformer_client_request_total_events", stats.CountType, labels.ToStatsTag()).Count(len(clientEvents))
+	data := lo.Map(clientEvents, func(clientEvent types.TransformerEvent, _ int) types.TrackingPlanValidationEvent {
+		return *clientEvent.ToTrackingPlanValidationEvent()
+	})
 	var (
 		rawJSON []byte
 		err     error
@@ -198,9 +194,9 @@ func (t *Client) sendBatch(ctx context.Context, url string, labels types.Transfo
 		endlessBackoff,
 		func(err error, time time.Duration) {
 			var transformationID, transformationVersionID string
-			if len(data[0].Destination.Transformations) > 0 {
-				transformationID = data[0].Destination.Transformations[0].ID
-				transformationVersionID = data[0].Destination.Transformations[0].VersionID
+			if len(clientEvents[0].Destination.Transformations) > 0 {
+				transformationID = clientEvents[0].Destination.Transformations[0].ID
+				transformationVersionID = clientEvents[0].Destination.Transformations[0].VersionID
 			}
 			t.log.Errorn("JS HTTP connection error",
 				obskit.Error(err),

--- a/processor/internal/transformer/trackingplan_validation/trackingplan_validation_test.go
+++ b/processor/internal/transformer/trackingplan_validation/trackingplan_validation_test.go
@@ -174,7 +174,6 @@ func TestTrackingPlanValidator(t *testing.T) {
 					statsStore, err := memstats.New()
 					require.NoError(t, err)
 
-					conf.Set("Processor.maxConcurrency", 200)
 					conf.Set("Processor.Transformer.failOnUserTransformTimeout", true)
 					conf.Set("Processor.Transformer.failOnError", true)
 					conf.Set("Processor.Transformer.maxRetryBackoffInterval", 1*time.Second)

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -181,7 +181,6 @@ func TestUserTransformer(t *testing.T) {
 				for _, tt := range tc {
 					statsStore, err := memstats.New()
 					require.NoError(t, err)
-					conf.Set("Processor.maxConcurrency", 200)
 					conf.Set("Processor.Transformer.failOnUserTransformTimeout", true)
 					conf.Set("Processor.Transformer.failOnError", true)
 					conf.Set("Processor.Transformer.maxRetryBackoffInterval", 1*time.Second)

--- a/processor/types/types.go
+++ b/processor/types/types.go
@@ -57,6 +57,13 @@ type UserTransformerEvent struct {
 	Credentials []Credential             `json:"credentials,omitempty"`
 }
 
+// TrackingPlanValidationEvent is the event sent to the trackingplan transformer,
+// whose fields are a subset of the [TransformerEvent]
+type TrackingPlanValidationEvent struct {
+	Message  SingularEventT `json:"message"`
+	Metadata Metadata       `json:"metadata"`
+}
+
 // CompactedTransformerEvent is similar to a [TransformerEvent] but without the connection and destination fields
 type CompactedTransformerEvent struct {
 	Message     SingularEventT           `json:"message"`
@@ -113,6 +120,15 @@ func (e *TransformerEvent) ToUserTransformerEvent() *UserTransformerEvent {
 		})
 	}
 	return ute
+}
+
+// ToTrackingPlanValidationEvent only keeps the message and metadata fields from the event
+// before sending it to the trackingplan validator thereby reducing the payload size
+func (e *TransformerEvent) ToTrackingPlanValidationEvent() *TrackingPlanValidationEvent {
+	return &TrackingPlanValidationEvent{
+		Message:  e.Message,
+		Metadata: e.Metadata,
+	}
 }
 
 type Credential struct {


### PR DESCRIPTION
# Description

`TrackingPlanValidationEvent` should only include `message` and `metadata`

## Additional items

- Remove `Processor.maxConcurrency` since concurrency can be controlled through `Transformer.Client.maxHTTPConnections`

## Linear Ticket

resolves PIPE-2011

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
