### PR TITLE
chore: enable oauthv2 by default

### DIFF
--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -317,7 +317,7 @@ func (rt *Handle) setupReloadableVars() {
 	rt.reloadableConfig.pickupFlushInterval = config.GetReloadableDurationVar(2, time.Second, "Router.pickupFlushInterval")
 	rt.reloadableConfig.failingJobsPenaltySleep = config.GetReloadableDurationVar(2000, time.Millisecond, "Router.failingJobsPenaltySleep")
 	rt.reloadableConfig.failingJobsPenaltyThreshold = config.GetReloadableFloat64Var(0.6, "Router.failingJobsPenaltyThreshold")
-	rt.reloadableConfig.oauthV2Enabled = config.GetReloadableBoolVar(false, "Router."+rt.destType+".oauthV2Enabled", "Router.oauthV2Enabled")
+	rt.reloadableConfig.oauthV2Enabled = config.GetReloadableBoolVar(true)
 	rt.reloadableConfig.oauthV2ExpirationTimeDiff = config.GetReloadableDurationVar(5, time.Minute, "Router."+rt.destType+".oauth.expirationTimeDiff", "Router.oauth.expirationTimeDiff")
 	rt.diagnosisTickerTime = config.GetDurationVar(60, time.Second, "Diagnostics.routerTimePeriod", "Diagnostics.routerTimePeriodInS")
 	rt.netClientTimeout = config.GetDurationVar(10, time.Second,


### PR DESCRIPTION
# Description

We are enabling OAuth v2 by default in router. 

## Linear Ticket

https://linear.app/rudderstack/issue/INT-3551/clean-up-oauth-v1-module-from-rudder-server

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
