### PR TITLE
fix: warehouse extracting messageid and receivedat

### DIFF
--- a/warehouse/transformer/events.go
+++ b/warehouse/transformer/events.go
@@ -101,7 +101,7 @@ func (t *Transformer) tracksResponse(tec *transformEventContext, commonData map[
 		"metadata": map[string]any{
 			"table":      table,
 			"columns":    columns,
-			"receivedAt": tec.event.Metadata.ReceivedAt,
+			"receivedAt": tec.event.ReceivedAt,
 		},
 		"userId": "",
 	}
@@ -156,7 +156,7 @@ func (t *Transformer) trackEventsResponse(tec *transformEventContext, transforme
 		"metadata": map[string]any{
 			"table":      excludeTable,
 			"columns":    columns,
-			"receivedAt": tec.event.Metadata.ReceivedAt,
+			"receivedAt": tec.event.ReceivedAt,
 		},
 		"userId": "",
 	}
@@ -216,7 +216,7 @@ func (t *Transformer) extractEvents(tec *transformEventContext) ([]map[string]an
 		"metadata": map[string]any{
 			"table":      excludeTableName,
 			"columns":    columns,
-			"receivedAt": tec.event.Metadata.ReceivedAt,
+			"receivedAt": tec.event.ReceivedAt,
 		},
 		"userId": "",
 	}
@@ -328,7 +328,7 @@ func (t *Transformer) identifiesResponse(tec *transformEventContext, commonData 
 		"metadata": map[string]any{
 			"table":      identifiesTable,
 			"columns":    identifiesColumns,
-			"receivedAt": tec.event.Metadata.ReceivedAt,
+			"receivedAt": tec.event.ReceivedAt,
 		},
 		"userId": "",
 	}
@@ -372,7 +372,7 @@ func (t *Transformer) usersResponse(tec *transformEventContext, commonData map[s
 		return nil, fmt.Errorf("users response: safe column name: %w", err)
 	}
 
-	data[receivedAtColName] = convertValIfDateTime(tec.event.Metadata.ReceivedAt, model.DateTimeDataType)
+	data[receivedAtColName] = convertValIfDateTime(tec.event.ReceivedAt, model.DateTimeDataType)
 	metadata[receivedAtColName] = model.DateTimeDataType
 
 	tableName, err := safeTableNameCached(tec, "users")
@@ -389,7 +389,7 @@ func (t *Transformer) usersResponse(tec *transformEventContext, commonData map[s
 		"metadata": map[string]any{
 			"table":      tableName,
 			"columns":    columns,
-			"receivedAt": tec.event.Metadata.ReceivedAt,
+			"receivedAt": tec.event.ReceivedAt,
 		},
 		"userId": "",
 	}
@@ -449,7 +449,7 @@ func (t *Transformer) pageEvents(tec *transformEventContext) ([]map[string]any, 
 		"metadata": map[string]any{
 			"table":      tableName,
 			"columns":    columns,
-			"receivedAt": tec.event.Metadata.ReceivedAt,
+			"receivedAt": tec.event.ReceivedAt,
 		},
 		"userId": "",
 	}
@@ -503,7 +503,7 @@ func (t *Transformer) screenEvents(tec *transformEventContext) ([]map[string]any
 		"metadata": map[string]any{
 			"table":      tableName,
 			"columns":    columns,
-			"receivedAt": tec.event.Metadata.ReceivedAt,
+			"receivedAt": tec.event.ReceivedAt,
 		},
 		"userId": "",
 	}
@@ -557,7 +557,7 @@ func (t *Transformer) groupEvents(tec *transformEventContext) ([]map[string]any,
 		"metadata": map[string]any{
 			"table":      tableName,
 			"columns":    columns,
-			"receivedAt": tec.event.Metadata.ReceivedAt,
+			"receivedAt": tec.event.ReceivedAt,
 		},
 		"userId": "",
 	}
@@ -611,7 +611,7 @@ func (t *Transformer) aliasEvents(tec *transformEventContext) ([]map[string]any,
 		"metadata": map[string]any{
 			"table":      tableName,
 			"columns":    columns,
-			"receivedAt": tec.event.Metadata.ReceivedAt,
+			"receivedAt": tec.event.ReceivedAt,
 		},
 		"userId": "",
 	}

--- a/warehouse/transformer/idresolution.go
+++ b/warehouse/transformer/idresolution.go
@@ -48,7 +48,7 @@ func (t *Transformer) mergeEvents(tec *transformEventContext) ([]map[string]any,
 		"table":        tableName,
 		"columns":      columnTypes,
 		"isMergeRule":  true,
-		"receivedAt":   tec.event.Metadata.ReceivedAt,
+		"receivedAt":   tec.event.ReceivedAt,
 		"mergePropOne": data[columns.Prop1Value],
 	}
 

--- a/warehouse/transformer/internal/rules/rules.go
+++ b/warehouse/transformer/internal/rules/rules.go
@@ -9,22 +9,23 @@ import (
 	"github.com/rudderlabs/rudder-server/processor/types"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/transformer/internal/response"
+	wtypes "github.com/rudderlabs/rudder-server/warehouse/transformer/internal/types"
 	"github.com/rudderlabs/rudder-server/warehouse/transformer/internal/utils"
 )
 
-type Rules func(event *types.TransformerEvent) (any, error)
+type Rules func(event *wtypes.WarehouseTransformerEvent) (any, error)
 
 var (
 	DefaultRules = map[string]Rules{
-		"id":                 messageIDFromMetadata(), // Use metadata, since we are not modifying Message
+		"id":                 messageIDFromEvent(), // Use extracted messageID
 		"anonymous_id":       staticRule("anonymousId"),
 		"user_id":            staticRule("userId"),
 		"sent_at":            staticRule("sentAt"),
 		"timestamp":          staticRule("timestamp"),
-		"received_at":        receivedAtFromMetadata(), // Use metadata, since we are not modifying Message
+		"received_at":        receivedAtFromEvent(), // Use extracted receivedAt
 		"original_timestamp": staticRule("originalTimestamp"),
 		"channel":            staticRule("channel"),
-		"context_ip": func(event *types.TransformerEvent) (any, error) {
+		"context_ip": func(event *wtypes.WarehouseTransformerEvent) (any, error) {
 			return firstValidValue(event.Message, []string{"context.ip", "request_ip"}), nil
 		},
 		"context_request_ip": staticRule("request_ip"),
@@ -35,17 +36,17 @@ var (
 		"event_text": staticRule("event"),
 	}
 	TrackEventTableRules = map[string]Rules{
-		"id": func(event *types.TransformerEvent) (any, error) {
+		"id": func(event *wtypes.WarehouseTransformerEvent) (any, error) {
 			eventType := event.Metadata.EventType
 			canUseRecordID := utils.CanUseRecordID(event.Metadata.SourceCategory)
 			if eventType == "track" && canUseRecordID {
-				return extractCloudRecordID(event.Message, &event.Metadata, event.Metadata.MessageID)
+				return extractCloudRecordID(event.Message, &event.Metadata, event.MessageID) // Use extracted messageID
 			}
-			return event.Metadata.MessageID, nil
+			return event.MessageID, nil // Use extracted messageID
 		},
 	}
 	TrackTableRules = map[string]Rules{
-		"record_id": func(event *types.TransformerEvent) (any, error) {
+		"record_id": func(event *wtypes.WarehouseTransformerEvent) (any, error) {
 			eventType := event.Metadata.EventType
 			canUseRecordID := utils.CanUseRecordID(event.Metadata.SourceCategory)
 			if eventType == "track" && canUseRecordID {
@@ -60,14 +61,14 @@ var (
 	}
 
 	IdentifyRules = map[string]Rules{
-		"context_ip": func(event *types.TransformerEvent) (any, error) {
+		"context_ip": func(event *wtypes.WarehouseTransformerEvent) (any, error) {
 			return firstValidValue(event.Message, []string{"context.ip", "request_ip"}), nil
 		},
 		"context_request_ip": staticRule("request_ip"),
 		"context_passed_ip":  staticRule("context.ip"),
 	}
 	IdentifyRulesNonDataLake = map[string]Rules{
-		"context_ip": func(event *types.TransformerEvent) (any, error) {
+		"context_ip": func(event *wtypes.WarehouseTransformerEvent) (any, error) {
 			return firstValidValue(event.Message, []string{"context.ip", "request_ip"}), nil
 		},
 		"context_request_ip": staticRule("request_ip"),
@@ -78,13 +79,13 @@ var (
 	}
 
 	PageRules = map[string]Rules{
-		"name": func(event *types.TransformerEvent) (any, error) {
+		"name": func(event *wtypes.WarehouseTransformerEvent) (any, error) {
 			return firstValidValue(event.Message, []string{"name", "properties.name"}), nil
 		},
 	}
 
 	ScreenRules = map[string]Rules{
-		"name": func(event *types.TransformerEvent) (any, error) {
+		"name": func(event *wtypes.WarehouseTransformerEvent) (any, error) {
 			return firstValidValue(event.Message, []string{"name", "properties.name"}), nil
 		},
 	}
@@ -98,29 +99,29 @@ var (
 	}
 
 	ExtractRules = map[string]Rules{
-		"id": func(event *types.TransformerEvent) (any, error) {
+		"id": func(event *wtypes.WarehouseTransformerEvent) (any, error) {
 			return extractRecordID(&event.Metadata)
 		},
-		"received_at": receivedAtFromMetadata(), // Use metadata, since we are not modifying Message
+		"received_at": receivedAtFromEvent(), // Use extracted receivedAt
 		"event":       staticRule("event"),
 	}
 )
 
 func staticRule(key string) Rules {
-	return func(event *types.TransformerEvent) (any, error) {
+	return func(event *wtypes.WarehouseTransformerEvent) (any, error) {
 		return misc.MapLookup(event.Message, strings.Split(key, ".")...), nil
 	}
 }
 
-func messageIDFromMetadata() Rules {
-	return func(event *types.TransformerEvent) (any, error) {
-		return event.Metadata.MessageID, nil
+func messageIDFromEvent() Rules {
+	return func(event *wtypes.WarehouseTransformerEvent) (any, error) {
+		return event.MessageID, nil
 	}
 }
 
-func receivedAtFromMetadata() Rules {
-	return func(event *types.TransformerEvent) (any, error) {
-		return event.Metadata.ReceivedAt, nil
+func receivedAtFromEvent() Rules {
+	return func(event *wtypes.WarehouseTransformerEvent) (any, error) {
+		return event.ReceivedAt, nil
 	}
 }
 

--- a/warehouse/transformer/internal/types/types.go
+++ b/warehouse/transformer/internal/types/types.go
@@ -1,0 +1,14 @@
+package types
+
+import (
+	proctypes "github.com/rudderlabs/rudder-server/processor/types"
+)
+
+type WarehouseTransformerEvent struct {
+	*proctypes.TransformerEvent
+
+	// Currently we don't modify anything on things like Message, Metadata present in processor TransformerEvent
+	// If something that needs to be modified in case if it is empty, those fields are present here and set once which can be later used
+	MessageID  any
+	ReceivedAt string
+}

--- a/warehouse/transformer/internal/utils/utils.go
+++ b/warehouse/transformer/internal/utils/utils.go
@@ -201,3 +201,24 @@ func IsJSONPathSupportedAsPartOfConfig(destType string) bool {
 	_, ok := destinationSupportJSONPathAsPartOfConfig[destType]
 	return ok
 }
+
+func ExtractMessageID(event *types.TransformerEvent, uuidGenerator func() string) any {
+	messageID, exists := event.Message["messageId"]
+	if !exists || IsBlank(messageID) {
+		return "auto-" + uuidGenerator()
+	}
+	return messageID
+}
+
+func ExtractReceivedAt(event *types.TransformerEvent, now func() time.Time) string {
+	receivedAt, exists := event.Message["receivedAt"]
+	if !exists || IsBlank(receivedAt) {
+		return now().Format(misc.RFC3339Milli)
+	}
+
+	strReceivedAt, isString := receivedAt.(string)
+	if !isString || !ValidTimestamp(strReceivedAt) {
+		return now().Format(misc.RFC3339Milli)
+	}
+	return strReceivedAt
+}

--- a/warehouse/transformer/types.go
+++ b/warehouse/transformer/types.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 
-	"github.com/rudderlabs/rudder-server/processor/types"
+	wtypes "github.com/rudderlabs/rudder-server/warehouse/transformer/internal/types"
 )
 
 type (
@@ -66,7 +66,7 @@ type (
 	}
 
 	transformEventContext struct {
-		event         *types.TransformerEvent
+		event         *wtypes.WarehouseTransformerEvent
 		intrOpts      *intrOptions
 		destOpts      *destOptions
 		jsonPathsInfo *jsonPathInfo


### PR DESCRIPTION
# Description

- **MessageID** and **receivedAt** in the event and metadata are coming differently. This can happen for several reasons, but the source of truth is the event payload rather than the metadata.
  - For one of the destinations, it was happening because during user transformation (2Q9YiwKH1OEKJrEn6zSe8hibYGt). Customer is trying to override **messageID** in event from properties using `updatedEvent.messageId = event.properties.messageId;` or `properties.meta.id;`
- Sample event.
```
{
  "message": {
    "messageId": 1090524,
    "originalTimestamp": "2025-04-22T10:31:31.388Z",
  },
  "metadata": {
    "messageId": "asdasdas-asdas-dasdas-dsadsaas-asdasdsad",
  }
}
```

## Linear Ticket

- Resolves WAR-526.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
