### PR TITLE
chore(jobsdb): remove jobMinRowsMigrateThres configuration option

### DIFF
--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -584,7 +584,7 @@ func TestJobsDB(t *testing.T) {
 		}
 		prefix := strings.ToLower(rand.String(5))
 		c.Set("JobsDB.jobDoneMigrateThreshold", 0.7)
-		c.Set("JobsDB.jobMinRowsMigrateThreshold", 0.6)
+		c.Set("JobsDB.jobMinRowsLeftMigrateThreshold", 0.41)
 		err := jobDB.Setup(ReadWrite, true, prefix)
 		require.NoError(t, err)
 		defer jobDB.TearDown()
@@ -622,7 +622,7 @@ func TestJobsDB(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// process some jobs
+		// process first 15 jobs
 		for _, job := range jobsResult.Jobs[:15] {
 			status := JobStatusT{
 				JobID:         job.JobID,
@@ -642,20 +642,36 @@ func TestJobsDB(t *testing.T) {
 
 		dsList = getDSList()
 		require.Lenf(t, dsList, 5, "dsList length is not 5, got %+v", dsList)
-		require.Equal(t, prefix+"_jobs_1_1", dsList[0].JobTable)
-		require.Equal(t, prefix+"_jobs_2", dsList[1].JobTable)
-		require.Equal(t, prefix+"_jobs_3", dsList[2].JobTable)
-		require.Equal(t, prefix+"_jobs_4", dsList[3].JobTable)
-		require.Equal(t, prefix+"_jobs_5", dsList[4].JobTable)
+		require.Equal(t, prefix+"_jobs_1_1", dsList[0].JobTable) // 5 jobs
+		require.Equal(t, prefix+"_jobs_2", dsList[1].JobTable)   // 20 jobs
+		require.Equal(t, prefix+"_jobs_3", dsList[2].JobTable)   // 20 jobs
+		require.Equal(t, prefix+"_jobs_4", dsList[3].JobTable)   // 20 jobs
+		require.Equal(t, prefix+"_jobs_5", dsList[4].JobTable)   // 20 jobs
 
-		trigger() // jobs_1_1 will remain as is even though it is now a small table (5 < 10*0.6)
+		// process 1 more job
+		for _, job := range jobsResult.Jobs[15:16] {
+			status := JobStatusT{
+				JobID:         job.JobID,
+				JobState:      "succeeded",
+				AttemptNum:    1,
+				ExecTime:      time.Now(),
+				RetryTime:     time.Now(),
+				ErrorCode:     "202",
+				ErrorResponse: []byte(`{"success":"OK"}`),
+				Parameters:    []byte(`{}`),
+			}
+			err := jobDB.UpdateJobStatus(context.Background(), []*JobStatusT{&status}, []string{customVal}, []ParameterFilterT{})
+			require.NoError(t, err)
+		}
+
+		trigger() // jobs_1_1 will remain as is even though it is now a small table 4/10 = 0.4 < 0.41
 		dsList = getDSList()
 		require.Lenf(t, dsList, 5, "dsList length is not 5, got %+v", dsList)
-		require.Equal(t, prefix+"_jobs_1_1", dsList[0].JobTable)
-		require.Equal(t, prefix+"_jobs_2", dsList[1].JobTable)
-		require.Equal(t, prefix+"_jobs_3", dsList[2].JobTable)
-		require.Equal(t, prefix+"_jobs_4", dsList[3].JobTable)
-		require.Equal(t, prefix+"_jobs_5", dsList[4].JobTable)
+		require.Equal(t, prefix+"_jobs_1_1", dsList[0].JobTable) // 4 jobs
+		require.Equal(t, prefix+"_jobs_2", dsList[1].JobTable)   // 20 jobs
+		require.Equal(t, prefix+"_jobs_3", dsList[2].JobTable)   // 20 jobs
+		require.Equal(t, prefix+"_jobs_4", dsList[3].JobTable)   // 20 jobs
+		require.Equal(t, prefix+"_jobs_5", dsList[4].JobTable)   // 20 jobs
 
 		// process some jobs
 		jobsResult, err = jobDB.GetUnprocessed(context.Background(), GetQueryParams{
@@ -664,7 +680,7 @@ func TestJobsDB(t *testing.T) {
 			ParameterFilters: []ParameterFilterT{},
 		})
 		require.NoError(t, err)
-		for _, job := range jobsResult.Jobs[5:20] {
+		for _, job := range jobsResult.Jobs[4:20] { // process 16 jobs from jobs_2
 			status := JobStatusT{
 				JobID:         job.JobID,
 				JobState:      Succeeded.State,
@@ -682,10 +698,10 @@ func TestJobsDB(t *testing.T) {
 		trigger() // both jobs_1_1 and jobs_2 would be migrated to jobs_2_1
 		dsList = getDSList()
 		require.Lenf(t, dsList, 4, "dsList length is not 4, got %+v", dsList)
-		require.Equal(t, prefix+"_jobs_2_1", dsList[0].JobTable)
-		require.Equal(t, prefix+"_jobs_3", dsList[1].JobTable)
-		require.Equal(t, prefix+"_jobs_4", dsList[2].JobTable)
-		require.Equal(t, prefix+"_jobs_5", dsList[3].JobTable)
+		require.Equal(t, prefix+"_jobs_2_1", dsList[0].JobTable) // 8 jobs
+		require.Equal(t, prefix+"_jobs_3", dsList[1].JobTable)   // 20 jobs
+		require.Equal(t, prefix+"_jobs_4", dsList[2].JobTable)   // 20 jobs
+		require.Equal(t, prefix+"_jobs_5", dsList[3].JobTable)   // 20 jobs
 	})
 
 	t.Run(`migrates only moves non-terminal jobs to a new DS`, func(t *testing.T) {

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -527,8 +527,7 @@ type Handle struct {
 			vacuumFullStatusTableThreshold             config.ValueLoader[int64]
 			vacuumAnalyzeStatusTableThreshold          config.ValueLoader[int64]
 			jobDoneMigrateThres, jobStatusMigrateThres config.ValueLoader[float64]
-			jobMinRowsMigrateThres                     config.ValueLoader[float64]
-			jobMinRowsLeftMigrateThres                 config.ValueLoader[float64]
+			jobMinRowsLeftMigrateThreshold             config.ValueLoader[float64]
 			migrateDSLoopSleepDuration                 config.ValueLoader[time.Duration]
 			migrateDSTimeout                           config.ValueLoader[time.Duration]
 		}
@@ -933,14 +932,10 @@ func (jd *Handle) loadConfig() {
 	jd.conf.migration.jobDoneMigrateThres = jd.config.GetReloadableFloat64Var(0.8, jd.configKeys("jobDoneMigrateThreshold")...)
 	// jobStatusMigrateThres: A DS is migrated if the job_status exceeds this (* no_of_jobs)
 	jd.conf.migration.jobStatusMigrateThres = jd.config.GetReloadableFloat64Var(3, jd.configKeys("jobStatusMigrateThreshold")...)
-	// jobMinRowsMigrateThres: A DS with a low number of total rows should be eligible for migration if the number of total rows are
-	// less than jobMinRowsMigrateThres percent of maxDSSize (e.g. if jobMinRowsMigrateThres is 0.2
-	// then DSs that have less than 20% of maxDSSize total rows are eligible for migration)
-	jd.conf.migration.jobMinRowsMigrateThres = jd.config.GetReloadableFloat64Var(0.2, jd.configKeys("jobMinRowsMigrateThreshold")...)
-	// jobMinRowsMigrateThres: A DS with a low number of pending rows should be eligible for migration if the number of pending rows are
-	// less than jobMinRowsLeftMigrateThres percent of maxDSSize (e.g. if jobMinRowsLeftMigrateThres is 0.5
+	// jobMinRowsLeftMigrateThreshold: A DS with a low number of pending rows should be eligible for migration if the number of pending rows are
+	// less than jobMinRowsLeftMigrateThreshold percent of maxDSSize (e.g. if jobMinRowsLeftMigrateThreshold is 0.5
 	// then DSs that have less than 50% of maxDSSize pending rows are eligible for migration)
-	jd.conf.migration.jobMinRowsLeftMigrateThres = jd.config.GetReloadableFloat64Var(0.4, jd.configKeys("jobMinRowsLeftMigrateThres")...)
+	jd.conf.migration.jobMinRowsLeftMigrateThreshold = jd.config.GetReloadableFloat64Var(0.4, jd.configKeys("jobMinRowsLeftMigrateThreshold")...)
 	// maxMigrateOnce: Maximum number of DSs that are migrated together into one destination
 	jd.conf.migration.maxMigrateOnce = jd.config.GetReloadableIntVar(10, 1, jd.configKeys("maxMigrateOnce")...)
 	// maxMigrateDSProbe: Maximum number of DSs that are checked from left to right if they are eligible for migration

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -657,18 +657,10 @@ func (jd *Handle) checkIfMigrateDS(ds dataSetT) (
 		return true, false, recordsLeft, nil
 	}
 
-	isSmallDS := float64(totalCount) < jd.conf.migration.jobMinRowsMigrateThres.Load()*float64(jd.conf.MaxDSSize.Load())
+	needsPair = float64(recordsLeft) < jd.conf.migration.jobMinRowsLeftMigrateThreshold.Load()*float64(jd.conf.MaxDSSize.Load())
 
-	if float64(delCount)/float64(totalCount) > jd.conf.migration.jobDoneMigrateThres.Load() {
-		return true, isSmallDS, recordsLeft, nil
-	}
-
-	if isSmallDS {
-		return true, true, recordsLeft, nil
-	}
-
-	if float64(recordsLeft) < jd.conf.migration.jobMinRowsLeftMigrateThres.Load()*float64(jd.conf.MaxDSSize.Load()) {
-		return true, true, recordsLeft, nil
+	if needsPair || float64(delCount)/float64(totalCount) >= jd.conf.migration.jobDoneMigrateThres.Load() {
+		return true, needsPair, recordsLeft, nil
 	}
 
 	return false, false, recordsLeft, nil


### PR DESCRIPTION
# Description

- `jobMinRowsLeftMigrateThreshold` is now the only configuration option that controls whether a table is small or not, i.e. the migration logic will expect two small tables to exists for an actual migration to happen (a.k.a ds compaction).
- Including equality check during `jobDoneMigrateThres` comparison, so that it is easier to disable this option by setting it to 1. It is now recommended to turn off `jobDoneMigrateThres`, so that datasets only get migrated whenever a ds compaction is possible. Migrating an incomplete dataset requires time and acquires a lock (stops-the-world), thus if this is to lead to the same number of datasets, it doesn't provide much benefit.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
