### PR TITLE
fix: warehouse transformations mismatches

### DIFF
--- a/warehouse/transformer/datatype.go
+++ b/warehouse/transformer/datatype.go
@@ -1,6 +1,8 @@
 package transformer
 
 import (
+	"unicode/utf8"
+
 	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-server/jsonrs"
@@ -81,11 +83,11 @@ func overrideForRedshift(val any, isJSONKey bool) string {
 func shouldUseTextForRedshift(data any) bool {
 	switch v := data.(type) {
 	case []any, []types.ValidationError, map[string]any:
-		if jsonVal, _ := jsonrs.Marshal(v); len(jsonVal) > redshiftStringLimit {
+		if jsonVal, _ := jsonrs.Marshal(v); utf8.RuneCount(jsonVal) > redshiftStringLimit {
 			return true
 		}
 	case string:
-		if len(v) > redshiftStringLimit {
+		if utf8.RuneCountInString(v) > redshiftStringLimit {
 			return true
 		}
 	}

--- a/warehouse/transformer/datatype_test.go
+++ b/warehouse/transformer/datatype_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 
@@ -21,6 +22,10 @@ func TestDataType(t *testing.T) {
 		}
 		anyMap[strconv.Itoa(i)] = i
 	}
+
+	japaneseProductsJSON := `[{"name_ar":"フルーツックスジュー","name_en":"Furūtsu Mikkusu Jūsu","name_ja":"フルーツミックスジュース","price_incl_vat":7,"quantity":3,"sku":"874593120"},{"name_ar":"チョコレートクロワッサン","name_en":"Chokorēto Kurowassan","name_ja":"チョコトクロワッサン","price_incl_vat":6,"quantity":2,"sku":"990127384"},{"name_ar":"天然水ボトル","name_en":"Tennensui Botoru","name_ja":"天然水ボトル","price_incl_vat":3,"quantity":1,"sku":"663748210"},{"name_ar":"ベーカリーとお菓子","name_en":"Bēkarī to Okashi","name_ja":"ベーカリーとお菓子","price_incl_vat":5,"quantity":4,"sku":"478120935"}]`
+	require.Greater(t, len(japaneseProductsJSON), redshiftStringLimit)
+	require.Less(t, utf8.RuneCountInString(japaneseProductsJSON), redshiftStringLimit)
 
 	testCases := []struct {
 		name, destType, key string
@@ -61,6 +66,7 @@ func TestDataType(t *testing.T) {
 		{"Redshift Text Type", whutils.RS, "someKey", strings.Repeat("a", 600), false, "text"},
 		{"Redshift String Type (nil)", whutils.RS, "someKey", nil, false, "string"},
 		{"Redshift String Type (shortValue)", whutils.RS, "someKey", "shortValue", false, "string"},
+		{"Redshift String Type (Japanese Products JSON)", whutils.RS, "someKey", japaneseProductsJSON, false, "string"},
 
 		{"Empty String Value", whutils.CLICKHOUSE, "someKey", "", false, "string"},
 	}

--- a/warehouse/transformer/events.go
+++ b/warehouse/transformer/events.go
@@ -238,7 +238,7 @@ func (t *Transformer) extractCommonProps(tec *transformEventContext) (map[string
 	}
 
 	eventName, _ = commonData[eventColName].(string)
-	if utils.IsBlank(eventName) {
+	if utils.IsEmptyString(eventName) {
 		return nil, nil, response.ErrExtractEventNameEmpty
 	}
 	return commonData, commonMetadata, nil
@@ -358,7 +358,7 @@ func (t *Transformer) identifiesResponse(tec *transformEventContext, commonData 
 
 func (t *Transformer) usersResponse(tec *transformEventContext, commonData map[string]any, commonMetadata map[string]string) ([]map[string]any, error) {
 	userID := misc.MapLookup(tec.event.Message, "userId")
-	if utils.IsBlank(userID) {
+	if utils.IsEmptyString(userID) {
 		return nil, nil
 	}
 	if shouldSkipUsersTable(tec) {

--- a/warehouse/transformer/events.go
+++ b/warehouse/transformer/events.go
@@ -164,21 +164,9 @@ func (t *Transformer) trackEventsResponse(tec *transformEventContext, transforme
 }
 
 func (t *Transformer) extractEvents(tec *transformEventContext) ([]map[string]any, error) {
-	data := make(map[string]any)
-	metadata := make(map[string]string)
-
-	if err := setDataAndMetadataFromInput(tec, t.eventContext(tec), data, metadata, &prefixInfo{
-		completePrefix: "extract_context_",
-		completeLevel:  2,
-		prefix:         "context_",
-	}); err != nil {
-		return nil, fmt.Errorf("extract: setting data and column types from input: %w", err)
-	}
-	if err := setDataAndMetadataFromInput(tec, tec.event.Message["properties"], data, metadata, &prefixInfo{
-		completePrefix: "extract_properties_",
-		completeLevel:  2,
-	}); err != nil {
-		return nil, fmt.Errorf("extract: setting data and column types from input: %w", err)
+	commonData, commonMetadata, err := t.extractCommonProps(tec)
+	if err != nil {
+		return nil, fmt.Errorf("identifies: common properties: %w", err)
 	}
 
 	eventColName, err := safeColumnNameCached(tec, "event")
@@ -186,20 +174,21 @@ func (t *Transformer) extractEvents(tec *transformEventContext) ([]map[string]an
 		return nil, fmt.Errorf("extract: safe column name: %w", err)
 	}
 
-	eventName, _ := tec.event.Message[eventColName].(string)
-	transformedEventName := transformTableNameCached(tec, eventName)
-	if utils.IsBlank(transformedEventName) {
-		return nil, response.ErrExtractEventNameEmpty
+	extractData := make(map[string]any)
+	extractMetadata := make(map[string]string)
+
+	if err := setDataAndMetadataFromInput(tec, tec.event.Message["properties"], extractData, extractMetadata, &prefixInfo{
+		completePrefix: "extract_properties_",
+		completeLevel:  2,
+	}); err != nil {
+		return nil, fmt.Errorf("extract: setting data and column types from input: %w", err)
 	}
 
-	data[eventColName] = transformedEventName
-	metadata[eventColName] = model.StringDataType
+	data := lo.Assign(extractData, commonData)
+	metadata := lo.Assign(extractMetadata, commonMetadata)
 
-	if err = setDataAndMetadataFromRules(tec, data, metadata, rules.ExtractRules); err != nil {
-		return nil, fmt.Errorf("extract: setting data and column types from rules: %w", err)
-	}
-
-	columnName := transformColumnNameCached(tec, transformedEventName)
+	eventName, _ := data[eventColName].(string)
+	columnName := transformColumnNameCached(tec, eventName)
 	tableName, err := safeTableNameCached(tec, columnName)
 	if err != nil {
 		return nil, fmt.Errorf("extract: safe table name: %w", err)
@@ -221,6 +210,38 @@ func (t *Transformer) extractEvents(tec *transformEventContext) ([]map[string]an
 		"userId": "",
 	}
 	return []map[string]any{extractOutput}, nil
+}
+
+func (t *Transformer) extractCommonProps(tec *transformEventContext) (map[string]any, map[string]string, error) {
+	commonData := make(map[string]any)
+	commonMetadata := make(map[string]string)
+
+	if err := setDataAndMetadataFromInput(tec, t.eventContext(tec), commonData, commonMetadata, &prefixInfo{
+		completePrefix: "extract_context_",
+		completeLevel:  2,
+		prefix:         "context_",
+	}); err != nil {
+		return nil, nil, fmt.Errorf("extract: setting data and column types from input: %w", err)
+	}
+
+	eventColName, err := safeColumnNameCached(tec, "event")
+	if err != nil {
+		return nil, nil, fmt.Errorf("extract: safe column name: %w", err)
+	}
+
+	eventName, _ := tec.event.Message[eventColName].(string)
+	commonData[eventColName] = transformTableNameCached(tec, eventName)
+	commonMetadata[eventColName] = model.StringDataType
+
+	if err = setDataAndMetadataFromRules(tec, commonData, commonMetadata, rules.ExtractRules); err != nil {
+		return nil, nil, fmt.Errorf("extract: setting data and column types from rules: %w", err)
+	}
+
+	eventName, _ = commonData[eventColName].(string)
+	if utils.IsBlank(eventName) {
+		return nil, nil, response.ErrExtractEventNameEmpty
+	}
+	return commonData, commonMetadata, nil
 }
 
 func excludeRudderCreatedTableNames(name string, skipReservedKeywordsEscaping bool) string {

--- a/warehouse/transformer/events_test.go
+++ b/warehouse/transformer/events_test.go
@@ -1019,6 +1019,32 @@ func TestEvents(t *testing.T) {
 					},
 				},
 			},
+			{
+				name:         "identify (Snowflake)",
+				eventPayload: `{"type":"identify","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","request_ip":"5.6.7.8","traits":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getMetadata("identify", "SNOWFLAKE"),
+				destination: getDestination("SNOWFLAKE", map[string]any{
+					"allowUsersContextTraits": true,
+				}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output: identifyDefaultOutput().
+								SetDataField("context_destination_type", "SNOWFLAKE").
+								BuildForSnowflake(),
+							Metadata:   getMetadata("identify", "SNOWFLAKE"),
+							StatusCode: http.StatusOK,
+						},
+						{
+							Output: userDefaultOutput().
+								SetDataField("context_destination_type", "SNOWFLAKE").
+								BuildForSnowflake(),
+							Metadata:   getMetadata("identify", "SNOWFLAKE"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
 
 			{
 				name:         "alias (Postgres)",
@@ -1131,6 +1157,23 @@ func TestEvents(t *testing.T) {
 					},
 				},
 			},
+			{
+				name:         "alias (Snowflake)",
+				eventPayload: `{"type":"alias","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","previousId":"previousId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","request_ip":"5.6.7.8","traits":{"title":"Home | RudderStack","url":"https://www.rudderstack.com"},"context":{"traits":{"email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getMetadata("alias", "SNOWFLAKE"),
+				destination:  getDestination("SNOWFLAKE", map[string]any{}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output: aliasDefaultOutput().
+								SetDataField("context_destination_type", "SNOWFLAKE").
+								BuildForSnowflake(),
+							Metadata:   getMetadata("alias", "SNOWFLAKE"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
 
 			{
 				name:         "extract (Postgres)",
@@ -1230,6 +1273,23 @@ func TestEvents(t *testing.T) {
 								SetDataField("event", "users").
 								SetTableName("_users"),
 							Metadata:   getMetadata("extract", "POSTGRES"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
+			{
+				name:         "extract (Snowflake)",
+				eventPayload: `{"type":"extract","recordId":"recordID","messageId":"messageId","event":"event","receivedAt":"2021-09-01T00:00:00.000Z","properties":{"name":"Home","title":"Home | RudderStack","url":"https://www.rudderstack.com"},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getMetadata("extract", "SNOWFLAKE"),
+				destination:  getDestination("SNOWFLAKE", map[string]any{}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output: extractDefaultOutput().
+								SetDataField("context_destination_type", "SNOWFLAKE").
+								BuildForSnowflake(),
+							Metadata:   getMetadata("extract", "SNOWFLAKE"),
 							StatusCode: http.StatusOK,
 						},
 					},
@@ -1347,6 +1407,23 @@ func TestEvents(t *testing.T) {
 					},
 				},
 			},
+			{
+				name:         "page (Snowflake)",
+				eventPayload: `{"type":"page","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","request_ip":"5.6.7.8","properties":{"name":"Home","title":"Home | RudderStack","url":"https://www.rudderstack.com"},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getMetadata("page", "SNOWFLAKE"),
+				destination:  getDestination("SNOWFLAKE", map[string]any{}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output: pageDefaultOutput().
+								SetDataField("context_destination_type", "SNOWFLAKE").
+								BuildForSnowflake(),
+							Metadata:   getMetadata("page", "SNOWFLAKE"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
 
 			{
 				name:         "screen (Postgres)",
@@ -1454,6 +1531,23 @@ func TestEvents(t *testing.T) {
 						{
 							Output:     screenMergeDefaultOutput(),
 							Metadata:   getMetadata("screen", "BQ"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
+			{
+				name:         "screen (Snowflake)",
+				eventPayload: `{"type":"screen","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","request_ip":"5.6.7.8","properties":{"name":"Main","title":"Home | RudderStack","url":"https://www.rudderstack.com"},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getMetadata("screen", "SNOWFLAKE"),
+				destination:  getDestination("SNOWFLAKE", map[string]any{}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output: screenDefaultOutput().
+								SetDataField("context_destination_type", "SNOWFLAKE").
+								BuildForSnowflake(),
+							Metadata:   getMetadata("screen", "SNOWFLAKE"),
 							StatusCode: http.StatusOK,
 						},
 					},
@@ -1567,6 +1661,23 @@ func TestEvents(t *testing.T) {
 						{
 							Output:     groupMergeDefaultOutput(),
 							Metadata:   getMetadata("group", "BQ"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
+			{
+				name:         "group (Snowflake)",
+				eventPayload: `{"type":"group","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","groupId":"groupId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","request_ip":"5.6.7.8","traits":{"title":"Home | RudderStack","url":"https://www.rudderstack.com"},"context":{"traits":{"email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getMetadata("group", "SNOWFLAKE"),
+				destination:  getDestination("SNOWFLAKE", map[string]any{}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output: groupDefaultOutput().
+								SetDataField("context_destination_type", "SNOWFLAKE").
+								BuildForSnowflake(),
+							Metadata:   getMetadata("group", "SNOWFLAKE"),
 							StatusCode: http.StatusOK,
 						},
 					},
@@ -1855,6 +1966,127 @@ func TestEvents(t *testing.T) {
 				},
 			},
 			{
+				name:         "track (POSTGRES) jsonPaths (escape characters for &, <, and >)",
+				eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"location": {"city":"Palo Alto <p>Ampersand: &;</p> Palo Alto","state":"California","country":"USA","coordinates":{"latitude":37.4419,"longitude":-122.143,"geo":{"altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}},"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getTrackMetadata("POSTGRES", "webhook"),
+				destination: getDestination("POSTGRES", map[string]any{
+					"jsonPaths": "location",
+				}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output:     trackDefaultOutput(),
+							Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+							StatusCode: http.StatusOK,
+						},
+						{
+							Output: trackEventDefaultOutput().
+								SetDataField("location", "{\"city\":\"Palo Alto <p>Ampersand: &;</p> Palo Alto\",\"coordinates\":{\"geo\":{\"accuracy\":5,\"altitude\":30.5,\"details\":{\"accuracyUnits\":\"meters\",\"altitudeUnits\":\"meters\"}},\"latitude\":37.4419,\"longitude\":-122.143},\"country\":\"USA\",\"state\":\"California\"}").
+								SetColumnField("location", "json"),
+							Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
+			{
+				name:         "track (POSTGRES) jsonPaths (nested object level limits to 3 when source category is cloud with escape characters for &, <, and >)",
+				eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2,"location":{"coordinates":{"geo":{"description":"Palo Alto <p>Ampersand: &;</p> Palo Alto","altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}}},"ip":"1.2.3.4"}}`,
+				metadata:     getTrackMetadata("POSTGRES", "cloud"),
+				destination:  getDestination("POSTGRES", map[string]any{}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output: trackDefaultOutput().
+								SetDataField("context_traits_location_coordinates_geo", `{"accuracy":5,"altitude":30.5,"description":"Palo Alto <p>Ampersand: &;</p> Palo Alto","details":{"accuracyUnits":"meters","altitudeUnits":"meters"}}`).
+								SetColumnField("context_traits_location_coordinates_geo", "string"),
+							Metadata:   getTrackMetadata("POSTGRES", "cloud"),
+							StatusCode: http.StatusOK,
+						},
+						{
+							Output: trackEventDefaultOutput().
+								SetDataField("context_traits_location_coordinates_geo", `{"accuracy":5,"altitude":30.5,"description":"Palo Alto <p>Ampersand: &;</p> Palo Alto","details":{"accuracyUnits":"meters","altitudeUnits":"meters"}}`).
+								SetColumnField("context_traits_location_coordinates_geo", "string"),
+							Metadata:   getTrackMetadata("POSTGRES", "cloud"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
+			{
+				name:         "track (POSTGRES) store rudder event with escape characters for &, <, and >",
+				eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. <p>Ampersand: &;</p>. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getTrackMetadata("POSTGRES", "webhook"),
+				destination: getDestination("POSTGRES", map[string]any{
+					"storeFullEvent": true,
+				}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output: trackDefaultOutput().
+								SetDataField("rudder_event", "{\"type\":\"track\",\"anonymousId\":\"anonymousId\",\"channel\":\"web\",\"context\":{\"destinationId\":\"destinationID\",\"destinationType\":\"POSTGRES\",\"ip\":\"1.2.3.4\",\"sourceId\":\"sourceID\",\"sourceType\":\"sourceType\",\"traits\":{\"email\":\"rhedricks@example.com\",\"logins\":2,\"name\":\"Richard Hendricks\"}},\"event\":\"event\",\"messageId\":\"messageId\",\"originalTimestamp\":\"2021-09-01T00:00:00.000Z\",\"properties\":{\"product_id\":\"9578257311\",\"review_id\":\"86ac1cd43\"},\"receivedAt\":\"2021-09-01T00:00:00.000Z\",\"request_ip\":\"5.6.7.8\",\"sentAt\":\"2021-09-01T00:00:00.000Z\",\"timestamp\":\"2021-09-01T00:00:00.000Z\",\"userId\":\"userId\",\"userProperties\":{\"rating\":3,\"review_body\":\"OK for the price. <p>Ampersand: &;</p>. It works but the material feels flimsy.\"}}").
+								SetColumnField("rudder_event", "json"),
+							Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+							StatusCode: http.StatusOK,
+						},
+						{
+							Output: trackEventDefaultOutput().
+								SetDataField("review_body", "OK for the price. <p>Ampersand: &;</p>. It works but the material feels flimsy."),
+							Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
+			{
+				name:         "track (POSTGRES) rules (anonymousId) being an object",
+				eventPayload: `{"type":"track","messageId":"messageId","anonymousId": { "anonymousId": "anon-1234567890abcdef" },"userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getTrackMetadata("POSTGRES", "webhook"),
+				destination:  getDestination("POSTGRES", map[string]any{}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output: trackDefaultOutput().
+								RemoveDataFields("anonymous_id").
+								RemoveColumnFields("anonymous_id"),
+							Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+							StatusCode: http.StatusOK,
+						},
+						{
+							Output: trackEventDefaultOutput().
+								RemoveDataFields("anonymous_id").
+								RemoveColumnFields("anonymous_id"),
+							Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
+			{
+				name:         "track (POSTGRES) rules (anonymousId) being an array",
+				eventPayload: `{"type":"track","messageId":"messageId","anonymousId": [ "anon-1234567890abcdef" ],"userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getTrackMetadata("POSTGRES", "webhook"),
+				destination:  getDestination("POSTGRES", map[string]any{}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output: trackDefaultOutput().
+								RemoveDataFields("anonymous_id").
+								RemoveColumnFields("anonymous_id"),
+							Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+							StatusCode: http.StatusOK,
+						},
+						{
+							Output: trackEventDefaultOutput().
+								RemoveDataFields("anonymous_id").
+								RemoveColumnFields("anonymous_id"),
+							Metadata:   getTrackMetadata("POSTGRES", "webhook"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
+			{
 				name:         "track (POSTGRES) jsonPaths (legacy destOpts for properties)",
 				eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"location": {"city":"Palo Alto","state":"California","country":"USA","coordinates":{"latitude":37.4419,"longitude":-122.143,"geo":{"altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}},"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
 				metadata:     getTrackMetadata("POSTGRES", "webhook"),
@@ -2041,6 +2273,30 @@ func TestEvents(t *testing.T) {
 						{
 							Output:     trackMergeDefaultOutput(),
 							Metadata:   getTrackMetadata("BQ", "webhook"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
+			{
+				name:         "track (Snowflake)",
+				eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getTrackMetadata("SNOWFLAKE", "webhook"),
+				destination:  getDestination("SNOWFLAKE", map[string]any{}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output: trackDefaultOutput().
+								SetDataField("context_destination_type", "SNOWFLAKE").
+								BuildForSnowflake(),
+							Metadata:   getTrackMetadata("SNOWFLAKE", "webhook"),
+							StatusCode: http.StatusOK,
+						},
+						{
+							Output: trackEventDefaultOutput().
+								SetDataField("context_destination_type", "SNOWFLAKE").
+								BuildForSnowflake(),
+							Metadata:   getTrackMetadata("SNOWFLAKE", "webhook"),
 							StatusCode: http.StatusOK,
 						},
 					},

--- a/warehouse/transformer/idresolution.go
+++ b/warehouse/transformer/idresolution.go
@@ -108,7 +108,7 @@ func mergePropsForMergeEventType(message types.SingularEventT) (*mergeRule, *mer
 	mergeProperties1Type := misc.MapLookup(mergePropertiesMap1, "type")
 	mergeProperties1Value := misc.MapLookup(mergePropertiesMap1, "value")
 
-	if utils.IsBlank(mergeProperties0Type) || utils.IsBlank(mergeProperties0Value) || utils.IsBlank(mergeProperties1Type) || utils.IsBlank(mergeProperties1Value) {
+	if utils.IsEmptyString(mergeProperties0Type) || utils.IsEmptyString(mergeProperties0Value) || utils.IsEmptyString(mergeProperties1Type) || utils.IsEmptyString(mergeProperties1Value) {
 		return nil, nil, response.ErrMergePropertyEmpty
 	}
 
@@ -131,7 +131,7 @@ func mergePropsForDefaultEventType(message types.SingularEventT) (*mergeRule, *m
 	userID := misc.MapLookup(message, "userId")
 
 	var mergeProp1, mergeProp2 *mergeRule
-	if utils.IsBlank(anonymousID) {
+	if utils.IsEmptyString(anonymousID) {
 		mergeProp1 = &mergeRule{Type: "user_id", Value: userID}
 	} else {
 		mergeProp1 = &mergeRule{Type: "anonymous_id", Value: anonymousID}
@@ -165,5 +165,5 @@ func mergeRuleColumns(tec *transformEventContext) (*mergeRulesColumns, error) {
 }
 
 func isMergePropEmpty(mergeProp *mergeRule) bool {
-	return mergeProp == nil || utils.IsBlank(mergeProp.Type) || utils.IsBlank(mergeProp.Value)
+	return mergeProp == nil || utils.IsEmptyString(mergeProp.Type) || utils.IsEmptyString(mergeProp.Value)
 }

--- a/warehouse/transformer/internal/response/response.go
+++ b/warehouse/transformer/internal/response/response.go
@@ -28,6 +28,7 @@ var (
 	ErrContextNotMap                = NewTransformerError("context is not a map", http.StatusInternalServerError)
 	ErrExtractEventNameEmpty        = NewTransformerError("cannot create event table with empty event name, event name is missing in the payload", http.StatusInternalServerError)
 	ErrRecordIDObject               = ErrRecordIDEmpty
+	ErrRecordIDArray                = ErrRecordIDEmpty
 )
 
 func NewTransformerError(message string, statusCode int) *TransformerError {

--- a/warehouse/transformer/internal/rules/rules.go
+++ b/warehouse/transformer/internal/rules/rules.go
@@ -144,7 +144,7 @@ func createReservedColumns(rules ...map[string]Rules) map[string]struct{} {
 func firstValidValue(message map[string]any, props []string) any {
 	for _, prop := range props {
 		propKeys := strings.Split(prop, ".")
-		if val := misc.MapLookup(message, propKeys...); !utils.IsBlank(val) {
+		if val := misc.MapLookup(message, propKeys...); !utils.IsEmptyString(val) {
 			return val
 		}
 	}
@@ -152,17 +152,20 @@ func firstValidValue(message map[string]any, props []string) any {
 }
 
 func extractRecordID(metadata *wtypes.Metadata) (any, error) {
-	if utils.IsBlank(metadata.RecordID) {
+	if utils.IsEmptyString(metadata.RecordID) {
 		return nil, response.ErrRecordIDEmpty
 	}
 	if utils.IsObject(metadata.RecordID) {
 		return nil, response.ErrRecordIDObject
 	}
+	if utils.IsArray(metadata.RecordID) {
+		return nil, response.ErrRecordIDArray
+	}
 	return metadata.RecordID, nil
 }
 
 func extractCloudRecordID(message types.SingularEventT, metadata *wtypes.Metadata, fallbackValue any) (any, error) {
-	if sv := misc.MapLookup(message, "context", "sources", "version"); !utils.IsBlank(sv) {
+	if sv := misc.MapLookup(message, "context", "sources", "version"); !utils.IsEmptyString(sv) {
 		return extractRecordID(metadata)
 	}
 	return fallbackValue, nil

--- a/warehouse/transformer/internal/rules/rules_test.go
+++ b/warehouse/transformer/internal/rules/rules_test.go
@@ -45,6 +45,7 @@ func TestExtractRecordID(t *testing.T) {
 		{name: "recordId is empty", metadata: wtypes.Metadata{RecordID: ""}, expectedRecordID: nil, expectedError: response.ErrRecordIDEmpty},
 		{name: "recordId is not empty", metadata: wtypes.Metadata{RecordID: "123"}, expectedRecordID: "123", expectedError: nil},
 		{name: "recordId is an object", metadata: wtypes.Metadata{RecordID: map[string]any{"key": "value"}}, expectedRecordID: nil, expectedError: response.ErrRecordIDObject},
+		{name: "recordId is an array", metadata: wtypes.Metadata{RecordID: []any{"value"}}, expectedRecordID: nil, expectedError: response.ErrRecordIDArray},
 		{name: "recordId is a string", metadata: wtypes.Metadata{RecordID: "123"}, expectedRecordID: "123", expectedError: nil},
 		{name: "recordId is a number", metadata: wtypes.Metadata{RecordID: 123}, expectedRecordID: 123, expectedError: nil},
 	}
@@ -72,6 +73,7 @@ func TestExtractCloudRecordID(t *testing.T) {
 		{name: "recordId is nil", message: types.SingularEventT{"context": map[string]any{"sources": map[string]any{"version": "1.0"}}}, metadata: wtypes.Metadata{}, fallbackValue: "fallback", expectedRecordID: nil, expectedError: response.ErrRecordIDEmpty},
 		{name: "recordId is empty", message: types.SingularEventT{"context": map[string]any{"sources": map[string]any{"version": "1.0"}}}, metadata: wtypes.Metadata{RecordID: ""}, fallbackValue: "fallback", expectedRecordID: nil, expectedError: response.ErrRecordIDEmpty},
 		{name: "recordId is an object", message: types.SingularEventT{"context": map[string]any{"sources": map[string]any{"version": "1.0"}}}, metadata: wtypes.Metadata{RecordID: map[string]any{"key": "value"}}, fallbackValue: "fallback", expectedRecordID: nil, expectedError: response.ErrRecordIDObject},
+		{name: "recordId is an array", message: types.SingularEventT{"context": map[string]any{"sources": map[string]any{"version": "1.0"}}}, metadata: wtypes.Metadata{RecordID: []any{"value"}}, fallbackValue: "fallback", expectedRecordID: nil, expectedError: response.ErrRecordIDArray},
 		{name: "recordId is a string", message: types.SingularEventT{"context": map[string]any{"sources": map[string]any{"version": "1.0"}}}, metadata: wtypes.Metadata{RecordID: "123"}, fallbackValue: "fallback", expectedRecordID: "123", expectedError: nil},
 		{name: "recordId is a number", message: types.SingularEventT{"context": map[string]any{"sources": map[string]any{"version": "1.0"}}}, metadata: wtypes.Metadata{RecordID: 123}, fallbackValue: "fallback", expectedRecordID: 123, expectedError: nil},
 	}

--- a/warehouse/transformer/internal/types/types.go
+++ b/warehouse/transformer/internal/types/types.go
@@ -44,7 +44,7 @@ func New(
 	wEvent.Metadata.DestinationID = event.Metadata.DestinationID
 	wEvent.Metadata.DestinationType = event.Metadata.DestinationType
 	wEvent.Metadata.SourceCategory = event.Metadata.SourceCategory
-	wEvent.Metadata.EventType = event.Metadata.EventType
+	wEvent.Metadata.EventType = utils.ToString(event.Message["type"])
 	wEvent.Metadata.RecordID = event.Metadata.RecordID
 	wEvent.Metadata.DestinationConfig = map[string]any{}
 	for _, key := range destConfigFields {

--- a/warehouse/transformer/internal/types/types.go
+++ b/warehouse/transformer/internal/types/types.go
@@ -17,7 +17,7 @@ type Metadata struct {
 	SourceCategory    string         `json:"sourceCategory"`
 	EventType         string         `json:"eventType,omitempty"`
 	RecordID          interface{}    `json:"recordId,omitempty"`
-	DestinationConfig map[string]any `json:"-"`
+	DestinationConfig map[string]any `json:"destinationConfig"`
 }
 
 type TransformerEvent struct {

--- a/warehouse/transformer/internal/utils/utils.go
+++ b/warehouse/transformer/internal/utils/utils.go
@@ -187,7 +187,9 @@ func IsBlank(value interface{}) bool {
 			return true
 		}
 		if len(v) == 1 {
-			return IsBlank(v[0])
+			if _, isMap := v[0].(map[string]any); !isMap {
+				return IsBlank(v[0])
+			}
 		}
 		return false
 	case []types.ValidationError:

--- a/warehouse/transformer/internal/utils/utils_test.go
+++ b/warehouse/transformer/internal/utils/utils_test.go
@@ -1,16 +1,16 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/araddon/dateparse"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-server/processor/types"
+	"github.com/rudderlabs/rudder-server/utils/misc"
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
@@ -80,9 +80,9 @@ func TestValidTimestamp(t *testing.T) {
 		{name: "Malicious string input should return false", timestamp: "%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216Windows%u2216win%u002ein", expected: false},
 		{name: "Date time ISO 8601", timestamp: "2025-04-02T01:09:03", expected: true},
 		{name: "Date time Millis timezone", timestamp: "2025-04-02 01:09:03.000+0530", expected: true},
-		{name: "Date time Micros Colon timezone", timestamp: "2025-02-22 03:46:41.714247+00:00", expected: true},
-		{name: "Date time ISO millis timezone", timestamp: "2025-04-13T11:24:48.000+1000", expected: true},
-		{name: "Date time Colon timezone", timestamp: "2025-04-18 02:00:00+00:00", expected: true},
+		{name: "Date time Micros Colon timezone", timestamp: "2025-04-02 01:09:03.714247+00:00", expected: true},
+		{name: "Date time ISO millis timezone", timestamp: "2025-04-02T01:09:03.000+1000", expected: true},
+		{name: "Date time Colon timezone", timestamp: "2025-04-02 01:09:03+00:00", expected: true},
 	}
 
 	for _, tc := range testCases {
@@ -94,20 +94,32 @@ func TestValidTimestamp(t *testing.T) {
 
 // BenchmarkValidTimestamp
 // BenchmarkValidTimestamp/old_parser
-// BenchmarkValidTimestamp/old_parser/ValidTimestamp_Valid
-// BenchmarkValidTimestamp/old_parser/ValidTimestamp_Valid-12         	   77277	     16020 ns/op
-// BenchmarkValidTimestamp/old_parser/ValidTimestamp_Invalid
-// BenchmarkValidTimestamp/old_parser/ValidTimestamp_Invalid-12       	 1314688	       903.8 ns/op
-// BenchmarkValidTimestamp/old_parser/ValidTimestamp_Invalid_Big_String
-// BenchmarkValidTimestamp/old_parser/ValidTimestamp_Invalid_Big_String-12         	  294691	      4207 ns/op
+// BenchmarkValidTimestamp/old_parser-12         	    6999	    163017 ns/op
 // BenchmarkValidTimestamp/new_parser
-// BenchmarkValidTimestamp/new_parser/ValidTimestamp_Valid
-// BenchmarkValidTimestamp/new_parser/ValidTimestamp_Valid-12                      	  310105	      3711 ns/op
-// BenchmarkValidTimestamp/new_parser/ValidTimestamp_Invalid
-// BenchmarkValidTimestamp/new_parser/ValidTimestamp_Invalid-12                    	 4276358	       278.7 ns/op
-// BenchmarkValidTimestamp/new_parser/ValidTimestamp_Invalid_Big_String
-// BenchmarkValidTimestamp/new_parser/ValidTimestamp_Invalid_Big_String-12         	  162741	      7419 ns/op
+// BenchmarkValidTimestamp/new_parser-12         	   89427	     13392 ns/op
 func BenchmarkValidTimestamp(b *testing.B) {
+	timeFormats := []string{
+		time.RFC3339Nano,
+		time.DateOnly,
+		misc.RFC3339Milli,
+		time.RFC3339,
+		time.RFC1123Z,
+		time.RFC1123,
+		time.RFC822Z,
+		time.RFC822,
+		time.UnixDate,
+		time.DateTime,
+		time.RubyDate,
+		time.ANSIC,
+		"2006-01-02 15:04:05.999999999 -0700 MST",
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05.000-0700",
+	}
+
 	testDates := []string{
 		"2012/03/19 10:11:59",
 		"2012/03/19 10:11:59.3186369",
@@ -123,88 +135,45 @@ func BenchmarkValidTimestamp(b *testing.B) {
 		"2014-04-26 05:24:37 PM",
 		"2014-04-26",
 	}
-	timeFormats := []string{
-		// ISO 8601ish formats
-		time.RFC3339Nano,
-		time.RFC3339,
-
-		// Unusual formats, prefer formats with timezones
-		time.RFC1123Z,
-		time.RFC1123,
-		time.RFC822Z,
-		time.RFC822,
-		time.UnixDate,
-		time.RubyDate,
-		time.ANSIC,
-
-		// Hilariously, Go doesn't have a const for it's own time layout.
-		// See: https://code.google.com/p/go/issues/detail?id=6587
-		"2006-01-02 15:04:05.999999999 -0700 MST",
-
-		// No timezone information
-		"2006-01-02T15:04:05.999999999",
-		"2006-01-02T15:04:05",
-		"2006-01-02 15:04:05.999999999",
-		"2006-01-02 15:04:05",
+	for i := 0; i < 100; i++ {
+		testDates = append(testDates, strings.Repeat("a", 1000))
+	}
+	for i := 0; i < 100; i++ {
+		testDates = append(testDates, uuid.NewString())
 	}
 
-	oldParser := func(input string) (time.Time, error) {
+	oldValidTimestamp := func(input string) bool {
+		if len(input) > validTimestampFormatsMaxLength {
+			return false
+		}
+		var t time.Time
+		var err error
+
 		for _, format := range timeFormats {
-			t, err := time.Parse(format, input)
+			t, err = time.Parse(format, input)
 			if err == nil {
-				return t, nil
+				break
 			}
 		}
-		return time.Time{}, errors.New("invalid timestamp")
+		return !t.IsZero() && !t.Before(minTimeInMs) && !t.After(maxTimeInMs)
 	}
-	newParser := func(input string) (time.Time, error) {
-		return dateparse.ParseAny(input)
-	}
-
-	var t time.Time
-	var err error
 
 	b.Run("old parser", func(b *testing.B) {
-		b.Run("ValidTimestamp_Valid", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				for _, dateStr := range testDates {
-					t, err = oldParser(dateStr)
-				}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for _, dateStr := range testDates {
+				oldValidTimestamp(dateStr)
 			}
-		})
-		b.Run("ValidTimestamp_Invalid", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				t, err = oldParser("invalid-timestamp")
-			}
-		})
-		b.Run("ValidTimestamp_Invalid Big String", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				t, err = oldParser(strings.Repeat("a", 1000))
-			}
-		})
+		}
 	})
 	b.Run("new parser", func(b *testing.B) {
-		b.Run("ValidTimestamp_Valid", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				for _, dateStr := range testDates {
-					t, err = newParser(dateStr)
-				}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for _, dateStr := range testDates {
+				ValidTimestamp(dateStr)
 			}
-		})
-		b.Run("ValidTimestamp_Invalid", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				t, err = newParser("invalid-timestamp")
-			}
-		})
-		b.Run("ValidTimestamp_Invalid Big String", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				t, err = newParser(strings.Repeat("a", 1000))
-			}
-		})
+		}
 	})
-
-	_ = t
-	_ = err
 }
 
 type Person struct {
@@ -258,7 +227,9 @@ func TestIsBlank(t *testing.T) {
 		{"BoolFalse", false, false},
 		{"BoolTrue", true, false},
 		{"EmptySlice", []any{}, true},
+		{"OneBlankNilSlice", []any{nil}, false},
 		{"NonEmptySlice", []any{1, 2, 3}, false},
+		{"OneBlankMapSlice", []any{map[string]any{}}, false},
 		{"OneBlankStringSlice", []any{""}, true},
 		{"ManyBlankStringSlice", []any{"", "", "", ""}, false},
 		{"NestedOneBlankStringSlice", []any{[]any{[]any{}}}, true},
@@ -275,7 +246,7 @@ func TestIsBlank(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, IsBlank(tc.input))
+			require.Equal(t, tc.expected, IsEmptyString(tc.input))
 		})
 	}
 }
@@ -375,6 +346,18 @@ func TestExtractReceivedAt(t *testing.T) {
 			},
 			expectedTime: "2023-10-20T12:34:56.789Z",
 		},
+		{
+			name: "receivedAt is not a string but present in metadata",
+			event: &types.TransformerEvent{
+				Message: map[string]any{
+					"receivedAt": 12345,
+				},
+				Metadata: types.Metadata{
+					ReceivedAt: "2023-10-19T14:00:00.000Z",
+				},
+			},
+			expectedTime: "2023-10-19T14:00:00.000Z",
+		},
 	}
 
 	for _, tt := range tests {
@@ -382,6 +365,61 @@ func TestExtractReceivedAt(t *testing.T) {
 			require.Equal(t, tt.expectedTime, ExtractReceivedAt(tt.event, func() time.Time {
 				return time.Date(2023, time.October, 20, 12, 34, 56, 789000000, time.UTC)
 			}))
+		})
+	}
+}
+
+func TestMarshalJSON(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    any
+		wantJSON string
+	}
+
+	type S struct {
+		A string `json:"a"`
+		B string `json:"b"`
+	}
+
+	cases := []testCase{
+		{
+			name:     "simple map",
+			input:    map[string]any{"foo": "<bar>", "baz": 123},
+			wantJSON: `{"baz":123,"foo":"<bar>"}`,
+		},
+		{
+			name:     "struct with special chars",
+			input:    S{A: "<hello>", B: "&world;"},
+			wantJSON: `{"a":"<hello>","b":"&world;"}`,
+		},
+		{
+			name:     "slice",
+			input:    []any{"<", ">", "&"},
+			wantJSON: `["<",">","&"]`,
+		},
+		{
+			name:     "nil",
+			input:    nil,
+			wantJSON: "null",
+		},
+		{
+			name:     "number",
+			input:    42,
+			wantJSON: "42",
+		},
+		{
+			name:     "boolean",
+			input:    true,
+			wantJSON: "true",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := MarshalJSON(tc.input)
+			require.NoError(t, err)
+			require.NotNil(t, out)
+			require.Equal(t, tc.wantJSON, string(out))
 		})
 	}
 }

--- a/warehouse/transformer/logger.go
+++ b/warehouse/transformer/logger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
@@ -70,6 +71,12 @@ func (t *Transformer) sampleDiff(eventsToTransform []types.TransformerEvent, pRe
 	for i := range pResponse.Events {
 		diff := cmp.Diff(wResponse.Events[i], pResponse.Events[i])
 		if len(diff) == 0 {
+			continue
+		}
+
+		// JS converts new Date('0001-01-01 00:00').toISOString() to 2001-01-01T00:00:00.000Z
+		// https://www.programiz.com/online-compiler/4SqZcIH5k6Yli
+		if strings.Contains(diff, "\"0001-01-01T00:00:00.000Z\"") {
 			continue
 		}
 		if differedEventsCount == 0 {

--- a/warehouse/transformer/set.go
+++ b/warehouse/transformer/set.go
@@ -32,7 +32,7 @@ func setDataAndMetadataFromInput(
 	}
 	for _, key := range tec.sorter(lo.Keys(inputMap)) {
 		val := inputMap[key]
-		if utils.IsBlank(val) {
+		if utils.IsEmptyString(val) {
 			continue
 		}
 		if isValidJSONPath(tec, key, pi) {
@@ -175,7 +175,7 @@ func setDataAndMetadataFromRules(
 		if err != nil {
 			return fmt.Errorf("applying functional rule: %w", err)
 		}
-		if utils.IsBlank(colVal) || utils.IsObject(colVal) {
+		if utils.IsEmptyString(colVal) || utils.IsObject(colVal) || utils.IsArray(colVal) {
 			continue
 		}
 

--- a/warehouse/transformer/set.go
+++ b/warehouse/transformer/set.go
@@ -7,7 +7,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/tidwall/sjson"
 
-	"github.com/rudderlabs/rudder-server/jsonrs"
 	"github.com/rudderlabs/rudder-server/warehouse/transformer/internal/rules"
 	"github.com/rudderlabs/rudder-server/warehouse/transformer/internal/stringlikeobject"
 	"github.com/rudderlabs/rudder-server/warehouse/transformer/internal/utils"
@@ -114,7 +113,7 @@ func handleValidJSONPath(
 	data map[string]any, metadata map[string]string,
 	pi *prefixInfo,
 ) error {
-	valJSON, err := jsonrs.Marshal(val)
+	valJSON, err := utils.MarshalJSON(val)
 	if err != nil {
 		return fmt.Errorf("marshalling value: %w", err)
 	}
@@ -148,7 +147,7 @@ func processNonNestedObject(
 ) error {
 	finalValue := val
 	if tec.event.Metadata.SourceCategory == "cloud" && pi.level >= 3 && utils.IsObject(val) {
-		jsonData, err := jsonrs.Marshal(val)
+		jsonData, err := utils.MarshalJSON(val)
 		if err != nil {
 			return fmt.Errorf("marshalling value: %w", err)
 		}
@@ -201,7 +200,7 @@ func (t *Transformer) storeRudderEvent(
 		return fmt.Errorf("safe column name: %w", err)
 	}
 
-	eventJSON, err := jsonrs.Marshal(tec.event.Message)
+	eventJSON, err := utils.MarshalJSON(tec.event.Message)
 	if err != nil {
 		return fmt.Errorf("marshalling event: %w", err)
 	}

--- a/warehouse/transformer/testhelper/outputbuilder.go
+++ b/warehouse/transformer/testhelper/outputbuilder.go
@@ -1,5 +1,11 @@
 package testhelper
 
+import (
+	"strings"
+
+	"github.com/samber/lo"
+)
+
 type OutputBuilder map[string]any
 
 func (ob OutputBuilder) SetDataField(key string, value any) OutputBuilder {
@@ -62,6 +68,30 @@ func (ob OutputBuilder) AddRandomEntries(count int, predicate func(index int) (d
 		dataKey, dataValue, columnKey, columnValue := predicate(i)
 		ob.SetDataField(dataKey, dataValue)
 		ob.SetColumnField(columnKey, columnValue)
+	}
+	return ob
+}
+
+func (ob OutputBuilder) BuildForSnowflake() OutputBuilder {
+	dataMap, ok := ob["data"].(map[string]any)
+	if ok {
+		ob["data"] = lo.MapEntries(dataMap, func(key string, value any) (string, any) {
+			return strings.ToUpper(key), value
+		})
+	}
+	metadataMap, ok := ob["metadata"].(map[string]any)
+	if ok {
+		columnsMap, ok := metadataMap["columns"].(map[string]any)
+		if ok {
+			metadataMap["columns"] = lo.MapEntries(columnsMap, func(key string, value any) (string, any) {
+				return strings.ToUpper(key), value
+			})
+		}
+
+		tableName, ok := metadataMap["table"].(string)
+		if ok {
+			metadataMap["table"] = strings.ToUpper(tableName)
+		}
 	}
 	return ob
 }

--- a/warehouse/transformer/transformer_fuzz_test.go
+++ b/warehouse/transformer/transformer_fuzz_test.go
@@ -645,7 +645,7 @@ func sanitizePayload(input string) (string, error) {
 
 	// Checking for valid datetime formats in the payload
 	// JS converts new Date('0001-01-01 00:00').toISOString() to 2001-01-01T00:00:00.000Z
-	// https://www.programiz.com/online-compiler/1P7KHTw0ClE9R
+	// https://www.programiz.com/online-compiler/4SqZcIH5k6Yli
 	dateTimes := reDateTime.FindAllString(sanitized, -1)
 	for _, dateTime := range dateTimes {
 		_, err := dateparse.ParseAny(dateTime, dateparse.PreferMonthFirst(true), dateparse.RetryAmbiguousDateWithSwap(true))

--- a/warehouse/transformer/transformer_test.go
+++ b/warehouse/transformer/transformer_test.go
@@ -211,7 +211,7 @@ func TestTransformer(t *testing.T) {
 		expectedResponse types.Response
 	}{
 		{
-			name:         "Unknown event",
+			name:         "Unknown event type",
 			eventPayload: `{"type":"unknown"}`,
 			metadata:     getMetadata("unknown", "POSTGRES"),
 			destination:  getDestination("POSTGRES", map[string]any{}),
@@ -220,6 +220,36 @@ func TestTransformer(t *testing.T) {
 					{
 						Error:      "Unknown event type: \"unknown\"",
 						Metadata:   getMetadata("unknown", "POSTGRES"),
+						StatusCode: http.StatusBadRequest,
+					},
+				},
+			},
+		},
+		{
+			name:         "Undefined event type",
+			eventPayload: `{}`,
+			metadata:     getMetadata("", "POSTGRES"),
+			destination:  getDestination("POSTGRES", map[string]any{}),
+			expectedResponse: types.Response{
+				FailedEvents: []types.TransformerResponse{
+					{
+						Error:      "No event type: \"\"",
+						Metadata:   getMetadata("", "POSTGRES"),
+						StatusCode: http.StatusBadRequest,
+					},
+				},
+			},
+		},
+		{
+			name:         "Undefined event type but present in metadata",
+			eventPayload: `{}`,
+			metadata:     getMetadata("track", "POSTGRES"),
+			destination:  getDestination("POSTGRES", map[string]any{}),
+			expectedResponse: types.Response{
+				FailedEvents: []types.TransformerResponse{
+					{
+						Error:      "No event type: \"\"",
+						Metadata:   getMetadata("track", "POSTGRES"),
 						StatusCode: http.StatusBadRequest,
 					},
 				},


### PR DESCRIPTION
# Description

- For string length calculation, always use `utf8.RuneCount` instead of `len` function to be compatible with JavaScript.
- Extract event name is coming as empty because rules calculation was being done later to the event name calculation.
- Using receivedAt from metadata if empty in the event.
- Extract recordID to be empty in case of slices.
- For getting event type use event instead of metadata.
- While doing JSON marshalling, handle HTML Unicode characters. By default, during marshalling, SetEscapeHTML is true. During Unmarshalling, the library is already taking care of the unescape. So if we do both Marshalling and UnMarshalling, there would be no effect,t which is why it's working for the Transformer response. But here in the warehouse, the transformer would need to handle it separately.
- Additional datetime formats for 2006-01-02T15:04:05.000-0700, 2006-01-02 15:04:05.000000-07:00, 2006-01-02 15:04:05+00:00. New data formats keep popping up. And it would be difficult to maintain list of supported date time formats. Also, with the current logic of iterating to valid formats and finding the the valid one will become more expensive if the list grows too long. Moving to existing implementation of using `dateparser.Any`.
  ```
  // BenchmarkValidTimestamp
  // BenchmarkValidTimestamp/old_parser
  // BenchmarkValidTimestamp/old_parser-12         	    6999	    163017 ns/op
  // BenchmarkValidTimestamp/new_parser
  // BenchmarkValidTimestamp/new_parser-12         	   89427	     13392 ns/op
  ```
- Modify IsBlank for maps and slice of to be compatible with `_.isEmpty(_.toString(value))`. Corresponding lodash implementation: https://playcode.io/2371369

## Linear Ticket

- Resolves WAR-621, WAR-584, WAR-583, WAR-622, WAR-623, WAR-586, WAR-582, WAR-585.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
