### PR TITLE
chore(batchrouter): limiter cleanup adjust stats and use harmonized config

### DIFF
--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -121,9 +121,8 @@ type Handle struct {
 	encounteredMergeRuleMap   map[string]map[string]bool
 
 	limiter struct {
-		read    kitsync.Limiter
-		process kitsync.Limiter
-		upload  kitsync.Limiter
+		read   kitsync.Limiter
+		upload kitsync.Limiter
 	}
 
 	batchRequestsMetricMu sync.RWMutex

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -139,17 +139,8 @@ func (brt *Handle) Setup(
 			return time.After(limiterStatsPeriod)
 		}),
 	)
-	brt.limiter.process = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "brt_process",
-		getReloadableBatchRouterConfigInt("Limiter.process.limit", brt.destType, 20),
-		stats.Default,
-		kitsync.WithLimiterDynamicPeriod(config.GetDuration("BatchRouter.Limiter.process.dynamicPeriod", 1, time.Second)),
-		kitsync.WithLimiterTags(map[string]string{"destType": brt.destType}),
-		kitsync.WithLimiterStatsTriggerFunc(func() <-chan time.Time {
-			return time.After(limiterStatsPeriod)
-		}),
-	)
 	brt.limiter.upload = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "brt_upload",
-		getReloadableBatchRouterConfigInt("Limiter.upload.limit", brt.destType, 50),
+		getReloadableBatchRouterConfigInt("Limiter.upload.limit", brt.destType, 200),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDuration("BatchRouter.Limiter.upload.dynamicPeriod", 1, time.Second)),
 		kitsync.WithLimiterTags(map[string]string{"destType": brt.destType}),


### PR DESCRIPTION
# Description

- remove `brt_process` limiter which is no longer used after latest changes
- increase `brt_upload` limiter to 200, since we'll be using multiple goroutines per worker now
- rename `batchrouter_partition_worker` limiter to `brt_work` to adhere to existing naming conventions
- use same options in `brt_work` limiter that we are using in other limiters
- rename `batchrouter_partition_worker_add_job_delay` to `brt_partition_worker_add_job_delay` and include `destType` in stats tags

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
