### PR TITLE
feat: enable worker-based kafka client batching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/rudderlabs/bing-ads-go-sdk v0.2.3
 	github.com/rudderlabs/compose-test v0.1.3
-	github.com/rudderlabs/rudder-go-kit v0.49.1-0.20250429065717-edbb5b4fe39c
+	github.com/rudderlabs/rudder-go-kit v0.49.1
 	github.com/rudderlabs/rudder-observability-kit v0.0.4
 	github.com/rudderlabs/rudder-schemas v0.5.5
 	github.com/rudderlabs/rudder-transformer/go v0.0.0-20240910055720-f77d2ab4125a

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/rudderlabs/bing-ads-go-sdk v0.2.3
 	github.com/rudderlabs/compose-test v0.1.3
-	github.com/rudderlabs/rudder-go-kit v0.49.0
+	github.com/rudderlabs/rudder-go-kit v0.49.1-0.20250429065717-edbb5b4fe39c
 	github.com/rudderlabs/rudder-observability-kit v0.0.4
 	github.com/rudderlabs/rudder-schemas v0.5.5
 	github.com/rudderlabs/rudder-transformer/go v0.0.0-20240910055720-f77d2ab4125a

--- a/go.sum
+++ b/go.sum
@@ -1177,8 +1177,8 @@ github.com/rudderlabs/goqu/v10 v10.3.1 h1:rnfX+b4EwBWQ2UQfIGeEW299JBBkK5biEbnf7K
 github.com/rudderlabs/goqu/v10 v10.3.1/go.mod h1:LH2vI5gGHBxEQuESqFyk5ZA2anGINc8o25hbidDWOYw=
 github.com/rudderlabs/parquet-go v0.0.2 h1:ZXRdZdimB0PdJtmxeSSxfI0fDQ3kZjwzBxRi6Ut1J8k=
 github.com/rudderlabs/parquet-go v0.0.2/go.mod h1:g6guum7o8uhj/uNhunnt7bw5Vabu/goI5i21/3fnxWQ=
-github.com/rudderlabs/rudder-go-kit v0.49.0 h1:TtO/CYpV20A00VoNjEeHTYJDt3w6KOMtWBdRKqxJg0k=
-github.com/rudderlabs/rudder-go-kit v0.49.0/go.mod h1:lLPM+p5eeXqzXb01A+1CH54I0OTCVAtXlIFadyWz5DI=
+github.com/rudderlabs/rudder-go-kit v0.49.1-0.20250429065717-edbb5b4fe39c h1:uqjJfHYlY0+X6lPEEIoL8oqJufOV8w0QSNQPINihsOw=
+github.com/rudderlabs/rudder-go-kit v0.49.1-0.20250429065717-edbb5b4fe39c/go.mod h1:LItSoAohWpJcIqBMygddPLx99CH+HsrwZoBoStCo2Kc=
 github.com/rudderlabs/rudder-observability-kit v0.0.4 h1:h9nLoWqiv/nqGOu1dhuVFAHNRkyodR6R3v36bqmavRs=
 github.com/rudderlabs/rudder-observability-kit v0.0.4/go.mod h1:YTsvJmpvh8OLk7c4C+wXiV8NRdcrrdLa8UvIdLoXTho=
 github.com/rudderlabs/rudder-schemas v0.5.5 h1:aIXxyn/PbEMMZBXGbNDTmf/gDDUoSHcF7DJYmHwiIUc=

--- a/go.sum
+++ b/go.sum
@@ -1177,8 +1177,8 @@ github.com/rudderlabs/goqu/v10 v10.3.1 h1:rnfX+b4EwBWQ2UQfIGeEW299JBBkK5biEbnf7K
 github.com/rudderlabs/goqu/v10 v10.3.1/go.mod h1:LH2vI5gGHBxEQuESqFyk5ZA2anGINc8o25hbidDWOYw=
 github.com/rudderlabs/parquet-go v0.0.2 h1:ZXRdZdimB0PdJtmxeSSxfI0fDQ3kZjwzBxRi6Ut1J8k=
 github.com/rudderlabs/parquet-go v0.0.2/go.mod h1:g6guum7o8uhj/uNhunnt7bw5Vabu/goI5i21/3fnxWQ=
-github.com/rudderlabs/rudder-go-kit v0.49.1-0.20250429065717-edbb5b4fe39c h1:uqjJfHYlY0+X6lPEEIoL8oqJufOV8w0QSNQPINihsOw=
-github.com/rudderlabs/rudder-go-kit v0.49.1-0.20250429065717-edbb5b4fe39c/go.mod h1:LItSoAohWpJcIqBMygddPLx99CH+HsrwZoBoStCo2Kc=
+github.com/rudderlabs/rudder-go-kit v0.49.1 h1:9SwwMBKB67Q6GvU/g/o5XhPKFrc4fY2zWejkrGp1W+Y=
+github.com/rudderlabs/rudder-go-kit v0.49.1/go.mod h1:LItSoAohWpJcIqBMygddPLx99CH+HsrwZoBoStCo2Kc=
 github.com/rudderlabs/rudder-observability-kit v0.0.4 h1:h9nLoWqiv/nqGOu1dhuVFAHNRkyodR6R3v36bqmavRs=
 github.com/rudderlabs/rudder-observability-kit v0.0.4/go.mod h1:YTsvJmpvh8OLk7c4C+wXiV8NRdcrrdLa8UvIdLoXTho=
 github.com/rudderlabs/rudder-schemas v0.5.5 h1:aIXxyn/PbEMMZBXGbNDTmf/gDDUoSHcF7DJYmHwiIUc=

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -274,7 +274,6 @@ func NewProducer(destination *backendconfig.DestinationT, o common.Opts) (*Produ
 		}
 	}
 
-	// TODO: once the latest control-plane changes are in production we can safely remove this
 	var sshConfig *client.SSHConfig
 	if destConfig.UseSSH {
 		privateKey, err := getSSHPrivateKey(context.Background(), destination.ID)

--- a/services/streammanager/kafka/kafkamanager.go
+++ b/services/streammanager/kafka/kafkamanager.go
@@ -338,14 +338,10 @@ func NewProducer(destination *backendconfig.DestinationT, o common.Opts) (*Produ
 		return nil, err
 	}
 
-	embedAvroSchemaID := config.GetBool("ROUTER_KAFKA_EMBED_AVRO_SCHEMA_ID_"+strings.ToUpper(destination.ID), false)
-	if !embedAvroSchemaID {
-		embedAvroSchemaID = destConfig.EmbedAvroSchemaID
-	}
 	return &ProducerManager{
 		p:                         p,
 		timeout:                   o.Timeout,
-		embedAvroSchemaID:         embedAvroSchemaID,
+		embedAvroSchemaID:         destConfig.EmbedAvroSchemaID,
 		codecs:                    codecs,
 		enableTransformerBatching: enableTransformerBatching,
 	}, nil

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -1138,56 +1138,6 @@ func TestPublish(t *testing.T) {
 	})
 }
 
-func TestSSHConfig(t *testing.T) {
-	t.Run("not enabled", func(t *testing.T) {
-		c := config.New()
-		conf, err := getSSHConfig("some id", c)
-		require.NoError(t, err)
-		require.Nil(t, conf)
-	})
-
-	t.Run("enabled for another destination", func(t *testing.T) {
-		c := config.New()
-		c.Set("ROUTER_KAFKA_SSH_ENABLED", "dest1,dest3")
-		conf, err := getSSHConfig("dest2", c)
-		require.NoError(t, err)
-		require.Nil(t, conf)
-	})
-
-	t.Run("no private key", func(t *testing.T) {
-		c := config.New()
-		c.Set("ROUTER_KAFKA_SSH_ENABLED", "dest2,dest1,dest5")
-		conf, err := getSSHConfig("dest1", c)
-		require.ErrorContains(t, err, "kafka SSH private key is not set")
-		require.Nil(t, conf)
-	})
-
-	t.Run("no base64 private key", func(t *testing.T) {
-		c := config.New()
-		c.Set("ROUTER_KAFKA_SSH_ENABLED", "dest3,dest1,dest7")
-		c.Set("ROUTER_KAFKA_SSH_PRIVATE_KEY", "not base64 encoded")
-		conf, err := getSSHConfig("dest1", c)
-		require.ErrorContains(t, err, "failed to decode base64 private key")
-		require.Nil(t, conf)
-	})
-
-	t.Run("ok", func(t *testing.T) {
-		c := config.New()
-		c.Set("ROUTER_KAFKA_SSH_ENABLED", "dest0,dest1,dest6")
-		c.Set("ROUTER_KAFKA_SSH_PRIVATE_KEY", "a2V5IGNvbnRlbnQ=")
-		c.Set("ROUTER_KAFKA_SSH_USER", "some-user")
-		c.Set("ROUTER_KAFKA_SSH_HOST", "1.2.3.4:22")
-		c.Set("ROUTER_KAFKA_SSH_ACCEPT_ANY_HOST_KEY", "true")
-		conf, err := getSSHConfig("dest1", c)
-		require.NoError(t, err)
-		require.Equal(t, &client.SSHConfig{
-			User:       "some-user",
-			Host:       "1.2.3.4:22",
-			PrivateKey: "key content",
-		}, conf)
-	})
-}
-
 func TestAvroSchemaRegistry(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)

--- a/services/streammanager/kafka/kafkamanager_test.go
+++ b/services/streammanager/kafka/kafkamanager_test.go
@@ -282,8 +282,8 @@ func TestNewProducer(t *testing.T) {
 
 func TestIntegration(t *testing.T) {
 	t.Run("batch", func(t *testing.T) {
-		kafkaBatchingEnabled = true
-		t.Cleanup(func() { kafkaBatchingEnabled = false })
+		config.Default.Set("Router.KAFKA.enableBatching", true)
+		t.Cleanup(func() { config.Default.Set("Router.KAFKA.enableBatching", false) })
 		ctrl := gomock.NewController(t)
 		kafkaStats.creationTime = getMockedTimer(t, ctrl, true)
 		kafkaStats.produceTime = getMockedTimer(t, ctrl, true)
@@ -354,11 +354,11 @@ func TestIntegration(t *testing.T) {
 }
 
 func TestAIOKafka(t *testing.T) {
-	kafkaBatchingEnabled = true
-	kafkaCompression = client.CompressionZstd
+	config.Default.Set("Router.KAFKA.enableBatching", true)
+	config.Default.Set("Router.KAFKA.compression", int(client.CompressionZstd))
 	t.Cleanup(func() {
-		kafkaBatchingEnabled = false
-		kafkaCompression = client.CompressionNone
+		config.Default.Set("Router.KAFKA.enableBatching", false)
+		config.Default.Set("Router.KAFKA.compression", int(client.CompressionNone))
 	})
 	ctrl := gomock.NewController(t)
 	kafkaStats.creationTime = getMockedTimer(t, ctrl, true)


### PR DESCRIPTION
# Description

Instead of enabling kafka client batching only whenever transformer-based batching is enabled, we are turning it on by default and using worker-based batching instead (multiple workers in same router using the same client which sends events in batches). This can achieve significantly higher throughput than transformer-based batching.

- We are using by default a batch size equal to the number of workers along with a batching timeout of `100ms`.
- We are using destination type-specific configuration for overriding kafka client parameters, different for `KAFKA`, `CONFLUENT_CLOUD` & `AZURE_EVENT_HUB`.
- Wherever transformer-based batching is enabled, we are falling back to the previous default configuration parameters (batch size: 100 & batch timeout: 1s)
- We are increasing default read & write timeouts from `2s` to `10s`.

## Additional cleanup

- removing logic for handling environment-based ssh configuration for kafka
- removing logic for handling environment-based avro embedding

## Linear Ticket

resolves PIPE-2051

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
