### PR TITLE
feat: support new consent resolution strategy values

### DIFF
--- a/processor/consent.go
+++ b/processor/consent.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/samber/lo"
@@ -261,7 +262,9 @@ func getConsentManagementInfo(event types.SingularEventT) (ConsentManagementInfo
 			consentManagementInfo.AllowedConsentIDs = val
 		case map[string]interface{}:
 			// Use keys from the map (legacy OneTrust format)
+			// Also, sort the keys
 			consentManagementInfo.AllowedConsentIDs = lo.Keys(val)
+			sort.Strings(consentManagementInfo.AllowedConsentIDs)
 		default:
 			consentManagementInfo.AllowedConsentIDs = []string{}
 		}

--- a/processor/consent.go
+++ b/processor/consent.go
@@ -262,7 +262,8 @@ func getConsentManagementInfo(event types.SingularEventT) (ConsentManagementInfo
 			consentManagementInfo.AllowedConsentIDs = val
 		case map[string]interface{}:
 			// Use keys from the map (legacy OneTrust format)
-			// Also, sort the keys
+			// Also, sort the keys as the unmarshalling of map is not deterministic of the order of keys
+			// and it can cause flaky tests.
 			consentManagementInfo.AllowedConsentIDs = lo.Keys(val)
 			sort.Strings(consentManagementInfo.AllowedConsentIDs)
 		default:

--- a/processor/consent.go
+++ b/processor/consent.go
@@ -73,7 +73,7 @@ func (proc *Handle) getConsentFilteredDestinations(event types.SingularEventT, s
 			// Once we realize no SDKs are sending the data in this format, we have to update the config backend
 			// and also remove this stat.
 			if finalResolutionStrategy == "or" || finalResolutionStrategy == "and" {
-				proc.statsFactory.NewTaggedStat("processor_legacy_consent_resolution_strategy_events_count", stats.CountType, stats.Tags{"sourceId": sourceID}).Count(1)
+				proc.statsFactory.NewTaggedStat("processor_legacy_consent_resolution_strategy_events_count", stats.CountType, stats.Tags{"source_id": sourceID, "resolution_strategy": finalResolutionStrategy}).Count(1)
 			}
 
 			// For custom provider, the resolution strategy is to be picked from the destination config

--- a/processor/consent_test.go
+++ b/processor/consent_test.go
@@ -2517,7 +2517,7 @@ func TestGetConsentManagementInfo(t *testing.T) {
 							"consent category 2",
 						},
 						"deniedConsentIds": []string{
-							"consent category 3",
+							"   consent category 3   ",
 							"",
 							"consent category 4",
 							"",
@@ -2552,9 +2552,9 @@ func TestGetConsentManagementInfo(t *testing.T) {
 				"context": map[string]interface{}{
 					"consentManagement": map[string]interface{}{
 						"deniedConsentIds": []string{
-							"consent category 3",
-							"",
-							"consent category 4",
+							"consent category 3 ",
+							"   ",
+							" consent category 4",
 							"",
 						},
 					},
@@ -2563,6 +2563,43 @@ func TestGetConsentManagementInfo(t *testing.T) {
 			expected: ConsentManagementInfo{
 				Provider:          "",
 				AllowedConsentIDs: []string{},
+				DeniedConsentIDs: []string{
+					"consent category 3",
+					"consent category 4",
+				},
+				ResolutionStrategy: "",
+			},
+		},
+		{
+			description: "should return consent management info when consent management data is sent from older SDKs with allowed consent IDs as an object",
+			input: types.SingularEventT{
+				"anonymousId": "123",
+				"type":        "track",
+				"event":       "test",
+				"properties": map[string]interface{}{
+					"category": "test",
+				},
+				"context": map[string]interface{}{
+					"consentManagement": map[string]interface{}{
+						"allowedConsentIds": map[string]interface{}{
+							"C0": "consent category 1",
+							"C1": "consent category 2",
+						},
+						"deniedConsentIds": []string{
+							"consent category 3 ",
+							"   ",
+							" consent category 4",
+							"",
+						},
+					},
+				},
+			},
+			expected: ConsentManagementInfo{
+				Provider: "",
+				AllowedConsentIDs: []string{
+					"C0",
+					"C1",
+				},
 				DeniedConsentIDs: []string{
 					"consent category 3",
 					"consent category 4",

--- a/processor/consent_test.go
+++ b/processor/consent_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/processor/types"
 )
@@ -2345,6 +2346,7 @@ func TestFilterDestinations(t *testing.T) {
 			proc.config.ketchConsentCategoriesMap = make(map[string][]string)
 			proc.config.genericConsentManagementMap = make(SourceConsentMap)
 			proc.logger = logger.NewLogger().Child("processor")
+			proc.statsFactory = stats.Default
 
 			for _, connection := range tc.connectionInfo {
 				proc.config.genericConsentManagementMap[SourceID(connection.sourceId)] = make(DestConsentMap)

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -3653,7 +3653,7 @@ var _ = Describe("Processor", Ordered, func() {
 						"destination-definition-name-enabled",
 					),
 				)),
-			).To(Equal(8)) // all except D13
+			).To(Equal(6)) // all except D6, D13, and D14
 
 			Expect(processor.isDestinationAvailable(eventWithDeniedConsentsGCM, SourceIDGCM, "")).To(BeTrue())
 			Expect(

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -3665,7 +3665,7 @@ var _ = Describe("Processor", Ordered, func() {
 						"destination-definition-name-enabled",
 					),
 				)),
-			).To(Equal(7)) // all except D6 and D7
+			).To(Equal(6)) // all except D6 and D7
 
 			Expect(processor.isDestinationAvailable(eventWithDeniedConsentsGCMKetch, SourceIDGCM, "")).To(BeTrue())
 			Expect(

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -3677,7 +3677,7 @@ var _ = Describe("Processor", Ordered, func() {
 						"destination-definition-name-enabled",
 					),
 				)),
-			).To(Equal(8)) // all except D7
+			).To(Equal(6)) // all except D7
 
 			// some unknown destination ID is passed destination will be unavailable
 			Expect(processor.isDestinationAvailable(eventWithDeniedConsentsGCMKetch, SourceIDGCM, "unknown-destination")).To(BeFalse())


### PR DESCRIPTION
# Description

Besides, "and" and "or" consent resolution strategies, we're now supporting the new "all" and "any" values. The UI changes will be rolled out very soon.

Also, the logic now prefers to use "allowed consent IDs" and falls back to "denied consent IDs" to align with the client side implementation. It's a bit tricky with allowed consent IDs as some older SDK versions send it as an object for OneTrust CMP.
So, we're handling both an object and array of strings.

Additionally, I've sanitized the consent IDs from the config and event before resolving them for filtering events to destinations.


## Linear Ticket

https://linear.app/rudderstack/view/scrum-board-75b83c60706a5

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
