### PR TITLE
fix: warehouse cached schema mismatch

### DIFF
--- a/warehouse/internal/repo/schema.go
+++ b/warehouse/internal/repo/schema.go
@@ -53,6 +53,31 @@ func (sh *WHSchema) Insert(ctx context.Context, whSchema *model.WHSchema) (int64
 		return id, fmt.Errorf("marshaling schema: %w", err)
 	}
 
+	// update all schemas with the same destination_id and namespace but different source_id
+	// this is to ensure all the connections for a destination have the same schema copy
+	_, err = sh.db.ExecContext(ctx, `
+		UPDATE `+whSchemaTableName+`
+		SET
+			schema = $1,
+			updated_at = $2,
+			expires_at = $3
+		WHERE
+			destination_id = $4 AND
+			namespace = $5 AND
+			source_id != $6;
+`,
+		schemaPayload,
+		now.UTC(),
+		whSchema.ExpiresAt,
+		whSchema.DestinationID,
+		whSchema.Namespace,
+		whSchema.SourceID,
+	)
+	if err != nil {
+		return id, fmt.Errorf("updating related schemas: %w", err)
+	}
+
+	// Then, insert/update the new schema using the unique constraint
 	err = sh.db.QueryRowContext(ctx, `
 		INSERT INTO `+whSchemaTableName+` (
           source_id, namespace, destination_id,
@@ -60,14 +85,16 @@ func (sh *WHSchema) Insert(ctx context.Context, whSchema *model.WHSchema) (int64
 		  updated_at, expires_at
 		)
 		VALUES
-		  ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT (
+		  ($1, $2, $3, $4, $5, $6, $7, $8) 
+		ON CONFLICT (
 			source_id, destination_id, namespace
-		  ) DO
+		) DO
 		UPDATE
 		SET
 		  schema = $5,
 		  updated_at = $7,
-		  expires_at = $8 RETURNING id;
+		  expires_at = $8 
+		RETURNING id;
 `,
 		whSchema.SourceID,
 		whSchema.Namespace,

--- a/warehouse/internal/repo/schema.go
+++ b/warehouse/internal/repo/schema.go
@@ -79,7 +79,7 @@ func (sh *WHSchema) Insert(ctx context.Context, whSchema *model.WHSchema) (int64
 		whSchema.SourceID,
 	)
 	if err != nil {
-		tx.Rollback()
+		_ = tx.Rollback()
 		return id, fmt.Errorf("updating related schemas: %w", err)
 	}
 
@@ -112,7 +112,7 @@ func (sh *WHSchema) Insert(ctx context.Context, whSchema *model.WHSchema) (int64
 		whSchema.ExpiresAt,
 	).Scan(&id)
 	if err != nil {
-		tx.Rollback()
+		_ = tx.Rollback()
 		return id, fmt.Errorf("inserting schema: %w", err)
 	}
 


### PR DESCRIPTION
# Description

Issue - In case of updates to a connection (source_1,destination_1, namespace_1), schema belonging to (source_2, destinaton_1, n1) is not valid. 

Fix -  In case of schema change, for one connection identified by three identifiers (sourceId, destinationId, namespace), we want to update the schema belonging to other connections involving same (destinationId, namespace) pair. 


## Linear Ticket
Part of WAR-606

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
