### PR TITLE
fix: add check for nil secret on oauthv2

### DIFF
--- a/services/oauth/v2/oauth.go
+++ b/services/oauth/v2/oauth.go
@@ -356,6 +356,10 @@ func (h *OAuthHandler) GetRefreshTokenErrResp(response string, accountSecret *Ac
 	return errorType, message
 }
 
+func isEmptySecret(accountSecret AccountSecret) bool {
+	return accountSecret.Secret == nil || string(accountSecret.Secret) == `{}` || string(accountSecret.Secret) == "\"\"" || string(accountSecret.Secret) == "null"
+}
+
 // This method hits the Control Plane to get the account information
 // As well update the account information into the destAuthInfoMap(which acts as an in-memory cache)
 func (h *OAuthHandler) fetchAccountInfoFromCp(refTokenParams *RefreshTokenParams, refTokenBody RefreshTokenBodyParams,
@@ -430,7 +434,7 @@ func (h *OAuthHandler) fetchAccountInfoFromCp(refTokenParams *RefreshTokenParams
 		return http.StatusInternalServerError, authResponse, fmt.Errorf("error occurred while fetching/refreshing account info from CP: %s", refErrMsg)
 	}
 
-	if accountSecret.Secret == nil {
+	if isEmptySecret(accountSecret) {
 		errMsg := errors.New("empty secret received from CP")
 		statsHandler.Increment("request", stats.Tags{
 			"errorMessage":  errMsg.Error(),

--- a/services/oauth/v2/oauth.go
+++ b/services/oauth/v2/oauth.go
@@ -429,6 +429,15 @@ func (h *OAuthHandler) fetchAccountInfoFromCp(refTokenParams *RefreshTokenParams
 		}
 		return http.StatusInternalServerError, authResponse, fmt.Errorf("error occurred while fetching/refreshing account info from CP: %s", refErrMsg)
 	}
+
+	if accountSecret.Secret == nil {
+		errMsg := errors.New("empty secret received from CP")
+		statsHandler.Increment("request", stats.Tags{
+			"errorMessage":  errMsg.Error(),
+			"isCallToCpApi": "true",
+		})
+		return http.StatusInternalServerError, nil, errMsg
+	}
 	statsHandler.Increment("request", stats.Tags{
 		"errorMessage":  "",
 		"isCallToCpApi": "true",


### PR DESCRIPTION
# Description

We are adding validation for a nil secret being stored in the cache, for OAuthV2. 

## Linear Ticket

https://linear.app/rudderstack/issue/INT-3599/fix-add-validation-for-nil-secret-being-stored-in-cache-for-oauthv2

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
