### PR TITLE
feat: support claim renewal in notifier jobs

### DIFF
--- a/services/notifier/notifier.go
+++ b/services/notifier/notifier.go
@@ -100,6 +100,7 @@ type notifierRepo interface {
 	claim(context.Context, string) (*Job, error)
 	onClaimFailed(context.Context, *Job, error, int) error
 	onClaimSuccess(context.Context, *Job, json.RawMessage) error
+	refreshClaim(context.Context, int64) error
 }
 
 type Notifier struct {
@@ -615,4 +616,8 @@ func (n *Notifier) Shutdown() error {
 
 	n.background.groupCancel()
 	return n.background.group.Wait()
+}
+
+func (n *Notifier) RefreshClaim(ctx context.Context, jobId int64) error {
+	return n.repo.refreshClaim(ctx, jobId)
 }

--- a/services/notifier/repo.go
+++ b/services/notifier/repo.go
@@ -485,3 +485,23 @@ func (n *repo) orphanJobIDs(
 
 	return ids, nil
 }
+
+func (n *repo) refreshClaim(ctx context.Context, jobId int64) error {
+	_, err := n.db.ExecContext(ctx, `
+		UPDATE
+		  `+notifierTableName+`
+		SET
+		  last_exec_time = $1
+		WHERE
+		  id = $2
+		  AND status = $3;
+	`,
+		n.now(),
+		jobId,
+		Executing,
+	)
+	if err != nil {
+		return fmt.Errorf("refreshing claim: %w", err)
+	}
+	return nil
+}

--- a/warehouse/slave/slave.go
+++ b/warehouse/slave/slave.go
@@ -24,6 +24,7 @@ type slaveNotifier interface {
 	Subscribe(ctx context.Context, workerId string, jobsBufferSize int) <-chan *notifier.ClaimJob
 	RunMaintenance(ctx context.Context) error
 	UpdateClaim(ctx context.Context, job *notifier.ClaimJob, response *notifier.ClaimJobResponse)
+	RefreshClaim(ctx context.Context, jobId int64) error
 }
 
 type Slave struct {

--- a/warehouse/slave/slave_test.go
+++ b/warehouse/slave/slave_test.go
@@ -32,6 +32,7 @@ type mockSlaveNotifier struct {
 	subscribeCh    chan *notifier.ClaimJobResponse
 	publishCh      chan *notifier.ClaimJob
 	maintenanceErr error
+	refreshClaim   func(ctx context.Context, jobId int64) error
 }
 
 func (m *mockSlaveNotifier) Subscribe(context.Context, string, int) <-chan *notifier.ClaimJob {
@@ -44,6 +45,13 @@ func (m *mockSlaveNotifier) UpdateClaim(_ context.Context, _ *notifier.ClaimJob,
 
 func (m *mockSlaveNotifier) RunMaintenance(context.Context) error {
 	return m.maintenanceErr
+}
+
+func (m *mockSlaveNotifier) RefreshClaim(ctx context.Context, jobId int64) error {
+	if m.refreshClaim != nil {
+		return m.refreshClaim(ctx, jobId)
+	}
+	return nil
 }
 
 func TestSlave(t *testing.T) {

--- a/warehouse/slave/worker.go
+++ b/warehouse/slave/worker.go
@@ -164,12 +164,6 @@ func (w *worker) start(ctx context.Context, notificationChan <-chan *notifier.Cl
 			// Clear active job ID after processing
 			w.activeJobId = 0
 
-			w.log.Infof("Successfully processed job:%d by slave worker-%d-%s",
-				claimedJob.Job.ID,
-				w.workerIdx,
-				slaveID,
-			)
-
 			workerIdleTimeStart = time.Now()
 		}
 	}

--- a/warehouse/slave/worker.go
+++ b/warehouse/slave/worker.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"reflect"
 	"strconv"
 	"time"
@@ -59,10 +60,14 @@ type worker struct {
 	constraintsManager *constraints.Manager
 	encodingFactory    *encoding.Factory
 	workerIdx          int
+	activeJobId        int64
+	refreshClaimJitter time.Duration
 
 	config struct {
 		maxStagingFileReadBufferCapacityInK config.ValueLoader[int]
 		maxConcurrentStagingFiles           config.ValueLoader[int]
+		claimRefreshInterval                config.ValueLoader[time.Duration]
+		enableNotifierHeartbeat             config.ValueLoader[bool]
 	}
 	stats struct {
 		workerIdleTime                 stats.Measurement
@@ -96,6 +101,8 @@ func newWorker(
 	s.config.maxStagingFileReadBufferCapacityInK = s.conf.GetReloadableIntVar(10240, 1, "Warehouse.maxStagingFileReadBufferCapacityInK")
 	// Increasing maxConcurrentStagingFiles config would also require increasing the memory requests for the slave pods
 	s.config.maxConcurrentStagingFiles = s.conf.GetReloadableIntVar(10, 1, "Warehouse.maxStagingFilesInUploadV2Job")
+	s.config.claimRefreshInterval = s.conf.GetReloadableDurationVar(30, time.Second, "Warehouse.claimRefreshIntervalInS")
+	s.config.enableNotifierHeartbeat = s.conf.GetReloadableBoolVar(false, "Warehouse.enableNotifierHeartbeat")
 
 	tags := stats.Tags{
 		"module":   "warehouse",
@@ -105,11 +112,18 @@ func newWorker(
 	s.stats.workerClaimProcessingTime = s.statsFactory.NewTaggedStat("worker_claim_processing_time", stats.TimerType, tags)
 	s.stats.workerClaimProcessingSucceeded = s.statsFactory.NewTaggedStat("worker_claim_processing_succeeded", stats.CountType, tags)
 	s.stats.workerClaimProcessingFailed = s.statsFactory.NewTaggedStat("worker_claim_processing_failed", stats.CountType, tags)
+	s.refreshClaimJitter = time.Duration(rand.Int63n(5)) * time.Second // Random jitter between [0-5) seconds
 	return s
 }
 
 func (w *worker) start(ctx context.Context, notificationChan <-chan *notifier.ClaimJob, slaveID string) {
 	workerIdleTimeStart := time.Now()
+
+	if w.config.enableNotifierHeartbeat.Load() {
+		refreshCtx, refreshCancel := context.WithCancel(ctx)
+		defer refreshCancel()
+		go w.runClaimRefresh(refreshCtx)
+	}
 
 	for {
 		select {
@@ -132,6 +146,9 @@ func (w *worker) start(ctx context.Context, notificationChan <-chan *notifier.Cl
 				logger.NewField("jobType", claimedJob.Job.Type),
 			)
 
+			// Set active job ID
+			w.activeJobId = claimedJob.Job.ID
+
 			switch claimedJob.Job.Type {
 			case notifier.JobTypeAsync:
 				w.processClaimedSourceJob(ctx, claimedJob)
@@ -144,8 +161,38 @@ func (w *worker) start(ctx context.Context, notificationChan <-chan *notifier.Cl
 				logger.NewField("workerIdx", w.workerIdx),
 				logger.NewField("slaveId", slaveID),
 			)
+			// Clear active job ID after processing
+			w.activeJobId = 0
+
+			w.log.Infof("Successfully processed job:%d by slave worker-%d-%s",
+				claimedJob.Job.ID,
+				w.workerIdx,
+				slaveID,
+			)
 
 			workerIdleTimeStart = time.Now()
+		}
+	}
+}
+
+// run claimRefresh periodically to make sure that job is not orphaned
+func (w *worker) runClaimRefresh(ctx context.Context) {
+	baseInterval := w.config.claimRefreshInterval.Load()
+	// Distribute claim refresh requests across workers by adding random delay
+	// This will prevent database load spikes from synchronized refresh attempts
+	ticker := time.NewTicker(baseInterval + w.refreshClaimJitter)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if w.activeJobId != 0 {
+				if err := w.notifier.RefreshClaim(ctx, w.activeJobId); err != nil {
+					w.log.Errorf("Failed to refresh claim for job %d: %v", w.activeJobId, err)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Description

**Notifier**

- Add a new method to the slaveNotifier interface: `RefreshClaim(ctx context.Context, jobId int64) error`
- This method updates the `last_exec_time` column to NOW() for the specified job ID.

**Slave**

- Extend the worker struct to include a new field: `activeJobId int64`
- When a worker picks up a notifier job, it sets `activeJobId` to the corresponding job ID. This value is cleared once the job processing completes.
- A background goroutine is being launched within each worker that periodically invokes `RefreshClaim` for the current activeJobId, if set. This acts as a heartbeat to signal that the job is still actively being processed.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
