### PR TITLE
chore: update rudder-go-kit to 0.49.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/rudderlabs/bing-ads-go-sdk v0.2.3
 	github.com/rudderlabs/compose-test v0.1.3
-	github.com/rudderlabs/rudder-go-kit v0.50.1
+	github.com/rudderlabs/rudder-go-kit v0.49.2
 	github.com/rudderlabs/rudder-observability-kit v0.0.4
 	github.com/rudderlabs/rudder-schemas v0.5.5
 	github.com/rudderlabs/rudder-transformer/go v0.0.0-20240910055720-f77d2ab4125a

--- a/go.sum
+++ b/go.sum
@@ -1173,8 +1173,8 @@ github.com/rudderlabs/goqu/v10 v10.3.1 h1:rnfX+b4EwBWQ2UQfIGeEW299JBBkK5biEbnf7K
 github.com/rudderlabs/goqu/v10 v10.3.1/go.mod h1:LH2vI5gGHBxEQuESqFyk5ZA2anGINc8o25hbidDWOYw=
 github.com/rudderlabs/parquet-go v0.0.2 h1:ZXRdZdimB0PdJtmxeSSxfI0fDQ3kZjwzBxRi6Ut1J8k=
 github.com/rudderlabs/parquet-go v0.0.2/go.mod h1:g6guum7o8uhj/uNhunnt7bw5Vabu/goI5i21/3fnxWQ=
-github.com/rudderlabs/rudder-go-kit v0.50.1 h1:wCKuRbcjCGd0r+toUHmZpwTla572QbHQ2LLOdSrnasg=
-github.com/rudderlabs/rudder-go-kit v0.50.1/go.mod h1:zOQd5e42FhXPV5W4TKVVyoZB6j8tVWA+e5POx4kM2BU=
+github.com/rudderlabs/rudder-go-kit v0.49.2 h1:nhZyv3Eet5eESZ/99I9ICkvkSp9BiShUbvlWuD97UnU=
+github.com/rudderlabs/rudder-go-kit v0.49.2/go.mod h1:lgXJjDysvopI3YdctvXT4HKIDqxheMaJQNqp8WNHzGE=
 github.com/rudderlabs/rudder-observability-kit v0.0.4 h1:h9nLoWqiv/nqGOu1dhuVFAHNRkyodR6R3v36bqmavRs=
 github.com/rudderlabs/rudder-observability-kit v0.0.4/go.mod h1:YTsvJmpvh8OLk7c4C+wXiV8NRdcrrdLa8UvIdLoXTho=
 github.com/rudderlabs/rudder-schemas v0.5.5 h1:aIXxyn/PbEMMZBXGbNDTmf/gDDUoSHcF7DJYmHwiIUc=


### PR DESCRIPTION
# Description

- Upgrading rudder-go-kit to v0.49.2

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
