### PR TITLE
fix: update account type to remove id which we are getting as map key

### DIFF
--- a/backend-config/account_association.go
+++ b/backend-config/account_association.go
@@ -46,7 +46,7 @@ func (c *ConfigT) setDestinationAccounts(dest *DestinationT) {
 					logger.NewStringField("destinationId", dest.ID))
 			}
 			dest.DeliveryAccount = &AccountWithDefinition{
-				Id:                account.Id,
+				Id:                accountID,
 				Options:           account.Options,
 				Secret:            account.Secret,
 				AccountDefinition: accountDefinition,
@@ -69,7 +69,7 @@ func (c *ConfigT) setDestinationAccounts(dest *DestinationT) {
 					logger.NewStringField("destinationId", dest.ID))
 			}
 			dest.DeleteAccount = &AccountWithDefinition{
-				Id:                account.Id,
+				Id:                deleteAccountID,
 				Options:           account.Options,
 				Secret:            account.Secret,
 				AccountDefinition: accountDefinition,

--- a/backend-config/account_association_test.go
+++ b/backend-config/account_association_test.go
@@ -24,7 +24,6 @@ func TestAccountAssociations(t *testing.T) {
 			},
 			Accounts: map[string]Account{
 				"acc-1": {
-					Id:                    "acc-1",
 					AccountDefinitionName: "oauth-def",
 					Options:               map[string]interface{}{"key1": "value1"},
 					Secret:                map[string]interface{}{"secret1": "secretValue1"},
@@ -81,7 +80,6 @@ func TestAccountAssociations(t *testing.T) {
 			},
 			Accounts: map[string]Account{
 				"acc-1": {
-					Id:                    "acc-1",
 					AccountDefinitionName: "oauth-def",
 					Options:               map[string]interface{}{"key1": "value1"},
 				},
@@ -124,7 +122,6 @@ func TestAccountAssociations(t *testing.T) {
 			},
 			Accounts: map[string]Account{
 				"acc-1": {
-					Id:                    "acc-1",
 					AccountDefinitionName: "oauth-def",
 					Options:               map[string]interface{}{"key1": "value1"},
 				},
@@ -161,7 +158,6 @@ func TestAccountAssociations(t *testing.T) {
 			},
 			Accounts: map[string]Account{
 				"acc-1": {
-					Id:                    "acc-1",
 					AccountDefinitionName: "oauth-def",
 				},
 			},
@@ -196,7 +192,6 @@ func TestAccountAssociations(t *testing.T) {
 			},
 			Accounts: map[string]Account{
 				"acc-1": {
-					Id:                    "acc-1",
 					AccountDefinitionName: "oauth-def",
 				},
 			},
@@ -230,7 +225,6 @@ func TestAccountAssociations(t *testing.T) {
 			},
 			Accounts: map[string]Account{
 				"acc-1": {
-					Id:                    "acc-1",
 					AccountDefinitionName: "non-existent-def",
 				},
 			},

--- a/backend-config/types.go
+++ b/backend-config/types.go
@@ -87,7 +87,6 @@ func (s *SourceT) IsReplaySource() bool {
 }
 
 type Account struct {
-	Id                    string                 `json:"id"`
 	AccountDefinitionName string                 `json:"accountDefinitionName"`
 	Options               map[string]interface{} `json:"options"`
 	Secret                map[string]interface{} `json:"secret"`


### PR DESCRIPTION
# Description

This PR optimizes the `Account` data structure by removing the redundant `Id` field from the `Account` struct. Since we're now using a map structure where the account ID is already the key (`map[string]Account`), storing the same ID inside the struct is redundant and inefficient.

## Changes

- Removed the `Id` field from the `Account` struct in `types.go`
- Updated the `setDestinationAccounts` method to use the map key (account ID) directly when creating `AccountWithDefinition` instances
- Removed redundant `Id` field references from all test cases in `account_association_test.go`

## Benefits

- Eliminates data duplication by not storing the same ID twice (as map key and inside the struct)
- Reduces memory usage by removing redundant fields
- Improves code clarity by making it explicit that the map key is the account ID
- Follows the optimization path started with the previous PR that converted arrays to maps

## Linear Ticket

This PR addresses [INT-3622](https://linear.app/rudderstack/issue/INT-3622/optimize-account-and-accountdefinition-merge-to-destinations), which focuses on optimizing the account and account definition merge process for destinations.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.