### PR TITLE
chore: enrich event with bot details

### DIFF
--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -150,5 +150,15 @@ func setupPipelineEnrichers(conf *config.Config, log logger.Logger, stats stats.
 		enrichers = append(enrichers, geoEnricher)
 	}
 
+	if conf.GetBool("BotEnrichment.enabled", true) {
+		log.Infof("Setting up the bot pipeline enricher")
+
+		botEnricher, err := enricher.NewBotEnricher()
+		if err != nil {
+			return nil, fmt.Errorf("starting bot enrichment process for pipeline: %w", err)
+		}
+		enrichers = append(enrichers, botEnricher)
+	}
+
 	return enrichers, nil
 }

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -745,14 +745,18 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 	[]jobWithStat, error,
 ) {
 	type params struct {
-		MessageID       string `json:"message_id"`
-		SourceID        string `json:"source_id"`
-		SourceJobRunID  string `json:"source_job_run_id"`
-		SourceTaskRunID string `json:"source_task_run_id"`
-		UserID          string `json:"user_id"`
-		TraceParent     string `json:"traceparent"`
-		DestinationID   string `json:"destination_id,omitempty"`
-		SourceCategory  string `json:"source_category"`
+		MessageID           string `json:"message_id"`
+		SourceID            string `json:"source_id"`
+		SourceJobRunID      string `json:"source_job_run_id"`
+		SourceTaskRunID     string `json:"source_task_run_id"`
+		UserID              string `json:"user_id"`
+		TraceParent         string `json:"traceparent"`
+		DestinationID       string `json:"destination_id,omitempty"`
+		SourceCategory      string `json:"source_category"`
+		IsBot               bool   `json:"is_bot,omitempty"`
+		BotName             string `json:"bot_name,omitempty"`
+		BotURL              string `json:"bot_url,omitempty"`
+		BotIsInvalidBrowser bool   `json:"bot_is_invalid_browser,omitempty"`
 	}
 
 	type singularEventBatch struct {
@@ -926,14 +930,18 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 		}).Since(msg.Properties.ReceivedAt)
 
 		jobsDBParams := params{
-			MessageID:       messageID,
-			SourceID:        msg.Properties.SourceID,
-			SourceJobRunID:  msg.Properties.SourceJobRunID,
-			SourceTaskRunID: msg.Properties.SourceTaskRunID,
-			UserID:          msg.Properties.UserID,
-			TraceParent:     msg.Properties.TraceID,
-			DestinationID:   msg.Properties.DestinationID,
-			SourceCategory:  msg.Properties.SourceType,
+			MessageID:           messageID,
+			SourceID:            msg.Properties.SourceID,
+			SourceJobRunID:      msg.Properties.SourceJobRunID,
+			SourceTaskRunID:     msg.Properties.SourceTaskRunID,
+			UserID:              msg.Properties.UserID,
+			TraceParent:         msg.Properties.TraceID,
+			DestinationID:       msg.Properties.DestinationID,
+			SourceCategory:      msg.Properties.SourceType,
+			IsBot:               msg.Properties.IsBot,
+			BotName:             msg.Properties.BotName,
+			BotURL:              msg.Properties.BotURL,
+			BotIsInvalidBrowser: msg.Properties.BotIsInvalidBrowser,
 		}
 
 		marshalledParams, err := jsonrs.Marshal(jobsDBParams)

--- a/internal/enricher/bot.go
+++ b/internal/enricher/bot.go
@@ -1,0 +1,56 @@
+package enricher
+
+import (
+	"errors"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/processor/types"
+)
+
+type BotDetails struct {
+	Name             string `json:"name,omitempty"`
+	URL              string `json:"url,omitempty"`
+	IsInvalidBrowser bool   `json:"isInvalidBrowser,omitempty"`
+}
+
+type botEnricher struct{}
+
+func NewBotEnricher() (PipelineEnricher, error) {
+	return &botEnricher{}, nil
+}
+
+func (e *botEnricher) Enrich(_ *backendconfig.SourceT, request *types.GatewayBatchRequest, eventParams *types.EventParams) error {
+	var enrichErrs []error
+	for _, event := range request.Batch {
+		// if the event is not a bot, we don't need to enrich it
+		if !eventParams.IsBot {
+			continue
+		}
+
+		// if the context section is missing on the event
+		// set it with default as map[string]interface{}
+		if _, ok := event["context"]; !ok {
+			event["context"] = map[string]interface{}{}
+		}
+
+		// if the context is other than map[string]interface{}, add error and continue
+		context, ok := event["context"].(map[string]interface{})
+		if !ok {
+			enrichErrs = append(enrichErrs, errors.New("event doesn't have a valid context section"))
+			continue
+		}
+
+		context["isBot"] = true
+		context["bot"] = BotDetails{
+			Name:             eventParams.BotName,
+			URL:              eventParams.BotURL,
+			IsInvalidBrowser: eventParams.BotIsInvalidBrowser,
+		}
+	}
+
+	return errors.Join(enrichErrs...)
+}
+
+func (e *botEnricher) Close() error {
+	return nil
+}

--- a/internal/enricher/bot_test.go
+++ b/internal/enricher/bot_test.go
@@ -1,0 +1,202 @@
+package enricher
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-server/processor/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBotEnricher(t *testing.T) {
+	tests := []struct {
+		name           string
+		request        *types.GatewayBatchRequest
+		eventParams    *types.EventParams
+		expectedEvents []types.SingularEventT
+		expectError    bool
+	}{
+		{
+			name: "non-bot event should not be enriched",
+			request: &types.GatewayBatchRequest{
+				Batch: []types.SingularEventT{
+					{
+						"event": "test-event",
+					},
+				},
+			},
+			eventParams: &types.EventParams{
+				IsBot: false,
+			},
+			expectedEvents: []types.SingularEventT{
+				{
+					"event": "test-event",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "bot event without context should be enriched with new context",
+			request: &types.GatewayBatchRequest{
+				Batch: []types.SingularEventT{
+					{
+						"event": "test-event",
+					},
+				},
+			},
+			eventParams: &types.EventParams{
+				IsBot:               true,
+				BotName:             "test-bot",
+				BotURL:              "https://test-bot.com",
+				BotIsInvalidBrowser: false,
+			},
+			expectedEvents: []types.SingularEventT{
+				{
+					"event": "test-event",
+					"context": map[string]interface{}{
+						"isBot": true,
+						"bot": BotDetails{
+							Name:             "test-bot",
+							URL:              "https://test-bot.com",
+							IsInvalidBrowser: false,
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "bot event with invalid browser should be enriched with isInvalidBrowser as true",
+			request: &types.GatewayBatchRequest{
+				Batch: []types.SingularEventT{
+					{
+						"event": "test-event",
+					},
+				},
+			},
+			eventParams: &types.EventParams{
+				IsBot:               true,
+				BotIsInvalidBrowser: true,
+			},
+			expectedEvents: []types.SingularEventT{
+				{
+					"event": "test-event",
+					"context": map[string]interface{}{
+						"isBot": true,
+						"bot": BotDetails{
+							IsInvalidBrowser: true,
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "bot event with existing context should be enriched",
+			request: &types.GatewayBatchRequest{
+				Batch: []types.SingularEventT{
+					{
+						"event": "test-event",
+						"context": map[string]interface{}{
+							"existing": "value",
+						},
+					},
+				},
+			},
+			eventParams: &types.EventParams{
+				IsBot:   true,
+				BotName: "test-bot",
+				BotURL:  "https://test-bot.com",
+			},
+			expectedEvents: []types.SingularEventT{
+				{
+					"event": "test-event",
+					"context": map[string]interface{}{
+						"existing": "value",
+						"isBot":    true,
+						"bot": BotDetails{
+							Name:             "test-bot",
+							URL:              "https://test-bot.com",
+							IsInvalidBrowser: false,
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "bot event with existing isBot should be enriched with new bot details",
+			request: &types.GatewayBatchRequest{
+				Batch: []types.SingularEventT{
+					{
+						"event": "test-event",
+						"context": map[string]interface{}{
+							"isBot": false,
+							"bot": BotDetails{
+								Name:             "old-bot",
+								URL:              "https://old-bot.com",
+								IsInvalidBrowser: false,
+							},
+						},
+					},
+				},
+			},
+			eventParams: &types.EventParams{
+				IsBot:               true,
+				BotName:             "new-bot",
+				BotURL:              "https://new-bot.com",
+				BotIsInvalidBrowser: false,
+			},
+			expectedEvents: []types.SingularEventT{
+				{
+					"event": "test-event",
+					"context": map[string]interface{}{
+						"isBot": true,
+						"bot": BotDetails{
+							Name:             "new-bot",
+							URL:              "https://new-bot.com",
+							IsInvalidBrowser: false,
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "bot event with invalid context should return error",
+			request: &types.GatewayBatchRequest{
+				Batch: []types.SingularEventT{
+					{
+						"event":   "test-event",
+						"context": "invalid-context",
+					},
+				},
+			},
+			eventParams: &types.EventParams{
+				IsBot: true,
+			},
+			expectedEvents: []types.SingularEventT{
+				{
+					"event":   "test-event",
+					"context": "invalid-context",
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enricher, err := NewBotEnricher()
+			assert.NoError(t, err)
+
+			err = enricher.Enrich(nil, tt.request, tt.eventParams)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expectedEvents, tt.request.Batch)
+		})
+	}
+}

--- a/internal/enricher/enricher.go
+++ b/internal/enricher/enricher.go
@@ -8,6 +8,6 @@ import (
 // PipelineEnricher is a new paradigm under which the gateway events in
 // processing pipeline are enriched with new information based on the handler passed.
 type PipelineEnricher interface {
-	Enrich(source *backendconfig.SourceT, request *types.GatewayBatchRequest) error
+	Enrich(source *backendconfig.SourceT, request *types.GatewayBatchRequest, eventParams *types.EventParams) error
 	Close() error
 }

--- a/internal/enricher/geolocation.go
+++ b/internal/enricher/geolocation.go
@@ -63,7 +63,7 @@ func NewGeoEnricher(conf *config.Config, log logger.Logger, statClient stats.Sta
 // Enrich function runs on a request of GatewayBatchRequest which contains
 // multiple singular events from a source. The enrich function augments the
 // geolocation information per event based on IP address.
-func (e *geoEnricher) Enrich(source *backendconfig.SourceT, request *types.GatewayBatchRequest) error {
+func (e *geoEnricher) Enrich(source *backendconfig.SourceT, request *types.GatewayBatchRequest, _ *types.EventParams) error {
 	if !source.GeoEnrichment.Enabled {
 		return nil
 	}

--- a/internal/enricher/geolocation_test.go
+++ b/internal/enricher/geolocation_test.go
@@ -82,7 +82,7 @@ func TestGeolocationEnrichment_Success(t *testing.T) {
 			err := enricher.Enrich(
 				NewSourceBuilder("source-id").
 					WithGeoEnrichment(true).
-					Build(), ip)
+					Build(), ip, nil)
 			require.Nil(t, err)
 			// require.Equal(t, nil, ip)
 			require.Equal(t, types.SingularEventT{"userId": "1", "context": map[string]interface{}{"app_version": "0.1.0", "geo": Geolocation{}}}, ip.Batch[0])
@@ -103,7 +103,7 @@ func TestGeolocationEnrichment_Success(t *testing.T) {
 			err := enricher.Enrich(
 				NewSourceBuilder("source-id").
 					WithGeoEnrichment(true).
-					Build(), input)
+					Build(), input, nil)
 			require.Nil(t, err)
 
 			require.Equal(t,
@@ -129,7 +129,7 @@ func TestGeolocationEnrichment_Success(t *testing.T) {
 			err := enricher.Enrich(
 				NewSourceBuilder("source-id").
 					WithGeoEnrichment(true).
-					Build(), input)
+					Build(), input, nil)
 			require.Nil(t, err)
 
 			require.Equal(t,
@@ -174,6 +174,7 @@ func TestGeolocationEnrichment_Success(t *testing.T) {
 					WithGeoEnrichment(false). // flag for enrichment is `false`
 					Build(),
 				input,
+				nil,
 			)
 			require.Nil(t, err)
 
@@ -207,7 +208,7 @@ func TestGeolocationEnrichment_Success(t *testing.T) {
 			err := enricher.Enrich(
 				NewSourceBuilder("source-id").
 					WithGeoEnrichment(true).
-					Build(), input)
+					Build(), input, nil)
 			require.Nil(t, err)
 
 			// In both the events below, we have context section
@@ -259,7 +260,7 @@ func TestGeolocationEnrichment_Success(t *testing.T) {
 			err := enricher.Enrich(
 				NewSourceBuilder("source-id").
 					WithGeoEnrichment(true).
-					Build(), input)
+					Build(), input, nil)
 			require.NotNil(t, err)
 
 			require.Equal(t, types.SingularEventT{
@@ -320,7 +321,7 @@ func TestGeolocationEnrichment_Success(t *testing.T) {
 			err := enricher.Enrich(
 				NewSourceBuilder("source-id").
 					WithGeoEnrichment(true).
-					Build(), input)
+					Build(), input, nil)
 			require.Nil(t, err)
 
 			// here the context.ip is present and invalid but the

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1802,7 +1802,7 @@ func (proc *Handle) preprocessStage(partition string, subJobs subJob) (*preTrans
 		}
 
 		for _, e := range proc.enrichers {
-			if err := e.Enrich(source, &gatewayBatchEvent); err != nil {
+			if err := e.Enrich(source, &gatewayBatchEvent, &eventParams); err != nil {
 				proc.logger.Errorf("unable to enrich the gateway batch event: %v", err.Error())
 			}
 		}

--- a/processor/types/types.go
+++ b/processor/types/types.go
@@ -238,11 +238,15 @@ func (r *Response) Equal(v *Response) (string, bool) {
 }
 
 type EventParams struct {
-	SourceJobRunId  string `json:"source_job_run_id"`
-	SourceId        string `json:"source_id"`
-	SourceTaskRunId string `json:"source_task_run_id"`
-	TraceParent     string `json:"traceparent"`
-	DestinationID   string `json:"destination_id"`
+	SourceJobRunId      string `json:"source_job_run_id"`
+	SourceId            string `json:"source_id"`
+	SourceTaskRunId     string `json:"source_task_run_id"`
+	TraceParent         string `json:"traceparent"`
+	DestinationID       string `json:"destination_id"`
+	IsBot               bool   `json:"is_bot,omitempty"`
+	BotName             string `json:"bot_name,omitempty"`
+	BotURL              string `json:"bot_url,omitempty"`
+	BotIsInvalidBrowser bool   `json:"bot_is_invalid_browser,omitempty"`
 }
 
 type TransformerMetricLabels struct {


### PR DESCRIPTION
# Description

Add bot encicher, which will add bot details present in event parameters to event context. 

## Linear Ticket

[Resolves PIPE-2028] (https://linear.app/rudderstack/issue/PIPE-2028/implement-event-flagging)

## Depedency

https://github.com/rudderlabs/rudder-schemas/pull/66

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
