### PR TITLE
chore: warehouse transformer sample diff

### DIFF
--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader.go
@@ -119,6 +119,9 @@ func (t *Transformer) sampleDiff(events []types.TransformerEvent, legacyResponse
 		if strings.Contains(diff, "\"0001-01-01T00:00:00.000Z\"") {
 			continue
 		}
+		if strings.Contains(diff, "\"auto-\"") {
+			continue
+		}
 		if differedEventsCount == 0 {
 			sampleDiff = diff
 		}


### PR DESCRIPTION
# Description

- For sample diff, avoid checking for `auto-` if the `messageId` is not present, because rudder-transformer will add some random UUID that will not match.

## Linear Ticket

- Resolves WAR-645

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
