### PR TITLE
chore(router): support destination-specific configuration overrides for all options

### DIFF
--- a/router/config.go
+++ b/router/config.go
@@ -5,11 +5,11 @@ import (
 )
 
 func getRouterConfigBool(key, destType string, defaultValue bool) bool {
-	return config.GetBoolVar(defaultValue, "Router."+destType+"."+key, "Router."+key)
+	return config.GetBoolVar(defaultValue, getRouterConfigKeys(key, destType)...)
 }
 
 func getRouterConfigInt(key, destType string, defaultValue int) int {
-	return config.GetIntVar(defaultValue, 1, "Router."+destType+"."+key, "Router."+key)
+	return config.GetIntVar(defaultValue, 1, getRouterConfigKeys(key, destType)...)
 }
 
 func getHierarchicalRouterConfigInt(destType string, defaultValue int, keys ...string) int {
@@ -22,5 +22,9 @@ func getHierarchicalRouterConfigInt(destType string, defaultValue int, keys ...s
 }
 
 func getReloadableRouterConfigInt(key, destType string, defaultValue int) config.ValueLoader[int] {
-	return config.GetReloadableIntVar(defaultValue, 1, "Router."+destType+"."+key, "Router."+key)
+	return config.GetReloadableIntVar(defaultValue, 1, getRouterConfigKeys(key, destType)...)
+}
+
+func getRouterConfigKeys(key, destType string) []string {
+	return []string{"Router." + destType + "." + key, "Router." + key}
 }

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -326,7 +326,7 @@ func (rt *Handle) setupReloadableVars() {
 	rt.reloadableConfig.failingJobsPenaltySleep = config.GetReloadableDurationVar(2000, time.Millisecond, getRouterConfigKeys("failingJobsPenaltySleep", rt.destType)...)
 	rt.reloadableConfig.failingJobsPenaltyThreshold = config.GetReloadableFloat64Var(0.6, getRouterConfigKeys("failingJobsPenaltyThreshold", rt.destType)...)
 	rt.reloadableConfig.oauthV2Enabled = config.GetReloadableBoolVar(false, getRouterConfigKeys("oauthV2Enabled", rt.destType)...)
-	rt.reloadableConfig.oauthV2ExpirationTimeDiff = config.GetReloadableDurationVar(5, time.Minute, getRouterConfigKeys("expirationTimeDiff", rt.destType)...)
+	rt.reloadableConfig.oauthV2ExpirationTimeDiff = config.GetReloadableDurationVar(5, time.Minute, getRouterConfigKeys("oauth.expirationTimeDiff", rt.destType)...)
 	rt.diagnosisTickerTime = config.GetDurationVar(60, time.Second, "Diagnostics.routerTimePeriod", "Diagnostics.routerTimePeriodInS")
 	rt.netClientTimeout = config.GetDurationVar(10, time.Second,
 		"Router."+rt.destType+".httpTimeout",


### PR DESCRIPTION
# Description

We should be able to override router's configuration for a specific destination type without affecting others.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
