### PR TITLE
fix: reporting common client path with query

### DIFF
--- a/enterprise/reporting/client/client.go
+++ b/enterprise/reporting/client/client.go
@@ -31,18 +31,18 @@ const (
 )
 
 const (
-	ServiceMetrics      ServiceRoute = "/metrics?version=v1"
-	ServiceRecordErrors ServiceRoute = "/recordErrors"
-	ServiceTrackedUsers ServiceRoute = "/trackedUser"
+	RouteMetrics      Route = "/metrics?version=v1"
+	RouteRecordErrors Route = "/recordErrors"
+	RouteTrackedUsers Route = "/trackedUser"
 )
 
-// ServiceRoute contains the HTTP path and query string for the service.
-type ServiceRoute string
+// Route contains the HTTP path and query string for the service.
+type Route string
 
-// URL returns the URL for the service endpoint, given the base URL.
-// * baseURL provides only the scheme, host, and port for the URL.
-// * ServiceEndpoint provides path and query parameters.
-func (p ServiceRoute) URL(baseURL string) (url.URL, error) {
+// URL returns the absolute URL for the route, given a base URL.
+// * baseURL provides only the scheme, host, and port.
+// * Route provides path and query parameters.
+func (p Route) URL(baseURL string) (url.URL, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return url.URL{}, fmt.Errorf("parsing base URL: %w", err)
@@ -61,7 +61,7 @@ func (p ServiceRoute) URL(baseURL string) (url.URL, error) {
 
 // Client handles sending metrics to the reporting service
 type Client struct {
-	route               ServiceRoute
+	route               Route
 	reportingServiceURL string
 
 	httpClient *http.Client
@@ -89,7 +89,7 @@ func backOffFromConfig(conf *config.Config) backoff.BackOff {
 }
 
 // New creates a new reporting client
-func New(path ServiceRoute, conf *config.Config, log logger.Logger, stats stats.Stats) *Client {
+func New(path Route, conf *config.Config, log logger.Logger, stats stats.Stats) *Client {
 	reportingServiceURL := conf.GetString("REPORTING_URL", "https://reporting.dev.rudderlabs.com")
 	reportingServiceURL = strings.TrimSuffix(reportingServiceURL, "/")
 

--- a/enterprise/reporting/client/client.go
+++ b/enterprise/reporting/client/client.go
@@ -31,16 +31,37 @@ const (
 )
 
 const (
-	PathMetrics      Path = "/metrics?version=v1"
-	PathRecordErrors Path = "/recordErrors"
-	PathTrackedUsers Path = "/trackedUser"
+	ServiceMetrics      ServiceEndpoint = "/metrics?version=v1"
+	ServiceRecordErrors ServiceEndpoint = "/recordErrors"
+	ServiceTrackedUsers ServiceEndpoint = "/trackedUser"
 )
 
-type Path string
+// ServiceEndpoint contains the HTTP path and query string for the service.
+type ServiceEndpoint string
+
+// URL returns the URL for the service endpoint, given the base URL.
+// * baseURL provides only the scheme, host, and port for the URL.
+// * ServiceEndpoint provides path and query parameters.
+func (p ServiceEndpoint) URL(baseURL string) (url.URL, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return url.URL{}, fmt.Errorf("parsing base URL: %w", err)
+	}
+
+	pathURL, err := url.Parse(string(p))
+	if err != nil {
+		return url.URL{}, fmt.Errorf("parsing service endpoint: %w", err)
+	}
+
+	u.Path = pathURL.Path
+	u.RawQuery = pathURL.RawQuery
+
+	return *u, nil
+}
 
 // Client handles sending metrics to the reporting service
 type Client struct {
-	path                Path
+	service             ServiceEndpoint
 	reportingServiceURL string
 
 	httpClient *http.Client
@@ -68,7 +89,7 @@ func backOffFromConfig(conf *config.Config) backoff.BackOff {
 }
 
 // New creates a new reporting client
-func New(path Path, conf *config.Config, log logger.Logger, stats stats.Stats) *Client {
+func New(path ServiceEndpoint, conf *config.Config, log logger.Logger, stats stats.Stats) *Client {
 	reportingServiceURL := conf.GetString("REPORTING_URL", "https://reporting.dev.rudderlabs.com")
 	reportingServiceURL = strings.TrimSuffix(reportingServiceURL, "/")
 
@@ -78,7 +99,7 @@ func New(path Path, conf *config.Config, log logger.Logger, stats stats.Stats) *
 		},
 		reportingServiceURL: reportingServiceURL,
 		backoff:             backOffFromConfig(conf),
-		path:                path,
+		service:             path,
 		instanceID:          conf.GetString("INSTANCE_ID", "1"),
 		moduleName:          conf.GetString("clientName", ""),
 		stats:               stats,
@@ -92,12 +113,15 @@ func (c *Client) Send(ctx context.Context, payload any) error {
 		return err
 	}
 
-	u := strings.TrimSuffix(c.reportingServiceURL, "/") + string(c.path)
+	u, err := c.service.URL(c.reportingServiceURL)
+	if err != nil {
+		return fmt.Errorf("constructing URL for service endpoint (%q, %q): %w", c.service, c.reportingServiceURL, err)
+	}
 
 	o := func() error {
-		req, err := http.NewRequestWithContext(ctx, "POST", u, bytes.NewBuffer(payloadBytes))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewBuffer(payloadBytes))
 		if err != nil {
-			return err
+			return fmt.Errorf("constructing HTTP request: %w", err)
 		}
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 		httpRequestStart := time.Now()
@@ -123,11 +147,11 @@ func (c *Client) Send(ctx context.Context, payload any) error {
 		defer func() { httputil.CloseResponse(resp) }()
 		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("reading response body from reporting service: %q: %w", c.path, err)
+			return fmt.Errorf("reading response body: %q: %w", c.service, err)
 		}
 
 		if !c.isHTTPRequestSuccessful(resp.StatusCode) {
-			err = fmt.Errorf("received unexpected response from reporting service: %q: statusCode: %d body: %v", c.path, resp.StatusCode, string(respBody))
+			err = fmt.Errorf("received unexpected response: %q: statusCode: %d body: %v", c.service, resp.StatusCode, string(respBody))
 		}
 		return err
 	}
@@ -149,7 +173,7 @@ func (c *Client) getTags() stats.Tags {
 		"module":     c.moduleName,
 		"instanceId": c.instanceID,
 		"endpoint":   serverURL.Host,
-		"path":       string(c.path),
+		"path":       string(c.service),
 	}
 }
 

--- a/enterprise/reporting/client/client.go
+++ b/enterprise/reporting/client/client.go
@@ -92,10 +92,7 @@ func (c *Client) Send(ctx context.Context, payload any) error {
 		return err
 	}
 
-	u, err := url.JoinPath(c.reportingServiceURL, string(c.path))
-	if err != nil {
-		return err
-	}
+	u := strings.TrimSuffix(c.reportingServiceURL, "/") + string(c.path)
 
 	o := func() error {
 		req, err := http.NewRequestWithContext(ctx, "POST", u, bytes.NewBuffer(payloadBytes))

--- a/enterprise/reporting/client/client_test.go
+++ b/enterprise/reporting/client/client_test.go
@@ -371,7 +371,7 @@ func TestClient5xx(t *testing.T) {
 func TestServiceEndpointURL(t *testing.T) {
 	tests := []struct {
 		name        string
-		endpoint    client.ServiceEndpoint
+		endpoint    client.ServiceRoute
 		baseURL     string
 		wantURL     string
 		wantErr     bool
@@ -407,7 +407,7 @@ func TestServiceEndpointURL(t *testing.T) {
 		},
 		{
 			name:        "invalid service endpoint",
-			endpoint:    client.ServiceEndpoint("://invalid-endpoint"),
+			endpoint:    client.ServiceRoute("://invalid-endpoint"),
 			baseURL:     "https://reporting.dev.rudderlabs.com",
 			wantErr:     true,
 			errContains: "parsing service endpoint",

--- a/enterprise/reporting/client/client_test.go
+++ b/enterprise/reporting/client/client_test.go
@@ -69,7 +69,7 @@ func TestClientSendMetric(t *testing.T) {
 	conf.Set("Reporting.httpClient.backoff.maxRetries", 1)
 
 	// Create the client
-	c := client.New(client.ServiceMetrics, conf, logger.NOP, statsStore)
+	c := client.New(client.RouteMetrics, conf, logger.NOP, statsStore)
 
 	bucket, _ := reporting.GetAggregationBucketMinute(28017690, 10)
 
@@ -152,7 +152,7 @@ func TestClientSendMetric(t *testing.T) {
 	t.Run("ensure metrics are recorded", func(t *testing.T) {
 		// Expected tags for all metrics
 		expectedTags := stats.Tags{
-			"path":       string(client.ServiceMetrics),
+			"path":       string(client.RouteMetrics),
 			"module":     "test-client",
 			"instanceId": instanceID,
 			"endpoint":   serverURL.Host,
@@ -160,7 +160,7 @@ func TestClientSendMetric(t *testing.T) {
 
 		// Expected tags for HTTP metrics
 		expectedHttpTags := stats.Tags{
-			"path":       string(client.ServiceMetrics),
+			"path":       string(client.RouteMetrics),
 			"module":     "test-client",
 			"instanceId": instanceID,
 			"endpoint":   serverURL.Host,
@@ -210,7 +210,7 @@ func TestClientSendErrorMetric(t *testing.T) {
 	conf.Set("REPORTING_URL", server.URL)
 
 	// Create the client
-	c := client.New(client.ServiceMetrics, conf, logger.NOP, statsStore)
+	c := client.New(client.RouteMetrics, conf, logger.NOP, statsStore)
 
 	// Create sample event as json.RawMessage
 	sampleEvent := json.RawMessage(`{"event": "test_event", "properties": {"test": "value"}}`)
@@ -272,7 +272,7 @@ func TestClientSendErrorMetric(t *testing.T) {
 
 	// Expected tags for all metrics
 	expectedTags := stats.Tags{
-		"path":       string(client.ServiceMetrics),
+		"path":       string(client.RouteMetrics),
 		"module":     "test-client",
 		"instanceId": "test-instance",
 		"endpoint":   serverURL.Host,
@@ -280,7 +280,7 @@ func TestClientSendErrorMetric(t *testing.T) {
 
 	// Expected tags for HTTP metrics
 	expectedHttpTags := stats.Tags{
-		"path":       string(client.ServiceMetrics),
+		"path":       string(client.RouteMetrics),
 		"module":     "test-client",
 		"instanceId": "test-instance",
 		"endpoint":   serverURL.Host,
@@ -341,7 +341,7 @@ func TestClient5xx(t *testing.T) {
 			conf.Set("REPORTING_URL", server.URL)
 			conf.Set("Reporting.httpClient.backoff.maxRetries", 1)
 
-			c := client.New(client.ServiceMetrics, conf, logger.NOP, statsStore)
+			c := client.New(client.RouteMetrics, conf, logger.NOP, statsStore)
 
 			// Send the metric and expect an error
 			err = c.Send(context.Background(), metric)
@@ -353,7 +353,7 @@ func TestClient5xx(t *testing.T) {
 
 			// Expected tags for HTTP metrics
 			expectedHttpTags := stats.Tags{
-				"path":       string(client.ServiceMetrics),
+				"path":       string(client.RouteMetrics),
 				"module":     "test-client",
 				"instanceId": "2",
 				"endpoint":   serverURL.Host,
@@ -368,126 +368,126 @@ func TestClient5xx(t *testing.T) {
 	}
 }
 
-func TestServiceEndpointURL(t *testing.T) {
+func TestRouteURL(t *testing.T) {
 	tests := []struct {
 		name        string
-		endpoint    client.ServiceRoute
+		route       client.Route
 		baseURL     string
 		wantURL     string
 		wantErr     bool
 		errContains string
 	}{
 		{
-			name:     "valid metrics endpoint",
-			endpoint: client.ServiceMetrics,
-			baseURL:  "https://reporting.dev.rudderlabs.com",
-			wantURL:  "https://reporting.dev.rudderlabs.com/metrics?version=v1",
-			wantErr:  false,
+			name:    "valid metrics endpoint",
+			route:   client.RouteMetrics,
+			baseURL: "https://reporting.dev.rudderlabs.com",
+			wantURL: "https://reporting.dev.rudderlabs.com/metrics?version=v1",
+			wantErr: false,
 		},
 		{
-			name:     "valid record errors endpoint",
-			endpoint: client.ServiceRecordErrors,
-			baseURL:  "https://reporting.dev.rudderlabs.com",
-			wantURL:  "https://reporting.dev.rudderlabs.com/recordErrors",
-			wantErr:  false,
+			name:    "valid record errors endpoint",
+			route:   client.RouteRecordErrors,
+			baseURL: "https://reporting.dev.rudderlabs.com",
+			wantURL: "https://reporting.dev.rudderlabs.com/recordErrors",
+			wantErr: false,
 		},
 		{
-			name:     "valid tracked users endpoint",
-			endpoint: client.ServiceTrackedUsers,
-			baseURL:  "https://reporting.dev.rudderlabs.com",
-			wantURL:  "https://reporting.dev.rudderlabs.com/trackedUser",
-			wantErr:  false,
+			name:    "valid tracked users endpoint",
+			route:   client.RouteTrackedUsers,
+			baseURL: "https://reporting.dev.rudderlabs.com",
+			wantURL: "https://reporting.dev.rudderlabs.com/trackedUser",
+			wantErr: false,
 		},
 		{
 			name:        "invalid base URL",
-			endpoint:    client.ServiceMetrics,
+			route:       client.RouteMetrics,
 			baseURL:     "://invalid-url",
 			wantErr:     true,
 			errContains: "parsing base URL",
 		},
 		{
 			name:        "invalid service endpoint",
-			endpoint:    client.ServiceRoute("://invalid-endpoint"),
+			route:       client.Route("://invalid-endpoint"),
 			baseURL:     "https://reporting.dev.rudderlabs.com",
 			wantErr:     true,
 			errContains: "parsing service endpoint",
 		},
 		{
-			name:     "base URL with trailing slash",
-			endpoint: client.ServiceMetrics,
-			baseURL:  "https://reporting.dev.rudderlabs.com/",
-			wantURL:  "https://reporting.dev.rudderlabs.com/metrics?version=v1",
-			wantErr:  false,
+			name:    "base URL with trailing slash",
+			route:   client.RouteMetrics,
+			baseURL: "https://reporting.dev.rudderlabs.com/",
+			wantURL: "https://reporting.dev.rudderlabs.com/metrics?version=v1",
+			wantErr: false,
 		},
 		{
-			name:     "base URL with trailing dot",
-			endpoint: client.ServiceMetrics,
-			baseURL:  "https://reporting.dev.rudderlabs.com./",
-			wantURL:  "https://reporting.dev.rudderlabs.com./metrics?version=v1",
-			wantErr:  false,
+			name:    "base URL with trailing dot",
+			route:   client.RouteMetrics,
+			baseURL: "https://reporting.dev.rudderlabs.com./",
+			wantURL: "https://reporting.dev.rudderlabs.com./metrics?version=v1",
+			wantErr: false,
 		},
 
 		{
-			name:     "base URL with existing path",
-			endpoint: client.ServiceMetrics,
-			baseURL:  "https://reporting.dev.rudderlabs.com/api",
-			wantURL:  "https://reporting.dev.rudderlabs.com/metrics?version=v1",
-			wantErr:  false,
+			name:    "base URL with existing path",
+			route:   client.RouteMetrics,
+			baseURL: "https://reporting.dev.rudderlabs.com/api",
+			wantURL: "https://reporting.dev.rudderlabs.com/metrics?version=v1",
+			wantErr: false,
 		},
 		{
-			name:     "base URL with multiple trailing slashes",
-			endpoint: client.ServiceMetrics,
-			baseURL:  "https://reporting.dev.rudderlabs.com///",
-			wantURL:  "https://reporting.dev.rudderlabs.com/metrics?version=v1",
-			wantErr:  false,
+			name:    "base URL with multiple trailing slashes",
+			route:   client.RouteMetrics,
+			baseURL: "https://reporting.dev.rudderlabs.com///",
+			wantURL: "https://reporting.dev.rudderlabs.com/metrics?version=v1",
+			wantErr: false,
 		},
 		{
-			name:     "base URL with relative path up",
-			endpoint: client.ServiceMetrics,
-			baseURL:  "https://reporting.dev.rudderlabs.com/api/../",
-			wantURL:  "https://reporting.dev.rudderlabs.com/metrics?version=v1",
-			wantErr:  false,
+			name:    "base URL with relative path up",
+			route:   client.RouteMetrics,
+			baseURL: "https://reporting.dev.rudderlabs.com/api/../",
+			wantURL: "https://reporting.dev.rudderlabs.com/metrics?version=v1",
+			wantErr: false,
 		},
 		{
-			name:     "base URL with relative path current",
-			endpoint: client.ServiceMetrics,
-			baseURL:  "https://reporting.dev.rudderlabs.com/api/./",
-			wantURL:  "https://reporting.dev.rudderlabs.com/metrics?version=v1",
-			wantErr:  false,
+			name:    "base URL with relative path current",
+			route:   client.RouteMetrics,
+			baseURL: "https://reporting.dev.rudderlabs.com/api/./",
+			wantURL: "https://reporting.dev.rudderlabs.com/metrics?version=v1",
+			wantErr: false,
 		},
 		{
-			name:     "base URL with complex relative path",
-			endpoint: client.ServiceMetrics,
-			baseURL:  "https://reporting.dev.rudderlabs.com/api/v1/../v2/./v3/",
-			wantURL:  "https://reporting.dev.rudderlabs.com/metrics?version=v1",
-			wantErr:  false,
+			name:    "base URL with complex relative path",
+			route:   client.RouteMetrics,
+			baseURL: "https://reporting.dev.rudderlabs.com/api/v1/../v2/./v3/",
+			wantURL: "https://reporting.dev.rudderlabs.com/metrics?version=v1",
+			wantErr: false,
 		},
 		{
-			name:     "base URL with encoded path",
-			endpoint: client.ServiceMetrics,
-			baseURL:  "https://reporting.dev.rudderlabs.com/api%2Fv1",
-			wantURL:  "https://reporting.dev.rudderlabs.com/metrics?version=v1",
-			wantErr:  false,
+			name:    "base URL with encoded path",
+			route:   client.RouteMetrics,
+			baseURL: "https://reporting.dev.rudderlabs.com/api%2Fv1",
+			wantURL: "https://reporting.dev.rudderlabs.com/metrics?version=v1",
+			wantErr: false,
 		},
 		{
-			name:     "base URL with query parameters",
-			endpoint: client.ServiceMetrics,
-			baseURL:  "https://reporting.dev.rudderlabs.com?param=value",
-			wantURL:  "https://reporting.dev.rudderlabs.com/metrics?version=v1",
-			wantErr:  false,
+			name:    "base URL with query parameters",
+			route:   client.RouteMetrics,
+			baseURL: "https://reporting.dev.rudderlabs.com?param=value",
+			wantURL: "https://reporting.dev.rudderlabs.com/metrics?version=v1",
+			wantErr: false,
 		},
 		{
-			name:     "base URL with port",
-			endpoint: client.ServiceMetrics,
-			baseURL:  "https://reporting.dev.rudderlabs.com:8080",
-			wantURL:  "https://reporting.dev.rudderlabs.com:8080/metrics?version=v1",
-			wantErr:  false,
+			name:    "base URL with port",
+			route:   client.RouteMetrics,
+			baseURL: "https://reporting.dev.rudderlabs.com:8080",
+			wantURL: "https://reporting.dev.rudderlabs.com:8080/metrics?version=v1",
+			wantErr: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.endpoint.URL(tt.baseURL)
+			got, err := tt.route.URL(tt.baseURL)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errContains != "" {

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -165,7 +165,7 @@ func NewErrorDetailReporter(
 		config:               conf,
 
 		useCommonClient: useCommonClient,
-		commonClient:    client.New(client.PathRecordErrors, conf, log, stats),
+		commonClient:    client.New(client.ServiceRecordErrors, conf, log, stats),
 	}
 }
 

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -165,7 +165,7 @@ func NewErrorDetailReporter(
 		config:               conf,
 
 		useCommonClient: useCommonClient,
-		commonClient:    client.New(client.ServiceRecordErrors, conf, log, stats),
+		commonClient:    client.New(client.RouteRecordErrors, conf, log, stats),
 	}
 }
 

--- a/enterprise/reporting/flusher/factory.go
+++ b/enterprise/reporting/flusher/factory.go
@@ -45,7 +45,7 @@ func CreateRunner(ctx context.Context, table string, log logger.Logger, stats st
 			return &NOPCronRunner{}, nil
 		}
 
-		commonClient := client.New(client.PathTrackedUsers, conf, log, stats)
+		commonClient := client.New(client.ServiceTrackedUsers, conf, log, stats)
 
 		// DEPRECATED: Remove this after migration to commonClient.
 		reportingBaseURL := config.GetString("REPORTING_URL", "https://reporting.rudderstack.com/")

--- a/enterprise/reporting/flusher/factory.go
+++ b/enterprise/reporting/flusher/factory.go
@@ -45,7 +45,7 @@ func CreateRunner(ctx context.Context, table string, log logger.Logger, stats st
 			return &NOPCronRunner{}, nil
 		}
 
-		commonClient := client.New(client.ServiceTrackedUsers, conf, log, stats)
+		commonClient := client.New(client.RouteTrackedUsers, conf, log, stats)
 
 		// DEPRECATED: Remove this after migration to commonClient.
 		reportingBaseURL := config.GetString("REPORTING_URL", "https://reporting.rudderstack.com/")

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -146,7 +146,7 @@ func NewDefaultReporter(ctx context.Context, conf *config.Config, log logger.Log
 		eventSamplingDuration:                eventSamplingDuration,
 		eventSampler:                         eventSampler,
 		useCommonClient:                      useCommonClient,
-		commonClient:                         client.New(client.PathMetrics, conf, log, stats),
+		commonClient:                         client.New(client.ServiceMetrics, conf, log, stats),
 	}
 }
 

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -146,7 +146,7 @@ func NewDefaultReporter(ctx context.Context, conf *config.Config, log logger.Log
 		eventSamplingDuration:                eventSamplingDuration,
 		eventSampler:                         eventSampler,
 		useCommonClient:                      useCommonClient,
-		commonClient:                         client.New(client.ServiceMetrics, conf, log, stats),
+		commonClient:                         client.New(client.RouteMetrics, conf, log, stats),
 	}
 }
 


### PR DESCRIPTION
# Description

url.JoinPath has a side effect of encoding query parameter. Causing `/metrics?version=v1` to be used as path, rather than `/metrics` with query `?version=v1`.

Added a test to cover this.


## Linear Ticket

Resolves PIPE-2062
https://linear.app/rudderstack/issue/PIPE-2062/fix-reporting-client-path-with-query


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
