### PR TITLE
fix: warehouse transformer uploader

### DIFF
--- a/processor/internal/transformer/destination_transformer/destination_transformer.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer.go
@@ -402,9 +402,7 @@ func (c *Client) Transform(ctx context.Context, clientEvents []types.Transformer
 	if _, ok := warehouseutils.WarehouseDestinationMap[destType]; ok && c.config.warehouseTransformations.enable.Load() {
 		if c.config.warehouseTransformations.verify.Load() {
 			legacyResponse := c.transform(ctx, clientEvents)
-			go func() {
-				c.warehouseClient.CompareResponsesAndUpload(ctx, clientEvents, legacyResponse)
-			}()
+			c.warehouseClient.CompareResponsesAndUpload(ctx, clientEvents, legacyResponse)
 			return legacyResponse
 		}
 		return c.warehouseClient.Transform(ctx, clientEvents)


### PR DESCRIPTION
# Description

- Use a go-routine when you only need to compare and upload. In case of early return, no need for a go-routine.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
