### PR TITLE
chore: revert use account to decide oauth type of a destination

### DIFF
--- a/router/factory.go
+++ b/router/factory.go
@@ -50,7 +50,6 @@ func (f *Factory) New(destination *backendconfig.DestinationT) *Handle {
 		f.Debugger,
 		f.ThrottlerFactory,
 		f.PendingEventsRegistry,
-		destination.DeliveryAccount,
 	)
 	return r
 }

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -31,8 +31,6 @@ import (
 	"github.com/rudderlabs/rudder-server/rruntime"
 	destinationdebugger "github.com/rudderlabs/rudder-server/services/debugger/destination"
 	"github.com/rudderlabs/rudder-server/services/oauth"
-	oauthv2 "github.com/rudderlabs/rudder-server/services/oauth/v2"
-	common "github.com/rudderlabs/rudder-server/services/oauth/v2/common"
 	"github.com/rudderlabs/rudder-server/services/rmetrics"
 	"github.com/rudderlabs/rudder-server/services/rsources"
 	transformerFeaturesService "github.com/rudderlabs/rudder-server/services/transformer"
@@ -55,7 +53,6 @@ func (rt *Handle) Setup(
 	debugger destinationdebugger.DestinationDebugger,
 	throttlerFactory throttler.Factory,
 	pendingEventsRegistry rmetrics.PendingEventsRegistry,
-	account *backendconfig.AccountWithDefinition,
 ) {
 	rt.backendConfig = backendConfig
 	rt.debugger = debugger
@@ -133,12 +130,7 @@ func (rt *Handle) Setup(
 		rt.reloadableConfig.oauthV2ExpirationTimeDiff,
 		rt.transformerFeaturesService,
 	)
-	destination := oauthv2.DestinationInfo{
-		Config:  destinationDefinition.Config,
-		Account: account,
-	}
-
-	rt.isOAuthDestination, _ = destination.IsOAuthDestination(common.RudderFlowDelivery)
+	rt.isOAuthDestination = oauth.IsOAuthDestination(destinationDefinition.Config)
 	rt.oauth = oauth.NewOAuthErrorHandler(backendConfig)
 
 	rt.isBackendConfigInitialized = false

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -526,7 +526,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 		})
 	})
@@ -557,7 +556,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 
 			gaPayload := `{"body": {"XML": {}, "FORM": {}, "JSON": {}}, "type": "REST", "files": {}, "method": "POST", "params": {"t": "event", "v": "1", "an": "RudderAndroidClient", "av": "1.0", "ds": "android-sdk", "ea": "Demo Track", "ec": "Demo Category", "el": "Demo Label", "ni": 0, "qt": 59268380964, "ul": "en-US", "cid": "anon_id", "tid": "UA-185645846-1", "uip": "[::1]", "aiid": "com.rudderlabs.android.sdk"}, "userId": "anon_id", "headers": {}, "version": "1", "endpoint": "https://www.google-analytics.com/collect"}`
@@ -662,7 +660,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 
 			mockNetHandle := mocksRouter.NewMockNetHandle(c.mockCtrl)
@@ -763,7 +760,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 			mockNetHandle := mocksRouter.NewMockNetHandle(c.mockCtrl)
 			router.netHandle = mockNetHandle
@@ -855,7 +851,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 			mockNetHandle := mocksRouter.NewMockNetHandle(c.mockCtrl)
 			router.netHandle = mockNetHandle
@@ -948,7 +943,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 			router.netHandle = mockNetHandle
 
@@ -1061,7 +1055,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 			router.netHandle = mockNetHandle
 
@@ -1182,7 +1175,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 			router.transformer = mockTransformer
 			router.noOfWorkers = 1
@@ -1294,7 +1286,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 
 			router.transformer = mockTransformer
@@ -1461,7 +1452,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 
 			router.transformer = mockTransformer
@@ -1652,7 +1642,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 			router.transformer = mockTransformer
 			router.noOfWorkers = 1
@@ -1875,7 +1864,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 			router.transformer = mockTransformer
 			router.noOfWorkers = 1
@@ -2056,7 +2044,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			router.transformer = mockTransformer
@@ -2229,7 +2216,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			router.transformer = mockTransformer
@@ -2389,7 +2375,6 @@ var _ = Describe("router", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 			mockTransformer := mocksTransformer.NewMockTransformer(c.mockCtrl)
 			router.transformer = mockTransformer

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -232,7 +232,6 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 				WorkspaceID:      transformMessageCopy.Data[0].JobMetadata.WorkspaceID,
 				DefinitionName:   transformMessageCopy.Data[0].Destination.DestinationDefinition.Name,
 				ID:               transformMessageCopy.Data[0].Destination.ID,
-				Account:          transformMessageCopy.Data[0].Destination.DeliveryAccount,
 			}
 			req = req.WithContext(cntx.CtxWithDestInfo(req.Context(), destinationInfo))
 			resp, err = trans.clientOAuthV2.Do(req)

--- a/router/worker.go
+++ b/router/worker.go
@@ -803,7 +803,6 @@ func (w *worker) proxyRequest(ctx context.Context, destinationJob types.Destinat
 			WorkspaceID:      destinationJob.Destination.WorkspaceID,
 			DefinitionName:   destinationJob.Destination.DestinationDefinition.Name,
 			ID:               destinationJob.Destination.ID,
-			Account:          destinationJob.Destination.DeliveryAccount,
 		},
 		Connection: destinationJob.Connection,
 		Adapter:    transformer.NewTransformerProxyAdapter(w.rt.transformerFeaturesService.TransformerProxyVersion(), w.rt.logger),

--- a/router/worker_test.go
+++ b/router/worker_test.go
@@ -226,7 +226,6 @@ var _ = Describe("Proxy Request", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 			router.transformer = mockTransformer
 
@@ -331,7 +330,6 @@ var _ = Describe("Proxy Request", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 			router.transformer = mockTransformer
 
@@ -443,7 +441,6 @@ var _ = Describe("Proxy Request", func() {
 				destinationdebugger.NewNoOpService(),
 				throttler.NewNoOpThrottlerFactory(),
 				rmetrics.NewPendingEventsRegistry(),
-				nil,
 			)
 			router.transformer = mockTransformer
 

--- a/services/oauth/v2/destination_info.go
+++ b/services/oauth/v2/destination_info.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/samber/lo"
 
-	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/services/oauth"
 	"github.com/rudderlabs/rudder-server/services/oauth/v2/common"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -17,17 +16,9 @@ type DestinationInfo struct {
 	DefinitionConfig map[string]interface{}
 	ID               string
 	Config           map[string]interface{}
-	Account          *backendconfig.AccountWithDefinition
 }
 
 func (d *DestinationInfo) IsOAuthDestination(flow common.RudderFlow) (bool, error) {
-	if d.Account != nil {
-		authValue, ok := d.Account.AccountDefinition.Config["refreshOAuthToken"].(bool)
-		if !ok {
-			return false, nil
-		}
-		return authValue, nil
-	}
 	authValue, _ := misc.NestedMapLookup(d.DefinitionConfig, "auth", "type")
 	if authValue == nil {
 		// valid use-case for non-OAuth destinations

--- a/services/oauth/v2/destination_info_test.go
+++ b/services/oauth/v2/destination_info_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	v2 "github.com/rudderlabs/rudder-server/services/oauth/v2"
 	"github.com/rudderlabs/rudder-server/services/oauth/v2/common"
 )
@@ -21,7 +20,6 @@ type destInfoTestCase struct {
 	flow           common.RudderFlow
 	inputDefConfig map[string]interface{}
 	expected       isOAuthResult
-	account        *backendconfig.AccountWithDefinition
 }
 
 var isOAuthDestTestCases = []destInfoTestCase{
@@ -111,77 +109,6 @@ var isOAuthDestTestCases = []destInfoTestCase{
 			isOAuth: false,
 		},
 	},
-	{
-		description:    "success scenario for a oauth destination where account is present",
-		flow:           common.RudderFlowDelivery,
-		inputDefConfig: map[string]interface{}{},
-		account: &backendconfig.AccountWithDefinition{
-			AccountDefinition: backendconfig.AccountDefinition{
-				Config: map[string]interface{}{
-					"refreshOAuthToken": true,
-				},
-			},
-		},
-		expected: isOAuthResult{
-			isOAuth: true,
-		},
-	},
-	{
-		description:    "success scenario for a non-oauth destination where account is not present",
-		flow:           common.RudderFlowDelivery,
-		inputDefConfig: map[string]interface{}{},
-		account:        nil,
-		expected: isOAuthResult{
-			isOAuth: false,
-		},
-	},
-	{
-		description:    "success scenario for a non-oauth destination where account is present",
-		flow:           common.RudderFlowDelivery,
-		inputDefConfig: map[string]interface{}{},
-		account: &backendconfig.AccountWithDefinition{
-			AccountDefinition: backendconfig.AccountDefinition{
-				Config: map[string]interface{}{
-					"refreshOAuthToken": false,
-				},
-			},
-		},
-		expected: isOAuthResult{
-			isOAuth: false,
-		},
-	},
-	{
-		description:    "failure scenario for a oauth destination where account is present and account config is wrong",
-		flow:           common.RudderFlowDelivery,
-		inputDefConfig: map[string]interface{}{},
-		account: &backendconfig.AccountWithDefinition{
-			AccountDefinition: backendconfig.AccountDefinition{
-				Config: map[string]interface{}{
-					"refreshToken": false,
-				},
-			},
-		},
-		expected: isOAuthResult{
-			isOAuth: false,
-			err:     nil,
-		},
-	},
-	{
-		description:    "failure scenario for a oauth destination where account is present and account config is not a boolean",
-		flow:           common.RudderFlowDelivery,
-		inputDefConfig: map[string]interface{}{},
-		account: &backendconfig.AccountWithDefinition{
-			AccountDefinition: backendconfig.AccountDefinition{
-				Config: map[string]interface{}{
-					"refreshOAuthToken": `{"foo":"bar"}`,
-				},
-			},
-		},
-		expected: isOAuthResult{
-			isOAuth: false,
-			err:     nil,
-		},
-	},
 }
 
 var _ = Describe("DestinationInfo tests", func() {
@@ -192,7 +119,6 @@ var _ = Describe("DestinationInfo tests", func() {
 					DefinitionName: "dest_def_name",
 				}
 				d.DefinitionConfig = tc.inputDefConfig
-				d.Account = tc.account
 				isOAuth, err := d.IsOAuthDestination(tc.flow)
 
 				Expect(isOAuth).To(Equal(tc.expected.isOAuth))


### PR DESCRIPTION
# Description

reverting #5810

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
