### PR TITLE
feat: update isOauthFunction to consider account to decide

### DIFF
--- a/services/oauth/v2/destination_info.go
+++ b/services/oauth/v2/destination_info.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/samber/lo"
 
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/services/oauth"
 	"github.com/rudderlabs/rudder-server/services/oauth/v2/common"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -16,12 +17,19 @@ type DestinationInfo struct {
 	DefinitionConfig map[string]interface{}
 	ID               string
 	Config           map[string]interface{}
+	Account          *backendconfig.AccountWithDefinition
 }
 
 func (d *DestinationInfo) IsOAuthDestination(flow common.RudderFlow) (bool, error) {
 	authValue, _ := misc.NestedMapLookup(d.DefinitionConfig, "auth", "type")
 	if authValue == nil {
-		// valid use-case for non-OAuth destinations
+		if d.Account != nil {
+			authValue, ok := d.Account.AccountDefinition.Config["refreshOAuthToken"].(bool)
+			if !ok {
+				return false, nil
+			}
+			return authValue, nil
+		}
 		return false, nil
 	}
 	authType, ok := authValue.(string)


### PR DESCRIPTION
# Description

This changes the `IsOAuthDestination` function in services/oauth/v2/destination_info.go to consider account information when determining if a destination uses OAuth. Specifically, it:

- Adds a new field Account of type *backendconfig.AccountWithDefinition to the DestinationInfo struct
- Updates the IsOAuthDestination function to check the account's configuration for a refreshOAuthToken boolean value when the destination's definition doesn't specify an auth type

## Linear Ticket

https://linear.app/rudderstack/issue/INT-3563/drive-the-oauth-flow-based-on-accounts-information-rather-than

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
