### PR TITLE
fix: warehouse pending tables to skip

### DIFF
--- a/warehouse/internal/repo/upload_test.go
+++ b/warehouse/internal/repo/upload_test.go
@@ -1061,34 +1061,6 @@ func TestUploads_PendingTableUploads(t *testing.T) {
 		})
 	})
 
-	t.Run("should return pending table uploads", func(t *testing.T) {
-		t.Parallel()
-
-		pendingTableUploads, err := repoUpload.PendingTableUploads(context.Background(), destID, namespace, 100, now, 3)
-		require.NoError(t, err)
-		require.NotEmpty(t, pendingTableUploads)
-
-		expectedPendingTableUploads := []model.PendingTableUpload{
-			{
-				UploadID:      3,
-				DestinationID: destID,
-				Namespace:     namespace,
-				TableName:     "test_table_1",
-				Status:        "exporting_data",
-				Error:         "{}",
-			},
-			{
-				UploadID:      3,
-				DestinationID: destID,
-				Namespace:     namespace,
-				TableName:     "test_table_2",
-				Status:        "exporting_data_failed",
-				Error:         "error loading data",
-			},
-		}
-		require.ElementsMatch(t, expectedPendingTableUploads, pendingTableUploads)
-	})
-
 	t.Run("should return empty pending table uploads", func(t *testing.T) {
 		t.Parallel()
 

--- a/warehouse/internal/repo/upload_test.go
+++ b/warehouse/internal/repo/upload_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
+
 	"github.com/rudderlabs/rudder-server/jsonrs"
 	sqlmiddleware "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
@@ -862,7 +863,6 @@ func TestUploads_PendingTableUploads(t *testing.T) {
 	t.Parallel()
 
 	const (
-		uploadID    = 1
 		namespace   = "namespace"
 		destID      = "destination_id"
 		sourceID    = "source_id"
@@ -871,14 +871,22 @@ func TestUploads_PendingTableUploads(t *testing.T) {
 	)
 
 	var (
-		ctx             = context.Background()
-		db              = setupDB(t)
-		repoUpload      = repo.NewUploads(db)
-		repoTableUpload = repo.NewTableUploads(db, config.New())
-		repoStaging     = repo.NewStagingFiles(db)
+		ctx = context.Background()
+		db  = setupDB(t)
+		now = time.Date(2021, 1, 1, 0, 0, 3, 0, time.UTC)
+
+		repoUpload = repo.NewUploads(db, repo.WithNow(func() time.Time {
+			return now
+		}))
+		repoTableUpload = repo.NewTableUploads(db, config.New(), repo.WithNow(func() time.Time {
+			return now
+		}))
+		repoStaging = repo.NewStagingFiles(db, repo.WithNow(func() time.Time {
+			return now
+		}))
 	)
 
-	for _, status := range []string{"exporting_data", "aborted"} {
+	for i, status := range []string{model.ExportedData, model.Aborted, model.ExportingDataFailed, model.ExportingData, model.Waiting} {
 		file := model.StagingFile{
 			WorkspaceID:   workspaceID,
 			Location:      "s3://bucket/path/to/file",
@@ -886,14 +894,12 @@ func TestUploads_PendingTableUploads(t *testing.T) {
 			DestinationID: destID,
 			Status:        warehouseutils.StagingFileWaitingState,
 			Error:         nil,
-			FirstEventAt:  time.Now(),
-			LastEventAt:   time.Now(),
 		}.WithSchema([]byte(`{"type": "object"}`))
 
 		stagingID, err := repoStaging.Insert(ctx, &file)
 		require.NoError(t, err)
 
-		_, err = repoUpload.CreateWithStagingFiles(
+		uploadID, err := repoUpload.CreateWithStagingFiles(
 			ctx,
 			model.Upload{
 				SourceID:        sourceID,
@@ -901,54 +907,170 @@ func TestUploads_PendingTableUploads(t *testing.T) {
 				Status:          status,
 				Namespace:       namespace,
 				DestinationType: destType,
+				Priority:        100 - (i + 1),
 			},
 			[]*model.StagingFile{
 				{
 					ID:            stagingID,
 					SourceID:      sourceID,
 					DestinationID: destID,
+					FirstEventAt:  now.Add(-time.Duration(i) * time.Minute),
+					LastEventAt:   now,
 				},
 			},
 		)
 		require.NoError(t, err)
+
+		for ti, tu := range []struct {
+			status string
+			err    string
+		}{
+			{
+				status: "exporting_data",
+				err:    "{}",
+			},
+			{
+				status: "exporting_data_failed",
+				err:    "error loading data",
+			},
+		} {
+			tableName := fmt.Sprintf("test_table_%d", ti+1)
+
+			err := repoTableUpload.Insert(ctx, uploadID, []string{tableName})
+			require.NoError(t, err)
+
+			err = repoTableUpload.Set(ctx, uploadID, tableName, repo.TableUploadSetOptions{
+				Status: &tu.status,
+				Error:  &tu.err,
+			})
+			require.NoError(t, err)
+		}
 	}
 
-	for i, tu := range []struct {
-		status string
-		err    string
-	}{
-		{
-			status: "exporting_data",
-			err:    "{}",
-		},
-		{
-			status: "exporting_data_failed",
-			err:    "error loading data",
-		},
-	} {
-		tableName := fmt.Sprintf("test_table_%d", i+1)
+	t.Run("ordering", func(t *testing.T) {
+		t.Parallel()
 
-		err := repoTableUpload.Insert(ctx, uploadID, []string{tableName})
-		require.NoError(t, err)
+		t.Run("by first event at", func(t *testing.T) {
+			pendingTableUploads, err := repoUpload.PendingTableUploads(context.Background(), destID, namespace, 100, now.Add(-time.Duration(4)*time.Minute), 5)
+			require.NoError(t, err)
+			require.NotEmpty(t, pendingTableUploads)
 
-		err = repoTableUpload.Set(ctx, uploadID, tableName, repo.TableUploadSetOptions{
-			Status: &tu.status,
-			Error:  &tu.err,
+			expectedPendingTableUploads := []model.PendingTableUpload{
+				{
+					UploadID:      5,
+					DestinationID: destID,
+					Namespace:     namespace,
+					TableName:     "test_table_1",
+					Status:        "exporting_data",
+					Error:         "{}",
+				},
+				{
+					UploadID:      5,
+					DestinationID: destID,
+					Namespace:     namespace,
+					TableName:     "test_table_2",
+					Status:        "exporting_data_failed",
+					Error:         "error loading data",
+				},
+			}
+			require.ElementsMatch(t, expectedPendingTableUploads, pendingTableUploads)
 		})
-		require.NoError(t, err)
-	}
+
+		t.Run("by priority", func(t *testing.T) {
+			pendingTableUploads, err := repoUpload.PendingTableUploads(context.Background(), destID, namespace, 95, now, 5)
+			require.NoError(t, err)
+			require.NotEmpty(t, pendingTableUploads)
+
+			expectedPendingTableUploads := []model.PendingTableUpload{
+				{
+					UploadID:      5,
+					DestinationID: destID,
+					Namespace:     namespace,
+					TableName:     "test_table_1",
+					Status:        "exporting_data",
+					Error:         "{}",
+				},
+				{
+					UploadID:      5,
+					DestinationID: destID,
+					Namespace:     namespace,
+					TableName:     "test_table_2",
+					Status:        "exporting_data_failed",
+					Error:         "error loading data",
+				},
+			}
+			require.ElementsMatch(t, expectedPendingTableUploads, pendingTableUploads)
+		})
+
+		t.Run("by id", func(t *testing.T) {
+			pendingTableUploads, err := repoUpload.PendingTableUploads(context.Background(), destID, namespace, 100, now, 5)
+			require.NoError(t, err)
+			require.NotEmpty(t, pendingTableUploads)
+
+			expectedPendingTableUploads := []model.PendingTableUpload{
+				{
+					UploadID:      5,
+					DestinationID: destID,
+					Namespace:     namespace,
+					TableName:     "test_table_1",
+					Status:        "exporting_data",
+					Error:         "{}",
+				},
+				{
+					UploadID:      5,
+					DestinationID: destID,
+					Namespace:     namespace,
+					TableName:     "test_table_2",
+					Status:        "exporting_data_failed",
+					Error:         "error loading data",
+				},
+				{
+					UploadID:      4,
+					DestinationID: destID,
+					Namespace:     namespace,
+					TableName:     "test_table_1",
+					Status:        "exporting_data",
+					Error:         "{}",
+				},
+				{
+					UploadID:      4,
+					DestinationID: destID,
+					Namespace:     namespace,
+					TableName:     "test_table_2",
+					Status:        "exporting_data_failed",
+					Error:         "error loading data",
+				},
+				{
+					UploadID:      3,
+					DestinationID: destID,
+					Namespace:     namespace,
+					TableName:     "test_table_1",
+					Status:        "exporting_data",
+					Error:         "{}",
+				},
+				{
+					UploadID:      3,
+					DestinationID: destID,
+					Namespace:     namespace,
+					TableName:     "test_table_2",
+					Status:        "exporting_data_failed",
+					Error:         "error loading data",
+				},
+			}
+			require.ElementsMatch(t, expectedPendingTableUploads, pendingTableUploads)
+		})
+	})
 
 	t.Run("should return pending table uploads", func(t *testing.T) {
 		t.Parallel()
 
-		repoUpload := repo.NewUploads(db)
-		pendingTableUploads, err := repoUpload.PendingTableUploads(context.Background(), namespace, uploadID, destID)
+		pendingTableUploads, err := repoUpload.PendingTableUploads(context.Background(), destID, namespace, 100, now, 3)
 		require.NoError(t, err)
 		require.NotEmpty(t, pendingTableUploads)
 
 		expectedPendingTableUploads := []model.PendingTableUpload{
 			{
-				UploadID:      uploadID,
+				UploadID:      3,
 				DestinationID: destID,
 				Namespace:     namespace,
 				TableName:     "test_table_1",
@@ -956,7 +1078,7 @@ func TestUploads_PendingTableUploads(t *testing.T) {
 				Error:         "{}",
 			},
 			{
-				UploadID:      uploadID,
+				UploadID:      3,
 				DestinationID: destID,
 				Namespace:     namespace,
 				TableName:     "test_table_2",
@@ -964,14 +1086,13 @@ func TestUploads_PendingTableUploads(t *testing.T) {
 				Error:         "error loading data",
 			},
 		}
-		require.Equal(t, expectedPendingTableUploads, pendingTableUploads)
+		require.ElementsMatch(t, expectedPendingTableUploads, pendingTableUploads)
 	})
 
 	t.Run("should return empty pending table uploads", func(t *testing.T) {
 		t.Parallel()
 
-		repoUpload := repo.NewUploads(db)
-		pendingTableUploads, err := repoUpload.PendingTableUploads(context.Background(), namespace, int64(-1), destID)
+		pendingTableUploads, err := repoUpload.PendingTableUploads(context.Background(), destID, namespace, 100, now, 2)
 		require.NoError(t, err)
 		require.Empty(t, pendingTableUploads)
 	})
@@ -979,10 +1100,9 @@ func TestUploads_PendingTableUploads(t *testing.T) {
 	t.Run("cancelled context", func(t *testing.T) {
 		t.Parallel()
 
-		repoUpload := repo.NewUploads(db)
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		_, err := repoUpload.PendingTableUploads(ctx, namespace, uploadID, destID)
+		_, err := repoUpload.PendingTableUploads(ctx, destID, namespace, 100, now, 1)
 		require.ErrorIs(t, err, context.Canceled)
 	})
 }

--- a/warehouse/router/state_export_data.go
+++ b/warehouse/router/state_export_data.go
@@ -140,9 +140,11 @@ func (job *UploadJob) TablesToSkip() (map[string]model.PendingTableUpload, map[s
 	job.pendingTableUploadsOnce.Do(func() {
 		job.pendingTableUploads, job.pendingTableUploadsError = job.pendingTableUploadsRepo.PendingTableUploads(
 			job.ctx,
-			job.upload.Namespace,
-			job.upload.ID,
 			job.upload.DestinationID,
+			job.upload.Namespace,
+			job.upload.Priority,
+			job.upload.FirstEventAt,
+			job.upload.ID,
 		)
 	})
 

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -127,7 +127,7 @@ type UploadJob struct {
 }
 
 type pendingTableUploadsRepo interface {
-	PendingTableUploads(ctx context.Context, namespace string, uploadID int64, destID string) ([]model.PendingTableUpload, error)
+	PendingTableUploads(ctx context.Context, destID, namespace string, priority int, firstEventAt time.Time, uploadID int64) ([]model.PendingTableUpload, error)
 }
 
 var (

--- a/warehouse/router/upload_test.go
+++ b/warehouse/router/upload_test.go
@@ -507,7 +507,7 @@ type mockPendingTablesRepo struct {
 	called        int
 }
 
-func (m *mockPendingTablesRepo) PendingTableUploads(context.Context, string, int64, string) ([]model.PendingTableUpload, error) {
+func (m *mockPendingTablesRepo) PendingTableUploads(context.Context, string, string, int, time.Time, int64) ([]model.PendingTableUpload, error) {
 	m.called++
 	return m.pendingTables, m.err
 }


### PR DESCRIPTION
# Description

- While picking up jobs we are relying on picking jobs via [COALESCE(metadata->>'priority', '100')::int ASC, COALESCE(first_event_at, NOW()) ASC, id ASC) AS row_number](https://github.com/rudderlabs/rudder-server/blob/6232755882293157539ad003f11eb7bbc67c2a78/warehouse/internal/repo/upload.go#L300-L319).
- Same thing this needs to be done while getting PendingTableUploads, so as to avoid dependency for skipping table uploads.
- Modified query still using the existing indexes.
  ```
  Sort  (cost=16.95..16.96 rows=1 width=522)
  --
  Sort Key: ((COALESCE((ut.metadata ->> 'priority'::text), '100'::text))::integer), (COALESCE((ut.first_event_at)::timestamp with time zone, now())), ut.id
  ->  Nested Loop  (cost=0.43..16.94 rows=1 width=522)
  ->  Nested Loop  (cost=0.29..16.36 rows=1 width=550)
  ->  Index Scan using wh_uploads_destination_id_namespace_index on wh_uploads ut  (cost=0.14..8.19 rows=1 width=340)
  Index Cond: (((destination_id)::text = 'destination_id'::text) AND ((namespace)::text = 'namespace'::text))
  Filter: (((status)::text <> 'exported_data'::text) AND ((status)::text <> 'aborted'::text) AND (id <= 5) AND (COALESCE((first_event_at)::timestamp with time zone, now()) <= '2021-01-01 00:00:00+00'::timestamp with time zone) AND ((COALESCE((metadata ->> 'priority'::text), '100'::text))::integer <= 100))
  ->  Index Scan using wh_table_uploads_wh_upload_id_status_index on wh_table_uploads tu  (cost=0.14..8.16 rows=1 width=218)
  Index Cond: (wh_upload_id = ut.id)
  ->  Index Only Scan using unique_table_upload_wh_upload on wh_table_uploads tu1  (cost=0.14..0.36 rows=1 width=32)
  Index Cond: ((wh_upload_id = 5) AND (table_name = tu.table_name))
  ```
  
  ```
  Sort  (cost=16.92..16.93 rows=1 width=510)
  --
  Sort Key: ut.id
  ->  Nested Loop  (cost=0.43..16.91 rows=1 width=510)
  ->  Nested Loop  (cost=0.29..16.34 rows=1 width=510)
  ->  Index Scan using wh_uploads_destination_id_namespace_index on wh_uploads ut  (cost=0.14..8.17 rows=1 width=300)
  Index Cond: (((destination_id)::text = 'destination_id'::text) AND ((namespace)::text = 'namespace'::text))
  Filter: ((id <= 5) AND ((status)::text <> 'exported_data'::text) AND ((status)::text <> 'aborted'::text))
  ->  Index Scan using wh_table_uploads_wh_upload_id_status_index on wh_table_uploads tu  (cost=0.14..8.16 rows=1 width=218)
  Index Cond: (wh_upload_id = ut.id)
  ->  Index Only Scan using unique_table_upload_wh_upload on wh_table_uploads tu1  (cost=0.14..0.36 rows=1 width=32)
  Index Cond: ((wh_upload_id = 5) AND (table_name = tu.table_name))
  ```

## Linear Ticket

- Resolves WAR-671

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
