### PR TITLE
chore(jobsdb): remove support for jobDoneMigrateThres

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -535,13 +535,13 @@ type Handle struct {
 		indexOptimizations             config.ValueLoader[bool] // TODO: remove this option after next release (true by default)
 
 		migration struct {
-			maxMigrateOnce, maxMigrateDSProbe          config.ValueLoader[int]
-			vacuumFullStatusTableThreshold             config.ValueLoader[int64]
-			vacuumAnalyzeStatusTableThreshold          config.ValueLoader[int64]
-			jobDoneMigrateThres, jobStatusMigrateThres config.ValueLoader[float64]
-			jobMinRowsLeftMigrateThreshold             config.ValueLoader[float64]
-			migrateDSLoopSleepDuration                 config.ValueLoader[time.Duration]
-			migrateDSTimeout                           config.ValueLoader[time.Duration]
+			maxMigrateOnce, maxMigrateDSProbe config.ValueLoader[int]
+			vacuumFullStatusTableThreshold    config.ValueLoader[int64]
+			vacuumAnalyzeStatusTableThreshold config.ValueLoader[int64]
+			jobStatusMigrateThres             config.ValueLoader[float64]
+			jobMinRowsLeftMigrateThreshold    config.ValueLoader[float64]
+			migrateDSLoopSleepDuration        config.ValueLoader[time.Duration]
+			migrateDSTimeout                  config.ValueLoader[time.Duration]
 		}
 		backup struct {
 			masterBackupEnabled config.ValueLoader[bool]
@@ -940,8 +940,6 @@ func (jd *Handle) loadConfig() {
 	// migrateDSLoopSleepDuration: How often is the loop (which checks for migrating DS) run
 	jd.conf.migration.migrateDSLoopSleepDuration = jd.config.GetReloadableDurationVar(30, time.Second, jd.configKeys("migrateDSLoopSleepDuration", "migrateDSLoopSleepDurationInS")...)
 	jd.conf.migration.migrateDSTimeout = jd.config.GetReloadableDurationVar(10, time.Minute, jd.configKeys("migrateDS.timeout")...)
-	// jobDoneMigrateThres: A DS is migrated when this fraction of the jobs have been processed
-	jd.conf.migration.jobDoneMigrateThres = jd.config.GetReloadableFloat64Var(0.8, jd.configKeys("jobDoneMigrateThreshold")...)
 	// jobStatusMigrateThres: A DS is migrated if the job_status exceeds this (* no_of_jobs)
 	jd.conf.migration.jobStatusMigrateThres = jd.config.GetReloadableFloat64Var(3, jd.configKeys("jobStatusMigrateThreshold")...)
 	// jobMinRowsLeftMigrateThreshold: A DS with a low number of pending rows should be eligible for migration if the number of pending rows are

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -663,7 +663,7 @@ func (jd *Handle) checkIfMigrateDS(ds dataSetT) (
 
 	needsPair = recordsLeft > 0 && float64(recordsLeft) < jd.conf.migration.jobMinRowsLeftMigrateThreshold.Load()*float64(jd.conf.MaxDSSize.Load())
 
-	if needsPair || recordsLeft == 0 || float64(delCount)/float64(totalCount) >= jd.conf.migration.jobDoneMigrateThres.Load() {
+	if needsPair || recordsLeft == 0 {
 		return true, needsPair, recordsLeft, nil
 	}
 


### PR DESCRIPTION
# Description

This configuration option is already disabled in production (by setting it to 1). Removing it, since the cost of migrating pending jobs without reducing the number of datasets is not worth taking.

**Coming next:** Avoid migrating a small and incomplete dataset (needing a pair) if all other datasets to be migrated are complete (without pending jobs). E.g. if dataset1 is complete and dataset2 needs a pair, only dataset1 will be migrated/deleted. Dataset2 will only be migrated if there is another dataset3 that needs a pair too.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
