### PR TITLE
fix: warehouse transformations

### DIFF
--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/datatype.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/datatype.go
@@ -1,11 +1,12 @@
 package warehouse
 
 import (
-	"unicode/utf8"
+	"fmt"
+	"math/big"
 
 	"github.com/samber/lo"
 
-	"github.com/rudderlabs/rudder-server/jsonrs"
+	"github.com/rudderlabs/rudder-server/internal/enricher"
 	"github.com/rudderlabs/rudder-server/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/model"
 	"github.com/rudderlabs/rudder-server/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils"
 	"github.com/rudderlabs/rudder-server/processor/types"
@@ -43,7 +44,9 @@ func primitiveType(val any) string {
 func getFloatType(v float64) string {
 	// JSON unmarshalling treats all numbers as float64 by default, even if they are whole numbers
 	// So, we need to check if the float is actually an integer
-	if v == float64(int64(v)) {
+	// We are using Number.isInteger(val) for detecting whether datatype is int or float in rudder-transformer
+	// which has higher range then what we have in Golang (9223372036854775807), therefore using big package for determining the type
+	if big.NewFloat(v).IsInt() {
 		return model.IntDataType
 	}
 	return model.FloatDataType
@@ -83,11 +86,14 @@ func overrideForRedshift(val any, isJSONKey bool) string {
 func shouldUseTextForRedshift(data any) bool {
 	switch v := data.(type) {
 	case []any, []types.ValidationError, map[string]any:
-		if jsonVal, _ := jsonrs.Marshal(v); utf8.RuneCount(jsonVal) > redshiftStringLimit {
+		jsonVal, _ := utils.MarshalJSON(v)
+		// Javascript strings are UTF-16 encoded, use utf16 instead of utf8 package for determining the length
+		if utils.UTF16RuneCountInString(string(jsonVal)) > redshiftStringLimit {
 			return true
 		}
 	case string:
-		if utf8.RuneCountInString(v) > redshiftStringLimit {
+		// Javascript strings are UTF-16 encoded, use utf16 instead of utf8 package for determining the length
+		if utils.UTF16RuneCountInString(v) > redshiftStringLimit {
 			return true
 		}
 	}
@@ -141,4 +147,59 @@ func convertToSliceIfViolationErrors(val any) any {
 		return result
 	}
 	return val
+}
+
+func addDataAndMetadataForContextGeoEnrichment(tec *transformEventContext, data map[string]any, metadata map[string]string, key string, val any) error {
+	if geoLocation, ok := val.(enricher.Geolocation); ok {
+		if len(geoLocation.IP) > 0 {
+			ipKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_ip"))
+			if err != nil {
+				return fmt.Errorf("could not get ip column name: %w", err)
+			}
+			data[ipKey], metadata[ipKey] = geoLocation.IP, model.StringDataType
+		}
+		if len(geoLocation.City) > 0 {
+			cityKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_city"))
+			if err != nil {
+				return fmt.Errorf("could not get city column name: %w", err)
+			}
+			data[cityKey], metadata[cityKey] = geoLocation.City, model.StringDataType
+		}
+		if len(geoLocation.Country) > 0 {
+			countryKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_country"))
+			if err != nil {
+				return fmt.Errorf("could not get country column name: %w", err)
+			}
+			data[countryKey], metadata[countryKey] = geoLocation.Country, model.StringDataType
+		}
+		if len(geoLocation.Region) > 0 {
+			regionKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_region"))
+			if err != nil {
+				return fmt.Errorf("could not get region column name: %w", err)
+			}
+			data[regionKey], metadata[regionKey] = geoLocation.Region, model.StringDataType
+		}
+		if len(geoLocation.Postal) > 0 {
+			postalKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_postal"))
+			if err != nil {
+				return fmt.Errorf("could not get postal column name: %w", err)
+			}
+			data[postalKey], metadata[postalKey] = geoLocation.Postal, model.StringDataType
+		}
+		if len(geoLocation.Location) > 0 {
+			locationKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_location"))
+			if err != nil {
+				return fmt.Errorf("could not get location column name: %w", err)
+			}
+			data[locationKey], metadata[locationKey] = geoLocation.Location, model.StringDataType
+		}
+		if len(geoLocation.Timezone) > 0 {
+			timezoneKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_timezone"))
+			if err != nil {
+				return fmt.Errorf("could not get timezone column name: %w", err)
+			}
+			data[timezoneKey], metadata[timezoneKey] = geoLocation.Timezone, model.StringDataType
+		}
+	}
+	return nil
 }

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/datatype_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/datatype_test.go
@@ -35,6 +35,7 @@ func TestDataType(t *testing.T) {
 	}{
 		// Primitive types
 		{"Primitive Type Int", whutils.POSTGRES, "someKey", 42, false, "int"},
+		{"Primitive Type Big Int", whutils.POSTGRES, "someKey", float64(654645465456456400000), false, "int"},
 		{"Primitive Type Float(64)", whutils.POSTGRES, "someKey", 42.0, false, "int"},
 		{"Primitive Type Float(32)", whutils.POSTGRES, "someKey", float32(42.0), false, "int"},
 		{"Primitive Type Float(non-int)", whutils.POSTGRES, "someKey", 42.5, false, "float"},

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/events.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/events.go
@@ -236,9 +236,7 @@ func (t *Transformer) extractCommonProps(tec *transformEventContext) (map[string
 	if err = setDataAndMetadataFromRules(tec, commonData, commonMetadata, rules.ExtractRules); err != nil {
 		return nil, nil, fmt.Errorf("extract: setting data and column types from rules: %w", err)
 	}
-
-	eventName, _ = commonData[eventColName].(string)
-	if utils.IsEmptyString(eventName) {
+	if len(strings.TrimSpace(utils.ToString(commonData[eventColName]))) == 0 {
 		return nil, nil, response.ErrExtractEventNameEmpty
 	}
 	return commonData, commonMetadata, nil
@@ -358,7 +356,7 @@ func (t *Transformer) identifiesResponse(tec *transformEventContext, commonData 
 
 func (t *Transformer) usersResponse(tec *transformEventContext, commonData map[string]any, commonMetadata map[string]string) ([]map[string]any, error) {
 	userID := misc.MapLookup(tec.event.Message, "userId")
-	if utils.IsEmptyString(userID) {
+	if len(strings.TrimSpace(utils.ToString(userID))) == 0 {
 		return nil, nil
 	}
 	if shouldSkipUsersTable(tec) {

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/events_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/events_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-server/internal/enricher"
 	"github.com/rudderlabs/rudder-server/processor/internal/transformer/destination_transformer"
 	"github.com/rudderlabs/rudder-server/processor/internal/transformer/destination_transformer/embedded/warehouse"
 	"github.com/rudderlabs/rudder-server/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/response"
@@ -694,6 +695,40 @@ func TestEvents(t *testing.T) {
 				},
 			},
 			{
+				name:         "identify (POSTGRES) Empty userID",
+				eventPayload: `{"type":"identify","messageId":"messageId","anonymousId":"anonymousId","userId":"","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","request_ip":"5.6.7.8","traits":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getMetadata("identify", "POSTGRES"),
+				destination: getDestination("POSTGRES", map[string]any{
+					"allowUsersContextTraits": true,
+				}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output:     identifyDefaultOutput().RemoveDataFields("user_id").RemoveColumnFields("user_id"),
+							Metadata:   getMetadata("identify", "POSTGRES"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
+			{
+				name:         "identify (POSTGRES) userID with spaces",
+				eventPayload: `{"type":"identify","messageId":"messageId","anonymousId":"anonymousId","userId":"   ","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","request_ip":"5.6.7.8","traits":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getMetadata("identify", "POSTGRES"),
+				destination: getDestination("POSTGRES", map[string]any{
+					"allowUsersContextTraits": true,
+				}),
+				expectedResponse: types.Response{
+					Events: []types.TransformerResponse{
+						{
+							Output:     identifyDefaultOutput().SetDataField("user_id", "   "),
+							Metadata:   getMetadata("identify", "POSTGRES"),
+							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
+			{
 				name:         "identify (S3_DATALAKE)",
 				eventPayload: `{"type":"identify","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","request_ip":"5.6.7.8","traits":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
 				metadata:     getMetadata("identify", "S3_DATALAKE"),
@@ -1187,6 +1222,36 @@ func TestEvents(t *testing.T) {
 							Output:     extractDefaultOutput(),
 							Metadata:   getMetadata("extract", "POSTGRES"),
 							StatusCode: http.StatusOK,
+						},
+					},
+				},
+			},
+			{
+				name:         "extract (Postgres) Empty event",
+				eventPayload: `{"type":"extract","recordId":"recordID","messageId":"messageId","event":"","receivedAt":"2021-09-01T00:00:00.000Z","properties":{"name":"Home","title":"Home | RudderStack","url":"https://www.rudderstack.com"},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getMetadata("extract", "POSTGRES"),
+				destination:  getDestination("POSTGRES", map[string]any{}),
+				expectedResponse: types.Response{
+					FailedEvents: []types.TransformerResponse{
+						{
+							Error:      response.ErrExtractEventNameEmpty.Error(),
+							StatusCode: response.ErrExtractEventNameEmpty.StatusCode(),
+							Metadata:   getMetadata("extract", "POSTGRES"),
+						},
+					},
+				},
+			},
+			{
+				name:         "extract (Postgres) Event with spaces",
+				eventPayload: `{"type":"extract","recordId":"recordID","messageId":"messageId","event":"","receivedAt":"2021-09-01T00:00:00.000Z","properties":{"name":"Home","title":"Home | RudderStack","url":"https://www.rudderstack.com"},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				metadata:     getMetadata("extract", "POSTGRES"),
+				destination:  getDestination("POSTGRES", map[string]any{}),
+				expectedResponse: types.Response{
+					FailedEvents: []types.TransformerResponse{
+						{
+							Error:      response.ErrExtractEventNameEmpty.Error(),
+							StatusCode: response.ErrExtractEventNameEmpty.StatusCode(),
+							Metadata:   getMetadata("extract", "POSTGRES"),
 						},
 					},
 				},
@@ -2863,6 +2928,54 @@ func TestEvents(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("Enrichment", func(t *testing.T) {
+		t.Run("geo", func(t *testing.T) {
+			message := map[string]any{
+				"context": map[string]any{
+					"geo": enricher.Geolocation{
+						IP:       "192.168.1.42",
+						City:     "San Francisco",
+						Country:  "US",
+						Region:   "CA",
+						Postal:   "94107",
+						Location: "37.7749,-122.4194",
+						Timezone: "America/Los_Angeles",
+					},
+				},
+				"messageId":         "messageId",
+				"originalTimestamp": "2021-09-01T00:00:00.000Z",
+				"receivedAt":        "2021-09-01T00:00:00.000Z",
+				"sentAt":            "2021-09-01T00:00:00.000Z",
+				"timestamp":         "2021-09-01T00:00:00.000Z",
+				"type":              "track",
+			}
+			for destination := range whutils.WarehouseDestinationMap {
+				t.Run(destination, func(t *testing.T) {
+					c := setupConfig(transformerResource, map[string]any{})
+
+					processorTransformer := destination_transformer.New(c, logger.NOP, stats.Default)
+					warehouseTransformer := warehouse.New(c, logger.NOP, stats.NOP)
+
+					ctx := context.Background()
+					events := []types.TransformerEvent{{
+						Message:     message,
+						Metadata:    getMetadata("track", destination),
+						Destination: getDestination(destination, map[string]any{}),
+					}}
+					legacyResponse := processorTransformer.Transform(ctx, events)
+					embeddedResponse := warehouseTransformer.Transform(ctx, events)
+
+					require.Equal(t, len(embeddedResponse.Events), len(legacyResponse.Events))
+					require.Nil(t, legacyResponse.FailedEvents)
+					require.Nil(t, embeddedResponse.FailedEvents)
+					for i := range legacyResponse.Events {
+						require.EqualValues(t, embeddedResponse.Events[i], legacyResponse.Events[i])
+					}
+				})
+			}
+		})
 	})
 
 	t.Run("Multiple fields for the same key", func(t *testing.T) {

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils/utils.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode/utf16"
 
 	"github.com/araddon/dateparse"
 	"github.com/samber/lo"
@@ -252,4 +253,13 @@ func MarshalJSON(input any) ([]byte, error) {
 		return nil, fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	return bytes.TrimSpace(buf.Bytes()), nil
+}
+
+// UTF16RuneCountInString returns the UTF-16 code unit count of the string.
+func UTF16RuneCountInString(s string) int {
+	count := 0
+	for _, r := range s {
+		count += utf16.RuneLen(r)
+	}
+	return count
 }

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils/utils_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils/utils_test.go
@@ -423,3 +423,48 @@ func TestMarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestUTF16RuneCountInString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: 0,
+		},
+		{
+			name:     "ASCII characters",
+			input:    "hello",
+			expected: 5, // All are single code units
+		},
+		{
+			name:     "BMP characters",
+			input:    "हिन्दी", // All in BMP
+			expected: len([]rune("हिन्दी")),
+		},
+		{
+			name:     "Supplementary characters (Emoji)",
+			input:    "😀", // U+1F600 is supplementary (needs surrogate pair)
+			expected: 2,
+		},
+		{
+			name:     "Mixed BMP and supplementary",
+			input:    "a😀b", // 'a' = 1, 😀 = 2, 'b' = 1
+			expected: 4,
+		},
+		{
+			name:     "Multiple supplementary characters",
+			input:    "👨‍👩‍👧‍👦",
+			expected: 11,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, UTF16RuneCountInString(tt.input))
+		})
+	}
+}

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/set.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/set.go
@@ -91,6 +91,10 @@ func addDataAndMetadata(tec *transformEventContext, key string, val any, isJSONK
 	metadata[safeKey] = dataType
 
 	switch safeKey {
+	case "context_geo", "CONTEXT_GEO":
+		if err := addDataAndMetadataForContextGeoEnrichment(tec, data, metadata, key, val); err != nil {
+			return fmt.Errorf("adding context geo enrichment: %w", err)
+		}
 	case "context_tracking_plan_version", "CONTEXT_TRACKING_PLAN_VERSION":
 		data[safeKey] = convertToFloat64IfInteger(val)
 	case "context_violation_errors", "CONTEXT_VIOLATION_ERRORS":

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/transformer.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/transformer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 
+	"github.com/rudderlabs/rudder-server/internal/enricher"
 	"github.com/rudderlabs/rudder-server/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/model"
 	"github.com/rudderlabs/rudder-server/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/response"
 	wtypes "github.com/rudderlabs/rudder-server/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/types"
@@ -41,6 +42,17 @@ var _ = struct {
 	Meta     map[string]string
 	Property string
 }(types.ValidationError{})
+
+// Compile-time check to ensure Geolocation struct remains unchanged
+var _ = struct {
+	IP       string
+	City     string
+	Country  string
+	Region   string
+	Postal   string
+	Location string
+	Timezone string
+}(enricher.Geolocation{})
 
 type Opts func(t *Transformer)
 

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader.go
@@ -124,7 +124,9 @@ func (t *Transformer) sampleDiff(events []types.TransformerEvent, legacyResponse
 		if strings.Contains(diff, "\"0001-01-01T00:00:00.000Z\"") {
 			continue
 		}
-		if strings.Contains(diff, "\"auto-\"") {
+		// If messageID's are not present, we add it in rudder-transformer
+		// https://github.com/rudderlabs/rudder-transformer/blob/develop/src/warehouse/index.js#L675-L677
+		if strings.Contains(diff, "\"auto-") {
 			continue
 		}
 		if differedEventsCount == 0 {


### PR DESCRIPTION
# Description

- In rudder-transformer, we are using `Number.isInteger` to determine for int datatype, in comparison with Golang, which has a lower range `9223372036854775807`. `654645465456456400000` is being calculated as a float in Golang and an int in JS. Using a `big` package to determine now.
- `utf16` Rune count for being in conjunction with JavaScript.
- GeoLocation enrichment struct getting embedded directly to a singular event. These need to be handled separately, like we are doing for the Tracking Plan.
- Exclude the extract event in case the event name is empty.
- Exclude the identity event in case the userID is empty. 

## Linear Ticket

- Resolves WAR-672.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
