### PR TITLE
chore: remove unused schemas repo in warehouse router

### DIFF
--- a/warehouse/router/router.go
+++ b/warehouse/router/router.go
@@ -52,7 +52,6 @@ type Router struct {
 	db           *sqlquerywrapper.DB
 	stagingRepo  *repo.StagingFiles
 	uploadRepo   *repo.Uploads
-	whSchemaRepo *repo.WHSchema
 
 	triggerStore       *sync.Map
 	createUploadAlways createUploadAlwaysLoader
@@ -145,7 +144,6 @@ func New(
 	r.db = db
 	r.stagingRepo = repo.NewStagingFiles(db)
 	r.uploadRepo = repo.NewUploads(db)
-	r.whSchemaRepo = repo.NewWHSchemas(db)
 
 	r.notifier = notifier
 	r.tenantManager = tenantManager

--- a/warehouse/router/router.go
+++ b/warehouse/router/router.go
@@ -49,9 +49,9 @@ type (
 type Router struct {
 	destType string
 
-	db           *sqlquerywrapper.DB
-	stagingRepo  *repo.StagingFiles
-	uploadRepo   *repo.Uploads
+	db          *sqlquerywrapper.DB
+	stagingRepo *repo.StagingFiles
+	uploadRepo  *repo.Uploads
 
 	triggerStore       *sync.Map
 	createUploadAlways createUploadAlwaysLoader


### PR DESCRIPTION
# Description
- Remove unused wh schemas repo in warehouse router

## Linear Ticket
Part of WAR-644

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
