### PR TITLE
fix : do not panic for invalid router payload

### DIFF
--- a/router/batchrouter/partition_worker.go
+++ b/router/batchrouter/partition_worker.go
@@ -235,8 +235,8 @@ func (pw *PartitionWorker) processAndUploadBatch(sourceID, destID string, jobs [
 		}
 	default:
 		// Handle any other destination types
-		pw.logger.Warnf("Unsupported destination type %s for job buffer. Attempting generic processing.", pw.brt.destType)
-		panic(fmt.Sprintf("Unsupported destination type %s for job buffer. Attempting generic processing.", pw.brt.destType))
+		pw.logger.Warnf("Unsupported destination type %s for job buffer.Panicing", pw.brt.destType)
+		panic(fmt.Sprintf("Unsupported destination type %s for job buffer.Panicing", pw.brt.destType))
 	}
 }
 

--- a/router/network.go
+++ b/router/network.go
@@ -83,10 +83,19 @@ func (network *netHandle) SendPost(ctx context.Context, structData integrations.
 		requestQueryParams := postInfo.QueryParams
 		var bodyFormat string
 		var bodyValue map[string]interface{}
-		for k, v := range requestBody {
-			if len(v.(map[string]interface{})) > 0 {
-				bodyFormat = k
-				bodyValue = v.(map[string]interface{})
+
+		for format, value := range requestBody {
+			bodyData, ok := value.(map[string]interface{})
+			if !ok {
+				return &utils.SendPostResponse{
+					StatusCode:   500,
+					ResponseBody: []byte("500 Invalid Router Payload: body value must be a map"),
+				}
+			}
+
+			if len(bodyData) > 0 {
+				bodyFormat = format
+				bodyValue = bodyData
 				break
 			}
 		}


### PR DESCRIPTION
# Description

This PR checks if the router payload is a valid map and continues processing only if its a valid map. If not we return an error

## Linear Ticket

Fixes PIPE-2048

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
