### PR TITLE
fix: server panicking with invalid byte sequence for encoding utf8 0x00

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -20,6 +20,7 @@ package jobsdb
 //go:generate mockgen -destination=../mocks/jobsdb/mock_jobsdb.go -package=mocks_jobsdb github.com/rudderlabs/rudder-server/jobsdb JobsDB
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -428,6 +429,7 @@ func (job *JobT) String() string {
 }
 
 func (job *JobT) sanitizeJSON() error {
+	job.UserID = string(bytes.ReplaceAll([]byte(job.UserID), []byte("\x00"), []byte("")))
 	var err error
 	job.EventPayload, err = misc.SanitizeJSON(job.EventPayload)
 	if err != nil {

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -1620,7 +1620,7 @@ type testingT interface {
 func startPostgres(t testingT) *postgres.Resource {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
-	postgresContainer, err := postgres.Setup(pool, t)
+	postgresContainer, err := postgres.Setup(pool, t, postgres.WithTag("15-alpine"))
 	require.NoError(t, err)
 	t.Setenv("LOG_LEVEL", "DEBUG")
 	t.Setenv("JOBS_DB_DB_NAME", postgresContainer.Database)

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -913,6 +913,7 @@ var jsonfast jsonrs.JSON = jsonrs.NewWithLibrary(jsonrs.JsoniterLib)
 func SanitizeJSON(input json.RawMessage) (json.RawMessage, error) {
 	// Remove null characters
 	v := bytes.ReplaceAll(input, []byte(`\u0000`), []byte(""))
+	v = bytes.ReplaceAll(v, []byte("\x00"), []byte(""))
 
 	if len(v) == 0 {
 		return []byte(`{}`), nil


### PR DESCRIPTION
# Description

- Removing null bytes while sanitizing. Previously we were only removing a unicode encoded null byte.
- Removing null bytes from UserID while sanitizing


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
