### PR TITLE
chore: move house keeping action to commit sha

### DIFF
--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -29,7 +29,7 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v4
         - name: Run delete-old-branches-action
-          uses: beatlabs/delete-old-branches-action@v0.0.11
+          uses: beatlabs/delete-old-branches-action@4eeeb8740ff8b3cb310296ddd6b43c3387734588
           with:
             repo_token: ${{ github.token }}
             date: '2 months ago'


### PR DESCRIPTION
# Description
Get the housekeeping github action back to running state
Follow the security guidelines and replace version with commit sha

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
