### PR TITLE
fix: under reporting of load files when using upload id

### DIFF
--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -492,7 +492,7 @@ func (lf *LoadFileGenerator) createUploadV2Jobs(ctx context.Context, job *model.
 		return fmt.Errorf("populating destination revision ID: %w", err)
 	}
 	g, gCtx := errgroup.WithContext(ctx)
-	stagingFileGroups := lf.GroupStagingFiles(stagingFiles, lf.Conf.GetInt("Warehouse.loadFiles.maxSizeInMB", 128))
+	stagingFileGroups := lf.GroupStagingFiles(stagingFiles, lf.Conf.GetInt("Warehouse.loadFiles.maxSizeInMB", 512))
 	for i, fileGroups := range lo.Chunk(stagingFileGroups, publishBatchSize) {
 		for j, group := range fileGroups {
 			lf.Logger.Infon("Processing chunk and group",

--- a/warehouse/internal/repo/table_upload.go
+++ b/warehouse/internal/repo/table_upload.go
@@ -194,27 +194,13 @@ func (tu *TableUploads) PopulateTotalEventsWithTx(ctx context.Context, tx *sqlmi
 	var queryArgs []any
 	if tu.queryLoadFilesWithUploadID.Load() {
 		subQuery = `
-		WITH row_numbered_load_files as (
-		  SELECT
-			total_events,
-			row_number() OVER (
-			  PARTITION BY upload_id,
-			  table_name
-			  ORDER BY
-				id DESC
-			) AS row_number
-		  FROM
-			` + loadTableName + `
-		  WHERE
-			upload_id = $1
-			AND table_name = $2
-		)
 		SELECT
 		  sum(total_events) as total
 		FROM
-		  row_numbered_load_files
+		  ` + loadTableName + `
 		WHERE
-		  row_number = 1
+		  upload_id = $1
+		AND table_name = $2
 `
 		queryArgs = []any{
 			uploadId,

--- a/warehouse/internal/repo/table_upload_test.go
+++ b/warehouse/internal/repo/table_upload_test.go
@@ -380,6 +380,10 @@ func TestTableUploadRepo(t *testing.T) {
 					TableName: tables2[i],
 					TotalRows: i + 1,
 					UploadID:  &uploadId,
+				}, model.LoadFile{
+					TableName: tables2[i],
+					TotalRows: i + 1,
+					UploadID:  &uploadId,
 				})
 			}
 			insertErr := l.Insert(ctx, loadFiles)
@@ -395,7 +399,7 @@ func TestTableUploadRepo(t *testing.T) {
 			require.NoError(t, txErr)
 			for _, loadFile := range loadFiles {
 				tableName := loadFile.TableName
-				expectedTotal := int64(loadFile.TotalRows)
+				expectedTotal := 2 * int64(loadFile.TotalRows) // Since there are 2 load files for each table
 				tableUpload, getErr := r.GetByUploadIDAndTableName(ctx, uploadId, tableName)
 				require.NoError(t, getErr)
 				require.Equal(t, uploadId, tableUpload.UploadID)

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -859,27 +859,14 @@ func (job *UploadJob) GetLoadFilesMetadata(ctx context.Context, options whutils.
 func (job *UploadJob) getLoadFilesMetadataQuery(tableFilterSQL, limitSQL string) string {
 	if job.config.queryLoadFilesWithUploadID.Load() {
 		return fmt.Sprintf(`
-			WITH row_numbered_load_files as (
-			  SELECT
-				location,
-				metadata,
-				row_number() OVER (
-				PARTITION BY upload_id,
-				table_name
-				ORDER BY
-					id DESC
-				) AS row_number
-			  FROM
-				%[1]s
-			  WHERE upload_id = %[2]d %[3]s
-			)
 			SELECT
 			  location,
 			  metadata
 			FROM
-			  row_numbered_load_files
+			  %[1]s
 			WHERE
-			  row_number = 1
+			  upload_id = %[2]d
+			%[3]s
 			%[4]s;
 			`,
 			whutils.WarehouseLoadFilesTable,

--- a/warehouse/router/upload_test.go
+++ b/warehouse/router/upload_test.go
@@ -748,12 +748,33 @@ func TestUploadJob_GetLoadFilesMetadata(t *testing.T) {
 	testCases := []struct {
 		name              string
 		queryWithUploadID bool
+		tableName         string
+		limit             int64
 		expectedLoadFiles int
 	}{
 		{
 			name:              "query with upload ID",
 			queryWithUploadID: true,
+			expectedLoadFiles: 4,
+		},
+		{
+			name:              "query with upload ID and table name",
+			queryWithUploadID: true,
+			tableName:         "test_table2",
+			expectedLoadFiles: 3,
+		},
+		{
+			name:              "query with upload ID, table name and limit",
+			queryWithUploadID: true,
+			tableName:         "test_table2",
+			limit:             2,
 			expectedLoadFiles: 2,
+		},
+		{
+			name:              "query with upload ID and limit",
+			queryWithUploadID: true,
+			limit:             1,
+			expectedLoadFiles: 1,
 		},
 		{
 			name:              "query with staging file IDs",
@@ -791,10 +812,21 @@ func TestUploadJob_GetLoadFilesMetadata(t *testing.T) {
 					UploadID:  &job.upload.ID,
 					TableName: "test_table2",
 				},
+				{
+					UploadID:  &job.upload.ID,
+					TableName: "test_table2",
+				},
+				{
+					UploadID:  &job.upload.ID,
+					TableName: "test_table2",
+				},
 			}
 			err := repo.NewLoadFiles(db, conf).Insert(ctx, loadFiles)
 			require.NoError(t, err)
-			result, err := job.GetLoadFilesMetadata(ctx, warehouseutils.GetLoadFilesOptions{})
+			result, err := job.GetLoadFilesMetadata(ctx, warehouseutils.GetLoadFilesOptions{
+				Table: tc.tableName,
+				Limit: tc.limit,
+			})
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedLoadFiles, len(result))
 		})


### PR DESCRIPTION
# Description

**BUG** - Using partition by on (upload_id, table_name) was picking only one file per table even though there exists multiple files per table

**FIX** - Now we are picking all the files for the given upload_id. Any load files generated in a previous attempt gets deleted so we need not worry about that

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
