### PR TITLE
fix: error gathering metrics, metric was collected before with the same name and label values

### DIFF
--- a/processor/internal/transformer/destination_transformer/destination_transformer.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer.go
@@ -218,8 +218,8 @@ func (d *Client) transform(ctx context.Context, clientEvents []types.Transformer
 		}
 	}
 
-	d.stat.NewStat("processor.transformer_sent", stats.CountType).Count(len(clientEvents))
-	d.stat.NewStat("processor.transformer_received", stats.CountType).Count(len(outClientEvents))
+	d.stat.NewStat("processor_transformer_sent", stats.CountType).Count(len(clientEvents))
+	d.stat.NewStat("processor_transformer_received", stats.CountType).Count(len(outClientEvents))
 
 	return types.Response{
 		Events:       outClientEvents,

--- a/processor/internal/transformer/trackingplan_validation/trackingplan_validation.go
+++ b/processor/internal/transformer/trackingplan_validation/trackingplan_validation.go
@@ -139,8 +139,8 @@ func (t *Client) Validate(ctx context.Context, clientEvents []types.TransformerE
 		}
 	}
 
-	t.stat.NewStat("processor.transformer_sent", stats.CountType).Count(len(clientEvents))
-	t.stat.NewStat("processor.transformer_received", stats.CountType).Count(len(outClientEvents))
+	t.stat.NewStat("processor_transformer_sent", stats.CountType).Count(len(clientEvents))
+	t.stat.NewStat("processor_transformer_received", stats.CountType).Count(len(outClientEvents))
 
 	return types.Response{
 		Events:       outClientEvents,

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -213,10 +213,10 @@ func (u *Client) sendBatch(ctx context.Context, url string, labels types.Transfo
 				panic(err)
 			}
 			if statusCode == transformerutils.StatusCPDown {
-				u.stat.NewStat("processor.control_plane_down", stats.GaugeType).Gauge(1)
+				u.stat.NewStat("processor_control_plane_down", stats.GaugeType).Gauge(1)
 				return fmt.Errorf("control plane not reachable")
 			}
-			u.stat.NewStat("processor.control_plane_down", stats.GaugeType).Gauge(0)
+			u.stat.NewStat("processor_control_plane_down", stats.GaugeType).Gauge(0)
 			return nil
 		},
 		endlessBackoff,


### PR DESCRIPTION
# Description

Renaming remaining dot (.) notated metrics

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
