### PR TITLE
test: add test case for dynamic config pattern with numeric default value

### DIFF
--- a/backend-config/dynamicconfig/utils_test.go
+++ b/backend-config/dynamicconfig/utils_test.go
@@ -58,6 +58,13 @@ func TestContainsPattern(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "pattern with number as default value",
+			input: map[string]interface{}{
+				"timeout": "{{ message.traits.key || 1233 }}",
+			},
+			expected: true,
+		},
+		{
 			name: "no patterns",
 			input: map[string]interface{}{
 				"key": "normal string",


### PR DESCRIPTION
## Summary

Adds a test case for dynamic config patterns that use numeric default values.

## Changes

- Added test case for pattern `{{ message.traits.key || 1233 }}`
- Ensures `ContainsPattern` function correctly identifies patterns with numeric defaults
- Improves test coverage for dynamic config pattern detection

## Testing

The new test case verifies that dynamic config patterns with numeric default values are properly detected by the `ContainsPattern` function.

## Type of Change

- [x] Test improvement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Resolves INT-3633

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author