### PR TITLE
test: flakiness in upload jobs count

### DIFF
--- a/integration_test/warehouse/warehouse_test.go
+++ b/integration_test/warehouse/warehouse_test.go
@@ -154,12 +154,6 @@ func TestUploads(t *testing.T) {
 					{A: "wh_uploads.destination_id", B: destinationID},
 					{A: "wh_uploads.namespace", B: namespace},
 				}...)
-				requireUploadJobsCount(t, ctx, db, jobs, []lo.Tuple2[string, any]{
-					{A: "source_id", B: sourceID},
-					{A: "destination_id", B: destinationID},
-					{A: "namespace", B: namespace},
-					{A: "status", B: exportedData},
-				}...)
 				requireDownstreamEventsCount(t, ctx, db, fmt.Sprintf("%s.%s", namespace, "tracks"), 2*events)
 			})
 		}


### PR DESCRIPTION
# Description

Previously, this test created only one staging file. After this [change](https://github.com/rudderlabs/rudder-server/pull/5889/files#diff-c863a7631fe529485c78f9402cc7509921578e68f99608488592b19169517e80R144), it started generating two staging files. While the test consistently passed locally with an expected upload jobs count of 1, it would intermittently fail on CI with an error indicating the actual count was 2 instead of 1.

## Linear Ticket

< Replace with Linear Link ( [create](https://linear.new?title=Awesome-pr-without-linear-ticket) or [search](https://linear.app/rudderstack/search) linear ticket) or  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
