### PR TITLE
fix: bq load users table failing with unrecognised _PARTITIONTIME

### DIFF
--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -226,6 +226,7 @@ func (bq *BigQuery) createTableView(ctx context.Context, tableName string, colum
 	}
 
 	// no need to pass partitioningInWarehouse here. dedup query considers the partition column, type from the destination config
+	// should always create a view with partition column and type from destination config
 	deduplicationQuery, err := bq.deduplicationQuery(tableName, columnMap, nil)
 	if err != nil {
 		return fmt.Errorf("deduplication query: %w", err)

--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -225,6 +225,7 @@ func (bq *BigQuery) createTableView(ctx context.Context, tableName string, colum
 		return nil
 	}
 
+	// no need to pass partitioningInWarehouse here. dedup query considers the partition column, type from the destination config
 	deduplicationQuery, err := bq.deduplicationQuery(tableName, columnMap, nil)
 	if err != nil {
 		return fmt.Errorf("deduplication query: %w", err)

--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -225,7 +225,7 @@ func (bq *BigQuery) createTableView(ctx context.Context, tableName string, colum
 		return nil
 	}
 
-	deduplicationQuery, err := bq.deduplicationQuery(tableName, columnMap)
+	deduplicationQuery, err := bq.deduplicationQuery(tableName, columnMap, nil)
 	if err != nil {
 		return fmt.Errorf("deduplication query: %w", err)
 	}
@@ -248,7 +248,16 @@ func (bq *BigQuery) createTableView(ctx context.Context, tableName string, colum
 	return nil
 }
 
-func (bq *BigQuery) deduplicationQuery(tableName string, columnMap model.TableSchema) (string, error) {
+func (bq *BigQuery) fetchTablePartitionFromWarehouse(ctx context.Context, tableName string) (*bigquery.TimePartitioning, error) {
+	table := bq.db.Dataset(bq.namespace).Table(tableName)
+	meta, err := table.Metadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return meta.TimePartitioning, nil
+}
+
+func (bq *BigQuery) deduplicationQuery(tableName string, columnMap model.TableSchema, partitioningInWarehouse *bigquery.TimePartitioning) (string, error) {
 	partitionKey := "id"
 	if column, ok := partitionKeyMap[tableName]; ok {
 		partitionKey = column
@@ -263,6 +272,17 @@ func (bq *BigQuery) deduplicationQuery(tableName string, columnMap model.TableSc
 		granularity, partitionFilter   string
 		partitionColumn, partitionType = bq.partitionColumn(), bq.partitionType()
 	)
+
+	if partitioningInWarehouse != nil {
+		if partitionColumn != partitioningInWarehouse.Field {
+			bq.logger.Warnn("partition column mismatch in config and warehouse",
+				logger.NewStringField("partitionColumnInConfig", partitionColumn),
+				logger.NewStringField("partitionColumnInWarehouse", partitioningInWarehouse.Field),
+			)
+		}
+		partitionColumn = partitioningInWarehouse.Field
+		partitionType = strings.ToLower(string(partitioningInWarehouse.Type))
+	}
 
 	if partitionColumn == "" || partitionType == "" {
 		granularity = "DAY"
@@ -659,9 +679,17 @@ func (bq *BigQuery) LoadUserTables(ctx context.Context) (errorMap map[string]err
 		firstValProps = append(firstValProps, firstValueSQL(colName))
 	}
 
+	usersTablePartitionInWarehouse, err := bq.fetchTablePartitionFromWarehouse(ctx, warehouseutils.UsersTable)
+	if err != nil {
+		log.Warnn("Fetching partitioning for users table", obskit.Error(err))
+		errorMap[warehouseutils.UsersTable] = fmt.Errorf("fetching partitioning for users table: %w", err)
+		return
+	}
+
 	deduplicationQuery, err := bq.deduplicationQuery(
 		warehouseutils.UsersTable,
 		bq.uploader.GetTableSchemaInUpload(warehouseutils.UsersTable),
+		usersTablePartitionInWarehouse,
 	)
 	if err != nil {
 		log.Warnn("Deduplication query for users table", obskit.Error(err))
@@ -688,7 +716,9 @@ func (bq *BigQuery) LoadUserTables(ctx context.Context) (errorMap map[string]err
 
 	log.Infon("Loading data")
 	var partitionedUsersTable string
-	if bq.avoidPartitionDecorator() {
+
+	// avoid writing to partioned table if there is a no or custom partition instead of ingestion time partition i.e _PARTITIONTIME
+	if bq.avoidPartitionDecorator() || usersTablePartitionInWarehouse == nil || usersTablePartitionInWarehouse.Field != "" {
 		partitionedUsersTable = warehouseutils.UsersTable
 	} else {
 		partitionedUsersTable = partitionedTable(warehouseutils.UsersTable, identifyLoadTable.partitionDate)

--- a/warehouse/integrations/bigquery/bigquery_test.go
+++ b/warehouse/integrations/bigquery/bigquery_test.go
@@ -839,7 +839,7 @@ func TestIntegration(t *testing.T) {
 			{
 				name: "partitionColumn: received_at, partitionType: day",
 				configOverride: map[string]any{
-					"partitionColumn": "loaded_at",
+					"partitionColumn": "received_at",
 					"partitionType":   "day",
 				},
 			},

--- a/warehouse/integrations/bigquery/bigquery_test.go
+++ b/warehouse/integrations/bigquery/bigquery_test.go
@@ -586,6 +586,90 @@ func TestIntegration(t *testing.T) {
 					require.ElementsMatch(t, groupsRecords, whth.UploadJobGroupsAppendRecords(userIDFormat, sourceID, destinationID, destType))
 				},
 			},
+			{
+				name:   "Append mode with default config (partitionColumn: _PARTITIONTIME, partitionType: day), users table partitioning altered to received_at",
+				tables: []string{"identifies", "users", "tracks", "product_track", "pages", "screens", "aliases", "_groups"},
+				warehouseEventsMap2: whth.EventsCountMap{
+					// For all tables we will be appending because of preferAppend config
+					"identifies": 8, "users": 2, "tracks": 8, "product_track": 8, "pages": 8, "screens": 8, "aliases": 8, "_groups": 8,
+				},
+				stagingFilePath1: "../testdata/upload-job.events-1.json",
+				stagingFilePath2: "../testdata/upload-job.events-1.json",
+				useSameUserID:    true,
+				preLoading: func(t testing.TB, ctx context.Context, db *bigquery.Client, namespace string) {
+					t.Helper()
+					err := db.Dataset(namespace).Create(context.Background(), &bigquery.DatasetMetadata{
+						Location: "US",
+					})
+					require.NoError(t, err)
+					usersTable := db.Dataset(namespace).Table("users")
+
+					err = usersTable.Create(context.Background(), &bigquery.TableMetadata{
+						Schema: []*bigquery.FieldSchema{
+							{Name: "received_at", Type: bigquery.TimestampFieldType},
+						},
+						TimePartitioning: &bigquery.TimePartitioning{
+							Field: "received_at",
+							Type:  bigquery.DayPartitioningType,
+						},
+					})
+					require.NoError(t, err)
+				},
+				postLoading: func(t testing.TB, ctx context.Context, db *bigquery.Client, namespace string) {
+					t.Helper()
+
+					checkTables := []string{"identifies", "users", "tracks", "product_track", "pages", "screens", "aliases", "_groups"}
+
+					tables := listTables(t, ctx, db, namespace)
+					filteredTables := lo.Filter(tables, func(table *bigquery.TableMetadata, _ int) bool {
+						return lo.Contains(checkTables, table.Name)
+					})
+					for _, table := range filteredTables {
+						require.NotNil(t, table.TimePartitioning)
+						// users table is recreated with different partition received_at
+						if table.Name == "users" {
+							require.Equal(t, "received_at", table.TimePartitioning.Field)
+						} else {
+							require.Empty(t, table.TimePartitioning.Field) // If empty, the table is partitioned by pseudo column '_PARTITIONTIME'
+						}
+						require.Equal(t, bigquery.DayPartitioningType, table.TimePartitioning.Type)
+					}
+
+					// not checking users view because we are not creating it again which would be using _PARTITIONTIME
+					// now that we are using received_at
+					verifyEventsUsingView(t, ctx, db, namespace, whth.EventsCountMap{
+						"identifies": 4, "tracks": 4, "product_track": 4, "pages": 4, "screens": 4, "aliases": 4, "_groups": 4,
+					})
+				},
+				configOverride: map[string]any{
+					"partitionColumn": "_PARTITIONTIME",
+					"partitionType":   "day",
+				},
+				verifySchema: func(t testing.TB, db *bigquery.Client, namespace string) {
+					t.Helper()
+					schema := bqhelper.RetrieveRecordsFromWarehouse(t, db, fmt.Sprintf(`SELECT t.table_name, c.column_name, c.data_type FROM %[1]s.INFORMATION_SCHEMA.TABLES as t LEFT JOIN %[1]s.INFORMATION_SCHEMA.COLUMNS as c ON (t.table_name = c.table_name) WHERE (t.table_type != 'VIEW') AND ( c.column_name != '_PARTITIONTIME' OR c.column_name IS NULL );`, namespace))
+					require.Equal(t, expectedUploadJobSchema, whth.ConvertRecordsToSchema(schema))
+				},
+				verifyRecords: func(t testing.TB, db *bigquery.Client, sourceID, destinationID, namespace, jobRunID, taskRunID string) {
+					t.Helper()
+					identifiesRecords := bqhelper.RetrieveRecordsFromWarehouse(t, db, fmt.Sprintf(`SELECT %s, %s, context_traits_logins, _as, name, logins, email, original_timestamp, context_ip, context_traits_as, timestamp, received_at, context_destination_type, sent_at, context_source_type, context_traits_between, context_source_id, context_traits_name, context_request_ip, _between, context_traits_email, context_destination_id, id FROM %s.%s ORDER BY id;`, userIDSQL, uuidTSSQL, namespace, "identifies"))
+					require.ElementsMatch(t, identifiesRecords, whth.UploadJobIdentifiesAppendRecords(userIDFormat, sourceID, destinationID, destType))
+					usersRecords := bqhelper.RetrieveRecordsFromWarehouse(t, db, fmt.Sprintf(`SELECT context_source_id, context_destination_type, context_request_ip, context_traits_name, context_traits_between, _as, logins, sent_at, context_traits_logins, context_ip, _between, context_traits_email, timestamp, context_destination_id, email, context_traits_as, context_source_type, SUBSTRING(id, 1, 9), %s, received_at, name, original_timestamp FROM %s.%s ORDER BY id;`, uuidTSSQL, namespace, "users"))
+					require.ElementsMatch(t, usersRecords, whth.UploadJobUsersAppendRecordsUsingUsersLoadFiles(userIDFormat, sourceID, destinationID, destType))
+					tracksRecords := bqhelper.RetrieveRecordsFromWarehouse(t, db, fmt.Sprintf(`SELECT original_timestamp, context_destination_id, context_destination_type, %s, context_source_type, timestamp, id, event, sent_at, context_ip, event_text, context_source_id, context_request_ip, received_at, %s FROM %s.%s ORDER BY id;`, uuidTSSQL, userIDSQL, namespace, "tracks"))
+					require.ElementsMatch(t, tracksRecords, whth.UploadJobTracksAppendRecords(userIDFormat, sourceID, destinationID, destType))
+					productTrackRecords := bqhelper.RetrieveRecordsFromWarehouse(t, db, fmt.Sprintf(`SELECT timestamp, %s, product_id, received_at, context_source_id, sent_at, context_source_type, context_ip, context_destination_type, original_timestamp, context_request_ip, context_destination_id, %s, _as, review_body, _between, review_id, event_text, id, event, rating FROM %s.%s ORDER BY id;`, userIDSQL, uuidTSSQL, namespace, "product_track"))
+					require.ElementsMatch(t, productTrackRecords, whth.UploadJobProductTrackAppendRecords(userIDFormat, sourceID, destinationID, destType))
+					pagesRecords := bqhelper.RetrieveRecordsFromWarehouse(t, db, fmt.Sprintf(`SELECT %s, context_source_id, id, title, timestamp, context_source_type, _as, received_at, context_destination_id, context_ip, context_destination_type, name, original_timestamp, _between, context_request_ip, sent_at, url, %s FROM %s.%s ORDER BY id;`, userIDSQL, uuidTSSQL, namespace, "pages"))
+					require.ElementsMatch(t, pagesRecords, whth.UploadJobPagesAppendRecords(userIDFormat, sourceID, destinationID, destType))
+					screensRecords := bqhelper.RetrieveRecordsFromWarehouse(t, db, fmt.Sprintf(`SELECT context_destination_type, url, context_source_type, title, original_timestamp, %s, _between, context_ip, name, context_request_ip, %s, context_source_id, id, received_at, context_destination_id, timestamp, sent_at, _as FROM %s.%s ORDER BY id;`, userIDSQL, uuidTSSQL, namespace, "screens"))
+					require.ElementsMatch(t, screensRecords, whth.UploadJobScreensAppendRecords(userIDFormat, sourceID, destinationID, destType))
+					aliasesRecords := bqhelper.RetrieveRecordsFromWarehouse(t, db, fmt.Sprintf(`SELECT context_source_id, context_destination_id, context_ip, sent_at, id, %s, %s, previous_id, original_timestamp, context_source_type, received_at, context_destination_type, context_request_ip, timestamp FROM %s.%s ORDER BY id;`, userIDSQL, uuidTSSQL, namespace, "aliases"))
+					require.ElementsMatch(t, aliasesRecords, whth.UploadJobAliasesAppendRecords(userIDFormat, sourceID, destinationID, destType))
+					groupsRecords := bqhelper.RetrieveRecordsFromWarehouse(t, db, fmt.Sprintf(`SELECT context_destination_type, id, _between, plan, original_timestamp, %s, context_source_id, sent_at, %s, group_id, industry, context_request_ip, context_source_type, timestamp, employees, _as, context_destination_id, received_at, name, context_ip FROM %s.%s ORDER BY id;`, uuidTSSQL, userIDSQL, namespace, "_groups"))
+					require.ElementsMatch(t, groupsRecords, whth.UploadJobGroupsAppendRecords(userIDFormat, sourceID, destinationID, destType))
+				},
+			},
 		}
 
 		for _, tc := range testcase {

--- a/warehouse/integrations/bigquery/partition.go
+++ b/warehouse/integrations/bigquery/partition.go
@@ -42,6 +42,8 @@ func (bq *BigQuery) customPartitionEnabledViaGlobalConfig() bool {
 	return bq.config.customPartitionsEnabled || slices.Contains(bq.config.customPartitionsEnabledWorkspaceIDs, bq.warehouse.WorkspaceID)
 }
 
+// isPartitionedByIngestionTime returns true if the table is partitioned by ingestion time
+// Field is empty for ingestion time partitioned tables
 func (bq *BigQuery) isPartitionedByIngestionTime(partitionInWarehouse *bigquery.TimePartitioning) bool {
 	return partitionInWarehouse != nil && partitionInWarehouse.Field == ""
 }

--- a/warehouse/integrations/bigquery/partition.go
+++ b/warehouse/integrations/bigquery/partition.go
@@ -93,6 +93,21 @@ func (bq *BigQuery) partitionDate() (string, error) {
 	}
 }
 
+func (bq *BigQuery) partitionDateByPartitioning(partitioning *bigquery.TimePartitioning) (string, error) {
+	if partitioning == nil {
+		return bq.now().Format("2006-01-02"), nil
+	}
+	partitionType := partitioning.Type
+	switch partitionType {
+	case bigquery.HourPartitioningType:
+		return bq.now().Format("2006-01-02T15"), nil
+	case bigquery.DayPartitioningType:
+		return bq.now().Format("2006-01-02"), nil
+	default:
+		return "", errPartitionTypeNotSupported
+	}
+}
+
 func partitionedTable(tableName, partitionDate string) string {
 	cleanedDate := strings.ReplaceAll(partitionDate, "-", "")
 	cleanedDate = strings.ReplaceAll(cleanedDate, "T", "")


### PR DESCRIPTION
# Description
- Use partition in the warehouse when building deduplication query
- skip writing to partition if bq table is not partitioned or partitioned with other than ingestion time


## Linear Ticket
PART OF WAR-685


## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
