### PR TITLE
fix(processor): throughput stalling due to mutex deadlock on full connection pool

### DIFF
--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -62,8 +62,11 @@ func NewDatabaseConnectionPool(
 	); err != nil {
 		return nil, fmt.Errorf("Error registering database stats collector: %w", err)
 	}
-
-	maxConnsVar := conf.GetReloadableIntVar(40, 1, "db."+componentName+".pool.maxOpenConnections", "db.pool.maxOpenConnections")
+	defaultMaxOpenConnections := 80
+	if componentName == "gateway-app" {
+		defaultMaxOpenConnections = 20
+	}
+	maxConnsVar := conf.GetReloadableIntVar(defaultMaxOpenConnections, 1, "db."+componentName+".pool.maxOpenConnections", "db.pool.maxOpenConnections")
 	maxConns := maxConnsVar.Load()
 	db.SetMaxOpenConns(maxConns)
 

--- a/utils/misc/dbutils_test.go
+++ b/utils/misc/dbutils_test.go
@@ -151,7 +151,7 @@ func TestCommonPool(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.Ping())
 	defer db.Close()
-	require.Equal(t, 40, db.Stats().MaxOpenConnections)
+	require.Equal(t, 80, db.Stats().MaxOpenConnections)
 
 	conf.Set("db.test.pool.maxOpenConnections", 5)
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
# Description

When `Processor.enableConcurrentStore` is enabled, the processor performs the following operations concurrently:

- Storing batchrouter jobs
- Storing router jobs
- Storing proc error jobs
- Updating gateway job statuses (transaction gets committed only after all above transactions are successfully committed)

Each of these operations uses a separate database connection.

In the "store router jobs" operation, before opening a connection, a mutex is acquired per destinationID to ensure that only one goroutine inserts jobs for a given destination at a time.

However, this can lead to a deadlock under high load: if all database connections in the pool are occupied by goroutines waiting to acquire a destinationID mutex, and the one goroutine that has acquired the mutex is blocked waiting for a database connection, progress stalls. The result is a circular wait where no goroutine can proceed, causing the processor's throughput to stall..

To fix this deadlock, whenever `Processor.enableConcurrentStore` is enabled, we're acquiring the mutexes early, before any other connection.

Additionally, we're increasing the default connection pool size to 80 and limiting it to 20 for gateway.

## Linear Ticket

resolves PIPE-2101

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
