### PR TITLE
feat: add support for Snowflake Iceberg tables

### DIFF
--- a/warehouse/integrations/snowflake/datatype_mapper.go
+++ b/warehouse/integrations/snowflake/datatype_mapper.go
@@ -1,15 +1,5 @@
 package snowflake
 
-var dataTypesMap = map[string]string{
-	"boolean":  "boolean",
-	"int":      "number",
-	"bigint":   "number",
-	"float":    "double precision",
-	"string":   "varchar",
-	"datetime": "timestamp_tz",
-	"json":     "variant",
-}
-
 var dataTypesMapToRudder = map[string]string{
 	"NUMBER":           "int",
 	"DECIMAL":          "int",

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -1158,6 +1158,9 @@ func (sf *Snowflake) DropTable(ctx context.Context, tableName string) (err error
 
 func (sf *Snowflake) AddColumns(ctx context.Context, tableName string, columnsInfo []whutils.ColumnInfo) (err error) {
 	schemaIdentifier := sf.schemaIdentifier()
+	if sf.tableManager == nil {
+		return fmt.Errorf("table manager not initialized")
+	}
 	query, err := sf.tableManager.addColumnsQuery(schemaIdentifier, tableName, columnsInfo)
 	if err != nil {
 		return fmt.Errorf("adding columns: %w", err)

--- a/warehouse/integrations/snowflake/snowflake_test.go
+++ b/warehouse/integrations/snowflake/snowflake_test.go
@@ -1255,8 +1255,25 @@ func TestIntegration(t *testing.T) {
 		})
 
 		sf := snowflake.New(config.New(), logger.NOP, stats.NOP)
+		warehouse := model.Warehouse{
+			Destination: backendconfig.DestinationT{
+				Config: map[string]any{
+					"account":              credentials.Account,
+					"database":             credentials.Database,
+					"warehouse":            credentials.Warehouse,
+					"user":                 credentials.User,
+					"useKeyPairAuth":       credentials.UseKeyPairAuth,
+					"privateKey":           credentials.PrivateKey,
+					"privateKeyPassphrase": credentials.PrivateKeyPassphrase,
+					"namespace":            namespace,
+				},
+			},
+			Namespace: namespace,
+		}
+		err = sf.Setup(ctx, warehouse, whutils.NewNoOpUploader())
+		require.NoError(t, err)
+
 		sf.DB = sqlquerywrapper.New(db)
-		sf.Namespace = namespace
 
 		_, err = sf.DB.ExecContext(ctx, fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`, namespace))
 		require.NoError(t, err, "should create schema")

--- a/warehouse/integrations/snowflake/table_manager.go
+++ b/warehouse/integrations/snowflake/table_manager.go
@@ -59,8 +59,7 @@ func (m *standardTableManager) addColumnsQuery(schemaIdentifier, tableName strin
 	))
 
 	for _, columnInfo := range columnsInfo {
-		dataType := m.dataTypesMap[columnInfo.Type]
-		queryBuilder.WriteString(fmt.Sprintf(` %q %s,`, columnInfo.Name, dataType))
+		queryBuilder.WriteString(fmt.Sprintf(` IF NOT EXISTS %q %s,`, columnInfo.Name, m.dataTypesMap[columnInfo.Type]))
 	}
 	return strings.TrimSuffix(queryBuilder.String(), ",") + ";", nil
 }
@@ -113,7 +112,7 @@ func (m *icebergTableManager) addColumnsQuery(schemaIdentifier, tableName string
 		if !ok {
 			return "", fmt.Errorf("invalid data type: %s", columnInfo.Type)
 		}
-		queryBuilder.WriteString(fmt.Sprintf(` %q %s,`, columnInfo.Name, dataType))
+		queryBuilder.WriteString(fmt.Sprintf(` IF NOT EXISTS %q %s,`, columnInfo.Name, dataType))
 	}
 	return strings.TrimSuffix(queryBuilder.String(), ",") + ";", nil
 }

--- a/warehouse/integrations/snowflake/table_manager.go
+++ b/warehouse/integrations/snowflake/table_manager.go
@@ -1,0 +1,128 @@
+package snowflake
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+type tableManager interface {
+	createTableQuery(schemaIdentifier, tableName string, columns model.TableSchema) string
+	addColumnsQuery(schemaIdentifier, tableName string, columnsInfo []whutils.ColumnInfo) (string, error)
+}
+
+func newTableManager(config *config.Config, warehouse model.Warehouse) tableManager {
+	if warehouse.GetBoolDestinationConfig(model.EnableIcebergSetting) {
+		externalVolume := warehouse.GetStringDestinationConfig(config, model.ExternalVolumeSetting)
+		return newIcebergTableManager(externalVolume)
+	}
+	return newStandardTableManager()
+}
+
+// for standard Snowflake tables
+type standardTableManager struct {
+	dataTypesMap map[string]string
+}
+
+func newStandardTableManager() tableManager {
+	return &standardTableManager{
+		dataTypesMap: map[string]string{
+			"boolean":  "boolean",
+			"int":      "number",
+			"bigint":   "number",
+			"float":    "double precision",
+			"string":   "varchar",
+			"datetime": "timestamp_tz",
+			"json":     "variant",
+		},
+	}
+}
+
+func (m *standardTableManager) createTableQuery(schemaIdentifier, tableName string, columns model.TableSchema) string {
+	return fmt.Sprintf(
+		`CREATE TABLE IF NOT EXISTS %s.%q ( %v )`,
+		schemaIdentifier, tableName, columnsWithDataTypes(columns, "", m.dataTypesMap),
+	)
+}
+
+func (m *standardTableManager) addColumnsQuery(schemaIdentifier, tableName string, columnsInfo []whutils.ColumnInfo) (string, error) {
+	var queryBuilder strings.Builder
+	queryBuilder.WriteString(fmt.Sprintf(`
+		ALTER TABLE
+		  %s.%q
+		ADD COLUMN`,
+		schemaIdentifier,
+		tableName,
+	))
+
+	for _, columnInfo := range columnsInfo {
+		dataType := m.dataTypesMap[columnInfo.Type]
+		queryBuilder.WriteString(fmt.Sprintf(` %q %s,`, columnInfo.Name, dataType))
+	}
+	return strings.TrimSuffix(queryBuilder.String(), ",") + ";", nil
+}
+
+// for snowflake managed Iceberg tables
+type icebergTableManager struct {
+	dataTypesMap   map[string]string
+	externalVolume string
+}
+
+func newIcebergTableManager(externalVolume string) tableManager {
+	return &icebergTableManager{
+		dataTypesMap: map[string]string{
+			"boolean":  "boolean",
+			"int":      "number(10,0)",
+			"bigint":   "number(19,0)",
+			"float":    "double precision",
+			"string":   "varchar",
+			"datetime": "timestamp_ltz(6)",
+			"json":     "varchar",
+		},
+		externalVolume: externalVolume,
+	}
+}
+
+func (m *icebergTableManager) createTableQuery(schemaIdentifier, tableName string, columns model.TableSchema) string {
+	baseLocation := fmt.Sprintf("%s/%s", schemaIdentifier, tableName)
+	return fmt.Sprintf(
+		`CREATE OR REPLACE ICEBERG TABLE %s.%q ( %v )
+		CATALOG = 'SNOWFLAKE'
+		EXTERNAL_VOLUME = '%s'
+		BASE_LOCATION = '%s'`,
+		schemaIdentifier, tableName, columnsWithDataTypes(columns, "", m.dataTypesMap),
+		m.externalVolume,
+		baseLocation,
+	)
+}
+
+func (m *icebergTableManager) addColumnsQuery(schemaIdentifier, tableName string, columnsInfo []whutils.ColumnInfo) (string, error) {
+	var queryBuilder strings.Builder
+	queryBuilder.WriteString(fmt.Sprintf(`
+		ALTER ICEBERG TABLE
+		  %s.%q
+		ADD COLUMN`,
+		schemaIdentifier,
+		tableName,
+	))
+	for _, columnInfo := range columnsInfo {
+		dataType, ok := m.dataTypesMap[columnInfo.Type]
+		if !ok {
+			return "", fmt.Errorf("invalid data type: %s", columnInfo.Type)
+		}
+		queryBuilder.WriteString(fmt.Sprintf(` %q %s,`, columnInfo.Name, dataType))
+	}
+	return strings.TrimSuffix(queryBuilder.String(), ",") + ";", nil
+}
+
+func columnsWithDataTypes(columns model.TableSchema, prefix string, dataTypesMap map[string]string) string {
+	var arr []string
+	sortedColumns := getSortedColumnsFromTableSchema(columns)
+	for _, name := range sortedColumns {
+		arr = append(arr, fmt.Sprintf(`"%s%s" %s`, prefix, name, dataTypesMap[columns[name]]))
+	}
+	return strings.Join(arr, ",")
+}

--- a/warehouse/integrations/snowflake/table_manager.go
+++ b/warehouse/integrations/snowflake/table_manager.go
@@ -44,7 +44,7 @@ func newStandardTableManager() tableManager {
 func (m *standardTableManager) createTableQuery(schemaIdentifier, tableName string, columns model.TableSchema) string {
 	return fmt.Sprintf(
 		`CREATE TABLE IF NOT EXISTS %s.%q ( %v )`,
-		schemaIdentifier, tableName, columnsWithDataTypes(columns, "", m.dataTypesMap),
+		schemaIdentifier, tableName, columnsWithDataTypes(columns, m.dataTypesMap),
 	)
 }
 
@@ -92,7 +92,7 @@ func (m *icebergTableManager) createTableQuery(schemaIdentifier, tableName strin
 		CATALOG = 'SNOWFLAKE'
 		EXTERNAL_VOLUME = '%s'
 		BASE_LOCATION = '%s'`,
-		schemaIdentifier, tableName, columnsWithDataTypes(columns, "", m.dataTypesMap),
+		schemaIdentifier, tableName, columnsWithDataTypes(columns, m.dataTypesMap),
 		m.externalVolume,
 		baseLocation,
 	)
@@ -117,11 +117,11 @@ func (m *icebergTableManager) addColumnsQuery(schemaIdentifier, tableName string
 	return strings.TrimSuffix(queryBuilder.String(), ",") + ";", nil
 }
 
-func columnsWithDataTypes(columns model.TableSchema, prefix string, dataTypesMap map[string]string) string {
+func columnsWithDataTypes(columns model.TableSchema, dataTypesMap map[string]string) string {
 	var arr []string
 	sortedColumns := getSortedColumnsFromTableSchema(columns)
 	for _, name := range sortedColumns {
-		arr = append(arr, fmt.Sprintf(`"%s%s" %s`, prefix, name, dataTypesMap[columns[name]]))
+		arr = append(arr, fmt.Sprintf(`"%s" %s`, name, dataTypesMap[columns[name]]))
 	}
 	return strings.Join(arr, ",")
 }

--- a/warehouse/integrations/snowflake/table_manager_test.go
+++ b/warehouse/integrations/snowflake/table_manager_test.go
@@ -89,7 +89,7 @@ func TestTableManager(t *testing.T) {
 				expectedAddColumnsQuery: `
 		ALTER TABLE
 		  myschema."mytable"
-		ADD COLUMN "new_col1" varchar, "new_col2" number;`,
+		ADD COLUMN IF NOT EXISTS "new_col1" varchar, IF NOT EXISTS "new_col2" number;`,
 			},
 			{
 				name:      "iceberg table",
@@ -101,7 +101,7 @@ func TestTableManager(t *testing.T) {
 				expectedAddColumnsQuery: `
 		ALTER ICEBERG TABLE
 		  myschema."mytable"
-		ADD COLUMN "new_col1" varchar, "new_col2" number(10,0);`,
+		ADD COLUMN IF NOT EXISTS "new_col1" varchar, IF NOT EXISTS "new_col2" number(10,0);`,
 			},
 			{
 				name:      "iceberg table - invalid data type",

--- a/warehouse/integrations/snowflake/table_manager_test.go
+++ b/warehouse/integrations/snowflake/table_manager_test.go
@@ -1,0 +1,130 @@
+package snowflake
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+
+	"github.com/stretchr/testify/require"
+
+	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+func TestTableManager(t *testing.T) {
+	columns := model.TableSchema{
+		"col1": "boolean",
+		"col2": "int",
+		"col3": "bigint",
+		"col4": "float",
+		"col5": "string",
+		"col6": "datetime",
+		"col7": "json",
+	}
+	standardWarehouse := model.Warehouse{
+		Destination: backendconfig.DestinationT{
+			Config: map[string]interface{}{
+				"enableIceberg": false,
+			},
+		},
+	}
+	icebergWarehouse := model.Warehouse{
+		Destination: backendconfig.DestinationT{
+			Config: map[string]interface{}{
+				"enableIceberg":  true,
+				"externalVolume": "myvolume",
+			},
+		},
+	}
+
+	t.Run("TestCreateTableQuery", func(t *testing.T) {
+		tests := []struct {
+			name                     string
+			warehouse                model.Warehouse
+			columns                  model.TableSchema
+			expectedCreateTableQuery string
+		}{
+			{
+				name:                     "standard table",
+				warehouse:                standardWarehouse,
+				columns:                  columns,
+				expectedCreateTableQuery: "CREATE TABLE IF NOT EXISTS myschema.\"mytable\" ( \"col1\" boolean,\"col2\" number,\"col3\" number,\"col4\" double precision,\"col5\" varchar,\"col6\" timestamp_tz,\"col7\" variant )",
+			},
+			{
+				name:      "iceberg table",
+				warehouse: icebergWarehouse,
+				columns:   columns,
+				expectedCreateTableQuery: `CREATE OR REPLACE ICEBERG TABLE myschema."mytable" ( "col1" boolean,"col2" number(10,0),"col3" number(19,0),"col4" double precision,"col5" varchar,"col6" timestamp_ltz(6),"col7" varchar )
+		CATALOG = 'SNOWFLAKE'
+		EXTERNAL_VOLUME = 'myvolume'
+		BASE_LOCATION = 'myschema/mytable'`,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				manager := newTableManager(config.New(), tt.warehouse)
+				result := manager.createTableQuery("myschema", "mytable", tt.columns)
+				require.Equal(t, tt.expectedCreateTableQuery, result)
+			})
+		}
+	})
+
+	t.Run("TestAddColumnsQuery", func(t *testing.T) {
+		tests := []struct {
+			name                    string
+			warehouse               model.Warehouse
+			additionalColumns       []whutils.ColumnInfo
+			expectedAddColumnsQuery string
+			expectedError           string
+		}{
+			{
+				name:      "standard table manager",
+				warehouse: standardWarehouse,
+				additionalColumns: []whutils.ColumnInfo{
+					{Name: "new_col1", Type: "string"},
+					{Name: "new_col2", Type: "int"},
+				},
+				expectedAddColumnsQuery: `
+		ALTER TABLE
+		  myschema."mytable"
+		ADD COLUMN "new_col1" varchar, "new_col2" number;`,
+			},
+			{
+				name:      "iceberg table",
+				warehouse: icebergWarehouse,
+				additionalColumns: []whutils.ColumnInfo{
+					{Name: "new_col1", Type: "string"},
+					{Name: "new_col2", Type: "int"},
+				},
+				expectedAddColumnsQuery: `
+		ALTER ICEBERG TABLE
+		  myschema."mytable"
+		ADD COLUMN "new_col1" varchar, "new_col2" number(10,0);`,
+			},
+			{
+				name:      "iceberg table - invalid data type",
+				warehouse: icebergWarehouse,
+				additionalColumns: []whutils.ColumnInfo{
+					{Name: "col1", Type: "hello"},
+				},
+				expectedError: "invalid data type: hello",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				manager := newTableManager(config.New(), tt.warehouse)
+				result, err := manager.addColumnsQuery("myschema", "mytable", tt.additionalColumns)
+
+				if tt.expectedError != "" {
+					require.EqualError(t, err, tt.expectedError)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tt.expectedAddColumnsQuery, result)
+				}
+			})
+		}
+	})
+}

--- a/warehouse/internal/model/settings.go
+++ b/warehouse/internal/model/settings.go
@@ -59,6 +59,8 @@ var (
 	ExcludeWindowSetting             DestinationConfigSetting = destConfSetting("excludeWindow")
 	PartitionColumnSetting           DestinationConfigSetting = destConfSetting("partitionColumn")
 	PartitionTypeSetting             DestinationConfigSetting = destConfSetting("partitionType")
+	EnableIcebergSetting             DestinationConfigSetting = destConfSetting("enableIceberg")
+	ExternalVolumeSetting            DestinationConfigSetting = destConfSetting("externalVolume")
 	CleanupObjectStorageFilesSetting DestinationConfigSetting = destConfSetting("cleanupObjectStorageFiles")
 	UseOauthSetting                  DestinationConfigSetting = destConfSetting("useOauth")
 	OauthClientIDSetting             DestinationConfigSetting = destConfSetting("oauthClientID")


### PR DESCRIPTION
# Description

This PR enhances the Snowflake implementation of the Manager interface by adding support for Iceberg tables.

Implementation Details:
- Introduced two new destination settings for Iceberg: `enableIceberg` and `externalVolume`.
- Created a `tableManager` interface to encapsulate table-specific behavior. This interface has two implementations: standard (existing) and Iceberg.
- Moved `dataTypesMap` and the corresponding Iceberg type handling behind this interface.
- `tableManager` is being initialized in the Setup method.
- Refactored `getSortedColumnsFromTableSchema` into a standalone function, making it reusable for `tableManager` instead of being a Snowflake-specific method.
- Removed unused `ColumnsWithDataTypes` method

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
