### PR TITLE
chore: disable load statistics for clickhouse

### DIFF
--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -153,6 +153,7 @@ type Clickhouse struct {
 		s3EngineEnabledWorkspaceIDs []string
 		slowQueryThreshold          time.Duration
 		randomLoadDelay             func(string) time.Duration
+		disableLoadTableStats       func(string) bool
 	}
 }
 
@@ -228,6 +229,13 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats) *Clickhouse {
 	ch.config.numWorkersDownloadLoadFiles = conf.GetInt("Warehouse.clickhouse.numWorkersDownloadLoadFiles", 8)
 	ch.config.s3EngineEnabledWorkspaceIDs = conf.GetStringSlice("Warehouse.clickhouse.s3EngineEnabledWorkspaceIDs", nil)
 	ch.config.slowQueryThreshold = conf.GetDuration("Warehouse.clickhouse.slowQueryThreshold", 5, time.Minute)
+	ch.config.disableLoadTableStats = func(workspaceID string) bool {
+		return conf.GetBoolVar(
+			false,
+			fmt.Sprintf("Warehouse.clickhouse.%s.disableLoadTableStats", workspaceID),
+			"Warehouse.clickhouse.disableLoadTableStats",
+		)
+	}
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	ch.config.randomLoadDelay = func(workspaceID string) time.Duration {
 		maxDelay := conf.GetDurationVar(
@@ -1029,9 +1037,15 @@ func (ch *Clickhouse) LoadUserTables(ctx context.Context) (errorMap map[string]e
 }
 
 func (ch *Clickhouse) LoadTable(ctx context.Context, tableName string) (*types.LoadTableStats, error) {
-	preLoadTableCount, err := ch.totalCountIntable(ctx, tableName)
-	if err != nil {
-		return nil, fmt.Errorf("pre load table count: %w", err)
+	var (
+		preLoadTableCount int64
+		err               error
+	)
+	if !ch.config.disableLoadTableStats(ch.Warehouse.WorkspaceID) {
+		preLoadTableCount, err = ch.totalCountIntable(ctx, tableName)
+		if err != nil {
+			return nil, fmt.Errorf("pre load table count: %w", err)
+		}
 	}
 
 	err = ch.loadTable(ctx, tableName, ch.Uploader.GetTableSchemaInUpload(tableName))
@@ -1039,9 +1053,12 @@ func (ch *Clickhouse) LoadTable(ctx context.Context, tableName string) (*types.L
 		return nil, fmt.Errorf("loading table: %w", err)
 	}
 
-	postLoadTableCount, err := ch.totalCountIntable(ctx, tableName)
-	if err != nil {
-		return nil, fmt.Errorf("post load table count: %w", err)
+	var postLoadTableCount int64
+	if !ch.config.disableLoadTableStats(ch.Warehouse.WorkspaceID) {
+		postLoadTableCount, err = ch.totalCountIntable(ctx, tableName)
+		if err != nil {
+			return nil, fmt.Errorf("post load table count: %w", err)
+		}
 	}
 
 	return &types.LoadTableStats{

--- a/warehouse/integrations/clickhouse/clickhouse_test.go
+++ b/warehouse/integrations/clickhouse/clickhouse_test.go
@@ -556,26 +556,36 @@ func TestIntegration(t *testing.T) {
 			fileName                    string
 			S3EngineEnabledWorkspaceIDs []string
 			disableNullable             bool
+			disableLoadTableStats       bool
 		}{
 			{
-				name:     "normal loading using downloading of load files",
-				fileName: "testdata/load.csv.gz",
+				name:                  "normal loading using downloading of load files",
+				fileName:              "testdata/load.csv.gz",
+				disableLoadTableStats: false,
 			},
 			{
 				name:                        "using s3 engine for loading",
 				S3EngineEnabledWorkspaceIDs: []string{workspaceID},
 				fileName:                    "testdata/load-copy.csv.gz",
+				disableLoadTableStats:       false,
 			},
 			{
-				name:            "normal loading using downloading of load files with disable nullable",
-				fileName:        "testdata/load.csv.gz",
-				disableNullable: true,
+				name:                  "normal loading using downloading of load files with disable nullable",
+				fileName:              "testdata/load.csv.gz",
+				disableNullable:       true,
+				disableLoadTableStats: false,
 			},
 			{
 				name:                        "using s3 engine for loading with disable nullable",
 				S3EngineEnabledWorkspaceIDs: []string{workspaceID},
 				fileName:                    "testdata/load-copy.csv.gz",
 				disableNullable:             true,
+				disableLoadTableStats:       false,
+			},
+			{
+				name:                  "normal loading using downloading of load files with disable load table stats",
+				fileName:              "testdata/load.csv.gz",
+				disableLoadTableStats: true,
 			},
 		}
 
@@ -584,6 +594,7 @@ func TestIntegration(t *testing.T) {
 				conf := config.New()
 				conf.Set("Warehouse.clickhouse.s3EngineEnabledWorkspaceIDs", tc.S3EngineEnabledWorkspaceIDs)
 				conf.Set("Warehouse.clickhouse.disableNullable", tc.disableNullable)
+				conf.Set("Warehouse.clickhouse.disableLoadTableStats", tc.disableLoadTableStats)
 
 				ch := clickhouse.New(conf, logger.NOP, stats.NOP)
 
@@ -733,8 +744,11 @@ func TestIntegration(t *testing.T) {
 				}
 
 				t.Log("Loading data into table")
-				_, err = ch.LoadTable(ctx, table)
+				loadTableStats, err := ch.LoadTable(ctx, table)
 				require.NoError(t, err)
+				if !tc.disableLoadTableStats {
+					require.NotEmpty(t, loadTableStats.RowsInserted)
+				}
 
 				t.Log("Drop table")
 				err = ch.DropTable(ctx, table)


### PR DESCRIPTION
# Description

- Add config to disable load stats for clickhouse. 

## Linear Ticket

Part of WAR-250

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
