### PR TITLE
chore: add new metric regulation_worker_attempted_user_deletions_count

### DIFF
--- a/regulation-worker/internal/service/service.go
+++ b/regulation-worker/internal/service/service.go
@@ -67,6 +67,8 @@ func (js *JobSvc) JobSvc(ctx context.Context) error {
 		jobStatus.Status = model.JobStatusAborted
 	}
 
+	stats.Default.NewTaggedStat("regulation_worker_attempted_user_deletions_count", stats.CountType, stats.Tags{"workspaceId": job.WorkspaceID, "destinationid": destDetail.DestinationID, "destinationType": destDetail.Name, "status": string(jobStatus.Status)}).Count(len(job.Users))
+
 	stats.Default.NewTaggedStat("regulation_worker_deletion_time", stats.TimerType, stats.Tags{"workspaceId": job.WorkspaceID, "destinationid": destDetail.DestinationID, "destinationType": destDetail.Name, "status": string(jobStatus.Status)}).Since(deletionStart)
 	if jobStatus.Status == model.JobStatusComplete {
 		stats.Default.NewTaggedStat("regulation_worker_deleted_user_count", stats.CountType, stats.Tags{"workspaceId": job.WorkspaceID, "destinationid": destDetail.DestinationID, "destinationType": destDetail.Name}).Count(len(job.Users))


### PR DESCRIPTION
# Description

Added this metric for setting up alerts when regulations are failing

## Linear Ticket

https://linear.app/rudderstack/issue/INT-3757/add-observability-on-data-regulation-failures

Resolves INT-3757

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
