### PR TITLE
feat: shutdown server on non-reloadable config change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/rudderlabs/bing-ads-go-sdk v0.2.3
 	github.com/rudderlabs/compose-test v0.1.3
-	github.com/rudderlabs/rudder-go-kit v0.54.1
+	github.com/rudderlabs/rudder-go-kit v0.55.0
 	github.com/rudderlabs/rudder-observability-kit v0.0.4
 	github.com/rudderlabs/rudder-schemas v0.6.0
 	github.com/rudderlabs/rudder-transformer/go v0.0.0-20250507094647-f18f2e217449

--- a/go.sum
+++ b/go.sum
@@ -1185,8 +1185,8 @@ github.com/rudderlabs/goqu/v10 v10.3.1 h1:rnfX+b4EwBWQ2UQfIGeEW299JBBkK5biEbnf7K
 github.com/rudderlabs/goqu/v10 v10.3.1/go.mod h1:LH2vI5gGHBxEQuESqFyk5ZA2anGINc8o25hbidDWOYw=
 github.com/rudderlabs/parquet-go v0.0.2 h1:ZXRdZdimB0PdJtmxeSSxfI0fDQ3kZjwzBxRi6Ut1J8k=
 github.com/rudderlabs/parquet-go v0.0.2/go.mod h1:g6guum7o8uhj/uNhunnt7bw5Vabu/goI5i21/3fnxWQ=
-github.com/rudderlabs/rudder-go-kit v0.54.1 h1:KFtBdd11LNpiWixsJWOYHuxXFUjNO1NTdUUl5FqJQxU=
-github.com/rudderlabs/rudder-go-kit v0.54.1/go.mod h1:5JzeZUBE6hBBXZ3KgtJwjrBuprxAXXDr8qnHVAbNVyM=
+github.com/rudderlabs/rudder-go-kit v0.55.0 h1:/CPaKgsjzfihmw9xPGwRH1GVB+jMCKWhB3Jk1ENM9/A=
+github.com/rudderlabs/rudder-go-kit v0.55.0/go.mod h1:5JzeZUBE6hBBXZ3KgtJwjrBuprxAXXDr8qnHVAbNVyM=
 github.com/rudderlabs/rudder-observability-kit v0.0.4 h1:h9nLoWqiv/nqGOu1dhuVFAHNRkyodR6R3v36bqmavRs=
 github.com/rudderlabs/rudder-observability-kit v0.0.4/go.mod h1:YTsvJmpvh8OLk7c4C+wXiV8NRdcrrdLa8UvIdLoXTho=
 github.com/rudderlabs/rudder-schemas v0.6.0 h1:VL/TAGQGTaSlBhXt6DrBmM6kx2sF22QjUdsrlctGz+I=

--- a/utils/signal/signal.go
+++ b/utils/signal/signal.go
@@ -1,0 +1,35 @@
+package signal
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+)
+
+// NotifyContextWithCallback creates a context that listens for OS signals (e.g. SIGINT, SIGTERM)
+// and calls the provided callback function when a signal is received, before canceling the context.
+func NotifyContextWithCallback(fn func(), signals ...os.Signal) (ctx context.Context, stop context.CancelFunc) {
+	signalCtx, signalCancel := signal.NotifyContext(context.Background(), signals...)
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		select {
+		case <-signalCtx.Done():
+			// If the signal context is done, we log an event and cancel our context.
+			fn()
+			cancel()
+		case <-ctx.Done():
+			signalCancel() // If our context is done, we cancel the signal context.
+		}
+	}()
+	// If the signal context is not done, we can just wait for it to be done.
+
+	return ctx, func() {
+		cancel()
+		signalCancel()
+		wg.Wait() // Wait for the goroutine to finish before returning
+	}
+}

--- a/utils/signal/signal_test.go
+++ b/utils/signal/signal_test.go
@@ -1,0 +1,52 @@
+package signal_test
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	rsignal "github.com/rudderlabs/rudder-server/utils/signal"
+)
+
+func TestNotifyContextWithCallback(t *testing.T) {
+	t.Run("receives a cancel signal and calls the callback", func(t *testing.T) {
+		called := false
+		ctx, cancel := rsignal.NotifyContextWithCallback(func() {
+			called = true
+		}, syscall.SIGINT)
+		defer cancel()
+
+		// Simulate a signal being sent
+		p, err := os.FindProcess(os.Getpid())
+		require.NoError(t, err, "it should be able to find the process")
+		require.NoError(t, p.Signal(os.Interrupt))
+
+		select {
+		case <-ctx.Done():
+			require.ErrorIs(t, ctx.Err(), context.Canceled)
+			require.True(t, called, "Callback should have been called")
+		case <-time.After(1 * time.Second):
+			t.Error("Expected context to be done within 1 second")
+		}
+	})
+
+	t.Run("does not call the callback if context is canceled by us", func(t *testing.T) {
+		called := false
+		ctx, cancel := rsignal.NotifyContextWithCallback(func() {
+			called = true
+		}, syscall.SIGINT)
+		cancel() // Cancel the context immediately
+
+		select {
+		case <-ctx.Done():
+			require.ErrorIs(t, ctx.Err(), context.Canceled)
+			require.False(t, called, "Callback should not have been called")
+		case <-time.After(1 * time.Second):
+			t.Error("Expected context to be done within 1 second")
+		}
+	})
+}


### PR DESCRIPTION
# Description

rudder-server can now shutdown in case a non-reloadable configuration change is detected

## Additional items

- added more logs to indicate server startup, shutdown and termination signals

## Linear Ticket

resolves PIPE-2102

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
