### PR TITLE
fix: warehouse transformations responses ordering

### DIFF
--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/transformer.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/transformer.go
@@ -98,7 +98,7 @@ func New(conf *config.Config, logger logger.Logger, statsFactory stats.Stats, op
 	t.config.populateSrcDestInfoInContext = conf.GetReloadableBoolVar(true, "WH_POPULATE_SRC_DEST_INFO_IN_CONTEXT")
 	t.config.maxColumnsInEvent = conf.GetReloadableIntVar(200, 1, "WH_MAX_COLUMNS_IN_EVENT")
 	t.config.maxLoggedEvents = conf.GetReloadableIntVar(100, 1, "Warehouse.Transformer.Sampling.maxLoggedEvents")
-	t.config.concurrentTransformations = conf.GetReloadableIntVar(10, 1, "Warehouse.concurrentTransformations")
+	t.config.concurrentTransformations = conf.GetReloadableIntVar(1, 1, "Warehouse.concurrentTransformations")
 	t.config.instanceID = conf.GetString("INSTANCE_ID", "1")
 
 	var err error

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"path"
-	"slices"
 	"strings"
 	"time"
 
@@ -101,11 +100,6 @@ func (t *Transformer) sampleDiff(events []types.TransformerEvent, legacyResponse
 		return "" // Don't diff in case there is no response from transformer
 	}
 
-	sortTransformerResponsesByJobID(legacyResponse.Events)
-	sortTransformerResponsesByJobID(legacyResponse.FailedEvents)
-	sortTransformerResponsesByJobID(embeddedResponse.Events)
-	sortTransformerResponsesByJobID(embeddedResponse.FailedEvents)
-
 	// If the event counts differ, return all events in the transformation
 	if len(legacyResponse.Events) != len(embeddedResponse.Events) || len(legacyResponse.FailedEvents) != len(embeddedResponse.FailedEvents) {
 		t.stats.mismatchedEvents.Observe(float64(len(events)))
@@ -140,12 +134,6 @@ func (t *Transformer) sampleDiff(events []types.TransformerEvent, legacyResponse
 	t.stats.matchedEvents.Observe(float64(len(legacyResponse.Events) - differedEventsCount))
 	t.stats.mismatchedEvents.Observe(float64(differedEventsCount))
 	return sampleDiff
-}
-
-func sortTransformerResponsesByJobID(responses []types.TransformerResponse) {
-	slices.SortStableFunc(responses, func(a, b types.TransformerResponse) int {
-		return int(a.Metadata.JobID - b.Metadata.JobID)
-	})
 }
 
 func write(w io.WriteCloser, data []string) error {


### PR DESCRIPTION
# Description

- Avoid making modifications, such as ordering a legacy response, as it will be consumed later.
- Avoid concurrent transformations like what's happening in the rudder-transformer JS code. Once we completely migrated to warehouse transformations, we can then later have concurrency set.

## Linear Ticket

- Resolves WAR-742, WAR-697

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
