### PR TITLE
chore: use zero transport on new common reporting client

### DIFF
--- a/enterprise/reporting/client/client.go
+++ b/enterprise/reporting/client/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -94,43 +93,10 @@ func New(path Route, conf *config.Config, log logger.Logger, stats stats.Stats) 
 	reportingServiceURL := conf.GetString("REPORTING_URL", "https://reporting.dev.rudderlabs.com")
 	reportingServiceURL = strings.TrimSuffix(reportingServiceURL, "/")
 
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-
-	if conf.IsSet("Reporting.httpClient.transport.maxIdleConns") {
-		transport.MaxIdleConns = conf.GetInt("Reporting.httpClient.transport.maxIdleConns", 100)
-	}
-
-	if conf.IsSet("Reporting.httpClient.transport.idleConnTimeout") {
-		transport.IdleConnTimeout = conf.GetDurationVar(90, time.Second, "Reporting.httpClient.transport.idleConnTimeout")
-	}
-
-	if conf.IsSet("Reporting.httpClient.transport.tlsHandshakeTimeout") {
-		transport.TLSHandshakeTimeout = conf.GetDurationVar(10, time.Second, "Reporting.httpClient.transport.tlsHandshakeTimeout")
-	}
-
-	if conf.IsSet("Reporting.httpClient.transport.disableKeepAlives") {
-		transport.DisableKeepAlives = conf.GetBool("Reporting.httpClient.transport.disableKeepAlives", false)
-	}
-
-	if conf.IsSet("Reporting.httpClient.transport.dialer.timeout") {
-		transport.DialContext = (&net.Dialer{
-			Timeout:   conf.GetDurationVar(30, time.Second, "Reporting.httpClient.transport.dialer.timeout"),
-			KeepAlive: conf.GetDurationVar(30, time.Second, "Reporting.httpClient.transport.dialer.keepAlive"),
-		}).DialContext
-	}
-
-	if conf.IsSet("Reporting.httpClient.transport.forceAttemptHTTP2") {
-		transport.ForceAttemptHTTP2 = conf.GetBool("Reporting.httpClient.transport.forceAttemptHTTP2", true)
-	}
-
-	if conf.IsSet("Reporting.httpClient.transport.expectContinueTimeout") {
-		transport.ExpectContinueTimeout = conf.GetDurationVar(1, time.Second, "Reporting.httpClient.transport.expectContinueTimeout")
-	}
-
 	return &Client{
 		httpClient: &http.Client{
 			Timeout:   conf.GetDurationVar(60, time.Second, "Reporting.httpClient.timeout", "HttpClient.reporting.timeout"),
-			Transport: transport,
+			Transport: &http.Transport{},
 		},
 		reportingServiceURL: reportingServiceURL,
 		backoff:             backOffFromConfig(conf),


### PR DESCRIPTION
# Description

- Using zero transport on new common reporting client
- With default transport, we were seeing increased times in flushing

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
