### PR TITLE
chore: sync release v1.50.6 to main branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.50.2](https://github.com/rudderlabs/rudder-server/compare/v1.50.1...v1.50.2) (2025-05-28)
+
+
+### Bug Fixes
+
+* **processor:** throughput stalling due to mutex deadlock on full connection pool ([#5919](https://github.com/rudderlabs/rudder-server/issues/5919)) ([a29dd15](https://github.com/rudderlabs/rudder-server/commit/a29dd1581a3785b7804b3772047741a851dbf41e))
+
 ## [1.50.1](https://github.com/rudderlabs/rudder-server/compare/v1.50.0...v1.50.1) (2025-05-27)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.50.6](https://github.com/rudderlabs/rudder-server/compare/v1.50.5...v1.50.6) (2025-06-09)
+
+
+### Bug Fixes
+
+* warehouse transformations responses ordering ([#5954](https://github.com/rudderlabs/rudder-server/issues/5954)) ([0fed576](https://github.com/rudderlabs/rudder-server/commit/0fed576e1a8c823f99024e08c53edfb656984904))
+
 ## [1.50.5](https://github.com/rudderlabs/rudder-server/compare/v1.50.4...v1.50.5) (2025-06-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.50.3](https://github.com/rudderlabs/rudder-server/compare/v1.50.2...v1.50.3) (2025-06-04)
+
+
+### Miscellaneous
+
+* proc sample store uploader ([#5917](https://github.com/rudderlabs/rudder-server/issues/5917)) ([39c8e46](https://github.com/rudderlabs/rudder-server/commit/39c8e46fc4b94b9e9fa08cd2c3dabf7b5e05e137))
+* warehouse transformations json diff with encoding ([#5937](https://github.com/rudderlabs/rudder-server/issues/5937)) ([bf75a96](https://github.com/rudderlabs/rudder-server/commit/bf75a96202457e5e77662052a933f0fa52468d43))
+
 ## [1.50.2](https://github.com/rudderlabs/rudder-server/compare/v1.50.1...v1.50.2) (2025-05-28)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.50.4](https://github.com/rudderlabs/rudder-server/compare/v1.50.3...v1.50.4) (2025-06-04)
+
+
+### Bug Fixes
+
+* use jsonrs stdlib for encoding warehouse transformations ([#5945](https://github.com/rudderlabs/rudder-server/issues/5945)) ([055b7de](https://github.com/rudderlabs/rudder-server/commit/055b7debc4c31e7915ed6a0a8fa3391f0dd8422c))
+
 ## [1.50.3](https://github.com/rudderlabs/rudder-server/compare/v1.50.2...v1.50.3) (2025-06-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.50.5](https://github.com/rudderlabs/rudder-server/compare/v1.50.4...v1.50.5) (2025-06-05)
+
+
+### Miscellaneous
+
+* add config to disable load table stats for clickhouse ([#5932](https://github.com/rudderlabs/rudder-server/issues/5932)) ([69c9345](https://github.com/rudderlabs/rudder-server/commit/69c93458424cf42d5c0f597154d97ba3d21b7217))
+
 ## [1.50.4](https://github.com/rudderlabs/rudder-server/compare/v1.50.3...v1.50.4) (2025-06-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.50.1](https://github.com/rudderlabs/rudder-server/compare/v1.50.0...v1.50.1) (2025-05-27)
+
+
+### Bug Fixes
+
+* under reporting of load files when using upload id ([#5889](https://github.com/rudderlabs/rudder-server/issues/5889)) ([#5906](https://github.com/rudderlabs/rudder-server/issues/5906)) ([84029f7](https://github.com/rudderlabs/rudder-server/commit/84029f723e50d4f11de91c39e48d366975fb4411))
+* warehouse transformations geo enrichment as string ([#5907](https://github.com/rudderlabs/rudder-server/issues/5907)) ([4caf359](https://github.com/rudderlabs/rudder-server/commit/4caf359c9006d4b702df5e5356b0d416333a5170))
+
 ## [1.50.0](https://github.com/rudderlabs/rudder-server/compare/v1.49.0...v1.50.0) (2025-05-26)
 
 

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/rudderlabs/bing-ads-go-sdk v0.2.3
 	github.com/rudderlabs/compose-test v0.1.3
-	github.com/rudderlabs/rudder-go-kit v0.52.0
+	github.com/rudderlabs/rudder-go-kit v0.52.1
 	github.com/rudderlabs/rudder-observability-kit v0.0.4
 	github.com/rudderlabs/rudder-schemas v0.6.0
 	github.com/rudderlabs/rudder-transformer/go v0.0.0-20250507094647-f18f2e217449

--- a/go.sum
+++ b/go.sum
@@ -1185,8 +1185,8 @@ github.com/rudderlabs/goqu/v10 v10.3.1 h1:rnfX+b4EwBWQ2UQfIGeEW299JBBkK5biEbnf7K
 github.com/rudderlabs/goqu/v10 v10.3.1/go.mod h1:LH2vI5gGHBxEQuESqFyk5ZA2anGINc8o25hbidDWOYw=
 github.com/rudderlabs/parquet-go v0.0.2 h1:ZXRdZdimB0PdJtmxeSSxfI0fDQ3kZjwzBxRi6Ut1J8k=
 github.com/rudderlabs/parquet-go v0.0.2/go.mod h1:g6guum7o8uhj/uNhunnt7bw5Vabu/goI5i21/3fnxWQ=
-github.com/rudderlabs/rudder-go-kit v0.52.0 h1:u2ygKrWDUcuIwjOFoecs6zW2cIc3OlR6DSG5H+AjlGs=
-github.com/rudderlabs/rudder-go-kit v0.52.0/go.mod h1:5JzeZUBE6hBBXZ3KgtJwjrBuprxAXXDr8qnHVAbNVyM=
+github.com/rudderlabs/rudder-go-kit v0.52.1 h1:7q1B4qxXXfuWdziP/RNvkSAvKnDhjTsq6AzQPNLqHNw=
+github.com/rudderlabs/rudder-go-kit v0.52.1/go.mod h1:5JzeZUBE6hBBXZ3KgtJwjrBuprxAXXDr8qnHVAbNVyM=
 github.com/rudderlabs/rudder-observability-kit v0.0.4 h1:h9nLoWqiv/nqGOu1dhuVFAHNRkyodR6R3v36bqmavRs=
 github.com/rudderlabs/rudder-observability-kit v0.0.4/go.mod h1:YTsvJmpvh8OLk7c4C+wXiV8NRdcrrdLa8UvIdLoXTho=
 github.com/rudderlabs/rudder-schemas v0.6.0 h1:VL/TAGQGTaSlBhXt6DrBmM6kx2sF22QjUdsrlctGz+I=

--- a/integration_test/warehouse/warehouse_test.go
+++ b/integration_test/warehouse/warehouse_test.go
@@ -85,68 +85,83 @@ func TestUploads(t *testing.T) {
 	t.Run("tracks loading", func(t *testing.T) {
 		testCases := []struct {
 			batchStagingFiles bool
+			maxSizeInMB       string
 		}{
 			{batchStagingFiles: false},
-			{batchStagingFiles: true},
+			{batchStagingFiles: true, maxSizeInMB: "100"},
+			{batchStagingFiles: true, maxSizeInMB: "0.00005"}, // Very low maxSizeInMB to ensure that staging files are not batched
 		}
 		for _, tc := range testCases {
-			if tc.batchStagingFiles {
-				t.Setenv(config.ConfigKeyToEnv(config.DefaultEnvPrefix, "Warehouse.enableV2NotifierJob"), "true")
-				t.Setenv(config.ConfigKeyToEnv(config.DefaultEnvPrefix, "Warehouse.loadFiles.queryWithUploadID.enable"), "true")
-			}
-			db, minioResource, whClient := setupServer(t, false, nil, nil)
+			t.Run(fmt.Sprintf("batchStagingFiles: %t, maxSizeInMB: %s", tc.batchStagingFiles, tc.maxSizeInMB), func(t *testing.T) {
+				if tc.batchStagingFiles {
+					t.Setenv(config.ConfigKeyToEnv(config.DefaultEnvPrefix, "Warehouse.enableV2NotifierJob"), "true")
+					t.Setenv(config.ConfigKeyToEnv(config.DefaultEnvPrefix, "Warehouse.loadFiles.queryWithUploadID.enable"), "true")
+					t.Setenv(config.ConfigKeyToEnv(config.DefaultEnvPrefix, "Warehouse.loadFiles.maxSizeInMB"), tc.maxSizeInMB)
+				}
+				db, minioResource, whClient := setupServer(t, false, nil, nil)
 
-			var (
-				ctx    = context.Background()
-				events = 100
-				jobs   = 1
-			)
-			eventsPayload := strings.Join(lo.RepeatBy(events, func(int) string {
-				return fmt.Sprintf(`{"data":{"id":%q,"user_id":%q,"received_at":"2023-05-12T04:36:50.199Z"},"metadata":{"columns":{"id":"string","user_id":"string","received_at":"datetime"}, "table": "tracks"}}`,
-					uuid.New().String(),
-					uuid.New().String(),
+				var (
+					ctx    = context.Background()
+					events = 100
+					jobs   = 1
 				)
-			}), "\n")
-
-			require.NoError(t, whClient.Process(ctx, whclient.StagingFile{
-				WorkspaceID:      workspaceID,
-				SourceID:         sourceID,
-				DestinationID:    destinationID,
-				Location:         prepareStagingFile(t, ctx, minioResource, eventsPayload).ObjectName,
-				TotalEvents:      events,
-				FirstEventAt:     time.Now().Format(misc.RFC3339Milli),
-				LastEventAt:      time.Now().Add(time.Minute * 30).Format(misc.RFC3339Milli),
-				UseRudderStorage: false,
-				BytesPerTable: map[string]int64{
-					"tracks": int64(len(eventsPayload)),
-				},
-				DestinationRevisionID: destinationID,
-				Schema: map[string]map[string]string{
-					"tracks": {
-						"id":          "string",
-						"user_id":     "string",
-						"received_at": "datetime",
+				eventsPayload := strings.Join(lo.RepeatBy(events, func(int) string {
+					return fmt.Sprintf(`{"data":{"id":%q,"user_id":%q,"received_at":"2023-05-12T04:36:50.199Z"},"metadata":{"columns":{"id":"string","user_id":"string","received_at":"datetime"}, "table": "tracks"}}`,
+						uuid.New().String(),
+						uuid.New().String(),
+					)
+				}), "\n")
+				stagingFile := whclient.StagingFile{
+					WorkspaceID:      workspaceID,
+					SourceID:         sourceID,
+					DestinationID:    destinationID,
+					TotalEvents:      events,
+					FirstEventAt:     time.Now().Format(misc.RFC3339Milli),
+					LastEventAt:      time.Now().Add(time.Minute * 30).Format(misc.RFC3339Milli),
+					UseRudderStorage: false,
+					BytesPerTable: map[string]int64{
+						"tracks": int64(len(eventsPayload)),
 					},
-				},
-			}))
-			requireStagingFileEventsCount(t, ctx, db, events, []lo.Tuple2[string, any]{
-				{A: "source_id", B: sourceID},
-				{A: "destination_id", B: destinationID},
-				{A: "status", B: succeeded},
-			}...)
-			requireTableUploadEventsCount(t, ctx, db, events, []lo.Tuple2[string, any]{
-				{A: "status", B: exportedData},
-				{A: "wh_uploads.source_id", B: sourceID},
-				{A: "wh_uploads.destination_id", B: destinationID},
-				{A: "wh_uploads.namespace", B: namespace},
-			}...)
-			requireUploadJobsCount(t, ctx, db, jobs, []lo.Tuple2[string, any]{
-				{A: "source_id", B: sourceID},
-				{A: "destination_id", B: destinationID},
-				{A: "namespace", B: namespace},
-				{A: "status", B: exportedData},
-			}...)
-			requireDownstreamEventsCount(t, ctx, db, fmt.Sprintf("%s.%s", namespace, "tracks"), events)
+					DestinationRevisionID: destinationID,
+					Schema: map[string]map[string]string{
+						"tracks": {
+							"id":          "string",
+							"user_id":     "string",
+							"received_at": "datetime",
+						},
+					},
+				}
+				stagingFile.Location = prepareStagingFileWithFileName(t, ctx, minioResource, eventsPayload, "staging1.json").ObjectName
+				require.NoError(t, whClient.Process(ctx, stagingFile))
+
+				// Create a new eventsPayload with different IDs for the second staging file
+				eventsPayload2 := strings.Join(lo.RepeatBy(events, func(int) string {
+					return fmt.Sprintf(`{"data":{"id":%q,"user_id":%q,"received_at":"2023-05-12T04:36:50.199Z"},"metadata":{"columns":{"id":"string","user_id":"string","received_at":"datetime"}, "table": "tracks"}}`,
+						uuid.New().String(),
+						uuid.New().String(),
+					)
+				}), "\n")
+				stagingFile.Location = prepareStagingFileWithFileName(t, ctx, minioResource, eventsPayload2, "staging2.json").ObjectName
+				require.NoError(t, whClient.Process(ctx, stagingFile))
+				requireStagingFileEventsCount(t, ctx, db, 2*events, []lo.Tuple2[string, any]{
+					{A: "source_id", B: sourceID},
+					{A: "destination_id", B: destinationID},
+					{A: "status", B: succeeded},
+				}...)
+				requireTableUploadEventsCount(t, ctx, db, 2*events, []lo.Tuple2[string, any]{
+					{A: "status", B: exportedData},
+					{A: "wh_uploads.source_id", B: sourceID},
+					{A: "wh_uploads.destination_id", B: destinationID},
+					{A: "wh_uploads.namespace", B: namespace},
+				}...)
+				requireUploadJobsCount(t, ctx, db, jobs, []lo.Tuple2[string, any]{
+					{A: "source_id", B: sourceID},
+					{A: "destination_id", B: destinationID},
+					{A: "namespace", B: namespace},
+					{A: "status", B: exportedData},
+				}...)
+				requireDownstreamEventsCount(t, ctx, db, fmt.Sprintf("%s.%s", namespace, "tracks"), 2*events)
+			})
 		}
 	})
 	t.Run("user and identifies loading", func(t *testing.T) {
@@ -2204,8 +2219,18 @@ func prepareStagingFile(
 	payload string,
 ) filemanager.UploadedFile {
 	t.Helper()
+	return prepareStagingFileWithFileName(t, ctx, minioResource, payload, "staging.json")
+}
 
-	filePath := path.Join(t.TempDir(), "staging.json")
+func prepareStagingFileWithFileName(
+	t testing.TB,
+	ctx context.Context,
+	minioResource *minio.Resource,
+	payload string,
+	fileName string,
+) filemanager.UploadedFile {
+	t.Helper()
+	filePath := path.Join(t.TempDir(), fileName)
 
 	gz, err := misc.CreateGZ(filePath)
 	require.NoError(t, err)

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/datatype.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/datatype.go
@@ -200,6 +200,8 @@ func addDataAndMetadataForContextGeoEnrichment(tec *transformEventContext, data 
 			}
 			data[timezoneKey], metadata[timezoneKey] = geoLocation.Timezone, model.StringDataType
 		}
+		return nil
 	}
+	data[key] = val
 	return nil
 }

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/events_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/events_test.go
@@ -2034,7 +2034,7 @@ func TestEvents(t *testing.T) {
 			},
 			{
 				name:         "track (POSTGRES) jsonPaths (escape characters for &, <, and >)",
-				eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"location": {"city":"Palo Alto <p>Ampersand: &;</p> Palo Alto","state":"California","country":"USA","coordinates":{"latitude":37.4419,"longitude":-122.143,"geo":{"altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}},"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"location": {"radiation_level": 0.000000006, "city":"Palo Alto <p>Ampersand: &;</p> Palo Alto","state":"California","country":"USA","coordinates":{"latitude":37.4419,"longitude":-122.143,"geo":{"altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}},"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
 				metadata:     getTrackMetadata("POSTGRES", "webhook"),
 				destination: getDestination("POSTGRES", map[string]any{
 					"jsonPaths": "location",
@@ -2048,7 +2048,7 @@ func TestEvents(t *testing.T) {
 						},
 						{
 							Output: trackEventDefaultOutput().
-								SetDataField("location", "{\"city\":\"Palo Alto <p>Ampersand: &;</p> Palo Alto\",\"coordinates\":{\"geo\":{\"accuracy\":5,\"altitude\":30.5,\"details\":{\"accuracyUnits\":\"meters\",\"altitudeUnits\":\"meters\"}},\"latitude\":37.4419,\"longitude\":-122.143},\"country\":\"USA\",\"state\":\"California\"}").
+								SetDataField("location", "{\"city\":\"Palo Alto <p>Ampersand: &;</p> Palo Alto\",\"coordinates\":{\"geo\":{\"accuracy\":5,\"altitude\":30.5,\"details\":{\"accuracyUnits\":\"meters\",\"altitudeUnits\":\"meters\"}},\"latitude\":37.4419,\"longitude\":-122.143},\"country\":\"USA\",\"radiation_level\":6e-9,\"state\":\"California\"}").
 								SetColumnField("location", "json"),
 							Metadata:   getTrackMetadata("POSTGRES", "webhook"),
 							StatusCode: http.StatusOK,

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/events_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/events_test.go
@@ -2034,7 +2034,7 @@ func TestEvents(t *testing.T) {
 			},
 			{
 				name:         "track (POSTGRES) jsonPaths (escape characters for &, <, and >)",
-				eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"location": {"radiation_level": 0.000000006, "city":"Palo Alto <p>Ampersand: &;</p> Palo Alto","state":"California","country":"USA","coordinates":{"latitude":37.4419,"longitude":-122.143,"geo":{"altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}},"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
+				eventPayload: `{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"location": {"radiation_level": 0.000000006, "city":"Palo Alto \b <p>Ampersand: &;</p> Palo Alto","state":"California","country":"USA","coordinates":{"latitude":37.4419,"longitude":-122.143,"geo":{"altitude":30.5,"accuracy":5,"details":{"altitudeUnits":"meters","accuracyUnits":"meters"}}}},"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},"ip":"1.2.3.4"}}`,
 				metadata:     getTrackMetadata("POSTGRES", "webhook"),
 				destination: getDestination("POSTGRES", map[string]any{
 					"jsonPaths": "location",
@@ -2048,7 +2048,7 @@ func TestEvents(t *testing.T) {
 						},
 						{
 							Output: trackEventDefaultOutput().
-								SetDataField("location", "{\"city\":\"Palo Alto <p>Ampersand: &;</p> Palo Alto\",\"coordinates\":{\"geo\":{\"accuracy\":5,\"altitude\":30.5,\"details\":{\"accuracyUnits\":\"meters\",\"altitudeUnits\":\"meters\"}},\"latitude\":37.4419,\"longitude\":-122.143},\"country\":\"USA\",\"radiation_level\":6e-9,\"state\":\"California\"}").
+								SetDataField("location", "{\"city\":\"Palo Alto \\b <p>Ampersand: &;</p> Palo Alto\",\"coordinates\":{\"geo\":{\"accuracy\":5,\"altitude\":30.5,\"details\":{\"accuracyUnits\":\"meters\",\"altitudeUnits\":\"meters\"}},\"latitude\":37.4419,\"longitude\":-122.143},\"country\":\"USA\",\"radiation_level\":6e-9,\"state\":\"California\"}").
 								SetColumnField("location", "json"),
 							Metadata:   getTrackMetadata("POSTGRES", "webhook"),
 							StatusCode: http.StatusOK,

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils/utils.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils/utils.go
@@ -12,6 +12,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+
 	"github.com/rudderlabs/rudder-server/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/model"
 	"github.com/rudderlabs/rudder-server/processor/types"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -49,6 +50,8 @@ var (
 
 	minTimeInMs = time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
 	maxTimeInMs = time.Date(9999, 12, 31, 23, 59, 59, 999000000, time.UTC)
+
+	jsonrsStd = jsonrs.NewWithLibrary(jsonrs.StdLib)
 )
 
 func init() {
@@ -246,7 +249,7 @@ func ExtractReceivedAt(event *types.TransformerEvent, now func() time.Time) stri
 func MarshalJSON(input any) ([]byte, error) {
 	var buf bytes.Buffer
 
-	enc := jsonrs.NewEncoder(&buf)
+	enc := jsonrsStd.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
 
 	if err := enc.Encode(input); err != nil {

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/set.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/set.go
@@ -87,12 +87,12 @@ func addDataAndMetadata(tec *transformEventContext, key string, val any, isJSONK
 		return nil
 	}
 
-	dataType := dataTypeFor(tec.event.Metadata.DestinationType, key, val, isJSONKey)
+	dataType := dataTypeFor(tec.event.Metadata.DestinationType, safeKey, val, isJSONKey)
 	metadata[safeKey] = dataType
 
 	switch safeKey {
 	case "context_geo", "CONTEXT_GEO":
-		if err := addDataAndMetadataForContextGeoEnrichment(tec, data, metadata, key, val); err != nil {
+		if err := addDataAndMetadataForContextGeoEnrichment(tec, data, metadata, safeKey, val); err != nil {
 			return fmt.Errorf("adding context geo enrichment: %w", err)
 		}
 	case "context_tracking_plan_version", "CONTEXT_TRACKING_PLAN_VERSION":

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/transformer.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/transformer.go
@@ -98,7 +98,7 @@ func New(conf *config.Config, logger logger.Logger, statsFactory stats.Stats, op
 	t.config.populateSrcDestInfoInContext = conf.GetReloadableBoolVar(true, "WH_POPULATE_SRC_DEST_INFO_IN_CONTEXT")
 	t.config.maxColumnsInEvent = conf.GetReloadableIntVar(200, 1, "WH_MAX_COLUMNS_IN_EVENT")
 	t.config.maxLoggedEvents = conf.GetReloadableIntVar(100, 1, "Warehouse.Transformer.Sampling.maxLoggedEvents")
-	t.config.concurrentTransformations = conf.GetReloadableIntVar(10, 1, "Warehouse.concurrentTransformations")
+	t.config.concurrentTransformations = conf.GetReloadableIntVar(1, 1, "Warehouse.concurrentTransformations")
 	t.config.instanceID = conf.GetString("INSTANCE_ID", "1")
 
 	var err error

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"path"
-	"slices"
 	"strings"
 	"time"
 
@@ -101,11 +100,6 @@ func (t *Transformer) sampleDiff(events []types.TransformerEvent, legacyResponse
 		return "" // Don't diff in case there is no response from transformer
 	}
 
-	sortTransformerResponsesByJobID(legacyResponse.Events)
-	sortTransformerResponsesByJobID(legacyResponse.FailedEvents)
-	sortTransformerResponsesByJobID(embeddedResponse.Events)
-	sortTransformerResponsesByJobID(embeddedResponse.FailedEvents)
-
 	// If the event counts differ, return all events in the transformation
 	if len(legacyResponse.Events) != len(embeddedResponse.Events) || len(legacyResponse.FailedEvents) != len(embeddedResponse.FailedEvents) {
 		t.stats.mismatchedEvents.Observe(float64(len(events)))
@@ -140,12 +134,6 @@ func (t *Transformer) sampleDiff(events []types.TransformerEvent, legacyResponse
 	t.stats.matchedEvents.Observe(float64(len(legacyResponse.Events) - differedEventsCount))
 	t.stats.mismatchedEvents.Observe(float64(differedEventsCount))
 	return sampleDiff
-}
-
-func sortTransformerResponsesByJobID(responses []types.TransformerResponse) {
-	slices.SortStableFunc(responses, func(a, b types.TransformerResponse) int {
-		return int(a.Metadata.JobID - b.Metadata.JobID)
-	})
 }
 
 func write(w io.WriteCloser, data []string) error {

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader.go
@@ -33,9 +33,8 @@ func (t *Transformer) CompareResponsesAndUpload(ctx context.Context, events []ty
 	if t.loggedSamples.Load() >= int64(t.config.maxLoggedEvents.Load()) {
 		return
 	}
-	defer t.stats.comparisonTime.RecordDuration()()
-
 	go func() {
+		defer t.stats.comparisonTime.RecordDuration()()
 		t.compareResponsesAndUpload(ctx, events, legacyResponse)
 	}()
 }

--- a/processor/internal/transformer/destination_transformer/logger.go
+++ b/processor/internal/transformer/destination_transformer/logger.go
@@ -28,8 +28,8 @@ func (c *Client) CompareAndLog(
 	if c.loggedEvents.Load() >= int64(c.config.maxLoggedEvents.Load()) {
 		return
 	}
-	defer c.stats.comparisonTime.RecordDuration()()
 	go func() {
+		defer c.stats.comparisonTime.RecordDuration()()
 		c.compareAndLog(ctx, embeddedResponse, legacyResponse)
 	}()
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"path"
 	"runtime/trace"
 	"slices"
 	"strconv"
@@ -29,6 +30,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stringify"
 	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/enterprise/trackedusers"
 	"github.com/rudderlabs/rudder-server/internal/enricher"
@@ -125,6 +127,7 @@ type Handle struct {
 	transientSources           transientsource.Service
 	fileuploader               fileuploader.Provider
 	utSamplingFileManager      filemanager.FileManager
+	storeSamplingFileManager   filemanager.FileManager
 	rsourcesService            rsources.JobService
 	transformerFeaturesService transformerFeaturesService.FeaturesService
 	destDebugger               destinationdebugger.DestinationDebugger
@@ -177,6 +180,7 @@ type Handle struct {
 		enableConcurrentStore                     config.ValueLoader[bool]
 		userTransformationMirroringSanitySampling config.ValueLoader[float64]
 		userTransformationMirroringFireAndForget  config.ValueLoader[bool]
+		storeSamplerEnabled                       config.ValueLoader[bool]
 	}
 
 	drainConfig struct {
@@ -432,6 +436,10 @@ func (proc *Handle) Setup(
 	if err != nil {
 		proc.logger.Errorn("failed to create ut sampling file manager", obskit.Error(err))
 		proc.utSamplingFileManager = nil
+	}
+	proc.storeSamplingFileManager, err = getStoreSamplingUploader(proc.conf, proc.logger)
+	if err != nil {
+		proc.logger.Errorn("failed to create store sampling file manager", obskit.Error(err))
 	}
 
 	if proc.adaptiveLimit == nil {
@@ -776,6 +784,7 @@ func (proc *Handle) loadReloadableConfig(defaultPayloadLimit int64, defaultMaxEv
 	// UserTransformation mirroring settings
 	proc.config.userTransformationMirroringSanitySampling = proc.conf.GetReloadableFloat64Var(0, "Processor.userTransformationMirroring.sanitySampling")
 	proc.config.userTransformationMirroringFireAndForget = proc.conf.GetReloadableBoolVar(false, "Processor.userTransformationMirroring.fireAndForget")
+	proc.config.storeSamplerEnabled = proc.conf.GetReloadableBoolVar(false, "Processor.storeSamplerEnabled")
 }
 
 type connection struct {
@@ -2606,7 +2615,29 @@ func (proc *Handle) storeStage(partition string, in *storeMessage) {
 						func(tx jobsdb.StoreSafeTx) error {
 							err := proc.batchRouterDB.StoreInTx(ctx, tx, batchDestJobs)
 							if err != nil {
-								return fmt.Errorf("storing batch router jobs: %w", err)
+								storeErr := fmt.Errorf("storing batch router jobs: %w", err)
+								if !proc.config.storeSamplerEnabled.Load() {
+									return storeErr
+								}
+								if proc.storeSamplingFileManager == nil {
+									proc.logger.Errorn("Cannot upload as store sampling file manager is nil")
+								} else {
+									batchDestJobsJSON, err := jsonrs.Marshal(batchDestJobs)
+									if err != nil {
+										return fmt.Errorf("marshalling batch router jobs: %w: %w ", storeErr, err)
+									}
+
+									objName := path.Join("proc-samples", proc.instanceID, uuid.NewString())
+									uploadFile, err := proc.storeSamplingFileManager.UploadReader(ctx, objName, strings.NewReader(string(batchDestJobsJSON)))
+									if err != nil {
+										return fmt.Errorf("uploading sample batch router jobs: %w: %w", storeErr, err)
+									}
+									proc.logger.Infon("Successfully upload proc sample",
+										logger.NewStringField("location", uploadFile.Location),
+										logger.NewStringField("objectName", uploadFile.ObjectName),
+									)
+								}
+								return storeErr
 							}
 
 							// rsources stats
@@ -2744,6 +2775,32 @@ func (proc *Handle) storeStage(partition string, in *storeMessage) {
 	proc.stats.statDBW(partition).Since(beforeStoreStatus)
 	proc.logger.Debugf("Processor GW DB Write Complete. Total Processed: %v", len(statusList))
 	proc.stats.statGatewayDBW(partition).Count(len(statusList))
+}
+
+func getStoreSamplingUploader(conf *config.Config, log logger.Logger) (filemanager.S3Manager, error) {
+	var (
+		bucket           = conf.GetStringVar("rudder-customer-sample-payloads", "Processor.Store.Sampling.Bucket")
+		regionHint       = conf.GetStringVar("us-east-1", "Processor.Store.Sampling.RegionHint", "AWS_S3_REGION_HINT")
+		endpoint         = conf.GetStringVar("", "Processor.Store.Sampling.Endpoint")
+		accessKeyID      = conf.GetStringVar("", "Processor.Store.Sampling.AccessKey", "AWS_ACCESS_KEY_ID")
+		secretAccessKey  = conf.GetStringVar("", "Processor.Store.Sampling.SecretAccessKey", "AWS_SECRET_ACCESS_KEY")
+		s3ForcePathStyle = conf.GetBoolVar(false, "Processor.Store.Sampling.S3ForcePathStyle")
+		disableSSL       = conf.GetBoolVar(false, "Processor.Store.Sampling.DisableSSL")
+		enableSSE        = conf.GetBoolVar(false, "Processor.Store.Sampling.EnableSSE", "AWS_ENABLE_SSE")
+	)
+	s3Config := map[string]any{
+		"bucketName":       bucket,
+		"regionHint":       regionHint,
+		"endpoint":         endpoint,
+		"accessKeyID":      accessKeyID,
+		"secretAccessKey":  secretAccessKey,
+		"s3ForcePathStyle": s3ForcePathStyle,
+		"disableSSL":       disableSSL,
+		"enableSSE":        enableSSE,
+	}
+	return filemanager.NewS3Manager(conf, s3Config, log.Withn(logger.NewStringField("component", "proc-uploader")), func() time.Duration {
+		return conf.GetDuration("Processor.Store.Sampling.Timeout", 120, time.Second)
+	})
 }
 
 // getJobCountsByWorkspaceDestType returns the number of jobs per workspace and destination type

--- a/utils/misc/dbutils.go
+++ b/utils/misc/dbutils.go
@@ -62,8 +62,11 @@ func NewDatabaseConnectionPool(
 	); err != nil {
 		return nil, fmt.Errorf("Error registering database stats collector: %w", err)
 	}
-
-	maxConnsVar := conf.GetReloadableIntVar(40, 1, "db."+componentName+".pool.maxOpenConnections", "db.pool.maxOpenConnections")
+	defaultMaxOpenConnections := 80
+	if componentName == "gateway-app" {
+		defaultMaxOpenConnections = 20
+	}
+	maxConnsVar := conf.GetReloadableIntVar(defaultMaxOpenConnections, 1, "db."+componentName+".pool.maxOpenConnections", "db.pool.maxOpenConnections")
 	maxConns := maxConnsVar.Load()
 	db.SetMaxOpenConns(maxConns)
 

--- a/utils/misc/dbutils_test.go
+++ b/utils/misc/dbutils_test.go
@@ -151,7 +151,7 @@ func TestCommonPool(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.Ping())
 	defer db.Close()
-	require.Equal(t, 40, db.Stats().MaxOpenConnections)
+	require.Equal(t, 80, db.Stats().MaxOpenConnections)
 
 	conf.Set("db.test.pool.maxOpenConnections", 5)
 	time.Sleep(100 * time.Millisecond)

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -153,6 +153,7 @@ type Clickhouse struct {
 		s3EngineEnabledWorkspaceIDs []string
 		slowQueryThreshold          time.Duration
 		randomLoadDelay             func(string) time.Duration
+		disableLoadTableStats       func(string) bool
 	}
 }
 
@@ -228,6 +229,13 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats) *Clickhouse {
 	ch.config.numWorkersDownloadLoadFiles = conf.GetInt("Warehouse.clickhouse.numWorkersDownloadLoadFiles", 8)
 	ch.config.s3EngineEnabledWorkspaceIDs = conf.GetStringSlice("Warehouse.clickhouse.s3EngineEnabledWorkspaceIDs", nil)
 	ch.config.slowQueryThreshold = conf.GetDuration("Warehouse.clickhouse.slowQueryThreshold", 5, time.Minute)
+	ch.config.disableLoadTableStats = func(workspaceID string) bool {
+		return conf.GetBoolVar(
+			false,
+			fmt.Sprintf("Warehouse.clickhouse.%s.disableLoadTableStats", workspaceID),
+			"Warehouse.clickhouse.disableLoadTableStats",
+		)
+	}
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	ch.config.randomLoadDelay = func(workspaceID string) time.Duration {
 		maxDelay := conf.GetDurationVar(
@@ -1029,9 +1037,15 @@ func (ch *Clickhouse) LoadUserTables(ctx context.Context) (errorMap map[string]e
 }
 
 func (ch *Clickhouse) LoadTable(ctx context.Context, tableName string) (*types.LoadTableStats, error) {
-	preLoadTableCount, err := ch.totalCountIntable(ctx, tableName)
-	if err != nil {
-		return nil, fmt.Errorf("pre load table count: %w", err)
+	var (
+		preLoadTableCount int64
+		err               error
+	)
+	if !ch.config.disableLoadTableStats(ch.Warehouse.WorkspaceID) {
+		preLoadTableCount, err = ch.totalCountIntable(ctx, tableName)
+		if err != nil {
+			return nil, fmt.Errorf("pre load table count: %w", err)
+		}
 	}
 
 	err = ch.loadTable(ctx, tableName, ch.Uploader.GetTableSchemaInUpload(tableName))
@@ -1039,9 +1053,12 @@ func (ch *Clickhouse) LoadTable(ctx context.Context, tableName string) (*types.L
 		return nil, fmt.Errorf("loading table: %w", err)
 	}
 
-	postLoadTableCount, err := ch.totalCountIntable(ctx, tableName)
-	if err != nil {
-		return nil, fmt.Errorf("post load table count: %w", err)
+	var postLoadTableCount int64
+	if !ch.config.disableLoadTableStats(ch.Warehouse.WorkspaceID) {
+		postLoadTableCount, err = ch.totalCountIntable(ctx, tableName)
+		if err != nil {
+			return nil, fmt.Errorf("post load table count: %w", err)
+		}
 	}
 
 	return &types.LoadTableStats{

--- a/warehouse/integrations/clickhouse/clickhouse_test.go
+++ b/warehouse/integrations/clickhouse/clickhouse_test.go
@@ -556,26 +556,36 @@ func TestIntegration(t *testing.T) {
 			fileName                    string
 			S3EngineEnabledWorkspaceIDs []string
 			disableNullable             bool
+			disableLoadTableStats       bool
 		}{
 			{
-				name:     "normal loading using downloading of load files",
-				fileName: "testdata/load.csv.gz",
+				name:                  "normal loading using downloading of load files",
+				fileName:              "testdata/load.csv.gz",
+				disableLoadTableStats: false,
 			},
 			{
 				name:                        "using s3 engine for loading",
 				S3EngineEnabledWorkspaceIDs: []string{workspaceID},
 				fileName:                    "testdata/load-copy.csv.gz",
+				disableLoadTableStats:       false,
 			},
 			{
-				name:            "normal loading using downloading of load files with disable nullable",
-				fileName:        "testdata/load.csv.gz",
-				disableNullable: true,
+				name:                  "normal loading using downloading of load files with disable nullable",
+				fileName:              "testdata/load.csv.gz",
+				disableNullable:       true,
+				disableLoadTableStats: false,
 			},
 			{
 				name:                        "using s3 engine for loading with disable nullable",
 				S3EngineEnabledWorkspaceIDs: []string{workspaceID},
 				fileName:                    "testdata/load-copy.csv.gz",
 				disableNullable:             true,
+				disableLoadTableStats:       false,
+			},
+			{
+				name:                  "normal loading using downloading of load files with disable load table stats",
+				fileName:              "testdata/load.csv.gz",
+				disableLoadTableStats: true,
 			},
 		}
 
@@ -584,6 +594,7 @@ func TestIntegration(t *testing.T) {
 				conf := config.New()
 				conf.Set("Warehouse.clickhouse.s3EngineEnabledWorkspaceIDs", tc.S3EngineEnabledWorkspaceIDs)
 				conf.Set("Warehouse.clickhouse.disableNullable", tc.disableNullable)
+				conf.Set("Warehouse.clickhouse.disableLoadTableStats", tc.disableLoadTableStats)
 
 				ch := clickhouse.New(conf, logger.NOP, stats.NOP)
 
@@ -733,8 +744,11 @@ func TestIntegration(t *testing.T) {
 				}
 
 				t.Log("Loading data into table")
-				_, err = ch.LoadTable(ctx, table)
+				loadTableStats, err := ch.LoadTable(ctx, table)
 				require.NoError(t, err)
+				if !tc.disableLoadTableStats {
+					require.NotEmpty(t, loadTableStats.RowsInserted)
+				}
 
 				t.Log("Drop table")
 				err = ch.DropTable(ctx, table)

--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -492,7 +492,7 @@ func (lf *LoadFileGenerator) createUploadV2Jobs(ctx context.Context, job *model.
 		return fmt.Errorf("populating destination revision ID: %w", err)
 	}
 	g, gCtx := errgroup.WithContext(ctx)
-	stagingFileGroups := lf.GroupStagingFiles(stagingFiles, lf.Conf.GetInt("Warehouse.loadFiles.maxSizeInMB", 128))
+	stagingFileGroups := lf.GroupStagingFiles(stagingFiles, lf.Conf.GetInt("Warehouse.loadFiles.maxSizeInMB", 512))
 	for i, fileGroups := range lo.Chunk(stagingFileGroups, publishBatchSize) {
 		for j, group := range fileGroups {
 			lf.Logger.Infon("Processing chunk and group",

--- a/warehouse/internal/repo/table_upload.go
+++ b/warehouse/internal/repo/table_upload.go
@@ -194,27 +194,13 @@ func (tu *TableUploads) PopulateTotalEventsWithTx(ctx context.Context, tx *sqlmi
 	var queryArgs []any
 	if tu.queryLoadFilesWithUploadID.Load() {
 		subQuery = `
-		WITH row_numbered_load_files as (
-		  SELECT
-			total_events,
-			row_number() OVER (
-			  PARTITION BY upload_id,
-			  table_name
-			  ORDER BY
-				id DESC
-			) AS row_number
-		  FROM
-			` + loadTableName + `
-		  WHERE
-			upload_id = $1
-			AND table_name = $2
-		)
 		SELECT
 		  sum(total_events) as total
 		FROM
-		  row_numbered_load_files
+		  ` + loadTableName + `
 		WHERE
-		  row_number = 1
+		  upload_id = $1
+		AND table_name = $2
 `
 		queryArgs = []any{
 			uploadId,

--- a/warehouse/internal/repo/table_upload_test.go
+++ b/warehouse/internal/repo/table_upload_test.go
@@ -380,6 +380,10 @@ func TestTableUploadRepo(t *testing.T) {
 					TableName: tables2[i],
 					TotalRows: i + 1,
 					UploadID:  &uploadId,
+				}, model.LoadFile{
+					TableName: tables2[i],
+					TotalRows: i + 1,
+					UploadID:  &uploadId,
 				})
 			}
 			insertErr := l.Insert(ctx, loadFiles)
@@ -395,7 +399,7 @@ func TestTableUploadRepo(t *testing.T) {
 			require.NoError(t, txErr)
 			for _, loadFile := range loadFiles {
 				tableName := loadFile.TableName
-				expectedTotal := int64(loadFile.TotalRows)
+				expectedTotal := 2 * int64(loadFile.TotalRows) // Since there are 2 load files for each table
 				tableUpload, getErr := r.GetByUploadIDAndTableName(ctx, uploadId, tableName)
 				require.NoError(t, getErr)
 				require.Equal(t, uploadId, tableUpload.UploadID)

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -860,27 +860,14 @@ func (job *UploadJob) GetLoadFilesMetadata(ctx context.Context, options whutils.
 func (job *UploadJob) getLoadFilesMetadataQuery(tableFilterSQL, limitSQL string) string {
 	if job.config.queryLoadFilesWithUploadID.Load() {
 		return fmt.Sprintf(`
-			WITH row_numbered_load_files as (
-			  SELECT
-				location,
-				metadata,
-				row_number() OVER (
-				PARTITION BY upload_id,
-				table_name
-				ORDER BY
-					id DESC
-				) AS row_number
-			  FROM
-				%[1]s
-			  WHERE upload_id = %[2]d %[3]s
-			)
 			SELECT
 			  location,
 			  metadata
 			FROM
-			  row_numbered_load_files
+			  %[1]s
 			WHERE
-			  row_number = 1
+			  upload_id = %[2]d
+			%[3]s
 			%[4]s;
 			`,
 			whutils.WarehouseLoadFilesTable,

--- a/warehouse/router/upload_test.go
+++ b/warehouse/router/upload_test.go
@@ -748,12 +748,33 @@ func TestUploadJob_GetLoadFilesMetadata(t *testing.T) {
 	testCases := []struct {
 		name              string
 		queryWithUploadID bool
+		tableName         string
+		limit             int64
 		expectedLoadFiles int
 	}{
 		{
 			name:              "query with upload ID",
 			queryWithUploadID: true,
+			expectedLoadFiles: 4,
+		},
+		{
+			name:              "query with upload ID and table name",
+			queryWithUploadID: true,
+			tableName:         "test_table2",
+			expectedLoadFiles: 3,
+		},
+		{
+			name:              "query with upload ID, table name and limit",
+			queryWithUploadID: true,
+			tableName:         "test_table2",
+			limit:             2,
 			expectedLoadFiles: 2,
+		},
+		{
+			name:              "query with upload ID and limit",
+			queryWithUploadID: true,
+			limit:             1,
+			expectedLoadFiles: 1,
 		},
 		{
 			name:              "query with staging file IDs",
@@ -791,10 +812,21 @@ func TestUploadJob_GetLoadFilesMetadata(t *testing.T) {
 					UploadID:  &job.upload.ID,
 					TableName: "test_table2",
 				},
+				{
+					UploadID:  &job.upload.ID,
+					TableName: "test_table2",
+				},
+				{
+					UploadID:  &job.upload.ID,
+					TableName: "test_table2",
+				},
 			}
 			err := repo.NewLoadFiles(db, conf).Insert(ctx, loadFiles)
 			require.NoError(t, err)
-			result, err := job.GetLoadFilesMetadata(ctx, warehouseutils.GetLoadFilesOptions{})
+			result, err := job.GetLoadFilesMetadata(ctx, warehouseutils.GetLoadFilesOptions{
+				Table: tc.tableName,
+				Limit: tc.limit,
+			})
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedLoadFiles, len(result))
 		})


### PR DESCRIPTION
# Description

Syncing patch release v1.50.6 to main branch

**↓↓ Please review and edit commit overrides before merging ↓↓**

BEGIN_COMMIT_OVERRIDE
fix: warehouse transformations geo enrichment as string (#5907)
fix: under reporting of load files when using upload id (#5889) (#5906)
fix(processor): throughput stalling due to mutex deadlock on full connection pool (#5919)
chore: warehouse transformations json diff with encoding (#5937)
chore: proc sample store uploader (#5917)
fix: use jsonrs stdlib for encoding warehouse transformations (#5945)
chore: add config to disable load table stats for clickhouse (#5932)
fix: warehouse transformations responses ordering (#5954)
END_COMMIT_OVERRIDE