### PR TITLE
fix: router request failing with unsupported media type error

### DIFF
--- a/router/network.go
+++ b/router/network.go
@@ -126,7 +126,6 @@ func (network *netHandle) SendPost(ctx context.Context, structData integrations.
 				if err != nil {
 					panic(err)
 				}
-				headers["Content-Type"] = "application/json"
 				payload = strings.NewReader(string(jsonValue))
 			case "JSON_ARRAY":
 				// support for JSON ARRAY
@@ -152,7 +151,6 @@ func (network *netHandle) SendPost(ctx context.Context, structData integrations.
 				for key, val := range bodyValue {
 					formValues.Set(key, fmt.Sprint(val)) // transformer ensures top level string values, still val.(string) would be restrictive
 				}
-				headers["Content-Type"] = "application/x-www-form-urlencoded"
 				payload = strings.NewReader(formValues.Encode())
 			case "GZIP":
 				strValue, ok := bodyValue["payload"].(string)

--- a/router/network_test.go
+++ b/router/network_test.go
@@ -424,7 +424,6 @@ func TestSendPost(t *testing.T) {
 		}
 
 		mockHTTPClient.EXPECT().Do(gomock.Any()).Times(1).Do(func(req *http.Request) {
-			require.Equal(t, "application/json", req.Header.Get("Content-Type"))
 			require.Equal(t, "RudderLabs", req.Header.Get("User-Agent"))
 			body, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
@@ -461,7 +460,6 @@ func TestSendPost(t *testing.T) {
 		}
 
 		mockHTTPClient.EXPECT().Do(gomock.Any()).Times(1).Do(func(req *http.Request) {
-			require.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
 			require.Equal(t, "RudderLabs", req.Header.Get("User-Agent"))
 			body, err := io.ReadAll(req.Body)
 			require.NoError(t, err)


### PR DESCRIPTION
# Description

Remove excess headers in `network.go` introduced by #5888


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
