### PR TITLE
fix: warehouse transformations deep copying arguments

### DIFF
--- a/processor/internal/transformer/destination_transformer/destination_transformer.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer.go
@@ -404,7 +404,7 @@ func (c *Client) Transform(ctx context.Context, clientEvents []types.Transformer
 	if c.canRunWarehouseTransformations(destType) {
 		if c.config.warehouseTransformations.verify.Load() {
 			legacyResponse := c.transform(ctx, clientEvents)
-			c.warehouseClient.CompareResponsesAndUpload(ctx, clientEvents, legacyResponse)
+			c.warehouseClient.CompareResponsesAndUpload(ctx, deepCopy(clientEvents), deepCopy(legacyResponse))
 			return legacyResponse
 		}
 		return c.warehouseClient.Transform(ctx, clientEvents)
@@ -424,6 +424,14 @@ func (c *Client) Transform(ctx context.Context, clientEvents []types.Transformer
 		return legacyTransformerResponse
 	}
 	return impl(ctx, clientEvents)
+}
+
+func deepCopy[T any](src T) T {
+	var dst T
+	if data, err := jsonrs.Marshal(src); err == nil {
+		_ = jsonrs.Unmarshal(data, &dst)
+	}
+	return dst
 }
 
 func (c *Client) canRunWarehouseTransformations(destType string) bool {

--- a/processor/internal/transformer/destination_transformer/destination_transformer_test.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer_test.go
@@ -795,10 +795,7 @@ func TestEmbeddedWarehouseTransformer(t *testing.T) {
 				"receivedAt":        "2021-09-01T00:00:00.000Z",
 				"sentAt":            "2021-09-01T00:00:00.000Z",
 				"timestamp":         "2021-09-01T00:00:00.000Z",
-				"traits": map[string]any{
-					"email": float64(12),
-				},
-				"type": "track",
+				"type":              "track",
 			},
 			Metadata: types.Metadata{
 				MessageID:       "messageId" + strconv.Itoa(index+1),

--- a/processor/internal/transformer/destination_transformer/destination_transformer_test.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer_test.go
@@ -12,6 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ory/dockertest/v3"
+	transformertest "github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/transformer"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -22,6 +25,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/gateway/response"
 	transformerutils "github.com/rudderlabs/rudder-server/processor/internal/transformer"
@@ -762,4 +766,126 @@ func TestLongRunningTransformation(t *testing.T) {
 		}
 		cancel()
 	})
+}
+
+func TestEmbeddedWarehouseTransformer(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	transformerResource, err := transformertest.Setup(pool, t)
+	require.NoError(t, err)
+
+	conf := config.New()
+	conf.Set("DEST_TRANSFORM_URL", transformerResource.TransformerURL)
+	conf.Set("USER_TRANSFORM_URL", transformerResource.TransformerURL)
+	conf.Set("Processor.enableWarehouseTransformations", true)
+	conf.Set("Processor.verifyWarehouseTransformations", true)
+
+	ctx := context.Background()
+	eventsCount := 10000
+	trans := destination_transformer.New(conf, logger.NOP, stats.NOP)
+
+	clientEvents := lo.RepeatBy(eventsCount, func(index int) types.TransformerEvent {
+		return types.TransformerEvent{
+			Message: map[string]interface{}{
+				"src-key-1":         "test-value-1",
+				"messageId":         "messageId" + strconv.Itoa(index+1),
+				"event":             "event" + strconv.Itoa(index+1),
+				"originalTimestamp": "2021-09-01T00:00:00.000Z",
+				"receivedAt":        "2021-09-01T00:00:00.000Z",
+				"sentAt":            "2021-09-01T00:00:00.000Z",
+				"timestamp":         "2021-09-01T00:00:00.000Z",
+				"traits": map[string]any{
+					"email": float64(12),
+				},
+				"type": "track",
+			},
+			Metadata: types.Metadata{
+				MessageID:       "messageId" + strconv.Itoa(index+1),
+				ReceivedAt:      "2021-09-01T00:00:00.000Z",
+				SourceID:        "test-source",
+				SourceType:      "JavaScript",
+				DestinationID:   "test-destination",
+				DestinationType: "RS",
+				SourceCategory:  "webhook",
+				EventType:       "track",
+				RecordID:        "test-record",
+				JobID:           int64(index + 1),
+			},
+			Destination: backendconfig.DestinationT{
+				ID: "test-destination",
+				DestinationDefinition: backendconfig.DestinationDefinitionT{
+					Name: "RS",
+				},
+				Config: map[string]any{
+					"skipTracksTable": true,
+				},
+			},
+		}
+	})
+	expectedResponse := lo.Flatten(lo.RepeatBy(eventsCount, func(index int) []types.TransformerResponse {
+		return []types.TransformerResponse{
+			{
+				Output: map[string]any{
+					"data": map[string]any{
+						"context_destination_id":   "test-destination",
+						"context_destination_type": "RS",
+						"context_source_id":        "test-source",
+						"context_source_type":      "JavaScript",
+						"event":                    "event" + strconv.Itoa(index+1),
+						"event_text":               "event" + strconv.Itoa(index+1),
+						"id":                       "messageId" + strconv.Itoa(index+1),
+						"original_timestamp":       "2021-09-01T00:00:00.000Z",
+						"received_at":              "2021-09-01T00:00:00.000Z",
+						"sent_at":                  "2021-09-01T00:00:00.000Z",
+						"timestamp":                "2021-09-01T00:00:00.000Z",
+					},
+					"metadata": map[string]any{
+						"columns": map[string]any{
+							"context_destination_id":   "string",
+							"context_destination_type": "string",
+							"context_source_id":        "string",
+							"context_source_type":      "string",
+							"event":                    "string",
+							"event_text":               "string",
+							"id":                       "string",
+							"original_timestamp":       "datetime",
+							"received_at":              "datetime",
+							"sent_at":                  "datetime",
+							"timestamp":                "datetime",
+							"uuid_ts":                  "datetime",
+						},
+						"receivedAt": "2021-09-01T00:00:00.000Z",
+						"table":      "event" + strconv.Itoa(index+1),
+					},
+					"userId": "",
+				},
+				Metadata: types.Metadata{
+					SourceID:        "test-source",
+					SourceType:      "JavaScript",
+					SourceCategory:  "webhook",
+					DestinationID:   "test-destination",
+					RecordID:        "test-record",
+					DestinationType: "RS",
+					MessageID:       "messageId" + strconv.Itoa(index+1),
+					ReceivedAt:      "2021-09-01T00:00:00.000Z",
+					EventType:       "track",
+					JobID:           int64(index + 1),
+				},
+				StatusCode: 200,
+			},
+		}
+	}))
+
+	r := trans.Transform(ctx, clientEvents)
+	require.Empty(t, r.FailedEvents)
+	require.Len(t, r.Events, eventsCount)
+
+	expectedMessageIDs := lo.Flatten(lo.RepeatBy(eventsCount, func(index int) []string {
+		return []string{"messageId" + strconv.Itoa(index+1)}
+	}))
+	actualMessageIDS := lo.Map(r.Events, func(item types.TransformerResponse, index int) string {
+		return item.Metadata.MessageID
+	})
+	require.ElementsMatch(t, expectedMessageIDs, actualMessageIDS)
+	require.ElementsMatch(t, expectedResponse, r.Events)
 }


### PR DESCRIPTION
# Description

- Using deepcopy for client events and legacy response, so as to be careful of any modifications within the embedded warehouse transformations module.
- Added test within the processor to cover the warehouse transformations component.

## Linear Ticket

- Resolves WAR-762

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
