### PR TITLE
fix: signal handling in NotifyContextWithCallback

### DIFF
--- a/utils/signal/signal.go
+++ b/utils/signal/signal.go
@@ -29,7 +29,6 @@ func NotifyContextWithCallback(fn func(), signals ...os.Signal) (ctx context.Con
 
 	return ctx, func() {
 		cancel()
-		signalCancel()
 		wg.Wait() // Wait for the goroutine to finish before returning
 	}
 }


### PR DESCRIPTION
# Description

test "does not call the callback if context is canceled by us" was flaky as

1. When cancel() is called in the test, it calls both cancel() and signalCancel()
2. The goroutine's select statement might choose either <-signalCtx.Done() or <-ctx.Done()
3. If it happens to select <-signalCtx.Done(), it will incorrectly call the callback function

---

solution: cancel `signalCtx` when ctx is done

## Linear Ticket

-

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
