### PR TITLE
fix: add golang.org/x/net/html vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ replace (
 	github.com/xitongsys/parquet-go => github.com/rudderlabs/parquet-go v0.0.2
 	golang.org/x/image => golang.org/x/image v0.24.0
 	golang.org/x/net => golang.org/x/net v0.34.0
+	golang.org/x/net/html => golang.org/x/net/html v0.41.0
 	golang.org/x/text => golang.org/x/text v0.22.0
 	gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
# Description

add golang.org/x/net/html vulnerability

## Linear Ticket

pipe-2132

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
