### PR TITLE
chore(processor): use pipeline-specific destination locks during store

### DIFF
--- a/processor/partition_worker.go
+++ b/processor/partition_worker.go
@@ -39,7 +39,7 @@ func newPartitionWorker(partition string, h workerHandle, t stats.Tracer) *parti
 	pipelinesPerPartition := h.config().pipelinesPerPartition
 	w.pipelines = make([]*pipelineWorker, pipelinesPerPartition)
 	for i := 0; i < pipelinesPerPartition; i++ {
-		w.pipelines[i] = newPipelineWorker(partition, h, tracing.New(t, tracing.WithNamePrefix("pipelineWorker")))
+		w.pipelines[i] = newPipelineWorker(i, partition, h, tracing.New(t, tracing.WithNamePrefix("pipelineWorker")))
 	}
 
 	return w

--- a/processor/partition_worker_handle.go
+++ b/processor/partition_worker_handle.go
@@ -25,7 +25,7 @@ type workerHandle interface {
 	pretransformStage(partition string, preTrans *preTransformationMessage) (*transformationMessage, error)
 	userTransformStage(partition string, in *transformationMessage) *userTransformData
 	destinationTransformStage(partition string, in *userTransformData) *storeMessage
-	storeStage(partition string, in *storeMessage)
+	storeStage(partition string, pipelineIndex int, in *storeMessage)
 }
 
 // workerHandleConfig is a struct containing the processor.Handle configuration relevant for workers

--- a/processor/partition_worker_test.go
+++ b/processor/partition_worker_test.go
@@ -234,7 +234,7 @@ func (m *mockWorkerHandle) handlePendingGatewayJobs(partition string) bool {
 		if err != nil {
 			return false
 		}
-		m.storeStage(partition, m.destinationTransformStage(partition,
+		m.storeStage(partition, 0, m.destinationTransformStage(partition,
 			m.userTransformStage(partition, dest),
 		))
 	}
@@ -381,7 +381,7 @@ func (m *mockWorkerHandle) destinationTransformStage(partition string, in *userT
 	}
 }
 
-func (m *mockWorkerHandle) storeStage(partition string, in *storeMessage) {
+func (m *mockWorkerHandle) storeStage(partition string, _ int, in *storeMessage) {
 	if m.limiters.store != nil {
 		defer m.limiters.store.Begin("")()
 	}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2591,7 +2591,7 @@ func (proc *Handle) sendQueryRetryStats(attempt int) {
 	stats.Default.NewTaggedStat("jobsdb_query_timeout", stats.CountType, stats.Tags{"attempt": fmt.Sprint(attempt), "module": "processor"}).Count(1)
 }
 
-func (proc *Handle) storeStage(partition string, in *storeMessage) {
+func (proc *Handle) storeStage(partition string, pipelineIndex int, in *storeMessage) {
 	lockRouterDestIDs := func() func() {
 		var deferred []func()
 		if len(in.destJobs) == 0 {
@@ -2601,8 +2601,10 @@ func (proc *Handle) storeStage(partition string, in *storeMessage) {
 			destIDs := lo.Uniq(in.routerDestIDs)
 			slices.Sort(destIDs)
 			for _, destID := range destIDs {
-				proc.storePlocker.Lock(destID)
-				deferred = append(deferred, func() { proc.storePlocker.Unlock(destID) })
+				// Use pipelineIndex in the lock pKey to avoid contention when multiple pipelines are running (each pipeline processes its own exclusive partition of userIDs)
+				pKey := destID + "-" + strconv.Itoa(pipelineIndex)
+				proc.storePlocker.Lock(pKey)
+				deferred = append(deferred, func() { proc.storePlocker.Unlock(pKey) })
 			}
 		} else {
 			proc.logger.Warnn("empty storeMessage.routerDestIDs",
@@ -3745,7 +3747,7 @@ func (proc *Handle) handlePendingGatewayJobs(partition string) bool {
 	if err != nil {
 		panic(err)
 	}
-	proc.storeStage(partition,
+	proc.storeStage(partition, 0,
 		proc.destinationTransformStage(partition,
 			proc.userTransformStage(partition, transMessage)),
 	)

--- a/utils/signal/signal.go
+++ b/utils/signal/signal.go
@@ -29,7 +29,6 @@ func NotifyContextWithCallback(fn func(), signals ...os.Signal) (ctx context.Con
 
 	return ctx, func() {
 		cancel()
-		signalCancel()
 		wg.Wait() // Wait for the goroutine to finish before returning
 	}
 }


### PR DESCRIPTION
# Description

Include the pipeline index when we’re creating the key for `storePlocker`. Since the same userID will always be processed by the same processor pipeline index, we should be fine with this change and wouldn't any cause out-of-order panics in router.

## Linear Ticket

resolves PIPE-2143

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
