### PR TITLE
chore: create enterprise images with an additional race enabled build

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -190,7 +190,7 @@ jobs:
           context: .
           platforms: ${{ matrix.build-config.platform }}
           push: true
-          tags: ${{ matrix.build-config.tags }}{{ matrix.race == 'true' && '-race' || '' }}
+          tags: ${{ matrix.build-config.tags }}${{ matrix.race == 'true' && '-race' || '' }}
           labels: ${{ matrix.build-config.labels }}
           build-args: |
             BUILD_DATE=${{ needs.docker-ent-meta.outputs.build-date }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -172,7 +172,7 @@ jobs:
             tags: ${{needs.docker-ent-meta.outputs.amd64_tags}}
             labels: ${{needs.docker-ent-meta.outputs.amd64_labels}}
             platform: linux/amd64
-        race: [true]
+        race: [false, true]
     runs-on: ${{matrix.build-config.os}}
     steps:
       - name: Checkout

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -125,9 +125,6 @@ jobs:
             REVISION=${{ needs.docker-oss-meta.outputs.revision }}
   docker-ent-meta:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        race: [false, true]
     outputs:
       labels: ${{ steps.meta.outputs.labels }}
       build-date: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
@@ -153,7 +150,7 @@ jobs:
           images: ${{env.docker_ent_images}}
           tags: ${{env.docker_ent_tags}}
           flavor: |
-            suffix=-${{env.arch_arm64}}${{ matrix.race == 'true' && '-race' || '' }},onlatest=true
+            suffix=-${{env.arch_arm64}},onlatest=true
       - name: Docker amd64 meta
         id: amd64_meta
         uses: docker/metadata-action@v5
@@ -161,7 +158,7 @@ jobs:
           images: ${{env.docker_ent_images}}
           tags: ${{env.docker_ent_tags}}
           flavor: |
-            suffix=-${{env.arch_amd64}}${{ matrix.race == 'true' && '-race' || '' }},onlatest=true
+            suffix=-${{env.arch_amd64}},onlatest=true
   docker-ent:
     needs:
       - docker-ent-meta
@@ -176,6 +173,7 @@ jobs:
             tags: ${{needs.docker-ent-meta.outputs.amd64_tags}}
             labels: ${{needs.docker-ent-meta.outputs.amd64_labels}}
             platform: linux/amd64
+        race: [false, true]
     runs-on: ${{matrix.build-config.os}}
     steps:
       - name: Checkout
@@ -193,7 +191,7 @@ jobs:
           context: .
           platforms: ${{ matrix.build-config.platform }}
           push: true
-          tags: ${{ matrix.build-config.tags }}
+          tags: ${{ matrix.build-config.tags }}{{ matrix.race == 'true' && '-race' || '' }}
           labels: ${{ matrix.build-config.labels }}
           build-args: |
             BUILD_DATE=${{ needs.docker-ent-meta.outputs.build-date }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -184,13 +184,16 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Set race suffix
+        id: race_suffix
+        run: echo "suffix=$(if [ '${{ matrix.race }}' == 'true' ]; then echo '-race'; else echo ''; fi)" >> $GITHUB_OUTPUT
       - name: Build, scan and push
         uses: rudderlabs/build-scan-push-action@v1.3.2
         with:
           context: .
           platforms: ${{ matrix.build-config.platform }}
           push: true
-          tags: ${{ matrix.build-config.tags }}${{ matrix.race == 'true' && '-race' || '' }}
+          tags: ${{ matrix.build-config.tags }}${{ steps.race_suffix.outputs.suffix }}
           labels: ${{ matrix.build-config.labels }}
           build-args: |
             BUILD_DATE=${{ needs.docker-ent-meta.outputs.build-date }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -146,7 +146,6 @@ jobs:
         with:
           images: ${{env.docker_ent_images}}
           tags: ${{env.docker_ent_tags}}
-          flavor: ${{ matrix.race && 'suffix=-race,onlatest=true' || '' }}
       - name: Docker arm64 meta
         id: arm64_meta
         uses: docker/metadata-action@v5
@@ -154,7 +153,7 @@ jobs:
           images: ${{env.docker_ent_images}}
           tags: ${{env.docker_ent_tags}}
           flavor: |
-            suffix=-${{env.arch_arm64}},onlatest=true
+            suffix=-${{env.arch_arm64}}${{ matrix.race && '-race' || '' }},onlatest=true
       - name: Docker amd64 meta
         id: amd64_meta
         uses: docker/metadata-action@v5
@@ -162,7 +161,7 @@ jobs:
           images: ${{env.docker_ent_images}}
           tags: ${{env.docker_ent_tags}}
           flavor: |
-            suffix=-${{env.arch_amd64}},onlatest=true
+            suffix=-${{env.arch_amd64}}${{ matrix.race && '-race' || '' }},onlatest=true
   docker-ent:
     needs:
       - docker-ent-meta
@@ -194,7 +193,7 @@ jobs:
           context: .
           platforms: ${{ matrix.build-config.platform }}
           push: true
-          tags: ${{ needs.docker-ent-meta.outputs.tags }}
+          tags: ${{ matrix.build-config.tags }}
           labels: ${{ matrix.build-config.labels }}
           build-args: |
             BUILD_DATE=${{ needs.docker-ent-meta.outputs.build-date }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -172,7 +172,7 @@ jobs:
             tags: ${{needs.docker-ent-meta.outputs.amd64_tags}}
             labels: ${{needs.docker-ent-meta.outputs.amd64_labels}}
             platform: linux/amd64
-        race: [false, true]
+        race: [false]
     runs-on: ${{matrix.build-config.os}}
     steps:
       - name: Checkout

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -145,7 +145,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{env.docker_ent_images}}
-          tags: ${{ env.docker_ent_tags }}${{ matrix.race == 'true' && '-race' || '' }}
+          tags: ${{ env.docker_ent_tags }}
       - name: Docker arm64 meta
         id: arm64_meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -135,6 +135,9 @@ jobs:
       arm64_labels: ${{ steps.arm64_meta.outputs.labels }}
       amd64_tags: ${{ steps.amd64_meta.outputs.tags }}
       amd64_labels: ${{ steps.amd64_meta.outputs.labels }}
+      arm64_tags_race: ${{ steps.arm64_meta_race.outputs.tags }}
+      amd64_tags_race: ${{ steps.amd64_meta_race.outputs.tags }}
+      tags_race: ${{ steps.meta_race.outputs.tags }}
     steps:
       - name: Docker meta
         id: meta
@@ -158,6 +161,30 @@ jobs:
           tags: ${{env.docker_ent_tags}}
           flavor: |
             suffix=-${{env.arch_amd64}},onlatest=true
+      - name: Docker race meta
+        id: meta_race
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.docker_ent_images}}
+          tags: ${{env.docker_ent_tags}}-race
+          flavor: |
+            suffix=-race
+      - name: Docker race arm64 meta
+        id: arm64_meta_race
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.docker_ent_images}}
+          tags: ${{env.docker_ent_tags}}
+          flavor: |
+            pattern={{tag}}-race-${{env.arch_arm64}}
+      - name: Docker race amd64 meta
+        id: amd64_meta_race
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.docker_ent_images}}
+          tags: ${{env.docker_ent_tags}}
+          flavor: |
+            pattern={{tag}}-race-${{env.arch_amd64}}
   docker-ent:
     needs:
       - docker-ent-meta
@@ -166,10 +193,12 @@ jobs:
         build-config:
           - os: [ self-hosted, Linux, ARM64 ]
             tags: ${{needs.docker-ent-meta.outputs.arm64_tags}}
+            tags_race: ${{needs.docker-ent-meta.outputs.arm64_tags_race}}
             labels: ${{needs.docker-ent-meta.outputs.arm64_labels}}
             platform: linux/arm64
           - os: ubuntu-latest
             tags: ${{needs.docker-ent-meta.outputs.amd64_tags}}
+            tags_race: ${{needs.docker-ent-meta.outputs.amd64_tags_race}}
             labels: ${{needs.docker-ent-meta.outputs.amd64_labels}}
             platform: linux/amd64
         race: [false, true]
@@ -184,16 +213,13 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Set race suffix
-        id: race_suffix
-        run: echo "suffix=$(if [ '${{ matrix.race }}' == 'true' ]; then echo '-race'; else echo ''; fi)" >> $GITHUB_OUTPUT
       - name: Build, scan and push
         uses: rudderlabs/build-scan-push-action@v1.3.2
         with:
           context: .
           platforms: ${{ matrix.build-config.platform }}
           push: true
-          tags: ${{ matrix.build-config.tags }}${{ steps.race_suffix.outputs.suffix }}
+          tags: ${{ matrix.race == 'true' && matrix.build-config.tags_race || matrix.build-config.tags }}
           labels: ${{ matrix.build-config.labels }}
           build-args: |
             BUILD_DATE=${{ needs.docker-ent-meta.outputs.build-date }}
@@ -322,6 +348,13 @@ jobs:
             docker buildx imagetools create -t $tag $arm_tag $amd_tag
 
           done <<< "${{ needs.docker-ent-meta.outputs.tags }}"
+
+          while read -r tag; do
+            echo "$tag"
+            arm_tag=$(echo "${{ needs.docker-ent-meta.outputs.arm64_tags_race }}" | grep "$tag")
+            amd_tag=$(echo "${{ needs.docker-ent-meta.outputs.amd64_tags_race }}" | grep "$tag")
+            docker buildx imagetools create -t $tag $arm_tag $amd_tag
+          done <<< "${{ needs.docker-ent-meta.outputs.tags_race }}"
   create-manifest-docker-sbsvc:
     runs-on: ubuntu-latest
     needs: [ docker-suppression-backup-service, docker-sbsvc-meta ]

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -194,7 +194,7 @@ jobs:
           context: .
           platforms: ${{ matrix.build-config.platform }}
           push: true
-          tags: ${{ matrix.build-config.tags }}
+          tags: ${{ needs.docker-ent-meta.outputs.tags }}
           labels: ${{ matrix.build-config.labels }}
           build-args: |
             BUILD_DATE=${{ needs.docker-ent-meta.outputs.build-date }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -125,6 +125,9 @@ jobs:
             REVISION=${{ needs.docker-oss-meta.outputs.revision }}
   docker-ent-meta:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        race: [false, true]
     outputs:
       labels: ${{ steps.meta.outputs.labels }}
       build-date: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
@@ -135,6 +138,7 @@ jobs:
       arm64_labels: ${{ steps.arm64_meta.outputs.labels }}
       amd64_tags: ${{ steps.amd64_meta.outputs.tags }}
       amd64_labels: ${{ steps.amd64_meta.outputs.labels }}
+      race: ${{ matrix.race }}
     steps:
       - name: Docker meta
         id: meta
@@ -142,6 +146,7 @@ jobs:
         with:
           images: ${{env.docker_ent_images}}
           tags: ${{env.docker_ent_tags}}
+          flavor: ${{ matrix.race && 'suffix=-race,onlatest=true' || '' }}
       - name: Docker arm64 meta
         id: arm64_meta
         uses: docker/metadata-action@v5
@@ -172,7 +177,6 @@ jobs:
             tags: ${{needs.docker-ent-meta.outputs.amd64_tags}}
             labels: ${{needs.docker-ent-meta.outputs.amd64_labels}}
             platform: linux/amd64
-        race: [false, true]
     runs-on: ${{matrix.build-config.os}}
     steps:
       - name: Checkout
@@ -184,21 +188,13 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Set tags
-        id: image_tags
-        run: |
-          if [ "${{ matrix.race }}" = "true" ]; then
-            echo "tags=$(echo '${{ matrix.build-config.tags }}' | sed 's/$/-race/')" >> $GITHUB_OUTPUT
-          else
-            echo "tags=${{ matrix.build-config.tags }}" >> $GITHUB_OUTPUT
-          fi
       - name: Build, scan and push
         uses: rudderlabs/build-scan-push-action@v1.3.2
         with:
           context: .
           platforms: ${{ matrix.build-config.platform }}
           push: true
-          tags: ${{ steps.image_tags.outputs.tags }}
+          tags: ${{ needs.docker-ent-meta.outputs.tags }}
           labels: ${{ matrix.build-config.labels }}
           build-args: |
             BUILD_DATE=${{ needs.docker-ent-meta.outputs.build-date }}
@@ -206,7 +202,7 @@ jobs:
             COMMIT_HASH=${{ github.sha }}
             REVISION=${{ needs.docker-ent-meta.outputs.revision }}
             ENTERPRISE_TOKEN=${{ secrets.ENTERPRISE_TOKEN }}
-            ${{ matrix.race && 'RACE_ENABLED=TRUE CGO_ENABLED=1' || '' }}
+            ${{ needs.docker-ent-meta.outputs.race == 'true' && 'RACE_ENABLED=TRUE CGO_ENABLED=1' || '' }}
   docker-sbsvc-meta:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -135,7 +135,6 @@ jobs:
       arm64_labels: ${{ steps.arm64_meta.outputs.labels }}
       amd64_tags: ${{ steps.amd64_meta.outputs.tags }}
       amd64_labels: ${{ steps.amd64_meta.outputs.labels }}
-      race: ${{ matrix.race }}
     steps:
       - name: Docker meta
         id: meta
@@ -199,7 +198,7 @@ jobs:
             COMMIT_HASH=${{ github.sha }}
             REVISION=${{ needs.docker-ent-meta.outputs.revision }}
             ENTERPRISE_TOKEN=${{ secrets.ENTERPRISE_TOKEN }}
-            ${{ needs.docker-ent-meta.outputs.race == 'true' && 'RACE_ENABLED=TRUE CGO_ENABLED=1' || '' }}
+            ${{ matrix.race == 'true' && 'RACE_ENABLED=TRUE CGO_ENABLED=1' || '' }}
   docker-sbsvc-meta:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -176,7 +176,7 @@ jobs:
           images: ${{env.docker_ent_images}}
           tags: ${{env.docker_ent_tags}}
           flavor: |
-            pattern={{tag}}-race-${{env.arch_arm64}}
+            suffix=race-${{env.arch_arm64}}
       - name: Docker race amd64 meta
         id: amd64_meta_race
         uses: docker/metadata-action@v5
@@ -184,7 +184,7 @@ jobs:
           images: ${{env.docker_ent_images}}
           tags: ${{env.docker_ent_tags}}
           flavor: |
-            pattern={{tag}}-race-${{env.arch_amd64}}
+            suffix=race-${{env.arch_amd64}}
   docker-ent:
     needs:
       - docker-ent-meta

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -172,6 +172,7 @@ jobs:
             tags: ${{needs.docker-ent-meta.outputs.amd64_tags}}
             labels: ${{needs.docker-ent-meta.outputs.amd64_labels}}
             platform: linux/amd64
+        race: [false, true]
     runs-on: ${{matrix.build-config.os}}
     steps:
       - name: Checkout
@@ -183,13 +184,21 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Set tags
+        id: image_tags
+        run: |
+          if [ "${{ matrix.race }}" = "true" ]; then
+            echo "tags=$(echo '${{ matrix.build-config.tags }}' | sed 's/\([^, ]*\)/\1-race/g')" >> $GITHUB_OUTPUT
+          else
+            echo "tags=${{ matrix.build-config.tags }}" >> $GITHUB_OUTPUT
+          fi
       - name: Build, scan and push
         uses: rudderlabs/build-scan-push-action@v1.3.2
         with:
           context: .
           platforms: ${{ matrix.build-config.platform }}
           push: true
-          tags: ${{ matrix.build-config.tags }}
+          tags: ${{ steps.image_tags.outputs.tags }}
           labels: ${{ matrix.build-config.labels }}
           build-args: |
             BUILD_DATE=${{ needs.docker-ent-meta.outputs.build-date }}
@@ -197,6 +206,7 @@ jobs:
             COMMIT_HASH=${{ github.sha }}
             REVISION=${{ needs.docker-ent-meta.outputs.revision }}
             ENTERPRISE_TOKEN=${{ secrets.ENTERPRISE_TOKEN }}
+            ${{ matrix.race && 'RACE_ENABLED=TRUE' || '' }}
   docker-sbsvc-meta:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -145,7 +145,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{env.docker_ent_images}}
-          tags: ${{env.docker_ent_tags}}
+          tags: ${{ env.docker_ent_tags }}${{ matrix.race == 'true' && '-race' || '' }}
       - name: Docker arm64 meta
         id: arm64_meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -206,7 +206,7 @@ jobs:
             COMMIT_HASH=${{ github.sha }}
             REVISION=${{ needs.docker-ent-meta.outputs.revision }}
             ENTERPRISE_TOKEN=${{ secrets.ENTERPRISE_TOKEN }}
-            ${{ matrix.race && 'RACE_ENABLED=TRUE' || '' }}
+            ${{ matrix.race && 'RACE_ENABLED=TRUE CGO_ENABLED=1' || '' }}
   docker-sbsvc-meta:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -194,7 +194,7 @@ jobs:
           context: .
           platforms: ${{ matrix.build-config.platform }}
           push: true
-          tags: ${{ needs.docker-ent-meta.outputs.tags }}
+          tags: ${{ matrix.build-config.tags }}
           labels: ${{ matrix.build-config.labels }}
           build-args: |
             BUILD_DATE=${{ needs.docker-ent-meta.outputs.build-date }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -35,8 +35,11 @@ env:
     type=ref,event=branch
     type=raw,value=latest,enable=${{ github.event_name == 'release' }}
     type=raw,value=${{ github.head_ref }},enable=${{ github.event_name == 'pull_request' }}
+    type=raw,value=${{ github.head_ref }}-race,enable=${{ github.event_name == 'pull_request' }}
     type=semver,pattern={{version}}
+    type=semver,pattern={{version}}-race
     type=semver,pattern={{major}}.{{minor}}
+    type=semver,pattern={{major}}.{{minor}}-race
     type=semver,pattern={{major}}
   docker_sbsvc_images: |
     name=rudderstack/develop-suppression-backup-service
@@ -135,9 +138,6 @@ jobs:
       arm64_labels: ${{ steps.arm64_meta.outputs.labels }}
       amd64_tags: ${{ steps.amd64_meta.outputs.tags }}
       amd64_labels: ${{ steps.amd64_meta.outputs.labels }}
-      arm64_tags_race: ${{ steps.arm64_meta_race.outputs.tags }}
-      amd64_tags_race: ${{ steps.amd64_meta_race.outputs.tags }}
-      tags_race: ${{ steps.meta_race.outputs.tags }}
     steps:
       - name: Docker meta
         id: meta
@@ -161,30 +161,6 @@ jobs:
           tags: ${{env.docker_ent_tags}}
           flavor: |
             suffix=-${{env.arch_amd64}},onlatest=true
-      - name: Docker race meta
-        id: meta_race
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{env.docker_ent_images}}
-          tags: ${{env.docker_ent_tags}}-race
-          flavor: |
-            suffix=-race
-      - name: Docker race arm64 meta
-        id: arm64_meta_race
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{env.docker_ent_images}}
-          tags: ${{env.docker_ent_tags}}
-          flavor: |
-            suffix=race-${{env.arch_arm64}}
-      - name: Docker race amd64 meta
-        id: amd64_meta_race
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{env.docker_ent_images}}
-          tags: ${{env.docker_ent_tags}}
-          flavor: |
-            suffix=race-${{env.arch_amd64}}
   docker-ent:
     needs:
       - docker-ent-meta
@@ -193,12 +169,10 @@ jobs:
         build-config:
           - os: [ self-hosted, Linux, ARM64 ]
             tags: ${{needs.docker-ent-meta.outputs.arm64_tags}}
-            tags_race: ${{needs.docker-ent-meta.outputs.arm64_tags_race}}
             labels: ${{needs.docker-ent-meta.outputs.arm64_labels}}
             platform: linux/arm64
           - os: ubuntu-latest
             tags: ${{needs.docker-ent-meta.outputs.amd64_tags}}
-            tags_race: ${{needs.docker-ent-meta.outputs.amd64_tags_race}}
             labels: ${{needs.docker-ent-meta.outputs.amd64_labels}}
             platform: linux/amd64
         race: [false, true]
@@ -219,7 +193,7 @@ jobs:
           context: .
           platforms: ${{ matrix.build-config.platform }}
           push: true
-          tags: ${{ matrix.race == 'true' && matrix.build-config.tags_race || matrix.build-config.tags }}
+          tags: ${{ matrix.build-config.tags }}
           labels: ${{ matrix.build-config.labels }}
           build-args: |
             BUILD_DATE=${{ needs.docker-ent-meta.outputs.build-date }}
@@ -349,12 +323,6 @@ jobs:
 
           done <<< "${{ needs.docker-ent-meta.outputs.tags }}"
 
-          while read -r tag; do
-            echo "$tag"
-            arm_tag=$(echo "${{ needs.docker-ent-meta.outputs.arm64_tags_race }}" | grep "$tag")
-            amd_tag=$(echo "${{ needs.docker-ent-meta.outputs.amd64_tags_race }}" | grep "$tag")
-            docker buildx imagetools create -t $tag $arm_tag $amd_tag
-          done <<< "${{ needs.docker-ent-meta.outputs.tags_race }}"
   create-manifest-docker-sbsvc:
     runs-on: ubuntu-latest
     needs: [ docker-suppression-backup-service, docker-sbsvc-meta ]

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -141,7 +141,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{env.docker_ent_images}}
-          tags: ${{ env.docker_ent_tags }}
+          tags: ${{env.docker_ent_tags}}
       - name: Docker arm64 meta
         id: arm64_meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -188,7 +188,7 @@ jobs:
         id: image_tags
         run: |
           if [ "${{ matrix.race }}" = "true" ]; then
-            echo "tags=$(echo '${{ matrix.build-config.tags }}' | sed 's/\([^, ]*\)/\1-race/g')" >> $GITHUB_OUTPUT
+            echo "tags=$(echo '${{ matrix.build-config.tags }}' | sed 's/$/-race/')" >> $GITHUB_OUTPUT
           else
             echo "tags=${{ matrix.build-config.tags }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -172,7 +172,7 @@ jobs:
             tags: ${{needs.docker-ent-meta.outputs.amd64_tags}}
             labels: ${{needs.docker-ent-meta.outputs.amd64_labels}}
             platform: linux/amd64
-        race: [false]
+        race: [true]
     runs-on: ${{matrix.build-config.os}}
     steps:
       - name: Checkout

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -153,7 +153,7 @@ jobs:
           images: ${{env.docker_ent_images}}
           tags: ${{env.docker_ent_tags}}
           flavor: |
-            suffix=-${{env.arch_arm64}}${{ matrix.race && '-race' || '' }},onlatest=true
+            suffix=-${{env.arch_arm64}}${{ matrix.race == 'true' && '-race' || '' }},onlatest=true
       - name: Docker amd64 meta
         id: amd64_meta
         uses: docker/metadata-action@v5
@@ -161,7 +161,7 @@ jobs:
           images: ${{env.docker_ent_images}}
           tags: ${{env.docker_ent_tags}}
           flavor: |
-            suffix=-${{env.arch_amd64}}${{ matrix.race && '-race' || '' }},onlatest=true
+            suffix=-${{env.arch_amd64}}${{ matrix.race == 'true' && '-race' || '' }},onlatest=true
   docker-ent:
     needs:
       - docker-ent-meta


### PR DESCRIPTION
# Description

- For every enterprise image/tag that is built and pushed, also build and push a new image with the environment variable RACE_ENABLED=TRUE.
- The new image should have the same tag as the original, but with -race appended (e.g., if the tag is 1.2.3, the new tag should be 1.2.3-race).

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
