### PR TITLE
chore: update nodeSelector for warehouse benchmark deploy

### DIFF
--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/benchmark/deployment.yaml
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/benchmark/deployment.yaml
@@ -152,7 +152,7 @@ spec:
             - name: MODE
               value: "<MODE>"
       nodeSelector:
-        karpenter.sh/provisioner-name: arm
+        karpenter.sh/nodepool: arm
       tolerations:
         - effect: NoExecute
           key: node.kubernetes.io/unreachable


### PR DESCRIPTION
# Description
`provisioner-name` is deprecated and we should now use `nodepool`.

## Linear Ticket
https://linear.app/rudderstack/issue/INF-1077/update-clusters-to-v0377

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
