### PR TITLE
fix: incorrect snowpipe channel id being returned if insert recreates the channel

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/apiadapter.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/apiadapter.go
@@ -93,7 +93,7 @@ func (a *apiAdapter) DeleteChannel(ctx context.Context, channelID string, sync b
 	return nil
 }
 
-func (a *apiAdapter) Insert(ctx context.Context, channelID string, insertRequest *model.InsertRequest, createChannelReq *model.CreateChannelRequest) (*model.InsertResponse, error) {
+func (a *apiAdapter) Insert(ctx context.Context, channelID string, insertRequest *model.InsertRequest) (*model.InsertResponse, error) {
 	a.logger.Debugn("Inserting data",
 		logger.NewStringField("channelId", channelID),
 		logger.NewIntField("rows", int64(len(insertRequest.Rows))),
@@ -103,7 +103,7 @@ func (a *apiAdapter) Insert(ctx context.Context, channelID string, insertRequest
 	tags := a.defaultTags(insertAPI)
 	defer a.recordDuration(tags)()
 
-	resp, err := a.api.Insert(ctx, channelID, insertRequest, createChannelReq)
+	resp, err := a.api.Insert(ctx, channelID, insertRequest)
 	if err != nil {
 		tags["success"] = "false"
 		return nil, err

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/discards.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/discards.go
@@ -7,10 +7,6 @@ import (
 
 	"github.com/samber/lo"
 
-	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
-
-	"github.com/rudderlabs/rudder-go-kit/logger"
-
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/model"
 	"github.com/rudderlabs/rudder-server/warehouse/slave"
@@ -27,12 +23,6 @@ func (m *Manager) sendDiscardEventsToSnowpipe(
 ) (*importInfo, error) {
 	tableName := discardsTable()
 
-	log := m.logger.Withn(
-		logger.NewStringField("table", tableName),
-		logger.NewIntField("discards", int64(len(discardInfos))),
-		logger.NewStringField("offset", offset),
-	)
-
 	insertReq := &model.InsertRequest{
 		Rows:   convertDiscardedInfosToRows(discardInfos),
 		Offset: offset,
@@ -43,30 +33,21 @@ func (m *Manager) sendDiscardEventsToSnowpipe(
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode destination config: %w", err)
 	}
-	createChannelReq := buildCreateChannelRequest(m.destination.ID, m.config.instanceID, &destConf, tableName)
 
-	insertRes, err := m.api.Insert(ctx, discardsChannelID, insertReq, createChannelReq)
-	defer func() {
-		if err != nil || !insertRes.Success {
-			if deleteErr := m.deleteChannel(ctx, tableName, discardsChannelID); deleteErr != nil {
-				log.Warnn("Failed to delete channel", obskit.Error(deleteErr))
-			}
-		}
-	}()
+	info := &uploadInfo{
+		tableName:    discardsTable(),
+		eventsSchema: discardsSchema(),
+	}
+
+	channelID, err := m.insert(ctx, m.destination.ID, &destConf, info, insertReq, discardsChannelID)
 	if err != nil {
 		return nil, fmt.Errorf("inserting data to discards: %v", err)
-	}
-	if !insertRes.Success {
-		errorMessages := lo.Map(insertRes.Errors, func(ie model.InsertError, _ int) string {
-			return ie.Message
-		})
-		return nil, fmt.Errorf("inserting data %s failed: %v", tableName, errorMessages)
 	}
 
 	m.stats.discards.Count(len(discardInfos))
 
 	imInfo := &importInfo{
-		ChannelID: discardsChannelID,
+		ChannelID: channelID,
 		Offset:    offset,
 		Table:     tableName,
 		Count:     len(discardInfos),

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/api/api.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/api/api.go
@@ -35,7 +35,7 @@ type (
 	}
 )
 
-var ErrChannelNotFound = errors.New("Channel not found")
+var ErrChannelNotFound = errors.New("channel not found")
 
 func New(conf *config.Config, statsFactory stats.Stats, clientURL string, requestDoer requestDoer) *API {
 	a := &API{

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/api/api_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/api/api_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
-	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/api"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/model"
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
@@ -108,7 +107,7 @@ func TestAPI(t *testing.T) {
 		ctx := context.Background()
 
 		t.Run("Status=200(success=true)", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, successSnowpipeServer.URL, successSnowpipeServer.Client())
+			manager := api.New(config.New(), stats.NOP, successSnowpipeServer.URL, successSnowpipeServer.Client())
 			res, err := manager.CreateChannel(ctx, ccr)
 			require.NoError(t, err)
 			require.EqualValues(t, &model.ChannelResponse{
@@ -124,7 +123,7 @@ func TestAPI(t *testing.T) {
 			)
 		})
 		t.Run("Status=200(success=false)", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, failureSnowpipeServer.URL, failureSnowpipeServer.Client())
+			manager := api.New(config.New(), stats.NOP, failureSnowpipeServer.URL, failureSnowpipeServer.Client())
 			res, err := manager.CreateChannel(ctx, ccr)
 			require.NoError(t, err)
 			require.EqualValues(t, &model.ChannelResponse{
@@ -140,7 +139,7 @@ func TestAPI(t *testing.T) {
 			)
 		})
 		t.Run("Request failure", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, successSnowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, successSnowpipeServer.URL, &mockRequestDoer{
 				err: errors.New("bad client"),
 			})
 			res, err := manager.CreateChannel(ctx, ccr)
@@ -148,7 +147,7 @@ func TestAPI(t *testing.T) {
 			require.Nil(t, res)
 		})
 		t.Run("Request failure (non 200's status code)", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, successSnowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, successSnowpipeServer.URL, &mockRequestDoer{
 				response: &http.Response{
 					StatusCode: http.StatusBadRequest,
 					Body:       nopReadCloser{Reader: bytes.NewReader([]byte(`{}`))},
@@ -159,7 +158,7 @@ func TestAPI(t *testing.T) {
 			require.Nil(t, res)
 		})
 		t.Run("Request failure (invalid response)", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, successSnowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, successSnowpipeServer.URL, &mockRequestDoer{
 				response: &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       nopReadCloser{Reader: bytes.NewReader([]byte(`{abd}`))},
@@ -190,25 +189,25 @@ func TestAPI(t *testing.T) {
 
 		t.Run("Success", func(t *testing.T) {
 			t.Run("sync=true", func(t *testing.T) {
-				manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
+				manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
 				err := manager.DeleteChannel(ctx, channelID, true)
 				require.NoError(t, err)
 			})
 			t.Run("sync=false", func(t *testing.T) {
-				manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
+				manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
 				err := manager.DeleteChannel(ctx, channelID, false)
 				require.NoError(t, err)
 			})
 		})
 		t.Run("Request failure", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
 				err: errors.New("bad client"),
 			})
 			err := manager.DeleteChannel(ctx, channelID, true)
 			require.Error(t, err)
 		})
 		t.Run("Request failure (non 200's status code)", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
 				response: &http.Response{
 					StatusCode: http.StatusBadRequest,
 					Body:       nopReadCloser{Reader: bytes.NewReader([]byte(`{}`))},
@@ -236,7 +235,7 @@ func TestAPI(t *testing.T) {
 		ctx := context.Background()
 
 		t.Run("Success", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
 			res, err := manager.GetChannel(ctx, channelID)
 			require.NoError(t, err)
 			require.EqualValues(t, &model.ChannelResponse{
@@ -251,7 +250,7 @@ func TestAPI(t *testing.T) {
 			)
 		})
 		t.Run("Request failure", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
 				err: errors.New("bad client"),
 			})
 			res, err := manager.GetChannel(ctx, channelID)
@@ -259,7 +258,7 @@ func TestAPI(t *testing.T) {
 			require.Nil(t, res)
 		})
 		t.Run("Request failure (non 200's status code)", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
 				response: &http.Response{
 					StatusCode: http.StatusBadRequest,
 					Body:       nopReadCloser{Reader: bytes.NewReader([]byte(`{}`))},
@@ -270,7 +269,7 @@ func TestAPI(t *testing.T) {
 			require.Nil(t, res)
 		})
 		t.Run("Request failure (invalid response)", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
 				response: &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       nopReadCloser{Reader: bytes.NewReader([]byte(`{abd}`))},
@@ -317,14 +316,22 @@ func TestAPI(t *testing.T) {
 		ctx := context.Background()
 
 		t.Run("Insert success", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
-			res, err := manager.Insert(ctx, successChannelID, ir, nil)
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
+			res, err := manager.Insert(ctx, successChannelID, ir)
 			require.NoError(t, err)
 			require.Equal(t, &model.InsertResponse{Success: true, Errors: nil}, res)
 		})
+
+		t.Run("Insert channel not found", func(t *testing.T) {
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
+			res, err := manager.Insert(ctx, "invalid-channel-id", ir)
+			require.ErrorIs(t, err, api.ErrChannelNotFound)
+			require.Nil(t, res)
+		})
+
 		t.Run("Insert failure", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
-			res, err := manager.Insert(ctx, failureChannelID, ir, nil)
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
+			res, err := manager.Insert(ctx, failureChannelID, ir)
 			require.NoError(t, err)
 			require.Equal(t, &model.InsertResponse{
 				Success: false,
@@ -349,35 +356,35 @@ func TestAPI(t *testing.T) {
 			)
 		})
 		t.Run("Request failure", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
 				err: errors.New("bad client"),
 				response: &http.Response{
 					StatusCode: http.StatusOK,
 				},
 			})
-			res, err := manager.Insert(ctx, successChannelID, ir, nil)
+			res, err := manager.Insert(ctx, successChannelID, ir)
 			require.Error(t, err)
 			require.Nil(t, res)
 		})
 		t.Run("Request failure (non 200's status code)", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
 				response: &http.Response{
 					StatusCode: http.StatusBadRequest,
 					Body:       nopReadCloser{Reader: bytes.NewReader([]byte(`{}`))},
 				},
 			})
-			res, err := manager.Insert(ctx, successChannelID, ir, nil)
+			res, err := manager.Insert(ctx, successChannelID, ir)
 			require.Error(t, err)
 			require.Nil(t, res)
 		})
 		t.Run("Request failure (invalid response)", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
 				response: &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       nopReadCloser{Reader: bytes.NewReader([]byte(`{abd}`))},
 				},
 			})
-			res, err := manager.Insert(ctx, successChannelID, ir, nil)
+			res, err := manager.Insert(ctx, successChannelID, ir)
 			require.Error(t, err)
 			require.Nil(t, res)
 		})
@@ -401,7 +408,7 @@ func TestAPI(t *testing.T) {
 		ctx := context.Background()
 
 		t.Run("Success", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
 			res, err := manager.GetStatus(ctx, channelID)
 			require.NoError(t, err)
 			require.Equal(t, &model.StatusResponse{
@@ -413,7 +420,7 @@ func TestAPI(t *testing.T) {
 			)
 		})
 		t.Run("Request failure", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
 				err: errors.New("bad client"),
 				response: &http.Response{
 					StatusCode: http.StatusOK,
@@ -424,7 +431,7 @@ func TestAPI(t *testing.T) {
 			require.Nil(t, res)
 		})
 		t.Run("Request failure (non 200's status code)", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
 				response: &http.Response{
 					StatusCode: http.StatusBadRequest,
 					Body:       nopReadCloser{Reader: bytes.NewReader([]byte(`{}`))},
@@ -435,7 +442,7 @@ func TestAPI(t *testing.T) {
 			require.Nil(t, res)
 		})
 		t.Run("Request failure (invalid response)", func(t *testing.T) {
-			manager := api.New(config.New(), logger.NOP, stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
 				response: &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       nopReadCloser{Reader: bytes.NewReader([]byte(`{abd}`))},

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -1050,6 +1050,11 @@ func TestSnowpipeStreaming(t *testing.T) {
 					}, nil
 				},
 			},
+			deleteChannelOutputMap: map[string]func() error{
+				"invalid-test-products-channel": func() error {
+					return nil
+				},
+			},
 			insertOutputMap: map[string]func() (*model.InsertResponse, error){
 				"test-users-channel": func() (*model.InsertResponse, error) {
 					return &model.InsertResponse{Success: true}, nil

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -42,7 +42,7 @@ func (m *mockAPI) DeleteChannel(_ context.Context, channelID string, _ bool) err
 	return m.deleteChannelOutputMap[channelID]()
 }
 
-func (m *mockAPI) Insert(_ context.Context, channelID string, _ *model.InsertRequest, _ *model.CreateChannelRequest) (*model.InsertResponse, error) {
+func (m *mockAPI) Insert(_ context.Context, channelID string, _ *model.InsertRequest) (*model.InsertResponse, error) {
 	return m.insertOutputMap[channelID]()
 }
 
@@ -1011,6 +1011,69 @@ func TestSnowpipeStreaming(t *testing.T) {
 			"destinationId": "test-destination",
 			"status":        "failed",
 		}).LastValue())
+	})
+
+	t.Run("Upload success but with a 404 error in the first call to insert", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		sm := New(config.New(), logger.NOP, statsStore, destination)
+		sm.channelCache.Store("RUDDER_DISCARDS", rudderDiscardsChannelResponse)
+		sm.channelCache.Store("USERS", usersChannelResponse)
+
+		productsCount := 0
+		productSchema := map[string]string{
+			"ID":          "int",
+			"PRODUCT_ID":  "string",
+			"PRICE":       "float",
+			"IN_STOCK":    "boolean",
+			"RECEIVED_AT": "datetime",
+		}
+
+		sm.api = &mockAPI{
+			createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
+				// For the first call to createChannel, we return a channel for which the insert will return a 404 error
+				// For the second call to createChannel, we return a channel for which the insert will be successful
+				"PRODUCTS": func() (*model.ChannelResponse, error) {
+					if productsCount == 0 {
+						productsCount++
+						return &model.ChannelResponse{
+							Success:        true,
+							ChannelID:      "invalid-test-products-channel",
+							SnowpipeSchema: productSchema,
+						}, nil
+					}
+					return &model.ChannelResponse{
+						Success:        true,
+						ChannelID:      "test-products-channel",
+						SnowpipeSchema: productSchema,
+					}, nil
+				},
+			},
+			insertOutputMap: map[string]func() (*model.InsertResponse, error){
+				"test-users-channel": func() (*model.InsertResponse, error) {
+					return &model.InsertResponse{Success: true}, nil
+				},
+				"test-products-channel": func() (*model.InsertResponse, error) {
+					return &model.InsertResponse{Success: true}, nil
+				},
+				"invalid-test-products-channel": func() (*model.InsertResponse, error) {
+					return nil, internalapi.ErrChannelNotFound
+				},
+				"test-rudder-discards-channel": func() (*model.InsertResponse, error) {
+					return &model.InsertResponse{Success: true}, nil
+				},
+			},
+		}
+		output := sm.Upload(&common.AsyncDestinationStruct{
+			Destination: destination,
+			FileName:    "testdata/successful_sort_records.txt",
+		})
+		require.Equal(t, []int64{1002, 1003, 1001, 1004}, output.ImportingJobIDs)
+		require.Equal(t, 4, output.ImportingCount)
+		require.Equal(t, `{"importId":[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":false,"reason":"","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":false,"reason":"","count":2}]}`, string(output.ImportingParameters))
+		require.Nil(t, output.FailedJobIDs)
+		require.Zero(t, output.FailedCount)
 	})
 
 	t.Run("Poll with invalid importID", func(t *testing.T) {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
@@ -134,7 +134,7 @@ type (
 	api interface {
 		CreateChannel(ctx context.Context, channelReq *model.CreateChannelRequest) (*model.ChannelResponse, error)
 		DeleteChannel(ctx context.Context, channelID string, sync bool) error
-		Insert(ctx context.Context, channelID string, insertRequest *model.InsertRequest, createChannelReq *model.CreateChannelRequest) (*model.InsertResponse, error)
+		Insert(ctx context.Context, channelID string, insertRequest *model.InsertRequest) (*model.InsertResponse, error)
 		GetStatus(ctx context.Context, channelID string) (*model.StatusResponse, error)
 	}
 


### PR DESCRIPTION
# Description

**BUG**
A fix was made for preventing duplicates in Snowpipe in PR #5957 . But it missed returning the id of the newly created channel in the `Upload` method. As a result, `Poll` method was still receiving the stale channel id. So the GetStatus API call was failing with 404, causing the event to be marked as failed. This failed event would be retried causing duplicates

**FIX**
- The actual fix was simple to propagate the new channel id from the Insert API method back to the caller. But there was another miss, that post channel recreation the cache was not being updated. So instead this PR, moves the recreation logic from the API layer to the manager layer. This meant reverting the changes done in `api.go` and `apiadapter.go` and the corresponding test files
- In case of 404 status code, the api insert method is now returning an error `ErrChannelNotFound`
- Created a `insert` method in manager which has the channel recreation logic based on the error type. This method is also being called from `discards`
- Added a regression unit test

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
