### PR TITLE
feat: propagate snowpipe iceberg config to snowpipe service

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/model/model.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/model/model.go
@@ -23,9 +23,10 @@ type (
 		PrivateKeyPassphrase string `json:"privateKeyPassphrase"`
 	}
 	TableConfig struct {
-		Database string `json:"database"`
-		Schema   string `json:"schema"`
-		Table    string `json:"table"`
+		Database      string `json:"database"`
+		Schema        string `json:"schema"`
+		Table         string `json:"table"`
+		EnableIceberg bool   `json:"enableIceberg"`
 	}
 
 	ChannelResponse struct {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -681,9 +681,10 @@ func buildCreateChannelRequest(destinationID, partition string, destConf *destCo
 			PrivateKeyPassphrase: destConf.PrivateKeyPassphrase,
 		},
 		TableConfig: model.TableConfig{
-			Database: destConf.Database,
-			Schema:   destConf.Namespace,
-			Table:    tableName,
+			Database:      destConf.Database,
+			Schema:        destConf.Namespace,
+			Table:         tableName,
+			EnableIceberg: destConf.EnableIceberg,
 		},
 	}
 }

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 type mockAPI struct {
+	channelReq             *model.CreateChannelRequest
 	createChannelOutputMap map[string]func() (*model.ChannelResponse, error)
 	deleteChannelOutputMap map[string]func() error
 	insertOutputMap        map[string]func() (*model.InsertResponse, error)
@@ -35,6 +36,7 @@ type mockAPI struct {
 }
 
 func (m *mockAPI) CreateChannel(_ context.Context, channelReq *model.CreateChannelRequest) (*model.ChannelResponse, error) {
+	m.channelReq = channelReq
 	return m.createChannelOutputMap[channelReq.TableConfig.Table]()
 }
 
@@ -173,16 +175,23 @@ func TestSnowpipeStreaming(t *testing.T) {
 		require.NoError(t, err)
 
 		sm := New(config.New(), logger.NOP, statsStore, destination)
-		sm.api = &mockAPI{
+		mockApi := &mockAPI{
 			createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
 				"RUDDER_DISCARDS": func() (*model.ChannelResponse, error) {
 					return nil, assert.AnError
 				},
 			},
 		}
+		sm.api = mockApi
+		dest := &backendconfig.DestinationT{
+			ID: destination.ID,
+			Config: map[string]interface{}{
+				"enableIceberg": true,
+			},
+		}
 		output := sm.Upload(&common.AsyncDestinationStruct{
 			ImportingJobIDs: []int64{1},
-			Destination:     destination,
+			Destination:     dest,
 			FileName:        "testdata/successful_records.txt",
 		})
 		require.Equal(t, []int64{1}, output.AbortJobIDs)
@@ -196,6 +205,15 @@ func TestSnowpipeStreaming(t *testing.T) {
 			"destinationId": "test-destination",
 			"status":        "aborted",
 		}).LastValue())
+		require.Equal(t, &model.CreateChannelRequest{
+			RudderIdentifier: dest.ID,
+			Partition:        "1",
+			TableConfig: model.TableConfig{
+				Schema:        "STRINGEMPTY",
+				Table:         "RUDDER_DISCARDS",
+				EnableIceberg: true,
+			},
+		}, mockApi.channelReq)
 	})
 	t.Run("Upload not able to create event channel", func(t *testing.T) {
 		statsStore, err := memstats.New()
@@ -1457,6 +1475,7 @@ func TestDestConfig_Decode(t *testing.T) {
 				"privateKey":           "test-key",
 				"privateKeyPassphrase": "test-passphrase",
 				"namespace":            "test-namespace",
+				"enableIceberg":        true,
 			},
 			expected: destConfig{
 				Account:              "test-account",
@@ -1467,6 +1486,7 @@ func TestDestConfig_Decode(t *testing.T) {
 				PrivateKey:           "test-key",
 				PrivateKeyPassphrase: "test-passphrase",
 				Namespace:            "TEST_NAMESPACE",
+				EnableIceberg:        true,
 			},
 			wantError: false,
 		},

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
@@ -101,6 +101,7 @@ type (
 		PrivateKey           string `mapstructure:"privateKey"`
 		PrivateKeyPassphrase string `mapstructure:"privateKeyPassphrase"`
 		Namespace            string `mapstructure:"namespace"`
+		EnableIceberg        bool   `mapstructure:"enableIceberg"`
 	}
 
 	importInfo struct {

--- a/warehouse/integrations/snowflake/table_manager.go
+++ b/warehouse/integrations/snowflake/table_manager.go
@@ -78,7 +78,7 @@ func newIcebergTableManager(externalVolume string) tableManager {
 			"bigint":   "number(19,0)",
 			"float":    "double precision",
 			"string":   "varchar",
-			"datetime": "timestamp_ltz(6)",
+			"datetime": "timestamp_ntz(6)",
 			"json":     "varchar",
 		},
 		externalVolume: externalVolume,


### PR DESCRIPTION
# Description

This PR adds propagates the `enableIceberg` field in the destination config to the Snowpipe service so that the service can create Iceberg clients.

Implementation
- Added a new field `EnableIceberg` in the `TableConfig` request body of create channel API

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
