### PR TITLE
chore: warehouse transformations parsing timestamp and serialisation

### DIFF
--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils/utils_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils/utils_test.go
@@ -83,11 +83,38 @@ func TestValidTimestamp(t *testing.T) {
 		{name: "Date time Micros Colon timezone", timestamp: "2025-04-02 01:09:03.714247+00:00", expected: true},
 		{name: "Date time ISO millis timezone", timestamp: "2025-04-02T01:09:03.000+1000", expected: true},
 		{name: "Date time Colon timezone", timestamp: "2025-04-02 01:09:03+00:00", expected: true},
+		{name: "Day out of range", timestamp: "1988-04-31", expected: true},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.expected, ValidTimestamp(tc.timestamp))
+		})
+	}
+}
+
+func TestToTimestamp(t *testing.T) {
+	testCases := []struct {
+		name, timestamp string
+		expected        string
+	}{
+		{name: "Timestamp without timezone", timestamp: "2021-06-01T00:00:00.000Z", expected: "2021-06-01T00:00:00.000Z"},
+		{name: "Timestamp with timezone", timestamp: "2021-06-01T00:00:00.000+00:00", expected: "2021-06-01T00:00:00.000Z"},
+		{name: "Timestamps at bounds (minTimeInMs)", timestamp: "0001-01-01T00:00:00.000Z", expected: "0001-01-01T00:00:00.000Z"},
+		{name: "Timestamps at bounds (maxTimeInMs)", timestamp: "9999-12-31T23:59:59.999Z", expected: "9999-12-31T23:59:59.999Z"},
+		{name: "Date Time only", timestamp: "2021-06-01 00:00:00", expected: "2021-06-01T00:00:00.000Z"},
+		{name: "Date-only", timestamp: "2023-06-14", expected: "2023-06-14T00:00:00.000Z"},
+		{name: "Date time ISO 8601", timestamp: "2025-04-02T01:09:03", expected: "2025-04-02T01:09:03.000Z"},
+		{name: "Date time Millis timezone", timestamp: "2025-04-02 01:09:03.000+0530", expected: "2025-04-01T19:39:03.000Z"},
+		{name: "Date time Micros Colon timezone", timestamp: "2025-04-02 01:09:03.714247+00:00", expected: "2025-04-02T01:09:03.714Z"},
+		{name: "Date time ISO millis timezone", timestamp: "2025-04-02T01:09:03.000+1000", expected: "2025-04-01T15:09:03.000Z"},
+		{name: "Date time Colon timezone", timestamp: "2025-04-02 01:09:03+00:00", expected: "2025-04-02T01:09:03.000Z"},
+		{name: "Date-only: Day out of range", timestamp: "1988-04-31", expected: "1988-05-01T00:00:00.000Z"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, ToTimestamp(tc.timestamp))
 		})
 	}
 }

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/transformer.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/transformer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -54,6 +55,8 @@ var _ = struct {
 	Timezone string
 }(enricher.Geolocation{})
 
+var unicodePattern = regexp.MustCompile(`\\u[0-9a-fA-F]{4}`)
+
 type Opts func(t *Transformer)
 
 func WithNow(now func() time.Time) Opts {
@@ -96,7 +99,7 @@ func New(conf *config.Config, logger logger.Logger, statsFactory stats.Stats, op
 
 	t.config.enableIDResolution = conf.GetReloadableBoolVar(false, "Warehouse.enableIDResolution")
 	t.config.populateSrcDestInfoInContext = conf.GetReloadableBoolVar(true, "WH_POPULATE_SRC_DEST_INFO_IN_CONTEXT")
-	t.config.maxColumnsInEvent = conf.GetReloadableIntVar(200, 1, "WH_MAX_COLUMNS_IN_EVENT")
+	t.config.maxColumnsInEvent = conf.GetReloadableIntVar(1600, 1, "WH_MAX_COLUMNS_IN_EVENT")
 	t.config.maxLoggedEvents = conf.GetReloadableIntVar(100, 1, "Warehouse.Transformer.Sampling.maxLoggedEvents")
 	t.config.concurrentTransformations = conf.GetReloadableIntVar(1, 1, "Warehouse.concurrentTransformations")
 	t.config.instanceID = conf.GetString("INSTANCE_ID", "1")

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/transformer_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/transformer_test.go
@@ -193,6 +193,7 @@ func TestTransformer(t *testing.T) {
 			"userId": "",
 		}
 	}
+	maxColumnsCount := 1800
 
 	testCases := []struct {
 		name             string
@@ -278,7 +279,7 @@ func TestTransformer(t *testing.T) {
 		},
 		{
 			name:         "Too many columns",
-			eventPayload: testhelper.AddRandomColumns(`{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","context":{%s},"ip":"1.2.3.4"}`, 500),
+			eventPayload: testhelper.AddRandomColumns(`{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","context":{%s},"ip":"1.2.3.4"}`, maxColumnsCount),
 			metadata:     getMetadata("track", "POSTGRES"),
 			destination:  getDestination("POSTGRES", map[string]any{}),
 			expectedResponse: types.Response{
@@ -293,20 +294,20 @@ func TestTransformer(t *testing.T) {
 		},
 		{
 			name:         "Too many columns (DataLake)",
-			eventPayload: testhelper.AddRandomColumns(`{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},%s,"ip":"1.2.3.4"}}`, 500),
+			eventPayload: testhelper.AddRandomColumns(`{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"web","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},%s,"ip":"1.2.3.4"}}`, maxColumnsCount),
 			metadata:     getMetadata("track", "GCS_DATALAKE"),
 			destination:  getDestination("GCS_DATALAKE", map[string]any{}),
 			expectedResponse: types.Response{
 				Events: []types.TransformerResponse{
 					{
-						Output: trackDefaultOutput().SetDataField("context_destination_type", "GCS_DATALAKE").AddRandomEntries(500, func(index int) (string, string, string, string) {
+						Output: trackDefaultOutput().SetDataField("context_destination_type", "GCS_DATALAKE").AddRandomEntries(maxColumnsCount, func(index int) (string, string, string, string) {
 							return fmt.Sprintf("context_random_column_%d", index), fmt.Sprintf("random_value_%d", index), fmt.Sprintf("context_random_column_%d", index), "string"
 						}),
 						Metadata:   getMetadata("track", "GCS_DATALAKE"),
 						StatusCode: http.StatusOK,
 					},
 					{
-						Output: trackEventDefaultOutput().SetDataField("context_destination_type", "GCS_DATALAKE").AddRandomEntries(500, func(index int) (string, string, string, string) {
+						Output: trackEventDefaultOutput().SetDataField("context_destination_type", "GCS_DATALAKE").AddRandomEntries(maxColumnsCount, func(index int) (string, string, string, string) {
 							return fmt.Sprintf("context_random_column_%d", index), fmt.Sprintf("random_value_%d", index), fmt.Sprintf("context_random_column_%d", index), "string"
 						}),
 						Metadata:   getMetadata("track", "GCS_DATALAKE"),
@@ -317,20 +318,20 @@ func TestTransformer(t *testing.T) {
 		},
 		{
 			name:         "Too many columns channel as sources",
-			eventPayload: testhelper.AddRandomColumns(`{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"sources","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},%s,"ip":"1.2.3.4"}}`, 500),
+			eventPayload: testhelper.AddRandomColumns(`{"type":"track","messageId":"messageId","anonymousId":"anonymousId","userId":"userId","sentAt":"2021-09-01T00:00:00.000Z","timestamp":"2021-09-01T00:00:00.000Z","receivedAt":"2021-09-01T00:00:00.000Z","originalTimestamp":"2021-09-01T00:00:00.000Z","channel":"sources","event":"event","request_ip":"5.6.7.8","properties":{"review_id":"86ac1cd43","product_id":"9578257311"},"userProperties":{"rating":3.0,"review_body":"OK for the price. It works but the material feels flimsy."},"context":{"traits":{"name":"Richard Hendricks","email":"rhedricks@example.com","logins":2},%s,"ip":"1.2.3.4"}}`, maxColumnsCount),
 			metadata:     getMetadata("track", "POSTGRES"),
 			destination:  getDestination("POSTGRES", map[string]any{}),
 			expectedResponse: types.Response{
 				Events: []types.TransformerResponse{
 					{
-						Output: trackDefaultOutput().SetDataField("channel", "sources").AddRandomEntries(500, func(index int) (string, string, string, string) {
+						Output: trackDefaultOutput().SetDataField("channel", "sources").AddRandomEntries(maxColumnsCount, func(index int) (string, string, string, string) {
 							return fmt.Sprintf("context_random_column_%d", index), fmt.Sprintf("random_value_%d", index), fmt.Sprintf("context_random_column_%d", index), "string"
 						}),
 						Metadata:   getMetadata("track", "POSTGRES"),
 						StatusCode: http.StatusOK,
 					},
 					{
-						Output: trackEventDefaultOutput().SetDataField("channel", "sources").AddRandomEntries(500, func(index int) (string, string, string, string) {
+						Output: trackEventDefaultOutput().SetDataField("channel", "sources").AddRandomEntries(maxColumnsCount, func(index int) (string, string, string, string) {
 							return fmt.Sprintf("context_random_column_%d", index), fmt.Sprintf("random_value_%d", index), fmt.Sprintf("context_random_column_%d", index), "string"
 						}),
 						Metadata:   getMetadata("track", "POSTGRES"),

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader.go
@@ -126,6 +126,10 @@ func (t *Transformer) sampleDiff(events []types.TransformerEvent, legacyResponse
 		if strings.Contains(diff, "\"auto-") {
 			continue
 		}
+		// Ignore Unicode diffs caused by Go vs JavaScript serialization differences
+		if unicodePattern.MatchString(diff) {
+			continue
+		}
 		if differedEventsCount == 0 {
 			sampleDiff = diff
 		}


### PR DESCRIPTION
# Description

- Keeping the constant to be 1600 for `WH_MAX_COLUMNS_IN_EVENT`, as is present for transformers. https://github.com/rudderlabs/rudder-devops/blob/158a05bd7a6c35b06795e3c46a109ce632bd2330/helm-charts/shared-services/per-az/environment/production/production.yaml#L34
- Ignore Unicode diffs caused by Go vs JavaScript serialisation differences, regex `\\u[0-9a-fA-F]{4}`.
- While parsing datetime, in case of "day out of range" error, fall back to normalising the date. This is being handle in JavaScript automatically `console.log(new Date('1988-04-31').toISOString()); // 1988-05-01T00:00:00.000Z`.

## Linear Ticket

- Resolves WAR-785

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
