### PR TITLE
chore: inject stats in source transformer

### DIFF
--- a/gateway/webhook/setup.go
+++ b/gateway/webhook/setup.go
@@ -131,8 +131,9 @@ func Setup(gwHandle Gateway, transformerFeaturesService TransformerFeaturesServi
 	for i := 0; i < maxTransformerProcess; i++ {
 		g.Go(crash.Wrapper(func() error {
 			bt := batchWebhookTransformerT{
-				webhook: webhook,
-				stats:   newWebhookStats(stat),
+				webhook:      webhook,
+				statsFactory: stat,
+				stats:        newWebhookStats(stat),
 				sourceTransformAdapter: func(ctx context.Context) (sourceTransformAdapter, error) {
 					return newSourceTransformAdapter(transformerFeaturesService.SourceTransformerVersion(), conf), nil
 				},


### PR DESCRIPTION
# Description

inject stats in source transformer to avoid using global stats.

## Linear Ticket

-

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
