### PR TITLE
chore: drop bot events in processor after capturing metrics

### DIFF
--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -1036,7 +1036,7 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 		jobUUID := uuid.New()
 		res = append(res, jobWithMetadata{
 			stat:                   stat,
-			skipLiveEventRecording: jobsDBParams.IsEventBlocked,
+			skipLiveEventRecording: (jobsDBParams.IsEventBlocked || (jobsDBParams.IsBot && jobsDBParams.BotAction == types.DropBotEventAction)),
 			job: &jobsdb.JobT{
 				UUID:         jobUUID,
 				UserID:       msg.Properties.RoutingKey,

--- a/gateway/handle_test.go
+++ b/gateway/handle_test.go
@@ -907,44 +907,6 @@ func TestExtractJobsFromInternalBatchPayload_LiveEventRecording(t *testing.T) {
 			description:               "Complex scenario: blocked events and bot drop events skip recording, others don't",
 		},
 		{
-			name: "bot events with invalid browser and drop action should skip live event recording",
-			messages: []stream.Message{
-				{
-					Properties: stream.MessageProperties{
-						RequestType:         "track",
-						RoutingKey:          "routing-key-1",
-						WorkspaceID:         "workspace1",
-						SourceID:            "source-id-1",
-						ReceivedAt:          time.Now(),
-						RequestIP:           "1.1.1.1",
-						IsBot:               true,
-						BotIsInvalidBrowser: true,
-						BotAction:           "drop",
-					},
-					Payload: json.RawMessage(`{"type":"track","event":"PageView","messageId":"msg-1","userId":"user1"}`),
-				},
-				{
-					Properties: stream.MessageProperties{
-						RequestType:         "track",
-						RoutingKey:          "routing-key-2",
-						WorkspaceID:         "workspace1",
-						SourceID:            "source-id-1",
-						ReceivedAt:          time.Now(),
-						RequestIP:           "1.1.1.1",
-						IsBot:               true,
-						BotIsInvalidBrowser: true,
-						BotAction:           "flag",
-					},
-					Payload: json.RawMessage(`{"type":"track","event":"Purchase","messageId":"msg-2","userId":"user1"}`),
-				},
-			},
-			eventBlockingSettings: backendconfig.EventBlocking{
-				Events: map[string][]string{},
-			},
-			expectedSkipLiveEventRecs: []bool{true, false},
-			description:               "Bot events with invalid browser - only 'drop' action should skip live event recording",
-		},
-		{
 			name: "blocked bot events with drop action and blocked events should skip live event recording",
 			messages: []stream.Message{
 				{

--- a/gateway/handle_test.go
+++ b/gateway/handle_test.go
@@ -685,3 +685,325 @@ func TestExtractJobsFromInternalBatchPayload_EventBlocking(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractJobsFromInternalBatchPayload_LiveEventRecording(t *testing.T) {
+	type testCase struct {
+		name                      string
+		messages                  []stream.Message
+		eventBlockingSettings     backendconfig.EventBlocking
+		expectedSkipLiveEventRecs []bool
+		description               string
+	}
+
+	tests := []testCase{
+		{
+			name: "normal events should not skip live event recording",
+			messages: []stream.Message{
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "track",
+						RoutingKey:  "routing-key-1",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1",
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       false,
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"PageView","messageId":"msg-1","userId":"user1"}`),
+				},
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "identify",
+						RoutingKey:  "routing-key-2",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1",
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       false,
+					},
+					Payload: json.RawMessage(`{"type":"identify","messageId":"msg-2","userId":"user1","traits":{"name":"John"}}`),
+				},
+			},
+			eventBlockingSettings: backendconfig.EventBlocking{
+				Events: map[string][]string{},
+			},
+			expectedSkipLiveEventRecs: []bool{false, false},
+			description:               "Normal events should allow live event recording",
+		},
+		{
+			name: "blocked events should skip live event recording",
+			messages: []stream.Message{
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "track",
+						RoutingKey:  "routing-key-1",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1", // Event stream source
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       false,
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"Purchase","messageId":"msg-1","userId":"user1"}`),
+				},
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "track",
+						RoutingKey:  "routing-key-2",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1",
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       false,
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"PageView","messageId":"msg-2","userId":"user1"}`),
+				},
+			},
+			eventBlockingSettings: backendconfig.EventBlocking{
+				Events: map[string][]string{
+					"track": {"Purchase"},
+				},
+			},
+			expectedSkipLiveEventRecs: []bool{true, false},
+			description:               "Blocked events should skip live event recording while non-blocked events should not",
+		},
+		{
+			name: "bot events with drop action should skip live event recording",
+			messages: []stream.Message{
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "track",
+						RoutingKey:  "routing-key-1",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1",
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       true,
+						BotName:     "test-bot",
+						BotURL:      "https://test-bot.com",
+						BotAction:   "drop",
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"PageView","messageId":"msg-1","userId":"user1"}`),
+				},
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "track",
+						RoutingKey:  "routing-key-2",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1",
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       false,
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"AddToCart","messageId":"msg-2","userId":"user1"}`),
+				},
+			},
+			eventBlockingSettings: backendconfig.EventBlocking{
+				Events: map[string][]string{},
+			},
+			expectedSkipLiveEventRecs: []bool{true, false},
+			description:               "Bot events with 'drop' action should skip live event recording",
+		},
+		{
+			name: "bot events with flag action should not skip live event recording",
+			messages: []stream.Message{
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "track",
+						RoutingKey:  "routing-key-1",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1",
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       true,
+						BotName:     "test-bot",
+						BotURL:      "https://test-bot.com",
+						BotAction:   "flag",
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"PageView","messageId":"msg-1","userId":"user1"}`),
+				},
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "track",
+						RoutingKey:  "routing-key-2",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1",
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       true,
+						BotName:     "another-bot",
+						BotAction:   "disable",
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"Purchase","messageId":"msg-2","userId":"user1"}`),
+				},
+			},
+			eventBlockingSettings: backendconfig.EventBlocking{
+				Events: map[string][]string{},
+			},
+			expectedSkipLiveEventRecs: []bool{false, false},
+			description:               "Bot events with 'flag' or 'disable' actions should allow live event recording",
+		},
+		{
+			name: "mixed scenario - blocked events and bot events with drop action",
+			messages: []stream.Message{
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "track",
+						RoutingKey:  "routing-key-1",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1", // Event stream source
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       false,
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"Purchase","messageId":"msg-1","userId":"user1"}`),
+				},
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "track",
+						RoutingKey:  "routing-key-2",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1",
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       true,
+						BotName:     "crawler-bot",
+						BotAction:   "drop",
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"PageView","messageId":"msg-2","userId":"user1"}`),
+				},
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "track",
+						RoutingKey:  "routing-key-3",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1",
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       true,
+						BotName:     "analytics-bot",
+						BotAction:   "flag",
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"AddToCart","messageId":"msg-3","userId":"user1"}`),
+				},
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "track",
+						RoutingKey:  "routing-key-4",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1",
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       false,
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"Checkout","messageId":"msg-4","userId":"user1"}`),
+				},
+			},
+			eventBlockingSettings: backendconfig.EventBlocking{
+				Events: map[string][]string{
+					"track": {"Purchase"},
+				},
+			},
+			expectedSkipLiveEventRecs: []bool{true, true, false, false},
+			description:               "Complex scenario: blocked events and bot drop events skip recording, others don't",
+		},
+		{
+			name: "bot events with invalid browser and drop action should skip live event recording",
+			messages: []stream.Message{
+				{
+					Properties: stream.MessageProperties{
+						RequestType:         "track",
+						RoutingKey:          "routing-key-1",
+						WorkspaceID:         "workspace1",
+						SourceID:            "source-id-1",
+						ReceivedAt:          time.Now(),
+						RequestIP:           "1.1.1.1",
+						IsBot:               true,
+						BotIsInvalidBrowser: true,
+						BotAction:           "drop",
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"PageView","messageId":"msg-1","userId":"user1"}`),
+				},
+				{
+					Properties: stream.MessageProperties{
+						RequestType:         "track",
+						RoutingKey:          "routing-key-2",
+						WorkspaceID:         "workspace1",
+						SourceID:            "source-id-1",
+						ReceivedAt:          time.Now(),
+						RequestIP:           "1.1.1.1",
+						IsBot:               true,
+						BotIsInvalidBrowser: true,
+						BotAction:           "flag",
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"Purchase","messageId":"msg-2","userId":"user1"}`),
+				},
+			},
+			eventBlockingSettings: backendconfig.EventBlocking{
+				Events: map[string][]string{},
+			},
+			expectedSkipLiveEventRecs: []bool{true, false},
+			description:               "Bot events with invalid browser - only 'drop' action should skip live event recording",
+		},
+		{
+			name: "blocked bot events with drop action should skip live event recording",
+			messages: []stream.Message{
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "track",
+						RoutingKey:  "routing-key-1",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1", // Event stream source
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       true,
+						BotName:     "blocked-bot",
+						BotAction:   "drop",
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"Purchase","messageId":"msg-1","userId":"user1"}`),
+				},
+				{
+					Properties: stream.MessageProperties{
+						RequestType: "track",
+						RoutingKey:  "routing-key-2",
+						WorkspaceID: "workspace1",
+						SourceID:    "source-id-1", // Event stream source
+						ReceivedAt:  time.Now(),
+						RequestIP:   "1.1.1.1",
+						IsBot:       true,
+						BotName:     "blocked-bot-2",
+						BotAction:   "flag",
+					},
+					Payload: json.RawMessage(`{"type":"track","event":"Purchase","messageId":"msg-2","userId":"user1"}`),
+				},
+			},
+			eventBlockingSettings: backendconfig.EventBlocking{
+				Events: map[string][]string{
+					"track": {"Purchase"},
+				},
+			},
+			expectedSkipLiveEventRecs: []bool{true, true},
+			description:               "Both blocked events and bot drop events should skip live event recording",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := createTestGateway(t, true, tt.eventBlockingSettings)
+
+			payloadBytes, err := jsonrs.Marshal(tt.messages)
+			require.NoError(t, err, "Failed to marshal test messages")
+
+			jobs, err := gw.extractJobsFromInternalBatchPayload("batch", payloadBytes)
+			require.NoError(t, err, "extractJobsFromInternalBatchPayload should not return error")
+
+			require.Len(t, jobs, len(tt.expectedSkipLiveEventRecs), "Number of jobs should match expected")
+
+			for i, expectedSkip := range tt.expectedSkipLiveEventRecs {
+				job := jobs[i]
+				require.Equal(t, expectedSkip, job.skipLiveEventRecording,
+					"Job %d: skipLiveEventRecording should be %t - %s",
+					i, expectedSkip, tt.description)
+			}
+		})
+	}
+}

--- a/gateway/handle_test.go
+++ b/gateway/handle_test.go
@@ -945,7 +945,7 @@ func TestExtractJobsFromInternalBatchPayload_LiveEventRecording(t *testing.T) {
 			description:               "Bot events with invalid browser - only 'drop' action should skip live event recording",
 		},
 		{
-			name: "blocked bot events with drop action should skip live event recording",
+			name: "blocked bot events with drop action and blocked events should skip live event recording",
 			messages: []stream.Message{
 				{
 					Properties: stream.MessageProperties{

--- a/internal/enricher/bot.go
+++ b/internal/enricher/bot.go
@@ -5,6 +5,7 @@ import (
 
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/processor/types"
+	utils "github.com/rudderlabs/rudder-server/utils/types"
 )
 
 type botDetails struct {
@@ -27,9 +28,7 @@ func (e *botEnricher) Enrich(_ *backendconfig.SourceT, request *types.GatewayBat
 			continue
 		}
 
-		// BotAction empty check is for backward compatibility, BotAction field might be absent indicating ingestion service is not released with BotAction field
-		// TODO: remove the empty check after ingestion service is released with BotAction field
-		if eventParams.BotAction != "flag" && eventParams.BotAction != "" {
+		if eventParams.BotAction != utils.FlagBotEventAction {
 			continue
 		}
 

--- a/internal/enricher/bot_test.go
+++ b/internal/enricher/bot_test.go
@@ -130,36 +130,6 @@ func TestBotEnricher(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "bot event with empty BotAction should be enriched",
-			request: &types.GatewayBatchRequest{
-				Batch: []types.SingularEventT{
-					{
-						"event": "test-event",
-					},
-				},
-			},
-			eventParams: &types.EventParams{
-				IsBot:     true,
-				BotName:   "test-bot",
-				BotURL:    "https://test-bot.com",
-				BotAction: "",
-			},
-			expectedEvents: []types.SingularEventT{
-				{
-					"event": "test-event",
-					"context": map[string]interface{}{
-						"isBot": true,
-						"bot": botDetails{
-							Name:             "test-bot",
-							URL:              "https://test-bot.com",
-							IsInvalidBrowser: false,
-						},
-					},
-				},
-			},
-			expectError: false,
-		},
-		{
 			name: "bot event with BotAction 'flag' and without context should be enriched with new context",
 			request: &types.GatewayBatchRequest{
 				Batch: []types.SingularEventT{

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1924,8 +1924,8 @@ func (proc *Handle) preprocessStage(partition string, subJobs subJob) (*preTrans
 					},
 					nil,
 				)
-
-				transformerEvent.StatusCode = 0 // reset status code to 0
+				// reset status code to 0 because transformerEvent is reused for GATEWAY metrics below, which expect statusCode = 0
+				transformerEvent.StatusCode = 0
 			}
 			// REPORTING - BOT_MANAGEMENT metrics - END
 

--- a/processor/processor_bot_enricher_test.go
+++ b/processor/processor_bot_enricher_test.go
@@ -31,7 +31,7 @@ func TestProcessorBotEnrichment(t *testing.T) {
 	t.Run("feature disabled", func(t *testing.T) {
 		new(botScenario).
 			WithBotEnrichmentEnabled(false).
-			WithBotInfo(true, "", "test-bot", "https://test-bot.com", false).
+			WithBotInfo(true, "flag", "test-bot", "https://test-bot.com", false).
 			Run(t, func(t *testing.T, event string) {
 				// missing fields checks
 				require.False(t, gjson.Get(event, "context.isBot").Exists(), "no bot information should be present when feature is disabled")
@@ -42,7 +42,7 @@ func TestProcessorBotEnrichment(t *testing.T) {
 	t.Run("feature enabled with non-bot event", func(t *testing.T) {
 		new(botScenario).
 			WithBotEnrichmentEnabled(true).
-			WithBotInfo(false, "", "", "", false).
+			WithBotInfo(false, "flag", "", "", false).
 			Run(t, func(t *testing.T, event string) {
 				// missing fields checks
 				require.False(t, gjson.Get(event, "context.isBot").Exists(), "no bot information should be present for non-bot event")
@@ -53,7 +53,7 @@ func TestProcessorBotEnrichment(t *testing.T) {
 	t.Run("feature enabled with bot event", func(t *testing.T) {
 		new(botScenario).
 			WithBotEnrichmentEnabled(true).
-			WithBotInfo(true, "", "test-bot", "https://test-bot.com", false).
+			WithBotInfo(true, "flag", "test-bot", "https://test-bot.com", false).
 			Run(t, func(t *testing.T, event string) {
 				require.True(t, gjson.Get(event, "context.isBot").Bool(), "isBot should be true")
 				require.Equal(t, "test-bot", gjson.Get(event, "context.bot.name").String(), "bot name should be set")
@@ -66,7 +66,7 @@ func TestProcessorBotEnrichment(t *testing.T) {
 	t.Run("feature enabled with bot details and empty bot URL", func(t *testing.T) {
 		new(botScenario).
 			WithBotEnrichmentEnabled(true).
-			WithBotInfo(true, "", "test-bot", "", false).
+			WithBotInfo(true, "flag", "test-bot", "", false).
 			Run(t, func(t *testing.T, event string) {
 				require.True(t, gjson.Get(event, "context.isBot").Bool(), "isBot should be true")
 				require.Equal(t, "test-bot", gjson.Get(event, "context.bot.name").String(), "bot name should be set")
@@ -79,7 +79,7 @@ func TestProcessorBotEnrichment(t *testing.T) {
 	t.Run("feature enabled with invalid browser", func(t *testing.T) {
 		new(botScenario).
 			WithBotEnrichmentEnabled(true).
-			WithBotInfo(true, "", "", "", true).
+			WithBotInfo(true, "flag", "", "", true).
 			Run(t, func(t *testing.T, event string) {
 				require.True(t, gjson.Get(event, "context.isBot").Bool(), "isBot should be true")
 				require.True(t, gjson.Get(event, "context.bot.isInvalidBrowser").Bool(), "isInvalidBrowser should be true")

--- a/utils/types/reporting_types.go
+++ b/utils/types/reporting_types.go
@@ -27,6 +27,7 @@ const (
 	BotDetectedStatus = "bot_detected"
 
 	// Module names
+	BOT_MANAGEMENT         = "bot_management"
 	GATEWAY                = "gateway"
 	DESTINATION_FILTER     = "destination_filter"
 	TRACKINGPLAN_VALIDATOR = "tracking_plan_validator"

--- a/utils/types/types.go
+++ b/utils/types/types.go
@@ -13,6 +13,10 @@ const (
 	FilterEventCode   = 298
 	SuppressEventCode = 299
 	DrainEventCode    = 410
+	SuccessEventCode  = 200
+
+	FlagBotEventAction = "flag"
+	DropBotEventAction = "drop"
 )
 
 // UserSuppression is interface to access Suppress user feature


### PR DESCRIPTION
# Description

This PR moves bot event dropping from the ingestion service to the processor to capture accurate reporting metrics before deduplication occurs.

### Background
Previously, bot events were dropped at the ingestion service level. The main issue was that there is currently no way to emit reporting metrics from ingestion, so we were using Prometheus metrics to power the UI which are not accurate. Now we are using reporting metrics in the processor to capture accurate bot event statistics.


### Changes made
- Drop bot events in the processor when botAction is set to "drop" in message parameters
- Block live events recording in gateway for bot events that will be dropped in the processor 
- Capture accurate bot event metrics before the deduplication stage

#### Additional changes
- Move event blocking logic to occur before dedup processing.
- Cleanup `botAction` empty check before enriching them.


## Linear Ticket

Resolves OBS-858

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
