### PR TITLE
chore: add logging for HasDynamicConfig flag in destination config

### DIFF
--- a/backend-config/types.go
+++ b/backend-config/types.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	"github.com/rudderlabs/rudder-server/backend-config/dynamicconfig"
 )
 
@@ -81,6 +84,12 @@ func (d *DestinationT) UpdateHasDynamicConfig(cache dynamicconfig.Cache) {
 
 	// RevisionID is not in cache or has changed, recompute the dynamic config flag
 	d.HasDynamicConfig = dynamicconfig.ContainsPattern(d.Config)
+
+	pkgLogger.Infon("HasDynamicConfig flag updated",
+		obskit.DestinationID(d.ID),
+		obskit.WorkspaceID(d.WorkspaceID),
+		logger.NewBoolField("hasDynamicConfig", d.HasDynamicConfig),
+	)
 
 	// Update the cache with the new value
 	cache.Set(d.ID, &dynamicconfig.DestinationRevisionInfo{


### PR DESCRIPTION
# Description

This PR adds informational logging when the HasDynamicConfig flag is enabled for destinations in the backend config. The logging includes destination ID and workspace ID to help with debugging and tracking which destinations have dynamic configuration patterns.

## Changes Made

- Added logging in the `UpdateHasDynamicConfig` method in `backend-config/types.go`
- The log is emitted only when `HasDynamicConfig` is true to avoid noise
- Includes relevant context (destination ID and workspace ID) for better debugging

## Linear Ticket

Resolves https://linear.app/rudderstack/issue/INT-3613/propagate-hasdynamicconfig-in-destination-in-rudder-server
## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.