### PR TITLE
feat: add support for snowpipe destination in rudder-cli

### DIFF
--- a/cmd/rudder-cli/warehouse/warehouse.go
+++ b/cmd/rudder-cli/warehouse/warehouse.go
@@ -42,6 +42,9 @@ func Query(c *cli.Context) (err error) {
 		}
 		sqlStmt = string(content)
 	}
+	if sqlStmt == "" {
+		return fmt.Errorf("no SQL statement provided")
+	}
 
 	input := QueryInput{
 		DestID:       c.String("dest"),

--- a/processor/internal/transformer/destination_transformer/destination_transformer.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer.go
@@ -373,13 +373,9 @@ func (d *Client) destTransformURL(destType string) string {
 	if _, ok := warehouseutils.PseudoWarehouseDestinationMap[destType]; ok {
 		whSchemaVersionQueryParam := fmt.Sprintf("whIDResolve=%t", d.conf.GetBool("Warehouse.enableIDResolution", false))
 		switch destType {
-		case warehouseutils.RS:
-			return destinationEndPoint + "?" + whSchemaVersionQueryParam
 		case warehouseutils.CLICKHOUSE:
 			enableArraySupport := fmt.Sprintf("chEnableArraySupport=%s", fmt.Sprintf("%v", d.conf.GetBool("Warehouse.clickhouse.enableArraySupport", false)))
 			return destinationEndPoint + "?" + whSchemaVersionQueryParam + "&" + enableArraySupport
-		case warehouseutils.SnowpipeStreaming:
-			return fmt.Sprintf("%s?whIDResolve=%t", destinationEndPoint, d.conf.GetBool("Warehouse.enableIDResolution", false))
 		default:
 			return destinationEndPoint + "?" + whSchemaVersionQueryParam
 		}

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/events_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/events_test.go
@@ -2988,7 +2988,7 @@ func TestEvents(t *testing.T) {
 			},
 			"type": "track",
 		}
-		for destination := range whutils.WarehouseDestinationMap {
+		for destination := range whutils.PseudoWarehouseDestinationMap {
 			t.Run(destination, func(t *testing.T) {
 				c := setupConfig(transformerResource, map[string]any{})
 
@@ -3029,7 +3029,7 @@ func TestEvents(t *testing.T) {
 				"timestamp":         "2021-09-01T00:00:00.000Z",
 				"type":              "track",
 			}
-			for destination := range whutils.WarehouseDestinationMap {
+			for destination := range whutils.PseudoWarehouseDestinationMap {
 				t.Run(destination, func(t *testing.T) {
 					c := setupConfig(transformerResource, map[string]any{})
 
@@ -3060,7 +3060,7 @@ func TestEvents(t *testing.T) {
 				"timestamp":         "2021-09-01T00:00:00.000Z",
 				"type":              "track",
 			}
-			for destination := range whutils.WarehouseDestinationMap {
+			for destination := range whutils.PseudoWarehouseDestinationMap {
 				t.Run(destination, func(t *testing.T) {
 					c := setupConfig(transformerResource, map[string]any{})
 
@@ -3091,7 +3091,7 @@ func TestEvents(t *testing.T) {
 				"timestamp":         "2021-09-01T00:00:00.000Z",
 				"type":              "track",
 			}
-			for destination := range whutils.WarehouseDestinationMap {
+			for destination := range whutils.PseudoWarehouseDestinationMap {
 				t.Run(destination, func(t *testing.T) {
 					c := setupConfig(transformerResource, map[string]any{})
 

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/events_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/events_test.go
@@ -3138,7 +3138,7 @@ func TestEvents(t *testing.T) {
 				"timestamp":         "2021-09-01T00:00:00.000Z",
 				"type":              "track",
 			}
-			for destination := range whutils.WarehouseDestinationMap {
+			for destination := range whutils.PseudoWarehouseDestinationMap {
 				t.Run(destination, func(t *testing.T) {
 					c := setupConfig(transformerResource, map[string]any{})
 
@@ -3208,7 +3208,7 @@ func TestEvents(t *testing.T) {
 				"timestamp":         "2021-09-01T00:00:00.000Z",
 				"type":              "track",
 			}
-			for destination := range whutils.WarehouseDestinationMap {
+			for destination := range whutils.PseudoWarehouseDestinationMap {
 				t.Run(destination, func(t *testing.T) {
 					c := setupConfig(transformerResource, map[string]any{})
 

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/transformer_fuzz_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/transformer_fuzz_test.go
@@ -534,7 +534,7 @@ func FuzzTransformer(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, destType, destConfigJSON, payload string) {
-		if _, exist := whutils.WarehouseDestinationMap[destType]; !exist {
+		if _, exist := whutils.PseudoWarehouseDestinationMap[destType]; !exist {
 			return
 		}
 

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/channel.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/channel.go
@@ -228,7 +228,5 @@ func (m *Manager) createSnowflakeManager(ctx context.Context, namespace string) 
 		Type:        m.destination.DestinationDefinition.Name,
 		Identifier:  m.destination.WorkspaceID + ":" + m.destination.ID,
 	}
-	modelWarehouse.Destination.Config["useKeyPairAuth"] = true // Since we are currently only supporting key pair auth
-
 	return m.managerCreator(ctx, modelWarehouse, m.appConfig, m.logger, m.statsFactory)
 }

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -139,7 +139,6 @@ func (m *Manager) retryableClient() *retryablehttp.Client {
 }
 
 func (m *Manager) validateConfig(ctx context.Context, dest *backendconfig.DestinationT) error {
-	dest.Config["useKeyPairAuth"] = true // Since we are currently only supporting key pair auth
 	response := m.validator.Validate(ctx, dest)
 	if response.Success {
 		return nil

--- a/warehouse/bcm/backend_config.go
+++ b/warehouse/bcm/backend_config.go
@@ -156,6 +156,8 @@ func (bcm *BackendConfigManager) processData(ctx context.Context, data map[strin
 			sourceIDsByWorkspace[workspaceID] = append(sourceIDsByWorkspace[workspaceID], source.ID)
 
 			for _, destination := range source.Destinations {
+				// PseudoWarehouseDestinationMap is being used instead of WarehouseDestinations because
+				// SnowpipeStreaming validation requires the destination to be in this workspace config
 				if _, ok := whutils.PseudoWarehouseDestinationMap[destination.DestinationDefinition.Name]; !ok {
 					bcm.logger.Debugf("Not a warehouse destination, skipping %s", destination.DestinationDefinition.Name)
 					continue

--- a/warehouse/bcm/backend_config.go
+++ b/warehouse/bcm/backend_config.go
@@ -156,7 +156,7 @@ func (bcm *BackendConfigManager) processData(ctx context.Context, data map[strin
 			sourceIDsByWorkspace[workspaceID] = append(sourceIDsByWorkspace[workspaceID], source.ID)
 
 			for _, destination := range source.Destinations {
-				if _, ok := whutils.WarehouseDestinationMap[destination.DestinationDefinition.Name]; !ok {
+				if _, ok := whutils.PseudoWarehouseDestinationMap[destination.DestinationDefinition.Name]; !ok {
 					bcm.logger.Debugf("Not a warehouse destination, skipping %s", destination.DestinationDefinition.Name)
 					continue
 				}

--- a/warehouse/encoding/encoding_test.go
+++ b/warehouse/encoding/encoding_test.go
@@ -176,7 +176,7 @@ func TestReaderLoader(t *testing.T) {
 			nullCount := metadata.GetStatistics().GetNullCount()
 			return columnName, nullCount
 		})
-		require.Equal(t, nullsMap, map[string]int64{
+		require.Equal(t, map[string]int64{
 			"column1":  0,
 			"column10": 100,
 			"column11": 100,
@@ -194,7 +194,7 @@ func TestReaderLoader(t *testing.T) {
 			"column7":  0,
 			"column8":  0,
 			"column9":  100,
-		})
+		}, nullsMap)
 	})
 
 	t.Run("JSON", func(t *testing.T) {

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -1082,6 +1082,11 @@ func (sf *Snowflake) connect(ctx context.Context, opts optionalCreds) (*sqlmw.DB
 		Application:          "Rudderstack_Warehouse",
 		LoginTimeout:         timeout,
 	}
+	if sf.Warehouse.Destination.DestinationDefinition.Name == whutils.SnowpipeStreaming {
+		// Unlike Snowflake destination, we don't expose the useKeyPairAuth config for Snowpipe Streaming in the UI
+		// So we should set it explicitly here
+		data.UseKeyPairAuth = true
+	}
 
 	credentialsJSON, err := jsonrs.Marshal(data)
 	if err != nil {

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -136,8 +137,7 @@ var (
 )
 
 func pseudoWarehouseDestinations() map[string]struct{} {
-	all := append([]string{}, WarehouseDestinations...)
-	all = append(all, SnowpipeStreaming)
+	all := append(slices.Clone(WarehouseDestinations), SnowpipeStreaming)
 	return lo.SliceToMap(all, func(destination string) (string, struct{}) {
 		return destination, struct{}{}
 	})

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -132,10 +132,17 @@ var (
 	S3PathStyleRegex          = regexp.MustCompile(`https?://s3([.-](?P<region>[^.]+))?.amazonaws\.com/(?P<bucket>[^/]+)/(?P<keyname>.*)`)
 	S3VirtualHostedRegex      = regexp.MustCompile(`https?://(?P<bucket>[^/]+).s3([.-](?P<region>[^.]+))?.amazonaws\.com/(?P<keyname>.*)`)
 
-	WarehouseDestinationMap = lo.SliceToMap(WarehouseDestinations, func(destination string) (string, struct{}) {
+	PseudoWarehouseDestinationMap = pseudoWarehouseDestinations()
+)
+
+func pseudoWarehouseDestinations() map[string]struct{} {
+	all := make([]string, len(WarehouseDestinations)+1)
+	all = append(all, WarehouseDestinations...)
+	all = append(all, SnowpipeStreaming)
+	return lo.SliceToMap(all, func(destination string) (string, struct{}) {
 		return destination, struct{}{}
 	})
-)
+}
 
 var WHDestNameMap = map[string]string{
 	BQ:            "bigquery",

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -136,8 +136,7 @@ var (
 )
 
 func pseudoWarehouseDestinations() map[string]struct{} {
-	all := make([]string, len(WarehouseDestinations)+1)
-	all = append(all, WarehouseDestinations...)
+	all := append([]string{}, WarehouseDestinations...)
 	all = append(all, SnowpipeStreaming)
 	return lo.SliceToMap(all, func(destination string) (string, struct{}) {
 		return destination, struct{}{}


### PR DESCRIPTION
# Description

Changes made to add support for Snowpipe streaming destination
1. Workspace config contained config only for warehouse destinations. Updated this code to included config for Snowpipe destination as well
2. For snowpipe streaming, the only mode of authentication supported is key pair auth. So that is why there is no explicit field `useKeyPairAuth` in its destination config. So added this logic in the connect function of snowflake. Post this change, also removed it from other places (validations and manager creation), since now it is unnecessary there.

Refactoring: Added Snowpipe in `WarehouseDestinationMap` to avoid having separate check for it at multiple places. Also renamed it to `PseudoWarehouseDestinationMap`. 

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.