### PR TITLE
fix: ensure hasDynamicConfig field always present in DestinationT JSON

### DIFF
--- a/backend-config/types.go
+++ b/backend-config/types.go
@@ -63,7 +63,7 @@ type DestinationT struct {
 	RevisionID            string
 	DeliveryAccount       *Account `json:"deliveryAccount,omitempty"`
 	DeleteAccount         *Account `json:"deleteAccount,omitempty"`
-	HasDynamicConfig      bool     `json:"hasDynamicConfig,omitempty"`
+	HasDynamicConfig      bool     `json:"hasDynamicConfig"`
 }
 
 // UpdateHasDynamicConfig checks if the destination config contains dynamic config patterns

--- a/backend-config/types_test.go
+++ b/backend-config/types_test.go
@@ -1,10 +1,11 @@
 package backendconfig
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 )
 
 func TestDestinationT_MarshalJSON_HasDynamicConfigAlwaysPresent(t *testing.T) {
@@ -41,12 +42,12 @@ func TestDestinationT_MarshalJSON_HasDynamicConfigAlwaysPresent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Marshal the destination to JSON
-			jsonData, err := json.Marshal(tt.destination)
+			jsonData, err := jsonrs.Marshal(tt.destination)
 			require.NoError(t, err)
 
 			// Unmarshal to a map to check for key presence
 			var result map[string]interface{}
-			err = json.Unmarshal(jsonData, &result)
+			err = jsonrs.Unmarshal(jsonData, &result)
 			require.NoError(t, err)
 
 			// Verify that hasDynamicConfig key is present

--- a/backend-config/types_test.go
+++ b/backend-config/types_test.go
@@ -1,0 +1,62 @@
+package backendconfig
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDestinationT_MarshalJSON_HasDynamicConfigAlwaysPresent(t *testing.T) {
+	tests := []struct {
+		name             string
+		destination      DestinationT
+		expectedKeyValue bool
+	}{
+		{
+			name: "HasDynamicConfig is false",
+			destination: DestinationT{
+				ID:               "test-dest-1",
+				Name:             "Test Destination 1",
+				HasDynamicConfig: false,
+			},
+			expectedKeyValue: false,
+		},
+		{
+			name: "HasDynamicConfig is true",
+			destination: DestinationT{
+				ID:               "test-dest-2",
+				Name:             "Test Destination 2",
+				HasDynamicConfig: true,
+			},
+			expectedKeyValue: true,
+		},
+		{
+			name:             "Zero value DestinationT",
+			destination:      DestinationT{},
+			expectedKeyValue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Marshal the destination to JSON
+			jsonData, err := json.Marshal(tt.destination)
+			require.NoError(t, err)
+
+			// Unmarshal to a map to check for key presence
+			var result map[string]interface{}
+			err = json.Unmarshal(jsonData, &result)
+			require.NoError(t, err)
+
+			// Verify that hasDynamicConfig key is present
+			value, exists := result["hasDynamicConfig"]
+			require.True(t, exists, "hasDynamicConfig key should always be present in marshaled JSON")
+
+			// Verify the value is correct
+			boolValue, ok := value.(bool)
+			require.True(t, ok, "hasDynamicConfig value should be a boolean")
+			require.Equal(t, tt.expectedKeyValue, boolValue, "hasDynamicConfig value should match expected")
+		})
+	}
+}

--- a/processor/testdata/goldenUtMirrorClientEvents.json
+++ b/processor/testdata/goldenUtMirrorClientEvents.json
@@ -52,7 +52,8 @@
                 }
             ],
             "IsProcessorEnabled": true,
-            "RevisionID": ""
+            "RevisionID": "",
+            "hasDynamicConfig": false
         },
         "connection": {
             "sourceId": "",
@@ -116,7 +117,8 @@
                 }
             ],
             "IsProcessorEnabled": true,
-            "RevisionID": ""
+            "RevisionID": "",
+            "hasDynamicConfig": false
         },
         "connection": {
             "sourceId": "",
@@ -178,7 +180,8 @@
                 }
             ],
             "IsProcessorEnabled": true,
-            "RevisionID": ""
+            "RevisionID": "",
+            "hasDynamicConfig": false
         },
         "connection": {
             "sourceId": "",


### PR DESCRIPTION
# Description

This PR ensures that the  field is always present in the JSON representation of  struct, even when its value is .

## Changes Made

1. **Updated JSON tag**: Removed  from  field in  struct
   - Before: `json:"hasDynamicConfig,omitempty"`
   - After: `json:"hasDynamicConfig"`

**Added comprehensive test**: Created `TestDestinationT_MarshalJSON_HasDynamicConfigAlwaysPresent` to verify:
   - Field is present when `HasDynamicConfig` is `false`
   - Field is present when `HasDynamicConfig` is `true`
   - Field is present for zero-value `DestinationT` structs

## Why This Change?

Previously, when  was  (the zero value for booleans), the  tag would cause the field to be omitted from the JSON output. This change ensures consistent JSON structure regardless of the boolean value.

## Testing

- All existing tests continue to pass
- New test specifically validates the field is always present in marshaled JSON

## Linear Ticket

N/A - Small bug fix for JSON serialization consistency

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.