### PR TITLE
feat: implement leaky uploader for invalid payloads

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -2820,7 +2820,8 @@ func TestLeakyUploader(t *testing.T) {
 		// Verify no files uploaded to Minio
 		require.Never(t, func() bool {
 			contents, err := minioContainer.Contents(context.Background(), "gw-failed-events")
-			return len(contents) != 0 && err == nil
+			require.NoError(t, err)
+			return len(contents) != 0
 		}, 5*time.Second, time.Second, "Minio bucket not updated within timeout")
 	})
 }

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -2763,7 +2763,7 @@ func TestLeakyUploader(t *testing.T) {
 		minioContainer, err := minio.Setup(pool, t)
 		require.NoError(t, err)
 
-		// create test gateway with leaky uploader enabled
+		// create a test gateway with leaky uploader enabled
 		gw, cleanupFn := createTestGatewayWithLeakyUploader(t, minioContainer.Endpoint, minioContainer.AccessKeyID, minioContainer.AccessKeySecret)
 		t.Cleanup(cleanupFn)
 

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -142,7 +142,7 @@ type Handle struct {
 	webhookAuthMiddleware *auth.WebhookAuth
 
 	// leakyUploader is an optional function that can be set to handle uploading of invalid payloads
-	leakyUploader func(upload leakyUpload)
+	leakyUploader func(upload msgToUpload)
 }
 
 // findUserWebRequestWorker finds and returns the worker that works on a particular `userID`.
@@ -788,7 +788,7 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 	defer func() {
 		// Upload the raw payload via leaky uploader if available
 		if err != nil && gw.leakyUploader != nil {
-			gw.leakyUploader(leakyUpload{
+			gw.leakyUploader(msgToUpload{
 				payload: body,
 				fields:  []logger.Field{obskit.Error(err)},
 			})

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -787,7 +787,7 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 
 	defer func() {
 		// Upload the raw payload via leaky uploader if available
-		if (err != nil && gw.leakyUploader != nil) || len(messages) == 0 {
+		if (err != nil || len(messages) == 0) && gw.leakyUploader != nil {
 			toUpload := msgToUpload{
 				payload: body,
 			}

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -787,7 +787,7 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 
 	defer func() {
 		// Upload the raw payload via leaky uploader if available
-		if (err != nil || len(messages) == 0) && gw.leakyUploader != nil {
+		if gw.leakyUploader != nil && (err != nil || len(messages) == 0) {
 			toUpload := msgToUpload{
 				payload: body,
 			}

--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -2,13 +2,18 @@ package gateway
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/filemanager"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
 	gwtypes "github.com/rudderlabs/rudder-server/gateway/types"
 
@@ -47,6 +52,11 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 )
+
+type leakyUpload struct {
+	payload []byte
+	fields  []logger.Field
+}
 
 /*
 Setup initializes this module:
@@ -203,7 +213,110 @@ func (gw *Handle) Setup(
 		gw.collectMetrics(ctx)
 		return nil
 	}))
+
+	if gw.config.GetBool("gateway.leakyUploader.enabled", false) {
+		leakyUploaderDone := make(chan struct{})
+		leakyUploaderBuffer := make(chan leakyUpload, config.GetInt("gateway.leakyUploader.bufferSize", 1))
+		fm, err := getLeakyUploaderFileManager(gw.config, gw.logger)
+		if err == nil {
+			gw.leakyUploader = func(upload leakyUpload) {
+				select {
+				case leakyUploaderBuffer <- leakyUpload{payload: upload.payload, fields: upload.fields}:
+				default:
+					// drop the payload if the channel is full
+				}
+			}
+			g.Go(crash.Wrapper(func() error {
+				leakyUploader(ctx, gw.config, gw.logger, leakyUploaderDone, leakyUploaderBuffer, fm)
+				defer func() {
+					<-leakyUploaderDone
+					close(leakyUploaderBuffer)
+				}()
+				return nil
+			}))
+		} else {
+			gw.logger.Errorn("failed to create leaky uploader file manager", obskit.Error(err))
+		}
+	}
 	return nil
+}
+
+func getLeakyUploaderFileManager(conf *config.Config, log logger.Logger) (filemanager.FileManager, error) {
+	var (
+		regionHint       = conf.GetStringVar("us-east-1", "leakyUploader.Storage.RegionHint", "AWS_S3_REGION_HINT")
+		endpoint         = conf.GetString("leakyUploader.Storage.Endpoint", "")
+		accessKeyID      = conf.GetStringVar("", "leakyUploader.Storage.AccessKeyId", "AWS_ACCESS_KEY_ID")
+		accessKey        = conf.GetStringVar("", "leakyUploader.Storage.AccessKey", "AWS_SECRET_ACCESS_KEY")
+		s3ForcePathStyle = conf.GetBool("leakyUploader.Storage.S3ForcePathStyle", false)
+		disableSSL       = conf.GetBool("leakyUploader.Storage.DisableSsl", false)
+		enableSSE        = conf.GetBoolVar(false, "leakyUploader.Storage.EnableSse", "AWS_ENABLE_SSE")
+		useGlue          = conf.GetBool("leakyUploader.Storage.UseGlue", false)
+		region           = conf.GetStringVar("us-east-1", "leakyUploader.Storage.Region", "AWS_DEFAULT_REGION")
+		bucket           = conf.GetStringVar("rudder-customer-sample-payloads-us", "leakyUploader.Storage.Bucket")
+	)
+
+	s3Config := map[string]any{
+		"bucketName":       bucket,
+		"endpoint":         endpoint,
+		"accessKeyID":      accessKeyID,
+		"accessKey":        accessKey,
+		"s3ForcePathStyle": s3ForcePathStyle,
+		"disableSSL":       disableSSL,
+		"enableSSE":        enableSSE,
+		"regionHint":       regionHint,
+		"useGlue":          useGlue,
+		"region":           region,
+	}
+	return filemanager.NewS3Manager(
+		conf,
+		s3Config,
+		log.Withn(logger.NewStringField("component", "leaky-uploader")),
+		func() time.Duration {
+			return conf.GetDuration("leakyUploader.Timeout", 120, time.Second)
+		},
+	)
+}
+
+func leakyUploader(ctx context.Context, conf *config.Config, log logger.Logger, done chan struct{}, uploads <-chan leakyUpload, fm filemanager.FileManager) {
+	backoff := conf.GetDuration("gateway.leakyUploader.backoff", 1, time.Second)
+	instanceName := conf.GetString("INSTANCE_ID", "unknown-instance")
+	log.Infon("starting leaky payload uploader", logger.NewStringField("instanceName", instanceName))
+	defer close(done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case upload := <-uploads:
+			file, err := os.CreateTemp("", "payload-dump*.txt")
+			if err != nil {
+				log.Errorn("Payload dump: cannot create temp file", obskit.Error(err))
+				continue
+			}
+			_, err = file.WriteString(base64.StdEncoding.EncodeToString(upload.payload))
+			if err != nil {
+				log.Errorn("Payload dump: cannot write base64 encoded payload to the file", obskit.Error(err))
+				continue
+			}
+			file, err = os.Open(file.Name())
+			if err != nil {
+				log.Errorn("Payload dump: cannot open temp file", obskit.Error(err))
+				continue
+			}
+			uploadedFile, err := fm.Upload(ctx, file, "gw-failed-events", instanceName, time.Now().Format("2006-01-02"))
+			if err != nil {
+				log.Errorn("Payload dump: cannot upload", obskit.Error(err))
+				continue
+			}
+			upload.fields = append(upload.fields, logger.NewStringField("payload", uploadedFile.Location))
+
+			log.Infon("Payload dump uploaded", upload.fields...)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+		}
+	}
 }
 
 type OptFunc func(*Handle)


### PR DESCRIPTION
# Description

- Add leaky uploader functionality to handle invalid JSON payloads
- Upload invalid payloads to s3 for debugging and analysis
- Ensure valid payloads are processed normally without being uploaded
- Configure leaky uploader with S3 storage options
- Implement backoff and buffer mechanisms for failed uploads

## Linear Ticket

pipe-2188

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
