### PR TITLE
fix: statsExcludedTags causes server to shutdown immediately

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,11 +39,16 @@ func main() {
 
 	shutdownOnNonReloadableConfigChange := c.GetReloadableBoolVar(false, "shutdownOnNonReloadableConfigChange")
 	c.OnNonReloadableConfigChange(func(key string) {
-		if shutdownOnNonReloadableConfigChange.Load() {
-			log.Infon("Config change detected, shutting down server...", logger.NewStringField("key", key))
-			cancel()
-		} else {
-			log.Infon("Config change detected, but server will not shut down", logger.NewStringField("key", key))
+		switch key {
+		case "statsExcludedTags": // keys to ignore
+			// no-op
+		default:
+			if shutdownOnNonReloadableConfigChange.Load() {
+				log.Infon("Config change detected, shutting down server...", logger.NewStringField("key", key))
+				cancel()
+			} else {
+				log.Infon("Config change detected, but server will not shut down", logger.NewStringField("key", key))
+			}
 		}
 	})
 


### PR DESCRIPTION
# Description

Ignoring `statsExcludedTags` config change during non-reloadable config restarts, since under some conditions it can be set after server starts, which will cause an unwanted immediate shutdown of the server.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
