### PR TITLE
fix: custom type in payload during enrichment

### DIFF
--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/datatype.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/datatype.go
@@ -23,7 +23,7 @@ func dataTypeFor(destType, key string, val any, isJSONKey bool) string {
 
 func primitiveType(val any) string {
 	switch v := val.(type) {
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, uintptr:
 		return model.IntDataType
 	case float64:
 		return getFloatType(v)

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/datatype.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/datatype.go
@@ -1,15 +1,10 @@
 package warehouse
 
 import (
-	"fmt"
 	"math/big"
 
-	"github.com/samber/lo"
-
-	"github.com/rudderlabs/rudder-server/internal/enricher"
 	"github.com/rudderlabs/rudder-server/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/model"
 	"github.com/rudderlabs/rudder-server/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils"
-	"github.com/rudderlabs/rudder-server/processor/types"
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
@@ -85,7 +80,7 @@ func overrideForRedshift(val any, isJSONKey bool) string {
 
 func shouldUseTextForRedshift(data any) bool {
 	switch v := data.(type) {
-	case []any, []types.ValidationError, map[string]any:
+	case []any, map[string]any:
 		jsonVal, _ := utils.MarshalJSON(v)
 		// Javascript strings are UTF-16 encoded, use utf16 instead of utf8 package for determining the length
 		if utils.UTF16RuneCountInString(string(jsonVal)) > redshiftStringLimit {
@@ -105,103 +100,4 @@ func convertValIfDateTime(val any, colType string) any {
 		return utils.ToTimestamp(val)
 	}
 	return val
-}
-
-func convertToFloat64IfInteger(val any) any {
-	switch v := val.(type) {
-	case int:
-		return float64(v)
-	case int8:
-		return float64(v)
-	case int16:
-		return float64(v)
-	case int32:
-		return float64(v)
-	case int64:
-		return float64(v)
-	case uint:
-		return float64(v)
-	case uint8:
-		return float64(v)
-	case uint16:
-		return float64(v)
-	case uint32:
-		return float64(v)
-	case uint64:
-		return float64(v)
-	}
-	return val
-}
-
-func convertToSliceIfViolationErrors(val any) any {
-	if validationErrors, ok := val.([]types.ValidationError); ok {
-		result := make([]any, len(validationErrors))
-		for i, e := range validationErrors {
-			result[i] = map[string]any{
-				"type":     e.Type,
-				"message":  e.Message,
-				"meta":     lo.MapValues(e.Meta, func(value, _ string) any { return value }),
-				"property": e.Property,
-			}
-		}
-		return result
-	}
-	return val
-}
-
-func addDataAndMetadataForContextGeoEnrichment(tec *transformEventContext, data map[string]any, metadata map[string]string, key string, val any) error {
-	if geoLocation, ok := val.(enricher.Geolocation); ok {
-		if len(geoLocation.IP) > 0 {
-			ipKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_ip"))
-			if err != nil {
-				return fmt.Errorf("could not get ip column name: %w", err)
-			}
-			data[ipKey], metadata[ipKey] = geoLocation.IP, model.StringDataType
-		}
-		if len(geoLocation.City) > 0 {
-			cityKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_city"))
-			if err != nil {
-				return fmt.Errorf("could not get city column name: %w", err)
-			}
-			data[cityKey], metadata[cityKey] = geoLocation.City, model.StringDataType
-		}
-		if len(geoLocation.Country) > 0 {
-			countryKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_country"))
-			if err != nil {
-				return fmt.Errorf("could not get country column name: %w", err)
-			}
-			data[countryKey], metadata[countryKey] = geoLocation.Country, model.StringDataType
-		}
-		if len(geoLocation.Region) > 0 {
-			regionKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_region"))
-			if err != nil {
-				return fmt.Errorf("could not get region column name: %w", err)
-			}
-			data[regionKey], metadata[regionKey] = geoLocation.Region, model.StringDataType
-		}
-		if len(geoLocation.Postal) > 0 {
-			postalKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_postal"))
-			if err != nil {
-				return fmt.Errorf("could not get postal column name: %w", err)
-			}
-			data[postalKey], metadata[postalKey] = geoLocation.Postal, model.StringDataType
-		}
-		if len(geoLocation.Location) > 0 {
-			locationKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_location"))
-			if err != nil {
-				return fmt.Errorf("could not get location column name: %w", err)
-			}
-			data[locationKey], metadata[locationKey] = geoLocation.Location, model.StringDataType
-		}
-		if len(geoLocation.Timezone) > 0 {
-			timezoneKey, err := safeColumnNameCached(tec, transformColumnNameCached(tec, key+"_timezone"))
-			if err != nil {
-				return fmt.Errorf("could not get timezone column name: %w", err)
-			}
-			data[timezoneKey], metadata[timezoneKey] = geoLocation.Timezone, model.StringDataType
-		}
-		return nil
-	}
-	data[key] = val
-	return nil
 }

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/datatype_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/datatype_test.go
@@ -8,18 +8,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/rudderlabs/rudder-server/processor/types"
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
 func TestDataType(t *testing.T) {
-	anySlice, validationErrorSlice := make([]any, 600), make([]types.ValidationError, 600)
+	anySlice := make([]any, 600)
 	anyMap := make(map[string]any)
 	for i := 0; i < 600; i++ {
 		anySlice[i] = i
-		validationErrorSlice[i] = types.ValidationError{
-			Type: "type",
-		}
 		anyMap[strconv.Itoa(i)] = i
 	}
 
@@ -60,8 +56,6 @@ func TestDataType(t *testing.T) {
 		// Redshift with text and string types
 		{"Redshift Text Type (Any Slice)", whutils.RS, "someKey", anySlice, false, "text"},
 		{"Redshift String Type (Any Slice)", whutils.RS, "someKey", []any{1, 2, 3}, false, "string"},
-		{"Redshift Text Type (Validation Error Slice)", whutils.RS, "someKey", validationErrorSlice, false, "text"},
-		{"Redshift String Type (Validation Error Slice)", whutils.RS, "someKey", []types.ValidationError{{Type: "type"}, {Type: "type"}, {Type: "type"}}, false, "string"},
 		{"Redshift Text Type (Any Map)", whutils.RS, "someKey", anyMap, false, "text"},
 		{"Redshift String Type (Any Map)", whutils.RS, "someKey", map[string]any{"1": 1, "2": 2, "3": 3}, false, "string"},
 		{"Redshift Text Type", whutils.RS, "someKey", strings.Repeat("a", 600), false, "text"},

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/response/response.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/response/response.go
@@ -26,7 +26,7 @@ var (
 	ErrEmptyColumnName              = NewTransformerError("Column name cannot be empty.", http.StatusBadRequest)
 	ErrRecordIDEmpty                = NewTransformerError("recordId cannot be empty for cloud sources events", http.StatusBadRequest)
 	ErrContextNotMap                = NewTransformerError("context is not a map", http.StatusInternalServerError)
-	ErrExtractEventNameEmpty        = NewTransformerError("cannot create event table with empty event name, event name is missing in the payload", http.StatusInternalServerError)
+	ErrExtractEventNameEmpty        = NewTransformerError("cannot create event table with empty event name, event name is missing in the payload", http.StatusBadRequest)
 	ErrRecordIDObject               = ErrRecordIDEmpty
 	ErrRecordIDArray                = ErrRecordIDEmpty
 )

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/types/types.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/types/types.go
@@ -16,7 +16,7 @@ type Metadata struct {
 	DestinationType   string         `json:"destinationType"`
 	SourceCategory    string         `json:"sourceCategory"`
 	EventType         string         `json:"eventType,omitempty"`
-	RecordID          interface{}    `json:"recordId,omitempty"`
+	RecordID          any            `json:"recordId,omitempty"`
 	DestinationConfig map[string]any `json:"destinationConfig"`
 }
 

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils/utils_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils/utils_test.go
@@ -214,7 +214,7 @@ func (p Person) String() string {
 
 func TestToString(t *testing.T) {
 	testCases := []struct {
-		input    interface{}
+		input    any
 		expected string
 	}{
 		{nil, ""},                                // nil
@@ -233,8 +233,8 @@ func TestToString(t *testing.T) {
 		{float64(1746422198716531200), "1746422198716531200"},            // big float
 	}
 
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("ToString(%v)", tc.input), func(t *testing.T) {
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("ToString(%d)", i+1), func(t *testing.T) {
 			require.Equal(t, tc.expected, ToString(tc.input))
 		})
 	}
@@ -243,7 +243,7 @@ func TestToString(t *testing.T) {
 func TestIsBlank(t *testing.T) {
 	testCases := []struct {
 		name     string
-		input    interface{}
+		input    any
 		expected bool
 	}{
 		{"NilValue", nil, true},
@@ -269,8 +269,6 @@ func TestIsBlank(t *testing.T) {
 		{"EmptyStruct", struct{}{}, false},
 		{"StructWithField", struct{ Field string }{"value"}, false},
 		{"StructWithMethod", Person{Name: "Alice", Age: 30}, false},
-		{"EmptyValidationError", []types.ValidationError{}, true},
-		{"NonEmptyValidationError", []types.ValidationError{{Type: "something"}}, false},
 	}
 
 	for _, tc := range testCases {
@@ -281,7 +279,7 @@ func TestIsBlank(t *testing.T) {
 }
 
 func TestExtractMessageID(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		name       string
 		event      map[string]any
 		expectedID string
@@ -309,20 +307,102 @@ func TestExtractMessageID(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
 			event := &types.TransformerEvent{
-				Message: tt.event,
+				Message: tc.event,
 			}
-			require.Equal(t, tt.expectedID, ExtractMessageID(event, func() string {
+			require.Equal(t, tc.expectedID, ExtractMessageID(event, func() string {
 				return "custom-message-id"
 			}))
 		})
 	}
 }
 
+func TestIsJSONCompatibleStructure(t *testing.T) {
+	type testStruct struct {
+		Foo string
+		Bar int
+	}
+
+	testCases := []struct {
+		input    any
+		expected bool
+	}{
+		{nil, false},
+		{true, false},
+		{123, false},
+		{"hello", false},
+		{[]any{"a", 1}, false},
+		{map[string]any{"k": "v"}, false},
+		{testStruct{}, true},
+		{&testStruct{}, true},
+		{[]any{}, false},
+		{[]any{1, 2, 3}, false},
+		{[]testStruct{{}, {}}, true},
+		{[][]testStruct{{{}, {}}, {{}, {}}}, true},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("IsJSONCompatibleStructure(%d)", i+1), func(t *testing.T) {
+			require.Equal(t, tc.expected, IsJSONCompatibleStructure(tc.input))
+		})
+	}
+}
+
+func TestToJSONCompatible(t *testing.T) {
+	type testStruct struct {
+		Foo string `json:"foo"`
+		Bar int    `json:"bar"`
+	}
+
+	testCases := []struct {
+		input    any
+		expected any
+	}{
+		{
+			input: testStruct{
+				Foo: "baz",
+				Bar: 42,
+			},
+			expected: map[string]any{
+				"foo": "baz",
+				"bar": float64(42),
+			},
+		},
+		{
+			input: &testStruct{
+				Foo: "ptr",
+				Bar: 99,
+			},
+			expected: map[string]any{
+				"foo": "ptr",
+				"bar": float64(99),
+			},
+		},
+		{
+			input: []testStruct{
+				{Foo: "foo"},
+				{Bar: 42},
+			},
+			expected: []any{
+				map[string]any{"foo": "foo", "bar": float64(0)},
+				map[string]any{"foo": "", "bar": float64(42)},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("ToJSONCompatible(%d)", i+1), func(t *testing.T) {
+			actual, err := ToJSONCompatible(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
 func TestExtractReceivedAt(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		name         string
 		event        *types.TransformerEvent
 		expectedTime string
@@ -389,9 +469,9 @@ func TestExtractReceivedAt(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expectedTime, ExtractReceivedAt(tt.event, func() time.Time {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedTime, ExtractReceivedAt(tc.event, func() time.Time {
 				return time.Date(2023, time.October, 20, 12, 34, 56, 789000000, time.UTC)
 			}))
 		})
@@ -454,7 +534,7 @@ func TestMarshalJSON(t *testing.T) {
 }
 
 func TestUTF16RuneCountInString(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		name     string
 		input    string
 		expected int
@@ -491,9 +571,9 @@ func TestUTF16RuneCountInString(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, UTF16RuneCountInString(tt.input))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, UTF16RuneCountInString(tc.input))
 		})
 	}
 }

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils/utils_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/internal/utils/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-server/processor/types"
@@ -331,16 +332,26 @@ func TestIsJSONCompatibleStructure(t *testing.T) {
 	}{
 		{nil, false},
 		{true, false},
+		{lo.ToPtr(true), true},
 		{123, false},
+		{lo.ToPtr(123), true},
 		{"hello", false},
+		{lo.ToPtr("hello"), true},
 		{[]any{"a", 1}, false},
+		{lo.ToPtr([]any{"a", 1}), true},
 		{map[string]any{"k": "v"}, false},
+		{lo.ToPtr(map[string]any{"k": "v"}), true},
 		{testStruct{}, true},
-		{&testStruct{}, true},
+		{lo.ToPtr(testStruct{}), true},
 		{[]any{}, false},
+		{lo.ToPtr([]any{}), true},
 		{[]any{1, 2, 3}, false},
+		{lo.ToPtr([]any{1, 2, 3}), true},
 		{[]testStruct{{}, {}}, true},
+		{[]*testStruct{lo.ToPtr(testStruct{}), lo.ToPtr(testStruct{})}, true},
 		{[][]testStruct{{{}, {}}, {{}, {}}}, true},
+		{[][]*testStruct{{lo.ToPtr(testStruct{}), lo.ToPtr(testStruct{})}, {lo.ToPtr(testStruct{}), lo.ToPtr(testStruct{})}}, true},
+		{[]*[]testStruct{lo.ToPtr([]testStruct{{}, {}}), lo.ToPtr([]testStruct{{}, {}})}, true},
 	}
 
 	for i, tc := range testCases {

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/testhelper/validate.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/testhelper/validate.go
@@ -15,7 +15,7 @@ import (
 func ValidateExpectedEvents(t testing.TB, expectedResponse, embeddedResponse, legacyResponse types.Response) {
 	t.Helper()
 	expectedResponse, embeddedResponse, legacyResponse = deepCopyResponse(t, expectedResponse), deepCopyResponse(t, embeddedResponse), deepCopyResponse(t, legacyResponse)
-	checkForMarshalledFieldsAndRemove(t, expectedResponse.Events, embeddedResponse.Events, legacyResponse.Events)
+	checkForMarshalledFieldsAndRemove(t, expectedResponse.Events, embeddedResponse.Events, legacyResponse.Events, []string{"data.rudder_event"}...)
 	cmpEvents(t, expectedResponse.Events, embeddedResponse.Events)
 	cmpFailedEvents(t, expectedResponse.FailedEvents, embeddedResponse.FailedEvents)
 	cmpEvents(t, expectedResponse.Events, legacyResponse.Events)
@@ -41,10 +41,8 @@ func cmpEvents(t testing.TB, expected, actual []types.TransformerResponse) {
 	}
 }
 
-func checkForMarshalledFieldsAndRemove(t testing.TB, expected, embedded, legacy []types.TransformerResponse) {
+func checkForMarshalledFieldsAndRemove(t testing.TB, expected, embedded, legacy []types.TransformerResponse, fields ...string) {
 	t.Helper()
-
-	fields := []string{"data.rudder_event"}
 
 	for i := range expected {
 		for _, field := range fields {

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/testhelper/validate.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/testhelper/validate.go
@@ -1,118 +1,109 @@
 package testhelper
 
 import (
-	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
-	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
-	"github.com/rudderlabs/rudder-server/processor/internal/transformer/destination_transformer"
-	"github.com/rudderlabs/rudder-server/processor/internal/transformer/destination_transformer/embedded/warehouse"
+
 	"github.com/rudderlabs/rudder-server/processor/types"
+	"github.com/rudderlabs/rudder-server/utils/misc"
 )
 
-type EventContext struct {
-	Payload     []byte
-	Metadata    types.Metadata
-	Destination backendconfig.DestinationT
+func ValidateExpectedEvents(t testing.TB, expectedResponse, embeddedResponse, legacyResponse types.Response) {
+	t.Helper()
+	expectedResponse, embeddedResponse, legacyResponse = deepCopyResponse(t, expectedResponse), deepCopyResponse(t, embeddedResponse), deepCopyResponse(t, legacyResponse)
+	checkForMarshalledFieldsAndRemove(t, expectedResponse.Events, embeddedResponse.Events, legacyResponse.Events)
+	cmpEvents(t, expectedResponse.Events, embeddedResponse.Events)
+	cmpFailedEvents(t, expectedResponse.FailedEvents, embeddedResponse.FailedEvents)
+	cmpEvents(t, expectedResponse.Events, legacyResponse.Events)
+	cmpFailedEvents(t, expectedResponse.FailedEvents, legacyResponse.FailedEvents)
 }
 
-func ValidateEvents(t *testing.T, eventContexts []EventContext, pTransformer *destination_transformer.Client, dTransformer *warehouse.Transformer, expectedResponse types.Response) {
+func ValidateEvents(t *testing.T, embeddedResponse, legacyResponse types.Response) {
 	t.Helper()
-
-	events := prepareEvents(t, eventContexts)
-
-	ctx := context.Background()
-
-	legacyResponse := pTransformer.Transform(ctx, events)
-	embeddedResponse := dTransformer.Transform(ctx, events)
-
-	validateResponseLengths(t, expectedResponse, legacyResponse, embeddedResponse)
-	validateRudderEventIfExists(t, expectedResponse, legacyResponse, embeddedResponse)
-	validateEventEquality(t, expectedResponse, legacyResponse, embeddedResponse)
-	validateFailedEventEquality(t, legacyResponse, embeddedResponse)
+	embeddedResponse, legacyResponse = deepCopyResponse(t, embeddedResponse), deepCopyResponse(t, legacyResponse)
+	cmpEvents(t, embeddedResponse.Events, legacyResponse.Events)
+	cmpFailedEvents(t, embeddedResponse.FailedEvents, legacyResponse.FailedEvents)
 }
 
-func prepareEvents(t *testing.T, eventContexts []EventContext) []types.TransformerEvent {
+func cmpEvents(t testing.TB, expected, actual []types.TransformerResponse) {
 	t.Helper()
-
-	events := make([]types.TransformerEvent, 0, len(eventContexts))
-	for _, eventContext := range eventContexts {
-		var singularEvent types.SingularEventT
-		err := jsonrs.Unmarshal(eventContext.Payload, &singularEvent)
-		require.NoError(t, err)
-
-		events = append(events, types.TransformerEvent{
-			Message:     singularEvent,
-			Metadata:    eventContext.Metadata,
-			Destination: eventContext.Destination,
-		})
+	require.Equal(t, len(expected), len(actual))
+	for i := range expected {
+		require.EqualValues(t, expected[i].Output, actual[i].Output)
+		require.EqualValues(t, expected[i].Metadata, actual[i].Metadata)
+		require.EqualValues(t, expected[i].StatusCode, actual[i].StatusCode)
+		require.EqualValues(t, expected[i].Error, actual[i].Error)
+		require.EqualValues(t, expected[i].ValidationErrors, actual[i].ValidationErrors)
 	}
-	return events
 }
 
-func validateResponseLengths(t *testing.T, expectedResponse, legacyResponse, embeddedResponse types.Response) {
+func checkForMarshalledFieldsAndRemove(t testing.TB, expected, embedded, legacy []types.TransformerResponse) {
 	t.Helper()
 
-	require.Equal(t, len(expectedResponse.Events), len(legacyResponse.Events))
-	require.Equal(t, len(expectedResponse.Events), len(embeddedResponse.Events))
-	require.Equal(t, len(expectedResponse.FailedEvents), len(legacyResponse.FailedEvents))
-	require.Equal(t, len(expectedResponse.FailedEvents), len(embeddedResponse.FailedEvents))
-}
+	fields := []string{"data.rudder_event"}
 
-func validateRudderEventIfExists(t *testing.T, expectedResponse, legacyResponse, embeddedResponse types.Response) {
-	t.Helper()
-
-	for i := range legacyResponse.Events {
-		data, ok := expectedResponse.Events[i].Output["data"].(map[string]interface{})
-		if !ok {
-			continue // No data to validate
+	for i := range expected {
+		for _, field := range fields {
+			keys := strings.Split(field, ".")
+			fieldMap := misc.MapLookup(expected[i].Output, keys...)
+			if fieldMap == nil {
+				continue
+			}
+			embeddedMap := misc.MapLookup(embedded[i].Output, keys...)
+			require.NotNil(t, embeddedMap)
+			require.JSONEq(t, fieldMap.(string), embeddedMap.(string))
+			legacyMap := misc.MapLookup(legacy[i].Output, keys...)
+			require.NotNil(t, legacyMap)
+			require.JSONEq(t, fieldMap.(string), legacyMap.(string))
 		}
-
-		rudderEvent, ok := data["rudder_event"].(string)
-		if !ok {
-			continue // No rudder_event key, skip validation
+	}
+	for i := range embedded {
+		for _, field := range fields {
+			lastKey := field[strings.LastIndex(field, ".")+1:]
+			removeLastKey := field[:strings.LastIndex(field, ".")]
+			keys := strings.Split(removeLastKey, ".")
+			fieldMap := misc.MapLookup(expected[i].Output, keys...)
+			if fieldMap == nil {
+				continue
+			}
+			embeddedMap := misc.MapLookup(embedded[i].Output, keys...)
+			require.NotNil(t, embeddedMap)
+			legacyMap := misc.MapLookup(legacy[i].Output, keys...)
+			require.NotNil(t, legacyMap)
+			delete(fieldMap.(map[string]any), lastKey)
+			delete(embeddedMap.(map[string]any), lastKey)
+			delete(legacyMap.(map[string]any), lastKey)
 		}
-
-		pEventData, ok := legacyResponse.Events[i].Output["data"].(map[string]interface{})
-		require.True(t, ok, "legacyResponse data must be a map")
-		pRudderEvent, ok := pEventData["rudder_event"].(string)
-		require.True(t, ok, "legacyResponse rudder_event must be a string")
-		require.JSONEq(t, rudderEvent, pRudderEvent)
-
-		wEventData, ok := embeddedResponse.Events[i].Output["data"].(map[string]interface{})
-		require.True(t, ok, "embeddedResponse data must be a map")
-		wRudderEvent, ok := wEventData["rudder_event"].(string)
-		require.True(t, ok, "embeddedResponse rudder_event must be a string")
-		require.JSONEq(t, rudderEvent, wRudderEvent)
-
-		require.JSONEq(t, pRudderEvent, wRudderEvent)
-
-		delete(pEventData, "rudder_event")
-		delete(wEventData, "rudder_event")
-		delete(data, "rudder_event")
 	}
 }
 
-func validateEventEquality(t *testing.T, expectedResponse, legacyResponse, embeddedResponse types.Response) {
+func cmpFailedEvents(t testing.TB, expected, actual []types.TransformerResponse) {
 	t.Helper()
 
-	for i := range legacyResponse.Events {
-		require.EqualValues(t, expectedResponse.Events[i], legacyResponse.Events[i])
-		require.EqualValues(t, expectedResponse.Events[i], embeddedResponse.Events[i])
+	require.Equal(t, len(expected), len(actual))
+	for i := range expected {
+		require.EqualValues(t, expected[i].Output, actual[i].Output)
+		require.EqualValues(t, expected[i].Metadata, actual[i].Metadata)
+		require.EqualValues(t, expected[i].StatusCode, actual[i].StatusCode)
+		require.EqualValues(t, expected[i].ValidationErrors, actual[i].ValidationErrors)
+
+		require.NotNil(t, expected[i].Error)
+		require.NotNil(t, actual[i].Error)
 	}
 }
 
-func validateFailedEventEquality(t *testing.T, legacyResponse, embeddedResponse types.Response) {
+func deepCopyResponse(t testing.TB, res types.Response) types.Response {
 	t.Helper()
 
-	for i := range legacyResponse.FailedEvents {
-		require.NotEmpty(t, legacyResponse.FailedEvents[i].Error)
-		require.NotEmpty(t, embeddedResponse.FailedEvents[i].Error)
+	resBytes, err := jsonrs.Marshal(res)
+	require.NoError(t, err, "failed to marshal response")
 
-		require.NotZero(t, legacyResponse.FailedEvents[i].StatusCode)
-		require.NotZero(t, embeddedResponse.FailedEvents[i].StatusCode)
-	}
+	var out types.Response
+	require.NoError(t, jsonrs.Unmarshal(resBytes, &out), "failed to unmarshal response")
+	require.NotNil(t, out)
+	return out
 }

--- a/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader_test.go
+++ b/processor/internal/transformer/destination_transformer/embedded/warehouse/uploader_test.go
@@ -45,7 +45,7 @@ func TestTransformer_CompareResponsesAndUpload(t *testing.T) {
 	eventsByMessageID := make(map[string]types.SingularEventWithReceivedAt, 50)
 	for index := 0; index < 50; index++ {
 		eventsByMessageID[strconv.Itoa(index)] = types.SingularEventWithReceivedAt{
-			SingularEvent: map[string]interface{}{
+			SingularEvent: map[string]any{
 				"event": "track" + strconv.Itoa(index),
 			},
 		}


### PR DESCRIPTION
# Description

- We rely on being `SingularEvent` only to contain `map[string]any`, but some context properties are being directly added to the SingularEvent as the struct type like these:
  - [Bot Details](https://github.com/rudderlabs/rudder-server/blob/master/internal/enricher/bot.go#L49-L54).
  - [Geo enrichment](https://github.com/rudderlabs/rudder-server/blob/master/internal/enricher/geolocation.go#L134-L135)
  - [Tracking plan.](https://github.com/rudderlabs/rudder-server/blob/master/processor/trackingplan.go#L32-L50)
- In case of Bot Details, we don't have access to the struct, so we can't infer the type and handle it. Adding support for any custom struct which checks for `reflect.Struct`, `reflect.Ptr`, `reflect.Slice`, `reflect.Array` using reflection.

## Linear Ticket

- Resolves WAR-821

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
