### PR TITLE
fix: bigquery load errors population

### DIFF
--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -558,7 +558,7 @@ func (bq *BigQuery) loadTableByAppend(
 		return nil, nil, fmt.Errorf("waiting for append job: %w", err)
 	}
 	if err := status.Err(); err != nil {
-		return nil, nil, fmt.Errorf("status for append job: %w, errors: %s", status.Err(), jobStatusError(status))
+		return nil, nil, fmt.Errorf("status for append job: %w", jobStatusError(status))
 	}
 
 	log.Debugn("job statistics")
@@ -579,13 +579,13 @@ func (bq *BigQuery) loadTableByAppend(
 	return tableStats, response, nil
 }
 
-func jobStatusError(status *bigquery.JobStatus) string {
-	return strings.Join(lo.Map(status.Errors, func(item *bigquery.Error, index int) string {
+func jobStatusError(status *bigquery.JobStatus) error {
+	return fmt.Errorf("job status with errors: %v", lo.Map(status.Errors, func(item *bigquery.Error, index int) string {
 		if item == nil {
 			return ""
 		}
 		return item.Error()
-	}), ",")
+	}))
 }
 
 // jobStatistics returns statistics for a job
@@ -758,7 +758,7 @@ func (bq *BigQuery) createAndLoadStagingUsersTable(ctx context.Context, stagingT
 		return fmt.Errorf("waiting for staging table load job: %w", err)
 	}
 	if err := status.Err(); err != nil {
-		return fmt.Errorf("status for staging table load job: %w, errors: %s", status.Err(), jobStatusError(status))
+		return fmt.Errorf("status for staging table load job: %w", jobStatusError(status))
 	}
 	return nil
 }
@@ -1249,7 +1249,7 @@ func (bq *BigQuery) TestLoadTable(ctx context.Context, location, tableName strin
 		return fmt.Errorf("waiting for test data load job: %w", err)
 	}
 	if status.Err() != nil {
-		return fmt.Errorf("status for test data load job: %w, errors: %s", status.Err(), jobStatusError(status))
+		return fmt.Errorf("status for test data load job: %w", jobStatusError(status))
 	}
 	return nil
 }

--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 	"github.com/rudderlabs/rudder-server/warehouse/client"
@@ -557,7 +558,7 @@ func (bq *BigQuery) loadTableByAppend(
 		return nil, nil, fmt.Errorf("waiting for append job: %w", err)
 	}
 	if err := status.Err(); err != nil {
-		return nil, nil, fmt.Errorf("status for append job: %w", err)
+		return nil, nil, fmt.Errorf("status for append job: %w, errors: %s", status.Err(), jobStatusError(status))
 	}
 
 	log.Debugn("job statistics")
@@ -576,6 +577,15 @@ func (bq *BigQuery) loadTableByAppend(
 		partitionDate: partitionDate,
 	}
 	return tableStats, response, nil
+}
+
+func jobStatusError(status *bigquery.JobStatus) string {
+	return strings.Join(lo.Map(status.Errors, func(item *bigquery.Error, index int) string {
+		if item == nil {
+			return ""
+		}
+		return item.Error()
+	}), ",")
 }
 
 // jobStatistics returns statistics for a job
@@ -748,7 +758,7 @@ func (bq *BigQuery) createAndLoadStagingUsersTable(ctx context.Context, stagingT
 		return fmt.Errorf("waiting for staging table load job: %w", err)
 	}
 	if err := status.Err(); err != nil {
-		return fmt.Errorf("status for staging table load job: %w", err)
+		return fmt.Errorf("status for staging table load job: %w, errors: %s", status.Err(), jobStatusError(status))
 	}
 	return nil
 }
@@ -1239,7 +1249,7 @@ func (bq *BigQuery) TestLoadTable(ctx context.Context, location, tableName strin
 		return fmt.Errorf("waiting for test data load job: %w", err)
 	}
 	if status.Err() != nil {
-		return fmt.Errorf("status for test data load job: %w", status.Err())
+		return fmt.Errorf("status for test data load job: %w, errors: %s", status.Err(), jobStatusError(status))
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

- Passing more information while bigquery load error as the current one does not have sufficient information (J`SON table encountered too many errors, giving up. Rows: 1; errors: 1. Please look into the errors[] collection for more details.`)

## Linear Ticket

- Resolves WAR-824

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
