### PR TITLE
feat: implement leaky uploader for invalid payloads

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -16,6 +16,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ory/dockertest/v3"
+
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/minio"
+
 	gwtypes "github.com/rudderlabs/rudder-server/gateway/types"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
@@ -2746,4 +2750,129 @@ func waitForBackendConfigInit(gw *Handle) {
 		},
 		2*time.Second,
 	).Should(BeTrue())
+}
+
+func TestLeakyUploader(t *testing.T) {
+	// Setup Minio test container
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = time.Minute
+
+	t.Run("invalid JSON payload should be uploaded to Minio", func(t *testing.T) {
+		t.Parallel()
+		minioContainer, err := minio.Setup(pool, t)
+		require.NoError(t, err)
+
+		// create a test gateway with leaky uploader enabled
+		gw, cleanupFn := createTestGatewayWithLeakyUploader(t, minioContainer.Endpoint, minioContainer.AccessKeyID, minioContainer.AccessKeySecret)
+		t.Cleanup(cleanupFn)
+
+		// Prepare invalid JSON payload
+		invalidPayload := []byte(`{"invalid": "json`)
+
+		// Call internal batch handler
+		jobs, err := gw.extractJobsFromInternalBatchPayload("batch", invalidPayload)
+
+		// Verify error response
+		require.Error(t, err)
+		require.Equal(t, response.InvalidJSON, err.Error())
+		require.Nil(t, jobs)
+
+		// verify file was uploaded to Minio
+		require.Eventually(t, func() bool {
+			contents, err := minioContainer.Contents(context.Background(), "gw-failed-events")
+			return err == nil && len(contents) != 0
+		}, 10*time.Second, time.Second, "Minio bucket not updated within timeout")
+	})
+
+	t.Run("valid JSON payload should be processed normally", func(t *testing.T) {
+		t.Parallel()
+		// Prepare valid payload
+		validPayload := []byte(`[
+			{
+				"properties": {
+					"requestType": "track",
+					"routingKey": "test-key",
+					"workspaceId": "workspace1",
+					"sourceId": "source-id-1",
+					"receivedAt": "2023-01-01T00:00:00Z",
+					"requestIP": "127.0.0.1"
+				},
+				"payload": "{\"type\":\"track\",\"event\":\"TestEvent\"}"
+			}
+		]`)
+
+		minioContainer, err := minio.Setup(pool, t)
+		require.NoError(t, err)
+
+		// create test gateway with leaky uploader enabled
+		gw, cleanupFn := createTestGatewayWithLeakyUploader(t, minioContainer.Endpoint, minioContainer.AccessKeyID, minioContainer.AccessKeySecret)
+		t.Cleanup(cleanupFn)
+
+		// Call internal batch handler
+		jobs, err := gw.extractJobsFromInternalBatchPayload("batch", validPayload)
+
+		// Verify successful processing
+		require.NoError(t, err)
+		require.NotNil(t, jobs)
+		require.Len(t, jobs, 1)
+
+		// Verify no files uploaded to Minio
+		require.Never(t, func() bool {
+			contents, err := minioContainer.Contents(context.Background(), "gw-failed-events")
+			require.NoError(t, err)
+			return len(contents) != 0
+		}, 5*time.Second, time.Second, "Minio bucket not updated within timeout")
+	})
+}
+
+// Helper function to create test gateway with leaky uploader
+func createTestGatewayWithLeakyUploader(t *testing.T, endpoint, accessKeyID, secretKey string) (gw *Handle, cleanup func()) {
+	mockCtrl := gomock.NewController(t)
+	mockJobsDB := mocksJobsDB.NewMockJobsDB(mockCtrl)
+	mockErrJobsDB := mocksJobsDB.NewMockJobsDB(mockCtrl)
+	mockBackendConfig := mocksBackendConfig.NewMockBackendConfig(mockCtrl)
+	mockApp := mocksApp.NewMockApp(mockCtrl)
+	mockRateLimiter := mockGateway.NewMockThrottler(mockCtrl)
+	mockWebhook := mockGateway.NewMockWebhookRequestHandler(mockCtrl)
+	mockWebhook.EXPECT().Shutdown().AnyTimes()
+	mockBackendConfig.EXPECT().Subscribe(gomock.Any(), backendconfig.TopicProcessConfig).
+		DoAndReturn(func(ctx context.Context, topic backendconfig.Topic) pubsub.DataChannel {
+			ch := make(chan pubsub.DataEvent, 1)
+			ch <- pubsub.DataEvent{Data: map[string]backendconfig.ConfigT{WorkspaceID: sampleBackendConfig}, Topic: string(topic)}
+			// on Subscribe, emulate a backend configuration event
+			go func() {
+				<-ctx.Done()
+				close(ch)
+			}()
+			return ch
+		})
+	mockVersionHandler := func(w http.ResponseWriter, r *http.Request) {}
+	enterpriseFeatures := &app.Features{}
+	mockApp.EXPECT().Features().Return(enterpriseFeatures).AnyTimes()
+	gw = &Handle{}
+	conf := config.New()
+	conf.Set("Gateway.leakyUploader.enabled", true)
+	conf.Set("Gateway.leakyUploader.Storage.Endpoint", endpoint)
+	conf.Set("Gateway.leakyUploader.Storage.AccessKeyId", accessKeyID)
+	conf.Set("Gateway.leakyUploader.Storage.AccessKey", secretKey)
+	conf.Set("Gateway.leakyUploader.Storage.Bucket", "rudder-saas")
+	conf.Set("Gateway.leakyUploader.Timeout", "2s")
+	conf.Set("Gateway.leakyUploader.Storage.DisableSsl", true)
+	conf.Set("Gateway.leakyUploader.Storage.UseGlue", true)
+	conf.Set("Gateway.leakyUploader.Storage.S3ForcePathStyle", true)
+	err := gw.Setup(context.Background(), conf, logger.NewLogger().With("component", "test"), stats.NOP, mockApp, mockBackendConfig, mockJobsDB, mockErrJobsDB, mockRateLimiter, mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		select {
+		case <-gw.backendConfigInitialisedChan:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, time.Second)
+	return gw, func() {
+		_ = gw.Shutdown()
+		mockCtrl.Finish()
+	}
 }

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -143,6 +143,9 @@ type Handle struct {
 	msgValidator messageValidator
 
 	webhookAuthMiddleware *auth.WebhookAuth
+
+	// leakyUploader is an optional function that can be set to handle uploading of invalid payloads
+	leakyUploader func(upload msgToUpload)
 }
 
 // findUserWebRequestWorker finds and returns the worker that works on a particular `userID`.
@@ -821,14 +824,27 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 		isEventBlocked   = gw.memoizedIsEventBlocked()
 		res              []jobWithMetadata
 		stat             = gwstats.SourceStat{ReqType: reqType}
+		err              error
 	)
 
-	err := jsonrs.Unmarshal(body, &messages)
+	defer func() {
+		// Upload the raw payload via leaky uploader if available
+		if gw.leakyUploader != nil && (err != nil || len(messages) == 0) {
+			toUpload := msgToUpload{
+				payload: body,
+			}
+			if err != nil {
+				toUpload.fields = []logger.Field{obskit.Error(err)}
+			}
+			gw.leakyUploader(toUpload)
+		}
+	}()
+
+	err = jsonrs.Unmarshal(body, &messages)
 	if err != nil {
 		stat.RequestFailed(response.InvalidJSON)
 		stat.Report(gw.stats)
-		gw.logger.Errorn("invalid json in request",
-			obskit.Error(err))
+		gw.logger.Errorn("invalid json in request", obskit.Error(err))
 		return nil, errors.New((response.InvalidJSON))
 	}
 	gw.requestSizeStat.Observe(float64(len(body)))
@@ -846,7 +862,13 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 	res = make([]jobWithMetadata, 0, len(messages))
 
 	for _, msg := range messages {
-		var messageID string
+		var (
+			rudderId         uuid.UUID
+			messageID        string
+			marshalledParams []byte
+			payload          []byte
+		)
+
 		stat := gwstats.SourceStat{ReqType: reqType}
 
 		if internalBatchEnrichmentEnabled {
@@ -891,7 +913,7 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 					return nil, errors.New((response.NotRudderEvent))
 				}
 			}
-			rudderId, err := getRudderId(userIDFromReq, anonIDFromReq)
+			rudderId, err = getRudderId(userIDFromReq, anonIDFromReq)
 			if err != nil {
 				stat.RequestFailed((response.NotRudderEvent))
 				stat.Report(gw.stats)
@@ -931,7 +953,8 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 		}
 
 		if internalBatchValidatorEnabled {
-			ok, err := gw.msgValidator.Validate(msg.Payload, &msg.Properties)
+			var ok bool
+			ok, err = gw.msgValidator.Validate(msg.Payload, &msg.Properties)
 			if err != nil || !ok {
 				errMsg := "validations failed"
 				if err != nil {
@@ -1004,7 +1027,7 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 			jobsDBParams.IsEventBlocked = true
 		}
 
-		marshalledParams, err := jsonrs.Marshal(jobsDBParams)
+		marshalledParams, err = jsonrs.Marshal(jobsDBParams)
 		if err != nil {
 			gw.logger.Errorn("[Gateway] Failed to marshal parameters map",
 				logger.NewField("params", jobsDBParams),
@@ -1022,7 +1045,7 @@ func (gw *Handle) extractJobsFromInternalBatchPayload(reqType string, body []byt
 			WriteKey:   writeKey,
 		}
 
-		payload, err := jsonrs.Marshal(eventBatch)
+		payload, err = jsonrs.Marshal(eventBatch)
 		if err != nil {
 			err = fmt.Errorf("marshalling event batch: %w", err)
 			stat.RequestEventsFailed(1, err.Error())


### PR DESCRIPTION
# Description

- Add leaky uploader functionality to handle invalid JSON payloads
- Upload invalid payloads to s3 for debugging and analysis
- Ensure valid payloads are processed normally without being uploaded
- Configure leaky uploader with S3 storage options
- Implement backoff and buffer mechanisms for failed uploads

## Linear Ticket

pipe-2188

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
