### PR TITLE
chore: change refresh time log to info

### DIFF
--- a/router/customdestinationmanager/customdestinationmanager.go
+++ b/router/customdestinationmanager/customdestinationmanager.go
@@ -223,7 +223,7 @@ func (customManager *CustomManagerT) close(destID string) {
 func (customManager *CustomManagerT) refreshClient(destID string) error {
 	startTime := time.Now()
 	defer func() {
-		pkgLogger.Debugn("[CDM]", logger.NewStringField("destType", customManager.destType),
+		pkgLogger.Infon("[CDM]", logger.NewStringField("destType", customManager.destType),
 			logger.NewStringField("destID", destID),
 			logger.NewDurationField("refreshTime", time.Since(startTime)),
 		)


### PR DESCRIPTION
# Description
This pull request makes a small but important change to the logging level in the `refreshClient` method of the `CustomManagerT` struct. The change updates the log level from `Debug` to `Info` to ensure that refresh operations are logged with higher visibility.

* [`router/customdestinationmanager/customdestinationmanager.go`](diffhunk://#diff-1e9610e1dd9e153448cfb4ad28adbe60b0b5d9cd300e998e0cc1bfda227aeedeL226-R226): Changed the logging level from `Debugn` to `Infon` in the `refreshClient` method to increase the visibility of refresh operations.
## Linear Ticket

https://linear.app/rudderstack/issue/INT-3715/investigate-zoopla-error-with-google-sheets-destination-delivery

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
