### PR TITLE
fix: disable column index for parquet writer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ replace (
 	github.com/gocql/gocql => github.com/scylladb/gocql v1.14.4
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.14
 	github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
-	github.com/xitongsys/parquet-go => github.com/rudderlabs/parquet-go v0.0.2
+	github.com/xitongsys/parquet-go => github.com/rudderlabs/parquet-go v0.0.3
 	golang.org/x/image => golang.org/x/image v0.24.0
 	golang.org/x/net => golang.org/x/net v0.34.0
 	golang.org/x/net/html => golang.org/x/net/html v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -1198,8 +1198,8 @@ github.com/rudderlabs/goqu/v10 v10.3.1 h1:rnfX+b4EwBWQ2UQfIGeEW299JBBkK5biEbnf7K
 github.com/rudderlabs/goqu/v10 v10.3.1/go.mod h1:LH2vI5gGHBxEQuESqFyk5ZA2anGINc8o25hbidDWOYw=
 github.com/rudderlabs/keydb v0.1.0-alpha h1:h87QGW9ut6jQExQjtZsp2BxPc0Hix58WELQ5OrzialM=
 github.com/rudderlabs/keydb v0.1.0-alpha/go.mod h1:gnyirkn1FWIQPCvo/E6rFmfDQ2pjVkAYHF3hJvsBpC0=
-github.com/rudderlabs/parquet-go v0.0.2 h1:ZXRdZdimB0PdJtmxeSSxfI0fDQ3kZjwzBxRi6Ut1J8k=
-github.com/rudderlabs/parquet-go v0.0.2/go.mod h1:g6guum7o8uhj/uNhunnt7bw5Vabu/goI5i21/3fnxWQ=
+github.com/rudderlabs/parquet-go v0.0.3 h1:/zgRj929pGKHsthc0kw8stVEcFu1JUcpxDRlhxjSLic=
+github.com/rudderlabs/parquet-go v0.0.3/go.mod h1:WmwBOdvwpXl2aZGRk3NxxgzC/DaWGfax3jrCRhKhtSo=
 github.com/rudderlabs/rudder-go-kit v0.56.2 h1:hY8LtYN+SOW0mALG7e9+Gjt19lqriSkbdP9HRkzLkJQ=
 github.com/rudderlabs/rudder-go-kit v0.56.2/go.mod h1:+lgIL66Mp/CiNogDZO2XoDb0Yy6O/ta7YRvCwFVxdw4=
 github.com/rudderlabs/rudder-observability-kit v0.0.4 h1:h9nLoWqiv/nqGOu1dhuVFAHNRkyodR6R3v36bqmavRs=

--- a/warehouse/encoding/parquetwriter.go
+++ b/warehouse/encoding/parquetwriter.go
@@ -84,7 +84,8 @@ func createParquetWriter(outputFilePath string, schema model.TableSchema, destTy
 		return nil, err
 	}
 
-	w, err := writer.NewCSVWriterFromWriter(pSchema, bufWriter, maxParallelWriters)
+	// Disable column index to avoid the column index being written to the parquet file.
+	w, err := writer.NewCSVWriterFromWriter(pSchema, bufWriter, maxParallelWriters, writer.WithDisableColumnIndex(true))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

* Disable column index for parquet writer.
* More details for the fix in parquet-go [PR](https://github.com/rudderlabs/parquet-go/pull/4)

## Linear Ticket

resolves https://linear.app/rudderstack/issue/WAR-877/parquet-go-corrupted-column-index-bug-fix

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
