### PR TITLE
chore: set wh validations default query timeout to 55 seconds

### DIFF
--- a/warehouse/validations/validations.go
+++ b/warehouse/validations/validations.go
@@ -53,8 +53,8 @@ func Init() {
 	fileManagerFactory = filemanager.New
 	objectStorageTimeout = config.GetDuration("Warehouse.Validations.ObjectStorageTimeout", 15, time.Second)
 
-	// Since we have a cp-router default timeout of 30 seconds, keeping the query timeout to 25 seconds
-	queryTimeout = config.GetDuration("Warehouse.Validations.QueryTimeout", 25, time.Second)
+	// setting default query timeout less than config-backend timeout of 60 seconds
+	queryTimeout = config.GetDuration("Warehouse.Validations.QueryTimeout", 55, time.Second)
 }
 
 // Validate the destination by running all the validation steps


### PR DESCRIPTION
# Description
- set warehouse validations query timeout to 55 seconds ( less than config-backend timeout) 

## Linear Ticket
Part of WAR-885

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
