### PR TITLE
feat: staging files schema snapshot cached repository with different strategies

### DIFF
--- a/warehouse/internal/model/staging_snapshot.go
+++ b/warehouse/internal/model/staging_snapshot.go
@@ -1,0 +1,17 @@
+package model
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type StagingFileSchemaSnapshot struct {
+	ID            uuid.UUID
+	Schema        json.RawMessage
+	SourceID      string
+	DestinationID string
+	WorkspaceID   string
+	CreatedAt     time.Time
+}

--- a/warehouse/internal/repo/staging_snapshot.go
+++ b/warehouse/internal/repo/staging_snapshot.go
@@ -1,0 +1,86 @@
+// Package repo provides repository implementations for warehouse entities.
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/rudderlabs/rudder-server/utils/timeutil"
+	sqlmiddleware "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+const (
+	stagingFileSchemaSnapshotTableName    = whutils.WarehouseStagingFileSchemaSnapshotTable
+	stagingFileSchemaSnapshotTableColumns = `id, schema, source_id, destination_id, workspace_id, created_at`
+)
+
+var ErrNoSchemaSnapshot = errors.New("no schema snapshot found")
+
+type StagingFileSchemaSnapshots repo
+
+// NewStagingFileSchemaSnapshots creates a new StagingFileSchemaSnapshots using the given DB connection.
+func NewStagingFileSchemaSnapshots(db *sqlmiddleware.DB, opts ...Opt) *StagingFileSchemaSnapshots {
+	r := &StagingFileSchemaSnapshots{
+		db:  db,
+		now: timeutil.Now,
+	}
+	for _, opt := range opts {
+		opt((*repo)(r))
+	}
+	return r
+}
+
+// Insert inserts a new schema snapshot into the database and returns its auto-generated ID.
+func (r *StagingFileSchemaSnapshots) Insert(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (uuid.UUID, error) {
+	query := `
+		INSERT INTO ` + stagingFileSchemaSnapshotTableName + ` (
+			id, schema, source_id, destination_id, workspace_id, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id;
+	`
+	id := uuid.New()
+	now := r.now()
+	_, err := r.db.ExecContext(ctx, query,
+		id,
+		schemaBytes,
+		sourceID,
+		destinationID,
+		workspaceID,
+		now,
+	)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("inserting schema snapshot: %w", err)
+	}
+	return id, nil
+}
+
+// GetLatest returns the most recent schema snapshot for the given source and destination.
+// Returns ErrNoSchemaSnapshot if not found.
+func (r *StagingFileSchemaSnapshots) GetLatest(ctx context.Context, sourceID, destinationID string) (*model.StagingFileSchemaSnapshot, error) {
+	query := `
+		SELECT ` + stagingFileSchemaSnapshotTableColumns + `
+		FROM ` + stagingFileSchemaSnapshotTableName + `
+		WHERE source_id = $1 AND destination_id = $2
+		ORDER BY created_at DESC
+		LIMIT 1;
+	`
+	row := r.db.QueryRowContext(ctx, query, sourceID, destinationID)
+	var snapshot model.StagingFileSchemaSnapshot
+	var schemaRaw []byte
+	if err := row.Scan(&snapshot.ID, &schemaRaw, &snapshot.SourceID, &snapshot.DestinationID, &snapshot.WorkspaceID, &snapshot.CreatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNoSchemaSnapshot
+		}
+		return nil, fmt.Errorf("scanning latest schema snapshot by source/dest: %w", err)
+	}
+	snapshot.Schema = schemaRaw
+	snapshot.CreatedAt = snapshot.CreatedAt.UTC()
+	return &snapshot, nil
+}

--- a/warehouse/internal/repo/staging_snapshot_test.go
+++ b/warehouse/internal/repo/staging_snapshot_test.go
@@ -1,0 +1,162 @@
+package repo_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/repo"
+)
+
+func TestStagingFileSchemaSnapshots(t *testing.T) {
+	schema := json.RawMessage(`{"foo":"bar"}`)
+
+	ctx := context.Background()
+	now := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("Insert and GetLatest success", func(t *testing.T) {
+		db := repo.NewStagingFileSchemaSnapshots(setupDB(t), repo.WithNow(func() time.Time {
+			return now
+		}))
+
+		id, err := db.Insert(ctx, "sourceID", "destinationID", "workspaceID", schema)
+		require.NoError(t, err)
+		require.NotEqual(t, uuid.Nil, id)
+
+		snap, err := db.GetLatest(ctx, "sourceID", "destinationID")
+		require.NoError(t, err)
+		expectedSnapshot := &model.StagingFileSchemaSnapshot{
+			ID:            id,
+			SourceID:      "sourceID",
+			DestinationID: "destinationID",
+			WorkspaceID:   "workspaceID",
+			Schema:        schema,
+			CreatedAt:     now,
+		}
+		require.Equal(t, expectedSnapshot, snap)
+	})
+
+	t.Run("GetLatest returns ErrNoSchemaSnapshot for missing entry", func(t *testing.T) {
+		db := repo.NewStagingFileSchemaSnapshots(setupDB(t), repo.WithNow(func() time.Time {
+			return now
+		}))
+
+		_, err := db.GetLatest(ctx, "notfound", "notfound")
+		require.ErrorIs(t, err, repo.ErrNoSchemaSnapshot)
+	})
+
+	t.Run("Multiple inserts, GetLatest returns most recent", func(t *testing.T) {
+		db := repo.NewStagingFileSchemaSnapshots(setupDB(t), repo.WithNow(func() time.Time {
+			return now
+		}))
+
+		schema1 := json.RawMessage(`{"version":1}`)
+		schema2 := json.RawMessage(`{"version":2}`)
+
+		id1, err := db.Insert(ctx, "multiSourceID", "multiDestinationID", "multiWorkspaceID", schema1)
+		require.NoError(t, err)
+		require.NotEqual(t, uuid.Nil, id1)
+
+		db = repo.NewStagingFileSchemaSnapshots(setupDB(t), repo.WithNow(func() time.Time {
+			return now.Add(1 * time.Second)
+		}))
+
+		id2, err := db.Insert(ctx, "multiSourceID", "multiDestinationID", "multiWorkspaceID", schema2)
+		require.NoError(t, err)
+		require.NotEqual(t, uuid.Nil, id2)
+
+		snap, err := db.GetLatest(ctx, "multiSourceID", "multiDestinationID")
+		require.NoError(t, err)
+		expectedSnapshot := &model.StagingFileSchemaSnapshot{
+			ID:            id2,
+			SourceID:      "multiSourceID",
+			DestinationID: "multiDestinationID",
+			WorkspaceID:   "multiWorkspaceID",
+			Schema:        schema2,
+			CreatedAt:     now.Add(1 * time.Second).UTC(),
+		}
+		require.Equal(t, expectedSnapshot, snap)
+	})
+
+	t.Run("Insert/GetLatest with different keys", func(t *testing.T) {
+		db := repo.NewStagingFileSchemaSnapshots(setupDB(t), repo.WithNow(func() time.Time {
+			return now
+		}))
+
+		idA, err := db.Insert(ctx, "sourceID1", "destinationID1", "workspaceID1", json.RawMessage(`{"version":1}`))
+		require.NoError(t, err)
+		require.NotEqual(t, uuid.Nil, idA)
+
+		idB, err := db.Insert(ctx, "sourceID2", "destinationID2", "workspaceID2", json.RawMessage(`{"version":2}`))
+		require.NoError(t, err)
+		require.NotEqual(t, uuid.Nil, idB)
+
+		snapA, err := db.GetLatest(ctx, "sourceID1", "destinationID1")
+		require.NoError(t, err)
+		expectedSnapshotA := &model.StagingFileSchemaSnapshot{
+			ID:            idA,
+			SourceID:      "sourceID1",
+			DestinationID: "destinationID1",
+			WorkspaceID:   "workspaceID1",
+			Schema:        json.RawMessage(`{"version":1}`),
+			CreatedAt:     now.UTC(),
+		}
+		require.Equal(t, expectedSnapshotA, snapA)
+
+		snapB, err := db.GetLatest(ctx, "sourceID2", "destinationID2")
+		require.NoError(t, err)
+		expectedSnapshotB := &model.StagingFileSchemaSnapshot{
+			ID:            idB,
+			SourceID:      "sourceID2",
+			DestinationID: "destinationID2",
+			WorkspaceID:   "workspaceID2",
+			Schema:        json.RawMessage(`{"version":2}`),
+			CreatedAt:     now,
+		}
+		require.Equal(t, expectedSnapshotB, snapB)
+	})
+
+	t.Run("Insert with empty schema", func(t *testing.T) {
+		db := repo.NewStagingFileSchemaSnapshots(setupDB(t), repo.WithNow(func() time.Time {
+			return now
+		}))
+
+		emptySchema := json.RawMessage([]byte{})
+		id, err := db.Insert(ctx, "emptySourceID", "emptyDestinationID", "emptyWorkspaceID", emptySchema)
+		require.NoError(t, err)
+		require.NotEqual(t, uuid.Nil, id)
+
+		snap, err := db.GetLatest(ctx, "emptySourceID", "emptyDestinationID")
+		require.NoError(t, err)
+		expectedSnapshot := &model.StagingFileSchemaSnapshot{
+			ID:            id,
+			SourceID:      "emptySourceID",
+			DestinationID: "emptyDestinationID",
+			WorkspaceID:   "emptyWorkspaceID",
+			Schema:        emptySchema,
+			CreatedAt:     now,
+		}
+		require.Equal(t, expectedSnapshot, snap)
+	})
+
+	t.Run("Context cancellation", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		db := repo.NewStagingFileSchemaSnapshots(setupDB(t), repo.WithNow(func() time.Time {
+			return now
+		}))
+
+		id, err := db.Insert(cancelCtx, "cancel", "cancel", "cancel", schema)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, uuid.Nil, id)
+
+		_, err = db.GetLatest(cancelCtx, "cancel", "cancel")
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}

--- a/warehouse/internal/snapshots/staging_schema.go
+++ b/warehouse/internal/snapshots/staging_schema.go
@@ -1,0 +1,116 @@
+// Package snapshots provides a memory-cached, pluggable-expiry schema snapshot lookup for staging files.
+package snapshots
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/rudderlabs/rudder-go-kit/cachettl"
+	"github.com/rudderlabs/rudder-go-kit/config"
+
+	"github.com/rudderlabs/rudder-server/utils/timeutil"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/repo"
+)
+
+// StagingFileSchemaDBRepo defines the interface for DB operations needed by the cache.
+type StagingFileSchemaDBRepo interface {
+	Insert(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (uuid.UUID, error)
+	GetLatest(ctx context.Context, sourceID, destinationID string) (*model.StagingFileSchemaSnapshot, error)
+}
+
+// StagingFileSchema provides a memory-cached, pluggable-expiry schema snapshot lookup.
+type StagingFileSchema struct {
+	dbRepo               StagingFileSchemaDBRepo
+	cache                *cachettl.Cache[string, *model.StagingFileSchemaSnapshot] // cache for the latest schema snapshot to avoid DB lookups
+	cacheRefreshInterval config.ValueLoader[time.Duration]                         // interval at which to refresh the cache
+	cacheRefreshJitter   func() time.Duration                                      // jitter to add to the cache refresh interval
+	now                  func() time.Time                                          // function to get the current time
+	expiryStrategy       StagingFileSchemaExpiryStrategy                           // strategy to determine if the cache is expired
+}
+
+// NewStagingFileSchema creates a new cache with the given DB repo and expiration strategy.
+func NewStagingFileSchema(conf *config.Config, dbRepo StagingFileSchemaDBRepo, expiryStrategy StagingFileSchemaExpiryStrategy) *StagingFileSchema {
+	cache := cachettl.New[string, *model.StagingFileSchemaSnapshot](cachettl.WithNoRefreshTTL)
+	cacheRefreshInterval := conf.GetReloadableDurationVar(60, time.Minute, "Warehouse.stagingSnapshotCacheRefreshInterval")
+	cacheRefreshJitter := func() time.Duration {
+		return time.Duration(rand.Int63n(10)) * time.Minute
+	}
+	return &StagingFileSchema{
+		dbRepo:               dbRepo,
+		cache:                cache,
+		now:                  timeutil.Now,
+		cacheRefreshInterval: cacheRefreshInterval,
+		cacheRefreshJitter:   cacheRefreshJitter,
+		expiryStrategy:       expiryStrategy,
+	}
+}
+
+// GetOrCreate returns the latest schema snapshot for the given IDs, using cache and DB as needed. If not found or expired, inserts a new snapshot.
+func (c *StagingFileSchema) GetOrCreate(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (*model.StagingFileSchemaSnapshot, error) {
+	key := cacheKey(sourceID, destinationID)
+
+	// Check cache
+	cachedSnapshot := c.cache.Get(key)
+	if cachedSnapshot != nil {
+		// Not expired: return the snapshot
+		if !c.expiryStrategy.IsExpired(cachedSnapshot) {
+			return cachedSnapshot, nil
+		}
+
+		// Expired: insert new and fetch
+		return c.insertAndCache(ctx, sourceID, destinationID, workspaceID, schemaBytes)
+	}
+
+	// Cache miss: fetch from DB
+	snap, err := c.dbRepo.GetLatest(ctx, sourceID, destinationID)
+	if err == nil {
+		if !c.expiryStrategy.IsExpired(snap) {
+			c.cache.Put(key, snap, c.cacheRefreshTTL())
+			return snap, nil
+		}
+		// Expired in DB: insert new and fetch
+		return c.insertAndCache(ctx, sourceID, destinationID, workspaceID, schemaBytes)
+	}
+
+	// Only insert if the error is ErrNoSchemaSnapshot (no entry)
+	if errors.Is(err, repo.ErrNoSchemaSnapshot) {
+		return c.insertAndCache(ctx, sourceID, destinationID, workspaceID, schemaBytes)
+	}
+
+	return nil, err
+}
+
+// insertAndCache inserts a new snapshot into the DB, and caches the result.
+func (c *StagingFileSchema) insertAndCache(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (*model.StagingFileSchemaSnapshot, error) {
+	snapshotID, err := c.dbRepo.Insert(ctx, sourceID, destinationID, workspaceID, schemaBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the snapshot and insert it into the cache
+	snap := &model.StagingFileSchemaSnapshot{
+		ID:            snapshotID,
+		SourceID:      sourceID,
+		DestinationID: destinationID,
+		WorkspaceID:   workspaceID,
+		Schema:        schemaBytes,
+		CreatedAt:     c.now(),
+	}
+	c.cache.Put(cacheKey(sourceID, destinationID), snap, c.cacheRefreshTTL())
+	return snap, nil
+}
+
+func (c *StagingFileSchema) cacheRefreshTTL() time.Duration {
+	return c.cacheRefreshInterval.Load() + c.cacheRefreshJitter()
+}
+
+func cacheKey(sourceID, destinationID string) string {
+	return fmt.Sprintf("%s:%s", sourceID, destinationID)
+}

--- a/warehouse/internal/snapshots/staging_schema_test.go
+++ b/warehouse/internal/snapshots/staging_schema_test.go
@@ -63,10 +63,10 @@ func TestStagingFileSchema(t *testing.T) {
 				return uuid.Nil, errors.New("should not be called")
 			},
 		}
-		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: false})
-		cache.cache.Put(cacheKey("279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ"), snapshot, cache.cacheRefreshTTL())
+		schemaCache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: false})
+		schemaCache.cache.Put(cacheKey("279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ"), snapshot, schemaCache.cacheRefreshTTL())
 
-		got, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		got, err := schemaCache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
 		require.NoError(t, err)
 		require.Equal(t, snapshot, got, "expected cache hit to return cached snapshot")
 		require.Zero(t, db.getLatestCalls.Load(), "expected no DB calls")
@@ -90,10 +90,10 @@ func TestStagingFileSchema(t *testing.T) {
 				return fresh.ID, nil
 			},
 		}
-		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: true})
-		cache.cache.Put(cacheKey("279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ"), &model.StagingFileSchemaSnapshot{CreatedAt: time.Now().Add(-time.Hour)}, cache.cacheRefreshTTL())
+		schemaCache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: true})
+		schemaCache.cache.Put(cacheKey("279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ"), &model.StagingFileSchemaSnapshot{CreatedAt: time.Now().Add(-time.Hour)}, schemaCache.cacheRefreshTTL())
 
-		got, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		got, err := schemaCache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
 		require.NoError(t, err)
 		require.Equal(t, fresh.ID, got.ID, "expected to fetch and cache new snapshot after expiry")
 		require.Equal(t, int64(1), db.insertCalls.Load(), "expected 1 insert call")
@@ -117,8 +117,8 @@ func TestStagingFileSchema(t *testing.T) {
 				return uuid.Nil, errors.New("should not be called")
 			},
 		}
-		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: false})
-		got, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		schemaCache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: false})
+		got, err := schemaCache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
 		require.NoError(t, err)
 		require.Equal(t, dbSnap.ID, got.ID, "expected to return DB snapshot on cache miss")
 		require.Equal(t, int64(1), db.getLatestCalls.Load(), "expected 1 DB getLatest call")
@@ -142,8 +142,8 @@ func TestStagingFileSchema(t *testing.T) {
 				return fresh.ID, nil
 			},
 		}
-		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: true})
-		got, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		schemaCache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: true})
+		got, err := schemaCache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
 		require.NoError(t, err)
 		require.Equal(t, fresh.ID, got.ID, "expected to insert and return new snapshot when DB is expired")
 		require.Equal(t, int64(1), db.insertCalls.Load(), "expected 1 insert call")
@@ -172,8 +172,8 @@ func TestStagingFileSchema(t *testing.T) {
 				return fresh, nil
 			},
 		}
-		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: false})
-		got, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		schemaCache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: false})
+		got, err := schemaCache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
 		require.NoError(t, err)
 		require.Equal(t, fresh.ID, got.ID, "expected to insert and return new snapshot when DB returns ErrNoSchemaSnapshot")
 		require.Equal(t, int64(1), db.insertCalls.Load(), "expected 1 insert call")
@@ -189,8 +189,8 @@ func TestStagingFileSchema(t *testing.T) {
 				return uuid.Nil, nil
 			},
 		}
-		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: true})
-		_, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		schemaCache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: true})
+		_, err := schemaCache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
 		require.Error(t, err)
 		require.Equal(t, int64(1), db.getLatestCalls.Load(), "expected 1 DB getLatest call")
 		require.Equal(t, int64(0), db.insertCalls.Load(), "expected no DB insert calls")
@@ -213,8 +213,8 @@ func TestStagingFileSchema(t *testing.T) {
 				return uuid.Nil, errors.New("db error")
 			},
 		}
-		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: true})
-		_, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		schemaCache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: true})
+		_, err := schemaCache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
 		require.Error(t, err)
 		require.Equal(t, int64(1), db.getLatestCalls.Load(), "expected 1 DB getLatest call")
 		require.Equal(t, int64(1), db.insertCalls.Load(), "expected 1 DB insert call")
@@ -237,14 +237,14 @@ func TestStagingFileSchema_ConcurrentAccess(t *testing.T) {
 			return uuid.Nil, nil
 		},
 	}
-	cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: false})
+	schemaCache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: false})
 
 	var wg sync.WaitGroup
 	for i := 0; i < 1000; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", json.RawMessage(`{"foo":"bar"}`))
+			_, err := schemaCache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", json.RawMessage(`{"foo":"bar"}`))
 			require.NoError(t, err)
 		}()
 	}

--- a/warehouse/internal/snapshots/staging_schema_test.go
+++ b/warehouse/internal/snapshots/staging_schema_test.go
@@ -1,0 +1,252 @@
+package snapshots
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/repo"
+)
+
+type mockStagingFileSchemaDBRepo struct {
+	insertCalls    atomic.Int64
+	getLatestCalls atomic.Int64
+	insertFunc     func(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (uuid.UUID, error)
+	getLatestFunc  func(ctx context.Context, sourceID, destinationID string) (*model.StagingFileSchemaSnapshot, error)
+}
+
+func (m *mockStagingFileSchemaDBRepo) Insert(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (uuid.UUID, error) {
+	m.insertCalls.Add(1)
+	return m.insertFunc(ctx, sourceID, destinationID, workspaceID, schemaBytes)
+}
+
+func (m *mockStagingFileSchemaDBRepo) GetLatest(ctx context.Context, sourceID, destinationID string) (*model.StagingFileSchemaSnapshot, error) {
+	m.getLatestCalls.Add(1)
+	return m.getLatestFunc(ctx, sourceID, destinationID)
+}
+
+type fixedExpiryStrategy struct {
+	expired bool
+}
+
+func (f *fixedExpiryStrategy) IsExpired(*model.StagingFileSchemaSnapshot) bool {
+	return f.expired
+}
+
+func TestStagingFileSchema(t *testing.T) {
+	schema := json.RawMessage(`{"foo":"bar"}`)
+	snapshot := &model.StagingFileSchemaSnapshot{
+		ID:            uuid.New(),
+		Schema:        schema,
+		SourceID:      "279L3gEKqwruBoKGsXZtSVX7vIy",
+		DestinationID: "27CHciD6leAhurSyFAeN4dp14qZ",
+		WorkspaceID:   "279L3V7FSpx43LaNJ0nIs9KRaNC",
+		CreatedAt:     time.Now(),
+	}
+
+	t.Run("cache hit", func(t *testing.T) {
+		db := &mockStagingFileSchemaDBRepo{
+			getLatestFunc: func(ctx context.Context, sourceID, destinationID string) (*model.StagingFileSchemaSnapshot, error) {
+				return nil, errors.New("should not be called")
+			},
+			insertFunc: func(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (uuid.UUID, error) {
+				return uuid.Nil, errors.New("should not be called")
+			},
+		}
+		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: false})
+		cache.cache.Put(cacheKey("279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ"), snapshot, cache.cacheRefreshTTL())
+
+		got, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		require.NoError(t, err)
+		require.Equal(t, snapshot, got, "expected cache hit to return cached snapshot")
+		require.Zero(t, db.getLatestCalls.Load(), "expected no DB calls")
+		require.Zero(t, db.insertCalls.Load(), "expected no DB insert calls")
+	})
+
+	t.Run("cache expired", func(t *testing.T) {
+		fresh := &model.StagingFileSchemaSnapshot{
+			ID:            uuid.New(),
+			Schema:        schema,
+			SourceID:      "279L3gEKqwruBoKGsXZtSVX7vIy",
+			DestinationID: "27CHciD6leAhurSyFAeN4dp14qZ",
+			WorkspaceID:   "279L3V7FSpx43LaNJ0nIs9KRaNC",
+			CreatedAt:     time.Now(),
+		}
+		db := &mockStagingFileSchemaDBRepo{
+			getLatestFunc: func(ctx context.Context, sourceID, destinationID string) (*model.StagingFileSchemaSnapshot, error) {
+				return fresh, nil
+			},
+			insertFunc: func(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (uuid.UUID, error) {
+				return fresh.ID, nil
+			},
+		}
+		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: true})
+		cache.cache.Put(cacheKey("279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ"), &model.StagingFileSchemaSnapshot{CreatedAt: time.Now().Add(-time.Hour)}, cache.cacheRefreshTTL())
+
+		got, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		require.NoError(t, err)
+		require.Equal(t, fresh.ID, got.ID, "expected to fetch and cache new snapshot after expiry")
+		require.Equal(t, int64(1), db.insertCalls.Load(), "expected 1 insert call")
+		require.Equal(t, int64(0), db.getLatestCalls.Load(), "expected 0 DB getLatest call")
+	})
+
+	t.Run("cache miss, db hit", func(t *testing.T) {
+		dbSnap := &model.StagingFileSchemaSnapshot{
+			ID:            uuid.New(),
+			Schema:        schema,
+			SourceID:      "279L3gEKqwruBoKGsXZtSVX7vIy",
+			DestinationID: "27CHciD6leAhurSyFAeN4dp14qZ",
+			WorkspaceID:   "279L3V7FSpx43LaNJ0nIs9KRaNC",
+			CreatedAt:     time.Now(),
+		}
+		db := &mockStagingFileSchemaDBRepo{
+			getLatestFunc: func(ctx context.Context, sourceID, destinationID string) (*model.StagingFileSchemaSnapshot, error) {
+				return dbSnap, nil
+			},
+			insertFunc: func(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (uuid.UUID, error) {
+				return uuid.Nil, errors.New("should not be called")
+			},
+		}
+		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: false})
+		got, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		require.NoError(t, err)
+		require.Equal(t, dbSnap.ID, got.ID, "expected to return DB snapshot on cache miss")
+		require.Equal(t, int64(1), db.getLatestCalls.Load(), "expected 1 DB getLatest call")
+		require.Equal(t, int64(0), db.insertCalls.Load(), "expected no DB insert calls")
+	})
+
+	t.Run("cache miss, db expired", func(t *testing.T) {
+		fresh := &model.StagingFileSchemaSnapshot{
+			ID:            uuid.New(),
+			Schema:        schema,
+			SourceID:      "279L3gEKqwruBoKGsXZtSVX7vIy",
+			DestinationID: "27CHciD6leAhurSyFAeN4dp14qZ",
+			WorkspaceID:   "279L3V7FSpx43LaNJ0nIs9KRaNC",
+			CreatedAt:     time.Now(),
+		}
+		db := &mockStagingFileSchemaDBRepo{
+			getLatestFunc: func(ctx context.Context, sourceID, destinationID string) (*model.StagingFileSchemaSnapshot, error) {
+				return fresh, nil
+			},
+			insertFunc: func(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (uuid.UUID, error) {
+				return fresh.ID, nil
+			},
+		}
+		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: true})
+		got, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		require.NoError(t, err)
+		require.Equal(t, fresh.ID, got.ID, "expected to insert and return new snapshot when DB is expired")
+		require.Equal(t, int64(1), db.insertCalls.Load(), "expected 1 insert call")
+		require.Equal(t, int64(1), db.getLatestCalls.Load(), "expected 1 DB getLatest call")
+	})
+
+	t.Run("cache miss, db no entry", func(t *testing.T) {
+		fresh := &model.StagingFileSchemaSnapshot{
+			ID:            uuid.New(),
+			Schema:        schema,
+			SourceID:      "279L3gEKqwruBoKGsXZtSVX7vIy",
+			DestinationID: "27CHciD6leAhurSyFAeN4dp14qZ",
+			WorkspaceID:   "279L3V7FSpx43LaNJ0nIs9KRaNC",
+			CreatedAt:     time.Now(),
+		}
+		calls := 0
+		db := &mockStagingFileSchemaDBRepo{
+			insertFunc: func(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (uuid.UUID, error) {
+				return fresh.ID, nil
+			},
+			getLatestFunc: func(ctx context.Context, sourceID, destinationID string) (*model.StagingFileSchemaSnapshot, error) {
+				calls++
+				if calls == 1 {
+					return nil, repo.ErrNoSchemaSnapshot
+				}
+				return fresh, nil
+			},
+		}
+		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: false})
+		got, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		require.NoError(t, err)
+		require.Equal(t, fresh.ID, got.ID, "expected to insert and return new snapshot when DB returns ErrNoSchemaSnapshot")
+		require.Equal(t, int64(1), db.insertCalls.Load(), "expected 1 insert call")
+		require.Equal(t, int64(1), db.getLatestCalls.Load(), "expected 1 DB getLatest call")
+	})
+
+	t.Run("db error: getLatest", func(t *testing.T) {
+		db := &mockStagingFileSchemaDBRepo{
+			getLatestFunc: func(ctx context.Context, sourceID, destinationID string) (*model.StagingFileSchemaSnapshot, error) {
+				return nil, errors.New("db error")
+			},
+			insertFunc: func(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (uuid.UUID, error) {
+				return uuid.Nil, nil
+			},
+		}
+		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: true})
+		_, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		require.Error(t, err)
+		require.Equal(t, int64(1), db.getLatestCalls.Load(), "expected 1 DB getLatest call")
+		require.Equal(t, int64(0), db.insertCalls.Load(), "expected no DB insert calls")
+	})
+
+	t.Run("db error: insert", func(t *testing.T) {
+		latest := &model.StagingFileSchemaSnapshot{
+			ID:            uuid.New(),
+			Schema:        schema,
+			SourceID:      "279L3gEKqwruBoKGsXZtSVX7vIy",
+			DestinationID: "27CHciD6leAhurSyFAeN4dp14qZ",
+			WorkspaceID:   "279L3V7FSpx43LaNJ0nIs9KRaNC",
+			CreatedAt:     time.Now(),
+		}
+		db := &mockStagingFileSchemaDBRepo{
+			getLatestFunc: func(ctx context.Context, sourceID, destinationID string) (*model.StagingFileSchemaSnapshot, error) {
+				return latest, nil
+			},
+			insertFunc: func(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (uuid.UUID, error) {
+				return uuid.Nil, errors.New("db error")
+			},
+		}
+		cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: true})
+		_, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", schema)
+		require.Error(t, err)
+		require.Equal(t, int64(1), db.getLatestCalls.Load(), "expected 1 DB getLatest call")
+		require.Equal(t, int64(1), db.insertCalls.Load(), "expected 1 DB insert call")
+	})
+}
+
+func TestStagingFileSchema_ConcurrentAccess(t *testing.T) {
+	db := &mockStagingFileSchemaDBRepo{
+		getLatestFunc: func(ctx context.Context, sourceID, destinationID string) (*model.StagingFileSchemaSnapshot, error) {
+			return &model.StagingFileSchemaSnapshot{
+				ID:            uuid.New(),
+				Schema:        json.RawMessage(`{"foo":"bar"}`),
+				SourceID:      "279L3gEKqwruBoKGsXZtSVX7vIy",
+				DestinationID: "27CHciD6leAhurSyFAeN4dp14qZ",
+				WorkspaceID:   "279L3V7FSpx43LaNJ0nIs9KRaNC",
+				CreatedAt:     time.Now(),
+			}, nil
+		},
+		insertFunc: func(ctx context.Context, sourceID, destinationID, workspaceID string, schemaBytes json.RawMessage) (uuid.UUID, error) {
+			return uuid.Nil, nil
+		},
+	}
+	cache := NewStagingFileSchema(config.New(), db, &fixedExpiryStrategy{expired: false})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := cache.GetOrCreate(context.Background(), "279L3gEKqwruBoKGsXZtSVX7vIy", "27CHciD6leAhurSyFAeN4dp14qZ", "279L3V7FSpx43LaNJ0nIs9KRaNC", json.RawMessage(`{"foo":"bar"}`))
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+}

--- a/warehouse/internal/snapshots/staging_strategy.go
+++ b/warehouse/internal/snapshots/staging_strategy.go
@@ -1,0 +1,26 @@
+package snapshots
+
+import (
+	"time"
+
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+)
+
+// StagingFileSchemaExpiryStrategy defines the interface for cache expiration strategies.
+type StagingFileSchemaExpiryStrategy interface {
+	IsExpired(snapshot *model.StagingFileSchemaSnapshot) bool
+}
+
+// StagingFileSchemaTimeBasedExpiryStrategy expires snapshots after a fixed duration from CreatedAt.
+type StagingFileSchemaTimeBasedExpiryStrategy struct {
+	duration time.Duration
+}
+
+func (t *StagingFileSchemaTimeBasedExpiryStrategy) IsExpired(snapshot *model.StagingFileSchemaSnapshot) bool {
+	return time.Since(snapshot.CreatedAt) > t.duration
+}
+
+// NewStagingFileSchemaTimeBasedExpiryStrategy returns a time-based expiry strategy for the cache.
+func NewStagingFileSchemaTimeBasedExpiryStrategy(duration time.Duration) StagingFileSchemaExpiryStrategy {
+	return &StagingFileSchemaTimeBasedExpiryStrategy{duration: duration}
+}

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -67,12 +67,13 @@ const (
 
 // warehouse table names
 const (
-	WarehouseStagingFilesTable = "wh_staging_files"
-	WarehouseLoadFilesTable    = "wh_load_files"
-	WarehouseUploadsTable      = "wh_uploads"
-	WarehouseTableUploadsTable = "wh_table_uploads"
-	WarehouseSchemasTable      = "wh_schemas"
-	WarehouseAsyncJobTable     = "wh_async_jobs"
+	WarehouseStagingFilesTable              = "wh_staging_files"
+	WarehouseStagingFileSchemaSnapshotTable = "wh_staging_file_schema_snapshots"
+	WarehouseLoadFilesTable                 = "wh_load_files"
+	WarehouseUploadsTable                   = "wh_uploads"
+	WarehouseTableUploadsTable              = "wh_table_uploads"
+	WarehouseSchemasTable                   = "wh_schemas"
+	WarehouseAsyncJobTable                  = "wh_async_jobs"
 )
 
 const (


### PR DESCRIPTION
# Description

- Introduces a new table: `wh_staging_file_schema_snapshots`
  - Stores JSON-encoded schema snapshots for staging files.
  - Keys: source_id, destination_id, workspace_id, and created_at.
- Adds columns to wh_staging_files:
  - `schema_snapshot_id` (UUID, references the new snapshot table)
  - `schema_patch` (TEXT, stores a JSON Patch diff from the snapshot to the actual schema)
- Adds supporting indexes for efficient lookup and retrieval.

# Linear Ticket

[WAR-867: Snapshot cached repository with different strategies](https://linear.app/rudderstack/issue/WAR-867/snapshot-cached-repository-with-different-strategies)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
