### PR TITLE
feat(router): support TRANSFORMER_PROXY_URL for dedicated transformer proxy

### DIFF
--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -179,8 +179,15 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 		nil
 }
 
+// router/transformer/transformer_proxy_adapter.go
+// getTransformerProxyURL constructs the transformer proxy URL, prioritizing TRANSFORMER_PROXY_URL for dedicated deployments.
 func getTransformerProxyURL(version, destType string) (string, error) {
-	baseURL := strings.TrimSuffix(config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090"), "/")
+	// Prefer TRANSFORMER_PROXY_URL for dedicated deployments, fallback to DEST_TRANSFORM_URL for backward compatibility
+	baseURL := config.GetString("TRANSFORMER_PROXY_URL", "")
+	if baseURL == "" {
+		baseURL = config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
+	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
 	return url.JoinPath(baseURL, version, "destinations", strings.ToLower(destType), "proxy")
 }
 

--- a/router/transformer/transformer_proxy_adapter_test.go
+++ b/router/transformer/transformer_proxy_adapter_test.go
@@ -324,3 +324,35 @@ func TestV1Adapter(t *testing.T) {
 		require.Equal(t, "", response.authErrorCategory)
 	})
 }
+
+func Test_getTransformerProxyURL_env_priority(t *testing.T) {
+	t.Setenv("TRANSFORMER_PROXY_URL", "http://proxy:1234")
+	t.Setenv("DEST_TRANSFORM_URL", "http://dest:5678")
+	url, err := getTransformerProxyURL("v0", "TestDest")
+	require.NoError(t, err)
+	require.Contains(t, url, "http://proxy:1234/v0/destinations/testdest/proxy")
+}
+
+func Test_getTransformerProxyURL_only_dest_transform(t *testing.T) {
+	t.Setenv("TRANSFORMER_PROXY_URL", "")
+	t.Setenv("DEST_TRANSFORM_URL", "http://dest:5678")
+	url, err := getTransformerProxyURL("v1", "TestDest")
+	require.NoError(t, err)
+	require.Contains(t, url, "http://dest:5678/v1/destinations/testdest/proxy")
+}
+
+func Test_getTransformerProxyURL_only_transformer_proxy(t *testing.T) {
+	t.Setenv("TRANSFORMER_PROXY_URL", "http://proxy:1234")
+	t.Setenv("DEST_TRANSFORM_URL", "")
+	url, err := getTransformerProxyURL("v0", "TestDest")
+	require.NoError(t, err)
+	require.Contains(t, url, "http://proxy:1234/v0/destinations/testdest/proxy")
+}
+
+func Test_getTransformerProxyURL_default(t *testing.T) {
+	t.Setenv("TRANSFORMER_PROXY_URL", "")
+	t.Setenv("DEST_TRANSFORM_URL", "")
+	url, err := getTransformerProxyURL("v1", "TestDest")
+	require.NoError(t, err)
+	require.Contains(t, url, "http://localhost:9090/v1/destinations/testdest/proxy")
+}


### PR DESCRIPTION
## Description

- The `getTransformerProxyURL` function now prioritizes the `TRANSFORMER_PROXY_URL` environment variable. If this variable is not set, it falls back to `DEST_TRANSFORM_URL`.
- Added unit tests to cover all environment variable scenarios.

## Linear Ticket

- Reference: [INT-3943 - Add support for dedicated deployment for transformer proxy/delivery](https://linear.app/rudderstack/issue/INT-3943/add-support-for-dedicated-deployment-for-transformer-proxydelivery)

## Security

- [x] The code changes in this pull request do not introduce any new security issues.