### PR TITLE
chore: reset timer to optimise router batching

### DIFF
--- a/router/worker.go
+++ b/router/worker.go
@@ -62,8 +62,8 @@ type workerJob struct {
 }
 
 func (w *worker) workLoop() {
-	timeout := time.After(w.rt.reloadableConfig.jobsBatchTimeout.Load())
 	for {
+		timeout := time.After(w.rt.reloadableConfig.jobsBatchTimeout.Load())
 		select {
 		case message, hasMore := <-w.input:
 			if !hasMore {
@@ -251,8 +251,6 @@ func (w *worker) workLoop() {
 			}
 
 		case <-timeout:
-			timeout = time.After(w.rt.reloadableConfig.jobsBatchTimeout.Load())
-
 			if len(w.routerJobs) > 0 {
 				if w.rt.enableBatching {
 					w.destinationJobs = w.batchTransform(w.routerJobs)


### PR DESCRIPTION
# Description

we end up sending smaller batches to router because the timer is not reset after making a call due to batch size. this pr resets the timer every-time a call is made to transformer 
      
## Linear Ticket

fixes PIPE-2204

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
