### PR TITLE
chore(router): rename TRANSFORMER_PROXY_URL to DELIVERY_TRANSFORMER_URL for transformer proxy

### DIFF
--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -180,10 +180,10 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 }
 
 // router/transformer/transformer_proxy_adapter.go
-// getTransformerProxyURL constructs the transformer proxy URL, prioritizing TRANSFORMER_PROXY_URL for dedicated deployments.
+// getTransformerProxyURL constructs the transformer proxy URL, prioritizing DELIVERY_TRANSFORMER_URL for dedicated deployments.
+// Prefer DELIVERY_TRANSFORMER_URL for dedicated deployments, fallback to DEST_TRANSFORM_URL for backward compatibility
 func getTransformerProxyURL(version, destType string) (string, error) {
-	// Prefer TRANSFORMER_PROXY_URL for dedicated deployments, fallback to DEST_TRANSFORM_URL for backward compatibility
-	baseURL := config.GetString("TRANSFORMER_PROXY_URL", "")
+	baseURL := config.GetString("DELIVERY_TRANSFORMER_URL", "")
 	if baseURL == "" {
 		baseURL = config.GetString("DEST_TRANSFORM_URL", "http://localhost:9090")
 	}

--- a/router/transformer/transformer_proxy_adapter_test.go
+++ b/router/transformer/transformer_proxy_adapter_test.go
@@ -326,7 +326,7 @@ func TestV1Adapter(t *testing.T) {
 }
 
 func Test_getTransformerProxyURL_env_priority(t *testing.T) {
-	t.Setenv("TRANSFORMER_PROXY_URL", "http://proxy:1234")
+	t.Setenv("DELIVERY_TRANSFORMER_URL", "http://proxy:1234")
 	t.Setenv("DEST_TRANSFORM_URL", "http://dest:5678")
 	url, err := getTransformerProxyURL("v0", "TestDest")
 	require.NoError(t, err)
@@ -334,7 +334,7 @@ func Test_getTransformerProxyURL_env_priority(t *testing.T) {
 }
 
 func Test_getTransformerProxyURL_only_dest_transform(t *testing.T) {
-	t.Setenv("TRANSFORMER_PROXY_URL", "")
+	t.Setenv("DELIVERY_TRANSFORMER_URL", "")
 	t.Setenv("DEST_TRANSFORM_URL", "http://dest:5678")
 	url, err := getTransformerProxyURL("v1", "TestDest")
 	require.NoError(t, err)
@@ -342,7 +342,7 @@ func Test_getTransformerProxyURL_only_dest_transform(t *testing.T) {
 }
 
 func Test_getTransformerProxyURL_only_transformer_proxy(t *testing.T) {
-	t.Setenv("TRANSFORMER_PROXY_URL", "http://proxy:1234")
+	t.Setenv("DELIVERY_TRANSFORMER_URL", "http://proxy:1234")
 	t.Setenv("DEST_TRANSFORM_URL", "")
 	url, err := getTransformerProxyURL("v0", "TestDest")
 	require.NoError(t, err)
@@ -350,7 +350,7 @@ func Test_getTransformerProxyURL_only_transformer_proxy(t *testing.T) {
 }
 
 func Test_getTransformerProxyURL_default(t *testing.T) {
-	t.Setenv("TRANSFORMER_PROXY_URL", "")
+	t.Setenv("DELIVERY_TRANSFORMER_URL", "")
 	t.Setenv("DEST_TRANSFORM_URL", "")
 	url, err := getTransformerProxyURL("v1", "TestDest")
 	require.NoError(t, err)


### PR DESCRIPTION
# Description

This PR renames the environment variable  to  for transformer proxy configuration. This is a **breaking change**: deployments must update their environment to use the new variable name. All code and tests have been updated accordingly.

- Prioritizes  for dedicated transformer proxy deployments.
- Falls back to  for backward compatibility.
- No changes to docker or documentation in this PR (see commit history for details).

## Linear Ticket

Resolves [INT-3943](https://linear.app/rudderstack/issue/INT-3943/add-support-for-dedicated-deployment-for-transformer-proxydelivery)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
