### PR TITLE
fix: invalidate warehouse schema cache in case of export error

### DIFF
--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 
@@ -410,7 +411,7 @@ func (job *UploadJob) run() (err error) {
 				// schema is being cleared only in ExportedData case and not in other cases.
 				invErr := job.whSchemaRepo.SetExpiryForDestination(job.ctx, job.warehouse.Destination.ID, job.now())
 				if invErr != nil {
-					job.logger.Errorf("Failed to invalidate schema cache: %v", invErr)
+					job.logger.Errorn("Failed to invalidate schema cache", obskit.Error(err))
 				} else {
 					job.logger.Infon("Invalidated warehouse schema cache due to sync error")
 				}


### PR DESCRIPTION
# Description

The warehouse schema cache can become outdated, leading to persistent data export failures until the cache expires. To improve reliability, the schema cache should be invalidated immediately upon encountering a sync error during data export. This ensures that the next export attempt fetches the latest schema, reducing the risk of repeated failures due to schema drift. The invalidation should be limited to cases where a sync error occurs during data delivery, and a log entry should be created whenever invalidation happens. This change will help the system recover more quickly from schema mismatches and improve overall data delivery robustness. 

## Linear Ticket

https://linear.app/rudderstack/issue/WAR-937

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
