### PR TITLE
fix: avoid cleanup object storage for datalakes

### DIFF
--- a/warehouse/integrations/azure-synapse/azure_synapse_test.go
+++ b/warehouse/integrations/azure-synapse/azure_synapse_test.go
@@ -152,6 +152,7 @@ func TestIntegration(t *testing.T) {
 					WithConfigOption("syncFrequency", "30").
 					WithConfigOption("allowUsersContextTraits", true).
 					WithConfigOption("underscoreDivideNumbers", true).
+					WithConfigOption("cleanupObjectStorageFiles", true).
 					Build()
 
 				workspaceConfig := backendconfigtest.NewConfigBuilder().

--- a/warehouse/integrations/bigquery/bigquery_test.go
+++ b/warehouse/integrations/bigquery/bigquery_test.go
@@ -607,7 +607,8 @@ func TestIntegration(t *testing.T) {
 					WithConfigOption("namespace", namespace).
 					WithConfigOption("syncFrequency", "30").
 					WithConfigOption("allowUsersContextTraits", true).
-					WithConfigOption("underscoreDivideNumbers", true)
+					WithConfigOption("underscoreDivideNumbers", true).
+					WithConfigOption("cleanupObjectStorageFiles", true)
 				for k, v := range tc.configOverride {
 					destinationBuilder = destinationBuilder.WithConfigOption(k, v)
 				}

--- a/warehouse/integrations/clickhouse/clickhouse_test.go
+++ b/warehouse/integrations/clickhouse/clickhouse_test.go
@@ -224,7 +224,8 @@ func TestIntegration(t *testing.T) {
 					WithConfigOption("useRudderStorage", false).
 					WithConfigOption("syncFrequency", "30").
 					WithConfigOption("allowUsersContextTraits", true).
-					WithConfigOption("underscoreDivideNumbers", true)
+					WithConfigOption("underscoreDivideNumbers", true).
+					WithConfigOption("cleanupObjectStorageFiles", true)
 				for k, v := range tc.configOverride {
 					destinationBuilder = destinationBuilder.WithConfigOption(k, v)
 				}

--- a/warehouse/integrations/datalake/datalake_test.go
+++ b/warehouse/integrations/datalake/datalake_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/samber/lo"
 	"github.com/spf13/cast"
-	trino "github.com/trinodb/trino-go-client/trino"
+	"github.com/trinodb/trino-go-client/trino"
 	"github.com/xitongsys/parquet-go-source/local"
 	"github.com/xitongsys/parquet-go/parquet"
 	"github.com/xitongsys/parquet-go/reader"
@@ -342,7 +342,8 @@ func TestIntegration(t *testing.T) {
 					WithConfigOption("namespace", namespace).
 					WithConfigOption("syncFrequency", "30").
 					WithConfigOption("allowUsersContextTraits", true).
-					WithConfigOption("underscoreDivideNumbers", true)
+					WithConfigOption("underscoreDivideNumbers", true).
+					WithConfigOption("cleanupObjectStorageFiles", true)
 				for k, v := range tc.configOverride {
 					destinationBuilder = destinationBuilder.WithConfigOption(k, v)
 				}
@@ -587,6 +588,7 @@ func TestIntegration(t *testing.T) {
 			WithConfigOption("prefix", "some-prefix").
 			WithConfigOption("allowUsersContextTraits", true).
 			WithConfigOption("underscoreDivideNumbers", true).
+			WithConfigOption("cleanupObjectStorageFiles", true).
 			Build()
 		workspaceConfig := backendconfigtest.NewConfigBuilder().
 			WithSource(
@@ -872,6 +874,7 @@ func TestIntegration(t *testing.T) {
 			WithConfigOption("prefix", "some-prefix").
 			WithConfigOption("allowUsersContextTraits", true).
 			WithConfigOption("underscoreDivideNumbers", true).
+			WithConfigOption("cleanupObjectStorageFiles", true).
 			Build()
 		workspaceConfig := backendconfigtest.NewConfigBuilder().
 			WithSource(

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -30,6 +30,7 @@ import (
 	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	th "github.com/rudderlabs/rudder-server/testhelper"
 	"github.com/rudderlabs/rudder-server/testhelper/backendconfigtest"
@@ -283,7 +284,8 @@ func TestIntegration(t *testing.T) {
 					WithConfigOption("accountKey", credentials.AccountKey).
 					WithConfigOption("syncFrequency", "30").
 					WithConfigOption("allowUsersContextTraits", true).
-					WithConfigOption("underscoreDivideNumbers", true)
+					WithConfigOption("underscoreDivideNumbers", true).
+					WithConfigOption("cleanupObjectStorageFiles", true)
 				for k, v := range tc.configOverride {
 					destinationBuilder = destinationBuilder.WithConfigOption(k, v)
 				}

--- a/warehouse/integrations/mssql/mssql_test.go
+++ b/warehouse/integrations/mssql/mssql_test.go
@@ -184,6 +184,7 @@ func TestIntegration(t *testing.T) {
 					WithConfigOption("syncFrequency", "30").
 					WithConfigOption("allowUsersContextTraits", true).
 					WithConfigOption("underscoreDivideNumbers", true).
+					WithConfigOption("cleanupObjectStorageFiles", true).
 					Build()
 
 				workspaceConfig := backendconfigtest.NewConfigBuilder().

--- a/warehouse/integrations/postgres/postgres_test.go
+++ b/warehouse/integrations/postgres/postgres_test.go
@@ -315,7 +315,8 @@ func TestIntegration(t *testing.T) {
 					WithConfigOption("useRudderStorage", false).
 					WithConfigOption("syncFrequency", "30").
 					WithConfigOption("allowUsersContextTraits", true).
-					WithConfigOption("underscoreDivideNumbers", true)
+					WithConfigOption("underscoreDivideNumbers", true).
+					WithConfigOption("cleanupObjectStorageFiles", true)
 				for k, v := range tc.configOverride {
 					destinationBuilder = destinationBuilder.WithConfigOption(k, v)
 				}
@@ -567,6 +568,7 @@ func TestIntegration(t *testing.T) {
 					WithConfigOption("sshPrivateKey", strings.ReplaceAll(string(tunnelledPrivateKey), "\\n", "\n")).
 					WithConfigOption("allowUsersContextTraits", true).
 					WithConfigOption("underscoreDivideNumbers", true).
+					WithConfigOption("cleanupObjectStorageFiles", true).
 					Build()
 
 				workspaceConfig := backendconfigtest.NewConfigBuilder().

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -564,7 +564,8 @@ func TestIntegration(t *testing.T) {
 					WithConfigOption("useRudderStorage", false).
 					WithConfigOption("syncFrequency", "30").
 					WithConfigOption("allowUsersContextTraits", true).
-					WithConfigOption("underscoreDivideNumbers", true)
+					WithConfigOption("underscoreDivideNumbers", true).
+					WithConfigOption("cleanupObjectStorageFiles", true)
 				for k, v := range tc.configOverride {
 					destinationBuilder = destinationBuilder.WithConfigOption(k, v)
 				}

--- a/warehouse/integrations/snowflake/snowflake_test.go
+++ b/warehouse/integrations/snowflake/snowflake_test.go
@@ -30,6 +30,7 @@ import (
 	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	th "github.com/rudderlabs/rudder-server/testhelper"
 	"github.com/rudderlabs/rudder-server/testhelper/backendconfigtest"
@@ -437,7 +438,8 @@ func TestIntegration(t *testing.T) {
 					WithConfigOption("underscoreDivideNumbers", true).
 					WithConfigOption("useKeyPairAuth", tc.cred.UseKeyPairAuth).
 					WithConfigOption("privateKey", tc.cred.PrivateKey).
-					WithConfigOption("privateKeyPassphrase", tc.cred.PrivateKeyPassphrase)
+					WithConfigOption("privateKeyPassphrase", tc.cred.PrivateKeyPassphrase).
+					WithConfigOption("cleanupObjectStorageFiles", true)
 				for k, v := range tc.configOverride {
 					destinationBuilder = destinationBuilder.WithConfigOption(k, v)
 				}

--- a/warehouse/router/upload_test.go
+++ b/warehouse/router/upload_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -849,25 +848,21 @@ func createUpload(t testing.TB, ctx context.Context, db *sqlmiddleware.DB) (int6
 }
 
 func TestCleanupObjectStorageFiles(t *testing.T) {
-	stagingFiles := []*model.StagingFile{
-		{Location: "test-location-1"},
-		{Location: "test-location-2"},
-		{Location: "test-location-3"},
-		{Location: "test-location-4"},
-	}
-	loadFiles := []model.LoadFile{
-		{Location: "test-load-location-1"},
-		{Location: "test-load-location-2"},
-		{Location: "test-load-location-3"},
-		{Location: "test-load-location-4"},
-	}
-
-	t.Run("cleanup disabled", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-		mockFileManager := mock_filemanager.NewMockFileManager(ctrl)
-		mockLoadFilesRepo := mockupload.NewMockloadFilesRepo(ctrl)
-
+	stagingFiles := lo.RepeatBy(4, func(i int) *model.StagingFile {
+		return &model.StagingFile{
+			ID:       int64(i + 1),
+			Location: fmt.Sprintf("test-location-%d", i+1),
+		}
+	})
+	stagingFilesIDs := lo.Map(stagingFiles, func(f *model.StagingFile, _ int) int64 {
+		return f.ID
+	})
+	loadFiles := lo.RepeatBy(4, func(i int) model.LoadFile {
+		return model.LoadFile{
+			Location: fmt.Sprintf("test-load-location-%d", i+1),
+		}
+	})
+	createUploadJob := func(destConfig map[string]interface{}, destName string, mockFileManager filemanager.FileManager, mockLoadFilesRepo loadFilesRepo, stagingFiles []*model.StagingFile) *UploadJob {
 		job := &UploadJob{
 			ctx: context.Background(),
 			upload: model.Upload{
@@ -876,281 +871,130 @@ func TestCleanupObjectStorageFiles(t *testing.T) {
 			},
 			warehouse: model.Warehouse{
 				Destination: backendconfig.DestinationT{
-					Config: map[string]interface{}{
-						model.CleanupObjectStorageFilesSetting.String(): false,
-						"bucketProvider": "s3",
-					},
+					Config: destConfig,
 					DestinationDefinition: backendconfig.DestinationDefinitionT{
-						Name: warehouseutils.SNOWFLAKE,
+						Name: destName,
 					},
 				},
 			},
-			conf: config.Default,
+			conf: config.New(),
 			fileManagerFactory: func(settings *filemanager.Settings) (filemanager.FileManager, error) {
 				return mockFileManager, nil
 			},
 			loadFilesRepo:  mockLoadFilesRepo,
-			stagingFiles:   stagingFiles[:2],
-			stagingFileIDs: []int64{1, 2},
+			stagingFiles:   stagingFiles,
+			stagingFileIDs: lo.Map(stagingFiles, func(f *model.StagingFile, _ int) int64 { return f.ID }),
 			statsFactory:   stats.NOP,
+			now:            time.Now,
+			logger:         logger.NOP,
 		}
 		job.stats.objectsDeleted = stats.NOP.NewStat("objects_deleted_count", stats.GaugeType)
 		job.stats.objectsDeletionTime = stats.NOP.NewStat("objects_deletion_time", stats.GaugeType)
+		return job
+	}
+	setupMockFileLocationCalls := func(mockFileManager *mock_filemanager.MockFileManager, stagingFiles []*model.StagingFile, loadFiles []model.LoadFile) {
+		for _, file := range stagingFiles {
+			mockFileManager.EXPECT().GetDownloadKeyFromFileLocation(file.Location).Return(file.Location).Times(1)
+		}
+		for _, file := range loadFiles {
+			mockFileManager.EXPECT().GetDownloadKeyFromFileLocation(file.Location).Return(file.Location).Times(1)
+		}
+	}
+	createDestConfig := func(cleanupEnabled bool, bucketProvider string) map[string]interface{} {
+		return map[string]interface{}{
+			model.CleanupObjectStorageFilesSetting.String(): cleanupEnabled,
+			"bucketProvider": bucketProvider,
+		}
+	}
+	setupMocks := func() (*gomock.Controller, *mock_filemanager.MockFileManager, *mockupload.MockloadFilesRepo) {
+		ctrl := gomock.NewController(t)
+		return ctrl, mock_filemanager.NewMockFileManager(ctrl), mockupload.NewMockloadFilesRepo(ctrl)
+	}
+
+	t.Run("cleanup disabled", func(t *testing.T) {
+		ctrl, mockFileManager, mockLoadFilesRepo := setupMocks()
+		defer ctrl.Finish()
+
+		destConfig := createDestConfig(false, warehouseutils.S3)
+		job := createUploadJob(destConfig, warehouseutils.SNOWFLAKE, mockFileManager, mockLoadFilesRepo, stagingFiles)
+
 		err := job.cleanupObjectStorageFiles()
 		require.NoError(t, err)
 	})
 
 	t.Run("cleanup enabled, successful deletion for Non-Datalakes", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
+		ctrl, mockFileManager, mockLoadFilesRepo := setupMocks()
 		defer ctrl.Finish()
-		mockFileManager := mock_filemanager.NewMockFileManager(ctrl)
-		mockLoadFilesRepo := mockupload.NewMockloadFilesRepo(ctrl)
 
-		// Mock GetDownloadKeyFromFileLocation for staging files
-		for _, file := range stagingFiles[:2] {
-			mockFileManager.EXPECT().GetDownloadKeyFromFileLocation(file.Location).Return(file.Location).Times(1)
-		}
-		// Mock GetDownloadKeyFromFileLocation for load files
-		for _, file := range loadFiles[:2] {
-			mockFileManager.EXPECT().GetDownloadKeyFromFileLocation(file.Location).Return(file.Location).Times(1)
-		}
-
-		// Mock Delete call with specific expected keys
+		setupMockFileLocationCalls(mockFileManager, stagingFiles, loadFiles)
 		expectedKeys := append(
-			lo.Map(stagingFiles[:2], func(f *model.StagingFile, _ int) string { return f.Location }),
-			lo.Map(loadFiles[:2], func(f model.LoadFile, _ int) string { return f.Location })...,
+			lo.Map(stagingFiles, func(f *model.StagingFile, _ int) string { return f.Location }),
+			lo.Map(loadFiles, func(f model.LoadFile, _ int) string { return f.Location })...,
 		)
 		mockFileManager.EXPECT().Delete(gomock.Any(), expectedKeys).Return(nil).Times(1)
+		mockLoadFilesRepo.EXPECT().Get(context.Background(), int64(1), stagingFilesIDs).Return(loadFiles, nil).Times(1)
 
-		mockLoadFilesRepo.EXPECT().Get(
-			context.Background(),
-			int64(1),
-			[]int64{1, 2},
-		).Return(loadFiles[:2], nil).Times(1)
-
-		job := &UploadJob{
-			ctx: context.Background(),
-			upload: model.Upload{
-				WorkspaceID: "test-workspace",
-				ID:          1,
-			},
-			warehouse: model.Warehouse{
-				Destination: backendconfig.DestinationT{
-					Config: map[string]interface{}{
-						model.CleanupObjectStorageFilesSetting.String(): true,
-						"bucketProvider": "s3",
-					},
-					DestinationDefinition: backendconfig.DestinationDefinitionT{
-						Name: warehouseutils.SNOWFLAKE,
-					},
-				},
-			},
-			conf: config.Default,
-			fileManagerFactory: func(settings *filemanager.Settings) (filemanager.FileManager, error) {
-				return mockFileManager, nil
-			},
-			loadFilesRepo:  mockLoadFilesRepo,
-			stagingFiles:   stagingFiles[:2],
-			stagingFileIDs: []int64{1, 2},
-			statsFactory:   stats.NOP,
-			now:            time.Now,
-		}
-		job.stats.objectsDeleted = stats.NOP.NewStat("objects_deleted_count", stats.GaugeType)
-		job.stats.objectsDeletionTime = stats.NOP.NewStat("objects_deletion_time", stats.GaugeType)
+		destConfig := createDestConfig(true, warehouseutils.S3)
+		job := createUploadJob(destConfig, warehouseutils.SNOWFLAKE, mockFileManager, mockLoadFilesRepo, stagingFiles)
 
 		err := job.cleanupObjectStorageFiles()
 		require.NoError(t, err)
 	})
 
 	t.Run("cleanup enabled, successful deletion for Datalakes", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
+		ctrl, mockFileManager, mockLoadFilesRepo := setupMocks()
 		defer ctrl.Finish()
-		mockFileManager := mock_filemanager.NewMockFileManager(ctrl)
-		mockLoadFilesRepo := mockupload.NewMockloadFilesRepo(ctrl)
 
-		// Mock GetDownloadKeyFromFileLocation for staging files
-		for _, file := range stagingFiles[:2] {
-			mockFileManager.EXPECT().GetDownloadKeyFromFileLocation(file.Location).Return(file.Location).Times(1)
-		}
-
-		// Mock Delete call with specific expected keys
-		expectedKeys := append(
-			lo.Map(stagingFiles[:2], func(f *model.StagingFile, _ int) string { return f.Location }),
-		)
+		setupMockFileLocationCalls(mockFileManager, stagingFiles, nil)
+		expectedKeys := lo.Map(stagingFiles, func(f *model.StagingFile, _ int) string { return f.Location })
 		mockFileManager.EXPECT().Delete(gomock.Any(), expectedKeys).Return(nil).Times(1)
 
-		job := &UploadJob{
-			ctx: context.Background(),
-			upload: model.Upload{
-				WorkspaceID: "test-workspace",
-				ID:          1,
-			},
-			warehouse: model.Warehouse{
-				Destination: backendconfig.DestinationT{
-					Config: map[string]interface{}{
-						model.CleanupObjectStorageFilesSetting.String(): true,
-						"bucketProvider": "s3",
-					},
-					DestinationDefinition: backendconfig.DestinationDefinitionT{
-						Name: warehouseutils.S3Datalake,
-					},
-				},
-			},
-			conf: config.Default,
-			fileManagerFactory: func(settings *filemanager.Settings) (filemanager.FileManager, error) {
-				return mockFileManager, nil
-			},
-			loadFilesRepo:  mockLoadFilesRepo,
-			stagingFiles:   stagingFiles[:2],
-			stagingFileIDs: []int64{1, 2},
-			statsFactory:   stats.NOP,
-			now:            time.Now,
-		}
-		job.stats.objectsDeleted = stats.NOP.NewStat("objects_deleted_count", stats.GaugeType)
-		job.stats.objectsDeletionTime = stats.NOP.NewStat("objects_deletion_time", stats.GaugeType)
+		destConfig := createDestConfig(true, warehouseutils.S3)
+		job := createUploadJob(destConfig, warehouseutils.S3Datalake, mockFileManager, mockLoadFilesRepo, stagingFiles)
 
 		err := job.cleanupObjectStorageFiles()
 		require.NoError(t, err)
 	})
 
 	t.Run("cleanup enabled, deletion error", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
+		ctrl, mockFileManager, mockLoadFilesRepo := setupMocks()
 		defer ctrl.Finish()
-		mockFileManager := mock_filemanager.NewMockFileManager(ctrl)
-		mockLoadFilesRepo := mockupload.NewMockloadFilesRepo(ctrl)
 
-		for _, file := range stagingFiles[:2] {
-			mockFileManager.EXPECT().GetDownloadKeyFromFileLocation(file.Location).Return(file.Location).Times(1)
-		}
-		for _, file := range loadFiles[:2] {
-			mockFileManager.EXPECT().GetDownloadKeyFromFileLocation(file.Location).Return(file.Location).Times(1)
-		}
-
+		setupMockFileLocationCalls(mockFileManager, stagingFiles, loadFiles)
 		expectedKeys := append(
-			lo.Map(stagingFiles[:2], func(f *model.StagingFile, _ int) string { return f.Location }),
-			lo.Map(loadFiles[:2], func(f model.LoadFile, _ int) string { return f.Location })...,
+			lo.Map(stagingFiles, func(f *model.StagingFile, _ int) string { return f.Location }),
+			lo.Map(loadFiles, func(f model.LoadFile, _ int) string { return f.Location })...,
 		)
 		mockFileManager.EXPECT().Delete(gomock.Any(), expectedKeys).Return(errors.New("delete error")).Times(1)
+		mockLoadFilesRepo.EXPECT().Get(context.Background(), int64(1), stagingFilesIDs).Return(loadFiles, nil).Times(1)
 
-		mockLoadFilesRepo.EXPECT().Get(
-			context.Background(),
-			int64(1),
-			[]int64{1, 2},
-		).Return(loadFiles[:2], nil).Times(1)
-
-		job := &UploadJob{
-			ctx: context.Background(),
-			upload: model.Upload{
-				WorkspaceID: "test-workspace",
-				ID:          1,
-			},
-			warehouse: model.Warehouse{
-				Destination: backendconfig.DestinationT{
-					Config: map[string]interface{}{
-						model.CleanupObjectStorageFilesSetting.String(): true,
-						"bucketProvider": "s3",
-					},
-					DestinationDefinition: backendconfig.DestinationDefinitionT{
-						Name: warehouseutils.SNOWFLAKE,
-					},
-				},
-			},
-			conf: config.Default,
-			fileManagerFactory: func(settings *filemanager.Settings) (filemanager.FileManager, error) {
-				return mockFileManager, nil
-			},
-			loadFilesRepo:  mockLoadFilesRepo,
-			stagingFiles:   stagingFiles[:2],
-			stagingFileIDs: []int64{1, 2},
-			statsFactory:   stats.NOP,
-			now:            time.Now,
-		}
-		job.stats.objectsDeleted = stats.NOP.NewStat("objects_deleted_count", stats.GaugeType)
-		job.stats.objectsDeletionTime = stats.NOP.NewStat("objects_deletion_time", stats.GaugeType)
+		destConfig := createDestConfig(true, warehouseutils.S3)
+		job := createUploadJob(destConfig, warehouseutils.SNOWFLAKE, mockFileManager, mockLoadFilesRepo, stagingFiles)
 
 		err := job.cleanupObjectStorageFiles()
 		require.EqualError(t, err, "deleting files from object storage: delete error")
 	})
 
 	t.Run("GCS cleanup enabled, chunked deletion", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
+		ctrl, mockFileManager, mockLoadFilesRepo := setupMocks()
 		defer ctrl.Finish()
-		mockFileManager := mock_filemanager.NewMockFileManager(ctrl)
-		mockLoadFilesRepo := mockupload.NewMockloadFilesRepo(ctrl)
 
-		for _, file := range stagingFiles {
-			mockFileManager.EXPECT().GetDownloadKeyFromFileLocation(file.Location).Return(file.Location).Times(1)
-		}
-
-		for _, file := range loadFiles {
-			mockFileManager.EXPECT().GetDownloadKeyFromFileLocation(file.Location).Return(file.Location).Times(1)
-		}
-
-		filesDeleted := make([][]string, 0)
-		filesDeletedMu := sync.Mutex{}
-		mockFileManager.EXPECT().Delete(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, keys []string) error {
-			require.Len(t, keys, 4)
-			filesDeletedMu.Lock()
-			filesDeleted = append(filesDeleted, keys)
-			filesDeletedMu.Unlock()
-			return nil
-		}).Times(2)
-
-		mockLoadFilesRepo.EXPECT().Get(
-			context.Background(),
-			int64(1),
-			[]int64{1, 2, 3, 4},
-		).Return(loadFiles, nil).Times(1)
-
-		job := &UploadJob{
-			ctx: context.Background(),
-			upload: model.Upload{
-				WorkspaceID: "test-workspace",
-				ID:          1,
-			},
-			warehouse: model.Warehouse{
-				Destination: backendconfig.DestinationT{
-					Config: map[string]interface{}{
-						model.CleanupObjectStorageFilesSetting.String(): true,
-						"bucketProvider": "GCS",
-					},
-					DestinationDefinition: backendconfig.DestinationDefinitionT{
-						Name: warehouseutils.BQ,
-					},
-				},
-			},
-			conf: config.Default,
-			fileManagerFactory: func(settings *filemanager.Settings) (filemanager.FileManager, error) {
-				return mockFileManager, nil
-			},
-			loadFilesRepo:  mockLoadFilesRepo,
-			stagingFiles:   stagingFiles,
-			stagingFileIDs: []int64{1, 2, 3, 4},
-			statsFactory:   stats.NOP,
-			now:            time.Now,
-		}
-		job.stats.objectsDeleted = stats.NOP.NewStat("objects_deleted_count", stats.GaugeType)
-		job.stats.objectsDeletionTime = stats.NOP.NewStat("objects_deletion_time", stats.GaugeType)
-
-		// Set up config for chunked deletion
-		job.config.maxConcurrentObjDeleteRequests = func(workspaceID string) int {
-			return 2
-		}
-		job.config.objDeleteBatchSize = func(workspaceID string) int {
-			return 4
-		}
-
-		err := job.cleanupObjectStorageFiles()
-		require.NoError(t, err)
-
-		allKeys := make([]string, 0)
-		for _, chunk := range filesDeleted {
-			allKeys = append(allKeys, chunk...)
-		}
+		setupMockFileLocationCalls(mockFileManager, stagingFiles, loadFiles)
 		expectedKeys := append(
 			lo.Map(stagingFiles, func(f *model.StagingFile, _ int) string { return f.Location }),
 			lo.Map(loadFiles, func(f model.LoadFile, _ int) string { return f.Location })...,
 		)
-		require.ElementsMatch(t, expectedKeys, allKeys)
+		for _, chunk := range lo.Chunk(expectedKeys, 4) {
+			mockFileManager.EXPECT().Delete(gomock.Any(), chunk).Return(nil).Times(1)
+		}
+		mockLoadFilesRepo.EXPECT().Get(context.Background(), int64(1), stagingFilesIDs).Return(loadFiles, nil).Times(1)
+
+		destConfig := createDestConfig(true, warehouseutils.GCS)
+		job := createUploadJob(destConfig, warehouseutils.BQ, mockFileManager, mockLoadFilesRepo, stagingFiles)
+		job.config.maxConcurrentObjDeleteRequests = func(workspaceID string) int { return 2 }
+		job.config.objDeleteBatchSize = func(workspaceID string) int { return 4 }
+
+		err := job.cleanupObjectStorageFiles()
+		require.NoError(t, err)
 	})
 }

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -882,3 +882,7 @@ func GetConnectionTimeout(destType, destID string) time.Duration {
 	}
 	return config.GetDuration(warehouseLevelConfig, defaultTimeout, defaultTimeoutUnits)
 }
+
+func IsDatalakeDestination(destType string) bool {
+	return destType == S3Datalake || destType == GCSDatalake || destType == AzureDatalake
+}


### PR DESCRIPTION
# Description

- Avoid cleaning up load files for Datalake destination

## Linear Ticket

- Resolves RUD-2448

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
