### PR TITLE
chore: generate temp creds in v2 for databricks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/rudderlabs/bing-ads-go-sdk v0.2.3
 	github.com/rudderlabs/compose-test v0.1.3
 	github.com/rudderlabs/keydb v0.1.0-alpha
-	github.com/rudderlabs/rudder-go-kit v0.57.1
+	github.com/rudderlabs/rudder-go-kit v0.58.1-0.20250718060440-968c4bc53fd0
 	github.com/rudderlabs/rudder-observability-kit v0.0.4
 	github.com/rudderlabs/rudder-schemas v0.7.0
 	github.com/rudderlabs/rudder-transformer/go v0.0.0-20250707171833-9cd525669b1b
@@ -182,7 +182,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.33.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bitfield/gotestdox v0.2.2 // indirect
 	github.com/bits-and-blooms/bitset v1.14.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1198,8 +1198,8 @@ github.com/rudderlabs/keydb v0.1.0-alpha h1:h87QGW9ut6jQExQjtZsp2BxPc0Hix58WELQ5
 github.com/rudderlabs/keydb v0.1.0-alpha/go.mod h1:gnyirkn1FWIQPCvo/E6rFmfDQ2pjVkAYHF3hJvsBpC0=
 github.com/rudderlabs/parquet-go v0.0.3 h1:/zgRj929pGKHsthc0kw8stVEcFu1JUcpxDRlhxjSLic=
 github.com/rudderlabs/parquet-go v0.0.3/go.mod h1:WmwBOdvwpXl2aZGRk3NxxgzC/DaWGfax3jrCRhKhtSo=
-github.com/rudderlabs/rudder-go-kit v0.57.1 h1:9yxiZFzmeRPXYuwTZGzovGwbK4cvYyVC5qiUKqQWrEA=
-github.com/rudderlabs/rudder-go-kit v0.57.1/go.mod h1:TQ9BE8LL1/GZsv0590NiHTG3f6TjOH7hYbjXobKoO5Q=
+github.com/rudderlabs/rudder-go-kit v0.58.1-0.20250718060440-968c4bc53fd0 h1:+7yf4YMlwLtouT3xVDAUMy1rdhyOZqLPMJ5tvhLTT+o=
+github.com/rudderlabs/rudder-go-kit v0.58.1-0.20250718060440-968c4bc53fd0/go.mod h1:TQ9BE8LL1/GZsv0590NiHTG3f6TjOH7hYbjXobKoO5Q=
 github.com/rudderlabs/rudder-observability-kit v0.0.4 h1:h9nLoWqiv/nqGOu1dhuVFAHNRkyodR6R3v36bqmavRs=
 github.com/rudderlabs/rudder-observability-kit v0.0.4/go.mod h1:YTsvJmpvh8OLk7c4C+wXiV8NRdcrrdLa8UvIdLoXTho=
 github.com/rudderlabs/rudder-schemas v0.7.0 h1:hKShHYpbIldE1Q591vodI6iaAZ/IUOyC1DqUUJZysNU=

--- a/utils/misc/misc.go
+++ b/utils/misc/misc.go
@@ -626,6 +626,10 @@ func GetRudderObjectStoragePrefix() (prefix string) {
 	return config.GetString("RUDDER_WAREHOUSE_BUCKET_PREFIX", config.GetNamespaceIdentifier())
 }
 
+func GetRegionHint() string {
+	return config.GetString("AWS_S3_REGION_HINT", "us-east-1")
+}
+
 func GetRudderObjectStorageConfig(prefixOverride string) (storageConfig map[string]interface{}) {
 	// TODO: add error log if s3 keys are not available
 	storageConfig = make(map[string]interface{})

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -17,29 +17,28 @@ import (
 	"strings"
 	"time"
 
-	"github.com/samber/lo"
-
-	"github.com/rudderlabs/rudder-go-kit/jsonrs"
-
-	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
-
 	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	stsv2 "github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/iancoleman/strcase"
+	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 
 	"github.com/rudderlabs/rudder-go-kit/awsutil"
 	"github.com/rudderlabs/rudder-go-kit/awsutil_v2"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/utils/awsutils"
 	"github.com/rudderlabs/rudder-server/utils/misc"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 )
 
 const (
@@ -682,15 +681,41 @@ func GetTemporaryS3CredV2(destination *backendconfig.DestinationT) (string, stri
 	if err != nil {
 		return "", "", "", err
 	}
+
+	if sessionConfig.Region == "" {
+		bucketName, ok := destination.Config["bucketName"].(string)
+		if !ok {
+			return "", "", "", fmt.Errorf("bucketName not found in destination config")
+		}
+		region, err := awsutil_v2.GetRegionFromBucket(context.Background(), bucketName, misc.GetRegionHint())
+		if err != nil {
+			return "", "", "", fmt.Errorf("failed to fetch AWS region for bucket: %w", err)
+		}
+		sessionConfig.Region = region
+	}
+
 	awsConfig, err := awsutil_v2.CreateAWSConfig(context.Background(), sessionConfig)
 	if err != nil {
 		return "", "", "", err
 	}
-	creds, err := awsConfig.Credentials.Retrieve(context.Background())
-	if err != nil {
-		return "", "", "", err
+
+	if sessionConfig.RoleBasedAuth {
+		creds, err := awsConfig.Credentials.Retrieve(context.Background())
+		if err != nil {
+			return "", "", "", err
+		}
+		return creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken, nil
 	}
-	return creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken, nil
+	client := stsv2.NewFromConfig(awsConfig)
+	expiryInSec := awsCredsExpiryInS.Load()
+	input := &stsv2.GetSessionTokenInput{
+		DurationSeconds: aws.Int32(int32(expiryInSec)),
+	}
+	output, err := client.GetSessionToken(context.Background(), input)
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to get session token: %w", err)
+	}
+	return *output.Credentials.AccessKeyId, *output.Credentials.SecretAccessKey, *output.Credentials.SessionToken, nil
 }
 
 type Tag struct {


### PR DESCRIPTION
# Description

- Loading into databricks expects mandatory temporary credentials
- Generating temporary credentials via sts mandates region in aws sdk v2
- Uses a helper function to get region from bucket and injects into SessionConfig

## Linear Ticket

Fixes PIPE-2240

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
