### PR TITLE
fix: empty bucket with use rudder storage

### DIFF
--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -641,6 +641,7 @@ func CreateAWSSessionConfigV2(destination *backendconfig.DestinationT, serviceNa
 		AccessKeyID: accessKeyID,
 		AccessKey:   accessKey,
 		Service:     serviceName,
+		Region:      misc.GetRegionHint(),
 	}, nil
 }
 
@@ -687,6 +688,11 @@ func GetTemporaryS3CredV2(destination *backendconfig.DestinationT) (string, stri
 		if !ok {
 			return "", "", "", fmt.Errorf("bucketName not found in destination config")
 		}
+
+		if bucketName == "" {
+			return "", "", "", fmt.Errorf("bucketName not found in destination config")
+		}
+
 		region, err := awsutil_v2.GetRegionFromBucket(context.Background(), bucketName, misc.GetRegionHint())
 		if err != nil {
 			return "", "", "", fmt.Errorf("failed to fetch AWS region for bucket: %w", err)

--- a/warehouse/utils/utils_test.go
+++ b/warehouse/utils/utils_test.go
@@ -1180,6 +1180,7 @@ func TestCreateAWSSessionConfig_V2(t *testing.T) {
 				AccessKeyID: rudderAccessKeyID,
 				AccessKey:   rudderAccessKey,
 				Service:     "redshift",
+				Region:      "us-east-1",
 			},
 		},
 	}


### PR DESCRIPTION
# Description

With `useRudderStorage`  we end up not getting any bucket in the destination configuration and resulting in a forbidden call to get region. If we have use rudder storage we know the region of the bucket which can be used directly skipping the get region call.


## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
