### PR TITLE
chore: use errgroup.Group instead of kitsync.ErrGroup

### DIFF
--- a/archiver/archiver.go
+++ b/archiver/archiver.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -26,7 +28,7 @@ type archiver struct {
 	adaptivePayloadLimitFunc payload.AdaptiveLimiterFunc
 
 	stopArchivalTrigger context.CancelFunc
-	waitGroup           *kitsync.ErrGroup
+	waitGroup           *errgroup.Group
 
 	archiveFrom string
 	config      struct {
@@ -94,7 +96,7 @@ func (a *archiver) Start() error {
 	a.log.Info("Starting archiver")
 	ctx, cancel := context.WithCancel(context.Background())
 	a.stopArchivalTrigger = cancel
-	g, ctx := kitsync.ErrGroupWithContext(ctx)
+	g, ctx := errgroup.WithContext(ctx)
 	a.waitGroup = g
 
 	var limiterGroup sync.WaitGroup

--- a/enterprise/reporting/error_index/error_index_reporting.go
+++ b/enterprise/reporting/error_index/error_index_reporting.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
@@ -27,7 +28,7 @@ import (
 type ErrorIndexReporter struct {
 	ctx              context.Context
 	cancel           context.CancelFunc
-	g                *kitsync.ErrGroup
+	g                *errgroup.Group
 	log              logger.Logger
 	conf             *config.Config
 	configSubscriber configSubscriber
@@ -60,7 +61,7 @@ type handleWithSqlDB struct {
 
 func NewErrorIndexReporter(ctx context.Context, log logger.Logger, configSubscriber configSubscriber, conf *config.Config, statsFactory stats.Stats) *ErrorIndexReporter {
 	ctx, cancel := context.WithCancel(ctx)
-	g, ctx := kitsync.ErrGroupWithContext(ctx)
+	g, ctx := errgroup.WithContext(ctx)
 
 	eir := &ErrorIndexReporter{
 		ctx:          ctx,

--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -27,7 +27,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats/collectors"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 	"github.com/rudderlabs/rudder-server/enterprise/reporting/client"
 	"github.com/rudderlabs/rudder-server/enterprise/reporting/event_sampler"
@@ -66,7 +65,7 @@ var ErrorDetailReportsColumns = []string{
 type ErrorDetailReporter struct {
 	ctx                 context.Context
 	cancel              context.CancelFunc
-	g                   *kitsync.ErrGroup
+	g                   *errgroup.Group
 	configSubscriber    *configSubscriber
 	reportingServiceURL string
 	syncersMu           sync.RWMutex
@@ -126,7 +125,7 @@ func NewErrorDetailReporter(
 	log := logger.NewLogger().Child("enterprise").Child("error-detail-reporting")
 	extractor := NewErrorDetailExtractor(log)
 	ctx, cancel := context.WithCancel(ctx)
-	g, ctx := kitsync.ErrGroupWithContext(ctx)
+	g, ctx := errgroup.WithContext(ctx)
 
 	var eventSampler event_sampler.EventSampler
 

--- a/enterprise/reporting/flusher/cron_runner.go
+++ b/enterprise/reporting/flusher/cron_runner.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 )
 
@@ -26,7 +26,7 @@ func (c *NOPCronRunner) Stop() {}
 type CronRunner struct {
 	ctx    context.Context
 	cancel context.CancelFunc
-	g      *kitsync.ErrGroup
+	g      *errgroup.Group
 
 	stats stats.Stats
 	log   logger.Logger
@@ -48,7 +48,7 @@ func NewCronRunner(ctx context.Context, log logger.Logger, stats stats.Stats, co
 	instanceId := conf.GetString("INSTANCE_ID", "1")
 
 	ctx, cancel := context.WithCancel(ctx)
-	g, ctx := kitsync.ErrGroupWithContext(ctx)
+	g, ctx := errgroup.WithContext(ctx)
 
 	c := &CronRunner{
 		ctx:           ctx,

--- a/enterprise/reporting/mediator.go
+++ b/enterprise/reporting/mediator.go
@@ -3,13 +3,14 @@ package reporting
 import (
 	"context"
 
+	"golang.org/x/sync/errgroup"
+
 	erridx "github.com/rudderlabs/rudder-server/enterprise/reporting/error_index"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/enterprise/reporting/flusher"
@@ -24,7 +25,7 @@ const (
 type Mediator struct {
 	log logger.Logger
 
-	g         *kitsync.ErrGroup
+	g         *errgroup.Group
 	ctx       context.Context
 	cancel    context.CancelFunc
 	reporters []types.Reporting
@@ -35,7 +36,7 @@ type Mediator struct {
 
 func NewReportingMediator(ctx context.Context, conf *config.Config, log logger.Logger, enterpriseToken string, backendConfig backendconfig.BackendConfig) *Mediator {
 	ctx, cancel := context.WithCancel(ctx)
-	g, ctx := kitsync.ErrGroupWithContext(ctx)
+	g, ctx := errgroup.WithContext(ctx)
 
 	rm := &Mediator{
 		log:    log,

--- a/enterprise/reporting/reporting.go
+++ b/enterprise/reporting/reporting.go
@@ -24,7 +24,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
@@ -54,7 +53,7 @@ const (
 type DefaultReporter struct {
 	ctx                 context.Context
 	cancel              context.CancelFunc
-	g                   *kitsync.ErrGroup
+	g                   *errgroup.Group
 	configSubscriber    *configSubscriber
 	syncersMu           sync.RWMutex
 	syncers             map[string]*types.SyncSource
@@ -121,7 +120,7 @@ func NewDefaultReporter(ctx context.Context, conf *config.Config, log logger.Log
 		}
 	}
 	ctx, cancel := context.WithCancel(ctx)
-	g, ctx := kitsync.ErrGroupWithContext(ctx)
+	g, ctx := errgroup.WithContext(ctx)
 	return &DefaultReporter{
 		ctx:                                  ctx,
 		cancel:                               cancel,

--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -36,7 +36,6 @@ import (
 	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 
 	"github.com/rudderlabs/rudder-server/app"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
@@ -195,7 +194,7 @@ func (gw *Handle) Setup(
 	var leakyUploaderBuffer chan msgToUpload
 
 	ctx, cancel := context.WithCancel(context.Background())
-	g, ctx := kitsync.ErrGroupWithContext(ctx)
+	g, ctx := errgroup.WithContext(ctx)
 	gw.backgroundCancel = cancel
 	gw.backgroundWait = func() error {
 		err := g.Wait()

--- a/gateway/webhook/setup.go
+++ b/gateway/webhook/setup.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
 	"github.com/rudderlabs/rudder-go-kit/retryablehttp"
@@ -20,7 +22,6 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
@@ -127,7 +128,7 @@ func Setup(gwHandle Gateway, transformerFeaturesService TransformerFeaturesServi
 
 	webhook.statReporterCreator = statReporterCreator
 
-	g, _ := kitsync.ErrGroupWithContext(ctx)
+	g, _ := errgroup.WithContext(ctx)
 	for i := 0; i < maxTransformerProcess; i++ {
 		g.Go(crash.Wrapper(func() error {
 			bt := batchWebhookTransformerT{

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -48,7 +48,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/collectors"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-server/jobsdb/internal/cache"
@@ -494,7 +493,7 @@ type Handle struct {
 	isStatDropDSPeriodInitialized bool
 
 	backgroundCancel context.CancelFunc
-	backgroundGroup  *kitsync.ErrGroup
+	backgroundGroup  *errgroup.Group
 
 	// skipSetupDBSetup is useful for testing as we mock the database client
 	// TODO: Remove this flag once we have test setup that uses real database
@@ -1014,7 +1013,7 @@ func (jd *Handle) Start() error {
 	jd.conf.readCapacity = make(chan struct{}, jd.conf.maxReaders)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	g, ctx := kitsync.ErrGroupWithContext(ctx)
+	g, ctx := errgroup.WithContext(ctx)
 
 	jd.backgroundCancel = cancel
 	jd.backgroundGroup = g

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -19,12 +19,12 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
 	rsRand "github.com/rudderlabs/rudder-go-kit/testhelper/rand"
 	"github.com/rudderlabs/rudder-server/admin"
@@ -171,7 +171,7 @@ func TestJobsdbLifecycle(t *testing.T) {
 			jd := startTestJobsDB(t)
 			defer jd.TearDown()
 			var wg sync.WaitGroup
-			bgGroups := make([]*kitsync.ErrGroup, 10)
+			bgGroups := make([]*errgroup.Group, 10)
 			wg.Add(10)
 			for i := 0; i < 10; i++ {
 				idx := i

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -579,7 +579,7 @@ func (proc *Handle) Setup(
 	}
 	proc.sourceObservers = []sourceObserver{delayed.NewEventStats(proc.statsFactory, proc.conf)}
 	ctx, cancel := context.WithCancel(context.Background())
-	g, ctx := kitsync.ErrGroupWithContext(ctx)
+	g, ctx := errgroup.WithContext(ctx)
 
 	proc.backgroundWait = g.Wait
 	proc.backgroundCancel = cancel

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -104,7 +104,7 @@ type Handle struct {
 
 	// state
 
-	backgroundGroup  *kitsync.ErrGroup
+	backgroundGroup  *errgroup.Group
 	backgroundCtx    context.Context
 	backgroundCancel context.CancelFunc
 	backgroundWait   func() error

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
@@ -110,7 +111,7 @@ func (brt *Handle) Setup(
 		})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	brt.backgroundGroup, brt.backgroundCtx = kitsync.ErrGroupWithContext(ctx)
+	brt.backgroundGroup, brt.backgroundCtx = errgroup.WithContext(ctx)
 	brt.backgroundCancel = cancel
 	brt.backgroundWait = brt.backgroundGroup.Wait
 

--- a/router/handle.go
+++ b/router/handle.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
@@ -111,7 +112,7 @@ type Handle struct {
 	throttlingErrorStat            stats.Measurement
 	throttledStat                  stats.Measurement
 	isolationStrategy              isolation.Strategy
-	backgroundGroup                *kitsync.ErrGroup
+	backgroundGroup                *errgroup.Group
 	backgroundCtx                  context.Context
 	backgroundCancel               context.CancelFunc
 	backgroundWait                 func() error

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 
 	"github.com/samber/lo"
@@ -181,7 +183,7 @@ func (rt *Handle) Setup(
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	g, ctx := kitsync.ErrGroupWithContext(ctx)
+	g, ctx := errgroup.WithContext(ctx)
 
 	rt.backgroundCtx = ctx
 	rt.backgroundGroup = g

--- a/router/manager/manager.go
+++ b/router/manager/manager.go
@@ -7,7 +7,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/router"
 	"github.com/rudderlabs/rudder-server/router/batchrouter"
@@ -20,7 +19,7 @@ type LifecycleManager struct {
 	brt           *batchrouter.Factory
 	backendConfig backendconfig.BackendConfig
 	currentCancel context.CancelFunc
-	waitGroup     *kitsync.ErrGroup
+	waitGroup     *errgroup.Group
 }
 
 // Start starts a Router, this is not a blocking call.
@@ -29,7 +28,7 @@ type LifecycleManager struct {
 func (r *LifecycleManager) Start() error {
 	currentCtx, cancel := context.WithCancel(context.Background())
 	r.currentCancel = cancel
-	g, _ := kitsync.ErrGroupWithContext(context.Background())
+	g, _ := errgroup.WithContext(context.Background())
 	r.waitGroup = g
 	g.Go(func() error {
 		r.monitorDestRouters(currentCtx, r.rt, r.brt)

--- a/router/partition_worker.go
+++ b/router/partition_worker.go
@@ -5,9 +5,10 @@ import (
 	"strconv"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	"github.com/rudderlabs/rudder-server/utils/crash"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
@@ -21,7 +22,7 @@ func newPartitionWorker(ctx context.Context, rt *Handle, partition string) *part
 		partition: partition,
 		ctx:       ctx,
 	}
-	pw.g, _ = kitsync.ErrGroupWithContext(context.Background())
+	pw.g, _ = errgroup.WithContext(context.Background())
 	pw.workers = make([]*worker, rt.noOfWorkers)
 	for i := 0; i < rt.noOfWorkers; i++ {
 		worker := &worker{
@@ -55,8 +56,8 @@ type partitionWorker struct {
 
 	// state
 	ctx     context.Context
-	g       *kitsync.ErrGroup // group against which all the workers are spawned
-	workers []*worker         // workers that are responsible for processing the jobs
+	g       *errgroup.Group // group against which all the workers are spawned
+	workers []*worker       // workers that are responsible for processing the jobs
 
 	pickupCount   int  // number of jobs picked up by the workers in the last iteration
 	limitsReached bool // whether the limits were reached in the last iteration

--- a/schema-forwarder/internal/forwarder/abortingforwarder.go
+++ b/schema-forwarder/internal/forwarder/abortingforwarder.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/utils/crash"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -28,7 +29,7 @@ func NewAbortingForwarder(terminalErrFn func(error), schemaDB jobsdb.JobsDB, con
 // Start starts the forwarder which reads jobs from the database and aborts them
 func (nf *AbortingForwarder) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
-	nf.g, ctx = kitsync.ErrGroupWithContext(ctx)
+	nf.g, ctx = errgroup.WithContext(ctx)
 	nf.cancel = cancel
 
 	nf.g.Go(crash.Wrapper(func() error {

--- a/schema-forwarder/internal/forwarder/baseforwarder.go
+++ b/schema-forwarder/internal/forwarder/baseforwarder.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 )
@@ -21,7 +22,7 @@ type BaseForwarder struct {
 	jobsDB        jobsdb.JobsDB
 
 	cancel context.CancelFunc // cancel function for the Start context (used to stop all goroutines during Stop)
-	g      *kitsync.ErrGroup  // errgroup for the Start context (used to wait for all goroutines to exit)
+	g      *errgroup.Group    // errgroup for the Start context (used to wait for all goroutines to exit)
 
 	conf struct {
 		pickupSize                int           // number of jobs to pickup in a single query

--- a/schema-forwarder/internal/forwarder/jobsforwarder.go
+++ b/schema-forwarder/internal/forwarder/jobsforwarder.go
@@ -11,13 +11,13 @@ import (
 	pulsarType "github.com/apache/pulsar-client-go/pulsar"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/samber/lo"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/internal/pulsar"
 	"github.com/rudderlabs/rudder-server/jobsdb"
@@ -79,7 +79,7 @@ func (jf *JobsForwarder) Start() error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	jf.cancel = cancel
-	jf.g, ctx = kitsync.ErrGroupWithContext(ctx)
+	jf.g, ctx = errgroup.WithContext(ctx)
 
 	jf.g.Go(crash.Wrapper(func() error {
 		var sleepTime time.Duration

--- a/schema-forwarder/internal/transformer/transformer.go
+++ b/schema-forwarder/internal/transformer/transformer.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/jeremywohl/flatten"
@@ -15,7 +16,6 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
 	proto "github.com/rudderlabs/rudder-server/proto/event-schema"
@@ -41,7 +41,7 @@ func New(backendConfig backendconfig.BackendConfig, config *config.Config) Trans
 func (st *transformer) Start() {
 	ctx, cancel := context.WithCancel(context.Background())
 	st.cancel = cancel
-	st.g, ctx = kitsync.ErrGroupWithContext(ctx)
+	st.g, ctx = errgroup.WithContext(ctx)
 
 	var initialisedOnce sync.Once
 	initialised := make(chan struct{})

--- a/schema-forwarder/internal/transformer/types.go
+++ b/schema-forwarder/internal/transformer/types.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"sync"
 
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
+	"golang.org/x/sync/errgroup"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 )
 
 type transformer struct {
 	cancel context.CancelFunc // cancel function for the Start context (used to stop all goroutines during Stop)
-	g      *kitsync.ErrGroup  // errgroup for the Start context (used to wait for all goroutines to exit)
+	g      *errgroup.Group    // errgroup for the Start context (used to wait for all goroutines to exit)
 
 	backendConfig backendconfig.BackendConfig
 

--- a/services/notifier/notifier.go
+++ b/services/notifier/notifier.go
@@ -14,13 +14,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 	"github.com/spaolacci/murmur3"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/sqlutil"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/collectors"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -114,7 +114,7 @@ type Notifier struct {
 	randGenerator       *rand.Rand
 	now                 func() time.Time
 	background          struct {
-		group       *kitsync.ErrGroup
+		group       *errgroup.Group
 		groupCtx    context.Context
 		groupCancel context.CancelFunc
 		groupWait   func() error
@@ -230,7 +230,7 @@ func (n *Notifier) Setup(
 	n.repo = newRepo(n.db)
 
 	groupCtx, groupCancel := context.WithCancel(ctx)
-	n.background.group, n.background.groupCtx = kitsync.ErrGroupWithContext(groupCtx)
+	n.background.group, n.background.groupCtx = errgroup.WithContext(groupCtx)
 	n.background.groupCancel = groupCancel
 	n.background.groupWait = n.background.group.Wait
 

--- a/warehouse/router/router.go
+++ b/warehouse/router/router.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	"github.com/samber/lo"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 
 	"github.com/rudderlabs/rudder-server/rruntime"
 	"github.com/rudderlabs/rudder-server/services/controlplane"
@@ -81,7 +81,7 @@ type Router struct {
 	now               func() time.Time
 	nowSQL            string
 
-	backgroundGroup *kitsync.ErrGroup
+	backgroundGroup *errgroup.Group
 
 	tenantManager    *multitenant.Manager
 	bcManager        *bcm.BackendConfigManager
@@ -184,7 +184,7 @@ func (r *Router) Start(ctx context.Context) error {
 		return err
 	}
 
-	g, gCtx := kitsync.ErrGroupWithContext(ctx)
+	g, gCtx := errgroup.WithContext(ctx)
 	r.backgroundGroup = g
 	g.Go(crash.NotifyWarehouse(func() error {
 		r.backendConfigSubscriber(gCtx)

--- a/warehouse/router/router_test.go
+++ b/warehouse/router/router_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
-	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
 
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
@@ -1106,7 +1106,7 @@ func TestRouter(t *testing.T) {
 		}))
 
 		ctx, cancel := context.WithCancel(context.Background())
-		g := &kitsync.ErrGroup{}
+		g := &errgroup.Group{}
 		defer cancel()
 
 		warehouse := model.Warehouse{


### PR DESCRIPTION
# Description

since sync 0.16.0 errgroup panic propagation has been reverted thus it is now safe to use again. 

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
