### PR TITLE
fix: oauthv2 integrations and remove oauthv1 implementation from regulation worker

### DIFF
--- a/regulation-worker/internal/delete/api/api.go
+++ b/regulation-worker/internal/delete/api/api.go
@@ -20,10 +20,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
-	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
-	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
-	"github.com/rudderlabs/rudder-server/services/oauth"
 	oauthv2 "github.com/rudderlabs/rudder-server/services/oauth/v2"
 	"github.com/rudderlabs/rudder-server/services/oauth/v2/common"
 	cntx "github.com/rudderlabs/rudder-server/services/oauth/v2/context"
@@ -39,15 +36,8 @@ var (
 type APIManager struct {
 	Client                       *http.Client
 	DestTransformURL             string
-	OAuth                        oauth.Authorizer
 	MaxOAuthRefreshRetryAttempts int
 	TransformerFeaturesService   transformer.FeaturesService
-	IsOAuthV2Enabled             bool
-}
-
-type oauthDetail struct {
-	secretToken *oauth.AuthResponse
-	id          string
 }
 
 func GetAuthErrorCategoryFromResponse(bodyBytes []byte) (string, error) {
@@ -109,24 +99,8 @@ func (m *APIManager) deleteWithRetry(ctx context.Context, job model.Job, destina
 		pkgLogger.Error(err)
 		return model.JobStatus{Status: model.JobStatusFailed, Error: err}
 	}
-	var oAuthDetail oauthDetail
-	if isOAuth && !m.IsOAuthV2Enabled {
-		oAuthDetail, err = m.getOAuthDetail(&destination, job.WorkspaceID)
-		if err != nil {
-			pkgLogger.Error(err)
-			return model.JobStatus{Status: model.JobStatusFailed, Error: err}
-		}
-		err = setOAuthHeader(oAuthDetail.secretToken, req)
-		if err != nil {
-			pkgLogger.Errorf("[%v] error occurred while setting oauth header for workspace: %v, destination: %v", destination.Name, job.WorkspaceID, destination.DestinationID)
-			pkgLogger.Error(err)
-			return model.JobStatus{Status: model.JobStatusFailed, Error: err}
-		}
-	}
 
-	if isOAuth && m.IsOAuthV2Enabled {
-		req = req.WithContext(cntx.CtxWithDestInfo(req.Context(), dest))
-	}
+	req = req.WithContext(cntx.CtxWithDestInfo(req.Context(), dest))
 
 	defer stats.Default.NewTaggedStat(
 		"regulation_worker_cleaning_time",
@@ -161,7 +135,7 @@ func (m *APIManager) deleteWithRetry(ctx context.Context, job model.Job, destina
 	respStatusCode := resp.StatusCode
 	respBodyBytes := bodyBytes
 	// Post response work to be done for OAuthV2
-	if isOAuth && m.IsOAuthV2Enabled {
+	if isOAuth {
 		var transportResponse oauthv2.TransportResponse
 		// We don't need to handle it, as we can receive a string response even before executing OAuth operations like Refresh Token or Auth Status Toggle.
 		// It's acceptable if the structure of bodyBytes doesn't match the oauthv2.TransportResponse struct.
@@ -187,7 +161,6 @@ func (m *APIManager) deleteWithRetry(ctx context.Context, job model.Job, destina
 		job:                      job,
 		isOAuthEnabled:           isOAuth,
 		currentOAuthRetryAttempt: currentOauthRetryAttempt,
-		oAuthDetail:              oAuthDetail,
 		responseBodyBytes:        respBodyBytes,
 		responseStatusCode:       respStatusCode,
 	})
@@ -232,82 +205,8 @@ func mapJobToPayload(job model.Job, destName string, destConfig map[string]inter
 
 func getOAuthErrorJob(jobResponses []JobRespSchema) (JobRespSchema, bool) {
 	return lo.Find(jobResponses, func(item JobRespSchema) bool {
-		return lo.Contains([]string{oauth.AUTH_STATUS_INACTIVE, oauth.REFRESH_TOKEN}, item.AuthErrorCategory)
+		return lo.Contains([]string{common.AuthStatusInActive, common.CategoryRefreshToken}, item.AuthErrorCategory)
 	})
-}
-
-func setOAuthHeader(secretToken *oauth.AuthResponse, req *http.Request) error {
-	payload, marshalErr := jsonrs.Marshal(secretToken.Account)
-	if marshalErr != nil {
-		marshalFailErr := fmt.Sprintf("error while marshalling account secret information: %v", marshalErr)
-		pkgLogger.Errorf(marshalFailErr)
-		return errors.New(marshalFailErr)
-	}
-	req.Header.Set("X-Rudder-Dest-Info", string(payload))
-	return nil
-}
-
-func (m *APIManager) getOAuthDetail(destDetail *model.Destination, workspaceId string) (oauthDetail, error) {
-	id := oauth.GetAccountId(destDetail.Config, oauth.DeleteAccountIdKey)
-	if strings.TrimSpace(id) == "" {
-		return oauthDetail{}, fmt.Errorf("[%v] Delete account ID key (%v) is not present for destination: %v", destDetail.Name, oauth.DeleteAccountIdKey, destDetail.DestinationID)
-	}
-	tokenStatusCode, secretToken := m.OAuth.FetchToken(&oauth.RefreshTokenParams{
-		AccountId:   id,
-		WorkspaceId: workspaceId,
-		DestDefName: destDetail.Name,
-	})
-	if tokenStatusCode != http.StatusOK {
-		return oauthDetail{}, fmt.Errorf("[%s][FetchToken] Error in Token Fetch statusCode: %d\t error: %s", destDetail.Name, tokenStatusCode, secretToken.ErrorMessage)
-	}
-	return oauthDetail{
-		id:          id,
-		secretToken: secretToken,
-	}, nil
-}
-
-func (m *APIManager) inactivateAuthStatus(destination *model.Destination, job model.Job, oAuthDetail oauthDetail) (jobStatus model.JobStatus) {
-	dest := &backendconfig.DestinationT{
-		ID:     destination.DestinationID,
-		Config: destination.Config,
-		DestinationDefinition: backendconfig.DestinationDefinitionT{
-			Name:   destination.Name,
-			Config: destination.DestDefConfig,
-		},
-	}
-	_, resp := m.OAuth.AuthStatusToggle(&oauth.AuthStatusToggleParams{
-		Destination:     dest,
-		WorkspaceId:     job.WorkspaceID,
-		RudderAccountId: oAuthDetail.id,
-		AuthStatus:      oauth.AuthStatusInactive,
-	})
-	jobStatus.Status = model.JobStatusAborted
-	jobStatus.Error = errors.New(resp)
-	return jobStatus
-}
-
-func (m *APIManager) refreshOAuthToken(destination *model.Destination, job model.Job, oAuthDetail oauthDetail) error {
-	refTokenParams := &oauth.RefreshTokenParams{
-		Secret:      oAuthDetail.secretToken.Account.Secret,
-		WorkspaceId: job.WorkspaceID,
-		AccountId:   oAuthDetail.id,
-		DestDefName: destination.Name,
-	}
-	statusCode, refreshResponse := m.OAuth.RefreshToken(refTokenParams)
-	if statusCode != http.StatusOK {
-		if refreshResponse.Err == oauth.REF_TOKEN_INVALID_GRANT {
-			// authStatus should be made inactive
-			m.inactivateAuthStatus(destination, job, oAuthDetail)
-			return errors.New(refreshResponse.ErrorMessage)
-		}
-
-		var refreshRespErr string
-		if refreshResponse != nil {
-			refreshRespErr = refreshResponse.ErrorMessage
-		}
-		return fmt.Errorf("[%v] Failed to refresh token for destination in workspace(%v) & account(%v) with %v", destination.Name, job.WorkspaceID, oAuthDetail.id, refreshRespErr)
-	}
-	return nil
 }
 
 type PostResponseParams struct {
@@ -315,7 +214,6 @@ type PostResponseParams struct {
 	isOAuthEnabled           bool
 	currentOAuthRetryAttempt int
 	job                      model.Job
-	oAuthDetail              oauthDetail
 	responseBodyBytes        []byte
 	responseStatusCode       int
 }
@@ -334,23 +232,8 @@ func (m *APIManager) PostResponse(ctx context.Context, params PostResponseParams
 	if oauthErrorJob, ok := getOAuthErrorJob(jobResp); ok {
 		authErrorCategory = oauthErrorJob.AuthErrorCategory
 	}
-	// old oauth handling
-	if authErrorCategory != "" && params.isOAuthEnabled && !m.IsOAuthV2Enabled {
-		if authErrorCategory == oauth.AUTH_STATUS_INACTIVE {
-			return m.inactivateAuthStatus(&params.destination, params.job, params.oAuthDetail)
-		}
-		if authErrorCategory == oauth.REFRESH_TOKEN && params.currentOAuthRetryAttempt < m.MaxOAuthRefreshRetryAttempts {
-			if err := m.refreshOAuthToken(&params.destination, params.job, params.oAuthDetail); err != nil {
-				pkgLogger.Errorn("Error while refreshing authToken", obskit.Error(err))
-				return model.JobStatus{Status: model.JobStatusFailed, Error: err}
-			}
-			// retry the request
-			pkgLogger.Infon("[%v] Retrying deleteRequest job(id: %v) for the whole batch, RetryAttempt: %v", logger.NewStringField("destinationName", params.destination.Name), logger.NewIntField("jobId", int64(params.job.ID)), logger.NewIntField("retryAttempt", int64(params.currentOAuthRetryAttempt+1)))
-			return m.deleteWithRetry(ctx, params.job, params.destination, params.currentOAuthRetryAttempt+1)
-		}
-	}
 	// new oauth handling
-	if params.isOAuthEnabled && m.IsOAuthV2Enabled {
+	if params.isOAuthEnabled {
 		if authErrorCategory == common.CategoryRefreshToken {
 			// All the handling related to OAuth has been done(inside api.Client.Do() itself)!
 			// retry the request

--- a/regulation-worker/internal/delete/api/api.go
+++ b/regulation-worker/internal/delete/api/api.go
@@ -205,7 +205,7 @@ func mapJobToPayload(job model.Job, destName string, destConfig map[string]inter
 
 func getOAuthErrorJob(jobResponses []JobRespSchema) (JobRespSchema, bool) {
 	return lo.Find(jobResponses, func(item JobRespSchema) bool {
-		return lo.Contains([]string{common.AuthStatusInActive, common.CategoryRefreshToken}, item.AuthErrorCategory)
+		return lo.Contains([]string{common.CategoryAuthStatusInactive, common.CategoryRefreshToken}, item.AuthErrorCategory)
 	})
 }
 

--- a/regulation-worker/internal/delete/api/api_test.go
+++ b/regulation-worker/internal/delete/api/api_test.go
@@ -842,8 +842,7 @@ func TestOAuth(t *testing.T) {
 			status := api.Delete(ctx, tt.job, tt.dest)
 			require.Equal(t, tt.expectedDeleteStatus.Status, status.Status)
 			if tt.expectedDeleteStatus.Status != model.JobStatusComplete {
-				exp := tt.expectedDeleteStatus.Error.Error()
-				exp = tt.expectedDeleteStatus_OAuthV2.Error.Error()
+				exp := tt.expectedDeleteStatus_OAuthV2.Error.Error()
 				jobError := strings.Replace(exp, "__cfgBE_server__", cfgBeSrv.URL, 1)
 
 				require.Contains(t, strings.ToLower(status.Error.Error()), strings.ToLower(jobError))

--- a/regulation-worker/internal/delete/api/api_test.go
+++ b/regulation-worker/internal/delete/api/api_test.go
@@ -23,7 +23,6 @@ import (
 	mock_features "github.com/rudderlabs/rudder-server/mocks/services/transformer"
 	"github.com/rudderlabs/rudder-server/regulation-worker/internal/delete/api"
 	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
-	"github.com/rudderlabs/rudder-server/services/oauth"
 	"github.com/rudderlabs/rudder-server/services/transformer"
 	testutils "github.com/rudderlabs/rudder-server/utils/tests"
 	"github.com/rudderlabs/rudder-server/utils/types/deployment"
@@ -650,7 +649,7 @@ var oauthTests = []oauthTestCases{
 		deleteResponses: []deleteResponseParams{
 			{
 				status:      400,
-				jobResponse: fmt.Sprintf(`[{"status":"failed","authErrorCategory": "%v", "error": "User does not have sufficient permissions"}]`, oauth.AUTH_STATUS_INACTIVE),
+				jobResponse: fmt.Sprintf(`[{"status":"failed","authErrorCategory": "%v", "error": "User does not have sufficient permissions"}]`, common.AuthStatusInActive),
 			},
 		},
 		cpResponses: []testutils.CpResponseParams{
@@ -697,7 +696,7 @@ var oauthTests = []oauthTestCases{
 		deleteResponses: []deleteResponseParams{
 			{
 				status:      400,
-				jobResponse: fmt.Sprintf(`[{"status":"failed","authErrorCategory": "%v", "error": "User does not have sufficient permissions"}]`, oauth.AUTH_STATUS_INACTIVE),
+				jobResponse: fmt.Sprintf(`[{"status":"failed","authErrorCategory": "%v", "error": "User does not have sufficient permissions"}]`, common.AuthStatusInActive),
 			},
 		},
 		cpResponses: []testutils.CpResponseParams{
@@ -821,8 +820,6 @@ func TestOAuth(t *testing.T) {
 				},
 			}
 
-			oauth.Init()
-			OAuth := oauth.NewOAuthErrorHandler(mockBackendConfig, oauth.WithRudderFlow(oauth.RudderFlow_Delete), oauth.WithOAuthClientTimeout(tt.oauthHttpClientTimeout))
 			if tt.isOAuthV2Enabled {
 				cache := oauthV2.NewCache()
 				oauthLock := rudderSync.NewPartitionRWLocker()
@@ -835,7 +832,7 @@ func TestOAuth(t *testing.T) {
 					Locker:    oauthLock,
 				}
 				cli = oauthv2_http.NewOAuthHttpClient(
-					cli, common.RudderFlow(oauth.RudderFlow_Delete),
+					cli, common.RudderFlowDelete,
 					&cache, mockBackendConfig,
 					api.GetAuthErrorCategoryFromResponse, &optionalArgs,
 				)
@@ -844,9 +841,7 @@ func TestOAuth(t *testing.T) {
 			api := api.APIManager{
 				Client:                       cli,
 				DestTransformURL:             svr.URL,
-				OAuth:                        OAuth,
 				MaxOAuthRefreshRetryAttempts: 1,
-				IsOAuthV2Enabled:             tt.isOAuthV2Enabled,
 			}
 
 			status := api.Delete(ctx, tt.job, tt.dest)

--- a/regulation-worker/internal/service/component_test.go
+++ b/regulation-worker/internal/service/component_test.go
@@ -1,0 +1,319 @@
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/backend-config"
+	"github.com/rudderlabs/rudder-server/regulation-worker/internal/client"
+	"github.com/rudderlabs/rudder-server/regulation-worker/internal/delete"
+	"github.com/rudderlabs/rudder-server/regulation-worker/internal/delete/api"
+	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
+	"github.com/rudderlabs/rudder-server/regulation-worker/internal/service"
+	oauthv2 "github.com/rudderlabs/rudder-server/services/oauth/v2"
+	"github.com/rudderlabs/rudder-server/services/oauth/v2/common"
+	"github.com/rudderlabs/rudder-server/services/oauth/v2/extensions"
+	oauthv2_http "github.com/rudderlabs/rudder-server/services/oauth/v2/http"
+	"github.com/rudderlabs/rudder-server/utils/types/deployment"
+)
+
+func runIntegrationTest(
+	t *testing.T,
+	testName string,
+	workspaceID, jobID, destinationID string,
+	destConfig *mockDestinationConfig,
+	configBackendServerFactory func(workspaceID, jobID, destinationID string) *httptest.Server,
+) {
+	t.Helper()
+
+	configBackendServer := configBackendServerFactory(workspaceID, jobID, destinationID)
+	transformerServer := createTransformerServer()
+	defer configBackendServer.Close()
+	defer transformerServer.Close()
+
+	t.Setenv("DEST_TRANSFORM_URL", transformerServer.URL)
+	t.Setenv("CONFIG_BACKEND_URL", configBackendServer.URL)
+	t.Setenv("CONFIG_BACKEND_TOKEN", "test-token")
+
+	backendconfig.Init()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockBackendConfig := mocksBackendConfig.NewMockBackendConfig(mockCtrl)
+	mockBackendConfig.EXPECT().AccessToken().AnyTimes().Return("test-token")
+	mockBackendConfig.EXPECT().Identity().AnyTimes().Return(&mockIdentifier{workspaceID: workspaceID})
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			IdleConnTimeout: 300 * time.Second,
+		},
+	}
+	cache := oauthv2.NewCache()
+	oauthLock := kitsync.NewPartitionRWLocker()
+	optionalArgs := oauthv2_http.HttpClientOptionalArgs{
+		Augmenter: extensions.HeaderAugmenter,
+		Locker:    oauthLock,
+	}
+	oauthClient := oauthv2_http.NewOAuthHttpClient(
+		httpClient, common.RudderFlowDelete,
+		&cache, mockBackendConfig,
+		api.GetAuthErrorCategoryFromResponse, &optionalArgs,
+	)
+
+	apiManager := &api.APIManager{
+		Client:                       oauthClient,
+		DestTransformURL:             transformerServer.URL,
+		MaxOAuthRefreshRetryAttempts: 1,
+		TransformerFeaturesService:   &mockTransformerFeaturesService{},
+	}
+
+	router := delete.NewRouter(apiManager)
+
+	jobSvc := &service.JobSvc{
+		API: &client.JobAPI{
+			Client:    &http.Client{},
+			URLPrefix: configBackendServer.URL,
+			Identity:  &mockIdentifier{workspaceID: workspaceID},
+		},
+		Deleter:           router,
+		DestDetail:        destConfig,
+		MaxFailedAttempts: 3,
+	}
+
+	ctx := context.Background()
+	err := jobSvc.JobSvc(ctx)
+
+	require.NoError(t, err, "%s should complete successfully", testName)
+}
+
+func TestOAuthV2Integration(t *testing.T) {
+	workspaceID := "test-workspace"
+	jobID := "1"
+	destinationID := "dest-123"
+	accountID := "account-123"
+	destConfig := &mockDestinationConfig{
+		destinations: map[string]model.Destination{
+			destinationID: {
+				DestinationID: destinationID,
+				Name:          "GA",
+				Config: map[string]interface{}{
+					"rudderDeleteAccountId": accountID,
+				},
+				DestDefConfig: map[string]interface{}{
+					"auth": map[string]interface{}{
+						"type":         "OAuth",
+						"rudderScopes": []interface{}{"delete"},
+					},
+				},
+			},
+		},
+	}
+	runIntegrationTest(
+		t,
+		"OAuthV2Integration",
+		workspaceID, jobID, destinationID,
+		destConfig,
+		createConfigBackendServer,
+	)
+}
+
+func TestNonOAuthIntegration(t *testing.T) {
+	workspaceID := "test-workspace"
+	jobID := "2"
+	destinationID := "dest-456"
+	destConfig := &mockDestinationConfig{
+		destinations: map[string]model.Destination{
+			destinationID: {
+				DestinationID: destinationID,
+				Name:          "GA",
+				Config:        map[string]interface{}{},
+				DestDefConfig: map[string]interface{}{
+					"auth": map[string]interface{}{
+						"type": "apiKey", // Not OAuth
+					},
+				},
+			},
+		},
+	}
+	runIntegrationTest(
+		t,
+		"NonOAuthIntegration",
+		workspaceID, jobID, destinationID,
+		destConfig,
+		createConfigBackendServerNonOAuth,
+	)
+}
+
+// Helper function to create config backend server
+func createConfigBackendServer(workspaceID, jobID, destinationID string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("Config Backend received request: %s %s\n", r.Method, r.URL.Path)
+
+		switch r.Method {
+		case "GET":
+			if r.URL.Path == fmt.Sprintf("/dataplane/workspaces/%s/regulations/workerJobs", workspaceID) {
+				jobResponse := fmt.Sprintf(`{
+					"jobId": "%s",
+					"workspaceId": "%s",
+					"destinationId": "%s",
+					"userAttributes": [
+						{
+							"userId": "user-1",
+							"email": "test@example.com"
+						}
+					]
+				}`, jobID, workspaceID, destinationID)
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(jobResponse))
+				return
+			}
+		case "PATCH":
+			if r.URL.Path == fmt.Sprintf("/dataplane/workspaces/%s/regulations/workerJobs/%s", workspaceID, jobID) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+		case "POST":
+			// Handle OAuth token requests
+			if r.URL.Path == fmt.Sprintf("/destination/workspaces/%s/accounts/account-123/token", workspaceID) {
+				tokenResponse := `{
+					"secret": {
+						"access_token": "test_access_token",
+						"refresh_token": "test_refresh_token",
+						"expires_in": 3600
+					}
+				}`
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tokenResponse))
+				return
+			}
+		}
+
+		// Default response for unmatched requests
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+// Helper function to create config backend server for non-OAuth test
+func createConfigBackendServerNonOAuth(workspaceID, jobID, destinationID string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("Config Backend (non-OAuth) received request: %s %s\n", r.Method, r.URL.Path)
+
+		switch r.Method {
+		case "GET":
+			if r.URL.Path == fmt.Sprintf("/dataplane/workspaces/%s/regulations/workerJobs", workspaceID) {
+				jobResponse := fmt.Sprintf(`{
+					"jobId": "%s",
+					"workspaceId": "%s",
+					"destinationId": "%s",
+					"userAttributes": [
+						{
+							"userId": "user-2",
+							"email": "non-oauth@example.com"
+						}
+					]
+				}`, jobID, workspaceID, destinationID)
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(jobResponse))
+				return
+			}
+		case "PATCH":
+			if r.URL.Path == fmt.Sprintf("/dataplane/workspaces/%s/regulations/workerJobs/%s", workspaceID, jobID) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+// Helper function to create transformer server
+func createTransformerServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("Transformer received request: %s %s\n", r.Method, r.URL.Path)
+
+		if r.Method == "POST" && r.URL.Path == "/deleteUsers" {
+			// Read and log the request body for debugging
+			body := make([]byte, 1024)
+			n, _ := r.Body.Read(body)
+			fmt.Printf("Transformer request body: %s\n", string(body[:n]))
+
+			response := `[{"status":"successful"}]`
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(response))
+			return
+		}
+
+		// Default response for unmatched requests
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+// Mock identifier for testing
+type mockIdentifier struct {
+	workspaceID string
+}
+
+func (m *mockIdentifier) ID() string                  { return m.workspaceID }
+func (m *mockIdentifier) BasicAuth() (string, string) { return "test-token", "" }
+func (m *mockIdentifier) Type() deployment.Type       { return deployment.DedicatedType }
+
+// Mock destination config for testing
+type mockDestinationConfig struct {
+	destinations map[string]model.Destination
+}
+
+func (m *mockDestinationConfig) GetDestDetails(destID string) (model.Destination, error) {
+	destination, ok := m.destinations[destID]
+	if !ok {
+		return model.Destination{}, model.ErrInvalidDestination
+	}
+	return destination, nil
+}
+
+// Mock transformer features service
+type mockTransformerFeaturesService struct{}
+
+func (m *mockTransformerFeaturesService) Wait() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+func (m *mockTransformerFeaturesService) Regulations() []string {
+	return []string{"BRAZE", "AM", "INTERCOM", "CLEVERTAP", "AF", "MP", "GA", "ITERABLE", "ENGAGE", "CUSTIFY", "SENDGRID", "SPRIG"}
+}
+
+func (m *mockTransformerFeaturesService) SourceTransformerVersion() string {
+	return "v2"
+}
+
+func (m *mockTransformerFeaturesService) RouterTransform(destType string) bool {
+	return false
+}
+
+func (m *mockTransformerFeaturesService) TransformerProxyVersion() string {
+	return "v0"
+}
+
+func (m *mockTransformerFeaturesService) SupportDestTransformCompactedPayloadV1() bool {
+	return false
+}


### PR DESCRIPTION
## What are the changes introduced in this PR?

This PR implements a comprehensive refactor of the regulation-worker's OAuth integration to:
1. **Remove legacy OAuth v1 implementation** - Eliminates dead code and simplifies the codebase
2. **Fix OAuth v2 framework compliance** - Ensures destination context is always attached for ALL destinations (OAuth + non-OAuth)
3. **Clean up unused dependencies** - Removes OAuth v1 imports and initialization code
4. **Update test coverage** - Removes OAuth v1 test scenarios and simplifies test structure

## What is the related Linear task?

[INT-3897: Fix OAuthv2 integrations and clean up OAuth v1 module from regulation](https://linear.app/rudderstack/issue/INT-3897/fix-oauthv2-integrations-and-clean-up-oauth-v1-module-from-regulation)

## Please explain the objectives of your changes below

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes?

**Critical Bug Fix**: Previously, destination context was only attached to HTTP requests when `isOAuth && m.IsOAuthV2Enabled` conditions were met. This violated the OAuth 2.0 framework design where destination context should be passed for ALL destinations.

**Changes Made**:
- **Always attach destination context**: `req = req.WithContext(cntx.CtxWithDestInfo(req.Context(), dest))` now runs for all destinations
- **Remove OAuth v1 conditional logic**: Eliminated `isOAuth && m.IsOAuthV2Enabled` checks
- **Simplify OAuth v2 handling**: Removed complex conditional branching for OAuth v1 vs v2

**Reason**: The regulation-worker currently has no OAuth destinations, making all OAuth v1 code dead code. The OAuth v2 framework requires destination context for proper interceptor functionality.

### Any new dependencies introduced with this change?

**No new dependencies added**. This change removes dependencies:
- Removed `github.com/rudderlabs/rudder-server/services/oauth` import
- Removed OAuth v1 initialization and configuration

### Any new generic utility introduced or modified. Please explain the changes.

**No new utilities introduced**. Modified existing utilities:
- **Simplified HTTP client creation**: `createHTTPClient()` now always enables OAuth v2 interceptor
- **Updated error handling**: Removed OAuth v1 specific error categories and handling logic
- **Streamlined test utilities**: Removed OAuth v1 test setup and mock configurations

### Any technical or performance related pointers to consider with the change?

**Performance Improvements**:
- **Reduced memory footprint**: Removed unused OAuth v1 structs and functions
- **Simplified request flow**: Eliminated conditional branching in HTTP request handling
- **Cleaner dependency graph**: Removed unused OAuth v1 service dependencies

**Technical Considerations**:
- **Backward compatibility**: No breaking changes - regulation-worker still supports all existing destinations
- **Error handling**: OAuth v2 error handling remains intact for future OAuth destinations
- **Testing**: All existing functionality preserved, only dead code removed

@coderabbitai review

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [x] All related docs linked with the PR?
- [x] All changes manually tested?
- [x] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.
- [ ] Code follows the established patterns and conventions
- [ ] Error handling is appropriate and comprehensive
- [ ] Test coverage is adequate for the changes made
- [ ] Documentation is updated where necessary 