### PR TITLE
fix(warehouse): add mutex to mockStageFilesRepo to prevent data race in tests (WAR-960

### DIFF
--- a/warehouse/internal/loadfiles/mock_stagefile_repo_test.go
+++ b/warehouse/internal/loadfiles/mock_stagefile_repo_test.go
@@ -2,6 +2,7 @@ package loadfiles_test
 
 import (
 	"context"
+	"sync"
 
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
 	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
@@ -9,9 +10,13 @@ import (
 
 type mockStageFilesRepo struct {
 	store map[int64]model.StagingFile
+	mu    sync.Mutex
 }
 
 func (m *mockStageFilesRepo) SetStatuses(_ context.Context, ids []int64, status string) (err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.store == nil {
 		m.store = make(map[int64]model.StagingFile)
 	}
@@ -27,6 +32,9 @@ func (m *mockStageFilesRepo) SetStatuses(_ context.Context, ids []int64, status 
 }
 
 func (m *mockStageFilesRepo) SetErrorStatus(_ context.Context, stagingFileID int64, stageFileErr error) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.store[stagingFileID] = model.StagingFile{
 		ID:     stagingFileID,
 		Status: warehouseutils.StagingFileFailedState,


### PR DESCRIPTION
# Description

This PR fixes a data race detected during test execution in the warehouse/internal/loadfiles package. The mockStageFilesRepo used in tests is now protected with a sync.Mutex to ensure safe concurrent access to the internal store map. This resolves the race condition observed in TestV2CreateLoadFiles/mixed_staging_files.

## Linear Ticket

[WAR-960: race detection during test code execution](https://linear.app/rudderstack/issue/WAR-960/race-detection-during-test-code-execution)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.