### PR TITLE
fix: dangling connection start time not being logged properly

### DIFF
--- a/router/transformer/transformer_proxy_adapter_test.go
+++ b/router/transformer/transformer_proxy_adapter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/logger/mock_logger"
@@ -326,6 +327,7 @@ func TestV1Adapter(t *testing.T) {
 }
 
 func Test_getTransformerProxyURL_env_priority(t *testing.T) {
+	config.Reset()
 	t.Setenv("DELIVERY_TRANSFORMER_URL", "http://proxy:1234")
 	t.Setenv("DEST_TRANSFORM_URL", "http://dest:5678")
 	url, err := getTransformerProxyURL("v0", "TestDest")
@@ -334,6 +336,7 @@ func Test_getTransformerProxyURL_env_priority(t *testing.T) {
 }
 
 func Test_getTransformerProxyURL_only_dest_transform(t *testing.T) {
+	config.Reset()
 	t.Setenv("DELIVERY_TRANSFORMER_URL", "")
 	t.Setenv("DEST_TRANSFORM_URL", "http://dest:5678")
 	url, err := getTransformerProxyURL("v1", "TestDest")
@@ -342,6 +345,7 @@ func Test_getTransformerProxyURL_only_dest_transform(t *testing.T) {
 }
 
 func Test_getTransformerProxyURL_only_transformer_proxy(t *testing.T) {
+	config.Reset()
 	t.Setenv("DELIVERY_TRANSFORMER_URL", "http://proxy:1234")
 	t.Setenv("DEST_TRANSFORM_URL", "")
 	url, err := getTransformerProxyURL("v0", "TestDest")
@@ -350,6 +354,7 @@ func Test_getTransformerProxyURL_only_transformer_proxy(t *testing.T) {
 }
 
 func Test_getTransformerProxyURL_default(t *testing.T) {
+	config.Reset()
 	t.Setenv("DELIVERY_TRANSFORMER_URL", "")
 	t.Setenv("DEST_TRANSFORM_URL", "")
 	url, err := getTransformerProxyURL("v1", "TestDest")

--- a/services/validators/envValidator.go
+++ b/services/validators/envValidator.go
@@ -61,7 +61,7 @@ func killDanglingDBConnections(db *sql.DB) error {
 
 	type danglingConnRow struct {
 		pid           int
-		queryStart    *string
+		queryStart    sql.NullString
 		waitEventType string
 		waitEvent     string
 		state         string


### PR DESCRIPTION
# Description
Using `sql.NullString` instead of a pointer to a `string`, so that value is being printed properly
```
dangling connection #37: {pid:2850595 queryStart:0x40005e8040 waitEventType:Client waitEvent:ClientRead state:active query:COPY "gw_job_status_47132" ("job_id", "job_state", "attempt", "exec_time", "retry_time", "error_code", "error_response", "parameters") FROM STDIN terminated:true}
```

resolves PIPE-2221

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
