### PR TITLE
fix(router): worker's batch timeout is getting resetted after new job arrival

### DIFF
--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -204,7 +204,7 @@ func (rt *Handle) Setup(
 	rt.limiter.stats.pickup = partition.NewStats()
 
 	rt.limiter.transform = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "rt_transform",
-		getReloadableRouterConfigInt("Limiter.transform.limit", rt.destType, 200),
+		getReloadableRouterConfigInt("Limiter.transform.limit", rt.destType, 1024),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDurationVar(1, time.Second, getRouterConfigKeys("Limiter.transform.dynamicPeriod", destType)...)),
 		kitsync.WithLimiterTags(map[string]string{"destType": rt.destType}),


### PR DESCRIPTION
# Description

Regression introduced by #6114
After a new job arrives in the worker's queue, the worker's batch timeout is getting reset. This causes the following behaviour:
- For pipelines with high traffic: no significant effect
- For pipelines with low traffic: 
  - No significant effect, as long as events arrive infrequently, i.e. less than 1 event to each worker every 5sec
  - Processing stalls until the full batch gets filled, as long as events arrive more frequent than 5sec. Increased delivery times are observed by customers in such a case.


We are now resetting the timer only after we actually process a batch

## Linear Ticket

resolves PIPE-2260

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
