### PR TITLE
Fix.router batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.55.1](https://github.com/rudderlabs/rudder-server/compare/v1.55.0...v1.55.1) (2025-07-24)
+
+
+### Bug Fixes
+
+* **router:** worker's batch timeout is getting resetted after new job arrival ([#6167](https://github.com/rudderlabs/rudder-server/issues/6167)) ([5c7e8d4](https://github.com/rudderlabs/rudder-server/commit/5c7e8d419abd038da0b4326d3e7b74752cb45e30))
+
 ## [1.55.0](https://github.com/rudderlabs/rudder-server/compare/v1.53.0...v1.55.0) (2025-07-22)
 
 

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -204,7 +204,7 @@ func (rt *Handle) Setup(
 	rt.limiter.stats.pickup = partition.NewStats()
 
 	rt.limiter.transform = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "rt_transform",
-		getReloadableRouterConfigInt("Limiter.transform.limit", rt.destType, 200),
+		getReloadableRouterConfigInt("Limiter.transform.limit", rt.destType, 1024),
 		stats.Default,
 		kitsync.WithLimiterDynamicPeriod(config.GetDurationVar(1, time.Second, getRouterConfigKeys("Limiter.transform.dynamicPeriod", destType)...)),
 		kitsync.WithLimiterTags(map[string]string{"destType": rt.destType}),

--- a/router/worker.go
+++ b/router/worker.go
@@ -264,8 +264,8 @@ func (w *worker) workLoop() {
 					w.destinationJobs = w.transform(w.routerJobs)
 				}
 				w.processDestinationJobs()
-				resetjobsBatchTimeout()
 			}
+			resetjobsBatchTimeout()
 		}
 	}
 }


### PR DESCRIPTION
# Description

We need to reset the timer after it fires no matter if there are jobs or not, otherwise it will start firing always, blocking job processing

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
