### PR TITLE
refactor(router): separate worker loop batching logic from processing logic

### DIFF
--- a/router/router_test.go
+++ b/router/router_test.go
@@ -269,7 +269,7 @@ func TestBackoff(t *testing.T) {
 		}
 		workers := []*worker{{
 			logger:  logger.NOP,
-			input:   make(chan workerJob, 3),
+			inputCh: make(chan workerJob, 3),
 			barrier: barrier,
 		}}
 		t.Run("eventorder disabled", func(t *testing.T) {

--- a/router/worker.go
+++ b/router/worker.go
@@ -40,12 +40,10 @@ type worker struct {
 	rt     *Handle // handle to router
 	logger logger.Logger
 
-	input             chan workerJob      // the worker's input channel
+	inputCh chan workerJob // the worker's input channel
+
 	inputReservations int                 // number of slots reserved in the input channel
 	barrier           *eventorder.Barrier // barrier to ensure ordering of events
-
-	routerJobs      []types.RouterJobT      // slice to hold router jobs to send to destination transformer
-	destinationJobs []types.DestinationJobT // slice to hold destination jobs
 
 	deliveryTimeStat          stats.Measurement
 	routerDeliveryLatencyStat stats.Measurement
@@ -61,213 +59,177 @@ type workerJob struct {
 	drainReason string
 }
 
-func (w *worker) workLoop() {
-	jobsBatchTimeout := time.After(w.rt.reloadableConfig.jobsBatchTimeout.Load())
-	resetjobsBatchTimeout := func() {
-		jobsBatchTimeout = time.After(w.rt.reloadableConfig.jobsBatchTimeout.Load())
+// acceptWorkerJob accepts a worker job and returns a router job if batching/router transformation is enabled.
+//
+//   - If the job is aborted, it sends an aborted job status to responseQ.
+//   - If the job needs to wait due to event ordering, it sends a waiting job status to responseQ.
+//   - If no batching or router transformation is enabled, it processes the job immediately, otherwise it returns a router job for batching or transformation.
+func (w *worker) acceptWorkerJob(workerJob workerJob) *types.RouterJobT {
+	job := workerJob.job
+	userID := job.UserID
+	parameters := workerJob.parameters
+	abortReason := workerJob.drainReason
+	abort := abortReason != ""
+	abortTag := abortReason
+	errResponse := routerutils.EnhanceJSON(job.LastJobStatus.ErrorResponse, "reason", abortReason)
+	if abort { // send aborted job status to responseQ and continue
+		status := jobsdb.JobStatusT{
+			JobID:         job.JobID,
+			AttemptNum:    job.LastJobStatus.AttemptNum,
+			JobState:      jobsdb.Aborted.State,
+			ExecTime:      time.Now(),
+			RetryTime:     time.Now(),
+			ErrorCode:     routerutils.DRAIN_ERROR_CODE,
+			Parameters:    routerutils.EmptyPayload,
+			JobParameters: job.Parameters,
+			ErrorResponse: errResponse,
+			WorkspaceId:   job.WorkspaceId,
+		}
+		// Enhancing job parameter with the drain reason.
+		job.Parameters = routerutils.EnhanceJSON(job.Parameters, "stage", "router")
+		job.Parameters = routerutils.EnhanceJSON(job.Parameters, "reason", abortReason)
+		w.rt.responseQ <- workerJobStatus{
+			userID:     userID,
+			worker:     w,
+			job:        job,
+			status:     &status,
+			payload:    job.EventPayload,
+			parameters: *parameters,
+		}
+		stats.Default.NewTaggedStat(`drained_events`, stats.CountType, stats.Tags{
+			"destType":    w.rt.destType,
+			"destId":      parameters.DestinationID,
+			"module":      "router",
+			"reasons":     abortTag,
+			"workspaceId": job.WorkspaceId,
+		}).Count(1)
+		return nil
 	}
-	for {
-		select {
-		case message, hasMore := <-w.input:
-			if !hasMore {
-				if len(w.routerJobs) == 0 {
-					w.logger.Debugf("worker channel closed")
-					return
-				}
 
-				if w.rt.enableBatching {
-					w.destinationJobs = w.batchTransform(w.routerJobs)
-				} else {
-					w.destinationJobs = w.transform(w.routerJobs)
-				}
-				w.processDestinationJobs()
-				w.logger.Debugf("worker channel closed, processed %d jobs", len(w.routerJobs))
-				return
+	if w.rt.guaranteeUserEventOrder {
+		orderKey := eventorder.BarrierKey{
+			UserID:        userID,
+			DestinationID: parameters.DestinationID,
+			WorkspaceID:   job.WorkspaceId,
+		}
+		if wait, previousFailedJobID := w.barrier.Wait(orderKey, job.JobID); wait { // send waiting job status to responseQ and continue
+			previousFailedJobIDStr := "<nil>"
+			if previousFailedJobID != nil {
+				previousFailedJobIDStr = strconv.FormatInt(*previousFailedJobID, 10)
 			}
+			w.logger.Debugf("EventOrder: [%d] job %d of key %s must wait (previousFailedJobID: %s)",
+				w.id, job.JobID, orderKey, previousFailedJobIDStr,
+			)
 
-			w.logger.Debugf("performing checks to send payload")
-
-			job := message.job
-			userID := job.UserID
-			parameters := message.parameters
-			abortReason := message.drainReason
-			abort := abortReason != ""
-			abortTag := abortReason
-			errResponse := routerutils.EnhanceJSON(job.LastJobStatus.ErrorResponse, "reason", abortReason)
-			if abort {
-				status := jobsdb.JobStatusT{
-					JobID:         job.JobID,
-					AttemptNum:    job.LastJobStatus.AttemptNum,
-					JobState:      jobsdb.Aborted.State,
-					ExecTime:      time.Now(),
-					RetryTime:     time.Now(),
-					ErrorCode:     routerutils.DRAIN_ERROR_CODE,
-					Parameters:    routerutils.EmptyPayload,
-					JobParameters: job.Parameters,
-					ErrorResponse: errResponse,
-					WorkspaceId:   job.WorkspaceId,
-				}
-				// Enhancing job parameter with the drain reason.
-				job.Parameters = routerutils.EnhanceJSON(job.Parameters, "stage", "router")
-				job.Parameters = routerutils.EnhanceJSON(job.Parameters, "reason", abortReason)
-				w.rt.responseQ <- workerJobStatus{
-					userID:     userID,
-					worker:     w,
-					job:        job,
-					status:     &status,
-					payload:    job.EventPayload,
-					parameters: *parameters,
-				}
-				stats.Default.NewTaggedStat(`drained_events`, stats.CountType, stats.Tags{
-					"destType":    w.rt.destType,
-					"destId":      parameters.DestinationID,
-					"module":      "router",
-					"reasons":     abortTag,
-					"workspaceId": job.WorkspaceId,
-				}).Count(1)
-				continue
+			// mark job as waiting if prev job from same user has not succeeded yet
+			w.logger.Debugf("skipping processing job for orderKey: %v since prev failed job exists, prev id %v, current id %v",
+				orderKey, previousFailedJobID, job.JobID,
+			)
+			resp := misc.UpdateJSONWithNewKeyVal(routerutils.EmptyPayload, "blocking_id", *previousFailedJobID)
+			resp = misc.UpdateJSONWithNewKeyVal(resp, "user_id", userID)
+			status := jobsdb.JobStatusT{
+				JobID:         job.JobID,
+				AttemptNum:    job.LastJobStatus.AttemptNum,
+				ExecTime:      time.Now(),
+				RetryTime:     time.Now(),
+				JobState:      jobsdb.Waiting.State,
+				ErrorResponse: resp, // check
+				Parameters:    routerutils.EmptyPayload,
+				JobParameters: job.Parameters,
+				WorkspaceId:   job.WorkspaceId,
 			}
-
-			if w.rt.guaranteeUserEventOrder {
-				orderKey := eventorder.BarrierKey{
-					UserID:        userID,
-					DestinationID: parameters.DestinationID,
-					WorkspaceID:   job.WorkspaceId,
-				}
-				if wait, previousFailedJobID := w.barrier.Wait(orderKey, job.JobID); wait {
-					previousFailedJobIDStr := "<nil>"
-					if previousFailedJobID != nil {
-						previousFailedJobIDStr = strconv.FormatInt(*previousFailedJobID, 10)
-					}
-					w.logger.Debugf("EventOrder: [%d] job %d of key %s must wait (previousFailedJobID: %s)",
-						w.id, job.JobID, orderKey, previousFailedJobIDStr,
-					)
-
-					// mark job as waiting if prev job from same user has not succeeded yet
-					w.logger.Debugf("skipping processing job for orderKey: %v since prev failed job exists, prev id %v, current id %v",
-						orderKey, previousFailedJobID, job.JobID,
-					)
-					resp := misc.UpdateJSONWithNewKeyVal(routerutils.EmptyPayload, "blocking_id", *previousFailedJobID)
-					resp = misc.UpdateJSONWithNewKeyVal(resp, "user_id", userID)
-					status := jobsdb.JobStatusT{
-						JobID:         job.JobID,
-						AttemptNum:    job.LastJobStatus.AttemptNum,
-						ExecTime:      time.Now(),
-						RetryTime:     time.Now(),
-						JobState:      jobsdb.Waiting.State,
-						ErrorResponse: resp, // check
-						Parameters:    routerutils.EmptyPayload,
-						JobParameters: job.Parameters,
-						WorkspaceId:   job.WorkspaceId,
-					}
-					w.rt.responseQ <- workerJobStatus{userID: userID, worker: w, job: job, status: &status, parameters: *parameters}
-					continue
-				}
-			}
-
-			firstAttemptedAt := gjson.GetBytes(job.LastJobStatus.ErrorResponse, "firstAttemptedAt").Str
-			dontBatch := gjson.GetBytes(job.LastJobStatus.ErrorResponse, "dontBatch").Bool()
-			jobMetadata := types.JobMetadataT{
-				UserID:             userID,
-				JobID:              job.JobID,
-				SourceID:           parameters.SourceID,
-				SourceCategory:     parameters.SourceCategory,
-				DestinationID:      parameters.DestinationID,
-				AttemptNum:         job.LastJobStatus.AttemptNum,
-				ReceivedAt:         parameters.ReceivedAt,
-				CreatedAt:          job.CreatedAt.Format(misc.RFC3339Milli),
-				FirstAttemptedAt:   firstAttemptedAt,
-				TransformAt:        parameters.TransformAt,
-				JobT:               job,
-				WorkspaceID:        parameters.WorkspaceID,
-				WorkerAssignedTime: message.assignedAt,
-				DontBatch:          dontBatch,
-				TraceParent:        parameters.TraceParent,
-				Parameters:         *parameters,
-			}
-
-			w.rt.destinationsMapMu.RLock()
-			batchDestination, destOK := w.rt.destinationsMap[parameters.DestinationID]
-			conn, connOK := w.rt.connectionsMap[types.SourceDest{
-				SourceID:      parameters.SourceID,
-				DestinationID: parameters.DestinationID,
-			}]
-			w.rt.destinationsMapMu.RUnlock()
-			if !destOK || (parameters.SourceCategory == "warehouse" && !connOK) {
-				continue
-			}
-			destination := batchDestination.Destination
-			connection := conn.Connection
-			oauthV2Enabled := w.rt.reloadableConfig.oauthV2Enabled.Load()
-			if w.rt.isOAuthDestination && !oauthV2Enabled {
-				rudderAccountID := oauth.GetAccountId(destination.Config, oauth.DeliveryAccountIdKey)
-
-				if routerutils.IsNotEmptyString(rudderAccountID) {
-					w.logger.Debugf(`[%s][FetchToken] Token Fetch Method to be called`, destination.DestinationDefinition.Name)
-					// Get Access Token Information to send it as part of the event
-					tokenStatusCode, accountSecretInfo := w.rt.oauth.FetchToken(&oauth.RefreshTokenParams{
-						AccountId:   rudderAccountID,
-						WorkspaceId: jobMetadata.WorkspaceID,
-						DestDefName: destination.DestinationDefinition.Name,
-					})
-					w.logger.Debugf(`[%s][FetchToken] Token Fetch Method finished (statusCode, value): (%v, %+v)`, destination.DestinationDefinition.Name, tokenStatusCode, accountSecretInfo)
-					if tokenStatusCode == http.StatusOK {
-						jobMetadata.Secret = accountSecretInfo.Account.Secret
-					} else {
-						w.logger.Errorf(`[%s][FetchToken] Token Fetch Method error (statusCode, error): (%d, %s)`, destination.DestinationDefinition.Name, tokenStatusCode, accountSecretInfo.Err)
-					}
-				}
-			}
-
-			if w.rt.enableBatching {
-				w.routerJobs = append(w.routerJobs, types.RouterJobT{
-					Message:     job.EventPayload,
-					JobMetadata: jobMetadata,
-					Destination: destination,
-					Connection:  connection,
-				})
-
-				if len(w.routerJobs) >= w.rt.reloadableConfig.noOfJobsToBatchInAWorker.Load() {
-					w.destinationJobs = w.batchTransform(w.routerJobs)
-					w.processDestinationJobs()
-					resetjobsBatchTimeout()
-				}
-			} else if parameters.TransformAt == "router" {
-				w.routerJobs = append(w.routerJobs, types.RouterJobT{
-					Message:     job.EventPayload,
-					JobMetadata: jobMetadata,
-					Destination: destination,
-					Connection:  connection,
-				})
-
-				if len(w.routerJobs) >= w.rt.reloadableConfig.noOfJobsToBatchInAWorker.Load() {
-					w.destinationJobs = w.transform(w.routerJobs)
-					w.processDestinationJobs()
-					resetjobsBatchTimeout()
-				}
-			} else {
-				w.destinationJobs = append(w.destinationJobs, types.DestinationJobT{
-					Message:          job.EventPayload,
-					Destination:      destination,
-					Connection:       connection,
-					JobMetadataArray: []types.JobMetadataT{jobMetadata},
-				})
-				w.processDestinationJobs()
-				resetjobsBatchTimeout()
-			}
-
-		case <-jobsBatchTimeout:
-			if len(w.routerJobs) > 0 {
-				if w.rt.enableBatching {
-					w.destinationJobs = w.batchTransform(w.routerJobs)
-				} else {
-					w.destinationJobs = w.transform(w.routerJobs)
-				}
-				w.processDestinationJobs()
-			}
-			resetjobsBatchTimeout()
+			w.rt.responseQ <- workerJobStatus{userID: userID, worker: w, job: job, status: &status, parameters: *parameters}
+			return nil
 		}
 	}
+
+	firstAttemptedAt := gjson.GetBytes(job.LastJobStatus.ErrorResponse, "firstAttemptedAt").Str
+	dontBatch := gjson.GetBytes(job.LastJobStatus.ErrorResponse, "dontBatch").Bool()
+	jobMetadata := types.JobMetadataT{
+		UserID:             userID,
+		JobID:              job.JobID,
+		SourceID:           parameters.SourceID,
+		SourceCategory:     parameters.SourceCategory,
+		DestinationID:      parameters.DestinationID,
+		AttemptNum:         job.LastJobStatus.AttemptNum,
+		ReceivedAt:         parameters.ReceivedAt,
+		CreatedAt:          job.CreatedAt.Format(misc.RFC3339Milli),
+		FirstAttemptedAt:   firstAttemptedAt,
+		TransformAt:        parameters.TransformAt,
+		JobT:               job,
+		WorkspaceID:        parameters.WorkspaceID,
+		WorkerAssignedTime: workerJob.assignedAt,
+		DontBatch:          dontBatch,
+		TraceParent:        parameters.TraceParent,
+		Parameters:         *parameters,
+	}
+
+	w.rt.destinationsMapMu.RLock()
+	batchDestination, destOK := w.rt.destinationsMap[parameters.DestinationID]
+	conn, connOK := w.rt.connectionsMap[types.SourceDest{
+		SourceID:      parameters.SourceID,
+		DestinationID: parameters.DestinationID,
+	}]
+	w.rt.destinationsMapMu.RUnlock()
+	if !destOK || (parameters.SourceCategory == "warehouse" && !connOK) { // destination or connection not found, skip processing
+		return nil
+	}
+	destination := batchDestination.Destination
+	connection := conn.Connection
+	oauthV2Enabled := w.rt.reloadableConfig.oauthV2Enabled.Load()
+	if w.rt.isOAuthDestination && !oauthV2Enabled {
+		rudderAccountID := oauth.GetAccountId(destination.Config, oauth.DeliveryAccountIdKey)
+
+		if routerutils.IsNotEmptyString(rudderAccountID) {
+			w.logger.Debugf(`[%s][FetchToken] Token Fetch Method to be called`, destination.DestinationDefinition.Name)
+			// Get Access Token Information to send it as part of the event
+			tokenStatusCode, accountSecretInfo := w.rt.oauth.FetchToken(&oauth.RefreshTokenParams{
+				AccountId:   rudderAccountID,
+				WorkspaceId: jobMetadata.WorkspaceID,
+				DestDefName: destination.DestinationDefinition.Name,
+			})
+			w.logger.Debugf(`[%s][FetchToken] Token Fetch Method finished (statusCode, value): (%v, %+v)`, destination.DestinationDefinition.Name, tokenStatusCode, accountSecretInfo)
+			if tokenStatusCode == http.StatusOK {
+				jobMetadata.Secret = accountSecretInfo.Account.Secret
+			} else {
+				w.logger.Errorf(`[%s][FetchToken] Token Fetch Method error (statusCode, error): (%d, %s)`, destination.DestinationDefinition.Name, tokenStatusCode, accountSecretInfo.Err)
+			}
+		}
+	}
+	if w.rt.enableBatching || parameters.TransformAt == "router" {
+		// add the job to the batch
+		return &types.RouterJobT{
+			Message:     job.EventPayload,
+			JobMetadata: jobMetadata,
+			Destination: destination,
+			Connection:  connection,
+		}
+	} else {
+		// then process the current single job
+		w.process([]types.DestinationJobT{
+			{
+				Message:          job.EventPayload,
+				Destination:      destination,
+				Connection:       connection,
+				JobMetadataArray: []types.JobMetadataT{jobMetadata},
+			},
+		})
+		return nil
+	}
+}
+
+func (w *worker) workLoop() {
+	wl := &workerBatchLoop{
+		jobsBatchTimeout:         w.rt.reloadableConfig.jobsBatchTimeout,
+		noOfJobsToBatchInAWorker: w.rt.reloadableConfig.noOfJobsToBatchInAWorker,
+		inputCh:                  w.inputCh,
+		enableBatching:           w.rt.enableBatching,
+		batchTransform:           w.batchTransform,
+		transform:                w.transform,
+		process:                  w.process,
+		acceptWorkerJob:          w.acceptWorkerJob,
+	}
+	wl.runLoop() // start the worker loop
 }
 
 func (w *worker) transformJobs(routerJobs []types.RouterJobT) []types.DestinationJobT {
@@ -385,378 +347,376 @@ func (w *worker) batchTransform(routerJobs []types.RouterJobT) []types.Destinati
 	return destinationJobs
 }
 
-func (w *worker) processDestinationJobs() {
-	// process limiter with dynamic priority
-	start := time.Now()
-	var attemptedRequests int
-	var attemptedJobs int
-	var successCount, errorCount int
-	limiter := w.rt.limiter.process
-	limiterStats := w.rt.limiter.stats.process
-	defer limiter.BeginWithPriority("", LimiterPriorityValueFrom(limiterStats.Score(w.partition), 100))()
-	defer func() {
-		limiterStats.Update(w.partition, time.Since(start), successCount+errorCount, errorCount)
-	}()
+func (w *worker) process(destinationJobs []types.DestinationJobT) {
+	func() { // wrap in a function for providing boundaries for defer statements
+		// process limiter with dynamic priority
+		start := time.Now()
+		var attemptedRequests int
+		var attemptedJobs int
+		var successCount, errorCount int
+		limiter := w.rt.limiter.process
+		limiterStats := w.rt.limiter.stats.process
+		defer limiter.BeginWithPriority("", LimiterPriorityValueFrom(limiterStats.Score(w.partition), 100))()
+		defer func() {
+			limiterStats.Update(w.partition, time.Since(start), successCount+errorCount, errorCount)
+		}()
 
-	ctx := context.TODO()
+		ctx := context.TODO()
 
-	transformerProxy := w.rt.reloadableConfig.transformerProxy.Load()
+		transformerProxy := w.rt.reloadableConfig.transformerProxy.Load()
 
-	traces := make(map[string]stats.TraceSpan)
-	defer func() {
-		for _, span := range traces {
-			span.End()
-		}
-	}()
+		traces := make(map[string]stats.TraceSpan)
+		defer func() {
+			for _, span := range traces {
+				span.End()
+			}
+		}()
 
-	for _, job := range w.destinationJobs {
-		for _, jobMetadata := range job.JobMetadataArray {
-			traceParent := jobMetadata.TraceParent
-			if traceParent != "" {
-				if _, ok := traces[traceParent]; !ok {
-					ctx := stats.InjectTraceParentIntoContext(context.Background(), traceParent)
-					_, span := w.rt.tracer.Start(ctx, "rt.process", stats.SpanKindInternal, stats.SpanWithTags(stats.Tags{
-						"workspaceId":   jobMetadata.WorkspaceID,
-						"sourceId":      jobMetadata.SourceID,
-						"destinationId": jobMetadata.DestinationID,
-						"destType":      w.rt.destType,
-					}))
-					traces[traceParent] = span
+		for _, job := range destinationJobs {
+			for _, jobMetadata := range job.JobMetadataArray {
+				traceParent := jobMetadata.TraceParent
+				if traceParent != "" {
+					if _, ok := traces[traceParent]; !ok {
+						ctx := stats.InjectTraceParentIntoContext(context.Background(), traceParent)
+						_, span := w.rt.tracer.Start(ctx, "rt.process", stats.SpanKindInternal, stats.SpanWithTags(stats.Tags{
+							"workspaceId":   jobMetadata.WorkspaceID,
+							"sourceId":      jobMetadata.SourceID,
+							"destinationId": jobMetadata.DestinationID,
+							"destType":      w.rt.destType,
+						}))
+						traces[traceParent] = span
+					}
+				} else {
+					w.rt.logger.Debugn("traceParent is empty during router process", logger.NewIntField("jobId", jobMetadata.JobID))
 				}
-			} else {
-				w.rt.logger.Debugn("traceParent is empty during router process", logger.NewIntField("jobId", jobMetadata.JobID))
 			}
 		}
-	}
 
-	var respContentType string
+		var respContentType string
 
-	/*
-		Batch
-		[u1e1, u2e1, u1e2, u2e2, u1e3, u2e3]
-		[b1, b2, b3]
-		b1 will send if success
-		b2 will send if b2 failed then will drop b3
+		/*
+			Batch
+			[u1e1, u2e1, u1e2, u2e2, u1e3, u2e3]
+			[b1, b2, b3]
+			b1 will send if success
+			b2 will send if b2 failed then will drop b3
 
-		Router transform
-		[u1e1, u2e1, u1e2, u2e2, u1e3, u2e3]
-		200, 200, 500, 200, 200, 200
+			Router transform
+			[u1e1, u2e1, u1e2, u2e2, u1e3, u2e3]
+			200, 200, 500, 200, 200, 200
 
-		Case 1:
-		u1e1 will send - success
-		u2e1 will send - success
-		u1e2 will drop because transformer gave 500
-		u2e2 will send - success
-		u1e3 should be dropped because u1e2 should be retried
-		u2e3 will send
+			Case 1:
+			u1e1 will send - success
+			u2e1 will send - success
+			u1e2 will drop because transformer gave 500
+			u2e2 will send - success
+			u1e3 should be dropped because u1e2 should be retried
+			u2e3 will send
 
-		Case 2:
-		u1e1 will send - success
-		u2e1 will send - failed 5xx
-		u1e2 will send
-		u2e2 will drop - because request to destination failed with 5xx
-		u1e3 will send
-		u2e3 will drop - because request to destination failed with 5xx
+			Case 2:
+			u1e1 will send - success
+			u2e1 will send - failed 5xx
+			u1e2 will send
+			u2e2 will drop - because request to destination failed with 5xx
+			u1e3 will send
+			u2e3 will drop - because request to destination failed with 5xx
 
-		Case 3:
-		u1e1 will send - success
-		u2e1 will send - failed 4xx
-		u1e2 will send
-		u2e2 will send - because previous job is aborted
-		u1e3 will send
-		u2e3 will send
-	*/
+			Case 3:
+			u1e1 will send - success
+			u2e1 will send - failed 4xx
+			u1e2 will send
+			u2e2 will send - because previous job is aborted
+			u1e3 will send
+			u2e3 will send
+		*/
 
-	failedJobOrderKeys := make(map[eventorder.BarrierKey]struct{})
-	var routerJobResponses []*JobResponse
+		failedJobOrderKeys := make(map[eventorder.BarrierKey]struct{})
+		var routerJobResponses []*JobResponse
 
-	sort.Slice(w.destinationJobs, func(i, j int) bool {
-		return w.destinationJobs[i].MinJobID() < w.destinationJobs[j].MinJobID()
-	})
+		sort.Slice(destinationJobs, func(i, j int) bool {
+			return destinationJobs[i].MinJobID() < destinationJobs[j].MinJobID()
+		})
 
-	dontBatchDirectives := make(map[int64]bool)
+		dontBatchDirectives := make(map[int64]bool)
 
-	for _, destinationJob := range w.destinationJobs {
-		var respStatusCodes map[int64]int
-		var respBodys map[int64]string
+		for _, destinationJob := range destinationJobs {
+			var respStatusCodes map[int64]int
+			var respBodys map[int64]string
 
-		var errorAt string
-		if destinationJob.StatusCode == 200 || destinationJob.StatusCode == 0 {
-			if w.canSendJobToDestination(failedJobOrderKeys, &destinationJob) {
-				diagnosisStartTime := time.Now()
-				destinationID := destinationJob.JobMetadataArray[0].DestinationID
-				transformAt := destinationJob.JobMetadataArray[0].TransformAt
+			var errorAt string
+			if destinationJob.StatusCode == 200 || destinationJob.StatusCode == 0 {
+				if w.canSendJobToDestination(failedJobOrderKeys, &destinationJob) {
+					diagnosisStartTime := time.Now()
+					destinationID := destinationJob.JobMetadataArray[0].DestinationID
+					transformAt := destinationJob.JobMetadataArray[0].TransformAt
 
-				// START: request to destination endpoint
-				workspaceID := destinationJob.JobMetadataArray[0].JobT.WorkspaceId
-				deliveryLatencyStat := stats.Default.NewTaggedStat("delivery_latency", stats.TimerType, stats.Tags{
-					"module":      "router",
-					"destType":    w.rt.destType,
-					"destination": misc.GetTagName(destinationJob.Destination.ID, destinationJob.Destination.Name),
-					"workspaceId": workspaceID,
-				})
-				startedAt := time.Now()
+					// START: request to destination endpoint
+					workspaceID := destinationJob.JobMetadataArray[0].JobT.WorkspaceId
+					deliveryLatencyStat := stats.Default.NewTaggedStat("delivery_latency", stats.TimerType, stats.Tags{
+						"module":      "router",
+						"destType":    w.rt.destType,
+						"destination": misc.GetTagName(destinationJob.Destination.ID, destinationJob.Destination.Name),
+						"workspaceId": workspaceID,
+					})
+					startedAt := time.Now()
 
-				if w.latestAssignedTime != destinationJob.JobMetadataArray[0].WorkerAssignedTime {
-					w.latestAssignedTime = destinationJob.JobMetadataArray[0].WorkerAssignedTime
-					w.processingStartTime = time.Now()
-				}
-				// TODO: remove trackStuckDelivery once we verify it is not needed,
-				//			router_delivery_exceeded_timeout -> goes to zero
-				ch := w.trackStuckDelivery()
-
-				if w.rt.customDestinationManager != nil {
-					for _, destinationJobMetadata := range destinationJob.JobMetadataArray {
-						if destinationID != destinationJobMetadata.DestinationID {
-							panic(fmt.Errorf("different destinations are grouped together"))
-						}
+					if w.latestAssignedTime != destinationJob.JobMetadataArray[0].WorkerAssignedTime {
+						w.latestAssignedTime = destinationJob.JobMetadataArray[0].WorkerAssignedTime
+						w.processingStartTime = time.Now()
 					}
-					attemptedRequests++
-					attemptedJobs += len(destinationJob.JobMetadataArray)
-					respStatusCode, respBody := w.rt.customDestinationManager.SendData(destinationJob.Message, destinationID)
-					respStatusCodes, respBodys = w.prepareResponsesForJobs(&destinationJob, respStatusCode, respBody)
-					errorAt = routerutils.ERROR_AT_CUST
-				} else {
-					result, err := getIterableStruct(destinationJob.Message, transformAt)
-					if err != nil {
-						errorAt = routerutils.ERROR_AT_TF
-						respStatusCode, respBody := types.RouterUnMarshalErrorCode, fmt.Errorf("transformer response unmarshal error: %w", err).Error()
-						jobIDs := lo.Map(destinationJob.JobMetadataArray, func(jobMetadata types.JobMetadataT, _ int) int64 {
-							return jobMetadata.JobID
-						})
-						// limiting the log to print 10KB of transformed payload
-						truncatedMessage := misc.TruncateStr(string(destinationJob.Message), int(10*bytesize.KB))
-						w.logger.Errorw("transformer response unmarshal error", "message", truncatedMessage, "jobIDs", jobIDs)
+					// TODO: remove trackStuckDelivery once we verify it is not needed,
+					//			router_delivery_exceeded_timeout -> goes to zero
+					ch := w.trackStuckDelivery()
+
+					if w.rt.customDestinationManager != nil {
+						for _, destinationJobMetadata := range destinationJob.JobMetadataArray {
+							if destinationID != destinationJobMetadata.DestinationID {
+								panic(fmt.Errorf("different destinations are grouped together"))
+							}
+						}
+						attemptedRequests++
+						attemptedJobs += len(destinationJob.JobMetadataArray)
+						respStatusCode, respBody := w.rt.customDestinationManager.SendData(destinationJob.Message, destinationID)
 						respStatusCodes, respBodys = w.prepareResponsesForJobs(&destinationJob, respStatusCode, respBody)
+						errorAt = routerutils.ERROR_AT_CUST
 					} else {
-						var respStatusCode int
-						var respBodyTemp string
-						var respBodyTemps map[int64]string
-						respBodyArr := make([]string, 0)
-						respBodyArrs := make([]map[int64]string, 0)
-						for i, val := range result {
-
-							w.logger.Debugf(`responseTransform status :%v, %s`, w.rt.reloadableConfig.transformerProxy, w.rt.destType)
-							errorAt = routerutils.ERROR_AT_DEL
-							if transformerProxy {
-								attemptedRequests++
-								attemptedJobs += len(destinationJob.JobMetadataArray)
-								resp := w.proxyRequest(ctx, destinationJob, val)
-								for k, v := range resp.DontBatchDirectives {
-									dontBatchDirectives[k] = v
-								}
-								respStatusCodes, respBodyTemps, respContentType = resp.RespStatusCodes, resp.RespBodys, resp.RespContentType
-								// If this is the last iteration, use respStatusCodes & respBodyTemps as is
-								// If this is not the last iteration, mark all the jobs as failed.
-								if i < len(result)-1 && anyNonTerminalCode(respStatusCodes) {
-									for k := range respStatusCodes {
-										respStatusCodes[k] = http.StatusInternalServerError
-									}
-									respBodyArrs = []map[int64]string{respBodyTemps}
-									break
-								} else {
-									respBodyArrs = append(respBodyArrs, respBodyTemps)
-								}
-							} else {
-								sendCtx, cancel := context.WithTimeout(ctx, w.rt.netClientTimeout)
-								rdlTime := time.Now()
-								attemptedRequests++
-								attemptedJobs += len(destinationJob.JobMetadataArray)
-								resp := w.rt.netHandle.SendPost(sendCtx, val)
-								cancel()
-								respStatusCode, respBodyTemp, respContentType = resp.StatusCode, string(resp.ResponseBody), resp.ResponseContentType
-								w.routerDeliveryLatencyStat.SendTiming(time.Since(rdlTime))
-
-								if isSuccessStatus(respStatusCode) {
-									respBodyArr = append(respBodyArr, respBodyTemp)
-								} else {
-									respBodyArr = []string{respBodyTemp}
-									break
-								}
-							}
-						}
-
-						if transformerProxy {
-							// respStatusCodes are already populated. Prepare respBodys from respBodyArrs
-							if len(respBodyArrs) == 0 { // Never the case
-								continue
-							} else {
-								respBodys = consolidateRespBodys(respBodyArrs)
-							}
-
-							// Are these useful?
-							stats.Default.NewTaggedStat("transformer_proxy.input_events_count", stats.CountType, stats.Tags{
-								"destType":      w.rt.destType,
-								"destinationId": destinationJob.Destination.ID,
-								"workspace":     workspaceID,
-								"workspaceId":   workspaceID,
-							}).Count(len(result))
-
-							w.logger.Debugf(`[TransformerProxy] (Dest-%v) Input Router Events: %v, Out router events: %v`, w.rt.destType,
-								len(result),
-								len(respBodyArr),
-							)
-
-							stats.Default.NewTaggedStat("transformer_proxy.output_events_count", stats.CountType, stats.Tags{
-								"destType":      w.rt.destType,
-								"destinationId": destinationJob.Destination.ID,
-								"workspace":     workspaceID,
-								"workspaceId":   workspaceID,
-							}).Count(len(respBodyArrs))
-						} else {
-							respBody := strings.Join(respBodyArr, " ")
+						result, err := getIterableStruct(destinationJob.Message, transformAt)
+						if err != nil {
+							errorAt = routerutils.ERROR_AT_TF
+							respStatusCode, respBody := types.RouterUnMarshalErrorCode, fmt.Errorf("transformer response unmarshal error: %w", err).Error()
+							jobIDs := lo.Map(destinationJob.JobMetadataArray, func(jobMetadata types.JobMetadataT, _ int) int64 {
+								return jobMetadata.JobID
+							})
+							// limiting the log to print 10KB of transformed payload
+							truncatedMessage := misc.TruncateStr(string(destinationJob.Message), int(10*bytesize.KB))
+							w.logger.Errorw("transformer response unmarshal error", "message", truncatedMessage, "jobIDs", jobIDs)
 							respStatusCodes, respBodys = w.prepareResponsesForJobs(&destinationJob, respStatusCode, respBody)
+						} else {
+							var respStatusCode int
+							var respBodyTemp string
+							var respBodyTemps map[int64]string
+							respBodyArr := make([]string, 0)
+							respBodyArrs := make([]map[int64]string, 0)
+							for i, val := range result {
+
+								w.logger.Debugf(`responseTransform status :%v, %s`, w.rt.reloadableConfig.transformerProxy, w.rt.destType)
+								errorAt = routerutils.ERROR_AT_DEL
+								if transformerProxy {
+									attemptedRequests++
+									attemptedJobs += len(destinationJob.JobMetadataArray)
+									resp := w.proxyRequest(ctx, destinationJob, val)
+									for k, v := range resp.DontBatchDirectives {
+										dontBatchDirectives[k] = v
+									}
+									respStatusCodes, respBodyTemps, respContentType = resp.RespStatusCodes, resp.RespBodys, resp.RespContentType
+									// If this is the last iteration, use respStatusCodes & respBodyTemps as is
+									// If this is not the last iteration, mark all the jobs as failed.
+									if i < len(result)-1 && anyNonTerminalCode(respStatusCodes) {
+										for k := range respStatusCodes {
+											respStatusCodes[k] = http.StatusInternalServerError
+										}
+										respBodyArrs = []map[int64]string{respBodyTemps}
+										break
+									} else {
+										respBodyArrs = append(respBodyArrs, respBodyTemps)
+									}
+								} else {
+									sendCtx, cancel := context.WithTimeout(ctx, w.rt.netClientTimeout)
+									rdlTime := time.Now()
+									attemptedRequests++
+									attemptedJobs += len(destinationJob.JobMetadataArray)
+									resp := w.rt.netHandle.SendPost(sendCtx, val)
+									cancel()
+									respStatusCode, respBodyTemp, respContentType = resp.StatusCode, string(resp.ResponseBody), resp.ResponseContentType
+									w.routerDeliveryLatencyStat.SendTiming(time.Since(rdlTime))
+
+									if isSuccessStatus(respStatusCode) {
+										respBodyArr = append(respBodyArr, respBodyTemp)
+									} else {
+										respBodyArr = []string{respBodyTemp}
+										break
+									}
+								}
+							}
+
+							if transformerProxy {
+								// respStatusCodes are already populated. Prepare respBodys from respBodyArrs
+								if len(respBodyArrs) == 0 { // Never the case
+									continue
+								} else {
+									respBodys = consolidateRespBodys(respBodyArrs)
+								}
+
+								// Are these useful?
+								stats.Default.NewTaggedStat("transformer_proxy.input_events_count", stats.CountType, stats.Tags{
+									"destType":      w.rt.destType,
+									"destinationId": destinationJob.Destination.ID,
+									"workspace":     workspaceID,
+									"workspaceId":   workspaceID,
+								}).Count(len(result))
+
+								w.logger.Debugf(`[TransformerProxy] (Dest-%v) Input Router Events: %v, Out router events: %v`, w.rt.destType,
+									len(result),
+									len(respBodyArr),
+								)
+
+								stats.Default.NewTaggedStat("transformer_proxy.output_events_count", stats.CountType, stats.Tags{
+									"destType":      w.rt.destType,
+									"destinationId": destinationJob.Destination.ID,
+									"workspace":     workspaceID,
+									"workspaceId":   workspaceID,
+								}).Count(len(respBodyArrs))
+							} else {
+								respBody := strings.Join(respBodyArr, " ")
+								respStatusCodes, respBodys = w.prepareResponsesForJobs(&destinationJob, respStatusCode, respBody)
+							}
+							stats.Default.NewTaggedStat("router_delivery_payload_size_bytes", stats.HistogramType, stats.Tags{
+								"destType":      w.rt.destType,
+								"workspaceID":   destinationJob.JobMetadataArray[0].WorkspaceID,
+								"destinationID": destinationJob.JobMetadataArray[0].DestinationID,
+							}).Observe(float64(len(destinationJob.Message)))
 						}
-						stats.Default.NewTaggedStat("router_delivery_payload_size_bytes", stats.HistogramType, stats.Tags{
-							"destType":      w.rt.destType,
-							"workspaceID":   destinationJob.JobMetadataArray[0].WorkspaceID,
-							"destinationID": destinationJob.JobMetadataArray[0].DestinationID,
-						}).Observe(float64(len(destinationJob.Message)))
 					}
+					ch <- struct{}{}
+					timeTaken := time.Since(startedAt)
+
+					w.deliveryTimeStat.SendTiming(timeTaken)
+					deliveryLatencyStat.Since(startedAt)
+
+					// END: request to destination endpoint
+
+					w.updateReqMetrics(respStatusCodes, &diagnosisStartTime)
+				} else {
+					respStatusCode := http.StatusInternalServerError
+					var respBody string
+					if !w.rt.enableBatching {
+						respBody = "skipping sending to destination because previous job (of user) in batch failed."
+					}
+					respStatusCodes, respBodys = w.prepareResponsesForJobs(&destinationJob, respStatusCode, respBody)
+					errorAt = routerutils.ERROR_AT_TF
 				}
-				ch <- struct{}{}
-				timeTaken := time.Since(startedAt)
-
-				w.deliveryTimeStat.SendTiming(timeTaken)
-				deliveryLatencyStat.Since(startedAt)
-
-				// END: request to destination endpoint
-
-				w.updateReqMetrics(respStatusCodes, &diagnosisStartTime)
 			} else {
-				respStatusCode := http.StatusInternalServerError
-				var respBody string
-				if !w.rt.enableBatching {
-					respBody = "skipping sending to destination because previous job (of user) in batch failed."
+				respStatusCode := destinationJob.StatusCode
+				respBody := destinationJob.Error
+				switch destinationJob.StatusCode {
+				case utilTypes.FilterEventCode:
+					if respBody == "" {
+						respBody = "Event filtered"
+					}
+				case utilTypes.SuppressEventCode:
+					if respBody == "" {
+						respBody = "Event handled by transformer"
+					}
+				default:
+					errorAt = routerutils.ERROR_AT_TF
 				}
 				respStatusCodes, respBodys = w.prepareResponsesForJobs(&destinationJob, respStatusCode, respBody)
-				errorAt = routerutils.ERROR_AT_TF
 			}
-		} else {
-			respStatusCode := destinationJob.StatusCode
-			respBody := destinationJob.Error
-			switch destinationJob.StatusCode {
-			case utilTypes.FilterEventCode:
-				if respBody == "" {
-					respBody = "Event filtered"
-				}
-			case utilTypes.SuppressEventCode:
-				if respBody == "" {
-					respBody = "Event handled by transformer"
-				}
-			default:
-				errorAt = routerutils.ERROR_AT_TF
-			}
-			respStatusCodes, respBodys = w.prepareResponsesForJobs(&destinationJob, respStatusCode, respBody)
+
+			w.updateFailedJobOrderKeys(failedJobOrderKeys, &destinationJob, respStatusCodes)
+			routerJobResponses = append(routerJobResponses, w.prepareRouterJobResponses(destinationJob, respStatusCodes, respBodys, errorAt, transformerProxy)...)
 		}
 
-		w.updateFailedJobOrderKeys(failedJobOrderKeys, &destinationJob, respStatusCodes)
-		routerJobResponses = append(routerJobResponses, w.prepareRouterJobResponses(destinationJob, respStatusCodes, respBodys, errorAt, transformerProxy)...)
-	}
+		sort.Slice(routerJobResponses, func(i, j int) bool {
+			return routerJobResponses[i].jobID < routerJobResponses[j].jobID
+		})
 
-	sort.Slice(routerJobResponses, func(i, j int) bool {
-		return routerJobResponses[i].jobID < routerJobResponses[j].jobID
-	})
+		// Struct to hold unique users in the batch (worker.destinationJobs)
+		jobOrderKeyToJobIDMap := make(map[eventorder.BarrierKey]int64)
 
-	// Struct to hold unique users in the batch (worker.destinationJobs)
-	jobOrderKeyToJobIDMap := make(map[eventorder.BarrierKey]int64)
-
-	for _, routerJobResponse := range routerJobResponses {
-		destinationJobMetadata := routerJobResponse.destinationJobMetadata
-		destinationJob := routerJobResponse.destinationJob
-		attemptNum := destinationJobMetadata.AttemptNum
-		respStatusCode := routerJobResponse.respStatusCode
-		status := jobsdb.JobStatusT{
-			JobID:         destinationJobMetadata.JobID,
-			AttemptNum:    attemptNum,
-			ExecTime:      time.Now(),
-			RetryTime:     time.Now(),
-			Parameters:    routerutils.EmptyPayload,
-			JobParameters: destinationJobMetadata.JobT.Parameters,
-			WorkspaceId:   destinationJobMetadata.WorkspaceID,
-		}
-
-		routerJobResponse.status = &status
-
-		if !isJobTerminated(respStatusCode) {
-			orderKey := eventorder.BarrierKey{
-				UserID:        destinationJobMetadata.UserID,
-				DestinationID: destinationJobMetadata.DestinationID,
-				WorkspaceID:   destinationJobMetadata.WorkspaceID,
+		for _, routerJobResponse := range routerJobResponses {
+			destinationJobMetadata := routerJobResponse.destinationJobMetadata
+			destinationJob := routerJobResponse.destinationJob
+			attemptNum := destinationJobMetadata.AttemptNum
+			respStatusCode := routerJobResponse.respStatusCode
+			status := jobsdb.JobStatusT{
+				JobID:         destinationJobMetadata.JobID,
+				AttemptNum:    attemptNum,
+				ExecTime:      time.Now(),
+				RetryTime:     time.Now(),
+				Parameters:    routerutils.EmptyPayload,
+				JobParameters: destinationJobMetadata.JobT.Parameters,
+				WorkspaceId:   destinationJobMetadata.WorkspaceID,
 			}
-			if prevFailedJobID, ok := jobOrderKeyToJobIDMap[orderKey]; ok {
-				// This means more than two jobs of the same user are in the batch & the batch job is failed
-				// Only one job is marked failed and the rest are marked waiting
-				// Job order logic requires that at any point of time, we should have only one failed job per user
-				// This is introduced to ensure the above statement
-				resp := misc.UpdateJSONWithNewKeyVal(routerutils.EmptyPayload, "blocking_id", prevFailedJobID)
-				resp = misc.UpdateJSONWithNewKeyVal(resp, "user_id", destinationJobMetadata.UserID)
-				resp = misc.UpdateJSONWithNewKeyVal(resp, "moreinfo", "attempted to send in a batch")
 
-				status.JobState = jobsdb.Waiting.State
-				status.ErrorResponse = resp
-				w.rt.responseQ <- workerJobStatus{userID: destinationJobMetadata.UserID, worker: w, job: destinationJobMetadata.JobT, status: &status, statTags: destinationJob.StatTags, parameters: destinationJobMetadata.Parameters}
+			routerJobResponse.status = &status
+
+			if !isJobTerminated(respStatusCode) {
+				orderKey := eventorder.BarrierKey{
+					UserID:        destinationJobMetadata.UserID,
+					DestinationID: destinationJobMetadata.DestinationID,
+					WorkspaceID:   destinationJobMetadata.WorkspaceID,
+				}
+				if prevFailedJobID, ok := jobOrderKeyToJobIDMap[orderKey]; ok {
+					// This means more than two jobs of the same user are in the batch & the batch job is failed
+					// Only one job is marked failed and the rest are marked waiting
+					// Job order logic requires that at any point of time, we should have only one failed job per user
+					// This is introduced to ensure the above statement
+					resp := misc.UpdateJSONWithNewKeyVal(routerutils.EmptyPayload, "blocking_id", prevFailedJobID)
+					resp = misc.UpdateJSONWithNewKeyVal(resp, "user_id", destinationJobMetadata.UserID)
+					resp = misc.UpdateJSONWithNewKeyVal(resp, "moreinfo", "attempted to send in a batch")
+
+					status.JobState = jobsdb.Waiting.State
+					status.ErrorResponse = resp
+					w.rt.responseQ <- workerJobStatus{userID: destinationJobMetadata.UserID, worker: w, job: destinationJobMetadata.JobT, status: &status, statTags: destinationJob.StatTags, parameters: destinationJobMetadata.Parameters}
+					errorCount++
+					continue
+				}
+				jobOrderKeyToJobIDMap[orderKey] = destinationJobMetadata.JobID
+			}
+
+			trimmedResponse := string(lo.Slice([]byte(routerJobResponse.respBody), 0, int(10*bytesize.KB)))
+			status.AttemptNum++
+			status.ErrorResponse = routerutils.EnhanceJSON(routerutils.EmptyPayload, "response", trimmedResponse)
+			status.ErrorCode = strconv.Itoa(respStatusCode)
+
+			if isJobTerminated(respStatusCode) {
+				successCount++
+			} else {
 				errorCount++
-				continue
 			}
-			jobOrderKeyToJobIDMap[orderKey] = destinationJobMetadata.JobID
-		}
 
-		trimmedResponse := string(lo.Slice([]byte(routerJobResponse.respBody), 0, int(10*bytesize.KB)))
-		status.AttemptNum++
-		status.ErrorResponse = routerutils.EnhanceJSON(routerutils.EmptyPayload, "response", trimmedResponse)
-		status.ErrorCode = strconv.Itoa(respStatusCode)
-
-		if isJobTerminated(respStatusCode) {
-			successCount++
-		} else {
-			errorCount++
-		}
-
-		if transformerProxy {
-			dontBatch, ok := dontBatchDirectives[destinationJobMetadata.JobID]
-			if ok && dontBatch {
-				// Used to send this as a directive for transformer to not let this job batch with other jobs
-				status.ErrorResponse = misc.UpdateJSONWithNewKeyVal(status.ErrorResponse, "dontBatch", true)
-			}
-		}
-		w.postStatusOnResponseQ(respStatusCode, destinationJob, respContentType, destinationJobMetadata, &status, routerJobResponse.errorAt)
-
-		w.sendEventDeliveryStat(destinationJobMetadata, &status, &destinationJob.Destination)
-
-		w.sendRouterResponseCountStat(&status, &destinationJob.Destination, routerJobResponse.errorAt)
-	}
-
-	// NOTE: Sending live events to config backend after the status objects are built completely.
-	destLiveEventSentMap := make(map[*types.DestinationJobT]struct{})
-	for _, routerJobResponse := range routerJobResponses {
-		// Sending only one destination live event for every destinationJob
-		if _, ok := destLiveEventSentMap[routerJobResponse.destinationJob]; !ok {
-			payload := routerJobResponse.destinationJob.Message
-			if routerJobResponse.destinationJob.Message == nil {
-				payload = routerJobResponse.destinationJobMetadata.JobT.EventPayload
-			}
-			sourcesIDs := make([]string, 0)
-			for _, metadata := range routerJobResponse.destinationJob.JobMetadataArray {
-				if !slices.Contains(sourcesIDs, metadata.SourceID) {
-					sourcesIDs = append(sourcesIDs, metadata.SourceID)
+			if transformerProxy {
+				dontBatch, ok := dontBatchDirectives[destinationJobMetadata.JobID]
+				if ok && dontBatch {
+					// Used to send this as a directive for transformer to not let this job batch with other jobs
+					status.ErrorResponse = misc.UpdateJSONWithNewKeyVal(status.ErrorResponse, "dontBatch", true)
 				}
 			}
-			w.sendDestinationResponseToConfigBackend(payload, routerJobResponse.destinationJobMetadata, routerJobResponse.status, sourcesIDs)
-			destLiveEventSentMap[routerJobResponse.destinationJob] = struct{}{}
+			w.postStatusOnResponseQ(respStatusCode, destinationJob, respContentType, destinationJobMetadata, &status, routerJobResponse.errorAt)
+
+			w.sendEventDeliveryStat(destinationJobMetadata, &status, &destinationJob.Destination)
+
+			w.sendRouterResponseCountStat(&status, &destinationJob.Destination, routerJobResponse.errorAt)
 		}
-	}
 
-	// the following stat (in combination with the limiter's timer stats) are used to capture the process stage
-	// average latency and max processing capacity
-	w.rt.processJobsCountStat.Count(attemptedJobs)
-	w.rt.processJobsHistogramStat.Observe(float64(attemptedJobs))
-	w.rt.processRequestsCountStat.Count(attemptedRequests)
-	w.rt.processRequestsHistogramStat.Observe(float64(attemptedRequests))
+		// NOTE: Sending live events to config backend after the status objects are built completely.
+		destLiveEventSentMap := make(map[*types.DestinationJobT]struct{})
+		for _, routerJobResponse := range routerJobResponses {
+			// Sending only one destination live event for every destinationJob
+			if _, ok := destLiveEventSentMap[routerJobResponse.destinationJob]; !ok {
+				payload := routerJobResponse.destinationJob.Message
+				if routerJobResponse.destinationJob.Message == nil {
+					payload = routerJobResponse.destinationJobMetadata.JobT.EventPayload
+				}
+				sourcesIDs := make([]string, 0)
+				for _, metadata := range routerJobResponse.destinationJob.JobMetadataArray {
+					if !slices.Contains(sourcesIDs, metadata.SourceID) {
+						sourcesIDs = append(sourcesIDs, metadata.SourceID)
+					}
+				}
+				w.sendDestinationResponseToConfigBackend(payload, routerJobResponse.destinationJobMetadata, routerJobResponse.status, sourcesIDs)
+				destLiveEventSentMap[routerJobResponse.destinationJob] = struct{}{}
+			}
+		}
 
-	// routerJobs/destinationJobs are processed. Clearing the queues.
-	w.routerJobs = nil
-	w.destinationJobs = nil
+		// the following stat (in combination with the limiter's timer stats) are used to capture the process stage
+		// average latency and max processing capacity
+		w.rt.processJobsCountStat.Count(attemptedJobs)
+		w.rt.processJobsHistogramStat.Observe(float64(attemptedJobs))
+		w.rt.processRequestsCountStat.Count(attemptedRequests)
+		w.rt.processRequestsHistogramStat.Observe(float64(attemptedRequests))
+	}()
 }
 
 func consolidateRespBodys(respBodyArrs []map[int64]string) map[int64]string {
@@ -1180,7 +1140,7 @@ func (w *worker) sendDestinationResponseToConfigBackend(payload json.RawMessage,
 
 // AvailableSlots returns the number of available slots in the worker's input channel
 func (w *worker) AvailableSlots() int {
-	return cap(w.input) - len(w.input) - w.inputReservations
+	return cap(w.inputCh) - len(w.inputCh) - w.inputReservations
 }
 
 // Reserve tries to reserve a slot in the worker's input channel, if available
@@ -1202,7 +1162,7 @@ func (w *worker) releaseSlot() {
 // accept accepts a job into the worker's input channel
 func (w *worker) accept(wj workerJob) {
 	w.releaseSlot()
-	w.input <- wj
+	w.inputCh <- wj
 }
 
 func (w *worker) trackStuckDelivery() chan struct{} {

--- a/router/worker_batch_loop.go
+++ b/router/worker_batch_loop.go
@@ -1,0 +1,60 @@
+package router
+
+import (
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-server/router/types"
+)
+
+type workerBatchLoop struct {
+	jobsBatchTimeout         config.ValueLoader[time.Duration]                           // timeout for processing jobs in a batch
+	noOfJobsToBatchInAWorker config.ValueLoader[int]                                     // maximum number of jobs to batch in a worker before processing
+	inputCh                  chan workerJob                                              // channel to receive jobs for processing
+	enableBatching           bool                                                        // whether to enable batching of jobs
+	batchTransform           func(routerJobs []types.RouterJobT) []types.DestinationJobT // function to transform router jobs into destination jobs in batch mode
+	transform                func(routerJobs []types.RouterJobT) []types.DestinationJobT // function to transform router jobs into destination jobs in non-batch mode
+	process                  func(destinationJobs []types.DestinationJobT)               // function to process the transformed destination jobs
+	acceptWorkerJob          func(workerJob workerJob) *types.RouterJobT                 // function to accept a worker job and return a router job if applicable
+}
+
+// runLoop processes jobs from the input channel, batching them if it is enabled.
+func (wl *workerBatchLoop) runLoop() {
+	jobsBatchTimeout := time.After(wl.jobsBatchTimeout.Load())
+	var routerJobs []types.RouterJobT
+	doProcessRouterJobs := func() {
+		if len(routerJobs) > 0 {
+			var destinationJobs []types.DestinationJobT
+			if wl.enableBatching {
+				destinationJobs = wl.batchTransform(routerJobs)
+			} else {
+				destinationJobs = wl.transform(routerJobs)
+			}
+			wl.process(destinationJobs)
+			routerJobs = nil // reset routerJobs for the next batch
+		}
+		jobsBatchTimeout = time.After(wl.jobsBatchTimeout.Load()) // reset the timeout
+	}
+	for {
+		select {
+		case workerJob, ok := <-wl.inputCh:
+			if !ok {
+				doProcessRouterJobs() // process any remaining jobs in the batch
+				return                // input channel is closed, exit the loop
+			}
+			if !wl.enableBatching && workerJob.parameters.TransformAt != "router" && len(routerJobs) > 0 {
+				// process the current batch if batching is not enabled, transform for the current job is not at router and there are pending jobs in the batch
+				// (scenario where we are switching from router to processor transformation)
+				doProcessRouterJobs()
+			}
+			if routerJob := wl.acceptWorkerJob(workerJob); routerJob != nil {
+				routerJobs = append(routerJobs, *routerJob)
+				if wl.noOfJobsToBatchInAWorker.Load() <= len(routerJobs) {
+					doProcessRouterJobs() // process the batch if it reaches the limit
+				}
+			}
+		case <-jobsBatchTimeout:
+			doProcessRouterJobs() // process any remaining jobs in the batch
+		}
+	}
+}

--- a/router/worker_batch_loop_test.go
+++ b/router/worker_batch_loop_test.go
@@ -1,0 +1,524 @@
+package router
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/router/types"
+	routerutils "github.com/rudderlabs/rudder-server/router/utils"
+)
+
+func TestWorkerBatchLoop(t *testing.T) {
+	t.Run("no batching and no transform at router, acceptWorkerJob returning always nil", func(t *testing.T) {
+		// Setup
+		inputCh := make(chan workerJob, 10)
+		batchSize := 5
+
+		var processedJobs []types.DestinationJobT
+		var transformCalls [][]types.RouterJobT
+		var batchTransformCalls [][]types.RouterJobT
+		var mu sync.Mutex
+
+		wl := &workerBatchLoop{
+			jobsBatchTimeout:         config.SingleValueLoader(50 * time.Millisecond),
+			noOfJobsToBatchInAWorker: config.SingleValueLoader(batchSize),
+			inputCh:                  inputCh,
+			enableBatching:           false,
+			batchTransform: func(routerJobs []types.RouterJobT) []types.DestinationJobT {
+				mu.Lock()
+				defer mu.Unlock()
+				batchTransformCalls = append(batchTransformCalls, routerJobs)
+				return []types.DestinationJobT{}
+			},
+			transform: func(routerJobs []types.RouterJobT) []types.DestinationJobT {
+				mu.Lock()
+				defer mu.Unlock()
+				transformCalls = append(transformCalls, routerJobs)
+				return []types.DestinationJobT{}
+			},
+			process: func(destinationJobs []types.DestinationJobT) {
+				mu.Lock()
+				defer mu.Unlock()
+				processedJobs = append(processedJobs, destinationJobs...)
+			},
+			acceptWorkerJob: func(workerJob workerJob) *types.RouterJobT {
+				// Always return nil to simulate accepting no jobs
+				return nil
+			},
+		}
+
+		// Start the worker loop in a goroutine
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			wl.runLoop()
+		}()
+
+		// Send some jobs with transform_at != "router"
+		for i := range 3 {
+			job := &jobsdb.JobT{
+				JobID:  int64(i + 1),
+				UserID: "user1",
+			}
+			params := &routerutils.JobParameters{
+				TransformAt: "processor", // Not "router"
+			}
+			inputCh <- workerJob{job: job, parameters: params}
+		}
+
+		// Wait a bit to ensure jobs are processed and some timeouts are triggered too
+		time.Sleep(200 * time.Millisecond)
+
+		// Close the input channel to stop the loop
+		close(inputCh)
+
+		// Wait for the loop to finish
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("Worker loop did not finish in time")
+		}
+
+		// Verify results
+		mu.Lock()
+		defer mu.Unlock()
+
+		// Since acceptWorkerJob always returns nil, no router jobs should be created
+		// Therefore no transform/batchTransform calls should happen
+		assert.Empty(t, transformCalls, "No transform calls should happen when acceptWorkerJob returns nil")
+		assert.Empty(t, batchTransformCalls, "No batch transform calls should happen when acceptWorkerJob returns nil")
+		assert.Empty(t, processedJobs, "No jobs should be processed when acceptWorkerJob returns nil")
+	})
+
+	t.Run("no batching and transform at router, then switch to no router transform", func(t *testing.T) {
+		// Setup
+		inputCh := make(chan workerJob, 10)
+		batchSize := 5
+
+		var processedJobs []types.DestinationJobT
+		var transformCalls [][]types.RouterJobT
+		var batchTransformCalls [][]types.RouterJobT
+		var mu sync.Mutex
+
+		// Track how many jobs we've seen to control the behavior of acceptWorkerJob
+		jobCount := 0
+
+		wl := &workerBatchLoop{
+			jobsBatchTimeout:         config.SingleValueLoader(50 * time.Millisecond),
+			noOfJobsToBatchInAWorker: config.SingleValueLoader(batchSize),
+			inputCh:                  inputCh,
+			enableBatching:           false,
+			batchTransform: func(routerJobs []types.RouterJobT) []types.DestinationJobT {
+				mu.Lock()
+				defer mu.Unlock()
+				batchTransformCalls = append(batchTransformCalls, routerJobs)
+				// Create destination jobs from router jobs
+				var destJobs []types.DestinationJobT
+				for _, rj := range routerJobs {
+					destJobs = append(destJobs, types.DestinationJobT{
+						Message:     rj.Message,
+						Destination: rj.Destination,
+					})
+				}
+				return destJobs
+			},
+			transform: func(routerJobs []types.RouterJobT) []types.DestinationJobT {
+				mu.Lock()
+				defer mu.Unlock()
+				transformCalls = append(transformCalls, routerJobs)
+				// Create destination jobs from router jobs
+				var destJobs []types.DestinationJobT
+				for _, rj := range routerJobs {
+					destJobs = append(destJobs, types.DestinationJobT{
+						Message:     rj.Message,
+						Destination: rj.Destination,
+					})
+				}
+				return destJobs
+			},
+			process: func(destinationJobs []types.DestinationJobT) {
+				mu.Lock()
+				defer mu.Unlock()
+				processedJobs = append(processedJobs, destinationJobs...)
+			},
+			acceptWorkerJob: func(workerJob workerJob) *types.RouterJobT {
+				if workerJob.parameters.TransformAt == "router" {
+					return &types.RouterJobT{
+						Message: json.RawMessage(`{"jobId": ` + string(rune(jobCount+'0')) + `}`),
+						Destination: backendconfig.DestinationT{
+							ID: "dest1",
+						},
+					}
+				}
+				return nil
+			},
+		}
+
+		// Start the worker loop in a goroutine
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			wl.runLoop()
+		}()
+
+		// Send jobs with transform_at = "router" first
+		for i := range 2 {
+			job := &jobsdb.JobT{
+				JobID:  int64(i + 1),
+				UserID: "user1",
+			}
+			params := &routerutils.JobParameters{
+				TransformAt: "router",
+			}
+			inputCh <- workerJob{job: job, parameters: params}
+		}
+
+		// Send a job with transform_at != "router" - this should trigger batch processing
+		job := &jobsdb.JobT{
+			JobID:  3,
+			UserID: "user1",
+		}
+		params := &routerutils.JobParameters{
+			TransformAt: "processor", // Not "router"
+		}
+		inputCh <- workerJob{job: job, parameters: params}
+
+		// Wait a bit to ensure processing
+		time.Sleep(200 * time.Millisecond)
+
+		// Close the input channel to stop the loop
+		close(inputCh)
+
+		// Wait for the loop to finish
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("Worker loop did not finish in time")
+		}
+
+		// Verify results
+		mu.Lock()
+		defer mu.Unlock()
+
+		// We should have at least one transform call (when switching from router to processor)
+		assert.NotEmpty(t, transformCalls, "Should have transform calls when processing router jobs")
+		assert.Empty(t, batchTransformCalls, "Should not have batch transform calls when batching is disabled")
+
+		// Verify that the first batch was processed
+		assert.Len(t, transformCalls, 1, "Should have exactly one transform call")
+		assert.Len(t, transformCalls[0], 2, "First batch should contain 2 router jobs")
+		assert.Len(t, processedJobs, 2, "Should have processed 2 destination jobs")
+	})
+
+	t.Run("with batching enabled", func(t *testing.T) {
+		// Setup
+		inputCh := make(chan workerJob, 10)
+		batchSize := 3
+
+		var processedJobs []types.DestinationJobT
+		var transformCalls [][]types.RouterJobT
+		var batchTransformCalls [][]types.RouterJobT
+		var mu sync.Mutex
+
+		wl := &workerBatchLoop{
+			jobsBatchTimeout:         config.SingleValueLoader(50 * time.Millisecond),
+			noOfJobsToBatchInAWorker: config.SingleValueLoader(batchSize),
+			inputCh:                  inputCh,
+			enableBatching:           true, // Enable batching
+			batchTransform: func(routerJobs []types.RouterJobT) []types.DestinationJobT {
+				mu.Lock()
+				defer mu.Unlock()
+				batchTransformCalls = append(batchTransformCalls, routerJobs)
+				// Create destination jobs from router jobs
+				var destJobs []types.DestinationJobT
+				for _, rj := range routerJobs {
+					destJobs = append(destJobs, types.DestinationJobT{
+						Message:     rj.Message,
+						Destination: rj.Destination,
+					})
+				}
+				return destJobs
+			},
+			transform: func(routerJobs []types.RouterJobT) []types.DestinationJobT {
+				mu.Lock()
+				defer mu.Unlock()
+				transformCalls = append(transformCalls, routerJobs)
+				return []types.DestinationJobT{}
+			},
+			process: func(destinationJobs []types.DestinationJobT) {
+				mu.Lock()
+				defer mu.Unlock()
+				processedJobs = append(processedJobs, destinationJobs...)
+			},
+			acceptWorkerJob: func(workerJob workerJob) *types.RouterJobT {
+				return &types.RouterJobT{
+					Message: json.RawMessage(`{"jobId": ` + string(rune(workerJob.job.JobID+'0')) + `}`),
+					Destination: backendconfig.DestinationT{
+						ID: "dest1",
+					},
+				}
+			},
+		}
+
+		// Start the worker loop in a goroutine
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			wl.runLoop()
+		}()
+
+		// Send jobs to reach the batch size
+		for i := 0; i < batchSize; i++ {
+			job := &jobsdb.JobT{
+				JobID:  int64(i + 1),
+				UserID: "user1",
+			}
+			params := &routerutils.JobParameters{
+				TransformAt: "router",
+			}
+			inputCh <- workerJob{job: job, parameters: params}
+		}
+
+		// Wait for batch processing
+		time.Sleep(50 * time.Millisecond)
+
+		// Send one more job to test that new batch starts
+		job := &jobsdb.JobT{
+			JobID:  int64(batchSize + 1),
+			UserID: "user1",
+		}
+		params := &routerutils.JobParameters{
+			TransformAt: "router",
+		}
+		inputCh <- workerJob{job: job, parameters: params}
+
+		// Wait for timeout to trigger processing of remaining jobs
+		time.Sleep(200*time.Millisecond + 50*time.Millisecond)
+
+		// Close the input channel to stop the loop
+		close(inputCh)
+
+		// Wait for the loop to finish
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("Worker loop did not finish in time")
+		}
+
+		// Verify results
+		mu.Lock()
+		defer mu.Unlock()
+
+		// When batching is enabled, should use batchTransform, not transform
+		assert.Empty(t, transformCalls, "Should not have transform calls when batching is enabled")
+		assert.NotEmpty(t, batchTransformCalls, "Should have batch transform calls when batching is enabled")
+
+		// Should have processed jobs in batches
+		assert.Len(t, batchTransformCalls, 2, "Should have 2 batch transform calls")
+		assert.Len(t, batchTransformCalls[0], batchSize, "First batch should have batch size jobs")
+		assert.Len(t, batchTransformCalls[1], 1, "Second batch should have 1 job")
+		assert.Len(t, processedJobs, batchSize+1, "Should have processed all jobs")
+	})
+
+	t.Run("jobsBatchTimeout resets even when no jobs during timeout", func(t *testing.T) {
+		// Setup
+		inputCh := make(chan workerJob, 10)
+		batchSize := 5
+
+		var timeoutFireCount int
+		var transformCallCount int
+		var mu sync.Mutex
+
+		wl := &workerBatchLoop{
+			jobsBatchTimeout:         config.SingleValueLoader(50 * time.Millisecond), // Shorter timeout for testing
+			noOfJobsToBatchInAWorker: config.SingleValueLoader(batchSize),
+			inputCh:                  inputCh,
+			enableBatching:           false,
+			batchTransform: func(routerJobs []types.RouterJobT) []types.DestinationJobT {
+				mu.Lock()
+				defer mu.Unlock()
+				transformCallCount++
+				return []types.DestinationJobT{}
+			},
+			transform: func(routerJobs []types.RouterJobT) []types.DestinationJobT {
+				mu.Lock()
+				defer mu.Unlock()
+				transformCallCount++
+				return []types.DestinationJobT{}
+			},
+			process: func(destinationJobs []types.DestinationJobT) {
+				// Process function - will be called when there are jobs to process
+			},
+			acceptWorkerJob: func(workerJob workerJob) *types.RouterJobT {
+				// Return a router job for the first few calls, then nil
+				mu.Lock()
+				defer mu.Unlock()
+				timeoutFireCount++
+				if timeoutFireCount <= 3 { // Return jobs for first 3 calls to ensure we have jobs to process
+					return &types.RouterJobT{
+						Message: json.RawMessage(`{"test": true}`),
+						Destination: backendconfig.DestinationT{
+							ID: "test-dest",
+						},
+					}
+				}
+				return nil
+			},
+		}
+
+		// Start the worker loop in a goroutine
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			wl.runLoop()
+		}()
+
+		// Send a few jobs with some delay between them to trigger timeout behavior
+		for i := range 3 {
+			job := &jobsdb.JobT{
+				JobID:  int64(i + 1),
+				UserID: "user1",
+			}
+			params := &routerutils.JobParameters{
+				TransformAt: "router",
+			}
+			inputCh <- workerJob{job: job, parameters: params}
+
+			// Wait longer than timeout to ensure timeout fires
+			time.Sleep(60 * time.Millisecond)
+		}
+
+		// Wait a bit more for final processing
+		time.Sleep(100 * time.Millisecond)
+
+		// Close the input channel to stop the loop
+		close(inputCh)
+
+		// Wait for the loop to finish
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("Worker loop did not finish in time")
+		}
+
+		// Verify that timeout was handled multiple times
+		mu.Lock()
+		defer mu.Unlock()
+
+		// We should have multiple transform calls due to timeout processing
+		// Each timeout should trigger processing of accumulated jobs
+		assert.GreaterOrEqual(t, transformCallCount, 2, "Timeout should fire multiple times and process batches")
+
+		// Verify we had multiple job acceptance calls
+		assert.GreaterOrEqual(t, timeoutFireCount, 3, "Should have processed multiple jobs")
+	})
+
+	t.Run("batch processing when batch size is reached", func(t *testing.T) {
+		// Setup
+		inputCh := make(chan workerJob, 10)
+		batchSize := 2 // Small batch size for testing
+
+		var processedBatches [][]types.DestinationJobT
+		var mu sync.Mutex
+
+		wl := &workerBatchLoop{
+			jobsBatchTimeout:         config.SingleValueLoader(1 * time.Second), // Long timeout so it doesn't interfere
+			noOfJobsToBatchInAWorker: config.SingleValueLoader(batchSize),
+			inputCh:                  inputCh,
+			enableBatching:           false,
+			batchTransform: func(routerJobs []types.RouterJobT) []types.DestinationJobT {
+				return []types.DestinationJobT{}
+			},
+			transform: func(routerJobs []types.RouterJobT) []types.DestinationJobT {
+				// Create destination jobs from router jobs
+				var destJobs []types.DestinationJobT
+				for _, rj := range routerJobs {
+					destJobs = append(destJobs, types.DestinationJobT{
+						Message:     rj.Message,
+						Destination: rj.Destination,
+					})
+				}
+				return destJobs
+			},
+			process: func(destinationJobs []types.DestinationJobT) {
+				mu.Lock()
+				defer mu.Unlock()
+				if len(destinationJobs) > 0 {
+					processedBatches = append(processedBatches, destinationJobs)
+				}
+			},
+			acceptWorkerJob: func(workerJob workerJob) *types.RouterJobT {
+				return &types.RouterJobT{
+					Message: json.RawMessage(`{"jobId": ` + string(rune(workerJob.job.JobID+'0')) + `}`),
+					Destination: backendconfig.DestinationT{
+						ID: "dest1",
+					},
+				}
+			},
+		}
+
+		// Start the worker loop in a goroutine
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			wl.runLoop()
+		}()
+
+		// Send exactly batch size jobs
+		for i := 0; i < batchSize; i++ {
+			job := &jobsdb.JobT{
+				JobID:  int64(i + 1),
+				UserID: "user1",
+			}
+			params := &routerutils.JobParameters{
+				TransformAt: "router",
+			}
+			inputCh <- workerJob{job: job, parameters: params}
+		}
+
+		// Wait for processing
+		time.Sleep(50 * time.Millisecond)
+
+		// Send one more batch
+		for i := 0; i < batchSize; i++ {
+			job := &jobsdb.JobT{
+				JobID:  int64(batchSize + i + 1),
+				UserID: "user1",
+			}
+			params := &routerutils.JobParameters{
+				TransformAt: "router",
+			}
+			inputCh <- workerJob{job: job, parameters: params}
+		}
+
+		// Wait for processing
+		time.Sleep(50 * time.Millisecond)
+
+		// Close the input channel to stop the loop
+		close(inputCh)
+
+		// Wait for the loop to finish
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("Worker loop did not finish in time")
+		}
+
+		// Verify results
+		mu.Lock()
+		defer mu.Unlock()
+
+		// Should have processed 2 batches, each with batchSize jobs
+		require.Len(t, processedBatches, 2, "Should have processed exactly 2 batches")
+		assert.Len(t, processedBatches[0], batchSize, "First batch should have correct size")
+		assert.Len(t, processedBatches[1], batchSize, "Second batch should have correct size")
+	})
+}

--- a/router/worker_test.go
+++ b/router/worker_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Proxy Request", func() {
 				logger:          router.logger.Child("w-0"),
 				partition:       "partition",
 				id:              1,
-				input:           make(chan workerJob, 1),
+				inputCh:         make(chan workerJob, 1),
 				rt:              router,
 				routerProxyStat: stats.NOP.NewTaggedStat("router_proxy_latency", stats.TimerType, stats.Tags{"destType": "ga"}),
 			}
@@ -338,7 +338,7 @@ var _ = Describe("Proxy Request", func() {
 				logger:          router.logger.Child("w-0"),
 				partition:       "partition",
 				id:              1,
-				input:           make(chan workerJob, 1),
+				inputCh:         make(chan workerJob, 1),
 				rt:              router,
 				routerProxyStat: stats.NOP.NewTaggedStat("router_proxy_latency", stats.TimerType, stats.Tags{"destType": "ga"}),
 			}
@@ -449,7 +449,7 @@ var _ = Describe("Proxy Request", func() {
 				logger:          router.logger.Child("w-0"),
 				partition:       "partition",
 				id:              1,
-				input:           make(chan workerJob, 1),
+				inputCh:         make(chan workerJob, 1),
 				rt:              router,
 				routerProxyStat: stats.NOP.NewTaggedStat("router_proxy_latency", stats.TimerType, stats.Tags{"destType": "ga"}),
 			}


### PR DESCRIPTION
# Description

Refactoring the worker processing logic in the `router` package to improve code clarity, modularity, and testability. 
- Introducing `workerBatchLoop` struct in a new file, `router/worker_batch_loop.go`, to encapsulate batch processing logic. This includes handling job batching, timeouts, and job transformations.
- Adding tests for the new batch processing logic in `router/worker_batch_loop_test.go` to ensure correctness.
- Original worker's `workLoop` logic is now refactored to use the new `workerBatchLoop` and we introduced `acceptWorkerJob` method for managing job filtering and processing, which was previously coupled with batching logic.

## Linear Ticket

resolves PIPE-2262

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
