### PR TITLE
chore: remove queryWithUploadId flag support for load files

### DIFF
--- a/integration_test/warehouse/warehouse_test.go
+++ b/integration_test/warehouse/warehouse_test.go
@@ -104,7 +104,7 @@ func TestUploads(t *testing.T) {
 			t.Run(fmt.Sprintf("batchStagingFiles: %t, maxSizeInMB: %s", tc.batchStagingFiles, tc.maxSizeInMB), func(t *testing.T) {
 				if tc.batchStagingFiles {
 					t.Setenv(config.ConfigKeyToEnv(config.DefaultEnvPrefix, "Warehouse.enableV2NotifierJob"), "true")
-					t.Setenv(config.ConfigKeyToEnv(config.DefaultEnvPrefix, "Warehouse.loadFiles.queryWithUploadID.enable"), "true")
+
 					t.Setenv(config.ConfigKeyToEnv(config.DefaultEnvPrefix, "Warehouse.loadFiles.maxSizeInMB"), tc.maxSizeInMB)
 				}
 				db, minioResource, whClient := setupServer(t, false, nil, nil)

--- a/warehouse/integrations/datalake/datalake_test.go
+++ b/warehouse/integrations/datalake/datalake_test.go
@@ -366,7 +366,6 @@ func TestIntegration(t *testing.T) {
 				t.Setenv(config.ConfigKeyToEnv(config.DefaultEnvPrefix, "Warehouse.schemaTTLInMinutes"), strconv.Itoa(tc.schemaTTLInMinutes))
 				if tc.batchStagingFiles {
 					t.Setenv(config.ConfigKeyToEnv(config.DefaultEnvPrefix, "Warehouse.enableV2NotifierJob"), "true")
-					t.Setenv(config.ConfigKeyToEnv(config.DefaultEnvPrefix, "Warehouse.loadFiles.queryWithUploadID.enable"), "true")
 				}
 
 				whth.BootstrapSvc(t, workspaceConfig, httpPort, jobsDBPort)

--- a/warehouse/internal/loadfiles/loadfiles.go
+++ b/warehouse/internal/loadfiles/loadfiles.go
@@ -46,7 +46,7 @@ type StageFileRepo interface {
 type LoadFileRepo interface {
 	Insert(ctx context.Context, loadFiles []model.LoadFile) error
 	Delete(ctx context.Context, uploadID int64, stagingFileIDs []int64) error
-	Get(ctx context.Context, uploadID int64, stagingFileIDs []int64) ([]model.LoadFile, error)
+	Get(ctx context.Context, uploadID int64) ([]model.LoadFile, error)
 }
 
 type ControlPlaneClient interface {
@@ -220,7 +220,7 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 		if err != nil {
 			return 0, 0, fmt.Errorf("creating upload jobs: %w", err)
 		}
-		return lf.getLoadFileIDs(ctx, job, stagingFileIDs, uniqueLoadGenID)
+		return lf.getLoadFileIDs(ctx, job, uniqueLoadGenID)
 	}
 
 	v1Files := make([]*model.StagingFile, 0)
@@ -254,11 +254,11 @@ func (lf *LoadFileGenerator) createFromStaging(ctx context.Context, job *model.U
 	if err = g.Wait(); err != nil {
 		return 0, 0, err
 	}
-	return lf.getLoadFileIDs(ctx, job, stagingFileIDs, uniqueLoadGenID)
+	return lf.getLoadFileIDs(ctx, job, uniqueLoadGenID)
 }
 
-func (lf *LoadFileGenerator) getLoadFileIDs(ctx context.Context, job *model.UploadJob, stagingFileIDs []int64, uniqueLoadGenID string) (int64, int64, error) {
-	loadFiles, err := lf.LoadRepo.Get(ctx, job.Upload.ID, stagingFileIDs)
+func (lf *LoadFileGenerator) getLoadFileIDs(ctx context.Context, job *model.UploadJob, uniqueLoadGenID string) (int64, int64, error) {
+	loadFiles, err := lf.LoadRepo.Get(ctx, job.Upload.ID)
 	if err != nil {
 		return 0, 0, fmt.Errorf("getting load files: %w", err)
 	}

--- a/warehouse/internal/loadfiles/mock_loadfile_repo_test.go
+++ b/warehouse/internal/loadfiles/mock_loadfile_repo_test.go
@@ -41,12 +41,12 @@ func (m *mockLoadFilesRepo) Delete(_ context.Context, uploadID int64, stagingFil
 	return nil
 }
 
-func (m *mockLoadFilesRepo) Get(_ context.Context, uploadID int64, stagingFileIDs []int64) ([]model.LoadFile, error) {
+func (m *mockLoadFilesRepo) Get(_ context.Context, uploadID int64) ([]model.LoadFile, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var loadFiles []model.LoadFile
 	for _, loadFile := range m.store {
-		if slices.Contains(stagingFileIDs, loadFile.StagingFileID) {
+		if *loadFile.UploadID == uploadID {
 			loadFiles = append(loadFiles, loadFile)
 		}
 	}

--- a/warehouse/internal/repo/load.go
+++ b/warehouse/internal/repo/load.go
@@ -120,7 +120,7 @@ func (lf *LoadFiles) Insert(ctx context.Context, loadFiles []model.LoadFile) err
 	})
 }
 
-func (lf *LoadFiles) Get(ctx context.Context, uploadID int64, stagingFileIDs []int64) ([]model.LoadFile, error) {
+func (lf *LoadFiles) Get(ctx context.Context, uploadID int64) ([]model.LoadFile, error) {
 	defer lf.TimerStat("get", nil)()
 
 	sqlStatement := `
@@ -236,7 +236,6 @@ func (lf *LoadFiles) GetByID(ctx context.Context, id int64) (*model.LoadFile, er
 func (lf *LoadFiles) TotalExportedEvents(
 	ctx context.Context,
 	uploadID int64,
-	stagingFileIDs []int64,
 	skipTables []string,
 ) (int64, error) {
 	defer lf.TimerStat("total_exported_events", nil)()

--- a/warehouse/internal/repo/load_test.go
+++ b/warehouse/internal/repo/load_test.go
@@ -2,7 +2,6 @@ package repo_test
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -36,114 +35,12 @@ func createUpload(t *testing.T, ctx context.Context, db *sqlmiddleware.DB) int64
 	return uploadID
 }
 
-func Test_LoadFiles(t *testing.T) {
-	ctx := context.Background()
-	now := time.Now().Truncate(time.Second).UTC()
-	db := setupDB(t)
-
-	r := repo.NewLoadFiles(db, config.New(), repo.WithNow(func() time.Time {
-		return now
-	}))
-
-	var expectedLoadFiles []model.LoadFile
-	var stagingIDs []int64
-	uploadID := int64(-1)
-
-	t.Run("insert", func(t *testing.T) {
-		var loadFiles []model.LoadFile
-
-		for i := 0; i < 10; i++ {
-			loadFile := model.LoadFile{
-				TableName:             "table_name",
-				Location:              "s3://bucket/path/to/file",
-				TotalRows:             10,
-				ContentLength:         1000,
-				StagingFileID:         int64(i + 1),
-				DestinationRevisionID: "revision_id",
-				UseRudderStorage:      true,
-				SourceID:              "source_id",
-				DestinationID:         "destination_id",
-				DestinationType:       "RS",
-			}
-
-			stagingIDs = append(stagingIDs, loadFile.StagingFileID)
-			loadFiles = append(loadFiles, loadFile)
-		}
-		err := r.Insert(ctx, loadFiles)
-		require.NoError(t, err)
-
-		for i := range loadFiles {
-			loadFiles[i].ID = int64(i + 1)
-			loadFiles[i].CreatedAt = now
-		}
-
-		expectedLoadFiles = loadFiles
-	})
-
-	t.Run("get", func(t *testing.T) {
-		loadFiles, err := r.Get(ctx, uploadID, stagingIDs)
-		require.Len(t, loadFiles, len(expectedLoadFiles))
-		require.NoError(t, err)
-
-		for i := range loadFiles {
-			require.Equal(t, expectedLoadFiles[i], loadFiles[i])
-		}
-	})
-
-	t.Run("delete", func(t *testing.T) {
-		err := r.Delete(ctx, uploadID, stagingIDs[1:])
-		require.NoError(t, err)
-
-		loadFiles, err := r.Get(ctx, uploadID, stagingIDs)
-		require.Len(t, loadFiles, 1)
-		require.NoError(t, err)
-
-		for i := range loadFiles {
-			require.Equal(t, expectedLoadFiles[i], loadFiles[i])
-		}
-	})
-
-	t.Run("get latest for stagingID", func(t *testing.T) {
-		stagingID := int64(42)
-
-		var lastLoadFile model.LoadFile
-		var loadFiles []model.LoadFile
-		for i := 0; i < 10; i++ {
-			loadFile := model.LoadFile{
-				TableName:             "table_name",
-				Location:              fmt.Sprintf("s3://bucket/path/to/file/%d", i),
-				TotalRows:             10,
-				ContentLength:         1000,
-				StagingFileID:         stagingID,
-				DestinationRevisionID: "revision_id",
-				UseRudderStorage:      true,
-				SourceID:              "source_id",
-				DestinationID:         "destination_id",
-				DestinationType:       "RS",
-			}
-			loadFiles = append(loadFiles, loadFile)
-			lastLoadFile = loadFile
-		}
-		err := r.Insert(ctx, loadFiles)
-		require.NoError(t, err)
-
-		gotLoadFiles, err := r.Get(ctx, uploadID, []int64{stagingID})
-		require.NoError(t, err)
-
-		require.Len(t, gotLoadFiles, 1)
-		lastLoadFile.ID = gotLoadFiles[0].ID
-		lastLoadFile.CreatedAt = gotLoadFiles[0].CreatedAt
-		require.Equal(t, lastLoadFile, gotLoadFiles[0])
-	})
-}
-
 func Test_LoadFiles_WithUploadID(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().Truncate(time.Second).UTC()
 	db := setupDB(t)
 
 	conf := config.New()
-	conf.Set("Warehouse.loadFiles.queryWithUploadID.enable", true)
 
 	r := repo.NewLoadFiles(db, conf, repo.WithNow(func() time.Time {
 		return now
@@ -269,102 +166,11 @@ func TestLoadFiles_GetByID(t *testing.T) {
 	})
 }
 
-func TestLoadFiles_TotalExportedEvents(t *testing.T) {
-	ctx := context.Background()
-	now := time.Now().Truncate(time.Second).UTC()
-	db := setupDB(t)
-
-	r := repo.NewLoadFiles(db, config.New(), repo.WithNow(func() time.Time {
-		return now
-	}))
-
-	stagingFilesCount := 960
-	loadFilesCount := 25
-	retriesCount := 3
-
-	loadFiles := make([]model.LoadFile, 0, stagingFilesCount*loadFilesCount*retriesCount)
-	stagingFileIDs := make([]int64, 0, stagingFilesCount)
-
-	for i := 0; i < stagingFilesCount; i++ {
-		for j := 0; j < loadFilesCount; j++ {
-			for k := 0; k < retriesCount; k++ {
-				loadFiles = append(loadFiles, model.LoadFile{
-					TableName:             "table_name_" + strconv.Itoa(j+1),
-					Location:              "s3://bucket/path/to/file",
-					TotalRows:             (i + 1) + (j + 1) + (k + 1),
-					ContentLength:         1000,
-					StagingFileID:         int64(i + 1),
-					DestinationRevisionID: "revision_id",
-					UseRudderStorage:      true,
-					SourceID:              "source_id",
-					DestinationID:         "destination_id",
-					DestinationType:       "RS",
-				})
-			}
-		}
-		stagingFileIDs = append(stagingFileIDs, int64(i+1))
-	}
-
-	err := r.Insert(ctx, loadFiles)
-	require.NoError(t, err)
-	uploadID := int64(-1)
-
-	t.Run("no staging files", func(t *testing.T) {
-		exportedEvents, err := r.TotalExportedEvents(ctx, uploadID, []int64{-1}, []string{})
-		require.NoError(t, err)
-		require.Zero(t, exportedEvents)
-	})
-	t.Run("without skip tables", func(t *testing.T) {
-		exportedEvents, err := r.TotalExportedEvents(ctx, uploadID, stagingFileIDs, nil)
-		require.NoError(t, err)
-
-		actualEvents := lo.SumBy(stagingFileIDs, func(item int64) int64 {
-			sum := 0
-			for j := 0; j < loadFilesCount; j++ {
-				sum += int(item) + (j + 1) + retriesCount
-			}
-			return int64(sum)
-		})
-		require.Equal(t, actualEvents, exportedEvents)
-	})
-	t.Run("with skip tables", func(t *testing.T) {
-		excludeIDS := []int64{1, 3, 5, 7, 9}
-
-		skipTable := lo.Map(excludeIDS, func(item int64, index int) string {
-			return "table_name_" + strconv.Itoa(int(item))
-		})
-
-		exportedEvents, err := r.TotalExportedEvents(ctx, uploadID, stagingFileIDs, skipTable) // 11916000
-		require.NoError(t, err)
-
-		actualEvents := lo.SumBy(stagingFileIDs, func(item int64) int64 {
-			sum := 0
-			for j := 0; j < loadFilesCount; j++ {
-				if lo.Contains(excludeIDS, int64(j+1)) {
-					continue
-				}
-				sum += int(item) + (j + 1) + retriesCount
-			}
-			return int64(sum)
-		})
-		require.Equal(t, actualEvents, exportedEvents)
-	})
-	t.Run("context cancelled", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(ctx)
-		cancel()
-
-		exportedEvents, err := r.TotalExportedEvents(ctx, uploadID, stagingFileIDs, nil)
-		require.ErrorIs(t, err, context.Canceled)
-		require.Zero(t, exportedEvents)
-	})
-}
-
 func TestLoadFiles_TotalExportedEvents_WithUploadID(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().Truncate(time.Second).UTC()
 	db := setupDB(t)
 	conf := config.New()
-	conf.Set("Warehouse.loadFiles.queryWithUploadID.enable", true)
 
 	r := repo.NewLoadFiles(db, conf, repo.WithNow(func() time.Time {
 		return now

--- a/warehouse/internal/repo/load_test.go
+++ b/warehouse/internal/repo/load_test.go
@@ -35,7 +35,7 @@ func createUpload(t *testing.T, ctx context.Context, db *sqlmiddleware.DB) int64
 	return uploadID
 }
 
-func Test_LoadFiles_WithUploadID(t *testing.T) {
+func Test_LoadFiles(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().Truncate(time.Second).UTC()
 	db := setupDB(t)
@@ -166,7 +166,7 @@ func TestLoadFiles_GetByID(t *testing.T) {
 	})
 }
 
-func TestLoadFiles_TotalExportedEvents_WithUploadID(t *testing.T) {
+func TestLoadFiles_TotalExportedEvents(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().Truncate(time.Second).UTC()
 	db := setupDB(t)

--- a/warehouse/internal/repo/load_test.go
+++ b/warehouse/internal/repo/load_test.go
@@ -89,7 +89,7 @@ func Test_LoadFiles_WithUploadID(t *testing.T) {
 	})
 
 	t.Run("get", func(t *testing.T) {
-		loadFiles, err := r.Get(ctx, uploadID1, []int64{})
+		loadFiles, err := r.Get(ctx, uploadID1)
 		require.Len(t, loadFiles, len(upload1LoadFiles))
 		require.NoError(t, err)
 
@@ -102,7 +102,7 @@ func Test_LoadFiles_WithUploadID(t *testing.T) {
 		err := r.Delete(ctx, uploadID2, []int64{})
 		require.NoError(t, err)
 
-		loadFiles, err := r.Get(ctx, uploadID2, []int64{})
+		loadFiles, err := r.Get(ctx, uploadID2)
 		require.Len(t, loadFiles, 0)
 		require.NoError(t, err)
 	})
@@ -217,18 +217,13 @@ func TestLoadFiles_TotalExportedEvents_WithUploadID(t *testing.T) {
 	err := r.Insert(ctx, loadFiles)
 	require.NoError(t, err)
 
-	t.Run("no staging files", func(t *testing.T) {
-		exportedEvents, err := r.TotalExportedEvents(ctx, int64(-1), []int64{-1}, []string{})
-		require.NoError(t, err)
-		require.Zero(t, exportedEvents)
-	})
 	t.Run("without skip tables", func(t *testing.T) {
-		exportedEvents, err := r.TotalExportedEvents(ctx, uploadID, []int64{}, nil)
+		exportedEvents, err := r.TotalExportedEvents(ctx, uploadID, nil)
 		require.NoError(t, err)
 		require.Equal(t, int64(totalEvents), exportedEvents)
 	})
 	t.Run("with skip tables", func(t *testing.T) {
-		exportedEvents, err := r.TotalExportedEvents(ctx, uploadID, []int64{}, skipTables)
+		exportedEvents, err := r.TotalExportedEvents(ctx, uploadID, skipTables)
 		require.NoError(t, err)
 		require.Equal(t, int64(skipTablesTotalEvents), exportedEvents)
 	})
@@ -236,7 +231,7 @@ func TestLoadFiles_TotalExportedEvents_WithUploadID(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		exportedEvents, err := r.TotalExportedEvents(ctx, uploadID, []int64{}, nil)
+		exportedEvents, err := r.TotalExportedEvents(ctx, uploadID, nil)
 		require.ErrorIs(t, err, context.Canceled)
 		require.Zero(t, exportedEvents)
 	})

--- a/warehouse/internal/repo/table_upload.go
+++ b/warehouse/internal/repo/table_upload.go
@@ -195,7 +195,7 @@ func scanTableUpload(scan scanFn, tableUpload *model.TableUpload) error {
 
 // PopulateTotalEventsWithTx Update the 'total_events' field in the Table Uploads table
 // by summing the 'total_events' from load files associated with specific staging file IDs.
-func (tu *TableUploads) PopulateTotalEventsWithTx(ctx context.Context, tx *sqlmiddleware.Tx, uploadId int64, tableName string, stagingFileIDs []int64) error {
+func (tu *TableUploads) PopulateTotalEventsWithTx(ctx context.Context, tx *sqlmiddleware.Tx, uploadId int64, tableName string) error {
 	defer tu.TimerStat("populate_total_events_with_tx", nil)()
 
 	subQuery := `

--- a/warehouse/internal/repo/table_upload.go
+++ b/warehouse/internal/repo/table_upload.go
@@ -43,7 +43,6 @@ const (
 // TableUploads is a repository for table uploads
 type TableUploads struct {
 	*repo
-	queryLoadFilesWithUploadID config.ValueLoader[bool]
 }
 
 type TableUploadSetOptions struct {
@@ -56,8 +55,7 @@ type TableUploadSetOptions struct {
 
 func NewTableUploads(db *sqlmiddleware.DB, conf *config.Config, opts ...Opt) *TableUploads {
 	r := &TableUploads{
-		repo:                       &repo{db: db, now: timeutil.Now, statsFactory: stats.NOP, repoType: tableUploadTableName},
-		queryLoadFilesWithUploadID: conf.GetReloadableBoolVar(false, "Warehouse.loadFiles.queryWithUploadID.enable"),
+		repo: &repo{db: db, now: timeutil.Now, statsFactory: stats.NOP, repoType: tableUploadTableName},
 	}
 	for _, opt := range opts {
 		opt(r.repo)
@@ -200,10 +198,7 @@ func scanTableUpload(scan scanFn, tableUpload *model.TableUpload) error {
 func (tu *TableUploads) PopulateTotalEventsWithTx(ctx context.Context, tx *sqlmiddleware.Tx, uploadId int64, tableName string, stagingFileIDs []int64) error {
 	defer tu.TimerStat("populate_total_events_with_tx", nil)()
 
-	var subQuery string
-	var queryArgs []any
-	if tu.queryLoadFilesWithUploadID.Load() {
-		subQuery = `
+	subQuery := `
 		SELECT
 		  sum(total_events) as total
 		FROM
@@ -212,39 +207,9 @@ func (tu *TableUploads) PopulateTotalEventsWithTx(ctx context.Context, tx *sqlmi
 		  upload_id = $1
 		AND table_name = $2
 `
-		queryArgs = []any{
-			uploadId,
-			tableName,
-		}
-	} else {
-		subQuery = `
-		WITH row_numbered_load_files as (
-		  SELECT
-			total_events,
-			row_number() OVER (
-			  PARTITION BY staging_file_id,
-			  table_name
-			  ORDER BY
-				id DESC
-			) AS row_number
-		  FROM
-			` + loadTableName + `
-		  WHERE
-			staging_file_id = ANY($3)
-			AND table_name = $2
-		)
-		SELECT
-		  sum(total_events) as total
-		FROM
-		  row_numbered_load_files
-		WHERE
-		  row_number = 1
-`
-		queryArgs = []any{
-			uploadId,
-			tableName,
-			pq.Array(stagingFileIDs),
-		}
+	queryArgs := []any{
+		uploadId,
+		tableName,
 	}
 
 	query := `

--- a/warehouse/internal/repo/table_upload_test.go
+++ b/warehouse/internal/repo/table_upload_test.go
@@ -311,7 +311,7 @@ func TestTableUploadRepo(t *testing.T) {
 	})
 
 	t.Run("TotalEvents", func(t *testing.T) {
-		t.Run("PopulateTotalEventsWithTx with upload id", func(t *testing.T) {
+		t.Run("PopulateTotalEventsWithTx", func(t *testing.T) {
 			tables2 := []string{"table_name_11", "table_name_12", "table_name_13", "table_name_14", "table_name_15", "table_name_16", "table_name_17", "table_name_18", "table_name_19", "table_name_20"}
 			uploadId := createUpload(t, ctx, db)
 			conf := config.New()

--- a/warehouse/internal/repo/table_upload_test.go
+++ b/warehouse/internal/repo/table_upload_test.go
@@ -358,9 +358,11 @@ func TestTableUploadRepo(t *testing.T) {
 			t.Run("all exported tables", func(t *testing.T) {
 				status := model.TableUploadExported
 
-				for _, table := range tables {
+				for i, table := range tables {
+					totalEvents := int64(i + 1)
 					err := r.Set(ctx, uploadID, table, repo.TableUploadSetOptions{
-						Status: &status,
+						Status:      &status,
+						TotalEvents: &totalEvents,
 					})
 					require.NoError(t, err)
 				}

--- a/warehouse/internal/repo/table_upload_test.go
+++ b/warehouse/internal/repo/table_upload_test.go
@@ -337,7 +337,7 @@ func TestTableUploadRepo(t *testing.T) {
 
 			txErr := r.WithTx(ctx, func(tx *sqlmw.Tx) error {
 				for _, table := range tables2 {
-					populateErr := r.PopulateTotalEventsWithTx(ctx, tx, uploadId, table, []int64{})
+					populateErr := r.PopulateTotalEventsWithTx(ctx, tx, uploadId, table)
 					require.NoError(t, populateErr)
 				}
 				return nil

--- a/warehouse/router/mocks/upload.go
+++ b/warehouse/router/mocks/upload.go
@@ -72,18 +72,18 @@ func (mr *MockloadFilesRepoMockRecorder) DistinctTableName(ctx, sourceID, destin
 }
 
 // Get mocks base method.
-func (m *MockloadFilesRepo) Get(ctx context.Context, uploadID int64, stagingFileIDs []int64) ([]model.LoadFile, error) {
+func (m *MockloadFilesRepo) Get(ctx context.Context, uploadID int64) ([]model.LoadFile, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", ctx, uploadID, stagingFileIDs)
+	ret := m.ctrl.Call(m, "Get", ctx, uploadID)
 	ret0, _ := ret[0].([]model.LoadFile)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockloadFilesRepoMockRecorder) Get(ctx, uploadID, stagingFileIDs any) *gomock.Call {
+func (mr *MockloadFilesRepoMockRecorder) Get(ctx, uploadID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockloadFilesRepo)(nil).Get), ctx, uploadID, stagingFileIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockloadFilesRepo)(nil).Get), ctx, uploadID)
 }
 
 // GetByID mocks base method.

--- a/warehouse/router/mocks/upload.go
+++ b/warehouse/router/mocks/upload.go
@@ -102,18 +102,18 @@ func (mr *MockloadFilesRepoMockRecorder) GetByID(ctx, id any) *gomock.Call {
 }
 
 // TotalExportedEvents mocks base method.
-func (m *MockloadFilesRepo) TotalExportedEvents(ctx context.Context, uploadID int64, stagingFileIDs []int64, skipTables []string) (int64, error) {
+func (m *MockloadFilesRepo) TotalExportedEvents(ctx context.Context, uploadID int64, skipTables []string) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TotalExportedEvents", ctx, uploadID, stagingFileIDs, skipTables)
+	ret := m.ctrl.Call(m, "TotalExportedEvents", ctx, uploadID, skipTables)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TotalExportedEvents indicates an expected call of TotalExportedEvents.
-func (mr *MockloadFilesRepoMockRecorder) TotalExportedEvents(ctx, uploadID, stagingFileIDs, skipTables any) *gomock.Call {
+func (mr *MockloadFilesRepoMockRecorder) TotalExportedEvents(ctx, uploadID, skipTables any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TotalExportedEvents", reflect.TypeOf((*MockloadFilesRepo)(nil).TotalExportedEvents), ctx, uploadID, stagingFileIDs, skipTables)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TotalExportedEvents", reflect.TypeOf((*MockloadFilesRepo)(nil).TotalExportedEvents), ctx, uploadID, skipTables)
 }
 
 // MockstagingFilesRepo is a mock of stagingFilesRepo interface.

--- a/warehouse/router/state_generate_load_files.go
+++ b/warehouse/router/state_generate_load_files.go
@@ -77,7 +77,7 @@ func (job *UploadJob) matchRowsInStagingAndLoadFiles(ctx context.Context) error 
 }
 
 func (job *UploadJob) getTotalRowsInLoadFiles(ctx context.Context) int64 {
-	exportedEvents, err := job.loadFilesRepo.TotalExportedEvents(ctx, job.upload.ID, job.stagingFileIDs, []string{
+	exportedEvents, err := job.loadFilesRepo.TotalExportedEvents(ctx, job.upload.ID, []string{
 		whutils.ToProviderCase(job.warehouse.Type, whutils.DiscardsTable),
 	})
 	if err != nil {

--- a/warehouse/router/state_update_table_uploads.go
+++ b/warehouse/router/state_update_table_uploads.go
@@ -14,7 +14,6 @@ func (job *UploadJob) updateTableUploadsCounts() error {
 				tx,
 				job.upload.ID,
 				tableName,
-				job.stagingFileIDs,
 			); err != nil {
 				return fmt.Errorf("populate total events from staging file ids for table: %s, %w", tableName, err)
 			}

--- a/warehouse/router/testdata/sql/upload_test.sql
+++ b/warehouse/router/testdata/sql/upload_test.sql
@@ -74,45 +74,45 @@ VALUES
   (
     5, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     '{}', 'test-sourceID', 'test-destinationID',
-    'succeeded', 1, NOW(), NOW(), NOW(),
-    NOW(), '{}',1
+    'succeeded', 5, NOW(), NOW(), NOW(),
+    NOW(), '{}',2
   );
 INSERT INTO wh_load_files (
   id, staging_file_id, location, source_id,
   destination_id, destination_type,
   table_name, total_events, created_at,
-  metadata
+  metadata, upload_id
 )
 VALUES
   (
     1, 1, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     'test-sourceID', 'test-destinationID',
     'POSTGRES', 'test-table', 1, NOW(),
-    '{}'
+    '{}', 1
   ),
   (
     2, 2, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     'test-sourceID', 'test-destinationID',
     'POSTGRES', 'test-table', 1, NOW(),
-    '{}'
+    '{}', 1
   ),
   (
     3, 3, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     'test-sourceID', 'test-destinationID',
     'POSTGRES', 'test-table', 1, NOW(),
-    '{}'
+    '{}', 1
   ),
   (
     4, 4, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     'test-sourceID', 'test-destinationID',
     'POSTGRES', 'test-table', 1, NOW(),
-    '{}'
+    '{}', 1
   ),
   (
     5, 5, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     'test-sourceID', 'test-destinationID',
-    'POSTGRES', 'test-table', 1, NOW(),
-    '{}'
+    'POSTGRES', 'test-table', 2, NOW(),
+    '{}', 2
   );
 INSERT INTO wh_table_uploads (
   id, wh_upload_id, table_name, status,

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -66,7 +66,7 @@ type UploadJobFactory struct {
 }
 
 type loadFilesRepo interface {
-	Get(ctx context.Context, uploadID int64, stagingFileIDs []int64) ([]model.LoadFile, error)
+	Get(ctx context.Context, uploadID int64) ([]model.LoadFile, error)
 	Delete(ctx context.Context, uploadID int64, stagingFileIDs []int64) error
 	TotalExportedEvents(ctx context.Context, uploadID int64, skipTables []string) (int64, error)
 	GetByID(ctx context.Context, id int64) (*model.LoadFile, error)
@@ -525,7 +525,7 @@ func (job *UploadJob) cleanupObjectStorageFiles() error {
 	)
 
 	if !whutils.IsDatalakeDestination(destination.DestinationDefinition.Name) {
-		loadingFiles, err := job.loadFilesRepo.Get(job.ctx, job.upload.ID, job.stagingFileIDs)
+		loadingFiles, err := job.loadFilesRepo.Get(job.ctx, job.upload.ID)
 		if err != nil {
 			return fmt.Errorf("fetching loading files: %w", err)
 		}

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -120,7 +120,6 @@ type UploadJob struct {
 		columnsBatchSize                    int
 		longRunningUploadStatThresholdInMin time.Duration
 		skipPreviouslyFailedTables          bool
-		queryLoadFilesWithUploadID          config.ValueLoader[bool]
 		// max number of parallel delete requests to filemanager (applies to GCS only)
 		maxConcurrentObjDeleteRequests func(workspaceID string) int
 		// batch size for parallel deletion of staging and loadfiles (applies to GCS only)
@@ -221,7 +220,6 @@ func (f *UploadJobFactory) NewUploadJob(ctx context.Context, dto *model.UploadJo
 	uj.config.maxUploadBackoff = f.conf.GetDurationVar(1800, time.Second, "Warehouse.maxUploadBackoff", "Warehouse.maxUploadBackoffInS")
 	uj.config.retryTimeWindow = f.conf.GetDurationVar(180, time.Minute, "Warehouse.retryTimeWindow", "Warehouse.retryTimeWindowInMins")
 	uj.config.skipPreviouslyFailedTables = f.conf.GetBool("Warehouse.skipPreviouslyFailedTables", false)
-	uj.config.queryLoadFilesWithUploadID = f.conf.GetReloadableBoolVar(false, "Warehouse.loadFiles.queryWithUploadID.enable")
 	uj.config.maxConcurrentObjDeleteRequests = func(workspaceID string) int {
 		return f.conf.GetIntVar(10, 1,
 			fmt.Sprintf("Warehouse.filemanager.%s.GCS.maxConcurrentObjDeleteRequests", workspaceID),
@@ -970,51 +968,19 @@ func (job *UploadJob) GetLoadFilesMetadata(ctx context.Context, options whutils.
 }
 
 func (job *UploadJob) getLoadFilesMetadataQuery(tableFilterSQL, limitSQL string) string {
-	if job.config.queryLoadFilesWithUploadID.Load() {
-		return fmt.Sprintf(`
-			SELECT
-			  location,
-			  metadata
-			FROM
-			  %[1]s
-			WHERE
-			  upload_id = %[2]d
-			%[3]s
-			%[4]s;
-			`,
-			whutils.WarehouseLoadFilesTable,
-			job.upload.ID,
-			tableFilterSQL,
-			limitSQL,
-		)
-	}
 	return fmt.Sprintf(`
-		WITH row_numbered_load_files as (
-		  SELECT
-			location,
-			metadata,
-			row_number() OVER (
-			  PARTITION BY staging_file_id,
-			  table_name
-			  ORDER BY
-				id DESC
-			) AS row_number
-		  FROM
-			%[1]s
-		  WHERE
-			staging_file_id IN (%[2]v) %[3]s
-		)
 		SELECT
 		  location,
 		  metadata
 		FROM
-		  row_numbered_load_files
+		  %[1]s
 		WHERE
-		  row_number = 1
+		  upload_id = %[2]d
+		%[3]s
 		%[4]s;
 		`,
 		whutils.WarehouseLoadFilesTable,
-		misc.IntArrayToString(job.stagingFileIDs, ","),
+		job.upload.ID,
 		tableFilterSQL,
 		limitSQL,
 	)

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -68,7 +68,7 @@ type UploadJobFactory struct {
 type loadFilesRepo interface {
 	Get(ctx context.Context, uploadID int64, stagingFileIDs []int64) ([]model.LoadFile, error)
 	Delete(ctx context.Context, uploadID int64, stagingFileIDs []int64) error
-	TotalExportedEvents(ctx context.Context, uploadID int64, stagingFileIDs []int64, skipTables []string) (int64, error)
+	TotalExportedEvents(ctx context.Context, uploadID int64, skipTables []string) (int64, error)
 	GetByID(ctx context.Context, id int64) (*model.LoadFile, error)
 	DistinctTableName(ctx context.Context, sourceID, destinationID string, startID, endID int64) ([]string, error)
 }

--- a/warehouse/router/upload_stats_test.go
+++ b/warehouse/router/upload_stats_test.go
@@ -204,12 +204,10 @@ func TestUploadJob_MatchRows(t *testing.T) {
 		}
 		job := ujf.NewUploadJob(context.Background(), &model.UploadJob{
 			Upload: model.Upload{
-				ID:                 1,
-				DestinationID:      destinationID,
-				SourceID:           sourceID,
-				StagingFileStartID: 1,
-				StagingFileEndID:   5,
-				Namespace:          namespace,
+				ID:            1,
+				DestinationID: destinationID,
+				SourceID:      sourceID,
+				Namespace:     namespace,
 			},
 			Warehouse: model.Warehouse{
 				Type: destinationType,
@@ -222,17 +220,10 @@ func TestUploadJob_MatchRows(t *testing.T) {
 					Name: destinationName,
 				},
 			},
-			StagingFiles: []*model.StagingFile{
-				{ID: 1},
-				{ID: 2},
-				{ID: 3},
-				{ID: 4},
-				{ID: 5},
-			},
 		}, nil)
 
 		count := job.getTotalRowsInLoadFiles(context.Background())
-		require.EqualValues(t, 5, count)
+		require.EqualValues(t, 4, count)
 	})
 
 	t.Run("Total rows in staging files", func(t *testing.T) {
@@ -244,12 +235,10 @@ func TestUploadJob_MatchRows(t *testing.T) {
 		}
 		job := ujf.NewUploadJob(context.Background(), &model.UploadJob{
 			Upload: model.Upload{
-				ID:                 1,
-				DestinationID:      destinationID,
-				SourceID:           sourceID,
-				StagingFileStartID: 1,
-				StagingFileEndID:   5,
-				Namespace:          namespace,
+				ID:            1,
+				DestinationID: destinationID,
+				SourceID:      sourceID,
+				Namespace:     namespace,
 			},
 			Warehouse: model.Warehouse{
 				Type: destinationType,
@@ -262,18 +251,11 @@ func TestUploadJob_MatchRows(t *testing.T) {
 					Name: destinationName,
 				},
 			},
-			StagingFiles: []*model.StagingFile{
-				{ID: 1},
-				{ID: 2},
-				{ID: 3},
-				{ID: 4},
-				{ID: 5},
-			},
 		}, nil)
 
 		count, err := repo.NewStagingFiles(sqlmiddleware.New(db), config.New()).TotalEventsForUploadID(context.Background(), job.upload.ID)
 		require.NoError(t, err)
-		require.EqualValues(t, 5, count)
+		require.EqualValues(t, 4, count)
 	})
 
 	t.Run("Get uploads timings", func(t *testing.T) {
@@ -331,25 +313,17 @@ func TestUploadJob_MatchRows(t *testing.T) {
 	t.Run("Staging files and load files events match", func(t *testing.T) {
 		testCases := []struct {
 			name          string
-			stagingFile   []*model.StagingFile
+			uploadID      int64
 			mismatchCount int
 		}{
 			{
-				name: "In case of no mismatch",
-				stagingFile: []*model.StagingFile{
-					{ID: 1},
-					{ID: 2},
-					{ID: 3},
-					{ID: 4},
-					{ID: 5},
-				},
+				name:          "In case of no mismatch",
+				uploadID:      1,
+				mismatchCount: 0,
 			},
 			{
-				name: "In case of mismatch",
-				stagingFile: []*model.StagingFile{
-					{ID: 1},
-					{ID: 2},
-				},
+				name:          "In case of mismatch",
+				uploadID:      2,
 				mismatchCount: 3,
 			},
 		}
@@ -367,12 +341,10 @@ func TestUploadJob_MatchRows(t *testing.T) {
 				}
 				job := ujf.NewUploadJob(context.Background(), &model.UploadJob{
 					Upload: model.Upload{
-						ID:                 1,
-						DestinationID:      destinationID,
-						SourceID:           sourceID,
-						StagingFileStartID: 1,
-						StagingFileEndID:   5,
-						Namespace:          namespace,
+						ID:            tc.uploadID,
+						DestinationID: destinationID,
+						SourceID:      sourceID,
+						Namespace:     namespace,
 					},
 					Warehouse: model.Warehouse{
 						Type: destinationType,
@@ -385,7 +357,6 @@ func TestUploadJob_MatchRows(t *testing.T) {
 							Name: destinationName,
 						},
 					},
-					StagingFiles: tc.stagingFile,
 				}, nil)
 
 				err = job.matchRowsInStagingAndLoadFiles(context.Background())

--- a/warehouse/router/upload_test.go
+++ b/warehouse/router/upload_test.go
@@ -849,9 +849,6 @@ func TestCleanupObjectStorageFiles(t *testing.T) {
 			Location: fmt.Sprintf("test-location-%d", i+1),
 		}
 	})
-	stagingFilesIDs := lo.Map(stagingFiles, func(f *model.StagingFile, _ int) int64 {
-		return f.ID
-	})
 	loadFiles := lo.RepeatBy(4, func(i int) model.LoadFile {
 		return model.LoadFile{
 			Location: fmt.Sprintf("test-load-location-%d", i+1),
@@ -927,7 +924,7 @@ func TestCleanupObjectStorageFiles(t *testing.T) {
 			lo.Map(loadFiles, func(f model.LoadFile, _ int) string { return f.Location })...,
 		)
 		mockFileManager.EXPECT().Delete(gomock.Any(), expectedKeys).Return(nil).Times(1)
-		mockLoadFilesRepo.EXPECT().Get(context.Background(), int64(1), stagingFilesIDs).Return(loadFiles, nil).Times(1)
+		mockLoadFilesRepo.EXPECT().Get(context.Background(), int64(1)).Return(loadFiles, nil).Times(1)
 
 		destConfig := createDestConfig(true, warehouseutils.S3)
 		job := createUploadJob(destConfig, warehouseutils.SNOWFLAKE, mockFileManager, mockLoadFilesRepo, stagingFiles)
@@ -961,7 +958,7 @@ func TestCleanupObjectStorageFiles(t *testing.T) {
 			lo.Map(loadFiles, func(f model.LoadFile, _ int) string { return f.Location })...,
 		)
 		mockFileManager.EXPECT().Delete(gomock.Any(), expectedKeys).Return(errors.New("delete error")).Times(1)
-		mockLoadFilesRepo.EXPECT().Get(context.Background(), int64(1), stagingFilesIDs).Return(loadFiles, nil).Times(1)
+		mockLoadFilesRepo.EXPECT().Get(context.Background(), int64(1)).Return(loadFiles, nil).Times(1)
 
 		destConfig := createDestConfig(true, warehouseutils.S3)
 		job := createUploadJob(destConfig, warehouseutils.SNOWFLAKE, mockFileManager, mockLoadFilesRepo, stagingFiles)
@@ -982,7 +979,7 @@ func TestCleanupObjectStorageFiles(t *testing.T) {
 		for _, chunk := range lo.Chunk(expectedKeys, 4) {
 			mockFileManager.EXPECT().Delete(gomock.Any(), chunk).Return(nil).Times(1)
 		}
-		mockLoadFilesRepo.EXPECT().Get(context.Background(), int64(1), stagingFilesIDs).Return(loadFiles, nil).Times(1)
+		mockLoadFilesRepo.EXPECT().Get(context.Background(), int64(1)).Return(loadFiles, nil).Times(1)
 
 		destConfig := createDestConfig(true, warehouseutils.GCS)
 		job := createUploadJob(destConfig, warehouseutils.BQ, mockFileManager, mockLoadFilesRepo, stagingFiles)

--- a/warehouse/router/upload_test.go
+++ b/warehouse/router/upload_test.go
@@ -752,38 +752,28 @@ func TestUploadJob_GetLoadFilesMetadata(t *testing.T) {
 
 	testCases := []struct {
 		name              string
-		queryWithUploadID bool
 		tableName         string
 		limit             int64
 		expectedLoadFiles int
 	}{
 		{
 			name:              "query with upload ID",
-			queryWithUploadID: true,
 			expectedLoadFiles: 4,
 		},
 		{
 			name:              "query with upload ID and table name",
-			queryWithUploadID: true,
 			tableName:         "test_table2",
 			expectedLoadFiles: 3,
 		},
 		{
 			name:              "query with upload ID, table name and limit",
-			queryWithUploadID: true,
 			tableName:         "test_table2",
 			limit:             2,
 			expectedLoadFiles: 2,
 		},
 		{
 			name:              "query with upload ID and limit",
-			queryWithUploadID: true,
 			limit:             1,
-			expectedLoadFiles: 1,
-		},
-		{
-			name:              "query with staging file IDs",
-			queryWithUploadID: false,
 			expectedLoadFiles: 1,
 		},
 	}
@@ -794,7 +784,6 @@ func TestUploadJob_GetLoadFilesMetadata(t *testing.T) {
 			db := setupDB(t)
 
 			conf := config.New()
-			conf.Set("Warehouse.loadFiles.queryWithUploadID.enable", tc.queryWithUploadID)
 
 			job := &UploadJob{
 				ctx:            ctx,
@@ -803,7 +792,6 @@ func TestUploadJob_GetLoadFilesMetadata(t *testing.T) {
 				stagingFileIDs: []int64{1, 2, 3},
 				logger:         logger.NOP,
 			}
-			job.config.queryLoadFilesWithUploadID = conf.GetReloadableBoolVar(false, "Warehouse.loadFiles.queryWithUploadID.enable")
 			var stagingFileId int64
 			stagingFileId, job.upload.ID = createUpload(t, ctx, db)
 			loadFiles := []model.LoadFile{


### PR DESCRIPTION
# Description

This PR is one of the cleanup PRs for the load file size optimization feature. It gets rid of `queryWithUploadId` flag. Going forward the value will always be true. 

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
