### PR TITLE
fix: overwrite payloadStage in error response for aborted jobs

### DIFF
--- a/router/worker.go
+++ b/router/worker.go
@@ -71,8 +71,9 @@ func (w *worker) acceptWorkerJob(workerJob workerJob) *types.RouterJobT {
 	abortReason := workerJob.drainReason
 	abort := abortReason != ""
 	abortTag := abortReason
-	errResponse := routerutils.EnhanceJSON(job.LastJobStatus.ErrorResponse, "reason", abortReason)
 	if abort { // send aborted job status to responseQ and continue
+		errResponse := routerutils.EnhanceJSON(job.LastJobStatus.ErrorResponse, "reason", abortReason)
+		errResponse = routerutils.EnhanceJSON(errResponse, "payloadStage", "router_input")
 		status := jobsdb.JobStatusT{
 			JobID:         job.JobID,
 			AttemptNum:    job.LastJobStatus.AttemptNum,


### PR DESCRIPTION
# Description

Currently, when a job is aborted, the payloadStage is incorrectly set to "delivery" in error response. This PR overwrites the payloadStage in such cases to reflect the correct stage i.e `router_input`.

## Linear Ticket

[Resolves OBS-879](https://linear.app/rudderstack/issue/OBS-879/overwrite-payloadstage-in-sample-response-when-a-job-is-aborted)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
