### PR TITLE
fix: adaptive throttling not applying dynamic throttling limits consistently

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/rudderlabs/bing-ads-go-sdk v0.2.3
 	github.com/rudderlabs/compose-test v0.1.3
 	github.com/rudderlabs/keydb v0.1.0-alpha
-	github.com/rudderlabs/rudder-go-kit v0.59.3
+	github.com/rudderlabs/rudder-go-kit v0.59.4
 	github.com/rudderlabs/rudder-observability-kit v0.0.4
 	github.com/rudderlabs/rudder-schemas v0.7.0
 	github.com/rudderlabs/rudder-transformer/go v0.0.0-20250707171833-9cd525669b1b

--- a/go.sum
+++ b/go.sum
@@ -1203,8 +1203,8 @@ github.com/rudderlabs/keydb v0.1.0-alpha h1:h87QGW9ut6jQExQjtZsp2BxPc0Hix58WELQ5
 github.com/rudderlabs/keydb v0.1.0-alpha/go.mod h1:gnyirkn1FWIQPCvo/E6rFmfDQ2pjVkAYHF3hJvsBpC0=
 github.com/rudderlabs/parquet-go v0.0.3 h1:/zgRj929pGKHsthc0kw8stVEcFu1JUcpxDRlhxjSLic=
 github.com/rudderlabs/parquet-go v0.0.3/go.mod h1:WmwBOdvwpXl2aZGRk3NxxgzC/DaWGfax3jrCRhKhtSo=
-github.com/rudderlabs/rudder-go-kit v0.59.3 h1:p+kiOrBgmpgRVAfByvxk2kkCvT8AVdZH+MySvcIfLQE=
-github.com/rudderlabs/rudder-go-kit v0.59.3/go.mod h1:0rArdYSgCAiBV+F0uHFSdJVTQTLyY4avmn+T9rosMxE=
+github.com/rudderlabs/rudder-go-kit v0.59.4 h1:iKtxLhRLvrfwck53l/2ZM1bnykuJ41l1ohreUpR9l6E=
+github.com/rudderlabs/rudder-go-kit v0.59.4/go.mod h1:0rArdYSgCAiBV+F0uHFSdJVTQTLyY4avmn+T9rosMxE=
 github.com/rudderlabs/rudder-observability-kit v0.0.4 h1:h9nLoWqiv/nqGOu1dhuVFAHNRkyodR6R3v36bqmavRs=
 github.com/rudderlabs/rudder-observability-kit v0.0.4/go.mod h1:YTsvJmpvh8OLk7c4C+wXiV8NRdcrrdLa8UvIdLoXTho=
 github.com/rudderlabs/rudder-schemas v0.7.0 h1:hKShHYpbIldE1Q591vodI6iaAZ/IUOyC1DqUUJZysNU=


### PR DESCRIPTION
# Description

Bumping rudder-go-kit version to [v0.59.4](https://github.com/rudderlabs/rudder-go-kit/releases/tag/v0.59.4) to fix gcra's throttler caching issue where the cache key was not including the throttling rate.

## Linear Ticket

resolves PIPE-2284

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
