### PR TITLE
chore: throttler should emit no warning if not enabled

### DIFF
--- a/router/throttler/internal/adaptive/adaptive_all_event_types.go
+++ b/router/throttler/internal/adaptive/adaptive_all_event_types.go
@@ -36,8 +36,7 @@ func NewAllEventTypesThrottler(destType, destinationID string, algorithm Algorit
 		),
 		staticCost: false,
 
-		everyInvalidConfig: kitsync.NewOnceEvery(time.Minute),
-		everyGauge:         kitsync.NewOnceEvery(time.Second),
+		everyGauge: kitsync.NewOnceEvery(time.Second),
 		limitFactorGauge: stat.NewTaggedStat("adaptive_throttler_limit_factor", stats.GaugeType, stats.Tags{
 			"destinationId": destinationID,
 			"destType":      destType,

--- a/router/throttler/internal/adaptive/adaptive_all_event_types_test.go
+++ b/router/throttler/internal/adaptive/adaptive_all_event_types_test.go
@@ -174,7 +174,6 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
-
 		})
 
 		t.Run("ReturnsNotLimitedWhenMinLimitGreaterThanMaxLimit", func(t *testing.T) {
@@ -199,7 +198,6 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog)
-
 		})
 	})
 
@@ -327,7 +325,6 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
-
 		})
 
 		t.Run("EmitsWarningForZeroMaxLimit", func(t *testing.T) {
@@ -356,7 +353,6 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
-
 		})
 
 		t.Run("EmitsWarningForZeroWindow", func(t *testing.T) {
@@ -381,7 +377,6 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
-
 		})
 
 		t.Run("EmitsWarningWhenMinLimitGreaterThanMaxLimit", func(t *testing.T) {
@@ -406,7 +401,6 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
-
 		})
 
 		t.Run("DoesNotEmitWarningForenabled", func(t *testing.T) {
@@ -619,7 +613,6 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			// Limit factor gauge should also exist but have value 0
 			factorMetrics := statsStore.GetByName("adaptive_throttler_limit_factor")
 			require.NotEmpty(t, factorMetrics)
-
 		})
 	})
 

--- a/router/throttler/internal/adaptive/adaptive_all_event_types_test.go
+++ b/router/throttler/internal/adaptive/adaptive_all_event_types_test.go
@@ -153,7 +153,7 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			require.False(t, limited)
 		})
 
-		t.Run("ReturnsNotLimitedForInvalidConfiguration", func(t *testing.T) {
+		t.Run("ReturnsNotLimitedIfNotEnabled", func(t *testing.T) {
 			config := config.New()
 			statsStore, err := memstats.New()
 			require.NoError(t, err)
@@ -175,9 +175,6 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 
 		t.Run("ReturnsNotLimitedWhenMinLimitGreaterThanMaxLimit", func(t *testing.T) {
@@ -203,13 +200,10 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog)
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 	})
 
-	t.Run("validConfiguration", func(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
 		t.Run("ReturnsTrueForValidConfig", func(t *testing.T) {
 			config := config.New()
 			statsStore, err := memstats.New()
@@ -226,7 +220,7 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 
 			throttler := NewAllEventTypesThrottler(destType, destinationID, mockAlgorithm, mockLimiter, config, statsStore, logger.NOP)
 
-			require.True(t, throttler.validConfiguration())
+			require.True(t, throttler.enabled())
 		})
 
 		t.Run("ReturnsFalseForZeroMinLimit", func(t *testing.T) {
@@ -245,7 +239,7 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 
 			throttler := NewAllEventTypesThrottler(destType, destinationID, mockAlgorithm, mockLimiter, config, statsStore, logger.NOP)
 
-			require.False(t, throttler.validConfiguration())
+			require.False(t, throttler.enabled())
 		})
 
 		t.Run("ReturnsFalseForZeroMaxLimit", func(t *testing.T) {
@@ -268,7 +262,7 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 
 			throttler := NewAllEventTypesThrottler(destType, destinationID, mockAlgorithm, mockLimiter, config, statsStore, logger.NOP)
 
-			require.False(t, throttler.validConfiguration())
+			require.False(t, throttler.enabled())
 		})
 
 		t.Run("ReturnsFalseForZeroWindow", func(t *testing.T) {
@@ -287,7 +281,7 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 
 			throttler := NewAllEventTypesThrottler(destType, destinationID, mockAlgorithm, mockLimiter, config, statsStore, logger.NOP)
 
-			require.False(t, throttler.validConfiguration())
+			require.False(t, throttler.enabled())
 		})
 
 		t.Run("ReturnsFalseWhenMinLimitGreaterThanMaxLimit", func(t *testing.T) {
@@ -306,11 +300,11 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 
 			throttler := NewAllEventTypesThrottler(destType, destinationID, mockAlgorithm, mockLimiter, config, statsStore, logger.NOP)
 
-			require.False(t, throttler.validConfiguration())
+			require.False(t, throttler.enabled())
 		})
 	})
 
-	t.Run("InvalidConfigurationWarningLogs", func(t *testing.T) {
+	t.Run("InenabledWarningLogs", func(t *testing.T) {
 		t.Run("EmitsWarningForZeroMinLimit", func(t *testing.T) {
 			config := config.New()
 			statsStore, err := memstats.New()
@@ -334,9 +328,6 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 
 		t.Run("EmitsWarningForZeroMaxLimit", func(t *testing.T) {
@@ -366,9 +357,6 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 
 		t.Run("EmitsWarningForZeroWindow", func(t *testing.T) {
@@ -394,9 +382,6 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 
 		t.Run("EmitsWarningWhenMinLimitGreaterThanMaxLimit", func(t *testing.T) {
@@ -422,12 +407,9 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 
-		t.Run("DoesNotEmitWarningForValidConfiguration", func(t *testing.T) {
+		t.Run("DoesNotEmitWarningForenabled", func(t *testing.T) {
 			config := config.New()
 			statsStore, err := memstats.New()
 			require.NoError(t, err)
@@ -626,7 +608,7 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 
 			throttler := NewAllEventTypesThrottler(destType, destinationID, mockAlgorithm, mockLimiter, config, statsStore, logger.NOP)
 
-			// This should not call limiter due to invalid config
+			// This should not call limiter due to not being enabled
 			_, err = throttler.CheckLimitReached(context.Background(), 1)
 			require.NoError(t, err)
 
@@ -634,20 +616,10 @@ func TestAdaptiveAllEventTypesThrottler(t *testing.T) {
 			rateLimitMetrics := statsStore.GetByName("throttling_rate_limit")
 			require.NotEmpty(t, rateLimitMetrics)
 
-			// But limit factor gauge should still be updated
+			// Limit factor gauge should also exist but have value 0
 			factorMetrics := statsStore.GetByName("adaptive_throttler_limit_factor")
 			require.NotEmpty(t, factorMetrics)
 
-			found := false
-			for _, metric := range factorMetrics {
-				if metric.Tags["destinationId"] == destinationID &&
-					metric.Tags["destType"] == destType {
-					require.Equal(t, float64(0.6), metric.Value)
-					found = true
-					break
-				}
-			}
-			require.True(t, found, "Should find limit factor metric with correct tags")
 		})
 	})
 

--- a/router/throttler/internal/adaptive/adaptive_per_event_type.go
+++ b/router/throttler/internal/adaptive/adaptive_per_event_type.go
@@ -44,8 +44,7 @@ func NewPerEventTypeThrottler(destType, destinationID, eventType string,
 		// static cost for per-event-type throttler: cost was originally introduced to address rate limit differences between different event types, so not needed when using per-event-type throttler
 		staticCost: true,
 
-		everyInvalidConfig: kitsync.NewOnceEvery(time.Minute),
-		everyGauge:         kitsync.NewOnceEvery(time.Second),
+		everyGauge: kitsync.NewOnceEvery(time.Second),
 		limitFactorGauge: stat.NewTaggedStat("adaptive_throttler_limit_factor", stats.GaugeType, stats.Tags{
 			"destinationId": destinationID,
 			"eventType":     eventType,

--- a/router/throttler/internal/adaptive/adaptive_per_event_type_test.go
+++ b/router/throttler/internal/adaptive/adaptive_per_event_type_test.go
@@ -182,7 +182,6 @@ func TestAdaptivePerEventTypeThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
-
 		})
 
 		t.Run("ReturnsNotLimitedWhenMinLimitGreaterThanMaxLimit", func(t *testing.T) {
@@ -208,7 +207,6 @@ func TestAdaptivePerEventTypeThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog)
-
 		})
 
 		t.Run("IgnoresCostParameterAndUsesConstantCost", func(t *testing.T) {
@@ -536,7 +534,6 @@ func TestAdaptivePerEventTypeThrottler(t *testing.T) {
 			// Limit factor gauge should also exist but have value 0
 			factorMetrics := statsStore.GetByName("adaptive_throttler_limit_factor")
 			require.NotEmpty(t, factorMetrics)
-
 		})
 	})
 

--- a/router/throttler/internal/adaptive/adaptive_per_event_type_test.go
+++ b/router/throttler/internal/adaptive/adaptive_per_event_type_test.go
@@ -160,7 +160,7 @@ func TestAdaptivePerEventTypeThrottler(t *testing.T) {
 			require.False(t, limited)
 		})
 
-		t.Run("ReturnsNotLimitedForInvalidConfiguration", func(t *testing.T) {
+		t.Run("ReturnsNotLimitedForInenabled", func(t *testing.T) {
 			config := config.New()
 			statsStore, err := memstats.New()
 			require.NoError(t, err)
@@ -183,9 +183,6 @@ func TestAdaptivePerEventTypeThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 
 		t.Run("ReturnsNotLimitedWhenMinLimitGreaterThanMaxLimit", func(t *testing.T) {
@@ -212,9 +209,6 @@ func TestAdaptivePerEventTypeThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog)
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 
 		t.Run("IgnoresCostParameterAndUsesConstantCost", func(t *testing.T) {
@@ -243,7 +237,7 @@ func TestAdaptivePerEventTypeThrottler(t *testing.T) {
 		})
 	})
 
-	t.Run("validConfiguration", func(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
 		t.Run("ReturnsTrueForValidConfig", func(t *testing.T) {
 			config := config.New()
 			statsStore, err := memstats.New()
@@ -261,7 +255,7 @@ func TestAdaptivePerEventTypeThrottler(t *testing.T) {
 
 			throttler := NewPerEventTypeThrottler(destType, destinationID, eventType, mockAlgorithm, mockLimiter, config, statsStore, logger.NOP)
 
-			require.True(t, throttler.validConfiguration())
+			require.True(t, throttler.enabled())
 		})
 
 		t.Run("ReturnsFalseForZeroMinLimit", func(t *testing.T) {
@@ -281,7 +275,7 @@ func TestAdaptivePerEventTypeThrottler(t *testing.T) {
 
 			throttler := NewPerEventTypeThrottler(destType, destinationID, eventType, mockAlgorithm, mockLimiter, config, statsStore, logger.NOP)
 
-			require.False(t, throttler.validConfiguration())
+			require.False(t, throttler.enabled())
 		})
 
 		t.Run("ReturnsFalseForZeroMaxLimit", func(t *testing.T) {
@@ -307,7 +301,7 @@ func TestAdaptivePerEventTypeThrottler(t *testing.T) {
 
 			throttler := NewPerEventTypeThrottler(destType, destinationID, eventType, mockAlgorithm, mockLimiter, config, statsStore, logger.NOP)
 
-			require.False(t, throttler.validConfiguration())
+			require.False(t, throttler.enabled())
 		})
 
 		t.Run("ReturnsFalseForZeroWindow", func(t *testing.T) {
@@ -327,7 +321,7 @@ func TestAdaptivePerEventTypeThrottler(t *testing.T) {
 
 			throttler := NewPerEventTypeThrottler(destType, destinationID, eventType, mockAlgorithm, mockLimiter, config, statsStore, logger.NOP)
 
-			require.False(t, throttler.validConfiguration())
+			require.False(t, throttler.enabled())
 		})
 
 		t.Run("ReturnsFalseWhenMinLimitGreaterThanMaxLimit", func(t *testing.T) {
@@ -347,7 +341,7 @@ func TestAdaptivePerEventTypeThrottler(t *testing.T) {
 
 			throttler := NewPerEventTypeThrottler(destType, destinationID, eventType, mockAlgorithm, mockLimiter, config, statsStore, logger.NOP)
 
-			require.False(t, throttler.validConfiguration())
+			require.False(t, throttler.enabled())
 		})
 	})
 
@@ -539,21 +533,10 @@ func TestAdaptivePerEventTypeThrottler(t *testing.T) {
 			rateLimitMetrics := statsStore.GetByName("throttling_rate_limit")
 			require.NotEmpty(t, rateLimitMetrics)
 
-			// But limit factor gauge should still be updated
+			// Limit factor gauge should also exist but have value 0
 			factorMetrics := statsStore.GetByName("adaptive_throttler_limit_factor")
 			require.NotEmpty(t, factorMetrics)
 
-			found := false
-			for _, metric := range factorMetrics {
-				if metric.Tags["destinationId"] == destinationID &&
-					metric.Tags["destType"] == destType &&
-					metric.Tags["eventType"] == eventType {
-					require.Equal(t, float64(0.6), metric.Value)
-					found = true
-					break
-				}
-			}
-			require.True(t, found, "Should find limit factor metric with correct tags")
 		})
 	})
 

--- a/router/throttler/internal/static/static_all_event_types.go
+++ b/router/throttler/internal/static/static_all_event_types.go
@@ -29,8 +29,7 @@ func NewAllEventTypesThrottler(destType, destinationID string, limiter types.Lim
 		),
 		staticCost: false,
 
-		onceEveryInvalidConfig: kitsync.NewOnceEvery(time.Minute),
-		onceEveryGauge:         kitsync.NewOnceEvery(time.Second),
+		onceEveryGauge: kitsync.NewOnceEvery(time.Second),
 		rateLimitGauge: stat.NewTaggedStat("throttling_rate_limit", stats.GaugeType, stats.Tags{
 			"destinationId": destinationID,
 			"destType":      destType,

--- a/router/throttler/internal/static/static_all_event_types_test.go
+++ b/router/throttler/internal/static/static_all_event_types_test.go
@@ -156,7 +156,6 @@ func TestAllEventTypesThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
-
 		})
 
 		t.Run("ReturnsNotLimitedForZeroLimit", func(t *testing.T) {
@@ -179,7 +178,6 @@ func TestAllEventTypesThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog)
-
 		})
 
 		t.Run("ReturnsNotLimitedForZeroWindow", func(t *testing.T) {
@@ -202,7 +200,6 @@ func TestAllEventTypesThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog)
-
 		})
 	})
 

--- a/router/throttler/internal/static/static_all_event_types_test.go
+++ b/router/throttler/internal/static/static_all_event_types_test.go
@@ -157,9 +157,6 @@ func TestAllEventTypesThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 
 		t.Run("ReturnsNotLimitedForZeroLimit", func(t *testing.T) {
@@ -183,9 +180,6 @@ func TestAllEventTypesThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog)
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 
 		t.Run("ReturnsNotLimitedForZeroWindow", func(t *testing.T) {
@@ -209,135 +203,10 @@ func TestAllEventTypesThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog)
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 	})
 
-	t.Run("InvalidConfigurationWarningLogs", func(t *testing.T) {
-		t.Run("EmitsWarningForZeroLimit", func(t *testing.T) {
-			config := config.New()
-			statsStore, err := memstats.New()
-			require.NoError(t, err)
-			mockLimiter := &MockLimiter{AllowResult: true}
-			mockLogger := &MockLogger{}
-
-			destType := "WEBHOOK"
-			destinationID := "dest123"
-
-			config.Set("Router.throttler.WEBHOOK.dest123.limit", 0)
-			config.Set("Router.throttler.WEBHOOK.dest123.timeWindow", "10s")
-
-			throttler := NewAllEventTypesThrottler(destType, destinationID, mockLimiter, config, statsStore, mockLogger)
-
-			limited, err := throttler.CheckLimitReached(context.Background(), 5)
-
-			require.NoError(t, err)
-			require.False(t, limited)
-			require.Empty(t, mockLimiter.CallLog)
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
-		})
-
-		t.Run("EmitsWarningForNegativeLimit", func(t *testing.T) {
-			config := config.New()
-			statsStore, err := memstats.New()
-			require.NoError(t, err)
-			mockLimiter := &MockLimiter{AllowResult: true}
-			mockLogger := &MockLogger{}
-
-			destType := "WEBHOOK"
-			destinationID := "dest123"
-
-			config.Set("Router.throttler.WEBHOOK.dest123.limit", -10)
-			config.Set("Router.throttler.WEBHOOK.dest123.timeWindow", "10s")
-
-			throttler := NewAllEventTypesThrottler(destType, destinationID, mockLimiter, config, statsStore, mockLogger)
-
-			limited, err := throttler.CheckLimitReached(context.Background(), 5)
-
-			require.NoError(t, err)
-			require.False(t, limited)
-			require.Empty(t, mockLimiter.CallLog)
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
-		})
-
-		t.Run("EmitsWarningForZeroTimeWindow", func(t *testing.T) {
-			config := config.New()
-			statsStore, err := memstats.New()
-			require.NoError(t, err)
-			mockLimiter := &MockLimiter{AllowResult: true}
-			mockLogger := &MockLogger{}
-
-			destType := "WEBHOOK"
-			destinationID := "dest123"
-
-			config.Set("Router.throttler.WEBHOOK.dest123.limit", 100)
-			config.Set("Router.throttler.WEBHOOK.dest123.timeWindow", "0s")
-
-			throttler := NewAllEventTypesThrottler(destType, destinationID, mockLimiter, config, statsStore, mockLogger)
-
-			limited, err := throttler.CheckLimitReached(context.Background(), 5)
-
-			require.NoError(t, err)
-			require.False(t, limited)
-			require.Empty(t, mockLimiter.CallLog)
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
-		})
-
-		t.Run("EmitsWarningForNegativeTimeWindow", func(t *testing.T) {
-			config := config.New()
-			statsStore, err := memstats.New()
-			require.NoError(t, err)
-			mockLimiter := &MockLimiter{AllowResult: true}
-			mockLogger := &MockLogger{}
-
-			destType := "WEBHOOK"
-			destinationID := "dest123"
-
-			config.Set("Router.throttler.WEBHOOK.dest123.limit", 100)
-			config.Set("Router.throttler.WEBHOOK.dest123.timeWindow", "-5s")
-
-			throttler := NewAllEventTypesThrottler(destType, destinationID, mockLimiter, config, statsStore, mockLogger)
-
-			limited, err := throttler.CheckLimitReached(context.Background(), 5)
-
-			require.NoError(t, err)
-			require.False(t, limited)
-			require.Empty(t, mockLimiter.CallLog)
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
-		})
-
-		t.Run("EmitsWarningForMultipleInvalidValues", func(t *testing.T) {
-			config := config.New()
-			statsStore, err := memstats.New()
-			require.NoError(t, err)
-			mockLimiter := &MockLimiter{AllowResult: true}
-			mockLogger := &MockLogger{}
-
-			destType := "WEBHOOK"
-			destinationID := "dest123"
-
-			config.Set("Router.throttler.WEBHOOK.dest123.limit", -1)
-			config.Set("Router.throttler.WEBHOOK.dest123.timeWindow", "0s")
-
-			throttler := NewAllEventTypesThrottler(destType, destinationID, mockLimiter, config, statsStore, mockLogger)
-
-			limited, err := throttler.CheckLimitReached(context.Background(), 5)
-
-			require.NoError(t, err)
-			require.False(t, limited)
-			require.Empty(t, mockLimiter.CallLog)
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
-		})
-	})
-
-	t.Run("validConfiguration", func(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
 		t.Run("ReturnsTrueForValidConfig", func(t *testing.T) {
 			config := config.New()
 			statsStore, err := memstats.New()
@@ -352,7 +221,7 @@ func TestAllEventTypesThrottler(t *testing.T) {
 
 			throttler := NewAllEventTypesThrottler(destType, destinationID, mockLimiter, config, statsStore, logger.NOP)
 
-			require.True(t, throttler.validConfiguration())
+			require.True(t, throttler.enabled())
 		})
 
 		t.Run("ReturnsFalseForZeroLimit", func(t *testing.T) {
@@ -369,7 +238,7 @@ func TestAllEventTypesThrottler(t *testing.T) {
 
 			throttler := NewAllEventTypesThrottler(destType, destinationID, mockLimiter, config, statsStore, logger.NOP)
 
-			require.False(t, throttler.validConfiguration())
+			require.False(t, throttler.enabled())
 		})
 
 		t.Run("ReturnsFalseForZeroWindow", func(t *testing.T) {
@@ -386,7 +255,7 @@ func TestAllEventTypesThrottler(t *testing.T) {
 
 			throttler := NewAllEventTypesThrottler(destType, destinationID, mockLimiter, config, statsStore, logger.NOP)
 
-			require.False(t, throttler.validConfiguration())
+			require.False(t, throttler.enabled())
 		})
 	})
 

--- a/router/throttler/internal/static/static_per_event_type.go
+++ b/router/throttler/internal/static/static_per_event_type.go
@@ -34,8 +34,7 @@ func NewPerEventTypeThrottler(destType, destinationID, eventType string, limiter
 		// static cost for per-event-type throttler: cost was originally introduced to address rate limit differences between different event types, so not needed when using per-event-type throttler
 		staticCost: true,
 
-		onceEveryInvalidConfig: kitsync.NewOnceEvery(time.Minute),
-		onceEveryGauge:         kitsync.NewOnceEvery(time.Second),
+		onceEveryGauge: kitsync.NewOnceEvery(time.Second),
 		rateLimitGauge: stat.NewTaggedStat("throttling_rate_limit", stats.GaugeType, stats.Tags{
 			"destinationId": destinationID,
 			"destType":      destType,

--- a/router/throttler/internal/static/static_per_event_type_test.go
+++ b/router/throttler/internal/static/static_per_event_type_test.go
@@ -165,9 +165,6 @@ func TestPerEventTypeThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 
 		t.Run("ReturnsNotLimitedForZeroLimit", func(t *testing.T) {
@@ -192,9 +189,6 @@ func TestPerEventTypeThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog)
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 
 		t.Run("ReturnsNotLimitedForZeroWindow", func(t *testing.T) {
@@ -219,9 +213,6 @@ func TestPerEventTypeThrottler(t *testing.T) {
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog)
 
-			// Verify warning log was emitted
-			require.Len(t, mockLogger.WarningLogs, 1)
-			require.Contains(t, mockLogger.WarningLogs[0].Message, "Invalid configuration detected")
 		})
 
 		t.Run("IgnoresCostParameterAndUsesConstantCost", func(t *testing.T) {
@@ -248,7 +239,7 @@ func TestPerEventTypeThrottler(t *testing.T) {
 		})
 	})
 
-	t.Run("validConfiguration", func(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
 		t.Run("ReturnsTrueForValidConfig", func(t *testing.T) {
 			config := config.New()
 			statsStore, err := memstats.New()
@@ -264,7 +255,7 @@ func TestPerEventTypeThrottler(t *testing.T) {
 
 			throttler := NewPerEventTypeThrottler(destType, destinationID, eventType, mockLimiter, config, statsStore, logger.NOP)
 
-			require.True(t, throttler.validConfiguration())
+			require.True(t, throttler.enabled())
 		})
 
 		t.Run("ReturnsFalseForZeroLimit", func(t *testing.T) {
@@ -282,7 +273,7 @@ func TestPerEventTypeThrottler(t *testing.T) {
 
 			throttler := NewPerEventTypeThrottler(destType, destinationID, eventType, mockLimiter, config, statsStore, logger.NOP)
 
-			require.False(t, throttler.validConfiguration())
+			require.False(t, throttler.enabled())
 		})
 
 		t.Run("ReturnsFalseForZeroWindow", func(t *testing.T) {
@@ -300,7 +291,7 @@ func TestPerEventTypeThrottler(t *testing.T) {
 
 			throttler := NewPerEventTypeThrottler(destType, destinationID, eventType, mockLimiter, config, statsStore, logger.NOP)
 
-			require.False(t, throttler.validConfiguration())
+			require.False(t, throttler.enabled())
 		})
 	})
 

--- a/router/throttler/internal/static/static_per_event_type_test.go
+++ b/router/throttler/internal/static/static_per_event_type_test.go
@@ -164,7 +164,6 @@ func TestPerEventTypeThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog) // Should not call limiter
-
 		})
 
 		t.Run("ReturnsNotLimitedForZeroLimit", func(t *testing.T) {
@@ -188,7 +187,6 @@ func TestPerEventTypeThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog)
-
 		})
 
 		t.Run("ReturnsNotLimitedForZeroWindow", func(t *testing.T) {
@@ -212,7 +210,6 @@ func TestPerEventTypeThrottler(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, limited)
 			require.Empty(t, mockLimiter.CallLog)
-
 		})
 
 		t.Run("IgnoresCostParameterAndUsesConstantCost", func(t *testing.T) {

--- a/router/throttler/internal/static/throttler.go
+++ b/router/throttler/internal/static/throttler.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
-	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 	"github.com/rudderlabs/rudder-server/router/throttler/internal/types"
@@ -23,17 +22,15 @@ type throttler struct {
 	window     config.ValueLoader[time.Duration]
 	staticCost bool
 
-	onceEveryInvalidConfig *kitsync.OnceEvery
-	onceEveryGauge         *kitsync.OnceEvery
-	rateLimitGauge         stats.Gauge
+	onceEveryGauge *kitsync.OnceEvery
+	rateLimitGauge stats.Gauge
 }
 
 func (t *throttler) CheckLimitReached(ctx context.Context, cost int64) (limited bool, retErr error) {
-	t.updateGauges()
-	if !t.validConfiguration() {
-		t.logInvalidConfigWarning()
+	if !t.enabled() {
 		return false, nil
 	}
+	t.updateGauges()
 	allowed, _, err := t.limiter.Allow(ctx, t.costFn(cost), t.GetLimit(), t.getTimeWindowInSeconds(), t.key)
 	if err != nil {
 		return false, fmt.Errorf("throttling failed for %s: %w", t.key, err)
@@ -41,7 +38,7 @@ func (t *throttler) CheckLimitReached(ctx context.Context, cost int64) (limited 
 	return !allowed, nil
 }
 
-func (t *throttler) validConfiguration() bool {
+func (t *throttler) enabled() bool {
 	return t.limit.Load() > 0 && t.window.Load() > 0
 }
 
@@ -66,15 +63,6 @@ func (t *throttler) updateGauges() {
 		if window := t.getTimeWindowInSeconds(); window > 0 {
 			t.rateLimitGauge.Gauge(t.GetLimit() / window)
 		}
-	})
-}
-
-func (t *throttler) logInvalidConfigWarning() {
-	t.onceEveryInvalidConfig.Do(func() {
-		t.log.Warnn("Invalid configuration detected",
-			logger.NewIntField("limit", t.GetLimit()),
-			logger.NewDurationField("window", t.window.Load()),
-		)
 	})
 }
 


### PR DESCRIPTION
# Description

Our only means of disabling throttling for a destination type or destination id is by setting the limit or window to zero. Thus it makes no sense to emit a warning log in case some throttler is disabled. Renamed `validConfiguration` to `enabled` to avoid any confusion in the future.

Regression introduced by #6181

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
