### PR TITLE
chore: stop collecting errors in proc_error jobsdb

### DIFF
--- a/app/apphandlers/gatewayAppHandler.go
+++ b/app/apphandlers/gatewayAppHandler.go
@@ -90,19 +90,19 @@ func (a *gatewayApp) StartRudderCore(ctx context.Context, options *app.Options) 
 	}
 	defer gatewayDB.Stop()
 
-	errDB := jobsdb.NewForWrite(
+	errorDB := jobsdb.NewForWrite(
 		"proc_error",
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithSkipMaintenanceErr(config.GetBool("Gateway.jobsDB.skipMaintenanceError", true)),
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(dbPool),
 	)
-	defer errDB.Close()
+	defer errorDB.Close()
 
-	if err := errDB.Start(); err != nil {
-		return fmt.Errorf("could not start errDB: %w", err)
+	if err := errorDB.Start(); err != nil {
+		return fmt.Errorf("could not start errorDB: %w", err)
 	}
-	defer errDB.Stop()
+	defer errorDB.Stop()
 
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -145,7 +145,7 @@ func (a *gatewayApp) StartRudderCore(ctx context.Context, options *app.Options) 
 	}
 	streamMsgValidator := stream.NewMessageValidator()
 	err = gw.Setup(ctx, config, logger.NewLogger().Child("gateway"), statsFactory, a.app, backendconfig.DefaultBackendConfig,
-		gatewayDB, errDB, rateLimiter, a.versionHandler, rsourcesService, transformerFeaturesService, sourceHandle,
+		gatewayDB, errorDB, rateLimiter, a.versionHandler, rsourcesService, transformerFeaturesService, sourceHandle,
 		streamMsgValidator, gateway.WithInternalHttpHandlers(
 			map[string]http.Handler{
 				"/drain": drainConfigHttpHandler,

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -186,7 +186,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 		jobsdb.WithDBHandle(dbPool),
 	)
 	defer batchRouterDB.Close()
-	errDBForRead := jobsdb.NewForRead(
+	errorDBForRead := jobsdb.NewForRead(
 		"proc_error",
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithDSLimit(a.config.procErrorDSLimit),
@@ -194,19 +194,19 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(dbPool),
 	)
-	defer errDBForRead.Close()
-	errDBForWrite := jobsdb.NewForWrite(
+	defer errorDBForRead.Close()
+	errorDBForWrite := jobsdb.NewForWrite(
 		"proc_error",
 		jobsdb.WithClearDB(options.ClearDB),
 		jobsdb.WithSkipMaintenanceErr(config.GetBool("Processor.jobsDB.skipMaintenanceError", true)),
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(dbPool),
 	)
-	errDBForWrite.Close()
-	if err = errDBForWrite.Start(); err != nil {
-		return fmt.Errorf("could not start errDBForWrite: %w", err)
+	errorDBForWrite.Close()
+	if err = errorDBForWrite.Start(); err != nil {
+		return fmt.Errorf("could not start errorDBForWrite: %w", err)
 	}
-	defer errDBForWrite.Stop()
+	defer errorDBForWrite.Stop()
 	schemaDB := jobsdb.NewForReadWrite(
 		"esch",
 		jobsdb.WithClearDB(options.ClearDB),
@@ -277,8 +277,8 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 		gwDBForProcessor,
 		routerDB,
 		batchRouterDB,
-		errDBForRead,
-		errDBForWrite,
+		errorDBForRead,
+		errorDBForWrite,
 		schemaDB,
 		archivalDB,
 		reporting,
@@ -306,7 +306,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 			config.GetReloadableDurationVar(1, time.Second, "JobsDB.rt.parameterValuesCacheTtl", "JobsDB.parameterValuesCacheTtl"),
 			routerDB,
 		),
-		ProcErrorDB:                errDBForWrite,
+		ProcErrorDB:                errorDBForWrite,
 		TransientSources:           transientSources,
 		RsourcesService:            rsourcesService,
 		TransformerFeaturesService: transformerFeaturesService,
@@ -322,7 +322,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 			config.GetReloadableDurationVar(1, time.Second, "JobsDB.rt.parameterValuesCacheTtl", "JobsDB.parameterValuesCacheTtl"),
 			batchRouterDB,
 		),
-		ProcErrorDB:           errDBForWrite,
+		ProcErrorDB:           errorDBForWrite,
 		TransientSources:      transientSources,
 		RsourcesService:       rsourcesService,
 		Debugger:              destinationHandle,
@@ -337,7 +337,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, options *app.Options
 		GatewayDB:        gwDBForProcessor,
 		RouterDB:         routerDB,
 		BatchRouterDB:    batchRouterDB,
-		ErrorDB:          errDBForRead,
+		ErrorDB:          errorDBForRead,
 		SchemaForwarder:  schemaForwarder,
 		EventSchemaDB:    schemaDB,
 		ArchivalDB:       archivalDB,

--- a/app/cluster/integration_test.go
+++ b/app/cluster/integration_test.go
@@ -114,11 +114,11 @@ func TestDynamicClusterManager(t *testing.T) {
 
 	archDB := jobsdb.NewForReadWrite("archival", jobsdb.WithStats(stats.NOP))
 	defer archDB.TearDown()
-	readErrDB := jobsdb.NewForRead("proc_error", jobsdb.WithStats(stats.NOP))
-	defer readErrDB.TearDown()
-	writeErrDB := jobsdb.NewForWrite("proc_error", jobsdb.WithStats(stats.NOP))
-	require.NoError(t, writeErrDB.Start())
-	defer writeErrDB.TearDown()
+	readErrorDB := jobsdb.NewForRead("proc_error", jobsdb.WithStats(stats.NOP))
+	defer readErrorDB.TearDown()
+	writeErrorDB := jobsdb.NewForWrite("proc_error", jobsdb.WithStats(stats.NOP))
+	require.NoError(t, writeErrorDB.Start())
+	defer writeErrorDB.TearDown()
 
 	clearDb := false
 	ctx := context.Background()
@@ -131,8 +131,8 @@ func TestDynamicClusterManager(t *testing.T) {
 		gwDB,
 		rtDB,
 		brtDB,
-		readErrDB,
-		writeErrDB,
+		readErrorDB,
+		writeErrorDB,
 		eschDB,
 		archDB,
 		&reporting.NOOP{},
@@ -155,7 +155,7 @@ func TestDynamicClusterManager(t *testing.T) {
 		Reporting:                  &reporting.NOOP{},
 		BackendConfig:              mockBackendConfig,
 		RouterDB:                   rtDB,
-		ProcErrorDB:                readErrDB,
+		ProcErrorDB:                readErrorDB,
 		TransientSources:           transientsource.NewEmptyService(),
 		RsourcesService:            mockRsourcesService,
 		TransformerFeaturesService: transformer.NewNoOpService(),
@@ -165,7 +165,7 @@ func TestDynamicClusterManager(t *testing.T) {
 		Reporting:        &reporting.NOOP{},
 		BackendConfig:    mockBackendConfig,
 		RouterDB:         brtDB,
-		ProcErrorDB:      readErrDB,
+		ProcErrorDB:      readErrorDB,
 		TransientSources: transientsource.NewEmptyService(),
 		RsourcesService:  mockRsourcesService,
 	}
@@ -192,7 +192,7 @@ func TestDynamicClusterManager(t *testing.T) {
 		GatewayDB:       gwDB,
 		RouterDB:        rtDB,
 		BatchRouterDB:   brtDB,
-		ErrorDB:         readErrDB,
+		ErrorDB:         readErrorDB,
 		EventSchemaDB:   eschDB,
 		ArchivalDB:      archDB,
 		SchemaForwarder: schemaForwarder,

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -62,7 +62,7 @@ type Handle struct {
 	application     app.App
 	backendConfig   backendconfig.BackendConfig
 	jobsDB          jobsdb.JobsDB
-	errDB           jobsdb.JobsDB
+	errorDB         jobsdb.JobsDB
 	rateLimiter     throttler.Throttler
 	versionHandler  func(w http.ResponseWriter, r *http.Request)
 	rsourcesService rsources.JobService
@@ -132,6 +132,7 @@ type Handle struct {
 		enableInternalBatchEnrichment        config.ValueLoader[bool]
 		enableEventBlocking                  config.ValueLoader[bool]
 		webhookV2HandlerEnabled              bool
+		errorDBEnabled                       config.ValueLoader[bool]
 	}
 
 	// additional internal http handlers

--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -70,7 +70,7 @@ This function will block until backend config is initially received.
 func (gw *Handle) Setup(
 	ctx context.Context,
 	config *config.Config, logger logger.Logger, stat stats.Stats,
-	application app.App, backendConfig backendconfig.BackendConfig, jobsDB, errDB jobsdb.JobsDB,
+	application app.App, backendConfig backendconfig.BackendConfig, jobsDB, errorDB jobsdb.JobsDB,
 	rateLimiter throttler.Throttler, versionHandler func(w http.ResponseWriter, r *http.Request),
 	rsourcesService rsources.JobService, transformerFeaturesService transformer.FeaturesService,
 	sourcehandle sourcedebugger.SourceDebugger, streamMsgValidator func(message *stream.Message) error,
@@ -83,7 +83,7 @@ func (gw *Handle) Setup(
 	gw.application = application
 	gw.backendConfig = backendConfig
 	gw.jobsDB = jobsDB
-	gw.errDB = errDB
+	gw.errorDB = errorDB
 	gw.rateLimiter = rateLimiter
 	gw.versionHandler = versionHandler
 	gw.rsourcesService = rsourcesService
@@ -129,6 +129,7 @@ func (gw *Handle) Setup(
 	gw.conf.enableInternalBatchEnrichment = config.GetReloadableBoolVar(true, "gateway.enableBatchEnrichment")
 	// enable webhook v2 handler. disabled by default
 	gw.conf.webhookV2HandlerEnabled = config.GetBoolVar(false, "Gateway.webhookV2HandlerEnabled")
+	gw.conf.errorDBEnabled = config.GetReloadableBoolVar(false, "ErrorDB.enabled")
 	// enable event blocking. false by default
 	gw.conf.enableEventBlocking = config.GetReloadableBoolVar(false, "enableEventBlocking")
 	// Registering stats

--- a/gateway/handle_test.go
+++ b/gateway/handle_test.go
@@ -92,6 +92,7 @@ func createTestGateway(t *testing.T, enableEventBlocking bool, eventBlockingSett
 			enableInternalBatchEnrichment                                                     config.ValueLoader[bool]
 			enableEventBlocking                                                               config.ValueLoader[bool]
 			webhookV2HandlerEnabled                                                           bool
+			errorDBEnabled                                                                    config.ValueLoader[bool]
 		}{
 			enableEventBlocking:           config.SingleValueLoader(enableEventBlocking),
 			enableInternalBatchValidator:  config.SingleValueLoader(false),

--- a/gateway/handle_webhook.go
+++ b/gateway/handle_webhook.go
@@ -30,6 +30,10 @@ func (gw *Handle) ProcessTransformedWebhookRequest(w *http.ResponseWriter, r *ht
 
 // SaveWebhookFailures saves errors to the error db
 func (gw *Handle) SaveWebhookFailures(reqs []*model.FailedWebhookPayload) error {
+	if !gw.conf.errorDBEnabled.Load() {
+		return nil
+	}
+
 	jobs := make([]*jobsdb.JobT, 0, len(reqs))
 	for _, req := range reqs {
 		params := map[string]any{
@@ -63,5 +67,5 @@ func (gw *Handle) SaveWebhookFailures(reqs []*model.FailedWebhookPayload) error 
 
 	ctx, cancel := context.WithTimeout(context.Background(), gw.conf.WriteTimeout)
 	defer cancel()
-	return gw.errDB.Store(ctx, jobs)
+	return gw.errorDB.Store(ctx, jobs)
 }

--- a/gateway/webhook/integration_test.go
+++ b/gateway/webhook/integration_test.go
@@ -99,13 +99,13 @@ func TestIntegrationWebhook(t *testing.T) {
 	require.NoError(t, gatewayDB.Start())
 	defer gatewayDB.TearDown()
 
-	errDB := jobsdb.NewForReadWrite(
+	errorDB := jobsdb.NewForReadWrite(
 		"err",
 		jobsdb.WithDBHandle(p.DB),
 		jobsdb.WithStats(stats.NOP),
 	)
-	require.NoError(t, errDB.Start())
-	defer errDB.TearDown()
+	require.NoError(t, errorDB.Start())
+	defer errorDB.TearDown()
 
 	var (
 		rateLimiter        throttler.Throttler
@@ -167,7 +167,7 @@ func TestIntegrationWebhook(t *testing.T) {
 		conf, logger, stat,
 		application,
 		backendconfigtest.NewStaticLibrary(bcs),
-		gatewayDB, errDB,
+		gatewayDB, errorDB,
 		rateLimiter, versionHandler, rsources.NewNoOpService(), transformerFeaturesService, sourcedebugger.NewNoOpService(),
 		streamMsgValidator,
 		gateway.WithNow(func() time.Time {
@@ -315,7 +315,7 @@ func TestIntegrationWebhook(t *testing.T) {
 			}
 
 			require.Eventually(t, func() bool {
-				r, err = errDB.GetUnprocessed(ctx, jobsdb.GetQueryParams{
+				r, err = errorDB.GetUnprocessed(ctx, jobsdb.GetQueryParams{
 					WorkspaceID: workspaceID,
 					ParameterFilters: []jobsdb.ParameterFilterT{{
 						Name:  "source_id",

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -32,8 +32,8 @@ type LifecycleManager struct {
 	gatewayDB                  jobsdb.JobsDB
 	routerDB                   jobsdb.JobsDB
 	batchRouterDB              jobsdb.JobsDB
-	readErrDB                  jobsdb.JobsDB
-	writeErrDB                 jobsdb.JobsDB
+	readErrorDB                jobsdb.JobsDB
+	writeErrorDB               jobsdb.JobsDB
 	esDB                       jobsdb.JobsDB
 	arcDB                      jobsdb.JobsDB
 	clearDB                    *bool
@@ -64,8 +64,8 @@ func (proc *LifecycleManager) Start() error {
 		proc.gatewayDB,
 		proc.routerDB,
 		proc.batchRouterDB,
-		proc.readErrDB,
-		proc.writeErrDB,
+		proc.readErrorDB,
+		proc.writeErrorDB,
 		proc.esDB,
 		proc.arcDB,
 		proc.ReportingI,
@@ -117,7 +117,7 @@ func (proc *LifecycleManager) Stop() {
 func New(
 	ctx context.Context,
 	clearDb *bool,
-	gwDb, rtDb, brtDb, errDbForRead, errDBForWrite, esDB, arcDB jobsdb.JobsDB,
+	gwDb, rtDb, brtDb, errorDBForRead, errorDBForWrite, esDB, arcDB jobsdb.JobsDB,
 	reporting types.Reporting,
 	transientSources transientsource.Service,
 	fileuploader fileuploader.Provider,
@@ -144,8 +144,8 @@ func New(
 		gatewayDB:                  gwDb,
 		routerDB:                   rtDb,
 		batchRouterDB:              brtDb,
-		readErrDB:                  errDbForRead,
-		writeErrDB:                 errDBForWrite,
+		readErrorDB:                errorDBForRead,
+		writeErrorDB:               errorDBForWrite,
 		esDB:                       esDB,
 		arcDB:                      arcDB,
 		clearDB:                    clearDb,

--- a/processor/manager_test.go
+++ b/processor/manager_test.go
@@ -136,17 +136,17 @@ func TestProcessorManager(t *testing.T) {
 		jobsdb.WithStats(stats.NOP),
 	)
 	defer brtDB.Close()
-	readErrDB := jobsdb.NewForRead("proc_error",
+	readErrorDB := jobsdb.NewForRead("proc_error",
 		jobsdb.WithConfig(c),
 		jobsdb.WithStats(stats.NOP),
 	)
-	defer readErrDB.Close()
-	writeErrDB := jobsdb.NewForWrite("proc_error",
+	defer readErrorDB.Close()
+	writeErrorDB := jobsdb.NewForWrite("proc_error",
 		jobsdb.WithConfig(c),
 		jobsdb.WithStats(stats.NOP),
 	)
-	require.NoError(t, writeErrDB.Start())
-	defer writeErrDB.TearDown()
+	require.NoError(t, writeErrorDB.Start())
+	defer writeErrorDB.TearDown()
 	eschDB := jobsdb.NewForReadWrite("esch",
 		jobsdb.WithConfig(c),
 		jobsdb.WithStats(stats.NOP),
@@ -167,8 +167,8 @@ func TestProcessorManager(t *testing.T) {
 		gwDB,
 		rtDB,
 		brtDB,
-		readErrDB,
-		writeErrDB,
+		readErrorDB,
+		writeErrorDB,
 		eschDB,
 		archDB,
 		&reporting.NOOP{},
@@ -193,8 +193,8 @@ func TestProcessorManager(t *testing.T) {
 		defer rtDB.Stop()
 		require.NoError(t, brtDB.Start())
 		defer brtDB.Stop()
-		require.NoError(t, readErrDB.Start())
-		defer readErrDB.Stop()
+		require.NoError(t, readErrorDB.Start())
+		defer readErrorDB.Stop()
 		mockBackendConfig.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
 			func(ctx context.Context, topic backendconfig.Topic) pubsub.DataChannel {
 				ch := make(chan pubsub.DataEvent, 1)
@@ -246,8 +246,8 @@ func TestProcessorManager(t *testing.T) {
 		defer rtDB.Stop()
 		require.NoError(t, brtDB.Start())
 		defer brtDB.Stop()
-		require.NoError(t, readErrDB.Start())
-		defer readErrDB.Stop()
+		require.NoError(t, readErrorDB.Start())
+		defer readErrorDB.Stop()
 		mockBackendConfig.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
 			func(ctx context.Context, topic backendconfig.Topic) pubsub.DataChannel {
 				ch := make(chan pubsub.DataEvent, 1)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -178,6 +178,7 @@ type Handle struct {
 		userTransformationMirroringFireAndForget  config.ValueLoader[bool]
 		storeSamplerEnabled                       config.ValueLoader[bool]
 		enableOptimizedConnectionDetailsKey       config.ValueLoader[bool]
+		errorDBEnabled                            config.ValueLoader[bool]
 	}
 
 	drainConfig struct {
@@ -779,6 +780,7 @@ func (proc *Handle) loadReloadableConfig(defaultPayloadLimit int64, defaultMaxEv
 	proc.config.userTransformationMirroringFireAndForget = proc.conf.GetReloadableBoolVar(false, "Processor.userTransformationMirroring.fireAndForget")
 	proc.config.storeSamplerEnabled = proc.conf.GetReloadableBoolVar(false, "Processor.storeSamplerEnabled")
 	proc.config.enableOptimizedConnectionDetailsKey = proc.conf.GetReloadableBoolVar(false, "Processor.enableOptimizedConnectionDetailsKey")
+	proc.config.errorDBEnabled = proc.conf.GetReloadableBoolVar(false, "ErrorDB.enabled")
 }
 
 type connection struct {
@@ -2848,15 +2850,17 @@ func (proc *Handle) storeStage(partition string, pipelineIndex int, in *storeMes
 	}
 	if len(in.procErrorJobs) > 0 {
 		g.Go(func() error {
-			err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout.Load(), proc.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
-				return proc.writeErrorDB.Store(ctx, in.procErrorJobs)
-			}, proc.sendRetryStoreStats)
-			if err != nil {
-				proc.logger.Errorn("Store into proc error table failed", obskit.Error(err))
-				proc.logger.Errorn("procErrorJobs", logger.NewIntField("jobCount", int64(len(in.procErrorJobs))))
-				return err
+			if proc.config.errorDBEnabled.Load() {
+				err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout.Load(), proc.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
+					return proc.writeErrorDB.Store(ctx, in.procErrorJobs)
+				}, proc.sendRetryStoreStats)
+				if err != nil {
+					proc.logger.Errorn("Store into proc error table failed", obskit.Error(err))
+					proc.logger.Errorn("procErrorJobs", logger.NewIntField("jobCount", int64(len(in.procErrorJobs))))
+					return err
+				}
+				proc.logger.Debugn("[Processor] Total jobs written to proc_error", logger.NewIntField("jobCount", int64(len(in.procErrorJobs))))
 			}
-			proc.logger.Debugn("[Processor] Total jobs written to proc_error", logger.NewIntField("jobCount", int64(len(in.procErrorJobs))))
 			proc.recordEventDeliveryStatus(in.procErrorJobsByDestID)
 			return nil
 		})

--- a/processor/stash/stash.go
+++ b/processor/stash/stash.go
@@ -52,7 +52,7 @@ type HandleT struct {
 		jobdDBQueryRequestTimeout config.ValueLoader[time.Duration]
 		jobdDBMaxRetries          config.ValueLoader[int]
 		errorStashEnabled         config.ValueLoader[bool]
-		errDBReadBatchSize        config.ValueLoader[int]
+		errorDBReadBatchSize      config.ValueLoader[int]
 		noOfErrStashWorkers       config.ValueLoader[int]
 		maxFailedCountForErrJob   config.ValueLoader[int]
 		pkgLogger                 logger.Logger
@@ -71,7 +71,7 @@ func (st *HandleT) Setup(
 	adaptiveLimitFunc func(int64) int64,
 ) {
 	st.config.errorStashEnabled = config.GetReloadableBoolVar(true, "Processor.errorStashEnabled")
-	st.config.errDBReadBatchSize = config.GetReloadableIntVar(1000, 1, "Processor.errDBReadBatchSize")
+	st.config.errorDBReadBatchSize = config.GetReloadableIntVar(1000, 1, "Processor.errDBReadBatchSize")
 	st.config.noOfErrStashWorkers = config.GetReloadableIntVar(2, 1, "Processor.noOfErrStashWorkers")
 	st.config.maxFailedCountForErrJob = config.GetReloadableIntVar(3, 1, "Processor.maxFailedCountForErrJob")
 	st.config.payloadLimit = config.GetReloadableInt64Var(100*bytesize.MB, 1, "Processor.stashPayloadLimit")
@@ -332,7 +332,7 @@ func (st *HandleT) readErrJobsLoop(ctx context.Context) {
 			queryParams := jobsdb.GetQueryParams{
 				CustomValFilters:              []string{""},
 				IgnoreCustomValFiltersInQuery: true,
-				JobsLimit:                     st.config.errDBReadBatchSize.Load(),
+				JobsLimit:                     st.config.errorDBReadBatchSize.Load(),
 				PayloadSizeLimit:              st.adaptiveLimit(st.config.payloadLimit.Load()),
 			}
 

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -416,13 +416,8 @@ var _ = Describe("BatchRouter", func() {
 				Do(func(ctx context.Context, _ interface{}, statuses []*jobsdb.JobStatusT, _, _ interface{}) {
 					assertJobStatus(toRetryJobsList[0], statuses[0], jobsdb.Aborted.State, "{\"reason\":\"source_not_found\"}", 130)
 					assertJobStatus(toRetryJobsList[1], statuses[1], jobsdb.Aborted.State, "{\"reason\":\"source_not_found\"}", 4)
-				}).Return(nil)
-			c.mockProcErrorsDB.EXPECT().Store(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
-				func(ctx context.Context, _ []*jobsdb.JobT) error {
 					cancel()
-					return nil
-				},
-			)
+				}).Return(nil)
 
 			<-batchrouter.backendConfigInitialized
 			batchrouter.minIdleSleep = config.SingleValueLoader(time.Microsecond)

--- a/router/batchrouter/batchrouter_test.go
+++ b/router/batchrouter/batchrouter_test.go
@@ -550,12 +550,12 @@ func TestBatchRouter(t *testing.T) {
 	require.NoError(t, routerDB.Start())
 	defer routerDB.TearDown()
 
-	errDB := jobsdb.NewForReadWrite(
+	errorDB := jobsdb.NewForReadWrite(
 		"err",
 		jobsdb.WithDBHandle(p.DB),
 	)
-	require.NoError(t, errDB.Start())
-	defer errDB.TearDown()
+	require.NoError(t, errorDB.Start())
+	defer errorDB.TearDown()
 
 	minioResource, err := minio.Setup(pool, t)
 	require.NoError(t, err)
@@ -637,7 +637,7 @@ func TestBatchRouter(t *testing.T) {
 		"MINIO",
 		backendconfigtest.NewStaticLibrary(bcs),
 		routerDB,
-		errDB,
+		errorDB,
 		nil,
 		transientsource.NewEmptyService(),
 		rsources.NewNoOpService(),

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -99,6 +99,7 @@ type Handle struct {
 	transformerURL               string
 	datePrefixOverride           config.ValueLoader[string]
 	customDatePrefix             config.ValueLoader[string]
+	errorDBEnabled               config.ValueLoader[bool]
 
 	drainer routerutils.Drainer
 
@@ -765,7 +766,7 @@ func (brt *Handle) updateJobStatus(batchJobs *BatchedJobs, isWarehouse bool, err
 	}
 
 	// Store the aborted jobs to errorDB
-	if abortedEvents != nil {
+	if len(abortedEvents) > 0 && brt.errorDBEnabled.Load() {
 		err := misc.RetryWithNotify(context.Background(), brt.jobsDBCommandTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
 			return brt.errorDB.Store(ctx, abortedEvents)
 		}, brt.sendRetryStoreStats)

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -210,6 +210,7 @@ func (brt *Handle) setupReloadableVars() {
 	brt.warehouseServiceMaxRetryTime = config.GetReloadableDurationVar(3, time.Hour, "BatchRouter.warehouseServiceMaxRetryTime", "BatchRouter.warehouseServiceMaxRetryTimeinHr")
 	brt.datePrefixOverride = config.GetReloadableStringVar("", "BatchRouter.datePrefixOverride")
 	brt.customDatePrefix = config.GetReloadableStringVar("", "BatchRouter.customDatePrefix")
+	brt.errorDBEnabled = config.GetReloadableBoolVar(false, "ErrorDB.enabled")
 }
 
 func (brt *Handle) startAsyncDestinationManager() {

--- a/router/handle.go
+++ b/router/handle.go
@@ -78,6 +78,7 @@ type Handle struct {
 	saveDestinationResponse            bool
 	saveDestinationResponseOverride    config.ValueLoader[bool]
 	reportJobsdbPayload                config.ValueLoader[bool]
+	errorDBEnabled                     config.ValueLoader[bool]
 
 	diagnosisTickerTime time.Duration
 
@@ -476,7 +477,7 @@ func (rt *Handle) commitStatusList(workerJobStatuses *[]workerJobStatus) {
 			return statusList[i].JobID < statusList[j].JobID
 		})
 		// Store the aborted jobs to errorDB
-		if routerAbortedJobs != nil {
+		if len(routerAbortedJobs) > 0 && rt.errorDBEnabled.Load() {
 			err := misc.RetryWithNotify(context.Background(), rt.reloadableConfig.jobsDBCommandTimeout.Load(), rt.reloadableConfig.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
 				return rt.errorDB.Store(ctx, routerAbortedJobs)
 			}, rt.sendRetryStoreStats)

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -119,6 +119,7 @@ func (rt *Handle) Setup(
 	rt.eventOrderDisabledStateDuration = config.GetReloadableDurationVar(20, time.Minute, getRouterConfigKeys("eventOrderDisabledStateDuration", destType)...)
 	rt.eventOrderHalfEnabledStateDuration = config.GetReloadableDurationVar(10, time.Minute, getRouterConfigKeys("eventOrderHalfEnabledStateDuration", destType)...)
 	rt.reportJobsdbPayload = config.GetReloadableBoolVar(true, getRouterConfigKeys("reportJobsdbPayload", destType)...)
+	rt.errorDBEnabled = config.GetReloadableBoolVar(false, "ErrorDB.enabled")
 	rt.saveDestinationResponseOverride = config.GetReloadableBoolVar(false, getRouterConfigKeys("saveDestinationResponseOverride", destType)...)
 
 	statTags := stats.Tags{"destType": rt.destType}

--- a/router/manager/manager_test.go
+++ b/router/manager/manager_test.go
@@ -128,16 +128,16 @@ func TestRouterManager(t *testing.T) {
 	rtDB := jobsdb.NewForReadWrite("rt")
 	mockRtDB := &mockJobsDB{JobsDB: rtDB}
 	brtDB := jobsdb.NewForReadWrite("batch_rt")
-	errDB := jobsdb.NewForReadWrite("proc_error")
+	errorDB := jobsdb.NewForReadWrite("proc_error")
 	defer rtDB.Close()
 	defer brtDB.Close()
-	defer errDB.Close()
+	defer errorDB.Close()
 	rtFactory := &router.Factory{
 		Logger:                     logger.NOP,
 		Reporting:                  &reporting.NOOP{},
 		BackendConfig:              mockBackendConfig,
 		RouterDB:                   mockRtDB,
-		ProcErrorDB:                errDB,
+		ProcErrorDB:                errorDB,
 		TransientSources:           transientsource.NewEmptyService(),
 		RsourcesService:            mockRsourcesService,
 		ThrottlerFactory:           throttler.NewNoOpThrottlerFactory(),
@@ -147,7 +147,7 @@ func TestRouterManager(t *testing.T) {
 		Reporting:        &reporting.NOOP{},
 		BackendConfig:    mockBackendConfig,
 		RouterDB:         brtDB,
-		ProcErrorDB:      errDB,
+		ProcErrorDB:      errorDB,
 		TransientSources: transientsource.NewEmptyService(),
 		RsourcesService:  mockRsourcesService,
 	}
@@ -156,7 +156,7 @@ func TestRouterManager(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		require.NoError(t, rtDB.Start())
 		require.NoError(t, brtDB.Start())
-		require.NoError(t, errDB.Start())
+		require.NoError(t, errorDB.Start())
 		require.NoError(t, r.Start())
 		require.Eventually(t, func() bool {
 			return mockRtDB.called.Load()
@@ -164,7 +164,7 @@ func TestRouterManager(t *testing.T) {
 		r.Stop()
 		rtDB.Stop()
 		brtDB.Stop()
-		errDB.Stop()
+		errorDB.Stop()
 		mockRtDB.called.Store(false)
 	}
 }


### PR DESCRIPTION
# Description

We are no longer be collecting errors in `proc_error` jobsdb as we are planning to remove error collection for debugging purposes in the near future. 

What was happening until now:

- rudder-server was collecting failed jobs from webhook, processor steps, router, and batchrouter, and was storing these failed jobs in the `proc_error` JobsDB.
- periodically, the `stash` processor component was creating backup files from the `proc_error` JobsDB and uploading them to `rudder-proc-err-logs` in object storage.

In the past, we relied on `proc_error` jobs for replays, but that’s no longer the case. At this point, it feels like we’re spending unnecessary resources collecting and storing all this information which no-one actually needs, using as an excuse that it is useful for debugging purposes…

As a first step we are stopping collection and storage of failed jobs to `proc_error`. In a follow up step we will be removing all relevant `proc_error` code altogether.

## Linear Ticket

resolves PIPE-2295

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
