### PR TITLE
fix: handling empty schema for table level schemas

### DIFF
--- a/warehouse/internal/repo/schema.go
+++ b/warehouse/internal/repo/schema.go
@@ -231,7 +231,7 @@ func (sh *WHSchema) GetForNamespace(ctx context.Context, destID, namespace strin
 	if err != nil {
 		return model.WHSchema{}, err
 	}
-	if !reflect.DeepEqual(originalSchema.Schema, tableLevelSchemas) {
+	if len(originalSchema.Schema) > 0 && !reflect.DeepEqual(originalSchema.Schema, tableLevelSchemas) {
 		return model.WHSchema{}, errors.New("parent schema does not match parent schema")
 	}
 	return originalSchema, nil

--- a/warehouse/internal/repo/schema_test.go
+++ b/warehouse/internal/repo/schema_test.go
@@ -417,6 +417,26 @@ func TestWHSchemasRepo(t *testing.T) {
 						{TableName: "table_name_2", Schema: schemaModel["table_name_2"]},
 					}, tableLevelSchemasResult)
 				})
+
+				t.Run("Empty schema", func(t *testing.T) {
+					emptySchema := model.WHSchema{
+						SourceID:        "empty_source_id_1",
+						Namespace:       "empty_namespace_1",
+						DestinationID:   "empty_destination_id_1",
+						DestinationType: destinationType,
+						Schema:          map[string]model.TableSchema{},
+						CreatedAt:       now,
+						UpdatedAt:       now,
+						ExpiresAt:       now.Add(time.Hour),
+					}
+
+					err := r.Insert(ctx, &emptySchema)
+					require.NoError(t, err)
+
+					expectedSchema, err := r.GetForNamespace(ctx, "empty_destination_id_1", "empty_namespace_1")
+					require.NoError(t, err)
+					require.Empty(t, expectedSchema.Schema)
+				})
 			})
 		})
 	}


### PR DESCRIPTION
# Description

- Do validation of table-level schemas only in case if some schema is present. 

## Linear Ticket

- Resolves WAR-1017

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
