### PR TITLE
chore: remove null handling of upload id in load files

### DIFF
--- a/warehouse/internal/loadfiles/loadfiles_test.go
+++ b/warehouse/internal/loadfiles/loadfiles_test.go
@@ -133,7 +133,7 @@ func TestCreateLoadFiles_DestinationHistory(t *testing.T) {
 	var tableNames []string
 	for _, loadFile := range loadFiles {
 		require.Contains(t, loadFile.Location, loadFile.TableName)
-		require.Equal(t, job.Upload.ID, *loadFile.UploadID)
+		require.Equal(t, job.Upload.ID, loadFile.UploadID)
 		require.Equal(t, stagingFile.SourceID, loadFile.SourceID)
 		require.Equal(t, stagingFile.DestinationID, loadFile.DestinationID)
 		require.Equal(t, job.Warehouse.Destination.RevisionID, loadFile.DestinationRevisionID)
@@ -664,12 +664,10 @@ func TestV2CreateLoadFiles(t *testing.T) {
 		},
 		StagingFiles: stagingFiles,
 	}
-
 	startID, endID, err := lf.CreateLoadFiles(ctx, &job)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), startID)
 	require.Equal(t, int64(2), endID)
-
 	require.Len(t, loadRepo.store, len(notifier.tables))
 	require.Len(t, stageRepo.store, len(stagingFiles))
 }
@@ -784,5 +782,6 @@ func TestV2CreateLoadFiles_Failure(t *testing.T) {
 		require.EqualError(t, err, "no load files generated")
 		require.Zero(t, startID)
 		require.Zero(t, endID)
+		require.Equal(t, warehouseutils.StagingFileFailedState, stageRepo.store[stagingFiles[0].ID].Status)
 	})
 }

--- a/warehouse/internal/loadfiles/mock_loadfile_repo_test.go
+++ b/warehouse/internal/loadfiles/mock_loadfile_repo_test.go
@@ -31,7 +31,7 @@ func (m *mockLoadFilesRepo) Delete(_ context.Context, uploadID int64) error {
 	defer m.mu.Unlock()
 	store := make([]model.LoadFile, 0)
 	for _, loadFile := range m.store {
-		if loadFile.UploadID != &uploadID {
+		if loadFile.UploadID != uploadID {
 			store = append(store, loadFile)
 		}
 	}
@@ -45,7 +45,7 @@ func (m *mockLoadFilesRepo) Get(_ context.Context, uploadID int64) ([]model.Load
 	defer m.mu.Unlock()
 	var loadFiles []model.LoadFile
 	for _, loadFile := range m.store {
-		if *loadFile.UploadID == uploadID {
+		if loadFile.UploadID == uploadID {
 			loadFiles = append(loadFiles, loadFile)
 		}
 	}

--- a/warehouse/internal/loadfiles/mock_stagefile_repo_test.go
+++ b/warehouse/internal/loadfiles/mock_stagefile_repo_test.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
-	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
 type mockStageFilesRepo struct {
@@ -26,19 +25,6 @@ func (m *mockStageFilesRepo) SetStatuses(_ context.Context, ids []int64, status 
 			ID:     id,
 			Status: status,
 		}
-	}
-
-	return nil
-}
-
-func (m *mockStageFilesRepo) SetErrorStatus(_ context.Context, stagingFileID int64, stageFileErr error) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	m.store[stagingFileID] = model.StagingFile{
-		ID:     stagingFileID,
-		Status: warehouseutils.StagingFileFailedState,
-		Error:  stageFileErr,
 	}
 
 	return nil

--- a/warehouse/internal/model/load.go
+++ b/warehouse/internal/model/load.go
@@ -14,9 +14,5 @@ type LoadFile struct {
 	DestinationID         string
 	DestinationType       string
 	CreatedAt             time.Time
-	// It is currently defined as a pointer (*int64) to support NULL values
-	// during the migration phase. This is temporary - once all existing load
-	// files are backfilled with their corresponding upload_id values, this
-	// field will be changed to a non-nullable int64.
-	UploadID *int64
+	UploadID              int64
 }

--- a/warehouse/internal/repo/load.go
+++ b/warehouse/internal/repo/load.go
@@ -166,10 +166,8 @@ func scanLoadFile(scan scanFn, loadFile *model.LoadFile) error {
 		ContentLength         int64  `json:"content_length"`
 		UseRudderStorage      bool   `json:"use_rudder_storage"`
 	}
-	var (
-		metadataRaw json.RawMessage
-		uploadID    sql.NullInt64
-	)
+
+	var metadataRaw json.RawMessage
 	err := scan(
 		&loadFile.ID,
 		&loadFile.Location,
@@ -180,13 +178,10 @@ func scanLoadFile(scan scanFn, loadFile *model.LoadFile) error {
 		&loadFile.TotalRows,
 		&metadataRaw,
 		&loadFile.CreatedAt,
-		&uploadID,
+		&loadFile.UploadID,
 	)
 	if err != nil {
 		return fmt.Errorf(`scanning row: %w`, err)
-	}
-	if uploadID.Valid {
-		loadFile.UploadID = &uploadID.Int64
 	}
 
 	var metadata metadataSchema

--- a/warehouse/internal/repo/load_test.go
+++ b/warehouse/internal/repo/load_test.go
@@ -117,7 +117,7 @@ func TestLoadFiles_GetByID(t *testing.T) {
 
 	uploadID := createUpload(t, ctx, db)
 	loadFiles := lo.RepeatBy(10, func(i int) model.LoadFile {
-		file := model.LoadFile{
+		return model.LoadFile{
 			TableName:             "table_name",
 			Location:              "s3://bucket/path/to/file",
 			TotalRows:             10,
@@ -127,12 +127,8 @@ func TestLoadFiles_GetByID(t *testing.T) {
 			SourceID:              "source_id",
 			DestinationID:         "destination_id",
 			DestinationType:       "RS",
+			UploadID:              uploadID,
 		}
-		// Not adding uploadID for first file to test NULL value
-		if i != 0 {
-			file.UploadID = uploadID
-		}
-		return file
 	})
 	require.NoError(t, r.Insert(ctx, loadFiles))
 

--- a/warehouse/internal/repo/load_test.go
+++ b/warehouse/internal/repo/load_test.go
@@ -60,7 +60,7 @@ func Test_LoadFiles(t *testing.T) {
 				Location:              "s3://bucket/path/to/file",
 				TotalRows:             10,
 				ContentLength:         1000,
-				UploadID:              &uploads[i%2],
+				UploadID:              uploads[i%2],
 				DestinationRevisionID: "revision_id",
 				UseRudderStorage:      true,
 				SourceID:              "source_id",
@@ -130,7 +130,7 @@ func TestLoadFiles_GetByID(t *testing.T) {
 		}
 		// Not adding uploadID for first file to test NULL value
 		if i != 0 {
-			file.UploadID = &uploadID
+			file.UploadID = uploadID
 		}
 		return file
 	})
@@ -193,7 +193,7 @@ func TestLoadFiles_TotalExportedEvents(t *testing.T) {
 					Location:              "s3://bucket/path/to/file",
 					TotalRows:             rows,
 					ContentLength:         1000,
-					UploadID:              &uploadID,
+					UploadID:              uploadID,
 					DestinationRevisionID: "revision_id",
 					UseRudderStorage:      true,
 					SourceID:              "source_id",

--- a/warehouse/internal/repo/load_test.go
+++ b/warehouse/internal/repo/load_test.go
@@ -246,6 +246,7 @@ func TestLoadFiles_DistinctTableName(t *testing.T) {
 	loadFilesCount := 25
 
 	loadFiles := make([]model.LoadFile, 0, stagingFilesCount*loadFilesCount)
+	uploadID := createUpload(t, ctx, db)
 
 	for i := 0; i < stagingFilesCount; i++ {
 		for j := 0; j < loadFilesCount; j++ {
@@ -259,6 +260,7 @@ func TestLoadFiles_DistinctTableName(t *testing.T) {
 				SourceID:              sourceID,
 				DestinationID:         destinationID,
 				DestinationType:       "RS",
+				UploadID:              uploadID,
 			})
 		}
 	}

--- a/warehouse/internal/repo/staging.go
+++ b/warehouse/internal/repo/staging.go
@@ -624,37 +624,3 @@ func (sf *StagingFiles) SetStatuses(ctx context.Context, ids []int64, status str
 
 	return nil
 }
-
-func (sf *StagingFiles) SetErrorStatus(ctx context.Context, stagingFileID int64, stageFileErr error) error {
-	defer sf.TimerStat("set_error_status", nil)()
-
-	sqlStatement := `
-		UPDATE
-		` + stagingTableName + `
-		SET
-			status = $1,
-			error = $2,
-			updated_at = $3
-		WHERE
-			id = $4;`
-
-	result, err := sf.db.ExecContext(
-		ctx,
-		sqlStatement,
-		warehouseutils.StagingFileFailedState,
-		stageFileErr.Error(),
-		sf.now(),
-		stagingFileID,
-	)
-	if err != nil {
-		return fmt.Errorf("update staging file with error: %w", err)
-	}
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("rows affected: %w", err)
-	}
-	if rowsAffected == 0 {
-		return fmt.Errorf("no rows affected")
-	}
-	return nil
-}

--- a/warehouse/internal/repo/staging_test.go
+++ b/warehouse/internal/repo/staging_test.go
@@ -648,29 +648,6 @@ func TestStagingFilesRepo(t *testing.T) {
 						[]int64{}, warehouseutils.StagingFileExecutingState)
 					require.EqualError(t, err, "no staging files to update")
 				})
-
-				t.Run("SetErrorStatus", func(t *testing.T) {
-					now = now.Add(time.Second)
-
-					err := r.SetErrorStatus(ctx,
-						4,
-						fmt.Errorf("the error"),
-					)
-					require.NoError(t, err)
-
-					file, err := r.GetByID(ctx, 4)
-					require.NoError(t, err)
-
-					require.Equal(t, warehouseutils.StagingFileFailedState, file.Status)
-					require.Equal(t, "the error", file.Error.Error())
-					require.Equal(t, now, file.UpdatedAt)
-
-					err = r.SetErrorStatus(ctx,
-						-1,
-						fmt.Errorf("the error"),
-					)
-					require.EqualError(t, err, "no rows affected")
-				})
 			})
 		})
 	}

--- a/warehouse/internal/repo/table_upload_test.go
+++ b/warehouse/internal/repo/table_upload_test.go
@@ -325,11 +325,11 @@ func TestTableUploadRepo(t *testing.T) {
 				loadFiles = append(loadFiles, model.LoadFile{
 					TableName: tables2[i],
 					TotalRows: i + 1,
-					UploadID:  &uploadId,
+					UploadID:  uploadId,
 				}, model.LoadFile{
 					TableName: tables2[i],
 					TotalRows: i + 1,
-					UploadID:  &uploadId,
+					UploadID:  uploadId,
 				})
 			}
 			insertErr := l.Insert(ctx, loadFiles)

--- a/warehouse/router/testdata/sql/stats_test.sql
+++ b/warehouse/router/testdata/sql/stats_test.sql
@@ -1,65 +1,72 @@
 BEGIN;
+INSERT INTO wh_uploads (
+  id, source_id, destination_id, destination_type, workspace_id, namespace, schema,
+  status, created_at, updated_at
+)
+VALUES
+  (1, 'test-sourceID', 'test-destinationID', 'destination_type', 'workspace_id', 'namespace', '{}', 'succeeded', NOW(), NOW());
+
 INSERT INTO wh_staging_files (
   id, location, schema, source_id, destination_id,
   status, total_events, first_event_at,
   last_event_at, created_at, updated_at,
-  metadata
+  metadata, upload_id
 )
 VALUES
   (
     1, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     '{}', 'test-sourceID', 'test-destinationID',
     'succeeded', 1, NOW(), NOW(), NOW(),
-    NOW(), '{}'
+    NOW(), '{}', 1
   ),
   (
     2, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     '{}', 'test-sourceID', 'test-destinationID',
     'succeeded', 1, NOW(), NOW(), NOW(),
-    NOW(), '{}'
+    NOW(), '{}', 1
   ),
   (
     3, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     '{}', 'test-sourceID', 'test-destinationID',
     'succeeded', 1, NOW(), NOW(), NOW(),
-    NOW(), '{}'
+    NOW(), '{}', 1
   ),
   (
     4, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     '{}', 'test-sourceID', 'test-destinationID',
     'succeeded', 1, NOW(), NOW(), NOW(),
-    NOW(), '{}'
+    NOW(), '{}', 1
   );
 INSERT INTO wh_load_files (
   id, location, source_id,
   destination_id, destination_type,
   table_name, total_events, created_at,
-  metadata
+  metadata, upload_id
 )
 VALUES
   (
     1, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     'test-sourceID', 'test-destinationID',
     'POSTGRES', 'test-table', 1, NOW() + INTERVAL '1 seconds',
-    '{}'
+    '{}', 1
   ),
   (
     2, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     'test-sourceID', 'test-destinationID',
     'POSTGRES', 'test-table', 1, NOW()+ INTERVAL '2 seconds',
-    '{}'
+    '{}', 1
   ),
   (
     3, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     'test-sourceID', 'test-destinationID',
     'POSTGRES', 'test-table', 1, NOW()+ INTERVAL '3 seconds',
-    '{}'
+    '{}', 1
   ),
   (
     4, 'rudder/rudder-warehouse-staging-logs/2EUralUySYUs7hgsdU1lFXRSm/2022-09-20/1663650685.2EUralsdsDyZjOKU1lFXRSm.eeadsb4-a066-42f4-a90b-460161378e1b.json.gz',
     'test-sourceID', 'test-destinationID',
     'POSTGRES', 'test-table', 1, NOW()+ INTERVAL '4 seconds',
-    '{}'
+    '{}', 1
   );
 INSERT INTO wh_table_uploads (
   id, wh_upload_id, table_name, status,

--- a/warehouse/router/upload_stats_test.go
+++ b/warehouse/router/upload_stats_test.go
@@ -52,9 +52,6 @@ func TestUploadJob_Stats(t *testing.T) {
 			},
 		}, nil)
 
-		_, err = repo.NewUploads(job.db).CreateWithStagingFiles(context.Background(), job.upload, job.stagingFiles)
-		require.NoError(t, err)
-
 		job.generateUploadSuccessMetrics()
 
 		tags := stats.Tags{

--- a/warehouse/router/upload_test.go
+++ b/warehouse/router/upload_test.go
@@ -795,19 +795,19 @@ func TestUploadJob_GetLoadFilesMetadata(t *testing.T) {
 			job.upload.ID = createUpload(t, ctx, db)
 			loadFiles := []model.LoadFile{
 				{
-					UploadID:  &job.upload.ID,
+					UploadID:  job.upload.ID,
 					TableName: "test_table",
 				},
 				{
-					UploadID:  &job.upload.ID,
+					UploadID:  job.upload.ID,
 					TableName: "test_table2",
 				},
 				{
-					UploadID:  &job.upload.ID,
+					UploadID:  job.upload.ID,
 					TableName: "test_table2",
 				},
 				{
-					UploadID:  &job.upload.ID,
+					UploadID:  job.upload.ID,
 					TableName: "test_table2",
 				},
 			}


### PR DESCRIPTION
# Description

Since we ran migration for all the deployments, a valid load file doesn't have null upload-id anymore. So this PR updated the code to reflect the same.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
