### PR TITLE
fix: cron tracker query taking long time

### DIFF
--- a/sql/migrations/warehouse/000035_add_wh_staging_files_created_at_idx.up.sql
+++ b/sql/migrations/warehouse/000035_add_wh_staging_files_created_at_idx.up.sql
@@ -1,0 +1,2 @@
+-- Add index on wh_staging_files table to speed up queries on source_id, destination_id, and created_at columns (e.g. for cron tracker query)
+CREATE INDEX CONUCURRENTLY IF NOT EXISTS wh_staging_files_source_id_destination_id_created_at_idx ON wh_staging_files(source_id, destination_id, created_at);


### PR DESCRIPTION
# Description

Create an index on the `wh_staging_files` table for columns `source_id`, `destination_id` and `created_at`

## Linear Ticket

Part of WAR-828

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
