### PR TITLE
chore: cleanup for schema snapshoting

### DIFF
--- a/warehouse/api/http.go
+++ b/warehouse/api/http.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/services/notifier"
 	"github.com/rudderlabs/rudder-server/utils/crash"
@@ -165,14 +166,12 @@ func (a *Api) addMasterEndpoints(ctx context.Context, r chi.Router) {
 	a.bcConfig.WaitForConfig(ctx)
 
 	stagingFileSchemaSnapshotTTL := a.conf.GetDurationVar(3, time.Hour, "Warehouse.stagingFileSchemaSnapshotTTL")
-	enableStagingFileSchemaSnapshot := a.conf.GetReloadableBoolVar(false, "Warehouse.enableStagingFileSchemaSnapshot")
 	stagingFileSchemaSnapshots := snapshots.NewStagingFileSchema(
 		a.conf,
 		repo.NewStagingFileSchemaSnapshots(a.db, repo.WithStats(a.statsFactory)),
 		snapshots.NewStagingFileSchemaTimeBasedExpiryStrategy(stagingFileSchemaSnapshotTTL),
 	)
 	schemaSnapshotHandler := &api.StagingFileSchemaSnapshotHandler{
-		Enable:    enableStagingFileSchemaSnapshot,
 		Snapshots: stagingFileSchemaSnapshots,
 		PatchGen:  warehouseutils.GenerateJSONPatch,
 	}


### PR DESCRIPTION
# Description

- Remove the `enableStagingFileSchemaSnapshot` flag-based changes.
- Stop populating the schema while inserting the staging file.
- Remove unmarshalling and deep equals.

## Linear Ticket

- Resolves WAR-906

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
