### PR TITLE
fix: warehouse migrations from master only

### DIFF
--- a/warehouse/app.go
+++ b/warehouse/app.go
@@ -247,15 +247,16 @@ func (a *App) setupDatabase(ctx context.Context) error {
 		sqlquerywrapper.WithStats(a.statsFactory),
 	)
 
-	err = a.migrate()
-	if err != nil {
-		return fmt.Errorf("could not migrate: %w", err)
+	if mode.IsMaster(a.config.mode) {
+		err = a.migrate()
+		if err != nil {
+			return fmt.Errorf("could not migrate: %w", err)
+		}
+		err = a.migrateAlways()
+		if err != nil {
+			return fmt.Errorf("could not migrate always: %w", err)
+		}
 	}
-	err = a.migrateAlways()
-	if err != nil {
-		return fmt.Errorf("could not migrate always: %w", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
# Description

- Run warehouse migrations only from the Master service.

## Linear Ticket

- Resolves WAR-1077

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
