### PR TITLE
fix: remove unwanted table level schemas

### DIFF
--- a/warehouse/api/grpc.go
+++ b/warehouse/api/grpc.go
@@ -111,7 +111,7 @@ func NewGRPCServer(
 		stagingRepo:        repo.NewStagingFiles(db, conf, repo.WithStats(statsFactory)),
 		uploadRepo:         repo.NewUploads(db, repo.WithStats(statsFactory)),
 		tableUploadsRepo:   repo.NewTableUploads(db, conf, repo.WithStats(statsFactory)),
-		schemaRepo:         repo.NewWHSchemas(db, conf, repo.WithStats(statsFactory)),
+		schemaRepo:         repo.NewWHSchemas(db, conf, logger, repo.WithStats(statsFactory)),
 		triggerStore:       triggerStore,
 		fileManagerFactory: filemanager.New,
 		now:                timeutil.Now,

--- a/warehouse/api/grpc_test.go
+++ b/warehouse/api/grpc_test.go
@@ -1915,7 +1915,7 @@ func TestGRPC(t *testing.T) {
 		})
 
 		t.Run("GetDestinationNamespaces", func(t *testing.T) {
-			schemaRepo := repo.NewWHSchemas(db, c)
+			schemaRepo := repo.NewWHSchemas(db, c, logger.NOP)
 			schema := model.WHSchema{
 				SourceID:        "source_1",
 				DestinationID:   destinationID,

--- a/warehouse/api/http.go
+++ b/warehouse/api/http.go
@@ -118,7 +118,7 @@ func NewApi(
 		triggerStore:  triggerStore,
 		stagingRepo:   repo.NewStagingFiles(db, conf, repo.WithStats(statsFactory)),
 		uploadRepo:    repo.NewUploads(db, repo.WithStats(statsFactory)),
-		schemaRepo:    repo.NewWHSchemas(db, conf, repo.WithStats(statsFactory)),
+		schemaRepo:    repo.NewWHSchemas(db, conf, log, repo.WithStats(statsFactory)),
 	}
 	a.config.healthTimeout = conf.GetDuration("Warehouse.healthTimeout", 10, time.Second)
 	a.config.readerHeaderTimeout = conf.GetDuration("Warehouse.readerHeaderTimeout", 3, time.Second)

--- a/warehouse/api/http_test.go
+++ b/warehouse/api/http_test.go
@@ -295,7 +295,7 @@ func TestHTTPApi(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	schemaRepo := repo.NewWHSchemas(db, c)
+	schemaRepo := repo.NewWHSchemas(db, c, logger.NOP)
 	err = schemaRepo.Insert(ctx,
 		&model.WHSchema{
 			SourceID:        sourceID,

--- a/warehouse/bcm/backend_config.go
+++ b/warehouse/bcm/backend_config.go
@@ -41,7 +41,7 @@ func New(
 	bcm := &BackendConfigManager{
 		conf:                 c,
 		db:                   db,
-		schema:               repo.NewWHSchemas(db, c, repo.WithStats(stats)),
+		schema:               repo.NewWHSchemas(db, c, log, repo.WithStats(stats)),
 		tenantManager:        tenantManager,
 		logger:               log,
 		stats:                stats,

--- a/warehouse/internal/repo/repo_test.go
+++ b/warehouse/internal/repo/repo_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 
@@ -25,7 +26,7 @@ func TestStatsEmission(t *testing.T) {
 		require.NoError(t, err)
 
 		repoLoadFiles := repo.NewLoadFiles(db, config.New(), repo.WithStats(statsStore))
-		repoSchemas := repo.NewWHSchemas(db, config.New(), repo.WithStats(statsStore))
+		repoSchemas := repo.NewWHSchemas(db, config.New(), logger.NOP, repo.WithStats(statsStore))
 		repoStagingFiles := repo.NewStagingFiles(db, config.New(), repo.WithStats(statsStore))
 		repoTableUploads := repo.NewTableUploads(db, config.New(), repo.WithStats(statsStore))
 		repoSources := repo.NewSource(db, repo.WithStats(statsStore))

--- a/warehouse/internal/repo/schema.go
+++ b/warehouse/internal/repo/schema.go
@@ -9,11 +9,16 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-
+	"github.com/lib/pq"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stringify"
+
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
 	sqlmiddleware "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
@@ -38,12 +43,13 @@ const whSchemaTableColumns = `
 type WHSchema struct {
 	*repo
 
+	log    logger.Logger
 	config struct {
 		enableTableLevelSchema config.ValueLoader[bool]
 	}
 }
 
-func NewWHSchemas(db *sqlmiddleware.DB, conf *config.Config, opts ...Opt) *WHSchema {
+func NewWHSchemas(db *sqlmiddleware.DB, conf *config.Config, log logger.Logger, opts ...Opt) *WHSchema {
 	r := &WHSchema{
 		repo: &repo{
 			db:           db,
@@ -51,6 +57,7 @@ func NewWHSchemas(db *sqlmiddleware.DB, conf *config.Config, opts ...Opt) *WHSch
 			statsFactory: stats.NOP,
 			repoType:     whSchemaTableName,
 		},
+		log: log.Child("repo.wh_schemas"),
 	}
 	r.config.enableTableLevelSchema = conf.GetReloadableBoolVar(false, "Warehouse.enableTableLevelSchema")
 	for _, opt := range opts {
@@ -75,6 +82,13 @@ func (sh *WHSchema) Insert(ctx context.Context, whSchema *model.WHSchema) error 
 		return fmt.Errorf("marshaling schema: %w", err)
 	}
 
+	log := sh.log.Withn(
+		obskit.SourceID(whSchema.SourceID),
+		obskit.Namespace(whSchema.Namespace),
+		obskit.DestinationID(whSchema.DestinationID),
+		obskit.DestinationType(whSchema.DestinationType),
+	)
+
 	err = sh.WithTx(ctx, func(tx *sqlmiddleware.Tx) error {
 		// update all schemas with the same destination_id and namespace but different source_id
 		// this is to ensure all the connections for a destination have the same schema copy
@@ -98,6 +112,7 @@ func (sh *WHSchema) Insert(ctx context.Context, whSchema *model.WHSchema) error 
 			whSchema.SourceID,
 		)
 		if err != nil {
+			log.Warnn("Updating related schemas", logger.NewStringField("schema", string(schemaPayload)))
 			return fmt.Errorf("updating related schemas: %w", err)
 		}
 
@@ -134,6 +149,27 @@ func (sh *WHSchema) Insert(ctx context.Context, whSchema *model.WHSchema) error 
 
 		// If table-level schema is enabled, insert/update for each table
 		if sh.config.enableTableLevelSchema.Load() {
+			if len(whSchema.Schema) > 0 {
+				// Delete orphaned table-level schemas for the current source_id + destination_id + namespace
+				// This ensures consistency between raw schema and table-level schemas
+				_, err = tx.ExecContext(ctx, `
+				DELETE FROM `+whSchemaTableName+`
+				WHERE destination_id = $1
+				  AND namespace = $2
+				  AND table_name != ''
+				  AND table_name NOT IN (
+					SELECT unnest($3::text[])
+				  );
+			`,
+					whSchema.DestinationID,
+					whSchema.Namespace,
+					pq.Array(lo.Keys(whSchema.Schema)),
+				)
+				if err != nil {
+					return fmt.Errorf("deleting orphaned table-level schemas: %w", err)
+				}
+			}
+
 			for tableName, tableSchema := range whSchema.Schema {
 				tableSchemaPayload, err := jsonrs.Marshal(tableSchema)
 				if err != nil {
@@ -161,6 +197,11 @@ func (sh *WHSchema) Insert(ctx context.Context, whSchema *model.WHSchema) error 
 					tableName,
 				)
 				if err != nil {
+					log.Warnn("Updating table-level related schemas",
+						logger.NewStringField("tableName", tableName),
+						logger.NewStringField("schema", string(schemaPayload)),
+						logger.NewStringField("tableLevelSchem", string(tableSchemaPayload)),
+					)
 					return fmt.Errorf("updating other table-level schemas for table %s: %w", tableName, err)
 				}
 
@@ -237,6 +278,12 @@ func (sh *WHSchema) GetForNamespace(ctx context.Context, destID, namespace strin
 	}
 	diff := cmp.Diff(originalSchema.Schema, tableLevelSchemas)
 	if len(diff) > 0 {
+		sh.log.Warnn("Parent schema does not match",
+			obskit.Namespace(namespace),
+			obskit.DestinationID(destID),
+			logger.NewStringField("schema", stringify.Any(originalSchema.Schema)),
+			logger.NewStringField("tableLevelSchemas", stringify.Any(tableLevelSchemas)),
+		)
 		return model.WHSchema{}, fmt.Errorf("parent schema does not match: %s", diff)
 	}
 	return originalSchema, nil

--- a/warehouse/internal/repo/schema_test.go
+++ b/warehouse/internal/repo/schema_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
 
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
@@ -73,7 +74,7 @@ func TestWHSchemasRepo(t *testing.T) {
 
 				var (
 					now = time.Now().Truncate(time.Second).UTC()
-					r   = repo.NewWHSchemas(db, conf, repo.WithNow(func() time.Time {
+					r   = repo.NewWHSchemas(db, conf, logger.NOP, repo.WithNow(func() time.Time {
 						return now
 					}))
 				)
@@ -286,7 +287,7 @@ func TestWHSchemasRepo(t *testing.T) {
 
 				var (
 					now = time.Now().Truncate(time.Second).UTC()
-					r   = repo.NewWHSchemas(db, conf, repo.WithNow(func() time.Time {
+					r   = repo.NewWHSchemas(db, conf, logger.NOP, repo.WithNow(func() time.Time {
 						return now
 					}))
 				)
@@ -364,7 +365,7 @@ func TestWHSchemasRepo(t *testing.T) {
 				})
 
 				t.Run("GetForNamespace (not already populated)", func(t *testing.T) {
-					rs1 := repo.NewWHSchemas(db, conf, repo.WithNow(func() time.Time {
+					rs1 := repo.NewWHSchemas(db, conf, logger.NOP, repo.WithNow(func() time.Time {
 						return now
 					}))
 					err := rs1.Insert(ctx, &model.WHSchema{
@@ -379,7 +380,7 @@ func TestWHSchemasRepo(t *testing.T) {
 					})
 					require.NoError(t, err)
 
-					rs2 := repo.NewWHSchemas(db, conf, repo.WithNow(func() time.Time {
+					rs2 := repo.NewWHSchemas(db, conf, logger.NOP, repo.WithNow(func() time.Time {
 						return now
 					}))
 					expectedSchema, err := rs2.GetForNamespace(ctx, "destination_id_1", "namespace_1")
@@ -445,9 +446,12 @@ func TestWHSchemasRepo(t *testing.T) {
 
 func TestWHSchemasRepo_GetForNamespace(t *testing.T) {
 	t.Run("SourceID ordering", func(t *testing.T) {
+		conf := config.New()
+		conf.Set("Warehouse.enableTableLevelSchema", true)
+
 		db, ctx := setupDB(t), context.Background()
 		now := time.Now().Truncate(time.Second).UTC()
-		r := repo.NewWHSchemas(db, config.New(), repo.WithNow(func() time.Time {
+		r := repo.NewWHSchemas(db, conf, logger.NOP, repo.WithNow(func() time.Time {
 			return now
 		}))
 
@@ -476,8 +480,6 @@ func TestWHSchemasRepo_GetForNamespace(t *testing.T) {
 					"column_name_3": "boolean",
 				},
 			},
-			CreatedAt: now,
-			UpdatedAt: now,
 		}))
 
 		expectedSchema, err := r.GetForNamespace(ctx, "destination_id_1", "namespace_1")
@@ -496,6 +498,103 @@ func TestWHSchemasRepo_GetForNamespace(t *testing.T) {
 		require.Equal(t, now, expectedSchema.CreatedAt)
 		require.Equal(t, now, expectedSchema.UpdatedAt)
 	})
+
+	t.Run("Unwanted fetch schema", func(t *testing.T) {
+		conf := config.New()
+		conf.Set("Warehouse.enableTableLevelSchema", true)
+
+		db, ctx := setupDB(t), context.Background()
+		now := time.Now().Truncate(time.Second).UTC()
+		r := repo.NewWHSchemas(db, conf, logger.NOP, repo.WithNow(func() time.Time {
+			return now
+		}))
+
+		require.NoError(t, r.Insert(ctx, &model.WHSchema{
+			SourceID:        "source_id_1",
+			Namespace:       "namespace_1",
+			DestinationID:   "destination_id_1",
+			DestinationType: "destination_type_1",
+			Schema: model.Schema{
+				"table_name_1": {
+					"column_name_1": "string",
+					"column_name_2": "int",
+					"column_name_3": "boolean",
+				},
+				"table_name_2": {
+					"column_name_1": "string",
+					"column_name_2": "int",
+					"column_name_3": "boolean",
+				},
+			},
+		}))
+		require.NoError(t, r.Insert(ctx, &model.WHSchema{
+			SourceID:        "source_id_2",
+			Namespace:       "namespace_1",
+			DestinationID:   "destination_id_1",
+			DestinationType: "destination_type_1",
+			Schema: model.Schema{
+				"table_name_1": {
+					"column_name_1": "string",
+					"column_name_2": "int",
+					"column_name_3": "boolean",
+				},
+				"table_name_2": {
+					"column_name_1": "string",
+					"column_name_2": "int",
+					"column_name_3": "boolean",
+				},
+			},
+		}))
+
+		expectedSchema, err := r.GetForNamespace(ctx, "destination_id_1", "namespace_1")
+		require.NoError(t, err)
+		require.Equal(t, model.Schema{
+			"table_name_1": {
+				"column_name_1": "string",
+				"column_name_2": "int",
+				"column_name_3": "boolean",
+			},
+			"table_name_2": {
+				"column_name_1": "string",
+				"column_name_2": "int",
+				"column_name_3": "boolean",
+			},
+		}, expectedSchema.Schema)
+
+		require.NoError(t, r.Insert(ctx, &model.WHSchema{
+			SourceID:        "source_id_1",
+			Namespace:       "namespace_1",
+			DestinationID:   "destination_id_1",
+			DestinationType: "destination_type_1",
+			Schema: model.Schema{
+				"table_name_1": {
+					"column_name_1": "string",
+					"column_name_2": "int",
+					"column_name_3": "boolean",
+				},
+				"table_name_3": {
+					"column_name_1": "string",
+					"column_name_2": "int",
+					"column_name_3": "boolean",
+				},
+			},
+		}))
+
+		expectedSchema, err = r.GetForNamespace(ctx, "destination_id_1", "namespace_1")
+		require.NoError(t, err)
+		require.Equal(t, model.Schema{
+			"table_name_1": {
+				"column_name_1": "string",
+				"column_name_2": "int",
+				"column_name_3": "boolean",
+			},
+			"table_name_3": {
+				"column_name_1": "string",
+				"column_name_2": "int",
+				"column_name_3": "boolean",
+			},
+		}, expectedSchema.Schema)
+	})
 }
 
 func TestWHSchemasRepo_GetDestinationNamespaces(t *testing.T) {
@@ -503,7 +602,7 @@ func TestWHSchemasRepo_GetDestinationNamespaces(t *testing.T) {
 	conf := config.New()
 	db, ctx := setupDB(t), context.Background()
 	now := timeutil.Now()
-	r := repo.NewWHSchemas(db, conf)
+	r := repo.NewWHSchemas(db, conf, logger.NOP)
 
 	// Insert test data with multiple sources and timestamps
 	schemas := []model.WHSchema{

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -188,7 +188,7 @@ func (f *UploadJobFactory) NewUploadJob(ctx context.Context, dto *model.UploadJo
 		uploadsRepo:          repo.NewUploads(f.db, repo.WithStats(f.statsFactory)),
 		stagingFileRepo:      repo.NewStagingFiles(f.db, f.conf, repo.WithStats(f.statsFactory)),
 		loadFilesRepo:        repo.NewLoadFiles(f.db, f.conf, repo.WithStats(f.statsFactory)),
-		whSchemaRepo:         repo.NewWHSchemas(f.db, f.conf, repo.WithStats(f.statsFactory)),
+		whSchemaRepo:         repo.NewWHSchemas(f.db, f.conf, f.logger, repo.WithStats(f.statsFactory)),
 		upload:               dto.Upload,
 		warehouse:            dto.Warehouse,
 		stagingFiles:         dto.StagingFiles,
@@ -338,7 +338,7 @@ func (job *UploadJob) run() (err error) {
 		job.logger.Child("warehouse"),
 		job.statsFactory,
 		whManager,
-		repo.NewWHSchemas(job.db, job.conf, repo.WithStats(job.statsFactory)),
+		repo.NewWHSchemas(job.db, job.conf, job.logger, repo.WithStats(job.statsFactory)),
 		repo.NewStagingFiles(job.db, job.conf, repo.WithStats(job.statsFactory)),
 	)
 	if err != nil {

--- a/warehouse/schema/schema_test.go
+++ b/warehouse/schema/schema_test.go
@@ -1400,7 +1400,7 @@ func TestSchema(t *testing.T) {
 
 	t.Run("SchemaOperationsAcrossConnections", func(t *testing.T) {
 		db, ctx := setupDB(t), context.Background()
-		schemaRepo := repo.NewWHSchemas(db, config.New())
+		schemaRepo := repo.NewWHSchemas(db, config.New(), logger.NOP)
 
 		// Create initial schema for connection 1
 		warehouse1 := model.Warehouse{


### PR DESCRIPTION
# Description

- When we fetch the schema from the warehouse, additional tables are also fetched, for which table-level schemas are also generated.
- Now, when these tables get deleted in the customer's warehouse, upon fetching the schema, we will not receive those. But since the table-level schemas got generated, they will be present.
- So deleting those table-level schemas which are not part of the warehouse schema.

## Linear Ticket

- Resolves WAR-1078.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
