### PR TITLE
chore: capture stats for failed transformer client requests

### DIFF
--- a/processor/internal/transformer/destination_transformer/destination_transformer.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer.go
@@ -293,58 +293,47 @@ func (d *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 	retryStrategy.MaxInterval = d.config.maxRetryBackoffInterval.Load()
 
 	err := backoff.RetryNotify(
-		func() error {
-			start := time.Now()
-			err := func() error {
-				var reqErr error
-				requestStartTime := time.Now()
+		transformerutils.WithProcTransformReqTimeStat(func() error {
+			var reqErr error
+			requestStartTime := time.Now()
 
-				var req *http.Request
-				req, reqErr = http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(rawJSON))
-				if reqErr != nil {
-					return reqErr
-				}
-
-				req.Header.Set("Content-Type", "application/json; charset=utf-8")
-				req.Header.Set("X-Feature-Gzip-Support", "?1")
-				// Header to let transformer know that the client understands event filter code
-				req.Header.Set("X-Feature-Filter-Code", "?1")
-				for k, v := range extraHeaders {
-					req.Header.Set(k, v)
-				}
-
-				resp, reqErr = d.client.Do(req)
-				defer func() { httputil.CloseResponse(resp) }()
-				// Record metrics with labels
-				tags := labels.ToStatsTag()
-				duration := time.Since(requestStartTime)
-				d.stat.NewTaggedStat("transformer_client_request_total_bytes", stats.CountType, tags).Count(len(rawJSON))
-				d.stat.NewTaggedStat("transformer_client_total_durations_seconds", stats.CountType, tags).Count(int(duration.Seconds()))
-
-				if reqErr != nil {
-					return reqErr
-				}
-
-				if !transformerutils.IsJobTerminated(resp.StatusCode) {
-					return fmt.Errorf("transformer returned status code: %v", resp.StatusCode)
-				}
-
-				respData, reqErr = io.ReadAll(resp.Body)
-				if reqErr == nil {
-					d.stat.NewTaggedStat("transformer_client_response_total_bytes", stats.CountType, tags).Count(len(respData))
-					// We'll count response events after unmarshaling in the request method
-				}
+			var req *http.Request
+			req, reqErr = http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(rawJSON))
+			if reqErr != nil {
 				return reqErr
-			}()
-			tags := labels.ToStatsTag()
-			if err == nil {
-				tags["success"] = "true"
-			} else {
-				tags["success"] = "false"
 			}
-			d.stat.NewTaggedStat("processor_transformer_request_time", stats.TimerType, tags).SendTiming(time.Since(start))
-			return err
-		},
+
+			req.Header.Set("Content-Type", "application/json; charset=utf-8")
+			req.Header.Set("X-Feature-Gzip-Support", "?1")
+			// Header to let transformer know that the client understands event filter code
+			req.Header.Set("X-Feature-Filter-Code", "?1")
+			for k, v := range extraHeaders {
+				req.Header.Set(k, v)
+			}
+
+			resp, reqErr = d.client.Do(req)
+			defer func() { httputil.CloseResponse(resp) }()
+			// Record metrics with labels
+			tags := labels.ToStatsTag()
+			duration := time.Since(requestStartTime)
+			d.stat.NewTaggedStat("transformer_client_request_total_bytes", stats.CountType, tags).Count(len(rawJSON))
+			d.stat.NewTaggedStat("transformer_client_total_durations_seconds", stats.CountType, tags).Count(int(duration.Seconds()))
+
+			if reqErr != nil {
+				return reqErr
+			}
+
+			if !transformerutils.IsJobTerminated(resp.StatusCode) {
+				return fmt.Errorf("transformer returned status code: %v", resp.StatusCode)
+			}
+
+			respData, reqErr = io.ReadAll(resp.Body)
+			if reqErr == nil {
+				d.stat.NewTaggedStat("transformer_client_response_total_bytes", stats.CountType, tags).Count(len(respData))
+				// We'll count response events after unmarshaling in the request method
+			}
+			return reqErr
+		}, d.stat, labels),
 		backoff.WithMaxRetries(retryStrategy, uint64(d.config.maxRetry.Load())),
 		func(err error, t time.Duration) {
 			retryCount++

--- a/processor/internal/transformer/destination_transformer/destination_transformer_test.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer_test.go
@@ -294,6 +294,7 @@ func TestDestinationTransformer(t *testing.T) {
 								"language":         "",
 								"transformationId": "",
 								"mirroring":        "false",
+								"success":          "true",
 
 								// Legacy tags: to be removed
 								"dest_type": destinationConfig.DestinationDefinition.Name,

--- a/processor/internal/transformer/trackingplan_validation/trackingplan_validation.go
+++ b/processor/internal/transformer/trackingplan_validation/trackingplan_validation.go
@@ -256,54 +256,43 @@ func (t *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 	retryStrategy.MaxInterval = t.config.maxRetryBackoffInterval.Load()
 
 	err := backoff.RetryNotify(
-		func() error {
-			start := time.Now()
-			err := func() error {
-				var reqErr error
-				requestStartTime := time.Now()
+		transformerutils.WithProcTransformReqTimeStat(func() error {
+			var reqErr error
+			requestStartTime := time.Now()
 
-				var req *http.Request
-				req, reqErr = http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(rawJSON))
-				if reqErr != nil {
-					return reqErr
-				}
-
-				req.Header.Set("Content-Type", "application/json; charset=utf-8")
-				req.Header.Set("X-Feature-Gzip-Support", "?1")
-				// Header to let transformer know that the client understands event filter code
-				req.Header.Set("X-Feature-Filter-Code", "?1")
-
-				resp, reqErr = t.client.Do(req)
-				defer func() { httputil.CloseResponse(resp) }()
-				// Record metrics with labels
-				tags := labels.ToStatsTag()
-				duration := time.Since(requestStartTime)
-				t.stat.NewTaggedStat("transformer_client_request_total_bytes", stats.CountType, tags).Count(len(rawJSON))
-				t.stat.NewTaggedStat("transformer_client_total_durations_seconds", stats.CountType, tags).Count(int(duration.Seconds()))
-				if reqErr != nil {
-					return reqErr
-				}
-
-				if !transformerutils.IsJobTerminated(resp.StatusCode) && resp.StatusCode != transformerutils.StatusCPDown {
-					return fmt.Errorf("transformer returned status code: %v", resp.StatusCode)
-				}
-
-				respData, reqErr = io.ReadAll(resp.Body)
-				if reqErr == nil {
-					t.stat.NewTaggedStat("transformer_client_response_total_bytes", stats.CountType, tags).Count(len(respData))
-					// We'll count response events after unmarshaling in the request method
-				}
+			var req *http.Request
+			req, reqErr = http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(rawJSON))
+			if reqErr != nil {
 				return reqErr
-			}()
-			tags := labels.ToStatsTag()
-			if err == nil {
-				tags["success"] = "true"
-			} else {
-				tags["success"] = "false"
 			}
-			t.stat.NewTaggedStat("processor_transformer_request_time", stats.TimerType, tags).SendTiming(time.Since(start))
-			return err
-		},
+
+			req.Header.Set("Content-Type", "application/json; charset=utf-8")
+			req.Header.Set("X-Feature-Gzip-Support", "?1")
+			// Header to let transformer know that the client understands event filter code
+			req.Header.Set("X-Feature-Filter-Code", "?1")
+
+			resp, reqErr = t.client.Do(req)
+			defer func() { httputil.CloseResponse(resp) }()
+			// Record metrics with labels
+			tags := labels.ToStatsTag()
+			duration := time.Since(requestStartTime)
+			t.stat.NewTaggedStat("transformer_client_request_total_bytes", stats.CountType, tags).Count(len(rawJSON))
+			t.stat.NewTaggedStat("transformer_client_total_durations_seconds", stats.CountType, tags).Count(int(duration.Seconds()))
+			if reqErr != nil {
+				return reqErr
+			}
+
+			if !transformerutils.IsJobTerminated(resp.StatusCode) && resp.StatusCode != transformerutils.StatusCPDown {
+				return fmt.Errorf("transformer returned status code: %v", resp.StatusCode)
+			}
+
+			respData, reqErr = io.ReadAll(resp.Body)
+			if reqErr == nil {
+				t.stat.NewTaggedStat("transformer_client_response_total_bytes", stats.CountType, tags).Count(len(respData))
+				// We'll count response events after unmarshaling in the request method
+			}
+			return reqErr
+		}, t.stat, labels),
 		backoff.WithMaxRetries(retryStrategy, uint64(t.config.maxRetry.Load())),
 		func(err error, time time.Duration) {
 			retryCount++

--- a/processor/internal/transformer/trackingplan_validation/trackingplan_validation_test.go
+++ b/processor/internal/transformer/trackingplan_validation/trackingplan_validation_test.go
@@ -274,6 +274,7 @@ func TestTrackingPlanValidator(t *testing.T) {
 								"workspaceId":      Metadata.WorkspaceID,
 								"language":         "",
 								"mirroring":        "false",
+								"success":          "true",
 
 								// Legacy tags: to be removed
 								"dest_type": "",

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -280,6 +280,7 @@ func TestUserTransformer(t *testing.T) {
 								"workspaceId":      Metadata.WorkspaceID,
 								"language":         "",
 								"mirroring":        "false",
+								"success":          "true",
 
 								// Legacy tags: to be removed
 								"dest_type": destinationConfig.DestinationDefinition.Name,

--- a/processor/internal/transformer/utils_test.go
+++ b/processor/internal/transformer/utils_test.go
@@ -1,0 +1,124 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+	"github.com/rudderlabs/rudder-server/processor/types"
+)
+
+func TestWithProcTransformReqTimeStat(t *testing.T) {
+	t.Run("successful request with correct timing and labels", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		labels := types.TransformerMetricLabels{
+			Endpoint:         "transformer.example.com",
+			DestinationType:  "GOOGLE_ANALYTICS",
+			SourceType:       "webhook",
+			Language:         "js",
+			Stage:            "processor",
+			WorkspaceID:      "workspace-123",
+			SourceID:         "source-456",
+			DestinationID:    "dest-789",
+			TransformationID: "transform-101",
+			Mirroring:        false,
+		}
+
+		executionTime := 100 * time.Millisecond
+		requestFunc := func() error {
+			time.Sleep(executionTime)
+			return nil
+		}
+
+		wrappedFunc := WithProcTransformReqTimeStat(requestFunc, statsStore, labels)
+		start := time.Now()
+		err = wrappedFunc()
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, elapsed, executionTime)
+
+		// Verify the metric was recorded
+		expectedTags := map[string]string{
+			"endpoint":         "transformer.example.com",
+			"destinationType":  "GOOGLE_ANALYTICS",
+			"sourceType":       "webhook",
+			"language":         "js",
+			"stage":            "processor",
+			"workspaceId":      "workspace-123",
+			"destinationId":    "dest-789",
+			"sourceId":         "source-456",
+			"transformationId": "transform-101",
+			"mirroring":        "false",
+			"dest_type":        "GOOGLE_ANALYTICS", // legacy tag
+			"dest_id":          "dest-789",         // legacy tag
+			"src_id":           "source-456",       // legacy tag
+			"success":          "true",
+		}
+
+		metric := statsStore.Get("processor_transformer_request_time", expectedTags)
+		require.NotNil(t, metric)
+		// Just check that some timing was recorded, not the exact value
+		require.Greater(t, metric.LastDuration(), time.Duration(0))
+	})
+
+	t.Run("failed request with error and timing", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		labels := types.TransformerMetricLabels{
+			Endpoint:        "transformer.example.com",
+			DestinationType: "WEBHOOK",
+			SourceType:      "android",
+			Language:        "python",
+			Stage:           "router",
+			WorkspaceID:     "workspace-456",
+			SourceID:        "source-789",
+			DestinationID:   "dest-123",
+			Mirroring:       true,
+		}
+
+		expectedError := errors.New("transformation failed")
+		executionTime := 50 * time.Millisecond
+		requestFunc := func() error {
+			time.Sleep(executionTime)
+			return expectedError
+		}
+
+		wrappedFunc := WithProcTransformReqTimeStat(requestFunc, statsStore, labels)
+		start := time.Now()
+		err = wrappedFunc()
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		require.Equal(t, expectedError, err)
+		require.GreaterOrEqual(t, elapsed, executionTime)
+
+		// Verify the metric was recorded with success=false
+		expectedTags := map[string]string{
+			"endpoint":         "transformer.example.com",
+			"destinationType":  "WEBHOOK",
+			"sourceType":       "android",
+			"language":         "python",
+			"stage":            "router",
+			"workspaceId":      "workspace-456",
+			"destinationId":    "dest-123",
+			"sourceId":         "source-789",
+			"transformationId": "",
+			"mirroring":        "true",
+			"dest_type":        "WEBHOOK",    // legacy tag
+			"dest_id":          "dest-123",   // legacy tag
+			"src_id":           "source-789", // legacy tag
+			"success":          "false",
+		}
+
+		metric := statsStore.Get("processor_transformer_request_time", expectedTags)
+		require.NotNil(t, metric)
+		require.GreaterOrEqual(t, metric.LastDuration(), time.Duration(executionTime.Nanoseconds()))
+	})
+}


### PR DESCRIPTION
# Description

Using existing metric `processor_transformer_request_time` to capture request errors as well (through a new `success` label) in order to be able to visualize them in dashboards and setup alerts for sources/destinations with constant failures.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
