### PR TITLE
chore: updating keydb client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/rudderlabs/bing-ads-go-sdk v0.2.3
 	github.com/rudderlabs/compose-test v0.1.3
-	github.com/rudderlabs/keydb v0.2.1-alpha
+	github.com/rudderlabs/keydb v0.4.2-alpha
 	github.com/rudderlabs/rudder-go-kit v0.61.1
 	github.com/rudderlabs/rudder-observability-kit v0.0.4
 	github.com/rudderlabs/rudder-schemas v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1197,8 +1197,8 @@ github.com/rudderlabs/compose-test v0.1.3 h1:uyep6jDCIF737sfv4zIaMsKRQKX95IDz5Xb
 github.com/rudderlabs/compose-test v0.1.3/go.mod h1:tuvS1eQdSfwOYv1qwyVAcpdJxPLQXJgy5xGDd/9XmMg=
 github.com/rudderlabs/goqu/v10 v10.3.1 h1:rnfX+b4EwBWQ2UQfIGeEW299JBBkK5biEbnf7Kq4/Gg=
 github.com/rudderlabs/goqu/v10 v10.3.1/go.mod h1:LH2vI5gGHBxEQuESqFyk5ZA2anGINc8o25hbidDWOYw=
-github.com/rudderlabs/keydb v0.2.1-alpha h1:7ZzBTguw3CzJZhBBxLBiZ7+cRN3ZczyxYmObXWCoaS4=
-github.com/rudderlabs/keydb v0.2.1-alpha/go.mod h1:VUiqQjSa4T/hMKu/b6Cq/c9gRANgKg1yL3h9anBYm5Q=
+github.com/rudderlabs/keydb v0.4.2-alpha h1:T6f1AAsznjuNtrhKNRGSLjWSL3+K56BbBexZcrUY8Yg=
+github.com/rudderlabs/keydb v0.4.2-alpha/go.mod h1:LV0zuwxLbt/Byrcg7KROJfnHTBokU/ZUUpotT2+IdfQ=
 github.com/rudderlabs/parquet-go v0.0.3 h1:/zgRj929pGKHsthc0kw8stVEcFu1JUcpxDRlhxjSLic=
 github.com/rudderlabs/parquet-go v0.0.3/go.mod h1:WmwBOdvwpXl2aZGRk3NxxgzC/DaWGfax3jrCRhKhtSo=
 github.com/rudderlabs/rudder-go-kit v0.61.1 h1:/yokabp3jWFlz/HCTdakTA3YjN4d831Nv0MCIV3uGuM=

--- a/services/dedup/dedup_test.go
+++ b/services/dedup/dedup_test.go
@@ -601,8 +601,9 @@ func startKeydb(t testing.TB, conf *config.Config) {
 	c, err := keydbclient.NewClient(keydbclient.Config{
 		Addresses:       []string{address},
 		TotalHashRanges: 128,
-		RetryCount:      3,
-		RetryDelay:      time.Second,
+		RetryPolicy: keydbclient.RetryPolicy{
+			Disabled: true,
+		},
 	}, logger.NOP)
 	require.NoError(t, err)
 	size := c.ClusterSize()

--- a/services/dedup/dedup_test.go
+++ b/services/dedup/dedup_test.go
@@ -342,6 +342,7 @@ func Test_Dedup_MirrorMode_KeyDB_Error(t *testing.T) {
 	// Test mirrorKeyDB mode with KeyDB error
 	conf.Set("Dedup.Mirror.Mode", "mirrorKeyDB")
 	conf.Set("KeyDB.Dedup.Addresses", "ransjkaljkl:12345") // Invalid address to simulate KeyDB failure
+	conf.Set("KeyDB.Dedup.RetryPolicy.Disabled", true)     // Invalid address to simulate KeyDB failure
 
 	d, err := dedup.New(conf, stats.NOP, logger.NOP)
 	require.NoError(t, err)

--- a/services/dedup/dedup_test.go
+++ b/services/dedup/dedup_test.go
@@ -311,6 +311,7 @@ func Test_Dedup_MirrorMode_Badger(t *testing.T) {
 
 	// Mock KeyDB to simulate failure, should fall back to badger only
 	conf.Set("KeyDB.Dedup.Addresses", "localhost:12345")
+	conf.Set("KeyDB.Dedup.RetryPolicy.Disabled", true)
 
 	d, err := dedup.New(conf, stats.NOP, logger.NOP)
 	require.NoError(t, err)
@@ -342,7 +343,7 @@ func Test_Dedup_MirrorMode_KeyDB_Error(t *testing.T) {
 	// Test mirrorKeyDB mode with KeyDB error
 	conf.Set("Dedup.Mirror.Mode", "mirrorKeyDB")
 	conf.Set("KeyDB.Dedup.Addresses", "ransjkaljkl:12345") // Invalid address to simulate KeyDB failure
-	conf.Set("KeyDB.Dedup.RetryPolicy.Disabled", true)     // Invalid address to simulate KeyDB failure
+	conf.Set("KeyDB.Dedup.RetryPolicy.Disabled", true)
 
 	d, err := dedup.New(conf, stats.NOP, logger.NOP)
 	require.NoError(t, err)

--- a/services/dedup/keydb/keydb.go
+++ b/services/dedup/keydb/keydb.go
@@ -38,6 +38,9 @@ func NewKeyDB(conf *config.Config, stat stats.Stats, log logger.Logger) (types.D
 			InitialInterval: conf.GetDuration("KeyDB.Dedup.RetryPolicy.InitialInterval", 100, time.Millisecond),
 			Multiplier:      conf.GetFloat64("KeyDB.Dedup.RetryPolicy.Multiplier", 1.5),
 			MaxInterval:     conf.GetDuration("KeyDB.Dedup.RetryPolicy.MaxInterval", 30, time.Second),
+			// No MaxElapsedTime, the client will retry forever.
+			// To detect issues monitor the client metrics:
+			// https://github.com/rudderlabs/keydb/blob/v0.4.2-alpha/client/client.go#L160
 		},
 	}, log.Child("keydb"))
 	if err != nil {

--- a/services/dedup/keydb/keydb.go
+++ b/services/dedup/keydb/keydb.go
@@ -33,9 +33,12 @@ func NewKeyDB(conf *config.Config, stat stats.Stats, log logger.Logger) (types.D
 	c, err := client.NewClient(client.Config{
 		Addresses:       strings.Split(nodeAddresses, ","),
 		TotalHashRanges: uint32(conf.GetInt("KeyDB.Dedup.TotalHashRanges", 128)),
-		// TODO the client should support exponential backoff and circuit breakers
-		RetryCount: conf.GetInt("KeyDB.Dedup.RetryCount", 60),
-		RetryDelay: conf.GetDuration("KeyDB.Dedup.RetryDelay", 1, time.Second),
+		RetryPolicy: client.RetryPolicy{
+			Disabled:        conf.GetBool("KeyDB.Dedup.RetryPolicy.Disabled", false),
+			InitialInterval: conf.GetDuration("KeyDB.Dedup.RetryPolicy.InitialInterval", 100, time.Millisecond),
+			Multiplier:      conf.GetFloat64("KeyDB.Dedup.RetryPolicy.Multiplier", 1.5),
+			MaxInterval:     conf.GetDuration("KeyDB.Dedup.RetryPolicy.MaxInterval", 30, time.Second),
+		},
 	}, log.Child("keydb"))
 	if err != nil {
 		return nil, err

--- a/services/dedup/keydb/keydb_test.go
+++ b/services/dedup/keydb/keydb_test.go
@@ -118,8 +118,9 @@ func startKeydb(t testing.TB, conf *config.Config) {
 	c, err := keydbclient.NewClient(keydbclient.Config{
 		Addresses:       []string{address},
 		TotalHashRanges: 128,
-		RetryCount:      3,
-		RetryDelay:      time.Second,
+		RetryPolicy: keydbclient.RetryPolicy{
+			Disabled: true,
+		},
 	}, logger.NOP)
 	require.NoError(t, err)
 	size := c.ClusterSize()
@@ -138,11 +139,11 @@ func (m *mockedFilemanagerSession) Next() (fileObjects []*filemanager.FileInfo, 
 
 type mockedCloudStorage struct{}
 
-func (m *mockedCloudStorage) Download(ctx context.Context, output io.WriterAt, key string, opts ...filemanager.DownloadOption) error {
+func (m *mockedCloudStorage) Download(_ context.Context, _ io.WriterAt, _ string, _ ...filemanager.DownloadOption) error {
 	return nil
 }
 
-func (m *mockedCloudStorage) Delete(ctx context.Context, keys []string) error {
+func (m *mockedCloudStorage) Delete(_ context.Context, _ []string) error {
 	return nil
 }
 


### PR DESCRIPTION
# Description

Updating keydb client with the latest version.

We're introducing infinite retries with an exponential backoff.
If we were to return an error it would cause the processor to panic and I'd prefer to avoid that.
The idea is to get an alert on the number of retries and act on those.

For that purpose we're exposing [these metrics](https://github.com/rudderlabs/keydb/blob/v0.4.2-alpha/client/client.go#L160):

```go
c.metrics.getReqCount = c.stats.NewTaggedStat("keydb_client_req_total", stats.CountType, stats.Tags{
	"method": "get",
})
c.metrics.getReqLatency = c.stats.NewTaggedStat("keydb_client_req_latency_seconds", stats.TimerType, stats.Tags{
	"method": "get",
})
c.metrics.getReqFailures = c.stats.NewTaggedStat("keydb_client_req_failures_total", stats.CountType, stats.Tags{
	"method": "get",
})
c.metrics.getReqRetries = c.stats.NewTaggedStat("keydb_client_req_retries_total", stats.CountType, stats.Tags{
	"method": "get",
})
c.metrics.getKeysQueried = c.stats.NewStat("keydb_client_get_keys_queried_total", stats.CountType)
c.metrics.getKeysFound = c.stats.NewStat("keydb_client_get_keys_found_total", stats.CountType)

c.metrics.putReqCount = c.stats.NewTaggedStat("keydb_client_req_count_total", stats.CountType, stats.Tags{
	"method": "put",
})
c.metrics.putReqLatency = c.stats.NewTaggedStat("keydb_client_req_latency_seconds", stats.TimerType, stats.Tags{
	"method": "put",
})
c.metrics.putReqFailures = c.stats.NewTaggedStat("keydb_client_req_failures_total", stats.CountType, stats.Tags{
	"method": "put",
})
c.metrics.putReqRetries = c.stats.NewTaggedStat("keydb_client_req_retries_total", stats.CountType, stats.Tags{
	"method": "put",
})
```

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-2351/keydb-processor-retries) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
