### PR TITLE
chore: make warehouse enableNotifierHeartbeat flag enabled by default

### DIFF
--- a/warehouse/slave/worker.go
+++ b/warehouse/slave/worker.go
@@ -110,7 +110,7 @@ func newWorker(
 	// Increasing maxConcurrentStagingFiles config would also require increasing the memory requests for the slave pods
 	s.config.maxConcurrentStagingFiles = s.conf.GetReloadableIntVar(10, 1, "Warehouse.maxStagingFilesInUploadV2Job")
 	s.config.claimRefreshInterval = s.conf.GetReloadableDurationVar(30, time.Second, "Warehouse.claimRefreshIntervalInS")
-	s.config.enableNotifierHeartbeat = s.conf.GetReloadableBoolVar(false, "Warehouse.enableNotifierHeartbeat")
+	s.config.enableNotifierHeartbeat = s.conf.GetReloadableBoolVar(true, "Warehouse.enableNotifierHeartbeat")
 
 	tags := stats.Tags{
 		"module":   "warehouse",

--- a/warehouse/slave/worker_test.go
+++ b/warehouse/slave/worker_test.go
@@ -1454,7 +1454,6 @@ func TestSlaveWorkerClaimRefresh(t *testing.T) {
 
 	conf := config.New()
 	conf.Set("Warehouse.claimRefreshIntervalInS", "1")
-	conf.Set("Warehouse.enableNotifierHeartbeat", true)
 
 	worker := newWorker(
 		conf,


### PR DESCRIPTION
# Description

This PR changes the default for `Warehouse.enableNotifierHeartbeat` env from `false` to `true`

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
