### PR TITLE
chore: update rudderlabs/build-scan-push-action to 1.7.0

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       matrix:
         build-config:
-          - os: [ self-hosted, Linux, ARM64 ]
+          - os: [ self-hosted, Linux, ARM64, ubuntu-22 ]
             tags: ${{needs.docker-oss-meta.outputs.arm64_tags}}
             labels: ${{needs.docker-oss-meta.outputs.arm64_labels}}
             platform: linux/arm64
@@ -167,7 +167,7 @@ jobs:
     strategy:
       matrix:
         build-config:
-          - os: [ self-hosted, Linux, ARM64 ]
+          - os: [ self-hosted, Linux, ARM64, ubuntu-22 ]
             tags: ${{needs.docker-ent-meta.outputs.arm64_tags}}
             labels: ${{needs.docker-ent-meta.outputs.arm64_labels}}
             platform: linux/arm64
@@ -243,7 +243,7 @@ jobs:
     strategy:
       matrix:
         build-config:
-          - os: [ self-hosted, Linux, ARM64 ]
+          - os: [ self-hosted, Linux, ARM64, ubuntu-22 ]
             tags: ${{needs.docker-sbsvc-meta.outputs.arm64_tags}}
             labels: ${{needs.docker-sbsvc-meta.outputs.arm64_labels}}
             platform: linux/arm64

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build, scan and push
-        uses: rudderlabs/build-scan-push-action@v1.3.2
+        uses: rudderlabs/build-scan-push-action@v1.7.0
         with:
           context: .
           platforms: ${{ matrix.build-config.platform }}
@@ -188,7 +188,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build, scan and push
-        uses: rudderlabs/build-scan-push-action@v1.3.2
+        uses: rudderlabs/build-scan-push-action@v1.7.0
         with:
           context: .
           platforms: ${{ matrix.build-config.platform }}
@@ -263,7 +263,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build, scan and push
-        uses: rudderlabs/build-scan-push-action@v1.3.2
+        uses: rudderlabs/build-scan-push-action@v1.7.0
         with:
           context: .
           platforms: ${{ matrix.build-config.platform }}


### PR DESCRIPTION
# Description

Bumping rudderlabs/build-scan-push-action to 1.7.0

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
