### PR TITLE
chore: renaming mirroring modes

### DIFF
--- a/services/dedup/db.go
+++ b/services/dedup/db.go
@@ -34,7 +34,7 @@ func NewDB(conf *config.Config, s stats.Stats, log logger.Logger) (types.DB, err
 	log.Infon("Starting deduplication db")
 
 	gauge := func(primary, mirror string) {
-		s.NewTaggedStat("dedup_mode", stats.GaugeType, stats.Tags{
+		s.NewTaggedStat("processor_dedup_mode", stats.GaugeType, stats.Tags{
 			"primary": primary,
 			"mirror":  mirror,
 		}).Gauge(1)

--- a/services/dedup/db.go
+++ b/services/dedup/db.go
@@ -3,11 +3,10 @@ package dedup
 import (
 	"fmt"
 
-	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
-
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 	"github.com/rudderlabs/rudder-server/services/dedup/badger"
 	kdb "github.com/rudderlabs/rudder-server/services/dedup/keydb"
 	"github.com/rudderlabs/rudder-server/services/dedup/types"
@@ -16,10 +15,10 @@ import (
 type mode string
 
 const (
-	badgerOnlyMode   mode = "badger"
-	keyDBOnlyMode    mode = "keydb"
-	mirrorBadgerMode mode = "mirrorBadger"
-	mirrorKeyDBMode  mode = "mirrorKeyDB"
+	badgerOnlyMode mode = "badger"
+	keyDBOnlyMode  mode = "keydb"
+	mirrorToKeyDB  mode = "mirrorToKeyDB"
+	mirrorToBadger mode = "mirrorToBadger"
 )
 
 // getMode determines which mode to use based on configuration
@@ -31,7 +30,7 @@ func getMode(conf *config.Config) mode {
 // NewDB creates a new DB implementation based on configuration
 func NewDB(conf *config.Config, stats stats.Stats, log logger.Logger) (types.DB, error) {
 	mirrorMode := getMode(conf)
-	log.Infon("starting deduplication db", logger.NewStringField("mode", string(mirrorMode)))
+	log.Infon("Starting deduplication db", logger.NewStringField("mode", string(mirrorMode)))
 	switch mirrorMode {
 	case badgerOnlyMode:
 		return badger.NewBadgerDB(conf, stats, badger.DefaultPath())
@@ -41,35 +40,33 @@ func NewDB(conf *config.Config, stats stats.Stats, log logger.Logger) (types.DB,
 			return nil, fmt.Errorf("create keydb: %w", err)
 		}
 		return keydb, nil
-	case mirrorBadgerMode:
-		// primary is badger, mirror is keydb
+	case mirrorToKeyDB:
+		// primary is badger, then we mirror to keydb
 		primary, err := badger.NewBadgerDB(conf, stats, badger.DefaultPath())
 		if err != nil {
 			return nil, fmt.Errorf("create badger primary: %w", err)
 		}
-		// try to create keydb mirror
 		mirror, err := kdb.NewKeyDB(conf, stats, log)
 		if err != nil {
-			log.Errorn("failed to create keydb mirror, falling back to badger only", obskit.Error(err))
+			log.Errorn("Failed to create keydb mirror, falling back to badger only", obskit.Error(err))
 			return primary, nil
 		}
-
-		return NewMirrorDB(primary, mirror, mirrorBadgerMode, conf, stats, log), nil
-	case mirrorKeyDBMode:
-		// primary is keydb, mirror is badger
+		return NewMirrorDB(primary, mirror, mirrorToKeyDB, conf, stats, log), nil
+	case mirrorToBadger:
+		// primary is keydb, then we mirror to badger
 		primary, err := kdb.NewKeyDB(conf, stats, log)
 		if err != nil {
 			return nil, fmt.Errorf("create keydb primary: %w", err)
 		}
-
 		mirror, err := badger.NewBadgerDB(conf, stats, badger.DefaultPath())
 		if err != nil {
 			primary.Close()
+			log.Errorn("Failed to create badger mirror, falling back to keydb only", obskit.Error(err))
 			return nil, fmt.Errorf("create badger mirror: %w", err)
 		}
-		return NewMirrorDB(primary, mirror, mirrorKeyDBMode, conf, stats, log), nil
+		return NewMirrorDB(primary, mirror, mirrorToBadger, conf, stats, log), nil
 	default:
-		log.Warnn("invalid mirror mode, falling back to badger only", logger.NewStringField("mode", string(mirrorMode)))
+		log.Warnn("Invalid mirror mode, falling back to badger only", logger.NewStringField("mode", string(mirrorMode)))
 		// Default to badger only
 		return badger.NewBadgerDB(conf, stats, badger.DefaultPath())
 	}

--- a/services/dedup/dedup_test.go
+++ b/services/dedup/dedup_test.go
@@ -306,8 +306,8 @@ func Test_Dedup_MirrorMode_Badger(t *testing.T) {
 	conf := config.New()
 	t.Setenv("RUDDER_TMPDIR", dbPath)
 
-	// Test mirrorBadger mode (default)
-	conf.Set("Dedup.Mirror.Mode", "mirrorBadger")
+	// Test mirrorToKeyDB mode (default)
+	conf.Set("Dedup.Mirror.Mode", "mirrorToKeyDB")
 
 	// Mock KeyDB to simulate failure, should fall back to badger only
 	conf.Set("KeyDB.Dedup.Addresses", "localhost:12345")
@@ -340,8 +340,8 @@ func Test_Dedup_MirrorMode_KeyDB_Error(t *testing.T) {
 	conf := config.New()
 	t.Setenv("RUDDER_TMPDIR", dbPath)
 
-	// Test mirrorKeyDB mode with KeyDB error
-	conf.Set("Dedup.Mirror.Mode", "mirrorKeyDB")
+	// Test mirrorToBadger mode with KeyDB error
+	conf.Set("Dedup.Mirror.Mode", "mirrorToBadger")
 	conf.Set("KeyDB.Dedup.Addresses", "ransjkaljkl:12345") // Invalid address to simulate KeyDB failure
 	conf.Set("KeyDB.Dedup.RetryPolicy.Disabled", true)
 
@@ -394,8 +394,8 @@ func Test_Dedup_MirrorMode_KeyDB_Success(t *testing.T) {
 	// Start a KeyDB instance
 	startKeydb(t, conf)
 
-	// Test mirrorKeyDB mode with working KeyDB
-	conf.Set("Dedup.Mirror.Mode", "mirrorKeyDB")
+	// Test mirrorToBadger mode with working KeyDB
+	conf.Set("Dedup.Mirror.Mode", "mirrorToBadger")
 
 	d, err := dedup.New(conf, stats.NOP, logger.NOP)
 	require.NoError(t, err)
@@ -442,7 +442,7 @@ func Test_Dedup_MirrorMode_Badger_Success(t *testing.T) {
 	// Start a KeyDB instance
 	startKeydb(t, conf)
 
-	// Test mirrorBadger mode (default) with working KeyDB
+	// Test mirrorToKeyDB mode (default) with working KeyDB
 	// Not setting the mode explicitly to test the default behavior
 
 	d, err := dedup.New(conf, stats.NOP, logger.NOP)


### PR DESCRIPTION
# Description

* Renaming mirroring modes to avoid confusion.
* Adding gauge to show current dedup modes in Grafana dashboards.

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-2373/keydb-follow-ups) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
