### PR TITLE
fix: remove credentials and libraries from destination transformer payload

### DIFF
--- a/processor/internal/transformer/destination_transformer/destination_transformer.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer.go
@@ -449,10 +449,8 @@ func (d *Client) getRequestPayload(data []types.TransformerEvent, compactRequest
 		}
 		for i := range data {
 			ctr.Input = append(ctr.Input, types.CompactedTransformerEvent{
-				Message:     data[i].Message,
-				Metadata:    data[i].Metadata,
-				Libraries:   data[i].Libraries,
-				Credentials: data[i].Credentials,
+				Message:  data[i].Message,
+				Metadata: data[i].Metadata,
 			})
 			if _, ok := ctr.Destinations[data[i].Metadata.DestinationID]; !ok {
 				ctr.Destinations[data[i].Metadata.DestinationID] = data[i].Destination


### PR DESCRIPTION
# Description

This PR removes the  and  fields from the  structure in the destination transformer to improve performance and security by reducing payload size and avoiding unnecessary data transmission.

## Changes Made

- **Removed Libraries field**: Eliminated the  field from  in destination transformer payload
- **Removed Credentials field**: Eliminated the  field from  in destination transformer payload
- **Simplified payload structure**: Reduced payload size and complexity for better performance
- **Maintained backward compatibility**: Existing transformer logic continues to work without these fields

## Technical Details

The changes affect the  method in :
- Previously included  and  in the compacted event structure
- Now only includes  and  fields
- Reduces memory usage and network payload size
- Improves security by not transmitting sensitive credential data

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
- [x] Removes potential exposure of credential data in transformer payloads