### PR TITLE
chore: sync release v1.58.3 to main branch

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       matrix:
         build-config:
-          - os: [ self-hosted, Linux, ARM64 ]
+          - os: [ self-hosted, Linux, ARM64, ubuntu-22 ]
             tags: ${{needs.docker-oss-meta.outputs.arm64_tags}}
             labels: ${{needs.docker-oss-meta.outputs.arm64_labels}}
             platform: linux/arm64
@@ -114,7 +114,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build, scan and push
-        uses: rudderlabs/build-scan-push-action@v1.3.2
+        uses: rudderlabs/build-scan-push-action@v1.7.0
         with:
           context: .
           platforms: ${{ matrix.build-config.platform }}
@@ -167,7 +167,7 @@ jobs:
     strategy:
       matrix:
         build-config:
-          - os: [ self-hosted, Linux, ARM64 ]
+          - os: [ self-hosted, Linux, ARM64, ubuntu-22 ]
             tags: ${{needs.docker-ent-meta.outputs.arm64_tags}}
             labels: ${{needs.docker-ent-meta.outputs.arm64_labels}}
             platform: linux/arm64
@@ -188,7 +188,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build, scan and push
-        uses: rudderlabs/build-scan-push-action@v1.3.2
+        uses: rudderlabs/build-scan-push-action@v1.7.0
         with:
           context: .
           platforms: ${{ matrix.build-config.platform }}
@@ -243,7 +243,7 @@ jobs:
     strategy:
       matrix:
         build-config:
-          - os: [ self-hosted, Linux, ARM64 ]
+          - os: [ self-hosted, Linux, ARM64, ubuntu-22 ]
             tags: ${{needs.docker-sbsvc-meta.outputs.arm64_tags}}
             labels: ${{needs.docker-sbsvc-meta.outputs.arm64_labels}}
             platform: linux/arm64
@@ -263,7 +263,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build, scan and push
-        uses: rudderlabs/build-scan-push-action@v1.3.2
+        uses: rudderlabs/build-scan-push-action@v1.7.0
         with:
           context: .
           platforms: ${{ matrix.build-config.platform }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.58.2](https://github.com/rudderlabs/rudder-server/compare/v1.58.1...v1.58.2) (2025-09-11)
+
+
+### Bug Fixes
+
+* **router:** kinesis rate exceeded errors are being aborted with http 400 ([#6329](https://github.com/rudderlabs/rudder-server/issues/6329)) ([c07565a](https://github.com/rudderlabs/rudder-server/commit/c07565a1bda50e4e252fcae7cdb870c133f76775))
+
 ## [1.58.1](https://github.com/rudderlabs/rudder-server/compare/v1.58.0...v1.58.1) (2025-09-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.58.3](https://github.com/rudderlabs/rudder-server/compare/v1.58.2...v1.58.3) (2025-09-15)
+
+
+### Bug Fixes
+
+* **batchrouter:** support configurable column ordering in CSVs in sftp ([#6342](https://github.com/rudderlabs/rudder-server/issues/6342)) ([1c0cf56](https://github.com/rudderlabs/rudder-server/commit/1c0cf56395a071b588c8d67400acff4bd6eb05fa))
+
 ## [1.58.2](https://github.com/rudderlabs/rudder-server/compare/v1.58.1...v1.58.2) (2025-09-11)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.58.1](https://github.com/rudderlabs/rudder-server/compare/v1.58.0...v1.58.1) (2025-09-04)
+
+
+### Bug Fixes
+
+* avoid running migrations for notifier from slaves ([#6303](https://github.com/rudderlabs/rudder-server/issues/6303)) ([f698749](https://github.com/rudderlabs/rudder-server/commit/f6987499c8a6fb3a61ebc8c787e4594712770cee))
+* remove unwanted table level schemas ([#6296](https://github.com/rudderlabs/rudder-server/issues/6296)) ([1b52d26](https://github.com/rudderlabs/rudder-server/commit/1b52d2698a44286fb32c1b5babb417c34e9966d8))
+
 ## [1.58.0](https://github.com/rudderlabs/rudder-server/compare/v1.57.0...v1.58.0) (2025-09-02)
 
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MOUNT_PATH=/local
 
 # go tools versions
 GOLANGCI=github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.2.1
-gofumpt=mvdan.cc/gofumpt@latest
+gofumpt=mvdan.cc/gofumpt@v0.8.0
 govulncheck=golang.org/x/vuln/cmd/govulncheck@latest
 goimports=golang.org/x/tools/cmd/goimports@latest
 mockgen=go.uber.org/mock/mockgen@v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -226,7 +226,7 @@ require (
 	github.com/go-playground/validator/v10 v10.23.0 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.3.0
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-reflect v1.2.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect

--- a/router/batchrouter/asyncdestinationmanager/sftp/sftp_test.go
+++ b/router/batchrouter/asyncdestinationmanager/sftp/sftp_test.go
@@ -1,6 +1,7 @@
 package sftp
 
 import (
+	"encoding/csv"
 	stdjson "encoding/json"
 	"fmt"
 	"os"
@@ -113,7 +114,7 @@ func TestSFTP(t *testing.T) {
 		t.Run("TestUploadWrongFilepath", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			fileManager := mock_sftp.NewMockFileManager(ctrl)
-			defaultManager := newDefaultManager(logger.NOP, stats.NOP, fileManager)
+			defaultManager := newDefaultManager(logger.NOP, stats.NOP, fileManager, destConfig{})
 			manager := common.SimpleAsyncDestinationManager{UploaderAndTransformer: defaultManager}
 			asyncDestination := common.AsyncDestinationStruct{
 				ImportingJobIDs: []int64{1014, 1015, 1016, 1017},
@@ -134,7 +135,7 @@ func TestSFTP(t *testing.T) {
 		t.Run("TestErrorUploadingFileOnRemoteServer", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			fileManager := mock_sftp.NewMockFileManager(ctrl)
-			defaultManager := newDefaultManager(logger.NOP, stats.NOP, fileManager)
+			defaultManager := newDefaultManager(logger.NOP, stats.NOP, fileManager, destConfig{})
 			fileManager.EXPECT().Upload(gomock.Any(), gomock.Any()).Return(fmt.Errorf("root directory does not exists"))
 			manager := common.SimpleAsyncDestinationManager{UploaderAndTransformer: defaultManager}
 			asyncDestination := common.AsyncDestinationStruct{
@@ -156,7 +157,7 @@ func TestSFTP(t *testing.T) {
 		t.Run("TestSuccessfulUpload", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			fileManager := mock_sftp.NewMockFileManager(ctrl)
-			defaultManager := newDefaultManager(logger.NOP, stats.NOP, fileManager)
+			defaultManager := newDefaultManager(logger.NOP, stats.NOP, fileManager, destConfig{})
 			now := time.Now()
 			filePath := fmt.Sprintf("/tmp/testDir1/destination_id_1_someJobRunId_1/file_%d_%02d_%02d_%d_1.csv", now.Year(), now.Month(), now.Day(), now.Unix())
 			fileManager.EXPECT().Upload(gomock.Any(), filePath).Return(nil)
@@ -206,35 +207,81 @@ func TestSFTP(t *testing.T) {
 
 	t.Run("createSSHConfig", func(t *testing.T) {
 		t.Run("TestMissingPassword", func(t *testing.T) {
-			sshConfig, err := createSSHConfig(&destinations[1])
+			config := destConfig{
+				AuthMethod: "passwordAuth",
+				Username:   "username",
+				Host:       "host",
+				Port:       "22",
+				Password:   "",
+				FileFormat: "csv",
+				FilePath:   "/tmp/testDir1/{destinationID}_{jobRunID}/file_{YYYY}_{MM}_{DD}_{timestampInSec}.csv",
+			}
+			sshConfig, err := createSSHConfig(config)
 			require.Nil(t, sshConfig)
 			require.EqualError(t, err, "invalid sftp configuration: password is required for password authentication")
 		})
 
 		t.Run("TestInvalidFileFormat", func(t *testing.T) {
-			sshConfig, err := createSSHConfig(&destinations[2])
+			config := destConfig{
+				AuthMethod: "passwordAuth",
+				Username:   "username",
+				Host:       "host",
+				Port:       "22",
+				Password:   "password",
+				FileFormat: "txt",
+				FilePath:   "/tmp/testDir1/{destinationID}_{jobRunID}/file_{YYYY}_{MM}_{DD}_{timestampInSec}.csv",
+			}
+			sshConfig, err := createSSHConfig(config)
 			require.Nil(t, sshConfig)
 			require.EqualError(t, err, "invalid sftp configuration: invalid file format: txt")
 		})
 
 		t.Run("TestInvalidPort", func(t *testing.T) {
-			sshConfig, err := createSSHConfig(&destinations[3])
+			config := destConfig{
+				AuthMethod: "passwordAuth",
+				Username:   "username",
+				Host:       "host",
+				Port:       "",
+				Password:   "password",
+				FileFormat: "csv",
+				FilePath:   "/tmp/testDir1/{destinationID}_{jobRunID}/file_{YYYY}_{MM}_{DD}_{timestampInSec}.csv",
+			}
+			sshConfig, err := createSSHConfig(config)
 			require.Nil(t, sshConfig)
 			require.EqualError(t, err, `invalid sftp configuration: strconv.Atoi: parsing "": invalid syntax`)
 
-			sshConfig, err = createSSHConfig(&destinations[4])
+			config.Port = "0"
+			sshConfig, err = createSSHConfig(config)
 			require.Nil(t, sshConfig)
 			require.EqualError(t, err, "invalid sftp configuration: invalid port: 0")
 		})
 
 		t.Run("TestSuccessfulSSHConfig", func(t *testing.T) {
-			sshConfig, err := createSSHConfig(&destinations[0])
+			config := destConfig{
+				AuthMethod: "passwordAuth",
+				Username:   "username",
+				Host:       "host",
+				Port:       "22",
+				Password:   "password",
+				FileFormat: "csv",
+				FilePath:   "/tmp/testDir1/{destinationID}_{jobRunID}/file_{YYYY}_{MM}_{DD}_{timestampInSec}.csv",
+			}
+			sshConfig, err := createSSHConfig(config)
 			require.NoError(t, err)
 			require.NotNil(t, sshConfig)
 		})
 
 		t.Run("TestSuccessfulSSHConfigWithPrivateKey", func(t *testing.T) {
-			sshConfig, err := createSSHConfig(&destinations[5])
+			config := destConfig{
+				AuthMethod: "keyAuth",
+				Username:   "username",
+				Host:       "host",
+				Port:       "22",
+				PrivateKey: "privateKey",
+				FileFormat: "csv",
+				FilePath:   "/tmp/testDir1/{destinationID}_{jobRunID}/file_{YYYY}_{MM}_{DD}_{timestampInSec}.csv",
+			}
+			sshConfig, err := createSSHConfig(config)
 			require.NoError(t, err)
 			require.NotNil(t, sshConfig)
 		})
@@ -242,17 +289,223 @@ func TestSFTP(t *testing.T) {
 
 	t.Run("generateFile", func(t *testing.T) {
 		t.Run("TestJSONFileGeneration", func(t *testing.T) {
-			path, err := generateFile(filepath.Join(currentDir, "testdata/uploadDataRecord.txt"), "json")
+			path, err := generateFile(filepath.Join(currentDir, "testdata/uploadDataRecord.txt"), "json", false)
 			require.NoError(t, err)
 			require.NotNil(t, path)
-			require.NoError(t, os.Remove(path))
+			t.Cleanup(func() { require.NoError(t, os.Remove(path)) })
+
+			// Verify JSON file exists and is readable
+			jsonFile, err := os.Open(path)
+			require.NoError(t, err)
+			defer jsonFile.Close()
+
+			var records []record
+			decoder := jsonrs.NewDecoder(jsonFile)
+			err = decoder.Decode(&records)
+			require.NoError(t, err)
+			require.Len(t, records, 4)
 		})
 
-		t.Run("TestCSVFileGeneration", func(t *testing.T) {
-			path, err := generateFile(filepath.Join(currentDir, "testdata/uploadDataRecord.txt"), "csv")
+		t.Run("TestCSVFileGenerationWithSorting", func(t *testing.T) {
+			path, err := generateFile(filepath.Join(currentDir, "testdata/uploadDataRecord.txt"), "csv", true)
 			require.NoError(t, err)
 			require.NotNil(t, path)
-			require.NoError(t, os.Remove(path))
+			t.Cleanup(func() { require.NoError(t, os.Remove(path)) })
+
+			// Verify CSV file has sorted headers
+			csvFile, err := os.Open(path)
+			require.NoError(t, err)
+			defer csvFile.Close()
+
+			reader := csv.NewReader(csvFile)
+			headers, err := reader.Read()
+			require.NoError(t, err)
+			expectedHeaders := []string{"C_Email", "C_FirstName", "action"}
+			require.Equal(t, expectedHeaders, headers)
+		})
+	})
+
+	t.Run("getFieldNames", func(t *testing.T) {
+		t.Run("TestFieldExtractionWithSorting", func(t *testing.T) {
+			records := []record{
+				{
+					"message": map[string]any{
+						"fields": map[string]any{
+							"zebra":  "value1",
+							"apple":  "value2",
+							"banana": "value3",
+						},
+					},
+				},
+			}
+			expected := []string{"action", "apple", "banana", "zebra"}
+			received, err := getFieldNames(records, true)
+			require.NoError(t, err)
+			require.Equal(t, expected, received)
+		})
+
+		t.Run("TestEmptyRecords", func(t *testing.T) {
+			records := []record{}
+			_, err := getFieldNames(records, false)
+			require.EqualError(t, err, "no records found")
+		})
+	})
+
+	t.Run("Upload with CSV column sorting verification", func(t *testing.T) {
+		t.Run("TestUploadWithSortedColumns", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			fileManager := mock_sftp.NewMockFileManager(ctrl)
+
+			// Create test data with unsorted field names
+			tempFile, err := os.CreateTemp("", "test_unsorted_data_*.txt")
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, os.Remove(tempFile.Name())) })
+
+			// Create test data with intentionally unsorted field names
+			testData := `{"message":{"action":"insert","fields":{"zebra_field":"zebra_value","apple_field":"apple_value","banana_field":"banana_value","cherry_field":"cherry_value"}}}
+{"message":{"action":"update","fields":{"zebra_field":"zebra_value2","apple_field":"apple_value2","banana_field":"banana_value2","cherry_field":"cherry_value2"}}}`
+			_, err = tempFile.WriteString(testData)
+			require.NoError(t, err)
+			tempFile.Close()
+
+			// Create manager with SortColumnNames enabled
+			config := destConfig{
+				SortColumnNames: true,
+			}
+			defaultManager := newDefaultManager(logger.NOP, stats.NOP, fileManager, config)
+			manager := common.SimpleAsyncDestinationManager{UploaderAndTransformer: defaultManager}
+
+			// Setup mock to capture and verify the uploaded file content
+			var csvContent [][]string
+			fileManager.EXPECT().Upload(gomock.Any(), gomock.Any()).DoAndReturn(func(localPath, remotePath string) error {
+				// Read the CSV file content before it gets cleaned up
+				csvFile, err := os.Open(localPath)
+				if err != nil {
+					return err
+				}
+				defer csvFile.Close()
+
+				reader := csv.NewReader(csvFile)
+				allRows, err := reader.ReadAll()
+				if err != nil {
+					return err
+				}
+				csvContent = allRows
+				return nil
+			})
+
+			now := time.Now()
+
+			asyncDestination := common.AsyncDestinationStruct{
+				ImportingJobIDs: []int64{1014, 1015},
+				FileName:        tempFile.Name(),
+				Destination:     &destinations[0],
+				Manager:         manager,
+				CreatedAt:       now,
+				PartFileNumber:  1,
+				SourceJobRunID:  "someJobRunId_1",
+			}
+
+			// Execute upload
+			result := manager.Upload(&asyncDestination)
+
+			// Verify upload was successful
+			require.Equal(t, "destination_id_1", result.DestinationID)
+			require.Equal(t, []int64{1014, 1015}, result.SucceededJobIDs)
+			require.Equal(t, "File Upload Success", result.SuccessResponse)
+
+			// Verify CSV content was captured and contains sorted columns
+			require.NotEmpty(t, csvContent)
+			require.Len(t, csvContent, 3) // Should have 1 header row + 2 data rows
+
+			// Verify headers are sorted alphabetically
+			headers := csvContent[0]
+			expectedHeaders := []string{"action", "apple_field", "banana_field", "cherry_field", "zebra_field"}
+			require.Equal(t, expectedHeaders, headers)
+
+			// Verify data rows exist and are in correct order
+			require.Equal(t, []string{"insert", "apple_value", "banana_value", "cherry_value", "zebra_value"}, csvContent[1])
+			require.Equal(t, []string{"update", "apple_value2", "banana_value2", "cherry_value2", "zebra_value2"}, csvContent[2])
+		})
+
+		t.Run("TestUploadWithUnsortedColumns", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			fileManager := mock_sftp.NewMockFileManager(ctrl)
+
+			// Create test data with unsorted field names
+			tempFile, err := os.CreateTemp("", "test_unsorted_data_*.txt")
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, os.Remove(tempFile.Name())) })
+
+			// Create test data with intentionally unsorted field names
+			testData := `{"message":{"action":"insert","fields":{"zebra_field":"zebra_value","apple_field":"apple_value","banana_field":"banana_value","cherry_field":"cherry_value"}}}
+{"message":{"action":"update","fields":{"zebra_field":"zebra_value2","apple_field":"apple_value2","banana_field":"banana_value2","cherry_field":"cherry_value2"}}}`
+			_, err = tempFile.WriteString(testData)
+			require.NoError(t, err)
+			tempFile.Close()
+
+			// Create manager with SortColumnNames disabled
+			config := destConfig{
+				SortColumnNames: false,
+			}
+			defaultManager := newDefaultManager(logger.NOP, stats.NOP, fileManager, config)
+			manager := common.SimpleAsyncDestinationManager{UploaderAndTransformer: defaultManager}
+
+			// Setup mock to capture and verify the uploaded file content
+			var csvContent [][]string
+			fileManager.EXPECT().Upload(gomock.Any(), gomock.Any()).DoAndReturn(func(localPath, remotePath string) error {
+				// Read the CSV file content before it gets cleaned up
+				csvFile, err := os.Open(localPath)
+				if err != nil {
+					return err
+				}
+				defer csvFile.Close()
+
+				reader := csv.NewReader(csvFile)
+				allRows, err := reader.ReadAll()
+				if err != nil {
+					return err
+				}
+				csvContent = allRows
+				return nil
+			})
+
+			now := time.Now()
+
+			asyncDestination := common.AsyncDestinationStruct{
+				ImportingJobIDs: []int64{1014, 1015},
+				FileName:        tempFile.Name(),
+				Destination:     &destinations[0],
+				Manager:         manager,
+				CreatedAt:       now,
+				PartFileNumber:  1,
+				SourceJobRunID:  "someJobRunId_1",
+			}
+
+			// Execute upload
+			result := manager.Upload(&asyncDestination)
+
+			// Verify upload was successful
+			require.Equal(t, "destination_id_1", result.DestinationID)
+			require.Equal(t, []int64{1014, 1015}, result.SucceededJobIDs)
+			require.Equal(t, "File Upload Success", result.SuccessResponse)
+
+			// Verify CSV content was captured
+			require.NotEmpty(t, csvContent)
+			require.Len(t, csvContent, 3) // Should have 1 header row + 2 data rows
+
+			// Verify headers are NOT in sorted order when SortColumnNames is false
+			headers := csvContent[0]
+			expectedSortedHeaders := []string{"action", "apple_field", "banana_field", "cherry_field", "zebra_field"}
+			require.NotEqual(t, expectedSortedHeaders, headers, "Headers should not be in sorted order when SortColumnNames is false")
+
+			// Verify headers contain all expected fields
+			require.Len(t, headers, 5)
+			require.Contains(t, headers, "action")
+			require.Contains(t, headers, "apple_field")
+			require.Contains(t, headers, "banana_field")
+			require.Contains(t, headers, "cherry_field")
+			require.Contains(t, headers, "zebra_field")
 		})
 	})
 
@@ -290,6 +543,187 @@ func TestSFTP(t *testing.T) {
 			expected := "/path/to/{invalid}/file.txt"
 			received, err := getUploadFilePath(input, nil)
 			require.NoError(t, err)
+			require.Equal(t, expected, received)
+		})
+	})
+
+	t.Run("parseRecords", func(t *testing.T) {
+		t.Run("TestSuccessfulParsing", func(t *testing.T) {
+			tempFile, err := os.CreateTemp("", "test_records_*.txt")
+			require.NoError(t, err)
+			defer os.Remove(tempFile.Name())
+
+			testData := `{"message":{"action":"insert","fields":{"email":"test1@email.com","name":"test1"}}}
+{"message":{"action":"update","fields":{"email":"test2@email.com","name":"test2"}}}
+{"message":{"action":"insert","fields":{"email":"test3@email.com","name":"test3"}}}`
+			_, err = tempFile.WriteString(testData)
+			require.NoError(t, err)
+			tempFile.Close()
+
+			records, err := parseRecords(tempFile.Name())
+			require.NoError(t, err)
+			require.Len(t, records, 3)
+
+			// Check first record
+			message, ok := records[0]["message"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "insert", message["action"])
+			fields, ok := message["fields"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "test1@email.com", fields["email"])
+			require.Equal(t, "test1", fields["name"])
+		})
+
+		t.Run("TestNonExistentFile", func(t *testing.T) {
+			_, err := parseRecords("non_existent_file.txt")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "opening file")
+		})
+
+		t.Run("TestInvalidJSON", func(t *testing.T) {
+			tempFile, err := os.CreateTemp("", "test_invalid_*.txt")
+			require.NoError(t, err)
+			defer os.Remove(tempFile.Name())
+
+			_, err = tempFile.WriteString(`{"invalid": json}`)
+			require.NoError(t, err)
+			tempFile.Close()
+
+			_, err = parseRecords(tempFile.Name())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "error parsing JSON record")
+		})
+
+		t.Run("TestEmptyFile", func(t *testing.T) {
+			tempFile, err := os.CreateTemp("", "test_empty_*.txt")
+			require.NoError(t, err)
+			defer os.Remove(tempFile.Name())
+			tempFile.Close()
+
+			records, err := parseRecords(tempFile.Name())
+			require.NoError(t, err)
+			require.Len(t, records, 0)
+		})
+	})
+
+	t.Run("validation functions", func(t *testing.T) {
+		t.Run("validateFilePath", func(t *testing.T) {
+			t.Run("ValidFilePath", func(t *testing.T) {
+				path := "/path/to/{destinationID}_{jobRunID}/file.csv"
+				err := validateFilePath(path)
+				require.NoError(t, err)
+			})
+
+			t.Run("MissingDestinationID", func(t *testing.T) {
+				path := "/path/to/{jobRunID}/file.csv"
+				err := validateFilePath(path)
+				require.EqualError(t, err, "destinationID placeholder is missing in the upload filePath")
+			})
+
+			t.Run("MissingJobRunID", func(t *testing.T) {
+				path := "/path/to/{destinationID}/file.csv"
+				err := validateFilePath(path)
+				require.EqualError(t, err, "jobRunID placeholder is missing in the upload filePath")
+			})
+		})
+
+		t.Run("isValidPort", func(t *testing.T) {
+			t.Run("ValidPorts", func(t *testing.T) {
+				validPorts := []string{"1", "22", "80", "443", "8080", "65535"}
+				for _, port := range validPorts {
+					err := isValidPort(port)
+					require.NoError(t, err, "Port %s should be valid", port)
+				}
+			})
+
+			t.Run("InvalidPorts", func(t *testing.T) {
+				invalidPorts := []string{"0", "65536", "-1", "abc", ""}
+				for _, port := range invalidPorts {
+					err := isValidPort(port)
+					require.Error(t, err, "Port %s should be invalid", port)
+				}
+			})
+		})
+
+		t.Run("isValidFileFormat", func(t *testing.T) {
+			t.Run("ValidFormats", func(t *testing.T) {
+				validFormats := []string{"json", "csv"}
+				for _, format := range validFormats {
+					err := isValidFileFormat(format)
+					require.NoError(t, err, "Format %s should be valid", format)
+				}
+			})
+
+			t.Run("InvalidFormats", func(t *testing.T) {
+				invalidFormats := []string{"JSON", "CSV", "Json", "Csv", "txt", "xml", "parquet", "avro", ""}
+				for _, format := range invalidFormats {
+					err := isValidFileFormat(format)
+					require.Error(t, err, "Format %s should be invalid", format)
+				}
+			})
+		})
+	})
+
+	t.Run("appendFileNumberInFilePath", func(t *testing.T) {
+		t.Run("TestWithExtension", func(t *testing.T) {
+			path := "/path/to/file.csv"
+			expected := "/path/to/file_1.csv"
+			received := appendFileNumberInFilePath(path, 1)
+			require.Equal(t, expected, received)
+		})
+
+		t.Run("TestWithoutExtension", func(t *testing.T) {
+			path := "/path/to/file"
+			expected := "/path/to/file_2"
+			received := appendFileNumberInFilePath(path, 2)
+			require.Equal(t, expected, received)
+		})
+
+		t.Run("TestMultipleExtensions", func(t *testing.T) {
+			path := "/path/to/file.backup.csv"
+			expected := "/path/to/file.backup_3.csv"
+			received := appendFileNumberInFilePath(path, 3)
+			require.Equal(t, expected, received)
+		})
+
+		t.Run("TestZeroFileNumber", func(t *testing.T) {
+			path := "/path/to/file.json"
+			expected := "/path/to/file_0.json"
+			received := appendFileNumberInFilePath(path, 0)
+			require.Equal(t, expected, received)
+		})
+	})
+
+	t.Run("generateErrorOutput", func(t *testing.T) {
+		t.Run("TestErrorOutputGeneration", func(t *testing.T) {
+			errMsg := "connection failed"
+			importingJobIds := []int64{1014, 1015, 1016, 1017}
+			destinationID := "test_destination_id"
+
+			expected := common.AsyncUploadOutput{
+				DestinationID: destinationID,
+				AbortCount:    len(importingJobIds),
+				AbortJobIDs:   importingJobIds,
+				AbortReason:   errMsg,
+			}
+
+			received := generateErrorOutput(errMsg, importingJobIds, destinationID)
+			require.Equal(t, expected, received)
+		})
+
+		t.Run("TestEmptyJobIds", func(t *testing.T) {
+			errMsg := "no jobs to process"
+			importingJobIds := []int64{}
+			destinationID := "test_destination_id"
+
+			expected := common.AsyncUploadOutput{
+				DestinationID: destinationID,
+				AbortCount:    0,
+				AbortJobIDs:   importingJobIds,
+				AbortReason:   errMsg,
+			}
+
+			received := generateErrorOutput(errMsg, importingJobIds, destinationID)
 			require.Equal(t, expected, received)
 		})
 	})

--- a/router/batchrouter/asyncdestinationmanager/sftp/types.go
+++ b/router/batchrouter/asyncdestinationmanager/sftp/types.go
@@ -12,17 +12,19 @@ type defaultManager struct {
 	statsFactory   stats.Stats
 	FileManager    sftp.FileManager
 	filePathPrefix string
+	config         destConfig
 }
 
 type destConfig struct {
-	AuthMethod string `json:"authMethod"`
-	Username   string `json:"username"`
-	Host       string `json:"host"`
-	Port       string `json:"port"`
-	Password   string `json:"password"`
-	PrivateKey string `json:"privateKey"`
-	FileFormat string `json:"fileFormat"`
-	FilePath   string `json:"filePath"`
+	AuthMethod      string `mapstructure:"authMethod"`
+	Username        string `mapstructure:"username"`
+	Host            string `mapstructure:"host"`
+	Port            string `mapstructure:"port"`
+	Password        string `mapstructure:"password"`
+	PrivateKey      string `mapstructure:"privateKey"`
+	FileFormat      string `mapstructure:"fileFormat"`
+	FilePath        string `mapstructure:"filePath"`
+	SortColumnNames bool   `mapstructure:"sortColumnNames"`
 }
 
 // Record represents a single JSON record.

--- a/services/notifier/notifier_test.go
+++ b/services/notifier/notifier_test.go
@@ -62,9 +62,9 @@ func TestNotifier(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
 
-		notifierWithIdentifier := notifier.New(config.New(), logger.NOP, statsStore, workspaceIdentifier)
+		notifierWithIdentifier := notifier.New(config.New(), logger.NOP, statsStore, workspaceIdentifier, true)
 		require.NoError(t, notifierWithIdentifier.Setup(ctx, db.DBDsn))
-		notifierWithoutIdentifier := notifier.New(config.New(), logger.NOP, statsStore, "")
+		notifierWithoutIdentifier := notifier.New(config.New(), logger.NOP, statsStore, "", true)
 		require.NoError(t, notifierWithoutIdentifier.Setup(ctx, db.DBDsn))
 
 		t.Run("without workspace identifier", func(t *testing.T) {
@@ -98,7 +98,7 @@ func TestNotifier(t *testing.T) {
 			statsStore, err := memstats.New()
 			require.NoError(t, err)
 
-			n := notifier.New(config.New(), logger.NOP, statsStore, workspaceIdentifier)
+			n := notifier.New(config.New(), logger.NOP, statsStore, workspaceIdentifier, true)
 			require.NoError(t, n.Setup(ctx, db.DBDsn))
 			require.True(t, n.CheckHealth(ctx))
 		})
@@ -109,7 +109,7 @@ func TestNotifier(t *testing.T) {
 			statsStore, err := memstats.New()
 			require.NoError(t, err)
 
-			n := notifier.New(config.New(), logger.NOP, statsStore, workspaceIdentifier)
+			n := notifier.New(config.New(), logger.NOP, statsStore, workspaceIdentifier, true)
 			require.NoError(t, n.Setup(ctx, db.DBDsn))
 			require.False(t, n.CheckHealth(cancelledCtx))
 		})
@@ -143,7 +143,7 @@ func TestNotifier(t *testing.T) {
 		groupCtx, groupCancel := context.WithCancel(ctx)
 		g, gCtx := errgroup.WithContext(groupCtx)
 
-		n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier)
+		n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier, true)
 		require.NoError(t, n.Setup(groupCtx, db.DBDsn))
 
 		const (
@@ -286,7 +286,7 @@ func TestNotifier(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
 
-		n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier)
+		n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier, true)
 		require.NoError(t, n.Setup(groupCtx, db.DBDsn))
 
 		publishResponses := make(chan *notifier.PublishResponse)
@@ -371,7 +371,7 @@ func TestNotifier(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
 
-		n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier)
+		n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier, true)
 		require.NoError(t, n.Setup(groupCtx, db.DBDsn))
 
 		publishResponses := make(chan *notifier.PublishResponse)
@@ -455,7 +455,7 @@ func TestNotifier(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
 
-		n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier)
+		n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier, true)
 		require.NoError(t, n.Setup(groupCtx, db.DBDsn))
 
 		publishResponses := make(chan *notifier.PublishResponse)
@@ -529,7 +529,7 @@ func TestNotifier(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
 
-		n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier)
+		n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier, true)
 		err = n.Setup(ctx, db.DBDsn)
 		require.NoError(t, err)
 	})
@@ -543,7 +543,7 @@ func TestNotifier(t *testing.T) {
 			defer cancel()
 			statsStore, err := memstats.New()
 			require.NoError(t, err)
-			n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier)
+			n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier, true)
 			require.NoError(t, n.Setup(ctx, db.DBDsn))
 			require.NoError(t, n.RunMaintenance(ctxWithTimeout))
 			return nil
@@ -555,7 +555,7 @@ func TestNotifier(t *testing.T) {
 			statsStore, err := memstats.New()
 			require.NoError(t, err)
 
-			n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier)
+			n := notifier.New(c, logger.NOP, statsStore, workspaceIdentifier, true)
 			require.NoError(t, n.Setup(ctx, db.DBDsn))
 			require.NoError(t, n.RunMaintenance(ctxWithTimeout))
 			return nil

--- a/warehouse/api/grpc.go
+++ b/warehouse/api/grpc.go
@@ -111,7 +111,7 @@ func NewGRPCServer(
 		stagingRepo:        repo.NewStagingFiles(db, conf, repo.WithStats(statsFactory)),
 		uploadRepo:         repo.NewUploads(db, repo.WithStats(statsFactory)),
 		tableUploadsRepo:   repo.NewTableUploads(db, conf, repo.WithStats(statsFactory)),
-		schemaRepo:         repo.NewWHSchemas(db, conf, repo.WithStats(statsFactory)),
+		schemaRepo:         repo.NewWHSchemas(db, conf, logger, repo.WithStats(statsFactory)),
 		triggerStore:       triggerStore,
 		fileManagerFactory: filemanager.New,
 		now:                timeutil.Now,

--- a/warehouse/api/grpc_test.go
+++ b/warehouse/api/grpc_test.go
@@ -1915,7 +1915,7 @@ func TestGRPC(t *testing.T) {
 		})
 
 		t.Run("GetDestinationNamespaces", func(t *testing.T) {
-			schemaRepo := repo.NewWHSchemas(db, c)
+			schemaRepo := repo.NewWHSchemas(db, c, logger.NOP)
 			schema := model.WHSchema{
 				SourceID:        "source_1",
 				DestinationID:   destinationID,

--- a/warehouse/api/http.go
+++ b/warehouse/api/http.go
@@ -118,7 +118,7 @@ func NewApi(
 		triggerStore:  triggerStore,
 		stagingRepo:   repo.NewStagingFiles(db, conf, repo.WithStats(statsFactory)),
 		uploadRepo:    repo.NewUploads(db, repo.WithStats(statsFactory)),
-		schemaRepo:    repo.NewWHSchemas(db, conf, repo.WithStats(statsFactory)),
+		schemaRepo:    repo.NewWHSchemas(db, conf, log, repo.WithStats(statsFactory)),
 	}
 	a.config.healthTimeout = conf.GetDuration("Warehouse.healthTimeout", 10, time.Second)
 	a.config.readerHeaderTimeout = conf.GetDuration("Warehouse.readerHeaderTimeout", 3, time.Second)

--- a/warehouse/api/http_test.go
+++ b/warehouse/api/http_test.go
@@ -295,7 +295,7 @@ func TestHTTPApi(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	schemaRepo := repo.NewWHSchemas(db, c)
+	schemaRepo := repo.NewWHSchemas(db, c, logger.NOP)
 	err = schemaRepo.Insert(ctx,
 		&model.WHSchema{
 			SourceID:        sourceID,

--- a/warehouse/api/http_test.go
+++ b/warehouse/api/http_test.go
@@ -178,7 +178,7 @@ func TestHTTPApi(t *testing.T) {
 
 	ctx, stopTest := context.WithCancel(context.Background())
 
-	n := notifier.New(config.New(), logger.NOP, stats.NOP, workspaceIdentifier)
+	n := notifier.New(config.New(), logger.NOP, stats.NOP, workspaceIdentifier, true)
 	err = n.Setup(ctx, pgResource.DBDsn)
 	require.NoError(t, err)
 

--- a/warehouse/app.go
+++ b/warehouse/app.go
@@ -166,6 +166,7 @@ func (a *App) Setup(ctx context.Context) error {
 		a.logger,
 		a.statsFactory,
 		workspaceIdentifier,
+		mode.IsMaster(a.config.mode),
 	)
 	err := a.notifier.Setup(ctx, a.connectionString("notifier"))
 	if err != nil {

--- a/warehouse/app_test.go
+++ b/warehouse/app_test.go
@@ -33,6 +33,7 @@ import (
 	mocksApp "github.com/rudderlabs/rudder-server/mocks/app"
 	mocksBackendConfig "github.com/rudderlabs/rudder-server/mocks/backend-config"
 	proto "github.com/rudderlabs/rudder-server/proto/warehouse"
+	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 	"github.com/rudderlabs/rudder-server/testhelper/health"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/utils/pubsub"
@@ -105,6 +106,12 @@ func TestApp(t *testing.T) {
 			for _, subTC := range subTestCases {
 				t.Run(tc.name+" with "+subTC.name, func(t *testing.T) {
 					pgResource, err := postgres.Setup(pool, t)
+					require.NoError(t, err)
+
+					err = (&migrator.Migrator{
+						Handle:          pgResource.DB,
+						MigrationsTable: "pg_notifier_queue_migrations",
+					}).Migrate("pg_notifier_queue")
 					require.NoError(t, err)
 
 					webPort, err := kithelper.GetFreePort()

--- a/warehouse/bcm/backend_config.go
+++ b/warehouse/bcm/backend_config.go
@@ -41,7 +41,7 @@ func New(
 	bcm := &BackendConfigManager{
 		conf:                 c,
 		db:                   db,
-		schema:               repo.NewWHSchemas(db, c, repo.WithStats(stats)),
+		schema:               repo.NewWHSchemas(db, c, log, repo.WithStats(stats)),
 		tenantManager:        tenantManager,
 		logger:               log,
 		stats:                stats,

--- a/warehouse/internal/repo/repo_test.go
+++ b/warehouse/internal/repo/repo_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 
@@ -25,7 +26,7 @@ func TestStatsEmission(t *testing.T) {
 		require.NoError(t, err)
 
 		repoLoadFiles := repo.NewLoadFiles(db, config.New(), repo.WithStats(statsStore))
-		repoSchemas := repo.NewWHSchemas(db, config.New(), repo.WithStats(statsStore))
+		repoSchemas := repo.NewWHSchemas(db, config.New(), logger.NOP, repo.WithStats(statsStore))
 		repoStagingFiles := repo.NewStagingFiles(db, config.New(), repo.WithStats(statsStore))
 		repoTableUploads := repo.NewTableUploads(db, config.New(), repo.WithStats(statsStore))
 		repoSources := repo.NewSource(db, repo.WithStats(statsStore))

--- a/warehouse/internal/repo/schema_test.go
+++ b/warehouse/internal/repo/schema_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
 
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 	"github.com/rudderlabs/rudder-server/utils/timeutil"
@@ -73,7 +74,7 @@ func TestWHSchemasRepo(t *testing.T) {
 
 				var (
 					now = time.Now().Truncate(time.Second).UTC()
-					r   = repo.NewWHSchemas(db, conf, repo.WithNow(func() time.Time {
+					r   = repo.NewWHSchemas(db, conf, logger.NOP, repo.WithNow(func() time.Time {
 						return now
 					}))
 				)
@@ -286,7 +287,7 @@ func TestWHSchemasRepo(t *testing.T) {
 
 				var (
 					now = time.Now().Truncate(time.Second).UTC()
-					r   = repo.NewWHSchemas(db, conf, repo.WithNow(func() time.Time {
+					r   = repo.NewWHSchemas(db, conf, logger.NOP, repo.WithNow(func() time.Time {
 						return now
 					}))
 				)
@@ -364,7 +365,7 @@ func TestWHSchemasRepo(t *testing.T) {
 				})
 
 				t.Run("GetForNamespace (not already populated)", func(t *testing.T) {
-					rs1 := repo.NewWHSchemas(db, conf, repo.WithNow(func() time.Time {
+					rs1 := repo.NewWHSchemas(db, conf, logger.NOP, repo.WithNow(func() time.Time {
 						return now
 					}))
 					err := rs1.Insert(ctx, &model.WHSchema{
@@ -379,7 +380,7 @@ func TestWHSchemasRepo(t *testing.T) {
 					})
 					require.NoError(t, err)
 
-					rs2 := repo.NewWHSchemas(db, conf, repo.WithNow(func() time.Time {
+					rs2 := repo.NewWHSchemas(db, conf, logger.NOP, repo.WithNow(func() time.Time {
 						return now
 					}))
 					expectedSchema, err := rs2.GetForNamespace(ctx, "destination_id_1", "namespace_1")
@@ -445,9 +446,12 @@ func TestWHSchemasRepo(t *testing.T) {
 
 func TestWHSchemasRepo_GetForNamespace(t *testing.T) {
 	t.Run("SourceID ordering", func(t *testing.T) {
+		conf := config.New()
+		conf.Set("Warehouse.enableTableLevelSchema", true)
+
 		db, ctx := setupDB(t), context.Background()
 		now := time.Now().Truncate(time.Second).UTC()
-		r := repo.NewWHSchemas(db, config.New(), repo.WithNow(func() time.Time {
+		r := repo.NewWHSchemas(db, conf, logger.NOP, repo.WithNow(func() time.Time {
 			return now
 		}))
 
@@ -476,8 +480,6 @@ func TestWHSchemasRepo_GetForNamespace(t *testing.T) {
 					"column_name_3": "boolean",
 				},
 			},
-			CreatedAt: now,
-			UpdatedAt: now,
 		}))
 
 		expectedSchema, err := r.GetForNamespace(ctx, "destination_id_1", "namespace_1")
@@ -496,6 +498,103 @@ func TestWHSchemasRepo_GetForNamespace(t *testing.T) {
 		require.Equal(t, now, expectedSchema.CreatedAt)
 		require.Equal(t, now, expectedSchema.UpdatedAt)
 	})
+
+	t.Run("Unwanted fetch schema", func(t *testing.T) {
+		conf := config.New()
+		conf.Set("Warehouse.enableTableLevelSchema", true)
+
+		db, ctx := setupDB(t), context.Background()
+		now := time.Now().Truncate(time.Second).UTC()
+		r := repo.NewWHSchemas(db, conf, logger.NOP, repo.WithNow(func() time.Time {
+			return now
+		}))
+
+		require.NoError(t, r.Insert(ctx, &model.WHSchema{
+			SourceID:        "source_id_1",
+			Namespace:       "namespace_1",
+			DestinationID:   "destination_id_1",
+			DestinationType: "destination_type_1",
+			Schema: model.Schema{
+				"table_name_1": {
+					"column_name_1": "string",
+					"column_name_2": "int",
+					"column_name_3": "boolean",
+				},
+				"table_name_2": {
+					"column_name_1": "string",
+					"column_name_2": "int",
+					"column_name_3": "boolean",
+				},
+			},
+		}))
+		require.NoError(t, r.Insert(ctx, &model.WHSchema{
+			SourceID:        "source_id_2",
+			Namespace:       "namespace_1",
+			DestinationID:   "destination_id_1",
+			DestinationType: "destination_type_1",
+			Schema: model.Schema{
+				"table_name_1": {
+					"column_name_1": "string",
+					"column_name_2": "int",
+					"column_name_3": "boolean",
+				},
+				"table_name_2": {
+					"column_name_1": "string",
+					"column_name_2": "int",
+					"column_name_3": "boolean",
+				},
+			},
+		}))
+
+		expectedSchema, err := r.GetForNamespace(ctx, "destination_id_1", "namespace_1")
+		require.NoError(t, err)
+		require.Equal(t, model.Schema{
+			"table_name_1": {
+				"column_name_1": "string",
+				"column_name_2": "int",
+				"column_name_3": "boolean",
+			},
+			"table_name_2": {
+				"column_name_1": "string",
+				"column_name_2": "int",
+				"column_name_3": "boolean",
+			},
+		}, expectedSchema.Schema)
+
+		require.NoError(t, r.Insert(ctx, &model.WHSchema{
+			SourceID:        "source_id_1",
+			Namespace:       "namespace_1",
+			DestinationID:   "destination_id_1",
+			DestinationType: "destination_type_1",
+			Schema: model.Schema{
+				"table_name_1": {
+					"column_name_1": "string",
+					"column_name_2": "int",
+					"column_name_3": "boolean",
+				},
+				"table_name_3": {
+					"column_name_1": "string",
+					"column_name_2": "int",
+					"column_name_3": "boolean",
+				},
+			},
+		}))
+
+		expectedSchema, err = r.GetForNamespace(ctx, "destination_id_1", "namespace_1")
+		require.NoError(t, err)
+		require.Equal(t, model.Schema{
+			"table_name_1": {
+				"column_name_1": "string",
+				"column_name_2": "int",
+				"column_name_3": "boolean",
+			},
+			"table_name_3": {
+				"column_name_1": "string",
+				"column_name_2": "int",
+				"column_name_3": "boolean",
+			},
+		}, expectedSchema.Schema)
+	})
 }
 
 func TestWHSchemasRepo_GetDestinationNamespaces(t *testing.T) {
@@ -503,7 +602,7 @@ func TestWHSchemasRepo_GetDestinationNamespaces(t *testing.T) {
 	conf := config.New()
 	db, ctx := setupDB(t), context.Background()
 	now := timeutil.Now()
-	r := repo.NewWHSchemas(db, conf)
+	r := repo.NewWHSchemas(db, conf, logger.NOP)
 
 	// Insert test data with multiple sources and timestamps
 	schemas := []model.WHSchema{

--- a/warehouse/router/router_test.go
+++ b/warehouse/router/router_test.go
@@ -87,7 +87,7 @@ func TestRouter(t *testing.T) {
 
 		ctx := context.Background()
 
-		n := notifier.New(config.New(), logger.NOP, stats.NOP, workspaceIdentifier)
+		n := notifier.New(config.New(), logger.NOP, stats.NOP, workspaceIdentifier, true)
 		err = n.Setup(ctx, pgResource.DBDsn)
 		require.NoError(t, err)
 

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -188,7 +188,7 @@ func (f *UploadJobFactory) NewUploadJob(ctx context.Context, dto *model.UploadJo
 		uploadsRepo:          repo.NewUploads(f.db, repo.WithStats(f.statsFactory)),
 		stagingFileRepo:      repo.NewStagingFiles(f.db, f.conf, repo.WithStats(f.statsFactory)),
 		loadFilesRepo:        repo.NewLoadFiles(f.db, f.conf, repo.WithStats(f.statsFactory)),
-		whSchemaRepo:         repo.NewWHSchemas(f.db, f.conf, repo.WithStats(f.statsFactory)),
+		whSchemaRepo:         repo.NewWHSchemas(f.db, f.conf, f.logger, repo.WithStats(f.statsFactory)),
 		upload:               dto.Upload,
 		warehouse:            dto.Warehouse,
 		stagingFiles:         dto.StagingFiles,
@@ -338,7 +338,7 @@ func (job *UploadJob) run() (err error) {
 		job.logger.Child("warehouse"),
 		job.statsFactory,
 		whManager,
-		repo.NewWHSchemas(job.db, job.conf, repo.WithStats(job.statsFactory)),
+		repo.NewWHSchemas(job.db, job.conf, job.logger, repo.WithStats(job.statsFactory)),
 		repo.NewStagingFiles(job.db, job.conf, repo.WithStats(job.statsFactory)),
 	)
 	if err != nil {

--- a/warehouse/schema/schema_test.go
+++ b/warehouse/schema/schema_test.go
@@ -1400,7 +1400,7 @@ func TestSchema(t *testing.T) {
 
 	t.Run("SchemaOperationsAcrossConnections", func(t *testing.T) {
 		db, ctx := setupDB(t), context.Background()
-		schemaRepo := repo.NewWHSchemas(db, config.New())
+		schemaRepo := repo.NewWHSchemas(db, config.New(), logger.NOP)
 
 		// Create initial schema for connection 1
 		warehouse1 := model.Warehouse{


### PR DESCRIPTION
# Description

Syncing patch release v1.58.3 to main branch

**↓↓ Please review and edit commit overrides before merging ↓↓**

BEGIN_COMMIT_OVERRIDE
fix: remove unwanted table level schemas (#6296)
fix: avoid running migrations for notifier from slaves (#6303)
fix(router): kinesis rate exceeded errors are being aborted with http 400 (#6329)
fix(batchrouter): support configurable column ordering in CSVs in sftp (#6342)
END_COMMIT_OVERRIDE