### PR TITLE
chore: limit 1 while getting schemas for namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ replace (
 	k8s.io/kubernetes => k8s.io/kubernetes v1.32.1
 )
 
+
+
 require (
 	cloud.google.com/go/bigquery v1.69.0
 	cloud.google.com/go/pubsub v1.49.0

--- a/warehouse/internal/repo/schema.go
+++ b/warehouse/internal/repo/schema.go
@@ -302,8 +302,8 @@ func (sh *WHSchema) getForNamespace(ctx context.Context, destID, namespace strin
 		namespace = $2 AND
 		table_name = ''
 	ORDER BY
-		source_id DESC;
-	`
+		source_id DESC
+	LIMIT 1;`
 
 	rows, err := sh.db.QueryContext(
 		ctx,


### PR DESCRIPTION
# Description

- We are unnecessarily scanning around **608MB** for `grafanainfs` and then taking the first entry and discarding others while scanning schemas. Instead, if we need one single entry, we can put a limit of 1, it’s coming around **32MB**. Notion [link](https://www.notion.so/rudderstacks/Warehouse-indexing-263f2b415dd08049a3f4f781f0bf087d?source=copy_link#26ff2b415dd0805597a0f1c764223139).
<img width="778" height="44" alt="Screenshot 2025-09-15 at 1 54 57 PM" src="https://github.com/user-attachments/assets/458e77da-15b8-408f-90b9-83c9f59d0192" />


## Linear Ticket

- Resolves WAR-1131

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
