### PR TITLE
chore: upgrade build-scan-push-action to v1.8.0

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build, scan and push
-        uses: rudderlabs/build-scan-push-action@v1.7.0
+        uses: rudderlabs/build-scan-push-action@v1.8.0
         with:
           context: .
           platforms: ${{ matrix.build-config.platform }}
@@ -188,7 +188,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build, scan and push
-        uses: rudderlabs/build-scan-push-action@v1.7.0
+        uses: rudderlabs/build-scan-push-action@v1.8.0
         with:
           context: .
           platforms: ${{ matrix.build-config.platform }}
@@ -263,7 +263,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build, scan and push
-        uses: rudderlabs/build-scan-push-action@v1.7.0
+        uses: rudderlabs/build-scan-push-action@v1.8.0
         with:
           context: .
           platforms: ${{ matrix.build-config.platform }}


### PR DESCRIPTION
# Description

 Upgrade build-scan-push-action to the latest version

## Linear Ticket


## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
