### PR TITLE
feat(processor): configurable delay option for event processing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/gomodule/redigo v1.9.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/grafana/jsonparser v0.0.0-20250430123630-2a684464cca1
+	github.com/grafana/jsonparser v0.0.0-20250908162026-5c2524e07b4c
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/golang-lru/v2 v2.0.7
@@ -88,7 +88,7 @@ require (
 	github.com/rudderlabs/bing-ads-go-sdk v0.2.3
 	github.com/rudderlabs/compose-test v0.1.3
 	github.com/rudderlabs/keydb v1.1.0
-	github.com/rudderlabs/rudder-go-kit v0.62.0
+	github.com/rudderlabs/rudder-go-kit v0.63.0
 	github.com/rudderlabs/rudder-observability-kit v0.0.5
 	github.com/rudderlabs/rudder-schemas v0.7.0
 	github.com/rudderlabs/rudder-transformer/go v0.0.0-20250707171833-9cd525669b1b

--- a/go.sum
+++ b/go.sum
@@ -801,8 +801,8 @@ github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/z
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafana/jsonparser v0.0.0-20250430123630-2a684464cca1 h1:/Z6I/wgDVU5FjPqy9ZbUlmFVXcAMO4+Xmvfj2a7/u1Q=
-github.com/grafana/jsonparser v0.0.0-20250430123630-2a684464cca1/go.mod h1:796sq+UcONnSlzA3RtlBZ+b/hrerkZXiEmO8oMjyRwY=
+github.com/grafana/jsonparser v0.0.0-20250908162026-5c2524e07b4c h1:qEltnsNJ0ZXbsvFbCNstFwMheGxpogecPAB5dvbbf00=
+github.com/grafana/jsonparser v0.0.0-20250908162026-5c2524e07b4c/go.mod h1:796sq+UcONnSlzA3RtlBZ+b/hrerkZXiEmO8oMjyRwY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 h1:X5VWvz21y3gzm9Nw/kaUeku/1+uBhcekkmy4IkffJww=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1/go.mod h1:Zanoh4+gvIgluNqcfMVTJueD4wSS5hT7zTt4Mrutd90=
@@ -1199,8 +1199,8 @@ github.com/rudderlabs/keydb v1.1.0 h1:ycuQOZVxqzKrkXq4CoRhPBGlYks2WDNg7LaQqlS7FH
 github.com/rudderlabs/keydb v1.1.0/go.mod h1:BXBXBGS06wr1twtd+mTyQJCxlR4kMq3CzkzUShkgkuU=
 github.com/rudderlabs/parquet-go v0.0.3 h1:/zgRj929pGKHsthc0kw8stVEcFu1JUcpxDRlhxjSLic=
 github.com/rudderlabs/parquet-go v0.0.3/go.mod h1:WmwBOdvwpXl2aZGRk3NxxgzC/DaWGfax3jrCRhKhtSo=
-github.com/rudderlabs/rudder-go-kit v0.62.0 h1:7wieb60KcKTmsMW0Ag7UwYeAEaG4pzPP6/21VhY5/es=
-github.com/rudderlabs/rudder-go-kit v0.62.0/go.mod h1:0xCvAIJfeA5ghD8hXyXb7s2mwsI8Tmi5XTKJhFkNb1A=
+github.com/rudderlabs/rudder-go-kit v0.63.0 h1:KUM2hy50pbd3E3wH/odxjyrYNhOMdnmGT0fmDWMrnyo=
+github.com/rudderlabs/rudder-go-kit v0.63.0/go.mod h1:mlyvmjQUaJzuP587DsPNgwbvLzJcJvMGCIS8hWE9GTc=
 github.com/rudderlabs/rudder-observability-kit v0.0.5 h1:s/+zsqdmpYG2LuWitFqQ2aIYFf67B7akJ3yxX4/KtXc=
 github.com/rudderlabs/rudder-observability-kit v0.0.5/go.mod h1:rL0zi374TMMx6YHzFxYyPItjl90iOaKxy1fdFCcq2DQ=
 github.com/rudderlabs/rudder-schemas v0.7.0 h1:hKShHYpbIldE1Q591vodI6iaAZ/IUOyC1DqUUJZysNU=

--- a/processor/internal/preprocessdelay/handle.go
+++ b/processor/internal/preprocessdelay/handle.go
@@ -1,0 +1,74 @@
+package preprocessdelay
+
+import (
+	"context"
+	"time"
+)
+
+// NewHandle creates a new Handle that ensures that at least 'delay' time has
+// passed since the most recent JobReceivedAt time before Sleep returns.
+// If delay is less than or equal to zero, a no-op Handle is returned.
+func NewHandle(delay time.Duration, sleeper Sleeper) Handle {
+	if delay <= 0 {
+		return &nopHandle{}
+	}
+
+	h := &handle{
+		delay:   delay,
+		sleeper: sleeper,
+	}
+	if h.sleeper == nil {
+		h.sleeper = func(ctx context.Context, d time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(d):
+				return nil
+			}
+		}
+	}
+	return h
+}
+
+type Handle interface {
+	// JobReceivedAt records the time a job was received. It should be called
+	// for each job that is part of the same processing batch.
+	// If called multiple times, the most recent time is kept.
+	JobReceivedAt(receivedAt time.Time)
+	// Sleep sleeps until at least 'delay' time has passed since the most recent
+	// JobReceivedAt time. If 'delay' time has already passed, it returns
+	// immediately. If JobReceivedAt was never called, it returns immediately.
+	// It returns any error returned by the Sleeper function.
+	// The context can be used to cancel the sleep.
+	Sleep(ctx context.Context) error
+}
+
+type Sleeper func(ctx context.Context, d time.Duration) error
+
+type handle struct {
+	delay                time.Duration
+	sleeper              Sleeper
+	mostRecentReceivedAt time.Time
+}
+
+func (h *handle) JobReceivedAt(receivedAt time.Time) {
+	if receivedAt.After(h.mostRecentReceivedAt) {
+		h.mostRecentReceivedAt = receivedAt
+	}
+}
+
+func (h *handle) Sleep(ctx context.Context) error {
+	if h.mostRecentReceivedAt.IsZero() {
+		return nil
+	}
+	if sleepFor := h.delay - time.Since(h.mostRecentReceivedAt); sleepFor > 0 {
+		return h.sleeper(ctx, sleepFor)
+	}
+	return nil
+}
+
+type nopHandle struct{}
+
+func (h *nopHandle) JobReceivedAt(receivedAt time.Time) {}
+
+func (h *nopHandle) Sleep(ctx context.Context) error { return nil }

--- a/processor/internal/preprocessdelay/handle_test.go
+++ b/processor/internal/preprocessdelay/handle_test.go
@@ -1,0 +1,120 @@
+package preprocessdelay_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/processor/internal/preprocessdelay"
+)
+
+func TestHandle(t *testing.T) {
+	t.Run("with delay", func(t *testing.T) {
+		t.Run("no received at calls", func(t *testing.T) {
+			sleeper := &mockSleeper{}
+			handle := preprocessdelay.NewHandle(10*time.Second, sleeper.Sleep)
+			err := handle.Sleep(context.Background())
+			require.NoError(t, err)
+			require.Len(t, sleeper.calls, 0)
+		})
+
+		t.Run("sleeps if latest received at is not met by delay", func(t *testing.T) {
+			sleeper := &mockSleeper{}
+			handle := preprocessdelay.NewHandle(10*time.Second, sleeper.Sleep)
+			handle.JobReceivedAt(time.Now().Add(-1 * time.Second))
+			handle.JobReceivedAt(time.Now().Add(-2 * time.Second))
+			handle.JobReceivedAt(time.Now().Add(-3 * time.Second))
+			handle.JobReceivedAt(time.Now().Add(-4 * time.Second))
+			handle.JobReceivedAt(time.Now().Add(-5 * time.Second))
+			err := handle.Sleep(context.Background())
+			require.NoError(t, err)
+			require.Len(t, sleeper.calls, 1)
+			require.GreaterOrEqual(t, sleeper.calls[0], 8*time.Second)
+			require.Less(t, sleeper.calls[0], 10*time.Second)
+		})
+
+		t.Run("doesn't sleep if latest received at is met by delay", func(t *testing.T) {
+			sleeper := &mockSleeper{}
+			handle := preprocessdelay.NewHandle(10*time.Second, sleeper.Sleep)
+			handle.JobReceivedAt(time.Now().Add(-15 * time.Second))
+			err := handle.Sleep(context.Background())
+			require.NoError(t, err)
+			require.Len(t, sleeper.calls, 0)
+		})
+
+		t.Run("cancelled context", func(t *testing.T) {
+			sleeper := &mockSleeper{}
+			handle := preprocessdelay.NewHandle(10*time.Second, sleeper.Sleep)
+			handle.JobReceivedAt(time.Now().Add(-5 * time.Second))
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			err := handle.Sleep(ctx)
+			require.Error(t, err)
+			require.Len(t, sleeper.calls, 1)
+		})
+
+		t.Run("sleeper error", func(t *testing.T) {
+			sleeper := &mockSleeper{err: errors.New("sleeper error")}
+			handle := preprocessdelay.NewHandle(10*time.Second, sleeper.Sleep)
+			handle.JobReceivedAt(time.Now().Add(-5 * time.Second))
+			err := handle.Sleep(context.Background())
+			require.Error(t, err)
+			require.Len(t, sleeper.calls, 1)
+		})
+
+		t.Run("default sleeper", func(t *testing.T) {
+			handle := preprocessdelay.NewHandle(1*time.Second, nil)
+			handle.JobReceivedAt(time.Now().Add(-500 * time.Millisecond))
+			start := time.Now()
+			err := handle.Sleep(context.Background())
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, time.Since(start), 500*time.Millisecond)
+
+			t.Run("with cancelled context", func(t *testing.T) {
+				handle := preprocessdelay.NewHandle(10*time.Second, nil)
+				handle.JobReceivedAt(time.Now().Add(-5 * time.Second))
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				start := time.Now()
+				err := handle.Sleep(ctx)
+				require.Error(t, err)
+				require.Less(t, time.Since(start), 1*time.Second)
+			})
+		})
+	})
+
+	t.Run("without delay", func(t *testing.T) {
+		t.Run("doesn't sleep", func(t *testing.T) {
+			sleeper := &mockSleeper{err: errors.New("should not be called")}
+			handle := preprocessdelay.NewHandle(0, sleeper.Sleep)
+			handle.JobReceivedAt(time.Now().Add(-10 * time.Second))
+			err := handle.Sleep(context.Background())
+			require.NoError(t, err)
+		})
+		t.Run("with cancelled context", func(t *testing.T) {
+			sleeper := &mockSleeper{err: errors.New("should not be called")}
+			handle := preprocessdelay.NewHandle(0, sleeper.Sleep)
+			handle.JobReceivedAt(time.Now().Add(-10 * time.Second))
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			err := handle.Sleep(ctx)
+			require.NoError(t, err)
+		})
+	})
+}
+
+type mockSleeper struct {
+	calls []time.Duration
+	err   error
+}
+
+func (m *mockSleeper) Sleep(ctx context.Context, d time.Duration) error {
+	m.calls = append(m.calls, d)
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return m.err
+}

--- a/processor/manager.go
+++ b/processor/manager.go
@@ -56,8 +56,9 @@ func (proc *LifecycleManager) Start() error {
 	if proc.TransformerClients != nil {
 		proc.Handle.transformerClients = proc.TransformerClients
 	}
-
+	currentCtx, cancel := context.WithCancel(context.Background())
 	if err := proc.Handle.Setup(
+		currentCtx,
 		proc.BackendConfig,
 		proc.gatewayDB,
 		proc.routerDB,
@@ -75,12 +76,11 @@ func (proc *LifecycleManager) Start() error {
 		proc.trackedUsersReporter,
 		proc.pendingEventsRegistry,
 	); err != nil {
+		cancel()
 		return err
 	}
 
-	currentCtx, cancel := context.WithCancel(context.Background())
 	proc.currentCancel = cancel
-
 	var wg sync.WaitGroup
 	proc.waitGroup = &wg
 

--- a/processor/partition_worker_handle.go
+++ b/processor/partition_worker_handle.go
@@ -21,7 +21,7 @@ type workerHandle interface {
 	getJobsStage(ctx context.Context, partition string) jobsdb.JobsResult
 	markExecuting(ctx context.Context, partition string, jobs []*jobsdb.JobT) error
 	jobSplitter(ctx context.Context, jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []subJob
-	preprocessStage(partition string, subJobs subJob) (*preTransformationMessage, error)
+	preprocessStage(partition string, subJobs subJob, delay time.Duration) (*preTransformationMessage, error)
 	pretransformStage(partition string, preTrans *preTransformationMessage) (*transformationMessage, error)
 	userTransformStage(partition string, in *transformationMessage) *userTransformData
 	destinationTransformStage(partition string, in *userTransformData) *storeMessage
@@ -37,6 +37,7 @@ type workerHandleConfig struct {
 	subJobSize            int
 	pipelinesPerPartition int
 
-	readLoopSleep config.ValueLoader[time.Duration]
-	maxLoopSleep  config.ValueLoader[time.Duration]
+	readLoopSleep            config.ValueLoader[time.Duration]
+	maxLoopSleep             config.ValueLoader[time.Duration]
+	partitionProcessingDelay func(partition string) config.ValueLoader[time.Duration]
 }

--- a/processor/partition_worker_handle_adapter.go
+++ b/processor/partition_worker_handle_adapter.go
@@ -1,6 +1,9 @@
 package processor
 
 import (
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-server/services/rsources"
 )
@@ -23,6 +26,9 @@ func (h *workerHandleAdapter) config() workerHandleConfig {
 		readLoopSleep:         h.Handle.config.readLoopSleep,
 		maxLoopSleep:          h.Handle.config.maxLoopSleep,
 		pipelinesPerPartition: h.Handle.config.pipelinesPerPartition,
+		partitionProcessingDelay: func(partition string) config.ValueLoader[time.Duration] {
+			return h.conf.GetReloadableDurationVar(0, time.Second, "Processor.preprocessDelay."+partition)
+		},
 	}
 }
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -37,6 +37,7 @@ import (
 	"github.com/rudderlabs/rudder-server/processor/delayed"
 	"github.com/rudderlabs/rudder-server/processor/eventfilter"
 	"github.com/rudderlabs/rudder-server/processor/integrations"
+	"github.com/rudderlabs/rudder-server/processor/internal/preprocessdelay"
 	"github.com/rudderlabs/rudder-server/processor/isolation"
 	"github.com/rudderlabs/rudder-server/processor/transformer"
 	"github.com/rudderlabs/rudder-server/processor/types"
@@ -113,6 +114,7 @@ type Handle struct {
 	dedup                      deduptypes.Dedup
 	reporting                  reportingtypes.Reporting
 	reportingEnabled           bool
+	backgroundCtx              context.Context
 	backgroundWait             func() error
 	backgroundCancel           context.CancelFunc
 	statsFactory               stats.Stats
@@ -378,6 +380,7 @@ func (proc *Handle) newEventFilterStat(sourceID, workspaceID string, destination
 
 // Setup initializes the module
 func (proc *Handle) Setup(
+	ctx context.Context,
 	backendConfig backendconfig.BackendConfig,
 	gatewayDB, routerDB, batchRouterDB,
 	eventSchemaDB, archivalDB jobsdb.JobsDB,
@@ -568,9 +571,10 @@ func (proc *Handle) Setup(
 		}
 	}
 	proc.sourceObservers = []sourceObserver{delayed.NewEventStats(proc.statsFactory, proc.conf)}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	g, ctx := errgroup.WithContext(ctx)
 
+	proc.backgroundCtx = ctx
 	proc.backgroundWait = g.Wait
 	proc.backgroundCancel = cancel
 
@@ -1682,17 +1686,21 @@ type preTransformationMessage struct {
 	dedupKeys                     map[string]struct{}
 }
 
-func (proc *Handle) preprocessStage(partition string, subJobs subJob) (*preTransformationMessage, error) {
+func (proc *Handle) preprocessStage(partition string, subJobs subJob, delay time.Duration) (*preTransformationMessage, error) {
 	start := time.Now()
 	spanTags := stats.Tags{"partition": partition}
 	ctx, processJobsSpan := proc.tracer.Trace(subJobs.ctx, "preprocessStage", tracing.WithTraceTags(spanTags))
 	defer processJobsSpan.End()
 
+	var preprocessdelaySleeper preprocessdelay.Sleeper
 	if proc.limiter.preprocess != nil {
-		defer proc.limiter.preprocess.BeginWithPriority(partition, proc.getLimiterPriority(partition))()
+		limiterExec := proc.limiter.preprocess.BeginWithSleepAndPriority(partition, proc.getLimiterPriority(partition))
+		preprocessdelaySleeper = limiterExec.Sleep
+		defer limiterExec.End()
 		defer proc.stats.statPreprocessStageCount(partition).Count(len(subJobs.subJobs))
 	}
 
+	delayHandler := preprocessdelay.NewHandle(delay, preprocessdelaySleeper)
 	jobList := subJobs.subJobs
 	proc.stats.statNumRequests(partition).Count(len(jobList))
 
@@ -1863,6 +1871,12 @@ func (proc *Handle) preprocessStage(partition string, subJobs subJob) (*preTrans
 			})
 			dedupBatchKeys = append(dedupBatchKeys, dedupBatchKey)
 		}
+		delayHandler.JobReceivedAt(receivedAt)
+	}
+
+	if err := delayHandler.Sleep(proc.backgroundCtx); err != nil {
+		proc.logger.Infon("preprocess delay sleep interrupted", logger.NewStringField("partition", partition), obskit.Error(err))
+		return nil, types.ErrProcessorStopping
 	}
 
 	var allowedBatchKeys map[dedup.BatchKey]bool
@@ -3788,6 +3802,7 @@ func (proc *Handle) handlePendingGatewayJobs(partition string) bool {
 			hasMore:       false,
 			rsourcesStats: rsourcesStats,
 		},
+		proc.conf.GetReloadableDurationVar(0, time.Second, "Processor.preprocessDelay."+partition).Load(),
 	)
 	if err != nil {
 		panic(err)

--- a/processor/processor_processing_delay_test.go
+++ b/processor/processor_processing_delay_test.go
@@ -1,0 +1,336 @@
+package processor_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samber/lo/mutable"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
+	transformertest "github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/transformer"
+	"github.com/rudderlabs/rudder-server/processor/isolation"
+	"github.com/rudderlabs/rudder-server/runner"
+	"github.com/rudderlabs/rudder-server/testhelper/health"
+	"github.com/rudderlabs/rudder-server/testhelper/workspaceConfig"
+	"github.com/rudderlabs/rudder-server/utils/types/deployment"
+)
+
+func TestProcessorProcessingDelay(t *testing.T) {
+	ProcProcessingDelayScenario(t, NewProcProcessingDelayScenarioSpec())
+}
+
+// ProcProcessingDelayScenarioSpec is a specification for a processor processing delay scenario.
+func NewProcProcessingDelayScenarioSpec() *ProcProcessingDelayScenarioSpec {
+	var s ProcProcessingDelayScenarioSpec
+	const batchSize = 10
+	s.batch1 = make([]*procProcessingDelayJobSpec, batchSize)
+	s.batch2 = make([]*procProcessingDelayJobSpec, batchSize)
+	s.received = map[int]struct{}{}
+
+	var idx int
+	workspaceID := "workspace-0"
+	for range batchSize {
+		jobID1 := idx + 1
+		js1 := procProcessingDelayJobSpec{
+			id:          jobID1,
+			workspaceID: workspaceID,
+			userID:      strconv.Itoa(jobID1),
+		}
+		s.batch1[idx] = &js1
+
+		jobID2 := jobID1 + 10000
+		js2 := procProcessingDelayJobSpec{
+			id:          jobID2,
+			workspaceID: workspaceID,
+			userID:      strconv.Itoa(jobID2),
+		}
+		s.batch2[idx] = &js2
+		idx++
+	}
+	return &s
+}
+
+// ProcProcessingDelayScenario runs a scenario with the given spec which:
+// 1. Sends batch1 events to gateway
+// 2. Waits for the events to be processed by processor
+// 3. Verifies that the correct number of events have been processed with a delay of 10s
+// 4. Sends batch2 events to gateway
+// 5. Waits for 3s and stops the server
+// 6. Verifies that the events in batch2 are left at executing stage due to shutdown while sleeping
+// 7. Starts the server again
+// 8. Waits for the events to be processed by processor
+func ProcProcessingDelayScenario(t testing.TB, spec *ProcProcessingDelayScenarioSpec) {
+	const processingDelay = 10 * time.Second
+
+	var m procProcessingDelayMethods
+
+	config.Reset()
+	defer jsonrs.Reset()
+	defer logger.Reset()
+	defer config.Reset()
+	config.Set("LOG_LEVEL", "WARN")
+	logger.Reset()
+	jsonrs.Reset()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var (
+		postgresContainer    *postgres.Resource
+		transformerContainer *transformertest.Resource
+		gatewayPort          string
+	)
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	containersGroup, _ := errgroup.WithContext(ctx)
+	containersGroup.Go(func() (err error) {
+		postgresContainer, err = postgres.Setup(pool, t, postgres.WithOptions("max_connections=1000"), postgres.WithTag("17-alpine"))
+		return err
+	})
+	containersGroup.Go(func() (err error) {
+		transformerContainer, err = transformertest.Setup(pool, t)
+		return err
+	})
+	require.NoError(t, containersGroup.Wait())
+
+	destinationID := "destination-0"
+
+	templateCtx := map[string]any{
+		"webhookUrl": "http://localhost:1234", // not important
+	}
+	configJsonPath := workspaceConfig.CreateTempFile(t, "testdata/procProcessingDelayTestTemplate.json.tpl", templateCtx)
+	mockCBE := m.newMockConfigBackend(t, configJsonPath)
+	config.Set("CONFIG_BACKEND_URL", mockCBE.URL)
+
+	config.Set("forceStaticModeProvider", true)
+	config.Set("DEPLOYMENT_TYPE", string(deployment.MultiTenantType))
+	config.Set("WORKSPACE_NAMESPACE", "proc_processing_delay_test")
+	config.Set("HOSTED_SERVICE_SECRET", "proc_processing_delay_secret")
+	config.Set("recovery.storagePath", path.Join(t.TempDir(), "/recovery_data.json"))
+
+	config.Set("DB.host", postgresContainer.Host)
+	config.Set("DB.port", postgresContainer.Port)
+	config.Set("DB.user", postgresContainer.User)
+	config.Set("DB.name", postgresContainer.Database)
+	config.Set("DB.password", postgresContainer.Password)
+	config.Set("DEST_TRANSFORM_URL", transformerContainer.TransformerURL)
+
+	config.Set("Warehouse.mode", "off")
+	config.Set("DestinationDebugger.disableEventDeliveryStatusUploads", true)
+	config.Set("SourceDebugger.disableEventUploads", true)
+	config.Set("TransformationDebugger.disableTransformationStatusUploads", true)
+	config.Set("AdaptivePayloadLimiter.enabled", false)
+	config.Set("JobsDB.backup.enabled", false)
+	config.Set("JobsDB.migrateDSLoopSleepDuration", "60m")
+	config.Set("JobsDB.payloadColumnType", "text")
+	config.Set("Router.toAbortDestinationIDs", []string{destinationID})
+	config.Set("archival.Enabled", false)
+	config.Set("enableStats", false)
+
+	config.Set("Processor.pipelinesPerPartition", 1)
+	config.Set("Processor.maxLoopSleep", 500*time.Millisecond)
+	config.Set("Processor.pingerSleep", 100*time.Millisecond)
+	config.Set("Processor.readLoopSleep", 100*time.Millisecond)
+	config.Set("Processor.maxLoopProcessEvents", 10000)
+	config.Set("Processor.isolationMode", string(isolation.ModeSource))
+	config.Set("Processor.preprocessDelay.source-0", processingDelay)
+
+	config.Set("JobsDB.enableWriterQueue", false)
+
+	// find free port for gateway http server to listen on
+	httpPortInt, err := kithelper.GetFreePort()
+	require.NoError(t, err)
+	gatewayPort = strconv.Itoa(httpPortInt)
+
+	config.Set("Gateway.webPort", gatewayPort)
+	config.Set("RUDDER_TMPDIR", os.TempDir())
+
+	startServer := func() (stop func(), stopped <-chan struct{}) {
+		ctx, cancel := context.WithCancel(ctx)
+		svcDone := make(chan struct{})
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("rudder-server panicked: %v", r)
+					close(svcDone)
+				}
+			}()
+			r := runner.New(runner.ReleaseInfo{})
+			c := r.Run(ctx, []string{"proc-isolation-test-rudder-server"})
+			if c != 0 {
+				t.Errorf("rudder-server exited with a non-0 exit code: %d", c)
+			}
+			close(svcDone)
+		}()
+
+		health.WaitUntilReady(ctx, t,
+			fmt.Sprintf("http://localhost:%s/health", gatewayPort),
+			200*time.Second,
+			100*time.Millisecond,
+			t.Name(),
+		)
+		return cancel, svcDone
+	}
+	stopServer, serverStopped := startServer()
+
+	sendBatches := func(batches [][]byte) {
+		g := &errgroup.Group{}
+		g.SetLimit(10)
+		client := &http.Client{}
+		url := fmt.Sprintf("http://localhost:%s/v1/batch", gatewayPort)
+		for _, payload := range batches {
+			g.Go(func() error {
+				writeKey := "source-0"
+				req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+				require.NoError(t, err, "should be able to create a new request")
+				req.SetBasicAuth(writeKey, "password")
+				resp, err := client.Do(req)
+				require.NoError(t, err, "should be able to send the request to gateway")
+				require.Equal(t, http.StatusOK, resp.StatusCode, "should be able to send the request to gateway successfully", payload)
+				func() { kithttputil.CloseResponse(resp) }()
+				return nil
+			})
+		}
+		require.NoError(t, g.Wait())
+	}
+
+	batches := m.splitInBatches(spec.batch1, len(spec.batch1))
+	t.Logf("sending %d events in %d batches", len(spec.batch1), len(batches))
+	sendBatches(batches)
+
+	t.Log("waiting for all events to be processed")
+	start := time.Now()
+	require.Eventually(t, func() bool {
+		var processedJobCount int
+		require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('gw',5) WHERE job_state = 'succeeded'").Scan(&processedJobCount))
+		return processedJobCount == len(spec.batch1)
+	}, 600*time.Second, 1*time.Second, "all batches should be successfully processed")
+
+	delay := time.Since(start)
+	require.Greater(t, delay, 10*time.Second, "processing should take at least 10s due to the configured delay")
+
+	// send the second batch of events
+	batches = m.splitInBatches(spec.batch2, len(spec.batch2))
+	t.Logf("sending %d events in %d batches", len(spec.batch2), len(batches))
+	sendBatches(batches)
+
+	// wait for 3 seconds and then stop the server
+	waitTime := 3 * time.Second
+	time.Sleep(waitTime)
+	t.Logf("stopping server after waiting for %v", waitTime)
+	stopServer()
+	start = time.Now()
+	<-serverStopped
+	shutdownDuration := time.Since(start)
+	require.Less(t, shutdownDuration, processingDelay-2*waitTime, "server should shut down before the processing delay times out")
+
+	var executingJobsCount int
+	require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('gw',5) WHERE job_state = 'executing'").Scan(&executingJobsCount))
+	require.Equal(t, len(spec.batch2), executingJobsCount, "batch2 should be left at executing stage due to shutdown while sleeping")
+
+	// start the server again to process the remaining events
+	stopServer, serverStopped = startServer()
+	t.Log("waiting for all events to be processed after restart")
+	require.Eventually(t, func() bool {
+		var processedJobCount int
+		require.NoError(t, postgresContainer.DB.QueryRow("SELECT count(*) FROM unionjobsdbmetadata('gw',5) WHERE job_state = 'succeeded'").Scan(&processedJobCount))
+		return processedJobCount == len(spec.batch1)+len(spec.batch2)
+	}, 600*time.Second, 1*time.Second, "all batches should be successfully processed")
+
+	stopServer()
+	<-serverStopped
+}
+
+type ProcProcessingDelayScenarioSpec struct {
+	batch1   []*procProcessingDelayJobSpec
+	batch2   []*procProcessingDelayJobSpec
+	received map[int]struct{}
+}
+
+type procProcessingDelayJobSpec struct {
+	id          int
+	workspaceID string
+	userID      string
+}
+
+func (jobSpec *procProcessingDelayJobSpec) payload() string {
+	template := `{
+				"userId": %q,
+				"anonymousId": %q,
+				"testJobId": %d,
+				"workspaceID": %q,
+				"type": "identify",
+				"context":
+				{
+					"traits":
+					{
+						"trait1": "new-val"
+					},
+					"ip": "14.5.67.21",
+					"library":
+					{
+						"name": "http"
+					}
+				},
+				"timestamp": "2020-02-02T00:23:09.544Z"
+			}`
+	return fmt.Sprintf(template, jobSpec.userID, jobSpec.userID, jobSpec.id, jobSpec.workspaceID)
+}
+
+// Using a struct to keep processor_test package clean and
+// avoid function collisions with other tests
+type procProcessingDelayMethods struct{}
+
+func (procProcessingDelayMethods) newMockConfigBackend(t testing.TB, path string) *httptest.Server {
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "should be able to read the config file")
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "features") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if strings.Contains(r.URL.Path, "settings") {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(data)
+		require.NoError(t, err, "should be able to write the response code to the response")
+	}))
+}
+
+// splitInBatches creates batches of jobs from the same workspace, shuffled so that
+// batches for the same workspace are not consecutive.
+func (procProcessingDelayMethods) splitInBatches(jobs []*procProcessingDelayJobSpec, batchSize int) [][]byte {
+	payloads := map[string][]string{}
+	for _, job := range jobs {
+		payloads[job.workspaceID] = append(payloads[job.workspaceID], job.payload())
+	}
+
+	var batches [][]byte
+	for _, payload := range payloads {
+		chunks := lo.Chunk(payload, batchSize)
+		batches = append(batches, lo.Map(chunks, func(chunk []string, _ int) []byte {
+			return []byte(fmt.Sprintf(`{"batch":[%s]}`, strings.Join(chunk, ",")))
+		})...)
+	}
+	mutable.Shuffle(batches)
+	return batches
+}

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -1014,6 +1014,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 						},
 					},
 				},
+				0,
 			)
 			Expect(err).To(BeNil())
 			_, _ = processor.pretransformStage("", preTransMessage)
@@ -1097,6 +1098,7 @@ var _ = Describe("Tracking Plan Validation", Ordered, func() {
 						},
 					},
 				},
+				0,
 			)
 			Expect(err).To(BeNil())
 			_, _ = processor.pretransformStage("", preTransMessage)
@@ -1305,6 +1307,7 @@ var _ = Describe("Processor with event schemas v2", Ordered, func() {
 				subJob{
 					subJobs: unprocessedJobsList,
 				},
+				0,
 			)
 			Expect(err).To(BeNil())
 			_, _ = processor.pretransformStage("", preTransMessage)
@@ -1492,6 +1495,7 @@ var _ = Describe("Processor with ArchivalV2 enabled", Ordered, func() {
 				subJob{
 					subJobs: unprocessedJobsList,
 				},
+				0,
 			)
 			Expect(err).To(BeNil())
 			_, _ = processor.pretransformStage("", preTransMessage)
@@ -1644,6 +1648,7 @@ var _ = Describe("Processor with ArchivalV2 enabled", Ordered, func() {
 				subJob{
 					subJobs: unprocessedJobsList,
 				},
+				0,
 			)
 			Expect(err).To(BeNil())
 			_, _ = processor.pretransformStage("", preTransMessage)
@@ -2004,6 +2009,7 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 
 			err := processor.Setup(
+				context.Background(),
 				c.mockBackendConfig,
 				c.mockGatewayJobsDB,
 				c.mockRouterJobsDB,
@@ -2034,6 +2040,7 @@ var _ = Describe("Processor", Ordered, func() {
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 
 			err := processor.Setup(
+				context.Background(),
 				c.mockBackendConfig,
 				c.mockGatewayJobsDB,
 				c.mockRouterJobsDB,
@@ -2069,6 +2076,7 @@ var _ = Describe("Processor", Ordered, func() {
 			processor := prepareHandle(NewHandle(config.Default, mockTransformerClients))
 
 			err := processor.Setup(
+				context.Background(),
 				c.mockBackendConfig,
 				c.mockGatewayJobsDB,
 				c.mockRouterJobsDB,
@@ -3074,6 +3082,7 @@ var _ = Describe("Processor", Ordered, func() {
 			// crash recover returns empty list
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 			err := processor.Setup(
+				context.Background(),
 				c.mockBackendConfig,
 				c.mockGatewayJobsDB,
 				c.mockRouterJobsDB,
@@ -3129,6 +3138,7 @@ var _ = Describe("Processor", Ordered, func() {
 			// crash recover returns empty list
 			c.mockGatewayJobsDB.EXPECT().DeleteExecuting().Times(1)
 			err := processor.Setup(
+				context.Background(),
 				c.mockBackendConfig,
 				c.mockGatewayJobsDB,
 				c.mockRouterJobsDB,
@@ -5146,6 +5156,7 @@ func processorSetupAndAssertJobHandling(processor *Handle, c *testContext) {
 func Setup(processor *Handle, c *testContext, enableDedup, enableReporting bool, t ...testing.TB) {
 	setDisableDedupFeature(processor, enableDedup)
 	err := processor.Setup(
+		context.Background(),
 		c.mockBackendConfig,
 		c.mockGatewayJobsDB,
 		c.mockRouterJobsDB,

--- a/processor/testdata/procProcessingDelayTestTemplate.json.tpl
+++ b/processor/testdata/procProcessingDelayTestTemplate.json.tpl
@@ -1,0 +1,103 @@
+{
+    "workspace-0" : {
+        "enableMetrics": false,
+        "workspaceId": "workspace-0",
+        "sources": [
+            {
+                "config": {},
+                "id": "source-0",
+                "name": "Dev Integration Test 1",
+                "writeKey": "source-0",
+                "enabled": true,
+                "sourceDefinitionId": "xxxyyyzzpWDzNxgGUYzq9sZdZZB",
+                "createdBy": "xxxyyyzzueyoBz4jb7bRdOzDxai",
+                "workspaceId": "workspace-0",
+                "deleted": false,
+                "createdAt": "2021-08-27T06:33:00.305Z",
+                "updatedAt": "2021-08-27T06:33:00.305Z",
+                "destinations": [
+                    {
+                        "config": {
+                            "webhookUrl": "{{$.webhookUrl}}",
+                            "webhookMethod": "POST"
+                        },
+                        "secretConfig": {},
+                        "id": "destination-0",
+                        "name": "Des WebHook Integration Test 1",
+                        "enabled": true,
+                        "workspaceId": "workspace-0",
+                        "deleted": false,
+                        "createdAt": "2021-08-27T06:49:38.546Z",
+                        "updatedAt": "2021-08-27T06:49:38.546Z",
+                        "transformations": [
+                            {
+                                "versionId": "23hZ5VLGt0Yl7Hxk9ysBGi5baud",
+                                "config": {},
+                                "id": "23VJjP3bbHMzUhWjI7bvNL5S9xx"
+                            }
+                        ],
+                        "destinationDefinition": {
+                            "config": {
+                                "destConfig": {
+                                    "defaultConfig": [
+                                        "webhookUrl",
+                                        "webhookMethod",
+                                        "headers"
+                                    ]
+                                },
+                                "secretKeys": [
+                                    "headers.to"
+                                ],
+                                "excludeKeys": [],
+                                "includeKeys": [],
+                                "transformAt": "processor",
+                                "transformAtV1": "processor",
+                                "supportedSourceTypes": [
+                                    "android",
+                                    "ios",
+                                    "web",
+                                    "unity",
+                                    "amp",
+                                    "cloud",
+                                    "warehouse",
+                                    "reactnative",
+                                    "flutter"
+                                ],
+                                "supportedMessageTypes": [
+                                    "alias",
+                                    "group",
+                                    "identify",
+                                    "page",
+                                    "screen",
+                                    "track"
+                                ],
+                                "saveDestinationResponse": false
+                            },
+                            "configSchema": null,
+                            "responseRules": null,
+                            "id": "xxxyyyzzSOU9pLRavMf0GuVnWV3",
+                            "name": "WEBHOOK",
+                            "displayName": "Webhook",
+                            "category": null,
+                            "createdAt": "2020-03-16T19:25:28.141Z",
+                            "updatedAt": "2021-08-26T07:06:01.445Z"
+                        },
+                        "isConnectionEnabled": true,
+                        "isProcessorEnabled": true
+                    }
+                ],
+                "sourceDefinition": {
+                    "id": "xxxyyyzzpWDzNxgGUYzq9sZdZZB",
+                    "name": "HTTP",
+                    "options": null,
+                    "displayName": "HTTP",
+                    "category": "",
+                    "createdAt": "2020-06-12T06:35:35.962Z",
+                    "updatedAt": "2020-06-12T06:35:35.962Z"
+                },
+                "dgSourceTrackingPlanConfig": null
+            }
+        ],
+        "libraries": []
+    }
+}

--- a/processor/types/types.go
+++ b/processor/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -15,6 +16,8 @@ import (
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 )
+
+var ErrProcessorStopping = errors.New("processor is stopping")
 
 // SingularEventT single event structure
 type SingularEventT map[string]interface{}


### PR DESCRIPTION
# Description

Introducing support for configurable delays in the processor’s pipeline for specific partitions (typically sourceIDs). Delay for a specific partition can be configured using the `Processor.preprocessDelay.<partition>` configuration property.

**Example:**
```yaml
Processor.preprocessDelay.sourceId-1: 5m  
```
This ensures that events from `sourceId-1` are processed at least **5 minutes** after their `receivedAt` timestamp.

The processor will still pick up events as usual, but during the `preprocess` stage (after `receivedAt` is read), it will pause processing based on the most recent event in the batch. 
If the processor is stopped while waiting (e.g. shutdown or node migration), the sleep will be interrupted and events will not be processed prematurely. When the processor restarts, processing will resume only after the configured delay has elapsed.

## Linear Ticket

resolves PIPE-2392

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
