### PR TITLE
chore: add explicit permissions in workflows

### DIFF
--- a/.github/workflows/dispatch-deploy-event-dev.yaml
+++ b/.github/workflows/dispatch-deploy-event-dev.yaml
@@ -2,6 +2,9 @@ name: Dispatch deploy event
 
 on: workflow_dispatch
 
+permissions:
+  contents: read # Required for basic repository access
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -25,6 +25,10 @@ jobs:
   branches:
       name: Cleanup old branches
       runs-on: ubuntu-latest
+      
+      permissions:
+        contents: write # Required for delete-old-branches-action
+        
       steps:
         - name: Checkout repository
           uses: actions/checkout@v4

--- a/.github/workflows/pr-description-enforcer.yaml
+++ b/.github/workflows/pr-description-enforcer.yaml
@@ -2,6 +2,9 @@ name: 'Pull Request Description'
 on:
   pull_request:
 
+permissions:
+  pull-requests: read
+
 jobs:
   enforce:
     runs-on: ubuntu-latest

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -3,6 +3,10 @@ on:
     branches:
       - "prerelease/*"
 name: prerelease
+
+permissions:
+  contents: write # Required for creating releases
+  pull-requests: write # Required for release-please to create/update PRs
 jobs:
   prerelease:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -3,6 +3,10 @@ on:
     branches:
       - "release/*"
 name: release-please
+
+permissions:
+  contents: write # Required for creating releases
+  pull-requests: write # Required for release-please to create/update PRs
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -9,6 +9,9 @@ on:
       - ready_for_review
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/sync-release.yaml
+++ b/.github/workflows/sync-release.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - "release/*"
 
+permissions:
+  contents: write # Required for creating branches and accessing repository
+  pull-requests: write # Required for creating PRs
+
 jobs:
   sync:
     env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
+
+permissions:
+  contents: read # Required for actions/checkout
+
 jobs:
   integration:
     name: Integration

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,6 +10,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
+
+permissions:
+  contents: read # Required for actions/checkout
 jobs:
   generate:
     name: Correct generated files


### PR DESCRIPTION
# Description

This PR adds explicit workflow permissions.  
By default, if a workflow does not define its own permissions, it inherits the repository’s permissions.

## Linear Ticket

[PIPE-2424](https://linear.app/rudderstack/issue/PIPE-2424/manage-git-token-permissions-in-git-workflows)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
