### PR TITLE
fix: destination namespaces api to contain tablename filter

### DIFF
--- a/warehouse/internal/repo/schema.go
+++ b/warehouse/internal/repo/schema.go
@@ -597,14 +597,14 @@ func (sh *WHSchema) GetDestinationNamespaces(ctx context.Context, destinationID 
 			namespace
 		FROM ` + whSchemaTableName + `
 		WHERE destination_id = $1
+		AND table_name = ''
 		ORDER BY source_id, updated_at DESC;
 	`
-
 	rows, err := sh.db.QueryContext(ctx, query, destinationID)
 	if err != nil {
 		return nil, fmt.Errorf("querying destination namespaces: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var mappings []model.NamespaceMapping
 	for rows.Next() {
@@ -615,10 +615,8 @@ func (sh *WHSchema) GetDestinationNamespaces(ctx context.Context, destinationID 
 		}
 		mappings = append(mappings, mapping)
 	}
-
 	if err = rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating over namespace mappings: %w", err)
 	}
-
 	return mappings, nil
 }


### PR DESCRIPTION
# Description

- Post adding table-level schemas, we would need to add a filter for `table_name` as well for the Destination Namespaces query, as there will be too many entries present. 
- More details in [notion doc](https://www.notion.so/rudderstacks/Warehouse-indexing-263f2b415dd08049a3f4f781f0bf087d?source=copy_link#279f2b415dd080b3bdf7fa5086082bd1).

## Linear Ticket

- Resolves WAR-1175

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
