### PR TITLE
chore: remove monitor database

### DIFF
--- a/services/notifier/notifier.go
+++ b/services/notifier/notifier.go
@@ -18,10 +18,10 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/sqlutil"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/collectors"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
 	migrator "github.com/rudderlabs/rudder-server/services/sql-migrator"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	sqlmw "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
@@ -583,16 +583,6 @@ func (n *Notifier) UpdateClaim(
 		n.stats.claimUpdateFailed.Increment()
 		n.logger.Errorn("update claimed: on claimed success", obskit.Error(err))
 	}
-}
-
-func (n *Notifier) Monitor(ctx context.Context) {
-	sqlutil.MonitorDatabase(
-		ctx,
-		n.conf,
-		n.statsFactory,
-		n.db.DB,
-		"notifier",
-	)
 }
 
 // RunMaintenance re-triggers zombie jobs which were left behind by dead workers in executing state

--- a/warehouse/app.go
+++ b/warehouse/app.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/sqlutil"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/collectors"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
@@ -360,16 +359,6 @@ func (a *App) Run(ctx context.Context) error {
 		a.bcManager.Start(gCtx)
 		return nil
 	})
-	g.Go(func() error {
-		sqlutil.MonitorDatabase(
-			gCtx,
-			a.conf,
-			a.statsFactory,
-			a.db.DB,
-			"warehouse",
-		)
-		return nil
-	})
 
 	if mode.IsDegraded(a.config.runningMode) {
 		a.logger.Infon("Running warehouse service in degraded mode...")
@@ -463,10 +452,6 @@ func (a *App) Run(ctx context.Context) error {
 
 	g.Go(func() error {
 		return a.api.Start(gCtx)
-	})
-	g.Go(func() error {
-		a.notifier.Monitor(gCtx)
-		return nil
 	})
 	g.Go(func() error {
 		<-gCtx.Done()


### PR DESCRIPTION
# Description

- Remove monitor database as we already are using [RegisterCollector](https://github.com/rudderlabs/rudder-go-kit/pull/648) for db stats.

## Linear Ticket

- Resolves WAR-1183

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
