### PR TITLE
fix: keydb consistent hashing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/rudderlabs/bing-ads-go-sdk v0.2.3
 	github.com/rudderlabs/compose-test v0.1.3
-	github.com/rudderlabs/keydb v1.1.0
+	github.com/rudderlabs/keydb v1.2.0
 	github.com/rudderlabs/rudder-go-kit v0.62.0
 	github.com/rudderlabs/rudder-observability-kit v0.0.5
 	github.com/rudderlabs/rudder-schemas v0.7.0
@@ -183,6 +183,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bitfield/gotestdox v0.2.2 // indirect
 	github.com/bits-and-blooms/bitset v1.14.3 // indirect
+	github.com/buraksezer/consistent v0.10.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 // indirect

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,8 @@ github.com/bufbuild/httplb v0.4.1 h1:f8dMp7tx2aJfMX2UcOId1A58QDiBag7Dv6BA1OtV/YA
 github.com/bufbuild/httplb v0.4.1/go.mod h1:9XDjl/3UvlkOQUKthLlKn92C1/1SuZ3UCiekxZbenck=
 github.com/buger/goterm v1.0.4 h1:Z9YvGmOih81P0FbVtEYTFF6YsSgxSUKEhf/f9bTMXbY=
 github.com/buger/goterm v1.0.4/go.mod h1:HiFWV3xnkolgrBV3mY8m0X0Pumt4zg4QhbdOzQtB8tE=
+github.com/buraksezer/consistent v0.10.0 h1:hqBgz1PvNLC5rkWcEBVAL9dFMBWz6I0VgUCW25rrZlU=
+github.com/buraksezer/consistent v0.10.0/go.mod h1:6BrVajWq7wbKZlTOUPs/XVfR8c0maujuPowduSpZqmw=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
@@ -1195,8 +1197,8 @@ github.com/rudderlabs/compose-test v0.1.3 h1:uyep6jDCIF737sfv4zIaMsKRQKX95IDz5Xb
 github.com/rudderlabs/compose-test v0.1.3/go.mod h1:tuvS1eQdSfwOYv1qwyVAcpdJxPLQXJgy5xGDd/9XmMg=
 github.com/rudderlabs/goqu/v10 v10.3.1 h1:rnfX+b4EwBWQ2UQfIGeEW299JBBkK5biEbnf7Kq4/Gg=
 github.com/rudderlabs/goqu/v10 v10.3.1/go.mod h1:LH2vI5gGHBxEQuESqFyk5ZA2anGINc8o25hbidDWOYw=
-github.com/rudderlabs/keydb v1.1.0 h1:ycuQOZVxqzKrkXq4CoRhPBGlYks2WDNg7LaQqlS7FHM=
-github.com/rudderlabs/keydb v1.1.0/go.mod h1:BXBXBGS06wr1twtd+mTyQJCxlR4kMq3CzkzUShkgkuU=
+github.com/rudderlabs/keydb v1.2.0 h1:LMwWezUh3C+xheNirHNMhUlcb09ZH0Alo6bDDwwMaNQ=
+github.com/rudderlabs/keydb v1.2.0/go.mod h1:ZYouneft71uF85OTUGS5cI9DoVdsfKDItgUTGNli9Mk=
 github.com/rudderlabs/parquet-go v0.0.3 h1:/zgRj929pGKHsthc0kw8stVEcFu1JUcpxDRlhxjSLic=
 github.com/rudderlabs/parquet-go v0.0.3/go.mod h1:WmwBOdvwpXl2aZGRk3NxxgzC/DaWGfax3jrCRhKhtSo=
 github.com/rudderlabs/rudder-go-kit v0.62.0 h1:7wieb60KcKTmsMW0Ag7UwYeAEaG4pzPP6/21VhY5/es=

--- a/services/dedup/dedup_test.go
+++ b/services/dedup/dedup_test.go
@@ -169,7 +169,7 @@ func Test_KeyDB(t *testing.T) {
 		found, err := d.Allowed(kvs...)
 		require.NoError(t, err)
 		for _, kv := range kvs {
-			require.True(t, found[kv])
+			require.True(t, found[kv], kv)
 		}
 		err = d.Commit([]string{"e", "f", "g"})
 		require.NoError(t, err)
@@ -570,6 +570,7 @@ func startKeydb(t testing.TB, conf *config.Config) {
 	address := "localhost:" + strconv.Itoa(freePort)
 	conf.Set("KeyDB.Dedup.Addresses", address)
 	conf.Set("KeyDB.Dedup.RetryCount", 3)
+	conf.Set("BadgerDB.Dedup.Path", t.TempDir())
 
 	nodeConfig := keydb.Config{
 		NodeID:           0,

--- a/services/dedup/keydb/keydb.go
+++ b/services/dedup/keydb/keydb.go
@@ -33,7 +33,7 @@ func NewKeyDB(conf *config.Config, stat stats.Stats, log logger.Logger) (types.D
 
 	clientConfig := client.Config{
 		Addresses:       strings.Split(nodeAddresses, ","),
-		TotalHashRanges: uint32(conf.GetInt("KeyDB.Dedup.TotalHashRanges", 128)),
+		TotalHashRanges: uint32(conf.GetInt("KeyDB.Dedup.TotalHashRanges", int(client.DefaultTotalHashRanges))),
 		RetryPolicy: client.RetryPolicy{
 			Disabled:        conf.GetBool("KeyDB.Dedup.RetryPolicy.Disabled", false),
 			InitialInterval: conf.GetDuration("KeyDB.Dedup.RetryPolicy.InitialInterval", 100, time.Millisecond),


### PR DESCRIPTION
# Description

Updating keydb to use new client with consistent hashing.

## Linear Ticket

Fixes [PIPE-2437](https://linear.app/rudderstack/issue/PIPE-2437/keydb-fix-flaky-test)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
