### PR TITLE
fix: save webhook failures

### DIFF
--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -142,6 +142,7 @@ func TestWebhookRequestHandlerWithTransformerBatchGeneralError(t *testing.T) {
 	})
 
 	mockGW.EXPECT().TrackRequestMetrics(gomock.Any()).Times(1)
+	mockGW.EXPECT().SaveWebhookFailures(gomock.Any()).Return(nil).Times(1)
 	arctx := &gwtypes.AuthRequestContext{
 		SourceDefName: sourceDefName,
 		WriteKey:      sampleWriteKey,
@@ -185,7 +186,7 @@ func TestWebhookRequestHandlerWithTransformerBatchPayloadLengthMismatchError(t *
 	})
 
 	mockGW.EXPECT().TrackRequestMetrics(gomock.Any()).Times(1)
-
+	mockGW.EXPECT().SaveWebhookFailures(gomock.Any()).Return(nil).Times(1)
 	webhookHandler.Register(sourceDefName)
 	req := httptest.NewRequest(http.MethodPost, "/v1/webhook?writeKey="+sampleWriteKey, bytes.NewBufferString(sampleJson))
 	w := httptest.NewRecorder()
@@ -226,7 +227,7 @@ func TestWebhookRequestHandlerWithTransformerRequestError(t *testing.T) {
 	})
 
 	mockGW.EXPECT().TrackRequestMetrics(gomock.Any()).Times(1)
-
+	mockGW.EXPECT().SaveWebhookFailures(gomock.Any()).Return(nil).Times(1)
 	webhookHandler.Register(sourceDefName)
 	req := httptest.NewRequest(http.MethodPost, "/v1/webhook?writeKey="+sampleWriteKey, bytes.NewBufferString(sampleJson))
 	w := httptest.NewRecorder()


### PR DESCRIPTION
# Description

## How It Works

1. When webhook requests are processed, they go through a batch transformation process
2. If any failures occur during transformation (either batch-level or individual request level), the system creates `FailedWebhookPayload` objects
3. These failed payloads are then passed to `SaveWebhookFailures` method
4. This method can be implemented by different services (like ingestion-svc) to handle these failures appropriately
5. In the context of ingestion-svc, these failures are published to proc errors for further processing


## Linear Ticket

pipe-2448

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
