### PR TITLE
fix(warehouse): int to float datatype handling

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/discards.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/discards.go
@@ -8,6 +8,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/model"
 	"github.com/rudderlabs/rudder-server/warehouse/slave"
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
@@ -70,6 +71,7 @@ func discardsSchema() whutils.ModelTableSchema {
 // If the conversion fails, the value is discarded
 // If the value is a slice, it is marshalled to a string
 func getDiscardedRecordsFromEvent(
+	log logger.Logger,
 	event *event,
 	snowpipeSchema whutils.ModelTableSchema,
 	tableName string,
@@ -79,7 +81,7 @@ func getDiscardedRecordsFromEvent(
 	for columnName, actualType := range event.Message.Metadata.Columns {
 		if expectedType, exists := snowpipeSchema[columnName]; exists && actualType != expectedType {
 			currentValue := event.Message.Data[columnName]
-			convertedVal, err := slave.HandleSchemaChange(expectedType, actualType, currentValue)
+			convertedVal, err := slave.HandleSchemaChange(log, expectedType, actualType, currentValue)
 			if err != nil {
 				event.Message.Data[columnName] = nil // Discard value if conversion fails
 

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -358,7 +358,7 @@ func (m *Manager) sendEventsToSnowpipe(
 	formattedTS := m.Now().Format(misc.RFC3339Milli)
 	var discardInfos []discardInfo
 	for _, tableEvent := range info.events {
-		discardInfos = append(discardInfos, getDiscardedRecordsFromEvent(tableEvent, channelResponse.SnowpipeSchema, info.tableName, formattedTS)...)
+		discardInfos = append(discardInfos, getDiscardedRecordsFromEvent(m.logger, tableEvent, channelResponse.SnowpipeSchema, info.tableName, formattedTS)...)
 	}
 
 	/*

--- a/warehouse/slave/worker.go
+++ b/warehouse/slave/worker.go
@@ -636,8 +636,8 @@ func (w *worker) destinationFromSlaveConnectionMap(destinationId, sourceId strin
 	return conn, nil
 }
 
-// HandleSchemaChange checks if the existing column type is compatible with the new column type
-func HandleSchemaChange(existingDataType, currentDataType model.SchemaType, value any) (any, error) {
+// HandleSchemaChange checks if the existing data type (from warehouse schema) is compatible with the inferred data type (from event data)
+func HandleSchemaChange(existingDataType, inferredDataType model.SchemaType, value any) (any, error) {
 	var (
 		newColumnVal any
 		err          error
@@ -645,28 +645,38 @@ func HandleSchemaChange(existingDataType, currentDataType model.SchemaType, valu
 
 	if existingDataType == model.StringDataType || existingDataType == model.TextDataType {
 		// only stringify if the previous type is non-string/text/json
-		if currentDataType != model.StringDataType && currentDataType != model.TextDataType && currentDataType != model.JSONDataType {
+		if inferredDataType != model.StringDataType && inferredDataType != model.TextDataType && inferredDataType != model.JSONDataType {
 			newColumnVal = fmt.Sprintf("%v", value)
 		} else {
 			newColumnVal = value
 		}
-	} else if (currentDataType == model.IntDataType || currentDataType == model.BigIntDataType) && existingDataType == model.FloatDataType {
-		intVal, ok := value.(int)
-		if !ok {
-			err = fmt.Errorf("incompatible schema conversion from %v to %v", existingDataType, currentDataType)
-		} else {
-			newColumnVal = float64(intVal)
+	} else if (inferredDataType == model.IntDataType || inferredDataType == model.BigIntDataType) && existingDataType == model.FloatDataType {
+		// All warehouse destinations currently support int to float coercion.
+		// value should be float (go json unmarshals all numbers as float64), unless explicitly converted to int. Keeping logic agnostic in this function.
+		switch v := value.(type) {
+		case int:
+			newColumnVal = float64(v)
+		case int32:
+			newColumnVal = float64(v)
+		case int64:
+			newColumnVal = float64(v)
+		case float32:
+			newColumnVal = float64(v)
+		case float64:
+			newColumnVal = v
+		default:
+			err = fmt.Errorf("incompatible schema conversion from %v to %v", existingDataType, inferredDataType)
 		}
-	} else if currentDataType == model.FloatDataType && (existingDataType == model.IntDataType || existingDataType == model.BigIntDataType) {
+	} else if inferredDataType == model.FloatDataType && (existingDataType == model.IntDataType || existingDataType == model.BigIntDataType) {
 		floatVal, ok := value.(float64)
 		if !ok {
-			err = fmt.Errorf("incompatible schema conversion from %v to %v", existingDataType, currentDataType)
+			err = fmt.Errorf("incompatible schema conversion from %v to %v", existingDataType, inferredDataType)
 		} else {
 			newColumnVal = int(floatVal)
 		}
 	} else if existingDataType == model.JSONDataType {
 		var interfaceSliceSample []any
-		if currentDataType == model.IntDataType || currentDataType == model.FloatDataType || currentDataType == model.BooleanDataType {
+		if inferredDataType == model.IntDataType || inferredDataType == model.FloatDataType || inferredDataType == model.BooleanDataType {
 			newColumnVal = fmt.Sprintf("%v", value)
 		} else if reflect.TypeOf(value) == reflect.TypeOf(interfaceSliceSample) {
 			newColumnVal = value
@@ -674,7 +684,7 @@ func HandleSchemaChange(existingDataType, currentDataType model.SchemaType, valu
 			newColumnVal = strconv.Quote(fmt.Sprintf("%v", value))
 		}
 	} else {
-		err = fmt.Errorf("incompatible schema conversion from %v to %v", existingDataType, currentDataType)
+		err = fmt.Errorf("incompatible schema conversion from %v to %v", existingDataType, inferredDataType)
 	}
 
 	return newColumnVal, err

--- a/warehouse/slave/worker_test.go
+++ b/warehouse/slave/worker_test.go
@@ -1201,6 +1201,13 @@ func TestHandleSchemaChange(t *testing.T) {
 			expectedColumnVal: 1.0,
 		},
 		{
+			name:              "should send float values if existing datatype is float, new datatype is int",
+			existingDatatype:  "float",
+			currentDataType:   "int",
+			value:             1.0,
+			expectedColumnVal: 1.0,
+		},
+		{
 			name:              "should send string values if existing datatype is string, new datatype is boolean",
 			existingDatatype:  "string",
 			currentDataType:   "boolean",
@@ -1360,13 +1367,6 @@ func TestHandleSchemaChange(t *testing.T) {
 			currentDataType:  "boolean",
 			value:            false,
 			expectedError:    errors.New("incompatible schema conversion from float to boolean"),
-		},
-		{
-			name:             "existing datatype is float, new datatype is int",
-			existingDatatype: "float",
-			currentDataType:  "int",
-			value:            1.0,
-			expectedError:    errors.New("incompatible schema conversion from float to int"),
 		},
 		{
 			name:             "existing datatype is float, new datatype is string",

--- a/warehouse/slave/worker_test.go
+++ b/warehouse/slave/worker_test.go
@@ -1428,6 +1428,7 @@ func TestHandleSchemaChange(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			newColumnVal, convError := HandleSchemaChange(
+				logger.NOP,
 				tc.existingDatatype,
 				tc.currentDataType,
 				tc.value,

--- a/warehouse/slave/worker_test.go
+++ b/warehouse/slave/worker_test.go
@@ -1369,6 +1369,13 @@ func TestHandleSchemaChange(t *testing.T) {
 			expectedError:    errors.New("incompatible schema conversion from float to boolean"),
 		},
 		{
+			name:             "existing datatype is float, new datatype is int, value incompatible",
+			existingDatatype: "float",
+			currentDataType:  "int",
+			value:            false,
+			expectedError:    errors.New("incompatible schema conversion from float to int"),
+		},
+		{
 			name:             "existing datatype is float, new datatype is string",
 			existingDatatype: "float",
 			currentDataType:  "string",


### PR DESCRIPTION
# Description

Enhanced the warehouse schema change handling to properly support integer to float datatype coercion across all warehouse destinations.

For all warehouses, if inferred datatype was int, we used to convert value to int explicitly. [Code Ref](https://github.com/rudderlabs/rudder-server/blob/master/warehouse/slave/worker.go#L404)

In case, inferred Data type from event payload was int and existingDatatype in WH was float, old logic in handleSchema used to explicitly check int type, else it used to consider it as error scenario. This used to work for all warehouses, as we used to convert value to int explicitly. [Code Ref](https://github.com/rudderlabs/rudder-server/blob/master/warehouse/slave/worker.go#L404)
For Snowpipe streaming, such mismatch meant int values will go to rudder_discards.

As all WHs support auto coercion of int to float, this PR considers all relevant value types to auto cast to float.

## Linear Ticket

resolves WAR-1198

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
