### PR TITLE
fix: improve HTML error extractration and truncation limits

### DIFF
--- a/enterprise/reporting/error_reporting.go
+++ b/enterprise/reporting/error_reporting.go
@@ -427,10 +427,9 @@ func (edr *ErrorDetailReporter) migrate(c types.SyncerConfig) (*sql.DB, error) {
 
 func (edr *ErrorDetailReporter) extractErrorDetails(sampleResponse string, statTags map[string]string, destType string) types.ErrorDetails {
 	errMsg := edr.errorDetailExtractor.GetErrorMessage(sampleResponse)
-	cleanedErrMsg := edr.errorDetailExtractor.CleanUpErrorMessage(errMsg)
-	errorCode := edr.errorDetailExtractor.GetErrorCode(cleanedErrMsg, statTags, destType)
+	errorCode := edr.errorDetailExtractor.GetErrorCode(errMsg, statTags, destType)
 	return types.ErrorDetails{
-		Message: cleanedErrMsg,
+		Message: errMsg,
 		Code:    errorCode,
 	}
 }


### PR DESCRIPTION
# Description

This PR enhances the HTML detection logic in error message handling and adjusts message truncation configuration for more flexible error reporting.

## Changes

- **Enhanced HTML Detection**: Improved isHTMLString function to detect additional HTML patterns:
  - DOCTYPE html with html tags
  - html with title tags
  - html with head tags
  - Existing body tag detection

- **Configuration Adjustment**: Changed maxMessageLength scaling factor 10 to 1 and increased length to 200 so effectively (`100*10 -> 200*1`)

- **Test Updates**: Updated test expectations to reflect the new truncation behavior and added comprehensive test coverage for the improved HTML detection

## Linear Ticket

Resolves https://linear.app/rudderstack/issue/INT-4198/on-call-oct-01-07-dilip-progress-on-following-tasks

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

