### PR TITLE
fix(warehouse): skip users table for duplicates check in staging file

### DIFF
--- a/warehouse/slave/worker.go
+++ b/warehouse/slave/worker.go
@@ -337,15 +337,18 @@ func (w *worker) processSingleStagingFile(
 		eventLoader := w.encodingFactory.NewEventLoader(writer, job.LoadFileType, job.DestinationType)
 
 		// Duplicate detection by id column
-		iDVal, ok := columnData[job.columnName("id")]
-		if ok {
-			iDStr, ok := iDVal.(string)
+		// skip duplicate detection for users table as multiple identifies events can be present for same user	id
+		if tableName != warehouseutils.UsersTable {
+			iDVal, ok := columnData[job.columnName("id")]
 			if ok {
-				dedupKey := dedupKey{tableName: tableName, idValue: iDStr}
-				if _, exists := tableIDColumnSet[dedupKey]; exists {
-					duplicateCount++
-				} else {
-					tableIDColumnSet[dedupKey] = struct{}{}
+				iDStr, ok := iDVal.(string)
+				if ok {
+					dedupKey := dedupKey{tableName: tableName, idValue: iDStr}
+					if _, exists := tableIDColumnSet[dedupKey]; exists {
+						duplicateCount++
+					} else {
+						tableIDColumnSet[dedupKey] = struct{}{}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
# Description

Duplicate events metric per staging file was added as a check for any bug. Ideally staging file should not have any duplicate considering small time window with dedupe in rudder-server. users events derived from identifies table can have duplicates though.
Skipping users table from duplicate check.

## Linear Ticket

resolves WAR-1206

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
