### PR TITLE
fix: respect context cancellation in gateway rate limiter

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1637,6 +1637,66 @@ var _ = Describe("Gateway", func() {
 			_, err := gateway.getJobDataFromRequest(req)
 			Expect(err).To(BeNil())
 		})
+
+		Context("rate limit checks", func() {
+			var (
+				req     *webRequestT
+				gateway *Handle
+			)
+			BeforeEach(func() {
+				c.initializeAppFeatures()
+				gateway = &Handle{}
+				conf.Set("Gateway.enableRateLimit", true)
+
+				// Create a new fresh logger and stats to avoid nils
+				err := gateway.Setup(context.Background(), conf, logger.NOP, stats.NOP, c.mockApp, c.mockBackendConfig, c.mockJobsDB, c.mockRateLimiter, c.mockVersionHandler, rsources.NewNoOpService(), transformer.NewNoOpService(), sourcedebugger.NewNoOpService(), nil)
+				Expect(err).To(BeNil())
+				waitForBackendConfigInit(gateway)
+
+				req = &webRequestT{
+					reqType:        "batch",
+					authContext:    rCtxEnabled,
+					done:           make(chan<- string),
+					userIDHeader:   userIDHeader,
+					requestPayload: []byte(`{"batch": [{"type": "track", "userId": "123"}]}`),
+				}
+			})
+
+			It("returns errRequestDropped when rate limit is reached", func() {
+				ctx := context.Background()
+				req.ctx = ctx
+				c.mockRateLimiter.EXPECT().CheckLimitReached(ctx, rCtxEnabled.WorkspaceID, int64(1)).Return(true, nil).Times(1)
+				
+				jobData, err := gateway.getJobDataFromRequest(req)
+				Expect(err).To(Equal(errRequestDropped))
+				Expect(jobData).To(Not(BeNil()))
+			})
+
+			It("returns context error when context is cancelled and rate limit returns error", func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				req.ctx = ctx
+				cancel() // This line cancels the context immediately
+				
+				expectedErr := errors.New("some rate limit error")
+				c.mockRateLimiter.EXPECT().CheckLimitReached(ctx, rCtxEnabled.WorkspaceID, int64(1)).Return(false, expectedErr).Times(1)
+				
+				jobData, err := gateway.getJobDataFromRequest(req)
+				Expect(err).To(Equal(context.Canceled))
+				Expect(jobData).To(Not(BeNil()))
+			})
+
+			It("logs error and allows request when rate limit returns error but context is not cancelled", func() {
+				ctx := context.Background()
+				req.ctx = ctx
+				expectedErr := errors.New("some rate limit error")
+				c.mockRateLimiter.EXPECT().CheckLimitReached(ctx, rCtxEnabled.WorkspaceID, int64(1)).Return(false, expectedErr).Times(1)
+				
+				jobData, err := gateway.getJobDataFromRequest(req)
+				Expect(err).To(BeNil())
+				Expect(jobData).To(Not(BeNil()))
+				Expect(jobData.jobs).To(HaveLen(1))
+			})
+		})
 	})
 
 	Context("Internal Batch", func() {

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1666,7 +1666,7 @@ var _ = Describe("Gateway", func() {
 				ctx := context.Background()
 				req.ctx = ctx
 				c.mockRateLimiter.EXPECT().CheckLimitReached(ctx, rCtxEnabled.WorkspaceID, int64(1)).Return(true, nil).Times(1)
-				
+
 				jobData, err := gateway.getJobDataFromRequest(req)
 				Expect(err).To(Equal(errRequestDropped))
 				Expect(jobData).To(Not(BeNil()))
@@ -1676,10 +1676,10 @@ var _ = Describe("Gateway", func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				req.ctx = ctx
 				cancel() // This line cancels the context immediately
-				
+
 				expectedErr := errors.New("some rate limit error")
 				c.mockRateLimiter.EXPECT().CheckLimitReached(ctx, rCtxEnabled.WorkspaceID, int64(1)).Return(false, expectedErr).Times(1)
-				
+
 				jobData, err := gateway.getJobDataFromRequest(req)
 				Expect(err).To(Equal(context.Canceled))
 				Expect(jobData).To(Not(BeNil()))
@@ -1690,7 +1690,7 @@ var _ = Describe("Gateway", func() {
 				req.ctx = ctx
 				expectedErr := errors.New("some rate limit error")
 				c.mockRateLimiter.EXPECT().CheckLimitReached(ctx, rCtxEnabled.WorkspaceID, int64(1)).Return(false, expectedErr).Times(1)
-				
+
 				jobData, err := gateway.getJobDataFromRequest(req)
 				Expect(err).To(BeNil())
 				Expect(jobData).To(Not(BeNil()))

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -198,7 +198,7 @@ func (c *testContext) Setup() {
 				close(ch)
 			}()
 			return ch
-		})
+		}).AnyTimes()
 	c.mockVersionHandler = func(w http.ResponseWriter, r *http.Request) {}
 }
 
@@ -1660,6 +1660,11 @@ var _ = Describe("Gateway", func() {
 					userIDHeader:   userIDHeader,
 					requestPayload: []byte(`{"batch": [{"type": "track", "userId": "123"}]}`),
 				}
+			})
+
+			AfterEach(func() {
+				err := gateway.Shutdown()
+				Expect(err).To(BeNil())
 			})
 
 			It("returns errRequestDropped when rate limit is reached", func() {

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -454,7 +454,7 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 		if limitReached {
 			return jobData, errRequestDropped
 		}
-		if req.ctx.Err()!= nil {
+		if req.ctx.Err() != nil {
 			return jobData, req.ctx.Err()
 		}
 	}

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -446,7 +446,7 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 
 	if gw.conf.enableRateLimit.Load() && sourcesJobRunID == "" && sourcesTaskRunID == "" {
 		// In case of "batch" requests, if rate-limiter returns true for LimitReached, just drop the event batch and continue.
-		ok, errCheck := gw.rateLimiter.CheckLimitReached(context.TODO(), workspaceId, int64(len(eventsBatch)))
+		ok, errCheck := gw.rateLimiter.CheckLimitReached(req.ctx, workspaceId, int64(len(eventsBatch)))
 		if errCheck != nil {
 			gw.stats.NewTaggedStat("gateway.rate_limiter_error", stats.CountType, stats.Tags{"workspaceId": workspaceId}).Increment()
 			gw.logger.Errorn("Rate limiter error: Allowing the request", obskit.Error(errCheck))
@@ -685,6 +685,7 @@ func (gw *Handle) addToWebRequestQ(_ *http.ResponseWriter, req *http.Request, do
 		traceParent:    traceParent,
 		ipAddr:         ipAddr,
 		userIDHeader:   userIDHeader,
+		ctx:            req.Context(),
 	}
 	userWebRequestWorker.webRequestQ <- &webReq
 }

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -446,13 +446,16 @@ func (gw *Handle) getJobDataFromRequest(req *webRequestT) (jobData *jobFromReq, 
 
 	if gw.conf.enableRateLimit.Load() && sourcesJobRunID == "" && sourcesTaskRunID == "" {
 		// In case of "batch" requests, if rate-limiter returns true for LimitReached, just drop the event batch and continue.
-		ok, errCheck := gw.rateLimiter.CheckLimitReached(req.ctx, workspaceId, int64(len(eventsBatch)))
-		if errCheck != nil {
+		limitReached, errCheck := gw.rateLimiter.CheckLimitReached(req.ctx, workspaceId, int64(len(eventsBatch)))
+		if errCheck != nil && req.ctx.Err() == nil {
 			gw.stats.NewTaggedStat("gateway.rate_limiter_error", stats.CountType, stats.Tags{"workspaceId": workspaceId}).Increment()
 			gw.logger.Errorn("Rate limiter error: Allowing the request", obskit.Error(errCheck))
 		}
-		if ok {
+		if limitReached {
 			return jobData, errRequestDropped
+		}
+		if req.ctx.Err()!= nil {
+			return jobData, req.ctx.Err()
 		}
 	}
 

--- a/gateway/types.go
+++ b/gateway/types.go
@@ -28,6 +28,7 @@ type webRequestT struct {
 	ipAddr         string
 	userIDHeader   string
 	errors         []string
+	ctx            context.Context
 }
 
 type batchWebRequestT struct {

--- a/gateway/types.go
+++ b/gateway/types.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/google/uuid"


### PR DESCRIPTION
# Description
Hi @atzoum  @mihir20 ,

Continuation of [#6694](https://github.com/rudderlabs/rudder-server/pull/6694)
This PR updates the gateway rate limiter in handle.go to propagate the request context (req.ctx) instead of context.TODO(), ensuring rate limit checks respect client disconnections. It also guards error logging and metric increments behind a req.ctx.Err() == nil check so that context cancellation errors are not mistakenly counted as rate limiter failures.

# Changes

1.) gateway/handle.go : Pass req.ctx to CheckLimitReached. Only log rate_limiter_error and increment stats when the context is still active. Return req.ctx.Err() early if the context was cancelled.

2.) gateway/types.go : Add ctx context.Context field to webRequestT, populated from req.Context() in addToWebRequestQ.

3.) gateway/gateway_test.go: Add .AnyTimes() to the Subscribe mock to support nested Ginkgo contexts. Add AfterEach for gateway cleanup. Add 3 tests covering:

          i) errRequestDropped returned when rate limit is genuinely reached.
          ii) errRequestDropped returned when rate limit is genuinely reached.
          iii) Error logged and request allowed when rate limiter errors but context is active.

After this changes, my 3 test cases, which are failing is now running by using these commands : 
1.) cd rudder-server/gateway
2.) go test -v -run='^TestGateway$' -ginkgo.focus='rate limit'

Please review the changes and let me know is there any changes for the enhancement.

Thank you