### PR TITLE
chore: update rudder-transformer version to 1.126.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/rudderlabs/rudder-go-kit v0.74.0
 	github.com/rudderlabs/rudder-observability-kit v0.0.6
 	github.com/rudderlabs/rudder-schemas v0.10.0
-	github.com/rudderlabs/rudder-transformer/go v1.122.0
+	github.com/rudderlabs/rudder-transformer/go v1.126.0
 	github.com/rudderlabs/sql-tunnels v0.1.7
 	github.com/rudderlabs/sqlconnect-go v1.20.3
 	github.com/samber/lo v1.52.0

--- a/go.sum
+++ b/go.sum
@@ -1213,6 +1213,8 @@ github.com/rudderlabs/rudder-schemas v0.10.0 h1:OzhmoV3wIyZG4cH7RtixYEF23VwWaxyI
 github.com/rudderlabs/rudder-schemas v0.10.0/go.mod h1:mb7XxrdYj6iqz5GNbhv4cvmGjMGYgirpQnfm7WPXmyE=
 github.com/rudderlabs/rudder-transformer/go v1.122.0 h1:XmCKiSbhj5SMRPPQzyXnx6RnP2FjPnZ4ARXGR4ByrPk=
 github.com/rudderlabs/rudder-transformer/go v1.122.0/go.mod h1:3NGitPz4pYRRZ6Xt09S+8hb0tHK/9pZcKJ3OgOTaSmE=
+github.com/rudderlabs/rudder-transformer/go v1.126.0 h1:KxHkKAexrpQxnsHrb9l1hrcg2psdvl5ZwnwShmknQK0=
+github.com/rudderlabs/rudder-transformer/go v1.126.0/go.mod h1:3NGitPz4pYRRZ6Xt09S+8hb0tHK/9pZcKJ3OgOTaSmE=
 github.com/rudderlabs/sonnet v1.0.2 h1:nPfmDKD9gUwT571Dwtcsx0VIglSchvyNjuRLju4Xs3s=
 github.com/rudderlabs/sonnet v1.0.2/go.mod h1:tjQmKEGAo/xwmhw9AwLkazP5b5m8VpUvWNzPSx4ve0g=
 github.com/rudderlabs/sql-tunnels v0.1.7 h1:wDCRl6zY4M5gfWazf7XkSTGQS3yjBzUiUgEMBIfHNDA=

--- a/go.sum
+++ b/go.sum
@@ -1211,8 +1211,6 @@ github.com/rudderlabs/rudder-observability-kit v0.0.6 h1:xIA/1Sp38B542EYzxR7qUfN
 github.com/rudderlabs/rudder-observability-kit v0.0.6/go.mod h1:nR3GvY7HvuBaBqOKFfzLP9uYZu7OpzMqW2eeT2ikXtU=
 github.com/rudderlabs/rudder-schemas v0.10.0 h1:OzhmoV3wIyZG4cH7RtixYEF23VwWaxyIGPKiVZ0XCT0=
 github.com/rudderlabs/rudder-schemas v0.10.0/go.mod h1:mb7XxrdYj6iqz5GNbhv4cvmGjMGYgirpQnfm7WPXmyE=
-github.com/rudderlabs/rudder-transformer/go v1.122.0 h1:XmCKiSbhj5SMRPPQzyXnx6RnP2FjPnZ4ARXGR4ByrPk=
-github.com/rudderlabs/rudder-transformer/go v1.122.0/go.mod h1:3NGitPz4pYRRZ6Xt09S+8hb0tHK/9pZcKJ3OgOTaSmE=
 github.com/rudderlabs/rudder-transformer/go v1.126.0 h1:KxHkKAexrpQxnsHrb9l1hrcg2psdvl5ZwnwShmknQK0=
 github.com/rudderlabs/rudder-transformer/go v1.126.0/go.mod h1:3NGitPz4pYRRZ6Xt09S+8hb0tHK/9pZcKJ3OgOTaSmE=
 github.com/rudderlabs/sonnet v1.0.2 h1:nPfmDKD9gUwT571Dwtcsx0VIglSchvyNjuRLju4Xs3s=


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.28.0

# Description

Updated rudder-transformer to latest (1.126.0)

## Linear Ticket

[Resolves INT-6057](https://linear.app/rudderstack/issue/INT-6057/integrations-release-12-03-2026)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
