### PR TITLE
refactor(webhook): use gateway request context for transformer adapter timeout

### DIFF
--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -321,6 +321,9 @@ func (webhook *HandleT) batchRequests(sourceDef string, requestQ chan *webhookT)
 func (bt *batchWebhookTransformerT) batchTransformLoop() {
 	for breq := range bt.webhook.batchRequestQ {
 		// If unable to fetch features from transformer, send GatewayTimeout to all requests
+		if len(breq.batchRequest) == 0 {       //ensures that we don't process empty batch requests
+			continue
+		}
 		ctx := breq.batchRequest[0].request.Context()
 		sourceTransformAdapter, err := bt.sourceTransformAdapter(ctx)
 		if err != nil {

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -321,9 +321,6 @@ func (webhook *HandleT) batchRequests(sourceDef string, requestQ chan *webhookT)
 func (bt *batchWebhookTransformerT) batchTransformLoop() {
 	for breq := range bt.webhook.batchRequestQ {
 		// If unable to fetch features from transformer, send GatewayTimeout to all requests
-		if len(breq.batchRequest) == 0 {       //ensures that we don't process empty batch requests
-			continue
-		}
 		ctx := breq.batchRequest[0].request.Context()
 		sourceTransformAdapter, err := bt.sourceTransformAdapter(ctx)
 		if err != nil {

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -321,8 +321,7 @@ func (webhook *HandleT) batchRequests(sourceDef string, requestQ chan *webhookT)
 func (bt *batchWebhookTransformerT) batchTransformLoop() {
 	for breq := range bt.webhook.batchRequestQ {
 		// If unable to fetch features from transformer, send GatewayTimeout to all requests
-		// TODO: Remove timeout from here after timeout handler is added in gateway
-		ctx, cancel := context.WithTimeout(context.Background(), config.GetDurationVar(10, time.Second, "WriteTimeout", "WriteTimeOutInSec"))
+		ctx := breq.batchRequest[0].request.Context()
 		sourceTransformAdapter, err := bt.sourceTransformAdapter(ctx)
 		if err != nil {
 			bt.webhook.logger.Errorn("webhook source transformation failed",
@@ -332,10 +331,8 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 			for _, req := range breq.batchRequest {
 				req.done <- transformerResponse{StatusCode: response.GetErrorStatusCode(response.GatewayTimeout), Err: response.GetStatus(response.GatewayTimeout)}
 			}
-			cancel()
 			continue
 		}
-		cancel()
 
 		transformerURL, err := sourceTransformAdapter.getTransformerURL(breq.sourceType)
 		if err != nil {


### PR DESCRIPTION
Hi @atzoum @mihir20 
# Description

This PR refactors the existing context in the batchTransformLoop in the webhook.go . Currently there is a TODO : Remove timeout from here after timeout handler is added in gateway. The worker was creating an isolated, hardcoded 10-second timer instead of properly inheriting the master HTTP timeout rules from the original incoming webhook request. . After the changes made in [#6751](https://github.com/rudderlabs/rudder-server/pull/6751), we can now safely use the original incoming webhook request as same as of gateway. 

## changes
- Removed `context.WithTimeout` and the associated `cancel()` function calls in `batchTransformLoop`.
- Replaced the manual context with `req.request.Context()`.
- Deleted the resolved `TODO` comment.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
