### PR TITLE
chore: contract tests for dns regressions and overrides

### DIFF
--- a/integration_test/pytransformer_contract/backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/backwards_compatibility_test.go
@@ -1820,6 +1820,240 @@ def transformEvent(event, metadata):
 				}
 			},
 		},
+		{
+			// MetadataMergeAllKeys tests event.update(metadata(event)) which merges
+			// all 29 metadata keys (including None for missing fields) into the event.
+			name:      "MetadataMergeAllKeys",
+			versionID: "bc-metadata-merge-all-v1",
+			config: configBackendEntry{code: `
+def transformEvent(event, metadata):
+    event.update(metadata(event))
+    return event
+`},
+			run: func(t *testing.T, env *bcTestEnv) {
+				const versionID = "bc-metadata-merge-all-v1"
+				events := []types.TransformerEvent{
+					{
+						Message: types.SingularEventT{
+							"messageId":   "msg-1",
+							"type":        "track",
+							"event":       "Test Event",
+							"instanceId":  "1",
+							"partitionId": "ws-1-42",
+						},
+						Metadata: types.Metadata{
+							JobID: 1234, WorkspaceID: "ws-1", MessageID: "msg-1",
+							SourceID: "src-1", SourceName: "test-source", SourceType: "javascript",
+							DestinationID: "dest-1", DestinationName: "test-dest", DestinationType: "AM",
+							InstanceID: "1", PartitionID: "ws-1-42", Namespace: "test-ns",
+							RudderID: "rudder-id-1", ReceivedAt: "2024-01-01T00:00:00.000Z",
+							EventName: "Test Event", EventType: "track",
+							SourceDefinitionID: "src-def-1", DestinationDefinitionID: "dest-def-1",
+							TransformationID: "tf-1", TransformationVersionID: versionID,
+						},
+						Destination: backendconfig.DestinationT{
+							Transformations: []backendconfig.TransformationT{
+								{VersionID: versionID, ID: "transformation-1", Language: "pythonfaas"},
+							},
+						},
+					},
+				}
+				oldResp := env.OldClient.Transform(context.Background(), events)
+				newResp := env.NewClient.Transform(context.Background(), events)
+				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
+				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				oldOutput := oldResp.Events[0].Output
+				newOutput := newResp.Events[0].Output
+				t.Logf("Old arch output keys: %d", len(oldOutput))
+				t.Logf("New arch output keys: %d", len(newOutput))
+				for _, key := range []string{
+					"instanceId", "partitionId",
+					"sourceJobId", "sourceJobRunId", "sourceTaskRunId",
+					"recordId", "trackingPlanId", "trackingPlanVersion", "messageIds",
+				} {
+					oldVal, oldOk := oldOutput[key]
+					newVal, newOk := newOutput[key]
+					t.Logf("Output field %q: old=(present=%v, val=%v) new=(present=%v, val=%v)",
+						key, oldOk, oldVal, newOk, newVal)
+				}
+				diff, equal := oldResp.Equal(&newResp)
+				if equal {
+					t.Log("Responses are equal")
+				} else {
+					t.Errorf("Responses differ:\n%s", diff)
+				}
+			},
+		},
+		{
+			// MetadataMergeIfFalsy tests the production user pattern where metadata
+			// values are added to the event only when the event doesn't already have
+			// a truthy value for that key: `if not event.get(k): event[k] = v`.
+			// This is sensitive to None vs "" vs 0 differences in the metadata dict.
+			name:      "MetadataMergeIfFalsy",
+			versionID: "bc-metadata-merge-falsy-v1",
+			config: configBackendEntry{code: `
+def transformEvent(event, metadata):
+    meta = metadata(event)
+    for k, v in meta.items():
+        if not event.get(k):
+            event[k] = v
+    return event
+`},
+			run: func(t *testing.T, env *bcTestEnv) {
+				const versionID = "bc-metadata-merge-falsy-v1"
+				events := []types.TransformerEvent{
+					{
+						Message: types.SingularEventT{
+							"messageId":   "msg-1",
+							"type":        "track",
+							"event":       "Test Event",
+							"instanceId":  "1",
+							"partitionId": "ws-1-42",
+						},
+						Metadata: types.Metadata{
+							JobID: 1234, WorkspaceID: "ws-1", MessageID: "msg-1",
+							SourceID: "src-1", SourceName: "test-source", SourceType: "javascript",
+							DestinationID: "dest-1", DestinationName: "test-dest", DestinationType: "AM",
+							InstanceID: "1", PartitionID: "ws-1-42", Namespace: "test-ns",
+							RudderID: "rudder-id-1", ReceivedAt: "2024-01-01T00:00:00.000Z",
+							EventName: "Test Event", EventType: "track",
+							SourceDefinitionID: "src-def-1", DestinationDefinitionID: "dest-def-1",
+							TransformationID: "tf-1", TransformationVersionID: versionID,
+						},
+						Destination: backendconfig.DestinationT{
+							Transformations: []backendconfig.TransformationT{
+								{VersionID: versionID, ID: "transformation-1", Language: "pythonfaas"},
+							},
+						},
+					},
+				}
+				oldResp := env.OldClient.Transform(context.Background(), events)
+				newResp := env.NewClient.Transform(context.Background(), events)
+				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
+				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				oldOutput := oldResp.Events[0].Output
+				newOutput := newResp.Events[0].Output
+				t.Logf("Old arch output keys: %d", len(oldOutput))
+				t.Logf("New arch output keys: %d", len(newOutput))
+				for _, key := range []string{
+					"instanceId", "partitionId",
+					"sourceJobId", "sourceJobRunId", "sourceTaskRunId",
+					"recordId", "trackingPlanId", "trackingPlanVersion", "messageIds",
+				} {
+					oldVal, oldOk := oldOutput[key]
+					newVal, newOk := newOutput[key]
+					t.Logf("Output field %q: old=(present=%v, val=%v) new=(present=%v, val=%v)",
+						key, oldOk, oldVal, newOk, newVal)
+				}
+				diff, equal := oldResp.Equal(&newResp)
+				if equal {
+					t.Log("Responses are equal")
+				} else {
+					t.Errorf("Responses differ:\n%s", diff)
+				}
+			},
+		},
+		{
+			// MetadataAddMetaPattern tests the production preprocessEvents.py pattern:
+			//
+			//   meta = self.metadata(self.event)
+			//   for k, v in meta.items():
+			//       if not self.event.get(k):
+			//           self.event[k] = v
+			//
+			// The key difference from MetadataMergeIfFalsy is the event setup:
+			// instanceId and partitionId are NOT present in the message body (so they
+			// will be copied from metadata), userId is an empty string (falsy, so it
+			// will also be overwritten), and SourceJobID/TrackingPlanID/etc. are zero
+			// values which are omitted from the metadata JSON (omitempty) so the metadata
+			// function returns None for them. This mirrors the production scenario that
+			// exposed the diff between old and new arch.
+			name:      "MetadataAddMetaPattern",
+			versionID: "bc-add-meta-pattern-v1",
+			config: configBackendEntry{code: `
+def transformEvent(event, metadata):
+    meta = metadata(event)
+    for k, v in meta.items():
+        if not event.get(k):
+            event[k] = v
+    return event
+`},
+			run: func(t *testing.T, env *bcTestEnv) {
+				const versionID = "bc-add-meta-pattern-v1"
+				events := []types.TransformerEvent{
+					{
+						Message: types.SingularEventT{
+							"messageId": "msg-1",
+							"type":      "track",
+							"event":     "Test Event",
+							"channel":   "web",
+							"userId":    "", // empty string — falsy, will be overwritten by metadata value
+							// instanceId and partitionId are intentionally absent from the message body
+						},
+						Metadata: types.Metadata{
+							JobID: 1234, WorkspaceID: "ws-1", MessageID: "msg-1",
+							SourceID: "src-1", SourceName: "test-source", SourceType: "javascript",
+							DestinationID: "dest-1", DestinationName: "test-dest", DestinationType: "AM",
+							// InstanceID and PartitionID are set (present in metadata JSON) but absent
+							// from the message body — the pattern will add them to the event.
+							InstanceID: "3", PartitionID: "ws-1-33", Namespace: "test-ns",
+							RudderID: "rudder-id-1", ReceivedAt: "2024-01-01T00:00:00.000Z",
+							EventName: "Test Event", EventType: "track",
+							SourceDefinitionID: "src-def-1", DestinationDefinitionID: "dest-def-1",
+							TransformationID: "tf-1", TransformationVersionID: versionID,
+							// SourceJobID, TrackingPlanID, TrackingPlanVersion, SourceJobRunID,
+							// SourceTaskRunID, RecordID and MessageIDs are left as zero values.
+							// They are omitted from the metadata JSON (omitempty) so the metadata
+							// function returns None for them (present in the dict, value is None).
+						},
+						Destination: backendconfig.DestinationT{
+							Transformations: []backendconfig.TransformationT{
+								{VersionID: versionID, ID: "transformation-1", Language: "pythonfaas"},
+							},
+						},
+					},
+				}
+
+				t.Log("Sending request to old architecture...")
+				oldResp := env.OldClient.Transform(context.Background(), events)
+				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+
+				t.Log("Sending request to new architecture...")
+				newResp := env.NewClient.Transform(context.Background(), events)
+				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+
+				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
+				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+
+				oldOutput := oldResp.Events[0].Output
+				newOutput := newResp.Events[0].Output
+				t.Logf("Old arch output keys: %d", len(oldOutput))
+				t.Logf("New arch output keys: %d", len(newOutput))
+
+				// Log the fields sensitive to the add-meta pattern:
+				// instanceId and partitionId should be added (absent from message body).
+				// sourceJobId, sourceJobRunId, sourceTaskRunId, recordId, trackingPlanId,
+				// trackingPlanVersion, messageIds are zero/omitted in metadata — both
+				// archs should behave the same for these.
+				for _, key := range []string{
+					"instanceId", "partitionId",
+					"sourceJobId", "sourceJobRunId", "sourceTaskRunId",
+					"recordId", "trackingPlanId", "trackingPlanVersion", "messageIds",
+				} {
+					oldVal, oldOk := oldOutput[key]
+					newVal, newOk := newOutput[key]
+					t.Logf("Output field %q: old=(present=%v, val=%v) new=(present=%v, val=%v)",
+						key, oldOk, oldVal, newOk, newVal)
+				}
+
+				diff, equal := oldResp.Equal(&newResp)
+				if equal {
+					t.Log("Responses are equal")
+				} else {
+					t.Errorf("Responses differ:\n%s", diff)
+				}
+			},
+		},
 	}
 
 	pool, err := dockertest.NewPool("")

--- a/integration_test/pytransformer_contract/backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/backwards_compatibility_test.go
@@ -1866,21 +1866,11 @@ def transformEvent(event, metadata):
 				newOutput := newResp.Events[0].Output
 				t.Logf("Old arch output keys: %d", len(oldOutput))
 				t.Logf("New arch output keys: %d", len(newOutput))
-				for _, key := range []string{
-					"instanceId", "partitionId",
-					"sourceJobId", "sourceJobRunId", "sourceTaskRunId",
-					"recordId", "trackingPlanId", "trackingPlanVersion", "messageIds",
-				} {
-					oldVal, oldOk := oldOutput[key]
-					newVal, newOk := newOutput[key]
-					t.Logf("Output field %q: old=(present=%v, val=%v) new=(present=%v, val=%v)",
-						key, oldOk, oldVal, newOk, newVal)
-				}
 				diff, equal := oldResp.Equal(&newResp)
 				if equal {
 					t.Log("Responses are equal")
 				} else {
-					t.Errorf("Responses differ:\n%s", diff)
+					t.Errorf("Responses differ: %s\n", diff)
 				}
 			},
 		},
@@ -1935,21 +1925,11 @@ def transformEvent(event, metadata):
 				newOutput := newResp.Events[0].Output
 				t.Logf("Old arch output keys: %d", len(oldOutput))
 				t.Logf("New arch output keys: %d", len(newOutput))
-				for _, key := range []string{
-					"instanceId", "partitionId",
-					"sourceJobId", "sourceJobRunId", "sourceTaskRunId",
-					"recordId", "trackingPlanId", "trackingPlanVersion", "messageIds",
-				} {
-					oldVal, oldOk := oldOutput[key]
-					newVal, newOk := newOutput[key]
-					t.Logf("Output field %q: old=(present=%v, val=%v) new=(present=%v, val=%v)",
-						key, oldOk, oldVal, newOk, newVal)
-				}
 				diff, equal := oldResp.Equal(&newResp)
 				if equal {
 					t.Log("Responses are equal")
 				} else {
-					t.Errorf("Responses differ:\n%s", diff)
+					t.Errorf("Responses differ: %s\n", diff)
 				}
 			},
 		},
@@ -2013,44 +1993,23 @@ def transformEvent(event, metadata):
 						},
 					},
 				}
-
 				t.Log("Sending request to old architecture...")
 				oldResp := env.OldClient.Transform(context.Background(), events)
 				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-
 				t.Log("Sending request to new architecture...")
 				newResp := env.NewClient.Transform(context.Background(), events)
 				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-
 				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
 				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
-
 				oldOutput := oldResp.Events[0].Output
 				newOutput := newResp.Events[0].Output
 				t.Logf("Old arch output keys: %d", len(oldOutput))
 				t.Logf("New arch output keys: %d", len(newOutput))
-
-				// Log the fields sensitive to the add-meta pattern:
-				// instanceId and partitionId should be added (absent from message body).
-				// sourceJobId, sourceJobRunId, sourceTaskRunId, recordId, trackingPlanId,
-				// trackingPlanVersion, messageIds are zero/omitted in metadata — both
-				// archs should behave the same for these.
-				for _, key := range []string{
-					"instanceId", "partitionId",
-					"sourceJobId", "sourceJobRunId", "sourceTaskRunId",
-					"recordId", "trackingPlanId", "trackingPlanVersion", "messageIds",
-				} {
-					oldVal, oldOk := oldOutput[key]
-					newVal, newOk := newOutput[key]
-					t.Logf("Output field %q: old=(present=%v, val=%v) new=(present=%v, val=%v)",
-						key, oldOk, oldVal, newOk, newVal)
-				}
-
 				diff, equal := oldResp.Equal(&newResp)
 				if equal {
 					t.Log("Responses are equal")
 				} else {
-					t.Errorf("Responses differ:\n%s", diff)
+					t.Errorf("Responses differ: %s\n", diff)
 				}
 			},
 		},

--- a/integration_test/pytransformer_contract/dns_cache_contract_test.go
+++ b/integration_test/pytransformer_contract/dns_cache_contract_test.go
@@ -2,17 +2,21 @@ package pytransformer_contract
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-go-kit/httputil"
@@ -183,20 +187,15 @@ def transformEvent(event, metadata):
 // correctly overrides DNS resolution for transformation HTTP calls.
 //
 // A mock HTTP server runs on the host. DNS_OVERRIDES maps a fake hostname
-// (custom-api.test) to 127.0.0.1. The transformation calls
+// (custom-api.test) to an IP that reaches the host's loopback from inside
+// the pytransformer container. The transformation calls
 // http://custom-api.test:PORT/data and should reach the mock server.
-//
-// Only runs on Linux (host networking) — on macOS, 127.0.0.1 inside the
-// container is the container's loopback, not the host's.
 func TestDNSOverrides(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("DNS override contract test requires host networking (Linux/CI only)")
-	}
-
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 	pool.MaxWait = 2 * time.Minute
 
+	hostIP := hostReachableIP(t, pool)
 	mockSrv, mockCalls := newMockAPIServer(t, "override-target")
 
 	u, err := url.Parse(mockSrv.URL)
@@ -222,7 +221,7 @@ def transformEvent(event, metadata):
 
 	container, pyURL := startRudderPytransformer(
 		t, pool, configBackend.URL,
-		"DNS_OVERRIDES=custom-api.test,127.0.0.1",
+		"DNS_OVERRIDES=custom-api.test,"+hostIP,
 	)
 	t.Cleanup(func() { _ = pool.Purge(container) })
 	waitForHealthy(t, pool, pyURL, "pytransformer", container)
@@ -232,8 +231,8 @@ def transformEvent(event, metadata):
 		status, items := sendRawTransform(t, pyURL, events)
 
 		require.Equal(t, http.StatusOK, status)
-		require.Equal(t, 1, len(items))
-		require.Equal(t, 200, items[0].StatusCode, "event error: %s", items[0].Error)
+		require.Len(t, items, 1)
+		require.Equal(t, http.StatusOK, items[0].StatusCode, "event error: %s", items[0].Error)
 
 		external, ok := items[0].Output["external"].(map[string]any)
 		require.True(t, ok, "external should be a map")
@@ -250,8 +249,8 @@ def transformEvent(event, metadata):
 			status, items := sendRawTransform(t, pyURL, events)
 
 			require.Equal(t, http.StatusOK, status)
-			require.Equal(t, 1, len(items))
-			require.Equal(t, 200, items[0].StatusCode, "event error: %s", items[0].Error)
+			require.Len(t, items, 1)
+			require.Equal(t, http.StatusOK, items[0].StatusCode, "event error: %s", items[0].Error)
 
 			external := items[0].Output["external"].(map[string]any)
 			require.Equal(t, "override-target", external["server"])
@@ -265,21 +264,19 @@ def transformEvent(event, metadata):
 // work correctly together — overrides are served from the override map
 // (not from the DNS cache), while non-overridden hosts use the DNS cache.
 func TestDNSCachingWithOverrides(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("requires host networking (Linux/CI only)")
-	}
-
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 	pool.MaxWait = 2 * time.Minute
 
-	// Mock server A: reached via DNS override (custom-api.test → 127.0.0.1)
+	hostIP := hostReachableIP(t, pool)
+
+	// Mock server A: reached via DNS override (custom-api.test → hostIP)
 	mockSrvA, _ := newMockAPIServer(t, "override-server")
 	uA, err := url.Parse(mockSrvA.URL)
 	require.NoError(t, err)
 	portA := uA.Port()
 
-	// Mock server B: reached via normal DNS resolution (localhost)
+	// Mock server B: reached via normal DNS resolution (localhost / host.docker.internal)
 	mockSrvB, _ := newMockAPIServer(t, "cached-server")
 
 	const (
@@ -306,7 +303,7 @@ def transformEvent(event, metadata):
     resp = requests.get("%s/data", timeout=5)
     event['external'] = resp.json()
     return event
-`, mockSrvB.URL),
+`, toContainerURL(mockSrvB.URL)),
 		},
 	}
 
@@ -317,7 +314,7 @@ def transformEvent(event, metadata):
 		t, pool, configBackend.URL,
 		"DNS_CACHE_ENABLED=true",
 		"DNS_CACHE_TTL_S=300",
-		"DNS_OVERRIDES=custom-api.test,127.0.0.1",
+		"DNS_OVERRIDES=custom-api.test,"+hostIP,
 	)
 	t.Cleanup(func() { _ = pool.Purge(container) })
 	waitForHealthy(t, pool, pyURL, "pytransformer", container)
@@ -356,8 +353,8 @@ def transformEvent(event, metadata):
 
 	for _, r := range results {
 		require.Equal(t, http.StatusOK, r.status, "HTTP status for %s", r.label)
-		require.Equal(t, 1, len(r.items), "expected 1 item for %s", r.label)
-		require.Equal(t, 200, r.items[0].StatusCode,
+		require.Len(t, r.items, 1, "expected 1 item for %s", r.label)
+		require.Equal(t, http.StatusOK, r.items[0].StatusCode,
 			"event status for %s: error=%s", r.label, r.items[0].Error)
 
 		external, ok := r.items[0].Output["external"].(map[string]any)
@@ -365,6 +362,69 @@ def transformEvent(event, metadata):
 		require.Equal(t, r.expectedServer, external["server"],
 			"%s should reach %s", r.label, r.expectedServer)
 	}
+}
+
+// hostReachableIP returns an IPv4 address that, from inside a Docker
+// container, reaches the host machine's loopback — i.e. the address where
+// httptest.NewServer has bound its listener.
+//
+// On Linux (host networking), containers share the host's network namespace
+// so 127.0.0.1 is the correct answer.
+//
+// On macOS (bridge networking), containers run inside a Docker Desktop VM
+// and must go through a special gateway to reach the host. We spawn a
+// short-lived alpine container with `host.docker.internal:host-gateway` in
+// ExtraHosts, resolve that name inside the container, and return the
+// resulting IP. Connecting to that IP from any subsequent container is
+// routed by Docker Desktop to the Mac host's loopback.
+//
+// We cannot use the literal string "host.docker.internal" because pytransformer's
+// parse_dns_overrides() validates the override target as IPv4 — hostnames
+// are rejected. We also cannot hardcode "127.0.0.1" on macOS because Docker
+// Desktop's bridge networking makes that the container's own loopback.
+func hostReachableIP(t *testing.T, pool *dockertest.Pool) string {
+	t.Helper()
+	if runtime.GOOS != "darwin" {
+		return "127.0.0.1"
+	}
+
+	// On Docker Desktop for Mac, host.docker.internal resolves to both an
+	// IPv4 and an IPv6 address. We need the IPv4 one because
+	// parse_dns_overrides() in pytransformer only accepts IPv4. musl's
+	// `getent ahostsv4` forces an IPv4-only lookup and returns lines of the
+	// form `<ipv4>  STREAM  host.docker.internal` — the first field is the
+	// IPv4 we want.
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: "alpine",
+		Tag:        "3",
+		Entrypoint: []string{"/bin/sh", "-c"},
+		Cmd:        []string{"getent ahostsv4 host.docker.internal | awk 'NR==1 {print $1}'"},
+		ExtraHosts: []string{"host.docker.internal:host-gateway"},
+	})
+	require.NoError(t, err, "failed to start alpine helper container")
+	t.Cleanup(func() { _ = pool.Purge(resource) })
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	exit, err := pool.Client.WaitContainerWithContext(resource.Container.ID, ctx)
+	require.NoError(t, err, "failed to wait for alpine helper container")
+	require.Zero(t, exit, "alpine helper container exited non-zero")
+
+	var buf bytes.Buffer
+	err = pool.Client.Logs(docker.LogsOptions{
+		Container:    resource.Container.ID,
+		OutputStream: &buf,
+		Stdout:       true,
+	})
+	require.NoError(t, err, "failed to read alpine helper container logs")
+
+	ip := strings.TrimSpace(buf.String())
+	require.NotEmpty(t, ip, "could not resolve host.docker.internal inside helper container")
+	parsed := net.ParseIP(ip)
+	require.NotNil(t, parsed, "expected a valid IP from alpine helper, got %q", ip)
+	require.NotNil(t, parsed.To4(), "expected an IPv4 address (not IPv6), got %q", ip)
+	t.Logf("resolved host.docker.internal → %s", ip)
+	return ip
 }
 
 // newMockAPIServer creates a test HTTP server that responds to all requests

--- a/integration_test/pytransformer_contract/dns_cache_contract_test.go
+++ b/integration_test/pytransformer_contract/dns_cache_contract_test.go
@@ -1,0 +1,365 @@
+package pytransformer_contract
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+
+	"github.com/rudderlabs/rudder-server/processor/types"
+)
+
+// newMockAPIServer creates a test HTTP server that responds to all requests
+// with a JSON payload identifying the server. Tracks invocation count.
+func newMockAPIServer(t *testing.T, name string) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	calls := &atomic.Int64{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = jsonrs.NewEncoder(w).Encode(map[string]string{"server": name})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, calls
+}
+
+// sendRawTransform sends events directly to pytransformer's /customTransform
+// endpoint and returns the HTTP status code and parsed response items.
+// Unlike the usertransformer.Client, this allows inspecting raw HTTP status.
+func sendRawTransform(t *testing.T, baseURL string, events []types.TransformerEvent) (int, []types.TransformerResponse) {
+	t.Helper()
+	payload := make([]any, len(events))
+	for i, ev := range events {
+		payload[i] = map[string]any{
+			"message":  ev.Message,
+			"metadata": ev.Metadata,
+			"destination": map[string]any{
+				"Transformations": ev.Destination.Transformations,
+			},
+		}
+	}
+	body, err := jsonrs.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", baseURL+"/customTransform", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var items []types.TransformerResponse
+	if len(respBody) > 0 {
+		err = jsonrs.Unmarshal(respBody, &items)
+		require.NoError(t, err, "failed to parse response: %s", string(respBody))
+	}
+	return resp.StatusCode, items
+}
+
+// TestDNSCaching verifies that DNS caching in pytransformer works correctly
+// and does not cause cross-request pollution.
+//
+// A single pytransformer container is started with DNS_CACHE_ENABLED=true.
+// Four mock API servers (alpha, bravo, charlie, delta) each return a unique
+// identifier. Four transformation versions each call a different mock server.
+// The tests verify that sequential and parallel requests always reach the
+// correct mock server, proving the DNS cache does not pollute across requests.
+func TestDNSCaching(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
+
+	names := []string{"alpha", "bravo", "charlie", "delta"}
+
+	type mockServer struct {
+		server *httptest.Server
+		calls  *atomic.Int64
+	}
+	mocks := make(map[string]mockServer, len(names))
+	versionIDs := make(map[string]string, len(names))
+	entries := make(map[string]configBackendEntry, len(names))
+
+	for _, name := range names {
+		srv, calls := newMockAPIServer(t, name)
+		mocks[name] = mockServer{server: srv, calls: calls}
+		vid := "dns-cache-" + name + "-v1"
+		versionIDs[name] = vid
+		entries[vid] = configBackendEntry{
+			code: fmt.Sprintf(`
+import requests
+
+def transformEvent(event, metadata):
+    resp = requests.get("%s/data", timeout=5)
+    event['external'] = resp.json()
+    return event
+`, toContainerURL(srv.URL)),
+		}
+	}
+
+	configBackend := newContractConfigBackend(t, entries)
+	t.Cleanup(configBackend.Close)
+
+	container, pyURL := startRudderPytransformer(
+		t, pool, configBackend.URL,
+		"DNS_CACHE_ENABLED=true",
+		"DNS_CACHE_TTL_S=300",
+	)
+	t.Cleanup(func() { _ = pool.Purge(container) })
+	waitForHealthy(t, pool, pyURL, "pytransformer", container)
+
+	// requireCorrectServer asserts that the response contains a single
+	// successfully transformed event whose external.server field matches
+	// the expected mock server name.
+	requireCorrectServer := func(t *testing.T, name string, status int, items []types.TransformerResponse) {
+		t.Helper()
+		require.Equal(t, http.StatusOK, status, "HTTP status for %s", name)
+		require.Equal(t, 1, len(items), "expected 1 item for %s", name)
+		require.Equal(t, 200, items[0].StatusCode, "event status for %s: error=%s", name, items[0].Error)
+
+		external, ok := items[0].Output["external"].(map[string]any)
+		require.True(t, ok, "external field should be a map for %s, got %v", name, items[0].Output["external"])
+		require.Equal(t, name, external["server"],
+			"should reach mock server %s, not another (DNS cache pollution check)", name)
+	}
+
+	t.Run("SequentialRequestsNoPollution", func(t *testing.T) {
+		// Send one request per mock server, sequentially
+		for _, name := range names {
+			events := []types.TransformerEvent{makeEvent("msg-"+name, versionIDs[name])}
+			status, items := sendRawTransform(t, pyURL, events)
+			requireCorrectServer(t, name, status, items)
+		}
+
+		// Now repeat the first two — DNS cache should still resolve correctly
+		for _, name := range []string{"alpha", "bravo"} {
+			events := []types.TransformerEvent{makeEvent("msg-"+name+"-repeat", versionIDs[name])}
+			status, items := sendRawTransform(t, pyURL, events)
+			requireCorrectServer(t, name, status, items)
+		}
+	})
+
+	t.Run("ParallelRequestsNoPollution", func(t *testing.T) {
+		// Send 4 requests in parallel, each calling a different mock server
+		for _, name := range names {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				events := []types.TransformerEvent{makeEvent("msg-parallel-"+name, versionIDs[name])}
+				status, items := sendRawTransform(t, pyURL, events)
+				requireCorrectServer(t, name, status, items)
+			})
+		}
+	})
+
+	t.Run("RepeatedRequestsSameEndpoint", func(t *testing.T) {
+		// Same transformation 3 times — DNS cache must remain correct
+		for i := 0; i < 3; i++ {
+			events := []types.TransformerEvent{makeEvent(fmt.Sprintf("msg-repeat-%d", i), versionIDs["alpha"])}
+			status, items := sendRawTransform(t, pyURL, events)
+			requireCorrectServer(t, "alpha", status, items)
+		}
+	})
+}
+
+// TestDNSOverrides verifies that the DNS_OVERRIDES environment variable
+// correctly overrides DNS resolution for transformation HTTP calls.
+//
+// A mock HTTP server runs on the host. DNS_OVERRIDES maps a fake hostname
+// (custom-api.test) to 127.0.0.1. The transformation calls
+// http://custom-api.test:PORT/data and should reach the mock server.
+//
+// Only runs on Linux (host networking) — on macOS, 127.0.0.1 inside the
+// container is the container's loopback, not the host's.
+func TestDNSOverrides(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("DNS override contract test requires host networking (Linux/CI only)")
+	}
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
+
+	mockSrv, mockCalls := newMockAPIServer(t, "override-target")
+
+	u, err := url.Parse(mockSrv.URL)
+	require.NoError(t, err)
+	mockPort := u.Port()
+
+	const versionID = "dns-override-v1"
+	entries := map[string]configBackendEntry{
+		versionID: {
+			code: fmt.Sprintf(`
+import requests
+
+def transformEvent(event, metadata):
+    resp = requests.get("http://custom-api.test:%s/data", timeout=5)
+    event['external'] = resp.json()
+    return event
+`, mockPort),
+		},
+	}
+
+	configBackend := newContractConfigBackend(t, entries)
+	t.Cleanup(configBackend.Close)
+
+	container, pyURL := startRudderPytransformer(
+		t, pool, configBackend.URL,
+		"DNS_OVERRIDES=custom-api.test,127.0.0.1",
+	)
+	t.Cleanup(func() { _ = pool.Purge(container) })
+	waitForHealthy(t, pool, pyURL, "pytransformer", container)
+
+	t.Run("OverrideResolvesToCorrectServer", func(t *testing.T) {
+		events := []types.TransformerEvent{makeEvent("msg-override-1", versionID)}
+		status, items := sendRawTransform(t, pyURL, events)
+
+		require.Equal(t, http.StatusOK, status)
+		require.Equal(t, 1, len(items))
+		require.Equal(t, 200, items[0].StatusCode, "event error: %s", items[0].Error)
+
+		external, ok := items[0].Output["external"].(map[string]any)
+		require.True(t, ok, "external should be a map")
+		require.Equal(t, "override-target", external["server"],
+			"DNS override should route custom-api.test to the mock server")
+		require.GreaterOrEqual(t, mockCalls.Load(), int64(1),
+			"mock server should have been called")
+	})
+
+	t.Run("OverrideWorksOnRepeatedCalls", func(t *testing.T) {
+		callsBefore := mockCalls.Load()
+		for i := 0; i < 3; i++ {
+			events := []types.TransformerEvent{makeEvent(fmt.Sprintf("msg-override-repeat-%d", i), versionID)}
+			status, items := sendRawTransform(t, pyURL, events)
+
+			require.Equal(t, http.StatusOK, status)
+			require.Equal(t, 1, len(items))
+			require.Equal(t, 200, items[0].StatusCode, "event error: %s", items[0].Error)
+
+			external := items[0].Output["external"].(map[string]any)
+			require.Equal(t, "override-target", external["server"])
+		}
+		require.GreaterOrEqual(t, mockCalls.Load(), callsBefore+3,
+			"mock server should have been called 3 more times")
+	})
+}
+
+// TestDNSCachingWithOverrides verifies that DNS caching and DNS overrides
+// work correctly together — overrides are served from the override map
+// (not from the DNS cache), while non-overridden hosts use the DNS cache.
+func TestDNSCachingWithOverrides(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("requires host networking (Linux/CI only)")
+	}
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
+
+	// Mock server A: reached via DNS override (custom-api.test → 127.0.0.1)
+	mockSrvA, _ := newMockAPIServer(t, "override-server")
+	uA, err := url.Parse(mockSrvA.URL)
+	require.NoError(t, err)
+	portA := uA.Port()
+
+	// Mock server B: reached via normal DNS resolution (localhost)
+	mockSrvB, _ := newMockAPIServer(t, "cached-server")
+
+	const (
+		versionOverride = "dns-combined-override-v1"
+		versionCached   = "dns-combined-cached-v1"
+	)
+
+	entries := map[string]configBackendEntry{
+		versionOverride: {
+			code: fmt.Sprintf(`
+import requests
+
+def transformEvent(event, metadata):
+    resp = requests.get("http://custom-api.test:%s/data", timeout=5)
+    event['external'] = resp.json()
+    return event
+`, portA),
+		},
+		versionCached: {
+			code: fmt.Sprintf(`
+import requests
+
+def transformEvent(event, metadata):
+    resp = requests.get("%s/data", timeout=5)
+    event['external'] = resp.json()
+    return event
+`, mockSrvB.URL),
+		},
+	}
+
+	configBackend := newContractConfigBackend(t, entries)
+	t.Cleanup(configBackend.Close)
+
+	container, pyURL := startRudderPytransformer(
+		t, pool, configBackend.URL,
+		"DNS_CACHE_ENABLED=true",
+		"DNS_CACHE_TTL_S=300",
+		"DNS_OVERRIDES=custom-api.test,127.0.0.1",
+	)
+	t.Cleanup(func() { _ = pool.Purge(container) })
+	waitForHealthy(t, pool, pyURL, "pytransformer", container)
+
+	// Interleave requests between override and cached paths
+	var wg sync.WaitGroup
+	type result struct {
+		label          string
+		expectedServer string
+		status         int
+		items          []types.TransformerResponse
+	}
+	results := make([]result, 4)
+
+	wg.Go(func() {
+		events := []types.TransformerEvent{makeEvent("msg-combined-override-1", versionOverride)}
+		s, items := sendRawTransform(t, pyURL, events)
+		results[0] = result{"override-1", "override-server", s, items}
+	})
+	wg.Go(func() {
+		events := []types.TransformerEvent{makeEvent("msg-combined-cached-1", versionCached)}
+		s, items := sendRawTransform(t, pyURL, events)
+		results[1] = result{"cached-1", "cached-server", s, items}
+	})
+	wg.Go(func() {
+		events := []types.TransformerEvent{makeEvent("msg-combined-override-2", versionOverride)}
+		s, items := sendRawTransform(t, pyURL, events)
+		results[2] = result{"override-2", "override-server", s, items}
+	})
+	wg.Go(func() {
+		events := []types.TransformerEvent{makeEvent("msg-combined-cached-2", versionCached)}
+		s, items := sendRawTransform(t, pyURL, events)
+		results[3] = result{"cached-2", "cached-server", s, items}
+	})
+	wg.Wait()
+
+	for _, r := range results {
+		require.Equal(t, http.StatusOK, r.status, "HTTP status for %s", r.label)
+		require.Equal(t, 1, len(r.items), "expected 1 item for %s", r.label)
+		require.Equal(t, 200, r.items[0].StatusCode,
+			"event status for %s: error=%s", r.label, r.items[0].Error)
+
+		external, ok := r.items[0].Output["external"].(map[string]any)
+		require.True(t, ok, "external should be a map for %s", r.label)
+		require.Equal(t, r.expectedServer, external["server"],
+			"%s should reach %s", r.label, r.expectedServer)
+	}
+}

--- a/integration_test/pytransformer_contract/dns_cache_contract_test.go
+++ b/integration_test/pytransformer_contract/dns_cache_contract_test.go
@@ -3,7 +3,6 @@ package pytransformer_contract
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -16,61 +15,11 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-go-kit/httputil"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 
 	"github.com/rudderlabs/rudder-server/processor/types"
 )
-
-// newMockAPIServer creates a test HTTP server that responds to all requests
-// with a JSON payload identifying the server. Tracks invocation count.
-func newMockAPIServer(t *testing.T, name string) (*httptest.Server, *atomic.Int64) {
-	t.Helper()
-	calls := &atomic.Int64{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls.Add(1)
-		w.Header().Set("Content-Type", "application/json")
-		_ = jsonrs.NewEncoder(w).Encode(map[string]string{"server": name})
-	}))
-	t.Cleanup(srv.Close)
-	return srv, calls
-}
-
-// sendRawTransform sends events directly to pytransformer's /customTransform
-// endpoint and returns the HTTP status code and parsed response items.
-// Unlike the usertransformer.Client, this allows inspecting raw HTTP status.
-func sendRawTransform(t *testing.T, baseURL string, events []types.TransformerEvent) (int, []types.TransformerResponse) {
-	t.Helper()
-	payload := make([]any, len(events))
-	for i, ev := range events {
-		payload[i] = map[string]any{
-			"message":  ev.Message,
-			"metadata": ev.Metadata,
-			"destination": map[string]any{
-				"Transformations": ev.Destination.Transformations,
-			},
-		}
-	}
-	body, err := jsonrs.Marshal(payload)
-	require.NoError(t, err)
-
-	req, err := http.NewRequest("POST", baseURL+"/customTransform", bytes.NewReader(body))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	var items []types.TransformerResponse
-	if len(respBody) > 0 {
-		err = jsonrs.Unmarshal(respBody, &items)
-		require.NoError(t, err, "failed to parse response: %s", string(respBody))
-	}
-	return resp.StatusCode, items
-}
 
 // TestDNSCaching verifies that DNS caching in pytransformer works correctly
 // and does not cause cross-request pollution.
@@ -129,8 +78,8 @@ def transformEvent(event, metadata):
 	requireCorrectServer := func(t *testing.T, name string, status int, items []types.TransformerResponse) {
 		t.Helper()
 		require.Equal(t, http.StatusOK, status, "HTTP status for %s", name)
-		require.Equal(t, 1, len(items), "expected 1 item for %s", name)
-		require.Equal(t, 200, items[0].StatusCode, "event status for %s: error=%s", name, items[0].Error)
+		require.Len(t, items, 1, "expected 1 item for %s", name)
+		require.Equal(t, http.StatusOK, items[0].StatusCode, "event status for %s: error=%s", name, items[0].Error)
 
 		external, ok := items[0].Output["external"].(map[string]any)
 		require.True(t, ok, "external field should be a map for %s, got %v", name, items[0].Output["external"])
@@ -138,12 +87,28 @@ def transformEvent(event, metadata):
 			"should reach mock server %s, not another (DNS cache pollution check)", name)
 	}
 
+	// resetCallCounts zeroes every mock server's invocation counter so each
+	// subtest can assert absolute call counts independently.
+	resetCallCounts := func() {
+		for _, m := range mocks {
+			m.calls.Store(0)
+		}
+	}
+
 	t.Run("SequentialRequestsNoPollution", func(t *testing.T) {
+		resetCallCounts()
+
 		// Send one request per mock server, sequentially
 		for _, name := range names {
 			events := []types.TransformerEvent{makeEvent("msg-"+name, versionIDs[name])}
 			status, items := sendRawTransform(t, pyURL, events)
 			requireCorrectServer(t, name, status, items)
+		}
+
+		// After one request to each, every mock should have been hit exactly once
+		for _, name := range names {
+			require.EqualValues(t, 1, mocks[name].calls.Load(),
+				"mock server %s should have been called exactly once", name)
 		}
 
 		// Now repeat the first two — DNS cache should still resolve correctly
@@ -152,26 +117,64 @@ def transformEvent(event, metadata):
 			status, items := sendRawTransform(t, pyURL, events)
 			requireCorrectServer(t, name, status, items)
 		}
+
+		// alpha/bravo now called twice; charlie/delta still once (no pollution)
+		require.EqualValues(t, 2, mocks["alpha"].calls.Load(), "alpha should be called twice")
+		require.EqualValues(t, 2, mocks["bravo"].calls.Load(), "bravo should be called twice")
+		require.EqualValues(t, 1, mocks["charlie"].calls.Load(), "charlie should not be called again")
+		require.EqualValues(t, 1, mocks["delta"].calls.Load(), "delta should not be called again")
 	})
 
 	t.Run("ParallelRequestsNoPollution", func(t *testing.T) {
-		// Send 4 requests in parallel, each calling a different mock server
-		for _, name := range names {
-			t.Run(name, func(t *testing.T) {
-				t.Parallel()
-				events := []types.TransformerEvent{makeEvent("msg-parallel-"+name, versionIDs[name])}
+		resetCallCounts()
+
+		// Send 4 requests in parallel, each calling a different mock server.
+		// Using wg.Go (instead of t.Parallel() subtests) so we can verify the
+		// call counts once all requests have finished.
+		type result struct {
+			name   string
+			status int
+			items  []types.TransformerResponse
+		}
+		results := make([]result, len(names))
+		var wg sync.WaitGroup
+		for i, name := range names {
+			idx, n := i, name
+			wg.Go(func() {
+				events := []types.TransformerEvent{makeEvent("msg-parallel-"+n, versionIDs[n])}
 				status, items := sendRawTransform(t, pyURL, events)
-				requireCorrectServer(t, name, status, items)
+				results[idx] = result{name: n, status: status, items: items}
 			})
+		}
+		wg.Wait()
+
+		for _, r := range results {
+			requireCorrectServer(t, r.name, r.status, r.items)
+		}
+
+		// Each mock should have been called exactly once — proves parallel
+		// requests did not cross-pollute via a shared DNS cache.
+		for _, name := range names {
+			require.EqualValues(t, 1, mocks[name].calls.Load(),
+				"parallel: mock server %s should have been called exactly once", name)
 		}
 	})
 
 	t.Run("RepeatedRequestsSameEndpoint", func(t *testing.T) {
+		resetCallCounts()
+
 		// Same transformation 3 times — DNS cache must remain correct
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			events := []types.TransformerEvent{makeEvent(fmt.Sprintf("msg-repeat-%d", i), versionIDs["alpha"])}
 			status, items := sendRawTransform(t, pyURL, events)
 			requireCorrectServer(t, "alpha", status, items)
+		}
+
+		// alpha called 3 times; others never touched
+		require.Equal(t, int64(3), mocks["alpha"].calls.Load(), "alpha should be called 3 times")
+		for _, name := range []string{"bravo", "charlie", "delta"} {
+			require.Equal(t, int64(0), mocks[name].calls.Load(),
+				"mock server %s should not have been called", name)
 		}
 	})
 }
@@ -242,7 +245,7 @@ def transformEvent(event, metadata):
 
 	t.Run("OverrideWorksOnRepeatedCalls", func(t *testing.T) {
 		callsBefore := mockCalls.Load()
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			events := []types.TransformerEvent{makeEvent(fmt.Sprintf("msg-override-repeat-%d", i), versionID)}
 			status, items := sendRawTransform(t, pyURL, events)
 
@@ -362,4 +365,57 @@ def transformEvent(event, metadata):
 		require.Equal(t, r.expectedServer, external["server"],
 			"%s should reach %s", r.label, r.expectedServer)
 	}
+}
+
+// newMockAPIServer creates a test HTTP server that responds to all requests
+// with a JSON payload identifying the server. Tracks invocation count.
+func newMockAPIServer(t *testing.T, name string) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	calls := &atomic.Int64{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = jsonrs.NewEncoder(w).Encode(map[string]string{"server": name})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, calls
+}
+
+// sendRawTransform sends events directly to pytransformer's /customTransform
+// endpoint and returns the HTTP status code and parsed response items.
+// Unlike the usertransformer.Client, this allows inspecting raw HTTP status.
+func sendRawTransform(
+	t *testing.T,
+	baseURL string,
+	events []types.TransformerEvent,
+) (
+	int,
+	[]types.TransformerResponse,
+) {
+	t.Helper()
+	payload := make([]any, len(events))
+	for i, ev := range events {
+		payload[i] = map[string]any{
+			"message":  ev.Message,
+			"metadata": ev.Metadata,
+			"destination": map[string]any{
+				"Transformations": ev.Destination.Transformations,
+			},
+		}
+	}
+	body, err := jsonrs.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", baseURL+"/customTransform", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httputil.DefaultHttpClient().Do(req)
+	require.NoError(t, err)
+	defer func() { httputil.CloseResponse(resp) }()
+
+	var items []types.TransformerResponse
+	require.NoError(t, jsonrs.NewDecoder(resp.Body).Decode(&items))
+
+	return resp.StatusCode, items
 }


### PR DESCRIPTION
# Description

New PyTransfomer Contract Tests to cover DNS overrides and DNS regressions.

## Linear Ticket

< Fixes [PIPE-2720](https://linear.app/rudderstack/issue/PIPE-2896/dns-pyt-contract-tests)  >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
