### PR TITLE
feat(jobsdb): improve migration compaction

### DIFF
--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -321,8 +321,7 @@ func (webhook *HandleT) batchRequests(sourceDef string, requestQ chan *webhookT)
 func (bt *batchWebhookTransformerT) batchTransformLoop() {
 	for breq := range bt.webhook.batchRequestQ {
 		// If unable to fetch features from transformer, send GatewayTimeout to all requests
-		// TODO: Remove timeout from here after timeout handler is added in gateway
-		ctx, cancel := context.WithTimeout(context.Background(), config.GetDurationVar(10, time.Second, "WriteTimeout", "WriteTimeOutInSec"))
+		ctx := breq.batchRequest[0].request.Context()
 		sourceTransformAdapter, err := bt.sourceTransformAdapter(ctx)
 		if err != nil {
 			bt.webhook.logger.Errorn("webhook source transformation failed",
@@ -332,10 +331,8 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 			for _, req := range breq.batchRequest {
 				req.done <- transformerResponse{StatusCode: response.GetErrorStatusCode(response.GatewayTimeout), Err: response.GetStatus(response.GatewayTimeout)}
 			}
-			cancel()
 			continue
 		}
-		cancel()
 
 		transformerURL, err := sourceTransformAdapter.getTransformerURL(breq.sourceType)
 		if err != nil {

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -476,14 +476,7 @@ func (jd *Handle) getMigrationList(dsList []dataSetT, skipBefore *dsindex.Index)
 			}
 		}
 
-		var idxCheck bool
-		if jd.ownerType == Read {
-			// if jobsdb owner is read, exempting the last two datasets from migration.
-			// This is done to avoid dsList conflicts between reader and writer
-			idxCheck = idx == len(dsList)-1 || idx == len(dsList)-2
-		} else {
-			idxCheck = idx == len(dsList)-1
-		}
+			idxCheck := idx == len(dsList)-1 // last DS is exempt
 
 		if liveDSCount >= jd.conf.migration.maxMigrateOnce.Load() || result.pendingJobsCount >= maxDSSize || idxCheck {
 			break
@@ -503,9 +496,6 @@ func (jd *Handle) getMigrationList(dsList []dataSetT, skipBefore *dsindex.Index)
 		)
 
 		if migrate {
-			if result.firstEligible == nil {
-				result.firstEligible = dsindex.MustParse(ds.Index)
-			}
 			if !needsPair {
 				result.migrateFrom = append(result.migrateFrom, dsWithPendingJobCount{ds: ds, numJobsPending: recordsLeft})
 				result.insertBeforeDS = dsList[idx+1]
@@ -513,17 +503,25 @@ func (jd *Handle) getMigrationList(dsList []dataSetT, skipBefore *dsindex.Index)
 				liveDSCount++
 			} else {
 				if waiting != nil { // have another dataset waiting for a pair
-					result.migrateFrom = append(result.migrateFrom, *waiting, dsWithPendingJobCount{ds: ds, numJobsPending: recordsLeft})
-					result.insertBeforeDS = dsList[idx+1]
-					result.pendingJobsCount += waiting.numJobsPending + recordsLeft
-					liveDSCount += 2
+				// guard: pair's combined count must not exceed maxDSSize
+				if waiting.numJobsPending+recordsLeft > maxDSSize {
 					waiting = nil
+					continue
+				}
+				result.migrateFrom = append(result.migrateFrom, *waiting, dsWithPendingJobCount{ds: ds, numJobsPending: recordsLeft})
+				result.insertBeforeDS = dsList[idx+1]
+				result.pendingJobsCount += waiting.numJobsPending + recordsLeft
+				liveDSCount += 2
+				waiting = nil
 				} else if result.pendingJobsCount > 0 { // we already know that we'll be migrating another dataset with pending jobs, so can add this one too
-					result.migrateFrom = append(result.migrateFrom, dsWithPendingJobCount{ds: ds, numJobsPending: recordsLeft})
-					result.insertBeforeDS = dsList[idx+1]
-					result.pendingJobsCount += recordsLeft
-					liveDSCount++
-					waiting = nil
+				if result.pendingJobsCount+recordsLeft > maxDSSize { // guard: ensure we don't exceed maxDSSize
+					break
+				}
+				result.migrateFrom = append(result.migrateFrom, dsWithPendingJobCount{ds: ds, numJobsPending: recordsLeft})
+				result.insertBeforeDS = dsList[idx+1]
+				result.pendingJobsCount += recordsLeft
+				liveDSCount++
+				waiting = nil
 				} else { // add the current DS as waiting for the next iteration to pickup
 					waiting = &dsWithPendingJobCount{ds: ds, numJobsPending: recordsLeft}
 				}
@@ -540,11 +538,9 @@ func (jd *Handle) getMigrationList(dsList []dataSetT, skipBefore *dsindex.Index)
 		}
 		migrateDSProbeCount++
 	}
-	// if we didn't find any eligible datasets, reset firstEligible to nil to avoid confusion,
-	// since a non-nil firstEligible with an empty migrateFrom slice would be contradictory,
-	// e.g. the case of needsPair without a pair actually being found.
-	if len(result.migrateFrom) == 0 {
-		result.firstEligible = nil
+	// Derive firstEligible from the first dataset we're actually migrating (if any)
+	if len(result.migrateFrom) > 0 {
+		result.firstEligible = dsindex.MustParse(result.migrateFrom[0].ds.Index)
 	}
 	return result, nil
 }


### PR DESCRIPTION
## Summary

- Writers only write to the last dataset, so shrinking their datasetList to only the last one (instead of last two) is sufficient.
- Migration now exempts only the last (currently-written) dataset from migration for both Read and ReadWrite owner types.
- Added two guards to getMigrationList 
eedsPair branch to ensure the destination dataset never exceeds maxDSSize pending jobs.
- irstEligible is now derived from migrateFrom[0] at the end of the loop.

## Security
- Scanned for secrets using gitleaks