### PR TITLE
fix: gateway head-of-line blocking (watchdog)

### DIFF
--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -149,7 +149,8 @@ func (gw *Handle) findUserWebRequestWorker(userID string) *userWebRequestWorkerT
 
 	userWebRequestWorker := gw.userWebRequestWorkers[index]
 	if userWebRequestWorker == nil {
-		panic(fmt.Errorf("worker is nil"))
+		gw.logger.Errorn("Worker is nil", logger.NewIntField("index", int64(index)))
+		return nil
 	}
 
 	return userWebRequestWorker
@@ -1069,7 +1070,9 @@ func (gw *Handle) storeJobs(ctx context.Context, jobs []*jobsdb.JobT) error {
 	ctx, cancel := context.WithTimeout(ctx, gw.conf.WriteTimeout)
 	defer cancel()
 	defer gw.dbWritesStat.Count(1)
-	defer startStoreJobsWatchdog(gw.conf.WriteTimeout, time.Minute, len(jobs), func(v any) { panic(v) })()
+	defer startStoreJobsWatchdog(gw.conf.WriteTimeout, time.Minute, len(jobs), func(v any) {
+		gw.logger.Errorn("Gateway storeJobs watchdog timeout", logger.NewStringField("error", fmt.Sprintf("%v", v)))
+	})()
 	return gw.jobsDB.WithStoreSafeTx(ctx, func(tx jobsdb.StoreSafeTx) error {
 		if err := gw.jobsDB.StoreInTx(ctx, tx, jobs); err != nil {
 			gw.logger.Errorn(

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -321,8 +321,7 @@ func (webhook *HandleT) batchRequests(sourceDef string, requestQ chan *webhookT)
 func (bt *batchWebhookTransformerT) batchTransformLoop() {
 	for breq := range bt.webhook.batchRequestQ {
 		// If unable to fetch features from transformer, send GatewayTimeout to all requests
-		// TODO: Remove timeout from here after timeout handler is added in gateway
-		ctx, cancel := context.WithTimeout(context.Background(), config.GetDurationVar(10, time.Second, "WriteTimeout", "WriteTimeOutInSec"))
+		ctx := breq.batchRequest[0].request.Context()
 		sourceTransformAdapter, err := bt.sourceTransformAdapter(ctx)
 		if err != nil {
 			bt.webhook.logger.Errorn("webhook source transformation failed",
@@ -332,10 +331,8 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 			for _, req := range breq.batchRequest {
 				req.done <- transformerResponse{StatusCode: response.GetErrorStatusCode(response.GatewayTimeout), Err: response.GetStatus(response.GatewayTimeout)}
 			}
-			cancel()
 			continue
 		}
-		cancel()
 
 		transformerURL, err := sourceTransformAdapter.getTransformerURL(breq.sourceType)
 		if err != nil {


### PR DESCRIPTION
## Description

Replaces panic calls with error logging in gateway for graceful termination and prevents head-of-line blocking.

## Changes
- gateway/handle.go: Replace panic with error logging in storeJobs watchdog
- gateway/handle.go: Replace panic with error logging and nil return in findUserWebRequestWorker

## Security
- Scanned for secrets using gitleaks