### PR TITLE
feat: add configurable batch size for bulk inserting failed rsources records

### DIFF
--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -70,6 +70,7 @@ func NewRsourcesService(deploymentType deployment.Type, shouldSetupSharedDB bool
 	}
 	rsourcesConfig.SharedConn = sharedDBConnUrl
 	rsourcesConfig.SkipFailedRecordsCollection = !config.GetBoolVar(true, "Router.failedKeysEnabled")
+	rsourcesConfig.FailedRecordsInsertBatchSize = config.GetIntVar(5000, 1, "Rsources.failedRecordsInsertBatchSize")
 
 	if deploymentType == deployment.MultiTenantType {
 		// For multitenant deployment type we shall require the existence of a SHARED_DB

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -70,7 +70,7 @@ func NewRsourcesService(deploymentType deployment.Type, shouldSetupSharedDB bool
 	}
 	rsourcesConfig.SharedConn = sharedDBConnUrl
 	rsourcesConfig.SkipFailedRecordsCollection = !config.GetBoolVar(true, "Router.failedKeysEnabled")
-	rsourcesConfig.FailedRecordsInsertBatchSize = config.GetIntVar(5000, 1, "Rsources.failedRecordsInsertBatchSize")
+	rsourcesConfig.FailedRecordsInsertBatchSize = config.GetReloadableIntVar(5000, 1, "Rsources.failedRecordsInsertBatchSize")
 
 	if deploymentType == deployment.MultiTenantType {
 		// For multitenant deployment type we shall require the existence of a SHARED_DB

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -128,10 +128,7 @@ func (sh *sourcesHandler) AddFailedRecords(ctx context.Context, tx *sql.Tx, jobR
 		return fmt.Errorf("scanning rsources_failed_keys_v2 id: %w", err)
 	}
 
-	batchSize := 5000
-	if sh.config.FailedRecordsInsertBatchSize != nil && sh.config.FailedRecordsInsertBatchSize.Load() > 0 {
-		batchSize = sh.config.FailedRecordsInsertBatchSize.Load()
-	}
+	batchSize := max(1, sh.config.FailedRecordsInsertBatchSize.Load())
 
 	for start := 0; start < len(records); start += batchSize {
 		end := min(start+batchSize, len(records))

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -128,9 +128,9 @@ func (sh *sourcesHandler) AddFailedRecords(ctx context.Context, tx *sql.Tx, jobR
 		return fmt.Errorf("scanning rsources_failed_keys_v2 id: %w", err)
 	}
 
-	batchSize := sh.config.FailedRecordsInsertBatchSize
-	if batchSize <= 0 {
-		batchSize = 5000
+	batchSize := 5000
+	if sh.config.FailedRecordsInsertBatchSize != nil && sh.config.FailedRecordsInsertBatchSize.Load() > 0 {
+		batchSize = sh.config.FailedRecordsInsertBatchSize.Load()
 	}
 
 	for start := 0; start < len(records); start += batchSize {

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -131,7 +131,8 @@ func (sh *sourcesHandler) AddFailedRecords(ctx context.Context, tx *sql.Tx, jobR
 
 	batchSize := sh.config.FailedRecordsInsertBatchSize
 	defaultFailedRecordsBatchSize := 5000
-	if batchSize <= 0 {
+	maxQweryParamsForPostgres := 65535
+	if batchSize <= 0 || batchSize > (maxQweryParamsForPostgres/3) {
 		batchSize = defaultFailedRecordsBatchSize
 	}
 

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -128,19 +129,36 @@ func (sh *sourcesHandler) AddFailedRecords(ctx context.Context, tx *sql.Tx, jobR
 		return fmt.Errorf("scanning rsources_failed_keys_v2 id: %w", err)
 	}
 
-	stmt, err := tx.Prepare(`INSERT INTO rsources_failed_keys_v2_records (id, record_id, code) VALUES ($1, $2, $3) ON CONFLICT (id, record_id) DO UPDATE SET ts = NOW()`)
-	if err != nil {
-		return err
+	batchSize := sh.config.FailedRecordsInsertBatchSize
+	defaultFailedRecordsBatchSize := 5000
+	if batchSize <= 0 {
+		batchSize = defaultFailedRecordsBatchSize
 	}
-	defer func() { _ = stmt.Close() }()
 
-	for i := range records {
-		if _, err = stmt.ExecContext(
-			ctx,
-			id,
-			records[i].Record,
-			records[i].Code,
-		); err != nil {
+	for start := 0; start < len(records); start += batchSize {
+		end := min(start+batchSize, len(records))
+		batch := records[start:end]
+
+		var sb strings.Builder
+		args := make([]any, 0, len(batch)*3)
+		sb.WriteString(`INSERT INTO rsources_failed_keys_v2_records (id, record_id, code) VALUES `)
+		for i, rec := range batch {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			paramIdx := i*3 + 1
+			sb.WriteString("($")
+			sb.WriteString(strconv.Itoa(paramIdx))
+			sb.WriteString(",$")
+			sb.WriteString(strconv.Itoa(paramIdx + 1))
+			sb.WriteString(",$")
+			sb.WriteString(strconv.Itoa(paramIdx + 2))
+			sb.WriteByte(')')
+			args = append(args, id, rec.Record, rec.Code)
+		}
+		sb.WriteString(` ON CONFLICT (id, record_id) DO UPDATE SET ts = NOW()`)
+
+		if _, err := tx.ExecContext(ctx, sb.String(), args...); err != nil {
 			return fmt.Errorf("inserting into rsources_failed_keys_v2_records: %w", err)
 		}
 	}

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -130,36 +129,29 @@ func (sh *sourcesHandler) AddFailedRecords(ctx context.Context, tx *sql.Tx, jobR
 	}
 
 	batchSize := sh.config.FailedRecordsInsertBatchSize
-	defaultFailedRecordsBatchSize := 5000
-	maxQweryParamsForPostgres := 65535
-	if batchSize <= 0 || batchSize > (maxQweryParamsForPostgres/3) {
-		batchSize = defaultFailedRecordsBatchSize
+	if batchSize <= 0 {
+		batchSize = 5000
 	}
 
 	for start := 0; start < len(records); start += batchSize {
 		end := min(start+batchSize, len(records))
 		batch := records[start:end]
 
-		var sb strings.Builder
-		args := make([]any, 0, len(batch)*3)
-		sb.WriteString(`INSERT INTO rsources_failed_keys_v2_records (id, record_id, code) VALUES `)
+		ids := make([]string, len(batch))
+		recordIDs := make([]string, len(batch))
+		codes := make([]int64, len(batch))
 		for i, rec := range batch {
-			if i > 0 {
-				sb.WriteByte(',')
-			}
-			paramIdx := i*3 + 1
-			sb.WriteString("($")
-			sb.WriteString(strconv.Itoa(paramIdx))
-			sb.WriteString(",$")
-			sb.WriteString(strconv.Itoa(paramIdx + 1))
-			sb.WriteString(",$")
-			sb.WriteString(strconv.Itoa(paramIdx + 2))
-			sb.WriteByte(')')
-			args = append(args, id, rec.Record, rec.Code)
+			ids[i] = id
+			recordIDs[i] = string(rec.Record)
+			codes[i] = int64(rec.Code)
 		}
-		sb.WriteString(` ON CONFLICT (id, record_id) DO UPDATE SET ts = NOW()`)
 
-		if _, err := tx.ExecContext(ctx, sb.String(), args...); err != nil {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO rsources_failed_keys_v2_records (id, record_id, code)
+			SELECT * FROM unnest($1::varchar(27)[], $2::text[], $3::numeric(4)[])
+			ON CONFLICT (id, record_id) DO UPDATE SET ts = NOW()`,
+			pq.Array(ids), pq.Array(recordIDs), pq.Array(codes),
+		); err != nil {
 			return fmt.Errorf("inserting into rsources_failed_keys_v2_records: %w", err)
 		}
 	}

--- a/services/rsources/handler_test.go
+++ b/services/rsources/handler_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Using sources handler", func() {
 		It("should be able to add and get failed records in multiple batches", func() {
 			handler := sh.(*sourcesHandler)
 			previous := handler.config.FailedRecordsInsertBatchSize
-			handler.config.FailedRecordsInsertBatchSize = 3 // force multiple batches
+			handler.config.FailedRecordsInsertBatchSize = config.GetReloadableIntVar(3, 1, "Rsources.failedRecordsInsertBatchSize")
 			defer func() { handler.config.FailedRecordsInsertBatchSize = previous }()
 
 			jobRunId := newJobRunId()

--- a/services/rsources/handler_test.go
+++ b/services/rsources/handler_test.go
@@ -152,6 +152,43 @@ var _ = Describe("Using sources handler", func() {
 			Expect(failedRecords.Paging).To(BeNil(), "last page should have no paging")
 		})
 
+		It("should be able to add and get failed records in multiple batches", func() {
+			handler := sh.(*sourcesHandler)
+			previous := handler.config.FailedRecordsInsertBatchSize
+			handler.config.FailedRecordsInsertBatchSize = 3 // force multiple batches
+			defer func() { handler.config.FailedRecordsInsertBatchSize = previous }()
+
+			jobRunId := newJobRunId()
+			records := make([]FailedRecord, 7)
+			expectedRecords := make([]FailedRecord, 7)
+			for i := range records {
+				record := fmt.Appendf(nil, `{"record-%d": "id-%d"}`, i+1, i+1)
+				records[i] = FailedRecord{Record: record, Code: i + 1}
+				expectedRecords[i] = FailedRecord{Record: record, Code: i + 1}
+			}
+			addFailedRecords(resource.db, jobRunId, defaultJobTargetKey, sh, records)
+
+			jobFilters := JobFilter{
+				SourceID:  []string{defaultJobTargetKey.SourceID},
+				TaskRunID: []string{defaultJobTargetKey.TaskRunID},
+			}
+			failedRecords, err := sh.GetFailedRecords(context.Background(), jobRunId, jobFilters, noPaging)
+			Expect(err).NotTo(HaveOccurred(), "it should be able to get failed records")
+			Expect(failedRecords).To(Equal(JobFailedRecordsV2{
+				ID: jobRunId,
+				Tasks: []TaskFailedRecords[FailedRecord]{{
+					ID: defaultJobTargetKey.TaskRunID,
+					Sources: []SourceFailedRecords[FailedRecord]{{
+						ID: defaultJobTargetKey.SourceID,
+						Destinations: []DestinationFailedRecords[FailedRecord]{{
+							ID:      defaultJobTargetKey.DestinationID,
+							Records: expectedRecords,
+						}},
+					}},
+				}},
+			}))
+		})
+
 		It("shouldn't be able to get failed records when failed records collection is disabled", func() {
 			handler := sh.(*sourcesHandler)
 			previous := handler.config.SkipFailedRecordsCollection

--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -247,45 +247,50 @@ type Gauger interface {
 	Gauge(any)
 }
 
-func NewJobService(config JobServiceConfig, stats stats.Stats) (JobService, error) {
-	if config.Log == nil {
-		config.Log = logger.NewLogger().Child("rsources")
+func NewJobService(jobServiceConfig JobServiceConfig, stats stats.Stats) (JobService, error) {
+	if jobServiceConfig.Log == nil {
+		jobServiceConfig.Log = logger.NewLogger().Child("rsources")
 	}
-	if config.MaxPoolSize <= 2 {
-		config.MaxPoolSize = 2 // minimum 2 connections in the pool for proper startup
+	if jobServiceConfig.MaxPoolSize <= 2 {
+		jobServiceConfig.MaxPoolSize = 2 // minimum 2 connections in the pool for proper startup
 	}
-	if config.MinPoolSize <= 0 {
-		config.MinPoolSize = 1
+	if jobServiceConfig.MinPoolSize <= 0 {
+		jobServiceConfig.MinPoolSize = 1
 	}
 	var (
 		localDB, sharedDB *sql.DB
 		err               error
 	)
 
-	localDB, err = sql.Open("postgres", config.LocalConn)
+	localDB, err = sql.Open("postgres", jobServiceConfig.LocalConn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create local postgresql connection pool: %w", err)
 	}
-	localDB.SetMaxOpenConns(config.MaxPoolSize)
+	localDB.SetMaxOpenConns(jobServiceConfig.MaxPoolSize)
 	err = stats.RegisterCollector(collectors.NewDatabaseSQLStats("rsources-local", localDB))
 	if err != nil {
 		return nil, fmt.Errorf("register local database stats collector: %w", err)
 	}
-	if config.SharedConn != "" {
-		sharedDB, err = sql.Open("postgres", config.SharedConn)
+	if jobServiceConfig.SharedConn != "" {
+		sharedDB, err = sql.Open("postgres", jobServiceConfig.SharedConn)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create shared postgresql connection pool: %w", err)
 		}
-		sharedDB.SetMaxOpenConns(config.MaxPoolSize)
-		sharedDB.SetMaxIdleConns(config.MinPoolSize)
+		sharedDB.SetMaxOpenConns(jobServiceConfig.MaxPoolSize)
+		sharedDB.SetMaxIdleConns(jobServiceConfig.MinPoolSize)
 		err = stats.RegisterCollector(collectors.NewDatabaseSQLStats("rsources-shared", sharedDB))
 		if err != nil {
 			return nil, fmt.Errorf("register shared database stats collector: %w", err)
 		}
 	}
+
+	if jobServiceConfig.FailedRecordsInsertBatchSize == nil {
+		jobServiceConfig.FailedRecordsInsertBatchSize = config.SingleValueLoader(5000)
+	}
+
 	handler := &sourcesHandler{
-		log:      config.Log,
-		config:   config,
+		log:      jobServiceConfig.Log,
+		config:   jobServiceConfig,
 		localDB:  localDB,
 		sharedDB: sharedDB,
 	}

--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -198,15 +198,16 @@ type StatsIncrementer interface {
 }
 
 type JobServiceConfig struct {
-	LocalHostname               string
-	LocalConn                   string
-	MaxPoolSize                 int
-	MinPoolSize                 int
-	SharedConn                  string
-	SubscriptionTargetConn      string
-	SkipFailedRecordsCollection bool
-	Log                         logger.Logger
-	ShouldSetupSharedDB         bool
+	LocalHostname                string
+	LocalConn                    string
+	MaxPoolSize                  int
+	MinPoolSize                  int
+	SharedConn                   string
+	SubscriptionTargetConn       string
+	SkipFailedRecordsCollection  bool
+	FailedRecordsInsertBatchSize int
+	Log                          logger.Logger
+	ShouldSetupSharedDB          bool
 }
 
 // JobService manages information about jobs created by rudder-sources

--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
@@ -205,7 +206,7 @@ type JobServiceConfig struct {
 	SharedConn                   string
 	SubscriptionTargetConn       string
 	SkipFailedRecordsCollection  bool
-	FailedRecordsInsertBatchSize int
+	FailedRecordsInsertBatchSize config.ValueLoader[int]
 	Log                          logger.Logger
 	ShouldSetupSharedDB          bool
 }


### PR DESCRIPTION
# Description

Txn Inserting into `rsources_failed_keys_v2_records` is taking too much time. The core bottleneck is `AddFailedRecords()` for rsources_stats. It uses tx.Prepare + a loop of individual stmt.ExecContext calls. Each ExecContext is a separate network round-trip to Postgres. If a batch
has 1,000 aborted jobs with record_ids, that's 1,000 sequential INSERT round-trips all within one transaction.

- Introduced batch processing for inserting failed records in `rsources_failed_keys_v2_records`
- Added FailedRecordsInsertBatchSize configuration to control batch size
- Implemented batch insert SQL statement with [unnest](https://www.tigerdata.com/blog/boosting-postgres-insert-performance)
- Updated unit tests to cover multi-batch scenarios
- Ensured default batch size is set when configuration is invalid

We could have used the COPY command, but the insert needs `ON CONFLICT (id, record_id) DO UPDATE SET ts = NOW()`, and COPY doesn't support ON CONFLICT

## Linear Ticket

-

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
