### PR TITLE
chore: update Slack notification method in scheduled release workflow

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -146,32 +146,20 @@ jobs:
       - name: Notify Slack
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
-          channel-id: ${{ secrets.SLACK_NOTIFICATIONS_CHANNEL_ID }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
           payload: |
-            {
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "${{ steps.create-branch.outputs.created == 'true' && format('Release Cut: v{0}', steps.version.outputs.version) || format('Release Cut Skipped: v{0}', steps.version.outputs.version) }}"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${{ steps.create-branch.outputs.created == 'true' && format('*Branch:* `{0}`\n*Version:* `{1}`\n*Cut from:* `master`', steps.version.outputs.branch, steps.version.outputs.version) || format('Branch `{0}` already exists. No action taken.', steps.version.outputs.branch) }}"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${{ steps.create-prerelease-branch.outputs.created == 'true' && format('*Prerelease Branch:* `{0}`', steps.version.outputs.prerelease_branch) || format('Prerelease branch `{0}` already exists. No action taken.', steps.version.outputs.prerelease_branch) }}"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+            channel: ${{ secrets.SLACK_NOTIFICATIONS_CHANNEL_ID }}
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: "${{ steps.create-branch.outputs.created == 'true' && format('Release Cut: v{0}', steps.version.outputs.version) || format('Release Cut Skipped: v{0}', steps.version.outputs.version) }}"
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.create-branch.outputs.created == 'true' && format('*Branch:* `{0}`\n*Version:* `{1}`\n*Cut from:* `master`', steps.version.outputs.branch, steps.version.outputs.version) || format('Branch `{0}` already exists. No action taken.', steps.version.outputs.branch) }}"
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "${{ steps.create-prerelease-branch.outputs.created == 'true' && format('*Prerelease Branch:* `{0}`', steps.version.outputs.prerelease_branch) || format('Prerelease branch `{0}` already exists. No action taken.', steps.version.outputs.prerelease_branch) }}"


### PR DESCRIPTION
# Description

post updating `slackapi/slack-github-action` to `v3.0.1` we need to migrate the deprecated params as well. 

ref: https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0

- Modify payload format to use chat.postMessage method
- Remove environment variable SLACK_BOT_TOKEN
- Update secrets to use SLACK_NOTIFICATIONS_BOT_TOKEN

## Linear Ticket

-

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
