### PR TITLE
test: pytransformer pooling contract tests

### DIFF
--- a/integration_test/pytransformer_contract/backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/backwards_compatibility_test.go
@@ -2063,12 +2063,7 @@ def transformEvent(event, metadata):
 	})
 
 	// Start shared rudder-pytransformer.
-	pyTransformerContainer, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
-	t.Cleanup(func() {
-		if err := pool.Purge(pyTransformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-pytransformer: %v", err)
-		}
-	})
+	_, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
 
 	// Wait for shared services to be healthy.
 	t.Log("Waiting for shared services to be healthy...")

--- a/integration_test/pytransformer_contract/backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/backwards_compatibility_test.go
@@ -2083,13 +2083,7 @@ def transformEvent(event, metadata):
 
 			if st.config.code != "" {
 				t.Logf("Starting openfaas-flask-base for %s (versionID=%s)...", st.name, st.versionID)
-				container, openFaasURL := startOpenFaasFlask(t, pool, st.versionID, configBackend.URL)
-				t.Cleanup(func() {
-					if err := pool.Purge(container); err != nil {
-						t.Logf("Failed to purge openfaas-flask-base: %v", err)
-					}
-				})
-				waitForOpenFaasFlask(t, pool, openFaasURL)
+				openFaasURL := startOpenFaasFlask(t, pool, st.versionID, configBackend.URL)
 
 				// Point the mock gateway to this subtest's openfaas container.
 				setGatewayTarget(openFaasURL)

--- a/integration_test/pytransformer_contract/backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/backwards_compatibility_test.go
@@ -2054,20 +2054,17 @@ def transformEvent(event, metadata):
 	mockGateway, _ := newMockOpenFaaSGateway(t, getGatewayTarget)
 	t.Cleanup(mockGateway.Close)
 
-	// Start shared rudder-transformer.
-	transformerContainer, transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
-	t.Cleanup(func() {
-		if err := pool.Purge(transformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-transformer: %v", err)
-		}
+	var (
+		wg                               sync.WaitGroup
+		transformerURL, pyTransformerURL string
+	)
+	wg.Go(func() {
+		transformerURL = startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
 	})
-
-	// Start shared rudder-pytransformer.
-	pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
-
-	// Wait for shared services to be healthy.
-	t.Log("Waiting for shared services to be healthy...")
-	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
+	wg.Go(func() {
+		pyTransformerURL = startRudderPytransformer(t, pool, configBackend.URL)
+	})
+	wg.Wait()
 
 	// Run subtests sequentially. Each subtest with python code spins up its own
 	// openfaas-flask-base since openfaas loads code at startup.

--- a/integration_test/pytransformer_contract/backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/backwards_compatibility_test.go
@@ -2063,12 +2063,11 @@ def transformEvent(event, metadata):
 	})
 
 	// Start shared rudder-pytransformer.
-	_, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
+	pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
 
 	// Wait for shared services to be healthy.
 	t.Log("Waiting for shared services to be healthy...")
 	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
-	waitForHealthy(t, pool, pyTransformerURL, "rudder-pytransformer")
 
 	// Run subtests sequentially. Each subtest with python code spins up its own
 	// openfaas-flask-base since openfaas loads code at startup.

--- a/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
@@ -27,24 +27,27 @@ import (
 //	requests.put(url, data=None, **kwargs)
 //	requests.patch(url, data=None, **kwargs)
 //
-// The corresponding “requests.Session“ methods accept only “url“ as a
-// positional; “params“/“data“ are keyword-only on “Session“. The
-// pytransformer connection pool reroutes bare “requests.<method>()“ calls
-// through a shared “Session“ when “ENABLE_CONN_POOL=true“, so the pooling
-// layer must bridge the two signature shapes. The contract is:
+// For GET, the corresponding “Session.get“ signature drops “params“ —
+// it's keyword-only on the session method — so the pytransformer pooling
+// layer must bridge the two shapes. For POST/PUT/PATCH the session
+// method shares the module-level signature, so the pooling layer must
+// forward positional arguments verbatim and must NOT re-promote them to
+// keywords (doing so makes “requests.post(url, body, json_payload)“
+// raise “TypeError: got multiple values for argument 'data'“ — the B2
+// blocker). The contract is:
 //
 //  1. Old arch (rudder-transformer + openfaas-flask-base): user code runs
-//     against vanilla “requests“, so “requests.get(url, {"q": "hello"})“
-//     succeeds and the backend receives “?q=hello“.
+//     against vanilla “requests“, so every two-positional call reaches
+//     the backend with the expected shape.
 //  2. New arch (rudder-pytransformer), “ENABLE_CONN_POOL=false“: bare
 //     calls reach “requests“ unmodified, same as old arch.
 //  3. New arch (rudder-pytransformer), “ENABLE_CONN_POOL=true“: bare
-//     calls flow through the pooled “Session“, but the promotion of the
-//     second positional to the matching keyword keeps the observable result
-//     identical to the other two paths.
+//     calls flow through the pooled “Session“. GET goes through the
+//     params-promotion bridge; POST/PUT/PATCH are forwarded verbatim.
+//     The observable result stays identical to the other two paths.
 //
-// For every new-arch configuration the old-arch and new-arch responses
-// must compare equal field-for-field via “types.Response.Equal“.
+// Every verb × every new-arch configuration: the old-arch and new-arch
+// responses must compare equal field-for-field via “types.Response.Equal“.
 func TestBareRequestsPositionalParamsContract(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
@@ -52,26 +55,47 @@ func TestBareRequestsPositionalParamsContract(t *testing.T) {
 
 	const versionID = "bare-requests-positional-params-v1"
 
-	// Echo server: returns the ``q`` query parameter back in a JSON body.
-	// Successful round-trip requires the user transformation to forward
-	// ``params={"q": "hello"}`` to the HTTP layer — regardless of which
-	// runtime the code executed in.
+	// Echo server: returns the ``q`` field back in a JSON body.
+	// ``r.FormValue`` pulls from the URL query string (GET) AND the
+	// form-encoded body (POST/PUT/PATCH), so the same handler can echo
+	// all four verbs without branching.
 	echo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		q := r.URL.Query().Get("q")
+		q := r.FormValue("q")
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(w, `{"echo": %q}`, q)
+		_, _ = fmt.Fprintf(w, `{"echo": %q, "method": %q}`, q, r.Method)
 	}))
 	t.Cleanup(echo.Close)
 
-	// User code that exercises the second-positional form of ``requests.get``.
-	// Every runtime must treat this as equivalent to ``requests.get(url,
-	// params={"q": "hello"})``.
+	// Dispatcher user code: picks the verb from the incoming event so
+	// the same versionID can exercise all four two-positional shapes
+	// without spinning up a separate openfaas-flask-base container per
+	// verb. The line actually under test — ``requests.<verb>(url,
+	// {"q": "hello"})`` — is identical to what a real customer would
+	// write; only the surrounding if/elif selects which verb runs.
+	//
+	// For GET the positional dict becomes the query string; for
+	// POST/PUT/PATCH the positional dict is form-encoded into the body.
+	// Both paths make the echo server's ``r.FormValue("q")`` return
+	// ``"hello"`` so the assertion shape is uniform across verbs.
 	code := fmt.Sprintf(`
 import requests
 
 def transformEvent(event, metadata):
-    resp = requests.get("%s/search", {"q": "hello"})
-    event["echo"] = resp.json()["echo"]
+    verb = event["verb"]
+    url = "%s/search"
+    if verb == "get":
+        resp = requests.get(url, {"q": "hello"})
+    elif verb == "post":
+        resp = requests.post(url, {"q": "hello"})
+    elif verb == "put":
+        resp = requests.put(url, {"q": "hello"})
+    elif verb == "patch":
+        resp = requests.patch(url, {"q": "hello"})
+    else:
+        raise ValueError("unknown verb: " + repr(verb))
+    body = resp.json()
+    event["echo"] = body["echo"]
+    event["method"] = body["method"]
     return event
 `, toContainerURL(echo.URL))
 
@@ -85,7 +109,7 @@ def transformEvent(event, metadata):
 	// The old stack runs the user code under vanilla ``requests`` with no
 	// pooling layer in front of it, so it defines the reference behaviour
 	// every new-arch configuration must match. Started once and shared
-	// across both new-arch subtests.
+	// across every new-arch / verb combination.
 
 	t.Log("Starting openfaas-flask-base (old arch backend)...")
 	openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
@@ -109,7 +133,7 @@ def transformEvent(event, metadata):
 	// ``requests.<method>`` calls reach the underlying helpers untouched)
 	// and once with it enabled (bare calls are routed through a shared
 	// pooled ``Session``). Both configurations must match the old-arch
-	// reference.
+	// reference for every verb.
 	newArchCases := []struct {
 		name            string
 		enableConnPool  string
@@ -126,6 +150,193 @@ def transformEvent(event, metadata):
 			// Pin pool + subprocess count to 1 so a single long-lived
 			// user session handles every call: no subprocess affinity
 			// or pool recycling can influence the outcome.
+			extraPytransEnv: []string{
+				"USER_CONN_POOL_MAX_SIZE=1",
+				"SANDBOX_POOL_MAX_SIZE=1",
+			},
+		},
+	}
+
+	// Every verb that accepts a second positional argument must survive
+	// the pooling bridge. GET exercises the params-promotion path; the
+	// rest exercise the verbatim forwarding path that the B2 fix restored.
+	verbCases := []struct {
+		verb   string
+		method string // HTTP method the echo server should observe
+	}{
+		{verb: "get", method: "GET"},
+		{verb: "post", method: "POST"},
+		{verb: "put", method: "PUT"},
+		{verb: "patch", method: "PATCH"},
+	}
+
+	for _, tc := range newArchCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pyEnv := append([]string{"ENABLE_CONN_POOL=" + tc.enableConnPool}, tc.extraPytransEnv...)
+			t.Logf("Starting rudder-pytransformer with %v...", pyEnv)
+			pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL, pyEnv...)
+
+			for _, vc := range verbCases {
+				t.Run(vc.verb, func(t *testing.T) {
+					// Fresh env per verb so memstats retry counters don't bleed between subtests (memstats accumulates
+					// and cannot be reset).
+					env := newBCTestEnv(t, transformerURL, pyTransformerURL,
+						withFailOnError(),
+						withLimitedRetryableHTTPRetries(),
+					)
+
+					event := makeEvent("msg-"+vc.verb, versionID)
+					event.Message["verb"] = vc.verb
+					events := []types.TransformerEvent{event}
+
+					t.Log("Sending request to old architecture...")
+					oldResp := env.OldClient.Transform(context.Background(), events)
+					t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+
+					t.Log("Sending request to new architecture...")
+					newResp := env.NewClient.Transform(context.Background(), events)
+					t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+
+					require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
+					require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
+					require.Equalf(t, 1, len(newResp.Events),
+						"new arch (ENABLE_CONN_POOL=%s, verb=%s): 1 success event "+
+							"expected — a buggy pooling wrapper raises TypeError "+
+							"before the HTTP call and fails the event instead",
+						tc.enableConnPool, vc.verb)
+					require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+
+					// Round-trip sanity check: the echo server must have
+					// seen ``q=hello`` on both stacks, which means the
+					// positional dict was forwarded correctly whether
+					// that happens via the GET params-promotion bridge
+					// or verbatim positional forwarding for the body
+					// verbs.
+					require.Equal(t, "hello", oldResp.Events[0].Output["echo"],
+						"old arch must forward the positional dict as q=hello")
+					require.Equalf(t, "hello", newResp.Events[0].Output["echo"],
+						"new arch (ENABLE_CONN_POOL=%s, verb=%s) must forward the "+
+							"positional dict as q=hello", tc.enableConnPool, vc.verb)
+
+					// Method sanity: the echo server must also have seen
+					// the right HTTP verb, proving that the pooling
+					// wrapper dispatched to the right Session method and
+					// didn't silently downgrade to GET.
+					require.Equalf(t, vc.method, newResp.Events[0].Output["method"],
+						"new arch (ENABLE_CONN_POOL=%s): echo server must have "+
+							"observed HTTP %s", tc.enableConnPool, vc.method)
+
+					// Strict parity: every field of the two responses must match.
+					diff, equal := oldResp.Equal(&newResp)
+					require.Truef(t, equal,
+						"ENABLE_CONN_POOL=%s, verb=%s: old and new architectures "+
+							"must produce identical responses for bare "+
+							"requests.%s(url, positional_dict):\n%s",
+						tc.enableConnPool, vc.verb, vc.verb, diff)
+
+					env.assertRetryCountsMatch(t)
+				})
+			}
+		})
+	}
+}
+
+// TestBareRequestsPostThreePositionalArgsContract locks the contract that
+// “requests.post(url, data, json)“ — all three arguments passed
+// positionally — behaves identically under both architectures and under
+// both values of the pytransformer connection-pool flag.
+//
+// The module-level signature “requests.post(url, data=None, json=None, **kwargs)“
+// allows every user to write:
+//
+//	requests.post("https://example.com/events", body, json_payload)
+//
+// The new-arch pooling layer used to mishandle this shape: it promoted
+// “args[1]“ (the body) to “data=“ while leaving “args[2]“ (the JSON
+// payload) positional, so the forwarded call became
+// “session.post(url, json_payload, data=body)“ — which binds
+// “json_payload“ to “data“ and then collides with the promoted
+// keyword, raising “TypeError: post() got multiple values for argument
+// 'data'“. The bug was silent until “ENABLE_CONN_POOL=true“ and a
+// three-positional “post“ call happened to reach the wrapper — exactly
+// the rollout we're aiming at.
+//
+// This contract pins the correct behaviour: the old arch (vanilla
+// “requests“) accepts this call shape; every new-arch configuration must
+// too.
+func TestBareRequestsPostThreePositionalArgsContract(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
+
+	const versionID = "bare-requests-post-three-positional-v1"
+
+	// Echo server: captures the raw body seen by the handler and surfaces
+	// it in the response. “requests.PreparedRequest.prepare_body“ picks
+	// “data“ over “json“ when both are provided, so the server sees the
+	// raw ``data`` bytes. That's fine for this test — what we need to
+	// verify is that the HTTP call completes at all, not which payload
+	// wins the precedence game.
+	echo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		if r.ContentLength > 0 {
+			_, _ = r.Body.Read(body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"received": %q}`, string(body))
+	}))
+	t.Cleanup(echo.Close)
+
+	// User code exercising the three-positional “post“ form. The second
+	// positional is the request body (“data“), the third is the JSON
+	// payload (“json“). A buggy pooling wrapper raises “TypeError“
+	// before the server is hit; the healthy path echoes the body back.
+	code := fmt.Sprintf(`
+import requests
+
+def transformEvent(event, metadata):
+    resp = requests.post("%s/events", b"raw=payload", {"flush": True})
+    event["received"] = resp.json()["received"]
+    return event
+`, toContainerURL(echo.URL))
+
+	configBackend := newContractConfigBackend(t, map[string]configBackendEntry{
+		versionID: {code: code},
+	})
+	t.Cleanup(configBackend.Close)
+
+	t.Log("Starting openfaas-flask-base (old arch backend)...")
+	openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
+
+	t.Log("Starting mock OpenFaaS gateway...")
+	mockGateway, _ := newMockOpenFaaSGateway(t, func() string { return openFaasURL })
+	t.Cleanup(mockGateway.Close)
+
+	t.Log("Starting rudder-transformer (old arch frontend)...")
+	transformerContainer, transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
+	t.Cleanup(func() {
+		if err := pool.Purge(transformerContainer); err != nil {
+			t.Logf("Failed to purge rudder-transformer: %v", err)
+		}
+	})
+	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
+
+	newArchCases := []struct {
+		name            string
+		enableConnPool  string
+		extraPytransEnv []string
+	}{
+		{
+			name:            "ConnPoolDisabled",
+			enableConnPool:  "false",
+			extraPytransEnv: nil,
+		},
+		{
+			name:           "ConnPoolEnabled",
+			enableConnPool: "true",
+			// Pin pool + subprocess count to 1 so the buggy code path
+			// (if reintroduced) cannot be masked by a cold subprocess
+			// bypassing the pool wrapper.
 			extraPytransEnv: []string{
 				"USER_CONN_POOL_MAX_SIZE=1",
 				"SANDBOX_POOL_MAX_SIZE=1",
@@ -156,23 +367,26 @@ def transformEvent(event, metadata):
 
 			require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
 			require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-			require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+			require.Equalf(t, 1, len(newResp.Events),
+				"new arch (ENABLE_CONN_POOL=%s): 1 success event expected — a "+
+					"buggy pooling wrapper raises TypeError before the HTTP "+
+					"call and fails the event instead",
+				tc.enableConnPool)
 			require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
 
 			// Round-trip sanity check: the echo server must have seen
-			// ``?q=hello`` on both stacks, which means the positional
-			// dict was forwarded as the ``params`` keyword under the hood.
-			require.Equal(t, "hello", oldResp.Events[0].Output["echo"],
-				"old arch must forward the positional params dict as ?q=hello")
-			require.Equalf(t, "hello", newResp.Events[0].Output["echo"],
-				"new arch (ENABLE_CONN_POOL=%s) must forward the positional params "+
-					"dict as ?q=hello", tc.enableConnPool)
+			// the raw body on both stacks, which means the second
+			// positional bound to ``data`` and the call completed.
+			require.Equal(t, "raw=payload", oldResp.Events[0].Output["received"],
+				"old arch must forward the positional body as the request payload")
+			require.Equalf(t, "raw=payload", newResp.Events[0].Output["received"],
+				"new arch (ENABLE_CONN_POOL=%s) must forward the positional "+
+					"body as the request payload", tc.enableConnPool)
 
-			// Strict parity: every field of the two responses must match.
 			diff, equal := oldResp.Equal(&newResp)
 			require.Truef(t, equal,
 				"ENABLE_CONN_POOL=%s: old and new architectures must produce "+
-					"identical responses for bare requests.get(url, params_dict):\n%s",
+					"identical responses for bare requests.post(url, body, json_payload):\n%s",
 				tc.enableConnPool, diff)
 
 			env.assertRetryCountsMatch(t)

--- a/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
@@ -33,8 +33,8 @@ import (
 // method shares the module-level signature, so the pooling layer must
 // forward positional arguments verbatim and must NOT re-promote them to
 // keywords (doing so makes “requests.post(url, body, json_payload)“
-// raise “TypeError: got multiple values for argument 'data'“ — the B2
-// blocker). The contract is:
+// raise “TypeError: got multiple values for argument 'data'“). The
+// contract is:
 //
 //  1. Old arch (rudder-transformer + openfaas-flask-base): user code runs
 //     against vanilla “requests“, so every two-positional call reaches
@@ -159,7 +159,7 @@ def transformEvent(event, metadata):
 
 	// Every verb that accepts a second positional argument must survive
 	// the pooling bridge. GET exercises the params-promotion path; the
-	// rest exercise the verbatim forwarding path that the B2 fix restored.
+	// rest exercise the verbatim forwarding path.
 	verbCases := []struct {
 		verb   string
 		method string // HTTP method the echo server should observe
@@ -201,7 +201,7 @@ def transformEvent(event, metadata):
 					require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
 					require.Equalf(t, 1, len(newResp.Events),
 						"new arch (ENABLE_CONN_POOL=%s, verb=%s): 1 success event "+
-							"expected — a buggy pooling wrapper raises TypeError "+
+							"expected — incorrect argument forwarding raises TypeError "+
 							"before the HTTP call and fails the event instead",
 						tc.enableConnPool, vc.verb)
 					require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
@@ -257,9 +257,8 @@ def transformEvent(event, metadata):
 // “session.post(url, json_payload, data=body)“ — which binds
 // “json_payload“ to “data“ and then collides with the promoted
 // keyword, raising “TypeError: post() got multiple values for argument
-// 'data'“. The bug was silent until “ENABLE_CONN_POOL=true“ and a
-// three-positional “post“ call happened to reach the wrapper — exactly
-// the rollout we're aiming at.
+// 'data'“. The failure only appears when “ENABLE_CONN_POOL=true“ and a
+// three-positional “post“ call reaches the wrapper.
 //
 // This contract pins the correct behaviour: the old arch (vanilla
 // “requests“) accepts this call shape; every new-arch configuration must
@@ -289,8 +288,8 @@ func TestBareRequestsPostThreePositionalArgsContract(t *testing.T) {
 
 	// User code exercising the three-positional “post“ form. The second
 	// positional is the request body (“data“), the third is the JSON
-	// payload (“json“). A buggy pooling wrapper raises “TypeError“
-	// before the server is hit; the healthy path echoes the body back.
+	// payload (“json“). Incorrect argument forwarding raises “TypeError“
+	// before the server is hit; the correct path echoes the body back.
 	code := fmt.Sprintf(`
 import requests
 
@@ -334,9 +333,9 @@ def transformEvent(event, metadata):
 		{
 			name:           "ConnPoolEnabled",
 			enableConnPool: "true",
-			// Pin pool + subprocess count to 1 so the buggy code path
-			// (if reintroduced) cannot be masked by a cold subprocess
-			// bypassing the pool wrapper.
+			// Pin pool + subprocess count to 1 so incorrect argument
+			// forwarding cannot be masked by a cold subprocess bypassing
+			// the pool wrapper.
 			extraPytransEnv: []string{
 				"USER_CONN_POOL_MAX_SIZE=1",
 				"SANDBOX_POOL_MAX_SIZE=1",
@@ -369,7 +368,7 @@ def transformEvent(event, metadata):
 			require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
 			require.Equalf(t, 1, len(newResp.Events),
 				"new arch (ENABLE_CONN_POOL=%s): 1 success event expected — a "+
-					"buggy pooling wrapper raises TypeError before the HTTP "+
+					"bad pooling wrapper raises TypeError before the HTTP "+
 					"call and fails the event instead",
 				tc.enableConnPool)
 			require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")

--- a/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
@@ -88,13 +88,7 @@ def transformEvent(event, metadata):
 	// across both new-arch subtests.
 
 	t.Log("Starting openfaas-flask-base (old arch backend)...")
-	openFaasContainer, openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
-	t.Cleanup(func() {
-		if err := pool.Purge(openFaasContainer); err != nil {
-			t.Logf("Failed to purge openfaas-flask-base: %v", err)
-		}
-	})
-	waitForOpenFaasFlask(t, pool, openFaasURL)
+	openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
 
 	t.Log("Starting mock OpenFaaS gateway...")
 	mockGateway, _ := newMockOpenFaaSGateway(t, func() string { return openFaasURL })

--- a/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
@@ -13,45 +13,47 @@ import (
 	"github.com/rudderlabs/rudder-server/processor/types"
 )
 
-// TestBareRequestsPositionalParamsRegression
+// TestBareRequestsPositionalParamsContract locks the contract that valid
+// user code calling bare “requests“ helpers with a second positional
+// argument produces identical results on both architectures, regardless
+// of the pytransformer connection-pool feature flag.
 //
-// The module-level helper `requests.get(url, params=None, **kwargs)` exposes
-// `params` as a SECOND POSITIONAL argument, so passing a dict positionally is
-// a supported, documented form. `requests.Session.get(self, url, **kwargs)` —
-// which the pytransformer routes bare calls through when ENABLE_CONN_POOL=true —
-// does NOT accept `params` positionally. The pooling wrapper forwards `*args`
-// verbatim, so the call blows up with:
+// The module-level “requests“ helpers expose a second positional argument
+// whose name depends on the verb:
 //
-//	TypeError: Session.get() takes 2 positional arguments but 3 were given
+//	requests.get(url, params=None, **kwargs)
+//	requests.post(url, data=None, json=None, **kwargs)
+//	requests.put(url, data=None, **kwargs)
+//	requests.patch(url, data=None, **kwargs)
 //
-// The same divergence affects `requests.post(url, data)`, `requests.put(url,
-// data)`, and `requests.patch(url, data)` where `data` is the second positional.
+// The corresponding “requests.Session“ methods accept only “url“ as a
+// positional; “params“/“data“ are keyword-only on “Session“. The
+// pytransformer connection pool reroutes bare “requests.<method>()“ calls
+// through a shared “Session“ when “ENABLE_CONN_POOL=true“, so the pooling
+// layer must bridge the two signature shapes. The contract is:
 //
-// This test proves the regression by running the SAME user transformation
-// against both architectures:
+//  1. Old arch (rudder-transformer + openfaas-flask-base): user code runs
+//     against vanilla “requests“, so “requests.get(url, {"q": "hello"})“
+//     succeeds and the backend receives “?q=hello“.
+//  2. New arch (rudder-pytransformer), “ENABLE_CONN_POOL=false“: bare
+//     calls reach “requests“ unmodified, same as old arch.
+//  3. New arch (rudder-pytransformer), “ENABLE_CONN_POOL=true“: bare
+//     calls flow through the pooled “Session“, but the promotion of the
+//     second positional to the matching keyword keeps the observable result
+//     identical to the other two paths.
 //
-//   - Old arch (rudder-transformer + openfaas-flask-base): the code runs under
-//     vanilla `requests`, so `requests.get(url, {"q": "hello"})` succeeds and
-//     the server sees `?q=hello`.
-//   - New arch (rudder-pytransformer with ENABLE_CONN_POOL=true): the bare
-//     `requests.get` is rerouted through the pooled user Session, and the
-//     positional dict triggers TypeError.
-//
-// The contract is that the two architectures MUST produce the same successful
-// response for valid user code. This test fails today because of Bug 1 and will
-// go green when the pooling wrapper maps the module-level positional signature
-// to the Session equivalent.
-func TestBareRequestsPositionalParamsRegression(t *testing.T) {
+// Every configuration must produce the same successful event output.
+func TestBareRequestsPositionalParamsContract(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 	pool.MaxWait = 2 * time.Minute
 
 	const versionID = "bare-requests-positional-params-v1"
 
-	// Echo server: returns the `q` query parameter back in a JSON body.
-	// If the user transformation correctly forwarded `params={"q": "hello"}`,
-	// the server observes `?q=hello` and the event round-trips the value.
-	// If the dict is dropped (or the call crashes), the round-trip breaks.
+	// Echo server: returns the ``q`` query parameter back in a JSON body.
+	// Successful round-trip requires the user transformation to forward
+	// ``params={"q": "hello"}`` to the HTTP layer — regardless of which
+	// runtime the code executed in.
 	echo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query().Get("q")
 		w.Header().Set("Content-Type", "application/json")
@@ -59,10 +61,9 @@ func TestBareRequestsPositionalParamsRegression(t *testing.T) {
 	}))
 	t.Cleanup(echo.Close)
 
-	// User code that is valid against plain `requests` (old arch) but is
-	// broken by the pytransformer pooling wrapper (new arch, Bug 1).
-	// Note: `{"q": "hello"}` is passed POSITIONALLY — this is the exact
-	// shape the bug turns into a TypeError.
+	// User code that exercises the second-positional form of ``requests.get``.
+	// Every runtime must treat this as equivalent to ``requests.get(url,
+	// params={"q": "hello"})``.
 	code := fmt.Sprintf(`
 import requests
 
@@ -78,6 +79,10 @@ def transformEvent(event, metadata):
 	t.Cleanup(configBackend.Close)
 
 	// --- Old architecture (rudder-transformer + openfaas-flask-base) ---
+	//
+	// The old stack runs the user code under vanilla ``requests`` with no
+	// pooling layer in front of it, so it defines the reference behaviour
+	// every new-arch configuration must match.
 
 	t.Log("Starting openfaas-flask-base (old arch backend)...")
 	openFaasContainer, openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
@@ -101,61 +106,76 @@ def transformEvent(event, metadata):
 	})
 	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
 
-	// --- New architecture (rudder-pytransformer with ENABLE_CONN_POOL=true) ---
-
-	t.Log("Starting rudder-pytransformer with ENABLE_CONN_POOL=true (new arch)...")
-	pyTransformerURL := startRudderPytransformer(
-		t, pool, configBackend.URL,
-		// Flag under test: flip the bare-requests path through the pooled
-		// user session. This is the code path Bug 1 lives on.
-		"ENABLE_CONN_POOL=true",
-		// Pin pool + subprocess count to 1 so a single long-lived user
-		// session handles every call — removes any chance the regression
-		// is masked by subprocess affinity or pool recycling.
-		"USER_CONN_POOL_MAX_SIZE=1",
-		"SANDBOX_POOL_MAX_SIZE=1",
-	)
-
-	events := []types.TransformerEvent{makeEvent("msg-positional-params-1", versionID)}
-
-	// --- Old arch: must succeed, round-tripping "hello" through the echo server. ---
-
+	oldArchEvents := []types.TransformerEvent{makeEvent("msg-old-arch", versionID)}
 	t.Log("Sending request to old architecture (rudder-transformer + openfaas)...")
-	oldStatus, oldItems := sendRawTransform(t, transformerURL, events)
+	oldStatus, oldItems := sendRawTransform(t, transformerURL, oldArchEvents)
 	require.Equal(t, http.StatusOK, oldStatus,
 		"old arch /customTransform must return HTTP 200")
 	require.Len(t, oldItems, 1)
 	require.Equalf(t, http.StatusOK, oldItems[0].StatusCode,
-		"old arch must succeed: requests.get(url, {\"q\": \"hello\"}) is valid "+
-			"Python against the real `requests` module. Got StatusCode=%d, Error=%q",
+		"old arch must succeed: requests.get(url, {\"q\": \"hello\"}) is a valid "+
+			"call against the real `requests` module. Got StatusCode=%d, Error=%q",
 		oldItems[0].StatusCode, oldItems[0].Error)
 	require.Equal(t, "hello", oldItems[0].Output["echo"],
 		"old arch must forward the positional params dict as a ?q=hello query string")
 
-	// --- New arch: must ALSO succeed under the contract, but currently fails. ---
+	// --- New architecture (rudder-pytransformer) ---
 	//
-	// Under Bug 1, the pooling wrapper forwards the positional dict to
-	// Session.get(self, url, **kwargs), triggering:
-	//   TypeError: Session.get() takes 2 positional arguments but 3 were given
-	// which the sandbox surfaces as a 400 per-event failure. This assertion
-	// therefore fails today and will pass only once the wrapper maps the
-	// module-level positional signature to the Session equivalent.
+	// Exercised twice — once with the connection pool disabled (bare
+	// ``requests.<method>`` calls reach the underlying helpers untouched)
+	// and once with it enabled (bare calls are routed through a shared
+	// pooled ``Session``). Both configurations must match the old-arch
+	// reference.
+	newArchCases := []struct {
+		name              string
+		enableConnPool    string
+		extraPytransEnv   []string
+		eventMessageIDTag string
+	}{
+		{
+			name:              "ConnPoolDisabled",
+			enableConnPool:    "false",
+			extraPytransEnv:   nil,
+			eventMessageIDTag: "msg-new-arch-nopool",
+		},
+		{
+			name:           "ConnPoolEnabled",
+			enableConnPool: "true",
+			// Pin pool + subprocess count to 1 so a single long-lived
+			// user session handles every call: no subprocess affinity
+			// or pool recycling can influence the outcome.
+			extraPytransEnv: []string{
+				"USER_CONN_POOL_MAX_SIZE=1",
+				"SANDBOX_POOL_MAX_SIZE=1",
+			},
+			eventMessageIDTag: "msg-new-arch-pool",
+		},
+	}
 
-	t.Log("Sending request to new architecture (rudder-pytransformer, ENABLE_CONN_POOL=true)...")
-	newStatus, newItems := sendRawTransform(t, pyTransformerURL, events)
-	require.Equal(t, http.StatusOK, newStatus,
-		"new arch /customTransform must return HTTP 200 "+
-			"(per-event errors sit inside the payload, not at the HTTP layer)")
-	require.Len(t, newItems, 1)
+	for _, tc := range newArchCases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := append([]string{"ENABLE_CONN_POOL=" + tc.enableConnPool}, tc.extraPytransEnv...)
+			t.Logf("Starting rudder-pytransformer with %v...", env)
+			pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL, env...)
 
-	require.Equalf(t, http.StatusOK, newItems[0].StatusCode,
-		"REGRESSION: with ENABLE_CONN_POOL=true, bare "+
-			"requests.get(url, {\"q\": \"hello\"}) must succeed the same way it "+
-			"does on the old arch. The pooling wrapper forwards the positional "+
-			"params dict to Session.get, which only accepts params as a keyword, "+
-			"raising TypeError. Got StatusCode=%d, Error=%q, Output=%v",
-		newItems[0].StatusCode, newItems[0].Error, newItems[0].Output)
-	require.Equalf(t, "hello", newItems[0].Output["echo"],
-		"new arch must round-trip the positional params dict identically to "+
-			"old arch (expected echo=%q)", "hello")
+			events := []types.TransformerEvent{makeEvent(tc.eventMessageIDTag, versionID)}
+			t.Log("Sending request to new architecture (rudder-pytransformer)...")
+			newStatus, newItems := sendRawTransform(t, pyTransformerURL, events)
+			require.Equal(t, http.StatusOK, newStatus,
+				"new arch /customTransform must return HTTP 200 "+
+					"(per-event errors sit inside the payload, not at the HTTP layer)")
+			require.Len(t, newItems, 1)
+
+			require.Equalf(t, http.StatusOK, newItems[0].StatusCode,
+				"new arch must succeed with ENABLE_CONN_POOL=%s: the pooling "+
+					"layer must promote the second positional argument of bare "+
+					"requests.<method>() calls to the matching keyword before "+
+					"forwarding to the session. Got StatusCode=%d, Error=%q, Output=%v",
+				tc.enableConnPool, newItems[0].StatusCode, newItems[0].Error, newItems[0].Output)
+			require.Equalf(t, "hello", newItems[0].Output["echo"],
+				"new arch (ENABLE_CONN_POOL=%s) must round-trip the positional "+
+					"params dict identically to old arch (expected echo=%q)",
+				tc.enableConnPool, "hello")
+		})
+	}
 }

--- a/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
@@ -119,13 +119,7 @@ def transformEvent(event, metadata):
 	t.Cleanup(mockGateway.Close)
 
 	t.Log("Starting rudder-transformer (old arch frontend)...")
-	transformerContainer, transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
-	t.Cleanup(func() {
-		if err := pool.Purge(transformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-transformer: %v", err)
-		}
-	})
-	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
+	transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
 
 	// --- New architecture (rudder-pytransformer) ---
 	//
@@ -312,13 +306,7 @@ def transformEvent(event, metadata):
 	t.Cleanup(mockGateway.Close)
 
 	t.Log("Starting rudder-transformer (old arch frontend)...")
-	transformerContainer, transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
-	t.Cleanup(func() {
-		if err := pool.Purge(transformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-transformer: %v", err)
-		}
-	})
-	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
+	transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
 
 	newArchCases := []struct {
 		name            string

--- a/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
@@ -1,0 +1,161 @@
+package pytransformer_contract
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/processor/types"
+)
+
+// TestBareRequestsPositionalParamsRegression
+//
+// The module-level helper `requests.get(url, params=None, **kwargs)` exposes
+// `params` as a SECOND POSITIONAL argument, so passing a dict positionally is
+// a supported, documented form. `requests.Session.get(self, url, **kwargs)` —
+// which the pytransformer routes bare calls through when ENABLE_CONN_POOL=true —
+// does NOT accept `params` positionally. The pooling wrapper forwards `*args`
+// verbatim, so the call blows up with:
+//
+//	TypeError: Session.get() takes 2 positional arguments but 3 were given
+//
+// The same divergence affects `requests.post(url, data)`, `requests.put(url,
+// data)`, and `requests.patch(url, data)` where `data` is the second positional.
+//
+// This test proves the regression by running the SAME user transformation
+// against both architectures:
+//
+//   - Old arch (rudder-transformer + openfaas-flask-base): the code runs under
+//     vanilla `requests`, so `requests.get(url, {"q": "hello"})` succeeds and
+//     the server sees `?q=hello`.
+//   - New arch (rudder-pytransformer with ENABLE_CONN_POOL=true): the bare
+//     `requests.get` is rerouted through the pooled user Session, and the
+//     positional dict triggers TypeError.
+//
+// The contract is that the two architectures MUST produce the same successful
+// response for valid user code. This test fails today because of Bug 1 and will
+// go green when the pooling wrapper maps the module-level positional signature
+// to the Session equivalent.
+func TestBareRequestsPositionalParamsRegression(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
+
+	const versionID = "bare-requests-positional-params-v1"
+
+	// Echo server: returns the `q` query parameter back in a JSON body.
+	// If the user transformation correctly forwarded `params={"q": "hello"}`,
+	// the server observes `?q=hello` and the event round-trips the value.
+	// If the dict is dropped (or the call crashes), the round-trip breaks.
+	echo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"echo": %q}`, q)
+	}))
+	t.Cleanup(echo.Close)
+
+	// User code that is valid against plain `requests` (old arch) but is
+	// broken by the pytransformer pooling wrapper (new arch, Bug 1).
+	// Note: `{"q": "hello"}` is passed POSITIONALLY — this is the exact
+	// shape the bug turns into a TypeError.
+	code := fmt.Sprintf(`
+import requests
+
+def transformEvent(event, metadata):
+    resp = requests.get("%s/search", {"q": "hello"})
+    event["echo"] = resp.json()["echo"]
+    return event
+`, toContainerURL(echo.URL))
+
+	configBackend := newContractConfigBackend(t, map[string]configBackendEntry{
+		versionID: {code: code},
+	})
+	t.Cleanup(configBackend.Close)
+
+	// --- Old architecture (rudder-transformer + openfaas-flask-base) ---
+
+	t.Log("Starting openfaas-flask-base (old arch backend)...")
+	openFaasContainer, openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
+	t.Cleanup(func() {
+		if err := pool.Purge(openFaasContainer); err != nil {
+			t.Logf("Failed to purge openfaas-flask-base: %v", err)
+		}
+	})
+	waitForOpenFaasFlask(t, pool, openFaasURL)
+
+	t.Log("Starting mock OpenFaaS gateway...")
+	mockGateway, _ := newMockOpenFaaSGateway(t, func() string { return openFaasURL })
+	t.Cleanup(mockGateway.Close)
+
+	t.Log("Starting rudder-transformer (old arch frontend)...")
+	transformerContainer, transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
+	t.Cleanup(func() {
+		if err := pool.Purge(transformerContainer); err != nil {
+			t.Logf("Failed to purge rudder-transformer: %v", err)
+		}
+	})
+	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
+
+	// --- New architecture (rudder-pytransformer with ENABLE_CONN_POOL=true) ---
+
+	t.Log("Starting rudder-pytransformer with ENABLE_CONN_POOL=true (new arch)...")
+	pyTransformerURL := startRudderPytransformer(
+		t, pool, configBackend.URL,
+		// Flag under test: flip the bare-requests path through the pooled
+		// user session. This is the code path Bug 1 lives on.
+		"ENABLE_CONN_POOL=true",
+		// Pin pool + subprocess count to 1 so a single long-lived user
+		// session handles every call — removes any chance the regression
+		// is masked by subprocess affinity or pool recycling.
+		"USER_CONN_POOL_MAX_SIZE=1",
+		"SANDBOX_POOL_MAX_SIZE=1",
+	)
+
+	events := []types.TransformerEvent{makeEvent("msg-positional-params-1", versionID)}
+
+	// --- Old arch: must succeed, round-tripping "hello" through the echo server. ---
+
+	t.Log("Sending request to old architecture (rudder-transformer + openfaas)...")
+	oldStatus, oldItems := sendRawTransform(t, transformerURL, events)
+	require.Equal(t, http.StatusOK, oldStatus,
+		"old arch /customTransform must return HTTP 200")
+	require.Len(t, oldItems, 1)
+	require.Equalf(t, http.StatusOK, oldItems[0].StatusCode,
+		"old arch must succeed: requests.get(url, {\"q\": \"hello\"}) is valid "+
+			"Python against the real `requests` module. Got StatusCode=%d, Error=%q",
+		oldItems[0].StatusCode, oldItems[0].Error)
+	require.Equal(t, "hello", oldItems[0].Output["echo"],
+		"old arch must forward the positional params dict as a ?q=hello query string")
+
+	// --- New arch: must ALSO succeed under the contract, but currently fails. ---
+	//
+	// Under Bug 1, the pooling wrapper forwards the positional dict to
+	// Session.get(self, url, **kwargs), triggering:
+	//   TypeError: Session.get() takes 2 positional arguments but 3 were given
+	// which the sandbox surfaces as a 400 per-event failure. This assertion
+	// therefore fails today and will pass only once the wrapper maps the
+	// module-level positional signature to the Session equivalent.
+
+	t.Log("Sending request to new architecture (rudder-pytransformer, ENABLE_CONN_POOL=true)...")
+	newStatus, newItems := sendRawTransform(t, pyTransformerURL, events)
+	require.Equal(t, http.StatusOK, newStatus,
+		"new arch /customTransform must return HTTP 200 "+
+			"(per-event errors sit inside the payload, not at the HTTP layer)")
+	require.Len(t, newItems, 1)
+
+	require.Equalf(t, http.StatusOK, newItems[0].StatusCode,
+		"REGRESSION: with ENABLE_CONN_POOL=true, bare "+
+			"requests.get(url, {\"q\": \"hello\"}) must succeed the same way it "+
+			"does on the old arch. The pooling wrapper forwards the positional "+
+			"params dict to Session.get, which only accepts params as a keyword, "+
+			"raising TypeError. Got StatusCode=%d, Error=%q, Output=%v",
+		newItems[0].StatusCode, newItems[0].Error, newItems[0].Output)
+	require.Equalf(t, "hello", newItems[0].Output["echo"],
+		"new arch must round-trip the positional params dict identically to "+
+			"old arch (expected echo=%q)", "hello")
+}

--- a/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
@@ -1,6 +1,7 @@
 package pytransformer_contract
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -42,7 +43,8 @@ import (
 //     second positional to the matching keyword keeps the observable result
 //     identical to the other two paths.
 //
-// Every configuration must produce the same successful event output.
+// For every new-arch configuration the old-arch and new-arch responses
+// must compare equal field-for-field via “types.Response.Equal“.
 func TestBareRequestsPositionalParamsContract(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
@@ -82,7 +84,8 @@ def transformEvent(event, metadata):
 	//
 	// The old stack runs the user code under vanilla ``requests`` with no
 	// pooling layer in front of it, so it defines the reference behaviour
-	// every new-arch configuration must match.
+	// every new-arch configuration must match. Started once and shared
+	// across both new-arch subtests.
 
 	t.Log("Starting openfaas-flask-base (old arch backend)...")
 	openFaasContainer, openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
@@ -106,19 +109,6 @@ def transformEvent(event, metadata):
 	})
 	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
 
-	oldArchEvents := []types.TransformerEvent{makeEvent("msg-old-arch", versionID)}
-	t.Log("Sending request to old architecture (rudder-transformer + openfaas)...")
-	oldStatus, oldItems := sendRawTransform(t, transformerURL, oldArchEvents)
-	require.Equal(t, http.StatusOK, oldStatus,
-		"old arch /customTransform must return HTTP 200")
-	require.Len(t, oldItems, 1)
-	require.Equalf(t, http.StatusOK, oldItems[0].StatusCode,
-		"old arch must succeed: requests.get(url, {\"q\": \"hello\"}) is a valid "+
-			"call against the real `requests` module. Got StatusCode=%d, Error=%q",
-		oldItems[0].StatusCode, oldItems[0].Error)
-	require.Equal(t, "hello", oldItems[0].Output["echo"],
-		"old arch must forward the positional params dict as a ?q=hello query string")
-
 	// --- New architecture (rudder-pytransformer) ---
 	//
 	// Exercised twice — once with the connection pool disabled (bare
@@ -127,16 +117,14 @@ def transformEvent(event, metadata):
 	// pooled ``Session``). Both configurations must match the old-arch
 	// reference.
 	newArchCases := []struct {
-		name              string
-		enableConnPool    string
-		extraPytransEnv   []string
-		eventMessageIDTag string
+		name            string
+		enableConnPool  string
+		extraPytransEnv []string
 	}{
 		{
-			name:              "ConnPoolDisabled",
-			enableConnPool:    "false",
-			extraPytransEnv:   nil,
-			eventMessageIDTag: "msg-new-arch-nopool",
+			name:            "ConnPoolDisabled",
+			enableConnPool:  "false",
+			extraPytransEnv: nil,
 		},
 		{
 			name:           "ConnPoolEnabled",
@@ -148,34 +136,52 @@ def transformEvent(event, metadata):
 				"USER_CONN_POOL_MAX_SIZE=1",
 				"SANDBOX_POOL_MAX_SIZE=1",
 			},
-			eventMessageIDTag: "msg-new-arch-pool",
 		},
 	}
 
 	for _, tc := range newArchCases {
 		t.Run(tc.name, func(t *testing.T) {
-			env := append([]string{"ENABLE_CONN_POOL=" + tc.enableConnPool}, tc.extraPytransEnv...)
-			t.Logf("Starting rudder-pytransformer with %v...", env)
-			pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL, env...)
+			pyEnv := append([]string{"ENABLE_CONN_POOL=" + tc.enableConnPool}, tc.extraPytransEnv...)
+			t.Logf("Starting rudder-pytransformer with %v...", pyEnv)
+			pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL, pyEnv...)
 
-			events := []types.TransformerEvent{makeEvent(tc.eventMessageIDTag, versionID)}
-			t.Log("Sending request to new architecture (rudder-pytransformer)...")
-			newStatus, newItems := sendRawTransform(t, pyTransformerURL, events)
-			require.Equal(t, http.StatusOK, newStatus,
-				"new arch /customTransform must return HTTP 200 "+
-					"(per-event errors sit inside the payload, not at the HTTP layer)")
-			require.Len(t, newItems, 1)
+			env := newBCTestEnv(t, transformerURL, pyTransformerURL,
+				withFailOnError(),
+				withLimitedRetryableHTTPRetries(),
+			)
 
-			require.Equalf(t, http.StatusOK, newItems[0].StatusCode,
-				"new arch must succeed with ENABLE_CONN_POOL=%s: the pooling "+
-					"layer must promote the second positional argument of bare "+
-					"requests.<method>() calls to the matching keyword before "+
-					"forwarding to the session. Got StatusCode=%d, Error=%q, Output=%v",
-				tc.enableConnPool, newItems[0].StatusCode, newItems[0].Error, newItems[0].Output)
-			require.Equalf(t, "hello", newItems[0].Output["echo"],
-				"new arch (ENABLE_CONN_POOL=%s) must round-trip the positional "+
-					"params dict identically to old arch (expected echo=%q)",
-				tc.enableConnPool, "hello")
+			events := []types.TransformerEvent{makeEvent("msg-1", versionID)}
+
+			t.Log("Sending request to old architecture...")
+			oldResp := env.OldClient.Transform(context.Background(), events)
+			t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+
+			t.Log("Sending request to new architecture...")
+			newResp := env.NewClient.Transform(context.Background(), events)
+			t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+
+			require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
+			require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
+			require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+			require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+
+			// Round-trip sanity check: the echo server must have seen
+			// ``?q=hello`` on both stacks, which means the positional
+			// dict was forwarded as the ``params`` keyword under the hood.
+			require.Equal(t, "hello", oldResp.Events[0].Output["echo"],
+				"old arch must forward the positional params dict as ?q=hello")
+			require.Equalf(t, "hello", newResp.Events[0].Output["echo"],
+				"new arch (ENABLE_CONN_POOL=%s) must forward the positional params "+
+					"dict as ?q=hello", tc.enableConnPool)
+
+			// Strict parity: every field of the two responses must match.
+			diff, equal := oldResp.Equal(&newResp)
+			require.Truef(t, equal,
+				"ENABLE_CONN_POOL=%s: old and new architectures must produce "+
+					"identical responses for bare requests.get(url, params_dict):\n%s",
+				tc.enableConnPool, diff)
+
+			env.assertRetryCountsMatch(t)
 		})
 	}
 }

--- a/integration_test/pytransformer_contract/base_test.go
+++ b/integration_test/pytransformer_contract/base_test.go
@@ -119,11 +119,10 @@ def transformEvent(event, metadata):
 	}()
 
 	t.Log("Starting rudder-pytransformer container...")
-	_, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
+	pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
 
 	t.Log("Waiting for transformers to be healthy...")
 	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
-	waitForHealthy(t, pool, pyTransformerURL, "rudder-pytransformer")
 
 	// Old architecture: PYTHON_TRANSFORM_URL is empty, so the client falls through
 	// to USER_TRANSFORM_URL for python transformations (same as production before pytransformer).

--- a/integration_test/pytransformer_contract/base_test.go
+++ b/integration_test/pytransformer_contract/base_test.go
@@ -97,13 +97,7 @@ def transformEvent(event, metadata):
 	t.Logf("Config backend at %s", configBackend.URL)
 
 	t.Log("Starting openfaas-flask-base container...")
-	openFaasContainer, openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
-	defer func() {
-		if err := pool.Purge(openFaasContainer); err != nil {
-			t.Logf("Failed to purge openfaas-flask-base container: %v", err)
-		}
-	}()
-	waitForOpenFaasFlask(t, pool, openFaasURL)
+	openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
 
 	t.Log("Starting mock OpenFaaS gateway...")
 	mockGateway, openFaaSInvocations := newMockOpenFaaSGateway(t, func() string { return openFaasURL })

--- a/integration_test/pytransformer_contract/base_test.go
+++ b/integration_test/pytransformer_contract/base_test.go
@@ -119,12 +119,7 @@ def transformEvent(event, metadata):
 	}()
 
 	t.Log("Starting rudder-pytransformer container...")
-	pyTransformerContainer, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
-	defer func() {
-		if err := pool.Purge(pyTransformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-pytransformer container: %v", err)
-		}
-	}()
+	_, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
 
 	t.Log("Waiting for transformers to be healthy...")
 	waitForHealthy(t, pool, transformerURL, "rudder-transformer")

--- a/integration_test/pytransformer_contract/base_test.go
+++ b/integration_test/pytransformer_contract/base_test.go
@@ -2,6 +2,7 @@ package pytransformer_contract
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/ory/dockertest/v3"
@@ -104,19 +105,17 @@ def transformEvent(event, metadata):
 	defer mockGateway.Close()
 	t.Logf("Mock OpenFaaS gateway at %s", mockGateway.URL)
 
-	t.Log("Starting rudder-transformer container...")
-	transformerContainer, transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
-	defer func() {
-		if err := pool.Purge(transformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-transformer container: %v", err)
-		}
-	}()
-
-	t.Log("Starting rudder-pytransformer container...")
-	pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
-
-	t.Log("Waiting for transformers to be healthy...")
-	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
+	var (
+		wg                               sync.WaitGroup
+		transformerURL, pyTransformerURL string
+	)
+	wg.Go(func() {
+		transformerURL = startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
+	})
+	wg.Go(func() {
+		pyTransformerURL = startRudderPytransformer(t, pool, configBackend.URL)
+	})
+	wg.Wait()
 
 	// Old architecture: PYTHON_TRANSFORM_URL is empty, so the client falls through
 	// to USER_TRANSFORM_URL for python transformations (same as production before pytransformer).

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -693,7 +693,7 @@ func (c *mockGeoConfig) setConnectionClose() {
 
 // setSlow makes the mock /geoip/* handler block for "delay" before responding
 // with HTTP 200. Used to simulate a hung geolocation backend so the
-// pytransformer's per-request timeout (or its urllib3 wall-clock cap) fires.
+// pytransformer's GEOLOCATION_TIMEOUT_SECS deadline fires.
 func (c *mockGeoConfig) setSlow(delay time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -401,12 +401,15 @@ func newMockOpenFaaSGateway(t *testing.T, getTarget func() string) (*httptest.Se
 // startOpenFaasFlask starts an openfaas-flask-base container with transformation code
 // loaded at startup via --vid and --config-backend-url. Optional extra environment
 // variables can be passed (e.g. "geolocation_url=http://...").
-// Returns the container resource and the URL to reach it from the host.
+//
+// The container is purged via “t.Cleanup“ and the function blocks until the
+// fwatchdog health endpoint is responsive, so callers get a URL that is
+// immediately ready to serve requests.
 func startOpenFaasFlask(
 	t *testing.T, pool *dockertest.Pool,
 	versionID, configBackendURL string,
 	extraEnv ...string,
-) (*dockertest.Resource, string) {
+) string {
 	t.Helper()
 	const containerPort = "8080"
 	cfg := newContainerConfig(t, containerPort)
@@ -427,7 +430,16 @@ func startOpenFaasFlask(
 		PortBindings: cfg.PortBindings,
 	}, cfg.hostConfigFn)
 	require.NoError(t, err, "failed to start openfaas-flask-base container")
-	return container, cfg.url(container, containerPort)
+
+	t.Cleanup(func() {
+		if err := pool.Purge(container); err != nil {
+			t.Logf("Failed to purge openfaas-flask-base container: %v", err)
+		}
+	})
+
+	openFaasURL := cfg.url(container, containerPort)
+	waitForOpenFaasFlask(t, pool, openFaasURL)
+	return openFaasURL
 }
 
 // startRudderTransformer starts a rudder-transformer container configured to use

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -483,6 +483,7 @@ func startRudderPytransformer(
 	for _, e := range extraEnv {
 		env = append(env, toContainerURL(e))
 	}
+
 	container, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository:   "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-pytransformer",
 		Tag:          "main", // todo: use latest after merging https://github.com/rudderlabs/rudder-pytransformer/pull/76
@@ -492,6 +493,13 @@ func startRudderPytransformer(
 		PortBindings: cfg.PortBindings,
 	}, cfg.hostConfigFn)
 	require.NoError(t, err, "failed to start rudder-pytransformer container")
+
+	t.Cleanup(func() {
+		if err := pool.Purge(container); err != nil {
+			t.Logf("Failed to purge pytransformer container: %v", err)
+		}
+	})
+
 	return container, cfg.url(container, containerPort)
 }
 

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -673,6 +673,7 @@ type mockGeoConfig struct {
 	mu         sync.Mutex
 	statusCode int
 	closeConn  bool
+	delay      time.Duration
 }
 
 func (c *mockGeoConfig) setResponse(statusCode int) {
@@ -680,12 +681,25 @@ func (c *mockGeoConfig) setResponse(statusCode int) {
 	defer c.mu.Unlock()
 	c.statusCode = statusCode
 	c.closeConn = false
+	c.delay = 0
 }
 
 func (c *mockGeoConfig) setConnectionClose() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.closeConn = true
+	c.delay = 0
+}
+
+// setSlow makes the mock /geoip/* handler block for "delay" before responding
+// with HTTP 200. Used to simulate a hung geolocation backend so the
+// pytransformer's per-request timeout (or its urllib3 wall-clock cap) fires.
+func (c *mockGeoConfig) setSlow(delay time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.statusCode = http.StatusOK
+	c.closeConn = false
+	c.delay = delay
 }
 
 // newConfigurableMockGeolocationService creates a mock geolocation HTTP server
@@ -705,6 +719,7 @@ func newConfigurableMockGeolocationService(t *testing.T) (*httptest.Server, *moc
 		cfg.mu.Lock()
 		code := cfg.statusCode
 		closeConn := cfg.closeConn
+		delay := cfg.delay
 		cfg.mu.Unlock()
 
 		if closeConn {
@@ -718,6 +733,15 @@ func newConfigurableMockGeolocationService(t *testing.T) (*httptest.Server, *moc
 			} else {
 				t.Log("MockGeolocation: failed to hijack connection")
 				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
+
+		if delay > 0 {
+			select {
+			case <-time.After(delay):
+			case <-r.Context().Done():
+				// Client gave up — stop waiting so we don't leak a goroutine.
 				return
 			}
 		}

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -448,7 +448,7 @@ func startOpenFaasFlask(
 func startRudderTransformer(
 	t *testing.T, pool *dockertest.Pool,
 	configBackendURL, openfaasGatewayURL string,
-) (*dockertest.Resource, string) {
+) string {
 	t.Helper()
 	const containerPort = "9090"
 	cfg := newContainerConfig(t, containerPort)
@@ -465,7 +465,17 @@ func startRudderTransformer(
 		PortBindings: cfg.PortBindings,
 	}, cfg.hostConfigFn)
 	require.NoError(t, err, "failed to start rudder-transformer container")
-	return container, cfg.url(container, containerPort)
+
+	t.Cleanup(func() {
+		if err := pool.Purge(container); err != nil {
+			t.Logf("Failed to purge rudder-transformer: %v", err)
+		}
+	})
+
+	transformerURL := cfg.url(container, containerPort)
+	waitForHealthy(t, pool, transformerURL, "rudder-transformer", container)
+
+	return transformerURL
 }
 
 // startRudderPytransformer starts a rudder-pytransformer container configured

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -464,7 +464,7 @@ func startRudderPytransformer(
 	t *testing.T, pool *dockertest.Pool,
 	configBackendURL string,
 	extraEnv ...string,
-) (*dockertest.Resource, string) {
+) string {
 	t.Helper()
 	const containerPort = "8080"
 	cfg := newContainerConfig(t, containerPort)
@@ -500,7 +500,10 @@ func startRudderPytransformer(
 		}
 	})
 
-	return container, cfg.url(container, containerPort)
+	pyURL := cfg.url(container, containerPort)
+	waitForHealthy(t, pool, pyURL, "rudder-pytransformer", container)
+
+	return pyURL
 }
 
 // waitForHealthy polls a service's /health endpoint until it returns 200 OK.

--- a/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
+++ b/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
@@ -482,7 +482,7 @@ func newCookieEchoServer(t *testing.T) (*httptest.Server, *atomic.Int64, *atomic
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n := hits.Add(1)
 		incoming := r.Header.Get("Cookie")
-		body := []byte(fmt.Sprintf(`{"received_cookie": %q}`, incoming))
+		body := fmt.Appendf(nil, `{"received_cookie": %q}`, incoming)
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 		// Unique cookie per response

--- a/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
+++ b/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
@@ -1,0 +1,227 @@
+package pytransformer_contract
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/processor/types"
+)
+
+// TestConnectionPoolCookieIsolation
+//
+// The test:
+//
+//  1. Starts a mock HTTP server that stamps a unique Set-Cookie header on
+//     every response AND echoes any incoming Cookie header back in the JSON
+//     body. Any leak is visible in the echoed body of a later request.
+//  2. Starts pytransformer with ENABLE_CONN_POOL=true and
+//     SANDBOX_POOL_MAX_SIZE=1 so ALL 10 parallel requests are serialized
+//     through ONE worker subprocess and therefore ONE _user_session. This
+//     is the worst case for leakage: if cookies could ever persist on the
+//     shared session, they will be observed here.
+//  3. Fires 10 concurrent /customTransform POSTs. Each transformation
+//     calls the cookie-echoing server once and copies the echoed Cookie
+//     header into the transformed event under "received_cookie".
+//  4. Asserts every transformation observed an empty Cookie header — if
+//     any carried a cookie from another invocation, the session leaked.
+//  5. Asserts the server saw exactly 10 hits so no event was silently
+//     dropped.
+//  6. Asserts the server saw exactly 1 new TCP connection (via the
+//     “ConnState“ hook used by “TestConnectionPoolBehavior“): with
+//     “USER_CONN_POOL_MAX_SIZE=1“ and a single worker subprocess the
+//     pooled session must reuse a single kept-alive socket across all
+//     10 invocations, proving that connection pooling is effective AND
+//     that stripping cookies did not accidentally force fresh handshakes.
+func TestConnectionPoolCookieIsolation(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
+
+	const (
+		versionID        = "cookie-isolation-v1"
+		parallelRequests = 10
+	)
+
+	cookieSrv, hits, newConns := newCookieEchoServer(t)
+
+	entries := map[string]configBackendEntry{
+		versionID: {code: fmt.Sprintf(`
+import requests
+
+def transformEvent(event, metadata):
+    resp = requests.get("%s/check")
+    data = resp.json()
+    # The mock echoes the incoming Cookie header. If the pooled session
+    # leaked state from a prior transformation, "received_cookie" will be
+    # non-empty — surfaced to the test via the transformed event.
+    event["received_cookie"] = data["received_cookie"]
+    # The response itself DID carry a Set-Cookie — we expose it so the
+    # test can assert the leak channel exists (the server sent a cookie,
+    # requests parsed it) even though nothing carried it forward.
+    event["response_cookie"] = resp.cookies.get("leaky", "")
+    event["status"] = resp.status_code
+    return event
+`, toContainerURL(cookieSrv.URL))},
+	}
+
+	configBackend := newContractConfigBackend(t, entries)
+	t.Cleanup(configBackend.Close)
+
+	pyURL := startRudderPytransformer(
+		t, pool, configBackend.URL,
+		"ENABLE_CONN_POOL=true",
+		// Single worker subprocess so every /customTransform request is
+		// dispatched through the SAME _user_session. Any cookie
+		// accumulated by an earlier invocation is guaranteed to be visible
+		// to later invocations, maximising leak-detection sensitivity.
+		"SANDBOX_POOL_MAX_SIZE=1",
+		// A single pooled connection forces the same underlying TCP
+		// socket to be reused across requests — the most aggressive
+		// pooling configuration, where leak mechanisms would be most
+		// pronounced.
+		"USER_CONN_POOL_MAX_SIZE=1",
+	)
+
+	type result struct {
+		idx            int
+		status         int
+		items          []types.TransformerResponse
+		receivedCookie string
+		responseCookie string
+		ok             bool
+	}
+
+	var (
+		wg      sync.WaitGroup
+		results = make([]result, parallelRequests)
+	)
+	for i := range parallelRequests {
+		wg.Go(func() {
+			msgID := fmt.Sprintf("msg-cookie-iso-%d", i)
+			events := []types.TransformerEvent{makeEvent(msgID, versionID)}
+			status, items := sendRawTransform(t, pyURL, events)
+
+			res := result{idx: i, status: status, items: items}
+			if len(items) == 1 && items[0].StatusCode == http.StatusOK {
+				gotReceived, okR := items[0].Output["received_cookie"].(string)
+				gotResponse, okP := items[0].Output["response_cookie"].(string)
+				if okR && okP {
+					res.receivedCookie = gotReceived
+					res.responseCookie = gotResponse
+					res.ok = true
+				}
+			}
+			results[i] = res
+		})
+	}
+	wg.Wait()
+
+	// Sanity: every transformation returned a 200 response and produced a
+	// single successful event whose output was parsed into our struct.
+	for _, r := range results {
+		require.Equal(t, http.StatusOK, r.status,
+			"request %d: /customTransform must return HTTP 200", r.idx)
+		require.Len(t, r.items, 1,
+			"request %d: expected exactly one transformer response item", r.idx)
+		require.Equal(t, http.StatusOK, r.items[0].StatusCode,
+			"request %d: per-event status must be 200 (error: %s)",
+			r.idx, r.items[0].Error)
+		require.True(t, r.ok,
+			"request %d: transformed event missing received_cookie/response_cookie fields", r.idx)
+	}
+
+	// PROOF THE LEAK CHANNEL EXISTS: every response MUST have carried a
+	// Set-Cookie ``leaky=secret_N`` header that the ``requests`` library
+	// parsed into ``resp.cookies``. Without this check, a regression that
+	// silently stopped the mock from setting cookies would make the
+	// leak-detection assertion below vacuously true.
+	for _, r := range results {
+		require.Regexp(t, "secret_[0-9]+", r.responseCookie,
+			"request %d: response must carry a leaky=secret_N cookie "+
+				"(got %q) — the leak channel must exist for the "+
+				"isolation assertion below to be meaningful",
+			r.idx, r.responseCookie)
+	}
+
+	// CORE ASSERTION: no transformation observed a cookie from any other
+	// transformation. A non-empty received_cookie on ANY event is proof
+	// that the shared pooled session leaked state across invocations.
+	for _, r := range results {
+		require.Empty(t, r.receivedCookie,
+			"request %d observed leaked cookie %q — the shared pooled "+
+				"user session must not carry Set-Cookie state across "+
+				"transformations (Bug 1 in rudder-pytransformer bugs.md)",
+			r.idx, r.receivedCookie)
+	}
+
+	// Exactly 10 hits: no silent retries, no silent drops. If this count
+	// drifts up, the test is noisy; if it drifts down, some transformation
+	// silently skipped its HTTP call and the cookie check above is
+	// vacuously true.
+	require.EqualValues(t, parallelRequests, hits.Load(),
+		"cookie server must have been hit exactly %d times "+
+			"(one per parallel transformation); got %d",
+		parallelRequests, hits.Load())
+
+	// Exactly ONE new TCP connection: with ENABLE_CONN_POOL=true,
+	// USER_CONN_POOL_MAX_SIZE=1 and SANDBOX_POOL_MAX_SIZE=1 the pooled
+	// session must serve every invocation from the same kept-alive
+	// socket. This is the same server-side proof used in
+	// ``TestConnectionPoolBehavior/ConnectionReusedWhenPoolEnabled``:
+	// ``http.StateNew`` fires exactly once per TCP handshake, so a
+	// count > 1 means the pool failed to reuse the connection and the
+	// test no longer exercises the "shared session" path that Bug 1
+	// lived on.
+	require.EqualValues(t, 1, newConns.Load(),
+		"expected exactly 1 new TCP connection for %d pooled requests, "+
+			"got %d — the pool must reuse a single kept-alive socket",
+		parallelRequests, newConns.Load())
+}
+
+// newCookieEchoServer returns an HTTP server that, on every request:
+//   - Stamps a unique Set-Cookie response header (leaky=secret_N). A naive
+//     shared requests.Session would store this cookie and re-send it on
+//     the next request to the same host.
+//   - Echoes the incoming Cookie header back in the JSON body under
+//     "received_cookie". A transformation that sees a non-empty value on
+//     its first (and only) call has observed a leaked cookie from another
+//     transformation that ran earlier on the same pooled session.
+//   - Setting Content-Length lets the client reuse the TCP connection
+//     without chunked transfer, so “http.StateNew“ fires exactly once
+//     per distinct TCP handshake — turning newConns into a reliable
+//     "how many connections were opened" counter.
+func newCookieEchoServer(t *testing.T) (*httptest.Server, *atomic.Int64, *atomic.Int64) {
+	t.Helper()
+	hits := &atomic.Int64{}
+	newConns := &atomic.Int64{}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := hits.Add(1)
+		incoming := r.Header.Get("Cookie")
+		body := []byte(fmt.Sprintf(`{"received_cookie": %q}`, incoming))
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		// Unique cookie per response
+		w.Header().Set("Set-Cookie", fmt.Sprintf("leaky=secret_%d; Path=/", n))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+	srv := httptest.NewUnstartedServer(handler)
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConns.Add(1)
+		}
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv, hits, newConns
+}

--- a/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
+++ b/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
@@ -311,13 +311,7 @@ def transformEvent(event, metadata):
 	t.Cleanup(mockGateway.Close)
 
 	t.Log("Starting rudder-transformer (old arch frontend)...")
-	transformerContainer, transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
-	t.Cleanup(func() {
-		if err := pool.Purge(transformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-transformer: %v", err)
-		}
-	})
-	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
+	transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
 
 	events := make([]types.TransformerEvent, numEvents)
 	for i := range events {

--- a/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
+++ b/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
@@ -160,7 +160,7 @@ def transformEvent(event, metadata):
 		require.Empty(t, r.receivedCookie,
 			"request %d observed leaked cookie %q — the shared pooled "+
 				"user session must not carry Set-Cookie state across "+
-				"transformations (Bug 1 in rudder-pytransformer bugs.md)",
+				"transformations",
 			r.idx, r.receivedCookie)
 	}
 
@@ -180,12 +180,98 @@ def transformEvent(event, metadata):
 	// ``TestConnectionPoolBehavior/ConnectionReusedWhenPoolEnabled``:
 	// ``http.StateNew`` fires exactly once per TCP handshake, so a
 	// count > 1 means the pool failed to reuse the connection and the
-	// test no longer exercises the "shared session" path that Bug 1
-	// lived on.
+	// test no longer exercises the shared-session path.
 	require.EqualValues(t, 1, newConns.Load(),
 		"expected exactly 1 new TCP connection for %d pooled requests, "+
 			"got %d — the pool must reuse a single kept-alive socket",
 		parallelRequests, newConns.Load())
+}
+
+// TestConnectionPoolRequestOptionIsolation verifies that per-request options
+// sent through bare requests calls never become defaults on the pooled user
+// session.
+func TestConnectionPoolRequestOptionIsolation(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
+
+	const versionID = "request-options-isolation-v1"
+
+	echoSrv := newSessionDefaultsEchoServer(t)
+
+	code := fmt.Sprintf(`
+import requests
+
+
+def hook(response, **kwargs):
+    response.headers["X-Hook-Ran"] = "1"
+    return response
+
+
+def transformEvent(event, metadata):
+    first = requests.get(
+        "%s/check",
+        params={"leak": "1"},
+        headers={"X-Leak": "1"},
+        auth=("user", "pass"),
+        cookies={"client_cookie": "1"},
+        hooks={"response": [hook]},
+        timeout=2,
+    )
+    first_data = first.json()
+
+    second = requests.get("%s/check", timeout=2)
+    second_data = second.json()
+
+    event["first_status"] = first.status_code
+    event["first_x_leak"] = first_data["x_leak"]
+    event["first_authorization"] = first_data["authorization"]
+    event["first_query"] = first_data["query"]
+    event["first_cookie"] = first_data["cookie"]
+    event["first_hook_ran"] = first.headers.get("X-Hook-Ran", "")
+    event["first_response_cookie"] = first.cookies.get("server_cookie", "")
+
+    event["second_status"] = second.status_code
+    event["second_x_leak"] = second_data["x_leak"]
+    event["second_authorization"] = second_data["authorization"]
+    event["second_query"] = second_data["query"]
+    event["second_cookie"] = second_data["cookie"]
+    event["second_hook_ran"] = second.headers.get("X-Hook-Ran", "")
+    return event
+`, toContainerURL(echoSrv.URL), toContainerURL(echoSrv.URL))
+
+	configBackend := newContractConfigBackend(t, map[string]configBackendEntry{
+		versionID: {code: code},
+	})
+	t.Cleanup(configBackend.Close)
+
+	pyURL := startRudderPytransformer(
+		t, pool, configBackend.URL,
+		"ENABLE_CONN_POOL=true",
+		"SANDBOX_POOL_MAX_SIZE=1",
+		"USER_CONN_POOL_MAX_SIZE=1",
+	)
+
+	event := makeEvent("msg-request-options-isolation", versionID)
+	status, items := sendRawTransform(t, pyURL, []types.TransformerEvent{event})
+	require.Equal(t, http.StatusOK, status)
+	require.Len(t, items, 1)
+	require.Equal(t, http.StatusOK, items[0].StatusCode, "event must succeed: %s", items[0].Error)
+
+	require.Equal(t, float64(http.StatusOK), items[0].Output["first_status"])
+	require.Equal(t, "1", items[0].Output["first_x_leak"])
+	require.NotEmpty(t, items[0].Output["first_authorization"], "first request must carry auth")
+	require.Equal(t, "leak=1", items[0].Output["first_query"])
+	require.Equal(t, "client_cookie=1", items[0].Output["first_cookie"])
+	require.Equal(t, "1", items[0].Output["first_hook_ran"])
+	require.Equal(t, "secret", items[0].Output["first_response_cookie"])
+
+	require.Equal(t, float64(http.StatusOK), items[0].Output["second_status"])
+	require.Empty(t, items[0].Output["second_x_leak"], "header must not carry into the next request")
+	require.Empty(t, items[0].Output["second_authorization"], "auth must not carry into the next request")
+	require.Empty(t, items[0].Output["second_query"], "params must not carry into the next request")
+	require.Empty(t, items[0].Output["second_cookie"], "cookies must not carry into the next request")
+	require.Empty(t, items[0].Output["second_hook_ran"], "response hook must not carry into the next request")
 }
 
 // newCookieEchoServer returns an HTTP server that, on every request:
@@ -224,4 +310,24 @@ func newCookieEchoServer(t *testing.T) (*httptest.Server, *atomic.Int64, *atomic
 	srv.Start()
 	t.Cleanup(srv.Close)
 	return srv, hits, newConns
+}
+
+func newSessionDefaultsEchoServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := []byte(fmt.Sprintf(
+			`{"x_leak": %q, "authorization": %q, "query": %q, "cookie": %q}`,
+			r.Header.Get("X-Leak"),
+			r.Header.Get("Authorization"),
+			r.URL.RawQuery,
+			r.Header.Get("Cookie"),
+		))
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.Header().Set("Set-Cookie", "server_cookie=secret; Path=/")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
 }

--- a/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
+++ b/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
@@ -334,41 +334,21 @@ def transformEvent(event, metadata):
 	// Every case must match the old arch field-for-field.
 	newArchCases := []struct {
 		name           string
-		enableConnPool string
-		extraEnv       []string
-		// assertOneConn is only meaningful when the pool is enabled: the
-		// ConnState counter on the echo server must observe exactly one
-		// new TCP socket across every HTTP call the transformations make.
-		assertOneConn bool
+		enableConnPool bool
 	}{
-		{
-			name:           "ConnPoolDisabled",
-			enableConnPool: "false",
-			// No pool-size pins: without ``ENABLE_CONN_POOL`` bare
-			// ``requests.get`` creates a throwaway Session per call, so
-			// pinning the pool size would be misleading decoration.
-			extraEnv:      nil,
-			assertOneConn: false,
-		},
-		{
-			name:           "ConnPoolEnabled",
-			enableConnPool: "true",
-			// Pin subprocess + pool count to 1 so every event and every
-			// HTTP call is forced through the SAME
-			// ``StatelessPooledSession``. This is the worst case for
-			// option leakage and the only configuration where
-			// ``newConns == 1`` is provable.
-			extraEnv: []string{
-				"SANDBOX_POOL_MAX_SIZE=1",
-				"USER_CONN_POOL_MAX_SIZE=1",
-			},
-			assertOneConn: true,
-		},
+		{name: "ConnPoolDisabled", enableConnPool: false},
+		{name: "ConnPoolEnabled", enableConnPool: true},
 	}
 
 	for _, tc := range newArchCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pyEnv := append([]string{"ENABLE_CONN_POOL=" + tc.enableConnPool}, tc.extraEnv...)
+			pyEnv := []string{"ENABLE_CONN_POOL=" + strconv.FormatBool(tc.enableConnPool)}
+			if tc.enableConnPool {
+				pyEnv = append(pyEnv,
+					"SANDBOX_POOL_MAX_SIZE=1",
+					"USER_CONN_POOL_MAX_SIZE=1",
+				)
+			}
 			t.Logf("Starting rudder-pytransformer with %v...", pyEnv)
 			pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL, pyEnv...)
 
@@ -396,7 +376,7 @@ def transformEvent(event, metadata):
 			require.Equalf(t, numEvents, len(oldResp.Events), "old arch: all %d events must succeed", numEvents)
 			require.Empty(t, oldResp.FailedEvents, "old arch: no failed events expected")
 			require.Equalf(t, numEvents, len(newResp.Events),
-				"new arch (ENABLE_CONN_POOL=%s): all %d events must succeed",
+				"new arch (ENABLE_CONN_POOL=%t): all %d events must succeed",
 				tc.enableConnPool, numEvents)
 			require.Empty(t, newResp.FailedEvents, "new arch: no failed events expected")
 
@@ -466,12 +446,12 @@ def transformEvent(event, metadata):
 			// transformation code but not to this test) surfaces here.
 			diff, equal := oldResp.Equal(&newResp)
 			require.Truef(t, equal,
-				"ENABLE_CONN_POOL=%s: old and new architectures must produce identical responses:\n%s",
+				"ENABLE_CONN_POOL=%t: old and new architectures must produce identical responses:\n%s",
 				tc.enableConnPool, diff)
 
 			env.assertRetryCountsMatch(t)
 
-			if tc.assertOneConn {
+			if tc.enableConnPool {
 				// With ``ENABLE_CONN_POOL=true``, ``SANDBOX_POOL_MAX_SIZE=1``
 				// and ``USER_CONN_POOL_MAX_SIZE=1`` every one of the
 				// ``numEvents * 2`` HTTP calls must have been served by

--- a/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
+++ b/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
@@ -1,6 +1,7 @@
 package pytransformer_contract
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -13,6 +14,8 @@ import (
 
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 
 	"github.com/rudderlabs/rudder-server/processor/types"
 )
@@ -187,18 +190,59 @@ def transformEvent(event, metadata):
 		parallelRequests, newConns.Load())
 }
 
-// TestConnectionPoolRequestOptionIsolation verifies that per-request options
-// sent through bare requests calls never become defaults on the pooled user
-// session.
+// TestConnectionPoolRequestOptionIsolation locks the cross-architecture
+// contract that per-request options attached to a bare “requests.<verb>“
+// call never become defaults on the user-facing HTTP session.
+//
+// The goal is parity, not a one-sided property check. The same transformation
+// code runs through three stacks:
+//
+//  1. Old arch — rudder-transformer + openfaas-flask-base (vanilla
+//     “requests“ inside the OpenFaaS container).
+//  2. New arch, “ENABLE_CONN_POOL=false“ — rudder-pytransformer with the
+//     pooling wrapper disabled, so bare “requests.get“ spins up a
+//     throwaway “Session“ per call just like the old arch.
+//  3. New arch, “ENABLE_CONN_POOL=true“ — rudder-pytransformer routing
+//     every bare call through a shared “StatelessPooledSession“ pinned
+//     to a single TCP socket. This is the path that could regress if the
+//     pooling wrapper ever started persisting “headers“ / “auth“ /
+//     “params“ / “cookies“ / “hooks“ onto the shared session.
+//
+// Every configuration must produce the exact same “types.Response“, so any
+// drift introduced by the pooling layer surfaces via “oldResp.Equal(&newResp)“.
+//
+// The batch of transformation events is larger than one so the assertion
+// covers cross-transformation isolation on the shared session, not only
+// cross-call isolation within one transformation.
+//
+// In the “ConnPoolEnabled“ case the echo server's “ConnState“ counter
+// is also asserted: with “SANDBOX_POOL_MAX_SIZE=1“ and
+// “USER_CONN_POOL_MAX_SIZE=1“ every HTTP call the transformations make
+// MUST flow through one kept-alive socket, otherwise the test is not
+// actually exercising the shared-session path and the isolation assertion
+// is vacuously true.
 func TestConnectionPoolRequestOptionIsolation(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 	pool.MaxWait = 2 * time.Minute
 
-	const versionID = "request-options-isolation-v1"
+	const (
+		versionID = "request-options-isolation-v1"
+		// Each event makes 2 sequential HTTP calls. ``numEvents`` > 1 so the
+		// batch exercises isolation ACROSS transformations sharing the
+		// pooled session, not just across sequential calls inside one
+		// transformation.
+		numEvents = 3
+	)
 
-	echoSrv := newSessionDefaultsEchoServer(t)
+	echoSrv, newConns := newSessionDefaultsEchoServer(t)
 
+	// User code: every ``transformEvent`` invocation issues two sequential
+	// requests. The first primes a vanilla ``requests.Session`` with every
+	// per-request option ``requests`` supports; the second issues a bare
+	// GET. If any option persisted to session state — on the old-arch
+	// vanilla session OR the new-arch ``StatelessPooledSession`` — the
+	// second call would observe it and the parity check would fail.
 	code := fmt.Sprintf(`
 import requests
 
@@ -229,6 +273,14 @@ def transformEvent(event, metadata):
     event["first_query"] = first_data["query"]
     event["first_cookie"] = first_data["cookie"]
     event["first_hook_ran"] = first.headers.get("X-Hook-Ran", "")
+    # Proof-of-mechanism (not a persistence check): the echo server sends
+    # Set-Cookie: server_cookie=secret on every response, and the requests
+    # library parses it into the per-RESPONSE cookie jar (first.cookies is
+    # a RequestsCookieJar bound to the response, not to the session). If
+    # this field were ever empty the parity / isolation assertions below
+    # would be vacuously true, so the Go test explicitly requires it to
+    # equal "secret" on both stacks — mirrors the proof-of-leak-channel
+    # check in TestConnectionPoolCookieIsolation.
     event["first_response_cookie"] = first.cookies.get("server_cookie", "")
 
     event["second_status"] = second.status_code
@@ -245,33 +297,196 @@ def transformEvent(event, metadata):
 	})
 	t.Cleanup(configBackend.Close)
 
-	pyURL := startRudderPytransformer(
-		t, pool, configBackend.URL,
-		"ENABLE_CONN_POOL=true",
-		"SANDBOX_POOL_MAX_SIZE=1",
-		"USER_CONN_POOL_MAX_SIZE=1",
-	)
+	// --- Old architecture (rudder-transformer + openfaas-flask-base) ---
+	//
+	// Shared across every new-arch subtest so it becomes the reference
+	// behaviour each ``ENABLE_CONN_POOL`` value must match. Mirrors the
+	// setup in TestBareRequestsPositionalParamsContract.
 
-	event := makeEvent("msg-request-options-isolation", versionID)
-	status, items := sendRawTransform(t, pyURL, []types.TransformerEvent{event})
-	require.Equal(t, http.StatusOK, status)
-	require.Len(t, items, 1)
-	require.Equal(t, http.StatusOK, items[0].StatusCode, "event must succeed: %s", items[0].Error)
+	t.Log("Starting openfaas-flask-base (old arch backend)...")
+	openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
 
-	require.Equal(t, float64(http.StatusOK), items[0].Output["first_status"])
-	require.Equal(t, "1", items[0].Output["first_x_leak"])
-	require.NotEmpty(t, items[0].Output["first_authorization"], "first request must carry auth")
-	require.Equal(t, "leak=1", items[0].Output["first_query"])
-	require.Equal(t, "client_cookie=1", items[0].Output["first_cookie"])
-	require.Equal(t, "1", items[0].Output["first_hook_ran"])
-	require.Equal(t, "secret", items[0].Output["first_response_cookie"])
+	t.Log("Starting mock OpenFaaS gateway...")
+	mockGateway, _ := newMockOpenFaaSGateway(t, func() string { return openFaasURL })
+	t.Cleanup(mockGateway.Close)
 
-	require.Equal(t, float64(http.StatusOK), items[0].Output["second_status"])
-	require.Empty(t, items[0].Output["second_x_leak"], "header must not carry into the next request")
-	require.Empty(t, items[0].Output["second_authorization"], "auth must not carry into the next request")
-	require.Empty(t, items[0].Output["second_query"], "params must not carry into the next request")
-	require.Empty(t, items[0].Output["second_cookie"], "cookies must not carry into the next request")
-	require.Empty(t, items[0].Output["second_hook_ran"], "response hook must not carry into the next request")
+	t.Log("Starting rudder-transformer (old arch frontend)...")
+	transformerContainer, transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
+	t.Cleanup(func() {
+		if err := pool.Purge(transformerContainer); err != nil {
+			t.Logf("Failed to purge rudder-transformer: %v", err)
+		}
+	})
+	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
+
+	events := make([]types.TransformerEvent, numEvents)
+	for i := range events {
+		events[i] = makeEvent(fmt.Sprintf("msg-req-opt-iso-%d", i), versionID)
+	}
+
+	// --- New architecture (rudder-pytransformer) ---
+	//
+	// Parameterized over both values of ``ENABLE_CONN_POOL``:
+	//   - ``false``: bare calls hit the throwaway-session path (same as
+	//     old arch, isolation is trivial).
+	//   - ``true``: bare calls route through ``StatelessPooledSession``;
+	//     this is the path under test.
+	// Every case must match the old arch field-for-field.
+	newArchCases := []struct {
+		name           string
+		enableConnPool string
+		extraEnv       []string
+		// assertOneConn is only meaningful when the pool is enabled: the
+		// ConnState counter on the echo server must observe exactly one
+		// new TCP socket across every HTTP call the transformations make.
+		assertOneConn bool
+	}{
+		{
+			name:           "ConnPoolDisabled",
+			enableConnPool: "false",
+			// No pool-size pins: without ``ENABLE_CONN_POOL`` bare
+			// ``requests.get`` creates a throwaway Session per call, so
+			// pinning the pool size would be misleading decoration.
+			extraEnv:      nil,
+			assertOneConn: false,
+		},
+		{
+			name:           "ConnPoolEnabled",
+			enableConnPool: "true",
+			// Pin subprocess + pool count to 1 so every event and every
+			// HTTP call is forced through the SAME
+			// ``StatelessPooledSession``. This is the worst case for
+			// option leakage and the only configuration where
+			// ``newConns == 1`` is provable.
+			extraEnv: []string{
+				"SANDBOX_POOL_MAX_SIZE=1",
+				"USER_CONN_POOL_MAX_SIZE=1",
+			},
+			assertOneConn: true,
+		},
+	}
+
+	for _, tc := range newArchCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pyEnv := append([]string{"ENABLE_CONN_POOL=" + tc.enableConnPool}, tc.extraEnv...)
+			t.Logf("Starting rudder-pytransformer with %v...", pyEnv)
+			pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL, pyEnv...)
+
+			// Fresh env per subtest so memstats retry counters don't bleed
+			// between runs — memstats accumulates and cannot be reset.
+			env := newBCTestEnv(t, transformerURL, pyTransformerURL,
+				withFailOnError(),
+				withLimitedRetryableHTTPRetries(),
+			)
+
+			t.Log("Sending batch to old arch (openfaas-flask-base)...")
+			oldResp := env.OldClient.Transform(context.Background(), events)
+			t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+
+			// Only the NEW-arch run's TCP activity counts toward the pool
+			// reuse assertion — reset the counter so every connection the
+			// old-arch stack (openfaas-flask-base) opened to the shared
+			// echo server is excluded.
+			newConns.Store(0)
+
+			t.Log("Sending batch to new arch (rudder-pytransformer)...")
+			newResp := env.NewClient.Transform(context.Background(), events)
+			t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+
+			require.Equalf(t, numEvents, len(oldResp.Events), "old arch: all %d events must succeed", numEvents)
+			require.Empty(t, oldResp.FailedEvents, "old arch: no failed events expected")
+			require.Equalf(t, numEvents, len(newResp.Events),
+				"new arch (ENABLE_CONN_POOL=%s): all %d events must succeed",
+				tc.enableConnPool, numEvents)
+			require.Empty(t, newResp.FailedEvents, "new arch: no failed events expected")
+
+			// Proof-of-mechanism: every event on BOTH stacks must have
+			// carried the full set of per-request options on its first
+			// call. Without these checks, a regression that stopped the
+			// mock echo from observing any single option would make the
+			// isolation parity check below vacuously true for that option.
+			for _, resp := range []*types.Response{&oldResp, &newResp} {
+				for _, ev := range resp.Events {
+					require.Equalf(t, "1", ev.Output["first_x_leak"],
+						"msg=%s: first request must carry X-Leak header",
+						ev.Metadata.MessageID)
+					// Exact match (rather than NotEmpty) — base64("user:pass").
+					// A malformed Authorization header would still be
+					// non-empty but would silently diverge from the
+					// old-arch reference.
+					require.Equalf(t, "Basic dXNlcjpwYXNz", ev.Output["first_authorization"],
+						"msg=%s: first request must carry Basic user:pass auth",
+						ev.Metadata.MessageID)
+					require.Equalf(t, "leak=1", ev.Output["first_query"],
+						"msg=%s: first request must carry params",
+						ev.Metadata.MessageID)
+					require.Equalf(t, "client_cookie=1", ev.Output["first_cookie"],
+						"msg=%s: first request must carry Cookie",
+						ev.Metadata.MessageID)
+					require.Equalf(t, "1", ev.Output["first_hook_ran"],
+						"msg=%s: response hook must have stamped X-Hook-Ran",
+						ev.Metadata.MessageID)
+					require.Equalf(t, "secret", ev.Output["first_response_cookie"],
+						"msg=%s: echo server must have sent Set-Cookie and requests must have parsed it — otherwise the parity check below is vacuous",
+						ev.Metadata.MessageID)
+				}
+			}
+
+			// Core isolation assertion: the second bare GET, issued without
+			// any options, must see NONE of the state the first call
+			// attached. Vanilla ``requests.Session`` does not persist
+			// per-request kwargs, so the old arch passes this trivially;
+			// ``StatelessPooledSession`` must match that guarantee on the
+			// new-arch pooled path. Per-field asserts keep failure output
+			// actionable; ``Equal`` below is the strict parity catch-all.
+			for _, resp := range []*types.Response{&oldResp, &newResp} {
+				for _, ev := range resp.Events {
+					require.Emptyf(t, ev.Output["second_x_leak"],
+						"msg=%s: header must not carry into the next request",
+						ev.Metadata.MessageID)
+					require.Emptyf(t, ev.Output["second_authorization"],
+						"msg=%s: auth must not carry into the next request",
+						ev.Metadata.MessageID)
+					require.Emptyf(t, ev.Output["second_query"],
+						"msg=%s: params must not carry into the next request",
+						ev.Metadata.MessageID)
+					require.Emptyf(t, ev.Output["second_cookie"],
+						"msg=%s: cookies must not carry into the next request",
+						ev.Metadata.MessageID)
+					require.Emptyf(t, ev.Output["second_hook_ran"],
+						"msg=%s: response hook must not carry into the next request",
+						ev.Metadata.MessageID)
+				}
+			}
+
+			// Strict parity: old arch and new arch must produce identical
+			// responses field-for-field. Any divergence the per-field
+			// asserts above missed (e.g. a difference in ``Metadata``,
+			// ``StatTags``, or an Output key that was added to the
+			// transformation code but not to this test) surfaces here.
+			diff, equal := oldResp.Equal(&newResp)
+			require.Truef(t, equal,
+				"ENABLE_CONN_POOL=%s: old and new architectures must produce identical responses:\n%s",
+				tc.enableConnPool, diff)
+
+			env.assertRetryCountsMatch(t)
+
+			if tc.assertOneConn {
+				// With ``ENABLE_CONN_POOL=true``, ``SANDBOX_POOL_MAX_SIZE=1``
+				// and ``USER_CONN_POOL_MAX_SIZE=1`` every one of the
+				// ``numEvents * 2`` HTTP calls must have been served by
+				// the SAME kept-alive socket. A count > 1 means the pool
+				// silently failed to reuse the connection and the test no
+				// longer exercises the shared-session path — the
+				// isolation assertion above becomes meaningless (each
+				// call would be getting a fresh session). Mirrors the
+				// same-shape assertion in TestConnectionPoolCookieIsolation.
+				require.EqualValuesf(t, 1, newConns.Load(),
+					"expected exactly 1 new TCP connection for %d pooled requests, got %d — the pool must reuse a single kept-alive socket",
+					numEvents*2, newConns.Load())
+			}
+		})
+	}
 }
 
 // newCookieEchoServer returns an HTTP server that, on every request:
@@ -312,22 +527,49 @@ func newCookieEchoServer(t *testing.T) (*httptest.Server, *atomic.Int64, *atomic
 	return srv, hits, newConns
 }
 
-func newSessionDefaultsEchoServer(t *testing.T) *httptest.Server {
+// newSessionDefaultsEchoServer returns an HTTP server used by the per-request
+// option isolation contract. Every response:
+//   - Echoes the incoming “X-Leak“ / “Authorization“ / query string /
+//     “Cookie“ headers back as JSON so user transformation code can prove
+//     which options reached the server.
+//   - Stamps “Set-Cookie: server_cookie=secret“ so the caller can verify
+//     the mock leak channel exists (see the “first_response_cookie“
+//     proof-of-mechanism check in “TestConnectionPoolRequestOptionIsolation“).
+//   - Sets “Content-Length“ so the client can keep-alive the TCP socket
+//     without chunked transfer.
+//
+// The “ConnState“ hook counts “http.StateNew“ transitions into the
+// returned “*atomic.Int64“ so the test can assert that the pytransformer
+// pooled session reused a single kept-alive connection across every call —
+// the same technique “newCookieEchoServer“ uses.
+func newSessionDefaultsEchoServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
 	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body := []byte(fmt.Sprintf(
-			`{"x_leak": %q, "authorization": %q, "query": %q, "cookie": %q}`,
-			r.Header.Get("X-Leak"),
-			r.Header.Get("Authorization"),
-			r.URL.RawQuery,
-			r.Header.Get("Cookie"),
-		))
+	newConns := &atomic.Int64{}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := jsonrs.Marshal(map[string]string{
+			"x_leak":        r.Header.Get("X-Leak"),
+			"authorization": r.Header.Get("Authorization"),
+			"query":         r.URL.RawQuery,
+			"cookie":        r.Header.Get("Cookie"),
+		})
+		if err != nil {
+			t.Errorf("sessionDefaultsEchoServer: failed to marshal body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 		w.Header().Set("Set-Cookie", "server_cookie=secret; Path=/")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(body)
-	}))
+	})
+	srv := httptest.NewUnstartedServer(handler)
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConns.Add(1)
+		}
+	}
+	srv.Start()
 	t.Cleanup(srv.Close)
-	return srv
+	return srv, newConns
 }

--- a/integration_test/pytransformer_contract/dns_cache_contract_test.go
+++ b/integration_test/pytransformer_contract/dns_cache_contract_test.go
@@ -73,7 +73,6 @@ def transformEvent(event, metadata):
 		"DNS_CACHE_ENABLED=true",
 		"DNS_CACHE_TTL_S=300",
 	)
-	t.Cleanup(func() { _ = pool.Purge(container) })
 	waitForHealthy(t, pool, pyURL, "pytransformer", container)
 
 	// requireCorrectServer asserts that the response contains a single
@@ -223,7 +222,6 @@ def transformEvent(event, metadata):
 		t, pool, configBackend.URL,
 		"DNS_OVERRIDES=custom-api.test,"+hostIP,
 	)
-	t.Cleanup(func() { _ = pool.Purge(container) })
 	waitForHealthy(t, pool, pyURL, "pytransformer", container)
 
 	t.Run("OverrideResolvesToCorrectServer", func(t *testing.T) {
@@ -316,7 +314,6 @@ def transformEvent(event, metadata):
 		"DNS_CACHE_TTL_S=300",
 		"DNS_OVERRIDES=custom-api.test,"+hostIP,
 	)
-	t.Cleanup(func() { _ = pool.Purge(container) })
 	waitForHealthy(t, pool, pyURL, "pytransformer", container)
 
 	// Interleave requests between override and cached paths

--- a/integration_test/pytransformer_contract/dns_cache_contract_test.go
+++ b/integration_test/pytransformer_contract/dns_cache_contract_test.go
@@ -68,12 +68,11 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, entries)
 	t.Cleanup(configBackend.Close)
 
-	container, pyURL := startRudderPytransformer(
+	pyURL := startRudderPytransformer(
 		t, pool, configBackend.URL,
 		"DNS_CACHE_ENABLED=true",
 		"DNS_CACHE_TTL_S=300",
 	)
-	waitForHealthy(t, pool, pyURL, "pytransformer", container)
 
 	// requireCorrectServer asserts that the response contains a single
 	// successfully transformed event whose external.server field matches
@@ -218,11 +217,10 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, entries)
 	t.Cleanup(configBackend.Close)
 
-	container, pyURL := startRudderPytransformer(
+	pyURL := startRudderPytransformer(
 		t, pool, configBackend.URL,
 		"DNS_OVERRIDES=custom-api.test,"+hostIP,
 	)
-	waitForHealthy(t, pool, pyURL, "pytransformer", container)
 
 	t.Run("OverrideResolvesToCorrectServer", func(t *testing.T) {
 		events := []types.TransformerEvent{makeEvent("msg-override-1", versionID)}
@@ -308,13 +306,12 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, entries)
 	t.Cleanup(configBackend.Close)
 
-	container, pyURL := startRudderPytransformer(
+	pyURL := startRudderPytransformer(
 		t, pool, configBackend.URL,
 		"DNS_CACHE_ENABLED=true",
 		"DNS_CACHE_TTL_S=300",
 		"DNS_OVERRIDES=custom-api.test,"+hostIP,
 	)
-	waitForHealthy(t, pool, pyURL, "pytransformer", container)
 
 	// Interleave requests between override and cached paths
 	var wg sync.WaitGroup

--- a/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
@@ -1353,12 +1353,11 @@ def transformEvent(event, metadata):
 	})
 
 	// Start shared rudder-pytransformer with geolocation URL.
-	_, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL, "GEOLOCATION_URL="+geoURL)
+	pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL, "GEOLOCATION_URL="+geoURL)
 
 	// Wait for shared services to be healthy.
 	t.Log("Waiting for shared services to be healthy...")
 	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
-	waitForHealthy(t, pool, pyTransformerURL, "rudder-pytransformer")
 
 	// Run subtests sequentially.
 	for _, st := range subtests {
@@ -1614,11 +1613,10 @@ def transformBatch(events, metadata):
 	})
 
 	// Start shared rudder-pytransformer (WITHOUT geolocation URL).
-	_, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
+	pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
 
 	t.Log("Waiting for shared services to be healthy...")
 	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
-	waitForHealthy(t, pool, pyTransformerURL, "rudder-pytransformer")
 
 	for _, st := range subtests {
 		t.Run(st.name, func(t *testing.T) {
@@ -2448,7 +2446,7 @@ def transformEvent(event, metadata):
 	// low as a guard for any future subtest exercising user HTTP traffic; it
 	// does NOT affect geolocation calls — see
 	// TestSandboxHTTPTimeoutDoesNotCapGeolocation.
-	_, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL,
+	pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL,
 		"GEOLOCATION_URL="+geoURL,
 		"SANDBOX_HTTP_TIMEOUT_S=0.5",
 		"GEOLOCATION_TIMEOUT_SECS=0.5",
@@ -2457,7 +2455,6 @@ def transformEvent(event, metadata):
 	// Wait for shared services to be healthy.
 	t.Log("Waiting for shared services to be healthy...")
 	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
-	waitForHealthy(t, pool, pyTransformerURL, "rudder-pytransformer")
 
 	// Run subtests sequentially.
 	for _, st := range subtests {

--- a/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
@@ -2352,6 +2353,63 @@ def transformBatch(events, metadata):
 				}
 			},
 		},
+		{
+			// Locks the contract that a slow/hung geolocation backend is
+			// distinguished from a slow user HTTP call: it must propagate as
+			// a retryable HTTP 503 (GeolocationServerError → retry) rather
+			// than a per-event 400. The mock service blocks for 1s while
+			// the pytransformer container is configured with a 0.5s cap, so
+			// either the urllib3 wall-clock patch or the geolocation
+			// session timeout fires first — both routes wrap the timeout in
+			// GeolocationServerError(BaseException), which bypasses the
+			// user-code except-Exception and surfaces as retryable.
+			name:      "GeoTimeout",
+			versionID: "bc-geo-timeout-v1",
+			config: configBackendEntry{code: `
+def transformEvent(event, metadata):
+    try:
+        result = geolocation("1.2.3.4")
+        event["geo"] = result
+    except Exception as e:
+        # New arch must NOT reach this branch — GeolocationServerError
+        # inherits BaseException so it bypasses except-Exception and
+        # propagates to the worker as a retryable 503.
+        event["geo_error"] = str(e)
+    return event
+`},
+			setup:               func() { mockGeoCfg.setSlow(1 * time.Second) },
+			skipRetryCountMatch: true,
+			run: func(t *testing.T, env *bcTestEnv) {
+				const versionID = "bc-geo-timeout-v1"
+
+				events := []types.TransformerEvent{
+					makeEvent("msg-1", versionID),
+				}
+
+				// Old arch: openfaas-flask-base catches the timeout via
+				// `except Exception` so the user code records geo_error
+				// and the event succeeds.
+
+				// New arch: timeout → GeolocationServerError →
+				// HTTP 503 + X-Rudder-Should-Retry → retries exhausted →
+				// failed event (with the user's `event["geo_error"]`
+				// branch never executed).
+				newResp := env.NewClient.Transform(context.Background(), events)
+				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				require.Len(t, newResp.Events, 0,
+					"new arch: slow geolocation must NOT produce a success event "+
+						"(GeolocationServerError must bypass user except-Exception)")
+				require.Len(t, newResp.FailedEvents, 1,
+					"new arch: slow geolocation must surface as a failed event after retries")
+				require.Contains(t, newResp.FailedEvents[0].Error,
+					"transformer returned status code: 503",
+					"new arch: failed event must carry the correct error message")
+
+				retriesCounter := env.NewStats.GetByName("processor_user_transformer_http_retries")
+				require.Len(t, retriesCounter, 1)
+				require.EqualValues(t, 2, retriesCounter[0].Value)
+			},
+		},
 	}
 
 	pool, err := dockertest.NewPool("")
@@ -2394,7 +2452,16 @@ def transformBatch(events, metadata):
 	})
 
 	// Start shared rudder-pytransformer with configurable mock geolocation URL.
-	pyTransformerContainer, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL, "GEOLOCATION_URL="+geoURL)
+	// SANDBOX_HTTP_TIMEOUT_S is set short so the GeoTimeout subtest's slow
+	// handler (1s delay) trips the urllib3 wall-clock cap quickly. Other
+	// subtests in this suite trigger failures via 5xx / connection reset and
+	// don't depend on the timeout magnitude, so the lower cap is safe for
+	// the whole shared container.
+	pyTransformerContainer, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL,
+		"GEOLOCATION_URL="+geoURL,
+		"SANDBOX_HTTP_TIMEOUT_S=0.5",
+		"GEOLOCATION_TIMEOUT_SECS=0.5",
+	)
 	t.Cleanup(func() {
 		if err := pool.Purge(pyTransformerContainer); err != nil {
 			t.Logf("Failed to purge rudder-pytransformer: %v", err)

--- a/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
@@ -2345,12 +2345,11 @@ def transformBatch(events, metadata):
 			// Locks the contract that a slow/hung geolocation backend is
 			// distinguished from a slow user HTTP call: it must propagate as
 			// a retryable HTTP 503 (GeolocationServerError → retry) rather
-			// than a per-event 400. The mock service blocks for 1s while
-			// GEOLOCATION_TIMEOUT_SECS=0.5, so the geolocation session
-			// deadline fires first and raises GeolocationServerError
-			// (BaseException), which bypasses the user-code except-Exception
-			// and surfaces as retryable. SANDBOX_HTTP_TIMEOUT_S does NOT
-			// apply to internal geolocation traffic — see
+			// than a per-event 400. The mock service blocks for longer than
+			// GEOLOCATION_TIMEOUT_SECS, so the geolocation session
+			// deadline fires and raises GeolocationServerError (BaseException),
+			// which bypasses the user-code except-Exception and surfaces as retryable.
+			// SANDBOX_HTTP_TIMEOUT_S does NOT apply to internal geolocation traffic — see
 			// TestSandboxHTTPTimeoutDoesNotCapGeolocation.
 			name:      "GeoTimeout",
 			versionID: "bc-geo-timeout-v1",

--- a/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
@@ -2366,7 +2366,7 @@ def transformEvent(event, metadata):
         event["geo_error"] = str(e)
     return event
 `},
-			setup:               func() { mockGeoCfg.setSlow(1 * time.Second) },
+			setup:               func() { mockGeoCfg.setSlow(500 * time.Millisecond) },
 			skipRetryCountMatch: true,
 			run: func(t *testing.T, env *bcTestEnv) {
 				const versionID = "bc-geo-timeout-v1"
@@ -2448,8 +2448,8 @@ def transformEvent(event, metadata):
 	// TestSandboxHTTPTimeoutDoesNotCapGeolocation.
 	pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL,
 		"GEOLOCATION_URL="+geoURL,
-		"SANDBOX_HTTP_TIMEOUT_S=0.5",
-		"GEOLOCATION_TIMEOUT_SECS=0.5",
+		"SANDBOX_HTTP_TIMEOUT_S=0.1",
+		"GEOLOCATION_TIMEOUT_SECS=0.1",
 	)
 
 	// Wait for shared services to be healthy.

--- a/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
@@ -1353,12 +1353,7 @@ def transformEvent(event, metadata):
 	})
 
 	// Start shared rudder-pytransformer with geolocation URL.
-	pyTransformerContainer, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL, "GEOLOCATION_URL="+geoURL)
-	t.Cleanup(func() {
-		if err := pool.Purge(pyTransformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-pytransformer: %v", err)
-		}
-	})
+	_, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL, "GEOLOCATION_URL="+geoURL)
 
 	// Wait for shared services to be healthy.
 	t.Log("Waiting for shared services to be healthy...")
@@ -1619,12 +1614,7 @@ def transformBatch(events, metadata):
 	})
 
 	// Start shared rudder-pytransformer (WITHOUT geolocation URL).
-	pyTransformerContainer, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
-	t.Cleanup(func() {
-		if err := pool.Purge(pyTransformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-pytransformer: %v", err)
-		}
-	})
+	_, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
 
 	t.Log("Waiting for shared services to be healthy...")
 	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
@@ -2458,16 +2448,11 @@ def transformEvent(event, metadata):
 	// low as a guard for any future subtest exercising user HTTP traffic; it
 	// does NOT affect geolocation calls — see
 	// TestSandboxHTTPTimeoutDoesNotCapGeolocation.
-	pyTransformerContainer, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL,
+	_, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL,
 		"GEOLOCATION_URL="+geoURL,
 		"SANDBOX_HTTP_TIMEOUT_S=0.5",
 		"GEOLOCATION_TIMEOUT_SECS=0.5",
 	)
-	t.Cleanup(func() {
-		if err := pool.Purge(pyTransformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-pytransformer: %v", err)
-		}
-	})
 
 	// Wait for shared services to be healthy.
 	t.Log("Waiting for shared services to be healthy...")

--- a/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
@@ -2358,11 +2358,12 @@ def transformBatch(events, metadata):
 			// distinguished from a slow user HTTP call: it must propagate as
 			// a retryable HTTP 503 (GeolocationServerError → retry) rather
 			// than a per-event 400. The mock service blocks for 1s while
-			// the pytransformer container is configured with a 0.5s cap, so
-			// either the urllib3 wall-clock patch or the geolocation
-			// session timeout fires first — both routes wrap the timeout in
-			// GeolocationServerError(BaseException), which bypasses the
-			// user-code except-Exception and surfaces as retryable.
+			// GEOLOCATION_TIMEOUT_SECS=0.5, so the geolocation session
+			// deadline fires first and raises GeolocationServerError
+			// (BaseException), which bypasses the user-code except-Exception
+			// and surfaces as retryable. SANDBOX_HTTP_TIMEOUT_S does NOT
+			// apply to internal geolocation traffic — see
+			// TestSandboxHTTPTimeoutDoesNotCapGeolocation.
 			name:      "GeoTimeout",
 			versionID: "bc-geo-timeout-v1",
 			config: configBackendEntry{code: `
@@ -2452,11 +2453,11 @@ def transformEvent(event, metadata):
 	})
 
 	// Start shared rudder-pytransformer with configurable mock geolocation URL.
-	// SANDBOX_HTTP_TIMEOUT_S is set short so the GeoTimeout subtest's slow
-	// handler (1s delay) trips the urllib3 wall-clock cap quickly. Other
-	// subtests in this suite trigger failures via 5xx / connection reset and
-	// don't depend on the timeout magnitude, so the lower cap is safe for
-	// the whole shared container.
+	// GEOLOCATION_TIMEOUT_SECS=0.5 governs the GeoTimeout subtest's 1s mock
+	// delay (500 ms < 1 s → retryable 503). SANDBOX_HTTP_TIMEOUT_S is kept
+	// low as a guard for any future subtest exercising user HTTP traffic; it
+	// does NOT affect geolocation calls — see
+	// TestSandboxHTTPTimeoutDoesNotCapGeolocation.
 	pyTransformerContainer, pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL,
 		"GEOLOCATION_URL="+geoURL,
 		"SANDBOX_HTTP_TIMEOUT_S=0.5",

--- a/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
@@ -1344,20 +1344,17 @@ def transformEvent(event, metadata):
 	mockGateway, _ := newMockOpenFaaSGateway(t, getGatewayTarget)
 	t.Cleanup(mockGateway.Close)
 
-	// Start shared rudder-transformer.
-	transformerContainer, transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
-	t.Cleanup(func() {
-		if err := pool.Purge(transformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-transformer: %v", err)
-		}
+	var (
+		wg                               sync.WaitGroup
+		transformerURL, pyTransformerURL string
+	)
+	wg.Go(func() {
+		transformerURL = startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
 	})
-
-	// Start shared rudder-pytransformer with geolocation URL.
-	pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL, "GEOLOCATION_URL="+geoURL)
-
-	// Wait for shared services to be healthy.
-	t.Log("Waiting for shared services to be healthy...")
-	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
+	wg.Go(func() {
+		pyTransformerURL = startRudderPytransformer(t, pool, configBackend.URL, "GEOLOCATION_URL="+geoURL)
+	})
+	wg.Wait()
 
 	// Run subtests sequentially.
 	for _, st := range subtests {
@@ -1598,19 +1595,17 @@ def transformBatch(events, metadata):
 	mockGateway, _ := newMockOpenFaaSGateway(t, getGatewayTarget)
 	t.Cleanup(mockGateway.Close)
 
-	// Start shared rudder-transformer (WITHOUT geolocation URL).
-	transformerContainer, transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
-	t.Cleanup(func() {
-		if err := pool.Purge(transformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-transformer: %v", err)
-		}
+	var (
+		wg                               sync.WaitGroup
+		transformerURL, pyTransformerURL string
+	)
+	wg.Go(func() {
+		transformerURL = startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
 	})
-
-	// Start shared rudder-pytransformer (WITHOUT geolocation URL).
-	pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL)
-
-	t.Log("Waiting for shared services to be healthy...")
-	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
+	wg.Go(func() {
+		pyTransformerURL = startRudderPytransformer(t, pool, configBackend.URL)
+	})
+	wg.Wait()
 
 	for _, st := range subtests {
 		t.Run(st.name, func(t *testing.T) {
@@ -2419,29 +2414,27 @@ def transformEvent(event, metadata):
 	mockGateway, _ := newMockOpenFaaSGateway(t, getGatewayTarget)
 	t.Cleanup(mockGateway.Close)
 
-	// Start shared rudder-transformer.
-	transformerContainer, transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
-	t.Cleanup(func() {
-		if err := pool.Purge(transformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-transformer: %v", err)
-		}
-	})
-
-	// Start shared rudder-pytransformer with configurable mock geolocation URL.
-	// GEOLOCATION_TIMEOUT_SECS=0.5 governs the GeoTimeout subtest's 1s mock
-	// delay (500 ms < 1 s → retryable 503). SANDBOX_HTTP_TIMEOUT_S is kept
-	// low as a guard for any future subtest exercising user HTTP traffic; it
-	// does NOT affect geolocation calls — see
-	// TestSandboxHTTPTimeoutDoesNotCapGeolocation.
-	pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL,
-		"GEOLOCATION_URL="+geoURL,
-		"SANDBOX_HTTP_TIMEOUT_S=0.1",
-		"GEOLOCATION_TIMEOUT_SECS=0.1",
+	var (
+		wg                               sync.WaitGroup
+		transformerURL, pyTransformerURL string
 	)
-
-	// Wait for shared services to be healthy.
-	t.Log("Waiting for shared services to be healthy...")
-	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
+	wg.Go(func() {
+		transformerURL = startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
+	})
+	wg.Go(func() {
+		// Start shared rudder-pytransformer with configurable mock geolocation URL.
+		// GEOLOCATION_TIMEOUT_SECS=0.5 governs the GeoTimeout subtest's 1s mock
+		// delay (500 ms < 1 s → retryable 503). SANDBOX_HTTP_TIMEOUT_S is kept
+		// low as a guard for any future subtest exercising user HTTP traffic; it
+		// does NOT affect geolocation calls — see
+		// TestSandboxHTTPTimeoutDoesNotCapGeolocation.
+		pyTransformerURL = startRudderPytransformer(t, pool, configBackend.URL,
+			"GEOLOCATION_URL="+geoURL,
+			"SANDBOX_HTTP_TIMEOUT_S=0.1",
+			"GEOLOCATION_TIMEOUT_SECS=0.1",
+		)
+	})
+	wg.Wait()
 
 	// Run subtests sequentially.
 	for _, st := range subtests {

--- a/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
@@ -1366,13 +1366,7 @@ def transformEvent(event, metadata):
 
 			if st.config.code != "" {
 				t.Logf("Starting openfaas-flask-base for %s (versionID=%s)...", st.name, st.versionID)
-				container, openFaasURL := startOpenFaasFlask(t, pool, st.versionID, configBackend.URL, "geolocation_url="+geoURL)
-				t.Cleanup(func() {
-					if err := pool.Purge(container); err != nil {
-						t.Logf("Failed to purge openfaas-flask-base: %v", err)
-					}
-				})
-				waitForOpenFaasFlask(t, pool, openFaasURL)
+				openFaasURL := startOpenFaasFlask(t, pool, st.versionID, configBackend.URL, "geolocation_url="+geoURL)
 
 				setGatewayTarget(openFaasURL)
 			}
@@ -1624,13 +1618,7 @@ def transformBatch(events, metadata):
 
 			if st.config.code != "" {
 				// Start openfaas WITHOUT geolocation URL (not configured test).
-				container, openFaasURL := startOpenFaasFlask(t, pool, st.versionID, configBackend.URL)
-				t.Cleanup(func() {
-					if err := pool.Purge(container); err != nil {
-						t.Logf("Failed to purge openfaas-flask-base: %v", err)
-					}
-				})
-				waitForOpenFaasFlask(t, pool, openFaasURL)
+				openFaasURL := startOpenFaasFlask(t, pool, st.versionID, configBackend.URL)
 
 				setGatewayTarget(openFaasURL)
 			}
@@ -2465,13 +2453,7 @@ def transformEvent(event, metadata):
 
 			if st.config.code != "" {
 				t.Logf("Starting openfaas-flask-base for %s (versionID=%s)...", st.name, st.versionID)
-				container, openFaasURL := startOpenFaasFlask(t, pool, st.versionID, configBackend.URL, "geolocation_url="+geoURL)
-				t.Cleanup(func() {
-					if err := pool.Purge(container); err != nil {
-						t.Logf("Failed to purge openfaas-flask-base: %v", err)
-					}
-				})
-				waitForOpenFaasFlask(t, pool, openFaasURL)
+				openFaasURL := startOpenFaasFlask(t, pool, st.versionID, configBackend.URL, "geolocation_url="+geoURL)
 
 				setGatewayTarget(openFaasURL)
 			}

--- a/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
+++ b/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
@@ -22,35 +22,39 @@ import (
 	"github.com/rudderlabs/rudder-server/processor/usertransformer"
 )
 
-// TestGeoTimeoutWithShorterHTTPTimeoutCap locks the contract that a slow
-// geolocation backend is retried even when SANDBOX_HTTP_TIMEOUT_S is shorter
-// than GEOLOCATION_TIMEOUT_SECS.
+// TestSandboxHTTPTimeoutDoesNotCapGeolocation locks the contract that
+// SANDBOX_HTTP_TIMEOUT_S (the user-HTTP wall-clock cap) does NOT apply to
+// internal geolocation traffic. The two timeouts are independent: geolocation
+// calls are bound exclusively by GEOLOCATION_TIMEOUT_SECS.
 //
-// The test distinguishes this from a user code HTTP timeout (400,
-// non-retryable) by verifying that the response carries a 503 status and
-// that the client's retry counter increments.
-func TestGeoTimeoutWithShorterHTTPTimeoutCap(t *testing.T) {
+// Scenario: a geolocation backend that replies in 300 ms, with
+// SANDBOX_HTTP_TIMEOUT_S=0.1 s (user cap is SHORTER than the geo response)
+// and GEOLOCATION_TIMEOUT_SECS=0.5 s. Under the contract, the geolocation
+// call must succeed:
+//
+//   - The 300 ms server reply is faster than the 500 ms geolocation budget.
+//   - The 100 ms sandbox cap is intended for user HTTP traffic and MUST NOT
+//     shadow the internal geolocation deadline.
+func TestSandboxHTTPTimeoutDoesNotCapGeolocation(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 	pool.MaxWait = 2 * time.Minute
 
-	const versionID = "geo-short-http-timeout-v1"
+	const versionID = "geo-cap-isolation-v1"
 
-	// Mock geolocation server that responds after 300 ms — well above the
-	// 100 ms HTTP cap but below the 500 ms geolocation timeout.
-	// The urllib3 wall-clock cap fires at 100 ms, before the server answers.
-	mockGeo, mockGeoCfg := newConfigurableMockGeolocationService(t)
-	mockGeoCfg.setSlow(300 * time.Millisecond)
+	// Geolocation mock that replies after 300 ms with a real JSON body.
+	// Placed between the 100 ms sandbox cap and the 500 ms geolocation
+	// budget so only the correct deadline can govern the call.
+	mockGeo, geoCalls := newSlowGeolocationServer(t, 200*time.Millisecond)
 
 	entries := map[string]configBackendEntry{
 		versionID: {code: `
 def transformEvent(event, metadata):
-    try:
-        result = geolocation("1.2.3.4")
-        event["geo"] = result
-    except Exception as e:
-        # Must NOT reach this branch
-        event["geo_error"] = str(e)
+    # If the sandbox HTTP cap leaked into the internal session, geolocation()
+    # would raise GeolocationServerError (retryable 503) — the test would
+    # never observe a successful event.
+    result = geolocation("1.2.3.4")
+    event["geo_country"] = result["country"]
     return event
 `},
 	}
@@ -60,10 +64,13 @@ def transformEvent(event, metadata):
 
 	container, pyURL := startRudderPytransformer(
 		t, pool, configBackend.URL,
-		// geolocation URL must be reachable from inside the container
 		"GEOLOCATION_URL="+mockGeo.URL,
-		// HTTP cap is intentionally shorter than GEOLOCATION_TIMEOUT_SECS
+		// The user HTTP cap is intentionally SHORTER than the geo reply
+		// (100 ms < 300 ms). If the cap were applied to internal traffic,
+		// the geolocation call would time out at 100 ms.
 		"SANDBOX_HTTP_TIMEOUT_S=0.1",
+		// The geolocation budget is LARGER than the geo reply (500 ms >
+		// 300 ms) so the only legal outcome is success.
 		"GEOLOCATION_TIMEOUT_SECS=0.5",
 	)
 	t.Cleanup(func() {
@@ -73,8 +80,8 @@ def transformEvent(event, metadata):
 	})
 	waitForHealthy(t, pool, pyURL, "pytransformer", container)
 
-	// Build a new-arch client with limited retries so the test terminates
-	// quickly and we can inspect the retry counter.
+	// Limited-retry client so a regression (which would trip retries) is
+	// visible within a bounded test runtime.
 	newStats, err := memstats.New()
 	require.NoError(t, err)
 	conf := config.New()
@@ -87,31 +94,40 @@ def transformEvent(event, metadata):
 	conf.Set("Transformer.Client.UserTransformer.retryRudderErrors.maxInterval", 1*time.Millisecond)
 	client := usertransformer.New(conf, logger.NOP, newStats)
 
-	events := []types.TransformerEvent{makeEvent("msg-geo-short-1", versionID)}
+	events := []types.TransformerEvent{makeEvent("msg-geo-iso-1", versionID)}
 	resp := client.Transform(context.Background(), events)
 
-	// The geolocation() call times out (urllib3 HTTP cap fires at 100 ms).
-	// GeolocationServerError bypasses the user's except-Exception block, so
-	// no success event is produced.
-	require.Len(t, resp.Events, 0,
-		"geolocation timeout must NOT produce a success event: "+
-			"GeolocationServerError must bypass user except-Exception")
+	// Happy path: geolocation returned within its 500 ms budget and the
+	// transformation produced a successful event.
+	require.Empty(t, resp.FailedEvents,
+		"geolocation call must succeed when the geo reply (300 ms) is within "+
+			"GEOLOCATION_TIMEOUT_SECS (500 ms); SANDBOX_HTTP_TIMEOUT_S (100 ms) "+
+			"must NOT apply to internal traffic")
+	require.Len(t, resp.Events, 1,
+		"exactly one successful event must be produced")
+	require.Equal(t, http.StatusOK, resp.Events[0].StatusCode)
 
-	// The worker returns 503 retryable.  After 2 retries the client gives up
-	// and surfaces the failure in FailedEvents.
-	require.Len(t, resp.FailedEvents, 1,
-		"geolocation timeout must surface as a failed event after retries are exhausted")
-	require.Contains(t, resp.FailedEvents[0].Error, "503",
-		"failed event must carry the 503 error from the retried geolocation timeout")
+	// The user code copies result["country"] into the event — verifying the
+	// geolocation body round-trips confirms the call actually completed
+	// (and wasn't retried into success by a different code path).
+	require.Equal(t, "IT", resp.Events[0].Output["geo_country"],
+		"successful geolocation response must reach user code intact")
 
-	// Verify that 2 retries actually happened — this is what proves the
-	// failure was treated as a geolocation timeout (retryable) and NOT as a
-	// user code HTTP timeout (non-retryable 400, zero retries).
+	// No retries: the client must NOT have retried anything. Under the
+	// pre-fix buggy behavior, the sandbox cap would fire at 100 ms, raise
+	// GeolocationServerError, and trigger the retry counter here.
 	retriesCounter := newStats.GetByName("processor_user_transformer_http_retries")
-	require.Len(t, retriesCounter, 1,
-		"http_retries counter must be recorded")
-	require.EqualValues(t, 2, retriesCounter[0].Value,
-		"geolocation timeout must trigger exactly 2 retries before failing")
+	if len(retriesCounter) > 0 {
+		require.EqualValues(t, 0, retriesCounter[0].Value,
+			"no retries must occur — any retry indicates the user HTTP cap "+
+				"leaked into the internal geolocation session")
+	}
+
+	// Exactly one geolocation call reached the mock: no redundant retries,
+	// no duplicate traffic.
+	require.EqualValues(t, 1, geoCalls.Load(),
+		"geolocation backend must be called exactly once for a successful "+
+			"transformation")
 }
 
 // TestUserHTTPTimeoutCapping verifies the urllib3 wall-clock cap behaviour for
@@ -341,6 +357,36 @@ def transformEvent(event, metadata):
 				"same host must reuse the pooled TCP connection "+
 				"(server-side StateNew count: want 1)")
 	})
+}
+
+// newSlowGeolocationServer creates an httptest server that serves the
+// pytransformer's /geoip/* contract: a JSON body containing a "country"
+// field, delayed by `delay` before responding. Returns the server and an
+// atomic counter of /geoip/* hits (health pings are not counted).
+func newSlowGeolocationServer(t *testing.T, delay time.Duration) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	calls := &atomic.Int64{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Ignore health pings so the counter reflects only real geo calls.
+		if r.URL.Path == "/" || r.URL.Path == "/health" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+			return
+		}
+		calls.Add(1)
+		select {
+		case <-time.After(delay):
+		case <-r.Context().Done():
+			return
+		}
+		body := []byte(`{"country": "IT"}`)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, calls
 }
 
 // newSlowServer creates an HTTP server that delays every response by delay.

--- a/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
+++ b/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
@@ -22,69 +22,9 @@ import (
 	"github.com/rudderlabs/rudder-server/processor/usertransformer"
 )
 
-// newSlowServer creates an HTTP server that delays every response by delay.
-// Returns the server (already started) and an atomic call counter.
-// The handler responds HTTP 200 with `{"ok": true}` after the delay,
-// or stops early if the request context is cancelled (client gave up).
-func newSlowServer(t *testing.T, delay time.Duration) (*httptest.Server, *atomic.Int64) {
-	t.Helper()
-	calls := &atomic.Int64{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls.Add(1)
-		select {
-		case <-time.After(delay):
-		case <-r.Context().Done():
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"ok": true}`))
-	}))
-	t.Cleanup(srv.Close)
-	return srv, calls
-}
-
-// newConnectionCountingServer creates an HTTP server that uses ConnState to
-// count the number of new TCP connections it accepts.  Every time the Go HTTP
-// server transitions a connection to http.StateNew (i.e. a fresh TCP handshake
-// completed), the atomic counter is incremented.  Subsequent HTTP requests on
-// the same keep-alive TCP connection do NOT trigger http.StateNew, so the
-// counter is a reliable proxy for "how many distinct TCP connections were
-// opened."
-//
-// The handler responds HTTP 200 with a small JSON body and sets
-// Content-Length so the client knows the response is complete and can keep
-// the connection alive for the next request without chunked transfer.
-func newConnectionCountingServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
-	t.Helper()
-	newConns := &atomic.Int64{}
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body := []byte(`{"ok": true}`)
-		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(body)
-	})
-	srv := httptest.NewUnstartedServer(handler)
-	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
-		if state == http.StateNew {
-			newConns.Add(1)
-		}
-	}
-	srv.Start()
-	t.Cleanup(srv.Close)
-	return srv, newConns
-}
-
 // TestGeoTimeoutWithShorterHTTPTimeoutCap locks the contract that a slow
 // geolocation backend is retried even when SANDBOX_HTTP_TIMEOUT_S is shorter
 // than GEOLOCATION_TIMEOUT_SECS.
-//
-// When the urllib3 wall-clock cap fires during a geolocation() call, the
-// resulting ReadTimeoutError is caught by the geolocation() function and
-// re-raised as GeolocationServerError (a BaseException subclass). This
-// bypasses the user's `except Exception` block and surfaces to the worker as
-// a retryable HTTP 503 — identical to the behaviour when
-// GEOLOCATION_TIMEOUT_SECS fires first.
 //
 // The test distinguishes this from a user code HTTP timeout (400,
 // non-retryable) by verifying that the response carries a 503 status and
@@ -97,8 +37,8 @@ func TestGeoTimeoutWithShorterHTTPTimeoutCap(t *testing.T) {
 	const versionID = "geo-short-http-timeout-v1"
 
 	// Mock geolocation server that responds after 300 ms — well above the
-	// 100 ms HTTP cap but below the 500 ms geolocation timeout.  The urllib3
-	// wall-clock cap fires at 100 ms, before the server answers.
+	// 100 ms HTTP cap but below the 500 ms geolocation timeout.
+	// The urllib3 wall-clock cap fires at 100 ms, before the server answers.
 	mockGeo, mockGeoCfg := newConfigurableMockGeolocationService(t)
 	mockGeoCfg.setSlow(300 * time.Millisecond)
 
@@ -109,9 +49,7 @@ def transformEvent(event, metadata):
         result = geolocation("1.2.3.4")
         event["geo"] = result
     except Exception as e:
-        # Must NOT reach this branch: GeolocationServerError inherits
-        # BaseException, so it bypasses except-Exception and propagates
-        # to the worker as a retryable 503.
+        # Must NOT reach this branch
         event["geo_error"] = str(e)
     return event
 `},
@@ -403,4 +341,57 @@ def transformEvent(event, metadata):
 				"same host must reuse the pooled TCP connection "+
 				"(server-side StateNew count: want 1)")
 	})
+}
+
+// newSlowServer creates an HTTP server that delays every response by delay.
+// Returns the server (already started) and an atomic call counter.
+// The handler responds HTTP 200 with `{"ok": true}` after the delay,
+// or stops early if the request context is cancelled (client gave up).
+func newSlowServer(t *testing.T, delay time.Duration) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	calls := &atomic.Int64{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		select {
+		case <-time.After(delay):
+		case <-r.Context().Done():
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, calls
+}
+
+// newConnectionCountingServer creates an HTTP server that uses ConnState to
+// count the number of new TCP connections it accepts.  Every time the Go HTTP
+// server transitions a connection to http.StateNew (i.e. a fresh TCP handshake
+// completed), the atomic counter is incremented.  Subsequent HTTP requests on
+// the same keep-alive TCP connection do NOT trigger http.StateNew, so the
+// counter is a reliable proxy for "how many distinct TCP connections were
+// opened."
+//
+// The handler responds HTTP 200 with a small JSON body and sets
+// Content-Length so the client knows the response is complete and can keep
+// the connection alive for the next request without chunked transfer.
+func newConnectionCountingServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	newConns := &atomic.Int64{}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := []byte(`{"ok": true}`)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+	srv := httptest.NewUnstartedServer(handler)
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConns.Add(1)
+		}
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv, newConns
 }

--- a/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
+++ b/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
@@ -572,7 +572,7 @@ func newSlowDripBodyServer(t *testing.T, chunks int, delay time.Duration) *httpt
 		// Flush headers immediately so urlopen returns fast. Everything
 		// after this point exercises the body-read deadline.
 		flusher.Flush()
-		for i := 0; i < chunks; i++ {
+		for range chunks {
 			select {
 			case <-time.After(delay):
 			case <-r.Context().Done():

--- a/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
+++ b/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
@@ -335,6 +335,132 @@ def transformEvent(event, metadata):
 	})
 }
 
+// TestSlowDripBodyFiresSandboxHTTPTimeout locks in the contract that a server
+// which flushes response headers quickly and then drips the body one byte at
+// a time must NOT pin a sandbox worker for longer than SANDBOX_HTTP_TIMEOUT_S.
+//
+// Scenario:
+//   - Body is 30 chunks × 200 ms = 6.0 s of wall-clock drip.
+//   - SANDBOX_HTTP_TIMEOUT_S = 1 s.
+//   - SANDBOX_TRANSFORMATION_TIMEOUT_S is set high enough that the
+//     subprocess-level SIGVTALRM safety net does NOT fire first — otherwise
+//     we would be measuring the wrong timeout.
+//
+// Legal outcomes are narrow: the per-event statusCode must be 400 (HTTP
+// timeout surfaces as a user-code failure), and the request must complete
+// well inside the full 6s body duration. Anything else means the slow-drip
+// body is still capable of pinning the worker.
+func TestSlowDripBodyFiresSandboxHTTPTimeout(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
+
+	const versionID = "slow-drip-body-v1"
+
+	slowSrv := newSlowDripBodyServer(t, 30, 200*time.Millisecond)
+
+	entries := map[string]configBackendEntry{
+		versionID: {code: fmt.Sprintf(`
+import requests
+
+def transformEvent(event, metadata):
+    # No explicit timeout — let SANDBOX_HTTP_TIMEOUT_S cap the wall-clock budget.
+    resp = requests.get("%s/drip")
+    event["status"] = resp.status_code
+    event["body_len"] = len(resp.content)
+    return event
+`, toContainerURL(slowSrv.URL))},
+	}
+
+	configBackend := newContractConfigBackend(t, entries)
+	t.Cleanup(configBackend.Close)
+
+	// SANDBOX_HTTP_TIMEOUT_S=1 < 6s body drip → our cap must fire.
+	// SANDBOX_TRANSFORMATION_TIMEOUT_S=20 / SANDBOX_PROCESS_TIMEOUT_S=30 keep
+	// the subprocess-level deadlines far above any plausible cap firing time,
+	// so the only thing that can cause a per-event 400 here is the HTTP-level
+	// wall-clock deadline we are testing.
+	pyURL := startRudderPytransformer(
+		t, pool, configBackend.URL,
+		"SANDBOX_HTTP_TIMEOUT_S=1",
+		"SANDBOX_TRANSFORMATION_TIMEOUT_S=20",
+		"SANDBOX_PROCESS_TIMEOUT_S=30",
+	)
+
+	events := []types.TransformerEvent{makeEvent("msg-slow-drip-1", versionID)}
+
+	start := time.Now()
+	status, items := sendRawTransform(t, pyURL, events)
+	elapsed := time.Since(start)
+	t.Logf("slow-drip request elapsed: %s", elapsed)
+
+	require.Equal(t, http.StatusOK, status,
+		"/customTransform HTTP response must be 200 (per-event errors live in the payload)")
+	require.Len(t, items, 1, "exactly one per-event result expected")
+
+	require.Equal(t, http.StatusBadRequest, items[0].StatusCode,
+		"slow-drip body must fire SANDBOX_HTTP_TIMEOUT_S and surface as a 400 per-event error; "+
+			"statusCode=%d error=%q", items[0].StatusCode, items[0].Error)
+	require.NotEmpty(t, items[0].Error,
+		"timeout error message must be propagated to the caller")
+	require.Empty(t, items[0].Output,
+		"a timed-out event must not carry a successful transformation output")
+
+	// Wall-clock budget: the pre-fix path would pin the worker for the full
+	// 6s body duration. Post-fix the cap must fire within ~1s + overhead,
+	// comfortably below 4s — and critically far below the 6s drip ceiling.
+	// Using 4 s as the bound keeps the assertion resilient to normal Docker
+	// container-start jitter while still catching any regression that
+	// reverts the deadline wrapper.
+	require.Less(t, elapsed, 4*time.Second,
+		"SANDBOX_HTTP_TIMEOUT_S must cap the wall-clock budget for slow-drip "+
+			"body reads; elapsed=%s (pre-fix would be ~6s)", elapsed)
+}
+
+// newSlowDripBodyServer creates an httptest server that flushes response
+// headers immediately, then trickles the body one byte at a time using
+// HTTP/1.1 chunked transfer encoding, pausing “delay“ between each chunk.
+//
+// The header flush happens before any sleep so urllib3's “urlopen“ (which
+// caps the time-to-first-byte) returns fast — the attack surface is the body
+// read phase. The connection is closed after the final chunk so the test
+// server shuts down cleanly when the httptest.Server is torn down.
+func newSlowDripBodyServer(t *testing.T, chunks int, delay time.Duration) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		// ``Connection: close`` prevents the handler from hanging in a
+		// keep-alive loop after the response completes — important for
+		// clean test shutdown when the client succeeds in reading the
+		// whole body (the bypass / happy path).
+		w.Header().Set("Connection", "close")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("response writer is not a flusher")
+			return
+		}
+		// Flush headers immediately so urlopen returns fast. Everything
+		// after this point exercises the body-read deadline.
+		flusher.Flush()
+		for i := 0; i < chunks; i++ {
+			select {
+			case <-time.After(delay):
+			case <-r.Context().Done():
+				// Client gave up (deadline fired upstream). Stop dripping
+				// to free the handler goroutine promptly.
+				return
+			}
+			if _, err := w.Write([]byte("a")); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
 // newSlowGeolocationServer creates an httptest server that serves the
 // pytransformer's /geoip/* contract: a JSON body containing a "country"
 // field, delayed by `delay` before responding. Returns the server and an

--- a/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
+++ b/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
@@ -62,7 +62,7 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, entries)
 	t.Cleanup(configBackend.Close)
 
-	container, pyURL := startRudderPytransformer(
+	pyURL := startRudderPytransformer(
 		t, pool, configBackend.URL,
 		"GEOLOCATION_URL="+mockGeo.URL,
 		// The user HTTP cap is intentionally SHORTER than the geo reply
@@ -73,7 +73,6 @@ def transformEvent(event, metadata):
 		// 300 ms) so the only legal outcome is success.
 		"GEOLOCATION_TIMEOUT_SECS=0.5",
 	)
-	waitForHealthy(t, pool, pyURL, "pytransformer", container)
 
 	// Limited-retry client so a regression (which would trip retries) is
 	// visible within a bounded test runtime.
@@ -180,11 +179,10 @@ def transformEvent(event, metadata):
 
 	// SANDBOX_HTTP_TIMEOUT_S=1: our cap is between the user's bigger (5s)
 	// and smaller (0.1s) values, so both subtests can verify the correct cap.
-	container, pyURL := startRudderPytransformer(
+	pyURL := startRudderPytransformer(
 		t, pool, configBackend.URL,
 		"SANDBOX_HTTP_TIMEOUT_S=1",
 	)
-	waitForHealthy(t, pool, pyURL, "pytransformer", container)
 
 	t.Run("OurCapHonouredWhenUserTimeoutIsBigger", func(t *testing.T) {
 		// Reset calls before test
@@ -274,7 +272,7 @@ def transformEvent(event, metadata):
 		// ENABLE_CONN_POOL=false (default): bare requests.get() creates a
 		// temporary Session per call, then closes it — so every call opens a
 		// fresh TCP connection even against a keep-alive-capable server.
-		noPoolContainer, noPoolURL := startRudderPytransformer(
+		noPoolURL := startRudderPytransformer(
 			t, pool, configBackend.URL,
 			"ENABLE_CONN_POOL=false",
 			// Single worker so both requests hit the same subprocess and
@@ -282,7 +280,6 @@ def transformEvent(event, metadata):
 			// affinity.
 			"SANDBOX_POOL_MAX_SIZE=1",
 		)
-		waitForHealthy(t, pool, noPoolURL, "pytransformer (no-pool)", noPoolContainer)
 
 		before := newConns.Load()
 
@@ -308,14 +305,13 @@ def transformEvent(event, metadata):
 		// ENABLE_CONN_POOL=true: bare requests.get() routes through the
 		// persistent user session.  The TCP connection established for the
 		// first request is kept in the pool and reused for the second.
-		poolContainer, poolURL := startRudderPytransformer(
+		poolURL := startRudderPytransformer(
 			t, pool, configBackend.URL,
 			"ENABLE_CONN_POOL=true",
 			"USER_CONN_POOL_MAX_SIZE=1",
 			// Single worker to guarantee the same session handles both requests.
 			"SANDBOX_POOL_MAX_SIZE=1",
 		)
-		waitForHealthy(t, pool, poolURL, "pytransformer (with-pool)", poolContainer)
 
 		before := newConns.Load()
 

--- a/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
+++ b/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
@@ -1,0 +1,406 @@
+package pytransformer_contract
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+
+	"github.com/rudderlabs/rudder-server/processor/types"
+	"github.com/rudderlabs/rudder-server/processor/usertransformer"
+)
+
+// newSlowServer creates an HTTP server that delays every response by delay.
+// Returns the server (already started) and an atomic call counter.
+// The handler responds HTTP 200 with `{"ok": true}` after the delay,
+// or stops early if the request context is cancelled (client gave up).
+func newSlowServer(t *testing.T, delay time.Duration) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	calls := &atomic.Int64{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		select {
+		case <-time.After(delay):
+		case <-r.Context().Done():
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, calls
+}
+
+// newConnectionCountingServer creates an HTTP server that uses ConnState to
+// count the number of new TCP connections it accepts.  Every time the Go HTTP
+// server transitions a connection to http.StateNew (i.e. a fresh TCP handshake
+// completed), the atomic counter is incremented.  Subsequent HTTP requests on
+// the same keep-alive TCP connection do NOT trigger http.StateNew, so the
+// counter is a reliable proxy for "how many distinct TCP connections were
+// opened."
+//
+// The handler responds HTTP 200 with a small JSON body and sets
+// Content-Length so the client knows the response is complete and can keep
+// the connection alive for the next request without chunked transfer.
+func newConnectionCountingServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	newConns := &atomic.Int64{}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := []byte(`{"ok": true}`)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+	srv := httptest.NewUnstartedServer(handler)
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConns.Add(1)
+		}
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv, newConns
+}
+
+// TestGeoTimeoutWithShorterHTTPTimeoutCap locks the contract that a slow
+// geolocation backend is retried even when SANDBOX_HTTP_TIMEOUT_S is shorter
+// than GEOLOCATION_TIMEOUT_SECS.
+//
+// When the urllib3 wall-clock cap fires during a geolocation() call, the
+// resulting ReadTimeoutError is caught by the geolocation() function and
+// re-raised as GeolocationServerError (a BaseException subclass). This
+// bypasses the user's `except Exception` block and surfaces to the worker as
+// a retryable HTTP 503 — identical to the behaviour when
+// GEOLOCATION_TIMEOUT_SECS fires first.
+//
+// The test distinguishes this from a user code HTTP timeout (400,
+// non-retryable) by verifying that the response carries a 503 status and
+// that the client's retry counter increments.
+func TestGeoTimeoutWithShorterHTTPTimeoutCap(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
+
+	const versionID = "geo-short-http-timeout-v1"
+
+	// Mock geolocation server that responds after 300 ms — well above the
+	// 100 ms HTTP cap but below the 500 ms geolocation timeout.  The urllib3
+	// wall-clock cap fires at 100 ms, before the server answers.
+	mockGeo, mockGeoCfg := newConfigurableMockGeolocationService(t)
+	mockGeoCfg.setSlow(300 * time.Millisecond)
+
+	entries := map[string]configBackendEntry{
+		versionID: {code: `
+def transformEvent(event, metadata):
+    try:
+        result = geolocation("1.2.3.4")
+        event["geo"] = result
+    except Exception as e:
+        # Must NOT reach this branch: GeolocationServerError inherits
+        # BaseException, so it bypasses except-Exception and propagates
+        # to the worker as a retryable 503.
+        event["geo_error"] = str(e)
+    return event
+`},
+	}
+
+	configBackend := newContractConfigBackend(t, entries)
+	t.Cleanup(configBackend.Close)
+
+	container, pyURL := startRudderPytransformer(
+		t, pool, configBackend.URL,
+		// geolocation URL must be reachable from inside the container
+		"GEOLOCATION_URL="+mockGeo.URL,
+		// HTTP cap is intentionally shorter than GEOLOCATION_TIMEOUT_SECS
+		"SANDBOX_HTTP_TIMEOUT_S=0.1",
+		"GEOLOCATION_TIMEOUT_SECS=0.5",
+	)
+	t.Cleanup(func() {
+		if err := pool.Purge(container); err != nil {
+			t.Logf("Failed to purge pytransformer container: %v", err)
+		}
+	})
+	waitForHealthy(t, pool, pyURL, "pytransformer", container)
+
+	// Build a new-arch client with limited retries so the test terminates
+	// quickly and we can inspect the retry counter.
+	newStats, err := memstats.New()
+	require.NoError(t, err)
+	conf := config.New()
+	conf.Set("PYTHON_TRANSFORM_URL", pyURL)
+	conf.Set("Processor.UserTransformer.maxRetry", 2)
+	conf.Set("Processor.UserTransformer.cpDownEndlessRetries", false)
+	conf.Set("Processor.UserTransformer.maxRetryBackoffInterval", 1*time.Millisecond)
+	conf.Set("Processor.UserTransformer.failOnError", true)
+	conf.Set("Transformer.Client.UserTransformer.retryRudderErrors.maxRetry", 2)
+	conf.Set("Transformer.Client.UserTransformer.retryRudderErrors.maxInterval", 1*time.Millisecond)
+	client := usertransformer.New(conf, logger.NOP, newStats)
+
+	events := []types.TransformerEvent{makeEvent("msg-geo-short-1", versionID)}
+	resp := client.Transform(context.Background(), events)
+
+	// The geolocation() call times out (urllib3 HTTP cap fires at 100 ms).
+	// GeolocationServerError bypasses the user's except-Exception block, so
+	// no success event is produced.
+	require.Len(t, resp.Events, 0,
+		"geolocation timeout must NOT produce a success event: "+
+			"GeolocationServerError must bypass user except-Exception")
+
+	// The worker returns 503 retryable.  After 2 retries the client gives up
+	// and surfaces the failure in FailedEvents.
+	require.Len(t, resp.FailedEvents, 1,
+		"geolocation timeout must surface as a failed event after retries are exhausted")
+	require.Contains(t, resp.FailedEvents[0].Error, "503",
+		"failed event must carry the 503 error from the retried geolocation timeout")
+
+	// Verify that 2 retries actually happened — this is what proves the
+	// failure was treated as a geolocation timeout (retryable) and NOT as a
+	// user code HTTP timeout (non-retryable 400, zero retries).
+	retriesCounter := newStats.GetByName("processor_user_transformer_http_retries")
+	require.Len(t, retriesCounter, 1,
+		"http_retries counter must be recorded")
+	require.EqualValues(t, 2, retriesCounter[0].Value,
+		"geolocation timeout must trigger exactly 2 retries before failing")
+}
+
+// TestUserHTTPTimeoutCapping verifies the urllib3 wall-clock cap behaviour for
+// user-initiated HTTP calls:
+//
+//   - When the user passes a timeout that is larger than SANDBOX_HTTP_TIMEOUT_S,
+//     the sandbox cap is honoured (our cap fires, not the user's).
+//   - When the user passes a timeout that is smaller than SANDBOX_HTTP_TIMEOUT_S,
+//     the user's timeout is honoured (user's fires, not ours).
+//
+// Both cases result in a non-retryable 400 per-event error (user code HTTP
+// timeout is not retried) — in contrast to the retryable 503 from a
+// geolocation timeout.
+//
+// A single pytransformer container (SANDBOX_HTTP_TIMEOUT_S=2) is shared by
+// both subtests.
+func TestUserHTTPTimeoutCapping(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
+
+	const (
+		versionBigger  = "user-timeout-bigger-v1"
+		versionSmaller = "user-timeout-smaller-v1"
+	)
+
+	// slowSrv3s: responds after 3s — longer than SANDBOX_HTTP_TIMEOUT_S (2s)
+	// but shorter than the user's requested timeout (10s).  Our cap fires.
+	slowSrv3s, _ := newSlowServer(t, 3*time.Second)
+
+	// slowSrv1s: responds after 1s — longer than the user's requested timeout
+	// (0.5s) but shorter than SANDBOX_HTTP_TIMEOUT_S (2s).  User's cap fires.
+	slowSrv1s, _ := newSlowServer(t, 1*time.Second)
+
+	entries := map[string]configBackendEntry{
+		versionBigger: {code: fmt.Sprintf(`
+import requests
+
+def transformEvent(event, metadata):
+    # timeout=10 — user wants 10 s, but SANDBOX_HTTP_TIMEOUT_S=2 caps it.
+    # Timeout intentionally not caught — propagates as per-event status 400.
+    resp = requests.get("%s/data", timeout=10)
+    event["status"] = resp.status_code
+    return event
+`, toContainerURL(slowSrv3s.URL))},
+
+		versionSmaller: {code: fmt.Sprintf(`
+import requests
+
+def transformEvent(event, metadata):
+    # timeout=0.5 — user's cap is smaller than SANDBOX_HTTP_TIMEOUT_S=2.
+    # Timeout intentionally not caught — propagates as per-event status 400.
+    resp = requests.get("%s/data", timeout=0.5)
+    event["status"] = resp.status_code
+    return event
+`, toContainerURL(slowSrv1s.URL))},
+	}
+
+	configBackend := newContractConfigBackend(t, entries)
+	t.Cleanup(configBackend.Close)
+
+	// SANDBOX_HTTP_TIMEOUT_S=2: our cap is between the user's bigger (10s)
+	// and smaller (0.5s) values, so both subtests can verify the correct cap.
+	container, pyURL := startRudderPytransformer(
+		t, pool, configBackend.URL,
+		"SANDBOX_HTTP_TIMEOUT_S=2",
+	)
+	t.Cleanup(func() {
+		if err := pool.Purge(container); err != nil {
+			t.Logf("Failed to purge pytransformer container: %v", err)
+		}
+	})
+	waitForHealthy(t, pool, pyURL, "pytransformer", container)
+
+	t.Run("OurCapHonouredWhenUserTimeoutIsBigger", func(t *testing.T) {
+		// The user passes timeout=10 s, but the server only replies after 3s.
+		// Our cap (2s) fires first.  The transformation fails with a 400
+		// per-event error (non-retryable user code HTTP timeout).
+		events := []types.TransformerEvent{makeEvent("msg-bigger-1", versionBigger)}
+		status, items := sendRawTransform(t, pyURL, events)
+		require.Equal(t, http.StatusOK, status,
+			"/customTransform HTTP response must be 200 (per-event errors are in the payload)")
+		require.Len(t, items, 1)
+		require.Equal(t, http.StatusBadRequest, items[0].StatusCode,
+			"our cap (2s) must fire before user timeout (10s) when server takes 3s")
+		// The error message should mention a timeout — both ReadTimeout and
+		// ConnectTimeout carry "timeout" or "timed out" in their string.
+		require.NotEmpty(t, items[0].Error,
+			"timeout error must be propagated as a non-empty per-event error")
+
+		// User code HTTP timeouts are NOT retried (400 is non-retryable).
+		// The event must appear in the failed payload, not silently swallowed.
+		require.Empty(t, items[0].Output,
+			"a timed-out event must not carry a successful output")
+	})
+
+	t.Run("UserTimeoutHonouredWhenSmallerThanCap", func(t *testing.T) {
+		// The user passes timeout=0.5 s; the server replies after 1s.
+		// The user's cap fires first (0.5s < our 2s cap < server's 1s delay).
+		events := []types.TransformerEvent{makeEvent("msg-smaller-1", versionSmaller)}
+		status, items := sendRawTransform(t, pyURL, events)
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, items, 1)
+		require.Equal(t, http.StatusBadRequest, items[0].StatusCode,
+			"user timeout (0.5s) must fire before our cap (2s) when server takes 1s")
+		require.NotEmpty(t, items[0].Error,
+			"timeout error must be propagated as a non-empty per-event error")
+		require.Empty(t, items[0].Output,
+			"a timed-out event must not carry a successful output")
+	})
+}
+
+// TestConnectionPoolBehavior verifies that the ENABLE_CONN_POOL feature flag
+// controls whether bare requests.get() calls reuse TCP connections.
+//
+//   - ENABLE_CONN_POOL=false (default): each call opens a fresh TCP connection.
+//   - ENABLE_CONN_POOL=true:            repeated calls to the same host reuse
+//     the pooled TCP connection.
+//
+// SANDBOX_POOL_MAX_SIZE=1 ensures a single worker subprocess handles every
+// request, so the per-process user session (and its connection pool) is shared
+// across the two sequential test requests.
+//
+// Connection reuse is verified server-side using the Go http.Server ConnState
+// hook: http.StateNew fires exactly once per TCP handshake.  Two requests on
+// a kept-alive connection produce only one StateNew event; two requests on
+// fresh connections produce two.
+func TestConnectionPoolBehavior(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
+
+	const versionID = "conn-pool-check-v1"
+
+	// A single connection-counting server shared by both subtests.
+	// Each subtest reads the delta to avoid interference.
+	trackSrv, newConns := newConnectionCountingServer(t)
+
+	entries := map[string]configBackendEntry{
+		versionID: {code: fmt.Sprintf(`
+import requests
+
+def transformEvent(event, metadata):
+    resp = requests.get("%s/check")
+    event["ok"] = resp.status_code == 200
+    return event
+`, toContainerURL(trackSrv.URL))},
+	}
+
+	configBackend := newContractConfigBackend(t, entries)
+	t.Cleanup(configBackend.Close)
+
+	t.Run("NewConnectionPerRequestWhenPoolDisabled", func(t *testing.T) {
+		// ENABLE_CONN_POOL=false (default): bare requests.get() creates a
+		// temporary Session per call, then closes it — so every call opens a
+		// fresh TCP connection even against a keep-alive-capable server.
+		noPoolContainer, noPoolURL := startRudderPytransformer(
+			t, pool, configBackend.URL,
+			"ENABLE_CONN_POOL=false",
+			// Single worker so both requests hit the same subprocess and
+			// the absence of a persistent pool is not masked by subprocess
+			// affinity.
+			"SANDBOX_POOL_MAX_SIZE=1",
+		)
+		t.Cleanup(func() {
+			if err := pool.Purge(noPoolContainer); err != nil {
+				t.Logf("Failed to purge no-pool pytransformer: %v", err)
+			}
+		})
+		waitForHealthy(t, pool, noPoolURL, "pytransformer (no-pool)", noPoolContainer)
+
+		before := newConns.Load()
+
+		ev1 := makeEvent("msg-nopool-1", versionID)
+		status1, items1 := sendRawTransform(t, noPoolURL, []types.TransformerEvent{ev1})
+		require.Equal(t, http.StatusOK, status1)
+		require.Len(t, items1, 1)
+		require.Equal(t, http.StatusOK, items1[0].StatusCode, "first request must succeed")
+
+		ev2 := makeEvent("msg-nopool-2", versionID)
+		status2, items2 := sendRawTransform(t, noPoolURL, []types.TransformerEvent{ev2})
+		require.Equal(t, http.StatusOK, status2)
+		require.Len(t, items2, 1)
+		require.Equal(t, http.StatusOK, items2[0].StatusCode, "second request must succeed")
+
+		delta := newConns.Load() - before
+		require.EqualValues(t, 2, delta,
+			"with ENABLE_CONN_POOL=false, each bare requests.get() must open "+
+				"a fresh TCP connection (server-side StateNew count: want 2)")
+	})
+
+	t.Run("ConnectionReusedWhenPoolEnabled", func(t *testing.T) {
+		// ENABLE_CONN_POOL=true: bare requests.get() routes through the
+		// persistent user session.  The TCP connection established for the
+		// first request is kept in the pool and reused for the second.
+		poolContainer, poolURL := startRudderPytransformer(
+			t, pool, configBackend.URL,
+			"ENABLE_CONN_POOL=true",
+			"USER_CONN_POOL_MAX_SIZE=1",
+			// Single worker to guarantee the same session handles both requests.
+			"SANDBOX_POOL_MAX_SIZE=1",
+		)
+		t.Cleanup(func() {
+			if err := pool.Purge(poolContainer); err != nil {
+				t.Logf("Failed to purge with-pool pytransformer: %v", err)
+			}
+		})
+		waitForHealthy(t, pool, poolURL, "pytransformer (with-pool)", poolContainer)
+
+		before := newConns.Load()
+
+		ev1 := makeEvent("msg-pool-1", versionID)
+		status1, items1 := sendRawTransform(t, poolURL, []types.TransformerEvent{ev1})
+		require.Equal(t, http.StatusOK, status1)
+		require.Len(t, items1, 1)
+		require.Equal(t, http.StatusOK, items1[0].StatusCode, "first request must succeed")
+
+		ev2 := makeEvent("msg-pool-2", versionID)
+		status2, items2 := sendRawTransform(t, poolURL, []types.TransformerEvent{ev2})
+		require.Equal(t, http.StatusOK, status2)
+		require.Len(t, items2, 1)
+		require.Equal(t, http.StatusOK, items2[0].StatusCode, "second request must succeed")
+
+		delta := newConns.Load() - before
+		require.EqualValues(t, 1, delta,
+			"with ENABLE_CONN_POOL=true, the second bare requests.get() to the "+
+				"same host must reuse the pooled TCP connection "+
+				"(server-side StateNew count: want 1)")
+	})
+}

--- a/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
+++ b/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
@@ -107,9 +107,9 @@ def transformEvent(event, metadata):
 	require.Equal(t, "IT", resp.Events[0].Output["geo_country"],
 		"successful geolocation response must reach user code intact")
 
-	// No retries: the client must NOT have retried anything. Under the
-	// pre-fix buggy behavior, the sandbox cap would fire at 100 ms, raise
-	// GeolocationServerError, and trigger the retry counter here.
+	// No retries: the client must NOT have retried anything. If the
+	// sandbox cap applied to this internal call, it would fire at 100 ms,
+	// raise GeolocationServerError, and trigger the retry counter here.
 	retriesCounter := newStats.GetByName("processor_user_transformer_http_retries")
 	if len(retriesCounter) > 0 {
 		require.EqualValues(t, 0, retriesCounter[0].Value,
@@ -335,6 +335,134 @@ def transformEvent(event, metadata):
 	})
 }
 
+// TestConnectionPoolPerTransformationIsolation locks the contract that when
+// CONN_POOL_PER_TRANSFORMATION=true (the default), two sequential
+// /customTransform requests with different transformationVersionIds — served
+// by the SAME worker subprocess (SANDBOX_POOL_MAX_SIZE=1) against the SAME
+// host — must NOT share a TCP connection. The subtest with the flag off is
+// the negative control: with partitioning disabled, the same two requests
+// collapse onto the process-wide pooled session and must share the socket.
+//
+// This prevents cross-version TLS-related connection state from carrying
+// over: if two transformations can ever share a connection pool, a
+// “verify=False“ socket warmed by one of them can be silently reused by a
+// default-“verify=True“ call from the other, bypassing certificate
+// validation. Partitioning the pooled session by
+// “transformation_version_id“ means no two transformations ever share an
+// “HTTPConnectionPool“ in the first place.
+//
+// Connection reuse is verified server-side using the Go http.Server
+// ConnState hook: http.StateNew fires exactly once per TCP handshake.
+// Two requests on partitioned sessions produce two StateNew events;
+// two requests on the shared session produce one.
+func TestConnectionPoolPerTransformationIsolation(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
+
+	const (
+		versionIDAlpha = "partition-iso-alpha"
+		versionIDBeta  = "partition-iso-beta"
+	)
+
+	// A single counting server reused across both subtests. Each
+	// subtest resets the counter first so it sees a clean delta.
+	trackSrv, newConns := newConnectionCountingServer(t)
+
+	// Both versions hit the same URL. The transformation code is
+	// identical — the ONLY thing that differs is the versionID they
+	// are registered under, so any connection reuse observed on the
+	// server side must have come from a pooled session shared across
+	// version_ids.
+	code := fmt.Sprintf(`
+import requests
+
+def transformEvent(event, metadata):
+    resp = requests.get("%s/check")
+    event["ok"] = resp.status_code == 200
+    return event
+`, toContainerURL(trackSrv.URL))
+
+	entries := map[string]configBackendEntry{
+		versionIDAlpha: {code: code},
+		versionIDBeta:  {code: code},
+	}
+
+	configBackend := newContractConfigBackend(t, entries)
+	t.Cleanup(configBackend.Close)
+
+	t.Run("DistinctConnectionPerVersionWhenPartitioned", func(t *testing.T) {
+		// CONN_POOL_PER_TRANSFORMATION=true is the default, but set
+		// it explicitly so the subtest is self-describing and a
+		// future default change does not silently flip the semantics.
+		partURL := startRudderPytransformer(
+			t, pool, configBackend.URL,
+			"ENABLE_CONN_POOL=true",
+			"CONN_POOL_PER_TRANSFORMATION=true",
+			"USER_CONN_POOL_MAX_SIZE=1",
+			// Pin to a single worker so both events land in the same
+			// subprocess — otherwise the "shared pool" hypothesis is
+			// not exercised at all and the assertion is vacuous.
+			"SANDBOX_POOL_MAX_SIZE=1",
+		)
+
+		newConns.Store(0)
+
+		ev1 := makeEvent("msg-part-alpha", versionIDAlpha)
+		status1, items1 := sendRawTransform(t, partURL, []types.TransformerEvent{ev1})
+		require.Equal(t, http.StatusOK, status1)
+		require.Len(t, items1, 1)
+		require.Equal(t, http.StatusOK, items1[0].StatusCode, "alpha request must succeed")
+
+		ev2 := makeEvent("msg-part-beta", versionIDBeta)
+		status2, items2 := sendRawTransform(t, partURL, []types.TransformerEvent{ev2})
+		require.Equal(t, http.StatusOK, status2)
+		require.Len(t, items2, 1)
+		require.Equal(t, http.StatusOK, items2[0].StatusCode, "beta request must succeed")
+
+		require.EqualValues(t, 2, newConns.Load(),
+			"with CONN_POOL_PER_TRANSFORMATION=true, two requests under "+
+				"distinct transformation_version_ids must open two TCP "+
+				"connections even through the same worker subprocess — "+
+				"server-side StateNew count: want 2, got %d", newConns.Load())
+	})
+
+	t.Run("SharedConnectionAcrossVersionsWhenDisabled", func(t *testing.T) {
+		// Negative control: with the escape hatch engaged, the two
+		// version_ids must collapse back onto the shared session. If
+		// this subtest also sees 2 new connections, the partitioning
+		// test above is passing for the wrong reason (e.g. pooling
+		// broken in both modes).
+		sharedURL := startRudderPytransformer(
+			t, pool, configBackend.URL,
+			"ENABLE_CONN_POOL=true",
+			"CONN_POOL_PER_TRANSFORMATION=false",
+			"USER_CONN_POOL_MAX_SIZE=1",
+			"SANDBOX_POOL_MAX_SIZE=1",
+		)
+
+		newConns.Store(0)
+
+		ev1 := makeEvent("msg-shared-alpha", versionIDAlpha)
+		status1, items1 := sendRawTransform(t, sharedURL, []types.TransformerEvent{ev1})
+		require.Equal(t, http.StatusOK, status1)
+		require.Len(t, items1, 1)
+		require.Equal(t, http.StatusOK, items1[0].StatusCode, "alpha request must succeed")
+
+		ev2 := makeEvent("msg-shared-beta", versionIDBeta)
+		status2, items2 := sendRawTransform(t, sharedURL, []types.TransformerEvent{ev2})
+		require.Equal(t, http.StatusOK, status2)
+		require.Len(t, items2, 1)
+		require.Equal(t, http.StatusOK, items2[0].StatusCode, "beta request must succeed")
+
+		require.EqualValues(t, 1, newConns.Load(),
+			"with CONN_POOL_PER_TRANSFORMATION=false, both version_ids "+
+				"must share the shared pooled session and reuse a single "+
+				"TCP connection — server-side StateNew count: want 1, "+
+				"got %d", newConns.Load())
+	})
+}
+
 // TestSlowDripBodyFiresSandboxHTTPTimeout locks in the contract that a server
 // which flushes response headers quickly and then drips the body one byte at
 // a time must NOT pin a sandbox worker for longer than SANDBOX_HTTP_TIMEOUT_S.
@@ -406,15 +534,16 @@ def transformEvent(event, metadata):
 	require.Empty(t, items[0].Output,
 		"a timed-out event must not carry a successful transformation output")
 
-	// Wall-clock budget: the pre-fix path would pin the worker for the full
-	// 6s body duration. Post-fix the cap must fire within ~1s + overhead,
-	// comfortably below 4s — and critically far below the 6s drip ceiling.
+	// Wall-clock budget: without the body-read deadline, the worker would
+	// be pinned for the full 6s body duration. The cap must fire within
+	// ~1s + overhead, comfortably below 4s — and critically far below the
+	// 6s drip ceiling.
 	// Using 4 s as the bound keeps the assertion resilient to normal Docker
 	// container-start jitter while still catching any regression that
 	// reverts the deadline wrapper.
 	require.Less(t, elapsed, 4*time.Second,
 		"SANDBOX_HTTP_TIMEOUT_S must cap the wall-clock budget for slow-drip "+
-			"body reads; elapsed=%s (pre-fix would be ~6s)", elapsed)
+			"body reads; elapsed=%s (uncapped would be ~6s)", elapsed)
 }
 
 // newSlowDripBodyServer creates an httptest server that flushes response

--- a/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
+++ b/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
@@ -281,7 +281,8 @@ def transformEvent(event, metadata):
 			"SANDBOX_POOL_MAX_SIZE=1",
 		)
 
-		before := newConns.Load()
+		// Reset newConns before sending events
+		newConns.Store(0)
 
 		ev1 := makeEvent("msg-nopool-1", versionID)
 		status1, items1 := sendRawTransform(t, noPoolURL, []types.TransformerEvent{ev1})
@@ -295,8 +296,7 @@ def transformEvent(event, metadata):
 		require.Len(t, items2, 1)
 		require.Equal(t, http.StatusOK, items2[0].StatusCode, "second request must succeed")
 
-		delta := newConns.Load() - before
-		require.EqualValues(t, 2, delta,
+		require.EqualValues(t, 2, newConns.Load(),
 			"with ENABLE_CONN_POOL=false, each bare requests.get() must open "+
 				"a fresh TCP connection (server-side StateNew count: want 2)")
 	})
@@ -313,7 +313,8 @@ def transformEvent(event, metadata):
 			"SANDBOX_POOL_MAX_SIZE=1",
 		)
 
-		before := newConns.Load()
+		// Reset newConns before sending events
+		newConns.Store(0)
 
 		ev1 := makeEvent("msg-pool-1", versionID)
 		status1, items1 := sendRawTransform(t, poolURL, []types.TransformerEvent{ev1})
@@ -327,8 +328,7 @@ def transformEvent(event, metadata):
 		require.Len(t, items2, 1)
 		require.Equal(t, http.StatusOK, items2[0].StatusCode, "second request must succeed")
 
-		delta := newConns.Load() - before
-		require.EqualValues(t, 1, delta,
+		require.EqualValues(t, 1, newConns.Load(),
 			"with ENABLE_CONN_POOL=true, the second bare requests.get() to the "+
 				"same host must reuse the pooled TCP connection "+
 				"(server-side StateNew count: want 1)")

--- a/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
+++ b/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
@@ -73,11 +73,6 @@ def transformEvent(event, metadata):
 		// 300 ms) so the only legal outcome is success.
 		"GEOLOCATION_TIMEOUT_SECS=0.5",
 	)
-	t.Cleanup(func() {
-		if err := pool.Purge(container); err != nil {
-			t.Logf("Failed to purge pytransformer container: %v", err)
-		}
-	})
 	waitForHealthy(t, pool, pyURL, "pytransformer", container)
 
 	// Limited-retry client so a regression (which would trip retries) is
@@ -150,69 +145,60 @@ func TestUserHTTPTimeoutCapping(t *testing.T) {
 	pool.MaxWait = 2 * time.Minute
 
 	const (
-		versionBigger  = "user-timeout-bigger-v1"
-		versionSmaller = "user-timeout-smaller-v1"
+		versionBiggerTimeout  = "user-timeout-bigger-v1"
+		versionSmallerTimeout = "user-timeout-smaller-v1"
 	)
 
-	// slowSrv3s: responds after 3s — longer than SANDBOX_HTTP_TIMEOUT_S (2s)
-	// but shorter than the user's requested timeout (10s).  Our cap fires.
-	slowSrv3s, _ := newSlowServer(t, 3*time.Second)
-
-	// slowSrv1s: responds after 1s — longer than the user's requested timeout
-	// (0.5s) but shorter than SANDBOX_HTTP_TIMEOUT_S (2s).  User's cap fires.
-	slowSrv1s, _ := newSlowServer(t, 1*time.Second)
+	slowServer, calls := newSlowServer(t, 2*time.Second)
 
 	entries := map[string]configBackendEntry{
-		versionBigger: {code: fmt.Sprintf(`
+		versionBiggerTimeout: {code: fmt.Sprintf(`
 import requests
 
 def transformEvent(event, metadata):
-    # timeout=10 — user wants 10 s, but SANDBOX_HTTP_TIMEOUT_S=2 caps it.
+    # timeout=5 — user wants 5s, but SANDBOX_HTTP_TIMEOUT_S=1 caps it.
     # Timeout intentionally not caught — propagates as per-event status 400.
-    resp = requests.get("%s/data", timeout=10)
+    resp = requests.get("%s/data", timeout=5)
     event["status"] = resp.status_code
     return event
-`, toContainerURL(slowSrv3s.URL))},
+`, toContainerURL(slowServer.URL))},
 
-		versionSmaller: {code: fmt.Sprintf(`
+		versionSmallerTimeout: {code: fmt.Sprintf(`
 import requests
 
 def transformEvent(event, metadata):
-    # timeout=0.5 — user's cap is smaller than SANDBOX_HTTP_TIMEOUT_S=2.
+    # timeout=0.1 — user's cap is smaller than SANDBOX_HTTP_TIMEOUT_S=2.
     # Timeout intentionally not caught — propagates as per-event status 400.
-    resp = requests.get("%s/data", timeout=0.5)
+    resp = requests.get("%s/data", timeout=0.1)
     event["status"] = resp.status_code
     return event
-`, toContainerURL(slowSrv1s.URL))},
+`, toContainerURL(slowServer.URL))},
 	}
 
 	configBackend := newContractConfigBackend(t, entries)
 	t.Cleanup(configBackend.Close)
 
-	// SANDBOX_HTTP_TIMEOUT_S=2: our cap is between the user's bigger (10s)
-	// and smaller (0.5s) values, so both subtests can verify the correct cap.
+	// SANDBOX_HTTP_TIMEOUT_S=1: our cap is between the user's bigger (5s)
+	// and smaller (0.1s) values, so both subtests can verify the correct cap.
 	container, pyURL := startRudderPytransformer(
 		t, pool, configBackend.URL,
-		"SANDBOX_HTTP_TIMEOUT_S=2",
+		"SANDBOX_HTTP_TIMEOUT_S=1",
 	)
-	t.Cleanup(func() {
-		if err := pool.Purge(container); err != nil {
-			t.Logf("Failed to purge pytransformer container: %v", err)
-		}
-	})
 	waitForHealthy(t, pool, pyURL, "pytransformer", container)
 
 	t.Run("OurCapHonouredWhenUserTimeoutIsBigger", func(t *testing.T) {
-		// The user passes timeout=10 s, but the server only replies after 3s.
-		// Our cap (2s) fires first.  The transformation fails with a 400
+		// Reset calls before test
+		calls.Store(0)
+		// The user passes timeout=5s, but the server only replies after 2s.
+		// Our cap (1s) fires first. The transformation fails with a 400
 		// per-event error (non-retryable user code HTTP timeout).
-		events := []types.TransformerEvent{makeEvent("msg-bigger-1", versionBigger)}
+		events := []types.TransformerEvent{makeEvent("msg-bigger-1", versionBiggerTimeout)}
 		status, items := sendRawTransform(t, pyURL, events)
 		require.Equal(t, http.StatusOK, status,
 			"/customTransform HTTP response must be 200 (per-event errors are in the payload)")
 		require.Len(t, items, 1)
 		require.Equal(t, http.StatusBadRequest, items[0].StatusCode,
-			"our cap (2s) must fire before user timeout (10s) when server takes 3s")
+			"our cap (1s) must fire before user timeout (5s) when server takes > 1s")
 		// The error message should mention a timeout — both ReadTimeout and
 		// ConnectTimeout carry "timeout" or "timed out" in their string.
 		require.NotEmpty(t, items[0].Error,
@@ -222,21 +208,25 @@ def transformEvent(event, metadata):
 		// The event must appear in the failed payload, not silently swallowed.
 		require.Empty(t, items[0].Output,
 			"a timed-out event must not carry a successful output")
+		require.EqualValues(t, 1, calls.Load())
 	})
 
 	t.Run("UserTimeoutHonouredWhenSmallerThanCap", func(t *testing.T) {
-		// The user passes timeout=0.5 s; the server replies after 1s.
-		// The user's cap fires first (0.5s < our 2s cap < server's 1s delay).
-		events := []types.TransformerEvent{makeEvent("msg-smaller-1", versionSmaller)}
+		// Reset calls before test
+		calls.Store(0)
+		// The user passes timeout=0.1 s; the server replies after 2s.
+		// The user's cap fires first (0.5s < our 1s cap < server's 2s delay).
+		events := []types.TransformerEvent{makeEvent("msg-smaller-1", versionSmallerTimeout)}
 		status, items := sendRawTransform(t, pyURL, events)
 		require.Equal(t, http.StatusOK, status)
 		require.Len(t, items, 1)
 		require.Equal(t, http.StatusBadRequest, items[0].StatusCode,
-			"user timeout (0.5s) must fire before our cap (2s) when server takes 1s")
+			"user timeout (0.1s) must fire before our cap (1s) when server takes > 1s")
 		require.NotEmpty(t, items[0].Error,
 			"timeout error must be propagated as a non-empty per-event error")
 		require.Empty(t, items[0].Output,
 			"a timed-out event must not carry a successful output")
+		require.EqualValues(t, 1, calls.Load())
 	})
 }
 
@@ -292,11 +282,6 @@ def transformEvent(event, metadata):
 			// affinity.
 			"SANDBOX_POOL_MAX_SIZE=1",
 		)
-		t.Cleanup(func() {
-			if err := pool.Purge(noPoolContainer); err != nil {
-				t.Logf("Failed to purge no-pool pytransformer: %v", err)
-			}
-		})
 		waitForHealthy(t, pool, noPoolURL, "pytransformer (no-pool)", noPoolContainer)
 
 		before := newConns.Load()
@@ -330,11 +315,6 @@ def transformEvent(event, metadata):
 			// Single worker to guarantee the same session handles both requests.
 			"SANDBOX_POOL_MAX_SIZE=1",
 		)
-		t.Cleanup(func() {
-			if err := pool.Purge(poolContainer); err != nil {
-				t.Logf("Failed to purge with-pool pytransformer: %v", err)
-			}
-		})
 		waitForHealthy(t, pool, poolURL, "pytransformer (with-pool)", poolContainer)
 
 		before := newConns.Load()

--- a/integration_test/pytransformer_contract/mirror_filter_test.go
+++ b/integration_test/pytransformer_contract/mirror_filter_test.go
@@ -68,23 +68,20 @@ def transformEvent(event, metadata):
 	defer configBackend.Close()
 
 	var (
-		pyFilteredContainer, pyNormalContainer *dockertest.Resource
-		pyFilteredURL, pyNormalURL             string
+		pyFilteredURL, pyNormalURL string
 	)
 	wg := sync.WaitGroup{}
 	wg.Go(func() {
 		// Start pytransformer WITH mirror filter enabled
-		pyFilteredContainer, pyFilteredURL = startRudderPytransformer(
+		pyFilteredURL = startRudderPytransformer(
 			t, pool, configBackend.URL, "MIRROR_FILTER_ENABLED=true",
 		)
-		waitForHealthy(t, pool, pyFilteredURL, "pytransformer-filtered", pyFilteredContainer)
 	})
 	wg.Go(func() {
 		// Start pytransformer WITHOUT mirror filter (default)
-		pyNormalContainer, pyNormalURL = startRudderPytransformer(
+		pyNormalURL = startRudderPytransformer(
 			t, pool, configBackend.URL,
 		)
-		waitForHealthy(t, pool, pyNormalURL, "pytransformer-normal", pyNormalContainer)
 	})
 	wg.Wait()
 

--- a/integration_test/pytransformer_contract/mirror_filter_test.go
+++ b/integration_test/pytransformer_contract/mirror_filter_test.go
@@ -77,7 +77,6 @@ def transformEvent(event, metadata):
 		pyFilteredContainer, pyFilteredURL = startRudderPytransformer(
 			t, pool, configBackend.URL, "MIRROR_FILTER_ENABLED=true",
 		)
-		t.Cleanup(func() { _ = pool.Purge(pyFilteredContainer) })
 		waitForHealthy(t, pool, pyFilteredURL, "pytransformer-filtered", pyFilteredContainer)
 	})
 	wg.Go(func() {
@@ -85,7 +84,6 @@ def transformEvent(event, metadata):
 		pyNormalContainer, pyNormalURL = startRudderPytransformer(
 			t, pool, configBackend.URL,
 		)
-		t.Cleanup(func() { _ = pool.Purge(pyNormalContainer) })
 		waitForHealthy(t, pool, pyNormalURL, "pytransformer-normal", pyNormalContainer)
 	})
 	wg.Wait()

--- a/integration_test/pytransformer_contract/mirror_filter_test.go
+++ b/integration_test/pytransformer_contract/mirror_filter_test.go
@@ -67,9 +67,7 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, allEntries)
 	defer configBackend.Close()
 
-	var (
-		pyFilteredURL, pyNormalURL string
-	)
+	var pyFilteredURL, pyNormalURL string
 	wg := sync.WaitGroup{}
 	wg.Go(func() {
 		// Start pytransformer WITH mirror filter enabled

--- a/integration_test/pytransformer_contract/pytransformer_contract_test.go
+++ b/integration_test/pytransformer_contract/pytransformer_contract_test.go
@@ -87,12 +87,7 @@ def transformEvent(event, metadata):
 	defer pyConfigBackend.Close()
 
 	// 4. Start rudder-pytransformer container
-	pyTransformerContainer, pyTransformerURL := startRudderPytransformer(t, pool, pyConfigBackend.URL)
-	defer func() {
-		if err := pool.Purge(pyTransformerContainer); err != nil {
-			t.Logf("Failed to purge pytransformer container: %v", err)
-		}
-	}()
+	_, pyTransformerURL := startRudderPytransformer(t, pool, pyConfigBackend.URL)
 	waitForHealthy(t, pool, pyTransformerURL, "rudder-pytransformer")
 
 	// 6. Create mock transformer for features and destination transforms

--- a/integration_test/pytransformer_contract/pytransformer_contract_test.go
+++ b/integration_test/pytransformer_contract/pytransformer_contract_test.go
@@ -87,8 +87,7 @@ def transformEvent(event, metadata):
 	defer pyConfigBackend.Close()
 
 	// 4. Start rudder-pytransformer container
-	_, pyTransformerURL := startRudderPytransformer(t, pool, pyConfigBackend.URL)
-	waitForHealthy(t, pool, pyTransformerURL, "rudder-pytransformer")
+	pyTransformerURL := startRudderPytransformer(t, pool, pyConfigBackend.URL)
 
 	// 6. Create mock transformer for features and destination transforms
 	// This handles everything except /customTransform (which goes to pytransformer)

--- a/integration_test/pytransformer_contract/requests_api_contract_test.go
+++ b/integration_test/pytransformer_contract/requests_api_contract_test.go
@@ -17,40 +17,41 @@ import (
 	"github.com/rudderlabs/rudder-server/processor/types"
 )
 
-// TestRequestsApiModuleContract locks the contract that user code importing
-// HTTP helpers from “requests.api“ (the submodule where the functions are
-// defined) produces identical results to the standard “import requests;
-// requests.get(url)“ path on both architectures.
+// TestRequestsModuleWrapperContract locks the contract that user code
+// accessing HTTP helpers through alternative module paths produces
+// identical results to the standard "import requests; requests.get(url)"
+// path on both architectures.
 //
-// “requests.__init__“ does “from .api import get, post, ...“ so the
-// top-level names and the submodule names start as the same object.
-// pytransformer's “wrap_requests_methods“ must rebind both namespaces;
-// otherwise “from requests.api import get“ or “requests.api.get(url)“
-// bypasses metrics and connection-pool wrappers.
+// pytransformer's "wrap_requests_methods" must rebind names on both
+// "requests" and "requests.api", and must also wrap
+// "requests.request" — the verb-parameterized entry point. Without
+// this, any of the following user-code patterns bypass metrics and
+// connection-pool wrappers:
 //
-// The test exercises two user-code import styles:
-//   - “from requests.api import get“ — binds at import time
-//   - “requests.api.get(url)“ — attribute chain resolved at call time
+//   - "from requests.api import get" — binds at import time
+//   - "requests.api.get(url)" — attribute chain resolved at call time
+//   - "requests.request("GET", url)" — verb-parameterized entry point
 //
-// Both must produce the same output as the old architecture (vanilla
-// “requests“) under every “ENABLE_CONN_POOL“ setting.
+// All three must produce the same output as the old architecture
+// (vanilla "requests") under every "ENABLE_CONN_POOL" setting.
 //
-// Under “ENABLE_CONN_POOL=true“, an additional “ConnectionReuse“ subtest
-// proves that the calls actually flow through the pooling wrapper by sending
-// two sequential requests and asserting that the server observed a single TCP
-// handshake (connection reuse). Without the wrapper, vanilla
-// “requests.api.get“ creates a throwaway “Session“ per call and opens a
-// fresh TCP connection each time — so “newConns == 1“ can only be true if
-// the call went through the persistent pooled session installed by the
-// wrapper.
-func TestRequestsApiModuleContract(t *testing.T) {
+// Under "ENABLE_CONN_POOL=true", additional "ConnectionReuse" subtests
+// prove that the calls actually flow through the pooling wrapper by
+// sending two sequential requests and asserting that the server
+// observed a single TCP handshake (connection reuse). Without the
+// wrapper, vanilla "requests.api.get" / "requests.request" creates a
+// throwaway "Session" per call and opens a fresh TCP connection each
+// time — so "newConns == 1" can only be true if the call went through
+// the persistent pooled session installed by the wrapper.
+func TestRequestsModuleWrapperContract(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 	pool.MaxWait = 2 * time.Minute
 
 	const (
-		parityVersionID = "requests-api-module-v1"
-		reuseVersionID  = "requests-api-reuse-v1"
+		parityVersionID       = "requests-wrapper-parity-v1"
+		reuseApiVersionID     = "requests-wrapper-reuse-api-v1"
+		reuseRequestVersionID = "requests-wrapper-reuse-request-v1"
 	)
 
 	echo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +61,7 @@ func TestRequestsApiModuleContract(t *testing.T) {
 	}))
 	t.Cleanup(echo.Close)
 
-	// Connection-counting echo server for the ConnectionReuse subtest.
+	// Connection-counting echo server for the ConnectionReuse subtests.
 	// ConnState fires StateNew exactly once per TCP handshake, so
 	// newConns == 1 after two HTTP calls proves the second call reused
 	// the pooled connection instead of opening a fresh one.
@@ -81,8 +82,7 @@ func TestRequestsApiModuleContract(t *testing.T) {
 	t.Cleanup(countingEcho.Close)
 
 	// Dispatcher user code: the "style" field in the incoming event
-	// selects between ``from requests.api import get`` and the dotted
-	// ``requests.api.get`` attribute-chain path.
+	// selects between the three alternative import / call paths.
 	parityCode := fmt.Sprintf(`
 import requests
 from requests.api import get as api_get
@@ -94,6 +94,8 @@ def transformEvent(event, metadata):
         resp = api_get(url, params={"q": "hello", "style": style}, timeout=5)
     elif style == "dotted":
         resp = requests.api.get(url, params={"q": "hello", "style": style}, timeout=5)
+    elif style == "request":
+        resp = requests.request("GET", url, params={"q": "hello", "style": style}, timeout=5)
     else:
         raise ValueError("unknown style: " + repr(style))
     body = resp.json()
@@ -102,10 +104,10 @@ def transformEvent(event, metadata):
     return event
 `, toContainerURL(echo.URL))
 
-	// Separate code for the connection-reuse subtest — hits the
-	// counting server via ``from requests.api import get`` so we can
-	// assert that the pooling wrapper is actually in the call path.
-	reuseCode := fmt.Sprintf(`
+	// Separate code for each connection-reuse subtest — each hits the
+	// counting server through a single call path so we can assert that
+	// the pooling wrapper is actually in the call path.
+	reuseApiCode := fmt.Sprintf(`
 from requests.api import get
 
 def transformEvent(event, metadata):
@@ -114,9 +116,19 @@ def transformEvent(event, metadata):
     return event
 `, toContainerURL(countingEcho.URL))
 
+	reuseRequestCode := fmt.Sprintf(`
+import requests
+
+def transformEvent(event, metadata):
+    resp = requests.request("GET", "%s/reuse-check", timeout=5)
+    event["echo"] = resp.json()["echo"]
+    return event
+`, toContainerURL(countingEcho.URL))
+
 	configBackend := newContractConfigBackend(t, map[string]configBackendEntry{
-		parityVersionID: {code: parityCode},
-		reuseVersionID:  {code: reuseCode},
+		parityVersionID:       {code: parityCode},
+		reuseApiVersionID:     {code: reuseApiCode},
+		reuseRequestVersionID: {code: reuseRequestCode},
 	})
 	t.Cleanup(configBackend.Close)
 
@@ -161,6 +173,7 @@ def transformEvent(event, metadata):
 	}{
 		{style: "from_import"},
 		{style: "dotted"},
+		{style: "request"},
 	}
 
 	for _, tc := range newArchCases {
@@ -204,48 +217,57 @@ def transformEvent(event, metadata):
 					diff, equal := oldResp.Equal(&newResp)
 					require.Truef(t, equal,
 						"ENABLE_CONN_POOL=%s, style=%s: old and new architectures "+
-							"must produce identical responses for requests.api import:\n%s",
+							"must produce identical responses:\n%s",
 						tc.enableConnPool, sc.style, diff)
 
 					env.assertRetryCountsMatch(t)
 				})
 			}
 
-			// Prove that ``from requests.api import get`` actually goes
-			// through the connection-pool wrapper, not just that it
-			// returns the correct response. With ENABLE_CONN_POOL=true,
-			// a wrapped call routes through a persistent pooled Session
-			// that keeps TCP connections alive across requests. An
-			// unwrapped call (vanilla ``requests.api.get``) creates a
-			// throwaway Session per invocation — every call opens a
-			// fresh TCP connection. Asserting that two sequential calls
-			// produced only one server-side TCP handshake (StateNew)
-			// proves the pooled Session was used, which is only possible
-			// if ``requests.api.get`` was rebound to the wrapper.
+			// Prove that the alternative call paths actually flow through
+			// the connection-pool wrapper, not just that they return the
+			// correct response. With ENABLE_CONN_POOL=true, a wrapped call
+			// routes through a persistent pooled Session that keeps TCP
+			// connections alive across requests. An unwrapped call (vanilla
+			// requests.api.get / requests.request) creates a throwaway
+			// Session per invocation — every call opens a fresh TCP
+			// connection. Asserting that two sequential calls produced only
+			// one server-side TCP handshake (StateNew) proves the pooled
+			// Session was used, which is only possible if the function was
+			// rebound to the wrapper.
 			if tc.enableConnPool == "true" {
-				t.Run("ConnectionReuse", func(t *testing.T) {
-					newConns.Store(0)
+				reuseCases := []struct {
+					name      string
+					versionID string
+				}{
+					{name: "from_requests.api_import_get", versionID: reuseApiVersionID},
+					{name: "requests.request", versionID: reuseRequestVersionID},
+				}
+				for _, rc := range reuseCases {
+					t.Run("ConnectionReuse/"+rc.name, func(t *testing.T) {
+						newConns.Store(0)
 
-					ev1 := makeEvent("msg-reuse-1", reuseVersionID)
-					status1, items1 := sendRawTransform(t, pyTransformerURL, []types.TransformerEvent{ev1})
-					require.Equal(t, http.StatusOK, status1)
-					require.Len(t, items1, 1)
-					require.Equal(t, http.StatusOK, items1[0].StatusCode, "first request must succeed")
+						ev1 := makeEvent("msg-reuse-1", rc.versionID)
+						status1, items1 := sendRawTransform(t, pyTransformerURL, []types.TransformerEvent{ev1})
+						require.Equal(t, http.StatusOK, status1)
+						require.Len(t, items1, 1)
+						require.Equal(t, http.StatusOK, items1[0].StatusCode, "first request must succeed")
 
-					ev2 := makeEvent("msg-reuse-2", reuseVersionID)
-					status2, items2 := sendRawTransform(t, pyTransformerURL, []types.TransformerEvent{ev2})
-					require.Equal(t, http.StatusOK, status2)
-					require.Len(t, items2, 1)
-					require.Equal(t, http.StatusOK, items2[0].StatusCode, "second request must succeed")
+						ev2 := makeEvent("msg-reuse-2", rc.versionID)
+						status2, items2 := sendRawTransform(t, pyTransformerURL, []types.TransformerEvent{ev2})
+						require.Equal(t, http.StatusOK, status2)
+						require.Len(t, items2, 1)
+						require.Equal(t, http.StatusOK, items2[0].StatusCode, "second request must succeed")
 
-					require.EqualValues(t, 1, newConns.Load(),
-						"with ENABLE_CONN_POOL=true, two sequential "+
-							"``from requests.api import get; get(url)`` calls "+
-							"must reuse the same TCP connection (server-side "+
-							"StateNew count: want 1). A count of 2 means the "+
-							"calls bypassed the pooling wrapper and each "+
-							"created a throwaway Session.")
-				})
+						require.EqualValues(t, 1, newConns.Load(),
+							"with ENABLE_CONN_POOL=true, two sequential calls "+
+								"via %s must reuse the same TCP connection "+
+								"(server-side StateNew count: want 1). A count "+
+								"of 2 means the calls bypassed the pooling "+
+								"wrapper and each created a throwaway Session.",
+							rc.name)
+					})
+				}
 			}
 		})
 	}

--- a/integration_test/pytransformer_contract/requests_api_contract_test.go
+++ b/integration_test/pytransformer_contract/requests_api_contract_test.go
@@ -1,0 +1,252 @@
+package pytransformer_contract
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/processor/types"
+)
+
+// TestRequestsApiModuleContract locks the contract that user code importing
+// HTTP helpers from “requests.api“ (the submodule where the functions are
+// defined) produces identical results to the standard “import requests;
+// requests.get(url)“ path on both architectures.
+//
+// “requests.__init__“ does “from .api import get, post, ...“ so the
+// top-level names and the submodule names start as the same object.
+// pytransformer's “wrap_requests_methods“ must rebind both namespaces;
+// otherwise “from requests.api import get“ or “requests.api.get(url)“
+// bypasses metrics and connection-pool wrappers.
+//
+// The test exercises two user-code import styles:
+//   - “from requests.api import get“ — binds at import time
+//   - “requests.api.get(url)“ — attribute chain resolved at call time
+//
+// Both must produce the same output as the old architecture (vanilla
+// “requests“) under every “ENABLE_CONN_POOL“ setting.
+//
+// Under “ENABLE_CONN_POOL=true“, an additional “ConnectionReuse“ subtest
+// proves that the calls actually flow through the pooling wrapper by sending
+// two sequential requests and asserting that the server observed a single TCP
+// handshake (connection reuse). Without the wrapper, vanilla
+// “requests.api.get“ creates a throwaway “Session“ per call and opens a
+// fresh TCP connection each time — so “newConns == 1“ can only be true if
+// the call went through the persistent pooled session installed by the
+// wrapper.
+func TestRequestsApiModuleContract(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
+
+	const (
+		parityVersionID = "requests-api-module-v1"
+		reuseVersionID  = "requests-api-reuse-v1"
+	)
+
+	echo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"echo": %q, "style": %q}`, q, r.URL.Query().Get("style"))
+	}))
+	t.Cleanup(echo.Close)
+
+	// Connection-counting echo server for the ConnectionReuse subtest.
+	// ConnState fires StateNew exactly once per TCP handshake, so
+	// newConns == 1 after two HTTP calls proves the second call reused
+	// the pooled connection instead of opening a fresh one.
+	newConns := &atomic.Int64{}
+	countingEcho := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := []byte(`{"echo": "reuse-check"}`)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	countingEcho.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConns.Add(1)
+		}
+	}
+	countingEcho.Start()
+	t.Cleanup(countingEcho.Close)
+
+	// Dispatcher user code: the "style" field in the incoming event
+	// selects between ``from requests.api import get`` and the dotted
+	// ``requests.api.get`` attribute-chain path.
+	parityCode := fmt.Sprintf(`
+import requests
+from requests.api import get as api_get
+
+def transformEvent(event, metadata):
+    style = event["style"]
+    url = "%s/search"
+    if style == "from_import":
+        resp = api_get(url, params={"q": "hello", "style": style}, timeout=5)
+    elif style == "dotted":
+        resp = requests.api.get(url, params={"q": "hello", "style": style}, timeout=5)
+    else:
+        raise ValueError("unknown style: " + repr(style))
+    body = resp.json()
+    event["echo"] = body["echo"]
+    event["resp_style"] = body["style"]
+    return event
+`, toContainerURL(echo.URL))
+
+	// Separate code for the connection-reuse subtest — hits the
+	// counting server via ``from requests.api import get`` so we can
+	// assert that the pooling wrapper is actually in the call path.
+	reuseCode := fmt.Sprintf(`
+from requests.api import get
+
+def transformEvent(event, metadata):
+    resp = get("%s/reuse-check", timeout=5)
+    event["echo"] = resp.json()["echo"]
+    return event
+`, toContainerURL(countingEcho.URL))
+
+	configBackend := newContractConfigBackend(t, map[string]configBackendEntry{
+		parityVersionID: {code: parityCode},
+		reuseVersionID:  {code: reuseCode},
+	})
+	t.Cleanup(configBackend.Close)
+
+	t.Log("Starting openfaas-flask-base (old arch backend)...")
+	openFaasURL := startOpenFaasFlask(t, pool, parityVersionID, configBackend.URL)
+
+	t.Log("Starting mock OpenFaaS gateway...")
+	mockGateway, _ := newMockOpenFaaSGateway(t, func() string { return openFaasURL })
+	t.Cleanup(mockGateway.Close)
+
+	t.Log("Starting rudder-transformer (old arch frontend)...")
+	transformerContainer, transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
+	t.Cleanup(func() {
+		if err := pool.Purge(transformerContainer); err != nil {
+			t.Logf("Failed to purge rudder-transformer: %v", err)
+		}
+	})
+	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
+
+	newArchCases := []struct {
+		name            string
+		enableConnPool  string
+		extraPytransEnv []string
+	}{
+		{
+			name:            "ConnPoolDisabled",
+			enableConnPool:  "false",
+			extraPytransEnv: nil,
+		},
+		{
+			name:           "ConnPoolEnabled",
+			enableConnPool: "true",
+			extraPytransEnv: []string{
+				"USER_CONN_POOL_MAX_SIZE=1",
+				"SANDBOX_POOL_MAX_SIZE=1",
+			},
+		},
+	}
+
+	styleCases := []struct {
+		style string
+	}{
+		{style: "from_import"},
+		{style: "dotted"},
+	}
+
+	for _, tc := range newArchCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pyEnv := append([]string{"ENABLE_CONN_POOL=" + tc.enableConnPool}, tc.extraPytransEnv...)
+			t.Logf("Starting rudder-pytransformer with %v...", pyEnv)
+			pyTransformerURL := startRudderPytransformer(t, pool, configBackend.URL, pyEnv...)
+
+			for _, sc := range styleCases {
+				t.Run(sc.style, func(t *testing.T) {
+					env := newBCTestEnv(t, transformerURL, pyTransformerURL,
+						withFailOnError(),
+						withLimitedRetryableHTTPRetries(),
+					)
+
+					event := makeEvent("msg-"+sc.style, parityVersionID)
+					event.Message["style"] = sc.style
+					events := []types.TransformerEvent{event}
+
+					t.Log("Sending request to old architecture...")
+					oldResp := env.OldClient.Transform(context.Background(), events)
+					t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+
+					t.Log("Sending request to new architecture...")
+					newResp := env.NewClient.Transform(context.Background(), events)
+					t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+
+					require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
+					require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
+					require.Equalf(t, 1, len(newResp.Events),
+						"new arch (ENABLE_CONN_POOL=%s, style=%s): 1 success event expected",
+						tc.enableConnPool, sc.style)
+					require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+
+					require.Equal(t, "hello", oldResp.Events[0].Output["echo"],
+						"old arch must echo q=hello")
+					require.Equalf(t, "hello", newResp.Events[0].Output["echo"],
+						"new arch (ENABLE_CONN_POOL=%s, style=%s) must echo q=hello",
+						tc.enableConnPool, sc.style)
+
+					diff, equal := oldResp.Equal(&newResp)
+					require.Truef(t, equal,
+						"ENABLE_CONN_POOL=%s, style=%s: old and new architectures "+
+							"must produce identical responses for requests.api import:\n%s",
+						tc.enableConnPool, sc.style, diff)
+
+					env.assertRetryCountsMatch(t)
+				})
+			}
+
+			// Prove that ``from requests.api import get`` actually goes
+			// through the connection-pool wrapper, not just that it
+			// returns the correct response. With ENABLE_CONN_POOL=true,
+			// a wrapped call routes through a persistent pooled Session
+			// that keeps TCP connections alive across requests. An
+			// unwrapped call (vanilla ``requests.api.get``) creates a
+			// throwaway Session per invocation — every call opens a
+			// fresh TCP connection. Asserting that two sequential calls
+			// produced only one server-side TCP handshake (StateNew)
+			// proves the pooled Session was used, which is only possible
+			// if ``requests.api.get`` was rebound to the wrapper.
+			if tc.enableConnPool == "true" {
+				t.Run("ConnectionReuse", func(t *testing.T) {
+					newConns.Store(0)
+
+					ev1 := makeEvent("msg-reuse-1", reuseVersionID)
+					status1, items1 := sendRawTransform(t, pyTransformerURL, []types.TransformerEvent{ev1})
+					require.Equal(t, http.StatusOK, status1)
+					require.Len(t, items1, 1)
+					require.Equal(t, http.StatusOK, items1[0].StatusCode, "first request must succeed")
+
+					ev2 := makeEvent("msg-reuse-2", reuseVersionID)
+					status2, items2 := sendRawTransform(t, pyTransformerURL, []types.TransformerEvent{ev2})
+					require.Equal(t, http.StatusOK, status2)
+					require.Len(t, items2, 1)
+					require.Equal(t, http.StatusOK, items2[0].StatusCode, "second request must succeed")
+
+					require.EqualValues(t, 1, newConns.Load(),
+						"with ENABLE_CONN_POOL=true, two sequential "+
+							"``from requests.api import get; get(url)`` calls "+
+							"must reuse the same TCP connection (server-side "+
+							"StateNew count: want 1). A count of 2 means the "+
+							"calls bypassed the pooling wrapper and each "+
+							"created a throwaway Session.")
+				})
+			}
+		})
+	}
+}

--- a/integration_test/pytransformer_contract/requests_api_contract_test.go
+++ b/integration_test/pytransformer_contract/requests_api_contract_test.go
@@ -140,13 +140,7 @@ def transformEvent(event, metadata):
 	t.Cleanup(mockGateway.Close)
 
 	t.Log("Starting rudder-transformer (old arch frontend)...")
-	transformerContainer, transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
-	t.Cleanup(func() {
-		if err := pool.Purge(transformerContainer); err != nil {
-			t.Logf("Failed to purge rudder-transformer: %v", err)
-		}
-	})
-	waitForHealthy(t, pool, transformerURL, "rudder-transformer")
+	transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
 
 	newArchCases := []struct {
 		name            string


### PR DESCRIPTION
# Description

## Summary

Add contract and backwards-compatibility tests for pytransformer HTTP timeout capping, connection pooling, cookie isolation, and `requests` module wrapper behaviour. Also simplifies Docker container lifecycle in existing tests (cleanup is now handled by `startRudderPytransformer`/`startOpenFaasFlask` internally) and fixes the Slack notification payload format in the scheduled-release workflow.

## Test scenarios

### HTTP timeout and connection pool (`http_timeout_conn_pool_contract_test.go`)

- `SANDBOX_HTTP_TIMEOUT_S` does not cap internal geolocation traffic (geolocation calls are bound exclusively by `GEOLOCATION_TIMEOUT_SECS`)
- User HTTP timeout is capped to `SANDBOX_HTTP_TIMEOUT_S` when the user-supplied timeout is larger than the sandbox cap
- User HTTP timeout is honoured when it is smaller than `SANDBOX_HTTP_TIMEOUT_S`
- Each bare `requests.get()` opens a fresh TCP connection when `ENABLE_CONN_POOL=false`
- Repeated bare `requests.get()` calls to the same host reuse the pooled TCP connection when `ENABLE_CONN_POOL=true`
- Two requests under distinct `transformation_version_id`s open separate TCP connections when `CONN_POOL_PER_TRANSFORMATION=true` (default), even through the same worker subprocess
- Two requests under distinct `transformation_version_id`s share a single TCP connection when `CONN_POOL_PER_TRANSFORMATION=false`
- A slow-drip response body (headers flushed immediately, body trickled one byte at a time) fires `SANDBOX_HTTP_TIMEOUT_S` and does not pin the sandbox worker for the full body duration

### Cookie isolation (`cookie_isolation_contract_test.go`)

- Cookies set by the server on one transformation invocation are never carried over to subsequent invocations on the same shared pooled session (`ENABLE_CONN_POOL=true`, single worker subprocess)
- Connection pooling still reuses a single TCP socket across all invocations despite cookie stripping
- Per-request options (`headers`, `auth`, `params`, `cookies`, `hooks`) attached to a bare `requests.get()` call never persist as session defaults on the shared pooled session, matching old-arch (vanilla `requests`) behaviour
- The response-level `Set-Cookie` is parsed by `requests` (proof the leak channel exists) but never forwarded to the next call

### Bare `requests` positional params (`bare_requests_backwards_compatibility_test.go`)

- `requests.get(url, {"q": "hello"})` (second positional = params) produces identical results on old arch, new arch with pool disabled, and new arch with pool enabled
- `requests.post(url, {"q": "hello"})` (second positional = data) produces identical results across all three architectures
- `requests.put(url, {"q": "hello"})` and `requests.patch(url, {"q": "hello"})` produce identical results across all three architectures
- `requests.post(url, data, json)` with all three arguments passed positionally completes without `TypeError` on the pooled path and matches old-arch output

### `requests` module wrapper (`requests_api_contract_test.go`)

- `from requests.api import get` (bound at import time) produces identical results to old-arch vanilla `requests`
- `requests.api.get(url)` (attribute chain resolved at call time) produces identical results to old-arch vanilla `requests`
- `requests.request("GET", url)` (verb-parameterized entry point) produces identical results to old-arch vanilla `requests`
- All three alternative import paths are tested with both `ENABLE_CONN_POOL=false` and `ENABLE_CONN_POOL=true`
- With `ENABLE_CONN_POOL=true`, `from requests.api import get` and `requests.request("GET", url)` reuse the pooled TCP connection across sequential calls (proving they flow through the pooling wrapper)

### Geolocation timeout (`geolocation_backwards_compatibility_test.go`)

- Geolocation timeout fires a retryable HTTP 503 (`GeolocationServerError` inherits `BaseException`, bypassing user `except Exception`) rather than a per-event 400

### Other changes

- Simplified Docker container lifecycle in existing backwards-compatibility and geolocation tests (container cleanup now handled internally by helpers)


## Linear Ticket

< Fixes [PIPE-2902](https://linear.app/rudderstack/issue/PIPE-2902/http-clients-pooling-contract-tests) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
