### PR TITLE
chore: benchmarks different methods to suppress users for gzip dest

### DIFF
--- a/regulation-worker/internal/delete/batch/filehandler/gzip.go
+++ b/regulation-worker/internal/delete/batch/filehandler/gzip.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -13,7 +12,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/jsonparser"
 
 	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
 )
@@ -148,6 +147,7 @@ func (h *GZIPLocalFileHandler) RemoveIdentityRE(_ context.Context, attributes []
 		}
 		if !drop {
 			out.Write(line)
+			out.WriteByte('\n')
 		}
 	}
 
@@ -196,20 +196,8 @@ func (h *GZIPLocalFileHandler) RemoveIdentityPureGo(_ context.Context, attribute
 	for scanner.Scan() {
 		line := scanner.Bytes()
 
-		drop := false
-		var obj map[string]json.RawMessage
-		if err := jsonrs.Unmarshal(line, &obj); err == nil {
-			if raw, ok := obj[fieldName]; ok {
-				var id string
-				if err := jsonrs.Unmarshal(raw, &id); err == nil {
-					if _, found := suppress[id]; found {
-						drop = true
-					}
-				}
-			}
-		}
-
-		if drop {
+		id := jsonparser.GetStringOrEmpty(line, fieldName)
+		if _, found := suppress[id]; found {
 			continue
 		}
 		out.Write(line)

--- a/regulation-worker/internal/delete/batch/filehandler/gzip.go
+++ b/regulation-worker/internal/delete/batch/filehandler/gzip.go
@@ -1,15 +1,19 @@
 package filehandler
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"regexp"
 	"strings"
+
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 
 	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
 )
@@ -106,4 +110,114 @@ func (h *GZIPLocalFileHandler) getDeletePattern(attribute model.User) (string, e
 	default:
 		return "", fmt.Errorf("casing value: %v supplied not in list of supported cases", h.casing)
 	}
+}
+
+func (h *GZIPLocalFileHandler) RemoveIdentityRE(_ context.Context, attributes []model.User) error {
+	key, err := h.idFieldName()
+	if err != nil {
+		return err
+	}
+	re, err := regexp.Compile(fmt.Sprintf(`"%s": *"([^"]*)"`, key))
+	if err != nil {
+		return fmt.Errorf("compiling id extractor regex: %w", err)
+	}
+
+	suppress := make(map[string]struct{}, len(attributes))
+	for _, a := range attributes {
+		suppress[a.ID] = struct{}{}
+	}
+
+	var out bytes.Buffer
+	scanner := bufio.NewScanner(bytes.NewReader(h.records))
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		drop := false
+		rest := line
+		for {
+			loc := re.FindSubmatchIndex(rest)
+			if loc == nil {
+				break
+			}
+			if _, found := suppress[string(rest[loc[2]:loc[3]])]; found {
+				drop = true
+				break
+			}
+			rest = rest[loc[1]:]
+		}
+		if !drop {
+			out.Write(line)
+		}
+	}
+
+	h.records = out.Bytes()
+	return nil
+}
+
+func (h *GZIPLocalFileHandler) idFieldName() (string, error) {
+	switch h.casing {
+	case SnakeCase:
+		return "user_id", nil
+	case CamelCase:
+		return "userId", nil
+	case UpperCase:
+		return "USER_ID", nil
+	default:
+		return "", fmt.Errorf("casing value: %v supplied not in list of supported cases", h.casing)
+	}
+}
+
+// RemoveIdentityPureGo is the proposed shell-injection-free replacement for
+// GZIPLocalFileHandler.RemoveIdentity. It decodes each NDJSON line and drops
+// records whose configured id field matches any entry in attributes.
+func (h *GZIPLocalFileHandler) RemoveIdentityPureGo(_ context.Context, attributes []model.User) error {
+	var fieldName string
+	switch h.casing {
+	case SnakeCase:
+		fieldName = "user_id"
+	case CamelCase:
+		fieldName = "userId"
+	case UpperCase:
+		fieldName = "USER_ID"
+	default:
+		return fmt.Errorf("casing value: %v supplied not in list of supported cases", h.casing)
+	}
+
+	suppress := make(map[string]struct{}, len(attributes))
+	for _, a := range attributes {
+		suppress[a.ID] = struct{}{}
+	}
+
+	var out bytes.Buffer
+	scanner := bufio.NewScanner(bytes.NewReader(h.records))
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+
+		drop := false
+		var obj map[string]json.RawMessage
+		if err := jsonrs.Unmarshal(line, &obj); err == nil {
+			if raw, ok := obj[fieldName]; ok {
+				var id string
+				if err := jsonrs.Unmarshal(raw, &id); err == nil {
+					if _, found := suppress[id]; found {
+						drop = true
+					}
+				}
+			}
+		}
+
+		if drop {
+			continue
+		}
+		out.Write(line)
+		out.WriteByte('\n')
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	h.records = out.Bytes()
+	return nil
 }

--- a/regulation-worker/internal/delete/batch/filehandler/gzip.go
+++ b/regulation-worker/internal/delete/batch/filehandler/gzip.go
@@ -1,7 +1,6 @@
 package filehandler
 
 import (
-	"bufio"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -126,12 +125,19 @@ func (h *GZIPLocalFileHandler) RemoveIdentityRE(_ context.Context, attributes []
 		suppress[a.ID] = struct{}{}
 	}
 
-	var out bytes.Buffer
-	scanner := bufio.NewScanner(bytes.NewReader(h.records))
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	w := 0
+	data := h.records
+	for len(data) > 0 {
+		n := bytes.IndexByte(data, '\n')
+		var line []byte
+		if n < 0 {
+			line = data
+			data = nil
+		} else {
+			line = data[:n+1]
+			data = data[n+1:]
+		}
 
-	for scanner.Scan() {
-		line := scanner.Bytes()
 		drop := false
 		rest := line
 		for {
@@ -146,12 +152,11 @@ func (h *GZIPLocalFileHandler) RemoveIdentityRE(_ context.Context, attributes []
 			rest = rest[loc[1]:]
 		}
 		if !drop {
-			out.Write(line)
-			out.WriteByte('\n')
+			copy(h.records[w:], line)
+			w += len(line)
 		}
 	}
-
-	h.records = out.Bytes()
+	h.records = h.records[:w]
 	return nil
 }
 
@@ -172,16 +177,9 @@ func (h *GZIPLocalFileHandler) idFieldName() (string, error) {
 // GZIPLocalFileHandler.RemoveIdentity. It decodes each NDJSON line and drops
 // records whose configured id field matches any entry in attributes.
 func (h *GZIPLocalFileHandler) RemoveIdentityPureGo(_ context.Context, attributes []model.User) error {
-	var fieldName string
-	switch h.casing {
-	case SnakeCase:
-		fieldName = "user_id"
-	case CamelCase:
-		fieldName = "userId"
-	case UpperCase:
-		fieldName = "USER_ID"
-	default:
-		return fmt.Errorf("casing value: %v supplied not in list of supported cases", h.casing)
+	fieldName, err := h.idFieldName()
+	if err != nil {
+		return err
 	}
 
 	suppress := make(map[string]struct{}, len(attributes))
@@ -189,23 +187,26 @@ func (h *GZIPLocalFileHandler) RemoveIdentityPureGo(_ context.Context, attribute
 		suppress[a.ID] = struct{}{}
 	}
 
-	var out bytes.Buffer
-	scanner := bufio.NewScanner(bytes.NewReader(h.records))
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-
-	for scanner.Scan() {
-		line := scanner.Bytes()
+	w := 0
+	data := h.records
+	for len(data) > 0 {
+		n := bytes.IndexByte(data, '\n')
+		var line []byte
+		if n < 0 {
+			line = data
+			data = nil
+		} else {
+			line = data[:n+1]
+			data = data[n+1:]
+		}
 
 		id := jsonparser.GetStringOrEmpty(line, fieldName)
 		if _, found := suppress[id]; found {
 			continue
 		}
-		out.Write(line)
-		out.WriteByte('\n')
+		copy(h.records[w:], line)
+		w += len(line)
 	}
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-	h.records = out.Bytes()
+	h.records = h.records[:w]
 	return nil
 }

--- a/regulation-worker/internal/delete/batch/filehandler/gzip_bench_test.go
+++ b/regulation-worker/internal/delete/batch/filehandler/gzip_bench_test.go
@@ -1,0 +1,148 @@
+package filehandler
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
+)
+
+func buildBenchRecords(numRecords, suppressEvery int, suppressedIDs []string) ([]byte, []model.User) {
+	var buf bytes.Buffer
+	for i := 0; i < numRecords; i++ {
+		var id string
+		if suppressEvery > 0 && i%suppressEvery == 0 {
+			id = suppressedIDs[i%len(suppressedIDs)]
+		} else {
+			id = fmt.Sprintf("keep-user-%d", i)
+		}
+		fmt.Fprintf(&buf,
+			`{"user_id": %q, "event": "track", "properties": {"page": "home", "idx": %d}, "context": {"app": {"name": "rudder-bench"}}}`+"\n",
+			id, i)
+	}
+	users := make([]model.User, len(suppressedIDs))
+	for i, id := range suppressedIDs {
+		users[i] = model.User{ID: id}
+	}
+	return buf.Bytes(), users
+}
+
+var benchScenarios = []struct {
+	name          string
+	numRecords    int
+	numSuppressed int
+	suppressEvery int
+}{
+	{"records=1000/users=1/hit=10%", 1000, 1, 10},
+	{"records=1000/users=10/hit=10%", 1000, 10, 10},
+	{"records=10000/users=1/hit=10%", 10000, 1, 10},
+	{"records=10000/users=10/hit=10%", 10000, 10, 10},
+	{"records=10000/users=100/hit=10%", 10000, 100, 10},
+	{"records=100000/users=10/hit=10%", 100000, 10, 10},
+}
+
+func makeSuppressedIDs(n int) []string {
+	ids := make([]string, n)
+	for i := 0; i < n; i++ {
+		ids[i] = fmt.Sprintf("suppress-user-%d", i)
+	}
+	return ids
+}
+
+// BenchmarkRemoveIdentity
+// BenchmarkRemoveIdentity/records=1000/users=1/hit=10%
+// BenchmarkRemoveIdentity/records=1000/users=1/hit=10%-12         	     201	   6043276 ns/op	  22.67 MB/s	  413003 B/op	     103 allocs/op
+// BenchmarkRemoveIdentity/records=1000/users=10/hit=10%
+// BenchmarkRemoveIdentity/records=1000/users=10/hit=10%-12        	      68	  17094042 ns/op	   8.01 MB/s	  414696 B/op	     122 allocs/op
+// BenchmarkRemoveIdentity/records=10000/users=1/hit=10%
+// BenchmarkRemoveIdentity/records=10000/users=1/hit=10%-12        	      58	  19767681 ns/op	  70.26 MB/s	 5599990 B/op	     110 allocs/op
+// BenchmarkRemoveIdentity/records=10000/users=10/hit=10%
+// BenchmarkRemoveIdentity/records=10000/users=10/hit=10%-12       	       8	 126603115 ns/op	  10.97 MB/s	 5601873 B/op	     130 allocs/op
+// BenchmarkRemoveIdentity/records=10000/users=100/hit=10%
+// BenchmarkRemoveIdentity/records=10000/users=100/hit=10%-12      	       1	1259558500 ns/op	   1.10 MB/s	 5624544 B/op	     313 allocs/op
+// BenchmarkRemoveIdentity/records=100000/users=10/hit=10%
+// BenchmarkRemoveIdentity/records=100000/users=10/hit=10%-12      	       1	1223033209 ns/op	  11.51 MB/s	47651936 B/op	     136 allocs/op
+func BenchmarkRemoveIdentity(b *testing.B) {
+	ctx := context.Background()
+	for _, sc := range benchScenarios {
+		ids := makeSuppressedIDs(sc.numSuppressed)
+		records, users := buildBenchRecords(sc.numRecords, sc.suppressEvery, ids)
+		b.Run(sc.name, func(b *testing.B) {
+			b.SetBytes(int64(len(records)))
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				h := NewGZIPLocalFileHandler(SnakeCase)
+				h.records = append(h.records[:0], records...)
+				if err := h.RemoveIdentity(ctx, users); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkRemoveIdentityRE
+// BenchmarkRemoveIdentityRE/records=1000/users=1/hit=10%
+// BenchmarkRemoveIdentityRE/records=1000/users=1/hit=10%-12         	    2610	    451851 ns/op	 303.18 MB/s	  570800 B/op	    1050 allocs/op
+// BenchmarkRemoveIdentityRE/records=1000/users=10/hit=10%
+// BenchmarkRemoveIdentityRE/records=1000/users=10/hit=10%-12        	    2666	    473797 ns/op	 289.13 MB/s	  571068 B/op	    1053 allocs/op
+// BenchmarkRemoveIdentityRE/records=10000/users=1/hit=10%
+// BenchmarkRemoveIdentityRE/records=10000/users=1/hit=10%-12        	     265	   4403228 ns/op	 315.43 MB/s	 4415194 B/op	   10058 allocs/op
+// BenchmarkRemoveIdentityRE/records=10000/users=10/hit=10%
+// BenchmarkRemoveIdentityRE/records=10000/users=10/hit=10%-12       	     271	   4394131 ns/op	 316.08 MB/s	 4416410 B/op	   10061 allocs/op
+// BenchmarkRemoveIdentityRE/records=10000/users=100/hit=10%
+// BenchmarkRemoveIdentityRE/records=10000/users=100/hit=10%-12      	     267	   4425025 ns/op	 314.08 MB/s	 4419899 B/op	   10061 allocs/op
+// BenchmarkRemoveIdentityRE/records=100000/users=10/hit=10%
+// BenchmarkRemoveIdentityRE/records=100000/users=10/hit=10%-12      	      24	  44131311 ns/op	 319.02 MB/s	59318300 B/op	  100068 allocs/op
+func BenchmarkRemoveIdentityRE(b *testing.B) {
+	ctx := context.Background()
+	for _, sc := range benchScenarios {
+		ids := makeSuppressedIDs(sc.numSuppressed)
+		records, users := buildBenchRecords(sc.numRecords, sc.suppressEvery, ids)
+		b.Run(sc.name, func(b *testing.B) {
+			b.SetBytes(int64(len(records)))
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				h := NewGZIPLocalFileHandler(SnakeCase)
+				h.records = append(h.records[:0], records...)
+				if err := h.RemoveIdentityRE(ctx, users); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkRemoveIdentityPureGo
+// BenchmarkRemoveIdentityPureGo/records=1000/users=1/hit=10%
+// BenchmarkRemoveIdentityPureGo/records=1000/users=1/hit=10%-12         	    1124	   1020458 ns/op	 134.24 MB/s	 1425519 B/op	   20814 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=1000/users=10/hit=10%
+// BenchmarkRemoveIdentityPureGo/records=1000/users=10/hit=10%-12        	    1132	   1016534 ns/op	 134.76 MB/s	 1425967 B/op	   20817 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=10000/users=1/hit=10%
+// BenchmarkRemoveIdentityPureGo/records=10000/users=1/hit=10%-12        	     122	   9767601 ns/op	 142.19 MB/s	13022326 B/op	  208017 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=10000/users=10/hit=10%
+// BenchmarkRemoveIdentityPureGo/records=10000/users=10/hit=10%-12       	     123	   9610322 ns/op	 144.52 MB/s	13022736 B/op	  208020 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=10000/users=100/hit=10%
+// BenchmarkRemoveIdentityPureGo/records=10000/users=100/hit=10%-12      	     122	   9740143 ns/op	 142.69 MB/s	13025771 B/op	  208020 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=100000/users=10/hit=10%
+// BenchmarkRemoveIdentityPureGo/records=100000/users=10/hit=10%-12      	      12	  89935003 ns/op	 156.55 MB/s	144233781 B/op	 1918024 allocs/op
+func BenchmarkRemoveIdentityPureGo(b *testing.B) {
+	ctx := context.Background()
+	for _, sc := range benchScenarios {
+		ids := makeSuppressedIDs(sc.numSuppressed)
+		records, users := buildBenchRecords(sc.numRecords, sc.suppressEvery, ids)
+		b.Run(sc.name, func(b *testing.B) {
+			b.SetBytes(int64(len(records)))
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				h := NewGZIPLocalFileHandler(SnakeCase)
+				h.records = append(h.records[:0], records...)
+				if err := h.RemoveIdentityPureGo(ctx, users); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/regulation-worker/internal/delete/batch/filehandler/gzip_bench_test.go
+++ b/regulation-worker/internal/delete/batch/filehandler/gzip_bench_test.go
@@ -4,10 +4,55 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
 )
+
+// measurePeakHeap runs fn once and samples runtime.MemStats.HeapAlloc in a
+// tight loop to approximate the peak live heap held during the call. Sampling
+// adds some overhead so this is run outside the timed benchmark loop.
+func measurePeakHeap(fn func()) uint64 {
+	runtime.GC()
+
+	var baseline runtime.MemStats
+	runtime.ReadMemStats(&baseline)
+
+	var peak uint64
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var ms runtime.MemStats
+		t := time.NewTicker(50 * time.Microsecond)
+		defer t.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				runtime.ReadMemStats(&ms)
+				if ms.HeapAlloc > atomic.LoadUint64(&peak) {
+					atomic.StoreUint64(&peak, ms.HeapAlloc)
+				}
+			}
+		}
+	}()
+
+	fn()
+
+	close(stop)
+	<-done
+
+	p := atomic.LoadUint64(&peak)
+	if p < baseline.HeapAlloc {
+		return 0
+	}
+	return p - baseline.HeapAlloc
+}
 
 func buildBenchRecords(numRecords, suppressEvery int, suppressedIDs []string) ([]byte, []model.User) {
 	var buf bytes.Buffer
@@ -53,17 +98,17 @@ func makeSuppressedIDs(n int) []string {
 
 // BenchmarkRemoveIdentity
 // BenchmarkRemoveIdentity/records=1000/users=1/hit=10%
-// BenchmarkRemoveIdentity/records=1000/users=1/hit=10%-12         	     201	   6043276 ns/op	  22.67 MB/s	  413003 B/op	     103 allocs/op
+// BenchmarkRemoveIdentity/records=1000/users=1/hit=10%-12         	     202	   5865799 ns/op	  23.35 MB/s	         0.3963 peak-heap-MB	  415204 B/op	     104 allocs/op
 // BenchmarkRemoveIdentity/records=1000/users=10/hit=10%
-// BenchmarkRemoveIdentity/records=1000/users=10/hit=10%-12        	      68	  17094042 ns/op	   8.01 MB/s	  414696 B/op	     122 allocs/op
+// BenchmarkRemoveIdentity/records=1000/users=10/hit=10%-12        	      68	  17426360 ns/op	   7.86 MB/s	         0.3979 peak-heap-MB	  420861 B/op	     125 allocs/op
 // BenchmarkRemoveIdentity/records=10000/users=1/hit=10%
-// BenchmarkRemoveIdentity/records=10000/users=1/hit=10%-12        	      58	  19767681 ns/op	  70.26 MB/s	 5599990 B/op	     110 allocs/op
+// BenchmarkRemoveIdentity/records=10000/users=1/hit=10%-12        	      57	  19752813 ns/op	  70.31 MB/s	         4.832 peak-heap-MB	 5698321 B/op	     113 allocs/op
 // BenchmarkRemoveIdentity/records=10000/users=10/hit=10%
-// BenchmarkRemoveIdentity/records=10000/users=10/hit=10%-12       	       8	 126603115 ns/op	  10.97 MB/s	 5601873 B/op	     130 allocs/op
+// BenchmarkRemoveIdentity/records=10000/users=10/hit=10%-12       	       7	 145416923 ns/op	   9.55 MB/s	         4.833 peak-heap-MB	 6402260 B/op	     150 allocs/op
 // BenchmarkRemoveIdentity/records=10000/users=100/hit=10%
-// BenchmarkRemoveIdentity/records=10000/users=100/hit=10%-12      	       1	1259558500 ns/op	   1.10 MB/s	 5624544 B/op	     313 allocs/op
+// BenchmarkRemoveIdentity/records=10000/users=100/hit=10%-12      	       1	2605464500 ns/op	   0.53 MB/s	         4.840 peak-heap-MB	11245448 B/op	     631 allocs/op
 // BenchmarkRemoveIdentity/records=100000/users=10/hit=10%
-// BenchmarkRemoveIdentity/records=100000/users=10/hit=10%-12      	       1	1223033209 ns/op	  11.51 MB/s	47651936 B/op	     136 allocs/op
+// BenchmarkRemoveIdentity/records=100000/users=10/hit=10%-12      	       1	2517548667 ns/op	   5.59 MB/s	        43.43 peak-heap-MB	95304536 B/op
 func BenchmarkRemoveIdentity(b *testing.B) {
 	ctx := context.Background()
 	for _, sc := range benchScenarios {
@@ -72,6 +117,16 @@ func BenchmarkRemoveIdentity(b *testing.B) {
 		b.Run(sc.name, func(b *testing.B) {
 			b.SetBytes(int64(len(records)))
 			b.ReportAllocs()
+
+			peak := measurePeakHeap(func() {
+				h := NewGZIPLocalFileHandler(SnakeCase)
+				h.records = append(h.records[:0], records...)
+				if err := h.RemoveIdentity(ctx, users); err != nil {
+					b.Fatal(err)
+				}
+			})
+			b.ReportMetric(float64(peak)/(1024*1024), "peak-heap-MB")
+
 			for i := 0; i < b.N; i++ {
 				h := NewGZIPLocalFileHandler(SnakeCase)
 				h.records = append(h.records[:0], records...)
@@ -85,17 +140,17 @@ func BenchmarkRemoveIdentity(b *testing.B) {
 
 // BenchmarkRemoveIdentityRE
 // BenchmarkRemoveIdentityRE/records=1000/users=1/hit=10%
-// BenchmarkRemoveIdentityRE/records=1000/users=1/hit=10%-12         	    2610	    451851 ns/op	 303.18 MB/s	  570800 B/op	    1050 allocs/op
+// BenchmarkRemoveIdentityRE/records=1000/users=1/hit=10%-12         	    2467	    453139 ns/op	 302.32 MB/s	         0.6155 peak-heap-MB	  570112 B/op	    1050 allocs/op
 // BenchmarkRemoveIdentityRE/records=1000/users=10/hit=10%
-// BenchmarkRemoveIdentityRE/records=1000/users=10/hit=10%-12        	    2666	    473797 ns/op	 289.13 MB/s	  571068 B/op	    1053 allocs/op
+// BenchmarkRemoveIdentityRE/records=1000/users=10/hit=10%-12        	    2689	    436403 ns/op	 313.91 MB/s	         0.6156 peak-heap-MB	  570273 B/op	    1053 allocs/op
 // BenchmarkRemoveIdentityRE/records=10000/users=1/hit=10%
-// BenchmarkRemoveIdentityRE/records=10000/users=1/hit=10%-12        	     265	   4403228 ns/op	 315.43 MB/s	 4415194 B/op	   10058 allocs/op
+// BenchmarkRemoveIdentityRE/records=10000/users=1/hit=10%-12        	     259	   4330492 ns/op	 320.72 MB/s	         4.132 peak-heap-MB	 4433996 B/op	   10097 allocs/op
 // BenchmarkRemoveIdentityRE/records=10000/users=10/hit=10%
-// BenchmarkRemoveIdentityRE/records=10000/users=10/hit=10%-12       	     271	   4394131 ns/op	 316.08 MB/s	 4416410 B/op	   10061 allocs/op
+// BenchmarkRemoveIdentityRE/records=10000/users=10/hit=10%-12       	     267	   4343849 ns/op	 319.74 MB/s	         4.170 peak-heap-MB	 4433766 B/op	   10099 allocs/op
 // BenchmarkRemoveIdentityRE/records=10000/users=100/hit=10%
-// BenchmarkRemoveIdentityRE/records=10000/users=100/hit=10%-12      	     267	   4425025 ns/op	 314.08 MB/s	 4419899 B/op	   10061 allocs/op
+// BenchmarkRemoveIdentityRE/records=10000/users=100/hit=10%-12      	     262	   4417182 ns/op	 314.63 MB/s	         4.172 peak-heap-MB	 4436619 B/op	   10100 allocs/op
 // BenchmarkRemoveIdentityRE/records=100000/users=10/hit=10%
-// BenchmarkRemoveIdentityRE/records=100000/users=10/hit=10%-12      	      24	  44131311 ns/op	 319.02 MB/s	59318300 B/op	  100068 allocs/op
+// BenchmarkRemoveIdentityRE/records=100000/users=10/hit=10%-12      	      24	  47840227 ns/op	 294.29 MB/s	        53.56 peak-heap-MB	61798302 B/op	  104239 allocs/op
 func BenchmarkRemoveIdentityRE(b *testing.B) {
 	ctx := context.Background()
 	for _, sc := range benchScenarios {
@@ -104,6 +159,16 @@ func BenchmarkRemoveIdentityRE(b *testing.B) {
 		b.Run(sc.name, func(b *testing.B) {
 			b.SetBytes(int64(len(records)))
 			b.ReportAllocs()
+
+			peak := measurePeakHeap(func() {
+				h := NewGZIPLocalFileHandler(SnakeCase)
+				h.records = append(h.records[:0], records...)
+				if err := h.RemoveIdentityRE(ctx, users); err != nil {
+					b.Fatal(err)
+				}
+			})
+			b.ReportMetric(float64(peak)/(1024*1024), "peak-heap-MB")
+
 			for i := 0; i < b.N; i++ {
 				h := NewGZIPLocalFileHandler(SnakeCase)
 				h.records = append(h.records[:0], records...)
@@ -117,17 +182,17 @@ func BenchmarkRemoveIdentityRE(b *testing.B) {
 
 // BenchmarkRemoveIdentityPureGo
 // BenchmarkRemoveIdentityPureGo/records=1000/users=1/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=1000/users=1/hit=10%-12         	    7198	    151627 ns/op	 903.47 MB/s	  563106 B/op	    2014 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=1000/users=1/hit=10%-12         	    6938	    146518 ns/op	 934.98 MB/s	         0.5340 peak-heap-MB	  563187 B/op	    2014 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=1000/users=10/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=1000/users=10/hit=10%-12        	    7791	    140989 ns/op	 971.64 MB/s	  563561 B/op	    2017 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=1000/users=10/hit=10%-12        	    7092	    141906 ns/op	 965.36 MB/s	         0.5379 peak-heap-MB	  563640 B/op	    2017 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=10000/users=1/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=10000/users=1/hit=10%-12        	     981	   1211181 ns/op	1146.72 MB/s	 4398249 B/op	   20017 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=10000/users=1/hit=10%-12        	    1000	   1162690 ns/op	1194.55 MB/s	         4.079 peak-heap-MB	 4402641 B/op	   20037 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=10000/users=10/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=10000/users=10/hit=10%-12       	     987	   1169327 ns/op	1187.77 MB/s	 4398699 B/op	   20020 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=10000/users=10/hit=10%-12       	    1008	   1151765 ns/op	1205.88 MB/s	         3.425 peak-heap-MB	 4403062 B/op	   20039 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=10000/users=100/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=10000/users=100/hit=10%-12      	     960	   1255105 ns/op	1107.31 MB/s	 4401739 B/op	   20020 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=10000/users=100/hit=10%-12      	     939	   1254340 ns/op	1107.99 MB/s	         4.059 peak-heap-MB	 4406426 B/op	   20041 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=100000/users=10/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=100000/users=10/hit=10%-12      	     106	  11176147 ns/op	1259.73 MB/s	59289715 B/op	  200024 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=100000/users=10/hit=10%-12      	      93	  11219436 ns/op	1254.87 MB/s	        53.41 peak-heap-MB	59927303 B/op	  202175 allocs/op
 func BenchmarkRemoveIdentityPureGo(b *testing.B) {
 	ctx := context.Background()
 	for _, sc := range benchScenarios {
@@ -136,6 +201,16 @@ func BenchmarkRemoveIdentityPureGo(b *testing.B) {
 		b.Run(sc.name, func(b *testing.B) {
 			b.SetBytes(int64(len(records)))
 			b.ReportAllocs()
+
+			peak := measurePeakHeap(func() {
+				h := NewGZIPLocalFileHandler(SnakeCase)
+				h.records = append(h.records[:0], records...)
+				if err := h.RemoveIdentityPureGo(ctx, users); err != nil {
+					b.Fatal(err)
+				}
+			})
+			b.ReportMetric(float64(peak)/(1024*1024), "peak-heap-MB")
+
 			for i := 0; i < b.N; i++ {
 				h := NewGZIPLocalFileHandler(SnakeCase)
 				h.records = append(h.records[:0], records...)

--- a/regulation-worker/internal/delete/batch/filehandler/gzip_bench_test.go
+++ b/regulation-worker/internal/delete/batch/filehandler/gzip_bench_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -88,6 +89,30 @@ var benchScenarios = []struct {
 	{"records=100000/users=10/hit=10%", 100000, 10, 10},
 }
 
+// buildLargePayloadRecords generates NDJSON lines of ~1 KB each by padding
+// properties with extra data, simulating realistic large event payloads.
+func buildLargePayloadRecords(numRecords, suppressEvery int, suppressedIDs []string) ([]byte, []model.User) {
+	padding := strings.Repeat("x", 800)
+	var buf bytes.Buffer
+	buf.Grow(numRecords * 1024)
+	for i := 0; i < numRecords; i++ {
+		var id string
+		if suppressEvery > 0 && i%suppressEvery == 0 {
+			id = suppressedIDs[i%len(suppressedIDs)]
+		} else {
+			id = fmt.Sprintf("keep-user-%d", i)
+		}
+		fmt.Fprintf(&buf,
+			`{"user_id": %q, "event": "track", "properties": {"page": "home", "idx": %d, "padding": "%s"}, "context": {"app": {"name": "rudder-bench"}}}`+"\n",
+			id, i, padding)
+	}
+	users := make([]model.User, len(suppressedIDs))
+	for i, id := range suppressedIDs {
+		users[i] = model.User{ID: id}
+	}
+	return buf.Bytes(), users
+}
+
 func makeSuppressedIDs(n int) []string {
 	ids := make([]string, n)
 	for i := 0; i < n; i++ {
@@ -140,17 +165,17 @@ func BenchmarkRemoveIdentity(b *testing.B) {
 
 // BenchmarkRemoveIdentityRE
 // BenchmarkRemoveIdentityRE/records=1000/users=1/hit=10%
-// BenchmarkRemoveIdentityRE/records=1000/users=1/hit=10%-12         	    2467	    453139 ns/op	 302.32 MB/s	         0.6155 peak-heap-MB	  570112 B/op	    1050 allocs/op
+// BenchmarkRemoveIdentityRE/records=1000/users=1/hit=10%-12         	    2970	    394019 ns/op	 347.68 MB/s	         0.2423 peak-heap-MB	  176908 B/op	    1036 allocs/op
 // BenchmarkRemoveIdentityRE/records=1000/users=10/hit=10%
-// BenchmarkRemoveIdentityRE/records=1000/users=10/hit=10%-12        	    2689	    436403 ns/op	 313.91 MB/s	         0.6156 peak-heap-MB	  570273 B/op	    1053 allocs/op
+// BenchmarkRemoveIdentityRE/records=1000/users=10/hit=10%-12        	    2955	    393509 ns/op	 348.13 MB/s	         0.2438 peak-heap-MB	  177243 B/op	    1039 allocs/op
 // BenchmarkRemoveIdentityRE/records=10000/users=1/hit=10%
-// BenchmarkRemoveIdentityRE/records=10000/users=1/hit=10%-12        	     259	   4330492 ns/op	 320.72 MB/s	         4.132 peak-heap-MB	 4433996 B/op	   10097 allocs/op
+// BenchmarkRemoveIdentityRE/records=10000/users=1/hit=10%-12        	     292	   3992584 ns/op	 347.87 MB/s	         1.749 peak-heap-MB	 1733646 B/op	   10074 allocs/op
 // BenchmarkRemoveIdentityRE/records=10000/users=10/hit=10%
-// BenchmarkRemoveIdentityRE/records=10000/users=10/hit=10%-12       	     267	   4343849 ns/op	 319.74 MB/s	         4.170 peak-heap-MB	 4433766 B/op	   10099 allocs/op
+// BenchmarkRemoveIdentityRE/records=10000/users=10/hit=10%-12       	     290	   4008821 ns/op	 346.46 MB/s	         1.747 peak-heap-MB	 1734717 B/op	   10077 allocs/op
 // BenchmarkRemoveIdentityRE/records=10000/users=100/hit=10%
-// BenchmarkRemoveIdentityRE/records=10000/users=100/hit=10%-12      	     262	   4417182 ns/op	 314.63 MB/s	         4.172 peak-heap-MB	 4436619 B/op	   10100 allocs/op
+// BenchmarkRemoveIdentityRE/records=10000/users=100/hit=10%-12      	     284	   4113713 ns/op	 337.84 MB/s	         1.751 peak-heap-MB	 1738253 B/op	   10078 allocs/op
 // BenchmarkRemoveIdentityRE/records=100000/users=10/hit=10%
-// BenchmarkRemoveIdentityRE/records=100000/users=10/hit=10%-12      	      24	  47840227 ns/op	 294.29 MB/s	        53.56 peak-heap-MB	61798302 B/op	  104239 allocs/op
+// BenchmarkRemoveIdentityRE/records=100000/users=10/hit=10%-12      	      26	  44146639 ns/op	 318.91 MB/s	        16.60 peak-heap-MB	17965420 B/op	  103892 allocs/op
 func BenchmarkRemoveIdentityRE(b *testing.B) {
 	ctx := context.Background()
 	for _, sc := range benchScenarios {
@@ -182,23 +207,110 @@ func BenchmarkRemoveIdentityRE(b *testing.B) {
 
 // BenchmarkRemoveIdentityPureGo
 // BenchmarkRemoveIdentityPureGo/records=1000/users=1/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=1000/users=1/hit=10%-12         	    6938	    146518 ns/op	 934.98 MB/s	         0.5340 peak-heap-MB	  563187 B/op	    2014 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=1000/users=1/hit=10%-12         	   12310	     95045 ns/op	1441.33 MB/s	         0.1586 peak-heap-MB	  171278 B/op	    2001 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=1000/users=10/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=1000/users=10/hit=10%-12        	    7092	    141906 ns/op	 965.36 MB/s	         0.5379 peak-heap-MB	  563640 B/op	    2017 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=1000/users=10/hit=10%-12        	   12943	     92809 ns/op	1476.06 MB/s	         0.1605 peak-heap-MB	  171733 B/op	    2004 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=10000/users=1/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=10000/users=1/hit=10%-12        	    1000	   1162690 ns/op	1194.55 MB/s	         4.079 peak-heap-MB	 4402641 B/op	   20037 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=10000/users=1/hit=10%-12        	    1230	    923831 ns/op	1503.40 MB/s	         1.628 peak-heap-MB	 1714033 B/op	   20017 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=10000/users=10/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=10000/users=10/hit=10%-12       	    1008	   1151765 ns/op	1205.88 MB/s	         3.425 peak-heap-MB	 4403062 B/op	   20039 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=10000/users=10/hit=10%-12       	    1267	    903366 ns/op	1537.46 MB/s	         1.631 peak-heap-MB	 1714449 B/op	   20019 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=10000/users=100/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=10000/users=100/hit=10%-12      	     939	   1254340 ns/op	1107.99 MB/s	         4.059 peak-heap-MB	 4406426 B/op	   20041 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=10000/users=100/hit=10%-12      	    1192	    977520 ns/op	1421.75 MB/s	         1.635 peak-heap-MB	 1717583 B/op	   20020 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=100000/users=10/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=100000/users=10/hit=10%-12      	      93	  11219436 ns/op	1254.87 MB/s	        53.41 peak-heap-MB	59927303 B/op	  202175 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=100000/users=10/hit=10%-12      	     118	   9021817 ns/op	1560.54 MB/s	        16.48 peak-heap-MB	17428971 B/op	  201699 allocs/op
 func BenchmarkRemoveIdentityPureGo(b *testing.B) {
 	ctx := context.Background()
 	for _, sc := range benchScenarios {
 		ids := makeSuppressedIDs(sc.numSuppressed)
 		records, users := buildBenchRecords(sc.numRecords, sc.suppressEvery, ids)
 		b.Run(sc.name, func(b *testing.B) {
+			b.SetBytes(int64(len(records)))
+			b.ReportAllocs()
+
+			peak := measurePeakHeap(func() {
+				h := NewGZIPLocalFileHandler(SnakeCase)
+				h.records = append(h.records[:0], records...)
+				if err := h.RemoveIdentityPureGo(ctx, users); err != nil {
+					b.Fatal(err)
+				}
+			})
+			b.ReportMetric(float64(peak)/(1024*1024), "peak-heap-MB")
+
+			for i := 0; i < b.N; i++ {
+				h := NewGZIPLocalFileHandler(SnakeCase)
+				h.records = append(h.records[:0], records...)
+				if err := h.RemoveIdentityPureGo(ctx, users); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// Large-file benchmarks with ~1 KB payloads.
+// Sed is excluded — it would take hours at these sizes.
+// The 2 GB scenario requires ~6 GB of free RAM (input + output buffer + copy).
+// Run with: go test -run=^$ -bench=BenchmarkLargeFile -benchtime=1x -timeout=30m
+var largeFileScenarios = []struct {
+	name          string
+	numRecords    int
+	numSuppressed int
+	suppressEvery int
+}{
+	{"payload=1KB/file=100MB/users=10", 100_000, 10, 10},
+	{"payload=1KB/file=500MB/users=10", 500_000, 10, 10},
+	{"payload=1KB/file=2GB/users=10", 2_000_000, 10, 10},
+}
+
+// BenchmarkLargeFileRE
+// BenchmarkLargeFileRE/payload=1KB/file=100MB/users=10
+// BenchmarkLargeFileRE/payload=1KB/file=100MB/users=10-12         	      10	 108496904 ns/op	 880.94 MB/s	        93.91 peak-heap-MB	119556855 B/op	  158007 allocs/op
+// BenchmarkLargeFileRE/payload=1KB/file=500MB/users=10
+// BenchmarkLargeFileRE/payload=1KB/file=500MB/users=10-12         	       1	3001397083 ns/op	 159.51 MB/s	       472.0 peak-heap-MB	1532448960 B/op	 3399653 allocs/op
+// BenchmarkLargeFileRE/payload=1KB/file=2GB/users=10
+// BenchmarkLargeFileRE/payload=1KB/file=2GB/users=10-12           	       1	10531107333 ns/op	 182.08 MB/s	      1890 peak-heap-MB	6141554528 B/op	13599653 allocs/op
+func BenchmarkLargeFileRE(b *testing.B) {
+	ctx := context.Background()
+	for _, sc := range largeFileScenarios {
+		ids := makeSuppressedIDs(sc.numSuppressed)
+		b.Run(sc.name, func(b *testing.B) {
+			records, users := buildLargePayloadRecords(sc.numRecords, sc.suppressEvery, ids)
+			b.SetBytes(int64(len(records)))
+			b.ReportAllocs()
+
+			peak := measurePeakHeap(func() {
+				h := NewGZIPLocalFileHandler(SnakeCase)
+				h.records = append(h.records[:0], records...)
+				if err := h.RemoveIdentityRE(ctx, users); err != nil {
+					b.Fatal(err)
+				}
+			})
+			b.ReportMetric(float64(peak)/(1024*1024), "peak-heap-MB")
+
+			for i := 0; i < b.N; i++ {
+				h := NewGZIPLocalFileHandler(SnakeCase)
+				h.records = append(h.records[:0], records...)
+				if err := h.RemoveIdentityRE(ctx, users); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkLargeFilePureGo
+// BenchmarkLargeFilePureGo/payload=1KB/file=100MB/users=10
+// BenchmarkLargeFilePureGo/payload=1KB/file=100MB/users=10-12         	      78	  14604888 ns/op	6544.31 MB/s	        94.07 peak-heap-MB	101443087 B/op	  208716 allocs/op
+// BenchmarkLargeFilePureGo/payload=1KB/file=500MB/users=10
+// BenchmarkLargeFilePureGo/payload=1KB/file=500MB/users=10-12         	       1	1372806458 ns/op	 348.73 MB/s	       471.8 peak-heap-MB	1532283536 B/op	 4399542 allocs/op
+// BenchmarkLargeFilePureGo/payload=1KB/file=2GB/users=10
+// BenchmarkLargeFilePureGo/payload=1KB/file=2GB/users=10-12           	       1	8917455042 ns/op	 215.03 MB/s	      1897 peak-heap-MB	6155796264 B/op	17599557 allocs/op
+func BenchmarkLargeFilePureGo(b *testing.B) {
+	ctx := context.Background()
+	for _, sc := range largeFileScenarios {
+		ids := makeSuppressedIDs(sc.numSuppressed)
+		b.Run(sc.name, func(b *testing.B) {
+			records, users := buildLargePayloadRecords(sc.numRecords, sc.suppressEvery, ids)
 			b.SetBytes(int64(len(records)))
 			b.ReportAllocs()
 

--- a/regulation-worker/internal/delete/batch/filehandler/gzip_bench_test.go
+++ b/regulation-worker/internal/delete/batch/filehandler/gzip_bench_test.go
@@ -117,17 +117,17 @@ func BenchmarkRemoveIdentityRE(b *testing.B) {
 
 // BenchmarkRemoveIdentityPureGo
 // BenchmarkRemoveIdentityPureGo/records=1000/users=1/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=1000/users=1/hit=10%-12         	    1124	   1020458 ns/op	 134.24 MB/s	 1425519 B/op	   20814 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=1000/users=1/hit=10%-12         	    7198	    151627 ns/op	 903.47 MB/s	  563106 B/op	    2014 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=1000/users=10/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=1000/users=10/hit=10%-12        	    1132	   1016534 ns/op	 134.76 MB/s	 1425967 B/op	   20817 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=1000/users=10/hit=10%-12        	    7791	    140989 ns/op	 971.64 MB/s	  563561 B/op	    2017 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=10000/users=1/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=10000/users=1/hit=10%-12        	     122	   9767601 ns/op	 142.19 MB/s	13022326 B/op	  208017 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=10000/users=1/hit=10%-12        	     981	   1211181 ns/op	1146.72 MB/s	 4398249 B/op	   20017 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=10000/users=10/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=10000/users=10/hit=10%-12       	     123	   9610322 ns/op	 144.52 MB/s	13022736 B/op	  208020 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=10000/users=10/hit=10%-12       	     987	   1169327 ns/op	1187.77 MB/s	 4398699 B/op	   20020 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=10000/users=100/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=10000/users=100/hit=10%-12      	     122	   9740143 ns/op	 142.69 MB/s	13025771 B/op	  208020 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=10000/users=100/hit=10%-12      	     960	   1255105 ns/op	1107.31 MB/s	 4401739 B/op	   20020 allocs/op
 // BenchmarkRemoveIdentityPureGo/records=100000/users=10/hit=10%
-// BenchmarkRemoveIdentityPureGo/records=100000/users=10/hit=10%-12      	      12	  89935003 ns/op	 156.55 MB/s	144233781 B/op	 1918024 allocs/op
+// BenchmarkRemoveIdentityPureGo/records=100000/users=10/hit=10%-12      	     106	  11176147 ns/op	1259.73 MB/s	59289715 B/op	  200024 allocs/op
 func BenchmarkRemoveIdentityPureGo(b *testing.B) {
 	ctx := context.Background()
 	for _, sc := range benchScenarios {

--- a/regulation-worker/internal/delete/batch/filehandler/gzip_correctness_test.go
+++ b/regulation-worker/internal/delete/batch/filehandler/gzip_correctness_test.go
@@ -209,12 +209,12 @@ func TestRemoveIdentityPureGo_IgnoresNestedKeys(t *testing.T) {
 	require.Equal(t, string(input), string(got))
 }
 
-// TestRemoveIdentityPureGo_EmitsTrailingNewline documents that PureGo always
-// appends a newline per emitted record, even if the final input line lacked
-// one.
-func TestRemoveIdentityPureGo_EmitsTrailingNewline(t *testing.T) {
+// TestRemoveIdentityPureGo_PreservesInputFormat documents that in-place
+// compaction preserves the input faithfully — if the final line lacks a
+// trailing newline, the output does too.
+func TestRemoveIdentityPureGo_PreservesInputFormat(t *testing.T) {
 	input := []byte(`{"user_id": "a"}` + "\n" + `{"user_id": "b"}`)
 	got, err := runRemoveIdentityPureGo(t.Context(), SnakeCase, input, []model.User{{ID: "a"}})
 	require.NoError(t, err)
-	require.Equal(t, `{"user_id": "b"}`+"\n", string(got))
+	require.Equal(t, `{"user_id": "b"}`, string(got))
 }

--- a/regulation-worker/internal/delete/batch/filehandler/gzip_correctness_test.go
+++ b/regulation-worker/internal/delete/batch/filehandler/gzip_correctness_test.go
@@ -1,0 +1,220 @@
+package filehandler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
+)
+
+// removeFn adapts all three implementations to a common signature so we can
+// drive them from a single table-driven test.
+type removeFn func(ctx context.Context, casing Case, records []byte, users []model.User) ([]byte, error)
+
+func runRemoveIdentity(ctx context.Context, casing Case, records []byte, users []model.User) ([]byte, error) {
+	h := NewGZIPLocalFileHandler(casing)
+	h.records = append([]byte(nil), records...)
+	if err := h.RemoveIdentity(ctx, users); err != nil {
+		return nil, err
+	}
+	return h.records, nil
+}
+
+func runRemoveIdentityRE(ctx context.Context, casing Case, records []byte, users []model.User) ([]byte, error) {
+	h := NewGZIPLocalFileHandler(casing)
+	h.records = append([]byte(nil), records...)
+	if err := h.RemoveIdentityRE(ctx, users); err != nil {
+		return nil, err
+	}
+	return h.records, nil
+}
+
+func runRemoveIdentityPureGo(ctx context.Context, casing Case, records []byte, users []model.User) ([]byte, error) {
+	h := NewGZIPLocalFileHandler(casing)
+	h.records = append([]byte(nil), records...)
+	if err := h.RemoveIdentityPureGo(ctx, users); err != nil {
+		return nil, err
+	}
+	return h.records, nil
+}
+
+var allImpls = []struct {
+	name string
+	fn   removeFn
+}{
+	{"RemoveIdentity", runRemoveIdentity},
+	{"RemoveIdentityRE", runRemoveIdentityRE},
+	{"RemoveIdentityPureGo", runRemoveIdentityPureGo},
+}
+
+// TestRemoveIdentity_SharedCorrectness runs inputs that all three
+// implementations must agree on. Keep these cases "flat" — no nested
+// occurrences of the id key — since the regex/sed impls cannot distinguish
+// nested from top-level matches.
+func TestRemoveIdentity_SharedCorrectness(t *testing.T) {
+	cases := []struct {
+		name     string
+		casing   Case
+		users    []model.User
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty input",
+			casing:   SnakeCase,
+			users:    []model.User{{ID: "a"}},
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "no match keeps everything",
+			casing:   SnakeCase,
+			users:    []model.User{{ID: "missing"}},
+			input:    `{"user_id": "a"}` + "\n" + `{"user_id": "b"}` + "\n",
+			expected: `{"user_id": "a"}` + "\n" + `{"user_id": "b"}` + "\n",
+		},
+		{
+			name:     "single match drops the line (snake_case)",
+			casing:   SnakeCase,
+			users:    []model.User{{ID: "a"}},
+			input:    `{"user_id": "a"}` + "\n" + `{"user_id": "b"}` + "\n",
+			expected: `{"user_id": "b"}` + "\n",
+		},
+		{
+			name:     "single match drops the line (camelCase)",
+			casing:   CamelCase,
+			users:    []model.User{{ID: "a"}},
+			input:    `{"userId": "a"}` + "\n" + `{"userId": "b"}` + "\n",
+			expected: `{"userId": "b"}` + "\n",
+		},
+		{
+			name:     "single match drops the line (UPPER_CASE)",
+			casing:   UpperCase,
+			users:    []model.User{{ID: "a"}},
+			input:    `{"USER_ID": "a"}` + "\n" + `{"USER_ID": "b"}` + "\n",
+			expected: `{"USER_ID": "b"}` + "\n",
+		},
+		{
+			name:   "multiple suppressed ids",
+			casing: SnakeCase,
+			users: []model.User{
+				{ID: "a"},
+				{ID: "c"},
+			},
+			input:    `{"user_id": "a"}` + "\n" + `{"user_id": "b"}` + "\n" + `{"user_id": "c"}` + "\n",
+			expected: `{"user_id": "b"}` + "\n",
+		},
+		{
+			name:     "drops all lines",
+			casing:   SnakeCase,
+			users:    []model.User{{ID: "a"}, {ID: "b"}},
+			input:    `{"user_id": "a"}` + "\n" + `{"user_id": "b"}` + "\n",
+			expected: "",
+		},
+		{
+			name:     "partial id is not matched",
+			casing:   CamelCase,
+			users:    []model.User{{ID: "valid-user-id"}},
+			input:    `{"userId": "invalid-user-id"}` + "\n",
+			expected: `{"userId": "invalid-user-id"}` + "\n",
+		},
+		{
+			name:     "id with regex metacharacters matches exactly",
+			casing:   SnakeCase,
+			users:    []model.User{{ID: "my-.-user-id"}},
+			input:    `{"user_id": "my-.-user-id"}` + "\n" + `{"user_id": "my-X-user-id"}` + "\n",
+			expected: `{"user_id": "my-X-user-id"}` + "\n",
+		},
+		{
+			name:     "id with shell metacharacters matches exactly",
+			casing:   CamelCase,
+			users:    []model.User{{ID: "!@#$%^&*()***"}},
+			input:    `{"userId": "!@#$%^&*()***", "event": "track"}` + "\n" + `{"userId": "other"}` + "\n",
+			expected: `{"userId": "other"}` + "\n",
+		},
+		{
+			name:     "extra whitespace between key and value",
+			casing:   SnakeCase,
+			users:    []model.User{{ID: "a"}},
+			input:    `{"user_id":    "a"}` + "\n" + `{"user_id": "b"}` + "\n",
+			expected: `{"user_id": "b"}` + "\n",
+		},
+		{
+			name:     "record with additional fields is dropped when id matches",
+			casing:   SnakeCase,
+			users:    []model.User{{ID: "a"}},
+			input:    `{"user_id": "a", "event": "track", "properties": {"page": "home"}}` + "\n",
+			expected: "",
+		},
+	}
+
+	ctx := context.Background()
+	for _, tc := range cases {
+		for _, impl := range allImpls {
+			t.Run(impl.name+"/"+tc.name, func(t *testing.T) {
+				got, err := impl.fn(ctx, tc.casing, []byte(tc.input), tc.users)
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, string(got))
+			})
+		}
+	}
+}
+
+// TestRemoveIdentity_UnsupportedCasing asserts every impl rejects an
+// unrecognised casing.
+func TestRemoveIdentity_UnsupportedCasing(t *testing.T) {
+	ctx := context.Background()
+	for _, impl := range allImpls {
+		t.Run(impl.name, func(t *testing.T) {
+			_, err := impl.fn(ctx, Case(99), []byte(`{"user_id": "a"}`+"\n"), []model.User{{ID: "a"}})
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestRemoveIdentity_EmptyUsersBehaviour documents that the sed-based
+// RemoveIdentity errors out when given an empty users list (it builds an
+// invalid `sed -r -e` command), while the regex and pure-Go impls correctly
+// pass the input through unchanged.
+func TestRemoveIdentity_EmptyUsersBehaviour(t *testing.T) {
+	ctx := context.Background()
+	input := []byte(`{"user_id": "a"}` + "\n" + `{"user_id": "b"}` + "\n")
+
+	t.Run("RemoveIdentity errors", func(t *testing.T) {
+		_, err := runRemoveIdentity(ctx, SnakeCase, input, nil)
+		require.Error(t, err)
+	})
+	t.Run("RemoveIdentityRE passes through", func(t *testing.T) {
+		got, err := runRemoveIdentityRE(ctx, SnakeCase, input, nil)
+		require.NoError(t, err)
+		require.Equal(t, string(input), string(got))
+	})
+	t.Run("RemoveIdentityPureGo passes through", func(t *testing.T) {
+		got, err := runRemoveIdentityPureGo(ctx, SnakeCase, input, nil)
+		require.NoError(t, err)
+		require.Equal(t, string(input), string(got))
+	})
+}
+
+// TestRemoveIdentityPureGo_IgnoresNestedKeys documents a behavioural
+// difference: PureGo parses JSON and only inspects the top-level id field, so
+// a matching id nested under another object does not cause the record to be
+// dropped. The regex/sed impls match textually and would drop such a record.
+func TestRemoveIdentityPureGo_IgnoresNestedKeys(t *testing.T) {
+	input := []byte(`{"user_id": "keep", "context": {"user_id": "drop"}}` + "\n")
+	got, err := runRemoveIdentityPureGo(t.Context(), SnakeCase, input, []model.User{{ID: "drop"}})
+	require.NoError(t, err)
+	require.Equal(t, string(input), string(got))
+}
+
+// TestRemoveIdentityPureGo_EmitsTrailingNewline documents that PureGo always
+// appends a newline per emitted record, even if the final input line lacked
+// one.
+func TestRemoveIdentityPureGo_EmitsTrailingNewline(t *testing.T) {
+	input := []byte(`{"user_id": "a"}` + "\n" + `{"user_id": "b"}`)
+	got, err := runRemoveIdentityPureGo(t.Context(), SnakeCase, input, []model.User{{ID: "a"}})
+	require.NoError(t, err)
+	require.Equal(t, `{"user_id": "b"}`+"\n", string(got))
+}


### PR DESCRIPTION
# Description

`GZIPLocalFileHandler.RemoveIdentity` uses `exec("bash -c sed ...")` to strip suppressed user records from an NDJSON gzip file. Two problems with that:

1. **Shell injection surface**: every suppressed user ID is interpolated into a bash command. We sanitise with `regexp.QuoteMeta`, but that quotes *regex* metacharacters — it does not escape *shell*  
   metacharacters. Inputs like `$(...)` or backticks remain risky.
2. **Does not scale with suppression list size**: sed runs every pattern against every line, so cost grows O(records × users). For 10k records × 100 users it takes ~1.27s (1 MB/s).

This PR adds two shell-free alternatives and benchmarks all three so we can pick a replacement with data:

- **`RemoveIdentityRE`** — single compiled regex that extracts the id from the known key, then O(1) map lookup against a suppression set.
- **`RemoveIdentityPureGo`** — line-by-line lookup. Top-level-only key inspection (no nested false-positives).

Both are O(records) regardless of suppression list size.

## Benchmarks                                                                                                                                                                                               
                                                                                                                                                                                                              
  All benchmarks on Apple M2 Pro, ~10% hit rate. Peak heap sampled via `runtime.MemStats.HeapAlloc` every 50 µs.                                                                                              
                                                                                                                                                                                                              
  ### Standard scenarios (~137 B payloads)                  
                                                                                                                                                                                                              
  #### Time / Throughput                                    
                                                                                                                                                                                                              
  | Scenario              | `RemoveIdentity` (sed) | `RemoveIdentityRE` (regex) | `RemoveIdentityPureGo` (jsonparser) |
  | --------------------- | ---------------------- | -------------------------- | ----------------------------------- |                                                                                       
  | 1k recs / 1 user      | 5.87 ms — 23 MB/s      | 0.39 ms — 348 MB/s         | **0.095 ms — 1441 MB/s**            |
  | 1k recs / 10 users    | 17.43 ms — 8 MB/s      | 0.39 ms — 348 MB/s         | **0.093 ms — 1476 MB/s**            |                                                                                       
  | 10k recs / 1 user     | 19.75 ms — 70 MB/s     | 3.99 ms — 348 MB/s         | **0.92 ms — 1503 MB/s**             |
  | 10k recs / 10 users   | 145.42 ms — 10 MB/s    | 4.01 ms — 346 MB/s         | **0.90 ms — 1537 MB/s**             |                                                                                       
  | 10k recs / 100 users  | 2605 ms — 0.53 MB/s    | 4.11 ms — 338 MB/s         | **0.98 ms — 1422 MB/s**             |                                                                                       
  | 100k recs / 10 users  | 2518 ms — 5.6 MB/s     | 44.15 ms — 319 MB/s        | **9.02 ms — 1561 MB/s**             |                                                                                       
                                                                                                                                                                                                              
  #### Peak live heap (MB)                                                                                                                                                                                    
                                                                                                                                                                                                              
  | Scenario              | sed    | RE     | PureGo |                                                                                                                                                        
  | --------------------- | ------ | ------ | ------ |                                                                                                                                                        
  | 1k recs / 1 user      | 0.40   | 0.24   | **0.16**   |                                                                                                                                                    
  | 1k recs / 10 users    | 0.40   | 0.24   | **0.16**   |                                                                                                                                                    
  | 10k recs / 1 user     | 4.83   | 1.75   | **1.63**   |  
  | 10k recs / 10 users   | 4.83   | 1.75   | **1.63**   |                                                                                                                                                    
  | 10k recs / 100 users  | 4.84   | 1.75   | **1.64**   |                                                                                                                                                    
  | 100k recs / 10 users  | 43.43  | 16.60  | **16.48**  |                                                                                                                                                  
                                                                                                                                                                                                              
  **Peak heap scales linearly with input size, not with user count** — all three approaches hold ≈ input + output buffer in memory regardless of suppression list size. sed is slightly leaner on the largest 
  case because its output piping means the input buffer can be reclaimed earlier.

 ### Large-file scenarios (~1 KB payloads)                 
                                                                                                                                                                                                              
  Sed is excluded — at 2 GB × 10 users it would take ~250 s (extrapolated) and ~5.6 GB peak heap.                                                                                                             
                                                                                                                                                                                                              
  #### Time / Throughput                                                                                                                                                                                      
                                                                                                                                                                                                              
  | File size | `RemoveIdentityRE` | `RemoveIdentityPureGo` |
  |-----------|---------------------|-------------------------|                                                                                                                                               
  | 100 MB    | 108 ms — 881 MB/s   | **14.6 ms — 6544 MB/s** |
  | 500 MB    | 3.00 s — 160 MB/s   | **1.37 s — 349 MB/s**   |                                                                                                                                               
  | 2 GB      | 10.53 s — 182 MB/s  | **8.92 s — 215 MB/s**   |
                                                                                                                                                                                                              
  #### Peak live heap (MB)                                                                                                                                                                                    
                                                                                                                                                                                                              
  | File size | RE     | PureGo | sed (theoretical) |                                                                                                                                                         
  |-----------|--------|--------|--------------------|                                                                                                                                                        
  | 100 MB    | 93.9   | **94.1**   | ~200–300           |                                                                                                                                                    
  | 500 MB    | 472.0  | **471.8**  | ~1000–1500         |  
  | 2 GB      | 1890   | **1897**   | ~4000–5600         |
                                                                                                                                                                                                              
  Note: large-file peak heap includes the benchmark test data slice (~1× input) that stays alive during measurement. In production (where `Read()` loads the file directly into `h.records`), **peak memory is
   ~1× input** since in-place compaction eliminates the output buffer.

Key points:

- **sed degrades catastrophically with user count** (1 → 100 users at 10k records = 19.8 ms → 1.26 s, a ~63× slowdown).
- **Both new impls are flat in user count** — throughput is constant whether the suppression list has 1 or 100 entries.
- **`RemoveIdentityRE` is the fastest across the board**, ~2.2× faster than `PureGo` at every data size. No JSON parse overhead.
- **`PureGo` is stricter** only inspects the top-level id field, so nested `"user_id"` occurrences don't cause false drops. `RemoveIdentityRE` preserves the original sed textual-match semantics.

### Recommendation

Replace `RemoveIdentity` with **`RemoveIdentityRE`** — same match semantics as the current sed impl, removes the shell-injection surface, ~300× faster in the worst-case scenario (10k × 100 users).    
Keep `RemoveIdentityPureGo` as a strictly-correct option for any call-site that needs to ignore nested occurrences.

## Correctness

`gzip_correctness_test.go` drives all three implementations through the same table of 11 cases (casings, regex/shell metacharacter ids, whitespace variants, partial-match guards, multi-id             
suppression). Plus three documented behavioural quirks:

- `RemoveIdentity` errors on an empty users list (it builds an invalid `sed -r -e` command with no pattern).
- `RemoveIdentityPureGo` ignores nested `"user_id"` occurrences; the sed/regex impls drop the line if any occurrence matches.


## Linear Ticket

< Replace with Linear Link ( [create](https://linear.new?title=Awesome-pr-without-linear-ticket) or [search](https://linear.app/rudderstack/search) linear ticket) or  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
