### PR TITLE
chore: bump build-scan-push-action from v2.1.0 to v2.2.0

### DIFF
--- a/.github/workflows/docker-build-ecr.yml
+++ b/.github/workflows/docker-build-ecr.yml
@@ -150,7 +150,7 @@ jobs:
               mirrors = ["422074288268.dkr.ecr.us-east-1.amazonaws.com/docker-hub"]
 
       - name: Build, scan and push
-        uses: rudderlabs/build-scan-push-action@96d7bfca912dd2e8805dbb322dc2540504ecac1e # v2.1.0
+        uses: rudderlabs/build-scan-push-action@865b4253caa57f8f20cd109e0efc1affe3a64939 # v2.2.0
         with:
           context: .
           file: ./${{ inputs.dockerfile }}


### PR DESCRIPTION
## Summary
- Update `rudderlabs/build-scan-push-action` from `v2.1.0` to `v2.2.0`
- SHA: `96d7bfca912dd2e8805dbb322dc2540504ecac1e` → `865b4253caa57f8f20cd109e0efc1affe3a64939`

## Files changed
- \`.github/workflows/docker-build-ecr.yml\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)