### PR TITLE
fix: add correct host for salesforceBU destination

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/augmenter/augmenter.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/augmenter/augmenter.go
@@ -45,6 +45,7 @@ func (s *requestAugmenter) Augment(r *http.Request, body []byte, secret json.Raw
 	// format -> Authorization : OAuth <accessToken>
 	r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 	r.URL.Host = instanceURL
+	r.Host = instanceURL
 	r.Body = io.NopCloser(bytes.NewReader(body))
 	return nil
 }

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/augmenter/augmenter_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/augmenter/augmenter_test.go
@@ -28,6 +28,7 @@ func TestRequestAugmenter_Augment(t *testing.T) {
 			validateFunc: func(t *testing.T, r *http.Request) {
 				require.Equal(t, "Bearer test_token_123", r.Header.Get("Authorization"))
 				require.Equal(t, "test.salesforce.com", r.URL.Host)
+				require.Equal(t, "test.salesforce.com", r.Host)
 				bodyBytes, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				require.Equal(t, []byte(`{"test":"data"}`), bodyBytes)
@@ -40,6 +41,7 @@ func TestRequestAugmenter_Augment(t *testing.T) {
 			validateFunc: func(t *testing.T, r *http.Request) {
 				require.Equal(t, "Bearer token_456", r.Header.Get("Authorization"))
 				require.Equal(t, "custom.salesforce.com", r.URL.Host)
+				require.Equal(t, "custom.salesforce.com", r.Host)
 				bodyBytes, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				require.Equal(t, []byte(`{"key":"value"}`), bodyBytes)
@@ -263,6 +265,7 @@ func TestRequestAugmenter_Augment_RequestModification(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, "newhost.salesforce.com", req.URL.Host)
+		require.Equal(t, "newhost.salesforce.com", req.Host)
 		require.Equal(t, "/path", req.URL.Path)
 		require.Equal(t, "query=value", req.URL.RawQuery)
 		require.Equal(t, "Bearer test_token", req.Header.Get("Authorization"))

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	ApiVersion = "v62.0"
-	ApiBaseURL = "https://default.salesforce.com/services/data/" + ApiVersion
-	CSVDir     = "/tmp/rudder-async-destination-logs"
+	ApiVersion  = "v62.0"
+	ApiBasePath = "/services/data/" + ApiVersion
+	ApiBaseURL  = "https://oauth-placeholder.invalid" + ApiBasePath
+	CSVDir      = "/tmp/rudder-async-destination-logs"
 )
 
 type Uploader struct {


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.28.0

# Description

Fixes a 403 from Salesforce Edge on Hyperforce-hosted orgs when calling the Bulk API through the Salesforce Bulk Upload destination.

# Root cause
The Salesforce OAuth augmenter at [augmenter.go](vscode-webview://04v3039e9pe19rdu9vplb86dddgdd2egpmj5pljj7ie5prn9pj2t/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/augmenter/augmenter.go) was mutating `r.URL.Host` to the org's instance URL but leaving `r.Host` pointing at the placeholder base host. `http.NewRequest` snapshots `Host` from the URL string at construction time, so mutating `URL.Host` alone leaves the outgoing `HTTP` `Host: header` stale. The transport then:

- Opened the TCP connection to <customer>.my.salesforce.com (correct, via URL.Host)
- Sent TLS SNI for <customer>.my.salesforce.com (correct)
- …but wrote Host: default.salesforce.com on the HTTP request line (wrong)
Classic Salesforce pods tolerate the mismatched Host header and route based on session token. Hyperforce pods (aws-prod*-*) validate the Host header at the edge layer and reject the mismatched request with a 403 HTML error page from "Salesforce Edge" before it ever reaches the org's API.

This explains why we saw:

✅ Our own Salesforce account (classic pod) succeeded on the same code path
❌ Customer on Hyperforce (aws-prod21-useast2) hit 403 repeatedly with edge trace IDs
❌ No INVALID_SESSION_ID JSON error — the request never reached the API layer
❌ Customer's IP restriction / Connected App changes had no effect — it was never an IP or auth issue

## Linear Ticket

https://linear.app/rudderstack/issue/INT-6254/debug-fullscript-salesforce-bulk-api-edge-error

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
