### PR TITLE
fix: use tid instead of vid

### DIFF
--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -206,10 +206,11 @@ func makeEvent(messageID, versionID string) types.TransformerEvent {
 			"event":     "Test Event",
 		},
 		Metadata: types.Metadata{
-			SourceID:      "src-1",
-			DestinationID: "dest-1",
-			WorkspaceID:   "ws-1",
-			MessageID:     messageID,
+			SourceID:         "src-1",
+			DestinationID:    "dest-1",
+			WorkspaceID:      "ws-1",
+			MessageID:        messageID,
+			TransformationID: versionID,
 		},
 		Destination: backendconfig.DestinationT{
 			Transformations: []backendconfig.TransformationT{


### PR DESCRIPTION
# Description

For the sake of the contract tests, using the same ID for both `transformation_id` and `transformation_version_id` should suffice given that we never test them changing during the lifetime of a test.

## Linear Ticket

< Fixes [PIPE-2926](https://linear.app/rudderstack/issue/PIPE-2926/track-transformation-version-id-where-it-makes-sense) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
