### PR TITLE
chore: extend transformer client perpetual retries stat

### DIFF
--- a/gateway/webhook/setup.go
+++ b/gateway/webhook/setup.go
@@ -100,7 +100,7 @@ func Setup(gwHandle Gateway, transformerFeaturesService TransformerFeaturesServi
 	transformerClientConfig.Recycle = conf.GetBoolVar(false, "Transformer.Client.sourceTransformer.recycle", "Transformer.Client.recycle")
 	transformerClientConfig.RecycleTTL = conf.GetDurationVar(60, time.Second, "Transformer.Client.sourceTransformer.recycleTTL", "Transformer.Client.recycleTTL")
 
-	transformerClient := transformerclient.NewClient(transformerClientConfig)
+	transformerClient := transformerclient.NewClient("SourceTransformer", transformerClientConfig)
 	retryableClientConfig := &retryablehttp.Config{
 		MaxRetry:        conf.GetIntVar(5, 1, "Gateway.webhook.maxRetry"),
 		InitialInterval: conf.GetDurationVar(100, time.Millisecond, "Gateway.webhook.minRetryTime"),

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/rudderlabs/bing-ads-go-sdk v0.2.3
 	github.com/rudderlabs/compose-test v0.1.3
 	github.com/rudderlabs/keydb v1.3.6
-	github.com/rudderlabs/rudder-go-kit v0.75.0
+	github.com/rudderlabs/rudder-go-kit v0.76.0
 	github.com/rudderlabs/rudder-observability-kit v0.0.6
 	github.com/rudderlabs/rudder-schemas v0.11.0
 	github.com/rudderlabs/rudder-transformer/go v1.129.1

--- a/go.sum
+++ b/go.sum
@@ -1217,8 +1217,8 @@ github.com/rudderlabs/keydb v1.3.6 h1:BZ/FxFiZ7qLKdMgS81aIulbE6T6TjAHLFoW/jDGZLV
 github.com/rudderlabs/keydb v1.3.6/go.mod h1:QRSppZAlyFqOOH30GrSbE0k/ttyL/aVcCeZ12SrXmW4=
 github.com/rudderlabs/parquet-go v0.0.3 h1:/zgRj929pGKHsthc0kw8stVEcFu1JUcpxDRlhxjSLic=
 github.com/rudderlabs/parquet-go v0.0.3/go.mod h1:WmwBOdvwpXl2aZGRk3NxxgzC/DaWGfax3jrCRhKhtSo=
-github.com/rudderlabs/rudder-go-kit v0.75.0 h1:FuxSIBN85GS3NVXVooSX8dbKepFaNzfkiY59nAyQj8k=
-github.com/rudderlabs/rudder-go-kit v0.75.0/go.mod h1:Hu1r6rgBR9NYpgz/y7CzIj+pr1Io7078a70n0GhdspM=
+github.com/rudderlabs/rudder-go-kit v0.76.0 h1:vvMX8W46ATY9DYpYb8JyZrWLPnGt3D6UvLuMqQgCtYs=
+github.com/rudderlabs/rudder-go-kit v0.76.0/go.mod h1:Hu1r6rgBR9NYpgz/y7CzIj+pr1Io7078a70n0GhdspM=
 github.com/rudderlabs/rudder-observability-kit v0.0.6 h1:xIA/1Sp38B542EYzxR7qUfNGJwsQCpmBnl6h5ul0AHA=
 github.com/rudderlabs/rudder-observability-kit v0.0.6/go.mod h1:nR3GvY7HvuBaBqOKFfzLP9uYZu7OpzMqW2eeT2ikXtU=
 github.com/rudderlabs/rudder-schemas v0.11.0 h1:3r0mLWhKADTCAqtEasENWFGofz3abvbmM55VIGEuf8A=

--- a/internal/transformer-client/client.go
+++ b/internal/transformer-client/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -65,17 +66,17 @@ type Client interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-func NewClient(config *ClientConfig) Client {
+func NewClient(name string, config *ClientConfig) Client {
 	switch config.ClientType {
 	case "httplb":
-		return buildHTTPLBClient(config)
+		return buildHTTPLBClient(name, config)
 	default:
-		return buildStandardClient(config)
+		return buildStandardClient(name, config)
 	}
 }
 
 // buildStandardClient creates a standard HTTP client with configuration applied
-func buildStandardClient(config *ClientConfig) Client {
+func buildStandardClient(name string, config *ClientConfig) Client {
 	transport := buildConfiguredTransport(config)
 	client := &http.Client{
 		Transport: transport,
@@ -84,13 +85,13 @@ func buildStandardClient(config *ClientConfig) Client {
 
 	retryableConfig := buildRetryableConfig(config)
 	if retryableConfig != nil {
-		return newRetryableHTTPClient(client, retryableConfig)
+		return newRetryableHTTPClient(name, client, retryableConfig)
 	}
 	return client
 }
 
 // buildHTTPLBClient creates an HTTP load balancer client
-func buildHTTPLBClient(config *ClientConfig) Client {
+func buildHTTPLBClient(name string, config *ClientConfig) Client {
 	transport := buildConfiguredTransport(config)
 
 	tr := &httplbtransport{
@@ -115,7 +116,7 @@ func buildHTTPLBClient(config *ClientConfig) Client {
 	retryableConfig := buildRetryableConfig(config)
 
 	if retryableConfig != nil {
-		return newRetryableHTTPClient(client, retryableConfig)
+		return newRetryableHTTPClient(name, client, retryableConfig)
 	}
 	return client
 }
@@ -199,18 +200,26 @@ func getRecycleTTL(config *ClientConfig) time.Duration {
 	return defaultRecycleTTL
 }
 
-func newRetryableHTTPClient(baseClient Client, retryableConfig *retryablehttp.Config) Client {
+func newRetryableHTTPClient(name string, baseClient Client, retryableConfig *retryablehttp.Config) Client {
 	return retryablehttp.NewRetryableHTTPClient(
 		retryableConfig,
 		retryablehttp.WithHttpClient(baseClient),
-		retryablehttp.WithCustomRetryStrategy(func(resp *http.Response, err error) (bool, error) {
+		retryablehttp.WithCustomRetryStrategy(func(attempt int, resp *http.Response, err error) (bool, error) {
 			if err != nil {
 				return false, backoff.Permanent(err)
 			}
 			if resp.StatusCode == http.StatusServiceUnavailable &&
 				strings.ToLower(resp.Header.Get("X-Rudder-Should-Retry")) == "true" {
 				reason := resp.Header.Get("X-Rudder-Error-Reason")
-				stats.Default.NewTaggedStat("transformer_client_perpetual_retry_count", stats.CountType, stats.Tags{"reason": reason}).Count(1)
+				attemptTag := strconv.Itoa(attempt)
+				if attempt > 4 {
+					attemptTag = "5+"
+				}
+				stats.Default.NewTaggedStat("transformer_client_perpetual_retry_count", stats.CountType, stats.Tags{
+					"name":    name,
+					"reason":  reason,
+					"attempt": attemptTag,
+				}).Increment()
 				resp.Body.Close()
 				return true, fmt.Errorf("got retryable error response from transformer: %s", reason)
 			}

--- a/internal/transformer-client/client.go
+++ b/internal/transformer-client/client.go
@@ -3,7 +3,9 @@
 package transformerclient
 
 import (
+	"context"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"strconv"
@@ -19,6 +21,21 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/retryablehttp"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 )
+
+type perpetualRetriesStatsTagsKey struct{}
+
+// WithPerpetualRetriesStatsTags returns a context carrying extra tags to be
+// added to the transformer_client_perpetual_retry_count stat for any request
+// made with this context. Callers are responsible for keeping tag cardinality
+// low.
+func WithPerpetualRetriesStatsTags(ctx context.Context, tags map[string]string) context.Context {
+	return context.WithValue(ctx, perpetualRetriesStatsTagsKey{}, tags)
+}
+
+func perpetualRetriesStatsTagsFromContext(ctx context.Context) map[string]string {
+	v, _ := ctx.Value(perpetualRetriesStatsTagsKey{}).(map[string]string)
+	return v
+}
 
 const (
 	defaultDisableKeepAlives   = true
@@ -215,11 +232,15 @@ func newRetryableHTTPClient(name string, baseClient Client, retryableConfig *ret
 				if attempt > 4 {
 					attemptTag = "5+"
 				}
-				stats.Default.NewTaggedStat("transformer_client_perpetual_retry_count", stats.CountType, stats.Tags{
+				tags := stats.Tags{
 					"name":    name,
 					"reason":  reason,
 					"attempt": attemptTag,
-				}).Increment()
+				}
+				if resp.Request != nil {
+					maps.Copy(tags, perpetualRetriesStatsTagsFromContext(resp.Request.Context()))
+				}
+				stats.Default.NewTaggedStat("transformer_client_perpetual_retry_count", stats.CountType, tags).Increment()
 				resp.Body.Close()
 				return true, fmt.Errorf("got retryable error response from transformer: %s", reason)
 			}

--- a/internal/transformer-client/client_test.go
+++ b/internal/transformer-client/client_test.go
@@ -52,7 +52,7 @@ func TestClient_RetryBehavior(t *testing.T) {
 				Multiplier:      2.0,
 			},
 		}
-		client := NewClient(clientConfig)
+		client := NewClient("testClient", clientConfig)
 
 		req, err := http.NewRequest("POST", server.URL, strings.NewReader("test data"))
 		require.NoError(t, err)
@@ -100,7 +100,7 @@ func TestClient_RetryBehavior(t *testing.T) {
 				Multiplier:      2.0,
 			},
 		}
-		client := NewClient(clientConfig)
+		client := NewClient("testClient", clientConfig)
 
 		req, err := http.NewRequest("POST", server.URL, strings.NewReader("test data"))
 		require.NoError(t, err)
@@ -158,7 +158,7 @@ func TestClient_RetryBehavior(t *testing.T) {
 				Multiplier:      2.0,
 			},
 		}
-		client := NewClient(clientConfig)
+		client := NewClient("testClient", clientConfig)
 
 		req, err := http.NewRequest("POST", server.URL, strings.NewReader("test data"))
 		require.NoError(t, err)
@@ -215,7 +215,7 @@ func TestClient_RetryBehavior(t *testing.T) {
 						Multiplier:      2.0,
 					},
 				}
-				client := NewClient(clientConfig)
+				client := NewClient("testClient", clientConfig)
 
 				req, err := http.NewRequest("POST", server.URL, strings.NewReader("test data"))
 				require.NoError(t, err)
@@ -261,7 +261,7 @@ func TestClient_RetryBehavior(t *testing.T) {
 				Multiplier:      2.0,
 			},
 		}
-		client := NewClient(clientConfig)
+		client := NewClient("testClient", clientConfig)
 
 		req, err := http.NewRequest("POST", server.URL, strings.NewReader("test data"))
 		require.NoError(t, err)
@@ -303,7 +303,7 @@ func TestClient_ErrorsNotRetried(t *testing.T) {
 				Multiplier:      2.0,
 			},
 		}
-		client := NewClient(clientConfig)
+		client := NewClient("testClient", clientConfig)
 
 		req, err := http.NewRequest("POST", url, strings.NewReader("test data"))
 		require.NoError(t, err)
@@ -344,7 +344,7 @@ func TestClient_ErrorsNotRetried(t *testing.T) {
 				Multiplier:      2.0,
 			},
 		}
-		client := NewClient(clientConfig)
+		client := NewClient("testClient", clientConfig)
 
 		req, err := http.NewRequest("POST", url, strings.NewReader("test data"))
 		require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestClient_ConfigurableRetrySettings(t *testing.T) {
 				Multiplier:      2.0,
 			},
 		}
-		client := NewClient(clientConfig)
+		client := NewClient("testClient", clientConfig)
 
 		req, err := http.NewRequest("POST", server.URL, strings.NewReader("test data"))
 		require.NoError(t, err)
@@ -440,7 +440,7 @@ func TestClient_ConfigurableRetrySettings(t *testing.T) {
 				Multiplier:      2.0,
 			},
 		}
-		client := NewClient(clientConfig)
+		client := NewClient("testClient", clientConfig)
 
 		req, err := http.NewRequest("POST", server.URL, strings.NewReader("test data"))
 		require.NoError(t, err)
@@ -482,7 +482,7 @@ func TestClient_RetryDisabled(t *testing.T) {
 				Enabled: false, // Explicitly disable retries
 			},
 		}
-		client := NewClient(clientConfig)
+		client := NewClient("testClient", clientConfig)
 
 		req, err := http.NewRequest("POST", server.URL, strings.NewReader("test data"))
 		require.NoError(t, err)

--- a/internal/transformer-client/client_test.go
+++ b/internal/transformer-client/client_test.go
@@ -1,6 +1,7 @@
 package transformerclient
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
 )
 
@@ -453,6 +456,121 @@ func TestClient_ConfigurableRetrySettings(t *testing.T) {
 		require.Equal(t, 1, requestCount, "Should make exactly 1 request due to very short MaxElapsedTime")
 
 		resp.Body.Close()
+	})
+}
+
+func TestClient_PerpetualRetriesStatsTags(t *testing.T) {
+	t.Run("merges context tags into perpetual retry stat", func(t *testing.T) {
+		var requestCount int
+		retryableResponses := 2
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			if requestCount <= retryableResponses {
+				w.Header().Set("X-Rudder-Should-Retry", "true")
+				w.Header().Set("X-Rudder-Error-Reason", "temporary-overload")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		originalStats := stats.Default
+		stats.Default = statsStore
+		defer func() { stats.Default = originalStats }()
+
+		clientConfig := &ClientConfig{
+			ClientTimeout: 10 * time.Second,
+			RetryRudderErrors: struct {
+				Enabled         bool
+				MaxRetry        int
+				InitialInterval time.Duration
+				MaxInterval     time.Duration
+				MaxElapsedTime  time.Duration
+				Multiplier      float64
+			}{
+				Enabled:         true,
+				MaxRetry:        -1,
+				InitialInterval: 10 * time.Millisecond,
+				MaxInterval:     50 * time.Millisecond,
+				MaxElapsedTime:  5 * time.Second,
+				Multiplier:      2.0,
+			},
+		}
+		client := NewClient("testClient", clientConfig)
+
+		ctx := WithPerpetualRetriesStatsTags(context.Background(), map[string]string{"language": "python"})
+		req, err := http.NewRequestWithContext(ctx, "POST", server.URL, strings.NewReader("test data"))
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		resp.Body.Close()
+
+		metrics := statsStore.GetByName("transformer_client_perpetual_retry_count")
+		require.Len(t, metrics, retryableResponses, "should have one perpetual retry stat per retryable response")
+		for i, m := range metrics {
+			require.Equal(t, "testClient", m.Tags["name"])
+			require.Equal(t, "temporary-overload", m.Tags["reason"])
+			require.Equal(t, "python", m.Tags["language"], "context tag should be propagated")
+			require.NotEmpty(t, m.Tags["attempt"], "attempt %d", i)
+		}
+	})
+
+	t.Run("does not add language tag when context has no extra tags", func(t *testing.T) {
+		var requestCount int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			if requestCount == 1 {
+				w.Header().Set("X-Rudder-Should-Retry", "true")
+				w.Header().Set("X-Rudder-Error-Reason", "temporary-overload")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		originalStats := stats.Default
+		stats.Default = statsStore
+		defer func() { stats.Default = originalStats }()
+
+		clientConfig := &ClientConfig{
+			ClientTimeout: 10 * time.Second,
+			RetryRudderErrors: struct {
+				Enabled         bool
+				MaxRetry        int
+				InitialInterval time.Duration
+				MaxInterval     time.Duration
+				MaxElapsedTime  time.Duration
+				Multiplier      float64
+			}{
+				Enabled:         true,
+				MaxRetry:        -1,
+				InitialInterval: 10 * time.Millisecond,
+				MaxInterval:     50 * time.Millisecond,
+				MaxElapsedTime:  5 * time.Second,
+				Multiplier:      2.0,
+			},
+		}
+		client := NewClient("testClient", clientConfig)
+
+		req, err := http.NewRequest("POST", server.URL, strings.NewReader("test data"))
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		resp.Body.Close()
+
+		metrics := statsStore.GetByName("transformer_client_perpetual_retry_count")
+		require.Len(t, metrics, 1)
+		require.NotContains(t, metrics[0].Tags, "language")
 	})
 }
 

--- a/processor/internal/transformer/destination_transformer/destination_transformer.go
+++ b/processor/internal/transformer/destination_transformer/destination_transformer.go
@@ -71,7 +71,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) 
 	handle.conf = conf
 	handle.log = log
 	handle.stat = stat
-	handle.client = transformerclient.NewClient(transformerutils.TransformerClientConfig(conf, "DestinationTransformer"))
+	handle.client = transformerclient.NewClient("DestinationTransformer", transformerutils.TransformerClientConfig(conf, "DestinationTransformer"))
 	handle.config.destTransformationURL = handle.conf.GetStringVar("http://localhost:9090", "DEST_TRANSFORM_URL")
 	handle.config.timeoutDuration = conf.GetDurationVar(600, time.Second, "HttpClient.procTransformer.timeout")
 	handle.config.maxRetry = conf.GetReloadableIntVar(30, 1, "Processor.DestinationTransformer.maxRetry", "Processor.maxRetry")

--- a/processor/internal/transformer/sourcehydration/source_hydration.go
+++ b/processor/internal/transformer/sourcehydration/source_hydration.go
@@ -62,7 +62,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) 
 	handle.conf = conf
 	handle.log = log
 	handle.stat = stat
-	handle.client = transformerclient.NewClient(transformerutils.TransformerClientConfig(conf, "SourceHydration"))
+	handle.client = transformerclient.NewClient("SourceHydration", transformerutils.TransformerClientConfig(conf, "SourceHydration"))
 	handle.config.sourceHydrationURL = handle.conf.GetStringVar("http://localhost:9090", "DEST_TRANSFORM_URL")
 	handle.config.logLongRunningTransformAfter = conf.GetDurationVar(600, time.Second, "HttpClient.procTransformer.logLongRunningTransformAfter")
 	handle.config.maxRetry = conf.GetReloadableIntVar(0, 1, "Processor.SourceHydration.maxRetry", "Processor.maxRetry")

--- a/processor/internal/transformer/trackingplan_validation/trackingplan_validation.go
+++ b/processor/internal/transformer/trackingplan_validation/trackingplan_validation.go
@@ -41,7 +41,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) 
 	handle.conf = conf
 	handle.log = log
 	handle.stat = stat
-	handle.client = transformerclient.NewClient(transformerutils.TransformerClientConfig(conf, "TrackingPlanValidation"))
+	handle.client = transformerclient.NewClient("TrackingPlanValidation", transformerutils.TransformerClientConfig(conf, "TrackingPlanValidation"))
 	handle.config.destTransformationURL = handle.conf.GetStringVar("http://localhost:9090", "DEST_TRANSFORM_URL")
 	handle.config.maxRetry = conf.GetReloadableIntVar(30, 1, "Processor.TrackingPlanValidation.maxRetry", "Processor.maxRetry")
 	handle.config.timeoutDuration = conf.GetDurationVar(600, time.Second, "HttpClient.procTransformer.timeout")

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -45,7 +45,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) 
 	handle.conf = conf
 	handle.log = log.Child("user_transformer")
 	handle.stat = stat
-	handle.client = transformerclient.NewClient(transformerutils.TransformerClientConfig(conf, "UserTransformer"))
+	handle.client = transformerclient.NewClient("UserTransformer", transformerutils.TransformerClientConfig(conf, "UserTransformer"))
 	handle.config.userTransformationURL = handle.conf.GetStringVar(handle.conf.GetStringVar("http://localhost:9090", "DEST_TRANSFORM_URL"), "USER_TRANSFORM_URL")
 	handle.config.pythonTransformationURL = handle.conf.GetStringVar("", "PYTHON_TRANSFORM_URL")
 	handle.config.pythonTransformConfig = transformerutils.LoadPythonTransformConfig(conf)

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -116,6 +116,7 @@ func (u *Client) Transform(ctx context.Context, clientEvents []types.Transformer
 	defer trackWg.Wait()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	ctx = transformerclient.WithPerpetualRetriesStatsTags(ctx, map[string]string{"language": transformationLanguage})
 
 	trackWg.Go(func() {
 		l := u.log.Withn(labels.ToLoggerFields()...)

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -573,7 +573,7 @@ func (trans *handle) setup(destType string, destinationTimeout, transformTimeout
 	// Basically this timeout we will configure when we make final call to destination to send event
 	trans.destinationTimeout = destinationTimeout
 	// This client is used for Router Transformation
-	trans.client = transformerclient.NewClient(trans.transformerClientConfig())
+	trans.client = transformerclient.NewClient("RouterTransformer", trans.transformerClientConfig())
 	optionalArgs := &oauthv2httpclient.HttpClientOptionalArgs{
 		Locker:              locker,
 		Augmenter:           extensions.RouterHeaderAugmenter,
@@ -591,7 +591,7 @@ func (trans *handle) setup(destType string, destinationTimeout, transformTimeout
 		OAuthBreakerOptions: oauthv2.ConfigToOauthBreakerOptions("Router."+destType, conf),
 	}
 	// This client is used for Transformer Proxy(delivered from transformer to destination)
-	trans.proxyClient = transformerclient.NewClient(trans.transformerClientConfig())
+	trans.proxyClient = transformerclient.NewClient("TransformerProxy", trans.transformerClientConfig())
 	// This client is used for Transformer Proxy(delivered from transformer to destination) using oauthV2
 	trans.proxyClientOAuthV2 = oauthv2httpclient.NewOAuthHttpClient(&http.Client{Transport: trans.tr, Timeout: trans.destinationTimeout + trans.transformTimeout}, common.RudderFlowDelivery, cache, backendConfig, GetAuthErrorCategoryFromTransformProxyResponse, proxyClientOptionalArgs)
 	trans.stats = stats.Default


### PR DESCRIPTION
# Description

Extends the `transformer_client_perpetual_retry_count` stat with additional dimensions to give better visibility into perpetual transformer retries:

- **`name` tag**: identifies which transformer client emitted the metric (e.g. `SourceTransformer`, `DestinationTransformer`, `UserTransformer`, `TrackingPlanValidation`, `SourceHydration`, `RouterTransformer`, `TransformerProxy`).
- **`attempt` tag**: the retry attempt number, capped at `5+` to keep cardinality bounded (values `0`, `1`, `2`, `3`, `4`, `5+`).
- **Per-request extra tags via context**: callers can attach extra low-cardinality tags to a request's context using `transformerclient.WithPerpetualRetriesStatsTags(ctx, map[string]string{...})`; the retry strategy merges them into the stat. `UserTransformer` uses this to add a `language` tag (`javascript` / `python`) so JS vs Python user-transformer retries can be differentiated even though they share the same client.

To plumb the `name` through, `transformerclient.NewClient` now takes a `name` parameter, propagated to the custom retry strategy. All call sites have been updated.

Also bumps `rudder-go-kit` to pick up the `attempt int` argument added to the custom retry strategy callback.

## Linear Ticket

N/A

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.