### PR TITLE
chore: filtering overflow events for snowpipe streaming above 16MB

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -38,8 +38,6 @@ import (
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
-const maxInsertRequestSizeBytes = 16 * bytesize.MB
-
 func New(
 	conf *config.Config,
 	log logger.Logger,
@@ -73,6 +71,7 @@ func New(
 	m.config.instanceID = conf.GetStringVar("1", "INSTANCE_ID")
 	m.config.maxBufferCapacity = conf.GetReloadableInt64Var(512*bytesize.KB, bytesize.B, "SnowpipeStreaming.maxBufferCapacity")
 	m.config.stuckPipelineThreshold = conf.GetReloadableDurationVar(15, time.Minute, "SnowpipeStreaming.stuckPipelineThresholdInMinutes")
+	m.config.maxInsertRequestSizeBytes = conf.GetReloadableInt64Var(16*bytesize.MB, bytesize.B, "SnowpipeStreaming.maxInsertRequestSizeBytes")
 
 	tags := stats.Tags{
 		"module":        "batch_router",
@@ -206,9 +205,10 @@ func (m *Manager) Upload(_ context.Context, asyncDest *common.AsyncDestinationSt
 		return event.Message.Metadata.Table
 	})
 
-	filteredGroupedEvents, overflowedEvents := m.filterOutEventsThatExceedMaxInsertRequestSize(groupedEvents)
+	maxInsertRequestSizeBytes := m.config.maxInsertRequestSizeBytes.Load()
+	includedGroupedEvents, overflowedEvents := splitEventsExceedingMaxInsertRequestSize(groupedEvents, maxInsertRequestSizeBytes)
 
-	uploadInfos := lo.MapToSlice(filteredGroupedEvents, func(tableName string, tableEvents []*event) *uploadInfo {
+	uploadInfos := lo.MapToSlice(includedGroupedEvents, func(tableName string, tableEvents []*event) *uploadInfo {
 		jobIDs := lo.Map(tableEvents, func(event *event, _ int) int64 {
 			return event.Metadata.JobID
 		})
@@ -359,10 +359,10 @@ func (m *Manager) eventsFromFile(fileName string, eventsCount int) ([]*event, er
 	return events, nil
 }
 
-// filterOutEventsThatExceedMaxInsertRequestSize filters out events that exceed the max insert request size
-// and returns the filtered grouped events and the overflowed events.
-func (m *Manager) filterOutEventsThatExceedMaxInsertRequestSize(groupedEvents map[string][]*event) (map[string][]*event, []*event) {
-	filteredGroupedEvents := make(map[string][]*event, len(groupedEvents))
+// splitEventsExceedingMaxInsertRequestSize splits grouped events into included and overflowed events
+// based on the configured max insert request size.
+func splitEventsExceedingMaxInsertRequestSize(groupedEvents map[string][]*event, maxInsertRequestSizeBytes int64) (map[string][]*event, []*event) {
+	includedGroupedEvents := make(map[string][]*event, len(groupedEvents))
 	overflowedEvents := make([]*event, 0)
 	for tableName, tableEvents := range groupedEvents {
 		// Only account for the insert rows payload size:
@@ -382,10 +382,10 @@ func (m *Manager) filterOutEventsThatExceedMaxInsertRequestSize(groupedEvents ma
 			kept = append(kept, event)
 		}
 		if len(kept) > 0 {
-			filteredGroupedEvents[tableName] = kept
+			includedGroupedEvents[tableName] = kept
 		}
 	}
-	return filteredGroupedEvents, overflowedEvents
+	return includedGroupedEvents, overflowedEvents
 }
 
 // sendEventsToSnowpipe sends events to Snowpipe for the given table.

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -38,6 +38,8 @@ import (
 	whutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
+const maxInsertRequestSizeBytes = 16 * bytesize.MB
+
 func New(
 	conf *config.Config,
 	log logger.Logger,
@@ -203,7 +205,10 @@ func (m *Manager) Upload(_ context.Context, asyncDest *common.AsyncDestinationSt
 	groupedEvents := lo.GroupBy(events, func(event *event) string {
 		return event.Message.Metadata.Table
 	})
-	uploadInfos := lo.MapToSlice(groupedEvents, func(tableName string, tableEvents []*event) *uploadInfo {
+
+	filteredGroupedEvents, overflowedEvents := m.filterOutEventsThatExceedMaxInsertRequestSize(groupedEvents)
+
+	uploadInfos := lo.MapToSlice(filteredGroupedEvents, func(tableName string, tableEvents []*event) *uploadInfo {
 		jobIDs := lo.Map(tableEvents, func(event *event, _ int) int64 {
 			return event.Metadata.JobID
 		})
@@ -273,6 +278,15 @@ func (m *Manager) Upload(_ context.Context, asyncDest *common.AsyncDestinationSt
 	if discardImportInfo != nil {
 		importInfos = append(importInfos, discardImportInfo)
 	}
+	if len(overflowedEvents) > 0 {
+		failedJobIDs = append(failedJobIDs, lo.Map(overflowedEvents, func(event *event, _ int) int64 {
+			return event.Metadata.JobID
+		})...)
+		// If failed reason is not set, set it to the default reason
+		if failedReason == "" {
+			failedReason = fmt.Sprintf("some events were not uploaded because they exceeded the max insert request size: %d bytes", maxInsertRequestSizeBytes)
+		}
+	}
 
 	var importParameters json.RawMessage
 	if len(importInfos) > 0 {
@@ -324,11 +338,18 @@ func (m *Manager) eventsFromFile(fileName string, eventsCount int) ([]*event, er
 	scanner.Buffer(nil, int(m.config.maxBufferCapacity.Load()))
 
 	for scanner.Scan() {
+		line := scanner.Bytes()
+
 		var e event
-		if err := jsonrs.Unmarshal(scanner.Bytes(), &e); err != nil {
+		if err := jsonrs.Unmarshal(line, &e); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal event: %w", err)
 		}
-		e.setUUIDTimestamp(formattedTS)
+		isUUIDTimestampSet := e.setUUIDTimestamp(formattedTS)
+
+		e.MessageDataByteSize = int64(len(gjson.GetBytes(line, "message.data").Raw))
+		if isUUIDTimestampSet {
+			e.MessageDataByteSize += int64(len(formattedTS))
+		}
 
 		events = append(events, &e)
 	}
@@ -336,6 +357,35 @@ func (m *Manager) eventsFromFile(fileName string, eventsCount int) ([]*event, er
 		return nil, fmt.Errorf("error reading from file: %w", err)
 	}
 	return events, nil
+}
+
+// filterOutEventsThatExceedMaxInsertRequestSize filters out events that exceed the max insert request size
+// and returns the filtered grouped events and the overflowed events.
+func (m *Manager) filterOutEventsThatExceedMaxInsertRequestSize(groupedEvents map[string][]*event) (map[string][]*event, []*event) {
+	filteredGroupedEvents := make(map[string][]*event, len(groupedEvents))
+	overflowedEvents := make([]*event, 0)
+	for tableName, tableEvents := range groupedEvents {
+		// Only account for the insert rows payload size:
+		// rows JSON = '[' + row1 + ',' + row2 + ... + ']'
+		eventsSize := int64(2) // '[' + ']'
+		kept := make([]*event, 0, len(tableEvents))
+		for _, event := range tableEvents {
+			eventSize := event.MessageDataByteSize
+			if len(kept) > 0 {
+				eventSize++ // ',' between rows
+			}
+			if eventsSize+eventSize > maxInsertRequestSizeBytes {
+				overflowedEvents = append(overflowedEvents, event)
+				continue
+			}
+			eventsSize += eventSize
+			kept = append(kept, event)
+		}
+		if len(kept) > 0 {
+			filteredGroupedEvents[tableName] = kept
+		}
+	}
+	return filteredGroupedEvents, overflowedEvents
 }
 
 // sendEventsToSnowpipe sends events to Snowpipe for the given table.

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
@@ -140,8 +141,11 @@ func TestSnowpipeStreaming(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
 
+		maxInsertRequestSizeBytes := 16 * bytesize.MB
+
 		conf := config.New()
 		conf.Set("SnowpipeStreaming.maxBufferCapacity", int64(64*1024*1024))
+		conf.Set("SnowpipeStreaming.maxInsertRequestSizeBytes", maxInsertRequestSizeBytes)
 
 		sm := New(conf, logger.NOP, statsStore, destination)
 		sm.channelCache.Store("RUDDER_DISCARDS", rudderDiscardsChannelResponse)
@@ -176,7 +180,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 		// then ensure a later small row can still fit.
 		// MessageDataByteSize is computed from the marshalled insert row.
 		baseTS := "2023-05-12T04:36:50.199Z"
-		largeName := strings.Repeat("a", int(maxInsertRequestSizeBytes-20000))
+		largeName := strings.Repeat("a", int(maxInsertRequestSizeBytes-int64(20000)))
 		overflowName := strings.Repeat("b", 30000)
 
 		_, err = fmt.Fprintf(f,

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -6,6 +6,8 @@ import (
 	"maps"
 	"math"
 	"net/http"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -132,6 +134,79 @@ func TestSnowpipeStreaming(t *testing.T) {
 			"destinationId": "test-destination",
 			"status":        "failed",
 		}).LastValue())
+	})
+
+	t.Run("Upload filters out events that exceed max insert request size", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		conf := config.New()
+		conf.Set("SnowpipeStreaming.maxBufferCapacity", int64(64*1024*1024))
+
+		sm := New(conf, logger.NOP, statsStore, destination)
+		sm.channelCache.Store("RUDDER_DISCARDS", rudderDiscardsChannelResponse)
+		sm.channelCache.Store("USERS", usersChannelResponse)
+
+		mockApi := &mockAPI{
+			insertOutputMap: map[string]func() (*model.InsertResponse, error){
+				"test-rudder-discards-channel": func() (*model.InsertResponse, error) {
+					return &model.InsertResponse{Success: true}, nil
+				},
+				"test-users-channel": func() (*model.InsertResponse, error) {
+					return &model.InsertResponse{Success: true}, nil
+				},
+			},
+			deleteChannelOutputMap: map[string]func() error{
+				"test-rudder-discards-channel": func() error { return nil },
+				"test-users-channel":           func() error { return nil },
+			},
+			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
+				"test-rudder-discards-channel": func() (*model.StatusResponse, error) { return nil, assert.AnError },
+				"test-users-channel":           func() (*model.StatusResponse, error) { return nil, assert.AnError },
+			},
+		}
+		sm.api = mockApi
+
+		f, err := os.CreateTemp("", "snowpipe-streaming-chunking-*.txt")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Remove(f.Name()) })
+		t.Cleanup(func() { _ = f.Close() })
+
+		// Fill the insert rows payload close to 16MB, make the next row overflow,
+		// then ensure a later small row can still fit.
+		// MessageDataByteSize is computed from the marshalled insert row.
+		baseTS := "2023-05-12T04:36:50.199Z"
+		largeName := strings.Repeat("a", int(maxInsertRequestSizeBytes-20000))
+		overflowName := strings.Repeat("b", 30000)
+
+		_, err = fmt.Fprintf(f,
+			`{"message":{"metadata":{"table":"USERS","columns":{"ID":"int","NAME":"string","AGE":"int","RECEIVED_AT":"datetime"}},"data":{"ID":1,"NAME":"%s","AGE":30,"RECEIVED_AT":"%s"}},"metadata":{"job_id":1001}}`+"\n",
+			largeName, baseTS,
+		)
+		require.NoError(t, err)
+		_, err = fmt.Fprintf(f,
+			`{"message":{"metadata":{"table":"USERS","columns":{"ID":"int","NAME":"string","AGE":"int","RECEIVED_AT":"datetime"}},"data":{"ID":2,"NAME":"%s","AGE":30,"RECEIVED_AT":"%s"}},"metadata":{"job_id":1002}}`+"\n",
+			overflowName, baseTS,
+		)
+		require.NoError(t, err)
+		_, err = fmt.Fprintf(f,
+			`{"message":{"metadata":{"table":"USERS","columns":{"ID":"int","NAME":"string","AGE":"int","RECEIVED_AT":"datetime"}},"data":{"ID":3,"NAME":"small","AGE":30,"RECEIVED_AT":"%s"}},"metadata":{"job_id":1003}}`+"\n",
+			baseTS,
+		)
+		require.NoError(t, err)
+		require.NoError(t, f.Sync())
+
+		output := sm.Upload(context.Background(), &common.AsyncDestinationStruct{
+			Destination: destination,
+			FileName:    f.Name(),
+			Count:       3,
+		})
+
+		require.Equal(t, []int64{1001, 1003}, output.ImportingJobIDs)
+		require.Equal(t, 2, output.ImportingCount)
+		require.Equal(t, []int64{1002}, output.FailedJobIDs)
+		require.Equal(t, 1, output.FailedCount)
+		require.Equal(t, fmt.Sprintf("some events were not uploaded because they exceeded the max insert request size: %d bytes", maxInsertRequestSizeBytes), output.FailedReason)
 	})
 
 	t.Run("Upload not able to create discards channel", func(t *testing.T) {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
@@ -43,9 +43,10 @@ type (
 				retryWaitMax           time.Duration
 				retryMax               int
 			}
-			instanceID             string
-			maxBufferCapacity      config.ValueLoader[int64]
-			stuckPipelineThreshold config.ValueLoader[time.Duration]
+			instanceID                string
+			maxBufferCapacity         config.ValueLoader[int64]
+			stuckPipelineThreshold    config.ValueLoader[time.Duration]
+			maxInsertRequestSizeBytes config.ValueLoader[int64]
 		}
 
 		stats struct {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
@@ -80,6 +80,7 @@ type (
 		Metadata struct {
 			JobID int64 `json:"job_id"`
 		}
+		MessageDataByteSize int64 `json:"-"` // Added to track the size of message.data field in bytes
 	}
 
 	destConfig struct {
@@ -157,12 +158,14 @@ func (d *destConfig) Decode(m map[string]any) error {
 	return nil
 }
 
-func (e *event) setUUIDTimestamp(formattedTimestamp string) {
+func (e *event) setUUIDTimestamp(formattedTimestamp string) bool {
 	if e.Message.Metadata.Columns == nil {
-		return
+		return false
 	}
 	uuidTimestampColumn := whutils.ToProviderCase(whutils.SnowpipeStreaming, "uuid_ts")
 	if _, columnExists := e.Message.Metadata.Columns[uuidTimestampColumn]; columnExists {
 		e.Message.Data[uuidTimestampColumn] = formattedTimestamp
+		return true
 	}
+	return false
 }


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

# Description

Snowpipe Streaming insert requests have a [maximum 'insertRows' size](https://github.com/snowflakedb/snowflake-ingest-java/blob/master/src/main/java/net/snowflake/ingest/streaming/internal/AbstractRowBuffer.java#L721). Previously, large batches could exceed this limit and fail. This change ensures we stay within the limit and fail only the overflow events deterministically.

- Compute per-event payload size from raw `message.data` JSON and store it as `MessageDataByteSize`.
- While uploading, group events by table and filter out events that would cause a table insert request to exceed the 16MB limit (`maxInsertRequestSizeBytes`).
- Mark any overflow events as failed with reason: `some events were not uploaded because they exceeded the max insert request size: 16777216`.


## Linear Ticket

- Resolves INT-5890

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
