### PR TITLE
fix: salesforce bulk upload null and numeric CSV formatting

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/common/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/common/utils.go
@@ -1,6 +1,12 @@
 package common
 
-import "slices"
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+)
 
 var (
 	asyncDestinations = []string{"MARKETO_BULK_UPLOAD", "BINGADS_AUDIENCE", "ELOQUA", "YANDEX_METRICA_OFFLINE_EVENTS", "BINGADS_OFFLINE_CONVERSIONS", "KLAVIYO_BULK_UPLOAD", "LYTICS_BULK_UPLOAD", "SNOWPIPE_STREAMING", "SALESFORCE_BULK_UPLOAD"}
@@ -17,4 +23,44 @@ func IsAsyncRegularDestination(destination string) bool {
 
 func IsAsyncDestination(destination string) bool {
 	return slices.Contains(append(asyncDestinations, sftpDestinations...), destination)
+}
+
+// FormatCSVValue stringifies a JSON-derived value for a CSV cell.
+// Top-level nil renders as an empty cell so destinations that treat empty
+// cells as null (e.g. Salesforce Bulk) get the expected semantics. All
+// other values go through stringify, which avoids scientific notation for
+// floats while preserving Go's default bracketed shape for arrays and maps.
+func FormatCSVValue(value any) string {
+	if value == nil {
+		return ""
+	}
+	return stringify(value)
+}
+
+func stringify(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return "<nil>"
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case []any:
+		parts := make([]string, len(v))
+		for i, item := range v {
+			parts[i] = stringify(item)
+		}
+		return "[" + strings.Join(parts, " ") + "]"
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts := make([]string, 0, len(keys))
+		for _, k := range keys {
+			parts = append(parts, k+":"+stringify(v[k]))
+		}
+		return "map[" + strings.Join(parts, " ") + "]"
+	default:
+		return fmt.Sprintf("%v", v)
+	}
 }

--- a/router/batchrouter/asyncdestinationmanager/common/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/common/utils.go
@@ -30,24 +30,21 @@ func IsAsyncDestination(destination string) bool {
 // cells as null (e.g. Salesforce Bulk) get the expected semantics. Floats
 // are rendered without scientific notation, and arrays/maps are emitted
 // as JSON so nested numbers stay plain and nested nulls become `null`.
-func FormatCSVValue(value any) string {
+// Returns an error when JSON marshalling of a composite value fails.
+func FormatCSVValue(value any) (string, error) {
 	if value == nil {
-		return ""
+		return "", nil
 	}
-	return stringify(value)
-}
-
-func stringify(value any) string {
 	switch v := value.(type) {
 	case float64:
-		return strconv.FormatFloat(v, 'f', -1, 64)
+		return strconv.FormatFloat(v, 'f', -1, 64), nil
 	case []any, map[string]any:
-		res, err := jsonrs.Marshal(value)
+		b, err := jsonrs.Marshal(v)
 		if err != nil {
-			return fmt.Sprintf("%v", value)
+			return "", err
 		}
-		return string(res)
+		return string(b), nil
 	default:
-		return fmt.Sprintf("%v", v)
+		return fmt.Sprintf("%v", v), nil
 	}
 }

--- a/router/batchrouter/asyncdestinationmanager/common/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/common/utils.go
@@ -3,9 +3,9 @@ package common
 import (
 	"fmt"
 	"slices"
-	"sort"
 	"strconv"
-	"strings"
+
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 )
 
 var (
@@ -27,9 +27,9 @@ func IsAsyncDestination(destination string) bool {
 
 // FormatCSVValue stringifies a JSON-derived value for a CSV cell.
 // Top-level nil renders as an empty cell so destinations that treat empty
-// cells as null (e.g. Salesforce Bulk) get the expected semantics. All
-// other values go through stringify, which avoids scientific notation for
-// floats while preserving Go's default bracketed shape for arrays and maps.
+// cells as null (e.g. Salesforce Bulk) get the expected semantics. Floats
+// are rendered without scientific notation, and arrays/maps are emitted
+// as JSON so nested numbers stay plain and nested nulls become `null`.
 func FormatCSVValue(value any) string {
 	if value == nil {
 		return ""
@@ -39,27 +39,14 @@ func FormatCSVValue(value any) string {
 
 func stringify(value any) string {
 	switch v := value.(type) {
-	case nil:
-		return "<nil>"
 	case float64:
 		return strconv.FormatFloat(v, 'f', -1, 64)
-	case []any:
-		parts := make([]string, len(v))
-		for i, item := range v {
-			parts[i] = stringify(item)
+	case []any, map[string]any:
+		res, err := jsonrs.Marshal(value)
+		if err != nil {
+			return fmt.Sprintf("%v", value)
 		}
-		return "[" + strings.Join(parts, " ") + "]"
-	case map[string]any:
-		keys := make([]string, 0, len(v))
-		for k := range v {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		parts := make([]string, 0, len(keys))
-		for _, k := range keys {
-			parts = append(parts, k+":"+stringify(v[k]))
-		}
-		return "map[" + strings.Join(parts, " ") + "]"
+		return string(res)
 	default:
 		return fmt.Sprintf("%v", v)
 	}

--- a/router/batchrouter/asyncdestinationmanager/common/utils_test.go
+++ b/router/batchrouter/asyncdestinationmanager/common/utils_test.go
@@ -20,6 +20,10 @@ func TestFormatCSVValue(t *testing.T) {
 		{name: "negative int float", input: float64(-42), expected: "-42"},
 		{name: "large int float never goes scientific", input: float64(1234567890), expected: "1234567890"},
 		{name: "very large int float never goes scientific", input: float64(9876543210), expected: "9876543210"},
+		// float64 only has ~15-16 digits of precision; an 18-digit literal loses
+		// the low digits when stored as float64. The point of this case is to
+		// verify the formatter never emits scientific notation at that scale.
+		{name: "18-digit numeric does not render in scientific notation", input: float64(123456789012345678), expected: "123456789012345680"},
 		{name: "small fractional float preserved", input: 0.1, expected: "0.1"},
 		{name: "fractional float preserved", input: 1234.5, expected: "1234.5"},
 		{name: "empty array", input: []any{}, expected: "[]"},
@@ -60,7 +64,9 @@ func TestFormatCSVValue(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tc.expected, FormatCSVValue(tc.input))
+			got, err := FormatCSVValue(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
 		})
 	}
 }

--- a/router/batchrouter/asyncdestinationmanager/common/utils_test.go
+++ b/router/batchrouter/asyncdestinationmanager/common/utils_test.go
@@ -1,0 +1,61 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatCSVValue(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{name: "nil top-level becomes empty cell", input: nil, expected: ""},
+		{name: "string passthrough", input: "hello", expected: "hello"},
+		{name: "bool passthrough", input: true, expected: "true"},
+		{name: "small int float renders without exponent", input: float64(1), expected: "1"},
+		{name: "negative int float", input: float64(-42), expected: "-42"},
+		{name: "large int float never goes scientific", input: float64(1234567890), expected: "1234567890"},
+		{name: "very large int float never goes scientific", input: float64(9876543210), expected: "9876543210"},
+		{name: "small fractional float preserved", input: 0.1, expected: "0.1"},
+		{name: "fractional float preserved", input: 1234.5, expected: "1234.5"},
+		{name: "empty array", input: []any{}, expected: "[]"},
+		{name: "string array", input: []any{"a", "b"}, expected: "[a b]"},
+		{
+			name:     "array of large numbers without exponent",
+			input:    []any{float64(1234567890), float64(9876543210)},
+			expected: "[1234567890 9876543210]",
+		},
+		{
+			name:     "mixed array with nil retains <nil> for nested null",
+			input:    []any{float64(1234567890), "abc", nil, true},
+			expected: "[1234567890 abc <nil> true]",
+		},
+		{
+			name:     "nested array",
+			input:    []any{[]any{float64(1), float64(2)}, []any{float64(3), float64(4)}},
+			expected: "[[1 2] [3 4]]",
+		},
+		{name: "empty map", input: map[string]any{}, expected: "map[]"},
+		{
+			name:     "map with large numeric value",
+			input:    map[string]any{"id": float64(1234567890)},
+			expected: "map[id:1234567890]",
+		},
+		{
+			name:     "map keys sorted deterministically",
+			input:    map[string]any{"b": float64(2), "a": float64(1)},
+			expected: "map[a:1 b:2]",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, FormatCSVValue(tc.input))
+		})
+	}
+}

--- a/router/batchrouter/asyncdestinationmanager/common/utils_test.go
+++ b/router/batchrouter/asyncdestinationmanager/common/utils_test.go
@@ -23,32 +23,37 @@ func TestFormatCSVValue(t *testing.T) {
 		{name: "small fractional float preserved", input: 0.1, expected: "0.1"},
 		{name: "fractional float preserved", input: 1234.5, expected: "1234.5"},
 		{name: "empty array", input: []any{}, expected: "[]"},
-		{name: "string array", input: []any{"a", "b"}, expected: "[a b]"},
+		{name: "string array", input: []any{"a", "b"}, expected: "[\"a\",\"b\"]"},
 		{
 			name:     "array of large numbers without exponent",
 			input:    []any{float64(1234567890), float64(9876543210)},
-			expected: "[1234567890 9876543210]",
+			expected: "[1234567890,9876543210]",
 		},
 		{
-			name:     "mixed array with nil retains <nil> for nested null",
+			name:     "mixed array with nil renders as JSON null",
 			input:    []any{float64(1234567890), "abc", nil, true},
-			expected: "[1234567890 abc <nil> true]",
+			expected: "[1234567890,\"abc\",null,true]",
 		},
 		{
 			name:     "nested array",
 			input:    []any{[]any{float64(1), float64(2)}, []any{float64(3), float64(4)}},
-			expected: "[[1 2] [3 4]]",
+			expected: "[[1,2],[3,4]]",
 		},
-		{name: "empty map", input: map[string]any{}, expected: "map[]"},
+		{name: "empty map", input: map[string]any{}, expected: "{}"},
 		{
 			name:     "map with large numeric value",
 			input:    map[string]any{"id": float64(1234567890)},
-			expected: "map[id:1234567890]",
+			expected: "{\"id\":1234567890}",
 		},
 		{
 			name:     "map keys sorted deterministically",
 			input:    map[string]any{"b": float64(2), "a": float64(1)},
-			expected: "map[a:1 b:2]",
+			expected: "{\"a\":1,\"b\":2}",
+		},
+		{
+			name:     "map keys with null values",
+			input:    map[string]any{"b": float64(2), "a": float64(1), "c": nil},
+			expected: "{\"a\":1,\"b\":2,\"c\":null}",
 		},
 	}
 

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
@@ -104,11 +104,11 @@ func createCSVFile(
 		row := make([]string, len(headers))
 		for key, value := range job.Message {
 			if idx, ok := headerIndex[key]; ok {
-				formatted, err := common.FormatCSVValue(value)
+				formattedValue, err := common.FormatCSVValue(value)
 				if err != nil {
 					return "", nil, nil, fmt.Errorf("formatting CSV cell %q: %w", key, err)
 				}
-				row[idx] = formatted
+				row[idx] = formattedValue
 			}
 		}
 		jobID := int64(job.Metadata["job_id"].(float64))

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
@@ -104,7 +104,7 @@ func createCSVFile(
 		row := make([]string, len(headers))
 		for key, value := range job.Message {
 			if idx, ok := headerIndex[key]; ok {
-				row[idx] = fmt.Sprintf("%v", value)
+				row[idx] = common.FormatCSVValue(value)
 			}
 		}
 		jobID := int64(job.Metadata["job_id"].(float64))

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
@@ -104,7 +104,11 @@ func createCSVFile(
 		row := make([]string, len(headers))
 		for key, value := range job.Message {
 			if idx, ok := headerIndex[key]; ok {
-				row[idx] = common.FormatCSVValue(value)
+				formatted, err := common.FormatCSVValue(value)
+				if err != nil {
+					return "", nil, nil, fmt.Errorf("formatting CSV cell %q: %w", key, err)
+				}
+				row[idx] = formatted
 			}
 		}
 		jobID := int64(job.Metadata["job_id"].(float64))

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
@@ -3,6 +3,7 @@ package salesforcebulkupload
 import (
 	"encoding/csv"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -363,6 +364,116 @@ func TestSalesforceBulk_calculateHashFromRecord_Integration(t *testing.T) {
 		require.NotEqual(t, hash1, hash2,
 			"Different records should produce different hashes")
 	})
+}
+
+func TestSalesforceBulk_createCSVFile_NumericNoScientificNotation(t *testing.T) {
+	t.Parallel()
+	jobs := []common.AsyncJob{
+		{
+			Message: map[string]any{
+				"Email":          "user@example.com",
+				"Account_Number": float64(1234567890),
+				"Account_IDs":    []any{float64(1234567890), float64(9876543210)},
+			},
+			Metadata: map[string]any{"job_id": float64(1)},
+		},
+	}
+
+	csvFilePath, headers, _, err := createCSVFile("test-dest-numeric", jobs)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(csvFilePath) })
+
+	file, err := os.Open(csvFilePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+
+	records, err := csv.NewReader(file).ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+
+	row := records[1]
+	require.Equal(t, "1234567890", row[indexOf(headers, "Account_Number")])
+	require.Equal(t, "[1234567890 9876543210]", row[indexOf(headers, "Account_IDs")])
+}
+
+func TestSalesforceBulk_createCSVFile_NullValues(t *testing.T) {
+	jobs := []common.AsyncJob{
+		{
+			Message: map[string]any{
+				"Email":     "middle@example.com",
+				"FirstName": "Mid",
+				"LastName":  nil,
+				"Phone":     "555-0001",
+			},
+			Metadata: map[string]any{"job_id": float64(1)},
+		},
+		{
+			Message: map[string]any{
+				"Email":     "trailing@example.com",
+				"FirstName": "End",
+				"LastName":  "User",
+				"Phone":     nil,
+			},
+			Metadata: map[string]any{"job_id": float64(2)},
+		},
+	}
+
+	csvFilePath, headers, _, err := createCSVFile("test-dest-null", jobs)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(csvFilePath) })
+
+	require.Equal(t, []string{"Email", "FirstName", "LastName", "Phone"}, headers)
+
+	raw, err := os.ReadFile(csvFilePath)
+	require.NoError(t, err)
+	rawStr := string(raw)
+
+	file, err := os.Open(csvFilePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+
+	records, err := csv.NewReader(file).ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 3)
+
+	emailIdx := indexOf(records[0], "Email")
+	rowByEmail := func(email string) []string {
+		for _, r := range records[1:] {
+			if r[emailIdx] == email {
+				return r
+			}
+		}
+		t.Fatalf("row with email %q not found", email)
+		return nil
+	}
+
+	middle := rowByEmail("middle@example.com")
+	require.Equal(t, "", middle[indexOf(headers, "LastName")], "null in middle field should be empty cell")
+	require.Equal(t, "555-0001", middle[indexOf(headers, "Phone")])
+
+	trailing := rowByEmail("trailing@example.com")
+	require.Equal(t, "User", trailing[indexOf(headers, "LastName")])
+	require.Equal(t, "", trailing[indexOf(headers, "Phone")], "null in trailing field should be empty cell")
+
+	lines := strings.Split(strings.TrimRight(rawStr, "\n"), "\n")
+	require.Len(t, lines, 3)
+	for _, line := range lines[1:] {
+		if strings.HasPrefix(line, "middle@example.com") {
+			require.Contains(t, line, ",,", "middle null should serialize as `,,`")
+		}
+		if strings.HasPrefix(line, "trailing@example.com") {
+			require.True(t, strings.HasSuffix(line, ","), "trailing null should serialize as a trailing comma; got %q", line)
+		}
+	}
+}
+
+func indexOf(s []string, target string) int {
+	for i, v := range s {
+		if v == target {
+			return i
+		}
+	}
+	return -1
 }
 
 func TestSalesforceBulk_createCSVFile_VaryingFields(t *testing.T) {

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
@@ -393,7 +393,7 @@ func TestSalesforceBulk_createCSVFile_NumericNoScientificNotation(t *testing.T) 
 
 	row := records[1]
 	require.Equal(t, "1234567890", row[indexOf(headers, "Account_Number")])
-	require.Equal(t, "[1234567890 9876543210]", row[indexOf(headers, "Account_IDs")])
+	require.Equal(t, "[1234567890,9876543210]", row[indexOf(headers, "Account_IDs")])
 }
 
 func TestSalesforceBulk_createCSVFile_NullValues(t *testing.T) {

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
@@ -3,7 +3,6 @@ package salesforcebulkupload
 import (
 	"encoding/csv"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -379,7 +378,7 @@ func TestSalesforceBulk_createCSVFile_NumericNoScientificNotation(t *testing.T) 
 		},
 	}
 
-	csvFilePath, headers, _, err := createCSVFile("test-dest-numeric", jobs)
+	csvFilePath, _, _, err := createCSVFile("test-dest-numeric", jobs)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Remove(csvFilePath) })
 
@@ -390,10 +389,8 @@ func TestSalesforceBulk_createCSVFile_NumericNoScientificNotation(t *testing.T) 
 	records, err := csv.NewReader(file).ReadAll()
 	require.NoError(t, err)
 	require.Len(t, records, 2)
-
-	row := records[1]
-	require.Equal(t, "1234567890", row[indexOf(headers, "Account_Number")])
-	require.Equal(t, "[1234567890,9876543210]", row[indexOf(headers, "Account_IDs")])
+	require.Equal(t, []string{"Account_IDs", "Account_Number", "Email"}, records[0])
+	require.Equal(t, []string{"[1234567890,9876543210]", "1234567890", "user@example.com"}, records[1])
 }
 
 func TestSalesforceBulk_createCSVFile_NullValues(t *testing.T) {
@@ -418,15 +415,9 @@ func TestSalesforceBulk_createCSVFile_NullValues(t *testing.T) {
 		},
 	}
 
-	csvFilePath, headers, _, err := createCSVFile("test-dest-null", jobs)
+	csvFilePath, _, _, err := createCSVFile("test-dest-null", jobs)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Remove(csvFilePath) })
-
-	require.Equal(t, []string{"Email", "FirstName", "LastName", "Phone"}, headers)
-
-	raw, err := os.ReadFile(csvFilePath)
-	require.NoError(t, err)
-	rawStr := string(raw)
 
 	file, err := os.Open(csvFilePath)
 	require.NoError(t, err)
@@ -435,45 +426,9 @@ func TestSalesforceBulk_createCSVFile_NullValues(t *testing.T) {
 	records, err := csv.NewReader(file).ReadAll()
 	require.NoError(t, err)
 	require.Len(t, records, 3)
-
-	emailIdx := indexOf(records[0], "Email")
-	rowByEmail := func(email string) []string {
-		for _, r := range records[1:] {
-			if r[emailIdx] == email {
-				return r
-			}
-		}
-		t.Fatalf("row with email %q not found", email)
-		return nil
-	}
-
-	middle := rowByEmail("middle@example.com")
-	require.Equal(t, "", middle[indexOf(headers, "LastName")], "null in middle field should be empty cell")
-	require.Equal(t, "555-0001", middle[indexOf(headers, "Phone")])
-
-	trailing := rowByEmail("trailing@example.com")
-	require.Equal(t, "User", trailing[indexOf(headers, "LastName")])
-	require.Equal(t, "", trailing[indexOf(headers, "Phone")], "null in trailing field should be empty cell")
-
-	lines := strings.Split(strings.TrimRight(rawStr, "\n"), "\n")
-	require.Len(t, lines, 3)
-	for _, line := range lines[1:] {
-		if strings.HasPrefix(line, "middle@example.com") {
-			require.Contains(t, line, ",,", "middle null should serialize as `,,`")
-		}
-		if strings.HasPrefix(line, "trailing@example.com") {
-			require.True(t, strings.HasSuffix(line, ","), "trailing null should serialize as a trailing comma; got %q", line)
-		}
-	}
-}
-
-func indexOf(s []string, target string) int {
-	for i, v := range s {
-		if v == target {
-			return i
-		}
-	}
-	return -1
+	require.Equal(t, []string{"Email", "FirstName", "LastName", "Phone"}, records[0])
+	require.Equal(t, []string{"middle@example.com", "Mid", "", "555-0001"}, records[1])
+	require.Equal(t, []string{"trailing@example.com", "End", "User", ""}, records[2])
 }
 
 func TestSalesforceBulk_createCSVFile_VaryingFields(t *testing.T) {


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.28.0

# Description

Fixes two CSV-formatting bugs in the Salesforce Bulk Upload destination that surfaced for Fullscript while integrating against the Salesforce Bulk API.

**Bug 1 — null values rendered as `<nil>`.** A trait whose JSON value was `null` arrived in the CSV as the literal four-character string `<nil>`, because `fmt.Sprintf("%v", nil)` is what the writer was using. Salesforce treats this as a real text value rather than a null, polluting target fields and breaking validation rules. The fix renders top-level nulls as empty cells, which Salesforce treats as null/unset:

```
value1,,value3        // null in the middle field
value1,value2,        // null in the trailing field
```

**Bug 2 — numeric values rendered in scientific notation.** Because every JSON number lands in Go as `float64` and `%v` falls back to `%g`, any integer-valued number with more than ~6 significant digits switched to scientific notation. So a phone number `1234567890` was being uploaded as `1.23456789e+09`, and an array of IDs as `[1.23456789e+09 9.87654321e+09]`. The fix uses `strconv.FormatFloat(v, 'f', -1, 64)` for floats — same round-trip precision guarantee, never scientific notation. Arrays and maps are emitted as JSON via `jsonrs.Marshal`, so nested numbers also stay plain and nested nulls render as `null` instead of `<nil>`.

The formatter (`FormatCSVValue`) lives in `router/batchrouter/asyncdestinationmanager/common` so other async destinations (Bing Ads, Lytics, Marketo, SFTP, Snowpipe discards) that exhibit the same pattern can adopt it in follow-ups.

## Changes

- New `common.FormatCSVValue` helper that:
  - returns `""` for top-level nil so CSV cells become empty
  - formats `float64` via `strconv.FormatFloat(_, 'f', -1, 64)` to avoid scientific notation
  - emits `[]any` and `map[string]any` as JSON via `jsonrs.Marshal` (e.g. `[1234567890,9876543210]`, `{"id":1234567890,"name":"foo"}`); falls back to `fmt.Sprintf("%v", v)` if marshalling fails
  - falls through to `fmt.Sprintf("%v", v)` for every other type so existing primitives (string, bool) are byte-identical
- Salesforce Bulk's `createCSVFile` now routes every cell through `common.FormatCSVValue`
- New unit tests for the helper (`common/utils_test.go`) and end-to-end CSV tests for null cells and numeric cells (`salesforce-bulk-upload/utils_test.go`)

## Behavior change for arrays and maps

Composite values are now serialized as JSON instead of Go's default `fmt.Sprintf("%v", …)` shape:

| Input | Before | After |
|---|---|---|
| `["Go", "Python"]` | `[Go Python]` | `["Go","Python"]` |
| `[1234567890, 9876543210]` | `[1.23456789e+09 9.87654321e+09]` | `[1234567890,9876543210]` |
| `{"id": 1234567890}` | `map[id:1.23456789e+09]` | `{"id":1234567890}` |

Primitive cells (strings, bools, small ints, fractional floats) and null cells are byte-identical to the old output where it was already correct.

The hash-based job-to-record matching in `matchRecordsToJobs` is unaffected because Salesforce echoes the exact CSV cell back in success/failure records — both sides of the hash change together, and `dataHashToJobID` has no cross-run state.

## Linear Ticket

[INT-6278 — Salesforce bulk upload: Fix null and array formatting](https://linear.app/rudderstack/issue/INT-6278/salesforce-bulk-upload-fix-null-and-array-formatting)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
