### PR TITLE
feat: snowpipe batch status

### DIFF
--- a/integration_test/snowpipestreaming/snowpipestreaming_test.go
+++ b/integration_test/snowpipestreaming/snowpipestreaming_test.go
@@ -799,6 +799,99 @@ func TestSnowpipeStreaming(t *testing.T) {
 		cancel()
 		require.NoError(t, <-done)
 	})
+
+	t.Run("many table (bulk status enabled)", func(t *testing.T) {
+		postgresContainer, gatewayPort := initializeTestEnvironment(t)
+		namespace := testhelper.RandSchema()
+		backendConfigServer, source, destination := setupBackendConfigTestServer(t, credentials, namespace)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error)
+		go func() {
+			defer close(done)
+			configOverrides := []lo.Tuple2[string, any]{
+				{A: "SnowpipeStreaming.bulkStatusEnabled", B: true},
+			}
+			done <- runRudderServer(ctx, cancel, gatewayPort, postgresContainer, backendConfigServer.URL, transformerURL, snowpipeClientsURL, t.TempDir(), configOverrides...)
+		}()
+
+		url := fmt.Sprintf("http://localhost:%d", gatewayPort)
+		health.WaitUntilReady(ctx, t, url+"/health", 60*time.Second, 10*time.Millisecond, t.Name())
+
+		warehouse := whutils.ModelWarehouse{
+			Namespace:   namespace,
+			Destination: destination,
+		}
+
+		t.Log("Creating schema and tables")
+		sm := snowflake.New(config.New(), logger.NOP, stats.NOP)
+		require.NoError(t, sm.Setup(ctx, warehouse, whutils.NewNoOpUploader()))
+		t.Cleanup(func() { sm.Cleanup(ctx) })
+		require.NoError(t, sm.CreateSchema(ctx))
+		t.Cleanup(func() { testhelper.DropSchema(t, sm.DB.DB, namespace) })
+
+		for i := range 10 {
+			eventFormat := func(int) string {
+				return fmt.Sprintf(`{"batch":[{"type":"track","userId":"%[1]s","event":"Product Reviewed %[1]s","properties":{"review_id":"86ac1cd43","product_id":"9578257311","rating":3,"review_body":"OK for the price. It works but the material feels flimsy."}, "timestamp":"2020-02-02T00:23:09.544Z","sentAt":"2020-02-02T00:23:09.544Z","originalTimestamp":"2020-02-02T00:23:09.544Z","receivedAt":"2020-02-02T00:23:09.544Z", "context":{"ip":"14.5.67.21"}}]}`,
+					strconv.Itoa(i+1),
+				)
+			}
+			require.NoError(t, sendEvents(5, eventFormat, "writekey1", url))
+		}
+
+		requireGatewayJobsCount(t, ctx, postgresContainer.DB, "succeeded", 5*10)
+		requireBatchRouterJobsCount(t, ctx, postgresContainer.DB, "succeeded", 2*5*10)
+
+		schema := whth.RetrieveRecordsFromWarehouse(t, sm.DB.DB, fmt.Sprintf(`SELECT table_name, column_name, data_type FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = '%s';`, namespace))
+		expectedSchema := lo.SliceToMap(
+			lo.RepeatBy(10, func(index int) string {
+				return "PRODUCT_REVIEWED_" + strconv.Itoa(index+1)
+			}),
+			func(tableName string) (string, map[string]string) {
+				return tableName, map[string]string{"CONTEXT_DESTINATION_ID": "TEXT", "CONTEXT_DESTINATION_TYPE": "TEXT", "CONTEXT_IP": "TEXT", "CONTEXT_REQUEST_IP": "TEXT", "CONTEXT_PASSED_IP": "TEXT", "CONTEXT_SOURCE_ID": "TEXT", "CONTEXT_SOURCE_TYPE": "TEXT", "EVENT": "TEXT", "EVENT_TEXT": "TEXT", "ID": "TEXT", "ORIGINAL_TIMESTAMP": "TIMESTAMP_TZ", "PRODUCT_ID": "TEXT", "RATING": "NUMBER", "RECEIVED_AT": "TIMESTAMP_TZ", "REVIEW_BODY": "TEXT", "REVIEW_ID": "TEXT", "SENT_AT": "TIMESTAMP_TZ", "TIMESTAMP": "TIMESTAMP_TZ", "USER_ID": "TEXT", "UUID_TS": "TIMESTAMP_TZ"}
+			},
+		)
+		expectedSchema = lo.Assign(expectedSchema, map[string]map[string]string{
+			"TRACKS":          {"CONTEXT_DESTINATION_ID": "TEXT", "CONTEXT_DESTINATION_TYPE": "TEXT", "CONTEXT_IP": "TEXT", "CONTEXT_REQUEST_IP": "TEXT", "CONTEXT_PASSED_IP": "TEXT", "CONTEXT_SOURCE_ID": "TEXT", "CONTEXT_SOURCE_TYPE": "TEXT", "EVENT": "TEXT", "EVENT_TEXT": "TEXT", "ID": "TEXT", "ORIGINAL_TIMESTAMP": "TIMESTAMP_TZ", "RECEIVED_AT": "TIMESTAMP_TZ", "SENT_AT": "TIMESTAMP_TZ", "TIMESTAMP": "TIMESTAMP_TZ", "USER_ID": "TEXT", "UUID_TS": "TIMESTAMP_TZ"},
+			"RUDDER_DISCARDS": {"COLUMN_NAME": "TEXT", "COLUMN_VALUE": "TEXT", "REASON": "TEXT", "RECEIVED_AT": "TIMESTAMP_TZ", "ROW_ID": "TEXT", "TABLE_NAME": "TEXT", "UUID_TS": "TIMESTAMP_TZ"},
+		})
+		require.Equal(t, expectedSchema, convertRecordsToSchema(schema))
+
+		for i := range 10 {
+			productIDIndex := i + 1
+			userID := strconv.Itoa(productIDIndex)
+			eventName := "Product Reviewed " + strconv.Itoa(productIDIndex)
+			tableName := strcase.ToSnake(eventName)
+			recordsFromDB := whth.RetrieveRecordsFromWarehouse(t, sm.DB.DB, fmt.Sprintf(`SELECT CONTEXT_DESTINATION_ID, CONTEXT_DESTINATION_TYPE, CONTEXT_SOURCE_ID, CONTEXT_SOURCE_TYPE, EVENT, EVENT_TEXT, ORIGINAL_TIMESTAMP, PRODUCT_ID, RATING, TO_CHAR(RECEIVED_AT, 'YYYY-MM-DD'), REVIEW_BODY, REVIEW_ID, SENT_AT, TIMESTAMP, USER_ID, TO_CHAR(UUID_TS, 'YYYY-MM-DD') FROM %q.%q;`, namespace, "PRODUCT_REVIEWED_"+strconv.Itoa(productIDIndex)))
+			ts := timeutil.Now().Format("2006-01-02")
+
+			expectedProductReviewedRecords := [][]string{
+				{destination.ID, "SNOWPIPE_STREAMING", source.ID, source.SourceDefinition.Name, tableName, eventName, "2020-02-02T00:23:09Z", "9578257311", "3", ts, "OK for the price. It works but the material feels flimsy.", "86ac1cd43", "2020-02-02T00:23:09Z", "2020-02-02T00:23:09Z", userID, ts},
+				{destination.ID, "SNOWPIPE_STREAMING", source.ID, source.SourceDefinition.Name, tableName, eventName, "2020-02-02T00:23:09Z", "9578257311", "3", ts, "OK for the price. It works but the material feels flimsy.", "86ac1cd43", "2020-02-02T00:23:09Z", "2020-02-02T00:23:09Z", userID, ts},
+				{destination.ID, "SNOWPIPE_STREAMING", source.ID, source.SourceDefinition.Name, tableName, eventName, "2020-02-02T00:23:09Z", "9578257311", "3", ts, "OK for the price. It works but the material feels flimsy.", "86ac1cd43", "2020-02-02T00:23:09Z", "2020-02-02T00:23:09Z", userID, ts},
+				{destination.ID, "SNOWPIPE_STREAMING", source.ID, source.SourceDefinition.Name, tableName, eventName, "2020-02-02T00:23:09Z", "9578257311", "3", ts, "OK for the price. It works but the material feels flimsy.", "86ac1cd43", "2020-02-02T00:23:09Z", "2020-02-02T00:23:09Z", userID, ts},
+				{destination.ID, "SNOWPIPE_STREAMING", source.ID, source.SourceDefinition.Name, tableName, eventName, "2020-02-02T00:23:09Z", "9578257311", "3", ts, "OK for the price. It works but the material feels flimsy.", "86ac1cd43", "2020-02-02T00:23:09Z", "2020-02-02T00:23:09Z", userID, ts},
+			}
+			require.ElementsMatch(t, expectedProductReviewedRecords, recordsFromDB)
+		}
+
+		trackRecordsFromDB := whth.RetrieveRecordsFromWarehouse(t, sm.DB.DB, fmt.Sprintf(`SELECT CONTEXT_DESTINATION_ID, CONTEXT_DESTINATION_TYPE, CONTEXT_SOURCE_ID, CONTEXT_SOURCE_TYPE, EVENT, EVENT_TEXT, ORIGINAL_TIMESTAMP, TO_CHAR(RECEIVED_AT, 'YYYY-MM-DD'), SENT_AT, TIMESTAMP, USER_ID, TO_CHAR(UUID_TS, 'YYYY-MM-DD') FROM %q.%q;`, namespace, "TRACKS"))
+		expectedTrackRecords := lo.RepeatBy(50, func(index int) []string {
+			productIDIndex := index/5 + 1
+			userID := strconv.Itoa(productIDIndex)
+			eventName := "Product Reviewed " + strconv.Itoa(productIDIndex)
+			tableName := strcase.ToSnake(eventName)
+			ts := timeutil.Now().Format("2006-01-02")
+
+			return []string{destination.ID, "SNOWPIPE_STREAMING", source.ID, source.SourceDefinition.Name, tableName, eventName, "2020-02-02T00:23:09Z", ts, "2020-02-02T00:23:09Z", "2020-02-02T00:23:09Z", userID, ts}
+		})
+		require.ElementsMatch(t, expectedTrackRecords, trackRecordsFromDB)
+
+		cancel()
+		require.NoError(t, <-done)
+	})
 	t.Run("schema modified after channel creation (schema deleted)", func(t *testing.T) {
 		postgresContainer, gatewayPort := initializeTestEnvironment(t)
 		namespace := testhelper.RandSchema()
@@ -1408,6 +1501,7 @@ func runRudderServer(
 	postgresContainer *postgres.Resource,
 	cbURL, transformerURL, snowpipeClientsURL,
 	tmpDir string,
+	configOverrides ...lo.Tuple2[string, any],
 ) (err error) {
 	config.Set("INSTANCE_ID", "1")
 	config.Set("CONFIG_BACKEND_URL", cbURL)
@@ -1442,6 +1536,9 @@ func runRudderServer(
 	config.Set("recovery.enabled", false)
 	config.Set("Profiler.Enabled", false)
 	config.Set("Gateway.enableSuppressUserFeature", false)
+	for _, override := range configOverrides {
+		config.Set(override.A, override.B)
+	}
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/apiadapter.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/apiadapter.go
@@ -16,6 +16,7 @@ const (
 	deleteChannelAPI = "delete_channel"
 	insertAPI        = "insert"
 	statusAPI        = "status"
+	bulkStatusAPI    = "bulk_status"
 )
 
 func newApiAdapter(
@@ -122,6 +123,21 @@ func (a *apiAdapter) GetStatus(ctx context.Context, channelID string) (*model.St
 	defer a.recordDuration(tags)()
 
 	resp, err := a.api.GetStatus(ctx, channelID)
+	if err != nil {
+		tags["success"] = "false"
+		return nil, err
+	}
+	tags["success"] = strconv.FormatBool(resp.Success)
+	return resp, nil
+}
+
+func (a *apiAdapter) GetBulkStatus(ctx context.Context, channelIDs []string) (*model.BulkStatusResponse, error) {
+	a.logger.Debugn("Getting bulk status", logger.NewIntField("channelCount", int64(len(channelIDs))))
+
+	tags := a.defaultTags(bulkStatusAPI)
+	defer a.recordDuration(tags)()
+
+	resp, err := a.api.GetBulkStatus(ctx, channelIDs)
 	if err != nil {
 		tags["success"] = "false"
 		return nil, err

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/api/api.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/api/api.go
@@ -229,6 +229,39 @@ func (a *API) GetStatus(ctx context.Context, channelID string) (*model.StatusRes
 	}
 }
 
+// GetBulkStatus retrieves statuses for the given channel IDs.
+func (a *API) GetBulkStatus(ctx context.Context, channelIDs []string) (*model.BulkStatusResponse, error) {
+	bulkStatusURL := a.clientURL + "/channels/bulk-status"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bulkStatusURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating bulk status request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	queryParams := req.URL.Query()
+	for _, channelID := range channelIDs {
+		queryParams.Add("channelIds", channelID)
+	}
+	req.URL.RawQuery = queryParams.Encode()
+
+	resp, reqErr := a.requestDoer.Do(req)
+	if reqErr != nil {
+		return nil, fmt.Errorf("sending bulk status request: %w", reqErr)
+	}
+	defer func() { httputil.CloseResponse(resp) }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("invalid status code for bulk status: %d, body: %s", resp.StatusCode, string(mustRead(resp.Body)))
+	}
+
+	var res model.BulkStatusResponse
+	if err := jsonrs.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return nil, fmt.Errorf("decoding bulk status response: %w", err)
+	}
+	return &res, nil
+}
+
 func gzippedReader(reqJSON []byte) (io.Reader, int, error) {
 	var b bytes.Buffer
 	gz := gzip.NewWriter(&b)

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/api/api_integration_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/api/api_integration_test.go
@@ -49,7 +49,7 @@ func TestAPIIntegration(t *testing.T) {
 		}
 	}
 
-	t.Run("Create channel + Get channel + Insert data + Status", func(t *testing.T) {
+	t.Run("Create channel + Get channel + Insert data + Status/Bulk status", func(t *testing.T) {
 		testCases := []struct {
 			name              string
 			enableCompression bool
@@ -128,6 +128,16 @@ func TestAPIIntegration(t *testing.T) {
 					30*time.Second,
 					300*time.Millisecond,
 				)
+
+				t.Log("Checking bulk status")
+				require.Eventually(t, func() bool {
+					bulkStatusRes, err := snowpipeAPI.GetBulkStatus(ctx, []string{createChannelRes.ChannelID})
+					if err != nil {
+						t.Log("Error getting bulk status:", err)
+						return false
+					}
+					return bulkStatusRes.Statuses[createChannelRes.ChannelID].Offset == "8"
+				}, 30*time.Second, 300*time.Millisecond)
 
 				t.Log("Checking records in warehouse")
 				records := whth.RetrieveRecordsFromWarehouse(t, testConfig.db, fmt.Sprintf(`SELECT ID, NAME, EMAIL, AGE, ACTIVE, DOB FROM %q.%q ORDER BY ID;`, testConfig.namespace, testConfig.tableName))

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/api/api_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/api/api_test.go
@@ -459,4 +459,78 @@ func TestAPI(t *testing.T) {
 			require.Nil(t, res)
 		})
 	})
+
+	t.Run("Get Bulk Status", func(t *testing.T) {
+		snowpipeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodGet, r.Method)
+			require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			require.Equal(t, "/channels/bulk-status?channelIds=channel-id&channelIds=invalid-channel-id", r.URL.String())
+
+			_, err := w.Write([]byte(`{
+				"success": true,
+				"statuses": {
+					"channel-id": {"success": true, "offset": "5", "latestInsertedOffset": "5", "valid": true}
+				},
+				"notFound": ["invalid-channel-id"]
+			}`))
+			require.NoError(t, err)
+		}))
+		defer snowpipeServer.Close()
+
+		ctx := context.Background()
+		manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, snowpipeServer.Client())
+
+		t.Run("Success", func(t *testing.T) {
+			res, err := manager.GetBulkStatus(ctx, []string{"channel-id", "invalid-channel-id"})
+			require.NoError(t, err)
+			require.Equal(t, &model.BulkStatusResponse{
+				Success: true,
+				Statuses: map[string]*model.StatusResponse{
+					"channel-id": {
+						Success:              true,
+						Offset:               "5",
+						LatestInsertedOffset: "5",
+						Valid:                true,
+					},
+				},
+				NotFound: []string{"invalid-channel-id"},
+			}, res)
+		})
+
+		t.Run("Request failure", func(t *testing.T) {
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+				err: errors.New("bad client"),
+				response: &http.Response{
+					StatusCode: http.StatusOK,
+				},
+			})
+			res, err := manager.GetBulkStatus(ctx, []string{"channel-id"})
+			require.Error(t, err)
+			require.Nil(t, res)
+		})
+
+		t.Run("Request failure (non 200's status code)", func(t *testing.T) {
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+				response: &http.Response{
+					StatusCode: http.StatusBadRequest,
+					Body:       nopReadCloser{Reader: bytes.NewReader([]byte(`{}`))},
+				},
+			})
+			res, err := manager.GetBulkStatus(ctx, []string{"channel-id"})
+			require.Error(t, err)
+			require.Nil(t, res)
+		})
+
+		t.Run("Request failure (invalid response)", func(t *testing.T) {
+			manager := api.New(config.New(), stats.NOP, snowpipeServer.URL, &mockRequestDoer{
+				response: &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       nopReadCloser{Reader: bytes.NewReader([]byte(`{abd}`))},
+				},
+			})
+			res, err := manager.GetBulkStatus(ctx, []string{"channel-id"})
+			require.Error(t, err)
+			require.Nil(t, res)
+		})
+	})
 }

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/model/model.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/internal/model/model.go
@@ -76,6 +76,12 @@ type (
 		Valid                bool   `json:"valid"`
 		LatestInsertedOffset string `json:"latestInsertedOffset"`
 	}
+
+	BulkStatusResponse struct {
+		Success  bool                       `json:"success"`
+		Statuses map[string]*StatusResponse `json:"statuses"`
+		NotFound []string                   `json:"notFound"`
+	}
 )
 
 func (c *ChannelResponse) UnmarshalJSON(data []byte) error {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -74,7 +74,7 @@ func New(
 	m.config.maxBufferCapacity = conf.GetReloadableInt64Var(512*bytesize.KB, bytesize.B, "SnowpipeStreaming.maxBufferCapacity")
 	m.config.stuckPipelineThreshold = conf.GetReloadableDurationVar(15, time.Minute, "SnowpipeStreaming.stuckPipelineThresholdInMinutes")
 	m.config.bulkStatusEnabled = conf.GetReloadableBoolVar(false, "SnowpipeStreaming.bulkStatusEnabled")
-	m.config.bulkStatusChannels = conf.GetReloadableIntVar(100, 1, "SnowpipeStreaming.bulkStatusChannels")
+	m.config.bulkStatusBatchSize = conf.GetReloadableIntVar(100, 1, "SnowpipeStreaming.bulkStatusBatchSize")
 
 	tags := stats.Tags{
 		"module":        "batch_router",
@@ -847,9 +847,10 @@ func isInProgress(statusRes *model.StatusResponse, info *importInfo, log logger.
 
 func (m *Manager) getBulkStatus(ctx context.Context, channelIDs []string) (map[string]*model.StatusResponse, []string, error) {
 	statuses := make(map[string]*model.StatusResponse)
-	notFound := make([]string, 0)
 
-	channelIDChunks := lo.Chunk(channelIDs, m.config.bulkStatusChannels.Load())
+	var notFound []string
+
+	channelIDChunks := lo.Chunk(channelIDs, m.config.bulkStatusBatchSize.Load())
 	for i := range channelIDChunks {
 		channelIDChunk := channelIDChunks[i]
 		bulkStatusRes, err := m.api.GetBulkStatus(ctx, channelIDChunk)
@@ -872,20 +873,14 @@ func (m *Manager) getNonProcessedImportInfosWithBulkStatus(ctx context.Context, 
 
 	statuses, notFound, err := m.getBulkStatus(ctx, channelIDs)
 	if err != nil {
-		for i := range infos {
-			info := infos[i]
-			info.FailedJobIds = nil
-			info.Failed = true
-			info.Reason = err.Error()
-			m.polledImportInfoMap[info.ChannelID] = info
-		}
-		return nil
+		// In case of failure, we return all the import infos to be polled again
+		m.logger.Warnn("Failed to get bulk status", obskit.Error(err))
+		return infos
 	}
 
-	notFoundMap := make(map[string]struct{}, len(notFound))
-	for _, channelID := range notFound {
-		notFoundMap[channelID] = struct{}{}
-	}
+	notFoundMap := lo.SliceToMap(notFound, func(channelID string) (string, struct{}) {
+		return channelID, struct{}{}
+	})
 
 	var inProgressInfos []*importInfo
 
@@ -895,7 +890,7 @@ func (m *Manager) getNonProcessedImportInfosWithBulkStatus(ctx context.Context, 
 		info.Failed = false
 
 		if _, exists := notFoundMap[info.ChannelID]; exists {
-			recreatedStatusRes, recreateErr := m.handleChannelNotFoundPostBulkStatus(ctx, info)
+			recreatedStatusRes, recreateErr := m.handleChannelRecoveryPostBulkStatus(ctx, info, false)
 			if recreateErr != nil {
 				info.Failed = true
 				info.Reason = recreateErr.Error()
@@ -919,7 +914,7 @@ func (m *Manager) getNonProcessedImportInfosWithBulkStatus(ctx context.Context, 
 
 		statusRes := statuses[info.ChannelID]
 		if !statusRes.Valid {
-			recreatedStatusRes, recreateErr := m.handleInvalidStatusResponsePostBulkStatus(ctx, info)
+			recreatedStatusRes, recreateErr := m.handleChannelRecoveryPostBulkStatus(ctx, info, true)
 			if recreateErr != nil {
 				info.Failed = true
 				info.Reason = recreateErr.Error()
@@ -937,6 +932,12 @@ func (m *Manager) getNonProcessedImportInfosWithBulkStatus(ctx context.Context, 
 				inProgressInfos = append(inProgressInfos, info)
 				continue
 			}
+			m.polledImportInfoMap[info.ChannelID] = info
+			continue
+		}
+		if !statusRes.Success {
+			info.Failed = true
+			info.Reason = fmt.Sprintf("failed to get status with success: %t", statusRes.Success)
 			m.polledImportInfoMap[info.ChannelID] = info
 			continue
 		}
@@ -958,70 +959,20 @@ func (m *Manager) getNonProcessedImportInfosWithBulkStatus(ctx context.Context, 
 	return inProgressInfos
 }
 
-func (m *Manager) handleChannelNotFoundPostBulkStatus(ctx context.Context, info *importInfo) (*model.StatusResponse, error) {
+func (m *Manager) handleChannelRecoveryPostBulkStatus(ctx context.Context, info *importInfo, deleteChannel bool) (*model.StatusResponse, error) {
 	log := m.logger.Withn(
 		logger.NewStringField("channelId", info.ChannelID),
 		logger.NewStringField("expectedOffset", info.Offset),
 		logger.NewStringField("table", info.Table),
+		logger.NewStringField("deleteChannel", strconv.FormatBool(deleteChannel)),
 	)
-	log.Infon("Handling channel not found post bulk status")
+	log.Infon("Handling channel recovery post bulk status")
 
-	var destConf destConfig
-	if decodeErr := destConf.Decode(m.destination.Config); decodeErr != nil {
-		return nil, fmt.Errorf("failed to decode destination config during channel recreation: %w", decodeErr)
-	}
-
-	req := buildCreateChannelRequest(m.destination.ID, m.config.instanceID, &destConf, info.Table)
-	recreatedChannel, recreateErr := m.api.CreateChannel(ctx, req)
-	if recreateErr != nil {
-		return nil, fmt.Errorf("recreating channel: %w", recreateErr)
-	}
-	m.channelCache.Store(info.Table, recreatedChannel)
-
-	m.logger.Infon("Recreated channel for polling", logger.NewStringField("channelID", recreatedChannel.ChannelID))
-
-	// The new channel id is not being associated with the import info. This is because even if we do that,
-	// it will update the in memory map and not the database
-	// So the next time we poll, we will get the old channel id and not the new one
-
-	statuses, notFound, err := m.getBulkStatus(ctx, []string{recreatedChannel.ChannelID})
-	if err != nil {
-		return nil, fmt.Errorf("getting status after channel recreation: %w", err)
-	}
-	if len(notFound) > 0 {
-		return nil, fmt.Errorf("channel not found after recreation: %s", strings.Join(notFound, ","))
-	}
-
-	recreatedStatusRes, ok := statuses[recreatedChannel.ChannelID]
-	if !ok {
-		return nil, fmt.Errorf("channel not found after recreation: %s", recreatedChannel.ChannelID)
-	}
-
-	log.Infon("Polled import info after recreation post bulk status",
-		logger.NewBoolField("success", recreatedStatusRes.Success),
-		logger.NewStringField("latestCommittedOffset", recreatedStatusRes.Offset),
-		logger.NewStringField("latestInsertedOffset", recreatedStatusRes.LatestInsertedOffset),
-		logger.NewBoolField("valid", recreatedStatusRes.Valid),
-	)
-
-	if !recreatedStatusRes.Valid || !recreatedStatusRes.Success {
-		return nil, fmt.Errorf("invalid status response after recreation with valid: %t, success: %t", recreatedStatusRes.Valid, recreatedStatusRes.Success)
-	}
-
-	return recreatedStatusRes, nil
-}
-
-func (m *Manager) handleInvalidStatusResponsePostBulkStatus(ctx context.Context, info *importInfo) (*model.StatusResponse, error) {
-	log := m.logger.Withn(
-		logger.NewStringField("channelId", info.ChannelID),
-		logger.NewStringField("expectedOffset", info.Offset),
-		logger.NewStringField("table", info.Table),
-	)
-	log.Infon("Handling invalid status response post bulk status")
-
-	// Delete the channel from the cache and the Snowpipe as it is invalid
-	if err := m.deleteChannel(ctx, info.Table, info.ChannelID); err != nil {
-		log.Warnn("Failed to delete channel", logger.NewStringField("table", info.Table), logger.NewStringField("channelID", info.ChannelID), obskit.Error(err))
+	if deleteChannel {
+		// Delete the channel from the cache and the Snowpipe as it is invalid
+		if err := m.deleteChannel(ctx, info.Table, info.ChannelID); err != nil {
+			log.Warnn("Failed to delete channel", logger.NewStringField("table", info.Table), logger.NewStringField("channelID", info.ChannelID), obskit.Error(err))
+		}
 	}
 
 	var destConf destConfig

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -6,11 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"net/http"
 	"os"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -71,6 +73,8 @@ func New(
 	m.config.instanceID = conf.GetStringVar("1", "INSTANCE_ID")
 	m.config.maxBufferCapacity = conf.GetReloadableInt64Var(512*bytesize.KB, bytesize.B, "SnowpipeStreaming.maxBufferCapacity")
 	m.config.stuckPipelineThreshold = conf.GetReloadableDurationVar(15, time.Minute, "SnowpipeStreaming.stuckPipelineThresholdInMinutes")
+	m.config.bulkStatusEnabled = conf.GetReloadableBoolVar(false, "SnowpipeStreaming.bulkStatusEnabled")
+	m.config.bulkStatusChannels = conf.GetReloadableIntVar(100, 1, "SnowpipeStreaming.bulkStatusChannels")
 
 	tags := stats.Tags{
 		"module":        "batch_router",
@@ -646,14 +650,24 @@ func (m *Manager) Poll(_ context.Context, pollInput common.AsyncPoll) common.Pol
 // provideInProgressImportInfos provides the import infos that are in progress.
 // It also updates the polledImportInfoMap with the import infos when the import reaches the terminal state.
 func (m *Manager) provideInProgressImportInfos(ctx context.Context, infos []*importInfo) []*importInfo {
+	nonProcessedInfos := lo.Filter(infos, func(info *importInfo, _ int) bool {
+		_, alreadyProcessed := m.polledImportInfoMap[info.ChannelID]
+		return !alreadyProcessed
+	})
+	if len(nonProcessedInfos) == 0 {
+		return nil
+	}
+	if !m.config.bulkStatusEnabled.Load() {
+		return m.getNonProcessedImportInfos(ctx, nonProcessedInfos)
+	}
+	return m.getNonProcessedImportInfosWithBulkStatus(ctx, nonProcessedInfos)
+}
+
+func (m *Manager) getNonProcessedImportInfos(ctx context.Context, infos []*importInfo) []*importInfo {
 	var inProgressInfos []*importInfo
 
 	for i := range infos {
 		info := infos[i]
-
-		if _, alreadyProcessed := m.polledImportInfoMap[info.ChannelID]; alreadyProcessed {
-			continue
-		}
 		info.FailedJobIds = nil
 		info.Failed = false
 
@@ -829,6 +843,226 @@ func isInProgress(statusRes *model.StatusResponse, info *importInfo, log logger.
 	log.Warnn("Unexpected polling state encountered")
 	return false, fmt.Errorf("unexpected polling state encountered, latestCommittedOffset=%d, latestInsertedOffset=%d, expectedOffset=%d",
 		latestCommittedOffset, latestInsertedOffset, expectedOffset)
+}
+
+func (m *Manager) getBulkStatus(ctx context.Context, channelIDs []string) (map[string]*model.StatusResponse, []string, error) {
+	statuses := make(map[string]*model.StatusResponse)
+	notFound := make([]string, 0)
+
+	channelIDChunks := lo.Chunk(channelIDs, m.config.bulkStatusChannels.Load())
+	for i := range channelIDChunks {
+		channelIDChunk := channelIDChunks[i]
+		bulkStatusRes, err := m.api.GetBulkStatus(ctx, channelIDChunk)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get bulk status: %w", err)
+		}
+		if !bulkStatusRes.Success {
+			return nil, nil, fmt.Errorf("failed to get bulk status with success: %t", bulkStatusRes.Success)
+		}
+		maps.Copy(statuses, bulkStatusRes.Statuses)
+		notFound = append(notFound, bulkStatusRes.NotFound...)
+	}
+	return statuses, notFound, nil
+}
+
+func (m *Manager) getNonProcessedImportInfosWithBulkStatus(ctx context.Context, infos []*importInfo) []*importInfo {
+	channelIDs := lo.Map(infos, func(info *importInfo, _ int) string {
+		return info.ChannelID
+	})
+
+	statuses, notFound, err := m.getBulkStatus(ctx, channelIDs)
+	if err != nil {
+		for i := range infos {
+			info := infos[i]
+			info.FailedJobIds = nil
+			info.Failed = true
+			info.Reason = err.Error()
+			m.polledImportInfoMap[info.ChannelID] = info
+		}
+		return nil
+	}
+
+	notFoundMap := make(map[string]struct{}, len(notFound))
+	for _, channelID := range notFound {
+		notFoundMap[channelID] = struct{}{}
+	}
+
+	var inProgressInfos []*importInfo
+
+	for i := range infos {
+		info := infos[i]
+		info.FailedJobIds = nil
+		info.Failed = false
+
+		if _, exists := notFoundMap[info.ChannelID]; exists {
+			recreatedStatusRes, recreateErr := m.handleChannelNotFoundPostBulkStatus(ctx, info)
+			if recreateErr != nil {
+				info.Failed = true
+				info.Reason = recreateErr.Error()
+				m.polledImportInfoMap[info.ChannelID] = info
+				continue
+			}
+			inProgress, statusErr := isInProgress(recreatedStatusRes, info, m.logger)
+			if statusErr != nil {
+				info.Failed = true
+				info.Reason = statusErr.Error()
+				m.polledImportInfoMap[info.ChannelID] = info
+				continue
+			}
+			if inProgress {
+				inProgressInfos = append(inProgressInfos, info)
+				continue
+			}
+			m.polledImportInfoMap[info.ChannelID] = info
+			continue
+		}
+
+		statusRes := statuses[info.ChannelID]
+		if !statusRes.Valid {
+			recreatedStatusRes, recreateErr := m.handleInvalidStatusResponsePostBulkStatus(ctx, info)
+			if recreateErr != nil {
+				info.Failed = true
+				info.Reason = recreateErr.Error()
+				m.polledImportInfoMap[info.ChannelID] = info
+				continue
+			}
+			inProgress, statusErr := isInProgress(recreatedStatusRes, info, m.logger)
+			if statusErr != nil {
+				info.Failed = true
+				info.Reason = statusErr.Error()
+				m.polledImportInfoMap[info.ChannelID] = info
+				continue
+			}
+			if inProgress {
+				inProgressInfos = append(inProgressInfos, info)
+				continue
+			}
+			m.polledImportInfoMap[info.ChannelID] = info
+			continue
+		}
+
+		inProgress, statusErr := isInProgress(statusRes, info, m.logger)
+		if statusErr != nil {
+			info.Failed = true
+			info.Reason = statusErr.Error()
+			m.polledImportInfoMap[info.ChannelID] = info
+			continue
+		}
+		if inProgress {
+			inProgressInfos = append(inProgressInfos, info)
+			continue
+		}
+		m.polledImportInfoMap[info.ChannelID] = info
+	}
+
+	return inProgressInfos
+}
+
+func (m *Manager) handleChannelNotFoundPostBulkStatus(ctx context.Context, info *importInfo) (*model.StatusResponse, error) {
+	log := m.logger.Withn(
+		logger.NewStringField("channelId", info.ChannelID),
+		logger.NewStringField("expectedOffset", info.Offset),
+		logger.NewStringField("table", info.Table),
+	)
+	log.Infon("Handling channel not found post bulk status")
+
+	var destConf destConfig
+	if decodeErr := destConf.Decode(m.destination.Config); decodeErr != nil {
+		return nil, fmt.Errorf("failed to decode destination config during channel recreation: %w", decodeErr)
+	}
+
+	req := buildCreateChannelRequest(m.destination.ID, m.config.instanceID, &destConf, info.Table)
+	recreatedChannel, recreateErr := m.api.CreateChannel(ctx, req)
+	if recreateErr != nil {
+		return nil, fmt.Errorf("recreating channel: %w", recreateErr)
+	}
+	m.channelCache.Store(info.Table, recreatedChannel)
+
+	m.logger.Infon("Recreated channel for polling", logger.NewStringField("channelID", recreatedChannel.ChannelID))
+
+	// The new channel id is not being associated with the import info. This is because even if we do that,
+	// it will update the in memory map and not the database
+	// So the next time we poll, we will get the old channel id and not the new one
+
+	statuses, notFound, err := m.getBulkStatus(ctx, []string{recreatedChannel.ChannelID})
+	if err != nil {
+		return nil, fmt.Errorf("getting status after channel recreation: %w", err)
+	}
+	if len(notFound) > 0 {
+		return nil, fmt.Errorf("channel not found after recreation: %s", strings.Join(notFound, ","))
+	}
+
+	recreatedStatusRes, ok := statuses[recreatedChannel.ChannelID]
+	if !ok {
+		return nil, fmt.Errorf("channel not found after recreation: %s", recreatedChannel.ChannelID)
+	}
+
+	log.Infon("Polled import info after recreation post bulk status",
+		logger.NewBoolField("success", recreatedStatusRes.Success),
+		logger.NewStringField("latestCommittedOffset", recreatedStatusRes.Offset),
+		logger.NewStringField("latestInsertedOffset", recreatedStatusRes.LatestInsertedOffset),
+		logger.NewBoolField("valid", recreatedStatusRes.Valid),
+	)
+
+	if !recreatedStatusRes.Valid || !recreatedStatusRes.Success {
+		return nil, fmt.Errorf("invalid status response after recreation with valid: %t, success: %t", recreatedStatusRes.Valid, recreatedStatusRes.Success)
+	}
+
+	return recreatedStatusRes, nil
+}
+
+func (m *Manager) handleInvalidStatusResponsePostBulkStatus(ctx context.Context, info *importInfo) (*model.StatusResponse, error) {
+	log := m.logger.Withn(
+		logger.NewStringField("channelId", info.ChannelID),
+		logger.NewStringField("expectedOffset", info.Offset),
+		logger.NewStringField("table", info.Table),
+	)
+	log.Infon("Handling invalid status response post bulk status")
+
+	// Delete the channel from the cache and the Snowpipe as it is invalid
+	if err := m.deleteChannel(ctx, info.Table, info.ChannelID); err != nil {
+		log.Warnn("Failed to delete channel", logger.NewStringField("table", info.Table), logger.NewStringField("channelID", info.ChannelID), obskit.Error(err))
+	}
+
+	var destConf destConfig
+	if decodeErr := destConf.Decode(m.destination.Config); decodeErr != nil {
+		return nil, fmt.Errorf("failed to decode destination config during channel recreation: %w", decodeErr)
+	}
+
+	req := buildCreateChannelRequest(m.destination.ID, m.config.instanceID, &destConf, info.Table)
+	recreatedChannel, recreateErr := m.api.CreateChannel(ctx, req)
+	if recreateErr != nil {
+		return nil, fmt.Errorf("recreating channel: %w", recreateErr)
+	}
+	m.channelCache.Store(info.Table, recreatedChannel)
+
+	log.Infon("Recreated channel for polling post bulk status", logger.NewStringField("channelID", recreatedChannel.ChannelID))
+
+	statuses, notFound, err := m.getBulkStatus(ctx, []string{recreatedChannel.ChannelID})
+	if err != nil {
+		return nil, fmt.Errorf("getting status after channel recreation: %w", err)
+	}
+	if len(notFound) > 0 {
+		return nil, fmt.Errorf("channel not found after recreation: %s", strings.Join(notFound, ","))
+	}
+
+	recreatedStatusRes, ok := statuses[recreatedChannel.ChannelID]
+	if !ok {
+		return nil, fmt.Errorf("channel not found after recreation: %s", recreatedChannel.ChannelID)
+	}
+
+	log.Infon("Polled import info after recreation post bulk status",
+		logger.NewBoolField("success", recreatedStatusRes.Success),
+		logger.NewStringField("latestCommittedOffset", recreatedStatusRes.Offset),
+		logger.NewStringField("latestInsertedOffset", recreatedStatusRes.LatestInsertedOffset),
+		logger.NewBoolField("valid", recreatedStatusRes.Valid),
+	)
+
+	if !recreatedStatusRes.Valid || !recreatedStatusRes.Success {
+		return nil, fmt.Errorf("invalid status response after recreation with valid: %t, success: %t", recreatedStatusRes.Valid, recreatedStatusRes.Success)
+	}
+
+	return recreatedStatusRes, nil
 }
 
 func convertToInt(a string) (int64, error) {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -1741,20 +1741,10 @@ func TestSnowpipeStreaming(t *testing.T) {
 					}, nil
 				},
 				"test-recreated-products-channel": func() (*model.BulkStatusResponse, error) {
-					return &model.BulkStatusResponse{
-						Success: true,
-						Statuses: map[string]*model.StatusResponse{
-							"test-recreated-products-channel": {Valid: false, Success: false, Offset: "0"},
-						},
-					}, nil
+					return nil, fmt.Errorf("failed to get status")
 				},
 				"test-recreated-users-channel": func() (*model.BulkStatusResponse, error) {
-					return &model.BulkStatusResponse{
-						Success: true,
-						Statuses: map[string]*model.StatusResponse{
-							"test-recreated-users-channel": {Valid: false, Success: false, Offset: "0"},
-						},
-					}, nil
+					return nil, fmt.Errorf("failed to get status")
 				},
 			},
 			deleteChannelOutputMap: map[string]func() error{
@@ -1781,7 +1771,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 		require.Equal(t, http.StatusOK, output.StatusCode)
 		require.True(t, output.Complete)
 		require.True(t, output.HasFailed)
-		require.JSONEq(t, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"invalid status response after recreation with valid: false, success: false","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":true,"reason":"invalid status response after recreation with valid: false, success: false","count":2}]`, output.FailedJobParameters)
+		require.JSONEq(t, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"getting status after channel recreation: failed to get bulk status: failed to get status","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":true,"reason":"getting status after channel recreation: failed to get bulk status: failed to get status","count":2}]`, output.FailedJobParameters)
 		require.EqualValues(t, 4, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
 			"module":        "batch_router",
 			"workspaceId":   "test-workspace",

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -6,6 +6,8 @@ import (
 	"maps"
 	"math"
 	"net/http"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,6 +34,7 @@ type mockAPI struct {
 	deleteChannelOutputMap map[string]func() error
 	insertOutputMap        map[string]func() (*model.InsertResponse, error)
 	getStatusOutputMap     map[string]func() (*model.StatusResponse, error)
+	getBulkStatusOutputMap map[string]func() (*model.BulkStatusResponse, error)
 }
 
 func (m *mockAPI) CreateChannel(_ context.Context, channelReq *model.CreateChannelRequest) (*model.ChannelResponse, error) {
@@ -49,6 +52,12 @@ func (m *mockAPI) Insert(_ context.Context, channelID string, _ *model.InsertReq
 
 func (m *mockAPI) GetStatus(_ context.Context, channelID string) (*model.StatusResponse, error) {
 	return m.getStatusOutputMap[channelID]()
+}
+
+func (m *mockAPI) GetBulkStatus(_ context.Context, channelIDs []string) (*model.BulkStatusResponse, error) {
+	slices.Sort(channelIDs)
+	channelIDsStr := strings.Join(channelIDs, ",")
+	return m.getBulkStatusOutputMap[channelIDsStr]()
 }
 
 var (
@@ -1507,6 +1516,361 @@ func TestSnowpipeStreaming(t *testing.T) {
 		}).LastValue())
 	})
 
+	t.Run("Poll status invalid, recreated channel but still status is invalid with bulk status enabled", func(t *testing.T) {
+		importID := `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":false,"reason":"","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":false,"reason":"","count":2}]`
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		conf := config.New()
+		conf.Set("SnowpipeStreaming.bulkStatusEnabled", true)
+
+		sm := New(conf, logger.NOP, statsStore, destination)
+		sm.api = &mockAPI{
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: false, Success: false, Offset: "0"},
+							"test-users-channel":    {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
+				},
+				"test-recreated-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-products-channel": {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
+				},
+				"test-recreated-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-users-channel": {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
+				},
+			},
+			deleteChannelOutputMap: map[string]func() error{
+				"test-users-channel": func() error {
+					return nil
+				},
+				"test-products-channel": func() error {
+					return nil
+				},
+			},
+			createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
+				"PRODUCTS": func() (*model.ChannelResponse, error) {
+					return &model.ChannelResponse{Success: true, Valid: true, ChannelID: "test-recreated-products-channel"}, nil
+				},
+				"USERS": func() (*model.ChannelResponse, error) {
+					return &model.ChannelResponse{Success: true, Valid: true, ChannelID: "test-recreated-users-channel"}, nil
+				},
+			},
+		}
+		output := sm.Poll(context.Background(), common.AsyncPoll{
+			ImportId: importID,
+		})
+		require.False(t, output.InProgress)
+		require.Equal(t, http.StatusOK, output.StatusCode)
+		require.True(t, output.Complete)
+		require.True(t, output.HasFailed)
+		require.JSONEq(t, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"invalid status response after recreation with valid: false, success: false","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":true,"reason":"invalid status response after recreation with valid: false, success: false","count":2}]`, output.FailedJobParameters)
+		require.EqualValues(t, 4, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"status":        "failed",
+		}).LastValue())
+	})
+
+	t.Run("Poll status invalid, recreated channel failed with bulk status enabled", func(t *testing.T) {
+		importID := `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":false,"reason":"","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":false,"reason":"","count":2}]`
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		conf := config.New()
+		conf.Set("SnowpipeStreaming.bulkStatusEnabled", true)
+
+		sm := New(conf, logger.NOP, statsStore, destination)
+		sm.api = &mockAPI{
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: false, Success: false, Offset: "0"},
+							"test-users-channel":    {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
+				},
+			},
+			// getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
+			// 	"test-products-channel": func() (*model.StatusResponse, error) {
+			// 		return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
+			// 	},
+			// 	"test-users-channel": func() (*model.StatusResponse, error) {
+			// 		return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
+			// 	},
+			// },
+			deleteChannelOutputMap: map[string]func() error{
+				"test-users-channel": func() error {
+					return nil
+				},
+				"test-products-channel": func() error {
+					return nil
+				},
+			},
+			createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
+				"PRODUCTS": func() (*model.ChannelResponse, error) {
+					return nil, fmt.Errorf("failed to recreate channel")
+				},
+				"USERS": func() (*model.ChannelResponse, error) {
+					return nil, fmt.Errorf("failed to recreate channel")
+				},
+			},
+		}
+		output := sm.Poll(context.Background(), common.AsyncPoll{
+			ImportId: importID,
+		})
+		require.False(t, output.InProgress)
+		require.Equal(t, http.StatusOK, output.StatusCode)
+		require.True(t, output.Complete)
+		require.True(t, output.HasFailed)
+		require.JSONEq(t, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"recreating channel: failed to recreate channel","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":true,"reason":"recreating channel: failed to recreate channel","count":2}]`, output.FailedJobParameters)
+		require.EqualValues(t, 4, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"status":        "failed",
+		}).LastValue())
+	})
+
+	t.Run("Poll status invalid, recreated channel but getting status failed with bulk status enabled", func(t *testing.T) {
+		importID := `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":false,"reason":"","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":false,"reason":"","count":2}]`
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		conf := config.New()
+		conf.Set("SnowpipeStreaming.bulkStatusEnabled", true)
+
+		sm := New(conf, logger.NOP, statsStore, destination)
+		sm.api = &mockAPI{
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: false, Success: false, Offset: "0"},
+							"test-users-channel":    {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
+				},
+				"test-recreated-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-products-channel": {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
+				},
+				"test-recreated-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-users-channel": {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
+				},
+			},
+			deleteChannelOutputMap: map[string]func() error{
+				"test-users-channel": func() error {
+					return nil
+				},
+				"test-products-channel": func() error {
+					return nil
+				},
+			},
+			createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
+				"PRODUCTS": func() (*model.ChannelResponse, error) {
+					return &model.ChannelResponse{Success: true, Valid: true, ChannelID: "test-recreated-products-channel"}, nil
+				},
+				"USERS": func() (*model.ChannelResponse, error) {
+					return &model.ChannelResponse{Success: true, Valid: true, ChannelID: "test-recreated-users-channel"}, nil
+				},
+			},
+		}
+		output := sm.Poll(context.Background(), common.AsyncPoll{
+			ImportId: importID,
+		})
+		require.False(t, output.InProgress)
+		require.Equal(t, http.StatusOK, output.StatusCode)
+		require.True(t, output.Complete)
+		require.True(t, output.HasFailed)
+		require.JSONEq(t, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"invalid status response after recreation with valid: false, success: false","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":true,"reason":"invalid status response after recreation with valid: false, success: false","count":2}]`, output.FailedJobParameters)
+		require.EqualValues(t, 4, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"status":        "failed",
+		}).LastValue())
+	})
+
+	t.Run("Poll status invalid, recreated channel and status is successful with bulk status enabled", func(t *testing.T) {
+		importID := `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":false,"reason":"","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":false,"reason":"","count":2}]`
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		conf := config.New()
+		conf.Set("SnowpipeStreaming.bulkStatusEnabled", true)
+
+		sm := New(conf, logger.NOP, statsStore, destination)
+		sm.api = &mockAPI{
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: false, Success: false, Offset: "0"},
+							"test-users-channel":    {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
+				},
+				"test-recreated-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-products-channel": {Valid: true, Success: true, Offset: "1003"},
+						},
+					}, nil
+				},
+				"test-recreated-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-users-channel": {Valid: true, Success: true, Offset: "1004"},
+						},
+					}, nil
+				},
+			},
+			deleteChannelOutputMap: map[string]func() error{
+				"test-users-channel": func() error {
+					return nil
+				},
+				"test-products-channel": func() error {
+					return nil
+				},
+			},
+			createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
+				"PRODUCTS": func() (*model.ChannelResponse, error) {
+					return &model.ChannelResponse{Success: true, Valid: true, ChannelID: "test-recreated-products-channel"}, nil
+				},
+				"USERS": func() (*model.ChannelResponse, error) {
+					return &model.ChannelResponse{Success: true, Valid: true, ChannelID: "test-recreated-users-channel"}, nil
+				},
+			},
+		}
+		output := sm.Poll(context.Background(), common.AsyncPoll{
+			ImportId: importID,
+		})
+		require.False(t, output.InProgress)
+		require.Equal(t, http.StatusOK, output.StatusCode)
+		require.True(t, output.Complete)
+		require.False(t, output.HasFailed)
+		require.False(t, output.HasWarning)
+		require.Empty(t, output.FailedJobParameters)
+		require.EqualValues(t, 4, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"status":        "succeeded",
+		}).LastValue())
+		require.Zero(t, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"status":        "failed",
+		}).LastValue())
+	})
+
+	t.Run("Poll status failed with deletion error with bulk status enabled", func(t *testing.T) {
+		importID := `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":false,"reason":"","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":false,"reason":"","count":2}]`
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		conf := config.New()
+		conf.Set("SnowpipeStreaming.bulkStatusEnabled", true)
+
+		sm := New(conf, logger.NOP, statsStore, destination)
+		sm.api = &mockAPI{
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: false, Success: false, Offset: "0"},
+							"test-users-channel":    {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
+				},
+				"test-recreated-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-products-channel": {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
+				},
+				"test-recreated-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-users-channel": {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
+				},
+			},
+			deleteChannelOutputMap: map[string]func() error{
+				"test-users-channel": func() error {
+					return assert.AnError
+				},
+				"test-products-channel": func() error {
+					return assert.AnError
+				},
+			},
+			createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
+				"PRODUCTS": func() (*model.ChannelResponse, error) {
+					return &model.ChannelResponse{Success: true, Valid: true, ChannelID: "test-recreated-products-channel"}, nil
+				},
+				"USERS": func() (*model.ChannelResponse, error) {
+					return &model.ChannelResponse{Success: true, Valid: true, ChannelID: "test-recreated-users-channel"}, nil
+				},
+			},
+		}
+		output := sm.Poll(context.Background(), common.AsyncPoll{
+			ImportId: importID,
+		})
+		require.False(t, output.InProgress)
+		require.Equal(t, http.StatusOK, output.StatusCode)
+		require.True(t, output.Complete)
+		require.True(t, output.HasFailed)
+		require.JSONEq(t, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"invalid status response after recreation with valid: false, success: false","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":true,"reason":"invalid status response after recreation with valid: false, success: false","count":2}]`, output.FailedJobParameters)
+		require.EqualValues(t, 4, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"status":        "failed",
+		}).LastValue())
+	})
+
 	t.Run("Poll error", func(t *testing.T) {
 		importID := `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":false,"reason":"","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":false,"reason":"","count":2}]`
 		statsStore, err := memstats.New()
@@ -2484,6 +2848,172 @@ func TestSnowpipeStreaming(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("provideInProgressImportInfos with bulk status enabled", func(t *testing.T) {
+		t.Run("channel not found in bulk status triggers recreate and bulk re-poll", func(t *testing.T) {
+			statsStore, err := memstats.New()
+			require.NoError(t, err)
+
+			conf := config.New()
+			conf.Set("SnowpipeStreaming.bulkStatusEnabled", true)
+			sm := New(conf, logger.NOP, statsStore, destination)
+
+			bulkCallCount := 0
+			sm.api = &mockAPI{
+				getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+					"test-channel-1,test-channel-2": func() (*model.BulkStatusResponse, error) {
+						bulkCallCount++
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-2": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "100",
+									LatestInsertedOffset: "100",
+								},
+							},
+							NotFound: []string{"test-channel-1"},
+						}, nil
+					},
+					"test-recreated-channel-1": func() (*model.BulkStatusResponse, error) {
+						bulkCallCount++
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-recreated-channel-1": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "100",
+									LatestInsertedOffset: "100",
+								},
+							},
+						}, nil
+					},
+				},
+				createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
+					"USERS": func() (*model.ChannelResponse, error) {
+						return &model.ChannelResponse{
+							Success:   true,
+							Valid:     true,
+							ChannelID: "test-recreated-channel-1",
+						}, nil
+					},
+				},
+			}
+
+			infos := []*importInfo{
+				{
+					ChannelID: "test-channel-1",
+					Offset:    "100",
+					Table:     "USERS",
+					Count:     5,
+				},
+				{
+					ChannelID: "test-channel-2",
+					Offset:    "100",
+					Table:     "TRACKING",
+					Count:     5,
+				},
+			}
+
+			inProgressInfos := sm.provideInProgressImportInfos(context.Background(), infos)
+			require.Empty(t, inProgressInfos)
+			require.Len(t, sm.polledImportInfoMap, 2)
+			require.Contains(t, sm.polledImportInfoMap, "test-channel-1")
+			require.False(t, sm.polledImportInfoMap["test-channel-1"].Failed)
+			require.Contains(t, sm.polledImportInfoMap, "test-channel-2")
+			require.False(t, sm.polledImportInfoMap["test-channel-2"].Failed)
+			require.Equal(t, 2, bulkCallCount)
+		})
+
+		t.Run("invalid bulk status triggers delete and recreate with bulk re-poll", func(t *testing.T) {
+			statsStore, err := memstats.New()
+			require.NoError(t, err)
+
+			conf := config.New()
+			conf.Set("SnowpipeStreaming.bulkStatusEnabled", true)
+			sm := New(conf, logger.NOP, statsStore, destination)
+
+			bulkCallCount := 0
+			sm.api = &mockAPI{
+				getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+					"test-channel-1,test-channel-2": func() (*model.BulkStatusResponse, error) {
+						bulkCallCount++
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-1": {
+									Valid:                false,
+									Success:              true,
+									Offset:               "100",
+									LatestInsertedOffset: "100",
+								},
+								"test-channel-2": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "100",
+									LatestInsertedOffset: "100",
+								},
+							},
+						}, nil
+					},
+					"test-recreated-channel-1": func() (*model.BulkStatusResponse, error) {
+						bulkCallCount++
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-recreated-channel-1": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "100",
+									LatestInsertedOffset: "100",
+								},
+							},
+						}, nil
+					},
+				},
+				deleteChannelOutputMap: map[string]func() error{
+					"test-channel-1": func() error {
+						return nil
+					},
+				},
+				createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
+					"USERS": func() (*model.ChannelResponse, error) {
+						return &model.ChannelResponse{
+							Success:   true,
+							Valid:     true,
+							ChannelID: "test-recreated-channel-1",
+						}, nil
+					},
+				},
+			}
+
+			infos := []*importInfo{
+				{
+					ChannelID: "test-channel-1",
+					Offset:    "100",
+					Table:     "USERS",
+					Count:     5,
+				},
+				{
+					ChannelID: "test-channel-2",
+					Offset:    "100",
+					Table:     "TRACKING",
+					Count:     5,
+				},
+			}
+
+			inProgressInfos := sm.provideInProgressImportInfos(context.Background(), infos)
+			require.Empty(t, inProgressInfos)
+			require.Len(t, sm.polledImportInfoMap, 2)
+			require.Contains(t, sm.polledImportInfoMap, "test-channel-1")
+			require.False(t, sm.polledImportInfoMap["test-channel-1"].Failed)
+			require.Contains(t, sm.polledImportInfoMap, "test-channel-2")
+			require.False(t, sm.polledImportInfoMap["test-channel-2"].Failed)
+			require.Equal(t, 2, bulkCallCount)
+		})
 	})
 }
 

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -1608,14 +1608,6 @@ func TestSnowpipeStreaming(t *testing.T) {
 					}, nil
 				},
 			},
-			// getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-			// 	"test-products-channel": func() (*model.StatusResponse, error) {
-			// 		return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
-			// 	},
-			// 	"test-users-channel": func() (*model.StatusResponse, error) {
-			// 		return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
-			// 	},
-			// },
 			deleteChannelOutputMap: map[string]func() error{
 				"test-users-channel": func() error {
 					return nil

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
@@ -46,6 +46,8 @@ type (
 			instanceID             string
 			maxBufferCapacity      config.ValueLoader[int64]
 			stuckPipelineThreshold config.ValueLoader[time.Duration]
+			bulkStatusEnabled      config.ValueLoader[bool]
+			bulkStatusChannels     config.ValueLoader[int]
 		}
 
 		stats struct {
@@ -136,6 +138,7 @@ type (
 		DeleteChannel(ctx context.Context, channelID string, sync bool) error
 		Insert(ctx context.Context, channelID string, insertRequest *model.InsertRequest) (*model.InsertResponse, error)
 		GetStatus(ctx context.Context, channelID string) (*model.StatusResponse, error)
+		GetBulkStatus(ctx context.Context, channelIDs []string) (*model.BulkStatusResponse, error)
 	}
 
 	apiAdapter struct {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
@@ -47,7 +47,7 @@ type (
 			maxBufferCapacity      config.ValueLoader[int64]
 			stuckPipelineThreshold config.ValueLoader[time.Duration]
 			bulkStatusEnabled      config.ValueLoader[bool]
-			bulkStatusChannels     config.ValueLoader[int]
+			bulkStatusBatchSize    config.ValueLoader[int]
 		}
 
 		stats struct {


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

# Description

Adds bulk status polling support for Snowpipe Streaming and integrates it across manager, API adapter, API client, and tests.

- Added bulk status API plumbing:
  - `GetBulkStatus` in `internal/api/api.go`
  - `GetBulkStatus` in `apiadapter.go`
  - `BulkStatusResponse` in `internal/model/model.go`
  - API interface update in `types.go`
- Added config flags:
  - `SnowpipeStreaming.bulkStatusEnabled`
  - `SnowpipeStreaming.bulkStatusChannels`
- Updated polling flow in `snowpipestreaming.go`:
  - routes polling through bulk path when enabled
  - chunks channel IDs for bulk calls
  - handles channel recovery in bulk mode:
    - `notFound` => recreate + re-poll
    - invalid status (`valid=false`) => delete + recreate + re-poll
  - retains existing in-progress/terminal semantics via `isInProgress`
- Added integration test configurability:
  - `runRudderServer(..., configOverrides...)` now accepts runtime config overrides
- Added new integration scenario:
  - `many table (bulk status enabled)` in `integration_test/snowpipestreaming/snowpipestreaming_test.go`


## Linear Ticket

- Resolves INT-5887

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
