### PR TITLE
feat: support concurrency during partition migration flushing

### DIFF
--- a/app/apphandlers/setup_partitionmigration.go
+++ b/app/apphandlers/setup_partitionmigration.go
@@ -79,6 +79,7 @@ func setupProcessorPartitionMigrator(ctx context.Context,
 	bufferFlushBatchSize := config.GetReloadableIntVar(2000, 1, "PartitionMigration.bufferFlushBatchSize")
 	bufferFlushPayloadSize := config.GetReloadableInt64Var(100, bytesize.MB, "PartitionMigration.bufferFlushPayloadSize")
 	bufferFlushMoveTimeout := config.GetReloadableDurationVar(30, time.Minute, "PartitionMigration.bufferFlushMoveTimeout")
+	bufferFlushMoveConcurrency := config.GetReloadableIntVar(1, 1, "PartitionMigration.bufferFlushMoveConcurrency")
 	bufferWatchdogInterval := config.GetReloadableDurationVar(5, time.Minute, "PartitionMigration.bufferWatchdogInterval")
 
 	// setup partition buffer for gateway jobsDB
@@ -132,6 +133,7 @@ func setupProcessorPartitionMigrator(ctx context.Context,
 		partitionbuffer.WithFlushBatchSize(bufferFlushBatchSize),
 		partitionbuffer.WithFlushPayloadSize(bufferFlushPayloadSize),
 		partitionbuffer.WithFlushMoveTimeout(bufferFlushMoveTimeout),
+		partitionbuffer.WithFlushMoveConcurrency(bufferFlushMoveConcurrency),
 		partitionbuffer.WithWatchdogInterval(bufferWatchdogInterval),
 	)
 	if err != nil {
@@ -157,6 +159,7 @@ func setupProcessorPartitionMigrator(ctx context.Context,
 		partitionbuffer.WithFlushBatchSize(bufferFlushBatchSize),
 		partitionbuffer.WithFlushPayloadSize(bufferFlushPayloadSize),
 		partitionbuffer.WithFlushMoveTimeout(bufferFlushMoveTimeout),
+		partitionbuffer.WithFlushMoveConcurrency(bufferFlushMoveConcurrency),
 		partitionbuffer.WithWatchdogInterval(bufferWatchdogInterval),
 	)
 	if err != nil {
@@ -182,6 +185,7 @@ func setupProcessorPartitionMigrator(ctx context.Context,
 		partitionbuffer.WithFlushBatchSize(bufferFlushBatchSize),
 		partitionbuffer.WithFlushPayloadSize(bufferFlushPayloadSize),
 		partitionbuffer.WithFlushMoveTimeout(bufferFlushMoveTimeout),
+		partitionbuffer.WithFlushMoveConcurrency(bufferFlushMoveConcurrency),
 		partitionbuffer.WithWatchdogInterval(bufferWatchdogInterval),
 	)
 	if err != nil {

--- a/cluster/partitionbuffer/jobsdb_partition_buffer.go
+++ b/cluster/partitionbuffer/jobsdb_partition_buffer.go
@@ -43,14 +43,15 @@ type jobsDBPartitionBuffer struct {
 	stats              stats.Stats
 
 	// configuration
-	differentBufferDBs bool                              // if having different reader/writer buffer DBs, we need to refresh buffered partitions on every Store
-	canStore           bool                              // indicates if Store operations are supported
-	canFlush           bool                              // indicates if Flush operations are supported
-	numPartitions      int                               // number of partitions used in partition function
-	flushBatchSize     config.ValueLoader[int]           // number of records to flush in a single batch
-	flushPayloadSize   config.ValueLoader[int64]         // total payload size (in bytes) to flush in a single batch
-	flushMoveTimeout   config.ValueLoader[time.Duration] // timeout for move operation, before forcing switchover
-	watchdogInterval   config.ValueLoader[time.Duration] // interval for watchdog to check for unbuffered partitions with buffered jobs
+	differentBufferDBs   bool                              // if having different reader/writer buffer DBs, we need to refresh buffered partitions on every Store
+	canStore             bool                              // indicates if Store operations are supported
+	canFlush             bool                              // indicates if Flush operations are supported
+	numPartitions        int                               // number of partitions used in partition function
+	flushBatchSize       config.ValueLoader[int]           // number of records to flush in a single batch
+	flushPayloadSize     config.ValueLoader[int64]         // total payload size (in bytes) to flush in a single batch
+	flushMoveTimeout     config.ValueLoader[time.Duration] // timeout for move operation, before forcing switchover
+	flushMoveConcurrency config.ValueLoader[int]           // number of goroutines distributing partitions during the move phase
+	watchdogInterval     config.ValueLoader[time.Duration] // interval for watchdog to check for unbuffered partitions with buffered jobs
 
 	// state
 	bufferedPartitionsMu      *golock.CASMutex                       // mutex to protect bufferedPartitionsVersion & bufferedPartitions

--- a/cluster/partitionbuffer/jobsdb_partition_buffer_factory.go
+++ b/cluster/partitionbuffer/jobsdb_partition_buffer_factory.go
@@ -116,6 +116,13 @@ func WithFlushMoveTimeout(flushMoveTimeout config.ValueLoader[time.Duration]) Op
 	}
 }
 
+// WithFlushMoveConcurrency sets the number of goroutines that distribute partitions during the move phase of a flush
+func WithFlushMoveConcurrency(flushMoveConcurrency config.ValueLoader[int]) Opt {
+	return func(b *jobsDBPartitionBuffer) {
+		b.flushMoveConcurrency = flushMoveConcurrency
+	}
+}
+
 // WithWatchdogInterval sets the watchdog interval for the JobsDBPartitionBuffer
 func WithWatchdogInterval(watchdogInterval config.ValueLoader[time.Duration]) Opt {
 	return func(b *jobsDBPartitionBuffer) {
@@ -130,6 +137,7 @@ func NewJobsDBPartitionBuffer(ctx context.Context, opts ...Opt) (JobsDBPartition
 		flushBatchSize:       config.SingleValueLoader(20000),
 		flushPayloadSize:     config.SingleValueLoader(500 * bytesize.MB),
 		flushMoveTimeout:     config.SingleValueLoader(30 * time.Minute),
+		flushMoveConcurrency: config.SingleValueLoader(1),
 		watchdogInterval:     config.SingleValueLoader(5 * time.Minute),
 		bufferedPartitionsMu: golock.NewCASMutex(),
 		flushingPartitions:   make(map[string]struct{}),

--- a/cluster/partitionbuffer/jobsdb_partition_buffer_flush.go
+++ b/cluster/partitionbuffer/jobsdb_partition_buffer_flush.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/samber/lo"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
@@ -71,7 +73,6 @@ func (b *jobsDBPartitionBuffer) FlushBufferedPartitions(ctx context.Context, par
 		logger.NewStringField("prefix", b.Identifier()),
 	)
 	for limitsReached := true; limitsReached; {
-		var err error
 		select {
 		case <-moveTimeout:
 			// timeout reached, break out to switchover
@@ -81,12 +82,12 @@ func (b *jobsDBPartitionBuffer) FlushBufferedPartitions(ctx context.Context, par
 			)
 			limitsReached = false
 		default:
-			var movedCount int
-			movedCount, limitsReached, err = b.moveBufferedPartitions(ctx, partitions, b.flushBatchSize.Load(), b.flushPayloadSize.Load())
+			movedCount, lr, err := b.moveBufferedPartitionsConcurrently(ctx, partitions, b.flushBatchSize.Load(), b.flushPayloadSize.Load(), b.flushMoveConcurrency.Load())
 			if err != nil {
 				return fmt.Errorf("moving buffered partitions: %w", err)
 			}
 			totalCount += movedCount
+			limitsReached = lr
 		}
 	}
 	// switchover
@@ -107,6 +108,50 @@ func (b *jobsDBPartitionBuffer) FlushBufferedPartitions(ctx context.Context, par
 		logger.NewIntField("totalCount", int64(totalCount)),
 	)
 	return nil
+}
+
+// moveBufferedPartitionsConcurrently distributes the given partition IDs across the requested number of goroutines, each calling moveBufferedPartitions on its share.
+// It returns the total moved count, whether any goroutine reached its limits, and the first encountered error.
+// All goroutines must finish before this returns, so the caller may safely re-read the concurrency setting between iterations.
+func (b *jobsDBPartitionBuffer) moveBufferedPartitionsConcurrently(ctx context.Context, partitionIDs []string, batchSize int, payloadSize int64, concurrency int) (count int, limitsReached bool, err error) {
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	if concurrency > len(partitionIDs) {
+		concurrency = len(partitionIDs)
+	}
+	chunkSize := (len(partitionIDs) + concurrency - 1) / concurrency
+	chunks := lo.Chunk(partitionIDs, chunkSize)
+
+	if len(chunks) == 1 {
+		return b.moveBufferedPartitions(ctx, chunks[0], batchSize, payloadSize)
+	}
+
+	var (
+		mu          sync.Mutex
+		totalMoved  int
+		anyLimitsLR bool
+	)
+	g, gCtx := errgroup.WithContext(ctx)
+	for _, chunk := range chunks {
+		g.Go(func() error {
+			moved, lr, err := b.moveBufferedPartitions(gCtx, chunk, batchSize, payloadSize)
+			if err != nil {
+				return err
+			}
+			mu.Lock()
+			totalMoved += moved
+			if lr {
+				anyLimitsLR = true
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return 0, false, err
+	}
+	return totalMoved, anyLimitsLR, nil
 }
 
 // moveBufferedPartitions moves a batch of buffered jobs to the primary JobsDB for the given partition IDs. It returns whether any limits were reached during the fetch.
@@ -201,7 +246,7 @@ func (b *jobsDBPartitionBuffer) switchoverBufferedPartitions(ctx context.Context
 		// move any remaining buffered data
 		for limitsReached := true; limitsReached; {
 			var movedCount int
-			movedCount, limitsReached, err = b.moveBufferedPartitions(ctx, partitionIDs, batchSize, payloadSize)
+			movedCount, limitsReached, err = b.moveBufferedPartitionsConcurrently(ctx, partitionIDs, batchSize, payloadSize, b.flushMoveConcurrency.Load())
 			if err != nil {
 				return fmt.Errorf("moving buffered partitions during switchover: %w", err)
 			}

--- a/cluster/partitionbuffer/jobsdb_partition_buffer_flush.go
+++ b/cluster/partitionbuffer/jobsdb_partition_buffer_flush.go
@@ -128,21 +128,21 @@ func (b *jobsDBPartitionBuffer) moveBufferedPartitionsConcurrently(ctx context.C
 	}
 
 	var (
-		mu          sync.Mutex
-		totalMoved  int
-		anyLimitsLR bool
+		mu               sync.Mutex
+		totalMoved       int
+		anyLimitsReached bool
 	)
 	g, gCtx := errgroup.WithContext(ctx)
 	for _, chunk := range chunks {
 		g.Go(func() error {
-			moved, lr, err := b.moveBufferedPartitions(gCtx, chunk, batchSize, payloadSize)
+			moved, limitsReached, err := b.moveBufferedPartitions(gCtx, chunk, batchSize, payloadSize)
 			if err != nil {
 				return err
 			}
 			mu.Lock()
 			totalMoved += moved
-			if lr {
-				anyLimitsLR = true
+			if limitsReached {
+				anyLimitsReached = true
 			}
 			mu.Unlock()
 			return nil
@@ -151,7 +151,7 @@ func (b *jobsDBPartitionBuffer) moveBufferedPartitionsConcurrently(ctx context.C
 	if err := g.Wait(); err != nil {
 		return 0, false, err
 	}
-	return totalMoved, anyLimitsLR, nil
+	return totalMoved, anyLimitsReached, nil
 }
 
 // moveBufferedPartitions moves a batch of buffered jobs to the primary JobsDB for the given partition IDs. It returns whether any limits were reached during the fetch.

--- a/cluster/partitionbuffer/jobsdb_partition_buffer_flush_test.go
+++ b/cluster/partitionbuffer/jobsdb_partition_buffer_flush_test.go
@@ -20,9 +20,10 @@ import (
 
 func TestFlushBufferedPartitions(t *testing.T) {
 	const (
-		flushBatchSizeConfig   = "flushBatchSize"
-		flushPayloadSizeConfig = "flushPayloadSize"
-		flushMoveTimeoutConfig = "flushMoveTimeout"
+		flushBatchSizeConfig       = "flushBatchSize"
+		flushPayloadSizeConfig     = "flushPayloadSize"
+		flushMoveTimeoutConfig     = "flushMoveTimeout"
+		flushMoveConcurrencyConfig = "flushMoveConcurrency"
 	)
 	t.Run("readwrite", func(t *testing.T) {
 		setup := func(t *testing.T) (pb JobsDBPartitionBuffer, c *config.Config, sqlDB *sql.DB, bufferDB jobsdb.JobsDB) {
@@ -56,6 +57,7 @@ func TestFlushBufferedPartitions(t *testing.T) {
 				WithFlushBatchSize(c.GetReloadableIntVar(3, 1, flushBatchSizeConfig)),
 				WithFlushPayloadSize(c.GetReloadableInt64Var(100*bytesize.MB, 1, flushPayloadSizeConfig)),
 				WithFlushMoveTimeout(c.GetReloadableDurationVar(60, time.Second, flushMoveTimeoutConfig)),
+				WithFlushMoveConcurrency(c.GetReloadableIntVar(2, 1, flushMoveConcurrencyConfig)),
 			)
 			require.NoError(t, err)
 			return pb, c, pg.DB, bufferRW
@@ -324,6 +326,7 @@ func TestFlushBufferedPartitions(t *testing.T) {
 				WithFlushBatchSize(c.GetReloadableIntVar(3, 1, flushBatchSizeConfig)),
 				WithFlushPayloadSize(c.GetReloadableInt64Var(100*bytesize.MB, 1, flushPayloadSizeConfig)),
 				WithFlushMoveTimeout(c.GetReloadableDurationVar(60, time.Second, flushMoveTimeoutConfig)),
+				WithFlushMoveConcurrency(c.GetReloadableIntVar(2, 1, flushMoveConcurrencyConfig)),
 			)
 			require.NoError(t, err)
 			return pbw, pbr, c, pg.DB, bufferRO

--- a/integration_test/partitionmigration/partitionmigration_embedded_test.go
+++ b/integration_test/partitionmigration/partitionmigration_embedded_test.go
@@ -160,10 +160,11 @@ func TestPartitionMigrationEmbeddedMode(t *testing.T) {
 		"PartitionMigration.failOnInvalidNodeHostPattern": "false",
 
 		// let migrations do multiple small batches
-		"PartitionMigration.Executor.BatchSize":     "100",
-		"PartitionMigration.Executor.ChunkSize":     "10",
-		"PartitionMigration.bufferFlushBatchSize":   "100",
-		"PartitionMigration.bufferWatchdogInterval": "10s", // watch more frequently for surfacing potentials issues
+		"PartitionMigration.Executor.BatchSize":         "100",
+		"PartitionMigration.Executor.ChunkSize":         "10",
+		"PartitionMigration.bufferFlushBatchSize":       "100",
+		"PartitionMigration.bufferFlushMoveConcurrency": "2",
+		"PartitionMigration.bufferWatchdogInterval":     "10s", // watch more frequently for surfacing potentials issues
 
 		"ETCD_HOSTS":            etcdResource.Hosts[0],
 		"DEST_TRANSFORM_URL":    tr.TransformerURL,

--- a/integration_test/partitionmigration/partitionmigration_gwproc_test.go
+++ b/integration_test/partitionmigration/partitionmigration_gwproc_test.go
@@ -228,6 +228,7 @@ func testPartitionMigrationGatewayProcessorMode(t *testing.T, extraStressWorkspa
 		"PartitionMigration.Executor.BatchSize":                    "100",                                                     // let migrations do multiple small batches
 		"PartitionMigration.Executor.ChunkSize":                    "10",
 		"PartitionMigration.bufferFlushBatchSize":                  "100",
+		"PartitionMigration.bufferFlushMoveConcurrency":            "2",
 		"PartitionMigration.bufferWatchdogInterval":                "10s", // watch more frequently for surfacing potentials issues
 
 		"ETCD_HOSTS":            etcdResource.Hosts[0],


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

# Description

Adds a reloadable `PartitionMigration.bufferFlushMoveConcurrency` config (default `1`) that controls how many goroutines distribute partitions during the move phase of a flush.

The motivation is to be able to maximize flush throughput when a single partition migration job is running, without having to restart the job to take effect — hence the config is reloadable.

## Linear Ticket

resolves PIPE-2951

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.