### PR TITLE
fix(router): delays in finding worker slots when event ordering is disabled

### DIFF
--- a/router/find_worker_slot_bench_test.go
+++ b/router/find_worker_slot_bench_test.go
@@ -1,0 +1,237 @@
+package router
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+	"github.com/rudderlabs/rudder-go-kit/stats/metric"
+	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
+
+	"github.com/rudderlabs/rudder-server/router/types"
+)
+
+// BenchmarkFindWorkerSlot exercises the hot path in Handle.findWorkerSlot for the
+// event-ordering-disabled branch (see reserveAnyWorkerSlot in handle.go) against
+// 512 workers.
+//
+// The benchmark sweeps three independent dimensions:
+//
+//   - mode: which workerBuffer configuration is in use:
+//     simple                — newSimpleWorkerBuffer (fixed capacity, no calculator)
+//     dynamic/standard      — newWorkerBuffer + newBufferSizeCalculatorSwitcher (experimental=false)
+//     dynamic/experimental  — newWorkerBuffer + newBufferSizeCalculatorSwitcher (experimental=true)
+//
+//   - strategy: how a worker with capacity is chosen:
+//     filter     — the old approach: lo.Filter on AvailableSlots, rand.Intn into the
+//     survivor list, then ReserveSlot. Kept here as a baseline.
+//     shuffleTry — the new approach (now in production): random start + sequential
+//     walk + ReserveSlot until one succeeds. No filter slice, no
+//     double check, no race window.
+//
+//   - scenario: per-worker fill ratio and/or fraction of workers fully exhausted,
+//     so we can see how shuffleTry's "average tries before success" varies.
+//
+// Inputs to the calculator switcher mirror the production defaults from
+// handle_lifecycle.go: maxNoOfJobsPerChannel=10000, noOfJobsPerChannel=1000,
+// noOfJobsToBatchInAWorker=20, scalingFactor=2.0, minBufferSize=500.
+func BenchmarkFindWorkerSlot(b *testing.B) {
+	const (
+		numWorkers             = 512
+		maxNoOfJobsPerChannel  = 10000
+		noOfJobsPerChannel     = 1000
+		noOfJobsToBatchPerWork = 20
+		jobQueryBatchSize      = 10000
+		workLoopThroughputObs  = 100.0
+		scalingFactor          = 2.0
+		experimentalMinSize    = 500
+		simpleBufferCapacity   = 1000 // matches the standard calculator's output for these defaults
+	)
+
+	// scenarios control the pre-occupation pattern across the 512 workers. They are
+	// designed so shuffleTry's "average tries before success" varies meaningfully —
+	// for filter the cost is roughly constant (always 512 AvailableSlots calls).
+	//
+	// perWorkerFillFrac: each worker is pre-filled to this fraction of its capacity
+	//                    (so it still has a few slots free).
+	// fullyFullFrac:     this fraction of workers are pre-filled to capacity (no
+	//                    slots free at all).
+	scenarios := []struct {
+		name              string
+		perWorkerFillFrac float64
+		fullyFullFrac     float64
+	}{
+		{"allEmpty", 0.0, 0.0},                  // every worker has full capacity → shuffleTry wins on 1st try
+		{"perWorkerHalf", 0.5, 0.0},             // every worker half-full → shuffleTry wins on 1st try
+		{"halfWorkersFull", 0.0, 0.5},           // 50% of workers exhausted → shuffleTry ~2 tries avg
+		{"mostWorkersFull_99pct", 0.0, 0.99},    // 99% of workers exhausted → shuffleTry ~100 tries avg
+		{"mostWorkersFull_99_8pct", 0.0, 0.998}, // 99.8% of workers exhausted → shuffleTry ~500 tries avg (≈ filter's 512 RLocks)
+	}
+
+	// Each mode returns a freshly constructed worker buffer along with its effective
+	// capacity (so we can pre-occupy the right number of slots for fill ratios).
+	modes := []struct {
+		name   string
+		newBuf func() (buf *workerBuffer, capacity int)
+	}{
+		{
+			name: "simple",
+			newBuf: func() (*workerBuffer, int) {
+				return newSimpleWorkerBuffer(simpleBufferCapacity), simpleBufferCapacity
+			},
+		},
+		{
+			name: "dynamic/standard",
+			newBuf: func() (*workerBuffer, int) {
+				calc := newBufferSizeCalculatorSwitcher(
+					config.SingleValueLoader(false), // experimental disabled
+					config.SingleValueLoader(jobQueryBatchSize),
+					numWorkers,
+					config.SingleValueLoader(noOfJobsToBatchPerWork),
+					seededSMA(workLoopThroughputObs),
+					config.SingleValueLoader(scalingFactor),
+					noOfJobsPerChannel,
+					config.SingleValueLoader(experimentalMinSize),
+				)
+				return newWorkerBuffer(maxNoOfJobsPerChannel, calc, newBufferStats()), calc()
+			},
+		},
+		{
+			name: "dynamic/experimental",
+			newBuf: func() (*workerBuffer, int) {
+				calc := newBufferSizeCalculatorSwitcher(
+					config.SingleValueLoader(true), // experimental enabled
+					config.SingleValueLoader(jobQueryBatchSize),
+					numWorkers,
+					config.SingleValueLoader(noOfJobsToBatchPerWork),
+					seededSMA(workLoopThroughputObs),
+					config.SingleValueLoader(scalingFactor),
+					noOfJobsPerChannel,
+					config.SingleValueLoader(experimentalMinSize),
+				)
+				return newWorkerBuffer(maxNoOfJobsPerChannel, calc, newBufferStats()), calc()
+			},
+		},
+	}
+
+	// Two strategies for finding a worker with an available slot:
+	//
+	//  - filter: the previous behavior — lo.Filter on AvailableSlots, then rand.Intn
+	//    into the survivor list, then ReserveSlot on the chosen one. Kept here as a
+	//    baseline to measure against.
+	//
+	//  - shuffleTry: the current production path (see reserveAnyWorkerSlot in
+	//    handle.go) — pick a random starting offset and walk the workers slice
+	//    sequentially (with wrap-around), calling ReserveSlot until one succeeds.
+	//    Avoids the filter slice allocation, the double check, and the
+	//    filter-then-reserve race window.
+	strategies := []struct {
+		name string
+		find func(workers []*worker, rng *rand.Rand) *reservedSlot
+	}{
+		{
+			name: "filter",
+			find: func(workers []*worker, rng *rand.Rand) *reservedSlot {
+				availableWorkers := lo.Filter(workers, func(w *worker, _ int) bool { return w.AvailableSlots() > 0 })
+				if len(availableWorkers) == 0 {
+					return nil
+				}
+				return availableWorkers[rng.Intn(len(availableWorkers))].ReserveSlot()
+			},
+		},
+		{
+			name: "shuffleTry",
+			find: func(workers []*worker, rng *rand.Rand) *reservedSlot {
+				n := len(workers)
+				start := rng.Intn(n)
+				for i := range n {
+					if slot := workers[(start+i)%n].ReserveSlot(); slot != nil {
+						return slot
+					}
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, mode := range modes {
+		for _, strategy := range strategies {
+			for _, sc := range scenarios {
+				b.Run(mode.name+"/"+strategy.name+"/"+sc.name, func(b *testing.B) {
+					workers := make([]*worker, numWorkers)
+					var capacity int
+					for i := range workers {
+						buf, c := mode.newBuf()
+						workers[i] = &worker{workerBuffer: buf}
+						capacity = c
+					}
+
+					// Per-worker partial fill (every worker still has free slots).
+					perWorkerOccupied := int(float64(capacity) * sc.perWorkerFillFrac)
+					if perWorkerOccupied > 0 {
+						for _, w := range workers {
+							for range perWorkerOccupied {
+								if s := w.ReserveSlot(); s != nil {
+									s.Use(workerJob{})
+								}
+							}
+						}
+					}
+
+					// Whole-worker exhaustion: pick a fraction of workers and fully fill them.
+					fullyFullCount := int(float64(numWorkers) * sc.fullyFullFrac)
+					for _, w := range workers[:fullyFullCount] {
+						for {
+							s := w.ReserveSlot()
+							if s == nil {
+								break
+							}
+							s.Use(workerJob{})
+						}
+					}
+
+					rng := rand.New(rand.NewSource(1))
+
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						slot := strategy.find(workers, rng)
+						if slot == nil {
+							b.Fatal(types.ErrWorkerNoSlot)
+						}
+						// Release the slot to keep the buffer state stable across iterations.
+						slot.Release()
+					}
+				})
+			}
+		}
+	}
+}
+
+// seededSMA returns a SimpleMovingAverage primed with a single observation, so the
+// experimental calculator sees a stable, non-zero throughput throughout the benchmark.
+func seededSMA(observation float64) metric.SimpleMovingAverage {
+	sma := metric.NewSimpleMovingAverage(1)
+	sma.Observe(observation)
+	return sma
+}
+
+// newBufferStats builds a workerBufferStats configured the same way as production
+// (see partition_worker.go): 5s OnceEvery throttle plus capacity & size histograms.
+// memstats is used so the benchmark stays isolated from the global stats registry.
+func newBufferStats() *workerBufferStats {
+	memStats, err := memstats.New()
+	if err != nil {
+		panic(err)
+	}
+	return &workerBufferStats{
+		onceEvery:       kitsync.NewOnceEvery(5 * time.Second),
+		currentCapacity: memStats.NewTaggedStat("router_worker_buffer_capacity", stats.HistogramType, nil),
+		currentSize:     memStats.NewTaggedStat("router_worker_buffer_size", stats.HistogramType, nil),
+	}
+}

--- a/router/handle.go
+++ b/router/handle.go
@@ -238,6 +238,14 @@ func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worke
 	var reservedJobs []reservedJob
 	blockedOrderKeys := make(map[eventorder.BarrierKey]struct{})
 
+	// Total wall-clock time spent in findWorkerSlot across this pickup loop.
+	// Published once at the end so dashboards can spot pathological slot-resolution latency
+	// (e.g. when buffers saturate or the calculator gets expensive).
+	var findWorkerSlotDuration time.Duration
+	defer func() {
+		stats.Default.NewTaggedStat("router_pickup_find_worker_slot_time", stats.TimerType, stats.Tags{"destType": rt.destType, "partition": partition}).SendTiming(findWorkerSlotDuration)
+	}()
+
 	flushTime := time.Now()
 	shouldFlush := func() bool {
 		return len(statusList) > 0 && time.Since(flushTime) > rt.reloadableConfig.pickupFlushInterval.Load()
@@ -287,7 +295,9 @@ func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worke
 			rt.logger.Errorn("Error occurred while unmarshalling job parameters. Panicking", obskit.Error(err))
 			panic(err)
 		}
+		findStart := time.Now()
 		workerJobSlot, err := rt.findWorkerSlot(ctx, workers, job, parameters, blockedOrderKeys)
+		findWorkerSlotDuration += time.Since(findStart)
 		if err == nil {
 			traceParent := jsonparser.GetStringOrEmpty(job.Parameters, "traceparent")
 			if traceParent != "" {
@@ -626,6 +636,24 @@ type workerJobSlot struct {
 	drainReason string
 }
 
+// reserveAnyWorkerSlot picks a random starting offset and walks the workers slice
+// with wrap-around, reserving the first worker that has a free slot. Returns nil if
+// no worker has capacity. ReserveSlot is the atomic decision point — there is no
+// pre-filter step (which would be redundant work and would race with the reservation).
+func reserveAnyWorkerSlot(workers []*worker) *reservedSlot {
+	n := len(workers)
+	if n == 0 {
+		return nil
+	}
+	start := rand.Intn(n)
+	for i := range n {
+		if slot := workers[(start+i)%n].ReserveSlot(); slot != nil {
+			return slot
+		}
+	}
+	return nil
+}
+
 func (rt *Handle) findWorkerSlot(ctx context.Context, workers []*worker, job *jobsdb.JobT, parameters routerutils.JobParameters, blockedOrderKeys map[eventorder.BarrierKey]struct{}) (*workerJobSlot, error) {
 	if rt.backgroundCtx.Err() != nil {
 		return nil, types.ErrContextCancelled
@@ -649,11 +677,11 @@ func (rt *Handle) findWorkerSlot(ctx context.Context, workers []*worker, job *jo
 	}
 	abortedJob, abortReason := rt.drainOrRetryLimitReached(job.CreatedAt, parameters.DestinationID, parameters.SourceJobRunID, &job.LastJobStatus) // if job's aborted, then send it to its worker right away
 	if eventOrderingDisabled {
-		availableWorkers := lo.Filter(workers, func(w *worker, _ int) bool { return w.AvailableSlots() > 0 })
-		if len(availableWorkers) == 0 {
-			return nil, types.ErrWorkerNoSlot
-		}
-		slot := availableWorkers[rand.Intn(len(availableWorkers))].ReserveSlot()
+		// Pick a random starting offset and walk the workers slice with wrap-around,
+		// reserving the first worker that has a free slot. ReserveSlot is the atomic
+		// decision point — checking AvailableSlots() first would be redundant work
+		// and would also leave a race window between the check and the reservation.
+		slot := reserveAnyWorkerSlot(workers)
 		if slot == nil {
 			return nil, types.ErrWorkerNoSlot
 		}

--- a/router/partition_worker.go
+++ b/router/partition_worker.go
@@ -20,11 +20,13 @@ import (
 // newPartitionWorker creates a worker that is responsible for picking up jobs for a single partition (none, workspace, destination).
 // A partition worker uses multiple workers internally to process the jobs that are being picked up asynchronously.
 func newPartitionWorker(ctx context.Context, rt *Handle, partition string) *partitionWorker {
+	samplerCtx, samplerCancel := context.WithCancel(context.Background())
 	pw := &partitionWorker{
 		logger:               rt.logger.Child("p-" + partition),
 		rt:                   rt,
 		partition:            partition,
 		ctx:                  ctx,
+		samplerCancel:        samplerCancel,
 		pickupBatchSizeGauge: newGaugeWithLastValue[int](stats.Default.NewTaggedStat("router_pickup_batch_size_gauge", stats.GaugeType, stats.Tags{"destType": rt.destType, "partition": partition})),
 	}
 	pw.g, _ = errgroup.WithContext(context.Background())
@@ -88,6 +90,25 @@ func newPartitionWorker(ctx context.Context, rt *Handle, partition string) *part
 		}))
 
 	}
+
+	// Sampler: refreshes each worker buffer's cached capacity once per second so the
+	// hot path (worker.AvailableSlots) doesn't have to invoke the calculator on every
+	// call. Stops when samplerCancel is called from Stop().
+	pw.g.Go(crash.Wrapper(func() error {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-samplerCtx.Done():
+				return nil
+			case <-ticker.C:
+				for _, w := range pw.workers {
+					w.workerBuffer.refreshCapacity()
+				}
+			}
+		}
+	}))
+
 	return pw
 }
 
@@ -102,6 +123,7 @@ type partitionWorker struct {
 	// state
 	ctx                  context.Context
 	g                    *errgroup.Group         // group against which all the workers are spawned
+	samplerCancel        context.CancelFunc      // stops the buffer-capacity sampler goroutine
 	pickupBatchSizeGauge GaugeWithLastValue[int] // gauge to track the pickup batch size used in the last pickup iteration
 	workers              []*worker               // workers that are responsible for processing the jobs
 
@@ -137,6 +159,7 @@ func (pw *partitionWorker) SleepDurations() (min, max time.Duration) {
 
 // Stop stops the partitioned worker by closing the input channel of all its internal workers and waiting for them to finish
 func (pw *partitionWorker) Stop() {
+	pw.samplerCancel()
 	for _, worker := range pw.workers {
 		worker.cancelFunc()
 		worker.workerBuffer.Close()

--- a/router/worker_buffer.go
+++ b/router/worker_buffer.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
@@ -10,10 +11,17 @@ import (
 // workerBuffer represents a buffer for a worker to hold jobs before processing.
 // It supports dynamic sizing based on a target size function
 // and allows reservation of slots to control job intake.
+//
+// The current capacity is cached in cachedCapacity and refreshed periodically by an
+// external sampler (see partitionWorker) via refreshCapacity(). The hot read path
+// (AvailableSlots) reads the cached value with an atomic load instead of invoking
+// the calculator on every call — this matters at high worker counts where the
+// calculator + stats observation dominate findWorkerSlot's cost.
 type workerBuffer struct {
 	maxCapacity    int
 	targetCapacity func() int
 	jobs           chan *workerJob
+	cachedCapacity atomic.Int64
 
 	stats        *workerBufferStats
 	mu           sync.RWMutex
@@ -39,6 +47,7 @@ func newWorkerBuffer(maxCapacity int, targetCapacity func() int, stats *workerBu
 		jobs:           make(chan *workerJob, maxCapacity),
 		stats:          stats,
 	}
+	wb.refreshCapacity()
 	return wb
 }
 
@@ -53,6 +62,7 @@ func newSimpleWorkerBuffer(capacity int) *workerBuffer {
 		jobs:           make(chan *workerJob, capacity),
 		stats:          nil,
 	}
+	wb.refreshCapacity()
 	return wb
 }
 
@@ -60,14 +70,13 @@ func (wb *workerBuffer) Jobs() <-chan *workerJob {
 	return wb.jobs
 }
 
-func (wb *workerBuffer) currentCapacity() int {
-	capacity := wb.targetCapacity()
-	if capacity < 1 {
-		return 1
-	}
-	if capacity > wb.maxCapacity {
-		capacity = wb.maxCapacity
-	}
+// refreshCapacity recomputes the buffer's target capacity (clamped to [1, maxCapacity]),
+// updates the cached value used by the AvailableSlots hot path, and observes stats.
+// It is invoked by an external sampler (typically once per second from partitionWorker)
+// and also from the constructor and tests; the returned int is the freshly computed value.
+func (wb *workerBuffer) refreshCapacity() int {
+	capacity := min(max(wb.targetCapacity(), 1), wb.maxCapacity)
+	wb.cachedCapacity.Store(int64(capacity))
 	if wb.stats != nil {
 		wb.stats.onceEvery.Do(func() {
 			wb.stats.currentCapacity.Observe(float64(capacity))
@@ -88,7 +97,7 @@ func (wb *workerBuffer) availableSlots() int {
 	if wb.closed {
 		return 0
 	}
-	available := wb.currentCapacity() - wb.reservations - len(wb.jobs)
+	available := int(wb.cachedCapacity.Load()) - wb.reservations - len(wb.jobs)
 	if available < 0 {
 		return 0
 	}

--- a/router/worker_buffer_test.go
+++ b/router/worker_buffer_test.go
@@ -23,7 +23,7 @@ func TestWorkerBuffer(t *testing.T) {
 			wb := newWorkerBuffer(maxSize, targetSize, nil)
 
 			require.Equal(t, maxSize, wb.maxCapacity)
-			require.Equal(t, maxSize, wb.currentCapacity())
+			require.Equal(t, maxSize, wb.refreshCapacity())
 			require.Equal(t, 0, wb.reservations)
 			require.NotNil(t, wb.jobs)
 			require.Equal(t, maxSize, cap(wb.jobs))
@@ -34,20 +34,20 @@ func TestWorkerBuffer(t *testing.T) {
 			t.Run("minimum size", func(t *testing.T) {
 				wb := newWorkerBuffer(1, func() int { return 1 }, nil)
 				require.Equal(t, 1, wb.maxCapacity)
-				require.Equal(t, 1, wb.currentCapacity())
+				require.Equal(t, 1, wb.refreshCapacity())
 			})
 
 			t.Run("zero size", func(t *testing.T) {
 				wb := newWorkerBuffer(0, func() int { return 0 }, nil)
 				require.Equal(t, 1, wb.maxCapacity)
-				require.Equal(t, 1, wb.currentCapacity())
+				require.Equal(t, 1, wb.refreshCapacity())
 				require.Equal(t, 1, cap(wb.jobs))
 			})
 
 			t.Run("large size", func(t *testing.T) {
 				wb := newWorkerBuffer(1000, func() int { return 1000 }, nil)
 				require.Equal(t, 1000, wb.maxCapacity)
-				require.Equal(t, 1000, wb.currentCapacity())
+				require.Equal(t, 1000, wb.refreshCapacity())
 			})
 		})
 
@@ -68,21 +68,21 @@ func TestWorkerBuffer(t *testing.T) {
 			wb := newWorkerBuffer(20, func() int { return targetSize }, nil)
 
 			t.Run("initial size", func(t *testing.T) {
-				require.Equal(t, 10, wb.currentCapacity())
+				require.Equal(t, 10, wb.refreshCapacity())
 			})
 
 			t.Run("change target to smaller size", func(t *testing.T) {
 				targetSize = 5
-				require.Equal(t, 5, wb.currentCapacity())
+				require.Equal(t, 5, wb.refreshCapacity())
 			})
 
 			t.Run("change target to larger size", func(t *testing.T) {
 				targetSize = 15
-				require.Equal(t, 15, wb.currentCapacity())
+				require.Equal(t, 15, wb.refreshCapacity())
 			})
 
 			t.Run("target same size (no-op)", func(t *testing.T) {
-				require.Equal(t, 15, wb.currentCapacity())
+				require.Equal(t, 15, wb.refreshCapacity())
 			})
 		})
 
@@ -92,25 +92,25 @@ func TestWorkerBuffer(t *testing.T) {
 
 			t.Run("target equals maxSize", func(t *testing.T) {
 				targetSize = 10
-				require.Equal(t, 10, wb.currentCapacity())
+				require.Equal(t, 10, wb.refreshCapacity())
 			})
 
 			t.Run("target above maxSize (should cap)", func(t *testing.T) {
 				targetSize = 15
-				require.Equal(t, 10, wb.currentCapacity()) // should be capped to maxSize
+				require.Equal(t, 10, wb.refreshCapacity()) // should be capped to maxSize
 			})
 
 			t.Run("target minimum (1)", func(t *testing.T) {
 				targetSize = 1
-				require.Equal(t, 1, wb.currentCapacity())
+				require.Equal(t, 1, wb.refreshCapacity())
 			})
 
 			t.Run("target below 1 (should set to 1)", func(t *testing.T) {
 				targetSize = 0
-				require.Equal(t, 1, wb.currentCapacity())
+				require.Equal(t, 1, wb.refreshCapacity())
 
 				targetSize = -5
-				require.Equal(t, 1, wb.currentCapacity())
+				require.Equal(t, 1, wb.refreshCapacity())
 			})
 		})
 
@@ -134,7 +134,7 @@ func TestWorkerBuffer(t *testing.T) {
 					targetSizeMu.Unlock()
 
 					// Check that currentSize returns a valid value
-					current := wb.currentCapacity()
+					current := wb.refreshCapacity()
 					require.True(t, current >= 1)
 					require.True(t, current <= wb.maxCapacity)
 				}(i)
@@ -143,8 +143,8 @@ func TestWorkerBuffer(t *testing.T) {
 			wg.Wait()
 
 			// Verify final state is valid
-			require.True(t, wb.currentCapacity() >= 1)
-			require.True(t, wb.currentCapacity() <= wb.maxCapacity)
+			require.True(t, wb.refreshCapacity() >= 1)
+			require.True(t, wb.refreshCapacity() <= wb.maxCapacity)
 		})
 	})
 
@@ -205,7 +205,8 @@ func TestWorkerBuffer(t *testing.T) {
 			targetSize := 10
 			wb := newWorkerBuffer(10, func() int { return targetSize }, nil)
 
-			targetSize = 5 // change target size
+			targetSize = 5       // change target size
+			wb.refreshCapacity() // simulate the periodic sampler picking up the change
 			slots := wb.AvailableSlots()
 			require.Equal(t, 5, slots)
 		})
@@ -435,8 +436,8 @@ func TestWorkerBuffer(t *testing.T) {
 
 			// Verify invariants
 			require.True(t, wb.reservations >= 0)
-			require.True(t, wb.currentCapacity() >= 1)
-			require.True(t, wb.currentCapacity() <= wb.maxCapacity)
+			require.True(t, wb.refreshCapacity() >= 1)
+			require.True(t, wb.refreshCapacity() <= wb.maxCapacity)
 			require.True(t, len(wb.jobs) <= cap(wb.jobs))
 		})
 	})
@@ -477,8 +478,8 @@ func TestWorkerBuffer(t *testing.T) {
 			targetSize := 5
 			wb := newWorkerBuffer(10, func() int { return targetSize }, bufferStats)
 
-			// Call currentCapacity to trigger stats recording
-			capacity := wb.currentCapacity()
+			// Call refreshCapacity to trigger stats recording
+			capacity := wb.refreshCapacity()
 			require.Equal(t, 5, capacity)
 
 			// Verify metrics were recorded
@@ -513,15 +514,19 @@ func TestWorkerBuffer(t *testing.T) {
 			wb.jobs <- &job1
 			wb.jobs <- &job2
 
+			// Wait past the OnceEvery window so the next observation isn't throttled
+			// by the initial observation made in the constructor.
+			time.Sleep(20 * time.Millisecond)
 			// Trigger stats recording
-			wb.currentCapacity()
+			wb.refreshCapacity()
 
-			// Verify size metric reflects the added jobs
+			// Verify size metric reflects the added jobs (initial constructor observation
+			// recorded 0; the post-sleep call above records the current size of 2).
 			sizeMetrics := memStats.GetByName("worker_buffer_size")
 			require.Len(t, sizeMetrics, 1, "Expected exactly one size metric")
 			require.Equal(t, stats.Tags{"test": "dynamic"}, sizeMetrics[0].Tags)
-			require.Len(t, sizeMetrics[0].Values, 1, "Expected exactly one size observation")
-			require.Equal(t, float64(2), sizeMetrics[0].Values[0])
+			require.Len(t, sizeMetrics[0].Values, 2, "Expected initial + post-sleep observations")
+			require.Equal(t, float64(2), sizeMetrics[0].Values[1])
 		})
 
 		t.Run("stats track capacity changes", func(t *testing.T) {
@@ -538,12 +543,12 @@ func TestWorkerBuffer(t *testing.T) {
 			wb := newWorkerBuffer(20, func() int { return targetSize }, bufferStats)
 
 			// Record initial capacity
-			wb.currentCapacity()
+			wb.refreshCapacity()
 			time.Sleep(20 * time.Millisecond) // sleep for >onceEvery
 
 			// Change target size
 			targetSize = 15
-			wb.currentCapacity()
+			wb.refreshCapacity()
 
 			// Verify both capacity values were recorded
 			capacityMetrics := memStats.GetByName("worker_buffer_capacity")
@@ -566,9 +571,9 @@ func TestWorkerBuffer(t *testing.T) {
 
 			wb := newWorkerBuffer(10, func() int { return 5 }, bufferStats)
 
-			// Call currentCapacity multiple times rapidly
+			// Call refreshCapacity multiple times rapidly
 			for range 5 {
-				wb.currentCapacity()
+				wb.refreshCapacity()
 				time.Sleep(10 * time.Millisecond)
 			}
 
@@ -585,7 +590,7 @@ func TestWorkerBuffer(t *testing.T) {
 
 			// Should not panic when stats is nil
 			require.NotPanics(t, func() {
-				wb.currentCapacity()
+				wb.refreshCapacity()
 			})
 		})
 
@@ -594,7 +599,7 @@ func TestWorkerBuffer(t *testing.T) {
 
 			require.Nil(t, wb.stats)
 			require.NotPanics(t, func() {
-				wb.currentCapacity()
+				wb.refreshCapacity()
 			})
 		})
 
@@ -618,7 +623,7 @@ func TestWorkerBuffer(t *testing.T) {
 
 			var wg sync.WaitGroup
 
-			// Launch multiple goroutines that access currentCapacity concurrently
+			// Launch multiple goroutines that access refreshCapacity concurrently
 			for i := range 10 {
 				wg.Add(1)
 				go func(id int) {
@@ -632,7 +637,7 @@ func TestWorkerBuffer(t *testing.T) {
 					}
 
 					// Access current capacity
-					capacity := wb.currentCapacity()
+					capacity := wb.refreshCapacity()
 					require.True(t, capacity >= 1)
 					require.True(t, capacity <= wb.maxCapacity)
 
@@ -679,7 +684,7 @@ func TestWorkerBuffer(t *testing.T) {
 
 			time.Sleep(20 * time.Millisecond)
 			// Trigger stats recording after job usage
-			wb.currentCapacity()
+			wb.refreshCapacity()
 
 			// Verify metrics reflect the workflow
 			sizeMetrics := memStats.GetByName("worker_buffer_size")


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

# Description

## Observed problem

When event ordering is disabled, `Handle.findWorkerSlot` becomes unexpectedly slow at high worker counts. With 512 workers per partition and the experimental buffer-size calculator enabled, each call to find a worker slot took ~47 µs locally — meaning a single pickup batch of 6 000 events spent ~280 ms of CPU just resolving which worker to assign each job to, before any actual processing happened. Latency is even worse on production machines.

## Root causes

The slow path is the event-ordering-disabled branch in `findWorkerSlot`:

```go
availableWorkers := lo.Filter(workers, func(w *worker, _ int) bool { return w.AvailableSlots() > 0 })
if len(availableWorkers) == 0 { return nil, types.ErrWorkerNoSlot }
slot := availableWorkers[rand.Intn(len(availableWorkers))].ReserveSlot()
```

Two compounding problems:

1. **`AvailableSlots()` recomputes the buffer's target capacity on every call.** Inside `workerBuffer.currentCapacity()`, the calculator closure runs (for the experimental calculator: a `SimpleMovingAverage.Load`, multiple `ValueLoader.Load`s, and `math.Max`/`math.Ceil`), plus the stats `OnceEvery.Do` check fires — and this happens **513 times per call** (once per worker for the filter, then once more on the chosen worker's `ReserveSlot`). With stats wired up, this path costs ~47 µs/call.

2. **Filter-then-pick is structurally redundant and racy.** `lo.Filter` allocates a ~5 KB survivor slice, takes 512 RLocks just to ask "do you have a slot?", then we take a write Lock on the chosen worker to actually reserve. The first 512 reads are throwaway work, and there's a (currently benign, single-threaded) race window between the filter and the reservation.

## What we're doing

**1. Cache the buffer capacity, refresh it from a 1 s sampler.**
- `workerBuffer` gains a `cachedCapacity atomic.Int64` field (initialized in the constructor).
- `availableSlots()` reads the cached value with an atomic load instead of invoking the calculator.
- `partitionWorker` runs a single sampler goroutine that ticks once per second and calls `refreshCapacity()` on every worker buffer it owns. The sampler is cancelled cleanly from `Stop()`.
- Since the calculator inputs (config values, throughput SMA) move slowly, a 1 s lag is harmless — production already throttles the corresponding stats observation to every 5 s via `OnceEvery`.

**2. Replace filter+pick with shuffle-and-try.**
- New helper `reserveAnyWorkerSlot(workers)` picks a random starting offset and walks the workers slice with wrap-around, calling `ReserveSlot` until one succeeds.
- `ReserveSlot` is the atomic decision point — no pre-filter step, no race window, no allocation for the survivor slice.
- The random start gives uniform worker selection (in expectation) just like the old `rand.Intn` over the filter result.

**3. New observability stat for slot-resolution latency.**
- `router_pickup_find_worker_slot_time` (TimerType, tags: `destType`, `partition`) — total wall-clock time spent inside `findWorkerSlot` across a single pickup loop. Published once per pickup. Lets us catch regressions in the future, alert on pathological saturation (when buffers run dry and `findWorkerSlot` keeps failing fast across all workers), and confirm the impact of this change in production.

## Benchmark results

Added `BenchmarkFindWorkerSlot` in `router/find_worker_slot_bench_test.go`. It exercises 512 workers across all three production buffer modes (`simple`, `dynamic/standard`, `dynamic/experimental`) and five fill scenarios. Numbers below are from an Apple M1 Pro at 2 s/case for the worst production mode (`dynamic/experimental` — switcher with `enableExperimental=true`, full `workerBufferStats` wired up).

| scenario | before | + cached capacity | + shuffleTry (this PR) |
|---|---|---|---|
| typical (slots widely available) | ~47 µs/op, 4 872 B/op | ~6.7 µs/op, 4 872 B/op | **~45 ns/op, 8 B/op** |
| 50% of workers full | ~47 µs/op | ~6.7 µs/op | **~1.1 µs/op** |
| 99% of workers full | ~47 µs/op | ~6.7 µs/op | **~4.3 µs/op** |
| 99.8% of workers full | ~47 µs/op | ~6.4 µs/op | **~4.4 µs/op** |

Even in the catastrophic 99.8%-full case, the new path wins — and allocations drop from ~5 KB/call to 8 B/call (boxed `int` from `rand.Intn`).

Extrapolated to a 6 000-event pickup batch, in the typical case:
- Before: ~280 ms of CPU just resolving worker slots.
- After: ~0.27 ms — roughly **1 000× lower CPU cost** on the hot path.

## Linear Ticket

resolves PIPE-2949

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.