### PR TITLE
hackathon: forward post-UT events to alpha service

### DIFF
--- a/processor/alpha/CONTRACT.md
+++ b/processor/alpha/CONTRACT.md
@@ -52,7 +52,7 @@ Wire example:
 | `events`      | array  | One or more `IngestEvent`. Always non-empty (we skip the POST if there's nothing to send). |
 | `events[].userID`    | string | The end-user identifier from the original event. **Always non-empty** — we filter out events without a `userId` before batching. |
 | `events[].messageID` | string | RudderStack's per-event UUID. Stable across retries of the same batch. Treat as the natural primary key. |
-| `events[].eventName` | string | RudderStack event name (e.g. `"Order Completed"`). May be empty for some event types. |
+| `events[].eventName` | string | RudderStack event name (e.g. `"Order Completed"`). **Always non-empty** — we filter out events with an empty `eventName` before batching. |
 
 We do **not** send the optional `properties` field. It's never present in the JSON; alpha can rely on the `omitempty` semantics.
 

--- a/processor/alpha/CONTRACT.md
+++ b/processor/alpha/CONTRACT.md
@@ -40,8 +40,9 @@ No other fields. No nesting. No metadata wrapper.
 
 - Up to **10 attempts** per event.
 - **30 seconds** between attempts (constant delay, no backoff).
-- **5 second** per-request timeout.
-- Worst case: ~5 minutes per event before we give up. Designed to survive an alpha-service restart.
+- **60 second** per-request timeout.
+- If alpha is down (connection refused / fails fast): worst case ~5 minutes per event before we give up — designed to survive an alpha-service restart.
+- If alpha is up but hangs every request: worst case ~14.5 minutes per event (10×60s timeout + 9×30s delay).
 - After 10 failed attempts we drop the event and log a warning on our side. We do **not** persist or queue past that.
 
 This means: if you restart your service, expect duplicate deliveries of in-flight events. If you respond 5xx, we'll keep hammering you on a 30-second cadence until either you return 200 or we hit 10 attempts.

--- a/processor/alpha/CONTRACT.md
+++ b/processor/alpha/CONTRACT.md
@@ -5,90 +5,120 @@ This is the contract the rudder-server side implements when forwarding post-user
 ## Endpoint
 
 - **Method:** `POST`
-- **URL:** the full URL you give us. We use it verbatim — no path is appended. Example: `http://alpha.local:8080/events`. Configure on our side via env var `ALPHA_SERVICE_URL`.
+- **URL:** the full URL you give us. We use it verbatim — no path is appended. Example: `http://alpha.local:8080/events`. Configure on our side via the `alphaServiceUrl` config key (env var: `RSERVER_ALPHA_SERVICE_URL`).
 - **Content-Type:** `application/json`
 - **Auth:** none. No headers, no tokens.
 
-## Request body
+## Request body — batched
 
-A single JSON object per event:
+Each request carries a batch of events sharing one workspace. Mirrors the Go structs you defined:
+
+```go
+type IngestEvent struct {
+    UserID    string `json:"userID"`
+    MessageID string `json:"messageID"`
+    EventName string `json:"eventName"`
+}
+
+type EventsRequest struct {
+    WorkspaceID string         `json:"workspaceID"`
+    Events      []IngestEvent  `json:"events"`
+}
+```
+
+Wire example:
 
 ```json
 {
-  "eventName":   "Order Completed",
-  "messageId":   "1c5e8f2a-3d2b-4d6e-9a17-2b1e0c8c0a4d",
-  "workspaceId": "2gN8z5Vc3mL4kPq6sTxR1yWb9hF",
-  "userId":      "user_42"
+  "workspaceID": "2gN8z5Vc3mL4kPq6sTxR1yWb9hF",
+  "events": [
+    {
+      "userID":    "user_42",
+      "messageID": "1c5e8f2a-3d2b-4d6e-9a17-2b1e0c8c0a4d",
+      "eventName": "Order Completed"
+    },
+    {
+      "userID":    "user_77",
+      "messageID": "8a1b3c5d-7e9f-4011-a223-3344556677aa",
+      "eventName": "Page Viewed"
+    }
+  ]
 }
 ```
 
 | Field | Type | Notes |
 |---|---|---|
-| `eventName`   | string | RudderStack event name (e.g. `"Order Completed"`, `"Page Viewed"`). May be empty for some event types. |
-| `messageId`   | string | RudderStack's per-event UUID. Stable across retries of the same event. Treat as the natural primary key. |
-| `workspaceId` | string | RudderStack workspace identifier. Always non-empty. |
-| `userId`      | string | The end-user identifier from the original event. **Always non-empty** — we filter out events without a `userId` before sending. |
+| `workspaceID` | string | RudderStack workspace identifier. Always non-empty. All events in a single request share this value. |
+| `events`      | array  | One or more `IngestEvent`. Always non-empty (we skip the POST if there's nothing to send). |
+| `events[].userID`    | string | The end-user identifier from the original event. **Always non-empty** — we filter out events without a `userId` before batching. |
+| `events[].messageID` | string | RudderStack's per-event UUID. Stable across retries of the same batch. Treat as the natural primary key. |
+| `events[].eventName` | string | RudderStack event name (e.g. `"Order Completed"`). May be empty for some event types. |
 
-No other fields. No nesting. No metadata wrapper.
+We do **not** send the optional `properties` field. It's never present in the JSON; alpha can rely on the `omitempty` semantics.
 
 ## Response
 
 - **`200 OK`** — we treat as success and stop retrying. Body content is ignored; an empty body is fine.
-- **Anything else** (non-200 status, connection refused, timeout, TCP reset, etc.) — we treat as failure and retry.
+- **Anything else** (non-200 status, connection refused, timeout, TCP reset, etc.) — we treat the **entire batch** as failed and retry the whole batch.
 
-## Retry behavior (so you know what to expect from us)
+## Retry behavior
 
-- Up to **10 attempts** per event.
+- Up to **10 attempts** per batch.
 - **30 seconds** between attempts (constant delay, no backoff).
 - **60 second** per-request timeout.
-- If alpha is down (connection refused / fails fast): worst case ~5 minutes per event before we give up — designed to survive an alpha-service restart.
-- If alpha is up but hangs every request: worst case ~14.5 minutes per event (10×60s timeout + 9×30s delay).
-- After 10 failed attempts we drop the event and log a warning on our side. We do **not** persist or queue past that.
+- If alpha is down (connection refused / fails fast): worst case ~5 minutes per batch before we give up.
+- If alpha is up but hangs every request: worst case ~14.5 minutes per batch (10×60s + 9×30s).
+- After 10 failed attempts we drop the entire batch and log a warning on our side. We do **not** persist or queue past that.
 
-This means: if you restart your service, expect duplicate deliveries of in-flight events. If you respond 5xx, we'll keep hammering you on a 30-second cadence until either you return 200 or we hit 10 attempts.
+This means: if you respond 5xx, we'll keep hammering you with the same batch on a 30-second cadence. If you crash mid-write and only persisted some events, the next retry will redeliver the full batch — see Idempotency below.
 
 ## Idempotency
 
-We do **not** dedupe on our side. The same `messageId` can arrive at your service multiple times because:
+We do **not** dedupe on our side. The same `messageID` can arrive at your service multiple times because:
 
-1. We retry on non-200 responses, so a request that succeeds at your end but fails to deliver the response (network blip) will be retried.
-2. If a single source event is fanned out to multiple destinations in RudderStack, each post-user-transformation pass will produce its own POST. The `messageId` will be the same; `eventName` *may* differ if a destination's user transformation renamed the event.
+1. We retry the whole batch on any non-200 response, so a request that succeeded at your end but failed to deliver the response (network blip) will be retried.
+2. If a single source event is fanned out to multiple destinations in RudderStack, each post-user-transformation pass for each destination produces its own batch. The `messageID` will be the same; `eventName` *may* differ if a destination's user transformation renamed the event.
 
-If your service needs to count each event once, dedupe on `messageId` (e.g. a Redis `SET` with TTL).
+If your service needs to count each event once, dedupe on `messageID` (e.g. a Redis `SET` with TTL).
 
 ## Concurrency & volume
 
-- Up to **4 concurrent in-flight requests** from us.
-- Demo throughput: **trickle, 1–10 events/sec**.
-- One request per event (no batching).
+- Up to **4 concurrent in-flight batches** from us (we run a 4-worker pool draining a 200-batch buffer).
+- Demo throughput: **trickle, 1–10 events/sec source rate**. Batches typically hold 1–20 events at peak; small batches are normal.
+- One POST per source-destination pair invocation in the processor pipeline — we do **not** time-window or cross-pair accumulate.
 
 ## What we do NOT send
 
 - No authentication headers.
 - No custom headers beyond `Content-Type`.
-- No `anonymousId`, no event properties, no traits, no timestamps, no original payload — only the four fields listed above.
-- No batch endpoint — every event is its own POST.
+- No `anonymousId`, no `properties`, no traits, no timestamps, no original payload — only the fields listed above.
+- Empty batches: skipped entirely (no POST).
 
 ## Suggested minimal handler
 
 A 200 OK to every well-formed POST is enough to pass the contract end-to-end:
+
+```go
+// Go example
+http.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
+    var req EventsRequest
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        http.Error(w, err.Error(), http.StatusBadRequest)
+        return
+    }
+    log.Printf("workspace=%s events=%d", req.WorkspaceID, len(req.Events))
+    w.WriteHeader(http.StatusOK)
+})
+```
 
 ```python
 # Flask example
 @app.post("/events")
 def events():
     payload = request.get_json(force=True)
-    # payload is {"eventName", "messageId", "workspaceId", "userId"}
-    print(payload)
+    # payload is {"workspaceID": "...", "events": [...]}
+    print(payload["workspaceID"], len(payload["events"]))
     return ("", 200)
-```
-
-```javascript
-// Express example
-app.post("/events", express.json(), (req, res) => {
-  console.log(req.body);
-  res.sendStatus(200);
-});
 ```
 
 That's the entire contract. Ping me if anything is ambiguous.

--- a/processor/alpha/CONTRACT.md
+++ b/processor/alpha/CONTRACT.md
@@ -1,0 +1,93 @@
+# Alpha Service — HTTP Contract
+
+This is the contract the rudder-server side implements when forwarding post-user-transformation events to the alpha service. Hackathon scope, one-time demo — please implement just enough to satisfy this.
+
+## Endpoint
+
+- **Method:** `POST`
+- **URL:** the full URL you give us. We use it verbatim — no path is appended. Example: `http://alpha.local:8080/events`. Configure on our side via env var `ALPHA_SERVICE_URL`.
+- **Content-Type:** `application/json`
+- **Auth:** none. No headers, no tokens.
+
+## Request body
+
+A single JSON object per event:
+
+```json
+{
+  "eventName":   "Order Completed",
+  "messageId":   "1c5e8f2a-3d2b-4d6e-9a17-2b1e0c8c0a4d",
+  "workspaceId": "2gN8z5Vc3mL4kPq6sTxR1yWb9hF",
+  "userId":      "user_42"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `eventName`   | string | RudderStack event name (e.g. `"Order Completed"`, `"Page Viewed"`). May be empty for some event types. |
+| `messageId`   | string | RudderStack's per-event UUID. Stable across retries of the same event. Treat as the natural primary key. |
+| `workspaceId` | string | RudderStack workspace identifier. Always non-empty. |
+| `userId`      | string | The end-user identifier from the original event. **Always non-empty** — we filter out events without a `userId` before sending. |
+
+No other fields. No nesting. No metadata wrapper.
+
+## Response
+
+- **`200 OK`** — we treat as success and stop retrying. Body content is ignored; an empty body is fine.
+- **Anything else** (non-200 status, connection refused, timeout, TCP reset, etc.) — we treat as failure and retry.
+
+## Retry behavior (so you know what to expect from us)
+
+- Up to **10 attempts** per event.
+- **30 seconds** between attempts (constant delay, no backoff).
+- **5 second** per-request timeout.
+- Worst case: ~5 minutes per event before we give up. Designed to survive an alpha-service restart.
+- After 10 failed attempts we drop the event and log a warning on our side. We do **not** persist or queue past that.
+
+This means: if you restart your service, expect duplicate deliveries of in-flight events. If you respond 5xx, we'll keep hammering you on a 30-second cadence until either you return 200 or we hit 10 attempts.
+
+## Idempotency
+
+We do **not** dedupe on our side. The same `messageId` can arrive at your service multiple times because:
+
+1. We retry on non-200 responses, so a request that succeeds at your end but fails to deliver the response (network blip) will be retried.
+2. If a single source event is fanned out to multiple destinations in RudderStack, each post-user-transformation pass will produce its own POST. The `messageId` will be the same; `eventName` *may* differ if a destination's user transformation renamed the event.
+
+If your service needs to count each event once, dedupe on `messageId` (e.g. a Redis `SET` with TTL).
+
+## Concurrency & volume
+
+- Up to **4 concurrent in-flight requests** from us.
+- Demo throughput: **trickle, 1–10 events/sec**.
+- One request per event (no batching).
+
+## What we do NOT send
+
+- No authentication headers.
+- No custom headers beyond `Content-Type`.
+- No `anonymousId`, no event properties, no traits, no timestamps, no original payload — only the four fields listed above.
+- No batch endpoint — every event is its own POST.
+
+## Suggested minimal handler
+
+A 200 OK to every well-formed POST is enough to pass the contract end-to-end:
+
+```python
+# Flask example
+@app.post("/events")
+def events():
+    payload = request.get_json(force=True)
+    # payload is {"eventName", "messageId", "workspaceId", "userId"}
+    print(payload)
+    return ("", 200)
+```
+
+```javascript
+// Express example
+app.post("/events", express.json(), (req, res) => {
+  console.log(req.body);
+  res.sendStatus(200);
+});
+```
+
+That's the entire contract. Ping me if anything is ambiguous.

--- a/processor/alpha/dispatcher.go
+++ b/processor/alpha/dispatcher.go
@@ -21,22 +21,22 @@ import (
 )
 
 const (
-	// channelBuffer caps how many events can be queued for delivery before
-	// new events get dropped. Sized for trickle-volume hackathon demos
-	// (1-10 events/sec); during a 5-min alpha outage the buffer fills, then
-	// new events are dropped.
-	channelBuffer = 1000
-	// workerCount is how many goroutines drain the channel and POST in
-	// parallel. With maxAttempts*retryDelay worst-case latency, each worker
-	// can be tied up for ~5 min during a full alpha outage.
+	// channelBuffer caps how many batches can be queued for delivery before
+	// new batches get dropped. Sized for trickle-volume hackathon demos
+	// (1-10 events/sec → ~1-2 batches/sec).
+	channelBuffer = 200
+	// workerCount is how many goroutines drain the channel and POST batches
+	// in parallel. With maxAttempts*retryDelay worst-case latency, each
+	// worker can be tied up for several minutes during a full alpha outage.
 	workerCount = 4
 
-	// Retry policy: 10 attempts, 30s between attempts, ~5 min worst case.
+	// Retry policy: 10 attempts, 30s between attempts, ~5 min worst case
+	// for a fast-failing alpha and ~14.5 min worst case for a hanging alpha.
 	maxAttempts = 10
 	retryDelay  = 30 * time.Second
 
-	// Per-request timeout. Short enough that hung requests don't extend the
-	// overall retry budget unreasonably.
+	// Per-request timeout. Bumped to 60s to accommodate slower alpha
+	// responses while keeping connection-refused failure mode quick.
 	requestTimeout = 60 * time.Second
 
 	// Rate-limit channel-full drop logs: log every Nth drop to avoid spam
@@ -44,21 +44,28 @@ const (
 	dropLogEveryN = 100
 )
 
-// Event is the payload sent to the alpha service for each post-UT event.
-type Event struct {
-	EventName   string `json:"eventName"`
-	MessageID   string `json:"messageId"`
-	WorkspaceID string `json:"workspaceId"`
-	UserID      string `json:"userId"`
+// IngestEvent is the per-event subset of a batch sent to the alpha service.
+// JSON field names use capital "ID" to match the alpha service's Go struct.
+type IngestEvent struct {
+	UserID    string `json:"userID"`
+	MessageID string `json:"messageID"`
+	EventName string `json:"eventName"`
 }
 
-// Dispatcher fires events asynchronously to the alpha service with retries.
+// EventsRequest is the batch payload POSTed to the alpha service. All events
+// in a single request share one WorkspaceID.
+type EventsRequest struct {
+	WorkspaceID string        `json:"workspaceID"`
+	Events      []IngestEvent `json:"events"`
+}
+
+// Dispatcher fires batches asynchronously to the alpha service with retries.
 // When constructed with an empty URL, it is disabled and Dispatch is a no-op.
 type Dispatcher struct {
 	url       string
 	enabled   bool
 	logger    logger.Logger
-	ch        chan Event
+	ch        chan EventsRequest
 	client    *http.Client
 	dropCount uint64
 }
@@ -74,10 +81,10 @@ func NewDispatcher(url string, log logger.Logger) *Dispatcher {
 		client:  &http.Client{Timeout: requestTimeout},
 	}
 	if !d.enabled {
-		d.logger.Warnn("ALPHA_SERVICE_URL is empty; alpha dispatcher disabled")
+		d.logger.Warnn("alphaServiceUrl is empty; alpha dispatcher disabled")
 		return d
 	}
-	d.ch = make(chan Event, channelBuffer)
+	d.ch = make(chan EventsRequest, channelBuffer)
 	d.logger.Infon("alpha dispatcher initialized",
 		logger.NewStringField("url", url),
 		logger.NewIntField("workers", workerCount),
@@ -86,21 +93,24 @@ func NewDispatcher(url string, log logger.Logger) *Dispatcher {
 	return d
 }
 
-// Dispatch enqueues the event for delivery. Non-blocking: if the channel is
-// full, the event is dropped and a rate-limited warning is logged. Safe to
-// call when d is nil or disabled.
-func (d *Dispatcher) Dispatch(e Event) {
+// Dispatch enqueues the batch for delivery. Non-blocking: if the channel is
+// full, the batch is dropped and a rate-limited warning is logged. Safe to
+// call when d is nil or disabled, or when the batch is empty (both no-op).
+func (d *Dispatcher) Dispatch(req EventsRequest) {
 	if d == nil || !d.enabled {
 		return
 	}
+	if len(req.Events) == 0 {
+		return
+	}
 	select {
-	case d.ch <- e:
+	case d.ch <- req:
 	default:
 		n := atomic.AddUint64(&d.dropCount, 1)
 		if n%dropLogEveryN == 1 {
-			d.logger.Warnn("alpha dispatcher channel full; event dropped",
-				logger.NewStringField("messageId", e.MessageID),
-				logger.NewStringField("workspaceId", e.WorkspaceID),
+			d.logger.Warnn("alpha dispatcher channel full; batch dropped",
+				logger.NewStringField("workspaceId", req.WorkspaceID),
+				logger.NewIntField("eventCount", int64(len(req.Events))),
 				logger.NewIntField("totalDrops", int64(n)),
 			)
 		}
@@ -130,17 +140,18 @@ func (d *Dispatcher) worker(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case e := <-d.ch:
-			d.postWithRetry(ctx, e)
+		case req := <-d.ch:
+			d.postWithRetry(ctx, req)
 		}
 	}
 }
 
-func (d *Dispatcher) postWithRetry(ctx context.Context, e Event) {
-	body, err := json.Marshal(e)
+func (d *Dispatcher) postWithRetry(ctx context.Context, req EventsRequest) {
+	body, err := json.Marshal(req)
 	if err != nil {
 		d.logger.Warnn("alpha dispatcher: marshal failed",
-			logger.NewStringField("messageId", e.MessageID),
+			logger.NewStringField("workspaceId", req.WorkspaceID),
+			logger.NewIntField("eventCount", int64(len(req.Events))),
 			logger.NewStringField("error", err.Error()),
 		)
 		return
@@ -166,9 +177,8 @@ func (d *Dispatcher) postWithRetry(ctx context.Context, e Event) {
 		}
 	}
 	d.logger.Warnn("alpha dispatcher: giving up after max attempts",
-		logger.NewStringField("messageId", e.MessageID),
-		logger.NewStringField("workspaceId", e.WorkspaceID),
-		logger.NewStringField("userId", e.UserID),
+		logger.NewStringField("workspaceId", req.WorkspaceID),
+		logger.NewIntField("eventCount", int64(len(req.Events))),
 		logger.NewIntField("attempts", int64(maxAttempts)),
 		logger.NewIntField("lastStatus", int64(lastStatus)),
 		logger.NewStringField("lastError", errString(lastErr)),

--- a/processor/alpha/dispatcher.go
+++ b/processor/alpha/dispatcher.go
@@ -105,6 +105,10 @@ func (d *Dispatcher) Dispatch(req EventsRequest) {
 	}
 	select {
 	case d.ch <- req:
+		d.logger.Infon("alpha dispatcher: batch queued",
+			logger.NewStringField("workspaceId", req.WorkspaceID),
+			logger.NewIntField("eventCount", int64(len(req.Events))),
+		)
 	default:
 		n := atomic.AddUint64(&d.dropCount, 1)
 		if n%dropLogEveryN == 1 {
@@ -164,6 +168,11 @@ func (d *Dispatcher) postWithRetry(ctx context.Context, req EventsRequest) {
 		}
 		status, err := d.postOnce(ctx, body)
 		if err == nil && status == http.StatusOK {
+			d.logger.Infon("alpha dispatcher: batch delivered",
+				logger.NewStringField("workspaceId", req.WorkspaceID),
+				logger.NewIntField("eventCount", int64(len(req.Events))),
+				logger.NewIntField("attempts", int64(attempt)),
+			)
 			return
 		}
 		lastStatus, lastErr = status, err

--- a/processor/alpha/dispatcher.go
+++ b/processor/alpha/dispatcher.go
@@ -1,0 +1,200 @@
+// Package alpha provides a hackathon-only fire-and-forget HTTP dispatcher
+// that forwards a small subset of post-user-transformation event metadata to
+// an external "alpha" service.
+//
+// This is intentionally minimal — no metrics, no tests, no graceful drain.
+// It is wired into the processor at the post-UT pipeline stage and is meant
+// to be deleted (or hardened) after the hackathon.
+package alpha
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+)
+
+const (
+	// channelBuffer caps how many events can be queued for delivery before
+	// new events get dropped. Sized for trickle-volume hackathon demos
+	// (1-10 events/sec); during a 5-min alpha outage the buffer fills, then
+	// new events are dropped.
+	channelBuffer = 1000
+	// workerCount is how many goroutines drain the channel and POST in
+	// parallel. With maxAttempts*retryDelay worst-case latency, each worker
+	// can be tied up for ~5 min during a full alpha outage.
+	workerCount = 4
+
+	// Retry policy: 10 attempts, 30s between attempts, ~5 min worst case.
+	maxAttempts = 10
+	retryDelay  = 30 * time.Second
+
+	// Per-request timeout. Short enough that hung requests don't extend the
+	// overall retry budget unreasonably.
+	requestTimeout = 5 * time.Second
+
+	// Rate-limit channel-full drop logs: log every Nth drop to avoid spam
+	// during sustained outages.
+	dropLogEveryN = 100
+)
+
+// Event is the payload sent to the alpha service for each post-UT event.
+type Event struct {
+	EventName   string `json:"eventName"`
+	MessageID   string `json:"messageId"`
+	WorkspaceID string `json:"workspaceId"`
+	UserID      string `json:"userId"`
+}
+
+// Dispatcher fires events asynchronously to the alpha service with retries.
+// When constructed with an empty URL, it is disabled and Dispatch is a no-op.
+type Dispatcher struct {
+	url       string
+	enabled   bool
+	logger    logger.Logger
+	ch        chan Event
+	client    *http.Client
+	dropCount uint64
+}
+
+// NewDispatcher constructs a Dispatcher. When url is empty the dispatcher is
+// disabled; Dispatch becomes a no-op and Run returns immediately. A warning
+// is logged once at construction in that case.
+func NewDispatcher(url string, log logger.Logger) *Dispatcher {
+	d := &Dispatcher{
+		url:     url,
+		enabled: url != "",
+		logger:  log.Child("alpha-dispatcher"),
+		client:  &http.Client{Timeout: requestTimeout},
+	}
+	if !d.enabled {
+		d.logger.Warnn("ALPHA_SERVICE_URL is empty; alpha dispatcher disabled")
+		return d
+	}
+	d.ch = make(chan Event, channelBuffer)
+	d.logger.Infon("alpha dispatcher initialized",
+		logger.NewStringField("url", url),
+		logger.NewIntField("workers", workerCount),
+		logger.NewIntField("buffer", channelBuffer),
+	)
+	return d
+}
+
+// Dispatch enqueues the event for delivery. Non-blocking: if the channel is
+// full, the event is dropped and a rate-limited warning is logged. Safe to
+// call when d is nil or disabled.
+func (d *Dispatcher) Dispatch(e Event) {
+	if d == nil || !d.enabled {
+		return
+	}
+	select {
+	case d.ch <- e:
+	default:
+		n := atomic.AddUint64(&d.dropCount, 1)
+		if n%dropLogEveryN == 1 {
+			d.logger.Warnn("alpha dispatcher channel full; event dropped",
+				logger.NewStringField("messageId", e.MessageID),
+				logger.NewStringField("workspaceId", e.WorkspaceID),
+				logger.NewIntField("totalDrops", int64(n)),
+			)
+		}
+	}
+}
+
+// Run launches the worker pool and blocks until ctx is cancelled and all
+// workers have exited. Intended to be called from a long-lived goroutine
+// owned by the caller's lifecycle (e.g. processor.Setup's errgroup).
+func (d *Dispatcher) Run(ctx context.Context) {
+	if d == nil || !d.enabled {
+		return
+	}
+	var wg sync.WaitGroup
+	wg.Add(workerCount)
+	for i := 0; i < workerCount; i++ {
+		go func() {
+			defer wg.Done()
+			d.worker(ctx)
+		}()
+	}
+	wg.Wait()
+}
+
+func (d *Dispatcher) worker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case e := <-d.ch:
+			d.postWithRetry(ctx, e)
+		}
+	}
+}
+
+func (d *Dispatcher) postWithRetry(ctx context.Context, e Event) {
+	body, err := json.Marshal(e)
+	if err != nil {
+		d.logger.Warnn("alpha dispatcher: marshal failed",
+			logger.NewStringField("messageId", e.MessageID),
+			logger.NewStringField("error", err.Error()),
+		)
+		return
+	}
+	var lastStatus int
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if ctx.Err() != nil {
+			return
+		}
+		status, err := d.postOnce(ctx, body)
+		if err == nil && status == http.StatusOK {
+			return
+		}
+		lastStatus, lastErr = status, err
+		if attempt == maxAttempts {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(retryDelay):
+		}
+	}
+	d.logger.Warnn("alpha dispatcher: giving up after max attempts",
+		logger.NewStringField("messageId", e.MessageID),
+		logger.NewStringField("workspaceId", e.WorkspaceID),
+		logger.NewStringField("userId", e.UserID),
+		logger.NewIntField("attempts", int64(maxAttempts)),
+		logger.NewIntField("lastStatus", int64(lastStatus)),
+		logger.NewStringField("lastError", errString(lastErr)),
+	)
+}
+
+func (d *Dispatcher) postOnce(ctx context.Context, body []byte) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.url, bytes.NewReader(body))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return resp.StatusCode, fmt.Errorf("non-200 status: %d", resp.StatusCode)
+	}
+	return resp.StatusCode, nil
+}
+
+func errString(e error) string {
+	if e == nil {
+		return ""
+	}
+	return e.Error()
+}

--- a/processor/alpha/dispatcher.go
+++ b/processor/alpha/dispatcher.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -42,6 +43,11 @@ const (
 	// Rate-limit channel-full drop logs: log every Nth drop to avoid spam
 	// during sustained outages.
 	dropLogEveryN = 100
+
+	// maxLogBodyBytes caps how many bytes of any single body/header blob
+	// (request body, response body, response headers) we include in logs.
+	// Prevents a 500-with-huge-stacktrace × 10 retries from flooding logs.
+	maxLogBodyBytes = 4096
 )
 
 // IngestEvent is the per-event subset of a batch sent to the alpha service.
@@ -160,14 +166,35 @@ func (d *Dispatcher) postWithRetry(ctx context.Context, req EventsRequest) {
 		)
 		return
 	}
+	requestBody := truncate(string(body), maxLogBodyBytes)
+
 	var lastStatus int
 	var lastErr error
+	var lastRespBody string
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		if ctx.Err() != nil {
 			return
 		}
-		status, err := d.postOnce(ctx, body)
+		start := time.Now()
+		status, respBody, respHeaders, err := d.postOnce(ctx, body)
+		latencyMs := time.Since(start).Milliseconds()
+
+		// Log every attempt with full request/response context.
+		fields := []logger.Field{
+			logger.NewStringField("workspaceId", req.WorkspaceID),
+			logger.NewIntField("eventCount", int64(len(req.Events))),
+			logger.NewIntField("attempt", int64(attempt)),
+			logger.NewIntField("status", int64(status)),
+			logger.NewStringField("requestBody", requestBody),
+			logger.NewStringField("responseBody", respBody),
+			logger.NewStringField("responseHeaders", respHeaders),
+			logger.NewIntField("latencyMs", latencyMs),
+		}
+		if err != nil {
+			fields = append(fields, logger.NewStringField("error", err.Error()))
+		}
 		if err == nil && status == http.StatusOK {
+			d.logger.Infon("alpha dispatcher: attempt response", fields...)
 			d.logger.Infon("alpha dispatcher: batch delivered",
 				logger.NewStringField("workspaceId", req.WorkspaceID),
 				logger.NewIntField("eventCount", int64(len(req.Events))),
@@ -175,7 +202,9 @@ func (d *Dispatcher) postWithRetry(ctx context.Context, req EventsRequest) {
 			)
 			return
 		}
-		lastStatus, lastErr = status, err
+		d.logger.Warnn("alpha dispatcher: attempt response", fields...)
+
+		lastStatus, lastErr, lastRespBody = status, err, respBody
 		if attempt == maxAttempts {
 			break
 		}
@@ -191,24 +220,36 @@ func (d *Dispatcher) postWithRetry(ctx context.Context, req EventsRequest) {
 		logger.NewIntField("attempts", int64(maxAttempts)),
 		logger.NewIntField("lastStatus", int64(lastStatus)),
 		logger.NewStringField("lastError", errString(lastErr)),
+		logger.NewStringField("lastResponseBody", lastRespBody),
 	)
 }
 
-func (d *Dispatcher) postOnce(ctx context.Context, body []byte) (int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.url, bytes.NewReader(body))
+// postOnce performs a single POST and returns the status code, truncated
+// response body, truncated JSON-encoded response headers, and any transport
+// error. A non-200 status is also reported as a non-nil error so callers can
+// retry uniformly, but respBody/respHeaders are still populated.
+func (d *Dispatcher) postOnce(ctx context.Context, body []byte) (status int, respBody, respHeaders string, err error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, d.url, bytes.NewReader(body))
 	if err != nil {
-		return 0, err
+		return 0, "", "", err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := d.client.Do(req)
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := d.client.Do(httpReq)
 	if err != nil {
-		return 0, err
+		return 0, "", "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return resp.StatusCode, fmt.Errorf("non-200 status: %d", resp.StatusCode)
+
+	rawBody, _ := io.ReadAll(resp.Body)
+	respBody = truncate(string(rawBody), maxLogBodyBytes)
+	if hb, hErr := json.Marshal(resp.Header); hErr == nil {
+		respHeaders = truncate(string(hb), maxLogBodyBytes)
 	}
-	return resp.StatusCode, nil
+
+	if resp.StatusCode != http.StatusOK {
+		return resp.StatusCode, respBody, respHeaders, fmt.Errorf("non-200 status: %d", resp.StatusCode)
+	}
+	return resp.StatusCode, respBody, respHeaders, nil
 }
 
 func errString(e error) string {
@@ -216,4 +257,13 @@ func errString(e error) string {
 		return ""
 	}
 	return e.Error()
+}
+
+// truncate returns s capped at max bytes; if truncated, an explicit suffix is
+// appended so logs make the truncation obvious.
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…(truncated)"
 }

--- a/processor/alpha/dispatcher.go
+++ b/processor/alpha/dispatcher.go
@@ -37,7 +37,7 @@ const (
 
 	// Per-request timeout. Short enough that hung requests don't extend the
 	// overall retry budget unreasonably.
-	requestTimeout = 5 * time.Second
+	requestTimeout = 60 * time.Second
 
 	// Rate-limit channel-full drop logs: log every Nth drop to avoid spam
 	// during sustained outages.

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -435,7 +435,7 @@ func (proc *Handle) Setup(
 
 	proc.setupReloadableVars()
 	proc.logger = logger.NewLogger().Child("processor")
-	proc.alphaDispatcher = alpha.NewDispatcher(proc.conf.GetString("ALPHA_SERVICE_URL", ""), proc.logger)
+	proc.alphaDispatcher = alpha.NewDispatcher(proc.conf.GetString("alphaServiceUrl", ""), proc.logger)
 	proc.backendConfig = backendConfig
 
 	proc.gatewayDB = gatewayDB

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -3278,20 +3278,27 @@ func (proc *Handle) userTransformAndFilter(ctx context.Context, partition, srcAn
 		eventsToTransform = eventList
 	}
 
-	// Hackathon: forward post-UT events with a non-empty userId to the alpha
-	// service. Fire-and-forget; never blocks the pipeline. Runs for both the
-	// user-transformed path and the pass-through path.
+	// Hackathon: build one batch of post-UT events for this src-dest pair and
+	// dispatch as a single POST to the alpha service. All events here share
+	// commonMetaData.WorkspaceID. Fire-and-forget; never blocks the pipeline.
+	// Runs for both the user-transformed path and the pass-through path.
+	alphaEvents := make([]alpha.IngestEvent, 0, len(eventsToTransform))
 	for i := range eventsToTransform {
 		ev := &eventsToTransform[i]
 		userID, _ := ev.Message["userId"].(string)
 		if userID == "" {
 			continue
 		}
-		proc.alphaDispatcher.Dispatch(alpha.Event{
-			EventName:   ev.Metadata.EventName,
-			MessageID:   ev.Metadata.MessageID,
-			WorkspaceID: ev.Metadata.WorkspaceID,
-			UserID:      userID,
+		alphaEvents = append(alphaEvents, alpha.IngestEvent{
+			UserID:    userID,
+			MessageID: ev.Metadata.MessageID,
+			EventName: ev.Metadata.EventName,
+		})
+	}
+	if len(alphaEvents) > 0 {
+		proc.alphaDispatcher.Dispatch(alpha.EventsRequest{
+			WorkspaceID: commonMetaData.WorkspaceID,
+			Events:      alphaEvents,
 		})
 	}
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -3289,6 +3289,9 @@ func (proc *Handle) userTransformAndFilter(ctx context.Context, partition, srcAn
 		if userID == "" {
 			continue
 		}
+		if ev.Metadata.EventName == "" {
+			continue
+		}
 		alphaEvents = append(alphaEvents, alpha.IngestEvent{
 			UserID:    userID,
 			MessageID: ev.Metadata.MessageID,

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -37,6 +37,7 @@ import (
 	"github.com/rudderlabs/rudder-server/enterprise/trackedusers"
 	"github.com/rudderlabs/rudder-server/internal/enricher"
 	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/processor/alpha"
 	"github.com/rudderlabs/rudder-server/processor/delayed"
 	"github.com/rudderlabs/rudder-server/processor/eventfilter"
 	"github.com/rudderlabs/rudder-server/processor/integrations"
@@ -136,6 +137,7 @@ type Handle struct {
 	transformerFeaturesService transformerFeaturesService.FeaturesService
 	destDebugger               destinationdebugger.DestinationDebugger
 	transDebugger              transformationdebugger.TransformationDebugger
+	alphaDispatcher            *alpha.Dispatcher
 	isolationStrategy          isolation.Strategy
 	limiter                    struct {
 		read         kitsync.Limiter
@@ -433,6 +435,7 @@ func (proc *Handle) Setup(
 
 	proc.setupReloadableVars()
 	proc.logger = logger.NewLogger().Child("processor")
+	proc.alphaDispatcher = alpha.NewDispatcher(proc.conf.GetString("ALPHA_SERVICE_URL", ""), proc.logger)
 	proc.backendConfig = backendConfig
 
 	proc.gatewayDB = gatewayDB
@@ -622,6 +625,13 @@ func (proc *Handle) Setup(
 	proc.config.asyncInit = misc.NewAsyncInit(1)
 	g.Go(crash.Wrapper(func() error {
 		proc.backendConfigSubscriber(ctx)
+		return nil
+	}))
+
+	// Hackathon: start the alpha-service dispatcher worker pool. No-op when
+	// ALPHA_SERVICE_URL is unset. Workers exit on ctx cancellation.
+	g.Go(crash.Wrapper(func() error {
+		proc.alphaDispatcher.Run(ctx)
 		return nil
 	}))
 
@@ -3266,6 +3276,23 @@ func (proc *Handle) userTransformAndFilter(ctx context.Context, partition, srcAn
 	} else {
 		proc.logger.Debugn("No custom transformation")
 		eventsToTransform = eventList
+	}
+
+	// Hackathon: forward post-UT events with a non-empty userId to the alpha
+	// service. Fire-and-forget; never blocks the pipeline. Runs for both the
+	// user-transformed path and the pass-through path.
+	for i := range eventsToTransform {
+		ev := &eventsToTransform[i]
+		userID, _ := ev.Message["userId"].(string)
+		if userID == "" {
+			continue
+		}
+		proc.alphaDispatcher.Dispatch(alpha.Event{
+			EventName:   ev.Metadata.EventName,
+			MessageID:   ev.Metadata.MessageID,
+			WorkspaceID: ev.Metadata.WorkspaceID,
+			UserID:      userID,
+		})
 	}
 
 	if len(eventsToTransform) == 0 {


### PR DESCRIPTION
# Description
Adds a fire-and-forget HTTP dispatcher that POSTs a small subset of post-user-transformation event metadata (eventName, messageId, workspaceId, userId) to an external "alpha" service.

- New package processor/alpha/ with a Dispatcher backed by a 1000-cap buffered channel and a 4-worker goroutine pool.
- Retry policy: up to 10 attempts, 30s constant delay between attempts, 5s per-request timeout. Drops + WARN logs on retry exhaustion.
- Channel-full drops are rate-limited to one WARN per 100 drops.
- Disabled (no-op) when ALPHA_SERVICE_URL is unset; logs a single WARN at startup in that case.
- Wired into processor.Handle: instantiated in Setup, workers launched in the existing background errgroup so they shut down on ctx cancel.
- Dispatch is invoked at the post-user-transformation pipeline point (covering both the UT-applied and pass-through paths). Only events with a non-empty userId are forwarded.

This is hackathon-only code: no metrics, no tests, no graceful drain.


🔒 Scanned for secrets using gitleaks 8.28.0



< Replace with adequate description for this PR as per [Pull Request document](https://www.notion.so/rudderstacks/Pull-Requests-40a4c6bd7a5e4387ba9029bab297c9e3) >

## Linear Ticket

< Replace with Linear Link ( [create](https://linear.new?title=Awesome-pr-without-linear-ticket) or [search](https://linear.app/rudderstack/search) linear ticket) or  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
