### PR TITLE
chore: debug snowpipe streaming importing job size

### DIFF
--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -177,6 +177,14 @@ func (brt *Handle) updatePollStatusToDB(ctx context.Context, destinationID, sour
 		return statusList, err
 	}
 	importingList := list.Jobs
+	if len(importingList) != importingCount {
+		brt.logger.Warnn("[Batch Router] Mismatch in importing list and importing count",
+			obskit.DestinationID(destinationID),
+			obskit.SourceID(sourceID),
+			logger.NewIntField("importingListSize", int64(len(importingList))),
+			logger.NewIntField("importingCount", int64(importingCount)),
+		)
+	}
 	if pollResp.StatusCode == http.StatusOK && pollResp.Complete {
 		if !pollResp.HasFailed && !pollResp.HasWarning {
 			statusList, _, jobIDConnectionDetailsMap = brt.prepareJobStatusList(importingList, jobsdb.JobStatusT{JobState: jobsdb.Succeeded.State}, sourceID, destinationID)


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

# Description

- Added logs when we get fewer importing jobs then exptected during the poll update scenario. Currently we are just logging in this scenario.

## Linear Ticket

- Resolves INT-5765.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
