### PR TITLE
fix: server getting stuck during startup while initializing rsources

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -131,7 +131,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, shutdownFn func(), op
 
 	fileUploaderProvider := fileuploader.NewProvider(ctx, backendconfig.DefaultBackendConfig)
 
-	rsourcesService, err := NewRsourcesService(deploymentType, true, statsFactory)
+	rsourcesService, err := NewRsourcesService(ctx, deploymentType, true, statsFactory)
 	if err != nil {
 		return err
 	}

--- a/app/apphandlers/gatewayAppHandler.go
+++ b/app/apphandlers/gatewayAppHandler.go
@@ -132,7 +132,7 @@ func (a *gatewayApp) StartRudderCore(ctx context.Context, _ func(), options *app
 	if err != nil {
 		return fmt.Errorf("failed to create rate limiter: %w", err)
 	}
-	rsourcesService, err := NewRsourcesService(deploymentType, false, statsFactory)
+	rsourcesService, err := NewRsourcesService(ctx, deploymentType, false, statsFactory)
 	if err != nil {
 		return err
 	}

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -138,7 +138,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, shutdownFn func(), o
 
 	fileUploaderProvider := fileuploader.NewProvider(ctx, backendconfig.DefaultBackendConfig)
 
-	rsourcesService, err := NewRsourcesService(deploymentType, true, statsFactory)
+	rsourcesService, err := NewRsourcesService(ctx, deploymentType, true, statsFactory)
 	if err != nil {
 		return err
 	}

--- a/app/apphandlers/setup.go
+++ b/app/apphandlers/setup.go
@@ -54,7 +54,7 @@ func rudderCoreNodeSetup() error {
 }
 
 // NewRsourcesService produces a rsources.JobService through environment configuration (env variables & config file)
-func NewRsourcesService(deploymentType deployment.Type, shouldSetupSharedDB bool, stats stats.Stats) (rsources.JobService, error) {
+func NewRsourcesService(ctx context.Context, deploymentType deployment.Type, shouldSetupSharedDB bool, stats stats.Stats) (rsources.JobService, error) {
 	var rsourcesConfig rsources.JobServiceConfig
 	rsourcesConfig.MaxPoolSize = config.GetIntVar(3, 1, "Rsources.MaxPoolSize")
 	rsourcesConfig.MinPoolSize = config.GetIntVar(1, 1, "Rsources.MinPoolSize")
@@ -82,7 +82,7 @@ func NewRsourcesService(deploymentType deployment.Type, shouldSetupSharedDB bool
 
 	rsourcesConfig.ShouldSetupSharedDB = shouldSetupSharedDB
 
-	return rsources.NewJobService(rsourcesConfig, stats)
+	return rsources.NewJobService(ctx, rsourcesConfig, stats)
 }
 
 func resolveModeProvider(log logger.Logger, deploymentType deployment.Type) (cluster.ChangeEventProvider, error) {

--- a/services/rsources/failed_records_pagination_test.go
+++ b/services/rsources/failed_records_pagination_test.go
@@ -45,7 +45,7 @@ func TestFailedRecords(t *testing.T) {
 	sts, err := memstats.New()
 	require.NoError(t, err, "should create stats")
 
-	service, err := NewJobService(JobServiceConfig{
+	service, err := NewJobService(context.Background(), JobServiceConfig{
 		LocalHostname:       postgresContainer.Host,
 		MaxPoolSize:         1,
 		LocalConn:           postgresContainer.DBDsn,
@@ -90,7 +90,7 @@ func RunFailedRecordsPerformanceTest(t testing.TB, recordCount, pageSize int) ti
 	sts, err := memstats.New()
 	require.NoError(t, err, "should create stats")
 
-	service, err := NewJobService(JobServiceConfig{
+	service, err := NewJobService(context.Background(), JobServiceConfig{
 		LocalHostname:       postgresContainer.Host,
 		MaxPoolSize:         1,
 		LocalConn:           postgresContainer.DBDsn,

--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -486,8 +486,9 @@ func (sh *sourcesHandler) readDB() *sql.DB {
 	return sh.localDB
 }
 
-func (sh *sourcesHandler) init() error {
-	ctx := context.TODO()
+func (sh *sourcesHandler) init(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, config.GetDurationVar(60, time.Second, "Rsources.setupTimeout"))
+	defer cancel()
 	if sh.cleanupTrigger == nil {
 		sh.cleanupTrigger = func() <-chan time.Time {
 			return time.After(config.GetDurationVar(1, time.Hour, "Rsources.stats.cleanup.interval"))

--- a/services/rsources/handler_test.go
+++ b/services/rsources/handler_test.go
@@ -1058,7 +1058,7 @@ var _ = Describe("Using sources handler", func() {
 			sts, err := memstats.New()
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = NewJobService(badConfig, sts)
+			_, err = NewJobService(context.Background(), badConfig, sts)
 			Expect(err).To(HaveOccurred(), "it shouldn't able to create the service")
 		})
 
@@ -1078,7 +1078,7 @@ var _ = Describe("Using sources handler", func() {
 			sts, err := memstats.New()
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = NewJobService(badConfig, sts)
+			_, err = NewJobService(context.Background(), badConfig, sts)
 			Expect(err).To(HaveOccurred(), "it shouldn't able to create the service")
 		})
 	})
@@ -1190,7 +1190,7 @@ func createService(config JobServiceConfig) JobService {
 	sts, err := memstats.New()
 	Expect(err).NotTo(HaveOccurred())
 
-	service, err := NewJobService(config, sts)
+	service, err := NewJobService(context.Background(), config, sts)
 	Expect(err).ShouldNot(HaveOccurred(), "it should be able to create the service")
 	return service
 }

--- a/services/rsources/http/http_integration_test.go
+++ b/services/rsources/http/http_integration_test.go
@@ -45,7 +45,7 @@ func prepare(
 	sts, err := memstats.New()
 	require.NoError(t, err, "should create stats")
 
-	service, err = rsources.NewJobService(config, sts)
+	service, err = rsources.NewJobService(context.Background(), config, sts)
 	require.NoError(t, err)
 	handler = handlerFunc(service, logger.NOP)
 	dbResource = postgresContainer

--- a/services/rsources/rsources.go
+++ b/services/rsources/rsources.go
@@ -247,7 +247,7 @@ type Gauger interface {
 	Gauge(any)
 }
 
-func NewJobService(jobServiceConfig JobServiceConfig, stats stats.Stats) (JobService, error) {
+func NewJobService(ctx context.Context, jobServiceConfig JobServiceConfig, stats stats.Stats) (JobService, error) {
 	if jobServiceConfig.Log == nil {
 		jobServiceConfig.Log = logger.NewLogger().Child("rsources")
 	}
@@ -294,7 +294,7 @@ func NewJobService(jobServiceConfig JobServiceConfig, stats stats.Stats) (JobSer
 		localDB:  localDB,
 		sharedDB: sharedDB,
 	}
-	err = handler.init()
+	err = handler.init(ctx)
 	return handler, err
 }
 


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

# Description

The rsources init step performs a DDL (CREATE TABLE/INDEX/PUBLICATION/SUBSCRIPTION) under an advisory lock during server startup. It used `context.TODO()`, so a stuck socket read inside `lib/pq` could block startup indefinitely.

To address this:
- We add a configurable timeout for rsources init (`Rsources.setupTimeout`, default `60s`)  so a hung DB call fails fast instead of blocking startup.
- Propagating the parent context through `NewRsourcesService` and `NewJobService` so shutdown also cancels in-flight setup.

## Linear Ticket

resolves PIPE-2930

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.