### PR TITLE
chore: remove deprecated fetch-tables endpoint

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -2413,8 +2413,6 @@ func endpointsToVerify() ([]string, []string, []string) {
 		"/v1/job-status/123",
 		"/v1/job-status/123/failed-records",
 		"/v1/warehouse/jobs/status",
-		// TODO: Remove this endpoint once sources change is released
-		"/v1/warehouse/fetch-tables",
 		"/internal/v1/warehouse/fetch-tables",
 		"/internal/v1/job-status/123",
 		"/internal/v1/job-status/123/failed-records",

--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -614,8 +614,6 @@ func (gw *Handle) StartWebHandler(ctx context.Context) error {
 			r.Post("/pending-events", gw.whProxy.ServeHTTP)
 			r.Post("/trigger-upload", gw.whProxy.ServeHTTP)
 			r.Post("/jobs", gw.whProxy.ServeHTTP)
-			// TODO: Remove this endpoint once sources change is released
-			r.Get("/fetch-tables", gw.whProxy.ServeHTTP)
 
 			r.Get("/jobs/status", gw.whProxy.ServeHTTP)
 		})

--- a/warehouse/api/http.go
+++ b/warehouse/api/http.go
@@ -191,8 +191,6 @@ func (a *Api) addMasterEndpoints(ctx context.Context, r chi.Router) {
 
 			r.Post("/jobs", a.logMiddleware(a.sourceManager.InsertJobHandler))       // TODO: add degraded mode
 			r.Get("/jobs/status", a.logMiddleware(a.sourceManager.StatusJobHandler)) // TODO: add degraded mode
-
-			r.Get("/fetch-tables", a.logMiddleware(a.fetchTablesHandler)) // TODO: Remove this endpoint once sources change is released
 		})
 	})
 	r.Route("/internal", func(r chi.Router) {

--- a/warehouse/api/http_test.go
+++ b/warehouse/api/http_test.go
@@ -856,11 +856,8 @@ func TestHTTPApi(t *testing.T) {
 			})
 
 			t.Run("fetch tables", func(t *testing.T) {
-				for _, u := range []string{
-					fmt.Sprintf("%s/v1/warehouse/fetch-tables", serverURL),
-					fmt.Sprintf("%s/internal/v1/warehouse/fetch-tables", serverURL),
-				} {
-					req, err := http.NewRequest(http.MethodGet, u, bytes.NewReader([]byte(`
+				u := fmt.Sprintf("%s/internal/v1/warehouse/fetch-tables", serverURL)
+				req, err := http.NewRequest(http.MethodGet, u, bytes.NewReader([]byte(`
 				{
 				  "connections": [
 					{
@@ -870,17 +867,16 @@ func TestHTTPApi(t *testing.T) {
 				  ]
 				}
 			`)))
-					require.NoError(t, err)
-					req.Header.Set("Content-Type", "application/json")
+				require.NoError(t, err)
+				req.Header.Set("Content-Type", "application/json")
 
-					resp, err := (&http.Client{}).Do(req)
-					require.NoError(t, err)
-					require.Equal(t, http.StatusOK, resp.StatusCode)
+				resp, err := (&http.Client{}).Do(req)
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, resp.StatusCode)
 
-					t.Cleanup(func() {
-						httputil.CloseResponse(resp)
-					})
-				}
+				t.Cleanup(func() {
+					httputil.CloseResponse(resp)
+				})
 			})
 
 			t.Run("jobs", func(t *testing.T) {
@@ -992,12 +988,6 @@ func TestHTTPApi(t *testing.T) {
 					{
 						name:   "jobs status",
 						url:    fmt.Sprintf("%s/v1/warehouse/jobs/status", serverURL),
-						method: http.MethodGet,
-						body:   nil,
-					},
-					{
-						name:   "fetch tables",
-						url:    fmt.Sprintf("%s/v1/warehouse/fetch-tables", serverURL),
 						method: http.MethodGet,
 						body:   nil,
 					},


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

# Description

Removing the old fetch-table endpoint

## Linear Ticket

resolves PIPE-2961

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
