### PR TITLE
feat: periodic cleanup of rsources shared db tables

### DIFF
--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -13,13 +13,18 @@ import (
 	"github.com/lib/pq"
 	"github.com/lib/pq/pqerror"
 	"github.com/segmentio/ksuid"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 )
 
-const defaultRetentionPeriodInHours = 3 * 24
+const (
+	defaultRetentionPeriodInHours             = 3 * 24
+	defaultSharedRetentionBufferPeriodInHours = 24
+	sharedCleanupLockID                       = 100020002
+)
 
 // ErrOperationNotSupported sentinel error indicating an unsupported operation
 var ErrOperationNotSupported = errors.New("rsources: operation not supported")
@@ -31,11 +36,12 @@ var ErrInvalidPaginationToken = errors.New("rsources: invalid pagination token")
 var replSlotDisallowedChars *regexp.Regexp = regexp.MustCompile(`[^a-z0-9_]`)
 
 type sourcesHandler struct {
-	log            logger.Logger
-	config         JobServiceConfig
-	localDB        *sql.DB
-	sharedDB       *sql.DB
-	cleanupTrigger func() <-chan time.Time
+	log                  logger.Logger
+	config               JobServiceConfig
+	localDB              *sql.DB
+	sharedDB             *sql.DB
+	cleanupTrigger       func() <-chan time.Time
+	sharedCleanupTrigger func() <-chan time.Time
 }
 
 func (sh *sourcesHandler) GetStatus(ctx context.Context, jobRunId string, filter JobFilter) (JobStatus, error) {
@@ -423,37 +429,101 @@ func (sh *sourcesHandler) DeleteJobStatus(ctx context.Context, jobRunId string, 
 }
 
 func (sh *sourcesHandler) CleanupLoop(ctx context.Context) error {
-	err := sh.doCleanupTables(ctx)
-	if err != nil {
-		return err
-	}
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-sh.cleanupTrigger():
-			err := sh.doCleanupTables(ctx)
-			if err != nil {
-				sh.log.Errorn("Failed to cleanup rsources tables", obskit.Error(err))
-				return err
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		if err := sh.doCleanupTables(ctx); err != nil {
+			return err
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-sh.cleanupTrigger():
+				if err := sh.doCleanupTables(ctx); err != nil {
+					sh.log.Errorn("Failed to cleanup rsources tables", obskit.Error(err))
+					return err
+				}
 			}
 		}
+	})
+	if sh.sharedDB != nil {
+		g.Go(func() error {
+			if err := sh.doCleanupSharedTables(ctx); err != nil {
+				sh.log.Errorn("Failed to cleanup shared rsources tables", obskit.Error(err))
+			}
+			for {
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-sh.sharedCleanupTrigger():
+					if err := sh.doCleanupSharedTables(ctx); err != nil {
+						sh.log.Errorn("Failed to cleanup shared rsources tables", obskit.Error(err))
+					}
+				}
+			}
+		})
 	}
+	return g.Wait()
 }
 
 func (sh *sourcesHandler) doCleanupTables(ctx context.Context) error {
 	sh.log.Infon("Cleaning up rsources tables")
-	tx, err := sh.localDB.Begin()
+	tx, err := sh.localDB.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	before := time.Now().Add(-config.GetDurationVar(defaultRetentionPeriodInHours, time.Hour, "Rsources.retention"))
+	if err := cleanupTablesBefore(ctx, tx, before); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if commitErr := tx.Commit(); commitErr != nil {
+		return commitErr
+	}
+	sh.log.Infon("Finished cleaning up rsources tables")
+	return nil
+}
+
+// doCleanupSharedTables garbage collects rows orphaned in the shared db by nodes that left the cluster; gated by an advisory lock so only one node runs at a time.
+func (sh *sourcesHandler) doCleanupSharedTables(ctx context.Context) error {
+	if sh.sharedDB == nil {
+		return nil
+	}
+	tx, err := sh.sharedDB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var acquired bool
+	if err := tx.QueryRowContext(ctx, `SELECT pg_try_advisory_xact_lock($1)`, sharedCleanupLockID).Scan(&acquired); err != nil {
+		return fmt.Errorf("acquiring shared cleanup advisory lock: %w", err)
+	}
+	if !acquired {
+		sh.log.Infon("Skipping shared rsources tables cleanup, another node holds the lock")
+		return nil
+	}
+
+	sh.log.Infon("Cleaning up shared rsources tables")
+	retention := config.GetDurationVar(defaultRetentionPeriodInHours, time.Hour, "Rsources.retention") +
+		config.GetDurationVar(defaultSharedRetentionBufferPeriodInHours, time.Hour, "Rsources.shared.retentionBuffer")
+	before := time.Now().Add(-retention)
+	if err := cleanupTablesBefore(ctx, tx, before); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	sh.log.Infon("Finished cleaning up shared rsources tables")
+	return nil
+}
+
+func cleanupTablesBefore(ctx context.Context, tx *sql.Tx, before time.Time) error {
 	if _, err := tx.ExecContext(ctx, `delete from "rsources_stats" where job_run_id in (
 		select lastUpdateToJobRunId.job_run_id from
 			(select job_run_id, max(ts) as mts from "rsources_stats" group by job_run_id) lastUpdateToJobRunId
 		where lastUpdateToJobRunId.mts <= $1
 	)`, before); err != nil {
-		_ = tx.Rollback()
 		return err
 	}
 	if _, err := tx.ExecContext(ctx, `WITH to_delete AS (
@@ -469,13 +539,8 @@ func (sh *sourcesHandler) doCleanupTables(ctx context.Context) error {
 		DELETE FROM "rsources_failed_keys_v2" WHERE id IN (SELECT id FROM to_delete) RETURNING id
 	)
 	DELETE FROM "rsources_failed_keys_v2_records" WHERE id IN (SELECT id FROM to_delete) RETURNING id`, before); err != nil {
-		_ = tx.Rollback()
 		return err
 	}
-	if commitErr := tx.Commit(); commitErr != nil {
-		return commitErr
-	}
-	sh.log.Infon("Finished cleaning up rsources tables")
 	return nil
 }
 
@@ -491,6 +556,11 @@ func (sh *sourcesHandler) init() error {
 	if sh.cleanupTrigger == nil {
 		sh.cleanupTrigger = func() <-chan time.Time {
 			return time.After(config.GetDurationVar(1, time.Hour, "Rsources.stats.cleanup.interval"))
+		}
+	}
+	if sh.sharedCleanupTrigger == nil {
+		sh.sharedCleanupTrigger = func() <-chan time.Time {
+			return time.After(config.GetDurationVar(1, time.Hour, "Rsources.shared.cleanup.interval"))
 		}
 	}
 

--- a/services/rsources/handler_test.go
+++ b/services/rsources/handler_test.go
@@ -1042,6 +1042,55 @@ var _ = Describe("Using sources handler", func() {
 			createService(configB)
 		})
 
+		It("should cleanup orphaned rows in the shared db older than the shared retention", func() {
+			ctx := context.Background()
+			jobRunId := newJobRunId()
+			oldTs := time.Now().Add(-time.Duration(defaultRetentionPeriodInHours+defaultSharedRetentionBufferPeriodInHours+1) * time.Hour)
+
+			insertOrphanRows(ctx, pgC.db, jobRunId, oldTs)
+
+			Expect(serviceA.(*sourcesHandler).doCleanupSharedTables(ctx)).To(Succeed())
+
+			Expect(countSharedRows(ctx, pgC.db, jobRunId)).To(Equal(sharedRowCounts{}))
+		})
+
+		It("should not cleanup shared db rows that are within the shared retention buffer", func() {
+			ctx := context.Background()
+			jobRunId := newJobRunId()
+			// older than local retention but within the shared retention buffer
+			midTs := time.Now().Add(-time.Duration(defaultRetentionPeriodInHours+1) * time.Hour)
+
+			insertOrphanRows(ctx, pgC.db, jobRunId, midTs)
+
+			Expect(serviceA.(*sourcesHandler).doCleanupSharedTables(ctx)).To(Succeed())
+
+			Expect(countSharedRows(ctx, pgC.db, jobRunId)).To(Equal(sharedRowCounts{stats: 1, keys: 1, records: 1}))
+		})
+
+		It("should skip shared cleanup when another node holds the advisory lock", func() {
+			ctx := context.Background()
+			jobRunId := newJobRunId()
+			oldTs := time.Now().Add(-time.Duration(defaultRetentionPeriodInHours+defaultSharedRetentionBufferPeriodInHours+1) * time.Hour)
+
+			insertOrphanRows(ctx, pgC.db, jobRunId, oldTs)
+
+			holdConn, err := pgC.db.Conn(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			holdTx, err := holdConn.BeginTx(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = holdTx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, sharedCleanupLockID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(serviceA.(*sourcesHandler).doCleanupSharedTables(ctx)).To(Succeed())
+			Expect(countSharedRows(ctx, pgC.db, jobRunId)).To(Equal(sharedRowCounts{stats: 1, keys: 1, records: 1}), "rows must survive while the lock is held")
+
+			Expect(holdTx.Rollback()).To(Succeed())
+			Expect(holdConn.Close()).To(Succeed())
+
+			Expect(serviceA.(*sourcesHandler).doCleanupSharedTables(ctx)).To(Succeed())
+			Expect(countSharedRows(ctx, pgC.db, jobRunId)).To(Equal(sharedRowCounts{}), "rows must be cleaned up after the lock is released")
+		})
+
 		It("shouldn't be able to create a service when wal_level=logical is not set on the local db", func() {
 			postgres4Hostname := randomString() + "-4"
 			pgD := newDBResource(pool, network.ID, postgres4Hostname)
@@ -1202,6 +1251,39 @@ func addFailedRecords(db *sql.DB, jobRunId string, jobTargetKey JobTargetKey, sh
 	Expect(err).ShouldNot(HaveOccurred(), "it should be able to add failed records")
 	err = tx.Commit()
 	Expect(err).ShouldNot(HaveOccurred(), "it should be able to commit the transaction")
+}
+
+type sharedRowCounts struct {
+	stats, keys, records int
+}
+
+func insertOrphanRows(ctx context.Context, db *sql.DB, jobRunId string, ts time.Time) {
+	_, err := db.ExecContext(ctx, `INSERT INTO rsources_stats
+		(db_name, job_run_id, task_run_id, source_id, destination_id, in_count, out_count, failed_count, ts)
+		VALUES ('ghost', $1, 'task', 'source', 'destination', 1, 1, 0, $2)`,
+		jobRunId, ts)
+	Expect(err).NotTo(HaveOccurred())
+
+	keyId := ksuid.New().String()
+	_, err = db.ExecContext(ctx, `INSERT INTO rsources_failed_keys_v2
+		(id, db_name, job_run_id, task_run_id, source_id, destination_id, ts)
+		VALUES ($1, 'ghost', $2, 'task', 'source', 'destination', $3)`,
+		keyId, jobRunId, ts)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = db.ExecContext(ctx, `INSERT INTO rsources_failed_keys_v2_records
+		(id, record_id, ts, code) VALUES ($1, 'record', $2, 0)`,
+		keyId, ts)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func countSharedRows(ctx context.Context, db *sql.DB, jobRunId string) sharedRowCounts {
+	var c sharedRowCounts
+	Expect(db.QueryRowContext(ctx, `SELECT count(*) FROM rsources_stats WHERE job_run_id = $1`, jobRunId).Scan(&c.stats)).To(Succeed())
+	Expect(db.QueryRowContext(ctx, `SELECT count(*) FROM rsources_failed_keys_v2 WHERE job_run_id = $1`, jobRunId).Scan(&c.keys)).To(Succeed())
+	Expect(db.QueryRowContext(ctx, `SELECT count(*) FROM rsources_failed_keys_v2_records r
+		JOIN rsources_failed_keys_v2 k ON k.id = r.id WHERE k.job_run_id = $1`, jobRunId).Scan(&c.records)).To(Succeed())
+	return c
 }
 
 func increment(db *sql.DB, jobRunId string, key JobTargetKey, stat Stats, sh JobService, wg *sync.WaitGroup) {


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

# Description

Up until now we were only removing stale rows from each node's **local** rsources db. But orphans can accumulate in the **shared** db when a node leaves the cluster — logical replication only propagates deletes from nodes that are still subscribed, so anything written by a now-departed node is left behind forever.

This PR adds a periodic shared-db cleanup that runs alongside the existing local cleanup loop:

- New `doCleanupSharedTables` reuses the same delete logic (extracted into a `cleanupTablesBefore` helper) but executes against `sharedDB` instead of `localDB`.
- With many nodes pointed at the same shared db, only one should be deleting at a time. The cleanup transaction first calls `pg_try_advisory_xact_lock(sharedCleanupLockID)` and **skips the run** (logs and returns) if another node is already holding the lock. Tx-scoped, so the lock is released automatically on commit/rollback — no leak risk if a node crashes mid-cleanup.
- Retention for the shared cleanup is `Rsources.retention + Rsources.shared.retentionBuffer` (defaults: 72h + 24h = 96h). The buffer guarantees that even with replication lag or a briefly-offline node, the shared row is never GC'd before the corresponding local-side delete has had time to propagate.
- `CleanupLoop` now runs the local and shared loops in parallel via `errgroup.WithContext`. Errors from the local loop still tear down the group (existing behavior); errors from the shared loop are logged and the loop continues — best-effort across nodes.

### New config keys

| key | default | meaning |
|---|---|---|
| `Rsources.shared.cleanup.interval` | `1h` | how often each node attempts a shared-db cleanup |
| `Rsources.shared.retentionBuffer` | `24h` | safety margin on top of `Rsources.retention` before shared rows are eligible for deletion |

## Linear Ticket

resolves PIPE-2963

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.