### PR TITLE
chore(ci): workflow cleanup (SEC-284)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,6 +55,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
+          cache: false
       - run: go version
       - run: go mod download # Not required, used to segregate module download vs test times
 
@@ -141,6 +142,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
+          cache: false
       - run: go version
       - run: go mod download # Not required, used to segregate module download vs test times
       - name: Set Redshift Ginkgo AWS Credentials
@@ -207,6 +209,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
+          cache: false
       - run: go version
       - run: go mod download # Not required, used to segregate module download vs test times
       - name: tests
@@ -293,6 +296,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
+          cache: false
       - run: go version
       - run: go mod download
       - name: Package Unit [ ${{ matrix.package }} ]
@@ -344,6 +348,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
+          cache: false
       - name: Download coverage reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - name: Merge Coverage


### PR DESCRIPTION
Disables implicit Go module cache restore on setup-go in this workflow. No behavioral change to tests; cache restore is removed from a privileged job.

Linear: SEC-284