### PR TITLE
feat(jobsdb): versioned dataset list and non-blocking drop for completed datasets

### DIFF
--- a/integration_test/partitionmigration/partitionmigration_embedded_test.go
+++ b/integration_test/partitionmigration/partitionmigration_embedded_test.go
@@ -202,6 +202,7 @@ func TestPartitionMigrationEmbeddedMode(t *testing.T) {
 		"JobsDB.addNewDSLoopSleepDuration":      "1s",
 		"JobsDB.dsLimit":                        "2",
 		"JobsDB.refreshDSListLoopSleepDuration": "5s",
+		"JobsDB.nonBlockingCompletedDSDrop":     "true",
 	}
 	rsBinaryPath := filepath.Join(t.TempDir(), "rudder-server-binary")
 	rudderserver.BuildRudderServerBinary(t, "../../main.go", rsBinaryPath)

--- a/integration_test/partitionmigration/partitionmigration_gwproc_test.go
+++ b/integration_test/partitionmigration/partitionmigration_gwproc_test.go
@@ -213,6 +213,7 @@ func testPartitionMigrationGatewayProcessorMode(t *testing.T, extraStressWorkspa
 		"JobsDB.addNewDSLoopSleepDuration":      "2s",
 		"JobsDB.dsLimit":                        "3",
 		"JobsDB.refreshDSListLoopSleepDuration": "5s",
+		"JobsDB.nonBlockingCompletedDSDrop":     "true",
 		"JobsDB.partitionCount":                 strconv.Itoa(numPartitions),
 	}
 
@@ -256,6 +257,7 @@ func testPartitionMigrationGatewayProcessorMode(t *testing.T, extraStressWorkspa
 		"JobsDB.addNewDSLoopSleepDuration":      "2s",
 		"JobsDB.dsLimit":                        "3",
 		"JobsDB.refreshDSListLoopSleepDuration": "5s",
+		"JobsDB.nonBlockingCompletedDSDrop":     "true",
 		"JobsDB.partitionCount":                 strconv.Itoa(numPartitions),
 
 		"Processor.pingerSleep":   "1s",

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
+
+	"github.com/rudderlabs/rudder-server/jobsdb/internal/lock"
 )
 
 /*
@@ -43,7 +45,7 @@ func (jd *Handle) deleteJobStatus() {
 				CustomValFilters: []string{jd.tablePrefix},
 			}).RecordDuration()()
 
-		dsList := jd.getDSList()
+		dsList := tx.getDSList()
 
 		for _, ds := range dsList {
 			if err := jd.deleteJobStatusDSInTx(tx.SqlTx(), ds); err != nil {
@@ -102,7 +104,7 @@ func (jd *Handle) failExecuting() {
 			&statTags{CustomValFilters: []string{jd.tablePrefix}},
 		).RecordDuration()()
 
-		dsList := jd.getDSList()
+		dsList := tx.getDSList()
 
 		for _, ds := range dsList {
 			err := jd.failExecutingDSInTx(tx.SqlTx(), ds)
@@ -136,8 +138,13 @@ func (jd *Handle) failExecutingDSInTx(txHandler transactionHandler, ds dataSetT)
 	return err
 }
 
-func (jd *Handle) doCleanup(ctx context.Context) error {
-	if err := jd.abortOldJobs(ctx, jd.getDSList()); err != nil {
+// doCleanup performs cleanup of old jobs and journal entries. It requires a ds list lock token to ensure that the list does not change during the cleanup process.
+func (jd *Handle) doCleanup(ctx context.Context, l lock.LockToken) error {
+	if l == nil {
+		return fmt.Errorf("lock token is required for cleanup")
+	}
+	dsList, _ := jd.dsList.snapshot()
+	if err := jd.abortOldJobs(ctx, dsList); err != nil {
 		return fmt.Errorf("aborting old jobs: %w", err)
 	}
 
@@ -169,7 +176,7 @@ func (jd *Handle) doCleanup(ctx context.Context) error {
 }
 
 func (jd *Handle) abortOldJobs(ctx context.Context, dsList []dataSetT) error {
-	jobState := "aborted"
+	jobState := Aborted.State
 	maxAgeStatusResponse := `{"reason": "job max age exceeded"}`
 	maxAge := jd.conf.jobMaxAge.Load()
 	for _, ds := range dsList {

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -517,7 +517,7 @@ func TestJobsDB(t *testing.T) {
 		triggerAddNewDS <- time.Now() // Second time, waits for the first loop to finish
 
 		jobDBInspector := HandleInspector{Handle: &jobDB}
-		require.EqualValues(t, 2, len(jobDBInspector.DSIndicesList()))
+		require.EqualValues(t, 2, len(jobDBInspector.getDSListSnapshot()))
 		require.EqualValues(t, 2, jobDB.GetMaxDSIndex())
 
 		jobs = genJobs(defaultWorkspaceID, customVal, 10, 1)
@@ -552,10 +552,10 @@ func TestJobsDB(t *testing.T) {
 		triggerMigrateDS <- time.Now() // trigger migrateDSLoop to run
 		triggerMigrateDS <- time.Now() // Second time, waits for the first loop to finish
 
-		dsIndicesList := jobDBInspector.DSIndicesList()
-		require.EqualValues(t, "1_1", dsIndicesList[0])
-		require.EqualValues(t, "2", dsIndicesList[1])
-		require.EqualValues(t, 2, len(jobDBInspector.DSIndicesList()))
+		dsIndicesList := jobDBInspector.getDSListSnapshot()
+		require.EqualValues(t, "1_1", dsIndicesList[0].Index)
+		require.EqualValues(t, "2", dsIndicesList[1].Index)
+		require.EqualValues(t, 2, len(jobDBInspector.getDSListSnapshot()))
 		require.EqualValues(t, 2, jobDB.GetMaxDSIndex())
 
 		jobsResult, err = jobDB.GetUnprocessed(context.Background(), GetQueryParams{
@@ -595,9 +595,7 @@ func TestJobsDB(t *testing.T) {
 		defer jobDB.TearDown()
 
 		getDSList := func() []dataSetT {
-			jobDB.dsListLock.RLock()
-			defer jobDB.dsListLock.RUnlock()
-			return jobDB.getDSList()
+			return jobDB.getDSListSnapshot()
 		}
 
 		jobs := genJobs(defaultWorkspaceID, customVal, 10, 1)
@@ -849,7 +847,7 @@ func TestJobsDB(t *testing.T) {
 		triggerAddNewDS <- time.Now() // Second time, waits for the first loop to finish
 
 		jobDBInspector := HandleInspector{Handle: &jobDB}
-		require.EqualValues(t, 2, len(jobDBInspector.DSIndicesList()))
+		require.EqualValues(t, 2, len(jobDBInspector.getDSListSnapshot()))
 		require.EqualValues(t, 2, jobDB.GetMaxDSIndex())
 
 		time.Sleep(time.Second * 2) // wait for some time to pass so that retention condition satisfies
@@ -857,10 +855,10 @@ func TestJobsDB(t *testing.T) {
 		triggerMigrateDS <- time.Now() // trigger migrateDSLoop to run
 		triggerMigrateDS <- time.Now() // Second time, waits for the first loop to finish
 
-		dsIndicesList := jobDBInspector.DSIndicesList()
-		require.EqualValues(t, 2, len(jobDBInspector.DSIndicesList()))
-		require.EqualValues(t, "1_1", dsIndicesList[0])
-		require.EqualValues(t, "2", dsIndicesList[1])
+		dsIndicesList := jobDBInspector.getDSListSnapshot()
+		require.EqualValues(t, 2, len(jobDBInspector.getDSListSnapshot()))
+		require.EqualValues(t, "1_1", dsIndicesList[0].Index)
+		require.EqualValues(t, "2", dsIndicesList[1].Index)
 		require.EqualValues(t, 2, jobDB.GetMaxDSIndex())
 
 		// only non-terminal jobs should be migrated

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -145,6 +145,7 @@ type UpdateSafeTx interface {
 	SqlTx() *sql.Tx
 	getDSList() []dataSetT
 	getDSRangeList() []dataSetRangeT
+	setDSList([]dataSetT, []dataSetRangeT)
 	updateSafeTxSealIdentifier() string
 }
 type updateSafeTx struct {
@@ -166,6 +167,11 @@ func (r *updateSafeTx) getDSRangeList() []dataSetRangeT {
 	return r.dsRangeList
 }
 
+func (r *updateSafeTx) setDSList(dsList []dataSetT, dsRangeList []dataSetRangeT) {
+	r.dsList = dsList
+	r.dsRangeList = dsRangeList
+}
+
 func (r *updateSafeTx) Tx() *Tx {
 	return r.tx
 }
@@ -182,18 +188,6 @@ func EmptyUpdateSafeTx() UpdateSafeTx {
 // HandleInspector is only intended to be used by tests for verifying the handle's internal state
 type HandleInspector struct {
 	*Handle
-}
-
-// DSIndicesList returns the slice of current ds indices
-func (h *HandleInspector) DSIndicesList() []string {
-	h.dsListLock.RLock()
-	defer h.dsListLock.RUnlock()
-	var indicesList []string
-	for _, ds := range h.getDSList() {
-		indicesList = append(indicesList, ds.Index)
-	}
-
-	return indicesList
 }
 
 // MoreToken is a token that can be used to fetch more jobs
@@ -359,24 +353,54 @@ Later we can move this to query
 IMP NOTE: AcquireUpdateJobStatusLocks Should be called before calling this function
 */
 func (jd *Handle) UpdateJobStatusInTx(ctx context.Context, tx UpdateSafeTx, statusList []*JobStatusT) error {
-	updateCmd := func(dsList []dataSetT, dsRangeList []dataSetRangeT) error {
-		if len(statusList) == 0 {
-			return nil
-		}
+	if len(statusList) == 0 {
+		return nil
+	}
+	if tx.updateSafeTxSealIdentifier() != jd.Identifier() {
+		return fmt.Errorf("invalid UpdateSafeTx: expected identifier %s, got %s", jd.Identifier(), tx.updateSafeTxSealIdentifier())
+	}
+	updateCmd := func() error {
 		tags := statTags{}
 		command := func() error {
-			return jd.internalUpdateJobStatusInTx(ctx, tx.Tx(), dsList, dsRangeList, statusList)
+			return jd.internalUpdateJobStatusInTx(ctx, tx.Tx(), tx.getDSList(), tx.getDSRangeList(), statusList)
 		}
 		err := executeDbRequest(ctx, jd, newWriteDbRequest("update_job_status", &tags, command))
 		return err
 	}
+	const (
+		savepointName = "updateJobStatusInTx"
+		savepointSql  = "SAVEPOINT " + savepointName
+		rollbackSql   = "ROLLBACK TO SAVEPOINT " + savepointName
+	)
+	for {
+		if _, err := tx.Tx().ExecContext(ctx, savepointSql); err != nil {
+			return fmt.Errorf("executing updateJobStatusInTx savepoint: %w", err)
+		}
+		err := updateCmd()
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, ErrStaleDsList) {
+			return err
+		}
+		if _, rbErr := tx.Tx().ExecContext(ctx, rollbackSql); rbErr != nil {
+			return fmt.Errorf("rolling back to updateJobStatusInTx savepoint: %w", rbErr)
+		}
 
-	if tx.updateSafeTxSealIdentifier() != jd.Identifier() {
-		return jd.inUpdateSafeCtx(ctx, func(dsList []dataSetT, dsRangeList []dataSetRangeT) error {
-			return updateCmd(dsList, dsRangeList)
-		})
+		jd.logger.Warnn("[JobsDB] :: Stale dataset list detected while updating job statuses, retrying after refreshing DS cache", obskit.Error(ErrStaleDsList))
+		if refreshErr := func() error {
+			return jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
+				if err := jd.doRefreshDSRangeListWithDB(l, tx.SqlTx()); err != nil {
+					return fmt.Errorf("refresh ds range list: %w", err)
+				}
+				dsList, dsRangeList := jd.dsList.snapshot()
+				tx.setDSList(dsList, dsRangeList)
+				return nil
+			})
+		}(); refreshErr != nil {
+			return refreshErr
+		}
 	}
-	return updateCmd(tx.getDSList(), tx.getDSRangeList())
 }
 
 /*
@@ -498,6 +522,12 @@ func (l dataSetTList) String() string {
 	return sb.String()
 }
 
+// dropDSEntry tracks a dataset to drop along with the dslist version that needs to be drained from readers before actually being able to drop the dataset
+type dropDSEntry struct {
+	ds      dataSetT // dataset to drop
+	version uint64   // the dslist version that needs to be drained from readers before dropping the dataset
+}
+
 type dataSetRangeT struct {
 	minJobID int64
 	maxJobID int64
@@ -539,8 +569,10 @@ type Handle struct {
 	logger               logger.Logger
 	stats                stats.Stats
 
-	datasetList         dataSetTList
-	datasetRangeList    dataSetRangeTList
+	dsList              *versionedDSList
+	dropDSListLock      sync.RWMutex  // protects dropDSList
+	dropDSList          []dropDSEntry // list of datasets to be dropped asynchronously in a non-blocking fashion
+	dropNotify          chan struct{} // used to notify the dropDSLoop of new entries in dropDSList
 	dsRangeFuncMap      map[string]func() (dsRangeMinMax, error)
 	distinctValuesCache *distinctValuesCache
 	dsListLock          *lock.Locker
@@ -625,6 +657,10 @@ type Handle struct {
 			jobMinRowsLeftMigrateThreshold    config.ValueLoader[float64]
 			migrateDSLoopSleepDuration        config.ValueLoader[time.Duration]
 			migrateDSTimeout                  config.ValueLoader[time.Duration]
+			// nonBlockingCompletedDSDrop routes datasets with zero pending jobs
+			// through the async dropDSLoop instead of the in-TX postMigrateHandleDS
+			// path, so the drop is migration-lock-free and does not block concurrent readers.
+			nonBlockingCompletedDSDrop config.ValueLoader[bool]
 		}
 		backup struct {
 			masterBackupEnabled config.ValueLoader[bool]
@@ -912,6 +948,8 @@ func (jd *Handle) Setup(
 func (jd *Handle) init() {
 	jd.dsListLock = lock.NewLocker()
 	jd.dsMigrationLock = lock.NewLocker()
+	jd.dsList = newVersionedDSList(nil, nil)
+	jd.dropNotify = make(chan struct{}, 1)
 	if jd.logger == nil {
 		jd.logger = logger.NewLogger().Child("jobsdb").Child(jd.tablePrefix)
 	}
@@ -958,11 +996,11 @@ func (jd *Handle) init() {
 			maxConns += jd.conf.maxReaders + jd.conf.maxWriters
 			switch jd.ownerType {
 			case Read:
-				maxConns += 2 // migrate, refreshDsList
+				maxConns += 3 // migrate, refreshDsList, dropDS
 			case Write:
 				maxConns += 1 // addNewDS
 			case ReadWrite:
-				maxConns += 3 // migrate, addNewDS, archive
+				maxConns += 3 // migrate, addNewDS, dropDS
 			}
 			if maxConns >= jd.conf.maxOpenConnections {
 				maxConns = jd.conf.maxOpenConnections
@@ -1092,6 +1130,7 @@ func (jd *Handle) loadConfig() {
 	jd.conf.migration.maxMigrateDSProbe = jd.config.GetReloadableIntVar(10, 1, jd.configKeys("maxMigrateDSProbe")...)
 	jd.conf.migration.vacuumFullStatusTableThreshold = jd.config.GetReloadableInt64Var(500*bytesize.MB, 1, jd.configKeys("vacuumFullStatusTableThreshold")...)
 	jd.conf.migration.vacuumAnalyzeStatusTableThreshold = jd.config.GetReloadableInt64Var(30000, 1, jd.configKeys("vacuumAnalyzeStatusTableThreshold")...)
+	jd.conf.migration.nonBlockingCompletedDSDrop = jd.config.GetReloadableBoolVar(false, jd.configKeys("nonBlockingCompletedDSDrop")...)
 
 	// masterBackupEnabled = true => all the jobsdb are eligible for backup
 	jd.conf.backup.masterBackupEnabled = jd.config.GetReloadableBoolVar(true, jd.configKeys("backup.enabled")...)
@@ -1188,9 +1227,16 @@ func (jd *Handle) readerSetup(ctx context.Context, l lock.LockToken) {
 	// This is a thread-safe operation.
 	// Even if two different services (gateway and processor) perform this operation, there should not be any problem.
 	jd.recoverFromJournal(ReadWrite)
+	jd.assertError(func() error {
+		err := jd.cleanupPreDropTables(ctx)
+		if err != nil && ctx.Err() == nil {
+			return err
+		}
+		return nil
+	}())
 	jd.assertError(jd.doRefreshDSRangeList(l))
 	jd.assertError(func() error {
-		err := jd.doCleanup(ctx)
+		err := jd.doCleanup(ctx, l)
 		if err != nil && ctx.Err() == nil {
 			return err
 		}
@@ -1205,6 +1251,7 @@ func (jd *Handle) readerSetup(ctx context.Context, l lock.LockToken) {
 	}))
 
 	jd.startMigrateDSLoop(ctx)
+	jd.startDropDSLoop(ctx)
 }
 
 func (jd *Handle) writerSetup(ctx context.Context, l lock.LockToken) {
@@ -1215,7 +1262,8 @@ func (jd *Handle) writerSetup(ctx context.Context, l lock.LockToken) {
 	jd.assertError(jd.doRefreshDSRangeList(l))
 
 	// If no DS present, add one
-	if len(jd.getDSList()) == 0 {
+	dsList, _ := jd.dsList.snapshot()
+	if len(dsList) == 0 {
 		jd.addNewDS(ctx, l, newDataSet(jd.tablePrefix, jd.computeNewIdxForAppend(l)))
 	}
 
@@ -1230,7 +1278,14 @@ func (jd *Handle) readerWriterSetup(ctx context.Context, l lock.LockToken) {
 
 	jd.writerSetup(ctx, l)
 	jd.assertError(func() error {
-		err := jd.doCleanup(ctx)
+		err := jd.cleanupPreDropTables(ctx)
+		if err != nil && ctx.Err() == nil {
+			return err
+		}
+		return nil
+	}())
+	jd.assertError(func() error {
+		err := jd.doCleanup(ctx, l)
 		if err != nil && ctx.Err() == nil {
 			return err
 		}
@@ -1239,6 +1294,7 @@ func (jd *Handle) readerWriterSetup(ctx context.Context, l lock.LockToken) {
 	jd.assertError(jd.loadReadExcludedPartitions())
 
 	jd.startMigrateDSLoop(ctx)
+	jd.startDropDSLoop(ctx)
 }
 
 // Stop stops the background goroutines and waits until they finish.
@@ -1276,17 +1332,18 @@ func (jd *Handle) Close() {
 }
 
 /*
-Function to return an ordered list of datasets and datasetRanges
-Most callers use the in-memory list of dataset and datasetRanges
-Caller must have the dsListLock readlocked
+Utility function to return an ordered list of datasets (for tests)
 */
-func (jd *Handle) getDSList() dataSetTList {
-	return jd.datasetList
+func (jd *Handle) getDSListSnapshot() dataSetTList {
+	jd.dsListLock.RLock()
+	defer jd.dsListLock.RUnlock()
+	list, _ := jd.dsList.snapshot()
+	return list
 }
 
-// getLastDS returns the last dataset in the list. Caller must have the dsListLock readlocked.
+// getLastDS returns the last dataset in the list. Caller must have the dsListLock readlocked
 func (jd *Handle) getLastDS() dataSetT {
-	list := jd.getDSList()
+	list, _ := jd.dsList.snapshot()
 	if len(list) == 0 {
 		return dataSetT{}
 	}
@@ -1294,40 +1351,98 @@ func (jd *Handle) getLastDS() dataSetT {
 }
 
 // doRefreshDSList refreshes the ds list from the database
-func (jd *Handle) doRefreshDSList(l lock.LockToken) (dataSetTList, error) {
+func (jd *Handle) doRefreshDSList(l lock.LockToken, db sqlDbOrTx) (dataSetTList, error) {
 	if l == nil {
 		return nil, fmt.Errorf("cannot refresh DS list without a valid lock token")
 	}
-	var err error
-	// Reset the global list
-	if jd.datasetList, err = getDSList(jd, jd.dbHandle, jd.tablePrefix); err != nil {
+	datasetList, err := getDSList(jd, db, jd.tablePrefix)
+	if err != nil {
 		return nil, fmt.Errorf("getDSList %w", err)
 	}
 	// report table count metrics before shrinking the datasetList
-	jd.statTableCount.Gauge(len(jd.datasetList))
+	jd.statTableCount.Gauge(len(datasetList))
 
 	// If the owner of this jobsdb is a writer, then shrinking datasetList to have only last dataset
 	// which is being written to.
 	// Writers only write to the last dataset and if this dataset is full, then create a new dataset.
 	if jd.ownerType == Write {
-		if len(jd.datasetList) > 1 {
-			jd.datasetList = jd.datasetList[len(jd.datasetList)-1 : len(jd.datasetList)]
+		if len(datasetList) > 1 {
+			datasetList = datasetList[len(datasetList)-1:]
 		}
 	}
 
-	return jd.datasetList, nil
+	return datasetList, nil
 }
 
-func (jd *Handle) getDSRangeList() dataSetRangeTList {
-	return jd.datasetRangeList
+// addCompletedDSToDropList adds the given datasets to the dropDSList and removes them from the dsList. Caller must have the dsListLock write-locked.
+// It returns the freshly published dsList snapshot (with the queued datasets filtered out) so callers can avoid an extra read.
+func (jd *Handle) addCompletedDSToDropList(ctx context.Context, l lock.LockToken, dsList ...dataSetT) (dataSetTList, error) {
+	if l == nil {
+		return nil, fmt.Errorf("cannot add to drop DS list without a valid lock token")
+	}
+	jd.dropDSListLock.Lock()
+	defer jd.dropDSListLock.Unlock()
+	currentList, currentRangeList := jd.dsList.snapshot()
+	if len(dsList) == 0 {
+		return currentList, nil
+	}
+	version := jd.dsList.currentVersion()
+	previousDropDSList := append([]dropDSEntry(nil), jd.dropDSList...)
+	existing := make(map[string]struct{}, len(jd.dropDSList)+len(dsList))
+	for _, entry := range jd.dropDSList {
+		existing[entry.ds.Index] = struct{}{}
+	}
+	var addedDSList []dataSetT
+	for _, ds := range dsList {
+		if _, ok := existing[ds.Index]; ok {
+			continue
+		}
+		jd.dropDSList = append(jd.dropDSList, dropDSEntry{ds: ds, version: version})
+		existing[ds.Index] = struct{}{}
+		addedDSList = append(addedDSList, ds)
+	}
+	if len(addedDSList) == 0 {
+		return currentList, nil
+	}
+	toDrop := lo.SliceToMap(jd.dropDSList, func(entry dropDSEntry) (string, struct{}) {
+		return entry.ds.Index, struct{}{}
+	})
+	newList := lo.Filter(currentList, func(ds dataSetT, _ int) bool {
+		_, ok := toDrop[ds.Index]
+		return !ok
+	})
+	if err := jd.markPreDropDS(ctx, addedDSList...); err != nil {
+		jd.dropDSList = previousDropDSList
+		return currentList, err
+	}
+	jd.dsList.set(
+		newList,
+		lo.Filter(currentRangeList, func(dsRange dataSetRangeT, _ int) bool {
+			_, ok := toDrop[dsRange.ds.Index]
+			return !ok
+		}))
+
+	jd.dropNotifyPing()
+	return newList, nil
+}
+
+func (jd *Handle) dropNotifyPing() {
+	select {
+	case jd.dropNotify <- struct{}{}:
+	default:
+	}
+}
+
+func (jd *Handle) doRefreshDSRangeList(l lock.LockToken) error {
+	return jd.doRefreshDSRangeListWithDB(l, jd.dbHandle)
 }
 
 // doRefreshDSRangeList first refreshes the DS list and then calculate the DS range list
-func (jd *Handle) doRefreshDSRangeList(l lock.LockToken) error {
+func (jd *Handle) doRefreshDSRangeListWithDB(l lock.LockToken, db sqlDbOrTx) error {
 	var prevMax int64
 
 	// At this point we must have write-locked dsListLock
-	dsList, err := jd.doRefreshDSList(l)
+	dsList, err := jd.doRefreshDSList(l, db)
 	if err != nil {
 		return fmt.Errorf("refreshDSList %w", err)
 	}
@@ -1341,7 +1456,7 @@ func (jd *Handle) doRefreshDSRangeList(l lock.LockToken) error {
 			getIndex := func() (sql.NullInt64, sql.NullInt64, error) {
 				var minID, maxID sql.NullInt64
 				sqlStatement := fmt.Sprintf(`SELECT MIN(job_id), MAX(job_id) FROM %q`, ds.JobTable)
-				row := jd.dbHandle.QueryRow(sqlStatement)
+				row := db.QueryRow(sqlStatement)
 				if err := row.Scan(&minID, &maxID); err != nil {
 					return sql.NullInt64{}, sql.NullInt64{}, fmt.Errorf("scanning min & max jobID %w", err)
 				}
@@ -1378,7 +1493,6 @@ func (jd *Handle) doRefreshDSRangeList(l lock.LockToken) error {
 			continue
 		}
 
-		// TODO: Cleanup - Remove the line below and jd.inProgressMigrationTargetDS
 		jd.assert(minID.Valid && maxID.Valid, fmt.Sprintf("minID.Valid: %v, maxID.Valid: %v. Either of them is false for table: %s", minID.Valid, maxID.Valid, ds.JobTable))
 		jd.assert(idx == 0 || prevMax < minID.Int64, fmt.Sprintf("idx: %d != 0 and prevMax: %d >= minID.Int64: %v of table: %s", idx, prevMax, minID.Int64, ds.JobTable))
 		datasetRangeList = append(datasetRangeList,
@@ -1389,8 +1503,20 @@ func (jd *Handle) doRefreshDSRangeList(l lock.LockToken) error {
 			})
 		prevMax = maxID.Int64
 	}
-	jd.datasetRangeList = datasetRangeList
+	jd.dsList.set(dsList, datasetRangeList)
 	return nil
+}
+
+// acquireDSListForRead returns the dsList and dsRangeList. Caller should call the release function after done reading from the lists.
+func (jd *Handle) acquireDSListForRead(ctx context.Context) (
+	list dataSetTList, ranges dataSetRangeTList, release func(), err error,
+) {
+	if !jd.dsListLock.RTryLockWithCtx(ctx) {
+		return nil, nil, nil, fmt.Errorf("could not acquire a dslist read lock: %w", ctx.Err())
+	}
+	list, ranges, _, release = jd.dsList.get()
+	jd.dsListLock.RUnlock()
+	return list, ranges, release, nil
 }
 
 func (jd *Handle) checkIfFullDSInTx(tx *Tx, ds dataSetT) (bool, error) {
@@ -1503,7 +1629,7 @@ func newDataSet(tablePrefix, dsIdx string) dataSetT {
 
 func (jd *Handle) addNewDS(ctx context.Context, l lock.LockToken, ds dataSetT) {
 	err := jd.WithTx(ctx, func(tx *Tx) error {
-		dsList, err := jd.doRefreshDSList(l)
+		dsList, err := jd.doRefreshDSList(l, tx.Tx)
 		jd.assertError(err)
 		return jd.addNewDSInTx(ctx, tx, l, dsList, ds)
 	})
@@ -1540,7 +1666,7 @@ func (jd *Handle) addNewDSInTx(ctx context.Context, tx *Tx, l lock.LockToken, ds
 }
 
 func (jd *Handle) computeNewIdxForAppend(l lock.LockToken) string {
-	dList, err := jd.doRefreshDSList(l)
+	dList, err := jd.doRefreshDSList(l, jd.dbHandle)
 	jd.assertError(err)
 	return jd.doComputeNewIdxForAppend(dList)
 }
@@ -1697,11 +1823,7 @@ func (jd *Handle) setSequenceNumberInTx(tx *Tx, l lock.LockToken, dsList []dataS
 func (jd *Handle) GetMaxDSIndex() (maxDSIndex int64) {
 	jd.dsListLock.RLock()
 	defer jd.dsListLock.RUnlock()
-
-	// dList is already sorted.
-	dList := jd.getDSList()
-	ds := dList[len(dList)-1]
-	maxDSIndex, err := strconv.ParseInt(ds.Index, 10, 64)
+	maxDSIndex, err := strconv.ParseInt(jd.getLastDS().Index, 10, 64)
 	if err != nil {
 		panic(err)
 	}
@@ -1749,9 +1871,94 @@ func (jd *Handle) prepareAndExecStmtInTxAllowMissing(tx *sql.Tx, sqlStatement st
 }
 
 func (jd *Handle) dropDS(ds dataSetT) error {
-	return jd.WithTx(context.Background(), func(tx *Tx) error {
+	return jd.dropDSWithCtx(context.Background(), ds)
+}
+
+func (jd *Handle) dropDSWithCtx(ctx context.Context, ds dataSetT) error {
+	return jd.WithTx(ctx, func(tx *Tx) error {
 		return jd.dropDSInTx(tx, ds)
 	})
+}
+
+func (jd *Handle) markPreDropDS(ctx context.Context, dsList ...dataSetT) error {
+	return jd.WithTx(ctx, func(tx *Tx) error {
+		for _, ds := range dsList {
+			if err := jd.markPreDropDSInTx(ctx, tx, ds); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (jd *Handle) markPreDropDSInTx(ctx context.Context, tx *Tx, ds dataSetT) error {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`COMMENT ON TABLE %q IS '%s'`, ds.JobStatusTable, preDropTableComment)); err != nil {
+		return fmt.Errorf("predrop comment %s: %w", ds.JobStatusTable, err)
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`COMMENT ON TABLE %q IS '%s'`, ds.JobTable, preDropTableComment)); err != nil {
+		return fmt.Errorf("predrop comment %s: %w", ds.JobTable, err)
+	}
+	return nil
+}
+
+func (jd *Handle) cleanupPreDropTables(ctx context.Context) error {
+	rows, err := jd.getDB(ctx).QueryContext(ctx, `SELECT c.relname
+									FROM pg_catalog.pg_class c
+									JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+									JOIN pg_catalog.pg_description d ON d.objoid = c.oid AND d.objsubid = 0
+									WHERE n.nspname != 'pg_catalog'
+										AND n.nspname != 'information_schema'
+										AND c.relkind = 'r'
+										AND d.description LIKE 'rudder:pre_drop:%'`)
+	if err != nil {
+		return fmt.Errorf("query pre-drop tables: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	datasets := make(map[string]dataSetT)
+	for rows.Next() {
+		var tableName string
+		if err = rows.Scan(&tableName); err != nil {
+			return fmt.Errorf("scan pre-drop table: %w", err)
+		}
+		jobTable, statusTable, ok := preDropDatasetTables(tableName)
+		if !ok ||
+			!strings.HasPrefix(jobTable, jd.tablePrefix+"_jobs_") ||
+			!strings.HasPrefix(statusTable, jd.tablePrefix+"_job_status_") {
+			continue
+		}
+		index := strings.TrimPrefix(jobTable, jd.tablePrefix+"_jobs_")
+		datasets[index] = dataSetT{
+			JobTable:       jobTable,
+			JobStatusTable: statusTable,
+			Index:          index,
+		}
+	}
+	if err = rows.Err(); err != nil {
+		return fmt.Errorf("iterate pre-drop tables: %w", err)
+	}
+
+	indices := lo.Keys(datasets)
+	sortDnumList(indices)
+	for _, index := range indices {
+		ds := datasets[index]
+		jd.logger.Infon("dropping pre-drop dataset",
+			logger.NewStringField("jobTable", ds.JobTable),
+			logger.NewStringField("jobStatusTable", ds.JobStatusTable),
+		)
+		if err = jd.WithTx(ctx, func(tx *Tx) error {
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %q CASCADE`, ds.JobStatusTable)); err != nil {
+				return fmt.Errorf("drop %s: %w", ds.JobStatusTable, err)
+			}
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %q CASCADE`, ds.JobTable)); err != nil {
+				return fmt.Errorf("drop %s: %w", ds.JobTable, err)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // dropDS drops a dataset
@@ -1771,6 +1978,77 @@ func (jd *Handle) dropDSInTx(tx *Tx, ds dataSetT) error {
 	}
 	jd.postDropDs(ds)
 	return nil
+}
+
+func (jd *Handle) startDropDSLoop(ctx context.Context) {
+	jd.backgroundGroup.Go(crash.Wrapper(func() error {
+		err := jd.dropDSLoop(ctx)
+		if err != nil && ctx.Err() == nil {
+			panic(fmt.Errorf("dropDSLoop for prefix %q: %w", jd.tablePrefix, err))
+		}
+		return nil
+	}))
+}
+
+func (jd *Handle) dropDSLoop(ctx context.Context) error {
+	nextDropDSEntry := func(ctx context.Context) (dropDSEntry, bool) {
+		for {
+			jd.dropDSListLock.RLock()
+			if len(jd.dropDSList) > 0 {
+				entry := jd.dropDSList[0]
+				jd.dropDSListLock.RUnlock()
+				return entry, true
+			}
+			jd.dropDSListLock.RUnlock()
+
+			select {
+			case <-ctx.Done():
+				return dropDSEntry{}, false
+			case <-jd.dropNotify:
+			}
+		}
+	}
+	for {
+		entry, ok := nextDropDSEntry(ctx)
+		if !ok {
+			return nil
+		}
+		// Wait until all operations using this dataset are done.
+		// This ensures that we don't drop a dataset which is currently being read.
+		drained, err := jd.dsList.wait(entry.version)
+		if err != nil {
+			return fmt.Errorf("wait for dsList drain: %w", err)
+		}
+		select {
+		case <-drained:
+		case <-ctx.Done():
+			return nil
+		}
+		// drop the dataset
+		if err := jd.dropDSWithCtx(ctx, entry.ds); err != nil {
+			return fmt.Errorf("dropDSWithCtx: %w", err)
+		}
+		// update the lists and cache
+		if err := jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
+			jd.dropDSListLock.Lock()
+			defer jd.dropDSListLock.Unlock()
+			// Remove the entry from dropDSList
+			jd.dropDSList = lo.Filter(jd.dropDSList, func(e dropDSEntry, _ int) bool {
+				return e.version != entry.version || e.ds.Index != entry.ds.Index
+			})
+			// delete the entry from dsRangeFuncMap
+			delete(jd.dsRangeFuncMap, entry.ds.Index)
+			// Invalidate the distinctValuesCache for the dropped dataset
+			jd.distinctValuesCache.RemoveDataset(entry.ds.JobTable)
+			// If there are more datasets to drop, notify the dropDSLoop to check the next one
+			if len(jd.dropDSList) > 0 {
+				jd.dropNotifyPing()
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("removeDropDSEntry: %w", err)
+		}
+	}
 }
 
 // Drop a dataset and ignore if a table is missing
@@ -1926,12 +2204,11 @@ func (jd *Handle) inUpdateSafeCtx(ctx context.Context, f func(dsList []dataSetT,
 	}
 	defer jd.dsMigrationLock.RUnlock()
 
-	if !jd.dsListLock.RTryLockWithCtx(ctx) {
-		return fmt.Errorf("could not acquire a dslist read lock: %w", ctx.Err())
+	dsList, dsRangeList, release, err := jd.acquireDSListForRead(ctx)
+	if err != nil {
+		return err
 	}
-	dsList := jd.getDSList()
-	dsRangeList := jd.getDSRangeList()
-	jd.dsListLock.RUnlock()
+	defer release()
 	return f(dsList, dsRangeList)
 }
 
@@ -2006,11 +2283,11 @@ func (jd *Handle) GetPileUpCounts(ctx context.Context, cutoffTime time.Time, inc
 		return fmt.Errorf("could not acquire a migration read lock: %w", ctx.Err())
 	}
 	defer jd.dsMigrationLock.RUnlock()
-	if !jd.dsListLock.RTryLockWithCtx(ctx) {
-		return fmt.Errorf("could not acquire a dslist read lock: %w", ctx.Err())
+	dsList, _, release, err := jd.acquireDSListForRead(ctx)
+	if err != nil {
+		return err
 	}
-	dsList := jd.getDSList()
-	jd.dsListLock.RUnlock()
+	defer release()
 
 	queryString := `WITH pending AS (
 	SELECT
@@ -2140,11 +2417,11 @@ func (jd *Handle) GetDistinctParameterValues(ctx context.Context, parameter Para
 		return nil, fmt.Errorf("could not acquire a migration read lock: %w", ctx.Err())
 	}
 	defer jd.dsMigrationLock.RUnlock()
-	if !jd.dsListLock.RTryLockWithCtx(ctx) {
-		return nil, fmt.Errorf("could not acquire a dslist read lock: %w", ctx.Err())
+	dsList, _, release, err := jd.acquireDSListForRead(ctx)
+	if err != nil {
+		return nil, err
 	}
-	dsList := jd.getDSList()
-	jd.dsListLock.RUnlock()
+	defer release()
 	return jd.distinctValuesCache.GetDistinctValues(
 		parameter.string()+customValFilter,
 		lo.Map(dsList, func(ds dataSetT, _ int) string { return ds.JobTable }),
@@ -2683,6 +2960,12 @@ func (jd *Handle) updateJobStatusDSInTx(ctx context.Context, tx *Tx, ds dataSetT
 	err = store()
 	var e *pq.Error
 	if err != nil && errors.As(err, &e) {
+		if e.Code == pgErrorCodeTableReadonly {
+			if _, err = tx.ExecContext(ctx, rollbackSql); err != nil {
+				return updatedStates, err
+			}
+			return updatedStates, ErrStaleDsList
+		}
 		if _, ok := dbInvalidJsonErrors[string(e.Code)]; ok {
 			if _, err = tx.ExecContext(ctx, rollbackSql); err != nil {
 				return updatedStates, err
@@ -2861,13 +3144,12 @@ func (jd *Handle) RefreshDSList(ctx context.Context) error {
 		jd.stats.NewTaggedStat("refresh_ds_loop", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix, "error": strconv.FormatBool(err != nil)}).Since(start)
 	}()
 	jd.dsListLock.RLock()
-	previousDS := jd.datasetList
+	previousLastDS := jd.getLastDS()
 	jd.dsListLock.RUnlock()
 	nextDS, err := getDSList(jd, jd.getDB(ctx), jd.tablePrefix)
 	if err != nil {
 		return fmt.Errorf("getDSList: %w", err)
 	}
-	previousLastDS, _ := lo.Last(previousDS)
 	nextLastDS, _ := lo.Last(nextDS)
 
 	if previousLastDS.Index == nextLastDS.Index {
@@ -3291,6 +3573,9 @@ func (jd *Handle) Store(ctx context.Context, jobList []*JobT) error {
 // StoreInTx stores new jobs to the jobsdb.
 // If enableWriterQueue is true, this goes through writer worker pool.
 func (jd *Handle) StoreInTx(ctx context.Context, tx StoreSafeTx, jobList []*JobT) error {
+	if tx.storeSafeTxIdentifier() != jd.Identifier() {
+		return fmt.Errorf("invalid store safe tx identifier, expected: %s, actual: %s", jd.Identifier(), tx.storeSafeTxIdentifier())
+	}
 	storeCmd := func() error {
 		command := func() error {
 			err := jd.internalStoreJobsInTx(ctx, tx.Tx(), tx.getLastDS(), jobList)
@@ -3298,10 +3583,6 @@ func (jd *Handle) StoreInTx(ctx context.Context, tx StoreSafeTx, jobList []*JobT
 		}
 		err := executeDbRequest(ctx, jd, newWriteDbRequest("store", nil, command))
 		return err
-	}
-
-	if tx.storeSafeTxIdentifier() != jd.Identifier() {
-		return fmt.Errorf("invalid store safe tx identifier, expected: %s, actual: %s", jd.Identifier(), tx.storeSafeTxIdentifier())
 	}
 	return storeCmd()
 }
@@ -3324,6 +3605,9 @@ func (jd *Handle) StoreEachBatchRetryInTx(
 	tx StoreSafeTx,
 	jobBatches [][]*JobT,
 ) (map[uuid.UUID]string, error) {
+	if tx.storeSafeTxIdentifier() != jd.Identifier() {
+		return nil, fmt.Errorf("invalid store safe tx identifier, expected: %s, actual: %s", jd.Identifier(), tx.storeSafeTxIdentifier())
+	}
 	var (
 		err error
 		res map[uuid.UUID]string
@@ -3340,9 +3624,6 @@ func (jd *Handle) StoreEachBatchRetryInTx(
 		}
 		res = executeDbRequest(ctx, jd, newWriteDbRequest("store_each_batch_retry", nil, command))
 		return err
-	}
-	if tx.storeSafeTxIdentifier() != jd.Identifier() {
-		return nil, fmt.Errorf("invalid store safe tx identifier, expected: %s, actual: %s", jd.Identifier(), tx.storeSafeTxIdentifier())
 	}
 	_ = storeCmd()
 	return res, err
@@ -3418,16 +3699,17 @@ printLists is a debugging function used to print
 the current in-memory copy of jobs and job ranges
 */
 func (jd *Handle) printLists(console bool) {
+	dsList, dsRangeList := jd.dsList.snapshot()
 	// This being an internal function, we don't lock
 	if jd.logger.IsDebugLevel() {
 		jd.logger.Debugn("printLists",
-			logger.NewStringField("list", jd.getDSList().String()),
-			logger.NewStringField("ranges", jd.getDSRangeList().String()),
+			logger.NewStringField("list", dsList.String()),
+			logger.NewStringField("ranges", dsRangeList.String()),
 		)
 	}
 	if console {
-		fmt.Println("List:", jd.getDSList())
-		fmt.Println("Ranges:", jd.getDSRangeList())
+		fmt.Println("List:", dsList)
+		fmt.Println("Ranges:", dsRangeList)
 	}
 }
 
@@ -3506,12 +3788,11 @@ func (jd *Handle) getJobs(ctx context.Context, params GetQueryParams, more MoreT
 		return nil, fmt.Errorf("could not acquire a migration read lock: %w", ctx.Err())
 	}
 	defer jd.dsMigrationLock.RUnlock()
-	if !jd.dsListLock.RTryLockWithCtx(ctx) {
-		return nil, fmt.Errorf("could not acquire a dslist read lock: %w", ctx.Err())
+	dsList, dsRangeList, release, err := jd.acquireDSListForRead(ctx)
+	if err != nil {
+		return nil, err
 	}
-	dsRangeList := jd.getDSRangeList()
-	dsList := jd.getDSList()
-	jd.dsListLock.RUnlock()
+	defer release()
 
 	limitByEventCount := params.EventsLimit > 0
 

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -146,8 +146,8 @@ func TestJobsdbLifecycle(t *testing.T) {
 		jd := startTestJobsDB(t)
 		defer jd.TearDown()
 		t.Run("doesn't make db calls if !refreshFromDB", func(t *testing.T) {
-			jd.datasetList = dsListInMemory
-			require.Equal(t, dsListInMemory, jd.getDSList())
+			jd.dsList.set(dsListInMemory, nil)
+			require.Equal(t, dsListInMemory, jd.getDSListSnapshot())
 		})
 	})
 
@@ -370,17 +370,463 @@ func TestRefreshDSList(t *testing.T) {
 	prefix := strings.ToLower(rsRand.String(5))
 	err = jobsDB.Setup(ReadWrite, false, prefix)
 	require.NoError(t, err)
+	jobsDB.Stop()
 	defer jobsDB.TearDown()
 
-	require.Equal(t, 1, len(jobsDB.getDSList()), "jobsDB should start with a ds list size of 1")
+	require.Equal(t, 1, len(jobsDB.getDSListSnapshot()), "jobsDB should start with a ds list size of 1")
 	require.NoError(t, jobsDB.WithTx(context.Background(), func(tx *Tx) error {
 		return jobsDB.createDSInTx(context.Background(), tx, newDataSet(prefix, "2"))
 	}))
-	require.Equal(t, 1, len(jobsDB.getDSList()), "addDS should not refresh the ds list")
+	require.Equal(t, 1, len(jobsDB.getDSListSnapshot()), "addDS should not refresh the ds list")
 	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
-		dsList, err := jobsDB.doRefreshDSList(l)
+		dsList, err := jobsDB.doRefreshDSList(l, jobsDB.dbHandle)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(dsList), "after refreshing the ds list jobsDB should have a ds list size of 2")
+		require.NoError(t, jobsDB.doRefreshDSRangeList(l))
+	})
+	require.Equal(t, 2, len(jobsDB.getDSListSnapshot()))
+
+	versionBeforeDrop := jobsDB.dsList.currentVersion()
+	dsToDrop := jobsDB.getDSListSnapshot()[0]
+	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
+		_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, dsToDrop)
+		require.NoError(t, err)
+		jobsDB.dropDSListLock.RLock()
+		require.Len(t, jobsDB.dropDSList, 1)
+		require.Equal(t, dsToDrop, jobsDB.dropDSList[0].ds)
+		require.Equal(t, versionBeforeDrop, jobsDB.dropDSList[0].version)
+		jobsDB.dropDSListLock.RUnlock()
+	})
+	require.Equal(t, versionBeforeDrop+1, jobsDB.dsList.currentVersion())
+	require.Equal(t, 1, len(jobsDB.getDSListSnapshot()), "adding to drop list should publish a ds list generation without the dataset")
+
+	require.NoError(t, jobsDB.RefreshDSList(context.Background()))
+	require.Equal(t, 1, len(jobsDB.getDSListSnapshot()), "refresh should hide datasets pending drop")
+	jobsDB.dropDSListLock.RLock()
+	require.Len(t, jobsDB.dropDSList, 1)
+	require.Equal(t, versionBeforeDrop, jobsDB.dropDSList[0].version)
+	jobsDB.dropDSListLock.RUnlock()
+
+	require.NoError(t, jobsDB.dropDS(dsToDrop))
+	require.NoError(t, jobsDB.RefreshDSList(context.Background()))
+	require.Equal(t, 1, len(jobsDB.getDSListSnapshot()))
+	jobsDB.dropDSListLock.RLock()
+	require.Len(t, jobsDB.dropDSList, 1, "refresh should not mutate the pending drop list")
+	require.Equal(t, versionBeforeDrop, jobsDB.dropDSList[0].version)
+	jobsDB.dropDSListLock.RUnlock()
+}
+
+func TestPreDropMarker(t *testing.T) {
+	_ = startPostgres(t)
+	statStore, err := memstats.New()
+	require.NoError(t, err)
+
+	prefix := strings.ToLower(rsRand.String(5))
+	jobsDB := &Handle{
+		config: config.New(),
+		stats:  statStore,
+	}
+	require.NoError(t, jobsDB.Setup(ReadWrite, true, prefix))
+	defer jobsDB.TearDown()
+
+	ds1 := jobsDB.getDSListSnapshot()[0]
+	require.NoError(t, jobsDB.dsListLock.WithLockInCtx(context.Background(), func(l lock.LockToken) error {
+		jobsDB.addNewDS(context.Background(), l, newDataSet(prefix, "2"))
+		return nil
+	}))
+	ds2 := jobsDB.getDSListSnapshot()[1]
+	jobsDB.Stop()
+
+	require.NoError(t, jobsDB.dsListLock.WithLockInCtx(context.Background(), func(l lock.LockToken) error {
+		_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1)
+		return err
+	}))
+
+	// marker-aware ds list discovery
+	dsList, err := getDSList(jobsDB, jobsDB.dbHandle, prefix)
+	require.NoError(t, err)
+	require.Equal(t, []dataSetT{ds2}, dsList)
+
+	// cleanup of pre-drop datasets during startup
+	restarted := &Handle{
+		config: config.New(),
+		stats:  statStore,
+	}
+	require.NoError(t, restarted.Setup(ReadWrite, false, prefix))
+	defer restarted.TearDown()
+
+	var exists bool
+	require.NoError(t, restarted.dbHandle.QueryRow(`SELECT to_regclass($1) IS NOT NULL`, ds1.JobTable).Scan(&exists))
+	require.False(t, exists)
+	require.NoError(t, restarted.dbHandle.QueryRow(`SELECT to_regclass($1) IS NOT NULL`, ds2.JobTable).Scan(&exists))
+	require.True(t, exists)
+}
+
+func TestGetAllTableNamesPreDropFiltering(t *testing.T) {
+	_ = startPostgres(t)
+
+	setup := func(t *testing.T) (*Handle, dataSetT, dataSetT) {
+		t.Helper()
+		statStore, err := memstats.New()
+		require.NoError(t, err)
+		prefix := strings.ToLower(rsRand.String(5))
+		jobsDB := &Handle{
+			config: config.New(),
+			stats:  statStore,
+		}
+		require.NoError(t, jobsDB.Setup(ReadWrite, true, prefix))
+		t.Cleanup(jobsDB.TearDown)
+
+		require.NoError(t, jobsDB.dsListLock.WithLockInCtx(context.Background(), func(l lock.LockToken) error {
+			jobsDB.addNewDS(context.Background(), l, newDataSet(prefix, "2"))
+			return nil
+		}))
+		jobsDB.Stop()
+		dsList := jobsDB.getDSListSnapshot()
+		require.Len(t, dsList, 2)
+		return jobsDB, dsList[0], dsList[1]
+	}
+	tableNamesForPrefix := func(t *testing.T, jobsDB *Handle, prefix string) map[string]struct{} {
+		t.Helper()
+		tableNames, err := getAllTableNames(jobsDB.dbHandle)
+		require.NoError(t, err)
+		return lo.SliceToMap(
+			lo.Filter(tableNames, func(tableName string, _ int) bool {
+				return strings.HasPrefix(tableName, prefix+"_")
+			}),
+			func(tableName string) (string, struct{}) { return tableName, struct{}{} },
+		)
+	}
+
+	t.Run("unmarked dataset tables are returned", func(t *testing.T) {
+		jobsDB, ds1, ds2 := setup(t)
+		tableNames := tableNamesForPrefix(t, jobsDB, jobsDB.tablePrefix)
+
+		require.Contains(t, tableNames, ds1.JobTable)
+		require.Contains(t, tableNames, ds1.JobStatusTable)
+		require.Contains(t, tableNames, ds2.JobTable)
+		require.Contains(t, tableNames, ds2.JobStatusTable)
+	})
+
+	t.Run("status-table marker hides both dataset tables", func(t *testing.T) {
+		jobsDB, ds1, ds2 := setup(t)
+		require.NoError(t, jobsDB.WithTx(context.Background(), func(tx *Tx) error {
+			_, err := tx.ExecContext(context.Background(), fmt.Sprintf(`COMMENT ON TABLE %q IS '%s'`, ds1.JobStatusTable, preDropTableComment))
+			return err
+		}))
+
+		tableNames := tableNamesForPrefix(t, jobsDB, jobsDB.tablePrefix)
+		require.NotContains(t, tableNames, ds1.JobTable)
+		require.NotContains(t, tableNames, ds1.JobStatusTable)
+		require.Contains(t, tableNames, ds2.JobTable)
+		require.Contains(t, tableNames, ds2.JobStatusTable)
+	})
+
+	t.Run("job-table marker hides both dataset tables", func(t *testing.T) {
+		jobsDB, ds1, ds2 := setup(t)
+		require.NoError(t, jobsDB.WithTx(context.Background(), func(tx *Tx) error {
+			_, err := tx.ExecContext(context.Background(), fmt.Sprintf(`COMMENT ON TABLE %q IS '%s'`, ds1.JobTable, preDropTableComment))
+			return err
+		}))
+
+		tableNames := tableNamesForPrefix(t, jobsDB, jobsDB.tablePrefix)
+		require.NotContains(t, tableNames, ds1.JobTable)
+		require.NotContains(t, tableNames, ds1.JobStatusTable)
+		require.Contains(t, tableNames, ds2.JobTable)
+		require.Contains(t, tableNames, ds2.JobStatusTable)
+	})
+
+	t.Run("unrelated marker hides only the marked unrelated table", func(t *testing.T) {
+		jobsDB, ds1, ds2 := setup(t)
+		unrelatedTable := jobsDB.tablePrefix + "_metadata"
+		require.NoError(t, jobsDB.WithTx(context.Background(), func(tx *Tx) error {
+			if _, err := tx.ExecContext(context.Background(), fmt.Sprintf(`CREATE TABLE %q (id BIGINT)`, unrelatedTable)); err != nil {
+				return err
+			}
+			_, err := tx.ExecContext(context.Background(), fmt.Sprintf(`COMMENT ON TABLE %q IS '%s'`, unrelatedTable, preDropTableComment))
+			return err
+		}))
+
+		tableNames := tableNamesForPrefix(t, jobsDB, jobsDB.tablePrefix)
+		require.NotContains(t, tableNames, unrelatedTable)
+		require.Contains(t, tableNames, ds1.JobTable)
+		require.Contains(t, tableNames, ds1.JobStatusTable)
+		require.Contains(t, tableNames, ds2.JobTable)
+		require.Contains(t, tableNames, ds2.JobStatusTable)
+	})
+}
+
+func TestUpdateJobStatusInExternalTxRetriesAfterReadonlyStatusTable(t *testing.T) {
+	_ = startPostgres(t)
+	statStore, err := memstats.New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	prefix := strings.ToLower(rsRand.String(5))
+	jobsDB := &Handle{
+		config: config.New(),
+		stats:  statStore,
+	}
+	require.NoError(t, jobsDB.Setup(ReadWrite, true, prefix))
+	defer jobsDB.TearDown()
+
+	jobs := genJobs(defaultWorkspaceID, "external-tx", 1, 1)
+	require.NoError(t, jobsDB.Store(ctx, jobs))
+
+	require.NoError(t, jobsDB.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
+		jobsDB.addNewDS(ctx, l, newDataSet(prefix, "2"))
+		return nil
+	}))
+	ds1 := jobsDB.getDSListSnapshot()[0]
+	replacement := newDataSet(prefix, "1_1")
+	jobsDB.Stop()
+
+	prepareReplacement := func() error {
+		return jobsDB.WithTx(ctx, func(tx *Tx) error {
+			if err := jobsDB.createDSInTx(ctx, tx, replacement); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+				`INSERT INTO %q (
+					job_id, workspace_id, uuid, user_id, partition_id, custom_val,
+					parameters, event_payload, event_count, created_at, expire_at
+				)
+				SELECT
+					job_id, workspace_id, uuid, user_id, partition_id, custom_val,
+					parameters, event_payload, event_count, created_at, expire_at
+				FROM %q`,
+				replacement.JobTable,
+				ds1.JobTable,
+			)); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+				`CREATE TRIGGER readonlyTableTrg
+				BEFORE INSERT
+				ON %q
+				FOR EACH STATEMENT
+				EXECUTE PROCEDURE %s;`,
+				ds1.JobStatusTable,
+				pgReadonlyTableExceptionFuncName,
+			)); err != nil {
+				return err
+			}
+			return jobsDB.markPreDropDSInTx(ctx, tx, ds1)
+		})
+	}
+
+	statuses := genJobStatuses(jobs, Failed.State)
+	require.NoError(t, jobsDB.WithTx(ctx, func(tx *Tx) error {
+		return jobsDB.WithUpdateSafeTxFromTx(ctx, tx, func(updateTx UpdateSafeTx) error {
+			require.Equal(t, ds1.Index, updateTx.getDSRangeList()[0].ds.Index)
+			if err := prepareReplacement(); err != nil {
+				return err
+			}
+			return jobsDB.UpdateJobStatusInTx(ctx, updateTx, statuses)
+		})
+	}))
+
+	var oldStatusCount, replacementStatusCount int
+	require.NoError(t, jobsDB.dbHandle.QueryRow(
+		fmt.Sprintf(`SELECT COUNT(*) FROM %q WHERE job_id = $1 AND job_state = $2`, ds1.JobStatusTable),
+		jobs[0].JobID,
+		Failed.State,
+	).Scan(&oldStatusCount))
+	require.NoError(t, jobsDB.dbHandle.QueryRow(
+		fmt.Sprintf(`SELECT COUNT(*) FROM %q WHERE job_id = $1 AND job_state = $2`, replacement.JobStatusTable),
+		jobs[0].JobID,
+		Failed.State,
+	).Scan(&replacementStatusCount))
+	require.Equal(t, 0, oldStatusCount)
+	require.Equal(t, 1, replacementStatusCount)
+}
+
+func TestDropDSLoop(t *testing.T) {
+	_ = startPostgres(t)
+
+	newHandle := func(t *testing.T) (*Handle, string) {
+		t.Helper()
+		statStore, err := memstats.New()
+		require.NoError(t, err)
+		jobsDB := &Handle{
+			TriggerAddNewDS:  func() <-chan time.Time { return make(chan time.Time) },
+			TriggerMigrateDS: func() <-chan time.Time { return make(chan time.Time) },
+			stats:            statStore,
+		}
+		prefix := strings.ToLower(rsRand.String(5))
+		require.NoError(t, jobsDB.Setup(ReadWrite, false, prefix))
+		t.Cleanup(jobsDB.TearDown)
+		return jobsDB, prefix
+	}
+	addDatasets := func(t *testing.T, jd *Handle, prefix string, indices ...string) {
+		t.Helper()
+		require.NoError(t, jd.WithTx(context.Background(), func(tx *Tx) error {
+			for _, idx := range indices {
+				if err := jd.createDSInTx(context.Background(), tx, newDataSet(prefix, idx)); err != nil {
+					return err
+				}
+			}
+			return nil
+		}))
+		jd.dsListLock.WithLock(func(l lock.LockToken) {
+			require.NoError(t, jd.doRefreshDSRangeList(l))
+		})
+	}
+	tableExists := func(t *testing.T, jd *Handle, ds dataSetT) bool {
+		t.Helper()
+		var exists bool
+		require.NoError(t, jd.dbHandle.QueryRow(`SELECT to_regclass($1) IS NOT NULL`, ds.JobTable).Scan(&exists))
+		return exists
+	}
+
+	t.Run("waits for readers before dropping", func(t *testing.T) {
+		jobsDB, prefix := newHandle(t)
+		addDatasets(t, jobsDB, prefix, "2")
+		require.Len(t, jobsDB.getDSListSnapshot(), 2)
+
+		dsToDrop := jobsDB.getDSListSnapshot()[0]
+
+		dsList, _, release, err := jobsDB.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, dsToDrop.Index, dsList[0].Index)
+
+		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
+			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, dsToDrop)
+			require.NoError(t, err)
+		})
+		require.Len(t, jobsDB.getDSListSnapshot(), 1)
+		require.Never(t, func() bool { return !tableExists(t, jobsDB, dsToDrop) }, 200*time.Millisecond, 20*time.Millisecond)
+
+		release()
+		require.Eventually(t, func() bool {
+			jobsDB.dropDSListLock.RLock()
+			pendingDrops := len(jobsDB.dropDSList)
+			jobsDB.dropDSListLock.RUnlock()
+			return !tableExists(t, jobsDB, dsToDrop) && pendingDrops == 0
+		}, 5*time.Second, 50*time.Millisecond)
+	})
+
+	t.Run("drains multiple queued drops", func(t *testing.T) {
+		jobsDB, prefix := newHandle(t)
+		addDatasets(t, jobsDB, prefix, "2", "3")
+		require.Len(t, jobsDB.getDSListSnapshot(), 3)
+
+		snapshot := jobsDB.getDSListSnapshot()
+		ds1, ds2 := snapshot[0], snapshot[1]
+
+		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
+			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1, ds2)
+			require.NoError(t, err)
+		})
+
+		require.Eventually(t, func() bool {
+			return !tableExists(t, jobsDB, ds1) && !tableExists(t, jobsDB, ds2)
+		}, 5*time.Second, 50*time.Millisecond, "both queued datasets should be dropped")
+
+		jobsDB.dropDSListLock.Lock()
+		require.Empty(t, jobsDB.dropDSList, "dropDSList should be empty after both datasets are dropped")
+		jobsDB.dropDSListLock.Unlock()
+	})
+
+	t.Run("addToDropDSList is idempotent", func(t *testing.T) {
+		jobsDB, prefix := newHandle(t)
+		// Stop background loops so the dropDSLoop doesn't consume queued entries mid-test.
+		jobsDB.Stop()
+		addDatasets(t, jobsDB, prefix, "2", "3")
+		require.Len(t, jobsDB.getDSListSnapshot(), 3)
+
+		snapshot := jobsDB.getDSListSnapshot()
+		ds1, ds2 := snapshot[0], snapshot[1]
+		versionBefore := jobsDB.dsList.currentVersion()
+
+		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
+			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1)
+			require.NoError(t, err)
+		})
+		jobsDB.dropDSListLock.RLock()
+		require.Len(t, jobsDB.dropDSList, 1)
+		jobsDB.dropDSListLock.RUnlock()
+		require.Equal(t, versionBefore+1, jobsDB.dsList.currentVersion(), "first add should bump the dsList version once")
+
+		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
+			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1)
+			require.NoError(t, err)
+		})
+		jobsDB.dropDSListLock.RLock()
+		require.Len(t, jobsDB.dropDSList, 1, "duplicate ds should not be re-added")
+		jobsDB.dropDSListLock.RUnlock()
+		require.Equal(t, versionBefore+1, jobsDB.dsList.currentVersion(), "duplicate add must NOT bump the dsList version")
+
+		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
+			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1, ds2)
+			require.NoError(t, err)
+		})
+		jobsDB.dropDSListLock.RLock()
+		require.Len(t, jobsDB.dropDSList, 2, "only the new ds2 should have been added")
+		jobsDB.dropDSListLock.RUnlock()
+		require.Equal(t, versionBefore+2, jobsDB.dsList.currentVersion(), "mixed add should bump version exactly once")
+	})
+
+	t.Run("exits when context cancelled mid-drop", func(t *testing.T) {
+		jobsDB, prefix := newHandle(t)
+		addDatasets(t, jobsDB, prefix, "2")
+		require.Len(t, jobsDB.getDSListSnapshot(), 2)
+
+		dsToDrop := jobsDB.getDSListSnapshot()[0]
+
+		// Hold a reader on the current snapshot so the drop loop blocks on <-drained.
+		_, _, release, err := jobsDB.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+		defer release()
+
+		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
+			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, dsToDrop)
+			require.NoError(t, err)
+		})
+		require.Never(t, func() bool { return !tableExists(t, jobsDB, dsToDrop) }, 200*time.Millisecond, 20*time.Millisecond)
+
+		stopDone := make(chan struct{})
+		go func() {
+			jobsDB.Stop()
+			close(stopDone)
+		}()
+		select {
+		case <-stopDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("dropDSLoop did not exit within 5s after context cancellation")
+		}
+
+		require.True(t, tableExists(t, jobsDB, dsToDrop), "ds table must not be dropped when the context is cancelled mid-drop")
+		jobsDB.dropDSListLock.RLock()
+		require.Len(t, jobsDB.dropDSList, 1, "the pending drop entry must remain since the drop did not happen")
+		jobsDB.dropDSListLock.RUnlock()
+	})
+
+	t.Run("cleans dsRangeFuncMap after drop", func(t *testing.T) {
+		jobsDB, prefix := newHandle(t)
+		addDatasets(t, jobsDB, prefix, "2")
+		require.Len(t, jobsDB.getDSListSnapshot(), 2)
+
+		dsToDrop := jobsDB.getDSListSnapshot()[0]
+
+		jobsDB.dsListLock.RLock()
+		_, present := jobsDB.dsRangeFuncMap[dsToDrop.Index]
+		jobsDB.dsListLock.RUnlock()
+		require.True(t, present, "dsRangeFuncMap must contain an entry for non-last datasets after refresh")
+
+		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
+			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, dsToDrop)
+			require.NoError(t, err)
+		})
+
+		require.Eventually(t, func() bool {
+			jobsDB.dsListLock.RLock()
+			defer jobsDB.dsListLock.RUnlock()
+			jobsDB.dropDSListLock.RLock()
+			defer jobsDB.dropDSListLock.RUnlock()
+			_, ok := jobsDB.dsRangeFuncMap[dsToDrop.Index]
+			return !ok && len(jobsDB.dropDSList) == 0
+		}, 5*time.Second, 50*time.Millisecond, "dsRangeFuncMap entry for the dropped dataset must be removed after drop")
 	})
 }
 
@@ -489,7 +935,7 @@ func TestThreadSafeAddNewDSLoop(t *testing.T) {
 	prefix := strings.ToLower(rsRand.String(5))
 	err = jobsDB1.Setup(ReadWrite, false, prefix)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(jobsDB1.getDSList()), "expected cache to be auto-updated with DS list length 1")
+	require.Equal(t, 1, len(jobsDB1.getDSListSnapshot()), "expected cache to be auto-updated with DS list length 1")
 	defer jobsDB1.TearDown()
 
 	// jobsDB-2 setup
@@ -504,7 +950,7 @@ func TestThreadSafeAddNewDSLoop(t *testing.T) {
 	err = jobsDB2.Setup(ReadWrite, false, prefix)
 	require.NoError(t, err)
 	defer jobsDB2.TearDown()
-	require.Equal(t, 1, len(jobsDB2.getDSList()), "expected cache to be auto-updated with DS list length 1")
+	require.Equal(t, 1, len(jobsDB2.getDSListSnapshot()), "expected cache to be auto-updated with DS list length 1")
 
 	generateJobs := func(numOfJob int) []*JobT {
 		customVal := "MOCKDS"
@@ -531,9 +977,7 @@ func TestThreadSafeAddNewDSLoop(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool {
-			jobsDB1.dsListLock.RLock()
-			defer jobsDB1.dsListLock.RUnlock()
-			return len(jobsDB1.getDSList()) == 2
+			return len(jobsDB1.getDSListSnapshot()) == 2
 		},
 		time.Second, time.Millisecond,
 		"expected cache to be auto-updated with DS list length 2")
@@ -548,9 +992,7 @@ func TestThreadSafeAddNewDSLoop(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool {
-			jobsDB2.dsListLock.RLock()
-			defer jobsDB2.dsListLock.RUnlock()
-			return len(jobsDB2.getDSList()) == 3
+			return len(jobsDB2.getDSListSnapshot()) == 3
 		},
 		10*time.Second, time.Millisecond,
 		"expected jobsDB2 to be refresh the cache before adding new DS, to get to know about the DS-2 already present & hence add DS-3")
@@ -569,12 +1011,8 @@ func TestThreadSafeAddNewDSLoop(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool {
-			jobsDB1.dsListLock.RLock()
-			dsLen1 = len(jobsDB1.getDSList())
-			jobsDB1.dsListLock.RUnlock()
-			jobsDB2.dsListLock.RLock()
-			dsLen2 = len(jobsDB2.getDSList())
-			jobsDB2.dsListLock.RUnlock()
+			dsLen1 = len(jobsDB1.getDSListSnapshot())
+			dsLen2 = len(jobsDB2.getDSListSnapshot())
 			return dsLen1 == 4 && dsLen2 == 4
 		},
 		time.Second, time.Millisecond,
@@ -600,7 +1038,7 @@ func TestThreadSafeJobStorage(t *testing.T) {
 		err = jobsDB.Setup(ReadWrite, true, strings.ToLower(rsRand.String(5)))
 		require.NoError(t, err)
 		defer jobsDB.TearDown()
-		require.Equal(t, 1, len(jobsDB.getDSList()), "expected cache to be auto-updated with DS list length 1")
+		require.Equal(t, 1, len(jobsDB.getDSListSnapshot()), "expected cache to be auto-updated with DS list length 1")
 
 		generateJobs := func(numOfJob int) []*JobT {
 			customVal := "MOCKDS"
@@ -628,13 +1066,11 @@ func TestThreadSafeJobStorage(t *testing.T) {
 		require.Eventually(
 			t,
 			func() bool {
-				jobsDB.dsListLock.RLock()
-				defer jobsDB.dsListLock.RUnlock()
-				return len(jobsDB.getDSList()) == 2
+				return len(jobsDB.getDSListSnapshot()) == 2
 			},
 			time.Second*5, time.Millisecond,
 			"expected number of tables to be 2")
-		ds := jobsDB.getDSList()
+		ds := jobsDB.getDSListSnapshot()
 		sqlStatement := fmt.Sprintf(`INSERT INTO %q (uuid, user_id, custom_val, parameters, event_payload, workspace_id)
 										   VALUES ($1, $2, $3, $4, $5, $6) RETURNING job_id`, ds[0].JobTable)
 		stmt, err := jobsDB.dbHandle.Prepare(sqlStatement)
@@ -673,7 +1109,7 @@ func TestThreadSafeJobStorage(t *testing.T) {
 		err = jobsDB1.Setup(ReadWrite, true, prefix)
 		require.NoError(t, err)
 		defer jobsDB1.TearDown()
-		require.Equal(t, 1, len(jobsDB1.getDSList()), "expected cache to be auto-updated with DS list length 1")
+		require.Equal(t, 1, len(jobsDB1.getDSListSnapshot()), "expected cache to be auto-updated with DS list length 1")
 
 		// jobsDB-2 setup
 		triggerAddNewDS2 := make(chan time.Time)
@@ -690,7 +1126,7 @@ func TestThreadSafeJobStorage(t *testing.T) {
 		err = jobsDB2.Setup(ReadWrite, !clearAllDS, prefix)
 		require.NoError(t, err)
 		defer jobsDB2.TearDown()
-		require.Equal(t, 1, len(jobsDB2.getDSList()), "expected cache to be auto-updated with DS list length 1")
+		require.Equal(t, 1, len(jobsDB2.getDSListSnapshot()), "expected cache to be auto-updated with DS list length 1")
 
 		// jobsDB-3 setup
 		triggerAddNewDS3 := make(chan time.Time)
@@ -707,7 +1143,7 @@ func TestThreadSafeJobStorage(t *testing.T) {
 		err = jobsDB3.Setup(ReadWrite, !clearAllDS, prefix)
 		require.NoError(t, err)
 		defer jobsDB3.TearDown()
-		require.Equal(t, 1, len(jobsDB3.getDSList()), "expected cache to be auto-updated with DS list length 1")
+		require.Equal(t, 1, len(jobsDB3.getDSListSnapshot()), "expected cache to be auto-updated with DS list length 1")
 
 		generateJobs := func(numOfJob int) []*JobT {
 			customVal := "MOCKDS"
@@ -734,35 +1170,106 @@ func TestThreadSafeJobStorage(t *testing.T) {
 		require.Eventually(
 			t,
 			func() bool {
-				jobsDB1.dsListLock.RLock()
-				defer jobsDB1.dsListLock.RUnlock()
-				return len(jobsDB1.getDSList()) == 2
+				return len(jobsDB1.getDSListSnapshot()) == 2
 			},
 			10*time.Second, time.Millisecond,
 			"expected cache to be auto-updated with DS list length 2")
 
-		require.Equal(t, 1, len(jobsDB2.getDSList()), "expected jobsDB2 to still have a list length of 1")
+		require.Equal(t, 1, len(jobsDB2.getDSListSnapshot()), "expected jobsDB2 to still have a list length of 1")
 		err = jobsDB2.Store(context.Background(), generateJobs(2))
 		require.NoError(t, err)
-		require.Equal(t, 2, len(jobsDB2.getDSList()), "expected jobsDB2 to have refreshed its ds list")
+		require.Equal(t, 2, len(jobsDB2.getDSListSnapshot()), "expected jobsDB2 to have refreshed its ds list")
 
-		require.Equal(t, 1, len(jobsDB3.getDSList()), "expected jobsDB3 to still have a list length of 1")
+		require.Equal(t, 1, len(jobsDB3.getDSListSnapshot()), "expected jobsDB3 to still have a list length of 1")
 		errorsMap := jobsDB3.StoreEachBatchRetry(context.Background(), [][]*JobT{generateJobs(2)})
 		require.Equal(t, 0, len(errorsMap))
 
-		require.Equal(t, 2, len(jobsDB3.getDSList()), "expected jobsDB3 to have refreshed its ds list")
+		require.Equal(t, 2, len(jobsDB3.getDSListSnapshot()), "expected jobsDB3 to have refreshed its ds list")
 
 		// since DS-2 is added, if storing jobs from jobsDB-2, should automatically add DS-2. So, both DS-1 and DS-2 should have 2 jobs
-		row := jobsDB2.dbHandle.QueryRow(fmt.Sprintf("select count(*) from %q", jobsDB2.getDSList()[0].JobTable))
+		row := jobsDB2.dbHandle.QueryRow(fmt.Sprintf("select count(*) from %q", jobsDB2.getDSListSnapshot()[0].JobTable))
 		var count int
 		err = row.Scan(&count)
 		require.NoError(t, err, "expected no error while scanning rows")
 		require.Equal(t, 2, count, "expected 2 jobs in DS-1")
 
-		row = jobsDB1.dbHandle.QueryRow(fmt.Sprintf("select count(*) from %q", jobsDB1.getDSList()[1].JobTable))
+		row = jobsDB1.dbHandle.QueryRow(fmt.Sprintf("select count(*) from %q", jobsDB1.getDSListSnapshot()[1].JobTable))
 		err = row.Scan(&count)
 		require.NoError(t, err, "expected no error while scanning rows")
 		require.Equal(t, 4, count, "expected 4 jobs in DS-2")
+	})
+
+	t.Run("WithStoreSafeTxFromTx retries on errStaleDsList using the caller's tx", func(t *testing.T) {
+		c := config.New()
+		c.Set("JobsDB.maxDSSize", 1)
+
+		triggerAddNewDS1 := make(chan time.Time)
+		triggerAddNewDS2 := make(chan time.Time)
+		triggerRefreshDS := make(chan time.Time)
+
+		statStore, err := memstats.New()
+		require.NoError(t, err)
+
+		prefix := strings.ToLower(rsRand.String(5))
+
+		jobsDB1 := &Handle{
+			TriggerAddNewDS: func() <-chan time.Time { return triggerAddNewDS1 },
+			config:          c,
+			stats:           statStore,
+		}
+		require.NoError(t, jobsDB1.Setup(ReadWrite, true, prefix))
+		defer jobsDB1.TearDown()
+
+		jobsDB2 := &Handle{
+			TriggerAddNewDS:  func() <-chan time.Time { return triggerAddNewDS2 },
+			TriggerRefreshDS: func() <-chan time.Time { return triggerRefreshDS },
+			config:           c,
+			stats:            statStore,
+		}
+		require.NoError(t, jobsDB2.Setup(ReadWrite, false, prefix))
+		defer jobsDB2.TearDown()
+
+		generateJobs := func(numOfJob int) []*JobT {
+			js := make([]*JobT, numOfJob)
+			for i := range numOfJob {
+				js[i] = &JobT{
+					Parameters:   []byte(`{"batch_id":1,"source_id":"sourceID","source_job_run_id":""}`),
+					EventPayload: []byte(`{"testKey":"testValue"}`),
+					UserID:       "a-292e-4e79-9880-f8009e0ae4a3",
+					UUID:         uuid.New(),
+					CustomVal:    "MOCKDS",
+					EventCount:   1,
+				}
+			}
+			return js
+		}
+
+		// jobsDB1 adds a new DS so jobsDB2's cached DS list becomes stale.
+		require.NoError(t, jobsDB1.Store(context.Background(), generateJobs(2)))
+		triggerAddNewDS1 <- time.Now()
+		require.Eventually(t, func() bool {
+			return len(jobsDB1.getDSListSnapshot()) == 2
+		}, 10*time.Second, time.Millisecond, "expected jobsDB1 to have 2 datasets")
+
+		require.Equal(t, 1, len(jobsDB2.getDSListSnapshot()), "jobsDB2 should still have a stale list of 1")
+
+		// Open an external tx and call WithStoreSafeTxFromTx through it.
+		// The first attempt must hit errStaleDsList; the retry must succeed
+		// on the same (recovered) tx, and the tx must remain commitable.
+		jobs := generateJobs(2)
+		require.NoError(t, jobsDB2.WithTx(context.Background(), func(tx *Tx) error {
+			return jobsDB2.WithStoreSafeTxFromTx(context.Background(), tx, func(stx StoreSafeTx) error {
+				return jobsDB2.StoreInTx(context.Background(), stx, jobs)
+			})
+		}))
+
+		require.Equal(t, 2, len(jobsDB2.getDSListSnapshot()), "jobsDB2 should have refreshed its ds list after the retry")
+
+		// The jobs should land in DS-2 (the new dataset created by jobsDB1).
+		row := jobsDB2.dbHandle.QueryRow(fmt.Sprintf("select count(*) from %q", jobsDB2.getDSListSnapshot()[1].JobTable))
+		var count int
+		require.NoError(t, row.Scan(&count))
+		require.Equal(t, 2, count, "expected 2 jobs in DS-2 after retried store via external tx")
 	})
 }
 
@@ -815,7 +1322,7 @@ func TestCacheScenarios(t *testing.T) {
 		prefix := strings.ToLower(rsRand.String(5))
 		err = dbWithOneLimit.Setup(ReadWrite, false, prefix)
 		require.NoError(t, err)
-		require.Equal(t, 1, len(dbWithOneLimit.getDSList()), "expected cache to be auto-updated with DS list length 1")
+		require.Equal(t, 1, len(dbWithOneLimit.getDSListSnapshot()), "expected cache to be auto-updated with DS list length 1")
 		defer dbWithOneLimit.TearDown()
 
 		err = dbWithOneLimit.Store(context.Background(), generateJobs(2, ""))
@@ -829,9 +1336,7 @@ func TestCacheScenarios(t *testing.T) {
 		require.Eventually(
 			t,
 			func() bool {
-				dbWithOneLimit.dsListLock.RLock()
-				defer dbWithOneLimit.dsListLock.RUnlock()
-				return len(dbWithOneLimit.getDSList()) == 2
+				return len(dbWithOneLimit.getDSListSnapshot()) == 2
 			},
 			time.Second, time.Millisecond,
 			"expected cache to be auto-updated with DS list length 2")
@@ -1260,7 +1765,10 @@ func TestMaxAgeCleanup(t *testing.T) {
 	))
 
 	// run cleanup once with an empty db
-	require.NoError(t, jobsDB.doCleanup(context.Background()))
+	l, c, err := jobsDB.dsListLock.AsyncLockWithCtx(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, jobsDB.doCleanup(context.Background(), l))
+	c <- l
 
 	// store some jobs
 	require.NoError(
@@ -1362,7 +1870,7 @@ func TestGetActiveWorkspaces(t *testing.T) {
 	require.NoError(t, err)
 	defer jobsDB.TearDown()
 
-	require.Equal(t, 1, len(jobsDB.getDSList()))
+	require.Equal(t, 1, len(jobsDB.getDSListSnapshot()))
 	customVal := "MOCKDS"
 	generateJobs := func(workspaceID string, numOfJob int) []*JobT {
 		js := make([]*JobT, numOfJob)
@@ -1404,10 +1912,8 @@ func TestGetActiveWorkspaces(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool {
-			jobsDB.dsListLock.RLock()
-			defer jobsDB.dsListLock.RUnlock()
-			t.Logf("tables %d", len(jobsDB.getDSList()))
-			return len(jobsDB.getDSList()) == 2
+			t.Logf("tables %d", len(jobsDB.getDSListSnapshot()))
+			return len(jobsDB.getDSListSnapshot()) == 2
 		},
 		time.Second*5, time.Millisecond,
 		"expected number of tables to be 2")
@@ -1434,9 +1940,7 @@ func TestGetActiveWorkspaces(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool {
-			jobsDB.dsListLock.RLock()
-			defer jobsDB.dsListLock.RUnlock()
-			return len(jobsDB.getDSList()) == 3
+			return len(jobsDB.getDSListSnapshot()) == 3
 		},
 		time.Second*5, time.Millisecond,
 		"expected number of tables to be 3")
@@ -1486,7 +1990,7 @@ func TestGetDistinctParameterValues(t *testing.T) {
 	require.NoError(t, err)
 	defer jobsDB.TearDown()
 
-	require.Equal(t, 1, len(jobsDB.getDSList()))
+	require.Equal(t, 1, len(jobsDB.getDSListSnapshot()))
 
 	generateJobs := func(paramValue string, numOfJob int) []*JobT {
 		customVal := "MOCKDS"
@@ -1521,9 +2025,7 @@ func TestGetDistinctParameterValues(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool {
-			jobsDB.dsListLock.RLock()
-			defer jobsDB.dsListLock.RUnlock()
-			return len(jobsDB.getDSList()) == 2
+			return len(jobsDB.getDSListSnapshot()) == 2
 		},
 		time.Second*5, time.Millisecond,
 		"expected number of tables to be 2")
@@ -1542,9 +2044,7 @@ func TestGetDistinctParameterValues(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool {
-			jobsDB.dsListLock.RLock()
-			defer jobsDB.dsListLock.RUnlock()
-			return len(jobsDB.getDSList()) == 3
+			return len(jobsDB.getDSListSnapshot()) == 3
 		},
 		time.Second*5, time.Millisecond,
 		"expected number of tables to be 3")
@@ -1612,8 +2112,11 @@ func TestPayloadSizeColumnQueries(t *testing.T) {
 		tablePrefix,
 	))
 
+	l, c, err := jobsDB.dsListLock.AsyncLockWithCtx(context.Background())
+	require.NoError(t, err)
 	// run cleanup once with an empty db
-	require.NoError(t, jobsDB.doCleanup(context.Background()))
+	require.NoError(t, jobsDB.doCleanup(context.Background(), l))
+	c <- l
 
 	// store some jobs
 	require.NoError(
@@ -1770,7 +2273,7 @@ func TestUpdateJobStatus(t *testing.T) {
 	require.NoError(t, err)
 	defer jobsDB.TearDown()
 
-	require.Equal(t, 1, len(jobsDB.getDSList()))
+	require.Equal(t, 1, len(jobsDB.getDSListSnapshot()))
 
 	generateJobs := func(sourceID, destinationID string, numOfJob int) []*JobT {
 		customVal := "MOCKDS"
@@ -1800,9 +2303,7 @@ func TestUpdateJobStatus(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool {
-			jobsDB.dsListLock.RLock()
-			defer jobsDB.dsListLock.RUnlock()
-			return len(jobsDB.getDSList()) == 2
+			return len(jobsDB.getDSListSnapshot()) == 2
 		},
 		time.Second*5, time.Millisecond,
 		"expected number of tables to be 2")
@@ -1816,9 +2317,7 @@ func TestUpdateJobStatus(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool {
-			jobsDB.dsListLock.RLock()
-			defer jobsDB.dsListLock.RUnlock()
-			return len(jobsDB.getDSList()) == 3
+			return len(jobsDB.getDSListSnapshot()) == 3
 		},
 		time.Second*5, time.Millisecond,
 		"expected number of tables to be 3")
@@ -1832,9 +2331,7 @@ func TestUpdateJobStatus(t *testing.T) {
 	require.Eventually(
 		t,
 		func() bool {
-			jobsDB.dsListLock.RLock()
-			defer jobsDB.dsListLock.RUnlock()
-			return len(jobsDB.getDSList()) == 4
+			return len(jobsDB.getDSListSnapshot()) == 4
 		},
 		time.Second*5, time.Millisecond,
 		"expected number of tables to be 4")

--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -15,7 +15,10 @@ import (
 
 type sqlDbOrTx interface {
 	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
 }
+
+const preDropTableComment = "rudder:pre_drop:v1"
 
 /*
 Function to return an ordered list of datasets and datasetRanges
@@ -81,26 +84,67 @@ func sortDnumList(dnumList []string) {
 	})
 }
 
-// getAllTableNames gets all table names from Postgres
+// getAllTableNames gets all table names from Postgres, excluding tables marked as pre-drop.
 func getAllTableNames(dbHandle sqlDbOrTx) ([]string, error) {
-	var tableNames []string
-	rows, err := dbHandle.Query(`SELECT tablename
-									FROM pg_catalog.pg_tables
-									WHERE schemaname != 'pg_catalog' AND
-									schemaname != 'information_schema'`)
+	type tableInfo struct {
+		name        string
+		description sql.NullString
+	}
+	var tables []tableInfo
+	rows, err := dbHandle.Query(`SELECT c.relname, d.description
+									FROM pg_catalog.pg_class c
+									JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+									LEFT JOIN pg_catalog.pg_description d ON d.objoid = c.oid AND d.objsubid = 0
+									WHERE n.nspname != 'pg_catalog'
+										AND n.nspname != 'information_schema'
+										AND c.relkind = 'r'`)
 	if err != nil {
-		return tableNames, err
+		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
-		var tbName string
-		err = rows.Scan(&tbName)
-		if err != nil {
-			return tableNames, err
+		var table tableInfo
+		if err = rows.Scan(&table.name, &table.description); err != nil {
+			return nil, err
 		}
-		tableNames = append(tableNames, tbName)
+		tables = append(tables, table)
 	}
-	return tableNames, rows.Err()
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	preDropTables := make(map[string]struct{})
+	for _, table := range tables {
+		if !table.description.Valid || !strings.HasPrefix(table.description.String, "rudder:pre_drop:") {
+			continue
+		}
+		jobTable, statusTable, ok := preDropDatasetTables(table.name)
+		if !ok {
+			preDropTables[table.name] = struct{}{}
+			continue
+		}
+		preDropTables[jobTable] = struct{}{}
+		preDropTables[statusTable] = struct{}{}
+	}
+
+	tableNames := make([]string, 0, len(tables))
+	for _, table := range tables {
+		if _, ok := preDropTables[table.name]; ok {
+			continue
+		}
+		tableNames = append(tableNames, table.name)
+	}
+	return tableNames, nil
+}
+
+func preDropDatasetTables(tableName string) (jobTable, statusTable string, ok bool) {
+	if prefix, index, found := strings.Cut(tableName, "_job_status_"); found && prefix != "" && index != "" {
+		return prefix + "_jobs_" + index, tableName, true
+	}
+	if prefix, index, found := strings.Cut(tableName, "_jobs_"); found && prefix != "" && index != "" {
+		return tableName, prefix + "_job_status_" + index, true
+	}
+	return "", "", false
 }
 
 // checkValidJobState Function to check validity of states

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -66,20 +66,52 @@ func (jd *Handle) migrateDSLoop(ctx context.Context) {
 }
 
 func (jd *Handle) doMigrateDS(ctx context.Context) error {
-	if !jd.dsListLock.RTryLockWithCtx(ctx) {
-		return fmt.Errorf("could not acquire a dslist read lock: %w", ctx.Err())
+	dsList, _, release, err := jd.acquireDSListForRead(ctx)
+	if err != nil {
+		return fmt.Errorf("could not acquire a dslist read lock: %w", err)
 	}
-	dsList := jd.getDSList()
-	jd.dsListLock.RUnlock()
 
 	if err := jd.cleanupStatusTables(ctx, dsList); err != nil {
+		release()
 		return err
 	}
+	release()
 
 	optimisticCheck, err := jd.getMigrationList(dsList, jd.lastMigrateProbeIndex)
 	jd.lastMigrateProbeIndex = nil
 	if err != nil {
 		return fmt.Errorf("could not get migration list: %w", err)
+	}
+
+	// Fast path: route datasets that have no pending jobs through the async
+	// dropDSLoop instead of the in-TX postMigrateHandleDS path. This skips the
+	// dsMigrationLock for empty-source drops so concurrent readers are not blocked.
+	if jd.conf.migration.nonBlockingCompletedDSDrop.Load() {
+		completed := lo.FilterMap(
+			optimisticCheck.migrateFrom,
+			func(d dsWithPendingJobCount, _ int) (dataSetT, bool) {
+				return d.ds, d.numJobsPending == 0
+			},
+		)
+		if len(completed) > 0 {
+			if err := jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
+				// addToDropDSList republishes dsList without the completed datasets;
+				// reuse that snapshot so the second getMigrationList pass inside the
+				// TX does not re-encounter datasets we just queued for async drop.
+				newList, err := jd.addCompletedDSToDropList(ctx, l, completed...)
+				if err != nil {
+					return err
+				}
+				dsList = newList
+				return nil
+			}); err != nil {
+				return fmt.Errorf("enqueue completed datasets for async drop: %w", err)
+			}
+			optimisticCheck.migrateFrom = lo.Filter(
+				optimisticCheck.migrateFrom,
+				func(d dsWithPendingJobCount, _ int) bool { return d.numJobsPending > 0 },
+			)
+		}
 	}
 
 	if len(optimisticCheck.migrateFrom) == 0 {
@@ -269,14 +301,15 @@ func (jd *Handle) getVacuumFullCandidates(ctx context.Context, dsList []dataSetT
 	var rows *sql.Rows
 	rows, err := jd.getDB(ctx).QueryContext(
 		ctx,
-		`SELECT pg_table_size(oid) AS size, relname
-		FROM pg_class
-		where relname = ANY(
-			SELECT tablename
-				FROM pg_catalog.pg_tables
-				WHERE schemaname NOT IN ('pg_catalog','information_schema')
-				AND tablename like $1
-		) order by relname;`,
+		`SELECT pg_catalog.pg_table_size(c.oid) AS size, c.relname
+		FROM pg_catalog.pg_class c
+		JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+		LEFT JOIN pg_catalog.pg_description d ON d.objoid = c.oid AND d.objsubid = 0
+		WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+			AND c.relkind = 'r'
+			AND c.relname LIKE $1
+			AND (d.description IS NULL OR d.description NOT LIKE 'rudder:pre_drop:%')
+		ORDER BY c.relname;`,
 		jd.tablePrefix+"_job_status%",
 	)
 	if err != nil {
@@ -287,14 +320,16 @@ func (jd *Handle) getVacuumFullCandidates(ctx context.Context, dsList []dataSetT
 	tableSizes := map[string]int64{}
 	for rows.Next() {
 		var (
-			tableSize int64
+			tableSize sql.NullInt64
 			tableName string
 		)
 		err = rows.Scan(&tableSize, &tableName)
 		if err != nil {
 			return nil, err
 		}
-		tableSizes[tableName] = tableSize
+		if tableSize.Valid {
+			tableSizes[tableName] = tableSize.Int64
+		}
 	}
 	err = rows.Err()
 	if err != nil {
@@ -316,14 +351,14 @@ func (jd *Handle) getCleanUpCandidates(ctx context.Context, dsList []dataSetT) (
 	var rows *sql.Rows
 	rows, err := jd.getDB(ctx).QueryContext(
 		ctx,
-		`SELECT reltuples AS estimate, relname
-		FROM pg_class
-		where relname = ANY(
-			SELECT tablename
-				FROM pg_catalog.pg_tables
-				WHERE schemaname NOT IN ('pg_catalog','information_schema')
-				AND tablename like $1
-		)`,
+		`SELECT c.reltuples AS estimate, c.relname
+		FROM pg_catalog.pg_class c
+		JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+		LEFT JOIN pg_catalog.pg_description d ON d.objoid = c.oid AND d.objsubid = 0
+		WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+			AND c.relkind = 'r'
+			AND c.relname LIKE $1
+			AND (d.description IS NULL OR d.description NOT LIKE 'rudder:pre_drop:%')`,
 		jd.tablePrefix+"_job%",
 	)
 	if err != nil {
@@ -646,7 +681,7 @@ func (jd *Handle) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dat
 
 func (jd *Handle) computeNewIdxForIntraNodeMigration(l lock.LockToken, insertBeforeDS dataSetT) (string, error) { // Within the node
 	jd.logger.Debugn("computeNewIdxForIntraNodeMigration", logger.NewStringField("insertBeforeDS", insertBeforeDS.String()))
-	dList, err := jd.doRefreshDSList(l)
+	dList, err := jd.doRefreshDSList(l, jd.dbHandle)
 	if err != nil {
 		return "", fmt.Errorf("refreshDSList: %w", err)
 	}

--- a/jobsdb/migration_test.go
+++ b/jobsdb/migration_test.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
 
+	"github.com/rudderlabs/rudder-server/jobsdb/internal/lock"
 	"github.com/rudderlabs/rudder-server/utils/tx"
 )
 
@@ -134,7 +136,7 @@ func TestMigration(t *testing.T) {
 		// the third DS should have all jobs with only the last status per job
 
 		// check that the first DS has only non-terminal jobs
-		dsList := jobDB.getDSList()
+		dsList := jobDB.getDSListSnapshot()
 		require.Equal(t, `1_1`, dsList[0].Index)
 		var count int64
 		err = jobDB.dbHandle.QueryRow(
@@ -223,7 +225,7 @@ func TestMigration(t *testing.T) {
 			require.NoError(t, jobDB.Store(context.Background(), genJobs(defaultWorkspaceID, "test", 10, 1)))
 			triggerAddNewDS <- time.Now() // trigger addNewDSLoop to run
 			triggerAddNewDS <- time.Now() // waits for last loop to finish
-			require.Equal(t, i+2, len(jobDB.getDSList()))
+			require.Equal(t, i+2, len(jobDB.getDSListSnapshot()))
 		}
 
 		// 1st ds 5 statuses each
@@ -258,14 +260,15 @@ func TestMigration(t *testing.T) {
 			}
 			tableSizes := make(map[string]int64)
 			rows, err := jobDB.dbHandle.QueryContext(context.Background(),
-				`SELECT relname, pg_table_size(oid) AS size
-				FROM pg_class
-				where relname = ANY(
-					SELECT tablename
-						FROM pg_catalog.pg_tables
-						WHERE schemaname NOT IN ('pg_catalog','information_schema')
-						AND tablename like $1
-				) order by relname;`,
+				`SELECT c.relname, pg_catalog.pg_table_size(c.oid) AS size
+				FROM pg_catalog.pg_class c
+				JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+				LEFT JOIN pg_catalog.pg_description d ON d.objoid = c.oid AND d.objsubid = 0
+				WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+					AND c.relkind = 'r'
+					AND c.relname LIKE $1
+					AND (d.description IS NULL OR d.description NOT LIKE 'rudder:pre_drop:%')
+				ORDER BY c.relname;`,
 				tablePrefix+"_job_status%",
 			)
 			require.NoError(t, err)
@@ -282,7 +285,7 @@ func TestMigration(t *testing.T) {
 			return tableSizes
 		}
 		// capture table sizes
-		originalTableSizes := getTableSizes(jobDB.getDSList())
+		originalTableSizes := getTableSizes(jobDB.getDSListSnapshot())
 
 		c.Set("JobsDB.jobStatusMigrateThreshold", 1)
 		c.Set("JobsDB.vacuumAnalyzeStatusTableThreshold", 4)
@@ -291,9 +294,9 @@ func TestMigration(t *testing.T) {
 		))
 
 		// run cleanup status tables
-		require.NoError(t, jobDB.cleanupStatusTables(context.Background(), jobDB.getDSList()))
+		require.NoError(t, jobDB.cleanupStatusTables(context.Background(), jobDB.getDSListSnapshot()))
 
-		newTableSizes := getTableSizes(jobDB.getDSList())
+		newTableSizes := getTableSizes(jobDB.getDSListSnapshot())
 
 		// 1st DS should have 10 jobs with 1 status each
 		require.NoError(t, jobDB.dbHandle.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %[1]s_job_status_1`, tablePrefix)).Scan(&count))
@@ -313,7 +316,7 @@ func TestMigration(t *testing.T) {
 			require.NoError(t, jobDB.UpdateJobStatus(context.Background(), genJobStatuses(jobs, "failed")))
 		}
 
-		updatedTableSizes := getTableSizes(jobDB.getDSList())
+		updatedTableSizes := getTableSizes(jobDB.getDSListSnapshot())
 		require.Equal(t, newTableSizes[fmt.Sprintf("%s_job_status_1", tablePrefix)], updatedTableSizes[fmt.Sprintf("%s_job_status_1", tablePrefix)])
 	})
 
@@ -444,7 +447,7 @@ func TestMigration(t *testing.T) {
 		// the third DS should have all jobs with only the last status per job
 
 		// check that the first DS has only non-terminal jobs
-		dsList := jobDB.getDSList()
+		dsList := jobDB.getDSListSnapshot()
 		require.Len(t, dsList, 2) // 2_1, 3
 		require.Equal(t, `2_1`, dsList[0].Index)
 		var count int64
@@ -705,7 +708,7 @@ func TestMigrationMaxDSSizeGuard(t *testing.T) {
 		}
 		require.NoError(t, jd.Store(context.Background(), allJobs[40:]))
 
-		dsList := jd.getDSList()
+		dsList := jd.getDSListSnapshot()
 		c.Set("JobsDB."+jd.tablePrefix+"."+"maxMigrateDSProbe", len(dsList))
 
 		result, err := jd.getMigrationList(dsList, nil)
@@ -726,7 +729,7 @@ func TestMigrationMaxDSSizeGuard(t *testing.T) {
 		addDS(t, jd, trigger, allJobs[10:20], 6)
 		require.NoError(t, jd.Store(context.Background(), allJobs[20:]))
 
-		dsList := jd.getDSList()
+		dsList := jd.getDSListSnapshot()
 		c.Set("JobsDB."+jd.tablePrefix+"."+"maxMigrateDSProbe", len(dsList))
 
 		result, err := jd.getMigrationList(dsList, nil)
@@ -767,7 +770,7 @@ func TestMigrationSkipsDatasets(t *testing.T) {
 	// Store jobs in the last DS too
 	require.NoError(t, jobDB.Store(context.Background(), genJobs(defaultWorkspaceID, "test", 10, 1)))
 
-	dsList := jobDB.getDSList()
+	dsList := jobDB.getDSListSnapshot()
 	require.Len(t, dsList, totalDS)
 
 	// Make all jobs in the dataset at eligibleDSPos terminal (succeeded)
@@ -859,5 +862,218 @@ func TestMigrationSkipsDatasets(t *testing.T) {
 		require.Greater(t, fullDuration, resumeDuration,
 			"resumed scan should be faster than full scan from scratch",
 		)
+	})
+}
+
+func TestMigrationNonBlockingCompletedDSDrop(t *testing.T) {
+	_ = startPostgres(t)
+
+	// newJobDB creates a ReadWrite Handle with the migrate and addNewDS loop triggers
+	// wired to never-firing channels — the tests below drive state changes synchronously
+	// via createDSInTx so there is no background addNewDSLoop racing with Store/UpdateJobStatus.
+	newJobDB := func(t *testing.T) (*Handle, *config.Config) {
+		t.Helper()
+		c := config.New()
+		c.Set("JobsDB.maxDSSize", 100000)
+		jd := &Handle{
+			TriggerAddNewDS:  func() <-chan time.Time { return make(chan time.Time) },
+			TriggerMigrateDS: func() <-chan time.Time { return make(chan time.Time) },
+			config:           c,
+		}
+		require.NoError(t, jd.Setup(ReadWrite, true, strings.ToLower(rand.String(5))))
+		t.Cleanup(jd.TearDown)
+		return jd, c
+	}
+
+	// createDS synchronously appends a new DS at the given index using addNewDSInTx
+	// (which also advances the new DS's job_id sequence to continue from the previous
+	// DS's max, preserving the monotonic range invariant), then refreshes the in-memory list.
+	createDS := func(t *testing.T, jd *Handle, idx string) {
+		t.Helper()
+		require.NoError(t, jd.dsListLock.WithLockInCtx(context.Background(), func(l lock.LockToken) error {
+			dsList, _ := jd.dsList.snapshot()
+			if err := jd.WithTx(context.Background(), func(txn *tx.Tx) error {
+				return jd.addNewDSInTx(context.Background(), txn, l, dsList, newDataSet(jd.tablePrefix, idx))
+			}); err != nil {
+				return err
+			}
+			return jd.doRefreshDSRangeList(l)
+		}))
+	}
+
+	// fillDS stores jobs in the current last DS, marks (len(jobs)-pending) of them as succeeded.
+	fillDS := func(t *testing.T, jd *Handle, jobs []*JobT, pending int) {
+		t.Helper()
+		require.NoError(t, jd.Store(context.Background(), jobs))
+		if terminal := len(jobs) - pending; terminal > 0 {
+			require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[:terminal], "executing")))
+			require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[:terminal], "succeeded")))
+		}
+	}
+
+	tableExists := func(t *testing.T, jd *Handle, ds dataSetT) bool {
+		t.Helper()
+		var exists bool
+		require.NoError(t, jd.dbHandle.QueryRow(`SELECT to_regclass($1) IS NOT NULL`, ds.JobTable).Scan(&exists))
+		return exists
+	}
+
+	t.Run("flag off (default): completed DS dropped in legacy in-tx path", func(t *testing.T) {
+		jd, _ := newJobDB(t)
+		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
+		fillDS(t, jd, jobs, 0) // DS_1 → all 10 succeeded (completed)
+		createDS(t, jd, "2")   // DS_2 → empty last (exempt from migration)
+
+		snapshot := jd.getDSListSnapshot()
+		require.Len(t, snapshot, 2)
+		completedDS := snapshot[0]
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+
+		listIndices := lo.Map(jd.getDSListSnapshot(), func(ds dataSetT, _ int) string { return ds.Index })
+		require.NotContains(t, listIndices, completedDS.Index, "completed DS should be removed from the published list")
+		require.False(t, tableExists(t, jd, completedDS), "table must be dropped synchronously by the legacy in-tx path")
+		jd.dropDSListLock.RLock()
+		require.Empty(t, jd.dropDSList, "legacy path must not enqueue any async drop entries")
+		jd.dropDSListLock.RUnlock()
+	})
+
+	t.Run("flag on: completed DS routed to async drop list", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompletedDSDrop", true)
+
+		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
+		fillDS(t, jd, jobs, 0) // DS_1 completed
+		createDS(t, jd, "2")   // DS_2 empty last
+
+		snapshot := jd.getDSListSnapshot()
+		require.Len(t, snapshot, 2)
+		completedDS := snapshot[0]
+
+		// Hold a reader on the current dsList version so dropDSLoop blocks on
+		// waitUntilDrained — lets us observe the enqueued entry before it is physically dropped.
+		_, _, release, err := jd.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+
+		listIndices := lo.Map(jd.getDSListSnapshot(), func(ds dataSetT, _ int) string { return ds.Index })
+		require.NotContains(t, listIndices, completedDS.Index, "completed DS hidden from new readers")
+		jd.dropDSListLock.RLock()
+		require.Len(t, jd.dropDSList, 1, "completed DS must be enqueued for async drop")
+		require.Equal(t, completedDS.Index, jd.dropDSList[0].ds.Index)
+		jd.dropDSListLock.RUnlock()
+		require.Never(t,
+			func() bool { return !tableExists(t, jd, completedDS) },
+			200*time.Millisecond, 20*time.Millisecond,
+			"physical drop must block until the held reader releases",
+		)
+
+		release()
+
+		require.Eventually(t, func() bool {
+			jd.dropDSListLock.RLock()
+			pending := len(jd.dropDSList)
+			jd.dropDSListLock.RUnlock()
+			return !tableExists(t, jd, completedDS) && pending == 0
+		}, 5*time.Second, 50*time.Millisecond, "table must be physically dropped once the reader releases")
+	})
+
+	t.Run("flag on: DS with pending jobs still migrated through the legacy TX", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompletedDSDrop", true)
+		// maxDSRetention=1ms makes DSes with old terminal jobs eligible without the needsPair logic,
+		// so a DS with pending jobs can be migrated alone.
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
+
+		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
+		fillDS(t, jd, jobs, 5) // DS_1: 5 succeeded + 5 pending
+		createDS(t, jd, "2")   // DS_2 empty last
+
+		snapshot := jd.getDSListSnapshot()
+		require.Len(t, snapshot, 2)
+		pendingDS := snapshot[0]
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+
+		require.False(t, tableExists(t, jd, pendingDS), "source DS must be dropped via legacy migration TX")
+		jd.dropDSListLock.RLock()
+		require.Empty(t, jd.dropDSList, "non-completed migrate paths must not touch dropDSList")
+		jd.dropDSListLock.RUnlock()
+		listIndices := lo.Map(jd.getDSListSnapshot(), func(ds dataSetT, _ int) string { return ds.Index })
+		require.NotContains(t, listIndices, pendingDS.Index, "source DS must be removed from published list")
+		require.Contains(t, listIndices, "1_1", "expecting a freshly migrated destination DS at index 1_1")
+	})
+
+	t.Run("flag on: mixed - completed goes async, pending uses legacy TX", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompletedDSDrop", true)
+		// maxDSRetention=1ms lets both DSes appear together in migrateFrom in a single call.
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
+
+		allJobs := genJobs(defaultWorkspaceID, "test", 20, 1)
+		fillDS(t, jd, allJobs[:10], 0) // DS_1 completed
+		createDS(t, jd, "2")
+		fillDS(t, jd, allJobs[10:20], 5) // DS_2: 5 pending
+		createDS(t, jd, "3")             // DS_3 empty last
+
+		snapshot := jd.getDSListSnapshot()
+		require.Len(t, snapshot, 3)
+		completedDS := snapshot[0]
+		pendingDS := snapshot[1]
+
+		// Hold a reader so the async drop for the completed DS blocks; this lets us
+		// observe the dropDSList entry before dropDSLoop drains it.
+		_, _, release, err := jd.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+		defer release()
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+
+		jd.dropDSListLock.RLock()
+		require.Len(t, jd.dropDSList, 1, "only the completed DS should be enqueued for async drop")
+		require.Equal(t, completedDS.Index, jd.dropDSList[0].ds.Index)
+		jd.dropDSListLock.RUnlock()
+
+		require.True(t, tableExists(t, jd, completedDS), "completed DS physical drop is blocked by the held reader")
+		require.False(t, tableExists(t, jd, pendingDS), "pending DS source must be dropped via legacy migration TX")
+	})
+
+	t.Run("flag toggled at runtime: takes effect on the next migration", func(t *testing.T) {
+		jd, c := newJobDB(t)
+
+		allJobs := genJobs(defaultWorkspaceID, "test", 20, 1)
+		fillDS(t, jd, allJobs[:10], 0) // DS_1 completed
+		createDS(t, jd, "2")           // DS_2 empty last
+		completed1 := jd.getDSListSnapshot()[0]
+
+		// Flag off (default): legacy in-tx drop.
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+		require.False(t, tableExists(t, jd, completed1), "first migration must use the legacy in-tx drop")
+		jd.dropDSListLock.RLock()
+		require.Empty(t, jd.dropDSList)
+		jd.dropDSListLock.RUnlock()
+
+		// Flip the flag and prepare another completed DS to migrate.
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompletedDSDrop", true)
+		fillDS(t, jd, allJobs[10:20], 0) // DS_2 now has 10 succeeded jobs (completed)
+		createDS(t, jd, "3")             // DS_3 empty last
+		snapshot := jd.getDSListSnapshot()
+		require.Len(t, snapshot, 2)
+		completed2 := snapshot[0]
+		require.Equal(t, "2", completed2.Index)
+
+		// Hold a reader so we can observe the async enqueue before dropDSLoop drains it.
+		_, _, release, err := jd.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+		defer release()
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+
+		jd.dropDSListLock.RLock()
+		require.Len(t, jd.dropDSList, 1, "second migration must use the async drop path after the flag is on")
+		require.Equal(t, completed2.Index, jd.dropDSList[0].ds.Index)
+		jd.dropDSListLock.RUnlock()
+		require.True(t, tableExists(t, jd, completed2), "physical drop blocked by held reader")
 	})
 }

--- a/jobsdb/versioned_ds_list.go
+++ b/jobsdb/versioned_ds_list.go
@@ -1,0 +1,123 @@
+package jobsdb
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var errInvalidDSListDrainVersion = errors.New("drain version must be older than current version")
+
+func newVersionedDSList(list dataSetTList, rangeList dataSetRangeTList) *versionedDSList {
+	return &versionedDSList{
+		list:      list,
+		rangeList: rangeList,
+		readers:   make(map[uint64]int),
+	}
+}
+
+type versionedDSList struct {
+	mu sync.Mutex
+
+	// version is the version assigned to readers reading the currently published snapshots.
+	version uint64
+
+	// list and rangeList are the currently published immutable snapshots.
+	// They are owned by versionedDSList so read and update cannot drift apart.
+	list      dataSetTList
+	rangeList dataSetRangeTList
+
+	// readers counts readers per version. A missing key means no reader is using that version.
+	readers map[uint64]int
+
+	// waiters are operations waiting for all readers at or before a version to drain.
+	waiters []dsListDrainWaiter
+}
+
+type dsListDrainWaiter struct {
+	through uint64        // through is inclusive: a drop for version N must wait for readers in versions 0..N.
+	drained chan struct{} // closed when there are no more readers at or before through
+}
+
+// get returns the currently published snapshots and a release function that must be called when the reader is done with the snapshots.
+func (v *versionedDSList) get() (list dataSetTList, ranges dataSetRangeTList, version uint64, release func()) {
+	v.mu.Lock()
+	version = v.version
+	v.readers[version]++
+	list = v.list
+	ranges = v.rangeList
+	v.mu.Unlock()
+
+	var once sync.Once
+	return list, ranges, version, func() {
+		once.Do(func() {
+			v.mu.Lock()
+			defer v.mu.Unlock()
+
+			if v.readers[version] <= 1 {
+				delete(v.readers, version)
+			} else {
+				v.readers[version]--
+			}
+			v.closeDrainedLocked()
+		})
+	}
+}
+
+func (v *versionedDSList) snapshot() (dataSetTList, dataSetRangeTList) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.list, v.rangeList
+}
+
+func (v *versionedDSList) currentVersion() uint64 {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.version
+}
+
+func (v *versionedDSList) set(list dataSetTList, ranges dataSetRangeTList) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	v.list = list
+	v.rangeList = ranges
+	v.version++
+	v.closeDrainedLocked()
+}
+
+// wait returns a channel that will be closed when there are no more readers at or before through. through must be less than the current version.
+func (v *versionedDSList) wait(through uint64) (<-chan struct{}, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if through >= v.version {
+		return nil, fmt.Errorf("%w: through=%d current=%d", errInvalidDSListDrainVersion, through, v.version)
+	}
+
+	drained := make(chan struct{})
+	v.waiters = append(v.waiters, dsListDrainWaiter{through: through, drained: drained})
+	v.closeDrainedLocked()
+	return drained, nil
+}
+
+// closeDrainedLocked closes the drained channels of all waiters that are waiting for versions that have no more readers. It must be called with v.mu held.
+func (v *versionedDSList) closeDrainedLocked() {
+	hasReaders := func(through uint64) bool {
+		for version, count := range v.readers {
+			if version <= through && count > 0 {
+				return true
+			}
+		}
+		return false
+	}
+	kept := v.waiters[:0]
+	for _, w := range v.waiters {
+		if hasReaders(w.through) {
+			kept = append(kept, w)
+			continue
+		}
+		close(w.drained)
+	}
+	v.waiters = kept
+}

--- a/jobsdb/versioned_ds_list_test.go
+++ b/jobsdb/versioned_ds_list_test.go
@@ -1,0 +1,149 @@
+package jobsdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionedDSList(t *testing.T) {
+	t.Run("read pins snapshot until release", func(t *testing.T) {
+		initialList := dataSetTList{testVersionedDS("1")}
+		initialRanges := dataSetRangeTList{testVersionedRange("1", 1, 10)}
+		nextList := dataSetTList{testVersionedDS("2")}
+		nextRanges := dataSetRangeTList{testVersionedRange("2", 11, 20)}
+
+		v := newVersionedDSList(initialList, initialRanges)
+
+		list, ranges, version, release := v.get()
+		require.Equal(t, uint64(0), version)
+		require.Equal(t, initialList, list)
+		require.Equal(t, initialRanges, ranges)
+
+		v.set(nextList, nextRanges)
+
+		drained, err := v.wait(version)
+		require.NoError(t, err)
+		requireNotClosed(t, drained)
+
+		nextReadList, nextReadRanges, nextVersion, nextRelease := v.get()
+		require.Equal(t, uint64(1), nextVersion)
+		require.Equal(t, nextList, nextReadList)
+		require.Equal(t, nextRanges, nextReadRanges)
+		nextRelease()
+
+		require.Equal(t, initialList, list)
+		require.Equal(t, initialRanges, ranges)
+		requireNotClosed(t, drained)
+
+		release()
+		requireClosed(t, drained)
+	})
+
+	t.Run("wait until drained includes older versions", func(t *testing.T) {
+		v := newVersionedDSList(dataSetTList{testVersionedDS("1")}, nil)
+
+		_, _, oldVersion, releaseOld := v.get()
+		require.Equal(t, uint64(0), oldVersion)
+
+		v.set(dataSetTList{testVersionedDS("2")}, nil)
+
+		_, _, removalVersion, releaseRemoval := v.get()
+		require.Equal(t, uint64(1), removalVersion)
+
+		v.set(dataSetTList{testVersionedDS("3")}, nil)
+
+		drained, err := v.wait(removalVersion)
+		require.NoError(t, err)
+		requireNotClosed(t, drained)
+
+		releaseRemoval()
+		requireNotClosed(t, drained)
+
+		releaseOld()
+		requireClosed(t, drained)
+	})
+
+	t.Run("wait until drained ignores newer versions", func(t *testing.T) {
+		v := newVersionedDSList(dataSetTList{testVersionedDS("1")}, nil)
+		v.set(dataSetTList{testVersionedDS("2")}, nil)
+
+		_, _, version, release := v.get()
+		require.Equal(t, uint64(1), version)
+		defer release()
+
+		drained, err := v.wait(0)
+		require.NoError(t, err)
+		requireClosed(t, drained)
+	})
+
+	t.Run("release is idempotent", func(t *testing.T) {
+		v := newVersionedDSList(dataSetTList{testVersionedDS("1")}, nil)
+
+		_, _, version, release := v.get()
+		v.set(dataSetTList{testVersionedDS("2")}, nil)
+
+		drained, err := v.wait(version)
+		require.NoError(t, err)
+		requireNotClosed(t, drained)
+
+		release()
+		release()
+
+		requireClosed(t, drained)
+	})
+
+	t.Run("wait until drained rejects current and future version", func(t *testing.T) {
+		v := newVersionedDSList(dataSetTList{testVersionedDS("1")}, nil)
+
+		drained, err := v.wait(0)
+		require.ErrorIs(t, err, errInvalidDSListDrainVersion)
+		require.Nil(t, drained)
+
+		drained, err = v.wait(1)
+		require.ErrorIs(t, err, errInvalidDSListDrainVersion)
+		require.Nil(t, drained)
+
+		v.set(dataSetTList{testVersionedDS("2")}, nil)
+
+		drained, err = v.wait(v.currentVersion())
+		require.ErrorIs(t, err, errInvalidDSListDrainVersion)
+		require.Nil(t, drained)
+	})
+}
+
+func testVersionedDS(index string) dataSetT {
+	return dataSetT{
+		JobTable:       "jobs_" + index,
+		JobStatusTable: "job_status_" + index,
+		Index:          index,
+	}
+}
+
+func testVersionedRange(index string, minID, maxID int64) dataSetRangeT {
+	return dataSetRangeT{
+		minJobID: minID,
+		maxJobID: maxID,
+		ds:       testVersionedDS(index),
+	}
+}
+
+func requireClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	default:
+		require.Fail(t, "expected channel to be closed")
+	}
+}
+
+func requireNotClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+		require.Fail(t, "expected channel to remain open")
+	default:
+	}
+}

--- a/processor/processor_isolation_test.go
+++ b/processor/processor_isolation_test.go
@@ -254,6 +254,7 @@ func ProcIsolationScenario(t testing.TB, spec *ProcIsolationScenarioSpec) (overa
 	config.Set("Processor.isolationMode", string(spec.isolationMode))
 
 	config.Set("JobsDB.enableWriterQueue", false)
+	config.Set("JobsDB.nonBlockingCompletedDSDrop", "true")
 
 	// find free port for gateway http server to listen on
 	httpPortInt, err := kithelper.GetFreePort()

--- a/router/batchrouter/batchrouter_isolation_test.go
+++ b/router/batchrouter/batchrouter_isolation_test.go
@@ -265,6 +265,7 @@ func BatchrouterIsolationScenario(t testing.TB, spec *BrtIsolationScenarioSpec) 
 	config.Set("BatchRouter.Limiter.statsPeriod", "1s")
 
 	config.Set("JobsDB.enableWriterQueue", false)
+	config.Set("JobsDB.nonBlockingCompletedDSDrop", "true")
 	config.Set("RUDDER_TMPDIR", os.TempDir())
 
 	t.Logf("Seeding batch_rt jobsdb with jobs")

--- a/router/router_isolation_test.go
+++ b/router/router_isolation_test.go
@@ -223,6 +223,7 @@ func RouterIsolationScenario(t testing.TB, spec *RtIsolationScenarioSpec) (overa
 	config.Set("TransformationDebugger.disableTransformationStatusUploads", true)
 	config.Set("JobsDB.backup.enabled", false)
 	config.Set("JobsDB.migrateDSLoopSleepDuration", "60m")
+	config.Set("JobsDB.nonBlockingCompletedDSDrop", "true")
 
 	config.Set("Router.isolationMode", string(spec.isolationMode))
 	config.Set("Router.Limiter.statsPeriod", "1s")

--- a/sql/migrations/node/000019_jobsdb_functions_pre_drop_filter.up.sql
+++ b/sql/migrations/node/000019_jobsdb_functions_pre_drop_filter.up.sql
@@ -1,0 +1,140 @@
+-- unionjobsdb function automatically joins datasets and returns jobs
+-- along with their latest jobs status (or null)
+--
+-- Parameters
+-- prefix: table prefix, e.g. gw, rt, batch_rt
+-- num: number of datasets to include in the query, e.g. 4
+CREATE OR REPLACE FUNCTION unionjobsdb(prefix text, num int)
+RETURNS table (
+  t_name text,
+  job_id bigint,
+  workspace_id text,
+  uuid uuid,
+  user_id text,
+  partition_id text,
+  parameters jsonb,
+  custom_val character varying(64),
+  event_payload text,
+  event_count integer,
+  created_at timestamp with time zone,
+  expire_at timestamp with time zone,
+  status_id bigint,
+  job_state character varying(64),
+  attempt smallint,
+  exec_time timestamp with time zone,
+  error_code character varying(32),
+  error_response jsonb
+)
+AS $$
+DECLARE
+  qry text;
+BEGIN
+SELECT string_agg(
+    format('SELECT %1$L, j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.parameters, j.custom_val, j.event_payload, j.event_count, j.created_at, j.expire_at, latest_status.id, latest_status.job_state, latest_status.attempt, latest_status.exec_time, latest_status.error_code, latest_status.error_response FROM %1$I j LEFT JOIN %2$I latest_status on latest_status.job_id = j.job_id', alltables.table_name, 'v_last_' || prefix || '_job_status_'|| substring(alltables.table_name, char_length(prefix)+7,30)),
+    ' UNION ') INTO qry
+  FROM (
+    select c.relname as table_name
+    from pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+    left join pg_catalog.pg_description d on d.objoid = c.oid and d.objsubid = 0
+    WHERE c.relkind = 'r'
+      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+      AND c.relname LIKE prefix || '_jobs_%'
+      AND COALESCE(d.description, '') NOT LIKE 'rudder:pre_drop:%'
+    order by c.relname asc LIMIT num
+  ) alltables;
+RETURN QUERY EXECUTE qry;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- unionjobsdbmetadata function automatically joins datasets and returns jobs
+-- along with their latest jobs status (or null) excluding the payload
+--
+-- Parameters
+-- prefix: table prefix, e.g. gw, rt, batch_rt
+-- num: number of datasets to include in the query, e.g. 4
+CREATE OR REPLACE FUNCTION unionjobsdbmetadata(prefix text, num int)
+RETURNS table (
+  t_name text,
+  job_id bigint,
+  workspace_id text,
+  uuid uuid,
+  user_id text,
+  partition_id text,
+  parameters jsonb,
+  custom_val character varying(64),
+  event_count integer,
+  created_at timestamp with time zone,
+  expire_at timestamp with time zone,
+  status_id bigint,
+  job_state character varying(64),
+  attempt smallint,
+  exec_time timestamp with time zone,
+  error_code character varying(32),
+  error_response jsonb
+)
+AS $$
+DECLARE
+  qry text;
+BEGIN
+SELECT string_agg(
+    format('SELECT %1$L, j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.parameters, j.custom_val, j.event_count, j.created_at, j.expire_at, latest_status.id, latest_status.job_state, latest_status.attempt, latest_status.exec_time, latest_status.error_code, latest_status.error_response FROM %1$I j LEFT JOIN %2$I latest_status on latest_status.job_id = j.job_id', alltables.table_name, 'v_last_' || prefix || '_job_status_'|| substring(alltables.table_name, char_length(prefix)+7,30)),
+    ' UNION ') INTO qry
+  FROM (
+    select c.relname as table_name
+    from pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+    left join pg_catalog.pg_description d on d.objoid = c.oid and d.objsubid = 0
+    WHERE c.relkind = 'r'
+      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+      AND c.relname LIKE prefix || '_jobs_%'
+      AND COALESCE(d.description, '') NOT LIKE 'rudder:pre_drop:%'
+    order by c.relname asc LIMIT num
+  ) alltables;
+RETURN QUERY EXECUTE qry;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- joborderlog function automatically joins datasets and returns all router job statuses
+-- for a given destination_id and user_id
+--
+-- Parameters
+-- destinationid: the destination id
+-- userid: the user id
+-- num: maximum number of datasets to include in the query, e.g. 4
+CREATE OR REPLACE FUNCTION joborderlog(destinationid text, userid text, num int)
+RETURNS table (
+  t_name text,
+  job_id bigint,
+  created_at timestamp with time zone,
+  status_id bigint,
+  job_state character varying(64),
+  attempt smallint,
+  exec_time timestamp with time zone,
+  error_code character varying(32),
+  parameters jsonb,
+  error_response jsonb
+)
+AS $$
+DECLARE
+  qry text;
+BEGIN
+SELECT 'SELECT q.* FROM (' || string_agg(
+    format('SELECT %1$L, j.job_id, j.created_at, js.id, js.job_state, js.attempt, js.exec_time, js.error_code, js.parameters, js.error_response FROM %1$I j LEFT JOIN %2$I js on js.job_id = j.job_id WHERE j.parameters->>''destination_id'' = %3$L AND j.user_id = %4$L', alltables.table_name, 'rt_job_status_'|| substring(alltables.table_name, 9,30), destinationid, userid),
+    ' UNION ') || ') q ORDER BY q.exec_time, q.id' INTO qry
+  FROM (
+    select c.relname as table_name
+    from pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+    left join pg_catalog.pg_description d on d.objoid = c.oid and d.objsubid = 0
+    WHERE c.relkind = 'r'
+      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+      AND c.relname LIKE 'rt_jobs_%'
+      AND COALESCE(d.description, '') NOT LIKE 'rudder:pre_drop:%'
+    order by c.relname asc LIMIT num
+  ) alltables;
+RETURN QUERY EXECUTE qry;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

# Description

Introducing support for dropping completed dataset tables in a non-blocking fashion without a migration lock:

### 1. Versioned dataset list with reader-drain semantics

A new `versionedDSList` replaces the bare `datasetList` / `datasetRangeList` fields on `Handle`. Each update bumps a version; readers acquire a snapshot tagged with that version and release it when done reading. An additional `wait(through)` API returns a channel that closes once no reader is still using a version `<= through`, so a dropper can block until in-flight queries that still see the old list have finished.

### 2. `nonBlockingCompletedDSDrop` fast path and async drop loop

- A new `dropDSLoop` consumes a `dropDSList` queue. Each entry records the dslist version that must drain before the table can be dropped.
- `addToDropDSList` republishes the dslist without the queued datasets, writes the persistent pre-drop marker (see §3), and pings the loop. The actual `DROP TABLE` happens off the hot path.
- `doMigrateDS` gains a fast path gated by **`jobsdb.<prefix>.nonBlockingCompletedDSDrop`** (default `false`): datasets with zero pending jobs are routed through the async drop loop instead of the in-lock `postMigrateHandleDS` path. When disabled, behavior is unchanged.

### 3. Persistent `pre_drop:v1` table marker

`COMMENT ON TABLE … IS 'rudder:pre_drop:v1'` is written as part of queuing a dataset for drop. This makes the queue crash-safe — the source of truth lives in Postgres, not just in-memory `dropDSList`.

- `getAllTableNames` now joins `pg_class`/`pg_namespace`/`pg_description` and filters out marked tables, masking half-pairs (drops both the jobs and status table when either is marked).
- New SQL migration `000019_jobsdb_functions_pre_drop_filter.up.sql` rewrites `unionjobsdb`, `unionjobsdbmetadata`, and `joborderlog` to apply the same `pg_description` filter, so server-side discovery skips marked tables too.
- `cleanupPreDropTables` runs once at startup of `read` or `readwrite` jobsdbs and after journal recovery, dropping any tables left marked by a previous crashed run.

If there isn't any marker present, behavior remains identical as before.

### 4. `RS001` tolerance on the `UpdateJobStatus` path

The readonly-trigger error code `RS001` was previously only handled on the `Store` path. The `Update` path now wraps each `internalUpdateJobStatusInTx` call in a savepoint: on `ErrStaleDsList` it rolls back to the savepoint, refreshes the dslist under the write lock, updates the `UpdateSafeTx`'s embedded dslist/rangeList snapshot, and retries the whole command. We do **not** replay the caller-owned outer transaction.

To support this, `UpdateSafeTx` now carries its own `dsList`/`dsRangeList` (with a `setDSList` setter) so retries reroute against the refreshed snapshot without re-running `inUpdateSafeCtx`.

This change is harmless until a follow-up PR starts marking status tables readonly during compaction.

## Linear Ticket

resolves PIPE-2996

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #6979 
- <kbd>&nbsp;3&nbsp;</kbd> #6967 
- <kbd>&nbsp;2&nbsp;</kbd> #6962 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6963 
<!-- GitButler Footer Boundary Bottom -->

