### PR TITLE
fix: clickhouse quarter partition type

### DIFF
--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -888,6 +888,8 @@ func (ch *Clickhouse) partitionExpr() (string, error) {
 		return fmt.Sprintf(`toStartOfWeek(%s)`, partitionField), nil
 	case "month":
 		return fmt.Sprintf(`toStartOfMonth(%s)`, partitionField), nil
+	case "quarter":
+		return fmt.Sprintf(`toStartOfQuarter(%s)`, partitionField), nil
 	default:
 		ch.logger.Warnn("CH: Invalid partition type for clickhouse destination",
 			logger.NewStringField("partitionType", partitionType),

--- a/warehouse/integrations/clickhouse/clickhouse_test.go
+++ b/warehouse/integrations/clickhouse/clickhouse_test.go
@@ -137,6 +137,21 @@ func TestIntegration(t *testing.T) {
 					require.Equal(t, "toStartOfMonth(received_at)", rows[0][0])
 				},
 			},
+			{
+				name: "Partition Type: quarter",
+				configOverride: map[string]any{
+					"partitionType": "quarter",
+				},
+				verifyPartition: func(t *testing.T, db *sql.DB) {
+					t.Helper()
+					rows := whth.RetrieveRecordsFromWarehouse(t, db, fmt.Sprintf(
+						`SELECT partition_key FROM system.tables WHERE database = '%s' AND name = 'identifies';`, database,
+					))
+					require.Len(t, rows, 1)
+					require.Len(t, rows[0], 1)
+					require.Equal(t, "toStartOfQuarter(received_at)", rows[0][0])
+				},
+			},
 		}
 
 		for _, tc := range testCases {

--- a/warehouse/integrations/clickhouse/partition_test.go
+++ b/warehouse/integrations/clickhouse/partition_test.go
@@ -41,6 +41,11 @@ func TestPartitionExpr(t *testing.T) {
 			expectedPartitionExpr: "toStartOfMonth(received_at)",
 		},
 		{
+			name:                  "explicit quarter",
+			partitionType:         "quarter",
+			expectedPartitionExpr: "toStartOfQuarter(received_at)",
+		},
+		{
 			name:                  "invalid value",
 			partitionType:         "invalid",
 			expectedPartitionExpr: "",


### PR DESCRIPTION
# Description

Add support for quarterly partitioning in ClickHouse destinations using \`toStartOfQuarter(received_at)\` as the partition expression.

## Changes

- \`clickhouse.go\`: Added \`case \"quarter\"\` to \`partitionExpr()\` returning \`toStartOfQuarter(received_at)\`
- \`partition_test.go\`: Added unit test case for \`\"quarter\"\` partition type
- \`clickhouse_test.go\`: Added integration test case verifying \`toStartOfQuarter(received_at)\` partition key in \`system.tables\`

## Linear Ticket

- Resolves INT-6377

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
