### PR TITLE
fix: snowpipe streaming bulk status offset

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -242,6 +242,26 @@ func (m *Manager) Upload(_ context.Context, asyncDest *common.AsyncDestinationSt
 		abortedJobIDs []int64
 		abortReason   string
 	)
+
+	// Get channel IDs from cache to avoid duplicate requests.
+	channelCacheIDs := lo.FilterMap(uploadInfos, func(info *uploadInfo, _ int) (string, bool) {
+		response, ok := m.channelCache.Load(info.tableName)
+		if !ok {
+			return "", false
+		}
+		return response.(*model.ChannelResponse).ChannelID, true
+	})
+
+	// Pre-fetch channel statuses for all channels to avoid duplicate requests.
+	var channelStatuses map[string]*model.StatusResponse
+	if m.config.bulkStatusEnabled.Load() {
+		channelStatuses, _, err = m.getBulkStatus(ctx, channelCacheIDs)
+		if err != nil {
+			m.logger.Warnn("Failed to get bulk status", obskit.Error(err))
+			return m.abortJobs(asyncDest, fmt.Errorf("failed to get bulk status: %w", err).Error())
+		}
+	}
+
 	for _, info := range uploadInfos {
 		fields := []logger.Field{
 			logger.NewStringField("table", info.tableName),
@@ -250,7 +270,7 @@ func (m *Manager) Upload(_ context.Context, asyncDest *common.AsyncDestinationSt
 		fields = append(fields, jobIDRangeFields(info.jobIDs)...)
 		log := m.logger.Withn(fields...)
 
-		imInfo, discardImInfo, err := m.sendEventsToSnowpipe(ctx, asyncDest.Destination.ID, &destConf, info)
+		imInfo, discardImInfo, err := m.sendEventsToSnowpipe(ctx, asyncDest.Destination.ID, &destConf, info, channelStatuses)
 		if err != nil {
 			log.Warnn("Failed to send events to Snowpipe", obskit.Error(err))
 
@@ -401,6 +421,7 @@ func (m *Manager) sendEventsToSnowpipe(
 	destinationID string,
 	destConf *destConfig,
 	info *uploadInfo,
+	channelStatuses map[string]*model.StatusResponse,
 ) (*importInfo, *importInfo, error) {
 	offset := strconv.FormatInt(info.latestJobID, 10)
 
@@ -442,7 +463,7 @@ func (m *Manager) sendEventsToSnowpipe(
 	var duplicateIDsInBatch, duplicateCountDueToOffset int
 	if info.tableName != whutils.ToProviderCase(whutils.SnowpipeStreaming, whutils.UsersTable) {
 		duplicateIDsInBatch = checkForDuplicateIDsInBatch(info.events)
-		duplicateCountDueToOffset = m.checkForDuplicatesDueToOffset(ctx, channelResponse.ChannelID, info.events)
+		duplicateCountDueToOffset = m.checkForDuplicatesDueToOffset(ctx, channelResponse.ChannelID, info.events, channelStatuses)
 	}
 
 	insertReq := &model.InsertRequest{
@@ -498,8 +519,39 @@ func checkForDuplicateIDsInBatch(events []*event) (duplicateCount int) {
 }
 
 // checkForDuplicatesDueToOffset checks for duplicate ids due to offset.
-func (m *Manager) checkForDuplicatesDueToOffset(ctx context.Context, channelID string, events []*event) (duplicateCount int) {
-	statusRes, err := m.api.GetStatus(ctx, channelID)
+func (m *Manager) checkForDuplicatesDueToOffset(
+	ctx context.Context,
+	channelID string,
+	events []*event,
+	channelStatuses map[string]*model.StatusResponse,
+) (duplicateCount int) {
+	var statusRes *model.StatusResponse
+	var err error
+
+	if m.config.bulkStatusEnabled.Load() {
+		var ok bool
+		statusRes, ok = channelStatuses[channelID]
+		if !ok {
+			// If channel status is not found in the cache, we need to get it from the Snowpipe.
+			bulkStatusRes, notFound, err := m.getBulkStatus(ctx, []string{channelID})
+			if err != nil {
+				m.logger.Warnn("Failed to get bulk status for channel", logger.NewStringField("channelID", channelID), obskit.Error(err))
+				return duplicateCount
+			}
+			if len(notFound) > 0 {
+				m.logger.Warnn("Channel not found in bulk status response for channel", logger.NewStringField("channelID", channelID), logger.NewStringField("notFound", strings.Join(notFound, ", ")))
+				return duplicateCount
+			}
+			statusRes, ok = bulkStatusRes[channelID]
+			if !ok {
+				m.logger.Warnn("Channel status not found in bulk status response for channel", logger.NewStringField("channelID", channelID))
+				return duplicateCount
+			}
+		}
+	} else {
+		statusRes, err = m.api.GetStatus(ctx, channelID)
+	}
+
 	if err != nil {
 		m.logger.Warnn("Failed to get status", obskit.Error(err))
 		return duplicateCount

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -243,22 +243,22 @@ func (m *Manager) Upload(_ context.Context, asyncDest *common.AsyncDestinationSt
 		abortReason   string
 	)
 
-	// Get channel IDs from cache to avoid duplicate requests.
-	channelCacheIDs := lo.FilterMap(uploadInfos, func(info *uploadInfo, _ int) (string, bool) {
-		response, ok := m.channelCache.Load(info.tableName)
-		if !ok {
-			return "", false
-		}
-		return response.(*model.ChannelResponse).ChannelID, true
-	})
-
 	// Pre-fetch channel statuses for all channels to avoid duplicate requests.
 	var channelStatuses map[string]*model.StatusResponse
 	if m.config.bulkStatusEnabled.Load() {
+		// Get channel IDs from cache to avoid duplicate requests.
+		channelCacheIDs := lo.FilterMap(uploadInfos, func(info *uploadInfo, _ int) (string, bool) {
+			response, ok := m.channelCache.Load(info.tableName)
+			if !ok {
+				return "", false
+			}
+			return response.(*model.ChannelResponse).ChannelID, true
+		})
+
 		channelStatuses, _, err = m.getBulkStatus(ctx, channelCacheIDs)
 		if err != nil {
 			m.logger.Warnn("Failed to get bulk status", obskit.Error(err))
-			return m.abortJobs(asyncDest, fmt.Errorf("failed to get bulk status: %w", err).Error())
+			return m.failedJobs(asyncDest, fmt.Errorf("failed to get bulk status: %w", err).Error())
 		}
 	}
 
@@ -530,23 +530,11 @@ func (m *Manager) checkForDuplicatesDueToOffset(
 
 	if m.config.bulkStatusEnabled.Load() {
 		var ok bool
+
 		statusRes, ok = channelStatuses[channelID]
 		if !ok {
 			// If channel status is not found in the cache, we need to get it from the Snowpipe.
-			bulkStatusRes, notFound, err := m.getBulkStatus(ctx, []string{channelID})
-			if err != nil {
-				m.logger.Warnn("Failed to get bulk status for channel", logger.NewStringField("channelID", channelID), obskit.Error(err))
-				return duplicateCount
-			}
-			if len(notFound) > 0 {
-				m.logger.Warnn("Channel not found in bulk status response for channel", logger.NewStringField("channelID", channelID), logger.NewStringField("notFound", strings.Join(notFound, ", ")))
-				return duplicateCount
-			}
-			statusRes, ok = bulkStatusRes[channelID]
-			if !ok {
-				m.logger.Warnn("Channel status not found in bulk status response for channel", logger.NewStringField("channelID", channelID))
-				return duplicateCount
-			}
+			statusRes, err = m.getBulkStatusForChannel(ctx, channelID)
 		}
 	} else {
 		statusRes, err = m.api.GetStatus(ctx, channelID)
@@ -945,6 +933,21 @@ func isInProgress(statusRes *model.StatusResponse, info *importInfo, log logger.
 	log.Warnn("Unexpected polling state encountered")
 	return false, fmt.Errorf("unexpected polling state encountered, latestCommittedOffset=%d, latestInsertedOffset=%d, expectedOffset=%d",
 		latestCommittedOffset, latestInsertedOffset, expectedOffset)
+}
+
+func (m *Manager) getBulkStatusForChannel(ctx context.Context, channelID string) (*model.StatusResponse, error) {
+	statuses, notFound, err := m.getBulkStatus(ctx, []string{channelID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get bulk status for channel: %w", err)
+	}
+	if len(notFound) > 0 {
+		return nil, fmt.Errorf("channel not found in bulk status response for channel: %s", channelID)
+	}
+	statusRes, ok := statuses[channelID]
+	if !ok {
+		return nil, fmt.Errorf("channel status not found in bulk status response for channel: %s", channelID)
+	}
+	return statusRes, nil
 }
 
 func (m *Manager) getBulkStatus(ctx context.Context, channelIDs []string) (map[string]*model.StatusResponse, []string, error) {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -1198,6 +1198,171 @@ func TestSnowpipeStreaming(t *testing.T) {
 		}).LastValue())
 	})
 
+	t.Run("Upload with duplicate ids due to offset with bulk status enabled", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		conf := config.New()
+		conf.Set("SnowpipeStreaming.bulkStatusEnabled", true)
+
+		sm := New(conf, logger.NOP, statsStore, destination)
+		sm.channelCache.Store("RUDDER_DISCARDS", rudderDiscardsChannelResponse)
+		sm.channelCache.Store("USERS", usersChannelResponse)
+		sm.channelCache.Store("PRODUCTS", productsChannelResponse)
+
+		sm.api = &mockAPI{
+			insertOutputMap: map[string]func() (*model.InsertResponse, error){
+				"test-users-channel": func() (*model.InsertResponse, error) {
+					return &model.InsertResponse{Success: true}, nil
+				},
+				"test-products-channel": func() (*model.InsertResponse, error) {
+					return &model.InsertResponse{Success: true}, nil
+				},
+				"test-rudder-discards-channel": func() (*model.InsertResponse, error) {
+					return &model.InsertResponse{Success: true}, nil
+				},
+			},
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: true, Success: true, Offset: "1002"},
+						},
+					}, nil
+				},
+			},
+		}
+		output := sm.Upload(context.Background(), &common.AsyncDestinationStruct{
+			Destination: destination,
+			FileName:    "testdata/successful_sort_records.txt",
+		})
+		require.Equal(t, []int64{1002, 1003, 1001, 1004}, output.ImportingJobIDs)
+		require.Equal(t, 4, output.ImportingCount)
+		require.JSONEq(t, `{"importId":[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":false,"reason":"","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":false,"reason":"","count":2}],"importCount":4}`, string(output.ImportingParameters))
+		require.Nil(t, output.FailedJobIDs)
+		require.Zero(t, output.FailedCount)
+		require.Equal(t, "test-destination", output.DestinationID)
+		require.EqualValues(t, 4, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"status":        "importing",
+		}).LastValue())
+		require.Zero(t, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"status":        "failed",
+		}).LastValue())
+		require.EqualValues(t, 0, statsStore.Get("snowpipe_streaming_duplicate_events", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"reason":        "batch",
+		}).LastValue())
+		require.EqualValues(t, 1, statsStore.Get("snowpipe_streaming_duplicate_events", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"reason":        "offset",
+		}).LastValue())
+	})
+
+	t.Run("Upload with duplicate ids due to offset with bulk status enabled but failed to get bulk status for all channels", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		conf := config.New()
+		conf.Set("SnowpipeStreaming.bulkStatusEnabled", true)
+
+		sm := New(conf, logger.NOP, statsStore, destination)
+		sm.channelCache.Store("RUDDER_DISCARDS", rudderDiscardsChannelResponse)
+		sm.channelCache.Store("USERS", usersChannelResponse)
+		sm.channelCache.Store("PRODUCTS", productsChannelResponse)
+
+		sm.api = &mockAPI{
+			insertOutputMap: map[string]func() (*model.InsertResponse, error){
+				"test-users-channel": func() (*model.InsertResponse, error) {
+					return &model.InsertResponse{Success: true}, nil
+				},
+				"test-products-channel": func() (*model.InsertResponse, error) {
+					return &model.InsertResponse{Success: true}, nil
+				},
+				"test-rudder-discards-channel": func() (*model.InsertResponse, error) {
+					return &model.InsertResponse{Success: true}, nil
+				},
+			},
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-users-channel", "test-products-channel"},
+						Statuses: map[string]*model.StatusResponse{},
+					}, nil
+				},
+				"test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-users-channel": {Valid: true, Success: true, Offset: "1002"},
+						},
+					}, nil
+				},
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: true, Success: true, Offset: "1002"},
+						},
+					}, nil
+				},
+			},
+		}
+		output := sm.Upload(context.Background(), &common.AsyncDestinationStruct{
+			Destination: destination,
+			FileName:    "testdata/successful_sort_records.txt",
+		})
+		require.Equal(t, []int64{1002, 1003, 1001, 1004}, output.ImportingJobIDs)
+		require.Equal(t, 4, output.ImportingCount)
+		require.JSONEq(t, `{"importId":[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":false,"reason":"","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":false,"reason":"","count":2}],"importCount":4}`, string(output.ImportingParameters))
+		require.Nil(t, output.FailedJobIDs)
+		require.Zero(t, output.FailedCount)
+		require.Equal(t, "test-destination", output.DestinationID)
+		require.EqualValues(t, 4, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"status":        "importing",
+		}).LastValue())
+		require.Zero(t, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"status":        "failed",
+		}).LastValue())
+		require.EqualValues(t, 0, statsStore.Get("snowpipe_streaming_duplicate_events", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"reason":        "batch",
+		}).LastValue())
+		require.EqualValues(t, 1, statsStore.Get("snowpipe_streaming_duplicate_events", stats.Tags{
+			"module":        "batch_router",
+			"workspaceId":   "test-workspace",
+			"destType":      "SNOWPIPE_STREAMING",
+			"destinationId": "test-destination",
+			"reason":        "offset",
+		}).LastValue())
+	})
+
 	t.Run("Upload success but with a 404 error in the first call to insert", func(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

# Description

- Fixes offset-based duplicate detection for Snowpipe Streaming when `SnowpipeStreaming.bulkStatusEnabled `is on. Duplicate checks now use the bulk status API (with a single pre-fetch per upload) instead of per-channel GetStatus calls.

## Linear Ticket

- Resolves INT-6378

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
