### PR TITLE
feat(jobsdb): non-blocking dataset compaction

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -143,8 +143,9 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, shutdownFn func(), op
 	})
 
 	var (
-		jobsdbPool   *sql.DB
-		priorityPool *sql.DB
+		jobsdbPool      *sql.DB
+		priorityPool    *sql.DB
+		maintenancePool *sql.DB
 	)
 	if config.GetBoolVar(true, "DB.embedded.Pool.enabled", "DB.Pool.enabled") {
 		jobsdbPool, err = misc.NewDatabaseConnectionPool(ctx, "embedded", misc.DatabaseConnectionPoolConfig{
@@ -172,6 +173,19 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, shutdownFn func(), op
 		}
 		defer priorityPool.Close()
 	}
+	if config.GetBoolVar(true, "DB.embedded.MaintenancePool.enabled", "DB.MaintenancePool.enabled") {
+		maintenancePool, err = misc.NewDatabaseConnectionPool(ctx, "emp", misc.DatabaseConnectionPoolConfig{
+			MaxOpenConns:    config.GetReloadableIntVar(20, 1, "DB.embedded.MaintenancePool.maxOpenConnections", "DB.MaintenancePool.maxOpenConnections"),
+			MaxIdleConns:    config.GetReloadableIntVar(2, 1, "DB.embedded.MaintenancePool.maxIdleConnections", "DB.MaintenancePool.maxIdleConnections"),
+			ConnMaxIdleTime: config.GetReloadableDurationVar(15, time.Minute, "DB.embedded.MaintenancePool.maxIdleTime", "DB.MaintenancePool.maxIdleTime"),
+			ConnMaxLifetime: config.GetReloadableDurationVar(0, time.Second, "DB.embedded.MaintenancePool.maxConnLifetime", "DB.MaintenancePool.maxConnLifetime"),
+			UpdateInterval:  config.GetDurationVar(60, time.Second, "DB.embedded.MaintenancePool.updateInterval", "DB.MaintenancePool.updateInterval"),
+		}, config, statsFactory)
+		if err != nil {
+			return err
+		}
+		defer maintenancePool.Close()
+	}
 	partitionCount := config.GetIntVar(0, 1, "JobsDB.partitionCount")
 
 	pendingEventsRegistry := rmetrics.NewPendingEventsRegistry()
@@ -186,6 +200,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, shutdownFn func(), op
 		jobsdb.WithDBHandle(jobsdbPool),
 		jobsdb.WithNumPartitions(partitionCount),
 		jobsdb.WithPriorityPoolDB(priorityPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 	)
 	defer gwWOHandle.Close()
 	if err = gwWOHandle.Start(); err != nil {
@@ -201,6 +216,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, shutdownFn func(), op
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(jobsdbPool),
 		jobsdb.WithPriorityPoolDB(priorityPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 		jobsdb.WithNumPartitions(partitionCount),
 	)
 	defer gwROHandle.Close()
@@ -214,6 +230,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, shutdownFn func(), op
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(jobsdbPool),
 		jobsdb.WithPriorityPoolDB(priorityPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 		jobsdb.WithNumPartitions(partitionCount),
 	)
 	defer rtRWHandle.Close()
@@ -227,6 +244,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, shutdownFn func(), op
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(jobsdbPool),
 		jobsdb.WithPriorityPoolDB(priorityPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 		jobsdb.WithNumPartitions(partitionCount),
 	)
 	defer brtRWHandle.Close()
@@ -239,6 +257,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, shutdownFn func(), op
 		jobsdb.WithSkipMaintenanceErr(config.GetBoolVar(false, "Processor.jobsDB.skipMaintenanceError")),
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(jobsdbPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 	)
 	defer eschRWDB.Close()
 
@@ -250,6 +269,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, shutdownFn func(), op
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithJobMaxAge(config.GetReloadableDurationVar(24, time.Hour, "archival.jobRetention")),
 		jobsdb.WithDBHandle(jobsdbPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 	)
 	defer arcRWDB.Close()
 
@@ -271,7 +291,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, shutdownFn func(), op
 	}
 
 	// setup partition migrator
-	ppmSetup, err := setupProcessorPartitionMigrator(ctx, shutdownFn, jobsdbPool, priorityPool,
+	ppmSetup, err := setupProcessorPartitionMigrator(ctx, shutdownFn, jobsdbPool, priorityPool, maintenancePool,
 		config, statsFactory,
 		gwRODB, gwWODB,
 		rtRWDB, brtRWDB,

--- a/app/apphandlers/gatewayAppHandler.go
+++ b/app/apphandlers/gatewayAppHandler.go
@@ -69,7 +69,10 @@ func (a *gatewayApp) StartRudderCore(ctx context.Context, _ func(), options *app
 	}
 	defer sourceHandle.Stop()
 
-	var jobsdbPool *sql.DB
+	var (
+		jobsdbPool      *sql.DB
+		maintenancePool *sql.DB
+	)
 	if config.GetBoolVar(true, "DB.gateway.Pool.enabled", "DB.Pool.enabled") {
 		jobsdbPool, err = misc.NewDatabaseConnectionPool(ctx, "gateway", misc.DatabaseConnectionPoolConfig{
 			MaxOpenConns:    config.GetReloadableIntVar(20, 1, "DB.gateway.Pool.maxOpenConnections", "DB.Pool.maxOpenConnections"),
@@ -83,6 +86,19 @@ func (a *gatewayApp) StartRudderCore(ctx context.Context, _ func(), options *app
 		}
 		defer jobsdbPool.Close()
 	}
+	if config.GetBoolVar(true, "DB.gateway.MaintenancePool.enabled", "DB.MaintenancePool.enabled") {
+		maintenancePool, err = misc.NewDatabaseConnectionPool(ctx, "gmp", misc.DatabaseConnectionPoolConfig{
+			MaxOpenConns:    config.GetReloadableIntVar(6, 1, "DB.gateway.MaintenancePool.maxOpenConnections", "DB.MaintenancePool.maxOpenConnections"),
+			MaxIdleConns:    config.GetReloadableIntVar(1, 1, "DB.gateway.MaintenancePool.maxIdleConnections", "DB.MaintenancePool.maxIdleConnections"),
+			ConnMaxIdleTime: config.GetReloadableDurationVar(15, time.Minute, "DB.gateway.MaintenancePool.maxIdleTime", "DB.MaintenancePool.maxIdleTime"),
+			ConnMaxLifetime: config.GetReloadableDurationVar(0, time.Second, "DB.gateway.MaintenancePool.maxConnLifetime", "DB.MaintenancePool.maxConnLifetime"),
+			UpdateInterval:  config.GetDurationVar(60, time.Second, "DB.gateway.MaintenancePool.updateInterval", "DB.MaintenancePool.updateInterval"),
+		}, config, statsFactory)
+		if err != nil {
+			return err
+		}
+		defer maintenancePool.Close()
+	}
 	partitionCount := config.GetIntVar(0, 1, "JobsDB.partitionCount")
 
 	gwWOHandle := jobsdb.NewForWrite(
@@ -91,6 +107,7 @@ func (a *gatewayApp) StartRudderCore(ctx context.Context, _ func(), options *app
 		jobsdb.WithSkipMaintenanceErr(config.GetBoolVar(true, "Gateway.jobsDB.skipMaintenanceError")),
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(jobsdbPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 		jobsdb.WithNumPartitions(partitionCount),
 	)
 	defer gwWOHandle.Close()
@@ -112,7 +129,7 @@ func (a *gatewayApp) StartRudderCore(ctx context.Context, _ func(), options *app
 	if err != nil {
 		return fmt.Errorf("resolving mode provider: %w", err)
 	}
-	partitionMigrator, gwDB, err := setupGatewayPartitionMigrator(ctx, jobsdbPool, config, statsFactory, gwWODB, modeProvider.EtcdClient)
+	partitionMigrator, gwDB, err := setupGatewayPartitionMigrator(ctx, jobsdbPool, maintenancePool, config, statsFactory, gwWODB, modeProvider.EtcdClient)
 	if err != nil {
 		return fmt.Errorf("setting up partition migrator: %w", err)
 	}

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -150,8 +150,9 @@ func (a *processorApp) StartRudderCore(ctx context.Context, shutdownFn func(), o
 	})
 
 	var (
-		jobsdbPool   *sql.DB
-		priorityPool *sql.DB
+		jobsdbPool      *sql.DB
+		priorityPool    *sql.DB
+		maintenancePool *sql.DB
 	)
 	if config.GetBoolVar(true, "DB.processor.Pool.enabled", "DB.Pool.enabled") {
 		jobsdbPool, err = misc.NewDatabaseConnectionPool(ctx, "processor", misc.DatabaseConnectionPoolConfig{
@@ -179,6 +180,19 @@ func (a *processorApp) StartRudderCore(ctx context.Context, shutdownFn func(), o
 		}
 		defer priorityPool.Close()
 	}
+	if config.GetBoolVar(true, "DB.processor.MaintenancePool.enabled", "DB.MaintenancePool.enabled") {
+		maintenancePool, err = misc.NewDatabaseConnectionPool(ctx, "pmp", misc.DatabaseConnectionPoolConfig{
+			MaxOpenConns:    config.GetReloadableIntVar(20, 1, "DB.processor.MaintenancePool.maxOpenConnections", "DB.MaintenancePool.maxOpenConnections"),
+			MaxIdleConns:    config.GetReloadableIntVar(2, 1, "DB.processor.MaintenancePool.maxIdleConnections", "DB.MaintenancePool.maxIdleConnections"),
+			ConnMaxIdleTime: config.GetReloadableDurationVar(15, time.Minute, "DB.processor.MaintenancePool.maxIdleTime", "DB.MaintenancePool.maxIdleTime"),
+			ConnMaxLifetime: config.GetReloadableDurationVar(0, time.Second, "DB.processor.MaintenancePool.maxConnLifetime", "DB.MaintenancePool.maxConnLifetime"),
+			UpdateInterval:  config.GetDurationVar(60, time.Second, "DB.processor.MaintenancePool.updateInterval", "DB.MaintenancePool.updateInterval"),
+		}, config, statsFactory)
+		if err != nil {
+			return err
+		}
+		defer maintenancePool.Close()
+	}
 	partitionCount := config.GetIntVar(0, 1, "JobsDB.partitionCount")
 	pendingEventsRegistry := rmetrics.NewPendingEventsRegistry()
 
@@ -189,6 +203,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, shutdownFn func(), o
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(jobsdbPool),
 		jobsdb.WithPriorityPoolDB(priorityPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 		jobsdb.WithNumPartitions(partitionCount),
 	)
 	defer gwROHandle.Close()
@@ -201,6 +216,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, shutdownFn func(), o
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(jobsdbPool),
 		jobsdb.WithPriorityPoolDB(priorityPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 		jobsdb.WithNumPartitions(partitionCount),
 	)
 	defer rtRWHandle.Close()
@@ -214,6 +230,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, shutdownFn func(), o
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(jobsdbPool),
 		jobsdb.WithPriorityPoolDB(priorityPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 		jobsdb.WithNumPartitions(partitionCount),
 	)
 	defer brtRWHandle.Close()
@@ -224,6 +241,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, shutdownFn func(), o
 		jobsdb.WithDSLimit(a.config.eschDSLimit),
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithDBHandle(jobsdbPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 	)
 	defer eschRWDB.Close()
 
@@ -235,6 +253,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, shutdownFn func(), o
 		jobsdb.WithStats(statsFactory),
 		jobsdb.WithJobMaxAge(config.GetReloadableDurationVar(24, time.Hour, "archival.jobRetention")),
 		jobsdb.WithDBHandle(jobsdbPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 	)
 	defer arcRWDB.Close()
 
@@ -256,7 +275,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, shutdownFn func(), o
 	}
 
 	// setup partition migrator
-	ppmSetup, err := setupProcessorPartitionMigrator(ctx, shutdownFn, jobsdbPool, priorityPool,
+	ppmSetup, err := setupProcessorPartitionMigrator(ctx, shutdownFn, jobsdbPool, priorityPool, maintenancePool,
 		config, statsFactory,
 		gwRODB, nil,
 		rtRWDB, brtRWDB,

--- a/app/apphandlers/setup_partitionmigration.go
+++ b/app/apphandlers/setup_partitionmigration.go
@@ -41,6 +41,7 @@ func setupProcessorPartitionMigrator(ctx context.Context,
 	shutdownFn func(), // called to initiate shutdown of the app
 	dbPool *sql.DB, // database handle
 	priorityPool *sql.DB, // priority database handle
+	maintenancePool *sql.DB, // maintenance database handle (may be nil; jobsdb falls back to dbPool)
 	config *config.Config, stats stats.Stats,
 	gwRODB, gwWODB, // gateway reader and writer jobsDB handles. if gwWODB is nil, gwRODB is used for reading and a new writer gw DB is created internally
 	rtRWDB, brtRWDB jobsdb.JobsDB,
@@ -95,6 +96,7 @@ func setupProcessorPartitionMigrator(ctx context.Context,
 			jobsdb.WithStats(stats),
 			jobsdb.WithDBHandle(dbPool),
 			jobsdb.WithPriorityPoolDB(priorityPool),
+			jobsdb.WithMaintenancePoolDB(maintenancePool),
 		)
 		if err := gwBuffRWHandle.Start(); err != nil {
 			return ppmSetup, fmt.Errorf("starting gw buffer jobsdb handle: %w", err)
@@ -112,6 +114,7 @@ func setupProcessorPartitionMigrator(ctx context.Context,
 			jobsdb.WithStats(stats),
 			jobsdb.WithDBHandle(dbPool),
 			jobsdb.WithPriorityPoolDB(priorityPool),
+			jobsdb.WithMaintenancePoolDB(maintenancePool),
 			jobsdb.WithNumPartitions(partitionCount),
 		)
 		gwBuffROHandle := jobsdb.NewForRead(
@@ -121,6 +124,7 @@ func setupProcessorPartitionMigrator(ctx context.Context,
 			jobsdb.WithStats(stats),
 			jobsdb.WithDBHandle(dbPool),
 			jobsdb.WithPriorityPoolDB(priorityPool),
+			jobsdb.WithMaintenancePoolDB(maintenancePool),
 		)
 		gwSetupOpt = partitionbuffer.WithReaderOnlyAndFlushJobsDBs(gwRODB, gwBuffROHandle, gwWODB)
 	}
@@ -150,6 +154,7 @@ func setupProcessorPartitionMigrator(ctx context.Context,
 		jobsdb.WithStats(stats),
 		jobsdb.WithDBHandle(dbPool),
 		jobsdb.WithPriorityPoolDB(priorityPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 	)
 	rtPartitionBuffer, err := partitionbuffer.NewJobsDBPartitionBuffer(ctx,
 		partitionbuffer.WithReadWriteJobsDBs(rtRWDB, rtBuffRWHandle),
@@ -176,6 +181,7 @@ func setupProcessorPartitionMigrator(ctx context.Context,
 		jobsdb.WithStats(stats),
 		jobsdb.WithDBHandle(dbPool),
 		jobsdb.WithPriorityPoolDB(priorityPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 	)
 	brtPartitionBuffer, err := partitionbuffer.NewJobsDBPartitionBuffer(ctx,
 		partitionbuffer.WithReadWriteJobsDBs(brtRWDB, brtBuffRWHandle),
@@ -272,6 +278,7 @@ func setupProcessorPartitionMigrator(ctx context.Context,
 
 func setupGatewayPartitionMigrator(ctx context.Context,
 	dbPool *sql.DB, // database handle pool
+	maintenancePool *sql.DB, // maintenance database handle (may be nil; jobsdb falls back to dbPool)
 	config *config.Config, stats stats.Stats,
 	gwWODB jobsdb.JobsDB,
 	etcdClientProvider func() (etcdclient.Client, error),
@@ -291,6 +298,7 @@ func setupGatewayPartitionMigrator(ctx context.Context,
 		jobsdb.WithSkipMaintenanceErr(config.GetBoolVar(true, "JobsDB.gw_buf.skipMaintenanceError", "JobsDB.buff.skipMaintenanceError", "JobsDB.skipMaintenanceError")),
 		jobsdb.WithStats(stats),
 		jobsdb.WithDBHandle(dbPool),
+		jobsdb.WithMaintenancePoolDB(maintenancePool),
 	)
 	if err := gwBuffWOHandle.Start(); err != nil {
 		return nil, nil, fmt.Errorf("starting gw buffer jobsdb handle: %w", err)

--- a/jobsdb/admin.go
+++ b/jobsdb/admin.go
@@ -152,7 +152,7 @@ func (jd *Handle) doCleanup(ctx context.Context, l lock.LockToken) error {
 	{
 		deleteStmt := "DELETE FROM %s_journal WHERE start_time < NOW() - INTERVAL '%d DAY'"
 		var journalEntryCount int64
-		res, err := jd.getDB(ctx).ExecContext(
+		res, err := jd.maintenanceDB().ExecContext(
 			ctx,
 			fmt.Sprintf(
 				deleteStmt,
@@ -180,7 +180,7 @@ func (jd *Handle) abortOldJobs(ctx context.Context, dsList []dataSetT) error {
 	maxAgeStatusResponse := `{"reason": "job max age exceeded"}`
 	maxAge := jd.conf.jobMaxAge.Load()
 	for _, ds := range dsList {
-		res, err := jd.getDB(ctx).ExecContext(
+		res, err := jd.maintenanceDB().ExecContext(
 			ctx,
 			fmt.Sprintf(
 				`INSERT INTO %[1]q (job_id, job_state, error_response)

--- a/jobsdb/internal/lock/lock.go
+++ b/jobsdb/internal/lock/lock.go
@@ -3,8 +3,11 @@ package lock
 import (
 	"context"
 	"fmt"
+	"time"
 
 	golock "github.com/viney-shih/go-lock"
+
+	"github.com/rudderlabs/rudder-go-kit/stats"
 )
 
 // LockToken represents proof that a list lock has been acquired
@@ -15,22 +18,52 @@ type LockToken interface {
 // Locker
 type Locker struct {
 	m *golock.CASMutex
+
+	readLockWait            stats.Measurement
+	writeLockWait           stats.Measurement
+	writeLockWaitAsync      stats.Measurement
+	writeLockTime           stats.Measurement
+	writeLockTimeAsync      stats.Measurement
+	writeLockTotalTime      stats.Measurement
+	writeLockTotalTimeAsync stats.Measurement
 }
 
-func NewLocker() *Locker {
+func NewLocker(name, prefix string, s stats.Stats) *Locker {
+	newTimer := func(metric, lockType, async string) stats.Measurement {
+		return s.NewTaggedStat(metric, stats.TimerType, stats.Tags{
+			"name":     name,
+			"prefix":   prefix,
+			"lockType": lockType,
+			"async":    async,
+		})
+	}
 	return &Locker{
-		m: golock.NewCASMutex(),
+		m:                       golock.NewCASMutex(),
+		readLockWait:            newTimer("jobsdb_lock_wait_time", "read", "false"),
+		writeLockWait:           newTimer("jobsdb_lock_wait_time", "write", "false"),
+		writeLockWaitAsync:      newTimer("jobsdb_lock_wait_time", "write", "true"),
+		writeLockTime:           newTimer("jobsdb_lock_time", "write", "false"),
+		writeLockTimeAsync:      newTimer("jobsdb_lock_time", "write", "true"),
+		writeLockTotalTime:      newTimer("jobsdb_lock_total_time", "write", "false"),
+		writeLockTotalTimeAsync: newTimer("jobsdb_lock_total_time", "write", "true"),
 	}
 }
 
 // RLock acquires a read lock
 func (r *Locker) RLock() {
+	start := time.Now()
 	r.m.RLock()
+	r.readLockWait.Since(start)
 }
 
 // RTryLockWithCtx tries to acquires a read lock with context and returns false if context is done, otherwise returns true.
 func (r *Locker) RTryLockWithCtx(ctx context.Context) bool {
-	return r.m.RTryLockWithContext(ctx)
+	start := time.Now()
+	if r.m.RTryLockWithContext(ctx) {
+		r.readLockWait.Since(start)
+		return true
+	}
+	return false
 }
 
 // RUnlock releases a read lock
@@ -40,7 +73,12 @@ func (r *Locker) RUnlock() {
 
 // TryLockWithCtx tries to acquires a lock with context and returns false if context is done, otherwise returns true.
 func (r *Locker) TryLockWithCtx(ctx context.Context) bool {
-	return r.m.TryLockWithContext(ctx)
+	start := time.Now()
+	if r.m.TryLockWithContext(ctx) {
+		r.writeLockWait.Since(start)
+		return true
+	}
+	return false
 }
 
 // Unlock releases a lock
@@ -51,22 +89,36 @@ func (r *Locker) Unlock() {
 // WithLock acquires a lock for the duration that the provided function
 // is being executed. A token as proof of the lock is passed to the function.
 func (r *Locker) WithLock(f func(l LockToken)) {
+	start := time.Now()
 	r.m.Lock()
-	defer r.m.Unlock()
+	acquired := time.Now()
+	r.writeLockWait.Since(start)
+	defer func() {
+		r.m.Unlock()
+		r.writeLockTime.Since(acquired)
+		r.writeLockTotalTime.Since(start)
+	}()
 	f(&lockToken{})
 }
 
 // WithLockInCtx tries to acquires a lock until it succeeds or context times out. If it fails, return value is false otherwise true. And, executes the function `f`, if lock is acquired.
 // A token as proof of the lock is passed to the function.
 func (r *Locker) WithLockInCtx(ctx context.Context, f func(l LockToken) error) error {
+	start := time.Now()
 	if r.m.TryLockWithContext(ctx) {
-		defer r.m.Unlock()
+		acquired := time.Now()
+		r.writeLockWait.Since(start)
+		defer func() {
+			r.m.Unlock()
+			r.writeLockTime.Since(acquired)
+			r.writeLockTotalTime.Since(start)
+		}()
 		return f(&lockToken{})
 	}
 	return fmt.Errorf("failed to acquire a lock: %w", ctx.Err())
 }
 
-// AsyncLock acquires a lock until the token is returned to the receiving channel
+// AsyncLockWithCtx acquires a lock until the token is returned to the receiving channel
 func (r *Locker) AsyncLockWithCtx(ctx context.Context) (LockToken, chan<- LockToken, error) {
 	type tokenOrErr struct {
 		token LockToken
@@ -74,14 +126,19 @@ func (r *Locker) AsyncLockWithCtx(ctx context.Context) (LockToken, chan<- LockTo
 	}
 	async := make(chan tokenOrErr)
 	release := make(chan LockToken)
+	start := time.Now()
 
 	go func() {
-		if err := r.WithLockInCtx(ctx, func(l LockToken) error {
-			async <- tokenOrErr{token: l}
+		if r.m.TryLockWithContext(ctx) {
+			acquired := time.Now()
+			r.writeLockWaitAsync.Since(start)
+			async <- tokenOrErr{token: &lockToken{}}
 			<-release
-			return nil
-		}); err != nil {
-			async <- tokenOrErr{err: err}
+			r.m.Unlock()
+			r.writeLockTimeAsync.Since(acquired)
+			r.writeLockTotalTimeAsync.Since(start)
+		} else {
+			async <- tokenOrErr{err: ctx.Err()}
 		}
 	}()
 

--- a/jobsdb/internal/lock/lock_test.go
+++ b/jobsdb/internal/lock/lock_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
 	"github.com/rudderlabs/rudder-server/jobsdb/internal/lock"
 )
 
 func TestRLock(t *testing.T) {
-	locker := lock.NewLocker()
+	locker := lock.NewLocker("test", "ds", stats.NOP)
 	locker.RLock()
 
 	t.Run("Multiple read locks can be acquired", func(t *testing.T) {
@@ -40,7 +42,7 @@ func TestRLock(t *testing.T) {
 
 func TestAsyncLock(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-	locker := lock.NewLocker()
+	locker := lock.NewLocker("test", "ds", stats.NOP)
 
 	l, c, err := locker.AsyncLockWithCtx(context.Background())
 	require.NoError(t, err)
@@ -73,7 +75,7 @@ func TestAsyncLock(t *testing.T) {
 
 func TestAsyncLockTimeout(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-	locker := lock.NewLocker()
+	locker := lock.NewLocker("test", "ds", stats.NOP)
 	locker.RLock()
 	defer locker.RUnlock()
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -524,8 +524,9 @@ func (l dataSetTList) String() string {
 
 // dropDSEntry tracks a dataset to drop along with the dslist version that needs to be drained from readers before actually being able to drop the dataset
 type dropDSEntry struct {
-	ds      dataSetT // dataset to drop
-	version uint64   // the dslist version that needs to be drained from readers before dropping the dataset
+	ds        dataSetT // dataset to drop
+	compacted bool     // true if the dataset is compacted, false if completed
+	version   uint64   // the dslist version that needs to be drained from readers before dropping the dataset
 }
 
 type dataSetRangeT struct {
@@ -563,6 +564,7 @@ jobs. The caller must call the SetUp function on a Handle object
 type Handle struct {
 	dbHandle             *sql.DB
 	priorityPool         *sql.DB // dedicated connection pool for high-priority operations (e.g., partition migration)
+	maintenancePool      *sql.DB // dedicated connection pool for jobsdb-internal maintenance ops (compaction setup, refresh, vacuum), isolated from the main pool to avoid deadlock when main-pool waiters hold the dsListLock writer
 	sharedConnectionPool bool
 	ownerType            OwnerType
 	tablePrefix          string
@@ -661,6 +663,16 @@ type Handle struct {
 			// through the async dropDSLoop instead of the in-TX postMigrateHandleDS
 			// path, so the drop is migration-lock-free and does not block concurrent readers.
 			nonBlockingCompletedDSDrop config.ValueLoader[bool]
+			// nonBlockingCompaction gates the new compaction TX shape (EXCLUSIVE
+			// lock + readonly trigger on the source status table, async source drop).
+			// When disabled, falls back to the legacy doMigrateDS flow.
+			nonBlockingCompaction config.ValueLoader[bool]
+			// getJobsRetryOnCompaction gates the snapshot revalidation in getJobs:
+			// when set, getJobs detects that a queried dataset is no longer in the
+			// published list (e.g. a non-blocking compaction completed mid-read) and
+			// retries from scratch. Requires nonBlockingCompaction to also be set;
+			// has no effect on its own.
+			getJobsRetryOnCompaction config.ValueLoader[bool]
 		}
 		backup struct {
 			masterBackupEnabled config.ValueLoader[bool]
@@ -895,6 +907,21 @@ func WithPriorityPoolDB(pool *sql.DB) OptsFunc {
 	}
 }
 
+// WithMaintenancePoolDB sets a dedicated connection pool for jobsdb-internal
+// maintenance operations (compaction setup queries, post-commit dsList refresh,
+// status-table cleanup/vacuum). Isolating these from the main pool prevents a
+// deadlock vector where main-pool waiters are queued on the dsListLock writer
+// that compaction holds while it tries to grab a connection for
+// doRefreshDSRangeList.
+//
+// If no maintenance pool is provided, maintenance operations fall back to the
+// main dbHandle.
+func WithMaintenancePoolDB(pool *sql.DB) OptsFunc {
+	return func(jd *Handle) {
+		jd.maintenancePool = pool
+	}
+}
+
 // withDatabaseTablesVersion sets the database tables version to use (internal use only for verifying database table migrations)
 func withDatabaseTablesVersion(dbVersion int) OptsFunc {
 	return func(jd *Handle) {
@@ -1029,7 +1056,7 @@ func (jd *Handle) init() {
 					// doesn't return the full list of datasets, only the rightmost two.
 					// But we need to run the schema migration against all datasets, no matter
 					// whether jobsdb is a writer or not.
-					datasets, err := getDSList(jd, jd.dbHandle, jd.tablePrefix)
+					datasets, err := getDSList(jd, tx, jd.tablePrefix)
 					jd.assertError(err)
 
 					datasetIndices := make([]string, 0)
@@ -1058,7 +1085,7 @@ func (jd *Handle) init() {
 				jd.runAlwaysChangesets(templateData)
 
 				// finally refresh the dataset list to make sure [datasetList] field is populated
-				err := jd.doRefreshDSRangeList(l)
+				err := jd.doRefreshDSRangeListWithDB(l, jd.dbHandle)
 				jd.assertError(err)
 			})
 			return nil
@@ -1131,6 +1158,8 @@ func (jd *Handle) loadConfig() {
 	jd.conf.migration.vacuumFullStatusTableThreshold = jd.config.GetReloadableInt64Var(500*bytesize.MB, 1, jd.configKeys("vacuumFullStatusTableThreshold")...)
 	jd.conf.migration.vacuumAnalyzeStatusTableThreshold = jd.config.GetReloadableInt64Var(30000, 1, jd.configKeys("vacuumAnalyzeStatusTableThreshold")...)
 	jd.conf.migration.nonBlockingCompletedDSDrop = jd.config.GetReloadableBoolVar(false, jd.configKeys("nonBlockingCompletedDSDrop")...)
+	jd.conf.migration.nonBlockingCompaction = jd.config.GetReloadableBoolVar(false, jd.configKeys("nonBlockingCompaction")...)
+	jd.conf.migration.getJobsRetryOnCompaction = jd.config.GetReloadableBoolVar(true, jd.configKeys("getJobsRetryOnCompaction")...)
 
 	// masterBackupEnabled = true => all the jobsdb are eligible for backup
 	jd.conf.backup.masterBackupEnabled = jd.config.GetReloadableBoolVar(true, jd.configKeys("backup.enabled")...)
@@ -1397,7 +1426,7 @@ func (jd *Handle) addCompletedDSToDropList(ctx context.Context, l lock.LockToken
 		if _, ok := existing[ds.Index]; ok {
 			continue
 		}
-		jd.dropDSList = append(jd.dropDSList, dropDSEntry{ds: ds, version: version})
+		jd.dropDSList = append(jd.dropDSList, dropDSEntry{ds: ds, compacted: false, version: version})
 		existing[ds.Index] = struct{}{}
 		addedDSList = append(addedDSList, ds)
 	}
@@ -1434,7 +1463,7 @@ func (jd *Handle) dropNotifyPing() {
 }
 
 func (jd *Handle) doRefreshDSRangeList(l lock.LockToken) error {
-	return jd.doRefreshDSRangeListWithDB(l, jd.dbHandle)
+	return jd.doRefreshDSRangeListWithDB(l, jd.maintenanceDB())
 }
 
 // doRefreshDSRangeList first refreshes the DS list and then calculate the DS range list
@@ -1628,7 +1657,7 @@ func newDataSet(tablePrefix, dsIdx string) dataSetT {
 }
 
 func (jd *Handle) addNewDS(ctx context.Context, l lock.LockToken, ds dataSetT) {
-	err := jd.WithTx(ctx, func(tx *Tx) error {
+	err := jd.withMaintenanceTx(ctx, func(tx *Tx) error {
 		dsList, err := jd.doRefreshDSList(l, tx.Tx)
 		jd.assertError(err)
 		return jd.addNewDSInTx(ctx, tx, l, dsList, ds)
@@ -1666,7 +1695,7 @@ func (jd *Handle) addNewDSInTx(ctx context.Context, tx *Tx, l lock.LockToken, ds
 }
 
 func (jd *Handle) computeNewIdxForAppend(l lock.LockToken) string {
-	dList, err := jd.doRefreshDSList(l, jd.dbHandle)
+	dList, err := jd.doRefreshDSList(l, jd.maintenanceDB())
 	jd.assertError(err)
 	return jd.doComputeNewIdxForAppend(dList)
 }
@@ -1875,13 +1904,13 @@ func (jd *Handle) dropDS(ds dataSetT) error {
 }
 
 func (jd *Handle) dropDSWithCtx(ctx context.Context, ds dataSetT) error {
-	return jd.WithTx(ctx, func(tx *Tx) error {
+	return jd.withMaintenanceTx(ctx, func(tx *Tx) error {
 		return jd.dropDSInTx(tx, ds)
 	})
 }
 
 func (jd *Handle) markPreDropDS(ctx context.Context, dsList ...dataSetT) error {
-	return jd.WithTx(ctx, func(tx *Tx) error {
+	return jd.withMaintenanceTx(ctx, func(tx *Tx) error {
 		for _, ds := range dsList {
 			if err := jd.markPreDropDSInTx(ctx, tx, ds); err != nil {
 				return err
@@ -1902,7 +1931,7 @@ func (jd *Handle) markPreDropDSInTx(ctx context.Context, tx *Tx, ds dataSetT) er
 }
 
 func (jd *Handle) cleanupPreDropTables(ctx context.Context) error {
-	rows, err := jd.getDB(ctx).QueryContext(ctx, `SELECT c.relname
+	rows, err := jd.maintenanceDB().QueryContext(ctx, `SELECT c.relname
 									FROM pg_catalog.pg_class c
 									JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 									JOIN pg_catalog.pg_description d ON d.objoid = c.oid AND d.objsubid = 0
@@ -1937,6 +1966,7 @@ func (jd *Handle) cleanupPreDropTables(ctx context.Context) error {
 	if err = rows.Err(); err != nil {
 		return fmt.Errorf("iterate pre-drop tables: %w", err)
 	}
+	_ = rows.Close()
 
 	indices := lo.Keys(datasets)
 	sortDnumList(indices)
@@ -1946,7 +1976,7 @@ func (jd *Handle) cleanupPreDropTables(ctx context.Context) error {
 			logger.NewStringField("jobTable", ds.JobTable),
 			logger.NewStringField("jobStatusTable", ds.JobStatusTable),
 		)
-		if err = jd.WithTx(ctx, func(tx *Tx) error {
+		if err = jd.withMaintenanceTx(ctx, func(tx *Tx) error {
 			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %q CASCADE`, ds.JobStatusTable)); err != nil {
 				return fmt.Errorf("drop %s: %w", ds.JobStatusTable, err)
 			}
@@ -1964,16 +1994,10 @@ func (jd *Handle) cleanupPreDropTables(ctx context.Context) error {
 // dropDS drops a dataset
 func (jd *Handle) dropDSInTx(tx *Tx, ds dataSetT) error {
 	var err error
-	if _, err = tx.Exec(fmt.Sprintf(`LOCK TABLE %q IN ACCESS EXCLUSIVE MODE;`, ds.JobStatusTable)); err != nil {
+	if _, err = tx.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %q CASCADE`, ds.JobStatusTable)); err != nil {
 		return err
 	}
-	if _, err = tx.Exec(fmt.Sprintf(`LOCK TABLE %q IN ACCESS EXCLUSIVE MODE;`, ds.JobTable)); err != nil {
-		return err
-	}
-	if _, err = tx.Exec(fmt.Sprintf(`DROP TABLE %q CASCADE`, ds.JobStatusTable)); err != nil {
-		return err
-	}
-	if _, err = tx.Exec(fmt.Sprintf(`DROP TABLE %q CASCADE`, ds.JobTable)); err != nil {
+	if _, err = tx.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %q CASCADE`, ds.JobTable)); err != nil {
 		return err
 	}
 	jd.postDropDs(ds)
@@ -2055,7 +2079,7 @@ func (jd *Handle) dropDSLoop(ctx context.Context) error {
 func (jd *Handle) dropDSForRecovery(ds dataSetT) {
 	var sqlStatement string
 	var err error
-	tx, err := jd.dbHandle.Begin()
+	tx, err := jd.maintenanceDB().Begin()
 	jd.assertError(err)
 	sqlStatement = fmt.Sprintf(`LOCK TABLE %q IN ACCESS EXCLUSIVE MODE;`, ds.JobStatusTable)
 	jd.prepareAndExecStmtInTxAllowMissing(tx, sqlStatement)
@@ -2088,14 +2112,19 @@ func (jd *Handle) dropAllDS(l lock.LockToken) error {
 	if err != nil {
 		return fmt.Errorf("getDSList: %w", err)
 	}
-	for _, ds := range dList {
-		if err = jd.dropDS(ds); err != nil {
-			return fmt.Errorf("dropDS: %w", err)
+	if err := jd.WithTx(context.Background(), func(tx *Tx) error {
+		for _, ds := range dList {
+			if err = jd.dropDSInTx(tx, ds); err != nil {
+				return fmt.Errorf("dropDS: %w", err)
+			}
 		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("withTx: %w", err)
 	}
 
 	// Update the lists
-	if err = jd.doRefreshDSRangeList(l); err != nil {
+	if err = jd.doRefreshDSRangeListWithDB(l, jd.dbHandle); err != nil {
 		return fmt.Errorf("refreshDSRangeList: %w", err)
 	}
 	return nil
@@ -2213,7 +2242,18 @@ func (jd *Handle) inUpdateSafeCtx(ctx context.Context, f func(dsList []dataSetT,
 }
 
 func (jd *Handle) WithTx(ctx context.Context, f func(tx *Tx) error) error {
-	sqltx, err := jd.getDB(ctx).BeginTx(ctx, nil)
+	return jd.withTxOnDB(ctx, jd.getDB(ctx), f)
+}
+
+// withMaintenanceTx runs f inside a transaction opened on the maintenance pool
+// (or dbHandle if no maintenance pool is configured). Used by jobsdb-internal
+// maintenance flows to keep their BeginTx off the main pool.
+func (jd *Handle) withMaintenanceTx(ctx context.Context, f func(tx *Tx) error) error {
+	return jd.withTxOnDB(ctx, jd.maintenanceDB(), f)
+}
+
+func (jd *Handle) withTxOnDB(ctx context.Context, db *sql.DB, f func(tx *Tx) error) error {
+	sqltx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -3025,7 +3065,7 @@ func (jd *Handle) addNewDSLoop(ctx context.Context) {
 			}()
 			// Adding a new DS only creates a new DS & updates the cache. It doesn't move any data so we only take the list lock.
 			// start a transaction
-			err := jd.WithTx(ctx, func(tx *Tx) error {
+			err := jd.withMaintenanceTx(ctx, func(tx *Tx) error {
 				return jd.withDistributedSharedLock(ctx, tx, "schema_migrate", func() error { // cannot run while schema migration is running
 					return jd.withDistributedLock(ctx, tx, "add_ds", func() error { // only one add_ds can run at a time
 						var err error
@@ -3069,7 +3109,7 @@ func (jd *Handle) addNewDSLoop(ctx context.Context) {
 							}
 						} else {
 							// maybe another node added a new DS that we need to make visible to us
-							if err := jd.RefreshDSList(ctx); err != nil {
+							if err := jd.refreshDSListWithDB(ctx, tx); err != nil {
 								return fmt.Errorf("refreshDSList: %w", err)
 							}
 						}
@@ -3134,8 +3174,12 @@ func (jd *Handle) refreshDSListLoop(ctx context.Context) {
 	}
 }
 
-// RefreshDSList refreshes the list of datasets in memory if the database view of the list has changed.
 func (jd *Handle) RefreshDSList(ctx context.Context) error {
+	return jd.refreshDSListWithDB(ctx, jd.maintenanceDB())
+}
+
+// RefreshDSList refreshes the list of datasets in memory if the database view of the list has changed.
+func (jd *Handle) refreshDSListWithDB(ctx context.Context, db sqlDbOrTx) error {
 	jd.logger.Debugn("Start", logger.NewStringField("operation", "refreshDSListLoop"))
 
 	start := time.Now()
@@ -3146,7 +3190,7 @@ func (jd *Handle) RefreshDSList(ctx context.Context) error {
 	jd.dsListLock.RLock()
 	previousLastDS := jd.getLastDS()
 	jd.dsListLock.RUnlock()
-	nextDS, err := getDSList(jd, jd.getDB(ctx), jd.tablePrefix)
+	nextDS, err := getDSList(jd, db, jd.tablePrefix)
 	if err != nil {
 		return fmt.Errorf("getDSList: %w", err)
 	}
@@ -3157,7 +3201,7 @@ func (jd *Handle) RefreshDSList(ctx context.Context) error {
 	}
 	defer jd.stats.NewTaggedStat("refresh_ds_loop_lock", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix}).RecordDuration()()
 	err = jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
-		return jd.doRefreshDSRangeList(l)
+		return jd.doRefreshDSRangeListWithDB(l, db)
 	})
 	if err != nil {
 		return fmt.Errorf("refreshDSRangeList: %w", err)
@@ -3177,6 +3221,17 @@ func (jd *Handle) Identifier() string {
 func (jd *Handle) getDB(ctx context.Context) *sql.DB {
 	if usePriorityPool(ctx) && jd.priorityPool != nil {
 		return jd.priorityPool
+	}
+	return jd.dbHandle
+}
+
+// maintenanceDB returns the connection pool to use for jobsdb-internal
+// maintenance operations (compaction, dsList refresh,
+// status-table cleanup/vacuum). Falls back to dbHandle when no dedicated
+// maintenance pool was injected via WithMaintenancePoolDB.
+func (jd *Handle) maintenanceDB() *sql.DB {
+	if jd.maintenancePool != nil {
+		return jd.maintenancePool
 	}
 	return jd.dbHandle
 }
@@ -3296,11 +3351,7 @@ func (jd *Handle) recoverFromCrash(owner OwnerType, goRoutineType string) {
 									owner = '%s'
                                 	ORDER BY id`, jd.tablePrefix, owner)
 
-	stmt, err := jd.dbHandle.Prepare(sqlStatement)
-	jd.assertError(err)
-	defer func() { _ = stmt.Close() }()
-
-	rows, err := stmt.Query(pq.Array(opTypes))
+	rows, err := jd.maintenanceDB().Query(sqlStatement, pq.Array(opTypes))
 	jd.assertError(err)
 	defer func() { _ = rows.Close() }()
 
@@ -3320,6 +3371,7 @@ func (jd *Handle) recoverFromCrash(owner OwnerType, goRoutineType string) {
 	}
 	jd.assertError(rows.Err())
 	jd.assert(count <= 1, fmt.Sprintf("count:%d > 1", count))
+	_ = rows.Close()
 
 	if count == 0 {
 		// Nothing to recover
@@ -3361,7 +3413,7 @@ func (jd *Handle) recoverFromCrash(owner OwnerType, goRoutineType string) {
 		sqlStatement = fmt.Sprintf(`UPDATE "%s_journal" SET done=True WHERE id=$1`, jd.tablePrefix)
 	}
 
-	_, err = jd.dbHandle.Exec(sqlStatement, opID)
+	_, err = jd.maintenanceDB().Exec(sqlStatement, opID)
 	jd.assertError(err)
 }
 
@@ -3756,7 +3808,25 @@ can return the same set of events. It is the responsibility of the caller to cal
 one thread, update the state (to "waiting") in the same thread and pass on the processors
 */
 func (jd *Handle) getJobs(ctx context.Context, params GetQueryParams, more MoreToken) (*MoreJobsResult, error) { // skipcq: CRT-P0003
+	// Retry loop: if the published dsList drops one of the datasets we queried
+	// while we were iterating (e.g. a compaction completed mid-read), our result
+	// may have been computed against a snapshot that is no longer canonical. Re-run
+	// from scratch against the freshly published list.
+	for {
+		res, err := jd.doGetJobs(ctx, params, more)
+		if err != nil {
+			if errors.Is(err, ErrStaleDsList) {
+				jd.logger.Warnn("[JobsDB] getJobs: dsList compacted during query, retrying",
+					logger.NewStringField("tablePrefix", jd.tablePrefix))
+				continue
+			}
+			return nil, err
+		}
+		return res, nil
+	}
+}
 
+func (jd *Handle) doGetJobs(ctx context.Context, params GetQueryParams, more MoreToken) (*MoreJobsResult, error) { // skipcq: CRT-P0003
 	mtoken := &moreToken{}
 	if more != nil {
 		var ok bool
@@ -3806,6 +3876,11 @@ func (jd *Handle) getJobs(ctx context.Context, params GetQueryParams, more MoreT
 	res := &MoreJobsResult{More: mtoken}
 	dsQueryCount := 0
 	cacheHitCount := 0
+
+	// Track every dataset we actually queried via getJobsDS so we can validate
+	// the post-iteration snapshot against the set of datasets our result was
+	// computed from.
+	queried := make(map[string]struct{}, len(dsList))
 	var dsLimit int
 	if jd.conf.dsLimit != nil {
 		dsLimit = jd.conf.dsLimit.Load()
@@ -3833,6 +3908,7 @@ func (jd *Handle) getJobs(ctx context.Context, params GetQueryParams, more MoreT
 		if err != nil {
 			return nil, err
 		}
+		queried[ds.Index] = struct{}{}
 		if dsHit {
 			dsQueryCount++
 		} else {
@@ -3872,6 +3948,22 @@ func (jd *Handle) getJobs(ctx context.Context, params GetQueryParams, more MoreT
 	}
 	jd.stats.NewTaggedStat("jobsdb_queried_jobs", stats.CountType, statTags).Count(len(res.Jobs))                                                         // number of jobs that we queried
 	jd.stats.NewTaggedStat("jobsdb_queried_bytes", stats.CountType, statTags).Count(lo.SumBy(res.Jobs, func(j *JobT) int { return len(j.EventPayload) })) // number of bytes that we queried
+	// Validate that none of the datasets we examined were compacted while we
+	// were querying. If any of them were, it means our result may be stale and we need to retry.
+	if jd.conf.migration.nonBlockingCompaction.Load() && jd.conf.migration.getJobsRetryOnCompaction.Load() {
+		jd.dropDSListLock.RLock()
+		_, found := lo.Find(jd.dropDSList, func(entry dropDSEntry) bool {
+			if !entry.compacted {
+				return false
+			}
+			_, ok := queried[entry.ds.Index]
+			return ok
+		})
+		jd.dropDSListLock.RUnlock()
+		if found {
+			return nil, ErrStaleDsList
+		}
+	}
 	return res, nil
 }
 

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -973,8 +973,6 @@ func (jd *Handle) Setup(
 }
 
 func (jd *Handle) init() {
-	jd.dsListLock = lock.NewLocker()
-	jd.dsMigrationLock = lock.NewLocker()
 	jd.dsList = newVersionedDSList(nil, nil)
 	jd.dropNotify = make(chan struct{}, 1)
 	if jd.logger == nil {
@@ -994,6 +992,8 @@ func (jd *Handle) init() {
 	if jd.stats == nil {
 		jd.stats = stats.Default
 	}
+	jd.dsListLock = lock.NewLocker("dsListLock", jd.tablePrefix, jd.stats)
+	jd.dsMigrationLock = lock.NewLocker("dsMigrationLock", jd.tablePrefix, jd.stats)
 
 	jd.loadConfig()
 

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -189,6 +189,7 @@ func (jd *Handle) doMigrateDS(ctx context.Context) error {
 
 				totalJobsMigrated := 0
 				var noJobsMigrated int
+				copyStart := time.Now()
 				for i := range migrateFrom {
 					source := migrateFrom[i]
 					if source.numJobsPending > 0 {
@@ -217,6 +218,7 @@ func (jd *Handle) doMigrateDS(ctx context.Context) error {
 						)
 					}
 				}
+				jd.getTimerStat("jobsdb_migration_copy_time", &statTags{CustomValFilters: []string{jd.tablePrefix}}).Since(copyStart)
 				if err = jd.createDSIndicesInTx(ctx, tx, destination); err != nil {
 					return fmt.Errorf("create %v indices: %w", destination, err)
 				}
@@ -799,6 +801,7 @@ func (jd *Handle) doCompactDS(ctx context.Context) error {
 				return fmt.Errorf("create dataset tables: %w", err)
 			}
 
+			var copyStart time.Time
 			for i, source := range migrationList.migrateFrom {
 				if source.numJobsPending == 0 {
 					jd.logger.Infon(
@@ -832,12 +835,18 @@ func (jd *Handle) doCompactDS(ctx context.Context) error {
 					logger.NewStringField("from", source.ds.Index),
 					logger.NewStringField("to", destination.Index),
 				)
+				if copyStart.IsZero() {
+					copyStart = time.Now()
+				}
 				count, err := jd.migrateJobsInTx(ctx, tx, source.ds, destination)
 				if err != nil {
 					return fmt.Errorf("copying jobs from %s: %w", source.ds.Index, err)
 				}
 				totalCopied += count
 				migrationList.migrateFrom[i].numJobsPending = count
+			}
+			if !copyStart.IsZero() {
+				jd.getTimerStat("jobsdb_migration_copy_time", &statTags{CustomValFilters: []string{jd.tablePrefix}}).Since(copyStart)
 			}
 
 			if err := jd.createDSIndicesInTx(ctx, tx, destination); err != nil {

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -66,6 +66,9 @@ func (jd *Handle) migrateDSLoop(ctx context.Context) {
 }
 
 func (jd *Handle) doMigrateDS(ctx context.Context) error {
+	if jd.conf.migration.nonBlockingCompaction.Load() {
+		return jd.doCompactDS(ctx)
+	}
 	dsList, _, release, err := jd.acquireDSListForRead(ctx)
 	if err != nil {
 		return fmt.Errorf("could not acquire a dslist read lock: %w", err)
@@ -77,7 +80,7 @@ func (jd *Handle) doMigrateDS(ctx context.Context) error {
 	}
 	release()
 
-	optimisticCheck, err := jd.getMigrationList(dsList, jd.lastMigrateProbeIndex)
+	optimisticCheck, err := jd.getMigrationList(dsList, jd.lastMigrateProbeIndex, jd.maintenanceDB())
 	jd.lastMigrateProbeIndex = nil
 	if err != nil {
 		return fmt.Errorf("could not get migration list: %w", err)
@@ -95,7 +98,7 @@ func (jd *Handle) doMigrateDS(ctx context.Context) error {
 		)
 		if len(completed) > 0 {
 			if err := jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
-				// addToDropDSList republishes dsList without the completed datasets;
+				// addCompletedDSToDropList republishes dsList without the completed datasets;
 				// reuse that snapshot so the second getMigrationList pass inside the
 				// TX does not re-encounter datasets we just queued for async drop.
 				newList, err := jd.addCompletedDSToDropList(ctx, l, completed...)
@@ -127,7 +130,7 @@ func (jd *Handle) doMigrateDS(ctx context.Context) error {
 	var lockChan chan<- lock.LockToken
 
 	lockStart := time.Now()
-	err = jd.WithTx(ctx, func(tx *Tx) error {
+	err = jd.withMaintenanceTx(ctx, func(tx *Tx) error {
 		return jd.withDistributedSharedLock(ctx, tx, "schema_migrate", func() error { // cannot run while schema migration is running
 			// Take the lock and run actual migration
 			if !jd.dsMigrationLock.TryLockWithCtx(ctx) {
@@ -137,7 +140,7 @@ func (jd *Handle) doMigrateDS(ctx context.Context) error {
 			// repeat the check after the dsMigrationLock is acquired to get correct pending jobs count.
 			// the pending jobs count cannot change after the dsMigrationLock is acquired.
 			// skip datasets before the first eligible one found in the optimistic check.
-			migrateResult, err := jd.getMigrationList(dsList, optimisticCheck.firstEligible)
+			migrateResult, err := jd.getMigrationList(dsList, optimisticCheck.firstEligible, tx)
 			if err != nil {
 				return fmt.Errorf("could not get migration list: %w", err)
 			}
@@ -152,7 +155,7 @@ func (jd *Handle) doMigrateDS(ctx context.Context) error {
 			if pendingJobsCount > 0 { // migrate incomplete jobs
 				var destination dataSetT
 				if err := jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
-					dsIdx, err := jd.computeNewIdxForIntraNodeMigration(l, insertBeforeDS)
+					dsIdx, err := jd.computeNewIdxForIntraNodeMigration(l, insertBeforeDS, tx)
 					if err != nil {
 						return fmt.Errorf("computing new index for intra-node migration: %w", err)
 					}
@@ -299,7 +302,7 @@ type migrationListResult struct {
 func (jd *Handle) getVacuumFullCandidates(ctx context.Context, dsList []dataSetT) ([]string, error) {
 	// get name and it's size of all tables
 	var rows *sql.Rows
-	rows, err := jd.getDB(ctx).QueryContext(
+	rows, err := jd.maintenanceDB().QueryContext(
 		ctx,
 		`SELECT pg_catalog.pg_table_size(c.oid) AS size, c.relname
 		FROM pg_catalog.pg_class c
@@ -349,7 +352,7 @@ func (jd *Handle) getVacuumFullCandidates(ctx context.Context, dsList []dataSetT
 func (jd *Handle) getCleanUpCandidates(ctx context.Context, dsList []dataSetT) ([]dataSetT, error) {
 	// get analyzer estimates for the number of rows(jobs, statuses) in each DS
 	var rows *sql.Rows
-	rows, err := jd.getDB(ctx).QueryContext(
+	rows, err := jd.maintenanceDB().QueryContext(
 		ctx,
 		`SELECT c.reltuples AS estimate, c.relname
 		FROM pg_catalog.pg_class c
@@ -415,7 +418,7 @@ func (jd *Handle) cleanupStatusTables(ctx context.Context, dsList []dataSetT) er
 		stats.Tags{"customVal": jd.tablePrefix},
 	).Since(start)
 
-	if err := jd.WithTx(ctx, func(tx *Tx) error {
+	if err := jd.withMaintenanceTx(ctx, func(tx *Tx) error {
 		for _, statusTable := range toCompact {
 			table := statusTable.JobStatusTable
 			// clean up and vacuum if not present in toVacuumFullMap
@@ -436,14 +439,14 @@ func (jd *Handle) cleanupStatusTables(ctx context.Context, dsList []dataSetT) er
 	// vacuum full
 	for _, table := range toVacuumFull {
 		jd.logger.Infon("vacuuming full", logger.NewStringField("table", table))
-		if _, err := jd.getDB(ctx).ExecContext(ctx, fmt.Sprintf(`VACUUM FULL %[1]q`, table)); err != nil {
+		if _, err := jd.maintenanceDB().ExecContext(ctx, fmt.Sprintf(`VACUUM FULL %[1]q`, table)); err != nil {
 			return err
 		}
 	}
 	// vacuum analyze
 	for _, table := range toVacuum {
 		jd.logger.Infon("vacuuming", logger.NewStringField("table", table))
-		if _, err := jd.getDB(ctx).ExecContext(ctx, fmt.Sprintf(`VACUUM ANALYZE %[1]q`, table)); err != nil {
+		if _, err := jd.maintenanceDB().ExecContext(ctx, fmt.Sprintf(`VACUUM ANALYZE %[1]q`, table)); err != nil {
 			return err
 		}
 	}
@@ -484,7 +487,7 @@ func (jd *Handle) cleanStatusTable(ctx context.Context, tx *Tx, table string, ca
 // If skipBefore is non-nil, datasets whose parsed index is Less than skipBefore
 // are skipped (not checked). This avoids redundant checkIfMigrateDS calls for
 // datasets already known to be ineligible.
-func (jd *Handle) getMigrationList(dsList []dataSetT, skipBefore *dsindex.Index) (result migrationListResult, err error) {
+func (jd *Handle) getMigrationList(dsList []dataSetT, skipBefore *dsindex.Index, db sqlDbOrTx) (result migrationListResult, err error) {
 	var (
 		liveDSCount, migrateDSProbeCount int
 		// we don't want `maxDSSize` value to change, during dsList loop
@@ -518,7 +521,7 @@ func (jd *Handle) getMigrationList(dsList []dataSetT, skipBefore *dsindex.Index)
 			break
 		}
 
-		migrate, needsPair, recordsLeft, migrateErr := jd.checkIfMigrateDS(ds)
+		migrate, needsPair, recordsLeft, migrateErr := jd.checkIfMigrateDS(ds, db)
 		if migrateErr != nil {
 			return result, migrateErr
 		}
@@ -679,9 +682,9 @@ func (jd *Handle) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dat
 	return numJobsMigrated, nil
 }
 
-func (jd *Handle) computeNewIdxForIntraNodeMigration(l lock.LockToken, insertBeforeDS dataSetT) (string, error) { // Within the node
+func (jd *Handle) computeNewIdxForIntraNodeMigration(l lock.LockToken, insertBeforeDS dataSetT, db sqlDbOrTx) (string, error) { // Within the node
 	jd.logger.Debugn("computeNewIdxForIntraNodeMigration", logger.NewStringField("insertBeforeDS", insertBeforeDS.String()))
-	dList, err := jd.doRefreshDSList(l, jd.dbHandle)
+	dList, err := jd.doRefreshDSList(l, db)
 	if err != nil {
 		return "", fmt.Errorf("refreshDSList: %w", err)
 	}
@@ -704,6 +707,235 @@ func (jd *Handle) computeNewIdxForIntraNodeMigration(l lock.LockToken, insertBef
 		}
 	}
 	return newDSIdx, nil
+}
+
+// doCompactDS is the non-blocking compaction flow which replaces the legacy doMigrateDS body when the nonBlockingCompaction flag is enabled.
+//
+// Lock semantics (vs. legacy):
+//   - dsMigrationLock is NOT taken. Concurrent reads via inUpdateSafeCtx grab their
+//     existing read lock against an uncontended write side.
+//   - dsListLock is taken exactly once, asynchronously, right before COMMIT — only
+//     the swap (in-memory) + COMMIT + enqueue + publish happen inside the lock window.
+//   - Source status tables are fenced with LOCK TABLE … IN EXCLUSIVE MODE and a
+//     post-commit readonly trigger; the trigger raises RS001 on subsequent inserts,
+//     which the UpdateJobStatus path treats as ErrStaleDsList and retries.
+func (jd *Handle) doCompactDS(ctx context.Context) error {
+	dsList, _, release, err := jd.acquireDSListForRead(ctx)
+	if err != nil {
+		return fmt.Errorf("could not acquire a dslist read lock: %w", err)
+	}
+	if err := jd.cleanupStatusTables(ctx, dsList); err != nil {
+		release()
+		return err
+	}
+	release()
+
+	migrationList, err := jd.getMigrationList(dsList, jd.lastMigrateProbeIndex, jd.maintenanceDB())
+	jd.lastMigrateProbeIndex = nil
+	if err != nil {
+		return fmt.Errorf("could not get migration list: %w", err)
+	}
+	if len(migrationList.migrateFrom) == 0 {
+		if migrationList.probeLimitReached {
+			jd.lastMigrateProbeIndex = migrationList.lastProbed
+		}
+		return nil
+	}
+
+	migrateFromDatasets := lo.Map(migrationList.migrateFrom, func(d dsWithPendingJobCount, _ int) dataSetT {
+		return d.ds
+	})
+
+	// If all source datasets are completed (no pending jobs), short-circuit through
+	// the async-drop path — no copy, no destination, no in-TX work needed.
+	if migrationList.pendingJobsCount == 0 {
+		if err := jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
+			_, err := jd.addCompletedDSToDropList(ctx, l, migrateFromDatasets...)
+			return err
+		}); err != nil {
+			return fmt.Errorf("enqueue completed datasets for async drop: %w", err)
+		}
+		return nil
+	}
+
+	// Pure-Go destination index computation from the optimistic snapshot — no DB read.
+	// addNewDSLoop only appends, so the optimistic insertBeforeDS still exists in the
+	// current published list at swap time; the computed index will not collide with
+	// any concurrently-added dataset.
+	candidateIdx, err := computeInsertIdxFromList(dsList, migrationList.insertBeforeDS)
+	if err != nil {
+		return fmt.Errorf("compute candidate dest index: %w", err)
+	}
+	destination := newDataSet(jd.tablePrefix, candidateIdx)
+	jd.logger.Infon(
+		"[[ doCompactDS ]]",
+		logger.NewIntField("pendingJobsCount", int64(migrationList.pendingJobsCount)),
+		logger.NewIntField("migrateFrom", int64(len(migrateFromDatasets))),
+		logger.NewStringField("to", destination.Index),
+		logger.NewStringField("insert before", migrationList.insertBeforeDS.Index),
+	)
+
+	var (
+		l           lock.LockToken
+		lockChan    chan<- lock.LockToken
+		totalCopied int
+	)
+	var lockStart time.Time
+
+	err = jd.withMaintenanceTx(ctx, func(tx *Tx) error {
+		return jd.withDistributedSharedLock(ctx, tx, "schema_migrate", func() error {
+			opPayload, err := jsonrs.Marshal(&journalOpPayloadT{From: migrateFromDatasets, To: destination})
+			if err != nil {
+				return fmt.Errorf("marshal journal payload: %w", err)
+			}
+			opID, err := jd.JournalMarkStartInTx(tx, migrateCopyOperation, opPayload)
+			if err != nil {
+				return fmt.Errorf("mark journal start: %w", err)
+			}
+
+			// Create destination tables BEFORE any source-table lock so the
+			// CREATE TABLE doesn't sit behind concurrent waiters on the source.
+			if err := jd.createDSTablesInTx(ctx, tx, destination); err != nil {
+				return fmt.Errorf("create dataset tables: %w", err)
+			}
+
+			for i, source := range migrationList.migrateFrom {
+				if source.numJobsPending == 0 {
+					jd.logger.Infon(
+						"[[ doCompactDS ]]: No jobs to migrate",
+						logger.NewStringField("from", source.ds.Index),
+						logger.NewStringField("to", destination.Index),
+					)
+					continue
+				}
+				if lockStart.IsZero() {
+					lockStart = time.Now()
+				}
+				// EXCLUSIVE (not ACCESS EXCLUSIVE): blocks INSERT/UPDATE/DELETE on the
+				// status table but allows reads (e.g. v_last_*).
+				if _, err := tx.ExecContext(ctx, fmt.Sprintf(`LOCK TABLE %q IN EXCLUSIVE MODE`, source.ds.JobStatusTable)); err != nil {
+					return fmt.Errorf("exclusive lock status table %s: %w", source.ds.JobStatusTable, err)
+				}
+				// Plant a readonly trigger on the source status table so that any
+				// UpdateJobStatus that lands here AFTER our commit raises RS001 and
+				// gets routed to the new destination via the refreshed dsRangeList.
+				if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+					`CREATE TRIGGER readonlyTableTrg
+					BEFORE INSERT
+					ON %q
+					FOR EACH STATEMENT
+					EXECUTE PROCEDURE %s;`, source.ds.JobStatusTable, pgReadonlyTableExceptionFuncName)); err != nil {
+					return fmt.Errorf("create readonly trigger on %s: %w", source.ds.JobStatusTable, err)
+				}
+				jd.logger.Infon(
+					"[[ doCompactDS ]]: Move",
+					logger.NewStringField("from", source.ds.Index),
+					logger.NewStringField("to", destination.Index),
+				)
+				count, err := jd.migrateJobsInTx(ctx, tx, source.ds, destination)
+				if err != nil {
+					return fmt.Errorf("copying jobs from %s: %w", source.ds.Index, err)
+				}
+				totalCopied += count
+				migrationList.migrateFrom[i].numJobsPending = count
+			}
+
+			if err := jd.createDSIndicesInTx(ctx, tx, destination); err != nil {
+				return fmt.Errorf("creating %v indices: %w", destination, err)
+			}
+
+			// Mark the source datasets with the pre-drop comment in the same TX as
+			// the swap, so that on a crash before the async drop runs, the next
+			// startup's cleanupPreDropTables drops the leftovers and getAllTableNames
+			// keeps them hidden in the meantime.
+			for _, source := range migrateFromDatasets {
+				if err := jd.markPreDropDSInTx(ctx, tx, source); err != nil {
+					return fmt.Errorf("marking pre-drop %s: %w", source.Index, err)
+				}
+			}
+
+			if err := jd.journalMarkDoneInTx(tx, opID); err != nil {
+				return fmt.Errorf("marking journal done: %w", err)
+			}
+			jd.logger.Infon("[[ doCompactDS ]]: Jobs migrated", logger.NewIntField("count", int64(totalCopied)))
+
+			// if nothing was copied, then we don't need the destination dataset at all...
+			if totalCopied == 0 {
+				if err := jd.dropDSInTx(tx, destination); err != nil {
+					return fmt.Errorf("dropping empty destination dataset: %w", err)
+				}
+			}
+
+			if lockStart.IsZero() { // no pending jobs were copied
+				lockStart = time.Now()
+			}
+			// Acquire dsListLock right before COMMIT. The lock window contains no DB
+			// I/O — only COMMIT plus an in-memory swap (no SQL, no lookups).
+			l, lockChan, err = jd.dsListLock.AsyncLockWithCtx(ctx)
+			if err != nil {
+				return fmt.Errorf("acquire dsListLock: %w", err)
+			}
+			return nil
+		})
+	})
+	if l == nil {
+		// The TX failed before we acquired dsListLock; nothing to publish.
+		return err
+	}
+	defer func() {
+		lockChan <- l
+		defer jd.stats.NewTaggedStat("migration_loop_lock", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix}).Since(lockStart)
+	}()
+	if err != nil {
+		return err
+	}
+
+	// Capture the version *before* refreshing — drop entries must record the
+	// pre-swap version so dropDSLoop's wait(through) passes the
+	// `through < currentVersion` check once doRefreshDSRangeList republishes.
+	preSwapVersion := jd.dsList.currentVersion()
+
+	// Update ds list
+	if err := jd.doRefreshDSRangeList(l); err != nil {
+		return fmt.Errorf("refresh ds range list: %w", err)
+	}
+
+	// Enqueue the sources for async drop with the PRE-SWAP version. dropDSLoop
+	// waits for readers at this version to drain before physically dropping.
+	jd.dropDSListLock.Lock()
+	existing := make(map[string]struct{}, len(jd.dropDSList))
+	for _, entry := range jd.dropDSList {
+		existing[entry.ds.Index] = struct{}{}
+	}
+	for _, src := range migrationList.migrateFrom {
+		if _, ok := existing[src.ds.Index]; ok {
+			continue
+		}
+		jd.dropDSList = append(jd.dropDSList, dropDSEntry{ds: src.ds, compacted: src.numJobsPending > 0, version: preSwapVersion})
+	}
+	jd.dropDSListLock.Unlock()
+	jd.dropNotifyPing()
+
+	return nil
+}
+
+// computeInsertIdxFromList computes the destination dataset index for an intra-node
+// compaction using a provided dataset list. Unlike computeNewIdxForIntraNodeMigration,
+// it does not require a dsListLock token because it operates on the caller-supplied
+// snapshot rather than re-reading the list from PG.
+func computeInsertIdxFromList(dList []dataSetT, insertBeforeDS dataSetT) (string, error) {
+	if len(dList) == 0 {
+		return "", fmt.Errorf("empty ds list")
+	}
+	for idx, ds := range dList {
+		if ds.Index == insertBeforeDS.Index {
+			if idx == 0 {
+				return "", fmt.Errorf("cannot insert before first dataset %q", insertBeforeDS.Index)
+			}
+			return computeInsertIdx(dList[idx-1].Index, insertBeforeDS.Index)
+		}
+	}
+	return "", fmt.Errorf("insertBeforeDS %q not found in list", insertBeforeDS.Index)
 }
 
 func (jd *Handle) postMigrateHandleDS(tx *Tx, migrateFrom []dataSetT) error {
@@ -740,7 +972,7 @@ func computeInsertIdx(beforeIndex, afterIndex string) (string, error) {
 // checkIfMigrateDS checks when DB is full or DB needs to be migrated.
 // We migrate the DB ONCE most of the jobs have been processed (succeeded/aborted)
 // Or when the job_status table gets too big because of lots of retries/failures
-func (jd *Handle) checkIfMigrateDS(ds dataSetT) (
+func (jd *Handle) checkIfMigrateDS(ds dataSetT, db sqlDbOrTx) (
 	migrate, needsPair bool, recordsLeft int, err error,
 ) {
 	defer jd.getTimerStat(
@@ -763,7 +995,7 @@ func (jd *Handle) checkIfMigrateDS(ds dataSetT) (
 		select totalJobCount, terminalJobCount, maxCreatedAt, retentionExpired from combinedResult`,
 		ds.JobTable, ds.JobStatusTable)
 
-	if err := jd.dbHandle.QueryRow(
+	if err := db.QueryRow(
 		query,
 		pq.Array(validTerminalStates),
 		time.Now().Add(-1*jd.conf.maxDSRetentionPeriod.Load()),

--- a/jobsdb/migration_test.go
+++ b/jobsdb/migration_test.go
@@ -2,11 +2,13 @@ package jobsdb
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
@@ -711,7 +713,7 @@ func TestMigrationMaxDSSizeGuard(t *testing.T) {
 		dsList := jd.getDSListSnapshot()
 		c.Set("JobsDB."+jd.tablePrefix+"."+"maxMigrateDSProbe", len(dsList))
 
-		result, err := jd.getMigrationList(dsList, nil)
+		result, err := jd.getMigrationList(dsList, nil, jd.maintenanceDB())
 		require.NoError(t, err)
 		require.Len(t, result.migrateFrom, 3)
 		require.Equal(t, 9, result.pendingJobsCount)
@@ -732,7 +734,7 @@ func TestMigrationMaxDSSizeGuard(t *testing.T) {
 		dsList := jd.getDSListSnapshot()
 		c.Set("JobsDB."+jd.tablePrefix+"."+"maxMigrateDSProbe", len(dsList))
 
-		result, err := jd.getMigrationList(dsList, nil)
+		result, err := jd.getMigrationList(dsList, nil, jd.maintenanceDB())
 		require.NoError(t, err)
 		require.Empty(t, result.migrateFrom)
 	})
@@ -794,7 +796,7 @@ func TestMigrationSkipsDatasets(t *testing.T) {
 
 		// Measure first getMigrationList call (full scan, no skip)
 		checkStart := time.Now()
-		checkResult, err := jobDB.getMigrationList(dsList, nil)
+		checkResult, err := jobDB.getMigrationList(dsList, nil, jobDB.maintenanceDB())
 		checkDuration := time.Since(checkStart)
 		require.NoError(t, err)
 		require.NotEmpty(t, checkResult.migrateFrom, "should find eligible datasets")
@@ -802,7 +804,7 @@ func TestMigrationSkipsDatasets(t *testing.T) {
 
 		// Measure second getMigrationList call (with skipBefore from first call)
 		lockCheckStart := time.Now()
-		lockResult, err := jobDB.getMigrationList(dsList, checkResult.firstEligible)
+		lockResult, err := jobDB.getMigrationList(dsList, checkResult.firstEligible, jobDB.maintenanceDB())
 		lockCheckDuration := time.Since(lockCheckStart)
 		require.NoError(t, err)
 		require.NotEmpty(t, lockResult.migrateFrom)
@@ -830,7 +832,7 @@ func TestMigrationSkipsDatasets(t *testing.T) {
 
 		// 1st iteration: probes datasets 1..100, finds nothing, hits probe limit.
 		// Should store lastMigrateProbeIndex for resumption.
-		result1, err := jobDB.getMigrationList(dsList, jobDB.lastMigrateProbeIndex)
+		result1, err := jobDB.getMigrationList(dsList, jobDB.lastMigrateProbeIndex, jobDB.maintenanceDB())
 		require.NoError(t, err)
 		require.Empty(t, result1.migrateFrom, "should not find eligible datasets in first 100")
 		require.True(t, result1.probeLimitReached, "should hit probe limit")
@@ -841,7 +843,7 @@ func TestMigrationSkipsDatasets(t *testing.T) {
 
 		// 2nd iteration: resumes from where the first left off, finds the eligible dataset.
 		resumeStart := time.Now()
-		result2, err := jobDB.getMigrationList(dsList, jobDB.lastMigrateProbeIndex)
+		result2, err := jobDB.getMigrationList(dsList, jobDB.lastMigrateProbeIndex, jobDB.maintenanceDB())
 		resumeDuration := time.Since(resumeStart)
 		require.NoError(t, err)
 		require.NotEmpty(t, result2.migrateFrom, "should find eligible datasets in second iteration")
@@ -850,7 +852,7 @@ func TestMigrationSkipsDatasets(t *testing.T) {
 		// Compare with a full scan from scratch
 		c.Set("JobsDB."+tablePrefix+"."+"maxMigrateDSProbe", totalDS)
 		fullStart := time.Now()
-		resultFull, err := jobDB.getMigrationList(dsList, nil)
+		resultFull, err := jobDB.getMigrationList(dsList, nil, jobDB.maintenanceDB())
 		fullDuration := time.Since(fullStart)
 		require.NoError(t, err)
 		require.NotEmpty(t, resultFull.migrateFrom)
@@ -918,8 +920,9 @@ func TestMigrationNonBlockingCompletedDSDrop(t *testing.T) {
 		return exists
 	}
 
-	t.Run("flag off (default): completed DS dropped in legacy in-tx path", func(t *testing.T) {
-		jd, _ := newJobDB(t)
+	t.Run("flag off: completed DS dropped in legacy in-tx path", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
 		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
 		fillDS(t, jd, jobs, 0) // DS_1 → all 10 succeeded (completed)
 		createDS(t, jd, "2")   // DS_2 → empty last (exempt from migration)
@@ -940,6 +943,7 @@ func TestMigrationNonBlockingCompletedDSDrop(t *testing.T) {
 
 	t.Run("flag on: completed DS routed to async drop list", func(t *testing.T) {
 		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
 		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompletedDSDrop", true)
 
 		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
@@ -981,7 +985,7 @@ func TestMigrationNonBlockingCompletedDSDrop(t *testing.T) {
 
 	t.Run("flag on: DS with pending jobs still migrated through the legacy TX", func(t *testing.T) {
 		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompletedDSDrop", true)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
 		// maxDSRetention=1ms makes DSes with old terminal jobs eligible without the needsPair logic,
 		// so a DS with pending jobs can be migrated alone.
 		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
@@ -1007,6 +1011,7 @@ func TestMigrationNonBlockingCompletedDSDrop(t *testing.T) {
 
 	t.Run("flag on: mixed - completed goes async, pending uses legacy TX", func(t *testing.T) {
 		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
 		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompletedDSDrop", true)
 		// maxDSRetention=1ms lets both DSes appear together in migrateFrom in a single call.
 		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
@@ -1041,6 +1046,8 @@ func TestMigrationNonBlockingCompletedDSDrop(t *testing.T) {
 
 	t.Run("flag toggled at runtime: takes effect on the next migration", func(t *testing.T) {
 		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompletedDSDrop", false)
 
 		allJobs := genJobs(defaultWorkspaceID, "test", 20, 1)
 		fillDS(t, jd, allJobs[:10], 0) // DS_1 completed
@@ -1075,5 +1082,461 @@ func TestMigrationNonBlockingCompletedDSDrop(t *testing.T) {
 		require.Equal(t, completed2.Index, jd.dropDSList[0].ds.Index)
 		jd.dropDSListLock.RUnlock()
 		require.True(t, tableExists(t, jd, completed2), "physical drop blocked by held reader")
+	})
+}
+
+func TestNonBlockingCompaction(t *testing.T) {
+	_ = startPostgres(t)
+
+	// newJobDB mirrors the pattern used by TestMigrationNonBlockingCompletedDSDrop:
+	// the migrate and addNewDS loop triggers are wired to never-firing channels so
+	// the tests drive state changes synchronously.
+	newJobDB := func(t *testing.T) (*Handle, *config.Config) {
+		t.Helper()
+		c := config.New()
+		c.Set("JobsDB.maxDSSize", 100000)
+		jd := &Handle{
+			TriggerAddNewDS:  func() <-chan time.Time { return make(chan time.Time) },
+			TriggerMigrateDS: func() <-chan time.Time { return make(chan time.Time) },
+			config:           c,
+		}
+		require.NoError(t, jd.Setup(ReadWrite, true, strings.ToLower(rand.String(5))))
+		t.Cleanup(jd.TearDown)
+		return jd, c
+	}
+
+	createDS := func(t *testing.T, jd *Handle, idx string) {
+		t.Helper()
+		require.NoError(t, jd.dsListLock.WithLockInCtx(context.Background(), func(l lock.LockToken) error {
+			dsList, _ := jd.dsList.snapshot()
+			if err := jd.WithTx(context.Background(), func(txn *tx.Tx) error {
+				return jd.addNewDSInTx(context.Background(), txn, l, dsList, newDataSet(jd.tablePrefix, idx))
+			}); err != nil {
+				return err
+			}
+			return jd.doRefreshDSRangeList(l)
+		}))
+	}
+
+	fillDS := func(t *testing.T, jd *Handle, jobs []*JobT, pending int) {
+		t.Helper()
+		require.NoError(t, jd.Store(context.Background(), jobs))
+		if terminal := len(jobs) - pending; terminal > 0 {
+			require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[:terminal], "executing")))
+			require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[:terminal], "succeeded")))
+		}
+	}
+
+	tableExists := func(t *testing.T, jd *Handle, ds dataSetT) bool {
+		t.Helper()
+		var exists bool
+		require.NoError(t, jd.dbHandle.QueryRow(`SELECT to_regclass($1) IS NOT NULL`, ds.JobTable).Scan(&exists))
+		return exists
+	}
+
+	hasReadonlyTrigger := func(t *testing.T, jd *Handle, ds dataSetT) bool {
+		t.Helper()
+		var present bool
+		// Trigger name is created via an unquoted identifier so PostgreSQL
+		// folds it to lower case in pg_trigger.tgname.
+		require.NoError(t, jd.dbHandle.QueryRow(
+			`SELECT EXISTS (
+				SELECT 1 FROM pg_trigger t
+				JOIN pg_class c ON c.oid = t.tgrelid
+				WHERE c.relname = $1 AND lower(t.tgname) = 'readonlytabletrg'
+			)`, ds.JobStatusTable).Scan(&present))
+		return present
+	}
+
+	tableMarkedPreDrop := func(t *testing.T, jd *Handle, table string) bool {
+		t.Helper()
+		var marker sql.NullString
+		require.NoError(t, jd.dbHandle.QueryRow(
+			`SELECT obj_description(c.oid, 'pg_class')
+			FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE c.relname = $1 AND n.nspname NOT IN ('pg_catalog','information_schema')`,
+			table).Scan(&marker))
+		return marker.Valid && strings.HasPrefix(marker.String, "rudder:pre_drop:")
+	}
+
+	t.Run("flag off: legacy in-tx drop path is used", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
+		// maxDSRetention=1ms makes a DS with old terminal jobs eligible immediately.
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
+
+		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
+		fillDS(t, jd, jobs, 5) // DS_1: 5 succeeded, 5 pending
+		createDS(t, jd, "2")   // empty last DS
+
+		snapshot := jd.getDSListSnapshot()
+		require.Len(t, snapshot, 2)
+		sourceDS := snapshot[0]
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+
+		require.False(t, tableExists(t, jd, sourceDS), "legacy flow drops source in-TX")
+		jd.dropDSListLock.RLock()
+		require.Empty(t, jd.dropDSList, "legacy flow must not enqueue async drops")
+		jd.dropDSListLock.RUnlock()
+	})
+
+	t.Run("flag on: source goes through async drop with pre-drop marker and readonly trigger", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
+
+		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
+		fillDS(t, jd, jobs, 5) // DS_1: 5 succeeded + 5 pending → copied to dest
+		createDS(t, jd, "2")   // DS_2 empty last DS
+
+		snapshot := jd.getDSListSnapshot()
+		require.Len(t, snapshot, 2)
+		sourceDS := snapshot[0]
+
+		// Hold a reader against the current dsList version so dropDSLoop blocks on the
+		// drain wait — lets us observe the async enqueue, marker, and trigger before
+		// dropDSLoop physically drops.
+		_, _, release, err := jd.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+
+		// Source must be hidden from the published list and replaced with a dest.
+		listIndices := lo.Map(jd.getDSListSnapshot(), func(ds dataSetT, _ int) string { return ds.Index })
+		require.NotContains(t, listIndices, sourceDS.Index, "source DS hidden from new readers")
+		require.Contains(t, listIndices, "1_1", "destination DS published")
+
+		// Source still physically exists (drop is blocked by held reader).
+		require.True(t, tableExists(t, jd, sourceDS), "physical drop must block until held reader releases")
+		require.True(t, hasReadonlyTrigger(t, jd, sourceDS), "readonly trigger must be planted on the source status table")
+		require.True(t, tableMarkedPreDrop(t, jd, sourceDS.JobTable), "source job table must carry pre-drop marker")
+		require.True(t, tableMarkedPreDrop(t, jd, sourceDS.JobStatusTable), "source status table must carry pre-drop marker")
+
+		jd.dropDSListLock.RLock()
+		require.Len(t, jd.dropDSList, 1, "source DS must be enqueued for async drop")
+		require.Equal(t, sourceDS.Index, jd.dropDSList[0].ds.Index)
+		jd.dropDSListLock.RUnlock()
+
+		// Pending jobs must have been copied to the dest.
+		var destJobs int64
+		require.NoError(t, jd.dbHandle.QueryRow(
+			fmt.Sprintf(`SELECT COUNT(*) FROM %q`, jd.tablePrefix+"_jobs_1_1"),
+		).Scan(&destJobs))
+		require.EqualValues(t, 5, destJobs, "non-terminal jobs must be copied to dest")
+
+		release()
+		require.Eventually(t, func() bool {
+			jd.dropDSListLock.RLock()
+			pending := len(jd.dropDSList)
+			jd.dropDSListLock.RUnlock()
+			return !tableExists(t, jd, sourceDS) && pending == 0
+		}, 5*time.Second, 50*time.Millisecond, "source table must be physically dropped once the reader releases")
+	})
+
+	t.Run("flag on: zero-copy compaction drops empty dest but still async-drops source", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
+
+		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
+		fillDS(t, jd, jobs, 5) // DS_1: 5 succeeded + 5 pending at optimistic check time
+		createDS(t, jd, "2")   // DS_2 empty last DS
+
+		snapshot := jd.getDSListSnapshot()
+		require.Len(t, snapshot, 2)
+		sourceDS := snapshot[0]
+		destinationDS := newDataSet(jd.tablePrefix, "1_1")
+
+		// Hold a reader so the source's async physical drop blocks long enough
+		// for this test to inspect the pre-drop marker and dropDSList entry.
+		_, _, releaseReader, err := jd.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+		readerReleased := false
+		defer func() {
+			if !readerReleased {
+				releaseReader()
+			}
+		}()
+
+		// Block compaction after getMigrationList's optimistic pending-count
+		// decision but before the TX copies jobs. doCompactDS takes this shared
+		// advisory lock only after computing migrationList.
+		blocker, err := jd.dbHandle.BeginTx(context.Background(), nil)
+		require.NoError(t, err)
+		defer func() { _ = blocker.Rollback() }()
+		_, err = blocker.ExecContext(
+			context.Background(),
+			`SELECT pg_advisory_xact_lock($1)`,
+			jd.getAdvisoryLockForOperation("schema_migrate"),
+		)
+		require.NoError(t, err)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- jd.doMigrateDS(context.Background())
+		}()
+
+		require.Eventually(t, func() bool {
+			select {
+			case err := <-done:
+				require.NoError(t, err)
+				require.FailNow(t, "migration finished before waiting on schema_migrate advisory lock")
+			default:
+			}
+			var waiting bool
+			require.NoError(t, jd.dbHandle.QueryRow(
+				`SELECT EXISTS (
+						SELECT 1 FROM pg_locks
+						WHERE locktype = 'advisory'
+							AND granted = false
+					)`,
+			).Scan(&waiting))
+			return waiting
+		}, 5*time.Second, 50*time.Millisecond, "migration should block on schema_migrate advisory lock")
+
+		// The optimistic check saw these as pending; before copy time they all
+		// become terminal, so migrateJobsInTx copies zero rows.
+		require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[5:10], "succeeded")))
+
+		require.NoError(t, blocker.Commit())
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "migration did not finish after releasing schema_migrate advisory lock")
+		}
+
+		listIndices := lo.Map(jd.getDSListSnapshot(), func(ds dataSetT, _ int) string { return ds.Index })
+		require.NotContains(t, listIndices, sourceDS.Index, "source DS hidden from new readers")
+		require.NotContains(t, listIndices, destinationDS.Index, "zero-copy destination must not be published")
+		require.False(t, tableExists(t, jd, destinationDS), "zero-copy destination must be dropped in the compaction TX")
+		require.True(t, tableExists(t, jd, sourceDS), "source physical drop must block until held reader releases")
+		require.True(t, tableMarkedPreDrop(t, jd, sourceDS.JobTable), "source job table must carry pre-drop marker")
+		require.True(t, tableMarkedPreDrop(t, jd, sourceDS.JobStatusTable), "source status table must carry pre-drop marker")
+
+		jd.dropDSListLock.RLock()
+		require.Len(t, jd.dropDSList, 1, "source DS must still be enqueued for async drop")
+		require.Equal(t, sourceDS.Index, jd.dropDSList[0].ds.Index)
+		jd.dropDSListLock.RUnlock()
+
+		releaseReader()
+		readerReleased = true
+		require.Eventually(t, func() bool {
+			jd.dropDSListLock.RLock()
+			pending := len(jd.dropDSList)
+			jd.dropDSListLock.RUnlock()
+			return !tableExists(t, jd, sourceDS) && pending == 0
+		}, 5*time.Second, 50*time.Millisecond, "source table must be physically dropped once the reader releases")
+	})
+
+	t.Run("flag on: dsRangeList reflects dest's exact min/max", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
+
+		// Store 20 jobs but mark the first 10 as terminal. Only the last 10
+		// non-terminal jobs (ids 11..20) should land in dest, so the dest's
+		// minJobID must be 11 — verifying we use the actual copied min/max
+		// rather than the original source range.
+		jobs := genJobs(defaultWorkspaceID, "test", 20, 1)
+		fillDS(t, jd, jobs, 10) // 10 succeeded (ids 1..10), 10 pending (ids 11..20)
+		createDS(t, jd, "2")    // empty last DS
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+
+		_, ranges, release, err := jd.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+		defer release()
+
+		var destRange *dataSetRangeT
+		for i := range ranges {
+			if ranges[i].ds.Index == "1_1" {
+				destRange = &ranges[i]
+				break
+			}
+		}
+		require.NotNil(t, destRange, "expected a range entry for dest 1_1")
+		require.EqualValues(t, 11, destRange.minJobID, "dest min must reflect first non-terminal job_id")
+		require.EqualValues(t, 20, destRange.maxJobID, "dest max must reflect last copied job_id")
+	})
+
+	t.Run("flag on: published swap preserves non-migrated DSes in the current list", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
+		// Disable needsPair so DS_2 (non-terminal only) is NOT eligible for migration.
+		// We need DS_2 non-empty so checkIfMigrateDS's created_at scan doesn't trip on NULL.
+		c.Set("JobsDB."+jd.tablePrefix+"."+"jobMinRowsLeftMigrateThreshold", 0.0)
+
+		jobs := genJobs(defaultWorkspaceID, "test", 30, 1)
+		fillDS(t, jd, jobs[:10], 5) // DS_1: 5 succeeded + 5 pending — eligible via retentionExpired
+		createDS(t, jd, "2")
+		fillDS(t, jd, jobs[10:20], 10) // DS_2: 10 non-terminal — ineligible with threshold=0
+		createDS(t, jd, "3")           // empty last DS (exempt via idxCheck)
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+
+		listIndices := lo.Map(jd.getDSListSnapshot(), func(ds dataSetT, _ int) string { return ds.Index })
+		// Source DS_1 was compacted into DS_1_1. DS_2 and DS_3 were not in migrateFrom
+		// and must survive the rebased swap.
+		require.Contains(t, listIndices, "1_1", "dest must be published")
+		require.NotContains(t, listIndices, "1", "source DS_1 must be hidden from the published list")
+		require.Contains(t, listIndices, "2", "non-migrated DS_2 must be preserved")
+		require.Contains(t, listIndices, "3", "non-migrated DS_3 must be preserved")
+	})
+
+	t.Run("flag on: completed-only sources skip the compaction TX and go straight to async drop", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
+		// No maxDSRetention needed: a DS with all-terminal jobs is naturally eligible.
+
+		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
+		fillDS(t, jd, jobs, 0) // DS_1 fully completed
+		createDS(t, jd, "2")   // empty last DS
+
+		snapshot := jd.getDSListSnapshot()
+		require.Len(t, snapshot, 2)
+		completedDS := snapshot[0]
+
+		// Hold a reader to observe the async enqueue before dropDSLoop drains it.
+		_, _, release, err := jd.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+
+		listIndices := lo.Map(jd.getDSListSnapshot(), func(ds dataSetT, _ int) string { return ds.Index })
+		require.NotContains(t, listIndices, completedDS.Index, "completed source hidden from list")
+		require.NotContains(t, listIndices, "1_1", "no destination DS should be created when all sources are completed")
+		jd.dropDSListLock.RLock()
+		require.Len(t, jd.dropDSList, 1)
+		require.Equal(t, completedDS.Index, jd.dropDSList[0].ds.Index)
+		jd.dropDSListLock.RUnlock()
+		require.True(t, tableExists(t, jd, completedDS), "drop blocked by held reader")
+
+		release()
+		require.Eventually(t, func() bool {
+			jd.dropDSListLock.RLock()
+			pending := len(jd.dropDSList)
+			jd.dropDSListLock.RUnlock()
+			return !tableExists(t, jd, completedDS) && pending == 0
+		}, 5*time.Second, 50*time.Millisecond)
+	})
+
+	t.Run("flag on: source status table rejects post-commit inserts with RS001", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
+
+		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
+		fillDS(t, jd, jobs, 5)
+		createDS(t, jd, "2")
+		snapshot := jd.getDSListSnapshot()
+		sourceDS := snapshot[0]
+
+		// Hold a reader so the async drop blocks — the source status table must
+		// remain around (with its planted trigger) so we can probe it directly.
+		_, _, release, err := jd.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+		defer release()
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+
+		// Direct INSERT into the (compacted-away) source status table must trip the
+		// readonly trigger and raise RS001 — proof the trigger fences late writers.
+		_, err = jd.dbHandle.Exec(fmt.Sprintf(
+			`INSERT INTO %q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters)
+			VALUES (1, 'executing', 0, NOW(), NOW(), '', '{}', '{}')`,
+			sourceDS.JobStatusTable))
+		require.Error(t, err, "insert on a compacted source status table must be rejected")
+		var pqErr *pq.Error
+		require.ErrorAs(t, err, &pqErr)
+		require.Equal(t, pgErrorCodeTableReadonly, string(pqErr.Code))
+
+		// Also assert that the regular UpdateJobStatus path (now using the refreshed
+		// dsRangeList) routes status updates to the dest — verifying end-to-end
+		// correctness for the non-blocking flow.
+		require.NoError(t,
+			jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[5:10], "executing")),
+		)
+		var destStatusCount int64
+		require.NoError(t, jd.dbHandle.QueryRow(
+			fmt.Sprintf(`SELECT COUNT(*) FROM %q WHERE job_state = 'executing'`, jd.tablePrefix+"_job_status_1_1"),
+		).Scan(&destStatusCount))
+		require.EqualValues(t, 5, destStatusCount, "status updates must land in dest after compaction")
+	})
+
+	t.Run("flag on: pre-drop marker survives a crash and cleanupPreDropTables drops the source on next startup", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
+
+		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
+		fillDS(t, jd, jobs, 5)
+		createDS(t, jd, "2")
+		snapshot := jd.getDSListSnapshot()
+		sourceDS := snapshot[0]
+
+		// Hold a reader so the async drop cannot run — emulates "process crashed
+		// before dropDSLoop got to it." The pre_drop marker is now on disk.
+		_, _, release, err := jd.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+		require.True(t, tableExists(t, jd, sourceDS), "drop blocked by held reader (simulates crash before drop)")
+		require.True(t, tableMarkedPreDrop(t, jd, sourceDS.JobTable))
+
+		// Call cleanupPreDropTables directly — this is what Start invokes at startup.
+		release()
+		require.NoError(t, jd.cleanupPreDropTables(context.Background()))
+		require.False(t, tableExists(t, jd, sourceDS), "cleanupPreDropTables must drop the marked source table")
+	})
+
+	t.Run("flag toggled at runtime: takes effect on the next migration", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
+		// Disable needsPair so the first migration's dest DS_1_1 isn't pulled back
+		// into the second iteration's migrateFrom (only the freshly-filled DS_2 is).
+		c.Set("JobsDB."+jd.tablePrefix+"."+"jobMinRowsLeftMigrateThreshold", 0.0)
+
+		// Use a single genJobs slice so the local JobID values match the DB-assigned
+		// IDs across both batches (the sequence continues from DS_1's max).
+		allJobs := genJobs(defaultWorkspaceID, "test", 20, 1)
+
+		// First migration with flag OFF → legacy in-TX drop.
+		fillDS(t, jd, allJobs[:10], 5)
+		createDS(t, jd, "2")
+		source1 := jd.getDSListSnapshot()[0]
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+		require.False(t, tableExists(t, jd, source1), "first migration uses legacy in-TX drop")
+		jd.dropDSListLock.RLock()
+		require.Empty(t, jd.dropDSList)
+		jd.dropDSListLock.RUnlock()
+
+		// Flip flag ON; fill the (now last) DS_2 with another batch and add DS_3.
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
+		fillDS(t, jd, allJobs[10:20], 5)
+		createDS(t, jd, "3")
+		snapshot := jd.getDSListSnapshot()
+		var source2 dataSetT
+		for _, ds := range snapshot {
+			if ds.Index == "2" {
+				source2 = ds
+				break
+			}
+		}
+		require.NotEmpty(t, source2.Index)
+
+		_, _, release, err := jd.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+		defer release()
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+		jd.dropDSListLock.RLock()
+		require.NotEmpty(t, jd.dropDSList, "second migration must use the async drop path")
+		jd.dropDSListLock.RUnlock()
+		require.True(t, tableExists(t, jd, source2), "drop blocked by held reader")
+		require.True(t, hasReadonlyTrigger(t, jd, source2), "source must carry readonly trigger after non-blocking compaction")
 	})
 }


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

# Description

Introduces a non-blocking compaction flow for the jobsdb migration loop, gated behind the `nonBlockingCompaction` flag. When enabled it dramatically shrinks the lock window taken during dataset migration:

- **`dsMigrationLock` is no longer taken.** Concurrent readers (`getJobs`, `GetPileUpCounts`, `GetDistinctParameterValues`) are not blocked by an in-flight compaction.
- **Caveat:** an `UpdateJobStatus` call that targets a source dataset *while it is being compacted* will block at the PG level on the `EXCLUSIVE` lock held against that source's status table, until the compaction TX commits — bounded by the per-source `COPY` duration. After commit, late writers landing on the old status table are fenced by the readonly trigger and routed to the new destination via the existing `ErrStaleDsList` retry path.

Compared to the legacy path, the writer side of `dsListLock` is reduced from "entire migration TX, including bulk `COPY` of all non-terminal jobs and `DROP TABLE` of every source" down to "`COMMIT` + a single `getDSList` + a `MIN/MAX` scan of the new destination".

## New maintenance pool

Introducing a new maintenance pool which can be used by maintenance operations, such as:

- adding new dataset
- refreshing dataset list
- compacting datasets
- compacting job status tables

This pool helps closing a connection-pool deadlock vector where jobsdb readers and writers could fully exhaust the pool, blocking an active maintenance goroutine while it still held a mutex (e.g. post-commit compaction which requires acquiring a new connection to refresh the dataset list). In addition, all maintenance goroutines were updated to ensure they require no more than a single connection at any time, eliminating pool-related deadlock risks caused by previously nested connection usage.
If no maintenance pool is injected, the calls fall back to `dbHandle` (backwards compatibility).

## Lock stats

`dsListLock` and `dsMigrationLock` now emit timing metrics, tagged by lock type (`read`/`write`) and whether the acquisition was async:

| Metric | Description |
|---|---|
| `jobsdb_lock_wait_time` | Time spent waiting to acquire the lock |
| `jobsdb_lock_time` | Time the lock was held (excluding wait) |
| `jobsdb_lock_total_time` | End-to-end time (wait + hold) |

All metrics carry a `name` tag so lock contention can be tracked per jobsdb instance.

## Flags

- `JobsDB.<prefix>.nonBlockingCompaction` (default `false`) — gates the new flow. When off, `doMigrateDS` falls back to the legacy in-TX migrate+drop path.
- `JobsDB.<prefix>.getJobsRetryOnCompaction` (default `true`) — gates the `getJobs` snapshot revalidation. When on, if a dataset that `getJobs` queried was compacted mid-read, the call returns `ErrStaleDsList` and is retried against the freshly published list. **Why:** while `getJobs` is reading the source's status table, an `UpdateJobStatus` for one of the same jobs could commit against the new dataset. Without the retry, `getJobs` would miss that status update, risking out-of-order processing downstream. This option has no effect unless `nonBlockingCompaction` is also on.

## Testing
#6979 runs all tests with non-blocking partition migration enabled

## Linear Ticket

resolves PIPE-2997

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #6979 
- <kbd>&nbsp;3&nbsp;</kbd> #6967 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #6962 
- <kbd>&nbsp;1&nbsp;</kbd> #6963 
<!-- GitButler Footer Boundary Bottom -->