### PR TITLE
chore: remove unused sed deletion method from GZIPLocalFileHandler

### DIFF
--- a/regulation-worker/internal/delete/batch/batch.go
+++ b/regulation-worker/internal/delete/batch/batch.go
@@ -462,11 +462,10 @@ func (bm *BatchManager) Delete(
 }
 
 func LocalFileHandlerFactory(dest, upstreamFilePath string) filehandler.LocalFileHandler {
-	nativeDeletion := config.Default.GetBoolVar(true, "gzip.nativeDeletion")
 	switch dest {
 	case "S3":
 		if strings.HasSuffix(upstreamFilePath, ".json.gz") {
-			return filehandler.NewGZIPLocalFileHandler(filehandler.CamelCase, nativeDeletion, []string{"userId"})
+			return filehandler.NewGZIPLocalFileHandler([]string{"userId"})
 		}
 
 	case "S3_DATALAKE":
@@ -475,7 +474,7 @@ func LocalFileHandlerFactory(dest, upstreamFilePath string) filehandler.LocalFil
 		}
 
 		if strings.HasSuffix(upstreamFilePath, ".json.gz") {
-			return filehandler.NewGZIPLocalFileHandler(filehandler.SnakeCase, nativeDeletion, []string{"data", "user_id"})
+			return filehandler.NewGZIPLocalFileHandler([]string{"data", "user_id"})
 		}
 	}
 

--- a/regulation-worker/internal/delete/batch/filehandler/gzip.go
+++ b/regulation-worker/internal/delete/batch/filehandler/gzip.go
@@ -7,9 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"regexp"
-	"strings"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonparser"
 
@@ -17,17 +14,13 @@ import (
 )
 
 type GZIPLocalFileHandler struct {
-	records        []byte
-	casing         Case
-	nativeDeletion bool
-	idFieldPath    []string
+	records     []byte
+	idFieldPath []string
 }
 
-func NewGZIPLocalFileHandler(casing Case, nativeDeletion bool, idFieldPath []string) *GZIPLocalFileHandler {
+func NewGZIPLocalFileHandler(idFieldPath []string) *GZIPLocalFileHandler {
 	return &GZIPLocalFileHandler{
-		casing:         casing,
-		nativeDeletion: nativeDeletion,
-		idFieldPath:    idFieldPath,
+		idFieldPath: idFieldPath,
 	}
 }
 
@@ -76,52 +69,7 @@ func (h *GZIPLocalFileHandler) Write(_ context.Context, path string) error {
 	return nil
 }
 
-func (h *GZIPLocalFileHandler) RemoveIdentity(ctx context.Context, attributes []model.User) error {
-	if h.nativeDeletion {
-		return h.removeIdentityNative(attributes)
-	}
-	return h.removeIdentitySed(ctx, attributes)
-}
-
-func (h *GZIPLocalFileHandler) removeIdentitySed(ctx context.Context, attributes []model.User) error {
-	var filteredContent []byte
-
-	patterns := make([]string, len(attributes))
-	for idx, attribute := range attributes {
-		pattern, err := h.getDeletePattern(attribute)
-		if err != nil {
-			return fmt.Errorf("creating delete pattern for userID: %s, %s", attribute.ID, err.Error())
-		}
-		patterns[idx] = pattern
-	}
-
-	cmd := exec.CommandContext(ctx, "bash", "-c", fmt.Sprintf("sed -r -e %s", strings.Join(patterns, " -e ")))
-	cmd.Stdin = bytes.NewBuffer(h.records)
-	filteredContent, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("filtering the content: %w", err)
-	}
-
-	h.records = filteredContent
-	return nil
-}
-
-func (h *GZIPLocalFileHandler) getDeletePattern(attribute model.User) (string, error) {
-	normalized := regexp.QuoteMeta(attribute.ID)
-	switch h.casing {
-
-	case SnakeCase:
-		return fmt.Sprintf("'/\"user_id\": *\"%s\"/d'", normalized), nil
-	case CamelCase:
-		return fmt.Sprintf("'/\"userId\": *\"%s\"/d'", normalized), nil
-	case UpperCase:
-		return fmt.Sprintf("'/\"USER_ID\": *\"%s\"/d'", normalized), nil
-	default:
-		return "", fmt.Errorf("casing value: %v supplied not in list of supported cases", h.casing)
-	}
-}
-
-func (h *GZIPLocalFileHandler) removeIdentityNative(attributes []model.User) error {
+func (h *GZIPLocalFileHandler) RemoveIdentity(_ context.Context, attributes []model.User) error {
 	if len(h.idFieldPath) == 0 {
 		return fmt.Errorf("id field path cannot be empty for native deletion")
 	}

--- a/regulation-worker/internal/delete/batch/filehandler/gzip_test.go
+++ b/regulation-worker/internal/delete/batch/filehandler/gzip_test.go
@@ -1,9 +1,7 @@
 package filehandler
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,213 +9,9 @@ import (
 	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
 )
 
-func TestRemoveIdentityRecordsFromGZIPFileWithReseredKeywords(t *testing.T) {
-	inputs := []struct {
-		casing       Case
-		userID       string
-		inputByte    []byte
-		expectedByte []byte
-	}{
-		{
-			CamelCase,
-			"!@#$%^&*()***",
-			[]byte("{\"userId\": \"!@#$%^&*()***\", \"context-app-name\": \"my-app-name\"}\n"),
-			[]byte(""),
-		},
-		{
-			CamelCase,
-			"abc.",
-			[]byte("{\"userId\":\"abc1\"}\n{\"userId\":\"abc.\"}\n"),
-			[]byte("{\"userId\":\"abc1\"}\n"),
-		},
-	}
-
-	for _, ip := range inputs {
-		h := NewGZIPLocalFileHandler(ip.casing, false, nil)
-
-		h.records = ip.inputByte
-		fmt.Println(h.getDeletePattern(model.User{ID: ip.userID}))
-		err := h.RemoveIdentity(context.TODO(), []model.User{{ID: ip.userID}})
-		require.Nil(t, err)
-		fmt.Println(string(h.records))
-		require.Equal(t, true, bytes.Equal(h.records, ip.expectedByte))
-	}
-}
-
-func TestRemoveIdentityRecordsFromGZIPFileWithSingleUserId(t *testing.T) {
-	inputs := []struct {
-		casing       Case
-		userID       string
-		inputByte    []byte
-		expectedByte []byte
-	}{
-		{
-			CamelCase,
-			"my-another-user-id",
-			[]byte("{\"userId\": \"my-user-id\", \"context-app-name\": \"my-app-name\"}\n{\"userId\": \"my-another-user-id\"}\n"),
-			[]byte("{\"userId\": \"my-user-id\", \"context-app-name\": \"my-app-name\"}\n"),
-		},
-		{
-			CamelCase,
-			"my-user-id",
-			[]byte("{\"userId\": \"my-user-id\"}\n"),
-			[]byte(""),
-		},
-		{
-			CamelCase,
-			"valid-user-id",
-			[]byte("{\"userId\": \"invalid-user-id\"}\n"),
-			[]byte("{\"userId\": \"invalid-user-id\"}\n"),
-		},
-		{
-			SnakeCase,
-			"my-another-user-id",
-			[]byte("{\"user_id\": \"my-user-id\", \"context-app-name\": \"my-app-name\"}\n{\"user_id\": \"my-another-user-id\"}\n"),
-			[]byte("{\"user_id\": \"my-user-id\", \"context-app-name\": \"my-app-name\"}\n"),
-		},
-		{
-			SnakeCase,
-			"my-user-id",
-			[]byte("{\"user_id\": \"my-user-id\"}\n"),
-			[]byte(""),
-		},
-		{
-			SnakeCase,
-			"valid-user-id",
-			[]byte("{\"user_id\": \"invalid-user-id\"}\n"),
-			[]byte("{\"user_id\": \"invalid-user-id\"}\n"),
-		},
-		{
-			SnakeCase,
-			"my-.-user-id",
-			[]byte("{\"user_id\": \"my-.-user-id\"}\n"),
-			[]byte(""), // This change uses regex variables in matched string
-		},
-		{
-			SnakeCase,
-			"",
-			[]byte("{\"user_id\": \"my-^-user-id\"}\n"),
-			[]byte("{\"user_id\": \"my-^-user-id\"}\n"),
-		},
-	}
-
-	for _, ip := range inputs {
-		h := NewGZIPLocalFileHandler(ip.casing, false, nil)
-
-		h.records = ip.inputByte
-		err := h.RemoveIdentity(context.TODO(), []model.User{{ID: ip.userID}})
-		require.Nil(t, err)
-		require.Equal(t, string(h.records), string(ip.expectedByte))
-	}
-}
-
-func TestRemoveIdentityRecordsFromGZIPByMultipleUserId(t *testing.T) {
-	inputs := []struct {
-		casing       Case
-		userIds      []model.User
-		inputByte    []byte
-		expectedByte []byte
-	}{
-		{
-			casing: SnakeCase,
-			userIds: []model.User{
-				{ID: "user-id-1"},
-				{ID: "user-id-3"},
-			},
-			inputByte:    []byte("{\"user_id\": \"user-id-1\"}\n{\"user_id\": \"user-id-2\"}\n{\"user_id\": \"user-id-3\"}\n"),
-			expectedByte: []byte("{\"user_id\": \"user-id-2\"}\n"),
-		},
-
-		{
-			casing: CamelCase,
-			userIds: []model.User{
-				{ID: "user-id-1"},
-				{ID: "user-id-3"},
-			},
-			inputByte:    []byte("{\"userId\": \"user-id-1\"}\n{\"userId\": \"user-id-2\"}\n{\"userId\": \"user-id-3\"}\n"),
-			expectedByte: []byte("{\"userId\": \"user-id-2\"}\n"),
-		},
-	}
-
-	for _, ip := range inputs {
-
-		h := NewGZIPLocalFileHandler(ip.casing, false, nil)
-		h.records = ip.inputByte
-		err := h.RemoveIdentity(context.TODO(), ip.userIds)
-		require.Nil(t, err)
-		require.Equal(t, true, bytes.Equal(h.records, ip.expectedByte))
-	}
-}
-
-func TestIdentityDeletePattern(t *testing.T) {
-	inputs := []struct {
-		casing          Case
-		userId          string
-		expectedPattern string
-	}{
-		{
-			CamelCase,
-			"my-user-id",
-			"'/\"userId\": *\"my-user-id\"/d'",
-		},
-		{
-			CamelCase,
-			"!@#$%^&*()***",
-			"'/\"userId\": *\"!@#\\$%\\^&\\*\\(\\)\\*\\*\\*\"/d'",
-		},
-		{
-			SnakeCase,
-			"my-user-id",
-			"'/\"user_id\": *\"my-user-id\"/d'",
-		},
-		{
-			SnakeCase,
-			"my-^-user-id",
-			"'/\"user_id\": *\"my-\\^-user-id\"/d'",
-		},
-		{
-			SnakeCase,
-			"!@#$%^&*()***",
-			"'/\"user_id\": *\"!@#\\$%\\^&\\*\\(\\)\\*\\*\\*\"/d'",
-		},
-	}
-
-	for _, ip := range inputs {
-		h := NewGZIPLocalFileHandler(ip.casing, false, nil)
-		actualPattern, err := h.getDeletePattern(model.User{ID: ip.userId})
-		require.Nil(t, err)
-		require.Equal(t, ip.expectedPattern, actualPattern)
-	}
-}
-
-func TestIdentityRemovalProcessSucceeds(t *testing.T) {
-	ctx := context.TODO()
-
-	manager := NewGZIPLocalFileHandler(SnakeCase, false, nil)
-	inputFile := "testdata/test_tracks.json.gz"
-	actualOutputFile := "testdata/actual_test_tracks_filtered.json.gz"
-	expectedOutputFile := "testdata/expected_test_tracks_filtered.json.gz"
-
-	err := manager.Read(ctx, inputFile)
-	require.Nil(t, err)
-
-	err = manager.RemoveIdentity(ctx, []model.User{{ID: "68108b4d-245f-4aba-b240-8fb107c9d7b2"}})
-	require.Nil(t, err)
-
-	err = manager.Write(ctx, actualOutputFile)
-	require.Nil(t, err)
-
-	defer cleanupFile(actualOutputFile)
-
-	same, err := sameFiles(expectedOutputFile, actualOutputFile)
-	require.Nil(t, err)
-	require.True(t, same)
-}
-
-func TestRemoveIdentityNativeSingleUser(t *testing.T) {
+func TestRemoveIdentitySingleUser(t *testing.T) {
 	inputs := []struct {
 		name         string
-		casing       Case
 		idFieldPath  []string
 		userID       string
 		inputByte    []byte
@@ -225,7 +19,6 @@ func TestRemoveIdentityNativeSingleUser(t *testing.T) {
 	}{
 		{
 			name:         "CamelCase top-level userId match",
-			casing:       CamelCase,
 			idFieldPath:  []string{"userId"},
 			userID:       "my-user-id",
 			inputByte:    []byte("{\"userId\": \"my-user-id\"}\n"),
@@ -233,7 +26,6 @@ func TestRemoveIdentityNativeSingleUser(t *testing.T) {
 		},
 		{
 			name:         "CamelCase top-level userId no match",
-			casing:       CamelCase,
 			idFieldPath:  []string{"userId"},
 			userID:       "other-id",
 			inputByte:    []byte("{\"userId\": \"my-user-id\"}\n"),
@@ -241,7 +33,6 @@ func TestRemoveIdentityNativeSingleUser(t *testing.T) {
 		},
 		{
 			name:         "CamelCase multiple lines removes matching",
-			casing:       CamelCase,
 			idFieldPath:  []string{"userId"},
 			userID:       "my-another-user-id",
 			inputByte:    []byte("{\"userId\": \"my-user-id\", \"context-app-name\": \"my-app-name\"}\n{\"userId\": \"my-another-user-id\"}\n"),
@@ -249,7 +40,6 @@ func TestRemoveIdentityNativeSingleUser(t *testing.T) {
 		},
 		{
 			name:         "CamelCase special characters in userId",
-			casing:       CamelCase,
 			idFieldPath:  []string{"userId"},
 			userID:       "!@#$%^&*()",
 			inputByte:    []byte("{\"userId\": \"!@#$%^&*()\"}\n"),
@@ -257,7 +47,6 @@ func TestRemoveIdentityNativeSingleUser(t *testing.T) {
 		},
 		{
 			name:         "SnakeCase nested data.user_id match",
-			casing:       SnakeCase,
 			idFieldPath:  []string{"data", "user_id"},
 			userID:       "my-user-id",
 			inputByte:    []byte("{\"data\": {\"user_id\": \"my-user-id\"}}\n"),
@@ -265,7 +54,6 @@ func TestRemoveIdentityNativeSingleUser(t *testing.T) {
 		},
 		{
 			name:         "SnakeCase nested data.user_id no match",
-			casing:       SnakeCase,
 			idFieldPath:  []string{"data", "user_id"},
 			userID:       "other-id",
 			inputByte:    []byte("{\"data\": {\"user_id\": \"my-user-id\"}}\n"),
@@ -273,7 +61,6 @@ func TestRemoveIdentityNativeSingleUser(t *testing.T) {
 		},
 		{
 			name:         "SnakeCase multiple lines removes matching",
-			casing:       SnakeCase,
 			idFieldPath:  []string{"data", "user_id"},
 			userID:       "user-id-2",
 			inputByte:    []byte("{\"data\": {\"user_id\": \"user-id-1\"}}\n{\"data\": {\"user_id\": \"user-id-2\"}}\n"),
@@ -283,7 +70,7 @@ func TestRemoveIdentityNativeSingleUser(t *testing.T) {
 
 	for _, ip := range inputs {
 		t.Run(ip.name, func(t *testing.T) {
-			h := NewGZIPLocalFileHandler(ip.casing, true, ip.idFieldPath)
+			h := NewGZIPLocalFileHandler(ip.idFieldPath)
 			h.records = ip.inputByte
 			err := h.RemoveIdentity(context.TODO(), []model.User{{ID: ip.userID}})
 			require.NoError(t, err)
@@ -292,10 +79,9 @@ func TestRemoveIdentityNativeSingleUser(t *testing.T) {
 	}
 }
 
-func TestRemoveIdentityNativeMultipleUsers(t *testing.T) {
+func TestRemoveIdentityMultipleUsers(t *testing.T) {
 	inputs := []struct {
 		name         string
-		casing       Case
 		idFieldPath  []string
 		userIds      []model.User
 		inputByte    []byte
@@ -303,7 +89,6 @@ func TestRemoveIdentityNativeMultipleUsers(t *testing.T) {
 	}{
 		{
 			name:        "CamelCase remove multiple users",
-			casing:      CamelCase,
 			idFieldPath: []string{"userId"},
 			userIds: []model.User{
 				{ID: "user-id-1"},
@@ -314,7 +99,6 @@ func TestRemoveIdentityNativeMultipleUsers(t *testing.T) {
 		},
 		{
 			name:        "SnakeCase remove multiple users from nested data",
-			casing:      SnakeCase,
 			idFieldPath: []string{"data", "user_id"},
 			userIds: []model.User{
 				{ID: "user-id-1"},
@@ -327,7 +111,7 @@ func TestRemoveIdentityNativeMultipleUsers(t *testing.T) {
 
 	for _, ip := range inputs {
 		t.Run(ip.name, func(t *testing.T) {
-			h := NewGZIPLocalFileHandler(ip.casing, true, ip.idFieldPath)
+			h := NewGZIPLocalFileHandler(ip.idFieldPath)
 			h.records = ip.inputByte
 			err := h.RemoveIdentity(context.TODO(), ip.userIds)
 			require.NoError(t, err)

--- a/regulation-worker/internal/delete/batch/filehandler/local_file.go
+++ b/regulation-worker/internal/delete/batch/filehandler/local_file.go
@@ -6,14 +6,6 @@ import (
 	"github.com/rudderlabs/rudder-server/regulation-worker/internal/model"
 )
 
-type Case uint
-
-const (
-	SnakeCase = iota
-	CamelCase
-	UpperCase
-)
-
 type LocalFileHandler interface {
 	Read(ctx context.Context, path string) error
 	RemoveIdentity(ctx context.Context, attributes []model.User) error


### PR DESCRIPTION
# Description

The vulnerable RCE path in regulation-worker for the GDPR batch deletion flow is currently behind a feature flag. The old code should be removed entirely so this is not one misconfiguration away from RCE.

## Linear Ticket

pipe-2939

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
