### PR TITLE
feat: per-workspace PyT routing + cold-start handling

### DIFF
--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -48,6 +48,8 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) 
 	handle.client = transformerclient.NewClient("UserTransformer", transformerutils.TransformerClientConfig(conf, "UserTransformer"))
 	handle.config.userTransformationURL = handle.conf.GetStringVar(handle.conf.GetStringVar("http://localhost:9090", "DEST_TRANSFORM_URL"), "USER_TRANSFORM_URL")
 	handle.config.pythonTransformationURL = handle.conf.GetStringVar("", "PYTHON_TRANSFORM_URL")
+	handle.config.perWorkspacePyTEnabled = handle.conf.GetBoolVar(false, "Processor.UserTransformer.perWorkspacePyTEnabled")
+	handle.config.perWorkspacePyTURLTemplate = handle.conf.GetStringVar("http://pyt-{workspaceID}:9090", "Processor.UserTransformer.perWorkspacePyTURLTemplate")
 	handle.config.pythonTransformConfig = transformerutils.LoadPythonTransformConfig(conf)
 	handle.config.timeoutDuration = conf.GetDurationVar(600, time.Second, "HttpClient.procTransformer.timeout")
 	handle.config.failOnUserTransformTimeout = conf.GetReloadableBoolVar(false, "Processor.UserTransformer.failOnUserTransformTimeout", "Processor.Transformer.failOnUserTransformTimeout")
@@ -84,6 +86,8 @@ type Client struct {
 		timeoutDuration            time.Duration
 		collectInstanceLevelStats  bool
 		batchSize                  config.ValueLoader[int]
+		perWorkspacePyTEnabled     bool
+		perWorkspacePyTURLTemplate string
 	}
 	conf   *config.Config
 	log    logger.Logger
@@ -97,7 +101,11 @@ func (u *Client) Transform(ctx context.Context, clientEvents []types.Transformer
 	}
 	batchSize := u.config.batchSize.Load()
 	transformationLanguage, transformationVersionID, transformationID := transformerutils.GetTransformationInfo(clientEvents)
-	userURL := u.userTransformURL(transformationLanguage, transformationVersionID)
+	workspaceID := ""
+	if len(clientEvents) > 0 {
+		workspaceID = clientEvents[0].Metadata.WorkspaceID
+	}
+	userURL := u.userTransformURL(transformationLanguage, transformationVersionID, workspaceID)
 
 	labels := types.TransformerMetricLabels{
 		Endpoint:         transformerutils.GetEndpointFromURL(userURL),
@@ -409,10 +417,16 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 	return respData, resp.StatusCode, nil
 }
 
-func (u *Client) userTransformURL(language, versionID string) string {
+func (u *Client) userTransformURL(language, versionID, workspaceID string) string {
 	isPython := strings.HasPrefix(language, "python")
-	if isPython && u.config.pythonTransformConfig.IsVersionAllowed(versionID) && u.config.pythonTransformationURL != "" {
-		return u.config.pythonTransformationURL + "/customTransform"
+	if isPython && u.config.pythonTransformConfig.IsVersionAllowed(versionID) {
+		if u.config.perWorkspacePyTEnabled && !u.config.forMirroring && workspaceID != "" {
+			base := strings.ReplaceAll(u.config.perWorkspacePyTURLTemplate, "{workspaceID}", workspaceID)
+			return base + "/customTransform"
+		}
+		if u.config.pythonTransformationURL != "" {
+			return u.config.pythonTransformationURL + "/customTransform"
+		}
 	}
 	return u.config.userTransformationURL + "/customTransform"
 }

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -362,11 +362,7 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 			u.stat.NewTaggedStat("transformer_client_total_durations_seconds", stats.CountType, tags).Count(int(duration.Seconds()))
 
 			// This metric is to track cold start errors for PyT, which are expected to be higher than usual due to the nature of PyT scaling.
-			if u.config.perWorkspacePyTEnabled &&
-				!u.config.forMirroring &&
-				strings.HasPrefix(labels.Language, "python") &&
-				labels.WorkspaceID != "" &&
-				isColdStartError(reqErr, resp) {
+			if u.shouldThrowPythonColdStartErr(labels, reqErr, resp) {
 				u.stat.NewTaggedStat(
 					"processor_user_transformer_cold_start_errors_total",
 					stats.CountType,
@@ -425,17 +421,17 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 	if err != nil {
 		u.log.Errorn("User transformation post error",
 			append(labels.ToLoggerFields(), obskit.Error(err))...)
-		if u.config.failOnUserTransformTimeout.Load() && os.IsTimeout(err) {
-			return fmt.Appendf(nil, "transformer request timed out: %s", err), transformerutils.TransformerRequestTimeout, nil
-		} else if u.config.failOnError.Load() {
-			return fmt.Appendf(nil, "transformer request failed: %s", err), transformerutils.TransformerRequestFailure, nil
-		}
 		// Per-workspace PyT: a persistent transport failure on the workspace-
 		// scoped URL is most likely a cold-start window (pod not yet scaled by
 		// HPA, EndpointSlice lag, kube-proxy 5xx). Surface a dedicated status
 		// code so sendBatch retries the whole call until the pod is up instead of treating it as a failed transformation.
 		if errors.Is(err, transformerutils.ErrColdStart) {
 			return fmt.Appendf(nil, "workspace transformer not reachable: %s", err), transformerutils.StatusColdStartWindowFailure, nil
+		}
+		if u.config.failOnUserTransformTimeout.Load() && os.IsTimeout(err) {
+			return fmt.Appendf(nil, "transformer request timed out: %s", err), transformerutils.TransformerRequestTimeout, nil
+		} else if u.config.failOnError.Load() {
+			return fmt.Appendf(nil, "transformer request failed: %s", err), transformerutils.TransformerRequestFailure, nil
 		}
 		return nil, 0, err
 	}
@@ -451,6 +447,14 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 	}
 
 	return respData, resp.StatusCode, nil
+}
+
+func (u *Client) shouldThrowPythonColdStartErr(labels types.TransformerMetricLabels, err error, resp *http.Response) bool {
+	return u.config.perWorkspacePyTEnabled &&
+		!u.config.forMirroring &&
+		strings.HasPrefix(labels.Language, "python") &&
+		labels.WorkspaceID != "" &&
+		isColdStartError(err, resp)
 }
 
 // isColdStartError returns true for transient errors that mean the target

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -52,7 +52,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) 
 	handle.config.userTransformationURL = handle.conf.GetStringVar(handle.conf.GetStringVar("http://localhost:9090", "DEST_TRANSFORM_URL"), "USER_TRANSFORM_URL")
 	handle.config.pythonTransformationURL = handle.conf.GetStringVar("", "PYTHON_TRANSFORM_URL")
 	handle.config.perWorkspacePyTEnabled = handle.conf.GetBoolVar(false, "Processor.UserTransformer.perWorkspacePyTEnabled")
-	handle.config.perWorkspacePyTURLTemplate = handle.conf.GetStringVar("http://pyt-{workspaceID}:9090", "Processor.UserTransformer.perWorkspacePyTURLTemplate")
+	handle.config.perWorkspacePyTURLTemplate = handle.conf.GetStringVar("http://pyt-{workspaceID}:8080", "Processor.UserTransformer.perWorkspacePyTURLTemplate")
 	handle.config.perWorkspacePyTEndlessRetries = handle.conf.GetReloadableBoolVar(true, "Processor.UserTransformer.perWorkspacePyTEndlessRetries")
 	handle.config.pythonTransformConfig = transformerutils.LoadPythonTransformConfig(conf)
 	handle.config.timeoutDuration = conf.GetDurationVar(600, time.Second, "HttpClient.procTransformer.timeout")
@@ -481,7 +481,11 @@ func isColdStartError(err error, resp *http.Response) bool {
 func (u *Client) userTransformURL(language, versionID, workspaceID string) string {
 	isPython := strings.HasPrefix(language, "python")
 	if isPython && u.config.pythonTransformConfig.IsVersionAllowed(versionID) {
-		if u.config.perWorkspacePyTEnabled && !u.config.forMirroring && workspaceID != "" {
+		if u.config.perWorkspacePyTEnabled && !u.config.forMirroring {
+			if workspaceID == "" {
+				// This should not happen, Panic so the bug surfaces immediately
+				panic("per-workspace PyT enabled but workspaceID is empty")
+			}
 			base := strings.ReplaceAll(u.config.perWorkspacePyTURLTemplate, "{workspaceID}", strings.ToLower(workspaceID))
 			return base + "/customTransform"
 		}

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -3,13 +3,16 @@ package user_transformer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
@@ -50,6 +53,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) 
 	handle.config.pythonTransformationURL = handle.conf.GetStringVar("", "PYTHON_TRANSFORM_URL")
 	handle.config.perWorkspacePyTEnabled = handle.conf.GetBoolVar(false, "Processor.UserTransformer.perWorkspacePyTEnabled")
 	handle.config.perWorkspacePyTURLTemplate = handle.conf.GetStringVar("http://pyt-{workspaceID}:9090", "Processor.UserTransformer.perWorkspacePyTURLTemplate")
+	handle.config.perWorkspacePyTEndlessRetries = handle.conf.GetReloadableBoolVar(true, "Processor.UserTransformer.perWorkspacePyTEndlessRetries")
 	handle.config.pythonTransformConfig = transformerutils.LoadPythonTransformConfig(conf)
 	handle.config.timeoutDuration = conf.GetDurationVar(600, time.Second, "HttpClient.procTransformer.timeout")
 	handle.config.failOnUserTransformTimeout = conf.GetReloadableBoolVar(false, "Processor.UserTransformer.failOnUserTransformTimeout", "Processor.Transformer.failOnUserTransformTimeout")
@@ -74,20 +78,21 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) 
 
 type Client struct {
 	config struct {
-		userTransformationURL      string
-		pythonTransformationURL    string
-		pythonTransformConfig      transformerutils.PythonTransformConfig
-		forMirroring               bool
-		maxRetry                   config.ValueLoader[int]
-		cpDownEndlessRetries       config.ValueLoader[bool]
-		failOnUserTransformTimeout config.ValueLoader[bool]
-		failOnError                config.ValueLoader[bool]
-		maxRetryBackoffInterval    config.ValueLoader[time.Duration]
-		timeoutDuration            time.Duration
-		collectInstanceLevelStats  bool
-		batchSize                  config.ValueLoader[int]
-		perWorkspacePyTEnabled     bool
-		perWorkspacePyTURLTemplate string
+		userTransformationURL         string
+		pythonTransformationURL       string
+		pythonTransformConfig         transformerutils.PythonTransformConfig
+		forMirroring                  bool
+		maxRetry                      config.ValueLoader[int]
+		cpDownEndlessRetries          config.ValueLoader[bool]
+		failOnUserTransformTimeout    config.ValueLoader[bool]
+		failOnError                   config.ValueLoader[bool]
+		maxRetryBackoffInterval       config.ValueLoader[time.Duration]
+		timeoutDuration               time.Duration
+		collectInstanceLevelStats     bool
+		batchSize                     config.ValueLoader[int]
+		perWorkspacePyTEnabled        bool
+		perWorkspacePyTURLTemplate    string
+		perWorkspacePyTEndlessRetries config.ValueLoader[bool]
 	}
 	conf   *config.Config
 	log    logger.Logger
@@ -256,9 +261,6 @@ func (u *Client) sendBatch(
 			)
 		}),
 	}
-	if !u.config.cpDownEndlessRetries.Load() {
-		retryOptions = append(retryOptions, backoff.WithMaxTries(uint(u.config.maxRetry.Load()+1)))
-	}
 	_ = backoffvoid.Retry(
 		context.Background(),
 		func() error {
@@ -268,9 +270,18 @@ func (u *Client) sendBatch(
 			}
 			if statusCode == transformerutils.StatusCPDown {
 				u.stat.NewStat("processor_control_plane_down", stats.GaugeType).Gauge(1)
+				if !u.config.cpDownEndlessRetries.Load() {
+					return backoff.Permanent(fmt.Errorf("control plane not reachable"))
+				}
 				return fmt.Errorf("control plane not reachable")
 			}
 			u.stat.NewStat("processor_control_plane_down", stats.GaugeType).Gauge(0)
+			if statusCode == transformerutils.StatusColdStartWindowFailure {
+				if !u.config.perWorkspacePyTEndlessRetries.Load() {
+					return backoff.Permanent(fmt.Errorf("cold start error for transformer"))
+				}
+				return fmt.Errorf("cold start window error for transformer")
+			}
 			return nil
 		},
 		retryOptions...,
@@ -350,6 +361,24 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 			u.stat.NewTaggedStat("transformer_client_request_total_bytes", stats.CountType, tags).Count(len(rawJSON))
 			u.stat.NewTaggedStat("transformer_client_total_durations_seconds", stats.CountType, tags).Count(int(duration.Seconds()))
 
+			// This metric is to track cold start errors for PyT, which are expected to be higher than usual due to the nature of PyT scaling.
+			if u.config.perWorkspacePyTEnabled &&
+				!u.config.forMirroring &&
+				strings.HasPrefix(labels.Language, "python") &&
+				labels.WorkspaceID != "" &&
+				isColdStartError(reqErr, resp) {
+				u.stat.NewTaggedStat(
+					"processor_user_transformer_cold_start_errors_total",
+					stats.CountType,
+					stats.Tags{
+						"workspaceID": labels.WorkspaceID,
+						"language":    "python",
+					},
+				).Increment()
+				u.log.Warnn("cold start error when connecting to workspace transformer", labels.ToLoggerFields()...)
+				return transformerutils.ColdStartError
+			}
+
 			if reqErr != nil {
 				return reqErr
 			}
@@ -401,6 +430,13 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 		} else if u.config.failOnError.Load() {
 			return fmt.Appendf(nil, "transformer request failed: %s", err), transformerutils.TransformerRequestFailure, nil
 		}
+		// Per-workspace PyT: a persistent transport failure on the workspace-
+		// scoped URL is most likely a cold-start window (pod not yet scaled by
+		// HPA, EndpointSlice lag, kube-proxy 5xx). Surface a dedicated status
+		// code so sendBatch retries the whole call until the pod is up instead of treating it as a failed transformation.
+		if errors.Is(err, transformerutils.ColdStartError) && u.config.perWorkspacePyTEnabled && !u.config.forMirroring {
+			return fmt.Appendf(nil, "workspace transformer not reachable: %s", err), transformerutils.StatusColdStartWindowFailure, nil
+		}
 		return nil, 0, err
 	}
 
@@ -415,6 +451,27 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 	}
 
 	return respData, resp.StatusCode, nil
+}
+
+// isColdStartError returns true for transient errors that mean the target
+// PyT deployment isn't ready yet — zero endpoints, pod not yet ready, or
+// kube-proxy returning a no-endpoints status.
+func isColdStartError(err error, resp *http.Response) bool {
+	if err != nil {
+		if errors.Is(err, syscall.ECONNREFUSED) {
+			return true
+		}
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) {
+			return true
+		}
+		return false
+	}
+	if resp != nil && (resp.StatusCode == http.StatusServiceUnavailable ||
+		resp.StatusCode == http.StatusBadGateway) {
+		return true
+	}
+	return false
 }
 
 func (u *Client) userTransformURL(language, versionID, workspaceID string) string {

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -376,7 +376,7 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 					},
 				).Increment()
 				u.log.Warnn("cold start error when connecting to workspace transformer", labels.ToLoggerFields()...)
-				return transformerutils.ColdStartError
+				return transformerutils.ErrColdStart
 			}
 
 			if reqErr != nil {
@@ -434,7 +434,7 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 		// scoped URL is most likely a cold-start window (pod not yet scaled by
 		// HPA, EndpointSlice lag, kube-proxy 5xx). Surface a dedicated status
 		// code so sendBatch retries the whole call until the pod is up instead of treating it as a failed transformation.
-		if errors.Is(err, transformerutils.ColdStartError) && u.config.perWorkspacePyTEnabled && !u.config.forMirroring {
+		if errors.Is(err, transformerutils.ErrColdStart) {
 			return fmt.Appendf(nil, "workspace transformer not reachable: %s", err), transformerutils.StatusColdStartWindowFailure, nil
 		}
 		return nil, 0, err
@@ -462,10 +462,7 @@ func isColdStartError(err error, resp *http.Response) bool {
 			return true
 		}
 		var dnsErr *net.DNSError
-		if errors.As(err, &dnsErr) {
-			return true
-		}
-		return false
+		return errors.As(err, &dnsErr)
 	}
 	if resp != nil && (resp.StatusCode == http.StatusServiceUnavailable ||
 		resp.StatusCode == http.StatusBadGateway) {

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -449,12 +449,18 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 	return respData, resp.StatusCode, nil
 }
 
-func (u *Client) shouldThrowPythonColdStartErr(labels types.TransformerMetricLabels, err error, resp *http.Response) bool {
+// isPerWorkspacePyTPath returns true when the request is targeting the
+// per-workspace PyT URL. Single source of truth shared by URL resolution and
+// the cold-start error / counter path so the two can't drift.
+func (u *Client) isPerWorkspacePyTPath(language, workspaceID string) bool {
 	return u.config.perWorkspacePyTEnabled &&
 		!u.config.forMirroring &&
-		strings.HasPrefix(labels.Language, "python") &&
-		labels.WorkspaceID != "" &&
-		isColdStartError(err, resp)
+		strings.HasPrefix(language, "python") &&
+		workspaceID != ""
+}
+
+func (u *Client) shouldThrowPythonColdStartErr(labels types.TransformerMetricLabels, err error, resp *http.Response) bool {
+	return u.isPerWorkspacePyTPath(labels.Language, labels.WorkspaceID) && isColdStartError(err, resp)
 }
 
 // isColdStartError returns true for transient errors that mean the target
@@ -479,19 +485,22 @@ func isColdStartError(err error, resp *http.Response) bool {
 }
 
 func (u *Client) userTransformURL(language, versionID, workspaceID string) string {
-	isPython := strings.HasPrefix(language, "python")
-	if isPython && u.config.pythonTransformConfig.IsVersionAllowed(versionID) {
-		if u.config.perWorkspacePyTEnabled && !u.config.forMirroring {
-			if workspaceID == "" {
-				// This should not happen, Panic so the bug surfaces immediately
-				panic("per-workspace PyT enabled but workspaceID is empty")
-			}
-			base := strings.ReplaceAll(u.config.perWorkspacePyTURLTemplate, "{workspaceID}", strings.ToLower(workspaceID))
-			return base + "/customTransform"
+	if !strings.HasPrefix(language, "python") {
+		return u.config.userTransformationURL + "/customTransform"
+	}
+	// Per-workspace PyT: a global version allowlist doesn't apply — each
+	// workspace runs its own pod with its own version.
+	if u.config.perWorkspacePyTEnabled && !u.config.forMirroring {
+		if workspaceID == "" {
+			// Panic so the bug surfaces immediately as this should not happen
+			panic("per-workspace PyT enabled but workspaceID is empty")
 		}
-		if u.config.pythonTransformationURL != "" {
-			return u.config.pythonTransformationURL + "/customTransform"
-		}
+		base := strings.ReplaceAll(u.config.perWorkspacePyTURLTemplate, "{workspaceID}", strings.ToLower(workspaceID))
+		return base + "/customTransform"
+	}
+	// Legacy shared-PyT path: the version allowlist is a rollout gate for the shared service.
+	if u.config.pythonTransformationURL != "" && u.config.pythonTransformConfig.IsVersionAllowed(versionID) {
+		return u.config.pythonTransformationURL + "/customTransform"
 	}
 	return u.config.userTransformationURL + "/customTransform"
 }

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -51,7 +51,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) 
 	handle.client = transformerclient.NewClient("UserTransformer", transformerutils.TransformerClientConfig(conf, "UserTransformer"))
 	handle.config.userTransformationURL = handle.conf.GetStringVar(handle.conf.GetStringVar("http://localhost:9090", "DEST_TRANSFORM_URL"), "USER_TRANSFORM_URL")
 	handle.config.pythonTransformationURL = handle.conf.GetStringVar("", "PYTHON_TRANSFORM_URL")
-	handle.config.perWorkspacePyTEnabled = handle.conf.GetBoolVar(false, "Processor.UserTransformer.perWorkspacePyTEnabled")
+	handle.config.perWorkspacePyTEnabled = handle.conf.GetReloadableBoolVar(false, "Processor.UserTransformer.perWorkspacePyTEnabled")
 	handle.config.perWorkspacePyTURLTemplate = handle.conf.GetStringVar("http://pyt-{workspaceID}:8080", "Processor.UserTransformer.perWorkspacePyTURLTemplate")
 	handle.config.perWorkspacePyTEndlessRetries = handle.conf.GetReloadableBoolVar(true, "Processor.UserTransformer.perWorkspacePyTEndlessRetries")
 	handle.config.pythonTransformConfig = transformerutils.LoadPythonTransformConfig(conf)
@@ -90,7 +90,7 @@ type Client struct {
 		timeoutDuration               time.Duration
 		collectInstanceLevelStats     bool
 		batchSize                     config.ValueLoader[int]
-		perWorkspacePyTEnabled        bool
+		perWorkspacePyTEnabled        config.ValueLoader[bool]
 		perWorkspacePyTURLTemplate    string
 		perWorkspacePyTEndlessRetries config.ValueLoader[bool]
 	}
@@ -453,7 +453,7 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 // per-workspace PyT URL. Single source of truth shared by URL resolution and
 // the cold-start error / counter path so the two can't drift.
 func (u *Client) isPerWorkspacePyTPath(language, workspaceID string) bool {
-	return u.config.perWorkspacePyTEnabled &&
+	return u.config.perWorkspacePyTEnabled.Load() &&
 		!u.config.forMirroring &&
 		strings.HasPrefix(language, "python") &&
 		workspaceID != ""
@@ -490,7 +490,7 @@ func (u *Client) userTransformURL(language, versionID, workspaceID string) strin
 	}
 	// Per-workspace PyT: a global version allowlist doesn't apply — each
 	// workspace runs its own pod with its own version.
-	if u.config.perWorkspacePyTEnabled && !u.config.forMirroring {
+	if u.config.perWorkspacePyTEnabled.Load() && !u.config.forMirroring {
 		if workspaceID == "" {
 			// Panic so the bug surfaces immediately as this should not happen
 			panic("per-workspace PyT enabled but workspaceID is empty")

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -462,7 +462,10 @@ func (u *Client) shouldThrowPythonColdStartErr(labels types.TransformerMetricLab
 // kube-proxy returning a no-endpoints status.
 func isColdStartError(err error, resp *http.Response) bool {
 	if err != nil {
-		if errors.Is(err, syscall.ECONNREFUSED) {
+		// ECONNREFUSED: Service has no endpoints (Deployment at 0 replicas).
+		// EHOSTUNREACH ("no route to host"): stale iptables / EndpointSlice
+		// after a pod replacement or scale-down — same transient signal.
+		if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.EHOSTUNREACH) {
 			return true
 		}
 		var dnsErr *net.DNSError

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -455,7 +455,7 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 func (u *Client) isPerWorkspacePyTPath(language, workspaceID string) bool {
 	return u.config.perWorkspacePyTEnabled.Load() &&
 		!u.config.forMirroring &&
-		strings.HasPrefix(language, "python") &&
+		isPythonTransformation(language) &&
 		workspaceID != ""
 }
 
@@ -484,8 +484,12 @@ func isColdStartError(err error, resp *http.Response) bool {
 	return false
 }
 
+func isPythonTransformation(language string) bool {
+	return strings.HasPrefix(language, "python")
+}
+
 func (u *Client) userTransformURL(language, versionID, workspaceID string) string {
-	if !strings.HasPrefix(language, "python") {
+	if !isPythonTransformation(language) {
 		return u.config.userTransformationURL + "/customTransform"
 	}
 	// Per-workspace PyT: a global version allowlist doesn't apply — each

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -479,7 +479,7 @@ func (u *Client) userTransformURL(language, versionID, workspaceID string) strin
 	isPython := strings.HasPrefix(language, "python")
 	if isPython && u.config.pythonTransformConfig.IsVersionAllowed(versionID) {
 		if u.config.perWorkspacePyTEnabled && !u.config.forMirroring && workspaceID != "" {
-			base := strings.ReplaceAll(u.config.perWorkspacePyTURLTemplate, "{workspaceID}", workspaceID)
+			base := strings.ReplaceAll(u.config.perWorkspacePyTURLTemplate, "{workspaceID}", strings.ToLower(workspaceID))
 			return base + "/customTransform"
 		}
 		if u.config.pythonTransformationURL != "" {

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"slices"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -1501,7 +1502,7 @@ func TestUserTransformURLRouting(t *testing.T) {
 			pyMir: newRecordingSrv(t),
 			perWS: newRecordingSrv(t),
 		}
-		f.perWSExpectPath = "/pyt-" + workspaceID + "/customTransform"
+		f.perWSExpectPath = "/pyt-" + strings.ToLower(workspaceID) + "/customTransform"
 		f.conf = config.New()
 		f.conf.Set("Processor.UserTransformer.maxRetry", 1)
 		f.conf.Set("USER_TRANSFORM_URL", f.js.srv.URL)

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -1685,6 +1685,14 @@ func TestColdStartCounter(t *testing.T) {
 		failErr    error
 		failures   int
 
+		// Optional per-case overrides on top of the default fixture
+		// (perWorkspacePyTEnabled=true, endless retries=true, language=python,
+		// non-mirroring). Each toggles one of the cold-start gating predicates.
+		disableFlag    bool   // sets perWorkspacePyTEnabled=false
+		mirroring      bool   // applies the ForMirroring() opt
+		language       string // overrides "pythonfaas"
+		disableEndless bool   // sets perWorkspacePyTEndlessRetries=false
+
 		expectCounter    int
 		expectEventCount int // events on the success path
 		expectFailedCode int // StatusCode on FailedEvent (0 = no failed event expected)
@@ -1756,6 +1764,49 @@ func TestColdStartCounter(t *testing.T) {
 			expectCounter:    0,
 			expectFailedCode: transformerutils.StatusCPDown,
 		},
+		// --- Guard negatives: cold-start counter must stay 0 when any of the
+		// gating predicates is false, even if the transport returns
+		// cold-start-looking errors. The transport warms after 2 failures so
+		// doPost recovers via its inner retry budget (3 inner attempts at
+		// maxRetry=2) — no panic, just a clean success. Empty-workspaceID is
+		// covered by TestUserTransformURLRouting's panic-on-invariant case.
+		{
+			name:             "guard: flag off → cold-start error not counted",
+			disableFlag:      true,
+			failErr:          connRefused,
+			failures:         2,
+			expectCounter:    0,
+			expectEventCount: 1,
+		},
+		{
+			name:             "guard: mirroring on → cold-start error not counted",
+			mirroring:        true,
+			failErr:          connRefused,
+			failures:         2,
+			expectCounter:    0,
+			expectEventCount: 1,
+		},
+		{
+			name:             "guard: JS language → cold-start error not counted",
+			language:         "javascript",
+			failErr:          connRefused,
+			failures:         2,
+			expectCounter:    0,
+			expectEventCount: 1,
+		},
+		{
+			// perWorkspacePyTEndlessRetries=false → after doPost exhausts its
+			// inner retries and returns StatusColdStartWindowFailure, the
+			// outer sendBatch loop bails via backoff.Permanent on the very
+			// next cycle (no further doPost call). Inner attempts still emit
+			// the counter, so counter = maxRetry+1 = 3.
+			name:             "endless retries disabled → bails with cold-start failed event",
+			disableEndless:   true,
+			failErr:          connRefused,
+			failures:         math.MaxInt,
+			expectCounter:    3,
+			expectFailedCode: transformerutils.StatusColdStartWindowFailure,
+		},
 	}
 
 	for _, tc := range cases {
@@ -1772,7 +1823,8 @@ func TestColdStartCounter(t *testing.T) {
 			c.Set("Processor.UserTransformer.cpDownEndlessRetries", false)
 			c.Set("USER_TRANSFORM_URL", "http://js-stub:9090")
 			c.Set("PYTHON_TRANSFORM_URL", "http://py-stub:9090")
-			c.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
+			c.Set("Processor.UserTransformer.perWorkspacePyTEnabled", !tc.disableFlag)
+			c.Set("Processor.UserTransformer.perWorkspacePyTEndlessRetries", !tc.disableEndless)
 			c.Set("Processor.UserTransformer.perWorkspacePyTURLTemplate", "http://pyt-{workspaceID}:9090")
 			c.Set("PYTHON_TRANSFORM_VERSION_IDS_ENABLE", true)
 			c.Set("PYTHON_TRANSFORM_VERSION_IDS", allowedV)
@@ -1783,8 +1835,16 @@ func TestColdStartCounter(t *testing.T) {
 				failures:    tc.failures,
 				successBody: successBody,
 			}
-			tr := user_transformer.New(c, logger.NOP, statsStore, user_transformer.WithClient(transport))
+			opts := []user_transformer.Opt{user_transformer.WithClient(transport)}
+			if tc.mirroring {
+				opts = append(opts, user_transformer.ForMirroring())
+			}
+			tr := user_transformer.New(c, logger.NOP, statsStore, opts...)
 
+			language := tc.language
+			if language == "" {
+				language = "pythonfaas"
+			}
 			events := []types.TransformerEvent{{
 				Metadata: types.Metadata{
 					MessageID:   messageID,
@@ -1796,7 +1856,7 @@ func TestColdStartCounter(t *testing.T) {
 					Transformations: []backendconfig.TransformationT{{
 						ID:        "transform-1",
 						VersionID: allowedV,
-						Language:  "pythonfaas",
+						Language:  language,
 					}},
 				},
 			}}

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -1650,6 +1650,11 @@ func TestColdStartCounter(t *testing.T) {
 		Net: "tcp",
 		Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
 	}
+	noRouteToHost := &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: &os.SyscallError{Syscall: "connect", Err: syscall.EHOSTUNREACH},
+	}
 	dnsErr := &net.DNSError{Err: "no such host", Name: "pyt-ws-A1", IsNotFound: true}
 
 	// Marshaled success response — what a warm PyT pod would return.
@@ -1684,6 +1689,15 @@ func TestColdStartCounter(t *testing.T) {
 		{
 			name:             "DNS not found twice → counted twice, then warm",
 			failErr:          dnsErr,
+			failures:         2,
+			expectCounter:    2,
+			expectEventCount: 1,
+		},
+		{
+			// "no route to host" — stale iptables / EndpointSlice during pod
+			// replacement or scale-down. Same transient signal as ECONNREFUSED.
+			name:             "EHOSTUNREACH twice → counted twice, then warm",
+			failErr:          noRouteToHost,
 			failures:         2,
 			expectCounter:    2,
 			expectEventCount: 1,

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -1407,3 +1407,174 @@ func TestTransformerEvent_ToUserTransformerEvent(t *testing.T) {
 		})
 	}
 }
+
+// TestUserTransformURLRouting verifies the URL-resolution branches added by
+// the per-workspace PyT routing feature. Each case spins up real httptest
+// servers for the JS, legacy-Python, mirror-Python, and per-workspace endpoints
+// and asserts which one is hit by Transform.
+func TestUserTransformURLRouting(t *testing.T) {
+	const (
+		workspaceID = "ws-A1"
+		messageID   = "messageID-0"
+		allowedV    = "v-allowed"
+		blockedV    = "v-blocked"
+	)
+
+	type recordingSrv struct {
+		srv   *httptest.Server
+		hits  *atomic.Int32
+		paths *atomic.Value // last hit path
+	}
+
+	newRecordingSrv := func(t *testing.T) recordingSrv {
+		var hits atomic.Int32
+		var path atomic.Value
+		path.Store("")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits.Add(1)
+			path.Store(r.URL.Path)
+
+			var reqBody []types.TransformerEvent
+			require.NoError(t, jsonrs.NewDecoder(r.Body).Decode(&reqBody))
+
+			responses := make([]types.TransformerResponse, len(reqBody))
+			for i := range reqBody {
+				responses[i] = types.TransformerResponse{
+					Output:     reqBody[i].Message,
+					Metadata:   reqBody[i].Metadata,
+					StatusCode: http.StatusOK,
+				}
+			}
+			w.Header().Set("apiVersion", strconv.Itoa(reportingtypes.SupportedTransformerApiVersion))
+			require.NoError(t, jsonrs.NewEncoder(w).Encode(responses))
+		}))
+		t.Cleanup(srv.Close)
+		return recordingSrv{srv: srv, hits: &hits, paths: &path}
+	}
+
+	makeEvents := func(language, versionID, wsID string) []types.TransformerEvent {
+		return []types.TransformerEvent{{
+			Metadata: types.Metadata{
+				MessageID:   messageID,
+				WorkspaceID: wsID,
+			},
+			Message: map[string]any{"src-key-1": messageID},
+			Destination: backendconfig.DestinationT{
+				DestinationDefinition: backendconfig.DestinationDefinitionT{Name: "test-destination"},
+				Transformations: []backendconfig.TransformationT{{
+					ID:        "test-transformation",
+					VersionID: versionID,
+					Language:  language,
+				}},
+			},
+		}}
+	}
+
+	type fixture struct {
+		conf            *config.Config
+		js, py, pyMir   recordingSrv
+		perWS           recordingSrv
+		perWSExpectPath string
+	}
+
+	newFixture := func(t *testing.T) *fixture {
+		f := &fixture{
+			js:    newRecordingSrv(t),
+			py:    newRecordingSrv(t),
+			pyMir: newRecordingSrv(t),
+			perWS: newRecordingSrv(t),
+		}
+		f.perWSExpectPath = "/pyt-" + workspaceID + "/customTransform"
+		f.conf = config.New()
+		f.conf.Set("Processor.UserTransformer.maxRetry", 1)
+		f.conf.Set("USER_TRANSFORM_URL", f.js.srv.URL)
+		f.conf.Set("PYTHON_TRANSFORM_URL", f.py.srv.URL)
+		f.conf.Set("USER_TRANSFORM_MIRROR_URL", f.js.srv.URL)
+		f.conf.Set("PYTHON_TRANSFORM_MIRROR_URL", f.pyMir.srv.URL)
+		// Pin the per-workspace template to the recording server so the request
+		// resolves; embed {workspaceID} in the path so we can assert it.
+		f.conf.Set("Processor.UserTransformer.perWorkspacePyTURLTemplate", f.perWS.srv.URL+"/pyt-{workspaceID}")
+		// Enable version allowlist with one allowed version.
+		f.conf.Set("PYTHON_TRANSFORM_VERSION_IDS_ENABLE", true)
+		f.conf.Set("PYTHON_TRANSFORM_VERSION_IDS", allowedV)
+		return f
+	}
+
+	assertOnly := func(t *testing.T, f *fixture, hit *recordingSrv, expectPath string) {
+		t.Helper()
+		require.Equal(t, int32(1), hit.hits.Load(), "expected target server to be hit once")
+		if expectPath != "" {
+			require.Equal(t, expectPath, hit.paths.Load().(string))
+		}
+		for name, s := range map[string]*recordingSrv{
+			"js": &f.js, "py": &f.py, "pyMir": &f.pyMir, "perWS": &f.perWS,
+		} {
+			if s == hit {
+				continue
+			}
+			require.Equal(t, int32(0), s.hits.Load(), "server %s should not be hit", name)
+		}
+	}
+
+	t.Run("JS — flag off → JS URL", func(t *testing.T) {
+		f := newFixture(t)
+		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
+		tr.Transform(context.Background(), makeEvents("javascript", allowedV, workspaceID))
+		assertOnly(t, f, &f.js, "/customTransform")
+	})
+
+	t.Run("JS — flag on → JS URL (unaffected)", func(t *testing.T) {
+		f := newFixture(t)
+		f.conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
+		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
+		tr.Transform(context.Background(), makeEvents("javascript", allowedV, workspaceID))
+		assertOnly(t, f, &f.js, "/customTransform")
+	})
+
+	t.Run("Python — flag off → global Python URL", func(t *testing.T) {
+		f := newFixture(t)
+		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
+		tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, workspaceID))
+		assertOnly(t, f, &f.py, "/customTransform")
+	})
+
+	t.Run("Python — flag on, version allowed → per-workspace URL", func(t *testing.T) {
+		f := newFixture(t)
+		f.conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
+		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
+		tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, workspaceID))
+		assertOnly(t, f, &f.perWS, f.perWSExpectPath)
+	})
+
+	t.Run("Python — flag on, version disallowed → JS URL fallback", func(t *testing.T) {
+		f := newFixture(t)
+		f.conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
+		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
+		tr.Transform(context.Background(), makeEvents("pythonfaas", blockedV, workspaceID))
+		assertOnly(t, f, &f.js, "/customTransform")
+	})
+
+	t.Run("Python — flag on, mirroring → mirror Python URL", func(t *testing.T) {
+		f := newFixture(t)
+		f.conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
+		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP, user_transformer.ForMirroring())
+		tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, workspaceID))
+		assertOnly(t, f, &f.pyMir, "/customTransform")
+	})
+
+	t.Run("Python — flag on, empty workspaceID → global Python URL", func(t *testing.T) {
+		f := newFixture(t)
+		f.conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
+		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
+		tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, ""))
+		assertOnly(t, f, &f.py, "/customTransform")
+	})
+
+	t.Run("legacy fallback key Processor.perWorkspacePyTEnabled enables routing", func(t *testing.T) {
+		f := newFixture(t)
+		f.conf.Set("Processor.perWorkspacePyTEnabled", true)
+		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
+		tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, workspaceID))
+		assertOnly(t, f, &f.perWS, f.perWSExpectPath)
+	})
+}

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -1593,19 +1593,18 @@ func TestUserTransformURLRouting(t *testing.T) {
 		require.Equal(t, expectedResponseFor(""), rsp)
 		assertOnly(t, f, &f.py, "/customTransform")
 	})
-
 }
 
 // fakeColdStartTransport is a transformerclient.Client that returns a
-// configured (resp, err) for the first `failures` calls and then a 200 success
-// (carrying successBody) for every subsequent call. Lets tests simulate a pod
-// that's cold for N attempts and then warms up.
+// configured failure (failStatus or failErr) for the first `failures` calls and
+// then a 200 success (carrying successBody) for every subsequent call. Lets
+// tests simulate a pod that's cold for N attempts and then warms up.
 type fakeColdStartTransport struct {
-	// failResp / failErr — at most one of these is non-nil. failResp is
-	// returned (with a fresh empty body) for cold-start-style HTTP responses;
-	// failErr is returned for transport-level errors like ECONNREFUSED / DNS.
-	failResp *http.Response
-	failErr  error
+	// At most one of failStatus / failErr is set. failStatus > 0 returns an
+	// HTTP response with that status code and an empty body; failErr returns
+	// a transport-level error (ECONNREFUSED / DNS / ...).
+	failStatus int
+	failErr    error
 	// failures: number of failing calls before switching to successBody. Use
 	// math.MaxInt for "always fail".
 	failures int
@@ -1617,17 +1616,19 @@ type fakeColdStartTransport struct {
 }
 
 func (f *fakeColdStartTransport) Do(_ *http.Request) (*http.Response, error) {
+	hdr := http.Header{}
+	hdr.Set("apiVersion", strconv.Itoa(reportingtypes.SupportedTransformerApiVersion))
 	n := int(f.calls.Add(1))
 	if n <= f.failures {
-		if f.failResp != nil {
-			r := *f.failResp
-			r.Body = io.NopCloser(bytes.NewReader(nil))
-			return &r, nil
+		if f.failStatus > 0 {
+			return &http.Response{
+				StatusCode: f.failStatus,
+				Header:     hdr,
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+			}, nil
 		}
 		return nil, f.failErr
 	}
-	hdr := http.Header{}
-	hdr.Set("apiVersion", strconv.Itoa(reportingtypes.SupportedTransformerApiVersion))
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     hdr,
@@ -1650,16 +1651,6 @@ func TestColdStartCounter(t *testing.T) {
 	}
 	dnsErr := &net.DNSError{Err: "no such host", Name: "pyt-ws-A1", IsNotFound: true}
 
-	respWithStatus := func(code int) *http.Response {
-		hdr := http.Header{}
-		hdr.Set("apiVersion", strconv.Itoa(reportingtypes.SupportedTransformerApiVersion))
-		return &http.Response{
-			StatusCode: code,
-			Header:     hdr,
-			Body:       io.NopCloser(bytes.NewReader(nil)),
-		}
-	}
-
 	// Marshaled success response — what a warm PyT pod would return.
 	successBody, err := jsonrs.Marshal([]types.TransformerResponse{{
 		Output:     map[string]any{"src-key-1": messageID},
@@ -1670,11 +1661,11 @@ func TestColdStartCounter(t *testing.T) {
 
 	cases := []struct {
 		name string
-		// failResp / failErr: what the fake transport returns for the first
+		// failStatus / failErr: what the fake transport returns for the first
 		// `failures` calls. After that it returns a 200 success.
-		failResp *http.Response
-		failErr  error
-		failures int
+		failStatus int
+		failErr    error
+		failures   int
 
 		expectCounter    int
 		expectEventCount int // events on the success path
@@ -1698,14 +1689,14 @@ func TestColdStartCounter(t *testing.T) {
 		},
 		{
 			name:             "503 twice → counted twice, then warm",
-			failResp:         respWithStatus(http.StatusServiceUnavailable),
+			failStatus:       http.StatusServiceUnavailable,
 			failures:         2,
 			expectCounter:    2,
 			expectEventCount: 1,
 		},
 		{
 			name:             "502 twice → counted twice, then warm",
-			failResp:         respWithStatus(http.StatusBadGateway),
+			failStatus:       http.StatusBadGateway,
 			failures:         2,
 			expectCounter:    2,
 			expectEventCount: 1,
@@ -1724,7 +1715,7 @@ func TestColdStartCounter(t *testing.T) {
 			// 4xx is job-terminated — no retry, no cold-start counter, just a
 			// straight FailedEvent with the upstream status code.
 			name:             "non-transient 400 → no retry, failed event with 400",
-			failResp:         respWithStatus(http.StatusBadRequest),
+			failStatus:       http.StatusBadRequest,
 			failures:         math.MaxInt,
 			expectCounter:    0,
 			expectFailedCode: http.StatusBadRequest,
@@ -1733,7 +1724,7 @@ func TestColdStartCounter(t *testing.T) {
 			// With cpDownEndlessRetries=false, CPDown bails after one attempt
 			// via backoff.Permanent. Not a cold-start signal — counter stays 0.
 			name:             "StatusCPDown → bails, not counted",
-			failResp:         respWithStatus(transformerutils.StatusCPDown),
+			failStatus:       transformerutils.StatusCPDown,
 			failures:         math.MaxInt,
 			expectCounter:    0,
 			expectFailedCode: transformerutils.StatusCPDown,
@@ -1760,7 +1751,7 @@ func TestColdStartCounter(t *testing.T) {
 			c.Set("PYTHON_TRANSFORM_VERSION_IDS", allowedV)
 
 			transport := &fakeColdStartTransport{
-				failResp:    tc.failResp,
+				failStatus:  tc.failStatus,
 				failErr:     tc.failErr,
 				failures:    tc.failures,
 				successBody: successBody,

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -1,8 +1,12 @@
 package user_transformer_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"math"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -10,6 +14,7 @@ import (
 	"slices"
 	"strconv"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1470,6 +1475,18 @@ func TestUserTransformURLRouting(t *testing.T) {
 		}}
 	}
 
+	// The recording server echoes back the request's Message + Metadata with
+	// StatusCode 200, so Transform's response is deterministic given the input.
+	expectedResponseFor := func(wsID string) types.Response {
+		return types.Response{
+			Events: []types.TransformerResponse{{
+				Output:     map[string]any{"src-key-1": messageID},
+				Metadata:   types.Metadata{MessageID: messageID, WorkspaceID: wsID},
+				StatusCode: http.StatusOK,
+			}},
+		}
+	}
+
 	type fixture struct {
 		conf            *config.Config
 		js, py, pyMir   recordingSrv
@@ -1519,7 +1536,8 @@ func TestUserTransformURLRouting(t *testing.T) {
 	t.Run("JS — flag off → JS URL", func(t *testing.T) {
 		f := newFixture(t)
 		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
-		tr.Transform(context.Background(), makeEvents("javascript", allowedV, workspaceID))
+		rsp := tr.Transform(context.Background(), makeEvents("javascript", allowedV, workspaceID))
+		require.Equal(t, expectedResponseFor(workspaceID), rsp)
 		assertOnly(t, f, &f.js, "/customTransform")
 	})
 
@@ -1527,14 +1545,16 @@ func TestUserTransformURLRouting(t *testing.T) {
 		f := newFixture(t)
 		f.conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
 		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
-		tr.Transform(context.Background(), makeEvents("javascript", allowedV, workspaceID))
+		rsp := tr.Transform(context.Background(), makeEvents("javascript", allowedV, workspaceID))
+		require.Equal(t, expectedResponseFor(workspaceID), rsp)
 		assertOnly(t, f, &f.js, "/customTransform")
 	})
 
 	t.Run("Python — flag off → global Python URL", func(t *testing.T) {
 		f := newFixture(t)
 		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
-		tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, workspaceID))
+		rsp := tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, workspaceID))
+		require.Equal(t, expectedResponseFor(workspaceID), rsp)
 		assertOnly(t, f, &f.py, "/customTransform")
 	})
 
@@ -1542,7 +1562,8 @@ func TestUserTransformURLRouting(t *testing.T) {
 		f := newFixture(t)
 		f.conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
 		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
-		tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, workspaceID))
+		rsp := tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, workspaceID))
+		require.Equal(t, expectedResponseFor(workspaceID), rsp)
 		assertOnly(t, f, &f.perWS, f.perWSExpectPath)
 	})
 
@@ -1550,7 +1571,8 @@ func TestUserTransformURLRouting(t *testing.T) {
 		f := newFixture(t)
 		f.conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
 		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
-		tr.Transform(context.Background(), makeEvents("pythonfaas", blockedV, workspaceID))
+		rsp := tr.Transform(context.Background(), makeEvents("pythonfaas", blockedV, workspaceID))
+		require.Equal(t, expectedResponseFor(workspaceID), rsp)
 		assertOnly(t, f, &f.js, "/customTransform")
 	})
 
@@ -1558,7 +1580,8 @@ func TestUserTransformURLRouting(t *testing.T) {
 		f := newFixture(t)
 		f.conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
 		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP, user_transformer.ForMirroring())
-		tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, workspaceID))
+		rsp := tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, workspaceID))
+		require.Equal(t, expectedResponseFor(workspaceID), rsp)
 		assertOnly(t, f, &f.pyMir, "/customTransform")
 	})
 
@@ -1566,15 +1589,229 @@ func TestUserTransformURLRouting(t *testing.T) {
 		f := newFixture(t)
 		f.conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
 		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
-		tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, ""))
+		rsp := tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, ""))
+		require.Equal(t, expectedResponseFor(""), rsp)
 		assertOnly(t, f, &f.py, "/customTransform")
 	})
 
-	t.Run("legacy fallback key Processor.perWorkspacePyTEnabled enables routing", func(t *testing.T) {
-		f := newFixture(t)
-		f.conf.Set("Processor.perWorkspacePyTEnabled", true)
-		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
-		tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, workspaceID))
-		assertOnly(t, f, &f.perWS, f.perWSExpectPath)
-	})
+}
+
+// fakeColdStartTransport is a transformerclient.Client that returns a
+// configured (resp, err) for the first `failures` calls and then a 200 success
+// (carrying successBody) for every subsequent call. Lets tests simulate a pod
+// that's cold for N attempts and then warms up.
+type fakeColdStartTransport struct {
+	// failResp / failErr — at most one of these is non-nil. failResp is
+	// returned (with a fresh empty body) for cold-start-style HTTP responses;
+	// failErr is returned for transport-level errors like ECONNREFUSED / DNS.
+	failResp *http.Response
+	failErr  error
+	// failures: number of failing calls before switching to successBody. Use
+	// math.MaxInt for "always fail".
+	failures int
+	// successBody: marshaled []TransformerResponse returned on the (failures+1)th
+	// and later calls. Empty body is fine when the test doesn't reach success.
+	successBody []byte
+
+	calls atomic.Int32
+}
+
+func (f *fakeColdStartTransport) Do(_ *http.Request) (*http.Response, error) {
+	n := int(f.calls.Add(1))
+	if n <= f.failures {
+		if f.failResp != nil {
+			r := *f.failResp
+			r.Body = io.NopCloser(bytes.NewReader(nil))
+			return &r, nil
+		}
+		return nil, f.failErr
+	}
+	hdr := http.Header{}
+	hdr.Set("apiVersion", strconv.Itoa(reportingtypes.SupportedTransformerApiVersion))
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     hdr,
+		Body:       io.NopCloser(bytes.NewReader(f.successBody)),
+	}, nil
+}
+
+func TestColdStartCounter(t *testing.T) {
+	const (
+		coldStartMetric = "processor_user_transformer_cold_start_errors_total"
+		workspaceID     = "ws-A1"
+		messageID       = "messageID-0"
+		allowedV        = "v-allowed"
+	)
+
+	connRefused := &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
+	}
+	dnsErr := &net.DNSError{Err: "no such host", Name: "pyt-ws-A1", IsNotFound: true}
+
+	respWithStatus := func(code int) *http.Response {
+		hdr := http.Header{}
+		hdr.Set("apiVersion", strconv.Itoa(reportingtypes.SupportedTransformerApiVersion))
+		return &http.Response{
+			StatusCode: code,
+			Header:     hdr,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+		}
+	}
+
+	// Marshaled success response — what a warm PyT pod would return.
+	successBody, err := jsonrs.Marshal([]types.TransformerResponse{{
+		Output:     map[string]any{"src-key-1": messageID},
+		Metadata:   types.Metadata{MessageID: messageID, WorkspaceID: workspaceID},
+		StatusCode: http.StatusOK,
+	}})
+	require.NoError(t, err)
+
+	cases := []struct {
+		name string
+		// failResp / failErr: what the fake transport returns for the first
+		// `failures` calls. After that it returns a 200 success.
+		failResp *http.Response
+		failErr  error
+		failures int
+
+		expectCounter    int
+		expectEventCount int // events on the success path
+		expectFailedCode int // StatusCode on FailedEvent (0 = no failed event expected)
+	}{
+		{
+			// 2 ECONNREFUSED then warm. Fits within doPost's inner retry budget
+			// (maxRetry+1 = 3), so the outer sendBatch loop runs exactly once.
+			name:             "ECONNREFUSED twice → counted twice, then warm",
+			failErr:          connRefused,
+			failures:         2,
+			expectCounter:    2,
+			expectEventCount: 1,
+		},
+		{
+			name:             "DNS not found twice → counted twice, then warm",
+			failErr:          dnsErr,
+			failures:         2,
+			expectCounter:    2,
+			expectEventCount: 1,
+		},
+		{
+			name:             "503 twice → counted twice, then warm",
+			failResp:         respWithStatus(http.StatusServiceUnavailable),
+			failures:         2,
+			expectCounter:    2,
+			expectEventCount: 1,
+		},
+		{
+			name:             "502 twice → counted twice, then warm",
+			failResp:         respWithStatus(http.StatusBadGateway),
+			failures:         2,
+			expectCounter:    2,
+			expectEventCount: 1,
+		},
+		{
+			// 4 failures > maxRetry+1, forces sendBatch's outer retry to kick
+			// in: doPost exhausts inner retries on cycle 1, returns the
+			// cold-start status, sendBatch retries doPost, second cycle warms.
+			name:             "cold-start spans multiple outer cycles → still recovers",
+			failErr:          connRefused,
+			failures:         4,
+			expectCounter:    4,
+			expectEventCount: 1,
+		},
+		{
+			// 4xx is job-terminated — no retry, no cold-start counter, just a
+			// straight FailedEvent with the upstream status code.
+			name:             "non-transient 400 → no retry, failed event with 400",
+			failResp:         respWithStatus(http.StatusBadRequest),
+			failures:         math.MaxInt,
+			expectCounter:    0,
+			expectFailedCode: http.StatusBadRequest,
+		},
+		{
+			// With cpDownEndlessRetries=false, CPDown bails after one attempt
+			// via backoff.Permanent. Not a cold-start signal — counter stays 0.
+			name:             "StatusCPDown → bails, not counted",
+			failResp:         respWithStatus(transformerutils.StatusCPDown),
+			failures:         math.MaxInt,
+			expectCounter:    0,
+			expectFailedCode: transformerutils.StatusCPDown,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			statsStore, err := memstats.New()
+			require.NoError(t, err)
+
+			c := config.New()
+			c.Set("Processor.UserTransformer.maxRetry", 2)
+			c.Set("Processor.UserTransformer.maxRetryBackoffInterval", "1ms")
+			// Bound CPDown retries so the CPDown case terminates. Per-workspace
+			// PyT retries stay at the production default (endless) — the
+			// transport itself warms up to end the loop.
+			c.Set("Processor.UserTransformer.cpDownEndlessRetries", false)
+			c.Set("USER_TRANSFORM_URL", "http://js-stub:9090")
+			c.Set("PYTHON_TRANSFORM_URL", "http://py-stub:9090")
+			c.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
+			c.Set("Processor.UserTransformer.perWorkspacePyTURLTemplate", "http://pyt-{workspaceID}:9090")
+			c.Set("PYTHON_TRANSFORM_VERSION_IDS_ENABLE", true)
+			c.Set("PYTHON_TRANSFORM_VERSION_IDS", allowedV)
+
+			transport := &fakeColdStartTransport{
+				failResp:    tc.failResp,
+				failErr:     tc.failErr,
+				failures:    tc.failures,
+				successBody: successBody,
+			}
+			tr := user_transformer.New(c, logger.NOP, statsStore, user_transformer.WithClient(transport))
+
+			events := []types.TransformerEvent{{
+				Metadata: types.Metadata{
+					MessageID:   messageID,
+					WorkspaceID: workspaceID,
+				},
+				Message: map[string]any{"src-key-1": messageID},
+				Destination: backendconfig.DestinationT{
+					DestinationDefinition: backendconfig.DestinationDefinitionT{Name: "test-destination"},
+					Transformations: []backendconfig.TransformationT{{
+						ID:        "transform-1",
+						VersionID: allowedV,
+						Language:  "pythonfaas",
+					}},
+				},
+			}}
+
+			rsp := tr.Transform(context.Background(), events)
+
+			require.Len(t, rsp.Events, tc.expectEventCount)
+			if tc.expectFailedCode != 0 {
+				require.Len(t, rsp.FailedEvents, 1)
+				require.Equal(t, tc.expectFailedCode, rsp.FailedEvents[0].StatusCode)
+				require.Equal(t, messageID, rsp.FailedEvents[0].Metadata.MessageID)
+				require.Equal(t, workspaceID, rsp.FailedEvents[0].Metadata.WorkspaceID)
+			} else {
+				require.Empty(t, rsp.FailedEvents)
+				require.Equal(t, messageID, rsp.Events[0].Metadata.MessageID)
+				require.Equal(t, workspaceID, rsp.Events[0].Metadata.WorkspaceID)
+				require.Equal(t, http.StatusOK, rsp.Events[0].StatusCode)
+			}
+
+			measurements := statsStore.GetByName(coldStartMetric)
+			total := 0
+			for _, m := range measurements {
+				total += int(m.Value)
+			}
+			require.Equal(t, tc.expectCounter, total)
+
+			if tc.expectCounter > 0 {
+				// All increments must land on the same tag set: workspaceID +
+				// hardcoded language=python (not the raw label).
+				require.Len(t, measurements, 1)
+				require.Equal(t, workspaceID, measurements[0].Tags["workspaceID"])
+				require.Equal(t, "python", measurements[0].Tags["language"])
+			}
+		})
+	}
 }

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -1586,13 +1586,16 @@ func TestUserTransformURLRouting(t *testing.T) {
 		assertOnly(t, f, &f.pyMir, "/customTransform")
 	})
 
-	t.Run("Python — flag on, empty workspaceID → global Python URL", func(t *testing.T) {
+	t.Run("Python — flag on, empty workspaceID → panics (invariant violation)", func(t *testing.T) {
 		f := newFixture(t)
 		f.conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
 		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
-		rsp := tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, ""))
-		require.Equal(t, expectedResponseFor(""), rsp)
-		assertOnly(t, f, &f.py, "/customTransform")
+		require.PanicsWithValue(t,
+			"per-workspace PyT enabled but workspaceID is empty",
+			func() {
+				tr.Transform(context.Background(), makeEvents("pythonfaas", allowedV, ""))
+			},
+		)
 	})
 }
 

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -1568,9 +1568,18 @@ func TestUserTransformURLRouting(t *testing.T) {
 		assertOnly(t, f, &f.perWS, f.perWSExpectPath)
 	})
 
-	t.Run("Python — flag on, version disallowed → JS URL fallback", func(t *testing.T) {
+	t.Run("Python — flag on, version disallowed → still routes to per-workspace URL (allowlist doesn't apply in per-ws mode)", func(t *testing.T) {
 		f := newFixture(t)
 		f.conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
+		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
+		rsp := tr.Transform(context.Background(), makeEvents("pythonfaas", blockedV, workspaceID))
+		require.Equal(t, expectedResponseFor(workspaceID), rsp)
+		assertOnly(t, f, &f.perWS, f.perWSExpectPath)
+	})
+
+	t.Run("Python — flag off, version disallowed → JS URL fallback (legacy allowlist still applies)", func(t *testing.T) {
+		f := newFixture(t)
+		// per-ws flag off, legacy path active; disallowed version → JS fallback.
 		tr := user_transformer.New(f.conf, logger.NOP, stats.NOP)
 		rsp := tr.Transform(context.Background(), makeEvents("pythonfaas", blockedV, workspaceID))
 		require.Equal(t, expectedResponseFor(workspaceID), rsp)

--- a/processor/internal/transformer/utils.go
+++ b/processor/internal/transformer/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -17,11 +18,14 @@ import (
 )
 
 const (
-	StatusCPDown              = 809
-	StatusMirrorFiltered      = 297
-	TransformerRequestFailure = 909
-	TransformerRequestTimeout = 919
+	StatusCPDown                 = 809
+	StatusColdStartWindowFailure = 819
+	StatusMirrorFiltered         = 297
+	TransformerRequestFailure    = 909
+	TransformerRequestTimeout    = 919
 )
+
+var ColdStartError = errors.New("cold start error")
 
 func IsJobTerminated(status int) bool {
 	if status == http.StatusTooManyRequests || status == http.StatusRequestTimeout {

--- a/processor/internal/transformer/utils.go
+++ b/processor/internal/transformer/utils.go
@@ -25,7 +25,7 @@ const (
 	TransformerRequestTimeout    = 919
 )
 
-var ColdStartError = errors.New("cold start error")
+var ErrColdStart = errors.New("cold start error")
 
 func IsJobTerminated(status int) bool {
 	if status == http.StatusTooManyRequests || status == http.StatusRequestTimeout {


### PR DESCRIPTION
# Description

## Summary

Adds support for routing the Python branch of user-transformations to a workspace-scoped PyT service (`pyt-<workspaceID>:9090`) instead of the static `PYTHON_TRANSFORM_URL`, plus the cold-start
observability and retry behavior the HPA scale-from-zero flow needs. JS, mirror, and existing Python paths are identical when the new flag is off.

## Behavior 

- **URL resolution.** New flag `Processor.UserTransformer.perWorkspacePyTEnabled` (default `false`). When on, non-mirror Python transformations route to a per-workspace URL templated from
  `Processor.UserTransformer.perWorkspacePyTURLTemplate` (default `http://pyt-{workspaceID}:9090`). Falls back to the global Python URL when the version-allowlist gates the version out, when mirroring,
  or when `workspaceID` is empty.
- **Cold-start counter.** New `processor_user_transformer_cold_start_errors_total{workspaceID, language}` increments per HTTP attempt classified as cold-start (ECONNREFUSED, DNS not-found, 502, 503)
  only on the per-workspace Python non-mirror path. Tag `language` is hard-coded to `"python"` to keep cardinality bounded. HPA reads `rate(...[1m])` against `activationThreshold: 0.01` to decide 0→1
  scaling.
- **Cold-start retry.** On cold-start detection the inner closure short-circuits with a sentinel `ColdStartError`. The `doPost` tail converts that sentinel to a dedicated status code
  `StatusColdStartWindowFailure = 819`. `sendBatch`'s outer retry treats `819` like `StatusCPDown` — keeps retrying the whole call so the request eventually lands once HPA scales the pod up. Gated by
  `Processor.UserTransformer.perWorkspacePyTEndlessRetries` (default `true`); when disabled, `backoff.Permanent` bails immediately so the batch surfaces a single FailedEvent with status 819 instead of
  panicking the processor.

## Behavior when the flag is off

Identical to current `master`. New config fields default off / endless-retries-on, but the gating predicate means none
of the new code paths are reachable until we explicitly enable the flag.

## Linear Ticket

pipe-3009, pipe-3010

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
