### PR TITLE
[WIP] feat(jobsdb): non-blocking dataset compaction (enabled by default)

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1161,7 +1161,7 @@ func (jd *Handle) loadConfig() {
 	jd.conf.migration.vacuumFullStatusTableThreshold = jd.config.GetReloadableInt64Var(500*bytesize.MB, 1, jd.configKeys("vacuumFullStatusTableThreshold")...)
 	jd.conf.migration.vacuumAnalyzeStatusTableThreshold = jd.config.GetReloadableInt64Var(30000, 1, jd.configKeys("vacuumAnalyzeStatusTableThreshold")...)
 	jd.conf.migration.nonBlockingCompletedDSDrop = jd.config.GetReloadableBoolVar(false, jd.configKeys("nonBlockingCompletedDSDrop")...)
-	jd.conf.migration.nonBlockingCompaction = jd.config.GetReloadableBoolVar(false, jd.configKeys("nonBlockingCompaction")...)
+	jd.conf.migration.nonBlockingCompaction = jd.config.GetReloadableBoolVar(true, jd.configKeys("nonBlockingCompaction")...)
 	jd.conf.migration.getJobsRetryOnCompaction = jd.config.GetReloadableBoolVar(true, jd.configKeys("getJobsRetryOnCompaction")...)
 
 	// masterBackupEnabled = true => all the jobsdb are eligible for backup


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

just for verifying all tests succeed with non blocking migration enabled by default

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #6979 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #6967 
- <kbd>&nbsp;2&nbsp;</kbd> #6962 
- <kbd>&nbsp;1&nbsp;</kbd> #6963 
<!-- GitButler Footer Boundary Bottom -->

