### PR TITLE
Add AGENTS.md for Cursor Cloud dev environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ ginkgo.report
 *.prof
 .cursor/*
 .claude/settings.local.json
+.local-dev/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is **rudder-server**, the core backend of the RudderStack open-source Customer Data Platform. It's a Go monolith that handles event ingestion (Gateway), processing (Processor), routing (Router/BatchRouter), and warehouse loading. See `README.md` for product context.
+
+### Required services
+
+| Service | How to start | Port |
+|---|---|---|
+| PostgreSQL 15 | `docker run -d --name rudder-postgres -p 6432:5432 -e POSTGRES_USER=rudder -e POSTGRES_PASSWORD=password -e POSTGRES_DB=jobsdb --shm-size=128mb postgres:15-alpine` | 6432 |
+| RudderStack Transformer | `docker run -d --name rudder-transformer -p 9090:9090 rudderstack/rudder-transformer:latest` | 9090 |
+
+### Running the server locally (without RudderStack Cloud)
+
+Use `RSERVER_BACKEND_CONFIG_CONFIG_FROM_FILE=true` with a local `workspaceConfig.json` to run without a `WORKSPACE_TOKEN`. Minimal env vars:
+
+```sh
+JOBS_DB_HOST=localhost JOBS_DB_USER=rudder JOBS_DB_PASSWORD=password \
+JOBS_DB_PORT=6432 JOBS_DB_DB_NAME=jobsdb JOBS_DB_SSL_MODE=disable \
+DEST_TRANSFORM_URL=http://localhost:9090 \
+RSERVER_BACKEND_CONFIG_CONFIG_FROM_FILE=true \
+RSERVER_BACKEND_CONFIG_CONFIG_JSONPATH=/path/to/workspaceConfig.json \
+go run main.go
+```
+
+A workspace config template is at `integration_test/docker_test/testdata/workspaceConfigTemplate.json`.
+
+### Build, lint, test commands
+
+All in `Makefile`:
+- **Build**: `make build` (or `go build`)
+- **Lint**: `golangci-lint run -v` (install binary via `curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin`; do **not** use `go run` as it may use an older Go toolchain)
+- **Format**: `make fmt`
+- **Unit tests**: `make test` (uses `gotestsum`, install via `make install-tools`)
+- **Test single package**: `gotestsum --format pkgname-and-test-fails -- -v ./path/to/package/...`
+
+### Gotchas
+
+- **golangci-lint toolchain mismatch**: The Makefile uses `go run $(GOLANGCI)` which builds golangci-lint with Go 1.25 (its go.mod version), but the project requires Go 1.26.3. Install the **binary** release instead of using `go run`.
+- **Docker rate limits**: Integration tests using `dockertest` may fail with 429 errors from Docker Hub. This is an environment limitation, not a code issue.
+- **PostgreSQL port**: The `docker-compose.yml` and local dev convention maps PostgreSQL to host port **6432** (not 5432).
+- **PATH**: Go tool binaries are installed to `$(go env GOPATH)/bin` (typically `~/go/bin`). Ensure this is in `$PATH`.
+- The devtool at `cmd/devtool` provides helpful commands: `event send` to send test events, `webhook run` to simulate a destination.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Add `AGENTS.md` with development environment instructions for Cursor Cloud agents. This documents how to set up and run rudder-server locally, including required services, build/lint/test commands, and known gotchas.

## What's included

- Required services table (PostgreSQL 15 on port 6432, RudderStack Transformer on port 9090)
- Instructions for running the server locally without a `WORKSPACE_TOKEN` using `CONFIG_FROM_FILE`
- Build, lint, and test commands (referencing the Makefile)
- Known gotchas: golangci-lint toolchain mismatch, Docker Hub rate limits, PostgreSQL port convention, Go bin PATH

## Verification

Setup was verified end-to-end:

- **Build**: `go build` succeeded
- **Lint**: `golangci-lint run -v` ran successfully (16 pre-existing findings)
- **Unit tests**: `gotestsum` passed on multiple packages (httputil: 6 tests, utils/types: 22 tests)
- **E2E pipeline**: Server started, 3 test events sent via gateway -> processor -> router -> webhook destination, all delivered successfully

[setup_verification.log](https://cursor.com/agents/bc-ab63134d-1fcd-42df-8c37-d46b809544f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsetup_verification.log)

## Linear Ticket

N/A - Infrastructure/tooling improvement

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab63134d-1fcd-42df-8c37-d46b809544f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab63134d-1fcd-42df-8c37-d46b809544f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

