### PR TITLE
fix(webhook): propagate request context in batchTransformLoop

### DIFF
--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -321,8 +321,7 @@ func (webhook *HandleT) batchRequests(sourceDef string, requestQ chan *webhookT)
 func (bt *batchWebhookTransformerT) batchTransformLoop() {
 	for breq := range bt.webhook.batchRequestQ {
 		// If unable to fetch features from transformer, send GatewayTimeout to all requests
-		// TODO: Remove timeout from here after timeout handler is added in gateway
-		ctx, cancel := context.WithTimeout(context.Background(), config.GetDurationVar(10, time.Second, "WriteTimeout", "WriteTimeOutInSec"))
+		ctx := breq.batchRequest[0].request.Context()
 		sourceTransformAdapter, err := bt.sourceTransformAdapter(ctx)
 		if err != nil {
 			bt.webhook.logger.Errorn("webhook source transformation failed",
@@ -332,7 +331,6 @@ func (bt *batchWebhookTransformerT) batchTransformLoop() {
 			for _, req := range breq.batchRequest {
 				req.done <- transformerResponse{StatusCode: response.GetErrorStatusCode(response.GatewayTimeout), Err: response.GetStatus(response.GatewayTimeout)}
 			}
-			cancel()
 			continue
 		}
 		cancel()


### PR DESCRIPTION
This PR resolves #6787.

The previous implementation used a hardcoded timeout context when calling the source transformer adapter, which detached execution from the original request lifecycle and ignored gateway-level timeout/cancellation handling.
This change replaces that with the HTTP request context from the batch request so transformer calls respect the existing gateway timeout behavior.
Note: I was unable to fully run the package tests locally because the repository currently has Windows-specific build incompatibilities (`syscall.Stat_t` in `utils/misc`), but the change is minimal and scoped to the requested fix.This is a clean resubmission of the previously stale PR #6788 with the requested minimal change.