### PR TITLE
chore: remove deprecated bulkStatusEnabled flag for snowpipe streaming

### DIFF
--- a/integration_test/snowpipestreaming/snowpipestreaming_test.go
+++ b/integration_test/snowpipestreaming/snowpipestreaming_test.go
@@ -800,98 +800,6 @@ func TestSnowpipeStreaming(t *testing.T) {
 		require.NoError(t, <-done)
 	})
 
-	t.Run("many table (bulk status enabled)", func(t *testing.T) {
-		postgresContainer, gatewayPort := initializeTestEnvironment(t)
-		namespace := testhelper.RandSchema()
-		backendConfigServer, source, destination := setupBackendConfigTestServer(t, credentials, namespace)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		done := make(chan error)
-		go func() {
-			defer close(done)
-			configOverrides := []lo.Tuple2[string, any]{
-				{A: "SnowpipeStreaming.bulkStatusEnabled", B: true},
-			}
-			done <- runRudderServer(ctx, cancel, gatewayPort, postgresContainer, backendConfigServer.URL, transformerURL, snowpipeClientsURL, t.TempDir(), configOverrides...)
-		}()
-
-		url := fmt.Sprintf("http://localhost:%d", gatewayPort)
-		health.WaitUntilReady(ctx, t, url+"/health", 60*time.Second, 10*time.Millisecond, t.Name())
-
-		warehouse := whutils.ModelWarehouse{
-			Namespace:   namespace,
-			Destination: destination,
-		}
-
-		t.Log("Creating schema and tables")
-		sm := snowflake.New(config.New(), logger.NOP, stats.NOP)
-		require.NoError(t, sm.Setup(ctx, warehouse, whutils.NewNoOpUploader()))
-		t.Cleanup(func() { sm.Cleanup(ctx) })
-		require.NoError(t, sm.CreateSchema(ctx))
-		t.Cleanup(func() { testhelper.DropSchema(t, sm.DB.DB, namespace) })
-
-		for i := range 10 {
-			eventFormat := func(int) string {
-				return fmt.Sprintf(`{"batch":[{"type":"track","userId":"%[1]s","event":"Product Reviewed %[1]s","properties":{"review_id":"86ac1cd43","product_id":"9578257311","rating":3,"review_body":"OK for the price. It works but the material feels flimsy."}, "timestamp":"2020-02-02T00:23:09.544Z","sentAt":"2020-02-02T00:23:09.544Z","originalTimestamp":"2020-02-02T00:23:09.544Z","receivedAt":"2020-02-02T00:23:09.544Z", "context":{"ip":"14.5.67.21"}}]}`,
-					strconv.Itoa(i+1),
-				)
-			}
-			require.NoError(t, sendEvents(5, eventFormat, "writekey1", url))
-		}
-
-		requireGatewayJobsCount(t, ctx, postgresContainer.DB, "succeeded", 5*10)
-		requireBatchRouterJobsCount(t, ctx, postgresContainer.DB, "succeeded", 2*5*10)
-
-		schema := whth.RetrieveRecordsFromWarehouse(t, sm.DB.DB, fmt.Sprintf(`SELECT table_name, column_name, data_type FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = '%s';`, namespace))
-		expectedSchema := lo.SliceToMap(
-			lo.RepeatBy(10, func(index int) string {
-				return "PRODUCT_REVIEWED_" + strconv.Itoa(index+1)
-			}),
-			func(tableName string) (string, map[string]string) {
-				return tableName, map[string]string{"CONTEXT_DESTINATION_ID": "TEXT", "CONTEXT_DESTINATION_TYPE": "TEXT", "CONTEXT_IP": "TEXT", "CONTEXT_REQUEST_IP": "TEXT", "CONTEXT_PASSED_IP": "TEXT", "CONTEXT_SOURCE_ID": "TEXT", "CONTEXT_SOURCE_TYPE": "TEXT", "EVENT": "TEXT", "EVENT_TEXT": "TEXT", "ID": "TEXT", "ORIGINAL_TIMESTAMP": "TIMESTAMP_TZ", "PRODUCT_ID": "TEXT", "RATING": "NUMBER", "RECEIVED_AT": "TIMESTAMP_TZ", "REVIEW_BODY": "TEXT", "REVIEW_ID": "TEXT", "SENT_AT": "TIMESTAMP_TZ", "TIMESTAMP": "TIMESTAMP_TZ", "USER_ID": "TEXT", "UUID_TS": "TIMESTAMP_TZ"}
-			},
-		)
-		expectedSchema = lo.Assign(expectedSchema, map[string]map[string]string{
-			"TRACKS":          {"CONTEXT_DESTINATION_ID": "TEXT", "CONTEXT_DESTINATION_TYPE": "TEXT", "CONTEXT_IP": "TEXT", "CONTEXT_REQUEST_IP": "TEXT", "CONTEXT_PASSED_IP": "TEXT", "CONTEXT_SOURCE_ID": "TEXT", "CONTEXT_SOURCE_TYPE": "TEXT", "EVENT": "TEXT", "EVENT_TEXT": "TEXT", "ID": "TEXT", "ORIGINAL_TIMESTAMP": "TIMESTAMP_TZ", "RECEIVED_AT": "TIMESTAMP_TZ", "SENT_AT": "TIMESTAMP_TZ", "TIMESTAMP": "TIMESTAMP_TZ", "USER_ID": "TEXT", "UUID_TS": "TIMESTAMP_TZ"},
-			"RUDDER_DISCARDS": {"COLUMN_NAME": "TEXT", "COLUMN_VALUE": "TEXT", "REASON": "TEXT", "RECEIVED_AT": "TIMESTAMP_TZ", "ROW_ID": "TEXT", "TABLE_NAME": "TEXT", "UUID_TS": "TIMESTAMP_TZ"},
-		})
-		require.Equal(t, expectedSchema, convertRecordsToSchema(schema))
-
-		for i := range 10 {
-			productIDIndex := i + 1
-			userID := strconv.Itoa(productIDIndex)
-			eventName := "Product Reviewed " + strconv.Itoa(productIDIndex)
-			tableName := strcase.ToSnake(eventName)
-			recordsFromDB := whth.RetrieveRecordsFromWarehouse(t, sm.DB.DB, fmt.Sprintf(`SELECT CONTEXT_DESTINATION_ID, CONTEXT_DESTINATION_TYPE, CONTEXT_SOURCE_ID, CONTEXT_SOURCE_TYPE, EVENT, EVENT_TEXT, ORIGINAL_TIMESTAMP, PRODUCT_ID, RATING, TO_CHAR(RECEIVED_AT, 'YYYY-MM-DD'), REVIEW_BODY, REVIEW_ID, SENT_AT, TIMESTAMP, USER_ID, TO_CHAR(UUID_TS, 'YYYY-MM-DD') FROM %q.%q;`, namespace, "PRODUCT_REVIEWED_"+strconv.Itoa(productIDIndex)))
-			ts := timeutil.Now().Format("2006-01-02")
-
-			expectedProductReviewedRecords := [][]string{
-				{destination.ID, "SNOWPIPE_STREAMING", source.ID, source.SourceDefinition.Name, tableName, eventName, "2020-02-02T00:23:09Z", "9578257311", "3", ts, "OK for the price. It works but the material feels flimsy.", "86ac1cd43", "2020-02-02T00:23:09Z", "2020-02-02T00:23:09Z", userID, ts},
-				{destination.ID, "SNOWPIPE_STREAMING", source.ID, source.SourceDefinition.Name, tableName, eventName, "2020-02-02T00:23:09Z", "9578257311", "3", ts, "OK for the price. It works but the material feels flimsy.", "86ac1cd43", "2020-02-02T00:23:09Z", "2020-02-02T00:23:09Z", userID, ts},
-				{destination.ID, "SNOWPIPE_STREAMING", source.ID, source.SourceDefinition.Name, tableName, eventName, "2020-02-02T00:23:09Z", "9578257311", "3", ts, "OK for the price. It works but the material feels flimsy.", "86ac1cd43", "2020-02-02T00:23:09Z", "2020-02-02T00:23:09Z", userID, ts},
-				{destination.ID, "SNOWPIPE_STREAMING", source.ID, source.SourceDefinition.Name, tableName, eventName, "2020-02-02T00:23:09Z", "9578257311", "3", ts, "OK for the price. It works but the material feels flimsy.", "86ac1cd43", "2020-02-02T00:23:09Z", "2020-02-02T00:23:09Z", userID, ts},
-				{destination.ID, "SNOWPIPE_STREAMING", source.ID, source.SourceDefinition.Name, tableName, eventName, "2020-02-02T00:23:09Z", "9578257311", "3", ts, "OK for the price. It works but the material feels flimsy.", "86ac1cd43", "2020-02-02T00:23:09Z", "2020-02-02T00:23:09Z", userID, ts},
-			}
-			require.ElementsMatch(t, expectedProductReviewedRecords, recordsFromDB)
-		}
-
-		trackRecordsFromDB := whth.RetrieveRecordsFromWarehouse(t, sm.DB.DB, fmt.Sprintf(`SELECT CONTEXT_DESTINATION_ID, CONTEXT_DESTINATION_TYPE, CONTEXT_SOURCE_ID, CONTEXT_SOURCE_TYPE, EVENT, EVENT_TEXT, ORIGINAL_TIMESTAMP, TO_CHAR(RECEIVED_AT, 'YYYY-MM-DD'), SENT_AT, TIMESTAMP, USER_ID, TO_CHAR(UUID_TS, 'YYYY-MM-DD') FROM %q.%q;`, namespace, "TRACKS"))
-		expectedTrackRecords := lo.RepeatBy(50, func(index int) []string {
-			productIDIndex := index/5 + 1
-			userID := strconv.Itoa(productIDIndex)
-			eventName := "Product Reviewed " + strconv.Itoa(productIDIndex)
-			tableName := strcase.ToSnake(eventName)
-			ts := timeutil.Now().Format("2006-01-02")
-
-			return []string{destination.ID, "SNOWPIPE_STREAMING", source.ID, source.SourceDefinition.Name, tableName, eventName, "2020-02-02T00:23:09Z", ts, "2020-02-02T00:23:09Z", "2020-02-02T00:23:09Z", userID, ts}
-		})
-		require.ElementsMatch(t, expectedTrackRecords, trackRecordsFromDB)
-
-		cancel()
-		require.NoError(t, <-done)
-	})
 	t.Run("schema modified after channel creation (schema deleted)", func(t *testing.T) {
 		postgresContainer, gatewayPort := initializeTestEnvironment(t)
 		namespace := testhelper.RandSchema()
@@ -1501,7 +1409,6 @@ func runRudderServer(
 	postgresContainer *postgres.Resource,
 	cbURL, transformerURL, snowpipeClientsURL,
 	tmpDir string,
-	configOverrides ...lo.Tuple2[string, any],
 ) (err error) {
 	config.Set("INSTANCE_ID", "1")
 	config.Set("CONFIG_BACKEND_URL", cbURL)
@@ -1536,9 +1443,6 @@ func runRudderServer(
 	config.Set("recovery.enabled", false)
 	config.Set("Profiler.Enabled", false)
 	config.Set("Gateway.enableSuppressUserFeature", false)
-	for _, override := range configOverrides {
-		config.Set(override.A, override.B)
-	}
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/apiadapter.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/apiadapter.go
@@ -15,7 +15,6 @@ const (
 	createChannelAPI = "create_channel"
 	deleteChannelAPI = "delete_channel"
 	insertAPI        = "insert"
-	statusAPI        = "status"
 	bulkStatusAPI    = "bulk_status"
 )
 
@@ -111,23 +110,6 @@ func (a *apiAdapter) Insert(ctx context.Context, channelID string, insertRequest
 	}
 	tags["success"] = strconv.FormatBool(resp.Success)
 	tags["code"] = resp.Code
-	return resp, nil
-}
-
-func (a *apiAdapter) GetStatus(ctx context.Context, channelID string) (*model.StatusResponse, error) {
-	a.logger.Debugn("Getting status",
-		logger.NewStringField("channelId", channelID),
-	)
-
-	tags := a.defaultTags(statusAPI)
-	defer a.recordDuration(tags)()
-
-	resp, err := a.api.GetStatus(ctx, channelID)
-	if err != nil {
-		tags["success"] = "false"
-		return nil, err
-	}
-	tags["success"] = strconv.FormatBool(resp.Success)
 	return resp, nil
 }
 

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -73,7 +73,6 @@ func New(
 	m.config.instanceID = conf.GetStringVar("1", "INSTANCE_ID")
 	m.config.maxBufferCapacity = conf.GetReloadableInt64Var(512*bytesize.KB, bytesize.B, "SnowpipeStreaming.maxBufferCapacity")
 	m.config.stuckPipelineThreshold = conf.GetReloadableDurationVar(15, time.Minute, "SnowpipeStreaming.stuckPipelineThresholdInMinutes")
-	m.config.bulkStatusEnabled = conf.GetReloadableBoolVar(false, "SnowpipeStreaming.bulkStatusEnabled")
 	m.config.bulkStatusBatchSize = conf.GetReloadableIntVar(100, 1, "SnowpipeStreaming.bulkStatusBatchSize")
 	m.config.maxInsertRequestSizeBytes = conf.GetReloadableInt64Var(16*bytesize.MB, bytesize.B, "SnowpipeStreaming.maxInsertRequestSizeBytes")
 
@@ -243,23 +242,19 @@ func (m *Manager) Upload(_ context.Context, asyncDest *common.AsyncDestinationSt
 		abortReason   string
 	)
 
-	// Pre-fetch channel statuses for all channels to avoid duplicate requests.
-	var channelStatuses map[string]*model.StatusResponse
-	if m.config.bulkStatusEnabled.Load() {
-		// Get channel IDs from cache to avoid duplicate requests.
-		channelCacheIDs := lo.FilterMap(uploadInfos, func(info *uploadInfo, _ int) (string, bool) {
-			response, ok := m.channelCache.Load(info.tableName)
-			if !ok {
-				return "", false
-			}
-			return response.(*model.ChannelResponse).ChannelID, true
-		})
-
-		channelStatuses, _, err = m.getBulkStatus(ctx, channelCacheIDs)
-		if err != nil {
-			m.logger.Warnn("Failed to get bulk status", obskit.Error(err))
-			return m.failedJobs(asyncDest, fmt.Errorf("failed to get bulk status: %w", err).Error())
+	// Pre-fetch channel statuses for all cached channels in a single bulk call to avoid duplicate requests.
+	channelCacheIDs := lo.FilterMap(uploadInfos, func(info *uploadInfo, _ int) (string, bool) {
+		response, ok := m.channelCache.Load(info.tableName)
+		if !ok {
+			return "", false
 		}
+		return response.(*model.ChannelResponse).ChannelID, true
+	})
+
+	channelStatuses, _, err := m.getBulkStatus(ctx, channelCacheIDs)
+	if err != nil {
+		m.logger.Warnn("Failed to get bulk status", obskit.Error(err))
+		return m.failedJobs(asyncDest, fmt.Errorf("failed to get bulk status: %w", err).Error())
 	}
 
 	for _, info := range uploadInfos {
@@ -525,19 +520,15 @@ func (m *Manager) checkForDuplicatesDueToOffset(
 	events []*event,
 	channelStatuses map[string]*model.StatusResponse,
 ) (duplicateCount int) {
-	var statusRes *model.StatusResponse
-	var err error
+	var (
+		statusRes *model.StatusResponse
+		err       error
+	)
 
-	if m.config.bulkStatusEnabled.Load() {
-		var ok bool
-
-		statusRes, ok = channelStatuses[channelID]
-		if !ok {
-			// If channel status is not found in the cache, we need to get it from the Snowpipe.
-			statusRes, err = m.getBulkStatusForChannel(ctx, channelID)
-		}
-	} else {
-		statusRes, err = m.api.GetStatus(ctx, channelID)
+	statusRes, ok := channelStatuses[channelID]
+	if !ok {
+		// If channel status is not found in the cache, we need to get it from the Snowpipe.
+		statusRes, err = m.getBulkStatusForChannel(ctx, channelID)
 	}
 
 	if err != nil {
@@ -747,149 +738,7 @@ func (m *Manager) provideInProgressImportInfos(ctx context.Context, infos []*imp
 	if len(nonProcessedInfos) == 0 {
 		return nil
 	}
-	if !m.config.bulkStatusEnabled.Load() {
-		return m.getNonProcessedImportInfos(ctx, nonProcessedInfos)
-	}
 	return m.getNonProcessedImportInfosWithBulkStatus(ctx, nonProcessedInfos)
-}
-
-func (m *Manager) getNonProcessedImportInfos(ctx context.Context, infos []*importInfo) []*importInfo {
-	var inProgressInfos []*importInfo
-
-	for i := range infos {
-		info := infos[i]
-		info.FailedJobIds = nil
-		info.Failed = false
-
-		inProgress, err := m.getImportStatus(ctx, info)
-		if err != nil {
-			m.logger.Warnn("Failed to get import status", obskit.Error(err),
-				logger.NewStringField("channelId", info.ChannelID),
-				logger.NewStringField("expectedOffset", info.Offset),
-				logger.NewStringField("table", info.Table),
-			)
-
-			info.Failed = true
-			info.Reason = err.Error()
-			m.polledImportInfoMap[info.ChannelID] = info
-			continue
-		}
-		if !inProgress {
-			m.polledImportInfoMap[info.ChannelID] = info
-		} else {
-			inProgressInfos = append(inProgressInfos, info)
-		}
-	}
-	return inProgressInfos
-}
-
-func (m *Manager) getImportStatus(ctx context.Context, info *importInfo) (bool, error) {
-	log := m.logger.Withn(
-		logger.NewStringField("channelId", info.ChannelID),
-		logger.NewStringField("expectedOffset", info.Offset),
-		logger.NewStringField("table", info.Table),
-	)
-	log.Infon("Polling for import info")
-
-	statusRes, err := m.api.GetStatus(ctx, info.ChannelID)
-	if err == nil {
-		log.Infon("Polled import info",
-			logger.NewBoolField("success", statusRes.Success),
-			logger.NewStringField("latestCommittedOffset", statusRes.Offset),
-			logger.NewStringField("latestInsertedOffset", statusRes.LatestInsertedOffset),
-			logger.NewBoolField("valid", statusRes.Valid),
-		)
-		if !statusRes.Valid {
-			log.Infon("Invalid status response, recreating channel")
-
-			// Delete the channel from the cache and the Snowpipe as it is invalid
-			if err := m.deleteChannel(ctx, info.Table, info.ChannelID); err != nil {
-				log.Warnn("Failed to delete channel", logger.NewStringField("table", info.Table), logger.NewStringField("channelID", info.ChannelID), obskit.Error(err))
-			}
-
-			var destConf destConfig
-			if decodeErr := destConf.Decode(m.destination.Config); decodeErr != nil {
-				return false, fmt.Errorf("failed to decode destination config during channel recreation: %w", decodeErr)
-			}
-
-			req := buildCreateChannelRequest(m.destination.ID, m.config.instanceID, &destConf, info.Table)
-			recreatedChannel, recreateErr := m.api.CreateChannel(ctx, req)
-			if recreateErr != nil {
-				return false, fmt.Errorf("recreating channel: %w", recreateErr)
-			}
-			m.channelCache.Store(info.Table, recreatedChannel)
-
-			log.Infon("Recreated channel for polling", logger.NewStringField("channelID", recreatedChannel.ChannelID))
-
-			recreatedStatusRes, err := m.api.GetStatus(ctx, recreatedChannel.ChannelID)
-			if err != nil {
-				return false, fmt.Errorf("getting status after channel recreation: %w", err)
-			}
-
-			log.Infon("Polled import info after recreation",
-				logger.NewBoolField("success", recreatedStatusRes.Success),
-				logger.NewStringField("latestCommittedOffset", recreatedStatusRes.Offset),
-				logger.NewStringField("latestInsertedOffset", recreatedStatusRes.LatestInsertedOffset),
-				logger.NewBoolField("valid", recreatedStatusRes.Valid),
-			)
-
-			if !recreatedStatusRes.Valid || !recreatedStatusRes.Success {
-				return false, fmt.Errorf("invalid status response after recreation with valid: %t, success: %t", recreatedStatusRes.Valid, recreatedStatusRes.Success)
-			}
-
-			return isInProgress(recreatedStatusRes, info, log)
-		}
-
-		if !statusRes.Success {
-			return false, fmt.Errorf("invalid status response with valid: %t, success: %t", statusRes.Valid, statusRes.Success)
-		}
-		return isInProgress(statusRes, info, log)
-	}
-	/*
-		404 can happen in the case where the channel is cached in the rudder-server,
-		but then the snowpipe service restarts making the channel id invalid.
-		During polling, we try to recreate the channel to check the status.
-	*/
-	if errors.Is(err, snowpipeapi.ErrChannelNotFound) {
-		log.Infon("Channel not found during polling, attempting to recreate channel", logger.NewStringField("channelID", info.ChannelID))
-
-		var destConf destConfig
-		if decodeErr := destConf.Decode(m.destination.Config); decodeErr != nil {
-			return false, fmt.Errorf("failed to decode destination config during channel recreation: %w", decodeErr)
-		}
-
-		req := buildCreateChannelRequest(m.destination.ID, m.config.instanceID, &destConf, info.Table)
-		recreatedChannel, recreateErr := m.api.CreateChannel(ctx, req)
-		if recreateErr != nil {
-			return false, fmt.Errorf("recreating channel: %w", recreateErr)
-		}
-		m.channelCache.Store(info.Table, recreatedChannel)
-
-		log.Infon("Recreated channel for polling", logger.NewStringField("channelID", recreatedChannel.ChannelID))
-
-		// The new channel id is not being associated with the import info. This is because even if we do that,
-		// it will update the in memory map and not the database
-		// So the next time we poll, we will get the old channel id and not the new one
-
-		recreatedStatusRes, err := m.api.GetStatus(ctx, recreatedChannel.ChannelID)
-		if err != nil {
-			return false, fmt.Errorf("getting status after channel recreation: %w", err)
-		}
-
-		log.Infon("Polled import info after recreation",
-			logger.NewBoolField("success", recreatedStatusRes.Success),
-			logger.NewStringField("latestCommittedOffset", recreatedStatusRes.Offset),
-			logger.NewStringField("latestInsertedOffset", recreatedStatusRes.LatestInsertedOffset),
-			logger.NewBoolField("valid", recreatedStatusRes.Valid),
-		)
-
-		if !recreatedStatusRes.Valid || !recreatedStatusRes.Success {
-			return false, fmt.Errorf("invalid status response after recreation with valid: %t, success: %t", recreatedStatusRes.Valid, recreatedStatusRes.Success)
-		}
-
-		return isInProgress(recreatedStatusRes, info, log)
-	}
-	return false, fmt.Errorf("getting status: %w", err)
 }
 
 func isInProgress(statusRes *model.StatusResponse, info *importInfo, log logger.Logger) (bool, error) {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -35,7 +35,6 @@ type mockAPI struct {
 	createChannelOutputMap map[string]func() (*model.ChannelResponse, error)
 	deleteChannelOutputMap map[string]func() error
 	insertOutputMap        map[string]func() (*model.InsertResponse, error)
-	getStatusOutputMap     map[string]func() (*model.StatusResponse, error)
 	getBulkStatusOutputMap map[string]func() (*model.BulkStatusResponse, error)
 }
 
@@ -52,14 +51,14 @@ func (m *mockAPI) Insert(_ context.Context, channelID string, _ *model.InsertReq
 	return m.insertOutputMap[channelID]()
 }
 
-func (m *mockAPI) GetStatus(_ context.Context, channelID string) (*model.StatusResponse, error) {
-	return m.getStatusOutputMap[channelID]()
+func (m *mockAPI) GetBulkStatus(_ context.Context, channelIDs []string) (*model.BulkStatusResponse, error) {
+	statusKey := bulkStatusKey(channelIDs...)
+	return m.getBulkStatusOutputMap[statusKey]()
 }
 
-func (m *mockAPI) GetBulkStatus(_ context.Context, channelIDs []string) (*model.BulkStatusResponse, error) {
+func bulkStatusKey(channelIDs ...string) string {
 	slices.Sort(channelIDs)
-	channelIDsStr := strings.Join(channelIDs, ",")
-	return m.getBulkStatusOutputMap[channelIDsStr]()
+	return strings.Join(channelIDs, ",")
 }
 
 var (
@@ -172,9 +171,19 @@ func TestSnowpipeStreaming(t *testing.T) {
 				"test-rudder-discards-channel": func() error { return nil },
 				"test-users-channel":           func() error { return nil },
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-rudder-discards-channel": func() (*model.StatusResponse, error) { return nil, assert.AnError },
-				"test-users-channel":           func() (*model.StatusResponse, error) { return nil, assert.AnError },
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-users-channel"},
+					}, nil
+				},
+				"test-rudder-discards-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-rudder-discards-channel"},
+					}, nil
+				},
 			},
 		}
 		sm.api = mockApi
@@ -266,6 +275,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			},
 		}, mockApi.channelReq)
 	})
+
 	t.Run("Upload not able to create event channel", func(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
@@ -293,9 +303,12 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return nil
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-products-channel"},
+					}, nil
 				},
 			},
 		}
@@ -352,12 +365,24 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return nil
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-users-channel", "test-products-channel"},
+					}, nil
 				},
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+				"test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-users-channel"},
+					}, nil
+				},
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-products-channel"},
+					}, nil
 				},
 			},
 		}
@@ -387,6 +412,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			"status":        "failed",
 		}).LastValue())
 	})
+
 	t.Run("Upload insert status failed with deletion error", func(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
@@ -413,12 +439,24 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return assert.AnError
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-products-channel", "test-users-channel"},
+					}, nil
 				},
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+				"test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-users-channel"},
+					}, nil
+				},
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-products-channel"},
+					}, nil
 				},
 			},
 		}
@@ -448,6 +486,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			"status":        "failed",
 		}).LastValue())
 	})
+
 	t.Run("Upload insert error for all events", func(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
@@ -474,12 +513,24 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return nil
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-products-channel", "test-users-channel"},
+					}, nil
 				},
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+				"test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-users-channel"},
+					}, nil
+				},
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-products-channel"},
+					}, nil
 				},
 			},
 		}
@@ -559,12 +610,24 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return nil
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-products-channel", "test-users-channel"},
+					}, nil
 				},
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+				"test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-users-channel"},
+					}, nil
+				},
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-products-channel"},
+					}, nil
 				},
 			},
 		}
@@ -594,6 +657,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			"status":        "failed",
 		}).LastValue())
 	})
+
 	t.Run("Upload discards inserts status failed with deletion error", func(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
@@ -643,12 +707,24 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return assert.AnError
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-users-channel", "test-products-channel"},
+					}, nil
 				},
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+				"test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-users-channel"},
+					}, nil
+				},
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-products-channel"},
+					}, nil
 				},
 			},
 		}
@@ -678,6 +754,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			"status":        "failed",
 		}).LastValue())
 	})
+
 	t.Run("Upload discards inserts error", func(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
@@ -727,12 +804,24 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return nil
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-users-channel", "test-products-channel"},
+					}, nil
 				},
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+				"test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-users-channel"},
+					}, nil
+				},
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-products-channel"},
+					}, nil
 				},
 			},
 		}
@@ -784,8 +873,11 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return &model.InsertResponse{Success: true}, nil
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{Success: true}, nil
+				},
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
 					return nil, assert.AnError
 				},
 			},
@@ -815,6 +907,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			"status":        "failed",
 		}).LastValue())
 	})
+
 	t.Run("Upload latest discards offset", func(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
@@ -853,8 +946,11 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return &model.InsertResponse{Success: true}, nil
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{Success: true}, nil
+				},
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
 					return nil, assert.AnError
 				},
 			},
@@ -884,6 +980,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			"status":        "failed",
 		}).LastValue())
 	})
+
 	t.Run("Upload failed some events", func(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
@@ -910,11 +1007,11 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return nil
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{Success: true}, nil
 				},
-				"test-products-channel": func() (*model.StatusResponse, error) {
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
 					return nil, assert.AnError
 				},
 			},
@@ -945,6 +1042,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			"status":        "failed",
 		}).LastValue())
 	})
+
 	t.Run("Upload with some events succeeding and some aborting", func(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
@@ -971,12 +1069,9 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return &model.InsertResponse{Success: true}, nil
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
-				},
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{Success: true}, nil
 				},
 			},
 		}
@@ -1018,6 +1113,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			}).LastValue(),
 		})
 	})
+
 	t.Run("Upload success", func(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
@@ -1039,8 +1135,11 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return &model.InsertResponse{Success: true}, nil
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{Success: true}, nil
+				},
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
 					return nil, assert.AnError
 				},
 			},
@@ -1092,9 +1191,14 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return &model.InsertResponse{Success: true}, nil
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: true, Success: true},
+						},
+					}, nil
 				},
 			},
 		}
@@ -1152,9 +1256,14 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return &model.InsertResponse{Success: true}, nil
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true, Offset: "1002"}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: true, Success: true, Offset: "1002"},
+						},
+					}, nil
 				},
 			},
 		}
@@ -1223,7 +1332,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 				},
 			},
 			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
-				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
 					return &model.BulkStatusResponse{
 						Success: true,
 						Statuses: map[string]*model.StatusResponse{
@@ -1298,7 +1407,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 				},
 			},
 			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
-				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
 					return &model.BulkStatusResponse{
 						Success:  true,
 						NotFound: []string{"test-users-channel", "test-products-channel"},
@@ -1419,18 +1528,30 @@ func TestSnowpipeStreaming(t *testing.T) {
 					return &model.InsertResponse{Success: true}, nil
 				},
 			},
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-users-channel": {Valid: true, Success: true},
+						},
+					}, nil
 				},
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true}, nil
+				"invalid-test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"invalid-test-products-channel": {Valid: true, Success: true},
+						},
+					}, nil
 				},
-				"test-rudder-discards-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true}, nil
-				},
-				"invalid-test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true}, nil
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: true, Success: true},
+						},
+					}, nil
 				},
 			},
 		}
@@ -1467,12 +1588,15 @@ func TestSnowpipeStreaming(t *testing.T) {
 
 		sm := New(config.New(), logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "1003"}, nil
-				},
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "1004"}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "1003"},
+							"test-users-channel":    {Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "1004"},
+						},
+					}, nil
 				},
 			},
 		}
@@ -1489,18 +1613,31 @@ func TestSnowpipeStreaming(t *testing.T) {
 
 		sm := New(config.New(), logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: false, Success: false, Offset: "0"},
+							"test-users-channel":    {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
 				},
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
+				"test-recreated-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-products-channel": {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
 				},
-				"test-recreated-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
-				},
-				"test-recreated-users-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
+				"test-recreated-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-users-channel": {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
 				},
 			},
 			deleteChannelOutputMap: map[string]func() error{
@@ -1544,12 +1681,15 @@ func TestSnowpipeStreaming(t *testing.T) {
 
 		sm := New(config.New(), logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
-				},
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: false, Success: false, Offset: "0"},
+							"test-users-channel":    {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
 				},
 			},
 			deleteChannelOutputMap: map[string]func() error{
@@ -1593,17 +1733,20 @@ func TestSnowpipeStreaming(t *testing.T) {
 
 		sm := New(config.New(), logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: false, Success: false, Offset: "0"},
+							"test-users-channel":    {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
 				},
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
-				},
-				"test-recreated-products-channel": func() (*model.StatusResponse, error) {
+				"test-recreated-products-channel": func() (*model.BulkStatusResponse, error) {
 					return nil, fmt.Errorf("failed to get status")
 				},
-				"test-recreated-users-channel": func() (*model.StatusResponse, error) {
+				"test-recreated-users-channel": func() (*model.BulkStatusResponse, error) {
 					return nil, fmt.Errorf("failed to get status")
 				},
 			},
@@ -1631,7 +1774,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 		require.Equal(t, http.StatusOK, output.StatusCode)
 		require.True(t, output.Complete)
 		require.True(t, output.HasFailed)
-		require.JSONEq(t, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"getting status after channel recreation: failed to get status","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":true,"reason":"getting status after channel recreation: failed to get status","count":2}]`, output.FailedJobParameters)
+		require.JSONEq(t, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"getting status after channel recreation: failed to get bulk status: failed to get status","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":true,"reason":"getting status after channel recreation: failed to get bulk status: failed to get status","count":2}]`, output.FailedJobParameters)
 		require.EqualValues(t, 4, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
 			"module":        "batch_router",
 			"workspaceId":   "test-workspace",
@@ -1648,18 +1791,31 @@ func TestSnowpipeStreaming(t *testing.T) {
 
 		sm := New(config.New(), logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: false, Success: false, Offset: "0"},
+							"test-users-channel":    {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
 				},
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
+				"test-recreated-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-products-channel": {Valid: true, Success: true, Offset: "1003"},
+						},
+					}, nil
 				},
-				"test-recreated-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true, Offset: "1003"}, nil
-				},
-				"test-recreated-users-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true, Offset: "1004"}, nil
+				"test-recreated-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-users-channel": {Valid: true, Success: true, Offset: "1004"},
+						},
+					}, nil
 				},
 			},
 			deleteChannelOutputMap: map[string]func() error{
@@ -1711,18 +1867,31 @@ func TestSnowpipeStreaming(t *testing.T) {
 
 		sm := New(config.New(), logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: false, Success: false, Offset: "0"},
+							"test-users-channel":    {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
 				},
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
+				"test-recreated-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-products-channel": {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
 				},
-				"test-recreated-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
-				},
-				"test-recreated-users-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: false, Success: false, Offset: "0"}, nil
+				"test-recreated-users-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-users-channel": {Valid: false, Success: false, Offset: "0"},
+						},
+					}, nil
 				},
 			},
 			deleteChannelOutputMap: map[string]func() error{
@@ -1770,7 +1939,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 		sm := New(conf, logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
 			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
-				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
 					return &model.BulkStatusResponse{
 						Success: true,
 						Statuses: map[string]*model.StatusResponse{
@@ -1841,7 +2010,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 		sm := New(conf, logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
 			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
-				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
 					return &model.BulkStatusResponse{
 						Success: true,
 						Statuses: map[string]*model.StatusResponse{
@@ -1896,7 +2065,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 		sm := New(conf, logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
 			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
-				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
 					return &model.BulkStatusResponse{
 						Success: true,
 						Statuses: map[string]*model.StatusResponse{
@@ -1957,7 +2126,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 		sm := New(conf, logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
 			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
-				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
 					return &model.BulkStatusResponse{
 						Success: true,
 						Statuses: map[string]*model.StatusResponse{
@@ -2036,7 +2205,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 		sm := New(conf, logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
 			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
-				"test-products-channel,test-users-channel": func() (*model.BulkStatusResponse, error) {
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
 					return &model.BulkStatusResponse{
 						Success: true,
 						Statuses: map[string]*model.StatusResponse{
@@ -2103,12 +2272,9 @@ func TestSnowpipeStreaming(t *testing.T) {
 
 		sm := New(config.New(), logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
-				},
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return nil, assert.AnError
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{Success: true}, nil
 				},
 			},
 			deleteChannelOutputMap: map[string]func() error{
@@ -2127,7 +2293,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 		require.Equal(t, http.StatusOK, output.StatusCode)
 		require.True(t, output.Complete)
 		require.True(t, output.HasFailed)
-		require.JSONEq(t, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"getting status: assert.AnError general error for testing","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":true,"reason":"getting status: assert.AnError general error for testing","count":2}]`, output.FailedJobParameters)
+		require.JSONEq(t, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"channel not found in bulk status: test-products-channel","count":2},{"channelId":"test-users-channel","offset":"1004","table":"USERS","failed":true,"reason":"channel not found in bulk status: test-users-channel","count":2}]`, output.FailedJobParameters)
 		require.EqualValues(t, 4, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
 			"module":        "batch_router",
 			"workspaceId":   "test-workspace",
@@ -2144,12 +2310,15 @@ func TestSnowpipeStreaming(t *testing.T) {
 
 		sm := New(config.New(), logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true, Offset: "1003"}, nil
-				},
-				"test-users-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true, Offset: "1004"}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-products-channel", "test-users-channel"): func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: true, Success: true, Offset: "1003"},
+							"test-users-channel":    {Valid: true, Success: true, Offset: "1004"},
+						},
+					}, nil
 				},
 			},
 		}
@@ -2187,14 +2356,22 @@ func TestSnowpipeStreaming(t *testing.T) {
 		getStatusCallCount := 0
 		createChannelCallCount := 0
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
 					getStatusCallCount++
-					return nil, internalapi.ErrChannelNotFound
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-products-channel"},
+					}, nil
 				},
-				"recreated-products-channel": func() (*model.StatusResponse, error) {
+				"recreated-products-channel": func() (*model.BulkStatusResponse, error) {
 					getStatusCallCount++
-					return &model.StatusResponse{Success: true, Valid: true, Offset: "1003"}, nil
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"recreated-products-channel": {Success: true, Valid: true, Offset: "1003"},
+						},
+					}, nil
 				},
 			},
 			createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
@@ -2220,9 +2397,12 @@ func TestSnowpipeStreaming(t *testing.T) {
 
 		sm := New(config.New(), logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return nil, internalapi.ErrChannelNotFound
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success:  true,
+						NotFound: []string{"test-products-channel"},
+					}, nil
 				},
 			},
 			createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
@@ -2252,26 +2432,27 @@ func TestSnowpipeStreaming(t *testing.T) {
 		statusCalls := 0
 		sm := New(config.New(), logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-channel-1": func() (*model.StatusResponse, error) {
-					statusCalls += 1
-					return &model.StatusResponse{Valid: false, Success: true}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				bulkStatusKey("test-channel-1", "test-channel-2", "test-channel-3", "test-channel-4"): func() (*model.BulkStatusResponse, error) {
+					statusCalls++
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-channel-1": {Valid: false, Success: true},
+							"test-channel-2": {Valid: true, Success: false},
+							"test-channel-3": {Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "3"},
+							"test-channel-4": {Valid: true, Success: true, Offset: "4", LatestInsertedOffset: "4"},
+						},
+					}, nil
 				},
-				"test-channel-2": func() (*model.StatusResponse, error) {
-					statusCalls += 1
-					return &model.StatusResponse{Valid: true, Success: false}, nil
-				},
-				"test-channel-3": func() (*model.StatusResponse, error) {
-					statusCalls += 1
-					return &model.StatusResponse{Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "3"}, nil
-				},
-				"test-channel-4": func() (*model.StatusResponse, error) {
-					statusCalls += 1
-					return &model.StatusResponse{Valid: true, Success: true, Offset: "4", LatestInsertedOffset: "4"}, nil
-				},
-				"test-recreated-channel-1": func() (*model.StatusResponse, error) {
-					statusCalls += 1
-					return &model.StatusResponse{Valid: false, Success: true, Offset: "1"}, nil
+				"test-recreated-channel-1": func() (*model.BulkStatusResponse, error) {
+					statusCalls++
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-recreated-channel-1": {Valid: false, Success: true, Offset: "1"},
+						},
+					}, nil
 				},
 			},
 			createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
@@ -2290,12 +2471,17 @@ func TestSnowpipeStreaming(t *testing.T) {
 		})
 		require.True(t, output.InProgress)
 
-		t.Log("Polling again should not call getStatus for channels 1, 2 and 4 since they already reached the terminal state")
+		t.Log("Polling again should not call getBulkStatus for channels 1, 2 and 4 since they already reached the terminal state")
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-channel-3": func() (*model.StatusResponse, error) {
-					statusCalls += 1
-					return &model.StatusResponse{Valid: true, Success: true, Offset: "3"}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-channel-3": func() (*model.BulkStatusResponse, error) {
+					statusCalls++
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-channel-3": {Valid: true, Success: true, Offset: "3"},
+						},
+					}, nil
 				},
 			},
 			deleteChannelOutputMap: map[string]func() error{
@@ -2314,7 +2500,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 		require.Equal(t, http.StatusOK, output.StatusCode)
 		require.True(t, output.Complete)
 		require.True(t, output.HasFailed)
-		require.Equal(t, `[{"channelId":"test-channel-1","offset":"1","table":"1","failed":true,"reason":"invalid status response after recreation with valid: false, success: true","count":1},{"channelId":"test-channel-2","offset":"2","table":"2","failed":true,"reason":"invalid status response with valid: true, success: false","count":2},{"channelId":"test-channel-3","offset":"3","table":"3","failed":false,"reason":"","count":3},{"channelId":"test-channel-4","offset":"4","table":"4","failed":false,"reason":"","count":4}]`, output.FailedJobParameters)
+		require.Equal(t, `[{"channelId":"test-channel-1","offset":"1","table":"1","failed":true,"reason":"invalid status response after recreation with valid: false, success: true","count":1},{"channelId":"test-channel-2","offset":"2","table":"2","failed":true,"reason":"failed to get status with success: false","count":2},{"channelId":"test-channel-3","offset":"3","table":"3","failed":false,"reason":"","count":3},{"channelId":"test-channel-4","offset":"4","table":"4","failed":false,"reason":"","count":4}]`, output.FailedJobParameters)
 		require.EqualValues(t, 3, statsStore.Get("snowpipe_streaming_jobs", stats.Tags{
 			"module":        "batch_router",
 			"workspaceId":   "test-workspace",
@@ -2335,7 +2521,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			"destType":      "SNOWPIPE_STREAMING",
 			"destinationId": "test-destination",
 		}).LastValue())
-		require.Equal(t, 6, statusCalls) // 4 channels + 1 for polling in progress + 1 for recreation
+		require.Equal(t, 3, statusCalls) // 1 bulk poll + 1 recreation bulk poll + 1 second poll
 	})
 
 	// Unexpected polling state encountered mark events as failed
@@ -2346,9 +2532,14 @@ func TestSnowpipeStreaming(t *testing.T) {
 
 		sm := New(config.New(), logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true, Offset: "1005", LatestInsertedOffset: "1003"}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: true, Success: true, Offset: "1005", LatestInsertedOffset: "1003"},
+						},
+					}, nil
 				},
 			},
 			deleteChannelOutputMap: map[string]func() error{
@@ -2374,9 +2565,14 @@ func TestSnowpipeStreaming(t *testing.T) {
 
 		sm := New(config.New(), logger.NOP, statsStore, destination)
 		sm.api = &mockAPI{
-			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
-				"test-products-channel": func() (*model.StatusResponse, error) {
-					return &model.StatusResponse{Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "1003"}, nil
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "1003"},
+						},
+					}, nil
 				},
 			},
 			deleteChannelOutputMap: map[string]func() error{
@@ -2575,7 +2771,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			name                       string
 			infos                      []*importInfo
 			prePopulatedCache          map[string]*importInfo
-			mockGetStatusResponses     map[string]func() (*model.StatusResponse, error)
+			mockGetBulkStatusResponses map[string]func() (*model.BulkStatusResponse, error)
 			mockDeleteChannelResponses map[string]func() error
 			mockCreateChannelResponses map[string]func() (*model.ChannelResponse, error)
 			expectedInProgress         bool
@@ -2622,9 +2818,9 @@ func TestSnowpipeStreaming(t *testing.T) {
 						Count:     5,
 					},
 				},
-				mockGetStatusResponses: map[string]func() (*model.StatusResponse, error){
-					"test-channel-1": func() (*model.StatusResponse, error) {
-						return nil, fmt.Errorf("API error")
+				mockGetBulkStatusResponses: map[string]func() (*model.BulkStatusResponse, error){
+					"test-channel-1": func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{Success: true}, nil
 					},
 				},
 				expectedInProgress:     false,
@@ -2641,13 +2837,18 @@ func TestSnowpipeStreaming(t *testing.T) {
 						Count:     5,
 					},
 				},
-				mockGetStatusResponses: map[string]func() (*model.StatusResponse, error){
-					"test-channel-1": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:                true,
-							Success:              true,
-							Offset:               "50",  // Less than expected "100"
-							LatestInsertedOffset: "100", // Greater than committed - flushing in progress
+				mockGetBulkStatusResponses: map[string]func() (*model.BulkStatusResponse, error){
+					"test-channel-1": func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-1": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "50",
+									LatestInsertedOffset: "100",
+								},
+							},
 						}, nil
 					},
 				},
@@ -2665,13 +2866,18 @@ func TestSnowpipeStreaming(t *testing.T) {
 						Count:     5,
 					},
 				},
-				mockGetStatusResponses: map[string]func() (*model.StatusResponse, error){
-					"test-channel-1": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:                true,
-							Success:              true,
-							Offset:               "100", // Equal to expected
-							LatestInsertedOffset: "100",
+				mockGetBulkStatusResponses: map[string]func() (*model.BulkStatusResponse, error){
+					"test-channel-1": func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-1": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "100",
+									LatestInsertedOffset: "100",
+								},
+							},
 						}, nil
 					},
 				},
@@ -2689,13 +2895,18 @@ func TestSnowpipeStreaming(t *testing.T) {
 						Count:     5,
 					},
 				},
-				mockGetStatusResponses: map[string]func() (*model.StatusResponse, error){
-					"test-channel-1": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:                true,
-							Success:              true,
-							Offset:               "50", // Less than expected
-							LatestInsertedOffset: "50", // Equal to committed - events lost
+				mockGetBulkStatusResponses: map[string]func() (*model.BulkStatusResponse, error){
+					"test-channel-1": func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-1": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "50",
+									LatestInsertedOffset: "50",
+								},
+							},
 						}, nil
 					},
 				},
@@ -2746,24 +2957,24 @@ func TestSnowpipeStreaming(t *testing.T) {
 						Failed:    false,
 					},
 				},
-				mockGetStatusResponses: map[string]func() (*model.StatusResponse, error){
-					"test-channel-1": func() (*model.StatusResponse, error) {
-						return nil, fmt.Errorf("network error")
-					},
-					"test-channel-3": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:                true,
-							Success:              true,
-							Offset:               "250",
-							LatestInsertedOffset: "300", // In progress
-						}, nil
-					},
-					"test-channel-4": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:                true,
-							Success:              true,
-							Offset:               "400", // Completed
-							LatestInsertedOffset: "400",
+				mockGetBulkStatusResponses: map[string]func() (*model.BulkStatusResponse, error){
+					bulkStatusKey("test-channel-1", "test-channel-3", "test-channel-4"): func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-3": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "250",
+									LatestInsertedOffset: "300",
+								},
+								"test-channel-4": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "400",
+									LatestInsertedOffset: "400",
+								},
+							},
 						}, nil
 					},
 				},
@@ -2788,21 +2999,24 @@ func TestSnowpipeStreaming(t *testing.T) {
 						Count:     3,
 					},
 				},
-				mockGetStatusResponses: map[string]func() (*model.StatusResponse, error){
-					"test-channel-1": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:                true,
-							Success:              true,
-							Offset:               "50",
-							LatestInsertedOffset: "100", // In progress
-						}, nil
-					},
-					"test-channel-2": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:                true,
-							Success:              true,
-							Offset:               "150",
-							LatestInsertedOffset: "200", // In progress
+				mockGetBulkStatusResponses: map[string]func() (*model.BulkStatusResponse, error){
+					bulkStatusKey("test-channel-1", "test-channel-2"): func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-1": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "50",
+									LatestInsertedOffset: "100",
+								},
+								"test-channel-2": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "150",
+									LatestInsertedOffset: "200",
+								},
+							},
 						}, nil
 					},
 				},
@@ -2826,17 +3040,19 @@ func TestSnowpipeStreaming(t *testing.T) {
 						Count:     3,
 					},
 				},
-				mockGetStatusResponses: map[string]func() (*model.StatusResponse, error){
-					"test-channel-1": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:                true,
-							Success:              true,
-							Offset:               "100", // Completed
-							LatestInsertedOffset: "100",
+				mockGetBulkStatusResponses: map[string]func() (*model.BulkStatusResponse, error){
+					bulkStatusKey("test-channel-1", "test-channel-2"): func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-1": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "100",
+									LatestInsertedOffset: "100",
+								},
+							},
 						}, nil
-					},
-					"test-channel-2": func() (*model.StatusResponse, error) {
-						return nil, fmt.Errorf("failed to get status")
 					},
 				},
 				expectedInProgress:     false,
@@ -2860,13 +3076,18 @@ func TestSnowpipeStreaming(t *testing.T) {
 						},
 					},
 				},
-				mockGetStatusResponses: map[string]func() (*model.StatusResponse, error){
-					"test-channel-1": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:                true,
-							Success:              true,
-							Offset:               "100",
-							LatestInsertedOffset: "100",
+				mockGetBulkStatusResponses: map[string]func() (*model.BulkStatusResponse, error){
+					"test-channel-1": func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-1": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "100",
+									LatestInsertedOffset: "100",
+								},
+							},
 						}, nil
 					},
 				},
@@ -2884,19 +3105,21 @@ func TestSnowpipeStreaming(t *testing.T) {
 						Count:     5,
 					},
 				},
-				mockGetStatusResponses: map[string]func() (*model.StatusResponse, error){
-					"test-channel-1": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:   false,
+				mockGetBulkStatusResponses: map[string]func() (*model.BulkStatusResponse, error){
+					"test-channel-1": func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{
 							Success: true,
-							Offset:  "100",
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-1": {Valid: false, Success: true, Offset: "100"},
+							},
 						}, nil
 					},
-					"test-recreated-channel-1": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:   false,
+					"test-recreated-channel-1": func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{
 							Success: true,
-							Offset:  "100",
+							Statuses: map[string]*model.StatusResponse{
+								"test-recreated-channel-1": {Valid: false, Success: true, Offset: "100"},
+							},
 						}, nil
 					},
 				},
@@ -2924,12 +3147,13 @@ func TestSnowpipeStreaming(t *testing.T) {
 						Count:     5,
 					},
 				},
-				mockGetStatusResponses: map[string]func() (*model.StatusResponse, error){
-					"test-channel-1": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:   true,
-							Success: false,
-							Offset:  "100",
+				mockGetBulkStatusResponses: map[string]func() (*model.BulkStatusResponse, error){
+					"test-channel-1": func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-1": {Valid: true, Success: false, Offset: "100"},
+							},
 						}, nil
 					},
 				},
@@ -2947,13 +3171,18 @@ func TestSnowpipeStreaming(t *testing.T) {
 						Count:     5,
 					},
 				},
-				mockGetStatusResponses: map[string]func() (*model.StatusResponse, error){
-					"test-channel-1": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:                true,
-							Success:              true,
-							Offset:               "", // Empty offset
-							LatestInsertedOffset: "100",
+				mockGetBulkStatusResponses: map[string]func() (*model.BulkStatusResponse, error){
+					"test-channel-1": func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-1": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "",
+									LatestInsertedOffset: "100",
+								},
+							},
 						}, nil
 					},
 				},
@@ -2971,13 +3200,18 @@ func TestSnowpipeStreaming(t *testing.T) {
 						Count:     5,
 					},
 				},
-				mockGetStatusResponses: map[string]func() (*model.StatusResponse, error){
-					"test-channel-1": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:                true,
-							Success:              true,
-							Offset:               "", // Empty offset
-							LatestInsertedOffset: "", // Empty LatestInsertedOffset
+				mockGetBulkStatusResponses: map[string]func() (*model.BulkStatusResponse, error){
+					"test-channel-1": func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-1": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "",
+									LatestInsertedOffset: "",
+								},
+							},
 						}, nil
 					},
 				},
@@ -3001,13 +3235,18 @@ func TestSnowpipeStreaming(t *testing.T) {
 						Count:     5,
 					},
 				},
-				mockGetStatusResponses: map[string]func() (*model.StatusResponse, error){
-					"test-channel-1": func() (*model.StatusResponse, error) {
-						return &model.StatusResponse{
-							Valid:                true,
-							Success:              true,
-							Offset:               "",   // Empty offset
-							LatestInsertedOffset: "75", // Less than expected
+				mockGetBulkStatusResponses: map[string]func() (*model.BulkStatusResponse, error){
+					"test-channel-1": func() (*model.BulkStatusResponse, error) {
+						return &model.BulkStatusResponse{
+							Success: true,
+							Statuses: map[string]*model.StatusResponse{
+								"test-channel-1": {
+									Valid:                true,
+									Success:              true,
+									Offset:               "",
+									LatestInsertedOffset: "75",
+								},
+							},
 						}, nil
 					},
 				},
@@ -3036,7 +3275,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 
 				// Set up mock API if needed
 				sm.api = &mockAPI{
-					getStatusOutputMap:     tt.mockGetStatusResponses,
+					getBulkStatusOutputMap: tt.mockGetBulkStatusResponses,
 					deleteChannelOutputMap: tt.mockDeleteChannelResponses,
 					createChannelOutputMap: tt.mockCreateChannelResponses,
 				}
@@ -3087,7 +3326,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			bulkCallCount := 0
 			sm.api = &mockAPI{
 				getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
-					"test-channel-1,test-channel-2": func() (*model.BulkStatusResponse, error) {
+					bulkStatusKey("test-channel-1", "test-channel-2"): func() (*model.BulkStatusResponse, error) {
 						bulkCallCount++
 						return &model.BulkStatusResponse{
 							Success: true,
@@ -3164,7 +3403,7 @@ func TestSnowpipeStreaming(t *testing.T) {
 			bulkCallCount := 0
 			sm.api = &mockAPI{
 				getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
-					"test-channel-1,test-channel-2": func() (*model.BulkStatusResponse, error) {
+					bulkStatusKey("test-channel-1", "test-channel-2"): func() (*model.BulkStatusResponse, error) {
 						bulkCallCount++
 						return &model.BulkStatusResponse{
 							Success: true,

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
@@ -46,7 +46,6 @@ type (
 			instanceID                string
 			maxBufferCapacity         config.ValueLoader[int64]
 			stuckPipelineThreshold    config.ValueLoader[time.Duration]
-			bulkStatusEnabled         config.ValueLoader[bool]
 			bulkStatusBatchSize       config.ValueLoader[int]
 			maxInsertRequestSizeBytes config.ValueLoader[int64]
 		}
@@ -139,7 +138,6 @@ type (
 		CreateChannel(ctx context.Context, channelReq *model.CreateChannelRequest) (*model.ChannelResponse, error)
 		DeleteChannel(ctx context.Context, channelID string, sync bool) error
 		Insert(ctx context.Context, channelID string, insertRequest *model.InsertRequest) (*model.InsertResponse, error)
-		GetStatus(ctx context.Context, channelID string) (*model.StatusResponse, error)
 		GetBulkStatus(ctx context.Context, channelIDs []string) (*model.BulkStatusResponse, error)
 	}
 


### PR DESCRIPTION
# Description

The bulk-status path has been tested at flags=true and works correctly, so we can drop the deprecated per-channel GetStatus path and the flag.

- Remove SnowpipeStreaming.bulkStatusEnabled config registration and field
- Remove GetStatus from the api interface; drop apiAdapter.GetStatus wrapper and the statusAPI const (the lower-level internal/api/api.go GetStatus is kept intact since it's tested independently)
- Remove getNonProcessedImportInfos and getImportStatus (dead code)
- Always pre-fetch bulk status in Upload and always use bulk status in checkForDuplicatesDueToOffset / provideInProgressImportInfos

Tests:
- Drop GetStatus from mockAPI; remove getStatusOutputMap from all test literals; add getBulkStatusOutputMap entries to Upload tests that pre-cache channels
- Delete tests that exclusively exercised the deprecated path (the 5 'Poll status invalid' tests with a non-bulk variant, the table-driven provideInProgressImportInfos non-bulk test, and the non-bulk 'Upload with duplicate ids due to offset' test); their bulk-status variants are kept
- Rename the bulk variants to drop the 'with bulk status enabled' suffix
- Convert remaining Poll tests (in progress, success, error, 404, caching, unexpected state, threshold) to use bulk-status mocks
- Drop the now-redundant 'many table (bulk status enabled)' integration subtest (duplicate of the existing 'many tables' test once bulk-status is the only path)


## Linear Ticket

- Resolves INT-6405

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
