### PR TITLE
fix(gateway/webhook): reject blank-body requests immediately instead …

### DIFF
--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -78,6 +78,8 @@ const (
 	NoDestinationIDInHeader = "failed to read destination id from header"
 	// ErrAuthenticatingWebhookRequest = "error occurred while authenticating the webhook request"
 	ErrAuthenticatingWebhookRequest = "error occurred while authenticating the webhook request"
+	 // NoRequestBody - request body is empty
+	NoRequestBody = "request body is empty"
 
 	transPixelResponse = "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x21\xF9\x04" +
 		"\x01\x00\x00\x00\x00\x2C\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3B"
@@ -123,6 +125,7 @@ var statusMap = map[string]status{
 	GatewayTimeout:                                 {message: GatewayTimeout, code: http.StatusGatewayTimeout},
 	ServiceUnavailable:                             {message: ServiceUnavailable, code: http.StatusServiceUnavailable},
 	ErrAuthenticatingWebhookRequest:                {message: ErrAuthenticatingWebhookRequest, code: http.StatusInternalServerError},
+	NoRequestBody:                                  {message: NoRequestBody, code: http.StatusBadRequest},
 }
 
 // status holds the gateway response status message and code

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -212,6 +212,21 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 		r.Header.Set("Content-Type", "application/json")
 	}
 
+// Short-circuit requests with a blank body before they hit the batch queue.
+ // GET-allowed sources (forwardGetRequestForSrcMap) carry their payload in the URL and are exempt.
+ _, isGetAllowed := webhook.config.forwardGetRequestForSrcMap[strings.ToLower(sourceDefName)]
+ if r.Method != http.MethodGet && !isGetAllowed && len(jsonByte) == 0 && r.ContentLength == 0 {
+     stat := webhook.statReporterCreator(arctx, reqType)
+     stat.RequestFailed(response.NoRequestBody)
+     stat.Report(webhook.stats)
+     webhook.failRequest(w, r,
+         response.GetStatus(response.NoRequestBody),
+         response.GetErrorStatusCode(response.NoRequestBody),
+     )
+     webhook.ackCount.Add(1)
+     return
+ }
+
 	done := make(chan transformerResponse)
 	req := webhookT{
 		request:     r,

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 	"testing/iotest"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,6 +121,50 @@ func TestWebhookMaxRequestSize(t *testing.T) {
 
 	webhookHandler.RequestHandler(resp, req.WithContext(reqCtx))
 	require.Equal(t, http.StatusRequestEntityTooLarge, resp.Result().StatusCode)
+}
+
+func TestWebhookBlankBodyRequestIsRejectedImmediately(t *testing.T) {
+   initWebhook()
+
+   ctrl := gomock.NewController(t)
+   mockGW := mockWebhook.NewMockGateway(ctrl)
+   mockTransformerFeaturesService := mock_features.NewMockFeaturesService(ctrl)
+
+   // Set a large batch timeout so the test would hang if the blank-body guard is missing.
+   config.Set("Gateway.webhook.batchTimeoutInMS", 5000)
+
+   webhookHandler := Setup(mockGW, mockTransformerFeaturesService, stats.NOP, config.Default, newSourceStatReporter, func(bt *batchWebhookTransformerT) {
+       bt.sourceTransformAdapter = func(ctx context.Context) (sourceTransformAdapter, error) {
+           return &mockSourceTransformAdapter{}, nil
+       }
+  })
+   t.Cleanup(func() { _ = webhookHandler.Shutdown() })
+
+   webhookHandler.Register(sourceDefName)
+
+   req := httptest.NewRequest(http.MethodPost, "/v1/webhook", http.NoBody)
+   req.ContentLength = 0
+   resp := httptest.NewRecorder()
+
+   reqCtx := context.WithValue(req.Context(), gwtypes.CtxParamCallType, "webhook")
+   reqCtx = context.WithValue(reqCtx, gwtypes.CtxParamAuthRequestContext, &gwtypes.AuthRequestContext{
+       SourceDefName: sourceDefName,
+   })
+
+   // Should return 400 immediately without waiting for batch timeout.
+   done := make(chan struct{})
+   go func() {
+       webhookHandler.RequestHandler(resp, req.WithContext(reqCtx))
+       close(done)
+   }()
+
+   select {
+   case <-done:
+       require.Equal(t, http.StatusBadRequest, resp.Result().StatusCode)
+       require.Contains(t, strings.TrimSpace(resp.Body.String()), response.NoRequestBody)
+   case <-time.After(2 * time.Second):
+       t.Fatal("RequestHandler did not return immediately for blank body — likely waiting for batch timeout")
+   }
 }
 
 func newSourceStatReporter(_ *gwtypes.AuthRequestContext, _ string) gwtypes.StatReporter {


### PR DESCRIPTION
Short-circuit blank-body webhook requests
Webhook POST requests with an empty body are now rejected at the HTTP layer with 400 request body is empty before entering the batch queue, instead of waiting for the batch timeout or burning a source transformer call.
GET-allowed sources (e.g. Adjust) are unaffected.
Files changed:

gateway/response/response.go — new NoRequestBody constant
gateway/webhook/webhook.go — blank-body guard in RequestHandler, removes resolved TODO
gateway/webhook/webhook_test.go — adds TestWebhookBlankBodyRequestIsRejectedImmediately