### PR TITLE
Return bad request for empty webhook payload

### DIFF
--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -10,6 +10,8 @@ const (
 	Ok = "ok"
 	// RequestBodyNil - Request body is nil
 	RequestBodyNil = "request body is nil"
+	// NoRequestBody - Request body is empty
+	NoRequestBody = "request body is empty"
 	// InvalidRequestMethod - Request Method is invalid
 	InvalidRequestMethod = "invalid http request method"
 	// TooManyRequests - too many requests
@@ -88,6 +90,7 @@ const (
 var statusMap = map[string]status{
 	Ok:                      {message: Ok, code: http.StatusOK},
 	RequestBodyNil:          {message: RequestBodyNil, code: http.StatusBadRequest},
+	NoRequestBody:           {message: NoRequestBody, code: http.StatusBadRequest},
 	InvalidRequestMethod:    {message: InvalidRequestMethod, code: http.StatusBadRequest},
 	TooManyRequests:         {message: TooManyRequests, code: http.StatusTooManyRequests},
 	NoWriteKeyInBasicAuth:   {message: NoWriteKeyInBasicAuth, code: http.StatusUnauthorized},

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -211,7 +211,17 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 		r.Body = io.NopCloser(bytes.NewReader(jsonByte))
 		r.Header.Set("Content-Type", "application/json")
 	}
+	if len(jsonByte) == 0 && r.ContentLength == 0 {
+		webhook.failRequest(
+			w,
+			r,
+			response.GetStatus(response.NoRequestBody),
+			response.GetErrorStatusCode(response.NoRequestBody),
+		)
 
+		webhook.ackCount.Add(1)
+		return
+	}
 	done := make(chan transformerResponse)
 	req := webhookT{
 		request:     r,


### PR DESCRIPTION
## Description

This PR adds validation for empty webhook payloads.

Previously, requests with an empty body were not explicitly handled. This change returns an HTTP 400 Bad Request response when a webhook request contains no payload.

## Changes

- Added `NoRequestBody` response status
- Added status mapping for HTTP 400 Bad Request
- Added validation in the webhook handler for empty payload requests

## Linear Ticket

N/A

## Security

- [x] The code changed as part of this pull request does not introduce any known security issues.