### PR TITLE
fix: use context.Background() for cleanup operations to prevent context deadline exceeded errors

### DIFF
--- a/warehouse/router/identities.go
+++ b/warehouse/router/identities.go
@@ -455,7 +455,7 @@ func (r *Router) populateHistoricIdentities(ctx context.Context, warehouse model
 			_, _ = job.setUploadError(err, model.Aborted)
 			return
 		}
-		defer whManager.Cleanup(ctx)
+		defer whManager.Cleanup(context.Background())
 		_ = job.setUploadStatus(UploadStatusOpts{Status: inProgressState(model.ExportedData)})
 		loadErrors, err := job.loadIdentityTables(true)
 		if err != nil {

--- a/warehouse/router/upload.go
+++ b/warehouse/router/upload.go
@@ -326,7 +326,7 @@ func (job *UploadJob) run() (err error) {
 		_, _ = job.setUploadError(err, InternalProcessingFailed)
 		return err
 	}
-	defer whManager.Cleanup(job.ctx)
+	defer whManager.Cleanup(context.Background())
 
 	job.schemaHandle, err = schema.New(
 		job.ctx,
@@ -526,7 +526,7 @@ func (job *UploadJob) cleanupObjectStorageFiles() error {
 	)
 
 	if !whutils.IsDatalakeDestination(destination.DestinationDefinition.Name) {
-		loadingFiles, err := job.loadFilesRepo.Get(job.ctx, job.upload.ID)
+		loadingFiles, err := job.loadFilesRepo.Get(context.Background(), job.upload.ID)
 		if err != nil {
 			return fmt.Errorf("fetching loading files: %w", err)
 		}
@@ -563,7 +563,7 @@ func (job *UploadJob) cleanupObjectStorageFiles() error {
 
 	startTime := job.now()
 
-	g, ctx := errgroup.WithContext(job.ctx)
+	g, ctx := errgroup.WithContext(context.Background())
 	g.SetLimit(concurrency)
 	for _, chunk := range lo.Chunk(filesToDel, chunkSize) {
 		g.Go(func() error {


### PR DESCRIPTION
## Description
When "Enable for cleanup of object storage files (deletion) after successful sync" is enabled, cleanup operations were using `job.ctx` which may be cancelled or have a deadline that expires. This caused constant "context deadline exceeded" errors as reported in issue #6349.

## Root Cause
The `job.ctx` context is derived from the router's errgroup context and may be cancelled at any time (e.g., on shutdown, errgroup errors, or parent context cancellation). Cleanup operations like `whManager.Cleanup()` and `cleanupObjectStorageFiles()` were using this context, causing failures when the context was no longer valid.

## Changes
1. **warehouse/router/upload.go**:
   - `defer whManager.Cleanup(job.ctx)` changed to `defer whManager.Cleanup(context.Background())` - ensures warehouse manager cleanup (closing DB connections, dropping dangling staging tables) runs regardless of job context state
   - `job.loadFilesRepo.Get(job.ctx, ...)` changed to `job.loadFilesRepo.Get(context.Background(), ...)` - ensures fetching load files for cleanup isn't tied to job context
   - `errgroup.WithContext(job.ctx)` changed to `errgroup.WithContext(context.Background())` - ensures object storage file deletions aren't cancelled by job context cancellation

2. **warehouse/router/identities.go**:
   - `defer whManager.Cleanup(ctx)` changed to `defer whManager.Cleanup(context.Background())` - same fix for identity table cleanup

## Testing
- Existing tests continue to work since they use `context.Background()` for `job.ctx`
- The filemanager already has its own configurable timeout (default 2 minutes), so using `context.Background()` won't cause hangs
