### PR TITLE
chore(gateway/webhook): short-circuit blank-body webhook requests instead of waiting for batch timeout

### DIFF
--- a/gateway/response/response.go
+++ b/gateway/response/response.go
@@ -78,6 +78,8 @@ const (
 	NoDestinationIDInHeader = "failed to read destination id from header"
 	// ErrAuthenticatingWebhookRequest = "error occurred while authenticating the webhook request"
 	ErrAuthenticatingWebhookRequest = "error occurred while authenticating the webhook request"
+	// NoRequestBody - request body is empty
+	NoRequestBody = "no request body"
 
 	transPixelResponse = "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x21\xF9\x04" +
 		"\x01\x00\x00\x00\x00\x2C\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3B"
@@ -123,6 +125,7 @@ var statusMap = map[string]status{
 	GatewayTimeout:                                 {message: GatewayTimeout, code: http.StatusGatewayTimeout},
 	ServiceUnavailable:                             {message: ServiceUnavailable, code: http.StatusServiceUnavailable},
 	ErrAuthenticatingWebhookRequest:                {message: ErrAuthenticatingWebhookRequest, code: http.StatusInternalServerError},
+	NoRequestBody:                                  {message: NoRequestBody, code: http.StatusBadRequest},
 }
 
 // status holds the gateway response status message and code

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -212,6 +212,15 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 		r.Header.Set("Content-Type", "application/json")
 	}
 
+	if r.Method != http.MethodGet && len(jsonByte) == 0 && r.ContentLength == 0 {
+		stat := webhook.statReporterCreator(arctx, reqType)
+		stat.RequestFailed(response.NoRequestBody)
+		stat.Report(webhook.stats)
+		webhook.failRequest(w, r, response.GetStatus(response.NoRequestBody), response.GetErrorStatusCode(response.NoRequestBody))
+		webhook.ackCount.Add(1)
+		return
+	}
+
 	done := make(chan transformerResponse)
 	req := webhookT{
 		request:     r,
@@ -317,7 +326,6 @@ func (webhook *HandleT) batchRequests(sourceDef string, requestQ chan *webhookT)
 	}
 }
 
-// TODO : return back immediately for blank request body. its waiting till timeout
 func (bt *batchWebhookTransformerT) batchTransformLoop() {
 	for breq := range bt.webhook.batchRequestQ {
 		// If unable to fetch features from transformer, send GatewayTimeout to all requests

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -126,6 +126,37 @@ func newSourceStatReporter(_ *gwtypes.AuthRequestContext, _ string) gwtypes.Stat
 	return &gwStats.SourceStat{}
 }
 
+func TestWebhookRequestHandlerWithEmptyBody(t *testing.T) {
+	initWebhook()
+
+	ctrl := gomock.NewController(t)
+	mockGW := mockWebhook.NewMockGateway(ctrl)
+
+	mockTransformerFeaturesService := mock_features.NewMockFeaturesService(ctrl)
+
+	webhookHandler := Setup(mockGW, mockTransformerFeaturesService, stats.NOP, config.Default, newSourceStatReporter, func(bt *batchWebhookTransformerT) {
+		bt.sourceTransformAdapter = func(ctx context.Context) (sourceTransformAdapter, error) {
+			return &mockSourceTransformAdapter{}, nil
+		}
+	})
+	t.Cleanup(func() {
+		_ = webhookHandler.Shutdown()
+	})
+
+	webhookHandler.Register(sourceDefName)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhook", http.NoBody)
+	resp := httptest.NewRecorder()
+	reqCtx := context.WithValue(req.Context(), gwtypes.CtxParamCallType, "webhook")
+	reqCtx = context.WithValue(reqCtx, gwtypes.CtxParamAuthRequestContext, &gwtypes.AuthRequestContext{
+		SourceDefName: sourceDefName,
+	})
+
+	webhookHandler.RequestHandler(resp, req.WithContext(reqCtx))
+	require.Equal(t, http.StatusBadRequest, resp.Result().StatusCode)
+	require.Equal(t, response.GetStatus(response.NoRequestBody), strings.TrimSpace(resp.Body.String()))
+}
+
 func TestWebhookRequestHandlerWithTransformerBatchGeneralError(t *testing.T) {
 	initWebhook()
 	ctrl := gomock.NewController(t)

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -145,16 +145,43 @@ func TestWebhookRequestHandlerWithEmptyBody(t *testing.T) {
 
 	webhookHandler.Register(sourceDefName)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/webhook", http.NoBody)
-	resp := httptest.NewRecorder()
-	reqCtx := context.WithValue(req.Context(), gwtypes.CtxParamCallType, "webhook")
-	reqCtx = context.WithValue(reqCtx, gwtypes.CtxParamAuthRequestContext, &gwtypes.AuthRequestContext{
-		SourceDefName: sourceDefName,
-	})
+	testCases := []struct {
+		name          string
+		body          io.Reader
+		contentLength int64
+	}{
+		{
+			name:          "no body",
+			body:          http.NoBody,
+			contentLength: 0,
+		},
+		{
+			name:          "empty body with unknown content length",
+			body:          strings.NewReader(""),
+			contentLength: -1,
+		},
+		{
+			name:          "whitespace-only body with unknown content length",
+			body:          strings.NewReader("   \n"),
+			contentLength: -1,
+		},
+	}
 
-	webhookHandler.RequestHandler(resp, req.WithContext(reqCtx))
-	require.Equal(t, http.StatusBadRequest, resp.Result().StatusCode)
-	require.Equal(t, response.GetStatus(response.NoRequestBody), strings.TrimSpace(resp.Body.String()))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/webhook", tc.body)
+			req.ContentLength = tc.contentLength
+			resp := httptest.NewRecorder()
+			reqCtx := context.WithValue(req.Context(), gwtypes.CtxParamCallType, "webhook")
+			reqCtx = context.WithValue(reqCtx, gwtypes.CtxParamAuthRequestContext, &gwtypes.AuthRequestContext{
+				SourceDefName: sourceDefName,
+			})
+
+			webhookHandler.RequestHandler(resp, req.WithContext(reqCtx))
+			require.Equal(t, http.StatusBadRequest, resp.Result().StatusCode)
+			require.Equal(t, response.GetStatus(response.NoRequestBody), strings.TrimSpace(resp.Body.String()))
+		})
+	}
 }
 
 func TestWebhookRequestHandlerWithTransformerBatchGeneralError(t *testing.T) {


### PR DESCRIPTION
## Description

While looking at the webhook batch processing path, I noticed there is an unrelated TODO in the same file that is still outstanding and looks small/self-contained enough for a follow-up chore.

Reference: `gateway/webhook/webhook.go:320`
```go
// TODO : return back immediately for blank request body. its waiting till timeout
```

This TODO predates the context/timeout work and was not addressed by #6835 or #6988.

## Current behavior

In `HandleT.RequestHandler` (`gateway/webhook/webhook.go:127`), after form / multipart parsing (lines 141–208) we always enqueue the request:

```go
requestQ <- &req      // webhook.go:229
// ...
resp := <-done        // webhook.go:233
```

If the incoming request has a blank body and no form/multipart payload (so `jsonByte` is empty and the original body is empty too), the request still:
1. Gets pushed onto the per-source `requestQ`.
2. Sits in `batchRequests` until either the buffer reaches `maxWebhookBatchSize` or the `webhookBatchTimeout` ticker fires.
3. Is then handed to `batchTransformLoop`, where the source transformer eventually rejects it.

The end result is the caller waits at least a full batch interval (and burns a transformer call) for a request we can already tell is invalid at the HTTP layer.

## Proposed fix

Reject blank-body requests in `RequestHandler` before they hit `requestQ`, after the existing form / multipart parsing has had a chance to populate `jsonByte`.

**Changes:**
- **gateway/response/response.go**: Add `NoRequestBody` error constant (HTTP 400)
- **gateway/webhook/webhook.go**: Add short-circuit check in `RequestHandler` for blank-body requests (exempting GET-allowed sources which carry payload in URL)
- **gateway/webhook/webhook.go**: Remove the now-resolved TODO comment
- **gateway/webhook/webhook_test.go**: Add unit test asserting POST with empty body returns 400 quickly

## Out of scope
- The other TODO at `webhook.go:324` ("Remove timeout from here after timeout handler is added in gateway") — already being addressed in #6787 / #6988.
- Any change to the batch sizing or batch timeout defaults.
- Behavior of GET-allowed sources (those listed in `Gateway.webhook.forwardGetRequestForSrcs`) — they remain unchanged.
