### PR TITLE
Fix/#7001

### DIFF
--- a/gateway/webhook/setup.go
+++ b/gateway/webhook/setup.go
@@ -61,6 +61,8 @@ func Setup(gwHandle Gateway, transformerFeaturesService TransformerFeaturesServi
 	webhook := &HandleT{gwHandle: gwHandle, stats: stat, logger: logger.NewLogger().Child("gateway").Child("webhook")}
 	// Number of incoming webhooks that are batched before calling source transformer
 	webhook.config.maxWebhookBatchSize = conf.GetReloadableIntVar(32, 1, "Gateway.webhook.maxBatchSize")
+	// Buffer size for the batchRequestQ channel; isolates batchRequests goroutines from slow transformer workers
+	webhook.config.batchRequestQSize = conf.GetReloadableIntVar(maxTransformerProcess, 1, "Gateway.webhook.batchRequestQSize")
 	// Timeout after which batch is formed anyway with whatever webhooks are available
 	webhook.config.webhookBatchTimeout = conf.GetReloadableDurationVar(20, time.Millisecond, []string{"Gateway.webhook.batchTimeout", "Gateway.webhook.batchTimeoutInMS"}...)
 	// Multiple source transformers are used to generate rudder events from webhooks
@@ -86,6 +88,8 @@ func Setup(gwHandle Gateway, transformerFeaturesService TransformerFeaturesServi
 
 	webhook.requestQ = make(map[string]chan *webhookT)
 	webhook.batchRequestQ = make(chan *batchWebhookT)
+	webhook.batchRequestQ = make(chan *batchWebhookT, webhook.config.batchRequestQSize.Load())
+
 
 	transformerClientConfig := &transformerclient.ClientConfig{
 		ClientTimeout: conf.GetDurationVar(30, time.Second, "HttpClient.sourceTransformer.timeout", "HttpClient.webhook.timeout"),

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -76,7 +76,8 @@ type HandleT struct {
 		maxWebhookBatchSize        config.ValueLoader[int]
 		sourceListForParsingParams []string
 		forwardGetRequestForSrcMap map[string]struct{}
-		webhookV2HandlerEnabled    bool
+		webhookV2HandlerEnabled    
+		batchRequestQSize          config.ValueLoader[int]
 	}
 	statReporterCreator StatReporterCreator
 	httpClient          retryablehttp.HttpClient


### PR DESCRIPTION
Add buffer to batchRequestQ channel
batchRequestQ was unbuffered, causing batchRequests goroutines to block on every send until a batchTransformLoop worker was free. Under transformer load, this cascaded — blocking requestQ draining and eventually stalling HTTP handlers across all source types.
Adds a configurable buffer (default: maxTransformerProcess, i.e. 64) via Gateway.webhook.batchRequestQSize, allowing batchRequests goroutines to continue draining their per-source requestQ even when all transformer workers are temporarily busy.
Files changed:

gateway/webhook/webhook.go — new batchRequestQSize config field on HandleT
gateway/webhook/setup.go — register config var and pass buffer size to make(chan)

fix #7001 