### PR TITLE
chore(jobsdb): lateral join for getting jobs

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -647,7 +647,10 @@ type Handle struct {
 		warnOnStatusMissingPartitionID  config.ValueLoader[bool]
 		holdDSListLockDuringStore       config.ValueLoader[bool] // escape hatch: hold the dsList read lock for the entire store callback
 		noResultsCacheStateOptimization config.ValueLoader[bool]
-		dbTablesVersion                 int // version of the database tables schema (0 means latest)
+		// getJobsUseLateralJoin replaces the v_last_* view join in getJobsDS with a
+		// correlated LATERAL subquery against the raw job_status table.
+		getJobsUseLateralJoin config.ValueLoader[bool]
+		dbTablesVersion       int // version of the database tables schema (0 means latest)
 
 		migration struct {
 			maxMigrateOnce, maxMigrateDSProbe config.ValueLoader[int]
@@ -1150,6 +1153,7 @@ func (jd *Handle) loadConfig() {
 	// when true, the per-state noResultsCache optimization is enabled: stateFilters are narrowed
 	// against the cache before querying, and (!ok && !limitsReached) is used as a commit predicate.
 	jd.conf.noResultsCacheStateOptimization = jd.config.GetReloadableBoolVar(false, jd.configKeys("noResultsCacheStateOptimization")...)
+	jd.conf.getJobsUseLateralJoin = jd.config.GetReloadableBoolVar(true, jd.configKeys("getJobsUseLateralJoin")...)
 
 	if jd.TriggerAddNewDS == nil {
 		jd.TriggerAddNewDS = func() <-chan time.Time {
@@ -2617,12 +2621,22 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 
 	joinType := "LEFT"
 	joinTable := "v_last_" + ds.JobStatusTable
+	onlyUnprocessed := slices.Equal(stateFilters, []string{Unprocessed.State})
 
 	if !containsUnprocessed { // If we are not querying for unprocessed jobs, we can use an inner join
 		joinType = "INNER"
-	} else if slices.Equal(stateFilters, []string{Unprocessed.State}) {
+	} else if onlyUnprocessed {
 		// If we are querying only for unprocessed jobs, we should join with the status table instead of the view (performance reasons)
 		joinTable = ds.JobStatusTable
+	}
+
+	// For the pure-unprocessed case the join is a NOT-EXISTS pattern (LEFT JOIN + IS NULL):
+	// we only need to know whether any status row exists, not which one is latest,
+	// so the lateral's ORDER BY / LIMIT 1 would be wasteful — skip it.
+	if jd.conf.getJobsUseLateralJoin.Load() && !onlyUnprocessed {
+		joinTable = fmt.Sprintf(`LATERAL (SELECT * FROM %q WHERE job_id = jobs.job_id ORDER BY id DESC LIMIT 1) job_latest_state ON true`, joinTable)
+	} else {
+		joinTable = fmt.Sprintf(`%q job_latest_state ON jobs.job_id=job_latest_state.job_id`, joinTable)
 	}
 
 	var rows *sql.Rows
@@ -2637,7 +2651,7 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 									job_latest_state.error_code, job_latest_state.error_response, job_latest_state.parameters
 								FROM
 									%[1]q AS jobs
-									%[2]s JOIN %[3]q job_latest_state ON jobs.job_id=job_latest_state.job_id
+									%[2]s JOIN %[3]s
 								    %[4]s
 									ORDER BY jobs.job_id %[5]s`,
 		ds.JobTable, joinType, joinTable, filterQuery, limitQuery)

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -2251,6 +2251,65 @@ func TestGetJobsLimitsReached(t *testing.T) {
 	}
 }
 
+func TestGetJobsLateralJoinToggle(t *testing.T) {
+	pgContainer := startPostgres(t)
+	customVal := strings.ToUpper(rsRand.String(8))
+	prefix := strings.ToLower(rsRand.String(5))
+
+	c := config.New()
+	db := NewForReadWrite(prefix, WithDBHandle(pgContainer.DB), WithConfig(c))
+	require.NoError(t, db.Start())
+	defer db.TearDown()
+
+	jobs := make([]*JobT, 5)
+	for i := range jobs {
+		jobs[i] = &JobT{
+			Parameters:   []byte(`{}`),
+			EventPayload: []byte(`{"k":"v"}`),
+			UserID:       "u",
+			UUID:         uuid.New(),
+			CustomVal:    customVal,
+			EventCount:   1,
+			WorkspaceId:  "ws",
+		}
+	}
+	require.NoError(t, db.Store(context.Background(), jobs))
+
+	all, err := db.GetUnprocessed(context.Background(), GetQueryParams{
+		CustomValFilters: []string{customVal},
+		JobsLimit:        100,
+	})
+	require.NoError(t, err)
+	require.Len(t, all.Jobs, 5)
+
+	// Mark jobs[2,3] failed, job[4] waiting; leave jobs[0,1] unprocessed.
+	statuses := []*JobStatusT{
+		{JobID: all.Jobs[2].JobID, JobState: Failed.State, AttemptNum: 1, ExecTime: time.Now(), RetryTime: time.Now(), ErrorCode: "500", ErrorResponse: []byte(`{}`), Parameters: []byte(`{}`), WorkspaceId: "ws", CustomVal: customVal},
+		{JobID: all.Jobs[3].JobID, JobState: Failed.State, AttemptNum: 1, ExecTime: time.Now(), RetryTime: time.Now(), ErrorCode: "500", ErrorResponse: []byte(`{}`), Parameters: []byte(`{}`), WorkspaceId: "ws", CustomVal: customVal},
+		{JobID: all.Jobs[4].JobID, JobState: Waiting.State, AttemptNum: 1, ExecTime: time.Now(), RetryTime: time.Now(), ErrorCode: "", ErrorResponse: []byte(`{}`), Parameters: []byte(`{}`), WorkspaceId: "ws", CustomVal: customVal},
+	}
+	require.NoError(t, db.UpdateJobStatus(context.Background(), statuses))
+
+	params := GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100}
+
+	// lateral path
+	c.Set("JobsDB.getJobsUseLateralJoin", true)
+	lateralResult, err := db.GetToProcess(context.Background(), params, nil)
+	require.NoError(t, err)
+	require.Len(t, lateralResult.Jobs, 5, "lateral join should return all 5 jobs")
+
+	// flip to v_last path
+	c.Set("JobsDB.getJobsUseLateralJoin", false)
+
+	vLastResult, err := db.GetToProcess(context.Background(), params, nil)
+	require.NoError(t, err)
+	require.Len(t, vLastResult.Jobs, 5, "v_last join should return all 5 jobs")
+
+	lateralIDs := lo.Map(lateralResult.Jobs, func(j *JobT, _ int) int64 { return j.JobID })
+	vLastIDs := lo.Map(vLastResult.Jobs, func(j *JobT, _ int) int64 { return j.JobID })
+	require.Equal(t, lateralIDs, vLastIDs, "v_last and lateral join should return the same job IDs in the same order")
+}
+
 func TestUpdateJobStatus(t *testing.T) {
 	_ = startPostgres(t)
 	c := config.New()


### PR DESCRIPTION
# Description

Adds a reloadable config option (`getJobsUseLateralJoin`, default `true`) that switches the `getJobsDS` query from joining the `v_last_*` view to a correlated `LATERAL` subquery against the raw job status table.

Driving the join from the jobs side rather than scanning the full `v_last_*` view can yield significant performance improvements, e.g. [plan using v_last](https://explain.dalibo.com/plan/158a74gfc7df8a44) vs [plan using lateral join](https://explain.dalibo.com/plan/f21ghgh581edb851)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.