### PR TITLE
Fix/#7000

### DIFF
--- a/router/batchrouter/partition_worker.go
+++ b/router/batchrouter/partition_worker.go
@@ -66,18 +66,28 @@ func NewPartitionWorker(log logger.Logger, partition string, brt *Handle, cb cir
 	return pw
 }
 
-func (pw *PartitionWorker) AddJob(job *jobsdb.JobT, sourceID, destID string) {
-	ctx, cancel := context.WithCancel(context.Background())
+func (pw *PartitionWorker) AddJob(ctx context.Context, job *jobsdb.JobT, sourceID, destID string) {
+	monitorCtx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go pw.monitorDelayedJobAddition(ctx, &wg, stats.Tags{"destType": pw.brt.destType, "source_id": sourceID, "destination_id": destID})
-	pw.channel <- &JobEntry{
+	go pw.monitorDelayedJobAddition(monitorCtx, &wg, stats.Tags{"destType": pw.brt.destType, "source_id": sourceID, "destination_id": destID})
+    defer func() {
+        cancel()
+        wg.Wait()
+    }()
+    select {
+    case pw.channel <- &JobEntry{
+
 		job:      job,
 		sourceID: sourceID,
 		destID:   destID,
+	 }:
++    case <-ctx.Done():
++        pw.logger.Warnn("AddJob cancelled while waiting for channel slot",
++            obskit.DestinationType(pw.brt.destType),
++        )
 	}
-	cancel()
-	wg.Wait()
+	
 }
 
 // monitorDelayedJobAddition runs in a goroutine to periodically report delayed job additions.

--- a/router/batchrouter/worker.go
+++ b/router/batchrouter/worker.go
@@ -231,7 +231,7 @@ func (w *worker) scheduleJobs(destinationJobs *DestinationJobs) {
 
 		// Now that all statuses are updated, we can safely send jobs to channels
 		for _, entry := range jobsToBuffer {
-			w.pw.AddJob(entry.job, entry.sourceID, entry.destID)
+			w.pw.AddJob(context.Background(), entry.job, entry.sourceID, entry.destID)
 		}
 	}
 }

--- a/warehouse/slave/worker_job.go
+++ b/warehouse/slave/worker_job.go
@@ -413,6 +413,10 @@ func (jr *jobRun) uploadLoadFiles(ctx context.Context, modifier func(result uplo
 
 	process := func() <-chan *uploadProcessingResult {
 		processStream := make(chan *uploadProcessingResult, len(jr.outputFileWritersMap))
+		jr.outputFileWritersMapMu.RLock()
+		processStreamSize := len(jr.outputFileWritersMap)
+		jr.outputFileWritersMapMu.RUnlock()
+		processStream := make(chan *uploadProcessingResult, processStreamSize)
 
 		g, groupCtx := errgroup.WithContext(ctx)
 		g.SetLimit(jr.config.numLoadFileUploadWorkers)
@@ -420,7 +424,20 @@ func (jr *jobRun) uploadLoadFiles(ctx context.Context, modifier func(result uplo
 		go func() {
 			defer close(processStream)
 
-			for tableName, uploadFile := range jr.outputFileWritersMap {
+			jr.outputFileWritersMapMu.RLock()
++         jr.tableEventCountMapMu.RLock()
++         writersSnapshot := make(map[string]encoding.LoadFileWriter, len(jr.outputFileWritersMap))
++         for k, v := range jr.outputFileWritersMap {
++             writersSnapshot[k] = v
++         }
++         countSnapshot := make(map[string]int, len(jr.tableEventCountMap))
++         for k, v := range jr.tableEventCountMap {
++             countSnapshot[k] = v
++         }
++         jr.tableEventCountMapMu.RUnlock()
++         jr.outputFileWritersMapMu.RUnlock()
+
+			for tableName, uploadFile := range writersSnapshot  {
 				g.Go(func() error {
 					select {
 					case <-ctx.Done():
@@ -447,7 +464,7 @@ func (jr *jobRun) uploadLoadFiles(ctx context.Context, modifier func(result uplo
 						result := uploadResult{
 							TableName:             tableName,
 							Location:              uploadOutput.Location,
-							TotalRows:             jr.tableEventCountMap[tableName],
+							TotalRows:              countSnapshot[tableName],
 							ContentLength:         loadFileStats.Size(),
 							DestinationRevisionID: jr.job.DestinationRevisionID,
 							UseRudderStorage:      jr.job.UseRudderStorage,


### PR DESCRIPTION
 #7000
 
Fix: PartitionWorker.AddJob blocks indefinitely when channel is full

AddJob used a bare blocking send to pw.channel. When all consumer goroutines were busy (slow destination uploads, API throttling), the channel buffer filled and AddJob blocked forever — stalling Work() and halting all partition processing for that destination type.

Changes:
router/batchrouter/partition_worker.go — AddJob now accepts ctx context.Context; channel send wrapped in select with ctx.Done() to unblock on cancellation. Monitor goroutine cleanup moved to defer for correctness.

router/batchrouter/worker.go — updated call site to pass context.Background()
