### PR TITLE
fix(batch_router): prevent indefinite blocking in PartitionWorker.Add

### DIFF
--- a/router/batchrouter/partition_worker.go
+++ b/router/batchrouter/partition_worker.go
@@ -66,18 +66,28 @@ func NewPartitionWorker(log logger.Logger, partition string, brt *Handle, cb cir
 	return pw
 }
 
-func (pw *PartitionWorker) AddJob(job *jobsdb.JobT, sourceID, destID string) {
-	ctx, cancel := context.WithCancel(context.Background())
+func (pw *PartitionWorker) AddJob(ctx context.Context, job *jobsdb.JobT, sourceID, destID string) {
+	monitorCtx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go pw.monitorDelayedJobAddition(ctx, &wg, stats.Tags{"destType": pw.brt.destType, "source_id": sourceID, "destination_id": destID})
-	pw.channel <- &JobEntry{
+	go pw.monitorDelayedJobAddition(monitorCtx, &wg, stats.Tags{"destType": pw.brt.destType, "source_id": sourceID, "destination_id": destID})
+    defer func() {
+        cancel()
+        wg.Wait()
+    }()
+    select {
+    case pw.channel <- &JobEntry{
+
 		job:      job,
 		sourceID: sourceID,
 		destID:   destID,
+	 }:
++    case <-ctx.Done():
++        pw.logger.Warnn("AddJob cancelled while waiting for channel slot",
++            obskit.DestinationType(pw.brt.destType),
++        )
 	}
-	cancel()
-	wg.Wait()
+	
 }
 
 // monitorDelayedJobAddition runs in a goroutine to periodically report delayed job additions.

--- a/router/batchrouter/worker.go
+++ b/router/batchrouter/worker.go
@@ -231,7 +231,7 @@ func (w *worker) scheduleJobs(destinationJobs *DestinationJobs) {
 
 		// Now that all statuses are updated, we can safely send jobs to channels
 		for _, entry := range jobsToBuffer {
-			w.pw.AddJob(entry.job, entry.sourceID, entry.destID)
+			w.pw.AddJob(context.Background(), entry.job, entry.sourceID, entry.destID)
 		}
 	}
 }


### PR DESCRIPTION
 #7000
 
Fix: PartitionWorker.AddJob blocks indefinitely when channel is full

AddJob used a bare blocking send to pw.channel. When all consumer goroutines were busy (slow destination uploads, API throttling), the channel buffer filled and AddJob blocked forever — stalling Work() and halting all partition processing for that destination type.

Changes:
router/batchrouter/partition_worker.go — AddJob now accepts ctx context.Context; channel send wrapped in select with ctx.Done() to unblock on cancellation. Monitor goroutine cleanup moved to defer for correctness.

router/batchrouter/worker.go — updated call site to pass context.Background()
