### PR TITLE
feat(jobsdb): deferred status table lock during compaction

### DIFF
--- a/jobsdb/bench/scenario/compaction.go
+++ b/jobsdb/bench/scenario/compaction.go
@@ -58,6 +58,7 @@ type flagSet struct {
 	name                       string
 	nonBlockingCompletedDSDrop bool
 	nonBlockingCompaction      bool
+	compactionDeferStatusLock  bool
 }
 
 func (p *compaction) Run(ctx context.Context) error {
@@ -124,6 +125,7 @@ func (p *compaction) Run(ctx context.Context) error {
 		{name: "baseline (blocking compaction)", nonBlockingCompletedDSDrop: false, nonBlockingCompaction: false},
 		{name: "nonBlockingCompletedDSDrop", nonBlockingCompletedDSDrop: true, nonBlockingCompaction: false},
 		{name: "nonBlockingCompaction", nonBlockingCompaction: true},
+		{name: "nonBlockingCompaction + deferStatusLock", nonBlockingCompaction: true, compactionDeferStatusLock: true},
 	}
 
 	type result struct {
@@ -141,6 +143,7 @@ func (p *compaction) Run(ctx context.Context) error {
 		// Apply the flag combination under test.
 		p.conf.Set("JobsDB."+tablePrefix+".nonBlockingCompletedDSDrop", s.nonBlockingCompletedDSDrop)
 		p.conf.Set("JobsDB."+tablePrefix+".nonBlockingCompaction", s.nonBlockingCompaction)
+		p.conf.Set("JobsDB."+tablePrefix+".compactionDeferStatusLock", s.compactionDeferStatusLock)
 
 		// Deterministic addNewDS trigger so we can seed exactly [datasets]
 		// datasets of [jobsPerDataset] jobs each.

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -677,6 +677,13 @@ type Handle struct {
 			// lock + readonly trigger on the source status table, async source drop).
 			// When disabled, falls back to the legacy doMigrateDS flow.
 			nonBlockingCompaction config.ValueLoader[bool]
+			// compactionDeferStatusLock further minimizes the status-table lock
+			// window during non-blocking compaction by splitting the copy into two
+			// phases: pending jobs are copied first WITHOUT any status-table lock,
+			// then each source status table is locked EXCLUSIVE one after another only
+			// to copy the latest statuses of the moved jobs. Requires
+			// nonBlockingCompaction; has no effect on its own.
+			compactionDeferStatusLock config.ValueLoader[bool]
 			// getJobsRetryOnCompaction gates the snapshot revalidation in getJobs:
 			// when set, getJobs detects that a queried dataset is no longer in the
 			// published list (e.g. a non-blocking compaction completed mid-read) and
@@ -1177,6 +1184,7 @@ func (jd *Handle) loadConfig() {
 	jd.conf.migration.vacuumAnalyzeStatusTableThreshold = jd.config.GetReloadableInt64Var(30000, 1, jd.configKeys("vacuumAnalyzeStatusTableThreshold")...)
 	jd.conf.migration.nonBlockingCompletedDSDrop = jd.config.GetReloadableBoolVar(false, jd.configKeys("nonBlockingCompletedDSDrop")...)
 	jd.conf.migration.nonBlockingCompaction = jd.config.GetReloadableBoolVar(false, jd.configKeys("nonBlockingCompaction")...)
+	jd.conf.migration.compactionDeferStatusLock = jd.config.GetReloadableBoolVar(false, jd.configKeys("compactionDeferStatusLock")...)
 	jd.conf.migration.getJobsRetryOnCompaction = jd.config.GetReloadableBoolVar(true, jd.configKeys("getJobsRetryOnCompaction")...)
 
 	// masterBackupEnabled = true => all the jobsdb are eligible for backup
@@ -1813,7 +1821,16 @@ func (jd *Handle) createDSTablesInTx(ctx context.Context, tx *Tx, newDS dataSetT
 	return nil
 }
 
+// createDSIndicesInTx creates the indices for the given dataset.
 func (jd *Handle) createDSIndicesInTx(ctx context.Context, tx *Tx, newDS dataSetT) error {
+	if err := jd.createDSJobIndicesInTx(ctx, tx, newDS); err != nil {
+		return err
+	}
+	return jd.createDSStatusIndicesInTx(ctx, tx, newDS)
+}
+
+// createDSJobIndicesInTx creates the indices that live on the jobs table
+func (jd *Handle) createDSJobIndicesInTx(ctx context.Context, tx *Tx, newDS dataSetT) error {
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_ws" ON %[1]q (workspace_id)`, newDS.JobTable)); err != nil {
 		return fmt.Errorf("creating workspace_id index: %w", err)
 	}
@@ -1828,6 +1845,12 @@ func (jd *Handle) createDSIndicesInTx(ctx context.Context, tx *Tx, newDS dataSet
 			return fmt.Errorf("creating %s index: %w", param, err)
 		}
 	}
+	return nil
+}
+
+// createDSStatusIndicesInTx creates the indices on the job status table plus the
+// v_last view.
+func (jd *Handle) createDSStatusIndicesInTx(ctx context.Context, tx *Tx, newDS dataSetT) error {
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_jid_id_js" ON %[1]q(job_id asc,id desc,job_state)`, newDS.JobStatusTable)); err != nil {
 		return fmt.Errorf("adding job_id_id index: %w", err)
 	}

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -619,12 +619,10 @@ func getColumnConversion(srcType, destType string) (string, error) {
 	return result, nil
 }
 
-func (jd *Handle) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) (int, error) {
-	defer jd.getTimerStat(
-		"migration_jobs",
-		&statTags{CustomValFilters: []string{jd.tablePrefix}},
-	).RecordDuration()()
-
+// resolvePayloadConversion inspects the event_payload column types of the source
+// and destination jobs tables and returns the SQL expression used to convert a
+// source payload to the destination column type (see getColumnConversion).
+func (jd *Handle) resolvePayloadConversion(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) (string, error) {
 	columnTypeMap := map[string]string{srcDS.JobTable: string(JSONB), destDS.JobTable: string(JSONB)}
 	// find column types first - to differentiate between `text`, `bytea` and `jsonb`
 	rows, err := tx.QueryContext(
@@ -635,23 +633,82 @@ func (jd *Handle) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dat
 		srcDS.JobTable, destDS.JobTable,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("get column types: %w", err)
+		return "", fmt.Errorf("get column types: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	var jobsTable, columnType string
 	for rows.Next() {
 		if err = rows.Scan(&jobsTable, &columnType); err != nil {
-			return 0, fmt.Errorf("scan column types: %w", err)
+			return "", fmt.Errorf("scan column types: %w", err)
 		}
 		if columnType != string(BYTEA) && columnType != string(JSONB) && columnType != string(TEXT) {
-			return 0, fmt.Errorf("unsupported column type %s", columnType)
+			return "", fmt.Errorf("unsupported column type %s", columnType)
 		}
 		columnTypeMap[jobsTable] = columnType
 	}
 	if err = rows.Err(); err != nil {
-		return 0, fmt.Errorf("rows.Err() on column types: %w", err)
+		return "", fmt.Errorf("rows.Err() on column types: %w", err)
 	}
-	payloadLiteral, err := getColumnConversion(columnTypeMap[srcDS.JobTable], columnTypeMap[destDS.JobTable])
+	return getColumnConversion(columnTypeMap[srcDS.JobTable], columnTypeMap[destDS.JobTable])
+}
+
+// copyJobsInTx copies the still-pending jobs (and jobs that were never picked up) from the source jobs
+// table to the destination. It returns the number of jobs copied.
+func (jd *Handle) copyJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) (int, error) {
+	defer jd.getTimerStat(
+		"migration_jobs",
+		&statTags{CustomValFilters: []string{jd.tablePrefix}},
+	).RecordDuration()()
+
+	payloadLiteral, err := jd.resolvePayloadConversion(ctx, tx, srcDS, destDS)
+	if err != nil {
+		return 0, err
+	}
+
+	copyQuery := fmt.Sprintf(
+		`insert into %[2]q (job_id,   workspace_id,   uuid,   user_id,   partition_id, custom_val,   parameters,   event_payload,   event_count,   created_at,   expire_at)
+		           (select j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.custom_val, j.parameters, %[4]s, j.event_count, j.created_at, j.expire_at from %[3]q j left join "v_last_%[1]s" js on js.job_id = j.job_id
+			where js.job_id is null or js.job_state = ANY('{%[5]s}') order by j.job_id)`,
+		srcDS.JobStatusTable,
+		destDS.JobTable,
+		srcDS.JobTable,
+		payloadLiteral,
+		strings.Join(validNonTerminalStates, ","),
+	)
+	res, err := tx.ExecContext(ctx, copyQuery)
+	if err != nil {
+		return 0, err
+	}
+	count, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(count), nil
+}
+
+// copyJobStatusesInTx copies the LATEST status of every job in the destDS (terminal or not) from the srcDS status table to the destDS status table.
+func (jd *Handle) copyJobStatusesInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) error {
+	copyQuery := fmt.Sprintf(
+		`insert into %[2]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters)
+		           (select js.job_id, js.job_state, js.attempt, js.exec_time, js.retry_time, js.error_code, js.error_response, js.parameters from "v_last_%[1]s" js
+			where exists (select 1 from %[3]q dj where dj.job_id = js.job_id))`,
+		srcDS.JobStatusTable,
+		destDS.JobStatusTable,
+		destDS.JobTable,
+	)
+	if _, err := tx.ExecContext(ctx, copyQuery); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (jd *Handle) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) (int, error) {
+	defer jd.getTimerStat(
+		"migration_jobs",
+		&statTags{CustomValFilters: []string{jd.tablePrefix}},
+	).RecordDuration()()
+
+	payloadLiteral, err := jd.resolvePayloadConversion(ctx, tx, srcDS, destDS)
 	if err != nil {
 		return 0, err
 	}
@@ -718,6 +775,25 @@ func (jd *Handle) computeNewIdxForIntraNodeMigration(l lock.LockToken, insertBef
 	return newDSIdx, nil
 }
 
+// lockAndFenceStatusTable takes an EXCLUSIVE lock on the status table and
+// plants the readonly trigger which raises RS001 whenever any subsequent insert is attempted on the status table.
+func (jd *Handle) lockAndFenceStatusTable(ctx context.Context, tx *Tx, statusTable string) error {
+	// EXCLUSIVE (not ACCESS EXCLUSIVE): blocks INSERT/UPDATE/DELETE on the
+	// status table but allows reads (e.g. v_last_*).
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`LOCK TABLE %q IN EXCLUSIVE MODE`, statusTable)); err != nil {
+		return fmt.Errorf("exclusive lock status table %s: %w", statusTable, err)
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+		`CREATE TRIGGER readonlyTableTrg
+		BEFORE INSERT
+		ON %q
+		FOR EACH STATEMENT
+		EXECUTE PROCEDURE %s;`, statusTable, pgReadonlyTableExceptionFuncName)); err != nil {
+		return fmt.Errorf("create readonly trigger on %s: %w", statusTable, err)
+	}
+	return nil
+}
+
 // doCompactDS is the non-blocking compaction flow which replaces the legacy doMigrateDS body when the nonBlockingCompaction flag is enabled.
 //
 // Lock semantics (vs. legacy):
@@ -728,6 +804,9 @@ func (jd *Handle) computeNewIdxForIntraNodeMigration(l lock.LockToken, insertBef
 //   - Source status tables are fenced with LOCK TABLE … IN EXCLUSIVE MODE and a
 //     post-commit readonly trigger; the trigger raises RS001 on subsequent inserts,
 //     which the UpdateJobStatus path treats as ErrStaleDsList and retries.
+//   - When compactionDeferStatusLock is set, the source status lock is deferred:
+//     pending jobs are copied first with no lock held, then each source status table
+//     is locked one after another only to copy the latest statuses of the moved jobs.
 func (jd *Handle) doCompactDS(ctx context.Context) error {
 	dsList, _, release, err := jd.acquireDSListForRead(ctx)
 	if err != nil {
@@ -810,55 +889,104 @@ func (jd *Handle) doCompactDS(ctx context.Context) error {
 			}
 
 			var copyStart time.Time
-			for i, source := range migrationList.migrateFrom {
-				if source.numJobsPending == 0 {
+			if jd.conf.migration.compactionDeferStatusLock.Load() {
+				// Deferred-status-lock mode. Phase 1: copy the pending jobs from every
+				// source WITHOUT locking any status table — this is the slow,
+				// payload-heavy work, and it must not sit inside the lock window.
+				for i, source := range migrationList.migrateFrom {
+					if source.numJobsPending == 0 {
+						jd.logger.Infon(
+							"[[ doCompactDS ]]: No jobs to migrate",
+							logger.NewStringField("from", source.ds.Index),
+							logger.NewStringField("to", destination.Index),
+						)
+						continue
+					}
+					if copyStart.IsZero() {
+						copyStart = time.Now()
+					}
+					count, err := jd.copyJobsInTx(ctx, tx, source.ds, destination)
+					if err != nil {
+						return fmt.Errorf("copying jobs from %s: %w", source.ds.Index, err)
+					}
+					totalCopied += count
+					// numJobsPending now reflects what phase 1 actually copied, so
+					// phase 2 below only locks sources that contributed jobs.
+					migrationList.migrateFrom[i].numJobsPending = count
+				}
+				// Build the jobs-table indices before taking any status lock.
+				if totalCopied > 0 {
+					if err := jd.createDSJobIndicesInTx(ctx, tx, destination); err != nil {
+						return fmt.Errorf("creating %v jobs indices: %w", destination, err)
+					}
+				}
+				// Phase 2: lock each source status table one after another and copy the
+				// latest status of the moved jobs. This is the only work under the lock,
+				// and the status rows carry no payload, so the lock window is minimal.
+				for _, source := range migrationList.migrateFrom {
+					if source.numJobsPending == 0 {
+						continue
+					}
+					if lockStart.IsZero() {
+						lockStart = time.Now()
+					}
+					if err := jd.lockAndFenceStatusTable(ctx, tx, source.ds.JobStatusTable); err != nil {
+						return err
+					}
 					jd.logger.Infon(
-						"[[ doCompactDS ]]: No jobs to migrate",
+						"[[ doCompactDS ]]: Move statuses",
 						logger.NewStringField("from", source.ds.Index),
 						logger.NewStringField("to", destination.Index),
 					)
-					continue
+					if err := jd.copyJobStatusesInTx(ctx, tx, source.ds, destination); err != nil {
+						return fmt.Errorf("copying statuses from %s: %w", source.ds.Index, err)
+					}
 				}
-				if lockStart.IsZero() {
-					lockStart = time.Now()
+				if totalCopied > 0 {
+					if err := jd.createDSStatusIndicesInTx(ctx, tx, destination); err != nil {
+						return fmt.Errorf("creating %v status indices: %w", destination, err)
+					}
+					if _, err := tx.Exec(fmt.Sprintf(`ANALYZE %q, %q`, destination.JobTable, destination.JobStatusTable)); err != nil {
+						return fmt.Errorf("analyzing %v: %w", destination, err)
+					}
 				}
-				// EXCLUSIVE (not ACCESS EXCLUSIVE): blocks INSERT/UPDATE/DELETE on the
-				// status table but allows reads (e.g. v_last_*).
-				if _, err := tx.ExecContext(ctx, fmt.Sprintf(`LOCK TABLE %q IN EXCLUSIVE MODE`, source.ds.JobStatusTable)); err != nil {
-					return fmt.Errorf("exclusive lock status table %s: %w", source.ds.JobStatusTable, err)
+			} else {
+				for i, source := range migrationList.migrateFrom {
+					if source.numJobsPending == 0 {
+						jd.logger.Infon(
+							"[[ doCompactDS ]]: No jobs to migrate",
+							logger.NewStringField("from", source.ds.Index),
+							logger.NewStringField("to", destination.Index),
+						)
+						continue
+					}
+					if lockStart.IsZero() {
+						lockStart = time.Now()
+					}
+					if err := jd.lockAndFenceStatusTable(ctx, tx, source.ds.JobStatusTable); err != nil {
+						return err
+					}
+					jd.logger.Infon(
+						"[[ doCompactDS ]]: Move",
+						logger.NewStringField("from", source.ds.Index),
+						logger.NewStringField("to", destination.Index),
+					)
+					if copyStart.IsZero() {
+						copyStart = time.Now()
+					}
+					count, err := jd.migrateJobsInTx(ctx, tx, source.ds, destination)
+					if err != nil {
+						return fmt.Errorf("copying jobs from %s: %w", source.ds.Index, err)
+					}
+					totalCopied += count
+					migrationList.migrateFrom[i].numJobsPending = count
 				}
-				// Plant a readonly trigger on the source status table so that any
-				// UpdateJobStatus that lands here AFTER our commit raises RS001 and
-				// gets routed to the new destination via the refreshed dsRangeList.
-				if _, err := tx.ExecContext(ctx, fmt.Sprintf(
-					`CREATE TRIGGER readonlyTableTrg
-					BEFORE INSERT
-					ON %q
-					FOR EACH STATEMENT
-					EXECUTE PROCEDURE %s;`, source.ds.JobStatusTable, pgReadonlyTableExceptionFuncName)); err != nil {
-					return fmt.Errorf("create readonly trigger on %s: %w", source.ds.JobStatusTable, err)
+				if err := jd.createDSIndicesInTx(ctx, tx, destination); err != nil {
+					return fmt.Errorf("creating %v indices: %w", destination, err)
 				}
-				jd.logger.Infon(
-					"[[ doCompactDS ]]: Move",
-					logger.NewStringField("from", source.ds.Index),
-					logger.NewStringField("to", destination.Index),
-				)
-				if copyStart.IsZero() {
-					copyStart = time.Now()
-				}
-				count, err := jd.migrateJobsInTx(ctx, tx, source.ds, destination)
-				if err != nil {
-					return fmt.Errorf("copying jobs from %s: %w", source.ds.Index, err)
-				}
-				totalCopied += count
-				migrationList.migrateFrom[i].numJobsPending = count
 			}
 			if !copyStart.IsZero() {
 				jd.getTimerStat("jobsdb_migration_copy_time", &statTags{CustomValFilters: []string{jd.tablePrefix}}).Since(copyStart)
-			}
-
-			if err := jd.createDSIndicesInTx(ctx, tx, destination); err != nil {
-				return fmt.Errorf("creating %v indices: %w", destination, err)
 			}
 
 			// Mark the source datasets with the pre-drop comment in the same TX as

--- a/jobsdb/migration_test.go
+++ b/jobsdb/migration_test.go
@@ -1539,4 +1539,68 @@ func TestNonBlockingCompaction(t *testing.T) {
 		require.True(t, tableExists(t, jd, source2), "drop blocked by held reader")
 		require.True(t, hasReadonlyTrigger(t, jd, source2), "source must carry readonly trigger after non-blocking compaction")
 	})
+
+	t.Run("flag on + deferStatusLock: copies pending jobs and their latest statuses, fences source", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"compactionDeferStatusLock", true)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
+
+		// jobs 1..4 terminal (succeeded), 5..7 non-terminal (failed), 8..10 never
+		// picked up (no status at all).
+		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
+		require.NoError(t, jd.Store(context.Background(), jobs))
+		require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[:4], "succeeded")))
+		require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[4:7], "failed")))
+		createDS(t, jd, "2") // empty last DS
+
+		snapshot := jd.getDSListSnapshot()
+		require.Len(t, snapshot, 2)
+		sourceDS := snapshot[0]
+
+		// Hold a reader so the source's async physical drop blocks long enough to
+		// inspect the trigger and pre-drop markers.
+		_, _, release, err := jd.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+
+		listIndices := lo.Map(jd.getDSListSnapshot(), func(ds dataSetT, _ int) string { return ds.Index })
+		require.NotContains(t, listIndices, sourceDS.Index, "source DS hidden from new readers")
+		require.Contains(t, listIndices, "1_1", "destination DS published")
+
+		// The status table must still be fenced even though it was locked in a
+		// separate phase from the jobs copy.
+		require.True(t, hasReadonlyTrigger(t, jd, sourceDS), "deferred mode must still plant the readonly trigger on the source status table")
+		require.True(t, tableMarkedPreDrop(t, jd, sourceDS.JobTable), "source job table must carry pre-drop marker")
+		require.True(t, tableMarkedPreDrop(t, jd, sourceDS.JobStatusTable), "source status table must carry pre-drop marker")
+
+		destJobsTable := jd.tablePrefix + "_jobs_1_1"
+		destStatusTable := jd.tablePrefix + "_job_status_1_1"
+
+		// Phase 1: the 6 pending jobs (ids 5..10) are copied; the 4 terminal jobs are not.
+		var copiedJobIDs string
+		require.NoError(t, jd.dbHandle.QueryRow(
+			fmt.Sprintf(`SELECT COALESCE(string_agg(job_id::text, ',' ORDER BY job_id), '') FROM %q`, destJobsTable),
+		).Scan(&copiedJobIDs))
+		require.Equal(t, "5,6,7,8,9,10", copiedJobIDs, "only pending jobs must be copied")
+
+		// Phase 2: only jobs that had a status (5,6,7) get a status row, and it is
+		// their latest status ("failed"). Jobs 8..10 were never picked up so they
+		// correctly carry no status and remain unprocessed in the destination.
+		var statusJobIDs, distinctStates string
+		require.NoError(t, jd.dbHandle.QueryRow(
+			fmt.Sprintf(`SELECT COALESCE(string_agg(job_id::text, ',' ORDER BY job_id), ''), COALESCE(string_agg(DISTINCT job_state, ','), '') FROM %q`, destStatusTable),
+		).Scan(&statusJobIDs, &distinctStates))
+		require.Equal(t, "5,6,7", statusJobIDs, "latest status copied only for moved jobs that had one")
+		require.Equal(t, "failed", distinctStates, "the latest (non-terminal) status must be preserved")
+
+		release()
+		require.Eventually(t, func() bool {
+			jd.dropDSListLock.RLock()
+			pending := len(jd.dropDSList)
+			jd.dropDSListLock.RUnlock()
+			return !tableExists(t, jd, sourceDS) && pending == 0
+		}, 5*time.Second, 50*time.Millisecond, "source table must be physically dropped once the reader releases")
+	})
 }

--- a/processor/processor_isolation_test.go
+++ b/processor/processor_isolation_test.go
@@ -255,6 +255,7 @@ func ProcIsolationScenario(t testing.TB, spec *ProcIsolationScenarioSpec) (overa
 
 	config.Set("JobsDB.enableWriterQueue", false)
 	config.Set("JobsDB.nonBlockingCompletedDSDrop", "true")
+	config.Set("JobsDB.compactionDeferStatusLock", "true")
 
 	// find free port for gateway http server to listen on
 	httpPortInt, err := kithelper.GetFreePort()

--- a/router/batchrouter/batchrouter_isolation_test.go
+++ b/router/batchrouter/batchrouter_isolation_test.go
@@ -266,6 +266,7 @@ func BatchrouterIsolationScenario(t testing.TB, spec *BrtIsolationScenarioSpec) 
 
 	config.Set("JobsDB.enableWriterQueue", false)
 	config.Set("JobsDB.nonBlockingCompletedDSDrop", "true")
+	config.Set("JobsDB.compactionDeferStatusLock", "true")
 	config.Set("RUDDER_TMPDIR", os.TempDir())
 
 	t.Logf("Seeding batch_rt jobsdb with jobs")

--- a/router/router_isolation_test.go
+++ b/router/router_isolation_test.go
@@ -224,6 +224,7 @@ func RouterIsolationScenario(t testing.TB, spec *RtIsolationScenarioSpec) (overa
 	config.Set("JobsDB.backup.enabled", false)
 	config.Set("JobsDB.migrateDSLoopSleepDuration", "60m")
 	config.Set("JobsDB.nonBlockingCompletedDSDrop", "true")
+	config.Set("JobsDB.compactionDeferStatusLock", "true")
 
 	config.Set("Router.isolationMode", string(spec.isolationMode))
 	config.Set("Router.Limiter.statsPeriod", "1s")


### PR DESCRIPTION
# Description

During non-blocking compaction, the source job status table is locked `EXCLUSIVE` early, before jobs are copied to the destination. Because the job copy includes the (potentially large) `event_payload`, the bulk of the lock window is spent moving data that does not actually need the lock — status updates for jobs in that dataset are blocked for the whole copy.

This PR adds an opt-in mode (`compactionDeferStatusLock`, off by default) that splits the copy into two phases:

1. **Copy pending jobs first, with no status lock held** — the slow, payload-heavy work.
2. **Then lock each source status table one after another** only to copy the latest statuses of the jobs that were moved.

The result is that the status-table lock window shrinks to roughly the (small, payload-free) status copy, minimizing how long status updates are blocked. As a side-effect, jobs that complete between the two phases are still moved to the new table (now carrying their terminal status). These few extra completed rows will get reclaimed on the next compaction.

#7021 runs all tests with this feature enabled

## Benchmark

Deferring the status lock shaves a further ~12% off `nonBlockingCompaction` alone.
Run it with:

```bash
RUN_COMPACTION_BENCH=1 GOMAXPROCS=2 go test ./jobsdb/bench/ -run 'TestBench/compaction' -v -timeout 30m
```

Drain time for 2M jobs (lower is better):

| Scenario                                   | Time      | vs. baseline |
| ------------------------------------------ | --------- | ------------ |
| baseline (blocking compaction)             | 2m56.6s   | —            |
| nonBlockingCompletedDSDrop                 | 2m10.9s   | −25.9%       |
| nonBlockingCompaction                      | 1m54.8s   | −35.0%       |
| nonBlockingCompaction + deferStatusLock    | 1m40.7s   | −43.0%       |

## Linear Ticket

resolves PIPE-3064

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #7038 
- <kbd>&nbsp;3&nbsp;</kbd> #7021 
- <kbd>&nbsp;2&nbsp;</kbd> #7020 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #7024 
<!-- GitButler Footer Boundary Bottom -->

