### PR TITLE
[WIP] feat(jobsdb): deferred status table lock during compaction (enabled by default)

### DIFF
--- a/jobsdb/bench/bench.go
+++ b/jobsdb/bench/bench.go
@@ -23,6 +23,8 @@ func New(conf *config.Config, stat stats.Stats, log logger.Logger, db *sql.DB) (
 		return scenario.NewSimple(conf, stat, log, db), nil
 	case "two_stage":
 		return scenario.NewTwoStage(conf, stat, log, db), nil
+	case "compaction":
+		return scenario.NewCompaction(conf, stat, log, db), nil
 	default:
 		return nil, fmt.Errorf("unknown jobsdb bench scenario name: %s", conf.GetStringVar("processor", "JobsDB.bench.scenario"))
 	}

--- a/jobsdb/bench/bench_test.go
+++ b/jobsdb/bench/bench_test.go
@@ -3,6 +3,7 @@ package bench_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -91,6 +92,86 @@ func TestBench(t *testing.T) {
 			return b.Run(ctx)
 		})
 		require.NoError(t, g.Wait())
+	})
+
+	// TestBench/compaction seeds a read-write jobsdb with 20 datasets of 100K
+	// jobs each (3KB payload) spread across 100 destinations, then drains it with
+	// 100 consumer goroutines (one per destination). It repeats this for every
+	// compaction flag combination and reports the time each takes to drain.
+	//
+	// This is a heavy benchmark (~1M * 2KB jobs, seeded 4 times). It is skipped
+	// unless RUN_COMPACTION_BENCH is set.
+	t.Run("compaction", func(t *testing.T) {
+		if os.Getenv("RUN_COMPACTION_BENCH") == "" {
+			t.Skip("set RUN_COMPACTION_BENCH=1 to run the compaction bench")
+		}
+		pool, err := dockertest.NewPool("")
+		require.NoError(t, err)
+		postgresContainer, err := postgres.Setup(pool, t, postgres.WithOptions(
+			"max_connections=200",
+			"max_wal_size=2GB",
+			"checkpoint_timeout=30",
+			"shared_buffers=512MB",
+			"work_mem=64MB",
+			"hash_mem_multiplier=4",
+			"maintenance_work_mem=200MB",
+			"effective_cache_size=4GB",
+			"wal_buffers=64MB",
+			"random_page_cost=1.1",
+			"autovacuum_vacuum_cost_delay=1",
+			"autovacuum_naptime=20",
+			"checkpoint_warning=0",
+		),
+			postgres.WithTag("17-alpine"),
+			postgres.WithShmSize(256*bytesize.MB),
+		)
+		require.NoError(t, err)
+		postgresContainer.DB.SetMaxOpenConns(80)
+		postgresContainer.DB.SetMaxIdleConns(10)
+
+		c := config.New()
+
+		// JobsDB configuration
+		c.Set("JobsDB.enableWriterQueue", true)
+		c.Set("JobsDB.maxWriters", 3)
+		c.Set("JobsDB.enableReaderQueue", true)
+		c.Set("JobsDB.maxReaders", 6)
+
+		// Common jobsdb configuration under test
+		c.Set("JobsDB.noResultsCacheStateOptimization", true)
+		c.Set("JobsDB.logCacheBranchInvalidation", true)
+		c.Set("JobsDB.warnOnStatusMissingPartitionID", true)
+		c.Set("JobsDB.cacheExpiration", 2*time.Hour)
+		c.Set("JobsDB.dsLimit", 4)
+		c.Set("JobsDB.maxDSRetention", 20*time.Second)
+		c.Set("JobsDB.migrateDSLoopSleepDuration", 10*time.Second)
+		c.Set("JobsDB.jobMinRowsLeftMigrateThreshold", 0.7)
+		c.Set("JobsDB.refreshDSListLoopSleepDuration", 2*time.Second)
+		c.Set("JobsDB.addNewDSLoopSleepDuration", 2*time.Second)
+		c.Set("JobsDB.maxMigrateDSProbe", 50)
+		c.Set("JobsDB.maxTableSizeInMB", 900)
+		c.Set("JobsDB.maxDSSize", 100000) // one dataset holds 100K jobs
+
+		// Bench configuration
+		c.Set("JobsDB.Bench.scenario", "compaction")
+		c.Set("JobsDB.Bench.maintenanceDSN", postgresContainer.DBDsn) // dedicated maintenance pool
+		c.Set("JobsDB.Bench.maintenancePoolConns", 10)
+		c.Set("JobsDB.Bench.datasets", 20)
+		c.Set("JobsDB.Bench.jobsPerDataset", 100000)
+		c.Set("JobsDB.Bench.payloadSize", 3*bytesize.KB)
+		c.Set("JobsDB.Bench.destinations", 100)
+		c.Set("JobsDB.Bench.batchSize", 1000)
+		c.Set("JobsDB.Bench.failProbability", 0.5)
+		c.Set("JobsDB.Bench.maxFailures", 3)
+		c.Set("JobsDB.Bench.seedConcurrency", 4)
+		c.Set("JobsDB.Bench.seedBatchSize", 10000)
+
+		l := logger.NewFactory(c)
+		stat := stats.NewStats(c, l, statsmetric.Instance)
+		b, err := bench.New(c, stat, l.NewLogger(), postgresContainer.DB)
+		require.NoError(t, err)
+
+		require.NoError(t, b.Run(context.Background()))
 	})
 
 	t.Run("two_stage", func(t *testing.T) {

--- a/jobsdb/bench/scenario/compaction.go
+++ b/jobsdb/bench/scenario/compaction.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 	"golang.org/x/sync/errgroup"
@@ -68,6 +69,7 @@ func (p *compaction) Run(ctx context.Context) error {
 		eventPayloadSize = p.conf.GetInt64Var(2*bytesize.KB, 1, "JobsDB.Bench.payloadSize") // size of the event payload
 		destinations     = p.conf.GetIntVar(50, 1, "JobsDB.Bench.destinations")             // number of destinations the jobs are spread between
 		batchSize        = p.conf.GetIntVar(1000, 1, "JobsDB.Bench.batchSize")              // number of jobs a consumer fetches in one go
+		statusBatchSize  = p.conf.GetIntVar(1000, 1, "JobsDB.Bench.statusBatchSize")        // number of terminal statuses the updater flushes in one UpdateJobStatus call
 		failProbability  = p.conf.GetFloat64Var(0.5, "JobsDB.Bench.failProbability")        // probability a job is marked as failed on a given attempt
 		maxFailures      = p.conf.GetIntVar(3, 1, "JobsDB.Bench.maxFailures")               // cap on the number of times a single job may fail before it must succeed
 		seedConcurrency  = p.conf.GetIntVar(4, 1, "JobsDB.Bench.seedConcurrency")           // number of concurrent writers used while seeding a dataset
@@ -177,7 +179,7 @@ func (p *compaction) Run(ctx context.Context) error {
 		)
 
 		// Consume (measured).
-		duration, err := p.consume(ctx, db, customVal, totalJobs, destinations, batchSize, payloadLimit)
+		duration, err := p.consume(ctx, db, customVal, totalJobs, destinations, batchSize, statusBatchSize, payloadLimit)
 		db.Stop()
 		db.Close()
 		if err != nil {
@@ -266,46 +268,37 @@ func (p *compaction) seed(
 	return nil
 }
 
-// consume spawns one goroutine per destination, each repeatedly fetching a batch
-// of pending jobs, marking them executing and then marking each job succeeded or
-// failed according to its precomputed failure count. It returns once every
-// destination has been fully drained.
+// consume spawns one goroutine per destination plus one status-updater goroutine.
+// Each destination goroutine repeatedly fetches a batch of pending jobs, marks
+// them executing, then pushes the computed terminal statuses onto a
+// channel. The updater goroutine drains that channel in batches of
+// [statusBatchSize] and calls UpdateJobStatus. It returns once every destination
+// has been fully drained.
 func (p *compaction) consume(
 	ctx context.Context,
 	db *jobsdb.Handle,
 	customVal string,
-	totalJobs, destinations, batchSize int,
+	totalJobs, destinations, batchSize, statusBatchSize int,
 	payloadLimit int64,
 ) (time.Duration, error) {
 	// attempts[jobID] counts how many times a job has been processed so far.
 	// Each jobID is owned by exactly one destination => one goroutine, so plain
-	// (non-atomic) access would be safe; we keep it simple with a slice.
+	// (non-atomic) access is safe.
 	attempts := make([]int32, totalJobs+1)
 
 	var (
 		succeeded atomic.Int64 // total jobs marked succeeded (terminal)
 		failed    atomic.Int64 // total job failures (retries)
-		remaining atomic.Int64 // jobs not yet succeeded; the run is over when this hits 0
+		done      = make(chan struct{})
 	)
-	remaining.Store(int64(totalJobs))
 
-	// done is closed once every job has reached a terminal succeeded state.
-	// We rely on a global completion signal rather than treating an empty
-	// GetToProcess result as "drained": with a dsLimit in effect, a destination's
-	// pending jobs may live in datasets outside the current query window and only
-	// become visible after earlier datasets are compacted/dropped, so an empty
-	// result is transient and we must keep polling.
-	done := make(chan struct{})
-
-	// emptyPollInterval throttles polling for a destination that currently has no
-	// visible pending jobs (drained, or hidden behind the dsLimit window).
-	emptyPollInterval := 200 * time.Millisecond
+	// emptyPollInterval throttles retries when jobs exist but are temporarily
+	// hidden behind the dsLimit window (res.DSLimitsReached == true).
+	emptyPollInterval := 100 * time.Millisecond
 
 	start := time.Now()
 
-	// progress reporting, stopped explicitly after the consumers finish so it
-	// does not deadlock the errgroup (errgroup's context is only cancelled once
-	// Wait returns).
+	// progress reporting, stopped explicitly after all goroutines finish.
 	reporterStop := make(chan struct{})
 	go func() {
 		ticker := time.NewTicker(2 * time.Second)
@@ -320,21 +313,36 @@ func (p *compaction) consume(
 				fmt.Printf("[%s] drained %d/%d (%.1f%%), retries so far: %d\n",
 					time.Now().Format("15:04:05"), succeeded.Load(), totalJobs,
 					float64(succeeded.Load())/float64(totalJobs)*100, failed.Load())
+				if succeeded.Load() == int64(totalJobs) {
+					close(done)
+					return
+				}
 			}
 		}
 	}()
 
 	g, gCtx := errgroup.WithContext(ctx)
+
+	// One consumer + one updater goroutine pair per destination. Each consumer
+	// owns its statusCh and closes it on exit, which signals the paired updater
+	// to flush and return.
 	for dest := range destinations {
 		destID := fmt.Sprintf("dest-%d", dest)
+
+		// statusCh is buffered to at least the number of jobs the consumer
+		// fetches in one call so that marking-executing never stalls on the send.
+		statusCh := make(chan *jobsdb.JobStatusT, batchSize)
+
+		// Consumer goroutine: fetches jobs, marks them executing, pushes terminal
+		// statuses onto statusCh, and closes the channel when done.
+		// Exits immediately when len(jobs)==0 && !res.DSLimitsReached, meaning
+		// this destination is genuinely empty (not just hidden behind the dsLimit
+		// window). Only polls when DSLimitsReached is true.
 		g.Go(func() error {
+			defer close(statusCh)
 			for {
-				select {
-				case <-done:
+				if gCtx.Err() != nil {
 					return nil
-				case <-gCtx.Done():
-					return nil
-				default:
 				}
 				res, err := db.GetToProcess(gCtx, jobsdb.GetQueryParams{
 					CustomValFilters: []string{customVal},
@@ -349,24 +357,24 @@ func (p *compaction) consume(
 					}
 					return fmt.Errorf("could not get jobs for %s: %w", destID, err)
 				}
-				jobs := res.Jobs
-				if len(jobs) == 0 {
-					// nothing visible right now: either this destination is fully
-					// drained, or its remaining jobs are behind the dsLimit window.
-					// Wait a bit and retry until the run is globally complete.
+				if len(res.Jobs) == 0 {
+					if res.DSLimitsReached {
+						continue // poll again immediately
+					}
+					// jobs may still exist but hidden (marked as failed by the updater soon)
 					select {
-					case <-done:
-						return nil
 					case <-gCtx.Done():
+						return nil
+					case <-done:
 						return nil
 					case <-time.After(emptyPollInterval):
 					}
 					continue
 				}
 
-				// 1. mark the whole batch as executing
-				executing := make([]*jobsdb.JobStatusT, len(jobs))
-				for i, job := range jobs {
+				// mark the whole batch as executing
+				executing := make([]*jobsdb.JobStatusT, len(res.Jobs))
+				for i, job := range res.Jobs {
 					executing[i] = newStatus(job, jobsdb.Executing.State, "executing")
 				}
 				if err := db.UpdateJobStatus(gCtx, executing); err != nil {
@@ -376,44 +384,63 @@ func (p *compaction) consume(
 					return fmt.Errorf("could not mark jobs executing for %s: %w", destID, err)
 				}
 
-				// 2. mark each job succeeded or failed per the precomputed pattern
-				terminal := make([]*jobsdb.JobStatusT, len(jobs))
-				var batchSucceeded, batchFailed int64
-				for i, job := range jobs {
+				// compute terminal status per job and push to channel
+				for _, job := range res.Jobs {
 					attempt := attempts[job.JobID] + 1
 					attempts[job.JobID] = attempt
 					fc := int32(gjson.GetBytes(job.Parameters, "fc").Int())
+					st := newStatus(job, jobsdb.Succeeded.State, "200")
 					if attempt <= fc {
-						terminal[i] = newStatus(job, jobsdb.Failed.State, "500")
-						terminal[i].AttemptNum = int(attempt)
-						batchFailed++
-					} else {
-						terminal[i] = newStatus(job, jobsdb.Succeeded.State, "200")
-						terminal[i].AttemptNum = int(attempt)
-						batchSucceeded++
+						st = newStatus(job, jobsdb.Failed.State, "500")
+					}
+					st.AttemptNum = int(attempt)
+					select {
+					case <-gCtx.Done():
+						return nil
+					case statusCh <- st:
 					}
 				}
-				if err := db.UpdateJobStatus(gCtx, terminal); err != nil {
-					if gCtx.Err() != nil {
-						return nil // nolint: nilerr
+			}
+		})
+
+		// Updater goroutine: collects terminal statuses from statusCh in batches
+		// of up to statusBatchSize (or whatever arrived within 1s) and calls
+		// UpdateJobStatus once per batch.
+		g.Go(func() error {
+			for {
+				batch, length, _, ok := lo.BufferWithTimeout(statusCh, statusBatchSize, time.Second)
+				if length > 0 {
+					if err := db.UpdateJobStatus(gCtx, batch); err != nil {
+						if gCtx.Err() != nil {
+							return nil // nolint: nilerr
+						}
+						return fmt.Errorf("could not update job statuses for %s: %w", destID, err)
 					}
-					return fmt.Errorf("could not mark jobs terminal for %s: %w", destID, err)
+					var batchSucceeded, batchFailed int64
+					for _, st := range batch {
+						if st.JobState == jobsdb.Succeeded.State {
+							batchSucceeded++
+						} else {
+							batchFailed++
+						}
+					}
+					succeeded.Add(batchSucceeded)
+					failed.Add(batchFailed)
 				}
-				succeeded.Add(batchSucceeded)
-				failed.Add(batchFailed)
-				// Each job succeeds exactly once, so remaining decreases
-				// monotonically to 0; the goroutine that hits 0 closes done.
-				if batchSucceeded > 0 && remaining.Add(-batchSucceeded) == 0 {
-					close(done)
+				if !ok {
 					return nil
 				}
 			}
 		})
 	}
+
 	err := g.Wait()
 	close(reporterStop)
 	if err != nil {
 		return 0, err
+	}
+	if s := succeeded.Load(); s != int64(totalJobs) {
+		return 0, fmt.Errorf("validation failed: expected %d succeeded jobs, got %d (retries: %d)", totalJobs, s, failed.Load())
 	}
 	return time.Since(start), nil
 }

--- a/jobsdb/bench/scenario/compaction.go
+++ b/jobsdb/bench/scenario/compaction.go
@@ -58,6 +58,7 @@ type flagSet struct {
 	name                       string
 	nonBlockingCompletedDSDrop bool
 	nonBlockingCompaction      bool
+	compactionDeferStatusLock  bool
 }
 
 func (p *compaction) Run(ctx context.Context) error {
@@ -124,6 +125,7 @@ func (p *compaction) Run(ctx context.Context) error {
 		{name: "baseline (blocking compaction)", nonBlockingCompletedDSDrop: false, nonBlockingCompaction: false},
 		{name: "nonBlockingCompletedDSDrop", nonBlockingCompletedDSDrop: true, nonBlockingCompaction: false},
 		{name: "nonBlockingCompaction", nonBlockingCompaction: true},
+		{name: "nonBlockingCompaction + deferStatusLock", nonBlockingCompaction: true, compactionDeferStatusLock: true},
 	}
 
 	type result struct {
@@ -141,6 +143,7 @@ func (p *compaction) Run(ctx context.Context) error {
 		// Apply the flag combination under test.
 		p.conf.Set("JobsDB."+tablePrefix+".nonBlockingCompletedDSDrop", s.nonBlockingCompletedDSDrop)
 		p.conf.Set("JobsDB."+tablePrefix+".nonBlockingCompaction", s.nonBlockingCompaction)
+		p.conf.Set("JobsDB."+tablePrefix+".compactionDeferStatusLock", s.compactionDeferStatusLock)
 
 		// Deterministic addNewDS trigger so we can seed exactly [datasets]
 		// datasets of [jobsPerDataset] jobs each.

--- a/jobsdb/bench/scenario/compaction.go
+++ b/jobsdb/bench/scenario/compaction.go
@@ -1,0 +1,437 @@
+package scenario
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	mathrand "math/rand/v2"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+)
+
+// NewCompaction creates a jobsdb bench scenario which compares how the various
+// compaction / completed-DS-drop strategies behave under a draining workload.
+//
+// For every configured flag combination it:
+//  1. creates a fresh read-write jobsdb seeded with [datasets] datasets, each
+//     holding [jobsPerDataset] jobs (spread evenly across [destinations]),
+//  2. spawns one consumer goroutine per destination which repeatedly fetches a
+//     batch of pending jobs, marks them as executing and then marks each job as
+//     succeeded or failed according to a precomputed pattern,
+//  3. measures the wall-clock time it takes for every consumer to drain its
+//     destination (i.e. until there are no pending jobs left).
+//
+// The success/failure pattern is precomputed once and reused verbatim for every
+// flag combination so that all scenarios face exactly the same workload.
+func NewCompaction(conf *config.Config, stats stats.Stats, log logger.Logger, db *sql.DB) *compaction {
+	return &compaction{
+		stats: stats,
+		log:   log,
+		conf:  conf,
+		db:    db,
+	}
+}
+
+type compaction struct {
+	stats stats.Stats
+	log   logger.Logger
+	conf  *config.Config
+	db    *sql.DB
+}
+
+// flagSet is a single jobsdb compaction configuration under test.
+type flagSet struct {
+	name                       string
+	nonBlockingCompletedDSDrop bool
+	nonBlockingCompaction      bool
+}
+
+func (p *compaction) Run(ctx context.Context) error {
+	var (
+		tablePrefix      = "bench"
+		customVal        = "benchmark"
+		datasets         = p.conf.GetIntVar(10, 1, "JobsDB.Bench.datasets")                 // number of datasets to seed
+		jobsPerDataset   = p.conf.GetIntVar(100000, 1, "JobsDB.Bench.jobsPerDataset")       // number of jobs per dataset
+		eventPayloadSize = p.conf.GetInt64Var(2*bytesize.KB, 1, "JobsDB.Bench.payloadSize") // size of the event payload
+		destinations     = p.conf.GetIntVar(50, 1, "JobsDB.Bench.destinations")             // number of destinations the jobs are spread between
+		batchSize        = p.conf.GetIntVar(1000, 1, "JobsDB.Bench.batchSize")              // number of jobs a consumer fetches in one go
+		failProbability  = p.conf.GetFloat64Var(0.5, "JobsDB.Bench.failProbability")        // probability a job is marked as failed on a given attempt
+		maxFailures      = p.conf.GetIntVar(3, 1, "JobsDB.Bench.maxFailures")               // cap on the number of times a single job may fail before it must succeed
+		seedConcurrency  = p.conf.GetIntVar(4, 1, "JobsDB.Bench.seedConcurrency")           // number of concurrent writers used while seeding a dataset
+		seedBatchSize    = p.conf.GetIntVar(10000, 1, "JobsDB.Bench.seedBatchSize")         // number of jobs written per Store call while seeding
+		payloadLimit     = p.conf.GetInt64Var(100*bytesize.MB, 1, "JobsDB.Bench.payloadLimit")
+		maintenanceDSN   = p.conf.GetStringVar("", "JobsDB.Bench.maintenanceDSN")       // if set, jobsdb-internal maintenance ops use a dedicated pool against this DSN
+		maintenanceConns = p.conf.GetIntVar(10, 1, "JobsDB.Bench.maintenancePoolConns") // size of the dedicated maintenance pool
+	)
+	totalJobs := datasets * jobsPerDataset
+
+	// Optional dedicated maintenance connection pool. Isolating jobsdb-internal
+	// maintenance ops (compaction setup, post-commit dsList refresh, status-table
+	// cleanup/vacuum) from the main pool avoids them contending for the same
+	// connections as the seeders/consumers. Opened once and shared across every
+	// scenario handle (they run sequentially against the same database).
+	var maintenancePool *sql.DB
+	if maintenanceDSN != "" {
+		var err error
+		maintenancePool, err = sql.Open("postgres", maintenanceDSN)
+		if err != nil {
+			return fmt.Errorf("could not open maintenance pool: %w", err)
+		}
+		maintenancePool.SetMaxOpenConns(maintenanceConns)
+		maintenancePool.SetMaxIdleConns(maintenanceConns)
+		defer maintenancePool.Close()
+	}
+
+	// Build a single reusable event payload of the requested size.
+	eventPayload := []byte("{}")
+	for actualSize := len(eventPayload); actualSize < int(eventPayloadSize); actualSize = len(eventPayload) {
+		var err error
+		eventPayload, err = sjson.SetBytes(eventPayload, "values.-1", rand.String(10))
+		if err != nil {
+			return fmt.Errorf("could not set payload: %w", err)
+		}
+	}
+
+	// Precompute, ONCE, the number of times each job (by creation index) should
+	// fail before it is allowed to succeed. This pattern is identical for every
+	// flag combination, so all scenarios face exactly the same workload.
+	rng := mathrand.New(mathrand.NewPCG(0x9E3779B97F4A7C15, 0xBF58476D1CE4E5B9))
+	failPattern := make([]uint8, totalJobs)
+	for i := range failPattern {
+		var fc uint8
+		for int(fc) < maxFailures && rng.Float64() < failProbability {
+			fc++
+		}
+		failPattern[i] = fc
+	}
+
+	scenarios := []flagSet{
+		{name: "baseline (blocking compaction)", nonBlockingCompletedDSDrop: false, nonBlockingCompaction: false},
+		{name: "nonBlockingCompletedDSDrop", nonBlockingCompletedDSDrop: true, nonBlockingCompaction: false},
+		{name: "nonBlockingCompaction", nonBlockingCompaction: true},
+	}
+
+	type result struct {
+		name     string
+		duration time.Duration
+	}
+	results := make([]result, 0, len(scenarios))
+
+	for _, s := range scenarios {
+		if ctx.Err() != nil {
+			return nil
+		}
+		p.log.Infon("running compaction bench scenario", logger.NewStringField("scenario", s.name))
+
+		// Apply the flag combination under test.
+		p.conf.Set("JobsDB."+tablePrefix+".nonBlockingCompletedDSDrop", s.nonBlockingCompletedDSDrop)
+		p.conf.Set("JobsDB."+tablePrefix+".nonBlockingCompaction", s.nonBlockingCompaction)
+
+		// Deterministic addNewDS trigger so we can seed exactly [datasets]
+		// datasets of [jobsPerDataset] jobs each.
+		triggerAddNewDS := make(chan time.Time)
+		opts := []jobsdb.OptsFunc{
+			jobsdb.WithClearDB(true),
+			jobsdb.WithStats(p.stats),
+			jobsdb.WithDBHandle(p.db),
+			jobsdb.WithConfig(p.conf),
+			jobsdb.WithSkipMaintenanceErr(true),
+			jobsdb.WithTriggerAddNewDS(func() <-chan time.Time { return triggerAddNewDS }),
+		}
+		if maintenancePool != nil {
+			opts = append(opts, jobsdb.WithMaintenancePoolDB(maintenancePool))
+		}
+		db := jobsdb.NewForReadWrite(tablePrefix, opts...)
+		if err := db.Start(); err != nil {
+			db.Close()
+			return fmt.Errorf("could not start bench jobsdb: %w", err)
+		}
+
+		// Seed the datasets (not measured).
+		seedStart := time.Now()
+		if err := p.seed(ctx, db, triggerAddNewDS, customVal, eventPayload, failPattern, datasets, jobsPerDataset, destinations, seedConcurrency, seedBatchSize); err != nil {
+			db.Stop()
+			db.Close()
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("could not seed jobsdb: %w", err)
+		}
+		p.log.Infon("seeding complete",
+			logger.NewStringField("scenario", s.name),
+			logger.NewIntField("jobs", int64(totalJobs)),
+			logger.NewDurationField("duration", time.Since(seedStart)),
+		)
+
+		// Consume (measured).
+		duration, err := p.consume(ctx, db, customVal, totalJobs, destinations, batchSize, payloadLimit)
+		db.Stop()
+		db.Close()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("scenario %q failed: %w", s.name, err)
+		}
+		results = append(results, result{name: s.name, duration: duration})
+		fmt.Printf("\n=== scenario %q drained %d jobs in %s ===\n\n", s.name, totalJobs, duration)
+	}
+
+	fmt.Printf("\n================ compaction bench summary (%d jobs) ================\n", totalJobs)
+	for _, r := range results {
+		fmt.Printf("  %-45s %s\n", r.name, r.duration)
+	}
+	fmt.Printf("===================================================================\n")
+	return nil
+}
+
+// seed writes [datasets] datasets of [jobsPerDataset] jobs each, triggering a
+// new DS between datasets so that every dataset holds exactly [jobsPerDataset]
+// jobs. Job [i] (global creation index) is assigned to destination i%destinations
+// and carries its precomputed failure count in its parameters.
+func (p *compaction) seed(
+	ctx context.Context,
+	db *jobsdb.Handle,
+	triggerAddNewDS chan time.Time,
+	customVal string,
+	eventPayload []byte,
+	failPattern []uint8,
+	datasets, jobsPerDataset, destinations, seedConcurrency, seedBatchSize int,
+) error {
+	for d := range datasets {
+		g, gCtx := errgroup.WithContext(ctx)
+		g.SetLimit(seedConcurrency)
+		for start := 0; start < jobsPerDataset; start += seedBatchSize {
+			end := min(start+seedBatchSize, jobsPerDataset)
+			g.Go(func() error {
+				jobs := make([]*jobsdb.JobT, 0, end-start)
+				for pos := start; pos < end; pos++ {
+					globalIdx := d*jobsPerDataset + pos
+					destID := globalIdx % destinations
+					params, err := sjson.SetBytes(
+						fmt.Appendf(nil, `{"destination_id":"dest-%d"}`, destID),
+						"fc", failPattern[globalIdx],
+					)
+					if err != nil {
+						return fmt.Errorf("could not set fc parameter: %w", err)
+					}
+					jobs = append(jobs, &jobsdb.JobT{
+						UUID:         uuid.New(),
+						UserID:       uuid.New().String(),
+						CreatedAt:    time.Now().UTC(),
+						EventCount:   1,
+						WorkspaceId:  "workspace",
+						Parameters:   params,
+						CustomVal:    customVal,
+						EventPayload: eventPayload,
+					})
+				}
+				if err := db.Store(gCtx, jobs); err != nil {
+					return fmt.Errorf("could not store seed jobs: %w", err)
+				}
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return err
+		}
+		// roll over to a new (empty) dataset, except after the last one so that
+		// we end up with exactly [datasets] full datasets.
+		if d < datasets-1 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case triggerAddNewDS <- time.Now():
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case triggerAddNewDS <- time.Now(): // second send waits for the first loop iteration to finish
+			}
+		}
+	}
+	return nil
+}
+
+// consume spawns one goroutine per destination, each repeatedly fetching a batch
+// of pending jobs, marking them executing and then marking each job succeeded or
+// failed according to its precomputed failure count. It returns once every
+// destination has been fully drained.
+func (p *compaction) consume(
+	ctx context.Context,
+	db *jobsdb.Handle,
+	customVal string,
+	totalJobs, destinations, batchSize int,
+	payloadLimit int64,
+) (time.Duration, error) {
+	// attempts[jobID] counts how many times a job has been processed so far.
+	// Each jobID is owned by exactly one destination => one goroutine, so plain
+	// (non-atomic) access would be safe; we keep it simple with a slice.
+	attempts := make([]int32, totalJobs+1)
+
+	var (
+		succeeded atomic.Int64 // total jobs marked succeeded (terminal)
+		failed    atomic.Int64 // total job failures (retries)
+		remaining atomic.Int64 // jobs not yet succeeded; the run is over when this hits 0
+	)
+	remaining.Store(int64(totalJobs))
+
+	// done is closed once every job has reached a terminal succeeded state.
+	// We rely on a global completion signal rather than treating an empty
+	// GetToProcess result as "drained": with a dsLimit in effect, a destination's
+	// pending jobs may live in datasets outside the current query window and only
+	// become visible after earlier datasets are compacted/dropped, so an empty
+	// result is transient and we must keep polling.
+	done := make(chan struct{})
+
+	// emptyPollInterval throttles polling for a destination that currently has no
+	// visible pending jobs (drained, or hidden behind the dsLimit window).
+	emptyPollInterval := 200 * time.Millisecond
+
+	start := time.Now()
+
+	// progress reporting, stopped explicitly after the consumers finish so it
+	// does not deadlock the errgroup (errgroup's context is only cancelled once
+	// Wait returns).
+	reporterStop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-reporterStop:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				fmt.Printf("[%s] drained %d/%d (%.1f%%), retries so far: %d\n",
+					time.Now().Format("15:04:05"), succeeded.Load(), totalJobs,
+					float64(succeeded.Load())/float64(totalJobs)*100, failed.Load())
+			}
+		}
+	}()
+
+	g, gCtx := errgroup.WithContext(ctx)
+	for dest := range destinations {
+		destID := fmt.Sprintf("dest-%d", dest)
+		g.Go(func() error {
+			for {
+				select {
+				case <-done:
+					return nil
+				case <-gCtx.Done():
+					return nil
+				default:
+				}
+				res, err := db.GetToProcess(gCtx, jobsdb.GetQueryParams{
+					CustomValFilters: []string{customVal},
+					JobsLimit:        batchSize,
+					EventsLimit:      batchSize,
+					PayloadSizeLimit: payloadLimit,
+					ParameterFilters: []jobsdb.ParameterFilterT{{Name: "destination_id", Value: destID}},
+				}, nil)
+				if err != nil {
+					if gCtx.Err() != nil {
+						return nil // nolint: nilerr
+					}
+					return fmt.Errorf("could not get jobs for %s: %w", destID, err)
+				}
+				jobs := res.Jobs
+				if len(jobs) == 0 {
+					// nothing visible right now: either this destination is fully
+					// drained, or its remaining jobs are behind the dsLimit window.
+					// Wait a bit and retry until the run is globally complete.
+					select {
+					case <-done:
+						return nil
+					case <-gCtx.Done():
+						return nil
+					case <-time.After(emptyPollInterval):
+					}
+					continue
+				}
+
+				// 1. mark the whole batch as executing
+				executing := make([]*jobsdb.JobStatusT, len(jobs))
+				for i, job := range jobs {
+					executing[i] = newStatus(job, jobsdb.Executing.State, "executing")
+				}
+				if err := db.UpdateJobStatus(gCtx, executing); err != nil {
+					if gCtx.Err() != nil {
+						return nil // nolint: nilerr
+					}
+					return fmt.Errorf("could not mark jobs executing for %s: %w", destID, err)
+				}
+
+				// 2. mark each job succeeded or failed per the precomputed pattern
+				terminal := make([]*jobsdb.JobStatusT, len(jobs))
+				var batchSucceeded, batchFailed int64
+				for i, job := range jobs {
+					attempt := attempts[job.JobID] + 1
+					attempts[job.JobID] = attempt
+					fc := int32(gjson.GetBytes(job.Parameters, "fc").Int())
+					if attempt <= fc {
+						terminal[i] = newStatus(job, jobsdb.Failed.State, "500")
+						terminal[i].AttemptNum = int(attempt)
+						batchFailed++
+					} else {
+						terminal[i] = newStatus(job, jobsdb.Succeeded.State, "200")
+						terminal[i].AttemptNum = int(attempt)
+						batchSucceeded++
+					}
+				}
+				if err := db.UpdateJobStatus(gCtx, terminal); err != nil {
+					if gCtx.Err() != nil {
+						return nil // nolint: nilerr
+					}
+					return fmt.Errorf("could not mark jobs terminal for %s: %w", destID, err)
+				}
+				succeeded.Add(batchSucceeded)
+				failed.Add(batchFailed)
+				// Each job succeeds exactly once, so remaining decreases
+				// monotonically to 0; the goroutine that hits 0 closes done.
+				if batchSucceeded > 0 && remaining.Add(-batchSucceeded) == 0 {
+					close(done)
+					return nil
+				}
+			}
+		})
+	}
+	err := g.Wait()
+	close(reporterStop)
+	if err != nil {
+		return 0, err
+	}
+	return time.Since(start), nil
+}
+
+func newStatus(job *jobsdb.JobT, state, errorCode string) *jobsdb.JobStatusT {
+	now := time.Now()
+	return &jobsdb.JobStatusT{
+		JobID:         job.JobID,
+		JobState:      state,
+		AttemptNum:    1,
+		ExecTime:      now,
+		RetryTime:     now,
+		ErrorCode:     errorCode,
+		ErrorResponse: []byte(`{}`),
+		Parameters:    []byte(`{}`),
+		JobParameters: job.Parameters,
+		WorkspaceId:   job.WorkspaceId,
+		PartitionID:   job.PartitionID,
+		CustomVal:     job.CustomVal,
+	}
+}

--- a/jobsdb/internal/dsindex/dsindex.go
+++ b/jobsdb/internal/dsindex/dsindex.go
@@ -71,6 +71,17 @@ func (idx *Index) Increment(segment int) (*Index, error) {
 	return res, nil
 }
 
+// Compare returns -1, 0, or 1 if this dataset index is less than, equal to, or greater than other.
+func (idx *Index) Compare(other *Index) int {
+	if idx.Less(other) {
+		return -1
+	}
+	if other.Less(idx) {
+		return 1
+	}
+	return 0
+}
+
 // Less returns true if this dataset index is Less than the other dataset index
 func (idx *Index) Less(other *Index) bool {
 	for i, segment := range idx.segments {

--- a/jobsdb/internal/dsindex/dsindex_test.go
+++ b/jobsdb/internal/dsindex/dsindex_test.go
@@ -84,6 +84,16 @@ func Test_Index_Increment(t *testing.T) {
 	})
 }
 
+func Test_Index_Compare(t *testing.T) {
+	require.Equal(t, -1, dsindex.MustParse("0").Compare(dsindex.MustParse("1")))
+	require.Equal(t, -1, dsindex.MustParse("0_1").Compare(dsindex.MustParse("1")))
+	require.Equal(t, -1, dsindex.MustParse("1_1").Compare(dsindex.MustParse("1_2")))
+	require.Equal(t, 0, dsindex.MustParse("1").Compare(dsindex.MustParse("1")))
+	require.Equal(t, 0, dsindex.MustParse("1_1").Compare(dsindex.MustParse("1_1")))
+	require.Equal(t, 1, dsindex.MustParse("1").Compare(dsindex.MustParse("0_1")))
+	require.Equal(t, 1, dsindex.MustParse("1_1_1").Compare(dsindex.MustParse("1_1")))
+}
+
 func Test_Index_Bump(t *testing.T) {
 	t.Run("success scenarios", func(t *testing.T) {
 		require.Equal(t, "0_1", dsindex.MustParse("0").MustBump(dsindex.MustParse("1")).String())

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -677,6 +677,13 @@ type Handle struct {
 			// lock + readonly trigger on the source status table, async source drop).
 			// When disabled, falls back to the legacy doMigrateDS flow.
 			nonBlockingCompaction config.ValueLoader[bool]
+			// compactionDeferStatusLock further minimizes the status-table lock
+			// window during non-blocking compaction by splitting the copy into two
+			// phases: pending jobs are copied first WITHOUT any status-table lock,
+			// then each source status table is locked EXCLUSIVE one after another only
+			// to copy the latest statuses of the moved jobs. Requires
+			// nonBlockingCompaction; has no effect on its own.
+			compactionDeferStatusLock config.ValueLoader[bool]
 			// getJobsRetryOnCompaction gates the snapshot revalidation in getJobs:
 			// when set, getJobs detects that a queried dataset is no longer in the
 			// published list (e.g. a non-blocking compaction completed mid-read) and
@@ -1177,6 +1184,7 @@ func (jd *Handle) loadConfig() {
 	jd.conf.migration.vacuumAnalyzeStatusTableThreshold = jd.config.GetReloadableInt64Var(30000, 1, jd.configKeys("vacuumAnalyzeStatusTableThreshold")...)
 	jd.conf.migration.nonBlockingCompletedDSDrop = jd.config.GetReloadableBoolVar(false, jd.configKeys("nonBlockingCompletedDSDrop")...)
 	jd.conf.migration.nonBlockingCompaction = jd.config.GetReloadableBoolVar(false, jd.configKeys("nonBlockingCompaction")...)
+	jd.conf.migration.compactionDeferStatusLock = jd.config.GetReloadableBoolVar(false, jd.configKeys("compactionDeferStatusLock")...)
 	jd.conf.migration.getJobsRetryOnCompaction = jd.config.GetReloadableBoolVar(true, jd.configKeys("getJobsRetryOnCompaction")...)
 
 	// masterBackupEnabled = true => all the jobsdb are eligible for backup
@@ -1813,7 +1821,16 @@ func (jd *Handle) createDSTablesInTx(ctx context.Context, tx *Tx, newDS dataSetT
 	return nil
 }
 
+// createDSIndicesInTx creates the indices for the given dataset.
 func (jd *Handle) createDSIndicesInTx(ctx context.Context, tx *Tx, newDS dataSetT) error {
+	if err := jd.createDSJobIndicesInTx(ctx, tx, newDS); err != nil {
+		return err
+	}
+	return jd.createDSStatusIndicesInTx(ctx, tx, newDS)
+}
+
+// createDSJobIndicesInTx creates the indices that live on the jobs table
+func (jd *Handle) createDSJobIndicesInTx(ctx context.Context, tx *Tx, newDS dataSetT) error {
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_ws" ON %[1]q (workspace_id)`, newDS.JobTable)); err != nil {
 		return fmt.Errorf("creating workspace_id index: %w", err)
 	}
@@ -1828,6 +1845,12 @@ func (jd *Handle) createDSIndicesInTx(ctx context.Context, tx *Tx, newDS dataSet
 			return fmt.Errorf("creating %s index: %w", param, err)
 		}
 	}
+	return nil
+}
+
+// createDSStatusIndicesInTx creates the indices on the job status table plus the
+// v_last view.
+func (jd *Handle) createDSStatusIndicesInTx(ctx context.Context, tx *Tx, newDS dataSetT) error {
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_jid_id_js" ON %[1]q(job_id asc,id desc,job_state)`, newDS.JobStatusTable)); err != nil {
 		return fmt.Errorf("adding job_id_id index: %w", err)
 	}

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -394,14 +394,15 @@ func (jd *Handle) UpdateJobStatusInTx(ctx context.Context, tx UpdateSafeTx, stat
 
 		jd.logger.Warnn("[JobsDB] :: Stale dataset list detected while updating job statuses, retrying after refreshing DS cache", obskit.Error(ErrStaleDsList))
 		if refreshErr := func() error {
-			return jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
-				if err := jd.doRefreshDSRangeListWithDB(l, tx.SqlTx()); err != nil {
-					return fmt.Errorf("refresh ds range list: %w", err)
-				}
-				dsList, dsRangeList := jd.dsList.snapshot()
-				tx.setDSList(dsList, dsRangeList)
-				return nil
-			})
+			// we don't need to actually refresh the ds list from the database, since compaction already does this,
+			// but we do need to acquire a read lock on dsListLock to ensure that the ds list is actually refreshed.
+			if lock := jd.dsListLock.RTryLockWithCtx(ctx); !lock {
+				return fmt.Errorf("acquiring read lock for refreshing ds list in update job status: %w", ctx.Err())
+			}
+			dsList, dsRangeList := jd.dsList.snapshot()
+			tx.setDSList(dsList, dsRangeList)
+			jd.dsListLock.RUnlock()
+			return nil
 		}(); refreshErr != nil {
 			return refreshErr
 		}
@@ -928,6 +929,14 @@ func WithPriorityPoolDB(pool *sql.DB) OptsFunc {
 func WithMaintenancePoolDB(pool *sql.DB) OptsFunc {
 	return func(jd *Handle) {
 		jd.maintenancePool = pool
+	}
+}
+
+// WithTriggerAddNewDS overrides the addNewDS loop trigger, allowing callers
+// (tests and benchmarks) to deterministically control when new datasets are created.
+func WithTriggerAddNewDS(trigger func() <-chan time.Time) OptsFunc {
+	return func(jd *Handle) {
+		jd.TriggerAddNewDS = trigger
 	}
 }
 
@@ -3117,7 +3126,7 @@ func (jd *Handle) addNewDSLoop(ctx context.Context) {
 							if err != nil {
 								return fmt.Errorf("acquiring dsListLock: %w", err)
 							}
-							jd.logger.Infon("Acquired lock",
+							jd.logger.Infon("[[ addNewDSLoop ]]: Acquired lock",
 								logger.NewStringField("ds", latestDS.String()),
 								logger.NewStringField("jobsdb", jd.tablePrefix))
 							if _, err = tx.ExecContext(ctx, fmt.Sprintf(`LOCK TABLE %q IN EXCLUSIVE MODE;`, latestDS.JobTable)); err != nil {
@@ -3472,10 +3481,12 @@ func (jd *Handle) internalUpdateJobStatusInTx(ctx context.Context, tx *Tx, dsLis
 	// do update
 	updatedStatesByDS, err := jd.doUpdateJobStatusInTx(ctx, tx, dsList, dsRangeList, statusList)
 	if err != nil {
-		jd.logger.Infon("Error occurred while updating job statuses",
-			logger.NewStringField("tablePrefix", jd.tablePrefix),
-			obskit.Error(err),
-		)
+		if !errors.Is(err, ErrStaleDsList) {
+			jd.logger.Infon("Error occurred while updating job statuses",
+				logger.NewStringField("tablePrefix", jd.tablePrefix),
+				obskit.Error(err),
+			)
+		}
 		return err
 	}
 

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1183,8 +1183,8 @@ func (jd *Handle) loadConfig() {
 	jd.conf.migration.vacuumFullStatusTableThreshold = jd.config.GetReloadableInt64Var(500*bytesize.MB, 1, jd.configKeys("vacuumFullStatusTableThreshold")...)
 	jd.conf.migration.vacuumAnalyzeStatusTableThreshold = jd.config.GetReloadableInt64Var(30000, 1, jd.configKeys("vacuumAnalyzeStatusTableThreshold")...)
 	jd.conf.migration.nonBlockingCompletedDSDrop = jd.config.GetReloadableBoolVar(false, jd.configKeys("nonBlockingCompletedDSDrop")...)
-	jd.conf.migration.nonBlockingCompaction = jd.config.GetReloadableBoolVar(false, jd.configKeys("nonBlockingCompaction")...)
-	jd.conf.migration.compactionDeferStatusLock = jd.config.GetReloadableBoolVar(false, jd.configKeys("compactionDeferStatusLock")...)
+	jd.conf.migration.nonBlockingCompaction = jd.config.GetReloadableBoolVar(true, jd.configKeys("nonBlockingCompaction")...)
+	jd.conf.migration.compactionDeferStatusLock = jd.config.GetReloadableBoolVar(true, jd.configKeys("compactionDeferStatusLock")...)
 	jd.conf.migration.getJobsRetryOnCompaction = jd.config.GetReloadableBoolVar(true, jd.configKeys("getJobsRetryOnCompaction")...)
 
 	// masterBackupEnabled = true => all the jobsdb are eligible for backup

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -622,6 +622,15 @@ func TestUpdateJobStatusInExternalTxRetriesAfterReadonlyStatusTable(t *testing.T
 			if err := prepareReplacement(); err != nil {
 				return err
 			}
+			// Refresh the in-memory ds list, mirroring what compaction does after
+			// it commits a layout change. The stale-ds retry in UpdateJobStatusInTx
+			// reads this in-memory snapshot (it no longer re-reads from the DB), so
+			// the replacement dataset must be visible there for the retry to target it.
+			if err := jobsDB.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
+				return jobsDB.doRefreshDSRangeList(l)
+			}); err != nil {
+				return err
+			}
 			return jobsDB.UpdateJobStatusInTx(ctx, updateTx, statuses)
 		})
 	}))

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -169,6 +170,7 @@ func (jd *Handle) doMigrateDS(ctx context.Context) error {
 					"[[ migrateDSLoop ]]",
 					logger.NewIntField("pendingJobsCount", int64(pendingJobsCount)),
 					logger.NewIntField("migrateFrom", int64(len(migrateFrom))),
+					logger.NewStringField("from", strings.Join(lo.Map(migrateFromDatasets, func(d dataSetT, _ int) string { return d.Index }), ",")),
 					logger.NewStringField("to", destination.Index),
 					logger.NewStringField("insert before", insertBeforeDS.Index),
 				)
@@ -580,6 +582,10 @@ func (jd *Handle) getMigrationList(dsList []dataSetT, skipBefore *dsindex.Index,
 		migrateDSProbeCount++
 	}
 	if len(result.migrateFrom) > 0 {
+		// sort migrateFrom, since needsPair & maxDSRetentionPeriod logic may have added datasets out of order
+		slices.SortFunc(result.migrateFrom, func(a, b dsWithPendingJobCount) int {
+			return dsindex.MustParse(a.ds.Index).Compare(dsindex.MustParse(b.ds.Index))
+		})
 		result.firstEligible = dsindex.MustParse(result.migrateFrom[0].ds.Index)
 	}
 	return result, nil
@@ -774,6 +780,7 @@ func (jd *Handle) doCompactDS(ctx context.Context) error {
 		"[[ doCompactDS ]]",
 		logger.NewIntField("pendingJobsCount", int64(migrationList.pendingJobsCount)),
 		logger.NewIntField("migrateFrom", int64(len(migrateFromDatasets))),
+		logger.NewStringField("from", strings.Join(lo.Map(migrateFromDatasets, func(d dataSetT, _ int) string { return d.Index }), ",")),
 		logger.NewStringField("to", destination.Index),
 		logger.NewStringField("insert before", migrationList.insertBeforeDS.Index),
 	)

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -619,12 +619,10 @@ func getColumnConversion(srcType, destType string) (string, error) {
 	return result, nil
 }
 
-func (jd *Handle) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) (int, error) {
-	defer jd.getTimerStat(
-		"migration_jobs",
-		&statTags{CustomValFilters: []string{jd.tablePrefix}},
-	).RecordDuration()()
-
+// resolvePayloadConversion inspects the event_payload column types of the source
+// and destination jobs tables and returns the SQL expression used to convert a
+// source payload to the destination column type (see getColumnConversion).
+func (jd *Handle) resolvePayloadConversion(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) (string, error) {
 	columnTypeMap := map[string]string{srcDS.JobTable: string(JSONB), destDS.JobTable: string(JSONB)}
 	// find column types first - to differentiate between `text`, `bytea` and `jsonb`
 	rows, err := tx.QueryContext(
@@ -635,23 +633,82 @@ func (jd *Handle) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dat
 		srcDS.JobTable, destDS.JobTable,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("get column types: %w", err)
+		return "", fmt.Errorf("get column types: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	var jobsTable, columnType string
 	for rows.Next() {
 		if err = rows.Scan(&jobsTable, &columnType); err != nil {
-			return 0, fmt.Errorf("scan column types: %w", err)
+			return "", fmt.Errorf("scan column types: %w", err)
 		}
 		if columnType != string(BYTEA) && columnType != string(JSONB) && columnType != string(TEXT) {
-			return 0, fmt.Errorf("unsupported column type %s", columnType)
+			return "", fmt.Errorf("unsupported column type %s", columnType)
 		}
 		columnTypeMap[jobsTable] = columnType
 	}
 	if err = rows.Err(); err != nil {
-		return 0, fmt.Errorf("rows.Err() on column types: %w", err)
+		return "", fmt.Errorf("rows.Err() on column types: %w", err)
 	}
-	payloadLiteral, err := getColumnConversion(columnTypeMap[srcDS.JobTable], columnTypeMap[destDS.JobTable])
+	return getColumnConversion(columnTypeMap[srcDS.JobTable], columnTypeMap[destDS.JobTable])
+}
+
+// copyJobsInTx copies the still-pending jobs (and jobs that were never picked up) from the source jobs
+// table to the destination. It returns the number of jobs copied.
+func (jd *Handle) copyJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) (int, error) {
+	defer jd.getTimerStat(
+		"migration_jobs",
+		&statTags{CustomValFilters: []string{jd.tablePrefix}},
+	).RecordDuration()()
+
+	payloadLiteral, err := jd.resolvePayloadConversion(ctx, tx, srcDS, destDS)
+	if err != nil {
+		return 0, err
+	}
+
+	copyQuery := fmt.Sprintf(
+		`insert into %[2]q (job_id,   workspace_id,   uuid,   user_id,   partition_id, custom_val,   parameters,   event_payload,   event_count,   created_at,   expire_at)
+		           (select j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.custom_val, j.parameters, %[4]s, j.event_count, j.created_at, j.expire_at from %[3]q j left join "v_last_%[1]s" js on js.job_id = j.job_id
+			where js.job_id is null or js.job_state = ANY('{%[5]s}') order by j.job_id)`,
+		srcDS.JobStatusTable,
+		destDS.JobTable,
+		srcDS.JobTable,
+		payloadLiteral,
+		strings.Join(validNonTerminalStates, ","),
+	)
+	res, err := tx.ExecContext(ctx, copyQuery)
+	if err != nil {
+		return 0, err
+	}
+	count, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(count), nil
+}
+
+// copyJobStatusesInTx copies the LATEST status of every job in the destDS (terminal or not) from the srcDS status table to the destDS status table.
+func (jd *Handle) copyJobStatusesInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) error {
+	copyQuery := fmt.Sprintf(
+		`insert into %[2]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters)
+		           (select js.job_id, js.job_state, js.attempt, js.exec_time, js.retry_time, js.error_code, js.error_response, js.parameters from "v_last_%[1]s" js
+			where exists (select 1 from %[3]q dj where dj.job_id = js.job_id))`,
+		srcDS.JobStatusTable,
+		destDS.JobStatusTable,
+		destDS.JobTable,
+	)
+	if _, err := tx.ExecContext(ctx, copyQuery); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (jd *Handle) migrateJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) (int, error) {
+	defer jd.getTimerStat(
+		"migration_jobs",
+		&statTags{CustomValFilters: []string{jd.tablePrefix}},
+	).RecordDuration()()
+
+	payloadLiteral, err := jd.resolvePayloadConversion(ctx, tx, srcDS, destDS)
 	if err != nil {
 		return 0, err
 	}
@@ -718,6 +775,25 @@ func (jd *Handle) computeNewIdxForIntraNodeMigration(l lock.LockToken, insertBef
 	return newDSIdx, nil
 }
 
+// lockAndFenceStatusTable takes an EXCLUSIVE lock on the status table and
+// plants the readonly trigger which raises RS001 whenever any subsequent insert is attempted on the status table.
+func (jd *Handle) lockAndFenceStatusTable(ctx context.Context, tx *Tx, statusTable string) error {
+	// EXCLUSIVE (not ACCESS EXCLUSIVE): blocks INSERT/UPDATE/DELETE on the
+	// status table but allows reads (e.g. v_last_*).
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`LOCK TABLE %q IN EXCLUSIVE MODE`, statusTable)); err != nil {
+		return fmt.Errorf("exclusive lock status table %s: %w", statusTable, err)
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+		`CREATE TRIGGER readonlyTableTrg
+		BEFORE INSERT
+		ON %q
+		FOR EACH STATEMENT
+		EXECUTE PROCEDURE %s;`, statusTable, pgReadonlyTableExceptionFuncName)); err != nil {
+		return fmt.Errorf("create readonly trigger on %s: %w", statusTable, err)
+	}
+	return nil
+}
+
 // doCompactDS is the non-blocking compaction flow which replaces the legacy doMigrateDS body when the nonBlockingCompaction flag is enabled.
 //
 // Lock semantics (vs. legacy):
@@ -728,6 +804,9 @@ func (jd *Handle) computeNewIdxForIntraNodeMigration(l lock.LockToken, insertBef
 //   - Source status tables are fenced with LOCK TABLE … IN EXCLUSIVE MODE and a
 //     post-commit readonly trigger; the trigger raises RS001 on subsequent inserts,
 //     which the UpdateJobStatus path treats as ErrStaleDsList and retries.
+//   - When compactionDeferStatusLock is set, the source status lock is deferred:
+//     pending jobs are copied first with no lock held, then each source status table
+//     is locked one after another only to copy the latest statuses of the moved jobs.
 func (jd *Handle) doCompactDS(ctx context.Context) error {
 	dsList, _, release, err := jd.acquireDSListForRead(ctx)
 	if err != nil {
@@ -810,55 +889,104 @@ func (jd *Handle) doCompactDS(ctx context.Context) error {
 			}
 
 			var copyStart time.Time
-			for i, source := range migrationList.migrateFrom {
-				if source.numJobsPending == 0 {
+			if jd.conf.migration.compactionDeferStatusLock.Load() {
+				// Deferred-status-lock mode. Phase 1: copy the pending jobs from every
+				// source WITHOUT locking any status table — this is the slow,
+				// payload-heavy work, and it must not sit inside the lock window.
+				for i, source := range migrationList.migrateFrom {
+					if source.numJobsPending == 0 {
+						jd.logger.Infon(
+							"[[ doCompactDS ]]: No jobs to migrate",
+							logger.NewStringField("from", source.ds.Index),
+							logger.NewStringField("to", destination.Index),
+						)
+						continue
+					}
+					if copyStart.IsZero() {
+						copyStart = time.Now()
+					}
+					count, err := jd.copyJobsInTx(ctx, tx, source.ds, destination)
+					if err != nil {
+						return fmt.Errorf("copying jobs from %s: %w", source.ds.Index, err)
+					}
+					totalCopied += count
+					// numJobsPending now reflects what phase 1 actually copied, so
+					// phase 2 below only locks sources that contributed jobs.
+					migrationList.migrateFrom[i].numJobsPending = count
+				}
+				// Build the jobs-table indices before taking any status lock.
+				if totalCopied > 0 {
+					if err := jd.createDSJobIndicesInTx(ctx, tx, destination); err != nil {
+						return fmt.Errorf("creating %v jobs indices: %w", destination, err)
+					}
+				}
+				// Phase 2: lock each source status table one after another and copy the
+				// latest status of the moved jobs. This is the only work under the lock,
+				// and the status rows carry no payload, so the lock window is minimal.
+				for _, source := range migrationList.migrateFrom {
+					if source.numJobsPending == 0 {
+						continue
+					}
+					if lockStart.IsZero() {
+						lockStart = time.Now()
+					}
+					if err := jd.lockAndFenceStatusTable(ctx, tx, source.ds.JobStatusTable); err != nil {
+						return err
+					}
 					jd.logger.Infon(
-						"[[ doCompactDS ]]: No jobs to migrate",
+						"[[ doCompactDS ]]: Move statuses",
 						logger.NewStringField("from", source.ds.Index),
 						logger.NewStringField("to", destination.Index),
 					)
-					continue
+					if err := jd.copyJobStatusesInTx(ctx, tx, source.ds, destination); err != nil {
+						return fmt.Errorf("copying statuses from %s: %w", source.ds.Index, err)
+					}
 				}
-				if lockStart.IsZero() {
-					lockStart = time.Now()
+				if totalCopied > 0 {
+					if err := jd.createDSStatusIndicesInTx(ctx, tx, destination); err != nil {
+						return fmt.Errorf("creating %v status indices: %w", destination, err)
+					}
+					if _, err := tx.Exec(fmt.Sprintf(`ANALYZE %q, %q`, destination.JobTable, destination.JobStatusTable)); err != nil {
+						return fmt.Errorf("analyzing %v: %w", destination, err)
+					}
 				}
-				// EXCLUSIVE (not ACCESS EXCLUSIVE): blocks INSERT/UPDATE/DELETE on the
-				// status table but allows reads (e.g. v_last_*).
-				if _, err := tx.ExecContext(ctx, fmt.Sprintf(`LOCK TABLE %q IN EXCLUSIVE MODE`, source.ds.JobStatusTable)); err != nil {
-					return fmt.Errorf("exclusive lock status table %s: %w", source.ds.JobStatusTable, err)
+			} else {
+				for i, source := range migrationList.migrateFrom {
+					if source.numJobsPending == 0 {
+						jd.logger.Infon(
+							"[[ doCompactDS ]]: No jobs to migrate",
+							logger.NewStringField("from", source.ds.Index),
+							logger.NewStringField("to", destination.Index),
+						)
+						continue
+					}
+					if lockStart.IsZero() {
+						lockStart = time.Now()
+					}
+					if err := jd.lockAndFenceStatusTable(ctx, tx, source.ds.JobStatusTable); err != nil {
+						return err
+					}
+					jd.logger.Infon(
+						"[[ doCompactDS ]]: Move",
+						logger.NewStringField("from", source.ds.Index),
+						logger.NewStringField("to", destination.Index),
+					)
+					if copyStart.IsZero() {
+						copyStart = time.Now()
+					}
+					count, err := jd.migrateJobsInTx(ctx, tx, source.ds, destination)
+					if err != nil {
+						return fmt.Errorf("copying jobs from %s: %w", source.ds.Index, err)
+					}
+					totalCopied += count
+					migrationList.migrateFrom[i].numJobsPending = count
 				}
-				// Plant a readonly trigger on the source status table so that any
-				// UpdateJobStatus that lands here AFTER our commit raises RS001 and
-				// gets routed to the new destination via the refreshed dsRangeList.
-				if _, err := tx.ExecContext(ctx, fmt.Sprintf(
-					`CREATE TRIGGER readonlyTableTrg
-					BEFORE INSERT
-					ON %q
-					FOR EACH STATEMENT
-					EXECUTE PROCEDURE %s;`, source.ds.JobStatusTable, pgReadonlyTableExceptionFuncName)); err != nil {
-					return fmt.Errorf("create readonly trigger on %s: %w", source.ds.JobStatusTable, err)
+				if err := jd.createDSIndicesInTx(ctx, tx, destination); err != nil {
+					return fmt.Errorf("creating %v indices: %w", destination, err)
 				}
-				jd.logger.Infon(
-					"[[ doCompactDS ]]: Move",
-					logger.NewStringField("from", source.ds.Index),
-					logger.NewStringField("to", destination.Index),
-				)
-				if copyStart.IsZero() {
-					copyStart = time.Now()
-				}
-				count, err := jd.migrateJobsInTx(ctx, tx, source.ds, destination)
-				if err != nil {
-					return fmt.Errorf("copying jobs from %s: %w", source.ds.Index, err)
-				}
-				totalCopied += count
-				migrationList.migrateFrom[i].numJobsPending = count
 			}
 			if !copyStart.IsZero() {
 				jd.getTimerStat("jobsdb_migration_copy_time", &statTags{CustomValFilters: []string{jd.tablePrefix}}).Since(copyStart)
-			}
-
-			if err := jd.createDSIndicesInTx(ctx, tx, destination); err != nil {
-				return fmt.Errorf("creating %v indices: %w", destination, err)
 			}
 
 			// Mark the source datasets with the pre-drop comment in the same TX as

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -257,6 +257,7 @@ func (jd *Handle) doMigrateDS(ctx context.Context) error {
 	})
 	if l != nil {
 		defer jd.stats.NewTaggedStat("migration_loop_lock", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix}).Since(lockStart)
+		jd.logger.Infon("[[ migrateDSLoop ]]: Lock duration", logger.NewDurationField("duration", time.Since(lockStart)))
 		defer func() { lockChan <- l }()
 		if err == nil {
 			if err = jd.doRefreshDSRangeList(l); err != nil {
@@ -893,7 +894,8 @@ func (jd *Handle) doCompactDS(ctx context.Context) error {
 	}
 	defer func() {
 		lockChan <- l
-		defer jd.stats.NewTaggedStat("migration_loop_lock", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix}).Since(lockStart)
+		jd.stats.NewTaggedStat("migration_loop_lock", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix}).Since(lockStart)
+		jd.logger.Infon("[[ migrateDSLoop ]]: Lock duration", logger.NewDurationField("duration", time.Since(lockStart)))
 	}()
 	if err != nil {
 		return err

--- a/jobsdb/migration_test.go
+++ b/jobsdb/migration_test.go
@@ -1539,4 +1539,68 @@ func TestNonBlockingCompaction(t *testing.T) {
 		require.True(t, tableExists(t, jd, source2), "drop blocked by held reader")
 		require.True(t, hasReadonlyTrigger(t, jd, source2), "source must carry readonly trigger after non-blocking compaction")
 	})
+
+	t.Run("flag on + deferStatusLock: copies pending jobs and their latest statuses, fences source", func(t *testing.T) {
+		jd, c := newJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"compactionDeferStatusLock", true)
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
+
+		// jobs 1..4 terminal (succeeded), 5..7 non-terminal (failed), 8..10 never
+		// picked up (no status at all).
+		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
+		require.NoError(t, jd.Store(context.Background(), jobs))
+		require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[:4], "succeeded")))
+		require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[4:7], "failed")))
+		createDS(t, jd, "2") // empty last DS
+
+		snapshot := jd.getDSListSnapshot()
+		require.Len(t, snapshot, 2)
+		sourceDS := snapshot[0]
+
+		// Hold a reader so the source's async physical drop blocks long enough to
+		// inspect the trigger and pre-drop markers.
+		_, _, release, err := jd.acquireDSListForRead(context.Background())
+		require.NoError(t, err)
+
+		require.NoError(t, jd.doMigrateDS(context.Background()))
+
+		listIndices := lo.Map(jd.getDSListSnapshot(), func(ds dataSetT, _ int) string { return ds.Index })
+		require.NotContains(t, listIndices, sourceDS.Index, "source DS hidden from new readers")
+		require.Contains(t, listIndices, "1_1", "destination DS published")
+
+		// The status table must still be fenced even though it was locked in a
+		// separate phase from the jobs copy.
+		require.True(t, hasReadonlyTrigger(t, jd, sourceDS), "deferred mode must still plant the readonly trigger on the source status table")
+		require.True(t, tableMarkedPreDrop(t, jd, sourceDS.JobTable), "source job table must carry pre-drop marker")
+		require.True(t, tableMarkedPreDrop(t, jd, sourceDS.JobStatusTable), "source status table must carry pre-drop marker")
+
+		destJobsTable := jd.tablePrefix + "_jobs_1_1"
+		destStatusTable := jd.tablePrefix + "_job_status_1_1"
+
+		// Phase 1: the 6 pending jobs (ids 5..10) are copied; the 4 terminal jobs are not.
+		var copiedJobIDs string
+		require.NoError(t, jd.dbHandle.QueryRow(
+			fmt.Sprintf(`SELECT COALESCE(string_agg(job_id::text, ',' ORDER BY job_id), '') FROM %q`, destJobsTable),
+		).Scan(&copiedJobIDs))
+		require.Equal(t, "5,6,7,8,9,10", copiedJobIDs, "only pending jobs must be copied")
+
+		// Phase 2: only jobs that had a status (5,6,7) get a status row, and it is
+		// their latest status ("failed"). Jobs 8..10 were never picked up so they
+		// correctly carry no status and remain unprocessed in the destination.
+		var statusJobIDs, distinctStates string
+		require.NoError(t, jd.dbHandle.QueryRow(
+			fmt.Sprintf(`SELECT COALESCE(string_agg(job_id::text, ',' ORDER BY job_id), ''), COALESCE(string_agg(DISTINCT job_state, ','), '') FROM %q`, destStatusTable),
+		).Scan(&statusJobIDs, &distinctStates))
+		require.Equal(t, "5,6,7", statusJobIDs, "latest status copied only for moved jobs that had one")
+		require.Equal(t, "failed", distinctStates, "the latest (non-terminal) status must be preserved")
+
+		release()
+		require.Eventually(t, func() bool {
+			jd.dropDSListLock.RLock()
+			pending := len(jd.dropDSList)
+			jd.dropDSListLock.RUnlock()
+			return !tableExists(t, jd, sourceDS) && pending == 0
+		}, 5*time.Second, 50*time.Millisecond, "source table must be physically dropped once the reader releases")
+	})
 }

--- a/processor/processor_isolation_test.go
+++ b/processor/processor_isolation_test.go
@@ -255,6 +255,7 @@ func ProcIsolationScenario(t testing.TB, spec *ProcIsolationScenarioSpec) (overa
 
 	config.Set("JobsDB.enableWriterQueue", false)
 	config.Set("JobsDB.nonBlockingCompletedDSDrop", "true")
+	config.Set("JobsDB.compactionDeferStatusLock", "true")
 
 	// find free port for gateway http server to listen on
 	httpPortInt, err := kithelper.GetFreePort()

--- a/router/batchrouter/batchrouter_isolation_test.go
+++ b/router/batchrouter/batchrouter_isolation_test.go
@@ -266,6 +266,7 @@ func BatchrouterIsolationScenario(t testing.TB, spec *BrtIsolationScenarioSpec) 
 
 	config.Set("JobsDB.enableWriterQueue", false)
 	config.Set("JobsDB.nonBlockingCompletedDSDrop", "true")
+	config.Set("JobsDB.compactionDeferStatusLock", "true")
 	config.Set("RUDDER_TMPDIR", os.TempDir())
 
 	t.Logf("Seeding batch_rt jobsdb with jobs")

--- a/router/router_isolation_test.go
+++ b/router/router_isolation_test.go
@@ -224,6 +224,7 @@ func RouterIsolationScenario(t testing.TB, spec *RtIsolationScenarioSpec) (overa
 	config.Set("JobsDB.backup.enabled", false)
 	config.Set("JobsDB.migrateDSLoopSleepDuration", "60m")
 	config.Set("JobsDB.nonBlockingCompletedDSDrop", "true")
+	config.Set("JobsDB.compactionDeferStatusLock", "true")
 
 	config.Set("Router.isolationMode", string(spec.isolationMode))
 	config.Set("Router.Limiter.statsPeriod", "1s")


### PR DESCRIPTION
# Description

Running all tests with `nonBlockingCompaction: true` & `compactionDeferStatusLock: true`

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #7038 
- <kbd>&nbsp;3&nbsp;</kbd> #7021 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #7020 
- <kbd>&nbsp;1&nbsp;</kbd> #7024 
<!-- GitButler Footer Boundary Bottom -->

