### PR TITLE
fix: server panics with sql database is closed in case of an etcd error

### DIFF
--- a/app/cluster/dynamic.go
+++ b/app/cluster/dynamic.go
@@ -78,6 +78,11 @@ func (d *Dynamic) Run(ctx context.Context) error {
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	defer func() {
+		if d.currentMode == servermode.NormalMode {
+			d.stop()
+		}
+	}()
 
 	serverModeChan := d.Provider.ServerMode(ctx)
 	if d.GatewayComponent {
@@ -93,15 +98,15 @@ func (d *Dynamic) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			if d.currentMode == servermode.NormalMode {
-				d.stop()
-			}
 			return nil
 		case req := <-serverModeChan:
 			if req.Err() != nil {
+				if ctx.Err() != nil { // context is cancelled, no need to return an error
+					return nil
+				}
+				d.logger.Errorn("Server mode request failed", obskit.Error(req.Err()))
 				return req.Err()
 			}
-
 			d.logger.Infon("Got trigger to change the mode",
 				logger.NewStringField("newMode", string(req.Mode())),
 				logger.NewStringField("oldMode", string(d.currentMode)))
@@ -117,7 +122,7 @@ func (d *Dynamic) Run(ctx context.Context) error {
 			d.logger.Debugn("Acknowledging the mode change")
 
 			if err := req.Ack(ctx); err != nil {
-				return fmt.Errorf("ack mode change: %w", err)
+				return fmt.Errorf("acking mode change: %w", err)
 			}
 		}
 	}
@@ -129,34 +134,58 @@ func (d *Dynamic) start() error {
 	}
 	d.logger.Infon("Starting the server")
 	start := time.Now()
+	var started []lifecycle
+	rollback := func() {
+		for i := len(started) - 1; i >= 0; i-- {
+			started[i].Stop()
+		}
+	}
 	if err := d.GatewayDB.Start(); err != nil {
 		return fmt.Errorf("gateway db start: %w", err)
 	}
+	started = append(started, d.GatewayDB)
 	if err := d.EventSchemaDB.Start(); err != nil {
+		rollback()
 		return fmt.Errorf("event schemas db start: %w", err)
 	}
+	started = append(started, d.EventSchemaDB)
 	if err := d.ArchivalDB.Start(); err != nil {
+		rollback()
 		return fmt.Errorf("archival db start: %w", err)
 	}
+	started = append(started, d.ArchivalDB)
 	if err := d.RouterDB.Start(); err != nil {
+		rollback()
 		return fmt.Errorf("router db start: %w", err)
 	}
+	started = append(started, d.RouterDB)
 	if err := d.BatchRouterDB.Start(); err != nil {
+		rollback()
 		return fmt.Errorf("batch router db start: %w", err)
 	}
+	started = append(started, d.BatchRouterDB)
 	if err := d.PartitionMigrator.Start(); err != nil {
+		rollback()
 		return fmt.Errorf("partition migrator start: %w", err)
 	}
+	started = append(started, d.PartitionMigrator)
 	if err := d.Processor.Start(); err != nil {
+		rollback()
 		return fmt.Errorf("processor start: %w", err)
 	}
+	started = append(started, d.Processor)
 	if err := d.Archiver.Start(); err != nil {
+		rollback()
 		return fmt.Errorf("archiver start: %w", err)
 	}
+	started = append(started, d.Archiver)
 	if err := d.SchemaForwarder.Start(); err != nil {
+		rollback()
 		return fmt.Errorf("jobs forwarder start: %w", err)
 	}
+	started = append(started, d.SchemaForwarder)
 	if err := d.Router.Start(); err != nil {
+		rollback()
 		return fmt.Errorf("router start: %w", err)
 	}
 	d.serverStartTimeStat.SendTiming(time.Since(start))

--- a/app/cluster/dynamic_test.go
+++ b/app/cluster/dynamic_test.go
@@ -39,12 +39,13 @@ type mockLifecycle struct {
 	status    string
 	callOrder uint64
 	callCount *uint64
+	startErr  error
 }
 
 func (m *mockLifecycle) Start() error {
 	m.callOrder = atomic.AddUint64(m.callCount, 1)
 	m.status = "start"
-	return nil
+	return m.startErr
 }
 
 func (m *mockLifecycle) Stop() {
@@ -227,4 +228,116 @@ func TestDynamicCluster(t *testing.T) {
 		require.True(t, routerDB.callOrder > router.callOrder)
 		require.True(t, batchRouterDB.callOrder > router.callOrder)
 	})
+}
+
+func TestDynamicClusterStopsServerBeforeReturningProviderError(t *testing.T) {
+	Init()
+
+	provider := &mockModeProvider{
+		modeCh: make(chan servermode.ChangeEvent),
+	}
+
+	callCount := uint64(0)
+	gatewayDB := &mockLifecycle{callCount: &callCount}
+	routerDB := &mockLifecycle{callCount: &callCount}
+	batchRouterDB := &mockLifecycle{callCount: &callCount}
+	schemaForwarder := mockjobsforwarder.NewMockForwarder(gomock.NewController(t))
+	eschDB := &mockLifecycle{callCount: &callCount}
+	archDB := &mockLifecycle{callCount: &callCount}
+	partitionMigrator := &mockLifecycle{callCount: &callCount}
+	archiver := &mockLifecycle{callCount: &callCount}
+	processor := &mockLifecycle{callCount: &callCount}
+	router := &mockLifecycle{callCount: &callCount}
+
+	dc := cluster.Dynamic{
+		Provider:          provider,
+		GatewayDB:         gatewayDB,
+		RouterDB:          routerDB,
+		BatchRouterDB:     batchRouterDB,
+		EventSchemaDB:     eschDB,
+		ArchivalDB:        archDB,
+		PartitionMigrator: partitionMigrator,
+		Processor:         processor,
+		Router:            router,
+		SchemaForwarder:   schemaForwarder,
+		Archiver:          archiver,
+	}
+
+	schemaForwarder.EXPECT().Start().Return(nil)
+	schemaForwarder.EXPECT().Stop()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- dc.Run(context.Background())
+	}()
+
+	provider.sendMode(servermode.NewChangeEvent(servermode.NormalMode, func(_ context.Context) error {
+		return nil
+	}))
+	require.Eventually(t, func() bool {
+		return dc.Mode() == servermode.NormalMode
+	}, time.Second, time.Millisecond)
+
+	provider.sendMode(servermode.ChangeEventError(fmt.Errorf("mode provider failed")))
+
+	require.Error(t, <-done)
+	require.Equal(t, "stop", gatewayDB.status)
+	require.Equal(t, "stop", routerDB.status)
+	require.Equal(t, "stop", batchRouterDB.status)
+	require.Equal(t, "stop", partitionMigrator.status)
+	require.Equal(t, "stop", processor.status)
+	require.Equal(t, "stop", router.status)
+	require.True(t, gatewayDB.callOrder > processor.callOrder)
+	require.True(t, routerDB.callOrder > router.callOrder)
+}
+
+func TestDynamicClusterRollsBackPartialStart(t *testing.T) {
+	Init()
+
+	provider := &mockModeProvider{
+		modeCh: make(chan servermode.ChangeEvent),
+	}
+
+	callCount := uint64(0)
+	gatewayDB := &mockLifecycle{callCount: &callCount}
+	routerDB := &mockLifecycle{callCount: &callCount}
+	batchRouterDB := &mockLifecycle{callCount: &callCount}
+	schemaForwarder := mockjobsforwarder.NewMockForwarder(gomock.NewController(t))
+	eschDB := &mockLifecycle{callCount: &callCount}
+	archDB := &mockLifecycle{callCount: &callCount}
+	partitionMigrator := &mockLifecycle{callCount: &callCount, startErr: fmt.Errorf("partition migrator failed")}
+	archiver := &mockLifecycle{callCount: &callCount}
+	processor := &mockLifecycle{callCount: &callCount}
+	router := &mockLifecycle{callCount: &callCount}
+
+	dc := cluster.Dynamic{
+		Provider:          provider,
+		GatewayDB:         gatewayDB,
+		RouterDB:          routerDB,
+		BatchRouterDB:     batchRouterDB,
+		EventSchemaDB:     eschDB,
+		ArchivalDB:        archDB,
+		PartitionMigrator: partitionMigrator,
+		Processor:         processor,
+		Router:            router,
+		SchemaForwarder:   schemaForwarder,
+		Archiver:          archiver,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- dc.Run(context.Background())
+	}()
+
+	require.Error(t, <-done)
+	require.Equal(t, "stop", gatewayDB.status)
+	require.Equal(t, "stop", routerDB.status)
+	require.Equal(t, "stop", batchRouterDB.status)
+	require.Equal(t, "stop", eschDB.status)
+	require.Equal(t, "stop", archDB.status)
+	require.Equal(t, "start", partitionMigrator.status)
+	require.Empty(t, processor.status)
+	require.Empty(t, router.status)
+	require.True(t, batchRouterDB.callOrder > partitionMigrator.callOrder)
+	require.True(t, gatewayDB.callOrder > batchRouterDB.callOrder)
 }


### PR DESCRIPTION
# Description

`cluster.Dynamic#Run` only stopped its components on the `ctx.Done()` path. When it returned early due to an error (e.g. an etcd error from the mode provider), any previously started components kept running, and once the database pools were closed during shutdown they panicked randomly with `sql: database is closed`.

- Moved `d.stop()` into a `defer` so components are stopped on every `Run` exit path.
- `start()` now rolls back already-started components in reverse order if a later component fails to start.

## Linear Ticket

resolves PIPE-3066

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
