### PR TITLE
chore(jobsdb): avoid refreshing ds list from database in case of a stale ds error while updating job statuses

### DIFF
--- a/jobsdb/bench/bench.go
+++ b/jobsdb/bench/bench.go
@@ -23,6 +23,8 @@ func New(conf *config.Config, stat stats.Stats, log logger.Logger, db *sql.DB) (
 		return scenario.NewSimple(conf, stat, log, db), nil
 	case "two_stage":
 		return scenario.NewTwoStage(conf, stat, log, db), nil
+	case "compaction":
+		return scenario.NewCompaction(conf, stat, log, db), nil
 	default:
 		return nil, fmt.Errorf("unknown jobsdb bench scenario name: %s", conf.GetStringVar("processor", "JobsDB.bench.scenario"))
 	}

--- a/jobsdb/bench/bench_test.go
+++ b/jobsdb/bench/bench_test.go
@@ -3,6 +3,7 @@ package bench_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -91,6 +92,86 @@ func TestBench(t *testing.T) {
 			return b.Run(ctx)
 		})
 		require.NoError(t, g.Wait())
+	})
+
+	// TestBench/compaction seeds a read-write jobsdb with 20 datasets of 100K
+	// jobs each (3KB payload) spread across 100 destinations, then drains it with
+	// 100 consumer goroutines (one per destination). It repeats this for every
+	// compaction flag combination and reports the time each takes to drain.
+	//
+	// This is a heavy benchmark (~1M * 2KB jobs, seeded 4 times). It is skipped
+	// unless RUN_COMPACTION_BENCH is set.
+	t.Run("compaction", func(t *testing.T) {
+		if os.Getenv("RUN_COMPACTION_BENCH") == "" {
+			t.Skip("set RUN_COMPACTION_BENCH=1 to run the compaction bench")
+		}
+		pool, err := dockertest.NewPool("")
+		require.NoError(t, err)
+		postgresContainer, err := postgres.Setup(pool, t, postgres.WithOptions(
+			"max_connections=200",
+			"max_wal_size=2GB",
+			"checkpoint_timeout=30",
+			"shared_buffers=512MB",
+			"work_mem=64MB",
+			"hash_mem_multiplier=4",
+			"maintenance_work_mem=200MB",
+			"effective_cache_size=4GB",
+			"wal_buffers=64MB",
+			"random_page_cost=1.1",
+			"autovacuum_vacuum_cost_delay=1",
+			"autovacuum_naptime=20",
+			"checkpoint_warning=0",
+		),
+			postgres.WithTag("17-alpine"),
+			postgres.WithShmSize(256*bytesize.MB),
+		)
+		require.NoError(t, err)
+		postgresContainer.DB.SetMaxOpenConns(80)
+		postgresContainer.DB.SetMaxIdleConns(10)
+
+		c := config.New()
+
+		// JobsDB configuration
+		c.Set("JobsDB.enableWriterQueue", true)
+		c.Set("JobsDB.maxWriters", 3)
+		c.Set("JobsDB.enableReaderQueue", true)
+		c.Set("JobsDB.maxReaders", 6)
+
+		// Common jobsdb configuration under test
+		c.Set("JobsDB.noResultsCacheStateOptimization", true)
+		c.Set("JobsDB.logCacheBranchInvalidation", true)
+		c.Set("JobsDB.warnOnStatusMissingPartitionID", true)
+		c.Set("JobsDB.cacheExpiration", 2*time.Hour)
+		c.Set("JobsDB.dsLimit", 4)
+		c.Set("JobsDB.maxDSRetention", 20*time.Second)
+		c.Set("JobsDB.migrateDSLoopSleepDuration", 10*time.Second)
+		c.Set("JobsDB.jobMinRowsLeftMigrateThreshold", 0.7)
+		c.Set("JobsDB.refreshDSListLoopSleepDuration", 2*time.Second)
+		c.Set("JobsDB.addNewDSLoopSleepDuration", 2*time.Second)
+		c.Set("JobsDB.maxMigrateDSProbe", 50)
+		c.Set("JobsDB.maxTableSizeInMB", 900)
+		c.Set("JobsDB.maxDSSize", 100000) // one dataset holds 100K jobs
+
+		// Bench configuration
+		c.Set("JobsDB.Bench.scenario", "compaction")
+		c.Set("JobsDB.Bench.maintenanceDSN", postgresContainer.DBDsn) // dedicated maintenance pool
+		c.Set("JobsDB.Bench.maintenancePoolConns", 10)
+		c.Set("JobsDB.Bench.datasets", 20)
+		c.Set("JobsDB.Bench.jobsPerDataset", 100000)
+		c.Set("JobsDB.Bench.payloadSize", 3*bytesize.KB)
+		c.Set("JobsDB.Bench.destinations", 100)
+		c.Set("JobsDB.Bench.batchSize", 1000)
+		c.Set("JobsDB.Bench.failProbability", 0.5)
+		c.Set("JobsDB.Bench.maxFailures", 3)
+		c.Set("JobsDB.Bench.seedConcurrency", 4)
+		c.Set("JobsDB.Bench.seedBatchSize", 10000)
+
+		l := logger.NewFactory(c)
+		stat := stats.NewStats(c, l, statsmetric.Instance)
+		b, err := bench.New(c, stat, l.NewLogger(), postgresContainer.DB)
+		require.NoError(t, err)
+
+		require.NoError(t, b.Run(context.Background()))
 	})
 
 	t.Run("two_stage", func(t *testing.T) {

--- a/jobsdb/bench/scenario/compaction.go
+++ b/jobsdb/bench/scenario/compaction.go
@@ -1,0 +1,437 @@
+package scenario
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	mathrand "math/rand/v2"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+)
+
+// NewCompaction creates a jobsdb bench scenario which compares how the various
+// compaction / completed-DS-drop strategies behave under a draining workload.
+//
+// For every configured flag combination it:
+//  1. creates a fresh read-write jobsdb seeded with [datasets] datasets, each
+//     holding [jobsPerDataset] jobs (spread evenly across [destinations]),
+//  2. spawns one consumer goroutine per destination which repeatedly fetches a
+//     batch of pending jobs, marks them as executing and then marks each job as
+//     succeeded or failed according to a precomputed pattern,
+//  3. measures the wall-clock time it takes for every consumer to drain its
+//     destination (i.e. until there are no pending jobs left).
+//
+// The success/failure pattern is precomputed once and reused verbatim for every
+// flag combination so that all scenarios face exactly the same workload.
+func NewCompaction(conf *config.Config, stats stats.Stats, log logger.Logger, db *sql.DB) *compaction {
+	return &compaction{
+		stats: stats,
+		log:   log,
+		conf:  conf,
+		db:    db,
+	}
+}
+
+type compaction struct {
+	stats stats.Stats
+	log   logger.Logger
+	conf  *config.Config
+	db    *sql.DB
+}
+
+// flagSet is a single jobsdb compaction configuration under test.
+type flagSet struct {
+	name                       string
+	nonBlockingCompletedDSDrop bool
+	nonBlockingCompaction      bool
+}
+
+func (p *compaction) Run(ctx context.Context) error {
+	var (
+		tablePrefix      = "bench"
+		customVal        = "benchmark"
+		datasets         = p.conf.GetIntVar(10, 1, "JobsDB.Bench.datasets")                 // number of datasets to seed
+		jobsPerDataset   = p.conf.GetIntVar(100000, 1, "JobsDB.Bench.jobsPerDataset")       // number of jobs per dataset
+		eventPayloadSize = p.conf.GetInt64Var(2*bytesize.KB, 1, "JobsDB.Bench.payloadSize") // size of the event payload
+		destinations     = p.conf.GetIntVar(50, 1, "JobsDB.Bench.destinations")             // number of destinations the jobs are spread between
+		batchSize        = p.conf.GetIntVar(1000, 1, "JobsDB.Bench.batchSize")              // number of jobs a consumer fetches in one go
+		failProbability  = p.conf.GetFloat64Var(0.5, "JobsDB.Bench.failProbability")        // probability a job is marked as failed on a given attempt
+		maxFailures      = p.conf.GetIntVar(3, 1, "JobsDB.Bench.maxFailures")               // cap on the number of times a single job may fail before it must succeed
+		seedConcurrency  = p.conf.GetIntVar(4, 1, "JobsDB.Bench.seedConcurrency")           // number of concurrent writers used while seeding a dataset
+		seedBatchSize    = p.conf.GetIntVar(10000, 1, "JobsDB.Bench.seedBatchSize")         // number of jobs written per Store call while seeding
+		payloadLimit     = p.conf.GetInt64Var(100*bytesize.MB, 1, "JobsDB.Bench.payloadLimit")
+		maintenanceDSN   = p.conf.GetStringVar("", "JobsDB.Bench.maintenanceDSN")       // if set, jobsdb-internal maintenance ops use a dedicated pool against this DSN
+		maintenanceConns = p.conf.GetIntVar(10, 1, "JobsDB.Bench.maintenancePoolConns") // size of the dedicated maintenance pool
+	)
+	totalJobs := datasets * jobsPerDataset
+
+	// Optional dedicated maintenance connection pool. Isolating jobsdb-internal
+	// maintenance ops (compaction setup, post-commit dsList refresh, status-table
+	// cleanup/vacuum) from the main pool avoids them contending for the same
+	// connections as the seeders/consumers. Opened once and shared across every
+	// scenario handle (they run sequentially against the same database).
+	var maintenancePool *sql.DB
+	if maintenanceDSN != "" {
+		var err error
+		maintenancePool, err = sql.Open("postgres", maintenanceDSN)
+		if err != nil {
+			return fmt.Errorf("could not open maintenance pool: %w", err)
+		}
+		maintenancePool.SetMaxOpenConns(maintenanceConns)
+		maintenancePool.SetMaxIdleConns(maintenanceConns)
+		defer maintenancePool.Close()
+	}
+
+	// Build a single reusable event payload of the requested size.
+	eventPayload := []byte("{}")
+	for actualSize := len(eventPayload); actualSize < int(eventPayloadSize); actualSize = len(eventPayload) {
+		var err error
+		eventPayload, err = sjson.SetBytes(eventPayload, "values.-1", rand.String(10))
+		if err != nil {
+			return fmt.Errorf("could not set payload: %w", err)
+		}
+	}
+
+	// Precompute, ONCE, the number of times each job (by creation index) should
+	// fail before it is allowed to succeed. This pattern is identical for every
+	// flag combination, so all scenarios face exactly the same workload.
+	rng := mathrand.New(mathrand.NewPCG(0x9E3779B97F4A7C15, 0xBF58476D1CE4E5B9))
+	failPattern := make([]uint8, totalJobs)
+	for i := range failPattern {
+		var fc uint8
+		for int(fc) < maxFailures && rng.Float64() < failProbability {
+			fc++
+		}
+		failPattern[i] = fc
+	}
+
+	scenarios := []flagSet{
+		{name: "baseline (blocking compaction)", nonBlockingCompletedDSDrop: false, nonBlockingCompaction: false},
+		{name: "nonBlockingCompletedDSDrop", nonBlockingCompletedDSDrop: true, nonBlockingCompaction: false},
+		{name: "nonBlockingCompaction", nonBlockingCompaction: true},
+	}
+
+	type result struct {
+		name     string
+		duration time.Duration
+	}
+	results := make([]result, 0, len(scenarios))
+
+	for _, s := range scenarios {
+		if ctx.Err() != nil {
+			return nil
+		}
+		p.log.Infon("running compaction bench scenario", logger.NewStringField("scenario", s.name))
+
+		// Apply the flag combination under test.
+		p.conf.Set("JobsDB."+tablePrefix+".nonBlockingCompletedDSDrop", s.nonBlockingCompletedDSDrop)
+		p.conf.Set("JobsDB."+tablePrefix+".nonBlockingCompaction", s.nonBlockingCompaction)
+
+		// Deterministic addNewDS trigger so we can seed exactly [datasets]
+		// datasets of [jobsPerDataset] jobs each.
+		triggerAddNewDS := make(chan time.Time)
+		opts := []jobsdb.OptsFunc{
+			jobsdb.WithClearDB(true),
+			jobsdb.WithStats(p.stats),
+			jobsdb.WithDBHandle(p.db),
+			jobsdb.WithConfig(p.conf),
+			jobsdb.WithSkipMaintenanceErr(true),
+			jobsdb.WithTriggerAddNewDS(func() <-chan time.Time { return triggerAddNewDS }),
+		}
+		if maintenancePool != nil {
+			opts = append(opts, jobsdb.WithMaintenancePoolDB(maintenancePool))
+		}
+		db := jobsdb.NewForReadWrite(tablePrefix, opts...)
+		if err := db.Start(); err != nil {
+			db.Close()
+			return fmt.Errorf("could not start bench jobsdb: %w", err)
+		}
+
+		// Seed the datasets (not measured).
+		seedStart := time.Now()
+		if err := p.seed(ctx, db, triggerAddNewDS, customVal, eventPayload, failPattern, datasets, jobsPerDataset, destinations, seedConcurrency, seedBatchSize); err != nil {
+			db.Stop()
+			db.Close()
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("could not seed jobsdb: %w", err)
+		}
+		p.log.Infon("seeding complete",
+			logger.NewStringField("scenario", s.name),
+			logger.NewIntField("jobs", int64(totalJobs)),
+			logger.NewDurationField("duration", time.Since(seedStart)),
+		)
+
+		// Consume (measured).
+		duration, err := p.consume(ctx, db, customVal, totalJobs, destinations, batchSize, payloadLimit)
+		db.Stop()
+		db.Close()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("scenario %q failed: %w", s.name, err)
+		}
+		results = append(results, result{name: s.name, duration: duration})
+		fmt.Printf("\n=== scenario %q drained %d jobs in %s ===\n\n", s.name, totalJobs, duration)
+	}
+
+	fmt.Printf("\n================ compaction bench summary (%d jobs) ================\n", totalJobs)
+	for _, r := range results {
+		fmt.Printf("  %-45s %s\n", r.name, r.duration)
+	}
+	fmt.Printf("===================================================================\n")
+	return nil
+}
+
+// seed writes [datasets] datasets of [jobsPerDataset] jobs each, triggering a
+// new DS between datasets so that every dataset holds exactly [jobsPerDataset]
+// jobs. Job [i] (global creation index) is assigned to destination i%destinations
+// and carries its precomputed failure count in its parameters.
+func (p *compaction) seed(
+	ctx context.Context,
+	db *jobsdb.Handle,
+	triggerAddNewDS chan time.Time,
+	customVal string,
+	eventPayload []byte,
+	failPattern []uint8,
+	datasets, jobsPerDataset, destinations, seedConcurrency, seedBatchSize int,
+) error {
+	for d := range datasets {
+		g, gCtx := errgroup.WithContext(ctx)
+		g.SetLimit(seedConcurrency)
+		for start := 0; start < jobsPerDataset; start += seedBatchSize {
+			end := min(start+seedBatchSize, jobsPerDataset)
+			g.Go(func() error {
+				jobs := make([]*jobsdb.JobT, 0, end-start)
+				for pos := start; pos < end; pos++ {
+					globalIdx := d*jobsPerDataset + pos
+					destID := globalIdx % destinations
+					params, err := sjson.SetBytes(
+						fmt.Appendf(nil, `{"destination_id":"dest-%d"}`, destID),
+						"fc", failPattern[globalIdx],
+					)
+					if err != nil {
+						return fmt.Errorf("could not set fc parameter: %w", err)
+					}
+					jobs = append(jobs, &jobsdb.JobT{
+						UUID:         uuid.New(),
+						UserID:       uuid.New().String(),
+						CreatedAt:    time.Now().UTC(),
+						EventCount:   1,
+						WorkspaceId:  "workspace",
+						Parameters:   params,
+						CustomVal:    customVal,
+						EventPayload: eventPayload,
+					})
+				}
+				if err := db.Store(gCtx, jobs); err != nil {
+					return fmt.Errorf("could not store seed jobs: %w", err)
+				}
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return err
+		}
+		// roll over to a new (empty) dataset, except after the last one so that
+		// we end up with exactly [datasets] full datasets.
+		if d < datasets-1 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case triggerAddNewDS <- time.Now():
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case triggerAddNewDS <- time.Now(): // second send waits for the first loop iteration to finish
+			}
+		}
+	}
+	return nil
+}
+
+// consume spawns one goroutine per destination, each repeatedly fetching a batch
+// of pending jobs, marking them executing and then marking each job succeeded or
+// failed according to its precomputed failure count. It returns once every
+// destination has been fully drained.
+func (p *compaction) consume(
+	ctx context.Context,
+	db *jobsdb.Handle,
+	customVal string,
+	totalJobs, destinations, batchSize int,
+	payloadLimit int64,
+) (time.Duration, error) {
+	// attempts[jobID] counts how many times a job has been processed so far.
+	// Each jobID is owned by exactly one destination => one goroutine, so plain
+	// (non-atomic) access would be safe; we keep it simple with a slice.
+	attempts := make([]int32, totalJobs+1)
+
+	var (
+		succeeded atomic.Int64 // total jobs marked succeeded (terminal)
+		failed    atomic.Int64 // total job failures (retries)
+		remaining atomic.Int64 // jobs not yet succeeded; the run is over when this hits 0
+	)
+	remaining.Store(int64(totalJobs))
+
+	// done is closed once every job has reached a terminal succeeded state.
+	// We rely on a global completion signal rather than treating an empty
+	// GetToProcess result as "drained": with a dsLimit in effect, a destination's
+	// pending jobs may live in datasets outside the current query window and only
+	// become visible after earlier datasets are compacted/dropped, so an empty
+	// result is transient and we must keep polling.
+	done := make(chan struct{})
+
+	// emptyPollInterval throttles polling for a destination that currently has no
+	// visible pending jobs (drained, or hidden behind the dsLimit window).
+	emptyPollInterval := 200 * time.Millisecond
+
+	start := time.Now()
+
+	// progress reporting, stopped explicitly after the consumers finish so it
+	// does not deadlock the errgroup (errgroup's context is only cancelled once
+	// Wait returns).
+	reporterStop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-reporterStop:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				fmt.Printf("[%s] drained %d/%d (%.1f%%), retries so far: %d\n",
+					time.Now().Format("15:04:05"), succeeded.Load(), totalJobs,
+					float64(succeeded.Load())/float64(totalJobs)*100, failed.Load())
+			}
+		}
+	}()
+
+	g, gCtx := errgroup.WithContext(ctx)
+	for dest := range destinations {
+		destID := fmt.Sprintf("dest-%d", dest)
+		g.Go(func() error {
+			for {
+				select {
+				case <-done:
+					return nil
+				case <-gCtx.Done():
+					return nil
+				default:
+				}
+				res, err := db.GetToProcess(gCtx, jobsdb.GetQueryParams{
+					CustomValFilters: []string{customVal},
+					JobsLimit:        batchSize,
+					EventsLimit:      batchSize,
+					PayloadSizeLimit: payloadLimit,
+					ParameterFilters: []jobsdb.ParameterFilterT{{Name: "destination_id", Value: destID}},
+				}, nil)
+				if err != nil {
+					if gCtx.Err() != nil {
+						return nil // nolint: nilerr
+					}
+					return fmt.Errorf("could not get jobs for %s: %w", destID, err)
+				}
+				jobs := res.Jobs
+				if len(jobs) == 0 {
+					// nothing visible right now: either this destination is fully
+					// drained, or its remaining jobs are behind the dsLimit window.
+					// Wait a bit and retry until the run is globally complete.
+					select {
+					case <-done:
+						return nil
+					case <-gCtx.Done():
+						return nil
+					case <-time.After(emptyPollInterval):
+					}
+					continue
+				}
+
+				// 1. mark the whole batch as executing
+				executing := make([]*jobsdb.JobStatusT, len(jobs))
+				for i, job := range jobs {
+					executing[i] = newStatus(job, jobsdb.Executing.State, "executing")
+				}
+				if err := db.UpdateJobStatus(gCtx, executing); err != nil {
+					if gCtx.Err() != nil {
+						return nil // nolint: nilerr
+					}
+					return fmt.Errorf("could not mark jobs executing for %s: %w", destID, err)
+				}
+
+				// 2. mark each job succeeded or failed per the precomputed pattern
+				terminal := make([]*jobsdb.JobStatusT, len(jobs))
+				var batchSucceeded, batchFailed int64
+				for i, job := range jobs {
+					attempt := attempts[job.JobID] + 1
+					attempts[job.JobID] = attempt
+					fc := int32(gjson.GetBytes(job.Parameters, "fc").Int())
+					if attempt <= fc {
+						terminal[i] = newStatus(job, jobsdb.Failed.State, "500")
+						terminal[i].AttemptNum = int(attempt)
+						batchFailed++
+					} else {
+						terminal[i] = newStatus(job, jobsdb.Succeeded.State, "200")
+						terminal[i].AttemptNum = int(attempt)
+						batchSucceeded++
+					}
+				}
+				if err := db.UpdateJobStatus(gCtx, terminal); err != nil {
+					if gCtx.Err() != nil {
+						return nil // nolint: nilerr
+					}
+					return fmt.Errorf("could not mark jobs terminal for %s: %w", destID, err)
+				}
+				succeeded.Add(batchSucceeded)
+				failed.Add(batchFailed)
+				// Each job succeeds exactly once, so remaining decreases
+				// monotonically to 0; the goroutine that hits 0 closes done.
+				if batchSucceeded > 0 && remaining.Add(-batchSucceeded) == 0 {
+					close(done)
+					return nil
+				}
+			}
+		})
+	}
+	err := g.Wait()
+	close(reporterStop)
+	if err != nil {
+		return 0, err
+	}
+	return time.Since(start), nil
+}
+
+func newStatus(job *jobsdb.JobT, state, errorCode string) *jobsdb.JobStatusT {
+	now := time.Now()
+	return &jobsdb.JobStatusT{
+		JobID:         job.JobID,
+		JobState:      state,
+		AttemptNum:    1,
+		ExecTime:      now,
+		RetryTime:     now,
+		ErrorCode:     errorCode,
+		ErrorResponse: []byte(`{}`),
+		Parameters:    []byte(`{}`),
+		JobParameters: job.Parameters,
+		WorkspaceId:   job.WorkspaceId,
+		PartitionID:   job.PartitionID,
+		CustomVal:     job.CustomVal,
+	}
+}

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -389,14 +389,15 @@ func (jd *Handle) UpdateJobStatusInTx(ctx context.Context, tx UpdateSafeTx, stat
 
 		jd.logger.Warnn("[JobsDB] :: Stale dataset list detected while updating job statuses, retrying after refreshing DS cache", obskit.Error(ErrStaleDsList))
 		if refreshErr := func() error {
-			return jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
-				if err := jd.doRefreshDSRangeListWithDB(l, tx.SqlTx()); err != nil {
-					return fmt.Errorf("refresh ds range list: %w", err)
-				}
-				dsList, dsRangeList := jd.dsList.snapshot()
-				tx.setDSList(dsList, dsRangeList)
-				return nil
-			})
+			// we don't need to actually refresh the ds list from the database, since compaction already does this,
+			// but we do need to acquire a read lock on dsListLock to ensure that the ds list is actually refreshed.
+			if lock := jd.dsListLock.RTryLockWithCtx(ctx); !lock {
+				return fmt.Errorf("acquiring read lock for refreshing ds list in update job status: %w", ctx.Err())
+			}
+			dsList, dsRangeList := jd.dsList.snapshot()
+			tx.setDSList(dsList, dsRangeList)
+			jd.dsListLock.RUnlock()
+			return nil
 		}(); refreshErr != nil {
 			return refreshErr
 		}
@@ -922,6 +923,14 @@ func WithPriorityPoolDB(pool *sql.DB) OptsFunc {
 func WithMaintenancePoolDB(pool *sql.DB) OptsFunc {
 	return func(jd *Handle) {
 		jd.maintenancePool = pool
+	}
+}
+
+// WithTriggerAddNewDS overrides the addNewDS loop trigger, allowing callers
+// (tests and benchmarks) to deterministically control when new datasets are created.
+func WithTriggerAddNewDS(trigger func() <-chan time.Time) OptsFunc {
+	return func(jd *Handle) {
+		jd.TriggerAddNewDS = trigger
 	}
 }
 
@@ -3104,7 +3113,7 @@ func (jd *Handle) addNewDSLoop(ctx context.Context) {
 							if err != nil {
 								return fmt.Errorf("acquiring dsListLock: %w", err)
 							}
-							jd.logger.Infon("Acquired lock",
+							jd.logger.Infon("[[ addNewDSLoop ]]: Acquired lock",
 								logger.NewStringField("ds", latestDS.String()),
 								logger.NewStringField("jobsdb", jd.tablePrefix))
 							if _, err = tx.ExecContext(ctx, fmt.Sprintf(`LOCK TABLE %q IN EXCLUSIVE MODE;`, latestDS.JobTable)); err != nil {
@@ -3459,10 +3468,12 @@ func (jd *Handle) internalUpdateJobStatusInTx(ctx context.Context, tx *Tx, dsLis
 	// do update
 	updatedStatesByDS, err := jd.doUpdateJobStatusInTx(ctx, tx, dsList, dsRangeList, statusList)
 	if err != nil {
-		jd.logger.Infon("Error occurred while updating job statuses",
-			logger.NewStringField("tablePrefix", jd.tablePrefix),
-			obskit.Error(err),
-		)
+		if !errors.Is(err, ErrStaleDsList) {
+			jd.logger.Infon("Error occurred while updating job statuses",
+				logger.NewStringField("tablePrefix", jd.tablePrefix),
+				obskit.Error(err),
+			)
+		}
 		return err
 	}
 

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -622,6 +622,15 @@ func TestUpdateJobStatusInExternalTxRetriesAfterReadonlyStatusTable(t *testing.T
 			if err := prepareReplacement(); err != nil {
 				return err
 			}
+			// Refresh the in-memory ds list, mirroring what compaction does after
+			// it commits a layout change. The stale-ds retry in UpdateJobStatusInTx
+			// reads this in-memory snapshot (it no longer re-reads from the DB), so
+			// the replacement dataset must be visible there for the retry to target it.
+			if err := jobsDB.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
+				return jobsDB.doRefreshDSRangeList(l)
+			}); err != nil {
+				return err
+			}
 			return jobsDB.UpdateJobStatusInTx(ctx, updateTx, statuses)
 		})
 	}))

--- a/jobsdb/migration.go
+++ b/jobsdb/migration.go
@@ -257,6 +257,7 @@ func (jd *Handle) doMigrateDS(ctx context.Context) error {
 	})
 	if l != nil {
 		defer jd.stats.NewTaggedStat("migration_loop_lock", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix}).Since(lockStart)
+		jd.logger.Infon("[[ migrateDSLoop ]]: Lock duration", logger.NewDurationField("duration", time.Since(lockStart)))
 		defer func() { lockChan <- l }()
 		if err == nil {
 			if err = jd.doRefreshDSRangeList(l); err != nil {
@@ -893,7 +894,8 @@ func (jd *Handle) doCompactDS(ctx context.Context) error {
 	}
 	defer func() {
 		lockChan <- l
-		defer jd.stats.NewTaggedStat("migration_loop_lock", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix}).Since(lockStart)
+		jd.stats.NewTaggedStat("migration_loop_lock", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix}).Since(lockStart)
+		jd.logger.Infon("[[ migrateDSLoop ]]: Lock duration", logger.NewDurationField("duration", time.Since(lockStart)))
 	}()
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

When updating job statuses, if a background compaction/migration has changed the dataset (DS) layout, the update hits a stale DS list (`ErrStaleDsList`) and retries. Previously the retry re-read the DS list **from the database**, which needs a connection from the main pool — so under high concurrency (in-flight updaters ≥ pool size) every connection is already in use, leaving none to perform the refresh, which can stall the whole update path.

The in-memory DS list cache is already kept up to date by the compaction/migration loop, so the retry doesn't need to touch the database. We now refresh from that cached snapshot under a read lock instead, removing the connection requirement from the retry path entirely.

## Benchmark

A new `compaction` jobsdb bench scenario (`TestBench/compaction`) drains a read-write jobsdb seeded with 2M jobs (20 datasets × 100K, 3KB payload) across 100 destinations, using 100 consumer goroutines against a pool of 80 connections, and measures the time for all consumers to fully drain. It is also used to compare the available compaction strategies under an identical workload.

Run it with:

```bash
RUN_COMPACTION_BENCH=1 GOMAXPROCS=2 go test ./jobsdb/bench/ -run 'TestBench/compaction' -v -timeout 30m
```

Drain time for 2M jobs (lower is better):

| Scenario                          | Time         | vs. baseline |
| --------------------------------- | ------------ | ------------ |
| baseline (blocking compaction)    | 2m56.6s      | —            |
| nonBlockingCompletedDSDrop        | 2m10.9s      | −25.9%       |
| nonBlockingCompaction             | 1m54.8s      | −35.0%       |

## Linear Ticket

resolves PIPE-2997

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.