### PR TITLE
fix(jobsdb): pq 42P01 error when trying to store to a dataset that has been dropped

### DIFF
--- a/enterprise/reporting/error_index/error_index_reporting_test.go
+++ b/enterprise/reporting/error_index/error_index_reporting_test.go
@@ -398,7 +398,6 @@ func TestErrorIndexReporter(t *testing.T) {
 				},
 			}, tx)
 			require.Error(t, err)
-			require.Error(t, tx.Commit())
 
 			<-syncerDone
 		})

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+	"github.com/lib/pq/pqerror"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	"golang.org/x/sync/errgroup"
@@ -372,7 +373,8 @@ func (jd *Handle) UpdateJobStatusInTx(ctx context.Context, tx UpdateSafeTx, stat
 		savepointSql  = "SAVEPOINT " + savepointName
 		rollbackSql   = "ROLLBACK TO SAVEPOINT " + savepointName
 	)
-	for {
+	maxRetries := jd.conf.staleDSListMaxRetries.Load()
+	for attempt := 0; ; attempt++ {
 		if _, err := tx.Tx().ExecContext(ctx, savepointSql); err != nil {
 			return fmt.Errorf("executing updateJobStatusInTx savepoint: %w", err)
 		}
@@ -382,6 +384,9 @@ func (jd *Handle) UpdateJobStatusInTx(ctx context.Context, tx UpdateSafeTx, stat
 		}
 		if !errors.Is(err, ErrStaleDsList) {
 			return err
+		}
+		if attempt >= maxRetries {
+			return fmt.Errorf("stale dataset list after %d retries: %w", maxRetries, err)
 		}
 		if _, rbErr := tx.Tx().ExecContext(ctx, rollbackSql); rbErr != nil {
 			return fmt.Errorf("rolling back to updateJobStatusInTx savepoint: %w", rbErr)
@@ -648,6 +653,7 @@ type Handle struct {
 		partitionFunction               func(job *JobT) string
 		warnOnStatusMissingPartitionID  config.ValueLoader[bool]
 		holdDSListLockDuringStore       config.ValueLoader[bool] // escape hatch: hold the dsList read lock for the entire store callback
+		staleDSListMaxRetries           config.ValueLoader[int]
 		noResultsCacheStateOptimization config.ValueLoader[bool]
 		// getJobsUseLateralJoin replaces the v_last_* view join in getJobsDS with a
 		// correlated LATERAL subquery against the raw job_status table.
@@ -1178,6 +1184,7 @@ func (jd *Handle) loadConfig() {
 	// Default false: snapshot lastDS and release the dsList read lock before running the store callback,
 	// so long-running stores don't block dsList writers. Flip to true to revert to holding the lock for the whole callback.
 	jd.conf.holdDSListLockDuringStore = jd.config.GetReloadableBoolVar(false, jd.configKeys("holdDSListLockDuringStore")...)
+	jd.conf.staleDSListMaxRetries = jd.config.GetReloadableIntVar(3, 1, jd.configKeys("staleDSListMaxRetries")...)
 
 	// when true, the per-state noResultsCache optimization is enabled: stateFilters are narrowed
 	// against the cache before querying, and (!ok && !limitsReached) is used as a commit predicate.
@@ -1890,7 +1897,7 @@ func (jd *Handle) prepareAndExecStmtInTxAllowMissing(tx *sql.Tx, sqlStatement st
 	if err != nil {
 		var pqError *pq.Error
 		ok := errors.As(err, &pqError)
-		if ok && pqError.Code == ("42P01") {
+		if ok && pqError.Code == pqerror.UndefinedTable {
 			jd.logger.Infon("sql statement exec failed because table doesn't exist",
 				logger.NewStringField("tablePrefix", jd.tablePrefix),
 				logger.NewStringField("sqlStatement", sqlStatement),
@@ -2181,9 +2188,13 @@ func (jd *Handle) inStoreSafeCtx(ctx context.Context, f func(lastDS dataSetT) er
 		jd.dsListLock.RUnlock()
 		return f(lastDS)
 	}
-	for {
+	maxRetries := jd.conf.staleDSListMaxRetries.Load()
+	for attempt := 0; ; attempt++ {
 		err := op()
 		if err != nil && errors.Is(err, ErrStaleDsList) {
+			if attempt >= maxRetries {
+				return fmt.Errorf("stale dataset list after %d retries: %w", maxRetries, err)
+			}
 			jd.logger.Warnn("[JobsDB] :: Stale dataset list detected, retrying after refreshing DS cache", obskit.Error(ErrStaleDsList))
 			if err := jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
 				if jd.getLastDS().Index != lastDS.Index {
@@ -2522,7 +2533,9 @@ func (jd *Handle) doStoreJobsInTx(ctx context.Context, tx *Tx, ds dataSetT, jobL
 		if !errors.As(err, &e) {
 			return err
 		}
-		if e.Code == pgErrorCodeTableReadonly {
+		// The table might be in read-only mode or might no longer exist (dropped by compaction goroutine).
+		// In both cases, we should return a stale dataset list error to trigger a refresh
+		if e.Code == pgErrorCodeTableReadonly || e.Code == pqerror.UndefinedTable {
 			if _, rbErr := tx.ExecContext(ctx, rollbackSql); rbErr != nil {
 				return rbErr
 			}

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -1271,6 +1271,109 @@ func TestThreadSafeJobStorage(t *testing.T) {
 		require.NoError(t, row.Scan(&count))
 		require.Equal(t, 2, count, "expected 2 jobs in DS-2 after retried store via external tx")
 	})
+
+	t.Run("WithStoreSafeTxFromTx retries on ErrStaleDsList when table is dropped by compaction", func(t *testing.T) {
+		c := config.New()
+		c.Set("JobsDB.maxDSSize", 1)
+
+		triggerAddNewDS := make(chan time.Time)
+		triggerMigrateDS := make(chan time.Time)
+		blockTrigger := make(chan time.Time) // never fires
+
+		statStore, err := memstats.New()
+		require.NoError(t, err)
+
+		prefix := strings.ToLower(rsRand.String(5))
+
+		// jobsDB1 has all loop triggers blocked so its in-memory DS list stays stale.
+		jobsDB1 := &Handle{
+			TriggerAddNewDS:  func() <-chan time.Time { return blockTrigger },
+			TriggerMigrateDS: func() <-chan time.Time { return blockTrigger },
+			TriggerRefreshDS: func() <-chan time.Time { return blockTrigger },
+			config:           c,
+			stats:            statStore,
+		}
+		require.NoError(t, jobsDB1.Setup(ReadWrite, true, prefix))
+		defer jobsDB1.TearDown()
+
+		// jobsDB2 controls the addNewDS and migrateDS loops.
+		jobsDB2 := &Handle{
+			TriggerAddNewDS:  func() <-chan time.Time { return triggerAddNewDS },
+			TriggerMigrateDS: func() <-chan time.Time { return triggerMigrateDS },
+			config:           c,
+			stats:            statStore,
+		}
+		require.NoError(t, jobsDB2.Setup(ReadWrite, false, prefix))
+		defer jobsDB2.TearDown()
+
+		require.Len(t, jobsDB1.getDSListSnapshot(), 1)
+		ds1 := jobsDB1.getDSListSnapshot()[0]
+
+		// Add one job to DS1 (fills it: maxDSSize=1).
+		require.NoError(t, jobsDB1.Store(context.Background(), []*JobT{{
+			Parameters:   []byte(`{"batch_id":1,"source_id":"sourceID","source_job_run_id":""}`),
+			EventPayload: []byte(`{"testKey":"testValue"}`),
+			UserID:       "a-292e-4e79-9880-f8009e0ae4a3",
+			UUID:         uuid.New(),
+			CustomVal:    "MOCKDS",
+			EventCount:   1,
+		}}))
+
+		// Run addDSLoop via jobsDB2 to create DS2; DS1 becomes readonly.
+		triggerAddNewDS <- time.Now()
+		require.Eventually(t, func() bool {
+			return len(jobsDB2.getDSListSnapshot()) == 2
+		}, 5*time.Second, 10*time.Millisecond, "expected DS2 to be created")
+
+		// jobsDB1 still has its stale DS list (DS1 as the last dataset).
+		require.Len(t, jobsDB1.getDSListSnapshot(), 1, "jobsDB1 should have stale DS list with DS1 as last")
+
+		// Mark the job as completed so DS1 becomes eligible for compaction.
+		res, err := jobsDB2.GetUnprocessed(context.Background(), GetQueryParams{JobsLimit: 10})
+		require.NoError(t, err)
+		require.Len(t, res.Jobs, 1)
+		require.NoError(t, jobsDB2.UpdateJobStatus(context.Background(), []*JobStatusT{{
+			JobID:      res.Jobs[0].JobID,
+			JobState:   Succeeded.State,
+			AttemptNum: 1,
+			CustomVal:  res.Jobs[0].CustomVal,
+		}}))
+
+		// Trigger migration via jobsDB2: DS1 has no pending jobs, so it is dropped.
+		triggerMigrateDS <- time.Now()
+
+		// Wait for DS1's job table to be physically dropped from the database.
+		require.Eventually(t, func() bool {
+			var exists bool
+			_ = jobsDB1.dbHandle.QueryRow(`SELECT to_regclass($1) IS NOT NULL`, ds1.JobTable).Scan(&exists)
+			return !exists
+		}, 5*time.Second, 10*time.Millisecond, "DS1 job table should be physically dropped by compaction")
+
+		// jobsDB1 has a stale DS list (DS1 as last) but DS1 is now gone.
+		// Begin a store tx via WithStoreSafeTxFromTx: it captures DS1 as lastDS.
+		// Writing to DS1 fails with UndefinedTable → ErrStaleDsList → DS list refreshed → retry on DS2.
+		newJobs := []*JobT{{
+			Parameters:   []byte(`{"batch_id":2,"source_id":"sourceID","source_job_run_id":""}`),
+			EventPayload: []byte(`{"testKey":"testValue2"}`),
+			UserID:       "b-292e-4e79-9880-f8009e0ae4a3",
+			UUID:         uuid.New(),
+			CustomVal:    "MOCKDS",
+			EventCount:   1,
+		}}
+		require.NoError(t, jobsDB1.WithTx(context.Background(), func(tx *Tx) error {
+			return jobsDB1.WithStoreSafeTxFromTx(context.Background(), tx, func(stx StoreSafeTx) error {
+				return jobsDB1.StoreInTx(context.Background(), stx, newJobs)
+			})
+		}))
+
+		// After the retry, jobsDB1's DS list should be refreshed and the job should be in DS2.
+		ds1Snapshot := jobsDB1.getDSListSnapshot()
+		require.Len(t, ds1Snapshot, 1, "jobsDB1 should have only DS2 after DS1 was dropped")
+		var count int
+		row := jobsDB1.dbHandle.QueryRow(fmt.Sprintf("select count(*) from %q", ds1Snapshot[0].JobTable))
+		require.NoError(t, row.Scan(&count))
+		require.Equal(t, 1, count, "job should have been written to DS2 after the dropped-table retry")
+	})
 }
 
 func TestCacheScenarios(t *testing.T) {


### PR DESCRIPTION
# Description

Since #6963, `Store` operates against a snapshot of the dataset list. In the rare case where a compaction manages to drop the previous rightmost dataset between when the snapshot was taken and when the store transaction executes, the `COPY INTO` fails with PostgreSQL error `42P01` (undefined table), treated as an unrecoverable error, causing server to panic.

**Fix:** Treat `42P01` (undefined table) the same as `RS001` (readonly trigger): return `ErrStaleDsList` so `inStoreSafeCtx` refreshes the dataset list and retries on the current last dataset. Set a maximum number of stale ds list retries to avoid infinite loops in test scenarios (default: 3).

## Linear Ticket

resolves PIPE-3080

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.