### PR TITLE
feat(gateway): throttling support for internal batch endpoint

### DIFF
--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -52,6 +52,27 @@ type messageValidator interface {
 	Validate(payload []byte, message *stream.MessageProperties) (bool, error)
 }
 
+type handleConfig struct {
+	webPort, maxUserWebRequestWorkerProcess, maxDBWriterProcess                       int
+	maxUserWebRequestBatchSize, maxDBBatchSize, maxHeaderBytes, maxConcurrentRequests int
+	userWebRequestBatchTimeout, dbBatchWriteTimeout                                   config.ValueLoader[time.Duration]
+
+	maxReqSize                           config.ValueLoader[int]
+	enableRateLimit                      config.ValueLoader[bool]
+	internalBatchThrottleEvents          config.ValueLoader[int]
+	internalBatchThrottleWindow          config.ValueLoader[time.Duration]
+	enableSuppressUserFeature            bool
+	diagnosisTickerTime                  time.Duration
+	ReadTimeout                          time.Duration
+	ReadHeaderTimeout                    time.Duration
+	WriteTimeout                         time.Duration
+	IdleTimeout                          time.Duration
+	allowReqsWithoutUserIDAndAnonymousID config.ValueLoader[bool]
+	webhookV2HandlerEnabled              bool
+	internalEndpointsEnabled             bool
+	legacyWarehouseEndpointsEnabled      bool
+}
+
 type Handle struct {
 	// dependencies
 
@@ -117,26 +138,7 @@ type Handle struct {
 	nonEventStreamSources             map[string]bool
 	blockedEventsWorkspaceTypeNameMap map[string]map[string]map[string]bool
 
-	conf struct { // configuration parameters
-		webPort, maxUserWebRequestWorkerProcess, maxDBWriterProcess                       int
-		maxUserWebRequestBatchSize, maxDBBatchSize, maxHeaderBytes, maxConcurrentRequests int
-		userWebRequestBatchTimeout, dbBatchWriteTimeout                                   config.ValueLoader[time.Duration]
-
-		maxReqSize                           config.ValueLoader[int]
-		enableRateLimit                      config.ValueLoader[bool]
-		internalBatchThrottleEvents          config.ValueLoader[int]
-		internalBatchThrottleWindow          config.ValueLoader[time.Duration]
-		enableSuppressUserFeature            bool
-		diagnosisTickerTime                  time.Duration
-		ReadTimeout                          time.Duration
-		ReadHeaderTimeout                    time.Duration
-		WriteTimeout                         time.Duration
-		IdleTimeout                          time.Duration
-		allowReqsWithoutUserIDAndAnonymousID config.ValueLoader[bool]
-		webhookV2HandlerEnabled              bool
-		internalEndpointsEnabled             bool
-		legacyWarehouseEndpointsEnabled      bool
-	}
+	conf handleConfig
 
 	// additional internal http handlers
 	internalHttpHandlers map[string]http.Handler

--- a/gateway/handle.go
+++ b/gateway/handle.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -25,6 +26,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/sanitize"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stringify"
+	"github.com/rudderlabs/rudder-go-kit/throttling"
 	kituuid "github.com/rudderlabs/rudder-go-kit/uuid"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 	"github.com/rudderlabs/rudder-schemas/go/stream"
@@ -76,6 +78,9 @@ type Handle struct {
 	addToBatchRequestQWaitTime                    stats.Measurement
 	processRequestTime                            stats.Measurement
 	emptyAnonIdHeaderStat                         stats.Measurement
+	internalBatchThrottleSkipDisabledCounter      stats.Counter
+	internalBatchThrottleSkipNoHeaderCounter      stats.Counter
+	internalBatchThrottleSkipInvalidHeaderCounter stats.Counter
 
 	// state initialised during Setup
 
@@ -93,6 +98,8 @@ type Handle struct {
 	backendConfigInitialisedChan   chan struct{}
 	transformerFeaturesInitialised chan struct{}
 	now                            func() time.Time
+
+	internalBatchLimiter *throttling.Limiter
 
 	// other state
 
@@ -117,6 +124,8 @@ type Handle struct {
 
 		maxReqSize                           config.ValueLoader[int]
 		enableRateLimit                      config.ValueLoader[bool]
+		internalBatchThrottleEvents          config.ValueLoader[int]
+		internalBatchThrottleWindow          config.ValueLoader[time.Duration]
 		enableSuppressUserFeature            bool
 		diagnosisTickerTime                  time.Duration
 		ReadTimeout                          time.Duration
@@ -695,6 +704,25 @@ func (gw *Handle) addToWebRequestQ(_ *http.ResponseWriter, req *http.Request, do
 	userWebRequestWorker.webRequestQ <- &webReq
 }
 
+// internalBatchAllow checks whether the incoming batch of n events is within the configured
+// global throttle for the internal batch endpoint. It returns true if the request is allowed.
+// Rate and window are passed per-call so the limiter itself is created once and the config
+// can be reloaded without recreating it.
+func (gw *Handle) internalBatchAllow(ctx context.Context, n int) bool {
+	limit := gw.conf.internalBatchThrottleEvents.Load()
+	if limit <= 0 {
+		gw.internalBatchThrottleSkipDisabledCounter.Increment()
+		return true
+	}
+	windowSecs := max(int64(gw.conf.internalBatchThrottleWindow.Load().Seconds()), 1)
+	allowed, _, err := gw.internalBatchLimiter.Allow(ctx, int64(n), int64(limit), windowSecs, "internalBatch")
+	if err != nil {
+		gw.logger.Errorn("internal batch throttle error, allowing request", obskit.Error(err))
+		return true
+	}
+	return allowed
+}
+
 func (gw *Handle) internalBatchHandlerFunc() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var (
@@ -709,8 +737,17 @@ func (gw *Handle) internalBatchHandlerFunc() http.HandlerFunc {
 			stat             = gwstats.SourceStat{ReqType: reqType}
 		)
 
-		// TODO: add tracing
 		gw.logger.LogRequest(r)
+
+		if batchSizeStr := r.Header.Get("X-Batch-Size"); batchSizeStr == "" {
+			gw.internalBatchThrottleSkipNoHeaderCounter.Increment()
+		} else if batchSize, parseErr := strconv.Atoi(batchSizeStr); parseErr != nil || batchSize <= 0 {
+			gw.internalBatchThrottleSkipInvalidHeaderCounter.Increment()
+		} else if !gw.internalBatchAllow(ctx, batchSize) {
+			http.Error(w, response.GetStatus(response.TooManyRequests), http.StatusTooManyRequests)
+			return
+		}
+
 		body, err = gw.getPayloadFromRequest(r)
 		if err != nil {
 			stat.RequestFailed("requestBodyReadFailed")

--- a/gateway/handle_lifecycle.go
+++ b/gateway/handle_lifecycle.go
@@ -26,6 +26,7 @@ import (
 	kithttputil "github.com/rudderlabs/rudder-go-kit/httputil"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/throttling"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 	"github.com/rudderlabs/rudder-schemas/go/stream"
 
@@ -103,6 +104,16 @@ func (gw *Handle) Setup(
 	gw.conf.maxReqSize = config.GetReloadableIntVar(4000, 1024, "Gateway.maxReqSizeInKB")
 	// Enable rate limit on incoming events. false by default
 	gw.conf.enableRateLimit = config.GetReloadableBoolVar(false, "Gateway.enableRateLimit")
+	// Global throttle for the internal batch endpoint: max events per window, <=0 means disabled
+	gw.conf.internalBatchThrottleEvents = config.GetReloadableIntVar(0, 1, "Gateway.internalBatchThrottleEvents")
+	gw.conf.internalBatchThrottleWindow = config.GetReloadableDurationVar(1, time.Second, "Gateway.internalBatchThrottleWindow")
+	{
+		l, err := throttling.New(throttling.WithInMemoryGCRA(0))
+		if err != nil {
+			return fmt.Errorf("failed to create internal batch throttler: %w", err)
+		}
+		gw.internalBatchLimiter = l
+	}
 	// Enable suppress user feature. false by default
 	gw.conf.enableSuppressUserFeature = config.GetBoolVar(true, "Gateway.enableSuppressUserFeature")
 	// Time period for diagnosis ticker
@@ -129,6 +140,9 @@ func (gw *Handle) Setup(
 	gw.addToBatchRequestQWaitTime = gw.stats.NewStat("gateway.batch_request_queue_wait_time", stats.TimerType)
 	gw.processRequestTime = gw.stats.NewStat("gateway.process_request_time", stats.TimerType)
 	gw.emptyAnonIdHeaderStat = gw.stats.NewStat("gateway.empty_anonymous_id_header", stats.CountType)
+	gw.internalBatchThrottleSkipDisabledCounter = gw.stats.NewTaggedStat("gateway.internal_batch_throttle_skip", stats.CountType, stats.Tags{"reason": "disabled"})
+	gw.internalBatchThrottleSkipNoHeaderCounter = gw.stats.NewTaggedStat("gateway.internal_batch_throttle_skip", stats.CountType, stats.Tags{"reason": "no_header"})
+	gw.internalBatchThrottleSkipInvalidHeaderCounter = gw.stats.NewTaggedStat("gateway.internal_batch_throttle_skip", stats.CountType, stats.Tags{"reason": "invalid_header"})
 
 	gw.now = timeutil.Now
 	gw.diagnosisTicker = time.NewTicker(gw.conf.diagnosisTickerTime)

--- a/gateway/handle_test.go
+++ b/gateway/handle_test.go
@@ -80,25 +80,7 @@ func createTestGateway(t *testing.T, eventBlockingSettings backendconfig.EventBl
 		stats:   statsStore,
 		logger:  logger.NOP,
 		webhook: mockWebhook,
-		conf: struct {
-			webPort, maxUserWebRequestWorkerProcess, maxDBWriterProcess                       int
-			maxUserWebRequestBatchSize, maxDBBatchSize, maxHeaderBytes, maxConcurrentRequests int
-			userWebRequestBatchTimeout, dbBatchWriteTimeout                                   config.ValueLoader[time.Duration]
-			maxReqSize                                                                        config.ValueLoader[int]
-			enableRateLimit                                                                   config.ValueLoader[bool]
-			internalBatchThrottleEvents                                                       config.ValueLoader[int]
-			internalBatchThrottleWindow                                                       config.ValueLoader[time.Duration]
-			enableSuppressUserFeature                                                         bool
-			diagnosisTickerTime                                                               time.Duration
-			ReadTimeout                                                                       time.Duration
-			ReadHeaderTimeout                                                                 time.Duration
-			WriteTimeout                                                                      time.Duration
-			IdleTimeout                                                                       time.Duration
-			allowReqsWithoutUserIDAndAnonymousID                                              config.ValueLoader[bool]
-			webhookV2HandlerEnabled                                                           bool
-			internalEndpointsEnabled                                                          bool
-			legacyWarehouseEndpointsEnabled                                                   bool
-		}{
+		conf: handleConfig{
 			webhookV2HandlerEnabled: false,
 		},
 		configSubscriberLock: sync.RWMutex{},
@@ -1016,24 +998,7 @@ func newThrottledHandle(t *testing.T, eventsLimit int, window time.Duration) *Ha
 		internalBatchThrottleSkipDisabledCounter: statsStore.NewTaggedStat("gateway.internal_batch_throttle_skip", stats.CountType, stats.Tags{"reason": "disabled"}),
 		internalBatchThrottleSkipNoHeaderCounter: statsStore.NewTaggedStat("gateway.internal_batch_throttle_skip", stats.CountType, stats.Tags{"reason": "no_header"}),
 		internalBatchThrottleSkipInvalidHeaderCounter: statsStore.NewTaggedStat("gateway.internal_batch_throttle_skip", stats.CountType, stats.Tags{"reason": "invalid_header"}),
-		conf: struct {
-			webPort, maxUserWebRequestWorkerProcess, maxDBWriterProcess                       int
-			maxUserWebRequestBatchSize, maxDBBatchSize, maxHeaderBytes, maxConcurrentRequests int
-			userWebRequestBatchTimeout, dbBatchWriteTimeout                                   config.ValueLoader[time.Duration]
-			maxReqSize                                                                        config.ValueLoader[int]
-			enableRateLimit                                                                   config.ValueLoader[bool]
-			internalBatchThrottleEvents                                                       config.ValueLoader[int]
-			internalBatchThrottleWindow                                                       config.ValueLoader[time.Duration]
-			enableSuppressUserFeature                                                         bool
-			diagnosisTickerTime                                                               time.Duration
-			ReadTimeout                                                                       time.Duration
-			ReadHeaderTimeout                                                                 time.Duration
-			WriteTimeout                                                                      time.Duration
-			IdleTimeout                                                                       time.Duration
-			allowReqsWithoutUserIDAndAnonymousID                                              config.ValueLoader[bool]
-			gwAllowPartialWriteWithErrors                                                     config.ValueLoader[bool]
-			webhookV2HandlerEnabled                                                           bool
-		}{
+		conf: handleConfig{
 			internalBatchThrottleEvents: config.SingleValueLoader(eventsLimit),
 			internalBatchThrottleWindow: config.SingleValueLoader(window),
 		},

--- a/gateway/handle_test.go
+++ b/gateway/handle_test.go
@@ -1,7 +1,10 @@
 package gateway
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +17,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+	"github.com/rudderlabs/rudder-go-kit/throttling"
 	"github.com/rudderlabs/rudder-schemas/go/stream"
 
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
@@ -82,6 +86,8 @@ func createTestGateway(t *testing.T, eventBlockingSettings backendconfig.EventBl
 			userWebRequestBatchTimeout, dbBatchWriteTimeout                                   config.ValueLoader[time.Duration]
 			maxReqSize                                                                        config.ValueLoader[int]
 			enableRateLimit                                                                   config.ValueLoader[bool]
+			internalBatchThrottleEvents                                                       config.ValueLoader[int]
+			internalBatchThrottleWindow                                                       config.ValueLoader[time.Duration]
 			enableSuppressUserFeature                                                         bool
 			diagnosisTickerTime                                                               time.Duration
 			ReadTimeout                                                                       time.Duration
@@ -993,4 +999,137 @@ func TestExtractJobsFromInternalBatchPayload_LiveEventRecording(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newThrottledHandle(t *testing.T, eventsLimit int, window time.Duration) *Handle {
+	t.Helper()
+	l, err := throttling.New(throttling.WithInMemoryGCRA(0))
+	require.NoError(t, err)
+	statsStore, err := memstats.New()
+	require.NoError(t, err)
+	return &Handle{
+		logger:                                   logger.NOP,
+		stats:                                    statsStore,
+		internalBatchLimiter:                     l,
+		bodyReadTimeStat:                         statsStore.NewStat("gateway.http_body_read_time", stats.TimerType),
+		requestSizeStat:                          statsStore.NewStat("gateway.request_size", stats.HistogramType),
+		internalBatchThrottleSkipDisabledCounter: statsStore.NewTaggedStat("gateway.internal_batch_throttle_skip", stats.CountType, stats.Tags{"reason": "disabled"}),
+		internalBatchThrottleSkipNoHeaderCounter: statsStore.NewTaggedStat("gateway.internal_batch_throttle_skip", stats.CountType, stats.Tags{"reason": "no_header"}),
+		internalBatchThrottleSkipInvalidHeaderCounter: statsStore.NewTaggedStat("gateway.internal_batch_throttle_skip", stats.CountType, stats.Tags{"reason": "invalid_header"}),
+		conf: struct {
+			webPort, maxUserWebRequestWorkerProcess, maxDBWriterProcess                       int
+			maxUserWebRequestBatchSize, maxDBBatchSize, maxHeaderBytes, maxConcurrentRequests int
+			userWebRequestBatchTimeout, dbBatchWriteTimeout                                   config.ValueLoader[time.Duration]
+			maxReqSize                                                                        config.ValueLoader[int]
+			enableRateLimit                                                                   config.ValueLoader[bool]
+			internalBatchThrottleEvents                                                       config.ValueLoader[int]
+			internalBatchThrottleWindow                                                       config.ValueLoader[time.Duration]
+			enableSuppressUserFeature                                                         bool
+			diagnosisTickerTime                                                               time.Duration
+			ReadTimeout                                                                       time.Duration
+			ReadHeaderTimeout                                                                 time.Duration
+			WriteTimeout                                                                      time.Duration
+			IdleTimeout                                                                       time.Duration
+			allowReqsWithoutUserIDAndAnonymousID                                              config.ValueLoader[bool]
+			gwAllowPartialWriteWithErrors                                                     config.ValueLoader[bool]
+			webhookV2HandlerEnabled                                                           bool
+		}{
+			internalBatchThrottleEvents: config.SingleValueLoader(eventsLimit),
+			internalBatchThrottleWindow: config.SingleValueLoader(window),
+		},
+	}
+}
+
+func TestInternalBatchAllow(t *testing.T) {
+	t.Run("disabled when limit is zero", func(t *testing.T) {
+		gw := newThrottledHandle(t, 0, time.Second)
+		for range 3 {
+			require.True(t, gw.internalBatchAllow(context.Background(), 50))
+		}
+		require.Equal(t, 3.0, gw.stats.(*memstats.Store).Get("gateway.internal_batch_throttle_skip", stats.Tags{"reason": "disabled"}).LastValue())
+	})
+
+	t.Run("disabled when limit is negative", func(t *testing.T) {
+		gw := newThrottledHandle(t, -1, time.Second)
+		for range 3 {
+			require.True(t, gw.internalBatchAllow(context.Background(), 50))
+		}
+		require.Equal(t, 3.0, gw.stats.(*memstats.Store).Get("gateway.internal_batch_throttle_skip", stats.Tags{"reason": "disabled"}).LastValue())
+	})
+
+	t.Run("allows requests within limit", func(t *testing.T) {
+		gw := newThrottledHandle(t, 100, time.Second)
+		require.True(t, gw.internalBatchAllow(context.Background(), 100))
+	})
+
+	t.Run("denies requests that exceed limit", func(t *testing.T) {
+		// GCRA burst is pre-filled to rate events. The max allowed single-shot cost
+		// is rate+1 (burst + 1 slot from the rate). Sending rate+1 exhausts the burst;
+		// any subsequent request is denied until the window replenishes.
+		gw := newThrottledHandle(t, 10, time.Second)
+		require.True(t, gw.internalBatchAllow(context.Background(), 11)) // rate+1 = exhausts burst
+		require.False(t, gw.internalBatchAllow(context.Background(), 1)) // denied: burst empty
+	})
+
+	t.Run("window is respected", func(t *testing.T) {
+		// Same burst exhaustion logic applies for any window size.
+		gw := newThrottledHandle(t, 10, 60*time.Second)
+		require.True(t, gw.internalBatchAllow(context.Background(), 11)) // rate+1 = exhausts burst
+		require.False(t, gw.internalBatchAllow(context.Background(), 1)) // denied: burst empty
+	})
+}
+
+func TestInternalBatchHandlerThrottle(t *testing.T) {
+	skipCounter := func(gw *Handle, reason string) float64 {
+		return gw.stats.(*memstats.Store).Get("gateway.internal_batch_throttle_skip", stats.Tags{"reason": reason}).LastValue()
+	}
+	makeRequest := func(gw *Handle, batchSizeHeader string) *httptest.ResponseRecorder {
+		handler := gw.callType("internalBatch", gw.internalBatchHandlerFunc())
+		req := httptest.NewRequest(http.MethodPost, "/internal/v1/batch", http.NoBody)
+		if batchSizeHeader != "" {
+			req.Header.Set("X-Batch-Size", batchSizeHeader)
+		}
+		w := httptest.NewRecorder()
+		handler(w, req)
+		return w
+	}
+
+	t.Run("returns 429 when throttle limit exceeded", func(t *testing.T) {
+		gw := newThrottledHandle(t, 10, time.Second)
+		require.True(t, gw.internalBatchAllow(context.Background(), 11)) // exhaust burst (rate+1)
+		w := makeRequest(gw, "1")
+		require.Equal(t, http.StatusTooManyRequests, w.Code)
+		require.Equal(t, 0.0, skipCounter(gw, "disabled"))
+		require.Equal(t, 0.0, skipCounter(gw, "no_header"))
+		require.Equal(t, 0.0, skipCounter(gw, "invalid_header"))
+	})
+
+	t.Run("no throttle when header is absent", func(t *testing.T) {
+		gw := newThrottledHandle(t, 10, time.Second)
+		require.True(t, gw.internalBatchAllow(context.Background(), 11)) // exhaust burst
+		w := makeRequest(gw, "")
+		require.NotEqual(t, http.StatusTooManyRequests, w.Code)
+		require.Equal(t, 1.0, skipCounter(gw, "no_header"))
+		require.Equal(t, 0.0, skipCounter(gw, "disabled"))
+		require.Equal(t, 0.0, skipCounter(gw, "invalid_header"))
+	})
+
+	t.Run("no throttle when header is invalid", func(t *testing.T) {
+		gw := newThrottledHandle(t, 10, time.Second)
+		require.True(t, gw.internalBatchAllow(context.Background(), 11)) // exhaust burst
+		w := makeRequest(gw, "not-a-number")
+		require.NotEqual(t, http.StatusTooManyRequests, w.Code)
+		require.Equal(t, 1.0, skipCounter(gw, "invalid_header"))
+		require.Equal(t, 0.0, skipCounter(gw, "disabled"))
+		require.Equal(t, 0.0, skipCounter(gw, "no_header"))
+	})
+
+	t.Run("no throttle when disabled", func(t *testing.T) {
+		gw := newThrottledHandle(t, 0, time.Second)
+		w := makeRequest(gw, "9999")
+		require.NotEqual(t, http.StatusTooManyRequests, w.Code)
+		require.Equal(t, 1.0, skipCounter(gw, "disabled"))
+		require.Equal(t, 0.0, skipCounter(gw, "no_header"))
+		require.Equal(t, 0.0, skipCounter(gw, "invalid_header"))
+	})
 }


### PR DESCRIPTION
# Description

Adding support for throttling the internal batch endpoint, using an in-memory throttler. Both event rate and event window is configurable and throttler can be disabled by setting the window to zero.
Throttler expects the presence of `X-Batch-Size` request header. If it is not present it will skip throttling and increment the `gateway_internal_batch_throttle_skip` counter with a `reason: no_header` label.

## Linear Ticket

resolves PIPE-3102

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
