### PR TITLE
fix(jobsdb): stale table count gauge after dropping dataset async

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -1478,7 +1478,8 @@ func (jd *Handle) addCompletedDSToDropList(ctx context.Context, l lock.LockToken
 			_, ok := toDrop[dsRange.ds.Index]
 			return !ok
 		}))
-
+	// update table count gauge after setting the new ds list
+	jd.statTableCount.Gauge(len(newList))
 	jd.dropNotifyPing()
 	return newList, nil
 }


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

# Description

Updating table count gauge after setting the new ds list during async drop

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
