### PR TITLE
fix(jobsdb): jobsdb_lock_total_time for dsMigrationLock missing

### DIFF
--- a/jobsdb/internal/lock/lock.go
+++ b/jobsdb/internal/lock/lock.go
@@ -26,6 +26,10 @@ type Locker struct {
 	writeLockTimeAsync      stats.Measurement
 	writeLockTotalTime      stats.Measurement
 	writeLockTotalTimeAsync stats.Measurement
+
+	// set by TryLockWithCtx on successful acquisition; read and cleared by Unlock
+	tryLockStart    time.Time
+	tryLockAcquired time.Time
 }
 
 func NewLocker(name, prefix string, s stats.Stats) *Locker {
@@ -75,7 +79,10 @@ func (r *Locker) RUnlock() {
 func (r *Locker) TryLockWithCtx(ctx context.Context) bool {
 	start := time.Now()
 	if r.m.TryLockWithContext(ctx) {
+		acquired := time.Now()
 		r.writeLockWait.Since(start)
+		r.tryLockStart = start
+		r.tryLockAcquired = acquired
 		return true
 	}
 	return false
@@ -84,6 +91,12 @@ func (r *Locker) TryLockWithCtx(ctx context.Context) bool {
 // Unlock releases a lock
 func (r *Locker) Unlock() {
 	r.m.Unlock()
+	if !r.tryLockAcquired.IsZero() {
+		r.writeLockTime.Since(r.tryLockAcquired)
+		r.writeLockTotalTime.Since(r.tryLockStart)
+		r.tryLockAcquired = time.Time{}
+		r.tryLockStart = time.Time{}
+	}
 }
 
 // WithLock acquires a lock for the duration that the provided function

--- a/jobsdb/internal/lock/lock_test.go
+++ b/jobsdb/internal/lock/lock_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 
 	"github.com/rudderlabs/rudder-server/jobsdb/internal/lock"
 )
@@ -84,4 +85,109 @@ func TestAsyncLockTimeout(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, l)
 	require.Nil(t, c)
+}
+
+func TestTimers(t *testing.T) {
+	newStore := func(t *testing.T) (*memstats.Store, *lock.Locker) {
+		t.Helper()
+		store, err := memstats.New()
+		require.NoError(t, err)
+		return store, lock.NewLocker("test", "ds", store)
+	}
+
+	writeTags := func(async string) stats.Tags {
+		return stats.Tags{"name": "test", "prefix": "ds", "lockType": "write", "async": async}
+	}
+	readTags := stats.Tags{"name": "test", "prefix": "ds", "lockType": "read", "async": "false"}
+
+	hasDurations := func(t *testing.T, store *memstats.Store, metric string, tags stats.Tags) {
+		t.Helper()
+		m := store.Get(metric, tags)
+		require.NotNil(t, m, "metric %q not recorded", metric)
+		require.NotEmpty(t, m.Durations(), "metric %q has no durations", metric)
+	}
+	noDurations := func(t *testing.T, store *memstats.Store, metric string, tags stats.Tags) {
+		t.Helper()
+		m := store.Get(metric, tags)
+		if m != nil {
+			require.Empty(t, m.Durations(), "metric %q should not have been recorded", metric)
+		}
+	}
+
+	t.Run("RTryLockWithCtx records read wait on success", func(t *testing.T) {
+		store, locker := newStore(t)
+		ctx := context.Background()
+		require.True(t, locker.RTryLockWithCtx(ctx))
+		locker.RUnlock()
+		hasDurations(t, store, "jobsdb_lock_wait_time", readTags)
+	})
+
+	t.Run("RTryLockWithCtx records nothing on failure", func(t *testing.T) {
+		store, locker := newStore(t)
+		locker.RLock()
+		defer locker.RUnlock()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		defer cancel()
+		require.False(t, locker.TryLockWithCtx(ctx)) // block with a write attempt
+		noDurations(t, store, "jobsdb_lock_wait_time", writeTags("false"))
+	})
+
+	t.Run("WithLock records wait, held, and total", func(t *testing.T) {
+		store, locker := newStore(t)
+		locker.WithLock(func(lock.LockToken) {})
+		hasDurations(t, store, "jobsdb_lock_wait_time", writeTags("false"))
+		hasDurations(t, store, "jobsdb_lock_time", writeTags("false"))
+		hasDurations(t, store, "jobsdb_lock_total_time", writeTags("false"))
+	})
+
+	t.Run("WithLockInCtx records wait, held, and total", func(t *testing.T) {
+		store, locker := newStore(t)
+		err := locker.WithLockInCtx(context.Background(), func(lock.LockToken) error { return nil })
+		require.NoError(t, err)
+		hasDurations(t, store, "jobsdb_lock_wait_time", writeTags("false"))
+		hasDurations(t, store, "jobsdb_lock_time", writeTags("false"))
+		hasDurations(t, store, "jobsdb_lock_total_time", writeTags("false"))
+	})
+
+	t.Run("TryLockWithCtx+Unlock records wait, held, and total", func(t *testing.T) {
+		store, locker := newStore(t)
+		require.True(t, locker.TryLockWithCtx(context.Background()))
+		hasDurations(t, store, "jobsdb_lock_wait_time", writeTags("false"))
+		noDurations(t, store, "jobsdb_lock_time", writeTags("false"))
+		noDurations(t, store, "jobsdb_lock_total_time", writeTags("false"))
+
+		locker.Unlock()
+		hasDurations(t, store, "jobsdb_lock_time", writeTags("false"))
+		hasDurations(t, store, "jobsdb_lock_total_time", writeTags("false"))
+	})
+
+	t.Run("TryLockWithCtx records nothing on failure", func(t *testing.T) {
+		store, locker := newStore(t)
+		locker.RLock()
+		defer locker.RUnlock()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		defer cancel()
+		require.False(t, locker.TryLockWithCtx(ctx))
+		noDurations(t, store, "jobsdb_lock_wait_time", writeTags("false"))
+		noDurations(t, store, "jobsdb_lock_time", writeTags("false"))
+		noDurations(t, store, "jobsdb_lock_total_time", writeTags("false"))
+	})
+
+	t.Run("AsyncLockWithCtx records async wait, held, and total", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+		store, locker := newStore(t)
+		token, release, err := locker.AsyncLockWithCtx(context.Background())
+		require.NoError(t, err)
+		hasDurations(t, store, "jobsdb_lock_wait_time", writeTags("true"))
+		noDurations(t, store, "jobsdb_lock_time", writeTags("true"))
+		noDurations(t, store, "jobsdb_lock_total_time", writeTags("true"))
+
+		release <- token
+		// give the goroutine time to record after unlock
+		require.Eventually(t, func() bool {
+			m := store.Get("jobsdb_lock_time", writeTags("true"))
+			return m != nil && len(m.Durations()) > 0
+		}, time.Second, time.Millisecond)
+		hasDurations(t, store, "jobsdb_lock_total_time", writeTags("true"))
+	})
 }


### PR DESCRIPTION
## Description

`TryLockWithCtx` was not recording `jobsdb_lock_time` or `jobsdb_lock_total_time` after the lock was released via `Unlock()`. This meant the `dsMigrationLock` (which uses the `TryLockWithCtx` + `Unlock` pattern) was missing held-time metrics.

**Fix:** store the lock acquisition timestamp on the `Locker` struct when `TryLockWithCtx` succeeds, and drain it in `Unlock()` to record both timers. Since only one write lock can be held at a time, a single pair of fields on the struct is sufficient.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.