### PR TITLE
fix(gateway/webhook): prevent nil-channel send DoS in RequestHandler

### DIFF
--- a/gateway/webhook/setup.go
+++ b/gateway/webhook/setup.go
@@ -119,6 +119,7 @@ func Setup(gwHandle Gateway, transformerFeaturesService TransformerFeaturesServi
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	webhook.backgroundCancel = cancel
+	webhook.ctx = ctx
 
 	webhook.statReporterCreator = statReporterCreator
 

--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -69,6 +69,7 @@ type HandleT struct {
 	batchRequestsWg  sync.WaitGroup
 	backgroundWait   func() error
 	backgroundCancel context.CancelFunc
+	ctx              context.Context // cancelled on Shutdown, before channels are closed
 
 	config struct {
 		maxReqSize                 config.ValueLoader[int]
@@ -212,7 +213,7 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 		r.Header.Set("Content-Type", "application/json")
 	}
 
-	done := make(chan transformerResponse)
+	done := make(chan transformerResponse, 1)
 	req := webhookT{
 		request:     r,
 		writer:      w,
@@ -226,11 +227,46 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	webhook.requestQMu.RLock()
 	requestQ := webhook.requestQ[sourceDefName]
-	requestQ <- &req
-	webhook.requestQMu.RUnlock()
+	if requestQ == nil {
+		webhook.requestQMu.RUnlock()
+		stat := webhook.statReporterCreator(arctx, reqType)
+		stat.RequestFailed("sourceNotRegistered")
+		stat.Report(webhook.stats)
+		webhook.failRequest(w, r,
+			response.GetStatus(response.ServiceUnavailable),
+			response.GetErrorStatusCode(response.ServiceUnavailable),
+		)
+		webhook.ackCount.Add(1)
+		return
+	}
+	select {
+	case requestQ <- &req:
+		webhook.requestQMu.RUnlock()
+	case <-r.Context().Done():
+		webhook.requestQMu.RUnlock()
+		webhook.ackCount.Add(1)
+		return
+	case <-webhook.ctx.Done():
+		webhook.requestQMu.RUnlock()
+		stat := webhook.statReporterCreator(arctx, reqType)
+		stat.RequestFailed("shuttingDown")
+		stat.Report(webhook.stats)
+		webhook.failRequest(w, r,
+			response.GetStatus(response.ServiceUnavailable),
+			response.GetErrorStatusCode(response.ServiceUnavailable),
+		)
+		webhook.ackCount.Add(1)
+		return
+	}
 
-	// Wait for batcher process to be done
-	resp := <-done
+	// Wait for batcher process to be done, or bail if the client disconnects.
+	var resp transformerResponse
+	select {
+	case resp = <-done:
+	case <-r.Context().Done():
+		webhook.ackCount.Add(1)
+		return
+	}
 	webhook.ackCount.Add(1)
 	webhook.gwHandle.TrackRequestMetrics(resp.Err)
 

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 	"testing/iotest"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -685,6 +686,78 @@ func TestWebhookRequestHandlerWithRetries(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
 		_ = webhookHandler.Shutdown()
 	})
+}
+
+func TestWebhookRequestHandlerSourceNotRegistered(t *testing.T) {
+	initWebhook()
+
+	ctrl := gomock.NewController(t)
+	mockGW := mockWebhook.NewMockGateway(ctrl)
+
+	conf := config.New()
+	conf.Set("Gateway.webhookV2HandlerEnabled", false)
+
+	webhookHandler := Setup(mockGW, transformer.NewNoOpService(), stats.NOP, conf, newSourceStatReporter)
+	t.Cleanup(func() { _ = webhookHandler.Shutdown() })
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhook", bytes.NewBufferString(sampleJson))
+	w := httptest.NewRecorder()
+	reqCtx := context.WithValue(req.Context(), gwtypes.CtxParamCallType, "webhook")
+	reqCtx = context.WithValue(reqCtx, gwtypes.CtxParamAuthRequestContext, &gwtypes.AuthRequestContext{
+		SourceDefName: sourceDefName,
+	})
+
+	// sourceDefName was never registered — must not block, must return 503
+	webhookHandler.RequestHandler(w, req.WithContext(reqCtx))
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Result().StatusCode)
+	assert.Contains(t, w.Body.String(), response.ServiceUnavailable)
+}
+
+func TestWebhookRequestHandlerRequestContextCancellation(t *testing.T) {
+	initWebhook()
+
+	ctrl := gomock.NewController(t)
+	mockGW := mockWebhook.NewMockGateway(ctrl)
+
+	// sourceTransformAdapter blocks until cleanup so the batcher can never respond.
+	blocked := make(chan struct{})
+	webhookHandler := Setup(mockGW, transformer.NewNoOpService(), stats.NOP, config.Default, newSourceStatReporter, func(bt *batchWebhookTransformerT) {
+		bt.sourceTransformAdapter = func(_ context.Context) (sourceTransformAdapter, error) {
+			<-blocked
+			return nil, errors.New("unreachable")
+		}
+	})
+	t.Cleanup(func() {
+		close(blocked)
+		_ = webhookHandler.Shutdown()
+	})
+
+	webhookHandler.Register(sourceDefName)
+
+	// Use a short-deadline context: expires well before the blocked adapter returns.
+	reqCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	reqCtx = context.WithValue(reqCtx, gwtypes.CtxParamCallType, "webhook")
+	reqCtx = context.WithValue(reqCtx, gwtypes.CtxParamAuthRequestContext, &gwtypes.AuthRequestContext{
+		SourceDefName: sourceDefName,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhook", bytes.NewBufferString(sampleJson))
+	w := httptest.NewRecorder()
+
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		webhookHandler.RequestHandler(w, req.WithContext(reqCtx))
+	}()
+
+	select {
+	case <-handlerDone:
+		// handler returned promptly after context expired — correct behaviour
+	case <-time.After(3 * time.Second):
+		t.Fatal("RequestHandler did not return after request context expired")
+	}
 }
 
 type mockTransformerServer struct {


### PR DESCRIPTION
## Summary

Fixes #6999 — sending on a nil channel in `RequestHandler` blocks the HTTP worker goroutine forever, enabling a denial-of-service condition.

**Root cause:** `webhook.requestQ[sourceDefName]` returns `nil` when the source has not been registered (e.g. `webhookV2HandlerEnabled=false` and no prior `Register` call). Go's nil channel send blocks indefinitely.

**Changes:**

- **Nil-channel guard** — check `requestQ == nil` after the map lookup and return HTTP 503 `service unavailable` immediately instead of blocking.
- **Shutdown-aware enqueue** — wrap the channel send in a `select` with `r.Context().Done()` (client disconnect / deadline) and `webhook.ctx.Done()` (server shutdown). The RLock is held across the select to prevent a concurrent `Shutdown` from closing the channel mid-send.
- **Buffered `done` channel** (size 1) — if `RequestHandler` exits early due to context cancellation, the batcher goroutine can still complete its send without leaking.
- **Context guard on `resp := <-done`** — also wraps the response-wait in a `select` with `r.Context().Done()` so a slow transformer doesn't permanently hold a worker after the client has gone.
- **Store shutdown context** — `HandleT.ctx` added and populated in `Setup` so `RequestHandler` can reference it.

## Test plan

- [x] `TestWebhookRequestHandlerSourceNotRegistered` — V1 mode, no `Register` call → asserts HTTP 503 returned immediately, no block
- [x] `TestWebhookRequestHandlerRequestContextCancellation` — blocking adapter + 100 ms request deadline → asserts handler returns promptly
- [x] All existing webhook unit tests pass (`go test ./gateway/webhook/... -race -count=1`)
- [ ] Manual: run with `webhookV2HandlerEnabled=false` and send a request for an unregistered source — expect immediate 503