### PR TITLE
fix(batchrouter): correlate poll results by externalId instead of whole-row hash

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/common/common.go
+++ b/router/batchrouter/asyncdestinationmanager/common/common.go
@@ -62,18 +62,19 @@ type PollStatusResponse struct {
 }
 
 type AsyncUploadOutput struct {
-	ImportingJobIDs     []int64
-	ImportingParameters stdjson.RawMessage
-	FailedJobIDs        []int64
-	SucceededJobIDs     []int64
-	SuccessResponse     string
-	FailedReason        string
-	AbortJobIDs         []int64
-	AbortReason         string
-	ImportingCount      int
-	FailedCount         int
-	AbortCount          int
-	DestinationID       string
+	ImportingJobIDs        []int64
+	ImportingParameters    stdjson.RawMessage
+	FailedJobIDs           []int64
+	SucceededJobIDs        []int64
+	SuccessResponse        string
+	FailedReason           string
+	AbortJobIDs            []int64
+	AbortReason            string
+	ImportingCount         int
+	FailedCount            int
+	AbortCount             int
+	DestinationID          string
+	JobImportingParameters map[int64]stdjson.RawMessage
 }
 
 type AsyncPoll struct {

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
@@ -70,10 +70,11 @@ func NewUploader(
 		statsFactory:      statsFactory,
 		destName:          destName,
 	}
-	statTags := stats.Tags{"module": "batch_router", "destType": destName}
-	if destination != nil {
-		statTags["destinationId"] = destination.ID
-		statTags["workspaceId"] = destination.WorkspaceID
+	statTags := stats.Tags{
+		"module":        "batch_router",
+		"destType":      destName,
+		"destinationId": destination.ID,
+		"workspaceId":   destination.WorkspaceID,
 	}
 	u.payloadSizeStat = statsFactory.NewTaggedStat("payload_size", stats.HistogramType, statTags)
 	u.eventsPerFileStat = statsFactory.NewTaggedStat("events_per_file", stats.HistogramType, statTags)
@@ -172,26 +173,23 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 	destinationID := asyncDestStruct.Destination.ID
 	filePath := asyncDestStruct.FileName
 
-	input, err := s.readJobsFromFile(filePath)
+	jobs, err := s.readJobsFromFile(filePath)
 	if err != nil {
 		return s.failedJobs(asyncDestStruct, fmt.Sprintf("reading jobs from file: %v", err))
 	}
 
-	objectInfo, err := extractObjectInfo(input)
+	objectInfo, err := extractObjectInfo(jobs)
 	if err != nil {
 		return s.failedJobs(asyncDestStruct, fmt.Sprintf("extracting object info: %v", err))
-	}
-	if objectInfo.ExternalIDField == "" {
-		return s.failedJobs(asyncDestStruct, externalIDFieldEmptyReason)
 	}
 
 	// Drop events without an externalId value up front: with no upsert key they
 	// cannot be sent to Salesforce, so abort them with an error rather than
 	// emitting an uncorrelatable CSV row. Valid events continue to the upload.
-	validJobs := make([]SalesforceAsyncJob, 0, len(input))
+	validJobs := make([]SalesforceAsyncJob, 0, len(jobs))
 	var abortedJobIDs []int64
-	for _, job := range input {
-		if externalIDValue, _ := common.FormatCSVValue(job.Message[objectInfo.ExternalIDField]); externalIDValue == "" {
+	for _, job := range jobs {
+		if len(job.Metadata.ExternalID) == 0 || job.Metadata.ExternalID[0].ID == "" {
 			abortedJobIDs = append(abortedJobIDs, job.Metadata.JobID)
 			continue
 		}

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
@@ -76,9 +76,9 @@ func NewUploader(
 		"destinationId": destination.ID,
 		"workspaceId":   destination.WorkspaceID,
 	}
-	u.payloadSizeStat = statsFactory.NewTaggedStat("payload_size", stats.HistogramType, statTags)
-	u.eventsPerFileStat = statsFactory.NewTaggedStat("events_per_file", stats.HistogramType, statTags)
-	u.asyncUploadTimeStat = statsFactory.NewTaggedStat("async_upload_time", stats.TimerType, statTags)
+	u.payloadSizeStat = statsFactory.NewTaggedStat("brt_async_dest_payload_size", stats.HistogramType, statTags)
+	u.eventsPerFileStat = statsFactory.NewTaggedStat("brt_async_dest_events_per_file", stats.HistogramType, statTags)
+	u.asyncUploadTimeStat = statsFactory.NewTaggedStat("brt_async_dest_async_upload_time", stats.TimerType, statTags)
 	u.config.maxBufferCapacity = conf.GetReloadableInt64Var(512*bytesize.KB, bytesize.B, "SalesforceBulkUpload.maxBufferCapacity")
 	return u
 }
@@ -121,7 +121,7 @@ func (s *Uploader) Transform(job *jobsdb.JobT) (string, error) {
 		Metadata: SalesforceJobMetadata{
 			JobID:           job.JobID,
 			RudderOperation: "upsert", // we only support upsert
-			ExternalID:      externalIDs,
+			ExternalIDs:     externalIDs,
 		},
 	}
 
@@ -183,40 +183,17 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		return s.failedJobs(asyncDestStruct, fmt.Sprintf("extracting object info: %v", err))
 	}
 
-	// Drop events without an externalId value up front: with no upsert key they
-	// cannot be sent to Salesforce, so abort them with an error rather than
-	// emitting an uncorrelatable CSV row. Valid events continue to the upload.
-	validJobs := make([]SalesforceAsyncJob, 0, len(jobs))
-	var abortedJobIDs []int64
-	for _, job := range jobs {
-		if len(job.Metadata.ExternalID) == 0 || job.Metadata.ExternalID[0].ID == "" {
-			abortedJobIDs = append(abortedJobIDs, job.Metadata.JobID)
-			continue
-		}
-		validJobs = append(validJobs, job)
-	}
-	if len(abortedJobIDs) > 0 {
-		s.logger.Infon("Aborting events with missing externalId", logger.NewIntField("abortedJobs", int64(len(abortedJobIDs))))
-	}
-
-	// Every event was aborted (no valid externalId); nothing to upload.
-	if len(validJobs) == 0 {
-		return common.AsyncUploadOutput{
-			AbortJobIDs:   abortedJobIDs,
-			AbortReason:   missingExternalIDReason,
-			AbortCount:    len(abortedJobIDs),
-			DestinationID: destinationID,
-		}
-	}
-
-	validJobIDs := lo.Map(validJobs, func(job SalesforceAsyncJob, _ int) int64 {
+	// Every job reaching Upload was already validated at the Transform boundary
+	// (externalId id, type and identifierType are guaranteed present), so we can
+	// upload them all without re-checking the upsert key here.
+	jobIDs := lo.Map(jobs, func(job SalesforceAsyncJob, _ int) int64 {
 		return job.Metadata.JobID
 	})
 
 	csvFilePath, fileSize, err := createCSVFile(
 		destinationID,
 		objectInfo.ExternalIDField,
-		validJobs,
+		jobs,
 	)
 	defer func() {
 		if err := os.Remove(csvFilePath); err != nil {
@@ -228,26 +205,13 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		return s.failedJobs(asyncDestStruct, fmt.Sprintf("creating CSV: %v", err))
 	}
 
-	// Persist each job's externalId in its importing status params, so the
-	// correlation can be rebuilt from the DB at poll time (restart-safe, no
-	// in-memory state, no payload reads).
-	jobImportingParameters := make(map[int64]stdjson.RawMessage, len(validJobs))
-	for _, job := range validJobs {
-		md, err := jsonrs.Marshal(importingMetadata{ExternalIDHash: hashExternalID(job.Metadata.ExternalID[0].ID)})
-		if err != nil {
-			s.logger.Errorn("marshalling importing metadata", logger.NewIntField("jobID", job.Metadata.JobID), obskit.Error(err))
-			continue
-		}
-		jobImportingParameters[job.Metadata.JobID] = md
-	}
-
 	// Track the size of the CSV we send to Salesforce and how many events it packs.
-	s.eventsPerFileStat.Observe(float64(len(validJobs)))
+	s.eventsPerFileStat.Observe(float64(len(jobs)))
 	s.payloadSizeStat.Observe(float64(fileSize))
 
 	s.logger.Infon("Created CSV file",
 		logger.NewStringField("csvFilePath", csvFilePath),
-		logger.NewIntField("jobs", int64(len(validJobs))),
+		logger.NewIntField("jobs", int64(len(jobs))),
 	)
 	sfJobID, apiError := s.apiService.CreateJob(
 		objectInfo.ObjectType,
@@ -281,29 +245,37 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 
 	s.logger.Infon("Successfully created and closed Salesforce Bulk job", logger.NewStringField("jobID", sfJobID))
 
+	// Persist each job's externalId (hashed) in its importing status params, so the
+	// correlation can be rebuilt from the DB at poll time (restart-safe, no
+	// in-memory state, no payload reads). Built only after the Salesforce job is
+	// created and closed, so we don't do this work for a failed upload.
+	jobImportingParameters := make(map[int64]stdjson.RawMessage, len(jobs))
+	for _, job := range jobs {
+		md, err := jsonrs.Marshal(importingMetadata{ExternalIDHash: hashExternalID(job.Metadata.ExternalIDs[0].ID)})
+		if err != nil {
+			s.logger.Errorn("marshalling importing metadata", logger.NewIntField("jobID", job.Metadata.JobID), obskit.Error(err))
+			continue
+		}
+		jobImportingParameters[job.Metadata.JobID] = md
+	}
+
 	importParameters, err := jsonrs.Marshal(common.ImportParameters{
 		ImportId: SalesforceJobInfo{
 			ID:              sfJobID,
 			ExternalIDField: objectInfo.ExternalIDField,
 		},
-		ImportCount: len(validJobIDs),
+		ImportCount: len(jobIDs),
 	})
 	if err != nil {
 		s.logger.Errorn("marshalling parameters", obskit.Error(err))
 	}
-	output := common.AsyncUploadOutput{
-		ImportingJobIDs:        validJobIDs,
+	return common.AsyncUploadOutput{
+		ImportingJobIDs:        jobIDs,
 		ImportingParameters:    importParameters,
-		ImportingCount:         len(validJobIDs),
+		ImportingCount:         len(jobIDs),
 		JobImportingParameters: jobImportingParameters,
 		DestinationID:          destinationID,
 	}
-	if len(abortedJobIDs) > 0 {
-		output.AbortJobIDs = abortedJobIDs
-		output.AbortReason = missingExternalIDReason
-		output.AbortCount = len(abortedJobIDs)
-	}
-	return output
 }
 
 func (s *Uploader) Poll(_ context.Context, pollInput common.AsyncPoll) common.PollStatusResponse {
@@ -441,6 +413,23 @@ func (s *Uploader) matchRecordsToJobs(
 		externalIDHashToJobID[externalIDHash] = append(externalIDHashToJobID[externalIDHash], job.JobID)
 	}
 
+	// No correlation metadata on any importing job: not a single Salesforce result
+	// can be matched back, so abort the whole batch up front (the records may
+	// already be in Salesforce, so retrying would only re-upsert). This is an
+	// abnormal state (pre-change in-flight jobs or a metadata-persistence bug), so
+	// log loudly for alerting.
+	if len(externalIDHashToJobID) == 0 {
+		s.logger.Errorn(
+			"No externalId correlation metadata found on importing jobs; aborting batch (records may already be in Salesforce)",
+			logger.NewIntField("importing_jobs", int64(len(importingList))),
+		)
+		for _, job := range importingList {
+			metadata.AbortedKeys = append(metadata.AbortedKeys, job.JobID)
+			metadata.AbortedReasons[job.JobID] = noCorrelationMetadataReason
+		}
+		return metadata
+	}
+
 	for _, failedRecord := range failedRecords {
 		key := hashExternalID(failedRecord[externalIDField])
 		if jobIDs, exists := externalIDHashToJobID[key]; exists {
@@ -469,30 +458,18 @@ func (s *Uploader) matchRecordsToJobs(
 		matchedJobIDs := lo.Concat(metadata.SucceededKeys, metadata.AbortedKeys)
 		missingJobIDs, _ := lo.Difference(importingJobIDs, matchedJobIDs)
 
-		// Abort the unmatched jobs. Re-uploading would only re-upsert records
-		// already in Salesforce, so retrying is pointless here.
-		reason := resultCorrelationFailedReason
-		if len(externalIDHashToJobID) == 0 {
-			// We could not correlate ANY result back to a job — abnormal state
-			// (pre-change in-flight jobs or a metadata-persistence bug). Log
-			// loudly so it can be alerted on.
-			s.logger.Errorn(
-				"No externalId correlation metadata found on importing jobs; aborting batch (records may already be in Salesforce)",
-				logger.NewIntField("importing_jobs", int64(len(importingList))),
-				logger.NewIntField("aborted", int64(len(missingJobIDs))),
-			)
-			reason = noCorrelationMetadataReason
-		} else {
-			s.logger.Errorn(
-				"Some Salesforce results could not be correlated back to jobs; aborting them",
-				logger.NewIntField("succeeded_keys", int64(len(metadata.SucceededKeys))),
-				logger.NewIntField("aborted_keys", int64(len(metadata.AbortedKeys))),
-				logger.NewIntField("importing_jobs", int64(len(importingList))),
-			)
-		}
+		// Some results couldn't be correlated back (e.g. Salesforce reformatted the
+		// externalId on store). Abort those jobs — re-uploading would only re-upsert
+		// records already in Salesforce, so retrying is pointless here.
+		s.logger.Errorn(
+			"Some Salesforce results could not be correlated back to jobs; aborting them",
+			logger.NewIntField("succeeded_keys", int64(len(metadata.SucceededKeys))),
+			logger.NewIntField("aborted_keys", int64(len(metadata.AbortedKeys))),
+			logger.NewIntField("importing_jobs", int64(len(importingList))),
+		)
 		metadata.AbortedKeys = append(metadata.AbortedKeys, missingJobIDs...)
 		for _, jobID := range missingJobIDs {
-			metadata.AbortedReasons[jobID] = reason
+			metadata.AbortedReasons[jobID] = resultCorrelationFailedReason
 		}
 	}
 	return metadata

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
@@ -76,19 +76,14 @@ func (s *Uploader) Transform(job *jobsdb.JobT) (string, error) {
 	traits := gjson.GetBytes(job.EventPayload, "traits")
 	externalID := gjson.GetBytes(job.EventPayload, "context.externalId")
 
-	// Build the metadata object
-	metadata := make(map[string]any)
-	metadata["job_id"] = float64(job.JobID)
-
-	// We are supporting only upsert operation
-	metadata["rudderOperation"] = "upsert"
-
-	// Add externalId to metadata if it exists
-	var externalIdArray []any
-	if externalID.Exists() {
-		if err := jsonrs.Unmarshal([]byte(externalID.Raw), &externalIdArray); err == nil {
-			metadata["externalId"] = externalIdArray
-		}
+	// externalId is mandatory — it is the upsert key. Fail the event up front if
+	// it is absent rather than letting it flow downstream.
+	if !externalID.Exists() {
+		return "", fmt.Errorf("externalId is required but not present in the event")
+	}
+	var externalIDs []SalesforceExternalID
+	if err := jsonrs.Unmarshal([]byte(externalID.Raw), &externalIDs); err != nil {
+		return "", fmt.Errorf("failed to unmarshal externalId: %w", err)
 	}
 
 	// Build the message object
@@ -102,17 +97,20 @@ func (s *Uploader) Transform(job *jobsdb.JobT) (string, error) {
 		})
 	}
 
-	externalIdObject, err := extractFromVDM(externalIdArray)
+	externalIdObject, err := extractFromVDM(externalIDs)
 	if err != nil {
 		return "", fmt.Errorf("failed to extract externalId: %w", err)
 	}
 	// Add externalId field to message
 	message[externalIdObject.ExternalIDField] = externalIdObject.ExternalIDValue
 
-	// Create the final AsyncJob structure
-	asyncJob := common.AsyncJob{
-		Message:  message,
-		Metadata: metadata,
+	asyncJob := SalesforceAsyncJob{
+		Message: message,
+		Metadata: SalesforceJobMetadata{
+			JobID:           job.JobID,
+			RudderOperation: "upsert", // we only support upsert
+			ExternalID:      externalIDs,
+		},
 	}
 
 	// Marshal and return
@@ -124,19 +122,19 @@ func (s *Uploader) Transform(job *jobsdb.JobT) (string, error) {
 	return string(responsePayload), nil
 }
 
-func (s *Uploader) readJobsFromFile(filePath string) ([]common.AsyncJob, error) {
+func (s *Uploader) readJobsFromFile(filePath string) ([]SalesforceAsyncJob, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("opening file: %w", err)
 	}
 	defer file.Close()
 
-	var jobs []common.AsyncJob
+	var jobs []SalesforceAsyncJob
 	scanner := bufio.NewScanner(file)
 	scanner.Buffer(nil, int(s.config.maxBufferCapacity.Load()))
 
 	for scanner.Scan() {
-		var job common.AsyncJob
+		var job SalesforceAsyncJob
 		if err := jsonrs.Unmarshal(scanner.Bytes(), &job); err != nil {
 			return nil, fmt.Errorf("unmarshalling job: %w", err)
 		}
@@ -150,58 +148,61 @@ func (s *Uploader) readJobsFromFile(filePath string) ([]common.AsyncJob, error) 
 	return jobs, nil
 }
 
+func (s *Uploader) failedJobs(asyncDestStruct *common.AsyncDestinationStruct, failedReason string) common.AsyncUploadOutput {
+	return common.AsyncUploadOutput{
+		FailedJobIDs:  asyncDestStruct.ImportingJobIDs,
+		FailedCount:   len(asyncDestStruct.ImportingJobIDs),
+		FailedReason:  failedReason,
+		DestinationID: asyncDestStruct.Destination.ID,
+	}
+}
+
 func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestinationStruct) common.AsyncUploadOutput {
-	destination := asyncDestStruct.Destination
-	destinationID := destination.ID
+	destinationID := asyncDestStruct.Destination.ID
 	filePath := asyncDestStruct.FileName
-	importingJobIDs := asyncDestStruct.ImportingJobIDs
 
 	input, err := s.readJobsFromFile(filePath)
 	if err != nil {
-		return common.AsyncUploadOutput{
-			FailedJobIDs:  importingJobIDs,
-			FailedReason:  fmt.Sprintf("Error reading jobs from file: %v", err),
-			FailedCount:   len(importingJobIDs),
-			DestinationID: destinationID,
-		}
+		return s.failedJobs(asyncDestStruct, fmt.Sprintf("Error reading jobs from file: %v", err))
 	}
 
 	objectInfo, err := extractObjectInfo(input)
 	if err != nil {
-		return common.AsyncUploadOutput{
-			FailedJobIDs:  importingJobIDs,
-			FailedReason:  fmt.Sprintf("Error extracting object info: %v", err),
-			FailedCount:   len(importingJobIDs),
-			DestinationID: destinationID,
-		}
+		return s.failedJobs(asyncDestStruct, fmt.Sprintf("Error extracting object info: %v", err))
 	}
 	if objectInfo.ExternalIDField == "" {
-		return common.AsyncUploadOutput{
-			FailedJobIDs:  importingJobIDs,
-			FailedReason:  "externalId field is empty; cannot correlate poll results back to jobs",
-			FailedCount:   len(importingJobIDs),
-			DestinationID: destinationID,
-		}
+		return s.failedJobs(asyncDestStruct, externalIDFieldEmptyReason)
 	}
 
 	// Drop events without an externalId value up front: with no upsert key they
 	// cannot be sent to Salesforce, so abort them with an error rather than
 	// emitting an uncorrelatable CSV row. Valid events continue to the upload.
-	validJobs := make([]common.AsyncJob, 0, len(input))
-	validJobIDs := make([]int64, 0, len(input))
+	validJobs := make([]SalesforceAsyncJob, 0, len(input))
 	var abortedJobIDs []int64
 	for _, job := range input {
-		jobID := int64(job.Metadata["job_id"].(float64))
 		if externalIDValue, _ := common.FormatCSVValue(job.Message[objectInfo.ExternalIDField]); externalIDValue == "" {
-			abortedJobIDs = append(abortedJobIDs, jobID)
+			abortedJobIDs = append(abortedJobIDs, job.Metadata.JobID)
 			continue
 		}
 		validJobs = append(validJobs, job)
-		validJobIDs = append(validJobIDs, jobID)
 	}
 	if len(abortedJobIDs) > 0 {
 		s.logger.Infon("Aborting events with missing externalId", logger.NewIntField("abortedJobs", int64(len(abortedJobIDs))))
 	}
+
+	// Every event was aborted (no valid externalId); nothing to upload.
+	if len(validJobs) == 0 {
+		return common.AsyncUploadOutput{
+			AbortJobIDs:   abortedJobIDs,
+			AbortReason:   missingExternalIDReason,
+			AbortCount:    len(abortedJobIDs),
+			DestinationID: destinationID,
+		}
+	}
+
+	validJobIDs := lo.Map(validJobs, func(job SalesforceAsyncJob, _ int) int64 {
+		return job.Metadata.JobID
+	})
 
 	csvFilePath, externalIDToJobID, err := createCSVFile(
 		destinationID,
@@ -215,12 +216,7 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 	}()
 	if err != nil {
 		s.logger.Errorn("Error creating CSV", obskit.Error(err))
-		return common.AsyncUploadOutput{
-			FailedJobIDs:  importingJobIDs,
-			FailedReason:  fmt.Sprintf("Error creating CSV: %v", err),
-			FailedCount:   len(importingJobIDs),
-			DestinationID: destinationID,
-		}
+		return s.failedJobs(asyncDestStruct, fmt.Sprintf("Error creating CSV: %v", err))
 	}
 	s.externalIDToJobID = externalIDToJobID
 
@@ -245,12 +241,7 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 	)
 	if apiError != nil {
 		s.logger.Errorn("Error creating Salesforce job for operation upsert.", logger.NewStringField("apiErrorMessage", apiError.Message), logger.NewStringField("category", apiError.Category), logger.NewIntField("statusCode", int64(apiError.StatusCode)))
-		return common.AsyncUploadOutput{
-			FailedJobIDs:  importingJobIDs,
-			FailedReason:  fmt.Sprintf("Error creating Salesforce job: %v", apiError.Message),
-			FailedCount:   len(importingJobIDs),
-			DestinationID: destinationID,
-		}
+		return s.failedJobs(asyncDestStruct, fmt.Sprintf("Error creating Salesforce job: %v", apiError.Message))
 	}
 
 	apiError = s.apiService.UploadData(sfJobID, csvFilePath)
@@ -259,12 +250,7 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		if err := s.apiService.DeleteJob(sfJobID); err != nil {
 			s.logger.Errorn("Error deleting Salesforce job.", logger.NewStringField("apiErrorMessage", err.Message))
 		}
-		return common.AsyncUploadOutput{
-			FailedJobIDs:  importingJobIDs,
-			FailedReason:  fmt.Sprintf("Error uploading data: %v", apiError.Message),
-			FailedCount:   len(importingJobIDs),
-			DestinationID: destinationID,
-		}
+		return s.failedJobs(asyncDestStruct, fmt.Sprintf("Error uploading data: %v", apiError.Message))
 	}
 
 	apiError = s.apiService.CloseJob(sfJobID)
@@ -273,12 +259,7 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		if err := s.apiService.DeleteJob(sfJobID); err != nil {
 			s.logger.Errorn("Error deleting Salesforce job.", logger.NewStringField("apiErrorMessage", err.Message))
 		}
-		return common.AsyncUploadOutput{
-			FailedJobIDs:  importingJobIDs,
-			FailedReason:  fmt.Sprintf("Error closing job: %v", apiError.Message),
-			FailedCount:   len(importingJobIDs),
-			DestinationID: destinationID,
-		}
+		return s.failedJobs(asyncDestStruct, fmt.Sprintf("Error closing job: %v", apiError.Message))
 	}
 
 	s.logger.Infon("Successfully created and closed Salesforce Bulk job", logger.NewStringField("jobID", sfJobID))
@@ -293,15 +274,18 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 	if err != nil {
 		s.logger.Errorn("marshalling parameters", obskit.Error(err))
 	}
-	return common.AsyncUploadOutput{
+	output := common.AsyncUploadOutput{
 		ImportingJobIDs:     validJobIDs,
 		ImportingParameters: importParameters,
 		ImportingCount:      len(validJobIDs),
-		AbortJobIDs:         abortedJobIDs,
-		AbortReason:         "externalId is missing for the event; cannot upsert to Salesforce",
-		AbortCount:          len(abortedJobIDs),
 		DestinationID:       destinationID,
 	}
+	if len(abortedJobIDs) > 0 {
+		output.AbortJobIDs = abortedJobIDs
+		output.AbortReason = missingExternalIDReason
+		output.AbortCount = len(abortedJobIDs)
+	}
+	return output
 }
 
 func (s *Uploader) Poll(_ context.Context, pollInput common.AsyncPoll) common.PollStatusResponse {
@@ -464,7 +448,7 @@ func (s *Uploader) matchRecordsToJobs(
 		importingJobIDs := lo.Map(importingList, func(job *jobsdb.JobT, _ int) int64 {
 			return job.JobID
 		})
-		matchedJobIDs := append(append([]int64{}, metadata.SucceededKeys...), metadata.AbortedKeys...)
+		matchedJobIDs := lo.Concat(metadata.SucceededKeys, metadata.AbortedKeys)
 		missingJobIDs, _ := lo.Difference(importingJobIDs, matchedJobIDs)
 
 		if len(s.externalIDToJobID) == 0 {

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
@@ -3,6 +3,7 @@ package salesforcebulkupload
 import (
 	"bufio"
 	"context"
+	stdjson "encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -63,12 +64,11 @@ func NewUploader(
 	destination *backendconfig.DestinationT,
 ) *Uploader {
 	u := &Uploader{
-		logger:            logger,
-		apiService:        apiService,
-		externalIDToJobID: make(map[string][]int64),
-		destination:       destination,
-		statsFactory:      statsFactory,
-		destName:          destName,
+		logger:       logger,
+		apiService:   apiService,
+		destination:  destination,
+		statsFactory: statsFactory,
+		destName:     destName,
 	}
 	statTags := stats.Tags{
 		"module":        "batch_router",
@@ -213,7 +213,7 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		return job.Metadata.JobID
 	})
 
-	csvFilePath, externalIDToJobID, fileSize, err := createCSVFile(
+	csvFilePath, fileSize, err := createCSVFile(
 		destinationID,
 		objectInfo.ExternalIDField,
 		validJobs,
@@ -227,16 +227,18 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		s.logger.Errorn("Error creating CSV", obskit.Error(err))
 		return s.failedJobs(asyncDestStruct, fmt.Sprintf("creating CSV: %v", err))
 	}
-	s.externalIDToJobID = externalIDToJobID
 
-	// The source is expected to send unique externalIds per batch. Fewer keys
-	// than valid jobs means duplicates collided onto the same key, which makes
-	// per-job status attribution ambiguous after polling.
-	if len(externalIDToJobID) < len(validJobs) {
-		s.logger.Warnn("Duplicate externalId values detected in batch; per-job status attribution may be ambiguous",
-			logger.NewIntField("uniqueExternalIds", int64(len(externalIDToJobID))),
-			logger.NewIntField("jobs", int64(len(validJobs))),
-		)
+	// Persist each job's externalId in its importing status params, so the
+	// correlation can be rebuilt from the DB at poll time (restart-safe, no
+	// in-memory state, no payload reads).
+	jobImportingParameters := make(map[int64]stdjson.RawMessage, len(validJobs))
+	for _, job := range validJobs {
+		md, err := jsonrs.Marshal(importingMetadata{ExternalIDHash: hashExternalID(job.Metadata.ExternalID[0].ID)})
+		if err != nil {
+			s.logger.Errorn("marshalling importing metadata", logger.NewIntField("jobID", job.Metadata.JobID), obskit.Error(err))
+			continue
+		}
+		jobImportingParameters[job.Metadata.JobID] = md
 	}
 
 	// Track the size of the CSV we send to Salesforce and how many events it packs.
@@ -290,10 +292,11 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		s.logger.Errorn("marshalling parameters", obskit.Error(err))
 	}
 	output := common.AsyncUploadOutput{
-		ImportingJobIDs:     validJobIDs,
-		ImportingParameters: importParameters,
-		ImportingCount:      len(validJobIDs),
-		DestinationID:       destinationID,
+		ImportingJobIDs:        validJobIDs,
+		ImportingParameters:    importParameters,
+		ImportingCount:         len(validJobIDs),
+		JobImportingParameters: jobImportingParameters,
+		DestinationID:          destinationID,
 	}
 	if len(abortedJobIDs) > 0 {
 		output.AbortJobIDs = abortedJobIDs
@@ -321,14 +324,10 @@ func (s *Uploader) Poll(_ context.Context, pollInput common.AsyncPoll) common.Po
 
 	switch jobStatus.State {
 	case "JobComplete":
-		hasFailed := jobStatus.NumberRecordsFailed > 0
-		if !hasFailed {
-			s.clearExternalIDToJobID()
-		}
 		return common.PollStatusResponse{
 			StatusCode: http.StatusOK,
 			Complete:   true,
-			HasFailed:  hasFailed,
+			HasFailed:  jobStatus.NumberRecordsFailed > 0,
 			InProgress: false,
 		}
 	case "InProgress", "UploadComplete":
@@ -354,9 +353,6 @@ func (s *Uploader) Poll(_ context.Context, pollInput common.AsyncPoll) common.Po
 }
 
 func (s *Uploader) GetUploadStats(input common.GetUploadStatsInput) common.GetUploadStatsResponse {
-	defer func() {
-		s.clearExternalIDToJobID()
-	}()
 	var saleforceJobInfo SalesforceJobInfo
 	importId := gjson.GetBytes(input.Parameters, "importId").String()
 	err := jsonrs.Unmarshal([]byte(importId), &saleforceJobInfo)
@@ -431,9 +427,23 @@ func (s *Uploader) matchRecordsToJobs(
 		AbortedReasons: make(map[int64]string),
 	}
 
+	// Rebuild externalIdHash -> jobIDs from the per-job metadata persisted on the
+	// importing job statuses. This is durable across restarts and needs no
+	// in-memory state or job payloads. We key on the hash because the raw
+	// externalId (often PII) is never stored; the Salesforce-returned externalId
+	// is re-hashed below to match.
+	externalIDHashToJobID := make(map[string][]int64)
+	for _, job := range importingList {
+		externalIDHash := gjson.GetBytes(job.LastJobStatus.Parameters, "metadata.externalIdHash").String()
+		if externalIDHash == "" {
+			continue
+		}
+		externalIDHashToJobID[externalIDHash] = append(externalIDHashToJobID[externalIDHash], job.JobID)
+	}
+
 	for _, failedRecord := range failedRecords {
-		key := failedRecord[externalIDField]
-		if jobIDs, exists := s.externalIDToJobID[key]; exists {
+		key := hashExternalID(failedRecord[externalIDField])
+		if jobIDs, exists := externalIDHashToJobID[key]; exists {
 			for _, jobID := range jobIDs {
 				metadata.AbortedKeys = append(metadata.AbortedKeys, jobID)
 				if errorMsg, ok := failedRecord["sf__Error"]; ok && errorMsg != "" {
@@ -446,50 +456,44 @@ func (s *Uploader) matchRecordsToJobs(
 	}
 
 	for _, successRecord := range successRecords {
-		key := successRecord[externalIDField]
-		if jobIDs, exists := s.externalIDToJobID[key]; exists {
+		key := hashExternalID(successRecord[externalIDField])
+		if jobIDs, exists := externalIDHashToJobID[key]; exists {
 			metadata.SucceededKeys = append(metadata.SucceededKeys, jobIDs...)
 		}
 	}
 
 	if len(metadata.SucceededKeys)+len(metadata.AbortedKeys) != len(importingList) {
-		s.logger.Errorn(
-			"Number of succeeded and aborted keys do not match the number of importing jobs",
-			logger.NewIntField("succeeded_keys", int64(len(metadata.SucceededKeys))),
-			logger.NewIntField("aborted_keys", int64(len(metadata.AbortedKeys))),
-			logger.NewIntField("importing_jobs", int64(len(importingList))),
-		)
-
 		importingJobIDs := lo.Map(importingList, func(job *jobsdb.JobT, _ int) int64 {
 			return job.JobID
 		})
 		matchedJobIDs := lo.Concat(metadata.SucceededKeys, metadata.AbortedKeys)
 		missingJobIDs, _ := lo.Difference(importingJobIDs, matchedJobIDs)
 
-		if len(s.externalIDToJobID) == 0 {
-			// No correlation data at all (e.g. the process restarted between
-			// Upload and GetUploadStats and lost the in-memory map). This is a
-			// systemic loss, not a per-record mismatch, so keep these jobs
-			// retryable rather than permanently dropping a batch that may have
-			// succeeded in Salesforce.
-			metadata.FailedKeys = missingJobIDs
-			metadata.FailedReasons = lo.SliceToMap(missingJobIDs, func(jobID int64) (int64, string) {
-				return jobID, emptyCorrelationMapReason
-			})
+		// Abort the unmatched jobs. Re-uploading would only re-upsert records
+		// already in Salesforce, so retrying is pointless here.
+		reason := resultCorrelationFailedReason
+		if len(externalIDHashToJobID) == 0 {
+			// We could not correlate ANY result back to a job — abnormal state
+			// (pre-change in-flight jobs or a metadata-persistence bug). Log
+			// loudly so it can be alerted on.
+			s.logger.Errorn(
+				"No externalId correlation metadata found on importing jobs; aborting batch (records may already be in Salesforce)",
+				logger.NewIntField("importing_jobs", int64(len(importingList))),
+				logger.NewIntField("aborted", int64(len(missingJobIDs))),
+			)
+			reason = noCorrelationMetadataReason
 		} else {
-			// The map was populated but these records could not be matched back
-			// to a job, most likely because Salesforce reformatted the
-			// externalId value on store. Retrying would re-upload the same value
-			// and miss again, so abort instead of looping through retries.
-			metadata.AbortedKeys = append(metadata.AbortedKeys, missingJobIDs...)
-			for _, jobID := range missingJobIDs {
-				metadata.AbortedReasons[jobID] = resultCorrelationFailedReason
-			}
+			s.logger.Errorn(
+				"Some Salesforce results could not be correlated back to jobs; aborting them",
+				logger.NewIntField("succeeded_keys", int64(len(metadata.SucceededKeys))),
+				logger.NewIntField("aborted_keys", int64(len(metadata.AbortedKeys))),
+				logger.NewIntField("importing_jobs", int64(len(importingList))),
+			)
+		}
+		metadata.AbortedKeys = append(metadata.AbortedKeys, missingJobIDs...)
+		for _, jobID := range missingJobIDs {
+			metadata.AbortedReasons[jobID] = reason
 		}
 	}
 	return metadata
-}
-
-func (s *Uploader) clearExternalIDToJobID() {
-	s.externalIDToJobID = make(map[string][]int64)
 }

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
@@ -60,12 +60,12 @@ func NewUploader(
 	destination *backendconfig.DestinationT,
 ) *Uploader {
 	u := &Uploader{
-		logger:          logger,
-		apiService:      apiService,
-		dataHashToJobID: make(map[string][]int64),
-		destination:     destination,
-		statsFactory:    statsFactory,
-		destName:        destName,
+		logger:            logger,
+		apiService:        apiService,
+		externalIDToJobID: make(map[string][]int64),
+		destination:       destination,
+		statsFactory:      statsFactory,
+		destName:          destName,
 	}
 	u.config.maxBufferCapacity = conf.GetReloadableInt64Var(512*bytesize.KB, bytesize.B, "SalesforceBulkUpload.maxBufferCapacity")
 	return u
@@ -203,7 +203,7 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		s.logger.Infon("Aborting events with missing externalId", logger.NewIntField("abortedJobs", int64(len(abortedJobIDs))))
 	}
 
-	csvFilePath, _, hashToJobID, err := createCSVFile(
+	csvFilePath, externalIDToJobID, err := createCSVFile(
 		destinationID,
 		objectInfo.ExternalIDField,
 		validJobs,
@@ -222,14 +222,14 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 			DestinationID: destinationID,
 		}
 	}
-	s.dataHashToJobID = hashToJobID
+	s.externalIDToJobID = externalIDToJobID
 
 	// The source is expected to send unique externalIds per batch. Fewer keys
 	// than valid jobs means duplicates collided onto the same key, which makes
 	// per-job status attribution ambiguous after polling.
-	if len(hashToJobID) < len(validJobs) {
+	if len(externalIDToJobID) < len(validJobs) {
 		s.logger.Warnn("Duplicate externalId values detected in batch; per-job status attribution may be ambiguous",
-			logger.NewIntField("uniqueExternalIds", int64(len(hashToJobID))),
+			logger.NewIntField("uniqueExternalIds", int64(len(externalIDToJobID))),
 			logger.NewIntField("jobs", int64(len(validJobs))),
 		)
 	}
@@ -324,7 +324,7 @@ func (s *Uploader) Poll(_ context.Context, pollInput common.AsyncPoll) common.Po
 	case "JobComplete":
 		hasFailed := jobStatus.NumberRecordsFailed > 0
 		if !hasFailed {
-			s.clearDataHashToJobID()
+			s.clearExternalIDToJobID()
 		}
 		return common.PollStatusResponse{
 			StatusCode: http.StatusOK,
@@ -356,7 +356,7 @@ func (s *Uploader) Poll(_ context.Context, pollInput common.AsyncPoll) common.Po
 
 func (s *Uploader) GetUploadStats(input common.GetUploadStatsInput) common.GetUploadStatsResponse {
 	defer func() {
-		s.clearDataHashToJobID()
+		s.clearExternalIDToJobID()
 	}()
 	var saleforceJobInfo SalesforceJobInfo
 	importId := gjson.GetBytes(input.Parameters, "importId").String()
@@ -433,8 +433,8 @@ func (s *Uploader) matchRecordsToJobs(
 	}
 
 	for _, failedRecord := range failedRecords {
-		key := calculateHashCode(failedRecord[externalIDField])
-		if jobIDs, exists := s.dataHashToJobID[key]; exists {
+		key := failedRecord[externalIDField]
+		if jobIDs, exists := s.externalIDToJobID[key]; exists {
 			for _, jobID := range jobIDs {
 				metadata.AbortedKeys = append(metadata.AbortedKeys, jobID)
 				if errorMsg, ok := failedRecord["sf__Error"]; ok && errorMsg != "" {
@@ -447,8 +447,8 @@ func (s *Uploader) matchRecordsToJobs(
 	}
 
 	for _, successRecord := range successRecords {
-		key := calculateHashCode(successRecord[externalIDField])
-		if jobIDs, exists := s.dataHashToJobID[key]; exists {
+		key := successRecord[externalIDField]
+		if jobIDs, exists := s.externalIDToJobID[key]; exists {
 			metadata.SucceededKeys = append(metadata.SucceededKeys, jobIDs...)
 		}
 	}
@@ -467,7 +467,7 @@ func (s *Uploader) matchRecordsToJobs(
 		matchedJobIDs := append(append([]int64{}, metadata.SucceededKeys...), metadata.AbortedKeys...)
 		missingJobIDs, _ := lo.Difference(importingJobIDs, matchedJobIDs)
 
-		if len(s.dataHashToJobID) == 0 {
+		if len(s.externalIDToJobID) == 0 {
 			// No correlation data at all (e.g. the process restarted between
 			// Upload and GetUploadStats and lost the in-memory map). This is a
 			// systemic loss, not a per-record mismatch, so keep these jobs
@@ -491,6 +491,6 @@ func (s *Uploader) matchRecordsToJobs(
 	return metadata
 }
 
-func (s *Uploader) clearDataHashToJobID() {
-	s.dataHashToJobID = make(map[string][]int64)
+func (s *Uploader) clearExternalIDToJobID() {
+	s.externalIDToJobID = make(map[string][]int64)
 }

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
@@ -71,7 +71,6 @@ func NewUploader(
 		destName:     destName,
 	}
 	statTags := stats.Tags{
-		"module":        "batch_router",
 		"destType":      destName,
 		"destinationId": destination.ID,
 		"workspaceId":   destination.WorkspaceID,

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
@@ -3,6 +3,7 @@ package salesforcebulkupload
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -26,6 +27,8 @@ import (
 	oauthv2common "github.com/rudderlabs/rudder-server/services/oauth/v2/common"
 	oauthv2httpclient "github.com/rudderlabs/rudder-server/services/oauth/v2/http"
 )
+
+var errExternalIDRequired = errors.New("externalId is required but not present in the event")
 
 func NewManager(
 	conf *config.Config,
@@ -79,7 +82,7 @@ func (s *Uploader) Transform(job *jobsdb.JobT) (string, error) {
 	// externalId is mandatory — it is the upsert key. Fail the event up front if
 	// it is absent rather than letting it flow downstream.
 	if !externalID.Exists() {
-		return "", fmt.Errorf("externalId is required but not present in the event")
+		return "", errExternalIDRequired
 	}
 	var externalIDs []SalesforceExternalID
 	if err := jsonrs.Unmarshal([]byte(externalID.Raw), &externalIDs); err != nil {
@@ -163,12 +166,12 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 
 	input, err := s.readJobsFromFile(filePath)
 	if err != nil {
-		return s.failedJobs(asyncDestStruct, fmt.Sprintf("Error reading jobs from file: %v", err))
+		return s.failedJobs(asyncDestStruct, fmt.Sprintf("reading jobs from file: %v", err))
 	}
 
 	objectInfo, err := extractObjectInfo(input)
 	if err != nil {
-		return s.failedJobs(asyncDestStruct, fmt.Sprintf("Error extracting object info: %v", err))
+		return s.failedJobs(asyncDestStruct, fmt.Sprintf("extracting object info: %v", err))
 	}
 	if objectInfo.ExternalIDField == "" {
 		return s.failedJobs(asyncDestStruct, externalIDFieldEmptyReason)
@@ -216,7 +219,7 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 	}()
 	if err != nil {
 		s.logger.Errorn("Error creating CSV", obskit.Error(err))
-		return s.failedJobs(asyncDestStruct, fmt.Sprintf("Error creating CSV: %v", err))
+		return s.failedJobs(asyncDestStruct, fmt.Sprintf("creating CSV: %v", err))
 	}
 	s.externalIDToJobID = externalIDToJobID
 
@@ -253,7 +256,7 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 	)
 	if apiError != nil {
 		s.logger.Errorn("Error creating Salesforce job for operation upsert.", logger.NewStringField("apiErrorMessage", apiError.Message), logger.NewStringField("category", apiError.Category), logger.NewIntField("statusCode", int64(apiError.StatusCode)))
-		return s.failedJobs(asyncDestStruct, fmt.Sprintf("Error creating Salesforce job: %v", apiError.Message))
+		return s.failedJobs(asyncDestStruct, fmt.Sprintf("creating Salesforce job: %v", apiError.Message))
 	}
 
 	uploadStartTime := time.Now()
@@ -264,7 +267,7 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		if err := s.apiService.DeleteJob(sfJobID); err != nil {
 			s.logger.Errorn("Error deleting Salesforce job.", logger.NewStringField("apiErrorMessage", err.Message))
 		}
-		return s.failedJobs(asyncDestStruct, fmt.Sprintf("Error uploading data: %v", apiError.Message))
+		return s.failedJobs(asyncDestStruct, fmt.Sprintf("uploading data: %v", apiError.Message))
 	}
 
 	apiError = s.apiService.CloseJob(sfJobID)
@@ -273,7 +276,7 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		if err := s.apiService.DeleteJob(sfJobID); err != nil {
 			s.logger.Errorn("Error deleting Salesforce job.", logger.NewStringField("apiErrorMessage", err.Message))
 		}
-		return s.failedJobs(asyncDestStruct, fmt.Sprintf("Error closing job: %v", apiError.Message))
+		return s.failedJobs(asyncDestStruct, fmt.Sprintf("closing job: %v", apiError.Message))
 	}
 
 	s.logger.Infon("Successfully created and closed Salesforce Bulk job", logger.NewStringField("jobID", sfJobID))
@@ -473,7 +476,7 @@ func (s *Uploader) matchRecordsToJobs(
 			// succeeded in Salesforce.
 			metadata.FailedKeys = missingJobIDs
 			metadata.FailedReasons = lo.SliceToMap(missingJobIDs, func(jobID int64) (int64, string) {
-				return jobID, "Correlation map is empty (likely a restart between upload and stats); retrying"
+				return jobID, emptyCorrelationMapReason
 			})
 		} else {
 			// The map was populated but these records could not be matched back
@@ -482,7 +485,7 @@ func (s *Uploader) matchRecordsToJobs(
 			// and miss again, so abort instead of looping through retries.
 			metadata.AbortedKeys = append(metadata.AbortedKeys, missingJobIDs...)
 			for _, jobID := range missingJobIDs {
-				metadata.AbortedReasons[jobID] = "Could not correlate Salesforce result back to the job: externalId not found in success/failed records (possibly reformatted by Salesforce on store)"
+				metadata.AbortedReasons[jobID] = resultCorrelationFailedReason
 			}
 		}
 	}

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
@@ -175,8 +175,17 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 			DestinationID: destinationID,
 		}
 	}
-	csvFilePath, csvHeaders, hashToJobID, err := createCSVFile(
+	if objectInfo.ExternalIDField == "" {
+		return common.AsyncUploadOutput{
+			FailedJobIDs:  importingJobIDs,
+			FailedReason:  "externalId field is empty; cannot correlate poll results back to jobs",
+			FailedCount:   len(importingJobIDs),
+			DestinationID: destinationID,
+		}
+	}
+	csvFilePath, _, hashToJobID, err := createCSVFile(
 		destinationID,
+		objectInfo.ExternalIDField,
 		input,
 	)
 	defer func() {
@@ -194,6 +203,16 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		}
 	}
 	s.dataHashToJobID = hashToJobID
+
+	// The source is expected to send unique externalIds per batch. Fewer keys
+	// than jobs means duplicates collided onto the same key, which makes
+	// per-job status attribution ambiguous after polling.
+	if len(hashToJobID) < len(input) {
+		s.logger.Warnn("Duplicate externalId values detected in batch; per-job status attribution may be ambiguous",
+			logger.NewIntField("uniqueExternalIds", int64(len(hashToJobID))),
+			logger.NewIntField("jobs", int64(len(input))),
+		)
+	}
 
 	s.logger.Infon("Created CSV file",
 		logger.NewStringField("csvFilePath", csvFilePath),
@@ -246,8 +265,8 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 
 	importParameters, err := jsonrs.Marshal(common.ImportParameters{
 		ImportId: SalesforceJobInfo{
-			ID:      sfJobID,
-			Headers: csvHeaders,
+			ID:              sfJobID,
+			ExternalIDField: objectInfo.ExternalIDField,
 		},
 		ImportCount: len(importingJobIDs),
 	})
@@ -343,7 +362,7 @@ func (s *Uploader) GetUploadStats(input common.GetUploadStatsInput) common.GetUp
 		}
 	}
 
-	metadata := s.matchRecordsToJobs(input.ImportingList, failedRecords, successRecords, saleforceJobInfo.Headers)
+	metadata := s.matchRecordsToJobs(input.ImportingList, failedRecords, successRecords, saleforceJobInfo.ExternalIDField)
 	return common.GetUploadStatsResponse{
 		StatusCode: http.StatusOK,
 		Metadata:   metadata,
@@ -380,7 +399,7 @@ func (s *Uploader) handlePollError(apiError *APIError) common.PollStatusResponse
 func (s *Uploader) matchRecordsToJobs(
 	importingList []*jobsdb.JobT,
 	failedRecords, successRecords []map[string]string,
-	headers []string,
+	externalIDField string,
 ) common.EventStatMeta {
 	metadata := common.EventStatMeta{
 		FailedKeys:     make([]int64, 0),
@@ -391,8 +410,8 @@ func (s *Uploader) matchRecordsToJobs(
 	}
 
 	for _, failedRecord := range failedRecords {
-		hash := calculateHashFromRecord(failedRecord, headers)
-		if jobIDs, exists := s.dataHashToJobID[hash]; exists {
+		key := calculateHashCode(failedRecord[externalIDField])
+		if jobIDs, exists := s.dataHashToJobID[key]; exists {
 			for _, jobID := range jobIDs {
 				metadata.AbortedKeys = append(metadata.AbortedKeys, jobID)
 				if errorMsg, ok := failedRecord["sf__Error"]; ok && errorMsg != "" {
@@ -405,8 +424,8 @@ func (s *Uploader) matchRecordsToJobs(
 	}
 
 	for _, successRecord := range successRecords {
-		hash := calculateHashFromRecord(successRecord, headers)
-		if jobIDs, exists := s.dataHashToJobID[hash]; exists {
+		key := calculateHashCode(successRecord[externalIDField])
+		if jobIDs, exists := s.dataHashToJobID[key]; exists {
 			metadata.SucceededKeys = append(metadata.SucceededKeys, jobIDs...)
 		}
 	}
@@ -422,12 +441,29 @@ func (s *Uploader) matchRecordsToJobs(
 		importingJobIDs := lo.Map(importingList, func(job *jobsdb.JobT, _ int) int64 {
 			return job.JobID
 		})
-		missingJobIDs, _ := lo.Difference(importingJobIDs, append(metadata.SucceededKeys, metadata.AbortedKeys...))
+		matchedJobIDs := append(append([]int64{}, metadata.SucceededKeys...), metadata.AbortedKeys...)
+		missingJobIDs, _ := lo.Difference(importingJobIDs, matchedJobIDs)
 
-		metadata.FailedKeys = missingJobIDs
-		metadata.FailedReasons = lo.SliceToMap(missingJobIDs, func(jobID int64) (int64, string) {
-			return jobID, "Input hash is not found in the data hash to job ID map or the job is not found in the successRespons or failedResponse"
-		})
+		if len(s.dataHashToJobID) == 0 {
+			// No correlation data at all (e.g. the process restarted between
+			// Upload and GetUploadStats and lost the in-memory map). This is a
+			// systemic loss, not a per-record mismatch, so keep these jobs
+			// retryable rather than permanently dropping a batch that may have
+			// succeeded in Salesforce.
+			metadata.FailedKeys = missingJobIDs
+			metadata.FailedReasons = lo.SliceToMap(missingJobIDs, func(jobID int64) (int64, string) {
+				return jobID, "Correlation map is empty (likely a restart between upload and stats); retrying"
+			})
+		} else {
+			// The map was populated but these records could not be matched back
+			// to a job, most likely because Salesforce reformatted the
+			// externalId value on store. Retrying would re-upload the same value
+			// and miss again, so abort instead of looping through retries.
+			metadata.AbortedKeys = append(metadata.AbortedKeys, missingJobIDs...)
+			for _, jobID := range missingJobIDs {
+				metadata.AbortedReasons[jobID] = "Could not correlate Salesforce result back to the job: externalId not found in success/failed records (possibly reformatted by Salesforce on store)"
+			}
+		}
 	}
 	return metadata
 }

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
@@ -183,10 +183,30 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 			DestinationID: destinationID,
 		}
 	}
+
+	// Drop events without an externalId value up front: with no upsert key they
+	// cannot be sent to Salesforce, so abort them with an error rather than
+	// emitting an uncorrelatable CSV row. Valid events continue to the upload.
+	validJobs := make([]common.AsyncJob, 0, len(input))
+	validJobIDs := make([]int64, 0, len(input))
+	var abortedJobIDs []int64
+	for _, job := range input {
+		jobID := int64(job.Metadata["job_id"].(float64))
+		if externalIDValue, _ := common.FormatCSVValue(job.Message[objectInfo.ExternalIDField]); externalIDValue == "" {
+			abortedJobIDs = append(abortedJobIDs, jobID)
+			continue
+		}
+		validJobs = append(validJobs, job)
+		validJobIDs = append(validJobIDs, jobID)
+	}
+	if len(abortedJobIDs) > 0 {
+		s.logger.Infon("Aborting events with missing externalId", logger.NewIntField("abortedJobs", int64(len(abortedJobIDs))))
+	}
+
 	csvFilePath, _, hashToJobID, err := createCSVFile(
 		destinationID,
 		objectInfo.ExternalIDField,
-		input,
+		validJobs,
 	)
 	defer func() {
 		if err := os.Remove(csvFilePath); err != nil {
@@ -205,18 +225,18 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 	s.dataHashToJobID = hashToJobID
 
 	// The source is expected to send unique externalIds per batch. Fewer keys
-	// than jobs means duplicates collided onto the same key, which makes
+	// than valid jobs means duplicates collided onto the same key, which makes
 	// per-job status attribution ambiguous after polling.
-	if len(hashToJobID) < len(input) {
+	if len(hashToJobID) < len(validJobs) {
 		s.logger.Warnn("Duplicate externalId values detected in batch; per-job status attribution may be ambiguous",
 			logger.NewIntField("uniqueExternalIds", int64(len(hashToJobID))),
-			logger.NewIntField("jobs", int64(len(input))),
+			logger.NewIntField("jobs", int64(len(validJobs))),
 		)
 	}
 
 	s.logger.Infon("Created CSV file",
 		logger.NewStringField("csvFilePath", csvFilePath),
-		logger.NewIntField("jobs", int64(len(input))),
+		logger.NewIntField("jobs", int64(len(validJobs))),
 	)
 	sfJobID, apiError := s.apiService.CreateJob(
 		objectInfo.ObjectType,
@@ -268,15 +288,18 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 			ID:              sfJobID,
 			ExternalIDField: objectInfo.ExternalIDField,
 		},
-		ImportCount: len(importingJobIDs),
+		ImportCount: len(validJobIDs),
 	})
 	if err != nil {
 		s.logger.Errorn("marshalling parameters", obskit.Error(err))
 	}
 	return common.AsyncUploadOutput{
-		ImportingJobIDs:     importingJobIDs,
+		ImportingJobIDs:     validJobIDs,
 		ImportingParameters: importParameters,
-		ImportingCount:      len(importingJobIDs),
+		ImportingCount:      len(validJobIDs),
+		AbortJobIDs:         abortedJobIDs,
+		AbortReason:         "externalId is missing for the event; cannot upsert to Salesforce",
+		AbortCount:          len(abortedJobIDs),
 		DestinationID:       destinationID,
 	}
 }

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
@@ -230,6 +230,18 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		)
 	}
 
+	// Track the size of the CSV we send to Salesforce and how many events it packs.
+	statTags := stats.Tags{
+		"module":        "batch_router",
+		"destType":      s.destName,
+		"destinationId": asyncDestStruct.Destination.ID,
+		"workspaceId":   asyncDestStruct.Destination.WorkspaceID,
+	}
+	s.statsFactory.NewTaggedStat("events_per_file", stats.HistogramType, statTags).Observe(float64(len(validJobs)))
+	if fileInfo, statErr := os.Stat(csvFilePath); statErr == nil {
+		s.statsFactory.NewTaggedStat("payload_size", stats.HistogramType, statTags).Observe(float64(fileInfo.Size()))
+	}
+
 	s.logger.Infon("Created CSV file",
 		logger.NewStringField("csvFilePath", csvFilePath),
 		logger.NewIntField("jobs", int64(len(validJobs))),
@@ -244,7 +256,9 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		return s.failedJobs(asyncDestStruct, fmt.Sprintf("Error creating Salesforce job: %v", apiError.Message))
 	}
 
+	uploadStartTime := time.Now()
 	apiError = s.apiService.UploadData(sfJobID, csvFilePath)
+	s.statsFactory.NewTaggedStat("async_upload_time", stats.TimerType, statTags).Since(uploadStartTime)
 	if apiError != nil {
 		s.logger.Errorn("Error uploading data for operation upsert", logger.NewStringField("apiErrorMessage", apiError.Message))
 		if err := s.apiService.DeleteJob(sfJobID); err != nil {

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
@@ -70,6 +70,14 @@ func NewUploader(
 		statsFactory:      statsFactory,
 		destName:          destName,
 	}
+	statTags := stats.Tags{"module": "batch_router", "destType": destName}
+	if destination != nil {
+		statTags["destinationId"] = destination.ID
+		statTags["workspaceId"] = destination.WorkspaceID
+	}
+	u.payloadSizeStat = statsFactory.NewTaggedStat("payload_size", stats.HistogramType, statTags)
+	u.eventsPerFileStat = statsFactory.NewTaggedStat("events_per_file", stats.HistogramType, statTags)
+	u.asyncUploadTimeStat = statsFactory.NewTaggedStat("async_upload_time", stats.TimerType, statTags)
 	u.config.maxBufferCapacity = conf.GetReloadableInt64Var(512*bytesize.KB, bytesize.B, "SalesforceBulkUpload.maxBufferCapacity")
 	return u
 }
@@ -207,7 +215,7 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 		return job.Metadata.JobID
 	})
 
-	csvFilePath, externalIDToJobID, err := createCSVFile(
+	csvFilePath, externalIDToJobID, fileSize, err := createCSVFile(
 		destinationID,
 		objectInfo.ExternalIDField,
 		validJobs,
@@ -234,16 +242,8 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 	}
 
 	// Track the size of the CSV we send to Salesforce and how many events it packs.
-	statTags := stats.Tags{
-		"module":        "batch_router",
-		"destType":      s.destName,
-		"destinationId": asyncDestStruct.Destination.ID,
-		"workspaceId":   asyncDestStruct.Destination.WorkspaceID,
-	}
-	s.statsFactory.NewTaggedStat("events_per_file", stats.HistogramType, statTags).Observe(float64(len(validJobs)))
-	if fileInfo, statErr := os.Stat(csvFilePath); statErr == nil {
-		s.statsFactory.NewTaggedStat("payload_size", stats.HistogramType, statTags).Observe(float64(fileInfo.Size()))
-	}
+	s.eventsPerFileStat.Observe(float64(len(validJobs)))
+	s.payloadSizeStat.Observe(float64(fileSize))
 
 	s.logger.Infon("Created CSV file",
 		logger.NewStringField("csvFilePath", csvFilePath),
@@ -261,7 +261,7 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 
 	uploadStartTime := time.Now()
 	apiError = s.apiService.UploadData(sfJobID, csvFilePath)
-	s.statsFactory.NewTaggedStat("async_upload_time", stats.TimerType, statTags).Since(uploadStartTime)
+	s.asyncUploadTimeStat.Since(uploadStartTime)
 	if apiError != nil {
 		s.logger.Errorn("Error uploading data for operation upsert", logger.NewStringField("apiErrorMessage", apiError.Message))
 		if err := s.apiService.DeleteJob(sfJobID); err != nil {

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk.go
@@ -251,7 +251,7 @@ func (s *Uploader) Upload(_ context.Context, asyncDestStruct *common.AsyncDestin
 	// created and closed, so we don't do this work for a failed upload.
 	jobImportingParameters := make(map[int64]stdjson.RawMessage, len(jobs))
 	for _, job := range jobs {
-		md, err := jsonrs.Marshal(importingMetadata{ExternalIDHash: hashExternalID(job.Metadata.ExternalIDs[0].ID)})
+		md, err := jsonrs.Marshal(importingMetadata{ExternalIDHash: HashExternalID(job.Metadata.ExternalIDs[0].ID)})
 		if err != nil {
 			s.logger.Errorn("marshalling importing metadata", logger.NewIntField("jobID", job.Metadata.JobID), obskit.Error(err))
 			continue
@@ -431,7 +431,7 @@ func (s *Uploader) matchRecordsToJobs(
 	}
 
 	for _, failedRecord := range failedRecords {
-		key := hashExternalID(failedRecord[externalIDField])
+		key := HashExternalID(failedRecord[externalIDField])
 		if jobIDs, exists := externalIDHashToJobID[key]; exists {
 			for _, jobID := range jobIDs {
 				metadata.AbortedKeys = append(metadata.AbortedKeys, jobID)
@@ -445,7 +445,7 @@ func (s *Uploader) matchRecordsToJobs(
 	}
 
 	for _, successRecord := range successRecords {
-		key := hashExternalID(successRecord[externalIDField])
+		key := HashExternalID(successRecord[externalIDField])
 		if jobIDs, exists := externalIDHashToJobID[key]; exists {
 			metadata.SucceededKeys = append(metadata.SucceededKeys, jobIDs...)
 		}

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
@@ -283,6 +283,42 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 		require.Empty(t, result.FailedJobIDs)
 		require.JSONEq(t, `{"importId":{"id":"sf-job-123","externalIdField":"Email"},"importCount":2}`, string(result.ImportingParameters))
 	})
+
+	t.Run("all events missing externalId are aborted without contacting Salesforce", func(t *testing.T) {
+		allAbortedFile, err := os.CreateTemp("", "test_upload_allaborted_*.json")
+		require.NoError(t, err)
+		defer os.Remove(allAbortedFile.Name())
+
+		extID := func(id string) []any {
+			return []any{map[string]any{"id": id, "identifierType": "Email", "type": "SALESFORCE_BULK_UPLOAD-Lead"}}
+		}
+		jobs := []common.AsyncJob{
+			{Message: map[string]any{"Email": "", "FirstName": "A"}, Metadata: map[string]any{"job_id": float64(1), "externalId": extID("")}},
+			{Message: map[string]any{"FirstName": "B"}, Metadata: map[string]any{"job_id": float64(2), "externalId": extID("")}},
+		}
+		for _, job := range jobs {
+			jobBytes, _ := jsonrs.Marshal(job)
+			_, err := allAbortedFile.Write(append(jobBytes, '\n'))
+			require.NoError(t, err)
+		}
+		require.NoError(t, allAbortedFile.Close())
+
+		ctrl := gomock.NewController(t)
+		// No CreateJob/UploadData/CloseJob expectations: Salesforce must not be contacted.
+		mockAPI := salesforcebulkupload_mocks.NewMockAPIServiceInterface(ctrl)
+		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, nil)
+
+		result := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
+			Destination:     &backendconfig.DestinationT{ID: "test-dest-1"},
+			FileName:        allAbortedFile.Name(),
+			ImportingJobIDs: []int64{1, 2},
+		})
+
+		require.Empty(t, result.ImportingJobIDs)
+		require.ElementsMatch(t, []int64{1, 2}, result.AbortJobIDs)
+		require.Equal(t, 2, result.AbortCount)
+		require.Contains(t, result.AbortReason, "externalId")
+	})
 }
 
 func TestSalesforceBulk_Poll(t *testing.T) {

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
@@ -2,6 +2,8 @@ package salesforcebulkupload_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"testing"
@@ -22,6 +24,13 @@ import (
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 	salesforcebulkupload "github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload"
 )
+
+// extIDHash mirrors the connector's externalId hashing so tests can assert the
+// hashed value persisted in the importing job status params.
+func extIDHash(externalID string) string {
+	sum := sha256.Sum256([]byte(externalID))
+	return hex.EncodeToString(sum[:])
+}
 
 func TestSalesforceBulk_Transform(t *testing.T) {
 	testCases := []struct {
@@ -186,6 +195,9 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 		require.Equal(t, 2, result.ImportingCount)
 		require.Equal(t, 0, result.FailedCount)
 		require.JSONEq(t, `{"importId":{"id":"sf-job-123","externalIdField":"Email"}, "importCount":2}`, string(result.ImportingParameters))
+		require.Len(t, result.JobImportingParameters, 2)
+		require.JSONEq(t, `{"externalIdHash":"`+extIDHash("test1@example.com")+`"}`, string(result.JobImportingParameters[1]))
+		require.JSONEq(t, `{"externalIdHash":"`+extIDHash("test2@example.com")+`"}`, string(result.JobImportingParameters[2]))
 	})
 
 	t.Run("emits payload_size, events_per_file and async_upload_time metrics", func(t *testing.T) {
@@ -438,57 +450,26 @@ func TestSalesforceBulk_Poll(t *testing.T) {
 }
 
 func TestSalesforceBulk_GetUploadStats(t *testing.T) {
-	// uploadTwoJobs uploads two jobs (job_id 1 -> test1@, job_id 2 -> test2@,
-	// externalId field "Email") so the uploader's in-memory correlation map is
-	// populated, then returns the uploader ready for GetUploadStats.
-	uploadTwoJobs := func(t *testing.T, mockAPI *salesforcebulkupload_mocks.MockAPIServiceInterface) *salesforcebulkupload.Uploader {
-		t.Helper()
-		tempFile, err := os.CreateTemp("", "test_upload_*.json")
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = os.Remove(tempFile.Name()) })
-		jobs := []common.AsyncJob{
-			{
-				Message: map[string]any{"Email": "test1@example.com", "FirstName": "John"},
-				Metadata: map[string]any{
-					"job_id":     float64(1),
-					"externalId": []any{map[string]any{"id": "test1@example.com", "identifierType": "Email", "type": "SALESFORCE_BULK_UPLOAD-Lead"}},
-				},
-			},
-			{
-				Message: map[string]any{"Email": "test2@example.com", "FirstName": "Jane"},
-				Metadata: map[string]any{
-					"job_id":     float64(2),
-					"externalId": []any{map[string]any{"id": "test2@example.com", "identifierType": "Email", "type": "SALESFORCE_BULK_UPLOAD-Lead"}},
-				},
+	// importingJob builds an importing job whose status params carry the per-job
+	// externalId metadata, exactly as handle_async persists it during upload.
+	// The stored value is the SHA-256 hash of the externalId, not the raw value.
+	importingJob := func(jobID int64, externalID string) *jobsdb.JobT {
+		return &jobsdb.JobT{
+			JobID: jobID,
+			LastJobStatus: jobsdb.JobStatusT{
+				Parameters: []byte(`{"metadata":{"externalIdHash":"` + extIDHash(externalID) + `"}}`),
 			},
 		}
-		for _, job := range jobs {
-			jobBytes, _ := jsonrs.Marshal(job)
-			_, err := tempFile.Write(append(jobBytes, '\n'))
-			require.NoError(t, err)
-		}
-		require.NoError(t, tempFile.Close())
-
-		mockAPI.EXPECT().CreateJob(gomock.Any(), gomock.Any(), gomock.Any()).Return("sf-job-123", nil)
-		mockAPI.EXPECT().UploadData(gomock.Any(), gomock.Any()).Return(nil)
-		mockAPI.EXPECT().CloseJob(gomock.Any()).Return(nil)
-
-		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
-		out := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
-			Destination:     &backendconfig.DestinationT{ID: "test-dest"},
-			FileName:        tempFile.Name(),
-			ImportingJobIDs: []int64{1, 2},
-		})
-		require.Equal(t, 0, out.FailedCount)
-		return uploader
+	}
+	newUploader := func(mockAPI *salesforcebulkupload_mocks.MockAPIServiceInterface) *salesforcebulkupload.Uploader {
+		return salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
 	}
 
 	importIDParams := json.RawMessage(`{"importId":"{\"id\":\"sf-job-123\",\"externalIdField\":\"Email\"}","metadata":{"csvHeader":""}}`)
 
-	t.Run("matches succeeded and aborted jobs by externalId", func(t *testing.T) {
+	t.Run("matches succeeded and aborted jobs by externalId from job status params", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockAPI := salesforcebulkupload_mocks.NewMockAPIServiceInterface(ctrl)
-		uploader := uploadTwoJobs(t, mockAPI)
 
 		// job 1 succeeded; job 2 failed. The CreatedDate column is coerced by
 		// Salesforce but the Email (externalId) round-trips, so both still match.
@@ -499,9 +480,9 @@ func TestSalesforceBulk_GetUploadStats(t *testing.T) {
 			{"Email": "test2@example.com", "FirstName": "Jane", "sf__Error": "REQUIRED_FIELD_MISSING:LastName"},
 		}, nil)
 
-		result := uploader.GetUploadStats(common.GetUploadStatsInput{
+		result := newUploader(mockAPI).GetUploadStats(common.GetUploadStatsInput{
 			Parameters:    importIDParams,
-			ImportingList: []*jobsdb.JobT{{JobID: 1}, {JobID: 2}},
+			ImportingList: []*jobsdb.JobT{importingJob(1, "test1@example.com"), importingJob(2, "test2@example.com")},
 		})
 
 		require.Equal(t, 200, result.StatusCode)
@@ -511,13 +492,12 @@ func TestSalesforceBulk_GetUploadStats(t *testing.T) {
 		require.Equal(t, "REQUIRED_FIELD_MISSING:LastName", result.Metadata.AbortedReasons[2])
 	})
 
-	t.Run("unmatched records with a populated map are aborted, not retried", func(t *testing.T) {
+	t.Run("unmatched records are aborted, not retried", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockAPI := salesforcebulkupload_mocks.NewMockAPIServiceInterface(ctrl)
-		uploader := uploadTwoJobs(t, mockAPI)
 
 		// Salesforce reformatted the externalId itself (e.g. a numeric/date
-		// external id), so neither returned record matches any uploaded job.
+		// external id), so neither returned record matches any importing job.
 		mockAPI.EXPECT().GetSuccessfulRecords(gomock.Any()).Return([]map[string]string{
 			{"Email": "TEST1@EXAMPLE.COM", "sf__Id": "001"},
 		}, nil)
@@ -525,9 +505,9 @@ func TestSalesforceBulk_GetUploadStats(t *testing.T) {
 			{"Email": "TEST2@EXAMPLE.COM", "sf__Error": "boom"},
 		}, nil)
 
-		result := uploader.GetUploadStats(common.GetUploadStatsInput{
+		result := newUploader(mockAPI).GetUploadStats(common.GetUploadStatsInput{
 			Parameters:    importIDParams,
-			ImportingList: []*jobsdb.JobT{{JobID: 1}, {JobID: 2}},
+			ImportingList: []*jobsdb.JobT{importingJob(1, "test1@example.com"), importingJob(2, "test2@example.com")},
 		})
 
 		require.Equal(t, 200, result.StatusCode)
@@ -537,24 +517,24 @@ func TestSalesforceBulk_GetUploadStats(t *testing.T) {
 		require.NotEmpty(t, result.Metadata.AbortedReasons[2])
 	})
 
-	t.Run("empty correlation map keeps jobs retryable", func(t *testing.T) {
+	t.Run("no externalId metadata on importing jobs aborts the batch", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockAPI := salesforcebulkupload_mocks.NewMockAPIServiceInterface(ctrl)
-		// No Upload call: simulates a process restart that lost the in-memory map.
 		mockAPI.EXPECT().GetFailedRecords(gomock.Any()).Return([]map[string]string{}, nil)
 		mockAPI.EXPECT().GetSuccessfulRecords(gomock.Any()).Return([]map[string]string{
 			{"Email": "test1@example.com"}, {"Email": "test2@example.com"},
 		}, nil)
 
-		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
-		result := uploader.GetUploadStats(common.GetUploadStatsInput{
+		// importing jobs with no metadata in their status params → the map can't
+		// be rebuilt, so the batch is aborted (and logged for alerting).
+		result := newUploader(mockAPI).GetUploadStats(common.GetUploadStatsInput{
 			Parameters:    importIDParams,
 			ImportingList: []*jobsdb.JobT{{JobID: 1}, {JobID: 2}},
 		})
 
 		require.Equal(t, 200, result.StatusCode)
-		require.ElementsMatch(t, []int64{1, 2}, result.Metadata.FailedKeys)
-		require.Empty(t, result.Metadata.AbortedKeys)
+		require.ElementsMatch(t, []int64{1, 2}, result.Metadata.AbortedKeys)
+		require.Empty(t, result.Metadata.FailedKeys)
 	})
 
 	t.Run("handles API error fetching failed records", func(t *testing.T) {

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
@@ -2,8 +2,6 @@ package salesforcebulkupload_test
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"os"
 	"testing"
@@ -24,13 +22,6 @@ import (
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 	salesforcebulkupload "github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload"
 )
-
-// extIDHash mirrors the connector's externalId hashing so tests can assert the
-// hashed value persisted in the importing job status params.
-func extIDHash(externalID string) string {
-	sum := sha256.Sum256([]byte(externalID))
-	return hex.EncodeToString(sum[:])
-}
 
 func TestSalesforceBulk_Transform(t *testing.T) {
 	testCases := []struct {
@@ -222,8 +213,8 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 		require.Equal(t, 0, result.FailedCount)
 		require.JSONEq(t, `{"importId":{"id":"sf-job-123","externalIdField":"Email"}, "importCount":2}`, string(result.ImportingParameters))
 		require.Len(t, result.JobImportingParameters, 2)
-		require.JSONEq(t, `{"externalIdHash":"`+extIDHash("test1@example.com")+`"}`, string(result.JobImportingParameters[1]))
-		require.JSONEq(t, `{"externalIdHash":"`+extIDHash("test2@example.com")+`"}`, string(result.JobImportingParameters[2]))
+		require.JSONEq(t, `{"externalIdHash":"`+salesforcebulkupload.HashExternalID("test1@example.com")+`"}`, string(result.JobImportingParameters[1]))
+		require.JSONEq(t, `{"externalIdHash":"`+salesforcebulkupload.HashExternalID("test2@example.com")+`"}`, string(result.JobImportingParameters[2]))
 	})
 
 	t.Run("emits brt_async_dest_payload_size, brt_async_dest_events_per_file and brt_async_dest_async_upload_time metrics", func(t *testing.T) {
@@ -404,7 +395,7 @@ func TestSalesforceBulk_GetUploadStats(t *testing.T) {
 		return &jobsdb.JobT{
 			JobID: jobID,
 			LastJobStatus: jobsdb.JobStatusT{
-				Parameters: []byte(`{"metadata":{"externalIdHash":"` + extIDHash(externalID) + `"}}`),
+				Parameters: []byte(`{"metadata":{"externalIdHash":"` + salesforcebulkupload.HashExternalID(externalID) + `"}}`),
 			},
 		}
 	}

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
@@ -237,7 +237,6 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 		require.Equal(t, 2, result.ImportingCount)
 
 		tags := stats.Tags{
-			"module":        "batch_router",
 			"destType":      "SALESFORCE_BULK_UPLOAD",
 			"destinationId": "test-dest-1",
 			"workspaceId":   "test-ws-1",

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
@@ -71,7 +71,7 @@ func TestSalesforceBulk_Transform(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "successful transform with valid payload",
+			name: "transform fails when externalId is absent",
 			job: &jobsdb.JobT{
 				JobID: 123,
 				EventPayload: []byte(`{
@@ -88,6 +88,32 @@ func TestSalesforceBulk_Transform(t *testing.T) {
 						"Industry": "AZ",
 						"LastName": "Gonzalez",
 						"Phone": "555-111-0020"
+					},
+					"type": "identify",
+					"userId": "evelyn.gonzalez@example.com"
+				}`),
+			},
+			wantErr: true,
+		},
+		{
+			name: "transform fails when externalId id is empty",
+			job: &jobsdb.JobT{
+				JobID: 124,
+				EventPayload: []byte(`{
+					"channel": "sources",
+					"context": {
+						"externalId": [
+							{
+								"id": "",
+								"identifierType": "Email",
+								"type": "SALESFORCE_BULK_UPLOAD-Lead"
+							}
+						],
+						"mappedToDestination": "true"
+					},
+					"traits": {
+						"FirstName": "Evelyn",
+						"LastName": "Gonzalez"
 					},
 					"type": "identify",
 					"userId": "evelyn.gonzalez@example.com"
@@ -200,7 +226,7 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 		require.JSONEq(t, `{"externalIdHash":"`+extIDHash("test2@example.com")+`"}`, string(result.JobImportingParameters[2]))
 	})
 
-	t.Run("emits payload_size, events_per_file and async_upload_time metrics", func(t *testing.T) {
+	t.Run("emits brt_async_dest_payload_size, brt_async_dest_events_per_file and brt_async_dest_async_upload_time metrics", func(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
 
@@ -225,9 +251,9 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 			"destinationId": "test-dest-1",
 			"workspaceId":   "test-ws-1",
 		}
-		require.Equal(t, float64(2), statsStore.Get("events_per_file", tags).LastValue())
-		require.Greater(t, statsStore.Get("payload_size", tags).LastValue(), float64(0))
-		require.Len(t, statsStore.Get("async_upload_time", tags).Durations(), 1)
+		require.Equal(t, float64(2), statsStore.Get("brt_async_dest_events_per_file", tags).LastValue())
+		require.Greater(t, statsStore.Get("brt_async_dest_payload_size", tags).LastValue(), float64(0))
+		require.Len(t, statsStore.Get("brt_async_dest_async_upload_time", tags).Durations(), 1)
 	})
 
 	t.Run("upload with API error", func(t *testing.T) {
@@ -282,85 +308,6 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 		require.Equal(t, 0, result.ImportingCount)
 		require.Greater(t, result.FailedCount, 0)
 		require.Contains(t, result.FailedReason, "creating Salesforce job: Rate limit exceeded")
-	})
-
-	t.Run("events with missing externalId are aborted up front, valid ones imported", func(t *testing.T) {
-		mixedFile, err := os.CreateTemp("", "test_upload_mixed_*.json")
-		require.NoError(t, err)
-		defer os.Remove(mixedFile.Name())
-
-		extID := func(id string) []any {
-			return []any{map[string]any{"id": id, "identifierType": "Email", "type": "SALESFORCE_BULK_UPLOAD-Lead"}}
-		}
-		jobs := []common.AsyncJob{
-			{Message: map[string]any{"Email": "a@example.com", "FirstName": "A"}, Metadata: map[string]any{"job_id": float64(1), "externalId": extID("a@example.com")}},
-			{Message: map[string]any{"Email": "", "FirstName": "B"}, Metadata: map[string]any{"job_id": float64(2), "externalId": extID("")}}, // empty externalId -> aborted
-			{Message: map[string]any{"FirstName": "C"}, Metadata: map[string]any{"job_id": float64(3), "externalId": extID("")}},              // missing externalId -> aborted
-			{Message: map[string]any{"Email": "d@example.com", "FirstName": "D"}, Metadata: map[string]any{"job_id": float64(4), "externalId": extID("d@example.com")}},
-		}
-		for _, job := range jobs {
-			jobBytes, _ := jsonrs.Marshal(job)
-			_, err := mixedFile.Write(append(jobBytes, '\n'))
-			require.NoError(t, err)
-		}
-		require.NoError(t, mixedFile.Close())
-
-		ctrl := gomock.NewController(t)
-		mockAPI := salesforcebulkupload_mocks.NewMockAPIServiceInterface(ctrl)
-		mockAPI.EXPECT().CreateJob(gomock.Any(), gomock.Any(), gomock.Any()).Return("sf-job-123", nil)
-		mockAPI.EXPECT().UploadData(gomock.Any(), gomock.Any()).Return(nil)
-		mockAPI.EXPECT().CloseJob(gomock.Any()).Return(nil)
-		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
-
-		result := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
-			Destination:     &backendconfig.DestinationT{ID: "test-dest-1"},
-			FileName:        mixedFile.Name(),
-			ImportingJobIDs: []int64{1, 2, 3, 4},
-		})
-
-		require.ElementsMatch(t, []int64{1, 4}, result.ImportingJobIDs)
-		require.Equal(t, 2, result.ImportingCount)
-		require.ElementsMatch(t, []int64{2, 3}, result.AbortJobIDs)
-		require.Equal(t, 2, result.AbortCount)
-		require.Contains(t, result.AbortReason, "externalId")
-		require.Empty(t, result.FailedJobIDs)
-		require.JSONEq(t, `{"importId":{"id":"sf-job-123","externalIdField":"Email"},"importCount":2}`, string(result.ImportingParameters))
-	})
-
-	t.Run("all events missing externalId are aborted without contacting Salesforce", func(t *testing.T) {
-		allAbortedFile, err := os.CreateTemp("", "test_upload_allaborted_*.json")
-		require.NoError(t, err)
-		defer os.Remove(allAbortedFile.Name())
-
-		extID := func(id string) []any {
-			return []any{map[string]any{"id": id, "identifierType": "Email", "type": "SALESFORCE_BULK_UPLOAD-Lead"}}
-		}
-		jobs := []common.AsyncJob{
-			{Message: map[string]any{"Email": "", "FirstName": "A"}, Metadata: map[string]any{"job_id": float64(1), "externalId": extID("")}},
-			{Message: map[string]any{"FirstName": "B"}, Metadata: map[string]any{"job_id": float64(2), "externalId": extID("")}},
-		}
-		for _, job := range jobs {
-			jobBytes, _ := jsonrs.Marshal(job)
-			_, err := allAbortedFile.Write(append(jobBytes, '\n'))
-			require.NoError(t, err)
-		}
-		require.NoError(t, allAbortedFile.Close())
-
-		ctrl := gomock.NewController(t)
-		// No CreateJob/UploadData/CloseJob expectations: Salesforce must not be contacted.
-		mockAPI := salesforcebulkupload_mocks.NewMockAPIServiceInterface(ctrl)
-		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
-
-		result := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
-			Destination:     &backendconfig.DestinationT{ID: "test-dest-1"},
-			FileName:        allAbortedFile.Name(),
-			ImportingJobIDs: []int64{1, 2},
-		})
-
-		require.Empty(t, result.ImportingJobIDs)
-		require.ElementsMatch(t, []int64{1, 2}, result.AbortJobIDs)
-		require.Equal(t, 2, result.AbortCount)
-		require.Contains(t, result.AbortReason, "externalId")
 	})
 }
 

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
@@ -240,6 +240,49 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 		require.Greater(t, result.FailedCount, 0)
 		require.Contains(t, result.FailedReason, "Error creating Salesforce job: Rate limit exceeded")
 	})
+
+	t.Run("events with missing externalId are aborted up front, valid ones imported", func(t *testing.T) {
+		mixedFile, err := os.CreateTemp("", "test_upload_mixed_*.json")
+		require.NoError(t, err)
+		defer os.Remove(mixedFile.Name())
+
+		extID := func(id string) []any {
+			return []any{map[string]any{"id": id, "identifierType": "Email", "type": "SALESFORCE_BULK_UPLOAD-Lead"}}
+		}
+		jobs := []common.AsyncJob{
+			{Message: map[string]any{"Email": "a@example.com", "FirstName": "A"}, Metadata: map[string]any{"job_id": float64(1), "externalId": extID("a@example.com")}},
+			{Message: map[string]any{"Email": "", "FirstName": "B"}, Metadata: map[string]any{"job_id": float64(2), "externalId": extID("")}}, // empty externalId -> aborted
+			{Message: map[string]any{"FirstName": "C"}, Metadata: map[string]any{"job_id": float64(3), "externalId": extID("")}},              // missing externalId -> aborted
+			{Message: map[string]any{"Email": "d@example.com", "FirstName": "D"}, Metadata: map[string]any{"job_id": float64(4), "externalId": extID("d@example.com")}},
+		}
+		for _, job := range jobs {
+			jobBytes, _ := jsonrs.Marshal(job)
+			_, err := mixedFile.Write(append(jobBytes, '\n'))
+			require.NoError(t, err)
+		}
+		require.NoError(t, mixedFile.Close())
+
+		ctrl := gomock.NewController(t)
+		mockAPI := salesforcebulkupload_mocks.NewMockAPIServiceInterface(ctrl)
+		mockAPI.EXPECT().CreateJob(gomock.Any(), gomock.Any(), gomock.Any()).Return("sf-job-123", nil)
+		mockAPI.EXPECT().UploadData(gomock.Any(), gomock.Any()).Return(nil)
+		mockAPI.EXPECT().CloseJob(gomock.Any()).Return(nil)
+		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, nil)
+
+		result := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
+			Destination:     &backendconfig.DestinationT{ID: "test-dest-1"},
+			FileName:        mixedFile.Name(),
+			ImportingJobIDs: []int64{1, 2, 3, 4},
+		})
+
+		require.ElementsMatch(t, []int64{1, 4}, result.ImportingJobIDs)
+		require.Equal(t, 2, result.ImportingCount)
+		require.ElementsMatch(t, []int64{2, 3}, result.AbortJobIDs)
+		require.Equal(t, 2, result.AbortCount)
+		require.Contains(t, result.AbortReason, "externalId")
+		require.Empty(t, result.FailedJobIDs)
+		require.JSONEq(t, `{"importId":{"id":"sf-job-123","externalIdField":"Email"},"importCount":2}`, string(result.ImportingParameters))
+	})
 }
 
 func TestSalesforceBulk_Poll(t *testing.T) {

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
@@ -242,7 +242,7 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 
 		require.Equal(t, 0, result.ImportingCount)
 		require.Greater(t, result.FailedCount, 0)
-		require.Contains(t, result.FailedReason, "Error creating Salesforce job: Internal Server Error")
+		require.Contains(t, result.FailedReason, "creating Salesforce job: Internal Server Error")
 	})
 
 	t.Run("upload with rate limit error", func(t *testing.T) {
@@ -269,7 +269,7 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 
 		require.Equal(t, 0, result.ImportingCount)
 		require.Greater(t, result.FailedCount, 0)
-		require.Contains(t, result.FailedReason, "Error creating Salesforce job: Rate limit exceeded")
+		require.Contains(t, result.FailedReason, "creating Salesforce job: Rate limit exceeded")
 	})
 
 	t.Run("events with missing externalId are aborted up front, valid ones imported", func(t *testing.T) {

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
@@ -184,7 +184,7 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 
 		require.Equal(t, 2, result.ImportingCount)
 		require.Equal(t, 0, result.FailedCount)
-		require.JSONEq(t, `{"importId":{"id":"sf-job-123","headers":["Email","FirstName","LastName"]}, "importCount":2}`, string(result.ImportingParameters))
+		require.JSONEq(t, `{"importId":{"id":"sf-job-123","externalIdField":"Email"}, "importCount":2}`, string(result.ImportingParameters))
 	})
 
 	t.Run("upload with API error", func(t *testing.T) {
@@ -328,51 +328,123 @@ func TestSalesforceBulk_Poll(t *testing.T) {
 }
 
 func TestSalesforceBulk_GetUploadStats(t *testing.T) {
-	t.Run("successful stats retrieval with failures", func(t *testing.T) {
+	// uploadTwoJobs uploads two jobs (job_id 1 -> test1@, job_id 2 -> test2@,
+	// externalId field "Email") so the uploader's in-memory correlation map is
+	// populated, then returns the uploader ready for GetUploadStats.
+	uploadTwoJobs := func(t *testing.T, mockAPI *salesforcebulkupload_mocks.MockAPIServiceInterface) *salesforcebulkupload.Uploader {
+		t.Helper()
 		tempFile, err := os.CreateTemp("", "test_upload_*.json")
 		require.NoError(t, err)
-		defer os.Remove(tempFile.Name())
-		testData := make([]common.AsyncJob, 0)
-		testData = append(testData, common.AsyncJob{
-			Message: map[string]any{
-				"Email":     "test1@example.com",
-				"FirstName": "John",
-				"LastName":  "Doe",
+		t.Cleanup(func() { _ = os.Remove(tempFile.Name()) })
+		jobs := []common.AsyncJob{
+			{
+				Message: map[string]any{"Email": "test1@example.com", "FirstName": "John"},
+				Metadata: map[string]any{
+					"job_id":     float64(1),
+					"externalId": []any{map[string]any{"id": "test1@example.com", "identifierType": "Email", "type": "SALESFORCE_BULK_UPLOAD-Lead"}},
+				},
 			},
-			Metadata: map[string]any{
-				"job_id": float64(1),
+			{
+				Message: map[string]any{"Email": "test2@example.com", "FirstName": "Jane"},
+				Metadata: map[string]any{
+					"job_id":     float64(2),
+					"externalId": []any{map[string]any{"id": "test2@example.com", "identifierType": "Email", "type": "SALESFORCE_BULK_UPLOAD-Lead"}},
+				},
 			},
-		})
-		for _, job := range testData {
+		}
+		for _, job := range jobs {
 			jobBytes, _ := jsonrs.Marshal(job)
-			_, err := tempFile.Write(jobBytes)
-			require.NoError(t, err)
-			_, err = tempFile.Write([]byte("\n"))
+			_, err := tempFile.Write(append(jobBytes, '\n'))
 			require.NoError(t, err)
 		}
-		tempFile.Close()
+		require.NoError(t, tempFile.Close())
 
-		ctrl := gomock.NewController(t)
-		mockAPI := salesforcebulkupload_mocks.NewMockAPIServiceInterface(ctrl)
-		mockAPI.EXPECT().GetFailedRecords(gomock.Any()).Return([]map[string]string{}, nil)
-		mockAPI.EXPECT().GetSuccessfulRecords(gomock.Any()).Return([]map[string]string{{"Email": "test1@example.com", "FirstName": "John", "LastName": "Doe"}, {"Email": "test2@example.com", "FirstName": "Jane", "LastName": "Smith"}}, nil)
+		mockAPI.EXPECT().CreateJob(gomock.Any(), gomock.Any(), gomock.Any()).Return("sf-job-123", nil)
+		mockAPI.EXPECT().UploadData(gomock.Any(), gomock.Any()).Return(nil)
+		mockAPI.EXPECT().CloseJob(gomock.Any()).Return(nil)
 
 		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, nil)
-		uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
-			Destination: &backendconfig.DestinationT{ID: "test-dest"},
-			FileName:    tempFile.Name(),
+		out := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
+			Destination:     &backendconfig.DestinationT{ID: "test-dest"},
+			FileName:        tempFile.Name(),
+			ImportingJobIDs: []int64{1, 2},
 		})
+		require.Equal(t, 0, out.FailedCount)
+		return uploader
+	}
+
+	importIDParams := json.RawMessage(`{"importId":"{\"id\":\"sf-job-123\",\"externalIdField\":\"Email\"}","metadata":{"csvHeader":""}}`)
+
+	t.Run("matches succeeded and aborted jobs by externalId", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockAPI := salesforcebulkupload_mocks.NewMockAPIServiceInterface(ctrl)
+		uploader := uploadTwoJobs(t, mockAPI)
+
+		// job 1 succeeded; job 2 failed. The CreatedDate column is coerced by
+		// Salesforce but the Email (externalId) round-trips, so both still match.
+		mockAPI.EXPECT().GetSuccessfulRecords(gomock.Any()).Return([]map[string]string{
+			{"Email": "test1@example.com", "FirstName": "John", "CreatedDate": "2025-11-25T03:45:21.142Z", "sf__Id": "001"},
+		}, nil)
+		mockAPI.EXPECT().GetFailedRecords(gomock.Any()).Return([]map[string]string{
+			{"Email": "test2@example.com", "FirstName": "Jane", "sf__Error": "REQUIRED_FIELD_MISSING:LastName"},
+		}, nil)
 
 		result := uploader.GetUploadStats(common.GetUploadStatsInput{
-			Parameters: json.RawMessage(`{"importId":"{\"id\":\"sf-job-123\",\"headers\":[\"Email\",\"FirstName\",\"LastName\"]}","metadata":{"csvHeader":""}}`),
-			ImportingList: []*jobsdb.JobT{
-				{JobID: 1},
-				{JobID: 2},
-			},
+			Parameters:    importIDParams,
+			ImportingList: []*jobsdb.JobT{{JobID: 1}, {JobID: 2}},
 		})
 
 		require.Equal(t, 200, result.StatusCode)
-		require.NotNil(t, result.Metadata)
+		require.Equal(t, []int64{1}, result.Metadata.SucceededKeys)
+		require.Equal(t, []int64{2}, result.Metadata.AbortedKeys)
+		require.Empty(t, result.Metadata.FailedKeys)
+		require.Equal(t, "REQUIRED_FIELD_MISSING:LastName", result.Metadata.AbortedReasons[2])
+	})
+
+	t.Run("unmatched records with a populated map are aborted, not retried", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockAPI := salesforcebulkupload_mocks.NewMockAPIServiceInterface(ctrl)
+		uploader := uploadTwoJobs(t, mockAPI)
+
+		// Salesforce reformatted the externalId itself (e.g. a numeric/date
+		// external id), so neither returned record matches any uploaded job.
+		mockAPI.EXPECT().GetSuccessfulRecords(gomock.Any()).Return([]map[string]string{
+			{"Email": "TEST1@EXAMPLE.COM", "sf__Id": "001"},
+		}, nil)
+		mockAPI.EXPECT().GetFailedRecords(gomock.Any()).Return([]map[string]string{
+			{"Email": "TEST2@EXAMPLE.COM", "sf__Error": "boom"},
+		}, nil)
+
+		result := uploader.GetUploadStats(common.GetUploadStatsInput{
+			Parameters:    importIDParams,
+			ImportingList: []*jobsdb.JobT{{JobID: 1}, {JobID: 2}},
+		})
+
+		require.Equal(t, 200, result.StatusCode)
+		require.ElementsMatch(t, []int64{1, 2}, result.Metadata.AbortedKeys)
+		require.Empty(t, result.Metadata.FailedKeys)
+		require.NotEmpty(t, result.Metadata.AbortedReasons[1])
+		require.NotEmpty(t, result.Metadata.AbortedReasons[2])
+	})
+
+	t.Run("empty correlation map keeps jobs retryable", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockAPI := salesforcebulkupload_mocks.NewMockAPIServiceInterface(ctrl)
+		// No Upload call: simulates a process restart that lost the in-memory map.
+		mockAPI.EXPECT().GetFailedRecords(gomock.Any()).Return([]map[string]string{}, nil)
+		mockAPI.EXPECT().GetSuccessfulRecords(gomock.Any()).Return([]map[string]string{
+			{"Email": "test1@example.com"}, {"Email": "test2@example.com"},
+		}, nil)
+
+		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, nil)
+		result := uploader.GetUploadStats(common.GetUploadStatsInput{
+			Parameters:    importIDParams,
+			ImportingList: []*jobsdb.JobT{{JobID: 1}, {JobID: 2}},
+		})
+
+		require.Equal(t, 200, result.StatusCode)
+		require.ElementsMatch(t, []int64{1, 2}, result.Metadata.FailedKeys)
+		require.Empty(t, result.Metadata.AbortedKeys)
 	})
 
 	t.Run("handles API error fetching failed records", func(t *testing.T) {

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/jobsdb"
@@ -185,6 +186,36 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 		require.Equal(t, 2, result.ImportingCount)
 		require.Equal(t, 0, result.FailedCount)
 		require.JSONEq(t, `{"importId":{"id":"sf-job-123","externalIdField":"Email"}, "importCount":2}`, string(result.ImportingParameters))
+	})
+
+	t.Run("emits payload_size, events_per_file and async_upload_time metrics", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		dest := &backendconfig.DestinationT{ID: "test-dest-1", WorkspaceID: "test-ws-1"}
+		ctrl := gomock.NewController(t)
+		mockAPI := salesforcebulkupload_mocks.NewMockAPIServiceInterface(ctrl)
+		mockAPI.EXPECT().CreateJob(gomock.Any(), gomock.Any(), gomock.Any()).Return("sf-job-123", nil)
+		mockAPI.EXPECT().UploadData(gomock.Any(), gomock.Any()).Return(nil)
+		mockAPI.EXPECT().CloseJob(gomock.Any()).Return(nil)
+		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, statsStore, mockAPI, dest)
+
+		result := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
+			Destination:     dest,
+			FileName:        tempFile.Name(),
+			ImportingJobIDs: []int64{1, 2},
+		})
+		require.Equal(t, 2, result.ImportingCount)
+
+		tags := stats.Tags{
+			"module":        "batch_router",
+			"destType":      "SALESFORCE_BULK_UPLOAD",
+			"destinationId": "test-dest-1",
+			"workspaceId":   "test-ws-1",
+		}
+		require.Equal(t, float64(2), statsStore.Get("events_per_file", tags).LastValue())
+		require.Greater(t, statsStore.Get("payload_size", tags).LastValue(), float64(0))
+		require.Len(t, statsStore.Get("async_upload_time", tags).Durations(), 1)
 	})
 
 	t.Run("upload with API error", func(t *testing.T) {

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/salesforce_bulk_upload_test.go
@@ -92,7 +92,7 @@ func TestSalesforceBulk_Transform(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, nil, nil)
+			uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, nil, &backendconfig.DestinationT{})
 			result, err := uploader.Transform(tc.job)
 
 			if tc.wantErr {
@@ -170,7 +170,7 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 		mockAPI.EXPECT().CreateJob(gomock.Any(), gomock.Any(), gomock.Any()).Return("sf-job-123", nil)
 		mockAPI.EXPECT().UploadData(gomock.Any(), gomock.Any()).Return(nil)
 		mockAPI.EXPECT().CloseJob(gomock.Any()).Return(nil)
-		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, nil)
+		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
 
 		result := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
 			Destination: &backendconfig.DestinationT{
@@ -227,7 +227,7 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 			Category:   "ServerError",
 		})
 
-		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, nil)
+		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
 
 		result := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
 			Destination: &backendconfig.DestinationT{
@@ -254,7 +254,7 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 			Category:   "RateLimit",
 		})
 
-		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, nil)
+		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
 
 		result := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
 			Destination: &backendconfig.DestinationT{
@@ -298,7 +298,7 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 		mockAPI.EXPECT().CreateJob(gomock.Any(), gomock.Any(), gomock.Any()).Return("sf-job-123", nil)
 		mockAPI.EXPECT().UploadData(gomock.Any(), gomock.Any()).Return(nil)
 		mockAPI.EXPECT().CloseJob(gomock.Any()).Return(nil)
-		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, nil)
+		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
 
 		result := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
 			Destination:     &backendconfig.DestinationT{ID: "test-dest-1"},
@@ -337,7 +337,7 @@ func TestSalesforceBulk_Upload(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		// No CreateJob/UploadData/CloseJob expectations: Salesforce must not be contacted.
 		mockAPI := salesforcebulkupload_mocks.NewMockAPIServiceInterface(ctrl)
-		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, nil)
+		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
 
 		result := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
 			Destination:     &backendconfig.DestinationT{ID: "test-dest-1"},
@@ -425,7 +425,7 @@ func TestSalesforceBulk_Poll(t *testing.T) {
 				mockAPI.EXPECT().GetJobStatus(jobStatus.ID).Return(jobStatus, nil)
 			}
 
-			uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, nil)
+			uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
 
 			result := uploader.Poll(context.Background(), tc.pollInput)
 
@@ -473,7 +473,7 @@ func TestSalesforceBulk_GetUploadStats(t *testing.T) {
 		mockAPI.EXPECT().UploadData(gomock.Any(), gomock.Any()).Return(nil)
 		mockAPI.EXPECT().CloseJob(gomock.Any()).Return(nil)
 
-		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, nil)
+		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
 		out := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
 			Destination:     &backendconfig.DestinationT{ID: "test-dest"},
 			FileName:        tempFile.Name(),
@@ -546,7 +546,7 @@ func TestSalesforceBulk_GetUploadStats(t *testing.T) {
 			{"Email": "test1@example.com"}, {"Email": "test2@example.com"},
 		}, nil)
 
-		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, nil)
+		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
 		result := uploader.GetUploadStats(common.GetUploadStatsInput{
 			Parameters:    importIDParams,
 			ImportingList: []*jobsdb.JobT{{JobID: 1}, {JobID: 2}},
@@ -566,7 +566,7 @@ func TestSalesforceBulk_GetUploadStats(t *testing.T) {
 			Category:   "ServerError",
 		})
 
-		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, nil)
+		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, mockAPI, &backendconfig.DestinationT{})
 
 		result := uploader.GetUploadStats(common.GetUploadStatsInput{
 			Parameters: json.RawMessage(`{"importId":"{\"id\":\"test-job-123\",\"headers\":[\"Email\"]}","metadata":{"csvHeader":""}}`),
@@ -577,7 +577,7 @@ func TestSalesforceBulk_GetUploadStats(t *testing.T) {
 	})
 
 	t.Run("handles invalid parameters", func(t *testing.T) {
-		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, nil, nil)
+		uploader := salesforcebulkupload.NewUploader(config.New(), logger.NOP, stats.NOP, nil, &backendconfig.DestinationT{})
 
 		result := uploader.GetUploadStats(common.GetUploadStatsInput{
 			Parameters: json.RawMessage(`invalid json`),

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
@@ -114,4 +114,10 @@ const (
 	// missingExternalIDReason is the abort reason for individual events that
 	// carry no externalId value (no upsert key).
 	missingExternalIDReason = "externalId is missing for the event; cannot upsert to Salesforce"
+	// emptyCorrelationMapReason keeps jobs retryable when the in-memory map is
+	// gone (e.g. a process restart between Upload and GetUploadStats).
+	emptyCorrelationMapReason = "correlation map is empty (likely a restart between upload and stats); retrying"
+	// resultCorrelationFailedReason aborts jobs whose externalId did not come
+	// back in the Salesforce success/failed records (e.g. reformatted on store).
+	resultCorrelationFailedReason = "could not correlate Salesforce result back to the job: externalId not found in success/failed records (possibly reformatted by Salesforce on store)"
 )

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
@@ -26,9 +26,9 @@ type Uploader struct {
 	apiService          APIServiceInterface
 	externalIDToJobID   map[string][]int64
 	destination         *backendconfig.DestinationT
-	payloadSizeStat     stats.Measurement
-	eventsPerFileStat   stats.Measurement
-	asyncUploadTimeStat stats.Measurement
+	payloadSizeStat     stats.Histogram
+	eventsPerFileStat   stats.Histogram
+	asyncUploadTimeStat stats.Timer
 	config              struct {
 		maxBufferCapacity config.ValueLoader[int64]
 	}
@@ -53,7 +53,7 @@ type apiService struct {
 type SalesforceJobInfo struct {
 	ID string `json:"id"`
 	// ExternalIDField is the upsert key field name. Job statuses are correlated
-	// after polling by hashing this field's value (not the whole row), so that
+	// after polling on this field's value (not the whole row), so that
 	// Salesforce's value coercion on other columns (e.g. datetime millisecond
 	// truncation, number scale) does not break the match.
 	ExternalIDField string `json:"externalIdField"`
@@ -111,9 +111,6 @@ type SalesforceAsyncJob struct {
 const (
 	destName = "SALESFORCE_BULK_UPLOAD"
 
-	// externalIDFieldEmptyReason is returned for the whole batch when the upsert
-	// externalId field name itself could not be resolved.
-	externalIDFieldEmptyReason = "externalId field is empty; cannot correlate poll results back to jobs"
 	// missingExternalIDReason is the abort reason for individual events that
 	// carry no externalId value (no upsert key).
 	missingExternalIDReason = "externalId is missing for the event; cannot upsert to Salesforce"

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
@@ -24,7 +24,6 @@ type Uploader struct {
 	logger              logger.Logger
 	statsFactory        stats.Stats
 	apiService          APIServiceInterface
-	externalIDToJobID   map[string][]int64
 	destination         *backendconfig.DestinationT
 	payloadSizeStat     stats.Histogram
 	eventsPerFileStat   stats.Histogram
@@ -108,15 +107,27 @@ type SalesforceAsyncJob struct {
 	Metadata SalesforceJobMetadata `json:"metadata"`
 }
 
+// importingMetadata is the per-job metadata persisted on the importing job
+// status params (JobImportingParameters). It lets us rebuild the externalId →
+// jobID correlation at poll time from the DB, without any in-memory state or
+// reading the job payload. We store the SHA-256 hash (not the raw externalId)
+// because the externalId is often PII (e.g. an email); correlation re-hashes the
+// Salesforce-returned externalId to match.
+type importingMetadata struct {
+	ExternalIDHash string `json:"externalIdHash"`
+}
+
 const (
 	destName = "SALESFORCE_BULK_UPLOAD"
 
 	// missingExternalIDReason is the abort reason for individual events that
 	// carry no externalId value (no upsert key).
 	missingExternalIDReason = "externalId is missing for the event; cannot upsert to Salesforce"
-	// emptyCorrelationMapReason keeps jobs retryable when the in-memory map is
-	// gone (e.g. a process restart between Upload and GetUploadStats).
-	emptyCorrelationMapReason = "correlation map is empty (likely a restart between upload and stats); retrying"
+	// noCorrelationMetadataReason aborts jobs when no externalId metadata is
+	// present on the importing job statuses, so none of the Salesforce results
+	// can be correlated back (e.g. pre-change in-flight jobs, or a bug). This is
+	// logged at error level so it can be alerted on.
+	noCorrelationMetadataReason = "no externalId correlation metadata found on the importing job; cannot correlate Salesforce result"
 	// resultCorrelationFailedReason aborts jobs whose externalId did not come
 	// back in the Salesforce success/failed records (e.g. reformatted on store).
 	resultCorrelationFailedReason = "could not correlate Salesforce result back to the job: externalId not found in success/failed records (possibly reformatted by Salesforce on store)"

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
@@ -48,8 +48,12 @@ type apiService struct {
 }
 
 type SalesforceJobInfo struct {
-	ID      string   `json:"id"`
-	Headers []string `json:"headers"`
+	ID string `json:"id"`
+	// ExternalIDField is the upsert key field name. Job statuses are correlated
+	// after polling by hashing this field's value (not the whole row), so that
+	// Salesforce's value coercion on other columns (e.g. datetime millisecond
+	// truncation, number scale) does not break the match.
+	ExternalIDField string `json:"externalIdField"`
 }
 
 type JobResponse struct {

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
@@ -20,13 +20,13 @@ const (
 )
 
 type Uploader struct {
-	destName        string
-	logger          logger.Logger
-	statsFactory    stats.Stats
-	apiService      APIServiceInterface
-	dataHashToJobID map[string][]int64
-	destination     *backendconfig.DestinationT
-	config          struct {
+	destName          string
+	logger            logger.Logger
+	statsFactory      stats.Stats
+	apiService        APIServiceInterface
+	externalIDToJobID map[string][]int64
+	destination       *backendconfig.DestinationT
+	config            struct {
 		maxBufferCapacity config.ValueLoader[int64]
 	}
 }

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
@@ -97,7 +97,7 @@ type SalesforceExternalID struct {
 type SalesforceJobMetadata struct {
 	JobID           int64                  `json:"job_id"`
 	RudderOperation string                 `json:"rudderOperation"`
-	ExternalID      []SalesforceExternalID `json:"externalId"`
+	ExternalIDs     []SalesforceExternalID `json:"externalId"`
 }
 
 // SalesforceAsyncJob is the typed representation of a transformed event line.
@@ -120,9 +120,6 @@ type importingMetadata struct {
 const (
 	destName = "SALESFORCE_BULK_UPLOAD"
 
-	// missingExternalIDReason is the abort reason for individual events that
-	// carry no externalId value (no upsert key).
-	missingExternalIDReason = "externalId is missing for the event; cannot upsert to Salesforce"
 	// noCorrelationMetadataReason aborts jobs when no externalId metadata is
 	// present on the importing job statuses, so none of the Salesforce results
 	// can be correlated back (e.g. pre-change in-flight jobs, or a bug). This is

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
@@ -20,13 +20,16 @@ const (
 )
 
 type Uploader struct {
-	destName          string
-	logger            logger.Logger
-	statsFactory      stats.Stats
-	apiService        APIServiceInterface
-	externalIDToJobID map[string][]int64
-	destination       *backendconfig.DestinationT
-	config            struct {
+	destName            string
+	logger              logger.Logger
+	statsFactory        stats.Stats
+	apiService          APIServiceInterface
+	externalIDToJobID   map[string][]int64
+	destination         *backendconfig.DestinationT
+	payloadSizeStat     stats.Measurement
+	eventsPerFileStat   stats.Measurement
+	asyncUploadTimeStat stats.Measurement
+	config              struct {
 		maxBufferCapacity config.ValueLoader[int64]
 	}
 }

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/types.go
@@ -83,6 +83,35 @@ type ObjectInfo struct {
 	ExternalIDValue string
 }
 
+// SalesforceExternalID is a single VDM externalId entry (the upsert key spec).
+type SalesforceExternalID struct {
+	ID             string `json:"id"`
+	IdentifierType string `json:"identifierType"`
+	Type           string `json:"type"`
+}
+
+// SalesforceJobMetadata is the metadata this connector's Transform writes for
+// each event and reads back during Upload.
+type SalesforceJobMetadata struct {
+	JobID           int64                  `json:"job_id"`
+	RudderOperation string                 `json:"rudderOperation"`
+	ExternalID      []SalesforceExternalID `json:"externalId"`
+}
+
+// SalesforceAsyncJob is the typed representation of a transformed event line.
+// Message holds the arbitrary traits plus the externalId field/value.
+type SalesforceAsyncJob struct {
+	Message  map[string]any        `json:"message"`
+	Metadata SalesforceJobMetadata `json:"metadata"`
+}
+
 const (
 	destName = "SALESFORCE_BULK_UPLOAD"
+
+	// externalIDFieldEmptyReason is returned for the whole batch when the upsert
+	// externalId field name itself could not be resolved.
+	externalIDFieldEmptyReason = "externalId field is empty; cannot correlate poll results back to jobs"
+	// missingExternalIDReason is the abort reason for individual events that
+	// carry no externalId value (no upsert key).
+	missingExternalIDReason = "externalId is missing for the event; cannot upsert to Salesforce"
 )

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
@@ -1,7 +1,9 @@
 package salesforcebulkupload
 
 import (
+	"crypto/sha256"
 	"encoding/csv"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +16,16 @@ import (
 
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 )
+
+// hashExternalID returns the SHA-256 hex digest of an externalId value. The
+// externalId is often PII (e.g. an email), so we persist only its hash in the
+// importing job status params and correlate by re-hashing the Salesforce-returned
+// externalId at poll time. This is safe because Salesforce returns the upsert key
+// unchanged (its value coercion only affects non-key columns).
+func hashExternalID(externalID string) string {
+	sum := sha256.Sum256([]byte(externalID))
+	return hex.EncodeToString(sum[:])
+}
 
 // countingWriter wraps an io.Writer and tracks the number of bytes written
 // through it, so createCSVFile can report the CSV size without a second stat.
@@ -67,14 +79,14 @@ func createCSVFile(
 	destinationID string,
 	externalIDField string,
 	input []SalesforceAsyncJob,
-) (string, map[string][]int64, int64, error) {
+) (string, int64, error) {
 	if err := os.MkdirAll(CSVDir, 0o755); err != nil {
-		return "", nil, 0, fmt.Errorf("creating CSV directory: %w", err)
+		return "", 0, fmt.Errorf("creating CSV directory: %w", err)
 	}
 	csvFilePath := filepath.Join(CSVDir, fmt.Sprintf("salesforce_%s_%d.csv", destinationID, time.Now().Unix()))
 	csvFile, err := os.Create(csvFilePath)
 	if err != nil {
-		return "", nil, 0, fmt.Errorf("creating CSV file: %w", err)
+		return "", 0, fmt.Errorf("creating CSV file: %w", err)
 	}
 	defer csvFile.Close()
 
@@ -96,7 +108,7 @@ func createCSVFile(
 	sort.Strings(headers)
 
 	if err := writer.Write(headers); err != nil {
-		return "", nil, 0, fmt.Errorf("writing CSV header: %w", err)
+		return "", 0, fmt.Errorf("writing CSV header: %w", err)
 	}
 
 	headerIndex := make(map[string]int, len(headers))
@@ -104,39 +116,33 @@ func createCSVFile(
 		headerIndex[key] = i
 	}
 
-	externalIDIndex, ok := headerIndex[externalIDField]
-	if !ok {
-		return "", nil, 0, fmt.Errorf("externalId field %q not present in job data", externalIDField)
+	// Correlation no longer relies on this file — the externalId → jobID mapping
+	// is rebuilt at poll time from the importing job status params. We only
+	// validate the upsert key column is present so Salesforce can match on it.
+	if _, ok := headerIndex[externalIDField]; !ok {
+		return "", 0, fmt.Errorf("externalId field %q not present in job data", externalIDField)
 	}
 
-	externalIDToJobID := make(map[string][]int64)
 	for _, job := range input {
 		row := make([]string, len(headers))
 		for key, value := range job.Message {
 			if idx, ok := headerIndex[key]; ok {
 				formattedValue, err := common.FormatCSVValue(value)
 				if err != nil {
-					return "", nil, 0, fmt.Errorf("formatting CSV cell %q: %w", key, err)
+					return "", 0, fmt.Errorf("formatting CSV cell %q: %w", key, err)
 				}
 				row[idx] = formattedValue
 			}
 		}
-		jobID := job.Metadata.JobID
 		if err := writer.Write(row); err != nil {
-			return "", nil, 0, fmt.Errorf("writing CSV row: %w", err)
+			return "", 0, fmt.Errorf("writing CSV row: %w", err)
 		}
-		// Correlate on the externalId value alone, not the whole row: Salesforce
-		// coerces other columns on store (datetime ms-truncation, number scale,
-		// ...) so a whole-row key would not survive the round-trip. Events with
-		// an empty externalId are dropped in Upload before reaching here.
-		key := row[externalIDIndex]
-		externalIDToJobID[key] = append(externalIDToJobID[key], jobID)
 	}
 
 	writer.Flush()
 	if err := writer.Error(); err != nil {
-		return "", nil, 0, fmt.Errorf("flushing CSV writer: %w", err)
+		return "", 0, fmt.Errorf("flushing CSV writer: %w", err)
 	}
 
-	return csvFilePath, externalIDToJobID, counter.n, nil
+	return csvFilePath, counter.n, nil
 }

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
@@ -61,6 +61,7 @@ func extractFromVDM(externalIDRaw any) (*ObjectInfo, error) {
 
 func createCSVFile(
 	destinationID string,
+	externalIDField string,
 	input []common.AsyncJob,
 ) (string, []string, map[string][]int64, error) {
 	if err := os.MkdirAll(CSVDir, 0o755); err != nil {
@@ -99,6 +100,11 @@ func createCSVFile(
 		headerIndex[key] = i
 	}
 
+	externalIDIndex, ok := headerIndex[externalIDField]
+	if !ok {
+		return "", nil, nil, fmt.Errorf("externalId field %q not present in job data", externalIDField)
+	}
+
 	dataHashToJobID := make(map[string][]int64)
 	for _, job := range input {
 		row := make([]string, len(headers))
@@ -115,23 +121,17 @@ func createCSVFile(
 		if err := writer.Write(row); err != nil {
 			return "", nil, nil, fmt.Errorf("writing CSV row: %w", err)
 		}
-		hash := calculateHashCode(row)
-		dataHashToJobID[hash] = append(dataHashToJobID[hash], jobID)
+		// Correlate on the externalId value alone, not the whole row: Salesforce
+		// coerces other columns on store (datetime ms-truncation, number scale,
+		// ...) so a whole-row hash would not survive the round-trip.
+		key := calculateHashCode(row[externalIDIndex])
+		dataHashToJobID[key] = append(dataHashToJobID[key], jobID)
 	}
 
 	return csvFilePath, headers, dataHashToJobID, nil
 }
 
-func calculateHashCode(row []string) string {
-	joined := strings.Join(row, ",")
-	hash := sha256.Sum256([]byte(joined))
+func calculateHashCode(value string) string {
+	hash := sha256.Sum256([]byte(value))
 	return fmt.Sprintf("%x", hash)
-}
-
-func calculateHashFromRecord(record map[string]string, csvHeaders []string) string {
-	values := make([]string, 0, len(csvHeaders))
-	for _, header := range csvHeaders {
-		values = append(values, record[header])
-	}
-	return calculateHashCode(values)
 }

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
@@ -1,7 +1,6 @@
 package salesforcebulkupload
 
 import (
-	"crypto/sha256"
 	"encoding/csv"
 	"fmt"
 	"os"
@@ -63,14 +62,14 @@ func createCSVFile(
 	destinationID string,
 	externalIDField string,
 	input []common.AsyncJob,
-) (string, []string, map[string][]int64, error) {
+) (string, map[string][]int64, error) {
 	if err := os.MkdirAll(CSVDir, 0o755); err != nil {
-		return "", nil, nil, fmt.Errorf("creating CSV directory: %w", err)
+		return "", nil, fmt.Errorf("creating CSV directory: %w", err)
 	}
 	csvFilePath := filepath.Join(CSVDir, fmt.Sprintf("salesforce_%s_%d.csv", destinationID, time.Now().Unix()))
 	csvFile, err := os.Create(csvFilePath)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("creating CSV file: %w", err)
+		return "", nil, fmt.Errorf("creating CSV file: %w", err)
 	}
 	defer csvFile.Close()
 
@@ -92,7 +91,7 @@ func createCSVFile(
 	sort.Strings(headers)
 
 	if err := writer.Write(headers); err != nil {
-		return "", nil, nil, fmt.Errorf("writing CSV header: %w", err)
+		return "", nil, fmt.Errorf("writing CSV header: %w", err)
 	}
 
 	headerIndex := make(map[string]int, len(headers))
@@ -102,37 +101,32 @@ func createCSVFile(
 
 	externalIDIndex, ok := headerIndex[externalIDField]
 	if !ok {
-		return "", nil, nil, fmt.Errorf("externalId field %q not present in job data", externalIDField)
+		return "", nil, fmt.Errorf("externalId field %q not present in job data", externalIDField)
 	}
 
-	dataHashToJobID := make(map[string][]int64)
+	externalIDToJobID := make(map[string][]int64)
 	for _, job := range input {
 		row := make([]string, len(headers))
 		for key, value := range job.Message {
 			if idx, ok := headerIndex[key]; ok {
 				formattedValue, err := common.FormatCSVValue(value)
 				if err != nil {
-					return "", nil, nil, fmt.Errorf("formatting CSV cell %q: %w", key, err)
+					return "", nil, fmt.Errorf("formatting CSV cell %q: %w", key, err)
 				}
 				row[idx] = formattedValue
 			}
 		}
 		jobID := int64(job.Metadata["job_id"].(float64))
 		if err := writer.Write(row); err != nil {
-			return "", nil, nil, fmt.Errorf("writing CSV row: %w", err)
+			return "", nil, fmt.Errorf("writing CSV row: %w", err)
 		}
 		// Correlate on the externalId value alone, not the whole row: Salesforce
 		// coerces other columns on store (datetime ms-truncation, number scale,
-		// ...) so a whole-row hash would not survive the round-trip. Events with
+		// ...) so a whole-row key would not survive the round-trip. Events with
 		// an empty externalId are dropped in Upload before reaching here.
-		key := calculateHashCode(row[externalIDIndex])
-		dataHashToJobID[key] = append(dataHashToJobID[key], jobID)
+		key := row[externalIDIndex]
+		externalIDToJobID[key] = append(externalIDToJobID[key], jobID)
 	}
 
-	return csvFilePath, headers, dataHashToJobID, nil
-}
-
-func calculateHashCode(value string) string {
-	hash := sha256.Sum256([]byte(value))
-	return fmt.Sprintf("%x", hash)
+	return csvFilePath, externalIDToJobID, nil
 }

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
@@ -18,11 +18,12 @@ func extractObjectInfo(jobs []SalesforceAsyncJob) (*ObjectInfo, error) {
 	if len(jobs) == 0 {
 		return nil, fmt.Errorf("no jobs to process")
 	}
-	if len(jobs[0].Metadata.ExternalID) == 0 {
+	externalID := jobs[0].Metadata.ExternalID
+	if len(externalID) == 0 {
 		return nil, fmt.Errorf("externalId not found in the first job")
 	}
 
-	objectInfo, err := extractFromVDM(jobs[0].Metadata.ExternalID)
+	objectInfo, err := extractFromVDM(externalID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract object info: %w", err)
 	}

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
@@ -44,7 +44,7 @@ func extractObjectInfo(jobs []SalesforceAsyncJob) (*ObjectInfo, error) {
 	if len(jobs) == 0 {
 		return nil, fmt.Errorf("no jobs to process")
 	}
-	externalID := jobs[0].Metadata.ExternalID
+	externalID := jobs[0].Metadata.ExternalIDs
 	if len(externalID) == 0 {
 		return nil, fmt.Errorf("externalId not found in the first job")
 	}
@@ -67,6 +67,9 @@ func extractFromVDM(externalIDs []SalesforceExternalID) (*ObjectInfo, error) {
 	}
 	if externalID.IdentifierType == "" {
 		return nil, fmt.Errorf("externalId identifierType is required")
+	}
+	if externalID.ID == "" {
+		return nil, fmt.Errorf("externalId id is required")
 	}
 	return &ObjectInfo{
 		ObjectType:      strings.Replace(externalID.Type, "SALESFORCE_BULK_UPLOAD-", "", 1),

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
@@ -123,7 +123,8 @@ func createCSVFile(
 		}
 		// Correlate on the externalId value alone, not the whole row: Salesforce
 		// coerces other columns on store (datetime ms-truncation, number scale,
-		// ...) so a whole-row hash would not survive the round-trip.
+		// ...) so a whole-row hash would not survive the round-trip. Events with
+		// an empty externalId are dropped in Upload before reaching here.
 		key := calculateHashCode(row[externalIDIndex])
 		dataHashToJobID[key] = append(dataHashToJobID[key], jobID)
 	}

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
@@ -14,54 +14,41 @@ import (
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 )
 
-func extractObjectInfo(jobs []common.AsyncJob) (*ObjectInfo, error) {
+func extractObjectInfo(jobs []SalesforceAsyncJob) (*ObjectInfo, error) {
 	if len(jobs) == 0 {
 		return nil, fmt.Errorf("no jobs to process")
 	}
-
-	firstJob := jobs[0]
-
-	externalIDRaw, ok := firstJob.Metadata["externalId"]
-	if !ok {
+	if len(jobs[0].Metadata.ExternalID) == 0 {
 		return nil, fmt.Errorf("externalId not found in the first job")
 	}
 
-	objectInfo, err := extractFromVDM(externalIDRaw)
+	objectInfo, err := extractFromVDM(jobs[0].Metadata.ExternalID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract object info: %w", err)
 	}
 	return objectInfo, nil
 }
 
-func extractFromVDM(externalIDRaw any) (*ObjectInfo, error) {
-	externalIDArray, ok := externalIDRaw.([]any)
-	if !ok || len(externalIDArray) == 0 {
+func extractFromVDM(externalIDs []SalesforceExternalID) (*ObjectInfo, error) {
+	if len(externalIDs) == 0 {
 		return nil, fmt.Errorf("externalId must be an array with at least one element")
 	}
 
-	externalIDMap, ok := externalIDArray[0].(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("externalId[0] must be an object")
-	}
-
-	typeStr, _ := externalIDMap["type"].(string)
-	if typeStr == "" {
+	first := externalIDs[0]
+	if first.Type == "" {
 		return nil, fmt.Errorf("externalId type is required")
 	}
-	objectType := strings.Replace(typeStr, "SALESFORCE_BULK_UPLOAD-", "", 1)
-	identifierType, _ := externalIDMap["identifierType"].(string)
-	identifierValue, _ := externalIDMap["id"].(string)
 	return &ObjectInfo{
-		ObjectType:      objectType,
-		ExternalIDField: identifierType,
-		ExternalIDValue: identifierValue,
+		ObjectType:      strings.Replace(first.Type, "SALESFORCE_BULK_UPLOAD-", "", 1),
+		ExternalIDField: first.IdentifierType,
+		ExternalIDValue: first.ID,
 	}, nil
 }
 
 func createCSVFile(
 	destinationID string,
 	externalIDField string,
-	input []common.AsyncJob,
+	input []SalesforceAsyncJob,
 ) (string, map[string][]int64, error) {
 	if err := os.MkdirAll(CSVDir, 0o755); err != nil {
 		return "", nil, fmt.Errorf("creating CSV directory: %w", err)
@@ -116,7 +103,7 @@ func createCSVFile(
 				row[idx] = formattedValue
 			}
 		}
-		jobID := int64(job.Metadata["job_id"].(float64))
+		jobID := job.Metadata.JobID
 		if err := writer.Write(row); err != nil {
 			return "", nil, fmt.Errorf("writing CSV row: %w", err)
 		}

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
@@ -17,12 +17,12 @@ import (
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 )
 
-// hashExternalID returns the SHA-256 hex digest of an externalId value. The
+// HashExternalID returns the SHA-256 hex digest of an externalId value. The
 // externalId is often PII (e.g. an email), so we persist only its hash in the
 // importing job status params and correlate by re-hashing the Salesforce-returned
 // externalId at poll time. This is safe because Salesforce returns the upsert key
 // unchanged (its value coercion only affects non-key columns).
-func hashExternalID(externalID string) string {
+func HashExternalID(externalID string) string {
 	sum := sha256.Sum256([]byte(externalID))
 	return hex.EncodeToString(sum[:])
 }

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
@@ -3,6 +3,7 @@ package salesforcebulkupload
 import (
 	"encoding/csv"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -13,6 +14,19 @@ import (
 
 	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 )
+
+// countingWriter wraps an io.Writer and tracks the number of bytes written
+// through it, so createCSVFile can report the CSV size without a second stat.
+type countingWriter struct {
+	w io.Writer
+	n int64
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.n += int64(n)
+	return n, err
+}
 
 func extractObjectInfo(jobs []SalesforceAsyncJob) (*ObjectInfo, error) {
 	if len(jobs) == 0 {
@@ -50,19 +64,19 @@ func createCSVFile(
 	destinationID string,
 	externalIDField string,
 	input []SalesforceAsyncJob,
-) (string, map[string][]int64, error) {
+) (string, map[string][]int64, int64, error) {
 	if err := os.MkdirAll(CSVDir, 0o755); err != nil {
-		return "", nil, fmt.Errorf("creating CSV directory: %w", err)
+		return "", nil, 0, fmt.Errorf("creating CSV directory: %w", err)
 	}
 	csvFilePath := filepath.Join(CSVDir, fmt.Sprintf("salesforce_%s_%d.csv", destinationID, time.Now().Unix()))
 	csvFile, err := os.Create(csvFilePath)
 	if err != nil {
-		return "", nil, fmt.Errorf("creating CSV file: %w", err)
+		return "", nil, 0, fmt.Errorf("creating CSV file: %w", err)
 	}
 	defer csvFile.Close()
 
-	writer := csv.NewWriter(csvFile)
-	defer writer.Flush()
+	counter := &countingWriter{w: csvFile}
+	writer := csv.NewWriter(counter)
 
 	headerSet := make(map[string]struct{})
 	for _, job := range input {
@@ -79,7 +93,7 @@ func createCSVFile(
 	sort.Strings(headers)
 
 	if err := writer.Write(headers); err != nil {
-		return "", nil, fmt.Errorf("writing CSV header: %w", err)
+		return "", nil, 0, fmt.Errorf("writing CSV header: %w", err)
 	}
 
 	headerIndex := make(map[string]int, len(headers))
@@ -89,7 +103,7 @@ func createCSVFile(
 
 	externalIDIndex, ok := headerIndex[externalIDField]
 	if !ok {
-		return "", nil, fmt.Errorf("externalId field %q not present in job data", externalIDField)
+		return "", nil, 0, fmt.Errorf("externalId field %q not present in job data", externalIDField)
 	}
 
 	externalIDToJobID := make(map[string][]int64)
@@ -99,14 +113,14 @@ func createCSVFile(
 			if idx, ok := headerIndex[key]; ok {
 				formattedValue, err := common.FormatCSVValue(value)
 				if err != nil {
-					return "", nil, fmt.Errorf("formatting CSV cell %q: %w", key, err)
+					return "", nil, 0, fmt.Errorf("formatting CSV cell %q: %w", key, err)
 				}
 				row[idx] = formattedValue
 			}
 		}
 		jobID := job.Metadata.JobID
 		if err := writer.Write(row); err != nil {
-			return "", nil, fmt.Errorf("writing CSV row: %w", err)
+			return "", nil, 0, fmt.Errorf("writing CSV row: %w", err)
 		}
 		// Correlate on the externalId value alone, not the whole row: Salesforce
 		// coerces other columns on store (datetime ms-truncation, number scale,
@@ -116,5 +130,10 @@ func createCSVFile(
 		externalIDToJobID[key] = append(externalIDToJobID[key], jobID)
 	}
 
-	return csvFilePath, externalIDToJobID, nil
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return "", nil, 0, fmt.Errorf("flushing CSV writer: %w", err)
+	}
+
+	return csvFilePath, externalIDToJobID, counter.n, nil
 }

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils.go
@@ -49,14 +49,17 @@ func extractFromVDM(externalIDs []SalesforceExternalID) (*ObjectInfo, error) {
 		return nil, fmt.Errorf("externalId must be an array with at least one element")
 	}
 
-	first := externalIDs[0]
-	if first.Type == "" {
+	externalID := externalIDs[0]
+	if externalID.Type == "" {
 		return nil, fmt.Errorf("externalId type is required")
 	}
+	if externalID.IdentifierType == "" {
+		return nil, fmt.Errorf("externalId identifierType is required")
+	}
 	return &ObjectInfo{
-		ObjectType:      strings.Replace(first.Type, "SALESFORCE_BULK_UPLOAD-", "", 1),
-		ExternalIDField: first.IdentifierType,
-		ExternalIDValue: first.ID,
+		ObjectType:      strings.Replace(externalID.Type, "SALESFORCE_BULK_UPLOAD-", "", 1),
+		ExternalIDField: externalID.IdentifierType,
+		ExternalIDValue: externalID.ID,
 	}, nil
 }
 

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
@@ -23,7 +23,7 @@ func TestSalesforceBulk_extractObjectInfo(t *testing.T) {
 					Message: map[string]any{"Email": "test@example.com"},
 					Metadata: SalesforceJobMetadata{
 						JobID: 1,
-						ExternalID: []SalesforceExternalID{
+						ExternalIDs: []SalesforceExternalID{
 							{Type: "SALESFORCE_BULK_UPLOAD-Contact", ID: "test@example.com", IdentifierType: "Email"},
 						},
 					},
@@ -42,7 +42,7 @@ func TestSalesforceBulk_extractObjectInfo(t *testing.T) {
 					Message: map[string]any{"Email": "lead@example.com"},
 					Metadata: SalesforceJobMetadata{
 						JobID: 2,
-						ExternalID: []SalesforceExternalID{
+						ExternalIDs: []SalesforceExternalID{
 							{Type: "SALESFORCE_BULK_UPLOAD-Lead", ID: "lead@example.com", IdentifierType: "Email"},
 						},
 					},
@@ -76,7 +76,7 @@ func TestSalesforceBulk_extractObjectInfo(t *testing.T) {
 			jobs: []SalesforceAsyncJob{
 				{
 					Message:  map[string]any{},
-					Metadata: SalesforceJobMetadata{ExternalID: []SalesforceExternalID{}},
+					Metadata: SalesforceJobMetadata{ExternalIDs: []SalesforceExternalID{}},
 				},
 			},
 			wantErr:  true,

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
@@ -132,7 +132,7 @@ func TestSalesforceBulk_createCSVFile(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			csvFilePath, externalIDToJobID, err := createCSVFile(
+			csvFilePath, externalIDToJobID, fileSize, err := createCSVFile(
 				"test-dest-123",
 				"Email",
 				tc.jobs,
@@ -146,8 +146,9 @@ func TestSalesforceBulk_createCSVFile(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, csvFilePath)
 
-			_, err = os.Stat(csvFilePath)
+			info, err := os.Stat(csvFilePath)
 			require.NoError(t, err)
+			require.Equal(t, info.Size(), fileSize, "returned size should match the file on disk")
 
 			t.Cleanup(func() {
 				require.NoError(t, os.Remove(csvFilePath))
@@ -171,7 +172,7 @@ func TestSalesforceBulk_createCSVFile_NumericNoScientificNotation(t *testing.T) 
 		},
 	}
 
-	csvFilePath, _, err := createCSVFile("test-dest-numeric", "Email", jobs)
+	csvFilePath, _, _, err := createCSVFile("test-dest-numeric", "Email", jobs)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Remove(csvFilePath) })
 
@@ -208,7 +209,7 @@ func TestSalesforceBulk_createCSVFile_NullValues(t *testing.T) {
 		},
 	}
 
-	csvFilePath, _, err := createCSVFile("test-dest-null", "Email", jobs)
+	csvFilePath, _, _, err := createCSVFile("test-dest-null", "Email", jobs)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Remove(csvFilePath) })
 
@@ -241,7 +242,7 @@ func TestSalesforceBulk_createCSVFile_VaryingFields(t *testing.T) {
 			},
 		}
 
-		csvFilePath, externalIDToJobID, err := createCSVFile(
+		csvFilePath, externalIDToJobID, _, err := createCSVFile(
 			"test-dest",
 			"Email",
 			jobs,

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
@@ -180,7 +180,7 @@ func TestSalesforceBulk_createCSVFile(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			csvFilePath, headers, hashToJobID, err := createCSVFile(
+			csvFilePath, externalIDToJobID, err := createCSVFile(
 				"test-dest-123",
 				"Email",
 				tc.jobs,
@@ -193,7 +193,6 @@ func TestSalesforceBulk_createCSVFile(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotEmpty(t, csvFilePath)
-			require.NotEmpty(t, headers)
 
 			_, err = os.Stat(csvFilePath)
 			require.NoError(t, err)
@@ -202,46 +201,9 @@ func TestSalesforceBulk_createCSVFile(t *testing.T) {
 				require.NoError(t, os.Remove(csvFilePath))
 			})
 
-			require.Len(t, hashToJobID, tc.expectedInserted)
+			require.Len(t, externalIDToJobID, tc.expectedInserted)
 		})
 	}
-}
-
-func TestSalesforceBulk_calculateHashCode(t *testing.T) {
-	t.Run("upload key and result key match for the same externalId, regardless of other columns", func(t *testing.T) {
-		t.Parallel()
-
-		// What we sent: the row keyed only on the externalId (Email) value.
-		uploadKey := calculateHashCode("integration@example.com")
-
-		// What Salesforce returns: the externalId round-trips unchanged even
-		// though the CreatedDate column was truncated from microseconds to
-		// milliseconds on store.
-		resultRecord := map[string]string{
-			"Email":       "integration@example.com",
-			"CreatedDate": "2025-11-25T03:45:21.142Z", // sent .14287Z, stored .142Z
-			"sf__Id":      "003xx000006TmiQCCU",
-			"sf__Created": "true",
-		}
-		resultKey := calculateHashCode(resultRecord["Email"])
-
-		require.Equal(t, uploadKey, resultKey,
-			"externalId-based key must survive Salesforce coercion of other columns")
-	})
-
-	t.Run("different externalIds produce different keys", func(t *testing.T) {
-		t.Parallel()
-		require.NotEqual(t,
-			calculateHashCode("user1@example.com"),
-			calculateHashCode("user2@example.com"),
-		)
-	})
-
-	t.Run("consistent across calls and never empty", func(t *testing.T) {
-		t.Parallel()
-		require.NotEmpty(t, calculateHashCode("a@b.com"))
-		require.Equal(t, calculateHashCode("a@b.com"), calculateHashCode("a@b.com"))
-	})
 }
 
 func TestSalesforceBulk_createCSVFile_NumericNoScientificNotation(t *testing.T) {
@@ -257,7 +219,7 @@ func TestSalesforceBulk_createCSVFile_NumericNoScientificNotation(t *testing.T) 
 		},
 	}
 
-	csvFilePath, _, _, err := createCSVFile("test-dest-numeric", "Email", jobs)
+	csvFilePath, _, err := createCSVFile("test-dest-numeric", "Email", jobs)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Remove(csvFilePath) })
 
@@ -294,7 +256,7 @@ func TestSalesforceBulk_createCSVFile_NullValues(t *testing.T) {
 		},
 	}
 
-	csvFilePath, _, _, err := createCSVFile("test-dest-null", "Email", jobs)
+	csvFilePath, _, err := createCSVFile("test-dest-null", "Email", jobs)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Remove(csvFilePath) })
 
@@ -339,7 +301,7 @@ func TestSalesforceBulk_createCSVFile_VaryingFields(t *testing.T) {
 			},
 		}
 
-		csvFilePath, headers, hashToJobID, err := createCSVFile(
+		csvFilePath, externalIDToJobID, err := createCSVFile(
 			"test-dest",
 			"Email",
 			jobs,
@@ -348,12 +310,7 @@ func TestSalesforceBulk_createCSVFile_VaryingFields(t *testing.T) {
 		require.NoError(t, err)
 		defer os.Remove(csvFilePath)
 
-		require.Len(t, hashToJobID, 3)
-		require.Contains(t, headers, "Email")
-		require.Contains(t, headers, "FirstName")
-		require.Contains(t, headers, "LastName")
-		require.Contains(t, headers, "Phone")
-		require.Contains(t, headers, "Company")
+		require.Len(t, externalIDToJobID, 3)
 
 		file, err := os.Open(csvFilePath)
 		require.NoError(t, err)
@@ -366,6 +323,11 @@ func TestSalesforceBulk_createCSVFile_VaryingFields(t *testing.T) {
 
 		headerRow := records[0]
 		require.Len(t, headerRow, 5)
+		require.Contains(t, headerRow, "Email")
+		require.Contains(t, headerRow, "FirstName")
+		require.Contains(t, headerRow, "LastName")
+		require.Contains(t, headerRow, "Phone")
+		require.Contains(t, headerRow, "Company")
 
 		for i, row := range records[1:] {
 			require.Len(t, row, 5, "Row %d should have 5 columns", i+1)

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
@@ -182,6 +182,7 @@ func TestSalesforceBulk_createCSVFile(t *testing.T) {
 			t.Parallel()
 			csvFilePath, headers, hashToJobID, err := createCSVFile(
 				"test-dest-123",
+				"Email",
 				tc.jobs,
 			)
 
@@ -207,161 +208,39 @@ func TestSalesforceBulk_createCSVFile(t *testing.T) {
 }
 
 func TestSalesforceBulk_calculateHashCode(t *testing.T) {
-	testCases := []struct {
-		name     string
-		row      []string
-		expected string
-	}{
-		{
-			name:     "simple row",
-			row:      []string{"test@example.com", "John", "Doe"},
-			expected: calculateHashCode([]string{"test@example.com", "John", "Doe"}),
-		},
-		{
-			name:     "empty row",
-			row:      []string{},
-			expected: calculateHashCode([]string{}),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			result := calculateHashCode(tc.row)
-
-			require.NotEmpty(t, result)
-			require.Equal(t, tc.expected, result)
-		})
-	}
-}
-
-func TestSalesforceBulk_calculateHashFromRecord(t *testing.T) {
-	testCases := []struct {
-		name        string
-		record      map[string]string
-		csvHeaders  []string
-		expected    string
-		shouldMatch bool
-		compareWith []string
-	}{
-		{
-			name: "match original CSV row - ignores Salesforce columns",
-			record: map[string]string{
-				"Email":       "test@example.com",
-				"FirstName":   "John",
-				"LastName":    "Doe",
-				"sf__Id":      "003xx000004TmiQAAS",
-				"sf__Created": "true",
-				"sf__Error":   "",
-			},
-			csvHeaders:  []string{"Email", "FirstName", "LastName"},
-			shouldMatch: true,
-			compareWith: []string{"test@example.com", "John", "Doe"},
-		},
-		{
-			name: "handles user's sf__ fields correctly",
-			record: map[string]string{
-				"Email":             "user@example.com",
-				"sf__AccountStatus": "Active",
-				"FirstName":         "Jane",
-				"sf__Id":            "003xx000005TmiQBBT",
-			},
-			csvHeaders:  []string{"Email", "FirstName", "sf__AccountStatus"},
-			shouldMatch: true,
-			compareWith: []string{"user@example.com", "Jane", "Active"},
-		},
-		{
-			name: "consistent hash with sorted headers",
-			record: map[string]string{
-				"LastName":  "Smith",
-				"Email":     "smith@example.com",
-				"FirstName": "Bob",
-			},
-			csvHeaders:  []string{"Email", "FirstName", "LastName"},
-			shouldMatch: true,
-			compareWith: []string{"smith@example.com", "Bob", "Smith"},
-		},
-		{
-			name: "handles missing fields with empty strings",
-			record: map[string]string{
-				"Email":     "partial@example.com",
-				"FirstName": "Only",
-			},
-			csvHeaders:  []string{"Email", "FirstName", "LastName"},
-			shouldMatch: true,
-			compareWith: []string{"partial@example.com", "Only", ""},
-		},
-		{
-			name:        "empty record",
-			record:      map[string]string{},
-			csvHeaders:  []string{"Email", "FirstName"},
-			shouldMatch: true,
-			compareWith: []string{"", ""},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			hash := calculateHashFromRecord(tc.record, tc.csvHeaders)
-
-			require.NotEmpty(t, hash)
-
-			if tc.shouldMatch {
-				expectedHash := calculateHashCode(tc.compareWith)
-				require.Equal(t, expectedHash, hash,
-					"Hash from record should match hash from original CSV values")
-			}
-
-			hash2 := calculateHashFromRecord(tc.record, tc.csvHeaders)
-			require.Equal(t, hash, hash2, "Hash should be consistent across multiple calls")
-		})
-	}
-}
-
-func TestSalesforceBulk_calculateHashFromRecord_Integration(t *testing.T) {
-	t.Run("upload and result matching flow", func(t *testing.T) {
+	t.Run("upload key and result key match for the same externalId, regardless of other columns", func(t *testing.T) {
 		t.Parallel()
 
-		csvHeaders := []string{"Email", "FirstName", "LastName"}
-		uploadRow := []string{"integration@example.com", "Test", "User"}
-		uploadHash := calculateHashCode(uploadRow)
+		// What we sent: the row keyed only on the externalId (Email) value.
+		uploadKey := calculateHashCode("integration@example.com")
 
-		salesforceResult := map[string]string{
+		// What Salesforce returns: the externalId round-trips unchanged even
+		// though the CreatedDate column was truncated from microseconds to
+		// milliseconds on store.
+		resultRecord := map[string]string{
 			"Email":       "integration@example.com",
-			"FirstName":   "Test",
-			"LastName":    "User",
+			"CreatedDate": "2025-11-25T03:45:21.142Z", // sent .14287Z, stored .142Z
 			"sf__Id":      "003xx000006TmiQCCU",
 			"sf__Created": "true",
-			"sf__Error":   "",
 		}
-		resultHash := calculateHashFromRecord(salesforceResult, csvHeaders)
+		resultKey := calculateHashCode(resultRecord["Email"])
 
-		require.Equal(t, uploadHash, resultHash,
-			"Upload hash and result hash should match for same data")
+		require.Equal(t, uploadKey, resultKey,
+			"externalId-based key must survive Salesforce coercion of other columns")
 	})
 
-	t.Run("different data produces different hashes", func(t *testing.T) {
+	t.Run("different externalIds produce different keys", func(t *testing.T) {
 		t.Parallel()
+		require.NotEqual(t,
+			calculateHashCode("user1@example.com"),
+			calculateHashCode("user2@example.com"),
+		)
+	})
 
-		csvHeaders := []string{"Email", "FirstName"}
-
-		record1 := map[string]string{
-			"Email":     "user1@example.com",
-			"FirstName": "User",
-		}
-		record2 := map[string]string{
-			"Email":     "user2@example.com",
-			"FirstName": "User",
-		}
-
-		hash1 := calculateHashFromRecord(record1, csvHeaders)
-		hash2 := calculateHashFromRecord(record2, csvHeaders)
-
-		require.NotEqual(t, hash1, hash2,
-			"Different records should produce different hashes")
+	t.Run("consistent across calls and never empty", func(t *testing.T) {
+		t.Parallel()
+		require.NotEmpty(t, calculateHashCode("a@b.com"))
+		require.Equal(t, calculateHashCode("a@b.com"), calculateHashCode("a@b.com"))
 	})
 }
 
@@ -378,7 +257,7 @@ func TestSalesforceBulk_createCSVFile_NumericNoScientificNotation(t *testing.T) 
 		},
 	}
 
-	csvFilePath, _, _, err := createCSVFile("test-dest-numeric", jobs)
+	csvFilePath, _, _, err := createCSVFile("test-dest-numeric", "Email", jobs)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Remove(csvFilePath) })
 
@@ -415,7 +294,7 @@ func TestSalesforceBulk_createCSVFile_NullValues(t *testing.T) {
 		},
 	}
 
-	csvFilePath, _, _, err := createCSVFile("test-dest-null", jobs)
+	csvFilePath, _, _, err := createCSVFile("test-dest-null", "Email", jobs)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Remove(csvFilePath) })
 
@@ -462,6 +341,7 @@ func TestSalesforceBulk_createCSVFile_VaryingFields(t *testing.T) {
 
 		csvFilePath, headers, hashToJobID, err := createCSVFile(
 			"test-dest",
+			"Email",
 			jobs,
 		)
 

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
@@ -132,7 +132,7 @@ func TestSalesforceBulk_createCSVFile(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			csvFilePath, externalIDToJobID, fileSize, err := createCSVFile(
+			csvFilePath, fileSize, err := createCSVFile(
 				"test-dest-123",
 				"Email",
 				tc.jobs,
@@ -153,8 +153,6 @@ func TestSalesforceBulk_createCSVFile(t *testing.T) {
 			t.Cleanup(func() {
 				require.NoError(t, os.Remove(csvFilePath))
 			})
-
-			require.Len(t, externalIDToJobID, tc.expectedInserted)
 		})
 	}
 }
@@ -172,7 +170,7 @@ func TestSalesforceBulk_createCSVFile_NumericNoScientificNotation(t *testing.T) 
 		},
 	}
 
-	csvFilePath, _, _, err := createCSVFile("test-dest-numeric", "Email", jobs)
+	csvFilePath, _, err := createCSVFile("test-dest-numeric", "Email", jobs)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Remove(csvFilePath) })
 
@@ -209,7 +207,7 @@ func TestSalesforceBulk_createCSVFile_NullValues(t *testing.T) {
 		},
 	}
 
-	csvFilePath, _, _, err := createCSVFile("test-dest-null", "Email", jobs)
+	csvFilePath, _, err := createCSVFile("test-dest-null", "Email", jobs)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.Remove(csvFilePath) })
 
@@ -242,7 +240,7 @@ func TestSalesforceBulk_createCSVFile_VaryingFields(t *testing.T) {
 			},
 		}
 
-		csvFilePath, externalIDToJobID, _, err := createCSVFile(
+		csvFilePath, _, err := createCSVFile(
 			"test-dest",
 			"Email",
 			jobs,
@@ -250,8 +248,6 @@ func TestSalesforceBulk_createCSVFile_VaryingFields(t *testing.T) {
 
 		require.NoError(t, err)
 		defer os.Remove(csvFilePath)
-
-		require.Len(t, externalIDToJobID, 3)
 
 		file, err := os.Open(csvFilePath)
 		require.NoError(t, err)

--- a/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
+++ b/router/batchrouter/asyncdestinationmanager/salesforce-bulk-upload/utils_test.go
@@ -6,33 +6,25 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
 )
 
 func TestSalesforceBulk_extractObjectInfo(t *testing.T) {
 	testCases := []struct {
 		name     string
-		jobs     []common.AsyncJob
+		jobs     []SalesforceAsyncJob
 		expected *ObjectInfo
 		wantErr  bool
 		errorMsg string
 	}{
 		{
 			name: "valid externalId with Contact object",
-			jobs: []common.AsyncJob{
+			jobs: []SalesforceAsyncJob{
 				{
-					Message: map[string]any{
-						"Email": "test@example.com",
-					},
-					Metadata: map[string]any{
-						"job_id": float64(1),
-						"externalId": []any{
-							map[string]any{
-								"type":           "SALESFORCE_BULK_UPLOAD-Contact",
-								"id":             "test@example.com",
-								"identifierType": "Email",
-							},
+					Message: map[string]any{"Email": "test@example.com"},
+					Metadata: SalesforceJobMetadata{
+						JobID: 1,
+						ExternalID: []SalesforceExternalID{
+							{Type: "SALESFORCE_BULK_UPLOAD-Contact", ID: "test@example.com", IdentifierType: "Email"},
 						},
 					},
 				},
@@ -45,19 +37,13 @@ func TestSalesforceBulk_extractObjectInfo(t *testing.T) {
 		},
 		{
 			name: "valid externalId with Lead object",
-			jobs: []common.AsyncJob{
+			jobs: []SalesforceAsyncJob{
 				{
-					Message: map[string]any{
-						"Email": "lead@example.com",
-					},
-					Metadata: map[string]any{
-						"job_id": float64(2),
-						"externalId": []any{
-							map[string]any{
-								"type":           "SALESFORCE_BULK_UPLOAD-Lead",
-								"id":             "lead@example.com",
-								"identifierType": "Email",
-							},
+					Message: map[string]any{"Email": "lead@example.com"},
+					Metadata: SalesforceJobMetadata{
+						JobID: 2,
+						ExternalID: []SalesforceExternalID{
+							{Type: "SALESFORCE_BULK_UPLOAD-Lead", ID: "lead@example.com", IdentifierType: "Email"},
 						},
 					},
 				},
@@ -70,20 +56,16 @@ func TestSalesforceBulk_extractObjectInfo(t *testing.T) {
 		},
 		{
 			name:     "empty jobs array",
-			jobs:     []common.AsyncJob{},
+			jobs:     []SalesforceAsyncJob{},
 			wantErr:  true,
 			errorMsg: "no jobs to process",
 		},
 		{
-			name: "missing externalId - falls back to config",
-			jobs: []common.AsyncJob{
+			name: "missing externalId",
+			jobs: []SalesforceAsyncJob{
 				{
-					Message: map[string]any{
-						"Email": "test@example.com",
-					},
-					Metadata: map[string]any{
-						"job_id": float64(3),
-					},
+					Message:  map[string]any{"Email": "test@example.com"},
+					Metadata: SalesforceJobMetadata{JobID: 3},
 				},
 			},
 			wantErr:  true,
@@ -91,16 +73,14 @@ func TestSalesforceBulk_extractObjectInfo(t *testing.T) {
 		},
 		{
 			name: "empty externalId array",
-			jobs: []common.AsyncJob{
+			jobs: []SalesforceAsyncJob{
 				{
-					Message: map[string]any{},
-					Metadata: map[string]any{
-						"externalId": []any{},
-					},
+					Message:  map[string]any{},
+					Metadata: SalesforceJobMetadata{ExternalID: []SalesforceExternalID{}},
 				},
 			},
 			wantErr:  true,
-			errorMsg: "at least one element",
+			errorMsg: "externalId not found in the first job",
 		},
 	}
 
@@ -128,51 +108,23 @@ func TestSalesforceBulk_extractObjectInfo(t *testing.T) {
 func TestSalesforceBulk_createCSVFile(t *testing.T) {
 	testCases := []struct {
 		name             string
-		jobs             []common.AsyncJob
+		jobs             []SalesforceAsyncJob
 		expectedInserted int
-		expectedOverflow int
 		wantErr          bool
 	}{
 		{
 			name: "create CSV with valid jobs",
-			jobs: []common.AsyncJob{
+			jobs: []SalesforceAsyncJob{
 				{
-					Message: map[string]any{
-						"Email":     "test1@example.com",
-						"FirstName": "John",
-						"LastName":  "Doe",
-					},
-					Metadata: map[string]any{
-						"job_id": float64(1),
-						"externalId": []any{
-							map[string]any{
-								"type":           "SALESFORCE_BULK_UPLOAD-Contact",
-								"id":             "test1@example.com",
-								"identifierType": "Email",
-							},
-						},
-					},
+					Message:  map[string]any{"Email": "test1@example.com", "FirstName": "John", "LastName": "Doe"},
+					Metadata: SalesforceJobMetadata{JobID: 1},
 				},
 				{
-					Message: map[string]any{
-						"Email":     "test2@example.com",
-						"FirstName": "Jane",
-						"LastName":  "Smith",
-					},
-					Metadata: map[string]any{
-						"job_id": float64(2),
-						"externalId": []any{
-							map[string]any{
-								"type":           "SALESFORCE_BULK_UPLOAD-Contact",
-								"id":             "test2@example.com",
-								"identifierType": "Email",
-							},
-						},
-					},
+					Message:  map[string]any{"Email": "test2@example.com", "FirstName": "Jane", "LastName": "Smith"},
+					Metadata: SalesforceJobMetadata{JobID: 2},
 				},
 			},
 			expectedInserted: 2,
-			expectedOverflow: 0,
 			wantErr:          false,
 		},
 	}
@@ -208,14 +160,14 @@ func TestSalesforceBulk_createCSVFile(t *testing.T) {
 
 func TestSalesforceBulk_createCSVFile_NumericNoScientificNotation(t *testing.T) {
 	t.Parallel()
-	jobs := []common.AsyncJob{
+	jobs := []SalesforceAsyncJob{
 		{
 			Message: map[string]any{
 				"Email":          "user@example.com",
 				"Account_Number": float64(1234567890),
 				"Account_IDs":    []any{float64(1234567890), float64(9876543210)},
 			},
-			Metadata: map[string]any{"job_id": float64(1)},
+			Metadata: SalesforceJobMetadata{JobID: 1},
 		},
 	}
 
@@ -235,7 +187,7 @@ func TestSalesforceBulk_createCSVFile_NumericNoScientificNotation(t *testing.T) 
 }
 
 func TestSalesforceBulk_createCSVFile_NullValues(t *testing.T) {
-	jobs := []common.AsyncJob{
+	jobs := []SalesforceAsyncJob{
 		{
 			Message: map[string]any{
 				"Email":     "middle@example.com",
@@ -243,7 +195,7 @@ func TestSalesforceBulk_createCSVFile_NullValues(t *testing.T) {
 				"LastName":  nil,
 				"Phone":     "555-0001",
 			},
-			Metadata: map[string]any{"job_id": float64(1)},
+			Metadata: SalesforceJobMetadata{JobID: 1},
 		},
 		{
 			Message: map[string]any{
@@ -252,7 +204,7 @@ func TestSalesforceBulk_createCSVFile_NullValues(t *testing.T) {
 				"LastName":  "User",
 				"Phone":     nil,
 			},
-			Metadata: map[string]any{"job_id": float64(2)},
+			Metadata: SalesforceJobMetadata{JobID: 2},
 		},
 	}
 
@@ -274,30 +226,18 @@ func TestSalesforceBulk_createCSVFile_NullValues(t *testing.T) {
 
 func TestSalesforceBulk_createCSVFile_VaryingFields(t *testing.T) {
 	t.Run("jobs with different fields get union of all fields in CSV", func(t *testing.T) {
-		jobs := []common.AsyncJob{
+		jobs := []SalesforceAsyncJob{
 			{
-				Message: map[string]any{
-					"Email":     "user1@example.com",
-					"FirstName": "John",
-				},
-				Metadata: map[string]any{"job_id": float64(1)},
+				Message:  map[string]any{"Email": "user1@example.com", "FirstName": "John"},
+				Metadata: SalesforceJobMetadata{JobID: 1},
 			},
 			{
-				Message: map[string]any{
-					"Email":    "user2@example.com",
-					"LastName": "Smith",
-					"Phone":    "555-1234",
-				},
-				Metadata: map[string]any{"job_id": float64(2)},
+				Message:  map[string]any{"Email": "user2@example.com", "LastName": "Smith", "Phone": "555-1234"},
+				Metadata: SalesforceJobMetadata{JobID: 2},
 			},
 			{
-				Message: map[string]any{
-					"Email":     "user3@example.com",
-					"FirstName": "Jane",
-					"LastName":  "Doe",
-					"Company":   "Acme Inc",
-				},
-				Metadata: map[string]any{"job_id": float64(3)},
+				Message:  map[string]any{"Email": "user3@example.com", "FirstName": "Jane", "LastName": "Doe", "Company": "Acme Inc"},
+				Metadata: SalesforceJobMetadata{JobID: 3},
 			},
 		}
 

--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -745,6 +746,29 @@ func (brt *Handle) setMultipleJobStatus(params setMultipleJobStatusParams) {
 				DestinationID: params.AsyncOutput.DestinationID,
 				SourceID:      gjson.GetBytes(jobParameters, "source_id").String(),
 			}
+			// Persist per-job metadata (e.g. the externalId) in the stored status
+			// Parameters, so it can be read back at poll time without loading the
+			// job payload or relying on any in-memory state. Example shape:
+			// {
+			//   "importId": {"id": "750Ie000003ZFLSIA4", "externalIdField": "Email"},
+			//   "importCount": 3,
+			//   "metadata": {"externalIdHash": "<sha256 hex of the externalId>"}
+			// }
+			statusParameters := params.AsyncOutput.ImportingParameters
+			if jobImportingParameters, ok := params.AsyncOutput.JobImportingParameters[jobId]; ok {
+				// copy the shared ImportingParameters before mutating, so each job's
+				// metadata does not leak into the others
+				base := append([]byte(nil), params.AsyncOutput.ImportingParameters...)
+				if merged, setErr := sjson.SetBytes(base, "metadata", jobImportingParameters); setErr != nil {
+					brt.logger.Errorn("[Batch Router] Failed to persist per-job importing metadata on status params",
+						obskit.DestinationType(brt.destType),
+						logger.NewIntField("jobId", jobId),
+						obskit.Error(setErr),
+					)
+				} else {
+					statusParameters = merged
+				}
+			}
 			status := jobsdb.JobStatusT{
 				JobID:         jobId,
 				JobState:      jobsdb.Importing.State,
@@ -753,7 +777,7 @@ func (brt *Handle) setMultipleJobStatus(params setMultipleJobStatusParams) {
 				RetryTime:     time.Now(),
 				ErrorCode:     "200",
 				ErrorResponse: routerutils.EnhanceJsonWithTime(params.FirstAttemptedAts[jobId], "firstAttemptedAt", routerutils.EmptyPayload),
-				Parameters:    params.AsyncOutput.ImportingParameters,
+				Parameters:    statusParameters,
 				JobParameters: jobParameters,
 				WorkspaceId:   workspaceID,
 				PartitionID:   params.PartitionIDs[jobId],

--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -1,6 +1,7 @@
 package batchrouter
 
 import (
+	"bytes"
 	"context"
 	stdjson "encoding/json"
 	"errors"
@@ -746,24 +747,20 @@ func (brt *Handle) setMultipleJobStatus(params setMultipleJobStatusParams) {
 				DestinationID: params.AsyncOutput.DestinationID,
 				SourceID:      gjson.GetBytes(jobParameters, "source_id").String(),
 			}
-			// Persist per-job metadata (e.g. the externalId) in the stored status
-			// Parameters, so it can be read back at poll time without loading the
-			// job payload or relying on any in-memory state. Example shape:
-			// {
-			//   "importId": {"id": "750Ie000003ZFLSIA4", "externalIdField": "Email"},
-			//   "importCount": 3,
-			//   "metadata": {"externalIdHash": "<sha256 hex of the externalId>"}
-			// }
+			// Persist any per-job metadata onto the stored status Parameters, so a
+			// destination can read it back at poll time without loading the job
+			// payload or relying on in-memory state. The metadata shape is
+			// destination-specific.
 			statusParameters := params.AsyncOutput.ImportingParameters
 			if jobImportingParameters, ok := params.AsyncOutput.JobImportingParameters[jobId]; ok {
 				// copy the shared ImportingParameters before mutating, so each job's
 				// metadata does not leak into the others
-				base := append([]byte(nil), params.AsyncOutput.ImportingParameters...)
-				if merged, setErr := sjson.SetBytes(base, "metadata", jobImportingParameters); setErr != nil {
+				base := bytes.Clone(params.AsyncOutput.ImportingParameters)
+				if merged, mergedErr := sjson.SetBytes(base, "metadata", jobImportingParameters); mergedErr != nil {
 					brt.logger.Errorn("[Batch Router] Failed to persist per-job importing metadata on status params",
 						obskit.DestinationType(brt.destType),
 						logger.NewIntField("jobId", jobId),
-						obskit.Error(setErr),
+						obskit.Error(mergedErr),
 					)
 				} else {
 					statusParameters = merged

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -189,7 +189,7 @@ func (brt *Handle) Setup(
 func (brt *Handle) setupReloadableVars() {
 	brt.maxFailedCountForJob = config.GetReloadableIntVar(128, 1, "BatchRouter."+brt.destType+".maxFailedCountForJob", "BatchRouter.maxFailedCountForJob")
 	brt.maxFailedCountForSourcesJob = config.GetReloadableIntVar(3, 1, "BatchRouter.RSources."+brt.destType+".maxFailedCountForJob", "BatchRouter.RSources.maxFailedCountForJob")
-	brt.asyncUploadTimeout = config.GetReloadableDurationVar(5, time.Second, "BatchRouter."+brt.destType+".asyncUploadTimeout", "BatchRouter.asyncUploadTimeout")
+	brt.asyncUploadTimeout = config.GetReloadableDurationVar(30, time.Minute, "BatchRouter."+brt.destType+".asyncUploadTimeout", "BatchRouter.asyncUploadTimeout")
 	brt.asyncUploadWorkerTimeout = config.GetReloadableDurationVar(10, time.Second, "BatchRouter."+brt.destType+".asyncUploadWorkerTimeout", "BatchRouter.asyncUploadWorkerTimeout")
 	brt.retryTimeWindow = config.GetReloadableDurationVar(180, time.Minute, "BatchRouter."+brt.destType+".retryTimeWindow", "BatchRouter."+brt.destType+".retryTimeWindowInMins", "BatchRouter.retryTimeWindow", "BatchRouter.retryTimeWindowInMins")
 	brt.sourcesRetryTimeWindow = config.GetReloadableDurationVar(1, time.Minute, "BatchRouter.RSources."+brt.destType+".retryTimeWindow", "BatchRouter.RSources."+brt.destType+".retryTimeWindowInMins", "BatchRouter.RSources.retryTimeWindow", "BatchRouter.RSources.retryTimeWindowInMins")

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -189,7 +189,7 @@ func (brt *Handle) Setup(
 func (brt *Handle) setupReloadableVars() {
 	brt.maxFailedCountForJob = config.GetReloadableIntVar(128, 1, "BatchRouter."+brt.destType+".maxFailedCountForJob", "BatchRouter.maxFailedCountForJob")
 	brt.maxFailedCountForSourcesJob = config.GetReloadableIntVar(3, 1, "BatchRouter.RSources."+brt.destType+".maxFailedCountForJob", "BatchRouter.RSources.maxFailedCountForJob")
-	brt.asyncUploadTimeout = config.GetReloadableDurationVar(30, time.Minute, "BatchRouter."+brt.destType+".asyncUploadTimeout", "BatchRouter.asyncUploadTimeout")
+	brt.asyncUploadTimeout = config.GetReloadableDurationVar(5, time.Second, "BatchRouter."+brt.destType+".asyncUploadTimeout", "BatchRouter.asyncUploadTimeout")
 	brt.asyncUploadWorkerTimeout = config.GetReloadableDurationVar(10, time.Second, "BatchRouter."+brt.destType+".asyncUploadWorkerTimeout", "BatchRouter.asyncUploadWorkerTimeout")
 	brt.retryTimeWindow = config.GetReloadableDurationVar(180, time.Minute, "BatchRouter."+brt.destType+".retryTimeWindow", "BatchRouter."+brt.destType+".retryTimeWindowInMins", "BatchRouter.retryTimeWindow", "BatchRouter.retryTimeWindowInMins")
 	brt.sourcesRetryTimeWindow = config.GetReloadableDurationVar(1, time.Minute, "BatchRouter.RSources."+brt.destType+".retryTimeWindow", "BatchRouter.RSources."+brt.destType+".retryTimeWindowInMins", "BatchRouter.RSources.retryTimeWindow", "BatchRouter.RSources.retryTimeWindowInMins")

--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -87,7 +87,13 @@ var (
 			float64(1 * bytesize.MB), float64(3 * bytesize.MB), float64(5 * bytesize.MB), float64(10 * bytesize.MB),
 			float64(1 * bytesize.GB),
 		},
-		"events_per_file": {
+		"brt_async_dest_payload_size": {
+			float64(10 * bytesize.B), float64(100 * bytesize.B),
+			float64(1 * bytesize.KB), float64(10 * bytesize.KB), float64(100 * bytesize.KB),
+			float64(1 * bytesize.MB), float64(3 * bytesize.MB), float64(5 * bytesize.MB), float64(10 * bytesize.MB),
+			float64(1 * bytesize.GB),
+		},
+		"brt_async_dest_events_per_file": {
 			1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000,
 		},
 		"backend_config_http_response_size": {

--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -87,6 +87,9 @@ var (
 			float64(1 * bytesize.MB), float64(3 * bytesize.MB), float64(5 * bytesize.MB), float64(10 * bytesize.MB),
 			float64(1 * bytesize.GB),
 		},
+		"events_per_file": {
+			1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000,
+		},
 		"backend_config_http_response_size": {
 			float64(10 * bytesize.B), float64(100 * bytesize.B),
 			float64(1 * bytesize.KB), float64(10 * bytesize.KB), float64(100 * bytesize.KB),


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.28.0

# Description

## Problem
The Salesforce Bulk Upload connector correlated async poll results back to RudderStack jobs using a SHA-256 hash of the **entire CSV row**. Salesforce coerces field values on store — e.g. datetime microsecond→millisecond truncation (`2025-11-25T03:45:21.14287Z` → `…142Z`) and number-scale rounding — so the rows returned in `successfulResults` / `failedResults` are not byte-identical to what was sent, and the hash no longer matches.

This only surfaces on **partially-failed imports** (`NumberRecordsFailed > 0`); fully-successful imports are marked succeeded without any result matching. In a partially-failed import, the successfully-upserted records couldn't be matched, fell into the reconciliation path, were marked retryable (`FailedKeys`), retried, and — because the mismatch is deterministic — eventually **aborted despite landing in Salesforce**. This drove a 100%-failure alert for a customer (INT-6506); the surfaced error was literally the reconciliation reason string *"Input hash is not found in the data hash to job ID map…"*.

## Changes
- **Correlate on the externalId field value** (the upsert key, which round-trips reliably) instead of the whole-row hash — removes sensitivity to Salesforce coercion of every other column. The externalId field name is now persisted in the import parameters (`SalesforceJobInfo.ExternalIDField`, replacing the now-unused `Headers`) so it's available at poll/stats time.
- **Abort deterministic mismatches instead of retrying.** On a genuine match miss the job is aborted rather than marked failed — retrying just re-uploads the same value, triggers the same coercion, and misses again. **Guard:** if the in-memory correlation map is empty (e.g. a process restart between `Upload` and poll), jobs stay retryable so a restart can't mass-abort an in-flight batch.
- **Validation / observability:** fail the upload fast if the externalId field is empty; warn-log when duplicate externalIds collide within a batch.
- Simplify `calculateHashCode` to take a `string`.
- **Tests** updated + added: externalId-based matching (succeeded/aborted), abort-on-mismatch with a populated map, and the empty-map → retry guard.

## Linear Ticket
https://linear.app/rudderstack/issue/INT-6506

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
