### PR TITLE
feat(batchrouter): raise getImportingJobs max iterations and remove payload size limit

### DIFF
--- a/router/batchrouter/handle_async.go
+++ b/router/batchrouter/handle_async.go
@@ -32,7 +32,7 @@ import (
 
 func (brt *Handle) getImportingJobs(ctx context.Context, augmentQueryParams func(*jobsdb.GetQueryParams), limit int) (jobsdb.JobsResult, error) {
 	var jobsResult jobsdb.JobsResult
-	// we need to get all importing jobs based on limit, overcoming dsLimits and payload size limits
+	// we need to get all importing jobs based on limit, overcoming dsLimits (no payload size limit is applied here)
 	var stop bool
 	var moreToken any
 	var iterations int
@@ -43,7 +43,6 @@ func (brt *Handle) getImportingJobs(ctx context.Context, augmentQueryParams func
 		queryParams := jobsdb.GetQueryParams{
 			CustomValFilters: []string{brt.destType},
 			JobsLimit:        jobsLimit,
-			PayloadSizeLimit: brt.adaptiveLimit(brt.payloadLimit.Load()),
 		}
 		augmentQueryParams(&queryParams)
 		r, err := misc.QueryWithRetriesAndNotify(ctx, brt.jobdDBQueryRequestTimeout.Load(), brt.jobdDBMaxRetries.Load(), func(ctx context.Context) (*jobsdb.MoreJobsResult, error) {
@@ -64,6 +63,17 @@ func (brt *Handle) getImportingJobs(ctx context.Context, augmentQueryParams func
 			iterations == maxIterations // or we have reached max iterations
 	}
 	brt.asyncGetImportingIterations.Observe(float64(iterations))
+
+	if iterations == maxIterations {
+		// This is a safeguard against infinite loops and should never be hit under normal
+		// circumstances. If we are here, the loop was cut short by the iteration cap and there
+		// may still be importing jobs left unfetched.
+		brt.logger.Warnn("GetImportingJobs reached the maximum iteration count, importing jobs may have been left unfetched",
+			logger.NewIntField("iterations", int64(iterations)),
+			logger.NewIntField("maxIterations", int64(maxIterations)),
+			obskit.DestinationType(brt.destType),
+		)
+	}
 	return jobsResult, nil
 }
 

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -206,7 +206,7 @@ func (brt *Handle) setupReloadableVars() {
 	brt.warehouseServiceMaxRetryTime = config.GetReloadableDurationVar(3, time.Hour, "BatchRouter.warehouseServiceMaxRetryTime", "BatchRouter.warehouseServiceMaxRetryTimeinHr")
 	brt.datePrefixOverride = config.GetReloadableStringVar("", "BatchRouter.datePrefixOverride")
 	brt.customDatePrefix = config.GetReloadableStringVar("", "BatchRouter.customDatePrefix")
-	brt.maxImportingQueryIterations = config.GetReloadableIntVar(50, 1, "BatchRouter."+brt.destType+".maxImportingQueryIterations", "BatchRouter.maxImportingQueryIterations")
+	brt.maxImportingQueryIterations = config.GetReloadableIntVar(100, 1, "BatchRouter."+brt.destType+".maxImportingQueryIterations", "BatchRouter.maxImportingQueryIterations")
 }
 
 func (brt *Handle) startAsyncDestinationManager() {


### PR DESCRIPTION
# Description

- Remove the payload size limit when fetching importing jobs
- Bump default maxImportingQueryIterations from 50 to 100
- Log a warning when the max iteration safeguard is reached so the pipelines team can be alerted (jobs may have been left unfetched)

## Linear Ticket

- Resolves INT-6463

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
