### PR TITLE
feat(jobsdb): introduce compaction min ds age

### DIFF
--- a/jobsdb/bench/scenario/compaction.go
+++ b/jobsdb/bench/scenario/compaction.go
@@ -144,6 +144,7 @@ func (p *compaction) Run(ctx context.Context) error {
 		p.conf.Set("JobsDB."+tablePrefix+".nonBlockingCompletedDSDrop", s.nonBlockingCompletedDSDrop)
 		p.conf.Set("JobsDB."+tablePrefix+".nonBlockingCompaction", s.nonBlockingCompaction)
 		p.conf.Set("JobsDB."+tablePrefix+".compactionDeferStatusLock", s.compactionDeferStatusLock)
+		p.conf.Set("JobsDB.compactionMinDSAge", "0s")
 
 		// Deterministic addNewDS trigger so we can seed exactly [datasets]
 		// datasets of [jobsPerDataset] jobs each.

--- a/jobsdb/integration_test.go
+++ b/jobsdb/integration_test.go
@@ -590,6 +590,7 @@ func TestJobsDB(t *testing.T) {
 		}
 		prefix := strings.ToLower(rand.String(5))
 		c.Set("JobsDB.jobMinRowsLeftMigrateThreshold", 0.41)
+		c.Set("JobsDB.compactionMinDSAge", "0s") // datasets are compacted right after creation in this test
 		err := jobDB.Setup(ReadWrite, true, prefix)
 		require.NoError(t, err)
 		defer jobDB.TearDown()

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -390,6 +390,12 @@ type Handle struct {
 			jobMinRowsLeftCompactionThreshold config.ValueLoader[float64]
 			compactionLoopSleepDuration       config.ValueLoader[time.Duration]
 			compactionTimeout                 config.ValueLoader[time.Duration]
+			// compactionMinDSAge is the minimum age a partially-processed dataset
+			// (one that needs pairing) must reach before it becomes eligible for
+			// compaction, preventing freshly-created datasets (typically compaction
+			// destinations) from being compacted again right away. Datasets without
+			// a recorded creation time are always considered old enough.
+			compactionMinDSAge config.ValueLoader[time.Duration]
 			// nonBlockingCompletedDSDrop routes datasets with zero pending jobs
 			// through the async dropDSLoop instead of the in-TX postCompactionHandleDS
 			// path, so the drop is compaction-lock-free and does not block concurrent readers.

--- a/jobsdb/jobsdb_compaction.go
+++ b/jobsdb/jobsdb_compaction.go
@@ -1116,7 +1116,10 @@ func computeInsertIdx(beforeIndex, afterIndex string) (string, error) {
 
 // checkIfCompactDS checks when DB is full or DB needs to be compacted.
 // We compact the DB ONCE most of the jobs have been processed (succeeded/aborted)
-// Or when the job_status table gets too big because of lots of retries/failures
+// Or when the job_status table gets too big because of lots of retries/failures.
+// Partially-processed datasets that would need pairing are not eligible until
+// they are at least compactionMinDSAge old, so that freshly-created compaction
+// destinations are not compacted again right away.
 func (jd *Handle) checkIfCompactDS(ds dataSetT, db sqlDbOrTx) (
 	compact, needsPair bool, recordsLeft int, err error,
 ) {
@@ -1128,6 +1131,7 @@ func (jd *Handle) checkIfCompactDS(ds dataSetT, db sqlDbOrTx) (
 	var delCount, totalCount int
 	var oldTerminalJobsExist bool
 	var maxCreatedAt time.Time
+	var tableComment sql.NullString
 
 	query := fmt.Sprintf(
 		`with combinedResult as (
@@ -1135,16 +1139,17 @@ func (jd *Handle) checkIfCompactDS(ds dataSetT, db sqlDbOrTx) (
 			(select count(*) from %[1]q) as totalJobCount,
 			(select count(*) from "v_last_%[2]s" where job_state = ANY($1)) as terminalJobCount,
 			(select created_at from %[1]q order by job_id desc limit 1) as maxCreatedAt,
-			COALESCE((select exec_time < $2 from %[2]q where job_state = ANY($1) order by id asc limit 1), false) as retentionExpired
+			COALESCE((select exec_time < $2 from %[2]q where job_state = ANY($1) order by id asc limit 1), false) as retentionExpired,
+			obj_description('%[1]s'::regclass, 'pg_class') as tableComment
 		)
-		select totalJobCount, terminalJobCount, maxCreatedAt, retentionExpired from combinedResult`,
+		select totalJobCount, terminalJobCount, maxCreatedAt, retentionExpired, tableComment from combinedResult`,
 		ds.JobTable, ds.JobStatusTable)
 
 	if err := db.QueryRow(
 		query,
 		pq.Array(validTerminalStates),
 		time.Now().Add(-1*jd.conf.maxDSRetentionPeriod.Load()),
-	).Scan(&totalCount, &delCount, &maxCreatedAt, &oldTerminalJobsExist); err != nil {
+	).Scan(&totalCount, &delCount, &maxCreatedAt, &oldTerminalJobsExist, &tableComment); err != nil {
 		return false, false, 0, fmt.Errorf("error running check query in %s: %w", ds.JobStatusTable, err)
 	}
 
@@ -1159,6 +1164,15 @@ func (jd *Handle) checkIfCompactDS(ds dataSetT, db sqlDbOrTx) (
 	}
 
 	needsPair = recordsLeft > 0 && float64(recordsLeft) < jd.conf.compaction.jobMinRowsLeftCompactionThreshold.Load()*float64(jd.conf.MaxDSSize.Load())
+
+	// A dataset that needs pairing is skipped while it is younger than
+	// compactionMinDSAge: it is usually a freshly-written compaction destination,
+	// and compacting it again right away would just churn its rows through yet
+	// another dataset. Datasets without a recorded creation time (created before
+	// creation times were introduced) yield a zero time and are never skipped.
+	if needsPair && time.Since(dsCreatedAt(tableComment.String)) < jd.conf.compaction.compactionMinDSAge.Load() {
+		return false, false, recordsLeft, nil
+	}
 
 	if needsPair || recordsLeft == 0 {
 		return true, needsPair, recordsLeft, nil

--- a/jobsdb/jobsdb_compaction_test.go
+++ b/jobsdb/jobsdb_compaction_test.go
@@ -327,6 +327,7 @@ func TestCompaction(t *testing.T) {
 		c := config.New()
 		c.Set("JobsDB.maxDSSize", 1)
 		c.Set("JobsDB.jobMinRowsLeftMigrateThres", 0.2)
+		c.Set("JobsDB.compactionMinDSAge", "0s") // datasets are compacted right after creation in this test
 
 		_ = startPostgres(t)
 
@@ -667,6 +668,7 @@ func TestCompactionMaxDSSizeGuard(t *testing.T) {
 		c := config.New()
 		c.Set("JobsDB.maxDSSize", maxDSSize)
 		c.Set("JobsDB.jobMinRowsLeftMigrateThreshold", threshold)
+		c.Set("JobsDB.compactionMinDSAge", "0s") // datasets are compacted right after creation in this test
 		triggerAddNewDS := make(chan time.Time)
 		jd := &Handle{
 			TriggerAddNewDS:   func() <-chan time.Time { return triggerAddNewDS },
@@ -737,6 +739,109 @@ func TestCompactionMaxDSSizeGuard(t *testing.T) {
 		result, err := jd.getCompactionList(dsList, nil, jd.maintenanceDB())
 		require.NoError(t, err)
 		require.Empty(t, result.compactFrom)
+	})
+}
+
+func TestCompactionMinDSAge(t *testing.T) {
+	_ = startPostgres(t)
+
+	// newJobDB creates a Handle with maxDSSize=10, pair threshold=0.7 and a one-hour compactionMinDSAge.
+	newJobDB := func(t *testing.T) (*Handle, chan time.Time, *config.Config) {
+		t.Helper()
+		c := config.New()
+		c.Set("JobsDB.maxDSSize", 10)
+		c.Set("JobsDB.jobMinRowsLeftMigrateThreshold", 0.7)
+		c.Set("JobsDB.compactionMinDSAge", "1h")
+		triggerAddNewDS := make(chan time.Time)
+		jd := &Handle{
+			TriggerAddNewDS:   func() <-chan time.Time { return triggerAddNewDS },
+			TriggerCompaction: func() <-chan time.Time { return make(chan time.Time) },
+			config:            c,
+		}
+		require.NoError(t, jd.Setup(ReadWrite, true, strings.ToLower(rand.String(5))))
+		t.Cleanup(jd.TearDown)
+		return jd, triggerAddNewDS, c
+	}
+
+	// addDS stores `jobs` with len(jobs)-pending marked as succeeded, then triggers addNewDS.
+	addDS := func(t *testing.T, jd *Handle, trigger chan time.Time, jobs []*JobT, pending int) {
+		t.Helper()
+		require.NoError(t, jd.Store(context.Background(), jobs))
+		if terminal := len(jobs) - pending; terminal > 0 {
+			require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[:terminal], "executing")))
+			require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[:terminal], "succeeded")))
+		}
+		trigger <- time.Now()
+		trigger <- time.Now()
+	}
+
+	t.Run("freshly created datasets needing a pair are skipped until old enough", func(t *testing.T) {
+		jd, trigger, c := newJobDB(t)
+		allJobs := genJobs(defaultWorkspaceID, "test", 30, 1)
+		addDS(t, jd, trigger, allJobs[:10], 3)   // 3 pending < 7 → needsPair
+		addDS(t, jd, trigger, allJobs[10:20], 3) // 3 pending < 7 → needsPair
+		require.NoError(t, jd.Store(context.Background(), allJobs[20:]))
+
+		dsList := jd.getDSListSnapshot()
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxMigrateDSProbe", len(dsList))
+
+		// the jobs table comment should carry the dataset's creation time
+		var comment string
+		require.NoError(t, jd.maintenanceDB().QueryRow(
+			fmt.Sprintf(`SELECT obj_description('%s'::regclass, 'pg_class')`, dsList[0].JobTable),
+		).Scan(&comment))
+		require.WithinDuration(t, time.Now(), dsCreatedAt(comment), time.Minute)
+
+		// both datasets are younger than compactionMinDSAge → nothing to compact
+		result, err := jd.getCompactionList(dsList, nil, jd.maintenanceDB())
+		require.NoError(t, err)
+		require.Empty(t, result.compactFrom)
+
+		// backdate their creation time beyond compactionMinDSAge → both become eligible
+		for _, ds := range dsList[:2] {
+			_, err := jd.maintenanceDB().Exec(fmt.Sprintf(`COMMENT ON TABLE %q IS '%s'`, ds.JobTable, dsCreatedAtComment(time.Now().Add(-2*time.Hour))))
+			require.NoError(t, err)
+		}
+		result, err = jd.getCompactionList(dsList, nil, jd.maintenanceDB())
+		require.NoError(t, err)
+		require.Len(t, result.compactFrom, 2)
+		require.Equal(t, 6, result.pendingJobsCount)
+	})
+
+	t.Run("completed datasets are eligible regardless of age", func(t *testing.T) {
+		jd, trigger, c := newJobDB(t)
+		allJobs := genJobs(defaultWorkspaceID, "test", 20, 1)
+		addDS(t, jd, trigger, allJobs[:10], 0) // fully processed
+		require.NoError(t, jd.Store(context.Background(), allJobs[10:]))
+
+		dsList := jd.getDSListSnapshot()
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxMigrateDSProbe", len(dsList))
+
+		result, err := jd.getCompactionList(dsList, nil, jd.maintenanceDB())
+		require.NoError(t, err)
+		require.Len(t, result.compactFrom, 1)
+		require.Equal(t, 0, result.pendingJobsCount)
+	})
+
+	t.Run("datasets without a recorded creation time are eligible", func(t *testing.T) {
+		jd, trigger, c := newJobDB(t)
+		allJobs := genJobs(defaultWorkspaceID, "test", 30, 1)
+		addDS(t, jd, trigger, allJobs[:10], 3)
+		addDS(t, jd, trigger, allJobs[10:20], 3)
+		require.NoError(t, jd.Store(context.Background(), allJobs[20:]))
+
+		dsList := jd.getDSListSnapshot()
+		c.Set("JobsDB."+jd.tablePrefix+"."+"maxMigrateDSProbe", len(dsList))
+
+		// simulate datasets created before creation times were introduced
+		for _, ds := range dsList[:2] {
+			_, err := jd.maintenanceDB().Exec(fmt.Sprintf(`COMMENT ON TABLE %q IS NULL`, ds.JobTable))
+			require.NoError(t, err)
+		}
+		result, err := jd.getCompactionList(dsList, nil, jd.maintenanceDB())
+		require.NoError(t, err)
+		require.Len(t, result.compactFrom, 2)
+		require.Equal(t, 6, result.pendingJobsCount)
 	})
 }
 

--- a/jobsdb/jobsdb_config.go
+++ b/jobsdb/jobsdb_config.go
@@ -39,6 +39,9 @@ func (jd *Handle) loadConfig() {
 	// less than jobMinRowsLeftCompactionThreshold percent of maxDSSize (e.g. if jobMinRowsLeftCompactionThreshold is 0.5
 	// then DSs that have less than 50% of maxDSSize pending rows are eligible for compaction)
 	jd.conf.compaction.jobMinRowsLeftCompactionThreshold = jd.config.GetReloadableFloat64Var(0.6, jd.configKeys("jobMinRowsLeftCompactionThreshold", "jobMinRowsLeftMigrateThreshold")...)
+	// compactionMinDSAge: a partially-processed DS (one that needs pairing) is not eligible for compaction
+	// until it is at least this old, so that freshly-created compaction destinations are not compacted again right away
+	jd.conf.compaction.compactionMinDSAge = jd.config.GetReloadableDurationVar(2, time.Minute, jd.configKeys("compactionMinDSAge")...)
 	// maxCompactOnce: Maximum number of DSs that are compacted together into one destination
 	jd.conf.compaction.maxCompactOnce = jd.config.GetReloadableIntVar(10, 1, jd.configKeys("maxCompactOnce", "maxMigrateOnce")...)
 	// maxCompactDSProbe: Maximum number of DSs that are checked from left to right if they are eligible for compaction

--- a/jobsdb/jobsdb_dataset_ddl.go
+++ b/jobsdb/jobsdb_dataset_ddl.go
@@ -177,6 +177,12 @@ func (jd *Handle) createDSTablesInTx(ctx context.Context, tx *Tx, newDS dataSetT
 		parameters JSONB DEFAULT '{}'::JSONB);`, newDS.JobStatusTable)); err != nil {
 		return fmt.Errorf("creating %s: %w", newDS.JobStatusTable, err)
 	}
+
+	// Record the dataset's creation time as a comment on the jobs table, so that
+	// compaction can tell how recently a dataset was created (see checkIfCompactDS).
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`COMMENT ON TABLE %q IS '%s'`, newDS.JobTable, dsCreatedAtComment(time.Now()))); err != nil {
+		return fmt.Errorf("commenting creation time on %s: %w", newDS.JobTable, err)
+	}
 	return nil
 }
 

--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/samber/lo"
 
@@ -18,7 +19,32 @@ type sqlDbOrTx interface {
 	QueryRow(query string, args ...any) *sql.Row
 }
 
-const preDropTableComment = "rudder:pre_drop:v1"
+const (
+	preDropTableComment = "rudder:pre_drop:v1"
+	// dsCreatedAtCommentPrefix prefixes the jobs table comment that records the
+	// dataset's creation time in RFC3339 format.
+	dsCreatedAtCommentPrefix = "rudder:created_at:"
+)
+
+// dsCreatedAtComment returns the jobs table comment recording a dataset's creation time.
+func dsCreatedAtComment(createdAt time.Time) string {
+	return dsCreatedAtCommentPrefix + createdAt.UTC().Format(time.RFC3339Nano)
+}
+
+// dsCreatedAt extracts a dataset's creation time from its jobs table comment.
+// It returns the zero time when no creation time is recorded, e.g. for datasets
+// created before creation times were introduced.
+func dsCreatedAt(comment string) time.Time {
+	value, found := strings.CutPrefix(comment, dsCreatedAtCommentPrefix)
+	if !found {
+		return time.Time{}
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return createdAt
+}
 
 // getDSList returns the datasets found in Postgres, ordered by dataset index.
 // Most runtime paths use the in-memory dataset list instead.


### PR DESCRIPTION
## Description

Without a minimum age guard, newly created datasets, whether written by normal ingestion or created as a compaction destination, can be picked up for compaction almost immediately, before workers have had a chance to process all their jobs. This causes premature I/O churn: jobs get moved again with little benefit.

This PR introduces `compactionMinDSAge` (default: `2m`): partially-processed datasets are skipped for compaction until they reach this minimum age, giving workers a processing window before a dataset becomes eligible. The age is read from a creation timestamp stored as a PostgreSQL table comment on each jobs table.

**Fully-processed datasets** and datasets without a recorded creation time **are unaffected**.

**Config:** `JobsDB.compactionMinDSAge` (reloadable)

## Linear Ticket

resolves PIPE-3114

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #7083 
- <kbd>&nbsp;2&nbsp;</kbd> #7082 
- <kbd>&nbsp;1&nbsp;</kbd> #7077 👈 
<!-- GitButler Footer Boundary Bottom -->

