### PR TITLE
chore(jobsdb): new columns for multi-consumer jobsdb

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -205,6 +205,7 @@ type JobStatusT struct {
 	ErrorCode     string          `json:"ErrorCode"`
 	ErrorResponse json.RawMessage `json:"ErrorResponse"`
 	Parameters    json.RawMessage `json:"Parameters"`
+	Consumer      string          `json:"Consumer"`
 	JobParameters json.RawMessage `json:"-"`           // not stored in DB
 	WorkspaceId   string          `json:"WorkspaceId"` // not stored in DB
 	PartitionID   string          `json:"-"`           // not stored in DB
@@ -248,6 +249,7 @@ type JobT struct {
 	Parameters    json.RawMessage `json:"Parameters"`
 	WorkspaceId   string          `json:"WorkspaceId"`
 	PartitionID   string          `json:"PartitionId"`
+	Consumers     []string        `json:"Consumers"`
 }
 
 func (job *JobT) String() string {

--- a/jobsdb/jobsdb_compaction.go
+++ b/jobsdb/jobsdb_compaction.go
@@ -666,8 +666,8 @@ func (jd *Handle) copyJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSe
 	}
 
 	copyQuery := fmt.Sprintf(
-		`insert into %[2]q (job_id,   workspace_id,   uuid,   user_id,   partition_id, custom_val,   parameters,   event_payload,   event_count,   created_at,   expire_at)
-		           (select j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.custom_val, j.parameters, %[4]s, j.event_count, j.created_at, j.expire_at from %[3]q j left join "v_last_%[1]s" js on js.job_id = j.job_id
+		`insert into %[2]q (job_id,   workspace_id,   uuid,   user_id,   partition_id, custom_val,   parameters,   event_payload,   event_count,   created_at,   expire_at,   consumers)
+		           (select j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.custom_val, j.parameters, %[4]s, j.event_count, j.created_at, j.expire_at, j.consumers from %[3]q j left join "v_last_%[1]s" js on js.job_id = j.job_id
 			where js.job_id is null or js.job_state = ANY('{%[5]s}') order by j.job_id)`,
 		srcDS.JobStatusTable,
 		destDS.JobTable,
@@ -689,8 +689,8 @@ func (jd *Handle) copyJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSe
 // copyJobStatusesInTx copies the LATEST status of every job in the destDS (terminal or not) from the srcDS status table to the destDS status table.
 func (jd *Handle) copyJobStatusesInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) error {
 	copyQuery := fmt.Sprintf(
-		`insert into %[2]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters)
-		           (select js.job_id, js.job_state, js.attempt, js.exec_time, js.retry_time, js.error_code, js.error_response, js.parameters from "v_last_%[1]s" js
+		`insert into %[2]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters, consumer)
+		           (select js.job_id, js.job_state, js.attempt, js.exec_time, js.retry_time, js.error_code, js.error_response, js.parameters, js.consumer from "v_last_%[1]s" js
 			where exists (select 1 from %[3]q dj where dj.job_id = js.job_id))`,
 		srcDS.JobStatusTable,
 		destDS.JobStatusTable,
@@ -717,14 +717,14 @@ func (jd *Handle) compactJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dat
 		`with last_status as (select * from "v_last_%[1]s"),
 		inserted_jobs as
 		(
-			insert into %[3]q (job_id,   workspace_id,   uuid,   user_id,   partition_id, custom_val,   parameters,   event_payload,   event_count,   created_at,   expire_at)
-			           (select j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.custom_val, j.parameters, %[6]s, j.event_count, j.created_at, j.expire_at from %[2]q j left join last_status js on js.job_id = j.job_id
+			insert into %[3]q (job_id,   workspace_id,   uuid,   user_id,   partition_id, custom_val,   parameters,   event_payload,   event_count,   created_at,   expire_at,   consumers)
+			           (select j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.custom_val, j.parameters, %[6]s, j.event_count, j.created_at, j.expire_at, j.consumers from %[2]q j left join last_status js on js.job_id = j.job_id
 				where js.job_id is null or js.job_state = ANY('{%[5]s}') order by j.job_id) returning job_id
 		),
 		insertedStatuses as
 		(
-			insert into %[4]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters)
-			           (select job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters from last_status where job_state = ANY('{%[5]s}'))
+			insert into %[4]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters, consumer)
+			           (select job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters, consumer from last_status where job_state = ANY('{%[5]s}'))
 		)
 		select count(*) from inserted_jobs;`,
 		srcDS.JobStatusTable,

--- a/jobsdb/jobsdb_dataset_ddl.go
+++ b/jobsdb/jobsdb_dataset_ddl.go
@@ -161,7 +161,8 @@ func (jd *Handle) createDSTablesInTx(ctx context.Context, tx *Tx, newDS dataSetT
 		event_payload `+string(columnType)+` NOT NULL,
 		event_count INTEGER NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-		expire_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW());`, newDS.JobTable)); err != nil {
+		expire_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+		consumers TEXT[] NOT NULL DEFAULT '{""}');`, newDS.JobTable)); err != nil {
 		return fmt.Errorf("creating %s: %w", newDS.JobTable, err)
 	}
 
@@ -174,7 +175,8 @@ func (jd *Handle) createDSTablesInTx(ctx context.Context, tx *Tx, newDS dataSetT
 		retry_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
 		error_code VARCHAR(32),
 		error_response JSONB DEFAULT '{}'::JSONB,
-		parameters JSONB DEFAULT '{}'::JSONB);`, newDS.JobStatusTable)); err != nil {
+		parameters JSONB DEFAULT '{}'::JSONB,
+		consumer TEXT NOT NULL DEFAULT '');`, newDS.JobStatusTable)); err != nil {
 		return fmt.Errorf("creating %s: %w", newDS.JobStatusTable, err)
 	}
 

--- a/jobsdb/jobsdb_get.go
+++ b/jobsdb/jobsdb_get.go
@@ -359,7 +359,7 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 
 	sqlStatement := fmt.Sprintf(`SELECT
 									jobs.job_id, jobs.uuid, jobs.user_id, jobs.parameters, jobs.custom_val, jobs.event_payload, jobs.event_count,
-									jobs.created_at, jobs.expire_at, jobs.workspace_id, jobs.partition_id,
+									jobs.created_at, jobs.expire_at, jobs.workspace_id, jobs.partition_id, jobs.consumers,
 									octet_length(jobs.event_payload::text) as payload_size,
 									sum(jobs.event_count) over (order by jobs.job_id asc) as running_event_counts,
 									sum(octet_length(jobs.event_payload::text)) over (order by jobs.job_id) as running_payload_size,
@@ -426,7 +426,7 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 		var jsErrorResponse []byte
 		var jsParameters []byte
 		err := rows.Scan(&job.JobID, &job.UUID, &job.UserID, &job.Parameters, &job.CustomVal,
-			&payload, &job.EventCount, &job.CreatedAt, &job.ExpireAt, &job.WorkspaceId, &job.PartitionID, &discardRowPayloadSize, &runningEventCount, &runningPayloadSize,
+			&payload, &job.EventCount, &job.CreatedAt, &job.ExpireAt, &job.WorkspaceId, &job.PartitionID, pq.Array(&job.Consumers), &discardRowPayloadSize, &runningEventCount, &runningPayloadSize,
 			&jsState, &jsAttemptNum,
 			&jsExecTime, &jsRetryTime,
 			&jsErrorCode, &jsErrorResponse, &jsParameters)

--- a/jobsdb/jobsdb_store.go
+++ b/jobsdb/jobsdb_store.go
@@ -136,7 +136,7 @@ func (jd *Handle) doStoreJobsInTx(ctx context.Context, tx *Tx, ds dataSetT, jobL
 		var stmt *sql.Stmt
 		var err error
 
-		stmt, err = tx.PrepareContext(ctx, misc.DBCopyIn(ds.JobTable, "uuid", "user_id", "custom_val", "parameters", "event_payload", "event_count", "workspace_id", "partition_id"))
+		stmt, err = tx.PrepareContext(ctx, misc.DBCopyIn(ds.JobTable, "uuid", "user_id", "custom_val", "parameters", "event_payload", "event_count", "workspace_id", "partition_id", "consumers"))
 		if err != nil {
 			return err
 		}
@@ -148,7 +148,11 @@ func (jd *Handle) doStoreJobsInTx(ctx context.Context, tx *Tx, ds dataSetT, jobL
 			if job.PartitionID == "" && jd.conf.numPartitions > 0 {
 				job.PartitionID = jd.conf.partitionFunction(job)
 			}
-			if _, err = stmt.ExecContext(ctx, job.UUID, job.UserID, job.CustomVal, string(job.Parameters), string(job.EventPayload), eventCount, job.WorkspaceId, job.PartitionID); err != nil {
+			consumers := job.Consumers
+			if len(consumers) == 0 {
+				consumers = []string{""}
+			}
+			if _, err = stmt.ExecContext(ctx, job.UUID, job.UserID, job.CustomVal, string(job.Parameters), string(job.EventPayload), eventCount, job.WorkspaceId, job.PartitionID, pq.Array(consumers)); err != nil {
 				return err
 			}
 		}

--- a/jobsdb/jobsdb_update.go
+++ b/jobsdb/jobsdb_update.go
@@ -221,7 +221,7 @@ func (jd *Handle) updateJobStatusDSInTx(ctx context.Context, tx *Tx, ds dataSetT
 	store := func() error {
 		updatedStates = updateJobStatusStats{} // reset in case of retry
 		stmt, err := tx.PrepareContext(ctx, misc.DBCopyIn(ds.JobStatusTable, "job_id", "job_state", "attempt", "exec_time",
-			"retry_time", "error_code", "error_response", "parameters"))
+			"retry_time", "error_code", "error_response", "parameters", "consumer"))
 		if err != nil {
 			return err
 		}
@@ -275,7 +275,7 @@ func (jd *Handle) updateJobStatusDSInTx(ctx context.Context, tx *Tx, ds dataSetT
 				status.ErrorResponse = []byte(`{}`)
 			}
 			_, err = stmt.ExecContext(ctx, status.JobID, status.JobState, status.AttemptNum, status.ExecTime,
-				status.RetryTime, status.ErrorCode, string(status.ErrorResponse), string(status.Parameters))
+				status.RetryTime, status.ErrorCode, string(status.ErrorResponse), string(status.Parameters), status.Consumer)
 			if err != nil {
 				return err
 			}

--- a/sql/migrations/jobsdb/000014_multi_consumer_columns.up.tmpl
+++ b/sql/migrations/jobsdb/000014_multi_consumer_columns.up.tmpl
@@ -1,0 +1,4 @@
+{{range .Datasets}}
+    ALTER TABLE "{{$.Prefix}}_jobs_{{.}}" ADD COLUMN IF NOT EXISTS consumers TEXT[] NOT NULL DEFAULT '{""}';
+    ALTER TABLE "{{$.Prefix}}_job_status_{{.}}" ADD COLUMN IF NOT EXISTS consumer TEXT NOT NULL DEFAULT '';
+{{end}}

--- a/sql/migrations/jobsdb_always/000016_multi_consumer_columns.up.tmpl
+++ b/sql/migrations/jobsdb_always/000016_multi_consumer_columns.up.tmpl
@@ -1,0 +1,4 @@
+{{range .Datasets}}
+    ALTER TABLE "{{$.Prefix}}_jobs_{{.}}" ADD COLUMN IF NOT EXISTS consumers TEXT[] NOT NULL DEFAULT '{""}';
+    ALTER TABLE "{{$.Prefix}}_job_status_{{.}}" ADD COLUMN IF NOT EXISTS consumer TEXT NOT NULL DEFAULT '';
+{{end}}


### PR DESCRIPTION
## Summary

Adds two new columns to all jobsdb tables (jobs and job_status) as the foundational schema step for multi-consumer jobsdb support:
- `consumers` on jobs tables — tracks which consumers a job is intended for
- `consumer` on job_status tables — identifies which consumer a status row belongs to

Both columns are added universally to all handles (single- and multi-consumer alike), with safe defaults that preserve existing single-consumer semantics. All existing read, write, and compaction paths are updated to carry the new columns through.

## Linear Ticket

Resolves PIPE-3115

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #7096 
- <kbd>&nbsp;4&nbsp;</kbd> #7083 
- <kbd>&nbsp;3&nbsp;</kbd> #7094 
- <kbd>&nbsp;2&nbsp;</kbd> #7093 
- <kbd>&nbsp;1&nbsp;</kbd> #7082 👈 
<!-- GitButler Footer Boundary Bottom -->

