### PR TITLE
feat(jobsdb): multi-consumer-specific datasets, indexes, views and flip

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -205,6 +205,7 @@ type JobStatusT struct {
 	ErrorCode     string          `json:"ErrorCode"`
 	ErrorResponse json.RawMessage `json:"ErrorResponse"`
 	Parameters    json.RawMessage `json:"Parameters"`
+	Consumer      string          `json:"Consumer"`
 	JobParameters json.RawMessage `json:"-"`           // not stored in DB
 	WorkspaceId   string          `json:"WorkspaceId"` // not stored in DB
 	PartitionID   string          `json:"-"`           // not stored in DB
@@ -248,6 +249,7 @@ type JobT struct {
 	Parameters    json.RawMessage `json:"Parameters"`
 	WorkspaceId   string          `json:"WorkspaceId"`
 	PartitionID   string          `json:"PartitionId"`
+	Consumers     []string        `json:"Consumers"`
 }
 
 func (job *JobT) String() string {

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -376,6 +376,7 @@ type Handle struct {
 		numPartitions                   int // if zero or negative, no partitioning
 		partitionFunction               func(job *JobT) string
 		multiConsumer                   bool // if true, enables per-consumer indexes, views, and query paths
+		disallowMultiConsumerDowngrade  bool
 		warnOnStatusMissingPartitionID  config.ValueLoader[bool]
 		holdDSListLockDuringStore       config.ValueLoader[bool] // escape hatch: hold the dsList read lock for the entire store callback
 		staleDSListMaxRetries           config.ValueLoader[int]

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -375,6 +375,7 @@ type Handle struct {
 		MaxDSSize                       config.ValueLoader[int]
 		numPartitions                   int // if zero or negative, no partitioning
 		partitionFunction               func(job *JobT) string
+		multiConsumer                   bool // if true, enables per-consumer indexes, views, and query paths
 		warnOnStatusMissingPartitionID  config.ValueLoader[bool]
 		holdDSListLockDuringStore       config.ValueLoader[bool] // escape hatch: hold the dsList read lock for the entire store callback
 		staleDSListMaxRetries           config.ValueLoader[int]

--- a/jobsdb/jobsdb_compaction.go
+++ b/jobsdb/jobsdb_compaction.go
@@ -666,8 +666,8 @@ func (jd *Handle) copyJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSe
 	}
 
 	copyQuery := fmt.Sprintf(
-		`insert into %[2]q (job_id,   workspace_id,   uuid,   user_id,   partition_id, custom_val,   parameters,   event_payload,   event_count,   created_at,   expire_at)
-		           (select j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.custom_val, j.parameters, %[4]s, j.event_count, j.created_at, j.expire_at from %[3]q j left join "v_last_%[1]s" js on js.job_id = j.job_id
+		`insert into %[2]q (job_id,   workspace_id,   uuid,   user_id,   partition_id, custom_val,   parameters,   event_payload,   event_count,   created_at,   expire_at,   consumers)
+		           (select j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.custom_val, j.parameters, %[4]s, j.event_count, j.created_at, j.expire_at, j.consumers from %[3]q j left join "v_last_%[1]s" js on js.job_id = j.job_id
 			where js.job_id is null or js.job_state = ANY('{%[5]s}') order by j.job_id)`,
 		srcDS.JobStatusTable,
 		destDS.JobTable,
@@ -689,8 +689,8 @@ func (jd *Handle) copyJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSe
 // copyJobStatusesInTx copies the LATEST status of every job in the destDS (terminal or not) from the srcDS status table to the destDS status table.
 func (jd *Handle) copyJobStatusesInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) error {
 	copyQuery := fmt.Sprintf(
-		`insert into %[2]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters)
-		           (select js.job_id, js.job_state, js.attempt, js.exec_time, js.retry_time, js.error_code, js.error_response, js.parameters from "v_last_%[1]s" js
+		`insert into %[2]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters, consumer)
+		           (select js.job_id, js.job_state, js.attempt, js.exec_time, js.retry_time, js.error_code, js.error_response, js.parameters, js.consumer from "v_last_%[1]s" js
 			where exists (select 1 from %[3]q dj where dj.job_id = js.job_id))`,
 		srcDS.JobStatusTable,
 		destDS.JobStatusTable,
@@ -717,14 +717,14 @@ func (jd *Handle) compactJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dat
 		`with last_status as (select * from "v_last_%[1]s"),
 		inserted_jobs as
 		(
-			insert into %[3]q (job_id,   workspace_id,   uuid,   user_id,   partition_id, custom_val,   parameters,   event_payload,   event_count,   created_at,   expire_at)
-			           (select j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.custom_val, j.parameters, %[6]s, j.event_count, j.created_at, j.expire_at from %[2]q j left join last_status js on js.job_id = j.job_id
+			insert into %[3]q (job_id,   workspace_id,   uuid,   user_id,   partition_id, custom_val,   parameters,   event_payload,   event_count,   created_at,   expire_at,   consumers)
+			           (select j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.custom_val, j.parameters, %[6]s, j.event_count, j.created_at, j.expire_at, j.consumers from %[2]q j left join last_status js on js.job_id = j.job_id
 				where js.job_id is null or js.job_state = ANY('{%[5]s}') order by j.job_id) returning job_id
 		),
 		insertedStatuses as
 		(
-			insert into %[4]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters)
-			           (select job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters from last_status where job_state = ANY('{%[5]s}'))
+			insert into %[4]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters, consumer)
+			           (select job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters, consumer from last_status where job_state = ANY('{%[5]s}'))
 		)
 		select count(*) from inserted_jobs;`,
 		srcDS.JobStatusTable,

--- a/jobsdb/jobsdb_config.go
+++ b/jobsdb/jobsdb_config.go
@@ -70,6 +70,7 @@ func (jd *Handle) loadConfig() {
 	// against the cache before querying, and (!ok && !limitsReached) is used as a commit predicate.
 	jd.conf.noResultsCacheStateOptimization = jd.config.GetReloadableBoolVar(false, jd.configKeys("noResultsCacheStateOptimization")...)
 	jd.conf.getJobsUseLateralJoin = jd.config.GetReloadableBoolVar(true, jd.configKeys("getJobsUseLateralJoin")...)
+	jd.conf.disallowMultiConsumerDowngrade = jd.config.GetBoolVar(false, jd.configKeys("disallowMultiConsumerDowngrade")...)
 
 	if jd.TriggerAddNewDS == nil {
 		jd.TriggerAddNewDS = func() <-chan time.Time {

--- a/jobsdb/jobsdb_consumer_test.go
+++ b/jobsdb/jobsdb_consumer_test.go
@@ -96,6 +96,80 @@ func TestMultiConsumerJobsDB_SingleConsumer(t *testing.T) {
 	verifyUnionJobsDBMetadata(t, postgres.DB, prefix, 3)
 }
 
+// TestMultiConsumerJobsDB_ConsumerIsolation verifies that consumer-scoped pickup is isolated:
+// consumer A's terminal status does not hide the job from consumer B, and the GIN membership
+// filter ensures only jobs assigned to the querying consumer are returned.
+func TestMultiConsumerJobsDB_ConsumerIsolation(t *testing.T) {
+	postgres := startPostgres(t)
+
+	c := config.New()
+	c.Set("jobsdb.maxDSSize", 10)
+
+	prefix := strings.ToLower(rand.String(5))
+	jd := NewForReadWrite(prefix,
+		WithDBHandle(postgres.DB),
+		WithConfig(c),
+		WithMultiConsumer(),
+	)
+	require.NoError(t, jd.Start())
+	defer jd.TearDown()
+
+	ctx := context.Background()
+	customVal := "ISO"
+
+	// store one job assigned to both consumers A and B
+	job := &JobT{
+		UUID:         uuid.New(),
+		UserID:       "user-1",
+		CustomVal:    customVal,
+		Parameters:   []byte(`{"source_id":"src1"}`),
+		EventPayload: []byte(`{}`),
+		EventCount:   1,
+		WorkspaceId:  defaultWorkspaceID,
+		Consumers:    []string{"A", "B"},
+	}
+	require.NoError(t, jd.Store(ctx, []*JobT{job}))
+
+	// both A and B see the job as unprocessed
+	resA, err := jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "A"})
+	require.NoError(t, err)
+	require.Len(t, resA.Jobs, 1)
+
+	resB, err := jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "B"})
+	require.NoError(t, err)
+	require.Len(t, resB.Jobs, 1)
+
+	// mark the job succeeded for consumer A
+	require.NoError(t, jd.UpdateJobStatus(ctx, []*JobStatusT{{
+		JobID:         resA.Jobs[0].JobID,
+		JobState:      Succeeded.State,
+		AttemptNum:    1,
+		ExecTime:      time.Now(),
+		RetryTime:     time.Now(),
+		ErrorCode:     "200",
+		ErrorResponse: []byte(`{}`),
+		Parameters:    []byte(`{}`),
+		WorkspaceId:   resA.Jobs[0].WorkspaceId,
+		CustomVal:     resA.Jobs[0].CustomVal,
+		Consumer:      "A",
+	}}))
+
+	// A sees no more unprocessed jobs
+	resA, err = jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "A"})
+	require.NoError(t, err)
+	require.Empty(t, resA.Jobs, "consumer A's terminal status should hide the job from A")
+
+	// B still sees the job as unprocessed — A's status does not affect B
+	resB, err = jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "B"})
+	require.NoError(t, err)
+	require.Len(t, resB.Jobs, 1, "consumer B should still see the job after A marked it done")
+
+	// a third consumer C never assigned to this job sees nothing
+	resC, err := jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "C"})
+	require.NoError(t, err)
+	require.Empty(t, resC.Jobs, "consumer C is not in the job's consumers list")
+}
+
 // TestMultiConsumerJobsDB_Conversion verifies the single → multi-consumer upgrade path.
 //
 // A plain handle stores and processes jobs using the legacy schema. When the same prefix
@@ -207,12 +281,12 @@ func verifyUnionJobsDBMetadata(t *testing.T, db *sql.DB, prefix string, expected
 	var count int
 	for rows.Next() {
 		var (
-			tName    string
-			jobID    int64
+			tName     string
+			jobID     int64
 			consumers pq.StringArray
-			statusID sql.NullInt64
-			consumer sql.NullString
-			jobState sql.NullString
+			statusID  sql.NullInt64
+			consumer  sql.NullString
+			jobState  sql.NullString
 		)
 		require.NoError(t, rows.Scan(&tName, &jobID, &consumers, &statusID, &consumer, &jobState))
 		require.NotEmpty(t, tName)
@@ -221,4 +295,99 @@ func verifyUnionJobsDBMetadata(t *testing.T, db *sql.DB, prefix string, expected
 	}
 	require.NoError(t, rows.Err())
 	require.Equal(t, expectedRows, count)
+}
+
+// TestMultiConsumerJobsDB_Cache verifies that the noResultsCache is correctly keyed,
+// populated, and invalidated per consumer. The test accesses the cache directly (same
+// package) rather than inferring its state from timing or DB call counts.
+func TestMultiConsumerJobsDB_Cache(t *testing.T) {
+	postgres := startPostgres(t)
+
+	c := config.New()
+	c.Set("jobsdb.maxDSSize", 100)
+
+	prefix := strings.ToLower(rand.String(5))
+	jd := NewForReadWrite(prefix,
+		WithDBHandle(postgres.DB),
+		WithConfig(c),
+		WithMultiConsumer(),
+	)
+	require.NoError(t, jd.Start())
+	defer jd.TearDown()
+
+	ctx := context.Background()
+	customVal := "CACHE"
+
+	dsIndex := func() string {
+		return HandleInspector{Handle: jd}.getDSListSnapshot()[0].Index
+	}
+	// cacheHit checks whether the noResultsCache has a live "no unprocessed" entry for
+	// the given consumer — workspace and partition are wildcards (empty query params).
+	cacheHit := func(consumer string) bool {
+		return jd.noResultsCache.Get(
+			dsIndex(), nil, "",
+			[]string{customVal},
+			[]string{Unprocessed.State},
+			[]ParameterFilterT{{Name: "consumer", Value: consumer}},
+		)
+	}
+	makeJob := func(consumers []string) *JobT {
+		return &JobT{
+			UUID:         uuid.New(),
+			UserID:       "u1",
+			CustomVal:    customVal,
+			Parameters:   []byte(`{}`),
+			EventPayload: []byte(`{}`),
+			EventCount:   1,
+			WorkspaceId:  defaultWorkspaceID,
+			Consumers:    consumers,
+		}
+	}
+	succeedFor := func(job *JobT, consumer string) *JobStatusT {
+		return &JobStatusT{
+			JobID:         job.JobID,
+			JobState:      Succeeded.State,
+			AttemptNum:    1,
+			ExecTime:      time.Now(),
+			RetryTime:     time.Now(),
+			ErrorCode:     "200",
+			ErrorResponse: []byte(`{}`),
+			Parameters:    []byte(`{}`),
+			WorkspaceId:   job.WorkspaceId,
+			CustomVal:     job.CustomVal,
+			Consumer:      consumer,
+		}
+	}
+
+	// Phase 1: empty DB — query A primes a "no results" cache entry for consumer A.
+	res, err := jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "A"})
+	require.NoError(t, err)
+	require.Empty(t, res.Jobs)
+	require.True(t, cacheHit("A"), "cache should be set for A after 0-result query")
+
+	// Storing a job for consumer B must not invalidate consumer A's cache entry.
+	require.NoError(t, jd.Store(ctx, []*JobT{makeJob([]string{"B"})}))
+	require.True(t, cacheHit("A"), "B's store must not invalidate A's cache")
+
+	// Storing a job for consumer A must invalidate A's cache.
+	require.NoError(t, jd.Store(ctx, []*JobT{makeJob([]string{"A"})}))
+	require.False(t, cacheHit("A"), "A's store must invalidate A's cache")
+
+	// Phase 2: A fetches and marks its job succeeded; cache re-primed.
+	res, err = jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "A"})
+	require.NoError(t, err)
+	require.Len(t, res.Jobs, 1)
+	require.NoError(t, jd.UpdateJobStatus(ctx, []*JobStatusT{succeedFor(res.Jobs[0], "A")}))
+
+	res, err = jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "A"})
+	require.NoError(t, err)
+	require.Empty(t, res.Jobs)
+	require.True(t, cacheHit("A"), "cache should be re-primed for A after 0-result query")
+
+	// Phase 3: B marks its job succeeded; A's cache must survive.
+	res, err = jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "B"})
+	require.NoError(t, err)
+	require.Len(t, res.Jobs, 1)
+	require.NoError(t, jd.UpdateJobStatus(ctx, []*JobStatusT{succeedFor(res.Jobs[0], "B")}))
+	require.True(t, cacheHit("A"), "B's status update must not invalidate A's cache")
 }

--- a/jobsdb/jobsdb_consumer_test.go
+++ b/jobsdb/jobsdb_consumer_test.go
@@ -1,0 +1,224 @@
+package jobsdb
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+)
+
+// TestMultiConsumerJobsDB_SingleConsumer verifies that a multi-consumer handle works
+// correctly when all jobs use the default (legacy) single consumer.
+//
+// The v_last_c_ view (DISTINCT ON job_id, consumer) is semantically equivalent to
+// v_last_ (DISTINCT ON job_id) when there is a single consumer per job, so Store,
+// GetUnprocessed and UpdateJobStatus should all behave identically to the
+// single-consumer path.
+func TestMultiConsumerJobsDB_SingleConsumer(t *testing.T) {
+	postgres := startPostgres(t)
+
+	c := config.New()
+	c.Set("jobsdb.maxDSSize", 10)
+
+	prefix := strings.ToLower(rand.String(5))
+	jd := NewForReadWrite(prefix,
+		WithDBHandle(postgres.DB),
+		WithConfig(c),
+		WithMultiConsumer(),
+	)
+	require.NoError(t, jd.Start())
+	defer jd.TearDown()
+
+	ctx := context.Background()
+	customVal := "MC"
+
+	// store jobs (no Consumers set → defaults to {""})
+	jobs := make([]*JobT, 3)
+	for i := range jobs {
+		jobs[i] = &JobT{
+			UUID:         uuid.New(),
+			UserID:       "user-1",
+			CustomVal:    customVal,
+			Parameters:   []byte(`{"source_id":"src1"}`),
+			EventPayload: []byte(`{}`),
+			EventCount:   1,
+			WorkspaceId:  defaultWorkspaceID,
+		}
+	}
+	require.NoError(t, jd.Store(ctx, jobs))
+
+	// get unprocessed — v_last_c_ is used internally
+	res, err := jd.GetUnprocessed(ctx, GetQueryParams{
+		CustomValFilters: []string{customVal},
+		JobsLimit:        10,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Jobs, 3, "all stored jobs should be unprocessed")
+	for _, j := range res.Jobs {
+		require.Equal(t, []string{""}, j.Consumers, "legacy consumer should be {\"\"}")
+	}
+
+	// mark all succeeded
+	statuses := make([]*JobStatusT, len(res.Jobs))
+	for i, j := range res.Jobs {
+		statuses[i] = &JobStatusT{
+			JobID:         j.JobID,
+			JobState:      Succeeded.State,
+			AttemptNum:    1,
+			ExecTime:      time.Now(),
+			RetryTime:     time.Now(),
+			ErrorCode:     "200",
+			ErrorResponse: []byte(`{}`),
+			Parameters:    []byte(`{}`),
+			WorkspaceId:   j.WorkspaceId,
+			CustomVal:     j.CustomVal,
+		}
+	}
+	require.NoError(t, jd.UpdateJobStatus(ctx, statuses))
+
+	// no more unprocessed after marking all succeeded
+	res, err = jd.GetUnprocessed(ctx, GetQueryParams{
+		CustomValFilters: []string{customVal},
+		JobsLimit:        10,
+	})
+	require.NoError(t, err)
+	require.Empty(t, res.Jobs)
+
+	// unionjobsdbmetadata detects the registry table and uses v_last_c_
+	verifyUnionJobsDBMetadata(t, postgres.DB, prefix, 3)
+}
+
+// TestMultiConsumerJobsDB_Conversion verifies the single → multi-consumer upgrade path.
+//
+// A plain handle stores and processes jobs using the legacy schema. When the same prefix
+// is re-opened with WithMultiConsumer(), applyMultiConsumerFlip runs and creates the
+// v_last_c_ view and consumers registry table for each existing dataset. After the flip,
+// GetUnprocessed and unionjobsdbmetadata must continue to work correctly.
+func TestMultiConsumerJobsDB_Conversion(t *testing.T) {
+	postgres := startPostgres(t)
+
+	c := config.New()
+	c.Set("jobsdb.maxDSSize", 10)
+
+	prefix := strings.ToLower(rand.String(5))
+	customVal := "CONV"
+
+	// Phase 1: plain single-consumer handle — store 3 jobs, mark 2 succeeded.
+	jdSingle := NewForReadWrite(prefix,
+		WithDBHandle(postgres.DB),
+		WithConfig(c),
+	)
+	require.NoError(t, jdSingle.Start())
+
+	ctx := context.Background()
+	jobs := make([]*JobT, 3)
+	for i := range jobs {
+		jobs[i] = &JobT{
+			UUID:         uuid.New(),
+			UserID:       "user-1",
+			CustomVal:    customVal,
+			Parameters:   []byte(`{"source_id":"src1"}`),
+			EventPayload: []byte(`{}`),
+			EventCount:   1,
+			WorkspaceId:  defaultWorkspaceID,
+		}
+	}
+	require.NoError(t, jdSingle.Store(ctx, jobs))
+
+	res, err := jdSingle.GetUnprocessed(ctx, GetQueryParams{
+		CustomValFilters: []string{customVal},
+		JobsLimit:        10,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Jobs, 3)
+
+	// mark first 2 succeeded, leave one pending
+	statuses := make([]*JobStatusT, 2)
+	for i := range statuses {
+		statuses[i] = &JobStatusT{
+			JobID:         res.Jobs[i].JobID,
+			JobState:      Succeeded.State,
+			AttemptNum:    1,
+			ExecTime:      time.Now(),
+			RetryTime:     time.Now(),
+			ErrorCode:     "200",
+			ErrorResponse: []byte(`{}`),
+			Parameters:    []byte(`{}`),
+			WorkspaceId:   res.Jobs[i].WorkspaceId,
+			CustomVal:     res.Jobs[i].CustomVal,
+		}
+	}
+	require.NoError(t, jdSingle.UpdateJobStatus(ctx, statuses))
+	jdSingle.TearDown()
+
+	// Phase 2: re-open with WithMultiConsumer() — flip runs on startup.
+	jdMC := NewForReadWrite(prefix,
+		WithDBHandle(postgres.DB),
+		WithConfig(c),
+		WithMultiConsumer(),
+	)
+	require.NoError(t, jdMC.Start())
+
+	// One unprocessed job should still be visible via the v_last_c_ view.
+	res, err = jdMC.GetUnprocessed(ctx, GetQueryParams{
+		CustomValFilters: []string{customVal},
+		JobsLimit:        10,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Jobs, 1, "exactly one job should remain unprocessed after conversion")
+	require.Equal(t, []string{""}, res.Jobs[0].Consumers)
+
+	// unionjobsdbmetadata should detect the registry table and use v_last_c_.
+	verifyUnionJobsDBMetadata(t, postgres.DB, prefix, 3)
+	jdMC.TearDown()
+
+	// Phase 3: re-open without WithMultiConsumer() and with downgrade guard enabled — must panic.
+	cStrict := config.New()
+	cStrict.Set("jobsdb.maxDSSize", 10)
+	cStrict.Set("jobsdb.disallowMultiConsumerDowngrade", true)
+	require.Panics(t, func() {
+		jdDowngrade := NewForReadWrite(prefix,
+			WithDBHandle(postgres.DB),
+			WithConfig(cStrict),
+		)
+		_ = jdDowngrade
+	})
+}
+
+// verifyUnionJobsDBMetadata calls unionjobsdbmetadata and asserts row count,
+// presence of consumers and consumer columns, and non-null status for each row.
+func verifyUnionJobsDBMetadata(t *testing.T, db *sql.DB, prefix string, expectedRows int) {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(),
+		`SELECT t_name, job_id, consumers, status_id, consumer, job_state FROM unionjobsdbmetadata($1, 10)`,
+		prefix,
+	)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var count int
+	for rows.Next() {
+		var (
+			tName    string
+			jobID    int64
+			consumers pq.StringArray
+			statusID sql.NullInt64
+			consumer sql.NullString
+			jobState sql.NullString
+		)
+		require.NoError(t, rows.Scan(&tName, &jobID, &consumers, &statusID, &consumer, &jobState))
+		require.NotEmpty(t, tName)
+		require.NotEmpty(t, consumers)
+		count++
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, expectedRows, count)
+}

--- a/jobsdb/jobsdb_dataset.go
+++ b/jobsdb/jobsdb_dataset.go
@@ -22,10 +22,16 @@ type dataSetT struct {
 	JobTable       string `json:"job"`
 	JobStatusTable string `json:"status"`
 	Index          string `json:"index"`
+	ConsumersTable string `json:"consumers,omitempty"` // non-empty only when the registry table exists
 }
 
 func (ds dataSetT) String() string {
 	return "JobTable=" + ds.JobTable + ",JobStatusTable=" + ds.JobStatusTable + ",Index=" + ds.Index
+}
+
+func (ds dataSetT) consumersRegistryTable() string {
+	prefix := strings.TrimSuffix(ds.JobTable, "_jobs_"+ds.Index)
+	return fmt.Sprintf("%s_consumers_%s", prefix, ds.Index)
 }
 
 type dataSetTList []dataSetT

--- a/jobsdb/jobsdb_dataset_ddl.go
+++ b/jobsdb/jobsdb_dataset_ddl.go
@@ -161,7 +161,8 @@ func (jd *Handle) createDSTablesInTx(ctx context.Context, tx *Tx, newDS dataSetT
 		event_payload `+string(columnType)+` NOT NULL,
 		event_count INTEGER NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-		expire_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW());`, newDS.JobTable)); err != nil {
+		expire_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+		consumers TEXT[] NOT NULL DEFAULT '{""}');`, newDS.JobTable)); err != nil {
 		return fmt.Errorf("creating %s: %w", newDS.JobTable, err)
 	}
 
@@ -174,7 +175,8 @@ func (jd *Handle) createDSTablesInTx(ctx context.Context, tx *Tx, newDS dataSetT
 		retry_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
 		error_code VARCHAR(32),
 		error_response JSONB DEFAULT '{}'::JSONB,
-		parameters JSONB DEFAULT '{}'::JSONB);`, newDS.JobStatusTable)); err != nil {
+		parameters JSONB DEFAULT '{}'::JSONB,
+		consumer TEXT NOT NULL DEFAULT '');`, newDS.JobStatusTable)); err != nil {
 		return fmt.Errorf("creating %s: %w", newDS.JobStatusTable, err)
 	}
 

--- a/jobsdb/jobsdb_dataset_ddl.go
+++ b/jobsdb/jobsdb_dataset_ddl.go
@@ -180,6 +180,13 @@ func (jd *Handle) createDSTablesInTx(ctx context.Context, tx *Tx, newDS dataSetT
 		return fmt.Errorf("creating %s: %w", newDS.JobStatusTable, err)
 	}
 
+	if jd.conf.multiConsumer {
+		registryTable := newDS.consumersRegistryTable()
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE TABLE %q (consumer TEXT PRIMARY KEY)`, registryTable)); err != nil {
+			return fmt.Errorf("creating %s: %w", registryTable, err)
+		}
+	}
+
 	// Record the dataset's creation time as a comment on the jobs table, so that
 	// compaction can tell how recently a dataset was created (see checkIfCompactDS).
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`COMMENT ON TABLE %q IS '%s'`, newDS.JobTable, dsCreatedAtComment(time.Now()))); err != nil {
@@ -356,6 +363,9 @@ func (jd *Handle) cleanupPreDropTables(ctx context.Context) error {
 			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %q CASCADE`, ds.JobTable)); err != nil {
 				return fmt.Errorf("drop %s: %w", ds.JobTable, err)
 			}
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %q`, ds.consumersRegistryTable())); err != nil {
+				return fmt.Errorf("drop %s: %w", ds.consumersRegistryTable(), err)
+			}
 			return nil
 		}); err != nil {
 			return err
@@ -371,6 +381,9 @@ func (jd *Handle) dropDSInTx(tx *Tx, ds dataSetT) error {
 		return err
 	}
 	if _, err = tx.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %q CASCADE`, ds.JobTable)); err != nil {
+		return err
+	}
+	if _, err = tx.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %q`, ds.consumersRegistryTable())); err != nil {
 		return err
 	}
 	jd.postDropDs(ds)
@@ -393,6 +406,8 @@ func (jd *Handle) dropDSForRecovery(ds dataSetT) {
 	jd.execStmtInTx(tx, sqlStatement)
 	sqlStatement = fmt.Sprintf(`DROP TABLE IF EXISTS %q CASCADE`, ds.JobTable)
 	jd.execStmtInTx(tx, sqlStatement)
+	sqlStatement = fmt.Sprintf(`DROP TABLE IF EXISTS %q`, ds.consumersRegistryTable())
+	jd.execStmtInTxAllowMissing(tx, sqlStatement)
 	err = tx.Commit()
 	jd.assertError(err)
 }

--- a/jobsdb/jobsdb_dataset_ddl.go
+++ b/jobsdb/jobsdb_dataset_ddl.go
@@ -212,22 +212,36 @@ func (jd *Handle) createDSJobIndicesInTx(ctx context.Context, tx *Tx, newDS data
 			return fmt.Errorf("creating %s index: %w", param, err)
 		}
 	}
+	if jd.conf.multiConsumer {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_consumers" ON %[1]q USING GIN (consumers)`, newDS.JobTable)); err != nil {
+			return fmt.Errorf("creating consumers GIN index: %w", err)
+		}
+	}
 	return nil
 }
 
 // createDSStatusIndicesInTx creates the indices on the job status table plus the
-// v_last view.
+// v_last view (single-consumer) or v_last_c_ view (multi-consumer).
 func (jd *Handle) createDSStatusIndicesInTx(ctx context.Context, tx *Tx, newDS dataSetT) error {
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_jid_id_js" ON %[1]q(job_id asc,id desc,job_state)`, newDS.JobStatusTable)); err != nil {
-		return fmt.Errorf("adding job_id_id index: %w", err)
-	}
-	// index used for maxDSRetention during compaction
+	// retention index — consumer-agnostic, always created
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_id_js" ON %[1]q(id ,job_state) INCLUDE (exec_time)`, newDS.JobStatusTable)); err != nil {
-		return fmt.Errorf("adding job_id_js index: %w", err)
+		return fmt.Errorf("adding id_js index: %w", err)
 	}
 
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE VIEW "v_last_%[1]s" AS SELECT DISTINCT ON (job_id) * FROM %[1]q ORDER BY job_id ASC, id DESC`, newDS.JobStatusTable)); err != nil {
-		return fmt.Errorf("create view: %w", err)
+	if jd.conf.multiConsumer {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_jid_c_id_js" ON %[1]q (job_id ASC, consumer, id DESC, job_state)`, newDS.JobStatusTable)); err != nil {
+			return fmt.Errorf("adding jid_c_id_js index: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE VIEW "v_last_c_%[1]s" AS SELECT DISTINCT ON (job_id, consumer) * FROM %[1]q ORDER BY job_id ASC, consumer, id DESC`, newDS.JobStatusTable)); err != nil {
+			return fmt.Errorf("creating v_last_c view: %w", err)
+		}
+	} else {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_jid_id_js" ON %[1]q(job_id asc,id desc,job_state)`, newDS.JobStatusTable)); err != nil {
+			return fmt.Errorf("adding jid_id_js index: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE VIEW "v_last_%[1]s" AS SELECT DISTINCT ON (job_id) * FROM %[1]q ORDER BY job_id ASC, id DESC`, newDS.JobStatusTable)); err != nil {
+			return fmt.Errorf("creating v_last view: %w", err)
+		}
 	}
 	return nil
 }

--- a/jobsdb/jobsdb_factory.go
+++ b/jobsdb/jobsdb_factory.go
@@ -114,8 +114,6 @@ func WithTriggerAddNewDS(trigger func() <-chan time.Time) OptsFunc {
 }
 
 // WithMultiConsumer enables multi-consumer mode for this handle.
-// This is a one-way option: once datasets exist with the multi-consumer schema,
-// removing this option will cause startup to fail.
 func WithMultiConsumer() OptsFunc {
 	return func(jd *Handle) {
 		jd.conf.multiConsumer = true

--- a/jobsdb/jobsdb_factory.go
+++ b/jobsdb/jobsdb_factory.go
@@ -113,6 +113,15 @@ func WithTriggerAddNewDS(trigger func() <-chan time.Time) OptsFunc {
 	}
 }
 
+// WithMultiConsumer enables multi-consumer mode for this handle.
+// This is a one-way option: once datasets exist with the multi-consumer schema,
+// removing this option will cause startup to fail.
+func WithMultiConsumer() OptsFunc {
+	return func(jd *Handle) {
+		jd.conf.multiConsumer = true
+	}
+}
+
 // withDatabaseTablesVersion sets the schema version used by table migration tests.
 func withDatabaseTablesVersion(dbVersion int) OptsFunc {
 	return func(jd *Handle) {

--- a/jobsdb/jobsdb_get.go
+++ b/jobsdb/jobsdb_get.go
@@ -359,7 +359,7 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 
 	sqlStatement := fmt.Sprintf(`SELECT
 									jobs.job_id, jobs.uuid, jobs.user_id, jobs.parameters, jobs.custom_val, jobs.event_payload, jobs.event_count,
-									jobs.created_at, jobs.expire_at, jobs.workspace_id, jobs.partition_id,
+									jobs.created_at, jobs.expire_at, jobs.workspace_id, jobs.partition_id, jobs.consumers,
 									octet_length(jobs.event_payload::text) as payload_size,
 									sum(jobs.event_count) over (order by jobs.job_id asc) as running_event_counts,
 									sum(octet_length(jobs.event_payload::text)) over (order by jobs.job_id) as running_payload_size,
@@ -426,7 +426,7 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 		var jsErrorResponse []byte
 		var jsParameters []byte
 		err := rows.Scan(&job.JobID, &job.UUID, &job.UserID, &job.Parameters, &job.CustomVal,
-			&payload, &job.EventCount, &job.CreatedAt, &job.ExpireAt, &job.WorkspaceId, &job.PartitionID, &discardRowPayloadSize, &runningEventCount, &runningPayloadSize,
+			&payload, &job.EventCount, &job.CreatedAt, &job.ExpireAt, &job.WorkspaceId, &job.PartitionID, pq.Array(&job.Consumers), &discardRowPayloadSize, &runningEventCount, &runningPayloadSize,
 			&jsState, &jsAttemptNum,
 			&jsExecTime, &jsRetryTime,
 			&jsErrorCode, &jsErrorResponse, &jsParameters)

--- a/jobsdb/jobsdb_get.go
+++ b/jobsdb/jobsdb_get.go
@@ -28,6 +28,10 @@ type GetQueryParams struct {
 	CustomValFilters []string
 	ParameterFilters []ParameterFilterT
 	PartitionFilters []string
+	// Consumer scopes the query to a single consumer.
+	// On a multi-consumer JobsDB this is always applied — an empty string targets the default '' consumer.
+	// On a single-consumer JobsDB this field is ignored.
+	Consumer string
 
 	stateFilters                   []string
 	afterJobID                     *int64
@@ -66,6 +70,8 @@ func (jd *Handle) GetToProcess(ctx context.Context, params GetQueryParams, more 
 }
 
 var cacheParameterFilters = []string{"source_id", "destination_id"}
+
+const consumerParamName = "consumer" // the name of the consumer parameter, used for multi-consumer scoping of queries and cache entries
 
 func (jd *Handle) GetPileUpCounts(ctx context.Context, cutoffTime time.Time, increaseFunc rmetrics.IncreasePendingEventsFunc) error {
 	// pause compaction to avoid any read locks being blocked during pileup count
@@ -243,12 +249,18 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 	workspaceID := params.WorkspaceID
 	checkValidJobState(jd, stateFilters)
 
-	if jd.noResultsCache.Get(ds.Index, partitionFilters, workspaceID, customValFilters, stateFilters, parameterFilters) {
+	// For multi-consumer JobsDB, consumer is a cache dimension: consumer=X scopes lookups to that consumer.
+	cacheParamFilters := parameterFilters
+	if jd.conf.multiConsumer {
+		cacheParamFilters = append(parameterFilters, ParameterFilterT{Name: consumerParamName, Value: params.Consumer})
+	}
+
+	if jd.noResultsCache.Get(ds.Index, partitionFilters, workspaceID, customValFilters, stateFilters, cacheParamFilters) {
 		jd.logger.Debugn("[getJobsDS] Empty cache hit for ds: %v, stateFilters: %v, customValFilters: %v, parameterFilters: %v",
 			logger.NewStringField("ds", ds.String()),
 			logger.NewStringField("stateFilters", strings.Join(stateFilters, ",")),
 			logger.NewStringField("customValFilters", strings.Join(customValFilters, ",")),
-			logger.NewStringField("parameterFilters", parameterFilters.String()),
+			logger.NewStringField("parameterFilters", cacheParamFilters.String()),
 		)
 		return JobsResult{}, false, nil
 	}
@@ -262,7 +274,7 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 
 	if stateFilterOptimization {
 		stateFilters = lo.Filter(stateFilters, func(state string, _ int) bool { // exclude states for which we already know that there are no jobs
-			return !jd.noResultsCache.Get(ds.Index, partitionFilters, workspaceID, customValFilters, []string{state}, parameterFilters)
+			return !jd.noResultsCache.Get(ds.Index, partitionFilters, workspaceID, customValFilters, []string{state}, cacheParamFilters)
 		})
 	}
 
@@ -280,7 +292,7 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 			if state == Unprocessed.State && jd.ownerType == Read && lastDS {
 				continue
 			}
-			cacheTx[state] = jd.noResultsCache.StartNoResultTx(ds.Index, partitionFilters, workspaceID, customValFilters, []string{state}, parameterFilters)
+			cacheTx[state] = jd.noResultsCache.StartNoResultTx(ds.Index, partitionFilters, workspaceID, customValFilters, []string{state}, cacheParamFilters)
 		}
 	}
 
@@ -327,6 +339,20 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 		jd.excludedReadPartitionsLock.RUnlock()
 	}
 
+	// query args are shared between the inner query (consumer) and the outer wrap (limits).
+	// Consumer must be added first so its $n position is stable when wrap args are appended.
+	var args []any
+
+	// innerConsumerClause is added inside LATERAL subqueries; outerConsumerClause is added to ON clauses.
+	var innerConsumerClause, outerConsumerClause string
+	if jd.conf.multiConsumer {
+		args = append(args, params.Consumer)
+		n := len(args)
+		filterConditions = append(filterConditions, fmt.Sprintf("jobs.consumers @> ARRAY[$%d]", n))
+		innerConsumerClause = fmt.Sprintf(" AND consumer = $%d", n)
+		outerConsumerClause = fmt.Sprintf(" AND job_latest_state.consumer = $%d", n)
+	}
+
 	var filterQuery string
 	if len(filterConditions) > 0 {
 		filterQuery = "WHERE " + strings.Join(filterConditions, " AND ")
@@ -356,9 +382,9 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 	// we only need to know whether any status row exists, not which one is latest,
 	// so the lateral's ORDER BY / LIMIT 1 would be wasteful — skip it.
 	if jd.conf.getJobsUseLateralJoin.Load() && !onlyUnprocessed {
-		joinTable = fmt.Sprintf(`LATERAL (SELECT * FROM %q WHERE job_id = jobs.job_id ORDER BY id DESC LIMIT 1) job_latest_state ON true`, joinTable)
+		joinTable = fmt.Sprintf(`LATERAL (SELECT * FROM %q WHERE job_id = jobs.job_id%s ORDER BY id DESC LIMIT 1) job_latest_state ON true`, joinTable, innerConsumerClause)
 	} else {
-		joinTable = fmt.Sprintf(`%q job_latest_state ON jobs.job_id=job_latest_state.job_id`, joinTable)
+		joinTable = fmt.Sprintf(`%q job_latest_state ON jobs.job_id=job_latest_state.job_id%s`, joinTable, outerConsumerClause)
 	}
 
 	sqlStatement := fmt.Sprintf(`SELECT
@@ -376,8 +402,6 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 								    %[4]s
 									ORDER BY jobs.job_id %[5]s`,
 		ds.JobTable, joinType, joinTable, filterQuery, limitQuery)
-
-	var args []any
 
 	var wrapQuery []string
 	if params.EventsLimit > 0 {

--- a/jobsdb/jobsdb_get.go
+++ b/jobsdb/jobsdb_get.go
@@ -338,7 +338,11 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 	}
 
 	joinType := "LEFT"
-	joinTable := "v_last_" + ds.JobStatusTable
+	viewPrefix := "v_last_"
+	if jd.conf.multiConsumer {
+		viewPrefix = "v_last_c_"
+	}
+	joinTable := viewPrefix + ds.JobStatusTable
 	onlyUnprocessed := slices.Equal(stateFilters, []string{Unprocessed.State})
 
 	if !containsUnprocessed { // If we are not querying for unprocessed jobs, we can use an inner join

--- a/jobsdb/jobsdb_lifecycle.go
+++ b/jobsdb/jobsdb_lifecycle.go
@@ -116,25 +116,28 @@ func (jd *Handle) init() {
 				if writer && jd.conf.clearAll {
 					jd.dropDatabaseTables(l)
 				}
-				templateData := func() map[string]any {
-					// Important: if jobsdb type is acting as a writer then refreshDSList
-					// doesn't return the full list of datasets, only the rightmost two.
-					// But we need to run the schema migration against all datasets, no matter
-					// whether jobsdb is a writer or not.
-					datasets, err := getDSList(jd, tx, jd.tablePrefix)
-					jd.assertError(err)
 
-					datasetIndices := make([]string, 0)
-					for _, dataset := range datasets {
-						datasetIndices = append(datasetIndices, dataset.Index)
-					}
+				// Important: if jobsdb type is acting as a writer then refreshDSList
+				// doesn't return the full list of datasets, only the rightmost two.
+				// But we need to run the schema migration against all datasets, no matter
+				// whether jobsdb is a writer or not.
+				allDatasets, err := getDSList(jd, tx, jd.tablePrefix)
+				jd.assertError(err)
 
-					return map[string]any{
-						"Prefix":              jd.tablePrefix,
-						"Datasets":            datasetIndices,
-						"PartitioningEnabled": jd.conf.numPartitions > 0,
-					}
-				}()
+				datasetIndices := make([]string, len(allDatasets))
+				for i, ds := range allDatasets {
+					datasetIndices[i] = ds.Index
+				}
+				templateData := map[string]any{
+					"Prefix":              jd.tablePrefix,
+					"Datasets":            datasetIndices,
+					"PartitioningEnabled": jd.conf.numPartitions > 0,
+				}
+
+				// One-way guard: opt-in check that panics if MC artifacts exist without WithMultiConsumer().
+				if !jd.conf.multiConsumer && jd.conf.disallowMultiConsumerDowngrade {
+					jd.assertNoMultiConsumerDowngrade(allDatasets)
+				}
 
 				if writer {
 					jd.setupDatabaseTables(templateData)
@@ -149,8 +152,16 @@ func (jd *Handle) init() {
 				// Changesets that run always can help in such cases, by bringing non-migrated tables into a usable state.
 				jd.runAlwaysChangesets(templateData)
 
+				// For multi-consumer handles, ensure every existing dataset has the
+				// v_last_c_ view and consumers registry table. This is the flip path:
+				// runs on first boot after WithMultiConsumer() is set, and is a no-op
+				// on subsequent boots once all datasets are up to date.
+				if jd.conf.multiConsumer {
+					jd.assertError(jd.applyMultiConsumerFlip(context.Background(), allDatasets))
+				}
+
 				// finally refresh the dataset list to make sure [datasetList] field is populated
-				err := jd.doRefreshDSRangeListWithDB(l, jd.dbHandle)
+				err = jd.doRefreshDSRangeListWithDB(l, jd.dbHandle)
 				jd.assertError(err)
 			})
 			return nil

--- a/jobsdb/jobsdb_lifecycle.go
+++ b/jobsdb/jobsdb_lifecycle.go
@@ -180,8 +180,12 @@ func (jd *Handle) workersAndAuxSetup() {
 	case "gw", "rt", "batch_rt", "arc":
 		defaultLogCacheBranchInvalidation = true
 	}
+	cacheParams := cacheParameterFilters
+	if jd.conf.multiConsumer {
+		cacheParams = append(cacheParams, consumerParamName)
+	}
 	jd.noResultsCache = cache.NewNoResultsCache(
-		cacheParameterFilters,
+		cacheParams,
 		func() time.Duration { return jd.conf.cacheExpiration.Load() },
 		cache.WithWarnOnBranchInvalidation[ParameterFilterT](
 			jd.config.GetReloadableBoolVar(defaultLogCacheBranchInvalidation, jd.configKeys("logCacheBranchInvalidation")...),

--- a/jobsdb/jobsdb_multiconsumer.go
+++ b/jobsdb/jobsdb_multiconsumer.go
@@ -1,0 +1,92 @@
+package jobsdb
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/lib/pq"
+	"github.com/samber/lo"
+
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
+)
+
+// applyMultiConsumerFlip ensures every dataset in dsList has the multi-consumer
+// schema artifacts: the v_last_c_ view and the consumers registry table.
+// It is idempotent — datasets that already carry both artifacts are skipped —
+// so it is safe to call on every startup. Any dataset left incomplete by a prior
+// crash will be finished on the next boot.
+//
+// The registry table is the canonical marker: if it exists (ConsumersTable != ""),
+// the dataset is fully migrated. The view uses CREATE OR REPLACE to handle the
+// rare case where a prior run created the view but crashed before the registry.
+func (jd *Handle) applyMultiConsumerFlip(ctx context.Context, dsList []dataSetT) error {
+	pending := lo.Filter(dsList, func(ds dataSetT, _ int) bool { return ds.ConsumersTable == "" })
+	if len(pending) == 0 {
+		return nil
+	}
+	return jd.withMaintenanceTx(ctx, func(tx *Tx) error {
+		for _, ds := range pending {
+			viewName := "v_last_c_" + ds.JobStatusTable
+			registry := ds.consumersRegistryTable()
+
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+				`CREATE OR REPLACE VIEW %q AS SELECT DISTINCT ON (job_id, consumer) * FROM %q ORDER BY job_id ASC, consumer, id DESC`,
+				viewName, ds.JobStatusTable,
+			)); err != nil {
+				return fmt.Errorf("creating view %s: %w", viewName, err)
+			}
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+				`CREATE TABLE %q (consumer TEXT PRIMARY KEY)`, registry,
+			)); err != nil {
+				return fmt.Errorf("creating registry table %s: %w", registry, err)
+			}
+			// All pre-existing jobs are legacy, so the only consumer is ''.
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+				`INSERT INTO %q VALUES ('')`, registry,
+			)); err != nil {
+				return fmt.Errorf("seeding registry table %s: %w", registry, err)
+			}
+		}
+		return nil
+	})
+}
+
+// registerConsumers inserts new consumer values from jobList into the dataset's
+// registry table. Existing entries are silently ignored (ON CONFLICT DO NOTHING).
+// Consumers are sorted before insertion for a stable, index-friendly, deadlock-avoiding order.
+func (jd *Handle) registerConsumers(ctx context.Context, tx *Tx, ds dataSetT, jobList []*JobT) error {
+	seen := map[string]struct{}{}
+	for _, job := range jobList {
+		consumers := job.Consumers
+		if len(consumers) == 0 {
+			seen[""] = struct{}{}
+			continue
+		}
+		for _, c := range consumers {
+			seen[c] = struct{}{}
+		}
+	}
+	sorted := lo.Keys(seen)
+	sort.Strings(sorted)
+	_, err := tx.ExecContext(ctx,
+		fmt.Sprintf(`INSERT INTO %q SELECT unnest($1::text[]) ON CONFLICT DO NOTHING`, ds.consumersRegistryTable()),
+		pq.Array(sorted),
+	)
+	return err
+}
+
+// assertNoMultiConsumerDowngrade panics at startup if any dataset has a consumers
+// registry table while WithMultiConsumer() is not set. Downgrade is one-way:
+// once a handle has been flipped, turning the option off is unsupported because
+// consumer-scoped status data cannot be faithfully represented in the single-consumer schema.
+func (jd *Handle) assertNoMultiConsumerDowngrade(dsList []dataSetT) {
+	for _, ds := range dsList {
+		if ds.ConsumersTable != "" {
+			panic(fmt.Errorf(
+				"jobsdb %q: multi-consumer schema artifacts exist but WithMultiConsumer() is not set — downgrade is unsupported",
+				jd.tablePrefix,
+			))
+		}
+	}
+}

--- a/jobsdb/jobsdb_store.go
+++ b/jobsdb/jobsdb_store.go
@@ -136,7 +136,7 @@ func (jd *Handle) doStoreJobsInTx(ctx context.Context, tx *Tx, ds dataSetT, jobL
 		var stmt *sql.Stmt
 		var err error
 
-		stmt, err = tx.PrepareContext(ctx, misc.DBCopyIn(ds.JobTable, "uuid", "user_id", "custom_val", "parameters", "event_payload", "event_count", "workspace_id", "partition_id"))
+		stmt, err = tx.PrepareContext(ctx, misc.DBCopyIn(ds.JobTable, "uuid", "user_id", "custom_val", "parameters", "event_payload", "event_count", "workspace_id", "partition_id", "consumers"))
 		if err != nil {
 			return err
 		}
@@ -148,7 +148,11 @@ func (jd *Handle) doStoreJobsInTx(ctx context.Context, tx *Tx, ds dataSetT, jobL
 			if job.PartitionID == "" && jd.conf.numPartitions > 0 {
 				job.PartitionID = jd.conf.partitionFunction(job)
 			}
-			if _, err = stmt.ExecContext(ctx, job.UUID, job.UserID, job.CustomVal, string(job.Parameters), string(job.EventPayload), eventCount, job.WorkspaceId, job.PartitionID); err != nil {
+			consumers := job.Consumers
+			if len(consumers) == 0 {
+				consumers = []string{""}
+			}
+			if _, err = stmt.ExecContext(ctx, job.UUID, job.UserID, job.CustomVal, string(job.Parameters), string(job.EventPayload), eventCount, job.WorkspaceId, job.PartitionID, pq.Array(consumers)); err != nil {
 				return err
 			}
 		}

--- a/jobsdb/jobsdb_store.go
+++ b/jobsdb/jobsdb_store.go
@@ -123,6 +123,19 @@ func (jd *Handle) invalidateCacheForJobs(ds dataSetT, jobList []*JobT) {
 			parameterFilters = append(parameterFilters, ParameterFilterT{Name: key, Value: val})
 		}
 
+		if jd.conf.multiConsumer {
+			consumers := job.Consumers
+			if len(consumers) == 0 {
+				consumers = []string{""}
+			}
+			for _, c := range consumers {
+				params = append(params, consumerParamName+":"+c)
+				parameterFilters = append(parameterFilters, ParameterFilterT{Name: consumerParamName, Value: c})
+			}
+			// also invalidate all-consumer query entries
+			parameterFilters = append(parameterFilters, ParameterFilterT{Name: consumerParamName, Value: "*"})
+		}
+
 		paramsKey := strings.Join(params, "#")
 		if _, ok := cacheKeys[workspace][customVal][paramsKey]; !ok {
 			cacheKeys[workspace][customVal][paramsKey] = struct{}{}

--- a/jobsdb/jobsdb_store.go
+++ b/jobsdb/jobsdb_store.go
@@ -160,9 +160,13 @@ func (jd *Handle) doStoreJobsInTx(ctx context.Context, tx *Tx, ds dataSetT, jobL
 			return err
 		}
 		if len(jobList) > jd.conf.analyzeThreshold.Load() {
-			_, err = tx.ExecContext(ctx, fmt.Sprintf(`ANALYZE %q`, ds.JobTable))
+			if _, err = tx.ExecContext(ctx, fmt.Sprintf(`ANALYZE %q`, ds.JobTable)); err != nil {
+				return err
+			}
 		}
-
+		if jd.conf.multiConsumer {
+			err = jd.registerConsumers(ctx, tx, ds, jobList)
+		}
 		return err
 	}
 	const (

--- a/jobsdb/jobsdb_update.go
+++ b/jobsdb/jobsdb_update.go
@@ -253,15 +253,16 @@ func (jd *Handle) updateJobStatusDSInTx(ctx context.Context, tx *Tx, ds dataSetT
 				updatedStates[partitionIDKey(partitionID)][workspaceIDKey(status.WorkspaceId)][customValKey(status.CustomVal)][jobStateKey(status.JobState)] = make(map[parameterFiltersKey]*UpdateJobStatusStats)
 			}
 			var parameters ParameterFilterList
-			var parametersKey parameterFiltersKey
 			if status.JobParameters != nil {
 				for _, param := range cacheParameterFilters {
 					v := gjson.GetBytes(status.JobParameters, param).Str
 					parameters = append(parameters, ParameterFilterT{Name: param, Value: v})
 				}
-				parametersKey = parameterFiltersKey(parameters.String())
-
 			}
+			if jd.conf.multiConsumer {
+				parameters = append(parameters, ParameterFilterT{Name: consumerParamName, Value: status.Consumer})
+			}
+			parametersKey := parameterFiltersKey(parameters.String())
 			pm, ok := updatedStates[partitionIDKey(partitionID)][workspaceIDKey(status.WorkspaceId)][customValKey(status.CustomVal)][jobStateKey(status.JobState)][parametersKey]
 			if !ok {
 				pm = &UpdateJobStatusStats{parameters: parameters}
@@ -380,6 +381,12 @@ func (jd *Handle) internalUpdateJobStatusInTx(ctx context.Context, tx *Tx, dsLis
 									return pf.String() // uniqueness by string representation
 								},
 							)
+							// If multi-consumer, also invalidate consumer=* so that all-consumer
+							// queries (e.g. GetPendingJobs) are not served stale results after
+							// any consumer writes a status.
+							if jd.conf.multiConsumer {
+								parameterFilters = append(parameterFilters, ParameterFilterT{Name: consumerParamName, Value: "*"})
+							}
 							// invalidate cache for this combination
 							jd.noResultsCache.Invalidate(ds.Index, []string{string(partition)}, string(workspace), []string{string(customVal)}, stateList, parameterFilters)
 						}

--- a/jobsdb/jobsdb_update.go
+++ b/jobsdb/jobsdb_update.go
@@ -221,7 +221,7 @@ func (jd *Handle) updateJobStatusDSInTx(ctx context.Context, tx *Tx, ds dataSetT
 	store := func() error {
 		updatedStates = updateJobStatusStats{} // reset in case of retry
 		stmt, err := tx.PrepareContext(ctx, misc.DBCopyIn(ds.JobStatusTable, "job_id", "job_state", "attempt", "exec_time",
-			"retry_time", "error_code", "error_response", "parameters"))
+			"retry_time", "error_code", "error_response", "parameters", "consumer"))
 		if err != nil {
 			return err
 		}
@@ -275,7 +275,7 @@ func (jd *Handle) updateJobStatusDSInTx(ctx context.Context, tx *Tx, ds dataSetT
 				status.ErrorResponse = []byte(`{}`)
 			}
 			_, err = stmt.ExecContext(ctx, status.JobID, status.JobState, status.AttemptNum, status.ExecTime,
-				status.RetryTime, status.ErrorCode, string(status.ErrorResponse), string(status.Parameters))
+				status.RetryTime, status.ErrorCode, string(status.ErrorResponse), string(status.Parameters), status.Consumer)
 			if err != nil {
 				return err
 			}

--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -62,6 +62,7 @@ func getDSList(jd asserter, dbHandle sqlDbOrTx, tablePrefix string) ([]dataSetT,
 
 	jobNameMap := map[string]string{}
 	jobStatusNameMap := map[string]string{}
+	consumersNameMap := map[string]string{}
 	var dnumList []string
 
 	for _, t := range tableNames {
@@ -74,6 +75,11 @@ func getDSList(jd asserter, dbHandle sqlDbOrTx, tablePrefix string) ([]dataSetT,
 		if strings.HasPrefix(t, tablePrefix+"_job_status_") {
 			dnum := t[len(tablePrefix+"_job_status_"):]
 			jobStatusNameMap[dnum] = t
+			continue
+		}
+		if strings.HasPrefix(t, tablePrefix+"_consumers_") {
+			dnum := t[len(tablePrefix+"_consumers_"):]
+			consumersNameMap[dnum] = t
 			continue
 		}
 	}
@@ -91,6 +97,7 @@ func getDSList(jd asserter, dbHandle sqlDbOrTx, tablePrefix string) ([]dataSetT,
 				JobTable:       jobName,
 				JobStatusTable: jobStatusName,
 				Index:          dnum,
+				ConsumersTable: consumersNameMap[dnum], // empty when registry table is absent
 			})
 	}
 

--- a/sql/migrations/jobsdb/000014_multi_consumer_columns.up.tmpl
+++ b/sql/migrations/jobsdb/000014_multi_consumer_columns.up.tmpl
@@ -1,0 +1,4 @@
+{{range .Datasets}}
+    ALTER TABLE "{{$.Prefix}}_jobs_{{.}}" ADD COLUMN IF NOT EXISTS consumers TEXT[] NOT NULL DEFAULT '{""}';
+    ALTER TABLE "{{$.Prefix}}_job_status_{{.}}" ADD COLUMN IF NOT EXISTS consumer TEXT NOT NULL DEFAULT '';
+{{end}}

--- a/sql/migrations/jobsdb_always/000016_multi_consumer_columns.up.tmpl
+++ b/sql/migrations/jobsdb_always/000016_multi_consumer_columns.up.tmpl
@@ -1,0 +1,4 @@
+{{range .Datasets}}
+    ALTER TABLE "{{$.Prefix}}_jobs_{{.}}" ADD COLUMN IF NOT EXISTS consumers TEXT[] NOT NULL DEFAULT '{""}';
+    ALTER TABLE "{{$.Prefix}}_job_status_{{.}}" ADD COLUMN IF NOT EXISTS consumer TEXT NOT NULL DEFAULT '';
+{{end}}

--- a/sql/migrations/node/000020_unionjobsdb_mc_fn.up.sql
+++ b/sql/migrations/node/000020_unionjobsdb_mc_fn.up.sql
@@ -1,0 +1,121 @@
+-- unionjobsdb function automatically joins datasets and returns jobs
+-- along with their latest jobs status (or null)
+--
+-- Parameters
+-- prefix: table prefix, e.g. gw, rt, batch_rt
+-- num: number of datasets to include in the query, e.g. 4
+DROP FUNCTION IF EXISTS unionjobsdb(text, integer);
+CREATE FUNCTION unionjobsdb(prefix text, num int)
+RETURNS table (
+  t_name text,
+  job_id bigint,
+  workspace_id text,
+  uuid uuid,
+  user_id text,
+  partition_id text,
+  parameters jsonb,
+  custom_val character varying(64),
+  event_payload text,
+  event_count integer,
+  created_at timestamp with time zone,
+  expire_at timestamp with time zone,
+  consumers text[],
+  status_id bigint,
+  consumer text,
+  job_state character varying(64),
+  attempt smallint,
+  exec_time timestamp with time zone,
+  error_code character varying(32),
+  error_response jsonb
+)
+AS $$
+DECLARE
+  qry text;
+BEGIN
+SELECT string_agg(
+    format(
+      'SELECT %1$L, j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.parameters, j.custom_val, j.event_payload, j.event_count, j.created_at, j.expire_at, j.consumers, s.id, s.consumer, s.job_state, s.attempt, s.exec_time, s.error_code, s.error_response'
+      ' FROM %1$I j LEFT JOIN %2$I s ON s.job_id = j.job_id',
+      alltables.table_name,
+      CASE
+        WHEN to_regclass(prefix || '_consumers_' || substring(alltables.table_name, char_length(prefix)+7, 30)) IS NOT NULL
+        THEN 'v_last_c_' || prefix || '_job_status_' || substring(alltables.table_name, char_length(prefix)+7, 30)
+        ELSE 'v_last_'   || prefix || '_job_status_' || substring(alltables.table_name, char_length(prefix)+7, 30)
+      END
+    ),
+    ' UNION ') INTO qry
+  FROM (
+    SELECT c.relname AS table_name
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    LEFT JOIN pg_catalog.pg_description d ON d.objoid = c.oid AND d.objsubid = 0
+    WHERE c.relkind = 'r'
+      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+      AND c.relname LIKE prefix || '_jobs_%'
+      AND COALESCE(d.description, '') NOT LIKE 'rudder:pre_drop:%'
+    ORDER BY c.relname ASC LIMIT num
+  ) alltables;
+RETURN QUERY EXECUTE qry;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- unionjobsdbmetadata function automatically joins datasets and returns jobs
+-- along with their latest jobs status (or null) excluding the payload
+--
+-- Parameters
+-- prefix: table prefix, e.g. gw, rt, batch_rt
+-- num: number of datasets to include in the query, e.g. 4
+DROP FUNCTION IF EXISTS unionjobsdbmetadata(text, integer);
+CREATE FUNCTION unionjobsdbmetadata(prefix text, num int)
+RETURNS table (
+  t_name text,
+  job_id bigint,
+  workspace_id text,
+  uuid uuid,
+  user_id text,
+  partition_id text,
+  parameters jsonb,
+  custom_val character varying(64),
+  event_count integer,
+  created_at timestamp with time zone,
+  expire_at timestamp with time zone,
+  consumers text[],
+  status_id bigint,
+  consumer text,
+  job_state character varying(64),
+  attempt smallint,
+  exec_time timestamp with time zone,
+  error_code character varying(32),
+  error_response jsonb
+)
+AS $$
+DECLARE
+  qry text;
+BEGIN
+SELECT string_agg(
+    format(
+      'SELECT %1$L, j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.parameters, j.custom_val, j.event_count, j.created_at, j.expire_at, j.consumers, s.id, s.consumer, s.job_state, s.attempt, s.exec_time, s.error_code, s.error_response'
+      ' FROM %1$I j LEFT JOIN %2$I s ON s.job_id = j.job_id',
+      alltables.table_name,
+      CASE
+        WHEN to_regclass(prefix || '_consumers_' || substring(alltables.table_name, char_length(prefix)+7, 30)) IS NOT NULL
+        THEN 'v_last_c_' || prefix || '_job_status_' || substring(alltables.table_name, char_length(prefix)+7, 30)
+        ELSE 'v_last_'   || prefix || '_job_status_' || substring(alltables.table_name, char_length(prefix)+7, 30)
+      END
+    ),
+    ' UNION ') INTO qry
+  FROM (
+    SELECT c.relname AS table_name
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    LEFT JOIN pg_catalog.pg_description d ON d.objoid = c.oid AND d.objsubid = 0
+    WHERE c.relkind = 'r'
+      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+      AND c.relname LIKE prefix || '_jobs_%'
+      AND COALESCE(d.description, '') NOT LIKE 'rudder:pre_drop:%'
+    ORDER BY c.relname ASC LIMIT num
+  ) alltables;
+RETURN QUERY EXECUTE qry;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
# Description

Adds the foundational schema and infrastructure for multi-consumer support in jobsdb. Today each jobsdb handle has a single implicit consumer: a job's latest status determines its state. This is a first step towards allowing jobs to be consumed independently by multiple consumers, each with its own status timeline per job.

The feature is opt-in per handle via `WithMultiConsumer()`. Single-consumer handles are completely unaffected — no schema changes, no query overhead.

An existing single-consumer jobsdb can be converted to multi-consumer at runtime. On first startup with `WithMultiConsumer()`, jobsdb upgrades any existing datasets to the multi-consumer schema. The upgrade is idempotent and crash-safe.

## Linear Ticket

resolves PIPE-3058

## Security

- [X] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #7096 
- <kbd>&nbsp;4&nbsp;</kbd> #7083 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #7094 
- <kbd>&nbsp;2&nbsp;</kbd> #7093 
- <kbd>&nbsp;1&nbsp;</kbd> #7082 
<!-- GitButler Footer Boundary Bottom -->

