### PR TITLE
chore: support using the full event schema key as pulsar ordering key

### DIFF
--- a/schema-forwarder/internal/batcher/batcher.go
+++ b/schema-forwarder/internal/batcher/batcher.go
@@ -8,9 +8,10 @@ import (
 
 // A batch of jobs that share the same schema.
 type EventSchemaMessageBatch struct {
-	Index   int
-	Message *proto.EventSchemaMessage
-	Jobs    []*jobsdb.JobT
+	Index    int
+	Message  *proto.EventSchemaMessage
+	SourceID string
+	Jobs     []*jobsdb.JobT
 }
 
 // NewEventSchemaMessageBatcher creates a new batcher.
@@ -32,7 +33,7 @@ type EventSchemaMessageBatcher struct {
 // Add adds a job to the batcher after transforming it to an [EventSchemaMessage].
 // If the message is already in the batcher, the two messages will be merged to one.
 func (sb *EventSchemaMessageBatcher) Add(job *jobsdb.JobT) error {
-	msg, err := sb.transformer.Transform(job)
+	msg, sourceID, err := sb.transformer.Transform(job)
 	if err != nil {
 		return err
 	}
@@ -45,8 +46,9 @@ func (sb *EventSchemaMessageBatcher) Add(job *jobsdb.JobT) error {
 	if _, ok := sb.batchIndex[key]; !ok {
 		sb.batchOrder = append(sb.batchOrder, key)
 		sb.batchIndex[key] = &EventSchemaMessageBatch{
-			Message: msg,
-			Jobs:    []*jobsdb.JobT{job},
+			Message:  msg,
+			SourceID: sourceID,
+			Jobs:     []*jobsdb.JobT{job},
 		}
 	} else {
 		sb.batchIndex[key].Jobs = append(sb.batchIndex[key].Jobs, job)

--- a/schema-forwarder/internal/batcher/batcher_test.go
+++ b/schema-forwarder/internal/batcher/batcher_test.go
@@ -84,16 +84,17 @@ func TestEventSchemaMessageBatcher(t *testing.T) {
 }
 
 type mockTransformer struct {
-	fail bool
-	msg  *proto.EventSchemaMessage
+	fail     bool
+	msg      *proto.EventSchemaMessage
+	sourceID string
 }
 
 func (*mockTransformer) Start() {}
 func (*mockTransformer) Stop()  {}
 
-func (mt *mockTransformer) Transform(job *jobsdb.JobT) (*proto.EventSchemaMessage, error) {
+func (mt *mockTransformer) Transform(job *jobsdb.JobT) (*proto.EventSchemaMessage, string, error) {
 	if mt.fail {
-		return nil, errors.New("failed")
+		return nil, "", errors.New("failed")
 	}
-	return mt.msg, nil
+	return mt.msg, mt.sourceID, nil
 }

--- a/schema-forwarder/internal/forwarder/jobsforwarder.go
+++ b/schema-forwarder/internal/forwarder/jobsforwarder.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -38,11 +39,13 @@ type JobsForwarder struct {
 	pulsarClient   *pulsar.Client          // pulsar client used to create producers
 	pulsarProducer pulsar.ProducerAdapter  // pulsar producer used to forward jobs to pulsar
 
-	topic                string                            // topic to which jobs are forwarded
-	maxSampleSize        config.ValueLoader[int64]         // max payload size for the samples to include in the schema messages
-	initialRetryInterval config.ValueLoader[time.Duration] // initial retry interval for the backoff mechanism
-	maxRetryInterval     config.ValueLoader[time.Duration] // max retry interval for the backoff mechanism
-	maxRetryElapsedTime  config.ValueLoader[time.Duration] // max retry elapsed time for the backoff mechanism
+	topic                string                              // topic to which jobs are forwarded
+	maxSampleSize        config.ValueLoader[int64]           // max payload size for the samples to include in the schema messages
+	initialRetryInterval config.ValueLoader[time.Duration]   // initial retry interval for the backoff mechanism
+	maxRetryInterval     config.ValueLoader[time.Duration]   // max retry interval for the backoff mechanism
+	maxRetryElapsedTime  config.ValueLoader[time.Duration]   // max retry elapsed time for the backoff mechanism
+	conf                 *config.Config                      // config used to resolve hierarchical settings at runtime
+	fullOrderKeyCache    map[string]*config.Reloadable[bool] // sourceID -> reloadable "full order key" setting, resolved hierarchically; only accessed by the single forwarder goroutine
 }
 
 // NewJobsForwarder returns a new, properly initialized, JobsForwarder
@@ -50,6 +53,7 @@ func NewJobsForwarder(terminalErrFn func(error), schemaDB jobsdb.JobsDB, client 
 	var forwarder JobsForwarder
 	forwarder.LoadMetaData(terminalErrFn, schemaDB, log, config, stat)
 
+	forwarder.conf = config
 	forwarder.transformer = transformer.New(backendConfig, config)
 	forwarder.sampler = newSampler[string](config.GetDurationVar(10, time.Minute, "SchemaForwarder.samplingPeriod"), config.GetIntVar(10000, 1, "SchemaForwarder.sampleCacheSize"))
 	forwarder.pulsarClient = client
@@ -65,6 +69,7 @@ func (jf *JobsForwarder) setupReloadableVars() {
 	jf.maxRetryInterval = config.GetReloadableDurationVar(60, time.Second, "SchemaForwarder.maxRetryInterval")
 	jf.maxRetryElapsedTime = config.GetReloadableDurationVar(60, time.Minute, "SchemaForwarder.maxRetryElapsedTime")
 	jf.maxSampleSize = config.GetReloadableInt64Var(10*bytesize.KB, 1, "SchemaForwarder.maxSampleSize")
+	jf.fullOrderKeyCache = make(map[string]*config.Reloadable[bool])
 }
 
 // Start starts the forwarder which will start forwarding jobs from database to the appropriate pulsar topics
@@ -142,7 +147,7 @@ func (jf *JobsForwarder) Start() error {
 					toForward := append([]*batcher.EventSchemaMessageBatch{}, messageBatches...)
 					for _, batch := range toForward {
 						msg := batch.Message
-						orderKey := msg.Key.WriteKey
+						orderKey := jf.orderKey(batch)
 						jf.pulsarProducer.SendMessageAsync(ctx, orderKey, orderKey, msg.MustMarshal(),
 							func(_ pulsarType.MessageID, _ *pulsarType.ProducerMessage, err error) {
 								if err == nil { // mark job as succeeded and remove from toRetry
@@ -241,4 +246,38 @@ func (jf *JobsForwarder) Stop() {
 	_ = jf.g.Wait()
 	jf.transformer.Stop()
 	jf.pulsarProducer.Close()
+}
+
+// orderKey builds the pulsar ordering/partition key for a batch.
+//
+// By default the key is the source's write key, which guarantees ordering and
+// co-location of all events belonging to the same source. When the full order
+// key is enabled (hierarchically, per source or globally) the event type and
+// event identifier are appended to the key, trading a coarser ordering
+// guarantee for finer-grained partitioning and higher downstream parallelism.
+func (jf *JobsForwarder) orderKey(batch *batcher.EventSchemaMessageBatch) string {
+	msg := batch.Message
+	if !jf.fullOrderKey(batch.SourceID).Load() {
+		return msg.Key.WriteKey
+	}
+	return strings.Join([]string{msg.Key.WriteKey, msg.Key.EventType, msg.Key.EventIdentifier}, ":")
+}
+
+// fullOrderKey returns the reloadable setting controlling whether the event type
+// and identifier should be included in the ordering key for the given source.
+// The setting is resolved hierarchically, the first key that is set wins, and
+// the resulting reloadable is cached per source id:
+//
+//	SchemaForwarder.<source-id>.fullOrderKey
+//	SchemaForwarder.fullOrderKey
+func (jf *JobsForwarder) fullOrderKey(sourceID string) *config.Reloadable[bool] {
+	if setting, ok := jf.fullOrderKeyCache[sourceID]; ok {
+		return setting
+	}
+	setting := jf.conf.GetReloadableBoolVar(false,
+		"SchemaForwarder."+sourceID+".fullOrderKey",
+		"SchemaForwarder.fullOrderKey",
+	)
+	jf.fullOrderKeyCache[sourceID] = setting
+	return setting
 }

--- a/schema-forwarder/internal/transformer/transformer.go
+++ b/schema-forwarder/internal/transformer/transformer.go
@@ -23,7 +23,7 @@ import (
 
 type Transformer interface {
 	Start()
-	Transform(job *jobsdb.JobT) (*proto.EventSchemaMessage, error)
+	Transform(job *jobsdb.JobT) (msg *proto.EventSchemaMessage, sourceID string, err error)
 	Stop()
 }
 
@@ -66,25 +66,26 @@ func (st *transformer) Stop() {
 }
 
 // Transform transforms the job into a schema message and returns the schema message along with write key
-func (st *transformer) Transform(job *jobsdb.JobT) (*proto.EventSchemaMessage, error) {
+func (st *transformer) Transform(job *jobsdb.JobT) (*proto.EventSchemaMessage, string, error) {
 	var eventPayload map[string]any
 	if err := jsonrs.Unmarshal(job.EventPayload, &eventPayload); err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	writeKey := st.getWriteKeyFromParams(job.Parameters)
+	sourceID := gjson.GetBytes(job.Parameters, "source_id").Str
+	writeKey := st.writeKeyForSourceID(sourceID)
 	if writeKey == "" {
-		return nil, fmt.Errorf("writeKey could not be found")
+		return nil, "", fmt.Errorf("writeKey could not be found")
 	}
 	schemaKey := st.getSchemaKeyFromJob(eventPayload, writeKey)
 	if st.identifierLimit > 0 && len(schemaKey.EventIdentifier) > st.identifierLimit {
-		return nil, fmt.Errorf("event identifier size is greater than %d", st.identifierLimit)
+		return nil, "", fmt.Errorf("event identifier size is greater than %d", st.identifierLimit)
 	}
 	schemaMessage, err := st.getSchemaMessage(schemaKey, eventPayload, []byte("{}"), job.WorkspaceId, job.CreatedAt)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
-	return schemaMessage, nil
+	return schemaMessage, sourceID, nil
 }
 
 // getSchemaKeyFromJob returns the schema key from the job based on the event type and event identifier
@@ -193,13 +194,12 @@ func (st *transformer) disablePIIReporting(writeKey string) bool {
 	return st.newPIIReportingSettings[writeKey]
 }
 
-// getWriteKeyFromParams returns the write key from the job parameters
-func (st *transformer) getWriteKeyFromParams(parameters json.RawMessage) string {
-	sourceId := gjson.GetBytes(parameters, "source_id").Str
-	if sourceId == "" {
-		return sourceId
+// writeKeyForSourceID returns the write key configured for the given source id
+func (st *transformer) writeKeyForSourceID(sourceID string) string {
+	if sourceID == "" {
+		return ""
 	}
 	st.mu.RLock()
 	defer st.mu.RUnlock()
-	return st.sourceWriteKeyMap[sourceId]
+	return st.sourceWriteKeyMap[sourceID]
 }

--- a/schema-forwarder/internal/transformer/transformer_test.go
+++ b/schema-forwarder/internal/transformer/transformer_test.go
@@ -72,8 +72,9 @@ func Test_SchemaTransformer_NoDataRetention(t *testing.T) {
 		require.Equal(t, schemaTransformer.getSchemaKeyFromJob(testdata.TrackEvent, testdata.WriteKeyEnabled), &testdata.TestEventSchemaKey)
 	})
 
-	t.Run("Test getWriteKeyFromParams", func(t *testing.T) {
-		require.Equal(t, schemaTransformer.getWriteKeyFromParams(testdata.TestParams), testdata.WriteKeyEnabled)
+	t.Run("Test writeKeyForSourceID", func(t *testing.T) {
+		require.Equal(t, schemaTransformer.writeKeyForSourceID(testdata.SourceIDEnabled), testdata.WriteKeyEnabled)
+		require.Empty(t, schemaTransformer.writeKeyForSourceID(""))
 	})
 
 	t.Run("Test getSchemaMessage", func(t *testing.T) {
@@ -87,8 +88,9 @@ func Test_SchemaTransformer_NoDataRetention(t *testing.T) {
 
 	t.Run("Test Transform", func(t *testing.T) {
 		timeNow := time.Now()
-		eventSchemaMessage, err := schemaTransformer.Transform(generateTestJob(t, timeNow))
+		eventSchemaMessage, sourceID, err := schemaTransformer.Transform(generateTestJob(t, timeNow))
 		require.Nil(t, err)
+		require.Equal(t, testdata.SourceIDEnabled, sourceID)
 		testSchemaMessage := generateTestEventSchemaMessage(timeNow)
 		require.Nil(t, err)
 		require.Equal(t, eventSchemaMessage.Schema, testSchemaMessage.Schema)
@@ -102,7 +104,7 @@ func Test_SchemaTransformer_NoDataRetention(t *testing.T) {
 		event1 := generateTestJob(t, time.Now())
 		event1.EventPayload = fmt.Appendf(nil, `{"type": "track", "event": %q}`, rand.String(schemaTransformer.identifierLimit+1))
 
-		e, err := schemaTransformer.Transform(event1)
+		e, _, err := schemaTransformer.Transform(event1)
 		require.Nil(t, e)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "event identifier size is greater than")
@@ -117,7 +119,7 @@ func Test_SchemaTransformer_NoDataRetention(t *testing.T) {
 		event2.EventPayload, err = jsonrs.Marshal(payload)
 		require.NoError(t, err)
 
-		e, err = schemaTransformer.Transform(event2)
+		e, _, err = schemaTransformer.Transform(event2)
 		require.Nil(t, e)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "event schema has more than")
@@ -143,7 +145,7 @@ func Test_SchemaTransformer_Interface(t *testing.T) {
 	<-closeChan
 	t.Run("Test Transform", func(t *testing.T) {
 		timeNow := time.Now()
-		eventSchemaMessage, err := schemaTransformer.Transform(generateTestJob(t, timeNow))
+		eventSchemaMessage, _, err := schemaTransformer.Transform(generateTestJob(t, timeNow))
 		require.Nil(t, err)
 		testSchemaMessage := generateTestEventSchemaMessage(timeNow)
 		require.Nil(t, err)


### PR DESCRIPTION
# Description

By default the schema forwarder uses a source's write key as the pulsar ordering/partition key, which keeps all of a source's events on a single partition. For sources with high throughput this caps downstream processing parallelism.

This adds an opt-in, hot-reloadable config to use the full event schema key (`writeKey:eventType:eventIdentifier`) as the ordering key, spreading a source's events across more partitions. It can be set per source or globally:

```
SchemaForwarder.<source-id>.fullOrderKey
SchemaForwarder.fullOrderKey   # default: false
```

Default behaviour is unchanged.

## Linear Ticket

resolves PIPE-3116

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.