### PR TITLE
chore(jobsdb): multi-consumer-specific indexes and views

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -375,6 +375,7 @@ type Handle struct {
 		MaxDSSize                       config.ValueLoader[int]
 		numPartitions                   int // if zero or negative, no partitioning
 		partitionFunction               func(job *JobT) string
+		multiConsumer                   bool // if true, enables per-consumer indexes, views, and query paths
 		warnOnStatusMissingPartitionID  config.ValueLoader[bool]
 		holdDSListLockDuringStore       config.ValueLoader[bool] // escape hatch: hold the dsList read lock for the entire store callback
 		staleDSListMaxRetries           config.ValueLoader[int]

--- a/jobsdb/jobsdb_dataset_ddl.go
+++ b/jobsdb/jobsdb_dataset_ddl.go
@@ -212,22 +212,41 @@ func (jd *Handle) createDSJobIndicesInTx(ctx context.Context, tx *Tx, newDS data
 			return fmt.Errorf("creating %s index: %w", param, err)
 		}
 	}
+	if jd.conf.multiConsumer {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_consumers" ON %[1]q USING GIN (consumers)`, newDS.JobTable)); err != nil {
+			return fmt.Errorf("creating consumers GIN index: %w", err)
+		}
+	}
 	return nil
 }
 
 // createDSStatusIndicesInTx creates the indices on the job status table plus the
-// v_last view.
+// v_last view. On multi-consumer handles it also creates the v_last_c_ view and
+// the wider (job_id, consumer, id DESC, job_state) pickup index.
+// v_last_ is always created so that a soft downgrade (disabling WithMultiConsumer without
+// the guard) finds the view and can at least start — callers accept single-consumer semantics
+// during a downgrade window.
 func (jd *Handle) createDSStatusIndicesInTx(ctx context.Context, tx *Tx, newDS dataSetT) error {
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_jid_id_js" ON %[1]q(job_id asc,id desc,job_state)`, newDS.JobStatusTable)); err != nil {
-		return fmt.Errorf("adding job_id_id index: %w", err)
-	}
-	// index used for maxDSRetention during compaction
+	// retention index — consumer-agnostic, always created
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_id_js" ON %[1]q(id ,job_state) INCLUDE (exec_time)`, newDS.JobStatusTable)); err != nil {
-		return fmt.Errorf("adding job_id_js index: %w", err)
+		return fmt.Errorf("adding id_js index: %w", err)
+	}
+	// v_last_ is always created (see comment above)
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE VIEW "v_last_%[1]s" AS SELECT DISTINCT ON (job_id) * FROM %[1]q ORDER BY job_id ASC, id DESC`, newDS.JobStatusTable)); err != nil {
+		return fmt.Errorf("creating v_last view: %w", err)
 	}
 
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE VIEW "v_last_%[1]s" AS SELECT DISTINCT ON (job_id) * FROM %[1]q ORDER BY job_id ASC, id DESC`, newDS.JobStatusTable)); err != nil {
-		return fmt.Errorf("create view: %w", err)
+	if jd.conf.multiConsumer {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_jid_c_id_js" ON %[1]q (job_id ASC, consumer, id DESC, job_state)`, newDS.JobStatusTable)); err != nil {
+			return fmt.Errorf("adding jid_c_id_js index: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE VIEW "v_last_c_%[1]s" AS SELECT DISTINCT ON (job_id, consumer) * FROM %[1]q ORDER BY job_id ASC, consumer, id DESC`, newDS.JobStatusTable)); err != nil {
+			return fmt.Errorf("creating v_last_c view: %w", err)
+		}
+	} else {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_jid_id_js" ON %[1]q(job_id asc,id desc,job_state)`, newDS.JobStatusTable)); err != nil {
+			return fmt.Errorf("adding jid_id_js index: %w", err)
+		}
 	}
 	return nil
 }

--- a/jobsdb/jobsdb_factory.go
+++ b/jobsdb/jobsdb_factory.go
@@ -113,6 +113,15 @@ func WithTriggerAddNewDS(trigger func() <-chan time.Time) OptsFunc {
 	}
 }
 
+// WithMultiConsumer enables multi-consumer mode for this handle.
+// This is a one-way option: once datasets exist with the multi-consumer schema,
+// removing this option will cause startup to fail.
+func WithMultiConsumer() OptsFunc {
+	return func(jd *Handle) {
+		jd.conf.multiConsumer = true
+	}
+}
+
 // withDatabaseTablesVersion sets the schema version used by table migration tests.
 func withDatabaseTablesVersion(dbVersion int) OptsFunc {
 	return func(jd *Handle) {


### PR DESCRIPTION
# Description

Adds the `WithMultiConsumer()` constructor option and branches the per-dataset index/view DDL on it.

**Single-consumer JobsDBs** are completely unchanged: they keep the existing `(job_id ASC, id DESC, job_state)` pickup index and the `v_last_<status>` view (`DISTINCT ON (job_id)`).

**Multi-consumer JobsDBs** get a different DDL set per dataset:
- GIN index on `consumers` — serves the `@>` array-containment membership filter used by consumer-scoped pickup queries.
- Composite status index `(job_id ASC, consumer, id DESC, job_state)` — one column wider than the single-consumer index, makes the per-consumer latest-status computation an index-ordered scan.
- `v_last_c_<status>` view — `DISTINCT ON (job_id, consumer)`, returns one latest-status row per *(job, consumer)* pair.

The retention index `(id, job_state) INCLUDE (exec_time)` is consumer-agnostic and created for all handles.

Zero runtime overhead for single-consumer handles: they never create the GIN index, the wider status index, or the `v_last_c_` view.

## Linear Ticket

resolves PIPE-3058

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.