### PR TITLE
chore(jobsdb): multiconsumer flip, registry table and unionjobsdb

### DIFF
--- a/jobsdb/jobsdb_consumer_test.go
+++ b/jobsdb/jobsdb_consumer_test.go
@@ -1,0 +1,250 @@
+package jobsdb
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+)
+
+// TestMultiConsumerJobsDB_SingleConsumer verifies that a multi-consumer handle works
+// correctly when all jobs use the default (legacy) single consumer.
+//
+// The v_last_c_ view (DISTINCT ON job_id, consumer) is semantically equivalent to
+// v_last_ (DISTINCT ON job_id) when there is a single consumer per job, so Store,
+// GetUnprocessed and UpdateJobStatus should all behave identically to the
+// single-consumer path.
+func TestMultiConsumerJobsDB_SingleConsumer(t *testing.T) {
+	postgres := startPostgres(t)
+
+	c := config.New()
+	c.Set("jobsdb.maxDSSize", 10)
+
+	prefix := strings.ToLower(rand.String(5))
+	jd := NewForReadWrite(prefix,
+		WithDBHandle(postgres.DB),
+		WithConfig(c),
+		WithMultiConsumer(),
+	)
+	require.NoError(t, jd.Start())
+	defer jd.TearDown()
+
+	ctx := context.Background()
+	customVal := "MC"
+
+	// store jobs (no Consumers set → defaults to {""})
+	jobs := make([]*JobT, 3)
+	for i := range jobs {
+		jobs[i] = &JobT{
+			UUID:         uuid.New(),
+			UserID:       "user-1",
+			CustomVal:    customVal,
+			Parameters:   []byte(`{"source_id":"src1"}`),
+			EventPayload: []byte(`{}`),
+			EventCount:   1,
+			WorkspaceId:  defaultWorkspaceID,
+		}
+	}
+	require.NoError(t, jd.Store(ctx, jobs))
+
+	// get unprocessed — v_last_c_ is used internally
+	res, err := jd.GetUnprocessed(ctx, GetQueryParams{
+		CustomValFilters: []string{customVal},
+		JobsLimit:        10,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Jobs, 3, "all stored jobs should be unprocessed")
+	for _, j := range res.Jobs {
+		require.Equal(t, []string{""}, j.Consumers, "legacy consumer should be {\"\"}")
+	}
+
+	// mark all succeeded
+	statuses := make([]*JobStatusT, len(res.Jobs))
+	for i, j := range res.Jobs {
+		statuses[i] = &JobStatusT{
+			JobID:         j.JobID,
+			JobState:      Succeeded.State,
+			AttemptNum:    1,
+			ExecTime:      time.Now(),
+			RetryTime:     time.Now(),
+			ErrorCode:     "200",
+			ErrorResponse: []byte(`{}`),
+			Parameters:    []byte(`{}`),
+			WorkspaceId:   j.WorkspaceId,
+			CustomVal:     j.CustomVal,
+		}
+	}
+	require.NoError(t, jd.UpdateJobStatus(ctx, statuses))
+
+	// no more unprocessed after marking all succeeded
+	res, err = jd.GetUnprocessed(ctx, GetQueryParams{
+		CustomValFilters: []string{customVal},
+		JobsLimit:        10,
+	})
+	require.NoError(t, err)
+	require.Empty(t, res.Jobs)
+
+	// unionjobsdbmetadata detects the registry table and uses v_last_c_
+	verifyUnionJobsDBMetadata(t, postgres.DB, prefix, 3)
+}
+
+// TestMultiConsumerJobsDB_Conversion verifies the single → multi-consumer upgrade path.
+//
+// A plain handle stores and processes jobs using the legacy schema. When the same prefix
+// is re-opened with WithMultiConsumer(), applyMultiConsumerFlip runs and creates the
+// v_last_c_ view and consumers registry table for each existing dataset. After the flip,
+// GetUnprocessed and unionjobsdbmetadata must continue to work correctly.
+func TestMultiConsumerJobsDB_Conversion(t *testing.T) {
+	postgres := startPostgres(t)
+
+	c := config.New()
+	c.Set("jobsdb.maxDSSize", 10)
+
+	prefix := strings.ToLower(rand.String(5))
+	customVal := "CONV"
+
+	// Phase 1: plain single-consumer handle — store 3 jobs, mark 2 succeeded.
+	jdSingle := NewForReadWrite(prefix,
+		WithDBHandle(postgres.DB),
+		WithConfig(c),
+	)
+	require.NoError(t, jdSingle.Start())
+
+	ctx := context.Background()
+	jobs := make([]*JobT, 3)
+	for i := range jobs {
+		jobs[i] = &JobT{
+			UUID:         uuid.New(),
+			UserID:       "user-1",
+			CustomVal:    customVal,
+			Parameters:   []byte(`{"source_id":"src1"}`),
+			EventPayload: []byte(`{}`),
+			EventCount:   1,
+			WorkspaceId:  defaultWorkspaceID,
+		}
+	}
+	require.NoError(t, jdSingle.Store(ctx, jobs))
+
+	res, err := jdSingle.GetUnprocessed(ctx, GetQueryParams{
+		CustomValFilters: []string{customVal},
+		JobsLimit:        10,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Jobs, 3)
+
+	// mark first 2 succeeded, leave one pending
+	statuses := make([]*JobStatusT, 2)
+	for i := range statuses {
+		statuses[i] = &JobStatusT{
+			JobID:         res.Jobs[i].JobID,
+			JobState:      Succeeded.State,
+			AttemptNum:    1,
+			ExecTime:      time.Now(),
+			RetryTime:     time.Now(),
+			ErrorCode:     "200",
+			ErrorResponse: []byte(`{}`),
+			Parameters:    []byte(`{}`),
+			WorkspaceId:   res.Jobs[i].WorkspaceId,
+			CustomVal:     res.Jobs[i].CustomVal,
+		}
+	}
+	require.NoError(t, jdSingle.UpdateJobStatus(ctx, statuses))
+	jdSingle.TearDown()
+
+	// Phase 2: re-open with WithMultiConsumer() — flip runs on startup.
+	jdMC := NewForReadWrite(prefix,
+		WithDBHandle(postgres.DB),
+		WithConfig(c),
+		WithMultiConsumer(),
+	)
+	require.NoError(t, jdMC.Start())
+
+	// One unprocessed job should still be visible via the v_last_c_ view.
+	res, err = jdMC.GetUnprocessed(ctx, GetQueryParams{
+		CustomValFilters: []string{customVal},
+		JobsLimit:        10,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Jobs, 1, "exactly one job should remain unprocessed after conversion")
+	require.Equal(t, []string{""}, res.Jobs[0].Consumers)
+
+	// unionjobsdbmetadata should detect the registry table and use v_last_c_.
+	verifyUnionJobsDBMetadata(t, postgres.DB, prefix, 3)
+	jdMC.TearDown()
+
+	// Phase 3: re-open without WithMultiConsumer() — should NOT panic since only the
+	// legacy empty consumer exists in the registry (no named consumers were ever registered).
+	jdDowngrade := NewForReadWrite(prefix,
+		WithDBHandle(postgres.DB),
+		WithConfig(c),
+	)
+	require.NoError(t, jdDowngrade.Start())
+	jdDowngrade.TearDown()
+
+	// Phase 4: re-open with WithMultiConsumer() and store a job with a named consumer.
+	jdMC2 := NewForReadWrite(prefix,
+		WithDBHandle(postgres.DB),
+		WithConfig(c),
+		WithMultiConsumer(),
+	)
+	require.NoError(t, jdMC2.Start())
+	namedJob := &JobT{
+		UUID:         uuid.New(),
+		UserID:       "user-2",
+		CustomVal:    customVal,
+		Parameters:   []byte(`{"source_id":"src1"}`),
+		EventPayload: []byte(`{}`),
+		EventCount:   1,
+		WorkspaceId:  defaultWorkspaceID,
+		Consumers:    []string{"c1"},
+	}
+	require.NoError(t, jdMC2.Store(ctx, []*JobT{namedJob}))
+	jdMC2.TearDown()
+
+	// Phase 5: re-open without WithMultiConsumer() — must panic since "c1" is in the registry.
+	require.Panics(t, func() {
+		jdDowngrade2 := NewForReadWrite(prefix,
+			WithDBHandle(postgres.DB),
+			WithConfig(c),
+		)
+		_ = jdDowngrade2
+	})
+}
+
+// verifyUnionJobsDBMetadata calls unionjobsdbmetadata and asserts row count,
+// presence of consumers and consumer columns, and non-null status for each row.
+func verifyUnionJobsDBMetadata(t *testing.T, db *sql.DB, prefix string, expectedRows int) {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(),
+		`SELECT t_name, job_id, consumers, status_id, consumer, job_state FROM unionjobsdbmetadata($1, 10)`,
+		prefix,
+	)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var count int
+	for rows.Next() {
+		var (
+			tName     string
+			jobID     int64
+			consumers pq.StringArray
+			statusID  sql.NullInt64
+			consumer  sql.NullString
+			jobState  sql.NullString
+		)
+		require.NoError(t, rows.Scan(&tName, &jobID, &consumers, &statusID, &consumer, &jobState))
+		require.NotEmpty(t, tName)
+		require.NotEmpty(t, consumers)
+		count++
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, expectedRows, count)
+}

--- a/jobsdb/jobsdb_dataset.go
+++ b/jobsdb/jobsdb_dataset.go
@@ -22,10 +22,16 @@ type dataSetT struct {
 	JobTable       string `json:"job"`
 	JobStatusTable string `json:"status"`
 	Index          string `json:"index"`
+	ConsumersTable string `json:"consumers,omitempty"` // non-empty only when the registry table exists
 }
 
 func (ds dataSetT) String() string {
 	return "JobTable=" + ds.JobTable + ",JobStatusTable=" + ds.JobStatusTable + ",Index=" + ds.Index
+}
+
+func (ds dataSetT) consumersRegistryTable() string {
+	prefix := strings.TrimSuffix(ds.JobTable, "_jobs_"+ds.Index)
+	return fmt.Sprintf("%s_consumers_%s", prefix, ds.Index)
 }
 
 type dataSetTList []dataSetT

--- a/jobsdb/jobsdb_dataset_ddl.go
+++ b/jobsdb/jobsdb_dataset_ddl.go
@@ -180,6 +180,13 @@ func (jd *Handle) createDSTablesInTx(ctx context.Context, tx *Tx, newDS dataSetT
 		return fmt.Errorf("creating %s: %w", newDS.JobStatusTable, err)
 	}
 
+	if jd.conf.multiConsumer {
+		registryTable := newDS.consumersRegistryTable()
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE TABLE %q (consumer TEXT PRIMARY KEY)`, registryTable)); err != nil {
+			return fmt.Errorf("creating %s: %w", registryTable, err)
+		}
+	}
+
 	// Record the dataset's creation time as a comment on the jobs table, so that
 	// compaction can tell how recently a dataset was created (see checkIfCompactDS).
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`COMMENT ON TABLE %q IS '%s'`, newDS.JobTable, dsCreatedAtComment(time.Now()))); err != nil {
@@ -361,6 +368,9 @@ func (jd *Handle) cleanupPreDropTables(ctx context.Context) error {
 			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %q CASCADE`, ds.JobTable)); err != nil {
 				return fmt.Errorf("drop %s: %w", ds.JobTable, err)
 			}
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %q`, ds.consumersRegistryTable())); err != nil {
+				return fmt.Errorf("drop %s: %w", ds.consumersRegistryTable(), err)
+			}
 			return nil
 		}); err != nil {
 			return err
@@ -376,6 +386,9 @@ func (jd *Handle) dropDSInTx(tx *Tx, ds dataSetT) error {
 		return err
 	}
 	if _, err = tx.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %q CASCADE`, ds.JobTable)); err != nil {
+		return err
+	}
+	if _, err = tx.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %q`, ds.consumersRegistryTable())); err != nil {
 		return err
 	}
 	jd.postDropDs(ds)
@@ -398,6 +411,8 @@ func (jd *Handle) dropDSForRecovery(ds dataSetT) {
 	jd.execStmtInTx(tx, sqlStatement)
 	sqlStatement = fmt.Sprintf(`DROP TABLE IF EXISTS %q CASCADE`, ds.JobTable)
 	jd.execStmtInTx(tx, sqlStatement)
+	sqlStatement = fmt.Sprintf(`DROP TABLE IF EXISTS %q`, ds.consumersRegistryTable())
+	jd.execStmtInTxAllowMissing(tx, sqlStatement)
 	err = tx.Commit()
 	jd.assertError(err)
 }

--- a/jobsdb/jobsdb_factory.go
+++ b/jobsdb/jobsdb_factory.go
@@ -114,8 +114,6 @@ func WithTriggerAddNewDS(trigger func() <-chan time.Time) OptsFunc {
 }
 
 // WithMultiConsumer enables multi-consumer mode for this handle.
-// This is a one-way option: once datasets exist with the multi-consumer schema,
-// removing this option will cause startup to fail.
 func WithMultiConsumer() OptsFunc {
 	return func(jd *Handle) {
 		jd.conf.multiConsumer = true

--- a/jobsdb/jobsdb_get.go
+++ b/jobsdb/jobsdb_get.go
@@ -338,7 +338,11 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 	}
 
 	joinType := "LEFT"
-	joinTable := "v_last_" + ds.JobStatusTable
+	viewPrefix := "v_last_"
+	if jd.conf.multiConsumer {
+		viewPrefix = "v_last_c_"
+	}
+	joinTable := viewPrefix + ds.JobStatusTable
 	onlyUnprocessed := slices.Equal(stateFilters, []string{Unprocessed.State})
 
 	if !containsUnprocessed { // If we are not querying for unprocessed jobs, we can use an inner join

--- a/jobsdb/jobsdb_lifecycle.go
+++ b/jobsdb/jobsdb_lifecycle.go
@@ -116,25 +116,22 @@ func (jd *Handle) init() {
 				if writer && jd.conf.clearAll {
 					jd.dropDatabaseTables(l)
 				}
-				templateData := func() map[string]any {
-					// Important: if jobsdb type is acting as a writer then refreshDSList
-					// doesn't return the full list of datasets, only the rightmost two.
-					// But we need to run the schema migration against all datasets, no matter
-					// whether jobsdb is a writer or not.
-					datasets, err := getDSList(jd, tx, jd.tablePrefix)
-					jd.assertError(err)
+				// Important: if jobsdb type is acting as a writer then refreshDSList
+				// doesn't return the full list of datasets, only the rightmost two.
+				// But we need to run the schema migration against all datasets, no matter
+				// whether jobsdb is a writer or not.
+				datasets, err := getDSList(jd, tx, jd.tablePrefix)
+				jd.assertError(err)
 
-					datasetIndices := make([]string, 0)
-					for _, dataset := range datasets {
-						datasetIndices = append(datasetIndices, dataset.Index)
-					}
-
-					return map[string]any{
-						"Prefix":              jd.tablePrefix,
-						"Datasets":            datasetIndices,
-						"PartitioningEnabled": jd.conf.numPartitions > 0,
-					}
-				}()
+				datasetIndices := make([]string, 0)
+				for _, dataset := range datasets {
+					datasetIndices = append(datasetIndices, dataset.Index)
+				}
+				templateData := map[string]any{
+					"Prefix":              jd.tablePrefix,
+					"Datasets":            datasetIndices,
+					"PartitioningEnabled": jd.conf.numPartitions > 0,
+				}
 
 				if writer {
 					jd.setupDatabaseTables(templateData)
@@ -149,8 +146,12 @@ func (jd *Handle) init() {
 				// Changesets that run always can help in such cases, by bringing non-migrated tables into a usable state.
 				jd.runAlwaysChangesets(templateData)
 
+				// Apply the multi-consumer flip: upgrades datasets to multi-consumer schema when
+				// multiConsumer is enabled, or asserts no named consumers exist when disabled.
+				jd.assertError(jd.applyMultiConsumerFlip(context.Background(), tx, datasets))
+
 				// finally refresh the dataset list to make sure [datasetList] field is populated
-				err := jd.doRefreshDSRangeListWithDB(l, jd.dbHandle)
+				err = jd.doRefreshDSRangeListWithDB(l, jd.dbHandle)
 				jd.assertError(err)
 			})
 			return nil

--- a/jobsdb/jobsdb_multiconsumer.go
+++ b/jobsdb/jobsdb_multiconsumer.go
@@ -1,0 +1,94 @@
+package jobsdb
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/lib/pq"
+	"github.com/samber/lo"
+
+	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
+)
+
+// applyMultiConsumerFlip handles both directions of the multi-consumer transition.
+//
+// Upgrade (multiConsumer=true): ensures every dataset in dsList has the v_last_c_ view
+// and consumers registry table. Idempotent — already-migrated datasets are skipped.
+// The registry table is the canonical marker: ConsumersTable != "" means fully migrated.
+//
+// Downgrade (multiConsumer=false): asserts that no dataset's registry contains a named
+// (non-empty) consumer. Datasets whose registry holds only the legacy empty-string consumer
+// are safe to ignore. Panics if named consumers are found, because consumer-scoped status
+// data cannot be faithfully represented in the single-consumer schema.
+func (jd *Handle) applyMultiConsumerFlip(ctx context.Context, tx *Tx, dsList []dataSetT) error {
+	if jd.conf.multiConsumer {
+		pending := lo.Filter(dsList, func(ds dataSetT, _ int) bool { return ds.ConsumersTable == "" })
+		if len(pending) == 0 {
+			return nil
+		}
+		return jd.withMaintenanceTx(ctx, func(mtx *Tx) error {
+			for _, ds := range pending {
+				viewName := "v_last_c_" + ds.JobStatusTable
+				registry := ds.consumersRegistryTable()
+
+				if _, err := mtx.ExecContext(ctx, fmt.Sprintf(
+					`CREATE OR REPLACE VIEW %q AS SELECT DISTINCT ON (job_id, consumer) * FROM %q ORDER BY job_id ASC, consumer, id DESC`,
+					viewName, ds.JobStatusTable,
+				)); err != nil {
+					return fmt.Errorf("creating view %s: %w", viewName, err)
+				}
+				// Create the registry and seed the legacy empty consumer in one shot.
+				if _, err := mtx.ExecContext(ctx, fmt.Sprintf(
+					`CREATE TABLE %q (consumer TEXT PRIMARY KEY); INSERT INTO %q VALUES ('')`,
+					registry, registry,
+				)); err != nil {
+					return fmt.Errorf("creating registry table %s: %w", registry, err)
+				}
+			}
+			return nil
+		})
+	}
+	for _, ds := range dsList {
+		if ds.ConsumersTable == "" {
+			continue
+		}
+		var count int
+		if err := tx.QueryRowContext(ctx,
+			fmt.Sprintf(`SELECT COUNT(*) FROM %q WHERE consumer != ''`, ds.ConsumersTable),
+		).Scan(&count); err != nil {
+			return fmt.Errorf("checking consumers registry %q: %w", ds.ConsumersTable, err)
+		}
+		if count > 0 {
+			return fmt.Errorf(
+				"jobsdb %q: named consumers exist in %q but WithMultiConsumer() is not set — downgrade is unsupported",
+				jd.tablePrefix, ds.ConsumersTable,
+			)
+		}
+	}
+	return nil
+}
+
+// registerConsumers inserts new consumer values from jobList into the dataset's
+// registry table. Existing entries are silently ignored (ON CONFLICT DO NOTHING).
+// Consumers are sorted before insertion for a stable, index-friendly, deadlock-avoiding order.
+func (jd *Handle) registerConsumers(ctx context.Context, tx *Tx, ds dataSetT, jobList []*JobT) error {
+	seen := map[string]struct{}{}
+	for _, job := range jobList {
+		consumers := job.Consumers
+		if len(consumers) == 0 {
+			seen[""] = struct{}{}
+			continue
+		}
+		for _, c := range consumers {
+			seen[c] = struct{}{}
+		}
+	}
+	sorted := lo.Keys(seen)
+	sort.Strings(sorted)
+	_, err := tx.ExecContext(ctx,
+		fmt.Sprintf(`INSERT INTO %q SELECT unnest($1::text[]) ON CONFLICT DO NOTHING`, ds.consumersRegistryTable()),
+		pq.Array(sorted),
+	)
+	return err
+}

--- a/jobsdb/jobsdb_store.go
+++ b/jobsdb/jobsdb_store.go
@@ -160,9 +160,13 @@ func (jd *Handle) doStoreJobsInTx(ctx context.Context, tx *Tx, ds dataSetT, jobL
 			return err
 		}
 		if len(jobList) > jd.conf.analyzeThreshold.Load() {
-			_, err = tx.ExecContext(ctx, fmt.Sprintf(`ANALYZE %q`, ds.JobTable))
+			if _, err = tx.ExecContext(ctx, fmt.Sprintf(`ANALYZE %q`, ds.JobTable)); err != nil {
+				return err
+			}
 		}
-
+		if jd.conf.multiConsumer {
+			err = jd.registerConsumers(ctx, tx, ds, jobList)
+		}
 		return err
 	}
 	const (

--- a/jobsdb/jobsdb_utils.go
+++ b/jobsdb/jobsdb_utils.go
@@ -62,6 +62,7 @@ func getDSList(jd asserter, dbHandle sqlDbOrTx, tablePrefix string) ([]dataSetT,
 
 	jobNameMap := map[string]string{}
 	jobStatusNameMap := map[string]string{}
+	consumersNameMap := map[string]string{}
 	var dnumList []string
 
 	for _, t := range tableNames {
@@ -74,6 +75,11 @@ func getDSList(jd asserter, dbHandle sqlDbOrTx, tablePrefix string) ([]dataSetT,
 		if strings.HasPrefix(t, tablePrefix+"_job_status_") {
 			dnum := t[len(tablePrefix+"_job_status_"):]
 			jobStatusNameMap[dnum] = t
+			continue
+		}
+		if strings.HasPrefix(t, tablePrefix+"_consumers_") {
+			dnum := t[len(tablePrefix+"_consumers_"):]
+			consumersNameMap[dnum] = t
 			continue
 		}
 	}
@@ -91,6 +97,7 @@ func getDSList(jd asserter, dbHandle sqlDbOrTx, tablePrefix string) ([]dataSetT,
 				JobTable:       jobName,
 				JobStatusTable: jobStatusName,
 				Index:          dnum,
+				ConsumersTable: consumersNameMap[dnum], // empty when registry table is absent
 			})
 	}
 

--- a/sql/migrations/node/000020_unionjobsdb_mc_fn.up.sql
+++ b/sql/migrations/node/000020_unionjobsdb_mc_fn.up.sql
@@ -1,0 +1,121 @@
+-- unionjobsdb function automatically joins datasets and returns jobs
+-- along with their latest jobs status (or null)
+--
+-- Parameters
+-- prefix: table prefix, e.g. gw, rt, batch_rt
+-- num: number of datasets to include in the query, e.g. 4
+DROP FUNCTION IF EXISTS unionjobsdb(text, integer);
+CREATE FUNCTION unionjobsdb(prefix text, num int)
+RETURNS table (
+  t_name text,
+  job_id bigint,
+  workspace_id text,
+  uuid uuid,
+  user_id text,
+  partition_id text,
+  parameters jsonb,
+  custom_val character varying(64),
+  event_payload text,
+  event_count integer,
+  created_at timestamp with time zone,
+  expire_at timestamp with time zone,
+  consumers text[],
+  status_id bigint,
+  consumer text,
+  job_state character varying(64),
+  attempt smallint,
+  exec_time timestamp with time zone,
+  error_code character varying(32),
+  error_response jsonb
+)
+AS $$
+DECLARE
+  qry text;
+BEGIN
+SELECT string_agg(
+    format(
+      'SELECT %1$L, j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.parameters, j.custom_val, j.event_payload, j.event_count, j.created_at, j.expire_at, j.consumers, s.id, s.consumer, s.job_state, s.attempt, s.exec_time, s.error_code, s.error_response'
+      ' FROM %1$I j LEFT JOIN %2$I s ON s.job_id = j.job_id',
+      alltables.table_name,
+      CASE
+        WHEN to_regclass(prefix || '_consumers_' || substring(alltables.table_name, char_length(prefix)+7, 30)) IS NOT NULL
+        THEN 'v_last_c_' || prefix || '_job_status_' || substring(alltables.table_name, char_length(prefix)+7, 30)
+        ELSE 'v_last_'   || prefix || '_job_status_' || substring(alltables.table_name, char_length(prefix)+7, 30)
+      END
+    ),
+    ' UNION ') INTO qry
+  FROM (
+    SELECT c.relname AS table_name
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    LEFT JOIN pg_catalog.pg_description d ON d.objoid = c.oid AND d.objsubid = 0
+    WHERE c.relkind = 'r'
+      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+      AND c.relname LIKE prefix || '_jobs_%'
+      AND COALESCE(d.description, '') NOT LIKE 'rudder:pre_drop:%'
+    ORDER BY c.relname ASC LIMIT num
+  ) alltables;
+RETURN QUERY EXECUTE qry;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- unionjobsdbmetadata function automatically joins datasets and returns jobs
+-- along with their latest jobs status (or null) excluding the payload
+--
+-- Parameters
+-- prefix: table prefix, e.g. gw, rt, batch_rt
+-- num: number of datasets to include in the query, e.g. 4
+DROP FUNCTION IF EXISTS unionjobsdbmetadata(text, integer);
+CREATE FUNCTION unionjobsdbmetadata(prefix text, num int)
+RETURNS table (
+  t_name text,
+  job_id bigint,
+  workspace_id text,
+  uuid uuid,
+  user_id text,
+  partition_id text,
+  parameters jsonb,
+  custom_val character varying(64),
+  event_count integer,
+  created_at timestamp with time zone,
+  expire_at timestamp with time zone,
+  consumers text[],
+  status_id bigint,
+  consumer text,
+  job_state character varying(64),
+  attempt smallint,
+  exec_time timestamp with time zone,
+  error_code character varying(32),
+  error_response jsonb
+)
+AS $$
+DECLARE
+  qry text;
+BEGIN
+SELECT string_agg(
+    format(
+      'SELECT %1$L, j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.parameters, j.custom_val, j.event_count, j.created_at, j.expire_at, j.consumers, s.id, s.consumer, s.job_state, s.attempt, s.exec_time, s.error_code, s.error_response'
+      ' FROM %1$I j LEFT JOIN %2$I s ON s.job_id = j.job_id',
+      alltables.table_name,
+      CASE
+        WHEN to_regclass(prefix || '_consumers_' || substring(alltables.table_name, char_length(prefix)+7, 30)) IS NOT NULL
+        THEN 'v_last_c_' || prefix || '_job_status_' || substring(alltables.table_name, char_length(prefix)+7, 30)
+        ELSE 'v_last_'   || prefix || '_job_status_' || substring(alltables.table_name, char_length(prefix)+7, 30)
+      END
+    ),
+    ' UNION ') INTO qry
+  FROM (
+    SELECT c.relname AS table_name
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    LEFT JOIN pg_catalog.pg_description d ON d.objoid = c.oid AND d.objsubid = 0
+    WHERE c.relkind = 'r'
+      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+      AND c.relname LIKE prefix || '_jobs_%'
+      AND COALESCE(d.description, '') NOT LIKE 'rudder:pre_drop:%'
+    ORDER BY c.relname ASC LIMIT num
+  ) alltables;
+RETURN QUERY EXECUTE qry;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
# Description

**Registry table** (`<prefix>_consumers_<idx>`):
Each dataset of a multi-consumer handle gets a third table alongside its jobs and status tables, with a single `consumer TEXT PRIMARY KEY` column. Its lifecycle is tied to the dataset — created in the same transaction as the jobs/status tables, dropped with them. It plays three roles:
1. enumerating distinct consumers cheaply without scanning the status table;
2. acting as the stateless schema-presence marker that lets the upgrade/downgrade logic work without a separate persisted flag
3. seeding the dataset's canonical consumer set at compaction time.

**`applyMultiConsumerFlip` — handles both upgrade and downgrade**:
A single function drives both directions of the multi-consumer transition, called unconditionally on every startup.

- **Upgrade** (`multiConsumer=true`): detects pre-flip datasets (those without a registry table) via `getDSList` and for each one runs a single maintenance transaction: creates the `v_last_c_` view (idempotent via `CREATE OR REPLACE`) then creates the registry table and seeds it with `('')` in one statement. Both reader and writer owner types run the flip; already-migrated datasets are skipped.

- **Downgrade** (`multiConsumer=false`): for each dataset that carries a registry table, queries it for any consumer whose value is not the empty string. If none exist the datasets contain only legacy (single-consumer) data and startup proceeds normally. If a named consumer is found the process returns an error (converted to a panic by the caller), because per-consumer status data cannot be faithfully represented in the single-consumer schema.

**`unionjobsdbmetadata` SQL migration**:
Updated to detect the registry table per dataset via `to_regclass` and join the correct view (`v_last_c_` for multi-consumer datasets, `v_last_` for single-consumer), returning `consumers` and `consumer` columns in its result type.

## Linear Ticket

resolves PIPE-3051

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.