### PR TITLE
chore(jobsdb): multi-consumer get and noresults cache handling

### DIFF
--- a/jobsdb/jobsdb_consumer_test.go
+++ b/jobsdb/jobsdb_consumer_test.go
@@ -96,6 +96,80 @@ func TestMultiConsumerJobsDB_SingleConsumer(t *testing.T) {
 	verifyUnionJobsDBMetadata(t, postgres.DB, prefix, 3)
 }
 
+// TestMultiConsumerJobsDB_ConsumerIsolation verifies that consumer-scoped pickup is isolated:
+// consumer A's terminal status does not hide the job from consumer B, and the GIN membership
+// filter ensures only jobs assigned to the querying consumer are returned.
+func TestMultiConsumerJobsDB_ConsumerIsolation(t *testing.T) {
+	postgres := startPostgres(t)
+
+	c := config.New()
+	c.Set("jobsdb.maxDSSize", 10)
+
+	prefix := strings.ToLower(rand.String(5))
+	jd := NewForReadWrite(prefix,
+		WithDBHandle(postgres.DB),
+		WithConfig(c),
+		WithMultiConsumer(),
+	)
+	require.NoError(t, jd.Start())
+	defer jd.TearDown()
+
+	ctx := context.Background()
+	customVal := "ISO"
+
+	// store one job assigned to both consumers A and B
+	job := &JobT{
+		UUID:         uuid.New(),
+		UserID:       "user-1",
+		CustomVal:    customVal,
+		Parameters:   []byte(`{"source_id":"src1"}`),
+		EventPayload: []byte(`{}`),
+		EventCount:   1,
+		WorkspaceId:  defaultWorkspaceID,
+		Consumers:    []string{"A", "B"},
+	}
+	require.NoError(t, jd.Store(ctx, []*JobT{job}))
+
+	// both A and B see the job as unprocessed
+	resA, err := jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "A"})
+	require.NoError(t, err)
+	require.Len(t, resA.Jobs, 1)
+
+	resB, err := jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "B"})
+	require.NoError(t, err)
+	require.Len(t, resB.Jobs, 1)
+
+	// mark the job succeeded for consumer A
+	require.NoError(t, jd.UpdateJobStatus(ctx, []*JobStatusT{{
+		JobID:         resA.Jobs[0].JobID,
+		JobState:      Succeeded.State,
+		AttemptNum:    1,
+		ExecTime:      time.Now(),
+		RetryTime:     time.Now(),
+		ErrorCode:     "200",
+		ErrorResponse: []byte(`{}`),
+		Parameters:    []byte(`{}`),
+		WorkspaceId:   resA.Jobs[0].WorkspaceId,
+		CustomVal:     resA.Jobs[0].CustomVal,
+		Consumer:      "A",
+	}}))
+
+	// A sees no more unprocessed jobs
+	resA, err = jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "A"})
+	require.NoError(t, err)
+	require.Empty(t, resA.Jobs, "consumer A's terminal status should hide the job from A")
+
+	// B still sees the job as unprocessed — A's status does not affect B
+	resB, err = jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "B"})
+	require.NoError(t, err)
+	require.Len(t, resB.Jobs, 1, "consumer B should still see the job after A marked it done")
+
+	// a third consumer C never assigned to this job sees nothing
+	resC, err := jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "C"})
+	require.NoError(t, err)
+	require.Empty(t, resC.Jobs, "consumer C is not in the job's consumers list")
+}
+
 // TestMultiConsumerJobsDB_Conversion verifies the single → multi-consumer upgrade path.
 //
 // A plain handle stores and processes jobs using the legacy schema. When the same prefix
@@ -247,4 +321,99 @@ func verifyUnionJobsDBMetadata(t *testing.T, db *sql.DB, prefix string, expected
 	}
 	require.NoError(t, rows.Err())
 	require.Equal(t, expectedRows, count)
+}
+
+// TestMultiConsumerJobsDB_Cache verifies that the noResultsCache is correctly keyed,
+// populated, and invalidated per consumer. The test accesses the cache directly (same
+// package) rather than inferring its state from timing or DB call counts.
+func TestMultiConsumerJobsDB_Cache(t *testing.T) {
+	postgres := startPostgres(t)
+
+	c := config.New()
+	c.Set("jobsdb.maxDSSize", 100)
+
+	prefix := strings.ToLower(rand.String(5))
+	jd := NewForReadWrite(prefix,
+		WithDBHandle(postgres.DB),
+		WithConfig(c),
+		WithMultiConsumer(),
+	)
+	require.NoError(t, jd.Start())
+	defer jd.TearDown()
+
+	ctx := context.Background()
+	customVal := "CACHE"
+
+	dsIndex := func() string {
+		return HandleInspector{Handle: jd}.getDSListSnapshot()[0].Index
+	}
+	// cacheHit checks whether the noResultsCache has a live "no unprocessed" entry for
+	// the given consumer — workspace and partition are wildcards (empty query params).
+	cacheHit := func(consumer string) bool {
+		return jd.noResultsCache.Get(
+			dsIndex(), nil, "",
+			[]string{customVal},
+			[]string{Unprocessed.State},
+			[]ParameterFilterT{{Name: "consumer", Value: consumer}},
+		)
+	}
+	makeJob := func(consumers []string) *JobT {
+		return &JobT{
+			UUID:         uuid.New(),
+			UserID:       "u1",
+			CustomVal:    customVal,
+			Parameters:   []byte(`{}`),
+			EventPayload: []byte(`{}`),
+			EventCount:   1,
+			WorkspaceId:  defaultWorkspaceID,
+			Consumers:    consumers,
+		}
+	}
+	succeedFor := func(job *JobT, consumer string) *JobStatusT {
+		return &JobStatusT{
+			JobID:         job.JobID,
+			JobState:      Succeeded.State,
+			AttemptNum:    1,
+			ExecTime:      time.Now(),
+			RetryTime:     time.Now(),
+			ErrorCode:     "200",
+			ErrorResponse: []byte(`{}`),
+			Parameters:    []byte(`{}`),
+			WorkspaceId:   job.WorkspaceId,
+			CustomVal:     job.CustomVal,
+			Consumer:      consumer,
+		}
+	}
+
+	// Phase 1: empty DB — query A primes a "no results" cache entry for consumer A.
+	res, err := jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "A"})
+	require.NoError(t, err)
+	require.Empty(t, res.Jobs)
+	require.True(t, cacheHit("A"), "cache should be set for A after 0-result query")
+
+	// Storing a job for consumer B must not invalidate consumer A's cache entry.
+	require.NoError(t, jd.Store(ctx, []*JobT{makeJob([]string{"B"})}))
+	require.True(t, cacheHit("A"), "B's store must not invalidate A's cache")
+
+	// Storing a job for consumer A must invalidate A's cache.
+	require.NoError(t, jd.Store(ctx, []*JobT{makeJob([]string{"A"})}))
+	require.False(t, cacheHit("A"), "A's store must invalidate A's cache")
+
+	// Phase 2: A fetches and marks its job succeeded; cache re-primed.
+	res, err = jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "A"})
+	require.NoError(t, err)
+	require.Len(t, res.Jobs, 1)
+	require.NoError(t, jd.UpdateJobStatus(ctx, []*JobStatusT{succeedFor(res.Jobs[0], "A")}))
+
+	res, err = jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "A"})
+	require.NoError(t, err)
+	require.Empty(t, res.Jobs)
+	require.True(t, cacheHit("A"), "cache should be re-primed for A after 0-result query")
+
+	// Phase 3: B marks its job succeeded; A's cache must survive.
+	res, err = jd.GetUnprocessed(ctx, GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "B"})
+	require.NoError(t, err)
+	require.Len(t, res.Jobs, 1)
+	require.NoError(t, jd.UpdateJobStatus(ctx, []*JobStatusT{succeedFor(res.Jobs[0], "B")}))
+	require.True(t, cacheHit("A"), "B's status update must not invalidate A's cache")
 }

--- a/jobsdb/jobsdb_get.go
+++ b/jobsdb/jobsdb_get.go
@@ -28,6 +28,10 @@ type GetQueryParams struct {
 	CustomValFilters []string
 	ParameterFilters []ParameterFilterT
 	PartitionFilters []string
+	// Consumer scopes the query to a single consumer.
+	// On a multi-consumer JobsDB this is always applied — an empty string targets the default '' consumer.
+	// On a single-consumer JobsDB this field is ignored.
+	Consumer string
 
 	stateFilters                   []string
 	afterJobID                     *int64
@@ -66,6 +70,8 @@ func (jd *Handle) GetToProcess(ctx context.Context, params GetQueryParams, more 
 }
 
 var cacheParameterFilters = []string{"source_id", "destination_id"}
+
+const consumerParamName = "consumer" // the name of the consumer parameter, used for multi-consumer scoping of queries and cache entries
 
 func (jd *Handle) GetPileUpCounts(ctx context.Context, cutoffTime time.Time, increaseFunc rmetrics.IncreasePendingEventsFunc) error {
 	// pause compaction to avoid any read locks being blocked during pileup count
@@ -243,12 +249,18 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 	workspaceID := params.WorkspaceID
 	checkValidJobState(jd, stateFilters)
 
-	if jd.noResultsCache.Get(ds.Index, partitionFilters, workspaceID, customValFilters, stateFilters, parameterFilters) {
+	// For multi-consumer JobsDB, consumer is a cache dimension: consumer=X scopes lookups to that consumer.
+	cacheParamFilters := parameterFilters
+	if jd.conf.multiConsumer {
+		cacheParamFilters = append(slices.Clone(parameterFilters), ParameterFilterT{Name: consumerParamName, Value: params.Consumer})
+	}
+
+	if jd.noResultsCache.Get(ds.Index, partitionFilters, workspaceID, customValFilters, stateFilters, cacheParamFilters) {
 		jd.logger.Debugn("[getJobsDS] Empty cache hit for ds: %v, stateFilters: %v, customValFilters: %v, parameterFilters: %v",
 			logger.NewStringField("ds", ds.String()),
 			logger.NewStringField("stateFilters", strings.Join(stateFilters, ",")),
 			logger.NewStringField("customValFilters", strings.Join(customValFilters, ",")),
-			logger.NewStringField("parameterFilters", parameterFilters.String()),
+			logger.NewStringField("parameterFilters", cacheParamFilters.String()),
 		)
 		return JobsResult{}, false, nil
 	}
@@ -262,7 +274,7 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 
 	if stateFilterOptimization {
 		stateFilters = lo.Filter(stateFilters, func(state string, _ int) bool { // exclude states for which we already know that there are no jobs
-			return !jd.noResultsCache.Get(ds.Index, partitionFilters, workspaceID, customValFilters, []string{state}, parameterFilters)
+			return !jd.noResultsCache.Get(ds.Index, partitionFilters, workspaceID, customValFilters, []string{state}, cacheParamFilters)
 		})
 	}
 
@@ -280,7 +292,7 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 			if state == Unprocessed.State && jd.ownerType == Read && lastDS {
 				continue
 			}
-			cacheTx[state] = jd.noResultsCache.StartNoResultTx(ds.Index, partitionFilters, workspaceID, customValFilters, []string{state}, parameterFilters)
+			cacheTx[state] = jd.noResultsCache.StartNoResultTx(ds.Index, partitionFilters, workspaceID, customValFilters, []string{state}, cacheParamFilters)
 		}
 	}
 
@@ -327,6 +339,20 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 		jd.excludedReadPartitionsLock.RUnlock()
 	}
 
+	// query args are shared between the inner query (consumer) and the outer wrap (limits).
+	// Consumer must be added first so its $n position is stable when wrap args are appended.
+	var args []any
+
+	// innerConsumerClause is added inside LATERAL subqueries; outerConsumerClause is added to ON clauses.
+	var innerConsumerClause, outerConsumerClause string
+	if jd.conf.multiConsumer {
+		args = append(args, params.Consumer)
+		n := len(args)
+		filterConditions = append(filterConditions, fmt.Sprintf("jobs.consumers @> ARRAY[$%d]", n))
+		innerConsumerClause = fmt.Sprintf(" AND consumer = $%d", n)
+		outerConsumerClause = fmt.Sprintf(" AND job_latest_state.consumer = $%d", n)
+	}
+
 	var filterQuery string
 	if len(filterConditions) > 0 {
 		filterQuery = "WHERE " + strings.Join(filterConditions, " AND ")
@@ -356,9 +382,9 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 	// we only need to know whether any status row exists, not which one is latest,
 	// so the lateral's ORDER BY / LIMIT 1 would be wasteful — skip it.
 	if jd.conf.getJobsUseLateralJoin.Load() && !onlyUnprocessed {
-		joinTable = fmt.Sprintf(`LATERAL (SELECT * FROM %q WHERE job_id = jobs.job_id ORDER BY id DESC LIMIT 1) job_latest_state ON true`, ds.JobStatusTable)
+		joinTable = fmt.Sprintf(`LATERAL (SELECT * FROM %q WHERE job_id = jobs.job_id%s ORDER BY id DESC LIMIT 1) job_latest_state ON true`, ds.JobStatusTable, innerConsumerClause)
 	} else {
-		joinTable = fmt.Sprintf(`%q job_latest_state ON jobs.job_id=job_latest_state.job_id`, joinTable)
+		joinTable = fmt.Sprintf(`%q job_latest_state ON jobs.job_id=job_latest_state.job_id%s`, joinTable, outerConsumerClause)
 	}
 
 	sqlStatement := fmt.Sprintf(`SELECT
@@ -376,8 +402,6 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 								    %[4]s
 									ORDER BY jobs.job_id %[5]s`,
 		ds.JobTable, joinType, joinTable, filterQuery, limitQuery)
-
-	var args []any
 
 	var wrapQuery []string
 	if params.EventsLimit > 0 {

--- a/jobsdb/jobsdb_lifecycle.go
+++ b/jobsdb/jobsdb_lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/samber/lo"
@@ -170,8 +171,12 @@ func (jd *Handle) workersAndAuxSetup() {
 	case "gw", "rt", "batch_rt", "arc":
 		defaultLogCacheBranchInvalidation = true
 	}
+	cacheParams := cacheParameterFilters
+	if jd.conf.multiConsumer {
+		cacheParams = append(slices.Clone(cacheParameterFilters), consumerParamName)
+	}
 	jd.noResultsCache = cache.NewNoResultsCache(
-		cacheParameterFilters,
+		cacheParams,
 		func() time.Duration { return jd.conf.cacheExpiration.Load() },
 		cache.WithWarnOnBranchInvalidation[ParameterFilterT](
 			jd.config.GetReloadableBoolVar(defaultLogCacheBranchInvalidation, jd.configKeys("logCacheBranchInvalidation")...),

--- a/jobsdb/jobsdb_store.go
+++ b/jobsdb/jobsdb_store.go
@@ -123,6 +123,19 @@ func (jd *Handle) invalidateCacheForJobs(ds dataSetT, jobList []*JobT) {
 			parameterFilters = append(parameterFilters, ParameterFilterT{Name: key, Value: val})
 		}
 
+		if jd.conf.multiConsumer {
+			consumers := job.Consumers
+			if len(consumers) == 0 {
+				consumers = []string{""}
+			}
+			for _, c := range consumers {
+				params = append(params, consumerParamName+":"+c)
+				parameterFilters = append(parameterFilters, ParameterFilterT{Name: consumerParamName, Value: c})
+			}
+			// also invalidate all-consumer query entries
+			parameterFilters = append(parameterFilters, ParameterFilterT{Name: consumerParamName, Value: "*"})
+		}
+
 		paramsKey := strings.Join(params, "#")
 		if _, ok := cacheKeys[workspace][customVal][paramsKey]; !ok {
 			cacheKeys[workspace][customVal][paramsKey] = struct{}{}

--- a/jobsdb/jobsdb_update.go
+++ b/jobsdb/jobsdb_update.go
@@ -253,15 +253,16 @@ func (jd *Handle) updateJobStatusDSInTx(ctx context.Context, tx *Tx, ds dataSetT
 				updatedStates[partitionIDKey(partitionID)][workspaceIDKey(status.WorkspaceId)][customValKey(status.CustomVal)][jobStateKey(status.JobState)] = make(map[parameterFiltersKey]*UpdateJobStatusStats)
 			}
 			var parameters ParameterFilterList
-			var parametersKey parameterFiltersKey
 			if status.JobParameters != nil {
 				for _, param := range cacheParameterFilters {
 					v := gjson.GetBytes(status.JobParameters, param).Str
 					parameters = append(parameters, ParameterFilterT{Name: param, Value: v})
 				}
-				parametersKey = parameterFiltersKey(parameters.String())
-
 			}
+			if jd.conf.multiConsumer {
+				parameters = append(parameters, ParameterFilterT{Name: consumerParamName, Value: status.Consumer})
+			}
+			parametersKey := parameterFiltersKey(parameters.String())
 			pm, ok := updatedStates[partitionIDKey(partitionID)][workspaceIDKey(status.WorkspaceId)][customValKey(status.CustomVal)][jobStateKey(status.JobState)][parametersKey]
 			if !ok {
 				pm = &UpdateJobStatusStats{parameters: parameters}
@@ -380,6 +381,12 @@ func (jd *Handle) internalUpdateJobStatusInTx(ctx context.Context, tx *Tx, dsLis
 									return pf.String() // uniqueness by string representation
 								},
 							)
+							// If multi-consumer, also invalidate consumer=* so that all-consumer
+							// queries (e.g. GetPendingJobs) are not served stale results after
+							// any consumer writes a status.
+							if jd.conf.multiConsumer {
+								parameterFilters = append(parameterFilters, ParameterFilterT{Name: consumerParamName, Value: "*"})
+							}
 							// invalidate cache for this combination
 							jd.noResultsCache.Invalidate(ds.Index, []string{string(partition)}, string(workspace), []string{string(customVal)}, stateList, parameterFilters)
 						}


### PR DESCRIPTION
# Description

**Consumer-scoped pickup** (`getJobsDS`): 
On a multi-consumer handle, the query adds a GIN membership pre-filter (`jobs.consumers @> ARRAY[$n]`) and scopes the latest-status join to that consumer. Both the view-join strategy (`v_last_c_` ON `job_id AND consumer = $n`) and the lateral-join strategy (`ORDER BY id DESC LIMIT 1` with `AND consumer = $n`) get the consumer-scoped variant. Single-consumer handles ignore the field entirely; their query plans are unchanged.

**`noResultsCache` consumer dimension**: 
The consumer participates in the cache as a `consumer=<value>` parameter-filter key entry, reusing the existing wildcard machinery, no new cache dimension is added. Consumer-scoped lookups key on `consumer=<value>`; all-consumer queries key on `consumer=*`. Invalidation on a status write for consumer X invalidates both `consumer=X` and `consumer=*`. Store writes invalidate only the consumers stored in that batch (plus `*`).

## Linear Ticket

resolves PIPE-3050

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.