### PR TITLE
chore(jobsdb): multi-consumer get distinct consumers

### DIFF
--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -150,6 +150,11 @@ type JobsDB interface {
 	// GetDistinctParameterValues returns the list of distinct parameter("source_id", "destination_id", "workspace_id") values inside the jobs tables filtering for the passed customVal
 	GetDistinctParameterValues(ctx context.Context, parameter ParameterName, customValFilter string) (values []string, err error)
 
+	// GetDistinctConsumers returns the list of distinct consumers known to a multi-consumer handle,
+	// read from the per-dataset consumers registry tables. Single-consumer handles return [""] —
+	// the legacy '' consumer that every job implicitly belongs to.
+	GetDistinctConsumers(ctx context.Context) (consumers []string, err error)
+
 	/* Admin */
 
 	Ping() error

--- a/jobsdb/jobsdb_distinct_consumers_test.go
+++ b/jobsdb/jobsdb_distinct_consumers_test.go
@@ -1,0 +1,111 @@
+package jobsdb
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
+
+	"github.com/rudderlabs/rudder-server/jobsdb/internal/lock"
+	"github.com/rudderlabs/rudder-server/utils/tx"
+)
+
+// TestGetDistinctConsumers covers the consumer-enumeration API across handle modes and datasets.
+func TestGetDistinctConsumers(t *testing.T) {
+	_ = startPostgres(t)
+	ctx := context.Background()
+
+	newJobDB := func(t *testing.T, multiConsumer bool) *Handle {
+		t.Helper()
+		c := config.New()
+		c.Set("JobsDB.maxDSSize", 100000)
+		jd := &Handle{
+			TriggerAddNewDS:   func() <-chan time.Time { return make(chan time.Time) },
+			TriggerCompaction: func() <-chan time.Time { return make(chan time.Time) },
+			config:            c,
+		}
+		jd.conf.multiConsumer = multiConsumer
+		require.NoError(t, jd.Setup(ReadWrite, true, strings.ToLower(rand.String(5))))
+		t.Cleanup(jd.TearDown)
+		return jd
+	}
+
+	createDS := func(t *testing.T, jd *Handle, idx string) {
+		t.Helper()
+		require.NoError(t, jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
+			dsList, _ := jd.dsList.snapshot()
+			if err := jd.WithTx(ctx, func(txn *tx.Tx) error {
+				return jd.addNewDSInTx(ctx, txn, l, dsList, newDataSet(jd.tablePrefix, idx))
+			}); err != nil {
+				return err
+			}
+			return jd.doRefreshDSRangeList(l)
+		}))
+	}
+
+	t.Run("single-consumer handle returns the legacy '' consumer", func(t *testing.T) {
+		jd := newJobDB(t, false)
+		consumers, err := jd.GetDistinctConsumers(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{""}, consumers)
+	})
+
+	t.Run("multi-consumer handle unions registries across datasets", func(t *testing.T) {
+		jd := newJobDB(t, true)
+
+		// DS1: consumers {A,B,C}.
+		jobs1 := genJobs(defaultWorkspaceID, "mc", 2, 1)
+		jobs1[0].Consumers = []string{"A", "B"}
+		jobs1[1].Consumers = []string{"C"}
+		require.NoError(t, jd.Store(ctx, jobs1))
+
+		// Rotate, then DS2: consumers {B,D} — B overlaps DS1, D is new.
+		createDS(t, jd, "2")
+		jobs2 := genJobs(defaultWorkspaceID, "mc", 1, 1)
+		jobs2[0].Consumers = []string{"B", "D"}
+		require.NoError(t, jd.Store(ctx, jobs2))
+
+		consumers, err := jd.GetDistinctConsumers(ctx)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"A", "B", "C", "D"}, consumers)
+	})
+
+	t.Run("legacy jobs (no Consumers) register the '' consumer", func(t *testing.T) {
+		jd := newJobDB(t, true)
+		jobs := genJobs(defaultWorkspaceID, "mc", 2, 1) // no explicit Consumers → default '{""}'
+		require.NoError(t, jd.Store(ctx, jobs))
+
+		consumers, err := jd.GetDistinctConsumers(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{""}, consumers)
+	})
+
+	t.Run("cached older dataset + live latest dataset both reflected", func(t *testing.T) {
+		jd := newJobDB(t, true)
+
+		jobs1 := genJobs(defaultWorkspaceID, "mc", 1, 1)
+		jobs1[0].Consumers = []string{"A"}
+		require.NoError(t, jd.Store(ctx, jobs1))
+
+		// Prime the cache: DS1 ("A") is now cached as a non-latest dataset.
+		createDS(t, jd, "2")
+		first, err := jd.GetDistinctConsumers(ctx)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"A"}, first)
+
+		// A new consumer written to the live latest dataset must still appear, since the
+		// latest dataset is never cached.
+		jobs2 := genJobs(defaultWorkspaceID, "mc", 1, 1)
+		jobs2[0].Consumers = []string{"B"}
+		require.NoError(t, jd.Store(ctx, jobs2))
+
+		second, err := jd.GetDistinctConsumers(ctx)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"A", "B"}, second)
+	})
+}

--- a/jobsdb/jobsdb_get.go
+++ b/jobsdb/jobsdb_get.go
@@ -229,6 +229,80 @@ func (jd *Handle) GetDistinctParameterValues(ctx context.Context, parameter Para
 	)
 }
 
+// distinctConsumersCacheKey is the distinctValuesCache key namespace for the consumer dimension.
+// Parameter keys are always `parameters->>'...'` or `workspace_id`, so this cannot collide.
+const distinctConsumersCacheKey = "__consumers__"
+
+func (jd *Handle) GetDistinctConsumers(ctx context.Context) ([]string, error) {
+	// A single-consumer handle is structurally a handle whose only consumer is the legacy ''
+	// consumer, so it has exactly that one distinct consumer.
+	if !jd.conf.multiConsumer {
+		return []string{""}, nil
+	}
+	if !jd.dsCompactionLock.RTryLockWithCtx(ctx) {
+		return nil, fmt.Errorf("could not acquire a compaction read lock: %w", ctx.Err())
+	}
+	defer jd.dsCompactionLock.RUnlock()
+	dsList, _, release, err := jd.acquireDSListForRead(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	// Only datasets that carry a registry table participate; during a rolling flip a peer
+	// may briefly have created a dataset without one (healed on its next boot). With no
+	// registry yet, every job is still legacy — the '' consumer.
+	mcDS := lo.Filter(dsList, func(ds dataSetT, _ int) bool { return ds.ConsumersTable != "" })
+	if len(mcDS) == 0 {
+		return []string{""}, nil
+	}
+	// The registry table is keyed by JobTable so the load function can resolve it. JobTable is
+	// also the cache's per-dataset key, matching the RemoveDataset(ds.JobTable) drop invalidation.
+	registryByJobTable := make(map[string]string, len(mcDS))
+	for _, ds := range mcDS {
+		registryByJobTable[ds.JobTable] = ds.ConsumersTable
+	}
+	return jd.distinctValuesCache.GetDistinctValues(
+		distinctConsumersCacheKey,
+		lo.Map(mcDS, func(ds dataSetT, _ int) string { return ds.JobTable }),
+		func(datasets []string) (map[string][]string, error) {
+			return jd.getDistinctConsumersPerDataset(ctx, datasets, registryByJobTable)
+		},
+	)
+}
+
+// getDistinctConsumersPerDataset reads the consumers registry table of each requested dataset
+// in a single UNION ALL query, returning the consumers keyed by the dataset's JobTable.
+func (jd *Handle) getDistinctConsumersPerDataset(
+	ctx context.Context,
+	datasets []string,
+	registryByJobTable map[string]string,
+) (map[string][]string, error) {
+	queries := make([]string, 0, len(datasets))
+	for _, jobTable := range datasets {
+		queries = append(queries, fmt.Sprintf(
+			`SELECT '%[1]s' AS ds, consumer FROM %[2]q`, jobTable, registryByJobTable[jobTable],
+		))
+	}
+	rows, err := jd.getDB(ctx).QueryContext(ctx, strings.Join(queries, " UNION ALL "))
+	if err != nil {
+		return nil, fmt.Errorf("couldn't query distinct consumers: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	result := make(map[string][]string, len(datasets))
+	for rows.Next() {
+		var ds, consumer string
+		if err := rows.Scan(&ds, &consumer); err != nil {
+			return nil, fmt.Errorf("couldn't scan distinct consumers: %w", err)
+		}
+		result[ds] = append(result[ds], consumer)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows.Err() on distinct consumers: %w", err)
+	}
+	return result, nil
+}
+
 type JobsResult struct {
 	Jobs            []*JobT
 	LimitsReached   bool

--- a/mocks/jobsdb/mock_jobsdb.go
+++ b/mocks/jobsdb/mock_jobsdb.go
@@ -98,6 +98,21 @@ func (mr *MockJobsDBMockRecorder) GetAborted(ctx, params any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAborted", reflect.TypeOf((*MockJobsDB)(nil).GetAborted), ctx, params)
 }
 
+// GetDistinctConsumers mocks base method.
+func (m *MockJobsDB) GetDistinctConsumers(ctx context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDistinctConsumers", ctx)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDistinctConsumers indicates an expected call of GetDistinctConsumers.
+func (mr *MockJobsDBMockRecorder) GetDistinctConsumers(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDistinctConsumers", reflect.TypeOf((*MockJobsDB)(nil).GetDistinctConsumers), ctx)
+}
+
 // GetDistinctParameterValues mocks base method.
 func (m *MockJobsDB) GetDistinctParameterValues(ctx context.Context, parameter jobsdb.ParameterName, customValFilter string) ([]string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Description

Adds `GetDistinctConsumers` to the `JobsDB` interface, so we can efficiently enumerate consumers and ping the relevant workers per consumer.

It reuses the existing `distinctValuesCache` machinery (already used by `GetDistinctParameterValues`), reading from the per-DS consumers registry tables materialized at Store time.

## Linear Ticket

resolves PIPE-3124

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #7122 
- <kbd>&nbsp;4&nbsp;</kbd> #7121 
- <kbd>&nbsp;3&nbsp;</kbd> #7098 
- <kbd>&nbsp;2&nbsp;</kbd> #7097 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #7096 
<!-- GitButler Footer Boundary Bottom -->

