### PR TITLE
fix(router): shared barrier causing illegal job sequence errors

### DIFF
--- a/router/handle.go
+++ b/router/handle.go
@@ -113,7 +113,7 @@ type Handle struct {
 	backgroundCancel               context.CancelFunc
 	backgroundWait                 func() error
 	startEnded                     chan struct{}
-	barrier                        *eventorder.Barrier
+	newBarrierFn                   func() *eventorder.Barrier
 
 	eventOrderingDisabledForWorkspace   func(workspaceID string) bool
 	eventOrderingDisabledForDestination func(destinationID string) bool
@@ -150,7 +150,7 @@ func (rt *Handle) activePartitions(ctx context.Context) []string {
 
 // pickup picks up jobs from the jobsDB for the provided partition and returns the number of jobs picked up and whether the limits were reached or not
 // picked up jobs are distributed to the workers
-func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worker, pickupBatchSizeGauge Gauge[int]) (pickupCount int, limitsReached bool) {
+func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worker, pickupBatchSizeGauge Gauge[int], barrier *eventorder.Barrier) (pickupCount int, limitsReached bool) {
 	// pickup limiter with dynamic priority
 	start := time.Now()
 	var discardedCount int
@@ -165,7 +165,7 @@ func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worke
 
 	//#JobOrder (See comment marked #JobOrder
 	if rt.guaranteeUserEventOrder {
-		rt.barrier.Sync()
+		barrier.Sync()
 	}
 
 	var firstJob *jobsdb.JobT
@@ -296,7 +296,7 @@ func (rt *Handle) pickup(ctx context.Context, partition string, workers []*worke
 			panic(err)
 		}
 		findStart := time.Now()
-		workerJobSlot, err := rt.findWorkerSlot(ctx, workers, job, parameters, blockedOrderKeys)
+		workerJobSlot, err := rt.findWorkerSlot(ctx, workers, barrier, job, parameters, blockedOrderKeys)
 		findWorkerSlotDuration += time.Since(findStart)
 		if err == nil {
 			traceParent := jsonparser.GetStringOrEmpty(job.Parameters, "traceparent")
@@ -654,7 +654,7 @@ func reserveAnyWorkerSlot(workers []*worker) *reservedSlot {
 	return nil
 }
 
-func (rt *Handle) findWorkerSlot(ctx context.Context, workers []*worker, job *jobsdb.JobT, parameters routerutils.JobParameters, blockedOrderKeys map[eventorder.BarrierKey]struct{}) (*workerJobSlot, error) {
+func (rt *Handle) findWorkerSlot(ctx context.Context, workers []*worker, barrier *eventorder.Barrier, job *jobsdb.JobT, parameters routerutils.JobParameters, blockedOrderKeys map[eventorder.BarrierKey]struct{}) (*workerJobSlot, error) {
 	if rt.backgroundCtx.Err() != nil {
 		return nil, types.ErrContextCancelled
 	}
@@ -665,7 +665,7 @@ func (rt *Handle) findWorkerSlot(ctx context.Context, workers []*worker, job *jo
 	}
 
 	eventOrderingDisabled := !rt.guaranteeUserEventOrder
-	if (rt.guaranteeUserEventOrder && rt.barrier.Disabled(orderKey)) ||
+	if (rt.guaranteeUserEventOrder && barrier.Disabled(orderKey)) ||
 		(rt.eventOrderingDisabledForWorkspace(job.WorkspaceId) ||
 			rt.eventOrderingDisabledForDestination(parameters.DestinationID)) {
 		eventOrderingDisabled = true

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -178,26 +178,28 @@ func (rt *Handle) Setup(
 			"location": location,
 		})
 	}
-	rt.barrier = eventorder.NewBarrier(eventorder.WithMetadata(map[string]string{
-		"destType":         rt.destType,
-		"batching":         strconv.FormatBool(rt.enableBatching),
-		"transformerProxy": strconv.FormatBool(rt.reloadableConfig.transformerProxy.Load()),
-	}),
-		eventorder.WithEventOrderKeyThreshold(rt.eventOrderKeyThreshold),
-		eventorder.WithDisabledStateDuration(rt.eventOrderDisabledStateDuration),
-		eventorder.WithHalfEnabledStateDuration(rt.eventOrderHalfEnabledStateDuration),
-		eventorder.WithDrainConcurrencyLimit(rt.drainConcurrencyLimit),
-		eventorder.WithDebugInfoProvider(rt.eventOrderDebugInfo),
-		eventorder.WithOrderingDisabledCheckForBarrierKey(func(key eventorder.BarrierKey) bool {
-			return rt.eventOrderingDisabledForWorkspace(key.WorkspaceID) || rt.eventOrderingDisabledForDestination(key.DestinationID)
+	rt.newBarrierFn = func() *eventorder.Barrier {
+		return eventorder.NewBarrier(eventorder.WithMetadata(map[string]string{
+			"destType":         rt.destType,
+			"batching":         strconv.FormatBool(rt.enableBatching),
+			"transformerProxy": strconv.FormatBool(rt.reloadableConfig.transformerProxy.Load()),
 		}),
-		eventorder.WithPanicOnIllegalJobSequence(orderingPanicOnIllegalSequence),
-		eventorder.WithIllegalJobSequenceCallback(func(location string) {
-			if m, ok := illegalJobSequenceStats[location]; ok {
-				m.Increment()
-			}
-		}),
-	)
+			eventorder.WithEventOrderKeyThreshold(rt.eventOrderKeyThreshold),
+			eventorder.WithDisabledStateDuration(rt.eventOrderDisabledStateDuration),
+			eventorder.WithHalfEnabledStateDuration(rt.eventOrderHalfEnabledStateDuration),
+			eventorder.WithDrainConcurrencyLimit(rt.drainConcurrencyLimit),
+			eventorder.WithDebugInfoProvider(rt.eventOrderDebugInfo),
+			eventorder.WithOrderingDisabledCheckForBarrierKey(func(key eventorder.BarrierKey) bool {
+				return rt.eventOrderingDisabledForWorkspace(key.WorkspaceID) || rt.eventOrderingDisabledForDestination(key.DestinationID)
+			}),
+			eventorder.WithPanicOnIllegalJobSequence(orderingPanicOnIllegalSequence),
+			eventorder.WithIllegalJobSequenceCallback(func(location string) {
+				if m, ok := illegalJobSequenceStats[location]; ok {
+					m.Increment()
+				}
+			}),
+		)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	g, ctx := errgroup.WithContext(ctx)

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -170,6 +170,14 @@ func (rt *Handle) Setup(
 	rt.eventOrderingDisabledForDestination = func(destinationID string) bool {
 		return slices.Contains(orderingDisabledDestinationIDs.Load(), destinationID)
 	}
+	orderingPanicOnIllegalSequence := config.GetReloadableBoolVar(true, getRouterConfigKeys("orderingPanicOnIllegalSequence", destType)...)
+	illegalJobSequenceStats := map[string]stats.Measurement{}
+	for _, location := range []string{"enter", "wait", "job_failed"} {
+		illegalJobSequenceStats[location] = stats.Default.NewTaggedStat("router_illegal_job_sequence", stats.CountType, stats.Tags{
+			"destType": rt.destType,
+			"location": location,
+		})
+	}
 	rt.barrier = eventorder.NewBarrier(eventorder.WithMetadata(map[string]string{
 		"destType":         rt.destType,
 		"batching":         strconv.FormatBool(rt.enableBatching),
@@ -182,6 +190,12 @@ func (rt *Handle) Setup(
 		eventorder.WithDebugInfoProvider(rt.eventOrderDebugInfo),
 		eventorder.WithOrderingDisabledCheckForBarrierKey(func(key eventorder.BarrierKey) bool {
 			return rt.eventOrderingDisabledForWorkspace(key.WorkspaceID) || rt.eventOrderingDisabledForDestination(key.DestinationID)
+		}),
+		eventorder.WithPanicOnIllegalJobSequence(orderingPanicOnIllegalSequence),
+		eventorder.WithIllegalJobSequenceCallback(func(location string) {
+			if m, ok := illegalJobSequenceStats[location]; ok {
+				m.Increment()
+			}
 		}),
 	)
 

--- a/router/internal/eventorder/eventorder.go
+++ b/router/internal/eventorder/eventorder.go
@@ -64,6 +64,22 @@ func WithOrderingDisabledCheckForBarrierKey(orderingDisabledForKey func(key Barr
 	}
 }
 
+// WithPanicOnIllegalJobSequence controls whether an illegal job sequence causes a panic.
+// When disabled (default), out-of-order jobs are treated as normal and the illegalSequenceCallback is invoked instead.
+func WithPanicOnIllegalJobSequence(panicOnIllegalSequence config.ValueLoader[bool]) OptFn {
+	return func(b *Barrier) {
+		b.panicOnIllegalSequence = panicOnIllegalSequence
+	}
+}
+
+// WithIllegalJobSequenceCallback sets a callback invoked when an illegal job sequence is detected and panics are disabled.
+// The location parameter identifies where the illegal sequence was detected: "enter", "wait", or "job_failed".
+func WithIllegalJobSequenceCallback(callback func(location string)) OptFn {
+	return func(b *Barrier) {
+		b.illegalSequenceCallback = callback
+	}
+}
+
 // NewBarrier creates a new properly initialized Barrier
 func NewBarrier(fns ...OptFn) *Barrier {
 	b := &Barrier{
@@ -73,6 +89,7 @@ func NewBarrier(fns ...OptFn) *Barrier {
 		disabledStateDuration:    config.SingleValueLoader(10 * time.Minute),
 		halfEnabledStateDuration: config.SingleValueLoader(5 * time.Minute),
 		drainLimit:               config.SingleValueLoader(0),
+		panicOnIllegalSequence:   config.SingleValueLoader(false),
 	}
 	for _, fn := range fns {
 		fn(b)
@@ -107,6 +124,9 @@ type Barrier struct {
 	debugInfo func(key BarrierKey) string
 
 	orderingDisabledForKey func(key BarrierKey) bool
+
+	panicOnIllegalSequence  config.ValueLoader[bool]
+	illegalSequenceCallback func(location string)
 }
 
 type BarrierKey struct {
@@ -166,13 +186,18 @@ func (b *Barrier) Enter(key BarrierKey, jobID int64) (accepted bool, previousFai
 			if b.debugInfo != nil {
 				debugInfo = "\nDEBUG INFO:\n" + b.debugInfo(key)
 			}
-			panic(fmt.Errorf("detected illegal job sequence during barrier enter %+v: key %q, previousFailedJob:%d > jobID:%d (previouslyDisabled: %t)%s",
-				b.metadata,
-				key,
-				failedJob,
-				jobID,
-				!barrier.stateTime.IsZero(),
-				debugInfo))
+			if b.panicOnIllegalSequence.Load() {
+				panic(fmt.Errorf("detected illegal job sequence during barrier enter %+v: key %q, previousFailedJob:%d > jobID:%d (previouslyDisabled: %t)%s",
+					b.metadata,
+					key,
+					failedJob,
+					jobID,
+					!barrier.stateTime.IsZero(),
+					debugInfo))
+			}
+			if b.illegalSequenceCallback != nil {
+				b.illegalSequenceCallback("enter")
+			}
 		}
 		accepted = jobID == failedJob
 	} else {
@@ -227,15 +252,20 @@ func (b *Barrier) Wait(key BarrierKey, jobID int64) (wait bool, previousFailedJo
 			if b.debugInfo != nil {
 				debugInfo = "\nDEBUG INFO:\n" + b.debugInfo(key)
 			}
-			panic(fmt.Errorf("detected illegal job sequence during barrier wait %+v: key %q, previousFailedJob:%d > jobID:%d  (previouslyDisabled: %t)%s",
-				b.metadata,
-				key,
-				failedJob,
-				jobID,
-				!barrier.stateTime.IsZero(),
-				debugInfo))
+			if b.panicOnIllegalSequence.Load() {
+				panic(fmt.Errorf("detected illegal job sequence during barrier wait %+v: key %q, previousFailedJob:%d > jobID:%d  (previouslyDisabled: %t)%s",
+					b.metadata,
+					key,
+					failedJob,
+					jobID,
+					!barrier.stateTime.IsZero(),
+					debugInfo))
+			}
+			if b.illegalSequenceCallback != nil {
+				b.illegalSequenceCallback("wait")
+			}
 		}
-		return jobID > failedJob, &failedJob // wait if this is not the failed job
+		return jobID != failedJob, &failedJob // wait if this is not the failed job
 	}
 	// no failed job, don't wait
 	return false, nil
@@ -449,13 +479,18 @@ func (c *jobFailedCommand) execute(b *Barrier) {
 		if b.debugInfo != nil {
 			debugInfo = "\nDEBUG INFO:\n" + b.debugInfo(c.key)
 		}
-		panic(fmt.Errorf("detected illegal job sequence during barrier job failed %+v: key %q, previousFailedJob:%d > jobID:%d (previouslyDisabled: %t)%s",
-			b.metadata,
-			c.key,
-			*barrier.failedJobID,
-			c.jobID,
-			!barrier.stateTime.IsZero(),
-			debugInfo))
+		if b.panicOnIllegalSequence.Load() {
+			panic(fmt.Errorf("detected illegal job sequence during barrier job failed %+v: key %q, previousFailedJob:%d > jobID:%d (previouslyDisabled: %t)%s",
+				b.metadata,
+				c.key,
+				*barrier.failedJobID,
+				c.jobID,
+				!barrier.stateTime.IsZero(),
+				debugInfo))
+		}
+		if b.illegalSequenceCallback != nil {
+			b.illegalSequenceCallback("job_failed")
+		}
 	}
 	barrier.drainLimiter = nil // turn off drain limiter
 }

--- a/router/internal/eventorder/eventorder_test.go
+++ b/router/internal/eventorder/eventorder_test.go
@@ -214,7 +214,7 @@ func Test_Job_Fail_then_Abort(t *testing.T) {
 }
 
 func Test_Panic_Scenarios(t *testing.T) {
-	barrier := NewBarrier()
+	barrier := NewBarrier(WithPanicOnIllegalJobSequence(config.SingleValueLoader(true)))
 
 	enter, _ := barrier.Enter(BarrierKey{UserID: "user1"}, 2)
 	require.True(t, enter, "job 2 for user1 should be accepted since no barrier exists")
@@ -238,6 +238,39 @@ func Test_Panic_Scenarios(t *testing.T) {
 		}()
 		_ = barrier.StateChanged(BarrierKey{UserID: "user1"}, 1, jobsdb.Failed.State)
 	}()
+}
+
+func Test_IllegalSequenceCallback(t *testing.T) {
+	var callbackLocations []string
+	barrier := NewBarrier(
+		WithIllegalJobSequenceCallback(func(location string) {
+			callbackLocations = append(callbackLocations, location)
+		}),
+	)
+
+	enter, _ := barrier.Enter(BarrierKey{UserID: "user1"}, 2)
+	require.True(t, enter)
+	require.NoError(t, barrier.StateChanged(BarrierKey{UserID: "user1"}, 2, jobsdb.Failed.State))
+
+	// illegal sequence during wait: no panic, callback invoked
+	require.NotPanics(t, func() {
+		_, _ = barrier.Wait(BarrierKey{UserID: "user1"}, 1)
+	})
+	require.Equal(t, []string{"wait"}, callbackLocations)
+
+	// illegal sequence during enter: no panic, callback invoked
+	callbackLocations = nil
+	require.NotPanics(t, func() {
+		_, _ = barrier.Enter(BarrierKey{UserID: "user1"}, 1)
+	})
+	require.Equal(t, []string{"enter"}, callbackLocations)
+
+	// illegal sequence during job_failed: no panic, callback invoked
+	callbackLocations = nil
+	require.NotPanics(t, func() {
+		require.NoError(t, barrier.StateChanged(BarrierKey{UserID: "user1"}, 1, jobsdb.Failed.State))
+	})
+	require.Equal(t, []string{"job_failed"}, callbackLocations)
 }
 
 func TestBarrier_Leave(t *testing.T) {
@@ -272,7 +305,8 @@ func TestEventOrderKeyThreshold(t *testing.T) {
 	barrier := NewBarrier(
 		WithEventOrderKeyThreshold(config.SingleValueLoader(2)),
 		WithDisabledStateDuration(config.SingleValueLoader(disabledStateDuration)),
-		WithHalfEnabledStateDuration(config.SingleValueLoader(halfEnabledStateDuration)))
+		WithHalfEnabledStateDuration(config.SingleValueLoader(halfEnabledStateDuration)),
+		WithPanicOnIllegalJobSequence(config.SingleValueLoader(true)))
 
 	enter, previous := barrier.Enter(orderKey, 1)
 	require.True(t, enter, "job 1 for %s should be accepted since no barrier exists and concurrency limiter should be 1", orderKey)

--- a/router/partition_worker.go
+++ b/router/partition_worker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/stats/metric"
 	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
 
+	"github.com/rudderlabs/rudder-server/router/internal/eventorder"
 	"github.com/rudderlabs/rudder-server/utils/cache"
 	"github.com/rudderlabs/rudder-server/utils/crash"
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -21,6 +22,7 @@ import (
 // A partition worker uses multiple workers internally to process the jobs that are being picked up asynchronously.
 func newPartitionWorker(ctx context.Context, rt *Handle, partition string) *partitionWorker {
 	samplerCtx, samplerCancel := context.WithCancel(context.Background())
+	barrier := rt.newBarrierFn()
 	pw := &partitionWorker{
 		logger:               rt.logger.Child("p-" + partition),
 		rt:                   rt,
@@ -30,6 +32,7 @@ func newPartitionWorker(ctx context.Context, rt *Handle, partition string) *part
 		pickupBatchSizeGauge: newGaugeWithLastValue[int](stats.Default.NewTaggedStat("router_pickup_batch_size_gauge", stats.GaugeType, stats.Tags{"destType": rt.destType, "partition": partition})),
 	}
 	pw.g, _ = errgroup.WithContext(context.Background())
+	pw.barrier = barrier
 	pw.workers = make([]*worker, rt.noOfWorkers)
 	deliveryTimeStat := stats.Default.NewTaggedStat("router_delivery_time", stats.TimerType, stats.Tags{"destType": rt.destType})
 	routerDeliveryLatencyStat := stats.Default.NewTaggedStat("router_delivery_latency", stats.TimerType, stats.Tags{"destType": rt.destType})
@@ -65,7 +68,7 @@ func newPartitionWorker(ctx context.Context, rt *Handle, partition string) *part
 					currentCapacity: bufferCapacityStat,
 					currentSize:     bufferSizeStat,
 				}),
-			barrier:                   rt.barrier,
+			barrier:                   barrier,
 			rt:                        rt,
 			deliveryTimeStat:          deliveryTimeStat,
 			routerDeliveryLatencyStat: routerDeliveryLatencyStat,
@@ -126,6 +129,7 @@ type partitionWorker struct {
 	samplerCancel        context.CancelFunc      // stops the buffer-capacity sampler goroutine
 	pickupBatchSizeGauge GaugeWithLastValue[int] // gauge to track the pickup batch size used in the last pickup iteration
 	workers              []*worker               // workers that are responsible for processing the jobs
+	barrier              *eventorder.Barrier     // barrier for this partition's event ordering
 
 	pickupCount   int  // number of jobs picked up by the workers in the last iteration
 	limitsReached bool // whether the limits were reached in the last iteration
@@ -134,7 +138,7 @@ type partitionWorker struct {
 // Work picks up jobs for the partitioned worker and returns whether it worked or not
 func (pw *partitionWorker) Work() bool {
 	start := time.Now()
-	pw.pickupCount, pw.limitsReached = pw.rt.pickup(pw.ctx, pw.partition, pw.workers, pw.pickupBatchSizeGauge)
+	pw.pickupCount, pw.limitsReached = pw.rt.pickup(pw.ctx, pw.partition, pw.workers, pw.pickupBatchSizeGauge, pw.barrier)
 	// the following stats are used to track the total time taken for the pickup process and the number of jobs picked up
 	stats.Default.NewTaggedStat("router_generator_loop", stats.TimerType, stats.Tags{"destType": pw.rt.destType}).Since(start)
 	stats.Default.NewTaggedStat("router_generator_events", stats.CountType, stats.Tags{"destType": pw.rt.destType, "partition": pw.partition}).Count(pw.pickupCount)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -265,7 +265,6 @@ func TestBackoff(t *testing.T) {
 			noOfWorkers:           1,
 			maxNoOfJobsPerChannel: 3,
 			noOfJobsPerChannel:    3,
-			barrier:               barrier,
 			reloadableConfig: &reloadableConfig{
 				maxFailedCountForJob: config.SingleValueLoader(3),
 				retryTimeWindow:      config.SingleValueLoader(180 * time.Minute),
@@ -289,27 +288,27 @@ func TestBackoff(t *testing.T) {
 			r.guaranteeUserEventOrder = false
 			workers[0].workerBuffer = newSimpleWorkerBuffer(3)
 
-			slot, err := r.findWorkerSlot(context.Background(), workers, backoffJob, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err := r.findWorkerSlot(context.Background(), workers, barrier, backoffJob, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.Nil(t, slot)
 			require.ErrorIs(t, err, types.ErrJobBackoff)
 
-			slot, err = r.findWorkerSlot(context.Background(), workers, noBackoffJob1, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err = r.findWorkerSlot(context.Background(), workers, barrier, noBackoffJob1, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.NotNil(t, slot)
 			require.NoError(t, err)
 			require.Equal(t, int64(1), r.throttlerFactory.(*mockThrottlerFactory).count.Load())
 
-			slot, err = r.findWorkerSlot(context.Background(), workers, noBackoffJob2, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err = r.findWorkerSlot(context.Background(), workers, barrier, noBackoffJob2, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.NotNil(t, slot)
 			require.NoError(t, err)
 			require.Equal(t, int64(2), r.throttlerFactory.(*mockThrottlerFactory).count.Load())
 
-			slot, err = r.findWorkerSlot(context.Background(), workers, noBackoffJob3, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err = r.findWorkerSlot(context.Background(), workers, barrier, noBackoffJob3, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.NotNil(t, slot)
 			require.NoError(t, err)
 			require.NotNil(t, slot)
 			require.Equal(t, int64(3), r.throttlerFactory.(*mockThrottlerFactory).count.Load())
 
-			slot, err = r.findWorkerSlot(context.Background(), workers, noBackoffJob4, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err = r.findWorkerSlot(context.Background(), workers, barrier, noBackoffJob4, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.Nil(t, slot)
 			require.ErrorIs(t, err, types.ErrWorkerNoSlot)
 			require.Equal(t, int64(3), r.throttlerFactory.(*mockThrottlerFactory).count.Load())
@@ -322,29 +321,29 @@ func TestBackoff(t *testing.T) {
 			r.guaranteeUserEventOrder = true
 			workers[0].workerBuffer = newSimpleWorkerBuffer(3)
 
-			slot, err := r.findWorkerSlot(context.Background(), workers, backoffJob, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err := r.findWorkerSlot(context.Background(), workers, barrier, backoffJob, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.Nil(t, slot)
 			require.ErrorIs(t, err, types.ErrJobBackoff)
 			require.Equal(t, int64(0), r.throttlerFactory.(*mockThrottlerFactory).count.Load())
 
-			slot, err = r.findWorkerSlot(context.Background(), workers, noBackoffJob1, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err = r.findWorkerSlot(context.Background(), workers, barrier, noBackoffJob1, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.NotNil(t, slot)
 			require.NoError(t, err)
 			require.Equal(t, int64(1), r.throttlerFactory.(*mockThrottlerFactory).count.Load())
 
-			slot, err = r.findWorkerSlot(context.Background(), workers, noBackoffJob2, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err = r.findWorkerSlot(context.Background(), workers, barrier, noBackoffJob2, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.NotNil(t, slot)
 			require.NoError(t, err)
 			require.Equal(t, int64(2), r.throttlerFactory.(*mockThrottlerFactory).count.Load())
 
-			slot, err = r.findWorkerSlot(context.Background(), workers, noBackoffJob3, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err = r.findWorkerSlot(context.Background(), workers, barrier, noBackoffJob3, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.NotNil(t, slot)
 			require.NoError(t, err)
 			require.Equal(t, int64(3), r.throttlerFactory.(*mockThrottlerFactory).count.Load())
 			slotToRelease := slot
 			defer func() { slotToRelease.slot.Release() }()
 
-			slot, err = r.findWorkerSlot(context.Background(), workers, noBackoffJob4, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err = r.findWorkerSlot(context.Background(), workers, barrier, noBackoffJob4, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.Nil(t, slot)
 			require.ErrorIs(t, err, types.ErrWorkerNoSlot)
 			require.Equal(t, int64(3), r.throttlerFactory.(*mockThrottlerFactory).count.Load())
@@ -358,7 +357,7 @@ func TestBackoff(t *testing.T) {
 			r.guaranteeUserEventOrder = true
 			workers[0].workerBuffer = newSimpleWorkerBuffer(3)
 
-			slot, err := r.findWorkerSlot(context.Background(), workers, backoffJob, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err := r.findWorkerSlot(context.Background(), workers, barrier, backoffJob, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.NotNil(t, slot)
 			require.NoError(t, err, "drain job should be accepted even if it's to be backed off")
 			require.Equal(
@@ -368,7 +367,7 @@ func TestBackoff(t *testing.T) {
 				"throttle check shouldn't even happen for drain job",
 			)
 
-			slot, err = r.findWorkerSlot(context.Background(), workers, noBackoffJob1, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err = r.findWorkerSlot(context.Background(), workers, barrier, noBackoffJob1, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.NotNil(t, slot)
 			require.NoError(t, err)
 			require.Equal(
@@ -378,7 +377,7 @@ func TestBackoff(t *testing.T) {
 				"throttle check shouldn't even happen for drain job",
 			)
 
-			slot, err = r.findWorkerSlot(context.Background(), workers, noBackoffJob1, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err = r.findWorkerSlot(context.Background(), workers, barrier, noBackoffJob1, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.NotNil(t, slot)
 			require.NoError(t, err)
 			require.Equal(
@@ -388,7 +387,7 @@ func TestBackoff(t *testing.T) {
 				"throttle check shouldn't even happen for drain job",
 			)
 
-			slot, err = r.findWorkerSlot(context.Background(), workers, noBackoffJob1, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err = r.findWorkerSlot(context.Background(), workers, barrier, noBackoffJob1, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.Nil(t, slot)
 			require.ErrorIs(t, err, types.ErrWorkerNoSlot)
 			require.Equal(
@@ -403,7 +402,7 @@ func TestBackoff(t *testing.T) {
 			defer func() { r.backgroundCtx = context.Background() }()
 			r.backgroundCtx, r.backgroundCancel = context.WithCancel(context.Background())
 			r.backgroundCancel()
-			slot, err := r.findWorkerSlot(context.Background(), workers, backoffJob, parameters, map[eventorder.BarrierKey]struct{}{})
+			slot, err := r.findWorkerSlot(context.Background(), workers, barrier, backoffJob, parameters, map[eventorder.BarrierKey]struct{}{})
 			require.Nil(t, slot)
 			require.ErrorIs(t, err, types.ErrContextCancelled)
 		})
@@ -418,7 +417,7 @@ func TestBackoff(t *testing.T) {
 					RetryTime:  time.Now().Add(1 * time.Hour),
 				},
 			}
-			slot, err := r.findWorkerSlot(context.Background(), workers, backoffJob, parameters, map[eventorder.BarrierKey]struct{}{{UserID: job.UserID, DestinationID: destinationID}: {}})
+			slot, err := r.findWorkerSlot(context.Background(), workers, barrier, backoffJob, parameters, map[eventorder.BarrierKey]struct{}{{UserID: job.UserID, DestinationID: destinationID}: {}})
 			require.Nil(t, slot)
 			require.ErrorIs(t, err, types.ErrJobOrderBlocked)
 		})
@@ -440,6 +439,7 @@ func TestBackoff(t *testing.T) {
 			slot, err := r.findWorkerSlot(
 				context.Background(),
 				workers,
+				barrier,
 				job,
 				parameters,
 				map[eventorder.BarrierKey]struct{}{{UserID: job.UserID, DestinationID: destinationID, WorkspaceID: job.WorkspaceId}: {}},
@@ -451,6 +451,7 @@ func TestBackoff(t *testing.T) {
 			slot, err = r.findWorkerSlot(
 				context.Background(),
 				workers,
+				barrier,
 				job,
 				parameters,
 				map[eventorder.BarrierKey]struct{}{{UserID: job.UserID, DestinationID: destinationID, WorkspaceID: job.WorkspaceId}: {}},
@@ -476,6 +477,7 @@ func TestBackoff(t *testing.T) {
 			slot, err := r.findWorkerSlot(
 				context.Background(),
 				workers,
+				barrier,
 				job,
 				parameters,
 				map[eventorder.BarrierKey]struct{}{{UserID: job.UserID, DestinationID: destinationID, WorkspaceID: job.WorkspaceId}: {}},
@@ -487,6 +489,7 @@ func TestBackoff(t *testing.T) {
 			slot, err = r.findWorkerSlot(
 				context.Background(),
 				workers,
+				barrier,
 				job,
 				parameters,
 				map[eventorder.BarrierKey]struct{}{{UserID: job.UserID, DestinationID: destinationID, WorkspaceID: job.WorkspaceId}: {}},


### PR DESCRIPTION
## Description

A single `*eventorder.Barrier` was shared across all partition workers for a given destination type. Each partition worker calls `barrier.Sync()` at the start of its pickup loop, so one partition worker's `Sync()` could clear `failedJobID` for a key while another partition worker was mid-pickup, after that worker's own `Sync()` had already run. This allowed a higher-JobID job to be admitted into pickup before a lower-JobID job for the same orderKey had completed, producing an illegal sequence error/panic.

Each `partitionWorker` now creates its own `*eventorder.Barrier`. `Sync()` is now only called by the partition worker that owns that barrier, restoring the snapshot guarantee.

### Secondary
Illegal job sequence panics are now configurable, they can be skipped in favour of incrementing a counter instead.

## Linear Ticket

resolves PIPE-2747

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.