### PR TITLE
chore(router): rename experimental buffer size calculator to dynamic

### DIFF
--- a/router/config.go
+++ b/router/config.go
@@ -28,3 +28,14 @@ func getReloadableRouterConfigInt(key, destType string, defaultValue int) config
 func getRouterConfigKeys(key, destType string) []string {
 	return []string{"Router." + destType + "." + key, "Router." + key}
 }
+
+func getHierarchicalRouterConfigKeys(destType string, keys ...string) []string {
+	orderedKeys := make([]string, 0, len(keys)*2)
+	for i := range keys {
+		orderedKeys = append(orderedKeys, "Router."+destType+"."+keys[i])
+	}
+	for i := range keys {
+		orderedKeys = append(orderedKeys, "Router."+keys[i])
+	}
+	return orderedKeys
+}

--- a/router/find_worker_slot_bench_test.go
+++ b/router/find_worker_slot_bench_test.go
@@ -24,8 +24,8 @@ import (
 //
 //   - mode: which workerBuffer configuration is in use:
 //     simple                — newSimpleWorkerBuffer (fixed capacity, no calculator)
-//     dynamic/standard      — newWorkerBuffer + newBufferSizeCalculatorSwitcher (experimental=false)
-//     dynamic/experimental  — newWorkerBuffer + newBufferSizeCalculatorSwitcher (experimental=true)
+//     dynamic/standard  — newWorkerBuffer + newBufferSizeCalculatorSwitcher (dynamic=false)
+//     dynamic/dynamic   — newWorkerBuffer + newBufferSizeCalculatorSwitcher (dynamic=true)
 //
 //   - strategy: how a worker with capacity is chosen:
 //     filter     — the old approach: lo.Filter on AvailableSlots, rand.Intn into the
@@ -49,7 +49,7 @@ func BenchmarkFindWorkerSlot(b *testing.B) {
 		jobQueryBatchSize      = 10000
 		workLoopThroughputObs  = 100.0
 		scalingFactor          = 2.0
-		experimentalMinSize    = 500
+		dynamicMinSize         = 500
 		simpleBufferCapacity   = 1000 // matches the standard calculator's output for these defaults
 	)
 
@@ -89,30 +89,30 @@ func BenchmarkFindWorkerSlot(b *testing.B) {
 			name: "dynamic/standard",
 			newBuf: func() (*workerBuffer, int) {
 				calc := newBufferSizeCalculatorSwitcher(
-					config.SingleValueLoader(false), // experimental disabled
+					config.SingleValueLoader(false), // dynamic disabled
 					config.SingleValueLoader(jobQueryBatchSize),
 					numWorkers,
 					config.SingleValueLoader(noOfJobsToBatchPerWork),
 					seededSMA(workLoopThroughputObs),
 					config.SingleValueLoader(scalingFactor),
 					noOfJobsPerChannel,
-					config.SingleValueLoader(experimentalMinSize),
+					config.SingleValueLoader(dynamicMinSize),
 				)
 				return newWorkerBuffer(maxNoOfJobsPerChannel, calc, newBufferStats()), calc()
 			},
 		},
 		{
-			name: "dynamic/experimental",
+			name: "dynamic/dynamic",
 			newBuf: func() (*workerBuffer, int) {
 				calc := newBufferSizeCalculatorSwitcher(
-					config.SingleValueLoader(true), // experimental enabled
+					config.SingleValueLoader(true), // dynamic enabled
 					config.SingleValueLoader(jobQueryBatchSize),
 					numWorkers,
 					config.SingleValueLoader(noOfJobsToBatchPerWork),
 					seededSMA(workLoopThroughputObs),
 					config.SingleValueLoader(scalingFactor),
 					noOfJobsPerChannel,
-					config.SingleValueLoader(experimentalMinSize),
+					config.SingleValueLoader(dynamicMinSize),
 				)
 				return newWorkerBuffer(maxNoOfJobsPerChannel, calc, newBufferStats()), calc()
 			},
@@ -214,7 +214,7 @@ func BenchmarkFindWorkerSlot(b *testing.B) {
 }
 
 // seededSMA returns a SimpleMovingAverage primed with a single observation, so the
-// experimental calculator sees a stable, non-zero throughput throughout the benchmark.
+// dynamic calculator sees a stable, non-zero throughput throughout the benchmark.
 func seededSMA(observation float64) metric.SimpleMovingAverage {
 	sma := metric.NewSimpleMovingAverage(1)
 	sma.Observe(observation)

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -334,9 +334,9 @@ func (rt *Handle) setupReloadableVars() {
 	rt.reloadableConfig.failingJobsPenaltySleep = config.GetReloadableDurationVar(2000, time.Millisecond, getRouterConfigKeys("failingJobsPenaltySleep", rt.destType)...)
 	rt.reloadableConfig.failingJobsPenaltyThreshold = config.GetReloadableFloat64Var(0.6, getRouterConfigKeys("failingJobsPenaltyThreshold", rt.destType)...)
 	rt.reloadableConfig.oauthV2ExpirationTimeDiff = config.GetReloadableDurationVar(5, time.Minute, getRouterConfigKeys("oauth.expirationTimeDiff", rt.destType)...)
-	rt.reloadableConfig.enableExperimentalBufferSizeCalculator = config.GetReloadableBoolVar(false, getRouterConfigKeys("enableExperimentalBufferSizeCalculator", rt.destType)...)
-	rt.reloadableConfig.experimentalBufferSizeScalingFactor = config.GetReloadableFloat64Var(2.0, getRouterConfigKeys("experimentalBufferSizeScalingFactor", rt.destType)...)
-	rt.reloadableConfig.experimentalBufferSizeMinimum = config.GetReloadableIntVar(500, 1, getRouterConfigKeys("experimentalBufferSizeMinimum", rt.destType)...)
+	rt.reloadableConfig.enableDynamicBufferSizeCalculator = config.GetReloadableBoolVar(true, getHierarchicalRouterConfigKeys(rt.destType, "enableDynamicBufferSizeCalculator", "enableExperimentalBufferSizeCalculator")...)
+	rt.reloadableConfig.dynamicBufferSizeScalingFactor = config.GetReloadableFloat64Var(2.0, getHierarchicalRouterConfigKeys(rt.destType, "dynamicBufferSizeScalingFactor", "experimentalBufferSizeScalingFactor")...)
+	rt.reloadableConfig.dynamicBufferSizeMinimum = config.GetReloadableIntVar(500, 1, getHierarchicalRouterConfigKeys(rt.destType, "dynamicBufferSizeMinimum", "experimentalBufferSizeMinimum")...)
 	rt.diagnosisTickerTime = config.GetDurationVar(60, time.Second, "Diagnostics.routerTimePeriod", "Diagnostics.routerTimePeriodInS")
 	rt.netClientTimeout = config.GetDurationVar(10, time.Second,
 		"Router."+rt.destType+".httpTimeout",

--- a/router/partition_worker.go
+++ b/router/partition_worker.go
@@ -51,14 +51,14 @@ func newPartitionWorker(ctx context.Context, rt *Handle, partition string) *part
 			workerBuffer: newWorkerBuffer(
 				rt.maxNoOfJobsPerChannel,
 				newBufferSizeCalculatorSwitcher(
-					rt.reloadableConfig.enableExperimentalBufferSizeCalculator,
+					rt.reloadableConfig.enableDynamicBufferSizeCalculator,
 					pw.pickupBatchSizeGauge,
 					rt.noOfWorkers,
 					rt.reloadableConfig.noOfJobsToBatchInAWorker,
 					workLoopThroughput,
-					rt.reloadableConfig.experimentalBufferSizeScalingFactor,
+					rt.reloadableConfig.dynamicBufferSizeScalingFactor,
 					rt.noOfJobsPerChannel,
-					rt.reloadableConfig.experimentalBufferSizeMinimum,
+					rt.reloadableConfig.dynamicBufferSizeMinimum,
 				),
 				&workerBufferStats{
 					onceEvery:       kitsync.NewOnceEvery(5 * time.Second),

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -507,6 +507,7 @@ var _ = Describe("router", func() {
 		conf = config.New()
 		config.Reset()
 		config.Set("Router.jobRetention", "175200h") // 20 Years(20*365*24)
+		config.Set("Router.enableDynamicBufferSizeCalculator", false)
 		c = &testContext{}
 		c.Setup()
 	})

--- a/router/types.go
+++ b/router/types.go
@@ -47,32 +47,32 @@ type JobResponse struct {
 }
 
 type reloadableConfig struct {
-	jobQueryBatchSize                      config.ValueLoader[int]
-	maxJobQueryBatchSize                   config.ValueLoader[int] // absolute max limit on job query batch size when adapting based on throttling limits
-	updateStatusBatchSize                  config.ValueLoader[int]
-	readSleep                              config.ValueLoader[time.Duration]
-	maxReadSleep                           config.ValueLoader[time.Duration]
-	maxStatusUpdateWait                    config.ValueLoader[time.Duration]
-	minRetryBackoff                        config.ValueLoader[time.Duration]
-	maxRetryBackoff                        config.ValueLoader[time.Duration]
-	jobsBatchTimeout                       config.ValueLoader[time.Duration]
-	failingJobsPenaltyThreshold            config.ValueLoader[float64]
-	failingJobsPenaltySleep                config.ValueLoader[time.Duration]
-	noOfJobsToBatchInAWorker               config.ValueLoader[int]
-	jobsDBCommandTimeout                   config.ValueLoader[time.Duration]
-	jobdDBMaxRetries                       config.ValueLoader[int]
-	maxFailedCountForJob                   config.ValueLoader[int]
-	maxFailedCountForSourcesJob            config.ValueLoader[int]
-	payloadLimit                           config.ValueLoader[int64]
-	retryTimeWindow                        config.ValueLoader[time.Duration]
-	sourcesRetryTimeWindow                 config.ValueLoader[time.Duration]
-	pickupFlushInterval                    config.ValueLoader[time.Duration]
-	maxDSQuerySize                         config.ValueLoader[int]
-	transformerProxy                       config.ValueLoader[bool]
-	skipRtAbortAlertForTransformation      config.ValueLoader[bool] // represents if event delivery(via transformerProxy) should be alerted via router-aborted-count alert def
-	skipRtAbortAlertForDelivery            config.ValueLoader[bool] // represents if transformation(router or batch) should be alerted via router-aborted-count alert def
-	oauthV2ExpirationTimeDiff              config.ValueLoader[time.Duration]
-	enableExperimentalBufferSizeCalculator config.ValueLoader[bool]    // whether to use the experimental worker buffer size calculator or not
-	experimentalBufferSizeScalingFactor    config.ValueLoader[float64] // scaling factor to scale up the buffer size in the experimental calculator
-	experimentalBufferSizeMinimum          config.ValueLoader[int]     // minimum buffer size in the experimental calculator
+	jobQueryBatchSize                 config.ValueLoader[int]
+	maxJobQueryBatchSize              config.ValueLoader[int] // absolute max limit on job query batch size when adapting based on throttling limits
+	updateStatusBatchSize             config.ValueLoader[int]
+	readSleep                         config.ValueLoader[time.Duration]
+	maxReadSleep                      config.ValueLoader[time.Duration]
+	maxStatusUpdateWait               config.ValueLoader[time.Duration]
+	minRetryBackoff                   config.ValueLoader[time.Duration]
+	maxRetryBackoff                   config.ValueLoader[time.Duration]
+	jobsBatchTimeout                  config.ValueLoader[time.Duration]
+	failingJobsPenaltyThreshold       config.ValueLoader[float64]
+	failingJobsPenaltySleep           config.ValueLoader[time.Duration]
+	noOfJobsToBatchInAWorker          config.ValueLoader[int]
+	jobsDBCommandTimeout              config.ValueLoader[time.Duration]
+	jobdDBMaxRetries                  config.ValueLoader[int]
+	maxFailedCountForJob              config.ValueLoader[int]
+	maxFailedCountForSourcesJob       config.ValueLoader[int]
+	payloadLimit                      config.ValueLoader[int64]
+	retryTimeWindow                   config.ValueLoader[time.Duration]
+	sourcesRetryTimeWindow            config.ValueLoader[time.Duration]
+	pickupFlushInterval               config.ValueLoader[time.Duration]
+	maxDSQuerySize                    config.ValueLoader[int]
+	transformerProxy                  config.ValueLoader[bool]
+	skipRtAbortAlertForTransformation config.ValueLoader[bool] // represents if event delivery(via transformerProxy) should be alerted via router-aborted-count alert def
+	skipRtAbortAlertForDelivery       config.ValueLoader[bool] // represents if transformation(router or batch) should be alerted via router-aborted-count alert def
+	oauthV2ExpirationTimeDiff         config.ValueLoader[time.Duration]
+	enableDynamicBufferSizeCalculator config.ValueLoader[bool]    // whether to use the dynamic worker buffer size calculator or not
+	dynamicBufferSizeScalingFactor    config.ValueLoader[float64] // scaling factor to scale up the buffer size in the dynamic calculator
+	dynamicBufferSizeMinimum          config.ValueLoader[int]     // minimum buffer size in the dynamic calculator
 }

--- a/router/worker_buffer_calculator.go
+++ b/router/worker_buffer_calculator.go
@@ -28,7 +28,7 @@ func newStandardBufferSizeCalculator(
 	}
 }
 
-// newExperimentalBufferSizeCalculator calculates the buffer size for a worker based on the following algorithm (minimum value returned is 1):
+// newDynamicBufferSizeCalculator calculates the buffer size for a worker based on the following algorithm (minimum value returned is 1):
 //
 //  1. Calculate the average throughput of jobs processed by the work loop per second (workLoopThroughput)
 //  2. Calculate the number of jobs that are queried during pickup divided by the number of workers (jobQueryBatchSize / noOfWorkers)
@@ -38,7 +38,7 @@ func newStandardBufferSizeCalculator(
 // Exceptional case:
 //
 //   - If throughput is less than 1 (workLoopThroughput < 1), set the buffer size to 1 so that we are forcing a slow buffer start & introducing backpressure in the buffer in case of slow processing.
-func newExperimentalBufferSizeCalculator(
+func newDynamicBufferSizeCalculator(
 	jobQueryBatchSize config.ValueLoader[int], // number of jobs that are queried during pickup
 	noOfWorkers int, // number of workers processing jobs
 	noOfJobsToBatchInAWorker config.ValueLoader[int], // number of jobs that a worker can batch together
@@ -65,10 +65,10 @@ func newExperimentalBufferSizeCalculator(
 	}
 }
 
-// newBufferSizeCalculatorSwitcher returns a function that switches between the standard and experimental calculators based on the
-// enableExperimentalBufferSizeCalculator flag
+// newBufferSizeCalculatorSwitcher returns a function that switches between the standard and dynamic calculators based on the
+// enableDynamicBufferSizeCalculator flag
 func newBufferSizeCalculatorSwitcher(
-	enableExperimentalBufferSizeCalculator config.ValueLoader[bool],
+	enableDynamicBufferSizeCalculator config.ValueLoader[bool],
 	jobQueryBatchSize config.ValueLoader[int], // number of jobs that are queried during pickup
 	noOfWorkers int, // number of workers processing jobs
 	noOfJobsToBatchInAWorker config.ValueLoader[int], // number of jobs that a worker can batch together
@@ -77,7 +77,7 @@ func newBufferSizeCalculatorSwitcher(
 	noOfJobsPerChannel int, // number of jobs per channel
 	minBufferSize config.ValueLoader[int], // minimum buffer size
 ) bufferSizeCalculator {
-	new := newExperimentalBufferSizeCalculator(
+	new := newDynamicBufferSizeCalculator(
 		jobQueryBatchSize,
 		noOfWorkers,
 		noOfJobsToBatchInAWorker,
@@ -91,7 +91,7 @@ func newBufferSizeCalculatorSwitcher(
 	)
 
 	return func() int {
-		if enableExperimentalBufferSizeCalculator.Load() {
+		if enableDynamicBufferSizeCalculator.Load() {
 			return new()
 		}
 		return legacy()

--- a/router/worker_buffer_calculator_test.go
+++ b/router/worker_buffer_calculator_test.go
@@ -61,7 +61,7 @@ func TestStandardBufferSizeCalculator(t *testing.T) {
 	})
 }
 
-func TestExperimentalBufferSizeCalculator(t *testing.T) {
+func TestDynamicBufferSizeCalculator(t *testing.T) {
 	scalingFactor := config.SingleValueLoader(1.2)
 	t.Run("Basic Calculations", func(t *testing.T) {
 		t.Run("calculates buffer size correctly with all metrics", func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 20}
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			workLoopThroughput.Observe(10)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			// max(100/5, 20, 10) * 1.2 = max(20, 20, 10) * 1.2 = 20 * 1.2 = 24
 			expectedSize := 24
@@ -84,7 +84,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 0}
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			workLoopThroughput.Observe(0)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			result := calculator()
 			require.Equal(t, 1, result)
@@ -96,7 +96,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 5}
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			workLoopThroughput.Observe(50) // This will be the maximum
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			// max(20/10, 5, 50) * 1.2 = max(2, 5, 50) * 1.2 = 50 * 1.2 = 60
 			expectedSize := 60
@@ -110,7 +110,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 100} // This will be the maximum
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			workLoopThroughput.Observe(1)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			// max(50/10, 100, 1) * 1.2 = max(5, 100, 1) * 1.2 = 100 * 1.2 = 120
 			expectedSize := 120
@@ -123,7 +123,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 10}
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			workLoopThroughput.Observe(5)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			// max(1000/5, 10, 5) * 1.2 = max(200, 10, 5) * 1.2 = 200 * 1.2 = 240
 			expectedSize := 240
@@ -138,7 +138,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 20}
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			// No observation made, throughput is 0
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			require.Equal(t, 1, calculator())
 		})
@@ -149,7 +149,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 10}
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			workLoopThroughput.Observe(5)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			// max(100/1, 10, 5) * 1.2 = max(100, 10, 5) * 1.2 = 100 * 1.2 = 120
 			expectedSize := 120
@@ -162,7 +162,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 500}
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			workLoopThroughput.Observe(200)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			// max(10000/100 * 1.2, 500, 200) * 1.2 = max(120, 500, 200) * 1.2 = 500 * 1.2 = 600
 			expectedSize := 600
@@ -175,7 +175,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 3}
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			workLoopThroughput.Observe(2.5)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			// max(10/5 * 1.2, 3, 2.5) * 1.2 = max(2.4, 3, 2.5) * 1.2 = 3 * 1.2 = 3.6, ceil = 4
 			expectedSize := 4
@@ -190,7 +190,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 10}
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			workLoopThroughput.Observe(5)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			// Initial calculation: max(100/5, 10, 5) * 1.2 = max(20, 10, 5) * 1.2 = 20 * 1.2 = 24
 			result1 := calculator()
@@ -209,7 +209,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 10}
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			workLoopThroughput.Observe(5)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			// Initial calculation: max(50/5, 10, 5) * 1.2 = max(10, 10, 5) * 1.2 = 10 * 1.2 = 12
 			require.Equal(t, 12, calculator())
@@ -226,7 +226,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 10}
 			workLoopThroughput := metric.NewSimpleMovingAverage(2)
 			workLoopThroughput.Observe(5)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			// Initial calculation: max(50/5, 10, 5) * 1.2 = max(10, 10, 5) * 1.2 = 10 * 1.2 = 12
 			require.Equal(t, 12, calculator())
@@ -245,7 +245,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 10}
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			workLoopThroughput.Observe(10)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			// All three metrics are equal: 100/10 = 10, 10, 10
 			// max(10, 10, 10) * 1.2 = 10 * 1.2 = 12
@@ -260,7 +260,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 20}
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			workLoopThroughput.Observe(10)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			// Call calculator multiple times to ensure stats are captured
 			expectedSize := 24
@@ -276,7 +276,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 10}
 			workLoopThroughput := metric.NewSimpleMovingAverage(1)
 			workLoopThroughput.Observe(5)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			// Call calculator - first call should capture the stat
 			expectedSize := 12 // max(50/5, 10, 5) * 1.2 = max(10, 10, 5) * 1.2 = 10 * 1.2 = 12
@@ -295,7 +295,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 			noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 20}
 			workLoopThroughput := metric.NewSimpleMovingAverage(10)
 			workLoopThroughput.Observe(10)
-			calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+			calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 			var wg sync.WaitGroup
 			results := make([]int, 100)
@@ -340,7 +340,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 
 			for _, tc := range testCases {
 				t.Run(fmt.Sprintf("workers=%d", tc.workers), func(t *testing.T) {
-					calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, tc.workers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+					calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, tc.workers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 					require.Equal(t, tc.expectedSize, calculator())
 				})
 			}
@@ -358,7 +358,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 					workLoopThroughput.Observe(float64(i * 50)) // 50, 100, 150, ..., 500
 				}
 
-				calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+				calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 				// Average throughput = (50+100+...+500)/10 = 2750/10 = 275
 				// max(10000/20, 100, 275) * 1.2 = max(500, 100, 275) * 1.2 = 500 * 1.2 = 600
@@ -376,7 +376,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 					workLoopThroughput.Observe(2.0) // Steady low throughput
 				}
 
-				calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+				calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 				// max(100/10, 10, 2) * 1.2 = max(10, 10, 2) * 1.2 = 10 * 1.2 = 12
 				require.Equal(t, 12, calculator())
@@ -394,7 +394,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 					workLoopThroughput.Observe(val)
 				}
 
-				calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+				calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 				// Average = (10+50+30+80+20+40)/6 = 230/6 ≈ 38.33
 				// max(500/8, 25, 38.33) * 1.2 = max(62.5, 25, 38.33) * 1.2 = 62.5 * 1.2 = 75
@@ -409,7 +409,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 				noOfJobsToBatchInAWorker := &mockValueLoader[int]{value: 50}
 				workLoopThroughput := metric.NewSimpleMovingAverage(10) // No observations yet
 
-				calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+				calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 				// Throughput is 0, so return minimum size
 				require.Equal(t, 1, calculator())
@@ -422,7 +422,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 				workLoopThroughput := metric.NewSimpleMovingAverage(3)
 				workLoopThroughput.Observe(50)
 
-				calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+				calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 				// max(500/1, 100, 50) * 1.2 = max(500, 100, 50) * 1.2 = 500 * 1.2 = 600
 				require.Equal(t, 600, calculator())
@@ -435,7 +435,7 @@ func TestExperimentalBufferSizeCalculator(t *testing.T) {
 				workLoopThroughput := metric.NewSimpleMovingAverage(5)
 				workLoopThroughput.Observe(3)
 
-				calculator := newExperimentalBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
+				calculator := newDynamicBufferSizeCalculator(jobQueryBatchSize, noOfWorkers, noOfJobsToBatchInAWorker, workLoopThroughput, scalingFactor, config.SingleValueLoader(1))
 
 				// max(10/5 * 1.2, 1, 3) * 1.2 = max(2.4, 1, 3) * 1.2 = 3 * 1.2 = 3.6, ceil = 4
 				require.Equal(t, 4, calculator())


### PR DESCRIPTION
## Description

Graduates the dynamic worker buffer size calculator out of experimental status:

- Renames `experimentalBufferSizeCalculator` → `dynamicBufferSizeCalculator` across all code, config keys, and tests
- Enables the dynamic calculator by default (`enableDynamicBufferSizeCalculator` now defaults to `true`)
- Maintains backwards compatibility: the old `experimental*` config keys are still accepted as fallbacks via `getHierarchicalRouterConfigKeys`, so any existing environment-level overrides continue to work without changes

The dynamic calculator uses a sliding-window throughput average to size the worker buffer adaptively, rather than the static standard calculator. It was previously opt-in behind a feature flag; this PR flips it on for all deployments.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.