### PR TITLE
fix(jobsdb): get jobs lateral join against the v_last view

### DIFF
--- a/jobsdb/jobsdb_get.go
+++ b/jobsdb/jobsdb_get.go
@@ -352,7 +352,7 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 	// we only need to know whether any status row exists, not which one is latest,
 	// so the lateral's ORDER BY / LIMIT 1 would be wasteful — skip it.
 	if jd.conf.getJobsUseLateralJoin.Load() && !onlyUnprocessed {
-		joinTable = fmt.Sprintf(`LATERAL (SELECT * FROM %q WHERE job_id = jobs.job_id ORDER BY id DESC LIMIT 1) job_latest_state ON true`, joinTable)
+		joinTable = fmt.Sprintf(`LATERAL (SELECT * FROM %q WHERE job_id = jobs.job_id ORDER BY id DESC LIMIT 1) job_latest_state ON true`, ds.JobStatusTable)
 	} else {
 		joinTable = fmt.Sprintf(`%q job_latest_state ON jobs.job_id=job_latest_state.job_id`, joinTable)
 	}


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

# Description

When using the lateral join optimization in jobsdb we should be joining with the raw job status table, not the latest job status view. Otherwise the performance improvements claimed by #7007 are not valid.

- [original](https://explain.dalibo.com/plan/b5db49h45fhg9dcc)
- [lateral on view](https://explain.dalibo.com/plan/3a1160h1fa932a42)
- [lateral on table](https://explain.dalibo.com/plan/e7ahec033df23908) 

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
