### PR TITLE
fix(batchrouter): file descriptor leak in upload() — outputFile never closed

### DIFF
--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -385,6 +385,7 @@ func (brt *Handle) upload(provider string, batchJobs *BatchedJobs, isWarehouse b
 	if err != nil {
 		panic(err)
 	}
+	defer outputFile.Close()
 
 	brt.logger.Debugn("BRT: Starting upload to", logger.NewStringField("provider", provider))
 	var folderName string

--- a/router/batchrouter/handle.go
+++ b/router/batchrouter/handle.go
@@ -385,7 +385,7 @@ func (brt *Handle) upload(provider string, batchJobs *BatchedJobs, isWarehouse b
 	if err != nil {
 		panic(err)
 	}
-	defer outputFile.Close()
+	defer func() { _ = outputFile.Close() }()
 
 	brt.logger.Debugn("BRT: Starting upload to", logger.NewStringField("provider", provider))
 	var folderName string


### PR DESCRIPTION
Closes #7071

## Summary

`outputFile` is opened via `os.Open(gzipFilePath)` in `Handle.upload()` but never closed — leaking one file descriptor on every batch upload call, on both the success and error return paths.

## Fix

Added `defer func() { _ = outputFile.Close() }()` immediately after `os.Open`, matching the existing pattern in `archiver/worker.go:187`.

```go
outputFile, err := os.Open(gzipFilePath)
if err != nil {
    panic(err)
}
defer func() { _ = outputFile.Close() }()  // ← added
```

## Impact without fix

`upload()` is called on every batch job cycle for every active destination. Each call leaks one fd. Under sustained load this exhausts the process fd limit (`ulimit -n`), causing `too many open files` errors — dropped events or a crashed process.

## Test plan

- [ ] `go test ./router/batchrouter/...` passes
- [ ] No new linter warnings