### PR TITLE
fix: klaviyo upload partial failures

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -28,6 +29,10 @@ const (
 	MAXPAYLOADSIZE        = 4600000
 	IMPORT_ID_SEPARATOR   = ":"
 )
+
+// profileIndexRegex extracts the profile index from a Klaviyo error pointer such
+// as "/data/attributes/profiles/data/3/attributes/email".
+var profileIndexRegex = regexp.MustCompile(`/profiles/data/(\d+)`)
 
 func createFinalPayload(combinedProfiles []Profile, listId string) Payload {
 	payload := Payload{
@@ -316,33 +321,18 @@ func (kbu *KlaviyoBulkUploader) Upload(_ context.Context, asyncDestStruct *commo
 	var importIds []string // DelimitedImportIds is : separated importIds
 
 	for idx, profileChunk := range profileChunks {
-		combinedPayload := createFinalPayload(profileChunk, listId)
-		uploadResp, err := kbu.KlaviyoAPIService.UploadProfiles(combinedPayload)
-		if err != nil {
-			var uploadError string
-			var statusCode int
-			if uploadResp != nil {
-				statusCode = uploadResp.StatusCode
-				if len(uploadResp.Errors) > 0 {
-					uploadError = uploadResp.Errors.String()
-				}
-			}
-			kbu.Logger.Errorn("Error while uploading profiles",
-				obskit.Error(err),
-				obskit.DestinationID(destinationID),
-				logger.NewStringField("uploadErrors", uploadError))
-
-			if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError && statusCode != http.StatusTooManyRequests {
-				abortedJobs = append(abortedJobs, jobIDChunks[idx]...)
-				abortReason = fmt.Sprintf("upload rejected by Klaviyo with status %d: %s", statusCode, uploadError)
-			} else {
-				failedJobs = append(failedJobs, jobIDChunks[idx]...)
-				failedReason = fmt.Sprintf("upload failed with status %d: %s", statusCode, uploadError)
-			}
-			continue
+		chunkResult := kbu.uploadChunk(profileChunk, jobIDChunks[idx], listId, destinationID)
+		if len(chunkResult.abortedJobs) > 0 {
+			abortedJobs = append(abortedJobs, chunkResult.abortedJobs...)
+			abortReason = chunkResult.abortReason
 		}
-
-		importIds = append(importIds, uploadResp.Data.Id)
+		if len(chunkResult.failedJobs) > 0 {
+			failedJobs = append(failedJobs, chunkResult.failedJobs...)
+			failedReason = chunkResult.failReason
+		}
+		if chunkResult.importID != "" {
+			importIds = append(importIds, chunkResult.importID)
+		}
 	}
 	importParameters, err := jsonrs.Marshal(common.ImportParameters{
 		ImportId:    strings.Join(importIds, IMPORT_ID_SEPARATOR),
@@ -365,6 +355,134 @@ func (kbu *KlaviyoBulkUploader) Upload(_ context.Context, asyncDestStruct *commo
 		ImportingJobIDs:     successJobs,
 		ImportingCount:      len(successJobs),
 		DestinationID:       destination.ID,
+	}
+}
+
+// uploadChunk uploads a single chunk of profiles. Klaviyo validates a chunk
+// all-or-nothing, so one invalid profile fails the whole batch with a 400. On a
+// 400 that pinpoints specific profiles, it aborts only those and retries ONCE
+// with the rest. There is no further looping: the single retry's outcome is
+// final. A 400 it can't attribute (e.g. an invalid list ID) and non-4xx errors
+// abort/fail the whole chunk respectively.
+func (kbu *KlaviyoBulkUploader) uploadChunk(profiles []Profile, jobIDs []int64, listId, destinationID string) chunkUploadResult {
+	var res chunkUploadResult
+
+	// First attempt with the full chunk.
+	resp, statusCode, detail, ok := kbu.tryUpload(profiles, listId, destinationID)
+	if ok {
+		res.importID = resp.Data.Id
+		return res
+	}
+
+	badIndices, canStrip := strippableProfiles(resp, statusCode)
+	if !canStrip {
+		res.recordError(jobIDs, statusCode, detail)
+		return res
+	}
+
+	// Abort the invalid profiles; keep the rest for a single retry.
+	var validProfiles []Profile
+	var validJobIDs []int64
+	for i := range profiles {
+		if reason, bad := badIndices[i]; bad {
+			res.abortedJobs = append(res.abortedJobs, jobIDs[i])
+			res.abortReason = fmt.Sprintf("profile rejected by Klaviyo's synchronous validation: %s", reason)
+			continue
+		}
+		validProfiles = append(validProfiles, profiles[i])
+		validJobIDs = append(validJobIDs, jobIDs[i])
+	}
+	if len(validProfiles) == 0 {
+		return res // every profile was rejected; all already aborted
+	}
+
+	// Single retry with the surviving profiles; its outcome is final.
+	retryResp, retryStatus, retryDetail, ok := kbu.tryUpload(validProfiles, listId, destinationID)
+	if ok {
+		res.importID = retryResp.Data.Id
+		return res
+	}
+	res.recordError(validJobIDs, retryStatus, retryDetail)
+	return res
+}
+
+// tryUpload performs a single upload attempt, logging and extracting the status
+// code and error detail on failure. resp may be nil on a transport error.
+func (kbu *KlaviyoBulkUploader) tryUpload(profiles []Profile, listId, destinationID string) (resp *UploadResp, statusCode int, detail string, ok bool) {
+	resp, err := kbu.KlaviyoAPIService.UploadProfiles(createFinalPayload(profiles, listId))
+	if err == nil {
+		return resp, 0, "", true
+	}
+	if resp != nil {
+		statusCode = resp.StatusCode
+		if len(resp.Errors) > 0 {
+			detail = resp.Errors.String()
+		}
+	}
+	kbu.Logger.Errorn("Error while uploading profiles",
+		obskit.Error(err),
+		obskit.DestinationID(destinationID),
+		logger.NewStringField("uploadErrors", detail))
+	return resp, statusCode, detail, false
+}
+
+// strippableProfiles returns the rejected profiles' indices (mapped to their error
+// detail) only when the failure is a synchronous 400 that attributes every error
+// to a specific profile. For any other failure (transport/5xx/429, a 4xx we can't
+// attribute, or no per-profile errors) it returns ok=false, telling the caller to
+// abort/fail the whole chunk rather than retry.
+func strippableProfiles(resp *UploadResp, statusCode int) (map[int]string, bool) {
+	if resp == nil || !isClientError(statusCode) {
+		return nil, false
+	}
+	indices, allAttributed := extractInvalidProfileIndices(resp.Errors)
+	if !allAttributed || len(indices) == 0 {
+		return nil, false
+	}
+	return indices, true
+}
+
+// extractInvalidProfileIndices inspects the errors returned by a synchronous 400
+// from Klaviyo and maps each offending profile's index (within the uploaded
+// payload) to its error detail. The second return value is true only when every
+// error could be attributed to a specific profile; if any error is structural
+// (e.g. an invalid list ID, which has no profile pointer) it returns false so the
+// caller can fall back to aborting the whole chunk instead of retrying blindly.
+func extractInvalidProfileIndices(errs ErrorDetailList) (map[int]string, bool) {
+	indices := make(map[int]string)
+	allAttributed := true
+	for _, e := range errs {
+		match := profileIndexRegex.FindStringSubmatch(e.Source.Pointer)
+		if match == nil {
+			allAttributed = false
+			continue
+		}
+		idx, err := strconv.Atoi(match[1])
+		if err != nil {
+			allAttributed = false
+			continue
+		}
+		indices[idx] = e.Detail
+	}
+	return indices, allAttributed
+}
+
+// isClientError reports whether a status code is a non-retryable 4xx (excluding
+// 429, which is retryable rate limiting).
+func isClientError(statusCode int) bool {
+	return statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError && statusCode != http.StatusTooManyRequests
+}
+
+// recordError classifies a set of jobs against a failed upload: a non-retryable
+// 4xx aborts them, anything else (5xx/429/transport) is reported as failed so the
+// batch router retries.
+func (r *chunkUploadResult) recordError(jobIDs []int64, statusCode int, detail string) {
+	if isClientError(statusCode) {
+		r.abortedJobs = append(r.abortedJobs, jobIDs...)
+		r.abortReason = fmt.Sprintf("upload rejected by Klaviyo with status %d: %s", statusCode, detail)
+	} else {
+		r.failedJobs = append(r.failedJobs, jobIDs...)
+		r.failReason = fmt.Sprintf("upload failed with status %d: %s", statusCode, detail)
 	}
 }
 

--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
@@ -435,36 +435,29 @@ func strippableProfiles(resp *UploadResp, statusCode int) (map[int]string, bool)
 	if resp == nil || !isClientError(statusCode) {
 		return nil, false
 	}
-	indices, allAttributed := extractInvalidProfileIndices(resp.Errors)
-	if !allAttributed || len(indices) == 0 {
-		return nil, false
-	}
-	return indices, true
+	return extractInvalidProfileIndices(resp.Errors)
 }
 
 // extractInvalidProfileIndices inspects the errors returned by a synchronous 400
 // from Klaviyo and maps each offending profile's index (within the uploaded
-// payload) to its error detail. The second return value is true only when every
-// error could be attributed to a specific profile; if any error is structural
-// (e.g. an invalid list ID, which has no profile pointer) it returns false so the
-// caller can fall back to aborting the whole chunk instead of retrying blindly.
+// payload) to its error detail. The second return value is true only when there
+// is at least one error and every error was attributed to a specific profile. If
+// any error is structural (e.g. an invalid list ID, which has no profile pointer)
+// it returns false so the caller aborts the whole chunk instead of retrying blindly.
 func extractInvalidProfileIndices(errs ErrorDetailList) (map[int]string, bool) {
 	indices := make(map[int]string)
-	allAttributed := true
 	for _, e := range errs {
 		match := profileIndexRegex.FindStringSubmatch(e.Source.Pointer)
 		if match == nil {
-			allAttributed = false
-			continue
+			return nil, false
 		}
 		idx, err := strconv.Atoi(match[1])
 		if err != nil {
-			allAttributed = false
-			continue
+			return nil, false
 		}
 		indices[idx] = e.Detail
 	}
-	return indices, allAttributed
+	return indices, len(indices) > 0
 }
 
 // isClientError reports whether a status code is a non-retryable 4xx (excluding

--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload.go
@@ -334,6 +334,8 @@ func (kbu *KlaviyoBulkUploader) Upload(_ context.Context, asyncDestStruct *commo
 			importIds = append(importIds, chunkResult.importID)
 		}
 	}
+
+	successJobs, _ = lo.Difference(importingJobIDs, append(failedJobs, abortedJobs...))
 	importParameters, err := jsonrs.Marshal(common.ImportParameters{
 		ImportId:    strings.Join(importIds, IMPORT_ID_SEPARATOR),
 		ImportCount: len(successJobs),
@@ -341,7 +343,6 @@ func (kbu *KlaviyoBulkUploader) Upload(_ context.Context, asyncDestStruct *commo
 	if err != nil {
 		return kbu.generateKlaviyoErrorOutput("Error while marshaling parameters.", err, importingJobIDs, destinationID)
 	}
-	successJobs, _ = lo.Difference(importingJobIDs, append(failedJobs, abortedJobs...))
 	eventsSuccessStat.Count(len(asyncDestStruct.ImportingJobIDs))
 
 	return common.AsyncUploadOutput{

--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload_test.go
@@ -245,6 +245,168 @@ func TestUpload(t *testing.T) {
 	})
 }
 
+// A chunk is rejected with a 400 that pinpoints one invalid profile (index 1).
+// That job must be aborted on its own and the chunk re-uploaded with the
+// remaining valid profiles, which then succeeds.
+func TestUploadStripAndRetryInvalidProfiles(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKlaviyoAPIService := mockAPIService.NewMockKlaviyoAPIService(ctrl)
+	uploader := klaviyobulkupload.KlaviyoBulkUploader{
+		DestName:              "Klaviyo Bulk Upload",
+		DestinationConfig:     destination.Config,
+		Logger:                logger.NOP,
+		StatsFactory:          stats.NOP,
+		KlaviyoAPIService:     mockKlaviyoAPIService,
+		BatchSize:             10000,
+		MaxPayloadSize:        4600000,
+		MaxAllowedProfileSize: 512000,
+	}
+
+	tempFile, err := os.CreateTemp("", "test_upload_strip_*.jsonl")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	const tmpl = `{"message":{"body":{"JSON":{"data":{"type":"profile-bulk-import-job","attributes":{"profiles":{"data":[{"type":"profile","attributes":{"email":"%s","jobIdentifier":"%s:%d"}}]}}}}}},"metadata":{"job_id":%d}}`
+	lines := []string{
+		fmt.Sprintf(tmpl, "good1@mail.com", "good1", 1, 1),
+		fmt.Sprintf(tmpl, "bad@", "bad", 2, 2), // index 1 -> rejected by Klaviyo
+		fmt.Sprintf(tmpl, "good2@mail.com", "good2", 3, 3),
+	}
+	for i, line := range lines {
+		if i > 0 {
+			_, err = tempFile.WriteString("\n")
+			require.NoError(t, err)
+		}
+		_, err = tempFile.WriteString(line)
+		require.NoError(t, err)
+	}
+	tempFile.Close()
+
+	callCount := 0
+	mockKlaviyoAPIService.EXPECT().
+		UploadProfiles(gomock.Any()).
+		DoAndReturn(func(payload klaviyobulkupload.Payload) (*klaviyobulkupload.UploadResp, error) {
+			callCount++
+			switch callCount {
+			case 1:
+				// All 3 profiles sent; Klaviyo rejects the one at index 1.
+				require.Len(t, payload.Data.Attributes.Profiles.Data, 3)
+				return &klaviyobulkupload.UploadResp{
+					Errors: klaviyobulkupload.ErrorDetailList{
+						{
+							Code:   "invalid",
+							Title:  "Invalid input.",
+							Detail: "Invalid email address",
+							Source: klaviyobulkupload.ErrorSource{Pointer: "/data/attributes/profiles/data/1/attributes/email"},
+						},
+					},
+					StatusCode: http.StatusBadRequest,
+				}, fmt.Errorf("upload rejected")
+			case 2:
+				// Retry with the bad profile stripped -> 2 profiles, succeeds.
+				require.Len(t, payload.Data.Attributes.Profiles.Data, 2)
+				return &klaviyobulkupload.UploadResp{
+					Data: struct {
+						Id string "json:\"id\""
+					}{Id: "importIdRetry"},
+				}, nil
+			}
+			return nil, fmt.Errorf("unexpected call count: %d", callCount)
+		}).Times(2)
+
+	output := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
+		Destination:     destination,
+		FileName:        tempFile.Name(),
+		ImportingJobIDs: []int64{1, 2, 3},
+	})
+
+	require.Equal(t, []int64{2}, output.AbortJobIDs)
+	require.Equal(t, 1, output.AbortCount)
+	require.Equal(t, "profile rejected by Klaviyo's synchronous validation: Invalid email address", output.AbortReason)
+	require.ElementsMatch(t, []int64{1, 3}, output.ImportingJobIDs)
+	require.Equal(t, 2, output.ImportingCount)
+	require.Empty(t, output.FailedJobIDs)
+	require.Equal(t, `{"importId":"importIdRetry","importCount":0}`, string(output.ImportingParameters))
+}
+
+// The first upload is rejected (one profile stripped) and the single retry is
+// rejected too. There must be no third attempt; the stripped job and the
+// surviving jobs are all aborted.
+func TestUploadRetryAlsoFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKlaviyoAPIService := mockAPIService.NewMockKlaviyoAPIService(ctrl)
+	uploader := klaviyobulkupload.KlaviyoBulkUploader{
+		DestName:              "Klaviyo Bulk Upload",
+		DestinationConfig:     destination.Config,
+		Logger:                logger.NOP,
+		StatsFactory:          stats.NOP,
+		KlaviyoAPIService:     mockKlaviyoAPIService,
+		BatchSize:             10000,
+		MaxPayloadSize:        4600000,
+		MaxAllowedProfileSize: 512000,
+	}
+
+	tempFile, err := os.CreateTemp("", "test_upload_retryfail_*.jsonl")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	const tmpl = `{"message":{"body":{"JSON":{"data":{"type":"profile-bulk-import-job","attributes":{"profiles":{"data":[{"type":"profile","attributes":{"email":"%s","jobIdentifier":"%s:%d"}}]}}}}}},"metadata":{"job_id":%d}}`
+	lines := []string{
+		fmt.Sprintf(tmpl, "good1@mail.com", "good1", 1, 1),
+		fmt.Sprintf(tmpl, "bad@", "bad", 2, 2),
+		fmt.Sprintf(tmpl, "good2@mail.com", "good2", 3, 3),
+	}
+	for i, line := range lines {
+		if i > 0 {
+			_, err = tempFile.WriteString("\n")
+			require.NoError(t, err)
+		}
+		_, err = tempFile.WriteString(line)
+		require.NoError(t, err)
+	}
+	tempFile.Close()
+
+	callCount := 0
+	mockKlaviyoAPIService.EXPECT().
+		UploadProfiles(gomock.Any()).
+		DoAndReturn(func(payload klaviyobulkupload.Payload) (*klaviyobulkupload.UploadResp, error) {
+			callCount++
+			switch callCount {
+			case 1: // index 1 rejected
+				return &klaviyobulkupload.UploadResp{
+					Errors: klaviyobulkupload.ErrorDetailList{
+						{Detail: "Invalid email address", Source: klaviyobulkupload.ErrorSource{Pointer: "/data/attributes/profiles/data/1/attributes/email"}},
+					},
+					StatusCode: http.StatusBadRequest,
+				}, fmt.Errorf("upload rejected")
+			case 2: // retry rejected again
+				return &klaviyobulkupload.UploadResp{
+					Errors: klaviyobulkupload.ErrorDetailList{
+						{Detail: "Invalid input.", Source: klaviyobulkupload.ErrorSource{Pointer: "/data/attributes/profiles/data/0/attributes/email"}},
+					},
+					StatusCode: http.StatusBadRequest,
+				}, fmt.Errorf("upload rejected")
+			}
+			return nil, fmt.Errorf("unexpected call count: %d", callCount)
+		}).Times(2)
+
+	output := uploader.Upload(context.Background(), &common.AsyncDestinationStruct{
+		Destination:     destination,
+		FileName:        tempFile.Name(),
+		ImportingJobIDs: []int64{1, 2, 3},
+	})
+
+	require.Equal(t, 2, callCount, "must try once then retry once, no third attempt")
+	require.ElementsMatch(t, []int64{1, 2, 3}, output.AbortJobIDs)
+	require.Equal(t, 3, output.AbortCount)
+	require.Empty(t, output.ImportingJobIDs)
+	require.Empty(t, output.FailedJobIDs)
+}
+
 func TestExtractProfileValidInput(t *testing.T) {
 	kbu := klaviyobulkupload.KlaviyoBulkUploader{}
 

--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload_test.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/klaviyobulkupload_test.go
@@ -115,7 +115,7 @@ func TestUpload(t *testing.T) {
 			ImportingCount:      1,
 			DestinationID:       destination.ID,
 		}, output)
-		require.Equal(t, `{"importId":"importId1","importCount":0}`, string(output.ImportingParameters))
+		require.Equal(t, `{"importId":"importId1","importCount":1}`, string(output.ImportingParameters))
 	})
 
 	t.Run("Unsuccessful Upload", func(t *testing.T) {
@@ -241,7 +241,7 @@ func TestUpload(t *testing.T) {
 			FailedReason:        "upload failed with status 429: {ID=, Code=, Title=, Detail=rate limit exceeded, Source={Pointer=, Parameter=}}",
 			DestinationID:       destination.ID,
 		}, output)
-		require.Equal(t, `{"importId":"importId3","importCount":0}`, string(output.ImportingParameters))
+		require.Equal(t, `{"importId":"importId3","importCount":2}`, string(output.ImportingParameters))
 	})
 }
 
@@ -328,7 +328,7 @@ func TestUploadStripAndRetryInvalidProfiles(t *testing.T) {
 	require.ElementsMatch(t, []int64{1, 3}, output.ImportingJobIDs)
 	require.Equal(t, 2, output.ImportingCount)
 	require.Empty(t, output.FailedJobIDs)
-	require.Equal(t, `{"importId":"importIdRetry","importCount":0}`, string(output.ImportingParameters))
+	require.Equal(t, `{"importId":"importIdRetry","importCount":2}`, string(output.ImportingParameters))
 }
 
 // The first upload is rejected (one profile stripped) and the single retry is

--- a/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/types.go
+++ b/router/batchrouter/asyncdestinationmanager/klaviyobulkupload/types.go
@@ -29,6 +29,16 @@ type KlaviyoBulkUploader struct {
 	MaxAllowedProfileSize int // Override MAXALLOWEDPROFILESIZE for testing (0 = use default)
 }
 
+// chunkUploadResult is the outcome of uploading a single chunk, after at most one
+// strip-and-retry.
+type chunkUploadResult struct {
+	importID    string  // non-empty when a job was created for the surviving valid profiles
+	abortedJobs []int64 // jobs rejected by Klaviyo's synchronous validation
+	failedJobs  []int64 // jobs that hit a retryable failure (5xx/429/transport)
+	abortReason string
+	failReason  string
+}
+
 type ErrorDetail struct {
 	ID     string      `json:"id"`
 	Code   string      `json:"code"`


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

# Description

Klaviyo's Bulk Profile Import API validates each request **all-or-nothing**: a single profile that fails synchronous validation (e.g. a malformed email) causes Klaviyo to reject the entire batch with HTTP 400, importing **zero** profiles. Today rudder-server mirrors that by aborting the whole chunk, so one bad record takes down every valid profile alongside it.

This PR adds **strip-and-retry on failure**. When Klaviyo returns a 400 whose error pointers identify specific profiles, we abort only those jobs and re-upload the chunk **once** with the remaining valid profiles, so the good records still get delivered.

### Behavior

- **Success** → jobs imported as before.
- **400 that pinpoints specific profiles** → those jobs are aborted (with Klaviyo's per-profile reason), the rest are re-uploaded once; the retry's outcome is final (no looping).
- **400 we can't attribute to a profile** (e.g. invalid `listId`) → whole chunk aborted, unchanged.
- **5xx / 429 / transport errors** → whole chunk marked failed for the batch router to retry, unchanged.

The retry path is bounded to a single extra attempt — there is no loop.

### Implementation

- `uploadChunk` orchestrates the try → strip → retry-once flow.
- `tryUpload` performs one upload attempt and normalizes the status/error.
- `strippableProfiles` decides whether a failure is a per-profile 400 we can safely retry.
- `extractInvalidProfileIndices` parses the offending profile indices from Klaviyo's JSON pointers.
- `recordError` classifies remaining jobs as aborted (4xx) vs failed (5xx/429).
- `chunkUploadResult` (added to `types.go`) carries the per-chunk outcome.

## Linear Ticket

- Resolves INT-6600

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
