### PR TITLE
chore: recreate stale rsources subscription on shared db

### DIFF
--- a/services/rsources/handler.go
+++ b/services/rsources/handler.go
@@ -35,6 +35,18 @@ var ErrInvalidPaginationToken = errors.New("rsources: invalid pagination token")
 // In postgres, the replication slot name can contain lower-case letters, underscore characters, and numbers.
 var replSlotDisallowedChars *regexp.Regexp = regexp.MustCompile(`[^a-z0-9_]`)
 
+// maxIdentifierLength is the maximum length of a postgres identifier (NAMEDATALEN-1). Longer
+// identifiers are silently truncated to this many bytes by the server.
+const maxIdentifierLength = 63
+
+// truncateIdentifier truncates an ASCII identifier to the length postgres would store it as.
+func truncateIdentifier(name string) string {
+	if len(name) > maxIdentifierLength {
+		return name[:maxIdentifierLength]
+	}
+	return name
+}
+
 type sourcesHandler struct {
 	log                  logger.Logger
 	config               JobServiceConfig
@@ -570,7 +582,17 @@ func (sh *sourcesHandler) setupLogicalReplication(ctx context.Context) error {
 	}
 
 	normalizedHostname := replSlotDisallowedChars.ReplaceAllString(strings.ToLower(sh.config.LocalHostname), "_")
-	subscriptionName := fmt.Sprintf("%s_rsources_stats_sub", normalizedHostname)
+	// Postgres truncates identifiers to NAMEDATALEN-1 (63) bytes, so truncate the name ourselves
+	// to match what is actually stored in the catalog. The name is ASCII-only after normalization,
+	// so a byte slice is a safe truncation.
+	subscriptionName := truncateIdentifier(fmt.Sprintf("%s_rsources_stats_sub", normalizedHostname))
+
+	// Drop the subscription if its replication slot no longer exists on the publisher,
+	// so that it can be recreated below along with a fresh slot.
+	if err := sh.dropStaleSubscription(ctx, subscriptionName); err != nil {
+		return err
+	}
+
 	// Create subscription for the above publication (ignore already exists error)
 	subscriptionConn := sh.config.SubscriptionTargetConn
 	if subscriptionConn == "" {
@@ -586,6 +608,51 @@ func (sh *sourcesHandler) setupLogicalReplication(ctx context.Context) error {
 		return fmt.Errorf("failed to refresh subscription on shared database: %w", err)
 	}
 
+	return nil
+}
+
+// dropStaleSubscription drops the named subscription from the shared (subscriber) database if
+// its replication slot no longer exists on the local (publisher) database, allowing it to be
+// recreated together with a fresh slot. A subscription is considered stale when it has no
+// associated slot name, or the slot it references is absent on the publisher (e.g. the local
+// database was recreated, or the slot was dropped or invalidated due to WAL retention limits).
+//
+// It is a no-op when the subscription does not exist or its slot is healthy.
+func (sh *sourcesHandler) dropStaleSubscription(ctx context.Context, subscriptionName string) error {
+	var slotName sql.NullString
+	err := sh.sharedDB.QueryRowContext(ctx,
+		`SELECT subslotname FROM pg_subscription WHERE subname = $1`, subscriptionName).Scan(&slotName)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return nil // no subscription yet, nothing to reconcile
+	case err != nil:
+		return fmt.Errorf("failed to look up subscription %q on shared database: %w", subscriptionName, err)
+	}
+
+	if slotName.Valid {
+		var slotExists bool
+		if err := sh.localDB.QueryRowContext(ctx,
+			`SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)`,
+			slotName.String).Scan(&slotExists); err != nil {
+			return fmt.Errorf("failed to check replication slot %q on local database: %w", slotName.String, err)
+		}
+		if slotExists {
+			return nil // slot is healthy, nothing to do
+		}
+	}
+
+	sh.log.Warnn("dropping stale rsources subscription with missing replication slot",
+		logger.NewStringField("subscription", subscriptionName),
+		logger.NewStringField("slot", slotName.String))
+	// Detach the (missing) slot before dropping so that DROP SUBSCRIPTION doesn't attempt to
+	// contact the publisher to drop it. The statements run in a single round trip; lib/pq uses
+	// the simple query protocol since there are no bind parameters.
+	if _, err := sh.sharedDB.ExecContext(ctx, fmt.Sprintf(`
+		ALTER SUBSCRIPTION %[1]q DISABLE;
+		ALTER SUBSCRIPTION %[1]q SET (slot_name = NONE);
+		DROP SUBSCRIPTION %[1]q;`, subscriptionName)); err != nil {
+		return fmt.Errorf("failed to drop stale subscription %q on shared database: %w", subscriptionName, err)
+	}
 	return nil
 }
 

--- a/services/rsources/handler_test.go
+++ b/services/rsources/handler_test.go
@@ -1042,6 +1042,41 @@ var _ = Describe("Using sources handler", func() {
 			createService(configB)
 		})
 
+		It("should recreate a subscription whose replication slot was deleted on the publisher", func() {
+			ctx := context.Background()
+			subscriptionName := truncateIdentifier(
+				replSlotDisallowedChars.ReplaceAllString(strings.ToLower(configA.LocalHostname), "_") + "_rsources_stats_sub",
+			)
+
+			// Sanity: the slot exists on the publisher (pgA) after the initial setup.
+			Expect(replicationSlotExists(ctx, pgA.db, subscriptionName)).To(BeTrue(), "slot should exist after initial setup")
+
+			// Simulate slot loss on the publisher while the subscription survives on the shared db:
+			// disable the subscription so the walsender releases the slot, then drop the slot.
+			_, err := pgC.db.ExecContext(ctx, fmt.Sprintf(`ALTER SUBSCRIPTION %q DISABLE`, subscriptionName))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() error {
+				_, err := pgA.db.ExecContext(ctx, `SELECT pg_drop_replication_slot($1)`, subscriptionName)
+				return err
+			}, "30s", "100ms").Should(Succeed(), "should be able to drop the slot once it becomes inactive")
+			Expect(replicationSlotExists(ctx, pgA.db, subscriptionName)).To(BeFalse())
+
+			// Re-running setup must detect the stale subscription, drop it and recreate it with a fresh slot.
+			serviceA = createService(configA)
+			Expect(replicationSlotExists(ctx, pgA.db, subscriptionName)).To(BeTrue(), "slot should be recreated")
+
+			// Replication should resume end-to-end: a stat written to the local db must reach the shared db.
+			jobRunId := newJobRunId()
+			increment(pgA.db, jobRunId, defaultJobTargetKey, Stats{In: 5, Out: 4, Failed: 1}, serviceA, nil)
+			Eventually(func() bool {
+				status, err := serviceA.GetStatus(ctx, jobRunId, JobFilter{
+					SourceID:  []string{"source_id"},
+					TaskRunID: []string{"task_run_id"},
+				})
+				return err == nil && len(status.TasksStatus) == 1
+			}, "30s", "100ms").Should(BeTrue(), "replication should resume after slot recreation")
+		})
+
 		It("should cleanup orphaned rows in the shared db older than the shared retention", func() {
 			ctx := context.Background()
 			jobRunId := newJobRunId()
@@ -1284,6 +1319,13 @@ func countSharedRows(ctx context.Context, db *sql.DB, jobRunId string) sharedRow
 	Expect(db.QueryRowContext(ctx, `SELECT count(*) FROM rsources_failed_keys_v2_records r
 		JOIN rsources_failed_keys_v2 k ON k.id = r.id WHERE k.job_run_id = $1`, jobRunId).Scan(&c.records)).To(Succeed())
 	return c
+}
+
+func replicationSlotExists(ctx context.Context, db *sql.DB, slotName string) bool {
+	var exists bool
+	Expect(db.QueryRowContext(ctx,
+		`SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)`, slotName).Scan(&exists)).To(Succeed())
+	return exists
 }
 
 func increment(db *sql.DB, jobRunId string, key JobTargetKey, stat Stats, sh JobService, wg *sync.WaitGroup) {


### PR DESCRIPTION
# Description

When rsources logical replication is set up, the shared (subscriber) database holds a subscription per instance, while the local (publisher) database holds the matching replication slot. Today, if that slot disappears — most notably when the local db's persistent volume is deleted and the db is recreated from scratch — the subscription on the shared db survives but is permanently broken: `CREATE SUBSCRIPTION` only ever returns `DuplicateObject` and is skipped, so the slot is never recreated and replication stays silently dead.

This PR makes setup self-healing. Before creating the subscription, we now detect a stale subscription (one whose replication slot no longer exists on the publisher) and drop it so it can be recreated together with a fresh slot. The drop uses `DISABLE` → `SET (slot_name = NONE)` → `DROP` so it doesn't try to contact the publisher for the missing slot.

Also truncates the subscription name to Postgres' 63-byte identifier limit so the catalog lookup matches what the server actually stored (long pod hostnames could otherwise bypass the detection).

## Linear Ticket

resolves PIPE-3134

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
