### PR TITLE
chore(jobsdb): capturing multi-consumer pending events

### DIFF
--- a/jobsdb/jobsdb_get.go
+++ b/jobsdb/jobsdb_get.go
@@ -97,6 +97,7 @@ func (jd *Handle) GetPileUpCounts(ctx context.Context, cutoffTime time.Time, inc
 	}
 	defer release()
 
+	// Single-consumer: one pending row per job, destination_id read from the job's parameters.
 	queryString := `WITH pending AS (
 	SELECT
 		j.workspace_id AS workspace_id,
@@ -114,6 +115,32 @@ SELECT
 	destination_id,
 	COUNT(*)
 FROM pending GROUP BY workspace_id, custom_val, destination_id;`
+
+	// Multi-consumer: assuming for now that a consumer IS a destination, so fan out per consumer over the narrow consumers
+	// array (no payload), counting each (job, consumer) whose latest pre-cutoff status is missing or
+	// non-terminal. The per-consumer latest status uses the (job_id, consumer, id DESC) index.
+	if jd.conf.multiConsumer {
+		queryString = `WITH pending AS (
+	SELECT
+		j.workspace_id AS workspace_id,
+		j.custom_val AS custom_val,
+		c.consumer AS destination_id
+	FROM
+		%[1]q j
+		CROSS JOIN LATERAL unnest(j.consumers) AS c(consumer)
+		LEFT JOIN LATERAL (
+			SELECT job_state FROM %[2]q WHERE job_id = j.job_id AND consumer = c.consumer AND exec_time < $1 ORDER BY id DESC LIMIT 1
+		) s ON true
+	WHERE
+		s.job_state is null OR s.job_state = ANY($2)
+)
+SELECT
+	workspace_id,
+	custom_val,
+	destination_id,
+	COUNT(*)
+FROM pending GROUP BY workspace_id, custom_val, destination_id;`
+	}
 
 	g, ctx := errgroup.WithContext(ctx)
 	const defaultConcurrency = 4

--- a/jobsdb/jobsdb_multiconsumer.go
+++ b/jobsdb/jobsdb_multiconsumer.go
@@ -12,6 +12,11 @@ import (
 	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 )
 
+// defaultConsumers is the shared, immutable single-element slice holding the legacy ” consumer.
+// It is the consumers value stored for single-consumer handles and the fallback for multi-consumer
+// jobs with no explicit consumers. Reused (never mutated) to avoid per-job allocations on hot paths.
+var defaultConsumers = []string{""}
+
 // applyMultiConsumerFlip handles both directions of the multi-consumer transition.
 //
 // Upgrade (multiConsumer=true): ensures every dataset in dsList has the v_last_c_ view

--- a/jobsdb/jobsdb_pending_events.go
+++ b/jobsdb/jobsdb_pending_events.go
@@ -3,7 +3,7 @@ package jobsdb
 import (
 	"context"
 
-	"github.com/tidwall/gjson"
+	"github.com/rudderlabs/rudder-go-kit/jsonparser"
 )
 
 type PendingEventsRegistry interface {
@@ -11,17 +11,70 @@ type PendingEventsRegistry interface {
 	DecreasePendingEvents(tablePrefix, workspaceID, destType, destinationID string, value float64)
 }
 
-// NewPendingEventsJobsDB wraps a JobsDB with pending events metrics collection
-func NewPendingEventsJobsDB(jobsDB JobsDB, registry PendingEventsRegistry) JobsDB {
-	return &pendingEventsJobsDB{
-		JobsDB:   jobsDB,
-		registry: registry,
+// PendingEventsOpt configures a pendingEventsJobsDB.
+type PendingEventsOpt func(*pendingEventsJobsDB)
+
+// WithConsumerAsDestinationID makes pending-events accounting derive the destination ID from a
+// job's consumers (resp. a status's consumer) instead of `parameters->>'destination_id'`. Intended
+// for multi-consumer handles where a consumer IS a destination ID: a single job pending for N
+// consumers contributes one pending event per consumer, and a per-consumer terminal status decrements
+// exactly that destination.
+func WithConsumerAsDestinationID() PendingEventsOpt {
+	return func(pejdb *pendingEventsJobsDB) {
+		pejdb.storeDestinationIDs = consumerStoreDestinationIDs
+		pejdb.statusDestinationID = consumerStatusDestinationID
 	}
+}
+
+// NewPendingEventsJobsDB wraps a JobsDB with pending events metrics collection. By default the
+// destination ID is read from `parameters->>'destination_id'`; pass WithConsumerAsDestinationID to
+// treat consumers as destination IDs (multi-consumer handles).
+func NewPendingEventsJobsDB(jobsDB JobsDB, registry PendingEventsRegistry, opts ...PendingEventsOpt) JobsDB {
+	pejdb := &pendingEventsJobsDB{
+		JobsDB:              jobsDB,
+		registry:            registry,
+		storeDestinationIDs: parametersStoreDestinationIDs,
+		statusDestinationID: parametersStatusDestinationID,
+	}
+	for _, opt := range opts {
+		opt(pejdb)
+	}
+	return pejdb
 }
 
 type pendingEventsJobsDB struct {
 	JobsDB
 	registry PendingEventsRegistry
+	// storeDestinationIDs returns the destination ID(s) a stored job is pending for.
+	storeDestinationIDs func(job *JobT) []string
+	// statusDestinationID returns the destination ID a status row belongs to.
+	statusDestinationID func(status *JobStatusT) string
+}
+
+// parametersStoreDestinationIDs reads the single destination ID from the job's parameters.
+func parametersStoreDestinationIDs(job *JobT) []string {
+	return []string{jsonparser.GetStringOrEmpty(job.Parameters, "destination_id")}
+}
+
+// parametersStatusDestinationID reads the destination ID from the status's job parameters.
+func parametersStatusDestinationID(status *JobStatusT) string {
+	if status.JobParameters == nil {
+		return ""
+	}
+	return jsonparser.GetStringOrEmpty(status.JobParameters, "destination_id")
+}
+
+// consumerStoreDestinationIDs treats the job's consumers as its destination IDs.
+func consumerStoreDestinationIDs(job *JobT) []string {
+	if len(job.Consumers) == 0 {
+		return []string{""}
+	}
+	return job.Consumers
+}
+
+// consumerStatusDestinationID treats the status's consumer as its destination ID.
+func consumerStatusDestinationID(status *JobStatusT) string {
+	return status.Consumer
 }
 
 func (pejdb *pendingEventsJobsDB) Store(ctx context.Context, jobList []*JobT) error {
@@ -36,14 +89,15 @@ func (pejdb *pendingEventsJobsDB) StoreInTx(ctx context.Context, tx StoreSafeTx,
 		for _, job := range jobList {
 			workspaceID := job.WorkspaceId
 			destType := job.CustomVal
-			destinationID := gjson.GetBytes(job.Parameters, "destination_id").String()
-			if _, ok := counters[workspaceID]; !ok {
-				counters[workspaceID] = make(map[string]map[string]float64)
+			for _, destinationID := range pejdb.storeDestinationIDs(job) {
+				if _, ok := counters[workspaceID]; !ok {
+					counters[workspaceID] = make(map[string]map[string]float64)
+				}
+				if _, ok := counters[workspaceID][destType]; !ok {
+					counters[workspaceID][destType] = make(map[string]float64)
+				}
+				counters[workspaceID][destType][destinationID]++
 			}
-			if _, ok := counters[workspaceID][destType]; !ok {
-				counters[workspaceID][destType] = make(map[string]float64)
-			}
-			counters[workspaceID][destType][destinationID]++
 		}
 		for workspaceID, destTypeMap := range counters {
 			for destType, destinationIDMap := range destTypeMap {
@@ -71,10 +125,7 @@ func (pejdb *pendingEventsJobsDB) UpdateJobStatusInTx(ctx context.Context, tx Up
 			}
 			workspaceID := status.WorkspaceId
 			destType := status.CustomVal
-			var destinationID string
-			if status.JobParameters != nil {
-				destinationID = gjson.GetBytes(status.JobParameters, "destination_id").String()
-			}
+			destinationID := pejdb.statusDestinationID(status)
 			if _, ok := counters[workspaceID]; !ok {
 				counters[workspaceID] = make(map[string]map[string]float64)
 			}

--- a/jobsdb/jobsdb_pending_events_test.go
+++ b/jobsdb/jobsdb_pending_events_test.go
@@ -289,6 +289,48 @@ func TestPendingEventsJobsDB(t *testing.T) {
 		require.Equal(t, 3, registry.increaseCallCount)
 		require.Equal(t, float64(4), registry.totalIncreased)
 	})
+
+	t.Run("consumer-as-destination-id: store fans out per consumer, status decrements one consumer", func(t *testing.T) {
+		_ = startPostgres(t)
+		c := config.New()
+		c.Set("jobsdb.maxDSSize", 100)
+
+		jobDB := Handle{config: c}
+		jobDB.conf.multiConsumer = true
+		tablePrefix := strings.ToLower(rand.String(5))
+		require.NoError(t, jobDB.Setup(ReadWrite, true, tablePrefix))
+		defer jobDB.TearDown()
+
+		registry := &mockPendingEventsRegistry{}
+		decoratedDB := NewPendingEventsJobsDB(&jobDB, registry, WithConsumerAsDestinationID())
+
+		// one job pending for destinations A and B, one job pending for A only
+		jobs := []*JobT{
+			{UUID: uuid.New(), UserID: "u", CustomVal: customVal, Parameters: []byte(`{}`), EventPayload: []byte(`{}`), EventCount: 1, WorkspaceId: workspaceID, Consumers: []string{"A", "B"}},
+			{UUID: uuid.New(), UserID: "u", CustomVal: customVal, Parameters: []byte(`{}`), EventPayload: []byte(`{}`), EventCount: 1, WorkspaceId: workspaceID, Consumers: []string{"A"}},
+		}
+		require.NoError(t, decoratedDB.Store(context.Background(), jobs))
+
+		// destination A got two pending events (both jobs), destination B got one
+		require.Equal(t, float64(3), registry.totalIncreased)
+		require.Equal(t, float64(2), registry.increasedByDest["A"])
+		require.Equal(t, float64(1), registry.increasedByDest["B"])
+
+		// Store is COPY-based and does not populate JobID; consumer "B" uniquely identifies the first job.
+		job0, err := jobDB.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "B"})
+		require.NoError(t, err)
+		require.Len(t, job0.Jobs, 1)
+
+		// consumer A finishes the first job → decrement destination A by one
+		require.NoError(t, decoratedDB.UpdateJobStatus(context.Background(), []*JobStatusT{{
+			JobID: job0.Jobs[0].JobID, JobState: Succeeded.State, AttemptNum: 1,
+			ErrorCode: "200", ErrorResponse: []byte(`{}`), Parameters: []byte(`{}`),
+			WorkspaceId: workspaceID, CustomVal: customVal, Consumer: "A",
+		}}))
+		require.Equal(t, float64(1), registry.totalDecreased)
+		require.Equal(t, float64(1), registry.decreasedByDest["A"])
+		require.Equal(t, float64(0), registry.decreasedByDest["B"])
+	})
 }
 
 // mockPendingEventsRegistry tracks calls to the pending events registry
@@ -301,6 +343,8 @@ type mockPendingEventsRegistry struct {
 	lastWorkspaceID   string
 	lastDestType      string
 	lastDestinationID string
+	increasedByDest   map[string]float64
+	decreasedByDest   map[string]float64
 }
 
 func (m *mockPendingEventsRegistry) IncreasePendingEvents(tablePrefix, workspaceID, destType, destinationID string, value float64) {
@@ -310,6 +354,10 @@ func (m *mockPendingEventsRegistry) IncreasePendingEvents(tablePrefix, workspace
 	m.lastWorkspaceID = workspaceID
 	m.lastDestType = destType
 	m.lastDestinationID = destinationID
+	if m.increasedByDest == nil {
+		m.increasedByDest = map[string]float64{}
+	}
+	m.increasedByDest[destinationID] += value
 }
 
 func (m *mockPendingEventsRegistry) DecreasePendingEvents(tablePrefix, workspaceID, destType, destinationID string, value float64) {
@@ -319,4 +367,8 @@ func (m *mockPendingEventsRegistry) DecreasePendingEvents(tablePrefix, workspace
 	m.lastWorkspaceID = workspaceID
 	m.lastDestType = destType
 	m.lastDestinationID = destinationID
+	if m.decreasedByDest == nil {
+		m.decreasedByDest = map[string]float64{}
+	}
+	m.decreasedByDest[destinationID] += value
 }

--- a/jobsdb/jobsdb_pileup_test.go
+++ b/jobsdb/jobsdb_pileup_test.go
@@ -2,6 +2,7 @@ package jobsdb
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
 )
 
 func TestJobsdbPileupCount(t *testing.T) {
@@ -200,4 +202,58 @@ func TestJobsdbPileupCount(t *testing.T) {
 	require.NoError(t, g2.Wait(), "goroutines 3 and 4 should not return an error")
 	require.EqualValues(t, 0, pileupCount.Load())
 	t.Logf("Queries: %d, Migrations: %d", queries, migrations)
+}
+
+// TestJobsdbPileupCountMultiConsumer verifies that GetPileUpCounts on a multi-consumer handle
+// reports pending events per consumer (consumer = destination_id): a job pending for N consumers
+// contributes N pending events, and a per-consumer terminal status drops exactly that consumer.
+func TestJobsdbPileupCountMultiConsumer(t *testing.T) {
+	_ = startPostgres(t)
+
+	const (
+		customVal   = "MCPILE"
+		workspaceID = "ws"
+	)
+
+	c := config.New()
+	c.Set("JobsDB.maxDSSize", 100)
+
+	jdb := Handle{config: c}
+	jdb.conf.multiConsumer = true
+	require.NoError(t, jdb.Setup(ReadWrite, true, strings.ToLower(rand.String(5))))
+	defer jdb.TearDown()
+
+	// job0 pending for A and B; job1 pending for A only
+	jobs := []*JobT{
+		{UUID: uuid.New(), UserID: "u", CustomVal: customVal, Parameters: []byte(`{}`), EventPayload: []byte(`{}`), EventCount: 1, WorkspaceId: workspaceID, Consumers: []string{"A", "B"}},
+		{UUID: uuid.New(), UserID: "u", CustomVal: customVal, Parameters: []byte(`{}`), EventPayload: []byte(`{}`), EventCount: 1, WorkspaceId: workspaceID, Consumers: []string{"A"}},
+	}
+	require.NoError(t, jdb.Store(context.Background(), jobs))
+
+	pileup := func() map[string]int {
+		counts := map[string]int{}
+		require.NoError(t, jdb.GetPileUpCounts(context.Background(), time.Now(), func(tablePrefix, ws, destType, destinationID string, value float64) {
+			require.Equal(t, customVal, destType)
+			require.Equal(t, workspaceID, ws)
+			counts[destinationID] += int(value)
+		}))
+		return counts
+	}
+
+	// Both jobs pending for A, one for B.
+	require.Equal(t, map[string]int{"A": 2, "B": 1}, pileup())
+
+	// Store is COPY-based and does not populate JobID; consumer "B" uniquely identifies job0.
+	job0, err := jdb.GetUnprocessed(context.Background(), GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 10, Consumer: "B"})
+	require.NoError(t, err)
+	require.Len(t, job0.Jobs, 1)
+
+	// Consumer A finishes job0 → A drops to 1, B unchanged.
+	require.NoError(t, jdb.UpdateJobStatus(context.Background(), []*JobStatusT{{
+		JobID: job0.Jobs[0].JobID, JobState: Succeeded.State, AttemptNum: 1,
+		ExecTime: time.Now(), RetryTime: time.Now(), ErrorCode: "200",
+		ErrorResponse: []byte(`{}`), Parameters: []byte(`{}`),
+		WorkspaceId: workspaceID, CustomVal: customVal, Consumer: "A",
+	}}))
+	require.Equal(t, map[string]int{"A": 1, "B": 1}, pileup())
 }

--- a/jobsdb/jobsdb_store.go
+++ b/jobsdb/jobsdb_store.go
@@ -126,7 +126,7 @@ func (jd *Handle) invalidateCacheForJobs(ds dataSetT, jobList []*JobT) {
 		if jd.conf.multiConsumer {
 			consumers := job.Consumers
 			if len(consumers) == 0 {
-				consumers = []string{""}
+				consumers = defaultConsumers
 			}
 			for _, c := range consumers {
 				params = append(params, consumerParamName+":"+c)
@@ -161,9 +161,13 @@ func (jd *Handle) doStoreJobsInTx(ctx context.Context, tx *Tx, ds dataSetT, jobL
 			if job.PartitionID == "" && jd.conf.numPartitions > 0 {
 				job.PartitionID = jd.conf.partitionFunction(job)
 			}
-			consumers := job.Consumers
-			if len(consumers) == 0 {
-				consumers = []string{""}
+			// Single-consumer handles always store the legacy '' consumer, regardless of what a
+			// caller may have set on job.Consumers — named consumers are only meaningful on MC handles.
+			// defaultConsumers is a shared immutable sentinel (read-only via pq.Array) to avoid a
+			// per-job allocation on the store hot path.
+			consumers := defaultConsumers
+			if jd.conf.multiConsumer && len(job.Consumers) > 0 {
+				consumers = job.Consumers
 			}
 			if _, err = stmt.ExecContext(ctx, job.UUID, job.UserID, job.CustomVal, string(job.Parameters), string(job.EventPayload), eventCount, job.WorkspaceId, job.PartitionID, pq.Array(consumers)); err != nil {
 				return err


### PR DESCRIPTION
# Description

Consumer-aware pending events on multi-consumer handles, where a consumer is a destination ID.

- **`pendingEventsJobsDB`**: new `WithConsumerAsDestinationID()` option. In consumer mode the destination ID comes from `job.Consumers` (store) and `status.Consumer` (update) instead of `parameters->>'destination_id'`, so a job pending for N consumers emits N pending events and a per-consumer terminal status decrements exactly that destination. Default behaviour is unchanged.
- **`GetPileUpCounts`**: for multi-consumer handles, defaults to per-consumer counting — fans out over `unnest(j.consumers)` and reports the `consumer` as `destination_id`. No payload fan-out; `increaseFunc` signature unchanged.
- **`Store`**: single-consumer handles now always persist `consumers = {''}` regardless of `job.Consumers`. A shared `defaultConsumers` sentinel avoids a per-job slice allocation on the store path.

## Linear Ticket

resolves PIPE-3154

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #7122 
- <kbd>&nbsp;4&nbsp;</kbd> #7121 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #7098 
- <kbd>&nbsp;2&nbsp;</kbd> #7097 
- <kbd>&nbsp;1&nbsp;</kbd> #7096 
<!-- GitButler Footer Boundary Bottom -->

