### PR TITLE
chore(jobsdb): cleanup legacy configuration flags

### DIFF
--- a/integration_test/partitionmigration/partitionmigration_embedded_test.go
+++ b/integration_test/partitionmigration/partitionmigration_embedded_test.go
@@ -202,7 +202,6 @@ func TestPartitionMigrationEmbeddedMode(t *testing.T) {
 		"JobsDB.addNewDSLoopSleepDuration":      "1s",
 		"JobsDB.dsLimit":                        "2",
 		"JobsDB.refreshDSListLoopSleepDuration": "5s",
-		"JobsDB.nonBlockingCompletedDSDrop":     "true",
 	}
 	rsBinaryPath := filepath.Join(t.TempDir(), "rudder-server-binary")
 	rudderserver.BuildRudderServerBinary(t, "../../main.go", rsBinaryPath)

--- a/integration_test/partitionmigration/partitionmigration_gwproc_test.go
+++ b/integration_test/partitionmigration/partitionmigration_gwproc_test.go
@@ -211,7 +211,6 @@ func testPartitionMigrationGatewayProcessorMode(t *testing.T, extraStressWorkspa
 		"JobsDB.addNewDSLoopSleepDuration":      "2s",
 		"JobsDB.dsLimit":                        "3",
 		"JobsDB.refreshDSListLoopSleepDuration": "5s",
-		"JobsDB.nonBlockingCompletedDSDrop":     "true",
 		"JobsDB.partitionCount":                 strconv.Itoa(numPartitions),
 	}
 
@@ -256,7 +255,6 @@ func testPartitionMigrationGatewayProcessorMode(t *testing.T, extraStressWorkspa
 		"JobsDB.addNewDSLoopSleepDuration":      "2s",
 		"JobsDB.dsLimit":                        "3",
 		"JobsDB.refreshDSListLoopSleepDuration": "5s",
-		"JobsDB.nonBlockingCompletedDSDrop":     "true",
 		"JobsDB.partitionCount":                 strconv.Itoa(numPartitions),
 
 		"Processor.pingerSleep":   "1s",

--- a/jobsdb/bench/bench_test.go
+++ b/jobsdb/bench/bench_test.go
@@ -138,7 +138,6 @@ func TestBench(t *testing.T) {
 		c.Set("JobsDB.maxReaders", 6)
 
 		// Common jobsdb configuration under test
-		c.Set("JobsDB.noResultsCacheStateOptimization", true)
 		c.Set("JobsDB.logCacheBranchInvalidation", true)
 		c.Set("JobsDB.warnOnStatusMissingPartitionID", true)
 		c.Set("JobsDB.cacheExpiration", 2*time.Hour)

--- a/jobsdb/bench/scenario/compaction.go
+++ b/jobsdb/bench/scenario/compaction.go
@@ -55,10 +55,7 @@ type compaction struct {
 
 // flagSet is a single jobsdb compaction configuration under test.
 type flagSet struct {
-	name                       string
-	nonBlockingCompletedDSDrop bool
-	nonBlockingCompaction      bool
-	compactionDeferStatusLock  bool
+	name string
 }
 
 func (p *compaction) Run(ctx context.Context) error {
@@ -122,10 +119,7 @@ func (p *compaction) Run(ctx context.Context) error {
 	}
 
 	scenarios := []flagSet{
-		{name: "baseline (blocking compaction)", nonBlockingCompletedDSDrop: false, nonBlockingCompaction: false},
-		{name: "nonBlockingCompletedDSDrop", nonBlockingCompletedDSDrop: true, nonBlockingCompaction: false},
-		{name: "nonBlockingCompaction", nonBlockingCompaction: true},
-		{name: "nonBlockingCompaction + deferStatusLock", nonBlockingCompaction: true, compactionDeferStatusLock: true},
+		{name: "compaction"},
 	}
 
 	type result struct {
@@ -140,10 +134,6 @@ func (p *compaction) Run(ctx context.Context) error {
 		}
 		p.log.Infon("running compaction bench scenario", logger.NewStringField("scenario", s.name))
 
-		// Apply the flag combination under test.
-		p.conf.Set("JobsDB."+tablePrefix+".nonBlockingCompletedDSDrop", s.nonBlockingCompletedDSDrop)
-		p.conf.Set("JobsDB."+tablePrefix+".nonBlockingCompaction", s.nonBlockingCompaction)
-		p.conf.Set("JobsDB."+tablePrefix+".compactionDeferStatusLock", s.compactionDeferStatusLock)
 		p.conf.Set("JobsDB.compactionMinDSAge", "0s")
 
 		// Deterministic addNewDS trigger so we can seed exactly [datasets]

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -318,7 +318,6 @@ type Handle struct {
 	dsRangeFuncMap      map[string]func() (dsRangeMinMax, error)
 	distinctValuesCache *distinctValuesCache
 	dsListLock          *lock.Locker
-	dsCompactionLock    *lock.Locker
 	// lastCompactionProbeIndex stores the dsindex of the last dataset probed by
 	// getCompactionList when no eligible datasets were found and scanning was
 	// cut short by maxCompactDSProbe. The next invocation resumes from here

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -386,7 +386,6 @@ type Handle struct {
 		partitionFunction              func(job *JobT) string
 		multiConsumer                  bool // if true, enables per-consumer indexes, views, and query paths
 		warnOnStatusMissingPartitionID config.ValueLoader[bool]
-		holdDSListLockDuringStore      config.ValueLoader[bool] // escape hatch: hold the dsList read lock for the entire store callback
 		staleDSListMaxRetries          config.ValueLoader[int]
 		dbTablesVersion                int // version of the database tables schema (0 means latest)
 

--- a/jobsdb/jobsdb.go
+++ b/jobsdb/jobsdb.go
@@ -361,39 +361,35 @@ type Handle struct {
 
 	config *config.Config
 	conf   struct {
-		payloadColumnType               payloadColumnType
-		maxTableSize                    config.ValueLoader[int64]
-		cacheExpiration                 config.ValueLoader[time.Duration]
-		addNewDSLoopSleepDuration       config.ValueLoader[time.Duration]
-		addNewDSTimeout                 config.ValueLoader[time.Duration]
-		refreshDSListLoopSleepDuration  config.ValueLoader[time.Duration]
-		refreshDSTimeout                config.ValueLoader[time.Duration]
-		minDSRetentionPeriod            config.ValueLoader[time.Duration]
-		maxDSRetentionPeriod            config.ValueLoader[time.Duration]
-		jobMaxAge                       config.ValueLoader[time.Duration]
-		writeCapacity                   chan struct{}
-		readCapacity                    chan struct{}
-		enableWriterQueue               bool
-		enableReaderQueue               bool
-		clearAll                        bool
-		skipMaintenanceError            bool
-		dsLimit                         config.ValueLoader[int]
-		maxReaders                      int
-		maxWriters                      int
-		maxOpenConnections              int
-		analyzeThreshold                config.ValueLoader[int]
-		MaxDSSize                       config.ValueLoader[int]
-		numPartitions                   int // if zero or negative, no partitioning
-		partitionFunction               func(job *JobT) string
-		multiConsumer                   bool // if true, enables per-consumer indexes, views, and query paths
-		warnOnStatusMissingPartitionID  config.ValueLoader[bool]
-		holdDSListLockDuringStore       config.ValueLoader[bool] // escape hatch: hold the dsList read lock for the entire store callback
-		staleDSListMaxRetries           config.ValueLoader[int]
-		noResultsCacheStateOptimization config.ValueLoader[bool]
-		// getJobsUseLateralJoin replaces the v_last_* view join in getJobsDS with a
-		// correlated LATERAL subquery against the raw job_status table.
-		getJobsUseLateralJoin config.ValueLoader[bool]
-		dbTablesVersion       int // version of the database tables schema (0 means latest)
+		payloadColumnType              payloadColumnType
+		maxTableSize                   config.ValueLoader[int64]
+		cacheExpiration                config.ValueLoader[time.Duration]
+		addNewDSLoopSleepDuration      config.ValueLoader[time.Duration]
+		addNewDSTimeout                config.ValueLoader[time.Duration]
+		refreshDSListLoopSleepDuration config.ValueLoader[time.Duration]
+		refreshDSTimeout               config.ValueLoader[time.Duration]
+		minDSRetentionPeriod           config.ValueLoader[time.Duration]
+		maxDSRetentionPeriod           config.ValueLoader[time.Duration]
+		jobMaxAge                      config.ValueLoader[time.Duration]
+		writeCapacity                  chan struct{}
+		readCapacity                   chan struct{}
+		enableWriterQueue              bool
+		enableReaderQueue              bool
+		clearAll                       bool
+		skipMaintenanceError           bool
+		dsLimit                        config.ValueLoader[int]
+		maxReaders                     int
+		maxWriters                     int
+		maxOpenConnections             int
+		analyzeThreshold               config.ValueLoader[int]
+		MaxDSSize                      config.ValueLoader[int]
+		numPartitions                  int // if zero or negative, no partitioning
+		partitionFunction              func(job *JobT) string
+		multiConsumer                  bool // if true, enables per-consumer indexes, views, and query paths
+		warnOnStatusMissingPartitionID config.ValueLoader[bool]
+		holdDSListLockDuringStore      config.ValueLoader[bool] // escape hatch: hold the dsList read lock for the entire store callback
+		staleDSListMaxRetries          config.ValueLoader[int]
+		dbTablesVersion                int // version of the database tables schema (0 means latest)
 
 		compaction struct {
 			maxCompactOnce, maxCompactDSProbe config.ValueLoader[int]
@@ -409,26 +405,10 @@ type Handle struct {
 			// destinations) from being compacted again right away. Datasets without
 			// a recorded creation time are always considered old enough.
 			compactionMinDSAge config.ValueLoader[time.Duration]
-			// nonBlockingCompletedDSDrop routes datasets with zero pending jobs
-			// through the async dropDSLoop instead of the in-TX postCompactionHandleDS
-			// path, so the drop is compaction-lock-free and does not block concurrent readers.
-			nonBlockingCompletedDSDrop config.ValueLoader[bool]
-			// nonBlockingCompaction gates the new compaction TX shape (EXCLUSIVE
-			// lock + readonly trigger on the source status table, async source drop).
-			// When disabled, falls back to the legacy doCompaction flow.
-			nonBlockingCompaction config.ValueLoader[bool]
-			// compactionDeferStatusLock further minimizes the status-table lock
-			// window during non-blocking compaction by splitting the copy into two
-			// phases: pending jobs are copied first WITHOUT any status-table lock,
-			// then each source status table is locked EXCLUSIVE one after another only
-			// to copy the latest statuses of the moved jobs. Requires
-			// nonBlockingCompaction; has no effect on its own.
-			compactionDeferStatusLock config.ValueLoader[bool]
 			// getJobsRetryOnCompaction gates the snapshot revalidation in getJobs:
 			// when set, getJobs detects that a queried dataset is no longer in the
-			// published list (e.g. a non-blocking compaction completed mid-read) and
-			// retries from scratch. Requires nonBlockingCompaction to also be set;
-			// has no effect on its own.
+			// published list (e.g. a compaction completed mid-read) and retries from
+			// scratch.
 			getJobsRetryOnCompaction config.ValueLoader[bool]
 			// skipStatusCompaction disables the periodic status-table cleanup
 			// (cleanupStatusTables) while leaving DS-level compaction (move + drop) intact.

--- a/jobsdb/jobsdb_compaction.go
+++ b/jobsdb/jobsdb_compaction.go
@@ -587,8 +587,6 @@ func (jd *Handle) lockAndFenceStatusTable(ctx context.Context, tx *Tx, statusTab
 // doCompaction is the non-blocking compaction flow.
 //
 // Lock semantics:
-//   - dsCompactionLock is NOT taken. Concurrent reads via inUpdateSafeCtx grab their
-//     existing read lock against an uncontended write side.
 //   - dsListLock is taken exactly once, asynchronously, right before COMMIT — only
 //     the swap (in-memory) + COMMIT + enqueue + publish happen inside the lock window.
 //   - Source status tables are fenced with LOCK TABLE … IN EXCLUSIVE MODE and a

--- a/jobsdb/jobsdb_compaction.go
+++ b/jobsdb/jobsdb_compaction.go
@@ -66,210 +66,6 @@ func (jd *Handle) compactionLoop(ctx context.Context) {
 	}
 }
 
-func (jd *Handle) doCompaction(ctx context.Context) error {
-	if jd.conf.compaction.nonBlockingCompaction.Load() {
-		return jd.doCompactDS(ctx)
-	}
-	dsList, _, release, err := jd.acquireDSListForRead(ctx)
-	if err != nil {
-		return fmt.Errorf("could not acquire a dslist read lock: %w", err)
-	}
-
-	if err := jd.cleanupStatusTables(ctx, dsList); err != nil {
-		release()
-		return err
-	}
-	release()
-
-	optimisticCheck, err := jd.getCompactionList(dsList, jd.lastCompactionProbeIndex, jd.maintenanceDB())
-	jd.lastCompactionProbeIndex = nil
-	if err != nil {
-		return fmt.Errorf("could not get compaction list: %w", err)
-	}
-
-	// Fast path: route datasets that have no pending jobs through the async
-	// dropDSLoop instead of the in-TX postCompactionHandleDS path. This skips the
-	// dsCompactionLock for empty-source drops so concurrent readers are not blocked.
-	if jd.conf.compaction.nonBlockingCompletedDSDrop.Load() {
-		completed := lo.FilterMap(
-			optimisticCheck.compactFrom,
-			func(d dsWithPendingJobCount, _ int) (dataSetT, bool) {
-				return d.ds, d.numJobsPending == 0
-			},
-		)
-		if len(completed) > 0 {
-			if err := jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
-				// addCompletedDSToDropList republishes dsList without the completed datasets;
-				// reuse that snapshot so the second getCompactionList pass inside the
-				// TX does not re-encounter datasets we just queued for async drop.
-				newList, err := jd.addCompletedDSToDropList(ctx, l, completed...)
-				if err != nil {
-					return err
-				}
-				dsList = newList
-				return nil
-			}); err != nil {
-				return fmt.Errorf("enqueue completed datasets for async drop: %w", err)
-			}
-			optimisticCheck.compactFrom = lo.Filter(
-				optimisticCheck.compactFrom,
-				func(d dsWithPendingJobCount, _ int) bool { return d.numJobsPending > 0 },
-			)
-		}
-	}
-
-	if len(optimisticCheck.compactFrom) == 0 {
-		// if we reached the probe limit, we know that all datasets before lastProbed are ineligible,
-		// so we can use lastProbed as the resume point for the next iteration
-		if optimisticCheck.probeLimitReached {
-			jd.lastCompactionProbeIndex = optimisticCheck.lastProbed
-		}
-		return nil // no eligible datasets found, nothing to compact
-	}
-
-	var l lock.LockToken
-	var lockChan chan<- lock.LockToken
-
-	lockStart := time.Now()
-	err = jd.withMaintenanceTx(ctx, func(tx *Tx) error {
-		return jd.withDistributedSharedLock(ctx, tx, "schema_migrate", func() error { // cannot run while schema migration is running
-			// Take the lock and run actual compaction
-			if !jd.dsCompactionLock.TryLockWithCtx(ctx) {
-				return fmt.Errorf("acquire dsCompactionLock: %w", ctx.Err())
-			}
-			defer jd.dsCompactionLock.Unlock()
-			// repeat the check after the dsCompactionLock is acquired to get correct pending jobs count.
-			// the pending jobs count cannot change after the dsCompactionLock is acquired.
-			// skip datasets before the first eligible one found in the optimistic check.
-			compactionResult, err := jd.getCompactionList(dsList, optimisticCheck.firstEligible, tx)
-			if err != nil {
-				return fmt.Errorf("could not get compaction list: %w", err)
-			}
-			if len(compactionResult.compactFrom) == 0 {
-				return nil
-			}
-
-			compactFrom := compactionResult.compactFrom
-			pendingJobsCount := compactionResult.pendingJobsCount
-			insertBeforeDS := compactionResult.insertBeforeDS
-			compactFromDatasets := lo.Map(compactFrom, func(ds dsWithPendingJobCount, _ int) dataSetT { return ds.ds })
-			if pendingJobsCount > 0 { // compact incomplete jobs
-				var destination dataSetT
-				if err := jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
-					dsIdx, err := jd.computeNewIdxForIntraNodeCompaction(l, insertBeforeDS, tx)
-					if err != nil {
-						return fmt.Errorf("computing new index for intra-node compaction: %w", err)
-					}
-					destination = newDataSet(jd.tablePrefix, dsIdx)
-					return nil
-				}); err != nil {
-					return err
-				}
-
-				jd.logger.Infon(
-					"[[ compactionLoop ]]",
-					logger.NewIntField("pendingJobsCount", int64(pendingJobsCount)),
-					logger.NewIntField("compactFrom", int64(len(compactFrom))),
-					logger.NewStringField("from", strings.Join(lo.Map(compactFromDatasets, func(d dataSetT, _ int) string { return d.Index }), ",")),
-					logger.NewStringField("to", destination.Index),
-					logger.NewStringField("insert before", insertBeforeDS.Index),
-				)
-
-				opPayload, err := jsonrs.Marshal(&journalOpPayloadT{From: compactFromDatasets, To: destination})
-				if err != nil {
-					return fmt.Errorf("marshal journal payload: %w", err)
-				}
-
-				opID, err := jd.JournalMarkStartInTx(tx, compactionCopyOperation, opPayload)
-				if err != nil {
-					return fmt.Errorf("mark journal start: %w", err)
-				}
-
-				if err = jd.createDSTablesInTx(ctx, tx, destination); err != nil {
-					return fmt.Errorf("create dataset tables: %w", err)
-				}
-
-				totalJobsCompacted := 0
-				var noJobsCompacted int
-				copyStart := time.Now()
-				for i := range compactFrom {
-					source := compactFrom[i]
-					if source.numJobsPending > 0 {
-						jd.logger.Infon(
-							"[[ compactionLoop ]]: Compact",
-							logger.NewStringField("from", source.ds.Index),
-							logger.NewStringField("to", destination.Index),
-						)
-						noJobsCompacted, err = jd.compactJobsInTx(ctx, tx, source.ds, destination)
-						if err != nil {
-							return fmt.Errorf("compact jobs: %w", err)
-						}
-						jd.assert(
-							noJobsCompacted == source.numJobsPending,
-							fmt.Sprintf(
-								"noJobsCompacted: %d != source.numJobsPending: %d",
-								noJobsCompacted, source.numJobsPending,
-							),
-						)
-						totalJobsCompacted += noJobsCompacted
-					} else {
-						jd.logger.Infon(
-							"[[ compactionLoop ]]: No jobs to compact",
-							logger.NewStringField("from", source.ds.Index),
-							logger.NewStringField("to", destination.Index),
-						)
-					}
-				}
-				jd.getTimerStat("jobsdb_migration_copy_time", &statTags{CustomValFilters: []string{jd.tablePrefix}}).Since(copyStart)
-				if err = jd.createDSIndicesInTx(ctx, tx, destination); err != nil {
-					return fmt.Errorf("create %v indices: %w", destination, err)
-				}
-				if err = jd.journalMarkDoneInTx(tx, opID); err != nil {
-					return fmt.Errorf("mark journal done: %w", err)
-				}
-				jd.logger.Infon("[[ compactionLoop ]]: Jobs compacted", logger.NewIntField("count", int64(totalJobsCompacted)))
-			}
-
-			opPayload, err := jsonrs.Marshal(&journalOpPayloadT{From: compactFromDatasets})
-			if err != nil {
-				return fmt.Errorf("marshal journal payload: %w", err)
-			}
-			opID, err := jd.JournalMarkStartInTx(tx, postCompactionDSOperation, opPayload)
-			if err != nil {
-				return fmt.Errorf("mark journal start: %w", err)
-			}
-			// acquire an async lock, as this needs to be released after the transaction commits
-			l, lockChan, err = jd.dsListLock.AsyncLockWithCtx(ctx)
-			if err != nil {
-				return fmt.Errorf("acquire lock: %w", err)
-			}
-			tx.AddSuccessListener(func() {
-				for _, ds := range compactFromDatasets {
-					jd.distinctValuesCache.RemoveDataset(ds.JobTable)
-				}
-			})
-			if err = jd.postCompactionHandleDS(tx, compactFromDatasets); err != nil {
-				return fmt.Errorf("post compaction handle ds: %w", err)
-			}
-			if err = jd.journalMarkDoneInTx(tx, opID); err != nil {
-				return fmt.Errorf("mark journal done: %w", err)
-			}
-			return nil
-		})
-	})
-	if l != nil {
-		defer jd.stats.NewTaggedStat("migration_loop_lock", stats.TimerType, stats.Tags{"customVal": jd.tablePrefix}).Since(lockStart)
-		jd.logger.Infon("[[ compactionLoop ]]: Lock duration", logger.NewDurationField("duration", time.Since(lockStart)))
-		defer func() { lockChan <- l }()
-		if err == nil {
-			if err = jd.doRefreshDSRangeList(l); err != nil {
-				return fmt.Errorf("refresh ds range list: %w", err)
-			}
-		}
-	}
-	return err
-}
-
 type dsWithPendingJobCount struct {
 	ds             dataSetT
 	numJobsPending int
@@ -769,125 +565,6 @@ func (jd *Handle) copyJobStatusesInTx(ctx context.Context, tx *Tx, srcDS, destDS
 	return nil
 }
 
-func (jd *Handle) compactJobsInTx(ctx context.Context, tx *Tx, srcDS, destDS dataSetT) (int, error) {
-	defer jd.getTimerStat(
-		"migration_jobs",
-		&statTags{CustomValFilters: []string{jd.tablePrefix}},
-	).RecordDuration()()
-
-	payloadLiteral, err := jd.resolvePayloadConversion(ctx, tx, srcDS, destDS)
-	if err != nil {
-		return 0, err
-	}
-
-	// multi-consumer datasets: trim terminal consumers from the stored array so each
-	// destination job only carries pending work. Status rows are carried only for consumers
-	// still in the (trimmed) array. Registry is seeded from the trimmed RETURNING.
-	var compactDSQuery string
-	if jd.conf.multiConsumer {
-		compactDSQuery = fmt.Sprintf(
-			`WITH last_status AS (SELECT * FROM %[5]q),
-			terminal_by_job AS (
-				SELECT ls.job_id, array_agg(ls.consumer) AS done
-				FROM last_status ls
-				WHERE ls.job_state = ANY('{%[7]s}')
-				GROUP BY ls.job_id
-			),
-			inserted_jobs AS (
-				INSERT INTO %[1]q (job_id, workspace_id, uuid, user_id, partition_id, custom_val, parameters, event_payload, event_count, created_at, expire_at, consumers)
-				(SELECT j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.custom_val, j.parameters, %[4]s, j.event_count, j.created_at, j.expire_at,
-				        CASE WHEN t.done IS NULL THEN j.consumers
-				             ELSE array(SELECT c FROM unnest(j.consumers) c WHERE NOT c = ANY(t.done))
-				        END
-				 FROM %[2]q j
-				 LEFT JOIN terminal_by_job t ON t.job_id = j.job_id
-				 WHERE t.done IS NULL OR NOT (j.consumers <@ t.done)
-				 ORDER BY j.job_id) RETURNING job_id, consumers
-			),
-			inserted_consumers AS (
-				INSERT INTO %[6]q (consumer)
-				SELECT DISTINCT unnest(consumers) FROM inserted_jobs
-				ON CONFLICT DO NOTHING
-			),
-			insertedStatuses AS (
-				INSERT INTO %[3]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters, consumer)
-				(SELECT ls.job_id, ls.job_state, ls.attempt, ls.exec_time, ls.retry_time, ls.error_code, ls.error_response, ls.parameters, ls.consumer
-				 FROM last_status ls
-				 JOIN inserted_jobs ij ON ij.job_id = ls.job_id AND ls.consumer = ANY(ij.consumers))
-			)
-			SELECT count(*) FROM inserted_jobs;`,
-			destDS.JobTable,
-			srcDS.JobTable,
-			destDS.JobStatusTable,
-			payloadLiteral,
-			"v_last_c_"+srcDS.JobStatusTable,
-			destDS.consumersRegistryTable(),
-			strings.Join(validTerminalStates, ","),
-		)
-	} else {
-		compactDSQuery = fmt.Sprintf(
-			`WITH last_status AS (SELECT * FROM %[5]q),
-			inserted_jobs AS (
-				INSERT INTO %[1]q (job_id, workspace_id, uuid, user_id, partition_id, custom_val, parameters, event_payload, event_count, created_at, expire_at, consumers)
-				(SELECT j.job_id, j.workspace_id, j.uuid, j.user_id, j.partition_id, j.custom_val, j.parameters, %[4]s, j.event_count, j.created_at, j.expire_at, j.consumers
-				 FROM %[2]q j LEFT JOIN last_status js ON js.job_id = j.job_id
-				 WHERE js.job_id IS NULL OR js.job_state = ANY('{%[6]s}') ORDER BY j.job_id) RETURNING job_id
-			),
-			insertedStatuses AS (
-				INSERT INTO %[3]q (job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters, consumer)
-				(SELECT job_id, job_state, attempt, exec_time, retry_time, error_code, error_response, parameters, consumer
-				 FROM last_status WHERE job_state = ANY('{%[6]s}'))
-			)
-			SELECT count(*) FROM inserted_jobs;`,
-			destDS.JobTable,
-			srcDS.JobTable,
-			destDS.JobStatusTable,
-			payloadLiteral,
-			"v_last_"+srcDS.JobStatusTable,
-			strings.Join(validNonTerminalStates, ","),
-		)
-	}
-
-	var numJobsCompacted int
-	if err := tx.QueryRowContext(
-		ctx,
-		compactDSQuery,
-	).Scan(&numJobsCompacted); err != nil {
-		return 0, err
-	}
-	if _, err := tx.Exec(fmt.Sprintf(`ANALYZE %q, %q`, destDS.JobTable, destDS.JobStatusTable)); err != nil {
-		return 0, err
-	}
-	return numJobsCompacted, nil
-}
-
-func (jd *Handle) computeNewIdxForIntraNodeCompaction(l lock.LockToken, insertBeforeDS dataSetT, db sqlDbOrTx) (string, error) { // Within the node
-	jd.logger.Debugn("computeNewIdxForIntraNodeCompaction", logger.NewStringField("insertBeforeDS", insertBeforeDS.String()))
-	dList, err := jd.doRefreshDSList(l, db)
-	if err != nil {
-		return "", fmt.Errorf("refreshDSList: %w", err)
-	}
-	if jd.logger.IsDebugLevel() {
-		list := make([]string, len(dList))
-		for i, ds := range dList {
-			list[i] = ds.String()
-		}
-		jd.logger.Debugn("dlist in which we are trying to find dataset in list",
-			logger.NewStringField("dataset", insertBeforeDS.String()),
-			logger.NewStringField("list", strings.Join(list, ",")))
-	}
-	newDSIdx := ""
-	jd.assert(len(dList) > 0, fmt.Sprintf("len(dList): %d <= 0", len(dList)))
-	for idx, ds := range dList {
-		if ds.Index == insertBeforeDS.Index {
-			jd.assert(idx > 0, "We never want to insert before first dataset")
-			newDSIdx, err = computeInsertIdx(dList[idx-1].Index, insertBeforeDS.Index)
-			jd.assertError(err)
-		}
-	}
-	return newDSIdx, nil
-}
-
 // lockAndFenceStatusTable takes an EXCLUSIVE lock on the status table and
 // plants the readonly trigger which raises RS001 whenever any subsequent insert is attempted on the status table.
 func (jd *Handle) lockAndFenceStatusTable(ctx context.Context, tx *Tx, statusTable string) error {
@@ -907,9 +584,9 @@ func (jd *Handle) lockAndFenceStatusTable(ctx context.Context, tx *Tx, statusTab
 	return nil
 }
 
-// doCompactDS is the non-blocking compaction flow which replaces the legacy doCompaction body when the nonBlockingCompaction flag is enabled.
+// doCompaction is the non-blocking compaction flow.
 //
-// Lock semantics (vs. legacy):
+// Lock semantics:
 //   - dsCompactionLock is NOT taken. Concurrent reads via inUpdateSafeCtx grab their
 //     existing read lock against an uncontended write side.
 //   - dsListLock is taken exactly once, asynchronously, right before COMMIT — only
@@ -917,10 +594,10 @@ func (jd *Handle) lockAndFenceStatusTable(ctx context.Context, tx *Tx, statusTab
 //   - Source status tables are fenced with LOCK TABLE … IN EXCLUSIVE MODE and a
 //     post-commit readonly trigger; the trigger raises RS001 on subsequent inserts,
 //     which the UpdateJobStatus path treats as ErrStaleDsList and retries.
-//   - When compactionDeferStatusLock is set, the source status lock is deferred:
-//     pending jobs are copied first with no lock held, then each source status table
-//     is locked one after another only to copy the latest statuses of the moved jobs.
-func (jd *Handle) doCompactDS(ctx context.Context) error {
+//   - The source status lock is deferred: pending jobs are copied first with no lock
+//     held, then each source status table is locked one after another only to copy the
+//     latest statuses of the moved jobs.
+func (jd *Handle) doCompaction(ctx context.Context) error {
 	dsList, _, release, err := jd.acquireDSListForRead(ctx)
 	if err != nil {
 		return fmt.Errorf("could not acquire a dslist read lock: %w", err)
@@ -951,8 +628,7 @@ func (jd *Handle) doCompactDS(ctx context.Context) error {
 	// the async-drop path — no copy, no destination, no in-TX work needed.
 	if compactionList.pendingJobsCount == 0 {
 		if err := jd.dsListLock.WithLockInCtx(ctx, func(l lock.LockToken) error {
-			_, err := jd.addCompletedDSToDropList(ctx, l, compactFromDatasets...)
-			return err
+			return jd.addCompletedDSToDropList(ctx, l, compactFromDatasets...)
 		}); err != nil {
 			return fmt.Errorf("enqueue completed datasets for async drop: %w", err)
 		}
@@ -969,7 +645,7 @@ func (jd *Handle) doCompactDS(ctx context.Context) error {
 	}
 	destination := newDataSet(jd.tablePrefix, candidateIdx)
 	jd.logger.Infon(
-		"[[ doCompactDS ]]",
+		"[[ doCompaction ]]",
 		logger.NewIntField("pendingJobsCount", int64(compactionList.pendingJobsCount)),
 		logger.NewIntField("compactFrom", int64(len(compactFromDatasets))),
 		logger.NewStringField("from", strings.Join(lo.Map(compactFromDatasets, func(d dataSetT, _ int) string { return d.Index }), ",")),
@@ -1002,100 +678,64 @@ func (jd *Handle) doCompactDS(ctx context.Context) error {
 			}
 
 			var copyStart time.Time
-			if jd.conf.compaction.compactionDeferStatusLock.Load() {
-				// Deferred-status-lock mode. Phase 1: copy the pending jobs from every
-				// source WITHOUT locking any status table — this is the slow,
-				// payload-heavy work, and it must not sit inside the lock window.
-				for i, source := range compactionList.compactFrom {
-					if source.numJobsPending == 0 {
-						jd.logger.Infon(
-							"[[ doCompactDS ]]: No jobs to compact",
-							logger.NewStringField("from", source.ds.Index),
-							logger.NewStringField("to", destination.Index),
-						)
-						continue
-					}
-					if copyStart.IsZero() {
-						copyStart = time.Now()
-					}
-					count, err := jd.copyJobsInTx(ctx, tx, source.ds, destination)
-					if err != nil {
-						return fmt.Errorf("copying jobs from %s: %w", source.ds.Index, err)
-					}
-					totalCopied += count
-					// numJobsPending now reflects what phase 1 actually copied, so
-					// phase 2 below only locks sources that contributed jobs.
-					compactionList.compactFrom[i].numJobsPending = count
-				}
-				// Build the jobs-table indices before taking any status lock.
-				if totalCopied > 0 {
-					if err := jd.createDSJobIndicesInTx(ctx, tx, destination); err != nil {
-						return fmt.Errorf("creating %v jobs indices: %w", destination, err)
-					}
-				}
-				// Phase 2: lock each source status table one after another and copy the
-				// latest status of the moved jobs. This is the only work under the lock,
-				// and the status rows carry no payload, so the lock window is minimal.
-				for _, source := range compactionList.compactFrom {
-					if source.numJobsPending == 0 {
-						continue
-					}
-					if lockStart.IsZero() {
-						lockStart = time.Now()
-					}
-					if err := jd.lockAndFenceStatusTable(ctx, tx, source.ds.JobStatusTable); err != nil {
-						return err
-					}
+			// Phase 1: copy the pending jobs from every source WITHOUT locking any
+			// status table — this is the slow, payload-heavy work, and it must not sit
+			// inside the lock window.
+			for i, source := range compactionList.compactFrom {
+				if source.numJobsPending == 0 {
 					jd.logger.Infon(
-						"[[ doCompactDS ]]: Move statuses",
+						"[[ doCompaction ]]: No jobs to compact",
 						logger.NewStringField("from", source.ds.Index),
 						logger.NewStringField("to", destination.Index),
 					)
-					if err := jd.copyJobStatusesInTx(ctx, tx, source.ds, destination); err != nil {
-						return fmt.Errorf("copying statuses from %s: %w", source.ds.Index, err)
-					}
+					continue
 				}
-				if totalCopied > 0 {
-					if err := jd.createDSStatusIndicesInTx(ctx, tx, destination); err != nil {
-						return fmt.Errorf("creating %v status indices: %w", destination, err)
-					}
-					if _, err := tx.Exec(fmt.Sprintf(`ANALYZE %q, %q`, destination.JobTable, destination.JobStatusTable)); err != nil {
-						return fmt.Errorf("analyzing %v: %w", destination, err)
-					}
+				if copyStart.IsZero() {
+					copyStart = time.Now()
 				}
-			} else {
-				for i, source := range compactionList.compactFrom {
-					if source.numJobsPending == 0 {
-						jd.logger.Infon(
-							"[[ doCompactDS ]]: No jobs to compact",
-							logger.NewStringField("from", source.ds.Index),
-							logger.NewStringField("to", destination.Index),
-						)
-						continue
-					}
-					if lockStart.IsZero() {
-						lockStart = time.Now()
-					}
-					if err := jd.lockAndFenceStatusTable(ctx, tx, source.ds.JobStatusTable); err != nil {
-						return err
-					}
-					jd.logger.Infon(
-						"[[ doCompactDS ]]: Move",
-						logger.NewStringField("from", source.ds.Index),
-						logger.NewStringField("to", destination.Index),
-					)
-					if copyStart.IsZero() {
-						copyStart = time.Now()
-					}
-					count, err := jd.compactJobsInTx(ctx, tx, source.ds, destination)
-					if err != nil {
-						return fmt.Errorf("copying jobs from %s: %w", source.ds.Index, err)
-					}
-					totalCopied += count
-					compactionList.compactFrom[i].numJobsPending = count
+				count, err := jd.copyJobsInTx(ctx, tx, source.ds, destination)
+				if err != nil {
+					return fmt.Errorf("copying jobs from %s: %w", source.ds.Index, err)
 				}
-				if err := jd.createDSIndicesInTx(ctx, tx, destination); err != nil {
-					return fmt.Errorf("creating %v indices: %w", destination, err)
+				totalCopied += count
+				// numJobsPending now reflects what phase 1 actually copied, so
+				// phase 2 below only locks sources that contributed jobs.
+				compactionList.compactFrom[i].numJobsPending = count
+			}
+			// Build the jobs-table indices before taking any status lock.
+			if totalCopied > 0 {
+				if err := jd.createDSJobIndicesInTx(ctx, tx, destination); err != nil {
+					return fmt.Errorf("creating %v jobs indices: %w", destination, err)
+				}
+			}
+			// Phase 2: lock each source status table one after another and copy the
+			// latest status of the moved jobs. This is the only work under the lock,
+			// and the status rows carry no payload, so the lock window is minimal.
+			for _, source := range compactionList.compactFrom {
+				if source.numJobsPending == 0 {
+					continue
+				}
+				if lockStart.IsZero() {
+					lockStart = time.Now()
+				}
+				if err := jd.lockAndFenceStatusTable(ctx, tx, source.ds.JobStatusTable); err != nil {
+					return err
+				}
+				jd.logger.Infon(
+					"[[ doCompaction ]]: Move statuses",
+					logger.NewStringField("from", source.ds.Index),
+					logger.NewStringField("to", destination.Index),
+				)
+				if err := jd.copyJobStatusesInTx(ctx, tx, source.ds, destination); err != nil {
+					return fmt.Errorf("copying statuses from %s: %w", source.ds.Index, err)
+				}
+			}
+			if totalCopied > 0 {
+				if err := jd.createDSStatusIndicesInTx(ctx, tx, destination); err != nil {
+					return fmt.Errorf("creating %v status indices: %w", destination, err)
+				}
+				if _, err := tx.Exec(fmt.Sprintf(`ANALYZE %q, %q`, destination.JobTable, destination.JobStatusTable)); err != nil {
+					return fmt.Errorf("analyzing %v: %w", destination, err)
 				}
 			}
 			if !copyStart.IsZero() {
@@ -1115,7 +755,7 @@ func (jd *Handle) doCompactDS(ctx context.Context) error {
 			if err := jd.journalMarkDoneInTx(tx, opID); err != nil {
 				return fmt.Errorf("marking journal done: %w", err)
 			}
-			jd.logger.Infon("[[ doCompactDS ]]: Jobs compacted", logger.NewIntField("count", int64(totalCopied)))
+			jd.logger.Infon("[[ doCompaction ]]: Jobs compacted", logger.NewIntField("count", int64(totalCopied)))
 
 			// if nothing was copied, then we don't need the destination dataset at all...
 			if totalCopied == 0 {
@@ -1179,9 +819,8 @@ func (jd *Handle) doCompactDS(ctx context.Context) error {
 }
 
 // computeInsertIdxFromList computes the destination dataset index for an intra-node
-// compaction using a provided dataset list. Unlike computeNewIdxForIntraNodeCompaction,
-// it does not require a dsListLock token because it operates on the caller-supplied
-// snapshot rather than re-reading the list from PG.
+// compaction using a provided dataset list. It does not require a dsListLock token
+// because it operates on the caller-supplied snapshot rather than re-reading the list from PG.
 func computeInsertIdxFromList(dList []dataSetT, insertBeforeDS dataSetT) (string, error) {
 	if len(dList) == 0 {
 		return "", fmt.Errorf("empty ds list")
@@ -1195,17 +834,6 @@ func computeInsertIdxFromList(dList []dataSetT, insertBeforeDS dataSetT) (string
 		}
 	}
 	return "", fmt.Errorf("insertBeforeDS %q not found in list", insertBeforeDS.Index)
-}
-
-func (jd *Handle) postCompactionHandleDS(tx *Tx, compactFrom []dataSetT) error {
-	for _, ds := range compactFrom {
-		jd.logger.Debugn("dropping dataset", logger.NewStringField("jobTable", ds.JobTable))
-		if err := jd.dropDSInTx(tx, ds); err != nil {
-			return err
-		}
-		delete(jd.dsRangeFuncMap, ds.Index)
-	}
-	return nil
 }
 
 func computeInsertIdx(beforeIndex, afterIndex string) (string, error) {

--- a/jobsdb/jobsdb_compaction_test.go
+++ b/jobsdb/jobsdb_compaction_test.go
@@ -553,7 +553,7 @@ func TestPayloadLiteral(t *testing.T) {
 	for i := range prefixes {
 		_, err := db.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %[1]s_jobs_1 DROP CONSTRAINT %[1]s_jobs_1_pkey`, prefixes[i]))
 		require.NoError(t, err)
-	} // we drop these two because compactJobsInTx moved jobIDs too, and we're only interested in moving jobs between two different column types
+	} // we drop these two because copyJobsInTx moved jobIDs too, and we're only interested in moving jobs between two different column types
 	txn, err := db.Begin()
 	require.NoError(t, err)
 	for i := range prefixes {
@@ -563,7 +563,7 @@ func TestPayloadLiteral(t *testing.T) {
 			}
 			src := prefixes[i]
 			dest := prefixes[j]
-			_, err := textJD.compactJobsInTx(
+			_, err := textJD.copyJobsInTx(
 				ctx,
 				&tx.Tx{Tx: txn},
 				dataSetT{
@@ -973,229 +973,10 @@ func TestCompactionSkipsDatasets(t *testing.T) {
 	})
 }
 
-func TestCompactionNonBlockingCompletedDSDrop(t *testing.T) {
-	_ = startPostgres(t)
-
-	// newJobDB creates a ReadWrite Handle with the compaction and addNewDS loop triggers
-	// wired to never-firing channels — the tests below drive state changes synchronously
-	// via createDSInTx so there is no background addNewDSLoop racing with Store/UpdateJobStatus.
-	newJobDB := func(t *testing.T) (*Handle, *config.Config) {
-		t.Helper()
-		c := config.New()
-		c.Set("JobsDB.maxDSSize", 100000)
-		jd := &Handle{
-			TriggerAddNewDS:   func() <-chan time.Time { return make(chan time.Time) },
-			TriggerCompaction: func() <-chan time.Time { return make(chan time.Time) },
-			config:            c,
-		}
-		require.NoError(t, jd.Setup(ReadWrite, true, strings.ToLower(rand.String(5))))
-		t.Cleanup(jd.TearDown)
-		return jd, c
-	}
-
-	// createDS synchronously appends a new DS at the given index using addNewDSInTx
-	// (which also advances the new DS's job_id sequence to continue from the previous
-	// DS's max, preserving the monotonic range invariant), then refreshes the in-memory list.
-	createDS := func(t *testing.T, jd *Handle, idx string) {
-		t.Helper()
-		require.NoError(t, jd.dsListLock.WithLockInCtx(context.Background(), func(l lock.LockToken) error {
-			dsList, _ := jd.dsList.snapshot()
-			if err := jd.WithTx(context.Background(), func(txn *tx.Tx) error {
-				return jd.addNewDSInTx(context.Background(), txn, l, dsList, newDataSet(jd.tablePrefix, idx))
-			}); err != nil {
-				return err
-			}
-			return jd.doRefreshDSRangeList(l)
-		}))
-	}
-
-	// fillDS stores jobs in the current last DS, marks (len(jobs)-pending) of them as succeeded.
-	fillDS := func(t *testing.T, jd *Handle, jobs []*JobT, pending int) {
-		t.Helper()
-		require.NoError(t, jd.Store(context.Background(), jobs))
-		if terminal := len(jobs) - pending; terminal > 0 {
-			require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[:terminal], "executing")))
-			require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[:terminal], "succeeded")))
-		}
-	}
-
-	tableExists := func(t *testing.T, jd *Handle, ds dataSetT) bool {
-		t.Helper()
-		var exists bool
-		require.NoError(t, jd.dbHandle.QueryRow(`SELECT to_regclass($1) IS NOT NULL`, ds.JobTable).Scan(&exists))
-		return exists
-	}
-
-	t.Run("flag off: completed DS dropped in legacy in-tx path", func(t *testing.T) {
-		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
-		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
-		fillDS(t, jd, jobs, 0) // DS_1 → all 10 succeeded (completed)
-		createDS(t, jd, "2")   // DS_2 → empty last (exempt from compaction)
-
-		snapshot := jd.getDSListSnapshot()
-		require.Len(t, snapshot, 2)
-		completedDS := snapshot[0]
-
-		require.NoError(t, jd.doCompaction(context.Background()))
-
-		listIndices := lo.Map(jd.getDSListSnapshot(), func(ds dataSetT, _ int) string { return ds.Index })
-		require.NotContains(t, listIndices, completedDS.Index, "completed DS should be removed from the published list")
-		require.False(t, tableExists(t, jd, completedDS), "table must be dropped synchronously by the legacy in-tx path")
-		jd.dropDSListLock.RLock()
-		require.Empty(t, jd.dropDSList, "legacy path must not enqueue any async drop entries")
-		jd.dropDSListLock.RUnlock()
-	})
-
-	t.Run("flag on: completed DS routed to async drop list", func(t *testing.T) {
-		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompletedDSDrop", true)
-
-		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
-		fillDS(t, jd, jobs, 0) // DS_1 completed
-		createDS(t, jd, "2")   // DS_2 empty last
-
-		snapshot := jd.getDSListSnapshot()
-		require.Len(t, snapshot, 2)
-		completedDS := snapshot[0]
-
-		// Hold a reader on the current dsList version so dropDSLoop blocks on
-		// waitUntilDrained — lets us observe the enqueued entry before it is physically dropped.
-		_, _, release, err := jd.acquireDSListForRead(context.Background())
-		require.NoError(t, err)
-
-		require.NoError(t, jd.doCompaction(context.Background()))
-
-		listIndices := lo.Map(jd.getDSListSnapshot(), func(ds dataSetT, _ int) string { return ds.Index })
-		require.NotContains(t, listIndices, completedDS.Index, "completed DS hidden from new readers")
-		jd.dropDSListLock.RLock()
-		require.Len(t, jd.dropDSList, 1, "completed DS must be enqueued for async drop")
-		require.Equal(t, completedDS.Index, jd.dropDSList[0].ds.Index)
-		jd.dropDSListLock.RUnlock()
-		require.Never(t,
-			func() bool { return !tableExists(t, jd, completedDS) },
-			200*time.Millisecond, 20*time.Millisecond,
-			"physical drop must block until the held reader releases",
-		)
-
-		release()
-
-		require.Eventually(t, func() bool {
-			jd.dropDSListLock.RLock()
-			pending := len(jd.dropDSList)
-			jd.dropDSListLock.RUnlock()
-			return !tableExists(t, jd, completedDS) && pending == 0
-		}, 5*time.Second, 50*time.Millisecond, "table must be physically dropped once the reader releases")
-	})
-
-	t.Run("flag on: DS with pending jobs still compacted through the legacy TX", func(t *testing.T) {
-		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
-		// maxDSRetention=1ms makes DSes with old terminal jobs eligible without the needsPair logic,
-		// so a DS with pending jobs can be compacted alone.
-		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
-
-		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
-		fillDS(t, jd, jobs, 5) // DS_1: 5 succeeded + 5 pending
-		createDS(t, jd, "2")   // DS_2 empty last
-
-		snapshot := jd.getDSListSnapshot()
-		require.Len(t, snapshot, 2)
-		pendingDS := snapshot[0]
-
-		require.NoError(t, jd.doCompaction(context.Background()))
-
-		require.False(t, tableExists(t, jd, pendingDS), "source DS must be dropped via legacy compaction TX")
-		jd.dropDSListLock.RLock()
-		require.Empty(t, jd.dropDSList, "non-completed compact paths must not touch dropDSList")
-		jd.dropDSListLock.RUnlock()
-		listIndices := lo.Map(jd.getDSListSnapshot(), func(ds dataSetT, _ int) string { return ds.Index })
-		require.NotContains(t, listIndices, pendingDS.Index, "source DS must be removed from published list")
-		require.Contains(t, listIndices, "1_1", "expecting a freshly compacted destination DS at index 1_1")
-	})
-
-	t.Run("flag on: mixed - completed goes async, pending uses legacy TX", func(t *testing.T) {
-		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompletedDSDrop", true)
-		// maxDSRetention=1ms lets both DSes appear together in compactFrom in a single call.
-		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
-
-		allJobs := genJobs(defaultWorkspaceID, "test", 20, 1)
-		fillDS(t, jd, allJobs[:10], 0) // DS_1 completed
-		createDS(t, jd, "2")
-		fillDS(t, jd, allJobs[10:20], 5) // DS_2: 5 pending
-		createDS(t, jd, "3")             // DS_3 empty last
-
-		snapshot := jd.getDSListSnapshot()
-		require.Len(t, snapshot, 3)
-		completedDS := snapshot[0]
-		pendingDS := snapshot[1]
-
-		// Hold a reader so the async drop for the completed DS blocks; this lets us
-		// observe the dropDSList entry before dropDSLoop drains it.
-		_, _, release, err := jd.acquireDSListForRead(context.Background())
-		require.NoError(t, err)
-		defer release()
-
-		require.NoError(t, jd.doCompaction(context.Background()))
-
-		jd.dropDSListLock.RLock()
-		require.Len(t, jd.dropDSList, 1, "only the completed DS should be enqueued for async drop")
-		require.Equal(t, completedDS.Index, jd.dropDSList[0].ds.Index)
-		jd.dropDSListLock.RUnlock()
-
-		require.True(t, tableExists(t, jd, completedDS), "completed DS physical drop is blocked by the held reader")
-		require.False(t, tableExists(t, jd, pendingDS), "pending DS source must be dropped via legacy compaction TX")
-	})
-
-	t.Run("flag toggled at runtime: takes effect on the next compaction", func(t *testing.T) {
-		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompletedDSDrop", false)
-
-		allJobs := genJobs(defaultWorkspaceID, "test", 20, 1)
-		fillDS(t, jd, allJobs[:10], 0) // DS_1 completed
-		createDS(t, jd, "2")           // DS_2 empty last
-		completed1 := jd.getDSListSnapshot()[0]
-
-		// Flag off (default): legacy in-tx drop.
-		require.NoError(t, jd.doCompaction(context.Background()))
-		require.False(t, tableExists(t, jd, completed1), "first compaction must use the legacy in-tx drop")
-		jd.dropDSListLock.RLock()
-		require.Empty(t, jd.dropDSList)
-		jd.dropDSListLock.RUnlock()
-
-		// Flip the flag and prepare another completed DS to compact.
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompletedDSDrop", true)
-		fillDS(t, jd, allJobs[10:20], 0) // DS_2 now has 10 succeeded jobs (completed)
-		createDS(t, jd, "3")             // DS_3 empty last
-		snapshot := jd.getDSListSnapshot()
-		require.Len(t, snapshot, 2)
-		completed2 := snapshot[0]
-		require.Equal(t, "2", completed2.Index)
-
-		// Hold a reader so we can observe the async enqueue before dropDSLoop drains it.
-		_, _, release, err := jd.acquireDSListForRead(context.Background())
-		require.NoError(t, err)
-		defer release()
-
-		require.NoError(t, jd.doCompaction(context.Background()))
-
-		jd.dropDSListLock.RLock()
-		require.Len(t, jd.dropDSList, 1, "second compaction must use the async drop path after the flag is on")
-		require.Equal(t, completed2.Index, jd.dropDSList[0].ds.Index)
-		jd.dropDSListLock.RUnlock()
-		require.True(t, tableExists(t, jd, completed2), "physical drop blocked by held reader")
-	})
-}
-
 func TestNonBlockingCompaction(t *testing.T) {
 	_ = startPostgres(t)
 
-	// newJobDB mirrors the pattern used by TestCompactionNonBlockingCompletedDSDrop:
-	// the compaction and addNewDS loop triggers are wired to never-firing channels so
+	// newJobDB wires the compaction and addNewDS loop triggers to never-firing channels so
 	// the tests drive state changes synchronously.
 	newJobDB := func(t *testing.T) (*Handle, *config.Config) {
 		t.Helper()
@@ -1265,31 +1046,8 @@ func TestNonBlockingCompaction(t *testing.T) {
 		return marker.Valid && strings.HasPrefix(marker.String, "rudder:pre_drop:")
 	}
 
-	t.Run("flag off: legacy in-tx drop path is used", func(t *testing.T) {
+	t.Run("source goes through async drop with pre-drop marker and readonly trigger", func(t *testing.T) {
 		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
-		// maxDSRetention=1ms makes a DS with old terminal jobs eligible immediately.
-		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
-
-		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
-		fillDS(t, jd, jobs, 5) // DS_1: 5 succeeded, 5 pending
-		createDS(t, jd, "2")   // empty last DS
-
-		snapshot := jd.getDSListSnapshot()
-		require.Len(t, snapshot, 2)
-		sourceDS := snapshot[0]
-
-		require.NoError(t, jd.doCompaction(context.Background()))
-
-		require.False(t, tableExists(t, jd, sourceDS), "legacy flow drops source in-TX")
-		jd.dropDSListLock.RLock()
-		require.Empty(t, jd.dropDSList, "legacy flow must not enqueue async drops")
-		jd.dropDSListLock.RUnlock()
-	})
-
-	t.Run("flag on: source goes through async drop with pre-drop marker and readonly trigger", func(t *testing.T) {
-		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
 		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
 
 		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
@@ -1340,9 +1098,8 @@ func TestNonBlockingCompaction(t *testing.T) {
 		}, 5*time.Second, 50*time.Millisecond, "source table must be physically dropped once the reader releases")
 	})
 
-	t.Run("flag on: zero-copy compaction drops empty dest but still async-drops source", func(t *testing.T) {
+	t.Run("zero-copy compaction drops empty dest but still async-drops source", func(t *testing.T) {
 		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
 		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
 
 		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
@@ -1366,7 +1123,7 @@ func TestNonBlockingCompaction(t *testing.T) {
 		}()
 
 		// Block compaction after getCompactionList's optimistic pending-count
-		// decision but before the TX copies jobs. doCompactDS takes this shared
+		// decision but before the TX copies jobs. doCompaction takes this shared
 		// advisory lock only after computing compactionList.
 		blocker, err := jd.dbHandle.BeginTx(context.Background(), nil)
 		require.NoError(t, err)
@@ -1402,7 +1159,7 @@ func TestNonBlockingCompaction(t *testing.T) {
 		}, 5*time.Second, 50*time.Millisecond, "compaction should block on schema_migrate advisory lock")
 
 		// The optimistic check saw these as pending; before copy time they all
-		// become terminal, so compactJobsInTx copies zero rows.
+		// become terminal, so the copy moves zero rows.
 		require.NoError(t, jd.UpdateJobStatus(context.Background(), genJobStatuses(jobs[5:10], "succeeded")))
 
 		require.NoError(t, blocker.Commit())
@@ -1436,9 +1193,8 @@ func TestNonBlockingCompaction(t *testing.T) {
 		}, 5*time.Second, 50*time.Millisecond, "source table must be physically dropped once the reader releases")
 	})
 
-	t.Run("flag on: dsRangeList reflects dest's exact min/max", func(t *testing.T) {
+	t.Run("dsRangeList reflects dest's exact min/max", func(t *testing.T) {
 		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
 		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
 
 		// Store 20 jobs but mark the first 10 as terminal. Only the last 10
@@ -1467,9 +1223,8 @@ func TestNonBlockingCompaction(t *testing.T) {
 		require.EqualValues(t, 20, destRange.maxJobID, "dest max must reflect last copied job_id")
 	})
 
-	t.Run("flag on: published swap preserves non-compacted DSes in the current list", func(t *testing.T) {
+	t.Run("published swap preserves non-compacted DSes in the current list", func(t *testing.T) {
 		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
 		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
 		// Disable needsPair so DS_2 (non-terminal only) is NOT eligible for compaction.
 		// We need DS_2 non-empty so checkIfCompactDS's created_at scan doesn't trip on NULL.
@@ -1492,9 +1247,8 @@ func TestNonBlockingCompaction(t *testing.T) {
 		require.Contains(t, listIndices, "3", "non-compacted DS_3 must be preserved")
 	})
 
-	t.Run("flag on: completed-only sources skip the compaction TX and go straight to async drop", func(t *testing.T) {
-		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
+	t.Run("completed-only sources skip the compaction TX and go straight to async drop", func(t *testing.T) {
+		jd, _ := newJobDB(t)
 		// No maxDSRetention needed: a DS with all-terminal jobs is naturally eligible.
 
 		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
@@ -1529,9 +1283,8 @@ func TestNonBlockingCompaction(t *testing.T) {
 		}, 5*time.Second, 50*time.Millisecond)
 	})
 
-	t.Run("flag on: source status table rejects post-commit inserts with RS001", func(t *testing.T) {
+	t.Run("source status table rejects post-commit inserts with RS001", func(t *testing.T) {
 		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
 		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
 
 		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
@@ -1572,9 +1325,8 @@ func TestNonBlockingCompaction(t *testing.T) {
 		require.EqualValues(t, 5, destStatusCount, "status updates must land in dest after compaction")
 	})
 
-	t.Run("flag on: pre-drop marker survives a crash and cleanupPreDropTables drops the source on next startup", func(t *testing.T) {
+	t.Run("pre-drop marker survives a crash and cleanupPreDropTables drops the source on next startup", func(t *testing.T) {
 		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
 		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
 
 		jobs := genJobs(defaultWorkspaceID, "test", 10, 1)
@@ -1598,58 +1350,8 @@ func TestNonBlockingCompaction(t *testing.T) {
 		require.False(t, tableExists(t, jd, sourceDS), "cleanupPreDropTables must drop the marked source table")
 	})
 
-	t.Run("flag toggled at runtime: takes effect on the next compaction", func(t *testing.T) {
+	t.Run("copies pending jobs and their latest statuses, fences source", func(t *testing.T) {
 		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", false)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
-		// Disable needsPair so the first compaction's dest DS_1_1 isn't pulled back
-		// into the second iteration's compactFrom (only the freshly-filled DS_2 is).
-		c.Set("JobsDB."+jd.tablePrefix+"."+"jobMinRowsLeftMigrateThreshold", 0.0)
-
-		// Use a single genJobs slice so the local JobID values match the DB-assigned
-		// IDs across both batches (the sequence continues from DS_1's max).
-		allJobs := genJobs(defaultWorkspaceID, "test", 20, 1)
-
-		// First compaction with flag OFF → legacy in-TX drop.
-		fillDS(t, jd, allJobs[:10], 5)
-		createDS(t, jd, "2")
-		source1 := jd.getDSListSnapshot()[0]
-		require.NoError(t, jd.doCompaction(context.Background()))
-		require.False(t, tableExists(t, jd, source1), "first compaction uses legacy in-TX drop")
-		jd.dropDSListLock.RLock()
-		require.Empty(t, jd.dropDSList)
-		jd.dropDSListLock.RUnlock()
-
-		// Flip flag ON; fill the (now last) DS_2 with another batch and add DS_3.
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
-		fillDS(t, jd, allJobs[10:20], 5)
-		createDS(t, jd, "3")
-		snapshot := jd.getDSListSnapshot()
-		var source2 dataSetT
-		for _, ds := range snapshot {
-			if ds.Index == "2" {
-				source2 = ds
-				break
-			}
-		}
-		require.NotEmpty(t, source2.Index)
-
-		_, _, release, err := jd.acquireDSListForRead(context.Background())
-		require.NoError(t, err)
-		defer release()
-
-		require.NoError(t, jd.doCompaction(context.Background()))
-		jd.dropDSListLock.RLock()
-		require.NotEmpty(t, jd.dropDSList, "second compaction must use the async drop path")
-		jd.dropDSListLock.RUnlock()
-		require.True(t, tableExists(t, jd, source2), "drop blocked by held reader")
-		require.True(t, hasReadonlyTrigger(t, jd, source2), "source must carry readonly trigger after non-blocking compaction")
-	})
-
-	t.Run("flag on + deferStatusLock: copies pending jobs and their latest statuses, fences source", func(t *testing.T) {
-		jd, c := newJobDB(t)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"nonBlockingCompaction", true)
-		c.Set("JobsDB."+jd.tablePrefix+"."+"compactionDeferStatusLock", true)
 		c.Set("JobsDB."+jd.tablePrefix+"."+"maxDSRetention", "1ms")
 
 		// jobs 1..4 terminal (succeeded), 5..7 non-terminal (failed), 8..10 never

--- a/jobsdb/jobsdb_config.go
+++ b/jobsdb/jobsdb_config.go
@@ -63,9 +63,6 @@ func (jd *Handle) loadConfig() {
 	// starting with false as default since initial set of migrated jobs will not have partitionID set
 	jd.conf.warnOnStatusMissingPartitionID = jd.config.GetReloadableBoolVar(false, jd.configKeys("warnOnStatusMissingPartitionID")...)
 
-	// Default false: snapshot lastDS and release the dsList read lock before running the store callback,
-	// so long-running stores don't block dsList writers. Flip to true to revert to holding the lock for the whole callback.
-	jd.conf.holdDSListLockDuringStore = jd.config.GetReloadableBoolVar(false, jd.configKeys("holdDSListLockDuringStore")...)
 	jd.conf.staleDSListMaxRetries = jd.config.GetReloadableIntVar(3, 1, jd.configKeys("staleDSListMaxRetries")...)
 
 	if jd.TriggerAddNewDS == nil {

--- a/jobsdb/jobsdb_config.go
+++ b/jobsdb/jobsdb_config.go
@@ -48,9 +48,6 @@ func (jd *Handle) loadConfig() {
 	jd.conf.compaction.maxCompactDSProbe = jd.config.GetReloadableIntVar(10, 1, jd.configKeys("maxCompactDSProbe", "maxMigrateDSProbe")...)
 	jd.conf.compaction.vacuumFullStatusTableThreshold = jd.config.GetReloadableInt64Var(500*bytesize.MB, 1, jd.configKeys("vacuumFullStatusTableThreshold")...)
 	jd.conf.compaction.vacuumAnalyzeStatusTableThreshold = jd.config.GetReloadableInt64Var(30000, 1, jd.configKeys("vacuumAnalyzeStatusTableThreshold")...)
-	jd.conf.compaction.nonBlockingCompletedDSDrop = jd.config.GetReloadableBoolVar(false, jd.configKeys("nonBlockingCompletedDSDrop")...)
-	jd.conf.compaction.nonBlockingCompaction = jd.config.GetReloadableBoolVar(false, jd.configKeys("nonBlockingCompaction")...)
-	jd.conf.compaction.compactionDeferStatusLock = jd.config.GetReloadableBoolVar(false, jd.configKeys("compactionDeferStatusLock")...)
 	jd.conf.compaction.getJobsRetryOnCompaction = jd.config.GetReloadableBoolVar(true, jd.configKeys("getJobsRetryOnCompaction")...)
 	if jd.conf.multiConsumer { // if multiConsumer is enabled, we skip status compaction by default
 		jd.conf.compaction.skipStatusCompaction = jd.config.GetReloadableBoolVar(true, jd.configKeys("skipMultiConsumerStatusCompaction", "skipStatusCompaction")...)
@@ -70,11 +67,6 @@ func (jd *Handle) loadConfig() {
 	// so long-running stores don't block dsList writers. Flip to true to revert to holding the lock for the whole callback.
 	jd.conf.holdDSListLockDuringStore = jd.config.GetReloadableBoolVar(false, jd.configKeys("holdDSListLockDuringStore")...)
 	jd.conf.staleDSListMaxRetries = jd.config.GetReloadableIntVar(3, 1, jd.configKeys("staleDSListMaxRetries")...)
-
-	// when true, the per-state noResultsCache optimization is enabled: stateFilters are narrowed
-	// against the cache before querying, and (!ok && !limitsReached) is used as a commit predicate.
-	jd.conf.noResultsCacheStateOptimization = jd.config.GetReloadableBoolVar(false, jd.configKeys("noResultsCacheStateOptimization")...)
-	jd.conf.getJobsUseLateralJoin = jd.config.GetReloadableBoolVar(true, jd.configKeys("getJobsUseLateralJoin")...)
 
 	if jd.TriggerAddNewDS == nil {
 		jd.TriggerAddNewDS = func() <-chan time.Time {

--- a/jobsdb/jobsdb_dataset.go
+++ b/jobsdb/jobsdb_dataset.go
@@ -126,16 +126,15 @@ func (jd *Handle) doRefreshDSList(l lock.LockToken, db sqlDbOrTx) (dataSetTList,
 }
 
 // addCompletedDSToDropList adds the given datasets to the dropDSList and removes them from the dsList. Caller must have the dsListLock write-locked.
-// It returns the freshly published dsList snapshot (with the queued datasets filtered out) so callers can avoid an extra read.
-func (jd *Handle) addCompletedDSToDropList(ctx context.Context, l lock.LockToken, dsList ...dataSetT) (dataSetTList, error) {
+func (jd *Handle) addCompletedDSToDropList(ctx context.Context, l lock.LockToken, dsList ...dataSetT) error {
 	if l == nil {
-		return nil, fmt.Errorf("cannot add to drop DS list without a valid lock token")
+		return fmt.Errorf("cannot add to drop DS list without a valid lock token")
 	}
 	jd.dropDSListLock.Lock()
 	defer jd.dropDSListLock.Unlock()
 	currentList, currentRangeList := jd.dsList.snapshot()
 	if len(dsList) == 0 {
-		return currentList, nil
+		return nil
 	}
 	version := jd.dsList.currentVersion()
 	previousDropDSList := append([]dropDSEntry(nil), jd.dropDSList...)
@@ -153,7 +152,7 @@ func (jd *Handle) addCompletedDSToDropList(ctx context.Context, l lock.LockToken
 		addedDSList = append(addedDSList, ds)
 	}
 	if len(addedDSList) == 0 {
-		return currentList, nil
+		return nil
 	}
 	toDrop := lo.SliceToMap(jd.dropDSList, func(entry dropDSEntry) (string, struct{}) {
 		return entry.ds.Index, struct{}{}
@@ -164,7 +163,7 @@ func (jd *Handle) addCompletedDSToDropList(ctx context.Context, l lock.LockToken
 	})
 	if err := jd.markPreDropDS(ctx, addedDSList...); err != nil {
 		jd.dropDSList = previousDropDSList
-		return currentList, err
+		return err
 	}
 	jd.dsList.set(
 		newList,
@@ -175,7 +174,7 @@ func (jd *Handle) addCompletedDSToDropList(ctx context.Context, l lock.LockToken
 	// update table count gauge after setting the new ds list
 	jd.statTableCount.Gauge(len(newList))
 	jd.dropNotifyPing()
-	return newList, nil
+	return nil
 }
 
 func (jd *Handle) dropNotifyPing() {

--- a/jobsdb/jobsdb_get.go
+++ b/jobsdb/jobsdb_get.go
@@ -84,13 +84,9 @@ var cacheParameterFilters = []string{"source_id", "destination_id"}
 const consumerParamName = "consumer" // the name of the consumer parameter, used for multi-consumer scoping of queries and cache entries
 
 func (jd *Handle) GetPileUpCounts(ctx context.Context, cutoffTime time.Time, increaseFunc rmetrics.IncreasePendingEventsFunc) error {
-	// pause compaction to avoid any read locks being blocked during pileup count
+	// pause compaction to get a consistent view during pileup count
 	jd.compactionPaused.Store(true)
 	defer jd.compactionPaused.Store(false)
-	if !jd.dsCompactionLock.RTryLockWithCtx(ctx) {
-		return fmt.Errorf("could not acquire a compaction read lock: %w", ctx.Err())
-	}
-	defer jd.dsCompactionLock.RUnlock()
 	dsList, _, release, err := jd.acquireDSListForRead(ctx)
 	if err != nil {
 		return err
@@ -248,10 +244,6 @@ func (jd *Handle) getDistinctValuesPerDataset(
 }
 
 func (jd *Handle) GetDistinctParameterValues(ctx context.Context, parameter ParameterName, customValFilter string) ([]string, error) {
-	if !jd.dsCompactionLock.RTryLockWithCtx(ctx) {
-		return nil, fmt.Errorf("could not acquire a compaction read lock: %w", ctx.Err())
-	}
-	defer jd.dsCompactionLock.RUnlock()
 	dsList, _, release, err := jd.acquireDSListForRead(ctx)
 	if err != nil {
 		return nil, err
@@ -276,10 +268,6 @@ func (jd *Handle) GetDistinctConsumers(ctx context.Context) ([]string, error) {
 	if !jd.conf.multiConsumer {
 		return []string{""}, nil
 	}
-	if !jd.dsCompactionLock.RTryLockWithCtx(ctx) {
-		return nil, fmt.Errorf("could not acquire a compaction read lock: %w", ctx.Err())
-	}
-	defer jd.dsCompactionLock.RUnlock()
 	dsList, _, release, err := jd.acquireDSListForRead(ctx)
 	if err != nil {
 		return nil, err
@@ -769,13 +757,6 @@ func (jd *Handle) doGetJobs(ctx context.Context, params GetQueryParams, more Mor
 	}
 	defer jd.getTimerStat("jobsdb_get_jobs_time", tags).RecordDuration()()
 
-	// Keep this order: take the compaction read lock before acquiring the
-	// dataset-list snapshot. Compaction and drop paths publish snapshots under
-	// the same ordering, so reversing it can deadlock.
-	if !jd.dsCompactionLock.RTryLockWithCtx(ctx) {
-		return nil, fmt.Errorf("could not acquire a compaction read lock: %w", ctx.Err())
-	}
-	defer jd.dsCompactionLock.RUnlock()
 	dsList, dsRangeList, release, err := jd.acquireDSListForRead(ctx)
 	if err != nil {
 		return nil, err

--- a/jobsdb/jobsdb_get.go
+++ b/jobsdb/jobsdb_get.go
@@ -363,11 +363,7 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 	// Multi-consumer "pending" variant (set internally by GetPendingConsumerJobs): instead of scoping to a single
 	// consumer, return each job once with its Consumers rewritten to the consumers whose latest status
 	// matches stateFilters, carrying no per-job status. Being an all-consumers query, it keys the
-	// noResultsCache on the wildcard consumer=* (which store/update writes invalidate). It also disables
-	// the per-state noResultsCache optimization (stateFilterOptimization below): that optimization infers
-	// "no jobs in state X" when X is absent from the result set's states, but this query reports which
-	// consumers match rather than each one's state (the scanned status is always NULL), so the inference
-	// would record false no-result markers. A no-result is therefore cached only when the whole query is empty.
+	// noResultsCache on the wildcard consumer=* (which store/update writes invalidate).
 	pendingConsumersMode := jd.conf.multiConsumer && params.allPendingConsumers
 
 	// For multi-consumer JobsDB, consumer is a cache dimension: consumer=X scopes lookups to that consumer;
@@ -396,14 +392,6 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 		CustomValFilters: params.CustomValFilters,
 		WorkspaceID:      workspaceID,
 	}
-	stateFilterOptimization := jd.conf.noResultsCacheStateOptimization.Load() && !pendingConsumersMode
-
-	if stateFilterOptimization {
-		stateFilters = lo.Filter(stateFilters, func(state string, _ int) bool { // exclude states for which we already know that there are no jobs
-			return !jd.noResultsCache.Get(ds.Index, partitionFilters, workspaceID, customValFilters, []string{state}, cacheParamFilters)
-		})
-	}
-
 	defer jd.getTimerStat("jobsdb_get_jobs_ds_time", &tags).RecordDuration()()
 
 	containsUnprocessed := lo.Contains(stateFilters, Unprocessed.State)
@@ -545,7 +533,7 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 	// so the lateral's ORDER BY / LIMIT 1 would be wasteful — skip it.
 	// (pendingConsumersMode already built its own join above.)
 	if !pendingConsumersMode {
-		if jd.conf.getJobsUseLateralJoin.Load() && !onlyUnprocessed {
+		if !onlyUnprocessed {
 			joinTable = fmt.Sprintf(`LATERAL (SELECT * FROM %q WHERE job_id = jobs.job_id%s ORDER BY id DESC LIMIT 1) job_latest_state ON true`, ds.JobStatusTable, innerConsumerClause)
 		} else {
 			joinTable = fmt.Sprintf(`%q job_latest_state ON jobs.job_id=job_latest_state.job_id%s`, joinTable, outerConsumerClause)
@@ -610,7 +598,6 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 	// inside the loop
 	var discardRowPayloadSize int64
 
-	resultsetStates := map[string]struct{}{}
 	for rows.Next() {
 		var job JobT
 		var runningEventCount int
@@ -633,7 +620,6 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 		}
 		job.EventPayload = payload
 		if jsState.Valid {
-			resultsetStates[jsState.String] = struct{}{}
 			job.LastJobStatus.JobState = jsState.String
 			job.LastJobStatus.AttemptNum = int(jsAttemptNum.Int64)
 			job.LastJobStatus.ExecTime = jsExecTime.Time
@@ -645,8 +631,6 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 			job.LastJobStatus.WorkspaceId = job.WorkspaceId
 			job.LastJobStatus.PartitionID = job.PartitionID
 			job.LastJobStatus.CustomVal = job.CustomVal
-		} else {
-			resultsetStates[Unprocessed.State] = struct{}{}
 		}
 
 		if params.EventsLimit > 0 && runningEventCount > params.EventsLimit && len(jobList) > 0 {
@@ -677,12 +661,8 @@ func (jd *Handle) getJobsDS(ctx context.Context, ds dataSetT, lastDS bool, param
 
 	if !skipCacheResult {
 		for state, cacheTx := range cacheTx {
-			// we are committing the cache Tx only if
-			// (a) no jobs are returned by the query or
-			// (b) the state is not present in the resultset and limits have not been reached
-			//     (skipped when the noResultsCache state-filter optimization is disabled)
-			_, ok := resultsetStates[state]
-			if len(jobList) == 0 || (stateFilterOptimization && !ok && !limitsReached) {
+			// we only cache a no-result when the whole query returned no jobs
+			if len(jobList) == 0 {
 				if allEntriesCommitted := cacheTx.Commit(); !allEntriesCommitted {
 					tags := &statTags{
 						StateFilters:     []string{state},
@@ -888,7 +868,7 @@ func (jd *Handle) doGetJobs(ctx context.Context, params GetQueryParams, more Mor
 	jd.stats.NewTaggedStat("jobsdb_queried_bytes", stats.CountType, statTags).Count(lo.SumBy(res.Jobs, func(j *JobT) int { return len(j.EventPayload) })) // number of bytes that we queried
 	// Validate that none of the datasets we examined were compacted while we
 	// were querying. If any of them were, it means our result may be stale and we need to retry.
-	if jd.conf.compaction.nonBlockingCompaction.Load() && jd.conf.compaction.getJobsRetryOnCompaction.Load() {
+	if jd.conf.compaction.getJobsRetryOnCompaction.Load() {
 		jd.dropDSListLock.RLock()
 		_, found := lo.Find(jd.dropDSList, func(entry dropDSEntry) bool {
 			if !entry.compacted {

--- a/jobsdb/jobsdb_lifecycle.go
+++ b/jobsdb/jobsdb_lifecycle.go
@@ -59,7 +59,6 @@ func (jd *Handle) init() {
 		jd.stats = stats.Default
 	}
 	jd.dsListLock = lock.NewLocker("dsListLock", jd.tablePrefix, jd.stats)
-	jd.dsCompactionLock = lock.NewLocker("dsCompactionLock", jd.tablePrefix, jd.stats)
 
 	jd.loadConfig()
 
@@ -409,21 +408,19 @@ func (jd *Handle) dropDSLoop(ctx context.Context) error {
 }
 
 /*
-JobsDB uses separate locks for dataset-list publication and compaction.
+JobsDB uses dsListLock for dataset-list publication.
 
 Store only needs a snapshot of the latest dataset, so it reads dsListLock and
 then writes to that dataset. If the snapshot is stale because another worker
 rolled the dataset over, the store path retries after refreshing the list.
 
 Reads and status updates need a dataset snapshot that stays valid while they
-query or route statuses. They take the compaction read lock and acquire a
-versioned dataset-list snapshot. Dataset drops wait for older snapshot versions
-to drain before physically dropping tables.
+query or route statuses. They acquire a versioned dataset-list snapshot. Dataset
+drops wait for older snapshot versions to drain before physically dropping tables.
 
-Legacy compaction takes the compaction write lock while moving jobs. The
-non-blocking compaction path avoids that write lock, fences source status
-tables with read-only triggers, publishes the refreshed dataset list near commit,
-and queues old datasets for asynchronous drop.
+The non-blocking compaction path takes no compaction lock: it fences source
+status tables with read-only triggers, publishes the refreshed dataset list near
+commit, and queues old datasets for asynchronous drop.
 */
 func (jd *Handle) addNewDSLoop(ctx context.Context) {
 	for {

--- a/jobsdb/jobsdb_multiconsumer_compaction_test.go
+++ b/jobsdb/jobsdb_multiconsumer_compaction_test.go
@@ -71,100 +71,88 @@ func TestMultiConsumerCompaction(t *testing.T) {
 		}
 	}
 
-	for _, tc := range []struct {
-		name            string
-		nonBlocking     bool
-		deferStatusLock bool
-	}{
-		{"blocking", false, false},
-		{"non-blocking", true, false},
-		{"non-blocking-deferred", true, true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			jd, c := newMCJobDB(t)
-			c.Set("JobsDB."+jd.tablePrefix+".nonBlockingCompaction", tc.nonBlocking)
-			c.Set("JobsDB."+jd.tablePrefix+".compactionDeferStatusLock", tc.deferStatusLock)
-			c.Set("JobsDB."+jd.tablePrefix+".maxDSRetention", "1ms")
-			c.Set("JobsDB."+jd.tablePrefix+".compactionMinDSAge", "0s")
-			// Disable status cleanup so it doesn't interfere with the compaction assertions.
-			c.Set("JobsDB."+jd.tablePrefix+".skipMultiConsumerStatusCompaction", true)
+	t.Run("multi-consumer", func(t *testing.T) {
+		ctx := context.Background()
+		jd, c := newMCJobDB(t)
+		c.Set("JobsDB."+jd.tablePrefix+".maxDSRetention", "1ms")
+		c.Set("JobsDB."+jd.tablePrefix+".compactionMinDSAge", "0s")
+		// Disable status cleanup so it doesn't interfere with the compaction assertions.
+		c.Set("JobsDB."+jd.tablePrefix+".skipMultiConsumerStatusCompaction", true)
 
-			// DS1: 4 jobs with mixed terminal/non-terminal consumer states.
-			//   job0: [A,B] A=succeeded B=succeeded → all terminal → NOT copied
-			//   job1: [A,B] A=succeeded B=failed    → A done, B pending → COPY
-			//   job2: [A,B] A=failed    B=failed    → both pending → COPY
-			//   job3: [A]   no status               → unprocessed → COPY
-			jobs := genJobs(defaultWorkspaceID, "mc", 4, 1)
-			jobs[0].Consumers = []string{"A", "B"}
-			jobs[1].Consumers = []string{"A", "B"}
-			jobs[2].Consumers = []string{"A", "B"}
-			jobs[3].Consumers = []string{"A"}
-			require.NoError(t, jd.Store(ctx, jobs))
+		// DS1: 4 jobs with mixed terminal/non-terminal consumer states.
+		//   job0: [A,B] A=succeeded B=succeeded → all terminal → NOT copied
+		//   job1: [A,B] A=succeeded B=failed    → A done, B pending → COPY
+		//   job2: [A,B] A=failed    B=failed    → both pending → COPY
+		//   job3: [A]   no status               → unprocessed → COPY
+		jobs := genJobs(defaultWorkspaceID, "mc", 4, 1)
+		jobs[0].Consumers = []string{"A", "B"}
+		jobs[1].Consumers = []string{"A", "B"}
+		jobs[2].Consumers = []string{"A", "B"}
+		jobs[3].Consumers = []string{"A"}
+		require.NoError(t, jd.Store(ctx, jobs))
 
-			require.NoError(t, jd.UpdateJobStatus(ctx, []*JobStatusT{
-				mcStatus(jobs[0], "A", Succeeded.State),
-				mcStatus(jobs[0], "B", Succeeded.State),
-				mcStatus(jobs[1], "A", Succeeded.State),
-				mcStatus(jobs[1], "B", Failed.State),
-				mcStatus(jobs[2], "A", Failed.State),
-				mcStatus(jobs[2], "B", Failed.State),
-			}))
+		require.NoError(t, jd.UpdateJobStatus(ctx, []*JobStatusT{
+			mcStatus(jobs[0], "A", Succeeded.State),
+			mcStatus(jobs[0], "B", Succeeded.State),
+			mcStatus(jobs[1], "A", Succeeded.State),
+			mcStatus(jobs[1], "B", Failed.State),
+			mcStatus(jobs[2], "A", Failed.State),
+			mcStatus(jobs[2], "B", Failed.State),
+		}))
 
-			// Acquire a reader before compaction so async drops are blocked long enough
-			// for the assertions below to inspect the destination tables.
-			_, _, release, err := jd.acquireDSListForRead(ctx)
-			require.NoError(t, err)
-			defer release()
+		// Acquire a reader before compaction so async drops are blocked long enough
+		// for the assertions below to inspect the destination tables.
+		_, _, release, err := jd.acquireDSListForRead(ctx)
+		require.NoError(t, err)
+		defer release()
 
-			createDS(t, jd, "2") // empty last DS — makes DS1 non-last and eligible
+		createDS(t, jd, "2") // empty last DS — makes DS1 non-last and eligible
 
-			// Let the statuses age past maxDSRetention=1ms before running compaction.
-			time.Sleep(5 * time.Millisecond)
+		// Let the statuses age past maxDSRetention=1ms before running compaction.
+		time.Sleep(5 * time.Millisecond)
 
-			require.NoError(t, jd.doCompaction(ctx))
+		require.NoError(t, jd.doCompaction(ctx))
 
-			destDS := newDataSet(jd.tablePrefix, "1_1")
+		destDS := newDataSet(jd.tablePrefix, "1_1")
 
-			// Invariant 1: only the 3 non-fully-terminal jobs are copied.
-			var jobCount int64
-			require.NoError(t, jd.dbHandle.QueryRow(
-				fmt.Sprintf(`SELECT count(*) FROM %q`, destDS.JobTable),
-			).Scan(&jobCount))
-			require.EqualValues(t, 3, jobCount)
+		// Invariant 1: only the 3 non-fully-terminal jobs are copied.
+		var jobCount int64
+		require.NoError(t, jd.dbHandle.QueryRow(
+			fmt.Sprintf(`SELECT count(*) FROM %q`, destDS.JobTable),
+		).Scan(&jobCount))
+		require.EqualValues(t, 3, jobCount)
 
-			var job0Count int64
-			require.NoError(t, jd.dbHandle.QueryRow(
-				fmt.Sprintf(`SELECT count(*) FROM %q WHERE job_id = $1`, destDS.JobTable),
-				jobs[0].JobID,
-			).Scan(&job0Count))
-			require.Zero(t, job0Count, "fully-terminal job must not be copied")
+		var job0Count int64
+		require.NoError(t, jd.dbHandle.QueryRow(
+			fmt.Sprintf(`SELECT count(*) FROM %q WHERE job_id = $1`, destDS.JobTable),
+			jobs[0].JobID,
+		).Scan(&job0Count))
+		require.Zero(t, job0Count, "fully-terminal job must not be copied")
 
-			// Invariant 2: only statuses for pending consumers are carried over.
-			// job1/A (succeeded) is trimmed from consumers, so its status is excluded.
-			// Remaining: job1/B=failed, job2/A=failed, job2/B=failed = 3 rows.
-			// job3 had no status, so it contributes 0.
-			var statusCount int64
-			require.NoError(t, jd.dbHandle.QueryRow(
-				fmt.Sprintf(`SELECT count(*) FROM %q`, destDS.JobStatusTable),
-			).Scan(&statusCount))
-			require.EqualValues(t, 3, statusCount, "only pending consumers' statuses must be carried over")
+		// Invariant 2: only statuses for pending consumers are carried over.
+		// job1/A (succeeded) is trimmed from consumers, so its status is excluded.
+		// Remaining: job1/B=failed, job2/A=failed, job2/B=failed = 3 rows.
+		// job3 had no status, so it contributes 0.
+		var statusCount int64
+		require.NoError(t, jd.dbHandle.QueryRow(
+			fmt.Sprintf(`SELECT count(*) FROM %q`, destDS.JobStatusTable),
+		).Scan(&statusCount))
+		require.EqualValues(t, 3, statusCount, "only pending consumers' statuses must be carried over")
 
-			// Invariant 3: destination registry = exact consumers of moved jobs = {A, B}.
-			statusRows, err := jd.dbHandle.QueryContext(ctx,
-				fmt.Sprintf(`SELECT consumer FROM %q ORDER BY consumer`, destDS.consumersRegistryTable()))
-			require.NoError(t, err)
-			var consumers []string
-			for statusRows.Next() {
-				var consumer string
-				require.NoError(t, statusRows.Scan(&consumer))
-				consumers = append(consumers, consumer)
-			}
-			require.NoError(t, statusRows.Err())
-			_ = statusRows.Close()
-			require.Equal(t, []string{"A", "B"}, consumers)
-		})
-	}
+		// Invariant 3: destination registry = exact consumers of moved jobs = {A, B}.
+		statusRows, err := jd.dbHandle.QueryContext(ctx,
+			fmt.Sprintf(`SELECT consumer FROM %q ORDER BY consumer`, destDS.consumersRegistryTable()))
+		require.NoError(t, err)
+		var consumers []string
+		for statusRows.Next() {
+			var consumer string
+			require.NoError(t, statusRows.Scan(&consumer))
+			consumers = append(consumers, consumer)
+		}
+		require.NoError(t, statusRows.Err())
+		_ = statusRows.Close()
+		require.Equal(t, []string{"A", "B"}, consumers)
+	})
 }
 
 // TestMCCleanStatusTable verifies that cleanStatusTable uses DISTINCT ON (job_id, consumer)

--- a/jobsdb/jobsdb_store.go
+++ b/jobsdb/jobsdb_store.go
@@ -60,10 +60,6 @@ func (jd *Handle) inStoreSafeCtx(ctx context.Context, f func(lastDS dataSetT) er
 			return fmt.Errorf("could not acquire a dslist read lock: %w", ctx.Err())
 		}
 		lastDS = jd.getLastDS()
-		if jd.conf.holdDSListLockDuringStore.Load() {
-			defer jd.dsListLock.RUnlock()
-			return f(lastDS)
-		}
 		jd.dsListLock.RUnlock()
 		return f(lastDS)
 	}

--- a/jobsdb/jobsdb_test.go
+++ b/jobsdb/jobsdb_test.go
@@ -389,7 +389,7 @@ func TestRefreshDSList(t *testing.T) {
 	versionBeforeDrop := jobsDB.dsList.currentVersion()
 	dsToDrop := jobsDB.getDSListSnapshot()[0]
 	jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
-		_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, dsToDrop)
+		err := jobsDB.addCompletedDSToDropList(context.Background(), l, dsToDrop)
 		require.NoError(t, err)
 		jobsDB.dropDSListLock.RLock()
 		require.Len(t, jobsDB.dropDSList, 1)
@@ -438,7 +438,7 @@ func TestPreDropMarker(t *testing.T) {
 	jobsDB.Stop()
 
 	require.NoError(t, jobsDB.dsListLock.WithLockInCtx(context.Background(), func(l lock.LockToken) error {
-		_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1)
+		err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1)
 		return err
 	}))
 
@@ -700,7 +700,7 @@ func TestDropDSLoop(t *testing.T) {
 		require.Equal(t, dsToDrop.Index, dsList[0].Index)
 
 		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
-			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, dsToDrop)
+			err := jobsDB.addCompletedDSToDropList(context.Background(), l, dsToDrop)
 			require.NoError(t, err)
 		})
 		require.Len(t, jobsDB.getDSListSnapshot(), 1)
@@ -724,7 +724,7 @@ func TestDropDSLoop(t *testing.T) {
 		ds1, ds2 := snapshot[0], snapshot[1]
 
 		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
-			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1, ds2)
+			err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1, ds2)
 			require.NoError(t, err)
 		})
 
@@ -749,7 +749,7 @@ func TestDropDSLoop(t *testing.T) {
 		versionBefore := jobsDB.dsList.currentVersion()
 
 		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
-			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1)
+			err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1)
 			require.NoError(t, err)
 		})
 		jobsDB.dropDSListLock.RLock()
@@ -758,7 +758,7 @@ func TestDropDSLoop(t *testing.T) {
 		require.Equal(t, versionBefore+1, jobsDB.dsList.currentVersion(), "first add should bump the dsList version once")
 
 		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
-			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1)
+			err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1)
 			require.NoError(t, err)
 		})
 		jobsDB.dropDSListLock.RLock()
@@ -767,7 +767,7 @@ func TestDropDSLoop(t *testing.T) {
 		require.Equal(t, versionBefore+1, jobsDB.dsList.currentVersion(), "duplicate add must NOT bump the dsList version")
 
 		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
-			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1, ds2)
+			err := jobsDB.addCompletedDSToDropList(context.Background(), l, ds1, ds2)
 			require.NoError(t, err)
 		})
 		jobsDB.dropDSListLock.RLock()
@@ -789,7 +789,7 @@ func TestDropDSLoop(t *testing.T) {
 		defer release()
 
 		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
-			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, dsToDrop)
+			err := jobsDB.addCompletedDSToDropList(context.Background(), l, dsToDrop)
 			require.NoError(t, err)
 		})
 		require.Never(t, func() bool { return !tableExists(t, jobsDB, dsToDrop) }, 200*time.Millisecond, 20*time.Millisecond)
@@ -824,7 +824,7 @@ func TestDropDSLoop(t *testing.T) {
 		require.True(t, present, "dsRangeFuncMap must contain an entry for non-last datasets after refresh")
 
 		jobsDB.dsListLock.WithLock(func(l lock.LockToken) {
-			_, err := jobsDB.addCompletedDSToDropList(context.Background(), l, dsToDrop)
+			err := jobsDB.addCompletedDSToDropList(context.Background(), l, dsToDrop)
 			require.NoError(t, err)
 		})
 
@@ -2360,65 +2360,6 @@ func TestGetJobsLimitsReached(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestGetJobsLateralJoinToggle(t *testing.T) {
-	pgContainer := startPostgres(t)
-	customVal := strings.ToUpper(rsRand.String(8))
-	prefix := strings.ToLower(rsRand.String(5))
-
-	c := config.New()
-	db := NewForReadWrite(prefix, WithDBHandle(pgContainer.DB), WithConfig(c))
-	require.NoError(t, db.Start())
-	defer db.TearDown()
-
-	jobs := make([]*JobT, 5)
-	for i := range jobs {
-		jobs[i] = &JobT{
-			Parameters:   []byte(`{}`),
-			EventPayload: []byte(`{"k":"v"}`),
-			UserID:       "u",
-			UUID:         uuid.New(),
-			CustomVal:    customVal,
-			EventCount:   1,
-			WorkspaceId:  "ws",
-		}
-	}
-	require.NoError(t, db.Store(context.Background(), jobs))
-
-	all, err := db.GetUnprocessed(context.Background(), GetQueryParams{
-		CustomValFilters: []string{customVal},
-		JobsLimit:        100,
-	})
-	require.NoError(t, err)
-	require.Len(t, all.Jobs, 5)
-
-	// Mark jobs[2,3] failed, job[4] waiting; leave jobs[0,1] unprocessed.
-	statuses := []*JobStatusT{
-		{JobID: all.Jobs[2].JobID, JobState: Failed.State, AttemptNum: 1, ExecTime: time.Now(), RetryTime: time.Now(), ErrorCode: "500", ErrorResponse: []byte(`{}`), Parameters: []byte(`{}`), WorkspaceId: "ws", CustomVal: customVal},
-		{JobID: all.Jobs[3].JobID, JobState: Failed.State, AttemptNum: 1, ExecTime: time.Now(), RetryTime: time.Now(), ErrorCode: "500", ErrorResponse: []byte(`{}`), Parameters: []byte(`{}`), WorkspaceId: "ws", CustomVal: customVal},
-		{JobID: all.Jobs[4].JobID, JobState: Waiting.State, AttemptNum: 1, ExecTime: time.Now(), RetryTime: time.Now(), ErrorCode: "", ErrorResponse: []byte(`{}`), Parameters: []byte(`{}`), WorkspaceId: "ws", CustomVal: customVal},
-	}
-	require.NoError(t, db.UpdateJobStatus(context.Background(), statuses))
-
-	params := GetQueryParams{CustomValFilters: []string{customVal}, JobsLimit: 100}
-
-	// lateral path
-	c.Set("JobsDB.getJobsUseLateralJoin", true)
-	lateralResult, err := db.GetToProcess(context.Background(), params, nil)
-	require.NoError(t, err)
-	require.Len(t, lateralResult.Jobs, 5, "lateral join should return all 5 jobs")
-
-	// flip to v_last path
-	c.Set("JobsDB.getJobsUseLateralJoin", false)
-
-	vLastResult, err := db.GetToProcess(context.Background(), params, nil)
-	require.NoError(t, err)
-	require.Len(t, vLastResult.Jobs, 5, "v_last join should return all 5 jobs")
-
-	lateralIDs := lo.Map(lateralResult.Jobs, func(j *JobT, _ int) int64 { return j.JobID })
-	vLastIDs := lo.Map(vLastResult.Jobs, func(j *JobT, _ int) int64 { return j.JobID })
-	require.Equal(t, lateralIDs, vLastIDs, "v_last and lateral join should return the same job IDs in the same order")
 }
 
 func TestUpdateJobStatus(t *testing.T) {

--- a/jobsdb/jobsdb_update.go
+++ b/jobsdb/jobsdb_update.go
@@ -105,14 +105,6 @@ func (jd *Handle) WithUpdateSafeTxFromTx(ctx context.Context, tx *Tx, f func(tx 
 }
 
 func (jd *Handle) inUpdateSafeCtx(ctx context.Context, f func(dsList []dataSetT, dsRangeList []dataSetRangeT) error) error {
-	// Keep this order: take the compaction read lock before acquiring the
-	// dataset-list snapshot. Compaction and drop paths publish snapshots under
-	// the same ordering, so reversing it can deadlock.
-	if !jd.dsCompactionLock.RTryLockWithCtx(ctx) {
-		return fmt.Errorf("could not acquire a compaction read lock: %w", ctx.Err())
-	}
-	defer jd.dsCompactionLock.RUnlock()
-
 	dsList, dsRangeList, release, err := jd.acquireDSListForRead(ctx)
 	if err != nil {
 		return err

--- a/processor/processor_isolation_test.go
+++ b/processor/processor_isolation_test.go
@@ -254,8 +254,6 @@ func ProcIsolationScenario(t testing.TB, spec *ProcIsolationScenarioSpec) (overa
 	config.Set("Processor.isolationMode", string(spec.isolationMode))
 
 	config.Set("JobsDB.enableWriterQueue", false)
-	config.Set("JobsDB.nonBlockingCompletedDSDrop", "true")
-	config.Set("JobsDB.compactionDeferStatusLock", "true")
 
 	// find free port for gateway http server to listen on
 	httpPortInt, err := kithelper.GetFreePort()

--- a/router/batchrouter/batchrouter_isolation_test.go
+++ b/router/batchrouter/batchrouter_isolation_test.go
@@ -265,8 +265,6 @@ func BatchrouterIsolationScenario(t testing.TB, spec *BrtIsolationScenarioSpec) 
 	config.Set("BatchRouter.Limiter.statsPeriod", "1s")
 
 	config.Set("JobsDB.enableWriterQueue", false)
-	config.Set("JobsDB.nonBlockingCompletedDSDrop", "true")
-	config.Set("JobsDB.compactionDeferStatusLock", "true")
 	config.Set("RUDDER_TMPDIR", os.TempDir())
 
 	t.Logf("Seeding batch_rt jobsdb with jobs")

--- a/router/router_isolation_test.go
+++ b/router/router_isolation_test.go
@@ -223,8 +223,6 @@ func RouterIsolationScenario(t testing.TB, spec *RtIsolationScenarioSpec) (overa
 	config.Set("TransformationDebugger.disableTransformationStatusUploads", true)
 	config.Set("JobsDB.backup.enabled", false)
 	config.Set("JobsDB.migrateDSLoopSleepDuration", "60m")
-	config.Set("JobsDB.nonBlockingCompletedDSDrop", "true")
-	config.Set("JobsDB.compactionDeferStatusLock", "true")
 
 	config.Set("Router.isolationMode", string(spec.isolationMode))
 	config.Set("Router.Limiter.statsPeriod", "1s")


### PR DESCRIPTION
# Description

Removes five jobsdb config flags that have settled on a single value, collapsing each gated code path to its always-taken branch:

- `noResultsCacheStateOptimization` (always false) — drop the per-state cache optimization
- `getJobsUseLateralJoin` (always true) — always use the LATERAL join in `getJobsDS`
- `nonBlockingCompaction` (always true) — remove the legacy `doCompaction` body (`doCompactDS` becomes `doCompaction`)
- `compactionDeferStatusLock` (always true) — deferred two-phase status copy is now the only path
- `nonBlockingCompletedDSDrop` — removed (only lived in the deleted legacy path)
- `holdDSListLockDuringStore` (always false) — remove the option to hold dsListLock while storing

Also drops the now-orphaned helpers (`compactJobsInTx`, `computeNewIdxForIntraNodeCompaction`, `postCompactionHandleDS`) and updates/removes the tests that exercised the removed branches.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #7122 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #7121 
- <kbd>&nbsp;3&nbsp;</kbd> #7098 
- <kbd>&nbsp;2&nbsp;</kbd> #7097 
- <kbd>&nbsp;1&nbsp;</kbd> #7096 
<!-- GitButler Footer Boundary Bottom -->
