### PR TITLE
feat: implement Kubernetes deployment scaler for workspace replica management

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,9 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
+	k8s.io/api v0.32.3
+	k8s.io/apimachinery v0.32.3
+	k8s.io/client-go v0.32.3
 )
 
 require (
@@ -211,6 +214,7 @@ require (
 	github.com/duckdb/duckdb-go-bindings/lib/windows-amd64 v0.10501.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dvsekhvalnov/jose2go v1.7.0 // indirect
+	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
@@ -224,6 +228,9 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/go-openapi/jsonpointer v0.21.0 // indirect
+	github.com/go-openapi/jsonreference v0.20.2 // indirect
+	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.1 // indirect
@@ -239,6 +246,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
+	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
 	github.com/google/renameio/v2 v2.0.0 // indirect
@@ -259,6 +267,7 @@ require (
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
@@ -267,6 +276,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20240909124753-873cd0166683 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-ieproxy v0.0.12 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -372,13 +382,13 @@ require (
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/gotestsum v1.12.3 // indirect
-	k8s.io/apimachinery v0.32.3 // indirect
-	k8s.io/client-go v0.32.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -448,6 +448,7 @@ github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHf
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
@@ -610,10 +611,12 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
+github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
 github.com/go-openapi/jsonpointer v0.21.0 h1:YgdVicSA9vH5RiHs9TZW5oyafXZFc6+2Vc1rr/O9oNQ=
 github.com/go-openapi/jsonpointer v0.21.0/go.mod h1:IUyH9l/+uyhIYQ/PXVA41Rexl+kOkAPDdXEYns6fzUY=
 github.com/go-openapi/jsonreference v0.20.2 h1:3sVjiK66+uXK/6oQ8xgcRKcFgQ5KXa2KvnJRumpMGbE=
 github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En5Ap4rVB5KVcIDZG2k=
+github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=

--- a/processor/internal/pytscaler/k8s.go
+++ b/processor/internal/pytscaler/k8s.go
@@ -1,0 +1,136 @@
+package pytscaler
+
+import (
+	"context"
+	"fmt"
+
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+)
+
+type k8sScaler struct {
+	client kubernetes.Interface
+	log    logger.Logger
+	retry  retrySettings
+}
+
+func (s *k8sScaler) GetReplicaCount(ctx context.Context, workspaceID string) (int, error) {
+	if workspaceID == "" {
+		return 0, fmt.Errorf("workspaceID is empty")
+	}
+	name := deploymentName(workspaceID)
+	namespace, err := s.resolveNamespace(ctx, name)
+	if err != nil {
+		return 0, err
+	}
+	scale, err := withRetry(ctx, s.retry, func() (*autoscalingv1.Scale, error) {
+		return s.client.AppsV1().Deployments(namespace).GetScale(ctx, name, metav1.GetOptions{})
+	})
+	if err != nil {
+		return 0, fmt.Errorf("getting scale for deployment %s/%s: %w", namespace, name, err)
+	}
+	return int(scale.Spec.Replicas), nil
+}
+
+func (s *k8sScaler) SetReplicaCount(ctx context.Context, workspaceID string, count int) error {
+	if workspaceID == "" {
+		return fmt.Errorf("workspaceID is empty")
+	}
+	name := deploymentName(workspaceID)
+	namespace, err := s.resolveNamespace(ctx, name)
+	if err != nil {
+		return err
+	}
+	scale := &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       autoscalingv1.ScaleSpec{Replicas: int32(count)}, //nolint:gosec // replica count is a small, bounded value
+	}
+	if _, err := withRetry(ctx, s.retry, func() (*autoscalingv1.Scale, error) {
+		return s.client.AppsV1().Deployments(namespace).UpdateScale(ctx, name, scale, metav1.UpdateOptions{})
+	}); err != nil {
+		return fmt.Errorf("scaling deployment %s/%s to %d replicas: %w", namespace, name, count, err)
+	}
+	s.log.Infon("scaled pyt deployment",
+		logger.NewStringField("namespace", namespace),
+		logger.NewStringField("deployment", name),
+		logger.NewIntField("replicas", int64(count)))
+	return nil
+}
+
+// resolveNamespace finds the single Deployment named name across all namespaces
+// and returns its namespace. metadata.name is a universally-supported field
+// selector, so this needs no namespace config or ExternalName parsing.
+func (s *k8sScaler) resolveNamespace(ctx context.Context, name string) (string, error) {
+	deployments, err := withRetry(ctx, s.retry, func() (*deploymentNames, error) {
+		list, err := s.client.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector("metadata.name", name).String(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out := &deploymentNames{}
+		for _, d := range list.Items {
+			out.namespaces = append(out.namespaces, d.Namespace)
+		}
+		return out, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("listing deployments named %s: %w", name, err)
+	}
+	switch len(deployments.namespaces) {
+	case 0:
+		return "", fmt.Errorf("%w: %s", ErrDeploymentNotFound, name)
+	case 1:
+		return deployments.namespaces[0], nil
+	default:
+		return "", fmt.Errorf("found %d deployments named %s across namespaces; expected exactly one",
+			len(deployments.namespaces), name)
+	}
+}
+
+// deploymentNames carries the namespaces of the Deployments matched by name. It
+// exists so withRetry returns a small value rather than a full DeploymentList.
+type deploymentNames struct {
+	namespaces []string
+}
+
+func newInClusterClientset(conf *config.Config) (kubernetes.Interface, error) {
+	cfg, err := restConfig(conf)
+	if err != nil {
+		return nil, err
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating kubernetes clientset: %w", err)
+	}
+	return client, nil
+}
+
+func restConfig(conf *config.Config) (*rest.Config, error) {
+	if conf.GetBoolVar(true, "Processor.UserTransformer.pytScaler.inCluster", "K8S_IN_CLUSTER") {
+		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("creating in-cluster kubernetes config: %w", err)
+		}
+		return cfg, nil
+	}
+	kubeConfigPath := conf.GetStringVar("", "Processor.UserTransformer.pytScaler.kubeConfigPath", "KUBECONFIG")
+	if kubeConfigPath == "" {
+		kubeConfigPath = clientcmd.RecommendedHomeFile
+	}
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeConfigPath},
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("creating kubernetes config from %s: %w", kubeConfigPath, err)
+	}
+	return cfg, nil
+}

--- a/processor/internal/pytscaler/pytscaler.go
+++ b/processor/internal/pytscaler/pytscaler.go
@@ -1,0 +1,116 @@
+// Package pytscaler reads and sets the replica count of a workspace's
+// per-workspace rudder-pytransformer (pyt-{workspaceID}) Deployment, so the
+// transformation test flow can scale it up from zero before forwarding a request
+// to it.
+//
+// The pyt Deployments default to 0 replicas (Keda scales them back to 0 when
+// idle) and live in one of several pyt namespaces — not a single fixed one and
+// not the processor's own namespace. Because the Kubernetes scale subresource is
+// namespace-scoped, the scaler first locates the Deployment by name across all
+// namespaces (a cluster-wide List by metadata.name) and then operates in the
+// namespace it was found in. It only ever touches the replica count via the scale
+// subresource, never the pod spec, so the deployment's Kata RuntimeClass is
+// preserved.
+//
+// The [Scaler] interface deliberately exposes just two thin primitives over the
+// scale subresource — [Scaler.GetReplicaCount] and [Scaler.SetReplicaCount].
+// Deciding whether a scale-up is actually needed (e.g. "set to N only when the
+// current count is 0") is the caller's responsibility, not this layer's.
+//
+// The Kubernetes dependency is hidden behind the [Scaler] interface. [New] builds
+// the real k8s-backed implementation; [NewNoop] returns a do-nothing
+// implementation so the processor can start and serve even when Kubernetes is not
+// available (local dev, k8s client build failure, or the feature disabled).
+package pytscaler
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+)
+
+// ErrDeploymentNotFound is returned by [Scaler.EnsureScaled] when no pyt
+// Deployment exists for the given workspace in any namespace.
+var ErrDeploymentNotFound = errors.New("pyt deployment not found")
+
+// Scaler reads and sets the replica count of a workspace's pyt Deployment. It is
+// a thin wrapper over the Kubernetes scale subresource; the get-before-set
+// idempotency decision is left to the caller.
+type Scaler interface {
+	// GetReplicaCount returns the current replica count of the workspace's
+	// pyt-{workspaceID} Deployment, locating it by name across all namespaces.
+	// It returns ErrDeploymentNotFound if no such Deployment exists.
+	GetReplicaCount(ctx context.Context, workspaceID string) (int, error)
+	// SetReplicaCount sets the replica count of the workspace's pyt-{workspaceID}
+	// Deployment via the scale subresource. It always writes the given count
+	// unconditionally — ensuring it is only called when a change is needed (e.g.
+	// the current count is 0) is the caller's responsibility.
+	SetReplicaCount(ctx context.Context, workspaceID string, count int) error
+}
+
+// Opt configures the k8s-backed Scaler built by [New].
+type Opt func(*k8sScaler)
+
+// WithClientset injects a Kubernetes clientset instead of building an in-cluster
+// one. Used in tests with a fake clientset.
+func WithClientset(client kubernetes.Interface) Opt {
+	return func(s *k8sScaler) { s.client = client }
+}
+
+// New builds a Kubernetes-backed [Scaler]. Unless a clientset is injected via
+// [WithClientset], it builds an in-cluster client (falling back to a kubeconfig
+// file when not running in-cluster) and returns an error if that fails — callers
+// that want the processor to start regardless should fall back to [NewNoop].
+func New(conf *config.Config, log logger.Logger, opts ...Opt) (Scaler, error) {
+	s := &k8sScaler{
+		log:   log.Child("pytscaler"),
+		retry: newRetrySettings(conf),
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.client == nil {
+		client, err := newInClusterClientset(conf)
+		if err != nil {
+			return nil, err
+		}
+		s.client = client
+	}
+	return s, nil
+}
+
+// NewNoop returns a [Scaler] that does nothing. Use it when k8s scaling is
+// unavailable or disabled, so the processor can still start and serve.
+func NewNoop(log logger.Logger) Scaler {
+	return &noopScaler{log: log.Child("pytscaler")}
+}
+
+type noopScaler struct {
+	log logger.Logger
+}
+
+// GetReplicaCount reports the deployment as already scaled (1) so callers using
+// the get-before-set pattern skip scaling when k8s is unavailable.
+func (n *noopScaler) GetReplicaCount(_ context.Context, workspaceID string) (int, error) {
+	n.log.Debugn("pyt scaler disabled; reporting deployment as already scaled",
+		logger.NewStringField("workspaceID", workspaceID))
+	return 1, nil
+}
+
+func (n *noopScaler) SetReplicaCount(_ context.Context, workspaceID string, count int) error {
+	n.log.Debugn("pyt scaler disabled; skipping scale",
+		logger.NewStringField("workspaceID", workspaceID),
+		logger.NewIntField("count", int64(count)))
+	return nil
+}
+
+// deploymentName returns the Deployment name convention for a workspace's pyt
+// transformer: pyt-{lowercase workspaceID}.
+func deploymentName(workspaceID string) string {
+	return "pyt-" + strings.ToLower(workspaceID)
+}

--- a/processor/internal/pytscaler/pytscaler_test.go
+++ b/processor/internal/pytscaler/pytscaler_test.go
@@ -1,0 +1,286 @@
+package pytscaler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+)
+
+const (
+	workspaceID = "2abcDEF" // pyt-2abcdef (lowercased)
+	deployName  = "pyt-2abcdef"
+)
+
+func TestGetReplicaCount(t *testing.T) {
+	t.Run("returns the current replica count", func(t *testing.T) {
+		cs := newFakeClient(t, deployment(deployName, "pyt-tenant-a", 3))
+		s := newScaler(t, cs, config.New())
+
+		count, err := s.GetReplicaCount(context.Background(), workspaceID)
+		require.NoError(t, err)
+		require.Equal(t, 3, count)
+	})
+
+	t.Run("locates the deployment by name across namespaces, ignoring others", func(t *testing.T) {
+		cs := newFakeClient(
+			t,
+			deployment("pyt-other", "pyt-tenant-a", 5),       // different name
+			deployment(deployName, "pyt-tenant-b", 2),        // the one we want
+			deployment("some-deployment", "pyt-tenant-b", 7), // unrelated
+		)
+		s := newScaler(t, cs, config.New())
+
+		count, err := s.GetReplicaCount(context.Background(), workspaceID)
+		require.NoError(t, err)
+		require.Equal(t, 2, count)
+	})
+
+	t.Run("returns ErrDeploymentNotFound when no deployment matches", func(t *testing.T) {
+		cs := newFakeClient(t, deployment("pyt-someoneelse", "pyt-tenant-a", 0))
+		s := newScaler(t, cs, config.New())
+
+		_, err := s.GetReplicaCount(context.Background(), workspaceID)
+		require.ErrorIs(t, err, ErrDeploymentNotFound)
+	})
+
+	t.Run("errors when the same name exists in multiple namespaces", func(t *testing.T) {
+		cs := newFakeClient(
+			t,
+			deployment(deployName, "pyt-tenant-a", 0),
+			deployment(deployName, "pyt-tenant-b", 0),
+		)
+		s := newScaler(t, cs, config.New())
+
+		_, err := s.GetReplicaCount(context.Background(), workspaceID)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, ErrDeploymentNotFound)
+	})
+
+	t.Run("errors on an empty workspaceID", func(t *testing.T) {
+		s := newScaler(t, newFakeClient(t), config.New())
+		_, err := s.GetReplicaCount(context.Background(), "")
+		require.Error(t, err)
+	})
+
+	t.Run("retries transient k8s errors then succeeds", func(t *testing.T) {
+		cs := newFakeClient(t, deployment(deployName, "pyt-tenant-a", 1))
+		// Fail the first two GetScale calls with a transient error, then let it through.
+		var attempts int
+		cs.PrependReactor("get", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
+			if action.(ktesting.GetActionImpl).GetSubresource() != "scale" {
+				return false, nil, nil
+			}
+			attempts++
+			if attempts <= 2 {
+				return true, nil, apierrors.NewTooManyRequests("slow down", 1)
+			}
+			return false, nil, nil // fall through to the scale reactor
+		})
+
+		conf := config.New()
+		conf.Set("Processor.UserTransformer.pytScaler.retry.initialInterval", "1ms")
+		conf.Set("Processor.UserTransformer.pytScaler.retry.maxElapsedTime", "5s")
+		s := newScaler(t, cs, conf)
+
+		count, err := s.GetReplicaCount(context.Background(), workspaceID)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+		require.GreaterOrEqual(t, attempts, 3, "GetScale should have been retried")
+	})
+}
+
+func TestSetReplicaCount(t *testing.T) {
+	t.Run("sets the replica count via the scale subresource", func(t *testing.T) {
+		cs := newFakeClient(t, deployment(deployName, "pyt-tenant-a", 0))
+		s := newScaler(t, cs, config.New())
+
+		require.NoError(t, s.SetReplicaCount(context.Background(), workspaceID, 1))
+
+		require.EqualValues(t, 1, currentReplicas(t, cs, "pyt-tenant-a", deployName))
+		require.True(t, scaleUpdated(cs), "UpdateScale should have been called")
+	})
+
+	t.Run("writes the count unconditionally, even when already scaled up", func(t *testing.T) {
+		// The layer has no idempotency of its own — that is the caller's duty.
+		cs := newFakeClient(t, deployment(deployName, "pyt-tenant-a", 2))
+		s := newScaler(t, cs, config.New())
+
+		require.NoError(t, s.SetReplicaCount(context.Background(), workspaceID, 5))
+
+		require.EqualValues(t, 5, currentReplicas(t, cs, "pyt-tenant-a", deployName))
+	})
+
+	t.Run("locates the deployment by name across namespaces", func(t *testing.T) {
+		cs := newFakeClient(
+			t,
+			deployment("pyt-other", "pyt-tenant-a", 0),
+			deployment(deployName, "pyt-tenant-b", 0),
+		)
+		s := newScaler(t, cs, config.New())
+
+		require.NoError(t, s.SetReplicaCount(context.Background(), workspaceID, 1))
+
+		require.EqualValues(t, 1, currentReplicas(t, cs, "pyt-tenant-b", deployName))
+		require.EqualValues(t, 0, currentReplicas(t, cs, "pyt-tenant-a", "pyt-other"),
+			"deployments with other names must be left untouched")
+	})
+
+	t.Run("returns ErrDeploymentNotFound when no deployment matches", func(t *testing.T) {
+		cs := newFakeClient(t, deployment("pyt-someoneelse", "pyt-tenant-a", 0))
+		s := newScaler(t, cs, config.New())
+
+		err := s.SetReplicaCount(context.Background(), workspaceID, 1)
+		require.ErrorIs(t, err, ErrDeploymentNotFound)
+	})
+
+	t.Run("errors on an empty workspaceID", func(t *testing.T) {
+		s := newScaler(t, newFakeClient(t), config.New())
+		require.Error(t, s.SetReplicaCount(context.Background(), "", 1))
+	})
+}
+
+func TestNoopScaler(t *testing.T) {
+	s := NewNoop(logger.NOP)
+	// Reports as already scaled so the get-before-set caller skips scaling.
+	count, err := s.GetReplicaCount(context.Background(), "anyWorkspace")
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+	require.NoError(t, s.SetReplicaCount(context.Background(), "anyWorkspace", 1))
+}
+
+// newScaler builds a k8sScaler over an injected (fake) clientset.
+func newScaler(t *testing.T, cs kubernetes.Interface, conf *config.Config) Scaler {
+	t.Helper()
+	s, err := New(conf, logger.NOP, WithClientset(cs))
+	require.NoError(t, err)
+	return s
+}
+
+func deployment(name, namespace string, replicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+	}
+}
+
+// newFakeClient returns a fake clientset that emulates real cluster behaviour for
+// the two things the default fake does NOT do and which this scaler relies on:
+//  1. the scale subresource (GetScale/UpdateScale) backed by the deployment's
+//     replica count — the default fake would panic type-asserting the deployment
+//     to a *Scale;
+//  2. metadata.name field-selector filtering on List — the default fake honours
+//     only label selectors, so a cluster-wide List would otherwise return every
+//     deployment regardless of name.
+func newFakeClient(t *testing.T, deployments ...*appsv1.Deployment) *fake.Clientset {
+	t.Helper()
+	objs := make([]runtime.Object, len(deployments))
+	for i, d := range deployments {
+		objs[i] = d
+	}
+	cs := fake.NewClientset(objs...)
+	gvk := appsv1.SchemeGroupVersion.WithKind("Deployment")
+
+	cs.PrependReactor("list", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
+		la := action.(ktesting.ListActionImpl)
+		obj, err := cs.Tracker().List(la.GetResource(), gvk, la.GetNamespace())
+		if err != nil {
+			return true, nil, err
+		}
+		list := obj.(*appsv1.DeploymentList)
+		fieldSel := la.GetListRestrictions().Fields
+		if fieldSel == nil || fieldSel.Empty() {
+			return true, list, nil
+		}
+		filtered := &appsv1.DeploymentList{}
+		for i := range list.Items {
+			d := list.Items[i]
+			if fieldSel.Matches(fields.Set{"metadata.name": d.Name, "metadata.namespace": d.Namespace}) {
+				filtered.Items = append(filtered.Items, d)
+			}
+		}
+		return true, filtered, nil
+	})
+
+	cs.PrependReactor("get", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
+		ga := action.(ktesting.GetActionImpl)
+		if ga.GetSubresource() != "scale" {
+			return false, nil, nil
+		}
+		d, err := getDeployment(cs, ga.GetNamespace(), ga.GetName())
+		if err != nil {
+			return true, nil, err
+		}
+		return true, scaleOf(d), nil
+	})
+
+	cs.PrependReactor("update", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
+		ua := action.(ktesting.UpdateActionImpl)
+		if ua.GetSubresource() != "scale" {
+			return false, nil, nil
+		}
+		scale := ua.GetObject().(*autoscalingv1.Scale)
+		d, err := getDeployment(cs, ua.GetNamespace(), scale.Name)
+		if err != nil {
+			return true, nil, err
+		}
+		replicas := scale.Spec.Replicas
+		d.Spec.Replicas = &replicas
+		if err := cs.Tracker().Update(action.GetResource(), d, d.Namespace); err != nil {
+			return true, nil, err
+		}
+		return true, scale, nil
+	})
+
+	return cs
+}
+
+func getDeployment(cs *fake.Clientset, namespace, name string) (*appsv1.Deployment, error) {
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	obj, err := cs.Tracker().Get(gvr, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*appsv1.Deployment), nil
+}
+
+func scaleOf(d *appsv1.Deployment) *autoscalingv1.Scale {
+	var replicas int32
+	if d.Spec.Replicas != nil {
+		replicas = *d.Spec.Replicas
+	}
+	return &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{Name: d.Name, Namespace: d.Namespace},
+		Spec:       autoscalingv1.ScaleSpec{Replicas: replicas},
+	}
+}
+
+func currentReplicas(t *testing.T, cs *fake.Clientset, namespace, name string) int32 {
+	t.Helper()
+	d, err := getDeployment(cs, namespace, name)
+	require.NoError(t, err)
+	require.NotNil(t, d.Spec.Replicas)
+	return *d.Spec.Replicas
+}
+
+func scaleUpdated(cs *fake.Clientset) bool {
+	for _, a := range cs.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "scale" {
+			return true
+		}
+	}
+	return false
+}

--- a/processor/internal/pytscaler/retry.go
+++ b/processor/internal/pytscaler/retry.go
@@ -1,0 +1,62 @@
+package pytscaler
+
+import (
+	"context"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+)
+
+// retrySettings holds the exponential-backoff parameters for k8s API calls. They
+// are read once at startup (not per call) and reused for every retry.
+type retrySettings struct {
+	initialInterval     time.Duration
+	maxInterval         time.Duration
+	maxElapsedTime      time.Duration
+	multiplier          float64
+	randomizationFactor float64
+}
+
+func newRetrySettings(conf *config.Config) retrySettings {
+	return retrySettings{
+		initialInterval:     conf.GetDurationVar(200, time.Millisecond, "Processor.UserTransformer.pytScaler.retry.initialInterval"),
+		maxInterval:         conf.GetDurationVar(3, time.Second, "Processor.UserTransformer.pytScaler.retry.maxInterval"),
+		maxElapsedTime:      conf.GetDurationVar(30, time.Second, "Processor.UserTransformer.pytScaler.retry.maxElapsedTime"),
+		multiplier:          conf.GetFloat64Var(1.5, "Processor.UserTransformer.pytScaler.retry.multiplier"),
+		randomizationFactor: conf.GetFloat64Var(0.5, "Processor.UserTransformer.pytScaler.retry.randomizationFactor"),
+	}
+}
+
+// withRetry runs fn with exponential backoff, retrying only transient Kubernetes
+// API errors (429, timeouts, internal/unavailable). Any other error is permanent
+// and returned immediately.
+func withRetry[T any](ctx context.Context, rs retrySettings, fn func() (T, error)) (T, error) {
+	return backoff.Retry(
+		ctx,
+		func() (T, error) {
+			v, err := fn()
+			if err == nil || isTransient(err) {
+				return v, err
+			}
+			return v, backoff.Permanent(err)
+		},
+		backoff.WithBackOff(&backoff.ExponentialBackOff{
+			InitialInterval:     rs.initialInterval,
+			RandomizationFactor: rs.randomizationFactor,
+			Multiplier:          rs.multiplier,
+			MaxInterval:         rs.maxInterval,
+		}),
+		backoff.WithMaxElapsedTime(rs.maxElapsedTime),
+	)
+}
+
+func isTransient(err error) bool {
+	return apierrors.IsTooManyRequests(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsInternalError(err) ||
+		apierrors.IsServiceUnavailable(err)
+}


### PR DESCRIPTION
# Description

Adds `processor/internal/pytscaler` — a small package that reads and sets the replica count of a workspace's per-workspace `rudder-pytransformer` (`pyt-{workspaceID}`) Deployment via the Kubernetes scale subresource.

The pyt Deployments default to 0 replicas (Keda scales them back to 0 when idle), so before the processor forwards a test request
to a workspace's pyt pod, it must scale that Deployment up from zero. This package is the scaling primitive the `Forward` handler (pipe-3144) will call. No call site is wired up yet — this PR only introduces the package and its tests.

## What's in here

- **`Scaler` interface** — two thin primitives over the scale subresource:
    - `GetReplicaCount(ctx, workspaceID) (int, error)`
    - `SetReplicaCount(ctx, workspaceID, count int) error`
- **`k8sScaler`** (unexported) — the real implementation:
    - The pyt Deployment lives in one of several pyt namespaces, not a fixed one. Since the scale subresource is namespace-scoped, it locates the Deployment cluster-wide by `metadata.name=pyt-{lower(workspaceID)}` (a
      universally-supported field selector) and reads the namespace off the match — no namespace config or ExternalName parsing.
    - Operates **only** through the scale subresource (`GetScale`/`UpdateScale`), never a full Deployment update, so the pod spec — including the Kata `RuntimeClass` — is never touched.
    - Transient k8s API errors (429, timeouts, 500, 503) are retried with exponential backoff; everything else fails fast.
- **`noopScaler`** (`NewNoop`) — a do-nothing implementation so the processor starts and serves even when Kubernetes is unavailable (local dev, client-build failure, or the feature disabled). Its `GetReplicaCount` reports `1` so
  a get-before-set caller naturally skips scaling.
- In-cluster client by default, with a kubeconfig fallback for local dev.

## Design notes

- **Idempotency is the caller's job, not this layer's.** `SetReplicaCount` writes the count unconditionally; the "scale to N only when the current count is 0" decision lives in the caller (the `Forward` handler). This keeps the
  k8s layer a pure pass-through to the scale subresource and mirrors the orchestrator's `ReplicaManager` (`GetReplicaCount`/`SetReplicaCount`) terminology.
- **The scale target (`Processor.UserTransformer.pytTestScaleReplicas`) is not read here** — the caller decides the count and passes it in.
- **`Scaler` is the abstraction boundary** — the `Forward` handler depends on the interface, not on Kubernetes. Two implementations (`k8sScaler`, `noopScaler`) plus a fake-client testing need justify the interface.

## Linear Ticket

pipe-3145

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
