### PR TITLE
feat: support compressing payloads in reporting client

### DIFF
--- a/enterprise/reporting/client/client.go
+++ b/enterprise/reporting/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -25,10 +26,11 @@ import (
 )
 
 const (
-	StatRequestTotalBytes     = "reporting_client_http_request_total_bytes"
-	StatTotalDurationsSeconds = "reporting_client_http_total_duration_seconds"
-	StatRequestLatency        = "reporting_client_http_request_latency"
-	StatHttpRequest           = "reporting_client_http_request"
+	StatRequestTotalBytes      = "reporting_client_http_request_total_bytes"
+	StatRequestCompressedBytes = "reporting_client_http_request_compressed_bytes"
+	StatTotalDurationsSeconds  = "reporting_client_http_total_duration_seconds"
+	StatRequestLatency         = "reporting_client_http_request_latency"
+	StatHttpRequest            = "reporting_client_http_request"
 )
 
 const (
@@ -74,6 +76,9 @@ type Client struct {
 	moduleName string
 	instanceID string
 
+	compress         config.ValueLoader[bool]
+	compressionLevel config.ValueLoader[int]
+
 	conf *config.Config
 }
 
@@ -101,6 +106,8 @@ func New(path Route, conf *config.Config, log logger.Logger, stats stats.Stats) 
 		route:               path,
 		instanceID:          conf.GetStringVar("1", "INSTANCE_ID"),
 		moduleName:          conf.GetStringVar("", "clientName"),
+		compress:            conf.GetReloadableBoolVar(false, "Reporting.httpClient.compression.enabled"),
+		compressionLevel:    conf.GetReloadableIntVar(gzip.DefaultCompression, 1, "Reporting.httpClient.compression.level"),
 		stats:               stats,
 		log:                 log,
 		conf:                conf,
@@ -112,6 +119,19 @@ func (c *Client) Send(ctx context.Context, payload any) error {
 	if err != nil {
 		return err
 	}
+	uncompressedBytes := len(payloadBytes)
+
+	// bodyBytes is what we actually put on the wire: either the raw payload or
+	// its gzip-compressed form. It is materialized once here (not streamed)
+	// because the request body is replayed on every backoff retry attempt.
+	bodyBytes := payloadBytes
+	compressed := c.compress.Load()
+	if compressed {
+		bodyBytes, err = c.gzipCompress(payloadBytes)
+		if err != nil {
+			return fmt.Errorf("compressing payload: %w", err)
+		}
+	}
 
 	u, err := c.route.URL(c.reportingServiceURL)
 	if err != nil {
@@ -119,11 +139,14 @@ func (c *Client) Send(ctx context.Context, payload any) error {
 	}
 
 	o := func() error {
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewBuffer(payloadBytes))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(bodyBytes))
 		if err != nil {
 			return fmt.Errorf("constructing HTTP request: %w", err)
 		}
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		if compressed {
+			req.Header.Set("Content-Encoding", "gzip")
+		}
 		req.SetBasicAuth(c.userName, c.password)
 		httpRequestStart := time.Now()
 		resp, err := c.httpClient.Do(req)
@@ -139,8 +162,9 @@ func (c *Client) Send(ctx context.Context, payload any) error {
 		httpStatTags := lo.Assign(tags, map[string]string{"status": strconv.Itoa(resp.StatusCode)})
 		c.stats.NewTaggedStat(StatHttpRequest, stats.CountType, httpStatTags).Count(1)
 
-		// Record total bytes sent
-		c.stats.NewTaggedStat(StatRequestTotalBytes, stats.CountType, tags).Count(len(payloadBytes))
+		// Record total (uncompressed) bytes and the bytes actually sent on the wire
+		c.stats.NewTaggedStat(StatRequestTotalBytes, stats.CountType, tags).Count(uncompressedBytes)
+		c.stats.NewTaggedStat(StatRequestCompressedBytes, stats.CountType, tags).Count(len(bodyBytes))
 
 		// Record request duration
 		c.stats.NewTaggedStat(StatTotalDurationsSeconds, stats.CountType, tags).Count(int(duration.Seconds()))
@@ -166,6 +190,27 @@ func (c *Client) Send(ctx context.Context, payload any) error {
 		c.log.Errorn(`Error making request to reporting service`, obskit.Error(err))
 	}
 	return err
+}
+
+// gzipCompress gzip-compresses the given bytes using the configured compression
+// level. The data is streamed through the gzip.Writer into a buffer so the result
+// can be replayed across retries and its size reported.
+func (c *Client) gzipCompress(b []byte) ([]byte, error) {
+	level := c.compressionLevel.Load()
+	var buf bytes.Buffer
+	gw, err := gzip.NewWriterLevel(&buf, level)
+	if err != nil {
+		c.log.Warnn("invalid gzip compression level, using default", logger.NewIntField("level", int64(level)))
+		gw, _ = gzip.NewWriterLevel(&buf, gzip.DefaultCompression)
+	}
+	if _, err := gw.Write(b); err != nil {
+		_ = gw.Close()
+		return nil, err
+	}
+	if err := gw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // getTags returns the common tags for reporting metrics

--- a/enterprise/reporting/client/client_test.go
+++ b/enterprise/reporting/client/client_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"flag"
@@ -327,6 +328,68 @@ func TestClientSendErrorMetric(t *testing.T) {
 	metrics = statsStore.GetByName(client.StatHttpRequest)
 	require.Len(t, metrics, 1, "should have exactly one http request metric")
 	require.Equal(t, expectedHttpTags, metrics[0].Tags, "http request metric should have correct tags")
+}
+
+func TestClientSendCompressed(t *testing.T) {
+	var capturedRequest *http.Request
+	payloadChan := make(chan []byte, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequest = r
+
+		var reader io.Reader = r.Body
+		if r.Header.Get("Content-Encoding") == "gzip" {
+			gr, err := gzip.NewReader(r.Body)
+			require.NoError(t, err)
+			defer func() { _ = gr.Close() }()
+			reader = gr
+		}
+		body, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		payloadChan <- body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	statsStore, err := memstats.New()
+	require.NoError(t, err)
+
+	conf := config.New()
+	conf.Set("INSTANCE_ID", "test-instance")
+	conf.Set("clientName", "test-client")
+	conf.Set("REPORTING_URL", server.URL)
+	conf.Set("REPORTING_USERNAME", "test_user")
+	conf.Set("REPORTING_PASSWORD", "test_pass")
+	conf.Set("Reporting.httpClient.compression.enabled", true)
+
+	c := client.New(client.RouteMetrics, conf, logger.NOP, statsStore)
+
+	metric := &types.Metric{
+		InstanceDetails: types.InstanceDetails{
+			WorkspaceID: "test-workspace",
+			InstanceID:  "test-instance",
+		},
+		StatusDetails: []*types.StatusDetail{
+			{Status: "success", Count: 100, StatusCode: 200},
+		},
+	}
+
+	err = c.Send(context.Background(), metric)
+	require.NoError(t, err)
+
+	// The server must have received a gzip-encoded request that decodes to valid JSON.
+	require.Equal(t, "gzip", capturedRequest.Header.Get("Content-Encoding"))
+	decoded := <-payloadChan
+	var decodedJSON any
+	require.NoError(t, jsonrs.Unmarshal(decoded, &decodedJSON), "decompressed payload should be valid JSON")
+
+	// Both uncompressed and compressed byte stats should be recorded, and compression
+	// should have reduced the size.
+	uncompressed := statsStore.GetByName(client.StatRequestTotalBytes)
+	require.Len(t, uncompressed, 1)
+	compressed := statsStore.GetByName(client.StatRequestCompressedBytes)
+	require.Len(t, compressed, 1)
+	require.Less(t, compressed[0].Value, uncompressed[0].Value, "compressed bytes should be smaller than uncompressed")
 }
 
 func TestClient5xx(t *testing.T) {


### PR DESCRIPTION
# Description

Adds optional gzip compression to the reporting client. When enabled, payloads are gzip-compressed and sent with `Content-Encoding: gzip`.

- Gated behind a reloadable config flag `Reporting.httpClient.compression.enabled` (default `false`), with a configurable level `Reporting.httpClient.compression.level` (default `gzip.DefaultCompression`).
- The compressed body is materialized once before the retry loop so it can be replayed across backoff retries.
- Reports both `reporting_client_http_request_total_bytes` (uncompressed) and the new `reporting_client_http_request_compressed_bytes` (on the wire).

## Linear Ticket

resolves PIPE-3157

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
