### PR TITLE
feat: carry integration version on DestinationT to the transformer

### DIFF
--- a/backend-config/types.go
+++ b/backend-config/types.go
@@ -70,6 +70,7 @@ type DestinationT struct {
 	DeliveryAccount       *Account `json:"deliveryAccount,omitempty"`
 	DeleteAccount         *Account `json:"deleteAccount,omitempty"`
 	HasDynamicConfig      bool     `json:"hasDynamicConfig"`
+	Version               int      `json:"version"` // integration major rudder-server carries to the transformer (never interprets); absent in the blob => 0, treated as v1 downstream.
 }
 
 // UpdateHasDynamicConfig checks if the destination config contains dynamic config patterns

--- a/backend-config/types.go
+++ b/backend-config/types.go
@@ -70,7 +70,7 @@ type DestinationT struct {
 	DeliveryAccount       *Account `json:"deliveryAccount,omitempty"`
 	DeleteAccount         *Account `json:"deleteAccount,omitempty"`
 	HasDynamicConfig      bool     `json:"hasDynamicConfig"`
-	Version               int      `json:"version"` // integration major rudder-server carries to the transformer (never interprets); absent in the blob => 0, treated as v1 downstream.
+	Version               int      `json:"version,omitempty"` // integration major rudder-server carries to the transformer (never interprets); absent/0 both mean v1, so omit when zero.
 }
 
 // UpdateHasDynamicConfig checks if the destination config contains dynamic config patterns

--- a/backend-config/types_test.go
+++ b/backend-config/types_test.go
@@ -65,17 +65,25 @@ func TestDestinationT_MarshalJSON_HasDynamicConfigAlwaysPresent(t *testing.T) {
 }
 
 func TestDestinationT_Version(t *testing.T) {
-	t.Run("marshals as a number under the version key, always present", func(t *testing.T) {
-		for _, v := range []int{0, 1, 2} {
+	t.Run("marshals as a number, omitted when zero", func(t *testing.T) {
+		for _, v := range []int{1, 2} {
 			data, err := jsonrs.Marshal(DestinationT{ID: "d1", Version: v})
 			require.NoError(t, err)
 
 			var raw map[string]json.RawMessage
 			require.NoError(t, jsonrs.Unmarshal(data, &raw))
 			val, ok := raw["version"]
-			require.True(t, ok, "version key must always be present (no omitempty)")
+			require.True(t, ok, "non-zero version must be present")
 			require.JSONEq(t, strconv.Itoa(v), string(val), "version must serialize as a JSON number")
 		}
+
+		// version 0 (== v1 default, == absent) is omitted to keep it off the wire
+		data, err := jsonrs.Marshal(DestinationT{ID: "d1", Version: 0})
+		require.NoError(t, err)
+		var raw map[string]json.RawMessage
+		require.NoError(t, jsonrs.Unmarshal(data, &raw))
+		_, ok := raw["version"]
+		require.False(t, ok, "zero version must be omitted (omitempty)")
 	})
 
 	// The workspace blob carries `version` on each destination. Config-backend writes it lowercase;

--- a/backend-config/types_test.go
+++ b/backend-config/types_test.go
@@ -1,6 +1,8 @@
 package backendconfig
 
 import (
+	"encoding/json"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -60,4 +62,60 @@ func TestDestinationT_MarshalJSON_HasDynamicConfigAlwaysPresent(t *testing.T) {
 			require.Equal(t, tt.expectedKeyValue, boolValue, "hasDynamicConfig value should match expected")
 		})
 	}
+}
+
+func TestDestinationT_Version(t *testing.T) {
+	t.Run("marshals as a number under the version key, always present", func(t *testing.T) {
+		for _, v := range []int{0, 1, 2} {
+			data, err := jsonrs.Marshal(DestinationT{ID: "d1", Version: v})
+			require.NoError(t, err)
+
+			var raw map[string]json.RawMessage
+			require.NoError(t, jsonrs.Unmarshal(data, &raw))
+			val, ok := raw["version"]
+			require.True(t, ok, "version key must always be present (no omitempty)")
+			require.JSONEq(t, strconv.Itoa(v), string(val), "version must serialize as a JSON number")
+		}
+	})
+
+	// The workspace blob carries `version` on each destination. Config-backend writes it lowercase;
+	// these blobs mirror the exact unmarshal targets used in production.
+	t.Run("round-trips through single-workspace and namespace unmarshal paths", func(t *testing.T) {
+		const blob = `{
+			"workspaceId": "ws-1",
+			"sources": [{
+				"id": "s1",
+				"destinations": [
+					{"id": "with-version", "version": 1},
+					{"id": "without-version"}
+				]
+			}]
+		}`
+
+		assertVersions := func(t *testing.T, cfg ConfigT) {
+			t.Helper()
+			require.Len(t, cfg.Sources, 1)
+			dests := cfg.Sources[0].Destinations
+			require.Len(t, dests, 2)
+			require.Equal(t, 1, dests[0].Version, "blob version must populate DestinationT.Version")
+			require.Zero(t, dests[1].Version, "missing version yields zero (treated as v1 downstream)")
+		}
+
+		// single-workspace path: single_workspace.go unmarshals the blob into ConfigT
+		var single ConfigT
+		require.NoError(t, jsonrs.Unmarshal([]byte(blob), &single))
+		assertVersions(t, single)
+
+		// namespace path: namespace_config.go unmarshals into map[string]*ConfigT
+		var namespace map[string]*ConfigT
+		require.NoError(t, jsonrs.Unmarshal([]byte(`{"ws-1": `+blob+`}`), &namespace))
+		require.NotNil(t, namespace["ws-1"])
+		assertVersions(t, *namespace["ws-1"])
+	})
+
+	t.Run("version key is case-insensitive on unmarshal", func(t *testing.T) {
+		var cfg ConfigT
+		require.NoError(t, jsonrs.Unmarshal([]byte(`{"sources":[{"destinations":[{"Version":2}]}]}`), &cfg))
+		require.Equal(t, 2, cfg.Sources[0].Destinations[0].Version)
+	})
 }

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -260,6 +260,7 @@ var sampleBackendConfig = backendconfig.ConfigT{
 					Name:               "B",
 					Enabled:            true,
 					IsProcessorEnabled: true,
+					Version:            1,
 					DestinationDefinition: backendconfig.DestinationDefinitionT{
 						ID:          "enabled-destination-b-definition-id",
 						Name:        "MINIO",
@@ -346,6 +347,7 @@ var sampleBackendConfig = backendconfig.ConfigT{
 					Name:               "B",
 					Enabled:            true,
 					IsProcessorEnabled: true,
+					Version:            1,
 					DestinationDefinition: backendconfig.DestinationDefinitionT{
 						ID:          "enabled-destination-b-definition-id",
 						Name:        "MINIO",
@@ -859,6 +861,7 @@ var sampleBackendConfig = backendconfig.ConfigT{
 					Name:               "B",
 					Enabled:            true,
 					IsProcessorEnabled: true,
+					Version:            1,
 					DestinationDefinition: backendconfig.DestinationDefinitionT{
 						ID:          "enabled-destination-b-definition-id",
 						Name:        "MINIO",

--- a/processor/testdata/goldenUtMirrorClientEvents.json
+++ b/processor/testdata/goldenUtMirrorClientEvents.json
@@ -53,7 +53,8 @@
             ],
             "IsProcessorEnabled": true,
             "RevisionID": "",
-            "hasDynamicConfig": false
+            "hasDynamicConfig": false,
+            "version": 1
         },
         "connection": {
             "sourceId": "",
@@ -118,7 +119,8 @@
             ],
             "IsProcessorEnabled": true,
             "RevisionID": "",
-            "hasDynamicConfig": false
+            "hasDynamicConfig": false,
+            "version": 1
         },
         "connection": {
             "sourceId": "",
@@ -181,7 +183,8 @@
             ],
             "IsProcessorEnabled": true,
             "RevisionID": "",
-            "hasDynamicConfig": false
+            "hasDynamicConfig": false,
+            "version": 1
         },
         "connection": {
             "sourceId": "",

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -89,7 +89,7 @@ type ProxyRequestPayload struct {
 	integrations.PostParametersT
 	Metadata           []ProxyRequestMetadata `json:"metadata"`
 	DestinationConfig  map[string]any         `json:"destinationConfig"`
-	DestinationVersion int                    `json:"destinationVersion"`
+	DestinationVersion int                    `json:"destinationVersion,omitempty"`
 }
 
 type ProxyRequestParams struct {

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -87,8 +87,9 @@ type ProxyRequestMetadata struct {
 
 type ProxyRequestPayload struct {
 	integrations.PostParametersT
-	Metadata          []ProxyRequestMetadata `json:"metadata"`
-	DestinationConfig map[string]any         `json:"destinationConfig"`
+	Metadata           []ProxyRequestMetadata `json:"metadata"`
+	DestinationConfig  map[string]any         `json:"destinationConfig"`
+	DestinationVersion int                    `json:"destinationVersion"`
 }
 
 type ProxyRequestParams struct {

--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -27,8 +27,9 @@ type transformerProxyAdapter interface {
 
 type ProxyRequestPayloadV0 struct {
 	integrations.PostParametersT
-	Metadata          ProxyRequestMetadata `json:"metadata"`
-	DestinationConfig map[string]any       `json:"destinationConfig"`
+	Metadata           ProxyRequestMetadata `json:"metadata"`
+	DestinationConfig  map[string]any       `json:"destinationConfig"`
+	DestinationVersion int                  `json:"destinationVersion"`
 }
 
 type ProxyResponseV0 struct {
@@ -68,9 +69,10 @@ type (
 func (v0 *v0Adapter) getPayload(proxyReqParams *ProxyRequestParams) ([]byte, error) {
 	params := proxyReqParams.ResponseData
 	proxyReqPayload := &ProxyRequestPayloadV0{
-		PostParametersT:   params.PostParametersT,
-		Metadata:          params.Metadata[0],
-		DestinationConfig: params.DestinationConfig,
+		PostParametersT:    params.PostParametersT,
+		Metadata:           params.Metadata[0],
+		DestinationConfig:  params.DestinationConfig,
+		DestinationVersion: params.DestinationVersion,
 	}
 	return jsonrs.Marshal(proxyReqPayload)
 }

--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -29,7 +29,7 @@ type ProxyRequestPayloadV0 struct {
 	integrations.PostParametersT
 	Metadata           ProxyRequestMetadata `json:"metadata"`
 	DestinationConfig  map[string]any       `json:"destinationConfig"`
-	DestinationVersion int                  `json:"destinationVersion"`
+	DestinationVersion int                  `json:"destinationVersion,omitempty"`
 }
 
 type ProxyResponseV0 struct {

--- a/router/transformer/transformer_proxy_adapter_test.go
+++ b/router/transformer/transformer_proxy_adapter_test.go
@@ -54,7 +54,7 @@ func TestV0Adapter(t *testing.T) {
 			},
 			DestName: "testDestType",
 		}
-		expectedPayload := `{"type":"a","endpoint":"a.com","method":"","userId":"","headers":null,"params":null,"body":{"jobId":1},"files":null,"metadata":{"jobId":1,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":true},"destinationConfig":{"key_1":"val_1","key_2":"val_2"}}`
+		expectedPayload := `{"type":"a","endpoint":"a.com","method":"","userId":"","headers":null,"params":null,"body":{"jobId":1},"files":null,"metadata":{"jobId":1,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":true},"destinationConfig":{"key_1":"val_1","key_2":"val_2"},"destinationVersion":0}`
 
 		payload, err := v0Adapter.getPayload(proxyReqParms)
 		require.Nil(t, err)
@@ -169,7 +169,7 @@ func TestV1Adapter(t *testing.T) {
 			},
 			DestName: "testDestType",
 		}
-		expectedPayload := `{"type":"a","endpoint":"a.com","method":"","userId":"","headers":null,"params":null,"body":{"jobId":1},"files":null,"metadata":[{"jobId":1,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":true},{"jobId":2,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":false}],"destinationConfig":{"key_1":"val_1","key_2":"val_2"}}`
+		expectedPayload := `{"type":"a","endpoint":"a.com","method":"","userId":"","headers":null,"params":null,"body":{"jobId":1},"files":null,"metadata":[{"jobId":1,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":true},{"jobId":2,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":false}],"destinationConfig":{"key_1":"val_1","key_2":"val_2"},"destinationVersion":0}`
 
 		payload, err := v1Adapter.getPayload(proxyReqParms)
 		require.Nil(t, err)
@@ -325,6 +325,29 @@ func TestV1Adapter(t *testing.T) {
 
 		require.Equal(t, "", response.authErrorCategory)
 	})
+}
+
+func TestProxyPayloadCarriesDestinationVersion(t *testing.T) {
+	params := &ProxyRequestParams{
+		ResponseData: ProxyRequestPayload{
+			Metadata:           []ProxyRequestMetadata{{JobID: 1}},
+			DestinationConfig:  map[string]any{"k": "v"},
+			DestinationVersion: 1,
+		},
+	}
+
+	for _, version := range []string{transformer.V0, transformer.V1} {
+		t.Run(version, func(t *testing.T) {
+			payload, err := NewTransformerProxyAdapter(version, logger.NOP).getPayload(params)
+			require.NoError(t, err)
+
+			var got struct {
+				DestinationVersion int `json:"destinationVersion"`
+			}
+			require.NoError(t, jsonrs.Unmarshal(payload, &got))
+			require.Equal(t, 1, got.DestinationVersion)
+		})
+	}
 }
 
 func Test_getTransformerProxyURL_env_priority(t *testing.T) {

--- a/router/transformer/transformer_proxy_adapter_test.go
+++ b/router/transformer/transformer_proxy_adapter_test.go
@@ -54,7 +54,7 @@ func TestV0Adapter(t *testing.T) {
 			},
 			DestName: "testDestType",
 		}
-		expectedPayload := `{"type":"a","endpoint":"a.com","method":"","userId":"","headers":null,"params":null,"body":{"jobId":1},"files":null,"metadata":{"jobId":1,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":true},"destinationConfig":{"key_1":"val_1","key_2":"val_2"},"destinationVersion":0}`
+		expectedPayload := `{"type":"a","endpoint":"a.com","method":"","userId":"","headers":null,"params":null,"body":{"jobId":1},"files":null,"metadata":{"jobId":1,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":true},"destinationConfig":{"key_1":"val_1","key_2":"val_2"}}`
 
 		payload, err := v0Adapter.getPayload(proxyReqParms)
 		require.Nil(t, err)
@@ -169,7 +169,7 @@ func TestV1Adapter(t *testing.T) {
 			},
 			DestName: "testDestType",
 		}
-		expectedPayload := `{"type":"a","endpoint":"a.com","method":"","userId":"","headers":null,"params":null,"body":{"jobId":1},"files":null,"metadata":[{"jobId":1,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":true},{"jobId":2,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":false}],"destinationConfig":{"key_1":"val_1","key_2":"val_2"},"destinationVersion":0}`
+		expectedPayload := `{"type":"a","endpoint":"a.com","method":"","userId":"","headers":null,"params":null,"body":{"jobId":1},"files":null,"metadata":[{"jobId":1,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":true},{"jobId":2,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":false}],"destinationConfig":{"key_1":"val_1","key_2":"val_2"}}`
 
 		payload, err := v1Adapter.getPayload(proxyReqParms)
 		require.Nil(t, err)

--- a/router/worker.go
+++ b/router/worker.go
@@ -795,9 +795,10 @@ func (w *worker) proxyRequest(ctx context.Context, destinationJob types.Destinat
 	proxyReqparams := &transformer.ProxyRequestParams{
 		DestName: w.rt.destType,
 		ResponseData: transformer.ProxyRequestPayload{
-			PostParametersT:   val,
-			Metadata:          m,
-			DestinationConfig: destinationJob.Destination.Config,
+			PostParametersT:    val,
+			Metadata:           m,
+			DestinationConfig:  destinationJob.Destination.Config,
+			DestinationVersion: destinationJob.Destination.Version,
 		},
 		Destination: &destinationJob.Destination,
 		Connection:  destinationJob.Connection,


### PR DESCRIPTION
## What

Adds an integration major `version` to `DestinationT` and carries it through to the transformer on every path a destination reaches it.

- **backend-config**: new `DestinationT.Version int` tagged `json:"version"` (no `omitempty`, always emitted). rudder-server only carries it — never interprets it.
- Rides along for free on whole-destination embed paths: processor `TransformerEvent`, router `RouterJobT`/`DestinationJobT`, and the compacted variants.
- The delivery **proxy** (slimmed payload) carries it explicitly via `ProxyRequestPayload.DestinationVersion` / `ProxyRequestPayloadV0`, populated in `router/worker.go`.

## Testing

- backend-config: round-trip for single-workspace + namespace unmarshal paths, case-insensitive key, missing→0, and always-present number marshalling.
- Presence in marshalled `TransformerEvent` (golden `goldenUtMirrorClientEvents.json`, now v1) and proxy payload (v0 + v1 adapters).

INT-6484