### PR TITLE
chore: use priority pool at migration start while polling for pending jobs

### DIFF
--- a/cluster/migrator/processor/processor_partition_migrator.go
+++ b/cluster/migrator/processor/processor_partition_migrator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rudderlabs/rudder-server/cluster/migrator/processor/sourcenode"
 	"github.com/rudderlabs/rudder-server/cluster/migrator/processor/targetnode"
 	"github.com/rudderlabs/rudder-server/cluster/migrator/retry"
+	"github.com/rudderlabs/rudder-server/jobsdb"
 )
 
 // PartitionMigrator handles partition migrations for a processor node
@@ -63,7 +64,7 @@ func (ppm *processorPartitionMigrator) Start() error {
 	wg, ctx := errgroup.WithContext(ppm.lifecycleCtx)
 	ppm.wg = wg
 	ppm.pendingMigrations = make(map[string]struct{})
-
+	ctx = jobsdb.WithPriorityPool(ctx) // use priority pool for migration job handling
 	// start watching for new partition migrations
 	wg.Go(func() error {
 		ppm.watchNewMigrations(ctx)

--- a/cluster/migrator/processor/sourcenode/sourcenode_migrator.go
+++ b/cluster/migrator/processor/sourcenode/sourcenode_migrator.go
@@ -120,11 +120,13 @@ func (m *migrator) removeReadExcludedPartitions(ctx context.Context, sourceParti
 // waitForNoInProgressJobs waits until there are no in-progress job statuses in all jobsdbs for the given source partitions.
 func (m *migrator) waitForNoInProgressJobs(ctx context.Context, sourcePartitions []string) error {
 	defer m.stats.NewTaggedStat("partition_mig_src_wait_inprogress", stats.TimerType, m.statsTags()).RecordDuration()()
+	parentCtx := ctx
 	pollTimeoutCtx, cancel := context.WithTimeout(ctx, m.c.waitForInProgressTimeout.Load())
 	defer cancel()
 	pollGroup, pollCtx := errgroup.WithContext(pollTimeoutCtx)
 
 	getInProgressJobs := func(ctx context.Context, readerJobsDB jobsdb.JobsDB) (bool, error) {
+		start := time.Now()
 		for {
 			r, err := readerJobsDB.GetJobs(
 				ctx,
@@ -135,6 +137,13 @@ func (m *migrator) waitForNoInProgressJobs(ctx context.Context, sourcePartitions
 				},
 			)
 			if err != nil {
+				if parentCtx.Err() == nil && pollTimeoutCtx.Err() == context.DeadlineExceeded {
+					m.logger.Errorn("Timeout reached before in-progress jobs query loop was done. Consider increasing PartitionMigration.Processor.SourceNode.waitForInProgressTimeout",
+						logger.NewStringField("jobsdb", readerJobsDB.Identifier()),
+						logger.NewStringField("partitions", misc.TruncatedList(sourcePartitions, 10)),
+						logger.NewDurationField("elapsed", time.Since(start)),
+					)
+				}
 				return false, fmt.Errorf("getting in-progress jobs from %q jobsdb: %w", readerJobsDB.Identifier(), err)
 			}
 			if len(r.Jobs) > 0 { // found in-progress jobs
@@ -187,7 +196,6 @@ func (m *migrator) waitForNoInProgressJobs(ctx context.Context, sourcePartitions
 // Run watches for new migration jobs assigned to this source node and handles them asynchronously.
 // All go routines are added to the provided errgroup.Group. It returns an error if the watcher cannot be created.
 func (m *migrator) Run(ctx context.Context, wg *errgroup.Group) error {
-	ctx = jobsdb.WithPriorityPool(ctx)                 // use priority pool for migration job handling
 	m.pendingMigrationJobs = make(map[string]struct{}) // reset pending migration jobs map
 
 	// create a watcher for partition migration jobs

--- a/cluster/migrator/processor/targetnode/targetnode_migrator.go
+++ b/cluster/migrator/processor/targetnode/targetnode_migrator.go
@@ -82,7 +82,6 @@ func (m *migrator) Handle(ctx context.Context, migration *etcdtypes.PartitionMig
 // All go routines are added to the provided errgroup.Group.
 // It returns an error if the watcher cannot be created, or if the gRPC server fails to start.
 func (m *migrator) Run(ctx context.Context, wg *errgroup.Group) error {
-	ctx = jobsdb.WithPriorityPool(ctx)                 // use priority pool for migration job handling
 	m.pendingMigrationJobs = make(map[string]struct{}) // reset pending migration jobs map
 
 	// create a watcher for partition migration jobs


### PR DESCRIPTION
# Description

- Using priority pool for polling jobsdb for in progress jobs after partition migrator marks partitions as read excluded.
- Logging an error if context deadline is exceeded and we haven't managed to poll once.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
