### PR TITLE
fix: partition migration restarts server on slow in-progress wait

### DIFF
--- a/cluster/migrator/partitionmigration/client/migration_job_executor.go
+++ b/cluster/migrator/partitionmigration/client/migration_job_executor.go
@@ -117,16 +117,19 @@ func (mpe *migrationJobExecutor) Run(ctx context.Context) error {
 	mpe.logger.Infon("Starting partition migration")
 
 	// refresh the DS list to ensure that we'll move partition data from all datasets
+	mpe.logger.Infon("Refreshing dataset list")
 	if err := mpe.sourceDB.RefreshDSList(ctx); err != nil {
-		return fmt.Errorf("refreshing DS list: %w", err)
+		return fmt.Errorf("refreshing dataset list: %w", err)
 	}
 
 	// mark any executing jobs as failed to handle previous interrupted migrations
+	mpe.logger.Infon("Marking executing jobs as failed")
 	if err := mpe.markExecutingJobsAsFailed(ctx); err != nil {
 		return fmt.Errorf("marking executing jobs as failed: %w", err)
 	}
 
 	// create a partition migrator client
+	mpe.logger.Infon("Creating partition migration client")
 	client, err := NewPartitionMigrationClient(mpe.target, mpe.conf)
 	if err != nil {
 		return fmt.Errorf("creating partition migrator client: %w", err)

--- a/cluster/migrator/processor/sourcenode/sourcenode_migrator.go
+++ b/cluster/migrator/processor/sourcenode/sourcenode_migrator.go
@@ -75,6 +75,10 @@ func (m *migrator) Handle(ctx context.Context, migration *etcdtypes.PartitionMig
 	if len(sourcePartitions) == 0 {
 		return nil // no partitions to handle
 	}
+	m.logger.Infon("Marking source partitions as read-excluded",
+		logger.NewStringField("partitions", misc.TruncatedList(sourcePartitions, 10)),
+	)
+
 	if err := m.addReadExcludedPartitions(ctx, sourcePartitions); err != nil {
 		return fmt.Errorf("adding read excluded partitions: %w", err)
 	}
@@ -86,7 +90,16 @@ func (m *migrator) Handle(ctx context.Context, migration *etcdtypes.PartitionMig
 		return fmt.Errorf("waiting for read exclude sleep: %w", err)
 	}
 	// wait until there are no in-progress job statuses in all jobsdbs for the source partitions
-	return m.waitForNoInProgressJobs(ctx, sourcePartitions)
+	m.logger.Infon("Waiting for in-progress jobs to settle",
+		logger.NewStringField("partitions", misc.TruncatedList(sourcePartitions, 10)),
+	)
+	err := m.waitForNoInProgressJobs(ctx, sourcePartitions)
+	if err == nil {
+		m.logger.Infon("Done waiting for in-progress jobs to settle",
+			logger.NewStringField("partitions", misc.TruncatedList(sourcePartitions, 10)),
+		)
+	}
+	return err
 }
 
 // addReadExcludedPartitions marks the given partitions as excluded from reading in all jobsdbs
@@ -120,10 +133,9 @@ func (m *migrator) removeReadExcludedPartitions(ctx context.Context, sourceParti
 // waitForNoInProgressJobs waits until there are no in-progress job statuses in all jobsdbs for the given source partitions.
 func (m *migrator) waitForNoInProgressJobs(ctx context.Context, sourcePartitions []string) error {
 	defer m.stats.NewTaggedStat("partition_mig_src_wait_inprogress", stats.TimerType, m.statsTags()).RecordDuration()()
-	parentCtx := ctx
-	pollTimeoutCtx, cancel := context.WithTimeout(ctx, m.c.waitForInProgressTimeout.Load())
+	pollGroup, pollCtx := errgroup.WithContext(ctx)
+	pollTimeoutCtx, cancel := context.WithTimeout(pollCtx, m.c.waitForInProgressTimeout.Load())
 	defer cancel()
-	pollGroup, pollCtx := errgroup.WithContext(pollTimeoutCtx)
 
 	getInProgressJobs := func(ctx context.Context, readerJobsDB jobsdb.JobsDB) (bool, error) {
 		start := time.Now()
@@ -137,7 +149,8 @@ func (m *migrator) waitForNoInProgressJobs(ctx context.Context, sourcePartitions
 				},
 			)
 			if err != nil {
-				if parentCtx.Err() == nil && pollTimeoutCtx.Err() == context.DeadlineExceeded {
+				// this can happen only on the second and subsequent queries
+				if pollCtx.Err() == nil && pollTimeoutCtx.Err() == context.DeadlineExceeded {
 					m.logger.Errorn("Timeout reached before in-progress jobs query loop was done. Consider increasing PartitionMigration.Processor.SourceNode.waitForInProgressTimeout",
 						logger.NewStringField("jobsdb", readerJobsDB.Identifier()),
 						logger.NewStringField("partitions", misc.TruncatedList(sourcePartitions, 10)),
@@ -157,14 +170,18 @@ func (m *migrator) waitForNoInProgressJobs(ctx context.Context, sourcePartitions
 	for _, readerJobsDB := range m.readerJobsDBs {
 		pollGroup.Go(func() error {
 			start := time.Now()
+			// the first query is not subject to the timeout (only to errgroup/parent cancellation), so a slow
+			// initial query does not count against the timeout; every subsequent query is bounded by the timeout.
+			queryCtx := pollCtx
 			hasInProgressJobs := true
 			for hasInProgressJobs {
 				select {
-				case <-pollCtx.Done():
-					return pollCtx.Err()
+				case <-pollTimeoutCtx.Done():
+					return pollTimeoutCtx.Err()
 				default:
 					var err error
-					hasInProgressJobs, err = getInProgressJobs(pollCtx, readerJobsDB)
+					hasInProgressJobs, err = getInProgressJobs(queryCtx, readerJobsDB)
+					queryCtx = pollTimeoutCtx
 					if err != nil {
 						return err
 					}
@@ -175,7 +192,7 @@ func (m *migrator) waitForNoInProgressJobs(ctx context.Context, sourcePartitions
 							logger.NewDurationField("elapsed", time.Since(start)),
 						)
 						// sleep for a short duration before checking again
-						if err := misc.SleepCtx(pollCtx, m.c.inProgressPollSleep.Load()); err != nil {
+						if err := misc.SleepCtx(pollTimeoutCtx, m.c.inProgressPollSleep.Load()); err != nil {
 							return fmt.Errorf("sleeping while waiting for no in-progress jobs in %q jobsdb: %w", readerJobsDB.Identifier(), err)
 						}
 					}
@@ -300,7 +317,7 @@ func (m *migrator) onNewJob(ctx context.Context, key string, job *etcdtypes.Part
 					return client.NewMigrationJobExecutor(
 						job.JobID, m.nodeIndex, job.Partitions, db, target,
 						client.WithConfig(m.config),
-						client.WithLogger(m.logger),
+						client.WithLogger(log),
 						client.WithStats(m.stats),
 					).Run(jobCtx)
 				})

--- a/cluster/migrator/processor/sourcenode/sourcenode_migrator_test.go
+++ b/cluster/migrator/processor/sourcenode/sourcenode_migrator_test.go
@@ -402,6 +402,74 @@ func TestMigrator(t *testing.T) {
 			require.ElementsMatch(t, []string{"partition-1"}, rtExcluded)
 		})
 
+		t.Run("slow first in-progress query with no in-progress jobs does not shut down", func(t *testing.T) {
+			env := newHandleEnv(t)
+
+			// Use a timeout shorter than how long the in-progress query takes. This
+			// exercises the guarantee that the first query per jobsdb is exempt from
+			// the timeout (it runs against pollCtx, not the timeout context): even
+			// though each query outlives waitForInProgressTimeout, the query observes
+			// no in-progress jobs and Handle completes successfully without taking the
+			// shutdown path.
+			env.conf.Set("PartitionMigration.Processor.SourceNode.waitForInProgressTimeout", "200ms")
+
+			// Generate jobs in both jobsdbs but leave them unprocessed, so the
+			// in-progress poll (executing/importing) never finds any jobs.
+			require.NoError(t, env.gwJobsDB.Store(t.Context(), generateJobs(t, "partition-1", 10)))
+			require.NoError(t, env.rtJobsDB.Store(t.Context(), generateJobs(t, "partition-1", 10)))
+
+			// Wrap both jobsdbs so the in-progress poll query blocks for longer than
+			// the timeout, and count how many times each is polled.
+			mockGWJobsDB := &mockJobsDB{
+				JobsDB:              env.gwJobsDB,
+				inProgressPollDelay: 500 * time.Millisecond,
+			}
+			mockRTJobsDB := &mockJobsDB{
+				JobsDB:              env.rtJobsDB,
+				inProgressPollDelay: 500 * time.Millisecond,
+			}
+
+			// Create a migration job where this node is the source
+			migration := &etcdtypes.PartitionMigration{
+				ID:     "migration-5",
+				Status: etcdtypes.PartitionMigrationStatusNew,
+				Jobs: []*etcdtypes.PartitionMigrationJobHeader{
+					{
+						JobID:      "job-5",
+						SourceNode: env.nodeIndex,
+						TargetNode: 1,
+						Partitions: []string{"partition-1"},
+					},
+				},
+			}
+
+			shutdownCalled := false
+			m, err := NewMigratorBuilder(env.nodeIndex, "test-node").
+				WithConfig(env.conf).
+				WithReaderJobsDBs([]jobsdb.JobsDB{mockGWJobsDB, mockRTJobsDB}).
+				WithShutdown(func() { shutdownCalled = true }).
+				WithTargetURLProvider(func(targetNodeIndex int) (string, error) {
+					return "localhost:1234", nil
+				}).
+				WithEtcdClient(env.etcdClient).
+				Build()
+			require.NoError(t, err)
+
+			// Call Handle - should succeed even though the query outlives the timeout,
+			// because the first query is timeout-exempt and finds no in-progress jobs.
+			err = m.Handle(t.Context(), migration)
+			require.NoError(t, err, "Handle should complete successfully when no in-progress jobs are found")
+
+			// Verify shutdown was NOT called even though the query outlived the timeout.
+			require.False(t, shutdownCalled, "shutdown should not be called when no in-progress jobs are found")
+
+			// Each jobsdb must have executed its first (timeout-exempt) in-progress query.
+			require.GreaterOrEqual(t, int(mockGWJobsDB.inProgressPollCount.Load()), 1,
+				"gw should be polled for in-progress jobs at least once")
+			require.GreaterOrEqual(t, int(mockRTJobsDB.inProgressPollCount.Load()), 1,
+				"rt should be polled for in-progress jobs at least once")
+		})
+
 		t.Run("with jobsdb intermittent failures", func(t *testing.T) {
 			env := newHandleEnv(t)
 
@@ -968,6 +1036,9 @@ type mockJobsDB struct {
 	addReadExcludedPartitionIDsCount     atomic.Int32
 	addReadExcludedPartitionIDsFailCount int   // number of times AddReadExcludedPartitionIDs should fail before succeeding
 	addReadExcludedPartitionIDsErr       error // error to return when failing
+
+	inProgressPollCount atomic.Int32  // number of times Handle's in-progress poll queried this jobsdb
+	inProgressPollDelay time.Duration // delay injected into Handle's in-progress poll query
 }
 
 func (m *mockJobsDB) GetToProcess(ctx context.Context, params jobsdb.GetQueryParams, more jobsdb.MoreToken) (*jobsdb.MoreJobsResult, error) {
@@ -980,10 +1051,22 @@ func (m *mockJobsDB) GetToProcess(ctx context.Context, params jobsdb.GetQueryPar
 
 func (m *mockJobsDB) GetPendingConsumerJobs(ctx context.Context, states []string, params jobsdb.GetQueryParams) (jobsdb.JobsResult, error) {
 	// Handle's waitForNoInProgressJobs is the only caller that polls with the
-	// Importing state; the migration executor (Run path) never does. Inject
-	// failures only for the executor's reads so they exercise the Run/onNewJob
-	// retry path and leave Handle's in-progress poll untouched.
-	if !slices.Contains(states, jobsdb.Importing.State) {
+	// Importing state; the migration executor (Run path) never does.
+	if slices.Contains(states, jobsdb.Importing.State) {
+		// Handle's in-progress poll path. Count the query and optionally block
+		// it for inProgressPollDelay so a test can make the first (timeout-exempt)
+		// query outlive waitForInProgressTimeout.
+		m.inProgressPollCount.Add(1)
+		if m.inProgressPollDelay > 0 {
+			select {
+			case <-time.After(m.inProgressPollDelay):
+			case <-ctx.Done():
+				return jobsdb.JobsResult{}, ctx.Err()
+			}
+		}
+	} else {
+		// Inject failures only for the executor's reads so they exercise the
+		// Run/onNewJob retry path and leave Handle's in-progress poll untouched.
 		count := m.getToProcessCount.Add(1)
 		if m.getToProcessErr != nil && int(count) <= m.getToProcessFailCount {
 			return jobsdb.JobsResult{}, m.getToProcessErr


### PR DESCRIPTION
# Description

- The initial in-progress jobs poll is no longer bound by `waitForInProgressTimeout`, preventing a slow first query over large datasets from triggering an unnecessary server restart.
- Added additional log statements to make migration progress easier to track.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
