### PR TITLE
fix(jobsdb): compaction panics with pq error column js.consumer does not exist at position

### DIFF
--- a/sql/migrations/jobsdb/000014_multi_consumer_columns.up.tmpl
+++ b/sql/migrations/jobsdb/000014_multi_consumer_columns.up.tmpl
@@ -1,4 +1,5 @@
 {{range .Datasets}}
     ALTER TABLE "{{$.Prefix}}_jobs_{{.}}" ADD COLUMN IF NOT EXISTS consumers TEXT[] NOT NULL DEFAULT '{""}';
     ALTER TABLE "{{$.Prefix}}_job_status_{{.}}" ADD COLUMN IF NOT EXISTS consumer TEXT NOT NULL DEFAULT '';
+    CREATE OR REPLACE VIEW "v_last_{{$.Prefix}}_job_status_{{.}}" AS SELECT DISTINCT ON (job_id) * FROM "{{$.Prefix}}_job_status_{{.}}" ORDER BY job_id ASC, id DESC;
 {{end}}

--- a/sql/migrations/jobsdb_always/000016_multi_consumer_columns.up.tmpl
+++ b/sql/migrations/jobsdb_always/000016_multi_consumer_columns.up.tmpl
@@ -1,4 +1,5 @@
 {{range .Datasets}}
     ALTER TABLE "{{$.Prefix}}_jobs_{{.}}" ADD COLUMN IF NOT EXISTS consumers TEXT[] NOT NULL DEFAULT '{""}';
     ALTER TABLE "{{$.Prefix}}_job_status_{{.}}" ADD COLUMN IF NOT EXISTS consumer TEXT NOT NULL DEFAULT '';
+    CREATE OR REPLACE VIEW "v_last_{{$.Prefix}}_job_status_{{.}}" AS SELECT DISTINCT ON (job_id) * FROM "{{$.Prefix}}_job_status_{{.}}" ORDER BY job_id ASC, id DESC;
 {{end}}


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

# Description

Older `v_last` views were missing the consumer field. Adding it now during database migration.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
