### PR TITLE
chore: enable compression for google pubsub

### DIFF
--- a/services/streammanager/googlepubsub/googlepubsubmanager.go
+++ b/services/streammanager/googlepubsub/googlepubsubmanager.go
@@ -101,6 +101,7 @@ func NewProducer(destination *backendconfig.DestinationT, o common.Opts) (*Googl
 	for _, s := range pubsubConfig.EventToTopicMap {
 		topic := client.Publisher(s["to"])
 		topic.PublishSettings.NumGoroutines = config.GetIntVar(25, 1, "Router.GOOGLEPUBSUB.Client.NumGoroutines")
+		topic.PublishSettings.EnableCompression = config.GetBoolVar(false, "Router.GOOGLEPUBSUB.Client.EnableCompression")
 		topic.PublishSettings.DelayThreshold = config.GetDurationVar(10, time.Millisecond, "Router.GOOGLEPUBSUB.Client.DelayThreshold")
 		topic.PublishSettings.CountThreshold = config.GetIntVar(64, 1, "Router.GOOGLEPUBSUB.Client.CountThreshold", "Router.GOOGLEPUBSUB.noOfWorkers", "Router.noOfWorkers")
 		topic.PublishSettings.ByteThreshold = config.GetIntVar(int(10*bytesize.MB), 1, "Router.GOOGLEPUBSUB.Client.ByteThreshold")


### PR DESCRIPTION
# Description

Add a configuration option for enabling compression in google pubsub transport

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
