### PR TITLE
chore: support compression in bqstream destinations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96
+	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
@@ -362,7 +363,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect
 	golang.org/x/term v0.43.0 // indirect

--- a/services/streammanager/bqstream/bqstreammanager.go
+++ b/services/streammanager/bqstream/bqstreammanager.go
@@ -14,6 +14,7 @@ import (
 	gbq "google.golang.org/api/bigquery/v2"
 	"google.golang.org/api/option"
 
+	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/googleutil"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -76,28 +77,40 @@ func init() {
 }
 
 func NewProducer(destination *backendconfig.DestinationT, o common.Opts) (*BQStreamProducer, error) {
-	var config Config
+	var destConf Config
 	jsonConfig, err := jsonrs.Marshal(destination.Config)
 	if err != nil {
 		return nil, fmt.Errorf("[BQStream] Error while marshalling destination config :: %w", err)
 	}
-	err = jsonrs.Unmarshal(jsonConfig, &config)
+	err = jsonrs.Unmarshal(jsonConfig, &destConf)
 	if err != nil {
 		return nil, createErr(err, "error in BQStream while unmarshalling destination config")
 	}
+	ctx := context.Background()
 	opts := []option.ClientOption{
 		option.WithScopes([]string{
 			gbq.BigqueryInsertdataScope,
 		}...),
 	}
-	if !googleutil.ShouldSkipCredentialsInit(config.Credentials) {
-		confCreds := []byte(config.Credentials)
+	if !googleutil.ShouldSkipCredentialsInit(destConf.Credentials) {
+		confCreds := []byte(destConf.Credentials)
 		if err = googleutil.CompatibleServiceAccountJSON(confCreds); err != nil {
 			return nil, createErr(err, "incompatible credentials")
 		}
 		opts = append(opts, option.WithAuthCredentialsJSON(option.ServiceAccount, confCreds))
 	}
-	bqClient, err := bigquery.NewClient(context.Background(), config.ProjectId, opts...)
+	// Always supply our own HTTP client so the connection pool is tuned to the
+	// number of router workers (see baseTransport). When enabled, it also gzip-
+	// compresses the streaming insert request bodies over the wire; the BigQuery
+	// insertAll endpoint accepts gzipped bodies via Content-Encoding: gzip
+	// (see https://github.com/googleapis/google-cloud-go/issues/1919).
+	compress := config.GetBoolVar(false, "Router.BQSTREAM.enableCompression")
+	httpClient, err := newHTTPClient(ctx, compress, opts...)
+	if err != nil {
+		return nil, createErr(err, "error while creating http client")
+	}
+	opts = append(opts, option.WithHTTPClient(httpClient))
+	bqClient, err := bigquery.NewClient(ctx, destConf.ProjectId, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/services/streammanager/bqstream/bqstreammanager_client.go
+++ b/services/streammanager/bqstream/bqstreammanager_client.go
@@ -1,0 +1,130 @@
+package bqstream
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"golang.org/x/net/http2"
+	"google.golang.org/api/option"
+	htransport "google.golang.org/api/transport/http"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+)
+
+// newHTTPClient returns the HTTP client used by the BigQuery client. It always
+// applies our tuned base transport (see baseTransport) and, when compress is
+// true, gzip-compresses request bodies. The standard Google authentication
+// middleware is preserved by building the transport via htransport.NewTransport.
+func newHTTPClient(ctx context.Context, compress bool, opts ...option.ClientOption) (*http.Client, error) {
+	base := baseTransport()
+	var rt http.RoundTripper = base
+	if compress {
+		rt = &gzipTransport{base: base}
+	}
+	authedTransport, err := htransport.NewTransport(ctx, rt, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Client{Transport: authedTransport}, nil
+}
+
+// baseTransport mirrors the defaults the Google API HTTP client applies in
+// google.golang.org/api/transport/http (defaultBaseTransport): a clone of
+// http.DefaultTransport with a larger idle-connection pool and HTTP/2 idle
+// connection health checks. Supplying our own client via option.WithHTTPClient
+// bypasses that setup, so we replicate it here to avoid regressing throughput
+// and connection resilience. (mTLS/S2A dial options are not reproduced, as they
+// depend on the library's internal settings.)
+//
+// The idle-connection pool is sized to the configured number of router workers,
+// consistent with the other stream managers and the HTTP router (services that
+// build their own transport all tune these to noOfWorkers).
+func baseTransport() *http.Transport {
+	// Clone http.DefaultTransport when possible; if it has been replaced by
+	// something that is not an *http.Transport, fall back to an equivalent one,
+	// mirroring defaultBaseTransport/fallbackBaseTransport in the Google library.
+	trans := clonedDefaultTransport()
+	if trans == nil {
+		trans = fallbackBaseTransport()
+	}
+	trans.MaxIdleConns = config.GetIntVar(64, 1, "Router.BQSTREAM.httpMaxIdleConns", "Router.BQSTREAM.noOfWorkers", "Router.noOfWorkers")
+	trans.MaxIdleConnsPerHost = config.GetIntVar(64, 1, "Router.BQSTREAM.httpMaxIdleConnsPerHost", "Router.BQSTREAM.noOfWorkers", "Router.noOfWorkers")
+	if http2Trans, err := http2.ConfigureTransports(trans); err == nil {
+		http2Trans.ReadIdleTimeout = 31 * time.Second
+	}
+	return trans
+}
+
+// clonedDefaultTransport returns a clone of http.DefaultTransport, or nil if it
+// is not an *http.Transport (e.g. it has been overridden in the process).
+func clonedDefaultTransport() *http.Transport {
+	t, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil
+	}
+	return t.Clone()
+}
+
+// fallbackBaseTransport mirrors the Google library's fallbackBaseTransport, used
+// when http.DefaultTransport is not an *http.Transport we can clone.
+func fallbackBaseTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
+// gzipTransport is an http.RoundTripper that gzip-compresses the request body and
+// sets the Content-Encoding header before delegating to the underlying transport.
+type gzipTransport struct {
+	base http.RoundTripper
+}
+
+func (t *gzipTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Nothing to compress, or the body is already encoded: pass through untouched.
+	if req.Body == nil || req.Body == http.NoBody || req.Header.Get("Content-Encoding") != "" {
+		return t.base.RoundTrip(req)
+	}
+
+	body, err := io.ReadAll(req.Body)
+	closeErr := req.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err = gz.Write(body); err != nil {
+		return nil, err
+	}
+	if err = gz.Close(); err != nil {
+		return nil, err
+	}
+	compressed := buf.Bytes()
+
+	// Per the RoundTripper contract we must not modify the caller's request.
+	newReq := req.Clone(req.Context())
+	newReq.Body = io.NopCloser(bytes.NewReader(compressed))
+	newReq.ContentLength = int64(len(compressed))
+	newReq.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(compressed)), nil
+	}
+	newReq.Header.Set("Content-Encoding", "gzip")
+	return t.base.RoundTrip(newReq)
+}

--- a/services/streammanager/bqstream/bqstreammanager_gzip_test.go
+++ b/services/streammanager/bqstream/bqstreammanager_gzip_test.go
@@ -1,0 +1,86 @@
+package bqstream
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGzipTransport covers the gzipTransport RoundTripper. It is self-contained
+// (no BigQuery credentials required) so it always runs in CI.
+func TestGzipTransport(t *testing.T) {
+	type capture struct {
+		contentEncoding string
+		body            []byte
+	}
+
+	// roundTrip sends the request built by newReq through a gzipTransport-backed
+	// client to a throwaway server, returning what the server actually received.
+	roundTrip := func(t *testing.T, newReq func(url string) *http.Request) capture {
+		t.Helper()
+		var got capture
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got.contentEncoding = r.Header.Get("Content-Encoding")
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			got.body = body
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		client := &http.Client{Transport: &gzipTransport{base: http.DefaultTransport}}
+		resp, err := client.Do(newReq(srv.URL))
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		return got
+	}
+
+	t.Run("compresses the request body", func(t *testing.T) {
+		payload := `{"properties":{"id":"25","name":"rudder"}}`
+		got := roundTrip(t, func(url string) *http.Request {
+			req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(payload))
+			require.NoError(t, err)
+			return req
+		})
+
+		require.Equal(t, "gzip", got.contentEncoding)
+		gr, err := gzip.NewReader(bytes.NewReader(got.body))
+		require.NoError(t, err)
+		defer func() { _ = gr.Close() }()
+		decompressed, err := io.ReadAll(gr)
+		require.NoError(t, err)
+		require.Equal(t, payload, string(decompressed))
+	})
+
+	t.Run("passes through bodiless requests", func(t *testing.T) {
+		got := roundTrip(t, func(url string) *http.Request {
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			require.NoError(t, err)
+			return req
+		})
+
+		require.Empty(t, got.contentEncoding)
+		require.Empty(t, got.body)
+	})
+
+	t.Run("passes through already-encoded requests", func(t *testing.T) {
+		payload := "already-encoded-body"
+		got := roundTrip(t, func(url string) *http.Request {
+			req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(payload))
+			require.NoError(t, err)
+			req.Header.Set("Content-Encoding", "custom")
+			return req
+		})
+
+		// The body must be forwarded untouched (not re-compressed).
+		require.Equal(t, "custom", got.contentEncoding)
+		require.Equal(t, payload, string(got.body))
+	})
+}

--- a/services/streammanager/bqstream/bqstreammanager_test.go
+++ b/services/streammanager/bqstream/bqstreammanager_test.go
@@ -1,15 +1,20 @@
 package bqstream_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
 	"time"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/api/option"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
@@ -19,6 +24,7 @@ import (
 	mock_bqstream "github.com/rudderlabs/rudder-server/mocks/services/streammanager/bqstream"
 	"github.com/rudderlabs/rudder-server/services/streammanager/bqstream"
 	"github.com/rudderlabs/rudder-server/services/streammanager/common"
+	bqhelper "github.com/rudderlabs/rudder-server/warehouse/integrations/bigquery/testhelper"
 )
 
 type BigQueryCredentials struct {
@@ -36,58 +42,101 @@ func initBQTest() {
 	})
 }
 
-func TestTimeout(t *testing.T) {
+// TestBQStreamIntegration exercises the producer against real BigQuery. It
+// provisions an isolated dataset + table for the run and tears them down
+// afterwards, then covers three scenarios: a timeout, a successful uncompressed
+// insert and a successful gzip-compressed insert.
+func TestBQStreamIntegration(t *testing.T) {
 	initBQTest()
-	cred := os.Getenv("BIGQUERY_INTEGRATION_TEST_USER_CRED")
-	if cred == "" {
-		t.Skip("Skipping bigquery test, since no credentials are available in the environment")
-	}
-	var bqCredentials BigQueryCredentials
-	var err error
-	err = jsonrs.Unmarshal([]byte(cred), &bqCredentials)
-	if err != nil {
-		t.Fatalf("could not unmarshal BIGQUERY_INTEGRATION_TEST_USER_CRED: %s", err)
-	}
-	credentials, _ := jsonrs.Marshal(bqCredentials.Credentials)
-	config := map[string]any{
-		"Credentials": string(credentials),
-		"ProjectId":   bqCredentials.ProjectID,
-	}
-	destination := backendconfig.DestinationT{Config: config}
-	opts := common.Opts{Timeout: 1 * time.Microsecond}
-	producer, err := bqstream.NewProducer(&destination, opts)
-	if err != nil {
-		t.Errorf(" %+v", err)
-		return
-	}
 
-	assert.NotNil(t, producer.Client)
-	assert.Equal(t, opts, producer.Opts)
-
-	payload := `{
-		"datasetId": "timeout_test",
-		"tableId": "rudder",
-		"properties": {
-			"key": "key",
-			"value": "value"
+	if _, exists := os.LookupEnv(bqhelper.TestKey); !exists {
+		if os.Getenv("FORCE_RUN_INTEGRATION_TESTS") == "true" {
+			t.Fatalf("%s environment variable not set", bqhelper.TestKey)
 		}
-	}`
-	statusCode, respStatus, responseMessage := producer.Produce([]byte(payload), nil)
+		t.Skipf("Skipping %s as %s is not set", t.Name(), bqhelper.TestKey)
+	}
+	credentials, err := bqhelper.GetBQTestCredentials()
+	require.NoError(t, err)
 
-	const expectedStatusCode = 504
-	if statusCode != expectedStatusCode {
-		t.Errorf("Expected status code %d, got %d.", expectedStatusCode, statusCode)
+	location := credentials.Location
+	if location == "" {
+		location = "US"
 	}
 
-	const expectedRespStatus = "Failure"
-	if respStatus != expectedRespStatus {
-		t.Errorf("Expected response status %s, got %s.", expectedRespStatus, respStatus)
+	ctx := context.Background()
+
+	// Admin client used only to create and tear down the test fixtures.
+	adminClient, err := bigquery.NewClient(ctx, credentials.ProjectID, option.WithAuthCredentialsJSON(option.ServiceAccount, []byte(credentials.Credentials)))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = adminClient.Close() })
+
+	datasetID := fmt.Sprintf("bqstream_integration_test_%d", time.Now().UnixNano())
+	const tableID = "streaming"
+	require.NoError(t, adminClient.Dataset(datasetID).Create(ctx, &bigquery.DatasetMetadata{Location: location}))
+	t.Cleanup(func() { _ = adminClient.Dataset(datasetID).DeleteWithContents(context.Background()) })
+	require.NoError(t, adminClient.Dataset(datasetID).Table(tableID).Create(ctx, &bigquery.TableMetadata{
+		Schema: bigquery.Schema{
+			{Name: "id", Type: bigquery.StringFieldType},
+			{Name: "name", Type: bigquery.StringFieldType},
+		},
+	}))
+
+	destinationConfig := map[string]any{
+		"Credentials": credentials.Credentials,
+		"ProjectId":   credentials.ProjectID,
+	}
+	payload := fmt.Sprintf(`{"datasetId":%q,"tableId":%q,"properties":{"id":"25","name":"rudder"}}`, datasetID, tableID)
+
+	newProducer := func(t *testing.T, compression bool, timeout time.Duration) *bqstream.BQStreamProducer {
+		t.Helper()
+		config.Set("Router.BQSTREAM.enableCompression", compression)
+		t.Cleanup(func() { config.Set("Router.BQSTREAM.enableCompression", false) })
+
+		destination := backendconfig.DestinationT{Config: destinationConfig}
+		opts := common.Opts{Timeout: timeout}
+		producer, err := bqstream.NewProducer(&destination, opts)
+		require.NoError(t, err)
+		require.NotNil(t, producer.Client)
+		require.Equal(t, opts, producer.Opts)
+		t.Cleanup(func() { _ = producer.Close() })
+		return producer
 	}
 
-	const expectedResponseMessage = "[BQStream] error :: timeout in data insertion:: context deadline exceeded"
-	if responseMessage != expectedResponseMessage {
-		t.Errorf("Expected response message %s, got %s.", expectedResponseMessage, responseMessage)
+	// A freshly created table's streaming buffer can take a moment to warm up, so
+	// retry transient failures before asserting the insert succeeded.
+	produceUntilSuccess := func(t *testing.T, producer *bqstream.BQStreamProducer) {
+		t.Helper()
+		var statusCode int
+		var respStatus, responseMessage string
+		deadline := time.Now().Add(90 * time.Second)
+		for {
+			statusCode, respStatus, responseMessage = producer.Produce([]byte(payload), nil)
+			if statusCode == 200 || time.Now().After(deadline) {
+				break
+			}
+			t.Logf("retrying insert, got %d %s: %s", statusCode, respStatus, responseMessage)
+			time.Sleep(3 * time.Second)
+		}
+		assert.Equal(t, 200, statusCode, responseMessage)
+		assert.Equal(t, "Success", respStatus)
+		assert.NotEmpty(t, responseMessage)
 	}
+
+	t.Run("timeout", func(t *testing.T) {
+		producer := newProducer(t, false, 1*time.Microsecond)
+		statusCode, respStatus, responseMessage := producer.Produce([]byte(payload), nil)
+		assert.Equal(t, 504, statusCode)
+		assert.Equal(t, "Failure", respStatus)
+		assert.Equal(t, "[BQStream] error :: timeout in data insertion:: context deadline exceeded", responseMessage)
+	})
+
+	t.Run("without compression", func(t *testing.T) {
+		produceUntilSuccess(t, newProducer(t, false, 30*time.Second))
+	})
+
+	t.Run("with compression", func(t *testing.T) {
+		produceUntilSuccess(t, newProducer(t, true, 30*time.Second))
+	})
 }
 
 func TestUnsupportedCredentials(t *testing.T) {


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

# Description

This PR improves the BigQuery streaming (bqstream) destination's transport:

- **Optional payload compression during transport** — it is now possible to gzip-compress the payloads we send to BigQuery over the wire, reducing egress bandwidth. It is opt-in via configuration and disabled by default.
- **Reuse the client as configured by Google** — rather than replacing the HTTP client, we build on top of the client/transport that the Google API library configures, so its authentication and connection defaults are preserved.
- **Worker-based connection pool tuning** — we override the maximum idle connections based on the configured number of workers, consistent with how the other stream managers already tune their pools.


The destination is now exercised through real integration tests against BigQuery.

## Linear Ticket

resolves PIPE-3163

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
