### PR TITLE
fix(router): transformer returning response with empty metadata array causes server to panic

### DIFF
--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -310,6 +310,7 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 		in := transformMessage.JobIDs()
 		var out []int64
 		invalid := make(map[int64]struct{}) // invalid jobIDs are the ones that are in the response but were not included in the request
+		emptyMetadataCount := 0
 		for i := range destinationJobs {
 			if oauthv2.IsValidAuthErrorCategory(destinationJobs[i].AuthErrorCategory) {
 				if transResp.InterceptorResponse.StatusCode > 0 {
@@ -318,6 +319,9 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 				if transResp.InterceptorResponse.Response != "" {
 					destinationJobs[i].Error = transResp.InterceptorResponse.Response
 				}
+			}
+			if len(destinationJobs[i].JobMetadataArray) == 0 {
+				emptyMetadataCount++
 			}
 			for k, v := range destinationJobs[i].JobIDs() {
 				out = append(out, k)
@@ -333,6 +337,9 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 		} else if len(in) != len(out) {
 			invalidResponseReason = "in out mismatch"
 			invalidResponseError = fmt.Sprintf("Transformer returned invalid output size: %d for input size: %d", len(out), len(in))
+		} else if emptyMetadataCount > 0 {
+			invalidResponseReason = "empty metadata array"
+			invalidResponseError = fmt.Sprintf("Transformer returned %d destination job(s) with an empty metadata array for input: %s", emptyMetadataCount, string(rawJSON))
 		} else if len(invalid) > 0 {
 			var invalidSlice []int64
 			for k := range invalid {


### PR DESCRIPTION
# Description

A malformed transformer response containing a destination job with an empty metadata array could slip past validation and crash the server with an index-out-of-range panic. 
We are now failing the batch instead (triggering the existing retry path) and we're relyingon the existing `router_transformer_invalid_response` counter for alerting.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.