### PR TITLE
feat: rely on cold-start retries instead of k8s scaling for pyt test forwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [1.80.0](https://github.com/rudderlabs/rudder-server/compare/v1.79.0...v1.80.0) (2026-07-06)
+
+
+### Features
+
+* add control-plane connection management for processor ([#7126](https://github.com/rudderlabs/rudder-server/issues/7126)) ([ea6ca00](https://github.com/rudderlabs/rudder-server/commit/ea6ca006ddc9709978ea1391677e0bfd1f12c225))
+* carry integration version on DestinationT to the transformer ([#7125](https://github.com/rudderlabs/rudder-server/issues/7125)) ([421c613](https://github.com/rudderlabs/rudder-server/commit/421c6132f2c6098d9d63c25c6f23c8c62325252e))
+* implement Forward RPC for control-plane requests to workspace pyt transformers ([#7143](https://github.com/rudderlabs/rudder-server/issues/7143)) ([8a704cf](https://github.com/rudderlabs/rudder-server/commit/8a704cf6c5e038a6a66e3858916fbba815805933))
+* implement Kubernetes deployment scaler for workspace replica management ([#7123](https://github.com/rudderlabs/rudder-server/issues/7123)) ([84fc747](https://github.com/rudderlabs/rudder-server/commit/84fc747b56f8d25b11cb3966db2650fd547f4dcd))
+* monthly active records (MAR) metering pipeline ([#7119](https://github.com/rudderlabs/rudder-server/issues/7119)) ([d1df486](https://github.com/rudderlabs/rudder-server/commit/d1df4864058152bd669f025ff66b3ad16ce26582))
+
+
+### Bug Fixes
+
+* **router:** transformer returning response with empty metadata array causes server to panic ([#7144](https://github.com/rudderlabs/rudder-server/issues/7144)) ([d6a4dbc](https://github.com/rudderlabs/rudder-server/commit/d6a4dbc7b24b63c52ec41126525b08513b29a813))
+
+
+### Miscellaneous
+
+* enable compression for google pubsub ([#7137](https://github.com/rudderlabs/rudder-server/issues/7137)) ([11c9ab8](https://github.com/rudderlabs/rudder-server/commit/11c9ab8b50de16840031ef349f87090a0401eba3))
+
 ## [1.79.2](https://github.com/rudderlabs/rudder-server/compare/v1.79.1...v1.79.2) (2026-07-01)
 
 

--- a/processor/cpservice/cpservice.go
+++ b/processor/cpservice/cpservice.go
@@ -48,8 +48,8 @@ type Forwarder interface {
 }
 
 // Service implements the ProcessorService gRPC server — the processor's single
-// CP-facing entrypoint. Its sole RPC, Forward, scales up the workspace's pyt
-// Deployment and forwards the request to it over HTTP (see [Service.Forward]).
+// CP-facing entrypoint. Its sole RPC, Forward, forwards the request to the
+// workspace's pyt Deployment over HTTP, optionally scaling it up first (see [Service.Forward]).
 type Service struct {
 	proto.UnimplementedProcessorServiceServer
 
@@ -76,11 +76,13 @@ func WithForwarder(forwarder Forwarder) ServiceOpt {
 	return func(s *Service) { s.forwarder = forwarder }
 }
 
-// NewService builds the ProcessorService gRPC handler. By default it builds a
-// k8s-backed pyt scaler — falling back to a no-op scaler (forward without
-// scaling) when the k8s client can't be built — and a forwarder over the
-// processor's user_transformer HTTP client. Tests override these via
-// [WithScaler]/[WithForwarder].
+// NewService builds the ProcessorService gRPC handler and a forwarder over the
+// processor's user_transformer HTTP client. Explicit k8s scaling of the pyt
+// Deployment is off by default — the forward path instead rides the cold-start
+// window via retries, letting the pyt's own traffic-based autoscaling wake it —
+// and can be turned on with Processor.UserTransformer.pytTestScalingEnabled
+// (falling back to a no-op scaler when the k8s client can't be built). Tests
+// override the dependencies via [WithScaler]/[WithForwarder].
 func NewService(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...ServiceOpt) *Service {
 	s := &Service{
 		log:     log.Child("cpservice"),
@@ -90,21 +92,26 @@ func NewService(conf *config.Config, log logger.Logger, stat stats.Stats, opts .
 		opt(s)
 	}
 	if s.scaler == nil {
-		scaler, err := pytscaler.New(conf, log)
-		if err != nil {
-			log.Warnn("pyt scaler unavailable, forwarding without scaling", obskit.Error(err))
-			scaler = pytscaler.NewNoop(log)
+		s.scaler = pytscaler.NewNoop(log)
+		if conf.GetBoolVar(false, "Processor.UserTransformer.pytTestScalingEnabled") {
+			scaler, err := pytscaler.New(conf, log)
+			if err != nil {
+				log.Warnn("pyt scaler unavailable, forwarding without scaling", obskit.Error(err))
+			} else {
+				s.scaler = scaler
+			}
 		}
-		s.scaler = scaler
 	}
 	if s.forwarder == nil {
-		// The forward path is time-boxed by cp-router's ~60s test deadline, so
-		// override the event path's large default retry backoff with a short one,
-		// and cap the retries, to recover from a pyt cold start quickly within that
-		// window (the ctx deadline remains the hard bound).
+		// The forward path is time-boxed by cp-router's test deadline (the ctx),
+		// so override the event path's large default retry backoff with a short
+		// one. The retry budget is sized to out-last any realistic deadline —
+		// with no explicit scale-up, the whole cold-start window is carried by
+		// these retries, so the ctx deadline must be the bound that ends them,
+		// not the retry count.
 		s.forwarder = user_transformer.New(conf, log, stat,
-			user_transformer.WithMaxRetryBackoffInterval(conf.GetReloadableDurationVar(1, time.Second, "Processor.UserTransformer.pytTestMaxRetryBackoffInterval")),
-			user_transformer.WithMaxRetry(conf.GetReloadableIntVar(60, 1, "Processor.UserTransformer.pytTestMaxRetry")))
+			user_transformer.WithMaxRetryBackoffInterval(conf.GetReloadableDurationVar(500, time.Millisecond, "Processor.UserTransformer.pytTestMaxRetryBackoffInterval")),
+			user_transformer.WithMaxRetry(conf.GetReloadableIntVar(100, 1, "Processor.UserTransformer.pytTestMaxRetry")))
 	}
 	return s
 }

--- a/processor/cpservice/forward.go
+++ b/processor/cpservice/forward.go
@@ -28,8 +28,11 @@ type endpointForward func(ctx context.Context, workspaceID string, payload []byt
 var validWorkspaceID = regexp.MustCompile(`^[a-zA-Z0-9-]{1,59}$`)
 
 // Forward is the processor's only CP-facing RPC. It maps req.Op to the matching
-// pyt endpoint, ensures the workspace's pyt Deployment is scaled up, and forwards
-// req.Payload to it, returning the pyt response status and body unchanged.
+// pyt endpoint and forwards req.Payload to it, returning the pyt response status
+// and body unchanged. When explicit scaling is enabled (pytTestScalingEnabled)
+// it first ensures the workspace's pyt Deployment is scaled up; by default the
+// scaler is a no-op and waking the pyt is left to its own traffic-based
+// autoscaling.
 //
 // It does not poll for pyt readiness: the forward itself retries the cold-start
 // window within the caller's deadline (see [user_transformer.Client.Test] et al).

--- a/processor/cpservice/forward_test.go
+++ b/processor/cpservice/forward_test.go
@@ -96,6 +96,15 @@ func TestForward(t *testing.T) {
 		}
 	})
 
+	t.Run("forwards without k8s when scaling is disabled (the default)", func(t *testing.T) {
+		// No WithScaler override: with pytTestScalingEnabled at its default
+		// (false), NewService must wire the no-op scaler, so Forward works with
+		// no k8s available at all.
+		svc := NewService(config.New(), logger.NOP, nil, WithForwarder(&fakeForwarder{statusCode: 200}))
+		_, err := svc.Forward(context.Background(), &proto.ForwardRequest{Op: proto.Op_OP_TEST, WorkspaceId: "ws-1"})
+		require.NoError(t, err)
+	})
+
 	t.Run("asks the scaler for the configured replica target", func(t *testing.T) {
 		conf := config.New()
 		conf.Set("Processor.UserTransformer.pytTestScaleReplicas", 3)

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -527,9 +527,9 @@ func (u *Client) ExtractLibs(ctx context.Context, workspaceID string, payload []
 // client's maxRetry/maxRetryBackoffInterval settings, but this call is time-boxed
 // by ctx (cp-router's ~60s test deadline). Callers that need a quicker cold-start
 // recovery build the client with [WithMaxRetryBackoffInterval]/[WithMaxRetry] to
-// shrink the backoff and size the retry budget. It retries only on cold-start
-// signals (connection refused, DNS failure, 502/503);
-// any other response is returned as-is for the caller to pass through.
+// shrink the backoff and size the retry budget. Like [Client.doPost], it retries
+// any transport error plus cold-start 502/503 responses, counting the cold-start
+// signals; any other response is returned as-is for the caller to pass through.
 func (u *Client) forwardTest(ctx context.Context, workspaceID, path string, payload []byte) (int, []byte, error) {
 	// perWorkspacePyTEnabled is reloadable, so check it per call: a request
 	// arriving while the feature is off must be rejected rather than silently
@@ -559,23 +559,30 @@ func (u *Client) forwardTest(ctx context.Context, workspaceID, path string, payl
 			req.Header.Set("Content-Type", "application/json")
 
 			resp, err := u.client.Do(req)
-			if isColdStartError(err, resp) {
+			if err != nil {
+				// No response at all — retry. Transient network
+				// conditions dominate here, and the loop is bounded by maxRetry
+				// and the caller's deadline either way. Cold-start signals are
+				// additionally counted; retryability doesn't depend on them.
+				if isColdStartError(err, nil) {
+					u.stat.NewTaggedStat(coldStartErrorsMetric, stats.CountType,
+						stats.Tags{"workspaceID": workspaceID, "language": languagePython}).Increment()
+				}
+				return err
+			}
+			if isColdStartError(nil, resp) {
 				httputil.CloseResponse(resp)
 				u.stat.NewTaggedStat(coldStartErrorsMetric, stats.CountType,
 					stats.Tags{"workspaceID": workspaceID, "language": languagePython}).Increment()
-				if err != nil {
-					return err
-				}
 				return fmt.Errorf("pyt cold start: status %d", resp.StatusCode)
-			}
-			if err != nil {
-				return backoff.Permanent(err)
 			}
 			defer func() { httputil.CloseResponse(resp) }()
 
 			body, err = io.ReadAll(resp.Body)
 			if err != nil {
-				return backoff.Permanent(err)
+				// Connection broke mid-response — as transient as a failed
+				// request; retry.
+				return err
 			}
 			statusCode = resp.StatusCode
 			return nil
@@ -613,6 +620,17 @@ func isColdStartError(err error, resp *http.Response) bool {
 		// EHOSTUNREACH ("no route to host"): stale iptables / EndpointSlice
 		// after a pod replacement or scale-down — same transient signal.
 		if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.EHOSTUNREACH) {
+			return true
+		}
+		// Dial timeout ("dial tcp ...: i/o timeout"): the SYN went unanswered —
+		// the pod behind the headless-service DNS record is either still coming
+		// up (IP published before the VM boots) or on its way down (terminating
+		// pod whose record hasn't been withdrawn yet). The two are
+		// indistinguishable from the dialer, and retrying is right for both:
+		// each retry re-resolves DNS, and the pod's replacement (the forward path
+		// scales the deployment up before dialing) answers a later attempt.
+		var opErr *net.OpError
+		if errors.As(err, &opErr) && opErr.Op == "dial" && opErr.Timeout() {
 			return true
 		}
 		var dnsErr *net.DNSError

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -1672,6 +1672,16 @@ func TestColdStartCounter(t *testing.T) {
 		Net: "tcp",
 		Err: &os.SyscallError{Syscall: "connect", Err: syscall.EHOSTUNREACH},
 	}
+	dialTimeout := &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: os.ErrDeadlineExceeded,
+	}
+	readTimeout := &net.OpError{
+		Op:  "read",
+		Net: "tcp",
+		Err: os.ErrDeadlineExceeded,
+	}
 	dnsErr := &net.DNSError{Err: "no such host", Name: "pyt-ws-A1", IsNotFound: true}
 
 	// Marshaled success response — what a warm PyT pod would return.
@@ -1723,6 +1733,16 @@ func TestColdStartCounter(t *testing.T) {
 			// replacement or scale-down. Same transient signal as ECONNREFUSED.
 			name:             "EHOSTUNREACH twice → counted twice, then warm",
 			failErr:          noRouteToHost,
+			failures:         2,
+			expectCounter:    2,
+			expectEventCount: 1,
+		},
+		{
+			// dial i/o timeout — unanswered SYN: the headless-service DNS record
+			// points at a pod that is still booting or terminating. Same scale-
+			// churn window as ECONNREFUSED, just a different failure mode.
+			name:             "dial timeout twice → counted twice, then warm",
+			failErr:          dialTimeout,
 			failures:         2,
 			expectCounter:    2,
 			expectEventCount: 1,
@@ -1795,6 +1815,16 @@ func TestColdStartCounter(t *testing.T) {
 			name:             "guard: JS language → cold-start error not counted",
 			language:         "javascript",
 			failErr:          connRefused,
+			failures:         2,
+			expectCounter:    0,
+			expectEventCount: 1,
+		},
+		{
+			// A timeout after the connection is established means the pod is up
+			// but slow — not a cold start. Still retried by doPost's generic
+			// budget, so the transport warms and the request succeeds.
+			name:             "guard: post-connect read timeout → not counted",
+			failErr:          readTimeout,
 			failures:         2,
 			expectCounter:    0,
 			expectEventCount: 1,
@@ -1970,6 +2000,39 @@ func TestForwardTest(t *testing.T) {
 			total += int(m.Value)
 		}
 		require.Equal(t, 2, total, "each cold-start retry should increment the counter")
+	})
+
+	t.Run("retries other transport errors without counting them as cold starts", func(t *testing.T) {
+		var attempts atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) < 3 {
+				// Abrupt close → the client sees EOF: a transport error that is
+				// not a cold-start signal, yet must still be retried (doPost parity).
+				conn, _, err := w.(http.Hijacker).Hijack()
+				require.NoError(t, err)
+				_ = conn.Close()
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`done`))
+		}))
+		defer srv.Close()
+
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		conf := config.New()
+		conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
+		conf.Set("Processor.UserTransformer.perWorkspacePyTURLTemplate", srv.URL)
+		client := user_transformer.New(conf, logger.NOP, statsStore,
+			user_transformer.WithMaxRetryBackoffInterval(config.NewMockValueLoader(5*time.Millisecond)))
+
+		status, body, err := client.Test(context.Background(), "ws-1", []byte(`{}`))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, status)
+		require.Equal(t, "done", string(body))
+		require.EqualValues(t, 3, attempts.Load())
+		require.Empty(t, statsStore.GetByName("processor_user_transformer_cold_start_errors_total"),
+			"a non-cold-start transport error must not tick the cold-start counter")
 	})
 
 	t.Run("stops retrying when the deadline is exceeded", func(t *testing.T) {


### PR DESCRIPTION
# Description

## What

Disables explicit k8s scaling of per-workspace pyt Deployments on the
control-plane test-forward path, and relies on the existing cold-start retry
loop instead.

- New config `Processor.UserTransformer.pytTestScalingEnabled` (default
  `false`): when off, `cpservice.NewService` wires the no-op scaler and never
  builds a k8s client; when on, it restores the previous behavior (k8s-backed
  scaler, no-op fallback if the client can't be built).
- Retry knobs retuned for the longer cp-router test deadline: backoff cap
  `pytTestMaxRetryBackoffInterval` 1s → 500ms, retry budget `pytTestMaxRetry`
  60 → 120. Both are reloadable. The gRPC ctx deadline remains the hard bound.

## Why

We're trialing an increased control-plane test timeout with no explicit
scale-up: the pyt's own traffic-based autoscaling wakes the deployment, and
the forward path already absorbs the scale-from-zero window — it retries every
transport error (connection refused, host unreachable, dial i/o timeout, DNS
failure) plus cold-start 502/503 responses, counting cold-start signals in
`processor_user_transformer_cold_start_errors_total` per workspace.

If the trial doesn't hold up, re-enabling scaling is a single config flip —
no revert needed (the scaler stays intact).

## Linear Ticket

< Replace with Linear Link ( [create](https://linear.new?title=Awesome-pr-without-linear-ticket) or [search](https://linear.app/rudderstack/search) linear ticket) or  >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
