### PR TITLE
fix: classify reverse-ETL sources from config for MAR metering

### DIFF
--- a/enterprise/activationrecords/noop.go
+++ b/enterprise/activationrecords/noop.go
@@ -17,7 +17,7 @@ func NewNoopActivationRecordsReporter() *NoopActivationRecordsReporter {
 	return &NoopActivationRecordsReporter{}
 }
 
-func (n *NoopActivationRecordsReporter) GenerateReportsFromJobs([]*jobsdb.JobT, func(sourceID string) string) []*ActivationRecord {
+func (n *NoopActivationRecordsReporter) GenerateReportsFromJobs([]*jobsdb.JobT, map[string]string) []*ActivationRecord {
 	return nil
 }
 

--- a/enterprise/activationrecords/noop.go
+++ b/enterprise/activationrecords/noop.go
@@ -17,7 +17,7 @@ func NewNoopActivationRecordsReporter() *NoopActivationRecordsReporter {
 	return &NoopActivationRecordsReporter{}
 }
 
-func (n *NoopActivationRecordsReporter) GenerateReportsFromJobs([]*jobsdb.JobT) []*ActivationRecord {
+func (n *NoopActivationRecordsReporter) GenerateReportsFromJobs([]*jobsdb.JobT, func(sourceID string) string) []*ActivationRecord {
 	return nil
 }
 

--- a/enterprise/activationrecords/records_reporter.go
+++ b/enterprise/activationrecords/records_reporter.go
@@ -35,8 +35,8 @@ const (
 
 	// retlSourceCategory is the SourceDefinition.Category of reverse-ETL ("warehouse
 	// actions") sources. MAR meters activation records from these sources only; the
-	// classification is resolved from the source's config category (via the lookup passed
-	// to GenerateReportsFromJobs), not from the job's source_category param.
+	// classification is resolved from the source's config category (via the source_id ->
+	// category map passed to GenerateReportsFromJobs), not from the job's source_category param.
 	retlSourceCategory = "warehouse"
 )
 
@@ -67,7 +67,7 @@ type ActivationRecord struct {
 
 // ActivationRecordsReporter is the interface to report monthly active records (MAR).
 type ActivationRecordsReporter interface {
-	GenerateReportsFromJobs(jobs []*jobsdb.JobT, getSourceCategoryBySourceID func(sourceID string) string) []*ActivationRecord
+	GenerateReportsFromJobs(jobs []*jobsdb.JobT, sourceCategoriesBySourceID map[string]string) []*ActivationRecord
 	ReportActivationRecords(ctx context.Context, reports []*ActivationRecord, tx *txn.Tx) error
 	MigrateDatabase(dbConn string, conf *config.Config) error
 }
@@ -131,10 +131,10 @@ func (u *UniqueActivationRecordsReporter) MigrateDatabase(dbConn string, conf *c
 
 // GenerateReportsFromJobs aggregates activation records from a batch of jobs.
 // It is FAIL-CLOSED: jobs missing fingerprint or origin are skipped (counted via stats).
-// getSourceCategoryBySourceID resolves a source_id to its SourceDefinition.Category (from
-// the backend config); reverse-ETL classification is done via this lookup rather than the
-// job's source_category param, which is not populated on every ingestion path.
-func (u *UniqueActivationRecordsReporter) GenerateReportsFromJobs(jobs []*jobsdb.JobT, getSourceCategoryBySourceID func(sourceID string) string) []*ActivationRecord {
+// sourceCategoriesBySourceID maps a source_id to its SourceDefinition.Category (from the
+// backend config); reverse-ETL classification is done via this map rather than the job's
+// source_category param, which is not populated on every ingestion path.
+func (u *UniqueActivationRecordsReporter) GenerateReportsFromJobs(jobs []*jobsdb.JobT, sourceCategoriesBySourceID map[string]string) []*ActivationRecord {
 	if len(jobs) == 0 {
 		return nil
 	}
@@ -157,7 +157,7 @@ func (u *UniqueActivationRecordsReporter) GenerateReportsFromJobs(jobs []*jobsdb
 		// being metered by stamping context.activation.fingerprint on a non-rETL source.
 		// A missing or unknown source_id resolves to "" here and is skipped. Non-rETL is
 		// the expected majority of traffic, so skip it silently — no per-job skip stat.
-		if !strings.EqualFold(getSourceCategoryBySourceID(sourceID), retlSourceCategory) {
+		if !strings.EqualFold(sourceCategoriesBySourceID[sourceID], retlSourceCategory) {
 			continue
 		}
 

--- a/enterprise/activationrecords/records_reporter.go
+++ b/enterprise/activationrecords/records_reporter.go
@@ -34,8 +34,9 @@ const (
 	activationRecordsTable = "activation_records_reports"
 
 	// retlSourceCategory is the SourceDefinition.Category of reverse-ETL ("warehouse
-	// actions") sources, stamped by the gateway into a job's source_category param.
-	// MAR meters activation records from these sources only.
+	// actions") sources. MAR meters activation records from these sources only; the
+	// classification is resolved from the source's config category (via the lookup passed
+	// to GenerateReportsFromJobs), not from the job's source_category param.
 	retlSourceCategory = "warehouse"
 )
 
@@ -66,7 +67,7 @@ type ActivationRecord struct {
 
 // ActivationRecordsReporter is the interface to report monthly active records (MAR).
 type ActivationRecordsReporter interface {
-	GenerateReportsFromJobs(jobs []*jobsdb.JobT) []*ActivationRecord
+	GenerateReportsFromJobs(jobs []*jobsdb.JobT, getSourceCategoryBySourceID func(sourceID string) string) []*ActivationRecord
 	ReportActivationRecords(ctx context.Context, reports []*ActivationRecord, tx *txn.Tx) error
 	MigrateDatabase(dbConn string, conf *config.Config) error
 }
@@ -130,7 +131,10 @@ func (u *UniqueActivationRecordsReporter) MigrateDatabase(dbConn string, conf *c
 
 // GenerateReportsFromJobs aggregates activation records from a batch of jobs.
 // It is FAIL-CLOSED: jobs missing fingerprint or origin are skipped (counted via stats).
-func (u *UniqueActivationRecordsReporter) GenerateReportsFromJobs(jobs []*jobsdb.JobT) []*ActivationRecord {
+// getSourceCategoryBySourceID resolves a source_id to its SourceDefinition.Category (from
+// the backend config); reverse-ETL classification is done via this lookup rather than the
+// job's source_category param, which is not populated on every ingestion path.
+func (u *UniqueActivationRecordsReporter) GenerateReportsFromJobs(jobs []*jobsdb.JobT, getSourceCategoryBySourceID func(sourceID string) string) []*ActivationRecord {
 	if len(jobs) == 0 {
 		return nil
 	}
@@ -144,24 +148,16 @@ func (u *UniqueActivationRecordsReporter) GenerateReportsFromJobs(jobs []*jobsdb
 			continue
 		}
 
-		// MAR meters reverse-ETL (warehouse) sources only. Classify by the source
-		// category the gateway stamps from SourceDefinition.Category, rather than
-		// relying solely on the fingerprint gate below: this prevents a client from
-		// being metered by stamping context.activation.fingerprint on a non-rETL
-		// (e.g. event-stream) source. Non-rETL is the expected majority of traffic,
-		// so skip it silently — no per-job skip stat on the hot path. Gated before
-		// resolving source_id so event-stream jobs bail out without the extra parse.
-		sourceCategory := jsonparser.GetStringOrEmpty(job.Parameters, "source_category")
-		if !strings.EqualFold(sourceCategory, retlSourceCategory) {
-			continue
-		}
-
 		sourceID := jsonparser.GetStringOrEmpty(job.Parameters, "source_id")
-		if sourceID == "" {
-			u.log.Warnn("source_id not found in job parameters",
-				obskit.WorkspaceID(job.WorkspaceId),
-				logger.NewIntField("jobId", job.JobID))
-			u.recordSkip("missing_source")
+
+		// MAR meters reverse-ETL (warehouse) sources only. Classify by the source's
+		// SourceDefinition.Category from the backend config (looked up by source_id), NOT
+		// the job's source_category param: the internal-batch ingestion path leaves that
+		// param empty, so trusting it would under-count. This also prevents a client from
+		// being metered by stamping context.activation.fingerprint on a non-rETL source.
+		// A missing or unknown source_id resolves to "" here and is skipped. Non-rETL is
+		// the expected majority of traffic, so skip it silently — no per-job skip stat.
+		if !strings.EqualFold(getSourceCategoryBySourceID(sourceID), retlSourceCategory) {
 			continue
 		}
 

--- a/enterprise/activationrecords/records_reporter_test.go
+++ b/enterprise/activationrecords/records_reporter_test.go
@@ -16,11 +16,13 @@ import (
 )
 
 func TestUniqueActivationRecordsReporter(t *testing.T) {
-	// prepareJob builds a job with the standard activation payload shape. rETL jobs
-	// carry source_category=warehouse, the grain MAR meters.
+	// prepareJob builds a job with the standard activation payload shape. The Parameters
+	// intentionally omit source_category: on the internal-batch ingestion path it is empty,
+	// and the reporter classifies reverse-ETL sources from the config map (sourceCategories
+	// below), not the param.
 	prepareJob := func(sourceID, destinationID, fingerprint, origin, workspaceID string) *jobsdb.JobT {
 		return &jobsdb.JobT{
-			Parameters:   fmt.Appendf(nil, `{"source_id":%q,"destination_id":%q,"source_category":"warehouse"}`, sourceID, destinationID),
+			Parameters:   fmt.Appendf(nil, `{"source_id":%q,"destination_id":%q}`, sourceID, destinationID),
 			EventPayload: fmt.Appendf(nil, `{"batch":[{"context":{"activation":{"fingerprint":%q,"origin":%q}}}]}`, fingerprint, origin),
 			UserID:       uuid.NewString(),
 			UUID:         uuid.New(),
@@ -32,7 +34,7 @@ func TestUniqueActivationRecordsReporter(t *testing.T) {
 	// prepareJobNoDstID builds a job whose Parameters JSON omits the destination_id key entirely.
 	prepareJobNoDstID := func(sourceID, fingerprint, origin, workspaceID string) *jobsdb.JobT {
 		return &jobsdb.JobT{
-			Parameters:   fmt.Appendf(nil, `{"source_id":%q,"source_category":"warehouse"}`, sourceID),
+			Parameters:   fmt.Appendf(nil, `{"source_id":%q}`, sourceID),
 			EventPayload: fmt.Appendf(nil, `{"batch":[{"context":{"activation":{"fingerprint":%q,"origin":%q}}}]}`, fingerprint, origin),
 			UserID:       uuid.NewString(),
 			UUID:         uuid.New(),
@@ -40,6 +42,16 @@ func TestUniqueActivationRecordsReporter(t *testing.T) {
 			WorkspaceId:  workspaceID,
 		}
 	}
+
+	// sourceCategories resolves a source_id -> SourceDefinition.Category, mirroring the
+	// lookup the processor passes from the backend config. "src1" is a reverse-ETL
+	// (warehouse) source; "src-eventstream" is not. Unknown source_ids resolve to "" and
+	// are treated as non-rETL.
+	categoriesByID := map[string]string{
+		"src1":            "warehouse",
+		"src-eventstream": "eventStream",
+	}
+	sourceCategories := func(sourceID string) string { return categoriesByID[sourceID] }
 
 	t.Run("constructor validates HLL settings", func(t *testing.T) {
 		// Default settings are valid.
@@ -108,13 +120,50 @@ func TestUniqueActivationRecordsReporter(t *testing.T) {
 				},
 			},
 			{
-				name: "non-rETL source category - skip even with fingerprint",
+				name: "non-rETL source - skip even with fingerprint",
 				jobs: []*jobsdb.JobT{
 					{
-						// An event-stream source whose payload carries a (client-stamped)
-						// fingerprint must NOT be metered: MAR meters warehouse sources only.
-						Parameters:   fmt.Appendf(nil, `{"source_id":%q,"destination_id":%q,"source_category":"eventStream"}`, "src1", "dst1"),
+						// An event-stream source (per the config map) whose payload carries a
+						// client-stamped fingerprint must NOT be metered: MAR meters warehouse
+						// sources only, classified from config.
+						Parameters:   fmt.Appendf(nil, `{"source_id":%q,"destination_id":%q}`, "src-eventstream", "dst1"),
 						EventPayload: []byte(`{"batch":[{"context":{"activation":{"fingerprint":"fp-injected","origin":"org1"}}}]}`),
+						UserID:       uuid.NewString(),
+						UUID:         uuid.New(),
+						CustomVal:    "GW",
+						WorkspaceId:  "ws1",
+					},
+				},
+				verify: func(t *testing.T, reports []*ActivationRecord) {
+					require.Empty(t, reports)
+				},
+			},
+			{
+				name: "config category is authoritative over a spoofed source_category param - skip",
+				jobs: []*jobsdb.JobT{
+					{
+						// The job param claims warehouse, but the source is event-stream in the
+						// config map; the param is not trusted, so the record is not metered.
+						Parameters:   fmt.Appendf(nil, `{"source_id":%q,"destination_id":%q,"source_category":"warehouse"}`, "src-eventstream", "dst1"),
+						EventPayload: []byte(`{"batch":[{"context":{"activation":{"fingerprint":"fp-spoof","origin":"org1"}}}]}`),
+						UserID:       uuid.NewString(),
+						UUID:         uuid.New(),
+						CustomVal:    "GW",
+						WorkspaceId:  "ws1",
+					},
+				},
+				verify: func(t *testing.T, reports []*ActivationRecord) {
+					require.Empty(t, reports)
+				},
+			},
+			{
+				name: "unknown source not in config - skip fail-closed",
+				jobs: []*jobsdb.JobT{
+					{
+						// A source_id absent from the config lookup resolves to "" and is
+						// skipped, even with a valid fingerprint.
+						Parameters:   fmt.Appendf(nil, `{"source_id":%q,"destination_id":%q}`, "src-unknown", "dst1"),
+						EventPayload: []byte(`{"batch":[{"context":{"activation":{"fingerprint":"fp-unknown","origin":"org1"}}}]}`),
 						UserID:       uuid.NewString(),
 						UUID:         uuid.New(),
 						CustomVal:    "GW",
@@ -156,7 +205,7 @@ func TestUniqueActivationRecordsReporter(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				reports := reporter.GenerateReportsFromJobs(tc.jobs)
+				reports := reporter.GenerateReportsFromJobs(tc.jobs, sourceCategories)
 				tc.verify(t, reports)
 			})
 		}
@@ -169,7 +218,7 @@ func TestUniqueActivationRecordsReporter(t *testing.T) {
 		// prepareTwoEventJob builds a job whose batch has TWO events with distinct fingerprints.
 		prepareTwoEventJob := func(sourceID, destinationID, fp1, fp2, origin, workspaceID string) *jobsdb.JobT {
 			return &jobsdb.JobT{
-				Parameters: fmt.Appendf(nil, `{"source_id":%q,"destination_id":%q,"source_category":"warehouse"}`, sourceID, destinationID),
+				Parameters: fmt.Appendf(nil, `{"source_id":%q,"destination_id":%q}`, sourceID, destinationID),
 				EventPayload: fmt.Appendf(nil,
 					`{"batch":[{"context":{"activation":{"fingerprint":%q,"origin":%q}}},{"context":{"activation":{"fingerprint":%q,"origin":%q}}}]}`,
 					fp1, origin, fp2, origin,
@@ -183,7 +232,7 @@ func TestUniqueActivationRecordsReporter(t *testing.T) {
 
 		t.Run("two distinct fingerprints in same batch => cardinality 2", func(t *testing.T) {
 			job := prepareTwoEventJob("src1", "dst1", "fp-1", "fp-2", "org1", "ws1")
-			reports := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job})
+			reports := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, sourceCategories)
 			require.Len(t, reports, 1)
 			require.Equal(t, "org1", reports[0].Origin)
 			require.NotNil(t, reports[0].FingerprintHll)
@@ -193,14 +242,14 @@ func TestUniqueActivationRecordsReporter(t *testing.T) {
 		t.Run("batch with one valid and one invalid element - valid element still metered", func(t *testing.T) {
 			// batch[0] has no fingerprint; batch[1] is valid.
 			job := &jobsdb.JobT{
-				Parameters:   fmt.Appendf(nil, `{"source_id":%q,"destination_id":%q,"source_category":"warehouse"}`, "src1", "dst1"),
+				Parameters:   fmt.Appendf(nil, `{"source_id":%q,"destination_id":%q}`, "src1", "dst1"),
 				EventPayload: []byte(`{"batch":[{"context":{"activation":{"origin":"org1"}}},{"context":{"activation":{"fingerprint":"fp-valid","origin":"org1"}}}]}`),
 				UserID:       uuid.NewString(),
 				UUID:         uuid.New(),
 				CustomVal:    "GW",
 				WorkspaceId:  "ws1",
 			}
-			reports := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job})
+			reports := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, sourceCategories)
 			require.Len(t, reports, 1)
 			require.Equal(t, uint64(1), reports[0].FingerprintHll.Cardinality())
 		})
@@ -223,11 +272,11 @@ func TestUniqueActivationRecordsReporter(t *testing.T) {
 
 		job := prepareJob("src1", "dst1", "fp1", "org1", "ws1")
 
-		first := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job})
+		first := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, sourceCategories)
 		require.Len(t, first, 1)
 		require.Equal(t, uint64(1), first[0].FingerprintHll.Cardinality())
 
-		second := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job})
+		second := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, sourceCategories)
 		require.Len(t, second, 1)
 		require.Equal(t, uint64(1), second[0].FingerprintHll.Cardinality())
 

--- a/enterprise/activationrecords/records_reporter_test.go
+++ b/enterprise/activationrecords/records_reporter_test.go
@@ -18,7 +18,7 @@ import (
 func TestUniqueActivationRecordsReporter(t *testing.T) {
 	// prepareJob builds a job with the standard activation payload shape. The Parameters
 	// intentionally omit source_category: on the internal-batch ingestion path it is empty,
-	// and the reporter classifies reverse-ETL sources from the config map (sourceCategories
+	// and the reporter classifies reverse-ETL sources from the config map (categoriesByID
 	// below), not the param.
 	prepareJob := func(sourceID, destinationID, fingerprint, origin, workspaceID string) *jobsdb.JobT {
 		return &jobsdb.JobT{
@@ -43,15 +43,14 @@ func TestUniqueActivationRecordsReporter(t *testing.T) {
 		}
 	}
 
-	// sourceCategories resolves a source_id -> SourceDefinition.Category, mirroring the
-	// lookup the processor passes from the backend config. "src1" is a reverse-ETL
-	// (warehouse) source; "src-eventstream" is not. Unknown source_ids resolve to "" and
-	// are treated as non-rETL.
+	// categoriesByID maps source_id -> SourceDefinition.Category, mirroring the map the
+	// processor passes from the backend config. "src1" is a reverse-ETL (warehouse)
+	// source; "src-eventstream" is not. Unknown source_ids resolve to "" and are treated
+	// as non-rETL.
 	categoriesByID := map[string]string{
 		"src1":            "warehouse",
 		"src-eventstream": "eventStream",
 	}
-	sourceCategories := func(sourceID string) string { return categoriesByID[sourceID] }
 
 	t.Run("constructor validates HLL settings", func(t *testing.T) {
 		// Default settings are valid.
@@ -205,7 +204,7 @@ func TestUniqueActivationRecordsReporter(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				reports := reporter.GenerateReportsFromJobs(tc.jobs, sourceCategories)
+				reports := reporter.GenerateReportsFromJobs(tc.jobs, categoriesByID)
 				tc.verify(t, reports)
 			})
 		}
@@ -232,7 +231,7 @@ func TestUniqueActivationRecordsReporter(t *testing.T) {
 
 		t.Run("two distinct fingerprints in same batch => cardinality 2", func(t *testing.T) {
 			job := prepareTwoEventJob("src1", "dst1", "fp-1", "fp-2", "org1", "ws1")
-			reports := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, sourceCategories)
+			reports := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, categoriesByID)
 			require.Len(t, reports, 1)
 			require.Equal(t, "org1", reports[0].Origin)
 			require.NotNil(t, reports[0].FingerprintHll)
@@ -249,7 +248,7 @@ func TestUniqueActivationRecordsReporter(t *testing.T) {
 				CustomVal:    "GW",
 				WorkspaceId:  "ws1",
 			}
-			reports := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, sourceCategories)
+			reports := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, categoriesByID)
 			require.Len(t, reports, 1)
 			require.Equal(t, uint64(1), reports[0].FingerprintHll.Cardinality())
 		})
@@ -272,11 +271,11 @@ func TestUniqueActivationRecordsReporter(t *testing.T) {
 
 		job := prepareJob("src1", "dst1", "fp1", "org1", "ws1")
 
-		first := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, sourceCategories)
+		first := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, categoriesByID)
 		require.Len(t, first, 1)
 		require.Equal(t, uint64(1), first[0].FingerprintHll.Cardinality())
 
-		second := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, sourceCategories)
+		second := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, categoriesByID)
 		require.Len(t, second, 1)
 		require.Equal(t, uint64(1), second[0].FingerprintHll.Cardinality())
 

--- a/enterprise/activationrecords/wire_compat_test.go
+++ b/enterprise/activationrecords/wire_compat_test.go
@@ -92,7 +92,7 @@ func TestWireCompat(t *testing.T) {
 		}),
 	}
 
-	reports := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, func(string) string { return "warehouse" })
+	reports := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, map[string]string{"src-1": "warehouse"})
 	require.Len(t, reports, 1)
 
 	// The reporter must resolve the full grain from the gateway's actual on-the-wire

--- a/enterprise/activationrecords/wire_compat_test.go
+++ b/enterprise/activationrecords/wire_compat_test.go
@@ -92,7 +92,7 @@ func TestWireCompat(t *testing.T) {
 		}),
 	}
 
-	reports := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job})
+	reports := reporter.GenerateReportsFromJobs([]*jobsdb.JobT{job}, func(string) string { return "warehouse" })
 	require.Len(t, reports, 1)
 
 	// The reporter must resolve the full grain from the gateway's actual on-the-wire

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -189,6 +189,7 @@ type Handle struct {
 		eventAuditEnabled                         map[string]bool
 		credentialsMap                            map[string][]types.Credential
 		nonEventStreamSources                     map[string]bool
+		sourceIdCategoryMap                       map[string]string
 		enableConcurrentStore                     config.ValueLoader[bool]
 		userTransformationMirroringSanitySampling config.ValueLoader[float64]
 		userTransformationMirroringFireAndForget  config.ValueLoader[bool]
@@ -851,6 +852,7 @@ func (proc *Handle) backendConfigSubscriber(ctx context.Context) {
 			eventAuditEnabled            = make(map[string]bool)
 			credentialsMap               = make(map[string][]types.Credential)
 			nonEventStreamSources        = make(map[string]bool)
+			sourceIdCategoryMap          = make(map[string]string)
 			connectionConfigMap          = make(map[connection]backendconfig.Connection)
 		)
 		for workspaceID, wConfig := range config {
@@ -860,6 +862,7 @@ func (proc *Handle) backendConfigSubscriber(ctx context.Context) {
 			for i := range wConfig.Sources {
 				source := &wConfig.Sources[i]
 				sourceIdSourceMap[source.ID] = *source
+				sourceIdCategoryMap[source.ID] = source.SourceDefinition.Category
 				if source.Enabled {
 					sourceIdDestinationMap[source.ID] = source.Destinations
 					genericConsentManagementMap[SourceID(source.ID)] = make(DestConsentMap)
@@ -901,6 +904,7 @@ func (proc *Handle) backendConfigSubscriber(ctx context.Context) {
 		proc.config.eventAuditEnabled = eventAuditEnabled
 		proc.config.credentialsMap = credentialsMap
 		proc.config.nonEventStreamSources = nonEventStreamSources
+		proc.config.sourceIdCategoryMap = sourceIdCategoryMap
 		proc.config.configSubscriberLock.Unlock()
 		if !initDone {
 			initDone = true
@@ -939,19 +943,15 @@ func (proc *Handle) getNonEventStreamSources() map[string]bool {
 	return proc.config.nonEventStreamSources
 }
 
-// getSourceCategoriesBySourceID returns a source_id -> SourceDefinition.Category snapshot
-// from the backend config. Activation-records (MAR) metering uses it to classify reverse-ETL
-// sources without depending on the source_category job param (which is not populated on
-// every ingestion path). Taken once per batch: unlike getSourceBySourceID it copies only the
-// category strings (not the full SourceT) and does not log on unknown sources.
+// getSourceCategoriesBySourceID returns the shared source_id -> SourceDefinition.Category
+// map, which the config subscriber rebuilds and swaps on each backend-config change (hence
+// the read lock). Activation-records (MAR) metering uses it to classify reverse-ETL sources
+// without depending on the source_category job param (which is not populated on every
+// ingestion path). The returned map is shared and must not be mutated.
 func (proc *Handle) getSourceCategoriesBySourceID() map[string]string {
 	proc.config.configSubscriberLock.RLock()
 	defer proc.config.configSubscriberLock.RUnlock()
-	categories := make(map[string]string, len(proc.config.sourceIdSourceMap))
-	for id, source := range proc.config.sourceIdSourceMap {
-		categories[id] = source.SourceDefinition.Category
-	}
-	return categories
+	return proc.config.sourceIdCategoryMap
 }
 
 func (proc *Handle) getEnabledDestinations(sourceId, destinationName string) []backendconfig.DestinationT {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -106,7 +106,7 @@ type trackedUsersReporter interface {
 }
 
 type activationRecordsReporter interface {
-	GenerateReportsFromJobs(jobs []*jobsdb.JobT) []*activationrecords.ActivationRecord
+	GenerateReportsFromJobs(jobs []*jobsdb.JobT, getSourceCategoryBySourceID func(sourceID string) string) []*activationrecords.ActivationRecord
 	ReportActivationRecords(ctx context.Context, reports []*activationrecords.ActivationRecord, tx *Tx) error
 }
 
@@ -937,6 +937,21 @@ func (proc *Handle) getNonEventStreamSources() map[string]bool {
 	proc.config.configSubscriberLock.RLock()
 	defer proc.config.configSubscriberLock.RUnlock()
 	return proc.config.nonEventStreamSources
+}
+
+// getSourceCategoriesBySourceID returns a source_id -> SourceDefinition.Category snapshot
+// from the backend config. Activation-records (MAR) metering uses it to classify reverse-ETL
+// sources without depending on the source_category job param (which is not populated on
+// every ingestion path). Taken once per batch: unlike getSourceBySourceID it copies only the
+// category strings (not the full SourceT) and does not log on unknown sources.
+func (proc *Handle) getSourceCategoriesBySourceID() map[string]string {
+	proc.config.configSubscriberLock.RLock()
+	defer proc.config.configSubscriberLock.RUnlock()
+	categories := make(map[string]string, len(proc.config.sourceIdSourceMap))
+	for id, source := range proc.config.sourceIdSourceMap {
+		categories[id] = source.SourceDefinition.Category
+	}
+	return categories
 }
 
 func (proc *Handle) getEnabledDestinations(sourceId, destinationName string) []backendconfig.DestinationT {
@@ -2407,7 +2422,12 @@ func (proc *Handle) pretransformStage(partition string, preTrans *preTransformat
 	// GenerateReportsFromJobs reads context.activation from the raw job payloads
 	// (left intact here so metering still works); the destination-bound copies are
 	// already stripped per-event in preprocessStage.
-	activationRecordsReports := proc.activationRecordsReporter.GenerateReportsFromJobs(preTrans.jobList)
+	// Snapshot source_id -> category once per batch (single lock, no per-job SourceT copy,
+	// no error log on unknown sources); the reporter classifies reverse-ETL sources off it.
+	sourceCategoriesBySourceID := proc.getSourceCategoriesBySourceID()
+	activationRecordsReports := proc.activationRecordsReporter.GenerateReportsFromJobs(preTrans.jobList, func(sourceID string) string {
+		return sourceCategoriesBySourceID[sourceID]
+	})
 
 	return &transformationMessage{
 		preTrans.subJobs.ctx,

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -106,7 +106,7 @@ type trackedUsersReporter interface {
 }
 
 type activationRecordsReporter interface {
-	GenerateReportsFromJobs(jobs []*jobsdb.JobT, getSourceCategoryBySourceID func(sourceID string) string) []*activationrecords.ActivationRecord
+	GenerateReportsFromJobs(jobs []*jobsdb.JobT, sourceCategoriesBySourceID map[string]string) []*activationrecords.ActivationRecord
 	ReportActivationRecords(ctx context.Context, reports []*activationrecords.ActivationRecord, tx *Tx) error
 }
 
@@ -2421,13 +2421,12 @@ func (proc *Handle) pretransformStage(partition string, preTrans *preTransformat
 
 	// GenerateReportsFromJobs reads context.activation from the raw job payloads
 	// (left intact here so metering still works); the destination-bound copies are
-	// already stripped per-event in preprocessStage.
-	// Snapshot source_id -> category once per batch (single lock, no per-job SourceT copy,
-	// no error log on unknown sources); the reporter classifies reverse-ETL sources off it.
+	// already stripped per-event in preprocessStage. Fetch the config subscriber's
+	// current source_id -> category map once here (single lock; the map is swapped
+	// atomically on config change), then pass it to the reporter, which indexes it
+	// per job to classify reverse-ETL sources.
 	sourceCategoriesBySourceID := proc.getSourceCategoriesBySourceID()
-	activationRecordsReports := proc.activationRecordsReporter.GenerateReportsFromJobs(preTrans.jobList, func(sourceID string) string {
-		return sourceCategoriesBySourceID[sourceID]
-	})
+	activationRecordsReports := proc.activationRecordsReporter.GenerateReportsFromJobs(preTrans.jobList, sourceCategoriesBySourceID)
 
 	return &transformationMessage{
 		preTrans.subJobs.ctx,


### PR DESCRIPTION
## What & why

MAR (Monthly Active Records) metering for reverse-ETL / Audiences sources produced **no data** in clustered/production deployments: `activation_records_reports` stayed empty and the MAR API returned `[]`.

The reporter gated reverse-ETL classification on the job's `source_category` **param**. That param is populated on the gateway web/auth path, but is **empty on the clustered `/internal/v1/batch` ingestion path** (rudder-sources → ingestion-svc → Pulsar → srcrouter → gateway). So every reverse-ETL record was silently skipped — no rows, no skip stats.

## Change

Classify reverse-ETL (warehouse) sources from the **source config** (`SourceDefinition.Category`) instead of the job param:

- `processor` snapshots a `source_id → category` map once per batch (single lock, category strings only) and passes a lookup `func(sourceID string) string` into the reporter.
- `records_reporter.GenerateReportsFromJobs` gates on that lookup (`== "warehouse"`), still reading the fingerprint from the raw pre-strip job.

Path-independent (works for `/internal/v1/batch`, `/internal/v1/retl`, single-node/mini) and fail-closed: an unknown/missing `source_id` resolves to `""` and is skipped; a spoofed `source_category` param can't force metering.

This supersedes an earlier gateway-side approach (stamping `source_category` in the internal-batch handler). Classifying at the consumer keeps the change contained to the MAR feature and independent of ingestion topology, and mirrors the sibling tracked-users reporter, which already takes a source-config lookup.

## Tests

`records_reporter_test.go`: warehouse source metered with an empty `source_category` param; non-warehouse source skipped; a spoofed `source_category=warehouse` param does not win over config; unknown source skipped fail-closed.

## Validation

Verified end-to-end in dev (`profiles-qa`): reverse-ETL sync → rows in `activation_records_reports` → flushed to the reporting store → MAR API returns per-connection counts (was `[]`).

Linear: [PRO-5810](https://linear.app/rudderstack/issue/PRO-5810)
