### PR TITLE
fix(gateway/webhook): return 404 for unregistered source instead of blocking on nil channel (#6999)

### DIFF
--- a/gateway/webhook/webhook.go
+++ b/gateway/webhook/webhook.go
@@ -225,7 +225,28 @@ func (webhook *HandleT) RequestHandler(w http.ResponseWriter, r *http.Request) {
 		webhook.Register(sourceDefName)
 	}
 	webhook.requestQMu.RLock()
-	requestQ := webhook.requestQ[sourceDefName]
+	requestQ, ok := webhook.requestQ[sourceDefName]
+	if !ok {
+		// The source type was not registered — either because
+		// `webhookV2HandlerEnabled` is false and the lazy registration in
+		// `processBackendConfig` has not yet run for this source, or because
+		// the source type is not one this instance handles. Sending on the
+		// nil channel returned by the map lookup would block this HTTP handler
+		// goroutine forever, leaving the client hanging and leaking a
+		// goroutine per unregistered request. Fail fast with 404 instead.
+		webhook.requestQMu.RUnlock()
+		stat := webhook.statReporterCreator(arctx, reqType)
+		stat.RequestFailed("invalidWebhookSource")
+		stat.Report(webhook.stats)
+		webhook.failRequest(
+			w,
+			r,
+			response.GetStatus(response.InvalidWebhookSource),
+			response.GetErrorStatusCode(response.InvalidWebhookSource),
+		)
+		webhook.ackCount.Add(1)
+		return
+	}
 	requestQ <- &req
 	webhook.requestQMu.RUnlock()
 

--- a/gateway/webhook/webhook_test.go
+++ b/gateway/webhook/webhook_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 	"testing/iotest"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -717,4 +718,63 @@ func newMockTransformerServer(successAfter int, successRespBody, failureRespBody
 		}))
 	mockServer.Server = handler
 	return mockServer
+}
+
+// Regression test for #6999: sending a webhook request for a source type that
+// has not been Register()ed used to send on a nil channel, blocking the HTTP
+// handler goroutine forever. The fix returns 404 (InvalidWebhookSource) fast
+// instead. This test intentionally does NOT call Register(sourceDefName) and
+// asserts that the handler returns quickly with the correct status.
+func TestWebhookRequestHandlerReturns404WhenSourceNotRegistered(t *testing.T) {
+	initWebhook()
+
+	ctrl := gomock.NewController(t)
+	mockGW := mockWebhook.NewMockGateway(ctrl)
+	mockTransformerFeaturesService := mock_features.NewMockFeaturesService(ctrl)
+
+	webhookHandler := Setup(
+		mockGW,
+		mockTransformerFeaturesService,
+		stats.NOP,
+		config.Default,
+		newSourceStatReporter,
+		func(bt *batchWebhookTransformerT) {
+			bt.sourceTransformAdapter = func(ctx context.Context) (sourceTransformAdapter, error) {
+				return &mockSourceTransformAdapter{}, nil
+			}
+		},
+	)
+	t.Cleanup(func() {
+		_ = webhookHandler.Shutdown()
+	})
+
+	// The nil-channel path is only reachable when webhookV2 is disabled, so
+	// the handler does not fall back to lazy Register() during RequestHandler.
+	webhookHandler.config.webhookV2HandlerEnabled = false
+
+	// NOTE: intentionally no webhookHandler.Register(...) — this is exactly
+	// the pre-condition that used to hang the handler goroutine.
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhook", bytes.NewBufferString(sampleJson))
+	w := httptest.NewRecorder()
+	ctx := context.WithValue(req.Context(), gwtypes.CtxParamCallType, "webhook")
+	ctx = context.WithValue(ctx, gwtypes.CtxParamAuthRequestContext, &gwtypes.AuthRequestContext{
+		SourceDefName: "some-unregistered-source-type",
+		WriteKey:      sampleWriteKey,
+	})
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		webhookHandler.RequestHandler(w, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RequestHandler blocked instead of returning 404 for unregistered source (#6999)")
+	}
+
+	assert.Equal(t, http.StatusNotFound, w.Result().StatusCode)
+	assert.Contains(t, strings.TrimSpace(w.Body.String()), response.InvalidWebhookSource)
 }


### PR DESCRIPTION
Fixes #6999.

## Problem

`RequestHandler` looked up the per-source request channel from `webhook.requestQ` and immediately sent on it. When the source type had not been `Register()`ed — a condition that can occur when `webhookV2` is disabled and the lazy registration in `processBackendConfig` has not yet run for a given source, or when a request arrives for a source type this instance does not handle — the map lookup returned a nil channel and the send blocked forever. The HTTP handler goroutine never returned, the client hung, and a goroutine leaked per unregistered request. This is the DoS described in #6999.

## Fix

- Comma-ok the map lookup at `gateway/webhook/webhook.go:228`.
- Release the read lock before writing the response (existing lock discipline preserved for the success path).
- Fail fast with the existing `response.InvalidWebhookSource` → HTTP 404 mapping (already defined in `gateway/response`).

## Test

Adds `TestWebhookRequestHandlerReturns404WhenSourceNotRegistered` which:
- Disables `webhookV2HandlerEnabled` (the pre-condition under which the bug reproduces on current HEAD).
- Deliberately omits `Register()`.
- Sends the request in a goroutine guarded by a 2-second `time.After` so the test fails hard (rather than hanging) if the handler ever regresses back to blocking on nil channel.
- Asserts `http.StatusNotFound` and body contains `response.InvalidWebhookSource`.

Passes under `go test -race ./gateway/webhook/...`. Full webhook test suite still passes.