### PR TITLE
fix: detect server-side snowpipe channel failures via per-channel status at stuck threshold

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/apiadapter.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/apiadapter.go
@@ -15,6 +15,7 @@ const (
 	createChannelAPI = "create_channel"
 	deleteChannelAPI = "delete_channel"
 	insertAPI        = "insert"
+	statusAPI        = "status"
 	bulkStatusAPI    = "bulk_status"
 )
 
@@ -110,6 +111,23 @@ func (a *apiAdapter) Insert(ctx context.Context, channelID string, insertRequest
 	}
 	tags["success"] = strconv.FormatBool(resp.Success)
 	tags["code"] = resp.Code
+	return resp, nil
+}
+
+func (a *apiAdapter) GetStatus(ctx context.Context, channelID string) (*model.StatusResponse, error) {
+	a.logger.Debugn("Getting status",
+		logger.NewStringField("channelId", channelID),
+	)
+
+	tags := a.defaultTags(statusAPI)
+	defer a.recordDuration(tags)()
+
+	resp, err := a.api.GetStatus(ctx, channelID)
+	if err != nil {
+		tags["success"] = "false"
+		return nil, err
+	}
+	tags["success"] = strconv.FormatBool(resp.Success)
 	return resp, nil
 }
 

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -701,15 +701,39 @@ func (m *Manager) Poll(_ context.Context, pollInput common.AsyncPoll) common.Pol
 			return common.PollStatusResponse{InProgress: true}
 		}
 
-		m.logger.Warnn("Stuck snowpipe pipeline detected",
-			logger.NewDurationField("duration", duration),
-			logger.NewDurationField("threshold", threshold),
-			logger.NewStringField("importID", pollInput.ImportId),
-		)
+		// The bulk-status endpoint can silently report a server-side broken channel as valid=true
+		// (snowflake-ingest-java#1154), so a channel that looks in-progress here may actually be invalid.
+		// Re-check each in-progress channel via the single-channel status endpoint, which surfaces the
+		// failure. Channels confirmed invalid are recovered through the normal failed-import path without
+		// raising the stuck-pipeline alert; genuinely stuck (or inconclusive) channels keep the alert.
+		var stuckInfos []*importInfo
 		for _, info := range inProgressInfos {
-			info.Failed = true
-			info.Reason = fmt.Sprintf("events still in progress after threshold: %s > %s", duration, threshold)
-			m.polledImportInfoMap[info.ChannelID] = info
+			if invalid := m.isChannelInvalidViaSingleStatus(ctx, info.ChannelID); invalid {
+				m.logger.Warnn("Channel reported invalid at stuck threshold; recovering without stuck-pipeline alert",
+					logger.NewStringField("channelId", info.ChannelID),
+					logger.NewStringField("table", info.Table),
+					logger.NewDurationField("duration", duration),
+					logger.NewDurationField("threshold", threshold),
+				)
+				info.Failed = true
+				info.Reason = "channel reported invalid by per-channel status check after threshold"
+				m.polledImportInfoMap[info.ChannelID] = info
+				continue
+			}
+			stuckInfos = append(stuckInfos, info)
+		}
+
+		if len(stuckInfos) > 0 {
+			m.logger.Warnn("Stuck snowpipe pipeline detected",
+				logger.NewDurationField("duration", duration),
+				logger.NewDurationField("threshold", threshold),
+				logger.NewStringField("importID", pollInput.ImportId),
+			)
+			for _, info := range stuckInfos {
+				info.Failed = true
+				info.Reason = fmt.Sprintf("events still in progress after threshold: %s > %s", duration, threshold)
+				m.polledImportInfoMap[info.ChannelID] = info
+			}
 		}
 	}
 
@@ -797,6 +821,22 @@ func (m *Manager) getBulkStatusForChannel(ctx context.Context, channelID string)
 		return nil, fmt.Errorf("channel status not found in bulk status response for channel: %s", channelID)
 	}
 	return statusRes, nil
+}
+
+// isChannelInvalidViaSingleStatus re-checks a single channel through the per-channel status endpoint,
+// which (unlike bulk status) surfaces server-side channel failures. It returns true only when the
+// channel is positively confirmed invalid. On an inconclusive result (request error) it returns false
+// so the caller falls back to stuck-pipeline handling (fail-safe: never suppress a genuine alert).
+func (m *Manager) isChannelInvalidViaSingleStatus(ctx context.Context, channelID string) bool {
+	statusRes, err := m.api.GetStatus(ctx, channelID)
+	if err != nil {
+		m.logger.Warnn("Failed to get single-channel status at stuck threshold; treating as stuck",
+			logger.NewStringField("channelId", channelID),
+			obskit.Error(err),
+		)
+		return false
+	}
+	return !statusRes.Valid || !statusRes.Success
 }
 
 func (m *Manager) getBulkStatus(ctx context.Context, channelIDs []string) (map[string]*model.StatusResponse, []string, error) {

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -2,6 +2,7 @@ package snowpipestreaming
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"math"
@@ -35,6 +36,7 @@ type mockAPI struct {
 	createChannelOutputMap map[string]func() (*model.ChannelResponse, error)
 	deleteChannelOutputMap map[string]func() error
 	insertOutputMap        map[string]func() (*model.InsertResponse, error)
+	getStatusOutputMap     map[string]func() (*model.StatusResponse, error)
 	getBulkStatusOutputMap map[string]func() (*model.BulkStatusResponse, error)
 }
 
@@ -49,6 +51,10 @@ func (m *mockAPI) DeleteChannel(_ context.Context, channelID string, _ bool) err
 
 func (m *mockAPI) Insert(_ context.Context, channelID string, _ *model.InsertRequest) (*model.InsertResponse, error) {
 	return m.insertOutputMap[channelID]()
+}
+
+func (m *mockAPI) GetStatus(_ context.Context, channelID string) (*model.StatusResponse, error) {
+	return m.getStatusOutputMap[channelID]()
 }
 
 func (m *mockAPI) GetBulkStatus(_ context.Context, channelIDs []string) (*model.BulkStatusResponse, error) {
@@ -2573,6 +2579,106 @@ func TestSnowpipeStreaming(t *testing.T) {
 							"test-products-channel": {Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "1003"},
 						},
 					}, nil
+				},
+			},
+			// At the threshold the channel is re-checked via single-channel status.
+			// It reports valid, so the channel is treated as genuinely stuck.
+			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
+				"test-products-channel": func() (*model.StatusResponse, error) {
+					return &model.StatusResponse{Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "1003"}, nil
+				},
+			},
+			deleteChannelOutputMap: map[string]func() error{
+				"test-products-channel": func() error {
+					return nil
+				},
+			},
+		}
+
+		now := time.Now().UTC()
+		sm.now = func() time.Time { return now }
+
+		first := sm.Poll(context.Background(), common.AsyncPoll{ImportId: importID})
+		require.True(t, first.InProgress)
+
+		now = now.Add(1 * time.Hour)
+		second := sm.Poll(context.Background(), common.AsyncPoll{ImportId: importID})
+		require.False(t, second.InProgress)
+		require.True(t, second.Complete)
+		require.Equal(t, http.StatusOK, second.StatusCode)
+		require.True(t, second.HasFailed)
+		require.JSONEq(t, second.FailedJobParameters, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"events still in progress after threshold: 1h0m0s > 15m0s","count":2}]`)
+	})
+
+	t.Run("Poll recovers invalid channel at threshold without stuck-pipeline alert", func(t *testing.T) {
+		importID := `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":false,"reason":"","count":2}]`
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		sm := New(config.New(), logger.NOP, statsStore, destination)
+		sm.api = &mockAPI{
+			// Bulk status silently reports the broken channel as valid (snowflake-ingest-java#1154).
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "1003"},
+						},
+					}, nil
+				},
+			},
+			// Single-channel status surfaces the real state: the channel is invalid.
+			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
+				"test-products-channel": func() (*model.StatusResponse, error) {
+					return &model.StatusResponse{Valid: false, Success: false}, nil
+				},
+			},
+			deleteChannelOutputMap: map[string]func() error{
+				"test-products-channel": func() error {
+					return nil
+				},
+			},
+		}
+
+		now := time.Now().UTC()
+		sm.now = func() time.Time { return now }
+
+		first := sm.Poll(context.Background(), common.AsyncPoll{ImportId: importID})
+		require.True(t, first.InProgress)
+
+		now = now.Add(1 * time.Hour)
+		second := sm.Poll(context.Background(), common.AsyncPoll{ImportId: importID})
+		require.False(t, second.InProgress)
+		require.True(t, second.Complete)
+		require.Equal(t, http.StatusOK, second.StatusCode)
+		require.True(t, second.HasFailed)
+		// Failed via the per-channel invalid path, not the stuck-pipeline path.
+		require.JSONEq(t, second.FailedJobParameters, `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":true,"reason":"channel reported invalid by per-channel status check after threshold","count":2}]`)
+	})
+
+	t.Run("Poll treats inconclusive single-channel check at threshold as stuck", func(t *testing.T) {
+		importID := `[{"channelId":"test-products-channel","offset":"1003","table":"PRODUCTS","failed":false,"reason":"","count":2}]`
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		sm := New(config.New(), logger.NOP, statsStore, destination)
+		sm.api = &mockAPI{
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-products-channel": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-products-channel": {Valid: true, Success: true, Offset: "0", LatestInsertedOffset: "1003"},
+						},
+					}, nil
+				},
+			},
+			// Single-channel status check errors out: we cannot confirm invalidity,
+			// so the channel is treated as genuinely stuck (fail-safe).
+			getStatusOutputMap: map[string]func() (*model.StatusResponse, error){
+				"test-products-channel": func() (*model.StatusResponse, error) {
+					return nil, errors.New("service unavailable")
 				},
 			},
 			deleteChannelOutputMap: map[string]func() error{

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/types.go
@@ -138,6 +138,7 @@ type (
 		CreateChannel(ctx context.Context, channelReq *model.CreateChannelRequest) (*model.ChannelResponse, error)
 		DeleteChannel(ctx context.Context, channelID string, sync bool) error
 		Insert(ctx context.Context, channelID string, insertRequest *model.InsertRequest) (*model.InsertResponse, error)
+		GetStatus(ctx context.Context, channelID string) (*model.StatusResponse, error)
 		GetBulkStatus(ctx context.Context, channelIDs []string) (*model.BulkStatusResponse, error)
 	}
 


### PR DESCRIPTION
## Description

The Snowflake Ingest SDK has a bug ([snowflake-ingest-java#1154](https://github.com/snowflakedb/snowflake-ingest-java/issues/1154)) where the **batch** channel-status method silently ignores server-side failure status codes (e.g. `status_code=35`) and reports channels as `valid=true` even when Snowflake has flagged them broken.

Our snowpipe-streaming consumer polls channel status via the **bulk-status** endpoint. When a channel is silently broken, bulk-status keeps returning `valid=true`, so the consumer never enters its normal invalid-channel recovery path. Instead it keeps polling until the **15-minute stuck-pipeline threshold** trips, at which point it logs `"Stuck snowpipe pipeline detected"` (an alert) and fails all in-progress jobs — a 15-minute delay, misreported as a stuck pipeline.

## Change

At the stuck-pipeline threshold in `Manager.Poll`, each still-in-progress channel is re-checked via the **single-channel** status endpoint (`GetStatus`), which correctly surfaces server-side failures (the per-channel method throws, and the snowpipe service returns `success=false`/`valid=false`).

- **Confirmed invalid** channels (`!Valid || !Success`) are failed through the normal failed-import path (channel deleted, jobs retried next batch) **without** the `"Stuck snowpipe pipeline detected"` alert.
- **Genuinely stuck** channels (single-channel check still reports valid) keep the existing alert + `"events still in progress after threshold…"` failure reason.
- **Inconclusive** checks (the `GetStatus` call itself errors) are treated as stuck — fail-safe: the alert is suppressed only on a positive invalid confirmation.

This re-wires `GetStatus` back into the `api` interface and `apiAdapter` (the reverse of #6992, which had removed the per-channel path when bulk-status became the default). The lower-level `internal/api/api.go` `GetStatus` was kept intact by that commit, so no new client code is needed. No change is required in `rudder-snowpipe-clients` — its single-channel `/channels/{id}/status` endpoint already surfaces broken channels. Once the upstream SDK fix ships, this per-channel recheck can be removed.

## Tests

- Re-added `mockAPI.GetStatus` + `getStatusOutputMap`.
- Updated the existing "marks in-progress imports as failed after threshold" test so the single-channel check reports valid (genuinely-stuck path unchanged).
- Added "recovers invalid channel at threshold without stuck-pipeline alert" (invalid → per-channel-invalid reason, no alert).
- Added "treats inconclusive single-channel check at threshold as stuck" (`GetStatus` errors → stuck reason, fail-safe).

Verified with `go build`, full-package `go test`, `gofmt`, and `go vet`.

## Linear Ticket

- Resolves INT-6530

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)