### PR TITLE
fix: handle Snowpipe auth errors during poll phase

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/channel.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/channel.go
@@ -120,13 +120,25 @@ func (m *Manager) createChannel(
 		}
 		m.channelCache.Store(tableName, resp)
 		return resp, nil
+	default:
+		return nil, classifyFailedChannelResponse(resp)
+	}
+}
+
+// classifyFailedChannelResponse maps a non-success CreateChannel response to an error.
+// Validation/authorization failures and unsupported-column failures are wrapped with errAbort
+// (terminal, non-retryable); all other codes yield a generic (retryable) error.
+// It is shared by the upload path (createChannel) and the poll recovery path
+// (handleChannelRecoveryPostBulkStatus) so both classify auth errors identically.
+func classifyFailedChannelResponse(resp *model.ChannelResponse) error {
+	switch resp.Code {
 	case internalapi.ErrValidationError, internalapi.ErrAuthenticationFailed, internalapi.ErrRoleDoesNotExistOrNotAuthorized, internalapi.ErrDatabaseDoesNotExistOrNotAuthorized:
-		return nil, fmt.Errorf("%w: validation or authorization error", errAbort)
+		return fmt.Errorf("%w: validation or authorization error", errAbort)
 	default:
 		if resp.SnowflakeAPIHttpCode == internalapi.ApiStatusUnsupportedColumn {
-			return nil, fmt.Errorf("%w: creating channel with code %s, message: %s and error: %s", errAbort, resp.Code, resp.SnowflakeAPIMessage, resp.Error)
+			return fmt.Errorf("%w: creating channel with code %s, message: %s and error: %s", errAbort, resp.Code, resp.SnowflakeAPIMessage, resp.Error)
 		}
-		return nil, fmt.Errorf("creating channel with code %s, message: %s and error: %s", resp.Code, resp.SnowflakeAPIMessage, resp.Error)
+		return fmt.Errorf("creating channel with code %s, message: %s and error: %s", resp.Code, resp.SnowflakeAPIMessage, resp.Error)
 	}
 }
 

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming.go
@@ -198,7 +198,7 @@ func (m *Manager) Upload(_ context.Context, asyncDest *common.AsyncDestinationSt
 		)
 
 		if errors.Is(err, errAbort) {
-			return m.abortJobs(asyncDest, fmt.Errorf("failed to prepare discards channel: %w", errAbort).Error())
+			return m.abortJobs(asyncDest, fmt.Errorf("failed to prepare discards channel: %w", err).Error())
 		}
 		return m.failedJobs(asyncDest, fmt.Errorf("failed to prepare discards channel: %w", err).Error())
 	}
@@ -964,6 +964,14 @@ func (m *Manager) handleChannelRecoveryPostBulkStatus(ctx context.Context, info 
 	recreatedChannel, recreateErr := m.api.CreateChannel(ctx, req)
 	if recreateErr != nil {
 		return nil, fmt.Errorf("recreating channel: %w", recreateErr)
+	}
+	// A non-transport failure (e.g. ERR_AUTHENTICATION_FAILED after a credential change) is
+	// surfaced here with success=false and an empty channel id. Classify it before caching or
+	// polling status: auth/authorization failures become errAbort so the import fails fast with
+	// a meaningful reason instead of caching an invalid channel and getting stuck until the
+	// stuck-pipeline threshold.
+	if !recreatedChannel.Success {
+		return nil, fmt.Errorf("recreating channel: %w", classifyFailedChannelResponse(recreatedChannel))
 	}
 	m.channelCache.Store(info.Table, recreatedChannel)
 

--- a/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
+++ b/router/batchrouter/asyncdestinationmanager/snowpipestreaming/snowpipestreaming_test.go
@@ -282,6 +282,30 @@ func TestSnowpipeStreaming(t *testing.T) {
 		}, mockApi.channelReq)
 	})
 
+	t.Run("Upload aborts discards channel on auth error with meaningful reason", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		sm := New(config.New(), logger.NOP, statsStore, destination)
+		sm.api = &mockAPI{
+			createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
+				"RUDDER_DISCARDS": func() (*model.ChannelResponse, error) {
+					return &model.ChannelResponse{Success: false, Code: internalapi.ErrAuthenticationFailed}, nil
+				},
+			},
+		}
+		output := sm.Upload(context.Background(), &common.AsyncDestinationStruct{
+			ImportingJobIDs: []int64{1},
+			Destination:     destination,
+			FileName:        "testdata/successful_records.txt",
+		})
+		require.Equal(t, []int64{1}, output.AbortJobIDs)
+		require.Equal(t, 1, output.AbortCount)
+		// The abort reason must carry the underlying auth cause, not just the generic "abort error".
+		require.Contains(t, output.AbortReason, "validation or authorization error")
+		require.Empty(t, output.FailedJobIDs)
+	})
+
 	t.Run("Upload not able to create event channel", func(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
@@ -3418,6 +3442,52 @@ func TestSnowpipeStreaming(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("provideInProgressImportInfos - channel recreation auth error fast-fails as abort", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		sm := New(config.New(), logger.NOP, statsStore, destination)
+
+		sm.api = &mockAPI{
+			// Bulk status reports the channel invalid, forcing the recovery/recreation path.
+			getBulkStatusOutputMap: map[string]func() (*model.BulkStatusResponse, error){
+				"test-channel-1": func() (*model.BulkStatusResponse, error) {
+					return &model.BulkStatusResponse{
+						Success: true,
+						Statuses: map[string]*model.StatusResponse{
+							"test-channel-1": {Valid: false, Success: true, Offset: "100"},
+						},
+					}, nil
+				},
+			},
+			deleteChannelOutputMap: map[string]func() error{
+				"test-channel-1": func() error { return nil },
+			},
+			// Recreation fails with an auth error (e.g. a rotated RSA key).
+			createChannelOutputMap: map[string]func() (*model.ChannelResponse, error){
+				"USERS": func() (*model.ChannelResponse, error) {
+					return &model.ChannelResponse{Success: false, Code: internalapi.ErrAuthenticationFailed}, nil
+				},
+			},
+		}
+
+		info := &importInfo{ChannelID: "test-channel-1", Offset: "100", Table: "USERS", Count: 5}
+		inProgress := sm.provideInProgressImportInfos(context.Background(), []*importInfo{info})
+
+		// Fast-fail: not left in progress, so it never reaches the stuck-pipeline threshold.
+		require.Empty(t, inProgress)
+
+		failed, ok := sm.polledImportInfoMap["test-channel-1"]
+		require.True(t, ok)
+		require.True(t, failed.Failed)
+		// Reason carries the auth cause, not the misleading generic/stuck message.
+		require.Contains(t, failed.Reason, "validation or authorization error")
+		require.NotContains(t, failed.Reason, "events still in progress after threshold")
+
+		// The invalid recreated channel must not be cached.
+		_, cached := sm.channelCache.Load("USERS")
+		require.False(t, cached)
 	})
 
 	t.Run("provideInProgressImportInfos with bulk status enabled", func(t *testing.T) {


### PR DESCRIPTION
# Description

Snowpipe streaming could enter a false **"stuck pipeline" P0** (`warehouse-snowpipe-stuck`) when a Snowflake auth credential changed underneath a running destination (e.g. a rotated RSA key).

Auth/abort errors were only classified in the **upload** path (`createChannel`). The **poll** recovery path (`handleChannelRecoveryPostBulkStatus`) called `m.api.CreateChannel` directly, bypassing that classification. Because `m.api.CreateChannel` returns `(resp, nil)` even when `resp.Success == false`, an auth failure during poll was:
- stored in `channelCache` as an **invalid** channel (empty channel id), and
- surfaced only as a generic error, leaving the import in-progress until the 15-minute stuck threshold — where it failed with the misleading `"events still in progress after threshold"` message and fired the P0 alert.

## Changes

- **Extract shared classification** — pull the terminal channel-response classification out of `createChannel` into `classifyFailedChannelResponse` (auth / validation / authorization and unsupported-column → `errAbort`; generic otherwise). `createChannel` delegates to it, so the upload path behaves exactly as before.
- **Classify auth errors in the poll recovery path** — `handleChannelRecoveryPostBulkStatus` now classifies a non-success recreate response *before* caching or re-polling. Auth failures **fail fast** with a meaningful reason, the invalid channel is **not cached**, and no stuck-pipeline alert is raised.
- **Propagate the real error** in the upload discards-channel abort — send the underlying `err` instead of the generic `errAbort` sentinel, so the job's abort reason carries the actual cause.

## Tests

- `provideInProgressImportInfos` — recovery auth error fast-fails as abort: asserts the import is not left in-progress, is marked failed with the auth reason (not the stuck message), and the invalid channel is not cached.
- `Upload` — discards-channel auth abort surfaces the meaningful reason (guards the line-201 change).

Full package suite (`SLOW=0 go test ./.../snowpipestreaming/...`) passes; `go vet` and `gofmt` clean.

## Linear Ticket

https://linear.app/rudderstack/issue/INT-6447/handle-auth-errors-during-snowpipe-poll-phase

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)