### PR TITLE
feat(router): detect and classify transformer-proxy contract breaches (INT-6839)

### DIFF
--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -559,13 +560,21 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	if err != nil {
 		return proxyErrorResponse(respCode, err.Error(), routerJobDontBatchDirectives)
 	}
+	// Compared as sets, so the check does not depend on duplicate jobIDs on either side: a batch can
+	// carry the same JobID more than once (router/worker.go only dedupes when building the final job
+	// responses) and the transformer may collapse or echo those. routerJobResponseCodes is keyed by
+	// the jobIDs the transformer answered for, so its keys are the response set.
+	jobIDsInMetadata := lo.Uniq(proxyJobIDs(proxyReqParams.ResponseData.Metadata))
+	slices.Sort(jobIDsInMetadata)
+	jobIDsInResponse := lo.Keys(transResp.routerJobResponseCodes)
+	slices.Sort(jobIDsInResponse)
 	// Non-fatal: the per-job results were still applied, but they may be attached to the wrong jobs.
 	// Recorded here, alongside the other breach reasons, so all three share one stats handle.
-	if transResp.jobIDMismatch {
+	if !slices.Equal(jobIDsInMetadata, jobIDsInResponse) {
 		emitProxyInvalidResponse(trans.stats, trans.logger, proxyReqParams, "in out mismatch",
 			"[TransformerProxy] JobIDs in out mismatch",
-			logger.NewIntSliceField("jobIDsInMetadata", transResp.jobIDsInMetadata),
-			logger.NewIntSliceField("jobIDsInResponse", transResp.jobIDsInResponse))
+			logger.NewIntSliceField("jobIDsInMetadata", jobIDsInMetadata),
+			logger.NewIntSliceField("jobIDsInResponse", jobIDsInResponse))
 	}
 	integrations.CollectIntegrationFailureDetailedStats(trans.stats, transResp.statTags)
 

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -421,23 +421,28 @@ func emitProxyInvalidResponse(statsHandle stats.Stats, log logger.Logger, reason
 	log.Warnn(msg, append([]logger.Field{obskit.DestinationID(destinationID)}, fields...)...)
 }
 
+// proxyErrorResponse builds the error-path response shared by every early return in ProxyRequest.
+// RespStatusCodes/RespBodys are always empty here by construction: per-job results only exist once
+// the adapter has parsed a response, which has not happened on any path that bails out early.
+func proxyErrorResponse(code int, body string, dontBatch map[int64]bool) ProxyRequestResponse {
+	return ProxyRequestResponse{
+		ProxyRequestStatusCode:   code,
+		ProxyRequestResponseBody: body,
+		RespContentType:          "text/plain; charset=utf-8",
+		RespStatusCodes:          map[int64]int{},
+		RespBodys:                map[int64]string{},
+		DontBatchDirectives:      dontBatch,
+	}
+}
+
 func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequestParams) ProxyRequestResponse {
 	start := time.Now()
-	routerJobResponseCodes := make(map[int64]int)
-	routerJobResponseBodys := make(map[int64]string)
 	routerJobDontBatchDirectives := make(map[int64]bool)
 
 	if len(proxyReqParams.ResponseData.Metadata) == 0 {
 		trans.logger.Warnn("[TransformerProxy] Input metadata is empty",
 			logger.NewStringField("destination", proxyReqParams.DestName))
-		return ProxyRequestResponse{
-			ProxyRequestStatusCode:   http.StatusBadRequest,
-			ProxyRequestResponseBody: "Input metadata is empty",
-			RespContentType:          "text/plain; charset=utf-8",
-			RespStatusCodes:          routerJobResponseCodes,
-			RespBodys:                routerJobResponseBodys,
-			DontBatchDirectives:      routerJobDontBatchDirectives,
-		}
+		return proxyErrorResponse(http.StatusBadRequest, "Input metadata is empty", routerJobDontBatchDirectives)
 	}
 
 	for _, m := range proxyReqParams.ResponseData.Metadata {
@@ -449,26 +454,12 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 
 	payload, err := proxyReqParams.Adapter.getPayload(proxyReqParams)
 	if err != nil {
-		return ProxyRequestResponse{
-			ProxyRequestStatusCode:   http.StatusInternalServerError,
-			ProxyRequestResponseBody: "Payload preparation failed",
-			RespContentType:          "text/plain; charset=utf-8",
-			RespStatusCodes:          routerJobResponseCodes,
-			RespBodys:                routerJobResponseBodys,
-			DontBatchDirectives:      routerJobDontBatchDirectives,
-		}
+		return proxyErrorResponse(http.StatusInternalServerError, "Payload preparation failed", routerJobDontBatchDirectives)
 	}
 
 	proxyURL, err := proxyReqParams.Adapter.getProxyURL(proxyReqParams.DestName)
 	if err != nil {
-		return ProxyRequestResponse{
-			ProxyRequestStatusCode:   http.StatusInternalServerError,
-			ProxyRequestResponseBody: "ProxyURL preparation failed",
-			RespContentType:          "text/plain; charset=utf-8",
-			RespStatusCodes:          routerJobResponseCodes,
-			RespBodys:                routerJobResponseBodys,
-			DontBatchDirectives:      routerJobDontBatchDirectives,
-		}
+		return proxyErrorResponse(http.StatusInternalServerError, "ProxyURL preparation failed", routerJobDontBatchDirectives)
 	}
 
 	// Create metric labels
@@ -498,14 +489,7 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	trans.stats.NewTaggedStat("transformer_proxy_request_result", stats.CountType, labelsWithSuccess).Increment()
 
 	if requestError != nil {
-		return ProxyRequestResponse{
-			ProxyRequestStatusCode:   respCode,
-			ProxyRequestResponseBody: requestError.Error(),
-			RespContentType:          "text/plain; charset=utf-8",
-			RespStatusCodes:          routerJobResponseCodes,
-			RespBodys:                routerJobResponseBodys,
-			DontBatchDirectives:      routerJobDontBatchDirectives,
-		}
+		return proxyErrorResponse(respCode, requestError.Error(), routerJobDontBatchDirectives)
 	}
 
 	/*
@@ -522,14 +506,7 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		// The payload is not JSON, so nothing downstream can read it: `output` cannot exist, and
 		// continuing would blank respData and fail inside getResponse on an empty body — losing the
 		// very payload that explains the breach. Stop here and return it.
-		return ProxyRequestResponse{
-			ProxyRequestStatusCode:   respCode,
-			ProxyRequestResponseBody: fmt.Sprintf("[TransformerProxy] response is not valid JSON: %s, err: %v", string(respData), err),
-			RespContentType:          "text/plain; charset=utf-8",
-			RespStatusCodes:          routerJobResponseCodes,
-			RespBodys:                routerJobResponseBodys,
-			DontBatchDirectives:      routerJobDontBatchDirectives,
-		}
+		return proxyErrorResponse(respCode, fmt.Sprintf("[TransformerProxy] response is not valid JSON: %s, err: %v", string(respData), err), routerJobDontBatchDirectives)
 	}
 	if transportResponse.OriginalResponse != "" {
 		respData = []byte(transportResponse.OriginalResponse)
@@ -560,27 +537,13 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		// There are no per-job results to apply without `output`. Continuing would set respData to
 		// an empty string and fail inside getResponse, reporting an empty body instead of the one
 		// we actually received. Stop here and return it.
-		return ProxyRequestResponse{
-			ProxyRequestStatusCode:   respCode,
-			ProxyRequestResponseBody: fmt.Sprintf("[TransformerProxy] response has no output field: %s", string(respData)),
-			RespContentType:          "text/plain; charset=utf-8",
-			RespStatusCodes:          routerJobResponseCodes,
-			RespBodys:                routerJobResponseBodys,
-			DontBatchDirectives:      routerJobDontBatchDirectives,
-		}
+		return proxyErrorResponse(respCode, fmt.Sprintf("[TransformerProxy] response has no output field: %s", string(respData)), routerJobDontBatchDirectives)
 	}
 	respData = []byte(output.Raw)
 
 	transResp, err := proxyReqParams.Adapter.getResponse(respData, respCode, proxyReqParams.ResponseData.Metadata)
 	if err != nil {
-		return ProxyRequestResponse{
-			ProxyRequestStatusCode:   respCode,
-			ProxyRequestResponseBody: err.Error(),
-			RespContentType:          "text/plain; charset=utf-8",
-			RespStatusCodes:          routerJobResponseCodes,
-			RespBodys:                routerJobResponseBodys,
-			DontBatchDirectives:      routerJobDontBatchDirectives,
-		}
+		return proxyErrorResponse(respCode, err.Error(), routerJobDontBatchDirectives)
 	}
 	// Non-fatal: the per-job results were still applied, but they may be attached to the wrong jobs.
 	// Recorded here, alongside the other breach reasons, so all three share one stats handle.

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
@@ -433,10 +434,15 @@ func (trans *handle) emitProxyInvalidResponse(proxyReqParams *ProxyRequestParams
 // and a batch response can be multi-MB.
 func truncatedBody(b []byte) string {
 	const maxBodyBytes = int(10 * bytesize.KB)
-	if len(b) > maxBodyBytes {
-		return string(b[:maxBodyBytes]) + "...[truncated]"
+	if len(b) <= maxBodyBytes {
+		return string(b)
 	}
-	return string(b)
+	cut := b[:maxBodyBytes]
+	// Trim back off a partial rune so the cut does not emit U+FFFD.
+	if r, size := utf8.DecodeLastRune(cut); r == utf8.RuneError && size <= 1 {
+		cut = cut[:len(cut)-size]
+	}
+	return string(cut) + "...[truncated]"
 }
 
 // proxyErrorResponse builds the error-path response shared by every early return in ProxyRequest.
@@ -510,11 +516,11 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		return proxyErrorResponse(respCode, requestError.Error(), routerJobDontBatchDirectives)
 	}
 
-	// Responses the oauth transport synthesized itself are infrastructure, not contract breaches, and
-	// get their own reason so the alert can exclude them. The upstream status is deliberately not part
-	// of this: v0 mirrors the destination's delivery status, so a destination 5xx would relabel a
-	// genuine breach as infra.
-	infraFailure := httpPrxResp.transportError
+	// Infrastructure, not a contract breach: either this transport synthesized the response, or it
+	// never came from the transformer at all (an ingress/LB error page sets no apiVersion). Status is
+	// deliberately not part of this - v0 mirrors the destination's delivery status, so a destination
+	// 5xx would relabel a genuine breach as infra.
+	infraFailure := httpPrxResp.transportError || !httpPrxResp.fromTransformer
 
 	/*
 		respData will be in ProxyResponseV0 or ProxyResponseV1
@@ -718,6 +724,10 @@ type httpProxyResponse struct {
 	// received from the transformer. Its body is a plain-text error string, so a non-JSON body on
 	// such a response is an infrastructure failure, not a transformer contract breach.
 	transportError bool
+	// fromTransformer reports that the response carried the apiVersion header, which only the
+	// transformer sets. An ingress/LB error page in front of the transformer carries neither it nor
+	// the transport marker, and is infrastructure rather than a contract breach.
+	fromTransformer bool
 }
 
 func (trans *handle) doProxyRequest(ctx context.Context, proxyUrl string, proxyReqParams *ProxyRequestParams, payload []byte) httpProxyResponse {
@@ -814,9 +824,10 @@ func (trans *handle) doProxyRequest(ctx context.Context, proxyUrl string, proxyR
 	}
 
 	return httpProxyResponse{
-		respData:       respData,
-		statusCode:     resp.StatusCode,
-		transportError: resp.Header.Get(oauthv2httpclient.TransportErrorHeader) != "",
+		respData:        respData,
+		statusCode:      resp.StatusCode,
+		transportError:  resp.Header.Get(oauthv2httpclient.TransportErrorHeader) != "",
+		fromTransformer: resp.Header.Get(apiVersionHeader) != "",
 	}
 }
 

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -412,10 +412,15 @@ func proxyJobIDs(metadata []ProxyRequestMetadata) []int64 {
 // to inspect the affected events. Every breach reason goes through here so the metric keeps a single
 // tag set and a single stats handle. The response body is deliberately not logged: these are
 // debugged by reading the events out of jobsDB by jobID.
-func emitProxyInvalidResponse(statsHandle stats.Stats, log logger.Logger, reason, destType, destinationID, msg string, fields ...logger.Field) {
+//
+// Takes proxyReqParams rather than the destType/destinationId strings so the two cannot be
+// transposed at a call site and silently mis-tag the metric. Callers must be past ProxyRequest's
+// empty-metadata guard, which every breach site is.
+func emitProxyInvalidResponse(statsHandle stats.Stats, log logger.Logger, proxyReqParams *ProxyRequestParams, reason, msg string, fields ...logger.Field) {
+	destinationID := proxyReqParams.ResponseData.Metadata[0].DestinationID
 	statsHandle.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
 		"reason":        reason,
-		"destType":      destType,
+		"destType":      proxyReqParams.DestName,
 		"destinationId": destinationID,
 	}).Increment()
 	log.Warnn(msg, append([]logger.Field{obskit.DestinationID(destinationID)}, fields...)...)
@@ -499,9 +504,15 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	// unmarshal unsuccessful scenarios
 	// if respData is not a valid json, surface it instead of discarding the error
 	if err := jsonrs.Unmarshal(respData, &transportResponse); err != nil {
-		emitProxyInvalidResponse(trans.stats, trans.logger, "unmarshal error", proxyReqParams.DestName,
-			proxyReqParams.ResponseData.Metadata[0].DestinationID,
-			"[TransformerProxy] proxy response unmarshal failed",
+		// A response synthesized by the oauth transport carries a plain-text error, not the
+		// transformer's payload, so a failed unmarshal there is an infrastructure failure (a short
+		// read, an unreachable transformer) rather than a contract breach. It stays observable under
+		// its own reason so the alert can exclude it without the signal disappearing.
+		reason, msg := "unmarshal error", "[TransformerProxy] proxy response unmarshal failed"
+		if httpPrxResp.transportError {
+			reason, msg = "transport error", "[TransformerProxy] transport returned a non-transformer response"
+		}
+		emitProxyInvalidResponse(trans.stats, trans.logger, proxyReqParams, reason, msg,
 			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
 		// The payload is not JSON, so nothing downstream can read it: `output` cannot exist, and
 		// continuing would blank respData and fail inside getResponse on an empty body — losing the
@@ -529,9 +540,12 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		}
 	**/
 	output := gjson.GetBytes(respData, "output")
-	if !output.Exists() {
-		emitProxyInvalidResponse(trans.stats, trans.logger, "missing output", proxyReqParams.DestName,
-			proxyReqParams.ResponseData.Metadata[0].DestinationID,
+	// gjson reports an explicit JSON null as existing (Exists is `Type != Null || len(Raw) != 0`, and
+	// a literal null has Raw == "null"), so the type has to be checked too. Otherwise
+	// `{"output":null}` slips through, unmarshals into an empty response set, and gets reported as an
+	// "in out mismatch" - sending the runbook down the data-corruption branch instead of this one.
+	if !output.Exists() || output.Type == gjson.Null {
+		emitProxyInvalidResponse(trans.stats, trans.logger, proxyReqParams, "missing output",
 			"[TransformerProxy] proxy response missing output",
 			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
 		// There are no per-job results to apply without `output`. Continuing would set respData to
@@ -548,8 +562,7 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	// Non-fatal: the per-job results were still applied, but they may be attached to the wrong jobs.
 	// Recorded here, alongside the other breach reasons, so all three share one stats handle.
 	if transResp.jobIDMismatch {
-		emitProxyInvalidResponse(trans.stats, trans.logger, "in out mismatch", proxyReqParams.DestName,
-			proxyReqParams.ResponseData.Metadata[0].DestinationID,
+		emitProxyInvalidResponse(trans.stats, trans.logger, proxyReqParams, "in out mismatch",
 			"[TransformerProxy] JobIDs in out mismatch",
 			logger.NewIntSliceField("jobIDsInMetadata", transResp.jobIDsInMetadata),
 			logger.NewIntSliceField("jobIDsInResponse", transResp.jobIDsInResponse))
@@ -667,6 +680,10 @@ type httpProxyResponse struct {
 	respData   []byte
 	statusCode int
 	err        error
+	// transportError reports that this response was synthesized by the oauth transport rather than
+	// received from the transformer. Its body is a plain-text error string, so a non-JSON body on
+	// such a response is an infrastructure failure, not a transformer contract breach.
+	transportError bool
 }
 
 func (trans *handle) doProxyRequest(ctx context.Context, proxyUrl string, proxyReqParams *ProxyRequestParams, payload []byte) httpProxyResponse {
@@ -763,8 +780,9 @@ func (trans *handle) doProxyRequest(ctx context.Context, proxyUrl string, proxyR
 	}
 
 	return httpProxyResponse{
-		respData:   respData,
-		statusCode: resp.StatusCode,
+		respData:       respData,
+		statusCode:     resp.StatusCode,
+		transportError: resp.Header.Get(oauthv2httpclient.TransportErrorHeader) != "",
 	}
 }
 

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -429,10 +429,8 @@ func (trans *handle) emitProxyInvalidResponse(proxyReqParams *ProxyRequestParams
 	trans.logger.Warnn(msg, append([]logger.Field{obskit.DestinationID(destinationID)}, fields...)...)
 }
 
-// truncatedBody bounds an upstream body embedded in an error string. Nothing consumes
-// ProxyRequestResponseBody (router/worker.go reads only the per-job maps), and a batch response can
-// be multi-MB, so the whole payload is never worth stringifying. Sliced before the conversion so the
-// full body is not allocated first.
+// truncatedBody bounds a body embedded in an error string: nothing reads ProxyRequestResponseBody
+// and a batch response can be multi-MB.
 func truncatedBody(b []byte) string {
 	const maxBodyBytes = int(10 * bytesize.KB)
 	if len(b) > maxBodyBytes {
@@ -512,24 +510,18 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		return proxyErrorResponse(respCode, requestError.Error(), routerJobDontBatchDirectives)
 	}
 
-	// A response the oauth transport synthesized itself (failed token fetch, augmentation failure, LB
-	// round-trip error, unreadable body) is an infrastructure failure rather than a transformer
-	// contract breach, so it is reported under its own reason and excluded from the paging alert.
-	//
-	// The upstream status is deliberately not part of this signal: for v0 the transformer mirrors the
-	// destination's delivery status (deliveryPostProcess in rudder-transformer), so any destination 5xx
-	// comes from a perfectly healthy transformer and would relabel a genuine breach as infra. The
-	// status is logged instead, and only selects the reason at the points below where the response
-	// cannot be processed - a response that parses is applied exactly as before.
+	// Responses the oauth transport synthesized itself are infrastructure, not contract breaches, and
+	// get their own reason so the alert can exclude them. The upstream status is deliberately not part
+	// of this: v0 mirrors the destination's delivery status, so a destination 5xx would relabel a
+	// genuine breach as infra.
 	infraFailure := httpPrxResp.transportError
 
 	/*
 		respData will be in ProxyResponseV0 or ProxyResponseV1
 	*/
 	var transportResponse oauthv2.TransportResponse // response that we get from oauth-interceptor in postRoundTrip
-	// A non-oauth destination hands back the raw upstream body, so a non-JSON body here is either that
-	// infra failure or a genuinely corrupt transformer response; surface the error instead of
-	// discarding it.
+	// A non-oauth destination hands back the raw upstream body, so a non-JSON body here is either infra
+	// or a corrupt transformer response.
 	if err := jsonrs.Unmarshal(respData, &transportResponse); err != nil {
 		reason, msg := "unmarshal error", "[TransformerProxy] proxy response unmarshal failed"
 		if infraFailure {
@@ -538,8 +530,7 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		trans.emitProxyInvalidResponse(proxyReqParams, reason, msg,
 			logger.NewIntField("statusCode", int64(httpPrxResp.statusCode)),
 			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
-		// The payload is not JSON, so nothing downstream can read it: `output` cannot exist, and
-		// continuing would blank respData and fail inside getResponse on an empty body. Stop here.
+		// Not JSON, so `output` cannot exist; continuing would blank respData and fail on an empty body.
 		return proxyErrorResponse(respCode, fmt.Sprintf("[TransformerProxy] response is not valid JSON: %s, err: %v", truncatedBody(respData), err), routerJobDontBatchDirectives)
 	}
 	if transportResponse.OriginalResponse != "" {
@@ -568,8 +559,7 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	// `{"output":null}` slips through, unmarshals into an empty response set, and gets reported as an
 	// "in out mismatch" - sending the runbook down the data-corruption branch instead of this one.
 	if !output.Exists() || output.Type == gjson.Null {
-		// A transport-synthesized body has no output either; keep it under its own reason so the
-		// breach signal stays clean. Anything else reaching here is a genuine missing-output breach.
+		// A transport-synthesized body has no output either, so it keeps its own reason.
 		reason, msg := "missing output", "[TransformerProxy] proxy response missing output"
 		if infraFailure {
 			reason, msg = "transport error", "[TransformerProxy] transport-synthesized response has no output field"
@@ -577,18 +567,15 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		trans.emitProxyInvalidResponse(proxyReqParams, reason, msg,
 			logger.NewIntField("statusCode", int64(httpPrxResp.statusCode)),
 			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
-		// There are no per-job results to apply without `output`. Continuing would set respData to
-		// an empty string and fail inside getResponse, reporting an empty body instead of the one
-		// we actually received. Stop here and return it.
+		// No per-job results to apply without `output`.
 		return proxyErrorResponse(respCode, fmt.Sprintf("[TransformerProxy] response has no output field: %s", truncatedBody(respData)), routerJobDontBatchDirectives)
 	}
 	respData = []byte(output.Raw)
 
 	transResp, err := proxyReqParams.Adapter.getResponse(respData, respCode, proxyReqParams.ResponseData.Metadata)
 	if err != nil {
-		// output was present but its per-job payload will not parse - a genuine contract breach, under
-		// the same "unmarshal error" reason as the outer envelope. A transport-synthesized body that
-		// happened to carry an output field is still infra.
+		// output was present but its payload will not parse - same "unmarshal error" reason as the
+		// outer envelope.
 		reason, msg := "unmarshal error", "[TransformerProxy] proxy response output unmarshal failed"
 		if infraFailure {
 			reason, msg = "transport error", "[TransformerProxy] transport-synthesized response output unmarshal failed"
@@ -598,23 +585,14 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
 		return proxyErrorResponse(respCode, err.Error(), routerJobDontBatchDirectives)
 	}
-	// Compared as sets, so the check does not depend on duplicate jobIDs on either side: a batch can
-	// carry the same JobID more than once (router/worker.go only dedupes when building the final job
-	// responses) and the transformer may collapse or echo those. routerJobResponseCodes is keyed by
-	// the jobIDs the transformer answered for, so its keys are the response set. This only bites for
-	// v1: v0 keys the map by the request metadata, so the sets are equal by construction and a v0
-	// mismatch is not detectable here (nor was it before).
+	// Compared as sets: a request can legitimately carry the same JobID twice (router/worker.go only
+	// dedupes when building final responses). Only meaningful for v1 - v0 keys the map by the request
+	// metadata, so the sets are equal by construction.
 	jobIDsInMetadata := lo.Uniq(proxyJobIDs(proxyReqParams.ResponseData.Metadata))
 	slices.Sort(jobIDsInMetadata)
 	jobIDsInResponse := slices.Sorted(maps.Keys(transResp.routerJobResponseCodes))
-	// Non-fatal: the per-job results were still applied, but they may be attached to the wrong jobs.
-	// Recorded here, alongside the other breach reasons, so all share one stats handle.
-	//
-	// Two distinct breaches, both "results attached to the wrong jobs":
-	//   sets differ      - the transformer answered for a different set of jobs than we sent
-	//   entries > keys   - it answered twice for the same job, so one status was silently dropped by
-	//                      the map write. Duplicates in the *request* are legitimate (see above) and
-	//                      are why the set comparison dedupes; duplicates in the *response* are not.
+	// Non-fatal: the results were applied, but may be attached to the wrong jobs. Duplicate response
+	// entries collapse to one map key, silently dropping a status - a breach the set check cannot see.
 	duplicateResponses := transResp.responseEntries > len(transResp.routerJobResponseCodes)
 	if !slices.Equal(jobIDsInMetadata, jobIDsInResponse) || duplicateResponses {
 		trans.emitProxyInvalidResponse(proxyReqParams, "in out mismatch",

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -495,9 +495,10 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	// if respData is not a valid json, surface it instead of discarding the error
 	if err := jsonrs.Unmarshal(respData, &transportResponse); err != nil {
 		trans.stats.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
-			"reason":      "unmarshal error",
-			"destType":    proxyReqParams.DestName,
-			"workspaceId": proxyReqParams.ResponseData.Metadata[0].WorkspaceID,
+			"reason":        "unmarshal error",
+			"destType":      proxyReqParams.DestName,
+			"workspaceId":   proxyReqParams.ResponseData.Metadata[0].WorkspaceID,
+			"destinationId": proxyReqParams.ResponseData.Metadata[0].DestinationID,
 		}).Increment()
 	}
 	if transportResponse.OriginalResponse != "" {
@@ -523,9 +524,10 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	output := gjson.GetBytes(respData, "output")
 	if !output.Exists() {
 		trans.stats.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
-			"reason":      "missing output",
-			"destType":    proxyReqParams.DestName,
-			"workspaceId": proxyReqParams.ResponseData.Metadata[0].WorkspaceID,
+			"reason":        "missing output",
+			"destType":      proxyReqParams.DestName,
+			"workspaceId":   proxyReqParams.ResponseData.Metadata[0].WorkspaceID,
+			"destinationId": proxyReqParams.ResponseData.Metadata[0].DestinationID,
 		}).Increment()
 	}
 	respData = []byte(output.Raw)

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -417,14 +417,14 @@ func proxyJobIDs(metadata []ProxyRequestMetadata) []int64 {
 // Takes proxyReqParams rather than the destType/destinationId strings so the two cannot be
 // transposed at a call site and silently mis-tag the metric. Callers must be past ProxyRequest's
 // empty-metadata guard, which every breach site is.
-func emitProxyInvalidResponse(statsHandle stats.Stats, log logger.Logger, proxyReqParams *ProxyRequestParams, reason, msg string, fields ...logger.Field) {
+func (trans *handle) emitProxyInvalidResponse(proxyReqParams *ProxyRequestParams, reason, msg string, fields ...logger.Field) {
 	destinationID := proxyReqParams.ResponseData.Metadata[0].DestinationID
-	statsHandle.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
+	trans.stats.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
 		"reason":        reason,
 		"destType":      proxyReqParams.DestName,
 		"destinationId": destinationID,
 	}).Increment()
-	log.Warnn(msg, append([]logger.Field{obskit.DestinationID(destinationID)}, fields...)...)
+	trans.logger.Warnn(msg, append([]logger.Field{obskit.DestinationID(destinationID)}, fields...)...)
 }
 
 // proxyErrorResponse builds the error-path response shared by every early return in ProxyRequest.
@@ -498,22 +498,27 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		return proxyErrorResponse(respCode, requestError.Error(), routerJobDontBatchDirectives)
 	}
 
+	// An upstream 5xx (transformer/LB/gateway) or a transport-synthesized response is an
+	// infrastructure failure, not a transformer contract breach. transportError marks the synthesized
+	// responses (including 4xx ones like a failed token fetch); the status marks a real upstream error
+	// that carried a body. Classifying these as breaches would page the contract owner on our own
+	// infra, so they get a reason the alert can exclude.
+	infraFailure := httpPrxResp.transportError || httpPrxResp.statusCode >= http.StatusInternalServerError
+
 	/*
 		respData will be in ProxyResponseV0 or ProxyResponseV1
 	*/
 	var transportResponse oauthv2.TransportResponse // response that we get from oauth-interceptor in postRoundTrip
-	// unmarshal unsuccessful scenarios
-	// if respData is not a valid json, surface it instead of discarding the error
+	// A non-oauth destination hands back the raw upstream body, so a non-JSON body here is either that
+	// infra failure or a genuinely corrupt transformer response; surface the error instead of
+	// discarding it.
 	if err := jsonrs.Unmarshal(respData, &transportResponse); err != nil {
-		// A response synthesized by the oauth transport carries a plain-text error, not the
-		// transformer's payload, so a failed unmarshal there is an infrastructure failure (a short
-		// read, an unreachable transformer) rather than a contract breach. It stays observable under
-		// its own reason so the alert can exclude it without the signal disappearing.
 		reason, msg := "unmarshal error", "[TransformerProxy] proxy response unmarshal failed"
-		if httpPrxResp.transportError {
+		if infraFailure {
 			reason, msg = "transport error", "[TransformerProxy] transport returned a non-transformer response"
 		}
-		emitProxyInvalidResponse(trans.stats, trans.logger, proxyReqParams, reason, msg,
+		trans.emitProxyInvalidResponse(proxyReqParams, reason, msg,
+			logger.NewIntField("statusCode", int64(httpPrxResp.statusCode)),
 			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
 		// The payload is not JSON, so nothing downstream can read it: `output` cannot exist, and
 		// continuing would blank respData and fail inside getResponse on an empty body — losing the
@@ -526,6 +531,17 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 
 	if transportResponse.InterceptorResponse.StatusCode > 0 {
 		respCode = transportResponse.InterceptorResponse.StatusCode
+	}
+
+	// For an oauth destination the transport wraps the upstream error into a valid envelope, so the
+	// unmarshal above succeeds and the infra failure only surfaces here, after OriginalResponse has
+	// been unwrapped. Classify it before the content checks, which assume a genuine transformer response.
+	if infraFailure {
+		trans.emitProxyInvalidResponse(proxyReqParams, "transport error",
+			"[TransformerProxy] transport returned a non-transformer response",
+			logger.NewIntField("statusCode", int64(httpPrxResp.statusCode)),
+			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
+		return proxyErrorResponse(respCode, string(respData), routerJobDontBatchDirectives)
 	}
 
 	/**
@@ -546,7 +562,7 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	// `{"output":null}` slips through, unmarshals into an empty response set, and gets reported as an
 	// "in out mismatch" - sending the runbook down the data-corruption branch instead of this one.
 	if !output.Exists() || output.Type == gjson.Null {
-		emitProxyInvalidResponse(trans.stats, trans.logger, proxyReqParams, "missing output",
+		trans.emitProxyInvalidResponse(proxyReqParams, "missing output",
 			"[TransformerProxy] proxy response missing output",
 			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
 		// There are no per-job results to apply without `output`. Continuing would set respData to
@@ -558,20 +574,28 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 
 	transResp, err := proxyReqParams.Adapter.getResponse(respData, respCode, proxyReqParams.ResponseData.Metadata)
 	if err != nil {
+		// The status was not an infra failure and `output` was present, so this is a genuine
+		// transformer response whose per-job payload will not parse - a contract breach, not infra.
+		// Same "unmarshal error" reason as the outer envelope; the other breach paths already emit.
+		trans.emitProxyInvalidResponse(proxyReqParams, "unmarshal error",
+			"[TransformerProxy] proxy response output unmarshal failed",
+			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
 		return proxyErrorResponse(respCode, err.Error(), routerJobDontBatchDirectives)
 	}
 	// Compared as sets, so the check does not depend on duplicate jobIDs on either side: a batch can
 	// carry the same JobID more than once (router/worker.go only dedupes when building the final job
 	// responses) and the transformer may collapse or echo those. routerJobResponseCodes is keyed by
-	// the jobIDs the transformer answered for, so its keys are the response set.
+	// the jobIDs the transformer answered for, so its keys are the response set. This only bites for
+	// v1: v0 keys the map by the request metadata, so the sets are equal by construction and a v0
+	// mismatch is not detectable here (nor was it before).
 	jobIDsInMetadata := lo.Uniq(proxyJobIDs(proxyReqParams.ResponseData.Metadata))
 	slices.Sort(jobIDsInMetadata)
 	jobIDsInResponse := lo.Keys(transResp.routerJobResponseCodes)
 	slices.Sort(jobIDsInResponse)
 	// Non-fatal: the per-job results were still applied, but they may be attached to the wrong jobs.
-	// Recorded here, alongside the other breach reasons, so all three share one stats handle.
+	// Recorded here, alongside the other breach reasons, so all share one stats handle.
 	if !slices.Equal(jobIDsInMetadata, jobIDsInResponse) {
-		emitProxyInvalidResponse(trans.stats, trans.logger, proxyReqParams, "in out mismatch",
+		trans.emitProxyInvalidResponse(proxyReqParams, "in out mismatch",
 			"[TransformerProxy] JobIDs in out mismatch",
 			logger.NewIntSliceField("jobIDsInMetadata", jobIDsInMetadata),
 			logger.NewIntSliceField("jobIDsInResponse", jobIDsInResponse))

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -400,6 +400,27 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 	return destinationJobs
 }
 
+// proxyJobIDs returns the jobIDs in a proxy request batch — what a responder needs to look the
+// affected events up in jobsDB.
+func proxyJobIDs(metadata []ProxyRequestMetadata) []int64 {
+	return lo.Map(metadata, func(m ProxyRequestMetadata, _ int) int64 {
+		return m.JobID
+	})
+}
+
+// emitProxyInvalidResponse records a transformer-proxy contract breach and logs the jobIDs needed
+// to inspect the affected events. Every breach reason goes through here so the metric keeps a single
+// tag set and a single stats handle. The response body is deliberately not logged: these are
+// debugged by reading the events out of jobsDB by jobID.
+func emitProxyInvalidResponse(statsHandle stats.Stats, log logger.Logger, reason, destType, destinationID, msg string, fields ...logger.Field) {
+	statsHandle.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
+		"reason":        reason,
+		"destType":      destType,
+		"destinationId": destinationID,
+	}).Increment()
+	log.Warnn(msg, append([]logger.Field{obskit.DestinationID(destinationID)}, fields...)...)
+}
+
 func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequestParams) ProxyRequestResponse {
 	start := time.Now()
 	routerJobResponseCodes := make(map[int64]int)
@@ -494,16 +515,21 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	// unmarshal unsuccessful scenarios
 	// if respData is not a valid json, surface it instead of discarding the error
 	if err := jsonrs.Unmarshal(respData, &transportResponse); err != nil {
-		trans.stats.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
-			"reason":        "unmarshal error",
-			"destType":      proxyReqParams.DestName,
-			"destinationId": proxyReqParams.ResponseData.Metadata[0].DestinationID,
-		}).Increment()
-		trans.logger.Warnn("[TransformerProxy] proxy response unmarshal failed",
-			obskit.DestinationID(proxyReqParams.ResponseData.Metadata[0].DestinationID),
-			logger.NewIntSliceField("jobIDs", lo.Map(proxyReqParams.ResponseData.Metadata, func(m ProxyRequestMetadata, _ int) int64 {
-				return m.JobID
-			})))
+		emitProxyInvalidResponse(trans.stats, trans.logger, "unmarshal error", proxyReqParams.DestName,
+			proxyReqParams.ResponseData.Metadata[0].DestinationID,
+			"[TransformerProxy] proxy response unmarshal failed",
+			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
+		// The payload is not JSON, so nothing downstream can read it: `output` cannot exist, and
+		// continuing would blank respData and fail inside getResponse on an empty body — losing the
+		// very payload that explains the breach. Stop here and return it.
+		return ProxyRequestResponse{
+			ProxyRequestStatusCode:   respCode,
+			ProxyRequestResponseBody: fmt.Sprintf("[TransformerProxy] response is not valid JSON: %s, err: %v", string(respData), err),
+			RespContentType:          "text/plain; charset=utf-8",
+			RespStatusCodes:          routerJobResponseCodes,
+			RespBodys:                routerJobResponseBodys,
+			DontBatchDirectives:      routerJobDontBatchDirectives,
+		}
 	}
 	if transportResponse.OriginalResponse != "" {
 		respData = []byte(transportResponse.OriginalResponse)
@@ -527,20 +553,25 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	**/
 	output := gjson.GetBytes(respData, "output")
 	if !output.Exists() {
-		trans.stats.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
-			"reason":        "missing output",
-			"destType":      proxyReqParams.DestName,
-			"destinationId": proxyReqParams.ResponseData.Metadata[0].DestinationID,
-		}).Increment()
-		trans.logger.Warnn("[TransformerProxy] proxy response missing output",
-			obskit.DestinationID(proxyReqParams.ResponseData.Metadata[0].DestinationID),
-			logger.NewIntSliceField("jobIDs", lo.Map(proxyReqParams.ResponseData.Metadata, func(m ProxyRequestMetadata, _ int) int64 {
-				return m.JobID
-			})))
+		emitProxyInvalidResponse(trans.stats, trans.logger, "missing output", proxyReqParams.DestName,
+			proxyReqParams.ResponseData.Metadata[0].DestinationID,
+			"[TransformerProxy] proxy response missing output",
+			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
+		// There are no per-job results to apply without `output`. Continuing would set respData to
+		// an empty string and fail inside getResponse, reporting an empty body instead of the one
+		// we actually received. Stop here and return it.
+		return ProxyRequestResponse{
+			ProxyRequestStatusCode:   respCode,
+			ProxyRequestResponseBody: fmt.Sprintf("[TransformerProxy] response has no output field: %s", string(respData)),
+			RespContentType:          "text/plain; charset=utf-8",
+			RespStatusCodes:          routerJobResponseCodes,
+			RespBodys:                routerJobResponseBodys,
+			DontBatchDirectives:      routerJobDontBatchDirectives,
+		}
 	}
 	respData = []byte(output.Raw)
 
-	transResp, err := proxyReqParams.Adapter.getResponse(respData, respCode, proxyReqParams.ResponseData.Metadata, proxyReqParams.DestName)
+	transResp, err := proxyReqParams.Adapter.getResponse(respData, respCode, proxyReqParams.ResponseData.Metadata)
 	if err != nil {
 		return ProxyRequestResponse{
 			ProxyRequestStatusCode:   respCode,
@@ -550,6 +581,15 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 			RespBodys:                routerJobResponseBodys,
 			DontBatchDirectives:      routerJobDontBatchDirectives,
 		}
+	}
+	// Non-fatal: the per-job results were still applied, but they may be attached to the wrong jobs.
+	// Recorded here, alongside the other breach reasons, so all three share one stats handle.
+	if transResp.jobIDMismatch {
+		emitProxyInvalidResponse(trans.stats, trans.logger, "in out mismatch", proxyReqParams.DestName,
+			proxyReqParams.ResponseData.Metadata[0].DestinationID,
+			"[TransformerProxy] JobIDs in out mismatch",
+			logger.NewIntSliceField("jobIDsInMetadata", transResp.jobIDsInMetadata),
+			logger.NewIntSliceField("jobIDsInResponse", transResp.jobIDsInResponse))
 	}
 	integrations.CollectIntegrationFailureDetailedStats(trans.stats, transResp.statTags)
 

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -590,8 +591,7 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	// mismatch is not detectable here (nor was it before).
 	jobIDsInMetadata := lo.Uniq(proxyJobIDs(proxyReqParams.ResponseData.Metadata))
 	slices.Sort(jobIDsInMetadata)
-	jobIDsInResponse := lo.Keys(transResp.routerJobResponseCodes)
-	slices.Sort(jobIDsInResponse)
+	jobIDsInResponse := slices.Sorted(maps.Keys(transResp.routerJobResponseCodes))
 	// Non-fatal: the per-job results were still applied, but they may be attached to the wrong jobs.
 	// Recorded here, alongside the other breach reasons, so all share one stats handle.
 	if !slices.Equal(jobIDsInMetadata, jobIDsInResponse) {

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -502,8 +502,9 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	// An upstream 5xx (transformer/LB/gateway) or a transport-synthesized response is an
 	// infrastructure failure, not a transformer contract breach. transportError marks the synthesized
 	// responses (including 4xx ones like a failed token fetch); the status marks a real upstream error
-	// that carried a body. Classifying these as breaches would page the contract owner on our own
-	// infra, so they get a reason the alert can exclude.
+	// that carried a body. It only selects the reason at the points below where the response cannot be
+	// processed - it never short-circuits a response that parses, so a 5xx that still carries a usable
+	// output is applied exactly as before, and only the metric reason changes for the failures.
 	infraFailure := httpPrxResp.transportError || httpPrxResp.statusCode >= http.StatusInternalServerError
 
 	/*
@@ -534,17 +535,6 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		respCode = transportResponse.InterceptorResponse.StatusCode
 	}
 
-	// For an oauth destination the transport wraps the upstream error into a valid envelope, so the
-	// unmarshal above succeeds and the infra failure only surfaces here, after OriginalResponse has
-	// been unwrapped. Classify it before the content checks, which assume a genuine transformer response.
-	if infraFailure {
-		trans.emitProxyInvalidResponse(proxyReqParams, "transport error",
-			"[TransformerProxy] transport returned a non-transformer response",
-			logger.NewIntField("statusCode", int64(httpPrxResp.statusCode)),
-			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
-		return proxyErrorResponse(respCode, string(respData), routerJobDontBatchDirectives)
-	}
-
 	/**
 
 		Structure of TransformerProxy Response:
@@ -563,8 +553,14 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	// `{"output":null}` slips through, unmarshals into an empty response set, and gets reported as an
 	// "in out mismatch" - sending the runbook down the data-corruption branch instead of this one.
 	if !output.Exists() || output.Type == gjson.Null {
-		trans.emitProxyInvalidResponse(proxyReqParams, "missing output",
-			"[TransformerProxy] proxy response missing output",
+		// A real upstream error (whose body has no output) lands here for oauth destinations - report
+		// it as transport error, not a breach. A 2xx with no output is a genuine missing-output breach.
+		reason, msg := "missing output", "[TransformerProxy] proxy response missing output"
+		if infraFailure {
+			reason, msg = "transport error", "[TransformerProxy] transport returned a non-transformer response"
+		}
+		trans.emitProxyInvalidResponse(proxyReqParams, reason, msg,
+			logger.NewIntField("statusCode", int64(httpPrxResp.statusCode)),
 			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
 		// There are no per-job results to apply without `output`. Continuing would set respData to
 		// an empty string and fail inside getResponse, reporting an empty body instead of the one
@@ -575,11 +571,15 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 
 	transResp, err := proxyReqParams.Adapter.getResponse(respData, respCode, proxyReqParams.ResponseData.Metadata)
 	if err != nil {
-		// The status was not an infra failure and `output` was present, so this is a genuine
-		// transformer response whose per-job payload will not parse - a contract breach, not infra.
-		// Same "unmarshal error" reason as the outer envelope; the other breach paths already emit.
-		trans.emitProxyInvalidResponse(proxyReqParams, "unmarshal error",
-			"[TransformerProxy] proxy response output unmarshal failed",
+		// output was present but its per-job payload will not parse. On a 2xx this is a genuine
+		// contract breach ("unmarshal error", like the outer envelope); an infra failure that happened
+		// to carry an output-shaped body is still infra.
+		reason, msg := "unmarshal error", "[TransformerProxy] proxy response output unmarshal failed"
+		if infraFailure {
+			reason, msg = "transport error", "[TransformerProxy] transport returned a non-transformer response"
+		}
+		trans.emitProxyInvalidResponse(proxyReqParams, reason, msg,
+			logger.NewIntField("statusCode", int64(httpPrxResp.statusCode)),
 			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
 		return proxyErrorResponse(respCode, err.Error(), routerJobDontBatchDirectives)
 	}

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -497,7 +497,6 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		trans.stats.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
 			"reason":        "unmarshal error",
 			"destType":      proxyReqParams.DestName,
-			"workspaceId":   proxyReqParams.ResponseData.Metadata[0].WorkspaceID,
 			"destinationId": proxyReqParams.ResponseData.Metadata[0].DestinationID,
 		}).Increment()
 		trans.logger.Warnn("[TransformerProxy] proxy response unmarshal failed",
@@ -531,7 +530,6 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		trans.stats.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
 			"reason":        "missing output",
 			"destType":      proxyReqParams.DestName,
-			"workspaceId":   proxyReqParams.ResponseData.Metadata[0].WorkspaceID,
 			"destinationId": proxyReqParams.ResponseData.Metadata[0].DestinationID,
 		}).Increment()
 		trans.logger.Warnn("[TransformerProxy] proxy response missing output",

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -500,6 +500,11 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 			"workspaceId":   proxyReqParams.ResponseData.Metadata[0].WorkspaceID,
 			"destinationId": proxyReqParams.ResponseData.Metadata[0].DestinationID,
 		}).Increment()
+		trans.logger.Warnn("[TransformerProxy] proxy response unmarshal failed",
+			obskit.DestinationID(proxyReqParams.ResponseData.Metadata[0].DestinationID),
+			logger.NewIntSliceField("jobIDs", lo.Map(proxyReqParams.ResponseData.Metadata, func(m ProxyRequestMetadata, _ int) int64 {
+				return m.JobID
+			})))
 	}
 	if transportResponse.OriginalResponse != "" {
 		respData = []byte(transportResponse.OriginalResponse)
@@ -529,6 +534,11 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 			"workspaceId":   proxyReqParams.ResponseData.Metadata[0].WorkspaceID,
 			"destinationId": proxyReqParams.ResponseData.Metadata[0].DestinationID,
 		}).Increment()
+		trans.logger.Warnn("[TransformerProxy] proxy response missing output",
+			obskit.DestinationID(proxyReqParams.ResponseData.Metadata[0].DestinationID),
+			logger.NewIntSliceField("jobIDs", lo.Map(proxyReqParams.ResponseData.Metadata, func(m ProxyRequestMetadata, _ int) int64 {
+				return m.JobID
+			})))
 	}
 	respData = []byte(output.Raw)
 

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -17,7 +17,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
@@ -437,12 +436,8 @@ func truncatedBody(b []byte) string {
 	if len(b) <= maxBodyBytes {
 		return string(b)
 	}
-	cut := b[:maxBodyBytes]
-	// Trim back off a partial rune so the cut does not emit U+FFFD.
-	if r, size := utf8.DecodeLastRune(cut); r == utf8.RuneError && size <= 1 {
-		cut = cut[:len(cut)-size]
-	}
-	return string(cut) + "...[truncated]"
+	// A cut can land mid-rune and render as U+FFFD; acceptable, since nothing reads this field.
+	return string(b[:maxBodyBytes]) + "...[truncated]"
 }
 
 // proxyErrorResponse builds the error-path response shared by every early return in ProxyRequest.
@@ -516,11 +511,11 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		return proxyErrorResponse(respCode, requestError.Error(), routerJobDontBatchDirectives)
 	}
 
-	// Infrastructure, not a contract breach: either this transport synthesized the response, or it
-	// never came from the transformer at all (an ingress/LB error page sets no apiVersion). Status is
-	// deliberately not part of this - v0 mirrors the destination's delivery status, so a destination
-	// 5xx would relabel a genuine breach as infra.
-	infraFailure := httpPrxResp.transportError || !httpPrxResp.fromTransformer
+	// Infrastructure, not a contract breach: the response never came from the transformer. Only the
+	// transformer sets apiVersion - an oauth-transport-synthesized error and an ingress/LB error page
+	// both lack it. Status is deliberately not part of this: v0 mirrors the destination's delivery
+	// status, so a destination 5xx would relabel a genuine breach as infra.
+	infraFailure := !httpPrxResp.fromTransformer
 
 	/*
 		respData will be in ProxyResponseV0 or ProxyResponseV1
@@ -599,13 +594,13 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	jobIDsInResponse := slices.Sorted(maps.Keys(transResp.routerJobResponseCodes))
 	// Non-fatal: the results were applied, but may be attached to the wrong jobs. Duplicate response
 	// entries collapse to one map key, silently dropping a status - a breach the set check cannot see.
-	duplicateResponses := transResp.responseEntries > len(transResp.routerJobResponseCodes)
+	duplicateResponses := transResp.responseEntriesCount > len(transResp.routerJobResponseCodes)
 	if !slices.Equal(jobIDsInMetadata, jobIDsInResponse) || duplicateResponses {
 		trans.emitProxyInvalidResponse(proxyReqParams, "in out mismatch",
 			"[TransformerProxy] JobIDs in out mismatch",
 			logger.NewIntSliceField("jobIDsInMetadata", jobIDsInMetadata),
 			logger.NewIntSliceField("jobIDsInResponse", jobIDsInResponse),
-			logger.NewIntField("responseEntries", int64(transResp.responseEntries)))
+			logger.NewIntField("responseEntries", int64(transResp.responseEntriesCount)))
 	}
 	integrations.CollectIntegrationFailureDetailedStats(trans.stats, transResp.statTags)
 
@@ -720,13 +715,9 @@ type httpProxyResponse struct {
 	respData   []byte
 	statusCode int
 	err        error
-	// transportError reports that this response was synthesized by the oauth transport rather than
-	// received from the transformer. Its body is a plain-text error string, so a non-JSON body on
-	// such a response is an infrastructure failure, not a transformer contract breach.
-	transportError bool
 	// fromTransformer reports that the response carried the apiVersion header, which only the
-	// transformer sets. An ingress/LB error page in front of the transformer carries neither it nor
-	// the transport marker, and is infrastructure rather than a contract breach.
+	// transformer sets. An oauth-transport-synthesized error or an ingress/LB error page carries none,
+	// and is infrastructure rather than a transformer contract breach.
 	fromTransformer bool
 }
 
@@ -826,7 +817,6 @@ func (trans *handle) doProxyRequest(ctx context.Context, proxyUrl string, proxyR
 	return httpProxyResponse{
 		respData:        respData,
 		statusCode:      resp.StatusCode,
-		transportError:  resp.Header.Get(oauthv2httpclient.TransportErrorHeader) != "",
 		fromTransformer: resp.Header.Get(apiVersionHeader) != "",
 	}
 }

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -491,9 +491,15 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		respData will be in ProxyResponseV0 or ProxyResponseV1
 	*/
 	var transportResponse oauthv2.TransportResponse // response that we get from oauth-interceptor in postRoundTrip
-	_ = jsonrs.Unmarshal(respData, &transportResponse)
 	// unmarshal unsuccessful scenarios
-	// if respData is not a valid json
+	// if respData is not a valid json, surface it instead of discarding the error
+	if err := jsonrs.Unmarshal(respData, &transportResponse); err != nil {
+		trans.stats.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
+			"reason":      "unmarshal error",
+			"destType":    proxyReqParams.DestName,
+			"workspaceId": proxyReqParams.ResponseData.Metadata[0].WorkspaceID,
+		}).Increment()
+	}
 	if transportResponse.OriginalResponse != "" {
 		respData = []byte(transportResponse.OriginalResponse)
 	}
@@ -514,9 +520,17 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 			}
 		}
 	**/
-	respData = []byte(gjson.GetBytes(respData, "output").Raw)
+	output := gjson.GetBytes(respData, "output")
+	if !output.Exists() {
+		trans.stats.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
+			"reason":      "missing output",
+			"destType":    proxyReqParams.DestName,
+			"workspaceId": proxyReqParams.ResponseData.Metadata[0].WorkspaceID,
+		}).Increment()
+	}
+	respData = []byte(output.Raw)
 
-	transResp, err := proxyReqParams.Adapter.getResponse(respData, respCode, proxyReqParams.ResponseData.Metadata)
+	transResp, err := proxyReqParams.Adapter.getResponse(respData, respCode, proxyReqParams.ResponseData.Metadata, proxyReqParams.DestName)
 	if err != nil {
 		return ProxyRequestResponse{
 			ProxyRequestStatusCode:   respCode,

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -428,6 +429,18 @@ func (trans *handle) emitProxyInvalidResponse(proxyReqParams *ProxyRequestParams
 	trans.logger.Warnn(msg, append([]logger.Field{obskit.DestinationID(destinationID)}, fields...)...)
 }
 
+// truncatedBody bounds an upstream body embedded in an error string. Nothing consumes
+// ProxyRequestResponseBody (router/worker.go reads only the per-job maps), and a batch response can
+// be multi-MB, so the whole payload is never worth stringifying. Sliced before the conversion so the
+// full body is not allocated first.
+func truncatedBody(b []byte) string {
+	const maxBodyBytes = int(10 * bytesize.KB)
+	if len(b) > maxBodyBytes {
+		return string(b[:maxBodyBytes]) + "...[truncated]"
+	}
+	return string(b)
+}
+
 // proxyErrorResponse builds the error-path response shared by every early return in ProxyRequest.
 // RespStatusCodes/RespBodys are always empty here by construction: per-job results only exist once
 // the adapter has parsed a response, which has not happened on any path that bails out early.
@@ -499,13 +512,16 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		return proxyErrorResponse(respCode, requestError.Error(), routerJobDontBatchDirectives)
 	}
 
-	// An upstream 5xx (transformer/LB/gateway) or a transport-synthesized response is an
-	// infrastructure failure, not a transformer contract breach. transportError marks the synthesized
-	// responses (including 4xx ones like a failed token fetch); the status marks a real upstream error
-	// that carried a body. It only selects the reason at the points below where the response cannot be
-	// processed - it never short-circuits a response that parses, so a 5xx that still carries a usable
-	// output is applied exactly as before, and only the metric reason changes for the failures.
-	infraFailure := httpPrxResp.transportError || httpPrxResp.statusCode >= http.StatusInternalServerError
+	// A response the oauth transport synthesized itself (failed token fetch, augmentation failure, LB
+	// round-trip error, unreadable body) is an infrastructure failure rather than a transformer
+	// contract breach, so it is reported under its own reason and excluded from the paging alert.
+	//
+	// The upstream status is deliberately not part of this signal: for v0 the transformer mirrors the
+	// destination's delivery status (deliveryPostProcess in rudder-transformer), so any destination 5xx
+	// comes from a perfectly healthy transformer and would relabel a genuine breach as infra. The
+	// status is logged instead, and only selects the reason at the points below where the response
+	// cannot be processed - a response that parses is applied exactly as before.
+	infraFailure := httpPrxResp.transportError
 
 	/*
 		respData will be in ProxyResponseV0 or ProxyResponseV1
@@ -517,15 +533,14 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	if err := jsonrs.Unmarshal(respData, &transportResponse); err != nil {
 		reason, msg := "unmarshal error", "[TransformerProxy] proxy response unmarshal failed"
 		if infraFailure {
-			reason, msg = "transport error", "[TransformerProxy] transport returned a non-transformer response"
+			reason, msg = "transport error", "[TransformerProxy] transport-synthesized response failed envelope unmarshal"
 		}
 		trans.emitProxyInvalidResponse(proxyReqParams, reason, msg,
 			logger.NewIntField("statusCode", int64(httpPrxResp.statusCode)),
 			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
 		// The payload is not JSON, so nothing downstream can read it: `output` cannot exist, and
-		// continuing would blank respData and fail inside getResponse on an empty body — losing the
-		// very payload that explains the breach. Stop here and return it.
-		return proxyErrorResponse(respCode, fmt.Sprintf("[TransformerProxy] response is not valid JSON: %s, err: %v", string(respData), err), routerJobDontBatchDirectives)
+		// continuing would blank respData and fail inside getResponse on an empty body. Stop here.
+		return proxyErrorResponse(respCode, fmt.Sprintf("[TransformerProxy] response is not valid JSON: %s, err: %v", truncatedBody(respData), err), routerJobDontBatchDirectives)
 	}
 	if transportResponse.OriginalResponse != "" {
 		respData = []byte(transportResponse.OriginalResponse)
@@ -553,11 +568,11 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	// `{"output":null}` slips through, unmarshals into an empty response set, and gets reported as an
 	// "in out mismatch" - sending the runbook down the data-corruption branch instead of this one.
 	if !output.Exists() || output.Type == gjson.Null {
-		// A real upstream error (whose body has no output) lands here for oauth destinations - report
-		// it as transport error, not a breach. A 2xx with no output is a genuine missing-output breach.
+		// A transport-synthesized body has no output either; keep it under its own reason so the
+		// breach signal stays clean. Anything else reaching here is a genuine missing-output breach.
 		reason, msg := "missing output", "[TransformerProxy] proxy response missing output"
 		if infraFailure {
-			reason, msg = "transport error", "[TransformerProxy] transport returned a non-transformer response"
+			reason, msg = "transport error", "[TransformerProxy] transport-synthesized response has no output field"
 		}
 		trans.emitProxyInvalidResponse(proxyReqParams, reason, msg,
 			logger.NewIntField("statusCode", int64(httpPrxResp.statusCode)),
@@ -565,18 +580,18 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 		// There are no per-job results to apply without `output`. Continuing would set respData to
 		// an empty string and fail inside getResponse, reporting an empty body instead of the one
 		// we actually received. Stop here and return it.
-		return proxyErrorResponse(respCode, fmt.Sprintf("[TransformerProxy] response has no output field: %s", string(respData)), routerJobDontBatchDirectives)
+		return proxyErrorResponse(respCode, fmt.Sprintf("[TransformerProxy] response has no output field: %s", truncatedBody(respData)), routerJobDontBatchDirectives)
 	}
 	respData = []byte(output.Raw)
 
 	transResp, err := proxyReqParams.Adapter.getResponse(respData, respCode, proxyReqParams.ResponseData.Metadata)
 	if err != nil {
-		// output was present but its per-job payload will not parse. On a 2xx this is a genuine
-		// contract breach ("unmarshal error", like the outer envelope); an infra failure that happened
-		// to carry an output-shaped body is still infra.
+		// output was present but its per-job payload will not parse - a genuine contract breach, under
+		// the same "unmarshal error" reason as the outer envelope. A transport-synthesized body that
+		// happened to carry an output field is still infra.
 		reason, msg := "unmarshal error", "[TransformerProxy] proxy response output unmarshal failed"
 		if infraFailure {
-			reason, msg = "transport error", "[TransformerProxy] transport returned a non-transformer response"
+			reason, msg = "transport error", "[TransformerProxy] transport-synthesized response output unmarshal failed"
 		}
 		trans.emitProxyInvalidResponse(proxyReqParams, reason, msg,
 			logger.NewIntField("statusCode", int64(httpPrxResp.statusCode)),
@@ -594,11 +609,19 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	jobIDsInResponse := slices.Sorted(maps.Keys(transResp.routerJobResponseCodes))
 	// Non-fatal: the per-job results were still applied, but they may be attached to the wrong jobs.
 	// Recorded here, alongside the other breach reasons, so all share one stats handle.
-	if !slices.Equal(jobIDsInMetadata, jobIDsInResponse) {
+	//
+	// Two distinct breaches, both "results attached to the wrong jobs":
+	//   sets differ      - the transformer answered for a different set of jobs than we sent
+	//   entries > keys   - it answered twice for the same job, so one status was silently dropped by
+	//                      the map write. Duplicates in the *request* are legitimate (see above) and
+	//                      are why the set comparison dedupes; duplicates in the *response* are not.
+	duplicateResponses := transResp.responseEntries > len(transResp.routerJobResponseCodes)
+	if !slices.Equal(jobIDsInMetadata, jobIDsInResponse) || duplicateResponses {
 		trans.emitProxyInvalidResponse(proxyReqParams, "in out mismatch",
 			"[TransformerProxy] JobIDs in out mismatch",
 			logger.NewIntSliceField("jobIDsInMetadata", jobIDsInMetadata),
-			logger.NewIntSliceField("jobIDsInResponse", jobIDsInResponse))
+			logger.NewIntSliceField("jobIDsInResponse", jobIDsInResponse),
+			logger.NewIntField("responseEntries", int64(transResp.responseEntries)))
 	}
 	integrations.CollectIntegrationFailureDetailedStats(trans.stats, transResp.statTags)
 

--- a/router/transformer/transformer.go
+++ b/router/transformer/transformer.go
@@ -50,6 +50,17 @@ const (
 	apiVersionHeader = "apiVersion"
 )
 
+// proxyInvalidResponseMetric and its reasons: a transformer-proxy response the server could not
+// reconcile with the request. transportError is infrastructure (the response did not come from the
+// transformer) and is excluded from the paging alert; the rest are contract breaches.
+const (
+	proxyInvalidResponseMetric = "router_transformerproxy_invalid_response"
+	reasonTransportError       = "transport error"
+	reasonUnmarshalError       = "unmarshal error"
+	reasonMissingOutput        = "missing output"
+	reasonInOutMismatch        = "in out mismatch"
+)
+
 // handle is the handle for this class
 type handle struct {
 	tr *http.Transport
@@ -97,7 +108,7 @@ type ProxyRequestPayload struct {
 
 type ProxyRequestParams struct {
 	ResponseData ProxyRequestPayload
-	DestName     string
+	DestType     string
 	Adapter      transformerProxyAdapter
 	Destination  *backendconfig.DestinationT
 	Connection   backendconfig.Connection `json:"connection"`
@@ -403,36 +414,18 @@ func (trans *handle) Transform(transformType string, transformMessage *types.Tra
 	return destinationJobs
 }
 
-// proxyJobIDs returns the jobIDs in a proxy request batch — what a responder needs to look the
-// affected events up in jobsDB.
-func proxyJobIDs(metadata []ProxyRequestMetadata) []int64 {
-	return lo.Map(metadata, func(m ProxyRequestMetadata, _ int) int64 {
+// JobIDs returns the jobIDs in a proxy request batch — what a responder needs to look the affected
+// events up in jobsDB.
+func (p *ProxyRequestPayload) JobIDs() []int64 {
+	return lo.Map(p.Metadata, func(m ProxyRequestMetadata, _ int) int64 {
 		return m.JobID
 	})
 }
 
-// emitProxyInvalidResponse records a transformer-proxy contract breach and logs the jobIDs needed
-// to inspect the affected events. Every breach reason goes through here so the metric keeps a single
-// tag set and a single stats handle. The response body is deliberately not logged: these are
-// debugged by reading the events out of jobsDB by jobID.
-//
-// Takes proxyReqParams rather than the destType/destinationId strings so the two cannot be
-// transposed at a call site and silently mis-tag the metric. Callers must be past ProxyRequest's
-// empty-metadata guard, which every breach site is.
-func (trans *handle) emitProxyInvalidResponse(proxyReqParams *ProxyRequestParams, reason, msg string, fields ...logger.Field) {
-	destinationID := proxyReqParams.ResponseData.Metadata[0].DestinationID
-	trans.stats.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
-		"reason":        reason,
-		"destType":      proxyReqParams.DestName,
-		"destinationId": destinationID,
-	}).Increment()
-	trans.logger.Warnn(msg, append([]logger.Field{obskit.DestinationID(destinationID)}, fields...)...)
-}
-
 // truncatedBody bounds a body embedded in an error string: nothing reads ProxyRequestResponseBody
-// and a batch response can be multi-MB.
+// and a batch response can be multi-MB. Sliced on the byte slice so the whole body is never allocated.
 func truncatedBody(b []byte) string {
-	const maxBodyBytes = int(10 * bytesize.KB)
+	const maxBodyBytes = int(1 * bytesize.KB)
 	if len(b) <= maxBodyBytes {
 		return string(b)
 	}
@@ -460,7 +453,7 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 
 	if len(proxyReqParams.ResponseData.Metadata) == 0 {
 		trans.logger.Warnn("[TransformerProxy] Input metadata is empty",
-			logger.NewStringField("destination", proxyReqParams.DestName))
+			logger.NewStringField("destination", proxyReqParams.DestType))
 		return proxyErrorResponse(http.StatusBadRequest, "Input metadata is empty", routerJobDontBatchDirectives)
 	}
 
@@ -469,14 +462,14 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	}
 
 	trans.logger.Debugn("[TransformerProxy] Proxy Request starts",
-		logger.NewStringField("destination", proxyReqParams.DestName))
+		logger.NewStringField("destination", proxyReqParams.DestType))
 
 	payload, err := proxyReqParams.Adapter.getPayload(proxyReqParams)
 	if err != nil {
 		return proxyErrorResponse(http.StatusInternalServerError, "Payload preparation failed", routerJobDontBatchDirectives)
 	}
 
-	proxyURL, err := proxyReqParams.Adapter.getProxyURL(proxyReqParams.DestName)
+	proxyURL, err := proxyReqParams.Adapter.getProxyURL(proxyReqParams.DestType)
 	if err != nil {
 		return proxyErrorResponse(http.StatusInternalServerError, "ProxyURL preparation failed", routerJobDontBatchDirectives)
 	}
@@ -485,7 +478,7 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	labels := transformerMetricLabels{
 		Endpoint:        getEndpointFromURL(proxyURL),
 		Stage:           "router_proxy",
-		DestinationType: proxyReqParams.DestName,
+		DestinationType: proxyReqParams.DestType,
 		WorkspaceID:     proxyReqParams.ResponseData.Metadata[0].WorkspaceID,
 		DestinationID:   proxyReqParams.ResponseData.Metadata[0].DestinationID,
 	}.ToStatsTag()
@@ -507,7 +500,28 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	trans.stats.NewTaggedStat("transformer_proxy_request_latency", stats.TimerType, labelsWithSuccess).SendTiming(duration)
 	trans.stats.NewTaggedStat("transformer_proxy_request_result", stats.CountType, labelsWithSuccess).Increment()
 
+	// emitBreach records a router_transformerproxy_invalid_response and logs the jobIDs needed to
+	// inspect the affected events in jobsDB. Declared here, past the empty-metadata guard, so Metadata[0]
+	// is safe and no destType/destinationId has to be threaded to a call site (and so mis-tagged). The
+	// body is deliberately not logged - these are debugged by reading the events out of jobsDB by jobID.
+	emitBreach := func(reason, msg string, fields ...logger.Field) {
+		destinationID := proxyReqParams.ResponseData.Metadata[0].DestinationID
+		trans.stats.NewTaggedStat(proxyInvalidResponseMetric, stats.CountType, stats.Tags{
+			"reason":        reason,
+			"destType":      proxyReqParams.DestType,
+			"destinationId": destinationID,
+		}).Increment()
+		trans.logger.Warnn(msg, append([]logger.Field{obskit.DestinationID(destinationID)}, fields...)...)
+	}
+
 	if requestError != nil {
+		// A raw transport failure (unreachable transformer, timeout, unreadable body). The oauth path
+		// synthesizes a response for these so they reach the classifier below, but a non-oauth
+		// destination surfaces them here as a Go error - emit so both show on the metric. Excluded from
+		// the alert like every transport error, so this pages nothing.
+		emitBreach(reasonTransportError, "[TransformerProxy] transport request failed",
+			logger.NewIntField("statusCode", int64(respCode)),
+			logger.NewIntSliceField("jobIDs", proxyReqParams.ResponseData.JobIDs()))
 		return proxyErrorResponse(respCode, requestError.Error(), routerJobDontBatchDirectives)
 	}
 
@@ -524,13 +538,13 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	// A non-oauth destination hands back the raw upstream body, so a non-JSON body here is either infra
 	// or a corrupt transformer response.
 	if err := jsonrs.Unmarshal(respData, &transportResponse); err != nil {
-		reason, msg := "unmarshal error", "[TransformerProxy] proxy response unmarshal failed"
+		reason, msg := reasonUnmarshalError, "[TransformerProxy] proxy response unmarshal failed"
 		if infraFailure {
-			reason, msg = "transport error", "[TransformerProxy] transport-synthesized response failed envelope unmarshal"
+			reason, msg = reasonTransportError, "[TransformerProxy] non-transformer response failed envelope unmarshal"
 		}
-		trans.emitProxyInvalidResponse(proxyReqParams, reason, msg,
+		emitBreach(reason, msg,
 			logger.NewIntField("statusCode", int64(httpPrxResp.statusCode)),
-			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
+			logger.NewIntSliceField("jobIDs", proxyReqParams.ResponseData.JobIDs()))
 		// Not JSON, so `output` cannot exist; continuing would blank respData and fail on an empty body.
 		return proxyErrorResponse(respCode, fmt.Sprintf("[TransformerProxy] response is not valid JSON: %s, err: %v", truncatedBody(respData), err), routerJobDontBatchDirectives)
 	}
@@ -560,14 +574,14 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	// `{"output":null}` slips through, unmarshals into an empty response set, and gets reported as an
 	// "in out mismatch" - sending the runbook down the data-corruption branch instead of this one.
 	if !output.Exists() || output.Type == gjson.Null {
-		// A transport-synthesized body has no output either, so it keeps its own reason.
-		reason, msg := "missing output", "[TransformerProxy] proxy response missing output"
+		// A non-transformer response has no output either, so it keeps its own reason.
+		reason, msg := reasonMissingOutput, "[TransformerProxy] proxy response missing output"
 		if infraFailure {
-			reason, msg = "transport error", "[TransformerProxy] transport-synthesized response has no output field"
+			reason, msg = reasonTransportError, "[TransformerProxy] non-transformer response has no output field"
 		}
-		trans.emitProxyInvalidResponse(proxyReqParams, reason, msg,
+		emitBreach(reason, msg,
 			logger.NewIntField("statusCode", int64(httpPrxResp.statusCode)),
-			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
+			logger.NewIntSliceField("jobIDs", proxyReqParams.ResponseData.JobIDs()))
 		// No per-job results to apply without `output`.
 		return proxyErrorResponse(respCode, fmt.Sprintf("[TransformerProxy] response has no output field: %s", truncatedBody(respData)), routerJobDontBatchDirectives)
 	}
@@ -577,26 +591,26 @@ func (trans *handle) ProxyRequest(ctx context.Context, proxyReqParams *ProxyRequ
 	if err != nil {
 		// output was present but its payload will not parse - same "unmarshal error" reason as the
 		// outer envelope.
-		reason, msg := "unmarshal error", "[TransformerProxy] proxy response output unmarshal failed"
+		reason, msg := reasonUnmarshalError, "[TransformerProxy] proxy response output unmarshal failed"
 		if infraFailure {
-			reason, msg = "transport error", "[TransformerProxy] transport-synthesized response output unmarshal failed"
+			reason, msg = reasonTransportError, "[TransformerProxy] non-transformer response output unmarshal failed"
 		}
-		trans.emitProxyInvalidResponse(proxyReqParams, reason, msg,
+		emitBreach(reason, msg,
 			logger.NewIntField("statusCode", int64(httpPrxResp.statusCode)),
-			logger.NewIntSliceField("jobIDs", proxyJobIDs(proxyReqParams.ResponseData.Metadata)))
+			logger.NewIntSliceField("jobIDs", proxyReqParams.ResponseData.JobIDs()))
 		return proxyErrorResponse(respCode, err.Error(), routerJobDontBatchDirectives)
 	}
 	// Compared as sets: a request can legitimately carry the same JobID twice (router/worker.go only
 	// dedupes when building final responses). Only meaningful for v1 - v0 keys the map by the request
 	// metadata, so the sets are equal by construction.
-	jobIDsInMetadata := lo.Uniq(proxyJobIDs(proxyReqParams.ResponseData.Metadata))
+	jobIDsInMetadata := lo.Uniq(proxyReqParams.ResponseData.JobIDs())
 	slices.Sort(jobIDsInMetadata)
 	jobIDsInResponse := slices.Sorted(maps.Keys(transResp.routerJobResponseCodes))
 	// Non-fatal: the results were applied, but may be attached to the wrong jobs. Duplicate response
 	// entries collapse to one map key, silently dropping a status - a breach the set check cannot see.
 	duplicateResponses := transResp.responseEntriesCount > len(transResp.routerJobResponseCodes)
 	if !slices.Equal(jobIDsInMetadata, jobIDsInResponse) || duplicateResponses {
-		trans.emitProxyInvalidResponse(proxyReqParams, "in out mismatch",
+		emitBreach(reasonInOutMismatch,
 			"[TransformerProxy] JobIDs in out mismatch",
 			logger.NewIntSliceField("jobIDsInMetadata", jobIDsInMetadata),
 			logger.NewIntSliceField("jobIDsInResponse", jobIDsInResponse),
@@ -723,7 +737,7 @@ type httpProxyResponse struct {
 
 func (trans *handle) doProxyRequest(ctx context.Context, proxyUrl string, proxyReqParams *ProxyRequestParams, payload []byte) httpProxyResponse {
 	var respData []byte
-	destName := proxyReqParams.DestName
+	destName := proxyReqParams.DestType
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, proxyUrl, bytes.NewReader(payload))
 	if err != nil {
 		trans.logger.Errorn("[TransformerProxy] NewRequestWithContext Failed",

--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -46,9 +46,8 @@ type TransResponse struct {
 	routerJobDontBatchDirectives map[int64]bool
 	authErrorCategory            string
 	statTags                     map[string]string
-	// responseEntries is how many per-job entries the transformer actually returned, before they were
-	// keyed into the maps above. It is not derivable from those maps: two entries for the same jobID
-	// collapse to one key (last write wins), which is a breach the caller has to be able to see.
+	// responseEntries is the raw per-job entry count. Not derivable from the maps above: two entries
+	// for one jobID collapse to a single key.
 	responseEntries int
 }
 
@@ -111,8 +110,7 @@ func (v0 *v0Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 			routerJobDontBatchDirectives: routerJobDontBatchDirectives,
 			authErrorCategory:            transformerResponse.AuthErrorCategory,
 			statTags:                     transformerResponse.StatTags,
-			// v0 has no per-job response array - the map is keyed off the request metadata, so there is
-			// one entry per key by construction and the duplicate check below can never trip.
+			// v0 has no per-job response array; keyed off the request metadata, so one entry per key.
 			responseEntries: len(routerJobResponseCodes),
 		},
 		nil
@@ -148,10 +146,7 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 			fmt.Errorf("[TransformerProxy Unmarshalling]:: respData: %s, err: %w", string(respData), err)
 	}
 
-	// routerJobResponseCodes is keyed by the jobIDs the transformer returned results for, so its keys
-	// are the response's jobID set. The caller compares that against the request's jobIDs to detect a
-	// transformer that answered for a different set of jobs than we sent - the "in out mismatch"
-	// breach - keeping all three breach reasons in one place.
+	// Keys become the response's jobID set, which the caller compares against the request's.
 	for _, resp := range transformerResponse.Response {
 		routerJobResponseCodes[resp.Metadata.JobID] = resp.StatusCode
 		routerJobResponseBodys[resp.Metadata.JobID] = resp.Error

--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -158,16 +158,17 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 			fmt.Errorf("[TransformerProxy Unmarshalling]:: respData: %s, err: %w", string(respData), err)
 	}
 
-	// Deduped: a batch can legitimately carry the same JobID more than once (router/worker.go dedupes
-	// the same way before building responses), while the transformer returns one entry per job. Without
-	// this, metadata [11,11,21] against response [11,21] is a spurious mismatch - and now an alerted one.
+	// Compared as sets: a batch can legitimately carry the same JobID more than once (router/worker.go
+	// only dedupes when building the final job responses), and the transformer may either collapse
+	// those duplicates or echo one entry per input item. Both are valid, so deduping only one side
+	// would make the comparison sensitive to which one it does - and this now pages.
 	jobIDsInMetadata := lo.Uniq(lo.Map(metadata, func(m ProxyRequestMetadata, _ int) int64 {
 		return m.JobID
 	}))
 	slices.Sort(jobIDsInMetadata)
-	jobIDsInResponse := lo.Map(transformerResponse.Response, func(resp TPDestResponse, _ int) int64 {
+	jobIDsInResponse := lo.Uniq(lo.Map(transformerResponse.Response, func(resp TPDestResponse, _ int) int64 {
 		return resp.Metadata.JobID
-	})
+	}))
 	slices.Sort(jobIDsInResponse)
 
 	// Report the mismatch rather than recording it here. Emitting from the adapter would write this

--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -164,7 +164,6 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 		stats.Default.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
 			"reason":        "in out mismatch",
 			"destType":      destType,
-			"workspaceId":   metadata[0].WorkspaceID,
 			"destinationId": metadata[0].DestinationID,
 		}).Increment()
 		v1.logger.Warnn("[TransformerProxy] JobIDs in out mismatch",

--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
 
 	"github.com/rudderlabs/rudder-server/processor/integrations"
 )
@@ -22,7 +21,7 @@ import (
 type transformerProxyAdapter interface {
 	getPayload(proxyReqParams *ProxyRequestParams) ([]byte, error)
 	getProxyURL(destType string) (string, error)
-	getResponse(response []byte, respCode int, metadata []ProxyRequestMetadata, destType string) (TransResponse, error)
+	getResponse(response []byte, respCode int, metadata []ProxyRequestMetadata) (TransResponse, error)
 }
 
 type ProxyRequestPayloadV0 struct {
@@ -52,6 +51,14 @@ type TransResponse struct {
 	routerJobDontBatchDirectives map[int64]bool
 	authErrorCategory            string
 	statTags                     map[string]string
+	// jobIDMismatch reports that the transformer returned results for a different set of jobIDs
+	// than were sent, meaning per-job results are attributed to the wrong jobs. The adapter only
+	// reports it; the caller records the metric, so every breach reason goes through one stats
+	// handle. jobIDsInMetadata/jobIDsInResponse are the two sorted sets, and their difference is
+	// what makes the breach diagnosable.
+	jobIDMismatch    bool
+	jobIDsInMetadata []int64
+	jobIDsInResponse []int64
 }
 
 type TPDestResponse struct {
@@ -84,7 +91,7 @@ func (v0 *v0Adapter) getProxyURL(destType string) (string, error) {
 	return getTransformerProxyURL("v0", destType)
 }
 
-func (v0 *v0Adapter) getResponse(respData []byte, respCode int, metadata []ProxyRequestMetadata, _ string) (TransResponse, error) {
+func (v0 *v0Adapter) getResponse(respData []byte, respCode int, metadata []ProxyRequestMetadata) (TransResponse, error) {
 	routerJobResponseCodes := make(map[int64]int)
 	routerJobResponseBodys := make(map[int64]string)
 	routerJobDontBatchDirectives := make(map[int64]bool)
@@ -129,7 +136,7 @@ func (v1 *v1Adapter) getProxyURL(destType string) (string, error) {
 	return getTransformerProxyURL("v1", destType)
 }
 
-func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []ProxyRequestMetadata, destType string) (TransResponse, error) {
+func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []ProxyRequestMetadata) (TransResponse, error) {
 	routerJobResponseCodes := make(map[int64]int)
 	routerJobResponseBodys := make(map[int64]string)
 	routerJobDontBatchDirectives := make(map[int64]bool)
@@ -160,17 +167,10 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 	})
 	slices.Sort(jobIDsInResponse)
 
-	if !reflect.DeepEqual(jobIDsInMetadata, jobIDsInResponse) {
-		stats.Default.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
-			"reason":        "in out mismatch",
-			"destType":      destType,
-			"destinationId": metadata[0].DestinationID,
-		}).Increment()
-		v1.logger.Warnn("[TransformerProxy] JobIDs in out mismatch",
-			logger.NewStringField("destinationId", metadata[0].DestinationID),
-			logger.NewIntSliceField("jobIDsInMetadata", jobIDsInMetadata),
-			logger.NewIntSliceField("jobIDsInResponse", jobIDsInResponse))
-	}
+	// Report the mismatch rather than recording it here. Emitting from the adapter would write this
+	// metric through the package-global stats handle while the other breach reasons use the
+	// caller's, splitting one metric across two sinks and hiding this reason from an injected mock.
+	jobIDMismatch := !reflect.DeepEqual(jobIDsInMetadata, jobIDsInResponse)
 
 	for _, resp := range transformerResponse.Response {
 		routerJobResponseCodes[resp.Metadata.JobID] = resp.StatusCode
@@ -184,6 +184,9 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 			routerJobDontBatchDirectives: routerJobDontBatchDirectives,
 			authErrorCategory:            transformerResponse.AuthErrorCategory,
 			statTags:                     transformerResponse.StatTags,
+			jobIDMismatch:                jobIDMismatch,
+			jobIDsInMetadata:             jobIDsInMetadata,
+			jobIDsInResponse:             jobIDsInResponse,
 		},
 		nil
 }

--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -46,9 +46,9 @@ type TransResponse struct {
 	routerJobDontBatchDirectives map[int64]bool
 	authErrorCategory            string
 	statTags                     map[string]string
-	// responseEntries is the raw per-job entry count. Not derivable from the maps above: two entries
-	// for one jobID collapse to a single key.
-	responseEntries int
+	// responseEntriesCount is the raw per-job entry count. Not derivable from the maps above: two
+	// entries for one jobID collapse to a single key.
+	responseEntriesCount int
 }
 
 type TPDestResponse struct {
@@ -111,7 +111,7 @@ func (v0 *v0Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 			authErrorCategory:            transformerResponse.AuthErrorCategory,
 			statTags:                     transformerResponse.StatTags,
 			// v0 has no per-job response array; keyed off the request metadata, so one entry per key.
-			responseEntries: len(routerJobResponseCodes),
+			responseEntriesCount: len(routerJobResponseCodes),
 		},
 		nil
 }
@@ -159,7 +159,7 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 			routerJobDontBatchDirectives: routerJobDontBatchDirectives,
 			authErrorCategory:            transformerResponse.AuthErrorCategory,
 			statTags:                     transformerResponse.StatTags,
-			responseEntries:              len(transformerResponse.Response),
+			responseEntriesCount:         len(transformerResponse.Response),
 		},
 		nil
 }

--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -5,11 +5,7 @@ package transformer
 import (
 	"fmt"
 	"net/url"
-	"reflect"
-	"slices"
 	"strings"
-
-	"github.com/samber/lo"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
@@ -51,14 +47,6 @@ type TransResponse struct {
 	routerJobDontBatchDirectives map[int64]bool
 	authErrorCategory            string
 	statTags                     map[string]string
-	// jobIDMismatch reports that the transformer returned results for a different set of jobIDs
-	// than were sent, meaning per-job results are attributed to the wrong jobs. The adapter only
-	// reports it; the caller records the metric, so every breach reason goes through one stats
-	// handle. jobIDsInMetadata/jobIDsInResponse are the two sorted sets, and their difference is
-	// what makes the breach diagnosable.
-	jobIDMismatch    bool
-	jobIDsInMetadata []int64
-	jobIDsInResponse []int64
 }
 
 type TPDestResponse struct {
@@ -158,24 +146,10 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 			fmt.Errorf("[TransformerProxy Unmarshalling]:: respData: %s, err: %w", string(respData), err)
 	}
 
-	// Compared as sets: a batch can legitimately carry the same JobID more than once (router/worker.go
-	// only dedupes when building the final job responses), and the transformer may either collapse
-	// those duplicates or echo one entry per input item. Both are valid, so deduping only one side
-	// would make the comparison sensitive to which one it does - and this now pages.
-	jobIDsInMetadata := lo.Uniq(lo.Map(metadata, func(m ProxyRequestMetadata, _ int) int64 {
-		return m.JobID
-	}))
-	slices.Sort(jobIDsInMetadata)
-	jobIDsInResponse := lo.Uniq(lo.Map(transformerResponse.Response, func(resp TPDestResponse, _ int) int64 {
-		return resp.Metadata.JobID
-	}))
-	slices.Sort(jobIDsInResponse)
-
-	// Report the mismatch rather than recording it here. Emitting from the adapter would write this
-	// metric through the package-global stats handle while the other breach reasons use the
-	// caller's, splitting one metric across two sinks and hiding this reason from an injected mock.
-	jobIDMismatch := !reflect.DeepEqual(jobIDsInMetadata, jobIDsInResponse)
-
+	// routerJobResponseCodes is keyed by the jobIDs the transformer returned results for, so its keys
+	// are the response's jobID set. The caller compares that against the request's jobIDs to detect a
+	// transformer that answered for a different set of jobs than we sent - the "in out mismatch"
+	// breach - keeping all three breach reasons in one place.
 	for _, resp := range transformerResponse.Response {
 		routerJobResponseCodes[resp.Metadata.JobID] = resp.StatusCode
 		routerJobResponseBodys[resp.Metadata.JobID] = resp.Error
@@ -188,9 +162,6 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 			routerJobDontBatchDirectives: routerJobDontBatchDirectives,
 			authErrorCategory:            transformerResponse.AuthErrorCategory,
 			statTags:                     transformerResponse.StatTags,
-			jobIDMismatch:                jobIDMismatch,
-			jobIDsInMetadata:             jobIDsInMetadata,
-			jobIDsInResponse:             jobIDsInResponse,
 		},
 		nil
 }

--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -158,9 +158,12 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 			fmt.Errorf("[TransformerProxy Unmarshalling]:: respData: %s, err: %w", string(respData), err)
 	}
 
-	jobIDsInMetadata := lo.Map(metadata, func(m ProxyRequestMetadata, _ int) int64 {
+	// Deduped: a batch can legitimately carry the same JobID more than once (router/worker.go dedupes
+	// the same way before building responses), while the transformer returns one entry per job. Without
+	// this, metadata [11,11,21] against response [11,21] is a spurious mismatch - and now an alerted one.
+	jobIDsInMetadata := lo.Uniq(lo.Map(metadata, func(m ProxyRequestMetadata, _ int) int64 {
 		return m.JobID
-	})
+	}))
 	slices.Sort(jobIDsInMetadata)
 	jobIDsInResponse := lo.Map(transformerResponse.Response, func(resp TPDestResponse, _ int) int64 {
 		return resp.Metadata.JobID

--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
-	"github.com/rudderlabs/rudder-go-kit/logger"
 
 	"github.com/rudderlabs/rudder-server/processor/integrations"
 )
@@ -47,6 +46,10 @@ type TransResponse struct {
 	routerJobDontBatchDirectives map[int64]bool
 	authErrorCategory            string
 	statTags                     map[string]string
+	// responseEntries is how many per-job entries the transformer actually returned, before they were
+	// keyed into the maps above. It is not derivable from those maps: two entries for the same jobID
+	// collapse to one key (last write wins), which is a breach the caller has to be able to see.
+	responseEntries int
 }
 
 type TPDestResponse struct {
@@ -56,12 +59,8 @@ type TPDestResponse struct {
 }
 
 type (
-	v0Adapter struct {
-		logger logger.Logger
-	}
-	v1Adapter struct {
-		logger logger.Logger
-	}
+	v0Adapter struct{}
+	v1Adapter struct{}
 )
 
 func (v0 *v0Adapter) getPayload(proxyReqParams *ProxyRequestParams) ([]byte, error) {
@@ -112,6 +111,9 @@ func (v0 *v0Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 			routerJobDontBatchDirectives: routerJobDontBatchDirectives,
 			authErrorCategory:            transformerResponse.AuthErrorCategory,
 			statTags:                     transformerResponse.StatTags,
+			// v0 has no per-job response array - the map is keyed off the request metadata, so there is
+			// one entry per key by construction and the duplicate check below can never trip.
+			responseEntries: len(routerJobResponseCodes),
 		},
 		nil
 }
@@ -162,6 +164,7 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 			routerJobDontBatchDirectives: routerJobDontBatchDirectives,
 			authErrorCategory:            transformerResponse.AuthErrorCategory,
 			statTags:                     transformerResponse.StatTags,
+			responseEntries:              len(transformerResponse.Response),
 		},
 		nil
 }
@@ -178,10 +181,10 @@ func getTransformerProxyURL(version, destType string) (string, error) {
 	return url.JoinPath(baseURL, version, "destinations", strings.ToLower(destType), "proxy")
 }
 
-func NewTransformerProxyAdapter(version string, logger logger.Logger) transformerProxyAdapter {
+func NewTransformerProxyAdapter(version string) transformerProxyAdapter {
 	switch version {
 	case "v1":
-		return &v1Adapter{logger: logger}
+		return &v1Adapter{}
 	}
-	return &v0Adapter{logger: logger}
+	return &v0Adapter{}
 }

--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -162,9 +162,10 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 
 	if !reflect.DeepEqual(jobIDsInMetadata, jobIDsInResponse) {
 		stats.Default.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
-			"reason":      "in out mismatch",
-			"destType":    destType,
-			"workspaceId": metadata[0].WorkspaceID,
+			"reason":        "in out mismatch",
+			"destType":      destType,
+			"workspaceId":   metadata[0].WorkspaceID,
+			"destinationId": metadata[0].DestinationID,
 		}).Increment()
 		v1.logger.Warnn("[TransformerProxy] JobIDs in out mismatch",
 			logger.NewIntSliceField("jobIDsInMetadata", jobIDsInMetadata),

--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -168,6 +168,7 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 			"destinationId": metadata[0].DestinationID,
 		}).Increment()
 		v1.logger.Warnn("[TransformerProxy] JobIDs in out mismatch",
+			logger.NewStringField("destinationId", metadata[0].DestinationID),
 			logger.NewIntSliceField("jobIDsInMetadata", jobIDsInMetadata),
 			logger.NewIntSliceField("jobIDsInResponse", jobIDsInResponse))
 	}

--- a/router/transformer/transformer_proxy_adapter.go
+++ b/router/transformer/transformer_proxy_adapter.go
@@ -22,7 +22,7 @@ import (
 type transformerProxyAdapter interface {
 	getPayload(proxyReqParams *ProxyRequestParams) ([]byte, error)
 	getProxyURL(destType string) (string, error)
-	getResponse(response []byte, respCode int, metadata []ProxyRequestMetadata) (TransResponse, error)
+	getResponse(response []byte, respCode int, metadata []ProxyRequestMetadata, destType string) (TransResponse, error)
 }
 
 type ProxyRequestPayloadV0 struct {
@@ -84,7 +84,7 @@ func (v0 *v0Adapter) getProxyURL(destType string) (string, error) {
 	return getTransformerProxyURL("v0", destType)
 }
 
-func (v0 *v0Adapter) getResponse(respData []byte, respCode int, metadata []ProxyRequestMetadata) (TransResponse, error) {
+func (v0 *v0Adapter) getResponse(respData []byte, respCode int, metadata []ProxyRequestMetadata, _ string) (TransResponse, error) {
 	routerJobResponseCodes := make(map[int64]int)
 	routerJobResponseBodys := make(map[int64]string)
 	routerJobDontBatchDirectives := make(map[int64]bool)
@@ -129,7 +129,7 @@ func (v1 *v1Adapter) getProxyURL(destType string) (string, error) {
 	return getTransformerProxyURL("v1", destType)
 }
 
-func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []ProxyRequestMetadata) (TransResponse, error) {
+func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []ProxyRequestMetadata, destType string) (TransResponse, error) {
 	routerJobResponseCodes := make(map[int64]int)
 	routerJobResponseBodys := make(map[int64]string)
 	routerJobDontBatchDirectives := make(map[int64]bool)
@@ -162,7 +162,9 @@ func (v1 *v1Adapter) getResponse(respData []byte, respCode int, metadata []Proxy
 
 	if !reflect.DeepEqual(jobIDsInMetadata, jobIDsInResponse) {
 		stats.Default.NewTaggedStat(`router.transformerproxy.invalid.response`, stats.CountType, stats.Tags{
-			"reason": "in out mismatch",
+			"reason":      "in out mismatch",
+			"destType":    destType,
+			"workspaceId": metadata[0].WorkspaceID,
 		}).Increment()
 		v1.logger.Warnn("[TransformerProxy] JobIDs in out mismatch",
 			logger.NewIntSliceField("jobIDsInMetadata", jobIDsInMetadata),

--- a/router/transformer/transformer_proxy_adapter_test.go
+++ b/router/transformer/transformer_proxy_adapter_test.go
@@ -80,7 +80,7 @@ func TestV0Adapter(t *testing.T) {
 		r, err := jsonrs.Marshal(resp)
 		require.Nil(t, err)
 
-		response, err := v0Adapter.getResponse(r, 200, metadata, "testDestType")
+		response, err := v0Adapter.getResponse(r, 200, metadata)
 		require.Nil(t, err)
 		require.Equal(t, 2, len(response.routerJobResponseCodes))
 		require.Equal(t, 2, len(response.routerJobResponseBodys))
@@ -110,7 +110,7 @@ func TestV0Adapter(t *testing.T) {
 			},
 		}
 
-		response, err := v0Adapter.getResponse([]byte(`abc`), 200, metadata, "testDestType")
+		response, err := v0Adapter.getResponse([]byte(`abc`), 200, metadata)
 		require.NotNil(t, err)
 
 		require.Equal(t, 0, len(response.routerJobResponseCodes))
@@ -212,7 +212,7 @@ func TestV1Adapter(t *testing.T) {
 		r, err := jsonrs.Marshal(resp)
 		require.Nil(t, err)
 
-		response, err := v1Adapter.getResponse(r, 200, metadata, "testDestType")
+		response, err := v1Adapter.getResponse(r, 200, metadata)
 		require.Nil(t, err)
 		require.Equal(t, 2, len(response.routerJobResponseCodes))
 		require.Equal(t, 2, len(response.routerJobResponseBodys))
@@ -230,7 +230,7 @@ func TestV1Adapter(t *testing.T) {
 		require.Equal(t, "oauth123", response.authErrorCategory)
 	})
 
-	t.Run("should produce warning log when in and out jobIDs mismatch", func(t *testing.T) {
+	t.Run("should report a jobID mismatch when in and out jobIDs differ", func(t *testing.T) {
 		metadata := []ProxyRequestMetadata{
 			{
 				JobID:     11,
@@ -274,10 +274,15 @@ func TestV1Adapter(t *testing.T) {
 		r, err := jsonrs.Marshal(resp)
 		require.Nil(t, err)
 
-		mockLogger.EXPECT().Warnn(gomock.Any(), gomock.Any()).Times(1)
-
-		response, err := v1Adapter.getResponse(r, 200, metadata, "testDestType")
+		response, err := v1Adapter.getResponse(r, 200, metadata)
 		require.Nil(t, err)
+
+		// The adapter reports the mismatch; ProxyRequest records the metric and logs it, so all
+		// breach reasons share one stats handle.
+		require.True(t, response.jobIDMismatch)
+		require.Equal(t, []int64{11, 21}, response.jobIDsInMetadata)
+		require.Equal(t, []int64{11, 21, 31}, response.jobIDsInResponse)
+
 		require.Equal(t, 3, len(response.routerJobResponseCodes))
 		require.Equal(t, 3, len(response.routerJobResponseBodys))
 		require.Equal(t, 3, len(response.routerJobDontBatchDirectives))
@@ -309,7 +314,7 @@ func TestV1Adapter(t *testing.T) {
 			},
 		}
 
-		response, err := v1Adapter.getResponse([]byte(`abc`), 200, metadata, "testDestType")
+		response, err := v1Adapter.getResponse([]byte(`abc`), 200, metadata)
 		require.NotNil(t, err)
 
 		require.Equal(t, 0, len(response.routerJobResponseCodes))

--- a/router/transformer/transformer_proxy_adapter_test.go
+++ b/router/transformer/transformer_proxy_adapter_test.go
@@ -80,7 +80,7 @@ func TestV0Adapter(t *testing.T) {
 		r, err := jsonrs.Marshal(resp)
 		require.Nil(t, err)
 
-		response, err := v0Adapter.getResponse(r, 200, metadata)
+		response, err := v0Adapter.getResponse(r, 200, metadata, "testDestType")
 		require.Nil(t, err)
 		require.Equal(t, 2, len(response.routerJobResponseCodes))
 		require.Equal(t, 2, len(response.routerJobResponseBodys))
@@ -110,7 +110,7 @@ func TestV0Adapter(t *testing.T) {
 			},
 		}
 
-		response, err := v0Adapter.getResponse([]byte(`abc`), 200, metadata)
+		response, err := v0Adapter.getResponse([]byte(`abc`), 200, metadata, "testDestType")
 		require.NotNil(t, err)
 
 		require.Equal(t, 0, len(response.routerJobResponseCodes))
@@ -212,7 +212,7 @@ func TestV1Adapter(t *testing.T) {
 		r, err := jsonrs.Marshal(resp)
 		require.Nil(t, err)
 
-		response, err := v1Adapter.getResponse(r, 200, metadata)
+		response, err := v1Adapter.getResponse(r, 200, metadata, "testDestType")
 		require.Nil(t, err)
 		require.Equal(t, 2, len(response.routerJobResponseCodes))
 		require.Equal(t, 2, len(response.routerJobResponseBodys))
@@ -276,7 +276,7 @@ func TestV1Adapter(t *testing.T) {
 
 		mockLogger.EXPECT().Warnn(gomock.Any(), gomock.Any()).Times(1)
 
-		response, err := v1Adapter.getResponse(r, 200, metadata)
+		response, err := v1Adapter.getResponse(r, 200, metadata, "testDestType")
 		require.Nil(t, err)
 		require.Equal(t, 3, len(response.routerJobResponseCodes))
 		require.Equal(t, 3, len(response.routerJobResponseBodys))
@@ -309,7 +309,7 @@ func TestV1Adapter(t *testing.T) {
 			},
 		}
 
-		response, err := v1Adapter.getResponse([]byte(`abc`), 200, metadata)
+		response, err := v1Adapter.getResponse([]byte(`abc`), 200, metadata, "testDestType")
 		require.NotNil(t, err)
 
 		require.Equal(t, 0, len(response.routerJobResponseCodes))

--- a/router/transformer/transformer_proxy_adapter_test.go
+++ b/router/transformer/transformer_proxy_adapter_test.go
@@ -7,19 +7,16 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
-	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/logger/mock_logger"
 
 	"github.com/rudderlabs/rudder-server/processor/integrations"
 	"github.com/rudderlabs/rudder-server/services/transformer"
 )
 
 func TestV0Adapter(t *testing.T) {
-	v0Adapter := NewTransformerProxyAdapter(transformer.V0, logger.NOP)
+	v0Adapter := NewTransformerProxyAdapter(transformer.V0)
 
 	t.Run("should return the right url", func(t *testing.T) {
 		testDestType := "testDestType"
@@ -130,10 +127,7 @@ func TestV0Adapter(t *testing.T) {
 }
 
 func TestV1Adapter(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockLogger := mock_logger.NewMockLogger(ctrl)
-
-	v1Adapter := NewTransformerProxyAdapter(transformer.V1, mockLogger)
+	v1Adapter := NewTransformerProxyAdapter(transformer.V1)
 
 	t.Run("should return the right url", func(t *testing.T) {
 		testDestType := "testDestType"
@@ -377,7 +371,7 @@ func TestProxyPayloadCarriesDestinationVersion(t *testing.T) {
 
 	for _, version := range []string{transformer.V0, transformer.V1} {
 		t.Run(version, func(t *testing.T) {
-			payload, err := NewTransformerProxyAdapter(version, logger.NOP).getPayload(params)
+			payload, err := NewTransformerProxyAdapter(version).getPayload(params)
 			require.NoError(t, err)
 
 			var got struct {

--- a/router/transformer/transformer_proxy_adapter_test.go
+++ b/router/transformer/transformer_proxy_adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -230,7 +231,7 @@ func TestV1Adapter(t *testing.T) {
 		require.Equal(t, "oauth123", response.authErrorCategory)
 	})
 
-	t.Run("should report a jobID mismatch when in and out jobIDs differ", func(t *testing.T) {
+	t.Run("should map every response entry by its jobID, including jobIDs not in the request", func(t *testing.T) {
 		metadata := []ProxyRequestMetadata{
 			{
 				JobID:     11,
@@ -277,11 +278,10 @@ func TestV1Adapter(t *testing.T) {
 		response, err := v1Adapter.getResponse(r, 200, metadata)
 		require.Nil(t, err)
 
-		// The adapter reports the mismatch; ProxyRequest records the metric and logs it, so all
-		// breach reasons share one stats handle.
-		require.True(t, response.jobIDMismatch)
-		require.Equal(t, []int64{11, 21}, response.jobIDsInMetadata)
-		require.Equal(t, []int64{11, 21, 31}, response.jobIDsInResponse)
+		// The keys of routerJobResponseCodes are the response's jobID set - what ProxyRequest compares
+		// against the request's jobIDs to detect an "in out mismatch". jobID 31 is in the response but
+		// not the request, so it is mapped and shows up in that set.
+		require.ElementsMatch(t, []int64{11, 21, 31}, lo.Keys(response.routerJobResponseCodes))
 
 		require.Equal(t, 3, len(response.routerJobResponseCodes))
 		require.Equal(t, 3, len(response.routerJobResponseBodys))
@@ -303,23 +303,24 @@ func TestV1Adapter(t *testing.T) {
 	})
 
 	// A batch can carry the same JobID more than once, and the transformer may either collapse the
-	// duplicates or echo one entry per input item. Neither is a contract breach, so neither may set
-	// jobIDMismatch - this metric pages.
+	// duplicates or echo one entry per input item. Either way the response map is keyed by jobID, so
+	// its keys are the deduped response set - the caller then compares that against the deduped request
+	// jobIDs, so a duplicate batch is never a spurious "in out mismatch" page.
 	for _, tc := range []struct {
-		name             string
-		jobIDsInResponse []int64
+		name          string
+		responseJobID []int64
 	}{
-		{name: "transformer collapses duplicate jobIDs", jobIDsInResponse: []int64{11, 21}},
-		{name: "transformer echoes duplicate jobIDs", jobIDsInResponse: []int64{11, 11, 21}},
+		{name: "transformer collapses duplicate jobIDs", responseJobID: []int64{11, 21}},
+		{name: "transformer echoes duplicate jobIDs", responseJobID: []int64{11, 11, 21}},
 	} {
-		t.Run("should not report a mismatch when the "+tc.name, func(t *testing.T) {
+		t.Run("should key the response map by the deduped set when the "+tc.name, func(t *testing.T) {
 			metadata := []ProxyRequestMetadata{
 				{JobID: 11, DontBatch: false},
 				{JobID: 11, DontBatch: false},
 				{JobID: 21, DontBatch: false},
 			}
 			resp := ProxyResponseV1{Message: "test"}
-			for _, jobID := range tc.jobIDsInResponse {
+			for _, jobID := range tc.responseJobID {
 				resp.Response = append(resp.Response, TPDestResponse{
 					StatusCode: 200,
 					Metadata:   ProxyRequestMetadata{JobID: jobID},
@@ -331,9 +332,7 @@ func TestV1Adapter(t *testing.T) {
 			response, err := v1Adapter.getResponse(r, 200, metadata)
 			require.Nil(t, err)
 
-			require.False(t, response.jobIDMismatch)
-			require.Equal(t, []int64{11, 21}, response.jobIDsInMetadata)
-			require.Equal(t, []int64{11, 21}, response.jobIDsInResponse)
+			require.ElementsMatch(t, []int64{11, 21}, lo.Keys(response.routerJobResponseCodes))
 		})
 	}
 

--- a/router/transformer/transformer_proxy_adapter_test.go
+++ b/router/transformer/transformer_proxy_adapter_test.go
@@ -302,6 +302,41 @@ func TestV1Adapter(t *testing.T) {
 		require.Equal(t, "oauth123", response.authErrorCategory)
 	})
 
+	// A batch can carry the same JobID more than once, and the transformer may either collapse the
+	// duplicates or echo one entry per input item. Neither is a contract breach, so neither may set
+	// jobIDMismatch - this metric pages.
+	for _, tc := range []struct {
+		name             string
+		jobIDsInResponse []int64
+	}{
+		{name: "transformer collapses duplicate jobIDs", jobIDsInResponse: []int64{11, 21}},
+		{name: "transformer echoes duplicate jobIDs", jobIDsInResponse: []int64{11, 11, 21}},
+	} {
+		t.Run("should not report a mismatch when the "+tc.name, func(t *testing.T) {
+			metadata := []ProxyRequestMetadata{
+				{JobID: 11, DontBatch: false},
+				{JobID: 11, DontBatch: false},
+				{JobID: 21, DontBatch: false},
+			}
+			resp := ProxyResponseV1{Message: "test"}
+			for _, jobID := range tc.jobIDsInResponse {
+				resp.Response = append(resp.Response, TPDestResponse{
+					StatusCode: 200,
+					Metadata:   ProxyRequestMetadata{JobID: jobID},
+				})
+			}
+			r, err := jsonrs.Marshal(resp)
+			require.Nil(t, err)
+
+			response, err := v1Adapter.getResponse(r, 200, metadata)
+			require.Nil(t, err)
+
+			require.False(t, response.jobIDMismatch)
+			require.Equal(t, []int64{11, 21}, response.jobIDsInMetadata)
+			require.Equal(t, []int64{11, 21}, response.jobIDsInResponse)
+		})
+	}
+
 	t.Run("should return the unmarshal error", func(t *testing.T) {
 		metadata := []ProxyRequestMetadata{
 			{

--- a/router/transformer/transformer_proxy_adapter_test.go
+++ b/router/transformer/transformer_proxy_adapter_test.go
@@ -50,7 +50,7 @@ func TestV0Adapter(t *testing.T) {
 					"key_2": "val_2",
 				},
 			},
-			DestName: "testDestType",
+			DestType: "testDestType",
 		}
 		expectedPayload := `{"type":"a","endpoint":"a.com","method":"","userId":"","headers":null,"params":null,"body":{"jobId":1},"files":null,"metadata":{"jobId":1,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":true},"destinationConfig":{"key_1":"val_1","key_2":"val_2"}}`
 
@@ -162,7 +162,7 @@ func TestV1Adapter(t *testing.T) {
 					"key_2": "val_2",
 				},
 			},
-			DestName: "testDestType",
+			DestType: "testDestType",
 		}
 		expectedPayload := `{"type":"a","endpoint":"a.com","method":"","userId":"","headers":null,"params":null,"body":{"jobId":1},"files":null,"metadata":[{"jobId":1,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":true},{"jobId":2,"attemptNum":0,"userId":"","sourceId":"","destinationId":"","workspaceId":"","secret":null,"dontBatch":false}],"destinationConfig":{"key_1":"val_1","key_2":"val_2"}}`
 

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -701,6 +701,9 @@ type oauthv2ProxyTcs struct {
 	destination backendconfig.DestinationT
 
 	ioReadError bool
+	// expected `reason` tag on router.transformerproxy.invalid.response.
+	// Empty means the metric is not asserted for this case.
+	expectedBreachReason string
 	// load-balancer erroring out
 	lbError bool
 }
@@ -1051,9 +1054,10 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 		destination: oauthDests[0],
 	},
 	{
-		description:  "[v1proxy] when transformer response body cannot be read, should have respStatus as 500, respBody should have transformer sent response",
-		proxyVersion: "v1",
-		ioReadError:  true,
+		description:          "[v1proxy] when transformer response body cannot be read, should have respStatus as 500, respBody should have transformer sent response",
+		proxyVersion:         "v1",
+		ioReadError:          true,
+		expectedBreachReason: "transport error",
 		transformerProxyResponseV1: ProxyResponseV1{
 			Message:           "some message that we got from transformer",
 			AuthErrorCategory: common.CategoryRefreshToken,
@@ -1131,10 +1135,11 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 		destination: oauthDests[0],
 	},
 	{
-		description:  "[v1proxy] when transformer does not respond properly",
-		proxyVersion: "v1",
-		lbError:      true,
-		destType:     "salesforce_oauth", // some destination
+		description:          "[v1proxy] when transformer does not respond properly",
+		proxyVersion:         "v1",
+		lbError:              true,
+		expectedBreachReason: "missing output",
+		destType:             "salesforce_oauth", // some destination
 		reqPayload: ProxyRequestPayload{
 			PostParametersT: integrations.PostParametersT{
 				Type:          "REST",
@@ -1188,10 +1193,11 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 		destination: oauthDests[0],
 	},
 	{
-		description:  "[v0proxy] when transformer does not respond properly",
-		proxyVersion: "v0",
-		lbError:      true,
-		destType:     "salesforce_oauth", // some destination
+		description:          "[v0proxy] when transformer does not respond properly",
+		proxyVersion:         "v0",
+		lbError:              true,
+		expectedBreachReason: "missing output",
+		destType:             "salesforce_oauth", // some destination
 		reqPayload: ProxyRequestPayload{
 			PostParametersT: integrations.PostParametersT{
 				Type:          "REST",
@@ -1692,6 +1698,10 @@ func TestProxyRequestWithOAuthV2(t *testing.T) {
 
 			tr := NewTransformer("destType", time.Minute, time.Minute, mockBackendConfig, expTimeDiff, nil, config.New())
 
+			statsStore, statsErr := memstats.New()
+			require.NoError(t, statsErr)
+			tr.(*handle).stats = statsStore
+
 			var adapter transformerProxyAdapter
 			adapter = NewTransformerProxyAdapter("v1", loggerOverride)
 			if tc.proxyVersion == "v0" {
@@ -1725,6 +1735,18 @@ func TestProxyRequestWithOAuthV2(t *testing.T) {
 				require.Equal(t, actualPrxResp, expectedPrxResp)
 			} else {
 				require.Contains(t, proxyResp.ProxyRequestResponseBody, tc.expected.ProxyRequestResponseBody)
+			}
+
+			// One breach must produce exactly one metric under exactly one reason: a body that is not
+			// valid JSON must not also trip "missing output", and a response synthesized by the oauth
+			// transport must not be reported as a transformer contract breach.
+			if tc.expectedBreachReason != "" {
+				breaches := statsStore.GetByName("router.transformerproxy.invalid.response")
+				reasons := make([]string, 0, len(breaches))
+				for _, b := range breaches {
+					reasons = append(reasons, b.Tags["reason"])
+				}
+				require.Equal(t, []string{tc.expectedBreachReason}, reasons)
 			}
 		})
 	}

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -1407,6 +1407,71 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 	},
 
 	{
+		description:  "[v1proxy] when the transformer answers for a different set of jobIDs than were sent, should page with reason in out mismatch",
+		proxyVersion: "v1",
+		transformerProxyResponseV1: ProxyResponseV1{
+			Message: "some message that we got from transformer",
+			// Two jobs were sent (see Metadata below) but the transformer only answered for job 1.
+			Response: []TPDestResponse{
+				{
+					StatusCode: http.StatusOK,
+					Metadata: ProxyRequestMetadata{
+						WorkspaceID:   "workspace_id",
+						DestinationID: "destination_id",
+						JobID:         1,
+					},
+					Error: "success",
+				},
+			},
+		},
+		destType: "salesforce_oauth", // some destination
+		reqPayload: ProxyRequestPayload{
+			PostParametersT: integrations.PostParametersT{
+				Type:          "REST",
+				URL:           "http://www.ctx_timeout_dest.domain.com",
+				RequestMethod: http.MethodPost,
+				QueryParams:   map[string]any{},
+				Body: map[string]any{
+					"JSON":       map[string]any{"key_1": "val_1"},
+					"FORM":       map[string]any{},
+					"JSON_ARRAY": map[string]any{},
+					"XML":        map[string]any{},
+				},
+				Files: map[string]any{},
+			},
+			Metadata: []ProxyRequestMetadata{
+				{
+					WorkspaceID:   "workspace_id",
+					DestinationID: "destination_id",
+					JobID:         1,
+				},
+				{
+					WorkspaceID:   "workspace_id",
+					DestinationID: "destination_id",
+					JobID:         2,
+				},
+			},
+			DestinationConfig: oauthDests[0].Config,
+		},
+		cpResponses: []testutils.CpResponseParams{},
+		expected: ProxyRequestResponse{
+			// DontBatchDirectives is seeded from the request metadata, so both jobs appear; the per-job
+			// status maps only carry job 1, the one the transformer actually answered for.
+			DontBatchDirectives: map[int64]bool{
+				1: false,
+				2: false,
+			},
+			RespBodys:                map[int64]string{1: "success"},
+			RespContentType:          "application/json",
+			ProxyRequestResponseBody: `{"message": "some message that we got from transformer","response":[{"statusCode":200,"error":"success","metadata":{"workspaceId":"workspace_id","destinationId":"destination_id","jobId":1}}]}`,
+			ProxyRequestStatusCode:   http.StatusOK,
+			RespStatusCodes:          map[int64]int{1: http.StatusOK},
+		},
+		destination:          oauthDests[0],
+		expectedBreachReason: "in out mismatch",
+	},
+
+	{
 		description:  "[v1proxy] when there are partial failures & no oauth errors, respective jobs should have their statuses",
 		proxyVersion: "v1",
 		transformerProxyResponseV1: ProxyResponseV1{

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -708,6 +708,9 @@ type oauthv2ProxyTcs struct {
 	lbError bool
 	// upstream HTTP status the mock transformer returns; 0 means the default 200.
 	upstreamStatusCode int
+	// body the mock returns verbatim, bypassing the {"output": ...} envelope. Used to exercise
+	// responses that have no output field at all, or an explicit null one.
+	rawBody string
 }
 
 var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
@@ -1140,7 +1143,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 		description:          "[v1proxy] when transformer does not respond properly",
 		proxyVersion:         "v1",
 		lbError:              true,
-		expectedBreachReason: "transport error",
+		expectedBreachReason: "missing output",
 		destType:             "salesforce_oauth", // some destination
 		reqPayload: ProxyRequestPayload{
 			PostParametersT: integrations.PostParametersT{
@@ -1198,7 +1201,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 		description:          "[v0proxy] when transformer does not respond properly",
 		proxyVersion:         "v0",
 		lbError:              true,
-		expectedBreachReason: "transport error",
+		expectedBreachReason: "missing output",
 		destType:             "salesforce_oauth", // some destination
 		reqPayload: ProxyRequestPayload{
 			PostParametersT: integrations.PostParametersT{
@@ -1619,6 +1622,145 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 	},
 
 	{
+		// The jobID sets match here, so the set comparison alone would miss this. The transformer
+		// answered twice for job 1 with conflicting statuses and the map write silently kept the last
+		// one - exactly the "results attached to the wrong jobs" breach, so the entry-count check
+		// has to catch it.
+		description:          "[v1proxy] when the transformer answers twice for the same jobID, should page with reason in out mismatch",
+		proxyVersion:         "v1",
+		expectedBreachReason: "in out mismatch",
+		transformerProxyResponseV1: ProxyResponseV1{
+			Message: "some message that we got from transformer",
+			Response: []TPDestResponse{
+				{
+					StatusCode: http.StatusOK,
+					Metadata:   ProxyRequestMetadata{WorkspaceID: "workspace_id", DestinationID: "destination_id", JobID: 1},
+					Error:      "first",
+				},
+				{
+					StatusCode: http.StatusOK,
+					Metadata:   ProxyRequestMetadata{WorkspaceID: "workspace_id", DestinationID: "destination_id", JobID: 2},
+					Error:      "success",
+				},
+				{
+					StatusCode: http.StatusInternalServerError,
+					Metadata:   ProxyRequestMetadata{WorkspaceID: "workspace_id", DestinationID: "destination_id", JobID: 1},
+					Error:      "second",
+				},
+			},
+		},
+		destType: "salesforce_oauth", // some destination
+		reqPayload: ProxyRequestPayload{
+			PostParametersT: integrations.PostParametersT{
+				Type:          "REST",
+				URL:           "http://www.ctx_timeout_dest.domain.com",
+				RequestMethod: http.MethodPost,
+				QueryParams:   map[string]any{},
+				Body: map[string]any{
+					"JSON":       map[string]any{"key_1": "val_1"},
+					"FORM":       map[string]any{},
+					"JSON_ARRAY": map[string]any{},
+					"XML":        map[string]any{},
+				},
+				Files: map[string]any{},
+			},
+			Metadata: []ProxyRequestMetadata{
+				{WorkspaceID: "workspace_id", DestinationID: "destination_id", JobID: 1},
+				{WorkspaceID: "workspace_id", DestinationID: "destination_id", JobID: 2},
+			},
+			DestinationConfig: oauthDests[0].Config,
+		},
+		cpResponses: []testutils.CpResponseParams{},
+		expected: ProxyRequestResponse{
+			DontBatchDirectives: map[int64]bool{1: false, 2: false},
+			// Job 1's first status is gone - last write wins - which is why this must be flagged.
+			RespBodys:                map[int64]string{1: "second", 2: "success"},
+			RespContentType:          "application/json",
+			ProxyRequestResponseBody: `{"message": "some message that we got from transformer","response":[{"statusCode":200,"error":"first","metadata":{"workspaceId":"workspace_id","destinationId":"destination_id","jobId":1}}]}`,
+			ProxyRequestStatusCode:   http.StatusOK,
+			RespStatusCodes:          map[int64]int{1: http.StatusInternalServerError, 2: http.StatusOK},
+		},
+		destination: oauthDests[0],
+	},
+
+	{
+		description:          "[v1proxy] when the response body has no output field, should page with reason missing output",
+		proxyVersion:         "v1",
+		rawBody:              `{"message":"transformer said something without an output field"}`,
+		expectedBreachReason: "missing output",
+		destType:             "salesforce_oauth", // some destination
+		reqPayload: ProxyRequestPayload{
+			PostParametersT: integrations.PostParametersT{
+				Type:          "REST",
+				URL:           "http://www.ctx_timeout_dest.domain.com",
+				RequestMethod: http.MethodPost,
+				QueryParams:   map[string]any{},
+				Body: map[string]any{
+					"JSON":       map[string]any{"key_1": "val_1"},
+					"FORM":       map[string]any{},
+					"JSON_ARRAY": map[string]any{},
+					"XML":        map[string]any{},
+				},
+				Files: map[string]any{},
+			},
+			Metadata: []ProxyRequestMetadata{
+				{WorkspaceID: "workspace_id", DestinationID: "destination_id", JobID: 1},
+			},
+			DestinationConfig: oauthDests[0].Config,
+		},
+		cpResponses: []testutils.CpResponseParams{},
+		expected: ProxyRequestResponse{
+			DontBatchDirectives:      map[int64]bool{1: false},
+			RespBodys:                map[int64]string{},
+			RespContentType:          "text/plain; charset=utf-8",
+			ProxyRequestResponseBody: `[TransformerProxy] response has no output field:`,
+			ProxyRequestStatusCode:   http.StatusInternalServerError,
+			RespStatusCodes:          map[int64]int{},
+		},
+		destination: oauthDests[0],
+	},
+
+	{
+		// Pins the output.Type == gjson.Null half of the guard: gjson reports an explicit null as
+		// existing, so dropping that check would let this through as an empty response set and get
+		// reported as "in out mismatch" instead.
+		description:          "[v1proxy] when the response output is explicitly null, should page with reason missing output",
+		proxyVersion:         "v1",
+		rawBody:              `{"output":null}`,
+		expectedBreachReason: "missing output",
+		destType:             "salesforce_oauth", // some destination
+		reqPayload: ProxyRequestPayload{
+			PostParametersT: integrations.PostParametersT{
+				Type:          "REST",
+				URL:           "http://www.ctx_timeout_dest.domain.com",
+				RequestMethod: http.MethodPost,
+				QueryParams:   map[string]any{},
+				Body: map[string]any{
+					"JSON":       map[string]any{"key_1": "val_1"},
+					"FORM":       map[string]any{},
+					"JSON_ARRAY": map[string]any{},
+					"XML":        map[string]any{},
+				},
+				Files: map[string]any{},
+			},
+			Metadata: []ProxyRequestMetadata{
+				{WorkspaceID: "workspace_id", DestinationID: "destination_id", JobID: 1},
+			},
+			DestinationConfig: oauthDests[0].Config,
+		},
+		cpResponses: []testutils.CpResponseParams{},
+		expected: ProxyRequestResponse{
+			DontBatchDirectives:      map[int64]bool{1: false},
+			RespBodys:                map[int64]string{},
+			RespContentType:          "text/plain; charset=utf-8",
+			ProxyRequestResponseBody: `[TransformerProxy] response has no output field:`,
+			ProxyRequestStatusCode:   http.StatusOK,
+			RespStatusCodes:          map[int64]int{},
+		},
+		destination: oauthDests[0],
+	},
+
+	{
 		description:  "[v1proxy] when there are partial failures & no oauth errors, respective jobs should have their statuses",
 		proxyVersion: "v1",
 		transformerProxyResponseV1: ProxyResponseV1{
@@ -1883,6 +2025,9 @@ func TestProxyRequestWithOAuthV2(t *testing.T) {
 					b = []byte(tc.transformerResponse)
 				}
 				outputJson, _ := sjson.SetRawBytes([]byte(`{}`), "output", b)
+				if tc.rawBody != "" {
+					outputJson = []byte(tc.rawBody)
+				}
 				// Lets a case set the upstream HTTP status while still returning a real transformer body,
 				// to exercise a 5xx that carries a usable output.
 				if tc.upstreamStatusCode != 0 {
@@ -1920,9 +2065,9 @@ func TestProxyRequestWithOAuthV2(t *testing.T) {
 			tr.(*handle).stats = statsStore
 
 			var adapter transformerProxyAdapter
-			adapter = NewTransformerProxyAdapter("v1", loggerOverride)
+			adapter = NewTransformerProxyAdapter("v1")
 			if tc.proxyVersion == "v0" {
-				adapter = NewTransformerProxyAdapter("v0", loggerOverride)
+				adapter = NewTransformerProxyAdapter("v0")
 			}
 
 			dest := tc.destination

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -706,6 +706,8 @@ type oauthv2ProxyTcs struct {
 	expectedBreachReason string
 	// load-balancer erroring out
 	lbError bool
+	// upstream HTTP status the mock transformer returns; 0 means the default 200.
+	upstreamStatusCode int
 }
 
 var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
@@ -1186,7 +1188,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 			RespBodys:       map[int64]string{},
 			RespContentType: "text/plain; charset=utf-8",
 			// Originally Response Body will look like this "Post \"http://<TF_SERVER>/v1/destinations/salesforce_oauth/proxy\": getting auth error category post roundTrip: LB cannot send to transformer"
-			ProxyRequestResponseBody: `LB cannot send to transformer`,
+			ProxyRequestResponseBody: `[TransformerProxy] response has no output field: LB cannot send to transformer`,
 			ProxyRequestStatusCode:   http.StatusInternalServerError,
 			RespStatusCodes:          map[int64]int{},
 		},
@@ -1238,7 +1240,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 			RespBodys:       map[int64]string{},
 			RespContentType: "text/plain; charset=utf-8",
 			// Originally Response Body will look like this "Post \"http://<TF_SERVER>/v1/destinations/salesforce_oauth/proxy\": getting auth error category post roundTrip: LB cannot send to transformer"
-			ProxyRequestResponseBody: `LB cannot send to transformer`,
+			ProxyRequestResponseBody: `[TransformerProxy] response has no output field: LB cannot send to transformer`,
 			ProxyRequestStatusCode:   http.StatusInternalServerError,
 			RespStatusCodes:          map[int64]int{},
 		},
@@ -1559,6 +1561,64 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 	},
 
 	{
+		description:        "[v1proxy] when the transformer returns a 5xx that still carries a usable output, per-job results are applied and it does not page",
+		proxyVersion:       "v1",
+		upstreamStatusCode: http.StatusBadGateway, // 502, but the body is a real, parseable transformer response
+		transformerProxyResponseV1: ProxyResponseV1{
+			Message: "some message that we got from transformer",
+			Response: []TPDestResponse{
+				{
+					StatusCode: http.StatusOK,
+					Metadata: ProxyRequestMetadata{
+						WorkspaceID:   "workspace_id",
+						DestinationID: "destination_id",
+						JobID:         1,
+					},
+					Error: "success",
+				},
+			},
+		},
+		destType: "salesforce_oauth", // some destination
+		reqPayload: ProxyRequestPayload{
+			PostParametersT: integrations.PostParametersT{
+				Type:          "REST",
+				URL:           "http://www.ctx_timeout_dest.domain.com",
+				RequestMethod: http.MethodPost,
+				QueryParams:   map[string]any{},
+				Body: map[string]any{
+					"JSON":       map[string]any{"key_1": "val_1"},
+					"FORM":       map[string]any{},
+					"JSON_ARRAY": map[string]any{},
+					"XML":        map[string]any{},
+				},
+				Files: map[string]any{},
+			},
+			Metadata: []ProxyRequestMetadata{
+				{
+					WorkspaceID:   "workspace_id",
+					DestinationID: "destination_id",
+					JobID:         1,
+				},
+			},
+			DestinationConfig: oauthDests[0].Config,
+		},
+		cpResponses: []testutils.CpResponseParams{},
+		expected: ProxyRequestResponse{
+			// The output parsed, so the per-job status is applied and the top-level 502 is preserved -
+			// exactly the pre-change behavior. A short-circuit on status would instead drop these and
+			// return empty maps, so this case guards against that regression.
+			DontBatchDirectives:      map[int64]bool{1: false},
+			RespBodys:                map[int64]string{1: "success"},
+			RespContentType:          "application/json",
+			ProxyRequestResponseBody: `{"message": "some message that we got from transformer","response":[{"statusCode":200,"error":"success","metadata":{"workspaceId":"workspace_id","destinationId":"destination_id","jobId":1}}]}`,
+			ProxyRequestStatusCode:   http.StatusBadGateway,
+			RespStatusCodes:          map[int64]int{1: http.StatusOK},
+		},
+		destination: oauthDests[0],
+		// No breach: a 5xx that carries a usable output is not an infra failure we page on.
+	},
+
+	{
 		description:  "[v1proxy] when there are partial failures & no oauth errors, respective jobs should have their statuses",
 		proxyVersion: "v1",
 		transformerProxyResponseV1: ProxyResponseV1{
@@ -1823,6 +1883,11 @@ func TestProxyRequestWithOAuthV2(t *testing.T) {
 					b = []byte(tc.transformerResponse)
 				}
 				outputJson, _ := sjson.SetRawBytes([]byte(`{}`), "output", b)
+				// Lets a case set the upstream HTTP status while still returning a real transformer body,
+				// to exercise a 5xx that carries a usable output.
+				if tc.upstreamStatusCode != 0 {
+					w.WriteHeader(tc.upstreamStatusCode)
+				}
 				if tc.ioReadError {
 					w.Header().Add("Content-Length", strconv.Itoa(len(string(outputJson))+10))
 					// return less bytes, which will result in an "unexpected EOF" from ioutil.ReadAll()

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -1138,7 +1138,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 		description:          "[v1proxy] when transformer does not respond properly",
 		proxyVersion:         "v1",
 		lbError:              true,
-		expectedBreachReason: "missing output",
+		expectedBreachReason: "transport error",
 		destType:             "salesforce_oauth", // some destination
 		reqPayload: ProxyRequestPayload{
 			PostParametersT: integrations.PostParametersT{
@@ -1186,7 +1186,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 			RespBodys:       map[int64]string{},
 			RespContentType: "text/plain; charset=utf-8",
 			// Originally Response Body will look like this "Post \"http://<TF_SERVER>/v1/destinations/salesforce_oauth/proxy\": getting auth error category post roundTrip: LB cannot send to transformer"
-			ProxyRequestResponseBody: `[TransformerProxy] response has no output field: LB cannot send to transformer`,
+			ProxyRequestResponseBody: `LB cannot send to transformer`,
 			ProxyRequestStatusCode:   http.StatusInternalServerError,
 			RespStatusCodes:          map[int64]int{},
 		},
@@ -1196,7 +1196,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 		description:          "[v0proxy] when transformer does not respond properly",
 		proxyVersion:         "v0",
 		lbError:              true,
-		expectedBreachReason: "missing output",
+		expectedBreachReason: "transport error",
 		destType:             "salesforce_oauth", // some destination
 		reqPayload: ProxyRequestPayload{
 			PostParametersT: integrations.PostParametersT{
@@ -1238,16 +1238,17 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 			RespBodys:       map[int64]string{},
 			RespContentType: "text/plain; charset=utf-8",
 			// Originally Response Body will look like this "Post \"http://<TF_SERVER>/v1/destinations/salesforce_oauth/proxy\": getting auth error category post roundTrip: LB cannot send to transformer"
-			ProxyRequestResponseBody: `[TransformerProxy] response has no output field: LB cannot send to transformer`,
+			ProxyRequestResponseBody: `LB cannot send to transformer`,
 			ProxyRequestStatusCode:   http.StatusInternalServerError,
 			RespStatusCodes:          map[int64]int{},
 		},
 		destination: oauthDests[0],
 	},
 	{
-		description:         "[v1proxy] when v1Proxy endpoint sending v0Proxy response, unmarshal should happen at proxyAdapter.getResponse level",
-		transformerResponse: `{"message": ["some other error"]}`,
-		destType:            "salesforce_oauth", // some destination
+		description:          "[v1proxy] when v1Proxy endpoint sending v0Proxy response, unmarshal should happen at proxyAdapter.getResponse level",
+		transformerResponse:  `{"message": ["some other error"]}`,
+		expectedBreachReason: "unmarshal error",
+		destType:             "salesforce_oauth", // some destination
 		reqPayload: ProxyRequestPayload{
 			PostParametersT: integrations.PostParametersT{
 				Type:          "REST",
@@ -1469,6 +1470,92 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 		},
 		destination:          oauthDests[0],
 		expectedBreachReason: "in out mismatch",
+	},
+
+	{
+		description:  "[v1proxy] when a batch carries duplicate jobIDs, the deduped set must not spuriously page as in out mismatch",
+		proxyVersion: "v1",
+		transformerProxyResponseV1: ProxyResponseV1{
+			Message: "some message that we got from transformer",
+			// The transformer collapses the duplicate job 1 into a single response entry.
+			Response: []TPDestResponse{
+				{
+					StatusCode: http.StatusOK,
+					Metadata: ProxyRequestMetadata{
+						WorkspaceID:   "workspace_id",
+						DestinationID: "destination_id",
+						JobID:         1,
+					},
+					Error: "success",
+				},
+				{
+					StatusCode: http.StatusOK,
+					Metadata: ProxyRequestMetadata{
+						WorkspaceID:   "workspace_id",
+						DestinationID: "destination_id",
+						JobID:         2,
+					},
+					Error: "success",
+				},
+			},
+		},
+		destType: "salesforce_oauth", // some destination
+		reqPayload: ProxyRequestPayload{
+			PostParametersT: integrations.PostParametersT{
+				Type:          "REST",
+				URL:           "http://www.ctx_timeout_dest.domain.com",
+				RequestMethod: http.MethodPost,
+				QueryParams:   map[string]any{},
+				Body: map[string]any{
+					"JSON":       map[string]any{"key_1": "val_1"},
+					"FORM":       map[string]any{},
+					"JSON_ARRAY": map[string]any{},
+					"XML":        map[string]any{},
+				},
+				Files: map[string]any{},
+			},
+			// Job 1 appears twice - a legitimate batch (router/worker.go only dedupes when building the
+			// final responses). Deduped, the request set {1,2} equals the response set {1,2}, so this
+			// must not page. Drop lo.Uniq on jobIDsInMetadata and this case fails.
+			Metadata: []ProxyRequestMetadata{
+				{
+					WorkspaceID:   "workspace_id",
+					DestinationID: "destination_id",
+					JobID:         1,
+				},
+				{
+					WorkspaceID:   "workspace_id",
+					DestinationID: "destination_id",
+					JobID:         1,
+				},
+				{
+					WorkspaceID:   "workspace_id",
+					DestinationID: "destination_id",
+					JobID:         2,
+				},
+			},
+			DestinationConfig: oauthDests[0].Config,
+		},
+		cpResponses: []testutils.CpResponseParams{},
+		expected: ProxyRequestResponse{
+			DontBatchDirectives: map[int64]bool{
+				1: false,
+				2: false,
+			},
+			RespBodys: map[int64]string{
+				1: "success",
+				2: "success",
+			},
+			RespContentType:          "application/json",
+			ProxyRequestResponseBody: `{"message": "some message that we got from transformer","response":[{"statusCode":200,"error":"success","metadata":{"workspaceId":"workspace_id","destinationId":"destination_id","jobId":1}},{"statusCode":200,"error":"success","metadata":{"workspaceId":"workspace_id","destinationId":"destination_id","jobId":2}}]}`,
+			ProxyRequestStatusCode:   http.StatusOK,
+			RespStatusCodes: map[int64]int{
+				1: http.StatusOK,
+				2: http.StatusOK,
+			},
+		},
+		destination: oauthDests[0],
+		// No breach: expectedBreachReason stays empty, so the runner asserts zero metrics were emitted.
 	},
 
 	{
@@ -1802,17 +1889,19 @@ func TestProxyRequestWithOAuthV2(t *testing.T) {
 				require.Contains(t, proxyResp.ProxyRequestResponseBody, tc.expected.ProxyRequestResponseBody)
 			}
 
-			// One breach must produce exactly one metric under exactly one reason: a body that is not
-			// valid JSON must not also trip "missing output", and a response synthesized by the oauth
-			// transport must not be reported as a transformer contract breach.
+			// A breach must produce exactly one metric under exactly one reason, and a healthy response
+			// (expectedBreachReason == "") must produce none - so a regression that spuriously pages on a
+			// success case is caught, not just a mislabeled breach.
+			var expectedReasons []string
 			if tc.expectedBreachReason != "" {
-				breaches := statsStore.GetByName("router.transformerproxy.invalid.response")
-				reasons := make([]string, 0, len(breaches))
-				for _, b := range breaches {
-					reasons = append(reasons, b.Tags["reason"])
-				}
-				require.Equal(t, []string{tc.expectedBreachReason}, reasons)
+				expectedReasons = []string{tc.expectedBreachReason}
 			}
+			breaches := statsStore.GetByName("router.transformerproxy.invalid.response")
+			reasons := make([]string, 0, len(breaches))
+			for _, b := range breaches {
+				reasons = append(reasons, b.Tags["reason"])
+			}
+			require.ElementsMatch(t, expectedReasons, reasons)
 		})
 	}
 }

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -46,7 +46,7 @@ func (a *mockAdapter) getProxyURL(destType string) (string, error) {
 	return url.JoinPath(a.url, "v0", "destinations", strings.ToLower(destType), "proxy")
 }
 
-func (a *mockAdapter) getResponse(response []byte, respCode int, metadata []ProxyRequestMetadata) (TransResponse, error) {
+func (a *mockAdapter) getResponse(response []byte, respCode int, metadata []ProxyRequestMetadata, _ string) (TransResponse, error) {
 	return TransResponse{
 		routerJobResponseCodes:       make(map[int64]int),
 		routerJobResponseBodys:       make(map[int64]string),

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/rudderlabs/rudder-server/processor/integrations"
 	"github.com/rudderlabs/rudder-server/router/types"
 	"github.com/rudderlabs/rudder-server/services/oauth/v2/common"
-	oauthv2httpclient "github.com/rudderlabs/rudder-server/services/oauth/v2/http"
 	testutils "github.com/rudderlabs/rudder-server/utils/tests"
 	utilTypes "github.com/rudderlabs/rudder-server/utils/types"
 	"github.com/rudderlabs/rudder-server/utils/types/deployment"
@@ -715,9 +714,6 @@ type oauthv2ProxyTcs struct {
 	// closes the mock transformer before the request, so Transport.RoundTrip fails and the oauth
 	// transport synthesizes the response (transport.go:294).
 	transformerUnreachable bool
-	// makes the mock set the transport marker itself, i.e. an upstream passing its response off as
-	// transport-synthesized. The transport must strip it so the breach is still reported.
-	spoofTransportErrorHeader bool
 }
 
 var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
@@ -1684,46 +1680,6 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 	},
 
 	{
-		// The marker must not be assertable from over the wire, or anything in front of the transformer
-		// could silence the breach alert by setting it.
-		description:               "[v1proxy] when an upstream sets the transport marker itself, the breach is still reported",
-		proxyVersion:              "v1",
-		rawBody:                   `{"message":"no output field here"}`,
-		spoofTransportErrorHeader: true,
-		expectedBreachReason:      "missing output",
-		destType:                  "salesforce_oauth", // some destination
-		reqPayload: ProxyRequestPayload{
-			PostParametersT: integrations.PostParametersT{
-				Type:          "REST",
-				URL:           "http://www.ctx_timeout_dest.domain.com",
-				RequestMethod: http.MethodPost,
-				QueryParams:   map[string]any{},
-				Body: map[string]any{
-					"JSON":       map[string]any{"key_1": "val_1"},
-					"FORM":       map[string]any{},
-					"JSON_ARRAY": map[string]any{},
-					"XML":        map[string]any{},
-				},
-				Files: map[string]any{},
-			},
-			Metadata: []ProxyRequestMetadata{
-				{WorkspaceID: "workspace_id", DestinationID: "destination_id", JobID: 1},
-			},
-			DestinationConfig: oauthDests[0].Config,
-		},
-		cpResponses: []testutils.CpResponseParams{},
-		expected: ProxyRequestResponse{
-			DontBatchDirectives:      map[int64]bool{1: false},
-			RespBodys:                map[int64]string{},
-			RespContentType:          "text/plain; charset=utf-8",
-			ProxyRequestResponseBody: `[TransformerProxy] response has no output field:`,
-			ProxyRequestStatusCode:   http.StatusInternalServerError,
-			RespStatusCodes:          map[int64]int{},
-		},
-		destination: oauthDests[0],
-	},
-
-	{
 		// v0 counterpart of the v1 null case. Before this PR v0 assigned respCode to every job, so a 200
 		// carrying a null output marked the batch delivered; now the jobs fail and retry.
 		description:          "[v0proxy] when the response output is explicitly null, should page with reason missing output",
@@ -2133,9 +2089,6 @@ func TestProxyRequestWithOAuthV2(t *testing.T) {
 					return
 				}
 				w.Header().Add(apiVersionHeader, strconv.Itoa(utilTypes.SupportedTransformerApiVersion))
-				if tc.spoofTransportErrorHeader {
-					w.Header().Set(oauthv2httpclient.TransportErrorHeader, "true")
-				}
 				switch tc.proxyVersion {
 				case "v1":
 					b, _ = jsonrs.Marshal(tc.transformerProxyResponseV1)

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -1461,8 +1461,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 		},
 		cpResponses: []testutils.CpResponseParams{},
 		expected: ProxyRequestResponse{
-			// DontBatchDirectives is seeded from the request metadata, so both jobs appear; the per-job
-			// status maps only carry job 1, the one the transformer actually answered for.
+			// DontBatchDirectives is seeded from metadata; the status maps carry only the answered job.
 			DontBatchDirectives: map[int64]bool{
 				1: false,
 				2: false,
@@ -1519,9 +1518,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 				},
 				Files: map[string]any{},
 			},
-			// Job 1 appears twice - a legitimate batch (router/worker.go only dedupes when building the
-			// final responses). Deduped, the request set {1,2} equals the response set {1,2}, so this
-			// must not page. Drop lo.Uniq on jobIDsInMetadata and this case fails.
+			// Job 1 twice is a legitimate batch; deduped the sets match, so this must not page.
 			Metadata: []ProxyRequestMetadata{
 				{
 					WorkspaceID:   "workspace_id",
@@ -1607,9 +1604,8 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 		},
 		cpResponses: []testutils.CpResponseParams{},
 		expected: ProxyRequestResponse{
-			// The output parsed, so the per-job status is applied and the top-level 502 is preserved -
-			// exactly the pre-change behavior. A short-circuit on status would instead drop these and
-			// return empty maps, so this case guards against that regression.
+			// The output parsed, so per-job status is applied and the 502 preserved. A short-circuit on
+			// status would drop these and return empty maps.
 			DontBatchDirectives:      map[int64]bool{1: false},
 			RespBodys:                map[int64]string{1: "success"},
 			RespContentType:          "application/json",
@@ -1622,10 +1618,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 	},
 
 	{
-		// The jobID sets match here, so the set comparison alone would miss this. The transformer
-		// answered twice for job 1 with conflicting statuses and the map write silently kept the last
-		// one - exactly the "results attached to the wrong jobs" breach, so the entry-count check
-		// has to catch it.
+		// The jobID sets match, so only the entry-count check can catch this.
 		description:          "[v1proxy] when the transformer answers twice for the same jobID, should page with reason in out mismatch",
 		proxyVersion:         "v1",
 		expectedBreachReason: "in out mismatch",
@@ -1673,7 +1666,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 		cpResponses: []testutils.CpResponseParams{},
 		expected: ProxyRequestResponse{
 			DontBatchDirectives: map[int64]bool{1: false, 2: false},
-			// Job 1's first status is gone - last write wins - which is why this must be flagged.
+			// Job 1's first status is gone - last write wins.
 			RespBodys:                map[int64]string{1: "second", 2: "success"},
 			RespContentType:          "application/json",
 			ProxyRequestResponseBody: `{"message": "some message that we got from transformer","response":[{"statusCode":200,"error":"first","metadata":{"workspaceId":"workspace_id","destinationId":"destination_id","jobId":1}}]}`,
@@ -1721,9 +1714,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 	},
 
 	{
-		// Pins the output.Type == gjson.Null half of the guard: gjson reports an explicit null as
-		// existing, so dropping that check would let this through as an empty response set and get
-		// reported as "in out mismatch" instead.
+		// Pins the output.Type == gjson.Null half of the guard.
 		description:          "[v1proxy] when the response output is explicitly null, should page with reason missing output",
 		proxyVersion:         "v1",
 		rawBody:              `{"output":null}`,
@@ -2028,8 +2019,7 @@ func TestProxyRequestWithOAuthV2(t *testing.T) {
 				if tc.rawBody != "" {
 					outputJson = []byte(tc.rawBody)
 				}
-				// Lets a case set the upstream HTTP status while still returning a real transformer body,
-				// to exercise a 5xx that carries a usable output.
+				// Lets a case return a real transformer body under a chosen upstream status.
 				if tc.upstreamStatusCode != 0 {
 					w.WriteHeader(tc.upstreamStatusCode)
 				}
@@ -2099,9 +2089,8 @@ func TestProxyRequestWithOAuthV2(t *testing.T) {
 				require.Contains(t, proxyResp.ProxyRequestResponseBody, tc.expected.ProxyRequestResponseBody)
 			}
 
-			// A breach must produce exactly one metric under exactly one reason, and a healthy response
-			// (expectedBreachReason == "") must produce none - so a regression that spuriously pages on a
-			// success case is caught, not just a mislabeled breach.
+			// Exactly one reason per breach, and none at all for a healthy response - so a spurious page
+			// is caught, not just a mislabel.
 			var expectedReasons []string
 			if tc.expectedBreachReason != "" {
 				expectedReasons = []string{tc.expectedBreachReason}

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -46,7 +46,7 @@ func (a *mockAdapter) getProxyURL(destType string) (string, error) {
 	return url.JoinPath(a.url, "v0", "destinations", strings.ToLower(destType), "proxy")
 }
 
-func (a *mockAdapter) getResponse(response []byte, respCode int, metadata []ProxyRequestMetadata, _ string) (TransResponse, error) {
+func (a *mockAdapter) getResponse(response []byte, respCode int, metadata []ProxyRequestMetadata) (TransResponse, error) {
 	return TransResponse{
 		routerJobResponseCodes:       make(map[int64]int),
 		routerJobResponseBodys:       make(map[int64]string),
@@ -1124,7 +1124,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 			},
 			RespBodys:                map[int64]string{},
 			RespContentType:          "text/plain; charset=utf-8",
-			ProxyRequestResponseBody: `[TransformerProxy Unmarshalling]:: respData: , err: sonnet: unexpected EOF reading a byte`,
+			ProxyRequestResponseBody: `[TransformerProxy] response is not valid JSON: [postRoundTrip]Error reading response body: unexpected EOF`,
 			ProxyRequestStatusCode:   http.StatusInternalServerError,
 			RespStatusCodes:          map[int64]int{},
 		},
@@ -1181,7 +1181,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 			RespBodys:       map[int64]string{},
 			RespContentType: "text/plain; charset=utf-8",
 			// Originally Response Body will look like this "Post \"http://<TF_SERVER>/v1/destinations/salesforce_oauth/proxy\": getting auth error category post roundTrip: LB cannot send to transformer"
-			ProxyRequestResponseBody: `[TransformerProxy Unmarshalling]:: respData: , err: sonnet: unexpected EOF reading a byte`,
+			ProxyRequestResponseBody: `[TransformerProxy] response has no output field: LB cannot send to transformer`,
 			ProxyRequestStatusCode:   http.StatusInternalServerError,
 			RespStatusCodes:          map[int64]int{},
 		},
@@ -1232,7 +1232,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 			RespBodys:       map[int64]string{},
 			RespContentType: "text/plain; charset=utf-8",
 			// Originally Response Body will look like this "Post \"http://<TF_SERVER>/v1/destinations/salesforce_oauth/proxy\": getting auth error category post roundTrip: LB cannot send to transformer"
-			ProxyRequestResponseBody: `[TransformerProxy Unmarshalling]:: respData: , err: sonnet: unexpected EOF reading a byte`,
+			ProxyRequestResponseBody: `[TransformerProxy] response has no output field: LB cannot send to transformer`,
 			ProxyRequestStatusCode:   http.StatusInternalServerError,
 			RespStatusCodes:          map[int64]int{},
 		},

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/rudderlabs/rudder-server/processor/integrations"
 	"github.com/rudderlabs/rudder-server/router/types"
 	"github.com/rudderlabs/rudder-server/services/oauth/v2/common"
+	oauthv2httpclient "github.com/rudderlabs/rudder-server/services/oauth/v2/http"
 	testutils "github.com/rudderlabs/rudder-server/utils/tests"
 	utilTypes "github.com/rudderlabs/rudder-server/utils/types"
 	"github.com/rudderlabs/rudder-server/utils/types/deployment"
@@ -711,6 +712,12 @@ type oauthv2ProxyTcs struct {
 	// body the mock returns verbatim, bypassing the {"output": ...} envelope. Used to exercise
 	// responses that have no output field at all, or an explicit null one.
 	rawBody string
+	// closes the mock transformer before the request, so Transport.RoundTrip fails and the oauth
+	// transport synthesizes the response (transport.go:294).
+	transformerUnreachable bool
+	// makes the mock set the transport marker itself, i.e. an upstream passing its response off as
+	// transport-synthesized. The transport must strip it so the breach is still reported.
+	spoofTransportErrorHeader bool
 }
 
 var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
@@ -1143,7 +1150,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 		description:          "[v1proxy] when transformer does not respond properly",
 		proxyVersion:         "v1",
 		lbError:              true,
-		expectedBreachReason: "missing output",
+		expectedBreachReason: "transport error",
 		destType:             "salesforce_oauth", // some destination
 		reqPayload: ProxyRequestPayload{
 			PostParametersT: integrations.PostParametersT{
@@ -1201,7 +1208,7 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 		description:          "[v0proxy] when transformer does not respond properly",
 		proxyVersion:         "v0",
 		lbError:              true,
-		expectedBreachReason: "missing output",
+		expectedBreachReason: "transport error",
 		destType:             "salesforce_oauth", // some destination
 		reqPayload: ProxyRequestPayload{
 			PostParametersT: integrations.PostParametersT{
@@ -1677,6 +1684,124 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 	},
 
 	{
+		// The marker must not be assertable from over the wire, or anything in front of the transformer
+		// could silence the breach alert by setting it.
+		description:               "[v1proxy] when an upstream sets the transport marker itself, the breach is still reported",
+		proxyVersion:              "v1",
+		rawBody:                   `{"message":"no output field here"}`,
+		spoofTransportErrorHeader: true,
+		expectedBreachReason:      "missing output",
+		destType:                  "salesforce_oauth", // some destination
+		reqPayload: ProxyRequestPayload{
+			PostParametersT: integrations.PostParametersT{
+				Type:          "REST",
+				URL:           "http://www.ctx_timeout_dest.domain.com",
+				RequestMethod: http.MethodPost,
+				QueryParams:   map[string]any{},
+				Body: map[string]any{
+					"JSON":       map[string]any{"key_1": "val_1"},
+					"FORM":       map[string]any{},
+					"JSON_ARRAY": map[string]any{},
+					"XML":        map[string]any{},
+				},
+				Files: map[string]any{},
+			},
+			Metadata: []ProxyRequestMetadata{
+				{WorkspaceID: "workspace_id", DestinationID: "destination_id", JobID: 1},
+			},
+			DestinationConfig: oauthDests[0].Config,
+		},
+		cpResponses: []testutils.CpResponseParams{},
+		expected: ProxyRequestResponse{
+			DontBatchDirectives:      map[int64]bool{1: false},
+			RespBodys:                map[int64]string{},
+			RespContentType:          "text/plain; charset=utf-8",
+			ProxyRequestResponseBody: `[TransformerProxy] response has no output field:`,
+			ProxyRequestStatusCode:   http.StatusInternalServerError,
+			RespStatusCodes:          map[int64]int{},
+		},
+		destination: oauthDests[0],
+	},
+
+	{
+		// v0 counterpart of the v1 null case. Before this PR v0 assigned respCode to every job, so a 200
+		// carrying a null output marked the batch delivered; now the jobs fail and retry.
+		description:          "[v0proxy] when the response output is explicitly null, should page with reason missing output",
+		proxyVersion:         "v0",
+		rawBody:              `{"output":null}`,
+		expectedBreachReason: "missing output",
+		destType:             "salesforce_oauth", // some destination
+		reqPayload: ProxyRequestPayload{
+			PostParametersT: integrations.PostParametersT{
+				Type:          "REST",
+				URL:           "http://www.ctx_timeout_dest.domain.com",
+				RequestMethod: http.MethodPost,
+				QueryParams:   map[string]any{},
+				Body: map[string]any{
+					"JSON":       map[string]any{"key_1": "val_1"},
+					"FORM":       map[string]any{},
+					"JSON_ARRAY": map[string]any{},
+					"XML":        map[string]any{},
+				},
+				Files: map[string]any{},
+			},
+			Metadata: []ProxyRequestMetadata{
+				{WorkspaceID: "workspace_id", DestinationID: "destination_id", JobID: 1},
+			},
+			DestinationConfig: oauthDests[0].Config,
+		},
+		cpResponses: []testutils.CpResponseParams{},
+		expected: ProxyRequestResponse{
+			DontBatchDirectives:      map[int64]bool{1: false},
+			RespBodys:                map[int64]string{},
+			RespContentType:          "text/plain; charset=utf-8",
+			ProxyRequestResponseBody: `[TransformerProxy] response has no output field:`,
+			ProxyRequestStatusCode:   http.StatusOK,
+			RespStatusCodes:          map[int64]int{},
+		},
+		destination: oauthDests[0],
+	},
+
+	{
+		// Pins transport.go:294 - RoundTrip fails, the oauth transport synthesizes the response, and the
+		// marker keeps it off the breach signal.
+		description:            "[v1proxy] when the transformer is unreachable, should report reason transport error",
+		proxyVersion:           "v1",
+		transformerUnreachable: true,
+		expectedBreachReason:   "transport error",
+		destType:               "salesforce_oauth", // some destination
+		reqPayload: ProxyRequestPayload{
+			PostParametersT: integrations.PostParametersT{
+				Type:          "REST",
+				URL:           "http://www.ctx_timeout_dest.domain.com",
+				RequestMethod: http.MethodPost,
+				QueryParams:   map[string]any{},
+				Body: map[string]any{
+					"JSON":       map[string]any{"key_1": "val_1"},
+					"FORM":       map[string]any{},
+					"JSON_ARRAY": map[string]any{},
+					"XML":        map[string]any{},
+				},
+				Files: map[string]any{},
+			},
+			Metadata: []ProxyRequestMetadata{
+				{WorkspaceID: "workspace_id", DestinationID: "destination_id", JobID: 1},
+			},
+			DestinationConfig: oauthDests[0].Config,
+		},
+		cpResponses: []testutils.CpResponseParams{},
+		expected: ProxyRequestResponse{
+			DontBatchDirectives:      map[int64]bool{1: false},
+			RespBodys:                map[int64]string{},
+			RespContentType:          "text/plain; charset=utf-8",
+			ProxyRequestResponseBody: `[TransformerProxy] response is not valid JSON:`,
+			ProxyRequestStatusCode:   http.StatusInternalServerError,
+			RespStatusCodes:          map[int64]int{},
+		},
+		destination: oauthDests[0],
+	},
+
+	{
 		description:          "[v1proxy] when the response body has no output field, should page with reason missing output",
 		proxyVersion:         "v1",
 		rawBody:              `{"message":"transformer said something without an output field"}`,
@@ -1998,14 +2123,18 @@ func TestProxyRequestWithOAuthV2(t *testing.T) {
 	for _, tc := range oauthv2ProxyTestCases {
 		t.Run(tc.description, func(t *testing.T) {
 			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Add(apiVersionHeader, strconv.Itoa(utilTypes.SupportedTransformerApiVersion))
 				b := []byte("LB cannot send to transformer")
 				statusCode := http.StatusBadGateway
 				var err error
 				if tc.lbError {
+					// An LB/ingress error page never reached the transformer, so it carries no apiVersion.
 					w.WriteHeader(statusCode)
 					_, _ = w.Write(b)
 					return
+				}
+				w.Header().Add(apiVersionHeader, strconv.Itoa(utilTypes.SupportedTransformerApiVersion))
+				if tc.spoofTransportErrorHeader {
+					w.Header().Set(oauthv2httpclient.TransportErrorHeader, "true")
 				}
 				switch tc.proxyVersion {
 				case "v1":
@@ -2067,6 +2196,10 @@ func TestProxyRequestWithOAuthV2(t *testing.T) {
 				DestName:     tc.destType,
 				Adapter:      adapter,
 				Destination:  &dest,
+			}
+
+			if tc.transformerUnreachable {
+				svr.Close()
 			}
 
 			proxyResp := tr.ProxyRequest(context.Background(), reqParams)

--- a/router/transformer/transformer_test.go
+++ b/router/transformer/transformer_test.go
@@ -340,7 +340,7 @@ func TestProxyRequest(t *testing.T) {
 				ctx := context.TODO()
 				reqParams := &ProxyRequestParams{
 					ResponseData: tc.postParameters,
-					DestName:     "not_found_dest",
+					DestType:     "not_found_dest",
 					Adapter:      &mockAdapter{url: srv.URL},
 					Destination: &backendconfig.DestinationT{
 						Config: tc.postParameters.DestinationConfig,
@@ -385,7 +385,7 @@ func TestProxyRequest(t *testing.T) {
 
 			reqParams := &ProxyRequestParams{
 				ResponseData: tc.postParameters,
-				DestName:     tc.destName,
+				DestType:     tc.destName,
 				Adapter:      &mockAdapter{url: srv.URL},
 				Destination: &backendconfig.DestinationT{
 					Config: tc.postParameters.DestinationConfig,
@@ -701,7 +701,7 @@ type oauthv2ProxyTcs struct {
 	destination backendconfig.DestinationT
 
 	ioReadError bool
-	// expected `reason` tag on router.transformerproxy.invalid.response.
+	// expected `reason` tag on router_transformerproxy_invalid_response.
 	// Empty means the metric is not asserted for this case.
 	expectedBreachReason string
 	// load-balancer erroring out
@@ -1621,6 +1621,56 @@ var oauthv2ProxyTestCases = []oauthv2ProxyTcs{
 	},
 
 	{
+		// A 404 makes doProxyRequest return a Go error, so this hits the requestError branch before
+		// content classification - the same path a non-oauth transport failure takes. It emits
+		// transport error so those show on the metric too (excluded from the alert, so it pages nothing).
+		description:          "[v1proxy] when the proxy returns 404, should report reason transport error via the request-error path",
+		proxyVersion:         "v1",
+		upstreamStatusCode:   http.StatusNotFound,
+		expectedBreachReason: "transport error",
+		transformerProxyResponseV1: ProxyResponseV1{
+			Message: "some message that we got from transformer",
+			Response: []TPDestResponse{
+				{
+					StatusCode: http.StatusOK,
+					Metadata:   ProxyRequestMetadata{WorkspaceID: "workspace_id", DestinationID: "destination_id", JobID: 1},
+					Error:      "success",
+				},
+			},
+		},
+		destType: "salesforce_oauth", // some destination
+		reqPayload: ProxyRequestPayload{
+			PostParametersT: integrations.PostParametersT{
+				Type:          "REST",
+				URL:           "http://www.ctx_timeout_dest.domain.com",
+				RequestMethod: http.MethodPost,
+				QueryParams:   map[string]any{},
+				Body: map[string]any{
+					"JSON":       map[string]any{"key_1": "val_1"},
+					"FORM":       map[string]any{},
+					"JSON_ARRAY": map[string]any{},
+					"XML":        map[string]any{},
+				},
+				Files: map[string]any{},
+			},
+			Metadata: []ProxyRequestMetadata{
+				{WorkspaceID: "workspace_id", DestinationID: "destination_id", JobID: 1},
+			},
+			DestinationConfig: oauthDests[0].Config,
+		},
+		cpResponses: []testutils.CpResponseParams{},
+		expected: ProxyRequestResponse{
+			DontBatchDirectives:      map[int64]bool{1: false},
+			RespBodys:                map[int64]string{},
+			RespContentType:          "text/plain; charset=utf-8",
+			ProxyRequestResponseBody: `not found`,
+			ProxyRequestStatusCode:   http.StatusInternalServerError,
+			RespStatusCodes:          map[int64]int{},
+		},
+		destination: oauthDests[0],
+	},
+
+	{
 		// The jobID sets match, so only the entry-count check can catch this.
 		description:          "[v1proxy] when the transformer answers twice for the same jobID, should page with reason in out mismatch",
 		proxyVersion:         "v1",
@@ -2146,7 +2196,7 @@ func TestProxyRequestWithOAuthV2(t *testing.T) {
 			dest.WorkspaceID = tc.reqPayload.Metadata[0].WorkspaceID
 			reqParams := &ProxyRequestParams{
 				ResponseData: tc.reqPayload,
-				DestName:     tc.destType,
+				DestType:     tc.destType,
 				Adapter:      adapter,
 				Destination:  &dest,
 			}
@@ -2181,7 +2231,7 @@ func TestProxyRequestWithOAuthV2(t *testing.T) {
 			if tc.expectedBreachReason != "" {
 				expectedReasons = []string{tc.expectedBreachReason}
 			}
-			breaches := statsStore.GetByName("router.transformerproxy.invalid.response")
+			breaches := statsStore.GetByName(proxyInvalidResponseMetric)
 			reasons := make([]string, 0, len(breaches))
 			for _, b := range breaches {
 				reasons = append(reasons, b.Tags["reason"])

--- a/router/worker.go
+++ b/router/worker.go
@@ -802,7 +802,7 @@ func (w *worker) proxyRequest(ctx context.Context, destinationJob types.Destinat
 		},
 		Destination: &destinationJob.Destination,
 		Connection:  destinationJob.Connection,
-		Adapter:     transformer.NewTransformerProxyAdapter(w.rt.transformerFeaturesService.TransformerProxyVersion(), w.rt.logger),
+		Adapter:     transformer.NewTransformerProxyAdapter(w.rt.transformerFeaturesService.TransformerProxyVersion()),
 	}
 	rtlTime := time.Now()
 

--- a/router/worker.go
+++ b/router/worker.go
@@ -793,7 +793,7 @@ func (w *worker) proxyRequest(ctx context.Context, destinationJob types.Destinat
 		})
 	}
 	proxyReqparams := &transformer.ProxyRequestParams{
-		DestName: w.rt.destType,
+		DestType: w.rt.destType,
 		ResponseData: transformer.ProxyRequestPayload{
 			PostParametersT:    val,
 			Metadata:           m,

--- a/services/oauth/v2/http/transport.go
+++ b/services/oauth/v2/http/transport.go
@@ -65,11 +65,18 @@ type roundTripState struct {
 	req         *http.Request
 }
 
+// TransportErrorHeader marks a response synthesized by this transport rather than received from the
+// upstream service. The body of such a response is a plain-text error string, not the upstream's
+// payload, so callers must not mistake it for a malformed upstream response.
+const TransportErrorHeader = "X-Rudder-Oauth-Transport-Error"
+
 func httpResponseCreator(statusCode int, body []byte) *http.Response {
+	header := http.Header{"apiVersion": []string{"2"}}
+	header.Set(TransportErrorHeader, "true")
 	return &http.Response{
 		StatusCode: statusCode,
 		Body:       io.NopCloser(bytes.NewReader(body)),
-		Header:     http.Header{"apiVersion": []string{"2"}},
+		Header:     header,
 	}
 }
 

--- a/services/oauth/v2/http/transport.go
+++ b/services/oauth/v2/http/transport.go
@@ -70,6 +70,15 @@ type roundTripState struct {
 // payload, so callers must not mistake it for a malformed upstream response.
 const TransportErrorHeader = "X-Rudder-Oauth-Transport-Error"
 
+// stripTransportErrorHeader removes the marker from a response that arrived over the wire, so only
+// this transport can assert it. Otherwise anything in front of the transformer could set it and
+// silently suppress the breach alert.
+func stripTransportErrorHeader(res *http.Response) {
+	if res != nil && res.Header != nil {
+		res.Header.Del(TransportErrorHeader)
+	}
+}
+
 func httpResponseCreator(statusCode int, body []byte) *http.Response {
 	header := http.Header{"apiVersion": []string{"2"}}
 	header.Set(TransportErrorHeader, "true")
@@ -253,7 +262,9 @@ func (t *OAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return httpResponseCreator(http.StatusInternalServerError, fmt.Appendf(nil, "[OAuthPlatformError]checking if destination is oauth destination: %v", err.Error())), nil
 	}
 	if !isOauthDestination {
-		return t.Transport.RoundTrip(req)
+		res, err := t.Transport.RoundTrip(req)
+		stripTransportErrorHeader(res)
+		return res, err
 	}
 	rts := &roundTripState{}
 	rts.destination = destination
@@ -283,6 +294,7 @@ func (t *OAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	roundTripStartTime := time.Now()
 	res, err := t.Transport.RoundTrip(rts.req)
+	stripTransportErrorHeader(res)
 	if err != nil {
 		t.log.Errorn("[RoundTrip]transport round trip",
 			obskit.DestinationID(rts.destination.ID),

--- a/services/oauth/v2/http/transport.go
+++ b/services/oauth/v2/http/transport.go
@@ -65,27 +65,14 @@ type roundTripState struct {
 	req         *http.Request
 }
 
-// TransportErrorHeader marks a response synthesized by this transport rather than received from the
-// upstream service. The body of such a response is a plain-text error string, not the upstream's
-// payload, so callers must not mistake it for a malformed upstream response.
-const TransportErrorHeader = "X-Rudder-Oauth-Transport-Error"
-
-// stripTransportErrorHeader removes the marker from a response that arrived over the wire, so only
-// this transport can assert it. Otherwise anything in front of the transformer could set it and
-// silently suppress the breach alert.
-func stripTransportErrorHeader(res *http.Response) {
-	if res != nil && res.Header != nil {
-		res.Header.Del(TransportErrorHeader)
-	}
-}
-
+// httpResponseCreator builds a response this transport synthesizes on an error path, rather than one
+// received from the upstream service. It carries no apiVersion header - only the transformer sets that
+// - so callers can tell a synthesized response apart from a real one by its absence.
 func httpResponseCreator(statusCode int, body []byte) *http.Response {
-	header := http.Header{"apiVersion": []string{"2"}}
-	header.Set(TransportErrorHeader, "true")
 	return &http.Response{
 		StatusCode: statusCode,
 		Body:       io.NopCloser(bytes.NewReader(body)),
-		Header:     header,
+		Header:     http.Header{},
 	}
 }
 
@@ -262,9 +249,7 @@ func (t *OAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return httpResponseCreator(http.StatusInternalServerError, fmt.Appendf(nil, "[OAuthPlatformError]checking if destination is oauth destination: %v", err.Error())), nil
 	}
 	if !isOauthDestination {
-		res, err := t.Transport.RoundTrip(req)
-		stripTransportErrorHeader(res)
-		return res, err
+		return t.Transport.RoundTrip(req)
 	}
 	rts := &roundTripState{}
 	rts.destination = destination
@@ -294,7 +279,6 @@ func (t *OAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	roundTripStartTime := time.Now()
 	res, err := t.Transport.RoundTrip(rts.req)
-	stripTransportErrorHeader(res)
 	if err != nil {
 		t.log.Errorn("[RoundTrip]transport round trip",
 			obskit.DestinationID(rts.destination.ID),

--- a/services/oauth/v2/http/transport.go
+++ b/services/oauth/v2/http/transport.go
@@ -66,8 +66,12 @@ type roundTripState struct {
 }
 
 // httpResponseCreator builds a response this transport synthesizes on an error path, rather than one
-// received from the upstream service. It carries no apiVersion header - only the transformer sets that
-// - so callers can tell a synthesized response apart from a real one by its absence.
+// received from the upstream service. It deliberately carries no apiVersion header: only the
+// transformer stamps that (ControllerUtility.deliveryPostProcess), so its absence marks a response that
+// did not come from the transformer. That covers more than this transport's own errors - an ingress or
+// reverse proxy in front of the transformer, or an unhandled transformer exception routed through the
+// global error handler rather than deliveryPostProcess, all lack it too - which is why the router keys
+// its infra-vs-breach classification on apiVersion presence rather than on this being a distinct marker.
 func httpResponseCreator(statusCode int, body []byte) *http.Response {
 	return &http.Response{
 		StatusCode: statusCode,


### PR DESCRIPTION
## What

Makes the transformer-proxy delivery contract observable for [INT-6839](https://linear.app/rudderstack/issue/INT-6839).

A contract breach is when rudder-server sends a batch of jobs to a destination's proxy endpoint and gets back a response it cannot reconcile with what it sent — per-job results end up attached to the **wrong jobs**, or the batch can't be read at all, and no ordinary delivery failure records it. Today `router_transformerproxy_invalid_response` (Go stat `router.transformerproxy.invalid.response`) is emitted for only one of those ways, carries no attribution, and has no alert.

This PR emits the metric at **every** breach site with attribution, classifies infrastructure failures separately so they don't page as breaches, and logs the affected **jobIDs** so on-call can pull the real events out of jobsDB.

## Reasons

| `reason` | When | Contract breach? |
| --- | --- | --- |
| `in out mismatch` | Returned jobIDs differ from those sent, **or** the transformer answered twice for one jobID (one status silently dropped by the map write) | Yes — results attached to the wrong jobs |
| `missing output` | Response carried no `output` field, or an explicit `"output":null` | Yes |
| `unmarshal error` | The response envelope, or its `output` payload, would not parse | Yes |
| `transport error` | The response was **synthesized by the oauth transport** — failed token fetch, augmentation failure, LB round-trip error, unreadable body | No — infrastructure |

All carry **`reason`, `destType`, `destinationId`**, and log the upstream `statusCode`.

### How infra is told apart from a breach

The signal is **provenance, not status**: did the response actually come from the transformer? Only the transformer stamps the `apiVersion` header (`ControllerUtility.deliveryPostProcess`), so a response lacking it did not come from the transformer — an oauth-transport-synthesized error, an ingress/reverse-proxy error page, or an unhandled transformer exception routed through the global error handler rather than `deliveryPostProcess`. `doProxyRequest` records `fromTransformer` from the header's presence, and `infraFailure := !fromTransformer` selects the `transport error` reason. No separate marker header is needed.

The upstream HTTP status is deliberately **not** part of that signal. For v0 the transformer mirrors the destination's delivery status (`deliveryPostProcess`), so any destination 5xx comes from a perfectly healthy transformer — using it would relabel a genuine breach that co-occurs with a destination 5xx as infra, which is exactly the case this exists to catch. The status is logged instead.

Infra only ever selects the *reason* at the points where the response can't be processed; a response that parses is applied exactly as before, so a 5xx still carrying a usable output is delivered normally. A raw transport failure (unreachable transformer, timeout, 404) surfaces as a request error and is emitted as `transport error` too, so the metric is symmetric across oauth and non-oauth destinations.

## The breach logs — jobIDs, not bodies

Each site logs via `Warnn` with `destinationId`, `jobIDs`, and `statusCode`. The three infra branches carry distinct messages so a log line identifies its site.

**The response body is deliberately not logged.** These get debugged by port-forwarding jobsDB and reading the events by jobID, so the jobIDs are what the logs carry. The runbook's lookup uses rudder-server's own `unionjobsdb('rt', N)` to span the rotating `rt_jobs_<n>` datasets and join each job's latest status. Bodies embedded in `ProxyRequestResponseBody` are truncated at 10KB — nothing consumes that field (`router/worker.go` reads only the per-job maps) and a batch response can be multi-MB.

## Behaviour change: `{"output":null}` is no longer a delivery

A response carrying an explicit null output is now treated as `missing output` and returned as an error, so the batch fails and retries.

On **v1** this matches what already happened (the per-job maps came back empty either way, and `hydrateRespStatusCodes` marked every job 500). On **v0** it is a real change: `v0Adapter.getResponse` assigns `respCode` to every job off the request metadata, so a 200 carrying a null output previously marked the whole batch **delivered**. Any destination that legitimately answers `{"output":null}` will now see those jobs fail and retry instead.

That is the intended semantics — a null output is not a delivery — but it is a change in outcome, not just in observability. Covered by tests on both versions.

## Why these labels — and why not `workspaceId`

`reason` drives the runbook branch and the page text; `destType` names the broken integration; `destinationId` pinpoints which destination is breaching (a workspace can run several destinations of one destType).

`workspaceId` was added in an earlier commit and then **deliberately dropped**: nothing consumes it. Alertmanager routes on `namespace`, the runbook never branches on it, and the affected workspace is recoverable from jobsDB — `unionjobsdb` returns `workspace_id`.

## Notable design points from review

- **Detection lives at the caller.** `TransResponse` no longer carries the mismatch flag or the jobID slices; `ProxyRequest` derives the response set from `maps.Keys(routerJobResponseCodes)` and compares against the deduped request jobIDs. All reasons are detected and emitted in one place, through one stats handle.
- **Request-side duplicate jobIDs are legitimate** (`router/worker.go` dedupes only when building final responses), so the set comparison dedupes both sides. **Response-side** duplicates are not — the adapter reports `responseEntries` so `entries > keys` is flagged, since the map write silently keeps the last status.
- **`{"output":null}` counts as missing.** gjson reports an explicit null as existing (`Raw == "null"`), so the type is checked too.

## Tests

Breach classification is asserted through a memstats store: each case pins the **exact set** of emitted reasons, so a healthy response asserting *none* catches a spurious page, not just a mislabel. Covered: all four reasons, `"output":null`, a body with no `output` field, a duplicate-jobID response, a duplicate-jobID **request** (must not page), and a 5xx carrying a usable output (must be applied, not dropped). Each was verified to fail when its guard is removed.

## Downstream / gating

Unblocks the operator alerts in **rudderlabs/rudderstack-operator#1452**, which split by blast radius: `in out mismatch` pages per destination, the response-shape reasons page coarsely per destType, and `transport error` pages from neither.

> **Sequencing:** this PR must be merged **and deployed**, with the new reasons and labels verified emitting in prod, before that alert PR merges.

