### PR TITLE
feat(processor): isolated destination processing pipeline

### DIFF
--- a/app/apphandlers/embeddedAppHandler.go
+++ b/app/apphandlers/embeddedAppHandler.go
@@ -289,6 +289,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, shutdownFn func(), op
 	if config.GetBoolVar(false, "Processor.DestinationIsolation.enabled") {
 		procRWHandle := jobsdb.NewForReadWrite(
 			"proc",
+			jobsdb.WithMultiConsumer(),
 			jobsdb.WithClearDB(options.ClearDB),
 			jobsdb.WithDSLimit(a.config.procDSLimit),
 			jobsdb.WithSkipMaintenanceErr(config.GetBoolVar(false, "Processor.jobsDB.skipMaintenanceError")),
@@ -299,7 +300,7 @@ func (a *embeddedApp) StartRudderCore(ctx context.Context, shutdownFn func(), op
 			jobsdb.WithNumPartitions(partitionCount),
 		)
 		defer procRWHandle.Close()
-		procRWDB = jobsdb.NewPendingEventsJobsDB(procRWHandle, pendingEventsRegistry)
+		procRWDB = jobsdb.NewPendingEventsJobsDB(procRWHandle, pendingEventsRegistry, jobsdb.WithConsumerAsDestinationID())
 	}
 
 	var schemaForwarder schema_forwarder.Forwarder

--- a/app/apphandlers/processorAppHandler.go
+++ b/app/apphandlers/processorAppHandler.go
@@ -273,6 +273,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, shutdownFn func(), o
 	if config.GetBoolVar(false, "Processor.DestinationIsolation.enabled") {
 		procRWHandle := jobsdb.NewForReadWrite(
 			"proc",
+			jobsdb.WithMultiConsumer(),
 			jobsdb.WithClearDB(options.ClearDB),
 			jobsdb.WithDSLimit(a.config.procDSLimit),
 			jobsdb.WithSkipMaintenanceErr(config.GetBoolVar(false, "Processor.jobsDB.skipMaintenanceError")),
@@ -283,7 +284,7 @@ func (a *processorApp) StartRudderCore(ctx context.Context, shutdownFn func(), o
 			jobsdb.WithNumPartitions(partitionCount),
 		)
 		defer procRWHandle.Close()
-		procRWDB = jobsdb.NewPendingEventsJobsDB(procRWHandle, pendingEventsRegistry)
+		procRWDB = jobsdb.NewPendingEventsJobsDB(procRWHandle, pendingEventsRegistry, jobsdb.WithConsumerAsDestinationID())
 	}
 
 	var schemaForwarder schema_forwarder.Forwarder

--- a/processor/gw_partition_worker.go
+++ b/processor/gw_partition_worker.go
@@ -19,9 +19,9 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/tracing"
 )
 
-type partitionWorker struct {
+type gwPartitionWorker struct {
 	partition    string
-	pipelines    []*pipelineWorker
+	pipelines    []*gwPipelineWorker
 	logger       logger.Logger
 	stats        *processorStats
 	tracer       *tracing.Tracer
@@ -29,21 +29,21 @@ type partitionWorker struct {
 	statsFactory stats.Stats
 }
 
-// newPartitionWorker creates a new worker for the specified partition
-func newPartitionWorker(partition string, h workerHandle, t stats.Tracer, statsFactory stats.Stats) *partitionWorker {
-	w := &partitionWorker{
+// newGwPartitionWorker creates a new worker for the specified partition
+func newGwPartitionWorker(partition string, h workerHandle, t stats.Tracer, statsFactory stats.Stats) *gwPartitionWorker {
+	w := &gwPartitionWorker{
 		partition:    partition,
 		logger:       h.logger().Child(partition),
 		stats:        h.stats(),
-		tracer:       tracing.New(t, tracing.WithNamePrefix("partitionWorker")),
+		tracer:       tracing.New(t, tracing.WithNamePrefix("gwPartitionWorker")),
 		handle:       h,
 		statsFactory: statsFactory,
 	}
 	// Create workers for each pipeline
 	pipelinesPerPartition := h.config().pipelinesPerPartition
-	w.pipelines = make([]*pipelineWorker, pipelinesPerPartition)
+	w.pipelines = make([]*gwPipelineWorker, pipelinesPerPartition)
 	for i := range pipelinesPerPartition {
-		w.pipelines[i] = newPipelineWorker(i, partition, h, tracing.New(t, tracing.WithNamePrefix("pipelineWorker")))
+		w.pipelines[i] = newGwPipelineWorker(i, partition, h, tracing.New(t, tracing.WithNamePrefix("gwPipelineWorker")))
 	}
 
 	return w
@@ -51,7 +51,7 @@ func newPartitionWorker(partition string, h workerHandle, t stats.Tracer, statsF
 
 // Work processes jobs for the specified partition
 // Returns true if work was done, false otherwise
-func (w *partitionWorker) Work() bool {
+func (w *gwPartitionWorker) Work() bool {
 	// If pipelining is disabled, use the legacy job handling path
 	if !w.handle.config().enablePipelining {
 		return w.handle.handlePendingGatewayJobs(w.partition)
@@ -106,16 +106,16 @@ func (w *partitionWorker) Work() bool {
 }
 
 // SleepDurations returns the min and max sleep durations for the worker
-func (w *partitionWorker) SleepDurations() (min, max time.Duration) {
+func (w *gwPartitionWorker) SleepDurations() (min, max time.Duration) {
 	return w.handle.config().readLoopSleep.Load(), w.handle.config().maxLoopSleep.Load()
 }
 
 // Stop stops the worker and waits until all its goroutines have stopped
-func (w *partitionWorker) Stop() {
+func (w *gwPartitionWorker) Stop() {
 	var wg sync.WaitGroup
 	for _, pipeline := range w.pipelines {
 		wg.Add(1)
-		go func(p *pipelineWorker) {
+		go func(p *gwPipelineWorker) {
 			defer wg.Done()
 			p.Stop()
 		}(pipeline)
@@ -123,7 +123,7 @@ func (w *partitionWorker) Stop() {
 	wg.Wait() // Wait for all stop operations to complete
 }
 
-func (w *partitionWorker) sendToPreProcess(ctx context.Context, jobsByPipeline map[int][]*jobsdb.JobT) error {
+func (w *gwPartitionWorker) sendToPreProcess(ctx context.Context, jobsByPipeline map[int][]*jobsdb.JobT) error {
 	spanTags := stats.Tags{"partition": w.partition}
 	_, span := w.tracer.Trace(ctx, "Work.sendToPreProcess", tracing.WithTraceTags(spanTags))
 	defer span.End()

--- a/processor/gw_partition_worker_test.go
+++ b/processor/gw_partition_worker_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/workerpool"
 )
 
-func TestWorkerPool(t *testing.T) {
+func TestGwWorkerPool(t *testing.T) {
 	run := func(t *testing.T, pipelining, limitsReached, shouldProcessMultipleSubJobs bool) {
 		wh := &mockWorkerHandle{
 			pipelining: pipelining,
@@ -61,7 +61,7 @@ func TestWorkerPool(t *testing.T) {
 
 		// create a worker pool
 		wp := workerpool.New(poolCtx, func(partition string) workerpool.Worker {
-			return newPartitionWorker(partition, wh, stats.NOP.NewTracer(""), stats.NOP)
+			return newGwPartitionWorker(partition, wh, stats.NOP.NewTracer(""), stats.NOP)
 		}, logger.NOP)
 
 		// start pinging for work for 100 partitions
@@ -116,7 +116,7 @@ func TestWorkerPool(t *testing.T) {
 	})
 }
 
-func TestWorkerPoolIdle(t *testing.T) {
+func TestGwWorkerPoolIdle(t *testing.T) {
 	wh := &mockWorkerHandle{
 		pipelining: true,
 		log:        logger.NewLogger(),
@@ -138,7 +138,7 @@ func TestWorkerPoolIdle(t *testing.T) {
 	// create a worker pool
 	wp := workerpool.New(poolCtx,
 		func(partition string) workerpool.Worker {
-			return newPartitionWorker(partition, wh, stats.NOP.NewTracer(""), stats.NOP)
+			return newGwPartitionWorker(partition, wh, stats.NOP.NewTracer(""), stats.NOP)
 		},
 		logger.NOP,
 		workerpool.WithCleanupPeriod(200*time.Millisecond),

--- a/processor/gw_pipeline_worker.go
+++ b/processor/gw_pipeline_worker.go
@@ -15,9 +15,9 @@ import (
 	"github.com/rudderlabs/rudder-server/utils/tracing"
 )
 
-// newPipelineWorker new worker which manages a single pipeline of a partition
-func newPipelineWorker(index int, partition string, h workerHandle, t *tracing.Tracer) *pipelineWorker {
-	w := &pipelineWorker{
+// newGwPipelineWorker new worker which manages a single pipeline of a partition
+func newGwPipelineWorker(index int, partition string, h workerHandle, t *tracing.Tracer) *gwPipelineWorker {
+	w := &gwPipelineWorker{
 		index:     index,
 		handle:    h,
 		logger:    h.logger().Withn(logger.NewStringField("partition", partition)),
@@ -45,12 +45,12 @@ func newPipelineWorker(index int, partition string, h workerHandle, t *tracing.T
 	return w
 }
 
-// pipelineWorker performs all processing steps of a partition's pipeline:
+// gwPipelineWorker performs all processing steps of a partition's pipeline:
 //  1. preprocess
 //  2. preTransform
 //  3. transform
 //  4. store
-type pipelineWorker struct {
+type gwPipelineWorker struct {
 	index     int
 	partition string
 	handle    workerHandle
@@ -73,7 +73,7 @@ type pipelineWorker struct {
 }
 
 // start launches the various worker goroutines for the pipelined processing
-func (w *pipelineWorker) start() {
+func (w *gwPipelineWorker) start() {
 	// Setup context cancellation handler
 	w.lifecycle.wg.Add(1)
 	rruntime.Go(func() {
@@ -230,7 +230,7 @@ func (w *pipelineWorker) start() {
 }
 
 // Stop gracefully terminates the worker by canceling its context and waiting for goroutines to finish
-func (w *pipelineWorker) Stop() {
+func (w *gwPipelineWorker) Stop() {
 	w.lifecycle.cancel()
 	w.lifecycle.wg.Wait()
 }

--- a/processor/proc_consumer.go
+++ b/processor/proc_consumer.go
@@ -1,0 +1,290 @@
+package processor
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/processor/types"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+	"github.com/rudderlabs/rudder-server/utils/tracing"
+	reportingtypes "github.com/rudderlabs/rudder-server/utils/types"
+	"github.com/rudderlabs/rudder-server/utils/workerpool"
+)
+
+// procJobPayload is the contract of a single intermediate (proc) job's EventPayload.
+// Destination-related information is not persisted inside Metadata and the full
+// Destination/Connection/Libraries/Credentials are re-hydrated from live backendConfig
+// at consume time.
+type procJobPayload struct {
+	Message  types.SingularEventT `json:"message"`
+	Metadata types.Metadata       `json:"metadata"`
+
+	// per-source pipeline steps already applied in gw pipeline (affects metric attribution)
+	SrcHydration           bool `json:"srcHydration,omitempty"`
+	TrackingPlanValidation bool `json:"trackingPlanValidation,omitempty"`
+}
+
+// startProcConsumer runs the proc pool: a second worker pool that polls
+// the intermediate (proc) jobsdb per partition and drains each pickup through
+// rebuild → userTransform → destinationTransform → store. It mirrors the main pinger
+// loop ([Handle.Start]) and is a no-op when procDB is not configured
+// (Processor.DestinationIsolation.enabled=false).
+func (proc *Handle) startProcConsumer(ctx context.Context) error {
+	if proc.procDB == nil {
+		return nil
+	}
+	proc.logger.Infon("Starting proc consumer loop")
+	proc.backendConfig.WaitForConfig(ctx)
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-proc.config.asyncInit.Wait():
+	}
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-proc.transformerFeaturesService.Wait():
+	}
+
+	h := &workerHandleAdapter{proc}
+	pool := workerpool.New(ctx, func(partition string) workerpool.Worker {
+		return newProcPartitionWorker(partition, h, proc.statsFactory.NewTracer("procPartitionWorker"), proc.statsFactory)
+	}, proc.logger.Child("proc-consumer"))
+	defer pool.Shutdown()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(proc.config.pingerSleep.Load()):
+		}
+		for _, partition := range proc.activeProcPartitions(ctx) {
+			pool.PingWorker(partition)
+		}
+	}
+}
+
+// activeProcPartitions returns the distinct destination IDs with pending jobs in the
+// proc jobsdb. Each destination ID is a partition for the proc pool, giving it
+// per-destination isolation.
+func (proc *Handle) activeProcPartitions(ctx context.Context) []string {
+	defer proc.statsFactory.NewStat("proc_dest_active_partitions_time", stats.TimerType).RecordDuration()()
+	keys, err := proc.procDB.GetDistinctConsumers(ctx)
+	if err != nil && ctx.Err() == nil {
+		panic(err)
+	}
+	proc.statsFactory.NewStat("proc_dest_active_partitions", stats.GaugeType).Gauge(len(keys))
+	return keys
+}
+
+// getProcJobs reads a batch of unprocessed jobs from the proc jobsdb for the given
+// destination ID.
+func (proc *Handle) getProcJobs(ctx context.Context, destinationID string) jobsdb.JobsResult {
+	s := time.Now()
+	_, span := proc.tracer.Trace(ctx, "getProcJobs", tracing.WithTraceTags(stats.Tags{"partition": destinationID}))
+	defer span.End()
+
+	if proc.limiter.pread != nil {
+		defer proc.limiter.pread.BeginWithPriority(destinationID, proc.getLimiterPriority(destinationID))()
+	}
+
+	var (
+		jobs jobsdb.JobsResult
+		err  error
+	)
+	for query := true; query; {
+		queryParams := jobsdb.GetQueryParams{
+			Consumer:         destinationID,
+			JobsLimit:        proc.config.maxEventsToProcess.Load(),
+			EventsLimit:      proc.config.maxEventsToProcess.Load(),
+			PayloadSizeLimit: proc.adaptiveLimit(proc.payloadLimit.Load()),
+		}
+		jobs, err = misc.QueryWithRetriesAndNotify(context.Background(), proc.jobdDBQueryRequestTimeout.Load(), proc.jobdDBMaxRetries.Load(), func(ctx context.Context) (jobsdb.JobsResult, error) {
+			return proc.procDB.GetUnprocessed(ctx, queryParams)
+		}, proc.sendQueryRetryStats)
+		if err != nil {
+			proc.logger.Errorn("Failed to get unprocessed jobs from proc DB", obskit.Error(err))
+			panic(err)
+		}
+		query = len(jobs.Jobs) == 0 && jobs.DSLimitsReached
+	}
+
+	proc.statsFactory.NewTaggedStat("proc_consumer_db_read", stats.TimerType, stats.Tags{"partition": destinationID}).Since(s)
+	proc.statsFactory.NewTaggedStat("proc_consumer_db_read_jobs", stats.CountType, stats.Tags{"partition": destinationID}).Count(len(jobs.Jobs))
+	return jobs
+}
+
+// procMarkExecuting marks the given proc jobs as executing. It mirrors
+// [Handle.markExecuting] but targets procDB.
+func (proc *Handle) procMarkExecuting(ctx context.Context, destinationID string, jobs []*jobsdb.JobT) error {
+	_, span := proc.tracer.Trace(ctx, "procMarkExecuting", tracing.WithTraceTags(stats.Tags{"destination_id": destinationID}))
+	defer span.End()
+
+	statusList := make([]*jobsdb.JobStatusT, len(jobs))
+	for i, job := range jobs {
+		statusList[i] = &jobsdb.JobStatusT{
+			JobID:         job.JobID,
+			AttemptNum:    job.LastJobStatus.AttemptNum,
+			JobState:      jobsdb.Executing.State,
+			ExecTime:      time.Now(),
+			RetryTime:     time.Now(),
+			ErrorResponse: []byte(`{}`),
+			Parameters:    []byte(`{}`),
+			Consumer:      destinationID,
+			JobParameters: job.Parameters,
+			WorkspaceId:   job.WorkspaceId,
+			PartitionID:   job.PartitionID,
+			CustomVal:     job.CustomVal,
+		}
+	}
+	err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout.Load(), proc.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
+		return proc.procDB.UpdateJobStatus(ctx, statusList)
+	}, proc.sendRetryUpdateStats)
+	if err != nil {
+		return fmt.Errorf("marking proc jobs as executing: %w", err)
+	}
+	return nil
+}
+
+// procStoreStage stores through the shared [Handle.storeStage] but directs the
+// job-status update (and the reports/rsources committed in the same tx) to procDB via
+// storeMessage.statusDB, instead of the default gatewayDB.
+func (proc *Handle) procStoreStage(partition string, pipelineIndex int, in *storeMessage) {
+	in.statusDB = proc.procDB
+	proc.storeStage(partition, pipelineIndex, in)
+}
+
+// procRebuildStage is proc pool's entry stage. It reconstructs the post-fan-out
+// [transformationMessage] from persisted proc jobs: it deserializes each job and
+// re-hydrates Destination/Connection/Libraries/Credentials from live backendConfig.
+// Dest-filter and consent are NOT re-applied here — they were already decided in gw
+// pool (preprocess/fan-out) and the proc job is only stored for the destinations that
+// passed them. A destination deleted/disabled between fan-out and consume is dropped
+// gracefully to a terminal status. Surviving events are grouped per (source,destination)
+// so the reused transform stages operate on them unchanged.
+func (proc *Handle) procRebuildStage(destinationID string, in subJob) (*transformationMessage, error) { //nolint: unparam
+	s := time.Now()
+	defer func() {
+		proc.statsFactory.NewTaggedStat("proc_consumer_rebuild_stage", stats.TimerType, stats.Tags{"destinationId": destinationID}).Since(s)
+	}()
+
+	groupedEvents := make(map[string][]types.TransformerEvent)
+	uniqueMessageIdsBySrcDestKey := make(map[string]map[string]struct{})
+	eventsByMessageID := make(map[string]types.SingularEventWithReceivedAt)
+	srcPipelineSteps := make(sourceIDPipelineSteps)
+	statusList := make([]*jobsdb.JobStatusT, 0, len(in.subJobs))
+	var reportMetrics []*reportingtypes.PUReportedMetric
+	var totalEvents int
+
+	for _, job := range in.subJobs {
+		var payload procJobPayload
+		if err := jsonrs.Unmarshal(job.EventPayload, &payload); err != nil {
+			proc.logger.Errorn("Unmarshalling proc job payload", obskit.Error(err), logger.NewIntField("jobId", job.JobID))
+			statusList = append(statusList, procJobStatus(job, destinationID, jobsdb.Aborted.State, fmt.Sprintf(`{"error":%q}`, err.Error())))
+			continue
+		}
+		totalEvents++
+		sourceID := payload.Metadata.SourceID
+
+		// Re-hydrate the destination from live config. Config drift: a destination
+		// deleted/disabled since fan-out is dropped gracefully to a terminal status.
+		dest, ok := proc.getEnabledDestinationByID(sourceID, destinationID)
+		if !ok {
+			statusList = append(statusList, procJobStatus(job, destinationID, jobsdb.Filtered.State, `{"reason":"destination not found or disabled"}`))
+			continue
+		}
+
+		event := types.TransformerEvent{
+			Message:     payload.Message,
+			Metadata:    payload.Metadata,
+			Destination: dest,
+			Connection:  proc.getConnectionConfig(connection{sourceID: sourceID, destinationID: destinationID}),
+			Libraries:   proc.getWorkspaceLibraries(payload.Metadata.WorkspaceID),
+			Credentials: proc.config.credentialsMap[payload.Metadata.WorkspaceID],
+		}
+		// Refresh destination metadata from the (possibly drifted) live config.
+		event.Metadata.DestinationID = dest.ID
+		event.Metadata.DestinationName = dest.Name
+		event.Metadata.DestinationType = dest.DestinationDefinition.Name
+		event.Metadata.DestinationDefinitionID = dest.DestinationDefinition.ID
+		if len(dest.Transformations) > 0 {
+			event.Metadata.TransformationID = dest.Transformations[0].ID
+			event.Metadata.TransformationVersionID = dest.Transformations[0].VersionID
+		}
+		filterConfig(&event)
+
+		srcAndDestKey := getKeyFromSourceAndDest(sourceID, destinationID)
+		groupedEvents[srcAndDestKey] = append(groupedEvents[srcAndDestKey], event)
+		if _, ok := uniqueMessageIdsBySrcDestKey[srcAndDestKey]; !ok {
+			uniqueMessageIdsBySrcDestKey[srcAndDestKey] = make(map[string]struct{})
+		}
+		uniqueMessageIdsBySrcDestKey[srcAndDestKey][payload.Metadata.MessageID] = struct{}{}
+
+		receivedAt, _ := misc.GetParsedTimestamp(payload.Metadata.ReceivedAt)
+		eventsByMessageID[payload.Metadata.MessageID] = types.SingularEventWithReceivedAt{
+			SingularEvent: payload.Message,
+			ReceivedAt:    receivedAt,
+		}
+		srcPipelineSteps[SourceIDT(sourceID)] = SourcePipelineSteps{
+			srcHydration:           payload.SrcHydration,
+			trackingPlanValidation: payload.TrackingPlanValidation,
+		}
+		statusList = append(statusList, procJobStatus(job, destinationID, jobsdb.Succeeded.State, `{}`))
+	}
+
+	return &transformationMessage{
+		ctx:                          in.ctx,
+		groupedEvents:                groupedEvents,
+		srcPipelineSteps:             srcPipelineSteps,
+		eventsByMessageID:            eventsByMessageID,
+		uniqueMessageIdsBySrcDestKey: uniqueMessageIdsBySrcDestKey,
+		reportMetrics:                reportMetrics,
+		statusList:                   statusList,
+		sourceDupStats:               make(map[dupStatKey]int),
+		dedupKeys:                    make(map[string]struct{}),
+		totalEvents:                  totalEvents,
+		hasMore:                      in.hasMore,
+		rsourcesStats:                in.rsourcesStats,
+		trackedUsersReports:          nil, // tracked users stay entirely in gw pool
+	}, nil
+}
+
+// getEnabledDestinationByID returns the live, enabled destination for the given
+// (source, destination) connection, or false when it no longer exists / is disabled.
+func (proc *Handle) getEnabledDestinationByID(sourceID, destinationID string) (backendconfig.DestinationT, bool) {
+	proc.config.configSubscriberLock.RLock()
+	defer proc.config.configSubscriberLock.RUnlock()
+	for i := range proc.config.sourceIdDestinationMap[sourceID] {
+		dest := &proc.config.sourceIdDestinationMap[sourceID][i]
+		if dest.ID == destinationID && dest.Enabled {
+			return *dest, true
+		}
+	}
+	return backendconfig.DestinationT{}, false
+}
+
+// procJobStatus builds a terminal job status for a proc job.
+func procJobStatus(job *jobsdb.JobT, destinationID, state, errorResponse string) *jobsdb.JobStatusT {
+	return &jobsdb.JobStatusT{
+		JobID:         job.JobID,
+		JobState:      state,
+		AttemptNum:    job.LastJobStatus.AttemptNum + 1,
+		ExecTime:      time.Now(),
+		RetryTime:     time.Now(),
+		ErrorResponse: []byte(errorResponse),
+		Parameters:    []byte(`{}`),
+		Consumer:      destinationID,
+		JobParameters: job.Parameters,
+		WorkspaceId:   job.WorkspaceId,
+		PartitionID:   job.PartitionID,
+		CustomVal:     job.CustomVal,
+	}
+}

--- a/processor/proc_consumer_test.go
+++ b/processor/proc_consumer_test.go
@@ -1,0 +1,190 @@
+package processor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/processor/types"
+)
+
+// newTestProcHandle builds a minimal *Handle wired only with what procRebuildStage
+// reads: a live backend config (source→destinations, connections, libraries, credentials),
+// a NOP logger and stats. No jobsdb, transformer or workerpool involved.
+func newTestProcHandle() *Handle {
+	proc := &Handle{}
+	proc.statsFactory = stats.NOP
+	proc.logger = logger.NOP
+	proc.config.sourceIdDestinationMap = map[string][]backendconfig.DestinationT{}
+	proc.config.connectionConfigMap = map[connection]backendconfig.Connection{}
+	proc.config.workspaceLibrariesMap = map[string]backendconfig.LibrariesT{}
+	proc.config.credentialsMap = map[string][]types.Credential{}
+	return proc
+}
+
+func testDestination(id, name string, enabled bool) backendconfig.DestinationT { //nolint: unparam
+	return backendconfig.DestinationT{
+		ID:      id,
+		Name:    name,
+		Enabled: enabled,
+		DestinationDefinition: backendconfig.DestinationDefinitionT{
+			ID:   "defID-" + id,
+			Name: "WEBHOOK",
+		},
+	}
+}
+
+// newProcJob serializes a payload the way the (out-of-scope) gw-pool siphon would.
+func newProcJob(jobID int64, payload procJobPayload) *jobsdb.JobT {
+	b, err := jsonrs.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return &jobsdb.JobT{
+		JobID:        jobID,
+		UserID:       payload.Metadata.RudderID,
+		EventPayload: b,
+		Parameters:   []byte(`{}`),
+	}
+}
+
+func procRebuildInput(jobs ...*jobsdb.JobT) subJob {
+	return subJob{ctx: context.Background(), subJobs: jobs}
+}
+
+func TestProcRebuildStage(t *testing.T) {
+	const (
+		srcID = "src-1"
+		dstID = "dest-1"
+		wsID  = "ws-1"
+	)
+
+	t.Run("happy path re-hydrates destination and groups per (source,destination)", func(t *testing.T) {
+		proc := newTestProcHandle()
+		proc.config.sourceIdDestinationMap[srcID] = []backendconfig.DestinationT{testDestination(dstID, "my-webhook", true)}
+		proc.config.connectionConfigMap[connection{sourceID: srcID, destinationID: dstID}] = backendconfig.Connection{SourceID: srcID, DestinationID: dstID}
+		proc.config.workspaceLibrariesMap[wsID] = backendconfig.LibrariesT{{VersionID: "lib-1"}}
+		proc.config.credentialsMap[wsID] = []types.Credential{{Key: "k", Value: "v"}}
+
+		job := newProcJob(1, procJobPayload{
+			Message: types.SingularEventT{"type": "track", "event": "clicked"},
+			Metadata: types.Metadata{
+				SourceID: srcID, WorkspaceID: wsID, MessageID: "msg-1",
+				RudderID: "user-1", ReceivedAt: "2026-07-21T10:00:00.000Z",
+			},
+			SrcHydration:           true,
+			TrackingPlanValidation: true,
+		})
+
+		out, err := proc.procRebuildStage(dstID, procRebuildInput(job))
+		require.NoError(t, err)
+
+		key := getKeyFromSourceAndDest(srcID, dstID)
+		require.Len(t, out.groupedEvents, 1)
+		require.Contains(t, out.groupedEvents, key)
+		require.Len(t, out.groupedEvents[key], 1)
+
+		ev := out.groupedEvents[key][0]
+		require.Equal(t, dstID, ev.Destination.ID)
+		require.Equal(t, dstID, ev.Metadata.DestinationID)
+		require.Equal(t, "my-webhook", ev.Metadata.DestinationName)
+		require.Equal(t, "WEBHOOK", ev.Metadata.DestinationType)
+		require.Equal(t, "defID-"+dstID, ev.Metadata.DestinationDefinitionID)
+		require.Equal(t, srcID, ev.Connection.SourceID)
+		require.Equal(t, []backendconfig.LibraryT(proc.config.workspaceLibrariesMap[wsID]), ev.Libraries)
+		require.Equal(t, proc.config.credentialsMap[wsID], ev.Credentials)
+
+		require.Equal(t, 1, out.totalEvents)
+		require.Len(t, out.statusList, 1)
+		require.Equal(t, jobsdb.Succeeded.State, out.statusList[0].JobState)
+		require.Equal(t, dstID, out.statusList[0].Consumer)
+		require.Contains(t, out.eventsByMessageID, "msg-1")
+		require.Equal(t, SourcePipelineSteps{srcHydration: true, trackingPlanValidation: true}, out.srcPipelineSteps[SourceIDT(srcID)])
+		require.Nil(t, out.trackedUsersReports, "tracked users stay in gw pool")
+	})
+
+	t.Run("destination metadata is rehydrated even when the persisted metadata has no destination_id", func(t *testing.T) {
+		proc := newTestProcHandle()
+		proc.config.sourceIdDestinationMap[srcID] = []backendconfig.DestinationT{testDestination(dstID, "my-webhook", true)}
+
+		// Persisted metadata deliberately carries NO destination fields (the siphon does
+		// not store them); the destination comes from the partition/consumer instead.
+		job := newProcJob(1, procJobPayload{
+			Message:  types.SingularEventT{"type": "track"},
+			Metadata: types.Metadata{SourceID: srcID, WorkspaceID: wsID, MessageID: "msg-1"},
+		})
+		require.Contains(t, string(job.EventPayload), `"destinationId":""`, "precondition: payload's destination_id is empty")
+
+		out, err := proc.procRebuildStage(dstID, procRebuildInput(job))
+		require.NoError(t, err)
+
+		ev := out.groupedEvents[getKeyFromSourceAndDest(srcID, dstID)][0]
+		require.Equal(t, dstID, ev.Metadata.DestinationID)
+		require.Equal(t, "my-webhook", ev.Metadata.DestinationName)
+		require.Equal(t, "WEBHOOK", ev.Metadata.DestinationType)
+		require.Equal(t, "defID-"+dstID, ev.Metadata.DestinationDefinitionID)
+	})
+
+	t.Run("config drift: disabled destination is dropped (filtered), not paniced", func(t *testing.T) {
+		proc := newTestProcHandle()
+		proc.config.sourceIdDestinationMap[srcID] = []backendconfig.DestinationT{testDestination(dstID, "my-webhook", false)}
+
+		job := newProcJob(1, procJobPayload{Metadata: types.Metadata{SourceID: srcID, MessageID: "msg-1"}})
+		out, err := proc.procRebuildStage(dstID, procRebuildInput(job))
+		require.NoError(t, err)
+
+		require.Empty(t, out.groupedEvents)
+		require.Len(t, out.statusList, 1)
+		require.Equal(t, jobsdb.Filtered.State, out.statusList[0].JobState)
+		require.Equal(t, dstID, out.statusList[0].Consumer)
+	})
+
+	t.Run("config drift: deleted destination is dropped (filtered)", func(t *testing.T) {
+		proc := newTestProcHandle() // no destinations at all
+
+		job := newProcJob(1, procJobPayload{Metadata: types.Metadata{SourceID: srcID, MessageID: "msg-1"}})
+		out, err := proc.procRebuildStage(dstID, procRebuildInput(job))
+		require.NoError(t, err)
+
+		require.Empty(t, out.groupedEvents)
+		require.Len(t, out.statusList, 1)
+		require.Equal(t, jobsdb.Filtered.State, out.statusList[0].JobState)
+	})
+
+	t.Run("unparseable payload is aborted, not paniced", func(t *testing.T) {
+		proc := newTestProcHandle()
+
+		job := &jobsdb.JobT{JobID: 1, EventPayload: []byte(`{not json`), Parameters: []byte(`{}`)}
+		out, err := proc.procRebuildStage(dstID, procRebuildInput(job))
+		require.NoError(t, err)
+
+		require.Empty(t, out.groupedEvents)
+		require.Equal(t, 0, out.totalEvents)
+		require.Len(t, out.statusList, 1)
+		require.Equal(t, jobsdb.Aborted.State, out.statusList[0].JobState)
+	})
+
+	t.Run("multiple sources for the same destination are grouped separately", func(t *testing.T) {
+		proc := newTestProcHandle()
+		proc.config.sourceIdDestinationMap["src-1"] = []backendconfig.DestinationT{testDestination(dstID, "wh", true)}
+		proc.config.sourceIdDestinationMap["src-2"] = []backendconfig.DestinationT{testDestination(dstID, "wh", true)}
+
+		job1 := newProcJob(1, procJobPayload{Metadata: types.Metadata{SourceID: "src-1", MessageID: "m1"}})
+		job2 := newProcJob(2, procJobPayload{Metadata: types.Metadata{SourceID: "src-2", MessageID: "m2"}})
+
+		out, err := proc.procRebuildStage(dstID, procRebuildInput(job1, job2))
+		require.NoError(t, err)
+
+		require.Len(t, out.groupedEvents, 2)
+		require.Contains(t, out.groupedEvents, getKeyFromSourceAndDest("src-1", dstID))
+		require.Contains(t, out.groupedEvents, getKeyFromSourceAndDest("src-2", dstID))
+		require.Len(t, out.statusList, 2)
+	})
+}

--- a/processor/proc_partition_worker.go
+++ b/processor/proc_partition_worker.go
@@ -1,0 +1,164 @@
+package processor
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/samber/lo"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/services/rsources"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+	"github.com/rudderlabs/rudder-server/utils/tracing"
+)
+
+// procWorkerHandle abstracts processor's [Handle] from the proc pool workers, mirroring
+// [workerHandle] for the gw pool so the proc workers can be unit-tested with a mock.
+// It is satisfied by [workerHandleAdapter] (which embeds *Handle).
+type procWorkerHandle interface {
+	logger() logger.Logger
+	config() workerHandleConfig
+	rsourcesService() rsources.JobService
+	stats() *processorStats
+
+	getProcJobs(ctx context.Context, destinationID string) jobsdb.JobsResult
+	procMarkExecuting(ctx context.Context, destinationID string, jobs []*jobsdb.JobT) error
+	jobSplitter(ctx context.Context, jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []subJob
+	procRebuildStage(destinationID string, in subJob) (*transformationMessage, error)
+	userTransformStage(partition string, in *transformationMessage) *userTransformData
+	destinationTransformStage(partition string, in *userTransformData) *storeMessage
+	// procStoreStage stores through the shared storeStage, directing the job-status
+	// update to procDB instead of gatewayDB.
+	procStoreStage(partition string, pipelineIndex int, in *storeMessage)
+}
+
+// procPartitionWorker drives the proc pool for a single destination (partition = destination ID).
+// It is the post-fan-out counterpart of [gwPartitionWorker]: it polls the intermediate
+// (proc) jobsdb filtered to its destination, distributes jobs across pipelines by userID
+// (to preserve per-user ordering, §7) and feeds each [procPipelineWorker].
+type procPartitionWorker struct {
+	partition    string
+	pipelines    []*procPipelineWorker
+	logger       logger.Logger
+	stats        *processorStats
+	tracer       *tracing.Tracer
+	handle       procWorkerHandle
+	statsFactory stats.Stats
+}
+
+func newProcPartitionWorker(partition string, h procWorkerHandle, t stats.Tracer, statsFactory stats.Stats) *procPartitionWorker {
+	w := &procPartitionWorker{
+		partition:    partition,
+		logger:       h.logger().Child("proc-consumer").Child(partition),
+		stats:        h.stats(),
+		tracer:       tracing.New(t, tracing.WithNamePrefix("procPartitionWorker")),
+		handle:       h,
+		statsFactory: statsFactory,
+	}
+	pipelinesPerPartition := h.config().pipelinesPerPartition
+	w.pipelines = make([]*procPipelineWorker, pipelinesPerPartition)
+	for i := range pipelinesPerPartition {
+		w.pipelines[i] = newProcPipelineWorker(i, partition, h, tracing.New(t, tracing.WithNamePrefix("procPipelineWorker")))
+	}
+	return w
+}
+
+// Work polls the proc jobsdb for this partition and pipelines any jobs found.
+// Returns true if work was done, false otherwise.
+func (w *procPartitionWorker) Work() bool {
+	start := time.Now()
+	spanTags := stats.Tags{"partition": w.partition}
+	ctx, span := w.tracer.Trace(context.Background(), "Work", tracing.WithTraceTags(spanTags))
+	defer span.End()
+
+	jobs := w.handle.getProcJobs(ctx, w.partition)
+	if len(jobs.Jobs) == 0 {
+		span.SetStatus(stats.SpanStatusOk, "No jobs found")
+		return false
+	}
+
+	if err := w.handle.procMarkExecuting(ctx, w.partition, jobs.Jobs); err != nil {
+		w.logger.Errorn("Error marking proc jobs as executing", obskit.Error(err))
+		panic(err)
+	}
+
+	// Distribute jobs across pipelines based on UserID so a single user's events for a
+	// destination are always drained by the same pipeline (per-user ordering, §7).
+	jobsByPipeline := lo.GroupBy(jobs.Jobs, func(job *jobsdb.JobT) int {
+		return int(misc.GetMurmurHash(job.UserID) % uint64(w.handle.config().pipelinesPerPartition))
+	})
+
+	if err := w.sendToRebuild(ctx, jobsByPipeline); err != nil && !errors.Is(err, context.Canceled) {
+		w.logger.Errorn("Error while processing proc jobs", obskit.Error(err))
+		panic(err)
+	}
+
+	if !jobs.LimitsReached {
+		readLoopSleep := w.handle.config().readLoopSleep
+		if elapsed := time.Since(start); elapsed < readLoopSleep.Load() {
+			_ = w.tracer.TraceFunc(ctx, "Work.sleep", func(ctx context.Context) {
+				if err := misc.SleepCtx(context.Background(), readLoopSleep.Load()-elapsed); err != nil {
+					panic(err)
+				}
+			}, tracing.WithTraceTags(spanTags))
+		}
+	}
+
+	return true
+}
+
+// SleepDurations returns the min and max sleep durations for the worker
+func (w *procPartitionWorker) SleepDurations() (minSleep, maxSleep time.Duration) {
+	return w.handle.config().readLoopSleep.Load(), w.handle.config().maxLoopSleep.Load()
+}
+
+// Stop stops the worker and waits until all its goroutines have stopped
+func (w *procPartitionWorker) Stop() {
+	var wg sync.WaitGroup
+	for _, pipeline := range w.pipelines {
+		wg.Add(1)
+		go func(p *procPipelineWorker) {
+			defer wg.Done()
+			p.Stop()
+		}(pipeline)
+	}
+	wg.Wait()
+}
+
+func (w *procPartitionWorker) sendToRebuild(ctx context.Context, jobsByPipeline map[int][]*jobsdb.JobT) error {
+	spanTags := stats.Tags{"partition": w.partition}
+	_, span := w.tracer.Trace(ctx, "Work.sendToRebuild", tracing.WithTraceTags(spanTags))
+	defer span.End()
+
+	g, gCtx := errgroup.WithContext(context.Background())
+
+	for pipelineIdx, pipelineJobs := range jobsByPipeline {
+		pipeline := pipelineIdx
+		jobs := pipelineJobs
+		rsourcesStats := rsources.NewStatsCollector(w.handle.rsourcesService(), "processor", w.statsFactory, rsources.IgnoreDestinationID())
+		rsourcesStats.BeginProcessing(jobs)
+
+		g.Go(func() error {
+			subJobs := w.handle.jobSplitter(ctx, jobs, rsourcesStats)
+			for _, subJob := range subJobs {
+				waitStart := time.Now()
+				select {
+				case <-gCtx.Done():
+					return gCtx.Err()
+				case w.pipelines[pipeline].channel.rebuild <- subJob:
+					w.tracer.RecordSpan(ctx, "Work.rebuildCh.wait", waitStart, tracing.WithRecordSpanTags(spanTags))
+				}
+			}
+			return nil
+		})
+	}
+
+	return g.Wait()
+}

--- a/processor/proc_partition_worker_test.go
+++ b/processor/proc_partition_worker_test.go
@@ -1,0 +1,243 @@
+package processor
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	kitsync "github.com/rudderlabs/rudder-go-kit/sync"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/services/rsources"
+	"github.com/rudderlabs/rudder-server/utils/workerpool"
+)
+
+// TestProcWorkerPool drives the proc pool (procPartitionWorker + procPipelineWorker)
+// through the workerpool with a mock handle, asserting event-count conservation across
+// the 4 proc stages (rebuild → userTransform → destinationTransform → store) for every
+// partition (destination), under pipelining, limits-reached and multi-subjob merging.
+func TestProcWorkerPool(t *testing.T) {
+	run := func(t *testing.T, limitsReached, shouldProcessMultipleSubJobs bool) {
+		wh := &mockProcWorkerHandle{
+			log:                          logger.NOP,
+			loopEvents:                   99, // divisible by 3 for the multi-subjob split
+			partitionStats:               map[string]procPartitionStat{},
+			limitsReached:                limitsReached,
+			shouldProcessMultipleSubJobs: shouldProcessMultipleSubJobs,
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		poolCtx, poolCancel := context.WithCancel(context.Background())
+
+		var limiterWg sync.WaitGroup
+		wh.limiters.pread = kitsync.NewLimiter(poolCtx, &limiterWg, "pread", 2, stats.Default)
+		wh.limiters.rebuild = kitsync.NewLimiter(poolCtx, &limiterWg, "rebuild", 2, stats.Default)
+		wh.limiters.usertransform = kitsync.NewLimiter(poolCtx, &limiterWg, "usertransform", 2, stats.Default)
+		wh.limiters.destinationtransform = kitsync.NewLimiter(poolCtx, &limiterWg, "destinationtransform", 2, stats.Default)
+		wh.limiters.store = kitsync.NewLimiter(poolCtx, &limiterWg, "store", 2, stats.Default)
+		defer limiterWg.Wait()
+		defer poolCancel()
+
+		wp := workerpool.New(poolCtx, func(partition string) workerpool.Worker {
+			return newProcPartitionWorker(partition, wh, stats.NOP.NewTracer(""), stats.NOP)
+		}, logger.NOP)
+
+		// ping for work for 20 destinations
+		var wg sync.WaitGroup
+		for i := range 20 {
+			destinationID := "dest-" + strconv.Itoa(i)
+			wg.Go(func() {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-time.After(10 * time.Millisecond):
+						wp.PingWorker(destinationID)
+					}
+				}
+			})
+		}
+		time.Sleep(2 * time.Second)
+		cancel()
+		wg.Wait()
+
+		wp.Shutdown()
+
+		wh.validate(t)
+	}
+
+	t.Run("limits not reached", func(t *testing.T) { run(t, false, false) })
+	t.Run("limits reached", func(t *testing.T) { run(t, true, false) })
+	t.Run("limits reached with multiple sub jobs", func(t *testing.T) { run(t, true, true) })
+	t.Run("limits not reached with multiple sub jobs", func(t *testing.T) { run(t, false, true) })
+}
+
+// TestProcWorkerPoolIdle asserts that a proc worker for a drained destination (no jobs)
+// is cleaned up by the pool.
+func TestProcWorkerPoolIdle(t *testing.T) {
+	wh := &mockProcWorkerHandle{
+		log:            logger.NOP,
+		loopEvents:     0,
+		partitionStats: map[string]procPartitionStat{},
+	}
+	wp := workerpool.New(t.Context(),
+		func(partition string) workerpool.Worker {
+			return newProcPartitionWorker(partition, wh, stats.NOP.NewTracer(""), stats.NOP)
+		},
+		logger.NOP,
+		workerpool.WithCleanupPeriod(200*time.Millisecond),
+		workerpool.WithIdleTimeout(200*time.Millisecond))
+
+	require.Equal(t, 0, wp.Size())
+	wp.PingWorker("dest-1")
+	require.Equal(t, 1, wp.Size())
+	require.Eventually(t, func() bool {
+		return wp.Size() == 0
+	}, 2*time.Second, 10*time.Millisecond, "idle worker (no jobs) should be cleaned up")
+	wp.Shutdown()
+}
+
+type procPartitionStat struct {
+	queried              int
+	marked               int
+	rebuilt              int
+	userTransform        int
+	destinationTransform int
+	stored               int
+	subBatches           int
+}
+
+type mockProcWorkerHandle struct {
+	loopEvents     int
+	statsMu        sync.RWMutex
+	log            logger.Logger
+	partitionStats map[string]procPartitionStat
+
+	limiters struct {
+		pread                kitsync.Limiter
+		rebuild              kitsync.Limiter
+		usertransform        kitsync.Limiter
+		destinationtransform kitsync.Limiter
+		store                kitsync.Limiter
+	}
+
+	limitsReached                bool
+	shouldProcessMultipleSubJobs bool
+}
+
+// validate asserts per-destination that no events were lost between any two stages.
+func (m *mockProcWorkerHandle) validate(t *testing.T) {
+	m.statsMu.RLock()
+	defer m.statsMu.RUnlock()
+	require.NotEmpty(t, m.partitionStats, "expected at least one destination to have been processed")
+	for destinationID, s := range m.partitionStats {
+		require.Positivef(t, s.queried, "dest %s: nothing queried", destinationID)
+		require.Equalf(t, s.queried, s.marked, "dest %s: queried %d != marked %d", destinationID, s.queried, s.marked)
+		require.Equalf(t, s.marked, s.rebuilt, "dest %s: marked %d != rebuilt %d", destinationID, s.marked, s.rebuilt)
+		require.Equalf(t, s.rebuilt, s.userTransform, "dest %s: rebuilt %d != userTransform %d", destinationID, s.rebuilt, s.userTransform)
+		require.Equalf(t, s.userTransform, s.destinationTransform, "dest %s: userTransform %d != destinationTransform %d", destinationID, s.userTransform, s.destinationTransform)
+		require.Equalf(t, s.destinationTransform, s.stored, "dest %s: destinationTransform %d != stored %d", destinationID, s.destinationTransform, s.stored)
+	}
+}
+
+func (m *mockProcWorkerHandle) update(partition string, f func(s *procPartitionStat)) {
+	m.statsMu.Lock()
+	defer m.statsMu.Unlock()
+	s := m.partitionStats[partition]
+	f(&s)
+	m.partitionStats[partition] = s
+}
+
+func (m *mockProcWorkerHandle) logger() logger.Logger { return m.log }
+
+func (m *mockProcWorkerHandle) config() workerHandleConfig {
+	return workerHandleConfig{
+		enablePipelining:      true,
+		maxEventsToProcess:    config.SingleValueLoader(m.loopEvents),
+		pipelineBufferedItems: 1,
+		subJobSize:            10,
+		readLoopSleep:         config.SingleValueLoader(1 * time.Millisecond),
+		maxLoopSleep:          config.SingleValueLoader(100 * time.Millisecond),
+		pipelinesPerPartition: 3,
+		partitionProcessingDelay: func(string) config.ValueLoader[time.Duration] {
+			return config.SingleValueLoader(0 * time.Millisecond)
+		},
+	}
+}
+
+func (*mockProcWorkerHandle) rsourcesService() rsources.JobService { return nil }
+func (*mockProcWorkerHandle) stats() *processorStats               { return &processorStats{} }
+
+func (m *mockProcWorkerHandle) getProcJobs(_ context.Context, destinationID string) jobsdb.JobsResult {
+	if m.limiters.pread != nil {
+		defer m.limiters.pread.Begin("")()
+	}
+	m.update(destinationID, func(s *procPartitionStat) { s.queried += m.loopEvents })
+
+	jobs := make([]*jobsdb.JobT, 0, m.loopEvents)
+	for i := 0; i < m.loopEvents; i++ {
+		jobs = append(jobs, &jobsdb.JobT{
+			UserID:    strconv.Itoa(i), // spread across pipelines
+			CustomVal: destinationID,
+		})
+	}
+	return jobsdb.JobsResult{Jobs: jobs, EventsCount: m.loopEvents, LimitsReached: m.limitsReached}
+}
+
+func (m *mockProcWorkerHandle) procMarkExecuting(_ context.Context, destinationID string, jobs []*jobsdb.JobT) error {
+	m.update(destinationID, func(s *procPartitionStat) { s.marked += len(jobs) })
+	return nil
+}
+
+func (m *mockProcWorkerHandle) jobSplitter(ctx context.Context, jobs []*jobsdb.JobT, rsourcesStats rsources.StatsCollector) []subJob {
+	if !m.shouldProcessMultipleSubJobs || len(jobs) < 3 {
+		return []subJob{{ctx: ctx, subJobs: jobs, hasMore: false, rsourcesStats: rsourcesStats}}
+	}
+	third := len(jobs) / 3
+	return []subJob{
+		{ctx: ctx, subJobs: jobs[:third], hasMore: true, rsourcesStats: rsourcesStats},
+		{ctx: ctx, subJobs: jobs[third : 2*third], hasMore: true, rsourcesStats: rsourcesStats},
+		{ctx: ctx, subJobs: jobs[2*third:], hasMore: false, rsourcesStats: rsourcesStats},
+	}
+}
+
+func (m *mockProcWorkerHandle) procRebuildStage(destinationID string, in subJob) (*transformationMessage, error) {
+	if m.limiters.rebuild != nil {
+		defer m.limiters.rebuild.Begin("")()
+	}
+	m.update(destinationID, func(s *procPartitionStat) {
+		s.rebuilt += len(in.subJobs)
+		s.subBatches++
+	})
+	return &transformationMessage{ctx: in.ctx, totalEvents: len(in.subJobs), hasMore: in.hasMore}, nil
+}
+
+func (m *mockProcWorkerHandle) userTransformStage(partition string, in *transformationMessage) *userTransformData {
+	if m.limiters.usertransform != nil {
+		defer m.limiters.usertransform.Begin("")()
+	}
+	m.update(partition, func(s *procPartitionStat) { s.userTransform += in.totalEvents })
+	return &userTransformData{ctx: in.ctx, totalEvents: in.totalEvents, hasMore: in.hasMore}
+}
+
+func (m *mockProcWorkerHandle) destinationTransformStage(partition string, in *userTransformData) *storeMessage {
+	if m.limiters.destinationtransform != nil {
+		defer m.limiters.destinationtransform.Begin("")()
+	}
+	m.update(partition, func(s *procPartitionStat) { s.destinationTransform += in.totalEvents })
+	return &storeMessage{ctx: in.ctx, totalEvents: in.totalEvents, hasMore: in.hasMore}
+}
+
+func (m *mockProcWorkerHandle) procStoreStage(partition string, _ int, in *storeMessage) {
+	if m.limiters.store != nil {
+		defer m.limiters.store.Begin("")()
+	}
+	m.update(partition, func(s *procPartitionStat) { s.stored += in.totalEvents })
+}

--- a/processor/proc_pipeline_worker.go
+++ b/processor/proc_pipeline_worker.go
@@ -1,0 +1,175 @@
+package processor
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+
+	"github.com/rudderlabs/rudder-server/processor/types"
+	"github.com/rudderlabs/rudder-server/rruntime"
+	"github.com/rudderlabs/rudder-server/utils/tracing"
+)
+
+// procPipelineWorker manages a single pipeline of the proc pool partition.
+// It is the post-fan-out counterpart of [gwPipelineWorker]: it reads already fanned-out
+// per-(source,destination) events from the intermediate (proc) jobsdb and runs the
+// remaining stages, reusing the existing transform and store stages verbatim:
+//
+//	rebuild → userTransform → destinationTransform → store
+//
+// The only new stage is procRebuildStage (config re-hydration + dest-filter/consent
+// re-check). userTransformStage, destinationTransformStage and storeStage are shared
+// with gw pool; store commits job-status updates against procDB instead of gatewayDB
+// via storeMessage.statusDB.
+type procPipelineWorker struct {
+	index     int
+	partition string
+	handle    procWorkerHandle
+	logger    logger.Logger
+	tracer    *tracing.Tracer
+
+	lifecycle struct {
+		ctx    context.Context
+		cancel context.CancelFunc
+		wg     sync.WaitGroup
+	}
+	channel struct {
+		rebuild              chan subJob
+		usertransform        chan *transformationMessage
+		destinationtransform chan *userTransformData
+		store                chan *storeMessage
+	}
+}
+
+func newProcPipelineWorker(index int, partition string, h procWorkerHandle, t *tracing.Tracer) *procPipelineWorker {
+	w := &procPipelineWorker{
+		index:     index,
+		handle:    h,
+		logger:    h.logger().Withn(logger.NewStringField("partition", partition)),
+		tracer:    t,
+		partition: partition,
+	}
+	w.lifecycle.ctx, w.lifecycle.cancel = context.WithCancel(context.Background())
+
+	bufSize := h.config().pipelineBufferedItems
+	w.channel.rebuild = make(chan subJob, bufSize)
+	w.channel.usertransform = make(chan *transformationMessage, bufSize)
+	w.channel.destinationtransform = make(chan *userTransformData, bufSize)
+	storeBufferSize := (bufSize + 1) * (h.config().maxEventsToProcess.Load()/h.config().subJobSize + 1)
+	w.channel.store = make(chan *storeMessage, storeBufferSize)
+
+	w.start()
+	return w
+}
+
+func (w *procPipelineWorker) start() {
+	// context cancellation handler closes the head of the pipeline
+	w.lifecycle.wg.Add(1)
+	rruntime.Go(func() {
+		defer w.lifecycle.wg.Done()
+		defer close(w.channel.rebuild)
+		<-w.lifecycle.ctx.Done()
+	})
+
+	spanTags := stats.Tags{"partition": w.partition}
+
+	// Rebuild goroutine: re-hydrate config, re-run dest-filter/consent and produce the
+	// post-fan-out transformationMessage from persisted proc jobs.
+	w.lifecycle.wg.Add(1)
+	rruntime.Go(func() {
+		defer w.lifecycle.wg.Done()
+		defer close(w.channel.usertransform)
+		defer w.logger.Debugn("proc rebuild routine stopped")
+
+		for jobs := range w.channel.rebuild {
+			val, err := w.handle.procRebuildStage(w.partition, jobs)
+			if errors.Is(err, types.ErrProcessorStopping) {
+				continue
+			}
+			if err != nil {
+				w.logger.Errorn("Error rebuilding proc jobs", obskit.Error(err))
+				panic(err)
+			}
+			waitStart := time.Now()
+			w.channel.usertransform <- val
+			w.tracer.RecordSpan(jobs.ctx, "start.userTransformCh.wait", waitStart, tracing.WithRecordSpanTags(spanTags))
+		}
+	})
+
+	// User transformation goroutine (reused stage)
+	w.lifecycle.wg.Add(1)
+	rruntime.Go(func() {
+		defer w.lifecycle.wg.Done()
+		defer close(w.channel.destinationtransform)
+		defer w.logger.Debugn("proc usertransform routine stopped")
+
+		for msg := range w.channel.usertransform {
+			data := w.handle.userTransformStage(w.partition, msg)
+			waitStart := time.Now()
+			w.channel.destinationtransform <- data
+			w.tracer.RecordSpan(msg.ctx, "start.destinationTransformCh.wait", waitStart, tracing.WithRecordSpanTags(spanTags))
+		}
+	})
+
+	// Destination transformation goroutine (reused stage)
+	w.lifecycle.wg.Add(1)
+	rruntime.Go(func() {
+		defer w.lifecycle.wg.Done()
+		defer close(w.channel.store)
+		defer w.logger.Debugn("proc destinationtransform routine stopped")
+
+		for msg := range w.channel.destinationtransform {
+			storeMsg := w.handle.destinationTransformStage(w.partition, msg)
+			waitStart := time.Now()
+			w.channel.store <- storeMsg
+			w.tracer.RecordSpan(msg.ctx, "start.storeCh.wait", waitStart, tracing.WithRecordSpanTags(spanTags))
+		}
+	})
+
+	// Storage goroutine (reused stage, targeting procDB for the status update)
+	w.lifecycle.wg.Add(1)
+	rruntime.Go(func() {
+		defer w.lifecycle.wg.Done()
+		defer w.logger.Debugn("proc store routine stopped")
+
+		var mergedJob *storeMessage
+		firstSubJob := true
+
+		for subJob := range w.channel.store {
+			if firstSubJob && !subJob.hasMore {
+				w.handle.procStoreStage(w.partition, w.index, subJob)
+				continue
+			}
+
+			if firstSubJob {
+				mergedJob = &storeMessage{
+					ctx:                   subJob.ctx,
+					rsourcesStats:         subJob.rsourcesStats,
+					dedupKeys:             make(map[string]struct{}),
+					procErrorJobsByDestID: make(map[string][]procErrorJob),
+					sourceDupStats:        make(map[dupStatKey]int),
+					start:                 subJob.start,
+				}
+				firstSubJob = false
+			}
+
+			mergedJob.merge(subJob)
+
+			if !subJob.hasMore {
+				w.handle.procStoreStage(w.partition, w.index, mergedJob)
+				firstSubJob = true
+			}
+		}
+	})
+}
+
+// Stop gracefully terminates the worker by canceling its context and waiting for goroutines to finish
+func (w *procPipelineWorker) Stop() {
+	w.lifecycle.cancel()
+	w.lifecycle.wg.Wait()
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -150,6 +150,7 @@ type Handle struct {
 	isolationStrategy          isolation.Strategy
 	limiter                    struct {
 		read         kitsync.Limiter
+		pread        kitsync.Limiter // proc pool read (getProcJobs), independent of gw pool read
 		preprocess   kitsync.Limiter
 		srcHydration kitsync.Limiter
 		pretransform kitsync.Limiter
@@ -682,6 +683,10 @@ func (proc *Handle) Start(ctx context.Context) error {
 		proc.conf.GetReloadableIntVar(50, 1, "Processor.Limiter.read.limit"),
 		s,
 		kitsync.WithLimiterDynamicPeriod(config.GetDurationVar(1, time.Second, "Processor.Limiter.read.dynamicPeriod")))
+	proc.limiter.pread = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "proc_pread",
+		proc.conf.GetReloadableIntVar(50, 1, "Processor.Limiter.pread.limit"),
+		s,
+		kitsync.WithLimiterDynamicPeriod(config.GetDurationVar(1, time.Second, "Processor.Limiter.pread.dynamicPeriod")))
 	proc.limiter.preprocess = kitsync.NewReloadableLimiter(ctx, &limiterGroup, "proc_preprocess",
 		proc.conf.GetReloadableIntVar(50, 1, "Processor.Limiter.preprocess.limit"),
 		s,
@@ -706,14 +711,15 @@ func (proc *Handle) Start(ctx context.Context) error {
 		proc.conf.GetReloadableIntVar(50, 1, "Processor.Limiter.store.limit"),
 		s,
 		kitsync.WithLimiterDynamicPeriod(config.GetDurationVar(1, time.Second, "Processor.Limiter.store.dynamicPeriod")))
+
 	g.Go(func() error {
 		limiterGroup.Wait()
 		return nil
 	})
 
-	// pinger loop
+	// gw consumer loop
 	g.Go(crash.Wrapper(func() error {
-		proc.logger.Infon("Starting pinger loop")
+		proc.logger.Infon("Starting gw consumer loop")
 		proc.backendConfig.WaitForConfig(ctx)
 		proc.logger.Infon("Backend config received")
 
@@ -739,7 +745,7 @@ func (proc *Handle) Start(ctx context.Context) error {
 
 		h := &workerHandleAdapter{proc}
 		pool := workerpool.New(ctx, func(partition string) workerpool.Worker {
-			return newPartitionWorker(partition, h, proc.statsFactory.NewTracer("partitionWorker"), proc.statsFactory)
+			return newGwPartitionWorker(partition, h, proc.statsFactory.NewTracer("gwPartitionWorker"), proc.statsFactory)
 		}, proc.logger)
 		defer pool.Shutdown()
 		for {
@@ -752,6 +758,11 @@ func (proc *Handle) Start(ctx context.Context) error {
 				pool.PingWorker(partition)
 			}
 		}
+	}))
+
+	// proc consumer loop — no-op unless procDB is configured
+	g.Go(crash.Wrapper(func() error {
+		return proc.startProcConsumer(ctx)
 	}))
 
 	return g.Wait()
@@ -2429,22 +2440,20 @@ func (proc *Handle) pretransformStage(partition string, preTrans *preTransformat
 	activationRecordsReports := proc.activationRecordsReporter.GenerateReportsFromJobs(preTrans.jobList, sourceCategoriesBySourceID)
 
 	return &transformationMessage{
-		preTrans.subJobs.ctx,
-		groupedEvents,
-		sourcePipelineSteps,
-		preTrans.eventsByMessageID,
-		uniqueMessageIdsBySrcDestKey,
-		preTrans.reportMetrics,
-		preTrans.statusList,
-		preTrans.sourceDupStats,
-		preTrans.dedupKeys,
-
-		preTrans.totalEvents,
-
-		preTrans.subJobs.hasMore,
-		preTrans.subJobs.rsourcesStats,
-		trackedUsersReports,
-		activationRecordsReports,
+		ctx:                          preTrans.subJobs.ctx,
+		groupedEvents:                groupedEvents,
+		srcPipelineSteps:             sourcePipelineSteps,
+		eventsByMessageID:            preTrans.eventsByMessageID,
+		uniqueMessageIdsBySrcDestKey: uniqueMessageIdsBySrcDestKey,
+		reportMetrics:                preTrans.reportMetrics,
+		statusList:                   preTrans.statusList,
+		sourceDupStats:               preTrans.sourceDupStats,
+		dedupKeys:                    preTrans.dedupKeys,
+		totalEvents:                  preTrans.totalEvents,
+		hasMore:                      preTrans.subJobs.hasMore,
+		rsourcesStats:                preTrans.subJobs.rsourcesStats,
+		trackedUsersReports:          trackedUsersReports,
+		activationRecordsReports:     activationRecordsReports,
 	}, nil
 }
 
@@ -2690,25 +2699,23 @@ func (proc *Handle) destinationTransformStage(partition string, in *userTransfor
 	}
 
 	return &storeMessage{
-		in.ctx,
-		in.trackedUsersReports,
-		in.activationRecordsReports,
-		in.statusList,
-		destJobs,
-		batchDestJobs,
-		droppedJobs,
-
-		procErrorJobsByDestID,
-		lo.Keys(routerDestIDs),
-
-		in.reportMetrics,
-		in.sourceDupStats,
-		in.dedupKeys,
-		in.totalEvents,
-		in.start,
-		in.hasMore,
-		in.rsourcesStats,
-		in.traces,
+		ctx:                      in.ctx,
+		trackedUsersReports:      in.trackedUsersReports,
+		activationRecordsReports: in.activationRecordsReports,
+		statusList:               in.statusList,
+		destJobs:                 destJobs,
+		batchDestJobs:            batchDestJobs,
+		droppedJobs:              droppedJobs,
+		procErrorJobsByDestID:    procErrorJobsByDestID,
+		routerDestIDs:            lo.Keys(routerDestIDs),
+		reportMetrics:            in.reportMetrics,
+		sourceDupStats:           in.sourceDupStats,
+		dedupKeys:                in.dedupKeys,
+		totalEvents:              in.totalEvents,
+		start:                    in.start,
+		hasMore:                  in.hasMore,
+		rsourcesStats:            in.rsourcesStats,
+		traces:                   in.traces,
 	}
 }
 
@@ -2735,6 +2742,21 @@ type storeMessage struct {
 	hasMore       bool
 	rsourcesStats rsources.StatsCollector
 	traces        map[string]stats.Tags
+
+	// statusDB is the jobsdb whose job statuses (statusList) are updated in the final
+	// commit. When nil it defaults to gatewayDB (the in-memory gw pipeline). The
+	// proc pool sets it to procDB so the same storeStage commits its
+	// status update + reports + rsources against the intermediate jobsdb instead.
+	statusDB jobsdb.JobsDB
+}
+
+// statusUpdateDB returns the jobsdb whose statuses storeStage must update: the
+// explicit statusDB when set (proc pool / procDB), otherwise gatewayDB (gw pool).
+func (proc *Handle) statusUpdateDB(in *storeMessage) jobsdb.JobsDB {
+	if in.statusDB != nil {
+		return in.statusDB
+	}
+	return proc.gatewayDB
 }
 
 func (sm *storeMessage) merge(subJob *storeMessage) {
@@ -2946,11 +2968,12 @@ func (proc *Handle) storeStage(partition string, pipelineIndex int, in *storeMes
 		}
 	}
 	in.rsourcesStats.CollectStats(statusList)
+	statusDB := proc.statusUpdateDB(in)
 	err := misc.RetryWithNotify(context.Background(), proc.jobsDBCommandTimeout.Load(), proc.jobdDBMaxRetries.Load(), func(ctx context.Context) error {
-		return proc.gatewayDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
-			err := proc.gatewayDB.UpdateJobStatusInTx(ctx, tx, statusList)
+		return statusDB.WithUpdateSafeTx(ctx, func(tx jobsdb.UpdateSafeTx) error {
+			err := statusDB.UpdateJobStatusInTx(ctx, tx, statusList)
 			if err != nil {
-				return fmt.Errorf("updating gateway jobs statuses: %w", err)
+				return fmt.Errorf("updating %s jobs statuses: %w", statusDB.Identifier(), err)
 			}
 
 			if proc.isReportingEnabled() {


### PR DESCRIPTION
# Description

Introduces the **proc pool**: a second processor worker pool that consumes a new intermediate **`proc` jobsdb** and runs the post-fan-out stages — `rebuild → user transform → destination transform → store` — isolated **per destination**, so a slow/failing destination no longer blocks the others. It reuses the existing processor stages as-is; only the `rebuild` entry stage is new.

This PR is the **consumer side only**. Nothing writes to the `proc` jobsdb yet — the gw-pool siphon that fans out and persists jobs into it is out of scope and will follow up in a separate pull request. With `Processor.DestinationIsolation.enabled=false` (default) the pool is a no-op.

**Multi-consumer jobsdb.** The `proc` jobsdb is multi-consumer: one job carries multiple consumer IDs (destination IDs), and each `(job, consumer)` pair has its own independent status lifecycle. The proc pool:
- discovers partitions via `GetDistinctConsumers` (one partition = one destination),
- picks up jobs scoped to a consumer (`GetUnprocessed` with `Consumer`), and
- commits per-consumer statuses through the shared `storeStage`, redirected to write against `procDB` instead of `gatewayDB`.

**Rebuild assumptions.** Proc jobs persist only IDs + the event/metadata; at consume time `rebuild` re-hydrates `Destination`/`Connection`/`Libraries`/`Credentials` from the **live** backend config. Therefore:
- Destination filtering and consent are **not** re-applied — they were already decided in the gw pool, and a job is only stored for the destinations that passed them.
- A destination deleted/disabled between fan-out and consume is dropped gracefully to a terminal status. Drop is silent, i.e. it is not being reported, similar to what is happening already during the pretransform stage when we fan out events.

## Linear Ticket

resolves PIPE-3048
resolves PIPE-3054

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #7207 
- <kbd>&nbsp;1&nbsp;</kbd> #7202 👈 
<!-- GitButler Footer Boundary Bottom -->