### PR TITLE
fix: use correct JSON tag for adjustedConversionTime in bing-ads

### DIFF
--- a/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bingads_test.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bingads_test.go
@@ -3,6 +3,7 @@ package offline_conversions
 import (
 	"archive/zip"
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -524,6 +526,18 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			Expect(err.Error()).To(Equal(expectedResult.Error()))
 		})
 
+		It("Transform() Test -> update reformats and preserves adjustedConversionTime", func() {
+			job := &jobsdb.JobT{
+				EventPayload: []byte("{\"type\": \"record\", \"action\": \"update\", \"fields\": {\"conversionName\": \"Test-Integration\", \"conversionTime\": \"2023-05-22T06:27:54Z\", \"adjustedConversionTime\": \"2023-05-22T18:27:54Z\", \"conversionValue\": \"100\", \"microsoftClickId\": \"click_id\", \"conversionCurrencyCode\": \"USD\"}}"),
+			}
+			uploader := &BingAdsBulkUploader{}
+			expectedResp := `{"message":{"fields":{"adjustedConversionTime":"5/22/2023 6:27:54 PM","conversionCurrencyCode":"USD","conversionName":"Test-Integration","conversionTime":"5/22/2023 6:27:54 AM","conversionValue":"100","microsoftClickId":"click_id"},"action":"update"},"metadata":{"jobId":0}}`
+			// Execute
+			resp, err := uploader.Transform(job)
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal(expectedResp))
+		})
+
 		It("Transform() Test -> microsoftClickId is required(email and phone undefined) but not present", func() {
 			job := &jobsdb.JobT{
 				EventPayload: []byte("{\"type\": \"record\", \"action\": \"update\", \"fields\": {\"conversionName\": \"Test-Integration\", \"conversionTime\": \"2023-05-22T06:27:54Z\", \"conversionValue\": \"100\", \"conversionCurrencyCode\": \"USD\"}}"),
@@ -637,6 +651,93 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			Expect(err).To(BeNil())
 			Expect(resp).To(Equal(expectedResp))
 		})
+		// populateZipFile writes one record into the action-specific CSV. Each case below
+		// supplies the input fields and the FULL expected CSV (header + format version +
+		// data row) so we compare the entire file, catching any column shift or drop.
+		// The canonical field name emitted by rETL/VDM is `adjustedConversionTime`
+		// (rudder-integrations-info/src/routes/bingads_offline_conversions/index.ts:46).
+		DescribeTable("populateZipFile() -> writes the full expected CSV per action",
+			func(action string, fields map[string]string, expectedCSV [][]string) {
+				initBingads()
+				bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", nil, false)
+
+				actionFile, err := createActionFile(action)
+				Expect(err).ShouldNot(HaveOccurred())
+				defer os.Remove(actionFile.CSVFilePath)
+				defer os.Remove(actionFile.ZipFilePath)
+
+				fieldsJSON, err := jsonrs.Marshal(fields)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				err = bulkUploader.populateZipFile(actionFile, "some line", Data{
+					Message:  Message{Action: action, Fields: fieldsJSON},
+					Metadata: Metadata{JobID: 7},
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+				actionFile.CSVWriter.Flush()
+
+				csvContent, err := os.ReadFile(actionFile.CSVFilePath)
+				Expect(err).ShouldNot(HaveOccurred())
+				records, err := csv.NewReader(strings.NewReader(string(csvContent))).ReadAll()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Full comparison of every row (header, format version, data row).
+				Expect(records).To(Equal(expectedCSV))
+			},
+			Entry("insert",
+				"insert",
+				map[string]string{
+					"conversionCurrencyCode":    "USD",
+					"conversionName":            "Test-Integration",
+					"conversionTime":            "4/19/2024 5:01:20 AM",
+					"conversionValue":           "10",
+					"microsoftClickId":          "click_id",
+					"email":                     "hashed_email",
+					"phone":                     "hashed_phone",
+					"externalAttributionCredit": "0.5",
+					"externalAttributionModel":  "dummy goal name",
+				},
+				[][]string{
+					{"Type", "Status", "Id", "Parent Id", "Client Id", "Name", "Conversion Currency Code", "Conversion Name", "Conversion Time", "Conversion Value", "Microsoft Click Id", "Hashed Email Address", "Hashed Phone Number", "External Attribution Credit", "External Attribution Model"},
+					{"Format Version", "", "", "", "", "6.0", "", "", "", "", "", "", "", "", ""},
+					{"Offline Conversion", "", "7", "", "", "", "USD", "Test-Integration", "4/19/2024 5:01:20 AM", "10", "click_id", "hashed_email", "hashed_phone", "0.5", "dummy goal name"},
+				},
+			),
+			Entry("update (Restate)",
+				"update",
+				map[string]string{
+					"conversionCurrencyCode": "USD",
+					"conversionName":         "Test-Integration",
+					"conversionTime":         "4/1/2024 9:23:54 AM",
+					"conversionValue":        "100",
+					"adjustedConversionTime": "4/1/2024 9:33:54 AM",
+					"microsoftClickId":       "click_id",
+					"email":                  "hashed_email",
+					"phone":                  "hashed_phone",
+				},
+				[][]string{
+					{"Type", "Adjustment Type", "Client Id", "Id", "Name", "Conversion Name", "Conversion Time", "Adjustment Value", "Microsoft Click Id", "Hashed Email Address", "Hashed Phone Number", "Adjusted Currency Code", "Adjustment Time"},
+					{"Format Version", "", "", "", "6.0", "", "", "", "", "", "", "", ""},
+					{"Offline Conversion", "Restate", "", "7", "", "Test-Integration", "4/1/2024 9:23:54 AM", "100", "click_id", "hashed_email", "hashed_phone", "USD", "4/1/2024 9:33:54 AM"},
+				},
+			),
+			Entry("delete (Retract)",
+				"delete",
+				map[string]string{
+					"conversionName":         "Test-Integration",
+					"conversionTime":         "4/1/2024 9:23:54 AM",
+					"adjustedConversionTime": "4/1/2024 9:33:54 AM",
+					"microsoftClickId":       "click_id",
+					"email":                  "hashed_email",
+					"phone":                  "hashed_phone",
+				},
+				[][]string{
+					{"Type", "Adjustment Type", "Client Id", "Id", "Name", "Conversion Name", "Conversion Time", "Microsoft Click Id", "Hashed Email Address", "Hashed Phone Number", "Adjustment Time"},
+					{"Format Version", "", "", "", "6.0", "", "", "", "", "", ""},
+					{"Offline Conversion", "Retract", "", "7", "", "Test-Integration", "4/1/2024 9:23:54 AM", "click_id", "hashed_email", "hashed_phone", "4/1/2024 9:33:54 AM"},
+				},
+			),
+		)
 	})
 })
 

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bingads_test.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bingads_test.go
@@ -538,6 +538,45 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			Expect(resp).To(Equal(expectedResp))
 		})
 
+		It("Transform() Test -> insert ignores a malformed adjustedConversionTime", func() {
+			job := &jobsdb.JobT{
+				EventPayload: []byte("{\"type\": \"record\", \"action\": \"insert\", \"fields\": {\"conversionName\": \"Test-Integration\", \"conversionTime\": \"2023-05-22T06:27:54Z\", \"adjustedConversionTime\": \"not-a-timestamp\", \"conversionValue\": \"100\", \"microsoftClickId\": \"click_id\"}}"),
+			}
+			uploader := &BingAdsBulkUploader{}
+			// insert does not validate adjustedConversionTime, so the malformed value
+			// does not cause an error; it is left untouched (and ignored downstream).
+			expectedResp := `{"message":{"fields":{"adjustedConversionTime":"not-a-timestamp","conversionName":"Test-Integration","conversionTime":"5/22/2023 6:27:54 AM","conversionValue":"100","microsoftClickId":"click_id"},"action":"insert"},"metadata":{"jobId":0}}`
+			// Execute
+			resp, err := uploader.Transform(job)
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal(expectedResp))
+		})
+
+		It("Transform() Test -> insert leaves a valid adjustedConversionTime untouched", func() {
+			job := &jobsdb.JobT{
+				EventPayload: []byte("{\"type\": \"record\", \"action\": \"insert\", \"fields\": {\"conversionName\": \"Test-Integration\", \"conversionTime\": \"2023-05-22T06:27:54Z\", \"adjustedConversionTime\": \"2023-05-22T18:27:54Z\", \"conversionValue\": \"100\", \"microsoftClickId\": \"click_id\"}}"),
+			}
+			uploader := &BingAdsBulkUploader{}
+			// conversionTime is reformatted; adjustedConversionTime is NOT reformatted
+			// on insert (it is not validated), so it stays in its original form.
+			expectedResp := `{"message":{"fields":{"adjustedConversionTime":"2023-05-22T18:27:54Z","conversionName":"Test-Integration","conversionTime":"5/22/2023 6:27:54 AM","conversionValue":"100","microsoftClickId":"click_id"},"action":"insert"},"metadata":{"jobId":0}}`
+			// Execute
+			resp, err := uploader.Transform(job)
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal(expectedResp))
+		})
+
+		It("Transform() Test -> update errors naming a malformed adjustedConversionTime", func() {
+			job := &jobsdb.JobT{
+				EventPayload: []byte("{\"type\": \"record\", \"action\": \"update\", \"fields\": {\"conversionName\": \"Test-Integration\", \"conversionTime\": \"2023-05-22T06:27:54Z\", \"adjustedConversionTime\": \"not-a-timestamp\", \"conversionValue\": \"100\", \"microsoftClickId\": \"click_id\", \"conversionCurrencyCode\": \"USD\"}}"),
+			}
+			uploader := &BingAdsBulkUploader{}
+			// Execute
+			_, err := uploader.Transform(job)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("adjustedConversionTime must be in ISO 8601"))
+		})
+
 		It("Transform() Test -> microsoftClickId is required(email and phone undefined) but not present", func() {
 			job := &jobsdb.JobT{
 				EventPayload: []byte("{\"type\": \"record\", \"action\": \"update\", \"fields\": {\"conversionName\": \"Test-Integration\", \"conversionTime\": \"2023-05-22T06:27:54Z\", \"conversionValue\": \"100\", \"conversionCurrencyCode\": \"USD\"}}"),
@@ -567,7 +606,9 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			uploader := &BingAdsBulkUploader{
 				isHashRequired: true,
 			}
-			expectedResp := `{"message":{"fields":{"adjustedConversionTime":"5/22/2023 6:27:54 PM","conversionCurrencyCode":"USD","conversionName":"Test-Integration","conversionTime":"5/22/2023 6:27:54 PM","conversionValue":"100","email":"28a4da98f8812110001ab8ffacde3b38b4725a9e3570c39299fbf2d12c5aa70e","phone":"8c229df83de8ab269e90918846e326c4008c86481393223d17a30ff5a407b08e"},"action":"insert"},"metadata":{"jobId":0}}`
+			// insert does not reformat adjustedConversionTime (it is not validated on
+			// insert), so it stays in its original ISO form; conversionTime is reformatted.
+			expectedResp := `{"message":{"fields":{"adjustedConversionTime":"2023-05-22T18:27:54Z","conversionCurrencyCode":"USD","conversionName":"Test-Integration","conversionTime":"5/22/2023 6:27:54 PM","conversionValue":"100","email":"28a4da98f8812110001ab8ffacde3b38b4725a9e3570c39299fbf2d12c5aa70e","phone":"8c229df83de8ab269e90918846e326c4008c86481393223d17a30ff5a407b08e"},"action":"insert"},"metadata":{"jobId":0}}`
 			// Execute
 			resp, err := uploader.Transform(job)
 			Expect(resp).To(Equal(expectedResp))

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bulk_uploader.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bulk_uploader.go
@@ -69,7 +69,7 @@ func (b *BingAdsBulkUploader) Transform(job *jobsdb.JobT) (string, error) {
 		}
 	}
 
-	err = validateAndTransformTimeFields(fields)
+	err = validateAndTransformTimeFields(fields, event.Action)
 	if err != nil {
 		return payload, err
 	}

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/types.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/types.go
@@ -71,7 +71,7 @@ type RecordFields struct {
 	Email                     string `json:"email"`
 	Phone                     string `json:"phone"`
 	MicrosoftClickId          string `json:"microsoftClickId"`
-	ConversionAdjustedTime    string `json:"conversionAdjustedTime"`
+	ConversionAdjustedTime    string `json:"adjustedConversionTime"`
 	ExternalAttributionCredit string `json:"externalAttributionCredit"`
 	ExternalAttributionModel  string `json:"externalAttributionModel"`
 }

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/util.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/util.go
@@ -511,8 +511,14 @@ func hashFields(input map[string]any) (json.RawMessage, error) {
 	return json.RawMessage(result), nil
 }
 
-func validateAndTransformTimeFields(fields map[string]any) error {
-	timeFields := []string{"conversionTime", "adjustedConversionTime"}
+func validateAndTransformTimeFields(fields map[string]any, action string) error {
+	// insert never uses adjustedConversionTime (populateZipFile's insert branch
+	// does not read it), so it is not validated for insert. It is left untouched
+	// in the fields and ignored downstream.
+	timeFields := []string{"conversionTime"}
+	if action != "insert" {
+		timeFields = append(timeFields, "adjustedConversionTime")
+	}
 
 	for _, field := range timeFields {
 		fieldValue, ok := fields[field]
@@ -525,7 +531,7 @@ func validateAndTransformTimeFields(fields map[string]any) error {
 			if parseErr != nil {
 				parsedTime, parseErr = time.Parse("1/2/2006 3:04:05 PM", fieldValueStr)
 				if parseErr != nil {
-					return fmt.Errorf("conversionTime must be in ISO 8601 (e.g. 2006-01-02T15:04:05Z07:00) or mm/dd/yyyy hh:mm:ss AM/PM (e.g. 7/2/2025 6:50:54 PM) format")
+					return fmt.Errorf("%s must be in ISO 8601 (e.g. 2006-01-02T15:04:05Z07:00) or mm/dd/yyyy hh:mm:ss AM/PM (e.g. 7/2/2025 6:50:54 PM) format", field)
 				}
 			}
 			fields[field] = parsedTime.Format("1/2/2006 3:04:05 PM")


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

# Description

The RecordFields struct read the adjustment time under the wrong JSON key (conversionAdjustedTime), while the VDM field, rETL record events, and the Transform validation all use adjustedConversionTime. As a result, update (Restate) and delete (Retract) rows shipped with an empty Adjustment Time column and Microsoft rejected them with OfflineConversionAdjustmentTimeNullOrEmpty; only inserts succeeded.

Fix the struct tag to adjustedConversionTime and add tests asserting the Adjustment Time column is populated: a Transform test and a table-driven populateZipFile test that compares the full CSV output per action.

## Linear Ticket

[Resolves INT-6853](https://linear.app/rudderstack/issue/INT-6853/bingads-offline-conversions-failures-in-the-sync)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
