### PR TITLE
fix: mid-run pod deaths under concurrent test runs

### DIFF
--- a/processor/cpservice/cpservice.go
+++ b/processor/cpservice/cpservice.go
@@ -62,6 +62,7 @@ type Service struct {
 	proto.UnimplementedProcessorServiceServer
 
 	log             logger.Logger
+	stat            stats.Stats
 	deployer        pytdeployer.Deployer
 	forwarder       Forwarder
 	staticASTURL    string
@@ -117,6 +118,7 @@ func (u *unavailableDeployer) RunOnEphemeral(
 func NewService(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...ServiceOpt) *Service {
 	s := &Service{
 		log:             log.Child("cpservice"),
+		stat:            stat,
 		staticASTURL:    conf.GetStringVar("", "Processor.pytTestStaticASTURL"),
 		prodURLTemplate: conf.GetStringVar(user_transformer.DefaultPerWorkspacePyTURLTemplate, "Processor.UserTransformer.perWorkspacePyTURLTemplate"),
 		prodRouted:      conf.GetReloadableStringMapVar(nil, "Processor.pytTestOverrides.routeToProduction"),
@@ -125,7 +127,7 @@ func NewService(conf *config.Config, log logger.Logger, stat stats.Stats, opts .
 		opt(s)
 	}
 	if s.deployer == nil {
-		deployer, err := pytdeployer.New(conf, log)
+		deployer, err := pytdeployer.New(conf, log, stat)
 		if err != nil {
 			log.Warnn("ephemeral pyt deployer unavailable; execution test ops will fail", obskit.Error(err))
 			deployer = &unavailableDeployer{err: err}

--- a/processor/cpservice/forward.go
+++ b/processor/cpservice/forward.go
@@ -125,6 +125,13 @@ func (s *Service) Forward(ctx context.Context, req *proto.ForwardRequest) (*prot
 	default:
 		statusCode, body, err = timedForward(ctx, s.staticASTURL)
 	}
+	// success here means the RPC delivered a pyt response, whatever its HTTP
+	// status — false marks infrastructure failures (deployer create errors,
+	// readiness timeouts, transport failures), which are the only way to tell
+	// a failed RPC apart from a slow success. On a deployer create failure
+	// this is the ONLY metric emitted: the readiness and request timers never
+	// get a sample because those phases never ran.
+	tags["success"] = strconv.FormatBool(err == nil)
 	s.stat.NewTaggedStat("processor_pyt_forward_rpc_time", stats.TimerType, tags).Since(start)
 	if err != nil {
 		s.log.Warnn("forwarding to pyt",

--- a/processor/cpservice/forward.go
+++ b/processor/cpservice/forward.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
 	"github.com/rudderlabs/rudder-server/processor/internal/transformer/user_transformer"
@@ -70,6 +71,7 @@ func (s *Service) Forward(ctx context.Context, req *proto.ForwardRequest) (*prot
 	var statusCode int
 	var body []byte
 	var err error
+	var route string
 	switch {
 	case isExecutionOp && s.isProdRouted(req.WorkspaceId):
 		// Config-flagged workspace: its tests must run with prod-only config
@@ -77,17 +79,25 @@ func (s *Service) Forward(ctx context.Context, req *proto.ForwardRequest) (*prot
 		// reproduce, so forward straight to the workspace's production pyt
 		// deployment. No readiness wait — the forwarder's cold-start retries
 		// ride out the prod deployment's scale-from-zero window.
+		route = "production"
 		statusCode, body, err = forward(ctx,
 			user_transformer.PerWorkspacePyTBaseURL(s.prodURLTemplate, req.WorkspaceId),
 			req.WorkspaceId, req.Payload)
 	case isExecutionOp:
+		route = "ephemeral"
 		statusCode, body, err = s.deployer.RunOnEphemeral(ctx, req.WorkspaceId,
 			func(ctx context.Context, baseURL string) (int, []byte, error) {
 				return forward(ctx, baseURL, req.WorkspaceId, req.Payload)
 			})
 	default:
+		route = "static"
 		statusCode, body, err = forward(ctx, s.staticASTURL, req.WorkspaceId, req.Payload)
 	}
+	s.stat.NewTaggedStat("processor_pyt_forward_time", stats.TimerType, stats.Tags{
+		"op":          req.Op.String(),
+		"route":       route,
+		"workspaceId": req.WorkspaceId,
+	}).Since(start)
 	if err != nil {
 		s.log.Warnn("forwarding to pyt",
 			obskit.WorkspaceID(req.WorkspaceId), logger.NewStringField("op", req.Op.String()), obskit.Error(err))

--- a/processor/cpservice/forward.go
+++ b/processor/cpservice/forward.go
@@ -68,36 +68,49 @@ func (s *Service) Forward(ctx context.Context, req *proto.ForwardRequest) (*prot
 		return nil, status.Error(codes.InvalidArgument, "workspaceId must be 1-59 alphanumeric or hyphen characters, starting and ending with an alphanumeric")
 	}
 
+	route := "static"
+	if isExecutionOp {
+		if s.isProdRouted(req.WorkspaceId) {
+			route = "production"
+		} else {
+			route = "ephemeral"
+		}
+	}
+	tags := stats.Tags{
+		"op":          req.Op.String(),
+		"route":       route,
+		"workspaceId": req.WorkspaceId,
+	}
+	// timedForward measures just the HTTP request to the pyt pod and emits the
+	// request timer itself, so on the ephemeral route it excludes the
+	// deployment creation and readiness wait (which RunOnEphemeral performs
+	// before invoking it) that the total timer includes — and a deployer
+	// failure that never invokes it produces no request sample.
+	timedForward := func(ctx context.Context, baseURL string) (int, []byte, error) {
+		execStart := time.Now()
+		statusCode, body, err := forward(ctx, baseURL, req.WorkspaceId, req.Payload)
+		s.stat.NewTaggedStat("processor_pyt_request_handle_time", stats.TimerType, tags).Since(execStart)
+		return statusCode, body, err
+	}
+
 	var statusCode int
 	var body []byte
 	var err error
-	var route string
-	switch {
-	case isExecutionOp && s.isProdRouted(req.WorkspaceId):
+	switch route {
+	case "production":
 		// Config-flagged workspace: its tests must run with prod-only config
 		// (custom DNS, pinned egress IPs, ...) the generic ephemeral spec can't
 		// reproduce, so forward straight to the workspace's production pyt
 		// deployment. No readiness wait — the forwarder's cold-start retries
 		// ride out the prod deployment's scale-from-zero window.
-		route = "production"
-		statusCode, body, err = forward(ctx,
-			user_transformer.PerWorkspacePyTBaseURL(s.prodURLTemplate, req.WorkspaceId),
-			req.WorkspaceId, req.Payload)
-	case isExecutionOp:
-		route = "ephemeral"
-		statusCode, body, err = s.deployer.RunOnEphemeral(ctx, req.WorkspaceId,
-			func(ctx context.Context, baseURL string) (int, []byte, error) {
-				return forward(ctx, baseURL, req.WorkspaceId, req.Payload)
-			})
+		statusCode, body, err = timedForward(ctx,
+			user_transformer.PerWorkspacePyTBaseURL(s.prodURLTemplate, req.WorkspaceId))
+	case "ephemeral":
+		statusCode, body, err = s.deployer.RunOnEphemeral(ctx, req.WorkspaceId, timedForward)
 	default:
-		route = "static"
-		statusCode, body, err = forward(ctx, s.staticASTURL, req.WorkspaceId, req.Payload)
+		statusCode, body, err = timedForward(ctx, s.staticASTURL)
 	}
-	s.stat.NewTaggedStat("processor_pyt_forward_time", stats.TimerType, stats.Tags{
-		"op":          req.Op.String(),
-		"route":       route,
-		"workspaceId": req.WorkspaceId,
-	}).Since(start)
+	s.stat.NewTaggedStat("processor_pyt_forward_rpc_time", stats.TimerType, tags).Since(start)
 	if err != nil {
 		s.log.Warnn("forwarding to pyt",
 			obskit.WorkspaceID(req.WorkspaceId), logger.NewStringField("op", req.Op.String()), obskit.Error(err))

--- a/processor/cpservice/forward.go
+++ b/processor/cpservice/forward.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -25,6 +27,14 @@ import (
 // pointed at either a freshly created ephemeral pyt Service or the shared
 // static AST deployment.
 type endpointForward func(ctx context.Context, baseURL, workspaceID string, payload []byte) (int, []byte, error)
+
+// route tag values for the processor_pyt_* metrics: which pyt deployment a
+// Forward request was served by.
+const (
+	routeEphemeral  = "ephemeral"  // fresh ephemeral deployment (execution ops)
+	routeProduction = "production" // the workspace's production pyt deployment (config-flagged execution ops)
+	routeStatic     = "static"     // the shared static AST deployment (AST ops)
+)
 
 // validWorkspaceID gates what Forward substitutes into the pyt URL template and
 // the pyt Deployment name. Anything beyond alphanumerics and hyphens must be
@@ -68,12 +78,12 @@ func (s *Service) Forward(ctx context.Context, req *proto.ForwardRequest) (*prot
 		return nil, status.Error(codes.InvalidArgument, "workspaceId must be 1-59 alphanumeric or hyphen characters, starting and ending with an alphanumeric")
 	}
 
-	route := "static"
+	route := routeStatic
 	if isExecutionOp {
 		if s.isProdRouted(req.WorkspaceId) {
-			route = "production"
+			route = routeProduction
 		} else {
-			route = "ephemeral"
+			route = routeEphemeral
 		}
 	}
 	tags := stats.Tags{
@@ -85,11 +95,16 @@ func (s *Service) Forward(ctx context.Context, req *proto.ForwardRequest) (*prot
 	// request timer itself, so on the ephemeral route it excludes the
 	// deployment creation and readiness wait (which RunOnEphemeral performs
 	// before invoking it) that the total timer includes — and a deployer
-	// failure that never invokes it produces no request sample.
+	// failure that never invokes it produces no request sample. The success
+	// tag separates unhealthy requests — transport failures (connection
+	// refused, exhausted retries) and non-200 pyt responses alike — from
+	// healthy ones, whose latencies are not comparable.
 	timedForward := func(ctx context.Context, baseURL string) (int, []byte, error) {
 		execStart := time.Now()
 		statusCode, body, err := forward(ctx, baseURL, req.WorkspaceId, req.Payload)
-		s.stat.NewTaggedStat("processor_pyt_request_handle_time", stats.TimerType, tags).Since(execStart)
+		reqTags := maps.Clone(tags)
+		reqTags["success"] = strconv.FormatBool(statusCode == http.StatusOK)
+		s.stat.NewTaggedStat("processor_pyt_request_handle_time", stats.TimerType, reqTags).Since(execStart)
 		return statusCode, body, err
 	}
 
@@ -97,7 +112,7 @@ func (s *Service) Forward(ctx context.Context, req *proto.ForwardRequest) (*prot
 	var body []byte
 	var err error
 	switch route {
-	case "production":
+	case routeProduction:
 		// Config-flagged workspace: its tests must run with prod-only config
 		// (custom DNS, pinned egress IPs, ...) the generic ephemeral spec can't
 		// reproduce, so forward straight to the workspace's production pyt
@@ -105,7 +120,7 @@ func (s *Service) Forward(ctx context.Context, req *proto.ForwardRequest) (*prot
 		// ride out the prod deployment's scale-from-zero window.
 		statusCode, body, err = timedForward(ctx,
 			user_transformer.PerWorkspacePyTBaseURL(s.prodURLTemplate, req.WorkspaceId))
-	case "ephemeral":
+	case routeEphemeral:
 		statusCode, body, err = s.deployer.RunOnEphemeral(ctx, req.WorkspaceId, timedForward)
 	default:
 		statusCode, body, err = timedForward(ctx, s.staticASTURL)

--- a/processor/cpservice/forward_test.go
+++ b/processor/cpservice/forward_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 
 	proto "github.com/rudderlabs/rudder-server/proto/processor"
 )
@@ -200,7 +201,7 @@ func TestForward(t *testing.T) {
 		// No WithDeployer override: NewService tries to build a real k8s-backed
 		// deployer, which fails outside a cluster/without a kubeconfig, and
 		// falls back to unavailableDeployer.
-		svc := NewService(conf, logger.NOP, nil, WithForwarder(fwd))
+		svc := NewService(conf, logger.NOP, stats.NOP, WithForwarder(fwd))
 
 		_, err := svc.Forward(context.Background(), &proto.ForwardRequest{Op: proto.Op_OP_TEST, WorkspaceId: "ws-1"})
 		require.Equal(t, codes.FailedPrecondition, status.Code(err),
@@ -225,6 +226,66 @@ func TestForward(t *testing.T) {
 		svc := newService(t, nil, deployer, &fakeForwarder{err: errors.New("connection refused")})
 		_, err := svc.Forward(context.Background(), &proto.ForwardRequest{Op: proto.Op_OP_TEST, WorkspaceId: "ws-1"})
 		require.Equal(t, codes.Unavailable, status.Code(err))
+	})
+
+	t.Run("emits a forward-time metric tagged by op, route and workspace", func(t *testing.T) {
+		cases := []struct {
+			name      string
+			op        proto.Op
+			prodRoute bool
+			fwdErr    error
+			wantRoute string
+		}{
+			{"execution op on an ephemeral deployment", proto.Op_OP_TEST, false, nil, "ephemeral"},
+			{"execution op routed to production", proto.Op_OP_TEST_RUN, true, nil, "production"},
+			{"AST op on the static deployment", proto.Op_OP_TEST_LIBRARY, false, nil, "static"},
+			{"emitted on a failed forward too", proto.Op_OP_TEST, false, errors.New("connection refused"), "ephemeral"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				statsStore, err := memstats.New()
+				require.NoError(t, err)
+				conf := config.New()
+				conf.Set("Processor.pytTestStaticASTURL", staticASTURL)
+				if tc.prodRoute {
+					conf.Set("Processor.pytTestOverrides.routeToProduction", map[string]any{"ws-1": true})
+				}
+				svc := NewService(conf, logger.NOP, statsStore,
+					WithDeployer(&fakeDeployer{baseURL: "http://pyt-test-abc.ns.svc:8080"}),
+					WithForwarder(&fakeForwarder{statusCode: 200, err: tc.fwdErr}))
+
+				_, err = svc.Forward(context.Background(), &proto.ForwardRequest{Op: tc.op, WorkspaceId: "ws-1"})
+				if tc.fwdErr != nil {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+
+				metrics := statsStore.GetByName("processor_pyt_forward_time")
+				require.Len(t, metrics, 1)
+				require.Equal(t, stats.Tags{
+					"op":          tc.op.String(),
+					"route":       tc.wantRoute,
+					"workspaceId": "ws-1",
+				}, metrics[0].Tags)
+			})
+		}
+	})
+
+	t.Run("no forward-time metric when the request is rejected before forwarding", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		conf := config.New()
+		conf.Set("Processor.pytTestStaticASTURL", staticASTURL)
+		svc := NewService(conf, logger.NOP, statsStore,
+			WithDeployer(&fakeDeployer{}), WithForwarder(&fakeForwarder{}))
+
+		_, err = svc.Forward(context.Background(), &proto.ForwardRequest{Op: proto.Op_OP_UNSPECIFIED, WorkspaceId: "ws-1"})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+		_, err = svc.Forward(context.Background(), &proto.ForwardRequest{Op: proto.Op_OP_TEST, WorkspaceId: "a@evil.com#"})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+		require.Empty(t, statsStore.GetByName("processor_pyt_forward_time"))
 	})
 }
 
@@ -288,5 +349,5 @@ func newService(t *testing.T, conf *config.Config, deployer *fakeDeployer, fwd F
 		conf = config.New()
 	}
 	conf.Set("Processor.pytTestStaticASTURL", staticASTURL)
-	return NewService(conf, logger.NOP, nil, WithDeployer(deployer), WithForwarder(fwd))
+	return NewService(conf, logger.NOP, stats.NOP, WithDeployer(deployer), WithForwarder(fwd))
 }

--- a/processor/cpservice/forward_test.go
+++ b/processor/cpservice/forward_test.go
@@ -3,6 +3,7 @@ package cpservice
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -250,9 +251,14 @@ func TestForward(t *testing.T) {
 				if tc.prodRoute {
 					conf.Set("Processor.pytTestOverrides.routeToProduction", map[string]any{"ws-1": true})
 				}
+				// The real forwarder returns no status code alongside an error.
+				fwdStatus := 200
+				if tc.fwdErr != nil {
+					fwdStatus = 0
+				}
 				svc := NewService(conf, logger.NOP, statsStore,
 					WithDeployer(&fakeDeployer{baseURL: "http://pyt-test-abc.ns.svc:8080"}),
-					WithForwarder(&fakeForwarder{statusCode: 200, err: tc.fwdErr}))
+					WithForwarder(&fakeForwarder{statusCode: fwdStatus, err: tc.fwdErr}))
 
 				_, err = svc.Forward(context.Background(), &proto.ForwardRequest{Op: tc.op, WorkspaceId: "ws-1"})
 				if tc.fwdErr != nil {
@@ -270,9 +276,15 @@ func TestForward(t *testing.T) {
 				require.Len(t, metrics, 1)
 				require.Equal(t, wantTags, metrics[0].Tags)
 
+				wantReqTags := stats.Tags{
+					"op":          tc.op.String(),
+					"route":       tc.wantRoute,
+					"workspaceId": "ws-1",
+					"success":     strconv.FormatBool(tc.fwdErr == nil),
+				}
 				execMetrics := statsStore.GetByName("processor_pyt_request_handle_time")
 				require.Len(t, execMetrics, 1, "the forward ran, so the request timer must have a sample too")
-				require.Equal(t, wantTags, execMetrics[0].Tags)
+				require.Equal(t, wantReqTags, execMetrics[0].Tags)
 			})
 		}
 	})

--- a/processor/cpservice/forward_test.go
+++ b/processor/cpservice/forward_test.go
@@ -228,7 +228,7 @@ func TestForward(t *testing.T) {
 		require.Equal(t, codes.Unavailable, status.Code(err))
 	})
 
-	t.Run("emits a forward-time metric tagged by op, route and workspace", func(t *testing.T) {
+	t.Run("emits total and request timers tagged by op, route and workspace", func(t *testing.T) {
 		cases := []struct {
 			name      string
 			op        proto.Op
@@ -261,18 +261,41 @@ func TestForward(t *testing.T) {
 					require.NoError(t, err)
 				}
 
-				metrics := statsStore.GetByName("processor_pyt_forward_time")
-				require.Len(t, metrics, 1)
-				require.Equal(t, stats.Tags{
+				wantTags := stats.Tags{
 					"op":          tc.op.String(),
 					"route":       tc.wantRoute,
 					"workspaceId": "ws-1",
-				}, metrics[0].Tags)
+				}
+				metrics := statsStore.GetByName("processor_pyt_forward_rpc_time")
+				require.Len(t, metrics, 1)
+				require.Equal(t, wantTags, metrics[0].Tags)
+
+				execMetrics := statsStore.GetByName("processor_pyt_request_handle_time")
+				require.Len(t, execMetrics, 1, "the forward ran, so the request timer must have a sample too")
+				require.Equal(t, wantTags, execMetrics[0].Tags)
 			})
 		}
 	})
 
-	t.Run("no forward-time metric when the request is rejected before forwarding", func(t *testing.T) {
+	t.Run("no request timer when the deployer fails before forwarding", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		conf := config.New()
+		conf.Set("Processor.pytTestStaticASTURL", staticASTURL)
+		svc := NewService(conf, logger.NOP, statsStore,
+			WithDeployer(&fakeDeployer{err: errors.New("create failed")}),
+			WithForwarder(&fakeForwarder{statusCode: 200}))
+
+		_, err = svc.Forward(context.Background(), &proto.ForwardRequest{Op: proto.Op_OP_TEST, WorkspaceId: "ws-1"})
+		require.Error(t, err)
+
+		require.Empty(t, statsStore.GetByName("processor_pyt_request_handle_time"),
+			"no request was made, so no request sample must be recorded")
+		require.Len(t, statsStore.GetByName("processor_pyt_forward_rpc_time"), 1,
+			"the total timer still records the failed attempt")
+	})
+
+	t.Run("no timers when the request is rejected before forwarding", func(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
 		conf := config.New()
@@ -285,7 +308,7 @@ func TestForward(t *testing.T) {
 		_, err = svc.Forward(context.Background(), &proto.ForwardRequest{Op: proto.Op_OP_TEST, WorkspaceId: "a@evil.com#"})
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
 
-		require.Empty(t, statsStore.GetByName("processor_pyt_forward_time"))
+		require.Empty(t, statsStore.GetByName("processor_pyt_forward_rpc_time"))
 	})
 }
 

--- a/processor/cpservice/forward_test.go
+++ b/processor/cpservice/forward_test.go
@@ -271,6 +271,7 @@ func TestForward(t *testing.T) {
 					"op":          tc.op.String(),
 					"route":       tc.wantRoute,
 					"workspaceId": "ws-1",
+					"success":     strconv.FormatBool(tc.fwdErr == nil),
 				}
 				metrics := statsStore.GetByName("processor_pyt_forward_rpc_time")
 				require.Len(t, metrics, 1)
@@ -303,8 +304,10 @@ func TestForward(t *testing.T) {
 
 		require.Empty(t, statsStore.GetByName("processor_pyt_request_handle_time"),
 			"no request was made, so no request sample must be recorded")
-		require.Len(t, statsStore.GetByName("processor_pyt_forward_rpc_time"), 1,
-			"the total timer still records the failed attempt")
+		rpcMetrics := statsStore.GetByName("processor_pyt_forward_rpc_time")
+		require.Len(t, rpcMetrics, 1, "the total timer still records the failed attempt")
+		require.Equal(t, "false", rpcMetrics[0].Tags["success"],
+			"a deployer failure must be distinguishable from a slow success")
 	})
 
 	t.Run("no timers when the request is rejected before forwarding", func(t *testing.T) {

--- a/processor/internal/pytdeployer/k8s.go
+++ b/processor/internal/pytdeployer/k8s.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 )
 
@@ -32,6 +34,7 @@ const (
 type k8sDeployer struct {
 	client kubernetes.Interface
 	log    logger.Logger
+	stat   stats.Stats
 	config deployerConfig
 }
 
@@ -65,15 +68,23 @@ func (d *k8sDeployer) RunOnEphemeral(
 		}
 		return created, err
 	}); err != nil {
-		d.delete(ctx, name)
+		d.delete(ctx, name, workspaceID)
 		return 0, nil, fmt.Errorf("creating ephemeral pyt service %s/%s: %w", d.config.namespace, name, err)
 	}
 	// Delete runs regardless of what happens below — on a readiness timeout,
 	// a forward error, or success alike. It never changes the response
 	// returned to the caller; a failed delete is only logged.
-	defer d.delete(ctx, name)
+	defer d.delete(ctx, name, workspaceID)
 
-	if err := d.waitReady(ctx, name); err != nil {
+	readyStart := time.Now()
+	err := d.waitReady(ctx, name)
+	// Emitted on both outcomes: the success:false series makes readiness
+	// timeouts visible and clusters at the configured readiness timeout.
+	d.stat.NewTaggedStat("processor_pyt_readiness_wait_time", stats.TimerType, stats.Tags{
+		"workspaceId": workspaceID,
+		"success":     strconv.FormatBool(err == nil),
+	}).Since(readyStart)
+	if err != nil {
 		return 0, nil, err
 	}
 
@@ -98,6 +109,12 @@ func (d *k8sDeployer) buildResources(name, workspaceID string) (*appsv1.Deployme
 	labels[LabelManagedBy] = LabelManagedByValue
 	labels[LabelPurpose] = LabelPurposeValue
 	labels[LabelWorkspaceID] = strings.ToLower(workspaceID)
+	// The run name makes the Deployment selector, pod labels, and Service
+	// selector unique per run. Concurrent runs (same workspace, same generic
+	// spec) otherwise carry identical labels, so each run's Service would
+	// select all runs' pods and route a request to a pod that another run
+	// deletes the moment it finishes.
+	labels[LabelRunName] = name
 
 	// WORKSPACE_ID is per-run, so it is injected programmatically on top of the
 	// config-provided env (prod injects it per workspace the same way). The
@@ -291,7 +308,7 @@ func (d *k8sDeployer) waitReady(ctx context.Context, name string) error {
 // already has. It runs on its own bounded timeout, detached from ctx's
 // cancellation, so cleanup still gets a chance to run when ctx is already
 // done (deadline exceeded, caller gone).
-func (d *k8sDeployer) delete(ctx context.Context, name string) {
+func (d *k8sDeployer) delete(ctx context.Context, name, workspaceID string) {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), d.config.deleteTimeout.Load())
 	defer cancel()
 
@@ -307,6 +324,8 @@ func (d *k8sDeployer) delete(ctx context.Context, name string) {
 		errs = append(errs, fmt.Errorf("deleting service %s/%s: %w", d.config.namespace, name, err))
 	}
 	if len(errs) > 0 {
+		d.stat.NewTaggedStat("processor_pyt_cleanup_failure_count", stats.CountType,
+			stats.Tags{"workspaceId": workspaceID}).Increment()
 		d.log.Errorn("cleaning up ephemeral pyt deployment; the reaper will collect any orphan",
 			logger.NewStringField("namespace", d.config.namespace),
 			logger.NewStringField("name", name),

--- a/processor/internal/pytdeployer/k8s.go
+++ b/processor/internal/pytdeployer/k8s.go
@@ -279,7 +279,11 @@ func (d *k8sDeployer) waitReady(ctx context.Context, name string) error {
 	ctx, cancel := context.WithTimeout(ctx, d.config.readinessTimeout.Load())
 	defer cancel()
 
-	ticker := time.NewTicker(d.config.readinessPollInterval.Load())
+	// The floor guards against misconfigured reloadable values: NewTicker
+	// panics on a non-positive interval, and anything shorter than 250ms
+	// would only hot-poll the k8s API.
+	interval := max(d.config.readinessPollInterval.Load(), 250*time.Millisecond)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	var lastErr error
 	for {

--- a/processor/internal/pytdeployer/k8s.go
+++ b/processor/internal/pytdeployer/k8s.go
@@ -25,13 +25,8 @@ import (
 )
 
 const (
-	pytContainerPort      = 8080
-	pytMetricsPort        = 9091
-	runIDLength           = 8
-	readinessPollInterval = 250 * time.Millisecond
-	// deleteTimeout bounds the best-effort cleanup so it can't hang the
-	// request past its own deadline even when ctx is already cancelled.
-	deleteTimeout = 15 * time.Second
+	pytContainerPort = 8080
+	pytMetricsPort   = 9091
 )
 
 type k8sDeployer struct {
@@ -49,7 +44,7 @@ func (d *k8sDeployer) RunOnEphemeral(
 	if d.config.namespace == "" {
 		return 0, nil, errors.New("pyt test namespace is not configured")
 	}
-	name := "pyt-test-" + rand.String(runIDLength)
+	name := "pyt-test-" + rand.String(d.config.runIDLength)
 	dep, svc := d.buildResources(name, workspaceID)
 
 	if _, err := withRetry(ctx, d.config.retry, func() (*appsv1.Deployment, error) {
@@ -267,7 +262,7 @@ func (d *k8sDeployer) waitReady(ctx context.Context, name string) error {
 	ctx, cancel := context.WithTimeout(ctx, d.config.readinessTimeout.Load())
 	defer cancel()
 
-	ticker := time.NewTicker(readinessPollInterval)
+	ticker := time.NewTicker(d.config.readinessPollInterval.Load())
 	defer ticker.Stop()
 	var lastErr error
 	for {
@@ -297,7 +292,7 @@ func (d *k8sDeployer) waitReady(ctx context.Context, name string) error {
 // cancellation, so cleanup still gets a chance to run when ctx is already
 // done (deadline exceeded, caller gone).
 func (d *k8sDeployer) delete(ctx context.Context, name string) {
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), deleteTimeout)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), d.config.deleteTimeout.Load())
 	defer cancel()
 
 	var errs []error

--- a/processor/internal/pytdeployer/k8s.go
+++ b/processor/internal/pytdeployer/k8s.go
@@ -61,6 +61,11 @@ func (d *k8sDeployer) RunOnEphemeral(
 	}); err != nil {
 		return 0, nil, fmt.Errorf("creating ephemeral pyt deployment %s/%s: %w", d.config.namespace, name, err)
 	}
+	// Delete runs regardless of what happens below — on a Service create
+	// failure, a readiness timeout, a forward error, or success alike. It
+	// never changes the response returned to the caller; a failed delete is
+	// only logged.
+	defer d.delete(ctx, name, workspaceID)
 	if _, err := withRetry(ctx, d.config.retry, func() (*corev1.Service, error) {
 		created, err := d.client.CoreV1().Services(d.config.namespace).Create(ctx, svc, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
@@ -68,13 +73,8 @@ func (d *k8sDeployer) RunOnEphemeral(
 		}
 		return created, err
 	}); err != nil {
-		d.delete(ctx, name, workspaceID)
 		return 0, nil, fmt.Errorf("creating ephemeral pyt service %s/%s: %w", d.config.namespace, name, err)
 	}
-	// Delete runs regardless of what happens below — on a readiness timeout,
-	// a forward error, or success alike. It never changes the response
-	// returned to the caller; a failed delete is only logged.
-	defer d.delete(ctx, name, workspaceID)
 
 	readyStart := time.Now()
 	err := d.waitReady(ctx, name)

--- a/processor/internal/pytdeployer/pytdeployer.go
+++ b/processor/internal/pytdeployer/pytdeployer.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 )
 
 // Cross-component label contract. The reaper CronJob (INFRA-2) and the RBAC
@@ -52,6 +53,12 @@ const (
 	LabelPurposeValue = "pyt-test"
 	// LabelWorkspaceID carries the (lowercased) workspace ID for traceability.
 	LabelWorkspaceID = "rudderstack.com/workspace-id"
+	// LabelRunName carries the per-run object name. It is what keeps concurrent
+	// runs disjoint: without it, all runs for a workspace share the same label
+	// set, so every run's Service selects every run's pods and a request can be
+	// routed to another run's pod — which gets deleted when that run finishes,
+	// killing the request mid-flight ("Subprocess died (exit code -15)").
+	LabelRunName = "rudderstack.com/run"
 
 	// defaultTolerationsJSON mirrors the prod pyt chart's kata.tolerations: the
 	// Kata nodepool is tainted, and without this toleration the pod stays Pending
@@ -91,9 +98,10 @@ func WithClientset(client kubernetes.Interface) Opt {
 // surface as pods stuck in ImagePullBackOff at request time. Failing here
 // instead makes the misconfiguration visible at startup, and cpservice maps
 // it to FailedPrecondition for execution ops.
-func New(conf *config.Config, log logger.Logger, opts ...Opt) (Deployer, error) {
+func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) (Deployer, error) {
 	d := &k8sDeployer{
 		log:    log.Child("pytdeployer"),
+		stat:   stat,
 		config: loadConfig(conf),
 	}
 	for _, opt := range opts {

--- a/processor/internal/pytdeployer/pytdeployer.go
+++ b/processor/internal/pytdeployer/pytdeployer.go
@@ -129,35 +129,42 @@ func New(conf *config.Config, log logger.Logger, opts ...Opt) (Deployer, error) 
 // deployerConfig holds the settings loaded once at construction time (per the
 // house rule: reloadable values go through config.ValueLoader, registered
 // once in loadConfig and Load()ed where used, never re-registered per
-// request). readinessTimeout, env, labels, and podAnnotations are reloadable
-// so they can change without a restart.
+// request). readinessTimeout, readinessPollInterval, deleteTimeout, env,
+// labels, and podAnnotations are reloadable so they can change without a
+// restart.
 //
 // The defaults mirror the production per-workspace pytransformer chart
 // (rudderstack-operator helm-charts/rudderstack-aux/charts/pytransformer), so
 // an ephemeral test pod schedules and runs the same way a prod pyt pod does
 // unless a key is deliberately overridden.
 type deployerConfig struct {
-	namespace        string
-	image            string
-	imagePullSecret  string
-	runtimeClass     string
-	zone             string
-	nodeSelector     map[string]string
-	tolerations      []corev1.Toleration
-	cpuRequest       resource.Quantity
-	memoryRequest    resource.Quantity
-	cpuLimit         resource.Quantity
-	memoryLimit      resource.Quantity
-	readinessTimeout config.ValueLoader[time.Duration]
-	env              config.ValueLoader[map[string]any]
-	labels           config.ValueLoader[map[string]any]
-	podAnnotations   config.ValueLoader[map[string]any]
-	retry            retrySettings
+	namespace             string
+	runIDLength           int
+	image                 string
+	imagePullSecret       string
+	runtimeClass          string
+	zone                  string
+	nodeSelector          map[string]string
+	tolerations           []corev1.Toleration
+	cpuRequest            resource.Quantity
+	memoryRequest         resource.Quantity
+	cpuLimit              resource.Quantity
+	memoryLimit           resource.Quantity
+	readinessTimeout      config.ValueLoader[time.Duration]
+	readinessPollInterval config.ValueLoader[time.Duration]
+	// deleteTimeout bounds the best-effort cleanup so it can't hang the
+	// request past its own deadline even when ctx is already cancelled.
+	deleteTimeout  config.ValueLoader[time.Duration]
+	env            config.ValueLoader[map[string]any]
+	labels         config.ValueLoader[map[string]any]
+	podAnnotations config.ValueLoader[map[string]any]
+	retry          retrySettings
 }
 
 func loadConfig(conf *config.Config) deployerConfig {
 	return deployerConfig{
-		namespace: conf.GetStringVar("test-pytransformer", "Processor.pytDeployer.pytTestNamespace"),
+		namespace:   conf.GetStringVar("test-pytransformer", "Processor.pytDeployer.pytTestNamespace"),
+		runIDLength: runIDLength(conf),
 		// image and imagePullSecret deliberately have no default — [New]
 		// rejects an empty value rather than guessing (a stale or leaked
 		// default would be worse than failing fast).
@@ -168,17 +175,29 @@ func loadConfig(conf *config.Config) deployerConfig {
 		nodeSelector: toStringMap(conf.GetStringMapVar(
 			map[string]any{"karpenter.sh/nodepool": "kata"}, "Processor.pytDeployer.pytTestNodeSelector",
 		)),
-		tolerations:      loadTolerations(conf),
-		cpuRequest:       parseQuantity(conf.GetStringVar("200m", "Processor.pytDeployer.pytTestCPURequest"), "200m"),
-		memoryRequest:    parseQuantity(conf.GetStringVar("500Mi", "Processor.pytDeployer.pytTestMemoryRequest"), "500Mi"),
-		cpuLimit:         parseQuantity(conf.GetStringVar("400m", "Processor.pytDeployer.pytTestCPULimit"), "400m"),
-		memoryLimit:      parseQuantity(conf.GetStringVar("700Mi", "Processor.pytDeployer.pytTestMemoryLimit"), "700Mi"),
-		readinessTimeout: conf.GetReloadableDurationVar(60, time.Second, "Processor.pytDeployer.pytTestReadinessTimeout"),
-		env:              conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestEnv"),
-		labels:           conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestLabels"),
-		podAnnotations:   conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestPodAnnotations"),
-		retry:            newRetrySettings(conf),
+		tolerations:           loadTolerations(conf),
+		cpuRequest:            parseQuantity(conf.GetStringVar("200m", "Processor.pytDeployer.pytTestCPURequest"), "200m"),
+		memoryRequest:         parseQuantity(conf.GetStringVar("500Mi", "Processor.pytDeployer.pytTestMemoryRequest"), "500Mi"),
+		cpuLimit:              parseQuantity(conf.GetStringVar("400m", "Processor.pytDeployer.pytTestCPULimit"), "400m"),
+		memoryLimit:           parseQuantity(conf.GetStringVar("700Mi", "Processor.pytDeployer.pytTestMemoryLimit"), "700Mi"),
+		readinessTimeout:      conf.GetReloadableDurationVar(60, time.Second, "Processor.pytDeployer.pytTestReadinessTimeout"),
+		readinessPollInterval: conf.GetReloadableDurationVar(250, time.Millisecond, "Processor.pytDeployer.pytTestReadinessPollInterval"),
+		deleteTimeout:         conf.GetReloadableDurationVar(15, time.Second, "Processor.pytDeployer.pytTestDeleteTimeout"),
+		env:                   conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestEnv"),
+		labels:                conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestLabels"),
+		podAnnotations:        conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestPodAnnotations"),
+		retry:                 newRetrySettings(conf),
 	}
+}
+
+// runIDLength loads the random-suffix length for ephemeral resource names,
+// clamped to what keeps "pyt-test-<suffix>" a valid DNS-1035 label (max 63
+// chars, so the suffix can be at most 54) rather than blocking the processor
+// from starting on an out-of-range value.
+func runIDLength(conf *config.Config) int {
+	const prefixLen = len("pyt-test-")
+	length := conf.GetIntVar(8, 1, "Processor.pytDeployer.pytTestRunIDLength")
+	return max(1, min(length, 63-prefixLen))
 }
 
 // toStringMap flattens a config map (map[string]any) into map[string]string.

--- a/processor/internal/pytdeployer/pytdeployer.go
+++ b/processor/internal/pytdeployer/pytdeployer.go
@@ -199,13 +199,16 @@ func loadConfig(conf *config.Config) deployerConfig {
 }
 
 // runIDLength loads the random-suffix length for ephemeral resource names,
-// clamped to what keeps "pyt-test-<suffix>" a valid DNS-1035 label (max 63
-// chars, so the suffix can be at most 54) rather than blocking the processor
-// from starting on an out-of-range value.
+// clamped to [8, 54] rather than blocking the processor from starting on an
+// out-of-range value. The upper bound keeps "pyt-test-<suffix>" a valid
+// DNS-1035 label (max 63 chars). The lower bound guards against a
+// misconfigured short suffix: with only a few characters, two concurrent runs
+// can generate the same name, and the colliding Create is swallowed by the
+// AlreadyExists-as-own-retry assumption — both runs would silently share one
+// Deployment/Service, and the first to finish would delete it under the other.
 func runIDLength(conf *config.Config) int {
 	const prefixLen = len("pyt-test-")
-	length := conf.GetIntVar(8, 1, "Processor.pytDeployer.pytTestRunIDLength")
-	return max(1, min(length, 63-prefixLen))
+	return max(8, min(conf.GetIntVar(8, 1, "Processor.pytDeployer.pytTestRunIDLength"), 63-prefixLen))
 }
 
 // toStringMap flattens a config map (map[string]any) into map[string]string.

--- a/processor/internal/pytdeployer/pytdeployer.go
+++ b/processor/internal/pytdeployer/pytdeployer.go
@@ -189,7 +189,7 @@ func loadConfig(conf *config.Config) deployerConfig {
 		cpuLimit:              parseQuantity(conf.GetStringVar("400m", "Processor.pytDeployer.pytTestCPULimit"), "400m"),
 		memoryLimit:           parseQuantity(conf.GetStringVar("700Mi", "Processor.pytDeployer.pytTestMemoryLimit"), "700Mi"),
 		readinessTimeout:      conf.GetReloadableDurationVar(60, time.Second, "Processor.pytDeployer.pytTestReadinessTimeout"),
-		readinessPollInterval: conf.GetReloadableDurationVar(250, time.Millisecond, "Processor.pytDeployer.pytTestReadinessPollInterval"),
+		readinessPollInterval: conf.GetReloadableDurationVar(1, time.Second, "Processor.pytDeployer.pytTestReadinessPollInterval"),
 		deleteTimeout:         conf.GetReloadableDurationVar(15, time.Second, "Processor.pytDeployer.pytTestDeleteTimeout"),
 		env:                   conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestEnv"),
 		labels:                conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestLabels"),

--- a/processor/internal/pytdeployer/pytdeployer_test.go
+++ b/processor/internal/pytdeployer/pytdeployer_test.go
@@ -672,6 +672,9 @@ func baseConfig() *config.Config {
 	conf.Set("Processor.pytDeployer.pytTestImage", "pytransformer/pyt:latest")
 	conf.Set("Processor.pytDeployer.pytTestImagePullSecret", "regcred")
 	conf.Set("Processor.pytDeployer.pytTestReadinessTimeout", "5s")
+	// Pinned so tests asserting on poll counts within short readiness windows
+	// don't depend on the production default poll interval.
+	conf.Set("Processor.pytDeployer.pytTestReadinessPollInterval", "100ms")
 	return conf
 }
 

--- a/processor/internal/pytdeployer/pytdeployer_test.go
+++ b/processor/internal/pytdeployer/pytdeployer_test.go
@@ -489,6 +489,20 @@ func TestRunOnEphemeral(t *testing.T) {
 		require.EqualValues(t, 1, metrics[0].Value)
 	})
 
+	t.Run("a too-short configured runIDLength is clamped to 8, keeping concurrent run names collision-safe", func(t *testing.T) {
+		conf := baseConfig()
+		conf.Set("Processor.pytDeployer.pytTestRunIDLength", 1)
+		cs := newAutoReadyClient()
+		dep := newDeployer(t, cs, conf)
+
+		_, _, err := dep.RunOnEphemeral(context.Background(), "ws-1",
+			func(context.Context, string) (int, []byte, error) { return 200, nil, nil })
+		require.NoError(t, err)
+
+		require.Len(t, findCreatedDeployment(t, cs).Name, len("pyt-test-")+8,
+			"a 1-char suffix would let concurrent runs collide and silently share one Deployment/Service")
+	})
+
 	t.Run("errors without calling forward when creating the Deployment fails", func(t *testing.T) {
 		cs := newFakeClient()
 		cs.PrependReactor("create", "deployments", func(ktesting.Action) (bool, runtime.Object, error) {
@@ -673,8 +687,9 @@ func baseConfig() *config.Config {
 	conf.Set("Processor.pytDeployer.pytTestImagePullSecret", "regcred")
 	conf.Set("Processor.pytDeployer.pytTestReadinessTimeout", "5s")
 	// Pinned so tests asserting on poll counts within short readiness windows
-	// don't depend on the production default poll interval.
-	conf.Set("Processor.pytDeployer.pytTestReadinessPollInterval", "100ms")
+	// don't depend on the production default poll interval. 250ms is the
+	// effective minimum — waitReady floors anything shorter.
+	conf.Set("Processor.pytDeployer.pytTestReadinessPollInterval", "250ms")
 	return conf
 }
 

--- a/processor/internal/pytdeployer/pytdeployer_test.go
+++ b/processor/internal/pytdeployer/pytdeployer_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 )
 
 const testNamespace = "pyt-test-ns"
@@ -45,6 +47,7 @@ func TestRunOnEphemeral(t *testing.T) {
 		require.Equal(t, LabelManagedByValue, created.Labels[LabelManagedBy])
 		require.Equal(t, LabelPurposeValue, created.Labels[LabelPurpose])
 		require.Equal(t, "ws-1", created.Labels[LabelWorkspaceID], "the workspace label must be lowercased")
+		require.Equal(t, created.Name, created.Labels[LabelRunName], "the run label must carry the per-run name")
 		require.Equal(t, "pytransformer/pyt:latest", created.Spec.Template.Spec.Containers[0].Image)
 		require.Equal(t, "kata-fc", *created.Spec.Template.Spec.RuntimeClassName)
 		require.EqualValues(t, 1, *created.Spec.Replicas)
@@ -54,6 +57,46 @@ func TestRunOnEphemeral(t *testing.T) {
 		require.Equal(t, LabelManagedByValue, createdSvc.Labels[LabelManagedBy])
 		require.Equal(t, created.Name, createdSvc.Name, "the Deployment and Service share the same run name")
 		require.Equal(t, created.Labels, createdSvc.Spec.Selector, "the Service selector must match the Deployment's pod labels")
+	})
+
+	t.Run("concurrent runs are label-disjoint: each Service selects only its own run's pods", func(t *testing.T) {
+		cs := newAutoReadyClient()
+		dep := newDeployer(t, cs, baseConfig())
+
+		// Two runs for the SAME workspace on the same generic spec — the
+		// worst case: every label except the run name is identical.
+		for range 2 {
+			_, _, err := dep.RunOnEphemeral(context.Background(), "ws-1",
+				func(context.Context, string) (int, []byte, error) { return 200, nil, nil })
+			require.NoError(t, err)
+		}
+
+		deps := findCreatedDeployments(t, cs)
+		svcs := findCreatedServices(t, cs)
+		require.Len(t, deps, 2)
+		require.Len(t, svcs, 2)
+		require.NotEqual(t, deps[0].Name, deps[1].Name, "each run must create uniquely named objects")
+
+		podLabelsByRun := map[string]map[string]string{}
+		for _, d := range deps {
+			require.Equal(t, d.Name, d.Spec.Template.Labels[LabelRunName])
+			podLabelsByRun[d.Name] = d.Spec.Template.Labels
+		}
+		// Without the run label in the selector, every run's Service selects
+		// every run's pods, so a request forwarded through Service A can land
+		// on run B's pod — which run B deletes the moment it finishes, killing
+		// A's request mid-flight ("Subprocess died (exit code -15)").
+		for _, svc := range svcs {
+			require.Equal(t, svc.Name, svc.Spec.Selector[LabelRunName], "the Service selector must pin its own run name")
+			for run, podLabels := range podLabelsByRun {
+				if run == svc.Name {
+					require.True(t, selectorMatches(svc.Spec.Selector, podLabels))
+				} else {
+					require.False(t, selectorMatches(svc.Spec.Selector, podLabels),
+						"Service %s must not select run %s's pods", svc.Name, run)
+				}
+			}
+		}
 	})
 
 	t.Run("applies the generic env to the container, deterministically ordered", func(t *testing.T) {
@@ -396,6 +439,56 @@ func TestRunOnEphemeral(t *testing.T) {
 		require.True(t, hasAction(cs, "deployments"), "delete must still have been attempted")
 	})
 
+	t.Run("emits a success-tagged readiness-wait timer and no cleanup-failure count on a clean run", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		dep := newDeployerWithStats(t, newAutoReadyClient(), baseConfig(), statsStore)
+
+		_, _, err = dep.RunOnEphemeral(context.Background(), "ws-1",
+			func(context.Context, string) (int, []byte, error) { return 200, nil, nil })
+		require.NoError(t, err)
+
+		metrics := statsStore.GetByName("processor_pyt_readiness_wait_time")
+		require.Len(t, metrics, 1)
+		require.Equal(t, stats.Tags{"workspaceId": "ws-1", "success": "true"}, metrics[0].Tags)
+		require.Empty(t, statsStore.GetByName("processor_pyt_cleanup_failure_count"))
+	})
+
+	t.Run("emits a failure-tagged readiness-wait timer on a readiness timeout", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		conf := baseConfig()
+		conf.Set("Processor.pytDeployer.pytTestReadinessTimeout", "300ms")
+		dep := newDeployerWithStats(t, newFakeClient(), conf, statsStore) // never becomes ready
+
+		_, _, err = dep.RunOnEphemeral(context.Background(), "ws-1",
+			func(context.Context, string) (int, []byte, error) { return 200, nil, nil })
+		require.Error(t, err)
+
+		metrics := statsStore.GetByName("processor_pyt_readiness_wait_time")
+		require.Len(t, metrics, 1)
+		require.Equal(t, stats.Tags{"workspaceId": "ws-1", "success": "false"}, metrics[0].Tags)
+	})
+
+	t.Run("increments the cleanup-failure count when the best-effort delete fails", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		cs := newAutoReadyClient()
+		cs.PrependReactor("delete", "deployments", func(ktesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("etcd is down")
+		})
+		dep := newDeployerWithStats(t, cs, baseConfig(), statsStore)
+
+		_, _, err = dep.RunOnEphemeral(context.Background(), "ws-1",
+			func(context.Context, string) (int, []byte, error) { return 200, nil, nil })
+		require.NoError(t, err)
+
+		metrics := statsStore.GetByName("processor_pyt_cleanup_failure_count")
+		require.Len(t, metrics, 1)
+		require.Equal(t, stats.Tags{"workspaceId": "ws-1"}, metrics[0].Tags)
+		require.EqualValues(t, 1, metrics[0].Value)
+	})
+
 	t.Run("errors without calling forward when creating the Deployment fails", func(t *testing.T) {
 		cs := newFakeClient()
 		cs.PrependReactor("create", "deployments", func(ktesting.Action) (bool, runtime.Object, error) {
@@ -494,7 +587,7 @@ func TestNew(t *testing.T) {
 		conf.Set("Processor.pytDeployer.inCluster", false)
 		conf.Set("Processor.pytDeployer.kubeConfigPath", "/nonexistent/kubeconfig")
 
-		_, err := New(conf, logger.NOP)
+		_, err := New(conf, logger.NOP, stats.NOP)
 		require.Error(t, err)
 	})
 
@@ -502,7 +595,7 @@ func TestNew(t *testing.T) {
 		conf := baseConfig()
 		conf.Set("Processor.pytDeployer.pytTestImage", "")
 
-		_, err := New(conf, logger.NOP, WithClientset(fake.NewClientset()))
+		_, err := New(conf, logger.NOP, stats.NOP, WithClientset(fake.NewClientset()))
 		require.ErrorContains(t, err, "pytTestImage")
 	})
 
@@ -510,7 +603,7 @@ func TestNew(t *testing.T) {
 		conf := baseConfig()
 		conf.Set("Processor.pytDeployer.pytTestImagePullSecret", "")
 
-		_, err := New(conf, logger.NOP, WithClientset(fake.NewClientset()))
+		_, err := New(conf, logger.NOP, stats.NOP, WithClientset(fake.NewClientset()))
 		require.ErrorContains(t, err, "pytTestImagePullSecret")
 	})
 
@@ -519,7 +612,7 @@ func TestNew(t *testing.T) {
 		conf.Set("Processor.pytDeployer.pytTestCPURequest", "500m")
 		conf.Set("Processor.pytDeployer.pytTestCPULimit", "200m")
 
-		_, err := New(conf, logger.NOP, WithClientset(fake.NewClientset()))
+		_, err := New(conf, logger.NOP, stats.NOP, WithClientset(fake.NewClientset()))
 		require.ErrorContains(t, err, "pytTestCPULimit",
 			"limits below requests are rejected by the apiserver, so they must fail at startup")
 	})
@@ -529,12 +622,12 @@ func TestNew(t *testing.T) {
 		conf.Set("Processor.pytDeployer.pytTestMemoryRequest", "1Gi")
 		conf.Set("Processor.pytDeployer.pytTestMemoryLimit", "500Mi")
 
-		_, err := New(conf, logger.NOP, WithClientset(fake.NewClientset()))
+		_, err := New(conf, logger.NOP, stats.NOP, WithClientset(fake.NewClientset()))
 		require.ErrorContains(t, err, "pytTestMemoryLimit")
 	})
 
 	t.Run("succeeds with an injected clientset", func(t *testing.T) {
-		d, err := New(baseConfig(), logger.NOP, WithClientset(fake.NewClientset()))
+		d, err := New(baseConfig(), logger.NOP, stats.NOP, WithClientset(fake.NewClientset()))
 		require.NoError(t, err)
 		require.NotNil(t, d)
 	})
@@ -593,7 +686,12 @@ func fastRetryConfig() *config.Config {
 
 func newDeployer(t *testing.T, cs *fake.Clientset, conf *config.Config) Deployer {
 	t.Helper()
-	d, err := New(conf, logger.NOP, WithClientset(cs))
+	return newDeployerWithStats(t, cs, conf, stats.NOP)
+}
+
+func newDeployerWithStats(t *testing.T, cs *fake.Clientset, conf *config.Config, stat stats.Stats) Deployer {
+	t.Helper()
+	d, err := New(conf, logger.NOP, stat, WithClientset(cs))
 	require.NoError(t, err)
 	return d
 }
@@ -653,6 +751,39 @@ func findCreatedDeployment(t *testing.T, cs *fake.Clientset) *appsv1.Deployment 
 	}
 	t.Fatal("no Deployment create action found")
 	return nil
+}
+
+func findCreatedDeployments(t *testing.T, cs *fake.Clientset) []*appsv1.Deployment {
+	t.Helper()
+	var deps []*appsv1.Deployment
+	for _, a := range cs.Actions() {
+		if a.GetVerb() == "create" && a.GetResource().Resource == "deployments" {
+			deps = append(deps, a.(ktesting.CreateActionImpl).GetObject().(*appsv1.Deployment))
+		}
+	}
+	return deps
+}
+
+func findCreatedServices(t *testing.T, cs *fake.Clientset) []*corev1.Service {
+	t.Helper()
+	var svcs []*corev1.Service
+	for _, a := range cs.Actions() {
+		if a.GetVerb() == "create" && a.GetResource().Resource == "services" {
+			svcs = append(svcs, a.(ktesting.CreateActionImpl).GetObject().(*corev1.Service))
+		}
+	}
+	return svcs
+}
+
+// selectorMatches reports whether a Service selector matches a pod label set
+// the way kube-proxy would: every selector entry present with the same value.
+func selectorMatches(selector, podLabels map[string]string) bool {
+	for k, v := range selector {
+		if podLabels[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 func findCreatedService(t *testing.T, cs *fake.Clientset) *corev1.Service {

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -588,14 +588,14 @@ func (u *Client) forwardTest(ctx context.Context, baseURL, workspaceID, path str
 				// additionally counted; retryability doesn't depend on them.
 				if isColdStartError(err, nil) {
 					u.stat.NewTaggedStat(coldStartErrorsMetric, stats.CountType,
-						stats.Tags{"workspaceID": workspaceID, "language": languagePython}).Increment()
+						stats.Tags{"workspaceID": workspaceID, "language": languagePython, "path": path}).Increment()
 				}
 				return err
 			}
 			defer func() { httputil.CloseResponse(resp) }()
 			if isColdStartError(nil, resp) {
 				u.stat.NewTaggedStat(coldStartErrorsMetric, stats.CountType,
-					stats.Tags{"workspaceID": workspaceID, "language": languagePython}).Increment()
+					stats.Tags{"workspaceID": workspaceID, "language": languagePython, "path": path}).Increment()
 				return fmt.Errorf("pyt cold start: status %d", resp.StatusCode)
 			}
 
@@ -618,7 +618,7 @@ func (u *Client) forwardTest(ctx context.Context, baseURL, workspaceID, path str
 		// otherwise mask what went wrong until the whole budget is exhausted.
 		backoff.WithNotify(func(err error, delay time.Duration) {
 			u.stat.NewTaggedStat(testForwardRetriesMetric, stats.CountType,
-				stats.Tags{"workspaceID": workspaceID, "language": languagePython}).Increment()
+				stats.Tags{"workspaceID": workspaceID, "language": languagePython, "path": path}).Increment()
 			u.log.Warnn("retrying pyt test forward",
 				obskit.WorkspaceID(workspaceID),
 				logger.NewStringField("path", path),

--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -179,8 +179,11 @@ var (
 		"rsources_publish_time_second": {
 			0.1, 0.5, 1, 5, 10, 30, 60,
 		},
-		"processor_pyt_forward_time": {
+		"processor_pyt_forward_rpc_time": {
 			0.5, 1, 2.5, 5, 10, 30, 60, // 0.5s, 1s, 2.5s, 5s, 10s, 30s, 1m
+		},
+		"processor_pyt_request_handle_time": {
+			0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, // 0.1s, 0.25s, 0.5s, 1s, 2.5s, 5s, 10s, 30s, 1m
 		},
 		"processor_pyt_readiness_wait_time": {
 			0.5, 1, 2.5, 5, 10, 30, 60, // 0.5s, 1s, 2.5s, 5s, 10s, 30s, 1m

--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -179,6 +179,9 @@ var (
 		"rsources_publish_time_second": {
 			0.1, 0.5, 1, 5, 10, 30, 60,
 		},
+		"processor_grpc_response_time": {
+			0.1, 0.25, 0.5, 1, 2.5, 5, 15, 30, 60, // 0.1s, 0.25s, 0.5s, 1s, 2.5s, 5s, 15s, 30s, 1m
+		},
 		"processor_pyt_forward_rpc_time": {
 			0.5, 1, 2.5, 5, 10, 30, 60, // 0.5s, 1s, 2.5s, 5s, 10s, 30s, 1m
 		},

--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -179,5 +179,11 @@ var (
 		"rsources_publish_time_second": {
 			0.1, 0.5, 1, 5, 10, 30, 60,
 		},
+		"processor_pyt_forward_time": {
+			0.5, 1, 2.5, 5, 10, 30, 60, // 0.5s, 1s, 2.5s, 5s, 10s, 30s, 1m
+		},
+		"processor_pyt_readiness_wait_time": {
+			0.5, 1, 2.5, 5, 10, 30, 60, // 0.5s, 1s, 2.5s, 5s, 10s, 30s, 1m
+		},
 	}
 )


### PR DESCRIPTION
# Description

Fixes a mid-run pod-death bug in concurrent ephemeral pyt test runs, adds per-operation observability to the processor's CP-facing `Forward` RPC (Python transformation tests), and makes the ephemeral pyt
  deployer's timing knobs configurable.

  ### Bug fix: mid-run pod deaths under concurrent test runs

  Concurrent ephemeral test runs for the same workspace carried identical label sets, so every run's Service selected **every** run's pods. A request forwarded through run A's Service could land on run B's
  pod — which run B deletes the moment it finishes, killing A's request mid-flight ("Subprocess died (exit code -15)").

  Each run's Deployment selector, pod template labels, and Service selector now also carry a per-run name label (`rudderstack.com/run` = the unique `pyt-test-<suffix>` name), making concurrent runs
  label-disjoint: each Service selects only its own run's pods. Covered by a test asserting two same-workspace runs produce Services that select their own pods and not each other's.

  ### New metrics

  | Metric | Type | Tags | What it measures |
  |---|---|---|---|
  | `processor_pyt_forward_rpc_time` | timer | `op`, `route`, `workspaceId` | The whole `Forward` RPC: deployment setup + readiness wait + request |
  | `processor_pyt_request_handle_time` | timer | `op`, `route`, `workspaceId` | Just the HTTP request to the pyt pod |
  | `processor_pyt_readiness_wait_time` | timer | `workspaceId`, `success` | Time spent waiting for the ephemeral Deployment to report ready |
  | `processor_pyt_cleanup_failure_count` | count | `workspaceId` | Best-effort delete failures (work leaked to the reaper) |

  - `route` distinguishes the three forwarding paths: `ephemeral` (fresh pyt deployment), `production` (config-flagged workspaces), `static` (AST ops).
  - On the ephemeral route, `forward_rpc_time − request_handle_time` tells you how much of a slow test was setup vs. actual execution; the readiness-wait timer breaks the setup portion down further.
  `success:false` readiness samples cluster at the configured timeout, making timeouts visible.
  - `processor_pyt_request_handle_time` is only emitted when a request was actually made — a deployer failure before forwarding records no sample. Rejected requests (invalid op/workspaceId) emit nothing.
  - Histogram buckets for all three timers are registered in `runner/buckets.go`.
  - The cold-start / retry counters in `user_transformer.forwardTest` now carry a `path` tag so retries can be attributed per pyt endpoint.

  ### New config keys (`Processor.pytDeployer.*`)

  | Key | Default | Notes |
  |---|---|---|
  | `pytTestReadinessPollInterval` | `250ms` | Reloadable; was a hardcoded constant |
  | `pytTestDeleteTimeout` | `15s` | Reloadable; bounds best-effort cleanup, was a hardcoded constant |
  | `pytTestRunIDLength` | `8` | Random suffix length for ephemeral resource names; clamped to keep `pyt-test-<suffix>` a valid DNS-1035 label |

  ### Implementation notes

  - `pytdeployer.New` now takes `stats.Stats`; `cpservice.Service` retains the stats handle it already received.
  - The three routes in `Forward` share a single `timedForward` closure that emits the request timer itself, so no forward ⇒ no sample, with no extra bookkeeping.

## Linear Ticket

-

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
