### PR TITLE
feat(router): gate 296 delivered-with-warning behind per-workspace rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.81.1](https://github.com/rudderlabs/rudder-server/compare/v1.81.0...v1.81.1) (2026-07-22)
+
+
+### Bug Fixes
+
+* use correct JSON tag for adjustedConversionTime in bing-ads ([#7204](https://github.com/rudderlabs/rudder-server/issues/7204)) ([a95807f](https://github.com/rudderlabs/rudder-server/commit/a95807fe5b19100e30b63255bba78f66a633cc71))
+
 ## [1.81.0](https://github.com/rudderlabs/rudder-server/compare/v1.80.0...v1.81.0) (2026-07-20)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.81.3](https://github.com/rudderlabs/rudder-server/compare/v1.81.2...v1.81.3) (2026-07-27)
+
+
+### Bug Fixes
+
+* apply configured client QPS and Burst settings in restConfig ([#7220](https://github.com/rudderlabs/rudder-server/issues/7220)) ([ab4dbf7](https://github.com/rudderlabs/rudder-server/commit/ab4dbf75140f7c7c515a59e86e7c75e2fc72fc76))
+
 ## [1.81.2](https://github.com/rudderlabs/rudder-server/compare/v1.81.1...v1.81.2) (2026-07-27)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.81.2](https://github.com/rudderlabs/rudder-server/compare/v1.81.1...v1.81.2) (2026-07-27)
+
+
+### Bug Fixes
+
+* mid-run pod deaths under concurrent test runs ([#7212](https://github.com/rudderlabs/rudder-server/issues/7212)) ([cf89256](https://github.com/rudderlabs/rudder-server/commit/cf89256c9dc4dc4f98e987d536b9d7078ea7720d))
+
 ## [1.81.1](https://github.com/rudderlabs/rudder-server/compare/v1.81.0...v1.81.1) (2026-07-22)
 
 

--- a/processor/cpservice/cpservice.go
+++ b/processor/cpservice/cpservice.go
@@ -62,6 +62,7 @@ type Service struct {
 	proto.UnimplementedProcessorServiceServer
 
 	log             logger.Logger
+	stat            stats.Stats
 	deployer        pytdeployer.Deployer
 	forwarder       Forwarder
 	staticASTURL    string
@@ -117,6 +118,7 @@ func (u *unavailableDeployer) RunOnEphemeral(
 func NewService(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...ServiceOpt) *Service {
 	s := &Service{
 		log:             log.Child("cpservice"),
+		stat:            stat,
 		staticASTURL:    conf.GetStringVar("", "Processor.pytTestStaticASTURL"),
 		prodURLTemplate: conf.GetStringVar(user_transformer.DefaultPerWorkspacePyTURLTemplate, "Processor.UserTransformer.perWorkspacePyTURLTemplate"),
 		prodRouted:      conf.GetReloadableStringMapVar(nil, "Processor.pytTestOverrides.routeToProduction"),
@@ -125,7 +127,7 @@ func NewService(conf *config.Config, log logger.Logger, stat stats.Stats, opts .
 		opt(s)
 	}
 	if s.deployer == nil {
-		deployer, err := pytdeployer.New(conf, log)
+		deployer, err := pytdeployer.New(conf, log, stat)
 		if err != nil {
 			log.Warnn("ephemeral pyt deployer unavailable; execution test ops will fail", obskit.Error(err))
 			deployer = &unavailableDeployer{err: err}

--- a/processor/cpservice/forward.go
+++ b/processor/cpservice/forward.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -13,6 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
 	"github.com/rudderlabs/rudder-server/processor/internal/transformer/user_transformer"
@@ -24,6 +27,14 @@ import (
 // pointed at either a freshly created ephemeral pyt Service or the shared
 // static AST deployment.
 type endpointForward func(ctx context.Context, baseURL, workspaceID string, payload []byte) (int, []byte, error)
+
+// route tag values for the processor_pyt_* metrics: which pyt deployment a
+// Forward request was served by.
+const (
+	routeEphemeral  = "ephemeral"  // fresh ephemeral deployment (execution ops)
+	routeProduction = "production" // the workspace's production pyt deployment (config-flagged execution ops)
+	routeStatic     = "static"     // the shared static AST deployment (AST ops)
+)
 
 // validWorkspaceID gates what Forward substitutes into the pyt URL template and
 // the pyt Deployment name. Anything beyond alphanumerics and hyphens must be
@@ -67,27 +78,61 @@ func (s *Service) Forward(ctx context.Context, req *proto.ForwardRequest) (*prot
 		return nil, status.Error(codes.InvalidArgument, "workspaceId must be 1-59 alphanumeric or hyphen characters, starting and ending with an alphanumeric")
 	}
 
+	route := routeStatic
+	if isExecutionOp {
+		if s.isProdRouted(req.WorkspaceId) {
+			route = routeProduction
+		} else {
+			route = routeEphemeral
+		}
+	}
+	tags := stats.Tags{
+		"op":          req.Op.String(),
+		"route":       route,
+		"workspaceId": req.WorkspaceId,
+	}
+	// timedForward measures just the HTTP request to the pyt pod and emits the
+	// request timer itself, so on the ephemeral route it excludes the
+	// deployment creation and readiness wait (which RunOnEphemeral performs
+	// before invoking it) that the total timer includes — and a deployer
+	// failure that never invokes it produces no request sample. The success
+	// tag separates unhealthy requests — transport failures (connection
+	// refused, exhausted retries) and non-200 pyt responses alike — from
+	// healthy ones, whose latencies are not comparable.
+	timedForward := func(ctx context.Context, baseURL string) (int, []byte, error) {
+		execStart := time.Now()
+		statusCode, body, err := forward(ctx, baseURL, req.WorkspaceId, req.Payload)
+		reqTags := maps.Clone(tags)
+		reqTags["success"] = strconv.FormatBool(statusCode == http.StatusOK)
+		s.stat.NewTaggedStat("processor_pyt_request_handle_time", stats.TimerType, reqTags).Since(execStart)
+		return statusCode, body, err
+	}
+
 	var statusCode int
 	var body []byte
 	var err error
-	switch {
-	case isExecutionOp && s.isProdRouted(req.WorkspaceId):
+	switch route {
+	case routeProduction:
 		// Config-flagged workspace: its tests must run with prod-only config
 		// (custom DNS, pinned egress IPs, ...) the generic ephemeral spec can't
 		// reproduce, so forward straight to the workspace's production pyt
 		// deployment. No readiness wait — the forwarder's cold-start retries
 		// ride out the prod deployment's scale-from-zero window.
-		statusCode, body, err = forward(ctx,
-			user_transformer.PerWorkspacePyTBaseURL(s.prodURLTemplate, req.WorkspaceId),
-			req.WorkspaceId, req.Payload)
-	case isExecutionOp:
-		statusCode, body, err = s.deployer.RunOnEphemeral(ctx, req.WorkspaceId,
-			func(ctx context.Context, baseURL string) (int, []byte, error) {
-				return forward(ctx, baseURL, req.WorkspaceId, req.Payload)
-			})
+		statusCode, body, err = timedForward(ctx,
+			user_transformer.PerWorkspacePyTBaseURL(s.prodURLTemplate, req.WorkspaceId))
+	case routeEphemeral:
+		statusCode, body, err = s.deployer.RunOnEphemeral(ctx, req.WorkspaceId, timedForward)
 	default:
-		statusCode, body, err = forward(ctx, s.staticASTURL, req.WorkspaceId, req.Payload)
+		statusCode, body, err = timedForward(ctx, s.staticASTURL)
 	}
+	// success here means the RPC delivered a pyt response, whatever its HTTP
+	// status — false marks infrastructure failures (deployer create errors,
+	// readiness timeouts, transport failures), which are the only way to tell
+	// a failed RPC apart from a slow success. On a deployer create failure
+	// this is the ONLY metric emitted: the readiness and request timers never
+	// get a sample because those phases never ran.
+	tags["success"] = strconv.FormatBool(err == nil)
+	s.stat.NewTaggedStat("processor_pyt_forward_rpc_time", stats.TimerType, tags).Since(start)
 	if err != nil {
 		s.log.Warnn("forwarding to pyt",
 			obskit.WorkspaceID(req.WorkspaceId), logger.NewStringField("op", req.Op.String()), obskit.Error(err))

--- a/processor/cpservice/forward_test.go
+++ b/processor/cpservice/forward_test.go
@@ -3,6 +3,7 @@ package cpservice
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 
 	proto "github.com/rudderlabs/rudder-server/proto/processor"
 )
@@ -200,7 +202,7 @@ func TestForward(t *testing.T) {
 		// No WithDeployer override: NewService tries to build a real k8s-backed
 		// deployer, which fails outside a cluster/without a kubeconfig, and
 		// falls back to unavailableDeployer.
-		svc := NewService(conf, logger.NOP, nil, WithForwarder(fwd))
+		svc := NewService(conf, logger.NOP, stats.NOP, WithForwarder(fwd))
 
 		_, err := svc.Forward(context.Background(), &proto.ForwardRequest{Op: proto.Op_OP_TEST, WorkspaceId: "ws-1"})
 		require.Equal(t, codes.FailedPrecondition, status.Code(err),
@@ -225,6 +227,103 @@ func TestForward(t *testing.T) {
 		svc := newService(t, nil, deployer, &fakeForwarder{err: errors.New("connection refused")})
 		_, err := svc.Forward(context.Background(), &proto.ForwardRequest{Op: proto.Op_OP_TEST, WorkspaceId: "ws-1"})
 		require.Equal(t, codes.Unavailable, status.Code(err))
+	})
+
+	t.Run("emits total and request timers tagged by op, route and workspace", func(t *testing.T) {
+		cases := []struct {
+			name      string
+			op        proto.Op
+			prodRoute bool
+			fwdErr    error
+			wantRoute string
+		}{
+			{"execution op on an ephemeral deployment", proto.Op_OP_TEST, false, nil, "ephemeral"},
+			{"execution op routed to production", proto.Op_OP_TEST_RUN, true, nil, "production"},
+			{"AST op on the static deployment", proto.Op_OP_TEST_LIBRARY, false, nil, "static"},
+			{"emitted on a failed forward too", proto.Op_OP_TEST, false, errors.New("connection refused"), "ephemeral"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				statsStore, err := memstats.New()
+				require.NoError(t, err)
+				conf := config.New()
+				conf.Set("Processor.pytTestStaticASTURL", staticASTURL)
+				if tc.prodRoute {
+					conf.Set("Processor.pytTestOverrides.routeToProduction", map[string]any{"ws-1": true})
+				}
+				// The real forwarder returns no status code alongside an error.
+				fwdStatus := 200
+				if tc.fwdErr != nil {
+					fwdStatus = 0
+				}
+				svc := NewService(conf, logger.NOP, statsStore,
+					WithDeployer(&fakeDeployer{baseURL: "http://pyt-test-abc.ns.svc:8080"}),
+					WithForwarder(&fakeForwarder{statusCode: fwdStatus, err: tc.fwdErr}))
+
+				_, err = svc.Forward(context.Background(), &proto.ForwardRequest{Op: tc.op, WorkspaceId: "ws-1"})
+				if tc.fwdErr != nil {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+
+				wantTags := stats.Tags{
+					"op":          tc.op.String(),
+					"route":       tc.wantRoute,
+					"workspaceId": "ws-1",
+					"success":     strconv.FormatBool(tc.fwdErr == nil),
+				}
+				metrics := statsStore.GetByName("processor_pyt_forward_rpc_time")
+				require.Len(t, metrics, 1)
+				require.Equal(t, wantTags, metrics[0].Tags)
+
+				wantReqTags := stats.Tags{
+					"op":          tc.op.String(),
+					"route":       tc.wantRoute,
+					"workspaceId": "ws-1",
+					"success":     strconv.FormatBool(tc.fwdErr == nil),
+				}
+				execMetrics := statsStore.GetByName("processor_pyt_request_handle_time")
+				require.Len(t, execMetrics, 1, "the forward ran, so the request timer must have a sample too")
+				require.Equal(t, wantReqTags, execMetrics[0].Tags)
+			})
+		}
+	})
+
+	t.Run("no request timer when the deployer fails before forwarding", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		conf := config.New()
+		conf.Set("Processor.pytTestStaticASTURL", staticASTURL)
+		svc := NewService(conf, logger.NOP, statsStore,
+			WithDeployer(&fakeDeployer{err: errors.New("create failed")}),
+			WithForwarder(&fakeForwarder{statusCode: 200}))
+
+		_, err = svc.Forward(context.Background(), &proto.ForwardRequest{Op: proto.Op_OP_TEST, WorkspaceId: "ws-1"})
+		require.Error(t, err)
+
+		require.Empty(t, statsStore.GetByName("processor_pyt_request_handle_time"),
+			"no request was made, so no request sample must be recorded")
+		rpcMetrics := statsStore.GetByName("processor_pyt_forward_rpc_time")
+		require.Len(t, rpcMetrics, 1, "the total timer still records the failed attempt")
+		require.Equal(t, "false", rpcMetrics[0].Tags["success"],
+			"a deployer failure must be distinguishable from a slow success")
+	})
+
+	t.Run("no timers when the request is rejected before forwarding", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		conf := config.New()
+		conf.Set("Processor.pytTestStaticASTURL", staticASTURL)
+		svc := NewService(conf, logger.NOP, statsStore,
+			WithDeployer(&fakeDeployer{}), WithForwarder(&fakeForwarder{}))
+
+		_, err = svc.Forward(context.Background(), &proto.ForwardRequest{Op: proto.Op_OP_UNSPECIFIED, WorkspaceId: "ws-1"})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+		_, err = svc.Forward(context.Background(), &proto.ForwardRequest{Op: proto.Op_OP_TEST, WorkspaceId: "a@evil.com#"})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+		require.Empty(t, statsStore.GetByName("processor_pyt_forward_rpc_time"))
 	})
 }
 
@@ -288,5 +387,5 @@ func newService(t *testing.T, conf *config.Config, deployer *fakeDeployer, fwd F
 		conf = config.New()
 	}
 	conf.Set("Processor.pytTestStaticASTURL", staticASTURL)
-	return NewService(conf, logger.NOP, nil, WithDeployer(deployer), WithForwarder(fwd))
+	return NewService(conf, logger.NOP, stats.NOP, WithDeployer(deployer), WithForwarder(fwd))
 }

--- a/processor/internal/pytdeployer/k8s.go
+++ b/processor/internal/pytdeployer/k8s.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,22 +22,19 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 )
 
 const (
-	pytContainerPort      = 8080
-	pytMetricsPort        = 9091
-	runIDLength           = 8
-	readinessPollInterval = 250 * time.Millisecond
-	// deleteTimeout bounds the best-effort cleanup so it can't hang the
-	// request past its own deadline even when ctx is already cancelled.
-	deleteTimeout = 15 * time.Second
+	pytContainerPort = 8080
+	pytMetricsPort   = 9091
 )
 
 type k8sDeployer struct {
 	client kubernetes.Interface
 	log    logger.Logger
+	stat   stats.Stats
 	config deployerConfig
 }
 
@@ -49,7 +47,7 @@ func (d *k8sDeployer) RunOnEphemeral(
 	if d.config.namespace == "" {
 		return 0, nil, errors.New("pyt test namespace is not configured")
 	}
-	name := "pyt-test-" + rand.String(runIDLength)
+	name := "pyt-test-" + rand.String(d.config.runIDLength)
 	dep, svc := d.buildResources(name, workspaceID)
 
 	if _, err := withRetry(ctx, d.config.retry, func() (*appsv1.Deployment, error) {
@@ -63,6 +61,11 @@ func (d *k8sDeployer) RunOnEphemeral(
 	}); err != nil {
 		return 0, nil, fmt.Errorf("creating ephemeral pyt deployment %s/%s: %w", d.config.namespace, name, err)
 	}
+	// Delete runs regardless of what happens below — on a Service create
+	// failure, a readiness timeout, a forward error, or success alike. It
+	// never changes the response returned to the caller; a failed delete is
+	// only logged.
+	defer d.delete(ctx, name, workspaceID)
 	if _, err := withRetry(ctx, d.config.retry, func() (*corev1.Service, error) {
 		created, err := d.client.CoreV1().Services(d.config.namespace).Create(ctx, svc, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
@@ -70,15 +73,18 @@ func (d *k8sDeployer) RunOnEphemeral(
 		}
 		return created, err
 	}); err != nil {
-		d.delete(ctx, name)
 		return 0, nil, fmt.Errorf("creating ephemeral pyt service %s/%s: %w", d.config.namespace, name, err)
 	}
-	// Delete runs regardless of what happens below — on a readiness timeout,
-	// a forward error, or success alike. It never changes the response
-	// returned to the caller; a failed delete is only logged.
-	defer d.delete(ctx, name)
 
-	if err := d.waitReady(ctx, name); err != nil {
+	readyStart := time.Now()
+	err := d.waitReady(ctx, name)
+	// Emitted on both outcomes: the success:false series makes readiness
+	// timeouts visible and clusters at the configured readiness timeout.
+	d.stat.NewTaggedStat("processor_pyt_readiness_wait_time", stats.TimerType, stats.Tags{
+		"workspaceId": workspaceID,
+		"success":     strconv.FormatBool(err == nil),
+	}).Since(readyStart)
+	if err != nil {
 		return 0, nil, err
 	}
 
@@ -103,6 +109,12 @@ func (d *k8sDeployer) buildResources(name, workspaceID string) (*appsv1.Deployme
 	labels[LabelManagedBy] = LabelManagedByValue
 	labels[LabelPurpose] = LabelPurposeValue
 	labels[LabelWorkspaceID] = strings.ToLower(workspaceID)
+	// The run name makes the Deployment selector, pod labels, and Service
+	// selector unique per run. Concurrent runs (same workspace, same generic
+	// spec) otherwise carry identical labels, so each run's Service would
+	// select all runs' pods and route a request to a pod that another run
+	// deletes the moment it finishes.
+	labels[LabelRunName] = name
 
 	// WORKSPACE_ID is per-run, so it is injected programmatically on top of the
 	// config-provided env (prod injects it per workspace the same way). The
@@ -267,7 +279,11 @@ func (d *k8sDeployer) waitReady(ctx context.Context, name string) error {
 	ctx, cancel := context.WithTimeout(ctx, d.config.readinessTimeout.Load())
 	defer cancel()
 
-	ticker := time.NewTicker(readinessPollInterval)
+	// The floor guards against misconfigured reloadable values: NewTicker
+	// panics on a non-positive interval, and anything shorter than 250ms
+	// would only hot-poll the k8s API.
+	interval := max(d.config.readinessPollInterval.Load(), 250*time.Millisecond)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	var lastErr error
 	for {
@@ -296,8 +312,8 @@ func (d *k8sDeployer) waitReady(ctx context.Context, name string) error {
 // already has. It runs on its own bounded timeout, detached from ctx's
 // cancellation, so cleanup still gets a chance to run when ctx is already
 // done (deadline exceeded, caller gone).
-func (d *k8sDeployer) delete(ctx context.Context, name string) {
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), deleteTimeout)
+func (d *k8sDeployer) delete(ctx context.Context, name, workspaceID string) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), d.config.deleteTimeout.Load())
 	defer cancel()
 
 	var errs []error
@@ -312,6 +328,8 @@ func (d *k8sDeployer) delete(ctx context.Context, name string) {
 		errs = append(errs, fmt.Errorf("deleting service %s/%s: %w", d.config.namespace, name, err))
 	}
 	if len(errs) > 0 {
+		d.stat.NewTaggedStat("processor_pyt_cleanup_failure_count", stats.CountType,
+			stats.Tags{"workspaceId": workspaceID}).Increment()
 		d.log.Errorn("cleaning up ephemeral pyt deployment; the reaper will collect any orphan",
 			logger.NewStringField("namespace", d.config.namespace),
 			logger.NewStringField("name", name),

--- a/processor/internal/pytdeployer/k8s.go
+++ b/processor/internal/pytdeployer/k8s.go
@@ -353,6 +353,25 @@ func newInClusterClientset(conf *config.Config) (kubernetes.Interface, error) {
 }
 
 func restConfig(conf *config.Config) (*rest.Config, error) {
+	cfg, err := loadRestConfig(conf)
+	if err != nil {
+		return nil, err
+	}
+	// client-go's default rate limit (5 QPS, burst 10) is sized for CLI use,
+	// and the limiter is shared by every RunOnEphemeral call on this client.
+	// All Forward traffic funnels through the node-0 processor, and each
+	// in-flight run creates, polls, and deletes objects, so a handful of
+	// concurrent runs exhausts the default budget — queued requests then fail
+	// with "client rate limiter Wait returned an error: rate: Wait(n=1) would
+	// exceed context deadline" before ever reaching the apiserver.
+	cfg.QPS = float32(conf.GetIntVar(10, 1, "Processor.pytDeployer.k8sClientQPS"))
+	cfg.Burst = conf.GetIntVar(20, 1, "Processor.pytDeployer.k8sClientBurst")
+	return cfg, nil
+}
+
+// loadRestConfig builds the raw client config: in-cluster by default, falling
+// back to a kubeconfig file for local dev.
+func loadRestConfig(conf *config.Config) (*rest.Config, error) {
 	if conf.GetBoolVar(true, "Processor.pytDeployer.inCluster", "K8S_IN_CLUSTER") {
 		cfg, err := rest.InClusterConfig()
 		if err != nil {

--- a/processor/internal/pytdeployer/pytdeployer.go
+++ b/processor/internal/pytdeployer/pytdeployer.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
 )
 
 // Cross-component label contract. The reaper CronJob (INFRA-2) and the RBAC
@@ -52,6 +53,12 @@ const (
 	LabelPurposeValue = "pyt-test"
 	// LabelWorkspaceID carries the (lowercased) workspace ID for traceability.
 	LabelWorkspaceID = "rudderstack.com/workspace-id"
+	// LabelRunName carries the per-run object name. It is what keeps concurrent
+	// runs disjoint: without it, all runs for a workspace share the same label
+	// set, so every run's Service selects every run's pods and a request can be
+	// routed to another run's pod — which gets deleted when that run finishes,
+	// killing the request mid-flight ("Subprocess died (exit code -15)").
+	LabelRunName = "rudderstack.com/run"
 
 	// defaultTolerationsJSON mirrors the prod pyt chart's kata.tolerations: the
 	// Kata nodepool is tainted, and without this toleration the pod stays Pending
@@ -91,9 +98,10 @@ func WithClientset(client kubernetes.Interface) Opt {
 // surface as pods stuck in ImagePullBackOff at request time. Failing here
 // instead makes the misconfiguration visible at startup, and cpservice maps
 // it to FailedPrecondition for execution ops.
-func New(conf *config.Config, log logger.Logger, opts ...Opt) (Deployer, error) {
+func New(conf *config.Config, log logger.Logger, stat stats.Stats, opts ...Opt) (Deployer, error) {
 	d := &k8sDeployer{
 		log:    log.Child("pytdeployer"),
+		stat:   stat,
 		config: loadConfig(conf),
 	}
 	for _, opt := range opts {
@@ -129,35 +137,42 @@ func New(conf *config.Config, log logger.Logger, opts ...Opt) (Deployer, error) 
 // deployerConfig holds the settings loaded once at construction time (per the
 // house rule: reloadable values go through config.ValueLoader, registered
 // once in loadConfig and Load()ed where used, never re-registered per
-// request). readinessTimeout, env, labels, and podAnnotations are reloadable
-// so they can change without a restart.
+// request). readinessTimeout, readinessPollInterval, deleteTimeout, env,
+// labels, and podAnnotations are reloadable so they can change without a
+// restart.
 //
 // The defaults mirror the production per-workspace pytransformer chart
 // (rudderstack-operator helm-charts/rudderstack-aux/charts/pytransformer), so
 // an ephemeral test pod schedules and runs the same way a prod pyt pod does
 // unless a key is deliberately overridden.
 type deployerConfig struct {
-	namespace        string
-	image            string
-	imagePullSecret  string
-	runtimeClass     string
-	zone             string
-	nodeSelector     map[string]string
-	tolerations      []corev1.Toleration
-	cpuRequest       resource.Quantity
-	memoryRequest    resource.Quantity
-	cpuLimit         resource.Quantity
-	memoryLimit      resource.Quantity
-	readinessTimeout config.ValueLoader[time.Duration]
-	env              config.ValueLoader[map[string]any]
-	labels           config.ValueLoader[map[string]any]
-	podAnnotations   config.ValueLoader[map[string]any]
-	retry            retrySettings
+	namespace             string
+	runIDLength           int
+	image                 string
+	imagePullSecret       string
+	runtimeClass          string
+	zone                  string
+	nodeSelector          map[string]string
+	tolerations           []corev1.Toleration
+	cpuRequest            resource.Quantity
+	memoryRequest         resource.Quantity
+	cpuLimit              resource.Quantity
+	memoryLimit           resource.Quantity
+	readinessTimeout      config.ValueLoader[time.Duration]
+	readinessPollInterval config.ValueLoader[time.Duration]
+	// deleteTimeout bounds the best-effort cleanup so it can't hang the
+	// request past its own deadline even when ctx is already cancelled.
+	deleteTimeout  config.ValueLoader[time.Duration]
+	env            config.ValueLoader[map[string]any]
+	labels         config.ValueLoader[map[string]any]
+	podAnnotations config.ValueLoader[map[string]any]
+	retry          retrySettings
 }
 
 func loadConfig(conf *config.Config) deployerConfig {
 	return deployerConfig{
-		namespace: conf.GetStringVar("test-pytransformer", "Processor.pytDeployer.pytTestNamespace"),
+		namespace:   conf.GetStringVar("test-pytransformer", "Processor.pytDeployer.pytTestNamespace"),
+		runIDLength: runIDLength(conf),
 		// image and imagePullSecret deliberately have no default — [New]
 		// rejects an empty value rather than guessing (a stale or leaked
 		// default would be worse than failing fast).
@@ -168,17 +183,32 @@ func loadConfig(conf *config.Config) deployerConfig {
 		nodeSelector: toStringMap(conf.GetStringMapVar(
 			map[string]any{"karpenter.sh/nodepool": "kata"}, "Processor.pytDeployer.pytTestNodeSelector",
 		)),
-		tolerations:      loadTolerations(conf),
-		cpuRequest:       parseQuantity(conf.GetStringVar("200m", "Processor.pytDeployer.pytTestCPURequest"), "200m"),
-		memoryRequest:    parseQuantity(conf.GetStringVar("500Mi", "Processor.pytDeployer.pytTestMemoryRequest"), "500Mi"),
-		cpuLimit:         parseQuantity(conf.GetStringVar("400m", "Processor.pytDeployer.pytTestCPULimit"), "400m"),
-		memoryLimit:      parseQuantity(conf.GetStringVar("700Mi", "Processor.pytDeployer.pytTestMemoryLimit"), "700Mi"),
-		readinessTimeout: conf.GetReloadableDurationVar(60, time.Second, "Processor.pytDeployer.pytTestReadinessTimeout"),
-		env:              conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestEnv"),
-		labels:           conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestLabels"),
-		podAnnotations:   conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestPodAnnotations"),
-		retry:            newRetrySettings(conf),
+		tolerations:           loadTolerations(conf),
+		cpuRequest:            parseQuantity(conf.GetStringVar("200m", "Processor.pytDeployer.pytTestCPURequest"), "200m"),
+		memoryRequest:         parseQuantity(conf.GetStringVar("500Mi", "Processor.pytDeployer.pytTestMemoryRequest"), "500Mi"),
+		cpuLimit:              parseQuantity(conf.GetStringVar("400m", "Processor.pytDeployer.pytTestCPULimit"), "400m"),
+		memoryLimit:           parseQuantity(conf.GetStringVar("700Mi", "Processor.pytDeployer.pytTestMemoryLimit"), "700Mi"),
+		readinessTimeout:      conf.GetReloadableDurationVar(60, time.Second, "Processor.pytDeployer.pytTestReadinessTimeout"),
+		readinessPollInterval: conf.GetReloadableDurationVar(1, time.Second, "Processor.pytDeployer.pytTestReadinessPollInterval"),
+		deleteTimeout:         conf.GetReloadableDurationVar(15, time.Second, "Processor.pytDeployer.pytTestDeleteTimeout"),
+		env:                   conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestEnv"),
+		labels:                conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestLabels"),
+		podAnnotations:        conf.GetReloadableStringMapVar(nil, "Processor.pytDeployer.pytTestPodAnnotations"),
+		retry:                 newRetrySettings(conf),
 	}
+}
+
+// runIDLength loads the random-suffix length for ephemeral resource names,
+// clamped to [8, 54] rather than blocking the processor from starting on an
+// out-of-range value. The upper bound keeps "pyt-test-<suffix>" a valid
+// DNS-1035 label (max 63 chars). The lower bound guards against a
+// misconfigured short suffix: with only a few characters, two concurrent runs
+// can generate the same name, and the colliding Create is swallowed by the
+// AlreadyExists-as-own-retry assumption — both runs would silently share one
+// Deployment/Service, and the first to finish would delete it under the other.
+func runIDLength(conf *config.Config) int {
+	const prefixLen = len("pyt-test-")
+	return max(8, min(conf.GetIntVar(8, 1, "Processor.pytDeployer.pytTestRunIDLength"), 63-prefixLen))
 }
 
 // toStringMap flattens a config map (map[string]any) into map[string]string.

--- a/processor/internal/pytdeployer/pytdeployer_test.go
+++ b/processor/internal/pytdeployer/pytdeployer_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 )
 
 const testNamespace = "pyt-test-ns"
@@ -45,6 +47,7 @@ func TestRunOnEphemeral(t *testing.T) {
 		require.Equal(t, LabelManagedByValue, created.Labels[LabelManagedBy])
 		require.Equal(t, LabelPurposeValue, created.Labels[LabelPurpose])
 		require.Equal(t, "ws-1", created.Labels[LabelWorkspaceID], "the workspace label must be lowercased")
+		require.Equal(t, created.Name, created.Labels[LabelRunName], "the run label must carry the per-run name")
 		require.Equal(t, "pytransformer/pyt:latest", created.Spec.Template.Spec.Containers[0].Image)
 		require.Equal(t, "kata-fc", *created.Spec.Template.Spec.RuntimeClassName)
 		require.EqualValues(t, 1, *created.Spec.Replicas)
@@ -54,6 +57,46 @@ func TestRunOnEphemeral(t *testing.T) {
 		require.Equal(t, LabelManagedByValue, createdSvc.Labels[LabelManagedBy])
 		require.Equal(t, created.Name, createdSvc.Name, "the Deployment and Service share the same run name")
 		require.Equal(t, created.Labels, createdSvc.Spec.Selector, "the Service selector must match the Deployment's pod labels")
+	})
+
+	t.Run("concurrent runs are label-disjoint: each Service selects only its own run's pods", func(t *testing.T) {
+		cs := newAutoReadyClient()
+		dep := newDeployer(t, cs, baseConfig())
+
+		// Two runs for the SAME workspace on the same generic spec — the
+		// worst case: every label except the run name is identical.
+		for range 2 {
+			_, _, err := dep.RunOnEphemeral(context.Background(), "ws-1",
+				func(context.Context, string) (int, []byte, error) { return 200, nil, nil })
+			require.NoError(t, err)
+		}
+
+		deps := findCreatedDeployments(t, cs)
+		svcs := findCreatedServices(t, cs)
+		require.Len(t, deps, 2)
+		require.Len(t, svcs, 2)
+		require.NotEqual(t, deps[0].Name, deps[1].Name, "each run must create uniquely named objects")
+
+		podLabelsByRun := map[string]map[string]string{}
+		for _, d := range deps {
+			require.Equal(t, d.Name, d.Spec.Template.Labels[LabelRunName])
+			podLabelsByRun[d.Name] = d.Spec.Template.Labels
+		}
+		// Without the run label in the selector, every run's Service selects
+		// every run's pods, so a request forwarded through Service A can land
+		// on run B's pod — which run B deletes the moment it finishes, killing
+		// A's request mid-flight ("Subprocess died (exit code -15)").
+		for _, svc := range svcs {
+			require.Equal(t, svc.Name, svc.Spec.Selector[LabelRunName], "the Service selector must pin its own run name")
+			for run, podLabels := range podLabelsByRun {
+				if run == svc.Name {
+					require.True(t, selectorMatches(svc.Spec.Selector, podLabels))
+				} else {
+					require.False(t, selectorMatches(svc.Spec.Selector, podLabels),
+						"Service %s must not select run %s's pods", svc.Name, run)
+				}
+			}
+		}
 	})
 
 	t.Run("applies the generic env to the container, deterministically ordered", func(t *testing.T) {
@@ -396,6 +439,70 @@ func TestRunOnEphemeral(t *testing.T) {
 		require.True(t, hasAction(cs, "deployments"), "delete must still have been attempted")
 	})
 
+	t.Run("emits a success-tagged readiness-wait timer and no cleanup-failure count on a clean run", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		dep := newDeployerWithStats(t, newAutoReadyClient(), baseConfig(), statsStore)
+
+		_, _, err = dep.RunOnEphemeral(context.Background(), "ws-1",
+			func(context.Context, string) (int, []byte, error) { return 200, nil, nil })
+		require.NoError(t, err)
+
+		metrics := statsStore.GetByName("processor_pyt_readiness_wait_time")
+		require.Len(t, metrics, 1)
+		require.Equal(t, stats.Tags{"workspaceId": "ws-1", "success": "true"}, metrics[0].Tags)
+		require.Empty(t, statsStore.GetByName("processor_pyt_cleanup_failure_count"))
+	})
+
+	t.Run("emits a failure-tagged readiness-wait timer on a readiness timeout", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		conf := baseConfig()
+		conf.Set("Processor.pytDeployer.pytTestReadinessTimeout", "300ms")
+		dep := newDeployerWithStats(t, newFakeClient(), conf, statsStore) // never becomes ready
+
+		_, _, err = dep.RunOnEphemeral(context.Background(), "ws-1",
+			func(context.Context, string) (int, []byte, error) { return 200, nil, nil })
+		require.Error(t, err)
+
+		metrics := statsStore.GetByName("processor_pyt_readiness_wait_time")
+		require.Len(t, metrics, 1)
+		require.Equal(t, stats.Tags{"workspaceId": "ws-1", "success": "false"}, metrics[0].Tags)
+	})
+
+	t.Run("increments the cleanup-failure count when the best-effort delete fails", func(t *testing.T) {
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		cs := newAutoReadyClient()
+		cs.PrependReactor("delete", "deployments", func(ktesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("etcd is down")
+		})
+		dep := newDeployerWithStats(t, cs, baseConfig(), statsStore)
+
+		_, _, err = dep.RunOnEphemeral(context.Background(), "ws-1",
+			func(context.Context, string) (int, []byte, error) { return 200, nil, nil })
+		require.NoError(t, err)
+
+		metrics := statsStore.GetByName("processor_pyt_cleanup_failure_count")
+		require.Len(t, metrics, 1)
+		require.Equal(t, stats.Tags{"workspaceId": "ws-1"}, metrics[0].Tags)
+		require.EqualValues(t, 1, metrics[0].Value)
+	})
+
+	t.Run("a too-short configured runIDLength is clamped to 8, keeping concurrent run names collision-safe", func(t *testing.T) {
+		conf := baseConfig()
+		conf.Set("Processor.pytDeployer.pytTestRunIDLength", 1)
+		cs := newAutoReadyClient()
+		dep := newDeployer(t, cs, conf)
+
+		_, _, err := dep.RunOnEphemeral(context.Background(), "ws-1",
+			func(context.Context, string) (int, []byte, error) { return 200, nil, nil })
+		require.NoError(t, err)
+
+		require.Len(t, findCreatedDeployment(t, cs).Name, len("pyt-test-")+8,
+			"a 1-char suffix would let concurrent runs collide and silently share one Deployment/Service")
+	})
+
 	t.Run("errors without calling forward when creating the Deployment fails", func(t *testing.T) {
 		cs := newFakeClient()
 		cs.PrependReactor("create", "deployments", func(ktesting.Action) (bool, runtime.Object, error) {
@@ -494,7 +601,7 @@ func TestNew(t *testing.T) {
 		conf.Set("Processor.pytDeployer.inCluster", false)
 		conf.Set("Processor.pytDeployer.kubeConfigPath", "/nonexistent/kubeconfig")
 
-		_, err := New(conf, logger.NOP)
+		_, err := New(conf, logger.NOP, stats.NOP)
 		require.Error(t, err)
 	})
 
@@ -502,7 +609,7 @@ func TestNew(t *testing.T) {
 		conf := baseConfig()
 		conf.Set("Processor.pytDeployer.pytTestImage", "")
 
-		_, err := New(conf, logger.NOP, WithClientset(fake.NewClientset()))
+		_, err := New(conf, logger.NOP, stats.NOP, WithClientset(fake.NewClientset()))
 		require.ErrorContains(t, err, "pytTestImage")
 	})
 
@@ -510,7 +617,7 @@ func TestNew(t *testing.T) {
 		conf := baseConfig()
 		conf.Set("Processor.pytDeployer.pytTestImagePullSecret", "")
 
-		_, err := New(conf, logger.NOP, WithClientset(fake.NewClientset()))
+		_, err := New(conf, logger.NOP, stats.NOP, WithClientset(fake.NewClientset()))
 		require.ErrorContains(t, err, "pytTestImagePullSecret")
 	})
 
@@ -519,7 +626,7 @@ func TestNew(t *testing.T) {
 		conf.Set("Processor.pytDeployer.pytTestCPURequest", "500m")
 		conf.Set("Processor.pytDeployer.pytTestCPULimit", "200m")
 
-		_, err := New(conf, logger.NOP, WithClientset(fake.NewClientset()))
+		_, err := New(conf, logger.NOP, stats.NOP, WithClientset(fake.NewClientset()))
 		require.ErrorContains(t, err, "pytTestCPULimit",
 			"limits below requests are rejected by the apiserver, so they must fail at startup")
 	})
@@ -529,12 +636,12 @@ func TestNew(t *testing.T) {
 		conf.Set("Processor.pytDeployer.pytTestMemoryRequest", "1Gi")
 		conf.Set("Processor.pytDeployer.pytTestMemoryLimit", "500Mi")
 
-		_, err := New(conf, logger.NOP, WithClientset(fake.NewClientset()))
+		_, err := New(conf, logger.NOP, stats.NOP, WithClientset(fake.NewClientset()))
 		require.ErrorContains(t, err, "pytTestMemoryLimit")
 	})
 
 	t.Run("succeeds with an injected clientset", func(t *testing.T) {
-		d, err := New(baseConfig(), logger.NOP, WithClientset(fake.NewClientset()))
+		d, err := New(baseConfig(), logger.NOP, stats.NOP, WithClientset(fake.NewClientset()))
 		require.NoError(t, err)
 		require.NotNil(t, d)
 	})
@@ -579,6 +686,10 @@ func baseConfig() *config.Config {
 	conf.Set("Processor.pytDeployer.pytTestImage", "pytransformer/pyt:latest")
 	conf.Set("Processor.pytDeployer.pytTestImagePullSecret", "regcred")
 	conf.Set("Processor.pytDeployer.pytTestReadinessTimeout", "5s")
+	// Pinned so tests asserting on poll counts within short readiness windows
+	// don't depend on the production default poll interval. 250ms is the
+	// effective minimum — waitReady floors anything shorter.
+	conf.Set("Processor.pytDeployer.pytTestReadinessPollInterval", "250ms")
 	return conf
 }
 
@@ -593,7 +704,12 @@ func fastRetryConfig() *config.Config {
 
 func newDeployer(t *testing.T, cs *fake.Clientset, conf *config.Config) Deployer {
 	t.Helper()
-	d, err := New(conf, logger.NOP, WithClientset(cs))
+	return newDeployerWithStats(t, cs, conf, stats.NOP)
+}
+
+func newDeployerWithStats(t *testing.T, cs *fake.Clientset, conf *config.Config, stat stats.Stats) Deployer {
+	t.Helper()
+	d, err := New(conf, logger.NOP, stat, WithClientset(cs))
 	require.NoError(t, err)
 	return d
 }
@@ -653,6 +769,39 @@ func findCreatedDeployment(t *testing.T, cs *fake.Clientset) *appsv1.Deployment 
 	}
 	t.Fatal("no Deployment create action found")
 	return nil
+}
+
+func findCreatedDeployments(t *testing.T, cs *fake.Clientset) []*appsv1.Deployment {
+	t.Helper()
+	var deps []*appsv1.Deployment
+	for _, a := range cs.Actions() {
+		if a.GetVerb() == "create" && a.GetResource().Resource == "deployments" {
+			deps = append(deps, a.(ktesting.CreateActionImpl).GetObject().(*appsv1.Deployment))
+		}
+	}
+	return deps
+}
+
+func findCreatedServices(t *testing.T, cs *fake.Clientset) []*corev1.Service {
+	t.Helper()
+	var svcs []*corev1.Service
+	for _, a := range cs.Actions() {
+		if a.GetVerb() == "create" && a.GetResource().Resource == "services" {
+			svcs = append(svcs, a.(ktesting.CreateActionImpl).GetObject().(*corev1.Service))
+		}
+	}
+	return svcs
+}
+
+// selectorMatches reports whether a Service selector matches a pod label set
+// the way kube-proxy would: every selector entry present with the same value.
+func selectorMatches(selector, podLabels map[string]string) bool {
+	for k, v := range selector {
+		if podLabels[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 func findCreatedService(t *testing.T, cs *fake.Clientset) *corev1.Service {

--- a/processor/internal/pytdeployer/pytdeployer_test.go
+++ b/processor/internal/pytdeployer/pytdeployer_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"net"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -596,6 +598,42 @@ func TestRunOnEphemeral(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
+	t.Run("applies the configured client QPS/Burst instead of client-go's defaults", func(t *testing.T) {
+		kubeconfig := filepath.Join(t.TempDir(), "kubeconfig")
+		require.NoError(t, os.WriteFile(kubeconfig, []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test
+  name: test
+current-context: test
+users:
+- name: test
+  user:
+    token: dummy
+`), 0o600))
+		conf := config.New()
+		conf.Set("Processor.pytDeployer.inCluster", false)
+		conf.Set("Processor.pytDeployer.kubeConfigPath", kubeconfig)
+
+		cfg, err := restConfig(conf)
+		require.NoError(t, err)
+		require.EqualValues(t, 10, cfg.QPS, "the default must override client-go's 5 QPS")
+		require.Equal(t, 20, cfg.Burst, "the default must override client-go's burst of 10")
+
+		conf.Set("Processor.pytDeployer.k8sClientQPS", 30)
+		conf.Set("Processor.pytDeployer.k8sClientBurst", 60)
+		cfg, err = restConfig(conf)
+		require.NoError(t, err)
+		require.EqualValues(t, 30, cfg.QPS)
+		require.Equal(t, 60, cfg.Burst)
+	})
+
 	t.Run("returns an error when no clientset is injected and no in-cluster/kubeconfig is available", func(t *testing.T) {
 		conf := baseConfig()
 		conf.Set("Processor.pytDeployer.inCluster", false)

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -588,14 +588,14 @@ func (u *Client) forwardTest(ctx context.Context, baseURL, workspaceID, path str
 				// additionally counted; retryability doesn't depend on them.
 				if isColdStartError(err, nil) {
 					u.stat.NewTaggedStat(coldStartErrorsMetric, stats.CountType,
-						stats.Tags{"workspaceID": workspaceID, "language": languagePython}).Increment()
+						stats.Tags{"workspaceID": workspaceID, "language": languagePython, "path": path}).Increment()
 				}
 				return err
 			}
 			defer func() { httputil.CloseResponse(resp) }()
 			if isColdStartError(nil, resp) {
 				u.stat.NewTaggedStat(coldStartErrorsMetric, stats.CountType,
-					stats.Tags{"workspaceID": workspaceID, "language": languagePython}).Increment()
+					stats.Tags{"workspaceID": workspaceID, "language": languagePython, "path": path}).Increment()
 				return fmt.Errorf("pyt cold start: status %d", resp.StatusCode)
 			}
 
@@ -618,7 +618,7 @@ func (u *Client) forwardTest(ctx context.Context, baseURL, workspaceID, path str
 		// otherwise mask what went wrong until the whole budget is exhausted.
 		backoff.WithNotify(func(err error, delay time.Duration) {
 			u.stat.NewTaggedStat(testForwardRetriesMetric, stats.CountType,
-				stats.Tags{"workspaceID": workspaceID, "language": languagePython}).Increment()
+				stats.Tags{"workspaceID": workspaceID, "language": languagePython, "path": path}).Increment()
 			u.log.Warnn("retrying pyt test forward",
 				obskit.WorkspaceID(workspaceID),
 				logger.NewStringField("path", path),

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bingads_test.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bingads_test.go
@@ -3,6 +3,7 @@ package offline_conversions
 import (
 	"archive/zip"
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -524,6 +526,57 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			Expect(err.Error()).To(Equal(expectedResult.Error()))
 		})
 
+		It("Transform() Test -> update reformats and preserves adjustedConversionTime", func() {
+			job := &jobsdb.JobT{
+				EventPayload: []byte("{\"type\": \"record\", \"action\": \"update\", \"fields\": {\"conversionName\": \"Test-Integration\", \"conversionTime\": \"2023-05-22T06:27:54Z\", \"adjustedConversionTime\": \"2023-05-22T18:27:54Z\", \"conversionValue\": \"100\", \"microsoftClickId\": \"click_id\", \"conversionCurrencyCode\": \"USD\"}}"),
+			}
+			uploader := &BingAdsBulkUploader{}
+			expectedResp := `{"message":{"fields":{"adjustedConversionTime":"5/22/2023 6:27:54 PM","conversionCurrencyCode":"USD","conversionName":"Test-Integration","conversionTime":"5/22/2023 6:27:54 AM","conversionValue":"100","microsoftClickId":"click_id"},"action":"update"},"metadata":{"jobId":0}}`
+			// Execute
+			resp, err := uploader.Transform(job)
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal(expectedResp))
+		})
+
+		It("Transform() Test -> insert ignores a malformed adjustedConversionTime", func() {
+			job := &jobsdb.JobT{
+				EventPayload: []byte("{\"type\": \"record\", \"action\": \"insert\", \"fields\": {\"conversionName\": \"Test-Integration\", \"conversionTime\": \"2023-05-22T06:27:54Z\", \"adjustedConversionTime\": \"not-a-timestamp\", \"conversionValue\": \"100\", \"microsoftClickId\": \"click_id\"}}"),
+			}
+			uploader := &BingAdsBulkUploader{}
+			// insert does not validate adjustedConversionTime, so the malformed value
+			// does not cause an error; it is left untouched (and ignored downstream).
+			expectedResp := `{"message":{"fields":{"adjustedConversionTime":"not-a-timestamp","conversionName":"Test-Integration","conversionTime":"5/22/2023 6:27:54 AM","conversionValue":"100","microsoftClickId":"click_id"},"action":"insert"},"metadata":{"jobId":0}}`
+			// Execute
+			resp, err := uploader.Transform(job)
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal(expectedResp))
+		})
+
+		It("Transform() Test -> insert leaves a valid adjustedConversionTime untouched", func() {
+			job := &jobsdb.JobT{
+				EventPayload: []byte("{\"type\": \"record\", \"action\": \"insert\", \"fields\": {\"conversionName\": \"Test-Integration\", \"conversionTime\": \"2023-05-22T06:27:54Z\", \"adjustedConversionTime\": \"2023-05-22T18:27:54Z\", \"conversionValue\": \"100\", \"microsoftClickId\": \"click_id\"}}"),
+			}
+			uploader := &BingAdsBulkUploader{}
+			// conversionTime is reformatted; adjustedConversionTime is NOT reformatted
+			// on insert (it is not validated), so it stays in its original form.
+			expectedResp := `{"message":{"fields":{"adjustedConversionTime":"2023-05-22T18:27:54Z","conversionName":"Test-Integration","conversionTime":"5/22/2023 6:27:54 AM","conversionValue":"100","microsoftClickId":"click_id"},"action":"insert"},"metadata":{"jobId":0}}`
+			// Execute
+			resp, err := uploader.Transform(job)
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal(expectedResp))
+		})
+
+		It("Transform() Test -> update errors naming a malformed adjustedConversionTime", func() {
+			job := &jobsdb.JobT{
+				EventPayload: []byte("{\"type\": \"record\", \"action\": \"update\", \"fields\": {\"conversionName\": \"Test-Integration\", \"conversionTime\": \"2023-05-22T06:27:54Z\", \"adjustedConversionTime\": \"not-a-timestamp\", \"conversionValue\": \"100\", \"microsoftClickId\": \"click_id\", \"conversionCurrencyCode\": \"USD\"}}"),
+			}
+			uploader := &BingAdsBulkUploader{}
+			// Execute
+			_, err := uploader.Transform(job)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("adjustedConversionTime must be in ISO 8601"))
+		})
+
 		It("Transform() Test -> microsoftClickId is required(email and phone undefined) but not present", func() {
 			job := &jobsdb.JobT{
 				EventPayload: []byte("{\"type\": \"record\", \"action\": \"update\", \"fields\": {\"conversionName\": \"Test-Integration\", \"conversionTime\": \"2023-05-22T06:27:54Z\", \"conversionValue\": \"100\", \"conversionCurrencyCode\": \"USD\"}}"),
@@ -553,7 +606,9 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			uploader := &BingAdsBulkUploader{
 				isHashRequired: true,
 			}
-			expectedResp := `{"message":{"fields":{"adjustedConversionTime":"5/22/2023 6:27:54 PM","conversionCurrencyCode":"USD","conversionName":"Test-Integration","conversionTime":"5/22/2023 6:27:54 PM","conversionValue":"100","email":"28a4da98f8812110001ab8ffacde3b38b4725a9e3570c39299fbf2d12c5aa70e","phone":"8c229df83de8ab269e90918846e326c4008c86481393223d17a30ff5a407b08e"},"action":"insert"},"metadata":{"jobId":0}}`
+			// insert does not reformat adjustedConversionTime (it is not validated on
+			// insert), so it stays in its original ISO form; conversionTime is reformatted.
+			expectedResp := `{"message":{"fields":{"adjustedConversionTime":"2023-05-22T18:27:54Z","conversionCurrencyCode":"USD","conversionName":"Test-Integration","conversionTime":"5/22/2023 6:27:54 PM","conversionValue":"100","email":"28a4da98f8812110001ab8ffacde3b38b4725a9e3570c39299fbf2d12c5aa70e","phone":"8c229df83de8ab269e90918846e326c4008c86481393223d17a30ff5a407b08e"},"action":"insert"},"metadata":{"jobId":0}}`
 			// Execute
 			resp, err := uploader.Transform(job)
 			Expect(resp).To(Equal(expectedResp))
@@ -637,6 +692,93 @@ var _ = Describe("Bing ads Offline Conversions", func() {
 			Expect(err).To(BeNil())
 			Expect(resp).To(Equal(expectedResp))
 		})
+		// populateZipFile writes one record into the action-specific CSV. Each case below
+		// supplies the input fields and the FULL expected CSV (header + format version +
+		// data row) so we compare the entire file, catching any column shift or drop.
+		// The canonical field name emitted by rETL/VDM is `adjustedConversionTime`
+		// (rudder-integrations-info/src/routes/bingads_offline_conversions/index.ts:46).
+		DescribeTable("populateZipFile() -> writes the full expected CSV per action",
+			func(action string, fields map[string]string, expectedCSV [][]string) {
+				initBingads()
+				bulkUploader := NewBingAdsBulkUploader(logger.NOP, stats.NOP, "BING_ADS", nil, false)
+
+				actionFile, err := createActionFile(action)
+				Expect(err).ShouldNot(HaveOccurred())
+				defer os.Remove(actionFile.CSVFilePath)
+				defer os.Remove(actionFile.ZipFilePath)
+
+				fieldsJSON, err := jsonrs.Marshal(fields)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				err = bulkUploader.populateZipFile(actionFile, "some line", Data{
+					Message:  Message{Action: action, Fields: fieldsJSON},
+					Metadata: Metadata{JobID: 7},
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+				actionFile.CSVWriter.Flush()
+
+				csvContent, err := os.ReadFile(actionFile.CSVFilePath)
+				Expect(err).ShouldNot(HaveOccurred())
+				records, err := csv.NewReader(strings.NewReader(string(csvContent))).ReadAll()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Full comparison of every row (header, format version, data row).
+				Expect(records).To(Equal(expectedCSV))
+			},
+			Entry("insert",
+				"insert",
+				map[string]string{
+					"conversionCurrencyCode":    "USD",
+					"conversionName":            "Test-Integration",
+					"conversionTime":            "4/19/2024 5:01:20 AM",
+					"conversionValue":           "10",
+					"microsoftClickId":          "click_id",
+					"email":                     "hashed_email",
+					"phone":                     "hashed_phone",
+					"externalAttributionCredit": "0.5",
+					"externalAttributionModel":  "dummy goal name",
+				},
+				[][]string{
+					{"Type", "Status", "Id", "Parent Id", "Client Id", "Name", "Conversion Currency Code", "Conversion Name", "Conversion Time", "Conversion Value", "Microsoft Click Id", "Hashed Email Address", "Hashed Phone Number", "External Attribution Credit", "External Attribution Model"},
+					{"Format Version", "", "", "", "", "6.0", "", "", "", "", "", "", "", "", ""},
+					{"Offline Conversion", "", "7", "", "", "", "USD", "Test-Integration", "4/19/2024 5:01:20 AM", "10", "click_id", "hashed_email", "hashed_phone", "0.5", "dummy goal name"},
+				},
+			),
+			Entry("update (Restate)",
+				"update",
+				map[string]string{
+					"conversionCurrencyCode": "USD",
+					"conversionName":         "Test-Integration",
+					"conversionTime":         "4/1/2024 9:23:54 AM",
+					"conversionValue":        "100",
+					"adjustedConversionTime": "4/1/2024 9:33:54 AM",
+					"microsoftClickId":       "click_id",
+					"email":                  "hashed_email",
+					"phone":                  "hashed_phone",
+				},
+				[][]string{
+					{"Type", "Adjustment Type", "Client Id", "Id", "Name", "Conversion Name", "Conversion Time", "Adjustment Value", "Microsoft Click Id", "Hashed Email Address", "Hashed Phone Number", "Adjusted Currency Code", "Adjustment Time"},
+					{"Format Version", "", "", "", "6.0", "", "", "", "", "", "", "", ""},
+					{"Offline Conversion", "Restate", "", "7", "", "Test-Integration", "4/1/2024 9:23:54 AM", "100", "click_id", "hashed_email", "hashed_phone", "USD", "4/1/2024 9:33:54 AM"},
+				},
+			),
+			Entry("delete (Retract)",
+				"delete",
+				map[string]string{
+					"conversionName":         "Test-Integration",
+					"conversionTime":         "4/1/2024 9:23:54 AM",
+					"adjustedConversionTime": "4/1/2024 9:33:54 AM",
+					"microsoftClickId":       "click_id",
+					"email":                  "hashed_email",
+					"phone":                  "hashed_phone",
+				},
+				[][]string{
+					{"Type", "Adjustment Type", "Client Id", "Id", "Name", "Conversion Name", "Conversion Time", "Microsoft Click Id", "Hashed Email Address", "Hashed Phone Number", "Adjustment Time"},
+					{"Format Version", "", "", "", "6.0", "", "", "", "", "", ""},
+					{"Offline Conversion", "Retract", "", "7", "", "Test-Integration", "4/1/2024 9:23:54 AM", "click_id", "hashed_email", "hashed_phone", "4/1/2024 9:33:54 AM"},
+				},
+			),
+		)
 	})
 })
 

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bulk_uploader.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/bulk_uploader.go
@@ -69,7 +69,7 @@ func (b *BingAdsBulkUploader) Transform(job *jobsdb.JobT) (string, error) {
 		}
 	}
 
-	err = validateAndTransformTimeFields(fields)
+	err = validateAndTransformTimeFields(fields, event.Action)
 	if err != nil {
 		return payload, err
 	}

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/types.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/types.go
@@ -71,7 +71,7 @@ type RecordFields struct {
 	Email                     string `json:"email"`
 	Phone                     string `json:"phone"`
 	MicrosoftClickId          string `json:"microsoftClickId"`
-	ConversionAdjustedTime    string `json:"conversionAdjustedTime"`
+	ConversionAdjustedTime    string `json:"adjustedConversionTime"`
 	ExternalAttributionCredit string `json:"externalAttributionCredit"`
 	ExternalAttributionModel  string `json:"externalAttributionModel"`
 }

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/util.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions/util.go
@@ -511,8 +511,14 @@ func hashFields(input map[string]any) (json.RawMessage, error) {
 	return json.RawMessage(result), nil
 }
 
-func validateAndTransformTimeFields(fields map[string]any) error {
-	timeFields := []string{"conversionTime", "adjustedConversionTime"}
+func validateAndTransformTimeFields(fields map[string]any, action string) error {
+	// insert never uses adjustedConversionTime (populateZipFile's insert branch
+	// does not read it), so it is not validated for insert. It is left untouched
+	// in the fields and ignored downstream.
+	timeFields := []string{"conversionTime"}
+	if action != "insert" {
+		timeFields = append(timeFields, "adjustedConversionTime")
+	}
 
 	for _, field := range timeFields {
 		fieldValue, ok := fields[field]
@@ -525,7 +531,7 @@ func validateAndTransformTimeFields(fields map[string]any) error {
 			if parseErr != nil {
 				parsedTime, parseErr = time.Parse("1/2/2006 3:04:05 PM", fieldValueStr)
 				if parseErr != nil {
-					return fmt.Errorf("conversionTime must be in ISO 8601 (e.g. 2006-01-02T15:04:05Z07:00) or mm/dd/yyyy hh:mm:ss AM/PM (e.g. 7/2/2025 6:50:54 PM) format")
+					return fmt.Errorf("%s must be in ISO 8601 (e.g. 2006-01-02T15:04:05Z07:00) or mm/dd/yyyy hh:mm:ss AM/PM (e.g. 7/2/2025 6:50:54 PM) format", field)
 				}
 			}
 			fields[field] = parsedTime.Format("1/2/2006 3:04:05 PM")

--- a/router/handle.go
+++ b/router/handle.go
@@ -76,6 +76,9 @@ type Handle struct {
 	saveDestinationResponse            bool
 	saveDestinationResponseOverride    config.ValueLoader[bool]
 	reportJobsdbPayload                config.ValueLoader[bool]
+	// supportsDeliveredWithWarnings mirrors the destination definition's capability flag. Written
+	// by the backend-config subscriber and read by workers, hence atomic.
+	supportsDeliveredWithWarnings atomic.Bool
 
 	diagnosisTickerTime time.Duration
 
@@ -107,6 +110,7 @@ type Handle struct {
 	processJobsCountStat           stats.Measurement
 	throttlingErrorStat            stats.Measurement
 	throttledStat                  stats.Measurement
+	warningStatusDowngradedStat    stats.Measurement
 	isolationStrategy              isolation.Strategy
 	backgroundGroup                *errgroup.Group
 	backgroundCtx                  context.Context
@@ -117,6 +121,10 @@ type Handle struct {
 
 	eventOrderingDisabledForWorkspace   func(workspaceID string) bool
 	eventOrderingDisabledForDestination func(destinationID string) bool
+
+	// deliveredWithWarningsEnabledForWorkspace reports whether a workspace is on the
+	// delivered-with-warnings controlled-rollout allow-list.
+	deliveredWithWarningsEnabledForWorkspace func(workspaceID string) bool
 
 	limiter struct {
 		pickup    kitsync.Limiter
@@ -134,6 +142,18 @@ type Handle struct {
 	drainer              routerutils.Drainer
 	drainingPartitionsMu sync.RWMutex
 	drainingPartitions   map[string]struct{} // keeps track of router partitions which are currently draining
+}
+
+// deliveredWithWarningsEnabled reports whether a 296 (Delivered with Warning) status should be
+// honoured for a job in the given workspace — either the destination definition advertises support
+// (general availability), or the workspace is on the controlled-rollout allow-list. Fails closed
+// when the allow-list predicate has not been wired, preserving the default-deny guarantee.
+func (rt *Handle) deliveredWithWarningsEnabled(workspaceID string) bool {
+	if rt.supportsDeliveredWithWarnings.Load() {
+		return true
+	}
+	return rt.deliveredWithWarningsEnabledForWorkspace != nil &&
+		rt.deliveredWithWarningsEnabledForWorkspace(workspaceID)
 }
 
 // activePartitions returns the list of active partitions, depending on the active isolation strategy

--- a/router/handle.go
+++ b/router/handle.go
@@ -110,7 +110,7 @@ type Handle struct {
 	processJobsCountStat           stats.Measurement
 	throttlingErrorStat            stats.Measurement
 	throttledStat                  stats.Measurement
-	statusDowngradedStat           stats.Counter
+	statusDowngradedStat           func(from, to int) stats.Counter
 	isolationStrategy              isolation.Strategy
 	backgroundGroup                *errgroup.Group
 	backgroundCtx                  context.Context

--- a/router/handle.go
+++ b/router/handle.go
@@ -76,6 +76,7 @@ type Handle struct {
 	saveDestinationResponse            bool
 	saveDestinationResponseOverride    config.ValueLoader[bool]
 	reportJobsdbPayload                config.ValueLoader[bool]
+	storeDeliveredWithWarningPayload   config.ValueLoader[bool]
 
 	diagnosisTickerTime time.Duration
 

--- a/router/handle.go
+++ b/router/handle.go
@@ -110,7 +110,7 @@ type Handle struct {
 	processJobsCountStat           stats.Measurement
 	throttlingErrorStat            stats.Measurement
 	throttledStat                  stats.Measurement
-	warningStatusDowngradedStat    stats.Measurement
+	statusDowngradedStat           stats.Counter
 	isolationStrategy              isolation.Strategy
 	backgroundGroup                *errgroup.Group
 	backgroundCtx                  context.Context
@@ -145,14 +145,10 @@ type Handle struct {
 }
 
 // deliveredWithWarningsEnabled reports whether a 296 (Delivered with Warning) status should be
-// honoured for a job in the given workspace — either the destination definition advertises support
-// (general availability), or the workspace is on the controlled-rollout allow-list. Fails closed
-// when the allow-list predicate has not been wired, preserving the default-deny guarantee.
+// honoured for a job in the given workspace — enabled either globally via the destination
+// definition (GA) or, before GA, for specific workspaces via the rollout allow-list.
 func (rt *Handle) deliveredWithWarningsEnabled(workspaceID string) bool {
-	if rt.supportsDeliveredWithWarnings.Load() {
-		return true
-	}
-	return rt.deliveredWithWarningsEnabledForWorkspace != nil &&
+	return rt.supportsDeliveredWithWarnings.Load() ||
 		rt.deliveredWithWarningsEnabledForWorkspace(workspaceID)
 }
 

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -99,6 +99,9 @@ func (rt *Handle) Setup(
 	if value, ok := destinationDefinition.Config["saveDestinationResponse"].(bool); ok {
 		rt.saveDestinationResponse = value
 	}
+	if value, ok := destinationDefinition.Config["supportsDeliveredWithWarnings"].(bool); ok {
+		rt.supportsDeliveredWithWarnings.Store(value)
+	}
 	rt.guaranteeUserEventOrder = getRouterConfigBool("guaranteeUserEventOrder", rt.destType, true)
 	rt.noOfWorkers = getRouterConfigInt("noOfWorkers", destType, 64)
 	rt.maxNoOfJobsPerChannel = getRouterConfigInt("maxNoOfJobsPerChannel", destType, 10000)
@@ -133,6 +136,7 @@ func (rt *Handle) Setup(
 	rt.routerTransformInputCountStat = stats.Default.NewTaggedStat("router_transform_num_input_jobs", stats.CountType, statTags)
 	rt.routerTransformOutputCountStat = stats.Default.NewTaggedStat("router_transform_num_output_jobs", stats.CountType, statTags)
 	rt.batchInputOutputDiffCountStat = stats.Default.NewTaggedStat("router_batch_input_output_diff_jobs", stats.CountType, statTags)
+	rt.warningStatusDowngradedStat = stats.Default.NewTaggedStat("router_warning_status_downgraded_count", stats.CountType, statTags)
 	rt.processJobsHistogramStat = stats.Default.NewTaggedStat("router_process_jobs_hist", stats.HistogramType, statTags)
 	rt.processJobsCountStat = stats.Default.NewTaggedStat("router_process_jobs_count", stats.CountType, statTags)
 	rt.processRequestsHistogramStat = stats.Default.NewTaggedStat("router_process_requests_hist", stats.HistogramType, statTags)
@@ -169,6 +173,10 @@ func (rt *Handle) Setup(
 	orderingDisabledDestinationIDs := config.GetReloadableStringSliceVar(nil, getRouterConfigKeys("orderingDisabledDestinationIDs", destType)...)
 	rt.eventOrderingDisabledForDestination = func(destinationID string) bool {
 		return slices.Contains(orderingDisabledDestinationIDs.Load(), destinationID)
+	}
+	deliveredWithWarningsEnabledWorkspaceIDs := config.GetReloadableStringSliceVar(nil, getRouterConfigKeys("deliveredWithWarningsEnabledWorkspaceIDs", destType)...)
+	rt.deliveredWithWarningsEnabledForWorkspace = func(workspaceID string) bool {
+		return slices.Contains(deliveredWithWarningsEnabledWorkspaceIDs.Load(), workspaceID)
 	}
 	orderingPanicOnIllegalSequence := config.GetReloadableBoolVar(true, getRouterConfigKeys("orderingPanicOnIllegalSequence", destType)...)
 	illegalJobSequenceStats := map[string]stats.Measurement{}
@@ -474,6 +482,9 @@ func (rt *Handle) backendConfigSubscriber() {
 
 						if value, ok := destination.DestinationDefinition.Config["saveDestinationResponse"].(bool); ok {
 							rt.saveDestinationResponse = value
+						}
+						if value, ok := destination.DestinationDefinition.Config["supportsDeliveredWithWarnings"].(bool); ok {
+							rt.supportsDeliveredWithWarnings.Store(value)
 						}
 
 						// Config key "throttlingCost" is expected to have the eventType as the first key and the call type

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -35,6 +35,7 @@ import (
 	transformerFeaturesService "github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/crash"
+	utilTypes "github.com/rudderlabs/rudder-server/utils/types"
 	"github.com/rudderlabs/rudder-server/utils/workerpool"
 )
 
@@ -136,7 +137,11 @@ func (rt *Handle) Setup(
 	rt.routerTransformInputCountStat = stats.Default.NewTaggedStat("router_transform_num_input_jobs", stats.CountType, statTags)
 	rt.routerTransformOutputCountStat = stats.Default.NewTaggedStat("router_transform_num_output_jobs", stats.CountType, statTags)
 	rt.batchInputOutputDiffCountStat = stats.Default.NewTaggedStat("router_batch_input_output_diff_jobs", stats.CountType, statTags)
-	rt.warningStatusDowngradedStat = stats.Default.NewTaggedStat("router_warning_status_downgraded_count", stats.CountType, statTags)
+	rt.statusDowngradedStat = stats.Default.NewTaggedStat("router_status_downgraded_count", stats.CountType, stats.Tags{
+		"destType": rt.destType,
+		"from":     strconv.Itoa(utilTypes.DeliveredWithWarningCode),
+		"to":       strconv.Itoa(utilTypes.SuccessEventCode),
+	})
 	rt.processJobsHistogramStat = stats.Default.NewTaggedStat("router_process_jobs_hist", stats.HistogramType, statTags)
 	rt.processJobsCountStat = stats.Default.NewTaggedStat("router_process_jobs_count", stats.CountType, statTags)
 	rt.processRequestsHistogramStat = stats.Default.NewTaggedStat("router_process_requests_hist", stats.HistogramType, statTags)

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -35,7 +35,6 @@ import (
 	transformerFeaturesService "github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/crash"
-	utilTypes "github.com/rudderlabs/rudder-server/utils/types"
 	"github.com/rudderlabs/rudder-server/utils/workerpool"
 )
 
@@ -137,11 +136,13 @@ func (rt *Handle) Setup(
 	rt.routerTransformInputCountStat = stats.Default.NewTaggedStat("router_transform_num_input_jobs", stats.CountType, statTags)
 	rt.routerTransformOutputCountStat = stats.Default.NewTaggedStat("router_transform_num_output_jobs", stats.CountType, statTags)
 	rt.batchInputOutputDiffCountStat = stats.Default.NewTaggedStat("router_batch_input_output_diff_jobs", stats.CountType, statTags)
-	rt.statusDowngradedStat = stats.Default.NewTaggedStat("router_status_downgraded_count", stats.CountType, stats.Tags{
-		"destType": rt.destType,
-		"from":     strconv.Itoa(utilTypes.DeliveredWithWarningCode),
-		"to":       strconv.Itoa(utilTypes.SuccessEventCode),
-	})
+	rt.statusDowngradedStat = func(from, to int) stats.Counter {
+		return stats.Default.NewTaggedStat("router_status_downgraded_count", stats.CountType, stats.Tags{
+			"destType": rt.destType,
+			"from":     strconv.Itoa(from),
+			"to":       strconv.Itoa(to),
+		})
+	}
 	rt.processJobsHistogramStat = stats.Default.NewTaggedStat("router_process_jobs_hist", stats.HistogramType, statTags)
 	rt.processJobsCountStat = stats.Default.NewTaggedStat("router_process_jobs_count", stats.CountType, statTags)
 	rt.processRequestsHistogramStat = stats.Default.NewTaggedStat("router_process_requests_hist", stats.HistogramType, statTags)

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -123,6 +123,7 @@ func (rt *Handle) Setup(
 	rt.eventOrderHalfEnabledStateDuration = config.GetReloadableDurationVar(10, time.Minute, getRouterConfigKeys("eventOrderHalfEnabledStateDuration", destType)...)
 	rt.deliveryThrottlerTimeout = config.GetReloadableDurationVar(5, time.Minute, getRouterConfigKeys("deliveryThrottlerTimeout", destType)...)
 	rt.reportJobsdbPayload = config.GetReloadableBoolVar(true, getRouterConfigKeys("reportJobsdbPayload", destType)...)
+	rt.storeDeliveredWithWarningPayload = config.GetReloadableBoolVar(false, getRouterConfigKeys("storeDeliveredWithWarningPayload", destType)...)
 	rt.saveDestinationResponseOverride = config.GetReloadableBoolVar(false, getRouterConfigKeys("saveDestinationResponseOverride", destType)...)
 
 	statTags := stats.Tags{"destType": rt.destType}

--- a/router/worker.go
+++ b/router/worker.go
@@ -821,6 +821,20 @@ func (w *worker) hydrateRespStatusCodes(destinationJob types.DestinationJobT, re
 	}
 }
 
+// gateDeliveredWithWarning downgrades 296 (Delivered with Warning) to 200 for any job whose
+// workspace has not enabled the feature. Only the status code is rewritten — response bodies are
+// left untouched. Rewriting to 200 also makes this idempotent across duplicate job IDs in
+// JobMetadataArray, so the downgrade counter fires exactly once per job.
+func (w *worker) gateDeliveredWithWarning(destinationJob types.DestinationJobT, respStatusCodes map[int64]int) {
+	for _, metadata := range destinationJob.JobMetadataArray {
+		if respStatusCodes[metadata.JobID] == utilTypes.DeliveredWithWarningCode &&
+			!w.rt.deliveredWithWarningsEnabled(metadata.WorkspaceID) {
+			respStatusCodes[metadata.JobID] = http.StatusOK
+			w.rt.warningStatusDowngradedStat.Count(1)
+		}
+	}
+}
+
 func (w *worker) updateFailedJobOrderKeys(failedJobOrderKeys map[eventorder.BarrierKey]struct{}, destinationJob *types.DestinationJobT, respStatusCodes map[int64]int) {
 	for _, metadata := range destinationJob.JobMetadataArray {
 		if !isJobTerminated(respStatusCodes[metadata.JobID]) {
@@ -838,6 +852,7 @@ func (w *worker) updateFailedJobOrderKeys(failedJobOrderKeys map[eventorder.Barr
 
 func (w *worker) prepareRouterJobResponses(destinationJob types.DestinationJobT, respStatusCodes map[int64]int, respBodys map[int64]string, errorAt string) []*JobResponse {
 	w.hydrateRespStatusCodes(destinationJob, respStatusCodes, respBodys)
+	w.gateDeliveredWithWarning(destinationJob, respStatusCodes)
 
 	// Failure - Save response body
 	// Success - Skip saving response body

--- a/router/worker.go
+++ b/router/worker.go
@@ -984,13 +984,23 @@ func (w *worker) postStatusOnResponseQ(respStatusCode int, destinationJob *types
 		if respStatusCode == utilTypes.FilterEventCode {
 			status.JobState = jobsdb.Filtered.State
 		}
+		// For 296 (Delivered with Warning) report the transformed delivery body actually sent to
+		// the destination, so the warnings UX can surface it. Gated by a per-destType opt-in flag
+		// (default off); every other success code keeps reporting the router input payload unchanged.
+		payload := inputPayload
+		if respStatusCode == utilTypes.DeliveredWithWarningCode && w.rt.storeDeliveredWithWarningPayload.Load() {
+			payload = destinationJob.Message
+			status.ErrorResponse = misc.UpdateJSONWithNewKeyVal(status.ErrorResponse, "payloadStage", "delivery")
+		}
+		// Non-296 success responses intentionally omit a payloadStage marker (e.g. "router_input"):
+		// it isn't surfaced in the UI, so we skip setting it for now.
 		w.logger.Debugn("sending success status to response")
 		w.rt.responseQ <- workerJobStatus{
 			userID:     destinationJobMetadata.UserID,
 			worker:     w,
 			job:        destinationJobMetadata.JobT,
 			status:     status,
-			payload:    inputPayload,
+			payload:    payload,
 			statTags:   destinationJob.StatTags,
 			parameters: destinationJobMetadata.Parameters,
 		}

--- a/router/worker.go
+++ b/router/worker.go
@@ -830,7 +830,7 @@ func (w *worker) gateDeliveredWithWarning(destinationJob types.DestinationJobT, 
 		if respStatusCodes[metadata.JobID] == utilTypes.DeliveredWithWarningCode &&
 			!w.rt.deliveredWithWarningsEnabled(metadata.WorkspaceID) {
 			respStatusCodes[metadata.JobID] = http.StatusOK
-			w.rt.warningStatusDowngradedStat.Count(1)
+			w.rt.statusDowngradedStat.Count(1)
 		}
 	}
 }

--- a/router/worker.go
+++ b/router/worker.go
@@ -830,7 +830,7 @@ func (w *worker) gateDeliveredWithWarning(destinationJob types.DestinationJobT, 
 		if respStatusCodes[metadata.JobID] == utilTypes.DeliveredWithWarningCode &&
 			!w.rt.deliveredWithWarningsEnabled(metadata.WorkspaceID) {
 			respStatusCodes[metadata.JobID] = http.StatusOK
-			w.rt.statusDowngradedStat.Count(1)
+			w.rt.statusDowngradedStat(utilTypes.DeliveredWithWarningCode, http.StatusOK).Count(1)
 		}
 	}
 }

--- a/router/worker_test.go
+++ b/router/worker_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/http"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -35,6 +37,7 @@ import (
 	transformerFeaturesService "github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/cache"
+	utilTypes "github.com/rudderlabs/rudder-server/utils/types"
 )
 
 // createTestWorker creates a worker instance for testing with properly initialized StatsCache instances
@@ -53,6 +56,149 @@ func createTestWorker(destType string, transformProxy bool, stat stats.Stats) *w
 			return stat.NewTaggedStat("transformer_outgoing_request_count", stats.CountType, labels.ToStatTags())
 		}),
 	}
+}
+
+// TestDeliveredWithWarningsEnabled covers the OR between the destination-definition capability
+// (the GA switch) and the per-workspace controlled-rollout allow-list.
+func TestDeliveredWithWarningsEnabled(t *testing.T) {
+	const (
+		enabledWorkspace = "workspace-enabled"
+		otherWorkspace   = "workspace-other"
+	)
+
+	newHandle := func(destDefSupports bool, allowList ...string) *Handle {
+		rt := &Handle{}
+		rt.supportsDeliveredWithWarnings.Store(destDefSupports)
+		rt.deliveredWithWarningsEnabledForWorkspace = func(workspaceID string) bool {
+			return slices.Contains(allowList, workspaceID)
+		}
+		return rt
+	}
+
+	t.Run("destination definition supports it, workspace not allow-listed", func(t *testing.T) {
+		require.True(t, newHandle(true).deliveredWithWarningsEnabled(otherWorkspace))
+	})
+
+	t.Run("destination definition does not support it, workspace allow-listed", func(t *testing.T) {
+		require.True(t, newHandle(false, enabledWorkspace).deliveredWithWarningsEnabled(enabledWorkspace))
+	})
+
+	t.Run("both enabled", func(t *testing.T) {
+		require.True(t, newHandle(true, enabledWorkspace).deliveredWithWarningsEnabled(enabledWorkspace))
+	})
+
+	t.Run("neither enabled", func(t *testing.T) {
+		require.False(t, newHandle(false, enabledWorkspace).deliveredWithWarningsEnabled(otherWorkspace))
+	})
+
+	t.Run("allow-list predicate not wired fails closed", func(t *testing.T) {
+		require.False(t, (&Handle{}).deliveredWithWarningsEnabled(enabledWorkspace))
+	})
+}
+
+// TestGateDeliveredWithWarning covers the 296 -> 200 downgrade applied per job, per workspace.
+func TestGateDeliveredWithWarning(t *testing.T) {
+	const (
+		gateDestType     = "BRAZE"
+		downgradeMetric  = "router_warning_status_downgraded_count"
+		enabledWorkspace = "workspace-enabled"
+		otherWorkspace   = "workspace-other"
+	)
+	downgradeTags := stats.Tags{"destType": gateDestType}
+
+	newGateWorker := func(t *testing.T, destDefSupports bool, allowList ...string) (*worker, *memstats.Store) {
+		t.Helper()
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+		rt := &Handle{
+			destType:                    gateDestType,
+			warningStatusDowngradedStat: statsStore.NewTaggedStat(downgradeMetric, stats.CountType, downgradeTags),
+		}
+		rt.supportsDeliveredWithWarnings.Store(destDefSupports)
+		rt.deliveredWithWarningsEnabledForWorkspace = func(workspaceID string) bool {
+			return slices.Contains(allowList, workspaceID)
+		}
+		return &worker{rt: rt, logger: logger.NOP}, statsStore
+	}
+
+	downgrades := func(statsStore *memstats.Store) float64 {
+		if m := statsStore.Get(downgradeMetric, downgradeTags); m != nil {
+			return m.LastValue()
+		}
+		return 0
+	}
+
+	jobsOf := func(metadata ...types.JobMetadataT) types.DestinationJobT {
+		return types.DestinationJobT{JobMetadataArray: metadata}
+	}
+	jobMeta := func(jobID int64, workspaceID string) types.JobMetadataT {
+		return types.JobMetadataT{JobID: jobID, WorkspaceID: workspaceID}
+	}
+
+	t.Run("allow-listed workspace keeps 296", func(t *testing.T) {
+		w, statsStore := newGateWorker(t, false, enabledWorkspace)
+		codes := map[int64]int{1: utilTypes.DeliveredWithWarningCode}
+		w.gateDeliveredWithWarning(jobsOf(jobMeta(1, enabledWorkspace)), codes)
+		require.Equal(t, utilTypes.DeliveredWithWarningCode, codes[1])
+		require.Zero(t, downgrades(statsStore))
+	})
+
+	t.Run("destination definition support keeps 296 for any workspace", func(t *testing.T) {
+		w, statsStore := newGateWorker(t, true)
+		codes := map[int64]int{1: utilTypes.DeliveredWithWarningCode}
+		w.gateDeliveredWithWarning(jobsOf(jobMeta(1, otherWorkspace)), codes)
+		require.Equal(t, utilTypes.DeliveredWithWarningCode, codes[1])
+		require.Zero(t, downgrades(statsStore))
+	})
+
+	t.Run("non allow-listed workspace downgrades to 200", func(t *testing.T) {
+		w, statsStore := newGateWorker(t, false, enabledWorkspace)
+		codes := map[int64]int{1: utilTypes.DeliveredWithWarningCode}
+		w.gateDeliveredWithWarning(jobsOf(jobMeta(1, otherWorkspace)), codes)
+		require.Equal(t, http.StatusOK, codes[1])
+		require.EqualValues(t, 1, downgrades(statsStore))
+	})
+
+	t.Run("batch spanning workspaces downgrades only the non allow-listed job", func(t *testing.T) {
+		w, statsStore := newGateWorker(t, false, enabledWorkspace)
+		codes := map[int64]int{
+			1: utilTypes.DeliveredWithWarningCode,
+			2: utilTypes.DeliveredWithWarningCode,
+		}
+		w.gateDeliveredWithWarning(jobsOf(jobMeta(1, enabledWorkspace), jobMeta(2, otherWorkspace)), codes)
+		require.Equal(t, utilTypes.DeliveredWithWarningCode, codes[1])
+		require.Equal(t, http.StatusOK, codes[2])
+		require.EqualValues(t, 1, downgrades(statsStore))
+	})
+
+	t.Run("only 296 is rewritten in a mixed-code batch", func(t *testing.T) {
+		w, statsStore := newGateWorker(t, false)
+		codes := map[int64]int{
+			1: http.StatusOK,
+			2: utilTypes.DeliveredWithWarningCode,
+			3: http.StatusBadRequest,
+			4: http.StatusInternalServerError,
+		}
+		w.gateDeliveredWithWarning(jobsOf(
+			jobMeta(1, otherWorkspace), jobMeta(2, otherWorkspace),
+			jobMeta(3, otherWorkspace), jobMeta(4, otherWorkspace),
+		), codes)
+		require.Equal(t, map[int64]int{
+			1: http.StatusOK,
+			2: http.StatusOK,
+			3: http.StatusBadRequest,
+			4: http.StatusInternalServerError,
+		}, codes)
+		require.EqualValues(t, 1, downgrades(statsStore))
+	})
+
+	t.Run("duplicate job metadata downgrades once", func(t *testing.T) {
+		w, statsStore := newGateWorker(t, false)
+		codes := map[int64]int{1: utilTypes.DeliveredWithWarningCode}
+		w.gateDeliveredWithWarning(jobsOf(jobMeta(1, otherWorkspace), jobMeta(1, otherWorkspace)), codes)
+		require.Equal(t, http.StatusOK, codes[1])
+		require.EqualValues(t, 1, downgrades(statsStore))
+	})
 }
 
 func TestConsolidateRespBodys(t *testing.T) {

--- a/router/worker_test.go
+++ b/router/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"slices"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -90,29 +91,29 @@ func TestDeliveredWithWarningsEnabled(t *testing.T) {
 	t.Run("neither enabled", func(t *testing.T) {
 		require.False(t, newHandle(false, enabledWorkspace).deliveredWithWarningsEnabled(otherWorkspace))
 	})
-
-	t.Run("allow-list predicate not wired fails closed", func(t *testing.T) {
-		require.False(t, (&Handle{}).deliveredWithWarningsEnabled(enabledWorkspace))
-	})
 }
 
 // TestGateDeliveredWithWarning covers the 296 -> 200 downgrade applied per job, per workspace.
 func TestGateDeliveredWithWarning(t *testing.T) {
 	const (
 		gateDestType     = "BRAZE"
-		downgradeMetric  = "router_warning_status_downgraded_count"
+		downgradeMetric  = "router_status_downgraded_count"
 		enabledWorkspace = "workspace-enabled"
 		otherWorkspace   = "workspace-other"
 	)
-	downgradeTags := stats.Tags{"destType": gateDestType}
+	downgradeTags := stats.Tags{
+		"destType": gateDestType,
+		"from":     strconv.Itoa(utilTypes.DeliveredWithWarningCode),
+		"to":       strconv.Itoa(utilTypes.SuccessEventCode),
+	}
 
 	newGateWorker := func(t *testing.T, destDefSupports bool, allowList ...string) (*worker, *memstats.Store) {
 		t.Helper()
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
 		rt := &Handle{
-			destType:                    gateDestType,
-			warningStatusDowngradedStat: statsStore.NewTaggedStat(downgradeMetric, stats.CountType, downgradeTags),
+			destType:             gateDestType,
+			statusDowngradedStat: statsStore.NewTaggedStat(downgradeMetric, stats.CountType, downgradeTags),
 		}
 		rt.supportsDeliveredWithWarnings.Store(destDefSupports)
 		rt.deliveredWithWarningsEnabledForWorkspace = func(workspaceID string) bool {

--- a/router/worker_test.go
+++ b/router/worker_test.go
@@ -112,8 +112,14 @@ func TestGateDeliveredWithWarning(t *testing.T) {
 		statsStore, err := memstats.New()
 		require.NoError(t, err)
 		rt := &Handle{
-			destType:             gateDestType,
-			statusDowngradedStat: statsStore.NewTaggedStat(downgradeMetric, stats.CountType, downgradeTags),
+			destType: gateDestType,
+			statusDowngradedStat: func(from, to int) stats.Counter {
+				return statsStore.NewTaggedStat(downgradeMetric, stats.CountType, stats.Tags{
+					"destType": gateDestType,
+					"from":     strconv.Itoa(from),
+					"to":       strconv.Itoa(to),
+				})
+			},
 		}
 		rt.supportsDeliveredWithWarnings.Store(destDefSupports)
 		rt.deliveredWithWarningsEnabledForWorkspace = func(workspaceID string) bool {

--- a/router/worker_test.go
+++ b/router/worker_test.go
@@ -23,6 +23,7 @@ import (
 
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/enterprise/reporting"
+	"github.com/rudderlabs/rudder-server/jobsdb"
 	mocksRouter "github.com/rudderlabs/rudder-server/mocks/router"
 	mocksTransformer "github.com/rudderlabs/rudder-server/mocks/router/transformer"
 	"github.com/rudderlabs/rudder-server/processor/integrations"
@@ -35,6 +36,7 @@ import (
 	transformerFeaturesService "github.com/rudderlabs/rudder-server/services/transformer"
 	"github.com/rudderlabs/rudder-server/services/transientsource"
 	"github.com/rudderlabs/rudder-server/utils/cache"
+	utilTypes "github.com/rudderlabs/rudder-server/utils/types"
 )
 
 // createTestWorker creates a worker instance for testing with properly initialized StatsCache instances
@@ -53,6 +55,63 @@ func createTestWorker(destType string, transformProxy bool, stat stats.Stats) *w
 			return stat.NewTaggedStat("transformer_outgoing_request_count", stats.CountType, labels.ToStatTags())
 		}),
 	}
+}
+
+// TestPostStatusOnResponseQStoreDeliveredWithWarningPayload verifies that, on the success path,
+// only a Delivered-with-Warning (296) status reports the transformed delivery body instead of the
+// router input payload, gated by the storeDeliveredWithWarningPayload flag.
+func TestPostStatusOnResponseQStoreDeliveredWithWarningPayload(t *testing.T) {
+	const (
+		destType     = "BRAZE"
+		inputPayload = `{"input":"event"}`
+		deliveryBody = `{"delivery":"transformed batch body"}`
+	)
+
+	newTestWorker := func(storePayload bool) *worker {
+		return &worker{
+			logger: logger.NOP,
+			rt: &Handle{
+				destType:                         destType,
+				responseQ:                        make(chan workerJobStatus, 1),
+				reportJobsdbPayload:              config.SingleValueLoader(true),
+				storeDeliveredWithWarningPayload: config.SingleValueLoader(storePayload),
+			},
+		}
+	}
+
+	report := func(w *worker, statusCode int, message string) workerJobStatus {
+		destinationJob := &types.DestinationJobT{Message: json.RawMessage(message)}
+		metadata := &types.JobMetadataT{JobT: &jobsdb.JobT{EventPayload: json.RawMessage(inputPayload)}}
+		status := &jobsdb.JobStatusT{ErrorResponse: json.RawMessage(`{}`)}
+		w.postStatusOnResponseQ(statusCode, destinationJob, "application/json", metadata, status, "")
+		return <-w.rt.responseQ
+	}
+
+	t.Run("296 reports the transformed delivery body and marks payloadStage=delivery", func(t *testing.T) {
+		got := report(newTestWorker(true), utilTypes.DeliveredWithWarningCode, deliveryBody)
+		require.JSONEq(t, deliveryBody, string(got.payload))
+		require.Equal(t, jobsdb.Succeeded.State, got.status.JobState)
+		require.Contains(t, string(got.status.ErrorResponse), `"payloadStage":"delivery"`)
+	})
+
+	t.Run("200 keeps the router input payload with no delivery marker", func(t *testing.T) {
+		got := report(newTestWorker(true), utilTypes.SuccessEventCode, deliveryBody)
+		require.JSONEq(t, inputPayload, string(got.payload))
+		require.Equal(t, jobsdb.Succeeded.State, got.status.JobState)
+		require.NotContains(t, string(got.status.ErrorResponse), "payloadStage")
+	})
+
+	t.Run("296 with storeDeliveredWithWarningPayload off falls back to the input payload", func(t *testing.T) {
+		got := report(newTestWorker(false), utilTypes.DeliveredWithWarningCode, deliveryBody)
+		require.JSONEq(t, inputPayload, string(got.payload))
+		require.NotContains(t, string(got.status.ErrorResponse), "payloadStage")
+	})
+
+	t.Run("filter event code stays Filtered with the input payload", func(t *testing.T) {
+		got := report(newTestWorker(true), utilTypes.FilterEventCode, deliveryBody)
+		require.JSONEq(t, inputPayload, string(got.payload))
+		require.Equal(t, jobsdb.Filtered.State, got.status.JobState)
+	})
 }
 
 func TestConsolidateRespBodys(t *testing.T) {

--- a/runner/buckets.go
+++ b/runner/buckets.go
@@ -179,5 +179,17 @@ var (
 		"rsources_publish_time_second": {
 			0.1, 0.5, 1, 5, 10, 30, 60,
 		},
+		"processor_grpc_response_time": {
+			0.1, 0.25, 0.5, 1, 2.5, 5, 15, 30, 60, // 0.1s, 0.25s, 0.5s, 1s, 2.5s, 5s, 15s, 30s, 1m
+		},
+		"processor_pyt_forward_rpc_time": {
+			0.5, 1, 2.5, 5, 10, 30, 60, // 0.5s, 1s, 2.5s, 5s, 10s, 30s, 1m
+		},
+		"processor_pyt_request_handle_time": {
+			0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, // 0.1s, 0.25s, 0.5s, 1s, 2.5s, 5s, 10s, 30s, 1m
+		},
+		"processor_pyt_readiness_wait_time": {
+			0.5, 1, 2.5, 5, 10, 30, 60, // 0.5s, 1s, 2.5s, 5s, 10s, 30s, 1m
+		},
 	}
 )

--- a/utils/types/types.go
+++ b/utils/types/types.go
@@ -10,10 +10,11 @@ import (
 )
 
 const (
-	FilterEventCode   = 298
-	SuppressEventCode = 299
-	DrainEventCode    = 410
-	SuccessEventCode  = 200
+	FilterEventCode          = 298
+	SuppressEventCode        = 299
+	DrainEventCode           = 410
+	SuccessEventCode         = 200
+	DeliveredWithWarningCode = 296
 
 	FlagBotEventAction = "flag"
 	DropBotEventAction = "drop"


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.28.0

# Description

This branch merged `release/1.81.x` before being squash-merged, so this single commit carries **two** related pieces of the "Delivered with Warning" work:

- **INT-6636** — gate `296 → 200` behind a per-workspace rollout (the primary subject of this PR).
- **INT-6637** — report the transformed delivery payload for 296 (originally #7213 / #7226; its code rode in with this merge).

## INT-6636 — gate 296 → 200

rudder-transformer converts Braze's `200 + warning` response into statusCode **296**. Honouring that unconditionally would let any destination surface 296 — including via handler bugs or destinations not yet onboarded — so rudder-server downgrades `296 → 200` unless the feature is enabled for that job.

**Enablement — the OR of two inputs, both defaulting to off**

| Input | Where | Purpose |
| -- | -- | -- |
| `supportsDeliveredWithWarnings` | `DestinationDefinition.Config`, read at `Setup` and refreshed by the backend-config subscriber | GA switch — enables the feature for every workspace at once |
| `deliveredWithWarningsEnabledWorkspaceIDs` | `Router.<destType>.deliveredWithWarningsEnabledWorkspaceIDs`, reloadable | Controlled-rollout allow-list — enables selected workspaces ahead of GA |

Both empty ⇒ downgrade, so un-onboarded destinations fail closed. `Handle.deliveredWithWarningsEnabled(workspaceID)` is the single place the OR is expressed.

**Changes**

- `utils/types`: add `DeliveredWithWarningCode = 296`.
- `router/handle.go`: `supportsDeliveredWithWarnings` (`atomic.Bool`), the workspace allow-list predicate, the `deliveredWithWarningsEnabled` OR helper, and `statusDowngradedStat` — a `func(from, to int) stats.Counter` constructor for the generic `router_status_downgraded_count{destType,from,to}` metric.
- `router/handle_lifecycle.go`: read the dest-def flag at both dest-def read sites, register the allow-list (mirroring `orderingDisabledWorkspaceIDs`), and wire the downgrade-metric constructor at `Setup`.
- `router/worker.go`: `gateDeliveredWithWarning`, called from `prepareRouterJobResponses` immediately after `hydrateRespStatusCodes` — the single funnel every delivery path (transformer proxy, direct HTTP, custom destination manager) converges on, upstream of `JobStatusT.ErrorCode` and reporting.

**Scope & safety** — only `296` is rewritten; 200/4xx/5xx pass through untouched, response bodies byte-identical. The rewrite-to-200 makes it idempotent across duplicate job IDs, so `router_status_downgraded_count` fires once per job.

## INT-6637 — report delivery payload for 296

On the success path, `postStatusOnResponseQ` reported the **router input payload** for every status code, so the transformed body actually sent to the destination was never available to reporting. For **296** the Events tab needs that delivery body, so this reports `destinationJob.Message` for 296 only and marks the status `payloadStage=delivery`.

- Gated by `storeDeliveredWithWarningPayload` — a reloadable per-destType bool, **default `false`** (opt-in), mirroring `reportJobsdbPayload`.
- Strictly limited to `respStatusCode == 296`; 200, filter (298), and the failure path are unchanged.

**Testing** — `TestDeliveredWithWarningsEnabled` (enablement matrix incl. fail-closed), `TestGateDeliveredWithWarning` (pass-through, downgrade + counter, mixed-workspace batch, mixed-code batch, duplicate-job idempotency), and `TestPostStatusOnResponseQStoreDeliveredWithWarningPayload` (296 → delivery body, 200 → input, flag-off → input, filter → Filtered). `go build ./...`, `go vet`, and the full `TestRouter` suite pass.

## Linear Tickets

- INT-6636: https://linear.app/rudderstack/issue/INT-6636/rudder-server-add-gate-logic-to-update-296-status-code-to-200-when
- INT-6637: https://linear.app/rudderstack/issue/INT-6637/rudder-server-add-delivery-payload-for-success-scenario-in-reporting

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
