### PR TITLE
fix: apply configured client QPS and Burst settings in restConfig

### DIFF
--- a/processor/internal/pytdeployer/k8s.go
+++ b/processor/internal/pytdeployer/k8s.go
@@ -353,6 +353,25 @@ func newInClusterClientset(conf *config.Config) (kubernetes.Interface, error) {
 }
 
 func restConfig(conf *config.Config) (*rest.Config, error) {
+	cfg, err := loadRestConfig(conf)
+	if err != nil {
+		return nil, err
+	}
+	// client-go's default rate limit (5 QPS, burst 10) is sized for CLI use,
+	// and the limiter is shared by every RunOnEphemeral call on this client.
+	// All Forward traffic funnels through the node-0 processor, and each
+	// in-flight run creates, polls, and deletes objects, so a handful of
+	// concurrent runs exhausts the default budget — queued requests then fail
+	// with "client rate limiter Wait returned an error: rate: Wait(n=1) would
+	// exceed context deadline" before ever reaching the apiserver.
+	cfg.QPS = float32(conf.GetIntVar(50, 1, "Processor.pytDeployer.k8sClientQPS"))
+	cfg.Burst = conf.GetIntVar(100, 1, "Processor.pytDeployer.k8sClientBurst")
+	return cfg, nil
+}
+
+// loadRestConfig builds the raw client config: in-cluster by default, falling
+// back to a kubeconfig file for local dev.
+func loadRestConfig(conf *config.Config) (*rest.Config, error) {
 	if conf.GetBoolVar(true, "Processor.pytDeployer.inCluster", "K8S_IN_CLUSTER") {
 		cfg, err := rest.InClusterConfig()
 		if err != nil {

--- a/processor/internal/pytdeployer/k8s.go
+++ b/processor/internal/pytdeployer/k8s.go
@@ -364,8 +364,8 @@ func restConfig(conf *config.Config) (*rest.Config, error) {
 	// concurrent runs exhausts the default budget — queued requests then fail
 	// with "client rate limiter Wait returned an error: rate: Wait(n=1) would
 	// exceed context deadline" before ever reaching the apiserver.
-	cfg.QPS = float32(conf.GetIntVar(50, 1, "Processor.pytDeployer.k8sClientQPS"))
-	cfg.Burst = conf.GetIntVar(100, 1, "Processor.pytDeployer.k8sClientBurst")
+	cfg.QPS = float32(conf.GetIntVar(10, 1, "Processor.pytDeployer.k8sClientQPS"))
+	cfg.Burst = conf.GetIntVar(20, 1, "Processor.pytDeployer.k8sClientBurst")
 	return cfg, nil
 }
 

--- a/processor/internal/pytdeployer/pytdeployer_test.go
+++ b/processor/internal/pytdeployer/pytdeployer_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"net"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -596,6 +598,42 @@ func TestRunOnEphemeral(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
+	t.Run("applies the configured client QPS/Burst instead of client-go's defaults", func(t *testing.T) {
+		kubeconfig := filepath.Join(t.TempDir(), "kubeconfig")
+		require.NoError(t, os.WriteFile(kubeconfig, []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test
+  name: test
+current-context: test
+users:
+- name: test
+  user:
+    token: dummy
+`), 0o600))
+		conf := config.New()
+		conf.Set("Processor.pytDeployer.inCluster", false)
+		conf.Set("Processor.pytDeployer.kubeConfigPath", kubeconfig)
+
+		cfg, err := restConfig(conf)
+		require.NoError(t, err)
+		require.EqualValues(t, 50, cfg.QPS, "the default must override client-go's 5 QPS")
+		require.Equal(t, 100, cfg.Burst, "the default must override client-go's burst of 10")
+
+		conf.Set("Processor.pytDeployer.k8sClientQPS", 10)
+		conf.Set("Processor.pytDeployer.k8sClientBurst", 20)
+		cfg, err = restConfig(conf)
+		require.NoError(t, err)
+		require.EqualValues(t, 10, cfg.QPS)
+		require.Equal(t, 20, cfg.Burst)
+	})
+
 	t.Run("returns an error when no clientset is injected and no in-cluster/kubeconfig is available", func(t *testing.T) {
 		conf := baseConfig()
 		conf.Set("Processor.pytDeployer.inCluster", false)

--- a/processor/internal/pytdeployer/pytdeployer_test.go
+++ b/processor/internal/pytdeployer/pytdeployer_test.go
@@ -623,15 +623,15 @@ users:
 
 		cfg, err := restConfig(conf)
 		require.NoError(t, err)
-		require.EqualValues(t, 50, cfg.QPS, "the default must override client-go's 5 QPS")
-		require.Equal(t, 100, cfg.Burst, "the default must override client-go's burst of 10")
+		require.EqualValues(t, 10, cfg.QPS, "the default must override client-go's 5 QPS")
+		require.Equal(t, 20, cfg.Burst, "the default must override client-go's burst of 10")
 
-		conf.Set("Processor.pytDeployer.k8sClientQPS", 10)
-		conf.Set("Processor.pytDeployer.k8sClientBurst", 20)
+		conf.Set("Processor.pytDeployer.k8sClientQPS", 30)
+		conf.Set("Processor.pytDeployer.k8sClientBurst", 60)
 		cfg, err = restConfig(conf)
 		require.NoError(t, err)
-		require.EqualValues(t, 10, cfg.QPS)
-		require.Equal(t, 20, cfg.Burst)
+		require.EqualValues(t, 30, cfg.QPS)
+		require.Equal(t, 60, cfg.Burst)
 	})
 
 	t.Run("returns an error when no clientset is injected and no in-cluster/kubeconfig is available", func(t *testing.T) {


### PR DESCRIPTION
# Description

apply configured client QPS and Burst settings in restConfig

## Linear Ticket

-

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
