### PR TITLE
fix(batchrouter): close crash-recovery temp file descriptors

### DIFF
--- a/router/batchrouter/crash_recover_test.go
+++ b/router/batchrouter/crash_recover_test.go
@@ -1,0 +1,136 @@
+package batchrouter
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/filemanager"
+	"github.com/rudderlabs/rudder-go-kit/filemanager/mock_filemanager"
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	mocksJobsDB "github.com/rudderlabs/rudder-server/mocks/jobsdb"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+)
+
+func TestCrashRecoverClosesFilesAndCleansUp(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, err := misc.GetTmpDir()
+	require.NoError(t, err)
+	recoveryDir := filepath.Join(tmpDir, "rudder-raw-data-dest-upload-crash-recovery")
+	require.NoError(t, os.MkdirAll(recoveryDir, 0o755))
+
+	gzipPayload := func(t *testing.T, lines ...string) []byte {
+		t.Helper()
+		var buf bytes.Buffer
+		zw := gzip.NewWriter(&buf)
+		for _, line := range lines {
+			_, err := zw.Write([]byte(line + "\n"))
+			require.NoError(t, err)
+		}
+		require.NoError(t, zw.Close())
+		return buf.Bytes()
+	}
+
+	t.Run("successful recovery closes download and read handles and removes temp file", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockJobsDB := mocksJobsDB.NewMockJobsDB(ctrl)
+		mockFM := mock_filemanager.NewMockFileManager(ctrl)
+
+		payload, err := jsonrs.Marshal(ObjectStorageDefinition{
+			Config:        map[string]any{"bucketName": "bucket"},
+			Key:           "uploads/file.gz",
+			Provider:      "S3",
+			DestinationID: "dest-1",
+		})
+		require.NoError(t, err)
+
+		mockJobsDB.EXPECT().GetJournalEntries(jobsdb.RawDataDestUploadOperation).Return([]jobsdb.JournalEntryT{
+			{OpID: 42, OpPayload: payload},
+		})
+		mockJobsDB.EXPECT().JournalDeleteEntry(int64(42))
+
+		content := gzipPayload(t, `{"messageId":"msg-1"}`, `{"messageId":"msg-2"}`)
+		mockFM.EXPECT().Download(gomock.Any(), gomock.Any(), "uploads/file.gz").DoAndReturn(
+			func(_ context.Context, w io.WriterAt, _ string, _ ...filemanager.DownloadOption) error {
+				_, err := w.WriteAt(content, 0)
+				return err
+			},
+		)
+
+		before, err := os.ReadDir(recoveryDir)
+		require.NoError(t, err)
+		beforeCount := len(before)
+
+		brt := &Handle{
+			destType:                 "S3",
+			logger:                   logger.NOP,
+			conf:                     config.New(),
+			jobsDB:                   mockJobsDB,
+			uploadedRawDataJobsCache: make(map[string]map[string]bool),
+			fileManagerFactory: func(_ *filemanager.Settings) (filemanager.FileManager, error) {
+				return mockFM, nil
+			},
+		}
+		brt.crashRecover()
+
+		require.True(t, brt.uploadedRawDataJobsCache["dest-1"]["msg-1"])
+		require.True(t, brt.uploadedRawDataJobsCache["dest-1"]["msg-2"])
+
+		after, err := os.ReadDir(recoveryDir)
+		require.NoError(t, err)
+		require.Equal(t, beforeCount, len(after), "temp recovery files must be removed")
+	})
+
+	t.Run("download failure closes create handle and removes temp file", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockJobsDB := mocksJobsDB.NewMockJobsDB(ctrl)
+		mockFM := mock_filemanager.NewMockFileManager(ctrl)
+
+		payload, err := jsonrs.Marshal(ObjectStorageDefinition{
+			Config:        map[string]any{"bucketName": "bucket"},
+			Key:           "uploads/missing.gz",
+			Provider:      "S3",
+			DestinationID: "dest-2",
+		})
+		require.NoError(t, err)
+
+		mockJobsDB.EXPECT().GetJournalEntries(jobsdb.RawDataDestUploadOperation).Return([]jobsdb.JournalEntryT{
+			{OpID: 99, OpPayload: payload},
+		})
+		mockJobsDB.EXPECT().JournalDeleteEntry(int64(99))
+		mockFM.EXPECT().Download(gomock.Any(), gomock.Any(), "uploads/missing.gz").Return(os.ErrNotExist)
+
+		before, err := os.ReadDir(recoveryDir)
+		require.NoError(t, err)
+		beforeCount := len(before)
+
+		brt := &Handle{
+			destType:                 "S3",
+			logger:                   logger.NOP,
+			conf:                     config.New(),
+			jobsDB:                   mockJobsDB,
+			uploadedRawDataJobsCache: make(map[string]map[string]bool),
+			fileManagerFactory: func(_ *filemanager.Settings) (filemanager.FileManager, error) {
+				return mockFM, nil
+			},
+		}
+		brt.crashRecover()
+
+		after, err := os.ReadDir(recoveryDir)
+		require.NoError(t, err)
+		require.Equal(t, beforeCount, len(after), "temp recovery files must be removed on download failure")
+		require.Empty(t, brt.uploadedRawDataJobsCache)
+	})
+}

--- a/router/batchrouter/handle_lifecycle.go
+++ b/router/batchrouter/handle_lifecycle.go
@@ -337,19 +337,23 @@ func (brt *Handle) crashRecover() {
 
 			err = downloader.Download(context.TODO(), jsonFile, objKey)
 			if err != nil {
+				_ = jsonFile.Close()
+				_ = os.Remove(jsonPath)
 				brt.logger.Errorn("BRT: Failed to download data for incomplete journal entry to recover from", logger.NewStringField("provider", object.Provider), logger.NewStringField("key", object.Key), obskit.Error(err))
 				brt.jobsDB.JournalDeleteEntry(entry.OpID)
 				continue
 			}
 
 			_ = jsonFile.Close()
-			defer func() { _ = os.Remove(jsonPath) }()
 			rawf, err := os.Open(jsonPath)
 			if err != nil {
+				_ = os.Remove(jsonPath)
 				panic(err)
 			}
 			reader, err := gzip.NewReader(rawf)
 			if err != nil {
+				_ = rawf.Close()
+				_ = os.Remove(jsonPath)
 				panic(err)
 			}
 
@@ -365,6 +369,8 @@ func (brt *Handle) crashRecover() {
 				brt.uploadedRawDataJobsCache[object.DestinationID][eventID] = true
 			}
 			_ = reader.Close()
+			_ = rawf.Close()
+			_ = os.Remove(jsonPath)
 			brt.jobsDB.JournalDeleteEntry(entry.OpID)
 		}
 	}


### PR DESCRIPTION
## Summary
- On download failure, `crashRecover` continued without closing the created temp file (FD leak + leftover file)
- On success it opened the gzip for read but never closed the underlying `*os.File` (`gzip.Reader.Close` does not close it)
- Close both handles, remove temp files immediately (instead of stacking `defer` in a loop), and add unit tests covering success and download-failure paths

This is distinct from #7071 (batchrouter `upload()`), which covers a different code path.

## Test plan
- [x] `go test ./router/batchrouter/ -run TestCrashRecoverClosesFilesAndCleansUp -v`

## Security
- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.