### PR TITLE
fix: pyt contract tests data race

### DIFF
--- a/integration_test/pytransformer_contract/backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/backwards_compatibility_test.go
@@ -2017,6 +2017,7 @@ def transformEvent(event, metadata):
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
 
 	// Collect all config backend entries for the shared config backend.
 	// Subtests with zero-value config are not registered — the config backend

--- a/integration_test/pytransformer_contract/base_test.go
+++ b/integration_test/pytransformer_contract/base_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
@@ -89,6 +90,7 @@ def transformEvent(event, metadata):
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
 
 	t.Log("Starting mock config backend...")
 	configBackend := newContractConfigBackend(t, map[string]configBackendEntry{

--- a/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
@@ -1306,6 +1306,7 @@ def transformEvent(event, metadata):
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
 
 	// Start rudder-geolocation container (starts MinIO internally and uploads test MMDB).
 	geoContainer, geoURL := startRudderGeolocation(t, pool)
@@ -1566,6 +1567,7 @@ def transformBatch(events, metadata):
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
 
 	// Collect all config backend entries.
 	allEntries := make(map[string]configBackendEntry, len(subtests))
@@ -2385,6 +2387,7 @@ def transformEvent(event, metadata):
 
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
+	pool.MaxWait = 2 * time.Minute
 
 	// Collect all config backend entries.
 	allEntries := make(map[string]configBackendEntry, len(subtests))


### PR DESCRIPTION
# Description

A simple fix for some occasional data races.

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-3239/pyt-contract-tests-data-races) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
