### PR TITLE
chore(jobsdb): multi-consumer compaction improvements

### DIFF
--- a/jobsdb/jobsdb_compaction.go
+++ b/jobsdb/jobsdb_compaction.go
@@ -606,7 +606,19 @@ func (jd *Handle) doCompaction(ctx context.Context) error {
 	}
 	release()
 
-	compactionList, err := jd.getCompactionList(dsList, jd.lastCompactionProbeIndex, jd.maintenanceDB())
+	// The probe's terminal-job subquery groups the status table, which the planner always costs
+	// at a fixed rows=200. On multi-consumer datasets that misestimate makes it pick a nested
+	// loop over the jobs table, one probe per job; a hash or merge join is ~2x cheaper and
+	// doesn't scale with the job count. No-op for single-consumer probes, which don't join.
+	var compactionList compactionListResult
+	err = jd.withMaintenanceTx(ctx, func(tx *Tx) error {
+		if _, err := tx.ExecContext(ctx, `SET LOCAL enable_nestloop = off`); err != nil {
+			return fmt.Errorf("disable nestloop for compaction probe: %w", err)
+		}
+		var err error
+		compactionList, err = jd.getCompactionList(dsList, jd.lastCompactionProbeIndex, tx)
+		return err
+	})
 	jd.lastCompactionProbeIndex = nil
 	if err != nil {
 		return fmt.Errorf("could not get compaction list: %w", err)

--- a/jobsdb/jobsdb_dataset_ddl.go
+++ b/jobsdb/jobsdb_dataset_ddl.go
@@ -17,6 +17,11 @@ import (
 	. "github.com/rudderlabs/rudder-server/utils/tx" //nolint:staticcheck
 )
 
+// Jobs and job status tables are append-only, so only insert-driven autovacuum ever fires on
+// them. Its default scale factor of 0.2 lets a table grow 20% between vacuums, leaving the
+// visibility map that stale and costing every index-only scan a heap fetch for those rows.
+const dsAutovacuumOptions = `WITH (autovacuum_vacuum_insert_scale_factor = 0.02)`
+
 func (jd *Handle) checkIfFullDSInTx(tx *Tx, ds dataSetT) (bool, error) {
 	var (
 		minJobCreatedAt sql.NullTime
@@ -162,7 +167,7 @@ func (jd *Handle) createDSTablesInTx(ctx context.Context, tx *Tx, newDS dataSetT
 		event_count INTEGER NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
 		expire_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-		consumers TEXT[] NOT NULL DEFAULT '{""}');`, newDS.JobTable)); err != nil {
+		consumers TEXT[] NOT NULL DEFAULT '{""}') `+dsAutovacuumOptions+`;`, newDS.JobTable)); err != nil {
 		return fmt.Errorf("creating %s: %w", newDS.JobTable, err)
 	}
 
@@ -176,7 +181,7 @@ func (jd *Handle) createDSTablesInTx(ctx context.Context, tx *Tx, newDS dataSetT
 		error_code VARCHAR(32),
 		error_response JSONB DEFAULT '{}'::JSONB,
 		parameters JSONB DEFAULT '{}'::JSONB,
-		consumer TEXT NOT NULL DEFAULT '');`, newDS.JobStatusTable)); err != nil {
+		consumer TEXT NOT NULL DEFAULT '') `+dsAutovacuumOptions+`;`, newDS.JobStatusTable)); err != nil {
 		return fmt.Errorf("creating %s: %w", newDS.JobStatusTable, err)
 	}
 
@@ -222,6 +227,13 @@ func (jd *Handle) createDSJobIndicesInTx(ctx context.Context, tx *Tx, newDS data
 	if jd.conf.multiConsumer {
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_consumers" ON %[1]q USING GIN (consumers)`, newDS.JobTable)); err != nil {
 			return fmt.Errorf("creating consumers GIN index: %w", err)
+		}
+		// Serves the compaction probe (checkIfCompactDS), which joins the jobs table only to
+		// evaluate array_length(consumers, 1) per job. INCLUDE keeps consumers as a real column,
+		// so that join side stays index-only and skips the heap entirely, roughly halving its
+		// cost. Single-consumer probes don't join the jobs table, hence multiConsumer only.
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX "idx_%[1]s_jid_c" ON %[1]q (job_id) INCLUDE (consumers)`, newDS.JobTable)); err != nil {
+			return fmt.Errorf("creating job_id/consumers covering index: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
# Description

Performance optimizations around the compaction probe (`checkIfCompactDS`):

- Disabling nested loops in order to force a hash/merge join during the compaction probing query. The planner always estimates the terminal-job subquery at 200 rows, no matter the actual count, so it ends up probing the jobs table once per job.
- Adding a `(job_id) INCLUDE (consumers)` index on multi-consumer jobs tables. The join only needs `array_length(consumers, 1)`, so with `consumers` in the index that side stays index-only and skips the heap.
- Lowering `autovacuum_vacuum_insert_scale_factor` to 0.02 on new jobs and job status tables. They're append-only, so only insert-driven autovacuum ever runs on them, and the 0.2 default lets them grow 20% between vacuums — leaving the visibility map that stale and costing every index-only scan a heap fetch for those rows.

Measured on a couple of live datasets, the probe went from ~4.1 to ~2.4 µs per job.

Existing datasets keep the old plan until compaction creates new ones — the index and the autovacuum setting only apply to newly created tables.

## Linear Ticket

Resolves PIPE-3240

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
