### PR TITLE
fix: harden warehouse SQL identifier quoting

### DIFF
--- a/integration_test/bqstreamallevents/bqstreamallevents_test.go
+++ b/integration_test/bqstreamallevents/bqstreamallevents_test.go
@@ -572,8 +572,6 @@ func TestBQStreamAllEvents(t *testing.T) {
 		require.NoError(t, <-done)
 	})
 	t.Run("schema modified after stream writer creation (table deleted)", func(t *testing.T) {
-		t.Skip("BigQuery Storage Write API default streams can keep returning NotFound after deleting and recreating a table with the same name.")
-
 		postgresContainer, gatewayPort := initializeTestEnvironment(t)
 		namespace := randSchema()
 		safeNamespace := whutils.ToSafeNamespace(whutils.BQStreamAllEvents, namespace)

--- a/integration_test/bqstreamallevents/bqstreamallevents_test.go
+++ b/integration_test/bqstreamallevents/bqstreamallevents_test.go
@@ -572,6 +572,8 @@ func TestBQStreamAllEvents(t *testing.T) {
 		require.NoError(t, <-done)
 	})
 	t.Run("schema modified after stream writer creation (table deleted)", func(t *testing.T) {
+		t.Skip("BigQuery Storage Write API default streams can keep returning NotFound after deleting and recreating a table with the same name.")
+
 		postgresContainer, gatewayPort := initializeTestEnvironment(t)
 		namespace := randSchema()
 		safeNamespace := whutils.ToSafeNamespace(whutils.BQStreamAllEvents, namespace)

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -533,65 +533,42 @@ func startRudderPytransformer(
 ) string {
 	t.Helper()
 	const containerPort = "8080"
-	var lastErr error
-	for attempt := 1; attempt <= 3; attempt++ {
-		cfg := newContainerConfig(t, containerPort)
-		env := []string{
-			"CONFIG_BACKEND_URL=" + toContainerURL(configBackendURL),
-			"UVICORN_PORT=" + cfg.portStr(containerPort),
-		}
-		// With host networking (Linux/CI) all containers share the same network
-		// namespace. This helper does not scrape Prometheus metrics, so let the OS
-		// pick an unused metrics port inside the container instead of racing on a
-		// host-side "free port" probe.
-		if runtime.GOOS != "darwin" {
-			env = append(env, "METRICS_PORT=0")
-		}
-		for _, e := range extraEnv {
-			env = append(env, toContainerURL(e))
-		}
-
-		container, err := pool.RunWithOptions(&dockertest.RunOptions{
-			Repository:   "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-pytransformer",
-			Tag:          "main", // todo: use latest after merging https://github.com/rudderlabs/rudder-pytransformer/pull/76
-			Auth:         registry.AuthConfiguration(),
-			Env:          env,
-			ExtraHosts:   cfg.ExtraHosts,
-			PortBindings: cfg.PortBindings,
-		}, cfg.hostConfigFn)
-		require.NoError(t, err, "failed to start rudder-pytransformer container")
-
-		purged := false
-		purge := func() {
-			if purged {
-				return
-			}
-			purged = true
-			if err := pool.Purge(container); err != nil {
-				t.Logf("Failed to purge pytransformer container: %v", err)
-			}
-		}
-		t.Cleanup(purge)
-
-		pyURL := cfg.url(container, containerPort)
-		err = waitForHealthyErr(pool, pyURL, "rudder-pytransformer")
-		if err == nil {
-			t.Logf("rudder-pytransformer is healthy at %s", pyURL)
-			return pyURL
-		}
-		lastErr = err
-
-		logs := containerLogs(t, pool, container, "rudder-pytransformer")
-		if strings.Contains(strings.ToLower(logs), "address already in use") && attempt < 3 {
-			t.Logf("Retrying rudder-pytransformer startup after host port collision (attempt %d): %v", attempt, err)
-			purge()
-			continue
-		}
-		dumpContainerLogs(t, pool, container, "rudder-pytransformer")
-		break
+	cfg := newContainerConfig(t, containerPort)
+	env := []string{
+		"CONFIG_BACKEND_URL=" + toContainerURL(configBackendURL),
+		"UVICORN_PORT=" + cfg.portStr(containerPort),
 	}
-	require.NoError(t, lastErr, "rudder-pytransformer failed to become healthy")
-	return ""
+	// With host networking (Linux/CI) all containers share the same network
+	// namespace. This helper does not scrape Prometheus metrics, so let the OS
+	// pick an unused metrics port inside the container instead of racing on a
+	// host-side "free port" probe.
+	if runtime.GOOS != "darwin" {
+		env = append(env, "METRICS_PORT=0")
+	}
+	for _, e := range extraEnv {
+		env = append(env, toContainerURL(e))
+	}
+
+	container, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository:   "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-pytransformer",
+		Tag:          "main", // todo: use latest after merging https://github.com/rudderlabs/rudder-pytransformer/pull/76
+		Auth:         registry.AuthConfiguration(),
+		Env:          env,
+		ExtraHosts:   cfg.ExtraHosts,
+		PortBindings: cfg.PortBindings,
+	}, cfg.hostConfigFn)
+	require.NoError(t, err, "failed to start rudder-pytransformer container")
+
+	t.Cleanup(func() {
+		if err := pool.Purge(container); err != nil {
+			t.Logf("Failed to purge pytransformer container: %v", err)
+		}
+	})
+
+	pyURL := cfg.url(container, containerPort)
+	waitForHealthy(t, pool, pyURL, "rudder-pytransformer", container)
+
+	return pyURL
 }
 
 // waitForHealthy polls a service's /health endpoint until it returns 200 OK.
@@ -600,16 +577,7 @@ func startRudderPytransformer(
 func waitForHealthy(t *testing.T, pool *dockertest.Pool, baseURL, name string, containers ...*dockertest.Resource) {
 	t.Helper()
 	t.Logf("Waiting for %s at %s to be healthy...", name, baseURL)
-	err := waitForHealthyErr(pool, baseURL, name)
-	if err != nil && len(containers) > 0 {
-		dumpContainerLogs(t, pool, containers[0], name)
-	}
-	require.NoError(t, err, "%s failed to become healthy", name)
-	t.Logf("%s is healthy at %s", name, baseURL)
-}
-
-func waitForHealthyErr(pool *dockertest.Pool, baseURL, name string) error {
-	return pool.Retry(func() error {
+	err := pool.Retry(func() error {
 		resp, err := http.Get(baseURL + "/health")
 		if err != nil {
 			return err
@@ -621,12 +589,17 @@ func waitForHealthyErr(pool *dockertest.Pool, baseURL, name string) error {
 		}
 		return nil
 	})
+	if err != nil && len(containers) > 0 {
+		dumpContainerLogs(t, pool, containers[0], name)
+	}
+	require.NoError(t, err, "%s failed to become healthy", name)
+	t.Logf("%s is healthy at %s", name, baseURL)
 }
 
 // dumpContainerLogs inspects a container's state and prints its last 100 log
 // lines. This is called when a health check fails so CI output contains enough
 // context to diagnose startup issues.
-func dumpContainerLogs(t testing.TB, pool *dockertest.Pool, container *dockertest.Resource, name string) {
+func dumpContainerLogs(t *testing.T, pool *dockertest.Pool, container *dockertest.Resource, name string) {
 	t.Helper()
 
 	info, err := pool.Client.InspectContainer(container.Container.ID)
@@ -637,18 +610,8 @@ func dumpContainerLogs(t testing.TB, pool *dockertest.Pool, container *dockertes
 			name, info.State.Running, info.State.ExitCode, info.State.Status)
 	}
 
-	logs := containerLogs(t, pool, container, name)
-	if logs == "" {
-		return
-	}
-	t.Logf("=== %s container logs ===\n%s=== end %s logs ===", name, logs, name)
-}
-
-func containerLogs(t testing.TB, pool *dockertest.Pool, container *dockertest.Resource, name string) string {
-	t.Helper()
-
 	var buf bytes.Buffer
-	err := pool.Client.Logs(docker.LogsOptions{
+	err = pool.Client.Logs(docker.LogsOptions{
 		Container:    container.Container.ID,
 		OutputStream: &buf,
 		ErrorStream:  &buf,
@@ -658,9 +621,9 @@ func containerLogs(t testing.TB, pool *dockertest.Pool, container *dockertest.Re
 	})
 	if err != nil {
 		t.Logf("Failed to fetch %s container logs: %v", name, err)
-		return ""
+		return
 	}
-	return buf.String()
+	t.Logf("=== %s container logs ===\n%s=== end %s logs ===", name, buf.String(), name)
 }
 
 // pollOpenFaasFlaskHealthy polls the openfaas-flask-base fwatchdog health

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -248,6 +248,24 @@ func makeEventWithCredentials(messageID, versionID string, credentials []types.C
 	return ev
 }
 
+// makeEvents creates n TransformerEvents for versionID, optionally carrying library version ids.
+//
+// Message ids are prefixed with versionID so a test sharing one mock config backend across
+// subtests can scope its assertions to its own requests.
+func makeEvents(versionID string, n int, libraryVersionIDs ...string) []types.TransformerEvent {
+	libraries := make([]backendconfig.LibraryT, len(libraryVersionIDs))
+	for i, id := range libraryVersionIDs {
+		libraries[i] = backendconfig.LibraryT{VersionID: id}
+	}
+
+	events := make([]types.TransformerEvent, n)
+	for i := range events {
+		events[i] = makeEvent(fmt.Sprintf("%s-msg-%d", versionID, i+1), versionID)
+		events[i].Libraries = libraries
+	}
+	return events
+}
+
 // configBackendEntry controls what the mock config backend returns for a given versionId.
 //
 // When statusCode is 0 (default), the entry is treated as a normal transformation:

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -248,24 +248,6 @@ func makeEventWithCredentials(messageID, versionID string, credentials []types.C
 	return ev
 }
 
-// makeEvents creates n TransformerEvents for versionID, optionally carrying library version ids.
-//
-// Message ids are prefixed with versionID so a test sharing one mock config backend across
-// subtests can scope its assertions to its own requests.
-func makeEvents(versionID string, n int, libraryVersionIDs ...string) []types.TransformerEvent {
-	libraries := make([]backendconfig.LibraryT, len(libraryVersionIDs))
-	for i, id := range libraryVersionIDs {
-		libraries[i] = backendconfig.LibraryT{VersionID: id}
-	}
-
-	events := make([]types.TransformerEvent, n)
-	for i := range events {
-		events[i] = makeEvent(fmt.Sprintf("%s-msg-%d", versionID, i+1), versionID)
-		events[i].Libraries = libraries
-	}
-	return events
-}
-
 // configBackendEntry controls what the mock config backend returns for a given versionId.
 //
 // When statusCode is 0 (default), the entry is treated as a normal transformation:

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -533,42 +533,65 @@ func startRudderPytransformer(
 ) string {
 	t.Helper()
 	const containerPort = "8080"
-	cfg := newContainerConfig(t, containerPort)
-	env := []string{
-		"CONFIG_BACKEND_URL=" + toContainerURL(configBackendURL),
-		"UVICORN_PORT=" + cfg.portStr(containerPort),
-	}
-	// With host networking (Linux/CI) all containers share the same network
-	// namespace. This helper does not scrape Prometheus metrics, so let the OS
-	// pick an unused metrics port inside the container instead of racing on a
-	// host-side "free port" probe.
-	if runtime.GOOS != "darwin" {
-		env = append(env, "METRICS_PORT=0")
-	}
-	for _, e := range extraEnv {
-		env = append(env, toContainerURL(e))
-	}
-
-	container, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository:   "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-pytransformer",
-		Tag:          "main", // todo: use latest after merging https://github.com/rudderlabs/rudder-pytransformer/pull/76
-		Auth:         registry.AuthConfiguration(),
-		Env:          env,
-		ExtraHosts:   cfg.ExtraHosts,
-		PortBindings: cfg.PortBindings,
-	}, cfg.hostConfigFn)
-	require.NoError(t, err, "failed to start rudder-pytransformer container")
-
-	t.Cleanup(func() {
-		if err := pool.Purge(container); err != nil {
-			t.Logf("Failed to purge pytransformer container: %v", err)
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		cfg := newContainerConfig(t, containerPort)
+		env := []string{
+			"CONFIG_BACKEND_URL=" + toContainerURL(configBackendURL),
+			"UVICORN_PORT=" + cfg.portStr(containerPort),
 		}
-	})
+		// With host networking (Linux/CI) all containers share the same network
+		// namespace. This helper does not scrape Prometheus metrics, so let the OS
+		// pick an unused metrics port inside the container instead of racing on a
+		// host-side "free port" probe.
+		if runtime.GOOS != "darwin" {
+			env = append(env, "METRICS_PORT=0")
+		}
+		for _, e := range extraEnv {
+			env = append(env, toContainerURL(e))
+		}
 
-	pyURL := cfg.url(container, containerPort)
-	waitForHealthy(t, pool, pyURL, "rudder-pytransformer", container)
+		container, err := pool.RunWithOptions(&dockertest.RunOptions{
+			Repository:   "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-pytransformer",
+			Tag:          "main", // todo: use latest after merging https://github.com/rudderlabs/rudder-pytransformer/pull/76
+			Auth:         registry.AuthConfiguration(),
+			Env:          env,
+			ExtraHosts:   cfg.ExtraHosts,
+			PortBindings: cfg.PortBindings,
+		}, cfg.hostConfigFn)
+		require.NoError(t, err, "failed to start rudder-pytransformer container")
 
-	return pyURL
+		purged := false
+		purge := func() {
+			if purged {
+				return
+			}
+			purged = true
+			if err := pool.Purge(container); err != nil {
+				t.Logf("Failed to purge pytransformer container: %v", err)
+			}
+		}
+		t.Cleanup(purge)
+
+		pyURL := cfg.url(container, containerPort)
+		err = waitForHealthyErr(pool, pyURL, "rudder-pytransformer")
+		if err == nil {
+			t.Logf("rudder-pytransformer is healthy at %s", pyURL)
+			return pyURL
+		}
+		lastErr = err
+
+		logs := containerLogs(t, pool, container, "rudder-pytransformer")
+		if strings.Contains(strings.ToLower(logs), "address already in use") && attempt < 3 {
+			t.Logf("Retrying rudder-pytransformer startup after host port collision (attempt %d): %v", attempt, err)
+			purge()
+			continue
+		}
+		dumpContainerLogs(t, pool, container, "rudder-pytransformer")
+		break
+	}
+	require.NoError(t, lastErr, "rudder-pytransformer failed to become healthy")
+	return ""
 }
 
 // waitForHealthy polls a service's /health endpoint until it returns 200 OK.
@@ -577,7 +600,16 @@ func startRudderPytransformer(
 func waitForHealthy(t *testing.T, pool *dockertest.Pool, baseURL, name string, containers ...*dockertest.Resource) {
 	t.Helper()
 	t.Logf("Waiting for %s at %s to be healthy...", name, baseURL)
-	err := pool.Retry(func() error {
+	err := waitForHealthyErr(pool, baseURL, name)
+	if err != nil && len(containers) > 0 {
+		dumpContainerLogs(t, pool, containers[0], name)
+	}
+	require.NoError(t, err, "%s failed to become healthy", name)
+	t.Logf("%s is healthy at %s", name, baseURL)
+}
+
+func waitForHealthyErr(pool *dockertest.Pool, baseURL, name string) error {
+	return pool.Retry(func() error {
 		resp, err := http.Get(baseURL + "/health")
 		if err != nil {
 			return err
@@ -589,17 +621,12 @@ func waitForHealthy(t *testing.T, pool *dockertest.Pool, baseURL, name string, c
 		}
 		return nil
 	})
-	if err != nil && len(containers) > 0 {
-		dumpContainerLogs(t, pool, containers[0], name)
-	}
-	require.NoError(t, err, "%s failed to become healthy", name)
-	t.Logf("%s is healthy at %s", name, baseURL)
 }
 
 // dumpContainerLogs inspects a container's state and prints its last 100 log
 // lines. This is called when a health check fails so CI output contains enough
 // context to diagnose startup issues.
-func dumpContainerLogs(t *testing.T, pool *dockertest.Pool, container *dockertest.Resource, name string) {
+func dumpContainerLogs(t testing.TB, pool *dockertest.Pool, container *dockertest.Resource, name string) {
 	t.Helper()
 
 	info, err := pool.Client.InspectContainer(container.Container.ID)
@@ -610,8 +637,18 @@ func dumpContainerLogs(t *testing.T, pool *dockertest.Pool, container *dockertes
 			name, info.State.Running, info.State.ExitCode, info.State.Status)
 	}
 
+	logs := containerLogs(t, pool, container, name)
+	if logs == "" {
+		return
+	}
+	t.Logf("=== %s container logs ===\n%s=== end %s logs ===", name, logs, name)
+}
+
+func containerLogs(t testing.TB, pool *dockertest.Pool, container *dockertest.Resource, name string) string {
+	t.Helper()
+
 	var buf bytes.Buffer
-	err = pool.Client.Logs(docker.LogsOptions{
+	err := pool.Client.Logs(docker.LogsOptions{
 		Container:    container.Container.ID,
 		OutputStream: &buf,
 		ErrorStream:  &buf,
@@ -621,9 +658,9 @@ func dumpContainerLogs(t *testing.T, pool *dockertest.Pool, container *dockertes
 	})
 	if err != nil {
 		t.Logf("Failed to fetch %s container logs: %v", name, err)
-		return
+		return ""
 	}
-	t.Logf("=== %s container logs ===\n%s=== end %s logs ===", name, buf.String(), name)
+	return buf.String()
 }
 
 // pollOpenFaasFlaskHealthy polls the openfaas-flask-base fwatchdog health

--- a/warehouse/integrations/azure-synapse/azure-synapse.go
+++ b/warehouse/integrations/azure-synapse/azure-synapse.go
@@ -202,7 +202,7 @@ func (as *AzureSynapse) connectionCredentials() *credentials {
 
 func columnsWithDataTypes(columns model.TableSchema, prefix string) string {
 	formattedColumns := lo.MapToSlice(columns, func(name, dataType string) string {
-		return fmt.Sprintf(`"%s%s" %s`, prefix, name, rudderDataTypesMapToAzureSynapse[dataType])
+		return fmt.Sprintf(`%s %s`, warehouseutils.BracketQuoteIdentifier(prefix+name), rudderDataTypesMapToAzureSynapse[dataType])
 	})
 	return strings.Join(formattedColumns, ",")
 }
@@ -253,12 +253,11 @@ func (as *AzureSynapse) loadTable(
 	log.Debugn("creating staging table")
 	createStagingTableStmt := fmt.Sprintf(`
 		SELECT
-		  TOP 0 * INTO %[1]s.%[2]s
+		  TOP 0 * INTO %[1]s
 		FROM
-		  %[1]s.%[3]s;`,
-		as.namespace,
-		stagingTableName,
-		tableName,
+		  %[2]s;`,
+		warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName),
+		warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, tableName),
 	)
 	if _, err = as.db.ExecContext(ctx, createStagingTableStmt); err != nil {
 		return nil, "", fmt.Errorf("creating temporary table: %w", err)
@@ -293,7 +292,7 @@ func (as *AzureSynapse) loadTable(
 	})
 
 	log.Debugn("creating prepared stmt for loading data")
-	copyInStmt := mssql.CopyIn(as.namespace+"."+stagingTableName, mssql.BulkOptions{CheckConstraints: false},
+	copyInStmt := mssql.CopyIn(warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName), mssql.BulkOptions{CheckConstraints: false},
 		append(sortedColumnKeys, extraColumns...)...,
 	)
 	stmt, err := txn.PrepareContext(ctx, copyInStmt)
@@ -555,32 +554,29 @@ func (as *AzureSynapse) deleteFromLoadTable(
 		primaryKey = column
 	}
 
-	var additionalJoinClause string
+	var additionalDeleteStmtClause string
 	if tableName == warehouseutils.DiscardsTable {
-		additionalJoinClause = fmt.Sprintf(`AND _source.%[3]s = %[1]q.%[2]q.%[3]q AND _source.%[4]s = %[1]q.%[2]q.%[4]q`,
-			as.namespace,
-			tableName,
-			"table_name",
-			"column_name",
+		additionalDeleteStmtClause = fmt.Sprintf(`AND _source.%[2]s = %[1]s.%[2]s AND _source.%[3]s = %[1]s.%[3]s`,
+			warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, tableName),
+			warehouseutils.BracketQuoteIdentifier("table_name"),
+			warehouseutils.BracketQuoteIdentifier("column_name"),
 		)
 	}
 
 	deleteStmt := fmt.Sprintf(`
-		DELETE FROM
-		  %[1]q.%[2]q
-		FROM
-		  %[1]q.%[3]q AS _source
-		WHERE
-		  (
-			_source.%[4]s = %[1]q.%[2]q.%[4]q %[5]s
-		  );`,
-		as.namespace,
-		tableName,
-		stagingTableName,
-		primaryKey,
-		additionalJoinClause,
+			DELETE FROM
+			  %[1]s
+			FROM
+			  %[2]s AS _source
+			WHERE
+			  (
+				_source.%[3]s = %[1]s.%[3]s %[4]s
+			  );`,
+		warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, tableName),
+		warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName),
+		warehouseutils.BracketQuoteIdentifier(primaryKey),
+		additionalDeleteStmtClause,
 	)
-
 	r, err := txn.ExecContext(ctx, deleteStmt)
 	if err != nil {
 		return 0, fmt.Errorf("deleting from main table: %w", err)
@@ -600,35 +596,34 @@ func (as *AzureSynapse) insertIntoLoadTable(
 		partitionKey = column
 	}
 
-	quotedColumnNames := warehouseutils.DoubleQuoteAndJoinByComma(
+	quotedColumnNames := warehouseutils.BracketQuoteAndJoinByComma(
 		sortedColumnKeys,
 	)
 
 	insertStmt := fmt.Sprintf(`
-		INSERT INTO %[1]q.%[2]q (%[3]s)
-		SELECT
-		  %[3]s
-		FROM
-		  (
+			INSERT INTO %[1]s (%[3]s)
 			SELECT
-			  *,
-			  ROW_NUMBER() OVER (
-				PARTITION BY %[5]s
-				ORDER BY
-				  received_at DESC
-			  ) AS _rudder_staging_row_number
+			  %[3]s
 			FROM
-			  %[1]q.%[4]q
-		  ) AS _
-		WHERE
-		  _rudder_staging_row_number = 1;`,
-		as.namespace,
-		tableName,
+			  (
+				SELECT
+				  *,
+				  ROW_NUMBER() OVER (
+					PARTITION BY %[4]s
+					ORDER BY
+					  %[5]s DESC
+				  ) AS _rudder_staging_row_number
+				FROM
+				  %[2]s
+			  ) AS _
+			WHERE
+			  _rudder_staging_row_number = 1;`,
+		warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, tableName),
+		warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName),
 		quotedColumnNames,
-		stagingTableName,
-		partitionKey,
+		warehouseutils.QuoteCommaSeparatedIdentifiers(partitionKey, warehouseutils.BracketQuoteIdentifier),
+		warehouseutils.BracketQuoteIdentifier("received_at"),
 	)
-
 	r, err := txn.ExecContext(ctx, insertStmt)
 	if err != nil {
 		return 0, fmt.Errorf("inserting intomain table: %w", err)
@@ -682,15 +677,15 @@ func (as *AzureSynapse) loadUserTables(ctx context.Context) (errorMap map[string
 		if colName == "id" {
 			continue
 		}
-		userColNames = append(userColNames, fmt.Sprintf(`%q`, colName))
+		userColNames = append(userColNames, warehouseutils.BracketQuoteIdentifier(colName))
 		caseSubQuery := fmt.Sprintf(`case
 						  when (exists(select 1)) then (
-						  	select top 1 %[1]q from %[2]s
-						  	where x.id = %[2]s.id
-							  and %[1]q is not null
+								select top 1 %[1]s from %[2]s
+								where x.[id] = %[2]s.[id]
+							  and %[1]s is not null
 							order by received_at desc
 							)
-						  end as %[1]q`, colName, as.namespace+"."+unionStagingTableName)
+						  end as %[1]s`, warehouseutils.BracketQuoteIdentifier(colName), warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, unionStagingTableName))
 		// IGNORE NULLS only supported in Azure SQL edge, in which case the query can be shortened to below
 		// https://docs.microsoft.com/en-us/sql/t-sql/functions/first-value-transact-sql?view=sql-server-ver15
 		// caseSubQuery := fmt.Sprintf(`FIRST_VALUE(%[1]s) IGNORE NULLS OVER (PARTITION BY id ORDER BY received_at DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "%[1]s"`, colName)
@@ -700,12 +695,12 @@ func (as *AzureSynapse) loadUserTables(ctx context.Context) (errorMap map[string
 	// TODO: skipped top level temporary table for now
 	sqlStatement := fmt.Sprintf(`SELECT * into %[5]s FROM
 												((
-													SELECT id, %[4]s FROM %[2]s WHERE id in (SELECT user_id FROM %[3]s WHERE user_id IS NOT NULL)
+													SELECT [id], %[4]s FROM %[2]s WHERE [id] in (SELECT [user_id] FROM %[3]s WHERE [user_id] IS NOT NULL)
 												) UNION
 												(
-													SELECT user_id, %[4]s FROM %[3]s  WHERE user_id IS NOT NULL
+													SELECT [user_id], %[4]s FROM %[3]s  WHERE [user_id] IS NOT NULL
 												)) a
-											`, as.namespace, as.namespace+"."+warehouseutils.UsersTable, as.namespace+"."+identifyStagingTable, strings.Join(userColNames, ","), as.namespace+"."+unionStagingTableName)
+											`, as.namespace, warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, warehouseutils.UsersTable), warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, identifyStagingTable), strings.Join(userColNames, ","), warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, unionStagingTableName))
 
 	as.logger.Debugn("AZ: Creating staging table for union of users table with identify staging table",
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -719,13 +714,13 @@ func (as *AzureSynapse) loadUserTables(ctx context.Context) (errorMap map[string
 	sqlStatement = fmt.Sprintf(`SELECT * INTO %[1]s FROM (SELECT DISTINCT * FROM
 										(
 											SELECT
-											x.id, %[2]s
+											x.[id], %[2]s
 											FROM %[3]s as x
 										) as xyz
 									) a`,
-		as.namespace+"."+stagingTableName,
+		warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName),
 		strings.Join(firstValProps, ","),
-		as.namespace+"."+unionStagingTableName,
+		warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, unionStagingTableName),
 	)
 
 	as.logger.Debugn("AZ: Creating staging table for users",
@@ -749,7 +744,7 @@ func (as *AzureSynapse) loadUserTables(ctx context.Context) (errorMap map[string
 	}
 
 	primaryKey := "id"
-	sqlStatement = fmt.Sprintf(`DELETE FROM %[1]s."%[2]s" FROM %[3]s _source where (_source.%[4]s = %[1]s.%[2]s.%[4]s)`, as.namespace, warehouseutils.UsersTable, as.namespace+"."+stagingTableName, primaryKey)
+	sqlStatement = fmt.Sprintf(`DELETE FROM %[1]s FROM %[2]s _source where (_source.%[3]s = %[1]s.%[3]s)`, warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, warehouseutils.UsersTable), warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName), warehouseutils.BracketQuoteIdentifier(primaryKey))
 	as.logger.Infon("AZ: Dedup records for table using staging table",
 		logger.NewStringField(logfield.TableName, warehouseutils.UsersTable),
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -764,7 +759,7 @@ func (as *AzureSynapse) loadUserTables(ctx context.Context) (errorMap map[string
 		return errorMap
 	}
 
-	sqlStatement = fmt.Sprintf(`INSERT INTO "%[1]s"."%[2]s" (%[4]s) SELECT %[4]s FROM  %[3]s`, as.namespace, warehouseutils.UsersTable, as.namespace+"."+stagingTableName, strings.Join(append([]string{"id"}, userColNames...), ","))
+	sqlStatement = fmt.Sprintf(`INSERT INTO %[1]s (%[3]s) SELECT %[3]s FROM %[2]s`, warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, warehouseutils.UsersTable), warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName), strings.Join(append([]string{warehouseutils.BracketQuoteIdentifier("id")}, userColNames...), ","))
 	as.logger.Infon("AZ: Inserting records for table using staging table",
 		logger.NewStringField(logfield.TableName, warehouseutils.UsersTable),
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -796,12 +791,12 @@ func (*AzureSynapse) DeleteBy(context.Context, []string, warehouseutils.DeleteBy
 }
 
 func (as *AzureSynapse) CreateSchema(ctx context.Context) (err error) {
-	sqlStatement := fmt.Sprintf(`IF NOT EXISTS ( SELECT  * FROM  sys.schemas WHERE   name = N'%s' )
-    EXEC('CREATE SCHEMA [%s]');`, as.namespace, as.namespace)
+	createSchemaStatement := fmt.Sprintf(`CREATE SCHEMA %s`, warehouseutils.BracketQuoteIdentifier(as.namespace))
+	sqlStatement := fmt.Sprintf(`IF NOT EXISTS ( SELECT * FROM sys.schemas WHERE name = N%s )
+	    EXEC(%s);`, warehouseutils.SQLStringLiteral(as.namespace), warehouseutils.SQLStringLiteral(createSchemaStatement))
 	as.logger.Infon("SYNAPSE: Creating schema name in synapse for AZ",
 		logger.NewStringField(logfield.DestinationID, as.warehouse.Destination.ID),
-		logger.NewStringField(logfield.Query, sqlStatement),
-	)
+		logger.NewStringField(logfield.Query, sqlStatement))
 	_, err = as.db.ExecContext(ctx, sqlStatement)
 	if errors.Is(err, io.EOF) {
 		return nil
@@ -813,40 +808,40 @@ func (as *AzureSynapse) dropStagingTable(ctx context.Context, stagingTableName s
 	as.logger.Infon("AZ: dropping table",
 		logger.NewStringField(logfield.TableName, stagingTableName),
 	)
-	_, err := as.db.ExecContext(ctx, fmt.Sprintf(`IF OBJECT_ID ('%[1]s','U') IS NOT NULL DROP TABLE %[1]s;`, as.namespace+"."+stagingTableName))
+	_, err := as.db.ExecContext(ctx, fmt.Sprintf(`IF OBJECT_ID (%s,'U') IS NOT NULL DROP TABLE %s;`, warehouseutils.SQLStringLiteral(as.namespace+"."+stagingTableName), warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName)))
 	if err != nil {
 		as.logger.Errorn("AZ: Error dropping staging table in synapse",
-			logger.NewStringField(logfield.TableName, as.namespace+"."+stagingTableName),
+			logger.NewStringField(logfield.TableName, warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName)),
 			obskit.Error(err),
 		)
 	}
 }
 
-func (as *AzureSynapse) createTable(ctx context.Context, name string, columns model.TableSchema) (err error) {
-	sqlStatement := fmt.Sprintf(`IF  NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'%[1]s') AND type = N'U')
-	CREATE TABLE %[1]s ( %v )`, name, columnsWithDataTypes(columns, ""))
+func (as *AzureSynapse) createTable(ctx context.Context, tableName string, columns model.TableSchema) (err error) {
+	tableIdentifier := warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, tableName)
+	sqlStatement := fmt.Sprintf(`IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N%s) AND type = N'U')
+		CREATE TABLE %s ( %v )`, warehouseutils.SQLStringLiteral(as.namespace+"."+tableName), tableIdentifier, columnsWithDataTypes(columns, ""))
 
 	as.logger.Infon("AZ: Creating table in synapse for AZ",
 		logger.NewStringField(logfield.DestinationID, as.warehouse.Destination.ID),
-		logger.NewStringField(logfield.Query, sqlStatement),
-	)
+		logger.NewStringField(logfield.Query, sqlStatement))
 	_, err = as.db.ExecContext(ctx, sqlStatement)
 	return err
 }
 
 func (as *AzureSynapse) CreateTable(ctx context.Context, tableName string, columnMap model.TableSchema) (err error) {
 	// Search paths doesn't exist unlike Postgres, default is dbo. Hence, use namespace wherever possible
-	err = as.createTable(ctx, as.namespace+"."+tableName, columnMap)
+	err = as.createTable(ctx, tableName, columnMap)
 	return err
 }
 
 func (as *AzureSynapse) DropTable(ctx context.Context, tableName string) (err error) {
-	sqlStatement := `DROP TABLE "%[1]s"."%[2]s"`
+	sqlStatement := `DROP TABLE %s`
 	as.logger.Infon("AZ: Dropping table in synapse for AZ",
 		logger.NewStringField(logfield.DestinationID, as.warehouse.Destination.ID),
 		logger.NewStringField(logfield.Query, sqlStatement),
 	)
-	_, err = as.db.ExecContext(ctx, fmt.Sprintf(sqlStatement, as.namespace, tableName))
+	_, err = as.db.ExecContext(ctx, fmt.Sprintf(sqlStatement, warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, tableName)))
 	return err
 }
 
@@ -858,31 +853,29 @@ func (as *AzureSynapse) AddColumns(ctx context.Context, tableName string, column
 
 	if len(columnsInfo) == 1 {
 		queryBuilder.WriteString(fmt.Sprintf(`
-			IF NOT EXISTS (
-			  SELECT
-				1
-			  FROM
-				SYS.COLUMNS
-			  WHERE
-				OBJECT_ID = OBJECT_ID(N'%[1]s.%[2]s')
-				AND name = '%[3]s'
-			)`,
-			as.namespace,
-			tableName,
-			columnsInfo[0].Name,
+				IF NOT EXISTS (
+				  SELECT
+					1
+				  FROM
+					SYS.COLUMNS
+				  WHERE
+					OBJECT_ID = OBJECT_ID(N%s)
+					AND name = %s
+				)`,
+			warehouseutils.SQLStringLiteral(as.namespace+"."+tableName),
+			warehouseutils.SQLStringLiteral(columnsInfo[0].Name),
 		))
 	}
 
 	queryBuilder.WriteString(fmt.Sprintf(`
-		ALTER TABLE
-		  %s.%s
-		ADD`,
-		as.namespace,
-		tableName,
+			ALTER TABLE
+			  %s
+			ADD`,
+		warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, tableName),
 	))
 
 	for _, columnInfo := range columnsInfo {
-		queryBuilder.WriteString(fmt.Sprintf(` %q %s,`, columnInfo.Name, rudderDataTypesMapToAzureSynapse[columnInfo.Type]))
+		queryBuilder.WriteString(fmt.Sprintf(` %s %s,`, warehouseutils.BracketQuoteIdentifier(columnInfo.Name), rudderDataTypesMapToAzureSynapse[columnInfo.Type]))
 	}
 
 	query = strings.TrimSuffix(queryBuilder.String(), ",")
@@ -891,8 +884,7 @@ func (as *AzureSynapse) AddColumns(ctx context.Context, tableName string, column
 	as.logger.Infon("AZ: Adding columns",
 		logger.NewStringField(logfield.DestinationID, as.warehouse.Destination.ID),
 		logger.NewStringField(logfield.TableName, tableName),
-		logger.NewStringField(logfield.Query, query),
-	)
+		logger.NewStringField(logfield.Query, query))
 	_, err = as.db.ExecContext(ctx, query)
 	return err
 }
@@ -962,7 +954,7 @@ func (as *AzureSynapse) dropDanglingStagingTables(ctx context.Context) error {
 		logger.NewStringField("table_names", strings.Join(stagingTableNames, ", ")),
 	)
 	for _, stagingTableName := range stagingTableNames {
-		_, err := as.db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE "%[1]s"."%[2]s"`, as.namespace, stagingTableName))
+		_, err := as.db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE %s`, warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName)))
 		if err != nil {
 			return fmt.Errorf("dropping dangling staging table %q.%q: %w", as.namespace, stagingTableName, err)
 		}
@@ -1080,10 +1072,9 @@ func (as *AzureSynapse) Connect(_ context.Context, warehouse model.Warehouse) (c
 }
 
 func (as *AzureSynapse) TestLoadTable(ctx context.Context, _, tableName string, payloadMap map[string]any, _ string) (err error) {
-	sqlStatement := fmt.Sprintf(`INSERT INTO %q.%q (%v) VALUES (%s)`,
-		as.namespace,
-		tableName,
-		fmt.Sprintf(`%q, %q`, "id", "val"),
+	sqlStatement := fmt.Sprintf(`INSERT INTO %s (%v) VALUES (%s)`,
+		warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, tableName),
+		warehouseutils.BracketQuoteAndJoinByComma([]string{"id", "val"}),
 		fmt.Sprintf(`'%d', '%s'`, payloadMap["id"], payloadMap["val"]),
 	)
 	_, err = as.db.ExecContext(ctx, sqlStatement)

--- a/warehouse/integrations/azure-synapse/azure-synapse.go
+++ b/warehouse/integrations/azure-synapse/azure-synapse.go
@@ -693,14 +693,14 @@ func (as *AzureSynapse) loadUserTables(ctx context.Context) (errorMap map[string
 	}
 
 	// TODO: skipped top level temporary table for now
-	sqlStatement := fmt.Sprintf(`SELECT * into %[5]s FROM
+	sqlStatement := fmt.Sprintf(`SELECT * into %[4]s FROM
 												((
-													SELECT [id], %[4]s FROM %[2]s WHERE [id] in (SELECT [user_id] FROM %[3]s WHERE [user_id] IS NOT NULL)
+													SELECT [id], %[3]s FROM %[1]s WHERE [id] in (SELECT [user_id] FROM %[2]s WHERE [user_id] IS NOT NULL)
 												) UNION
 												(
-													SELECT [user_id], %[4]s FROM %[3]s  WHERE [user_id] IS NOT NULL
+													SELECT [user_id], %[3]s FROM %[2]s  WHERE [user_id] IS NOT NULL
 												)) a
-											`, as.namespace, warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, warehouseutils.UsersTable), warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, identifyStagingTable), strings.Join(userColNames, ","), warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, unionStagingTableName))
+											`, warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, warehouseutils.UsersTable), warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, identifyStagingTable), strings.Join(userColNames, ","), warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, unionStagingTableName))
 
 	as.logger.Debugn("AZ: Creating staging table for union of users table with identify staging table",
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -925,11 +925,11 @@ func (as *AzureSynapse) dropDanglingStagingTables(ctx context.Context) error {
 		from
 		  information_schema.tables
 		where
-		  table_schema = '%s'
-		  AND table_name like '%s';
+		  table_schema = %s
+		  AND table_name like %s;
 	`,
-		as.namespace,
-		fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider)),
+		warehouseutils.SQLStringLiteral(as.namespace),
+		warehouseutils.SQLStringLiteral(fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider))),
 	)
 	rows, err := as.db.QueryContext(ctx, sqlStatement)
 	if err != nil {

--- a/warehouse/integrations/azure-synapse/azure-synapse.go
+++ b/warehouse/integrations/azure-synapse/azure-synapse.go
@@ -808,7 +808,7 @@ func (as *AzureSynapse) dropStagingTable(ctx context.Context, stagingTableName s
 	as.logger.Infon("AZ: dropping table",
 		logger.NewStringField(logfield.TableName, stagingTableName),
 	)
-	_, err := as.db.ExecContext(ctx, fmt.Sprintf(`IF OBJECT_ID (%s,'U') IS NOT NULL DROP TABLE %s;`, warehouseutils.SQLStringLiteral(as.namespace+"."+stagingTableName), warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName)))
+	_, err := as.db.ExecContext(ctx, fmt.Sprintf(`IF OBJECT_ID (%s,'U') IS NOT NULL DROP TABLE %s;`, warehouseutils.SQLStringLiteral(warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName)), warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName)))
 	if err != nil {
 		as.logger.Errorn("AZ: Error dropping staging table in synapse",
 			logger.NewStringField(logfield.TableName, warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, stagingTableName)),
@@ -820,7 +820,7 @@ func (as *AzureSynapse) dropStagingTable(ctx context.Context, stagingTableName s
 func (as *AzureSynapse) createTable(ctx context.Context, tableName string, columns model.TableSchema) (err error) {
 	tableIdentifier := warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, tableName)
 	sqlStatement := fmt.Sprintf(`IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N%s) AND type = N'U')
-		CREATE TABLE %s ( %v )`, warehouseutils.SQLStringLiteral(as.namespace+"."+tableName), tableIdentifier, columnsWithDataTypes(columns, ""))
+		CREATE TABLE %s ( %v )`, warehouseutils.SQLStringLiteral(warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, tableName)), tableIdentifier, columnsWithDataTypes(columns, ""))
 
 	as.logger.Infon("AZ: Creating table in synapse for AZ",
 		logger.NewStringField(logfield.DestinationID, as.warehouse.Destination.ID),
@@ -862,7 +862,7 @@ func (as *AzureSynapse) AddColumns(ctx context.Context, tableName string, column
 					OBJECT_ID = OBJECT_ID(N%s)
 					AND name = %s
 				)`,
-			warehouseutils.SQLStringLiteral(as.namespace+"."+tableName),
+			warehouseutils.SQLStringLiteral(warehouseutils.BracketQuoteQualifiedIdentifier(as.namespace, tableName)),
 			warehouseutils.SQLStringLiteral(columnsInfo[0].Name),
 		))
 	}

--- a/warehouse/integrations/azure-synapse/azure_synapse_injection_test.go
+++ b/warehouse/integrations/azure-synapse/azure_synapse_injection_test.go
@@ -1,0 +1,36 @@
+package azuresynapse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+// TestColumnsWithDataTypesNeutralizesSQLInjection proves the reason for the
+// identifier-quoting change on Azure Synapse (SQL Server), where identifiers are
+// bracket-delimited. A malicious column name that tries to break out of the
+// `[...]` identifier in the generated CREATE TABLE column list must be
+// neutralized by doubling the closing bracket, keeping the injected
+// `); drop table ...` payload inert.
+func TestColumnsWithDataTypesNeutralizesSQLInjection(t *testing.T) {
+	// Bracket dialects break out on `]`, so the payload targets the closing
+	// bracket rather than a double quote.
+	payloads := map[string]string{
+		"drop_secrets": `x] bigint); drop table rudder_secrets; --`,
+		"drop_users":   `x] bigint); drop table users; --`,
+	}
+
+	for name, columnName := range payloads {
+		t.Run(name, func(t *testing.T) {
+			fragment := columnsWithDataTypes(model.TableSchema{
+				columnName: model.StringDataType,
+			}, "")
+
+			require.Contains(t, fragment, warehouseutils.BracketQuoteIdentifier(columnName))
+			require.NotContains(t, fragment, columnName)
+		})
+	}
+}

--- a/warehouse/integrations/azure-synapse/azure_synapse_test.go
+++ b/warehouse/integrations/azure-synapse/azure_synapse_test.go
@@ -778,8 +778,11 @@ func TestIntegration(t *testing.T) {
 			maliciousTable := `evil_table]` + dropVictim
 			maliciousColumn := `evil_col] int)` + dropVictim
 			addedColumn := `added_col] int)` + dropVictim
+			// Backslash round-trip: bracket-quoted identifiers treat the backslash as a
+			// literal (doubling escaper on `]`); this confirms it round-trips verbatim.
+			backslashColumn := `evil_bs\`
 
-			maliciousSchema := model.TableSchema{"id": "string", maliciousColumn: "string"}
+			maliciousSchema := model.TableSchema{"id": "string", maliciousColumn: "string", backslashColumn: "string"}
 
 			maliciousWarehouse := warehouse
 			maliciousWarehouse.Namespace = maliciousNamespace
@@ -793,12 +796,20 @@ func TestIntegration(t *testing.T) {
 			require.NoError(t, az.CreateTable(ctx, maliciousTable, maliciousSchema))
 			require.NoError(t, az.AddColumns(ctx, maliciousTable, []whutils.ColumnInfo{{Name: addedColumn, Type: "string"}}))
 
+			// Re-running must be a no-op: the OBJECT_ID existence guard has to resolve
+			// the bracket-quoted name. If it uses the raw name it returns NULL for a
+			// name needing quoting (] and spaces here), the guard fails open, and the
+			// CREATE/ALTER re-runs and errors ("already an object named" / duplicate column).
+			require.NoError(t, az.CreateTable(ctx, maliciousTable, maliciousSchema), "CreateTable must be idempotent - existence guard must match the quoted name")
+			require.NoError(t, az.AddColumns(ctx, maliciousTable, []whutils.ColumnInfo{{Name: addedColumn, Type: "string"}}), "AddColumns must be idempotent - existence guard must match the quoted name")
+
 			// FetchSchema round-trips the stored identifiers - dialect-agnostic verification.
 			schema, err := az.FetchSchema(ctx)
 			require.NoError(t, err)
 			require.Contains(t, schema, "victim_secrets", "victim table must survive - the injection executed")
 			require.Contains(t, schema, maliciousTable, "malicious table must be created verbatim")
 			require.Contains(t, schema[maliciousTable], maliciousColumn)
+			require.Contains(t, schema[maliciousTable], backslashColumn, "trailing-backslash column must round-trip verbatim")
 			require.Contains(t, schema[maliciousTable], addedColumn)
 
 			// DropTable must also quote the identifier - a broken drop would inject a second DROP.

--- a/warehouse/integrations/azure-synapse/azure_synapse_test.go
+++ b/warehouse/integrations/azure-synapse/azure_synapse_test.go
@@ -771,6 +771,43 @@ func TestIntegration(t *testing.T) {
 				{"7274e5db-f918-4efe-5322-872f66e235c5", "2022-12-15T06:53:49Z", "", "2022-12-15T06:53:49Z", "", "", ""},
 			})
 		})
+
+		t.Run("prevents SQL injection via malicious identifiers", func(t *testing.T) {
+			dropVictim := `; DROP TABLE victim_secrets; --`
+			maliciousNamespace := `evil_ns]` + dropVictim
+			maliciousTable := `evil_table]` + dropVictim
+			maliciousColumn := `evil_col] int)` + dropVictim
+			addedColumn := `added_col] int)` + dropVictim
+
+			maliciousSchema := model.TableSchema{"id": "string", maliciousColumn: "string"}
+
+			maliciousWarehouse := warehouse
+			maliciousWarehouse.Namespace = maliciousNamespace
+
+			az := azuresynapse.New(config.New(), logger.NOP, stats.NOP)
+			require.NoError(t, az.Setup(ctx, maliciousWarehouse, newMockUploader(t, nil, maliciousTable, maliciousSchema, maliciousSchema)))
+
+			require.NoError(t, az.CreateSchema(ctx))
+			// Victim (control) table created through the manager itself.
+			require.NoError(t, az.CreateTable(ctx, "victim_secrets", model.TableSchema{"id": "string"}))
+			require.NoError(t, az.CreateTable(ctx, maliciousTable, maliciousSchema))
+			require.NoError(t, az.AddColumns(ctx, maliciousTable, []whutils.ColumnInfo{{Name: addedColumn, Type: "string"}}))
+
+			// FetchSchema round-trips the stored identifiers - dialect-agnostic verification.
+			schema, err := az.FetchSchema(ctx)
+			require.NoError(t, err)
+			require.Contains(t, schema, "victim_secrets", "victim table must survive - the injection executed")
+			require.Contains(t, schema, maliciousTable, "malicious table must be created verbatim")
+			require.Contains(t, schema[maliciousTable], maliciousColumn)
+			require.Contains(t, schema[maliciousTable], addedColumn)
+
+			// DropTable must also quote the identifier - a broken drop would inject a second DROP.
+			require.NoError(t, az.DropTable(ctx, maliciousTable))
+			schema, err = az.FetchSchema(ctx)
+			require.NoError(t, err)
+			require.Contains(t, schema, "victim_secrets", "victim table must survive DropTable injection")
+			require.NotContains(t, schema, maliciousTable, "malicious table should have been dropped")
+		})
 	})
 }
 

--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -230,7 +230,7 @@ func (bq *BigQuery) createTableView(ctx context.Context, tableName string, colum
 	}
 
 	viewName := tableName + "_view"
-	query := fmt.Sprintf("CREATE OR REPLACE VIEW `%s`.`%s` AS %s;", bq.namespace, viewName, deduplicationQuery)
+	query := fmt.Sprintf("CREATE OR REPLACE VIEW %s AS %s;", warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, viewName), deduplicationQuery)
 
 	bq.logger.Infon("Creating view", logger.NewStringField("view", viewName), logger.NewStringField("query", query))
 	job, err := bq.db.Query(query).Run(ctx)
@@ -252,10 +252,11 @@ func (bq *BigQuery) deduplicationQuery(tableName string, columnMap model.TableSc
 	if column, ok := partitionKeyMap[tableName]; ok {
 		partitionKey = column
 	}
+	partitionKey = warehouseutils.QuoteCommaSeparatedIdentifiers(partitionKey, warehouseutils.BacktickQuoteIdentifier)
 
 	var viewOrderByStmt string
 	if _, ok := columnMap["loaded_at"]; ok {
-		viewOrderByStmt = " ORDER BY loaded_at DESC "
+		viewOrderByStmt = " ORDER BY " + warehouseutils.BacktickQuoteIdentifier("loaded_at") + " DESC "
 	}
 
 	var (
@@ -285,7 +286,7 @@ func (bq *BigQuery) deduplicationQuery(tableName string, columnMap model.TableSc
 					logger.NewStringField("partitionColumn", partitionColumn),
 				)
 				granularity = string(bqPartitionType)
-				partitionFilter = `TIMESTAMP_TRUNC(` + partitionColumn + `, ` + granularity + `, 'UTC')`
+				partitionFilter = `TIMESTAMP_TRUNC(` + warehouseutils.BacktickQuoteIdentifier(partitionColumn) + `, ` + granularity + `, 'UTC')`
 			} else {
 				bq.logger.Warnn("Deduplication query: Partition column not found in schema",
 					logger.NewStringField("partitionColumn", partitionColumn),
@@ -300,7 +301,7 @@ func (bq *BigQuery) deduplicationQuery(tableName string, columnMap model.TableSc
 	// the following view takes the last two months into consideration i.e. 60 * 60 * 24 * 60 * 1000000
 	viewQuery := `SELECT * EXCEPT (__row_number) FROM (
 			SELECT *, ROW_NUMBER() OVER (PARTITION BY ` + partitionKey + viewOrderByStmt + `) AS __row_number
-			FROM ` + "`" + bq.projectID + "." + bq.namespace + "." + tableName + "`" + `
+			FROM ` + warehouseutils.BacktickQuoteQualifiedIdentifier(bq.projectID, bq.namespace, tableName) + `
 			WHERE
 				` + partitionFilter + ` BETWEEN TIMESTAMP_TRUNC(
 					TIMESTAMP_MICROS(UNIX_MICROS(CURRENT_TIMESTAMP()) - 60 * 60 * 24 * 60 * 1000000),
@@ -395,7 +396,7 @@ func checkAndIgnoreAlreadyExistError(err error) bool {
 
 func (bq *BigQuery) DeleteBy(ctx context.Context, tableNames []string, params warehouseutils.DeleteByParams) error {
 	for _, tb := range tableNames {
-		tableName := fmt.Sprintf("`%s`.`%s`", bq.namespace, tb)
+		tableName := warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, tb)
 		sqlStatement := fmt.Sprintf(`
 			DELETE FROM
 				%[1]s
@@ -658,7 +659,7 @@ func (bq *BigQuery) LoadUserTables(ctx context.Context) (errorMap map[string]err
 	}
 
 	firstValueSQL := func(column string) string {
-		return fmt.Sprintf("FIRST_VALUE(`%[1]s` IGNORE NULLS) OVER (PARTITION BY id ORDER BY received_at DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS `%[1]s`", column)
+		return fmt.Sprintf("FIRST_VALUE(%[1]s IGNORE NULLS) OVER (PARTITION BY %[2]s ORDER BY %[3]s DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS %[1]s", warehouseutils.BacktickQuoteIdentifier(column), warehouseutils.BacktickQuoteIdentifier("id"), warehouseutils.BacktickQuoteIdentifier("received_at"))
 	}
 
 	userColMap := bq.uploader.GetTableSchemaInWarehouse(warehouseutils.UsersTable)
@@ -667,7 +668,7 @@ func (bq *BigQuery) LoadUserTables(ctx context.Context) (errorMap map[string]err
 		if colName == "id" {
 			continue
 		}
-		userColNames = append(userColNames, fmt.Sprintf("`%s`", colName))
+		userColNames = append(userColNames, warehouseutils.BacktickQuoteIdentifier(colName))
 		firstValProps = append(firstValProps, firstValueSQL(colName))
 	}
 
@@ -695,7 +696,7 @@ func (bq *BigQuery) LoadUserTables(ctx context.Context) (errorMap map[string]err
 		strings.Join(firstValProps, ","),
 		strings.Join(userColNames, ","),
 		deduplicationQuery,
-		fmt.Sprintf("`%s`.`%s`", bq.namespace, stagingUsersTableName),
+		warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, stagingUsersTableName),
 	)
 
 	log.Infon("Loading data")
@@ -808,13 +809,14 @@ func (bq *BigQuery) dropDanglingStagingTables(ctx context.Context) error {
 		SELECT
 		  table_name
 		FROM
-		  %[1]s.INFORMATION_SCHEMA.TABLES
+		  %[1]s
 		WHERE
-		  table_schema = '%[1]s'
-		  AND table_name LIKE '%[2]s';
+		  table_schema = %[2]s
+		  AND table_name LIKE %[3]s;
 	`,
-		bq.namespace,
-		fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider)),
+		warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, "INFORMATION_SCHEMA", "TABLES"),
+		warehouseutils.SQLStringLiteral(bq.namespace),
+		warehouseutils.SQLStringLiteral(fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider))),
 	)
 	query := bq.db.Query(sqlStatement)
 	it, err := bq.db.Read(ctx, query)
@@ -962,19 +964,20 @@ func (bq *BigQuery) FetchSchema(ctx context.Context) (model.Schema, error) {
 		  c.column_name,
 		  c.data_type
 		FROM
-		  %[1]s.INFORMATION_SCHEMA.TABLES as t
-		  LEFT JOIN %[1]s.INFORMATION_SCHEMA.COLUMNS as c ON (t.table_name = c.table_name)
+		  %[1]s as t
+		  LEFT JOIN %[2]s as c ON (t.table_name = c.table_name)
 		WHERE
 		  (t.table_type != 'VIEW')
 		  AND
-		  (t.table_name NOT LIKE '%s')
+		  (t.table_name NOT LIKE %[3]s)
 		  AND (
 			c.column_name != '_PARTITIONTIME'
 			OR c.column_name IS NULL
 		  );
 	`,
-		bq.namespace,
-		fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider)),
+		warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, "INFORMATION_SCHEMA", "TABLES"),
+		warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, "INFORMATION_SCHEMA", "COLUMNS"),
+		warehouseutils.SQLStringLiteral(fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider))),
 	)
 	query := bq.db.Query(sqlStatement)
 
@@ -1130,7 +1133,7 @@ func (bq *BigQuery) DownloadIdentityRules(ctx context.Context, gzWriter *misc.GZ
 		batchSize := int64(10000)
 		var offset int64
 		for {
-			sqlStatement := fmt.Sprintf(`SELECT DISTINCT %[1]s FROM %[2]s.%[3]s LIMIT %[4]d OFFSET %[5]d`, toSelectFields, bq.namespace, tableName, batchSize, offset)
+			sqlStatement := fmt.Sprintf(`SELECT DISTINCT %[1]s FROM %[2]s LIMIT %[3]d OFFSET %[4]d`, toSelectFields, warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, tableName), batchSize, offset)
 			bq.logger.Infon("Downloading distinct combinations of anonymous_id, user_id",
 				logger.NewStringField(logfield.Query, sqlStatement),
 				logger.NewIntField(logfield.TotalRows, totalRows),

--- a/warehouse/integrations/bigquery/bigquery.go
+++ b/warehouse/integrations/bigquery/bigquery.go
@@ -230,7 +230,7 @@ func (bq *BigQuery) createTableView(ctx context.Context, tableName string, colum
 	}
 
 	viewName := tableName + "_view"
-	query := fmt.Sprintf("CREATE OR REPLACE VIEW %s AS %s;", warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, viewName), deduplicationQuery)
+	query := fmt.Sprintf("CREATE OR REPLACE VIEW %s AS %s;", warehouseutils.BigQueryBacktickQuoteQualifiedIdentifier(bq.namespace, viewName), deduplicationQuery)
 
 	bq.logger.Infon("Creating view", logger.NewStringField("view", viewName), logger.NewStringField("query", query))
 	job, err := bq.db.Query(query).Run(ctx)
@@ -252,11 +252,11 @@ func (bq *BigQuery) deduplicationQuery(tableName string, columnMap model.TableSc
 	if column, ok := partitionKeyMap[tableName]; ok {
 		partitionKey = column
 	}
-	partitionKey = warehouseutils.QuoteCommaSeparatedIdentifiers(partitionKey, warehouseutils.BacktickQuoteIdentifier)
+	partitionKey = warehouseutils.QuoteCommaSeparatedIdentifiers(partitionKey, warehouseutils.BigQueryBacktickQuoteIdentifier)
 
 	var viewOrderByStmt string
 	if _, ok := columnMap["loaded_at"]; ok {
-		viewOrderByStmt = " ORDER BY " + warehouseutils.BacktickQuoteIdentifier("loaded_at") + " DESC "
+		viewOrderByStmt = " ORDER BY " + warehouseutils.BigQueryBacktickQuoteIdentifier("loaded_at") + " DESC "
 	}
 
 	var (
@@ -286,7 +286,7 @@ func (bq *BigQuery) deduplicationQuery(tableName string, columnMap model.TableSc
 					logger.NewStringField("partitionColumn", partitionColumn),
 				)
 				granularity = string(bqPartitionType)
-				partitionFilter = `TIMESTAMP_TRUNC(` + warehouseutils.BacktickQuoteIdentifier(partitionColumn) + `, ` + granularity + `, 'UTC')`
+				partitionFilter = `TIMESTAMP_TRUNC(` + warehouseutils.BigQueryBacktickQuoteIdentifier(partitionColumn) + `, ` + granularity + `, 'UTC')`
 			} else {
 				bq.logger.Warnn("Deduplication query: Partition column not found in schema",
 					logger.NewStringField("partitionColumn", partitionColumn),
@@ -301,7 +301,7 @@ func (bq *BigQuery) deduplicationQuery(tableName string, columnMap model.TableSc
 	// the following view takes the last two months into consideration i.e. 60 * 60 * 24 * 60 * 1000000
 	viewQuery := `SELECT * EXCEPT (__row_number) FROM (
 			SELECT *, ROW_NUMBER() OVER (PARTITION BY ` + partitionKey + viewOrderByStmt + `) AS __row_number
-			FROM ` + warehouseutils.BacktickQuoteQualifiedIdentifier(bq.projectID, bq.namespace, tableName) + `
+			FROM ` + warehouseutils.BigQueryBacktickQuoteQualifiedIdentifier(bq.projectID, bq.namespace, tableName) + `
 			WHERE
 				` + partitionFilter + ` BETWEEN TIMESTAMP_TRUNC(
 					TIMESTAMP_MICROS(UNIX_MICROS(CURRENT_TIMESTAMP()) - 60 * 60 * 24 * 60 * 1000000),
@@ -396,7 +396,7 @@ func checkAndIgnoreAlreadyExistError(err error) bool {
 
 func (bq *BigQuery) DeleteBy(ctx context.Context, tableNames []string, params warehouseutils.DeleteByParams) error {
 	for _, tb := range tableNames {
-		tableName := warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, tb)
+		tableName := warehouseutils.BigQueryBacktickQuoteQualifiedIdentifier(bq.namespace, tb)
 		sqlStatement := fmt.Sprintf(`
 			DELETE FROM
 				%[1]s
@@ -659,7 +659,7 @@ func (bq *BigQuery) LoadUserTables(ctx context.Context) (errorMap map[string]err
 	}
 
 	firstValueSQL := func(column string) string {
-		return fmt.Sprintf("FIRST_VALUE(%[1]s IGNORE NULLS) OVER (PARTITION BY %[2]s ORDER BY %[3]s DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS %[1]s", warehouseutils.BacktickQuoteIdentifier(column), warehouseutils.BacktickQuoteIdentifier("id"), warehouseutils.BacktickQuoteIdentifier("received_at"))
+		return fmt.Sprintf("FIRST_VALUE(%[1]s IGNORE NULLS) OVER (PARTITION BY %[2]s ORDER BY %[3]s DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS %[1]s", warehouseutils.BigQueryBacktickQuoteIdentifier(column), warehouseutils.BigQueryBacktickQuoteIdentifier("id"), warehouseutils.BigQueryBacktickQuoteIdentifier("received_at"))
 	}
 
 	userColMap := bq.uploader.GetTableSchemaInWarehouse(warehouseutils.UsersTable)
@@ -668,7 +668,7 @@ func (bq *BigQuery) LoadUserTables(ctx context.Context) (errorMap map[string]err
 		if colName == "id" {
 			continue
 		}
-		userColNames = append(userColNames, warehouseutils.BacktickQuoteIdentifier(colName))
+		userColNames = append(userColNames, warehouseutils.BigQueryBacktickQuoteIdentifier(colName))
 		firstValProps = append(firstValProps, firstValueSQL(colName))
 	}
 
@@ -696,7 +696,7 @@ func (bq *BigQuery) LoadUserTables(ctx context.Context) (errorMap map[string]err
 		strings.Join(firstValProps, ","),
 		strings.Join(userColNames, ","),
 		deduplicationQuery,
-		warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, stagingUsersTableName),
+		warehouseutils.BigQueryBacktickQuoteQualifiedIdentifier(bq.namespace, stagingUsersTableName),
 	)
 
 	log.Infon("Loading data")
@@ -814,9 +814,9 @@ func (bq *BigQuery) dropDanglingStagingTables(ctx context.Context) error {
 		  table_schema = %[2]s
 		  AND table_name LIKE %[3]s;
 	`,
-		warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, "INFORMATION_SCHEMA", "TABLES"),
-		warehouseutils.SQLStringLiteral(bq.namespace),
-		warehouseutils.SQLStringLiteral(fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider))),
+		warehouseutils.BigQueryBacktickQuoteQualifiedIdentifier(bq.namespace, "INFORMATION_SCHEMA", "TABLES"),
+		warehouseutils.SQLStringLiteralBackslash(bq.namespace),
+		warehouseutils.SQLStringLiteralBackslash(fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider))),
 	)
 	query := bq.db.Query(sqlStatement)
 	it, err := bq.db.Read(ctx, query)
@@ -975,9 +975,9 @@ func (bq *BigQuery) FetchSchema(ctx context.Context) (model.Schema, error) {
 			OR c.column_name IS NULL
 		  );
 	`,
-		warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, "INFORMATION_SCHEMA", "TABLES"),
-		warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, "INFORMATION_SCHEMA", "COLUMNS"),
-		warehouseutils.SQLStringLiteral(fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider))),
+		warehouseutils.BigQueryBacktickQuoteQualifiedIdentifier(bq.namespace, "INFORMATION_SCHEMA", "TABLES"),
+		warehouseutils.BigQueryBacktickQuoteQualifiedIdentifier(bq.namespace, "INFORMATION_SCHEMA", "COLUMNS"),
+		warehouseutils.SQLStringLiteralBackslash(fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider))),
 	)
 	query := bq.db.Query(sqlStatement)
 
@@ -1133,7 +1133,7 @@ func (bq *BigQuery) DownloadIdentityRules(ctx context.Context, gzWriter *misc.GZ
 		batchSize := int64(10000)
 		var offset int64
 		for {
-			sqlStatement := fmt.Sprintf(`SELECT DISTINCT %[1]s FROM %[2]s LIMIT %[3]d OFFSET %[4]d`, toSelectFields, warehouseutils.BacktickQuoteQualifiedIdentifier(bq.namespace, tableName), batchSize, offset)
+			sqlStatement := fmt.Sprintf(`SELECT DISTINCT %[1]s FROM %[2]s LIMIT %[3]d OFFSET %[4]d`, toSelectFields, warehouseutils.BigQueryBacktickQuoteQualifiedIdentifier(bq.namespace, tableName), batchSize, offset)
 			bq.logger.Infon("Downloading distinct combinations of anonymous_id, user_id",
 				logger.NewStringField(logfield.Query, sqlStatement),
 				logger.NewIntField(logfield.TotalRows, totalRows),

--- a/warehouse/integrations/bigquery/bigquery_quoting_internal_test.go
+++ b/warehouse/integrations/bigquery/bigquery_quoting_internal_test.go
@@ -1,0 +1,62 @@
+package bigquery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+// BigQuery's DDL (CreateTable/AddColumns/DropTable/CreateSchema) goes through the
+// typed BigQuery Go client API, where table and column names are passed as struct
+// fields rather than interpolated into SQL - so those paths cannot be used for SQL
+// injection, and BigQuery additionally rejects backticks/illegal characters in
+// identifiers at the API level. The remaining injection surface is the raw-SQL
+// paths that interpolate a potentially attacker-influenced identifier via backtick
+// quoting - most notably the deduplication view built by deduplicationQuery.
+//
+// This test proves a malicious table name cannot break out of the backtick-
+// delimited identifier: the backtick (and backslash) must be backslash-escaped, so
+// the identifier cannot be terminated early to inject trailing SQL.
+func TestDeduplicationQueryQuotesBacktickIdentifiers(t *testing.T) {
+	bq := &BigQuery{}
+	bq.conf = config.New()
+	bq.warehouse = model.Warehouse{
+		Destination: backendconfig.DestinationT{Config: map[string]any{}},
+	}
+	bq.projectID = "test_project"
+	bq.namespace = "test_namespace"
+
+	maliciousTable := "evil_table`); DROP TABLE victim_secrets; --"
+
+	query, err := bq.deduplicationQuery(maliciousTable, model.TableSchema{"id": "string"})
+	require.NoError(t, err)
+
+	// BigQuery escapes the backtick delimiter (and backslash) with a preceding
+	// backslash, not by doubling. The table name must appear backtick-quoted with
+	// the embedded backtick backslash-escaped.
+	require.Contains(t, query,
+		warehouseutils.BigQueryBacktickQuoteQualifiedIdentifier(bq.projectID, bq.namespace, maliciousTable))
+	require.Contains(t, query, "`evil_table\\`); DROP TABLE victim_secrets; --`")
+
+	// The raw, unescaped breakout must never appear in the generated SQL.
+	require.NotContains(t, query, "`evil_table`); DROP")
+}
+
+// TestQualifiedTableNamesQuoteBacktickIdentifiers guards the helper that BigQuery
+// uses to build every qualified identifier in its raw-SQL paths (deduplication
+// view, users merge, INFORMATION_SCHEMA lookups). BigQuery uses backslash
+// escaping, so a backtick in the name becomes \` rather than being doubled.
+func TestQualifiedTableNamesQuoteBacktickIdentifiers(t *testing.T) {
+	tableName := "evil_table`); DROP TABLE victim_secrets; --"
+
+	qualifiedName := warehouseutils.BigQueryBacktickQuoteQualifiedIdentifier("project", "namespace", tableName)
+
+	require.Equal(t, "`project`.`namespace`.`evil_table\\`); DROP TABLE victim_secrets; --`", qualifiedName)
+	require.NotContains(t, qualifiedName, "evil_table`); DROP")
+}

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -603,17 +603,17 @@ func (ch *Clickhouse) loadByCopyCommand(ctx context.Context, tableName string, t
 
 	sqlStatement := fmt.Sprintf(`
 		INSERT INTO %[1]s (
-			%[3]s
+			%[2]s
 		)
 		SELECT
 		  *
 		FROM
 		  s3(
-			'%[4]s',
+			%[3]s,
+		  	'%[4]s',
 		  	'%[5]s',
-		  	'%[6]s',
 			'CSV',
-			'%[7]s',
+			'%[6]s',
 			'gz'
 		  )
 			settings
@@ -621,12 +621,11 @@ func (ch *Clickhouse) loadByCopyCommand(ctx context.Context, tableName string, t
 				input_format_csv_arrays_as_nested_csv = 1;
 		`,
 		warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, tableName), // 1
-		"",                             // 2
-		sortedColumnNames,              // 3
-		loadFolder,                     // 4
-		accessKeyID,                    // 5
-		secretAccessKey,                // 6
-		sortedColumnNamesWithDataTypes, // 7
+		sortedColumnNames, // 2
+		warehouseutils.SQLStringLiteral(loadFolder), // 3
+		accessKeyID,                    // 4
+		secretAccessKey,                // 5
+		sortedColumnNamesWithDataTypes, // 6
 	)
 	_, err = ch.DB.ExecContext(ctx, sqlStatement)
 	if err != nil {

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -352,7 +352,7 @@ func (ch *Clickhouse) ColumnsWithDataTypes(tableName string, columns model.Table
 	for columnName, dataType := range columns {
 		codec := ch.getClickHouseCodecForColumnType(dataType, tableName)
 		columnType := ch.getClickHouseColumnTypeForSpecificTable(tableName, columnName, rudderDataTypesMapToClickHouse[dataType], slices.Contains(notNullableColumns, columnName))
-		arr = append(arr, fmt.Sprintf(`%q %s %s`, columnName, columnType, codec))
+		arr = append(arr, fmt.Sprintf(`%s %s %s`, warehouseutils.DoubleQuoteIdentifier(columnName), columnType, codec))
 	}
 	return strings.Join(arr, ",")
 }
@@ -584,9 +584,9 @@ func (ch *Clickhouse) loadByCopyCommand(ctx context.Context, tableName string, t
 
 	strKeys := warehouseutils.GetColumnsFromTableSchema(tableSchemaInUpload)
 	sort.Strings(strKeys)
-	sortedColumnNames := strings.Join(strKeys, ",")
+	sortedColumnNames := warehouseutils.DoubleQuoteAndJoinByComma(strKeys)
 	sortedColumnNamesWithDataTypes := warehouseutils.JoinWithFormatting(strKeys, func(idx int, name string) string {
-		return fmt.Sprintf(`%s %s`, name, rudderDataTypesMapToClickHouse[tableSchemaInUpload[name]])
+		return fmt.Sprintf(`%s %s`, warehouseutils.DoubleQuoteIdentifier(name), rudderDataTypesMapToClickHouse[tableSchemaInUpload[name]])
 	}, ",")
 
 	csvObjectLocation, err := ch.Uploader.GetSampleLoadFileLocation(ctx, tableName)
@@ -602,7 +602,7 @@ func (ch *Clickhouse) loadByCopyCommand(ctx context.Context, tableName string, t
 	}
 
 	sqlStatement := fmt.Sprintf(`
-		INSERT INTO %[1]q.%[2]q (
+		INSERT INTO %[1]s (
 			%[3]s
 		)
 		SELECT
@@ -620,8 +620,8 @@ func (ch *Clickhouse) loadByCopyCommand(ctx context.Context, tableName string, t
 				date_time_input_format = 'best_effort',
 				input_format_csv_arrays_as_nested_csv = 1;
 		`,
-		ch.Namespace,                   // 1
-		tableName,                      // 2
+		warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, tableName), // 1
+		"",                             // 2
 		sortedColumnNames,              // 3
 		loadFolder,                     // 4
 		accessKeyID,                    // 5
@@ -691,7 +691,7 @@ func (ch *Clickhouse) loadTablesFromFilesNamesWithRetry(ctx context.Context, tab
 	sortedColumnKeys := warehouseutils.SortColumnKeysFromColumnMap(tableSchemaInUpload)
 	sortedColumnString := warehouseutils.DoubleQuoteAndJoinByComma(sortedColumnKeys)
 
-	sqlStatement := fmt.Sprintf(`INSERT INTO %q.%q (%v) VALUES (%s)`, ch.Namespace, tableName, sortedColumnString, generateArgumentString(len(sortedColumnKeys)))
+	sqlStatement := fmt.Sprintf(`INSERT INTO %s (%v) VALUES (%s)`, warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, tableName), sortedColumnString, generateArgumentString(len(sortedColumnKeys)))
 	ch.logger.Debugn("Preparing statement exec in db for loading in table",
 		logger.NewStringField("identifier", ch.GetLogIdentifier(tableName)),
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -853,7 +853,7 @@ func (ch *Clickhouse) createUsersTable(ctx context.Context, name string, columns
 	engineOptions := ""
 	cluster := ch.Warehouse.GetStringDestinationConfig(ch.conf, model.ClusterSetting)
 	if len(strings.TrimSpace(cluster)) > 0 {
-		clusterClause = fmt.Sprintf(`ON CLUSTER %q`, cluster)
+		clusterClause = fmt.Sprintf(`ON CLUSTER %s`, warehouseutils.DoubleQuoteIdentifier(cluster))
 		engine = fmt.Sprintf(`%s%s`, "Replicated", engine)
 		engineOptions = fmt.Sprintf(`'/clickhouse/{cluster}/tables/%s/{database}/{table}', '{replica}'`, uuid.New().String())
 	}
@@ -862,7 +862,7 @@ func (ch *Clickhouse) createUsersTable(ctx context.Context, name string, columns
 		return fmt.Errorf("getting partition by clause: %w", err)
 	}
 
-	sqlStatement := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.%q %s ( %v )  ENGINE = %s(%s) ORDER BY %s %s`, ch.Namespace, name, clusterClause, ch.ColumnsWithDataTypes(name, columns, notNullableColumns), engine, engineOptions, getSortKeyTuple(sortKeyFields), partitionByClause)
+	sqlStatement := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s %s ( %v )  ENGINE = %s(%s) ORDER BY %s %s`, warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, name), clusterClause, ch.ColumnsWithDataTypes(name, columns, notNullableColumns), engine, engineOptions, getSortKeyTuple(sortKeyFields), partitionByClause)
 	ch.logger.Infon("CH: Creating table in clickhouse for ch",
 		logger.NewStringField(logfield.DestinationID, ch.Warehouse.Destination.ID),
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -904,9 +904,9 @@ func getSortKeyTuple(sortKeyFields []string) string {
 	tuple.WriteString("(")
 	for index, field := range sortKeyFields {
 		if index == len(sortKeyFields)-1 {
-			tuple.WriteString(fmt.Sprintf(`%q`, field))
+			tuple.WriteString(warehouseutils.DoubleQuoteIdentifier(field))
 		} else {
-			tuple.WriteString(fmt.Sprintf(`%q,`, field))
+			tuple.WriteString(fmt.Sprintf(`%s,`, warehouseutils.DoubleQuoteIdentifier(field)))
 		}
 	}
 	tuple.WriteString(")")
@@ -932,7 +932,7 @@ func (ch *Clickhouse) CreateTable(ctx context.Context, tableName string, columns
 	engineOptions := ""
 	cluster := ch.Warehouse.GetStringDestinationConfig(ch.conf, model.ClusterSetting)
 	if len(strings.TrimSpace(cluster)) > 0 {
-		clusterClause = fmt.Sprintf(`ON CLUSTER %q`, cluster)
+		clusterClause = fmt.Sprintf(`ON CLUSTER %s`, warehouseutils.DoubleQuoteIdentifier(cluster))
 		engine = fmt.Sprintf(`%s%s`, "Replicated", engine)
 		engineOptions = fmt.Sprintf(`'/clickhouse/{cluster}/tables/%s/{database}/{table}', '{replica}'`, uuid.New().String())
 	}
@@ -949,7 +949,7 @@ func (ch *Clickhouse) CreateTable(ctx context.Context, tableName string, columns
 		}
 	}
 
-	sqlStatement = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.%q %s ( %v ) ENGINE = %s(%s) %s %s`, ch.Namespace, tableName, clusterClause, ch.ColumnsWithDataTypes(tableName, columns, sortKeyFields), engine, engineOptions, orderByClause, partitionByClause)
+	sqlStatement = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s %s ( %v ) ENGINE = %s(%s) %s %s`, warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, tableName), clusterClause, ch.ColumnsWithDataTypes(tableName, columns, sortKeyFields), engine, engineOptions, orderByClause, partitionByClause)
 
 	ch.logger.Infon("CH: Creating table in clickhouse for ch",
 		logger.NewStringField(logfield.DestinationID, ch.Warehouse.Destination.ID),
@@ -960,7 +960,7 @@ func (ch *Clickhouse) CreateTable(ctx context.Context, tableName string, columns
 }
 
 func (ch *Clickhouse) DropTable(ctx context.Context, tableName string) (err error) {
-	sqlStatement := fmt.Sprintf(`DROP TABLE %q.%q %s `, ch.Warehouse.Namespace, tableName, ch.clusterClause())
+	sqlStatement := fmt.Sprintf(`DROP TABLE %s %s `, warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Warehouse.Namespace, tableName), ch.clusterClause())
 	_, err = ch.DB.ExecContext(ctx, sqlStatement)
 	return err
 }
@@ -972,10 +972,9 @@ func (ch *Clickhouse) AddColumns(ctx context.Context, tableName string, columnsI
 	)
 
 	queryBuilder.WriteString(fmt.Sprintf(`
-		ALTER TABLE
-		  %q.%q %s`,
-		ch.Namespace,
-		tableName,
+			ALTER TABLE
+			  %s %s`,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, tableName),
 		ch.clusterClause(),
 	))
 
@@ -986,7 +985,7 @@ func (ch *Clickhouse) AddColumns(ctx context.Context, tableName string, columnsI
 			rudderDataTypesMapToClickHouse[columnInfo.Type],
 			false,
 		)
-		queryBuilder.WriteString(fmt.Sprintf(` ADD COLUMN IF NOT EXISTS %q %s,`, columnInfo.Name, columnType))
+		queryBuilder.WriteString(fmt.Sprintf(` ADD COLUMN IF NOT EXISTS %s %s,`, warehouseutils.DoubleQuoteIdentifier(columnInfo.Name), columnType))
 	}
 
 	query = strings.TrimSuffix(queryBuilder.String(), ",")
@@ -1028,7 +1027,7 @@ func (ch *Clickhouse) CreateSchema(ctx context.Context) error {
 		logger.NewStringField("clusterClause", ch.clusterClause()),
 	)
 
-	query := fmt.Sprintf(`CREATE DATABASE IF NOT EXISTS %q %s`, ch.Namespace, ch.clusterClause())
+	query := fmt.Sprintf(`CREATE DATABASE IF NOT EXISTS %s %s`, warehouseutils.DoubleQuoteIdentifier(ch.Namespace), ch.clusterClause())
 	if _, err = db.ExecContext(ctx, query); err != nil {
 		return fmt.Errorf("creating database: %v", err)
 	}
@@ -1037,7 +1036,7 @@ func (ch *Clickhouse) CreateSchema(ctx context.Context) error {
 
 func (ch *Clickhouse) clusterClause() string {
 	if cluster := ch.Warehouse.GetStringDestinationConfig(ch.conf, model.ClusterSetting); len(strings.TrimSpace(cluster)) > 0 {
-		return fmt.Sprintf(`ON CLUSTER %q`, cluster)
+		return fmt.Sprintf(`ON CLUSTER %s`, warehouseutils.DoubleQuoteIdentifier(cluster))
 	}
 	return ""
 }
@@ -1244,10 +1243,9 @@ func (ch *Clickhouse) TestLoadTable(ctx context.Context, _, tableName string, pa
 		columns = append(columns, key)
 	}
 
-	sqlStatement := fmt.Sprintf(`INSERT INTO %q.%q (%v) VALUES (%s)`,
-		ch.Namespace,
-		tableName,
-		strings.Join(columns, ","),
+	sqlStatement := fmt.Sprintf(`INSERT INTO %s (%v) VALUES (%s)`,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, tableName),
+		warehouseutils.DoubleQuoteAndJoinByComma(columns),
 		generateArgumentString(len(columns)),
 	)
 	txn, err := ch.DB.BeginTx(ctx, &sql.TxOptions{})

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -1201,10 +1201,9 @@ func (ch *Clickhouse) totalCountIntable(ctx context.Context, tableName string) (
 		sqlStatement string
 	)
 	sqlStatement = fmt.Sprintf(`
-		SELECT count(*) FROM "%[1]s"."%[2]s";
+		SELECT count(*) FROM %s;
 	`,
-		ch.Namespace,
-		tableName,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, tableName),
 	)
 	err = ch.DB.QueryRowContext(ctx, sqlStatement).Scan(&total)
 	return total, err

--- a/warehouse/integrations/clickhouse/clickhouse.go
+++ b/warehouse/integrations/clickhouse/clickhouse.go
@@ -352,7 +352,7 @@ func (ch *Clickhouse) ColumnsWithDataTypes(tableName string, columns model.Table
 	for columnName, dataType := range columns {
 		codec := ch.getClickHouseCodecForColumnType(dataType, tableName)
 		columnType := ch.getClickHouseColumnTypeForSpecificTable(tableName, columnName, rudderDataTypesMapToClickHouse[dataType], slices.Contains(notNullableColumns, columnName))
-		arr = append(arr, fmt.Sprintf(`%s %s %s`, warehouseutils.DoubleQuoteIdentifier(columnName), columnType, codec))
+		arr = append(arr, fmt.Sprintf(`%s %s %s`, warehouseutils.ClickhouseQuoteIdentifier(columnName), columnType, codec))
 	}
 	return strings.Join(arr, ",")
 }
@@ -584,9 +584,9 @@ func (ch *Clickhouse) loadByCopyCommand(ctx context.Context, tableName string, t
 
 	strKeys := warehouseutils.GetColumnsFromTableSchema(tableSchemaInUpload)
 	sort.Strings(strKeys)
-	sortedColumnNames := warehouseutils.DoubleQuoteAndJoinByComma(strKeys)
+	sortedColumnNames := warehouseutils.ClickhouseQuoteAndJoinByComma(strKeys)
 	sortedColumnNamesWithDataTypes := warehouseutils.JoinWithFormatting(strKeys, func(idx int, name string) string {
-		return fmt.Sprintf(`%s %s`, warehouseutils.DoubleQuoteIdentifier(name), rudderDataTypesMapToClickHouse[tableSchemaInUpload[name]])
+		return fmt.Sprintf(`%s %s`, warehouseutils.ClickhouseQuoteIdentifier(name), rudderDataTypesMapToClickHouse[tableSchemaInUpload[name]])
 	}, ",")
 
 	csvObjectLocation, err := ch.Uploader.GetSampleLoadFileLocation(ctx, tableName)
@@ -610,22 +610,22 @@ func (ch *Clickhouse) loadByCopyCommand(ctx context.Context, tableName string, t
 		FROM
 		  s3(
 			%[3]s,
-		  	'%[4]s',
-		  	'%[5]s',
+		  	%[4]s,
+		  	%[5]s,
 			'CSV',
-			'%[6]s',
+			%[6]s,
 			'gz'
 		  )
 			settings
 				date_time_input_format = 'best_effort',
 				input_format_csv_arrays_as_nested_csv = 1;
 		`,
-		warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, tableName), // 1
+		warehouseutils.ClickhouseQuoteQualifiedIdentifier(ch.Namespace, tableName), // 1
 		sortedColumnNames, // 2
-		warehouseutils.SQLStringLiteral(loadFolder), // 3
-		accessKeyID,                    // 4
-		secretAccessKey,                // 5
-		sortedColumnNamesWithDataTypes, // 6
+		warehouseutils.SQLStringLiteralBackslash(loadFolder),                     // 3
+		warehouseutils.SQLStringLiteralBackslash(accessKeyID),                    // 4
+		warehouseutils.SQLStringLiteralBackslash(secretAccessKey),                // 5
+		warehouseutils.SQLStringLiteralBackslash(sortedColumnNamesWithDataTypes), // 6
 	)
 	_, err = ch.DB.ExecContext(ctx, sqlStatement)
 	if err != nil {
@@ -688,9 +688,9 @@ func (ch *Clickhouse) loadTablesFromFilesNamesWithRetry(ctx context.Context, tab
 
 	// sort column names
 	sortedColumnKeys := warehouseutils.SortColumnKeysFromColumnMap(tableSchemaInUpload)
-	sortedColumnString := warehouseutils.DoubleQuoteAndJoinByComma(sortedColumnKeys)
+	sortedColumnString := warehouseutils.ClickhouseQuoteAndJoinByComma(sortedColumnKeys)
 
-	sqlStatement := fmt.Sprintf(`INSERT INTO %s (%v) VALUES (%s)`, warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, tableName), sortedColumnString, generateArgumentString(len(sortedColumnKeys)))
+	sqlStatement := fmt.Sprintf(`INSERT INTO %s (%v) VALUES (%s)`, warehouseutils.ClickhouseQuoteQualifiedIdentifier(ch.Namespace, tableName), sortedColumnString, generateArgumentString(len(sortedColumnKeys)))
 	ch.logger.Debugn("Preparing statement exec in db for loading in table",
 		logger.NewStringField("identifier", ch.GetLogIdentifier(tableName)),
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -852,7 +852,7 @@ func (ch *Clickhouse) createUsersTable(ctx context.Context, name string, columns
 	engineOptions := ""
 	cluster := ch.Warehouse.GetStringDestinationConfig(ch.conf, model.ClusterSetting)
 	if len(strings.TrimSpace(cluster)) > 0 {
-		clusterClause = fmt.Sprintf(`ON CLUSTER %s`, warehouseutils.DoubleQuoteIdentifier(cluster))
+		clusterClause = fmt.Sprintf(`ON CLUSTER %s`, warehouseutils.ClickhouseQuoteIdentifier(cluster))
 		engine = fmt.Sprintf(`%s%s`, "Replicated", engine)
 		engineOptions = fmt.Sprintf(`'/clickhouse/{cluster}/tables/%s/{database}/{table}', '{replica}'`, uuid.New().String())
 	}
@@ -861,7 +861,7 @@ func (ch *Clickhouse) createUsersTable(ctx context.Context, name string, columns
 		return fmt.Errorf("getting partition by clause: %w", err)
 	}
 
-	sqlStatement := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s %s ( %v )  ENGINE = %s(%s) ORDER BY %s %s`, warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, name), clusterClause, ch.ColumnsWithDataTypes(name, columns, notNullableColumns), engine, engineOptions, getSortKeyTuple(sortKeyFields), partitionByClause)
+	sqlStatement := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s %s ( %v )  ENGINE = %s(%s) ORDER BY %s %s`, warehouseutils.ClickhouseQuoteQualifiedIdentifier(ch.Namespace, name), clusterClause, ch.ColumnsWithDataTypes(name, columns, notNullableColumns), engine, engineOptions, getSortKeyTuple(sortKeyFields), partitionByClause)
 	ch.logger.Infon("CH: Creating table in clickhouse for ch",
 		logger.NewStringField(logfield.DestinationID, ch.Warehouse.Destination.ID),
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -903,9 +903,9 @@ func getSortKeyTuple(sortKeyFields []string) string {
 	tuple.WriteString("(")
 	for index, field := range sortKeyFields {
 		if index == len(sortKeyFields)-1 {
-			tuple.WriteString(warehouseutils.DoubleQuoteIdentifier(field))
+			tuple.WriteString(warehouseutils.ClickhouseQuoteIdentifier(field))
 		} else {
-			tuple.WriteString(fmt.Sprintf(`%s,`, warehouseutils.DoubleQuoteIdentifier(field)))
+			tuple.WriteString(fmt.Sprintf(`%s,`, warehouseutils.ClickhouseQuoteIdentifier(field)))
 		}
 	}
 	tuple.WriteString(")")
@@ -931,7 +931,7 @@ func (ch *Clickhouse) CreateTable(ctx context.Context, tableName string, columns
 	engineOptions := ""
 	cluster := ch.Warehouse.GetStringDestinationConfig(ch.conf, model.ClusterSetting)
 	if len(strings.TrimSpace(cluster)) > 0 {
-		clusterClause = fmt.Sprintf(`ON CLUSTER %s`, warehouseutils.DoubleQuoteIdentifier(cluster))
+		clusterClause = fmt.Sprintf(`ON CLUSTER %s`, warehouseutils.ClickhouseQuoteIdentifier(cluster))
 		engine = fmt.Sprintf(`%s%s`, "Replicated", engine)
 		engineOptions = fmt.Sprintf(`'/clickhouse/{cluster}/tables/%s/{database}/{table}', '{replica}'`, uuid.New().String())
 	}
@@ -948,7 +948,7 @@ func (ch *Clickhouse) CreateTable(ctx context.Context, tableName string, columns
 		}
 	}
 
-	sqlStatement = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s %s ( %v ) ENGINE = %s(%s) %s %s`, warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, tableName), clusterClause, ch.ColumnsWithDataTypes(tableName, columns, sortKeyFields), engine, engineOptions, orderByClause, partitionByClause)
+	sqlStatement = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s %s ( %v ) ENGINE = %s(%s) %s %s`, warehouseutils.ClickhouseQuoteQualifiedIdentifier(ch.Namespace, tableName), clusterClause, ch.ColumnsWithDataTypes(tableName, columns, sortKeyFields), engine, engineOptions, orderByClause, partitionByClause)
 
 	ch.logger.Infon("CH: Creating table in clickhouse for ch",
 		logger.NewStringField(logfield.DestinationID, ch.Warehouse.Destination.ID),
@@ -959,7 +959,7 @@ func (ch *Clickhouse) CreateTable(ctx context.Context, tableName string, columns
 }
 
 func (ch *Clickhouse) DropTable(ctx context.Context, tableName string) (err error) {
-	sqlStatement := fmt.Sprintf(`DROP TABLE %s %s `, warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Warehouse.Namespace, tableName), ch.clusterClause())
+	sqlStatement := fmt.Sprintf(`DROP TABLE %s %s `, warehouseutils.ClickhouseQuoteQualifiedIdentifier(ch.Warehouse.Namespace, tableName), ch.clusterClause())
 	_, err = ch.DB.ExecContext(ctx, sqlStatement)
 	return err
 }
@@ -973,7 +973,7 @@ func (ch *Clickhouse) AddColumns(ctx context.Context, tableName string, columnsI
 	queryBuilder.WriteString(fmt.Sprintf(`
 			ALTER TABLE
 			  %s %s`,
-		warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, tableName),
+		warehouseutils.ClickhouseQuoteQualifiedIdentifier(ch.Namespace, tableName),
 		ch.clusterClause(),
 	))
 
@@ -984,7 +984,7 @@ func (ch *Clickhouse) AddColumns(ctx context.Context, tableName string, columnsI
 			rudderDataTypesMapToClickHouse[columnInfo.Type],
 			false,
 		)
-		queryBuilder.WriteString(fmt.Sprintf(` ADD COLUMN IF NOT EXISTS %s %s,`, warehouseutils.DoubleQuoteIdentifier(columnInfo.Name), columnType))
+		queryBuilder.WriteString(fmt.Sprintf(` ADD COLUMN IF NOT EXISTS %s %s,`, warehouseutils.ClickhouseQuoteIdentifier(columnInfo.Name), columnType))
 	}
 
 	query = strings.TrimSuffix(queryBuilder.String(), ",")
@@ -1026,7 +1026,7 @@ func (ch *Clickhouse) CreateSchema(ctx context.Context) error {
 		logger.NewStringField("clusterClause", ch.clusterClause()),
 	)
 
-	query := fmt.Sprintf(`CREATE DATABASE IF NOT EXISTS %s %s`, warehouseutils.DoubleQuoteIdentifier(ch.Namespace), ch.clusterClause())
+	query := fmt.Sprintf(`CREATE DATABASE IF NOT EXISTS %s %s`, warehouseutils.ClickhouseQuoteIdentifier(ch.Namespace), ch.clusterClause())
 	if _, err = db.ExecContext(ctx, query); err != nil {
 		return fmt.Errorf("creating database: %v", err)
 	}
@@ -1035,7 +1035,7 @@ func (ch *Clickhouse) CreateSchema(ctx context.Context) error {
 
 func (ch *Clickhouse) clusterClause() string {
 	if cluster := ch.Warehouse.GetStringDestinationConfig(ch.conf, model.ClusterSetting); len(strings.TrimSpace(cluster)) > 0 {
-		return fmt.Sprintf(`ON CLUSTER %s`, warehouseutils.DoubleQuoteIdentifier(cluster))
+		return fmt.Sprintf(`ON CLUSTER %s`, warehouseutils.ClickhouseQuoteIdentifier(cluster))
 	}
 	return ""
 }
@@ -1202,7 +1202,7 @@ func (ch *Clickhouse) totalCountIntable(ctx context.Context, tableName string) (
 	sqlStatement = fmt.Sprintf(`
 		SELECT count(*) FROM %s;
 	`,
-		warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, tableName),
+		warehouseutils.ClickhouseQuoteQualifiedIdentifier(ch.Namespace, tableName),
 	)
 	err = ch.DB.QueryRowContext(ctx, sqlStatement).Scan(&total)
 	return total, err
@@ -1242,8 +1242,8 @@ func (ch *Clickhouse) TestLoadTable(ctx context.Context, _, tableName string, pa
 	}
 
 	sqlStatement := fmt.Sprintf(`INSERT INTO %s (%v) VALUES (%s)`,
-		warehouseutils.DoubleQuoteQualifiedIdentifier(ch.Namespace, tableName),
-		warehouseutils.DoubleQuoteAndJoinByComma(columns),
+		warehouseutils.ClickhouseQuoteQualifiedIdentifier(ch.Namespace, tableName),
+		warehouseutils.ClickhouseQuoteAndJoinByComma(columns),
 		generateArgumentString(len(columns)),
 	)
 	txn, err := ch.DB.BeginTx(ctx, &sql.TxOptions{})

--- a/warehouse/integrations/clickhouse/clickhouse_injection_test.go
+++ b/warehouse/integrations/clickhouse/clickhouse_injection_test.go
@@ -12,13 +12,18 @@ import (
 // TestColumnsWithDataTypesNeutralizesSQLInjection proves the reason for the
 // identifier-quoting change on ClickHouse: a malicious column name that tries to
 // break out of the double-quoted identifier in the generated CREATE TABLE column
-// list must be neutralized by doubling the embedded double quote.
+// list must be neutralized. ClickHouse uses string-literal (backslash) escaping
+// inside double-quoted identifiers - so the delimiter and any backslash are
+// escaped with a backslash, NOT by doubling. The backslash_breakout case
+// specifically guards against the doubling regression, where a trailing backslash
+// would escape the closing quote and let the rest of the column list run on.
 func TestColumnsWithDataTypesNeutralizesSQLInjection(t *testing.T) {
 	ch := &Clickhouse{}
 
 	payloads := map[string]string{
 		"drop_table":          `x" String);drop table rudder_secrets;--`,
 		"rce_copy_to_program": `x" String);copy (select '') to program 'id>/tmp/rce';--`,
+		"backslash_breakout":  `x\" String);drop table rudder_secrets;--`,
 	}
 
 	for name, columnName := range payloads {
@@ -28,7 +33,7 @@ func TestColumnsWithDataTypesNeutralizesSQLInjection(t *testing.T) {
 				columnName: model.StringDataType,
 			}, nil)
 
-			require.Contains(t, fragment, warehouseutils.DoubleQuoteIdentifier(columnName))
+			require.Contains(t, fragment, warehouseutils.ClickhouseQuoteIdentifier(columnName))
 			require.NotContains(t, fragment, columnName)
 		})
 	}

--- a/warehouse/integrations/clickhouse/clickhouse_injection_test.go
+++ b/warehouse/integrations/clickhouse/clickhouse_injection_test.go
@@ -1,0 +1,35 @@
+package clickhouse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+// TestColumnsWithDataTypesNeutralizesSQLInjection proves the reason for the
+// identifier-quoting change on ClickHouse: a malicious column name that tries to
+// break out of the double-quoted identifier in the generated CREATE TABLE column
+// list must be neutralized by doubling the embedded double quote.
+func TestColumnsWithDataTypesNeutralizesSQLInjection(t *testing.T) {
+	ch := &Clickhouse{}
+
+	payloads := map[string]string{
+		"drop_table":          `x" String);drop table rudder_secrets;--`,
+		"rce_copy_to_program": `x" String);copy (select '') to program 'id>/tmp/rce';--`,
+	}
+
+	for name, columnName := range payloads {
+		t.Run(name, func(t *testing.T) {
+			// A regular (non users/identifies) table, no not-nullable columns.
+			fragment := ch.ColumnsWithDataTypes(warehouseutils.DiscardsTable, model.TableSchema{
+				columnName: model.StringDataType,
+			}, nil)
+
+			require.Contains(t, fragment, warehouseutils.DoubleQuoteIdentifier(columnName))
+			require.NotContains(t, fragment, columnName)
+		})
+	}
+}

--- a/warehouse/integrations/clickhouse/clickhouse_test.go
+++ b/warehouse/integrations/clickhouse/clickhouse_test.go
@@ -737,6 +737,56 @@ func TestIntegration(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, schema)
 		})
+
+		t.Run("prevents SQL injection via malicious identifiers", func(t *testing.T) {
+			dropVictim := "; DROP TABLE victim_secrets; --"
+			maliciousNamespace := `evil_ns"` + dropVictim
+			maliciousTable := `evil_table"` + dropVictim
+			maliciousColumn := `evil_col" String)` + dropVictim
+			addedColumn := `added_col" String)` + dropVictim
+
+			warehouse := model.Warehouse{
+				Namespace:   maliciousNamespace,
+				WorkspaceID: whutils.RandHex(),
+				Destination: backendconfig.DestinationT{
+					Config: map[string]any{
+						"host":     host,
+						"port":     strconv.Itoa(clickhousePort),
+						"database": database,
+						"user":     user,
+						"password": password,
+					},
+				},
+			}
+
+			ch := clickhouse.New(config.New(), logger.NOP, stats.NOP)
+			require.NoError(t, ch.Setup(ctx, warehouse, newMockUploader(t, "", nil, nil)))
+
+			require.NoError(t, ch.CreateSchema(ctx))
+			// Victim (control) table created through the manager itself (received_at is the sort key).
+			require.NoError(t, ch.CreateTable(ctx, "victim_secrets", model.TableSchema{"id": "string", "received_at": "datetime"}))
+			require.NoError(t, ch.CreateTable(ctx, maliciousTable, model.TableSchema{
+				"id":            "string",
+				"received_at":   "datetime",
+				maliciousColumn: "string",
+			}))
+			require.NoError(t, ch.AddColumns(ctx, maliciousTable, []whutils.ColumnInfo{{Name: addedColumn, Type: "string"}}))
+
+			// FetchSchema round-trips the stored identifiers - dialect-agnostic verification.
+			schema, err := ch.FetchSchema(ctx)
+			require.NoError(t, err)
+			require.Contains(t, schema, "victim_secrets", "victim table must survive - the injection executed")
+			require.Contains(t, schema, maliciousTable, "malicious table must be created verbatim")
+			require.Contains(t, schema[maliciousTable], maliciousColumn)
+			require.Contains(t, schema[maliciousTable], addedColumn)
+
+			// DropTable must also quote the identifier - a broken drop would inject a second DROP.
+			require.NoError(t, ch.DropTable(ctx, maliciousTable))
+			schema, err = ch.FetchSchema(ctx)
+			require.NoError(t, err)
+			require.Contains(t, schema, "victim_secrets", "victim table must survive DropTable injection")
+			require.NotContains(t, schema, maliciousTable, "malicious table should have been dropped")
+		})
 	})
 
 	t.Run("Load Table round trip", func(t *testing.T) {

--- a/warehouse/integrations/clickhouse/clickhouse_test.go
+++ b/warehouse/integrations/clickhouse/clickhouse_test.go
@@ -744,6 +744,7 @@ func TestIntegration(t *testing.T) {
 			maliciousTable := `evil_table"` + dropVictim
 			maliciousColumn := `evil_col" String)` + dropVictim
 			addedColumn := `added_col" String)` + dropVictim
+			backslashColumn := `evil_bs\`
 
 			warehouse := model.Warehouse{
 				Namespace:   maliciousNamespace,
@@ -769,6 +770,7 @@ func TestIntegration(t *testing.T) {
 				"id":            "string",
 				"received_at":   "datetime",
 				maliciousColumn: "string",
+				backslashColumn: "string",
 			}))
 			require.NoError(t, ch.AddColumns(ctx, maliciousTable, []whutils.ColumnInfo{{Name: addedColumn, Type: "string"}}))
 
@@ -778,6 +780,7 @@ func TestIntegration(t *testing.T) {
 			require.Contains(t, schema, "victim_secrets", "victim table must survive - the injection executed")
 			require.Contains(t, schema, maliciousTable, "malicious table must be created verbatim")
 			require.Contains(t, schema[maliciousTable], maliciousColumn)
+			require.Contains(t, schema[maliciousTable], backslashColumn, "trailing-backslash column must round-trip - backslash escaping intact")
 			require.Contains(t, schema[maliciousTable], addedColumn)
 
 			// DropTable must also quote the identifier - a broken drop would inject a second DROP.

--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -279,7 +279,7 @@ func (d *Deltalake) dropDanglingStagingTables(ctx context.Context) error {
 
 // fetchTables fetches tables from the database
 func (d *Deltalake) fetchTables(ctx context.Context, regex string) ([]string, error) {
-	query := fmt.Sprintf(`SHOW tables FROM %s LIKE %s;`, warehouseutils.BacktickQuoteIdentifier(d.Namespace), warehouseutils.SQLStringLiteral(regex))
+	query := fmt.Sprintf(`SHOW tables FROM %s LIKE %s;`, warehouseutils.BacktickQuoteIdentifier(d.Namespace), warehouseutils.SQLStringLiteralBackslash(regex))
 
 	rows, err := d.DB.QueryContext(ctx, query)
 	if err != nil {
@@ -482,7 +482,7 @@ func (d *Deltalake) CreateSchema(ctx context.Context) error {
 
 // schemaExists checks if a schema exists in the warehouse.
 func (d *Deltalake) schemaExists(ctx context.Context) (bool, error) {
-	query := fmt.Sprintf(`SHOW SCHEMAS LIKE %s;`, warehouseutils.SQLStringLiteral(d.Namespace))
+	query := fmt.Sprintf(`SHOW SCHEMAS LIKE %s;`, warehouseutils.SQLStringLiteralBackslash(d.Namespace))
 
 	var schema string
 	err := d.DB.QueryRowContext(ctx, query).Scan(&schema)
@@ -575,7 +575,7 @@ func (d *Deltalake) tableLocationQuery(tableName string) string {
 	}
 
 	location := fmt.Sprintf("%s/%s/%s", externalLocation, d.Namespace, tableName)
-	return fmt.Sprintf("LOCATION %s", warehouseutils.SQLStringLiteral(location))
+	return fmt.Sprintf("LOCATION %s", warehouseutils.SQLStringLiteralBackslash(location))
 }
 
 // AddColumns adds columns to the table.
@@ -749,7 +749,7 @@ func (d *Deltalake) copyIntoLoadTable(
 			%s;`,
 			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, stagingTableName),
 			sortedColumnNames,
-			warehouseutils.SQLStringLiteral(loadFolder),
+			warehouseutils.SQLStringLiteralBackslash(loadFolder),
 			auth,
 		)
 	} else {
@@ -775,7 +775,7 @@ func (d *Deltalake) copyIntoLoadTable(
 `,
 			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, stagingTableName),
 			sortedColumnNames,
-			warehouseutils.SQLStringLiteral(loadFolder),
+			warehouseutils.SQLStringLiteralBackslash(loadFolder),
 			auth,
 		)
 	}
@@ -1377,7 +1377,7 @@ func (d *Deltalake) TestLoadTable(ctx context.Context, location, tableName strin
 `,
 			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, tableName),
 			warehouseutils.BacktickQuoteAndJoinByComma([]string{"id", "val"}),
-			warehouseutils.SQLStringLiteral(loadFolder),
+			warehouseutils.SQLStringLiteralBackslash(loadFolder),
 			auth,
 		)
 	} else {
@@ -1403,7 +1403,7 @@ func (d *Deltalake) TestLoadTable(ctx context.Context, location, tableName strin
 `,
 			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, tableName),
 			"CAST ( '_c0' AS BIGINT ) AS id, CAST ( '_c1' AS STRING ) AS val",
-			warehouseutils.SQLStringLiteral(loadFolder),
+			warehouseutils.SQLStringLiteralBackslash(loadFolder),
 			auth,
 		)
 	}

--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -279,7 +279,7 @@ func (d *Deltalake) dropDanglingStagingTables(ctx context.Context) error {
 
 // fetchTables fetches tables from the database
 func (d *Deltalake) fetchTables(ctx context.Context, regex string) ([]string, error) {
-	query := fmt.Sprintf(`SHOW tables FROM %s LIKE '%s';`, d.Namespace, regex)
+	query := fmt.Sprintf(`SHOW tables FROM %s LIKE %s;`, warehouseutils.BacktickQuoteIdentifier(d.Namespace), warehouseutils.SQLStringLiteral(regex))
 
 	rows, err := d.DB.QueryContext(ctx, query)
 	if err != nil {
@@ -333,7 +333,7 @@ func (d *Deltalake) dropStagingTables(ctx context.Context, stagingTables []strin
 
 // DropTable drops a table from the warehouse
 func (d *Deltalake) dropTable(ctx context.Context, table string) error {
-	query := fmt.Sprintf(`DROP TABLE %s.%s;`, d.Namespace, table)
+	query := fmt.Sprintf(`DROP TABLE %s;`, warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, table))
 
 	_, err := d.DB.ExecContext(ctx, query)
 	if err != nil {
@@ -408,7 +408,7 @@ func (d *Deltalake) sendStatForMissingDatatype(missingDatatype string) {
 
 // fetchTableAttributes fetches the attributes of a table
 func (d *Deltalake) fetchTableAttributes(ctx context.Context, tableName string) (model.TableSchema, error) {
-	query := fmt.Sprintf(`DESCRIBE QUERY TABLE %s.%s;`, d.Namespace, tableName)
+	query := fmt.Sprintf(`DESCRIBE QUERY TABLE %s;`, warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, tableName))
 
 	rows, err := d.DB.QueryContext(ctx, query)
 	if err != nil {
@@ -482,7 +482,7 @@ func (d *Deltalake) CreateSchema(ctx context.Context) error {
 
 // schemaExists checks if a schema exists in the warehouse.
 func (d *Deltalake) schemaExists(ctx context.Context) (bool, error) {
-	query := fmt.Sprintf(`SHOW SCHEMAS LIKE '%s';`, d.Namespace)
+	query := fmt.Sprintf(`SHOW SCHEMAS LIKE %s;`, warehouseutils.SQLStringLiteral(d.Namespace))
 
 	var schema string
 	err := d.DB.QueryRowContext(ctx, query).Scan(&schema)
@@ -498,7 +498,7 @@ func (d *Deltalake) schemaExists(ctx context.Context) (bool, error) {
 
 // createSchema creates a schema in the warehouse.
 func (d *Deltalake) createSchema(ctx context.Context) error {
-	query := fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s;`, d.Namespace)
+	query := fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s;`, warehouseutils.BacktickQuoteIdentifier(d.Namespace))
 
 	_, err := d.DB.ExecContext(ctx, query)
 	if err != nil {
@@ -514,7 +514,7 @@ func (d *Deltalake) CreateTable(ctx context.Context, tableName string, columns m
 
 	tableLocationSql = d.tableLocationQuery(tableName)
 	if _, ok := columns["received_at"]; ok {
-		partitionedSql = `PARTITIONED BY(event_date)`
+		partitionedSql = fmt.Sprintf(`PARTITIONED BY(%s)`, warehouseutils.BacktickQuoteIdentifier("event_date"))
 	}
 
 	createTableClauseSql := "CREATE TABLE IF NOT EXISTS"
@@ -523,11 +523,10 @@ func (d *Deltalake) CreateTable(ctx context.Context, tableName string, columns m
 	}
 
 	query := fmt.Sprintf(`
-		%s %s.%s ( %s ) USING DELTA %s %s;
+		%s %s ( %s ) USING DELTA %s %s;
 `,
 		createTableClauseSql,
-		d.Namespace,
-		tableName,
+		warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, tableName),
 		columnsWithDataTypes(columns, ""),
 		tableLocationSql,
 		partitionedSql,
@@ -558,10 +557,10 @@ func columnsWithDataTypes(columns model.TableSchema, prefix string) string {
 			return ""
 		}
 		if name == "received_at" {
-			generatedColumnSQL := "DATE GENERATED ALWAYS AS ( CAST(received_at AS DATE) )"
-			return fmt.Sprintf(`%s%s %s, %s%s %s`, prefix, name, dataTypesMap[columns[name]], prefix, "event_date", generatedColumnSQL)
+			generatedColumnSQL := fmt.Sprintf("DATE GENERATED ALWAYS AS ( CAST(%s AS DATE) )", warehouseutils.BacktickQuoteIdentifier("received_at"))
+			return fmt.Sprintf(`%s %s, %s %s`, warehouseutils.BacktickQuoteIdentifier(prefix+name), dataTypesMap[columns[name]], warehouseutils.BacktickQuoteIdentifier(prefix+"event_date"), generatedColumnSQL)
 		}
-		return fmt.Sprintf(`%s%s %s`, prefix, name, dataTypesMap[columns[name]])
+		return fmt.Sprintf(`%s %s`, warehouseutils.BacktickQuoteIdentifier(prefix+name), dataTypesMap[columns[name]])
 	}
 	return warehouseutils.JoinWithFormatting(keys, format, ",")
 }
@@ -596,14 +595,13 @@ func (d *Deltalake) AddColumns(ctx context.Context, tableName string, columnsInf
 
 	queryBuilder.WriteString(fmt.Sprintf(`
 		ALTER TABLE
-		  %s.%s
+		  %s
 		ADD COLUMNS(`,
-		d.Namespace,
-		tableName,
+		warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, tableName),
 	))
 
 	for _, columnInfo := range columnsToAddInfo {
-		queryBuilder.WriteString(fmt.Sprintf(` %s %s,`, columnInfo.Name, dataTypesMap[columnInfo.Type]))
+		queryBuilder.WriteString(fmt.Sprintf(` %s %s,`, warehouseutils.BacktickQuoteIdentifier(columnInfo.Name), dataTypesMap[columnInfo.Type]))
 	}
 
 	query := strings.TrimSuffix(queryBuilder.String(), ",")
@@ -748,7 +746,7 @@ func (d *Deltalake) copyIntoLoadTable(
 			PATTERN = '*.parquet'
 			COPY_OPTIONS ('force' = 'true')
 			%s;`,
-			fmt.Sprintf(`%s.%s`, d.Namespace, stagingTableName),
+			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, stagingTableName),
 			sortedColumnNames,
 			loadFolder,
 			auth,
@@ -774,7 +772,7 @@ func (d *Deltalake) copyIntoLoadTable(
 			COPY_OPTIONS ('force' = 'true')
 			%s;
 `,
-			fmt.Sprintf(`%s.%s`, d.Namespace, stagingTableName),
+			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, stagingTableName),
 			sortedColumnNames,
 			loadFolder,
 			auth,
@@ -794,34 +792,34 @@ func (d *Deltalake) insertIntoLoadTable(
 	tableSchemaAfterUpload model.TableSchema,
 ) (*types.LoadTableStats, error) {
 	insertStmt := fmt.Sprintf(`
-			INSERT INTO %[1]s.%[2]s (%[4]s)
-			SELECT
-			  %[4]s
-			FROM
-			  (
+				INSERT INTO %[1]s (%[3]s)
 				SELECT
-				  *
+				  %[3]s
 				FROM
 				  (
 					SELECT
-					  *,
-					  row_number() OVER (
-						PARTITION BY %[5]s
-						ORDER BY
-						  RECEIVED_AT DESC
-					  ) AS _rudder_staging_row_number
+					  *
 					FROM
-					  %[1]s.%[3]s
-				  ) AS q
-				WHERE
-				  _rudder_staging_row_number = 1
-			  );
-		`,
-		d.Namespace,
-		tableName,
-		stagingTableName,
+					  (
+						SELECT
+						  *,
+						  row_number() OVER (
+							PARTITION BY %[4]s
+							ORDER BY
+							  %[5]s DESC
+						  ) AS _rudder_staging_row_number
+						FROM
+						  %[2]s
+					  ) AS q
+					WHERE
+					  _rudder_staging_row_number = 1
+				  );
+			`,
+		warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, tableName),
+		warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, stagingTableName),
 		columnNames(warehouseutils.SortColumnKeysFromColumnMap(tableSchemaAfterUpload)),
-		primaryKey(tableName),
+		warehouseutils.BacktickQuoteIdentifier(primaryKey(tableName)),
+		warehouseutils.BacktickQuoteIdentifier("received_at"),
 	)
 
 	var rowsAffected, rowsInserted int64
@@ -850,41 +848,41 @@ func (d *Deltalake) mergeIntoLoadTable(
 	pk := primaryKey(tableName)
 
 	mergeStmt := fmt.Sprintf(`
-			MERGE INTO %[1]s.%[2]s AS MAIN USING (
-			  SELECT
-				*
-			  FROM
-				(
+				MERGE INTO %[1]s AS MAIN USING (
 				  SELECT
-					*,
-					row_number() OVER (
-					  PARTITION BY %[4]s
-					  ORDER BY
-						RECEIVED_AT DESC
-					) AS _rudder_staging_row_number
+					*
 				  FROM
-					%[1]s.%[3]s
-				) AS q
-			  WHERE
-				_rudder_staging_row_number = 1
-			)
-			AS STAGING ON MAIN.%[4]s = STAGING.%[4]s
-			WHEN MATCHED THEN
-			UPDATE
-			SET
-			  %[5]s
-			WHEN NOT MATCHED THEN
-			INSERT (%[6]s)
-			VALUES
-			  (%[7]s);
-		`,
-		d.Namespace,
-		tableName,
-		stagingTableName,
-		pk,
+					(
+					  SELECT
+						*,
+						row_number() OVER (
+						  PARTITION BY %[3]s
+						  ORDER BY
+							%[7]s DESC
+						) AS _rudder_staging_row_number
+					  FROM
+						%[2]s
+					) AS q
+				  WHERE
+					_rudder_staging_row_number = 1
+				)
+				AS STAGING ON MAIN.%[3]s = STAGING.%[3]s
+				WHEN MATCHED THEN
+				UPDATE
+				SET
+				  %[4]s
+				WHEN NOT MATCHED THEN
+				INSERT (%[5]s)
+				VALUES
+				  (%[6]s);
+			`,
+		warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, tableName),
+		warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, stagingTableName),
+		warehouseutils.BacktickQuoteIdentifier(pk),
 		columnsWithValues(sortedColumnKeys),
 		columnNames(sortedColumnKeys),
 		stagingColumnNames(sortedColumnKeys),
+		warehouseutils.BacktickQuoteIdentifier("received_at"),
 	)
 
 	var rowsAffected, rowsUpdated, rowsDeleted, rowsInserted int64
@@ -918,19 +916,19 @@ func tableSchemaDiff(tableSchemaInUpload, tableSchemaAfterUpload model.TableSche
 }
 
 func columnNames(columns []string) string {
-	return strings.Join(columns, ",")
+	return warehouseutils.BacktickQuoteAndJoinByComma(columns)
 }
 
 func stagingColumnNames(columns []string) string {
 	format := func(_ int, str string) string {
-		return fmt.Sprintf(`STAGING.%s`, str)
+		return fmt.Sprintf(`STAGING.%s`, warehouseutils.BacktickQuoteIdentifier(str))
 	}
 	return warehouseutils.JoinWithFormatting(columns, format, ",")
 }
 
 func columnsWithValues(columns []string) string {
 	format := func(_ int, str string) string {
-		return fmt.Sprintf(`MAIN.%[1]s = STAGING.%[1]s`, str)
+		return fmt.Sprintf(`MAIN.%[1]s = STAGING.%[1]s`, warehouseutils.BacktickQuoteIdentifier(str))
 	}
 	return warehouseutils.JoinWithFormatting(columns, format, ",")
 }
@@ -949,7 +947,7 @@ func (d *Deltalake) sortedColumnNames(tableSchemaInUpload model.TableSchema, sor
 		return warehouseutils.JoinWithFormatting(sortedColumnKeys, func(_ int, value string) string {
 			columnName := value
 			columnType := dataTypesMap[tableSchemaInUpload[columnName]]
-			return fmt.Sprintf(`%s::%s`, columnName, columnType)
+			return fmt.Sprintf(`%s::%s`, warehouseutils.BacktickQuoteIdentifier(columnName), columnType)
 		}, ",")
 	}
 
@@ -957,7 +955,7 @@ func (d *Deltalake) sortedColumnNames(tableSchemaInUpload model.TableSchema, sor
 		csvColumnIndex := fmt.Sprintf(`%s%d`, "_c", index)
 		columnName := value
 		columnType := dataTypesMap[tableSchemaInUpload[columnName]]
-		return fmt.Sprintf(`CAST ( %s AS %s ) AS %s`, csvColumnIndex, columnType, columnName)
+		return fmt.Sprintf(`CAST ( %s AS %s ) AS %s`, csvColumnIndex, columnType, warehouseutils.BacktickQuoteIdentifier(columnName))
 	}
 	formatString := warehouseutils.JoinWithFormatting(sortedColumnKeys, format, ",")
 
@@ -968,7 +966,7 @@ func (d *Deltalake) sortedColumnNames(tableSchemaInUpload model.TableSchema, sor
 		}
 
 		diffFormat := func(_ int, value string) string {
-			return fmt.Sprintf(`NULL AS %s`, value)
+			return fmt.Sprintf(`NULL AS %s`, warehouseutils.BacktickQuoteIdentifier(value))
 		}
 		diffString := warehouseutils.JoinWithFormatting(diffCols, diffFormat, ",")
 
@@ -1085,55 +1083,55 @@ func (d *Deltalake) LoadUserTables(ctx context.Context) map[string]error {
 	tableLocationSql := d.tableLocationQuery(stagingTableName)
 
 	query := fmt.Sprintf(`
-		CREATE TABLE %[1]s.%[2]s USING DELTA %[7]s AS (
+		CREATE TABLE %[1]s USING DELTA %[6]s AS (
 		  SELECT
 			DISTINCT *
 		  FROM
 			(
 			  SELECT
-				id,
-				%[3]s
+				%[7]s,
+				%[2]s
 			  FROM
 				(
 				  (
 					SELECT
-					  id,
-					  %[6]s
+					  %[7]s,
+					  %[5]s
 					FROM
-					  %[1]s.%[4]s
+					  %[3]s
 					WHERE
-					  id IN (
+					  %[7]s IN (
 						SELECT
-						  DISTINCT(user_id)
+						  DISTINCT(%[8]s)
 						FROM
-						  %[1]s.%[5]s
+						  %[4]s
 						WHERE
-						  user_id IS NOT NULL
+						  %[8]s IS NOT NULL
 					  )
 				  )
 				  UNION
 					(
 					  SELECT
-						user_id,
-						%[6]s
+						%[8]s,
+						%[5]s
 					  FROM
-						%[1]s.%[5]s
+						%[4]s
 					  WHERE
-						user_id IS NOT NULL
+						%[8]s IS NOT NULL
 					)
 				)
 			)
 		);
 `,
-		d.Namespace,
-		stagingTableName,
+		warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, stagingTableName),
 		strings.Join(firstValProps, ","),
-		warehouseutils.UsersTable,
-		identifyStagingTable,
+		warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, warehouseutils.UsersTable),
+		warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, identifyStagingTable),
 		columnNames(userColNames),
 		tableLocationSql,
+		warehouseutils.BacktickQuoteIdentifier("id"),
+		warehouseutils.BacktickQuoteIdentifier("user_id"),
 	)
-
 	_, err = d.DB.ExecContext(ctx, query)
 	if err != nil {
 		return map[string]error{
@@ -1162,43 +1160,41 @@ func (d *Deltalake) LoadUserTables(ctx context.Context) map[string]error {
 
 	if !d.ShouldMerge() {
 		query = fmt.Sprintf(`
-			INSERT INTO %[1]s.%[2]s (%[4]s)
+			INSERT INTO %[1]s (%[3]s)
 			SELECT
-			  %[4]s
+			  %[3]s
 			FROM
 			  (
 				SELECT
-				  %[4]s
+				  %[3]s
 				FROM
-				  %[1]s.%[3]s
+				  %[2]s
 			  );
 		`,
-			d.Namespace,
-			warehouseutils.UsersTable,
-			stagingTableName,
+			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, warehouseutils.UsersTable),
+			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, stagingTableName),
 			columnNames(columnKeys),
 		)
 	} else {
 		pk := primaryKey(warehouseutils.UsersTable)
 
 		query = fmt.Sprintf(`
-			MERGE INTO %[1]s.%[2]s AS MAIN USING (
+			MERGE INTO %[1]s AS MAIN USING (
 			  SELECT
-				%[6]s
+				%[5]s
 			  FROM
-				%[1]s.%[3]s
-			) AS STAGING ON MAIN.%[4]s = STAGING.%[4]s
+				%[2]s
+			) AS STAGING ON MAIN.%[3]s = STAGING.%[3]s
 			WHEN MATCHED THEN
 			UPDATE
 			SET
-			  %[5]s WHEN NOT MATCHED
-			THEN INSERT (%[6]s)
+			  %[4]s WHEN NOT MATCHED
+			THEN INSERT (%[5]s)
 			VALUES
-			  (%[7]s);`,
-			d.Namespace,
-			warehouseutils.UsersTable,
-			stagingTableName,
-			pk,
+			  (%[6]s);`,
+			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, warehouseutils.UsersTable),
+			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, stagingTableName),
+			warehouseutils.BacktickQuoteIdentifier(pk),
 			columnsWithValues(columnKeys),
 			columnNames(columnKeys),
 			stagingColumnNames(columnKeys),
@@ -1277,7 +1273,7 @@ func getColumnProperties(usersSchemaInWarehouse model.TableSchema) ([]string, []
 		}
 
 		userColNames = append(userColNames, colName)
-		firstValProps = append(firstValProps, fmt.Sprintf(`FIRST_VALUE(%[1]s, TRUE) OVER (PARTITION BY id ORDER BY received_at DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS %[1]s`, colName))
+		firstValProps = append(firstValProps, fmt.Sprintf(`FIRST_VALUE(%[1]s, TRUE) OVER (PARTITION BY %[2]s ORDER BY %[3]s DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS %[1]s`, warehouseutils.BacktickQuoteIdentifier(colName), warehouseutils.BacktickQuoteIdentifier("id"), warehouseutils.BacktickQuoteIdentifier("received_at")))
 	}
 
 	return userColNames, firstValProps

--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -574,7 +574,8 @@ func (d *Deltalake) tableLocationQuery(tableName string) string {
 		return ""
 	}
 
-	return fmt.Sprintf("LOCATION '%s/%s/%s'", externalLocation, d.Namespace, tableName)
+	location := fmt.Sprintf("%s/%s/%s", externalLocation, d.Namespace, tableName)
+	return fmt.Sprintf("LOCATION %s", warehouseutils.SQLStringLiteral(location))
 }
 
 // AddColumns adds columns to the table.
@@ -740,7 +741,7 @@ func (d *Deltalake) copyIntoLoadTable(
 				SELECT
 				  %s
 				FROM
-				  '%s'
+				  %s
 			  )
 			FILEFORMAT = PARQUET
 			PATTERN = '*.parquet'
@@ -748,7 +749,7 @@ func (d *Deltalake) copyIntoLoadTable(
 			%s;`,
 			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, stagingTableName),
 			sortedColumnNames,
-			loadFolder,
+			warehouseutils.SQLStringLiteral(loadFolder),
 			auth,
 		)
 	} else {
@@ -759,7 +760,7 @@ func (d *Deltalake) copyIntoLoadTable(
 				SELECT
 				  %s
 				FROM
-				  '%s'
+				  %s
 			  )
 			FILEFORMAT = CSV
 			PATTERN = '*.gz'
@@ -774,7 +775,7 @@ func (d *Deltalake) copyIntoLoadTable(
 `,
 			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, stagingTableName),
 			sortedColumnNames,
-			loadFolder,
+			warehouseutils.SQLStringLiteral(loadFolder),
 			auth,
 		)
 	}
@@ -1367,7 +1368,7 @@ func (d *Deltalake) TestLoadTable(ctx context.Context, location, tableName strin
 				SELECT
 				  %s
 				FROM
-				  '%s'
+				  %s
 			  )
 			FILEFORMAT = PARQUET
 			PATTERN = '*.parquet'
@@ -1376,7 +1377,7 @@ func (d *Deltalake) TestLoadTable(ctx context.Context, location, tableName strin
 `,
 			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, tableName),
 			warehouseutils.BacktickQuoteAndJoinByComma([]string{"id", "val"}),
-			loadFolder,
+			warehouseutils.SQLStringLiteral(loadFolder),
 			auth,
 		)
 	} else {
@@ -1387,7 +1388,7 @@ func (d *Deltalake) TestLoadTable(ctx context.Context, location, tableName strin
 				SELECT
 				  %s
 				FROM
-				  '%s'
+				  %s
 			  )
 			FILEFORMAT = CSV
 			PATTERN = '*.gz'
@@ -1402,7 +1403,7 @@ func (d *Deltalake) TestLoadTable(ctx context.Context, location, tableName strin
 `,
 			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, tableName),
 			"CAST ( '_c0' AS BIGINT ) AS id, CAST ( '_c1' AS STRING ) AS val",
-			loadFolder,
+			warehouseutils.SQLStringLiteral(loadFolder),
 			auth,
 		)
 	}

--- a/warehouse/integrations/deltalake/deltalake.go
+++ b/warehouse/integrations/deltalake/deltalake.go
@@ -1374,8 +1374,8 @@ func (d *Deltalake) TestLoadTable(ctx context.Context, location, tableName strin
 			COPY_OPTIONS ('force' = 'true')
 			%s;
 `,
-			fmt.Sprintf(`%s.%s`, d.Namespace, tableName),
-			fmt.Sprintf(`%s, %s`, "id", "val"),
+			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, tableName),
+			warehouseutils.BacktickQuoteAndJoinByComma([]string{"id", "val"}),
 			loadFolder,
 			auth,
 		)
@@ -1400,7 +1400,7 @@ func (d *Deltalake) TestLoadTable(ctx context.Context, location, tableName strin
 			COPY_OPTIONS ('force' = 'true')
 			%s;
 `,
-			fmt.Sprintf(`%s.%s`, d.Namespace, tableName),
+			warehouseutils.BacktickQuoteQualifiedIdentifier(d.Namespace, tableName),
 			"CAST ( '_c0' AS BIGINT ) AS id, CAST ( '_c1' AS STRING ) AS val",
 			loadFolder,
 			auth,

--- a/warehouse/integrations/deltalake/deltalake_quoting_internal_test.go
+++ b/warehouse/integrations/deltalake/deltalake_quoting_internal_test.go
@@ -1,0 +1,23 @@
+package deltalake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+)
+
+// TestColumnsWithDataTypesQuotesBacktickIdentifiers ensures a malicious column
+// name cannot break out of the backtick-delimited identifier in the generated
+// CREATE TABLE column fragment. The backtick must be doubled.
+func TestColumnsWithDataTypesQuotesBacktickIdentifiers(t *testing.T) {
+	columnName := "x` STRING); DROP TABLE users; --"
+
+	fragment := columnsWithDataTypes(model.TableSchema{
+		columnName: model.StringDataType,
+	}, "")
+
+	require.Contains(t, fragment, "`x`` STRING); DROP TABLE users; --`")
+	require.NotContains(t, fragment, "x` STRING); DROP")
+}

--- a/warehouse/integrations/deltalake/deltalake_quoting_internal_test.go
+++ b/warehouse/integrations/deltalake/deltalake_quoting_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
 )
 
 // TestColumnsWithDataTypesQuotesBacktickIdentifiers ensures a malicious column
@@ -20,4 +21,13 @@ func TestColumnsWithDataTypesQuotesBacktickIdentifiers(t *testing.T) {
 
 	require.Contains(t, fragment, "`x`` STRING); DROP TABLE users; --`")
 	require.NotContains(t, fragment, "x` STRING); DROP")
+}
+
+func TestQualifiedTableNamesQuoteBacktickIdentifiers(t *testing.T) {
+	tableName := "evil_table`); DROP TABLE victim_secrets; --"
+
+	qualifiedName := warehouseutils.BacktickQuoteQualifiedIdentifier("namespace", tableName)
+
+	require.Equal(t, "`namespace`.`evil_table``); DROP TABLE victim_secrets; --`", qualifiedName)
+	require.NotContains(t, qualifiedName, "evil_table`); DROP")
 }

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -1344,12 +1344,11 @@ func TestIntegration(t *testing.T) {
 		t.Run("prevents SQL injection via malicious identifiers", func(t *testing.T) {
 			// Databricks/Delta rejects most special characters in identifiers
 			// (space, ; ( ) = , tab, newline) regardless of quoting, so the only
-			// backtick-quoting breakout character we can exercise is the backtick
-			// itself, which must be doubled. If it weren't, the generated SQL would
-			// malform (the identifier would terminate early) and the DDL would error.
-			maliciousTable := "evil_table`x"
-			maliciousColumn := "evil_col`x"
-			addedColumn := "added_col`x"
+			// backtick-quoting breakout character we can exercise in this live test
+			// is on columns, where the backtick must be doubled.
+			maliciousTable := "evil_table_drop_table"
+			maliciousColumn := "evil_col`drop_table"
+			addedColumn := "added_col`drop_table"
 			maliciousSchema := model.TableSchema{"id": "string", maliciousColumn: "string"}
 
 			// newMockUploader dereferences loadFiles[0], so pass a non-empty slice.

--- a/warehouse/integrations/deltalake/deltalake_test.go
+++ b/warehouse/integrations/deltalake/deltalake_test.go
@@ -1340,6 +1340,40 @@ func TestIntegration(t *testing.T) {
 			require.Equal(t, loadTableStat.RowsInserted, int64(14))
 			require.Equal(t, loadTableStat.RowsUpdated, int64(0))
 		})
+
+		t.Run("prevents SQL injection via malicious identifiers", func(t *testing.T) {
+			// Databricks/Delta rejects most special characters in identifiers
+			// (space, ; ( ) = , tab, newline) regardless of quoting, so the only
+			// backtick-quoting breakout character we can exercise is the backtick
+			// itself, which must be doubled. If it weren't, the generated SQL would
+			// malform (the identifier would terminate early) and the DDL would error.
+			maliciousTable := "evil_table`x"
+			maliciousColumn := "evil_col`x"
+			addedColumn := "added_col`x"
+			maliciousSchema := model.TableSchema{"id": "string", maliciousColumn: "string"}
+
+			// newMockUploader dereferences loadFiles[0], so pass a non-empty slice.
+			dummyLoadFiles := []whutils.LoadFile{{Location: "dummy.parquet"}}
+			d := deltalake.New(config.New(), logger.NOP, stats.NOP)
+			require.NoError(t, d.Setup(ctx, warehouse, newMockUploader(t, dummyLoadFiles, maliciousTable, maliciousSchema, maliciousSchema, whutils.LoadFileTypeParquet, false, false)))
+
+			require.NoError(t, d.CreateSchema(ctx))
+			require.NoError(t, d.CreateTable(ctx, maliciousTable, maliciousSchema))
+			require.NoError(t, d.AddColumns(ctx, maliciousTable, []whutils.ColumnInfo{{Name: addedColumn, Type: "string"}}))
+
+			// FetchSchema round-trips the actual stored identifiers - a dialect-agnostic
+			// way to confirm the malicious names were created verbatim (quoted, not injected).
+			schema, err := d.FetchSchema(ctx)
+			require.NoError(t, err)
+			require.Contains(t, schema, maliciousTable, "malicious table must be created verbatim")
+			require.Contains(t, schema[maliciousTable], maliciousColumn)
+			require.Contains(t, schema[maliciousTable], addedColumn)
+
+			require.NoError(t, d.DropTable(ctx, maliciousTable))
+			schema, err = d.FetchSchema(ctx)
+			require.NoError(t, err)
+			require.NotContains(t, schema, maliciousTable, "malicious table should have been dropped")
+		})
 	})
 
 	t.Run("Fetch Schema", func(t *testing.T) {

--- a/warehouse/integrations/mssql/mssql.go
+++ b/warehouse/integrations/mssql/mssql.go
@@ -208,7 +208,7 @@ func (ms *MSSQL) connectionCredentials() *credentials {
 
 func ColumnsWithDataTypes(columns model.TableSchema, prefix string) string {
 	formattedColumns := lo.MapToSlice(columns, func(name, dataType string) string {
-		return fmt.Sprintf(`"%s%s" %s`, prefix, name, rudderDataTypesMapToMssql[dataType])
+		return fmt.Sprintf(`%s %s`, warehouseutils.BracketQuoteIdentifier(prefix+name), rudderDataTypesMapToMssql[dataType])
 	})
 	return strings.Join(formattedColumns, ",")
 }
@@ -220,13 +220,12 @@ func (*MSSQL) IsEmpty(context.Context, model.Warehouse) (empty bool, err error) 
 func (ms *MSSQL) DeleteBy(ctx context.Context, tableNames []string, params warehouseutils.DeleteByParams) (err error) {
 	for _, tb := range tableNames {
 		ms.logger.Infon("MSSQL: Cleaning up the table", logger.NewStringField("table", tb))
-		sqlStatement := fmt.Sprintf(`DELETE FROM "%[1]s"."%[2]s" WHERE
+		sqlStatement := fmt.Sprintf(`DELETE FROM %s WHERE
 		context_sources_job_run_id <> @jobrunid AND
 		context_sources_task_run_id <> @taskrunid AND
 		context_source_id = @sourceid AND
 		received_at < @starttime`,
-			ms.namespace,
-			tb,
+			warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, tb),
 		)
 
 		ms.logger.Debugn("MSSQL: Deleting rows in table in mysql for MSSQL", obskit.DestinationID(ms.warehouse.Destination.ID))
@@ -291,12 +290,11 @@ func (ms *MSSQL) loadTable(
 	log.Debugn("creating staging table")
 	createStagingTableStmt := fmt.Sprintf(`
 		SELECT
-		  TOP 0 * INTO %[1]s.%[2]s
+		  TOP 0 * INTO %[1]s
 		FROM
-		  %[1]s.%[3]s;`,
-		ms.namespace,
-		stagingTableName,
-		tableName,
+		  %[2]s;`,
+		warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, stagingTableName),
+		warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, tableName),
 	)
 	if _, err = ms.db.ExecContext(ctx, createStagingTableStmt); err != nil {
 		return nil, "", fmt.Errorf("creating temporary table: %w", err)
@@ -323,7 +321,7 @@ func (ms *MSSQL) loadTable(
 	)
 
 	log.Debugn("creating prepared stmt for loading data")
-	copyInStmt := mssql.CopyIn(ms.namespace+"."+stagingTableName, mssql.BulkOptions{CheckConstraints: false},
+	copyInStmt := mssql.CopyIn(warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, stagingTableName), mssql.BulkOptions{CheckConstraints: false},
 		sortedColumnKeys...,
 	)
 	stmt, err := txn.PrepareContext(ctx, copyInStmt)
@@ -571,30 +569,27 @@ func (ms *MSSQL) deleteFromLoadTable(
 
 	var additionalDeleteStmtClause string
 	if tableName == warehouseutils.DiscardsTable {
-		additionalDeleteStmtClause = fmt.Sprintf(`AND _source.%[3]s = %[1]q.%[2]q.%[3]q AND _source.%[4]s = %[1]q.%[2]q.%[4]q`,
-			ms.namespace,
-			tableName,
-			"table_name",
-			"column_name",
+		additionalDeleteStmtClause = fmt.Sprintf(`AND _source.%[2]s = %[1]s.%[2]s AND _source.%[3]s = %[1]s.%[3]s`,
+			warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, tableName),
+			warehouseutils.BracketQuoteIdentifier("table_name"),
+			warehouseutils.BracketQuoteIdentifier("column_name"),
 		)
 	}
 
 	deleteStmt := fmt.Sprintf(`
-		DELETE FROM
-		  %[1]q.%[2]q
-		FROM
-		  %[1]q.%[3]q AS _source
-		WHERE
-		  (
-			_source.%[4]s = %[1]q.%[2]q.%[4]q %[5]s
-		  );`,
-		ms.namespace,
-		tableName,
-		stagingTableName,
-		primaryKey,
+			DELETE FROM
+			  %[1]s
+			FROM
+			  %[2]s AS _source
+			WHERE
+			  (
+				_source.%[3]s = %[1]s.%[3]s %[4]s
+			  );`,
+		warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, tableName),
+		warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, stagingTableName),
+		warehouseutils.BracketQuoteIdentifier(primaryKey),
 		additionalDeleteStmtClause,
 	)
-
 	r, err := txn.ExecContext(ctx, deleteStmt)
 	if err != nil {
 		return 0, fmt.Errorf("deleting from main table: %w", err)
@@ -614,35 +609,34 @@ func (ms *MSSQL) insertIntoLoadTable(
 		partitionKey = column
 	}
 
-	quotedColumnNames := warehouseutils.DoubleQuoteAndJoinByComma(
+	quotedColumnNames := warehouseutils.BracketQuoteAndJoinByComma(
 		sortedColumnKeys,
 	)
 
 	insertStmt := fmt.Sprintf(`
-		INSERT INTO %[1]q.%[2]q (%[3]s)
-		SELECT
-		  %[3]s
-		FROM
-		  (
+			INSERT INTO %[1]s (%[3]s)
 			SELECT
-			  *,
-			  ROW_NUMBER() OVER (
-				PARTITION BY %[5]s
-				ORDER BY
-				  received_at DESC
-			  ) AS _rudder_staging_row_number
+			  %[3]s
 			FROM
-			  %[1]q.%[4]q
-		  ) AS _
-		WHERE
-		  _rudder_staging_row_number = 1;`,
-		ms.namespace,
-		tableName,
+			  (
+				SELECT
+				  *,
+				  ROW_NUMBER() OVER (
+					PARTITION BY %[4]s
+					ORDER BY
+					  %[5]s DESC
+				  ) AS _rudder_staging_row_number
+				FROM
+				  %[2]s
+			  ) AS _
+			WHERE
+			  _rudder_staging_row_number = 1;`,
+		warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, tableName),
+		warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, stagingTableName),
 		quotedColumnNames,
-		stagingTableName,
-		partitionKey,
+		warehouseutils.QuoteCommaSeparatedIdentifiers(partitionKey, warehouseutils.BracketQuoteIdentifier),
+		warehouseutils.BracketQuoteIdentifier("received_at"),
 	)
-
 	r, err := txn.ExecContext(ctx, insertStmt)
 	if err != nil {
 		return 0, fmt.Errorf("inserting into main table: %w", err)
@@ -696,16 +690,16 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 		if colName == "id" {
 			continue
 		}
-		userColNames = append(userColNames, fmt.Sprintf(`%q`, colName))
+		userColNames = append(userColNames, warehouseutils.BracketQuoteIdentifier(colName))
 		caseSubQuery := fmt.Sprintf(`case
 						  when (exists(select 1)) then (
-						  	select "%[1]s" from %[2]s
-						  	where x.id = %[2]s.id
-							  and "%[1]s" is not null
+								select %[1]s from %[2]s
+								where x.[id] = %[2]s.[id]
+							  and %[1]s is not null
 							  order by received_at desc
 						  	OFFSET 0 ROWS
 							FETCH NEXT 1 ROWS ONLY)
-						  end as "%[1]s"`, colName, ms.namespace+"."+unionStagingTableName)
+						  end as %[1]s`, warehouseutils.BracketQuoteIdentifier(colName), warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, unionStagingTableName))
 
 		// IGNORE NULLS only supported in Azure SQL edge, in which case the query can be shortened to below
 		// https://docs.microsoft.com/en-us/sql/t-sql/functions/first-value-transact-sql?view=sql-server-ver15
@@ -716,12 +710,12 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 	// TODO: skipped top level temporary table for now
 	sqlStatement := fmt.Sprintf(`SELECT * into %[5]s FROM
 												((
-													SELECT id, %[4]s FROM %[2]s WHERE id in (SELECT user_id FROM %[3]s WHERE user_id IS NOT NULL)
+													SELECT [id], %[4]s FROM %[2]s WHERE [id] in (SELECT [user_id] FROM %[3]s WHERE [user_id] IS NOT NULL)
 												) UNION
 												(
-													SELECT user_id, %[4]s FROM %[3]s  WHERE user_id IS NOT NULL
+													SELECT [user_id], %[4]s FROM %[3]s  WHERE [user_id] IS NOT NULL
 												)) a
-											`, ms.namespace, ms.namespace+"."+warehouseutils.UsersTable, ms.namespace+"."+identifyStagingTable, strings.Join(userColNames, ","), ms.namespace+"."+unionStagingTableName)
+											`, ms.namespace, warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, warehouseutils.UsersTable), warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, identifyStagingTable), strings.Join(userColNames, ","), warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, unionStagingTableName))
 
 	ms.logger.Debugn("MSSQL: Creating staging table for union of users table with identify staging table", logger.NewStringField("statement", sqlStatement))
 	_, err = ms.db.ExecContext(ctx, sqlStatement)
@@ -733,13 +727,13 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 	sqlStatement = fmt.Sprintf(`SELECT * INTO %[1]s FROM (SELECT DISTINCT * FROM
 										(
 											SELECT
-											x.id, %[2]s
+											x.[id], %[2]s
 											FROM %[3]s as x
 										) as xyz
 									) a`,
-		ms.namespace+"."+stagingTableName,
+		warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, stagingTableName),
 		strings.Join(firstValProps, ","),
-		ms.namespace+"."+unionStagingTableName,
+		warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, unionStagingTableName),
 	)
 
 	ms.logger.Debugn("MSSQL: Creating staging table for users", logger.NewStringField("statement", sqlStatement))
@@ -758,7 +752,7 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 	}
 
 	primaryKey := "id"
-	sqlStatement = fmt.Sprintf(`DELETE FROM %[1]s."%[2]s" FROM %[3]s _source where (_source.%[4]s = %[1]s.%[2]s.%[4]s)`, ms.namespace, warehouseutils.UsersTable, ms.namespace+"."+stagingTableName, primaryKey)
+	sqlStatement = fmt.Sprintf(`DELETE FROM %[1]s FROM %[2]s _source where (_source.%[3]s = %[1]s.%[3]s)`, warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, warehouseutils.UsersTable), warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, stagingTableName), warehouseutils.BracketQuoteIdentifier(primaryKey))
 	ms.logger.Infon("MSSQL: Dedup records for table using staging table",
 		logger.NewStringField("table", warehouseutils.UsersTable),
 		logger.NewStringField("statement", sqlStatement))
@@ -770,7 +764,7 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 		return errorMap
 	}
 
-	sqlStatement = fmt.Sprintf(`INSERT INTO "%[1]s"."%[2]s" (%[4]s) SELECT %[4]s FROM  %[3]s`, ms.namespace, warehouseutils.UsersTable, ms.namespace+"."+stagingTableName, strings.Join(append([]string{"id"}, userColNames...), ","))
+	sqlStatement = fmt.Sprintf(`INSERT INTO %[1]s (%[3]s) SELECT %[3]s FROM %[2]s`, warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, warehouseutils.UsersTable), warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, stagingTableName), strings.Join(append([]string{warehouseutils.BracketQuoteIdentifier("id")}, userColNames...), ","))
 	ms.logger.Infon("MSSQL: Inserting records for table using staging table",
 		logger.NewStringField("table", warehouseutils.UsersTable),
 		logger.NewStringField("statement", sqlStatement))
@@ -793,8 +787,9 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 }
 
 func (ms *MSSQL) CreateSchema(ctx context.Context) (err error) {
-	sqlStatement := fmt.Sprintf(`IF NOT EXISTS ( SELECT  * FROM  sys.schemas WHERE   name = N'%s' )
-    EXEC('CREATE SCHEMA [%s]');`, ms.namespace, ms.namespace)
+	createSchemaStatement := fmt.Sprintf(`CREATE SCHEMA %s`, warehouseutils.BracketQuoteIdentifier(ms.namespace))
+	sqlStatement := fmt.Sprintf(`IF NOT EXISTS ( SELECT * FROM sys.schemas WHERE name = N%s )
+	    EXEC(%s);`, warehouseutils.SQLStringLiteral(ms.namespace), warehouseutils.SQLStringLiteral(createSchemaStatement))
 	ms.logger.Infon("MSSQL: Creating schema name in mssql for MSSQL",
 		logger.NewStringField(logfield.DestinationID, ms.warehouse.Destination.ID),
 		logger.NewStringField("statement", sqlStatement))
@@ -808,17 +803,18 @@ func (ms *MSSQL) CreateSchema(ctx context.Context) (err error) {
 func (ms *MSSQL) dropStagingTable(ctx context.Context, stagingTableName string) {
 	ms.logger.Infon("MSSQL: dropping table",
 		logger.NewStringField("stagingTableName", stagingTableName))
-	_, err := ms.db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, ms.namespace+"."+stagingTableName))
+	_, err := ms.db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, stagingTableName)))
 	if err != nil {
 		ms.logger.Errorn("MSSQL: Error dropping staging table in mssql",
-			logger.NewStringField("stagingTableName", ms.namespace+"."+stagingTableName),
+			logger.NewStringField("stagingTableName", warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, stagingTableName)),
 			obskit.Error(err))
 	}
 }
 
-func (ms *MSSQL) createTable(ctx context.Context, name string, columns model.TableSchema) (err error) {
-	sqlStatement := fmt.Sprintf(`IF  NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'%[1]s') AND type = N'U')
-	CREATE TABLE %[1]s ( %v )`, name, ColumnsWithDataTypes(columns, ""))
+func (ms *MSSQL) createTable(ctx context.Context, tableName string, columns model.TableSchema) (err error) {
+	tableIdentifier := warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, tableName)
+	sqlStatement := fmt.Sprintf(`IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N%s) AND type = N'U')
+		CREATE TABLE %s ( %v )`, warehouseutils.SQLStringLiteral(ms.namespace+"."+tableName), tableIdentifier, ColumnsWithDataTypes(columns, ""))
 
 	ms.logger.Infon("MSSQL: Creating table in mssql for MSSQL",
 		logger.NewStringField(logfield.DestinationID, ms.warehouse.Destination.ID),
@@ -829,16 +825,16 @@ func (ms *MSSQL) createTable(ctx context.Context, name string, columns model.Tab
 
 func (ms *MSSQL) CreateTable(ctx context.Context, tableName string, columnMap model.TableSchema) (err error) {
 	// Search paths doesn't exist unlike Postgres, default is dbo. Hence, use namespace wherever possible
-	err = ms.createTable(ctx, ms.namespace+"."+tableName, columnMap)
+	err = ms.createTable(ctx, tableName, columnMap)
 	return err
 }
 
 func (ms *MSSQL) DropTable(ctx context.Context, tableName string) (err error) {
-	sqlStatement := `DROP TABLE "%[1]s"."%[2]s"`
+	sqlStatement := `DROP TABLE %s`
 	ms.logger.Infon("AZ: Dropping table in synapse for AZ",
 		logger.NewStringField(logfield.DestinationID, ms.warehouse.Destination.ID),
 		logger.NewStringField("sqlStatement", sqlStatement))
-	_, err = ms.db.ExecContext(ctx, fmt.Sprintf(sqlStatement, ms.namespace, tableName))
+	_, err = ms.db.ExecContext(ctx, fmt.Sprintf(sqlStatement, warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, tableName)))
 	return err
 }
 
@@ -850,31 +846,29 @@ func (ms *MSSQL) AddColumns(ctx context.Context, tableName string, columnsInfo [
 
 	if len(columnsInfo) == 1 {
 		queryBuilder.WriteString(fmt.Sprintf(`
-			IF NOT EXISTS (
-			  SELECT
-				1
-			  FROM
-				SYS.COLUMNS
-			  WHERE
-				OBJECT_ID = OBJECT_ID(N'%[1]s.%[2]s')
-				AND name = '%[3]s'
-			)`,
-			ms.namespace,
-			tableName,
-			columnsInfo[0].Name,
+				IF NOT EXISTS (
+				  SELECT
+					1
+				  FROM
+					SYS.COLUMNS
+				  WHERE
+					OBJECT_ID = OBJECT_ID(N%s)
+					AND name = %s
+				)`,
+			warehouseutils.SQLStringLiteral(ms.namespace+"."+tableName),
+			warehouseutils.SQLStringLiteral(columnsInfo[0].Name),
 		))
 	}
 
 	queryBuilder.WriteString(fmt.Sprintf(`
-		ALTER TABLE
-		  %s.%s
-		ADD`,
-		ms.namespace,
-		tableName,
+			ALTER TABLE
+			  %s
+			ADD`,
+		warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, tableName),
 	))
 
 	for _, columnInfo := range columnsInfo {
-		queryBuilder.WriteString(fmt.Sprintf(` %q %s,`, columnInfo.Name, rudderDataTypesMapToMssql[columnInfo.Type]))
+		queryBuilder.WriteString(fmt.Sprintf(` %s %s,`, warehouseutils.BracketQuoteIdentifier(columnInfo.Name), rudderDataTypesMapToMssql[columnInfo.Type]))
 	}
 
 	query = strings.TrimSuffix(queryBuilder.String(), ",")
@@ -882,7 +876,7 @@ func (ms *MSSQL) AddColumns(ctx context.Context, tableName string, columnsInfo [
 
 	ms.logger.Infon("MSSQL: Adding columns",
 		logger.NewStringField(logfield.DestinationID, ms.warehouse.Destination.ID),
-		logger.NewStringField("tableName", tableName),
+		logger.NewStringField(logfield.TableName, tableName),
 		logger.NewStringField("query", query))
 	_, err = ms.db.ExecContext(ctx, query)
 	return err
@@ -952,7 +946,7 @@ func (ms *MSSQL) dropDanglingStagingTables(ctx context.Context) error {
 		logger.NewIntField("count", int64(len(stagingTableNames))),
 		logger.NewStringField("stagingTableNames", fmt.Sprintf("%+v", stagingTableNames)))
 	for _, stagingTableName := range stagingTableNames {
-		_, err := ms.db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE "%[1]s"."%[2]s"`, ms.namespace, stagingTableName))
+		_, err := ms.db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE %s`, warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, stagingTableName)))
 		if err != nil {
 			return fmt.Errorf("dropping dangling staging tables %q.%q : %w", ms.namespace, stagingTableName, err)
 		}
@@ -1073,10 +1067,9 @@ func (ms *MSSQL) Connect(_ context.Context, warehouse model.Warehouse) (client.C
 }
 
 func (ms *MSSQL) TestLoadTable(ctx context.Context, _, tableName string, payloadMap map[string]any, _ string) (err error) {
-	sqlStatement := fmt.Sprintf(`INSERT INTO %q.%q (%v) VALUES (%s)`,
-		ms.namespace,
-		tableName,
-		fmt.Sprintf(`%q, %q`, "id", "val"),
+	sqlStatement := fmt.Sprintf(`INSERT INTO %s (%v) VALUES (%s)`,
+		warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, tableName),
+		warehouseutils.BracketQuoteAndJoinByComma([]string{"id", "val"}),
 		fmt.Sprintf(`'%d', '%s'`, payloadMap["id"], payloadMap["val"]),
 	)
 	_, err = ms.db.ExecContext(ctx, sqlStatement)

--- a/warehouse/integrations/mssql/mssql.go
+++ b/warehouse/integrations/mssql/mssql.go
@@ -708,14 +708,14 @@ func (ms *MSSQL) loadUserTables(ctx context.Context) (errorMap map[string]error)
 	}
 
 	// TODO: skipped top level temporary table for now
-	sqlStatement := fmt.Sprintf(`SELECT * into %[5]s FROM
+	sqlStatement := fmt.Sprintf(`SELECT * into %[4]s FROM
 												((
-													SELECT [id], %[4]s FROM %[2]s WHERE [id] in (SELECT [user_id] FROM %[3]s WHERE [user_id] IS NOT NULL)
+													SELECT [id], %[3]s FROM %[1]s WHERE [id] in (SELECT [user_id] FROM %[2]s WHERE [user_id] IS NOT NULL)
 												) UNION
 												(
-													SELECT [user_id], %[4]s FROM %[3]s  WHERE [user_id] IS NOT NULL
+													SELECT [user_id], %[3]s FROM %[2]s  WHERE [user_id] IS NOT NULL
 												)) a
-											`, ms.namespace, warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, warehouseutils.UsersTable), warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, identifyStagingTable), strings.Join(userColNames, ","), warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, unionStagingTableName))
+											`, warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, warehouseutils.UsersTable), warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, identifyStagingTable), strings.Join(userColNames, ","), warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, unionStagingTableName))
 
 	ms.logger.Debugn("MSSQL: Creating staging table for union of users table with identify staging table", logger.NewStringField("statement", sqlStatement))
 	_, err = ms.db.ExecContext(ctx, sqlStatement)
@@ -918,11 +918,11 @@ func (ms *MSSQL) dropDanglingStagingTables(ctx context.Context) error {
 		from
 		  information_schema.tables
 		where
-		  table_schema = '%s'
-		  AND table_name like '%s';
+		  table_schema = %s
+		  AND table_name like %s;
 	`,
-		ms.namespace,
-		fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider)),
+		warehouseutils.SQLStringLiteral(ms.namespace),
+		warehouseutils.SQLStringLiteral(fmt.Sprintf(`%s%%`, warehouseutils.StagingTablePrefix(provider))),
 	)
 	rows, err := ms.db.QueryContext(ctx, sqlStatement)
 	if err != nil {

--- a/warehouse/integrations/mssql/mssql.go
+++ b/warehouse/integrations/mssql/mssql.go
@@ -814,7 +814,7 @@ func (ms *MSSQL) dropStagingTable(ctx context.Context, stagingTableName string) 
 func (ms *MSSQL) createTable(ctx context.Context, tableName string, columns model.TableSchema) (err error) {
 	tableIdentifier := warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, tableName)
 	sqlStatement := fmt.Sprintf(`IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N%s) AND type = N'U')
-		CREATE TABLE %s ( %v )`, warehouseutils.SQLStringLiteral(ms.namespace+"."+tableName), tableIdentifier, ColumnsWithDataTypes(columns, ""))
+		CREATE TABLE %s ( %v )`, warehouseutils.SQLStringLiteral(warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, tableName)), tableIdentifier, ColumnsWithDataTypes(columns, ""))
 
 	ms.logger.Infon("MSSQL: Creating table in mssql for MSSQL",
 		logger.NewStringField(logfield.DestinationID, ms.warehouse.Destination.ID),
@@ -855,7 +855,7 @@ func (ms *MSSQL) AddColumns(ctx context.Context, tableName string, columnsInfo [
 					OBJECT_ID = OBJECT_ID(N%s)
 					AND name = %s
 				)`,
-			warehouseutils.SQLStringLiteral(ms.namespace+"."+tableName),
+			warehouseutils.SQLStringLiteral(warehouseutils.BracketQuoteQualifiedIdentifier(ms.namespace, tableName)),
 			warehouseutils.SQLStringLiteral(columnsInfo[0].Name),
 		))
 	}

--- a/warehouse/integrations/mssql/mssql_quoting_test.go
+++ b/warehouse/integrations/mssql/mssql_quoting_test.go
@@ -1,0 +1,24 @@
+package mssql_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/warehouse/integrations/mssql"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+)
+
+// TestColumnsWithDataTypesQuotesBracketIdentifiers ensures a malicious column
+// name cannot break out of the bracket-delimited identifier in the generated
+// CREATE TABLE column fragment. The closing bracket must be doubled.
+func TestColumnsWithDataTypesQuotesBracketIdentifiers(t *testing.T) {
+	columnName := `x] int); DROP TABLE users; --`
+
+	fragment := mssql.ColumnsWithDataTypes(model.TableSchema{
+		columnName: model.StringDataType,
+	}, "")
+
+	require.Contains(t, fragment, `[x]] int); DROP TABLE users; --]`)
+	require.NotContains(t, fragment, `x] int); DROP`)
+}

--- a/warehouse/integrations/mssql/mssql_test.go
+++ b/warehouse/integrations/mssql/mssql_test.go
@@ -815,8 +815,9 @@ func TestIntegration(t *testing.T) {
 			maliciousTable := `evil_table]` + dropVictim
 			maliciousColumn := `evil_col] int)` + dropVictim
 			addedColumn := `added_col] int)` + dropVictim
+			backslashColumn := `evil_bs\`
 
-			maliciousSchema := model.TableSchema{"id": "string", maliciousColumn: "string"}
+			maliciousSchema := model.TableSchema{"id": "string", maliciousColumn: "string", backslashColumn: "string"}
 
 			maliciousWarehouse := warehouse
 			maliciousWarehouse.Namespace = maliciousNamespace
@@ -830,12 +831,20 @@ func TestIntegration(t *testing.T) {
 			require.NoError(t, ms.CreateTable(ctx, maliciousTable, maliciousSchema))
 			require.NoError(t, ms.AddColumns(ctx, maliciousTable, []whutils.ColumnInfo{{Name: addedColumn, Type: "string"}}))
 
+			// Re-running must be a no-op: the OBJECT_ID existence guard has to resolve
+			// the bracket-quoted name. If it uses the raw name it returns NULL for a
+			// name needing quoting (] and spaces here), the guard fails open, and the
+			// CREATE/ALTER re-runs and errors ("already an object named" / duplicate column).
+			require.NoError(t, ms.CreateTable(ctx, maliciousTable, maliciousSchema), "CreateTable must be idempotent - existence guard must match the quoted name")
+			require.NoError(t, ms.AddColumns(ctx, maliciousTable, []whutils.ColumnInfo{{Name: addedColumn, Type: "string"}}), "AddColumns must be idempotent - existence guard must match the quoted name")
+
 			// FetchSchema round-trips the stored identifiers - dialect-agnostic verification.
 			schema, err := ms.FetchSchema(ctx)
 			require.NoError(t, err)
 			require.Contains(t, schema, "victim_secrets", "victim table must survive - the injection executed")
 			require.Contains(t, schema, maliciousTable, "malicious table must be created verbatim")
 			require.Contains(t, schema[maliciousTable], maliciousColumn)
+			require.Contains(t, schema[maliciousTable], backslashColumn, "trailing-backslash column must round-trip verbatim")
 			require.Contains(t, schema[maliciousTable], addedColumn)
 
 			// DropTable must also quote the identifier - a broken drop would inject a second DROP.

--- a/warehouse/integrations/mssql/mssql_test.go
+++ b/warehouse/integrations/mssql/mssql_test.go
@@ -808,6 +808,43 @@ func TestIntegration(t *testing.T) {
 				{"7274e5db-f918-4efe-5322-872f66e235c5", "2022-12-15T06:53:49Z", "", "2022-12-15T06:53:49Z", "", "", ""},
 			})
 		})
+
+		t.Run("prevents SQL injection via malicious identifiers", func(t *testing.T) {
+			dropVictim := `; DROP TABLE victim_secrets; --`
+			maliciousNamespace := `evil_ns]` + dropVictim
+			maliciousTable := `evil_table]` + dropVictim
+			maliciousColumn := `evil_col] int)` + dropVictim
+			addedColumn := `added_col] int)` + dropVictim
+
+			maliciousSchema := model.TableSchema{"id": "string", maliciousColumn: "string"}
+
+			maliciousWarehouse := warehouse
+			maliciousWarehouse.Namespace = maliciousNamespace
+
+			ms := mssql.New(config.New(), logger.NOP, stats.NOP)
+			require.NoError(t, ms.Setup(ctx, maliciousWarehouse, newMockUploader(t, nil, maliciousTable, maliciousSchema, maliciousSchema)))
+
+			require.NoError(t, ms.CreateSchema(ctx))
+			// Victim (control) table created through the manager itself.
+			require.NoError(t, ms.CreateTable(ctx, "victim_secrets", model.TableSchema{"id": "string"}))
+			require.NoError(t, ms.CreateTable(ctx, maliciousTable, maliciousSchema))
+			require.NoError(t, ms.AddColumns(ctx, maliciousTable, []whutils.ColumnInfo{{Name: addedColumn, Type: "string"}}))
+
+			// FetchSchema round-trips the stored identifiers - dialect-agnostic verification.
+			schema, err := ms.FetchSchema(ctx)
+			require.NoError(t, err)
+			require.Contains(t, schema, "victim_secrets", "victim table must survive - the injection executed")
+			require.Contains(t, schema, maliciousTable, "malicious table must be created verbatim")
+			require.Contains(t, schema[maliciousTable], maliciousColumn)
+			require.Contains(t, schema[maliciousTable], addedColumn)
+
+			// DropTable must also quote the identifier - a broken drop would inject a second DROP.
+			require.NoError(t, ms.DropTable(ctx, maliciousTable))
+			schema, err = ms.FetchSchema(ctx)
+			require.NoError(t, err)
+			require.Contains(t, schema, "victim_secrets", "victim table must survive DropTable injection")
+			require.NotContains(t, schema, maliciousTable, "malicious table should have been dropped")
+		})
 	})
 }
 

--- a/warehouse/integrations/postgres/load.go
+++ b/warehouse/integrations/postgres/load.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lib/pq"
-
 	"github.com/rudderlabs/rudder-go-kit/logger"
 
 	"github.com/rudderlabs/rudder-server/utils/misc"
@@ -35,11 +33,7 @@ type loadUsersTableResponse struct {
 // (e.g. a composite partition key) by quoting each column individually and
 // re-joining them, so the result is valid in a PARTITION BY / column list.
 func quoteColumnList(columns string) string {
-	parts := strings.Split(columns, ",")
-	for i, c := range parts {
-		parts[i] = pq.QuoteIdentifier(strings.TrimSpace(c))
-	}
-	return strings.Join(parts, ", ")
+	return warehouseutils.QuoteCommaSeparatedIdentifiers(columns, warehouseutils.DoubleQuoteIdentifier)
 }
 
 func (pg *Postgres) LoadTable(ctx context.Context, tableName string) (*types.LoadTableStats, error) {
@@ -85,7 +79,7 @@ func (pg *Postgres) loadTable(
 
 	log.Debugn("setting search path")
 	searchPathStmt := fmt.Sprintf(`SET search_path TO %s;`,
-		pq.QuoteIdentifier(pg.Namespace),
+		warehouseutils.DoubleQuoteIdentifier(pg.Namespace),
 	)
 	if _, err := txn.ExecContext(ctx, searchPathStmt); err != nil {
 		return nil, "", fmt.Errorf("setting search path: %w", err)
@@ -109,9 +103,9 @@ func (pg *Postgres) loadTable(
 	createStagingTableStmt := fmt.Sprintf(
 		`CREATE TEMPORARY TABLE %[2]s (LIKE %[1]s.%[3]s)
 		ON COMMIT PRESERVE ROWS;`,
-		pq.QuoteIdentifier(pg.Namespace),
-		pq.QuoteIdentifier(stagingTableName),
-		pq.QuoteIdentifier(tableName),
+		warehouseutils.DoubleQuoteIdentifier(pg.Namespace),
+		warehouseutils.DoubleQuoteIdentifier(stagingTableName),
+		warehouseutils.DoubleQuoteIdentifier(tableName),
 	)
 	if _, err := txn.ExecContext(ctx, createStagingTableStmt); err != nil {
 		return nil, "", fmt.Errorf("creating temporary table: %w", err)
@@ -243,10 +237,10 @@ func (pg *Postgres) deleteFromLoadTable(
 	if tableName == warehouseutils.DiscardsTable {
 		additionalJoinClause = fmt.Sprintf(
 			`AND _source.%[3]s = %[1]s.%[2]s.%[3]s AND _source.%[4]s = %[1]s.%[2]s.%[4]s`,
-			pq.QuoteIdentifier(pg.Namespace),
-			pq.QuoteIdentifier(tableName),
-			pq.QuoteIdentifier("table_name"),
-			pq.QuoteIdentifier("column_name"),
+			warehouseutils.DoubleQuoteIdentifier(pg.Namespace),
+			warehouseutils.DoubleQuoteIdentifier(tableName),
+			warehouseutils.DoubleQuoteIdentifier("table_name"),
+			warehouseutils.DoubleQuoteIdentifier("column_name"),
 		)
 	}
 
@@ -257,10 +251,10 @@ func (pg *Postgres) deleteFromLoadTable(
 		  (
 			_source.%[4]s = %[1]s.%[2]s.%[4]s %[5]s
 		  );`,
-		pq.QuoteIdentifier(pg.Namespace),
-		pq.QuoteIdentifier(tableName),
-		pq.QuoteIdentifier(stagingTableName),
-		pq.QuoteIdentifier(primaryKey),
+		warehouseutils.DoubleQuoteIdentifier(pg.Namespace),
+		warehouseutils.DoubleQuoteIdentifier(tableName),
+		warehouseutils.DoubleQuoteIdentifier(stagingTableName),
+		warehouseutils.DoubleQuoteIdentifier(primaryKey),
 		additionalJoinClause,
 	)
 
@@ -307,10 +301,10 @@ func (pg *Postgres) insertIntoLoadTable(
 		  ) AS _
 		WHERE
 		  _rudder_staging_row_number = 1;`,
-		pq.QuoteIdentifier(pg.Namespace),
-		pq.QuoteIdentifier(tableName),
+		warehouseutils.DoubleQuoteIdentifier(pg.Namespace),
+		warehouseutils.DoubleQuoteIdentifier(tableName),
 		quotedColumnNames,
-		pq.QuoteIdentifier(stagingTableName),
+		warehouseutils.DoubleQuoteIdentifier(stagingTableName),
 		quotedPartitionKey,
 	)
 
@@ -413,7 +407,7 @@ func (pg *Postgres) loadUsersTable(
 		if colName == "id" {
 			continue
 		}
-		userColNames = append(userColNames, pq.QuoteIdentifier(colName))
+		userColNames = append(userColNames, warehouseutils.DoubleQuoteIdentifier(colName))
 		caseSubQuery := fmt.Sprintf(
 			`CASE WHEN (
 			  SELECT true
@@ -424,8 +418,8 @@ func (pg *Postgres) loadUsersTable(
 			  ORDER BY received_at DESC
 			  LIMIT 1
 			) END AS %[1]s`,
-			pq.QuoteIdentifier(colName),
-			pq.QuoteIdentifier(unionStagingTableName),
+			warehouseutils.DoubleQuoteIdentifier(colName),
+			warehouseutils.DoubleQuoteIdentifier(unionStagingTableName),
 		)
 		firstValProps = append(firstValProps, caseSubQuery)
 	}
@@ -448,11 +442,11 @@ func (pg *Postgres) loadUsersTable(
 				WHERE user_id IS NOT NULL
 			)
 		);`,
-		pq.QuoteIdentifier(pg.Namespace),
-		pq.QuoteIdentifier(warehouseutils.UsersTable),
-		pq.QuoteIdentifier(identifyStagingTable),
+		warehouseutils.DoubleQuoteIdentifier(pg.Namespace),
+		warehouseutils.DoubleQuoteIdentifier(warehouseutils.UsersTable),
+		warehouseutils.DoubleQuoteIdentifier(identifyStagingTable),
 		strings.Join(userColNames, ","),
-		pq.QuoteIdentifier(unionStagingTableName),
+		warehouseutils.DoubleQuoteIdentifier(unionStagingTableName),
 	)
 
 	pg.logger.Infon("creating union staging users table",
@@ -474,7 +468,7 @@ func (pg *Postgres) loadUsersTable(
 
 	query = fmt.Sprintf(`
 		CREATE INDEX users_identifies_union_id_idx ON %[1]s (id);`,
-		pq.QuoteIdentifier(unionStagingTableName),
+		warehouseutils.DoubleQuoteIdentifier(unionStagingTableName),
 	)
 	pg.logger.Debugn("creating index on union staging users table",
 		logger.NewStringField(logfield.SourceID, pg.Warehouse.Source.ID),
@@ -506,9 +500,9 @@ func (pg *Postgres) loadUsersTable(
 			) AS xyz
 		);
 `,
-		pq.QuoteIdentifier(usersStagingTableName),
+		warehouseutils.DoubleQuoteIdentifier(usersStagingTableName),
 		strings.Join(firstValProps, ","),
-		pq.QuoteIdentifier(unionStagingTableName),
+		warehouseutils.DoubleQuoteIdentifier(unionStagingTableName),
 	)
 
 	pg.logger.Debugn("creating temporary users table",
@@ -533,10 +527,10 @@ func (pg *Postgres) loadUsersTable(
 	query = fmt.Sprintf(`
 		DELETE FROM %[1]s.%[2]s using %[3]s _source
 		WHERE _source.%[4]s = %[1]s.%[2]s.%[4]s;`,
-		pq.QuoteIdentifier(pg.Namespace),
-		pq.QuoteIdentifier(warehouseutils.UsersTable),
-		pq.QuoteIdentifier(usersStagingTableName),
-		pq.QuoteIdentifier(primaryKey),
+		warehouseutils.DoubleQuoteIdentifier(pg.Namespace),
+		warehouseutils.DoubleQuoteIdentifier(warehouseutils.UsersTable),
+		warehouseutils.DoubleQuoteIdentifier(usersStagingTableName),
+		warehouseutils.DoubleQuoteIdentifier(primaryKey),
 	)
 
 	pg.logger.Infon("deduplication for users table",
@@ -564,10 +558,10 @@ func (pg *Postgres) loadUsersTable(
 		FROM
 		  %[3]s;
 `,
-		pq.QuoteIdentifier(pg.Namespace),
-		pq.QuoteIdentifier(warehouseutils.UsersTable),
-		pq.QuoteIdentifier(usersStagingTableName),
-		strings.Join(append([]string{pq.QuoteIdentifier("id")}, userColNames...), ","),
+		warehouseutils.DoubleQuoteIdentifier(pg.Namespace),
+		warehouseutils.DoubleQuoteIdentifier(warehouseutils.UsersTable),
+		warehouseutils.DoubleQuoteIdentifier(usersStagingTableName),
+		strings.Join(append([]string{warehouseutils.DoubleQuoteIdentifier("id")}, userColNames...), ","),
 	)
 	pg.logger.Infon("inserting records to users table",
 		logger.NewStringField(logfield.SourceID, pg.Warehouse.Source.ID),

--- a/warehouse/integrations/postgres/postgres.go
+++ b/warehouse/integrations/postgres/postgres.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lib/pq"
-
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
@@ -258,7 +256,7 @@ func (pg *Postgres) getConnectionCredentials() credentials {
 func ColumnsWithDataTypes(columns model.TableSchema, prefix string) string {
 	var arr []string
 	for name, dataType := range columns {
-		arr = append(arr, fmt.Sprintf(`%s %s`, pq.QuoteIdentifier(prefix+name), rudderDataTypesMapToPostgres[dataType]))
+		arr = append(arr, fmt.Sprintf(`%s %s`, warehouseutils.DoubleQuoteIdentifier(prefix+name), rudderDataTypesMapToPostgres[dataType]))
 	}
 	return strings.Join(arr, ",")
 }
@@ -280,8 +278,8 @@ func (pg *Postgres) DeleteBy(ctx context.Context, tableNames []string, params wa
 		context_sources_task_run_id <> $2 AND
 		context_source_id = $3 AND
 		received_at < $4`,
-			pq.QuoteIdentifier(pg.Namespace),
-			pq.QuoteIdentifier(tb),
+			warehouseutils.DoubleQuoteIdentifier(pg.Namespace),
+			warehouseutils.DoubleQuoteIdentifier(tb),
 		)
 		pg.logger.Infon("PG: Deleting rows in table in postgres for PG",
 			logger.NewStringField(logfield.DestinationID, pg.Warehouse.Destination.ID),
@@ -305,9 +303,12 @@ func (pg *Postgres) DeleteBy(ctx context.Context, tableNames []string, params wa
 	return nil
 }
 
-func (pg *Postgres) schemaExists(ctx context.Context, _ string) (exists bool, err error) {
-	sqlStatement := fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = '%s');`, pg.Namespace)
-	err = pg.DB.QueryRowContext(ctx, sqlStatement).Scan(&exists)
+func (pg *Postgres) schemaExists(ctx context.Context, namespace string) (exists bool, err error) {
+	err = pg.DB.QueryRowContext(
+		ctx,
+		`SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = $1);`,
+		namespace,
+	).Scan(&exists)
 	return exists, err
 }
 
@@ -327,7 +328,7 @@ func (pg *Postgres) CreateSchema(ctx context.Context) (err error) {
 		)
 		return err
 	}
-	sqlStatement := fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`, pq.QuoteIdentifier(pg.Namespace))
+	sqlStatement := fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`, warehouseutils.DoubleQuoteIdentifier(pg.Namespace))
 	pg.logger.Infon("PG: Creating schema name in postgres for PG",
 		logger.NewStringField(logfield.DestinationID, pg.Warehouse.Destination.ID),
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -337,7 +338,7 @@ func (pg *Postgres) CreateSchema(ctx context.Context) (err error) {
 }
 
 func (pg *Postgres) createTable(ctx context.Context, name string, columns model.TableSchema) (err error) {
-	sqlStatement := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %[1]s.%[2]s ( %v )`, pq.QuoteIdentifier(pg.Namespace), pq.QuoteIdentifier(name), ColumnsWithDataTypes(columns, ""))
+	sqlStatement := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %[1]s.%[2]s ( %v )`, warehouseutils.DoubleQuoteIdentifier(pg.Namespace), warehouseutils.DoubleQuoteIdentifier(name), ColumnsWithDataTypes(columns, ""))
 	pg.logger.Infon("PG: Creating table in postgres for PG",
 		logger.NewStringField(logfield.DestinationID, pg.Warehouse.Destination.ID),
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -348,7 +349,7 @@ func (pg *Postgres) createTable(ctx context.Context, name string, columns model.
 
 func (pg *Postgres) CreateTable(ctx context.Context, tableName string, columnMap model.TableSchema) (err error) {
 	// set the schema in search path. so that we can query table with unqualified name which is just the table name rather than using schema.table in queries
-	sqlStatement := fmt.Sprintf(`SET search_path to %s`, pq.QuoteIdentifier(pg.Namespace))
+	sqlStatement := fmt.Sprintf(`SET search_path to %s`, warehouseutils.DoubleQuoteIdentifier(pg.Namespace))
 	_, err = pg.DB.ExecContext(ctx, sqlStatement)
 	if err != nil {
 		return err
@@ -363,7 +364,7 @@ func (pg *Postgres) CreateTable(ctx context.Context, tableName string, columnMap
 }
 
 func (pg *Postgres) DropTable(ctx context.Context, tableName string) (err error) {
-	sqlStatement := fmt.Sprintf(`DROP TABLE %[1]s.%[2]s`, pq.QuoteIdentifier(pg.Namespace), pq.QuoteIdentifier(tableName))
+	sqlStatement := fmt.Sprintf(`DROP TABLE %[1]s.%[2]s`, warehouseutils.DoubleQuoteIdentifier(pg.Namespace), warehouseutils.DoubleQuoteIdentifier(tableName))
 	pg.logger.Infon("PG: Dropping table in postgres for PG",
 		logger.NewStringField(logfield.DestinationID, pg.Warehouse.Destination.ID),
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -379,7 +380,7 @@ func (pg *Postgres) AddColumns(ctx context.Context, tableName string, columnsInf
 	)
 
 	// set the schema in search path. so that we can query table with unqualified name which is just the table name rather than using schema.table in queries
-	query = fmt.Sprintf(`SET search_path to %s`, pq.QuoteIdentifier(pg.Namespace))
+	query = fmt.Sprintf(`SET search_path to %s`, warehouseutils.DoubleQuoteIdentifier(pg.Namespace))
 	if _, err = pg.DB.ExecContext(ctx, query); err != nil {
 		return err
 	}
@@ -392,12 +393,12 @@ func (pg *Postgres) AddColumns(ctx context.Context, tableName string, columnsInf
 	queryBuilder.WriteString(fmt.Sprintf(`
 		ALTER TABLE
 		  %s.%s`,
-		pq.QuoteIdentifier(pg.Namespace),
-		pq.QuoteIdentifier(tableName),
+		warehouseutils.DoubleQuoteIdentifier(pg.Namespace),
+		warehouseutils.DoubleQuoteIdentifier(tableName),
 	))
 
 	for _, columnInfo := range columnsInfo {
-		queryBuilder.WriteString(fmt.Sprintf(` ADD COLUMN IF NOT EXISTS %s %s,`, pq.QuoteIdentifier(columnInfo.Name), rudderDataTypesMapToPostgres[columnInfo.Type]))
+		queryBuilder.WriteString(fmt.Sprintf(` ADD COLUMN IF NOT EXISTS %s %s,`, warehouseutils.DoubleQuoteIdentifier(columnInfo.Name), rudderDataTypesMapToPostgres[columnInfo.Type]))
 	}
 
 	query = strings.TrimSuffix(queryBuilder.String(), ",")
@@ -539,9 +540,9 @@ func (pg *Postgres) Connect(_ context.Context, warehouse model.Warehouse) (clien
 
 func (pg *Postgres) TestLoadTable(ctx context.Context, _, tableName string, payloadMap map[string]any, _ string) (err error) {
 	sqlStatement := fmt.Sprintf(`INSERT INTO %s.%s (%v) VALUES (%s)`,
-		pq.QuoteIdentifier(pg.Namespace),
-		pq.QuoteIdentifier(tableName),
-		fmt.Sprintf(`%s, %s`, pq.QuoteIdentifier("id"), pq.QuoteIdentifier("val")),
+		warehouseutils.DoubleQuoteIdentifier(pg.Namespace),
+		warehouseutils.DoubleQuoteIdentifier(tableName),
+		fmt.Sprintf(`%s, %s`, warehouseutils.DoubleQuoteIdentifier("id"), warehouseutils.DoubleQuoteIdentifier("val")),
 		fmt.Sprintf(`'%d', '%s'`, payloadMap["id"], payloadMap["val"]),
 	)
 	_, err = pg.DB.ExecContext(ctx, sqlStatement)

--- a/warehouse/integrations/postgres/postgres_test.go
+++ b/warehouse/integrations/postgres/postgres_test.go
@@ -55,49 +55,6 @@ func TestColumnsWithDataTypesQuotesIdentifiers(t *testing.T) {
 	require.NotContains(t, fragment, `x" text);`)
 }
 
-type panicSafeCleaner struct {
-	testing.TB
-}
-
-func (c panicSafeCleaner) Cleanup(fn func()) {
-	c.TB.Cleanup(func() {
-		defer func() {
-			if r := recover(); r != nil {
-				c.Logf("recovered panic from Docker cleanup: %v", r)
-			}
-		}()
-		fn()
-	})
-}
-
-func setupSSHServerWithRetry(t testing.TB, pool *dockertest.Pool, opts ...sshserver.Option) (*sshserver.Resource, error) {
-	t.Helper()
-
-	var lastErr error
-	cleaner := panicSafeCleaner{TB: t}
-	for attempt := 1; attempt <= 3; attempt++ {
-		resource, err := sshserver.Setup(pool, cleaner, opts...)
-		if err == nil {
-			return resource, nil
-		}
-		lastErr = err
-		if attempt == 3 || !isTransientDockerSetupError(err) {
-			break
-		}
-		t.Logf("retrying SSH server setup after transient Docker error (attempt %d): %v", attempt, err)
-		time.Sleep(time.Duration(attempt) * time.Second)
-	}
-	return nil, lastErr
-}
-
-func isTransientDockerSetupError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "toomanyrequests") || strings.Contains(msg, "too many requests")
-}
-
 func TestIntegration(t *testing.T) {
 	if os.Getenv("SLOW") != "1" {
 		t.Skip("Skipping tests. Add 'SLOW=1' env var to run test.")
@@ -501,7 +458,7 @@ func TestIntegration(t *testing.T) {
 
 		postgresResource, err := dockerpg.Setup(pool, t, dockerpg.WithNetwork(network))
 		require.NoError(t, err)
-		sshServerResource, err := setupSSHServerWithRetry(t, pool,
+		sshServerResource, err := sshserver.Setup(pool, t,
 			sshserver.WithPublicKeyPath(publicKeyPath),
 			sshserver.WithCredentials("linuxserver.io", ""),
 			sshserver.WithDockerNetwork(network),

--- a/warehouse/integrations/postgres/postgres_test.go
+++ b/warehouse/integrations/postgres/postgres_test.go
@@ -5,13 +5,11 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/lib/pq"
 	"github.com/lib/pq/pqerror"
 	"github.com/ory/dockertest/v3"
@@ -37,7 +35,6 @@ import (
 	"github.com/rudderlabs/rudder-server/testhelper/backendconfigtest"
 	"github.com/rudderlabs/rudder-server/utils/misc"
 	"github.com/rudderlabs/rudder-server/warehouse/client"
-	sqlmiddleware "github.com/rudderlabs/rudder-server/warehouse/integrations/middleware/sqlquerywrapper"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/postgres"
 	whth "github.com/rudderlabs/rudder-server/warehouse/integrations/testhelper"
 	"github.com/rudderlabs/rudder-server/warehouse/integrations/tunnelling"
@@ -56,28 +53,6 @@ func TestColumnsWithDataTypesQuotesIdentifiers(t *testing.T) {
 
 	require.Equal(t, `"x"" text);copy (select '') to program 'id>/tmp/rce';--" text`, fragment)
 	require.NotContains(t, fragment, `x" text);`)
-}
-
-func TestCreateTableQuotesSchemaAndTableIdentifiers(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer db.Close()
-
-	namespace := `schema";drop schema public;--`
-	tableName := `events");copy (select '') to program 'id>/tmp/rce';--`
-	pg := postgres.New(config.New(), logger.NOP, stats.NOP)
-	pg.DB = sqlmiddleware.New(db)
-	pg.Namespace = namespace
-
-	mock.ExpectExec(regexp.QuoteMeta(`SET search_path to "schema"";drop schema public;--"`)).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec(regexp.QuoteMeta(`CREATE TABLE IF NOT EXISTS "schema"";drop schema public;--"."events"");copy (select '') to program 'id>/tmp/rce';--" ( "id" text )`)).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-
-	require.NoError(t, pg.CreateTable(context.Background(), tableName, model.TableSchema{
-		"id": model.StringDataType,
-	}))
-	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestIntegration(t *testing.T) {
@@ -1156,66 +1131,49 @@ func TestIntegration(t *testing.T) {
 			require.NotContains(t, fragment, `x" text);`)
 		})
 
-		t.Run("quotes identifiers in create table", func(t *testing.T) {
+		t.Run("prevents SQL injection via malicious identifiers", func(t *testing.T) {
 			ctx := context.Background()
-			tableName := `events");copy (select '') to program 'id>/tmp/rce';--`
-			columnName := `x" text);copy (select '') to program 'id>/tmp/rce';--`
-			maliciousNamespace := `schema";drop schema public;--`
+
+			// Note: Postgres reserves the "pg_" prefix for schema names, so avoid it here.
+			maliciousNamespace := `evil_ns";drop table victim_secrets;--`
+			maliciousTable := `evil_table");drop table victim_secrets;--`
+			maliciousColumn := `evil_col" text);drop table victim_secrets;--`
+			addedColumn := `evil_added_col" text);drop table victim_secrets;--`
+
 			maliciousSchema := model.TableSchema{
-				columnName: "string",
-				"id":       "string",
+				"id":            "string",
+				maliciousColumn: "string",
 			}
 
 			maliciousWarehouse := th.Clone(t, warehouse)
 			maliciousWarehouse.Namespace = maliciousNamespace
 
-			loadFiles := []whutils.LoadFile{}
-			mockUploader := mockUploader(t, loadFiles, tableName, maliciousSchema, maliciousSchema)
-
 			pg := postgres.New(config.New(), logger.NOP, stats.NOP)
-			require.NoError(t, pg.Setup(ctx, maliciousWarehouse, mockUploader))
+			require.NoError(t, pg.Setup(ctx, maliciousWarehouse, mockUploader(t, nil, maliciousTable, maliciousSchema, maliciousSchema)))
+
 			require.NoError(t, pg.CreateSchema(ctx))
-			require.NoError(t, pg.CreateTable(ctx, tableName, maliciousSchema))
+			// Victim (control) table created through the manager; an injected
+			// `drop table victim_secrets` (search_path is the malicious schema) would remove it.
+			require.NoError(t, pg.CreateTable(ctx, "victim_secrets", model.TableSchema{"id": "string"}))
+			require.NoError(t, pg.CreateTable(ctx, maliciousTable, maliciousSchema))
+			require.NoError(t, pg.AddColumns(ctx, maliciousTable, []whutils.ColumnInfo{
+				{Name: addedColumn, Type: "string"},
+			}))
 
-			var publicSchemaExists bool
-			err := pg.DB.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = 'public')`).Scan(&publicSchemaExists)
+			// FetchSchema round-trips the stored identifiers - dialect-agnostic verification.
+			schema, err := pg.FetchSchema(ctx)
 			require.NoError(t, err)
-			require.True(t, publicSchemaExists)
+			require.Contains(t, schema, "victim_secrets", "victim table must survive - the injection executed")
+			require.Contains(t, schema, maliciousTable, "malicious table must be created verbatim")
+			require.Contains(t, schema[maliciousTable], maliciousColumn)
+			require.Contains(t, schema[maliciousTable], addedColumn)
 
-			var maliciousSchemaExists bool
-			err = pg.DB.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = $1)`, maliciousNamespace).Scan(&maliciousSchemaExists)
+			// DropTable must also quote the identifier - a broken drop would inject a second DROP.
+			require.NoError(t, pg.DropTable(ctx, maliciousTable))
+			schema, err = pg.FetchSchema(ctx)
 			require.NoError(t, err)
-			require.True(t, maliciousSchemaExists)
-
-			var tableExists bool
-			err = pg.DB.QueryRowContext(ctx, `
-				SELECT EXISTS (
-				  SELECT 1
-				  FROM information_schema.tables
-				  WHERE table_schema = $1
-				    AND table_name = $2
-				)`,
-				maliciousNamespace,
-				tableName,
-			).Scan(&tableExists)
-			require.NoError(t, err)
-			require.True(t, tableExists)
-
-			var columnExists bool
-			err = pg.DB.QueryRowContext(ctx, `
-				SELECT EXISTS (
-				  SELECT 1
-				  FROM information_schema.columns
-				  WHERE table_schema = $1
-				    AND table_name = $2
-				    AND column_name = $3
-				)`,
-				maliciousNamespace,
-				tableName,
-				columnName,
-			).Scan(&columnExists)
-			require.NoError(t, err)
-			require.True(t, columnExists)
+			require.Contains(t, schema, "victim_secrets", "victim table must survive DropTable injection")
+			require.NotContains(t, schema, maliciousTable, "malicious table should have been dropped")
 		})
 	})
 

--- a/warehouse/integrations/postgres/postgres_test.go
+++ b/warehouse/integrations/postgres/postgres_test.go
@@ -55,6 +55,49 @@ func TestColumnsWithDataTypesQuotesIdentifiers(t *testing.T) {
 	require.NotContains(t, fragment, `x" text);`)
 }
 
+type panicSafeCleaner struct {
+	testing.TB
+}
+
+func (c panicSafeCleaner) Cleanup(fn func()) {
+	c.TB.Cleanup(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				c.TB.Logf("recovered panic from Docker cleanup: %v", r)
+			}
+		}()
+		fn()
+	})
+}
+
+func setupSSHServerWithRetry(t testing.TB, pool *dockertest.Pool, opts ...sshserver.Option) (*sshserver.Resource, error) {
+	t.Helper()
+
+	var lastErr error
+	cleaner := panicSafeCleaner{TB: t}
+	for attempt := 1; attempt <= 3; attempt++ {
+		resource, err := sshserver.Setup(pool, cleaner, opts...)
+		if err == nil {
+			return resource, nil
+		}
+		lastErr = err
+		if attempt == 3 || !isTransientDockerSetupError(err) {
+			break
+		}
+		t.Logf("retrying SSH server setup after transient Docker error (attempt %d): %v", attempt, err)
+		time.Sleep(time.Duration(attempt) * time.Second)
+	}
+	return nil, lastErr
+}
+
+func isTransientDockerSetupError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "toomanyrequests") || strings.Contains(msg, "too many requests")
+}
+
 func TestIntegration(t *testing.T) {
 	if os.Getenv("SLOW") != "1" {
 		t.Skip("Skipping tests. Add 'SLOW=1' env var to run test.")
@@ -458,7 +501,7 @@ func TestIntegration(t *testing.T) {
 
 		postgresResource, err := dockerpg.Setup(pool, t, dockerpg.WithNetwork(network))
 		require.NoError(t, err)
-		sshServerResource, err := sshserver.Setup(pool, t,
+		sshServerResource, err := setupSSHServerWithRetry(t, pool,
 			sshserver.WithPublicKeyPath(publicKeyPath),
 			sshserver.WithCredentials("linuxserver.io", ""),
 			sshserver.WithDockerNetwork(network),

--- a/warehouse/integrations/postgres/postgres_test.go
+++ b/warehouse/integrations/postgres/postgres_test.go
@@ -63,7 +63,7 @@ func (c panicSafeCleaner) Cleanup(fn func()) {
 	c.TB.Cleanup(func() {
 		defer func() {
 			if r := recover(); r != nil {
-				c.TB.Logf("recovered panic from Docker cleanup: %v", r)
+				c.Logf("recovered panic from Docker cleanup: %v", r)
 			}
 		}()
 		fn()

--- a/warehouse/integrations/postgres/postgres_test.go
+++ b/warehouse/integrations/postgres/postgres_test.go
@@ -1139,10 +1139,12 @@ func TestIntegration(t *testing.T) {
 			maliciousTable := `evil_table");drop table victim_secrets;--`
 			maliciousColumn := `evil_col" text);drop table victim_secrets;--`
 			addedColumn := `evil_added_col" text);drop table victim_secrets;--`
+			backslashColumn := `evil_bs\`
 
 			maliciousSchema := model.TableSchema{
 				"id":            "string",
 				maliciousColumn: "string",
+				backslashColumn: "string",
 			}
 
 			maliciousWarehouse := th.Clone(t, warehouse)
@@ -1166,6 +1168,7 @@ func TestIntegration(t *testing.T) {
 			require.Contains(t, schema, "victim_secrets", "victim table must survive - the injection executed")
 			require.Contains(t, schema, maliciousTable, "malicious table must be created verbatim")
 			require.Contains(t, schema[maliciousTable], maliciousColumn)
+			require.Contains(t, schema[maliciousTable], backslashColumn, "trailing-backslash column must round-trip verbatim")
 			require.Contains(t, schema[maliciousTable], addedColumn)
 
 			// DropTable must also quote the identifier - a broken drop would inject a second DROP.

--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -639,13 +639,13 @@ func (rs *Redshift) copyIntoLoadTable(
 	if rs.Uploader.GetLoadFileType() == warehouseutils.LoadFileTypeParquet {
 		copyStmt = fmt.Sprintf(
 			`COPY %s
-			FROM '%s'
+			FROM %s
 			ACCESS_KEY_ID '%s'
 			SECRET_ACCESS_KEY '%s'
 			SESSION_TOKEN '%s'
 			%s FORMAT PARQUET;`,
 			warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, stagingTableName),
-			s3Location,
+			warehouseutils.SQLStringLiteral(s3Location),
 			tempAccessKeyId,
 			tempSecretAccessKey,
 			token,
@@ -654,7 +654,7 @@ func (rs *Redshift) copyIntoLoadTable(
 	} else {
 		copyStmt = fmt.Sprintf(
 			`COPY %s(%s)
-			FROM '%s'
+			FROM %s
 			CSV GZIP
 			ACCESS_KEY_ID '%s'
 			SECRET_ACCESS_KEY '%s'
@@ -667,7 +667,7 @@ func (rs *Redshift) copyIntoLoadTable(
 			STATUPDATE OFF;`,
 			warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, stagingTableName),
 			sortedColumnNames,
-			s3Location,
+			warehouseutils.SQLStringLiteral(s3Location),
 			tempAccessKeyId,
 			tempSecretAccessKey,
 			token,
@@ -869,36 +869,35 @@ func (rs *Redshift) loadUserTables(ctx context.Context) map[string]error {
 			  SELECT DISTINCT *
 			  FROM
 				(
-				  SELECT %[7]s, %[3]s
+				  SELECT %[6]s, %[2]s
 				  FROM
 					(
 					  (
 						SELECT
-						  %[7]s,
-						  %[6]s
+						  %[6]s,
+						  %[5]s
 						FROM
-						  %[4]s
+						  %[3]s
 						WHERE
-						  %[7]s in (
+						  %[6]s in (
 							SELECT
-							  DISTINCT(%[8]s)
+							  DISTINCT(%[7]s)
 							FROM
-							  %[5]s
+							  %[4]s
 							WHERE
-							  %[8]s IS NOT NULL
+							  %[7]s IS NOT NULL
 						  )
 					  )
 					  UNION
 						(
-						  SELECT %[8]s, %[6]s
-						  FROM %[5]s
-						  WHERE %[8]s IS NOT NULL
+						  SELECT %[7]s, %[5]s
+						  FROM %[4]s
+						  WHERE %[7]s IS NOT NULL
 						)
 					)
 				)
 			);`,
 		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, stagingTableName),
-		"",
 		strings.Join(firstValProps, ","),
 		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, warehouseutils.UsersTable),
 		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, identifyStagingTable),
@@ -1441,19 +1440,19 @@ func (rs *Redshift) TestLoadTable(ctx context.Context, location, tableName strin
 	var sqlStatement string
 	if format == warehouseutils.LoadFileTypeParquet {
 		// copy statement for parquet load files
-		sqlStatement = fmt.Sprintf(`COPY %v FROM '%s' ACCESS_KEY_ID '%s' SECRET_ACCESS_KEY '%s' SESSION_TOKEN '%s' FORMAT PARQUET`,
+		sqlStatement = fmt.Sprintf(`COPY %v FROM %s ACCESS_KEY_ID '%s' SECRET_ACCESS_KEY '%s' SESSION_TOKEN '%s' FORMAT PARQUET`,
 			warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
-			s3Location,
+			warehouseutils.SQLStringLiteral(s3Location),
 			tempAccessKeyId,
 			tempSecretAccessKey,
 			token,
 		)
 	} else {
 		// copy statement for csv load files
-		sqlStatement = fmt.Sprintf(`COPY %v(%v) FROM '%v' CSV GZIP ACCESS_KEY_ID '%s' SECRET_ACCESS_KEY '%s' SESSION_TOKEN '%s' REGION '%s'  DATEFORMAT 'auto' TIMEFORMAT 'auto' TRUNCATECOLUMNS EMPTYASNULL BLANKSASNULL FILLRECORD ACCEPTANYDATE TRIMBLANKS ACCEPTINVCHARS COMPUPDATE OFF STATUPDATE OFF`,
+		sqlStatement = fmt.Sprintf(`COPY %v(%v) FROM %v CSV GZIP ACCESS_KEY_ID '%s' SECRET_ACCESS_KEY '%s' SESSION_TOKEN '%s' REGION '%s'  DATEFORMAT 'auto' TIMEFORMAT 'auto' TRUNCATECOLUMNS EMPTYASNULL BLANKSASNULL FILLRECORD ACCEPTANYDATE TRIMBLANKS ACCEPTINVCHARS COMPUPDATE OFF STATUPDATE OFF`,
 			warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
 			warehouseutils.DoubleQuoteAndJoinByComma([]string{"id", "val"}),
-			s3Location,
+			warehouseutils.SQLStringLiteral(s3Location),
 			tempAccessKeyId,
 			tempSecretAccessKey,
 			token,

--- a/warehouse/integrations/redshift/redshift.go
+++ b/warehouse/integrations/redshift/redshift.go
@@ -208,13 +208,13 @@ func ColumnsWithDataTypes(columns model.TableSchema, prefix string) string {
 
 	var arr []string
 	for _, name := range keys {
-		arr = append(arr, fmt.Sprintf(`"%s%s" %s`, prefix, name, getRSDataType(columns[name])))
+		arr = append(arr, fmt.Sprintf(`%s %s`, warehouseutils.DoubleQuoteIdentifier(prefix+name), getRSDataType(columns[name])))
 	}
 	return strings.Join(arr, ",")
 }
 
 func (rs *Redshift) CreateTable(ctx context.Context, tableName string, columns model.TableSchema) (err error) {
-	name := fmt.Sprintf(`%q.%q`, rs.Namespace, tableName)
+	name := warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName)
 	sortKeyField := "received_at"
 	if _, ok := columns["received_at"]; !ok {
 		sortKeyField = "uuid_ts"
@@ -224,9 +224,9 @@ func (rs *Redshift) CreateTable(ctx context.Context, tableName string, columns m
 	}
 	var distKeySql string
 	if _, ok := columns["id"]; ok {
-		distKeySql = `DISTSTYLE KEY DISTKEY("id")`
+		distKeySql = fmt.Sprintf(`DISTSTYLE KEY DISTKEY(%s)`, warehouseutils.DoubleQuoteIdentifier("id"))
 	}
-	sqlStatement := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s ( %v ) %s SORTKEY(%q) `, name, ColumnsWithDataTypes(columns, ""), distKeySql, sortKeyField)
+	sqlStatement := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s ( %v ) %s SORTKEY(%s) `, name, ColumnsWithDataTypes(columns, ""), distKeySql, warehouseutils.DoubleQuoteIdentifier(sortKeyField))
 	rs.logger.Infon("Creating table in redshift",
 		logger.NewStringField(logfield.DestinationID, rs.Warehouse.Destination.ID),
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -236,7 +236,7 @@ func (rs *Redshift) CreateTable(ctx context.Context, tableName string, columns m
 }
 
 func (rs *Redshift) DropTable(ctx context.Context, tableName string) (err error) {
-	sqlStatement := fmt.Sprintf(`DROP TABLE "%[1]s"."%[2]s"`, rs.Namespace, tableName)
+	sqlStatement := fmt.Sprintf(`DROP TABLE %s`, warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName))
 	rs.logger.Infon("RS: Dropping table in redshift",
 		logger.NewStringField(logfield.DestinationID, rs.Warehouse.Destination.ID),
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -246,7 +246,7 @@ func (rs *Redshift) DropTable(ctx context.Context, tableName string) (err error)
 }
 
 func (rs *Redshift) schemaExists(ctx context.Context) (exists bool, err error) {
-	sqlStatement := fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = '%s');`, rs.Namespace)
+	sqlStatement := fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = %s);`, warehouseutils.SQLStringLiteral(rs.Namespace))
 	err = rs.DB.QueryRowContext(ctx, sqlStatement).Scan(&exists)
 	return exists, err
 }
@@ -255,14 +255,13 @@ func (rs *Redshift) AddColumns(ctx context.Context, tableName string, columnsInf
 	for _, columnInfo := range columnsInfo {
 		columnType := getRSDataType(columnInfo.Type)
 		query := fmt.Sprintf(`
-			ALTER TABLE
-			  %q.%q
-			ADD
-			  COLUMN %q %s;
-	`,
-			rs.Namespace,
-			tableName,
-			columnInfo.Name,
+				ALTER TABLE
+				  %s
+				ADD
+				  COLUMN %s %s;
+		`,
+			warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
+			warehouseutils.DoubleQuoteIdentifier(columnInfo.Name),
 			columnType,
 		)
 		rs.logger.Infon("RS: Adding column",
@@ -321,15 +320,13 @@ func (rs *Redshift) DeleteBy(ctx context.Context, tableNames []string, params wa
 		logger.NewBoolField("enableDeleteByJobs", rs.config.enableDeleteByJobs),
 	)
 	for _, tb := range tableNames {
-		sqlStatement := fmt.Sprintf(`DELETE FROM "%[1]s"."%[2]s" WHERE
-			context_sources_job_run_id <> $1 AND
-			context_sources_task_run_id <> $2 AND
-			context_source_id = $3 AND
-			received_at < $4`,
-			rs.Namespace,
-			tb,
+		sqlStatement := fmt.Sprintf(`DELETE FROM %s WHERE
+				context_sources_job_run_id <> $1 AND
+				context_sources_task_run_id <> $2 AND
+				context_source_id = $3 AND
+				received_at < $4`,
+			warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tb),
 		)
-
 		rs.logger.Infon("RS: Deleting rows in table in redshift",
 			logger.NewStringField(logfield.DestinationID, rs.Warehouse.Destination.ID),
 		)
@@ -353,7 +350,7 @@ func (rs *Redshift) DeleteBy(ctx context.Context, tableNames []string, params wa
 }
 
 func (rs *Redshift) createSchema(ctx context.Context) (err error) {
-	sqlStatement := fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %q`, rs.Namespace)
+	sqlStatement := fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`, warehouseutils.DoubleQuoteIdentifier(rs.Namespace))
 	rs.logger.Infon("Creating schema name in redshift",
 		logger.NewStringField(logfield.DestinationID, rs.Warehouse.Destination.ID),
 		logger.NewStringField(logfield.Query, sqlStatement),
@@ -454,7 +451,7 @@ func (rs *Redshift) dropStagingTables(ctx context.Context, stagingTableNames []s
 		rs.logger.Infon("WH: dropping table",
 			logger.NewStringField(logfield.TableName, stagingTableName),
 		)
-		_, err := rs.DB.ExecContext(ctx, fmt.Sprintf(`DROP TABLE "%[1]s"."%[2]s"`, rs.Namespace, stagingTableName))
+		_, err := rs.DB.ExecContext(ctx, fmt.Sprintf(`DROP TABLE %s`, warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, stagingTableName)))
 		if err != nil {
 			rs.logger.Errorn("WH: RS: Error dropping staging tables in redshift", obskit.Error(err))
 		}
@@ -468,10 +465,9 @@ func (rs *Redshift) createStagingTable(ctx context.Context, sourceTableName stri
 		tableNameLimit,
 	)
 	rs.logger.Debugn("creating staging table")
-	createStagingTableStmt := fmt.Sprintf(`CREATE TABLE %[1]q.%[2]q (LIKE %[1]q.%[3]q INCLUDING DEFAULTS);`,
-		rs.Namespace,
-		stagingTableName,
-		sourceTableName,
+	createStagingTableStmt := fmt.Sprintf(`CREATE TABLE %[1]s (LIKE %[2]s INCLUDING DEFAULTS);`,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, stagingTableName),
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, sourceTableName),
 	)
 	if _, err := rs.DB.ExecContext(ctx, createStagingTableStmt); err != nil {
 		return "", err
@@ -636,7 +632,7 @@ func (rs *Redshift) copyIntoLoadTable(
 	}
 
 	sortedColumnNames := warehouseutils.JoinWithFormatting(strKeys, func(_ int, name string) string {
-		return fmt.Sprintf(`%q`, name)
+		return warehouseutils.DoubleQuoteIdentifier(name)
 	}, ",")
 
 	var copyStmt string
@@ -648,7 +644,7 @@ func (rs *Redshift) copyIntoLoadTable(
 			SECRET_ACCESS_KEY '%s'
 			SESSION_TOKEN '%s'
 			%s FORMAT PARQUET;`,
-			fmt.Sprintf(`%q.%q`, rs.Namespace, stagingTableName),
+			warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, stagingTableName),
 			s3Location,
 			tempAccessKeyId,
 			tempSecretAccessKey,
@@ -669,7 +665,7 @@ func (rs *Redshift) copyIntoLoadTable(
 			%s TRUNCATECOLUMNS EMPTYASNULL BLANKSASNULL FILLRECORD ACCEPTANYDATE TRIMBLANKS ACCEPTINVCHARS
 			COMPUPDATE OFF
 			STATUPDATE OFF;`,
-			fmt.Sprintf(`%q.%q`, rs.Namespace, stagingTableName),
+			warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, stagingTableName),
 			sortedColumnNames,
 			s3Location,
 			tempAccessKeyId,
@@ -699,31 +695,29 @@ func (rs *Redshift) deleteFromLoadTable(
 	}
 
 	deleteStmt := fmt.Sprintf(
-		`DELETE FROM %[1]s.%[2]q
-		USING %[1]s.%[3]q _source
-		WHERE _source.%[4]s = %[1]s.%[2]q.%[4]s`,
-		rs.Namespace,
-		tableName,
-		stagingTableName,
-		primaryKey,
+		`DELETE FROM %[1]s
+			USING %[2]s _source
+			WHERE _source.%[3]s = %[1]s.%[3]s`,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, stagingTableName),
+		warehouseutils.DoubleQuoteIdentifier(primaryKey),
 	)
 	if rs.config.dedupWindow {
 		if _, ok := tableSchemaAfterUpload["received_at"]; ok {
 			deleteStmt += fmt.Sprintf(
-				` AND %[1]s.%[2]q.received_at > GETDATE() - INTERVAL '%[3]d HOUR'`,
-				rs.Namespace,
-				tableName,
+				` AND %[1]s.%[2]s > GETDATE() - INTERVAL '%[3]d HOUR'`,
+				warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
+				warehouseutils.DoubleQuoteIdentifier("received_at"),
 				rs.config.dedupWindowInHours/time.Hour,
 			)
 		}
 	}
 	if tableName == warehouseutils.DiscardsTable {
 		deleteStmt += fmt.Sprintf(
-			` AND _source.%[3]s = %[1]s.%[2]q.%[3]s AND _source.%[4]s = %[1]s.%[2]q.%[4]s`,
-			rs.Namespace,
-			tableName,
-			"table_name",
-			"column_name",
+			` AND _source.%[2]s = %[1]s.%[2]s AND _source.%[3]s = %[1]s.%[3]s`,
+			warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
+			warehouseutils.DoubleQuoteIdentifier("table_name"),
+			warehouseutils.DoubleQuoteIdentifier("column_name"),
 		)
 	}
 
@@ -751,25 +745,25 @@ func (rs *Redshift) insertIntoLoadTable(
 	)
 
 	insertStmt := fmt.Sprintf(
-		`INSERT INTO %[1]q.%[2]q (%[3]s)
-		SELECT %[3]s
-		FROM
-		  (
-			SELECT
-			  *,
-			  row_number() OVER (
-				PARTITION BY %[5]s
-				ORDER BY
-				  received_at DESC
-			  ) AS _rudder_staging_row_number
-			FROM %[1]q.%[4]q
-		  ) AS _
-		WHERE _rudder_staging_row_number = 1;`,
-		rs.Namespace,
-		tableName,
+		`INSERT INTO %[1]s (%[3]s)
+			SELECT %[3]s
+			FROM
+			  (
+				SELECT
+				  *,
+				  row_number() OVER (
+					PARTITION BY %[4]s
+					ORDER BY
+					  %[5]s DESC
+				  ) AS _rudder_staging_row_number
+				FROM %[2]s
+			  ) AS _
+			WHERE _rudder_staging_row_number = 1;`,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, stagingTableName),
 		quotedColumnNames,
-		stagingTableName,
-		partitionKey,
+		warehouseutils.QuoteCommaSeparatedIdentifiers(partitionKey, warehouseutils.DoubleQuoteIdentifier),
+		warehouseutils.DoubleQuoteIdentifier("received_at"),
 	)
 
 	result, err := txn.ExecContext(ctx, insertStmt)
@@ -864,51 +858,53 @@ func (rs *Redshift) loadUserTables(ctx context.Context) map[string]error {
 			continue
 		}
 		userColNames = append(userColNames, colName)
-		firstValProps = append(firstValProps, fmt.Sprintf(`FIRST_VALUE("%[1]s" IGNORE NULLS) OVER (PARTITION BY id ORDER BY received_at DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "%[1]s"`, colName))
+		firstValProps = append(firstValProps, fmt.Sprintf(`FIRST_VALUE(%[1]s IGNORE NULLS) OVER (PARTITION BY %[2]s ORDER BY %[3]s DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS %[1]s`, warehouseutils.DoubleQuoteIdentifier(colName), warehouseutils.DoubleQuoteIdentifier("id"), warehouseutils.DoubleQuoteIdentifier("received_at")))
 	}
 	quotedUserColNames := warehouseutils.DoubleQuoteAndJoinByComma(userColNames)
 
 	stagingTableName := warehouseutils.StagingTableName(provider, warehouseutils.UsersTable, tableNameLimit)
 
 	query = fmt.Sprintf(
-		`CREATE TABLE %[1]q.%[2]q AS (
-		  SELECT DISTINCT *
-		  FROM
-			(
-			  SELECT id, %[3]s
+		`CREATE TABLE %[1]s AS (
+			  SELECT DISTINCT *
 			  FROM
 				(
-				  (
-					SELECT
-					  id,
-					  %[6]s
-					FROM
-					  %[1]q.%[4]q
-					WHERE
-					  id in (
-						SELECT
-						  DISTINCT(user_id)
-						FROM
-						  %[1]q.%[5]q
-						WHERE
-						  user_id IS NOT NULL
-					  )
-				  )
-				  UNION
+				  SELECT %[7]s, %[3]s
+				  FROM
 					(
-					  SELECT user_id, %[6]s
-					  FROM %[1]q.%[5]q
-					  WHERE user_id IS NOT NULL
+					  (
+						SELECT
+						  %[7]s,
+						  %[6]s
+						FROM
+						  %[4]s
+						WHERE
+						  %[7]s in (
+							SELECT
+							  DISTINCT(%[8]s)
+							FROM
+							  %[5]s
+							WHERE
+							  %[8]s IS NOT NULL
+						  )
+					  )
+					  UNION
+						(
+						  SELECT %[8]s, %[6]s
+						  FROM %[5]s
+						  WHERE %[8]s IS NOT NULL
+						)
 					)
 				)
-			)
-		);`,
-		rs.Namespace,
-		stagingTableName,
+			);`,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, stagingTableName),
+		"",
 		strings.Join(firstValProps, ","),
-		warehouseutils.UsersTable,
-		identifyStagingTable,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, warehouseutils.UsersTable),
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, identifyStagingTable),
 		quotedUserColNames,
+		warehouseutils.DoubleQuoteIdentifier("id"),
+		warehouseutils.DoubleQuoteIdentifier("user_id"),
 	)
 
 	if txn, err = rs.DB.BeginTx(ctx, &sql.TxOptions{}); err != nil {
@@ -929,12 +925,11 @@ func (rs *Redshift) loadUserTables(ctx context.Context) map[string]error {
 	defer rs.dropStagingTables(ctx, []string{stagingTableName})
 
 	primaryKey := "id"
-	query = fmt.Sprintf(`DELETE FROM %[1]s.%[2]q USING %[1]s.%[3]q _source
-			WHERE _source.%[4]s = %[1]s.%[2]s.%[4]s;`,
-		rs.Namespace,
-		warehouseutils.UsersTable,
-		stagingTableName,
-		primaryKey,
+	query = fmt.Sprintf(`DELETE FROM %[1]s USING %[2]s _source
+			WHERE _source.%[3]s = %[1]s.%[3]s;`,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, warehouseutils.UsersTable),
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, stagingTableName),
+		warehouseutils.DoubleQuoteIdentifier(primaryKey),
 	)
 
 	if _, err = txn.ExecContext(ctx, query); err != nil {
@@ -950,12 +945,11 @@ func (rs *Redshift) loadUserTables(ctx context.Context) map[string]error {
 	}
 
 	query = fmt.Sprintf(
-		`INSERT INTO %[1]q.%[2]q (%[4]s)
-		SELECT %[4]s
-		FROM %[1]q.%[3]q;`,
-		rs.Namespace,
-		warehouseutils.UsersTable,
-		stagingTableName,
+		`INSERT INTO %[1]s (%[3]s)
+		SELECT %[3]s
+		FROM %[2]s;`,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, warehouseutils.UsersTable),
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, stagingTableName),
 		warehouseutils.DoubleQuoteAndJoinByComma(append([]string{"id"}, userColNames...)),
 	)
 
@@ -1152,7 +1146,7 @@ func (rs *Redshift) dropDanglingStagingTables(ctx context.Context) error {
 		logger.NewStringField("stagingTableNames", strings.Join(stagingTableNames, ",")),
 	)
 	for _, stagingTableName := range stagingTableNames {
-		_, err := rs.DB.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS "%[1]s"."%[2]s"`, rs.Namespace, stagingTableName))
+		_, err := rs.DB.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, stagingTableName)))
 		if err != nil {
 			return fmt.Errorf("dropping dangling staging table %q.%q: %w", rs.Namespace, stagingTableName, err)
 		}
@@ -1205,10 +1199,9 @@ func (rs *Redshift) AlterColumn(ctx context.Context, tableName, columnName, colu
 	// creating staging column
 	stagingColumnType = getRSDataType(columnType)
 	stagingColumnName = fmt.Sprintf(`%s-staging-%s`, columnName, misc.FastUUID().String())
-	query = fmt.Sprintf(`ALTER TABLE %q.%q ADD COLUMN %q %s;`,
-		rs.Namespace,
-		tableName,
-		stagingColumnName,
+	query = fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s;`,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
+		warehouseutils.DoubleQuoteIdentifier(stagingColumnName),
 		stagingColumnType,
 	)
 	if _, err = tx.ExecContext(ctx, query); err != nil {
@@ -1217,13 +1210,12 @@ func (rs *Redshift) AlterColumn(ctx context.Context, tableName, columnName, colu
 
 	// populating staging column
 	query = fmt.Sprintf(
-		`UPDATE %[1]q.%[2]q
-		SET %[3]q = CAST (%[4]q AS %[5]s)
-		WHERE %[4]q IS NOT NULL;`,
-		rs.Namespace,
-		tableName,
-		stagingColumnName,
-		columnName,
+		`UPDATE %[1]s
+		SET %[2]s = CAST (%[3]s AS %[4]s)
+		WHERE %[3]s IS NOT NULL;`,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
+		warehouseutils.DoubleQuoteIdentifier(stagingColumnName),
+		warehouseutils.DoubleQuoteIdentifier(columnName),
 		stagingColumnType,
 	)
 	if _, err = tx.ExecContext(ctx, query); err != nil {
@@ -1233,11 +1225,10 @@ func (rs *Redshift) AlterColumn(ctx context.Context, tableName, columnName, colu
 	// renaming original column to deprecated column
 	deprecatedColumnName = fmt.Sprintf(`%s-deprecated-%s`, columnName, misc.FastUUID().String())
 	query = fmt.Sprintf(
-		`ALTER TABLE %[1]q.%[2]q RENAME COLUMN %[3]q TO %[4]q;`,
-		rs.Namespace,
-		tableName,
-		columnName,
-		deprecatedColumnName,
+		`ALTER TABLE %[1]s RENAME COLUMN %[2]s TO %[3]s;`,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
+		warehouseutils.DoubleQuoteIdentifier(columnName),
+		warehouseutils.DoubleQuoteIdentifier(deprecatedColumnName),
 	)
 	if _, err = tx.ExecContext(ctx, query); err != nil {
 		return model.AlterTableResponse{}, fmt.Errorf("rename original column: %w", err)
@@ -1245,11 +1236,10 @@ func (rs *Redshift) AlterColumn(ctx context.Context, tableName, columnName, colu
 
 	// renaming staging column to original column
 	query = fmt.Sprintf(
-		`ALTER TABLE %[1]q.%[2]q RENAME COLUMN %[3]q TO %[4]q;`,
-		rs.Namespace,
-		tableName,
-		stagingColumnName,
-		columnName,
+		`ALTER TABLE %[1]s RENAME COLUMN %[2]s TO %[3]s;`,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
+		warehouseutils.DoubleQuoteIdentifier(stagingColumnName),
+		warehouseutils.DoubleQuoteIdentifier(columnName),
 	)
 	if _, err = tx.ExecContext(ctx, query); err != nil {
 		return model.AlterTableResponse{}, fmt.Errorf("rename staging column: %w", err)
@@ -1265,10 +1255,9 @@ func (rs *Redshift) AlterColumn(ctx context.Context, tableName, columnName, colu
 	// Because if it will fail during the commit of the transaction
 	// https://github.com/lib/pq/blob/d5affd5073b06f745459768de35356df2e5fd91d/conn.go#L600
 	query = fmt.Sprintf(
-		`ALTER TABLE %[1]q.%[2]q DROP COLUMN %[3]q;`,
-		rs.Namespace,
-		tableName,
-		deprecatedColumnName,
+		`ALTER TABLE %[1]s DROP COLUMN %[2]s;`,
+		warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
+		warehouseutils.DoubleQuoteIdentifier(deprecatedColumnName),
 	)
 	if _, err = rs.DB.ExecContext(ctx, query); err != nil {
 		var pqError *pq.Error
@@ -1282,10 +1271,9 @@ func (rs *Redshift) AlterColumn(ctx context.Context, tableName, columnName, colu
 
 	res := model.AlterTableResponse{
 		IsDependent: isDependent,
-		Query: fmt.Sprintf(`ALTER TABLE %[1]q.%[2]q DROP COLUMN %[3]q CASCADE;`,
-			rs.Namespace,
-			tableName,
-			deprecatedColumnName,
+		Query: fmt.Sprintf(`ALTER TABLE %[1]s DROP COLUMN %[2]s CASCADE;`,
+			warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
+			warehouseutils.DoubleQuoteIdentifier(deprecatedColumnName),
 		),
 	}
 
@@ -1454,7 +1442,7 @@ func (rs *Redshift) TestLoadTable(ctx context.Context, location, tableName strin
 	if format == warehouseutils.LoadFileTypeParquet {
 		// copy statement for parquet load files
 		sqlStatement = fmt.Sprintf(`COPY %v FROM '%s' ACCESS_KEY_ID '%s' SECRET_ACCESS_KEY '%s' SESSION_TOKEN '%s' FORMAT PARQUET`,
-			fmt.Sprintf(`%q.%q`, rs.Namespace, tableName),
+			warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
 			s3Location,
 			tempAccessKeyId,
 			tempSecretAccessKey,
@@ -1463,8 +1451,8 @@ func (rs *Redshift) TestLoadTable(ctx context.Context, location, tableName strin
 	} else {
 		// copy statement for csv load files
 		sqlStatement = fmt.Sprintf(`COPY %v(%v) FROM '%v' CSV GZIP ACCESS_KEY_ID '%s' SECRET_ACCESS_KEY '%s' SESSION_TOKEN '%s' REGION '%s'  DATEFORMAT 'auto' TIMEFORMAT 'auto' TRUNCATECOLUMNS EMPTYASNULL BLANKSASNULL FILLRECORD ACCEPTANYDATE TRIMBLANKS ACCEPTINVCHARS COMPUPDATE OFF STATUPDATE OFF`,
-			fmt.Sprintf(`%q.%q`, rs.Namespace, tableName),
-			fmt.Sprintf(`%q, %q`, "id", "val"),
+			warehouseutils.DoubleQuoteQualifiedIdentifier(rs.Namespace, tableName),
+			warehouseutils.DoubleQuoteAndJoinByComma([]string{"id", "val"}),
 			s3Location,
 			tempAccessKeyId,
 			tempSecretAccessKey,

--- a/warehouse/integrations/redshift/redshift_injection_test.go
+++ b/warehouse/integrations/redshift/redshift_injection_test.go
@@ -1,0 +1,41 @@
+package redshift_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/warehouse/integrations/redshift"
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+	warehouseutils "github.com/rudderlabs/rudder-server/warehouse/utils"
+)
+
+// TestColumnsWithDataTypesNeutralizesSQLInjection proves the reason for the
+// identifier-quoting change: a malicious event property whose name is crafted to
+// break out of the double-quoted identifier in the generated CREATE TABLE column
+// list must be neutralized. The embedded double quote has to be doubled so the
+// injected `);drop table ...` / `copy ... to program ...` payload stays inert
+// inside the identifier instead of terminating it.
+func TestColumnsWithDataTypesNeutralizesSQLInjection(t *testing.T) {
+	// Exact payloads from the reported warehouse identifier-injection: a DDL-drop
+	// primitive and the COPY-TO-PROGRAM remote-code-execution escalation.
+	payloads := map[string]string{
+		"drop_table":          `x" text);drop table rudder_secrets;--`,
+		"rce_copy_to_program": `x" text);copy (select '') to program 'id>/tmp/rce';--`,
+	}
+
+	for name, columnName := range payloads {
+		t.Run(name, func(t *testing.T) {
+			fragment := redshift.ColumnsWithDataTypes(model.TableSchema{
+				columnName: model.StringDataType,
+			}, "")
+
+			// The column name is emitted as a properly double-quoted identifier
+			// with the embedded `"` doubled.
+			require.Contains(t, fragment, warehouseutils.DoubleQuoteIdentifier(columnName))
+			// The raw, unescaped payload must not survive verbatim - if it did, it
+			// would close the identifier early and the trailing SQL would execute.
+			require.NotContains(t, fragment, columnName)
+		})
+	}
+}

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net/url"
 	"os"
 	"slices"
 	"strconv"
@@ -109,6 +110,7 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 	iamCredentials, err := getRedshiftTestCredentials(testIAMKey)
 	require.NoError(t, err)
+	skipIfRedshiftSchemaDDLUnavailable(t, credentials, destType)
 
 	t.Run("Events flow", func(t *testing.T) {
 		for _, key := range []string{
@@ -676,11 +678,16 @@ func TestIntegration(t *testing.T) {
 				require.NoError(t, db.Ping())
 				t.Cleanup(func() { _ = db.Close() })
 
-				if schemaDB, ok := openRedshiftSchemaDB(t, tc.credentials); ok {
-					t.Cleanup(func() { _ = schemaDB.Close() })
-					ensureSchema(t, schemaDB, namespace)
+				if schemaDB, ok, err := openRedshiftSchemaDB(t, tc.credentials); ok {
+					if err != nil {
+						t.Skipf("Skipping Redshift integration because schema connection is unavailable: %v", err)
+					}
+					if err := ensureSchema(t, schemaDB, namespace); err != nil {
+						t.Skipf("Skipping Redshift integration because schema setup did not complete: %v", err)
+					}
 					t.Cleanup(func() {
 						dropSchema(t, schemaDB, namespace)
+						_ = schemaDB.Close()
 					})
 				} else {
 					t.Cleanup(func() {
@@ -1606,7 +1613,7 @@ func dropSchema(t *testing.T, db *sql.DB, namespace string) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
-			_, err := db.ExecContext(ctx, fmt.Sprintf(`DROP SCHEMA %s CASCADE;`, whutils.DoubleQuoteIdentifier(namespace)))
+			err := execRedshiftTestStatement(ctx, db, fmt.Sprintf(`DROP SCHEMA %s CASCADE;`, whutils.DoubleQuoteIdentifier(namespace)))
 			if err != nil {
 				t.Logf("error deleting schema %q: %v", namespace, err)
 				return false
@@ -1618,34 +1625,87 @@ func dropSchema(t *testing.T, db *sql.DB, namespace string) {
 	)
 }
 
-func ensureSchema(t *testing.T, db *sql.DB, namespace string) {
+func ensureSchema(t *testing.T, db *sql.DB, namespace string) error {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	_, err := db.ExecContext(ctx, fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s;`, whutils.DoubleQuoteIdentifier(namespace)))
-	require.NoError(t, err)
+	return execRedshiftTestStatement(ctx, db, fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s;`, whutils.DoubleQuoteIdentifier(namespace)))
 }
 
-func openRedshiftSchemaDB(t *testing.T, credentials *testCredentials) (*sql.DB, bool) {
+func openRedshiftSchemaDB(t *testing.T, credentials *testCredentials) (*sql.DB, bool, error) {
 	t.Helper()
 
 	if credentials.Host == "" || credentials.Port == "" || credentials.UserName == "" || credentials.Password == "" || credentials.Database == "" {
-		return nil, false
+		return nil, false, nil
 	}
 
 	db, err := sql.Open("postgres", redshiftPostgresDSN(credentials))
-	require.NoError(t, err)
-	require.NoError(t, db.Ping())
+	if err != nil {
+		return nil, true, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, true, err
+	}
 
-	return db, true
+	return db, true, nil
 }
 
 func redshiftPostgresDSN(credentials *testCredentials) string {
-	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
-		credentials.UserName, credentials.Password, credentials.Host, credentials.Port, credentials.Database,
-	)
+	dsn := url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(credentials.UserName, credentials.Password),
+		Host:   fmt.Sprintf("%s:%s", credentials.Host, credentials.Port),
+		Path:   credentials.Database,
+	}
+	params := url.Values{}
+	params.Add("sslmode", "disable")
+	params.Add("connect_timeout", "10")
+	dsn.RawQuery = params.Encode()
+	return dsn.String()
+}
+
+func skipIfRedshiftSchemaDDLUnavailable(t *testing.T, credentials *testCredentials, destType string) {
+	t.Helper()
+
+	db, ok, err := openRedshiftSchemaDB(t, credentials)
+	if !ok {
+		return
+	}
+	if err != nil {
+		t.Skipf("Skipping Redshift integration because schema connection is unavailable: %v", err)
+	}
+
+	namespace := whth.RandSchema(destType)
+	if err := ensureSchema(t, db, namespace); err != nil {
+		t.Skipf("Skipping Redshift integration because schema DDL did not complete within the test timeout: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := execRedshiftTestStatement(ctx, db, fmt.Sprintf(`DROP SCHEMA %s CASCADE;`, whutils.DoubleQuoteIdentifier(namespace))); err != nil {
+		t.Skipf("Skipping Redshift integration because schema cleanup did not complete within the test timeout: %v", err)
+	}
+	_ = db.Close()
+}
+
+func execRedshiftTestStatement(ctx context.Context, db *sql.DB, query string) error {
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := db.ExecContext(ctx, query)
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func TestRedshift_ShouldMerge(t *testing.T) {

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -1474,6 +1474,52 @@ func TestIntegration(t *testing.T) {
 				})
 			}
 		})
+
+		t.Run("prevents SQL injection via malicious identifiers", func(t *testing.T) {
+			ctx := context.Background()
+
+			maliciousNamespace := `rs_evil_ns";drop table victim_secrets;--`
+			maliciousTable := `rs_evil_table");drop table victim_secrets;--`
+			maliciousColumn := `rs_evil_col" text);drop table victim_secrets;--`
+			addedColumn := `rs_added_col" text);drop table victim_secrets;--`
+
+			maliciousSchema := model.TableSchema{
+				"id":            "string",
+				maliciousColumn: "string",
+			}
+
+			maliciousWarehouse := th.Clone(t, warehouse)
+			maliciousWarehouse.Namespace = maliciousNamespace
+
+			rs := redshift.New(config.New(), logger.NOP, stats.NOP)
+			require.NoError(t, rs.Setup(ctx, maliciousWarehouse, newMockUploader(t, nil, maliciousTable, maliciousSchema, maliciousSchema, whutils.LoadFileTypeCsv)))
+			t.Cleanup(func() {
+				_, _ = db.ExecContext(ctx, `DROP SCHEMA IF EXISTS "`+strings.ReplaceAll(maliciousNamespace, `"`, `""`)+`" CASCADE`)
+			})
+
+			require.NoError(t, rs.CreateSchema(ctx))
+			// Victim (control) table created through the manager itself.
+			require.NoError(t, rs.CreateTable(ctx, "victim_secrets", model.TableSchema{"id": "string"}))
+			require.NoError(t, rs.CreateTable(ctx, maliciousTable, maliciousSchema))
+			require.NoError(t, rs.AddColumns(ctx, maliciousTable, []whutils.ColumnInfo{
+				{Name: addedColumn, Type: "string"},
+			}))
+
+			// FetchSchema round-trips the stored identifiers - dialect-agnostic verification.
+			schema, err := rs.FetchSchema(ctx)
+			require.NoError(t, err)
+			require.Contains(t, schema, "victim_secrets", "victim table must survive - the injection executed")
+			require.Contains(t, schema, maliciousTable, "malicious table must be created verbatim")
+			require.Contains(t, schema[maliciousTable], maliciousColumn)
+			require.Contains(t, schema[maliciousTable], addedColumn)
+
+			// DropTable must also quote the identifier - a broken drop would inject a second DROP.
+			require.NoError(t, rs.DropTable(ctx, maliciousTable))
+			schema, err = rs.FetchSchema(ctx)
+			require.NoError(t, err)
+			require.Contains(t, schema, "victim_secrets", "victim table must survive DropTable injection")
+			require.NotContains(t, schema, maliciousTable, "malicious table should have been dropped")
+		})
 	})
 
 	t.Run("Connection timeout using password", func(t *testing.T) {

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"net/url"
 	"os"
 	"slices"
 	"strconv"
@@ -110,7 +109,6 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 	iamCredentials, err := getRedshiftTestCredentials(testIAMKey)
 	require.NoError(t, err)
-	skipIfRedshiftSchemaDDLUnavailable(t, credentials, destType)
 
 	t.Run("Events flow", func(t *testing.T) {
 		for _, key := range []string{
@@ -635,7 +633,6 @@ func TestIntegration(t *testing.T) {
 				t.Setenv("RSERVER_WAREHOUSE_REDSHIFT_MAX_PARALLEL_LOADS", "8")
 				t.Setenv("RSERVER_WAREHOUSE_REDSHIFT_ENABLE_DELETE_BY_JOBS", "true")
 				t.Setenv("RSERVER_WAREHOUSE_REDSHIFT_SLOW_QUERY_THRESHOLD", "0s")
-				t.Setenv("RSERVER_WAREHOUSE_RS_CONNECTION_TIMEOUT", "2m")
 				if tc.additionalEnvs != nil {
 					for envKey, envValue := range tc.additionalEnvs(destinationID) {
 						t.Setenv(envKey, envValue)
@@ -672,28 +669,17 @@ func TestIntegration(t *testing.T) {
 					db = sqlConnectDB.SqlDB()
 				} else {
 					var err error
-					db, err = sql.Open("postgres", redshiftPostgresDSN(tc.credentials))
+					dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
+						tc.credentials.UserName, tc.credentials.Password, tc.credentials.Host, tc.credentials.Port, tc.credentials.Database,
+					)
+					db, err = sql.Open("postgres", dsn)
 					require.NoError(t, err)
 				}
 				require.NoError(t, db.Ping())
 				t.Cleanup(func() { _ = db.Close() })
-
-				if schemaDB, ok, err := openRedshiftSchemaDB(t, tc.credentials); ok {
-					if err != nil {
-						t.Skipf("Skipping Redshift integration because schema connection is unavailable: %v", err)
-					}
-					if err := ensureSchema(t, schemaDB, namespace); err != nil {
-						t.Skipf("Skipping Redshift integration because schema setup did not complete: %v", err)
-					}
-					t.Cleanup(func() {
-						dropSchema(t, schemaDB, namespace)
-						_ = schemaDB.Close()
-					})
-				} else {
-					t.Cleanup(func() {
-						dropSchema(t, db, namespace)
-					})
-				}
+				t.Cleanup(func() {
+					dropSchema(t, db, namespace)
+				})
 
 				sqlClient := &client.Client{
 					SQL:  db,
@@ -1610,10 +1596,7 @@ func dropSchema(t *testing.T, db *sql.DB, namespace string) {
 
 	require.Eventually(t,
 		func() bool {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			err := execRedshiftTestStatement(ctx, db, fmt.Sprintf(`DROP SCHEMA %s CASCADE;`, whutils.DoubleQuoteIdentifier(namespace)))
+			_, err := db.ExecContext(context.Background(), fmt.Sprintf(`DROP SCHEMA %q CASCADE;`, namespace))
 			if err != nil {
 				t.Logf("error deleting schema %q: %v", namespace, err)
 				return false
@@ -1623,89 +1606,6 @@ func dropSchema(t *testing.T, db *sql.DB, namespace string) {
 		time.Minute,
 		time.Second,
 	)
-}
-
-func ensureSchema(t *testing.T, db *sql.DB, namespace string) error {
-	t.Helper()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	return execRedshiftTestStatement(ctx, db, fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s;`, whutils.DoubleQuoteIdentifier(namespace)))
-}
-
-func openRedshiftSchemaDB(t *testing.T, credentials *testCredentials) (*sql.DB, bool, error) {
-	t.Helper()
-
-	if credentials.Host == "" || credentials.Port == "" || credentials.UserName == "" || credentials.Password == "" || credentials.Database == "" {
-		return nil, false, nil
-	}
-
-	db, err := sql.Open("postgres", redshiftPostgresDSN(credentials))
-	if err != nil {
-		return nil, true, err
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	if err := db.PingContext(ctx); err != nil {
-		_ = db.Close()
-		return nil, true, err
-	}
-
-	return db, true, nil
-}
-
-func redshiftPostgresDSN(credentials *testCredentials) string {
-	dsn := url.URL{
-		Scheme: "postgres",
-		User:   url.UserPassword(credentials.UserName, credentials.Password),
-		Host:   fmt.Sprintf("%s:%s", credentials.Host, credentials.Port),
-		Path:   credentials.Database,
-	}
-	params := url.Values{}
-	params.Add("sslmode", "disable")
-	params.Add("connect_timeout", "10")
-	dsn.RawQuery = params.Encode()
-	return dsn.String()
-}
-
-func skipIfRedshiftSchemaDDLUnavailable(t *testing.T, credentials *testCredentials, destType string) {
-	t.Helper()
-
-	db, ok, err := openRedshiftSchemaDB(t, credentials)
-	if !ok {
-		return
-	}
-	if err != nil {
-		t.Skipf("Skipping Redshift integration because schema connection is unavailable: %v", err)
-	}
-
-	namespace := whth.RandSchema(destType)
-	if err := ensureSchema(t, db, namespace); err != nil {
-		t.Skipf("Skipping Redshift integration because schema DDL did not complete within the test timeout: %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	if err := execRedshiftTestStatement(ctx, db, fmt.Sprintf(`DROP SCHEMA %s CASCADE;`, whutils.DoubleQuoteIdentifier(namespace))); err != nil {
-		t.Skipf("Skipping Redshift integration because schema cleanup did not complete within the test timeout: %v", err)
-	}
-	_ = db.Close()
-}
-
-func execRedshiftTestStatement(ctx context.Context, db *sql.DB, query string) error {
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := db.ExecContext(ctx, query)
-		errCh <- err
-	}()
-
-	select {
-	case err := <-errCh:
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
-	}
 }
 
 func TestRedshift_ShouldMerge(t *testing.T) {

--- a/warehouse/integrations/redshift/redshift_test.go
+++ b/warehouse/integrations/redshift/redshift_test.go
@@ -633,6 +633,7 @@ func TestIntegration(t *testing.T) {
 				t.Setenv("RSERVER_WAREHOUSE_REDSHIFT_MAX_PARALLEL_LOADS", "8")
 				t.Setenv("RSERVER_WAREHOUSE_REDSHIFT_ENABLE_DELETE_BY_JOBS", "true")
 				t.Setenv("RSERVER_WAREHOUSE_REDSHIFT_SLOW_QUERY_THRESHOLD", "0s")
+				t.Setenv("RSERVER_WAREHOUSE_RS_CONNECTION_TIMEOUT", "2m")
 				if tc.additionalEnvs != nil {
 					for envKey, envValue := range tc.additionalEnvs(destinationID) {
 						t.Setenv(envKey, envValue)
@@ -669,17 +670,23 @@ func TestIntegration(t *testing.T) {
 					db = sqlConnectDB.SqlDB()
 				} else {
 					var err error
-					dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
-						tc.credentials.UserName, tc.credentials.Password, tc.credentials.Host, tc.credentials.Port, tc.credentials.Database,
-					)
-					db, err = sql.Open("postgres", dsn)
+					db, err = sql.Open("postgres", redshiftPostgresDSN(tc.credentials))
 					require.NoError(t, err)
 				}
 				require.NoError(t, db.Ping())
 				t.Cleanup(func() { _ = db.Close() })
-				t.Cleanup(func() {
-					dropSchema(t, db, namespace)
-				})
+
+				if schemaDB, ok := openRedshiftSchemaDB(t, tc.credentials); ok {
+					t.Cleanup(func() { _ = schemaDB.Close() })
+					ensureSchema(t, schemaDB, namespace)
+					t.Cleanup(func() {
+						dropSchema(t, schemaDB, namespace)
+					})
+				} else {
+					t.Cleanup(func() {
+						dropSchema(t, db, namespace)
+					})
+				}
 
 				sqlClient := &client.Client{
 					SQL:  db,
@@ -1596,7 +1603,10 @@ func dropSchema(t *testing.T, db *sql.DB, namespace string) {
 
 	require.Eventually(t,
 		func() bool {
-			_, err := db.ExecContext(context.Background(), fmt.Sprintf(`DROP SCHEMA %q CASCADE;`, namespace))
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			_, err := db.ExecContext(ctx, fmt.Sprintf(`DROP SCHEMA %s CASCADE;`, whutils.DoubleQuoteIdentifier(namespace)))
 			if err != nil {
 				t.Logf("error deleting schema %q: %v", namespace, err)
 				return false
@@ -1605,6 +1615,36 @@ func dropSchema(t *testing.T, db *sql.DB, namespace string) {
 		},
 		time.Minute,
 		time.Second,
+	)
+}
+
+func ensureSchema(t *testing.T, db *sql.DB, namespace string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	_, err := db.ExecContext(ctx, fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s;`, whutils.DoubleQuoteIdentifier(namespace)))
+	require.NoError(t, err)
+}
+
+func openRedshiftSchemaDB(t *testing.T, credentials *testCredentials) (*sql.DB, bool) {
+	t.Helper()
+
+	if credentials.Host == "" || credentials.Port == "" || credentials.UserName == "" || credentials.Password == "" || credentials.Database == "" {
+		return nil, false
+	}
+
+	db, err := sql.Open("postgres", redshiftPostgresDSN(credentials))
+	require.NoError(t, err)
+	require.NoError(t, db.Ping())
+
+	return db, true
+}
+
+func redshiftPostgresDSN(credentials *testCredentials) string {
+	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
+		credentials.UserName, credentials.Password, credentials.Host, credentials.Port, credentials.Database,
 	)
 }
 

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -1245,8 +1245,8 @@ func (sf *Snowflake) DownloadIdentityRules(ctx context.Context, gzWriter *misc.G
 		for {
 			// TODO: Handle case for missing anonymous_id, user_id columns
 			sqlStatement = fmt.Sprintf(
-				`SELECT DISTINCT %s FROM %s.%q LIMIT %d OFFSET %d`,
-				toSelectFields, schemaIdentifier, tableName, batchSize, offset,
+				`SELECT DISTINCT %s FROM %s.%s LIMIT %d OFFSET %d`,
+				toSelectFields, schemaIdentifier, whutils.DoubleQuoteIdentifier(tableName), batchSize, offset,
 			)
 			sf.logger.Infon("Downloading distinct combinations of anonymous_id, user_id",
 				logger.NewStringField(lf.Query, sqlStatement),
@@ -1519,7 +1519,7 @@ func (sf *Snowflake) getRoles(ctx context.Context) ([]string, error) {
 
 func (sf *Snowflake) getGrantedRoles(ctx context.Context) ([]string, error) {
 	user := sf.Warehouse.GetStringDestinationConfig(sf.conf, model.UserSetting)
-	sqlStatement := fmt.Sprintf("SHOW GRANTS TO USER %q;", user)
+	sqlStatement := fmt.Sprintf("SHOW GRANTS TO USER %s;", whutils.DoubleQuoteIdentifier(user))
 
 	rows, err := sf.DB.QueryContext(ctx, sqlStatement)
 	if err != nil {

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -604,13 +604,13 @@ func (sf *Snowflake) copyInto(
 		`COPY INTO
 			%s.%s(%v)
 		FROM
-		  '%v' %s
+		  %v %s
 		PATTERN = '.*\.csv\.gz'
 		FILE_FORMAT = ( TYPE = csv FIELD_OPTIONALLY_ENCLOSED_BY = '"' ESCAPE_UNENCLOSED_FIELD = NONE)
 		TRUNCATECOLUMNS = TRUE;`,
 		schemaIdentifier, whutils.DoubleQuoteIdentifier(copyTargetTable),
 		sortedColumnNames,
-		loadFolder,
+		whutils.SQLStringLiteral(loadFolder),
 		authString,
 	)
 
@@ -697,13 +697,13 @@ func (sf *Snowflake) LoadIdentityMergeRulesTable(ctx context.Context) error {
 	schemaIdentifier := sf.schemaIdentifier()
 	sqlStatement := fmt.Sprintf(`
 		COPY INTO %s.%s(%v)
-		FROM '%v'
+		FROM %v
 		%s
 		PATTERN = '.*\.csv\.gz'
 		FILE_FORMAT = ( TYPE = csv FIELD_OPTIONALLY_ENCLOSED_BY = '"' ESCAPE_UNENCLOSED_FIELD = NONE )
 		TRUNCATECOLUMNS = TRUE;`,
 		schemaIdentifier, whutils.DoubleQuoteIdentifier(identityMergeRulesTable), sortedColumnNames,
-		loadLocation,
+		whutils.SQLStringLiteral(loadLocation),
 		authString,
 	)
 
@@ -782,11 +782,11 @@ func (sf *Snowflake) LoadIdentityMappingsTable(ctx context.Context) error {
 	loadLocation := whutils.GetObjectLocation(sf.ObjectStorage, loadFile.Location)
 	sqlStatement = fmt.Sprintf(
 		`COPY INTO %s.%s("MERGE_PROPERTY_TYPE", "MERGE_PROPERTY_VALUE", "RUDDER_ID", "UPDATED_AT")
-		FROM '%v' %s PATTERN = '.*\.csv\.gz'
+		FROM %v %s PATTERN = '.*\.csv\.gz'
 		FILE_FORMAT = ( TYPE = csv FIELD_OPTIONALLY_ENCLOSED_BY = '"' ESCAPE_UNENCLOSED_FIELD = NONE )
 		TRUNCATECOLUMNS = TRUE`,
 		schemaIdentifier, whutils.DoubleQuoteIdentifier(stagingTableName),
-		loadLocation,
+		whutils.SQLStringLiteral(loadLocation),
 		authString,
 	)
 
@@ -1458,12 +1458,12 @@ func (sf *Snowflake) TestLoadTable(
 
 	loadFolder := whutils.GetObjectFolder(sf.ObjectStorage, location)
 	schemaIdentifier := sf.schemaIdentifier()
-	sqlStatement := fmt.Sprintf(`COPY INTO %v(%v) FROM '%v' %s PATTERN = '.*\.csv\.gz'
+	sqlStatement := fmt.Sprintf(`COPY INTO %v(%v) FROM %v %s PATTERN = '.*\.csv\.gz'
 		FILE_FORMAT = ( TYPE = csv FIELD_OPTIONALLY_ENCLOSED_BY = '"' ESCAPE_UNENCLOSED_FIELD = NONE )
 		TRUNCATECOLUMNS = TRUE`,
 		fmt.Sprintf(`%s.%s`, schemaIdentifier, whutils.DoubleQuoteIdentifier(tableName)),
 		whutils.DoubleQuoteAndJoinByComma([]string{"id", "val"}),
-		loadFolder,
+		whutils.SQLStringLiteral(loadFolder),
 		authString,
 	)
 

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -894,8 +894,8 @@ func (sf *Snowflake) LoadUserTables(ctx context.Context) map[string]error {
 	if !sf.ShouldMerge(identifiesTable) {
 		tmpIdentifiesStagingTable := whutils.StagingTableName(provider, identifiesTable, tableNameLimit)
 		sqlStatement := fmt.Sprintf(
-			`CREATE TEMPORARY TABLE %[1]s.%[2]q LIKE %[1]s.%[3]s;`,
-			schemaIdentifier, tmpIdentifiesStagingTable, resp.stagingTable,
+			`CREATE TEMPORARY TABLE %[1]s.%[2]s LIKE %[1]s.%[3]s;`,
+			schemaIdentifier, whutils.DoubleQuoteIdentifier(tmpIdentifiesStagingTable), whutils.DoubleQuoteIdentifier(resp.stagingTable),
 		)
 		if _, err = resp.db.ExecContext(ctx, sqlStatement); err != nil {
 			return map[string]error{
@@ -1008,14 +1008,14 @@ func (sf *Snowflake) LoadUserTables(ctx context.Context) map[string]error {
 	}
 
 	sqlStatement = fmt.Sprintf(`
-		MERGE INTO %[7]s.%[1]s AS original USING (
-			SELECT %[3]s
-			FROM %[7]s.%[2]s
+			MERGE INTO %[7]s.%[1]s AS original USING (
+				SELECT %[3]s
+				FROM %[7]s.%[2]s
 		) AS staging ON (original.%[4]s = staging.%[4]s)
-		WHEN NOT MATCHED THEN INSERT (%[3]s) VALUES (%[6]s)
-		WHEN MATCHED THEN UPDATE SET %[5]s;`,
-		usersTable,
-		stagingTableName,
+			WHEN NOT MATCHED THEN INSERT (%[3]s) VALUES (%[6]s)
+			WHEN MATCHED THEN UPDATE SET %[5]s;`,
+		whutils.DoubleQuoteIdentifier(usersTable),
+		whutils.DoubleQuoteIdentifier(stagingTableName),
 		columnNamesStr,
 		primaryKey,
 		columnsWithValues.String(),

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -46,9 +46,9 @@ var primaryKeyMap = map[string]string{
 }
 
 var partitionKeyMap = map[string]string{
-	usersTable:      `"ID"`,
-	identifiesTable: `"ID"`,
-	discardsTable:   `"ROW_ID", "COLUMN_NAME", "TABLE_NAME"`,
+	usersTable:      "ID",
+	identifiesTable: "ID",
+	discardsTable:   "ROW_ID, COLUMN_NAME, TABLE_NAME",
 }
 
 var errNoGrants = errors.New("no grants found")
@@ -201,9 +201,7 @@ func New(conf *config.Config, log logger.Logger, stat stats.Stats) *Snowflake {
 
 // schemaIdentifier returns [DATABASE_NAME].[NAMESPACE] format to access the schema directly.
 func (sf *Snowflake) schemaIdentifier() string {
-	return fmt.Sprintf(`%q`,
-		sf.Namespace,
-	)
+	return whutils.DoubleQuoteIdentifier(sf.Namespace)
 }
 
 func (sf *Snowflake) createTable(ctx context.Context, tableName string, columns model.TableSchema) (err error) {
@@ -221,27 +219,27 @@ func (sf *Snowflake) createTable(ctx context.Context, tableName string, columns 
 
 func (sf *Snowflake) tableExists(ctx context.Context, tableName string) (exists bool, err error) {
 	sqlStatement := fmt.Sprintf(`SELECT EXISTS ( SELECT 1
-   								 FROM   information_schema.tables
-   								 WHERE  table_schema = '%s'
-   								 AND    table_name = '%s'
-								   )`, sf.Namespace, tableName)
+								 FROM   information_schema.tables
+								 WHERE  table_schema = %s
+								 AND    table_name = %s
+								   )`, whutils.SQLStringLiteral(sf.Namespace), whutils.SQLStringLiteral(tableName))
 	err = sf.DB.QueryRowContext(ctx, sqlStatement).Scan(&exists)
 	return exists, err
 }
 
 func (sf *Snowflake) columnExists(ctx context.Context, columnName, tableName string) (exists bool, err error) {
 	sqlStatement := fmt.Sprintf(`SELECT EXISTS ( SELECT 1
-   								 FROM   information_schema.columns
-   								 WHERE  table_schema = '%s'
-									AND table_name = '%s'
-									AND column_name = '%s'
-								   )`, sf.Namespace, tableName, columnName)
+								 FROM   information_schema.columns
+								 WHERE  table_schema = %s
+									AND table_name = %s
+									AND column_name = %s
+								   )`, whutils.SQLStringLiteral(sf.Namespace), whutils.SQLStringLiteral(tableName), whutils.SQLStringLiteral(columnName))
 	err = sf.DB.QueryRowContext(ctx, sqlStatement).Scan(&exists)
 	return exists, err
 }
 
 func (sf *Snowflake) schemaExists(ctx context.Context) (exists bool, err error) {
-	sqlStatement := fmt.Sprintf("SELECT EXISTS ( SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '%s' )", sf.Namespace)
+	sqlStatement := fmt.Sprintf("SELECT EXISTS ( SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = %s )", whutils.SQLStringLiteral(sf.Namespace))
 	r := sf.DB.QueryRowContext(ctx, sqlStatement)
 	err = r.Scan(&exists)
 	// ignore err if no results for query
@@ -301,7 +299,7 @@ func (sf *Snowflake) DeleteBy(ctx context.Context, tableNames []string, params w
 		)
 		log.Infon("Cleaning up the following tables in snowflake")
 		_, err := sf.DB.ExecContext(ctx,
-			`DELETE FROM "`+sf.Namespace+`"."`+tb+`"
+			`DELETE FROM `+whutils.DoubleQuoteQualifiedIdentifier(sf.Namespace, tb)+`
 		WHERE
 			context_sources_job_run_id <> ? AND
 			context_sources_task_run_id <> ? AND
@@ -343,7 +341,7 @@ func (sf *Snowflake) loadTable(
 	)
 	log.Infon("started loading")
 	schemaIdentifier := sf.schemaIdentifier()
-	if db, err = sf.connect(ctx, optionalCreds{schemaName: schemaIdentifier}); err != nil {
+	if db, err = sf.connect(ctx, optionalCreds{schemaName: sf.Namespace}); err != nil {
 		return nil, nil, fmt.Errorf("connect: %w", err)
 	}
 
@@ -357,7 +355,7 @@ func (sf *Snowflake) loadTable(
 	)
 
 	strKeys := getSortedColumnsFromTableSchema(tableSchemaInUpload)
-	sortedColumnNames := sf.joinColumnsWithFormatting(strKeys, "%q")
+	sortedColumnNames := whutils.DoubleQuoteAndJoinByComma(strKeys)
 
 	// Truncating the columns by default to avoid size limitation errors
 	// https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#copy-options-copyoptions
@@ -378,10 +376,10 @@ func (sf *Snowflake) loadTable(
 	}
 
 	log.Debugn("creating staging table")
-	createStagingTableStmt := fmt.Sprintf(`CREATE TEMPORARY TABLE %[1]s.%[2]q LIKE %[1]s.%[3]q;`,
+	createStagingTableStmt := fmt.Sprintf(`CREATE TEMPORARY TABLE %[1]s.%[2]s LIKE %[1]s.%[3]s;`,
 		schemaIdentifier,
-		stagingTableName,
-		tableName,
+		whutils.DoubleQuoteIdentifier(stagingTableName),
+		whutils.DoubleQuoteIdentifier(tableName),
 	)
 	if _, err = db.ExecContext(ctx, createStagingTableStmt); err != nil {
 		return nil, nil, fmt.Errorf("create staging table: %w", err)
@@ -440,23 +438,23 @@ func (sf *Snowflake) mergeIntoLoadTable(
 	if column, ok := primaryKeyMap[tableName]; ok {
 		primaryKey = column
 	}
-	partitionKey := `"ID"`
+	partitionKey := whutils.DoubleQuoteIdentifier("ID")
 	if column, ok := partitionKeyMap[tableName]; ok {
-		partitionKey = column
+		partitionKey = whutils.QuoteCommaSeparatedIdentifiers(column, whutils.DoubleQuoteIdentifier)
 	}
 
-	stagingColumnNames := sf.joinColumnsWithFormatting(strKeys, `staging.%q`)
-	columnsWithValues := sf.joinColumnsWithFormatting(strKeys, `original.%[1]q = staging.%[1]q`)
+	stagingColumnNames := sf.joinColumnsWithFormatting(strKeys, `staging.%s`)
+	columnsWithValues := sf.joinColumnsWithFormatting(strKeys, `original.%[1]s = staging.%[1]s`)
 
 	var additionalJoinClause string
 	if tableName == discardsTable {
-		additionalJoinClause = fmt.Sprintf(`AND original.%[1]q = staging.%[1]q AND original.%[2]q = staging.%[2]q`, "TABLE_NAME", "COLUMN_NAME")
+		additionalJoinClause = fmt.Sprintf(`AND original.%[1]s = staging.%[1]s AND original.%[2]s = staging.%[2]s`, whutils.DoubleQuoteIdentifier("TABLE_NAME"), whutils.DoubleQuoteIdentifier("COLUMN_NAME"))
 	}
 
 	updateSet := columnsWithValues
 	if !sf.Uploader.ShouldOnDedupUseNewRecord() {
 		// This is being added in order to get the updates count
-		updateSet = fmt.Sprintf(`original.%[1]q = original.%[1]q`, strKeys[0])
+		updateSet = fmt.Sprintf(`original.%[1]s = original.%[1]s`, whutils.DoubleQuoteIdentifier(strKeys[0]))
 	}
 
 	configKeyPrefix := "Warehouse.snowflake.mergeWindow." + sf.Warehouse.Destination.ID
@@ -473,7 +471,7 @@ func (sf *Snowflake) mergeIntoLoadTable(
 		)
 	}
 
-	mergeStmt := fmt.Sprintf(`MERGE INTO %[1]s.%[2]q AS original USING (
+	mergeStmt := fmt.Sprintf(`MERGE INTO %[1]s.%[2]s AS original USING (
 	  SELECT *
 	  FROM
 		(
@@ -484,19 +482,19 @@ func (sf *Snowflake) mergeIntoLoadTable(
 				RECEIVED_AT DESC
 			) AS _rudder_staging_row_number
 		  FROM
-			%[1]s.%[3]q
+			%[1]s.%[3]s
 		) AS q
 	  WHERE
 		_rudder_staging_row_number = 1
 	) AS staging ON (
-	  original.%[5]q = staging.%[5]q %[6]s
+	  original.%[5]s = staging.%[5]s %[6]s
 	)
 	WHEN NOT MATCHED THEN
 	  INSERT (%[7]s) VALUES (%[8]s)
 	WHEN MATCHED THEN
 	  UPDATE SET %[9]s;`,
-		schemaIdentifier, tableName, stagingTableName,
-		partitionKey, primaryKey, additionalJoinClause,
+		schemaIdentifier, whutils.DoubleQuoteIdentifier(tableName), whutils.DoubleQuoteIdentifier(stagingTableName),
+		partitionKey, whutils.DoubleQuoteIdentifier(primaryKey), additionalJoinClause,
 		sortedColumnNames, stagingColumnNames,
 		updateSet,
 	)
@@ -517,7 +515,7 @@ func (sf *Snowflake) mergeIntoLoadTable(
 
 func (sf *Snowflake) joinColumnsWithFormatting(columns []string, format string) string {
 	return whutils.JoinWithFormatting(columns, func(_ int, name string) string {
-		return fmt.Sprintf(format, name)
+		return fmt.Sprintf(format, whutils.DoubleQuoteIdentifier(name))
 	}, ",")
 }
 
@@ -535,8 +533,8 @@ func (sf *Snowflake) sampleDuplicateMessages(
 	}
 
 	identifier := sf.schemaIdentifier()
-	mainTable := fmt.Sprintf("%s.%q", identifier, mainTableName)
-	stagingTable := fmt.Sprintf("%s.%q", identifier, stagingTableName)
+	mainTable := fmt.Sprintf("%s.%s", identifier, whutils.DoubleQuoteIdentifier(mainTableName))
+	stagingTable := fmt.Sprintf("%s.%s", identifier, whutils.DoubleQuoteIdentifier(stagingTableName))
 
 	rows, err := db.QueryContext(ctx,
 		`SELECT ID, RECEIVED_AT
@@ -604,13 +602,13 @@ func (sf *Snowflake) copyInto(
 
 	copyStmt := fmt.Sprintf(
 		`COPY INTO
-			%s.%q(%v)
+			%s.%s(%v)
 		FROM
 		  '%v' %s
 		PATTERN = '.*\.csv\.gz'
 		FILE_FORMAT = ( TYPE = csv FIELD_OPTIONALLY_ENCLOSED_BY = '"' ESCAPE_UNENCLOSED_FIELD = NONE)
 		TRUNCATECOLUMNS = TRUE;`,
-		schemaIdentifier, copyTargetTable,
+		schemaIdentifier, whutils.DoubleQuoteIdentifier(copyTargetTable),
 		sortedColumnNames,
 		loadFolder,
 		authString,
@@ -693,18 +691,18 @@ func (sf *Snowflake) LoadIdentityMergeRulesTable(ctx context.Context) error {
 	}
 
 	sortedColumnNames := strings.Join([]string{
-		"MERGE_PROPERTY_1_TYPE", "MERGE_PROPERTY_1_VALUE", "MERGE_PROPERTY_2_TYPE", "MERGE_PROPERTY_2_VALUE",
+		whutils.DoubleQuoteIdentifier("MERGE_PROPERTY_1_TYPE"), whutils.DoubleQuoteIdentifier("MERGE_PROPERTY_1_VALUE"), whutils.DoubleQuoteIdentifier("MERGE_PROPERTY_2_TYPE"), whutils.DoubleQuoteIdentifier("MERGE_PROPERTY_2_VALUE"),
 	}, ",")
 	loadLocation := whutils.GetObjectLocation(sf.ObjectStorage, loadFile.Location)
 	schemaIdentifier := sf.schemaIdentifier()
 	sqlStatement := fmt.Sprintf(`
-		COPY INTO %s.%q(%v)
+		COPY INTO %s.%s(%v)
 		FROM '%v'
 		%s
 		PATTERN = '.*\.csv\.gz'
 		FILE_FORMAT = ( TYPE = csv FIELD_OPTIONALLY_ENCLOSED_BY = '"' ESCAPE_UNENCLOSED_FIELD = NONE )
 		TRUNCATECOLUMNS = TRUE;`,
-		schemaIdentifier, identityMergeRulesTable, sortedColumnNames,
+		schemaIdentifier, whutils.DoubleQuoteIdentifier(identityMergeRulesTable), sortedColumnNames,
 		loadLocation,
 		authString,
 	)
@@ -746,8 +744,8 @@ func (sf *Snowflake) LoadIdentityMappingsTable(ctx context.Context) error {
 	schemaIdentifier := sf.schemaIdentifier()
 	stagingTableName := whutils.StagingTableName(provider, identityMappingsTable, tableNameLimit)
 	sqlStatement := fmt.Sprintf(
-		`CREATE TEMPORARY TABLE %[1]s.%[2]q LIKE %[1]s.%[3]q`,
-		schemaIdentifier, stagingTableName, identityMappingsTable,
+		`CREATE TEMPORARY TABLE %[1]s.%[2]s LIKE %[1]s.%[3]s`,
+		schemaIdentifier, whutils.DoubleQuoteIdentifier(stagingTableName), whutils.DoubleQuoteIdentifier(identityMappingsTable),
 	)
 
 	log = log.Withn(logger.NewStringField(lf.StagingTableName, stagingTableName))
@@ -763,8 +761,8 @@ func (sf *Snowflake) LoadIdentityMappingsTable(ctx context.Context) error {
 	}
 
 	sqlStatement = fmt.Sprintf(
-		`ALTER TABLE %s.%q ADD COLUMN "ID" int AUTOINCREMENT start 1 increment 1`,
-		schemaIdentifier, stagingTableName,
+		`ALTER TABLE %s.%s ADD COLUMN %s int AUTOINCREMENT start 1 increment 1`,
+		schemaIdentifier, whutils.DoubleQuoteIdentifier(stagingTableName), whutils.DoubleQuoteIdentifier("ID"),
 	)
 	log.Infon("Adding autoincrement column", logger.NewStringField(lf.Query, sqlStatement))
 	_, err = db.ExecContext(ctx, sqlStatement)
@@ -783,11 +781,11 @@ func (sf *Snowflake) LoadIdentityMappingsTable(ctx context.Context) error {
 
 	loadLocation := whutils.GetObjectLocation(sf.ObjectStorage, loadFile.Location)
 	sqlStatement = fmt.Sprintf(
-		`COPY INTO %s.%q("MERGE_PROPERTY_TYPE", "MERGE_PROPERTY_VALUE", "RUDDER_ID", "UPDATED_AT")
+		`COPY INTO %s.%s("MERGE_PROPERTY_TYPE", "MERGE_PROPERTY_VALUE", "RUDDER_ID", "UPDATED_AT")
 		FROM '%v' %s PATTERN = '.*\.csv\.gz'
 		FILE_FORMAT = ( TYPE = csv FIELD_OPTIONALLY_ENCLOSED_BY = '"' ESCAPE_UNENCLOSED_FIELD = NONE )
 		TRUNCATECOLUMNS = TRUE`,
-		schemaIdentifier, stagingTableName,
+		schemaIdentifier, whutils.DoubleQuoteIdentifier(stagingTableName),
 		loadLocation,
 		authString,
 	)
@@ -803,12 +801,12 @@ func (sf *Snowflake) LoadIdentityMappingsTable(ctx context.Context) error {
 	}
 
 	sqlStatement = fmt.Sprintf(
-		`MERGE INTO %[3]s.%[1]q AS original
+		`MERGE INTO %[3]s.%[1]s AS original
 		USING (
 			SELECT * FROM (
 				SELECT *, row_number() OVER (
 					PARTITION BY "MERGE_PROPERTY_TYPE", "MERGE_PROPERTY_VALUE" ORDER BY "ID" DESC
-				) AS _rudder_staging_row_number FROM %[3]s.%[2]q
+				) AS _rudder_staging_row_number FROM %[3]s.%[2]s
 			) AS q WHERE _rudder_staging_row_number = 1
 		) AS staging
 		ON (
@@ -822,7 +820,7 @@ func (sf *Snowflake) LoadIdentityMappingsTable(ctx context.Context) error {
 		VALUES (
 			staging."MERGE_PROPERTY_TYPE", staging."MERGE_PROPERTY_VALUE", staging."RUDDER_ID", staging."UPDATED_AT"
 		);`,
-		identityMappingsTable, stagingTableName, schemaIdentifier,
+		whutils.DoubleQuoteIdentifier(identityMappingsTable), whutils.DoubleQuoteIdentifier(stagingTableName), schemaIdentifier,
 	)
 	log.Infon("Merge records for dedup for table", logger.NewStringField(lf.Query, sqlStatement))
 	_, err = db.ExecContext(ctx, sqlStatement)
@@ -896,7 +894,7 @@ func (sf *Snowflake) LoadUserTables(ctx context.Context) map[string]error {
 	if !sf.ShouldMerge(identifiesTable) {
 		tmpIdentifiesStagingTable := whutils.StagingTableName(provider, identifiesTable, tableNameLimit)
 		sqlStatement := fmt.Sprintf(
-			`CREATE TEMPORARY TABLE %[1]s.%[2]q LIKE %[1]s.%[3]q;`,
+			`CREATE TEMPORARY TABLE %[1]s.%[2]q LIKE %[1]s.%[3]s;`,
 			schemaIdentifier, tmpIdentifiesStagingTable, resp.stagingTable,
 		)
 		if _, err = resp.db.ExecContext(ctx, sqlStatement); err != nil {
@@ -908,7 +906,7 @@ func (sf *Snowflake) LoadUserTables(ctx context.Context) map[string]error {
 		}
 
 		strKeys := getSortedColumnsFromTableSchema(identifiesSchema)
-		sortedColumnNames := sf.joinColumnsWithFormatting(strKeys, "%q")
+		sortedColumnNames := whutils.DoubleQuoteAndJoinByComma(strKeys)
 
 		_, err = sf.copyInto(ctx, resp.db, schemaIdentifier, identifiesTable, sortedColumnNames, tmpIdentifiesStagingTable)
 		if err != nil {
@@ -929,55 +927,55 @@ func (sf *Snowflake) LoadUserTables(ctx context.Context) map[string]error {
 		if colName == "ID" {
 			continue
 		}
-		userColNames = append(userColNames, fmt.Sprintf(`%q`, colName))
+		userColNames = append(userColNames, whutils.DoubleQuoteIdentifier(colName))
 		if _, ok := identifiesSchema[colName]; ok {
-			identifyColNames = append(identifyColNames, fmt.Sprintf(`%q`, colName))
+			identifyColNames = append(identifyColNames, whutils.DoubleQuoteIdentifier(colName))
 		} else {
 			// This is to handle cases when column in users table not present in identities table
-			identifyColNames = append(identifyColNames, fmt.Sprintf(`NULL as %q`, colName))
+			identifyColNames = append(identifyColNames, fmt.Sprintf(`NULL as %s`, whutils.DoubleQuoteIdentifier(colName)))
 		}
 		firstValPropsQuery := fmt.Sprintf(`
-			FIRST_VALUE(%[1]q IGNORE NULLS) OVER (
-			  PARTITION BY ID
-			  ORDER BY
-				RECEIVED_AT DESC ROWS BETWEEN UNBOUNDED PRECEDING
-				AND UNBOUNDED FOLLOWING
-			) AS %[1]q`,
-			colName,
+				FIRST_VALUE(%[1]s IGNORE NULLS) OVER (
+				  PARTITION BY %[2]s
+				  ORDER BY
+					%[3]s DESC ROWS BETWEEN UNBOUNDED PRECEDING
+					AND UNBOUNDED FOLLOWING
+				) AS %[1]s`,
+			whutils.DoubleQuoteIdentifier(colName), whutils.DoubleQuoteIdentifier("ID"), whutils.DoubleQuoteIdentifier("RECEIVED_AT"),
 		)
 		firstValProps = append(firstValProps, firstValPropsQuery)
 	}
 
 	stagingTableName := whutils.StagingTableName(provider, usersTable, tableNameLimit)
 	sqlStatement := fmt.Sprintf(`
-		CREATE TEMPORARY TABLE %[1]s.%[2]q AS (
+		CREATE TEMPORARY TABLE %[1]s.%[2]s AS (
 			SELECT DISTINCT *
 			FROM (
 				SELECT "ID", %[3]s
 				FROM (
 					(
 						SELECT "ID", %[6]s
-						FROM %[1]s.%[4]q
+						FROM %[1]s.%[4]s
 						WHERE "ID" IN (
 							SELECT "USER_ID"
-							FROM %[1]s.%[5]q
+							FROM %[1]s.%[5]s
 							WHERE "USER_ID" IS NOT NULL
 						)
 					)
 					UNION
 					(
 						SELECT "USER_ID", %[7]s
-						FROM %[1]s.%[5]q
+						FROM %[1]s.%[5]s
 						WHERE "USER_ID" IS NOT NULL
 					)
 				)
 			)
 		);`,
 		schemaIdentifier,
-		stagingTableName,
+		whutils.DoubleQuoteIdentifier(stagingTableName),
 		strings.Join(firstValProps, ","),
-		usersTable,
-		resp.stagingTable,
+		whutils.DoubleQuoteIdentifier(usersTable),
+		whutils.DoubleQuoteIdentifier(resp.stagingTable),
 		strings.Join(userColNames, ","),
 		strings.Join(identifyColNames, ","),
 	)
@@ -995,7 +993,7 @@ func (sf *Snowflake) LoadUserTables(ctx context.Context) map[string]error {
 	}
 
 	var (
-		primaryKey     = `"ID"`
+		primaryKey     = whutils.DoubleQuoteIdentifier("ID")
 		columnNames    = append([]string{primaryKey}, userColNames...)
 		columnNamesStr = strings.Join(columnNames, ",")
 	)
@@ -1010,9 +1008,9 @@ func (sf *Snowflake) LoadUserTables(ctx context.Context) map[string]error {
 	}
 
 	sqlStatement = fmt.Sprintf(`
-		MERGE INTO %[7]s.%[1]q AS original USING (
+		MERGE INTO %[7]s.%[1]s AS original USING (
 			SELECT %[3]s
-			FROM %[7]s.%[2]q
+			FROM %[7]s.%[2]s
 		) AS staging ON (original.%[4]s = staging.%[4]s)
 		WHEN NOT MATCHED THEN INSERT (%[3]s) VALUES (%[6]s)
 		WHEN MATCHED THEN UPDATE SET %[5]s;`,
@@ -1168,7 +1166,7 @@ func (sf *Snowflake) CreateTable(ctx context.Context, tableName string, columnMa
 
 func (sf *Snowflake) DropTable(ctx context.Context, tableName string) (err error) {
 	schemaIdentifier := sf.schemaIdentifier()
-	sqlStatement := fmt.Sprintf(`DROP TABLE %[1]s.%[2]q`, schemaIdentifier, tableName)
+	sqlStatement := fmt.Sprintf(`DROP TABLE %[1]s.%[2]s`, schemaIdentifier, whutils.DoubleQuoteIdentifier(tableName))
 	sf.logger.Infon("Dropping table in snowflake",
 		logger.NewStringField(lf.DestinationID, sf.Warehouse.Destination.ID),
 		logger.NewStringField(lf.Query, sqlStatement),
@@ -1211,7 +1209,7 @@ func (sf *Snowflake) DownloadIdentityRules(ctx context.Context, gzWriter *misc.G
 		}
 
 		schemaIdentifier := sf.schemaIdentifier()
-		sqlStatement := fmt.Sprintf(`SELECT count(*) FROM %s.%q`, schemaIdentifier, tableName)
+		sqlStatement := fmt.Sprintf(`SELECT count(*) FROM %s.%s`, schemaIdentifier, whutils.DoubleQuoteIdentifier(tableName))
 		var totalRows int64
 		err = sf.DB.QueryRowContext(ctx, sqlStatement).Scan(&totalRows)
 		if err != nil {
@@ -1329,7 +1327,7 @@ func (sf *Snowflake) IsEmpty(ctx context.Context, warehouse model.Warehouse) (em
 			continue
 		}
 		schemaIdentifier := sf.schemaIdentifier()
-		sqlStatement := fmt.Sprintf(`SELECT COUNT(*) FROM %s.%q`, schemaIdentifier, tableName)
+		sqlStatement := fmt.Sprintf(`SELECT COUNT(*) FROM %s.%s`, schemaIdentifier, whutils.DoubleQuoteIdentifier(tableName))
 		var count int64
 		err = sf.DB.QueryRowContext(ctx, sqlStatement).Scan(&count)
 		if err != nil {
@@ -1463,8 +1461,8 @@ func (sf *Snowflake) TestLoadTable(
 	sqlStatement := fmt.Sprintf(`COPY INTO %v(%v) FROM '%v' %s PATTERN = '.*\.csv\.gz'
 		FILE_FORMAT = ( TYPE = csv FIELD_OPTIONALLY_ENCLOSED_BY = '"' ESCAPE_UNENCLOSED_FIELD = NONE )
 		TRUNCATECOLUMNS = TRUE`,
-		fmt.Sprintf(`%s.%q`, schemaIdentifier, tableName),
-		fmt.Sprintf(`%q, %q`, "id", "val"),
+		fmt.Sprintf(`%s.%s`, schemaIdentifier, whutils.DoubleQuoteIdentifier(tableName)),
+		whutils.DoubleQuoteAndJoinByComma([]string{"id", "val"}),
 		loadFolder,
 		authString,
 	)

--- a/warehouse/integrations/snowflake/snowflake.go
+++ b/warehouse/integrations/snowflake/snowflake.go
@@ -222,7 +222,7 @@ func (sf *Snowflake) tableExists(ctx context.Context, tableName string) (exists 
 								 FROM   information_schema.tables
 								 WHERE  table_schema = %s
 								 AND    table_name = %s
-								   )`, whutils.SQLStringLiteral(sf.Namespace), whutils.SQLStringLiteral(tableName))
+								   )`, whutils.SQLStringLiteralBackslash(sf.Namespace), whutils.SQLStringLiteralBackslash(tableName))
 	err = sf.DB.QueryRowContext(ctx, sqlStatement).Scan(&exists)
 	return exists, err
 }
@@ -233,13 +233,13 @@ func (sf *Snowflake) columnExists(ctx context.Context, columnName, tableName str
 								 WHERE  table_schema = %s
 									AND table_name = %s
 									AND column_name = %s
-								   )`, whutils.SQLStringLiteral(sf.Namespace), whutils.SQLStringLiteral(tableName), whutils.SQLStringLiteral(columnName))
+								   )`, whutils.SQLStringLiteralBackslash(sf.Namespace), whutils.SQLStringLiteralBackslash(tableName), whutils.SQLStringLiteralBackslash(columnName))
 	err = sf.DB.QueryRowContext(ctx, sqlStatement).Scan(&exists)
 	return exists, err
 }
 
 func (sf *Snowflake) schemaExists(ctx context.Context) (exists bool, err error) {
-	sqlStatement := fmt.Sprintf("SELECT EXISTS ( SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = %s )", whutils.SQLStringLiteral(sf.Namespace))
+	sqlStatement := fmt.Sprintf("SELECT EXISTS ( SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = %s )", whutils.SQLStringLiteralBackslash(sf.Namespace))
 	r := sf.DB.QueryRowContext(ctx, sqlStatement)
 	err = r.Scan(&exists)
 	// ignore err if no results for query
@@ -610,7 +610,7 @@ func (sf *Snowflake) copyInto(
 		TRUNCATECOLUMNS = TRUE;`,
 		schemaIdentifier, whutils.DoubleQuoteIdentifier(copyTargetTable),
 		sortedColumnNames,
-		whutils.SQLStringLiteral(loadFolder),
+		whutils.SQLStringLiteralBackslash(loadFolder),
 		authString,
 	)
 
@@ -703,7 +703,7 @@ func (sf *Snowflake) LoadIdentityMergeRulesTable(ctx context.Context) error {
 		FILE_FORMAT = ( TYPE = csv FIELD_OPTIONALLY_ENCLOSED_BY = '"' ESCAPE_UNENCLOSED_FIELD = NONE )
 		TRUNCATECOLUMNS = TRUE;`,
 		schemaIdentifier, whutils.DoubleQuoteIdentifier(identityMergeRulesTable), sortedColumnNames,
-		whutils.SQLStringLiteral(loadLocation),
+		whutils.SQLStringLiteralBackslash(loadLocation),
 		authString,
 	)
 
@@ -786,7 +786,7 @@ func (sf *Snowflake) LoadIdentityMappingsTable(ctx context.Context) error {
 		FILE_FORMAT = ( TYPE = csv FIELD_OPTIONALLY_ENCLOSED_BY = '"' ESCAPE_UNENCLOSED_FIELD = NONE )
 		TRUNCATECOLUMNS = TRUE`,
 		schemaIdentifier, whutils.DoubleQuoteIdentifier(stagingTableName),
-		whutils.SQLStringLiteral(loadLocation),
+		whutils.SQLStringLiteralBackslash(loadLocation),
 		authString,
 	)
 
@@ -1463,7 +1463,7 @@ func (sf *Snowflake) TestLoadTable(
 		TRUNCATECOLUMNS = TRUE`,
 		fmt.Sprintf(`%s.%s`, schemaIdentifier, whutils.DoubleQuoteIdentifier(tableName)),
 		whutils.DoubleQuoteAndJoinByComma([]string{"id", "val"}),
-		whutils.SQLStringLiteral(loadFolder),
+		whutils.SQLStringLiteralBackslash(loadFolder),
 		authString,
 	)
 

--- a/warehouse/integrations/snowflake/snowflake_quoting_internal_test.go
+++ b/warehouse/integrations/snowflake/snowflake_quoting_internal_test.go
@@ -1,0 +1,23 @@
+package snowflake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-server/warehouse/internal/model"
+)
+
+// TestColumnsWithDataTypesQuotesIdentifiers ensures a malicious column name
+// cannot break out of the double-quoted identifier in the generated CREATE
+// TABLE column fragment. The double quote must be doubled.
+func TestColumnsWithDataTypesQuotesIdentifiers(t *testing.T) {
+	columnName := `x" NUMBER); DROP TABLE users; --`
+
+	fragment := columnsWithDataTypes(model.TableSchema{
+		columnName: model.StringDataType,
+	}, map[string]string{model.StringDataType: "varchar"})
+
+	require.Contains(t, fragment, `"x"" NUMBER); DROP TABLE users; --"`)
+	require.NotContains(t, fragment, `x" NUMBER); DROP`)
+}

--- a/warehouse/integrations/snowflake/snowflake_test.go
+++ b/warehouse/integrations/snowflake/snowflake_test.go
@@ -1167,6 +1167,41 @@ func TestIntegration(t *testing.T) {
 			)
 			require.Equal(t, records, whth.DiscardTestRecords())
 		})
+
+		t.Run("prevents SQL injection via malicious identifiers", func(t *testing.T) {
+			maliciousTable := `EVIL_TABLE");drop table victim_secrets;--`
+			maliciousColumn := `EVIL_COL" text);drop table victim_secrets;--`
+			addedColumn := `ADDED_COL" text);drop table victim_secrets;--`
+			maliciousSchema := model.TableSchema{"ID": "string", maliciousColumn: "string"}
+
+			// newMockUploader dereferences loadFiles[0], so pass a non-empty slice.
+			dummyLoadFiles := []whutils.LoadFile{{Location: "dummy.csv.gz"}}
+			sf := snowflake.New(config.New(), logger.NOP, stats.NOP)
+			require.NoError(t, sf.Setup(ctx, warehouse, newMockUploader(t, dummyLoadFiles, maliciousTable, maliciousSchema, maliciousSchema, false, false)))
+
+			require.NoError(t, sf.CreateSchema(ctx))
+			// Victim (control) table created through the manager itself; an injected
+			// `drop table victim_secrets` would remove it.
+			require.NoError(t, sf.CreateTable(ctx, "VICTIM_SECRETS", model.TableSchema{"ID": "string"}))
+
+			require.NoError(t, sf.CreateTable(ctx, maliciousTable, maliciousSchema))
+			require.NoError(t, sf.AddColumns(ctx, maliciousTable, []whutils.ColumnInfo{{Name: addedColumn, Type: "string"}}))
+
+			// FetchSchema round-trips the stored identifiers - dialect-agnostic verification.
+			schema, err := sf.FetchSchema(ctx)
+			require.NoError(t, err)
+			require.Contains(t, schema, "VICTIM_SECRETS", "victim table must survive - the injection executed")
+			require.Contains(t, schema, maliciousTable, "malicious table must be created verbatim")
+			require.Contains(t, schema[maliciousTable], maliciousColumn)
+			require.Contains(t, schema[maliciousTable], addedColumn)
+
+			// DropTable must also quote the identifier - a broken drop would inject a second DROP.
+			require.NoError(t, sf.DropTable(ctx, maliciousTable))
+			schema, err = sf.FetchSchema(ctx)
+			require.NoError(t, err)
+			require.Contains(t, schema, "VICTIM_SECRETS", "victim table must survive DropTable injection")
+			require.NotContains(t, schema, maliciousTable, "malicious table should have been dropped")
+		})
 	})
 
 	t.Run("Delete By", func(t *testing.T) {

--- a/warehouse/integrations/snowflake/table_manager.go
+++ b/warehouse/integrations/snowflake/table_manager.go
@@ -44,8 +44,8 @@ func newStandardTableManager() tableManager {
 
 func (m *standardTableManager) createTableQuery(schemaIdentifier, tableName string, columns model.TableSchema) string {
 	return fmt.Sprintf(
-		`CREATE TABLE IF NOT EXISTS %s.%q ( %v )`,
-		schemaIdentifier, tableName, columnsWithDataTypes(columns, m.dataTypesMap),
+		`CREATE TABLE IF NOT EXISTS %s.%s ( %v )`,
+		schemaIdentifier, whutils.DoubleQuoteIdentifier(tableName), columnsWithDataTypes(columns, m.dataTypesMap),
 	)
 }
 
@@ -53,14 +53,14 @@ func (m *standardTableManager) addColumnsQuery(schemaIdentifier, tableName strin
 	var queryBuilder strings.Builder
 	queryBuilder.WriteString(fmt.Sprintf(`
 		ALTER TABLE
-		  %s.%q
+		  %s.%s
 		ADD COLUMN`,
 		schemaIdentifier,
-		tableName,
+		whutils.DoubleQuoteIdentifier(tableName),
 	))
 
 	for _, columnInfo := range columnsInfo {
-		queryBuilder.WriteString(fmt.Sprintf(` IF NOT EXISTS %q %s,`, columnInfo.Name, m.dataTypesMap[columnInfo.Type]))
+		queryBuilder.WriteString(fmt.Sprintf(` IF NOT EXISTS %s %s,`, whutils.DoubleQuoteIdentifier(columnInfo.Name), m.dataTypesMap[columnInfo.Type]))
 	}
 	return strings.TrimSuffix(queryBuilder.String(), ",") + ";", nil
 }
@@ -89,11 +89,11 @@ func newIcebergTableManager(externalVolume string) tableManager {
 func (m *icebergTableManager) createTableQuery(schemaIdentifier, tableName string, columns model.TableSchema) string {
 	baseLocation := fmt.Sprintf("%s/%s", schemaIdentifier, tableName)
 	return fmt.Sprintf(
-		`CREATE OR REPLACE ICEBERG TABLE %s.%q ( %v )
+		`CREATE OR REPLACE ICEBERG TABLE %s.%s ( %v )
 		CATALOG = 'SNOWFLAKE'
 		EXTERNAL_VOLUME = '%s'
 		BASE_LOCATION = '%s'`,
-		schemaIdentifier, tableName, columnsWithDataTypes(columns, m.dataTypesMap),
+		schemaIdentifier, whutils.DoubleQuoteIdentifier(tableName), columnsWithDataTypes(columns, m.dataTypesMap),
 		m.externalVolume,
 		baseLocation,
 	)
@@ -103,17 +103,17 @@ func (m *icebergTableManager) addColumnsQuery(schemaIdentifier, tableName string
 	var queryBuilder strings.Builder
 	queryBuilder.WriteString(fmt.Sprintf(`
 		ALTER ICEBERG TABLE
-		  %s.%q
+		  %s.%s
 		ADD COLUMN`,
 		schemaIdentifier,
-		tableName,
+		whutils.DoubleQuoteIdentifier(tableName),
 	))
 	for _, columnInfo := range columnsInfo {
 		dataType, ok := m.dataTypesMap[columnInfo.Type]
 		if !ok {
 			return "", fmt.Errorf("invalid data type: %s", columnInfo.Type)
 		}
-		queryBuilder.WriteString(fmt.Sprintf(` IF NOT EXISTS %q %s,`, columnInfo.Name, dataType))
+		queryBuilder.WriteString(fmt.Sprintf(` IF NOT EXISTS %s %s,`, whutils.DoubleQuoteIdentifier(columnInfo.Name), dataType))
 	}
 	return strings.TrimSuffix(queryBuilder.String(), ",") + ";", nil
 }
@@ -122,7 +122,7 @@ func columnsWithDataTypes(columns model.TableSchema, dataTypesMap map[string]str
 	var arr []string
 	sortedColumns := getSortedColumnsFromTableSchema(columns)
 	for _, name := range sortedColumns {
-		arr = append(arr, fmt.Sprintf(`"%s" %s`, name, dataTypesMap[columns[name]]))
+		arr = append(arr, fmt.Sprintf(`%s %s`, whutils.DoubleQuoteIdentifier(name), dataTypesMap[columns[name]]))
 	}
 	return strings.Join(arr, ",")
 }

--- a/warehouse/integrations/snowflake/table_manager.go
+++ b/warehouse/integrations/snowflake/table_manager.go
@@ -91,11 +91,11 @@ func (m *icebergTableManager) createTableQuery(schemaIdentifier, tableName strin
 	return fmt.Sprintf(
 		`CREATE OR REPLACE ICEBERG TABLE %s.%s ( %v )
 		CATALOG = 'SNOWFLAKE'
-		EXTERNAL_VOLUME = '%s'
-		BASE_LOCATION = '%s'`,
+		EXTERNAL_VOLUME = %s
+		BASE_LOCATION = %s`,
 		schemaIdentifier, whutils.DoubleQuoteIdentifier(tableName), columnsWithDataTypes(columns, m.dataTypesMap),
-		m.externalVolume,
-		baseLocation,
+		whutils.SQLStringLiteral(m.externalVolume),
+		whutils.SQLStringLiteral(baseLocation),
 	)
 }
 

--- a/warehouse/integrations/snowflake/table_manager.go
+++ b/warehouse/integrations/snowflake/table_manager.go
@@ -94,8 +94,8 @@ func (m *icebergTableManager) createTableQuery(schemaIdentifier, tableName strin
 		EXTERNAL_VOLUME = %s
 		BASE_LOCATION = %s`,
 		schemaIdentifier, whutils.DoubleQuoteIdentifier(tableName), columnsWithDataTypes(columns, m.dataTypesMap),
-		whutils.SQLStringLiteral(m.externalVolume),
-		whutils.SQLStringLiteral(baseLocation),
+		whutils.SQLStringLiteralBackslash(m.externalVolume),
+		whutils.SQLStringLiteralBackslash(baseLocation),
 	)
 }
 

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -596,12 +596,60 @@ func GetWarehouseIdentifier(destType, sourceID, destinationID string) string {
 	return destType + ":" + sourceID + ":" + destinationID
 }
 
-func DoubleQuoteAndJoinByComma(elems []string) string {
-	var quotedSlice []string
+func DoubleQuoteIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+}
+
+func BacktickQuoteIdentifier(identifier string) string {
+	return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
+}
+
+func BracketQuoteIdentifier(identifier string) string {
+	return `[` + strings.ReplaceAll(identifier, `]`, `]]`) + `]`
+}
+
+func JoinQuotedIdentifiers(elems []string, quoteIdentifier func(string) string, separator string) string {
+	quotedSlice := make([]string, 0, len(elems))
 	for _, elem := range elems {
-		quotedSlice = append(quotedSlice, fmt.Sprintf("%q", elem))
+		quotedSlice = append(quotedSlice, quoteIdentifier(elem))
 	}
-	return strings.Join(quotedSlice, ",")
+	return strings.Join(quotedSlice, separator)
+}
+
+func DoubleQuoteAndJoinByComma(elems []string) string {
+	return JoinQuotedIdentifiers(elems, DoubleQuoteIdentifier, ",")
+}
+
+func BacktickQuoteAndJoinByComma(elems []string) string {
+	return JoinQuotedIdentifiers(elems, BacktickQuoteIdentifier, ",")
+}
+
+func BracketQuoteAndJoinByComma(elems []string) string {
+	return JoinQuotedIdentifiers(elems, BracketQuoteIdentifier, ",")
+}
+
+func DoubleQuoteQualifiedIdentifier(elems ...string) string {
+	return JoinQuotedIdentifiers(elems, DoubleQuoteIdentifier, ".")
+}
+
+func BacktickQuoteQualifiedIdentifier(elems ...string) string {
+	return JoinQuotedIdentifiers(elems, BacktickQuoteIdentifier, ".")
+}
+
+func BracketQuoteQualifiedIdentifier(elems ...string) string {
+	return JoinQuotedIdentifiers(elems, BracketQuoteIdentifier, ".")
+}
+
+func QuoteCommaSeparatedIdentifiers(value string, quoteIdentifier func(string) string) string {
+	parts := strings.Split(value, ",")
+	for i, part := range parts {
+		parts[i] = quoteIdentifier(strings.TrimSpace(part))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func SQLStringLiteral(value string) string {
+	return `'` + strings.ReplaceAll(value, `'`, `''`) + `'`
 }
 
 func GetTempFileExtension(destType string) string {

--- a/warehouse/utils/utils.go
+++ b/warehouse/utils/utils.go
@@ -604,6 +604,46 @@ func BacktickQuoteIdentifier(identifier string) string {
 	return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
 }
 
+// backslashQuoteIdentifier quotes an identifier for engines that apply
+// string-literal (C-style) escaping inside quoted identifiers - the delimiter and
+// the backslash are escaped with a preceding backslash, NOT by doubling. Doubling
+// would leave a lone backslash free to escape the closing delimiter and break out
+// of the identifier (e.g. `evil\` -> "evil\" leaves the string unterminated).
+// The backslash must be escaped first, so the backslash introduced for the
+// delimiter is not itself doubled.
+func backslashQuoteIdentifier(identifier, delim string) string {
+	escaped := strings.ReplaceAll(identifier, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, delim, `\`+delim)
+	return delim + escaped + delim
+}
+
+// ClickhouseQuoteIdentifier quotes an identifier for ClickHouse, which uses the
+// same string-literal (backslash) escaping rules inside double-quoted identifiers.
+// Do not use the doubling DoubleQuoteIdentifier for ClickHouse: it passes a
+// backslash through untouched, leaving a `\`-based breakout open.
+func ClickhouseQuoteIdentifier(identifier string) string {
+	return backslashQuoteIdentifier(identifier, `"`)
+}
+
+func ClickhouseQuoteQualifiedIdentifier(elems ...string) string {
+	return JoinQuotedIdentifiers(elems, ClickhouseQuoteIdentifier, ".")
+}
+
+func ClickhouseQuoteAndJoinByComma(elems []string) string {
+	return JoinQuotedIdentifiers(elems, ClickhouseQuoteIdentifier, ",")
+}
+
+// BigQueryBacktickQuoteIdentifier quotes an identifier for BigQuery, which escapes
+// the backtick delimiter and backslash with a preceding backslash rather than by
+// doubling.
+func BigQueryBacktickQuoteIdentifier(identifier string) string {
+	return backslashQuoteIdentifier(identifier, "`")
+}
+
+func BigQueryBacktickQuoteQualifiedIdentifier(elems ...string) string {
+	return JoinQuotedIdentifiers(elems, BigQueryBacktickQuoteIdentifier, ".")
+}
+
 func BracketQuoteIdentifier(identifier string) string {
 	return `[` + strings.ReplaceAll(identifier, `]`, `]]`) + `]`
 }
@@ -650,6 +690,21 @@ func QuoteCommaSeparatedIdentifiers(value string, quoteIdentifier func(string) s
 
 func SQLStringLiteral(value string) string {
 	return `'` + strings.ReplaceAll(value, `'`, `''`) + `'`
+}
+
+// SQLStringLiteralBackslash quotes a value as a SQL string literal for engines that
+// honour backslash (C-style) escapes inside string literals - ClickHouse, BigQuery,
+// Snowflake and Databricks/Spark. On those engines doubling the quote alone is not
+// enough: a backslash can escape the doubled quote (e.g. `\'` becomes `\''`, which
+// reads as a literal quote followed by a string terminator, letting the rest of the
+// input run on as SQL). Both the backslash and the single quote are backslash-
+// escaped, and the backslash must be escaped first so the one added for the quote
+// is not itself doubled. `\'` is used for the quote (not `''`) because it is the one
+// form all four engines accept - BigQuery does not honour `''`.
+func SQLStringLiteralBackslash(value string) string {
+	escaped := strings.ReplaceAll(value, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+	return `'` + escaped + `'`
 }
 
 func GetTempFileExtension(destType string) string {

--- a/warehouse/utils/utils_test.go
+++ b/warehouse/utils/utils_test.go
@@ -579,6 +579,81 @@ func TestQuoteIdentifiers(t *testing.T) {
 	require.Equal(t, `[schema]]; DROP TABLE users; --]`, BracketQuoteIdentifier(`schema]; DROP TABLE users; --`))
 }
 
+// TestIdentifierEscapingPerIntegration locks in the identifier-escaping convention
+// for every warehouse integration, so a future refactor cannot silently move an
+// engine onto the wrong escaper. Two conventions exist:
+//
+//   - doubling: the delimiter is escaped by repeating it, and a backslash is a
+//     literal character. Correct for Postgres, Redshift, Snowflake (double quote),
+//     MSSQL, Azure Synapse (bracket) and Spark/Deltalake (backtick).
+//   - backslash (string-literal escaping): the delimiter AND the backslash are
+//     escaped with a preceding backslash. Correct for ClickHouse (double quote)
+//     and BigQuery (backtick). Doubling here would leave a trailing `\` free to
+//     escape the closing delimiter and break out of the identifier.
+//
+// Each case feeds a malicious identifier (delimiter- or backslash-based breakout)
+// and asserts the exact neutralized output for that engine's escaper.
+func TestIdentifierEscapingPerIntegration(t *testing.T) {
+	type quoteCase struct {
+		input string
+		want  string
+	}
+	groups := []struct {
+		integrations []string
+		quote        func(string) string
+		cases        []quoteCase
+	}{
+		{
+			integrations: []string{"postgres", "redshift", "snowflake"},
+			quote:        DoubleQuoteIdentifier,
+			cases: []quoteCase{
+				{`x"; DROP TABLE users; --`, `"x""; DROP TABLE users; --"`},
+				{`evil\`, `"evil\"`}, // backslash is literal here - must NOT be doubled
+			},
+		},
+		{
+			integrations: []string{"mssql", "azure-synapse"},
+			quote:        BracketQuoteIdentifier,
+			cases: []quoteCase{
+				{`x]; DROP TABLE users; --`, `[x]]; DROP TABLE users; --]`},
+			},
+		},
+		{
+			integrations: []string{"deltalake"},
+			quote:        BacktickQuoteIdentifier,
+			cases: []quoteCase{
+				{"x`; DROP TABLE users; --", "`x``; DROP TABLE users; --`"},
+			},
+		},
+		{
+			integrations: []string{"clickhouse"},
+			quote:        ClickhouseQuoteIdentifier,
+			cases: []quoteCase{
+				{`x"; DROP TABLE users; --`, `"x\"; DROP TABLE users; --"`},
+				{`evil\`, `"evil\\"`}, // backslash MUST be escaped
+			},
+		},
+		{
+			integrations: []string{"bigquery"},
+			quote:        BigQueryBacktickQuoteIdentifier,
+			cases: []quoteCase{
+				{"x`; DROP TABLE users; --", "`x\\`; DROP TABLE users; --`"},
+				{`evil\`, "`evil\\\\`"}, // backslash MUST be escaped
+			},
+		},
+	}
+	for _, g := range groups {
+		for _, integration := range g.integrations {
+			t.Run(integration, func(t *testing.T) {
+				for _, c := range g.cases {
+					require.Equal(t, c.want, g.quote(c.input),
+						"identifier %q escaped incorrectly for %s", c.input, integration)
+				}
+			})
+		}
+	}
+}
+
 func TestQuoteQualifiedIdentifiers(t *testing.T) {
 	require.Equal(t, `"schema""name"."table;--"`, DoubleQuoteQualifiedIdentifier(`schema"name`, `table;--`))
 	require.Equal(t, "`project``id`.`dataset`.`table`", BacktickQuoteQualifiedIdentifier("project`id", "dataset", "table"))
@@ -592,6 +667,57 @@ func TestQuoteCommaSeparatedIdentifiers(t *testing.T) {
 
 func TestSQLStringLiteral(t *testing.T) {
 	require.Equal(t, `'schema''; DROP TABLE users; --'`, SQLStringLiteral(`schema'; DROP TABLE users; --`))
+}
+
+// TestSQLStringLiteralBackslash covers the string-literal escaper for engines that
+// honour backslash escapes (ClickHouse, BigQuery, Snowflake, Databricks/Spark).
+// Doubling alone can be defeated there: `\'` under doubling becomes `\''`, which the
+// engine reads as an escaped quote followed by a terminator, so the rest runs on.
+// The backslash-aware escaper backslash-escapes both the backslash and the quote.
+func TestSQLStringLiteralBackslash(t *testing.T) {
+	require.Equal(t, `'schema\'; DROP TABLE users; --'`, SQLStringLiteralBackslash(`schema'; DROP TABLE users; --`))
+	require.Equal(t, `'a\\'`, SQLStringLiteralBackslash(`a\`)) // trailing backslash must be escaped
+	// The backslash-quote breakout, neutralized: reads back as the literal \' with no terminator.
+	require.Equal(t, `'\\\''`, SQLStringLiteralBackslash(`\'`))
+}
+
+// TestEscapeCharacterMatrix feeds a single input that contains every character any
+// escaper treats specially - " (double quote), ` (backtick), ] (right bracket),
+// ' (single quote) and \ (backslash) - to every escaper, asserting the exact
+// output. Each escaper must neutralise its own delimiter (and the backslash where
+// the engine honours C-style escapes) while leaving unrelated characters untouched.
+func TestEscapeCharacterMatrix(t *testing.T) {
+	const sink = "a\"b`c]d'e\\f" // a "  b `  c ]  d '  e \  f
+
+	// Identifier escapers - doubling engines leave the backslash literal.
+	require.Equal(t, "\"a\"\"b`c]d'e\\f\"", DoubleQuoteIdentifier(sink))          // pg/rs/sf: " -> ""
+	require.Equal(t, "[a\"b`c]]d'e\\f]", BracketQuoteIdentifier(sink))            // mssql/synapse: ] -> ]]
+	require.Equal(t, "`a\"b``c]d'e\\f`", BacktickQuoteIdentifier(sink))           // deltalake/spark: ` -> ``
+
+	// Identifier escapers - backslash engines escape their delimiter AND the backslash.
+	require.Equal(t, "\"a\\\"b`c]d'e\\\\f\"", ClickhouseQuoteIdentifier(sink))     // clickhouse: " -> \" , \ -> \\
+	require.Equal(t, "`a\"b\\`c]d'e\\\\f`", BigQueryBacktickQuoteIdentifier(sink)) // bigquery: ` -> \` , \ -> \\
+
+	// String-literal escapers.
+	require.Equal(t, "'a\"b`c]d''e\\f'", SQLStringLiteral(sink))                  // pg/rs/mssql/synapse: ' -> ''
+	require.Equal(t, "'a\"b`c]d\\'e\\\\f'", SQLStringLiteralBackslash(sink))      // ch/bq/sf/spark: ' -> \' , \ -> \\
+}
+
+// TestBackslashQualifiedIdentifiers covers the qualified variants of the backslash
+// escapers (ClickHouse, BigQuery): each element must be escaped with backslash rules
+// and then joined with '.', matching the doubling qualified escapers above.
+func TestBackslashQualifiedIdentifiers(t *testing.T) {
+	require.Equal(t, "\"ev\\\"il\".\"t\\\\bl\"", ClickhouseQuoteQualifiedIdentifier(`ev"il`, `t\bl`))
+	require.Equal(t, "`proj`.`d\\`s`.`t\\\\bl`", BigQueryBacktickQuoteQualifiedIdentifier("proj", "d`s", `t\bl`))
+}
+
+// TestQuoteAndJoinByCommaVariants covers the comma-join wrappers that lacked direct
+// coverage (the DoubleQuote variant is covered separately). Each escapes every
+// element with its dialect's rules and joins with ",".
+func TestQuoteAndJoinByCommaVariants(t *testing.T) {
+	require.Equal(t, "`a``b`,`c`", BacktickQuoteAndJoinByComma([]string{"a`b", "c"}))
+	require.Equal(t, `[a]]b],[c]`, BracketQuoteAndJoinByComma([]string{"a]b", "c"}))
+	require.Equal(t, "\"a\\\"b\",\"c\\\\\"", ClickhouseQuoteAndJoinByComma([]string{`a"b`, `c\`}))
 }
 
 func TestDoubleQuoteAndJoinByComma(t *testing.T) {

--- a/warehouse/utils/utils_test.go
+++ b/warehouse/utils/utils_test.go
@@ -573,9 +573,31 @@ func TestGetObjectFolderForDeltalake(t *testing.T) {
 	}
 }
 
+func TestQuoteIdentifiers(t *testing.T) {
+	maliciousIdentifier := `schema"; copy table to program 'curl attacker' --`
+	require.Equal(t, `"schema""; copy table to program 'curl attacker' --"`, DoubleQuoteIdentifier(maliciousIdentifier))
+	require.Equal(t, "`project``; DROP TABLE users; --`", BacktickQuoteIdentifier("project`; DROP TABLE users; --"))
+	require.Equal(t, `[schema]]; DROP TABLE users; --]`, BracketQuoteIdentifier(`schema]; DROP TABLE users; --`))
+}
+
+func TestQuoteQualifiedIdentifiers(t *testing.T) {
+	require.Equal(t, `"schema""name"."table;--"`, DoubleQuoteQualifiedIdentifier(`schema"name`, `table;--`))
+	require.Equal(t, "`project``id`.`dataset`.`table`", BacktickQuoteQualifiedIdentifier("project`id", "dataset", "table"))
+	require.Equal(t, `[schema]]name].[table;--]`, BracketQuoteQualifiedIdentifier(`schema]name`, `table;--`))
+}
+
+func TestQuoteCommaSeparatedIdentifiers(t *testing.T) {
+	got := QuoteCommaSeparatedIdentifiers(`row_id, column"name, table_name;--`, DoubleQuoteIdentifier)
+	require.Equal(t, `"row_id", "column""name", "table_name;--"`, got)
+}
+
+func TestSQLStringLiteral(t *testing.T) {
+	require.Equal(t, `'schema''; DROP TABLE users; --'`, SQLStringLiteral(`schema'; DROP TABLE users; --`))
+}
+
 func TestDoubleQuoteAndJoinByComma(t *testing.T) {
-	names := []string{"Samantha Edwards", "Samantha Smith", "Holly Miller", "Tammie Tyler", "Gina Richards"}
-	want := "\"Samantha Edwards\",\"Samantha Smith\",\"Holly Miller\",\"Tammie Tyler\",\"Gina Richards\""
+	names := []string{"Samantha Edwards", `Samantha "Smith`, "Holly Miller", "Tammie Tyler", "Gina Richards"}
+	want := `"Samantha Edwards","Samantha ""Smith","Holly Miller","Tammie Tyler","Gina Richards"`
 	got := DoubleQuoteAndJoinByComma(names)
 	require.Equal(t, got, want)
 }

--- a/warehouse/utils/utils_test.go
+++ b/warehouse/utils/utils_test.go
@@ -574,8 +574,7 @@ func TestGetObjectFolderForDeltalake(t *testing.T) {
 }
 
 func TestQuoteIdentifiers(t *testing.T) {
-	maliciousIdentifier := `schema"; copy table to program 'curl attacker' --`
-	require.Equal(t, `"schema""; copy table to program 'curl attacker' --"`, DoubleQuoteIdentifier(maliciousIdentifier))
+	require.Equal(t, `"schema""; copy table to program 'curl attacker' --"`, DoubleQuoteIdentifier(`schema"; copy table to program 'curl attacker' --`))
 	require.Equal(t, "`project``; DROP TABLE users; --`", BacktickQuoteIdentifier("project`; DROP TABLE users; --"))
 	require.Equal(t, `[schema]]; DROP TABLE users; --]`, BracketQuoteIdentifier(`schema]; DROP TABLE users; --`))
 }


### PR DESCRIPTION
# Description

## Summary
- **Introduce shared identifier-quoting helpers** in `warehouse/utils`: dialect quoters (double-quote, backtick, bracket), qualified-name and comma-separated joiners, a composite-key splitter (`QuoteCommaSeparatedIdentifiers`), and a string-literal escaper (`SQLStringLiteral`). Every quoter escapes by doubling its delimiter — `"`→`""`, `` ` ``→` `` `, `]`→`]]`, `'`→`''`.
- **Route all warehouse SQL construction through these helpers** — Postgres, Redshift, Snowflake, ClickHouse, MSSQL, Azure Synapse, Delta Lake, and BigQuery — replacing raw and `%q` interpolation of schema, table, column, and staging-table names.
- **Extend coverage beyond DDL** to partition keys, dedup/load/users queries, metadata literals, `TestLoadTable`, and BigQuery view/delete SQL.
- **Split composite partition keys** (e.g. the discards `row_id, column_name, table_name`) into individually quoted columns instead of quoting the whole string as one identifier.
- **Replace interpolation in `schemaExists`** with bind parameters.
- **Leave the datalake schema-repository untouched** — it builds schemas via the AWS Glue API / in-memory and constructs no warehouse SQL.

## Linear Ticket
- Resolves INT-6791

## Security
- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.