### PR TITLE
chore: bump sqlconnect-go to v1.30.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/rudderlabs/rudder-schemas v0.12.0
 	github.com/rudderlabs/rudder-transformer/go v1.141.4
 	github.com/rudderlabs/sql-tunnels v0.1.8
-	github.com/rudderlabs/sqlconnect-go v1.30.0
+	github.com/rudderlabs/sqlconnect-go v1.30.1
 	github.com/samber/lo v1.53.0
 	github.com/segmentio/go-hll v1.0.1
 	github.com/segmentio/kafka-go v0.4.51

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/rudderlabs/rudder-schemas v0.12.0
 	github.com/rudderlabs/rudder-transformer/go v1.141.4
 	github.com/rudderlabs/sql-tunnels v0.1.8
-	github.com/rudderlabs/sqlconnect-go v1.28.0
+	github.com/rudderlabs/sqlconnect-go v1.30.0
 	github.com/samber/lo v1.53.0
 	github.com/segmentio/go-hll v1.0.1
 	github.com/segmentio/kafka-go v0.4.51

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/rudderlabs/rudder-schemas v0.12.0
 	github.com/rudderlabs/rudder-transformer/go v1.141.4
 	github.com/rudderlabs/sql-tunnels v0.1.8
-	github.com/rudderlabs/sqlconnect-go v1.30.1
+	github.com/rudderlabs/sqlconnect-go v1.30.2
 	github.com/samber/lo v1.53.0
 	github.com/segmentio/go-hll v1.0.1
 	github.com/segmentio/kafka-go v0.4.51

--- a/go.sum
+++ b/go.sum
@@ -1141,8 +1141,8 @@ github.com/rudderlabs/sonnet v1.0.2 h1:nPfmDKD9gUwT571Dwtcsx0VIglSchvyNjuRLju4Xs
 github.com/rudderlabs/sonnet v1.0.2/go.mod h1:tjQmKEGAo/xwmhw9AwLkazP5b5m8VpUvWNzPSx4ve0g=
 github.com/rudderlabs/sql-tunnels v0.1.8 h1:owX5QL9BEXxtRW3a+JwMGlGQwpDUQGGtDOvnJG4evgs=
 github.com/rudderlabs/sql-tunnels v0.1.8/go.mod h1:/t75DbI2eQQsolWtHawF3MzIddI1iAhE7X/rTy3X27o=
-github.com/rudderlabs/sqlconnect-go v1.30.1 h1:ZfKi3fYkxvdApKSMQYvrQoZtnW1Ugf5bciuAl/M2nVw=
-github.com/rudderlabs/sqlconnect-go v1.30.1/go.mod h1:RmP0FwylGXeP4kjQumIKNHv0Wl9Ok29QdDW14W+nhVE=
+github.com/rudderlabs/sqlconnect-go v1.30.2 h1:ssT/mmHyZR141OjS+jT8e/AZZJMogvXMUKnBsQMeh7A=
+github.com/rudderlabs/sqlconnect-go v1.30.2/go.mod h1:RmP0FwylGXeP4kjQumIKNHv0Wl9Ok29QdDW14W+nhVE=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=

--- a/go.sum
+++ b/go.sum
@@ -1141,8 +1141,8 @@ github.com/rudderlabs/sonnet v1.0.2 h1:nPfmDKD9gUwT571Dwtcsx0VIglSchvyNjuRLju4Xs
 github.com/rudderlabs/sonnet v1.0.2/go.mod h1:tjQmKEGAo/xwmhw9AwLkazP5b5m8VpUvWNzPSx4ve0g=
 github.com/rudderlabs/sql-tunnels v0.1.8 h1:owX5QL9BEXxtRW3a+JwMGlGQwpDUQGGtDOvnJG4evgs=
 github.com/rudderlabs/sql-tunnels v0.1.8/go.mod h1:/t75DbI2eQQsolWtHawF3MzIddI1iAhE7X/rTy3X27o=
-github.com/rudderlabs/sqlconnect-go v1.30.0 h1:4HJwJ0JSowRgs9GIQCqKNWXQGZOw/2WgK6URHu+cynk=
-github.com/rudderlabs/sqlconnect-go v1.30.0/go.mod h1:RmP0FwylGXeP4kjQumIKNHv0Wl9Ok29QdDW14W+nhVE=
+github.com/rudderlabs/sqlconnect-go v1.30.1 h1:ZfKi3fYkxvdApKSMQYvrQoZtnW1Ugf5bciuAl/M2nVw=
+github.com/rudderlabs/sqlconnect-go v1.30.1/go.mod h1:RmP0FwylGXeP4kjQumIKNHv0Wl9Ok29QdDW14W+nhVE=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=

--- a/go.sum
+++ b/go.sum
@@ -1141,8 +1141,8 @@ github.com/rudderlabs/sonnet v1.0.2 h1:nPfmDKD9gUwT571Dwtcsx0VIglSchvyNjuRLju4Xs
 github.com/rudderlabs/sonnet v1.0.2/go.mod h1:tjQmKEGAo/xwmhw9AwLkazP5b5m8VpUvWNzPSx4ve0g=
 github.com/rudderlabs/sql-tunnels v0.1.8 h1:owX5QL9BEXxtRW3a+JwMGlGQwpDUQGGtDOvnJG4evgs=
 github.com/rudderlabs/sql-tunnels v0.1.8/go.mod h1:/t75DbI2eQQsolWtHawF3MzIddI1iAhE7X/rTy3X27o=
-github.com/rudderlabs/sqlconnect-go v1.28.0 h1:qtBO6KlvadqpLXVXQ4q+GlEXNdvaOsKuSigpC8XUyEM=
-github.com/rudderlabs/sqlconnect-go v1.28.0/go.mod h1:RmP0FwylGXeP4kjQumIKNHv0Wl9Ok29QdDW14W+nhVE=
+github.com/rudderlabs/sqlconnect-go v1.30.0 h1:4HJwJ0JSowRgs9GIQCqKNWXQGZOw/2WgK6URHu+cynk=
+github.com/rudderlabs/sqlconnect-go v1.30.0/go.mod h1:RmP0FwylGXeP4kjQumIKNHv0Wl9Ok29QdDW14W+nhVE=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=


### PR DESCRIPTION
Picks up the connection-config hardening released in sqlconnect-go **v1.30.2**.

**What comes with it**

- MySQL DSN built from typed fields, so a crafted `dbname` can no longer inject driver parameters.
- BigQuery credential documents must be `service_account`.
- Host validation across every connector, including the ssh tunnel host, which was previously caller-supplied with only a non-empty check.
- Snowflake `protocol` constrained to https, so a config can no longer request cleartext.
- Instance metadata blocked over IPv4 (`169.254.169.254`) and IPv6 (`fd00:ec2::/32`).

**Private addresses are allowed on purpose — please do not "tighten" this later**

Warehouse destinations for Snowflake (`snowflake.go:1110`), Deltalake (`deltalake.go:234`) and Redshift (`redshift.go:1072`) all build clients via `sqlconnect.NewDB`, so these rules apply to all three.

An earlier revision of this PR pointed at v1.30.1, which rejected RFC1918/ULA space. **We have Redshift customers connecting over PrivateLink, and others reaching Elasticache the same way** — those endpoints resolve to a private address in the customer's VPC, so that version would have severed every one of them. Caught before anything shipped. v1.30.2 is the first version safe for those customers; do not roll back to v1.30.0 or v1.30.1.

Containing access to our own internal network is a real gap and is tracked in PRO-5898. It needs a decision on where to enforce it — application, network layer, or a dedicated egress path — rather than another attempt at filtering by IP, since customer PrivateLink ranges and our cluster ranges are both private and can overlap.

Internal tracking: PRO-5879, PRO-5883.