### PR TITLE
chore: pyt contract tests for candidate releases

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -283,6 +283,24 @@ jobs:
       - name: Login to ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+      # Must run while the AWS credentials are still set, i.e. before the step below unsets them.
+      # The contract suite compares two rudder-pytransformer releases and requires both tags; resolving
+      # them here means a new release is picked up automatically instead of going stale in the source.
+      - name: Resolve rudder-pytransformer tags to compare
+        if: matrix.package == 'integration_test/pytransformer_contract'
+        run: |
+          set -euo pipefail
+          tags=$(aws ecr describe-images \
+            --repository-name rudderstack/rudder-pytransformer \
+            --query 'imageDetails[].imageTags[]' --output text \
+            | tr '\t' '\n' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V -u | tail -2)
+          if [ "$(echo "$tags" | wc -l)" -ne 2 ]; then
+            echo "expected 2 released tags, got: ${tags:-<none>}" >&2
+            exit 1
+          fi
+          echo "PYT_BASELINE_TAG=$(echo "$tags" | head -1)" >> $GITHUB_ENV
+          echo "PYT_CANDIDATE_TAG=$(echo "$tags" | tail -1)" >> $GITHUB_ENV
+          echo "comparing rudder-pytransformer $(echo "$tags" | head -1) -> $(echo "$tags" | tail -1)"
       - name: Unset AWS Credentials
         run: |
           echo "AWS_ACCESS_KEY_ID=" >> $GITHUB_ENV

--- a/integration_test/pytransformer_contract/README.md
+++ b/integration_test/pytransformer_contract/README.md
@@ -1,0 +1,57 @@
+# pytransformer contract tests
+
+These tests run **two rudder-pytransformer containers side by side** and assert they behave identically. One is the
+*baseline* (a released version), the other the *candidate* (what you're checking). Requests go through the real
+`usertransformer.Client`, so the suite covers the actual rudder-server → PyT path rather than a stand-in.
+
+A subtest that only exercises one container is a property test (connection pooling, DNS caching, redirects); those use
+the candidate only. Everything else compares.
+
+## Which two images
+
+|                | candidate                 | baseline              |
+|----------------|---------------------------|-----------------------|
+| Local          | your build, tagged `main` | latest release        |
+| CI (`CI=true`) | latest release            | the release before it |
+
+The release tags are the `latestReleaseTag` / `previousReleaseTag` constants in `bc_helpers_test.go`. **Bump both when a
+new PyT version ships** — nothing does it automatically.
+
+Override either side:
+
+```sh
+PYT_CANDIDATE_TAG=0.11.0 PYT_BASELINE_TAG=0.10.2 go test ./integration_test/pytransformer_contract/ -count=1
+```
+
+If the two resolve to the same tag, `startBaselinePytransformer` panics rather than let every comparison pass against
+itself.
+
+## Running
+
+You need to be able to pull from ECR (see the Notion docs). Then:
+
+```sh
+make test package=integration_test/pytransformer_contract
+# or one suite while iterating:
+go test ./integration_test/pytransformer_contract/ -run TestBackwardsCompatibility -count=1 -timeout=30m
+```
+
+To check your own PyT build, build it first in the rudder-pytransformer repo (`make build-ecr-latest`, which tags it
+`main`) and run with no flags — the local default already compares that against the latest release.
+
+**Docker only pulls a tag it doesn't already have.** Skip the rebuild and `main` is whatever you last built or pulled,
+and the suite compares that instead, silently. Rebuild before trusting a green run.
+
+## Adding a test
+
+`TestBaseContract` in `base_test.go` is the smallest complete example — copy it and change the Python code and events.
+For a case that belongs with the existing table-driven suites, add an entry to the `subtests`
+slice in `backwards_compatibility_test.go` or `geolocation_backwards_compatibility_test.go`.
+
+Two rules worth knowing:
+
+- **Assert on both sides, then compare.** `baselineResp.Equal(&candidateResp)` is what makes it a contract test;
+  per-field asserts on each side keep the failure output readable when it breaks.
+- **Give every subtest its own `versionID`.** Containers are shared across subtests, so the versionID is the only
+  isolation boundary between them — a collision serves one subtest's transformation code to another. The suites assert
+  on this, so a duplicate fails loudly.

--- a/integration_test/pytransformer_contract/README.md
+++ b/integration_test/pytransformer_contract/README.md
@@ -9,35 +9,34 @@ the candidate only. Everything else compares.
 
 ## Which two images
 
-|                | candidate                 | baseline              |
-|----------------|---------------------------|-----------------------|
-| Local          | your build, tagged `main` | latest release        |
-| CI (`CI=true`) | latest release            | the release before it |
-
-The release tags are the `latestReleaseTag` / `previousReleaseTag` constants in `bc_helpers_test.go`. **Bump both when a
-new PyT version ships** — nothing does it automatically.
-
-Override either side:
+**`PYT_CANDIDATE_TAG` and `PYT_BASELINE_TAG` are both required.** There is no default pair, because a hardcoded one
+goes stale: the suite would keep passing while comparing two versions nobody ships any more. `TestMain` fails the
+package if either is missing, before any container starts.
 
 ```sh
 PYT_CANDIDATE_TAG=0.11.0 PYT_BASELINE_TAG=0.10.2 go test ./integration_test/pytransformer_contract/ -count=1
 ```
+
+CI resolves the two most recent released tags from ECR and exports them, so a new release is picked up without editing
+anything here.
 
 If the two resolve to the same tag, `startBaselinePytransformer` panics rather than let every comparison pass against
 itself.
 
 ## Running
 
-You need to be able to pull from ECR (see the Notion docs). Then:
+You need to be able to pull from ECR (see the Notion docs), and both tags set. To check your own PyT build, build it
+first in the rudder-pytransformer repo — `make build-ecr-latest` tags it `main` — then point the candidate at it:
 
 ```sh
-make test package=integration_test/pytransformer_contract
+PYT_CANDIDATE_TAG=main PYT_BASELINE_TAG=<last released tag> make test package=integration_test/pytransformer_contract
 # or one suite while iterating:
-go test ./integration_test/pytransformer_contract/ -run TestBackwardsCompatibility -count=1 -timeout=30m
+PYT_CANDIDATE_TAG=main PYT_BASELINE_TAG=<last released tag> go test ./integration_test/pytransformer_contract/ \
+   -run TestBackwardsCompatibility -count=1 -timeout=20m
 ```
 
-To check your own PyT build, build it first in the rudder-pytransformer repo (`make build-ecr-latest`, which tags it
-`main`) and run with no flags — the local default already compares that against the latest release.
+The rudder-pytransformer Makefile recipe that builds and runs this suite sets both for you, and requires the baseline
+tag as an argument.
 
 **Docker only pulls a tag it doesn't already have.** Skip the rebuild and `main` is whatever you last built or pulled,
 and the suite compares that instead, silently. Rebuild before trusting a green run.

--- a/integration_test/pytransformer_contract/backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/backwards_compatibility_test.go
@@ -17,13 +17,12 @@ import (
 	utilstypes "github.com/rudderlabs/rudder-server/utils/types"
 )
 
-// TestBackwardsCompatibility compares responses from the old architecture
-// (rudder-transformer + openfaas-flask-base) against the new architecture
-// (rudder-pytransformer) for various edge cases.
+// TestBackwardsCompatibility compares responses from the baseline
+// rudder-pytransformer against the candidate one for various edge cases.
 //
-// rudder-transformer and rudder-pytransformer are started once and shared
-// across all subtests. Each subtest gets its own openfaas-flask-base container
-// since openfaas loads transformation code at startup (one version per container).
+// Both containers are started once and shared across all subtests: each fetches
+// transformation code per request from the shared mock config backend, so one
+// container per version serves every versionID.
 func TestBackwardsCompatibility(t *testing.T) {
 	type subtest struct {
 		name                string
@@ -38,8 +37,8 @@ func TestBackwardsCompatibility(t *testing.T) {
 			name:      "TransformationCodeNotFound",
 			versionID: "bc-not-found-v1",
 			// config is zero-value — versionId is NOT registered in config backend.
-			// Config backend returns 404 for unknown versionIds.
-			// No openfaas container is needed (error happens before execution).
+			// Config backend returns 404 for unknown versionIds, so the error
+			// happens before the transformation ever executes.
 			run: func(t *testing.T, env *bcTestEnv) {
 				const versionId = "bc-not-found-v1"
 
@@ -48,22 +47,22 @@ func TestBackwardsCompatibility(t *testing.T) {
 					makeEvent("msg-2", versionId),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.True(t, len(oldResp.FailedEvents) > 0, "old arch: expected at least 1 failed event")
-				require.True(t, len(newResp.FailedEvents) > 0, "new arch: expected at least 1 failed event")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.True(t, len(baselineResp.FailedEvents) > 0, "baseline: expected at least 1 failed event")
+				require.True(t, len(candidateResp.FailedEvents) > 0, "candidate: expected at least 1 failed event")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical error responses for unknown versionId")
+					t.Log("Both versions produce identical error responses for unknown versionId")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -88,23 +87,23 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionId),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Both should expand 1 input event into 3 output events (including one without messageId)
-				require.Equal(t, 3, len(oldResp.Events), "old arch: 3 expanded events expected")
-				require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-				require.Equal(t, 3, len(newResp.Events), "new arch: 3 expanded events expected")
-				require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+				require.Equal(t, 3, len(baselineResp.Events), "baseline: 3 expanded events expected")
+				require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+				require.Equal(t, 3, len(candidateResp.Events), "candidate: 3 expanded events expected")
+				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical expanded event responses")
+					t.Log("Both versions produce identical expanded event responses")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -129,37 +128,37 @@ def helper(event):
 					makeEvent("msg-1", versionId),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 1, len(oldResp.FailedEvents), "old arch: 1 failed event expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 
-				oldError := oldResp.FailedEvents[0].Error
-				newError := newResp.FailedEvents[0].Error
+				baselineError := baselineResp.FailedEvents[0].Error
+				candidateError := candidateResp.FailedEvents[0].Error
 
-				t.Logf("Old arch error message:\n%s", oldError)
-				t.Logf("New arch error message:\n%s", newError)
+				t.Logf("Baseline error message:\n%s", baselineError)
+				t.Logf("Candidate error message:\n%s", candidateError)
 
-				require.Contains(t, oldError, "intentional error for testing", "old arch: error should contain the message")
-				require.Contains(t, newError, "intentional error for testing", "new arch: error should contain the message")
+				require.Contains(t, baselineError, "intentional error for testing", "baseline: error should contain the message")
+				require.Contains(t, candidateError, "intentional error for testing", "candidate: error should contain the message")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical error messages")
+					t.Log("Both versions produce identical error messages")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 
-					if len(oldError) > len(newError) {
-						t.Logf("Old arch error is longer (%d chars vs %d chars), likely contains stack trace",
-							len(oldError), len(newError))
+					if len(baselineError) > len(candidateError) {
+						t.Logf("Baseline error is longer (%d chars vs %d chars), likely contains stack trace",
+							len(baselineError), len(candidateError))
 					}
 				}
 			},
@@ -180,32 +179,32 @@ def transformBatch(events, metadata):
 					makeEvent("msg-3", versionId),
 				}
 
-				t.Log("Sending 3 events to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending 3 events to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending 3 events to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending 3 events to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				for i, fe := range oldResp.FailedEvents {
-					t.Logf("Old arch FailedEvent[%d]: statusCode=%d, error=%q, messageId=%q, messageIds=%v",
+				for i, fe := range baselineResp.FailedEvents {
+					t.Logf("Baseline FailedEvent[%d]: statusCode=%d, error=%q, messageId=%q, messageIds=%v",
 						i, fe.StatusCode, fe.Error, fe.Metadata.MessageID, fe.Metadata.MessageIDs)
 				}
-				for i, fe := range newResp.FailedEvents {
-					t.Logf("New arch FailedEvent[%d]: statusCode=%d, error=%q, messageId=%q, messageIds=%v",
+				for i, fe := range candidateResp.FailedEvents {
+					t.Logf("Candidate FailedEvent[%d]: statusCode=%d, error=%q, messageId=%q, messageIds=%v",
 						i, fe.StatusCode, fe.Error, fe.Metadata.MessageID, fe.Metadata.MessageIDs)
 				}
 
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Logf("Both architectures returned %d failed events", len(oldResp.FailedEvents))
+					t.Logf("Both versions returned %d failed events", len(baselineResp.FailedEvents))
 				} else {
-					t.Logf("Old arch: %d failed events, New arch: %d failed events",
-						len(oldResp.FailedEvents), len(newResp.FailedEvents))
+					t.Logf("Baseline: %d failed events, Candidate: %d failed events",
+						len(baselineResp.FailedEvents), len(candidateResp.FailedEvents))
 					t.Errorf("Responses differ:\n%s", diff)
 				}
 			},
@@ -224,26 +223,26 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionId),
 				}
 
-				t.Log("Sending request to old architecture (rudder-transformer + openfaas)...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline pytransformer...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture (rudder-pytransformer)...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate (rudder-pytransformer)...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 1, len(oldResp.FailedEvents), "old arch: 1 failed event expected")
-				t.Logf("Old arch error: statusCode=%d, error=%q", oldResp.FailedEvents[0].StatusCode, oldResp.FailedEvents[0].Error)
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				t.Logf("Baseline error: statusCode=%d, error=%q", baselineResp.FailedEvents[0].StatusCode, baselineResp.FailedEvents[0].Error)
 
-				if len(newResp.FailedEvents) > 0 {
-					t.Logf("New arch error: statusCode=%d, error=%q", newResp.FailedEvents[0].StatusCode, newResp.FailedEvents[0].Error)
+				if len(candidateResp.FailedEvents) > 0 {
+					t.Logf("Candidate error: statusCode=%d, error=%q", candidateResp.FailedEvents[0].StatusCode, candidateResp.FailedEvents[0].Error)
 				}
-				if len(newResp.Events) > 0 {
-					t.Logf("New arch success: statusCode=%d, output=%v", newResp.Events[0].StatusCode, newResp.Events[0].Output)
+				if len(candidateResp.Events) > 0 {
+					t.Logf("Candidate success: statusCode=%d, output=%v", candidateResp.Events[0].StatusCode, candidateResp.Events[0].Output)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal")
 				} else {
@@ -288,20 +287,20 @@ def transformEvent(event, metadata):
 					},
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
-				require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
+				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
-				newOutput := newResp.Events[0].Output
+				newOutput := candidateResp.Events[0].Output
 				require.Equal(t, "src-1", newOutput["sourceId"])
 				require.Equal(t, "2", newOutput["instanceId"])
 				require.Equal(t, "ws-1-42", newOutput["partitionId"])
@@ -320,7 +319,7 @@ def transformEvent(event, metadata):
 					require.Falsef(t, ok, "key %q should stay absent when it wasn't present in the input metadata", key)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal")
 				} else {
@@ -373,13 +372,13 @@ def transformEvent(event, metadata):
 						},
 					},
 				}
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				newResp := env.NewClient.Transform(context.Background(), events)
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
-				require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
-				diff, equal := oldResp.Equal(&newResp)
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
+				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal")
 				} else {
@@ -407,49 +406,49 @@ def transformEvent(event, metadata):
 				}
 
 				oldStartedAt := time.Now().UTC()
-				oldResp := env.OldClient.Transform(context.Background(), events)
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
 				oldFinishedAt := time.Now().UTC()
 
 				newStartedAt := time.Now().UTC()
-				newResp := env.NewClient.Transform(context.Background(), events)
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
 				newFinishedAt := time.Now().UTC()
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
-				require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
+				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
-				oldTimestamp, ok := oldResp.Events[0].Output["rudderstackTransformedUtc"].(string)
-				require.True(t, ok, "old arch: generated timestamp should be present")
-				newTimestamp, ok := newResp.Events[0].Output["rudderstackTransformedUtc"].(string)
-				require.True(t, ok, "new arch: generated timestamp should be present")
+				oldTimestamp, ok := baselineResp.Events[0].Output["rudderstackTransformedUtc"].(string)
+				require.True(t, ok, "baseline: generated timestamp should be present")
+				newTimestamp, ok := candidateResp.Events[0].Output["rudderstackTransformedUtc"].(string)
+				require.True(t, ok, "candidate: generated timestamp should be present")
 
 				oldParsed, err := time.ParseInLocation(time.DateTime, oldTimestamp, time.UTC)
-				require.NoError(t, err, "old arch: generated timestamp should parse")
+				require.NoError(t, err, "baseline: generated timestamp should parse")
 				newParsed, err := time.ParseInLocation(time.DateTime, newTimestamp, time.UTC)
-				require.NoError(t, err, "new arch: generated timestamp should parse")
+				require.NoError(t, err, "candidate: generated timestamp should parse")
 
-				require.False(t, oldParsed.Before(oldStartedAt.Add(-time.Second)), "old arch timestamp should be created during the old request window")
-				require.False(t, oldParsed.After(oldFinishedAt.Add(time.Second)), "old arch timestamp should be created during the old request window")
-				require.False(t, newParsed.Before(newStartedAt.Add(-time.Second)), "new arch timestamp should be created during the new request window")
-				require.False(t, newParsed.After(newFinishedAt.Add(time.Second)), "new arch timestamp should be created during the new request window")
+				require.False(t, oldParsed.Before(oldStartedAt.Add(-time.Second)), "baseline timestamp should be created during the old request window")
+				require.False(t, oldParsed.After(oldFinishedAt.Add(time.Second)), "baseline timestamp should be created during the old request window")
+				require.False(t, newParsed.Before(newStartedAt.Add(-time.Second)), "candidate timestamp should be created during the new request window")
+				require.False(t, newParsed.After(newFinishedAt.Add(time.Second)), "candidate timestamp should be created during the new request window")
 				if oldTimestamp != newTimestamp {
 					t.Logf("Timestamps differ as expected: old=%s new=%s", oldTimestamp, newTimestamp)
 				} else {
 					t.Log("Timestamps happened to land in the same second — datetime matching path not exercised this run")
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal once datetime matching is applied")
 				} else {
 					t.Errorf("Responses differ despite datetime matching:\n%s", diff)
 				}
 
-				delete(oldResp.Events[0].Output, "rudderstackTransformedUtc")
-				delete(newResp.Events[0].Output, "rudderstackTransformedUtc")
+				delete(baselineResp.Events[0].Output, "rudderstackTransformedUtc")
+				delete(candidateResp.Events[0].Output, "rudderstackTransformedUtc")
 
-				require.Equal(t, oldResp, newResp, "execution-time field should be the only raw response difference")
+				require.Equal(t, baselineResp, candidateResp, "execution-time field should be the only raw response difference")
 			},
 		},
 		{
@@ -476,7 +475,7 @@ def transformBatch(events, metadata):
 							DestinationID: "dest-1",
 							WorkspaceID:   "ws-1",
 							MessageID:     "msg-1",
-							// Non-curated fields that should be stripped by old arch but kept by new arch:
+							// Non-curated fields that should be stripped by baseline but kept by candidate:
 							TraceParent: "00-trace-id-span-id-01",
 						},
 						Destination: backendconfig.DestinationT{
@@ -487,38 +486,38 @@ def transformBatch(events, metadata):
 					},
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Both should succeed
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldMeta := oldResp.Events[0].Metadata
-				newMeta := newResp.Events[0].Metadata
+				oldMeta := baselineResp.Events[0].Metadata
+				newMeta := candidateResp.Events[0].Metadata
 
-				t.Logf("Old arch metadata: TraceParent=%q, SourceID=%q, MessageID=%q",
+				t.Logf("Baseline metadata: TraceParent=%q, SourceID=%q, MessageID=%q",
 					oldMeta.TraceParent, oldMeta.SourceID, oldMeta.MessageID)
-				t.Logf("New arch metadata: TraceParent=%q, SourceID=%q, MessageID=%q",
+				t.Logf("Candidate metadata: TraceParent=%q, SourceID=%q, MessageID=%q",
 					newMeta.TraceParent, newMeta.SourceID, newMeta.MessageID)
 
 				// Control: both should have curated fields
-				require.Equal(t, "src-1", oldMeta.SourceID, "old arch: sourceId should be present")
-				require.Equal(t, "src-1", newMeta.SourceID, "new arch: sourceId should be present")
+				require.Equal(t, "src-1", oldMeta.SourceID, "baseline: sourceId should be present")
+				require.Equal(t, "src-1", newMeta.SourceID, "candidate: sourceId should be present")
 
 				// Compare: responses should be equal after Go unmarshaling (non-curated metadata differences are not observable)
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal")
 					t.Log("This means the metadata difference is not observable after Go unmarshaling")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
-					t.Logf("Old arch TraceParent=%q (expected empty), New arch TraceParent=%q (expected set)",
+					t.Logf("Baseline TraceParent=%q (expected empty), Candidate TraceParent=%q (expected set)",
 						oldMeta.TraceParent, newMeta.TraceParent)
 				}
 			},
@@ -541,17 +540,17 @@ def transformEvent(event, metadata):
 					makeEvent("body-msg-2", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Len(t, oldResp.FailedEvents, 1, "old arch: 1 failed event expected")
-				require.Len(t, oldResp.Events, 1, "old arch: 1 event expected")
-				require.EqualValues(t, utilstypes.FilterEventCode, oldResp.FailedEvents[0].StatusCode, "old arch: 298 filter detected")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Len(t, baselineResp.FailedEvents, 1, "baseline: 1 failed event expected")
+				require.Len(t, baselineResp.Events, 1, "baseline: 1 event expected")
+				require.EqualValues(t, utilstypes.FilterEventCode, baselineResp.FailedEvents[0].StatusCode, "baseline: 298 filter detected")
 
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Compare: responses may differ in the 298 response metadata
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal")
 					t.Log("This means the messageId source difference doesn't affect the output")
@@ -565,17 +564,17 @@ def transformEvent(event, metadata):
 					makeEvent("body-msg-4", versionID),
 				}
 
-				oldResp = env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Len(t, oldResp.FailedEvents, 2)
-				require.Len(t, oldResp.Events, 0)
-				require.EqualValues(t, utilstypes.FilterEventCode, oldResp.FailedEvents[0].StatusCode, "old arch: 298 filter detected")
+				baselineResp = env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Len(t, baselineResp.FailedEvents, 2)
+				require.Len(t, baselineResp.Events, 0)
+				require.EqualValues(t, utilstypes.FilterEventCode, baselineResp.FailedEvents[0].StatusCode, "baseline: 298 filter detected")
 
-				newResp = env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				candidateResp = env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Compare: responses may differ in the 298 response metadata
-				diff, equal = oldResp.Equal(&newResp)
+				diff, equal = baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal")
 					t.Log("This means the messageId source difference doesn't affect the output")
@@ -637,15 +636,15 @@ def transformEvent(event, metadata):
 					},
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				// When all events are filtered, both architectures should produce 298 responses.
+				// When all events are filtered, both versions should produce 298 responses.
 				// The X-Feature-Filter-Code header is set by the usertransformer client.
 				// Status 298 goes to FailedEvents (not 200).
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal")
 					t.Log("This means the messageId source difference doesn't affect the output")
@@ -666,19 +665,19 @@ def transformEvent(event, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.True(t, len(oldResp.FailedEvents) > 0, "old arch: expected at least 1 failed event")
-				require.True(t, len(newResp.FailedEvents) > 0, "new arch: expected at least 1 failed event")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.True(t, len(baselineResp.FailedEvents) > 0, "baseline: expected at least 1 failed event")
+				require.True(t, len(candidateResp.FailedEvents) > 0, "candidate: expected at least 1 failed event")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for empty config backend body")
+					t.Log("Both versions produce identical responses for empty config backend body")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -696,19 +695,19 @@ def transformEvent(event, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.True(t, len(oldResp.FailedEvents) > 0, "old arch: expected at least 1 failed event")
-				require.True(t, len(newResp.FailedEvents) > 0, "new arch: expected at least 1 failed event")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.True(t, len(baselineResp.FailedEvents) > 0, "baseline: expected at least 1 failed event")
+				require.True(t, len(candidateResp.FailedEvents) > 0, "candidate: expected at least 1 failed event")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for unexpected config backend body")
+					t.Log("Both versions produce identical responses for unexpected config backend body")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -726,19 +725,19 @@ def transformEvent(event, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.True(t, len(oldResp.FailedEvents) > 0, "old arch: expected at least 1 failed event")
-				require.True(t, len(newResp.FailedEvents) > 0, "new arch: expected at least 1 failed event")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.True(t, len(baselineResp.FailedEvents) > 0, "baseline: expected at least 1 failed event")
+				require.True(t, len(candidateResp.FailedEvents) > 0, "candidate: expected at least 1 failed event")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for 404 config backend")
+					t.Log("Both versions produce identical responses for 404 config backend")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -757,18 +756,18 @@ def transformEvent(event, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				// Old arch: transformer returns 809 (CP down) → failed events
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.True(t, len(oldResp.FailedEvents) > 0, "old arch: expected at least 1 failed event")
+				// Baseline: transformer returns 809 (CP down) → failed events
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.True(t, len(baselineResp.FailedEvents) > 0, "baseline: expected at least 1 failed event")
 
-				// New arch: pytransformer returns 503 + retry for config backend 5xx
-				// → retries exhausted → failed events (different status code from old arch)
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.True(t, len(newResp.FailedEvents) > 0, "new arch: expected at least 1 failed event")
+				// Candidate: pytransformer returns 503 + retry for config backend 5xx
+				// → retries exhausted → failed events (different status code from baseline)
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.True(t, len(candidateResp.FailedEvents) > 0, "candidate: expected at least 1 failed event")
 			},
 		},
 		{
@@ -790,18 +789,18 @@ def transformEvent(event, metadata):
 							makeEvent("msg-2", versionID),
 						}
 
-						// Old arch: transformer returns 809 (CP down) → failed events
-						oldResp := env.OldClient.Transform(context.Background(), events)
-						t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-						require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-						require.True(t, len(oldResp.FailedEvents) > 0, "old arch: expected at least 1 failed event")
+						// Baseline: transformer returns 809 (CP down) → failed events
+						baselineResp := env.BaselineClient.Transform(context.Background(), events)
+						t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+						require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+						require.True(t, len(baselineResp.FailedEvents) > 0, "baseline: expected at least 1 failed event")
 
-						// New arch: pytransformer returns 503 + retry for config backend 5xx
-						// → retries exhausted → failed events (different status code from old arch)
-						newResp := env.NewClient.Transform(context.Background(), events)
-						t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-						require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-						require.True(t, len(newResp.FailedEvents) > 0, "new arch: expected at least 1 failed event")
+						// Candidate: pytransformer returns 503 + retry for config backend 5xx
+						// → retries exhausted → failed events (different status code from baseline)
+						candidateResp := env.CandidateClient.Transform(context.Background(), events)
+						t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+						require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+						require.True(t, len(candidateResp.FailedEvents) > 0, "candidate: expected at least 1 failed event")
 					})
 				}
 			},
@@ -818,21 +817,21 @@ def transformEvent(event, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.True(t, len(oldResp.FailedEvents) > 0, "old arch: expected at least 1 failed event")
-				require.True(t, len(newResp.FailedEvents) > 0, "new arch: expected at least 1 failed event")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.True(t, len(baselineResp.FailedEvents) > 0, "baseline: expected at least 1 failed event")
+				require.True(t, len(candidateResp.FailedEvents) > 0, "candidate: expected at least 1 failed event")
 
-				normalizeResponseErrors(&oldResp)
-				normalizeResponseErrors(&newResp)
-				diff, equal := oldResp.Equal(&newResp)
+				normalizeResponseErrors(&baselineResp)
+				normalizeResponseErrors(&candidateResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for 400 config backend")
+					t.Log("Both versions produce identical responses for 400 config backend")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -859,31 +858,31 @@ def transformEvent(event, metadata):
 					events[i] = makeEvent(fmt.Sprintf("msg-%d", i+1), versionId)
 				}
 
-				t.Log("Sending 10 events to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending 10 events to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending 10 events to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending 10 events to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// 8 events should succeed, 2 should fail
-				require.Equal(t, 8, len(oldResp.Events), "old arch: 8 success events expected")
-				require.Equal(t, 2, len(oldResp.FailedEvents), "old arch: 2 failed events expected")
-				require.Equal(t, 8, len(newResp.Events), "new arch: 8 success events expected")
-				require.Equal(t, 2, len(newResp.FailedEvents), "new arch: 2 failed events expected")
+				require.Equal(t, 8, len(baselineResp.Events), "baseline: 8 success events expected")
+				require.Equal(t, 2, len(baselineResp.FailedEvents), "baseline: 2 failed events expected")
+				require.Equal(t, 8, len(candidateResp.Events), "candidate: 8 success events expected")
+				require.Equal(t, 2, len(candidateResp.FailedEvents), "candidate: 2 failed events expected")
 
 				// Log error details
-				for i, fe := range oldResp.FailedEvents {
-					t.Logf("Old arch FailedEvent[%d]: statusCode=%d, error=%q", i, fe.StatusCode, fe.Error)
+				for i, fe := range baselineResp.FailedEvents {
+					t.Logf("Baseline FailedEvent[%d]: statusCode=%d, error=%q", i, fe.StatusCode, fe.Error)
 				}
-				for i, fe := range newResp.FailedEvents {
-					t.Logf("New arch FailedEvent[%d]: statusCode=%d, error=%q", i, fe.StatusCode, fe.Error)
+				for i, fe := range candidateResp.FailedEvents {
+					t.Logf("Candidate FailedEvent[%d]: statusCode=%d, error=%q", i, fe.StatusCode, fe.Error)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for partial errors")
+					t.Log("Both versions produce identical responses for partial errors")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -907,35 +906,35 @@ def transformEvent(event, metadata):
 					makeEvent("msg-3", versionId),
 				}
 
-				t.Log("Sending 3 events to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending 3 events to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending 3 events to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending 3 events to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// All 3 should succeed
-				require.Equal(t, 3, len(oldResp.Events), "old arch: 3 success events expected")
-				require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-				require.Equal(t, 3, len(newResp.Events), "new arch: 3 success events expected")
-				require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+				require.Equal(t, 3, len(baselineResp.Events), "baseline: 3 success events expected")
+				require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+				require.Equal(t, 3, len(candidateResp.Events), "candidate: 3 success events expected")
+				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
 				// Verify tampering was applied
-				for i, ev := range oldResp.Events {
+				for i, ev := range baselineResp.Events {
 					output := ev.Output
-					t.Logf("Old arch Event[%d]: messageId=%v, originalMessageId=%v, metadata.messageId=%v",
+					t.Logf("Baseline Event[%d]: messageId=%v, originalMessageId=%v, metadata.messageId=%v",
 						i, output["messageId"], output["originalMessageId"], ev.Metadata.MessageID)
 				}
-				for i, ev := range newResp.Events {
+				for i, ev := range candidateResp.Events {
 					output := ev.Output
-					t.Logf("New arch Event[%d]: messageId=%v, originalMessageId=%v, metadata.messageId=%v",
+					t.Logf("Candidate Event[%d]: messageId=%v, originalMessageId=%v, metadata.messageId=%v",
 						i, output["messageId"], output["originalMessageId"], ev.Metadata.MessageID)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for messageId tampering")
+					t.Log("Both versions produce identical responses for messageId tampering")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -953,20 +952,20 @@ def transformEvent(event, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.True(t, len(oldResp.FailedEvents) > 0, "old arch: expected at least 1 failed event")
-				require.True(t, len(newResp.FailedEvents) > 0, "new arch: expected at least 1 failed event")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.True(t, len(baselineResp.FailedEvents) > 0, "baseline: expected at least 1 failed event")
+				require.True(t, len(candidateResp.FailedEvents) > 0, "candidate: expected at least 1 failed event")
 
-				// Only compare status codes — error messages may differ between architectures
-				require.Equal(t, len(oldResp.FailedEvents), len(newResp.FailedEvents), "failed event count mismatch")
-				for i := range oldResp.FailedEvents {
-					require.Equal(t, oldResp.FailedEvents[i].StatusCode, newResp.FailedEvents[i].StatusCode,
+				// Only compare status codes — error messages may differ between versions
+				require.Equal(t, len(baselineResp.FailedEvents), len(candidateResp.FailedEvents), "failed event count mismatch")
+				for i := range baselineResp.FailedEvents {
+					require.Equal(t, baselineResp.FailedEvents[i].StatusCode, candidateResp.FailedEvents[i].StatusCode,
 						"status code mismatch for failed event %d", i)
 				}
 			},
@@ -983,20 +982,20 @@ def transformEvent(event, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.True(t, len(oldResp.FailedEvents) > 0, "old arch: expected at least 1 failed event")
-				require.True(t, len(newResp.FailedEvents) > 0, "new arch: expected at least 1 failed event")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.True(t, len(baselineResp.FailedEvents) > 0, "baseline: expected at least 1 failed event")
+				require.True(t, len(candidateResp.FailedEvents) > 0, "candidate: expected at least 1 failed event")
 
-				// Only compare status codes — error messages may differ between architectures
-				require.Equal(t, len(oldResp.FailedEvents), len(newResp.FailedEvents), "failed event count mismatch")
-				for i := range oldResp.FailedEvents {
-					require.Equal(t, oldResp.FailedEvents[i].StatusCode, newResp.FailedEvents[i].StatusCode,
+				// Only compare status codes — error messages may differ between versions
+				require.Equal(t, len(baselineResp.FailedEvents), len(candidateResp.FailedEvents), "failed event count mismatch")
+				for i := range baselineResp.FailedEvents {
+					require.Equal(t, baselineResp.FailedEvents[i].StatusCode, candidateResp.FailedEvents[i].StatusCode,
 						"status code mismatch for failed event %d", i)
 				}
 			},
@@ -1025,23 +1024,23 @@ def transformBatch(events, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				t.Log("Sending 2 events to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending 2 events to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending 2 events to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending 2 events to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Both should expand 2 input events into 4 output events (2 per input)
-				require.Equal(t, 4, len(oldResp.Events), "old arch: 4 expanded events expected")
-				require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-				require.Equal(t, 4, len(newResp.Events), "new arch: 4 expanded events expected")
-				require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+				require.Equal(t, 4, len(baselineResp.Events), "baseline: 4 expanded events expected")
+				require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+				require.Equal(t, 4, len(candidateResp.Events), "candidate: 4 expanded events expected")
+				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical expanded batch event responses")
+					t.Log("Both versions produce identical expanded batch event responses")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1074,23 +1073,23 @@ def transformBatch(events, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				t.Log("Sending 2 events to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending 2 events to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending 2 events to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending 2 events to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 2, len(oldResp.FailedEvents), "old arch: 2 failed events expected")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 2, len(baselineResp.FailedEvents), "baseline: 2 failed events expected")
 
-				require.Equal(t, 0, len(newResp.Events), "new arch: 0 success events expected (KeyError)")
-				require.Equal(t, 2, len(newResp.FailedEvents), "new arch: 2 failed events expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: 0 success events expected (KeyError)")
+				require.Equal(t, 2, len(candidateResp.FailedEvents), "candidate: 2 failed events expected")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical expanded batch event responses")
+					t.Log("Both versions produce identical expanded batch event responses")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1113,28 +1112,28 @@ def transformBatch(events, metadata):
 					makeEvent("msg-3", versionID),
 				}
 
-				t.Log("Sending 3 events to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending 3 events to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending 3 events to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending 3 events to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// msg-2 should be dropped, msg-1 and msg-3 should pass through
-				require.Equal(t, 2, len(oldResp.Events), "old arch: 2 success events expected")
-				require.Equal(t, 2, len(newResp.Events), "new arch: 2 success events expected")
+				require.Equal(t, 2, len(baselineResp.Events), "baseline: 2 success events expected")
+				require.Equal(t, 2, len(candidateResp.Events), "candidate: 2 success events expected")
 
-				for i, ev := range oldResp.Events {
-					t.Logf("Old arch Event[%d]: messageId=%v", i, ev.Output["messageId"])
+				for i, ev := range baselineResp.Events {
+					t.Logf("Baseline Event[%d]: messageId=%v", i, ev.Output["messageId"])
 				}
-				for i, ev := range newResp.Events {
-					t.Logf("New arch Event[%d]: messageId=%v", i, ev.Output["messageId"])
+				for i, ev := range candidateResp.Events {
+					t.Logf("Candidate Event[%d]: messageId=%v", i, ev.Output["messageId"])
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for batch partial drop")
+					t.Log("Both versions produce identical responses for batch partial drop")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1155,22 +1154,22 @@ def transformBatch(events, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				t.Log("Sending 2 events to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending 2 events to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending 2 events to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending 2 events to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.True(t, len(oldResp.FailedEvents) == 2, "old arch: expected 2 failed events")
-				require.True(t, len(newResp.FailedEvents) == 2, "new arch: expected 2 failed events")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.True(t, len(baselineResp.FailedEvents) == 2, "baseline: expected 2 failed events")
+				require.True(t, len(candidateResp.FailedEvents) == 2, "candidate: expected 2 failed events")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for mixed indentation")
+					t.Log("Both versions produce identical responses for mixed indentation")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1188,31 +1187,31 @@ def transformBatch(events, metadata):
 					makeEvent("msg-2", versionId),
 				}
 
-				t.Log("Sending 2 events to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending 2 events to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending 2 events to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending 2 events to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Both should fail (compilation error)
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.True(t, len(oldResp.FailedEvents) > 0, "old arch: expected at least 1 failed event")
-				require.True(t, len(newResp.FailedEvents) > 0, "new arch: expected at least 1 failed event")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.True(t, len(baselineResp.FailedEvents) > 0, "baseline: expected at least 1 failed event")
+				require.True(t, len(candidateResp.FailedEvents) > 0, "candidate: expected at least 1 failed event")
 
 				// Log error details for debugging
-				for i, fe := range oldResp.FailedEvents {
-					t.Logf("Old arch FailedEvent[%d]: statusCode=%d, error=%q", i, fe.StatusCode, fe.Error)
+				for i, fe := range baselineResp.FailedEvents {
+					t.Logf("Baseline FailedEvent[%d]: statusCode=%d, error=%q", i, fe.StatusCode, fe.Error)
 				}
-				for i, fe := range newResp.FailedEvents {
-					t.Logf("New arch FailedEvent[%d]: statusCode=%d, error=%q", i, fe.StatusCode, fe.Error)
+				for i, fe := range candidateResp.FailedEvents {
+					t.Logf("Candidate FailedEvent[%d]: statusCode=%d, error=%q", i, fe.StatusCode, fe.Error)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for mixed indentation")
+					t.Log("Both versions produce identical responses for mixed indentation")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1238,26 +1237,26 @@ def transformEvent(event, metadata):
 					makeEventWithCredentials("msg-1", versionID, creds),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
-				require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
+				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
 				// Verify credential value was retrieved correctly
-				require.Equal(t, "testValue1", oldResp.Events[0].Output["credential"], "old arch: credential value should be testValue1")
-				require.Equal(t, "testValue1", newResp.Events[0].Output["credential"], "new arch: credential value should be testValue1")
+				require.Equal(t, "testValue1", baselineResp.Events[0].Output["credential"], "baseline: credential value should be testValue1")
+				require.Equal(t, "testValue1", candidateResp.Events[0].Output["credential"], "candidate: credential value should be testValue1")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for credential with valid key")
+					t.Log("Both versions produce identical responses for credential with valid key")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1282,24 +1281,24 @@ def transformEvent(event, metadata):
 					makeEventWithCredentials("msg-1", versionID, creds),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// getCredential returns None for missing keys — event should succeed with null value
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				require.Nil(t, oldResp.Events[0].Output["credential"], "old arch: credential should be nil for missing key")
-				require.Nil(t, newResp.Events[0].Output["credential"], "new arch: credential should be nil for missing key")
+				require.Nil(t, baselineResp.Events[0].Output["credential"], "baseline: credential should be nil for missing key")
+				require.Nil(t, candidateResp.Events[0].Output["credential"], "candidate: credential should be nil for missing key")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for credential with missing key")
+					t.Log("Both versions produce identical responses for credential with missing key")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1324,31 +1323,31 @@ def transformEvent(event, metadata):
 					makeEventWithCredentials("msg-1", versionID, creds),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// getCredential() with no args raises TypeError — event should fail
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 1, len(oldResp.FailedEvents), "old arch: 1 failed event expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 
-				oldError := oldResp.FailedEvents[0].Error
-				newError := newResp.FailedEvents[0].Error
-				t.Logf("Old arch error: %q", oldError)
-				t.Logf("New arch error: %q", newError)
+				baselineError := baselineResp.FailedEvents[0].Error
+				candidateError := candidateResp.FailedEvents[0].Error
+				t.Logf("Baseline error: %q", baselineError)
+				t.Logf("Candidate error: %q", candidateError)
 
-				require.Contains(t, oldError, "Key should be valid and defined", "old arch: error should mention invalid key")
-				require.Contains(t, newError, "Key should be valid and defined", "new arch: error should mention invalid key")
+				require.Contains(t, baselineError, "Key should be valid and defined", "baseline: error should mention invalid key")
+				require.Contains(t, candidateError, "Key should be valid and defined", "candidate: error should mention invalid key")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for credential with no arguments")
+					t.Log("Both versions produce identical responses for credential with no arguments")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1377,31 +1376,31 @@ def transformEvent(event, metadata):
 					makeEventWithCredentials("msg-1", versionID, creds),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Non-string keys should return None (not raise errors)
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
-				require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
+				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
 				// All non-string keys (including None) should return None
-				oldOutput := oldResp.Events[0].Output
-				newOutput := newResp.Events[0].Output
+				oldOutput := baselineResp.Events[0].Output
+				newOutput := candidateResp.Events[0].Output
 				for _, key := range []string{"credentialValueForNoneKey", "credentialValueForNumkey", "credentialValueForBoolkey", "credentialValueForObjkey", "credentialValueForArrkey"} {
-					require.Nilf(t, oldOutput[key], "old arch: %s should be nil", key)
-					require.Nilf(t, newOutput[key], "new arch: %s should be nil", key)
+					require.Nilf(t, oldOutput[key], "baseline: %s should be nil", key)
+					require.Nilf(t, newOutput[key], "candidate: %s should be nil", key)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for credential with non-string keys")
+					t.Log("Both versions produce identical responses for credential with non-string keys")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1424,24 +1423,24 @@ def transformEvent(event, metadata):
 					makeEventWithCredentials("msg-1", versionID, []types.Credential{}),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// With empty credentials, getCredential returns None for any key
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				require.Nil(t, oldResp.Events[0].Output["credential"], "old arch: credential should be nil with empty credentials")
-				require.Nil(t, newResp.Events[0].Output["credential"], "new arch: credential should be nil with empty credentials")
+				require.Nil(t, baselineResp.Events[0].Output["credential"], "baseline: credential should be nil with empty credentials")
+				require.Nil(t, candidateResp.Events[0].Output["credential"], "candidate: credential should be nil with empty credentials")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for credential with empty list")
+					t.Log("Both versions produce identical responses for credential with empty list")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1464,24 +1463,24 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// With no credentials field, getCredential returns None for any key
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				require.Nil(t, oldResp.Events[0].Output["credential"], "old arch: credential should be nil with no credentials")
-				require.Nil(t, newResp.Events[0].Output["credential"], "new arch: credential should be nil with no credentials")
+				require.Nil(t, baselineResp.Events[0].Output["credential"], "baseline: credential should be nil with no credentials")
+				require.Nil(t, candidateResp.Events[0].Output["credential"], "candidate: credential should be nil with no credentials")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for credential with no credentials field")
+					t.Log("Both versions produce identical responses for credential with no credentials field")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1509,31 +1508,31 @@ def transformBatch(events, metadata):
 					makeEventWithCredentials("msg-2", versionID, creds),
 				}
 
-				t.Log("Sending 2 events to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending 2 events to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending 2 events to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending 2 events to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Both events should succeed with credential from first event
-				require.Equal(t, 2, len(oldResp.Events), "old arch: 2 success events expected")
-				require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-				require.Equal(t, 2, len(newResp.Events), "new arch: 2 success events expected")
-				require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+				require.Equal(t, 2, len(baselineResp.Events), "baseline: 2 success events expected")
+				require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+				require.Equal(t, 2, len(candidateResp.Events), "candidate: 2 success events expected")
+				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
 				// Both events should have the same credential value
-				for i := range oldResp.Events {
-					require.Equal(t, "testValue1", oldResp.Events[i].Output["credential"],
-						"old arch: event %d credential should be testValue1", i)
-					require.Equal(t, "testValue1", newResp.Events[i].Output["credential"],
-						"new arch: event %d credential should be testValue1", i)
+				for i := range baselineResp.Events {
+					require.Equal(t, "testValue1", baselineResp.Events[i].Output["credential"],
+						"baseline: event %d credential should be testValue1", i)
+					require.Equal(t, "testValue1", candidateResp.Events[i].Output["credential"],
+						"candidate: event %d credential should be testValue1", i)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for credential in batch transform")
+					t.Log("Both versions produce identical responses for credential in batch transform")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1553,7 +1552,7 @@ def transformBatch(events, metadata):
 				const versionID = "bc-cred-first-event-v1"
 
 				// First event has key1, second event has key2.
-				// Both architectures extract credentials from the first event only.
+				// Both versions extract credentials from the first event only.
 				events := []types.TransformerEvent{
 					makeEventWithCredentials("msg-1", versionID, []types.Credential{
 						{ID: "id1", Key: "key1", Value: "value1", IsSecret: false},
@@ -1563,28 +1562,28 @@ def transformBatch(events, metadata):
 					}),
 				}
 
-				t.Log("Sending 2 events to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending 2 events to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending 2 events to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending 2 events to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 2, len(oldResp.Events), "old arch: 2 success events expected")
-				require.Equal(t, 2, len(newResp.Events), "new arch: 2 success events expected")
+				require.Equal(t, 2, len(baselineResp.Events), "baseline: 2 success events expected")
+				require.Equal(t, 2, len(candidateResp.Events), "candidate: 2 success events expected")
 
 				// key1 from first event should be available, key2 from second event should not
-				for i, ev := range oldResp.Events {
-					t.Logf("Old arch Event[%d]: cred1=%v, cred2=%v", i, ev.Output["cred1"], ev.Output["cred2"])
+				for i, ev := range baselineResp.Events {
+					t.Logf("Baseline Event[%d]: cred1=%v, cred2=%v", i, ev.Output["cred1"], ev.Output["cred2"])
 				}
-				for i, ev := range newResp.Events {
-					t.Logf("New arch Event[%d]: cred1=%v, cred2=%v", i, ev.Output["cred1"], ev.Output["cred2"])
+				for i, ev := range candidateResp.Events {
+					t.Logf("Candidate Event[%d]: cred1=%v, cred2=%v", i, ev.Output["cred1"], ev.Output["cred2"])
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for credentials from first event only")
+					t.Log("Both versions produce identical responses for credentials from first event only")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1612,34 +1611,34 @@ def transformEvent(event, metadata):
 					makeEventWithCredentials("msg-1", versionID, creds),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldOutput := oldResp.Events[0].Output
-				newOutput := newResp.Events[0].Output
+				oldOutput := baselineResp.Events[0].Output
+				newOutput := candidateResp.Events[0].Output
 
 				// Verify multiple credential accesses and repeated access
-				require.Equal(t, "testValue1", oldOutput["cred1"], "old arch: cred1 should be testValue1")
-				require.Equal(t, "testValue2", oldOutput["cred2"], "old arch: cred2 should be testValue2")
-				require.Equal(t, "testValue1", oldOutput["cred1_again"], "old arch: cred1_again should be testValue1")
-				require.Nil(t, oldOutput["missing"], "old arch: missing should be nil")
+				require.Equal(t, "testValue1", oldOutput["cred1"], "baseline: cred1 should be testValue1")
+				require.Equal(t, "testValue2", oldOutput["cred2"], "baseline: cred2 should be testValue2")
+				require.Equal(t, "testValue1", oldOutput["cred1_again"], "baseline: cred1_again should be testValue1")
+				require.Nil(t, oldOutput["missing"], "baseline: missing should be nil")
 
-				require.Equal(t, "testValue1", newOutput["cred1"], "new arch: cred1 should be testValue1")
-				require.Equal(t, "testValue2", newOutput["cred2"], "new arch: cred2 should be testValue2")
-				require.Equal(t, "testValue1", newOutput["cred1_again"], "new arch: cred1_again should be testValue1")
-				require.Nil(t, newOutput["missing"], "new arch: missing should be nil")
+				require.Equal(t, "testValue1", newOutput["cred1"], "candidate: cred1 should be testValue1")
+				require.Equal(t, "testValue2", newOutput["cred2"], "candidate: cred2 should be testValue2")
+				require.Equal(t, "testValue1", newOutput["cred1_again"], "candidate: cred1_again should be testValue1")
+				require.Nil(t, newOutput["missing"], "candidate: missing should be nil")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for multiple credential accesses")
+					t.Log("Both versions produce identical responses for multiple credential accesses")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1666,26 +1665,26 @@ def transformEvent(event, metadata):
 					makeEventWithCredentials("msg-1", versionID, creds),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
 				// Both secret and public credentials should be accessible via getCredential
-				require.Equal(t, "secretValue", oldResp.Events[0].Output["secretCred"], "old arch: secret credential should be accessible")
-				require.Equal(t, "publicValue", oldResp.Events[0].Output["publicCred"], "old arch: public credential should be accessible")
-				require.Equal(t, "secretValue", newResp.Events[0].Output["secretCred"], "new arch: secret credential should be accessible")
-				require.Equal(t, "publicValue", newResp.Events[0].Output["publicCred"], "new arch: public credential should be accessible")
+				require.Equal(t, "secretValue", baselineResp.Events[0].Output["secretCred"], "baseline: secret credential should be accessible")
+				require.Equal(t, "publicValue", baselineResp.Events[0].Output["publicCred"], "baseline: public credential should be accessible")
+				require.Equal(t, "secretValue", candidateResp.Events[0].Output["secretCred"], "candidate: secret credential should be accessible")
+				require.Equal(t, "publicValue", candidateResp.Events[0].Output["publicCred"], "candidate: public credential should be accessible")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for credentials with isSecret flag")
+					t.Log("Both versions produce identical responses for credentials with isSecret flag")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1709,23 +1708,23 @@ def transformEvent(event, metadata):
 					makeEventWithCredentials("msg-1", versionID, creds),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				require.Equal(t, "special-value!@#$%", oldResp.Events[0].Output["cred"], "old arch: credential value with special chars")
-				require.Equal(t, "special-value!@#$%", newResp.Events[0].Output["cred"], "new arch: credential value with special chars")
+				require.Equal(t, "special-value!@#$%", baselineResp.Events[0].Output["cred"], "baseline: credential value with special chars")
+				require.Equal(t, "special-value!@#$%", candidateResp.Events[0].Output["cred"], "candidate: credential value with special chars")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for credentials with special characters")
+					t.Log("Both versions produce identical responses for credentials with special characters")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1742,7 +1741,7 @@ def transformEvent(event, metadata):
 			run: func(t *testing.T, env *bcTestEnv) {
 				const versionID = "bc-cred-dup-keys-v1"
 
-				// When duplicate keys exist, the last one wins (both architectures
+				// When duplicate keys exist, the last one wins (both versions
 				// iterate the credentials slice in order, overwriting earlier values).
 				creds := []types.Credential{
 					{ID: "id1", Key: "dupKey", Value: "firstValue", IsSecret: false},
@@ -1752,24 +1751,24 @@ def transformEvent(event, metadata):
 					makeEventWithCredentials("msg-1", versionID, creds),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
 				// Assert that the last credential wins when keys are duplicated
-				require.Equal(t, "secondValue", oldResp.Events[0].Output["cred"], "old arch: last credential value should win for duplicate keys")
-				require.Equal(t, "secondValue", newResp.Events[0].Output["cred"], "new arch: last credential value should win for duplicate keys")
+				require.Equal(t, "secondValue", baselineResp.Events[0].Output["cred"], "baseline: last credential value should win for duplicate keys")
+				require.Equal(t, "secondValue", candidateResp.Events[0].Output["cred"], "candidate: last credential value should win for duplicate keys")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for duplicate credential keys")
+					t.Log("Both versions produce identical responses for duplicate credential keys")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1795,26 +1794,26 @@ def transformEvent(event, metadata):
 					makeEventWithCredentials("msg-1", versionID, creds),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
 				// An empty string value should be returned (not None)
-				oldOutput := oldResp.Events[0].Output
-				newOutput := newResp.Events[0].Output
-				t.Logf("Old arch: cred=%v, credIsNone=%v, credIsEmpty=%v", oldOutput["cred"], oldOutput["credIsNone"], oldOutput["credIsEmpty"])
-				t.Logf("New arch: cred=%v, credIsNone=%v, credIsEmpty=%v", newOutput["cred"], newOutput["credIsNone"], newOutput["credIsEmpty"])
+				oldOutput := baselineResp.Events[0].Output
+				newOutput := candidateResp.Events[0].Output
+				t.Logf("Baseline: cred=%v, credIsNone=%v, credIsEmpty=%v", oldOutput["cred"], oldOutput["credIsNone"], oldOutput["credIsEmpty"])
+				t.Logf("Candidate: cred=%v, credIsNone=%v, credIsEmpty=%v", newOutput["cred"], newOutput["credIsNone"], newOutput["credIsEmpty"])
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for credential with empty value")
+					t.Log("Both versions produce identical responses for credential with empty value")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1858,15 +1857,15 @@ def transformEvent(event, metadata):
 						},
 					},
 				}
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				newResp := env.NewClient.Transform(context.Background(), events)
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
-				oldOutput := oldResp.Events[0].Output
-				newOutput := newResp.Events[0].Output
-				t.Logf("Old arch output keys: %d", len(oldOutput))
-				t.Logf("New arch output keys: %d", len(newOutput))
-				diff, equal := oldResp.Equal(&newResp)
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
+				oldOutput := baselineResp.Events[0].Output
+				newOutput := candidateResp.Events[0].Output
+				t.Logf("Baseline output keys: %d", len(oldOutput))
+				t.Logf("Candidate output keys: %d", len(newOutput))
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal")
 				} else {
@@ -1917,15 +1916,15 @@ def transformEvent(event, metadata):
 						},
 					},
 				}
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				newResp := env.NewClient.Transform(context.Background(), events)
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
-				oldOutput := oldResp.Events[0].Output
-				newOutput := newResp.Events[0].Output
-				t.Logf("Old arch output keys: %d", len(oldOutput))
-				t.Logf("New arch output keys: %d", len(newOutput))
-				diff, equal := oldResp.Equal(&newResp)
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
+				oldOutput := baselineResp.Events[0].Output
+				newOutput := candidateResp.Events[0].Output
+				t.Logf("Baseline output keys: %d", len(oldOutput))
+				t.Logf("Candidate output keys: %d", len(newOutput))
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal")
 				} else {
@@ -1947,7 +1946,7 @@ def transformEvent(event, metadata):
 			// will also be overwritten), and SourceJobID/TrackingPlanID/etc. are zero
 			// values which are omitted from the metadata JSON (omitempty) so the metadata
 			// function returns None for them. This mirrors the production scenario that
-			// exposed the diff between old and new arch.
+			// exposed the diff between old and candidate.
 			name:      "MetadataAddMetaPattern",
 			versionID: "bc-add-meta-pattern-v1",
 			config: configBackendEntry{code: `
@@ -1993,19 +1992,19 @@ def transformEvent(event, metadata):
 						},
 					},
 				}
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
-				oldOutput := oldResp.Events[0].Output
-				newOutput := newResp.Events[0].Output
-				t.Logf("Old arch output keys: %d", len(oldOutput))
-				t.Logf("New arch output keys: %d", len(newOutput))
-				diff, equal := oldResp.Equal(&newResp)
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
+				oldOutput := baselineResp.Events[0].Output
+				newOutput := candidateResp.Events[0].Output
+				t.Logf("Baseline output keys: %d", len(oldOutput))
+				t.Logf("Candidate output keys: %d", len(newOutput))
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal")
 				} else {
@@ -2035,59 +2034,28 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, allEntries)
 	t.Cleanup(configBackend.Close)
 
-	// Create a mock OpenFaaS gateway with a dynamic proxy target.
-	// The target URL is updated before each subtest to point to that
-	// subtest's openfaas-flask-base container.
+	// Both rudder-pytransformer versions read from the same config backend, so
+	// one container per version serves every subtest.
 	var (
-		gatewayMu        sync.Mutex
-		gatewayTargetURL string
-	)
-	getGatewayTarget := func() string {
-		gatewayMu.Lock()
-		defer gatewayMu.Unlock()
-		return gatewayTargetURL
-	}
-	setGatewayTarget := func(url string) {
-		gatewayMu.Lock()
-		defer gatewayMu.Unlock()
-		gatewayTargetURL = url
-	}
-	mockGateway, _ := newMockOpenFaaSGateway(t, getGatewayTarget)
-	t.Cleanup(mockGateway.Close)
-
-	var (
-		wg                               sync.WaitGroup
-		transformerURL, pyTransformerURL string
+		wg                        sync.WaitGroup
+		baselineURL, candidateURL string
 	)
 	wg.Go(func() {
-		transformerURL = startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
+		baselineURL = startBaselinePytransformer(t, pool, configBackend.URL)
 	})
 	wg.Go(func() {
-		pyTransformerURL = startRudderPytransformer(t, pool, configBackend.URL)
+		candidateURL = startRudderPytransformer(t, pool, configBackend.URL)
 	})
 	wg.Wait()
 
-	// Run subtests sequentially. Each subtest with python code spins up its own
-	// openfaas-flask-base since openfaas loads code at startup.
-	// Subtests without python code skip openfaas (error happens before execution).
-	// Each subtest gets a fresh bcTestEnv with its own memstats stores so that
-	// retry counts are isolated per subtest.
+	// Run subtests sequentially. Each subtest gets a fresh bcTestEnv with its own
+	// memstats stores so that retry counts are isolated per subtest.
 	for _, st := range subtests {
 		t.Run(st.name, func(t *testing.T) {
-			env := newBCTestEnv(t, transformerURL, pyTransformerURL,
+			env := newBCTestEnv(t, baselineURL, candidateURL,
 				withFailOnError(),
 				withLimitedRetryableHTTPRetries(),
 			)
-
-			if st.config.code != "" {
-				t.Logf("Starting openfaas-flask-base for %s (versionID=%s)...", st.name, st.versionID)
-				openFaasURL := startOpenFaasFlask(t, pool, st.versionID, configBackend.URL)
-
-				// Point the mock gateway to this subtest's openfaas container.
-				setGatewayTarget(openFaasURL)
-			} else {
-				t.Logf("Skipping openfaas-flask-base for %s (error path test)", st.name)
-			}
 
 			st.run(t, env)
 			if !st.skipRetryCountMatch {

--- a/integration_test/pytransformer_contract/backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/backwards_compatibility_test.go
@@ -756,18 +756,24 @@ def transformEvent(event, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				// Baseline: transformer returns 809 (CP down) → failed events
+				// Both versions return 503 + retry for a config backend 5xx, so the retries are exhausted and the
+				// events fail on either side.
 				baselineResp := env.BaselineClient.Transform(context.Background(), events)
 				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
 				require.True(t, len(baselineResp.FailedEvents) > 0, "baseline: expected at least 1 failed event")
 
-				// Candidate: pytransformer returns 503 + retry for config backend 5xx
-				// → retries exhausted → failed events (different status code from baseline)
 				candidateResp := env.CandidateClient.Transform(context.Background(), events)
 				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
 				require.True(t, len(candidateResp.FailedEvents) > 0, "candidate: expected at least 1 failed event")
+
+				// Only compare status codes — error messages may differ between versions
+				require.Equal(t, len(baselineResp.FailedEvents), len(candidateResp.FailedEvents), "failed event count mismatch")
+				for i := range baselineResp.FailedEvents {
+					require.Equal(t, baselineResp.FailedEvents[i].StatusCode, candidateResp.FailedEvents[i].StatusCode,
+						"status code mismatch for failed event %d", i)
+				}
 			},
 		},
 		{
@@ -789,18 +795,24 @@ def transformEvent(event, metadata):
 							makeEvent("msg-2", versionID),
 						}
 
-						// Baseline: transformer returns 809 (CP down) → failed events
+						// Both versions return 503 + retry for a config backend 5xx, so the
+						// retries are exhausted and the events fail on either side.
 						baselineResp := env.BaselineClient.Transform(context.Background(), events)
 						t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 						require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
 						require.True(t, len(baselineResp.FailedEvents) > 0, "baseline: expected at least 1 failed event")
 
-						// Candidate: pytransformer returns 503 + retry for config backend 5xx
-						// → retries exhausted → failed events (different status code from baseline)
 						candidateResp := env.CandidateClient.Transform(context.Background(), events)
 						t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 						require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
 						require.True(t, len(candidateResp.FailedEvents) > 0, "candidate: expected at least 1 failed event")
+
+						// Only compare status codes — error messages may differ between versions
+						require.Equal(t, len(baselineResp.FailedEvents), len(candidateResp.FailedEvents), "failed event count mismatch")
+						for i := range baselineResp.FailedEvents {
+							require.Equal(t, baselineResp.FailedEvents[i].StatusCode, candidateResp.FailedEvents[i].StatusCode,
+								"status code mismatch for failed event %d", i)
+						}
 					})
 				}
 			},

--- a/integration_test/pytransformer_contract/backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/backwards_compatibility_test.go
@@ -2035,7 +2035,7 @@ def transformEvent(event, metadata):
 	// returns 404 for those versionIds, which tests error handling paths.
 	allEntries := make(map[string]configBackendEntry, len(subtests))
 	for _, st := range subtests {
-		if st.config != (configBackendEntry{}) {
+		if !st.config.isZero() {
 			_, dup := allEntries[st.versionID]
 			require.Falsef(t, dup, "duplicate versionID %q: with shared containers the versionID is the only "+
 				"isolation boundary between subtests, so a collision serves one subtest's code to another", st.versionID)

--- a/integration_test/pytransformer_contract/backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/backwards_compatibility_test.go
@@ -300,10 +300,10 @@ def transformEvent(event, metadata):
 				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
-				newOutput := candidateResp.Events[0].Output
-				require.Equal(t, "src-1", newOutput["sourceId"])
-				require.Equal(t, "2", newOutput["instanceId"])
-				require.Equal(t, "ws-1-42", newOutput["partitionId"])
+				candidateOutput := candidateResp.Events[0].Output
+				require.Equal(t, "src-1", candidateOutput["sourceId"])
+				require.Equal(t, "2", candidateOutput["instanceId"])
+				require.Equal(t, "ws-1-42", candidateOutput["partitionId"])
 
 				for _, key := range []string{
 					"eventName",
@@ -315,7 +315,7 @@ def transformEvent(event, metadata):
 					"trackingPlanId",
 					"trackingPlanVersion",
 				} {
-					_, ok := newOutput[key]
+					_, ok := candidateOutput[key]
 					require.Falsef(t, ok, "key %q should stay absent when it wasn't present in the input metadata", key)
 				}
 
@@ -405,35 +405,35 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldStartedAt := time.Now().UTC()
+				baselineStartedAt := time.Now().UTC()
 				baselineResp := env.BaselineClient.Transform(context.Background(), events)
-				oldFinishedAt := time.Now().UTC()
+				baselineFinishedAt := time.Now().UTC()
 
-				newStartedAt := time.Now().UTC()
+				candidateStartedAt := time.Now().UTC()
 				candidateResp := env.CandidateClient.Transform(context.Background(), events)
-				newFinishedAt := time.Now().UTC()
+				candidateFinishedAt := time.Now().UTC()
 
 				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
 				require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
 				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
-				oldTimestamp, ok := baselineResp.Events[0].Output["rudderstackTransformedUtc"].(string)
+				baselineTimestamp, ok := baselineResp.Events[0].Output["rudderstackTransformedUtc"].(string)
 				require.True(t, ok, "baseline: generated timestamp should be present")
-				newTimestamp, ok := candidateResp.Events[0].Output["rudderstackTransformedUtc"].(string)
+				candidateTimestamp, ok := candidateResp.Events[0].Output["rudderstackTransformedUtc"].(string)
 				require.True(t, ok, "candidate: generated timestamp should be present")
 
-				oldParsed, err := time.ParseInLocation(time.DateTime, oldTimestamp, time.UTC)
+				baselineParsed, err := time.ParseInLocation(time.DateTime, baselineTimestamp, time.UTC)
 				require.NoError(t, err, "baseline: generated timestamp should parse")
-				newParsed, err := time.ParseInLocation(time.DateTime, newTimestamp, time.UTC)
+				candidateParsed, err := time.ParseInLocation(time.DateTime, candidateTimestamp, time.UTC)
 				require.NoError(t, err, "candidate: generated timestamp should parse")
 
-				require.False(t, oldParsed.Before(oldStartedAt.Add(-time.Second)), "baseline timestamp should be created during the old request window")
-				require.False(t, oldParsed.After(oldFinishedAt.Add(time.Second)), "baseline timestamp should be created during the old request window")
-				require.False(t, newParsed.Before(newStartedAt.Add(-time.Second)), "candidate timestamp should be created during the new request window")
-				require.False(t, newParsed.After(newFinishedAt.Add(time.Second)), "candidate timestamp should be created during the new request window")
-				if oldTimestamp != newTimestamp {
-					t.Logf("Timestamps differ as expected: old=%s new=%s", oldTimestamp, newTimestamp)
+				require.False(t, baselineParsed.Before(baselineStartedAt.Add(-time.Second)), "baseline timestamp should be created during the old request window")
+				require.False(t, baselineParsed.After(baselineFinishedAt.Add(time.Second)), "baseline timestamp should be created during the old request window")
+				require.False(t, candidateParsed.Before(candidateStartedAt.Add(-time.Second)), "candidate timestamp should be created during the new request window")
+				require.False(t, candidateParsed.After(candidateFinishedAt.Add(time.Second)), "candidate timestamp should be created during the new request window")
+				if baselineTimestamp != candidateTimestamp {
+					t.Logf("Timestamps differ as expected: old=%s new=%s", baselineTimestamp, candidateTimestamp)
 				} else {
 					t.Log("Timestamps happened to land in the same second — datetime matching path not exercised this run")
 				}
@@ -498,17 +498,17 @@ def transformBatch(events, metadata):
 				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
 				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldMeta := baselineResp.Events[0].Metadata
-				newMeta := candidateResp.Events[0].Metadata
+				baselineMeta := baselineResp.Events[0].Metadata
+				candidateMeta := candidateResp.Events[0].Metadata
 
 				t.Logf("Baseline metadata: TraceParent=%q, SourceID=%q, MessageID=%q",
-					oldMeta.TraceParent, oldMeta.SourceID, oldMeta.MessageID)
+					baselineMeta.TraceParent, baselineMeta.SourceID, baselineMeta.MessageID)
 				t.Logf("Candidate metadata: TraceParent=%q, SourceID=%q, MessageID=%q",
-					newMeta.TraceParent, newMeta.SourceID, newMeta.MessageID)
+					candidateMeta.TraceParent, candidateMeta.SourceID, candidateMeta.MessageID)
 
 				// Control: both should have curated fields
-				require.Equal(t, "src-1", oldMeta.SourceID, "baseline: sourceId should be present")
-				require.Equal(t, "src-1", newMeta.SourceID, "candidate: sourceId should be present")
+				require.Equal(t, "src-1", baselineMeta.SourceID, "baseline: sourceId should be present")
+				require.Equal(t, "src-1", candidateMeta.SourceID, "candidate: sourceId should be present")
 
 				// Compare: responses should be equal after Go unmarshaling (non-curated metadata differences are not observable)
 				diff, equal := baselineResp.Equal(&candidateResp)
@@ -518,7 +518,7 @@ def transformBatch(events, metadata):
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 					t.Logf("Baseline TraceParent=%q (expected empty), Candidate TraceParent=%q (expected set)",
-						oldMeta.TraceParent, newMeta.TraceParent)
+						baselineMeta.TraceParent, candidateMeta.TraceParent)
 				}
 			},
 		},
@@ -1403,11 +1403,11 @@ def transformEvent(event, metadata):
 				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
 				// All non-string keys (including None) should return None
-				oldOutput := baselineResp.Events[0].Output
-				newOutput := candidateResp.Events[0].Output
+				baselineOutput := baselineResp.Events[0].Output
+				candidateOutput := candidateResp.Events[0].Output
 				for _, key := range []string{"credentialValueForNoneKey", "credentialValueForNumkey", "credentialValueForBoolkey", "credentialValueForObjkey", "credentialValueForArrkey"} {
-					require.Nilf(t, oldOutput[key], "baseline: %s should be nil", key)
-					require.Nilf(t, newOutput[key], "candidate: %s should be nil", key)
+					require.Nilf(t, baselineOutput[key], "baseline: %s should be nil", key)
+					require.Nilf(t, candidateOutput[key], "candidate: %s should be nil", key)
 				}
 
 				diff, equal := baselineResp.Equal(&candidateResp)
@@ -1634,19 +1634,19 @@ def transformEvent(event, metadata):
 				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
 				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldOutput := baselineResp.Events[0].Output
-				newOutput := candidateResp.Events[0].Output
+				baselineOutput := baselineResp.Events[0].Output
+				candidateOutput := candidateResp.Events[0].Output
 
 				// Verify multiple credential accesses and repeated access
-				require.Equal(t, "testValue1", oldOutput["cred1"], "baseline: cred1 should be testValue1")
-				require.Equal(t, "testValue2", oldOutput["cred2"], "baseline: cred2 should be testValue2")
-				require.Equal(t, "testValue1", oldOutput["cred1_again"], "baseline: cred1_again should be testValue1")
-				require.Nil(t, oldOutput["missing"], "baseline: missing should be nil")
+				require.Equal(t, "testValue1", baselineOutput["cred1"], "baseline: cred1 should be testValue1")
+				require.Equal(t, "testValue2", baselineOutput["cred2"], "baseline: cred2 should be testValue2")
+				require.Equal(t, "testValue1", baselineOutput["cred1_again"], "baseline: cred1_again should be testValue1")
+				require.Nil(t, baselineOutput["missing"], "baseline: missing should be nil")
 
-				require.Equal(t, "testValue1", newOutput["cred1"], "candidate: cred1 should be testValue1")
-				require.Equal(t, "testValue2", newOutput["cred2"], "candidate: cred2 should be testValue2")
-				require.Equal(t, "testValue1", newOutput["cred1_again"], "candidate: cred1_again should be testValue1")
-				require.Nil(t, newOutput["missing"], "candidate: missing should be nil")
+				require.Equal(t, "testValue1", candidateOutput["cred1"], "candidate: cred1 should be testValue1")
+				require.Equal(t, "testValue2", candidateOutput["cred2"], "candidate: cred2 should be testValue2")
+				require.Equal(t, "testValue1", candidateOutput["cred1_again"], "candidate: cred1_again should be testValue1")
+				require.Nil(t, candidateOutput["missing"], "candidate: missing should be nil")
 
 				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
@@ -1818,10 +1818,10 @@ def transformEvent(event, metadata):
 				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
 				// An empty string value should be returned (not None)
-				oldOutput := baselineResp.Events[0].Output
-				newOutput := candidateResp.Events[0].Output
-				t.Logf("Baseline: cred=%v, credIsNone=%v, credIsEmpty=%v", oldOutput["cred"], oldOutput["credIsNone"], oldOutput["credIsEmpty"])
-				t.Logf("Candidate: cred=%v, credIsNone=%v, credIsEmpty=%v", newOutput["cred"], newOutput["credIsNone"], newOutput["credIsEmpty"])
+				baselineOutput := baselineResp.Events[0].Output
+				candidateOutput := candidateResp.Events[0].Output
+				t.Logf("Baseline: cred=%v, credIsNone=%v, credIsEmpty=%v", baselineOutput["cred"], baselineOutput["credIsNone"], baselineOutput["credIsEmpty"])
+				t.Logf("Candidate: cred=%v, credIsNone=%v, credIsEmpty=%v", candidateOutput["cred"], candidateOutput["credIsNone"], candidateOutput["credIsEmpty"])
 
 				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
@@ -1832,17 +1832,17 @@ def transformEvent(event, metadata):
 			},
 		},
 		{
-			// MetadataMergeAllKeys tests event.update(metadata(event)) which merges
-			// all 29 metadata keys (including None for missing fields) into the event.
-			name:      "MetadataMergeAllKeys",
-			versionID: "bc-metadata-merge-all-v1",
+			// Same merge as MetadataMergeAllKeys above, but with every metadata field populated:
+			// that one leaves most of them unset, so this pins how the fully-populated shape merges.
+			name:      "MetadataMergeAllKeysPopulated",
+			versionID: "bc-metadata-merge-all-populated-v1",
 			config: configBackendEntry{code: `
 def transformEvent(event, metadata):
     event.update(metadata(event))
     return event
 `},
 			run: func(t *testing.T, env *bcTestEnv) {
-				const versionID = "bc-metadata-merge-all-v1"
+				const versionID = "bc-metadata-merge-all-populated-v1"
 				events := []types.TransformerEvent{
 					{
 						Message: types.SingularEventT{
@@ -1873,10 +1873,10 @@ def transformEvent(event, metadata):
 				candidateResp := env.CandidateClient.Transform(context.Background(), events)
 				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
 				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
-				oldOutput := baselineResp.Events[0].Output
-				newOutput := candidateResp.Events[0].Output
-				t.Logf("Baseline output keys: %d", len(oldOutput))
-				t.Logf("Candidate output keys: %d", len(newOutput))
+				baselineOutput := baselineResp.Events[0].Output
+				candidateOutput := candidateResp.Events[0].Output
+				t.Logf("Baseline output keys: %d", len(baselineOutput))
+				t.Logf("Candidate output keys: %d", len(candidateOutput))
 				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal")
@@ -1932,10 +1932,10 @@ def transformEvent(event, metadata):
 				candidateResp := env.CandidateClient.Transform(context.Background(), events)
 				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
 				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
-				oldOutput := baselineResp.Events[0].Output
-				newOutput := candidateResp.Events[0].Output
-				t.Logf("Baseline output keys: %d", len(oldOutput))
-				t.Logf("Candidate output keys: %d", len(newOutput))
+				baselineOutput := baselineResp.Events[0].Output
+				candidateOutput := candidateResp.Events[0].Output
+				t.Logf("Baseline output keys: %d", len(baselineOutput))
+				t.Logf("Candidate output keys: %d", len(candidateOutput))
 				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal")
@@ -2012,10 +2012,10 @@ def transformEvent(event, metadata):
 				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
 				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
-				oldOutput := baselineResp.Events[0].Output
-				newOutput := candidateResp.Events[0].Output
-				t.Logf("Baseline output keys: %d", len(oldOutput))
-				t.Logf("Candidate output keys: %d", len(newOutput))
+				baselineOutput := baselineResp.Events[0].Output
+				candidateOutput := candidateResp.Events[0].Output
+				t.Logf("Baseline output keys: %d", len(baselineOutput))
+				t.Logf("Candidate output keys: %d", len(candidateOutput))
 				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
 					t.Log("Responses are equal")
@@ -2036,6 +2036,9 @@ def transformEvent(event, metadata):
 	allEntries := make(map[string]configBackendEntry, len(subtests))
 	for _, st := range subtests {
 		if st.config != (configBackendEntry{}) {
+			_, dup := allEntries[st.versionID]
+			require.Falsef(t, dup, "duplicate versionID %q: with shared containers the versionID is the only "+
+				"isolation boundary between subtests, so a collision serves one subtest's code to another", st.versionID)
 			allEntries[st.versionID] = st.config
 		}
 	}
@@ -2056,7 +2059,7 @@ def transformEvent(event, metadata):
 		baselineURL = startBaselinePytransformer(t, pool, configBackend.URL)
 	})
 	wg.Go(func() {
-		candidateURL = startRudderPytransformer(t, pool, configBackend.URL)
+		candidateURL = startCandidatePytransformer(t, pool, configBackend.URL)
 	})
 	wg.Wait()
 

--- a/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
@@ -118,7 +118,7 @@ def transformEvent(event, metadata):
 	baselineURL := startBaselinePytransformer(t, pool, configBackend.URL, pytEnv...)
 
 	t.Log("Starting candidate rudder-pytransformer...")
-	candidateURL := startRudderPytransformer(t, pool, configBackend.URL, pytEnv...)
+	candidateURL := startCandidatePytransformer(t, pool, configBackend.URL, pytEnv...)
 
 	// Every verb that accepts a second positional argument must survive
 	// the pooling bridge. GET exercises the params-promotion path; the
@@ -212,8 +212,8 @@ def transformEvent(event, metadata):
 // keyword, raising “TypeError: post() got multiple values for argument
 // 'data'“.
 //
-// This contract pins the correct behaviour: the baseline (vanilla
-// “requests“) accepts this call shape; the candidate must too.
+// This contract pins the correct behaviour: this call shape is accepted, and
+// both versions must keep accepting it.
 func TestBareRequestsPostThreePositionalArgsContract(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
@@ -266,7 +266,7 @@ def transformEvent(event, metadata):
 	baselineURL := startBaselinePytransformer(t, pool, configBackend.URL, pytEnv...)
 
 	t.Log("Starting candidate rudder-pytransformer...")
-	candidateURL := startRudderPytransformer(t, pool, configBackend.URL, pytEnv...)
+	candidateURL := startCandidatePytransformer(t, pool, configBackend.URL, pytEnv...)
 
 	env := newBCTestEnv(t, baselineURL, candidateURL,
 		withFailOnError(),

--- a/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/bare_requests_backwards_compatibility_test.go
@@ -16,7 +16,7 @@ import (
 
 // TestBareRequestsPositionalParamsContract locks the contract that valid
 // user code calling bare "requests" helpers with a second positional
-// argument produces identical results on both architectures, regardless
+// argument produces identical results on both versions, regardless
 // of the pytransformer connection-pool feature flag.
 //
 // The module-level “requests“ helpers expose a second positional argument
@@ -36,15 +36,15 @@ import (
 // raise “TypeError: got multiple values for argument 'data'“). The
 // contract is:
 //
-//  1. Old arch (rudder-transformer + openfaas-flask-base): user code runs
-//     against vanilla “requests“, so every two-positional call reaches
-//     the backend with the expected shape.
-//  2. New arch (rudder-pytransformer): bare calls flow through the
+//  1. Baseline (last released rudder-pytransformer): the reference
+//     behaviour — every two-positional call reaches the backend with
+//     the expected shape.
+//  2. Candidate (rudder-pytransformer): bare calls flow through the
 //     pooled “Session“. GET goes through the params-promotion bridge;
 //     POST/PUT/PATCH are forwarded verbatim. The observable result stays
-//     identical to the old arch.
+//     identical to the baseline.
 //
-// Every verb: the old-arch and new-arch responses must compare equal
+// Every verb: the baseline and candidate responses must compare equal
 // field-for-field via “types.Response.Equal“.
 func TestBareRequestsPositionalParamsContract(t *testing.T) {
 	pool, err := dockertest.NewPool("")
@@ -66,10 +66,10 @@ func TestBareRequestsPositionalParamsContract(t *testing.T) {
 
 	// Dispatcher user code: picks the verb from the incoming event so
 	// the same versionID can exercise all four two-positional shapes
-	// without spinning up a separate openfaas-flask-base container per
-	// verb. The line actually under test — `requests.<verb>(url,
-	// {"q": "hello"})` — is identical to what a real customer would
-	// write; only the surrounding if/elif selects which verb runs.
+	// without a separate container per verb. The line actually under
+	// test — `requests.<verb>(url, {"q": "hello"})` — is identical to
+	// what a real customer would write; only the surrounding if/elif
+	// selects which verb runs.
 	//
 	// For GET the positional dict becomes the query string; for
 	// POST/PUT/PATCH the positional dict is form-encoded into the body.
@@ -102,34 +102,23 @@ def transformEvent(event, metadata):
 	})
 	t.Cleanup(configBackend.Close)
 
-	// --- Old architecture (rudder-transformer + openfaas-flask-base) ---
+	// Bare `requests.<method>` calls are routed through a per-transformation
+	// pooled `Session`. Pin pool + subprocess count to 1 so a single long-lived
+	// user session handles every call: no subprocess affinity or pool recycling
+	// can influence the outcome.
 	//
-	// The old stack runs the user code under vanilla `requests` with no
-	// pooling layer in front of it, so it defines the reference behaviour
-	// every new-arch configuration must match. Started once and shared
-	// across every new-arch / verb combination.
-
-	t.Log("Starting openfaas-flask-base (old arch backend)...")
-	openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
-
-	t.Log("Starting mock OpenFaaS gateway...")
-	mockGateway, _ := newMockOpenFaaSGateway(t, func() string { return openFaasURL })
-	t.Cleanup(mockGateway.Close)
-
-	t.Log("Starting rudder-transformer (old arch frontend)...")
-	transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
-
-	// --- New architecture (rudder-pytransformer) ---
-	//
-	// Bare `requests.<method>` calls are routed through a per-
-	// transformation pooled `Session`. Pin pool + subprocess count
-	// to 1 so a single long-lived user session handles every call: no
-	// subprocess affinity or pool recycling can influence the outcome.
-	pyTransformerURL := startRudderPytransformer(
-		t, pool, configBackend.URL,
+	// Both versions get identical environment so the comparison isolates the
+	// version difference and nothing else.
+	pytEnv := []string{
 		"USER_CONN_POOL_MAX_SIZE=1",
 		"SANDBOX_POOL_MAX_SIZE=1",
-	)
+	}
+
+	t.Log("Starting baseline rudder-pytransformer...")
+	baselineURL := startBaselinePytransformer(t, pool, configBackend.URL, pytEnv...)
+
+	t.Log("Starting candidate rudder-pytransformer...")
+	candidateURL := startRudderPytransformer(t, pool, configBackend.URL, pytEnv...)
 
 	// Every verb that accepts a second positional argument must survive
 	// the pooling bridge. GET exercises the params-promotion path; the
@@ -148,7 +137,7 @@ def transformEvent(event, metadata):
 		t.Run(vc.verb, func(t *testing.T) {
 			// Fresh env per verb so memstats retry counters don't bleed between subtests (memstats accumulates
 			// and cannot be reset).
-			env := newBCTestEnv(t, transformerURL, pyTransformerURL,
+			env := newBCTestEnv(t, baselineURL, candidateURL,
 				withFailOnError(),
 				withLimitedRetryableHTTPRetries(),
 			)
@@ -157,22 +146,22 @@ def transformEvent(event, metadata):
 			event.Message["verb"] = vc.verb
 			events := []types.TransformerEvent{event}
 
-			t.Log("Sending request to old architecture...")
-			oldResp := env.OldClient.Transform(context.Background(), events)
-			t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+			t.Log("Sending request to baseline...")
+			baselineResp := env.BaselineClient.Transform(context.Background(), events)
+			t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-			t.Log("Sending request to new architecture...")
-			newResp := env.NewClient.Transform(context.Background(), events)
-			t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+			t.Log("Sending request to candidate...")
+			candidateResp := env.CandidateClient.Transform(context.Background(), events)
+			t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-			require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-			require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-			require.Equalf(t, 1, len(newResp.Events),
-				"new arch (verb=%s): 1 success event expected — incorrect "+
+			require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+			require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+			require.Equalf(t, 1, len(candidateResp.Events),
+				"candidate (verb=%s): 1 success event expected — incorrect "+
 					"argument forwarding raises TypeError before the HTTP "+
 					"call and fails the event instead",
 				vc.verb)
-			require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+			require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
 			// Round-trip sanity check: the echo server must have
 			// seen `q=hello` on both stacks, which means the
@@ -180,23 +169,23 @@ def transformEvent(event, metadata):
 			// that happens via the GET params-promotion bridge
 			// or verbatim positional forwarding for the body
 			// verbs.
-			require.Equal(t, "hello", oldResp.Events[0].Output["echo"],
-				"old arch must forward the positional dict as q=hello")
-			require.Equalf(t, "hello", newResp.Events[0].Output["echo"],
-				"new arch (verb=%s) must forward the positional dict as q=hello",
+			require.Equal(t, "hello", baselineResp.Events[0].Output["echo"],
+				"baseline must forward the positional dict as q=hello")
+			require.Equalf(t, "hello", candidateResp.Events[0].Output["echo"],
+				"candidate (verb=%s) must forward the positional dict as q=hello",
 				vc.verb)
 
 			// Method sanity: the echo server must also have seen
 			// the right HTTP verb, proving that the pooling
 			// wrapper dispatched to the right Session method and
 			// didn't silently downgrade to GET.
-			require.Equalf(t, vc.method, newResp.Events[0].Output["method"],
-				"new arch: echo server must have observed HTTP %s", vc.method)
+			require.Equalf(t, vc.method, candidateResp.Events[0].Output["method"],
+				"candidate: echo server must have observed HTTP %s", vc.method)
 
 			// Strict parity: every field of the two responses must match.
-			diff, equal := oldResp.Equal(&newResp)
+			diff, equal := baselineResp.Equal(&candidateResp)
 			require.Truef(t, equal,
-				"verb=%s: old and new architectures must produce identical "+
+				"verb=%s: baseline and candidate must produce identical "+
 					"responses for bare requests.%s(url, positional_dict):\n%s",
 				vc.verb, vc.verb, diff)
 
@@ -207,7 +196,7 @@ def transformEvent(event, metadata):
 
 // TestBareRequestsPostThreePositionalArgsContract locks the contract that
 // “requests.post(url, data, json)“ — all three arguments passed
-// positionally — behaves identically under both architectures and under
+// positionally — behaves identically under both versions and under
 // both values of the pytransformer connection-pool flag.
 //
 // The module-level signature “requests.post(url, data=None, json=None, **kwargs)“
@@ -215,7 +204,7 @@ def transformEvent(event, metadata):
 //
 //	requests.post("https://example.com/events", body, json_payload)
 //
-// The new-arch pooling layer used to mishandle this shape: it promoted
+// The candidate pooling layer used to mishandle this shape: it promoted
 // “args[1]“ (the body) to “data=“ while leaving “args[2]“ (the JSON
 // payload) positional, so the forwarded call became
 // “session.post(url, json_payload, data=body)“ — which binds
@@ -223,8 +212,8 @@ def transformEvent(event, metadata):
 // keyword, raising “TypeError: post() got multiple values for argument
 // 'data'“.
 //
-// This contract pins the correct behaviour: the old arch (vanilla
-// “requests“) accepts this call shape; the new arch must too.
+// This contract pins the correct behaviour: the baseline (vanilla
+// “requests“) accepts this call shape; the candidate must too.
 func TestBareRequestsPostThreePositionalArgsContract(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
@@ -266,57 +255,52 @@ def transformEvent(event, metadata):
 	})
 	t.Cleanup(configBackend.Close)
 
-	t.Log("Starting openfaas-flask-base (old arch backend)...")
-	openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
-
-	t.Log("Starting mock OpenFaaS gateway...")
-	mockGateway, _ := newMockOpenFaaSGateway(t, func() string { return openFaasURL })
-	t.Cleanup(mockGateway.Close)
-
-	t.Log("Starting rudder-transformer (old arch frontend)...")
-	transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
-
 	// Pin pool + subprocess count to 1 so incorrect argument forwarding
 	// cannot be masked by a cold subprocess bypassing the pool wrapper.
-	pyTransformerURL := startRudderPytransformer(
-		t, pool, configBackend.URL,
+	pytEnv := []string{
 		"USER_CONN_POOL_MAX_SIZE=1",
 		"SANDBOX_POOL_MAX_SIZE=1",
-	)
+	}
 
-	env := newBCTestEnv(t, transformerURL, pyTransformerURL,
+	t.Log("Starting baseline rudder-pytransformer...")
+	baselineURL := startBaselinePytransformer(t, pool, configBackend.URL, pytEnv...)
+
+	t.Log("Starting candidate rudder-pytransformer...")
+	candidateURL := startRudderPytransformer(t, pool, configBackend.URL, pytEnv...)
+
+	env := newBCTestEnv(t, baselineURL, candidateURL,
 		withFailOnError(),
 		withLimitedRetryableHTTPRetries(),
 	)
 
 	events := []types.TransformerEvent{makeEvent("msg-1", versionID)}
 
-	t.Log("Sending request to old architecture...")
-	oldResp := env.OldClient.Transform(context.Background(), events)
-	t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+	t.Log("Sending request to baseline...")
+	baselineResp := env.BaselineClient.Transform(context.Background(), events)
+	t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-	t.Log("Sending request to new architecture...")
-	newResp := env.NewClient.Transform(context.Background(), events)
-	t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+	t.Log("Sending request to candidate...")
+	candidateResp := env.CandidateClient.Transform(context.Background(), events)
+	t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-	require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-	require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-	require.Equal(t, 1, len(newResp.Events),
-		"new arch: 1 success event expected — a bad pooling wrapper raises "+
+	require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+	require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+	require.Equal(t, 1, len(candidateResp.Events),
+		"candidate: 1 success event expected — a bad pooling wrapper raises "+
 			"TypeError before the HTTP call and fails the event instead")
-	require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+	require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
 	// Round-trip sanity check: the echo server must have seen the raw
 	// body on both stacks, which means the second positional bound to
 	// `data` and the call completed.
-	require.Equal(t, "raw=payload", oldResp.Events[0].Output["received"],
-		"old arch must forward the positional body as the request payload")
-	require.Equal(t, "raw=payload", newResp.Events[0].Output["received"],
-		"new arch must forward the positional body as the request payload")
+	require.Equal(t, "raw=payload", baselineResp.Events[0].Output["received"],
+		"baseline must forward the positional body as the request payload")
+	require.Equal(t, "raw=payload", candidateResp.Events[0].Output["received"],
+		"candidate must forward the positional body as the request payload")
 
-	diff, equal := oldResp.Equal(&newResp)
+	diff, equal := baselineResp.Equal(&candidateResp)
 	require.Truef(t, equal,
-		"old and new architectures must produce identical responses for "+
+		"baseline and candidate must produce identical responses for "+
 			"bare requests.post(url, body, json_payload):\n%s", diff)
 
 	env.assertRetryCountsMatch(t)

--- a/integration_test/pytransformer_contract/base_test.go
+++ b/integration_test/pytransformer_contract/base_test.go
@@ -9,13 +9,8 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rudderlabs/rudder-go-kit/config"
-	"github.com/rudderlabs/rudder-go-kit/logger"
-	"github.com/rudderlabs/rudder-go-kit/stats"
-
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/processor/types"
-	"github.com/rudderlabs/rudder-server/processor/usertransformer"
 )
 
 // TestBaseContract is the base contract test that compares responses from the
@@ -102,22 +97,21 @@ def transformEvent(event, metadata):
 		baselineURL = startBaselinePytransformer(t, pool, configBackend.URL)
 	})
 	wg.Go(func() {
-		candidateURL = startRudderPytransformer(t, pool, configBackend.URL)
+		candidateURL = startCandidatePytransformer(t, pool, configBackend.URL)
 	})
 	wg.Wait()
 
-	newClientFor := func(url string) *usertransformer.Client {
-		conf := config.New()
-		setPytransformerRouting(conf, url)
-		return usertransformer.New(conf, logger.NOP, stats.NOP)
-	}
+	// newBCTestEnv rather than hand-rolled clients: it bounds maxRetry, the retry backoff and
+	// cpDownEndlessRetries, so a container that answers 809/503 fails this test instead of retrying
+	// until the package timeout and taking every other test in the package down with it.
+	env := newBCTestEnv(t, baselineURL, candidateURL)
 
 	t.Logf("Sending request to rudder-pytransformer:%s (baseline)...", baselinePytransformerTag())
-	baselineResp := newClientFor(baselineURL).Transform(context.Background(), events)
+	baselineResp := env.BaselineClient.Transform(context.Background(), events)
 	t.Logf("Baseline returned %d events, %d failed", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
 	t.Logf("Sending request to rudder-pytransformer:%s (candidate)...", candidatePytransformerTag())
-	candidateResp := newClientFor(candidateURL).Transform(context.Background(), events)
+	candidateResp := env.CandidateClient.Transform(context.Background(), events)
 	t.Logf("Candidate returned %d events, %d failed", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 	t.Log("Comparing responses...")

--- a/integration_test/pytransformer_contract/base_test.go
+++ b/integration_test/pytransformer_contract/base_test.go
@@ -19,18 +19,14 @@ import (
 )
 
 // TestBaseContract is the base contract test that compares responses from the
-// old architecture (rudder-transformer + openfaas-flask-base) against the new
-// architecture (rudder-pytransformer).
+// baseline rudder-pytransformer (the last released version) against the
+// candidate one (main).
 //
 // This test:
-// 1. Starts a mock config backend serving Python transformation code
-// 2. Starts openfaas-flask-base with the transformation pre-loaded
-// 3. Starts a mock OpenFaaS gateway that proxies invocations to openfaas-flask-base
-// 4. Starts rudder-transformer connected to the mock gateway
-// 5. Starts rudder-pytransformer connected to the mock config backend
-// 6. Uses the actual user_transformer.Client to send /customTransform to both
-// 7. Asserts the OpenFaaS gateway was invoked (proving the old architecture path)
-// 8. Compares the responses for equivalence
+//  1. Starts a mock config backend serving Python transformation code
+//  2. Starts both rudder-pytransformer versions against that config backend
+//  3. Uses the actual user_transformer.Client to send /customTransform to both
+//  4. Compares the responses for equivalence
 //
 // Copy this test and change pythonCode + events to create new contract test cases.
 //
@@ -44,10 +40,9 @@ def transformEvent(event, metadata):
     return event
 `
 
-	// Language "pythonfaas" is required: the user_transformer.Client reads it from
-	// Destination.Transformations[0].Language to decide URL routing.
-	// - When PYTHON_TRANSFORM_URL is empty, python falls through to USER_TRANSFORM_URL (old architecture).
-	// - When PYTHON_TRANSFORM_URL is set, python routes there (new architecture).
+	// Language "pythonfaas" is what production stores for Python transformations:
+	// the user_transformer.Client reads it from Destination.Transformations[0].Language
+	// to decide URL routing, and any "python" prefix routes to rudder-pytransformer.
 	events := []types.TransformerEvent{
 		{
 			Message: types.SingularEventT{
@@ -99,52 +94,35 @@ def transformEvent(event, metadata):
 	defer configBackend.Close()
 	t.Logf("Config backend at %s", configBackend.URL)
 
-	t.Log("Starting openfaas-flask-base container...")
-	openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
-
-	t.Log("Starting mock OpenFaaS gateway...")
-	mockGateway, openFaaSInvocations := newMockOpenFaaSGateway(t, func() string { return openFaasURL })
-	defer mockGateway.Close()
-	t.Logf("Mock OpenFaaS gateway at %s", mockGateway.URL)
-
 	var (
-		wg                               sync.WaitGroup
-		transformerURL, pyTransformerURL string
+		wg                        sync.WaitGroup
+		baselineURL, candidateURL string
 	)
 	wg.Go(func() {
-		transformerURL = startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
+		baselineURL = startBaselinePytransformer(t, pool, configBackend.URL)
 	})
 	wg.Go(func() {
-		pyTransformerURL = startRudderPytransformer(t, pool, configBackend.URL)
+		candidateURL = startRudderPytransformer(t, pool, configBackend.URL)
 	})
 	wg.Wait()
 
-	// Old architecture: PYTHON_TRANSFORM_URL is empty, so the client falls through
-	// to USER_TRANSFORM_URL for python transformations (same as production before pytransformer).
-	t.Log("Sending request to rudder-transformer (old architecture)...")
-	oldArchConf := config.New()
-	oldArchConf.Set("USER_TRANSFORM_URL", transformerURL)
-	oldClient := usertransformer.New(oldArchConf, logger.NOP, stats.NOP)
-	oldResp := oldClient.Transform(context.Background(), events)
-	t.Logf("Old architecture returned %d events, %d failed", len(oldResp.Events), len(oldResp.FailedEvents))
+	newClientFor := func(url string) *usertransformer.Client {
+		conf := config.New()
+		setPytransformerRouting(conf, url)
+		return usertransformer.New(conf, logger.NOP, stats.NOP)
+	}
 
-	t.Log("Asserting OpenFaaS gateway was invoked by rudder-transformer...")
-	require.Greater(t, openFaaSInvocations.Load(), int64(0),
-		"expected OpenFaaS gateway to be invoked at least once by rudder-transformer")
-	t.Logf("OpenFaaS gateway was invoked %d times", openFaaSInvocations.Load())
+	t.Logf("Sending request to rudder-pytransformer:%s (baseline)...", baselinePytransformerTag())
+	baselineResp := newClientFor(baselineURL).Transform(context.Background(), events)
+	t.Logf("Baseline returned %d events, %d failed", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-	// New architecture: PYTHON_TRANSFORM_URL is set, so the client routes python
-	// transformations directly to rudder-pytransformer.
-	t.Log("Sending request to rudder-pytransformer (new architecture)...")
-	newArchConf := config.New()
-	newArchConf.Set("PYTHON_TRANSFORM_URL", pyTransformerURL)
-	newClient := usertransformer.New(newArchConf, logger.NOP, stats.NOP)
-	newResp := newClient.Transform(context.Background(), events)
-	t.Logf("New architecture returned %d events, %d failed", len(newResp.Events), len(newResp.FailedEvents))
+	t.Logf("Sending request to rudder-pytransformer:%s (candidate)...", candidatePytransformerTag())
+	candidateResp := newClientFor(candidateURL).Transform(context.Background(), events)
+	t.Logf("Candidate returned %d events, %d failed", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 	t.Log("Comparing responses...")
-	diff, equal := oldResp.Equal(&newResp)
+	diff, equal := baselineResp.Equal(&candidateResp)
 	require.True(t, equal, "responses differ:\n%s", diff)
 
-	t.Log("Contract test passed: old and new architectures return equivalent responses")
+	t.Log("Contract test passed: baseline and candidate return equivalent responses")
 }

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -202,15 +202,15 @@ func getRetryCount(store *memstats.Store, name string) int {
 func (env *bcTestEnv) assertRetryCountsMatch(t *testing.T) {
 	t.Helper()
 
-	oldCPRetries := getRetryCount(env.BaselineStats, "processor_user_transformer_cp_down_retries")
-	newCPRetries := getRetryCount(env.CandidateStats, "processor_user_transformer_cp_down_retries")
-	t.Logf("CP down retries: baseline=%d, candidate=%d", oldCPRetries, newCPRetries)
-	require.Equal(t, oldCPRetries, newCPRetries, "CP down retry counts should match between baseline and candidate")
+	baselineCPRetries := getRetryCount(env.BaselineStats, "processor_user_transformer_cp_down_retries")
+	candidateCPRetries := getRetryCount(env.CandidateStats, "processor_user_transformer_cp_down_retries")
+	t.Logf("CP down retries: baseline=%d, candidate=%d", baselineCPRetries, candidateCPRetries)
+	require.Equal(t, baselineCPRetries, candidateCPRetries, "CP down retry counts should match between baseline and candidate")
 
-	oldHTTPRetries := getRetryCount(env.BaselineStats, "processor_user_transformer_http_retries")
-	newHTTPRetries := getRetryCount(env.CandidateStats, "processor_user_transformer_http_retries")
-	t.Logf("HTTP retries: baseline=%d, candidate=%d", oldHTTPRetries, newHTTPRetries)
-	require.Equal(t, oldHTTPRetries, newHTTPRetries, "HTTP retry counts should match between baseline and candidate")
+	baselineHTTPRetries := getRetryCount(env.BaselineStats, "processor_user_transformer_http_retries")
+	candidateHTTPRetries := getRetryCount(env.CandidateStats, "processor_user_transformer_http_retries")
+	t.Logf("HTTP retries: baseline=%d, candidate=%d", baselineHTTPRetries, candidateHTTPRetries)
+	require.Equal(t, baselineHTTPRetries, candidateHTTPRetries, "HTTP retry counts should match between baseline and candidate")
 }
 
 // makeEvent creates a TransformerEvent for backwards compatibility testing with minimal required fields.
@@ -349,7 +349,9 @@ func newContractConfigBackend(t *testing.T, entries map[string]configBackendEntr
 //
 // Either side can be overridden to point the suite at any pair:
 //
-//	PYTRANSFORMER_CANDIDATE_TAG=0.11.0 PYTRANSFORMER_BASELINE_TAG=0.10.0 go test ...
+//	PYT_CANDIDATE_TAG=0.11.0 PYT_BASELINE_TAG=0.10.0 go test ...
+//
+// See README.md in this directory for how to run the suite against your own build.
 const (
 	pytransformerImage = "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-pytransformer"
 
@@ -372,7 +374,7 @@ func runningInCI() bool {
 // candidatePytransformerTag returns the tag under test: the local build when a
 // developer runs the suite, the latest release on CI.
 func candidatePytransformerTag() string {
-	if tag := os.Getenv("PYTRANSFORMER_CANDIDATE_TAG"); tag != "" {
+	if tag := os.Getenv("PYT_CANDIDATE_TAG"); tag != "" {
 		return tag
 	}
 	if runningInCI() {
@@ -384,7 +386,7 @@ func candidatePytransformerTag() string {
 // baselinePytransformerTag returns the tag the candidate is compared against:
 // the latest release locally, the release before it on CI.
 func baselinePytransformerTag() string {
-	if tag := os.Getenv("PYTRANSFORMER_BASELINE_TAG"); tag != "" {
+	if tag := os.Getenv("PYT_BASELINE_TAG"); tag != "" {
 		return tag
 	}
 	if runningInCI() {
@@ -393,11 +395,11 @@ func baselinePytransformerTag() string {
 	return latestReleaseTag
 }
 
-// startRudderPytransformer starts the candidate rudder-pytransformer container
+// startCandidatePytransformer starts the candidate rudder-pytransformer container
 // configured to use the mock config backend. Optional extra environment
 // variables can be passed (e.g. "GEOLOCATION_URL=http://...").
 // Returns the URL to reach it from the host.
-func startRudderPytransformer(
+func startCandidatePytransformer(
 	t *testing.T, pool *dockertest.Pool,
 	configBackendURL string,
 	extraEnv ...string,
@@ -420,7 +422,7 @@ func startBaselinePytransformer(
 		panic(fmt.Sprintf(
 			"baseline and candidate both resolved to rudder-pytransformer:%s — every comparison in this suite "+
 				"would pass without testing anything. Bump latestReleaseTag/previousReleaseTag, or set "+
-				"PYTRANSFORMER_BASELINE_TAG and PYTRANSFORMER_CANDIDATE_TAG to different tags.", baseline))
+				"PYT_BASELINE_TAG and PYT_CANDIDATE_TAG to different tags.", baseline))
 	}
 	t.Logf("Comparing rudder-pytransformer baseline=%s against candidate=%s", baseline, candidate)
 	return startRudderPytransformerWithTag(t, pool, baseline, configBackendURL, extraEnv...)
@@ -530,8 +532,8 @@ func dumpContainerLogs(t *testing.T, pool *dockertest.Pool, container *dockertes
 
 // normalizeJSON re-marshals a JSON string so keys are in deterministic (sorted) order.
 // For non-200 responses, the Go usertransformer client stores the raw JSON body as the
-// Error string. Different transformers (JS vs Python) may serialize JSON keys in different
-// orders, so we normalize before comparison.
+// Error string. Two pytransformer releases can still serialize the same object's keys in a
+// different order, so normalize before comparing rather than asserting on byte equality.
 func normalizeJSON(s string) string {
 	var v any
 	if err := jsonrs.Unmarshal([]byte(s), &v); err != nil {
@@ -620,7 +622,10 @@ func waitForGeolocation(t *testing.T, pool *dockertest.Pool, baseURL string) {
 }
 
 // mockGeoConfig holds configurable behavior for the mock geolocation service.
-// Use setResponse to change the HTTP status code and body between subtests.
+//
+// One instance is shared by every subtest, because the server's URL is fixed in the containers'
+// GEOLOCATION_URL at startup. Configure a failure mode with setResponse/setConnectionClose/setSlow,
+// and pair it with reset so the next subtest starts from a healthy backend.
 type mockGeoConfig struct {
 	mu         sync.Mutex
 	statusCode int
@@ -628,31 +633,35 @@ type mockGeoConfig struct {
 	delay      time.Duration
 }
 
-func (c *mockGeoConfig) setResponse(statusCode int) {
+// apply is the single place every field is assigned, so a new failure mode cannot be added to one
+// setter and forgotten in the others — which is what would let it leak between subtests.
+func (c *mockGeoConfig) apply(statusCode int, closeConn bool, delay time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.statusCode = statusCode
-	c.closeConn = false
-	c.delay = 0
+	c.closeConn = closeConn
+	c.delay = delay
 }
 
-func (c *mockGeoConfig) setConnectionClose() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.closeConn = true
-	c.delay = 0
-}
+// reset returns the mock to a healthy backend: HTTP 200, no delay, no connection close.
+//
+// This is the teardown for a subtest that configured a failure mode. The server itself keeps
+// running — its URL is baked into GEOLOCATION_URL when the containers start, and the containers
+// outlive the subtests, so the mock can only ever be reconfigured, never restarted. Without this,
+// a subtest that does not configure the mock inherits whatever the previous one left behind.
+func (c *mockGeoConfig) reset() { c.apply(http.StatusOK, false, 0) }
+
+// setResponse makes the mock answer /geoip/* with statusCode.
+func (c *mockGeoConfig) setResponse(statusCode int) { c.apply(statusCode, false, 0) }
+
+// setConnectionClose makes the mock hijack the connection and close it without responding,
+// simulating a geolocation backend that drops the connection mid-request.
+func (c *mockGeoConfig) setConnectionClose() { c.apply(http.StatusOK, true, 0) }
 
 // setSlow makes the mock /geoip/* handler block for "delay" before responding
 // with HTTP 200. Used to simulate a hung geolocation backend so the
 // pytransformer's GEOLOCATION_TIMEOUT_SECS deadline fires.
-func (c *mockGeoConfig) setSlow(delay time.Duration) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.statusCode = http.StatusOK
-	c.closeConn = false
-	c.delay = delay
-}
+func (c *mockGeoConfig) setSlow(delay time.Duration) { c.apply(http.StatusOK, false, delay) }
 
 // newConfigurableMockGeolocationService creates a mock geolocation HTTP server
 // whose /geoip/* responses can be changed between subtests via mockGeoConfig.
@@ -702,4 +711,26 @@ func newConfigurableMockGeolocationService(t *testing.T) (*httptest.Server, *moc
 		w.WriteHeader(code)
 	}))
 	return server, cfg
+}
+
+// TestMockGeoConfigReset pins that reset clears every failure mode, not just the one a given setter
+// happens to set. The mock is shared across subtests and outlives them, so a field left behind here
+// silently changes the geolocation backend a later subtest runs against.
+func TestMockGeoConfigReset(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(*mockGeoConfig)
+	}{
+		{"after setResponse", func(c *mockGeoConfig) { c.setResponse(http.StatusInternalServerError) }},
+		{"after setConnectionClose", func(c *mockGeoConfig) { c.setConnectionClose() }},
+		{"after setSlow", func(c *mockGeoConfig) { c.setSlow(500 * time.Millisecond) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &mockGeoConfig{statusCode: http.StatusOK}
+			tc.configure(cfg)
+			cfg.reset()
+			require.Equal(t, &mockGeoConfig{statusCode: http.StatusOK}, cfg,
+				"reset must restore a healthy backend; a leftover field leaks into the next subtest")
+		})
+	}
 }

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -414,7 +414,13 @@ func startBaselinePytransformer(
 	extraEnv ...string,
 ) string {
 	t.Helper()
-	return startRudderPytransformerWithTag(t, pool, baselinePytransformerTag(), configBackendURL, extraEnv...)
+	baseline, candidate := baselinePytransformerTag(), candidatePytransformerTag()
+	require.NotEqualf(t, candidate, baseline,
+		"baseline and candidate both resolved to rudder-pytransformer:%s — the comparison would be vacuous. "+
+			"Bump latestReleaseTag/previousReleaseTag, or set PYTRANSFORMER_BASELINE_TAG and "+
+			"PYTRANSFORMER_CANDIDATE_TAG to different tags.", baseline)
+	t.Logf("Comparing rudder-pytransformer baseline=%s against candidate=%s", baseline, candidate)
+	return startRudderPytransformerWithTag(t, pool, baseline, configBackendURL, extraEnv...)
 }
 
 // startRudderPytransformerWithTag starts a rudder-pytransformer container at an

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -415,10 +415,13 @@ func startBaselinePytransformer(
 ) string {
 	t.Helper()
 	baseline, candidate := baselinePytransformerTag(), candidatePytransformerTag()
-	require.NotEqualf(t, candidate, baseline,
-		"baseline and candidate both resolved to rudder-pytransformer:%s — the comparison would be vacuous. "+
-			"Bump latestReleaseTag/previousReleaseTag, or set PYTRANSFORMER_BASELINE_TAG and "+
-			"PYTRANSFORMER_CANDIDATE_TAG to different tags.", baseline)
+	if baseline == candidate {
+		// Panic rather than t.Fatal: most callers start the two containers from a wg.Go goroutine
+		panic(fmt.Sprintf(
+			"baseline and candidate both resolved to rudder-pytransformer:%s — every comparison in this suite "+
+				"would pass without testing anything. Bump latestReleaseTag/previousReleaseTag, or set "+
+				"PYTRANSFORMER_BASELINE_TAG and PYTRANSFORMER_CANDIDATE_TAG to different tags.", baseline))
+	}
 	t.Logf("Comparing rudder-pytransformer baseline=%s against candidate=%s", baseline, candidate)
 	return startRudderPytransformerWithTag(t, pool, baseline, configBackendURL, extraEnv...)
 }

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -6,11 +6,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"runtime"
 	"strconv"
-	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -36,8 +35,8 @@ import (
 
 // containerConfig holds platform-specific Docker container configuration.
 // On Linux, containers use host networking (sharing the host's network namespace).
-// On macOS — or when bridge networking is forced via withBridgeNetworking —
-// containers use bridge networking with port bindings and host.docker.internal.
+// On macOS, containers use bridge networking with port bindings and
+// host.docker.internal.
 type containerConfig struct {
 	bridge       bool // bridge networking (vs host networking)
 	hostPort     int  // allocated host port (host networking only)
@@ -46,30 +45,12 @@ type containerConfig struct {
 	hostConfigFn func(*docker.HostConfig)
 }
 
-type containerConfigOpts struct {
-	forceBridge bool
-}
-
-type containerConfigOpt func(*containerConfigOpts)
-
-// withBridgeNetworking forces bridge networking even where host networking is
-// the default (Linux). For containers that must not share the host's network
-// namespace — e.g. openfaas-flask function containers, whose of-watchdog binds
-// a hard-coded metrics port that collides when two of them share a namespace.
-func withBridgeNetworking() containerConfigOpt {
-	return func(o *containerConfigOpts) { o.forceBridge = true }
-}
-
 // newContainerConfig returns the appropriate Docker configuration for the current platform.
 // Default is host networking (Linux, CI, production). On macOS, Docker Desktop does not
 // support host networking so we fall back to bridge networking with port bindings.
-func newContainerConfig(t *testing.T, containerPort string, opts ...containerConfigOpt) containerConfig {
+func newContainerConfig(t *testing.T, containerPort string) containerConfig {
 	t.Helper()
-	var o containerConfigOpts
-	for _, opt := range opts {
-		opt(&o)
-	}
-	if runtime.GOOS == "darwin" || o.forceBridge {
+	if runtime.GOOS == "darwin" {
 		return containerConfig{
 			bridge:     true,
 			ExtraHosts: []string{"host.docker.internal:host-gateway"},
@@ -118,78 +99,92 @@ func toContainerURL(url string) string {
 	return url
 }
 
-// bcTestEnv holds clients for both the old architecture (rudder-transformer + openfaas)
-// and the new architecture (rudder-pytransformer) to compare their responses.
+// bcTestEnv holds clients for the two rudder-pytransformer builds under
+// comparison: the baseline (last released version) and the candidate (main).
 type bcTestEnv struct {
-	OldClient *usertransformer.Client // rudder-transformer + openfaas (old architecture)
-	NewClient *usertransformer.Client // rudder-pytransformer (new architecture)
-	OldStats  *memstats.Store         // stats store for old architecture client
-	NewStats  *memstats.Store         // stats store for new architecture client
+	BaselineClient  *usertransformer.Client // baseline rudder-pytransformer
+	CandidateClient *usertransformer.Client // candidate rudder-pytransformer
+	BaselineStats   *memstats.Store         // stats store for the baseline client
+	CandidateStats  *memstats.Store         // stats store for the candidate client
 }
 
-type bcTestEnvOpt func(oldConf, newConf *config.Config)
+type bcTestEnvOpt func(baselineConf, candidateConf *config.Config)
 
 // withFailOnError configures the test env to return error responses (instead of
 // panicking) when transformer retries are exhausted. Required for tests where
-// the new architecture triggers retries (e.g. geolocation 5xx → HTTP 503).
+// pytransformer triggers retries (e.g. geolocation 5xx → HTTP 503).
 func withFailOnError() bcTestEnvOpt {
-	return func(oldConf, newConf *config.Config) {
-		oldConf.Set("Processor.UserTransformer.failOnError", true)
-		newConf.Set("Processor.UserTransformer.failOnError", true)
+	return func(baselineConf, candidateConf *config.Config) {
+		baselineConf.Set("Processor.UserTransformer.failOnError", true)
+		candidateConf.Set("Processor.UserTransformer.failOnError", true)
 	}
 }
 
 // withLimitedRetryableHTTPRetries caps the retryable HTTP client retries so that
 // 503 + X-Rudder-Should-Retry responses don't retry indefinitely in tests.
 func withLimitedRetryableHTTPRetries() bcTestEnvOpt {
-	return func(oldConf, newConf *config.Config) {
-		for _, c := range []*config.Config{oldConf, newConf} {
+	return func(baselineConf, candidateConf *config.Config) {
+		for _, c := range []*config.Config{baselineConf, candidateConf} {
 			c.Set("Transformer.Client.UserTransformer.retryRudderErrors.maxRetry", 2)
 			c.Set("Transformer.Client.UserTransformer.retryRudderErrors.maxInterval", 1*time.Millisecond)
 		}
 	}
 }
 
+// setPytransformerRouting points a client at one pytransformer container the way
+// production addresses PyT: the per-workspace path. PerWorkspacePyTBaseURL only
+// substitutes "{workspaceID}", so a template without that placeholder resolves
+// to the container URL verbatim and one container serves every workspace id.
+func setPytransformerRouting(conf *config.Config, pyTransformerURL string) {
+	conf.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
+	conf.Set("Processor.UserTransformer.perWorkspacePyTURLTemplate", pyTransformerURL)
+	// The per-workspace path classifies ECONNREFUSED/502/503 from PyT as a cold
+	// start, and cold starts retry forever by default so a Deployment scaling off
+	// zero is waited out rather than failed. Tests must not hang on that: several
+	// subtests make pytransformer answer 503 deliberately.
+	conf.Set("Processor.UserTransformer.perWorkspacePyTEndlessRetries", false)
+}
+
 // newBCTestEnv creates a bcTestEnv with fresh memstats stores per subtest.
 // Fresh stores are needed because memstats accumulates counts and cannot be reset.
-func newBCTestEnv(t *testing.T, transformerURL, pyTransformerURL string, opts ...bcTestEnvOpt) *bcTestEnv {
+func newBCTestEnv(t *testing.T, baselineURL, candidateURL string, opts ...bcTestEnvOpt) *bcTestEnv {
 	t.Helper()
 
-	oldStats, err := memstats.New()
+	baselineStats, err := memstats.New()
 	require.NoError(t, err)
-	newStats, err := memstats.New()
+	candidateStats, err := memstats.New()
 	require.NoError(t, err)
 
-	oldArchConf := config.New()
-	oldArchConf.Set("Processor.UserTransformer.maxRetry", 2)
-	oldArchConf.Set("Processor.UserTransformer.cpDownEndlessRetries", false)
-	oldArchConf.Set("Processor.UserTransformer.maxRetryBackoffInterval", 1*time.Millisecond)
-	oldArchConf.Set("USER_TRANSFORM_URL", transformerURL)
+	baselineConf := config.New()
+	baselineConf.Set("Processor.UserTransformer.maxRetry", 2)
+	baselineConf.Set("Processor.UserTransformer.cpDownEndlessRetries", false)
+	baselineConf.Set("Processor.UserTransformer.maxRetryBackoffInterval", 1*time.Millisecond)
+	setPytransformerRouting(baselineConf, baselineURL)
 
-	newArchConf := config.New()
-	newArchConf.Set("Processor.UserTransformer.maxRetry", 2)
-	newArchConf.Set("Processor.UserTransformer.cpDownEndlessRetries", false)
-	newArchConf.Set("Processor.UserTransformer.maxRetryBackoffInterval", 1*time.Millisecond)
-	newArchConf.Set("PYTHON_TRANSFORM_URL", pyTransformerURL)
+	candidateConf := config.New()
+	candidateConf.Set("Processor.UserTransformer.maxRetry", 2)
+	candidateConf.Set("Processor.UserTransformer.cpDownEndlessRetries", false)
+	candidateConf.Set("Processor.UserTransformer.maxRetryBackoffInterval", 1*time.Millisecond)
+	setPytransformerRouting(candidateConf, candidateURL)
 
 	for _, opt := range opts {
-		opt(oldArchConf, newArchConf)
+		opt(baselineConf, candidateConf)
 	}
 
 	var (
-		oldArchLogger = logger.NOP
-		newArchLogger = logger.NOP
+		baselineLogger  = logger.NOP
+		candidateLogger = logger.NOP
 	)
 	if testing.Verbose() {
-		oldArchLogger = logger.NewLogger().Child("old-arch")
-		newArchLogger = logger.NewLogger().Child("new-arch")
+		baselineLogger = logger.NewLogger().Child("baseline")
+		candidateLogger = logger.NewLogger().Child("candidate")
 	}
 
 	return &bcTestEnv{
-		OldClient: usertransformer.New(oldArchConf, oldArchLogger, oldStats),
-		NewClient: usertransformer.New(newArchConf, newArchLogger, newStats),
-		OldStats:  oldStats,
-		NewStats:  newStats,
+		BaselineClient:  usertransformer.New(baselineConf, baselineLogger, baselineStats),
+		CandidateClient: usertransformer.New(candidateConf, candidateLogger, candidateStats),
+		BaselineStats:   baselineStats,
+		CandidateStats:  candidateStats,
 	}
 }
 
@@ -203,19 +198,19 @@ func getRetryCount(store *memstats.Store, name string) int {
 	return int(m.LastValue())
 }
 
-// assertRetryCountsMatch asserts that both architectures triggered the same number of retries.
+// assertRetryCountsMatch asserts that both PyT versions triggered the same number of retries.
 func (env *bcTestEnv) assertRetryCountsMatch(t *testing.T) {
 	t.Helper()
 
-	oldCPRetries := getRetryCount(env.OldStats, "processor_user_transformer_cp_down_retries")
-	newCPRetries := getRetryCount(env.NewStats, "processor_user_transformer_cp_down_retries")
-	t.Logf("CP down retries: old=%d, new=%d", oldCPRetries, newCPRetries)
-	require.Equal(t, oldCPRetries, newCPRetries, "CP down retry counts should match between old and new arch")
+	oldCPRetries := getRetryCount(env.BaselineStats, "processor_user_transformer_cp_down_retries")
+	newCPRetries := getRetryCount(env.CandidateStats, "processor_user_transformer_cp_down_retries")
+	t.Logf("CP down retries: baseline=%d, candidate=%d", oldCPRetries, newCPRetries)
+	require.Equal(t, oldCPRetries, newCPRetries, "CP down retry counts should match between baseline and candidate")
 
-	oldHTTPRetries := getRetryCount(env.OldStats, "processor_user_transformer_http_retries")
-	newHTTPRetries := getRetryCount(env.NewStats, "processor_user_transformer_http_retries")
-	t.Logf("HTTP retries: old=%d, new=%d", oldHTTPRetries, newHTTPRetries)
-	require.Equal(t, oldHTTPRetries, newHTTPRetries, "HTTP retry counts should match between old and new arch")
+	oldHTTPRetries := getRetryCount(env.BaselineStats, "processor_user_transformer_http_retries")
+	newHTTPRetries := getRetryCount(env.CandidateStats, "processor_user_transformer_http_retries")
+	t.Logf("HTTP retries: baseline=%d, candidate=%d", oldHTTPRetries, newHTTPRetries)
+	require.Equal(t, oldHTTPRetries, newHTTPRetries, "HTTP retry counts should match between baseline and candidate")
 }
 
 // makeEvent creates a TransformerEvent for backwards compatibility testing with minimal required fields.
@@ -280,11 +275,11 @@ type configBackendEntry struct {
 }
 
 // newContractConfigBackend creates a mock config backend that serves
-// transformation code for both rudder-transformer and rudder-pytransformer.
+// transformation code to both rudder-pytransformer containers under comparison.
 //
-// The response includes language: "pythonfaas" so rudder-transformer routes
-// to the OpenFaaS path. rudder-pytransformer and openfaas-flask-base only
-// use the "code" field.
+// The response includes language: "pythonfaas", which is what production still
+// stores for Python transformations; rudder-pytransformer only uses the "code"
+// field.
 func newContractConfigBackend(t *testing.T, entries map[string]configBackendEntry) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -339,196 +334,94 @@ func newContractConfigBackend(t *testing.T, entries map[string]configBackendEntr
 	}))
 }
 
-// newMockOpenFaaSGateway creates a mock OpenFaaS gateway that:
-// - Accepts function deployment requests (POST /system/functions)
-// - Reports functions as healthy (GET /function/*)
-// - Proxies function invocations (POST /function/*) to the URL returned by getTarget()
+// The suite always compares two rudder-pytransformer builds — a candidate
+// against a baseline — so a behaviour change between two PyT versions fails here
+// the same way it would surface in a mirrored production comparison.
 //
-// getTarget is called on each invocation, allowing the target to change between subtests.
-// Returns the server and an atomic counter tracking POST /function/* invocations.
-func newMockOpenFaaSGateway(t *testing.T, getTarget func() string) (*httptest.Server, *atomic.Int64) {
-	t.Helper()
-	invocations := &atomic.Int64{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		// Deploy function
-		case r.Method == http.MethodPost && r.URL.Path == "/system/functions":
-			w.WriteHeader(http.StatusOK)
-
-		// Update function
-		case r.Method == http.MethodPut && r.URL.Path == "/system/functions":
-			w.WriteHeader(http.StatusOK)
-
-		// Delete function
-		case r.Method == http.MethodDelete && r.URL.Path == "/system/functions":
-			w.WriteHeader(http.StatusOK)
-
-		// List functions
-		case r.Method == http.MethodGet && r.URL.Path == "/system/functions":
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte("[]"))
-
-		// Get function info
-		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/system/function/"):
-			name := strings.TrimPrefix(r.URL.Path, "/system/function/")
-			w.Header().Set("Content-Type", "application/json")
-			_ = jsonrs.NewEncoder(w).Encode(map[string]any{
-				"name":     name,
-				"replicas": 1,
-			})
-
-		// Health check or invoke function
-		case strings.HasPrefix(r.URL.Path, "/function/"):
-			if r.Method == http.MethodGet {
-				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`{"service": "UP"}`))
-				return
-			}
-			if r.Method == http.MethodPost {
-				invocations.Add(1)
-				targetURL := getTarget()
-				if targetURL == "" {
-					t.Log("MockOpenFaaS: no target URL set")
-					w.WriteHeader(http.StatusServiceUnavailable)
-					return
-				}
-
-				body, err := io.ReadAll(r.Body)
-				if err != nil {
-					t.Logf("MockOpenFaaS: failed to read body: %v", err)
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
-
-				proxyReq, err := http.NewRequest(http.MethodPost, targetURL+"/", bytes.NewReader(body))
-				if err != nil {
-					t.Logf("MockOpenFaaS: failed to create proxy request: %v", err)
-					w.WriteHeader(http.StatusBadGateway)
-					return
-				}
-				proxyReq.Header.Set("Content-Type", "application/json")
-
-				resp, err := http.DefaultClient.Do(proxyReq)
-				if err != nil {
-					t.Logf("MockOpenFaaS: failed to proxy to openfaas-flask-base: %v", err)
-					w.WriteHeader(http.StatusBadGateway)
-					return
-				}
-				defer func() { _ = resp.Body.Close() }()
-
-				respBody, err := io.ReadAll(resp.Body)
-				if err != nil {
-					t.Logf("MockOpenFaaS: failed to read proxy response: %v", err)
-					w.WriteHeader(http.StatusBadGateway)
-					return
-				}
-
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(resp.StatusCode)
-				_, _ = w.Write(respBody)
-				return
-			}
-			w.WriteHeader(http.StatusMethodNotAllowed)
-
-		default:
-			t.Logf("MockOpenFaaS: unhandled %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	return srv, invocations
-}
-
-// startOpenFaasFlask starts an openfaas-flask-base container with transformation code
-// loaded at startup via --vid and --config-backend-url. Optional extra environment
-// variables can be passed (e.g. "geolocation_url=http://...").
+// Which pair depends on where the suite runs:
 //
-// The container is purged via “t.Cleanup“ and the function blocks until the
-// fwatchdog health endpoint is responsive, so callers get a URL that is
-// immediately ready to serve requests.
-func startOpenFaasFlask(
-	t *testing.T, pool *dockertest.Pool,
-	versionID, configBackendURL string,
-	extraEnv ...string,
-) string {
-	t.Helper()
-	const containerPort = "8080"
-	cfg := newContainerConfig(t, containerPort)
-	env := []string{
-		fmt.Sprintf("fprocess=python index.py --vid %s --config-backend-url %s", versionID, toContainerURL(configBackendURL)),
-		fmt.Sprintf("port=%s", cfg.portStr(containerPort)),
-	}
-	for _, e := range extraEnv {
-		env = append(env, toContainerURL(e))
-	}
-	container, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/openfaas-flask",
-		// Pinned to match the production version
-		Tag:          "1.13.2",
-		Auth:         registry.AuthConfiguration(),
-		Env:          env,
-		ExtraHosts:   cfg.ExtraHosts,
-		PortBindings: cfg.PortBindings,
-	}, cfg.hostConfigFn)
-	require.NoError(t, err, "failed to start openfaas-flask-base container")
+//   - Locally: the image you just built with "make build-ecr-latest" in the
+//     rudder-pytransformer repo (tagged "main") against the latest release. This
+//     is the question a developer is asking — does my change regress anything?
+//   - On CI: the latest release against the one before it. CI has no locally
+//     built image, so comparing against "main" would compare a release to
+//     whatever last landed on that branch.
+//
+// Either side can be overridden to point the suite at any pair:
+//
+//	PYTRANSFORMER_CANDIDATE_TAG=0.11.0 PYTRANSFORMER_BASELINE_TAG=0.10.0 go test ...
+const (
+	pytransformerImage = "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-pytransformer"
 
-	t.Cleanup(func() {
-		if err := pool.Purge(container); err != nil {
-			t.Logf("Failed to purge openfaas-flask-base container: %v", err)
-		}
-	})
+	// localBuildTag is the tag "make build-ecr-latest" writes in the
+	// rudder-pytransformer repo, so a locally built image is picked up as-is.
+	localBuildTag = "main"
+	// latestReleaseTag and previousReleaseTag are the two most recent released
+	// rudder-pytransformer versions. Bump both when a new version ships.
+	latestReleaseTag   = "0.10.2"
+	previousReleaseTag = "0.10.1"
+)
 
-	openFaasURL := cfg.url(container, containerPort)
-	waitForOpenFaasFlask(t, pool, openFaasURL)
-	return openFaasURL
+// runningInCI reports whether the suite is running on CI rather than a
+// developer machine. Every mainstream CI provider sets CI=true.
+func runningInCI() bool {
+	inCI, err := strconv.ParseBool(os.Getenv("CI"))
+	return err == nil && inCI
 }
 
-// startRudderTransformer starts a rudder-transformer container configured to use
-// the mock config backend and mock OpenFaaS gateway. Optional extra environment
-// variables can be passed (e.g. "TRANSFORMER_TEST_MODE=true").
-// Returns the container resource and the URL to reach it from the host.
-func startRudderTransformer(
-	t *testing.T, pool *dockertest.Pool,
-	configBackendURL, openfaasGatewayURL string,
-	extraEnv ...string,
-) string {
-	t.Helper()
-	const containerPort = "9090"
-	cfg := newContainerConfig(t, containerPort)
-	env := []string{
-		"CONFIG_BACKEND_URL=" + toContainerURL(configBackendURL),
-		"OPENFAAS_GATEWAY_URL=" + toContainerURL(openfaasGatewayURL),
-		"PORT=" + cfg.portStr(containerPort),
-		"NODE_OPTIONS=--no-node-snapshot",
+// candidatePytransformerTag returns the tag under test: the local build when a
+// developer runs the suite, the latest release on CI.
+func candidatePytransformerTag() string {
+	if tag := os.Getenv("PYTRANSFORMER_CANDIDATE_TAG"); tag != "" {
+		return tag
 	}
-	env = append(env, extraEnv...)
-	container, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository:   "rudderstack/rudder-transformer",
-		Tag:          "latest",
-		Env:          env,
-		ExtraHosts:   cfg.ExtraHosts,
-		PortBindings: cfg.PortBindings,
-	}, cfg.hostConfigFn)
-	require.NoError(t, err, "failed to start rudder-transformer container")
-
-	t.Cleanup(func() {
-		if err := pool.Purge(container); err != nil {
-			t.Logf("Failed to purge rudder-transformer: %v", err)
-		}
-	})
-
-	transformerURL := cfg.url(container, containerPort)
-	waitForHealthy(t, pool, transformerURL, "rudder-transformer", container)
-
-	return transformerURL
+	if runningInCI() {
+		return latestReleaseTag
+	}
+	return localBuildTag
 }
 
-// startRudderPytransformer starts a rudder-pytransformer container configured
-// to use the mock config backend. Optional extra environment variables can be
-// passed (e.g. "GEOLOCATION_URL=http://...").
-// Returns the container resource and the URL to reach it from the host.
+// baselinePytransformerTag returns the tag the candidate is compared against:
+// the latest release locally, the release before it on CI.
+func baselinePytransformerTag() string {
+	if tag := os.Getenv("PYTRANSFORMER_BASELINE_TAG"); tag != "" {
+		return tag
+	}
+	if runningInCI() {
+		return previousReleaseTag
+	}
+	return latestReleaseTag
+}
+
+// startRudderPytransformer starts the candidate rudder-pytransformer container
+// configured to use the mock config backend. Optional extra environment
+// variables can be passed (e.g. "GEOLOCATION_URL=http://...").
+// Returns the URL to reach it from the host.
 func startRudderPytransformer(
 	t *testing.T, pool *dockertest.Pool,
 	configBackendURL string,
+	extraEnv ...string,
+) string {
+	t.Helper()
+	return startRudderPytransformerWithTag(t, pool, candidatePytransformerTag(), configBackendURL, extraEnv...)
+}
+
+// startBaselinePytransformer starts the baseline rudder-pytransformer container,
+// i.e. the released version the candidate is compared against.
+func startBaselinePytransformer(
+	t *testing.T, pool *dockertest.Pool,
+	configBackendURL string,
+	extraEnv ...string,
+) string {
+	t.Helper()
+	return startRudderPytransformerWithTag(t, pool, baselinePytransformerTag(), configBackendURL, extraEnv...)
+}
+
+// startRudderPytransformerWithTag starts a rudder-pytransformer container at an
+// explicit image tag.
+func startRudderPytransformerWithTag(
+	t *testing.T, pool *dockertest.Pool,
+	tag, configBackendURL string,
 	extraEnv ...string,
 ) string {
 	t.Helper()
@@ -550,23 +443,23 @@ func startRudderPytransformer(
 	}
 
 	container, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository:   "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-pytransformer",
-		Tag:          "main", // todo: use latest after merging https://github.com/rudderlabs/rudder-pytransformer/pull/76
+		Repository:   pytransformerImage,
+		Tag:          tag,
 		Auth:         registry.AuthConfiguration(),
 		Env:          env,
 		ExtraHosts:   cfg.ExtraHosts,
 		PortBindings: cfg.PortBindings,
 	}, cfg.hostConfigFn)
-	require.NoError(t, err, "failed to start rudder-pytransformer container")
+	require.NoErrorf(t, err, "failed to start rudder-pytransformer:%s container", tag)
 
 	t.Cleanup(func() {
 		if err := pool.Purge(container); err != nil {
-			t.Logf("Failed to purge pytransformer container: %v", err)
+			t.Logf("Failed to purge pytransformer:%s container: %v", tag, err)
 		}
 	})
 
 	pyURL := cfg.url(container, containerPort)
-	waitForHealthy(t, pool, pyURL, "rudder-pytransformer", container)
+	waitForHealthy(t, pool, pyURL, "rudder-pytransformer:"+tag, container)
 
 	return pyURL
 }
@@ -624,40 +517,6 @@ func dumpContainerLogs(t *testing.T, pool *dockertest.Pool, container *dockertes
 		return
 	}
 	t.Logf("=== %s container logs ===\n%s=== end %s logs ===", name, buf.String(), name)
-}
-
-// pollOpenFaasFlaskHealthy polls the openfaas-flask-base fwatchdog health
-// endpoint until it returns 200. fwatchdog responds to GET / with the
-// X-REQUEST-TYPE: HEALTH-CHECK header. It returns an error instead of failing
-// the test so it is safe to call from a non-test goroutine (e.g. the dynamic
-// gateway's HTTP handler).
-func pollOpenFaasFlaskHealthy(pool *dockertest.Pool, baseURL string) error {
-	return pool.Retry(func() error {
-		req, err := http.NewRequest(http.MethodGet, baseURL+"/", nil)
-		if err != nil {
-			return err
-		}
-		req.Header.Set("X-REQUEST-TYPE", "HEALTH-CHECK")
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = resp.Body.Close() }()
-		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			return fmt.Errorf("openfaas-flask health check failed: %d - %s", resp.StatusCode, string(body))
-		}
-		return nil
-	})
-}
-
-// waitForOpenFaasFlask polls the openfaas-flask-base fwatchdog health endpoint.
-// fwatchdog responds to GET / with X-REQUEST-TYPE: HEALTH-CHECK header.
-func waitForOpenFaasFlask(t *testing.T, pool *dockertest.Pool, baseURL string) {
-	t.Helper()
-	t.Logf("Waiting for openfaas-flask-base at %s to be healthy...", baseURL)
-	require.NoError(t, pollOpenFaasFlaskHealthy(pool, baseURL), "openfaas-flask-base failed to become healthy")
-	t.Logf("openfaas-flask-base is healthy at %s", baseURL)
 }
 
 // normalizeJSON re-marshals a JSON string so keys are in deterministic (sorted) order.

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -32,6 +33,59 @@ import (
 	"github.com/rudderlabs/rudder-server/processor/types"
 	"github.com/rudderlabs/rudder-server/processor/usertransformer"
 )
+
+// The suite always compares two rudder-pytransformer builds — a candidate against a baseline — so a behaviour change
+// between two PyT versions fails here the same way it would surface in a mirrored production comparison.
+//
+// Which pair to compare is the caller's decision, not this file's. Both tags are required and neither has a default:
+// a hardcoded pair silently goes stale, and the suite then keeps passing while comparing two versions nobody ships.
+//
+// TestMain rejects a run that omits either.
+//
+//   - CI resolves the two most recent released tags and exports them, so it always compares the
+//     current release against the one before it without anyone editing this file.
+//
+//   - Locally, build your image and point the candidate at it:
+//
+//     PYT_CANDIDATE_TAG=main PYT_BASELINE_TAG=0.10.2 go test ./integration_test/pytransformer_contract/...
+//
+// See README.md in this directory.
+const (
+	pytransformerImage = "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-pytransformer"
+
+	candidateTagEnv = "PYT_CANDIDATE_TAG"
+	baselineTagEnv  = "PYT_BASELINE_TAG"
+)
+
+// TestMain fails the whole package when either tag is missing.
+//
+// Every test in this package starts at least the candidate container, so there is no useful subset to
+// run without them; failing here reports the cause once instead of once per test, and before any
+// container is started.
+func TestMain(m *testing.M) {
+	var missing []string
+	for _, key := range []string{candidateTagEnv, baselineTagEnv} {
+		if os.Getenv(key) == "" {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"pytransformer contract tests: %s must be set to the rudder-pytransformer image tags to compare.\n"+
+				"Locally, build your image and run:\n"+
+				"  %s=main %s=<last released tag> go test ./integration_test/pytransformer_contract/...\n"+
+				"On CI both are resolved from the released tags and exported for you.\n",
+			strings.Join(missing, " and "), candidateTagEnv, baselineTagEnv)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
+
+// candidatePytransformerTag returns the tag under test.
+func candidatePytransformerTag() string { return os.Getenv(candidateTagEnv) }
+
+// baselinePytransformerTag returns the tag the candidate is compared against.
+func baselinePytransformerTag() string { return os.Getenv(baselineTagEnv) }
 
 // containerConfig holds platform-specific Docker container configuration.
 // On Linux, containers use host networking (sharing the host's network namespace).
@@ -334,67 +388,6 @@ func newContractConfigBackend(t *testing.T, entries map[string]configBackendEntr
 	}))
 }
 
-// The suite always compares two rudder-pytransformer builds — a candidate
-// against a baseline — so a behaviour change between two PyT versions fails here
-// the same way it would surface in a mirrored production comparison.
-//
-// Which pair depends on where the suite runs:
-//
-//   - Locally: the image you just built with "make build-ecr-latest" in the
-//     rudder-pytransformer repo (tagged "main") against the latest release. This
-//     is the question a developer is asking — does my change regress anything?
-//   - On CI: the latest release against the one before it. CI has no locally
-//     built image, so comparing against "main" would compare a release to
-//     whatever last landed on that branch.
-//
-// Either side can be overridden to point the suite at any pair:
-//
-//	PYT_CANDIDATE_TAG=0.11.0 PYT_BASELINE_TAG=0.10.0 go test ...
-//
-// See README.md in this directory for how to run the suite against your own build.
-const (
-	pytransformerImage = "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-pytransformer"
-
-	// localBuildTag is the tag "make build-ecr-latest" writes in the
-	// rudder-pytransformer repo, so a locally built image is picked up as-is.
-	localBuildTag = "main"
-	// latestReleaseTag and previousReleaseTag are the two most recent released
-	// rudder-pytransformer versions. Bump both when a new version ships.
-	latestReleaseTag   = "0.10.2"
-	previousReleaseTag = "0.10.1"
-)
-
-// runningInCI reports whether the suite is running on CI rather than a
-// developer machine. Every mainstream CI provider sets CI=true.
-func runningInCI() bool {
-	inCI, err := strconv.ParseBool(os.Getenv("CI"))
-	return err == nil && inCI
-}
-
-// candidatePytransformerTag returns the tag under test: the local build when a
-// developer runs the suite, the latest release on CI.
-func candidatePytransformerTag() string {
-	if tag := os.Getenv("PYT_CANDIDATE_TAG"); tag != "" {
-		return tag
-	}
-	if runningInCI() {
-		return latestReleaseTag
-	}
-	return localBuildTag
-}
-
-// baselinePytransformerTag returns the tag the candidate is compared against:
-// the latest release locally, the release before it on CI.
-func baselinePytransformerTag() string {
-	if tag := os.Getenv("PYT_BASELINE_TAG"); tag != "" {
-		return tag
-	}
-	if runningInCI() {
-		return previousReleaseTag
-	}
-	return latestReleaseTag
-}
-
 // startCandidatePytransformer starts the candidate rudder-pytransformer container
 // configured to use the mock config backend. Optional extra environment
 // variables can be passed (e.g. "GEOLOCATION_URL=http://...").
@@ -421,7 +414,7 @@ func startBaselinePytransformer(
 		// Panic rather than t.Fatal: most callers start the two containers from a wg.Go goroutine
 		panic(fmt.Sprintf(
 			"baseline and candidate both resolved to rudder-pytransformer:%s — every comparison in this suite "+
-				"would pass without testing anything. Bump latestReleaseTag/previousReleaseTag, or set "+
+				"would pass without testing anything. Set "+
 				"PYT_BASELINE_TAG and PYT_CANDIDATE_TAG to different tags.", baseline))
 	}
 	t.Logf("Comparing rudder-pytransformer baseline=%s against candidate=%s", baseline, candidate)

--- a/integration_test/pytransformer_contract/bc_helpers_test.go
+++ b/integration_test/pytransformer_contract/bc_helpers_test.go
@@ -322,10 +322,27 @@ func makeEvents(versionID string, n int, libraryVersionIDs ...string) []types.Tr
 //
 // When statusCode is non-zero, the config backend returns that status code with body
 // as the raw response body (no JSON envelope).
+// contractLibrary is a user transformation library the mock config backend serves from
+// /transformationLibrary/getByVersionId, so contract tests can exercise library-importing transformations
+// (the event must also carry the library version ids in its Libraries — see makeEvents).
+type contractLibrary struct {
+	versionID  string
+	importName string
+	code       string
+}
+
 type configBackendEntry struct {
 	statusCode int
 	body       string
 	code       string
+	// libraries this transformation imports; served by version id from the mock config backend.
+	libraries []contractLibrary
+}
+
+// isZero reports whether the entry is the zero value (nothing configured). Used instead of == because the
+// struct carries a slice field and is therefore no longer comparable.
+func (e configBackendEntry) isZero() bool {
+	return e.statusCode == 0 && e.body == "" && e.code == "" && len(e.libraries) == 0
 }
 
 // newContractConfigBackend creates a mock config backend that serves
@@ -336,6 +353,14 @@ type configBackendEntry struct {
 // field.
 func newContractConfigBackend(t *testing.T, entries map[string]configBackendEntry) *httptest.Server {
 	t.Helper()
+	// Library registry keyed by library versionId, deduped across all transformation entries, so the mock
+	// can serve /transformationLibrary/getByVersionId (pytransformer fetches each library the event lists).
+	libByVersion := map[string]contractLibrary{}
+	for _, e := range entries {
+		for _, lib := range e.libraries {
+			libByVersion[lib.versionID] = lib
+		}
+	}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/transformation/getByVersionId":
@@ -379,8 +404,26 @@ func newContractConfigBackend(t *testing.T, entries map[string]configBackendEntr
 				t.Errorf("ConfigBackend: failed to encode response: %v", err)
 			}
 		case "/transformationLibrary/getByVersionId":
-			t.Logf("ConfigBackend: library request for %s (not configured)", r.URL.Query().Get("versionId"))
-			w.WriteHeader(http.StatusNotFound)
+			versionID := r.URL.Query().Get("versionId")
+			lib, ok := libByVersion[versionID]
+			if !ok {
+				t.Logf("ConfigBackend: unknown library versionId %q", versionID)
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			t.Logf("ConfigBackend: serving library %q (importName %q)", versionID, lib.importName)
+			w.Header().Set("Content-Type", "application/json")
+			resp := map[string]any{
+				"versionId":   lib.versionID,
+				"importName":  lib.importName,
+				"handleName":  lib.importName,
+				"code":        lib.code,
+				"language":    "pythonfaas",
+				"codeVersion": "1",
+			}
+			if err := jsonrs.NewEncoder(w).Encode(resp); err != nil {
+				t.Errorf("ConfigBackend: failed to encode library response: %v", err)
+			}
 		default:
 			t.Logf("ConfigBackend: unexpected path %s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)

--- a/integration_test/pytransformer_contract/benchmark_helpers_test.go
+++ b/integration_test/pytransformer_contract/benchmark_helpers_test.go
@@ -35,10 +35,10 @@ type pytransformerEndpoints struct {
 	metricsURL string
 }
 
-// startRudderPytransformerWithTag is a copy of startRudderPytransformer that
+// startBenchPytransformerWithTag is a copy of startRudderPytransformerWithTag that
 // accepts an explicit image tag and ALSO binds the Prometheus metrics port
 // so benchmarks can scrape it. Returns both URLs.
-func startRudderPytransformerWithTag(
+func startBenchPytransformerWithTag(
 	t *testing.T,
 	pool *dockertest.Pool,
 	tag string,
@@ -75,7 +75,7 @@ func startRudderPytransformerWithTag(
 	}
 
 	container, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository:   "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-pytransformer",
+		Repository:   pytransformerImage,
 		Tag:          tag,
 		Auth:         registry.AuthConfiguration(),
 		Env:          env,

--- a/integration_test/pytransformer_contract/config_backend_auth_test.go
+++ b/integration_test/pytransformer_contract/config_backend_auth_test.go
@@ -92,7 +92,7 @@ func TestConfigBackendAuthWithoutHostedSecret(t *testing.T) {
 
 	// No CONFIG_BACKEND_HOSTED_SECRET passed at all — not empty, absent. This is the
 	// pre-change deployment, and every self-hosted one.
-	pyURL := startRudderPytransformer(t, pool, cb.server.URL)
+	pyURL := startCandidatePytransformer(t, pool, cb.server.URL)
 
 	t.Run("public unauthenticated routes are reached with no Authorization header", func(t *testing.T) {
 		const versionID = "cbauth-nosecret-public-v1"
@@ -172,7 +172,7 @@ func TestConfigBackendAuthWithHostedSecret(t *testing.T) {
 	require.NoError(t, err)
 
 	cb := newConfigBackendAuthMock(t, cbAuthSecret, cbAuthOtherSecret)
-	pyURL := startRudderPytransformer(t, pool, cb.server.URL,
+	pyURL := startCandidatePytransformer(t, pool, cb.server.URL,
 		"CONFIG_BACKEND_HOSTED_SECRET="+cbAuthSecret)
 
 	// What the config backend must receive, spelled out rather than recomputed from the same
@@ -258,7 +258,7 @@ func TestConfigBackendAuthWithWrongHostedSecret(t *testing.T) {
 
 	cb := newConfigBackendAuthMock(t, cbAuthSecret, cbAuthOtherSecret)
 	cb.setMode(cbModeHostedSecret)
-	pyURL := startRudderPytransformer(t, pool, cb.server.URL,
+	pyURL := startCandidatePytransformer(t, pool, cb.server.URL,
 		"CONFIG_BACKEND_HOSTED_SECRET=py-contract-hosted-secret-rotated-away")
 
 	const versionID = "cbauth-wrongsecret-v1"
@@ -293,7 +293,7 @@ func TestConfigBackendHostedSecretTrailingNewlineIsTrimmed(t *testing.T) {
 
 	cb := newConfigBackendAuthMock(t, cbAuthSecret)
 	cb.setMode(cbModeHostedSecret)
-	pyURL := startRudderPytransformer(t, pool, cb.server.URL,
+	pyURL := startCandidatePytransformer(t, pool, cb.server.URL,
 		"CONFIG_BACKEND_HOSTED_SECRET="+cbAuthSecret+"\n")
 
 	const versionID = "cbauth-trailing-newline-v1"

--- a/integration_test/pytransformer_contract/config_backend_auth_test.go
+++ b/integration_test/pytransformer_contract/config_backend_auth_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 )
 
-// This file pins what CONFIG_BACKEND_HOSTED_SECRET does to the wire, both variants, against a
+// This file pins what CONFIG_BACKEND_TRANSFORMER_SERVICE_SECRET does to the wire, both variants, against a
 // mock config backend ported from ../rudder-config-backend rather than invented here (see
 // configBackendAuthMock below for the file-by-file provenance).
 //
@@ -76,7 +76,7 @@ def transformEvent(event, metadata):
 )
 
 // TestConfigBackendAuthWithoutHostedSecret is the regression guard for the change being
-// additive: with CONFIG_BACKEND_HOSTED_SECRET absent from the environment, pytransformer must
+// additive: with CONFIG_BACKEND_TRANSFORMER_SERVICE_SECRET absent from the environment, pytransformer must
 // talk to the config backend exactly as the build before it did.
 //
 // The assertion that carries the claim is not "it still works" — it is that every request the
@@ -90,7 +90,7 @@ func TestConfigBackendAuthWithoutHostedSecret(t *testing.T) {
 
 	cb := newConfigBackendAuthMock(t, cbAuthSecret, cbAuthOtherSecret)
 
-	// No CONFIG_BACKEND_HOSTED_SECRET passed at all — not empty, absent. This is the
+	// No CONFIG_BACKEND_TRANSFORMER_SERVICE_SECRET passed at all — not empty, absent. This is the
 	// pre-change deployment, and every self-hosted one.
 	pyURL := startCandidatePytransformer(t, pool, cb.server.URL)
 
@@ -113,7 +113,7 @@ func TestConfigBackendAuthWithoutHostedSecret(t *testing.T) {
 		require.NotEmpty(t, seen, "config backend was never asked for the transformation code")
 		for _, r := range seen {
 			require.Empty(t, r.authorization,
-				"an unset CONFIG_BACKEND_HOSTED_SECRET must send no Authorization header at all")
+				"an unset CONFIG_BACKEND_TRANSFORMER_SERVICE_SECRET must send no Authorization header at all")
 			require.Equal(t, versionID, r.versionID)
 		}
 	})
@@ -173,7 +173,7 @@ func TestConfigBackendAuthWithHostedSecret(t *testing.T) {
 
 	cb := newConfigBackendAuthMock(t, cbAuthSecret, cbAuthOtherSecret)
 	pyURL := startCandidatePytransformer(t, pool, cb.server.URL,
-		"CONFIG_BACKEND_HOSTED_SECRET="+cbAuthSecret)
+		"CONFIG_BACKEND_TRANSFORMER_SERVICE_SECRET="+cbAuthSecret)
 
 	// What the config backend must receive, spelled out rather than recomputed from the same
 	// helper the assertion is checking: the secret is the username and the password is empty.
@@ -259,7 +259,7 @@ func TestConfigBackendAuthWithWrongHostedSecret(t *testing.T) {
 	cb := newConfigBackendAuthMock(t, cbAuthSecret, cbAuthOtherSecret)
 	cb.setMode(cbModeHostedSecret)
 	pyURL := startCandidatePytransformer(t, pool, cb.server.URL,
-		"CONFIG_BACKEND_HOSTED_SECRET=py-contract-hosted-secret-rotated-away")
+		"CONFIG_BACKEND_TRANSFORMER_SERVICE_SECRET=py-contract-hosted-secret-rotated-away")
 
 	const versionID = "cbauth-wrongsecret-v1"
 	status, headers, items := sendRawTransform(t, pyURL, makeEvents(versionID, 3))
@@ -294,7 +294,7 @@ func TestConfigBackendHostedSecretTrailingNewlineIsTrimmed(t *testing.T) {
 	cb := newConfigBackendAuthMock(t, cbAuthSecret)
 	cb.setMode(cbModeHostedSecret)
 	pyURL := startCandidatePytransformer(t, pool, cb.server.URL,
-		"CONFIG_BACKEND_HOSTED_SECRET="+cbAuthSecret+"\n")
+		"CONFIG_BACKEND_TRANSFORMER_SERVICE_SECRET="+cbAuthSecret+"\n")
 
 	const versionID = "cbauth-trailing-newline-v1"
 	status, _, items := sendRawTransform(t, pyURL, makeEvents(versionID, 1))

--- a/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
+++ b/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
@@ -80,7 +80,7 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, entries)
 	t.Cleanup(configBackend.Close)
 
-	pyURL := startRudderPytransformer(
+	pyURL := startCandidatePytransformer(
 		t, pool, configBackend.URL,
 		// Single worker subprocess so every /customTransform request is
 		// dispatched through the SAME _user_session. Any cookie
@@ -231,11 +231,10 @@ func TestConnectionPoolRequestOptionIsolation(t *testing.T) {
 
 	echoSrv, newConns := newSessionDefaultsEchoServer(t)
 
-	// User code: every `transformEvent` invocation issues two sequential
-	// requests. The first primes a vanilla `requests.Session` with every
-	// per-request option `requests` supports; the second issues a bare
-	// GET. If any option persisted to session state — on the baseline	// vanilla session OR the candidate `StatelessPooledSession` — the
-	// second call would observe it and the parity check would fail.
+	// User code: every `transformEvent` invocation issues two sequential requests.
+	// The first primes a vanilla `requests.Session` with every per-request option `requests` supports; the second
+	// issues a bare GET. If any option persisted to session state — on either version's session implementation —
+	// the second call would observe it and the parity check would fail.
 	code := fmt.Sprintf(`
 import requests
 
@@ -309,7 +308,7 @@ def transformEvent(event, metadata):
 	baselineURL := startBaselinePytransformer(t, pool, configBackend.URL, pytEnv...)
 
 	t.Log("Starting candidate rudder-pytransformer...")
-	candidateURL := startRudderPytransformer(t, pool, configBackend.URL, pytEnv...)
+	candidateURL := startCandidatePytransformer(t, pool, configBackend.URL, pytEnv...)
 
 	env := newBCTestEnv(t, baselineURL, candidateURL,
 		withFailOnError(),
@@ -320,8 +319,8 @@ def transformEvent(event, metadata):
 	baselineResp := env.BaselineClient.Transform(context.Background(), events)
 	t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-	// Only the NEW-arch run's TCP activity counts toward the pool reuse
-	// assertion — reset the counter so every connection the baseline	// stack opened to the shared echo server is excluded.
+	// Only the candidate run's TCP activity counts toward the pool reuse assertion — reset the counter so every
+	// connection the baseline opened to the shared echo server is excluded.
 	newConns.Store(0)
 
 	t.Log("Sending batch to candidate (rudder-pytransformer)...")
@@ -366,13 +365,11 @@ def transformEvent(event, metadata):
 		}
 	}
 
-	// Core isolation assertion: the second bare GET, issued without any
-	// options, must see NONE of the state the first call attached.
-	// Vanilla `requests.Session` does not persist per-request kwargs,
-	// so the baseline passes this trivially; `StatelessPooledSession`
-	// must match that guarantee on the candidate pooled path. Per-field
-	// asserts keep failure output actionable; `Equal` below is the
-	// strict parity catch-all.
+	// Core isolation assertion: the second bare GET, issued without any options, must see NONE of the state the first
+	// call attached.
+	// Per-request kwargs must not persist into the session, on either version: that is the guarantee
+	// `StatelessPooledSession` has to preserve on the pooled path.
+	// Per-field asserts keep failure output actionable; `Equal` below is the strict parity catch-all.
 	for _, resp := range []*types.Response{&baselineResp, &candidateResp} {
 		for _, ev := range resp.Events {
 			require.Emptyf(t, ev.Output["second_x_leak"],

--- a/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
+++ b/integration_test/pytransformer_contract/cookie_isolation_contract_test.go
@@ -188,23 +188,23 @@ def transformEvent(event, metadata):
 		parallelRequests, newConns.Load())
 }
 
-// TestConnectionPoolRequestOptionIsolation locks the cross-architecture
+// TestConnectionPoolRequestOptionIsolation locks the cross-version
 // contract that per-request options attached to a bare “requests.<verb>“
 // call never become defaults on the user-facing HTTP session.
 //
 // The goal is parity, not a one-sided property check. The same
 // transformation code runs through two stacks:
 //
-//  1. Old arch — rudder-transformer + openfaas-flask-base (vanilla
-//     “requests“ inside the OpenFaaS container).
-//  2. New arch — rudder-pytransformer routing every bare call through a
+//  1. Baseline — the last released rudder-pytransformer (the reference
+//     behaviour the candidate must match).
+//  2. Candidate — rudder-pytransformer routing every bare call through a
 //     “StatelessPooledSession“ pinned to a single TCP socket. This is
 //     the path that could regress if the pooling wrapper ever started
 //     persisting “headers“ / “auth“ / “params“ / “cookies“ / “hooks“
 //     onto the shared session.
 //
 // Both stacks must produce the exact same “types.Response“, so any drift
-// introduced by the pooling layer surfaces via “oldResp.Equal(&newResp)“.
+// introduced by the pooling layer surfaces via “baselineResp.Equal(&candidateResp)“.
 //
 // The batch of transformation events is larger than one so the assertion
 // covers cross-transformation isolation on the shared session, not only
@@ -234,8 +234,7 @@ func TestConnectionPoolRequestOptionIsolation(t *testing.T) {
 	// User code: every `transformEvent` invocation issues two sequential
 	// requests. The first primes a vanilla `requests.Session` with every
 	// per-request option `requests` supports; the second issues a bare
-	// GET. If any option persisted to session state — on the old-arch
-	// vanilla session OR the new-arch `StatelessPooledSession` — the
+	// GET. If any option persisted to session state — on the baseline	// vanilla session OR the candidate `StatelessPooledSession` — the
 	// second call would observe it and the parity check would fail.
 	code := fmt.Sprintf(`
 import requests
@@ -291,67 +290,56 @@ def transformEvent(event, metadata):
 	})
 	t.Cleanup(configBackend.Close)
 
-	// --- Old architecture (rudder-transformer + openfaas-flask-base) ---
-	//
-	// Becomes the reference behaviour the new arch must match.
-
-	t.Log("Starting openfaas-flask-base (old arch backend)...")
-	openFaasURL := startOpenFaasFlask(t, pool, versionID, configBackend.URL)
-
-	t.Log("Starting mock OpenFaaS gateway...")
-	mockGateway, _ := newMockOpenFaaSGateway(t, func() string { return openFaasURL })
-	t.Cleanup(mockGateway.Close)
-
-	t.Log("Starting rudder-transformer (old arch frontend)...")
-	transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
-
 	events := make([]types.TransformerEvent, numEvents)
 	for i := range events {
 		events[i] = makeEvent(fmt.Sprintf("msg-req-opt-iso-%d", i), versionID)
 	}
 
-	// --- New architecture (rudder-pytransformer) ---
-	//
 	// Every bare requests.<verb> call routes through StatelessPooledSession.
 	// Pin SANDBOX_POOL_MAX_SIZE=1 and USER_CONN_POOL_MAX_SIZE=1 so the
 	// test actually exercises the shared-session path, not a fresh
-	// session per subprocess.
-	pyTransformerURL := startRudderPytransformer(
-		t, pool, configBackend.URL,
+	// session per subprocess. Identical on both sides so the comparison
+	// isolates the version difference.
+	pytEnv := []string{
 		"SANDBOX_POOL_MAX_SIZE=1",
 		"USER_CONN_POOL_MAX_SIZE=1",
-	)
+	}
 
-	env := newBCTestEnv(t, transformerURL, pyTransformerURL,
+	t.Log("Starting baseline rudder-pytransformer...")
+	baselineURL := startBaselinePytransformer(t, pool, configBackend.URL, pytEnv...)
+
+	t.Log("Starting candidate rudder-pytransformer...")
+	candidateURL := startRudderPytransformer(t, pool, configBackend.URL, pytEnv...)
+
+	env := newBCTestEnv(t, baselineURL, candidateURL,
 		withFailOnError(),
 		withLimitedRetryableHTTPRetries(),
 	)
 
-	t.Log("Sending batch to old arch (openfaas-flask-base)...")
-	oldResp := env.OldClient.Transform(context.Background(), events)
-	t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+	t.Log("Sending batch to baseline pytransformer...")
+	baselineResp := env.BaselineClient.Transform(context.Background(), events)
+	t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
 	// Only the NEW-arch run's TCP activity counts toward the pool reuse
-	// assertion — reset the counter so every connection the old-arch
-	// stack opened to the shared echo server is excluded.
+	// assertion — reset the counter so every connection the baseline	// stack opened to the shared echo server is excluded.
 	newConns.Store(0)
 
-	t.Log("Sending batch to new arch (rudder-pytransformer)...")
-	newResp := env.NewClient.Transform(context.Background(), events)
-	t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+	t.Log("Sending batch to candidate (rudder-pytransformer)...")
+	candidateResp := env.CandidateClient.Transform(context.Background(), events)
+	t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-	require.Equalf(t, numEvents, len(oldResp.Events), "old arch: all %d events must succeed", numEvents)
-	require.Empty(t, oldResp.FailedEvents, "old arch: no failed events expected")
-	require.Equalf(t, numEvents, len(newResp.Events),
-		"new arch: all %d events must succeed", numEvents)
-	require.Empty(t, newResp.FailedEvents, "new arch: no failed events expected")
+	require.Equalf(t, numEvents, len(baselineResp.Events), "baseline: all %d events must succeed", numEvents)
+	require.Empty(t, baselineResp.FailedEvents, "baseline: no failed events expected")
+	require.Equalf(t, numEvents, len(candidateResp.Events),
+		"candidate: all %d events must succeed", numEvents)
+	require.Empty(t, candidateResp.FailedEvents, "candidate: no failed events expected")
 
 	// Proof-of-mechanism: every event on BOTH stacks must have carried
 	// the full set of per-request options on its first call. Without
 	// these checks, a regression that stopped the mock echo from
 	// observing any single option would make the isolation parity check
 	// below vacuously true for that option.
-	for _, resp := range []*types.Response{&oldResp, &newResp} {
+	for _, resp := range []*types.Response{&baselineResp, &candidateResp} {
 		for _, ev := range resp.Events {
 			require.Equalf(t, "1", ev.Output["first_x_leak"],
 				"msg=%s: first request must carry X-Leak header",
@@ -359,7 +347,7 @@ def transformEvent(event, metadata):
 			// Exact match (rather than NotEmpty) — base64("user:pass").
 			// A malformed Authorization header would still be
 			// non-empty but would silently diverge from the
-			// old-arch reference.
+			// baseline reference.
 			require.Equalf(t, "Basic dXNlcjpwYXNz", ev.Output["first_authorization"],
 				"msg=%s: first request must carry Basic user:pass auth",
 				ev.Metadata.MessageID)
@@ -381,11 +369,11 @@ def transformEvent(event, metadata):
 	// Core isolation assertion: the second bare GET, issued without any
 	// options, must see NONE of the state the first call attached.
 	// Vanilla `requests.Session` does not persist per-request kwargs,
-	// so the old arch passes this trivially; `StatelessPooledSession`
-	// must match that guarantee on the new-arch pooled path. Per-field
+	// so the baseline passes this trivially; `StatelessPooledSession`
+	// must match that guarantee on the candidate pooled path. Per-field
 	// asserts keep failure output actionable; `Equal` below is the
 	// strict parity catch-all.
-	for _, resp := range []*types.Response{&oldResp, &newResp} {
+	for _, resp := range []*types.Response{&baselineResp, &candidateResp} {
 		for _, ev := range resp.Events {
 			require.Emptyf(t, ev.Output["second_x_leak"],
 				"msg=%s: header must not carry into the next request",
@@ -405,14 +393,14 @@ def transformEvent(event, metadata):
 		}
 	}
 
-	// Strict parity: old arch and new arch must produce identical
+	// Strict parity: baseline and candidate must produce identical
 	// responses field-for-field. Any divergence the per-field asserts
 	// above missed (e.g. a difference in `Metadata`, `StatTags`, or
 	// an Output key that was added to the transformation code but not
 	// to this test) surfaces here.
-	diff, equal := oldResp.Equal(&newResp)
+	diff, equal := baselineResp.Equal(&candidateResp)
 	require.Truef(t, equal,
-		"old and new architectures must produce identical responses:\n%s", diff)
+		"baseline and candidate must produce identical responses:\n%s", diff)
 
 	env.assertRetryCountsMatch(t)
 

--- a/integration_test/pytransformer_contract/dns_cache_contract_test.go
+++ b/integration_test/pytransformer_contract/dns_cache_contract_test.go
@@ -68,7 +68,7 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, entries)
 	t.Cleanup(configBackend.Close)
 
-	pyURL := startRudderPytransformer(
+	pyURL := startCandidatePytransformer(
 		t, pool, configBackend.URL,
 		"DNS_CACHE_ENABLED=true",
 		"DNS_CACHE_TTL_S=300",
@@ -217,7 +217,7 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, entries)
 	t.Cleanup(configBackend.Close)
 
-	pyURL := startRudderPytransformer(
+	pyURL := startCandidatePytransformer(
 		t, pool, configBackend.URL,
 		"DNS_OVERRIDES=custom-api.test,"+hostIP,
 	)
@@ -306,7 +306,7 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, entries)
 	t.Cleanup(configBackend.Close)
 
-	pyURL := startRudderPytransformer(
+	pyURL := startCandidatePytransformer(
 		t, pool, configBackend.URL,
 		"DNS_CACHE_ENABLED=true",
 		"DNS_CACHE_TTL_S=300",

--- a/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
@@ -14,14 +14,13 @@ import (
 )
 
 // TestBackwardsCompatibilityGeolocation compares geolocation() behavior between
-// the old architecture (rudder-transformer + openfaas-flask-base) and the new
-// architecture (rudder-pytransformer).
+// the baseline rudder-pytransformer and the candidate one.
 //
 // Both implementations expose a geolocation(ip) function to user transformation
 // code that calls an external geolocation service at {base_url}/geoip/{ip}.
 //
 // This test starts a rudder-geolocation container and configures both
-// architectures to use it, then exercises all edge cases.
+// versions to use it, then exercises all edge cases.
 func TestBackwardsCompatibilityGeolocation(t *testing.T) {
 	type subtest struct {
 		name      string
@@ -47,31 +46,31 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
-				require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
+				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
 				// Verify geo data was returned with correct IP
-				oldGeo, _ := oldResp.Events[0].Output["geo"].(map[string]any)
-				newGeo, _ := newResp.Events[0].Output["geo"].(map[string]any)
-				require.Equal(t, "1.2.3.4", oldGeo["ip"], "old arch: geo should contain correct ip")
-				require.Equal(t, "1.2.3.4", newGeo["ip"], "new arch: geo should contain correct ip")
+				oldGeo, _ := baselineResp.Events[0].Output["geo"].(map[string]any)
+				newGeo, _ := candidateResp.Events[0].Output["geo"].(map[string]any)
+				require.Equal(t, "1.2.3.4", oldGeo["ip"], "baseline: geo should contain correct ip")
+				require.Equal(t, "1.2.3.4", newGeo["ip"], "candidate: geo should contain correct ip")
 
-				t.Logf("Old arch geo: %v", oldResp.Events[0].Output["geo"])
-				t.Logf("New arch geo: %v", newResp.Events[0].Output["geo"])
+				t.Logf("Baseline geo: %v", baselineResp.Events[0].Output["geo"])
+				t.Logf("Candidate geo: %v", candidateResp.Events[0].Output["geo"])
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for valid IP geolocation")
+					t.Log("Both versions produce identical responses for valid IP geolocation")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -96,30 +95,30 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				t.Log("Sending request to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending request to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending request to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending request to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Both should succeed (error caught by try/except)
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
 				// Both should have geo_error containing the validation message
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				newError, _ := newResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				t.Logf("New arch geo_error: %q", newError)
+				baselineError, _ := baselineResp.Events[0].Output["geo_error"].(string)
+				candidateError, _ := candidateResp.Events[0].Output["geo_error"].(string)
+				t.Logf("Baseline geo_error: %q", baselineError)
+				t.Logf("Candidate geo_error: %q", candidateError)
 
-				require.Contains(t, oldError, "single string argument", "old arch: error should mention single string argument")
-				require.Contains(t, newError, "single string argument", "new arch: error should mention single string argument")
+				require.Contains(t, baselineError, "single string argument", "baseline: error should mention single string argument")
+				require.Contains(t, candidateError, "single string argument", "candidate: error should mention single string argument")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for geolocation with no args")
+					t.Log("Both versions produce identical responses for geolocation with no args")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -144,25 +143,25 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				newError, _ := newResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				t.Logf("New arch geo_error: %q", newError)
+				baselineError, _ := baselineResp.Events[0].Output["geo_error"].(string)
+				candidateError, _ := candidateResp.Events[0].Output["geo_error"].(string)
+				t.Logf("Baseline geo_error: %q", baselineError)
+				t.Logf("Candidate geo_error: %q", candidateError)
 
-				require.Contains(t, oldError, "single string argument", "old arch: error should mention single string argument")
-				require.Contains(t, newError, "single string argument", "new arch: error should mention single string argument")
+				require.Contains(t, baselineError, "single string argument", "baseline: error should mention single string argument")
+				require.Contains(t, candidateError, "single string argument", "candidate: error should mention single string argument")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for geolocation with multiple args")
+					t.Log("Both versions produce identical responses for geolocation with multiple args")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -187,25 +186,25 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				newError, _ := newResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				t.Logf("New arch geo_error: %q", newError)
+				baselineError, _ := baselineResp.Events[0].Output["geo_error"].(string)
+				candidateError, _ := candidateResp.Events[0].Output["geo_error"].(string)
+				t.Logf("Baseline geo_error: %q", baselineError)
+				t.Logf("Candidate geo_error: %q", candidateError)
 
-				require.Contains(t, oldError, "single string argument", "old arch: error should mention single string argument")
-				require.Contains(t, newError, "single string argument", "new arch: error should mention single string argument")
+				require.Contains(t, baselineError, "single string argument", "baseline: error should mention single string argument")
+				require.Contains(t, candidateError, "single string argument", "candidate: error should mention single string argument")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for geolocation with non-string arg")
+					t.Log("Both versions produce identical responses for geolocation with non-string arg")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -230,25 +229,25 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				newError, _ := newResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				t.Logf("New arch geo_error: %q", newError)
+				baselineError, _ := baselineResp.Events[0].Output["geo_error"].(string)
+				candidateError, _ := candidateResp.Events[0].Output["geo_error"].(string)
+				t.Logf("Baseline geo_error: %q", baselineError)
+				t.Logf("Candidate geo_error: %q", candidateError)
 
-				require.Contains(t, oldError, "single string argument", "old arch: error should mention single string argument")
-				require.Contains(t, newError, "single string argument", "new arch: error should mention single string argument")
+				require.Contains(t, baselineError, "single string argument", "baseline: error should mention single string argument")
+				require.Contains(t, candidateError, "single string argument", "candidate: error should mention single string argument")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for geolocation with None arg")
+					t.Log("Both versions produce identical responses for geolocation with None arg")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -273,25 +272,25 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				newError, _ := newResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				t.Logf("New arch geo_error: %q", newError)
+				baselineError, _ := baselineResp.Events[0].Output["geo_error"].(string)
+				candidateError, _ := candidateResp.Events[0].Output["geo_error"].(string)
+				t.Logf("Baseline geo_error: %q", baselineError)
+				t.Logf("Candidate geo_error: %q", candidateError)
 
-				require.Contains(t, oldError, "single string argument", "old arch: error should mention single string argument")
-				require.Contains(t, newError, "single string argument", "new arch: error should mention single string argument")
+				require.Contains(t, baselineError, "single string argument", "baseline: error should mention single string argument")
+				require.Contains(t, candidateError, "single string argument", "candidate: error should mention single string argument")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for geolocation with list arg")
+					t.Log("Both versions produce identical responses for geolocation with list arg")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -316,26 +315,26 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				newError, _ := newResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				t.Logf("New arch geo_error: %q", newError)
+				baselineError, _ := baselineResp.Events[0].Output["geo_error"].(string)
+				candidateError, _ := candidateResp.Events[0].Output["geo_error"].(string)
+				t.Logf("Baseline geo_error: %q", baselineError)
+				t.Logf("Candidate geo_error: %q", candidateError)
 
 				// In Python, isinstance(True, str) is False, so bool should be rejected
-				require.Contains(t, oldError, "single string argument", "old arch: error should mention single string argument")
-				require.Contains(t, newError, "single string argument", "new arch: error should mention single string argument")
+				require.Contains(t, baselineError, "single string argument", "baseline: error should mention single string argument")
+				require.Contains(t, candidateError, "single string argument", "candidate: error should mention single string argument")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for geolocation with bool arg")
+					t.Log("Both versions produce identical responses for geolocation with bool arg")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -360,25 +359,25 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				newError, _ := newResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				t.Logf("New arch geo_error: %q", newError)
+				baselineError, _ := baselineResp.Events[0].Output["geo_error"].(string)
+				candidateError, _ := candidateResp.Events[0].Output["geo_error"].(string)
+				t.Logf("Baseline geo_error: %q", baselineError)
+				t.Logf("Candidate geo_error: %q", candidateError)
 
-				require.Contains(t, oldError, "single string argument", "old arch: error should mention single string argument")
-				require.Contains(t, newError, "single string argument", "new arch: error should mention single string argument")
+				require.Contains(t, baselineError, "single string argument", "baseline: error should mention single string argument")
+				require.Contains(t, candidateError, "single string argument", "candidate: error should mention single string argument")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for geolocation with dict arg")
+					t.Log("Both versions produce identical responses for geolocation with dict arg")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -403,24 +402,24 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Empty string passes isinstance(args[0], str) check but the geolocation
 				// service will likely return an error for an empty IP.
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				t.Logf("Old arch output: geo=%v, geo_error=%v",
-					oldResp.Events[0].Output["geo"], oldResp.Events[0].Output["geo_error"])
-				t.Logf("New arch output: geo=%v, geo_error=%v",
-					newResp.Events[0].Output["geo"], newResp.Events[0].Output["geo_error"])
+				t.Logf("Baseline output: geo=%v, geo_error=%v",
+					baselineResp.Events[0].Output["geo"], baselineResp.Events[0].Output["geo_error"])
+				t.Logf("Candidate output: geo=%v, geo_error=%v",
+					candidateResp.Events[0].Output["geo"], candidateResp.Events[0].Output["geo_error"])
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for geolocation with empty string")
+					t.Log("Both versions produce identical responses for geolocation with empty string")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -447,32 +446,32 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
 				// Both should have two different geo results with correct IPs
-				oldGeo1, _ := oldResp.Events[0].Output["geo1"].(map[string]any)
-				oldGeo2, _ := oldResp.Events[0].Output["geo2"].(map[string]any)
-				newGeo1, _ := newResp.Events[0].Output["geo1"].(map[string]any)
-				newGeo2, _ := newResp.Events[0].Output["geo2"].(map[string]any)
-				require.Equal(t, "1.2.3.4", oldGeo1["ip"], "old arch: geo1 should contain correct ip")
-				require.Equal(t, "8.8.8.8", oldGeo2["ip"], "old arch: geo2 should contain correct ip")
-				require.Equal(t, "1.2.3.4", newGeo1["ip"], "new arch: geo1 should contain correct ip")
-				require.Equal(t, "8.8.8.8", newGeo2["ip"], "new arch: geo2 should contain correct ip")
+				oldGeo1, _ := baselineResp.Events[0].Output["geo1"].(map[string]any)
+				oldGeo2, _ := baselineResp.Events[0].Output["geo2"].(map[string]any)
+				newGeo1, _ := candidateResp.Events[0].Output["geo1"].(map[string]any)
+				newGeo2, _ := candidateResp.Events[0].Output["geo2"].(map[string]any)
+				require.Equal(t, "1.2.3.4", oldGeo1["ip"], "baseline: geo1 should contain correct ip")
+				require.Equal(t, "8.8.8.8", oldGeo2["ip"], "baseline: geo2 should contain correct ip")
+				require.Equal(t, "1.2.3.4", newGeo1["ip"], "candidate: geo1 should contain correct ip")
+				require.Equal(t, "8.8.8.8", newGeo2["ip"], "candidate: geo2 should contain correct ip")
 
-				t.Logf("Old arch geo1: %v", oldResp.Events[0].Output["geo1"])
-				t.Logf("Old arch geo2: %v", oldResp.Events[0].Output["geo2"])
-				t.Logf("New arch geo1: %v", newResp.Events[0].Output["geo1"])
-				t.Logf("New arch geo2: %v", newResp.Events[0].Output["geo2"])
+				t.Logf("Baseline geo1: %v", baselineResp.Events[0].Output["geo1"])
+				t.Logf("Baseline geo2: %v", baselineResp.Events[0].Output["geo2"])
+				t.Logf("Candidate geo1: %v", candidateResp.Events[0].Output["geo1"])
+				t.Logf("Candidate geo2: %v", candidateResp.Events[0].Output["geo2"])
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for multiple geolocation calls")
+					t.Log("Both versions produce identical responses for multiple geolocation calls")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -497,21 +496,21 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
 				// Same IP should produce same result both times
-				require.Equal(t, true, oldResp.Events[0].Output["same"], "old arch: same IP should produce same result")
-				require.Equal(t, true, newResp.Events[0].Output["same"], "new arch: same IP should produce same result")
+				require.Equal(t, true, baselineResp.Events[0].Output["same"], "baseline: same IP should produce same result")
+				require.Equal(t, true, candidateResp.Events[0].Output["same"], "candidate: same IP should produce same result")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for same IP called twice")
+					t.Log("Both versions produce identical responses for same IP called twice")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -557,28 +556,28 @@ def transformEvent(event, metadata):
 					},
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
 				// Verify geo data was placed in context.geo with correct IP
-				oldCtx, _ := oldResp.Events[0].Output["context"].(map[string]any)
-				newCtx, _ := newResp.Events[0].Output["context"].(map[string]any)
+				oldCtx, _ := baselineResp.Events[0].Output["context"].(map[string]any)
+				newCtx, _ := candidateResp.Events[0].Output["context"].(map[string]any)
 				oldGeo, _ := oldCtx["geo"].(map[string]any)
 				newGeo, _ := newCtx["geo"].(map[string]any)
-				require.Equal(t, "8.8.8.8", oldGeo["ip"], "old arch: context.geo should contain correct ip")
-				require.Equal(t, "8.8.8.8", newGeo["ip"], "new arch: context.geo should contain correct ip")
+				require.Equal(t, "8.8.8.8", oldGeo["ip"], "baseline: context.geo should contain correct ip")
+				require.Equal(t, "8.8.8.8", newGeo["ip"], "candidate: context.geo should contain correct ip")
 
-				t.Logf("Old arch context.geo: %v", oldCtx["geo"])
-				t.Logf("New arch context.geo: %v", newCtx["geo"])
+				t.Logf("Baseline context.geo: %v", oldCtx["geo"])
+				t.Logf("Candidate context.geo: %v", newCtx["geo"])
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for geolocation enrichment")
+					t.Log("Both versions produce identical responses for geolocation enrichment")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -606,30 +605,30 @@ def transformBatch(events, metadata):
 					makeEvent("msg-3", versionID),
 				}
 
-				t.Log("Sending 3 events to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending 3 events to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending 3 events to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending 3 events to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 3, len(oldResp.Events), "old arch: 3 success events expected")
-				require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-				require.Equal(t, 3, len(newResp.Events), "new arch: 3 success events expected")
-				require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+				require.Equal(t, 3, len(baselineResp.Events), "baseline: 3 success events expected")
+				require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+				require.Equal(t, 3, len(candidateResp.Events), "candidate: 3 success events expected")
+				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
 				// All events should have geo data with correct IP
-				for i := range oldResp.Events {
-					oldGeo, _ := oldResp.Events[i].Output["geo"].(map[string]any)
-					newGeo, _ := newResp.Events[i].Output["geo"].(map[string]any)
-					require.Equalf(t, "1.2.3.4", oldGeo["ip"], "old arch: event %d geo should contain correct ip", i)
-					require.Equalf(t, "1.2.3.4", newGeo["ip"], "new arch: event %d geo should contain correct ip", i)
+				for i := range baselineResp.Events {
+					oldGeo, _ := baselineResp.Events[i].Output["geo"].(map[string]any)
+					newGeo, _ := candidateResp.Events[i].Output["geo"].(map[string]any)
+					require.Equalf(t, "1.2.3.4", oldGeo["ip"], "baseline: event %d geo should contain correct ip", i)
+					require.Equalf(t, "1.2.3.4", newGeo["ip"], "candidate: event %d geo should contain correct ip", i)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for geolocation in batch transform")
+					t.Log("Both versions produce identical responses for geolocation in batch transform")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -652,28 +651,28 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Both should fail since the exception propagates
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 1, len(oldResp.FailedEvents), "old arch: 1 failed event expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 
-				oldError := oldResp.FailedEvents[0].Error
-				newError := newResp.FailedEvents[0].Error
-				t.Logf("Old arch error: %q", oldError)
-				t.Logf("New arch error: %q", newError)
+				baselineError := baselineResp.FailedEvents[0].Error
+				candidateError := candidateResp.FailedEvents[0].Error
+				t.Logf("Baseline error: %q", baselineError)
+				t.Logf("Candidate error: %q", candidateError)
 
-				require.Contains(t, oldError, "single string argument", "old arch: error should mention validation")
-				require.Contains(t, newError, "single string argument", "new arch: error should mention validation")
+				require.Contains(t, baselineError, "single string argument", "baseline: error should mention validation")
+				require.Contains(t, candidateError, "single string argument", "candidate: error should mention validation")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical error responses for uncaught geolocation error")
+					t.Log("Both versions produce identical error responses for uncaught geolocation error")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -704,23 +703,23 @@ def transformEvent(event, metadata):
 					makeEvent("msg-3", versionID),
 				}
 
-				t.Log("Sending 3 events to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending 3 events to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending 3 events to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending 3 events to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// msg-1 and msg-3 should succeed, msg-2 should fail
-				require.Equal(t, 2, len(oldResp.Events), "old arch: 2 success events expected")
-				require.Equal(t, 1, len(oldResp.FailedEvents), "old arch: 1 failed event expected")
-				require.Equal(t, 2, len(newResp.Events), "new arch: 2 success events expected")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
+				require.Equal(t, 2, len(baselineResp.Events), "baseline: 2 success events expected")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				require.Equal(t, 2, len(candidateResp.Events), "candidate: 2 success events expected")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for partial geolocation errors")
+					t.Log("Both versions produce identical responses for partial geolocation errors")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -750,24 +749,24 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
 				// Verify the geo result is a dict
-				require.Contains(t, oldResp.Events[0].Output["geo_type"], "dict", "old arch: geo should be a dict")
-				require.Contains(t, newResp.Events[0].Output["geo_type"], "dict", "new arch: geo should be a dict")
+				require.Contains(t, baselineResp.Events[0].Output["geo_type"], "dict", "baseline: geo should be a dict")
+				require.Contains(t, candidateResp.Events[0].Output["geo_type"], "dict", "candidate: geo should be a dict")
 
-				t.Logf("Old arch: type=%v, keys=%v", oldResp.Events[0].Output["geo_type"], oldResp.Events[0].Output["geo_keys"])
-				t.Logf("New arch: type=%v, keys=%v", newResp.Events[0].Output["geo_type"], newResp.Events[0].Output["geo_keys"])
+				t.Logf("Baseline: type=%v, keys=%v", baselineResp.Events[0].Output["geo_type"], baselineResp.Events[0].Output["geo_keys"])
+				t.Logf("Candidate: type=%v, keys=%v", candidateResp.Events[0].Output["geo_type"], candidateResp.Events[0].Output["geo_keys"])
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for geolocation field access")
+					t.Log("Both versions produce identical responses for geolocation field access")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -815,22 +814,22 @@ def transformEvent(event, metadata):
 					},
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldGeo, _ := oldResp.Events[0].Output["geo_lookup"].(map[string]any)
-				newGeo, _ := newResp.Events[0].Output["geo_lookup"].(map[string]any)
-				require.Equal(t, "8.8.8.8", oldGeo["ip"], "old arch: geo_lookup should contain correct ip")
-				require.Equal(t, "8.8.8.8", newGeo["ip"], "new arch: geo_lookup should contain correct ip")
+				oldGeo, _ := baselineResp.Events[0].Output["geo_lookup"].(map[string]any)
+				newGeo, _ := candidateResp.Events[0].Output["geo_lookup"].(map[string]any)
+				require.Equal(t, "8.8.8.8", oldGeo["ip"], "baseline: geo_lookup should contain correct ip")
+				require.Equal(t, "8.8.8.8", newGeo["ip"], "candidate: geo_lookup should contain correct ip")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for geolocation with IP from event")
+					t.Log("Both versions produce identical responses for geolocation with IP from event")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -860,30 +859,30 @@ def transformBatch(events, metadata):
 					makeEvent("msg-3", versionID),
 				}
 
-				t.Log("Sending 3 events to old architecture...")
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				t.Log("Sending 3 events to baseline...")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				t.Log("Sending 3 events to new architecture...")
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				t.Log("Sending 3 events to candidate...")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 3, len(oldResp.Events), "old arch: 3 success events expected")
-				require.Equal(t, 3, len(newResp.Events), "new arch: 3 success events expected")
+				require.Equal(t, 3, len(baselineResp.Events), "baseline: 3 success events expected")
+				require.Equal(t, 3, len(candidateResp.Events), "candidate: 3 success events expected")
 
 				// First and third should have same geo data (same IP)
 				// Second should have different geo data
 				expectedIPs := []string{"1.2.3.4", "8.8.8.8", "1.2.3.4"}
-				for i := range oldResp.Events {
-					oldGeo, _ := oldResp.Events[i].Output["geo"].(map[string]any)
-					newGeo, _ := newResp.Events[i].Output["geo"].(map[string]any)
-					require.Equalf(t, expectedIPs[i], oldGeo["ip"], "old arch: event %d geo should contain correct ip", i)
-					require.Equalf(t, expectedIPs[i], newGeo["ip"], "new arch: event %d geo should contain correct ip", i)
+				for i := range baselineResp.Events {
+					oldGeo, _ := baselineResp.Events[i].Output["geo"].(map[string]any)
+					newGeo, _ := candidateResp.Events[i].Output["geo"].(map[string]any)
+					require.Equalf(t, expectedIPs[i], oldGeo["ip"], "baseline: event %d geo should contain correct ip", i)
+					require.Equalf(t, expectedIPs[i], newGeo["ip"], "candidate: event %d geo should contain correct ip", i)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for batch geolocation with different IPs")
+					t.Log("Both versions produce identical responses for batch geolocation with different IPs")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -908,25 +907,25 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				newError, _ := newResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				t.Logf("New arch geo_error: %q", newError)
+				baselineError, _ := baselineResp.Events[0].Output["geo_error"].(string)
+				candidateError, _ := candidateResp.Events[0].Output["geo_error"].(string)
+				t.Logf("Baseline geo_error: %q", baselineError)
+				t.Logf("Candidate geo_error: %q", candidateError)
 
-				require.Contains(t, oldError, "status code: 400", "old arch: error should mention 400")
-				require.Contains(t, newError, "status code: 400", "new arch: error should mention 400")
+				require.Contains(t, baselineError, "status code: 400", "baseline: error should mention 400")
+				require.Contains(t, candidateError, "status code: 400", "candidate: error should mention 400")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for invalid IP")
+					t.Log("Both versions produce identical responses for invalid IP")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -951,25 +950,25 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				newError, _ := newResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				t.Logf("New arch geo_error: %q", newError)
+				baselineError, _ := baselineResp.Events[0].Output["geo_error"].(string)
+				candidateError, _ := candidateResp.Events[0].Output["geo_error"].(string)
+				t.Logf("Baseline geo_error: %q", baselineError)
+				t.Logf("Candidate geo_error: %q", candidateError)
 
-				require.Contains(t, oldError, "status code: 400", "old arch: error should mention 400")
-				require.Contains(t, newError, "status code: 400", "new arch: error should mention 400")
+				require.Contains(t, baselineError, "status code: 400", "baseline: error should mention 400")
+				require.Contains(t, candidateError, "status code: 400", "candidate: error should mention 400")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for special chars IP")
+					t.Log("Both versions produce identical responses for special chars IP")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -992,28 +991,28 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Both should produce a failed event since the exception propagates
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 1, len(oldResp.FailedEvents), "old arch: 1 failed event expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 
-				oldError := oldResp.FailedEvents[0].Error
-				newError := newResp.FailedEvents[0].Error
-				t.Logf("Old arch error: %q", oldError)
-				t.Logf("New arch error: %q", newError)
+				baselineError := baselineResp.FailedEvents[0].Error
+				candidateError := candidateResp.FailedEvents[0].Error
+				t.Logf("Baseline error: %q", baselineError)
+				t.Logf("Candidate error: %q", candidateError)
 
-				require.Contains(t, oldError, "status code: 400", "old arch: error should mention 400")
-				require.Contains(t, newError, "status code: 400", "new arch: error should mention 400")
+				require.Contains(t, baselineError, "status code: 400", "baseline: error should mention 400")
+				require.Contains(t, candidateError, "status code: 400", "candidate: error should mention 400")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical error for uncaught invalid IP")
+					t.Log("Both versions produce identical error for uncaught invalid IP")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1041,24 +1040,24 @@ def transformBatch(events, metadata):
 					makeEvent("msg-3", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 3, len(oldResp.Events), "old arch: 3 success events expected")
-				require.Equal(t, 3, len(newResp.Events), "new arch: 3 success events expected")
+				require.Equal(t, 3, len(baselineResp.Events), "baseline: 3 success events expected")
+				require.Equal(t, 3, len(candidateResp.Events), "candidate: 3 success events expected")
 
-				for i := range oldResp.Events {
-					oldError, _ := oldResp.Events[i].Output["geo_error"].(string)
-					newError, _ := newResp.Events[i].Output["geo_error"].(string)
-					require.Containsf(t, oldError, "status code: 400", "old arch: event %d error should mention 400", i)
-					require.Containsf(t, newError, "status code: 400", "new arch: event %d error should mention 400", i)
+				for i := range baselineResp.Events {
+					baselineError, _ := baselineResp.Events[i].Output["geo_error"].(string)
+					candidateError, _ := candidateResp.Events[i].Output["geo_error"].(string)
+					require.Containsf(t, baselineError, "status code: 400", "baseline: event %d error should mention 400", i)
+					require.Containsf(t, candidateError, "status code: 400", "candidate: event %d error should mention 400", i)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for batch invalid IP")
+					t.Log("Both versions produce identical responses for batch invalid IP")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1092,17 +1091,17 @@ def transformEvent(event, metadata):
 					makeEvent("msg-3", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// All 3 events succeed (errors are caught)
-				require.Equal(t, 3, len(oldResp.Events), "old arch: 3 success events expected")
-				require.Equal(t, 3, len(newResp.Events), "new arch: 3 success events expected")
+				require.Equal(t, 3, len(baselineResp.Events), "baseline: 3 success events expected")
+				require.Equal(t, 3, len(candidateResp.Events), "candidate: 3 success events expected")
 
 				// msg-1 and msg-3 should have geo data, msg-2 should have geo_error
-				for _, resp := range []*types.Response{&oldResp, &newResp} {
+				for _, resp := range []*types.Response{&baselineResp, &candidateResp} {
 					for _, ev := range resp.Events {
 						msgID, _ := ev.Output["messageId"].(string)
 						if msgID == "msg-2" {
@@ -1121,9 +1120,9 @@ def transformEvent(event, metadata):
 					}
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for partial invalid IP")
+					t.Log("Both versions produce identical responses for partial invalid IP")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1145,29 +1144,29 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Private IP returns 200 with empty string fields — no error
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
-				require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
+				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
 				// Geo data should be present with correct IP but empty values
-				oldGeo, _ := oldResp.Events[0].Output["geo"].(map[string]any)
-				newGeo, _ := newResp.Events[0].Output["geo"].(map[string]any)
-				require.Equal(t, "127.0.0.1", oldGeo["ip"], "old arch: geo should contain correct ip")
-				require.Equal(t, "127.0.0.1", newGeo["ip"], "new arch: geo should contain correct ip")
+				oldGeo, _ := baselineResp.Events[0].Output["geo"].(map[string]any)
+				newGeo, _ := candidateResp.Events[0].Output["geo"].(map[string]any)
+				require.Equal(t, "127.0.0.1", oldGeo["ip"], "baseline: geo should contain correct ip")
+				require.Equal(t, "127.0.0.1", newGeo["ip"], "candidate: geo should contain correct ip")
 
-				t.Logf("Old arch geo: %v", oldResp.Events[0].Output["geo"])
-				t.Logf("New arch geo: %v", newResp.Events[0].Output["geo"])
+				t.Logf("Baseline geo: %v", baselineResp.Events[0].Output["geo"])
+				t.Logf("Candidate geo: %v", candidateResp.Events[0].Output["geo"])
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for private IP")
+					t.Log("Both versions produce identical responses for private IP")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1191,25 +1190,25 @@ def transformBatch(events, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// All events should fail since the exception propagates
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 2, len(oldResp.FailedEvents), "old arch: 2 failed events expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 2, len(newResp.FailedEvents), "new arch: 2 failed events expected")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 2, len(baselineResp.FailedEvents), "baseline: 2 failed events expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 2, len(candidateResp.FailedEvents), "candidate: 2 failed events expected")
 
-				for i := range oldResp.FailedEvents {
-					require.Containsf(t, oldResp.FailedEvents[i].Error, "status code: 400", "old arch: event %d error should mention 400", i)
-					require.Containsf(t, newResp.FailedEvents[i].Error, "status code: 400", "new arch: event %d error should mention 400", i)
+				for i := range baselineResp.FailedEvents {
+					require.Containsf(t, baselineResp.FailedEvents[i].Error, "status code: 400", "baseline: event %d error should mention 400", i)
+					require.Containsf(t, candidateResp.FailedEvents[i].Error, "status code: 400", "candidate: event %d error should mention 400", i)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for batch invalid IP uncaught")
+					t.Log("Both versions produce identical responses for batch invalid IP uncaught")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1236,24 +1235,24 @@ def transformBatch(events, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 2, len(oldResp.Events), "old arch: 2 success events expected")
-				require.Equal(t, 2, len(newResp.Events), "new arch: 2 success events expected")
+				require.Equal(t, 2, len(baselineResp.Events), "baseline: 2 success events expected")
+				require.Equal(t, 2, len(candidateResp.Events), "candidate: 2 success events expected")
 
-				for i := range oldResp.Events {
-					oldError, _ := oldResp.Events[i].Output["geo_error"].(string)
-					newError, _ := newResp.Events[i].Output["geo_error"].(string)
-					require.Containsf(t, oldError, "single string argument", "old arch: event %d error should mention single string argument", i)
-					require.Containsf(t, newError, "single string argument", "new arch: event %d error should mention single string argument", i)
+				for i := range baselineResp.Events {
+					baselineError, _ := baselineResp.Events[i].Output["geo_error"].(string)
+					candidateError, _ := candidateResp.Events[i].Output["geo_error"].(string)
+					require.Containsf(t, baselineError, "single string argument", "baseline: event %d error should mention single string argument", i)
+					require.Containsf(t, candidateError, "single string argument", "candidate: event %d error should mention single string argument", i)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for batch no args")
+					t.Log("Both versions produce identical responses for batch no args")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1278,25 +1277,25 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				newError, _ := newResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				t.Logf("New arch geo_error: %q", newError)
+				baselineError, _ := baselineResp.Events[0].Output["geo_error"].(string)
+				candidateError, _ := candidateResp.Events[0].Output["geo_error"].(string)
+				t.Logf("Baseline geo_error: %q", baselineError)
+				t.Logf("Candidate geo_error: %q", candidateError)
 
-				require.NotEmpty(t, oldError, "old arch: should have a geo_error")
-				require.NotEmpty(t, newError, "new arch: should have a geo_error")
+				require.NotEmpty(t, baselineError, "baseline: should have a geo_error")
+				require.NotEmpty(t, candidateError, "candidate: should have a geo_error")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for keyword arg")
+					t.Log("Both versions produce identical responses for keyword arg")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1327,47 +1326,22 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, allEntries)
 	t.Cleanup(configBackend.Close)
 
-	// Mock OpenFaaS gateway with dynamic target.
 	var (
-		gatewayMu        sync.Mutex
-		gatewayTargetURL string
-	)
-	getGatewayTarget := func() string {
-		gatewayMu.Lock()
-		defer gatewayMu.Unlock()
-		return gatewayTargetURL
-	}
-	setGatewayTarget := func(url string) {
-		gatewayMu.Lock()
-		defer gatewayMu.Unlock()
-		gatewayTargetURL = url
-	}
-	mockGateway, _ := newMockOpenFaaSGateway(t, getGatewayTarget)
-	t.Cleanup(mockGateway.Close)
-
-	var (
-		wg                               sync.WaitGroup
-		transformerURL, pyTransformerURL string
+		wg                        sync.WaitGroup
+		baselineURL, candidateURL string
 	)
 	wg.Go(func() {
-		transformerURL = startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
+		baselineURL = startBaselinePytransformer(t, pool, configBackend.URL, "GEOLOCATION_URL="+geoURL)
 	})
 	wg.Go(func() {
-		pyTransformerURL = startRudderPytransformer(t, pool, configBackend.URL, "GEOLOCATION_URL="+geoURL)
+		candidateURL = startRudderPytransformer(t, pool, configBackend.URL, "GEOLOCATION_URL="+geoURL)
 	})
 	wg.Wait()
 
 	// Run subtests sequentially.
 	for _, st := range subtests {
 		t.Run(st.name, func(t *testing.T) {
-			env := newBCTestEnv(t, transformerURL, pyTransformerURL, withLimitedRetryableHTTPRetries())
-
-			if st.config.code != "" {
-				t.Logf("Starting openfaas-flask-base for %s (versionID=%s)...", st.name, st.versionID)
-				openFaasURL := startOpenFaasFlask(t, pool, st.versionID, configBackend.URL, "geolocation_url="+geoURL)
-
-				setGatewayTarget(openFaasURL)
-			}
+			env := newBCTestEnv(t, baselineURL, candidateURL, withLimitedRetryableHTTPRetries())
 
 			st.run(t, env)
 			env.assertRetryCountsMatch(t)
@@ -1376,7 +1350,7 @@ def transformEvent(event, metadata):
 }
 
 // TestBackwardsCompatibilityGeolocationNotConfigured tests geolocation behavior
-// when the geolocation service URL is NOT configured in either architecture.
+// when the geolocation service URL is NOT configured in either version.
 // Both should produce the same "not supported" error.
 func TestBackwardsCompatibilityGeolocationNotConfigured(t *testing.T) {
 	type subtest struct {
@@ -1406,27 +1380,27 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Both should succeed (error caught by try/except)
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
 				// Both should report "not supported" error
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				newError, _ := newResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				t.Logf("New arch geo_error: %q", newError)
+				baselineError, _ := baselineResp.Events[0].Output["geo_error"].(string)
+				candidateError, _ := candidateResp.Events[0].Output["geo_error"].(string)
+				t.Logf("Baseline geo_error: %q", baselineError)
+				t.Logf("Candidate geo_error: %q", candidateError)
 
-				require.Contains(t, oldError, "not supported", "old arch: error should mention not supported")
-				require.Contains(t, newError, "not supported", "new arch: error should mention not supported")
+				require.Contains(t, baselineError, "not supported", "baseline: error should mention not supported")
+				require.Contains(t, candidateError, "not supported", "candidate: error should mention not supported")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses when geolocation is not configured")
+					t.Log("Both versions produce identical responses when geolocation is not configured")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1449,28 +1423,28 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// Both should fail since exception propagates
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 1, len(oldResp.FailedEvents), "old arch: 1 failed event expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 
-				oldError := oldResp.FailedEvents[0].Error
-				newError := newResp.FailedEvents[0].Error
-				t.Logf("Old arch error: %q", oldError)
-				t.Logf("New arch error: %q", newError)
+				baselineError := baselineResp.FailedEvents[0].Error
+				candidateError := candidateResp.FailedEvents[0].Error
+				t.Logf("Baseline error: %q", baselineError)
+				t.Logf("Candidate error: %q", candidateError)
 
-				require.Contains(t, oldError, "not supported", "old arch: error should mention not supported")
-				require.Contains(t, newError, "not supported", "new arch: error should mention not supported")
+				require.Contains(t, baselineError, "not supported", "baseline: error should mention not supported")
+				require.Contains(t, candidateError, "not supported", "candidate: error should mention not supported")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical error for uncaught geolocation not configured")
+					t.Log("Both versions produce identical error for uncaught geolocation not configured")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1497,25 +1471,25 @@ def transformBatch(events, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 2, len(oldResp.Events), "old arch: 2 success events expected")
-				require.Equal(t, 2, len(newResp.Events), "new arch: 2 success events expected")
+				require.Equal(t, 2, len(baselineResp.Events), "baseline: 2 success events expected")
+				require.Equal(t, 2, len(candidateResp.Events), "candidate: 2 success events expected")
 
 				// Both should have geo_error for all events
-				for i := range oldResp.Events {
-					oldError, _ := oldResp.Events[i].Output["geo_error"].(string)
-					newError, _ := newResp.Events[i].Output["geo_error"].(string)
-					require.Containsf(t, oldError, "not supported", "old arch: event %d error should mention not supported", i)
-					require.Containsf(t, newError, "not supported", "new arch: event %d error should mention not supported", i)
+				for i := range baselineResp.Events {
+					baselineError, _ := baselineResp.Events[i].Output["geo_error"].(string)
+					candidateError, _ := candidateResp.Events[i].Output["geo_error"].(string)
+					require.Containsf(t, baselineError, "not supported", "baseline: event %d error should mention not supported", i)
+					require.Containsf(t, candidateError, "not supported", "candidate: event %d error should mention not supported", i)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for batch geolocation not configured")
+					t.Log("Both versions produce identical responses for batch geolocation not configured")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1539,25 +1513,25 @@ def transformBatch(events, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
 				// All events should fail since the exception propagates
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 2, len(oldResp.FailedEvents), "old arch: 2 failed events expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 2, len(newResp.FailedEvents), "new arch: 2 failed events expected")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 2, len(baselineResp.FailedEvents), "baseline: 2 failed events expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 2, len(candidateResp.FailedEvents), "candidate: 2 failed events expected")
 
-				for i := range oldResp.FailedEvents {
-					require.Containsf(t, oldResp.FailedEvents[i].Error, "not supported", "old arch: event %d error should mention not supported", i)
-					require.Containsf(t, newResp.FailedEvents[i].Error, "not supported", "new arch: event %d error should mention not supported", i)
+				for i := range baselineResp.FailedEvents {
+					require.Containsf(t, baselineResp.FailedEvents[i].Error, "not supported", "baseline: event %d error should mention not supported", i)
+					require.Containsf(t, candidateResp.FailedEvents[i].Error, "not supported", "candidate: event %d error should mention not supported", i)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for batch geolocation not configured uncaught")
+					t.Log("Both versions produce identical responses for batch geolocation not configured uncaught")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1579,46 +1553,23 @@ def transformBatch(events, metadata):
 	configBackend := newContractConfigBackend(t, allEntries)
 	t.Cleanup(configBackend.Close)
 
-	// Mock OpenFaaS gateway with dynamic target.
+	// Both containers start WITHOUT a geolocation URL — that is what this test
+	// is about.
 	var (
-		gatewayMu        sync.Mutex
-		gatewayTargetURL string
-	)
-	getGatewayTarget := func() string {
-		gatewayMu.Lock()
-		defer gatewayMu.Unlock()
-		return gatewayTargetURL
-	}
-	setGatewayTarget := func(url string) {
-		gatewayMu.Lock()
-		defer gatewayMu.Unlock()
-		gatewayTargetURL = url
-	}
-	mockGateway, _ := newMockOpenFaaSGateway(t, getGatewayTarget)
-	t.Cleanup(mockGateway.Close)
-
-	var (
-		wg                               sync.WaitGroup
-		transformerURL, pyTransformerURL string
+		wg                        sync.WaitGroup
+		baselineURL, candidateURL string
 	)
 	wg.Go(func() {
-		transformerURL = startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
+		baselineURL = startBaselinePytransformer(t, pool, configBackend.URL)
 	})
 	wg.Go(func() {
-		pyTransformerURL = startRudderPytransformer(t, pool, configBackend.URL)
+		candidateURL = startRudderPytransformer(t, pool, configBackend.URL)
 	})
 	wg.Wait()
 
 	for _, st := range subtests {
 		t.Run(st.name, func(t *testing.T) {
-			env := newBCTestEnv(t, transformerURL, pyTransformerURL, withLimitedRetryableHTTPRetries())
-
-			if st.config.code != "" {
-				// Start openfaas WITHOUT geolocation URL (not configured test).
-				openFaasURL := startOpenFaasFlask(t, pool, st.versionID, configBackend.URL)
-
-				setGatewayTarget(openFaasURL)
-			}
+			env := newBCTestEnv(t, baselineURL, candidateURL, withLimitedRetryableHTTPRetries())
 
 			st.run(t, env)
 			env.assertRetryCountsMatch(t)
@@ -1630,7 +1581,7 @@ def transformBatch(events, metadata):
 // geolocation service experiences network failures or returns various HTTP
 // error status codes. Uses a configurable mock geolocation service to
 // simulate different failure scenarios.
-// Both architectures raise: "geolocation fetch failed with status code: {code}"
+// Both versions raise: "geolocation fetch failed with status code: {code}"
 func TestBackwardsCompatibilityGeolocationFailure(t *testing.T) {
 	type subtest struct {
 		name                string
@@ -1638,7 +1589,7 @@ func TestBackwardsCompatibilityGeolocationFailure(t *testing.T) {
 		config              configBackendEntry
 		setup               func() // called before run to configure mock behavior
 		run                 func(t *testing.T, env *bcTestEnv)
-		skipRetryCountMatch bool // skip assertRetryCountsMatch when old/new arch retry differently
+		skipRetryCountMatch bool // skip assertRetryCountsMatch when old/candidate retry differently
 	}
 
 	mockGeoService, mockGeoCfg := newConfigurableMockGeolocationService(t)
@@ -1667,22 +1618,18 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				// Old arch: except Exception catches the error → success event with geo_error
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				require.Contains(t, oldError, "status code: 500", "old arch: error should mention 500")
+				// Baseline: except Exception catches the error → success event with geo_error
 
-				// New arch: GeolocationServerError(BaseException) bypasses except Exception
+				// Candidate: GeolocationServerError(BaseException) bypasses except Exception
 				// → propagates as HTTP 503 with retry → retries exhausted → failed event
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected (geo 5xx triggers retries)")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
-				t.Logf("New arch error: %q", newResp.FailedEvents[0].Error)
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo 5xx triggers retries)")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
+				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
 			},
 		},
 		{
@@ -1706,18 +1653,14 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				require.Contains(t, oldError, "status code: 502", "old arch: error should mention 502")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected (geo 5xx triggers retries)")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
-				t.Logf("New arch error: %q", newResp.FailedEvents[0].Error)
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo 5xx triggers retries)")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
+				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
 			},
 		},
 		{
@@ -1741,18 +1684,14 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				require.Contains(t, oldError, "status code: 503", "old arch: error should mention 503")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected (geo 5xx triggers retries)")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
-				t.Logf("New arch error: %q", newResp.FailedEvents[0].Error)
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo 5xx triggers retries)")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
+				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
 			},
 		},
 		{
@@ -1775,25 +1714,25 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				newError, _ := newResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				t.Logf("New arch geo_error: %q", newError)
+				baselineError, _ := baselineResp.Events[0].Output["geo_error"].(string)
+				candidateError, _ := candidateResp.Events[0].Output["geo_error"].(string)
+				t.Logf("Baseline geo_error: %q", baselineError)
+				t.Logf("Candidate geo_error: %q", candidateError)
 
-				require.Contains(t, oldError, "status code: 429", "old arch: error should mention 429")
-				require.Contains(t, newError, "status code: 429", "new arch: error should mention 429")
+				require.Contains(t, baselineError, "status code: 429", "baseline: error should mention 429")
+				require.Contains(t, candidateError, "status code: 429", "candidate: error should mention 429")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for 429")
+					t.Log("Both versions produce identical responses for 429")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -1817,23 +1756,18 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
 				// Both produce failed events, but via different paths:
-				// Old arch: exception propagates → failed event with "status code: 500"
-				// New arch: GeolocationServerError → 503 retries → exhausted → failed event
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 1, len(oldResp.FailedEvents), "old arch: 1 failed event expected")
-				oldError := oldResp.FailedEvents[0].Error
-				t.Logf("Old arch error: %q", oldError)
-				require.Contains(t, oldError, "status code: 500", "old arch: error should mention 500")
+				// Baseline: exception propagates → failed event with "status code: 500"
+				// Candidate: GeolocationServerError → 503 retries → exhausted → failed event
 
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
-				t.Logf("New arch error: %q", newResp.FailedEvents[0].Error)
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
+				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
 			},
 		},
 		{
@@ -1860,18 +1794,13 @@ def transformBatch(events, metadata):
 					makeEvent("msg-3", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Equal(t, 3, len(oldResp.Events), "old arch: 3 success events expected")
-				for i := range oldResp.Events {
-					oldError, _ := oldResp.Events[i].Output["geo_error"].(string)
-					require.Containsf(t, oldError, "status code: 500", "old arch: event %d error should mention 500", i)
-				}
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected (geo 5xx triggers retries)")
-				require.Equal(t, 3, len(newResp.FailedEvents), "new arch: 3 failed events expected")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo 5xx triggers retries)")
+				require.Equal(t, 3, len(candidateResp.FailedEvents), "candidate: 3 failed events expected")
 			},
 		},
 		{
@@ -1898,18 +1827,13 @@ def transformBatch(events, metadata):
 					makeEvent("msg-3", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Equal(t, 3, len(oldResp.Events), "old arch: 3 success events expected")
-				for i := range oldResp.Events {
-					oldError, _ := oldResp.Events[i].Output["geo_error"].(string)
-					require.Containsf(t, oldError, "status code: 502", "old arch: event %d error should mention 502", i)
-				}
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected (geo 5xx triggers retries)")
-				require.Equal(t, 3, len(newResp.FailedEvents), "new arch: 3 failed events expected")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo 5xx triggers retries)")
+				require.Equal(t, 3, len(candidateResp.FailedEvents), "candidate: 3 failed events expected")
 			},
 		},
 		{
@@ -1936,18 +1860,13 @@ def transformBatch(events, metadata):
 					makeEvent("msg-3", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Equal(t, 3, len(oldResp.Events), "old arch: 3 success events expected")
-				for i := range oldResp.Events {
-					oldError, _ := oldResp.Events[i].Output["geo_error"].(string)
-					require.Containsf(t, oldError, "status code: 503", "old arch: event %d error should mention 503", i)
-				}
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected (geo 5xx triggers retries)")
-				require.Equal(t, 3, len(newResp.FailedEvents), "new arch: 3 failed events expected")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo 5xx triggers retries)")
+				require.Equal(t, 3, len(candidateResp.FailedEvents), "candidate: 3 failed events expected")
 			},
 		},
 		{
@@ -1973,24 +1892,24 @@ def transformBatch(events, metadata):
 					makeEvent("msg-3", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 3, len(oldResp.Events), "old arch: 3 success events expected")
-				require.Equal(t, 3, len(newResp.Events), "new arch: 3 success events expected")
+				require.Equal(t, 3, len(baselineResp.Events), "baseline: 3 success events expected")
+				require.Equal(t, 3, len(candidateResp.Events), "candidate: 3 success events expected")
 
-				for i := range oldResp.Events {
-					oldError, _ := oldResp.Events[i].Output["geo_error"].(string)
-					newError, _ := newResp.Events[i].Output["geo_error"].(string)
-					require.Containsf(t, oldError, "status code: 429", "old arch: event %d error should mention 429", i)
-					require.Containsf(t, newError, "status code: 429", "new arch: event %d error should mention 429", i)
+				for i := range baselineResp.Events {
+					baselineError, _ := baselineResp.Events[i].Output["geo_error"].(string)
+					candidateError, _ := candidateResp.Events[i].Output["geo_error"].(string)
+					require.Containsf(t, baselineError, "status code: 429", "baseline: event %d error should mention 429", i)
+					require.Containsf(t, candidateError, "status code: 429", "candidate: event %d error should mention 429", i)
 				}
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for batch 429")
+					t.Log("Both versions produce identical responses for batch 429")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -2017,20 +1936,16 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				// Old arch: connection error raises Exception → caught by except → success with geo_error
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				require.NotEmpty(t, oldError, "old arch: should have a geo_error")
+				// Baseline: connection error raises Exception → caught by except → success with geo_error
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				// New arch: connection error → GeolocationServerError(BaseException) → 503 retries → failed event
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected (geo errors trigger retries)")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
-				t.Logf("New arch error: %q", newResp.FailedEvents[0].Error)
+				// Candidate: connection error → GeolocationServerError(BaseException) → 503 retries → failed event
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo errors trigger retries)")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
+				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
 			},
 		},
 		{
@@ -2057,18 +1972,16 @@ def transformBatch(events, metadata):
 					makeEvent("msg-3", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Equal(t, 3, len(oldResp.Events), "old arch: 3 success events expected")
-				for i := range oldResp.Events {
-					oldError, _ := oldResp.Events[i].Output["geo_error"].(string)
-					require.NotEmptyf(t, oldError, "old arch: event %d should have a geo_error", i)
-				}
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected (geo errors trigger retries)")
-				require.Equal(t, 3, len(newResp.FailedEvents), "new arch: 3 failed events expected")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo errors trigger retries)")
+				require.Equal(t, 3, len(candidateResp.FailedEvents), "candidate: 3 failed events expected")
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -2091,25 +2004,25 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-				require.Equal(t, 1, len(newResp.Events), "new arch: 1 success event expected")
+				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldError, _ := oldResp.Events[0].Output["geo_error"].(string)
-				newError, _ := newResp.Events[0].Output["geo_error"].(string)
-				t.Logf("Old arch geo_error: %q", oldError)
-				t.Logf("New arch geo_error: %q", newError)
+				baselineError, _ := baselineResp.Events[0].Output["geo_error"].(string)
+				candidateError, _ := candidateResp.Events[0].Output["geo_error"].(string)
+				t.Logf("Baseline geo_error: %q", baselineError)
+				t.Logf("Candidate geo_error: %q", candidateError)
 
-				require.Contains(t, oldError, "status code: 400", "old arch: error should mention 400")
-				require.Contains(t, newError, "status code: 400", "new arch: error should mention 400")
+				require.Contains(t, baselineError, "status code: 400", "baseline: error should mention 400")
+				require.Contains(t, candidateError, "status code: 400", "candidate: error should mention 400")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical responses for 400")
+					t.Log("Both versions produce identical responses for 400")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -2133,18 +2046,17 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 1, len(oldResp.FailedEvents), "old arch: 1 failed event expected")
-				t.Logf("Old arch error: %q", oldResp.FailedEvents[0].Error)
-				require.Contains(t, oldResp.FailedEvents[0].Error, "status code: 502", "old arch: error should mention 502")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				t.Logf("Baseline error: %q", baselineResp.FailedEvents[0].Error)
 
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
-				t.Logf("New arch error: %q", newResp.FailedEvents[0].Error)
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
+				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
 			},
 		},
 		{
@@ -2165,18 +2077,17 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 1, len(oldResp.FailedEvents), "old arch: 1 failed event expected")
-				t.Logf("Old arch error: %q", oldResp.FailedEvents[0].Error)
-				require.Contains(t, oldResp.FailedEvents[0].Error, "status code: 503", "old arch: error should mention 503")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				t.Logf("Baseline error: %q", baselineResp.FailedEvents[0].Error)
 
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
-				t.Logf("New arch error: %q", newResp.FailedEvents[0].Error)
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
+				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
 			},
 		},
 		{
@@ -2196,27 +2107,27 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 1, len(oldResp.FailedEvents), "old arch: 1 failed event expected")
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 
-				oldError := oldResp.FailedEvents[0].Error
-				newError := newResp.FailedEvents[0].Error
-				t.Logf("Old arch error: %q", oldError)
-				t.Logf("New arch error: %q", newError)
+				baselineError := baselineResp.FailedEvents[0].Error
+				candidateError := candidateResp.FailedEvents[0].Error
+				t.Logf("Baseline error: %q", baselineError)
+				t.Logf("Candidate error: %q", candidateError)
 
-				require.Contains(t, oldError, "status code: 429", "old arch: error should mention 429")
-				require.Contains(t, newError, "status code: 429", "new arch: error should mention 429")
+				require.Contains(t, baselineError, "status code: 429", "baseline: error should mention 429")
+				require.Contains(t, candidateError, "status code: 429", "candidate: error should mention 429")
 
-				diff, equal := oldResp.Equal(&newResp)
+				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
-					t.Log("Both architectures produce identical error for uncaught 429")
+					t.Log("Both versions produce identical error for uncaught 429")
 				} else {
 					t.Errorf("Responses differ:\n%s", diff)
 				}
@@ -2240,19 +2151,19 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 1, len(oldResp.FailedEvents), "old arch: 1 failed event expected")
-				t.Logf("Old arch error: %q", oldResp.FailedEvents[0].Error)
-				require.NotEmpty(t, oldResp.FailedEvents[0].Error, "old arch: should have an error")
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				t.Logf("Baseline error: %q", baselineResp.FailedEvents[0].Error)
+				require.NotEmpty(t, baselineResp.FailedEvents[0].Error, "baseline: should have an error")
 
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 1, len(newResp.FailedEvents), "new arch: 1 failed event expected")
-				t.Logf("New arch error: %q", newResp.FailedEvents[0].Error)
-				require.NotEmpty(t, newResp.FailedEvents[0].Error, "new arch: should have an error")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
+				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
+				require.NotEmpty(t, candidateResp.FailedEvents[0].Error, "candidate: should have an error")
 			},
 		},
 		{
@@ -2275,18 +2186,15 @@ def transformBatch(events, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 2, len(oldResp.FailedEvents), "old arch: 2 failed events expected")
-				for i := range oldResp.FailedEvents {
-					require.Containsf(t, oldResp.FailedEvents[i].Error, "status code: 500", "old arch: event %d error should mention 500", i)
-				}
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 2, len(baselineResp.FailedEvents), "baseline: 2 failed events expected")
 
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 2, len(newResp.FailedEvents), "new arch: 2 failed events expected")
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 2, len(candidateResp.FailedEvents), "candidate: 2 failed events expected")
 			},
 		},
 		{
@@ -2309,20 +2217,20 @@ def transformBatch(events, metadata):
 					makeEvent("msg-2", versionID),
 				}
 
-				oldResp := env.OldClient.Transform(context.Background(), events)
-				t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
-				require.Equal(t, 0, len(oldResp.Events), "old arch: no success events expected")
-				require.Equal(t, 2, len(oldResp.FailedEvents), "old arch: 2 failed events expected")
-				for i := range oldResp.FailedEvents {
-					require.NotEmptyf(t, oldResp.FailedEvents[i].Error, "old arch: event %d should have an error", i)
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 2, len(baselineResp.FailedEvents), "baseline: 2 failed events expected")
+				for i := range baselineResp.FailedEvents {
+					require.NotEmptyf(t, baselineResp.FailedEvents[i].Error, "baseline: event %d should have an error", i)
 				}
 
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Equal(t, 0, len(newResp.Events), "new arch: no success events expected")
-				require.Equal(t, 2, len(newResp.FailedEvents), "new arch: 2 failed events expected")
-				for i := range newResp.FailedEvents {
-					require.NotEmptyf(t, newResp.FailedEvents[i].Error, "new arch: event %d should have an error", i)
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
+				require.Equal(t, 2, len(candidateResp.FailedEvents), "candidate: 2 failed events expected")
+				for i := range candidateResp.FailedEvents {
+					require.NotEmptyf(t, candidateResp.FailedEvents[i].Error, "candidate: event %d should have an error", i)
 				}
 			},
 		},
@@ -2344,7 +2252,7 @@ def transformEvent(event, metadata):
         result = geolocation("1.2.3.4")
         event["geo"] = result
     except Exception as e:
-        # New arch must NOT reach this branch — GeolocationServerError
+        # Candidate must NOT reach this branch — GeolocationServerError
         # inherits BaseException so it bypasses except-Exception and
         # propagates to the worker as a retryable 503.
         event["geo_error"] = str(e)
@@ -2359,26 +2267,26 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				// Old arch: openfaas-flask-base catches the timeout via
+				// Baseline: openfaas-flask-base catches the timeout via
 				// `except Exception` so the user code records geo_error
 				// and the event succeeds.
 
-				// New arch: timeout → GeolocationServerError →
+				// Candidate: timeout → GeolocationServerError →
 				// HTTP 503 + X-Rudder-Should-Retry → retries exhausted →
 				// failed event (with the user's `event["geo_error"]`
 				// branch never executed).
-				newResp := env.NewClient.Transform(context.Background(), events)
-				t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
-				require.Len(t, newResp.Events, 0,
-					"new arch: slow geolocation must NOT produce a success event "+
+				candidateResp := env.CandidateClient.Transform(context.Background(), events)
+				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
+				require.Len(t, candidateResp.Events, 0,
+					"candidate: slow geolocation must NOT produce a success event "+
 						"(GeolocationServerError must bypass user except-Exception)")
-				require.Len(t, newResp.FailedEvents, 1,
-					"new arch: slow geolocation must surface as a failed event after retries")
-				require.Contains(t, newResp.FailedEvents[0].Error,
+				require.Len(t, candidateResp.FailedEvents, 1,
+					"candidate: slow geolocation must surface as a failed event after retries")
+				require.Contains(t, candidateResp.FailedEvents[0].Error,
 					"transformer returned status code: 503",
-					"new arch: failed event must carry the correct error message")
+					"candidate: failed event must carry the correct error message")
 
-				retriesCounter := env.NewStats.GetByName("processor_user_transformer_http_retries")
+				retriesCounter := env.CandidateStats.GetByName("processor_user_transformer_http_retries")
 				require.Len(t, retriesCounter, 1)
 				require.EqualValues(t, 2, retriesCounter[0].Value)
 			},
@@ -2399,60 +2307,37 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, allEntries)
 	t.Cleanup(configBackend.Close)
 
-	// Mock OpenFaaS gateway with dynamic target.
-	var (
-		gatewayMu        sync.Mutex
-		gatewayTargetURL string
-	)
-	getGatewayTarget := func() string {
-		gatewayMu.Lock()
-		defer gatewayMu.Unlock()
-		return gatewayTargetURL
+	// Both containers run with the configurable mock geolocation URL.
+	// GEOLOCATION_TIMEOUT_SECS=0.5 governs the GeoTimeout subtest's 1s mock
+	// delay (500 ms < 1 s → retryable 503). SANDBOX_HTTP_BUDGET_S is kept
+	// low as a guard for any future subtest exercising user HTTP traffic; it
+	// does NOT affect geolocation calls — see
+	// TestSandboxHTTPBudgetDoesNotCapGeolocation.
+	pytEnv := []string{
+		"GEOLOCATION_URL=" + geoURL,
+		"SANDBOX_HTTP_BUDGET_S=0.1",
+		"GEOLOCATION_TIMEOUT_SECS=0.1",
 	}
-	setGatewayTarget := func(url string) {
-		gatewayMu.Lock()
-		defer gatewayMu.Unlock()
-		gatewayTargetURL = url
-	}
-	mockGateway, _ := newMockOpenFaaSGateway(t, getGatewayTarget)
-	t.Cleanup(mockGateway.Close)
 
 	var (
-		wg                               sync.WaitGroup
-		transformerURL, pyTransformerURL string
+		wg                        sync.WaitGroup
+		baselineURL, candidateURL string
 	)
 	wg.Go(func() {
-		transformerURL = startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
+		baselineURL = startBaselinePytransformer(t, pool, configBackend.URL, pytEnv...)
 	})
 	wg.Go(func() {
-		// Start shared rudder-pytransformer with configurable mock geolocation URL.
-		// GEOLOCATION_TIMEOUT_SECS=0.5 governs the GeoTimeout subtest's 1s mock
-		// delay (500 ms < 1 s → retryable 503). SANDBOX_HTTP_BUDGET_S is kept
-		// low as a guard for any future subtest exercising user HTTP traffic; it
-		// does NOT affect geolocation calls — see
-		// TestSandboxHTTPBudgetDoesNotCapGeolocation.
-		pyTransformerURL = startRudderPytransformer(t, pool, configBackend.URL,
-			"GEOLOCATION_URL="+geoURL,
-			"SANDBOX_HTTP_BUDGET_S=0.1",
-			"GEOLOCATION_TIMEOUT_SECS=0.1",
-		)
+		candidateURL = startRudderPytransformer(t, pool, configBackend.URL, pytEnv...)
 	})
 	wg.Wait()
 
 	// Run subtests sequentially.
 	for _, st := range subtests {
 		t.Run(st.name, func(t *testing.T) {
-			env := newBCTestEnv(t, transformerURL, pyTransformerURL,
+			env := newBCTestEnv(t, baselineURL, candidateURL,
 				withFailOnError(),
 				withLimitedRetryableHTTPRetries(),
 			)
-
-			if st.config.code != "" {
-				t.Logf("Starting openfaas-flask-base for %s (versionID=%s)...", st.name, st.versionID)
-				openFaasURL := startOpenFaasFlask(t, pool, st.versionID, configBackend.URL, "geolocation_url="+geoURL)
-
-				setGatewayTarget(openFaasURL)
-			}
 
 			if st.setup != nil {
 				st.setup()

--- a/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
@@ -60,10 +60,10 @@ def transformEvent(event, metadata):
 				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
 				// Verify geo data was returned with correct IP
-				oldGeo, _ := baselineResp.Events[0].Output["geo"].(map[string]any)
-				newGeo, _ := candidateResp.Events[0].Output["geo"].(map[string]any)
-				require.Equal(t, "1.2.3.4", oldGeo["ip"], "baseline: geo should contain correct ip")
-				require.Equal(t, "1.2.3.4", newGeo["ip"], "candidate: geo should contain correct ip")
+				baselineGeo, _ := baselineResp.Events[0].Output["geo"].(map[string]any)
+				candidateGeo, _ := candidateResp.Events[0].Output["geo"].(map[string]any)
+				require.Equal(t, "1.2.3.4", baselineGeo["ip"], "baseline: geo should contain correct ip")
+				require.Equal(t, "1.2.3.4", candidateGeo["ip"], "candidate: geo should contain correct ip")
 
 				t.Logf("Baseline geo: %v", baselineResp.Events[0].Output["geo"])
 				t.Logf("Candidate geo: %v", candidateResp.Events[0].Output["geo"])
@@ -455,14 +455,14 @@ def transformEvent(event, metadata):
 				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
 				// Both should have two different geo results with correct IPs
-				oldGeo1, _ := baselineResp.Events[0].Output["geo1"].(map[string]any)
-				oldGeo2, _ := baselineResp.Events[0].Output["geo2"].(map[string]any)
-				newGeo1, _ := candidateResp.Events[0].Output["geo1"].(map[string]any)
-				newGeo2, _ := candidateResp.Events[0].Output["geo2"].(map[string]any)
-				require.Equal(t, "1.2.3.4", oldGeo1["ip"], "baseline: geo1 should contain correct ip")
-				require.Equal(t, "8.8.8.8", oldGeo2["ip"], "baseline: geo2 should contain correct ip")
-				require.Equal(t, "1.2.3.4", newGeo1["ip"], "candidate: geo1 should contain correct ip")
-				require.Equal(t, "8.8.8.8", newGeo2["ip"], "candidate: geo2 should contain correct ip")
+				baselineGeo1, _ := baselineResp.Events[0].Output["geo1"].(map[string]any)
+				baselineGeo2, _ := baselineResp.Events[0].Output["geo2"].(map[string]any)
+				candidateGeo1, _ := candidateResp.Events[0].Output["geo1"].(map[string]any)
+				candidateGeo2, _ := candidateResp.Events[0].Output["geo2"].(map[string]any)
+				require.Equal(t, "1.2.3.4", baselineGeo1["ip"], "baseline: geo1 should contain correct ip")
+				require.Equal(t, "8.8.8.8", baselineGeo2["ip"], "baseline: geo2 should contain correct ip")
+				require.Equal(t, "1.2.3.4", candidateGeo1["ip"], "candidate: geo1 should contain correct ip")
+				require.Equal(t, "8.8.8.8", candidateGeo2["ip"], "candidate: geo2 should contain correct ip")
 
 				t.Logf("Baseline geo1: %v", baselineResp.Events[0].Output["geo1"])
 				t.Logf("Baseline geo2: %v", baselineResp.Events[0].Output["geo2"])
@@ -565,15 +565,15 @@ def transformEvent(event, metadata):
 				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
 				// Verify geo data was placed in context.geo with correct IP
-				oldCtx, _ := baselineResp.Events[0].Output["context"].(map[string]any)
-				newCtx, _ := candidateResp.Events[0].Output["context"].(map[string]any)
-				oldGeo, _ := oldCtx["geo"].(map[string]any)
-				newGeo, _ := newCtx["geo"].(map[string]any)
-				require.Equal(t, "8.8.8.8", oldGeo["ip"], "baseline: context.geo should contain correct ip")
-				require.Equal(t, "8.8.8.8", newGeo["ip"], "candidate: context.geo should contain correct ip")
+				baselineCtx, _ := baselineResp.Events[0].Output["context"].(map[string]any)
+				candidateCtx, _ := candidateResp.Events[0].Output["context"].(map[string]any)
+				baselineGeo, _ := baselineCtx["geo"].(map[string]any)
+				candidateGeo, _ := candidateCtx["geo"].(map[string]any)
+				require.Equal(t, "8.8.8.8", baselineGeo["ip"], "baseline: context.geo should contain correct ip")
+				require.Equal(t, "8.8.8.8", candidateGeo["ip"], "candidate: context.geo should contain correct ip")
 
-				t.Logf("Baseline context.geo: %v", oldCtx["geo"])
-				t.Logf("Candidate context.geo: %v", newCtx["geo"])
+				t.Logf("Baseline context.geo: %v", baselineCtx["geo"])
+				t.Logf("Candidate context.geo: %v", candidateCtx["geo"])
 
 				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
@@ -620,10 +620,10 @@ def transformBatch(events, metadata):
 
 				// All events should have geo data with correct IP
 				for i := range baselineResp.Events {
-					oldGeo, _ := baselineResp.Events[i].Output["geo"].(map[string]any)
-					newGeo, _ := candidateResp.Events[i].Output["geo"].(map[string]any)
-					require.Equalf(t, "1.2.3.4", oldGeo["ip"], "baseline: event %d geo should contain correct ip", i)
-					require.Equalf(t, "1.2.3.4", newGeo["ip"], "candidate: event %d geo should contain correct ip", i)
+					baselineGeo, _ := baselineResp.Events[i].Output["geo"].(map[string]any)
+					candidateGeo, _ := candidateResp.Events[i].Output["geo"].(map[string]any)
+					require.Equalf(t, "1.2.3.4", baselineGeo["ip"], "baseline: event %d geo should contain correct ip", i)
+					require.Equalf(t, "1.2.3.4", candidateGeo["ip"], "candidate: event %d geo should contain correct ip", i)
 				}
 
 				diff, equal := baselineResp.Equal(&candidateResp)
@@ -822,10 +822,10 @@ def transformEvent(event, metadata):
 				require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
 				require.Equal(t, 1, len(candidateResp.Events), "candidate: 1 success event expected")
 
-				oldGeo, _ := baselineResp.Events[0].Output["geo_lookup"].(map[string]any)
-				newGeo, _ := candidateResp.Events[0].Output["geo_lookup"].(map[string]any)
-				require.Equal(t, "8.8.8.8", oldGeo["ip"], "baseline: geo_lookup should contain correct ip")
-				require.Equal(t, "8.8.8.8", newGeo["ip"], "candidate: geo_lookup should contain correct ip")
+				baselineGeo, _ := baselineResp.Events[0].Output["geo_lookup"].(map[string]any)
+				candidateGeo, _ := candidateResp.Events[0].Output["geo_lookup"].(map[string]any)
+				require.Equal(t, "8.8.8.8", baselineGeo["ip"], "baseline: geo_lookup should contain correct ip")
+				require.Equal(t, "8.8.8.8", candidateGeo["ip"], "candidate: geo_lookup should contain correct ip")
 
 				diff, equal := baselineResp.Equal(&candidateResp)
 				if equal {
@@ -874,10 +874,10 @@ def transformBatch(events, metadata):
 				// Second should have different geo data
 				expectedIPs := []string{"1.2.3.4", "8.8.8.8", "1.2.3.4"}
 				for i := range baselineResp.Events {
-					oldGeo, _ := baselineResp.Events[i].Output["geo"].(map[string]any)
-					newGeo, _ := candidateResp.Events[i].Output["geo"].(map[string]any)
-					require.Equalf(t, expectedIPs[i], oldGeo["ip"], "baseline: event %d geo should contain correct ip", i)
-					require.Equalf(t, expectedIPs[i], newGeo["ip"], "candidate: event %d geo should contain correct ip", i)
+					baselineGeo, _ := baselineResp.Events[i].Output["geo"].(map[string]any)
+					candidateGeo, _ := candidateResp.Events[i].Output["geo"].(map[string]any)
+					require.Equalf(t, expectedIPs[i], baselineGeo["ip"], "baseline: event %d geo should contain correct ip", i)
+					require.Equalf(t, expectedIPs[i], candidateGeo["ip"], "candidate: event %d geo should contain correct ip", i)
 				}
 
 				diff, equal := baselineResp.Equal(&candidateResp)
@@ -1156,10 +1156,10 @@ def transformEvent(event, metadata):
 				require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
 				// Geo data should be present with correct IP but empty values
-				oldGeo, _ := baselineResp.Events[0].Output["geo"].(map[string]any)
-				newGeo, _ := candidateResp.Events[0].Output["geo"].(map[string]any)
-				require.Equal(t, "127.0.0.1", oldGeo["ip"], "baseline: geo should contain correct ip")
-				require.Equal(t, "127.0.0.1", newGeo["ip"], "candidate: geo should contain correct ip")
+				baselineGeo, _ := baselineResp.Events[0].Output["geo"].(map[string]any)
+				candidateGeo, _ := candidateResp.Events[0].Output["geo"].(map[string]any)
+				require.Equal(t, "127.0.0.1", baselineGeo["ip"], "baseline: geo should contain correct ip")
+				require.Equal(t, "127.0.0.1", candidateGeo["ip"], "candidate: geo should contain correct ip")
 
 				t.Logf("Baseline geo: %v", baselineResp.Events[0].Output["geo"])
 				t.Logf("Candidate geo: %v", candidateResp.Events[0].Output["geo"])
@@ -1320,6 +1320,9 @@ def transformEvent(event, metadata):
 	allEntries := make(map[string]configBackendEntry, len(subtests))
 	for _, st := range subtests {
 		if st.config != (configBackendEntry{}) {
+			_, dup := allEntries[st.versionID]
+			require.Falsef(t, dup, "duplicate versionID %q: with shared containers the versionID is the only "+
+				"isolation boundary between subtests, so a collision serves one subtest's code to another", st.versionID)
 			allEntries[st.versionID] = st.config
 		}
 	}
@@ -1334,7 +1337,7 @@ def transformEvent(event, metadata):
 		baselineURL = startBaselinePytransformer(t, pool, configBackend.URL, "GEOLOCATION_URL="+geoURL)
 	})
 	wg.Go(func() {
-		candidateURL = startRudderPytransformer(t, pool, configBackend.URL, "GEOLOCATION_URL="+geoURL)
+		candidateURL = startCandidatePytransformer(t, pool, configBackend.URL, "GEOLOCATION_URL="+geoURL)
 	})
 	wg.Wait()
 
@@ -1547,6 +1550,9 @@ def transformBatch(events, metadata):
 	allEntries := make(map[string]configBackendEntry, len(subtests))
 	for _, st := range subtests {
 		if st.config != (configBackendEntry{}) {
+			_, dup := allEntries[st.versionID]
+			require.Falsef(t, dup, "duplicate versionID %q: with shared containers the versionID is the only "+
+				"isolation boundary between subtests, so a collision serves one subtest's code to another", st.versionID)
 			allEntries[st.versionID] = st.config
 		}
 	}
@@ -1563,7 +1569,7 @@ def transformBatch(events, metadata):
 		baselineURL = startBaselinePytransformer(t, pool, configBackend.URL)
 	})
 	wg.Go(func() {
-		candidateURL = startRudderPytransformer(t, pool, configBackend.URL)
+		candidateURL = startCandidatePytransformer(t, pool, configBackend.URL)
 	})
 	wg.Wait()
 
@@ -1584,12 +1590,15 @@ def transformBatch(events, metadata):
 // Both versions raise: "geolocation fetch failed with status code: {code}"
 func TestBackwardsCompatibilityGeolocationFailure(t *testing.T) {
 	type subtest struct {
-		name                string
-		versionID           string
-		config              configBackendEntry
-		setup               func() // called before run to configure mock behavior
-		run                 func(t *testing.T, env *bcTestEnv)
-		skipRetryCountMatch bool // skip assertRetryCountsMatch when old/candidate retry differently
+		name      string
+		versionID string
+		config    configBackendEntry
+		setup     func() // called before run to configure mock behavior
+		run       func(t *testing.T, env *bcTestEnv)
+		// skipRetryCountMatch skips assertRetryCountsMatch. Two releases of the same engine should retry
+		// identically, so a divergence is a real regression: set this only where the subtest itself makes the
+		// counts incomparable (e.g. it drives the two sides differently), and say why at the call site.
+		skipRetryCountMatch bool
 	}
 
 	mockGeoService, mockGeoCfg := newConfigurableMockGeolocationService(t)
@@ -2356,6 +2365,9 @@ def transformEvent(event, metadata):
 	allEntries := make(map[string]configBackendEntry, len(subtests))
 	for _, st := range subtests {
 		if st.config != (configBackendEntry{}) {
+			_, dup := allEntries[st.versionID]
+			require.Falsef(t, dup, "duplicate versionID %q: with shared containers the versionID is the only "+
+				"isolation boundary between subtests, so a collision serves one subtest's code to another", st.versionID)
 			allEntries[st.versionID] = st.config
 		}
 	}
@@ -2363,8 +2375,8 @@ def transformEvent(event, metadata):
 	t.Cleanup(configBackend.Close)
 
 	// Both containers run with the configurable mock geolocation URL.
-	// GEOLOCATION_TIMEOUT_SECS=0.5 governs the GeoTimeout subtest's 1s mock
-	// delay (500 ms < 1 s → retryable 503). SANDBOX_HTTP_BUDGET_S is kept
+	// GEOLOCATION_TIMEOUT_SECS=0.1 governs the GeoTimeout subtest's 500 ms mock
+	// delay (100 ms < 500 ms → retryable 503). SANDBOX_HTTP_BUDGET_S is kept
 	// low as a guard for any future subtest exercising user HTTP traffic; it
 	// does NOT affect geolocation calls — see
 	// TestSandboxHTTPBudgetDoesNotCapGeolocation.
@@ -2382,7 +2394,7 @@ def transformEvent(event, metadata):
 		baselineURL = startBaselinePytransformer(t, pool, configBackend.URL, pytEnv...)
 	})
 	wg.Go(func() {
-		candidateURL = startRudderPytransformer(t, pool, configBackend.URL, pytEnv...)
+		candidateURL = startCandidatePytransformer(t, pool, configBackend.URL, pytEnv...)
 	})
 	wg.Wait()
 
@@ -2394,6 +2406,9 @@ def transformEvent(event, metadata):
 				withLimitedRetryableHTTPRetries(),
 			)
 
+			// The mock is shared with every other subtest, so hand it back healthy however this one
+			// ends — including on failure, which is when a leaked failure mode would be most confusing.
+			t.Cleanup(mockGeoCfg.reset)
 			if st.setup != nil {
 				st.setup()
 			}

--- a/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
@@ -1618,18 +1618,23 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
+				// Both versions raise GeolocationServerError(BaseException), which bypasses
+				// the user's except Exception and propagates as HTTP 503 with retry →
+				// retries exhausted → failed event. The user's geo_error branch never runs.
 				baselineResp := env.BaselineClient.Transform(context.Background(), events)
 				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected (geo 5xx triggers retries)")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				t.Logf("Baseline error: %q", baselineResp.FailedEvents[0].Error)
 
-				// Baseline: except Exception catches the error → success event with geo_error
-
-				// Candidate: GeolocationServerError(BaseException) bypasses except Exception
-				// → propagates as HTTP 503 with retry → retries exhausted → failed event
 				candidateResp := env.CandidateClient.Transform(context.Background(), events)
 				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo 5xx triggers retries)")
 				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -1655,12 +1660,18 @@ def transformEvent(event, metadata):
 
 				baselineResp := env.BaselineClient.Transform(context.Background(), events)
 				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected (geo 5xx triggers retries)")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				t.Logf("Baseline error: %q", baselineResp.FailedEvents[0].Error)
 
 				candidateResp := env.CandidateClient.Transform(context.Background(), events)
 				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo 5xx triggers retries)")
 				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -1686,12 +1697,18 @@ def transformEvent(event, metadata):
 
 				baselineResp := env.BaselineClient.Transform(context.Background(), events)
 				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected (geo 5xx triggers retries)")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				t.Logf("Baseline error: %q", baselineResp.FailedEvents[0].Error)
 
 				candidateResp := env.CandidateClient.Transform(context.Background(), events)
 				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo 5xx triggers retries)")
 				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -1731,11 +1748,7 @@ def transformEvent(event, metadata):
 				require.Contains(t, candidateError, "status code: 429", "candidate: error should mention 429")
 
 				diff, equal := baselineResp.Equal(&candidateResp)
-				if equal {
-					t.Log("Both versions produce identical responses for 429")
-				} else {
-					t.Errorf("Responses differ:\n%s", diff)
-				}
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -1756,18 +1769,22 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
+				// No try/except here, so the GeolocationServerError propagates on both versions:
+				// 503 with retry → retries exhausted → failed event.
 				baselineResp := env.BaselineClient.Transform(context.Background(), events)
 				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
-
-				// Both produce failed events, but via different paths:
-				// Baseline: exception propagates → failed event with "status code: 500"
-				// Candidate: GeolocationServerError → 503 retries → exhausted → failed event
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				t.Logf("Baseline error: %q", baselineResp.FailedEvents[0].Error)
 
 				candidateResp := env.CandidateClient.Transform(context.Background(), events)
 				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
 				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -1796,11 +1813,16 @@ def transformBatch(events, metadata):
 
 				baselineResp := env.BaselineClient.Transform(context.Background(), events)
 				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected (geo 5xx triggers retries)")
+				require.Equal(t, 3, len(baselineResp.FailedEvents), "baseline: 3 failed events expected")
 
 				candidateResp := env.CandidateClient.Transform(context.Background(), events)
 				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo 5xx triggers retries)")
 				require.Equal(t, 3, len(candidateResp.FailedEvents), "candidate: 3 failed events expected")
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -1829,11 +1851,16 @@ def transformBatch(events, metadata):
 
 				baselineResp := env.BaselineClient.Transform(context.Background(), events)
 				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected (geo 5xx triggers retries)")
+				require.Equal(t, 3, len(baselineResp.FailedEvents), "baseline: 3 failed events expected")
 
 				candidateResp := env.CandidateClient.Transform(context.Background(), events)
 				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo 5xx triggers retries)")
 				require.Equal(t, 3, len(candidateResp.FailedEvents), "candidate: 3 failed events expected")
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -1862,11 +1889,16 @@ def transformBatch(events, metadata):
 
 				baselineResp := env.BaselineClient.Transform(context.Background(), events)
 				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected (geo 5xx triggers retries)")
+				require.Equal(t, 3, len(baselineResp.FailedEvents), "baseline: 3 failed events expected")
 
 				candidateResp := env.CandidateClient.Transform(context.Background(), events)
 				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo 5xx triggers retries)")
 				require.Equal(t, 3, len(candidateResp.FailedEvents), "candidate: 3 failed events expected")
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -1908,11 +1940,7 @@ def transformBatch(events, metadata):
 				}
 
 				diff, equal := baselineResp.Equal(&candidateResp)
-				if equal {
-					t.Log("Both versions produce identical responses for batch 429")
-				} else {
-					t.Errorf("Responses differ:\n%s", diff)
-				}
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -1936,16 +1964,22 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				// Baseline: connection error raises Exception → caught by except → success with geo_error
+				// On both versions the connection error becomes a GeolocationServerError(BaseException), which bypasses
+				// the user's except Exception → 503 retries → failed event.
 				baselineResp := env.BaselineClient.Transform(context.Background(), events)
 				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Equal(t, 0, len(baselineResp.Events), "baseline: no success events expected (geo errors trigger retries)")
+				require.Equal(t, 1, len(baselineResp.FailedEvents), "baseline: 1 failed event expected")
+				t.Logf("Baseline error: %q", baselineResp.FailedEvents[0].Error)
 
-				// Candidate: connection error → GeolocationServerError(BaseException) → 503 retries → failed event
 				candidateResp := env.CandidateClient.Transform(context.Background(), events)
 				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected (geo errors trigger retries)")
 				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -2021,11 +2055,7 @@ def transformEvent(event, metadata):
 				require.Contains(t, candidateError, "status code: 400", "candidate: error should mention 400")
 
 				diff, equal := baselineResp.Equal(&candidateResp)
-				if equal {
-					t.Log("Both versions produce identical responses for 400")
-				} else {
-					t.Errorf("Responses differ:\n%s", diff)
-				}
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -2057,6 +2087,9 @@ def transformEvent(event, metadata):
 				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
 				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -2088,6 +2121,9 @@ def transformEvent(event, metadata):
 				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
 				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -2126,11 +2162,7 @@ def transformEvent(event, metadata):
 				require.Contains(t, candidateError, "status code: 429", "candidate: error should mention 429")
 
 				diff, equal := baselineResp.Equal(&candidateResp)
-				if equal {
-					t.Log("Both versions produce identical error for uncaught 429")
-				} else {
-					t.Errorf("Responses differ:\n%s", diff)
-				}
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -2164,6 +2196,9 @@ def transformEvent(event, metadata):
 				require.Equal(t, 1, len(candidateResp.FailedEvents), "candidate: 1 failed event expected")
 				t.Logf("Candidate error: %q", candidateResp.FailedEvents[0].Error)
 				require.NotEmpty(t, candidateResp.FailedEvents[0].Error, "candidate: should have an error")
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -2195,6 +2230,9 @@ def transformBatch(events, metadata):
 				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 				require.Equal(t, 0, len(candidateResp.Events), "candidate: no success events expected")
 				require.Equal(t, 2, len(candidateResp.FailedEvents), "candidate: 2 failed events expected")
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -2232,6 +2270,9 @@ def transformBatch(events, metadata):
 				for i := range candidateResp.FailedEvents {
 					require.NotEmptyf(t, candidateResp.FailedEvents[i].Error, "candidate: event %d should have an error", i)
 				}
+
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
 			},
 		},
 		{
@@ -2267,14 +2308,19 @@ def transformEvent(event, metadata):
 					makeEvent("msg-1", versionID),
 				}
 
-				// Baseline: openfaas-flask-base catches the timeout via
-				// `except Exception` so the user code records geo_error
-				// and the event succeeds.
+				// Both versions: timeout → GeolocationServerError → HTTP 503 + X-Rudder-Should-Retry →
+				// retries exhausted → failed event (with the user's event["geo_error"] branch never executed).
+				baselineResp := env.BaselineClient.Transform(context.Background(), events)
+				t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
+				require.Len(t, baselineResp.Events, 0,
+					"baseline: slow geolocation must NOT produce a success event "+
+						"(GeolocationServerError must bypass user except-Exception)")
+				require.Len(t, baselineResp.FailedEvents, 1,
+					"baseline: slow geolocation must surface as a failed event after retries")
+				require.Contains(t, baselineResp.FailedEvents[0].Error,
+					"transformer returned status code: 503",
+					"baseline: failed event must carry the correct error message")
 
-				// Candidate: timeout → GeolocationServerError →
-				// HTTP 503 + X-Rudder-Should-Retry → retries exhausted →
-				// failed event (with the user's `event["geo_error"]`
-				// branch never executed).
 				candidateResp := env.CandidateClient.Transform(context.Background(), events)
 				t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 				require.Len(t, candidateResp.Events, 0,
@@ -2286,9 +2332,18 @@ def transformEvent(event, metadata):
 					"transformer returned status code: 503",
 					"candidate: failed event must carry the correct error message")
 
+				diff, equal := baselineResp.Equal(&candidateResp)
+				require.Truef(t, equal, "baseline and candidate must agree:\n%s", diff)
+
 				retriesCounter := env.CandidateStats.GetByName("processor_user_transformer_http_retries")
 				require.Len(t, retriesCounter, 1)
 				require.EqualValues(t, 2, retriesCounter[0].Value)
+
+				// Both versions must exhaust the same retry budget on the same 503.
+				baselineRetries := env.BaselineStats.GetByName("processor_user_transformer_http_retries")
+				require.Len(t, baselineRetries, 1)
+				require.EqualValues(t, retriesCounter[0].Value, baselineRetries[0].Value,
+					"baseline and candidate must retry the same number of times")
 			},
 		},
 	}

--- a/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
+++ b/integration_test/pytransformer_contract/geolocation_backwards_compatibility_test.go
@@ -1319,7 +1319,7 @@ def transformEvent(event, metadata):
 	// Collect all config backend entries.
 	allEntries := make(map[string]configBackendEntry, len(subtests))
 	for _, st := range subtests {
-		if st.config != (configBackendEntry{}) {
+		if !st.config.isZero() {
 			_, dup := allEntries[st.versionID]
 			require.Falsef(t, dup, "duplicate versionID %q: with shared containers the versionID is the only "+
 				"isolation boundary between subtests, so a collision serves one subtest's code to another", st.versionID)
@@ -1549,7 +1549,7 @@ def transformBatch(events, metadata):
 	// Collect all config backend entries.
 	allEntries := make(map[string]configBackendEntry, len(subtests))
 	for _, st := range subtests {
-		if st.config != (configBackendEntry{}) {
+		if !st.config.isZero() {
 			_, dup := allEntries[st.versionID]
 			require.Falsef(t, dup, "duplicate versionID %q: with shared containers the versionID is the only "+
 				"isolation boundary between subtests, so a collision serves one subtest's code to another", st.versionID)
@@ -2364,7 +2364,7 @@ def transformEvent(event, metadata):
 	// Collect all config backend entries.
 	allEntries := make(map[string]configBackendEntry, len(subtests))
 	for _, st := range subtests {
-		if st.config != (configBackendEntry{}) {
+		if !st.config.isZero() {
 			_, dup := allEntries[st.versionID]
 			require.Falsef(t, dup, "duplicate versionID %q: with shared containers the versionID is the only "+
 				"isolation boundary between subtests, so a collision serves one subtest's code to another", st.versionID)

--- a/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
+++ b/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
@@ -27,12 +27,12 @@ import (
 // internal geolocation traffic. The two budgets are independent: geolocation
 // calls are bound exclusively by GEOLOCATION_TIMEOUT_SECS.
 //
-// Scenario: a geolocation backend that replies in 300 ms, with
+// Scenario: a geolocation backend that replies in 200 ms, with
 // SANDBOX_HTTP_BUDGET_S=0.1 s (user cap is SHORTER than the geo response)
 // and GEOLOCATION_TIMEOUT_SECS=0.5 s. Under the contract, the geolocation
 // call must succeed:
 //
-//   - The 300 ms server reply is faster than the 500 ms geolocation budget.
+//   - The 200 ms server reply is faster than the 500 ms geolocation budget.
 //   - The 100 ms sandbox cap is intended for user HTTP traffic and MUST NOT
 //     shadow the internal geolocation deadline.
 func TestSandboxHTTPBudgetDoesNotCapGeolocation(t *testing.T) {
@@ -42,7 +42,7 @@ func TestSandboxHTTPBudgetDoesNotCapGeolocation(t *testing.T) {
 
 	const versionID = "geo-cap-isolation-v1"
 
-	// Geolocation mock that replies after 300 ms with a real JSON body.
+	// Geolocation mock that replies after 200 ms with a real JSON body.
 	// Placed between the 100 ms sandbox cap and the 500 ms geolocation
 	// budget so only the correct deadline can govern the call.
 	mockGeo, geoCalls := newSlowGeolocationServer(t, 200*time.Millisecond)
@@ -62,21 +62,21 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, entries)
 	t.Cleanup(configBackend.Close)
 
-	pyURL := startRudderPytransformer(
+	pyURL := startCandidatePytransformer(
 		t, pool, configBackend.URL,
 		"GEOLOCATION_URL="+mockGeo.URL,
 		// The user HTTP cap is intentionally SHORTER than the geo reply
-		// (100 ms < 300 ms). If the cap were applied to internal traffic,
+		// (100 ms < 200 ms). If the cap were applied to internal traffic,
 		// the geolocation call would time out at 100 ms.
 		"SANDBOX_HTTP_BUDGET_S=0.1",
 		// The geolocation budget is LARGER than the geo reply (500 ms >
-		// 300 ms) so the only legal outcome is success.
+		// 200 ms) so the only legal outcome is success.
 		"GEOLOCATION_TIMEOUT_SECS=0.5",
 	)
 
 	// Limited-retry client so a regression (which would trip retries) is
 	// visible within a bounded test runtime.
-	newStats, err := memstats.New()
+	candidateStats, err := memstats.New()
 	require.NoError(t, err)
 	conf := config.New()
 	setPytransformerRouting(conf, pyURL)
@@ -86,7 +86,7 @@ def transformEvent(event, metadata):
 	conf.Set("Processor.UserTransformer.failOnError", true)
 	conf.Set("Transformer.Client.UserTransformer.retryRudderErrors.maxRetry", 2)
 	conf.Set("Transformer.Client.UserTransformer.retryRudderErrors.maxInterval", 1*time.Millisecond)
-	client := usertransformer.New(conf, logger.NOP, newStats)
+	client := usertransformer.New(conf, logger.NOP, candidateStats)
 
 	events := []types.TransformerEvent{makeEvent("msg-geo-iso-1", versionID)}
 	resp := client.Transform(context.Background(), events)
@@ -94,7 +94,7 @@ def transformEvent(event, metadata):
 	// Happy path: geolocation returned within its 500 ms budget and the
 	// transformation produced a successful event.
 	require.Empty(t, resp.FailedEvents,
-		"geolocation call must succeed when the geo reply (300 ms) is within "+
+		"geolocation call must succeed when the geo reply (200 ms) is within "+
 			"GEOLOCATION_TIMEOUT_SECS (500 ms); SANDBOX_HTTP_BUDGET_S (100 ms) "+
 			"must NOT apply to internal traffic")
 	require.Len(t, resp.Events, 1,
@@ -110,7 +110,7 @@ def transformEvent(event, metadata):
 	// No retries: the client must NOT have retried anything. If the
 	// sandbox cap applied to this internal call, it would fire at 100 ms,
 	// raise GeolocationServerError, and trigger the retry counter here.
-	retriesCounter := newStats.GetByName("processor_user_transformer_http_retries")
+	retriesCounter := candidateStats.GetByName("processor_user_transformer_http_retries")
 	if len(retriesCounter) > 0 {
 		require.EqualValues(t, 0, retriesCounter[0].Value,
 			"no retries must occur — any retry indicates the user HTTP cap "+
@@ -179,7 +179,7 @@ def transformEvent(event, metadata):
 
 	// SANDBOX_HTTP_BUDGET_S=1: our cap is between the user's bigger (5s)
 	// and smaller (0.1s) values, so both subtests can verify the correct cap.
-	pyURL := startRudderPytransformer(
+	pyURL := startCandidatePytransformer(
 		t, pool, configBackend.URL,
 		"SANDBOX_HTTP_BUDGET_S=1",
 	)
@@ -261,7 +261,7 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, entries)
 	t.Cleanup(configBackend.Close)
 
-	poolURL := startRudderPytransformer(
+	poolURL := startCandidatePytransformer(
 		t, pool, configBackend.URL,
 		"USER_CONN_POOL_MAX_SIZE=1",
 		// Single worker so both requests hit the same subprocess
@@ -340,7 +340,7 @@ def transformEvent(event, metadata):
 	configBackend := newContractConfigBackend(t, entries)
 	t.Cleanup(configBackend.Close)
 
-	sharedURL := startRudderPytransformer(
+	sharedURL := startCandidatePytransformer(
 		t, pool, configBackend.URL,
 		"USER_CONN_POOL_MAX_SIZE=1",
 		// Pin to a single worker so both events land in the same
@@ -414,7 +414,7 @@ def transformEvent(event, metadata):
 	// the subprocess-level deadlines far above any plausible cap firing time,
 	// so the only thing that can cause a per-event 400 here is the HTTP-level
 	// wall-clock deadline we are testing.
-	pyURL := startRudderPytransformer(
+	pyURL := startCandidatePytransformer(
 		t, pool, configBackend.URL,
 		"SANDBOX_HTTP_BUDGET_S=1",
 		"SANDBOX_TRANSFORMATION_TIMEOUT_S=20",

--- a/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
+++ b/integration_test/pytransformer_contract/http_timeout_conn_pool_contract_test.go
@@ -79,7 +79,7 @@ def transformEvent(event, metadata):
 	newStats, err := memstats.New()
 	require.NoError(t, err)
 	conf := config.New()
-	conf.Set("PYTHON_TRANSFORM_URL", pyURL)
+	setPytransformerRouting(conf, pyURL)
 	conf.Set("Processor.UserTransformer.maxRetry", 2)
 	conf.Set("Processor.UserTransformer.cpDownEndlessRetries", false)
 	conf.Set("Processor.UserTransformer.maxRetryBackoffInterval", 1*time.Millisecond)

--- a/integration_test/pytransformer_contract/managed_session_contract_test.go
+++ b/integration_test/pytransformer_contract/managed_session_contract_test.go
@@ -917,9 +917,10 @@ def transformEvent(event, metadata):
 	})
 }
 
-// startRudderPytransformerWithMetrics is startRudderPytransformer plus the
+// startRudderPytransformerWithMetrics is startCandidatePytransformer plus the
 // Prometheus metrics port wired through to the host so contract tests can
-// scrape counters and gauges.
+// scrape counters and gauges. Like startCandidatePytransformer it runs the
+// candidate tag, so these tests exercise the same image as the rest of the suite.
 func startRudderPytransformerWithMetrics(
 	t *testing.T, pool *dockertest.Pool,
 	configBackendURL string,
@@ -961,15 +962,16 @@ func startRudderPytransformerWithMetrics(
 		env = append(env, toContainerURL(e))
 	}
 
+	tag := candidatePytransformerTag()
 	container, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository:   "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-pytransformer",
-		Tag:          "main",
+		Repository:   pytransformerImage,
+		Tag:          tag,
 		Auth:         registry.AuthConfiguration(),
 		Env:          env,
 		ExtraHosts:   cfg.ExtraHosts,
 		PortBindings: cfg.PortBindings,
 	}, cfg.hostConfigFn)
-	require.NoError(t, err, "failed to start rudder-pytransformer container")
+	require.NoErrorf(t, err, "failed to start rudder-pytransformer:%s container", tag)
 
 	t.Cleanup(func() {
 		if err := pool.Purge(container); err != nil {

--- a/integration_test/pytransformer_contract/mirror_filter_test.go
+++ b/integration_test/pytransformer_contract/mirror_filter_test.go
@@ -71,13 +71,13 @@ def transformEvent(event, metadata):
 	wg := sync.WaitGroup{}
 	wg.Go(func() {
 		// Start pytransformer WITH mirror filter enabled
-		pyFilteredURL = startRudderPytransformer(
+		pyFilteredURL = startCandidatePytransformer(
 			t, pool, configBackend.URL, "MIRROR_FILTER_ENABLED=true",
 		)
 	})
 	wg.Go(func() {
 		// Start pytransformer WITHOUT mirror filter (default)
-		pyNormalURL = startRudderPytransformer(
+		pyNormalURL = startCandidatePytransformer(
 			t, pool, configBackend.URL,
 		)
 	})

--- a/integration_test/pytransformer_contract/pytransformer_contract_test.go
+++ b/integration_test/pytransformer_contract/pytransformer_contract_test.go
@@ -87,7 +87,7 @@ def transformEvent(event, metadata):
 	defer pyConfigBackend.Close()
 
 	// 4. Start rudder-pytransformer container
-	pyTransformerURL := startRudderPytransformer(t, pool, pyConfigBackend.URL)
+	pyTransformerURL := startCandidatePytransformer(t, pool, pyConfigBackend.URL)
 
 	// 6. Create mock transformer for features and destination transforms
 	// This handles everything except /customTransform (which goes to pytransformer)

--- a/integration_test/pytransformer_contract/redirects_test.go
+++ b/integration_test/pytransformer_contract/redirects_test.go
@@ -45,7 +45,7 @@ func TestConfigBackendRedirectResponse(t *testing.T) {
 			require.NoError(t, err)
 
 			cb := newRedirectingConfigBackend(t, redirectStatus)
-			pyURL := startRudderPytransformer(t, pool, cb.backend.URL)
+			pyURL := startCandidatePytransformer(t, pool, cb.backend.URL)
 
 			status, headers, items := sendRawTransform(t, pyURL, makeEvents(versionID, 1))
 
@@ -101,7 +101,7 @@ func TestConfigBackendRedirectIsRetriedNotDropped(t *testing.T) {
 	defer webhookServer.Close()
 
 	cb := newRedirectingConfigBackend(t, redirectStatus)
-	pyTransformerURL := startRudderPytransformer(t, pool, cb.backend.URL)
+	pyTransformerURL := startCandidatePytransformer(t, pool, cb.backend.URL)
 
 	trServer := transformertest.NewBuilder().Build()
 	defer trServer.Close()

--- a/integration_test/pytransformer_contract/requests_api_contract_test.go
+++ b/integration_test/pytransformer_contract/requests_api_contract_test.go
@@ -20,7 +20,7 @@ import (
 // TestRequestsModuleWrapperContract locks the contract that user code
 // accessing HTTP helpers through alternative module paths produces
 // identical results to the standard "import requests; requests.get(url)"
-// path on both architectures.
+// path on both versions.
 //
 // pytransformer's "wrap_requests_methods" must rebind names on both
 // "requests" and "requests.api", and must also wrap
@@ -32,7 +32,7 @@ import (
 //   - "requests.api.get(url)" — attribute chain resolved at call time
 //   - "requests.request("GET", url)" — verb-parameterized entry point
 //
-// All three must produce the same output as the old architecture
+// All three must produce the same output as the baseline
 // (vanilla "requests").
 //
 // Additional "ConnectionReuse" subtests prove that the calls actually
@@ -132,23 +132,19 @@ def transformEvent(event, metadata):
 	})
 	t.Cleanup(configBackend.Close)
 
-	t.Log("Starting openfaas-flask-base (old arch backend)...")
-	openFaasURL := startOpenFaasFlask(t, pool, parityVersionID, configBackend.URL)
-
-	t.Log("Starting mock OpenFaaS gateway...")
-	mockGateway, _ := newMockOpenFaaSGateway(t, func() string { return openFaasURL })
-	t.Cleanup(mockGateway.Close)
-
-	t.Log("Starting rudder-transformer (old arch frontend)...")
-	transformerURL := startRudderTransformer(t, pool, configBackend.URL, mockGateway.URL)
-
 	// Pin pool + subprocess count to 1 so the ConnectionReuse subtests
-	// actually exercise the shared pooled session.
-	pyTransformerURL := startRudderPytransformer(
-		t, pool, configBackend.URL,
+	// actually exercise the shared pooled session. Identical on both sides
+	// so the comparison isolates the version difference.
+	pytEnv := []string{
 		"USER_CONN_POOL_MAX_SIZE=1",
 		"SANDBOX_POOL_MAX_SIZE=1",
-	)
+	}
+
+	t.Log("Starting baseline rudder-pytransformer...")
+	baselineURL := startBaselinePytransformer(t, pool, configBackend.URL, pytEnv...)
+
+	t.Log("Starting candidate rudder-pytransformer...")
+	candidateURL := startRudderPytransformer(t, pool, configBackend.URL, pytEnv...)
 
 	styleCases := []struct {
 		style string
@@ -160,7 +156,7 @@ def transformEvent(event, metadata):
 
 	for _, sc := range styleCases {
 		t.Run(sc.style, func(t *testing.T) {
-			env := newBCTestEnv(t, transformerURL, pyTransformerURL,
+			env := newBCTestEnv(t, baselineURL, candidateURL,
 				withFailOnError(),
 				withLimitedRetryableHTTPRetries(),
 			)
@@ -169,28 +165,28 @@ def transformEvent(event, metadata):
 			event.Message["style"] = sc.style
 			events := []types.TransformerEvent{event}
 
-			t.Log("Sending request to old architecture...")
-			oldResp := env.OldClient.Transform(context.Background(), events)
-			t.Logf("Old arch: Events=%d, FailedEvents=%d", len(oldResp.Events), len(oldResp.FailedEvents))
+			t.Log("Sending request to baseline...")
+			baselineResp := env.BaselineClient.Transform(context.Background(), events)
+			t.Logf("Baseline: Events=%d, FailedEvents=%d", len(baselineResp.Events), len(baselineResp.FailedEvents))
 
-			t.Log("Sending request to new architecture...")
-			newResp := env.NewClient.Transform(context.Background(), events)
-			t.Logf("New arch: Events=%d, FailedEvents=%d", len(newResp.Events), len(newResp.FailedEvents))
+			t.Log("Sending request to candidate...")
+			candidateResp := env.CandidateClient.Transform(context.Background(), events)
+			t.Logf("Candidate: Events=%d, FailedEvents=%d", len(candidateResp.Events), len(candidateResp.FailedEvents))
 
-			require.Equal(t, 1, len(oldResp.Events), "old arch: 1 success event expected")
-			require.Equal(t, 0, len(oldResp.FailedEvents), "old arch: no failed events expected")
-			require.Equalf(t, 1, len(newResp.Events),
-				"new arch (style=%s): 1 success event expected", sc.style)
-			require.Equal(t, 0, len(newResp.FailedEvents), "new arch: no failed events expected")
+			require.Equal(t, 1, len(baselineResp.Events), "baseline: 1 success event expected")
+			require.Equal(t, 0, len(baselineResp.FailedEvents), "baseline: no failed events expected")
+			require.Equalf(t, 1, len(candidateResp.Events),
+				"candidate (style=%s): 1 success event expected", sc.style)
+			require.Equal(t, 0, len(candidateResp.FailedEvents), "candidate: no failed events expected")
 
-			require.Equal(t, "hello", oldResp.Events[0].Output["echo"],
-				"old arch must echo q=hello")
-			require.Equalf(t, "hello", newResp.Events[0].Output["echo"],
-				"new arch (style=%s) must echo q=hello", sc.style)
+			require.Equal(t, "hello", baselineResp.Events[0].Output["echo"],
+				"baseline must echo q=hello")
+			require.Equalf(t, "hello", candidateResp.Events[0].Output["echo"],
+				"candidate (style=%s) must echo q=hello", sc.style)
 
-			diff, equal := oldResp.Equal(&newResp)
+			diff, equal := baselineResp.Equal(&candidateResp)
 			require.Truef(t, equal,
-				"style=%s: old and new architectures must produce identical responses:\n%s",
+				"style=%s: baseline and candidate must produce identical responses:\n%s",
 				sc.style, diff)
 
 			env.assertRetryCountsMatch(t)
@@ -209,7 +205,7 @@ def transformEvent(event, metadata):
 	// rebound to the wrapper. (The count can legitimately be 0 if an
 	// earlier subtest already warmed a connection to the shared
 	// countingEcho host; both subtests run against the same
-	// pyTransformerURL and thus the same subprocess-shared pool.)
+	// candidate container and thus the same subprocess-shared pool.)
 	reuseCases := []struct {
 		name      string
 		versionID string
@@ -222,13 +218,13 @@ def transformEvent(event, metadata):
 			newConns.Store(0)
 
 			ev1 := makeEvent("msg-reuse-1", rc.versionID)
-			status1, _, items1 := sendRawTransform(t, pyTransformerURL, []types.TransformerEvent{ev1})
+			status1, _, items1 := sendRawTransform(t, candidateURL, []types.TransformerEvent{ev1})
 			require.Equal(t, http.StatusOK, status1)
 			require.Len(t, items1, 1)
 			require.Equal(t, http.StatusOK, items1[0].StatusCode, "first request must succeed")
 
 			ev2 := makeEvent("msg-reuse-2", rc.versionID)
-			status2, _, items2 := sendRawTransform(t, pyTransformerURL, []types.TransformerEvent{ev2})
+			status2, _, items2 := sendRawTransform(t, candidateURL, []types.TransformerEvent{ev2})
 			require.Equal(t, http.StatusOK, status2)
 			require.Len(t, items2, 1)
 			require.Equal(t, http.StatusOK, items2[0].StatusCode, "second request must succeed")

--- a/integration_test/pytransformer_contract/requests_api_contract_test.go
+++ b/integration_test/pytransformer_contract/requests_api_contract_test.go
@@ -32,8 +32,7 @@ import (
 //   - "requests.api.get(url)" — attribute chain resolved at call time
 //   - "requests.request("GET", url)" — verb-parameterized entry point
 //
-// All three must produce the same output as the baseline
-// (vanilla "requests").
+// All three must produce the same output on both versions.
 //
 // Additional "ConnectionReuse" subtests prove that the calls actually
 // flow through the pooling wrapper by sending two sequential requests
@@ -144,7 +143,7 @@ def transformEvent(event, metadata):
 	baselineURL := startBaselinePytransformer(t, pool, configBackend.URL, pytEnv...)
 
 	t.Log("Starting candidate rudder-pytransformer...")
-	candidateURL := startRudderPytransformer(t, pool, configBackend.URL, pytEnv...)
+	candidateURL := startCandidatePytransformer(t, pool, configBackend.URL, pytEnv...)
 
 	styleCases := []struct {
 		style string

--- a/integration_test/pytransformer_contract/test_endpoints_contract_test.go
+++ b/integration_test/pytransformer_contract/test_endpoints_contract_test.go
@@ -1,15 +1,11 @@
 package pytransformer_contract
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -21,36 +17,28 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/stats"
-	dockertesthelper "github.com/rudderlabs/rudder-go-kit/testhelper/docker"
-	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/registry"
 
 	"github.com/rudderlabs/rudder-server/processor/usertransformer"
 )
 
 // TestPyTransformerTestEndpoints pins the wire contract of the four
-// control-plane endpoints introduced for the Python transformation-test flow,
-// comparing the new architecture against the old one:
+// control-plane endpoints for the Python transformation-test flow:
 //
-//	pyt POST /test          ~ rudder-transformer POST /transformation/test
-//	pyt POST /testRun       ~ rudder-transformer POST /transformation/testRun
-//	pyt POST /test-library  ~ rudder-transformer POST /transformationLibrary/test
-//	pyt POST /extract-libs  ~ rudder-transformer POST /extractLibs
+//	POST /test
+//	POST /testRun
+//	POST /test-library
+//	POST /extract-libs
 //
-// Old architecture: rudder-transformer (TRANSFORMER_TEST_MODE=true) deploys a
-// per-request OpenFaaS function whose fprocess carries the inline code, invokes
-// it, and deletes it; the AST routes invoke the long-lived fn-ast function. The
-// dynamic mock gateway backs each deployment with a real openfaas-flask-base
-// container so the inline code actually runs.
+// Both sides go through usertransformer.Client.Test/TestRun/TestLibrary/
+// ExtractLibs — the same methods cpservice.Forward uses in production — so the
+// test covers the exact client → pyt path. Only the target base URL differs:
+// the baseline release on one side, the candidate on the other, which is the
+// role cpservice.Forward plays in production.
 //
-// New architecture: requests go through usertransformer.Client.Test/TestRun/
-// TestLibrary/ExtractLibs — the same methods cpservice.Forward uses in
-// production — so the test covers the exact client → pyt path.
-//
-// Responses are compared byte-for-byte except where rudder-pytransformer
-// deliberately (and documentedly, see its README) diverges:
-//   - AST import-violation messages: pyt surfaces the runtime's wording
-//     ("Import of 'os' is not allowed. ...") instead of fn-ast's
-//     ("Unpermitted import(s). ...") — the runtime is the source of truth.
+// Responses are compared byte-for-byte. Several assertions below carry comments
+// about wording that "deliberately differs" from openfaas's fn-ast; those record
+// why pyt's wording is what it is, and are kept as documentation of the intended
+// message. They no longer describe a difference between the two sides.
 func TestPyTransformerTestEndpoints(t *testing.T) {
 	env := newTestEndpointsEnv(t)
 
@@ -67,17 +55,17 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "m2"}, "metadata": map[string]any{"messageId": "m2"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.Test, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.Test, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old status %d, old body: %s", oldStatus, oldBody)
-			resp := decodeFlow(t, newBody)
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old status %d, old body: %s", baselineStatus, baselineBody)
+			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 2)
 			for _, ev := range resp.TransformedEvents {
 				require.Equal(t, "bar", ev["foo"])
 			}
-			compareTestFlowBodies(t, oldBody, newBody)
+			compareTestFlowBodies(t, baselineBody, candidateBody)
 		})
 
 		t.Run("should fetch libraries from the config backend", func(t *testing.T) {
@@ -92,15 +80,15 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				},
 				"libraryVersionIDs": []string{libVersionID},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.Test, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.Test, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			resp := decodeFlow(t, newBody)
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			require.EqualValues(t, 42, resp.TransformedEvents[0]["doubled"])
-			compareTestFlowBodies(t, oldBody, newBody)
+			compareTestFlowBodies(t, baselineBody, candidateBody)
 		})
 
 		t.Run("should expose request credentials via getCredential", func(t *testing.T) {
@@ -115,15 +103,15 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				},
 				"credentials": []map[string]any{{"key": "API_KEY", "value": "secret123"}},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.Test, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.Test, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			resp := decodeFlow(t, newBody)
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			require.Equal(t, "secret123", resp.TransformedEvents[0]["secret"])
-			compareTestFlowBodies(t, oldBody, newBody)
+			compareTestFlowBodies(t, baselineBody, candidateBody)
 		})
 
 		t.Run("should keep a single event's error inline with HTTP 200", func(t *testing.T) {
@@ -138,13 +126,13 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "m1", "n": 1}, "metadata": map[string]any{"messageId": "m1"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.Test, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.Test, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
 
-			resp := decodeFlow(t, newBody)
+			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 2)
 			var errored []map[string]any
 			for _, ev := range resp.TransformedEvents {
@@ -157,7 +145,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			require.NotContains(t, errored[0], "metadata",
 				"errored /test elements are {error} only, matching rudder-transformer")
 
-			compareTestFlowBodies(t, oldBody, newBody)
+			compareTestFlowBodies(t, baselineBody, candidateBody)
 		})
 
 		// Both engines key per-event metadata by the message body's messageId,
@@ -174,16 +162,16 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "dup-1", "n": 2}, "metadata": map[string]any{"messageId": "dup-1", "sourceId": "s2"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.Test, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.Test, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			resp := decodeFlow(t, newBody)
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 2)
 			require.EqualValues(t, 2, resp.TransformedEvents[0]["doubled"])
 			require.EqualValues(t, 4, resp.TransformedEvents[1]["doubled"])
-			compareTestFlowBodies(t, oldBody, newBody)
+			compareTestFlowBodies(t, baselineBody, candidateBody)
 		})
 
 		// Metadata without a messageId is echoed as-is on errored elements —
@@ -200,18 +188,18 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "m1", "n": 1}, "metadata": map[string]any{"sourceId": "s1"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.Test, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.Test, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			resp := decodeFlow(t, newBody)
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 2)
 			errored := resp.TransformedEvents[1]
 			require.Contains(t, errored["error"], "no meta id")
 			require.NotContains(t, errored, "metadata",
 				"errored /test elements are {error} only, matching rudder-transformer")
-			compareTestFlowBodies(t, oldBody, newBody)
+			compareTestFlowBodies(t, baselineBody, candidateBody)
 		})
 
 		t.Run("should return HTTP 400 with a top-level error for a compile error", func(t *testing.T) {
@@ -226,17 +214,17 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "m1"}, "metadata": map[string]any{"messageId": "m1"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.Test, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.Test, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			// The wording deliberately differs: the old arch surfaces fn-ast's
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			// The wording deliberately differs: the baseline surfaces fn-ast's
 			// BadCodeError (its import extraction parses the code before the
 			// function is even deployed), pyt surfaces its runtime compiler's
 			// message. Both must carry Python's syntax diagnosis.
-			oldErr := decodeError(t, oldBody)
-			newErr := decodeError(t, newBody)
+			oldErr := decodeError(t, baselineBody)
+			newErr := decodeError(t, candidateBody)
 			t.Logf("compile error — old: %q new: %q", oldErr, newErr)
 			require.Contains(t, oldErr, "expected ':'")
 			require.Contains(t, newErr, "expected ':'")
@@ -249,13 +237,13 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "m1"}, "metadata": map[string]any{"messageId": "m1"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.Test, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.Test, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus)
-			require.Equal(t, "Error: Invalid Request. Missing parameters in transformation code block", decodeError(t, newBody))
-			require.Equal(t, decodeError(t, oldBody), decodeError(t, newBody))
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus)
+			require.Equal(t, "Error: Invalid Request. Missing parameters in transformation code block", decodeError(t, candidateBody))
+			require.Equal(t, decodeError(t, baselineBody), decodeError(t, candidateBody))
 		})
 
 		t.Run("should return the verbatim missing-events error", func(t *testing.T) {
@@ -267,22 +255,23 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				},
 				"events": []map[string]any{},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.Test, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.Test, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus)
-			require.Equal(t, "Error: Invalid request. Missing events", decodeError(t, newBody))
-			require.Equal(t, decodeError(t, oldBody), decodeError(t, newBody))
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus)
+			require.Equal(t, "Error: Invalid request. Missing events", decodeError(t, candidateBody))
+			require.Equal(t, decodeError(t, baselineBody), decodeError(t, candidateBody))
 		})
 
-		// Known security tightening: pyt compiles with RestrictedPython 8, whose
-		// transformer blocks generator/frame introspection attributes
-		// (INSPECT_ATTRIBUTES — the CVE-2023-37271 sandbox-escape fix: gi_frame,
-		// f_back, cr_frame, ...). The old architecture runs RestrictedPython 6.1,
-		// which predates the fix and only guards underscore-prefixed names, so
-		// the same code compiles AND executes there.
-		t.Run("should reject frame-introspection code the old architecture compiles and runs", func(t *testing.T) {
+		// Security property, not a parity check: pyt compiles with
+		// RestrictedPython 8, whose transformer blocks generator/frame
+		// introspection attributes (INSPECT_ATTRIBUTES — the CVE-2023-37271
+		// sandbox-escape fix: gi_frame, f_back, cr_frame, ...). openfaas ran
+		// RestrictedPython 6.1, which predates the fix, and this case existed to
+		// pin that tightening. Both versions must now reject it — a release that
+		// loosened it back would be a security regression.
+		t.Run("should reject frame-introspection code", func(t *testing.T) {
 			payload := map[string]any{
 				"trRevCode": map[string]any{
 					"code":        "def transformEvent(event, metadata):\n    gen = (x for x in [1])\n    event['has_frame'] = gen.gi_frame is None\n    return event",
@@ -293,26 +282,23 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "m1"}, "metadata": map[string]any{"messageId": "m1"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.Test, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.Test, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
-			require.Equal(t, http.StatusOK, oldStatus, "old architecture accepts, body: %s", oldBody)
-			oldResp := decodeFlow(t, oldBody)
-			require.Len(t, oldResp.TransformedEvents, 1)
-			require.Equal(t, false, oldResp.TransformedEvents[0]["has_frame"],
-				"old architecture executed the gi_frame access")
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "candidate must reject at compile, body: %s", candidateBody)
+			require.Contains(t, decodeError(t, candidateBody), "gi_frame")
+			require.Contains(t, decodeError(t, candidateBody), "restricted name")
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "pyt rejects at compile, body: %s", newBody)
-			require.Contains(t, decodeError(t, newBody), "gi_frame")
-			require.Contains(t, decodeError(t, newBody), "restricted name")
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
+			require.Equal(t, decodeError(t, baselineBody), decodeError(t, candidateBody))
 		})
 
-		// pyt-only: in the old architecture an unknown library version crashes
+		// pyt-only: in the baseline an unknown library version crashes
 		// the deployed flask container at startup (its --lvids fetch fails), so
 		// the request degenerates into a readiness-timeout/retry loop rather
 		// than a comparable 400.
 		t.Run("should return HTTP 400 when a library cannot be fetched", func(t *testing.T) {
-			newStatus, newBody := env.callNew(t, env.client.Test, map[string]any{
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, map[string]any{
 				"trRevCode": map[string]any{
 					"code":        "def transformEvent(event, metadata):\n    return event",
 					"codeVersion": "1",
@@ -323,8 +309,8 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				},
 				"libraryVersionIDs": []string{"unknown-library-version"},
 			})
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.NotEmpty(t, decodeError(t, newBody))
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.NotEmpty(t, decodeError(t, candidateBody))
 		})
 	})
 
@@ -340,19 +326,19 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "m1"}, "metadata": map[string]any{"messageId": "m1", "sourceId": "s1"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/testRun", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestRun, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestRun, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			resp := decodeFlow(t, newBody)
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			el := resp.TransformedEvents[0]
 			transformed, ok := el["transformedEvent"].(map[string]any)
 			require.True(t, ok, "element carries the transformed event under the transformedEvent key, matching rudder-transformer")
 			require.Equal(t, "bar", transformed["foo"])
 			require.NotContains(t, el, "statusCode", "no statusCode, matching rudder-transformer")
-			compareTestFlowBodies(t, oldBody, newBody)
+			compareTestFlowBodies(t, baselineBody, candidateBody)
 		})
 
 		// Test-case metadata is user-authored JSON: neither engine validates its
@@ -376,18 +362,18 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/testRun", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestRun, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestRun, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			resp := decodeFlow(t, newBody)
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			meta, ok := resp.TransformedEvents[0]["metadata"].(map[string]any)
 			require.True(t, ok)
 			require.EqualValues(t, 123, meta["rudderId"], "int rudderId is echoed back, not rejected")
 			require.Contains(t, meta, "customKey", "unknown metadata keys are echoed back, not dropped")
-			compareTestFlowBodies(t, oldBody, newBody)
+			compareTestFlowBodies(t, baselineBody, candidateBody)
 		})
 
 		t.Run("should resolve dependencies libraries and credentials", func(t *testing.T) {
@@ -405,18 +391,18 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					"credentials": []map[string]any{{"key": "API_KEY", "value": "secret123"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/testRun", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestRun, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestRun, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			resp := decodeFlow(t, newBody)
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			transformed, ok := resp.TransformedEvents[0]["transformedEvent"].(map[string]any)
 			require.True(t, ok)
 			require.EqualValues(t, 42, transformed["doubled"])
 			require.Equal(t, "secret123", transformed["secret"])
-			compareTestFlowBodies(t, oldBody, newBody)
+			compareTestFlowBodies(t, baselineBody, candidateBody)
 		})
 
 		t.Run("should keep a per-event error inline with its metadata", func(t *testing.T) {
@@ -430,12 +416,12 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "m1"}, "metadata": map[string]any{"messageId": "m1"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/testRun", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestRun, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestRun, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			resp := decodeFlow(t, newBody)
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			el := resp.TransformedEvents[0]
 			require.Contains(t, el["error"], "boom")
@@ -443,7 +429,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			require.True(t, ok, "errored /testRun elements keep the input event's metadata")
 			require.Equal(t, "m1", meta["messageId"])
 			require.NotContains(t, el, "statusCode", "no statusCode, matching rudder-transformer")
-			compareTestFlowBodies(t, oldBody, newBody)
+			compareTestFlowBodies(t, baselineBody, candidateBody)
 		})
 
 		// Both engines key echoed metadata by the message body's messageId, so
@@ -461,12 +447,12 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "dup-1", "n": 2}, "metadata": map[string]any{"messageId": "dup-1", "sourceId": "s2"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/testRun", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestRun, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestRun, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			resp := decodeFlow(t, newBody)
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 2)
 			for i, el := range resp.TransformedEvents {
 				transformed, ok := el["transformedEvent"].(map[string]any)
@@ -476,7 +462,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				require.True(t, ok)
 				require.Equal(t, "s2", meta["sourceId"], "last event's metadata wins for element %d", i)
 			}
-			compareTestFlowBodies(t, oldBody, newBody)
+			compareTestFlowBodies(t, baselineBody, candidateBody)
 		})
 
 		t.Run("should echo metadata without messageId as-is", func(t *testing.T) {
@@ -490,16 +476,16 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "m1"}, "metadata": map[string]any{"sourceId": "s1"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/testRun", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestRun, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestRun, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			resp := decodeFlow(t, newBody)
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			require.Equal(t, map[string]any{"sourceId": "s1"}, resp.TransformedEvents[0]["metadata"],
 				"metadata is echoed as-is, without injecting a messageId")
-			compareTestFlowBodies(t, oldBody, newBody)
+			compareTestFlowBodies(t, baselineBody, candidateBody)
 		})
 
 		t.Run("should return HTTP 400 with a top-level error for a compile error", func(t *testing.T) {
@@ -514,15 +500,15 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "m1"}, "metadata": map[string]any{"messageId": "m1"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/testRun", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestRun, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestRun, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
 			// Wording deliberately differs (fn-ast BadCodeError vs pyt's runtime
 			// compiler); both must carry Python's syntax diagnosis.
-			oldErr := decodeError(t, oldBody)
-			newErr := decodeError(t, newBody)
+			oldErr := decodeError(t, baselineBody)
+			newErr := decodeError(t, candidateBody)
 			t.Logf("compile error — old: %q new: %q", oldErr, newErr)
 			require.Contains(t, oldErr, "expected ':'")
 			require.Contains(t, newErr, "expected ':'")
@@ -535,13 +521,13 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "m1"}, "metadata": map[string]any{"messageId": "m1"}},
 				},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/testRun", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestRun, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestRun, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus)
-			require.Equal(t, "Error: Invalid Request. Missing parameters in transformation code block", decodeError(t, newBody))
-			require.Equal(t, decodeError(t, oldBody), decodeError(t, newBody))
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus)
+			require.Equal(t, "Error: Invalid Request. Missing parameters in transformation code block", decodeError(t, candidateBody))
+			require.Equal(t, decodeError(t, baselineBody), decodeError(t, candidateBody))
 		})
 
 		t.Run("should return the verbatim missing-events error", func(t *testing.T) {
@@ -553,13 +539,13 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				},
 				"input": []map[string]any{},
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformation/testRun", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestRun, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestRun, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus)
-			require.Equal(t, "Error: Invalid request. Missing events", decodeError(t, newBody))
-			require.Equal(t, decodeError(t, oldBody), decodeError(t, newBody))
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus)
+			require.Equal(t, "Error: Invalid request. Missing events", decodeError(t, candidateBody))
+			require.Equal(t, decodeError(t, baselineBody), decodeError(t, candidateBody))
 		})
 	})
 
@@ -569,13 +555,13 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				"code":     "import json\nimport datetime\ndef double(x):\n    return x * 2",
 				"language": "pythonfaas",
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformationLibrary/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestLibrary, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestLibrary, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestLibrary, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			require.Equal(t, map[string]any{"json": []any{}, "datetime": []any{}}, decodeImportMap(t, newBody))
-			require.Equal(t, decodeImportMap(t, oldBody), decodeImportMap(t, newBody))
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, map[string]any{"json": []any{}, "datetime": []any{}}, decodeImportMap(t, candidateBody))
+			require.Equal(t, decodeImportMap(t, baselineBody), decodeImportMap(t, candidateBody))
 		})
 
 		t.Run("should reject a non-whitelisted import with the runtime's message", func(t *testing.T) {
@@ -583,16 +569,16 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				"code":     "import os\ndef double(x):\n    return x * 2",
 				"language": "pythonfaas",
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformationLibrary/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestLibrary, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestLibrary, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestLibrary, payload)
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
 			// The wording deliberately differs: fn-ast says "Unpermitted
 			// import(s). ...", pyt surfaces the runtime's message so static
 			// validation and runtime can't drift.
-			require.NotEmpty(t, decodeError(t, oldBody))
-			require.Contains(t, decodeError(t, newBody), "Import of 'os' is not allowed.")
+			require.NotEmpty(t, decodeError(t, baselineBody))
+			require.Contains(t, decodeError(t, candidateBody), "Import of 'os' is not allowed.")
 		})
 
 		t.Run("should key the import map by the module path as written", func(t *testing.T) {
@@ -600,49 +586,50 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				"code":     "import urllib.parse\nfrom dateutil.parser import parse",
 				"language": "pythonfaas",
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformationLibrary/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestLibrary, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestLibrary, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestLibrary, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			require.Equal(t, map[string]any{"urllib.parse": []any{}, "dateutil.parser": []any{}}, decodeImportMap(t, newBody))
-			require.Equal(t, decodeImportMap(t, oldBody), decodeImportMap(t, newBody))
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, map[string]any{"urllib.parse": []any{}, "dateutil.parser": []any{}}, decodeImportMap(t, candidateBody))
+			require.Equal(t, decodeImportMap(t, baselineBody), decodeImportMap(t, candidateBody))
 		})
 
-		// Known security tightening: pyt's runtime blocks urllib.request (raw
-		// HTTP would bypass the requests wrappers), and its validator agrees
-		// with its runtime. fn-ast accepted it (only the top-level "urllib" is
-		// whitelisted-checked there).
-		t.Run("should reject urllib.request that the old architecture accepts", func(t *testing.T) {
+		// Security property, not a parity check: pyt's runtime blocks
+		// urllib.request (raw HTTP would bypass the requests wrappers) and its
+		// validator agrees with its runtime. openfaas's fn-ast accepted it (only
+		// the top-level "urllib" was whitelist-checked there), and this case
+		// existed to pin that tightening. Both versions must now reject it.
+		t.Run("should reject urllib.request", func(t *testing.T) {
 			payload := map[string]any{
 				"code":     "import urllib.request",
 				"language": "pythonfaas",
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformationLibrary/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestLibrary, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestLibrary, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestLibrary, payload)
 
-			require.Equal(t, http.StatusOK, oldStatus, "old architecture accepts, body: %s", oldBody)
-			require.Equal(t, map[string]any{"urllib.request": []any{}}, decodeImportMap(t, oldBody))
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "candidate must reject, body: %s", candidateBody)
+			require.Contains(t, decodeError(t, candidateBody), "Import of 'urllib.request' is not allowed.")
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "pyt rejects, body: %s", newBody)
-			require.Contains(t, decodeError(t, newBody), "Import of 'urllib.request' is not allowed.")
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
+			require.Equal(t, decodeError(t, baselineBody), decodeError(t, candidateBody))
 		})
 
 		// Both reject relative imports; the wording deliberately differs —
 		// fn-ast surfaces an incidental crash trace ("'NoneType' object has no
 		// attribute 'split'"), pyt a clean message.
-		t.Run("should reject relative imports like the old architecture", func(t *testing.T) {
+		t.Run("should reject relative imports", func(t *testing.T) {
 			payload := map[string]any{
 				"code":     "from . import helper",
 				"language": "pythonfaas",
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformationLibrary/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestLibrary, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestLibrary, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestLibrary, payload)
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			require.NotEmpty(t, decodeError(t, oldBody))
-			require.Equal(t, "Relative imports are not allowed.", decodeError(t, newBody))
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.NotEmpty(t, decodeError(t, baselineBody))
+			require.Equal(t, "Relative imports are not allowed.", decodeError(t, candidateBody))
 		})
 
 		t.Run("should return HTTP 400 for a syntax error", func(t *testing.T) {
@@ -650,26 +637,26 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				"code":     "def double(x)\n    return x * 2",
 				"language": "pythonfaas",
 			}
-			oldStatus, oldBody := env.callOld(t, "/transformationLibrary/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestLibrary, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestLibrary, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestLibrary, payload)
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
 			// Wording deliberately differs (fn-ast BadCodeError vs pyt's runtime
 			// compiler); both must carry Python's syntax diagnosis.
-			require.Contains(t, decodeError(t, oldBody), "expected ':'")
-			require.Contains(t, decodeError(t, newBody), "expected ':'")
+			require.Contains(t, decodeError(t, baselineBody), "expected ':'")
+			require.Contains(t, decodeError(t, candidateBody), "expected ':'")
 		})
 
 		t.Run("should return the verbatim missing-code error", func(t *testing.T) {
 			payload := map[string]any{"language": "pythonfaas"}
-			oldStatus, oldBody := env.callOld(t, "/transformationLibrary/test", payload)
-			newStatus, newBody := env.callNew(t, env.client.TestLibrary, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.TestLibrary, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestLibrary, payload)
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus)
-			require.Equal(t, "Invalid request. Missing code", decodeError(t, newBody))
-			require.Equal(t, decodeError(t, oldBody), decodeError(t, newBody))
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus)
+			require.Equal(t, "Invalid request. Missing code", decodeError(t, candidateBody))
+			require.Equal(t, decodeError(t, baselineBody), decodeError(t, candidateBody))
 		})
 	})
 
@@ -680,13 +667,13 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				"language":        "pythonfaas",
 				"validateImports": false,
 			}
-			oldStatus, oldBody := env.callOld(t, "/extractLibs", payload)
-			newStatus, newBody := env.callNew(t, env.client.ExtractLibs, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.ExtractLibs, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.ExtractLibs, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			require.Equal(t, map[string]any{"os": []any{}, "json": []any{}}, decodeImportMap(t, newBody))
-			require.Equal(t, decodeImportMap(t, oldBody), decodeImportMap(t, newBody))
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, map[string]any{"os": []any{}, "json": []any{}}, decodeImportMap(t, candidateBody))
+			require.Equal(t, decodeImportMap(t, baselineBody), decodeImportMap(t, candidateBody))
 		})
 
 		t.Run("should allow additional libraries under validation", func(t *testing.T) {
@@ -696,13 +683,13 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				"validateImports":     true,
 				"additionalLibraries": []string{"mylib"},
 			}
-			oldStatus, oldBody := env.callOld(t, "/extractLibs", payload)
-			newStatus, newBody := env.callNew(t, env.client.ExtractLibs, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.ExtractLibs, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.ExtractLibs, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			require.Equal(t, map[string]any{"mylib": []any{}, "json": []any{}}, decodeImportMap(t, newBody))
-			require.Equal(t, decodeImportMap(t, oldBody), decodeImportMap(t, newBody))
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, map[string]any{"mylib": []any{}, "json": []any{}}, decodeImportMap(t, candidateBody))
+			require.Equal(t, decodeImportMap(t, baselineBody), decodeImportMap(t, candidateBody))
 		})
 
 		t.Run("should extract dotted imports with their full path when validation is off", func(t *testing.T) {
@@ -711,32 +698,32 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				"language":        "pythonfaas",
 				"validateImports": false,
 			}
-			oldStatus, oldBody := env.callOld(t, "/extractLibs", payload)
-			newStatus, newBody := env.callNew(t, env.client.ExtractLibs, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.ExtractLibs, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.ExtractLibs, payload)
 
-			require.Equal(t, http.StatusOK, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			require.Equal(t, map[string]any{"os.path": []any{}}, decodeImportMap(t, newBody))
-			require.Equal(t, decodeImportMap(t, oldBody), decodeImportMap(t, newBody))
+			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, map[string]any{"os.path": []any{}}, decodeImportMap(t, candidateBody))
+			require.Equal(t, decodeImportMap(t, baselineBody), decodeImportMap(t, candidateBody))
 		})
 
 		// Both reject relative imports (regardless of validateImports); the
 		// wording deliberately differs — fn-ast surfaces an incidental crash
 		// trace ("'NoneType' object has no attribute 'split'"), pyt a clean
 		// message.
-		t.Run("should reject relative imports like the old architecture", func(t *testing.T) {
+		t.Run("should reject relative imports", func(t *testing.T) {
 			payload := map[string]any{
 				"code":            "from . import helper",
 				"language":        "pythonfaas",
 				"validateImports": false,
 			}
-			oldStatus, oldBody := env.callOld(t, "/extractLibs", payload)
-			newStatus, newBody := env.callNew(t, env.client.ExtractLibs, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.ExtractLibs, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.ExtractLibs, payload)
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
-			require.NotEmpty(t, decodeError(t, oldBody))
-			require.Equal(t, "Relative imports are not allowed.", decodeError(t, newBody))
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.NotEmpty(t, decodeError(t, baselineBody))
+			require.Equal(t, "Relative imports are not allowed.", decodeError(t, candidateBody))
 		})
 
 		t.Run("should reject a non-whitelisted import when validation is on", func(t *testing.T) {
@@ -745,14 +732,14 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				"language":        "pythonfaas",
 				"validateImports": true,
 			}
-			oldStatus, oldBody := env.callOld(t, "/extractLibs", payload)
-			newStatus, newBody := env.callNew(t, env.client.ExtractLibs, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.ExtractLibs, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.ExtractLibs, payload)
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus, "old body: %s", oldBody)
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
 			// Deliberate wording difference — see the test-library subtest above.
-			require.NotEmpty(t, decodeError(t, oldBody))
-			require.Contains(t, decodeError(t, newBody), "Import of 'os' is not allowed.")
+			require.NotEmpty(t, decodeError(t, baselineBody))
+			require.Contains(t, decodeError(t, candidateBody), "Import of 'os' is not allowed.")
 		})
 
 		t.Run("should return the verbatim missing-code error", func(t *testing.T) {
@@ -760,37 +747,35 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 				"language":        "pythonfaas",
 				"validateImports": true,
 			}
-			oldStatus, oldBody := env.callOld(t, "/extractLibs", payload)
-			newStatus, newBody := env.callNew(t, env.client.ExtractLibs, payload)
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.ExtractLibs, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.ExtractLibs, payload)
 
-			require.Equal(t, http.StatusBadRequest, newStatus, "body: %s", newBody)
-			require.Equal(t, oldStatus, newStatus)
-			require.Equal(t, "Invalid request. Code is missing", decodeError(t, newBody))
-			require.Equal(t, decodeError(t, oldBody), decodeError(t, newBody))
+			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
+			require.Equal(t, baselineStatus, candidateStatus)
+			require.Equal(t, "Invalid request. Code is missing", decodeError(t, candidateBody))
+			require.Equal(t, decodeError(t, baselineBody), decodeError(t, candidateBody))
 		})
 	})
 }
 
 const (
-	// workspaceID is the workspace the new-architecture client calls are made as.
+	// workspaceID is the workspace the client calls are made as.
 	workspaceID = "ws-test-endpoints"
 	// libVersionID is the only library version the mock config backend serves.
 	libVersionID = "lib-mathhelper-v1"
 )
 
 // testEndpointsEnv is everything TestPyTransformerTestEndpoints' subtests need:
-// the old architecture reachable over plain HTTP (transformerURL) and the new
-// one through the production client.
+// the two rudder-pytransformer versions under comparison, both reached through
+// the production client.
 type testEndpointsEnv struct {
-	transformerURL   string
-	pyTransformerURL string
-	client           *usertransformer.Client
+	baselineURL  string
+	candidateURL string
+	client       *usertransformer.Client
 }
 
-// newTestEndpointsEnv brings up both architectures against a shared mock config
-// backend: rudder-transformer in test mode backed by the dynamic OpenFaaS
-// gateway (plus the long-lived fn-ast function it routes AST requests to), and
-// rudder-pytransformer with the production client pointed at it.
+// newTestEndpointsEnv brings up both rudder-pytransformer versions against a
+// shared mock config backend, with the production client pointed at them.
 func newTestEndpointsEnv(t *testing.T) *testEndpointsEnv {
 	t.Helper()
 
@@ -803,10 +788,9 @@ func newTestEndpointsEnv(t *testing.T) *testEndpointsEnv {
 	pool.MaxWait = time.Minute
 
 	// The inline test endpoints never fetch transformation code (it arrives in
-	// the request body). Libraries are fetched by rudder-transformer
-	// (getLibraryCodeV1: name/handleName), openfaas-flask-base (--lvids at
-	// startup: importName/code) and pyt (fetch_library: importName/code) — one
-	// response body serves all three.
+	// the request body). Libraries are fetched by pyt (fetch_library:
+	// importName/code). The extra name/handleName fields are harmless and keep
+	// the body shape identical to what the real config backend returns.
 	configBackendHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/transformationLibrary/getByVersionId" {
 			t.Logf("ConfigBackend: unexpected path %s", r.URL.Path)
@@ -829,12 +813,11 @@ func newTestEndpointsEnv(t *testing.T) *testEndpointsEnv {
 			"language":   "pythonfaas",
 		})
 	})
-	// The flask containers run in isolated bridge namespaces and reach this
-	// server through host.docker.internal. On Linux that resolves to the docker
-	// bridge IP, so the server must listen on all interfaces — httptest's
-	// default 127.0.0.1 binding is unreachable from inside the container. macOS
-	// Docker Desktop forwards host.docker.internal to the host loopback, so the
-	// default binding is fine there.
+	// Listen on all interfaces on Linux so the server stays reachable from a
+	// container in its own network namespace (host.docker.internal resolves to
+	// the docker bridge IP there, which httptest's default 127.0.0.1 binding
+	// does not answer). macOS Docker Desktop forwards host.docker.internal to
+	// the host loopback, so the default binding is fine there.
 	configBackend := httptest.NewUnstartedServer(configBackendHandler)
 	if runtime.GOOS != "darwin" {
 		ln, lerr := net.Listen("tcp", "0.0.0.0:0") //nolint:gosec // deliberate: must be reachable from the docker bridge
@@ -852,68 +835,59 @@ func newTestEndpointsEnv(t *testing.T) *testEndpointsEnv {
 	require.NoError(t, err)
 	configBackendURL := "http://127.0.0.1:" + configBackendPort
 
-	gateway := newDynamicFaasGateway(t, pool)
-
 	var (
-		wg                               sync.WaitGroup
-		transformerURL, pyTransformerURL string
+		wg                        sync.WaitGroup
+		baselineURL, candidateURL string
 	)
 	wg.Go(func() {
-		transformerURL = startRudderTransformer(t, pool, configBackendURL, gateway.server.URL,
-			"TRANSFORMER_TEST_MODE=true")
+		baselineURL = startBaselinePytransformer(t, pool, configBackendURL)
 	})
 	wg.Go(func() {
-		pyTransformerURL = startRudderPytransformer(t, pool, configBackendURL)
-	})
-	wg.Go(func() {
-		// The AST routes invoke the long-lived fn-ast function (versionId
-		// "ast" makes flask-base load its built-in AST parser instead of
-		// fetching code).
-		astURL, astContainer, err := startOpenFaasFlaskFprocess(t, pool, "python index.py --vid ast")
-		require.NoError(t, err, "failed to start fn-ast container")
-		waitForOpenFaasFlask(t, pool, astURL)
-		gateway.register("fn-ast", astURL, astContainer)
+		candidateURL = startRudderPytransformer(t, pool, configBackendURL)
 	})
 	wg.Wait()
 
 	// This mirrors production: cpservice.Forward resolves the target base URL
 	// (an ephemeral deployment, the prod pyt, or the static AST deployment) and
 	// passes it to the client per call — the client itself needs no pyt config.
-	// Here the single pyt container serves as the target for every call.
+	// One client serves both versions; only the base URL differs per call.
 	return &testEndpointsEnv{
-		transformerURL:   transformerURL,
-		pyTransformerURL: pyTransformerURL,
-		client:           usertransformer.New(config.New(), logger.NOP, stats.NOP),
+		baselineURL:  baselineURL,
+		candidateURL: candidateURL,
+		client:       usertransformer.New(config.New(), logger.NOP, stats.NOP),
 	}
 }
 
-// callOld POSTs payload to a rudder-transformer test route and returns the
-// HTTP status and body. These routes were only ever called by the control
-// plane (never rudder-server), so a plain HTTP call is the faithful client.
-func (env *testEndpointsEnv) callOld(t *testing.T, path string, payload map[string]any) (int, []byte) {
+// testEndpointMethod is the shape of the client's four test-flow entry points.
+type testEndpointMethod func(ctx context.Context, baseURL, workspaceID string, payload []byte) (int, []byte, error)
+
+// callBaseline sends payload through the given client method against the baseline
+// pytransformer container.
+func (env *testEndpointsEnv) callBaseline(t *testing.T, method testEndpointMethod, payload map[string]any) (int, []byte) {
 	t.Helper()
-	body, err := jsonrs.Marshal(payload)
-	require.NoError(t, err)
-	resp, err := http.Post(env.transformerURL+path, "application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	respBody, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	return resp.StatusCode, respBody
+	return env.call(t, method, env.baselineURL, payload)
 }
 
-// callNew marshals payload and sends it through the given client method
-// against the pyt container's base URL (the role cpservice.Forward plays in
-// production), returning the pyt HTTP status code and response body unchanged.
-func (env *testEndpointsEnv) callNew(
+// callCandidate sends payload through the given client method against the candidate
+// pytransformer container.
+func (env *testEndpointsEnv) callCandidate(t *testing.T, method testEndpointMethod, payload map[string]any) (int, []byte) {
+	t.Helper()
+	return env.call(t, method, env.candidateURL, payload)
+}
+
+// call marshals payload and sends it through the given client method against
+// one container's base URL (the role cpservice.Forward plays in production),
+// returning the pyt HTTP status code and response body unchanged.
+func (env *testEndpointsEnv) call(
 	t *testing.T,
-	method func(ctx context.Context, baseURL, workspaceID string, payload []byte) (int, []byte, error),
+	method testEndpointMethod,
+	baseURL string,
 	payload map[string]any,
 ) (int, []byte) {
 	t.Helper()
 	body, err := jsonrs.Marshal(payload)
 	require.NoError(t, err)
-	statusCode, respBody, err := method(context.Background(), env.pyTransformerURL, workspaceID, body)
+	statusCode, respBody, err := method(context.Background(), baseURL, workspaceID, body)
 	require.NoError(t, err)
 	return statusCode, respBody
 }
@@ -950,262 +924,17 @@ func decodeImportMap(t *testing.T, body []byte) map[string]any {
 	return resp
 }
 
-// compareTestFlowBodies compares old- and new-arch /test and /testRun bodies
+// compareTestFlowBodies compares baseline and candidate /test and /testRun bodies
 // element-by-element — byte-identical on both sides. /test elements are bare
 // transformed events on success and {error} on per-event failure; /testRun
 // elements are {transformedEvent|error, metadata}.
-func compareTestFlowBodies(t *testing.T, oldBody, newBody []byte) {
+func compareTestFlowBodies(t *testing.T, baselineBody, candidateBody []byte) {
 	t.Helper()
-	oldResp, newResp := decodeFlow(t, oldBody), decodeFlow(t, newBody)
-	require.Len(t, newResp.TransformedEvents, len(oldResp.TransformedEvents),
-		"old and new arch must return the same number of transformed events\nold: %s\nnew: %s", oldBody, newBody)
-	for i, oldEl := range oldResp.TransformedEvents {
-		require.Equal(t, oldEl, newResp.TransformedEvents[i], "transformed event %d", i)
+	baselineResp, candidateResp := decodeFlow(t, baselineBody), decodeFlow(t, candidateBody)
+	require.Len(t, candidateResp.TransformedEvents, len(baselineResp.TransformedEvents),
+		"old and candidate must return the same number of transformed events\nold: %s\nnew: %s", baselineBody, candidateBody)
+	for i, oldEl := range baselineResp.TransformedEvents {
+		require.Equal(t, oldEl, candidateResp.TransformedEvents[i], "transformed event %d", i)
 	}
-	require.Equal(t, oldResp.Logs, newResp.Logs, "logs must match")
-}
-
-// faasDeployRequest is the subset of the OpenFaaS deployment payload
-// (buildOpenfaasFn in rudder-transformer) the mock gateway needs.
-type faasDeployRequest struct {
-	Service    string `json:"service"`
-	Name       string `json:"name"`
-	EnvProcess string `json:"envProcess"`
-}
-
-// dynamicFaasGateway mocks the OpenFaaS gateway for the control-plane test flow.
-// Unlike newMockOpenFaaSGateway (fixed proxy target), it honours function
-// deployments: POST /system/functions starts a real openfaas-flask-base
-// container whose fprocess is the deployed envProcess — which is how test-mode
-// inline code reaches the old architecture (`python index.py --code "..."`).
-// Health checks and invocations are routed to the per-function container, and
-// DELETE purges it (rudder-transformer deletes test functions after each run).
-type dynamicFaasGateway struct {
-	t          *testing.T
-	pool       *dockertest.Pool
-	server     *httptest.Server
-	mu         sync.Mutex
-	fnURLs     map[string]string
-	containers map[string]*dockertest.Resource
-}
-
-func newDynamicFaasGateway(t *testing.T, pool *dockertest.Pool) *dynamicFaasGateway {
-	t.Helper()
-	g := &dynamicFaasGateway{
-		t:          t,
-		pool:       pool,
-		fnURLs:     map[string]string{},
-		containers: map[string]*dockertest.Resource{},
-	}
-	g.server = httptest.NewServer(http.HandlerFunc(g.handle))
-	t.Cleanup(g.server.Close)
-	return g
-}
-
-// register makes the gateway route /function/{name} traffic to the function's
-// container at url.
-func (g *dynamicFaasGateway) register(name, url string, container *dockertest.Resource) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	g.fnURLs[name] = url
-	g.containers[name] = container
-}
-
-func (g *dynamicFaasGateway) lookup(name string) (string, bool) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	url, ok := g.fnURLs[name]
-	return url, ok
-}
-
-func (g *dynamicFaasGateway) lookupContainer(name string) *dockertest.Resource {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	return g.containers[name]
-}
-
-func (g *dynamicFaasGateway) handle(w http.ResponseWriter, r *http.Request) {
-	switch {
-	// Deploy function: start a flask-base container with the deployed envProcess.
-	case r.Method == http.MethodPost && r.URL.Path == "/system/functions":
-		var req faasDeployRequest
-		if err := jsonrs.NewDecoder(r.Body).Decode(&req); err != nil {
-			g.t.Errorf("DynamicFaasGateway: decoding deploy request: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		name := req.Service
-		if name == "" {
-			name = req.Name
-		}
-		// rudder-transformer builds the fprocess with the config-backend URL as
-		// the host sees it (127.0.0.1 on Linux). The flask container runs in its
-		// own bridge namespace, so rewrite host-local addresses to
-		// host.docker.internal so the function can reach the host. On macOS the
-		// URL is already host.docker.internal, so this is a no-op there.
-		envProcess := dockertesthelper.ToInternalDockerHost(req.EnvProcess)
-		g.t.Logf("DynamicFaasGateway: deploying %q with fprocess %q", name, envProcess)
-		url, container, err := startOpenFaasFlaskFprocess(g.t, g.pool, envProcess)
-		if err != nil {
-			g.t.Errorf("DynamicFaasGateway: starting flask container for %q: %v", name, err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		// Wait for the container to actually accept connections before returning
-		// 200. On Linux host networking the mapped port is unreachable
-		// (connection refused) until fwatchdog binds it — without this gate the
-		// caller invokes prematurely and the deploy appears to have failed.
-		if err := pollOpenFaasFlaskHealthy(g.pool, url); err != nil {
-			g.t.Errorf("DynamicFaasGateway: %q did not become healthy: %v", name, err)
-			dumpContainerLogs(g.t, g.pool, container, name)
-			_ = g.pool.Purge(container)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		g.register(name, url, container)
-		w.WriteHeader(http.StatusOK)
-
-	// Update function
-	case r.Method == http.MethodPut && r.URL.Path == "/system/functions":
-		w.WriteHeader(http.StatusOK)
-
-	// Delete function: purge its container.
-	case r.Method == http.MethodDelete && r.URL.Path == "/system/functions":
-		var req struct {
-			FunctionName string `json:"functionName"`
-		}
-		if err := jsonrs.NewDecoder(r.Body).Decode(&req); err != nil {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		g.mu.Lock()
-		container := g.containers[req.FunctionName]
-		delete(g.containers, req.FunctionName)
-		delete(g.fnURLs, req.FunctionName)
-		g.mu.Unlock()
-		if container != nil {
-			if err := g.pool.Purge(container); err != nil {
-				g.t.Logf("DynamicFaasGateway: purging %q: %v", req.FunctionName, err)
-			}
-		}
-		w.WriteHeader(http.StatusOK)
-
-	// List functions
-	case r.Method == http.MethodGet && r.URL.Path == "/system/functions":
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte("[]"))
-
-	// Get function info
-	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/system/function/"):
-		name := strings.TrimPrefix(r.URL.Path, "/system/function/")
-		if _, ok := g.lookup(name); !ok {
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = fmt.Fprintf(w, "error finding function %s", name)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = jsonrs.NewEncoder(w).Encode(map[string]any{"name": name, "replicas": 1})
-
-	// Health check (GET) or invoke (POST) — proxied to the function's container.
-	case strings.HasPrefix(r.URL.Path, "/function/"):
-		name := strings.TrimPrefix(r.URL.Path, "/function/")
-		target, ok := g.lookup(name)
-		if !ok {
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = fmt.Fprintf(w, "error finding function %s", name)
-			return
-		}
-		switch r.Method {
-		case http.MethodGet:
-			// fwatchdog health check; 503 until the container is up.
-			req, err := http.NewRequest(http.MethodGet, target+"/", nil)
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-			req.Header.Set("X-REQUEST-TYPE", "HEALTH-CHECK")
-			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				w.WriteHeader(http.StatusServiceUnavailable)
-				return
-			}
-			defer func() { _ = resp.Body.Close() }()
-			w.WriteHeader(resp.StatusCode)
-			_, _ = io.Copy(w, resp.Body)
-		case http.MethodPost:
-			body, err := io.ReadAll(r.Body)
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-			resp, err := http.Post(target+"/", "application/json", bytes.NewReader(body))
-			if err != nil {
-				g.t.Logf("DynamicFaasGateway: invoking %q: %v", name, err)
-				w.WriteHeader(http.StatusBadGateway)
-				return
-			}
-			defer func() { _ = resp.Body.Close() }()
-			respBody, _ := io.ReadAll(resp.Body)
-			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-				g.t.Logf("DynamicFaasGateway: invoke %q returned %d: %s", name, resp.StatusCode, respBody)
-				if c := g.lookupContainer(name); c != nil {
-					dumpContainerLogs(g.t, g.pool, c, name)
-				}
-			}
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(resp.StatusCode)
-			_, _ = w.Write(respBody)
-		default:
-			w.WriteHeader(http.StatusMethodNotAllowed)
-		}
-
-	default:
-		g.t.Logf("DynamicFaasGateway: unhandled %s %s", r.Method, r.URL.Path)
-		w.WriteHeader(http.StatusNotFound)
-	}
-}
-
-// startOpenFaasFlaskFprocess starts an openfaas-flask-base container running
-// the given fprocess verbatim (as rudder-transformer deploys it). It does not
-// wait for readiness — callers gate on pollOpenFaasFlaskHealthy (the deploy
-// handler) or waitForOpenFaasFlask (fn-ast startup) before use. Returns an
-// error instead of failing the test because it is called from the gateway's
-// HTTP handler goroutine.
-//
-// Each flask container runs in its own bridge-network namespace — never host
-// networking, even on Linux — because of-watchdog binds a HARD-CODED Prometheus
-// metrics port 8081 that is not configurable via env. Under host networking two
-// flask containers (the long-lived fn-ast and a per-request fn-test) share the
-// host namespace and collide on 8081: of-watchdog panics with "bind: address
-// already in use", the container exits, and the invoke port never comes up
-// ("connection refused"). A per-container namespace keeps each 8081 private.
-func startOpenFaasFlaskFprocess(
-	t *testing.T, pool *dockertest.Pool, fprocess string,
-) (string, *dockertest.Resource, error) {
-	t.Helper()
-	const containerPort = "8080"
-	cfg := newContainerConfig(t, containerPort, withBridgeNetworking())
-	container, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/openfaas-flask",
-		// Pinned to match the production version
-		Tag:  "1.13.2",
-		Auth: registry.AuthConfiguration(),
-		Env: []string{
-			"fprocess=" + fprocess,
-			"port=" + cfg.portStr(containerPort),
-		},
-		// The image does not EXPOSE any port, and Docker ignores port bindings
-		// for unexposed ports.
-		ExposedPorts: []string{containerPort + "/tcp"},
-		ExtraHosts:   cfg.ExtraHosts,
-		PortBindings: cfg.PortBindings,
-	}, cfg.hostConfigFn)
-	if err != nil {
-		return "", nil, err
-	}
-	t.Cleanup(func() {
-		// Best effort: functions deleted by rudder-transformer are already gone.
-		_ = pool.Purge(container)
-	})
-	return cfg.url(container, containerPort), container, nil
+	require.Equal(t, baselineResp.Logs, candidateResp.Logs, "logs must match")
 }

--- a/integration_test/pytransformer_contract/test_endpoints_contract_test.go
+++ b/integration_test/pytransformer_contract/test_endpoints_contract_test.go
@@ -32,13 +32,11 @@ import (
 // Both sides go through usertransformer.Client.Test/TestRun/TestLibrary/
 // ExtractLibs — the same methods cpservice.Forward uses in production — so the
 // test covers the exact client → pyt path. Only the target base URL differs:
-// the baseline release on one side, the candidate on the other, which is the
-// role cpservice.Forward plays in production.
+// the baseline release on one side, the candidate on the other.
 //
-// Responses are compared byte-for-byte. Several assertions below carry comments
-// about wording that "deliberately differs" from openfaas's fn-ast; those record
-// why pyt's wording is what it is, and are kept as documentation of the intended
-// message. They no longer describe a difference between the two sides.
+// Responses are compared byte-for-byte. A few assertions carry historical notes
+// about how the pre-pyt architecture worded an error; those explain why pyt's
+// message is what it is and do not describe a difference between the two sides.
 func TestPyTransformerTestEndpoints(t *testing.T) {
 	env := newTestEndpointsEnv(t)
 
@@ -59,7 +57,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old status %d, old body: %s", baselineStatus, baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline status %d, baseline body: %s", baselineStatus, baselineBody)
 			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 2)
 			for _, ev := range resp.TransformedEvents {
@@ -84,7 +82,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			require.EqualValues(t, 42, resp.TransformedEvents[0]["doubled"])
@@ -107,7 +105,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			require.Equal(t, "secret123", resp.TransformedEvents[0]["secret"])
@@ -130,7 +128,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 
 			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 2)
@@ -166,7 +164,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 2)
 			require.EqualValues(t, 2, resp.TransformedEvents[0]["doubled"])
@@ -192,7 +190,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 2)
 			errored := resp.TransformedEvents[1]
@@ -218,16 +216,15 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
 
 			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
-			// The wording deliberately differs: the baseline surfaces fn-ast's
-			// BadCodeError (its import extraction parses the code before the
-			// function is even deployed), pyt surfaces its runtime compiler's
-			// message. Both must carry Python's syntax diagnosis.
-			oldErr := decodeError(t, baselineBody)
-			newErr := decodeError(t, candidateBody)
-			t.Logf("compile error — old: %q new: %q", oldErr, newErr)
-			require.Contains(t, oldErr, "expected ':'")
-			require.Contains(t, newErr, "expected ':'")
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
+			// Both versions surface their runtime compiler's message, and it must carry Python's syntax
+			// diagnosis. (Historically the old architecture reported fn-ast's BadCodeError here instead,
+			// which is why this was once a deliberate wording difference rather than a parity check.)
+			baselineErr := decodeError(t, baselineBody)
+			candidateErr := decodeError(t, candidateBody)
+			t.Logf("compile error — baseline: %q candidate: %q", baselineErr, candidateErr)
+			require.Contains(t, baselineErr, "expected ':'")
+			require.Contains(t, candidateErr, "expected ':'")
 		})
 
 		t.Run("should return the verbatim missing-code error", func(t *testing.T) {
@@ -331,7 +328,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			el := resp.TransformedEvents[0]
@@ -367,7 +364,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			meta, ok := resp.TransformedEvents[0]["metadata"].(map[string]any)
@@ -396,7 +393,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			transformed, ok := resp.TransformedEvents[0]["transformedEvent"].(map[string]any)
@@ -421,7 +418,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			el := resp.TransformedEvents[0]
@@ -452,7 +449,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 2)
 			for i, el := range resp.TransformedEvents {
@@ -481,7 +478,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			resp := decodeFlow(t, candidateBody)
 			require.Len(t, resp.TransformedEvents, 1)
 			require.Equal(t, map[string]any{"sourceId": "s1"}, resp.TransformedEvents[0]["metadata"],
@@ -505,14 +502,14 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestRun, payload)
 
 			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			// Wording deliberately differs (fn-ast BadCodeError vs pyt's runtime
 			// compiler); both must carry Python's syntax diagnosis.
-			oldErr := decodeError(t, baselineBody)
-			newErr := decodeError(t, candidateBody)
-			t.Logf("compile error — old: %q new: %q", oldErr, newErr)
-			require.Contains(t, oldErr, "expected ':'")
-			require.Contains(t, newErr, "expected ':'")
+			baselineErr := decodeError(t, baselineBody)
+			candidateErr := decodeError(t, candidateBody)
+			t.Logf("compile error — old: %q new: %q", baselineErr, candidateErr)
+			require.Contains(t, baselineErr, "expected ':'")
+			require.Contains(t, candidateErr, "expected ':'")
 		})
 
 		t.Run("should return the verbatim missing-code error", func(t *testing.T) {
@@ -560,7 +557,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestLibrary, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			require.Equal(t, map[string]any{"json": []any{}, "datetime": []any{}}, decodeImportMap(t, candidateBody))
 			require.Equal(t, decodeImportMap(t, baselineBody), decodeImportMap(t, candidateBody))
 		})
@@ -574,7 +571,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestLibrary, payload)
 
 			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			// The wording deliberately differs: fn-ast says "Unpermitted
 			// import(s). ...", pyt surfaces the runtime's message so static
 			// validation and runtime can't drift.
@@ -591,7 +588,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestLibrary, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			require.Equal(t, map[string]any{"urllib.parse": []any{}, "dateutil.parser": []any{}}, decodeImportMap(t, candidateBody))
 			require.Equal(t, decodeImportMap(t, baselineBody), decodeImportMap(t, candidateBody))
 		})
@@ -628,7 +625,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestLibrary, payload)
 
 			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			require.NotEmpty(t, decodeError(t, baselineBody))
 			require.Equal(t, "Relative imports are not allowed.", decodeError(t, candidateBody))
 		})
@@ -642,7 +639,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.TestLibrary, payload)
 
 			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			// Wording deliberately differs (fn-ast BadCodeError vs pyt's runtime
 			// compiler); both must carry Python's syntax diagnosis.
 			require.Contains(t, decodeError(t, baselineBody), "expected ':'")
@@ -672,7 +669,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.ExtractLibs, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			require.Equal(t, map[string]any{"os": []any{}, "json": []any{}}, decodeImportMap(t, candidateBody))
 			require.Equal(t, decodeImportMap(t, baselineBody), decodeImportMap(t, candidateBody))
 		})
@@ -688,7 +685,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.ExtractLibs, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			require.Equal(t, map[string]any{"mylib": []any{}, "json": []any{}}, decodeImportMap(t, candidateBody))
 			require.Equal(t, decodeImportMap(t, baselineBody), decodeImportMap(t, candidateBody))
 		})
@@ -703,7 +700,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.ExtractLibs, payload)
 
 			require.Equal(t, http.StatusOK, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			require.Equal(t, map[string]any{"os.path": []any{}}, decodeImportMap(t, candidateBody))
 			require.Equal(t, decodeImportMap(t, baselineBody), decodeImportMap(t, candidateBody))
 		})
@@ -722,7 +719,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.ExtractLibs, payload)
 
 			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			require.NotEmpty(t, decodeError(t, baselineBody))
 			require.Equal(t, "Relative imports are not allowed.", decodeError(t, candidateBody))
 		})
@@ -737,7 +734,7 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			candidateStatus, candidateBody := env.callCandidate(t, env.client.ExtractLibs, payload)
 
 			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
-			require.Equal(t, baselineStatus, candidateStatus, "old body: %s", baselineBody)
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
 			// Deliberate wording difference — see the test-library subtest above.
 			require.NotEmpty(t, decodeError(t, baselineBody))
 			require.Contains(t, decodeError(t, candidateBody), "Import of 'os' is not allowed.")
@@ -828,7 +825,7 @@ func newTestEndpointsEnv(t *testing.T) *testEndpointsEnv {
 	}
 	configBackend.Start()
 	t.Cleanup(configBackend.Close)
-	// Host-networked containers (rudder-transformer, pytransformer) and the test
+	// Host-networked containers (both pytransformer versions) and the test
 	// process reach the backend on the loopback; a wildcard listener reports
 	// 0.0.0.0, so pin the host explicitly. toContainerURL later rewrites this to
 	// host.docker.internal for the containers that need it.
@@ -844,7 +841,7 @@ func newTestEndpointsEnv(t *testing.T) *testEndpointsEnv {
 		baselineURL = startBaselinePytransformer(t, pool, configBackendURL)
 	})
 	wg.Go(func() {
-		candidateURL = startRudderPytransformer(t, pool, configBackendURL)
+		candidateURL = startCandidatePytransformer(t, pool, configBackendURL)
 	})
 	wg.Wait()
 
@@ -933,9 +930,9 @@ func compareTestFlowBodies(t *testing.T, baselineBody, candidateBody []byte) {
 	t.Helper()
 	baselineResp, candidateResp := decodeFlow(t, baselineBody), decodeFlow(t, candidateBody)
 	require.Len(t, candidateResp.TransformedEvents, len(baselineResp.TransformedEvents),
-		"old and candidate must return the same number of transformed events\nold: %s\nnew: %s", baselineBody, candidateBody)
-	for i, oldEl := range baselineResp.TransformedEvents {
-		require.Equal(t, oldEl, candidateResp.TransformedEvents[i], "transformed event %d", i)
+		"baseline and candidate must return the same number of transformed events\nbaseline: %s\ncandidate: %s", baselineBody, candidateBody)
+	for i, baselineEl := range baselineResp.TransformedEvents {
+		require.Equal(t, baselineEl, candidateResp.TransformedEvents[i], "transformed event %d", i)
 	}
 	require.Equal(t, baselineResp.Logs, candidateResp.Logs, "logs must match")
 }

--- a/integration_test/pytransformer_contract/test_endpoints_contract_test.go
+++ b/integration_test/pytransformer_contract/test_endpoints_contract_test.go
@@ -293,12 +293,8 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 			require.Equal(t, decodeError(t, baselineBody), decodeError(t, candidateBody))
 		})
 
-		// pyt-only: in the baseline an unknown library version crashes
-		// the deployed flask container at startup (its --lvids fetch fails), so
-		// the request degenerates into a readiness-timeout/retry loop rather
-		// than a comparable 400.
 		t.Run("should return HTTP 400 when a library cannot be fetched", func(t *testing.T) {
-			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, map[string]any{
+			payload := map[string]any{
 				"trRevCode": map[string]any{
 					"code":        "def transformEvent(event, metadata):\n    return event",
 					"codeVersion": "1",
@@ -308,9 +304,14 @@ func TestPyTransformerTestEndpoints(t *testing.T) {
 					{"message": map[string]any{"messageId": "m1"}, "metadata": map[string]any{"messageId": "m1"}},
 				},
 				"libraryVersionIDs": []string{"unknown-library-version"},
-			})
+			}
+			baselineStatus, baselineBody := env.callBaseline(t, env.client.Test, payload)
+			candidateStatus, candidateBody := env.callCandidate(t, env.client.Test, payload)
+
 			require.Equal(t, http.StatusBadRequest, candidateStatus, "body: %s", candidateBody)
 			require.NotEmpty(t, decodeError(t, candidateBody))
+			require.Equal(t, baselineStatus, candidateStatus, "baseline body: %s", baselineBody)
+			require.NotEmpty(t, decodeError(t, baselineBody))
 		})
 	})
 

--- a/integration_test/pytransformer_contract/threading_benchmark_test.go
+++ b/integration_test/pytransformer_contract/threading_benchmark_test.go
@@ -124,12 +124,12 @@ func TestThreadingBenchmark(t *testing.T) {
 	}
 
 	t.Logf("Starting baseline pytransformer (threading OFF)...")
-	baselineEP := startRudderPytransformerWithTag(
+	baselineEP := startBenchPytransformerWithTag(
 		t, pool, imageTag, configBackend.URL,
 		append(commonEnv, "ENABLE_THREAD_POOL_IO_BOUND=false")...,
 	)
 	t.Logf("Starting threaded pytransformer (threading ON)...")
-	threadedEP := startRudderPytransformerWithTag(
+	threadedEP := startBenchPytransformerWithTag(
 		t, pool, imageTag, configBackend.URL,
 		append(commonEnv, "ENABLE_THREAD_POOL_IO_BOUND=true")...,
 	)

--- a/integration_test/pytransformer_contract/threading_benchmark_test.go
+++ b/integration_test/pytransformer_contract/threading_benchmark_test.go
@@ -62,12 +62,11 @@ import (
 // is supposed to help, and the regime where the L1 cache marks the
 // transformation as I/O-bound.
 func TestThreadingBenchmark(t *testing.T) {
-	const (
-		imageTag           = "main"
-		benchmarkVersionID = "thread-bench-v1"
-	)
+	const benchmarkVersionID = "thread-bench-v1"
+	// Benchmark the candidate, i.e. the same image the contract tests treat as under test.
+	imageTag := candidatePytransformerTag()
 
-	// Workload parameters — tuneable via env (envInt helper from ipc_benchmark_test.go).
+	// Workload parameters — tuneable via env (envInt helper from benchmark_helpers_test.go).
 	eventsPerRequest := envInt(t, "THREAD_BENCH_EVENTS_PER_REQUEST", 10)
 	httpLatencyMs := envInt(t, "THREAD_BENCH_HTTP_LATENCY_MS", 50)
 	threadPoolSize := envInt(t, "THREAD_BENCH_THREAD_POOL_SIZE", 8)

--- a/internal/transformer-client/client.go
+++ b/internal/transformer-client/client.go
@@ -92,7 +92,7 @@ type ClientConfig struct {
 	Recycle       bool          // false
 	RecycleTTL    time.Duration // 60s
 
-	// Configuration for retryable HTTP client in case of [X-Rudder-Should-Retry: true] HTTP 503 responses
+	// Configuration for the retryable HTTP client, for responses matching [IsRetryableResponse]
 	RetryRudderErrors struct {
 		Enabled         bool          // false
 		MaxRetry        int           // -1 - no limit

--- a/internal/transformer-client/client.go
+++ b/internal/transformer-client/client.go
@@ -66,6 +66,17 @@ const (
 	HeaderErrorReason = "X-Rudder-Error-Reason"
 )
 
+// IsRetryableResponse reports whether resp is the transformer signalling a transient downstream failure that the
+// caller should retry, as opposed to the transformer being unreachable.
+//
+// This is the single definition of that signal. The retryable transport below decides what to retry with it, and
+// user_transformer's cold-start classifier decides what is *not* a cold start with it.
+func IsRetryableResponse(resp *http.Response) bool {
+	return resp != nil &&
+		resp.StatusCode == http.StatusServiceUnavailable &&
+		strings.EqualFold(resp.Header.Get(HeaderShouldRetry), "true")
+}
+
 type ClientConfig struct {
 	TransportConfig struct {
 		DisableKeepAlives   bool          //	true
@@ -238,8 +249,7 @@ func newRetryableHTTPClient(name string, baseClient Client, retryableConfig *ret
 			if err != nil {
 				return false, backoff.Permanent(err)
 			}
-			if resp.StatusCode == http.StatusServiceUnavailable &&
-				strings.EqualFold(resp.Header.Get(HeaderShouldRetry), "true") {
+			if IsRetryableResponse(resp) {
 				reason := resp.Header.Get(HeaderErrorReason)
 				attemptTag := strconv.Itoa(attempt)
 				if attempt > 4 {

--- a/internal/transformer-client/client.go
+++ b/internal/transformer-client/client.go
@@ -254,7 +254,6 @@ func newRetryableHTTPClient(name string, baseClient Client, retryableConfig *ret
 					maps.Copy(tags, perpetualRetriesStatsTagsFromContext(resp.Request.Context()))
 				}
 				stats.Default.NewTaggedStat("transformer_client_perpetual_retry_count", stats.CountType, tags).Increment()
-				resp.Body.Close()
 				return true, fmt.Errorf("got retryable error response from transformer: %s", reason)
 			}
 			return false, nil

--- a/internal/transformer-client/client.go
+++ b/internal/transformer-client/client.go
@@ -53,6 +53,19 @@ const (
 	defaultRetryRudderErrorsMultiplier      = 2.0
 )
 
+// Headers of the transformer's retryable-error contract.
+// A transformer that is up and answering signals a transient downstream failure with HTTP 503 plus these headers,
+// so callers can retry the request instead of concluding that the transformer itself is unavailable.
+//
+// The peer half of this contract lives in rudder-pytransformer, which necessarily hardcodes the same strings, so these
+// values are a wire format: renaming the constants is free, changing their values is a breaking change on both sides.
+const (
+	// HeaderShouldRetry is "true" when the response is worth retrying.
+	HeaderShouldRetry = "X-Rudder-Should-Retry"
+	// HeaderErrorReason carries a short cause, used as a stat tag.
+	HeaderErrorReason = "X-Rudder-Error-Reason"
+)
+
 type ClientConfig struct {
 	TransportConfig struct {
 		DisableKeepAlives   bool          //	true
@@ -226,8 +239,8 @@ func newRetryableHTTPClient(name string, baseClient Client, retryableConfig *ret
 				return false, backoff.Permanent(err)
 			}
 			if resp.StatusCode == http.StatusServiceUnavailable &&
-				strings.ToLower(resp.Header.Get("X-Rudder-Should-Retry")) == "true" {
-				reason := resp.Header.Get("X-Rudder-Error-Reason")
+				strings.EqualFold(resp.Header.Get(HeaderShouldRetry), "true") {
+				reason := resp.Header.Get(HeaderErrorReason)
 				attemptTag := strconv.Itoa(attempt)
 				if attempt > 4 {
 					attemptTag = "5+"

--- a/internal/transformer-client/client_test.go
+++ b/internal/transformer-client/client_test.go
@@ -3,6 +3,7 @@ package transformerclient
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-go-kit/httputil"
 	"github.com/rudderlabs/rudder-go-kit/stats"
 	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
 	kithelper "github.com/rudderlabs/rudder-go-kit/testhelper"
@@ -615,5 +617,97 @@ func TestClient_RetryDisabled(t *testing.T) {
 		require.True(t, elapsed < 100*time.Millisecond, "Should complete quickly without retries")
 
 		resp.Body.Close()
+	})
+}
+
+// TestClient_ResponseBodyReadableAfterRetriesExhausted pins the contract that [Client.Do] returns a response whose body
+// the caller can still read.
+//
+// The retryable transport closes the previous response between attempts to avoid leaking connections, but the attempt
+// that exhausts the budget is not followed by a retry — its response is handed back to the caller, so its body must
+// stay open.
+func TestClient_ResponseBodyReadableAfterRetriesExhausted(t *testing.T) {
+	const responseBody = `{"error":"geolocation timeout"}`
+
+	newRetryingServer := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(HeaderShouldRetry, "true")
+			w.Header().Set(HeaderErrorReason, "geolocation_timeout")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(responseBody))
+		}))
+	}
+
+	retryConfig := func(maxRetry int, maxElapsedTime time.Duration) *ClientConfig {
+		return &ClientConfig{
+			ClientTimeout: 10 * time.Second,
+			RetryRudderErrors: struct {
+				Enabled         bool
+				MaxRetry        int
+				InitialInterval time.Duration
+				MaxInterval     time.Duration
+				MaxElapsedTime  time.Duration
+				Multiplier      float64
+			}{
+				Enabled:         true,
+				MaxRetry:        maxRetry,
+				InitialInterval: 10 * time.Millisecond,
+				MaxInterval:     20 * time.Millisecond,
+				MaxElapsedTime:  maxElapsedTime,
+				Multiplier:      2.0,
+			},
+		}
+	}
+
+	t.Run("maxRetry exhausted", func(t *testing.T) {
+		server := newRetryingServer()
+		defer server.Close()
+
+		client := NewClient("testClient", retryConfig(1, 500*time.Millisecond))
+
+		req, err := http.NewRequest("POST", server.URL, strings.NewReader("test data"))
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		defer func() { httputil.CloseResponse(resp) }()
+
+		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+		read, err := io.ReadAll(resp.Body)
+		require.NoError(t, err, "body of the returned response must still be readable")
+		require.Equal(t, responseBody, string(read))
+	})
+
+	// Documents a limitation this package cannot fix: when the context is cancelled during a backoff wait,
+	// retryablehttp returns the response of the last *completed* attempt — one its own notify hook already drained and
+	// closed in order to retry — and pairs it with a nil error.
+	// Callers therefore cannot treat a nil error from Do as "this body is readable"; see user_transformer's
+	// forwardTest, which reports the status and error reason instead of the bare read failure.
+	t.Run("context cancelled mid-backoff returns a stale, closed response", func(t *testing.T) {
+		server := newRetryingServer()
+		defer server.Close()
+
+		// Unlimited retries, as in production: only the caller's context ends them.
+		client := NewClient("testClient", retryConfig(-1, 0))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, "POST", server.URL, strings.NewReader("test data"))
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err, "Do reports no error even though the context ended the retries")
+		require.NotNil(t, resp)
+		defer func() { httputil.CloseResponse(resp) }()
+
+		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+		require.Equal(t, "true", resp.Header.Get(HeaderShouldRetry), "headers survive; only the body is gone")
+
+		_, err = io.ReadAll(resp.Body)
+		require.ErrorContains(t, err, "read on closed response body",
+			"upstream behaviour: change this expectation if rudder-go-kit stops returning a stale response")
 	})
 }

--- a/internal/transformer-client/client_test.go
+++ b/internal/transformer-client/client_test.go
@@ -690,9 +690,12 @@ func TestClient_ResponseBodyReadableAfterRetriesExhausted(t *testing.T) {
 		defer server.Close()
 
 		// Unlimited retries, as in production: only the caller's context ends them.
-		client := NewClient("testClient", retryConfig(-1, 0))
+		cfg := retryConfig(-1, 0)
+		cfg.RetryRudderErrors.InitialInterval = 2 * time.Second
+		cfg.RetryRudderErrors.MaxInterval = 2 * time.Second
+		client := NewClient("testClient", cfg)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 
 		req, err := http.NewRequestWithContext(ctx, "POST", server.URL, strings.NewReader("test data"))

--- a/internal/transformer-client/client_test.go
+++ b/internal/transformer-client/client_test.go
@@ -27,8 +27,8 @@ func TestClient_RetryBehavior(t *testing.T) {
 
 			if requestCount <= retryableResponses {
 				// Return retriable error
-				w.Header().Set("X-Rudder-Should-Retry", "true")
-				w.Header().Set("X-Rudder-Error-Reason", "temporary-overload")
+				w.Header().Set(HeaderShouldRetry, "true")
+				w.Header().Set(HeaderErrorReason, "temporary-overload")
 				w.WriteHeader(http.StatusServiceUnavailable)
 				_, _ = w.Write([]byte("Service temporarily unavailable"))
 			} else {
@@ -80,8 +80,8 @@ func TestClient_RetryBehavior(t *testing.T) {
 		var requestCount int
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestCount++
-			w.Header().Set("X-Rudder-Should-Retry", "true")
-			w.Header().Set("X-Rudder-Error-Reason", "persistent-overload")
+			w.Header().Set(HeaderShouldRetry, "true")
+			w.Header().Set(HeaderErrorReason, "persistent-overload")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte("Service permanently unavailable"))
 		}))
@@ -133,8 +133,8 @@ func TestClient_RetryBehavior(t *testing.T) {
 
 			if requestCount <= switchAfter {
 				// Return retriable error
-				w.Header().Set("X-Rudder-Should-Retry", "true")
-				w.Header().Set("X-Rudder-Error-Reason", "temporary-overload")
+				w.Header().Set(HeaderShouldRetry, "true")
+				w.Header().Set(HeaderErrorReason, "temporary-overload")
 				w.WriteHeader(http.StatusServiceUnavailable)
 				_, _ = w.Write([]byte("Service temporarily unavailable"))
 			} else {
@@ -374,8 +374,8 @@ func TestClient_ConfigurableRetrySettings(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestCount++
 			// Always return retriable error
-			w.Header().Set("X-Rudder-Should-Retry", "true")
-			w.Header().Set("X-Rudder-Error-Reason", "test-overload")
+			w.Header().Set(HeaderShouldRetry, "true")
+			w.Header().Set(HeaderErrorReason, "test-overload")
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}))
 		defer server.Close()
@@ -421,8 +421,8 @@ func TestClient_ConfigurableRetrySettings(t *testing.T) {
 		var requestCount int
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestCount++
-			w.Header().Set("X-Rudder-Should-Retry", "true")
-			w.Header().Set("X-Rudder-Error-Reason", "test-overload")
+			w.Header().Set(HeaderShouldRetry, "true")
+			w.Header().Set(HeaderErrorReason, "test-overload")
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}))
 		defer server.Close()
@@ -468,8 +468,8 @@ func TestClient_PerpetualRetriesStatsTags(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestCount++
 			if requestCount <= retryableResponses {
-				w.Header().Set("X-Rudder-Should-Retry", "true")
-				w.Header().Set("X-Rudder-Error-Reason", "temporary-overload")
+				w.Header().Set(HeaderShouldRetry, "true")
+				w.Header().Set(HeaderErrorReason, "temporary-overload")
 				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}
@@ -527,8 +527,8 @@ func TestClient_PerpetualRetriesStatsTags(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestCount++
 			if requestCount == 1 {
-				w.Header().Set("X-Rudder-Should-Retry", "true")
-				w.Header().Set("X-Rudder-Error-Reason", "temporary-overload")
+				w.Header().Set(HeaderShouldRetry, "true")
+				w.Header().Set(HeaderErrorReason, "temporary-overload")
 				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}
@@ -582,8 +582,8 @@ func TestClient_RetryDisabled(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestCount++
 			// Return retriable error that would normally be retried
-			w.Header().Set("X-Rudder-Should-Retry", "true")
-			w.Header().Set("X-Rudder-Error-Reason", "temporary-overload")
+			w.Header().Set(HeaderShouldRetry, "true")
+			w.Header().Set(HeaderErrorReason, "temporary-overload")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte("Service temporarily unavailable"))
 		}))

--- a/processor/internal/transformer/user_transformer/cold_start_internal_test.go
+++ b/processor/internal/transformer/user_transformer/cold_start_internal_test.go
@@ -49,10 +49,14 @@ func TestIsColdStartError(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "502 with X-Rudder-Should-Retry is not a cold start",
+			// The contract is 503-only: pyt normalises downstream failures (a downstream 502 included) into its
+			// own 503 plus these headers, so a 502 is infrastructure no matter what headers ride along with it.
+			// Honouring the header here too would put 502 in the one state that has no owner — not retried by the
+			// transport, which is 503-only, and not retried as a cold start either.
+			name:    "502 with X-Rudder-Should-Retry is still a cold start",
 			status:  http.StatusBadGateway,
 			headers: map[string]string{transformerclient.HeaderShouldRetry: "true"},
-			want:    false,
+			want:    true,
 		},
 		{
 			name:    "X-Rudder-Should-Retry is matched case-insensitively",

--- a/processor/internal/transformer/user_transformer/cold_start_internal_test.go
+++ b/processor/internal/transformer/user_transformer/cold_start_internal_test.go
@@ -164,12 +164,12 @@ func (timeoutError) Temporary() bool { return true }
 // The value is picked by the peer, so anything that is not a short plain identifier has to collapse to a
 // constant. One per-request string reaching the metrics backend is a new time series per request.
 func TestRetryReasonTag(t *testing.T) {
-	respWith := func(reason string) *http.Response {
+	headerWith := func(reason string) http.Header {
 		hdr := http.Header{}
 		if reason != "" {
 			hdr.Set(transformerclient.HeaderErrorReason, reason)
 		}
-		return &http.Response{StatusCode: http.StatusServiceUnavailable, Header: hdr, Body: http.NoBody}
+		return hdr
 	}
 
 	for _, tc := range []struct{ name, reason, want string }{
@@ -181,7 +181,7 @@ func TestRetryReasonTag(t *testing.T) {
 		{"a value at the length limit is kept", strings.Repeat("x", 64), strings.Repeat("x", 64)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, retryReasonTag(respWith(tc.reason)))
+			require.Equal(t, tc.want, retryReasonTag(headerWith(tc.reason)))
 		})
 	}
 }

--- a/processor/internal/transformer/user_transformer/cold_start_internal_test.go
+++ b/processor/internal/transformer/user_transformer/cold_start_internal_test.go
@@ -1,0 +1,99 @@
+package user_transformer
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	transformerclient "github.com/rudderlabs/rudder-server/internal/transformer-client"
+)
+
+// TestIsColdStartError pins which 503/502 responses mean "the PyT pod isn't up yet".
+//
+// The distinction is what makes Transformer.Client.UserTransformer.retryRudderErrors.maxRetry enforceable.
+// A cold start is retried by perWorkspacePyTEndlessRetries, which never gives up, so classifying a PyT application
+// error as one would let that outer loop resume the retrying the transport was just told to stop.
+//
+// On the default retryRudderErrors settings (enabled, maxRetry -1, maxElapsedTime 0) the transport retries such
+// responses forever and never returns them, so this only bites once they are bounded or disabled.
+func TestIsColdStartError(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		// status 0 means "no response at all", i.e. a transport-level failure.
+		status  int
+		headers map[string]string
+		want    bool
+	}{
+		{
+			// kube-proxy answering for a Service with no endpoints behind it.
+			name:   "bare 503 is a cold start",
+			status: http.StatusServiceUnavailable,
+			want:   true,
+		},
+		{
+			name:   "bare 502 is a cold start",
+			status: http.StatusBadGateway,
+			want:   true,
+		},
+		{
+			// PyT itself reporting a transient downstream failure — e.g. the
+			// geolocation service timing out. The pod is up and answering.
+			name:    "503 with X-Rudder-Should-Retry is not a cold start",
+			status:  http.StatusServiceUnavailable,
+			headers: map[string]string{transformerclient.HeaderShouldRetry: "true"},
+			want:    false,
+		},
+		{
+			name:    "502 with X-Rudder-Should-Retry is not a cold start",
+			status:  http.StatusBadGateway,
+			headers: map[string]string{transformerclient.HeaderShouldRetry: "true"},
+			want:    false,
+		},
+		{
+			name:    "X-Rudder-Should-Retry is matched case-insensitively",
+			status:  http.StatusServiceUnavailable,
+			headers: map[string]string{transformerclient.HeaderShouldRetry: "True"},
+			want:    false,
+		},
+		{
+			// Only "true" suppresses the cold-start classification; any other
+			// value is not the PyT retry contract.
+			name:    "503 with a non-true X-Rudder-Should-Retry is still a cold start",
+			status:  http.StatusServiceUnavailable,
+			headers: map[string]string{transformerclient.HeaderShouldRetry: "false"},
+			want:    true,
+		},
+		{
+			name:   "200 is never a cold start",
+			status: http.StatusOK,
+			want:   false,
+		},
+		{
+			name: "connection refused is a cold start",
+			err: &net.OpError{
+				Op: "dial", Net: "tcp",
+				Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var resp *http.Response
+			if tc.status != 0 {
+				hdr := http.Header{}
+				for k, v := range tc.headers {
+					hdr.Set(k, v)
+				}
+				resp = &http.Response{StatusCode: tc.status, Header: hdr, Body: http.NoBody}
+			}
+			require.Equal(t, tc.want, isColdStartError(tc.err, resp))
+		})
+	}
+}

--- a/processor/internal/transformer/user_transformer/cold_start_internal_test.go
+++ b/processor/internal/transformer/user_transformer/cold_start_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -78,12 +79,60 @@ func TestIsColdStartError(t *testing.T) {
 			want:   false,
 		},
 		{
+			// The header only means anything inside the 503/502 branch. Pinning this stops a refactor that
+			// hoists the header check above the status check from silently reclassifying every 5xx.
+			name:    "500 with X-Rudder-Should-Retry is not a cold start",
+			status:  http.StatusInternalServerError,
+			headers: map[string]string{transformerclient.HeaderShouldRetry: "true"},
+			want:    false,
+		},
+		{
+			name: "no error and no response is not a cold start",
+			want: false,
+		},
+		{
 			name: "connection refused is a cold start",
 			err: &net.OpError{
 				Op: "dial", Net: "tcp",
 				Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
 			},
 			want: true,
+		},
+		{
+			// Stale iptables / EndpointSlice after a pod replacement.
+			name: "no route to host is a cold start",
+			err: &net.OpError{
+				Op: "dial", Net: "tcp",
+				Err: &os.SyscallError{Syscall: "connect", Err: syscall.EHOSTUNREACH},
+			},
+			want: true,
+		},
+		{
+			// The SYN went unanswered: the pod is coming up, or going down and its DNS record has not
+			// been withdrawn yet. Indistinguishable from the dialer, and retryable either way.
+			name: "dial timeout is a cold start",
+			err:  &net.OpError{Op: "dial", Net: "tcp", Err: timeoutError{}},
+			want: true,
+		},
+		{
+			// Not a dial: a read timeout mid-response means the pod answered, so it is up.
+			name: "non-dial timeout is not a cold start",
+			err:  &net.OpError{Op: "read", Net: "tcp", Err: timeoutError{}},
+			want: false,
+		},
+		{
+			name: "DNS error is a cold start",
+			err:  &net.DNSError{Err: "no such host", Name: "pyt-ws-1", IsNotFound: true},
+			want: true,
+		},
+		{
+			// err wins: the branch returns before resp is consulted, so a transport failure is classified
+			// on its own merits even when a stale response is still in hand.
+			name:    "err takes precedence over resp",
+			err:     &net.DNSError{Err: "no such host", Name: "pyt-ws-1", IsNotFound: true},
+			status:  http.StatusOK,
+			headers: map[string]string{transformerclient.HeaderShouldRetry: "true"},
+			want:    true,
 		},
 	}
 
@@ -98,6 +147,41 @@ func TestIsColdStartError(t *testing.T) {
 				resp = &http.Response{StatusCode: tc.status, Header: hdr, Body: http.NoBody}
 			}
 			require.Equal(t, tc.want, isColdStartError(tc.err, resp))
+		})
+	}
+}
+
+// timeoutError is a net.Error that reports Timeout() == true, so a case can exercise the dial-timeout branch
+// without waiting on a real unanswered SYN.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+// TestRetryReasonTag pins that a transformer-chosen header cannot become an unbounded stats tag.
+//
+// The value is picked by the peer, so anything that is not a short plain identifier has to collapse to a
+// constant. One per-request string reaching the metrics backend is a new time series per request.
+func TestRetryReasonTag(t *testing.T) {
+	respWith := func(reason string) *http.Response {
+		hdr := http.Header{}
+		if reason != "" {
+			hdr.Set(transformerclient.HeaderErrorReason, reason)
+		}
+		return &http.Response{StatusCode: http.StatusServiceUnavailable, Header: hdr, Body: http.NoBody}
+	}
+
+	for _, tc := range []struct{ name, reason, want string }{
+		{"a known reason passes through", "geolocation_timeout", "geolocation_timeout"},
+		{"hyphens and digits are fine", "config-backend-503", "config-backend-503"},
+		{"absent header is reported as unknown", "", "unknown"},
+		{"a per-request id is collapsed", "failed for message 0b41-9f2a at 12:04:11", "other"},
+		{"an over-long value is collapsed", strings.Repeat("x", 65), "other"},
+		{"a value at the length limit is kept", strings.Repeat("x", 64), strings.Repeat("x", 64)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, retryReasonTag(respWith(tc.reason)))
 		})
 	}
 }

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -37,7 +37,11 @@ import (
 const (
 	coldStartErrorsMetric    = "processor_user_transformer_cold_start_errors_total"
 	testForwardRetriesMetric = "processor_user_transformer_test_forward_retries_total"
-	languagePython           = "python"
+	// retryableErrorsMetric counts responses PyT labelled retryable that still reached the processor, i.e. the
+	// transport's retry budget was spent. Distinct from coldStartErrorsMetric, which no longer fires for these:
+	// without it, the two very different causes of a 503 are indistinguishable from rudder-server's own metrics.
+	retryableErrorsMetric = "processor_user_transformer_retryable_errors_total"
+	languagePython        = "python"
 )
 
 // ErrEmptyForwardBaseURL is returned by the test-forwarding methods ([Client.Test]
@@ -430,6 +434,20 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 				return transformerutils.ErrColdStart
 			}
 
+			// The transformer is up and reporting a downstream failure, and the transport already gave up retrying it.
+			// coldStartErrorsMetric deliberately does not fire here, so count it separately — otherwise this
+			// case is invisible and looks identical to any other unexpected status code.
+			if transformerclient.IsRetryableResponse(resp) {
+				u.stat.NewTaggedStat(retryableErrorsMetric, stats.CountType, stats.Tags{
+					"workspaceID": labels.WorkspaceID,
+					"language":    labels.Language,
+					"reason":      retryReasonTag(resp),
+				}).Increment()
+				u.log.Warnn("transformer reported a retryable failure and the transport's retries were exhausted",
+					append(labels.ToLoggerFields(),
+						logger.NewStringField("reason", retryReasonTag(resp)))...)
+			}
+
 			if reqErr != nil {
 				return reqErr
 			}
@@ -686,6 +704,28 @@ func isColdStartError(err error, resp *http.Response) bool {
 		return !transformerclient.IsRetryableResponse(resp)
 	}
 	return false
+}
+
+// retryReasonTag returns [transformerclient.HeaderErrorReason] in a form that is safe to use as a stats tag.
+//
+// The value is chosen by the transformer, so it must not reach the metrics backend unbounded: one unexpected
+// per-request string there is a new time series per request. Anything that isn't a short, plain identifier
+// becomes "other" — the tag is for grouping, and the exact string is already in the log line beside it.
+func retryReasonTag(resp *http.Response) string {
+	const maxReasonLen = 64
+	reason := resp.Header.Get(transformerclient.HeaderErrorReason)
+	if reason == "" {
+		return "unknown"
+	}
+	if len(reason) > maxReasonLen {
+		return "other"
+	}
+	for _, r := range reason {
+		if !(r == '_' || r == '-' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9') {
+			return "other"
+		}
+	}
+	return reason
 }
 
 func isPythonTransformation(language string) bool {

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -438,14 +438,14 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 			// coldStartErrorsMetric deliberately does not fire here, so count it separately — otherwise this
 			// case is invisible and looks identical to any other unexpected status code.
 			if transformerclient.IsRetryableResponse(resp) {
+				reason := retryReasonTag(resp.Header)
 				u.stat.NewTaggedStat(retryableErrorsMetric, stats.CountType, stats.Tags{
 					"workspaceID": labels.WorkspaceID,
 					"language":    labels.Language,
-					"reason":      retryReasonTag(resp),
+					"reason":      reason,
 				}).Increment()
 				u.log.Warnn("transformer reported a retryable failure and the transport's retries were exhausted",
-					append(labels.ToLoggerFields(),
-						logger.NewStringField("reason", retryReasonTag(resp)))...)
+					append(labels.ToLoggerFields(), logger.NewStringField("reason", reason))...)
 			}
 
 			if reqErr != nil {
@@ -711,9 +711,9 @@ func isColdStartError(err error, resp *http.Response) bool {
 // The value is chosen by the transformer, so it must not reach the metrics backend unbounded: one unexpected
 // per-request string there is a new time series per request. Anything that isn't a short, plain identifier
 // becomes "other" — the tag is for grouping, and the exact string is already in the log line beside it.
-func retryReasonTag(resp *http.Response) string {
+func retryReasonTag(header http.Header) string {
 	const maxReasonLen = 64
-	reason := resp.Header.Get(transformerclient.HeaderErrorReason)
+	reason := header.Get(transformerclient.HeaderErrorReason)
 	if reason == "" {
 		return "unknown"
 	}
@@ -721,7 +721,12 @@ func retryReasonTag(resp *http.Response) string {
 		return "other"
 	}
 	for _, r := range reason {
-		if !(r == '_' || r == '-' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9') {
+		switch {
+		case r == '_', r == '-',
+			r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9':
+		default:
 			return "other"
 		}
 	}

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -540,21 +540,20 @@ func (u *Client) ExtractLibs(ctx context.Context, baseURL, workspaceID string, p
 	return u.forwardTest(ctx, baseURL, workspaceID, "/extract-libs", payload)
 }
 
-// forwardTest is the shared machinery behind the per-endpoint test methods: it
-// POSTs payload to baseURL+path and returns the pyt HTTP status code and
-// response body unchanged.
+// forwardTest is the shared machinery behind the per-endpoint test methods: it POSTs payload to baseURL+path and
+// returns the pyt HTTP status code and response body unchanged.
 //
-// It is the cp-router test path's counterpart to the event-processing path
-// ([Client.doPost]): both share the client's maxRetry/maxRetryBackoffInterval
-// settings, but this call is time-boxed by ctx (cp-router's test deadline).
-// Callers that need a quicker cold-start recovery build the client with
-// [WithMaxRetryBackoffInterval]/[WithMaxRetry] to shrink the backoff and size
-// the retry budget — with the caller now waiting for the ephemeral pod's
-// readiness before calling in (see pytdeployer.Deployer), that budget only
-// needs to ride out whatever residual latency remains after the readiness
-// check, not a full cold-start window. Like [Client.doPost], it retries any
-// transport error plus cold-start 502/503 responses, counting the cold-start
-// signals; any other response is returned as-is for the caller to pass through.
+// It is the cp-router test path's counterpart to the event-processing path ([Client.doPost]): both share the client's
+// maxRetry/maxRetryBackoffInterval settings, but this call is time-boxed by ctx (cp-router's test deadline).
+// Callers that need a quicker cold-start recovery build the client with [WithMaxRetryBackoffInterval]/[WithMaxRetry] to
+// shrink the backoff and size the retry budget — with the caller now waiting for the ephemeral pod's readiness before
+// calling in (see pytdeployer.Deployer), that budget only needs to ride out whatever residual latency remains after the
+// readiness check, not a full cold-start window. Like [Client.doPost], it retries any transport error plus cold-start
+// 502/503 responses, counting the cold-start signals; any other response is returned as-is for the caller.
+//
+// A 502/503 carrying [transformerclient.HeaderShouldRetry] is not a cold start (see [isColdStartError]): pyt is up and
+// reporting a transient downstream failure, so the retryable transport owns retrying it and whatever it finally
+// returns is passed through here rather than retried again.
 func (u *Client) forwardTest(ctx context.Context, baseURL, workspaceID, path string, payload []byte) (int, []byte, error) {
 	if baseURL == "" {
 		return 0, nil, ErrEmptyForwardBaseURL
@@ -601,12 +600,12 @@ func (u *Client) forwardTest(ctx context.Context, baseURL, workspaceID, path str
 
 			body, err = io.ReadAll(resp.Body)
 			if err != nil {
-				// Reading the body can fail for several transport-level reasons
-				// (connection reset mid-response, idle timeout, ...). Like the
-				// event path, treat any of them as retryable — bounded by
-				// maxRetry and ctx — with each attempt made visible by the
-				// retry notify below.
-				return err
+				// Reading the body can fail for several transport-level reasons (connection reset mid-response,
+				// idle timeout, ...). Like the event path, treat any of them as retryable — bounded by
+				// maxRetry and ctx — with each attempt made visible by the retry notify below.
+				return fmt.Errorf("reading pyt response body (status %d, %s=%q): %w",
+					resp.StatusCode, transformerclient.HeaderErrorReason,
+					resp.Header.Get(transformerclient.HeaderErrorReason), err)
 			}
 			statusCode = resp.StatusCode
 			return nil

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -483,6 +483,12 @@ func (u *Client) doPost(ctx context.Context, rawJSON []byte, url string, labels 
 		if errors.Is(err, transformerutils.ErrColdStart) {
 			return fmt.Appendf(nil, "workspace transformer not reachable: %s", err), transformerutils.StatusColdStartWindowFailure, nil
 		}
+		// Deliberately no special case for a spent retryable-response budget here: it falls through to the bare
+		// error below, which sendBatch turns into a panic. Retries are effectively infinite in production
+		// (retryRudderErrors maxRetry=-1, maxElapsedTime=0); maxRetry exists to stop the contract tests running
+		// forever. We don't want to fail such events so crashing is the safe response to it: the jobs are still in
+		// jobsdb and are retried after the restart.
+		// Failing the events instead would abort them into proc-errors, i.e. lose customer data, quietly.
 		if u.config.failOnUserTransformTimeout.Load() && os.IsTimeout(err) {
 			return fmt.Appendf(nil, "transformer request timed out: %s", err), transformerutils.TransformerRequestTimeout, nil
 		} else if u.config.failOnError.Load() {
@@ -671,13 +677,13 @@ func isColdStartError(err error, resp *http.Response) bool {
 	}
 	if resp != nil && (resp.StatusCode == http.StatusServiceUnavailable ||
 		resp.StatusCode == http.StatusBadGateway) {
-		// A 503/502 carrying the should-retry header comes from PyT itself, not from the infrastructure in front of it.
-		// The pod is up and answering, reporting a transient downstream failure (e.g. the geolocation timeout).
-		// Reaching this line means the retryable transport in transformer-client stopped retrying it, which only
-		// happens once retryRudderErrors is bounded or disabled (by default it's enabled with maxRetry=-1).
+		// A response carrying the should-retry contract came from PyT itself: the pod is up and answering, reporting
+		// a transient downstream failure such as a geolocation timeout. Anything else is the infrastructure in front
+		// of it — a bare 502 from kube-proxy with no endpoints behind the Service — and means "not ready yet".
 		//
-		// Only an unlabelled 503/502, i.e. kube-proxy with no endpoints behind the Service, means "not ready yet".
-		return !strings.EqualFold(resp.Header.Get(transformerclient.HeaderShouldRetry), "true")
+		// Same predicate the transport retries on, so the two halves of the contract cannot drift apart on which
+		// responses mean "PyT is alive but degraded".
+		return !transformerclient.IsRetryableResponse(resp)
 	}
 	return false
 }

--- a/processor/internal/transformer/user_transformer/user_transformer.go
+++ b/processor/internal/transformer/user_transformer/user_transformer.go
@@ -672,7 +672,13 @@ func isColdStartError(err error, resp *http.Response) bool {
 	}
 	if resp != nil && (resp.StatusCode == http.StatusServiceUnavailable ||
 		resp.StatusCode == http.StatusBadGateway) {
-		return true
+		// A 503/502 carrying the should-retry header comes from PyT itself, not from the infrastructure in front of it.
+		// The pod is up and answering, reporting a transient downstream failure (e.g. the geolocation timeout).
+		// Reaching this line means the retryable transport in transformer-client stopped retrying it, which only
+		// happens once retryRudderErrors is bounded or disabled (by default it's enabled with maxRetry=-1).
+		//
+		// Only an unlabelled 503/502, i.e. kube-proxy with no endpoints behind the Service, means "not ready yet".
+		return !strings.EqualFold(resp.Header.Get(transformerclient.HeaderShouldRetry), "true")
 	}
 	return false
 }

--- a/processor/internal/transformer/user_transformer/user_transformer_test.go
+++ b/processor/internal/transformer/user_transformer/user_transformer_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"slices"
 	"strconv"
 	"strings"
@@ -34,6 +35,7 @@ import (
 
 	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
 	"github.com/rudderlabs/rudder-server/gateway/response"
+	transformerclient "github.com/rudderlabs/rudder-server/internal/transformer-client"
 	transformerutils "github.com/rudderlabs/rudder-server/processor/internal/transformer"
 	"github.com/rudderlabs/rudder-server/processor/internal/transformer/user_transformer"
 	"github.com/rudderlabs/rudder-server/processor/types"
@@ -1623,6 +1625,9 @@ type fakeColdStartTransport struct {
 	// a transport-level error (ECONNREFUSED / DNS / ...).
 	failStatus int
 	failErr    error
+	// failHeaders are set on the failing response, so tests can drive the
+	// transformer's retryable-error contract (X-Rudder-Should-Retry).
+	failHeaders map[string]string
 	// failures: number of failing calls before switching to successBody. Use
 	// math.MaxInt for "always fail".
 	failures int
@@ -1639,9 +1644,13 @@ func (f *fakeColdStartTransport) Do(_ *http.Request) (*http.Response, error) {
 	n := int(f.calls.Add(1))
 	if n <= f.failures {
 		if f.failStatus > 0 {
+			failHdr := hdr.Clone()
+			for k, v := range f.failHeaders {
+				failHdr.Set(k, v)
+			}
 			return &http.Response{
 				StatusCode: f.failStatus,
-				Header:     hdr,
+				Header:     failHdr,
 				Body:       io.NopCloser(bytes.NewReader(nil)),
 			}, nil
 		}
@@ -2049,5 +2058,91 @@ func TestForwardTest(t *testing.T) {
 
 		_, _, err := client.Test(context.Background(), "", "ws-1", []byte(`{}`))
 		require.ErrorIs(t, err, user_transformer.ErrEmptyForwardBaseURL)
+	})
+}
+
+// TestRetryableResponseExhaustedPanics pins that a spent retry budget crashes the processor instead of quietly
+// failing the events.
+//
+// This looks like a bug and is not. In production the retryable transport retries forever
+// (retryRudderErrors maxRetry=-1, maxElapsedTime=0); maxRetry exists so the contract tests terminate.
+// A bounded budget in production is therefore a misconfiguration, and the two ways out of it are not equivalent:
+// panicking leaves the jobs in jobsdb to be retried after the restart, whereas returning a failed event aborts them
+// into proc-errors and loses customer data. Loud and recoverable beats quiet and lossy.
+//
+// If this test starts failing because someone made the exhausted path return a status instead of an error, that
+// change is dropping events — fix the misconfiguration, not this.
+func TestRetryableResponseExhaustedPanics(t *testing.T) {
+	const (
+		workspaceID = "ws-retryable"
+		messageID   = "msg-retryable"
+		versionID   = "v-retryable"
+	)
+
+	newClient := func(t *testing.T, headers map[string]string) (*user_transformer.Client, []types.TransformerEvent) {
+		t.Helper()
+		c := config.New()
+		c.Set("Processor.UserTransformer.perWorkspacePyTEnabled", true)
+		c.Set("Processor.UserTransformer.perWorkspacePyTURLTemplate", "http://pyt-{workspaceID}:9090")
+		// Bounded, so the outer cold-start loop terminates and the response reaches the caller.
+		c.Set("Processor.UserTransformer.perWorkspacePyTEndlessRetries", false)
+		c.Set("Processor.UserTransformer.maxRetry", 1)
+		c.Set("Processor.UserTransformer.maxRetryBackoffInterval", "1ms")
+
+		transport := &fakeColdStartTransport{
+			failStatus:  http.StatusServiceUnavailable,
+			failHeaders: headers,
+			failures:    math.MaxInt,
+		}
+		statsStore, err := memstats.New()
+		require.NoError(t, err)
+
+		events := []types.TransformerEvent{{
+			Metadata: types.Metadata{MessageID: messageID, WorkspaceID: workspaceID},
+			Message:  map[string]any{"src-key-1": messageID},
+			Destination: backendconfig.DestinationT{
+				DestinationDefinition: backendconfig.DestinationDefinitionT{Name: "test-destination"},
+				Transformations: []backendconfig.TransformationT{{
+					ID: "transform-1", VersionID: versionID, Language: "pythonfaas",
+				}},
+			},
+		}}
+		return user_transformer.New(c, logger.NOP, statsStore, user_transformer.WithClient(transport)), events
+	}
+
+	// The panic happens inside a wg.Go goroutine, so it cannot be recovered by the caller and takes the process
+	// with it — which is the whole point, but also means require.Panics cannot observe it. Re-exec this test in a
+	// child process and assert that the child died instead.
+	const crashEnv = "USER_TRANSFORMER_CRASH_CHILD"
+
+	t.Run("503 with should-retry crashes rather than dropping the events", func(t *testing.T) {
+		if os.Getenv(crashEnv) == "1" {
+			tr, events := newClient(t, map[string]string{
+				transformerclient.HeaderShouldRetry: "true",
+				transformerclient.HeaderErrorReason: "geolocation_timeout",
+			})
+			_ = tr.Transform(context.Background(), events)
+			return // unreachable: the transform above must take the process down
+		}
+
+		cmd := exec.Command(os.Args[0], "-test.run="+t.Name()+"$", "-test.v")
+		cmd.Env = append(os.Environ(), crashEnv+"=1")
+		out, err := cmd.CombinedOutput()
+
+		require.Error(t, err, "child must die: the events have to survive in jobsdb via a crash, "+
+			"not be aborted into proc-errors\n%s", out)
+		require.Contains(t, string(out), "transformer returned status code: 503",
+			"child must die on the transformer error, not something incidental")
+	})
+
+	t.Run("bare 503 stays a cold start and never reaches the panic", func(t *testing.T) {
+		// No contract header: the infrastructure is answering, not pyt. This is the case
+		// [transformerclient.IsRetryableResponse] keeps out of the panic path, a bare 502 included.
+		tr, events := newClient(t, nil)
+		var rsp types.Response
+		require.NotPanics(t, func() { rsp = tr.Transform(context.Background(), events) })
+		require.Empty(t, rsp.Events)
+		require.Len(t, rsp.FailedEvents, 1)
+		require.Equal(t, transformerutils.StatusColdStartWindowFailure, rsp.FailedEvents[0].StatusCode)
 	})
 }


### PR DESCRIPTION
# Description

Repurposes the `integration_test/pytransformer_contract` suite from "old architecture vs new architecture" to "baseline rudder-pytransformer vs candidate rudder-pytransformer", and fixes the retry classification that the new routing exposed.

The suite previously compared rudder-transformer + a per-subtest `openfaas-flask-base` container against rudder-pytransformer. That comparison is obsolete now that PyT is the only implementation, so both sides are now PyT images at two different tags and the openfaas/rudder-transformer scaffolding is deleted. Because both sides fetch transformation code per request, one container per version serves every `versionID` instead of one container per subtest — roughly 90 fewer container starts per run.

**Which two images are compared** is the caller's decision: `PYT_CANDIDATE_TAG` and `PYT_BASELINE_TAG` are both required and neither has a default, so `TestMain` fails the package before any container starts if either is missing. CI resolves the two most recent released tags from ECR and exports them, so a new release is picked up automatically; locally you build your image (`make build-ecr-latest` tags it `main`) and point the candidate at it. This also replaces the floating `main`/`latest` tags the suite used to pull, so runs are reproducible. If both tags resolve to the same value the suite refuses to run rather than compare an image against itself.

## Running it against your own PyT build

In the **rudder-pytransformer** repo, build the image — `make build-ecr-latest`, which tags it `main` — then from **rudder-server** point the candidate at that build and the baseline at the release you want to compare against:

```sh
PYT_CANDIDATE_TAG=main PYT_BASELINE_TAG=<last released tag> make test package=integration_test/pytransformer_contract
# or, for one suite while iterating:
PYT_CANDIDATE_TAG=main PYT_BASELINE_TAG=<last released tag> go test ./integration_test/pytransformer_contract/ -run TestBackwardsCompatibility -count=1 -timeout=30m
```

The rudder-pytransformer Makefile recipe sets both for you and takes the baseline tag as a required argument. You need to be able to pull from ECR for the baseline image (see the Notion docs); the candidate comes from your local build. Two things to know:

- **Docker only pulls a tag it doesn't already have.** If you skip the rebuild, `main` is whatever you last pulled or built, and the suite will happily compare that instead — with no warning. Rebuild before you trust a green run.
- **Omitting either tag fails the whole package** with a message naming the missing one, before any container starts. Setting both to the same value is refused too, rather than passing every parity assertion vacuously.

## Behaviour change (not test-only)

The suite now routes through the per-workspace PyT path, which activates cold-start classification and made an existing bug reachable:

- `isColdStartError` no longer treats a 503 as a PyT cold start when the response carries `X-Rudder-Should-Retry: true`. A labelled 503 means PyT is up and reporting a transient downstream failure (e.g. a geolocation timeout), not that the pod is missing; anything else, including a bare 502 from kube-proxy with no endpoints, still means "not ready yet". Without this, `Transformer.Client.UserTransformer.retryRudderErrors.maxRetry` is unenforceable, because the endless cold-start loop resumes retrying what the transport was just told to stop.
- `X-Rudder-Should-Retry` and `X-Rudder-Error-Reason` are lifted into exported constants in `internal/transformer-client`, documented as a wire format shared with rudder-pytransformer: renaming the constants is free, changing their values is a breaking change on both sides. The signal itself is defined once, as `transformerclient.IsRetryableResponse`, and both consumers — the retryable transport and the cold-start classifier — call it, so they cannot disagree about which responses carry the contract. The status set is 503-only, matching what PyT emits: it normalises downstream failures (a downstream 502 included) into its own 503 plus these headers.
- An exhausted retry budget still crashes the processor, deliberately, and there is now a test pinning that. Retries are effectively infinite in production (`maxRetry=-1`, `maxElapsedTime=0`); `maxRetry` exists so the contract tests terminate. A bounded budget in production is a misconfiguration, and crashing is the safe response: the jobs stay in jobsdb and are retried after the restart, whereas failing the events would abort them into proc-errors and lose customer data.
- `internal/transformer-client` no longer closes the response body inside its retry strategy. `retryablehttp` already drains and closes between attempts; our close also fired on the attempt that exhausts the budget, and that response is the one handed back to the caller — so `forwardTest` (the control-plane "test a transformation" path) got `http: read on closed response body` instead of PyT's real status and body. Removing it also restores the 2KB drain that keep-alive reuse depends on.
- `forwardTest` now reports the status code and `X-Rudder-Error-Reason` when a body read fails, so a lost body still says whether PyT answered and why.

## Tests

- `TestIsColdStartError` — new table test pinning which 5xx responses mean "pod isn't up yet", including the case-insensitive header match and the bare-5xx cold-start cases.
- `TestRetryableResponseExhaustedPanics` — drives a permanently-failing 503 + `X-Rudder-Should-Retry` through `Transform()` and asserts the process dies rather than dropping the events. The panic happens in a `wg.Go` goroutine so it cannot be recovered in-process; the test re-execs itself in a child and asserts the child died on the transformer error. Verified to fail if the events are made to fail instead.
- The geolocation and backwards-compatibility contract subtests that called the baseline and then asserted nothing on it now assert both sides and compare them, so a divergence between two PyT releases fails the suite instead of being logged and ignored.
- `TestClient_ResponseBodyReadableAfterRetriesExhausted` — pins that `Do` returns a readable body once retries are exhausted. Its second case documents a limitation we cannot fix here: when the context ends the retries mid-backoff, `retryablehttp` returns the last completed attempt's response, already closed, paired with a nil error.

## Linear Ticket

< Fixes [PIPE-3256](https://linear.app/rudderstack/issue/PIPE-3256/remove-openfaas-from-rudder-server-contract-tests)  >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
