### PR TITLE
feat: bingads integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -175,6 +175,67 @@ jobs:
         with:
           name: ${{ matrix.destination }}
           path: coverage.txt
+  async-destination-integration:
+    name: Async Destination Integration
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        destination: [ bingads ]
+        include:
+          - destination: bingads
+            package: router/batchrouter/asyncdestinationmanager/bing-ads
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: ${{ vars.AWS_ECR_READ_ONLY_IAM_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_ECR_REGION }}
+          role-session-name: ${{ github.event.repository.name }}
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+      - name: Pull rudder-auth image
+        run: docker pull 422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-auth:develop
+      - name: Unset AWS Credentials
+        run: |
+          echo "AWS_ACCESS_KEY_ID=" >> $GITHUB_ENV
+          echo "AWS_SECRET_ACCESS_KEY=" >> $GITHUB_ENV
+          echo "AWS_SESSION_TOKEN=" >> $GITHUB_ENV
+          echo "AWS_REGION=" >> $GITHUB_ENV
+          echo "AWS_DEFAULT_REGION=" >> $GITHUB_ENV
+      - name: Disable IPv6 (temporary fix)
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+      - run: go version
+      - run: go mod download # Not required, used to segregate module download vs test times
+      - name: Async Destination Integration [ ${{ matrix.destination }} ]
+        run: make test-async-destination package=${{ matrix.package }}
+        env:
+          BINGADS_OFFLINE_CONVERSIONS_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.BINGADS_OFFLINE_CONVERSIONS_INTEGRATION_TEST_CREDENTIALS }}
+          BINGADS_AUDIENCE_INTEGRATION_TEST_CREDENTIALS: ${{ secrets.BINGADS_AUDIENCE_INTEGRATION_TEST_CREDENTIALS }}
+          RACE_ENABLED: "true"
+          FORCE_RUN_INTEGRATION_TESTS: "true"
+      - name: Upload coverage report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: async-${{ matrix.destination }}
+          path: coverage.txt
   unit:
     name: Unit
     runs-on: ubuntu-latest
@@ -269,6 +330,8 @@ jobs:
             exclude: services/dedup
           - package: warehouse
             race: true
+          - package: router
+            exclude: router/batchrouter/asyncdestinationmanager/bing-ads
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -337,6 +400,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - warehouse-integration
+      - async-destination-integration
       - unit
       - package-unit
     steps:
@@ -370,6 +434,7 @@ jobs:
     needs:
       - integration
       - warehouse-integration
+      - async-destination-integration
       - unit
       - package-unit
     steps:

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,17 @@ endif
 
 test-warehouse: test-warehouse-integration test-teardown
 
+test-async-destination-integration:
+	$(eval TEST_PATTERN = $(if $(run),$(run),Integration))
+	$(eval TEST_CMD = SLOW=1 go test)
+	$(eval TEST_OPTIONS = -v -p 8 -timeout 30m -count 1 -run $(TEST_PATTERN) -coverprofile=profile.out -covermode=atomic -coverpkg=./...)
+ifeq ($(RACE_ENABLED), true)
+	$(eval TEST_OPTIONS := $(TEST_OPTIONS) -race)
+endif
+	$(TEST_CMD) $(TEST_OPTIONS) ./$(package)/... && touch $(TESTFILE) || true
+
+test-async-destination: test-async-destination-integration test-teardown
+
 test-teardown:
 	@if [ -f "$(TESTFILE)" ]; then \
     	echo "Tests passed, tearing down..." ;\

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/bingads_audience_integration_test.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/bingads_audience_integration_test.go
@@ -59,7 +59,7 @@ func TestBingAdsAudienceIntegration(t *testing.T) {
 					jobs = append(jobs, newAudienceJob(t, jobID, action, hashedEmail))
 				}
 			}
-			pollResponse, ids := runUpload(t, uploader, destination, jobs)
+			pollResponse, ids := runUploadAndPoll(t, uploader, destination, jobs)
 			requireImportSucceeded(t, pollResponse, len(ids))
 		})
 	}
@@ -84,7 +84,7 @@ func TestBingAdsAudienceIntegration(t *testing.T) {
 			jobs = append(jobs, newAudienceJob(t, jobID, "Add", email))
 		}
 
-		pollResponse, ids := runUpload(t, uploader, destination, jobs)
+		pollResponse, ids := runUploadAndPoll(t, uploader, destination, jobs)
 		meta := fetchUploadStats(t, uploader, pollResponse, ids)
 		require.ElementsMatch(t, abortedJobIDs, meta.AbortedKeys, "unexpected set of aborted jobs")
 		require.ElementsMatch(t, succeededJobIDs, meta.SucceededKeys, "unexpected set of succeeded jobs")

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/bingads_audience_integration_test.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/bingads_audience_integration_test.go
@@ -1,0 +1,169 @@
+package bingads
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/bing-ads/audience"
+	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/testhelper/rudderauth"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+)
+
+const (
+	audienceDestName           = "BING_ADS"
+	audienceCredsEnvVar        = "BINGADS_AUDIENCE_INTEGRATION_TEST_CREDENTIALS"
+	audienceRefreshDestination = "bingads_audience"
+)
+
+func TestBingAdsAudienceIntegration(t *testing.T) {
+	creds := getAudienceCredentials(t)
+	misc.Init()
+
+	secret := resolveRudderAuthSecret(t, creds.bingAdsCredentials, audienceRefreshDestination)
+
+	const eventsPerAction = 5
+	actions := []string{"Add", "Remove", "Replace"}
+
+	audiences := []struct {
+		name       string
+		audienceID string
+	}{
+		{name: "hashed", audienceID: creds.HashedAudienceID},
+		{name: "unhashed", audienceID: creds.UnhashedAudienceID},
+	}
+
+	for _, aud := range audiences {
+		t.Run(aud.name, func(t *testing.T) {
+			t.Logf("audience=%s clubbing %d Add/Remove/Replace events in a single import", aud.name, len(actions)*eventsPerAction)
+			uploader := newAudienceUploader(t, creds, secret)
+			destination := newAudienceDestination(creds, aud.audienceID)
+
+			jobs := make([]*jobsdb.JobT, 0, len(actions)*eventsPerAction)
+			var jobID int64
+			for _, action := range actions {
+				for range eventsPerAction {
+					jobID++
+					email := fmt.Sprintf("audience-%d@example.com", jobID)
+					hashedEmail := hashEmail(email)
+					t.Logf("job=%d action=%s email=%s hashedEmail=%s", jobID, action, email, hashedEmail)
+					jobs = append(jobs, newAudienceJob(t, jobID, action, hashedEmail))
+				}
+			}
+			pollResponse, ids := runUpload(t, uploader, destination, jobs)
+			requireImportSucceeded(t, pollResponse, len(ids))
+		})
+	}
+
+	t.Run("valid and invalid emails in one import", func(t *testing.T) {
+		uploader := newAudienceUploader(t, creds, secret)
+		destination := newAudienceDestination(creds, creds.HashedAudienceID)
+
+		jobs := make([]*jobsdb.JobT, 0, eventsPerAction)
+		var abortedJobIDs, succeededJobIDs []int64
+		for jobID := int64(1); jobID <= eventsPerAction; jobID++ {
+			var email string
+			if jobID%2 == 0 {
+				email = hashEmail(fmt.Sprintf("audience-valid-%d@example.com", jobID))
+				succeededJobIDs = append(succeededJobIDs, jobID)
+				t.Logf("job=%d action=Add email=%s (valid hash, expecting success)", jobID, email)
+			} else {
+				email = fmt.Sprintf("audience-invalid-%d@example.com", jobID)
+				abortedJobIDs = append(abortedJobIDs, jobID)
+				t.Logf("job=%d action=Add email=%s (plain-text, expecting abort)", jobID, email)
+			}
+			jobs = append(jobs, newAudienceJob(t, jobID, "Add", email))
+		}
+
+		pollResponse, ids := runUpload(t, uploader, destination, jobs)
+		meta := fetchUploadStats(t, uploader, pollResponse, ids)
+		require.ElementsMatch(t, abortedJobIDs, meta.AbortedKeys, "unexpected set of aborted jobs")
+		require.ElementsMatch(t, succeededJobIDs, meta.SucceededKeys, "unexpected set of succeeded jobs")
+		for _, jobID := range abortedJobIDs {
+			require.Equal(t, "EmailMustBeHashed", meta.AbortedReasons[jobID], "expected an abort reason for job %d", jobID)
+		}
+	})
+}
+
+func hashEmail(email string) string {
+	sum := sha256.Sum256([]byte(email))
+	return hex.EncodeToString(sum[:])
+}
+
+func newAudienceDestination(creds *audienceCredentials, audienceID string) *backendconfig.DestinationT {
+	return &backendconfig.DestinationT{
+		Name: "BingAds",
+		Config: map[string]any{
+			"customerAccountId": creds.CustomerAccountID,
+			"customerId":        creds.CustomerID,
+			"audienceId":        audienceID,
+		},
+		WorkspaceID: "integration_test_workspace",
+	}
+}
+
+type audienceCredentials struct {
+	bingAdsCredentials
+
+	HashedAudienceID   string `json:"hashedAudienceId"`
+	UnhashedAudienceID string `json:"unhashedAudienceId"`
+}
+
+func getAudienceCredentials(t *testing.T) *audienceCredentials {
+	t.Helper()
+
+	raw := requireIntegrationEnv(t, audienceCredsEnvVar)
+
+	var creds audienceCredentials
+	require.NoErrorf(t, jsonrs.Unmarshal([]byte(raw), &creds), "unmarshalling %s", audienceCredsEnvVar)
+
+	requireCredentialFields(t, audienceCredsEnvVar, map[string]string{
+		"clientId":           creds.ClientID,
+		"clientSecret":       creds.ClientSecret,
+		"developerToken":     creds.DeveloperToken,
+		"refreshToken":       creds.RefreshToken,
+		"customerAccountId":  creds.CustomerAccountID,
+		"customerId":         creds.CustomerID,
+		"hashedAudienceId":   creds.HashedAudienceID,
+		"unhashedAudienceId": creds.UnhashedAudienceID,
+	})
+	t.Log("Loaded audience credentials")
+	return &creds
+}
+
+func newAudienceUploader(t *testing.T, creds *audienceCredentials, secret rudderauth.Secret) *audience.BingAdsBulkUploader {
+	t.Helper()
+	t.Log("Creating audience uploader")
+
+	return audience.NewBingAdsBulkUploader(
+		logger.NOP, stats.NOP, audienceDestName,
+		newBulkService(creds.bingAdsCredentials, secret), &audience.Client{},
+	)
+}
+
+func newAudienceJob(t *testing.T, jobID int64, action, hashedEmail string) *jobsdb.JobT {
+	t.Helper()
+
+	payload := map[string]any{
+		"body": map[string]any{
+			"JSON": map[string]any{
+				"Action": action,
+				"List": []map[string]any{
+					{"hashedEmail": hashedEmail},
+				},
+			},
+		},
+	}
+	raw, err := jsonrs.Marshal(payload)
+	require.NoError(t, err)
+	return &jobsdb.JobT{JobID: jobID, EventPayload: raw}
+}

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/bingads_common_test.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/bingads_common_test.go
@@ -113,7 +113,7 @@ func writeUploadDataFile(t *testing.T, uploader common.AsyncUploadAndTransformMa
 	return filePath
 }
 
-func runUpload(t *testing.T, uploader common.AsyncDestinationManager, destination *backendconfig.DestinationT, jobs []*jobsdb.JobT) (common.PollStatusResponse, []int64) {
+func runUploadAndPoll(t *testing.T, uploader common.AsyncDestinationManager, destination *backendconfig.DestinationT, jobs []*jobsdb.JobT) (common.PollStatusResponse, []int64) {
 	t.Helper()
 	ctx := context.Background()
 

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/bingads_common_test.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/bingads_common_test.go
@@ -1,0 +1,184 @@
+package bingads
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	bingadssdk "github.com/rudderlabs/bing-ads-go-sdk/bingads"
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/common"
+	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/testhelper/rudderauth"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+)
+
+const sessionHTTPTimeout = 60 * time.Second
+
+type bingAdsCredentials struct {
+	ClientID       string `json:"clientId"`
+	ClientSecret   string `json:"clientSecret"`
+	DeveloperToken string `json:"developerToken"`
+	RefreshToken   string `json:"refreshToken"`
+
+	CustomerAccountID string `json:"customerAccountId"`
+	CustomerID        string `json:"customerId"`
+}
+
+func requireIntegrationEnv(t *testing.T, envVar string) string {
+	t.Helper()
+	raw, exists := os.LookupEnv(envVar)
+	if !exists {
+		if os.Getenv("FORCE_RUN_INTEGRATION_TESTS") == "true" {
+			t.Fatalf("%s environment variable not set", envVar)
+		}
+		t.Skipf("Skipping %s as %s is not set", t.Name(), envVar)
+	}
+	return raw
+}
+
+func requireCredentialFields(t *testing.T, envVar string, fields map[string]string) {
+	t.Helper()
+	for field, value := range fields {
+		require.NotEmptyf(t, value, "%s is required in %s", field, envVar)
+	}
+}
+
+func newBulkService(creds bingAdsCredentials, secret rudderauth.Secret) bingadssdk.BulkServiceI {
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: secret.AccessToken()})
+	session := bingadssdk.NewSession(bingadssdk.SessionConfig{
+		DeveloperToken: creds.DeveloperToken,
+		AccountId:      creds.CustomerAccountID,
+		CustomerId:     creds.CustomerID,
+		HTTPClient:     &http.Client{Timeout: sessionHTTPTimeout},
+		TokenSource:    tokenSource,
+	})
+	return bingadssdk.NewBulkService(session)
+}
+
+func resolveRudderAuthSecret(t *testing.T, creds bingAdsCredentials, refreshDestination string) rudderauth.Secret {
+	t.Helper()
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	t.Log("Starting rudder-auth container")
+	rudderAuth, err := rudderauth.Setup(pool, t, rudderauth.WithEnv(map[string]string{
+		"BINGADS_AUDIENCE_CLIENT_ID_DESTINATION":     creds.ClientID,
+		"BINGADS_AUDIENCE_CLIENT_SECRET_DESTINATION": creds.ClientSecret,
+		"BINGADS_AUDIENCE_DEVELOPER_TOKEN":           creds.DeveloperToken,
+	}))
+	require.NoError(t, err)
+	t.Logf("rudder-auth ready at %s", rudderAuth.URL)
+
+	secret, err := rudderAuth.RefreshToken(context.Background(), rudderauth.RefreshRequest{
+		Destination:  refreshDestination,
+		RefreshToken: creds.RefreshToken,
+	})
+	require.NoError(t, err)
+	t.Log("Resolved access token from rudder-auth")
+	return secret
+}
+
+func writeUploadDataFile(t *testing.T, uploader common.AsyncUploadAndTransformManager, jobs []*jobsdb.JobT) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	t.Setenv("RUDDER_TMPDIR", tmpDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, misc.RudderAsyncDestinationLogs), 0o755))
+
+	filePath := filepath.Join(tmpDir, "uploadData.txt")
+	file, err := os.Create(filePath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, file.Close()) }()
+
+	for _, job := range jobs {
+		line, err := uploader.Transform(job)
+		require.NoErrorf(t, err, "transforming job %d", job.JobID)
+		_, err = fmt.Fprintln(file, line)
+		require.NoError(t, err)
+	}
+	t.Logf("Wrote %d job(s) to upload file %s", len(jobs), filePath)
+	return filePath
+}
+
+func runUpload(t *testing.T, uploader common.AsyncDestinationManager, destination *backendconfig.DestinationT, jobs []*jobsdb.JobT) (common.PollStatusResponse, []int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	importingJobIDs := lo.Map(jobs, func(job *jobsdb.JobT, _ int) int64 { return job.JobID })
+
+	uploadFile := writeUploadDataFile(t, uploader, jobs)
+
+	t.Log("Uploading bulk file")
+	uploadOutput := uploader.Upload(ctx, &common.AsyncDestinationStruct{
+		ImportingJobIDs: importingJobIDs,
+		FailedJobIDs:    []int64{},
+		FileName:        uploadFile,
+		Destination:     destination,
+		Manager:         uploader,
+	})
+	require.Zerof(t, uploadOutput.FailedCount, "upload reported failures: %s", uploadOutput.FailedReason)
+	require.Equal(t, len(importingJobIDs), uploadOutput.ImportingCount)
+	require.NotEmpty(t, uploadOutput.ImportingParameters)
+
+	var importParameters common.ImportParameters
+	require.NoError(t, jsonrs.Unmarshal(uploadOutput.ImportingParameters, &importParameters))
+	importID, ok := importParameters.ImportId.(string)
+	require.Truef(t, ok, "import id is not a string: %v", importParameters.ImportId)
+	require.NotEmpty(t, importID, "empty import id returned from Upload")
+	t.Logf("Import id: %s", importID)
+
+	t.Log("Polling until the import reaches a terminal state")
+	var pollResponse common.PollStatusResponse
+	require.Eventually(t, func() bool {
+		pollResponse = uploader.Poll(ctx, common.AsyncPoll{ImportId: importID})
+		return pollResponse.Complete || pollResponse.HasFailed
+	}, 5*time.Minute, 15*time.Second)
+
+	require.Equalf(t, http.StatusOK, pollResponse.StatusCode, "poll returned non-200: %+v", pollResponse)
+	require.Truef(t, pollResponse.Complete, "import did not complete: %+v", pollResponse)
+	t.Logf("Import terminal: complete=%v hasFailed=%v", pollResponse.Complete, pollResponse.HasFailed)
+
+	return pollResponse, importingJobIDs
+}
+
+func requireImportSucceeded(t *testing.T, pollResponse common.PollStatusResponse, jobCount int) {
+	t.Helper()
+	require.Falsef(t, pollResponse.HasFailed,
+		"expected all jobs to succeed, but import completed with errors: %+v", pollResponse)
+	require.Falsef(t, pollResponse.HasWarning,
+		"expected a clean success, but import completed with warnings: %+v", pollResponse)
+	t.Logf("All %d job(s) succeeded", jobCount)
+}
+
+func fetchUploadStats(t *testing.T, uploader common.AsyncDestinationManager, pollResponse common.PollStatusResponse, importingJobIDs []int64) common.EventStatMeta {
+	t.Helper()
+	require.Truef(t, pollResponse.HasFailed,
+		"expected import to complete with errors, got %+v", pollResponse)
+	require.NotEmptyf(t, pollResponse.FailedJobParameters,
+		"expected a result file for the failed import, got %+v", pollResponse)
+
+	importingList := lo.Map(importingJobIDs, func(jobID int64, _ int) *jobsdb.JobT {
+		return &jobsdb.JobT{JobID: jobID}
+	})
+	uploadStats := uploader.GetUploadStats(common.GetUploadStatsInput{
+		FailedJobParameters: pollResponse.FailedJobParameters,
+		ImportingList:       importingList,
+	})
+	require.Equal(t, http.StatusOK, uploadStats.StatusCode)
+	t.Logf("upload result: succeeded=%v aborted=%v reasons=%v",
+		uploadStats.Metadata.SucceededKeys, uploadStats.Metadata.AbortedKeys, uploadStats.Metadata.AbortedReasons)
+	return uploadStats.Metadata
+}

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/bingads_offline_conversions_integration_test.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/bingads_offline_conversions_integration_test.go
@@ -151,7 +151,7 @@ func TestBingAdsOfflineConversionsIntegration(t *testing.T) {
 				jobs = append(jobs, newConversionJob(t, jobID, tc.action, fields))
 			}
 
-			pollResponse, ids := runUpload(t, uploader, destination, jobs)
+			pollResponse, ids := runUploadAndPoll(t, uploader, destination, jobs)
 			if tc.wantAbortReason == "" {
 				requireImportSucceeded(t, pollResponse, len(ids))
 				return

--- a/router/batchrouter/asyncdestinationmanager/bing-ads/bingads_offline_conversions_integration_test.go
+++ b/router/batchrouter/asyncdestinationmanager/bing-ads/bingads_offline_conversions_integration_test.go
@@ -1,0 +1,242 @@
+package bingads
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+
+	backendconfig "github.com/rudderlabs/rudder-server/backend-config"
+	"github.com/rudderlabs/rudder-server/jobsdb"
+	offlineconversions "github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/bing-ads/offline-conversions"
+	"github.com/rudderlabs/rudder-server/router/batchrouter/asyncdestinationmanager/testhelper/rudderauth"
+	"github.com/rudderlabs/rudder-server/utils/misc"
+)
+
+const (
+	offlineConversionsDestName           = "BING_ADS_OFFLINE_CONVERSIONS"
+	offlineConversionsCredsEnvVar        = "BINGADS_OFFLINE_CONVERSIONS_INTEGRATION_TEST_CREDENTIALS"
+	offlineConversionsRefreshDestination = "bingads_offline_conversions"
+
+	offlineConversionGoalName = "Qualified Lead"
+)
+
+func TestBingAdsOfflineConversionsIntegration(t *testing.T) {
+	creds := getOfflineConversionsCredentials(t)
+	misc.Init()
+
+	secret := resolveRudderAuthSecret(t, *creds, offlineConversionsRefreshDestination)
+
+	now := time.Now().UTC()
+	conversionTime := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	adjustedConversionTime := now.Add(-30 * time.Minute).Format(time.RFC3339)
+
+	testCases := []struct {
+		name            string
+		action          string
+		isHashRequired  bool
+		fields          map[string]any
+		wantAbortReason string
+	}{
+		{
+			name:           "insert pre-hashed email/phone (isHashRequired=false)",
+			action:         "insert",
+			isHashRequired: false,
+			fields: map[string]any{
+				"conversionTime":         conversionTime,
+				"conversionValue":        "100",
+				"conversionCurrencyCode": "USD",
+				"email":                  "973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b",
+				"phone":                  "8a59780bb8cd2ba022bfa5ba2ea3b6e07af17a7d8b30c1f9b3390e36f69019e4",
+			},
+		},
+		{
+			name:           "insert raw email/phone (isHashRequired=true)",
+			action:         "insert",
+			isHashRequired: true,
+			fields: map[string]any{
+				"conversionTime":         conversionTime,
+				"conversionValue":        "100",
+				"conversionCurrencyCode": "USD",
+				"email":                  "test@example.com",
+				"phone":                  "+15551234567",
+			},
+		},
+		{
+			name:           "update Restate raw email/phone (isHashRequired=true)",
+			action:         "update",
+			isHashRequired: true,
+			fields: map[string]any{
+				"conversionTime":         conversionTime,
+				"adjustedConversionTime": adjustedConversionTime,
+				"conversionValue":        "150",
+				"conversionCurrencyCode": "USD",
+				"email":                  "test@example.com",
+				"phone":                  "+15551234567",
+			},
+		},
+		{
+			name:           "delete Retract raw email/phone (isHashRequired=true)",
+			action:         "delete",
+			isHashRequired: true,
+			fields: map[string]any{
+				"conversionTime":         conversionTime,
+				"adjustedConversionTime": adjustedConversionTime,
+				"email":                  "test@example.com",
+				"phone":                  "+15551234567",
+			},
+		},
+		{
+			name:            "insert invalid conversion name -> OfflineConversionNameInvalid",
+			action:          "insert",
+			isHashRequired:  true,
+			wantAbortReason: "OfflineConversionNameInvalid",
+			fields: map[string]any{
+				"conversionName":         "NonExistentGoalName",
+				"conversionTime":         conversionTime,
+				"conversionValue":        "100",
+				"conversionCurrencyCode": "USD",
+				"email":                  "test@example.com",
+				"phone":                  "+15551234567",
+			},
+		},
+		{
+			name:            "insert invalid msclkid -> OfflineConversionMicrosoftClickIdInvalid",
+			action:          "insert",
+			isHashRequired:  false,
+			wantAbortReason: "OfflineConversionMicrosoftClickIdInvalid",
+			fields: map[string]any{
+				"conversionTime":         conversionTime,
+				"conversionValue":        "100",
+				"conversionCurrencyCode": "USD",
+				"microsoftClickId":       "invalid-click-id",
+			},
+		},
+	}
+
+	const eventsPerCase = 5
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("action=%s isHashRequired=%v events=%d", tc.action, tc.isHashRequired, eventsPerCase)
+			uploader := newOfflineConversionsUploader(t, creds, secret, tc.isHashRequired)
+			destination := newOfflineConversionsDestination(creds)
+
+			jobs := make([]*jobsdb.JobT, 0, eventsPerCase)
+			var abortedJobIDs, succeededJobIDs []int64
+			for jobID := int64(1); jobID <= eventsPerCase; jobID++ {
+				invalid := tc.wantAbortReason != "" && jobID%2 == 1
+
+				var fields map[string]any
+				if tc.wantAbortReason != "" && !invalid {
+					fields = validConversionFields(conversionTime, conversionEmail(jobID, tc.isHashRequired))
+				} else {
+					fields = lo.Assign(tc.fields)
+					if _, ok := fields["email"]; ok {
+						fields["email"] = conversionEmail(jobID, tc.isHashRequired)
+					}
+				}
+
+				if invalid {
+					abortedJobIDs = append(abortedJobIDs, jobID)
+				} else {
+					succeededJobIDs = append(succeededJobIDs, jobID)
+				}
+				t.Logf("job=%d action=%s invalid=%v", jobID, tc.action, invalid)
+				jobs = append(jobs, newConversionJob(t, jobID, tc.action, fields))
+			}
+
+			pollResponse, ids := runUpload(t, uploader, destination, jobs)
+			if tc.wantAbortReason == "" {
+				requireImportSucceeded(t, pollResponse, len(ids))
+				return
+			}
+
+			meta := fetchUploadStats(t, uploader, pollResponse, ids)
+			require.ElementsMatch(t, abortedJobIDs, meta.AbortedKeys, "unexpected set of aborted jobs")
+			require.ElementsMatch(t, succeededJobIDs, meta.SucceededKeys, "unexpected set of succeeded jobs")
+			for _, jobID := range abortedJobIDs {
+				require.Equalf(t, tc.wantAbortReason, meta.AbortedReasons[jobID],
+					"unexpected abort reason for job %d", jobID)
+			}
+		})
+	}
+}
+
+func getOfflineConversionsCredentials(t *testing.T) *bingAdsCredentials {
+	t.Helper()
+
+	raw := requireIntegrationEnv(t, offlineConversionsCredsEnvVar)
+
+	var creds bingAdsCredentials
+	require.NoErrorf(t, jsonrs.Unmarshal([]byte(raw), &creds), "unmarshalling %s", offlineConversionsCredsEnvVar)
+
+	requireCredentialFields(t, offlineConversionsCredsEnvVar, map[string]string{
+		"clientId":          creds.ClientID,
+		"clientSecret":      creds.ClientSecret,
+		"developerToken":    creds.DeveloperToken,
+		"refreshToken":      creds.RefreshToken,
+		"customerAccountId": creds.CustomerAccountID,
+		"customerId":        creds.CustomerID,
+	})
+	t.Log("Loaded offline conversions credentials")
+	return &creds
+}
+
+func newOfflineConversionsDestination(creds *bingAdsCredentials) *backendconfig.DestinationT {
+	return &backendconfig.DestinationT{
+		Name: "BingAds",
+		Config: map[string]any{
+			"customerAccountId": creds.CustomerAccountID,
+			"customerId":        creds.CustomerID,
+		},
+		WorkspaceID: "integration_test_workspace",
+	}
+}
+
+func newOfflineConversionsUploader(t *testing.T, creds *bingAdsCredentials, secret rudderauth.Secret, isHashRequired bool) *offlineconversions.BingAdsBulkUploader {
+	t.Helper()
+	t.Logf("Creating offline conversions uploader (isHashRequired=%v)", isHashRequired)
+
+	return offlineconversions.NewBingAdsBulkUploader(
+		logger.NOP, stats.NOP, offlineConversionsDestName,
+		newBulkService(*creds, secret), isHashRequired,
+	)
+}
+
+func conversionEmail(jobID int64, isHashRequired bool) string {
+	email := fmt.Sprintf("offline-%d@example.com", jobID)
+	if isHashRequired {
+		return email
+	}
+	return hashEmail(email)
+}
+
+func validConversionFields(conversionTime, email string) map[string]any {
+	return map[string]any{
+		"conversionTime":         conversionTime,
+		"conversionValue":        "100",
+		"conversionCurrencyCode": "USD",
+		"email":                  email,
+	}
+}
+
+func newConversionJob(t *testing.T, jobID int64, action string, fields map[string]any) *jobsdb.JobT {
+	t.Helper()
+
+	record := lo.Assign(map[string]any{"conversionName": offlineConversionGoalName}, fields)
+
+	payload := map[string]any{
+		"type":   "record",
+		"action": action,
+		"fields": record,
+	}
+	raw, err := jsonrs.Marshal(payload)
+	require.NoError(t, err)
+	return &jobsdb.JobT{JobID: jobID, EventPayload: raw}
+}

--- a/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/lytics_test.go
+++ b/router/batchrouter/asyncdestinationmanager/lytics_bulk_upload/lytics_test.go
@@ -56,6 +56,10 @@ var _ = Describe("LYTICS_BULK_UPLOAD test", func() {
 		BeforeEach(func() {
 			config.Reset()
 			config.Set("BatchRouter.LYTICS_BULK_UPLOAD.MaxUploadLimit", 1*bytesize.MB)
+
+			tmpDir := GinkgoT().TempDir()
+			GinkgoT().Setenv("RUDDER_TMPDIR", tmpDir)
+			Expect(os.MkdirAll(filepath.Join(tmpDir, misc.RudderAsyncDestinationLogs), 0o755)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/router/batchrouter/asyncdestinationmanager/testhelper/rudderauth/rudderauth.go
+++ b/router/batchrouter/asyncdestinationmanager/testhelper/rudderauth/rudderauth.go
@@ -1,0 +1,253 @@
+// Package rudderauth provides a rudder-go-kit-style docker resource helper for
+// the rudder-auth container that async destination integration tests use to
+// resolve OAuth tokens. It mirrors the rudder-go-kit testhelper/docker/resource
+// convention: Setup(pool, cleaner, opts...) (*Resource, error).
+package rudderauth
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+	"github.com/samber/lo"
+
+	"github.com/rudderlabs/rudder-go-kit/jsonrs"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
+)
+
+const (
+	defaultImage = "422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-auth"
+	defaultTag   = "develop"
+	defaultPort  = "3033/tcp"
+
+	clientTimeout = 30 * time.Second
+)
+
+// Resource is a running rudder-auth container.
+type Resource struct {
+	URL  string // base URL, e.g. http://localhost:3000
+	Port string // mapped host port
+
+	httpClient *http.Client // created once with the resource; reused by RefreshToken
+}
+
+type config struct {
+	image string
+	tag   string
+	port  string
+	env   map[string]string
+}
+
+// Opt configures Setup.
+type Opt func(*config)
+
+// WithImage overrides the container image (default: the rudder-auth ECR image).
+func WithImage(image string) Opt { return func(c *config) { c.image = image } }
+
+// WithTag overrides the image tag (default: "develop").
+func WithTag(tag string) Opt { return func(c *config) { c.tag = tag } }
+
+// WithPort overrides the container port in "port/tcp" form (default: "3033/tcp").
+func WithPort(port string) Opt { return func(c *config) { c.port = port } }
+
+// WithEnv sets the OAuth app credentials the container needs to perform a
+// refresh, keyed by the container env var name the rudder-auth image expects
+// (e.g. "BINGADS_OFFLINE_CONVERSIONS_CLIENT_ID"). Repeated calls merge.
+func WithEnv(env map[string]string) Opt {
+	return func(c *config) {
+		c.env = lo.Assign(c.env, env)
+	}
+}
+
+// Setup starts the rudder-auth container (assumed already present locally — it is
+// NOT pulled here; the CI job pulls it beforehand), waits for /health, registers
+// teardown with cln, and returns the running resource.
+func Setup(pool *dockertest.Pool, cln resource.Cleaner, opts ...Opt) (*Resource, error) {
+	conf := &config{image: defaultImage, tag: defaultTag, port: defaultPort}
+	for _, opt := range opts {
+		opt(conf)
+	}
+
+	env := make([]string, 0, len(conf.env))
+	for key, value := range conf.env {
+		if value == "" {
+			return nil, fmt.Errorf("empty value for rudder-auth container env %q", key)
+		}
+		env = append(env, key+"="+value)
+	}
+
+	container, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository:   conf.image,
+		Tag:          conf.tag,
+		ExposedPorts: []string{conf.port},
+		Env:          env,
+	}, func(hc *docker.HostConfig) {
+		hc.AutoRemove = true
+		hc.RestartPolicy = docker.RestartPolicy{Name: "no"}
+	})
+	if err != nil {
+		return nil, fmt.Errorf("running rudder-auth container: %w", err)
+	}
+	cln.Cleanup(func() {
+		if purgeErr := pool.Purge(container); purgeErr != nil {
+			cln.Logf("purging rudder-auth container: %v", purgeErr)
+		}
+	})
+
+	hostPort := container.GetPort(conf.port)
+	res := &Resource{
+		URL:        fmt.Sprintf("http://localhost:%s", hostPort),
+		Port:       hostPort,
+		httpClient: &http.Client{Timeout: clientTimeout},
+	}
+
+	if pool.MaxWait == 0 {
+		pool.MaxWait = 2 * time.Minute
+	}
+	if err := pool.Retry(func() error {
+		req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, res.URL+"/health", nil)
+		if reqErr != nil {
+			return reqErr
+		}
+		resp, doErr := res.httpClient.Do(req)
+		if doErr != nil {
+			return doErr
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+			return fmt.Errorf("rudder-auth health status %d", resp.StatusCode)
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("waiting for rudder-auth to be healthy: %w", err)
+	}
+
+	return res, nil
+}
+
+// AccountDefinition describes an OAuth account for a rudder-auth v1 refresh.
+type AccountDefinition struct {
+	Type     string `json:"type"`
+	Category string `json:"category"`
+	Name     string `json:"name"`
+}
+
+// RefreshRequest describes a token refresh against rudder-auth.
+type RefreshRequest struct {
+	// Version selects the rudder-auth refresh API: "v0" or "v1". When empty it
+	// defaults to "v1" if AccountDefinition is set, otherwise "v0".
+	Version string
+
+	RefreshToken string
+
+	// Destination is the v0 path segment, e.g. "bingads_offline_conversions".
+	Destination string
+
+	// AccountDefinition and ProviderFields are used by the v1 API.
+	AccountDefinition *AccountDefinition
+	ProviderFields    map[string]string
+}
+
+func (r RefreshRequest) version() string {
+	if r.Version != "" {
+		return r.Version
+	}
+	if r.AccountDefinition != nil {
+		return "v1"
+	}
+	return "v0"
+}
+
+// Secret is the flat set of string fields rudder-auth returns from a refresh.
+type Secret map[string]string
+
+// AccessToken returns the resolved access token (accessToken, or access_token).
+func (s Secret) AccessToken() string {
+	if v := s["accessToken"]; v != "" {
+		return v
+	}
+	return s["access_token"]
+}
+
+// DeveloperToken returns the developer token if rudder-auth included one.
+func (s Secret) DeveloperToken() string { return s["developerToken"] }
+
+// RefreshToken exchanges a refresh token for a fresh secret (access token, and
+// optionally a developer token) via this rudder-auth instance. It mirrors the
+// rudder-transformer live suite's OAuthTokenResolver. For an already-running
+// instance, construct a Resource directly: (&Resource{URL: url}).RefreshToken(...).
+func (r *Resource) RefreshToken(ctx context.Context, req RefreshRequest) (Secret, error) {
+	baseURL := strings.TrimRight(r.URL, "/")
+	if r.httpClient == nil {
+		r.httpClient = &http.Client{Timeout: clientTimeout}
+	}
+
+	var url string
+	var body any
+	switch req.version() {
+	case "v0":
+		if req.Destination == "" {
+			return nil, fmt.Errorf("destination is required for a v0 rudder-auth refresh")
+		}
+		url = fmt.Sprintf("%s/tokens/destination/%s/refresh", baseURL, req.Destination)
+		body = map[string]string{"refreshToken": req.RefreshToken}
+	case "v1":
+		if req.AccountDefinition == nil {
+			return nil, fmt.Errorf("accountDefinition is required for a v1 rudder-auth refresh")
+		}
+		secret := lo.Assign(map[string]string{"refreshToken": req.RefreshToken}, req.ProviderFields)
+		url = baseURL + "/auth/v1/refresh"
+		body = map[string]any{
+			"accountDefinition": req.AccountDefinition,
+			"account":           map[string]any{"secret": secret, "options": map[string]any{}},
+		}
+	default:
+		return nil, fmt.Errorf("unknown rudder-auth oauth version %q (want v0 or v1)", req.version())
+	}
+
+	payload, err := jsonrs.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("calling rudder-auth %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("rudder-auth refresh %s failed: status %d: %s", url, resp.StatusCode, string(respBody))
+	}
+
+	var raw map[string]any
+	if err := jsonrs.Unmarshal(respBody, &raw); err != nil {
+		return nil, fmt.Errorf("unmarshalling rudder-auth response: %w", err)
+	}
+	secret := make(Secret, len(raw))
+	for k, v := range raw {
+		if s, ok := v.(string); ok {
+			secret[k] = s
+		}
+	}
+	if secret.AccessToken() == "" {
+		return nil, fmt.Errorf("rudder-auth %s returned no access token: %s", url, string(respBody))
+	}
+	return secret, nil
+}


### PR DESCRIPTION
## Description

Adds live integration tests for the Bing Ads async destination managers — offline conversions and audience (Customer List) — exercising the full batch-router path (Transform → Upload → Poll → GetUploadStats) against a real Microsoft Advertising account.

OAuth access tokens are resolved from refresh tokens the same way the rudder-transformer live suite does: a `rudder-auth` container is started via dockertest and the refresh token is exchanged for an access token, rather than performing the OAuth flow in-process. This is wrapped in a new, reusable rudder-go-kit-style docker resource helper (`asyncdestinationmanager/testhelper/rudderauth`) that both destinations share.

Resolves INT-6892, INT-6879

### What's covered

**Offline conversions** (`BING_ADS_OFFLINE_CONVERSIONS`)
- insert with pre-hashed and raw email/phone identifiers (`isHashRequired` false/true)
- update (Restate) and delete (Retract)
- negative cases asserting the exact abort reasons `OfflineConversionNameInvalid` and `OfflineConversionMicrosoftClickIdInvalid`
- mixed batches where valid records succeed alongside invalid ones, asserting the succeeded/aborted job split

**Audience / Customer List** (`BING_ADS`)
- Add / Remove / Replace clubbed into a single import (multiple events per action) for both hashed and unhashed audiences
- a mixed valid/invalid batch asserting per-job success vs abort