### PR TITLE
fix(warehouse/slave): guard outputFileWritersMap and tableEventCountMap reads in uploadLoadFiles (#7002)

### DIFF
--- a/warehouse/slave/worker_job.go
+++ b/warehouse/slave/worker_job.go
@@ -411,8 +411,33 @@ func (jr *jobRun) uploadLoadFiles(ctx context.Context, modifier func(result uplo
 		)
 	}
 
+	// Snapshot outputFileWritersMap and tableEventCountMap under their respective
+	// read locks before starting concurrent uploads. The upload workers then run
+	// over local slices/maps rather than reading jr.outputFileWritersMap and
+	// jr.tableEventCountMap directly, which the Go race detector otherwise flags
+	// as unsynchronised concurrent reads (#7002). In practice these maps are
+	// fully populated by handlePendingStagingFile before this method is called,
+	// but locking here removes the implicit ordering assumption.
+	type pendingUpload struct {
+		tableName  string
+		uploadFile encoding.LoadFileWriter
+	}
+	jr.outputFileWritersMapMu.RLock()
+	pending := make([]pendingUpload, 0, len(jr.outputFileWritersMap))
+	for tableName, uploadFile := range jr.outputFileWritersMap {
+		pending = append(pending, pendingUpload{tableName: tableName, uploadFile: uploadFile})
+	}
+	jr.outputFileWritersMapMu.RUnlock()
+
+	jr.tableEventCountMapMu.RLock()
+	tableEventCounts := make(map[string]int, len(jr.tableEventCountMap))
+	for tableName, count := range jr.tableEventCountMap {
+		tableEventCounts[tableName] = count
+	}
+	jr.tableEventCountMapMu.RUnlock()
+
 	process := func() <-chan *uploadProcessingResult {
-		processStream := make(chan *uploadProcessingResult, len(jr.outputFileWritersMap))
+		processStream := make(chan *uploadProcessingResult, len(pending))
 
 		g, groupCtx := errgroup.WithContext(ctx)
 		g.SetLimit(jr.config.numLoadFileUploadWorkers)
@@ -420,7 +445,9 @@ func (jr *jobRun) uploadLoadFiles(ctx context.Context, modifier func(result uplo
 		go func() {
 			defer close(processStream)
 
-			for tableName, uploadFile := range jr.outputFileWritersMap {
+			for _, pu := range pending {
+				tableName := pu.tableName
+				uploadFile := pu.uploadFile
 				g.Go(func() error {
 					select {
 					case <-ctx.Done():
@@ -447,7 +474,7 @@ func (jr *jobRun) uploadLoadFiles(ctx context.Context, modifier func(result uplo
 						result := uploadResult{
 							TableName:             tableName,
 							Location:              uploadOutput.Location,
-							TotalRows:             jr.tableEventCountMap[tableName],
+							TotalRows:             tableEventCounts[tableName],
 							ContentLength:         loadFileStats.Size(),
 							DestinationRevisionID: jr.job.DestinationRevisionID,
 							UseRudderStorage:      jr.job.UseRudderStorage,
@@ -470,7 +497,7 @@ func (jr *jobRun) uploadLoadFiles(ctx context.Context, modifier func(result uplo
 	}
 
 	processStream := process()
-	output := make([]uploadResult, 0, len(jr.outputFileWritersMap))
+	output := make([]uploadResult, 0, len(pending))
 
 	for processedJob := range processStream {
 		if err := processedJob.err; err != nil {
@@ -480,8 +507,8 @@ func (jr *jobRun) uploadLoadFiles(ctx context.Context, modifier func(result uplo
 		output = append(output, processedJob.result)
 	}
 
-	if len(output) != len(jr.outputFileWritersMap) {
-		return nil, fmt.Errorf("matching number of load file upload outputs: expected %d, got %d", len(jr.outputFileWritersMap), len(output))
+	if len(output) != len(pending) {
+		return nil, fmt.Errorf("matching number of load file upload outputs: expected %d, got %d", len(pending), len(output))
 	}
 
 	return output, nil


### PR DESCRIPTION
Fixes #7002.

## Problem

In `warehouse/slave/worker_job.go`, `uploadLoadFiles` reads `jr.outputFileWritersMap` and `jr.tableEventCountMap` from both the main goroutine and a spawned upload goroutine without holding their respective mutexes (`outputFileWritersMapMu` / `tableEventCountMapMu`). The Go race detector flags this as unsynchronised concurrent access — the exact behaviour described in #7002.

Sites affected on current `master`:
- `warehouse/slave/worker_job.go:415` — `len(jr.outputFileWritersMap)` in the main goroutine
- `warehouse/slave/worker_job.go:423` — `for tableName, uploadFile := range jr.outputFileWritersMap` in the spawned goroutine
- `warehouse/slave/worker_job.go:450` — `jr.tableEventCountMap[tableName]` in the errgroup worker
- `warehouse/slave/worker_job.go:473`, `483`, `484` — three more `len(jr.outputFileWritersMap)` reads in the main goroutine

In practice both maps are fully populated by `handlePendingStagingFile` before this method runs, but the ordering is implicit — there is no formal synchronisation guarantee, and layering more concurrent work on top would trip the race for real.

## Fix

Rather than sprinkling `RLock` / `RUnlock` at each read site (which still leaves the errgroup workers touching the shared maps), snapshot both maps under their read locks into local slices/maps before starting the errgroup workers. The workers then run entirely over local data.

- `pending []pendingUpload` — snapshot of `outputFileWritersMap` under `outputFileWritersMapMu.RLock()`
- `tableEventCounts map[string]int` — snapshot of `tableEventCountMap` under `tableEventCountMapMu.RLock()`

The workers no longer read the shared maps, which eliminates both the reported race and any future regression as more concurrent work is layered on the same maps.

## Semantics preserved

- Same tables uploaded (iteration order of the snapshot mirrors the original range).
- Same `TotalRows` values reported (via `tableEventCounts[tableName]`).
- Same output-length invariant checked (`len(output) != len(pending)`).
- Same channel-buffer size (`len(pending)`).

## Verified locally

- `go build ./warehouse/slave/...` — clean.
- `go vet ./warehouse/slave/...` — clean.
- `go test -race -run "TestSlaveJobPayload|TestSlaveJob/writer_and_reader|TestSlaveJob/discards" ./warehouse/slave/` — passes (the docker-dependent `TestSlaveJob/upload_load_files` and `TestSlaveJob/download_staging_file` were skipped locally due to a docker socket path mismatch on the reviewer's machine; CI will exercise them).