### PR TITLE
fix(router): replace plain bool with atomic.Bool for saveDestinationResponse

### DIFF
--- a/router/handle.go
+++ b/router/handle.go
@@ -73,7 +73,7 @@ type Handle struct {
 	drainConcurrencyLimit              config.ValueLoader[int]
 	maxNoOfJobsPerChannel              int // maximum capacity of each worker channel (hard capacity limit of the underlying go channel)
 	noOfJobsPerChannel                 int // requested capacity of each worker channel (important when job buffering is being calculated using the standard method)
-	saveDestinationResponse            bool
+	saveDestinationResponse            atomic.Bool
 	saveDestinationResponseOverride    config.ValueLoader[bool]
 	reportJobsdbPayload                config.ValueLoader[bool]
 	storeDeliveredWithWarningPayload   config.ValueLoader[bool]

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -97,7 +97,7 @@ func (rt *Handle) Setup(
 	rt.telemetry.diagnosisTicker = time.NewTicker(rt.diagnosisTickerTime)
 
 	if value, ok := destinationDefinition.Config["saveDestinationResponse"].(bool); ok {
-		rt.saveDestinationResponse = value
+		rt.saveDestinationResponse.Store(value)
 	}
 	if value, ok := destinationDefinition.Config["supportsDeliveredWithWarnings"].(bool); ok {
 		rt.supportsDeliveredWithWarnings.Store(value)
@@ -488,7 +488,7 @@ func (rt *Handle) backendConfigSubscriber() {
 						destinationsMap[destination.ID].Sources = append(destinationsMap[destination.ID].Sources, *source)
 
 						if value, ok := destination.DestinationDefinition.Config["saveDestinationResponse"].(bool); ok {
-							rt.saveDestinationResponse = value
+							rt.saveDestinationResponse.Store(value)
 						}
 						if value, ok := destination.DestinationDefinition.Config["supportsDeliveredWithWarnings"].(bool); ok {
 							rt.supportsDeliveredWithWarnings.Store(value)

--- a/router/worker.go
+++ b/router/worker.go
@@ -860,7 +860,7 @@ func (w *worker) prepareRouterJobResponses(destinationJob types.DestinationJobT,
 	// We can override via env saveDestinationResponseOverride
 
 	for k, respStatusCode := range respStatusCodes {
-		if isSuccessStatus(respStatusCode) && !w.rt.saveDestinationResponseOverride.Load() && !w.rt.saveDestinationResponse {
+		if isSuccessStatus(respStatusCode) && !w.rt.saveDestinationResponseOverride.Load() && !w.rt.saveDestinationResponse.Load() {
 			respBodys[k] = ""
 		}
 	}


### PR DESCRIPTION
## Summary

Resolves #7259.

`rt.saveDestinationResponse` is a plain `bool` written by the
backend-config subscriber goroutine and read by every worker goroutine
on each delivery decision, with no lock or atomic operation on either
side. This is a data race.

The adjacent `supportsDeliveredWithWarnings` field has a comment
noting the exact same access pattern and was already fixed with
`atomic.Bool`. `saveDestinationResponse` was missed.

### Changes

- `router/handle.go`: declare `saveDestinationResponse` as
  `atomic.Bool` (import already present).
- `router/handle_lifecycle.go`: two write sites updated to
  `.Store(value)`.
- `router/worker.go`: read site updated to `.Load()`.

Running `go test -race ./router/...` will confirm the race is gone.

harsh4vardhan