### PR TITLE
fix(router): check outer event key in failuresMetric guard to prevent inner-map wipe

### DIFF
--- a/router/handle.go
+++ b/router/handle.go
@@ -540,7 +540,7 @@ func (rt *Handle) commitStatusList(workerJobStatuses *[]workerJobStatus) {
 				}
 
 				rt.telemetry.failureMetricLock.Lock()
-				if _, ok := rt.telemetry.failuresMetric[event][string(workerJobStatus.status.ErrorResponse)]; !ok {
+				if _, ok := rt.telemetry.failuresMetric[event]; !ok {
 					rt.telemetry.failuresMetric[event] = make(map[string]int)
 				}
 				rt.telemetry.failuresMetric[event][string(workerJobStatus.status.ErrorResponse)] += 1


### PR DESCRIPTION
## Summary

Resolves #7260.

The guard that initialises `failuresMetric`'s inner map checks whether
the **error string** exists in the inner map, not whether the **event
type** key exists in the outer map:

```go
// Before (checks inner key — wrong)
if _, ok := rt.telemetry.failuresMetric[event][errorStr]; !ok {
    rt.telemetry.failuresMetric[event] = make(map[string]int)
}
```

Whenever a destination produces a second distinct error string within
one reporting window, the inner-map lookup returns `false` (the new
string isn't there yet), `make()` fires, and **every count accumulated
so far for that event type is lost**. In a busy destination this resets
on every new error variant.

### Fix

Check the outer event-type key so the inner map is initialised once
per event type and never overwritten:

```go
if _, ok := rt.telemetry.failuresMetric[event]; !ok {
    rt.telemetry.failuresMetric[event] = make(map[string]int)
}
```

harsh4vardhan