### PR TITLE
fix(router): swap requestsMetric slice under exclusive Lock instead of RLock in collectMetrics

### DIFF
--- a/router/handle_observability.go
+++ b/router/handle_observability.go
@@ -39,34 +39,35 @@ func (rt *Handle) collectMetrics(ctx context.Context) {
 			return
 		case <-rt.telemetry.diagnosisTicker.C:
 		}
-		rt.telemetry.requestsMetricLock.RLock()
+		rt.telemetry.requestsMetricLock.Lock()
+		snapshot := rt.telemetry.requestsMetric
+		rt.telemetry.requestsMetric = nil
+		rt.telemetry.requestsMetricLock.Unlock()
+
 		var diagnosisProperties map[string]any
 		retries := 0
 		aborted := 0
 		success := 0
 		var compTime time.Duration
-		for _, reqMetric := range rt.telemetry.requestsMetric {
+		for _, reqMetric := range snapshot {
 			retries += reqMetric.RequestRetries
 			aborted += reqMetric.RequestAborted
 			success += reqMetric.RequestSuccess
 			compTime += reqMetric.RequestCompletedTime
 		}
-		if len(rt.telemetry.requestsMetric) > 0 {
+		if len(snapshot) > 0 {
 			diagnosisProperties = map[string]any{
 				rt.destType: map[string]any{
 					diagnostics.RouterAborted:       aborted,
 					diagnostics.RouterRetries:       retries,
 					diagnostics.RouterSuccess:       success,
-					diagnostics.RouterCompletedTime: (compTime / time.Duration(len(rt.telemetry.requestsMetric))) / time.Millisecond,
+					diagnostics.RouterCompletedTime: (compTime / time.Duration(len(snapshot))) / time.Millisecond,
 				},
 			}
 			if diagnostics.Diagnostics != nil {
 				diagnostics.Diagnostics.Track(diagnostics.RouterEvents, diagnosisProperties)
 			}
 		}
-
-		rt.telemetry.requestsMetric = nil
-		rt.telemetry.requestsMetricLock.RUnlock()
 
 		// This lock will ensure we don't send out Track Request while filling up the
 		// failureMetric struct


### PR DESCRIPTION
## Summary

Resolves #7261.

`collectMetrics` acquires `requestsMetricLock.RLock()` (shared) and
then sets `rt.telemetry.requestsMetric = nil` while holding it. Writing
shared state under `RLock` violates `sync.RWMutex`'s contract.
`trackRequestMetrics`, called from every worker, takes the exclusive
`Lock()` to append to the same slice — a concurrent read+reset under
`RLock` races with those appends.

### Fix

Take a short exclusive lock, swap the slice into a local snapshot,
release the lock, then iterate the snapshot outside the lock:

```go
rt.telemetry.requestsMetricLock.Lock()
snapshot := rt.telemetry.requestsMetric
rt.telemetry.requestsMetric = nil
rt.telemetry.requestsMetricLock.Unlock()

for _, reqMetric := range snapshot { ... }
```

This is shorter under lock than the original (lock held only for the
pointer swap, not for the full iteration and diagnostics call) and
correct by `sync.RWMutex` contract.

harsh4vardhan