### PR TITLE
fix(router): use backgroundCtx and backgroundGroup for backendConfigSubscriber to prevent goroutine leak

### DIFF
--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -29,7 +29,6 @@ import (
 	"github.com/rudderlabs/rudder-server/router/transformer"
 	"github.com/rudderlabs/rudder-server/router/types"
 	routerutils "github.com/rudderlabs/rudder-server/router/utils"
-	"github.com/rudderlabs/rudder-server/rruntime"
 	destinationdebugger "github.com/rudderlabs/rudder-server/services/debugger/destination"
 	"github.com/rudderlabs/rudder-server/services/rsources"
 	transformerFeaturesService "github.com/rudderlabs/rudder-server/services/transformer"

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -334,8 +334,9 @@ func (rt *Handle) Setup(
 		rt.adaptiveLimit = func(limit int64) int64 { return limit }
 	}
 
-	rruntime.Go(func() {
+	rt.backgroundGroup.Go(func() error {
 		rt.backendConfigSubscriber()
+		return nil
 	})
 }
 
@@ -468,7 +469,7 @@ func (rt *Handle) statusInsertLoop() {
 }
 
 func (rt *Handle) backendConfigSubscriber() {
-	ch := rt.backendConfig.Subscribe(context.TODO(), backendconfig.TopicBackendConfig)
+	ch := rt.backendConfig.Subscribe(rt.backgroundCtx, backendconfig.TopicBackendConfig)
 	for configEvent := range ch {
 		destinationsMap := map[string]*routerutils.DestinationWithSources{}
 		connectionsMap := map[types.SourceDest]types.ConnectionWithID{}


### PR DESCRIPTION
## Summary

Resolves #7262.

Two issues cause a goroutine leak on every router shutdown:

**1. context.TODO() in Subscribe**

`backendConfigSubscriber` passes `context.TODO()` to
`rt.backendConfig.Subscribe()`. When `Shutdown()` calls
`rt.backgroundCancel()`, the pubsub goroutine inside `Subscribe`
blocks on `<-ctx.Done()` from the non-cancellable `context.TODO()`.
The channel is never closed and the `for configEvent := range ch`
loop never exits.

**2. rruntime.Go instead of backgroundGroup.Go**

The goroutine is started outside `backgroundGroup`, so
`backgroundWait()` returns without waiting for it to finish.

### Fix

- Pass `rt.backgroundCtx` to `Subscribe` so the pubsub goroutine
  cancels when the router shuts down.
- Start the subscriber via `rt.backgroundGroup.Go` so `Shutdown`
  blocks until the goroutine exits.
- Remove now-unused `rruntime` import.

harsh4vardhan