### PR TITLE
chore(router): support per-partition noOfWorkers override

### DIFF
--- a/integration_test/srchydration/src_hydration_test.go
+++ b/integration_test/srchydration/src_hydration_test.go
@@ -413,15 +413,20 @@ func prepareExpectedReports(t *testing.T, sourceId string, gwOnly bool, numEvent
 
 func requireReports(t *testing.T, ctx context.Context, db *sql.DB, expectedReports []reportRow) {
 	t.Helper()
+	// multiple rows can be recorded for the same report key, so aggregate their counts
 	query := `
 					SELECT
 					  workspace_id, instance_id, source_id, destination_id,
-					  in_pu, pu, status_code, status, count,
+					  in_pu, pu, status_code, status, SUM(count),
 					  terminal_state, initial_state, source_category, event_type
 					FROM
 					  reports
+					GROUP BY
+					  workspace_id, instance_id, source_id, destination_id,
+					  in_pu, pu, status_code, status,
+					  terminal_state, initial_state, source_category, event_type
 					ORDER BY
-					  source_id, id;
+					  source_id, MIN(id);
 				`
 	require.Eventuallyf(t, func() bool {
 		rows, err := db.QueryContext(ctx, query)

--- a/router/config.go
+++ b/router/config.go
@@ -21,12 +21,27 @@ func getHierarchicalRouterConfigInt(destType string, defaultValue int, keys ...s
 	return config.GetIntVar(defaultValue, 1, orderedKeys...)
 }
 
+// getPartitionRouterConfigInt returns the value of a partition-scoped router configuration key, in order
+// of precedence: Router.<destType>.<partition>.<key>, Router.<destType>.<key>, Router.<key>
+func getPartitionRouterConfigInt(key, destType, partition string, defaultValue int) int {
+	return config.GetIntVar(defaultValue, 1, getPartitionRouterConfigKeys(key, destType, partition)...)
+}
+
 func getReloadableRouterConfigInt(key, destType string, defaultValue int) config.ValueLoader[int] {
 	return config.GetReloadableIntVar(defaultValue, 1, getRouterConfigKeys(key, destType)...)
 }
 
 func getRouterConfigKeys(key, destType string) []string {
 	return []string{"Router." + destType + "." + key, "Router." + key}
+}
+
+// getPartitionRouterConfigKeys returns the configuration keys for a partition-scoped router setting, in order
+// of precedence: Router.<destType>.<partition>.<key>, Router.<destType>.<key>, Router.<key>
+func getPartitionRouterConfigKeys(key, destType, partition string) []string {
+	if partition == "" { // no isolation, thus no partition-scoped configuration
+		return getRouterConfigKeys(key, destType)
+	}
+	return append([]string{"Router." + destType + "." + partition + "." + key}, getRouterConfigKeys(key, destType)...)
 }
 
 func getHierarchicalRouterConfigKeys(destType string, keys ...string) []string {

--- a/router/config_test.go
+++ b/router/config_test.go
@@ -1,0 +1,24 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPartitionRouterConfigKeys(t *testing.T) {
+	t.Run("with partition", func(t *testing.T) {
+		require.Equal(t, []string{
+			"Router.WEBHOOK.partition1.noOfWorkers",
+			"Router.WEBHOOK.noOfWorkers",
+			"Router.noOfWorkers",
+		}, getPartitionRouterConfigKeys("noOfWorkers", "WEBHOOK", "partition1"))
+	})
+
+	t.Run("without partition", func(t *testing.T) {
+		require.Equal(t, []string{
+			"Router.WEBHOOK.noOfWorkers",
+			"Router.noOfWorkers",
+		}, getPartitionRouterConfigKeys("noOfWorkers", "WEBHOOK", ""))
+	})
+}

--- a/router/handle.go
+++ b/router/handle.go
@@ -65,7 +65,7 @@ type Handle struct {
 	netClientTimeout                   time.Duration
 	transformerTimeout                 time.Duration
 	enableBatching                     bool
-	noOfWorkers                        int
+	defaultNoOfWorkers                 int // handle for overriding the default value in tests
 	eventOrderKeyThreshold             config.ValueLoader[int]
 	eventOrderDisabledStateDuration    config.ValueLoader[time.Duration]
 	eventOrderHalfEnabledStateDuration config.ValueLoader[time.Duration]

--- a/router/handle_lifecycle.go
+++ b/router/handle_lifecycle.go
@@ -103,7 +103,7 @@ func (rt *Handle) Setup(
 		rt.supportsDeliveredWithWarnings.Store(value)
 	}
 	rt.guaranteeUserEventOrder = getRouterConfigBool("guaranteeUserEventOrder", rt.destType, true)
-	rt.noOfWorkers = getRouterConfigInt("noOfWorkers", destType, 64)
+	rt.defaultNoOfWorkers = 64
 	rt.maxNoOfJobsPerChannel = getRouterConfigInt("maxNoOfJobsPerChannel", destType, 10000)
 	rt.noOfJobsPerChannel = getRouterConfigInt("noOfJobsPerChannel", destType, 1000)
 	if rt.noOfJobsPerChannel > rt.maxNoOfJobsPerChannel { // if noOfJobsPerChannel is more than max, set it as the new max

--- a/router/partition_worker.go
+++ b/router/partition_worker.go
@@ -33,7 +33,8 @@ func newPartitionWorker(ctx context.Context, rt *Handle, partition string) *part
 	}
 	pw.g, _ = errgroup.WithContext(context.Background())
 	pw.barrier = barrier
-	pw.workers = make([]*worker, rt.noOfWorkers)
+	noOfWorkers := getPartitionRouterConfigInt("noOfWorkers", rt.destType, partition, rt.defaultNoOfWorkers)
+	pw.workers = make([]*worker, noOfWorkers)
 	deliveryTimeStat := stats.Default.NewTaggedStat("router_delivery_time", stats.TimerType, stats.Tags{"destType": rt.destType})
 	routerDeliveryLatencyStat := stats.Default.NewTaggedStat("router_delivery_latency", stats.TimerType, stats.Tags{"destType": rt.destType})
 	routerProxyStat := stats.Default.NewTaggedStat("router_proxy_latency", stats.TimerType, stats.Tags{"destType": rt.destType})
@@ -41,7 +42,7 @@ func newPartitionWorker(ctx context.Context, rt *Handle, partition string) *part
 	bufferCapacityStat := stats.Default.NewTaggedStat("router_worker_buffer_capacity", stats.HistogramType, stats.Tags{"destType": rt.destType, "partition": partition})
 	bufferSizeStat := stats.Default.NewTaggedStat("router_worker_buffer_size", stats.HistogramType, stats.Tags{"destType": rt.destType, "partition": partition})
 
-	for i := 0; i < rt.noOfWorkers; i++ {
+	for i := range noOfWorkers {
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		workLoopThroughput := metric.NewSimpleMovingAverage(20)
 		workLoopThroughputStat := stats.Default.NewTaggedStat("router_worker_work_loop_throughput", stats.HistogramType, stats.Tags{"destType": rt.destType, "partition": partition})
@@ -56,7 +57,7 @@ func newPartitionWorker(ctx context.Context, rt *Handle, partition string) *part
 				newBufferSizeCalculatorSwitcher(
 					rt.reloadableConfig.enableDynamicBufferSizeCalculator,
 					pw.pickupBatchSizeGauge,
-					rt.noOfWorkers,
+					noOfWorkers,
 					rt.reloadableConfig.noOfJobsToBatchInAWorker,
 					workLoopThroughput,
 					rt.reloadableConfig.dynamicBufferSizeScalingFactor,

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -262,7 +262,7 @@ func TestBackoff(t *testing.T) {
 		r := &Handle{
 			logger:                logger.NOP,
 			backgroundCtx:         context.Background(),
-			noOfWorkers:           1,
+			defaultNoOfWorkers:    1,
 			maxNoOfJobsPerChannel: 3,
 			noOfJobsPerChannel:    3,
 			reloadableConfig: &reloadableConfig{
@@ -1096,7 +1096,7 @@ var _ = Describe("router", func() {
 				throttler.NewNoOpThrottlerFactory(),
 			)
 			router.transformer = mockTransformer
-			router.noOfWorkers = 1
+			router.defaultNoOfWorkers = 1
 			router.reloadableConfig.noOfJobsToBatchInAWorker = config.SingleValueLoader(5)
 
 			gaPayload := `{"body": {"XML": {}, "FORM": {}, "JSON": {}}, "type": "REST", "files": {}, "method": "POST", "params": {"t": "event", "v": "1", "an": "RudderAndroidClient", "av": "1.0", "ds": "android-sdk", "ea": "Demo Track", "ec": "Demo Category", "el": "Demo Label", "ni": 0, "qt": 59268380964, "ul": "en-US", "cid": "anon_id", "tid": "UA-185645846-1", "uip": "[::1]", "aiid": "com.rudderlabs.android.sdk"}, "userId": "anon_id", "headers": {}, "version": "1", "endpoint": "https://www.google-analytics.com/collect"}`
@@ -1207,7 +1207,7 @@ var _ = Describe("router", func() {
 
 			router.enableBatching = true
 			router.reloadableConfig.noOfJobsToBatchInAWorker = config.SingleValueLoader(3)
-			router.noOfWorkers = 1
+			router.defaultNoOfWorkers = 1
 
 			gaPayload := `{"body": {"XML": {}, "FORM": {}, "JSON": {}}, "type": "REST", "files": {}, "method": "POST", "params": {"t": "event", "v": "1", "an": "RudderAndroidClient", "av": "1.0", "ds": "android-sdk", "ea": "Demo Track", "ec": "Demo Category", "el": "Demo Label", "ni": 0, "qt": 59268380964, "ul": "en-US", "cid": "anon_id", "tid": "UA-185645846-1", "uip": "[::1]", "aiid": "com.rudderlabs.android.sdk"}, "userId": "anon_id", "headers": {}, "version": "1", "endpoint": "https://www.google-analytics.com/collect"}`
 			parameters := fmt.Sprintf(`{"source_id": "%s", "destination_id": "%s", "message_id": "2f548e6d-60f6-44af-a1f4-62b3272445c3", "received_at": "2021-06-28T10:04:48.527+05:30", "transform_at": "processor"}`, sourceIDEnabled, gaDestinationID) // skipcq: GO-R4002
@@ -1555,7 +1555,7 @@ var _ = Describe("router", func() {
 				throttler.NewNoOpThrottlerFactory(),
 			)
 			router.transformer = mockTransformer
-			router.noOfWorkers = 1
+			router.defaultNoOfWorkers = 1
 			router.reloadableConfig.noOfJobsToBatchInAWorker = config.SingleValueLoader(5)
 
 			gaPayload := `{"body": {"XML": {}, "FORM": {}, "JSON": {}}, "type": "REST", "files": {}, "method": "POST", "params": {"t": "event", "v": "1", "an": "RudderAndroidClient", "av": "1.0", "ds": "android-sdk", "ea": "Demo Track", "ec": "Demo Category", "el": "Demo Label", "ni": 0, "qt": 59268380964, "ul": "en-US", "cid": "anon_id", "tid": "UA-185645846-1", "uip": "[::1]", "aiid": "com.rudderlabs.android.sdk"}, "userId": "anon_id", "headers": {}, "version": "1", "endpoint": "https://www.google-analytics.com/collect"}`
@@ -1775,7 +1775,7 @@ var _ = Describe("router", func() {
 				throttler.NewNoOpThrottlerFactory(),
 			)
 			router.transformer = mockTransformer
-			router.noOfWorkers = 1
+			router.defaultNoOfWorkers = 1
 			router.reloadableConfig.noOfJobsToBatchInAWorker = config.SingleValueLoader(3)
 
 			gaPayload := `{"body": {"XML": {}, "FORM": {}, "JSON": {}}, "type": "REST", "files": {}, "method": "POST", "params": {"t": "event", "v": "1", "an": "RudderAndroidClient", "av": "1.0", "ds": "android-sdk", "ea": "Demo Track", "ec": "Demo Category", "el": "Demo Label", "ni": 0, "qt": 59268380964, "ul": "en-US", "cid": "anon_id", "tid": "UA-185645846-1", "uip": "[::1]", "aiid": "com.rudderlabs.android.sdk"}, "userId": "anon_id", "headers": {}, "version": "1", "endpoint": "https://www.google-analytics.com/collect"}`
@@ -1956,7 +1956,7 @@ var _ = Describe("router", func() {
 			router.transformer = mockTransformer
 
 			router.reloadableConfig.noOfJobsToBatchInAWorker = config.SingleValueLoader(3)
-			router.noOfWorkers = 1
+			router.defaultNoOfWorkers = 1
 
 			gaPayload := `{"body": {"XML": {}, "FORM": {}, "JSON": {}}, "type": "REST", "files": {}, "method": "POST", "params": {"t": "event", "v": "1", "an": "RudderAndroidClient", "av": "1.0", "ds": "android-sdk", "ea": "Demo Track", "ec": "Demo Category", "el": "Demo Label", "ni": 0, "qt": 59268380964, "ul": "en-US", "cid": "anon_id", "tid": "UA-185645846-1", "uip": "[::1]", "aiid": "com.rudderlabs.android.sdk"}, "userId": "anon_id", "headers": {}, "version": "1", "endpoint": "https://www.google-analytics.com/collect"}`
 			parameters := fmt.Sprintf(`{"source_id": "%s", "destination_id": "%s", "message_id": "2f548e6d-60f6-44af-a1f4-62b3272445c3", "received_at": "2021-06-28T10:04:48.527+05:30", "transform_at": "router"}`, sourceIDEnabled, gaDestinationID) // skipcq: GO-R4002
@@ -2127,7 +2127,7 @@ var _ = Describe("router", func() {
 
 			router.reloadableConfig.noOfJobsToBatchInAWorker = config.SingleValueLoader(3)
 			router.reloadableConfig.transformerProxy = config.SingleValueLoader(true)
-			router.noOfWorkers = 1
+			router.defaultNoOfWorkers = 1
 
 			gaPayload := `{"body": {"XML": {}, "FORM": {}, "JSON": {}}, "type": "REST", "files": {}, "method": "POST", "params": {"t": "event", "v": "1", "an": "RudderAndroidClient", "av": "1.0", "ds": "android-sdk", "ea": "Demo Track", "ec": "Demo Category", "el": "Demo Label", "ni": 0, "qt": 59268380964, "ul": "en-US", "cid": "anon_id", "tid": "UA-185645846-1", "uip": "[::1]", "aiid": "com.rudderlabs.android.sdk"}, "userId": "anon_id", "headers": {}, "version": "1", "endpoint": "https://www.google-analytics.com/collect"}`
 			parameters := fmt.Sprintf(`{"source_id": "%s", "destination_id": "%s", "message_id": "2f548e6d-60f6-44af-a1f4-62b3272445c3", "received_at": "2021-06-28T10:04:48.527+05:30", "transform_at": "router"}`, sourceIDEnabled, gaDestinationID) // skipcq: GO-R4002
@@ -2284,7 +2284,7 @@ var _ = Describe("router", func() {
 
 			router.reloadableConfig.noOfJobsToBatchInAWorker = config.SingleValueLoader(3)
 			router.reloadableConfig.transformerProxy = config.SingleValueLoader(true)
-			router.noOfWorkers = 1
+			router.defaultNoOfWorkers = 1
 
 			gaPayload := `{"body": {"XML": {}, "FORM": {}, "JSON": {}}, "type": "REST", "files": {}, "method": "POST", "params": {"t": "event", "v": "1", "an": "RudderAndroidClient", "av": "1.0", "ds": "android-sdk", "ea": "Demo Track", "ec": "Demo Category", "el": "Demo Label", "ni": 0, "qt": 59268380964, "ul": "en-US", "cid": "anon_id", "tid": "UA-185645846-1", "uip": "[::1]", "aiid": "com.rudderlabs.android.sdk"}, "userId": "anon_id", "headers": {}, "version": "1", "endpoint": "https://www.google-analytics.com/collect"}`
 			parameters := fmt.Sprintf(`{"source_id": "%s", "destination_id": "%s", "message_id": "2f548e6d-60f6-44af-a1f4-62b3272445c3", "received_at": "2021-06-28T10:04:48.527+05:30", "transform_at": "router"}`, sourceIDEnabled, gaDestinationID) // skipcq: GO-R4002


### PR DESCRIPTION
# Description

The number of router workers can now be configured per partition, i.e. per workspace or per destination, depending on the router's isolation mode. The configuration hierarchy becomes `Router.<destType>.<partitionId>.noOfWorkers`, `Router.<destType>.noOfWorkers`, `Router.noOfWorkers`, the default remaining 64.

## Linear Ticket

resolves PIPE-3272

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
